### PR TITLE
Fix find-references for file-local identifiers

### DIFF
--- a/src/Lean/Server/References.lean
+++ b/src/Lean/Server/References.lean
@@ -235,10 +235,15 @@ def findAt (self : References) (module : Name) (pos : Lsp.Position) : Array RefI
     return refs.findAt pos
   #[]
 
-def referringTo (self : References) (ident : RefIdent) (srcSearchPath : SearchPath)
+def referringTo (self : References) (identModule : Name) (ident : RefIdent) (srcSearchPath : SearchPath)
     (includeDefinition : Bool := true) : IO (Array Location) := do
+  let refsToCheck := match ident with
+    | RefIdent.const _ => self.allRefs.toList
+    | RefIdent.fvar _ => match self.allRefs.find? identModule with
+      | none => []
+      | some refs => [(identModule, refs)]
   let mut result := #[]
-  for (module, refs) in self.allRefs.toList do
+  for (module, refs) in refsToCheck do
     if let some info := refs.find? ident then
       if let some path ← srcSearchPath.findModuleWithExt "lean" module then
         -- Resolve symlinks (such as `src` in the build dir) so that files are

--- a/src/Lean/Server/Watchdog.lean
+++ b/src/Lean/Server/Watchdog.lean
@@ -389,7 +389,7 @@ def handleReference (p : ReferenceParams) : ServerM (Array Location) := do
     if let some module ← searchModuleNameOfFileName path srcSearchPath then
       let references ← (← read).references.get
       for ident in references.findAt module p.position do
-        let identRefs ← references.referringTo ident srcSearchPath p.context.includeDeclaration
+        let identRefs ← references.referringTo module ident srcSearchPath p.context.includeDeclaration
         result := result.append identRefs
   return result
 


### PR DESCRIPTION
Previously, it would also find local references from other files on accident.