### PR TITLE
fix(src/CMakeLists): sanitize regex

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -475,8 +475,17 @@ file(GLOB_RECURSE LEAN_SOURCES
   "${LEAN_SOURCE_DIR}"
   "${LEAN_SOURCE_DIR}/[A-Za-z]*.cpp"
   "${LEAN_SOURCE_DIR}/[A-Za-z]*.h")
+
+function(escape_regex OUT_NAME INPUT)
+    foreach(CHAR IN ITEMS ^ $ . [ ] - + * \( \) )
+        string(REPLACE "${CHAR}" "\\${CHAR}" INPUT ${INPUT})
+    endforeach(CHAR)
+    set(${OUT_NAME} ${INPUT} PARENT_SCOPE)
+endfunction()
+escape_regex(LEAN_SOURCE_DIR_REGEX_SAFE ${LEAN_SOURCE_DIR})
+
 foreach(SOURCE ${LEAN_SOURCES})
-  if(${SOURCE} MATCHES "${LEAN_SOURCE_DIR}/boot/.*")
+  if(${SOURCE} MATCHES "${LEAN_SOURCE_DIR_REGEX_SAFE}/boot/.*")
     LIST(REMOVE_ITEM LEAN_SOURCES ${SOURCE})
   endif()
 endforeach()


### PR DESCRIPTION
This fixes the use of a regex in `CMakeLists` with the absolute path to the Lean source directory to sanitize regex special characters. Without this, Lean won't build under paths containing folders like `c++` (which happens to be the case on my laptop). I adapted `escape_regex` from [here](https://gitlab.kitware.com/cmake/cmake/issues/18409).

I'm not entirely sure how a test case for this could be added.