### PR TITLE
fix: bug in do expansion

### DIFF
--- a/src/Lean/Elab/Do.lean
+++ b/src/Lean/Elab/Do.lean
@@ -576,6 +576,8 @@ def mkMatch (ref : Syntax) (genParam : Syntax) (discrs : Syntax) (optMotive : Sy
 def concat (terminal : CodeBlock) (kRef : Syntax) (y? : Option Var) (k : CodeBlock) : TermElabM CodeBlock := do
   unless hasTerminalAction terminal.code do
     throwErrorAt kRef "`do` element is unreachable"
+  -- remove updates to variable `y` in `k` because `y` is being defined (see #2663)
+  let k := if let some y := y? then { k with uvars := eraseVars k.uvars #[y] } else k
   let (terminal, k) ← homogenize terminal k
   let xs := varSetToArray k.uvars
   let y ← match y? with | some y => pure y | none => `(y)

--- a/tests/lean/doIssue.lean
+++ b/tests/lean/doIssue.lean
@@ -21,3 +21,6 @@ def h (xs : Array Nat) : IO Unit := do
 def h' (xs : Array Nat) : IO Unit := do
   discard <| pure (xs.set! 0 1)
   IO.println xs
+
+example : IO Unit := do
+  let x ← if true then pure true else pure false

--- a/tests/lean/doIssue.lean
+++ b/tests/lean/doIssue.lean
@@ -24,3 +24,8 @@ def h' (xs : Array Nat) : IO Unit := do
 
 example : IO Unit := do
   let x ← if true then pure true else pure false
+
+example : Id Unit := do
+  let mut x ← if true then pure true else pure false
+  if let .true := x then
+    x := false

--- a/tests/lean/run/doNotation6.lean
+++ b/tests/lean/run/doNotation6.lean
@@ -12,7 +12,7 @@ if (← get) == 0 then
 modify (· - x)
 
 def f1 (x : Nat) : M Nat := do
-let v ←
+let v : Bool ←
   try
     dec x
     return x


### PR DESCRIPTION
As [reported on zulip](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/unknown.20identifier.20in.20.60let.20var.20.3A.3D.20if.20let.60/near/396272940). The second commit fixes #2663, which looks similar but is a separate issue. I also fixed some typos and formatting issues in the debugging code in this file.

This change now causes an unreachable warning on the following code:
```lean
example := do
  let x <- return
```
which is kind of true? But the error message points at the following doElem and says that is unreachable, which doesn't make much sense here since it points at the whole statement including the `return`. So I added a mechanism to suppress this error. (PS: this should really be a warning, not an error. The code is perfectly well interpretable even if parts of it are not reachable, and this can make editing annoying.)