### PR TITLE
fix(.../tactic/tactic_state.cpp): 'target' must instantiate goal type

### DIFF
--- a/src/library/tactic/tactic_state.cpp
+++ b/src/library/tactic/tactic_state.cpp
@@ -320,7 +320,9 @@ vm_obj tactic_target(vm_obj const & o) {
     tactic_state const & s = tactic::to_state(o);
     optional<metavar_decl> g = s.get_main_goal_decl();
     if (!g) return mk_no_goals_exception(s);
-    return tactic::mk_success(to_obj(g->get_type()), s);
+    metavar_context mctx = s.mctx();
+    expr r = mctx.instantiate_mvars(g->get_type());
+    return tactic::mk_success(to_obj(r), s);
 }
 
 tactic_state_context_cache::tactic_state_context_cache(tactic_state & s):


### PR DESCRIPTION
This is a suggested, preemptive fix based on an observed issue in Lean3. The following test fails in Lean3 but works after the PR:
```Lean
set_option pp.all true
set_option pp.instantiate_mvars false

example (m n : ℕ) : psigma (λ (P : Prop), P) :=
begin
fapply psigma.mk,
exact (nat.add m (nat.succ n) = nat.succ (nat.add m n)),
trace_state,
-- m n : nat
-- ⊢ ?m_1
dunfold nat.add,
tactic.to_expr ``(rfl) >>= λ e, tactic.apply e {md := tactic.transparency.none}
-- @eq.{1} nat (nat.add m (nat.succ n)) (nat.succ (nat.add m n))
-- with
-- @eq.{?l_1} ?m_2 ?m_3 ?m_3
end
```
The issue is that since the `target` tactic does not instantiate metavars, the `dunfold` tactic does not find the desired subterm, even though (without  `set_option pp.instantiate_mvars false`) it looks like the subterm is present, even with `set_option pp.all true`. There may be performance reasons for not doing it this way, but it seems like an appealing goal for nothing to break in interactive mode because metavars are not instantiated under the hood. 

I do not provide a test for Lean4 because there doesn't seem to be a `dunfold` tactic yet or anything like it.