### PR TITLE
feat: add simple `Ordering` lemmas

### DIFF
--- a/src/Init/Core.lean
+++ b/src/Init/Core.lean
@@ -1409,9 +1409,6 @@ theorem Nat.succ.injEq (u v : Nat) : (u.succ = v.succ) = (u = v) :=
 @[simp] theorem beq_iff_eq [BEq α] [LawfulBEq α] {a b : α} : a == b ↔ a = b :=
   ⟨eq_of_beq, by intro h; subst h; exact LawfulBEq.rfl⟩
 
-theorem beq_eq_eq [BEq α] [LawfulBEq α] {a b : α} : (a == b) = (a = b) :=
-  propext beq_iff_eq
-
 /-! # Prop lemmas -/
 
 /-- *Ex falso* for negation: from `¬a` and `a` anything follows. This is the same as `absurd` with

--- a/src/Init/Core.lean
+++ b/src/Init/Core.lean
@@ -1409,6 +1409,9 @@ theorem Nat.succ.injEq (u v : Nat) : (u.succ = v.succ) = (u = v) :=
 @[simp] theorem beq_iff_eq [BEq α] [LawfulBEq α] {a b : α} : a == b ↔ a = b :=
   ⟨eq_of_beq, by intro h; subst h; exact LawfulBEq.rfl⟩
 
+theorem beq_eq_eq [BEq α] [LawfulBEq α] {a b : α} : (a == b) = (a = b) :=
+  propext beq_iff_eq
+
 /-! # Prop lemmas -/
 
 /-- *Ex falso* for negation: from `¬a` and `a` anything follows. This is the same as `absurd` with

--- a/src/Init/Data/Ord.lean
+++ b/src/Init/Data/Ord.lean
@@ -235,6 +235,25 @@ theorem isGE_of_eq_eq {o : Ordering} : o = .eq → o.isGE := by
 theorem isGT_iff_eq_gt {o : Ordering} : o.isGT ↔ o = .gt := by
   cases o <;> simp
 
+@[simp]
+theorem swap_swap {o : Ordering} : o.swap.swap = o := by
+  cases o <;> simp
+
+@[simp] theorem swap_inj {o₁ o₂ : Ordering} : o₁.swap = o₂.swap ↔ o₁ = o₂ :=
+  ⟨fun h => by simpa using congrArg swap h, congrArg _⟩
+
+theorem swap_then (o₁ o₂ : Ordering) : (o₁.then o₂).swap = o₁.swap.then o₂.swap := by
+  cases o₁ <;> rfl
+
+theorem then_eq_lt {o₁ o₂ : Ordering} : o₁.then o₂ = lt ↔ o₁ = lt ∨ o₁ = eq ∧ o₂ = lt := by
+  cases o₁ <;> cases o₂ <;> decide
+
+theorem then_eq_eq {o₁ o₂ : Ordering} : o₁.then o₂ = eq ↔ o₁ = eq ∧ o₂ = eq := by
+  cases o₁ <;> simp [«then»]
+
+theorem then_eq_gt {o₁ o₂ : Ordering} : o₁.then o₂ = gt ↔ o₁ = gt ∨ o₁ = eq ∧ o₂ = gt := by
+  cases o₁ <;> cases o₂ <;> decide
+
 end Lemmas
 
 end Ordering

--- a/src/Init/Data/Ord.lean
+++ b/src/Init/Data/Ord.lean
@@ -16,6 +16,11 @@ namespace Ordering
 
 deriving instance DecidableEq for Ordering
 
+-- This becomes obsolete with https://github.com/leanprover/lean4/issues/5295
+instance : LawfulBEq Ordering where
+  eq_of_beq {a b} := by cases a <;> cases b <;> simp <;> rfl
+  rfl {a} := by cases a <;> rfl
+
 /-- Swaps less and greater ordering results -/
 def swap : Ordering → Ordering
   | .lt => .gt
@@ -85,6 +90,116 @@ Check whether the ordering is 'greater than or equal'.
 def isGE : Ordering → Bool
   | lt => false
   | _ => true
+
+section Lemmas
+
+@[simp]
+theorem lt_isLT : lt.isLT := rfl
+
+@[simp]
+theorem lt_isLE : lt.isLE := rfl
+
+@[simp]
+theorem lt_isEq : lt.isEq = false := rfl
+
+@[simp]
+theorem lt_isGE : lt.isGE = false := rfl
+
+@[simp]
+theorem lt_isGT : lt.isGT = false := rfl
+
+@[simp]
+theorem eq_isLT : eq.isLT = false := rfl
+
+@[simp]
+theorem eq_isLE : eq.isLE := rfl
+
+@[simp]
+theorem eq_isEq : eq.isEq := rfl
+
+@[simp]
+theorem eq_isGE : eq.isGE := rfl
+
+@[simp]
+theorem eq_isGT : eq.isGT = false := rfl
+
+@[simp]
+theorem gt_isLT : gt.isLT = false := rfl
+
+@[simp]
+theorem gt_isLE : gt.isLE = false := rfl
+
+@[simp]
+theorem gt_isEq : gt.isEq = false := rfl
+
+@[simp]
+theorem gt_isGE : gt.isGE := rfl
+
+@[simp]
+theorem gt_isGT : gt.isGT := rfl
+
+@[simp]
+theorem lt_swap : lt.swap = .gt := rfl
+
+@[simp]
+theorem eq_swap : eq.swap = .eq := rfl
+
+@[simp]
+theorem gt_swap : gt.swap = .lt := rfl
+
+theorem eq_eq_of_isLE_of_isLE_swap {o : Ordering} : o.isLE → o.swap.isLE → o = .eq := by
+  cases o <;> simp
+
+theorem eq_eq_of_isGE_of_isGE_swap {o : Ordering} : o.isGE → o.swap.isGE → o = .eq := by
+  cases o <;> simp
+
+theorem eq_eq_of_isLE_of_isGE {o : Ordering} : o.isLE → o.isGE → o = .eq := by
+  cases o <;> simp
+
+theorem eq_eq_of_eq_swap {o : Ordering} : o = o.swap → o = .eq := by
+  cases o <;> simp
+
+@[simp]
+theorem isLE_eq_false {o : Ordering} : o.isLE = false ↔ o = gt := by
+  cases o <;> simp
+
+@[simp]
+theorem swap_eq_gt {o : Ordering} : o.swap = .gt ↔ o = .lt := by
+  cases o <;> simp
+
+@[simp]
+theorem swap_eq_lt {o : Ordering} : o.swap = .lt ↔ o = .gt := by
+  cases o <;> simp
+
+@[simp]
+theorem swap_eq_eq {o : Ordering} : o.swap = .eq ↔ o = .eq := by
+  cases o <;> simp
+
+theorem isLT_iff_eq_lt {o : Ordering} : o.isLT ↔ o = .lt := by
+  cases o <;> simp
+
+theorem isLE_iff_eq_lt_or_eq_eq {o : Ordering} : o.isLE ↔ o = .lt ∨ o = .eq := by
+  cases o <;> simp
+
+theorem isLE_of_eq_lt {o : Ordering} : o = .lt → o.isLE := by
+  rintro rfl; rfl
+
+theorem isLE_of_eq_eq {o : Ordering} : o = .eq → o.isLE := by
+  rintro rfl; rfl
+
+theorem isGE_iff_eq_gt_or_eq_eq {o : Ordering} : o.isGE ↔ o = .gt ∨ o = .eq := by
+  cases o <;> simp
+
+theorem isGE_of_eq_gt {o : Ordering} : o = .gt → o.isGE := by
+  rintro rfl; rfl
+
+theorem isGE_of_eq_eq {o : Ordering} : o = .eq → o.isGE := by
+  rintro rfl; rfl
+
+theorem isGT_iff_eq_gt {o : Ordering} : o.isGT ↔ o = .gt := by
+  cases o <;> simp
+
+end Lemmas
 
 end Ordering
 

--- a/src/Init/Data/Ord.lean
+++ b/src/Init/Data/Ord.lean
@@ -10,16 +10,9 @@ import Init.Data.Array.Basic
 
 inductive Ordering where
   | lt | eq | gt
-deriving Inhabited, BEq
+deriving Inhabited, DecidableEq
 
 namespace Ordering
-
-deriving instance DecidableEq for Ordering
-
--- This becomes obsolete with https://github.com/leanprover/lean4/issues/5295
-instance : LawfulBEq Ordering where
-  eq_of_beq {a b} := by cases a <;> cases b <;> simp <;> rfl
-  rfl {a} := by cases a <;> rfl
 
 /-- Swaps less and greater ordering results -/
 def swap : Ordering → Ordering

--- a/src/Init/Data/Ord.lean
+++ b/src/Init/Data/Ord.lean
@@ -103,6 +103,9 @@ theorem lt_isLE : lt.isLE := rfl
 theorem lt_isEq : lt.isEq = false := rfl
 
 @[simp]
+theorem lt_isNe : lt.isNe = true := rfl
+
+@[simp]
 theorem lt_isGE : lt.isGE = false := rfl
 
 @[simp]
@@ -118,6 +121,9 @@ theorem eq_isLE : eq.isLE := rfl
 theorem eq_isEq : eq.isEq := rfl
 
 @[simp]
+theorem eq_isNe : eq.isNe = false := rfl
+
+@[simp]
 theorem eq_isGE : eq.isGE := rfl
 
 @[simp]
@@ -131,6 +137,9 @@ theorem gt_isLE : gt.isLE = false := rfl
 
 @[simp]
 theorem gt_isEq : gt.isEq = false := rfl
+
+@[simp]
+theorem gt_isNe : gt.isNe = true := rfl
 
 @[simp]
 theorem gt_isGE : gt.isGE := rfl
@@ -160,7 +169,11 @@ theorem eq_eq_of_eq_swap {o : Ordering} : o = o.swap → o = .eq := by
   cases o <;> simp
 
 @[simp]
-theorem isLE_eq_false {o : Ordering} : o.isLE = false ↔ o = gt := by
+theorem isLE_eq_false {o : Ordering} : o.isLE = false ↔ o = .gt := by
+  cases o <;> simp
+
+@[simp]
+theorem isGE_eq_false {o : Ordering} : o.isGE = false ↔ o = .lt := by
   cases o <;> simp
 
 @[simp]
@@ -175,6 +188,30 @@ theorem swap_eq_lt {o : Ordering} : o.swap = .lt ↔ o = .gt := by
 theorem swap_eq_eq {o : Ordering} : o.swap = .eq ↔ o = .eq := by
   cases o <;> simp
 
+@[simp]
+theorem isLT_swap {o : Ordering} : o.swap.isLT = o.isGT := by
+  cases o <;> simp
+
+@[simp]
+theorem isLE_swap {o : Ordering} : o.swap.isLE = o.isGE := by
+  cases o <;> simp
+
+@[simp]
+theorem isEq_swap {o : Ordering} : o.swap.isEq = o.isEq := by
+  cases o <;> simp
+
+@[simp]
+theorem isNe_swap {o : Ordering} : o.swap.isNe = o.isNe := by
+  cases o <;> simp
+
+@[simp]
+theorem isGE_swap {o : Ordering} : o.swap.isGE = o.isLE := by
+  cases o <;> simp
+
+@[simp]
+theorem isGT_swap {o : Ordering} : o.swap.isGT = o.isLT := by
+  cases o <;> simp
+
 theorem isLT_iff_eq_lt {o : Ordering} : o.isLT ↔ o = .lt := by
   cases o <;> simp
 
@@ -186,6 +223,12 @@ theorem isLE_of_eq_lt {o : Ordering} : o = .lt → o.isLE := by
 
 theorem isLE_of_eq_eq {o : Ordering} : o = .eq → o.isLE := by
   rintro rfl; rfl
+
+theorem isEq_iff_eq_eq {o : Ordering} : o.isEq ↔ o = .eq := by
+  cases o <;> simp
+
+theorem isNe_iff_ne_eq {o : Ordering} : o.isNe ↔ o ≠ .eq := by
+  cases o <;> simp
 
 theorem isGE_iff_eq_gt_or_eq_eq {o : Ordering} : o.isGE ↔ o = .gt ∨ o = .eq := by
   cases o <;> simp

--- a/src/Init/Data/Ord.lean
+++ b/src/Init/Data/Ord.lean
@@ -87,67 +87,67 @@ def isGE : Ordering → Bool
 section Lemmas
 
 @[simp]
-theorem lt_isLT : lt.isLT := rfl
+theorem isLT_lt : lt.isLT := rfl
 
 @[simp]
-theorem lt_isLE : lt.isLE := rfl
+theorem isLE_lt : lt.isLE := rfl
 
 @[simp]
-theorem lt_isEq : lt.isEq = false := rfl
+theorem isEq_lt : lt.isEq = false := rfl
 
 @[simp]
-theorem lt_isNe : lt.isNe = true := rfl
+theorem isNe_lt : lt.isNe = true := rfl
 
 @[simp]
-theorem lt_isGE : lt.isGE = false := rfl
+theorem isGE_lt : lt.isGE = false := rfl
 
 @[simp]
-theorem lt_isGT : lt.isGT = false := rfl
+theorem isGT_lt : lt.isGT = false := rfl
 
 @[simp]
-theorem eq_isLT : eq.isLT = false := rfl
+theorem isLT_eq : eq.isLT = false := rfl
 
 @[simp]
-theorem eq_isLE : eq.isLE := rfl
+theorem isLE_eq : eq.isLE := rfl
 
 @[simp]
-theorem eq_isEq : eq.isEq := rfl
+theorem isEq_eq : eq.isEq := rfl
 
 @[simp]
-theorem eq_isNe : eq.isNe = false := rfl
+theorem isNe_eq : eq.isNe = false := rfl
 
 @[simp]
-theorem eq_isGE : eq.isGE := rfl
+theorem isGE_eq : eq.isGE := rfl
 
 @[simp]
-theorem eq_isGT : eq.isGT = false := rfl
+theorem isGT_eq : eq.isGT = false := rfl
 
 @[simp]
-theorem gt_isLT : gt.isLT = false := rfl
+theorem isLT_gt : gt.isLT = false := rfl
 
 @[simp]
-theorem gt_isLE : gt.isLE = false := rfl
+theorem isLE_gt : gt.isLE = false := rfl
 
 @[simp]
-theorem gt_isEq : gt.isEq = false := rfl
+theorem isEq_gt : gt.isEq = false := rfl
 
 @[simp]
-theorem gt_isNe : gt.isNe = true := rfl
+theorem isNe_gt : gt.isNe = true := rfl
 
 @[simp]
-theorem gt_isGE : gt.isGE := rfl
+theorem isGE_gt : gt.isGE := rfl
 
 @[simp]
-theorem gt_isGT : gt.isGT := rfl
+theorem isGT_gt : gt.isGT := rfl
 
 @[simp]
-theorem lt_swap : lt.swap = .gt := rfl
+theorem swap_lt : lt.swap = .gt := rfl
 
 @[simp]
-theorem eq_swap : eq.swap = .eq := rfl
+theorem swap_eq : eq.swap = .eq := rfl
 
 @[simp]
-theorem gt_swap : gt.swap = .lt := rfl
+theorem swap_gt : gt.swap = .lt := rfl
 
 theorem eq_eq_of_isLE_of_isLE_swap {o : Ordering} : o.isLE → o.swap.isLE → o = .eq := by
   cases o <;> simp
@@ -158,8 +158,11 @@ theorem eq_eq_of_isGE_of_isGE_swap {o : Ordering} : o.isGE → o.swap.isGE → o
 theorem eq_eq_of_isLE_of_isGE {o : Ordering} : o.isLE → o.isGE → o = .eq := by
   cases o <;> simp
 
-theorem eq_eq_of_eq_swap {o : Ordering} : o = o.swap → o = .eq := by
+theorem eq_swap_iff_eq_eq {o : Ordering} : o = o.swap ↔ o = .eq := by
   cases o <;> simp
+
+theorem eq_eq_of_eq_swap {o : Ordering} : o = o.swap → o = .eq :=
+  eq_swap_iff_eq_eq.mp
 
 @[simp]
 theorem isLE_eq_false {o : Ordering} : o.isLE = false ↔ o = .gt := by

--- a/tests/lean/run/simpConfigPropagationIssue3.lean
+++ b/tests/lean/run/simpConfigPropagationIssue3.lean
@@ -22,6 +22,6 @@ open OrientedCmp
 
 theorem ge_trans (h₁ : cmp x y ≠ .lt) (h₂ : cmp y z ≠ .lt) : cmp x z ≠ .lt := by
   have := @TransCmp.le_trans _ cmp _ z y x
-  simp? [cmp_eq_gt] at *
+  simp [cmp_eq_gt] at *
   -- `simp` did not fire at `this`
   exact this h₂ h₁

--- a/tests/lean/run/simpConfigPropagationIssue3.lean
+++ b/tests/lean/run/simpConfigPropagationIssue3.lean
@@ -1,12 +1,3 @@
-namespace Ordering
-
-@[simp] theorem swap_swap {o : Ordering} : o.swap.swap = o := by cases o <;> rfl
-
-@[simp] theorem swap_inj {o₁ o₂ : Ordering} : o₁.swap = o₂.swap ↔ o₁ = o₂ :=
-  ⟨fun h => by simpa using congrArg swap h, congrArg _⟩
-
-end Ordering
-
 /-- `OrientedCmp cmp` asserts that `cmp` is determined by the relation `cmp x y = .lt`. -/
 class OrientedCmp (cmp : α → α → Ordering) : Prop where
   /-- The comparator operation is symmetric, in the sense that if `cmp x y` equals `.lt` then
@@ -31,6 +22,6 @@ open OrientedCmp
 
 theorem ge_trans (h₁ : cmp x y ≠ .lt) (h₂ : cmp y z ≠ .lt) : cmp x z ≠ .lt := by
   have := @TransCmp.le_trans _ cmp _ z y x
-  simp [cmp_eq_gt] at *
+  simp? [cmp_eq_gt] at *
   -- `simp` did not fire at `this`
   exact this h₂ h₁


### PR DESCRIPTION
This PR adds basic lemmas about `Ordering`, describing the interaction of `isLT`/`isLE`/`isGE`/`isGT`, `swap` and the constructors. Additionally, it refactors the instance derivation code such that a `LawfulBEq Ordering` instance is also derived automatically.

Some of these lemmas are helpful for the `TreeMap` verification.