### PR TITLE
disable simpcase pre-condition that checks for default case to allow optimization

### DIFF
--- a/src/Lean/Compiler/IR/SimpCase.lean
+++ b/src/Lean/Compiler/IR/SimpCase.lean
@@ -35,7 +35,7 @@ private def maxOccs (alts : Array Alt) : Alt × Nat := do
   return (maxAlt, max)
 
 private def addDefault (alts : Array Alt) : Array Alt :=
-  if alts.size <= 1 || alts.any Alt.isDefault then alts
+  if alts.size <= 1 then alts
   else
     let (max, noccs) := maxOccs alts;
     if noccs == 1 then alts


### PR DESCRIPTION
`simpCase` is capable of "improving" the default case to a new default case which groups the maximum number of right-hand-sides. This precondition seems to block this valid use-case of the `simpCase` pass. 

[Numbers I ran locally](https://gist.github.com/bollu/0882e4f9af28d03df712e0f37c5e6979#file-bench-oct-15-remove-isdefault-simpcase-guard-L8-L10) seem to indicate that this is beneficial for performance. Would it be possible to run a `!bench` here, as I'm not sure if I incorrectly ran Lean's benchmark suite.  