### PR TITLE
feat: option to prettyprint fvarid instead of binder name in LCNF

### DIFF
--- a/src/Lean/PrettyPrinter/Delaborator/Options.lean
+++ b/src/Lean/PrettyPrinter/Delaborator/Options.lean
@@ -58,6 +58,11 @@ register_builtin_option pp.letVarTypes : Bool := {
   group    := "pp"
   descr    := "(pretty printer) display types of let-bound variables"
 }
+register_builtin_option pp.letShowFVarId : Bool := {
+  defValue := false
+  group    := "pp"
+  descr    := "(pretty printer) display fvarId instead of binder name of let-bound variables"
+}
 register_builtin_option pp.instantiateMVars : Bool := {
   defValue := false -- TODO: default to true?
   group    := "pp"


### PR DESCRIPTION
For debugging, I often need to pretty print LCNF declarations and these declarations are not really internalized:
```
set_option trace.Compiler.result true in
#eval runOnDecls [``String.toSubstring] <|
  Probe.ppDecl
```
And here is an example of what I get:
```
def Array.getD α a i v₀ : _uniq.1 :=
  let _x.1 := @Array.size _ _uniq.2;
  let _x.2 := Nat.decLt _uniq.3 _uniq.5;
  cases _uniq.6 : _uniq.1
  | Decidable.isFalse x.3 =>
    return _uniq.4
  | Decidable.isTrue h =>
    let _x.4 := @Fin.mk _uniq.5 _uniq.3 ◾;
    let _x.5 := @Array.get _ _uniq.2 _uniq.9;
    return _uniq.10
```

One possibility is to explicitly internalize before pretty printing, but this changes the compiler state.

This PR proposes an alternative one: a new option, namely `pp.letShowFVarId`, to use fvarid's instead of binderNames when pretty printing (we always have fvarId's). We lose the pretty binder names, but we now are able to link let terms in LCNF when debugging. And without changing the compiler state.

For instance:
```
set_option pp.letShowFVarId true in
set_option trace.Compiler.result true in
def add1 (x : Nat) : Nat := x + 1
```
And the corresponding pretty-printed LCNF:
```
 def add1 _uniq.3652 : Nat :=
      let _uniq.3653 := 1;
      let _uniq.3654 := Nat.add _uniq.3652 _uniq.3653;
      return _uniq.3654
```
