### PR TITLE
feat(src/frontends/lean/decl_util): ignore out_params when deciding w…

### DIFF
--- a/tests/lean/include_out_param.lean
+++ b/tests/lean/include_out_param.lean
@@ -1,0 +1,9 @@
+class c (α : Type) (β : out_param Type) :=
+(n : α → nat)
+
+variables {α β : Type} [c α β]
+
+def f : nat := 1
+#print f -- don't include anything
+def g (a : α) : nat := c.n a
+#print g -- include everything

--- a/tests/lean/include_out_param.lean.expected.out
+++ b/tests/lean/include_out_param.lean.expected.out
@@ -1,0 +1,4 @@
+def f : ℕ :=
+1
+def g : Π {α β : Type} [_inst_1 : c α β], α → ℕ :=
+λ {α β : Type} [_inst_1 : c α β] (a : α), c.n a


### PR DESCRIPTION
…hether to include an anonymous inst implicit section variable

@leodemoura Does this look reasonable to you? I've often wanted this, but now that `monad_parsec` has an `out_param`, it's especially helpful.