### PR TITLE
chore: add newline at end of file for `lake new` templates

### DIFF
--- a/src/lake/Lake/CLI/Init.lean
+++ b/src/lake/Lake/CLI/Init.lean
@@ -24,12 +24,14 @@ s!"/{defaultLakeDir}
 "
 
 def basicFileContents :=
-  s!"def hello := \"world\""
+s!"def hello := \"world\"
+"
 
 def libRootFileContents (libName : String) (libRoot : Name) :=
 s!"-- This module serves as the root of the `{libName}` library.
 -- Import modules here that should be built as part of the library.
-import {libRoot}.Basic"
+import {libRoot}.Basic
+"
 
 def mainFileName : FilePath :=
   s!"{defaultExeRoot}.lean"


### PR DESCRIPTION
This PR adds a newline at end of each Lean file generated by `lake new` templates.

I have tested it with a locally compiled Lean with this commit. I hope these changes make `lake new`'s behavior more consistent with the Lean 4 plugins and libraries newlines convention.