### PR TITLE
chore: use binderIdent consistently in grammar

### DIFF
--- a/src/Init/Notation.lean
+++ b/src/Init/Notation.lean
@@ -447,11 +447,13 @@ macro_rules
   | `($f $args* $ $a) => `($f $args* $a)
   | `($f $ $a) => `($f $a)
 
-@[inherit_doc Subtype] syntax "{ " withoutPosition(ident (" : " term)? " // " term) " }" : term
+@[inherit_doc Subtype] syntax "{ " withoutPosition(Lean.binderIdent (" : " term)? " // " term) " }" : term
 
 macro_rules
-  | `({ $x : $type // $p }) => ``(Subtype (fun ($x:ident : $type) => $p))
-  | `({ $x // $p })         => ``(Subtype (fun ($x:ident : _) => $p))
+  | `({ $x:ident : $type // $p }) => ``(Subtype (fun ($x:ident : $type) => $p))
+  | `({ $x:ident // $p })         => ``(Subtype (fun ($x:ident : _) => $p))
+  | `({ _ : $type // $p }) => ``(Subtype (fun (_ : $type) => $p))
+  | `({ _ // $p })         => ``(Subtype (fun (_ : _) => $p))
 
 /--
 `without_expected_type t` instructs Lean to elaborate `t` without an expected type.

--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -36,8 +36,8 @@ We provide two kinds of hints to the termination checker:
 2- A tactic for proving the recursive applications are "decreasing" (`p` is `tacticSeq`)
 -/
 def terminationHintMany (p : Parser) := leading_parser
-  atomic (lookahead (ident >> " => ")) >>
-  many1Indent (group (ppLine >> ident >> " => " >> p >> optional ";"))
+  atomic (lookahead (binderIdent >> " => ")) >>
+  many1Indent (group (ppLine >> binderIdent >> " => " >> p >> optional ";"))
 def terminationHint1 (p : Parser) := leading_parser p
 def terminationHint (p : Parser) := terminationHintMany p <|> terminationHint1 p
 
@@ -47,7 +47,7 @@ def decreasingBy := leading_parser
   "decreasing_by " >> terminationHint Tactic.tacticSeq
 
 def terminationByElement   := leading_parser
-  ppLine >> (ident <|> Term.hole) >> many (ident <|> Term.hole) >>
+  ppLine >> binderIdent >> many binderIdent >>
   " => " >> termParser >> optional ";"
 def terminationBy          := leading_parser
   ppLine >> "termination_by " >> many1Indent terminationByElement
@@ -259,7 +259,7 @@ def initializeKeyword := leading_parser
   "initialize " <|> "builtin_initialize "
 @[builtin_command_parser] def «initialize» := leading_parser
   declModifiers false >> initializeKeyword >>
-  optional (atomic (ident >> Term.typeSpec >> Term.leftArrow)) >> Term.doSeq
+  optional (atomic (binderIdent >> Term.typeSpec >> Term.leftArrow)) >> Term.doSeq
 
 @[builtin_command_parser] def «in»  := trailing_parser withOpen (" in " >> commandParser)
 

--- a/src/Lean/Parser/Syntax.lean
+++ b/src/Lean/Parser/Syntax.lean
@@ -67,7 +67,7 @@ def mixfixKind := «prefix» <|> «infix» <|> «infixl» <|> «infixr» <|> «p
   precedence >> optNamedName >> optNamedPrio >> ppSpace >> strLit >> darrow >> termParser
 -- NOTE: We use `suppressInsideQuot` in the following parsers because quotations inside them are evaluated in the same stage and
 -- thus should be ignored when we use `checkInsideQuot` to prepare the next stage for a builtin syntax change
-def identPrec  := leading_parser ident >> optPrecedence
+def identPrec  := leading_parser binderIdent >> optPrecedence
 
 def optKind : Parser := optional ("(" >> nonReservedSymbol "kind" >> ":=" >> ident >> ")")
 
@@ -89,7 +89,7 @@ def catBehavior := optional ("(" >> nonReservedSymbol "behavior" >> " := " >> (c
 @[builtin_command_parser] def syntaxCat := leading_parser
   optional docComment >> "declare_syntax_cat " >> ident >> catBehavior
 def macroArg  := leading_parser
-  optional (atomic (ident >> checkNoWsBefore "no space before ':'" >> ":")) >> syntaxParser argPrec
+  optional (atomic (binderIdent >> checkNoWsBefore "no space before ':'" >> ":")) >> syntaxParser argPrec
 def macroRhs : Parser := leading_parser withPosition termParser
 def macroTail := leading_parser atomic (" : " >> ident) >> darrow >> macroRhs
 @[builtin_command_parser] def «macro»       := leading_parser suppressInsideQuot <|

--- a/src/Lean/Parser/Term.lean
+++ b/src/Lean/Parser/Term.lean
@@ -160,7 +160,7 @@ are turned into a new anonymous constructor application. For example,
 @[builtin_term_parser] def anonymousCtor := leading_parser
   "⟨" >> sepBy termParser ", " >> "⟩"
 def optIdent : Parser :=
-  optional (atomic (ident >> " : "))
+  optional (atomic (binderIdent >> " : "))
 def fromTerm   := leading_parser
   "from " >> termParser
 def showRhs := fromTerm <|> byTactic'
@@ -209,7 +209,6 @@ In contrast to regular patterns, `e` may be an arbitrary term of the appropriate
 -/
 @[builtin_term_parser] def inaccessible := leading_parser
   ".(" >> withoutPosition termParser >> ")"
-def binderIdent : Parser  := ident <|> hole
 def binderType (requireType := false) : Parser :=
   if requireType then node nullKind (" : " >> termParser) else optional (" : " >> termParser)
 def binderTactic  := leading_parser
@@ -298,7 +297,7 @@ def matchAlts (rhsParser : Parser := termParser) : Parser :=
   leading_parser withPosition $ many1Indent (ppLine >> matchAlt rhsParser)
 
 def matchDiscr := leading_parser
-  optional (atomic (ident >> " : ")) >> termParser
+  optional (atomic (binderIdent >> " : ")) >> termParser
 
 def trueVal  := leading_parser nonReservedSymbol "true"
 def falseVal := leading_parser nonReservedSymbol "false"
@@ -394,7 +393,7 @@ def letIdBinder :=
     binderIdent <|> bracketedBinder
 /- Remark: we use `checkWsBefore` to ensure `let x[i] := e; b` is not parsed as `let x [i] := e; b` where `[i]` is an `instBinder`. -/
 def letIdLhs    : Parser :=
-  ident >> notFollowedBy (checkNoWsBefore "" >> "[")
+  binderIdent >> notFollowedBy (checkNoWsBefore "" >> "[")
     "space is required before instance '[...]' binders to distinguish them from array updates `let x[i] := e; ...`" >>
   many (ppSpace >> letIdBinder) >> optType
 def letIdDecl   := leading_parser (withAnonymousAntiquot := false)
@@ -467,7 +466,7 @@ It is often used when building macros.
   withPosition ("let_tmp " >> letDecl) >> optSemicolon termParser
 
 /- like `let_fun` but with optional name -/
-def haveIdLhs    := optional (ident >> many (ppSpace >> letIdBinder)) >> optType
+def haveIdLhs    := optional (binderIdent >> many (ppSpace >> letIdBinder)) >> optType
 def haveIdDecl   := leading_parser (withAnonymousAntiquot := false)
   atomic (haveIdLhs >> " := ") >> termParser
 def haveEqnsDecl := leading_parser (withAnonymousAntiquot := false)
@@ -612,7 +611,7 @@ def isIdent (stx : Syntax) : Bool :=
 @[builtin_term_parser] def namedPattern : TrailingParser := trailing_parser
   checkStackTop isIdent "expected preceding identifier" >>
   checkNoWsBefore "no space before '@'" >> "@" >>
-  optional (atomic (ident >> ":")) >> termParser maxPrec
+  optional (atomic (binderIdent >> ":")) >> termParser maxPrec
 
 /--
 `e |>.x` is a shorthand for `(e).x`.


### PR DESCRIPTION
This PR normalizes usage of `binderIdent` vs `ident` across the lean grammar. To construct this PR I reviewed every occurrence of `ident` to determine whether (1) it is introducing a new binding and (2) it would make sense to be allowed to use `_` with the meaning of introducing an unnamed (hygienic automatically named) variable, especially in cases where the unused variables linter might fire.

Currently the PR does not compile because there will be some staging and other bugfixing regarding the use and implementation of the `_` part of these commands. Before proceeding I would like a thumbs-up regarding all (or a subset of) the grammar changes proposed here. In the examples below each occurrence of `_x` represents an `ident` that would be allowed to be `_` under the proposal.

1. `{ _x // e }`
2. `by intros _x`
3. `by rename a => _x`
4. `by injection e with _x`
5. `by injections _x`
6. `by have' _x := e`
7. `by generalize _x : e = _x`
8. `by cases _x : e`
9. `termination_by' _x => e`
10. `decreasing_by _x => tac`
11. `initialize _x : e <- e`
12. `notation "foo" _x => e`
13. `macro "foo" _x:cat : cat => e`
14. `match _x : e with | _x@pat => e`
15. `let _x y := e; e`
16. `have _x y := e; e`

Additionally, places which used `ident <|> hole` for binders were changed to use `binderIdent`. This decreases the amount of ad-hoc special casing required in programs consuming and constructing lean syntax like mathport. (Unfortunately there is still some conversion required to go from `binderIdent` to `term`, since the `_` case is represented differently in each case.)
