### PR TITLE
fix: reduce precedence of prefix `!` to 'lead'

### DIFF
--- a/src/Init/Data/BitVec/Lemmas.lean
+++ b/src/Init/Data/BitVec/Lemmas.lean
@@ -1845,7 +1845,7 @@ theorem getElem_concat (x : BitVec w) (b : Bool) (i : Nat) (h : i < w + 1) :
     (concat x b)[i + 1] = x[i] := by
   simp [getElem_concat, h, getLsbD_eq_getElem]
 
-@[simp] theorem not_concat (x : BitVec w) (b : Bool) : ~~~(concat x b) = concat (~~~x) !b := by
+@[simp] theorem not_concat (x : BitVec w) (b : Bool) : ~~~(concat x b) = concat (~~~x) (!b) := by
   ext i; cases i using Fin.succRecOn <;> simp [*, Nat.succ_lt_succ]
 
 @[simp] theorem concat_or_concat (x y : BitVec w) (a b : Bool) :

--- a/src/Init/Data/Bool.lean
+++ b/src/Init/Data/Bool.lean
@@ -462,7 +462,7 @@ theorem eq_true_imp_eq_false : ∀ {b : Bool}, (b = true → b = false) ↔ (b =
 
 /-! ### forall -/
 
-theorem forall_bool' {p : Bool → Prop} (b : Bool) : (∀ x, p x) ↔ p b ∧ p !b :=
+theorem forall_bool' {p : Bool → Prop} (b : Bool) : (∀ x, p x) ↔ p b ∧ p (!b) :=
   ⟨fun h ↦ ⟨h _, h _⟩, fun ⟨h₁, h₂⟩ x ↦ by cases b <;> cases x <;> assumption⟩
 
 @[simp]
@@ -471,7 +471,7 @@ theorem forall_bool {p : Bool → Prop} : (∀ b, p b) ↔ p false ∧ p true :=
 
 /-! ### exists -/
 
-theorem exists_bool' {p : Bool → Prop} (b : Bool) : (∃ x, p x) ↔ p b ∨ p !b :=
+theorem exists_bool' {p : Bool → Prop} (b : Bool) : (∃ x, p x) ↔ p b ∨ p (!b) :=
   ⟨fun ⟨x, hx⟩ ↦ by cases x <;> cases b <;> first | exact .inl ‹_› | exact .inr ‹_›,
     fun h ↦ by cases h <;> exact ⟨_, ‹_›⟩⟩
 

--- a/src/Init/Notation.lean
+++ b/src/Init/Notation.lean
@@ -334,7 +334,7 @@ macro_rules | `($x == $y) => `(binrel_no_prop% BEq.beq $x $y)
 
 @[inherit_doc] infixl:35 " && " => and
 @[inherit_doc] infixl:30 " || " => or
-@[inherit_doc] notation:max "!" b:40 => not b
+@[inherit_doc] notation:lead "!" b:40 => not b
 
 @[inherit_doc] notation:50 a:50 " ∈ " b:50 => Membership.mem b a
 /-- `a ∉ b` is negated elementhood. It is notation for `¬ (a ∈ b)`. -/

--- a/src/Lean/Compiler/LCNF/MonoTypes.lean
+++ b/src/Lean/Compiler/LCNF/MonoTypes.lean
@@ -22,7 +22,7 @@ def getRelevantCtorFields (ctorName : Name) : CoreM (Array Bool) := do
       let mut result := #[]
       for x in xs[info.numParams:] do
         let type ← Meta.inferType x
-        result := result.push !(← Meta.isProp type <||> Meta.isTypeFormerType type)
+        result := result.push <| !(← Meta.isProp type <||> Meta.isTypeFormerType type)
       return result
 
 /--

--- a/src/Lean/Elab/DeclNameGen.lean
+++ b/src/Lean/Elab/DeclNameGen.lean
@@ -71,7 +71,7 @@ private partial def winnowExpr (e : Expr) : MetaM Expr := do
           let .forallE _ _ fty' bi := fty | failure
           fty := fty'
           let arg := args[i]
-          if ← pure bi.isExplicit <||> (pure !arg.isSort <&&> isTypeFormer arg) then
+          if ← pure bi.isExplicit <||> (pure (!arg.isSort) <&&> isTypeFormer arg) then
             unless (← isProof arg) do
               e' := .app e' (← visit arg)
         return e'

--- a/src/Lean/Elab/Notation.lean
+++ b/src/Lean/Elab/Notation.lean
@@ -102,7 +102,7 @@ def mkUnexpander (attrKind : TSyntax ``attrKind) (pat qrhs : Term) : OptionT Mac
   The user could mention the same antiquotation from the lhs multiple
   times on the rhs, this heuristic does not support this.
   -/
-  guard !hasDuplicateAntiquot args
+  guard <| !hasDuplicateAntiquot args
   -- replace head constant with antiquotation so we're not dependent on the exact pretty printing of the head
   -- The reference is attached to the syntactic representation of the called function itself, not the entire function application
   let lhs ← `($$f:ident)

--- a/src/Lean/Elab/SyntheticMVars.lean
+++ b/src/Lean/Elab/SyntheticMVars.lean
@@ -427,7 +427,7 @@ mutual
        let succeeded ← synthesizeSyntheticMVar mvarId postponeOnError runTactics
        if succeeded then markAsResolved mvarId
        trace[Elab.postpone] if succeeded then format "succeeded" else format "not ready yet"
-       pure !succeeded
+       return !succeeded
     -- Merge new synthetic metavariables with `remainingPendingMVars`, i.e., metavariables that still couldn't be synthesized
     modify fun s => { s with pendingMVars := s.pendingMVars ++ remainingPendingMVars }
     return numSyntheticMVars != remainingPendingMVars.length

--- a/src/Lean/Elab/Tactic/BVDecide/Frontend/BVDecide.lean
+++ b/src/Lean/Elab/Tactic/BVDecide/Frontend/BVDecide.lean
@@ -157,12 +157,12 @@ def diagnose : DiagnosisM Unit := do
 end DiagnosisM
 
 def uninterpretedExplainer (d : Diagnosis) : Option MessageData := do
-  guard !d.uninterpretedSymbols.isEmpty
+  guard <| !d.uninterpretedSymbols.isEmpty
   let symList := d.uninterpretedSymbols.toList
   return m!"It abstracted the following unsupported expressions as opaque variables: {symList}"
 
 def unusedRelevantHypothesesExplainer (d : Diagnosis) : Option MessageData := do
-  guard !d.unusedRelevantHypotheses.isEmpty
+  guard <| !d.unusedRelevantHypotheses.isEmpty
   let hypList := d.unusedRelevantHypotheses.toList.map mkFVar
   return m!"The following potentially relevant hypotheses could not be used: {hypList}"
 
@@ -313,4 +313,3 @@ def evalBvTrace : Tactic := fun
 
 end Frontend
 end Lean.Elab.Tactic.BVDecide
-

--- a/src/Lean/Meta/Tactic/Backtrack.lean
+++ b/src/Lean/Meta/Tactic/Backtrack.lean
@@ -171,7 +171,7 @@ private partial def processIndependentGoals (orig : List MVarId) (goals remainin
     withTraceNode trace
       (fun _ => return m!"failed: {← ppMVarIds failed}, new: {← ppMVarIds newSubgoals}") do
     -- Update the list of goals with respect to which we need to check independence.
-    let goals' := (← goals.filterM (fun g => do pure !(← g.isAssigned))) ++ newSubgoals
+    let goals' := (← goals.filterM (fun g => not <$> g.isAssigned)) ++ newSubgoals
     -- If `commitIndependentGoals` is `true`, we will return the new goals
     -- regardless of whether we can make further progress on the other goals.
     if cfg.commitIndependentGoals && !newSubgoals.isEmpty then

--- a/src/Lean/Meta/Tactic/IndependentOf.lean
+++ b/src/Lean/Meta/Tactic/IndependentOf.lean
@@ -53,6 +53,6 @@ def isIndependentOf (L : List MVarId) (g : MVarId) : MetaM Bool := g.withContext
     -- If the goal is a subsingleton, it is independent of any other goals.
     return true
   -- Finally, we check if the goal `g` appears in the type of any of the goals `L`.
-  L.allM fun g' => do pure !((← getMVarDependencies g').contains g)
+  L.allM fun g' => do return !((← getMVarDependencies g').contains g)
 
 end Lean.MVarId

--- a/src/Lean/Meta/Tactic/Induction.lean
+++ b/src/Lean/Meta/Tactic/Induction.lean
@@ -205,7 +205,7 @@ def _root_.Lean.MVarId.induction (mvarId : MVarId) (majorFVarId : FVarId) (recur
         | some paramPos => if paramPos ≥ majorTypeArgs.size then throwTacticEx `induction mvarId m!"major premise type is ill-formed{indentExpr majorType}"
       let indices ← getMajorTypeIndices mvarId `induction recursorInfo majorType
       let target ← mvarId.getType
-      if (← pure !recursorInfo.depElim <&&> exprDependsOn target majorFVarId) then
+      if (← pure (!recursorInfo.depElim) <&&> exprDependsOn target majorFVarId) then
         throwTacticEx `induction mvarId m!"recursor '{recursorName}' does not support dependent elimination, but conclusion depends on major premise"
       -- Revert indices and major premise preserving variable order
       let (reverted, mvarId) ← mvarId.revert ((indices.map Expr.fvarId!).push majorFVarId) true

--- a/src/Lean/PrettyPrinter/Delaborator/Basic.lean
+++ b/src/Lean/PrettyPrinter/Delaborator/Basic.lean
@@ -391,7 +391,7 @@ partial def delab : Delab := do
 
   let k ← getExprKind
   let stx ← withIncDepth <| delabFor k <|> (liftM $ show MetaM _ from throwError "don't know how to delaborate '{k}'")
-  if ← getPPOption getPPAnalyzeTypeAscriptions <&&> getPPOption getPPAnalysisNeedsType <&&> pure !e.isMData then
+  if ← getPPOption getPPAnalyzeTypeAscriptions <&&> getPPOption getPPAnalysisNeedsType <&&> pure (!e.isMData) then
     let typeStx ← withType delab
     `(($stx : $typeStx)) >>= annotateCurPos
   else

--- a/src/Lean/PrettyPrinter/Delaborator/FieldNotation.lean
+++ b/src/Lean/PrettyPrinter/Delaborator/FieldNotation.lean
@@ -72,7 +72,7 @@ private def generalizedFieldInfo (c : Name) (args : Array Expr) : MetaM (Name ×
         return (field, i)
       else
         -- We only use the first explicit argument for field notation.
-        guard !(← fvarId.getBinderInfo).isExplicit
+        guard <| !(← fvarId.getBinderInfo).isExplicit
     failure
 
 /--
@@ -97,7 +97,7 @@ def fieldNotationCandidate? (f : Expr) (args : Array Expr) (useGeneralizedFieldN
   if useGeneralizedFieldNotation then
     try
       -- Avoid field notation for theorems
-      guard !(← isProof f)
+      guard <| !(← isProof f)
       return ← generalizedFieldInfo c args
     catch _ => pure ()
   -- It's not handled by any of the above.

--- a/tests/lean/run/arthur1.lean
+++ b/tests/lean/run/arthur1.lean
@@ -124,7 +124,7 @@ def opError1 (app v : String) : String :=
   s!"I can't perform a '{app}' operation on '{v}'"
 
 def Value.not : Value → Except String Value
-  | lit $ .bool b => return lit $ .bool !b
+  | lit $ .bool b => return lit $ .bool $ !b
   | v             => throw $ opError1 "!" v.typeStr
 
 def Value.add : Value → Value → Except String Value
@@ -196,7 +196,7 @@ def Value.eq : Value → Value → Except String Value
 def Value.ne : Value → Value → Except String Value
   | nil,     nil      => return lit $ .bool false
   | lit  lₗ, lit lᵣ   => return lit $ .bool $ !(lₗ.eq lᵣ)
-  | list lₗ, list  lᵣ => return lit $ .bool !(listLiteralEq lₗ lᵣ)
+  | list lₗ, list  lᵣ => return lit $ .bool $ !(listLiteralEq lₗ lᵣ)
   | lam ..,  lam ..   => throw "I can't compare functions"
   | _,       _        => return lit $ .bool true
 

--- a/tests/lean/run/arthur2.lean
+++ b/tests/lean/run/arthur2.lean
@@ -124,7 +124,7 @@ def opError1 (app v : String) : String :=
   s!"I can't perform a '{app}' operation on '{v}'"
 
 def Value.not : Value → Except String Value
-  | lit $ .bool b => return lit $ .bool !b
+  | lit $ .bool b => return lit $ .bool $ !b
   | v             => throw $ opError1 "!" v.typeStr
 
 def Value.add : Value → Value → Except String Value
@@ -196,7 +196,7 @@ def Value.eq : Value → Value → Except String Value
 def Value.ne : Value → Value → Except String Value
   | nil,     nil      => return lit $ .bool false
   | lit  lₗ, lit lᵣ   => return lit $ .bool $ !(lₗ.eq lᵣ)
-  | list lₗ, list  lᵣ => return lit $ .bool !(listLiteralEq lₗ lᵣ)
+  | list lₗ, list  lᵣ => return lit $ .bool $ !(listLiteralEq lₗ lᵣ)
   | lam ..,  lam ..   => throw "I can't compare functions"
   | _,       _        => return lit $ .bool true
 

--- a/tests/lean/run/constProp.lean
+++ b/tests/lean/run/constProp.lean
@@ -54,7 +54,7 @@ instance : OfNat Expr n where
   | _,    _,        _        => none
 
 @[simp] def UnaryOp.eval : UnaryOp → Val → Option Val
-  | .not, .bool b => some (.bool !b)
+  | .not, .bool b => some (.bool $ !b)
   | _,    _       => none
 
 inductive Stmt where
@@ -329,7 +329,7 @@ instance : Repr State where
   | op, a, b => .bin a op b
 
 @[simp] def UnaryOp.simplify : UnaryOp → Expr → Expr
-  | .not, .val (.bool b) => .val (.bool !b)
+  | .not, .val (.bool b) => .val (.bool $ !b)
   | op, a => .una op a
 
 @[simp] def Expr.simplify : Expr → Expr

--- a/tests/lean/run/doNotation2.lean
+++ b/tests/lean/run/doNotation2.lean
@@ -170,7 +170,7 @@ rfl
 
 def f3 (x : Nat) : IO Bool := do
 let y ← cond (x == 0) (do IO.println "hello"; pure true) (pure false);
-pure !y
+pure <| !y
 
 def f4 (x y : Nat) : Nat × Nat := Id.run <| do
   let mut (x, y) := (x, y)


### PR DESCRIPTION
The high precedence of `!` is causing issues with factorial notation in mathlib.

For example, in the following, the argument to `use` is being parsed as `3 (! contradiction)`.
```lean
example (h : False) : ∃ n : ℕ, n ≠ n := by
  use 3 !
  contradiction
```

Breaking change: expressions such as `guard !b` now need to be written as `guard <| !b` or `guard (!b)`.

Alternative solution (#5826): we could make prefix `!` require that it not be followed by any whitespace.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/precedence.20of.20Nat.2Efactorial/near/478253033)