### PR TITLE
chore: run nix-ci whenever we run ci

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -6,6 +6,7 @@ on:
     tags:
       - '*'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
   merge_group:
 
 concurrency:


### PR DESCRIPTION
this unifies the `on` settings between nix-ci and ci, less confusion when adding a label doesn’t trigger all the CI stuff.
