### PR TITLE
RFC: avoid metavariables at `CompletionItem`s

### DIFF
--- a/tests/lean/interactive/completion2.lean.expected.out
+++ b/tests/lean/interactive/completion2.lean.expected.out
@@ -1,31 +1,31 @@
 {"textDocument": {"uri": "file://completion2.lean"},
  "position": {"line": 19, "character": 10}}
 {"items":
- [{"label": "ex2", "detail": "?a ≤ ?b → ?a + 2 ≤ ?b + 2"},
-  {"label": "ex3", "detail": "?a ≤ ?b → ?c ≤ ?d → ?a + ?c ≤ ?b + ?d"},
-  {"label": "ax1", "detail": "?a ≤ ?b → ?a - ?a ≤ ?b - ?b"},
-  {"label": "ex1", "detail": "?a ≤ ?b → ?a + ?a ≤ ?b + ?b"}],
+ [{"label": "ex2", "detail": "a ≤ b → a + 2 ≤ b + 2"},
+  {"label": "ex3", "detail": "a ≤ b → c ≤ d → a + c ≤ b + d"},
+  {"label": "ax1", "detail": "a ≤ b → a - a ≤ b - b"},
+  {"label": "ex1", "detail": "a ≤ b → a + a ≤ b + b"}],
  "isIncomplete": true}
 {"textDocument": {"uri": "file://completion2.lean"},
  "position": {"line": 25, "character": 6}}
 {"items":
- [{"label": "ex2", "detail": "?a ≤ ?b → ?a + 2 ≤ ?b + 2"},
-  {"label": "ex3", "detail": "?a ≤ ?b → ?c ≤ ?d → ?a + ?c ≤ ?b + ?d"},
-  {"label": "ax1", "detail": "?a ≤ ?b → ?a - ?a ≤ ?b - ?b"},
-  {"label": "ex1", "detail": "?a ≤ ?b → ?a + ?a ≤ ?b + ?b"}],
+ [{"label": "ex2", "detail": "a ≤ b → a + 2 ≤ b + 2"},
+  {"label": "ex3", "detail": "a ≤ b → c ≤ d → a + c ≤ b + d"},
+  {"label": "ax1", "detail": "a ≤ b → a - a ≤ b - b"},
+  {"label": "ex1", "detail": "a ≤ b → a + a ≤ b + b"}],
  "isIncomplete": true}
 {"textDocument": {"uri": "file://completion2.lean"},
  "position": {"line": 30, "character": 21}}
 {"items":
- [{"label": "ex2", "detail": "?a ≤ ?b → ?a + 2 ≤ ?b + 2"},
-  {"label": "ex3", "detail": "?a ≤ ?b → ?c ≤ ?d → ?a + ?c ≤ ?b + ?d"},
-  {"label": "ax1", "detail": "?a ≤ ?b → ?a - ?a ≤ ?b - ?b"},
-  {"label": "ex1", "detail": "?a ≤ ?b → ?a + ?a ≤ ?b + ?b"}],
+ [{"label": "ex2", "detail": "a ≤ b → a + 2 ≤ b + 2"},
+  {"label": "ex3", "detail": "a ≤ b → c ≤ d → a + c ≤ b + d"},
+  {"label": "ax1", "detail": "a ≤ b → a - a ≤ b - b"},
+  {"label": "ex1", "detail": "a ≤ b → a + a ≤ b + b"}],
  "isIncomplete": true}
 {"textDocument": {"uri": "file://completion2.lean"},
  "position": {"line": 37, "character": 22}}
 {"items":
- [{"label": "ex2", "detail": "?a ≤ ?b → ?a + 2 ≤ ?b + 2"},
-  {"label": "ex3", "detail": "?a ≤ ?b → ?c ≤ ?d → ?a + ?c ≤ ?b + ?d"},
-  {"label": "ex1", "detail": "?a ≤ ?b → ?a + ?a ≤ ?b + ?b"}],
+ [{"label": "ex2", "detail": "a ≤ b → a + 2 ≤ b + 2"},
+  {"label": "ex3", "detail": "a ≤ b → c ≤ d → a + c ≤ b + d"},
+  {"label": "ex1", "detail": "a ≤ b → a + a ≤ b + b"}],
  "isIncomplete": true}

--- a/tests/lean/interactive/completion7.lean.expected.out
+++ b/tests/lean/interactive/completion7.lean.expected.out
@@ -8,7 +8,7 @@
 {"textDocument": {"uri": "file://completion7.lean"},
  "position": {"line": 2, "character": 11}}
 {"items":
- [{"label": "intro", "detail": "?a → ?b → ?a ∧ ?b"},
-  {"label": "left", "detail": "?a ∧ ?b → ?a"},
-  {"label": "right", "detail": "?a ∧ ?b → ?b"}],
+ [{"label": "intro", "detail": "a → b → a ∧ b"},
+  {"label": "left", "detail": "a ∧ b → a"},
+  {"label": "right", "detail": "a ∧ b → b"}],
  "isIncomplete": true}

--- a/tests/lean/interactive/completionDocString.lean.expected.out
+++ b/tests/lean/interactive/completionDocString.lean.expected.out
@@ -5,6 +5,6 @@
    "documentation":
    {"value": "Insert element `a` at position `i`.\n  Pre: `i < as.size` ",
     "kind": "markdown"},
-   "detail": "Array ?α → Nat → ?α → Array ?α"},
-  {"label": "insertAtAux", "detail": "Nat → Array ?α → Nat → Array ?α"}],
+   "detail": "Array α → Nat → α → Array α"},
+  {"label": "insertAtAux", "detail": "Nat → Array α → Nat → Array α"}],
  "isIncomplete": true}


### PR DESCRIPTION
Not sure whether it helps or creates more confusion.
We are still using the `?` prefix for metavariables on the InfoView and hover info.

Perhaps, we should just change how we display metavariables.  
