### PR TITLE
fix: widget messages

### DIFF
--- a/src/Lean/Server/Requests.lean
+++ b/src/Lean/Server/Requests.lean
@@ -95,9 +95,9 @@ def bindTask (t : Task α) (f : α → RequestM (RequestTask β)) : RequestM (Re
     | Except.error e => throwThe RequestError e
     | Except.ok v    => v
 
-/-- Create a task which waits for a snapshot matching `p`, handles various errors,
-and if a matching snapshot was found executes `x` with it. If not found, the task
-executes `notFoundX`. -/
+/-- Create a task which waits for the first snapshot matching `p`, handles various errors,
+and if a matching snapshot was found executes `x` with it. If not found, the task executes
+`notFoundX`. -/
 def withWaitFindSnap (doc : EditableDocument) (p : Snapshot → Bool)
   (notFoundX : RequestM β)
   (x : Snapshot → RequestM β)

--- a/src/Lean/Widget/InteractiveCode.lean
+++ b/src/Lean/Widget/InteractiveCode.lean
@@ -78,6 +78,7 @@ private def formatWithOpts (e : Expr) (optsPerPos : Delaborator.OptionsPerPos)
     let currNamespace ← getCurrNamespace
     let openDecls ← getOpenDecls
     let opts ← getOptions
+    let e ← Meta.instantiateMVars e
     let (stx, infos) ← PrettyPrinter.delabCore currNamespace openDecls e optsPerPos
     let stx := sanitizeSyntax stx |>.run' { options := opts }
     let stx ← PrettyPrinter.parenthesizeTerm stx


### PR DESCRIPTION
Fixes no messages being sent if `lineRange?` is empty (CC @gebner -- I was wrong to suggest `withWaitFindSnap` since we want *all* snaps that match the predicate), and a bug reported on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Trace.20while.20compilation.20vs.20goal.20view/near/257716614).