### PR TITLE
chore: use ' instead of brackets for quotes

### DIFF
--- a/src/Lean/Attributes.lean
+++ b/src/Lean/Attributes.lean
@@ -332,7 +332,7 @@ unsafe def mkAttributeImplOfConstantUnsafe (env : Environment) (opts : Options) 
   | some info =>
     match info.type with
     | Expr.const `Lean.AttributeImpl _ => env.evalConst AttributeImpl opts declName
-    | _ => throw ("unexpected attribute implementation type at '" ++ toString declName ++ "' (`AttributeImpl` expected")
+    | _ => throw ("unexpected attribute implementation type at '" ++ toString declName ++ "' `AttributeImpl` expected")
 
 @[implemented_by mkAttributeImplOfConstantUnsafe]
 opaque mkAttributeImplOfConstant (env : Environment) (opts : Options) (declName : Name) : Except String AttributeImpl

--- a/src/Lean/Elab/App.lean
+++ b/src/Lean/Elab/App.lean
@@ -1029,7 +1029,7 @@ private def findMethodAlias? (env : Environment) (structName fieldName : Name) :
   | _   => none
 
 private def throwInvalidFieldNotation (e eType : Expr) : TermElabM α :=
-  throwLValError e eType "invalid field notation, type is not of the form (C ...) where C is a constant"
+  throwLValError e eType "invalid field notation, type is not of the form 'C ...' where C is a constant"
 
 private def resolveLValAux (e : Expr) (eType : Expr) (lval : LVal) : TermElabM LValResolution := do
   if eType.isForall then
@@ -1326,7 +1326,7 @@ where
     try
       tryPostponeIfMVar resultTypeFn
       let .const declName .. := resultTypeFn.cleanupAnnotations
-        | throwError "invalid dotted identifier notation, expected type is not of the form (... → C ...) where C is a constant{indentExpr expectedType}"
+        | throwError "invalid dotted identifier notation, expected type is not of the form '... → C ...' where C is a constant{indentExpr expectedType}"
       let idNew := declName ++ id.getId.eraseMacroScopes
       unless (← getEnv).contains idNew do
         throwError "invalid dotted identifier notation, unknown identifier `{idNew}` from expected type{indentExpr expectedType}"

--- a/src/Lean/Elab/StructInst.lean
+++ b/src/Lean/Elab/StructInst.lean
@@ -234,7 +234,7 @@ where
     if type.getAppFn.isMVar then
       throwUnknownExpectedType
     else
-      throwError "invalid \{...} notation, {kind} type is not of the form (C ...){indentExpr type}"
+      throwError "invalid \{...} notation, {kind} type is not of the form 'C ...'{indentExpr type}"
 
 inductive FieldLHS where
   | fieldName  (ref : Syntax) (name : Name)

--- a/src/Lean/Elab/Tactic/RCases.lean
+++ b/src/Lean/Elab/Tactic/RCases.lean
@@ -248,7 +248,7 @@ def subst' (goal : MVarId) (hFVarId : FVarId)
     (fvarSubst : FVarSubst := {}) : MetaM (FVarSubst × MVarId) := do
   let hLocalDecl ← hFVarId.getDecl
   let error {α} _ : MetaM α := throwTacticEx `subst goal
-    m!"invalid equality proof, it is not of the form (x = t) or (t = x){indentExpr hLocalDecl.type}"
+    m!"invalid equality proof, it is not of the form 'x = t' or 't = x'{indentExpr hLocalDecl.type}"
   let some (_, lhs, rhs) ← matchEq? hLocalDecl.type | error ()
   let substReduced (newType : Expr) (symm : Bool) : MetaM (FVarSubst × MVarId) := do
     let goal ← goal.assert hLocalDecl.userName newType (mkFVar hFVarId)

--- a/src/Lean/Meta/Instances.lean
+++ b/src/Lean/Meta/Instances.lean
@@ -267,7 +267,7 @@ def addDefaultInstance (declName : Name) (prio : Nat := 0) : MetaM Unit := do
         unless isClass (← getEnv) className do
           throwError "invalid default instance '{declName}', it has type '({className} ...)', but {className}' is not a type class"
         setEnv <| defaultInstanceExtension.addEntry (← getEnv) { className := className, instanceName := declName, priority := prio }
-      | _ => throwError "invalid default instance '{declName}', type must be of the form '(C ...)' where 'C' is a type class"
+      | _ => throwError "invalid default instance '{declName}', type must be of the form 'C ...' where 'C' is a type class"
 
 builtin_initialize
   registerBuiltinAttribute {

--- a/src/Lean/Meta/Tactic/Induction.lean
+++ b/src/Lean/Meta/Tactic/Induction.lean
@@ -188,7 +188,7 @@ def mkRecursorAppPrefix (mvarId : MVarId) (tacticName : Name) (majorFVarId : FVa
       let motive ← mkLambdaFVars indices motive
       return mkApp recursor motive
     | _ =>
-      throwTacticEx tacticName mvarId "major premise is not of the form (C ...)"
+      throwTacticEx tacticName mvarId "major premise is not of the form 'C ...'"
 
 def _root_.Lean.MVarId.induction (mvarId : MVarId) (majorFVarId : FVarId) (recursorName : Name) (givenNames : Array AltVarNames := #[]) : MetaM (Array InductionSubgoal) :=
   mvarId.withContext do

--- a/src/Lean/Meta/Tactic/Subst.lean
+++ b/src/Lean/Meta/Tactic/Subst.lean
@@ -112,9 +112,9 @@ def substCore (mvarId : MVarId) (hFVarId : FVarId) (symm := false) (fvarSubst : 
                 let newType := type.replaceFVar a b
                 cont motive newType
       | _ =>
-        let eqMsg := if symm then "(t = x)" else "(x = t)"
+        let eqMsg := if symm then "t = x" else "x = t"
         throwTacticEx `subst mvarId
-          m!"invalid equality proof, it is not of the form {eqMsg}{indentExpr hLocalDecl.type}\nafter WHNF, variable expected, but obtained{indentExpr a}"
+          m!"invalid equality proof, it is not of the form '{eqMsg}'{indentExpr hLocalDecl.type}\nafter WHNF, variable expected, but obtained{indentExpr a}"
 
 /--
   Given `h : HEq α a α b` in the given goal, produce a new goal where `h : Eq α a b`.
@@ -204,7 +204,7 @@ where
         else
           return (← substCore mvarId h (symm := false) (tryToSkip := true)).2
       else do
-        throwTacticEx `subst mvarId m!"invalid equality proof, it is not of the form (x = t) or (t = x){indentExpr localDecl.type}"
+        throwTacticEx `subst mvarId m!"invalid equality proof, it is not of the form 'x = t' or 't = x'{indentExpr localDecl.type}"
 
 /--
 Given `x`, try to find an equation of the form `heq : x = rhs` or `heq : lhs = x`,

--- a/tests/elabissues/invalid_field_notation_error_msg.lean
+++ b/tests/elabissues/invalid_field_notation_error_msg.lean
@@ -23,5 +23,5 @@ def Foo.f5 (f : Foo) : Nat := f.n
   (λ f g h => f.f1 + g.f2 + h.f3 + f.f4 + g.f5 + h.f6) f g h)
 
 /-
-/home/dselsam/omega/lean4/tests/elabissues/invalid_field_notation_error.lean:8:0: error: invalid field notation, type is not of the form (C ...) where C is a constant
+/home/dselsam/omega/lean4/tests/elabissues/invalid_field_notation_error.lean:8:0: error: invalid field notation, type is not of the form 'C ...' where C is a constant
 -/

--- a/tests/lean/run/4144.lean
+++ b/tests/lean/run/4144.lean
@@ -1,5 +1,5 @@
 /--
-error: invalid field notation, type is not of the form (C ...) where C is a constant
+error: invalid field notation, type is not of the form 'C ...' where C is a constant
   x✝
 has type
   ?m.9

--- a/tests/lean/run/funind_tests.lean
+++ b/tests/lean/run/funind_tests.lean
@@ -791,7 +791,7 @@ def nonmutual : Nat → Bool
 #check nonmutual.mutual_induct
 
 /--
-error: invalid field notation, type is not of the form (C ...) where C is a constant
+error: invalid field notation, type is not of the form 'C ...' where C is a constant
   id
 has type
   ?_ → ?_


### PR DESCRIPTION
Bracket used for quoting an expression, such as (C ...) in
```
invalid {...} notation, {kind} type is not of the form (C ...){indentExpr type}
```
have been replaced by 'C ...'. This makes the messages clearer.