### PR TITLE
feat: binary recursive implementation of List.mapA

### DIFF
--- a/src/Init/Data/List/Control.lean
+++ b/src/Init/Data/List/Control.lean
@@ -6,6 +6,7 @@ Author: Leonardo de Moura
 prelude
 import Init.Control.Basic
 import Init.Data.List.Basic
+import Init.Data.Nat.Log2
 
 namespace List
 universe u v w u₁ u₂
@@ -48,9 +49,15 @@ def mapM {m : Type u → Type v} [Monad m] {α : Type w} {β : Type u} (f : α �
   loop as []
 
 @[specialize]
-def mapA {m : Type u → Type v} [Applicative m] {α : Type w} {β : Type u} (f : α → m β) : List α → m (List β)
-  | []    => pure []
-  | a::as => List.cons <$> f a <*> mapA f as
+def mapA {m : Type u → Type v} [Applicative m] {α : Type w} {β : Type u} (f : α → m β) (as : List α) : m (List β) :=
+  let rec @[specialize] go : List α → Nat → List α × m (List β → List β)
+    | [],    _   => ([], pure id)
+    | a::as, 0   => (as, List.cons <$> f a)
+    | as,    n+1 =>
+      let (as, f₁) := go as n
+      let (as, f₂) := go as n
+      (as, Function.comp <$> f₁ <*> f₂)
+  (· []) <$> (go as as.length.log2).2
 
 @[specialize]
 protected def forM {m : Type u → Type v} [Monad m] {α : Type w} (as : List α) (f : α → m PUnit) : m PUnit :=


### PR DESCRIPTION
Inspired by https://github.com/leanprover/lean4/pull/3867#discussion_r1559543688 . After playing with this function a bit more, I was able to confirm that it's not really possible to implement it tail recursively in most monads (note that tail-recursiveness depends on the monad itself), because `seq` is not tail recursive in most monads and you have to stack up at least `n-1` of them to reduce a list of length `n`. However, we can do the next best thing which is to use a balanced tree of `seq` applications. I have confirmed that this will evaluate
```lean
#eval List.mapA (m := StateT Nat Id) pure (List.range 10000) |>.run 1
```
without stack overflow, unlike the original implementation, but it still deserves a `!bench` because the binary reduction has overhead and it may be worthwhile to switch over to naive recursion below some threshold.