### PR TITLE
perf: fix linearity issue in insertIfNew

### DIFF
--- a/src/Lean/Data/HashMap.lean
+++ b/src/Lean/Data/HashMap.lean
@@ -122,7 +122,7 @@ def expand [Hashable α] (size : Nat) (buckets : HashMapBucket α β) : HashMapI
     let ⟨i, h⟩ := mkIdx (hash a) buckets.property
     let bkt    := buckets.val[i]
     if let some b := bkt.find? a then
-      (m, some b)
+      (⟨size, buckets⟩, some b)
     else
       let size'    := size + 1
       let buckets' := buckets.update i (AssocList.cons a b bkt) h


### PR DESCRIPTION
This fixes a linearity isssue in `insertIfNew`. As `insertIfNew` is used in `Lean.finalizeImport` we expect this to improve performance.