### PR TITLE
feat: add range parameter to getInteractiveDiagnostics

### DIFF
--- a/src/Lean/Data/Lsp/Extra.lean
+++ b/src/Lean/Data/Lsp/Extra.lean
@@ -137,4 +137,12 @@ structure RpcKeepAliveParams where
   sessionId : UInt64
   deriving FromJson, ToJson
 
+/--
+Range of lines in a document, including `start` but excluding `end`.
+-/
+structure LineRange where
+  start : Nat
+  «end» : Nat
+  deriving Inhabited, Repr, FromJson, ToJson
+
 end Lean.Lsp

--- a/src/Lean/Server/FileWorker/WidgetRequests.lean
+++ b/src/Lean/Server/FileWorker/WidgetRequests.lean
@@ -67,16 +67,26 @@ builtin_initialize
     (Option InteractiveTermGoal)
     FileWorker.getInteractiveTermGoal
 
+structure GetInteractiveDiagnosticsParams where
+  lineRange? : Option Lsp.LineRange
+  deriving Inhabited, FromJson, ToJson
+
 open RequestM in
-def getInteractiveDiagnostics (_ : Json) : RequestM (RequestTask (Array InteractiveDiagnostic)) := do
+def getInteractiveDiagnostics (params : GetInteractiveDiagnosticsParams) : RequestM (RequestTask (Array InteractiveDiagnostic)) := do
   let doc ← readDoc
-  let t₁ ← doc.cmdSnaps.waitAll
-  t₁.map fun (snaps, _) => snaps.getLast!.interactiveDiags.toArray
+  let rangeEnd ← params.lineRange?.map fun range =>
+    doc.meta.text.lspPosToUtf8Pos ⟨range.«end», 0⟩
+  withWaitFindSnap doc (fun snap => rangeEnd.all (· ≤ snap.endPos)) #[]
+    fun snap => snap.interactiveDiags.toArray.filter fun diag =>
+      params.lineRange?.all fun ⟨s, e⟩ =>
+        -- does [s,e) intersect [diag.fullRange.start.line,diag.fullRange.end.line)?
+        s ≤ diag.fullRange.start.line ∧ diag.fullRange.start.line < e ∨
+        diag.fullRange.start.line ≤ s ∧ s < diag.fullRange.end.line
 
 builtin_initialize
   registerRpcCallHandler
     `Lean.Widget.getInteractiveDiagnostics
-    Json
+    GetInteractiveDiagnosticsParams
     (Array InteractiveDiagnostic)
     getInteractiveDiagnostics
 


### PR DESCRIPTION
Currently, `getInteractiveDiagnostics` blocks until the whole file is processed.  This means that the infoview hangs and doesn't show diagnostics.  See e.g. https://github.com/Julian/lean.nvim/issues/162

This PR adds a range parameter to the `getInteractiveDiagnostics` RPC call:
```typescript
interface LineRange {
  start: number;
  end: number;
}

interface GetInteractiveDiagnosticsParams {
  /** Only return diagnostics for the specified range. */
  lineRange?: LineRange;
}
```

If `lineRange` is present, the server will only wait until the document has finished processing up to the end position.  Furthermore only diagnostics whose `fullRange` intersects the range parameter are returned.  This also solves another potential performance issue by significantly reducing the amount of diagnostics that are sent.

Tested using https://github.com/Julian/lean.nvim/pull/169