### PR TITLE
Remove unused header from lean.h

### DIFF
--- a/src/include/lean/lean.h
+++ b/src/include/lean/lean.h
@@ -21,7 +21,6 @@ Author: Leonardo de Moura
 #define LEAN_USING_STD using namespace std; /* NOLINT */
 extern "C" {
 #else
-#include <stdatomic.h>
 #define  LEAN_USING_STD
 #endif
 #include <lean/config.h>


### PR DESCRIPTION
chore: remove <stdatomic.h> because it is no longer needed.