### PR TITLE
fix: out-of-bounds array access

### DIFF
--- a/src/Lean/Elab/Syntax.lean
+++ b/src/Lean/Elab/Syntax.lean
@@ -342,8 +342,7 @@ def checkRuleKind (given expected : SyntaxNodeKind) : Bool :=
   given == expected || given == expected ++ `antiquot
 
 def inferMacroRulesAltKind : Syntax → CommandElabM SyntaxNodeKind
-  | `(matchAltExpr| | $pats,* => $rhs) => do
-    let pat := pats.elemsAndSeps[0]
+  | `(matchAltExpr| | $pat:term => $rhs) => do
     if !pat.isQuot then
       throwUnsupportedSyntax
     let quoted := getQuotContent pat


### PR DESCRIPTION
This fixes a panic with the following file (and also every single time you write `macro_rules`):
```lean
macro_rules
```

Since `macro_rules` parses `many1` alternatives, this parses as a single alternative with no patterns.  And that case was not handled in `inferMacroRulesAltKind`.