### PR TITLE
chore: upstream Std's linter framework

### DIFF
--- a/src/Lean/Linter/OtherLinter/Basic.lean
+++ b/src/Lean/Linter/OtherLinter/Basic.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2020 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn, Robert Y. Lewis, Gabriel Ebner
+-/
+import Lean.Structure
+import Lean.Elab.InfoTree.Main
+import Lean.Elab.Exception
+
+open Lean Meta
+
+namespace Std.Tactic.Lint
+
+/-!
+# Basic linter types and attributes
+
+This file defines the basic types and attributes used by the linting
+framework.  A linter essentially consists of a function
+`(declaration : Name) → MetaM (Option MessageData)`, this function together with some
+metadata is stored in the `Linter` structure. We define two attributes:
+
+ * `@[std_linter]` applies to a declaration of type `Linter` and adds it to the default linter set.
+
+ * `@[nolint linterName]` omits the tagged declaration from being checked by
+   the linter with name `linterName`.
+-/
+
+/--
+Returns true if `decl` is an automatically generated declaration.
+
+Also returns true if `decl` is an internal name or created during macro
+expansion.
+-/
+def isAutoDecl (decl : Name) : CoreM Bool := do
+  if decl.hasMacroScopes then return true
+  if decl.isInternal then return true
+  if let Name.str n s := decl then
+    if s.startsWith "proof_" || s.startsWith "match_" then return true
+    if (← getEnv).isConstructor n && ["injEq", "inj", "sizeOf_spec"].any (· == s) then
+      return true
+    if let ConstantInfo.inductInfo _ := (← getEnv).find? n then
+      if [casesOnSuffix, recOnSuffix, brecOnSuffix, binductionOnSuffix, belowSuffix, "ibelow",
+          "ndrec", "ndrecOn", "noConfusionType", "noConfusion", "ofNat", "toCtorIdx"
+        ].any (· == s) then
+        return true
+      if let some _ := isSubobjectField? (← getEnv) n s then
+        return true
+  pure false
+
+/-- A linting test for the `#lint` command. -/
+structure Linter where
+  /-- `test` defines a test to perform on every declaration. It should never fail. Returning `none`
+  signifies a passing test. Returning `some msg` reports a failing test with error `msg`. -/
+  test : Name → MetaM (Option MessageData)
+  /-- `noErrorsFound` is the message printed when all tests are negative -/
+  noErrorsFound : MessageData
+  /-- `errorsFound` is printed when at least one test is positive -/
+  errorsFound : MessageData
+  /-- If `isFast` is false, this test will be omitted from `#lint-`. -/
+  isFast := true
+
+/-- A `NamedLinter` is a linter associated to a particular declaration. -/
+structure NamedLinter extends Linter where
+  /-- The name of the named linter. This is just the declaration name without the namespace. -/
+  name : Name
+  /-- The linter declaration name -/
+  declName : Name
+
+/-- Gets a linter by declaration name. -/
+def getLinter (name declName : Name) : CoreM NamedLinter := unsafe
+  return { ← evalConstCheck Linter ``Linter declName with name, declName }
+
+/-- Defines the `std_linter` extension for adding a linter to the default set. -/
+initialize stdLinterExt :
+    PersistentEnvExtension (Name × Bool) (Name × Bool) (NameMap (Name × Bool)) ←
+  let addEntryFn := fun m (n, b) => m.insert (n.updatePrefix .anonymous) (n, b)
+  registerPersistentEnvExtension {
+    mkInitial := pure {}
+    addImportedFn := fun nss => pure <|
+      nss.foldl (init := {}) fun m ns => ns.foldl (init := m) addEntryFn
+    addEntryFn
+    exportEntriesFn := fun es => es.fold (fun a _ e => a.push e) #[]
+  }
+
+/--
+Defines the `@[std_linter]` attribute for adding a linter to the default set.
+The form `@[std_linter disabled]` will not add the linter to the default set,
+but it will be shown by `#list_linters` and can be selected by the `#lint` command.
+
+Linters are named using their declaration names, without the namespace. These must be distinct.
+-/
+syntax (name := std_linter) "std_linter" &" disabled"? : attr
+
+initialize registerBuiltinAttribute {
+  name := `std_linter
+  descr := "Use this declaration as a linting test in #lint"
+  add   := fun decl stx kind => do
+    let dflt := stx[1].isNone
+    unless kind == .global do throwError "invalid attribute 'std_linter', must be global"
+    let shortName := decl.updatePrefix .anonymous
+    if let some (declName, _) := (stdLinterExt.getState (← getEnv)).find? shortName then
+      Elab.addConstInfo stx declName
+      throwError "invalid attribute 'std_linter', linter '{shortName}' has already been declared"
+    let constInfo ← getConstInfo decl
+    unless ← (isDefEq constInfo.type (mkConst ``Linter)).run' do
+      throwError "must have type Linter, got {constInfo.type}"
+    modifyEnv fun env => stdLinterExt.addEntry env (decl, dflt)
+}
+
+/-- `@[nolint linterName]` omits the tagged declaration from being checked by
+the linter with name `linterName`. -/
+syntax (name := nolint) "nolint" (ppSpace ident)+ : attr
+
+/-- Defines the user attribute `nolint` for skipping `#lint` -/
+initialize nolintAttr : ParametricAttribute (Array Name) ←
+  registerParametricAttribute {
+    name := `nolint
+    descr := "Do not report this declaration in any of the tests of `#lint`"
+    getParam := fun _ => fun
+      | `(attr| nolint $[$ids]*) => ids.mapM fun id => withRef id <| do
+        let shortName := id.getId.eraseMacroScopes
+        let some (declName, _) := (stdLinterExt.getState (← getEnv)).find? shortName
+          | throwError "linter '{shortName}' not found"
+        Elab.addConstInfo id declName
+        pure shortName
+      | _ => Elab.throwUnsupportedSyntax
+  }
+
+/-- Returns true if `decl` should be checked
+using `linter`, i.e., if there is no `nolint` attribute. -/
+def shouldBeLinted [Monad m] [MonadEnv m] (linter : Name) (decl : Name) : m Bool :=
+  return !((nolintAttr.getParam? (← getEnv) decl).getD #[]).contains linter

--- a/src/Lean/Linter/OtherLinter/Frontend.lean
+++ b/src/Lean/Linter/OtherLinter/Frontend.lean
@@ -1,0 +1,264 @@
+/-
+Copyright (c) 2020 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn, Robert Y. Lewis, Gabriel Ebner
+-/
+import Lean.Util.Paths
+import Lean.DeclarationRange
+import Lean.Elab.Command
+import Lean.Linter.OtherLinter.Basic
+
+/-!
+# Linter frontend and commands
+
+This file defines the linter commands which spot common mistakes in the code.
+* `#lint`: check all declarations in the current file
+* `#lint in Pkg`: check all declarations in the package `Pkg`
+  (so excluding core or other projects, and also excluding the current file)
+* `#lint in all`: check all declarations in the environment
+  (the current file and all imported files)
+
+For a list of default / non-default linters, see the "Linting Commands" user command doc entry.
+
+The command `#list_linters` prints a list of the names of all available linters.
+
+You can append a `*` to any command (e.g. `#lint* in Std`) to omit the slow tests.
+
+You can append a `-` to any command (e.g. `#lint- in Std`) to run a silent lint
+that suppresses the output if all checks pass.
+A silent lint will fail if any test fails.
+
+You can append a `+` to any command (e.g. `#lint+ in Std`) to run a verbose lint
+that reports the result of each linter, including  the successes.
+
+You can append a sequence of linter names to any command to run extra tests, in addition to the
+default ones. e.g. `#lint doc_blame_thm` will run all default tests and `doc_blame_thm`.
+
+You can append `only name1 name2 ...` to any command to run a subset of linters, e.g.
+`#lint only unused_arguments in Std`
+
+You can add custom linters by defining a term of type `Linter` with the `@[std_linter]` attribute.
+A linter defined with the name `Std.Tactic.Lint.myNewCheck` can be run with `#lint myNewCheck`
+or `#lint only myNewCheck`.
+If you add the attribute `@[std_linter disabled]` to `linter.myNewCheck` it will be registered,
+but not run by default.
+
+Adding the attribute `@[nolint doc_blame unused_arguments]` to a declaration
+omits it from only the specified linter checks.
+
+## Tags
+
+sanity check, lint, cleanup, command, tactic
+-/
+
+namespace Std.Tactic.Lint
+open Lean Std
+
+/-- Verbosity for the linter output. -/
+inductive LintVerbosity
+  /-- `low`: only print failing checks, print nothing on success. -/
+  | low
+  /-- `medium`: only print failing checks, print confirmation on success. -/
+  | medium
+  /-- `high`: print output of every check. -/
+  | high
+  deriving Inhabited, DecidableEq, Repr
+
+/-- `getChecks slow extra use_only` produces a list of linters.
+`extras` is a list of names that should resolve to declarations with type `linter`.
+If `useOnly` is true, it only uses the linters in `extra`.
+Otherwise, it uses all linters in the environment tagged with `@[std_linter]`.
+If `slow` is false, it only uses the fast default tests. -/
+def getChecks (slow : Bool) (useOnly : Bool) : CoreM (Array NamedLinter) := do
+  let mut result := #[]
+  unless useOnly do
+    for (name, declName, dflt) in stdLinterExt.getState (← getEnv) do
+      if dflt then
+        let linter ← getLinter name declName
+        if slow || linter.isFast then
+          let _ := Inhabited.mk linter
+          result := result.binInsert (·.name.lt ·.name) linter
+  pure result
+
+/--
+Runs all the specified linters on all the specified declarations in parallel,
+producing a list of results.
+-/
+def lintCore (decls : Array Name) (linters : Array NamedLinter) :
+    CoreM (Array (NamedLinter × HashMap Name MessageData)) := do
+  let env ← getEnv
+  let options ← getOptions -- TODO: sanitize options?
+
+  let tasks : Array (NamedLinter × Array (Name × Task (Option MessageData))) ←
+    linters.mapM fun linter => do
+      let decls ← decls.filterM (shouldBeLinted linter.name)
+      (linter, ·) <$> decls.mapM fun decl => (decl, ·) <$> do
+        BaseIO.asTask do
+          match ← withCurrHeartbeats (linter.test decl)
+              |>.run'.run' {options, fileName := "", fileMap := default} {env}
+              |>.toBaseIO with
+          | Except.ok msg? => pure msg?
+          | Except.error err => pure m!"LINTER FAILED:\n{err.toMessageData}"
+
+  tasks.mapM fun (linter, decls) => do
+    let mut msgs : HashMap Name MessageData := {}
+    for (declName, msg?) in decls do
+      if let some msg := msg?.get then
+        msgs := msgs.insert declName msg
+    pure (linter, msgs)
+
+/-- Sorts a map with declaration keys as names by line number. -/
+def sortResults (results : HashMap Name α) : CoreM <| Array (Name × α) := do
+  let mut key : HashMap Name Nat := {}
+  for (n, _) in results.toArray do
+    if let some range ← findDeclarationRanges? n then
+      key := key.insert n <| range.range.pos.line
+  pure $ results.toArray.qsort fun (a, _) (b, _) => key.findD a 0 < key.findD b 0
+
+/-- Formats a linter warning as `#check` command with comment. -/
+def printWarning (declName : Name) (warning : MessageData) (useErrorFormat : Bool := false)
+  (filePath : System.FilePath := default) : CoreM MessageData := do
+  if useErrorFormat then
+    if let some range ← findDeclarationRanges? declName then
+      return m!"{filePath}:{range.range.pos.line}:{range.range.pos.column + 1}: error: {
+          ← mkConstWithLevelParams declName} {warning}"
+  pure m!"#check {← mkConstWithLevelParams declName} /- {warning} -/"
+
+/-- Formats a map of linter warnings using `print_warning`, sorted by line number. -/
+def printWarnings (results : HashMap Name MessageData) (filePath : System.FilePath := default)
+    (useErrorFormat : Bool := false) : CoreM MessageData := do
+  (MessageData.joinSep ·.toList Format.line) <$>
+    (← sortResults results).mapM fun (declName, warning) =>
+      printWarning declName warning (useErrorFormat := useErrorFormat) (filePath := filePath)
+
+/--
+Formats a map of linter warnings grouped by filename with `-- filename` comments.
+The first `drop_fn_chars` characters are stripped from the filename.
+-/
+def groupedByFilename (results : HashMap Name MessageData) (useErrorFormat : Bool := false) :
+    CoreM MessageData := do
+  let sp ← if useErrorFormat then initSrcSearchPath ["."] else pure {}
+  let grouped : HashMap Name (System.FilePath × HashMap Name MessageData) ←
+    results.foldM (init := {}) fun grouped declName msg => do
+      let mod ← findModuleOf? declName
+      let mod := mod.getD (← getEnv).mainModule
+      grouped.insert mod <$>
+        match grouped.find? mod with
+        | some (fp, msgs) => pure (fp, msgs.insert declName msg)
+        | none => do
+          let fp ← if useErrorFormat then
+            pure <| (← sp.findWithExt "lean" mod).getD (modToFilePath "." mod "lean")
+          else pure default
+          pure (fp, .insert {} declName msg)
+  let grouped' := grouped.toArray.qsort fun (a, _) (b, _) => toString a < toString b
+  (MessageData.joinSep · (Format.line ++ Format.line)) <$>
+    grouped'.toList.mapM fun (mod, fp, msgs) => do
+      pure m!"-- {mod}\n{← printWarnings msgs (filePath := fp) (useErrorFormat := useErrorFormat)}"
+
+/--
+Formats the linter results as Lean code with comments and `#check` commands.
+-/
+def formatLinterResults
+    (results : Array (NamedLinter × HashMap Name MessageData))
+    (decls : Array Name)
+    (groupByFilename : Bool)
+    (whereDesc : String) (runSlowLinters : Bool)
+    (verbose : LintVerbosity) (numLinters : Nat) (useErrorFormat : Bool := false) :
+    CoreM MessageData := do
+  let formattedResults ← results.filterMapM fun (linter, results) => do
+    if !results.isEmpty then
+      let warnings ←
+        if groupByFilename || useErrorFormat then
+          groupedByFilename results (useErrorFormat := useErrorFormat)
+        else
+          printWarnings results
+      pure $ some m!"/- The `{linter.name}` linter reports:\n{linter.errorsFound} -/\n{warnings}\n"
+    else if verbose = LintVerbosity.high then
+      pure $ some m!"/- OK: {linter.noErrorsFound} -/"
+    else
+      pure none
+  let mut s := MessageData.joinSep formattedResults.toList Format.line
+  let numAutoDecls := (← decls.filterM isAutoDecl).size
+  let failed := results.map (·.2.size) |>.foldl (·+·) 0
+  unless verbose matches LintVerbosity.low do
+    s := m!"-- Found {failed} error{if failed == 1 then "" else "s"
+      } in {decls.size - numAutoDecls} declarations (plus {
+      numAutoDecls} automatically generated ones) {whereDesc
+      } with {numLinters} linters\n\n{s}"
+  unless runSlowLinters do s := m!"{s}-- (slow linters skipped)\n"
+  pure s
+
+/-- Get the list of declarations in the current module. -/
+def getDeclsInCurrModule : CoreM (Array Name) := do
+  pure $ (← getEnv).constants.map₂.foldl (init := #[]) fun r k _ => r.push k
+
+/-- Get the list of all declarations in the environment. -/
+def getAllDecls : CoreM (Array Name) := do
+  pure $ (← getEnv).constants.map₁.fold (init := ← getDeclsInCurrModule) fun r k _ => r.push k
+
+/-- Get the list of all declarations in the specified package. -/
+def getDeclsInPackage (pkg : Name) : CoreM (Array Name) := do
+  let env ← getEnv
+  let mut decls ← getDeclsInCurrModule
+  let modules := env.header.moduleNames.map (pkg.isPrefixOf ·)
+  return env.constants.map₁.fold (init := decls) fun decls declName _ =>
+    if modules[env.const2ModIdx[declName].get! (α := Nat)]! then
+      decls.push declName
+    else decls
+
+/-- The `in foo` config argument allows running the linter on a specified project. -/
+syntax inProject := " in " ident
+
+open Elab Command in
+/-- The command `#lint` runs the linters on the current file (by default).
+
+`#lint only someLinter` can be used to run only a single linter. -/
+elab tk:"#lint" verbosity:("+" <|> "-")? fast:"*"? only:(&" only")?
+    linters:(ppSpace ident)* project:(inProject)? : command => do
+  let (decls, whereDesc, groupByFilename) ← match project with
+    | none => do pure (← liftCoreM getDeclsInCurrModule, "in the current file", false)
+    | some cfg => match cfg with
+      | `(inProject| in $id) =>
+        let id := id.getId.eraseMacroScopes
+        if id == `all then
+          pure (← liftCoreM getAllDecls, "in all files", true)
+        else
+          pure (← liftCoreM (getDeclsInPackage id), s!"in {id}", true)
+      | _ => throwUnsupportedSyntax
+  let verbosity : LintVerbosity ← match verbosity with
+    | none => pure .medium
+    | some ⟨.node _ `token.«+» _⟩ => pure .high
+    | some ⟨.node _ `token.«-» _⟩ => pure .low
+    | _ => throwUnsupportedSyntax
+  let fast := fast.isSome
+  let only := only.isSome
+  let linters ← liftCoreM do
+    let mut result ← getChecks (slow := !fast) only
+    let linterState := stdLinterExt.getState (← getEnv)
+    for id in linters do
+      let name := id.getId.eraseMacroScopes
+      let some (declName, _) := linterState.find? name | throwErrorAt id "not a linter: {name}"
+      Elab.addConstInfo id declName
+      let linter ← getLinter name declName
+      result := result.binInsert (·.name.lt ·.name) linter
+    pure result
+  let results ← liftCoreM <| lintCore decls linters
+  let failed := results.any (!·.2.isEmpty)
+  let mut fmtResults ← liftCoreM <|
+    formatLinterResults results decls (groupByFilename := groupByFilename)
+      whereDesc (runSlowLinters := !fast) verbosity linters.size
+  if failed then
+    logError fmtResults
+  else if verbosity != LintVerbosity.low then
+    logInfoAt tk m!"{fmtResults}\n-- All linting checks passed!"
+
+open Elab Command in
+/-- The command `#list_linters` prints a list of all available linters. -/
+elab "#list_linters" : command => do
+  let mut result := #[]
+  for (name, _, dflt) in stdLinterExt.getState (← getEnv) do
+    result := result.binInsert (·.1.lt ·.1) (name, dflt)
+  let mut msg := m!"Available linters (linters marked with (*) are in the default lint set):"
+  for (name, dflt) in result do
+    msg := msg ++ m!"\n{name}{if dflt then " (*)" else ""}"
+  logInfo msg

--- a/src/Lean/Linter/OtherLinter/Misc.lean
+++ b/src/Lean/Linter/OtherLinter/Misc.lean
@@ -1,0 +1,283 @@
+/-
+Copyright (c) 2020 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn, Robert Y. Lewis, Arthur Paulino, Gabriel Ebner
+-/
+import Lean.Util.CollectLevelParams
+import Lean.Util.ForEachExpr
+import Lean.Util.Recognizers
+import Lean.Meta.Check
+import Lean.Meta.ForEachExpr
+import Lean.Meta.GlobalInstances
+import Lean.DocString
+import Lean.Linter.OtherLinter.Basic
+
+open Lean Meta
+
+namespace Std.Tactic.Lint
+
+/-!
+# Various linters
+
+This file defines several small linters.
+-/
+
+/-- A linter for checking whether a declaration has a namespace twice consecutively in its name. -/
+@[std_linter] def dupNamespace : Linter where
+  noErrorsFound := "No declarations have a duplicate namespace."
+  errorsFound := "DUPLICATED NAMESPACES IN NAME:"
+  test declName := do
+    if ← isAutoDecl declName then return none
+    if isGlobalInstance (← getEnv) declName then return none
+    let nm := declName.components
+    let some (dup, _) := nm.zip nm.tail! |>.find? fun (x, y) => x == y
+      | return none
+    return m!"The namespace {dup} is duplicated in the name"
+
+/-- A linter for checking for unused arguments.
+We skip all declarations that contain `sorry` in their value. -/
+@[std_linter] def unusedArguments : Linter where
+  noErrorsFound := "No unused arguments."
+  errorsFound := "UNUSED ARGUMENTS."
+  test declName := do
+    if ← isAutoDecl declName then return none
+    if ← isProjectionFn declName then return none
+    let info ← getConstInfo declName
+    let ty := info.type
+    let some val := info.value? | return none
+    if val.hasSorry || ty.hasSorry then return none
+    forallTelescope ty fun args ty => do
+      let mut e := (mkAppN val args).headBeta
+      e := mkApp e ty
+      for arg in args do
+        let ldecl ← getFVarLocalDecl arg
+        e := mkApp e ldecl.type
+        if let some val := ldecl.value? then
+          e := mkApp e val
+      let unused := args.zip (.range args.size) |>.filter fun (arg, _) =>
+        !e.containsFVar arg.fvarId!
+      if unused.isEmpty then return none
+      addMessageContextFull <| .joinSep (← unused.toList.mapM fun (arg, i) =>
+          return m!"argument {i+1} {arg} : {← inferType arg}") m!", "
+
+/-- A linter for checking definition doc strings. -/
+@[std_linter] def docBlame : Linter where
+  noErrorsFound := "No definitions are missing documentation."
+  errorsFound := "DEFINITIONS ARE MISSING DOCUMENTATION STRINGS:"
+  test declName := do
+    if (← isAutoDecl declName) || isGlobalInstance (← getEnv) declName then
+      return none -- FIXME: scoped/local instances should also not be linted
+    if let .str _ s := declName then
+      if s == "parenthesizer" || s == "formatter" || s == "delaborator" || s == "quot" then
+      return none
+    let kind ← match ← getConstInfo declName with
+      | .axiomInfo .. => pure "axiom"
+      | .opaqueInfo .. => pure "constant"
+      | .defnInfo info =>
+          -- leanprover/lean4#2575:
+          -- projections are generated as `def`s even when they should be `theorem`s
+          if ← isProjectionFn declName <&&> isProp info.type then
+            return none
+          pure "definition"
+      | .inductInfo .. => pure "inductive"
+      | _ => return none
+    let (none) ← findDocString? (← getEnv) declName | return none
+    return m!"{kind} missing documentation string"
+
+/-- A linter for checking theorem doc strings. -/
+@[std_linter disabled] def docBlameThm : Linter where
+  noErrorsFound := "No theorems are missing documentation."
+  errorsFound := "THEOREMS ARE MISSING DOCUMENTATION STRINGS:"
+  test declName := do
+    if ← isAutoDecl declName then
+      return none
+    let kind ← match ← getConstInfo declName with
+      | .thmInfo .. => pure "theorem"
+      | .defnInfo info =>
+          -- leanprover/lean4#2575:
+          -- projections are generated as `def`s even when they should be `theorem`s
+          if ← isProjectionFn declName <&&> isProp info.type then
+            pure "Prop projection"
+          else
+            return none
+      | _ => return none
+    let (none) ← findDocString? (← getEnv) declName | return none
+    return m!"{kind} missing documentation string"
+
+/-- A linter for checking whether the correct declaration constructor (definition or theorem)
+has been used. -/
+@[std_linter] def defLemma : Linter where
+  noErrorsFound := "All declarations correctly marked as def/lemma."
+  errorsFound := "INCORRECT DEF/LEMMA:"
+  test declName := do
+    if (← isAutoDecl declName) || isGlobalInstance (← getEnv) declName then
+      return none
+    -- leanprover/lean4#2575:
+    -- projections are generated as `def`s even when they should be `theorem`s
+    if ← isProjectionFn declName then return none
+    let info ← getConstInfo declName
+    let isThm ← match info with
+      | .defnInfo .. => pure false
+      | .thmInfo .. => pure true
+      | _ => return none
+    match isThm, ← isProp info.type with
+    | true, false => pure "is a lemma/theorem, should be a def"
+    | false, true => pure "is a def, should be lemma/theorem"
+    | _, _ => return none
+
+/-- A linter for checking whether statements of declarations are well-typed. -/
+@[std_linter] def checkType : Linter where
+  noErrorsFound :=
+    "The statements of all declarations type-check with default reducibility settings."
+  errorsFound := "THE STATEMENTS OF THE FOLLOWING DECLARATIONS DO NOT TYPE-CHECK."
+  isFast := true
+  test declName := do
+    if ← isAutoDecl declName then return none
+    if ← isTypeCorrect (← getConstInfo declName).type then return none
+    return m!"the statement doesn't type check."
+
+/--
+`univParamsGrouped e` computes for each `level` `u` of `e` the parameters that occur in `u`,
+and returns the corresponding set of lists of parameters.
+In pseudo-mathematical form, this returns `{{p : parameter | p ∈ u} | (u : level) ∈ e}`
+FIXME: We use `Array Name` instead of `HashSet Name`, since `HashSet` does not have an equality
+instance. It will ignore `nm₀.proof_i` declarations.
+-/
+private def univParamsGrouped (e : Expr) (nm₀ : Name) : Lean.HashSet (Array Name) :=
+  runST fun σ => do
+    let res ← ST.mkRef (σ := σ) {}
+    e.forEach fun
+      | .sort u =>
+        res.modify (·.insert (CollectLevelParams.visitLevel u {}).params)
+      | .const n us => do
+        if let .str n s .. := n then
+          if n == nm₀ && s.startsWith "proof_" then
+            return
+        res.modify <| us.foldl (·.insert <| CollectLevelParams.visitLevel · {} |>.params)
+      | _ => pure ()
+    res.get
+
+/--
+The good parameters are the parameters that occur somewhere in the set as a singleton or
+(recursively) with only other good parameters.
+All other parameters in the set are bad.
+-/
+private partial def badParams (l : Array (Array Name)) : Array Name :=
+  let goodLevels := l.filterMap fun
+    | #[u] => some u
+    | _ => none
+  if goodLevels.isEmpty then
+    l.flatten.toList.eraseDups.toArray
+  else
+    badParams <| l.map (·.filter (!goodLevels.contains ·))
+
+/-- A linter for checking that there are no bad `max u v` universe levels.
+Checks whether all universe levels `u` in the type of `d` are "good".
+This means that `u` either occurs in a `level` of `d` by itself, or (recursively)
+with only other good levels.
+When this fails, usually this means that there is a level `max u v`, where neither `u` nor `v`
+occur by themselves in a level. It is ok if *one* of `u` or `v` never occurs alone. For example,
+`(α : Type u) (β : Type (max u v))` is a occasionally useful method of saying that `β` lives in
+a higher universe level than `α`.
+-/
+@[std_linter] def checkUnivs : Linter where
+  noErrorsFound :=
+    "All declarations have good universe levels."
+  errorsFound := "THE STATEMENTS OF THE FOLLOWING DECLARATIONS HAVE BAD UNIVERSE LEVELS. \
+    This usually means that there is a `max u v` in the type where neither `u` nor `v` \
+    occur by themselves. Solution: Find the type (or type bundled with data) that has this \
+    universe argument and provide the universe level explicitly. If this happens in an implicit \
+    argument of the declaration, a better solution is to move this argument to a `variables` \
+    command (then it's not necessary to provide the universe level).\n\n\
+    It is possible that this linter gives a false positive on definitions where the value of the \
+    definition has the universes occur separately, and the definition will usually be used with \
+    explicit universe arguments. In this case, feel free to add `@[nolint checkUnivs]`."
+  isFast := true
+  test declName := do
+    if ← isAutoDecl declName then return none
+    let bad := badParams (univParamsGrouped (← getConstInfo declName).type declName).toArray
+    if bad.isEmpty then return none
+    return m!"universes {bad} only occur together."
+
+/-- A linter for checking that declarations aren't syntactic tautologies.
+Checks whether a lemma is a declaration of the form `∀ a b ... z, e₁ = e₂`
+where `e₁` and `e₂` are identical exprs.
+We call declarations of this form syntactic tautologies.
+Such lemmas are (mostly) useless and sometimes introduced unintentionally when proving basic facts
+with rfl when elaboration results in a different term than the user intended. -/
+@[std_linter] def synTaut : Linter where
+  noErrorsFound :=
+    "No declarations are syntactic tautologies."
+  errorsFound := "THE FOLLOWING DECLARATIONS ARE SYNTACTIC TAUTOLOGIES. \
+    This usually means that they are of the form `∀ a b ... z, e₁ = e₂` where `e₁` and `e₂` are \
+    identical expressions. We call declarations of this form syntactic tautologies. \
+    Such lemmas are (mostly) useless and sometimes introduced unintentionally when proving \
+    basic facts using `rfl`, when elaboration results in a different term than the user intended. \
+    You should check that the declaration really says what you think it does."
+  isFast := true
+  test declName := do
+    if ← isAutoDecl declName then return none
+    forallTelescope (← getConstInfo declName).type fun _ ty => do
+      let some (lhs, rhs) := ty.eq?.map (fun (_, l, r) => (l, r)) <|> ty.iff?
+        | return none
+      if lhs == rhs then
+        return m!"LHS equals RHS syntactically"
+      return none
+
+/--
+Return a list of unused `let_fun` terms in an expression.
+-/
+def findUnusedHaves (e : Expr) : MetaM (Array MessageData) := do
+  let res ← IO.mkRef #[]
+  forEachExpr e fun e => do
+    match e.letFun? with
+    | some (n, t, _, b) =>
+      if n.isInternal then return
+      if b.hasLooseBVars then return
+      let msg ← addMessageContextFull m!"unnecessary have {n.eraseMacroScopes} : {t}"
+      res.modify (·.push msg)
+    | _ => return
+  res.get
+
+/-- A linter for checking that declarations don't have unused term mode have statements. We do not
+tag this as `@[std_linter]` so that it is not in the default linter set as it is slow and an
+uncommon problem. -/
+@[std_linter] def unusedHavesSuffices : Linter where
+  noErrorsFound := "No declarations have unused term mode have statements."
+  errorsFound := "THE FOLLOWING DECLARATIONS HAVE INEFFECTUAL TERM MODE HAVE/SUFFICES BLOCKS. \
+    In the case of `have` this is a term of the form `have h := foo, bar` where `bar` does not \
+    refer to `foo`. Such statements have no effect on the generated proof, and can just be \
+    replaced by `bar`, in addition to being ineffectual, they may make unnecessary assumptions \
+    in proofs appear as if they are used. \
+    For `suffices` this is a term of the form `suffices h : foo, proof_of_goal, proof_of_foo` \
+    where `proof_of_goal` does not refer to `foo`. \
+    Such statements have no effect on the generated proof, and can just be replaced by \
+    `proof_of_goal`, in addition to being ineffectual, they may make unnecessary assumptions \
+    in proofs appear as if they are used."
+  test declName := do
+    if ← isAutoDecl declName then return none
+    let info ← getConstInfo declName
+    let mut unused ← findUnusedHaves info.type
+    if let some value := info.value? then
+      unused := unused ++ (← findUnusedHaves value)
+    unless unused.isEmpty do
+      return some <| .joinSep unused.toList ", "
+    return none
+
+/--
+A linter for checking if variables appearing on both sides of an iff are explicit. Ideally, such
+variables should be implicit instead.
+-/
+@[std_linter disabled] def explicitVarsOfIff : Linter where
+  noErrorsFound := "No explicit variables on both sides of iff"
+  errorsFound := "EXPLICIT VARIABLES ON BOTH SIDES OF IFF"
+  test declName := do
+    if ← isAutoDecl declName then return none
+    forallTelescope (← getConstInfo declName).type fun args ty => do
+      let some (lhs, rhs) := ty.iff? | return none
+      let explicit ← args.filterM fun arg =>
+        return (← getFVarLocalDecl arg).binderInfo.isExplicit &&
+          lhs.containsFVar arg.fvarId! && rhs.containsFVar arg.fvarId!
+      if explicit.isEmpty then return none
+      addMessageContextFull m!"should be made implicit: {
+        MessageData.joinSep (explicit.toList.map (m!"{·}")) ", "}"

--- a/src/Lean/Linter/OtherLinter/Simp.lean
+++ b/src/Lean/Linter/OtherLinter/Simp.lean
@@ -1,0 +1,243 @@
+/-
+Copyright (c) 2020 Gabriel Ebner. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gabriel Ebner
+-/
+import Lean.Meta.Tactic.Simp.Main
+import Lean.Linter.OtherLinter.Basic
+
+-- import Std.Util.LibraryNote -- Not yet ported
+
+open Lean Meta
+
+namespace Std.Tactic.Lint
+
+/-!
+# Linter for simplification lemmas
+
+This files defines several linters that prevent common mistakes when declaring simp lemmas:
+
+ * `simpNF` checks that the left-hand side of a simp lemma is not simplified by a different lemma.
+ * `simpVarHead` checks that the head symbol of the left-hand side is not a variable.
+ * `simpComm` checks that commutativity lemmas are not marked as simplification lemmas.
+-/
+
+/-- The data associated to a simp theorem. -/
+structure SimpTheoremInfo where
+  /-- The hypotheses of the theorem -/
+  hyps : Array Expr
+  /-- True if this is a conditional rewrite rule -/
+  isConditional : Bool
+  /-- The thing to replace -/
+  lhs : Expr
+  /-- The result of replacement -/
+  rhs : Expr
+
+/-- Given the list of hypotheses, is this a conditional rewrite rule? -/
+def isConditionalHyps (lhs : Expr) : List Expr → MetaM Bool
+  | [] => pure false
+  | h :: hs => do
+    let ldecl ← getFVarLocalDecl h
+    if !ldecl.binderInfo.isInstImplicit
+        && !(← hs.anyM fun h' =>
+          return (← inferType h').consumeTypeAnnotations.containsFVar h.fvarId!)
+        && !lhs.containsFVar h.fvarId! then
+      return true
+    isConditionalHyps lhs hs
+
+-- FIXME
+-- open private preprocess from Lean.Meta.Tactic.Simp.SimpTheorems in
+/-- Runs the continuation on all the simp theorems encoded in the given type. -/
+def withSimpTheoremInfos (ty : Expr) (k : SimpTheoremInfo → MetaM α) : MetaM (Array α) :=
+  withReducible do
+    sorry
+    -- let e ← preprocess (← mkSorry ty true) ty (inv := false) (isGlobal := true)
+    -- e.toArray.mapM fun (_, ty') => do
+    --   forallTelescopeReducing ty' fun hyps eq => do
+    --     let some (_, lhs, rhs) := eq.eq? | throwError "not an equality {eq}"
+    --     let isConditional ← isConditionalHyps lhs hyps.toList
+    --     k { hyps, lhs, rhs, isConditional }
+
+/-- Checks whether two expressions are equal for the simplifier. That is,
+they are reducibly-definitional equal, and they have the same head symbol. -/
+def isSimpEq (a b : Expr) (whnfFirst := true) : MetaM Bool := withReducible do
+  let a ← if whnfFirst then whnf a else pure a
+  let b ← if whnfFirst then whnf b else pure b
+  if a.getAppFn.constName? != b.getAppFn.constName? then return false
+  isDefEq a b
+
+/-- Constructs a message from all the simp theorems encoded in the given type. -/
+def checkAllSimpTheoremInfos (ty : Expr) (k : SimpTheoremInfo → MetaM (Option MessageData)) :
+    MetaM (Option MessageData) := do
+  let errors :=
+    (← withSimpTheoremInfos ty fun i => do (← k i).mapM addMessageContextFull).filterMap id
+  if errors.isEmpty then
+    return none
+  return MessageData.joinSep errors.toList Format.line
+
+/-- Returns true if this is a `@[simp]` declaration. -/
+def isSimpTheorem (declName : Name) : MetaM Bool := do
+  pure $ (← getSimpTheorems).lemmaNames.contains (.decl declName)
+
+open Lean.Meta.DiscrTree in
+/-- Returns the list of elements in the discrimination tree. -/
+partial def _root_.Lean.Meta.DiscrTree.elements (d : DiscrTree α) : Array α :=
+  d.root.foldl (init := #[]) fun arr _ => trieElements arr
+where
+  /-- Returns the list of elements in the trie. -/
+  trieElements (arr)
+  | Trie.node vs children =>
+    children.foldl (init := arr ++ vs) fun arr (_, child) => trieElements arr child
+
+open Std
+
+/-- Add message `msg` to any errors thrown inside `k`. -/
+def decorateError (msg : MessageData) (k : MetaM α) : MetaM α := do
+  try k catch e => throw (.error e.getRef m!"{msg}\n{e.toMessageData}")
+
+/-- Render the list of simp lemmas. -/
+def formatLemmas (usedSimps : Simp.UsedSimps) : MetaM MessageData := do
+  let mut args := #[]
+  let env ← getEnv
+  for (thm, _) in usedSimps.toArray.qsort (·.2 < ·.2) do
+    if let .decl declName := thm then
+      if env.contains declName && declName != ``eq_self then
+        args := args.push (← mkConstWithFreshMVarLevels declName)
+  return m!"simp only {args.toList}"
+
+/-- A linter for simp lemmas whose lhs is not in simp-normal form, and which hence never fire. -/
+@[std_linter] def simpNF : Linter where
+  noErrorsFound := "All left-hand sides of simp lemmas are in simp-normal form."
+  errorsFound := "SOME SIMP LEMMAS ARE NOT IN SIMP-NORMAL FORM.
+see note [simp-normal form] for tips how to debug this.
+https://leanprover-community.github.io/mathlib_docs/notes.html#simp-normal%20form"
+  test := fun declName => do
+    unless ← isSimpTheorem declName do return none
+    let ctx := { ← Simp.Context.mkDefault with config.decide := false }
+    checkAllSimpTheoremInfos (← getConstInfo declName).type fun {lhs, rhs, isConditional, ..} => do
+      let ({ expr := lhs', proof? := prf1, .. }, prf1Lems) ←
+        decorateError "simplify fails on left-hand side:" <| simp lhs ctx
+      if prf1Lems.contains (.decl declName) then return none
+      let ({ expr := rhs', .. }, used_lemmas) ←
+        decorateError "simplify fails on right-hand side:" <| simp rhs ctx (usedSimps := prf1Lems)
+      let lhs'EqRhs' ← isSimpEq lhs' rhs' (whnfFirst := false)
+      let lhsInNF ← isSimpEq lhs' lhs
+      if lhs'EqRhs' then
+        if prf1.isNone then return none -- TODO: FP rewriting foo.eq_2 using `simp only [foo]`
+        return m!"simp can prove this:
+  by {← formatLemmas used_lemmas}
+One of the lemmas above could be a duplicate.
+If that's not the case try reordering lemmas or adding @[priority].
+"
+      else if ¬ lhsInNF then
+        return m!"Left-hand side simplifies from
+  {lhs}
+to
+  {lhs'}
+using
+  {← formatLemmas prf1Lems}
+Try to change the left-hand side to the simplified term!
+"
+      else if !isConditional && lhs == lhs' then
+        return m!"Left-hand side does not simplify, when using the simp lemma on itself.
+This usually means that it will never apply.
+"
+      else
+        return none
+
+-- We haven't yet ported `Std.Util.LibraryNote`
+-- (which is incomplete in any case),
+-- so this is just a normal comment.
+-- library_note "simp-normal form"
+/-
+This note gives you some tips to debug any errors that the simp-normal form linter raises.
+
+The reason that a lemma was considered faulty is because its left-hand side is not in simp-normal
+form.
+These lemmas are hence never used by the simplifier.
+
+This linter gives you a list of other simp lemmas: look at them!
+
+Here are some tips depending on the error raised by the linter:
+
+  1. 'the left-hand side reduces to XYZ':
+     you should probably use XYZ as the left-hand side.
+
+  2. 'simp can prove this':
+     This typically means that lemma is a duplicate, or is shadowed by another lemma:
+
+     2a. Always put more general lemmas after specific ones:
+      ```
+      @[simp] lemma zero_add_zero : 0 + 0 = 0 := rfl
+      @[simp] lemma add_zero : x + 0 = x := rfl
+      ```
+
+      And not the other way around!  The simplifier always picks the last matching lemma.
+
+     2b. You can also use `@[priority]` instead of moving simp-lemmas around in the file.
+
+      Tip: the default priority is 1000.
+      Use `@[priority 1100]` instead of moving a lemma down,
+      and `@[priority 900]` instead of moving a lemma up.
+
+     2c. Conditional simp lemmas are tried last. If they are shadowed
+         just remove the `simp` attribute.
+
+     2d. If two lemmas are duplicates, the linter will complain about the first one.
+         Try to fix the second one instead!
+         (You can find it among the other simp lemmas the linter prints out!)
+
+  3. 'try_for tactic failed, timeout':
+     This typically means that there is a loop of simp lemmas.
+     Try to apply squeeze_simp to the right-hand side (removing this lemma from the simp set) to see
+     what lemmas might be causing the loop.
+
+     Another trick is to `set_option trace.simplify.rewrite true` and
+     then apply `try_for 10000 { simp }` to the right-hand side.  You will
+     see a periodic sequence of lemma applications in the trace message.
+-/
+
+/--
+A linter for simp lemmas whose lhs has a variable as head symbol,
+and which hence never fire.
+-/
+@[std_linter] def simpVarHead : Linter where
+  noErrorsFound :=
+    "No left-hand sides of a simp lemma has a variable as head symbol."
+  errorsFound := "LEFT-HAND SIDE HAS VARIABLE AS HEAD SYMBOL.
+Some simp lemmas have a variable as head symbol of the left-hand side (after whnfR):"
+  test := fun declName => do
+    unless ← isSimpTheorem declName do return none
+    checkAllSimpTheoremInfos (← getConstInfo declName).type fun {lhs, ..} => do
+    let lhs ← whnfR lhs
+    let headSym := lhs.getAppFn
+    unless headSym.isFVar do return none
+    return m!"Left-hand side has variable as head symbol: {headSym}"
+
+private def Expr.eqOrIff? : Expr → Option (Expr × Expr)
+  | .app (.app (.app (.const ``Eq _) _) lhs) rhs
+  | .app (.app (.const ``Iff _) lhs) rhs
+    => (lhs, rhs)
+  | _ => none
+
+/-- A linter for commutativity lemmas that are marked simp. -/
+@[std_linter] def simpComm : Linter where
+  noErrorsFound := "No commutativity lemma is marked simp."
+  errorsFound := "COMMUTATIVITY LEMMA IS SIMP.
+Some commutativity lemmas are simp lemmas:"
+  test := fun declName => withReducible do
+    unless ← isSimpTheorem declName do return none
+    let ty := (← getConstInfo declName).type
+    forallTelescopeReducing ty fun _ ty' => do
+    let some (lhs, rhs) := ty'.eqOrIff? | return none
+    unless lhs.getAppFn.constName? == rhs.getAppFn.constName? do return none
+    let (_, _, ty') ← forallMetaTelescopeReducing ty
+    let some (lhs', rhs') := ty'.eqOrIff? | return none
+    unless ← isDefEq rhs lhs' do return none
+    unless ← withNewMCtxDepth (isDefEq rhs lhs') do return none
+    -- make sure that the discrimination tree will actually find this match (see #69)
+    if (← (← DiscrTree.empty.insert rhs () simpDtConfig).getMatch lhs' simpDtConfig).isEmpty then
+      return none
+    -- ensure that the second application makes progress:
+    if ← isDefEq lhs' rhs' then return none
+    pure m!"should not be marked simp"

--- a/src/Lean/Linter/OtherLinter/TypeClass.lean
+++ b/src/Lean/Linter/OtherLinter/TypeClass.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2022 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gabriel Ebner
+-/
+import Lean.Meta.Instances
+import Lean.Linter.OtherLinter.Basic
+
+namespace Std.Tactic.Lint
+open Lean Meta
+
+/--
+Lints for instances with arguments that cannot be filled in, like
+```
+instance {α β : Type} [Group α] : Mul α where ...
+```
+-/
+@[std_linter] def impossibleInstance : Linter where
+  noErrorsFound := "No instance has arguments that are impossible to infer"
+  errorsFound := "SOME INSTANCES HAVE ARGUMENTS THAT ARE IMPOSSIBLE TO INFER
+These are arguments that are not instance-implicit and do not appear in
+another instance-implicit argument or the return type."
+  test declName := do
+    unless ← isInstance declName do return none
+    forallTelescopeReducing (← inferType (← mkConstWithLevelParams declName)) fun args ty => do
+    let argTys ← args.mapM inferType
+    let impossibleArgs ← args.zipWithIndex.filterMapM fun (arg, i) => do
+      let fv := arg.fvarId!
+      if (← fv.getDecl).binderInfo.isInstImplicit then return none
+      if ty.containsFVar fv then return none
+      if argTys[i+1:].any (·.containsFVar fv) then return none
+      return some m!"argument {i+1} {arg} : {← inferType arg}"
+    if impossibleArgs.isEmpty then return none
+    addMessageContextFull <| .joinSep impossibleArgs.toList ", "
+
+/--
+A linter for checking if any declaration whose type is not a class is marked as an instance.
+-/
+@[std_linter] def nonClassInstance : Linter where
+  noErrorsFound := "No instances of non-classes"
+  errorsFound := "INSTANCES OF NON-CLASSES"
+  test declName := do
+    if !(← isInstance declName) then return none
+    let info ← getConstInfo declName
+    if !(← isClass? info.type).isSome then return "should not be an instance"
+    return none


### PR DESCRIPTION
 It is the second linter framework from Std. It runs *after* declarations have been made, and e.g. can verify global properties of simp sets.

WIP, there are a number of problems here:

* Where does this go? 
* What namespace does it live in?
* The `simp` linter, which I've included here, uses `open private` to get access to simp internals.
* Do we actually want this? We could proceed without it for now, at the cost of separating some `@[nolint]` attributes from their declarations.