### PR TITLE
chore: adjust DecidableRel instance for leOfOrd

### DIFF
--- a/src/Init/Data/Ord.lean
+++ b/src/Init/Data/Ord.lean
@@ -187,13 +187,15 @@ def lexOrd [Ord α] [Ord β] : Ord (α × β) where
 def ltOfOrd [Ord α] : LT α where
   lt a b := compare a b = Ordering.lt
 
-instance [Ord α] : DecidableRel (@LT.lt α ltOfOrd) :=
+attribute [local instance] ltOfOrd in
+instance [Ord α] : DecidableRel ((· : α) < ·) :=
   inferInstanceAs (DecidableRel (fun a b => compare a b = Ordering.lt))
 
 def leOfOrd [Ord α] : LE α where
   le a b := (compare a b).isLE
 
-instance [Ord α] : DecidableRel (@LE.le α leOfOrd) :=
+attribute [local instance] leOfOrd in
+instance [Ord α] : DecidableRel ((· : α) ≤ ·) :=
   inferInstanceAs (DecidableRel (fun a b => (compare a b).isLE))
 
 namespace Ord


### PR DESCRIPTION
Seeing if this helps with the problem reported at https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/synth.20.60DecidableRel.20.28.CE.B1.20.3A.3D.20.E2.84.9A.E2.89.A50.29.20.28.C2.B7.20.E2.89.A4.20.C2.B7.29.60.20fails/near/473519044