### PR TITLE
feat: set_option for conv mode

### DIFF
--- a/src/Lean/Elab/Tactic/Conv/Basic.lean
+++ b/src/Lean/Elab/Tactic/Conv/Basic.lean
@@ -187,3 +187,17 @@ private def convLocalDecl (conv : Syntax) (hUserName : Name) : TacticM Unit := w
   Tactic.evalFirst
 
 end Lean.Elab.Tactic.Conv
+
+open Lean.Parser Tactic.Conv in
+/-- `set_option opt val in tacs` (the conv tactic) acts like `set_option opt val` at the command level,
+but it sets the option only within the conv tactics `tacs`. -/
+syntax (name := Lean.Parser.Tactic.Conv.«set_option») "set_option " ident ppSpace Lean.Parser.Command.optionValue " in " convSeq : conv
+
+namespace Lean.Elab.Tactic.Conv
+
+@[builtin_tactic Lean.Parser.Tactic.Conv.set_option] def elabSetOption : Tactic := fun stx => do
+  let options ← Elab.elabSetOption stx[1] stx[2]
+  withTheReader Core.Context (fun ctx => { ctx with maxRecDepth := maxRecDepth.get options, options := options }) do
+    evalTactic stx[4]
+
+end Lean.Elab.Tactic.Conv

--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -343,6 +343,11 @@ but it opens a namespace only within the tactics `tacs`. -/
 but it sets the option only within the tactics `tacs`. -/
 @[builtin_tactic_parser] def «set_option» := leading_parser:leadPrec
   "set_option " >> ident >> ppSpace >> Command.optionValue >> " in " >> tacticSeq
+
+-- /-- `set_option opt val in tacs` (the conv tactic) acts like `set_option opt val` at the command level,
+-- but it sets the option only within the conv tactics `tacs`. -/
+-- @[builtin_tactic_parser] def Conv.«set_option» := leading_parser:leadPrec
+--   "set_option " >> ident >> ppSpace >> Command.optionValue >> " in " >> convSeq
 end Tactic
 
 end Parser

--- a/tests/lean/setOptionConv.lean
+++ b/tests/lean/setOptionConv.lean
@@ -1,0 +1,21 @@
+import Lean
+
+example 
+  : (fun x : Nat => x + 0)
+    =
+    fun x => x
+  := 
+by
+  trace_state
+  set_option pp.funBinderTypes true in
+  trace_state; trace_state
+  trace_state
+
+  set_option pp.funBinderTypes false in
+
+  conv => 
+    trace_state
+    set_option pp.funBinderTypes true in
+    trace_state; trace_state
+    trace_state
+

--- a/tests/lean/setOptionConv.lean.expected.out
+++ b/tests/lean/setOptionConv.lean.expected.out
@@ -1,0 +1,8 @@
+⊢ (fun x => x + 0) = fun x => x
+⊢ (fun (x : Nat) => x + 0) = fun (x : Nat) => x
+⊢ (fun (x : Nat) => x + 0) = fun (x : Nat) => x
+⊢ (fun (x : Nat) => x + 0) = fun (x : Nat) => x
+| (fun x => x + 0) = fun x => x
+| (fun (x : Nat) => x + 0) = fun (x : Nat) => x
+| (fun (x : Nat) => x + 0) = fun (x : Nat) => x
+| (fun (x : Nat) => x + 0) = fun (x : Nat) => x


### PR DESCRIPTION
Setting options with `set_option ... in ...` was only possible in tactic mode. This PR enables it to do it in conv mode too. 

The only issue with my fix is that the syntax definition is in `src/Lean/Elab/Tactic/Conv/Basic.lean` which is clearly a bad place for it. Ideally it should be in `src/Lean/Parser/Command.lean` just next to the definition of `set_option` tactic but I do not know how to write the parser with `convSeq`

