### PR TITLE
Catch delab attribute exceptions

### DIFF
--- a/src/Lean/PrettyPrinter/Delaborator/Basic.lean
+++ b/src/Lean/PrettyPrinter/Delaborator/Basic.lean
@@ -223,7 +223,7 @@ where
 partial def delabFor : Name → Delab
   | Name.anonymous => failure
   | k              =>
-    (do let stx ← (delabAttribute.getValues (← getEnv) k).firstM id
+    (do let stx ← (delabAttribute.getValues (← getEnv) k).firstM (try . catch _ => failure)
         let stx ← annotateCurPos stx
         addTermInfo (← getPos) stx (← getExpr)
         stx)

--- a/tests/lean/catchDelab.lean
+++ b/tests/lean/catchDelab.lean
@@ -1,0 +1,9 @@
+import Lean
+
+@[delab app]
+partial def Lean.PrettyPrinter.Delaborator.delabThrow : Delab := do
+  let e ← SubExpr.getExpr
+  let ty ← Meta.inferType e
+  failure
+
+#check test

--- a/tests/lean/catchDelab.lean.expected.out
+++ b/tests/lean/catchDelab.lean.expected.out
@@ -1,0 +1,1 @@
+catchDelab.lean:9:7-9:11: error: unknown identifier 'test'


### PR DESCRIPTION
This commit makes the delaborator wrap delab attribute calls with try/catch, as suggested at https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/inferType.20in.20delaborator/near/258607289