### PR TITLE
refactor: simplify excluded middle proof

### DIFF
--- a/src/Init/Classical.lean
+++ b/src/Init/Classical.lean
@@ -24,37 +24,30 @@ theorem choose_spec {α : Sort u} {p : α → Prop} (h : ∃ x, p x) : p (choose
 
 /-- Diaconescu's theorem: excluded middle from choice, Function extensionality and propositional extensionality. -/
 theorem em (p : Prop) : p ∨ ¬p :=
-  let U (x : Prop) : Prop := x = True ∨ p
-  let V (x : Prop) : Prop := x = False ∨ p
-  have exU : ∃ x, U x := ⟨True, Or.inl rfl⟩
-  have exV : ∃ x, V x := ⟨False, Or.inl rfl⟩
-  let u : Prop := choose exU
-  let v : Prop := choose exV
-  have u_def : U u := choose_spec exU
-  have v_def : V v := choose_spec exV
-  have not_uv_or_p : u ≠ v ∨ p :=
-    match u_def, v_def with
-    | Or.inr h, _ => Or.inr h
-    | _, Or.inr h => Or.inr h
-    | Or.inl hut, Or.inl hvf =>
-      have hne : u ≠ v := by simp [hvf, hut, true_ne_false]
-      Or.inl hne
-  have p_implies_uv : p → u = v :=
-    fun hp =>
-    have hpred : U = V :=
-      funext fun x =>
-        have hl : (x = True ∨ p) → (x = False ∨ p) :=
-          fun _ => Or.inr hp
-        have hr : (x = False ∨ p) → (x = True ∨ p) :=
-          fun _ => Or.inr hp
-        show (x = True ∨ p) = (x = False ∨ p) from
-          propext (Iff.intro hl hr)
-    have h₀ : ∀ exU exV, @choose _ U exU = @choose _ V exV := by
-      rw [hpred]; intros; rfl
-    show u = v from h₀ _ _
-  match not_uv_or_p with
-  | Or.inl hne => Or.inr (mt p_implies_uv hne)
-  | Or.inr h   => Or.inl h
+  -- Divide `Bool` by `p`
+  let A := Quotient ⟨
+    fun x y => x = y ∨ p,
+    fun _ => Or.inl rfl,
+    fun
+      | Or.inl hxy => Or.inl (Eq.symm hxy)
+      | Or.inr hp => Or.inr hp,
+    fun
+      | Or.inl hxy, Or.inl hyz => Or.inl (Eq.trans hxy hyz)
+      | Or.inr hp, _ => Or.inr hp
+      | _, Or.inr hp => Or.inr hp
+  ⟩
+
+  -- Choose a section `σ : A → Bool` of the projection `π : Bool → A`
+  let π : Bool → A := Quotient.mk _
+  let σ : A → Bool := fun a => Classical.choose (Quotient.exists_rep a)
+  have σ_section (a : A) : π (σ a) = a := Classical.choose_spec (Quotient.exists_rep a)
+  have σ_injective {x y : A} (e : σ x = σ y) : x = y := σ_section x ▸ σ_section y ▸ congrArg π e
+
+  -- Whether `P` is true matches whether `σ (π true) = σ (π false)`, which is decidable
+  if h : σ (π true) = σ (π false) then
+    Or.inl (match Quotient.exact (σ_injective h) with | Or.inr b => b)
+  else
+    Or.inr (fun hp => h (congrArg σ (Quotient.sound (Or.inr hp))))
 
 theorem exists_true_of_nonempty {α : Sort u} : Nonempty α → ∃ _ : α, True
   | ⟨x⟩ => ⟨x, trivial⟩


### PR DESCRIPTION
The current `Classical.em` proof isn't that easy to follow. Since Lean has quotients, we can take a two-element type like `Bool`, and quotient it by `x = y ∨ P`. Then, the surjection `Bool → A` splits and we use the fact that `Bool` has decidable equality to decide `P`.

Based on proof at https://ncatlab.org/nlab/show/Diaconescu-Goodman-Myhill+theorem.