### PR TITLE
remove manual shell scripting from our cmake files

### DIFF
--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -10,11 +10,11 @@ set_target_properties(leanrt_initial-exec PROPERTIES
 # The above library, like all other C++ code, is built using `-ftls-model=initial-exec`, which is necessary for linking it into `leanshared`,
 # but introduces a measurable overhead while accessing the thread-local variable `g_heap` when allocating and deallocating. Therefore we compile
 # the runtime again with the more restrictive `local-exec` and use it when linking Lean code statically, i.e. not against `leanshared`.
-add_library(libleanrt STATIC ${RUNTIME_OBJS})
-set_target_properties(libleanrt PROPERTIES
-  ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_library(leanrt STATIC ${RUNTIME_OBJS})
+set_target_properties(leanrt PROPERTIES
+  ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
 if (NOT MSVC)
-target_compile_options(libleanrt PRIVATE -ftls-model=local-exec)
+target_compile_options(leanrt PRIVATE -ftls-model=local-exec)
 endif()
 
 if(LLVM)


### PR DESCRIPTION
fix: remove manual shell scripting for compiling libleanrt with the additional compile flag "-ftls-model=local-exec".  I think cmake can easily do this just using target_compile_options.  Removing bash shell will eventually get us a cmake system that will work on windows.

This is proof that the cmake change works, there are two sets of object files, one for lean_rt-initial-exec and one for leanrt and they are different:
![image](https://user-images.githubusercontent.com/18707114/137422230-6c071c47-443b-44c3-8b94-fa3b8c47c8d7.png)
