### PR TITLE
feat: containsThenInsertIfNew for the tree map

### DIFF
--- a/src/Std/Data/DTreeMap/Basic.lean
+++ b/src/Std/Data/DTreeMap/Basic.lean
@@ -101,6 +101,13 @@ def containsThenInsert (t : DTreeMap α β cmp) (a : α) (b : β a) : Bool × DT
 def insertIfNew (t : DTreeMap α β cmp) (a : α) (b : β a) : DTreeMap α β cmp :=
     letI : Ord α := ⟨cmp⟩; ⟨(t.inner.insertIfNew a b t.wf.balanced).impl, t.wf.insertIfNew⟩
 
+@[inline, inherit_doc Raw.containsThenInsertIfNew]
+def containsThenInsertIfNew (t : DTreeMap α β cmp) (a : α) (b : β a) :
+    Bool × DTreeMap α β cmp :=
+  letI : Ord α := ⟨cmp⟩
+  let p := t.inner.containsThenInsertIfNew a b t.wf.balanced
+  (p.1, ⟨p.2.impl, t.wf.containsThenInsertIfNew⟩)
+
 instance : Membership α (DTreeMap α β cmp) where
   mem m a := m.contains a
 

--- a/src/Std/Data/DTreeMap/Internal/Impl.lean
+++ b/src/Std/Data/DTreeMap/Internal/Impl.lean
@@ -48,12 +48,10 @@ inductive WF [Ord α] : Impl α β → Prop where
 
 /-- A well-formed tree is balanced. This is needed here already because we need to know that the
 tree is balanced to call the optimized modification functions. -/
-theorem WF.balanced [Ord α] {t : Impl α β} : WF t → t.Balanced
-  | .wf h _ => h
-  | .empty => balanced_empty
-  | .insert _ => TreeB.balanced_impl _
-  | .erase _ => TreeB.balanced_impl _
-  | .containsThenInsert _ => TreeB.balanced_impl _
+theorem WF.balanced [Ord α] {t : Impl α β} (h : WF t) : t.Balanced := by
+  cases h <;> try apply TreeB.balanced_impl
+  case wf htb hto => exact htb
+  case empty => exact balanced_empty
 
 end Impl
 

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -197,6 +197,22 @@ theorem containsThenInsertSlow_snd [TransOrd α] (h : t.WF) {k : α} {v : β k} 
   rw [snd_containsThenInsertSlow_eq_containsThenInsert _ h.balanced, containsThenInsert_snd h,
     insert_eq_insertSlow]
 
+theorem containsThenInsertIfNew_fst [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.containsThenInsertIfNew k v h.balanced).1 = t.contains k := by
+  rw [fst_containsThenInsertIfNew_eq_containsₘ, contains_eq_containsₘ]
+
+theorem containsThenInsertIfNewSlow_fst [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.containsThenInsertIfNewSlow k v).1 = t.contains k := by
+  rw [fst_containsThenInsertIfNewSlow_eq_containsₘ, contains_eq_containsₘ]
+
+theorem containsThenInsertIfNew_snd [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.containsThenInsertIfNew k v h.balanced).2 = t.insertIfNew k v h.balanced := by
+  rw [snd_containsThenInsertIfNew_eq_insertIfNew]
+
+theorem containsThenInsertIfNewSlow_snd [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.containsThenInsertIfNewSlow k v).2 = t.insertIfNewSlow k v := by
+  rw [snd_containsThenInsertIfNewSlow_eq_insertIfNewSlow]
+
 @[simp]
 theorem isEmpty_insertIfNew [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.insertIfNew k v h.balanced).impl.isEmpty = false := by

--- a/src/Std/Data/DTreeMap/Internal/Model.lean
+++ b/src/Std/Data/DTreeMap/Internal/Model.lean
@@ -377,18 +377,6 @@ theorem containsThenInsertSlow_eq_insertₘ [Ord α] (t : Impl α β) (htb : t.B
     (t.containsThenInsertSlow a b).2 = t.insertₘ a b htb := by
   rw [snd_containsThenInsertSlow_eq_containsThenInsert, containsThenInsert_eq_insertₘ]
 
-theorem fst_containsThenInsertIfNewSlow_eq_containsThenInsert [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
-    (t.containsThenInsertIfNewSlow a b).1 = (t.containsThenInsertIfNew a b htb).1 := by
-  simp [containsThenInsertIfNew, containsThenInsertIfNewSlow]
-  split <;> rfl
-
-theorem snd_containsThenInsertIfNewSlow_eq_containsThenInsert [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
-    (t.containsThenInsertIfNewSlow a b).2 = (t.containsThenInsertIfNew a b htb).2.impl := by
-  simp [containsThenInsertIfNew, containsThenInsertIfNewSlow]
-  split
-  · rfl
-  · simp [insertSlow_eq_insertₘ, insert_eq_insertₘ, htb]
-
 theorem insertIfNew_eq_insertIfNewSlow [Ord α] {k : α} {v : β k} {l : Impl α β} {h} :
     (insertIfNew k v l h).impl = insertIfNewSlow k v l := by
   simp [insertIfNew, insertIfNewSlow]
@@ -396,17 +384,37 @@ theorem insertIfNew_eq_insertIfNewSlow [Ord α] {k : α} {v : β k} {l : Impl α
   · rfl
   · simp [insert_eq_insertSlow]
 
--- theorem insertIfNew_eq_insertₘ [Ord α] {k : α} {v : β k} {l : Impl α β} {h} :
---     (insertIfNew k v l h).impl = insertₘ k v l h := by
---   simp only [insertIfNewₘ]
---   induction l
---   · simp only [insertIfNew, updateCell]
---     split <;> split <;> simp_all [balanceL_eq_balance, balanceR_eq_balance]
---   · simp [insertIfNew, insertₘ, updateCell]
+theorem fst_containsThenInsertIfNewSlow_eq_containsThenInsertIfNew [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+    (t.containsThenInsertIfNewSlow a b).1 = (t.containsThenInsertIfNew a b htb).1 := by
+  simp [containsThenInsertIfNew, containsThenInsertIfNewSlow]
+  split <;> rfl
 
--- theorem insertIfNewSlow_eq_insertₘ [Ord α] {k : α} {v : β k} {l : Impl α β} (h : l.Balanced) :
---     insertIfNewSlow k v l = insertₘ k v l h := by
---   rw [← insertIfNew_eq_insertSlow (h := h), insert_eq_insertₘ]
+theorem snd_containsThenInsertIfNewSlow_eq_containsThenInsertIfNew [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+    (t.containsThenInsertIfNewSlow a b).2 = (t.containsThenInsertIfNew a b htb).2.impl := by
+  simp [containsThenInsertIfNew, containsThenInsertIfNewSlow]
+  split
+  · rfl
+  · simp [insertSlow_eq_insertₘ, insert_eq_insertₘ, htb]
+
+theorem fst_containsThenInsertIfNew_eq_containsₘ [Ord α] [TransOrd α] (t : Impl α β) (htb : t.Balanced)
+    (a : α) (b : β a) : (t.containsThenInsertIfNew a b htb).1 = t.containsₘ a := by
+  simp [containsThenInsertIfNew, contains_eq_containsₘ]
+  split <;> next h => simp only [h]
+
+theorem snd_containsThenInsertIfNew_eq_insertIfNew [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+    (t.containsThenInsertIfNew a b htb).2.impl = (t.insertIfNew a b htb).impl := by
+  rw [containsThenInsertIfNew, insertIfNew]
+  split <;> rfl
+
+theorem fst_containsThenInsertIfNewSlow_eq_containsₘ [Ord α] [TransOrd α] (t : Impl α β) (htb : t.Balanced)
+    (a : α) (b : β a) : (t.containsThenInsertIfNewSlow a b).1 = t.containsₘ a := by
+  simp [containsThenInsertIfNewSlow, contains_eq_containsₘ]
+  split <;> next h => simp only [h]
+
+theorem snd_containsThenInsertIfNewSlow_eq_insertIfNewSlow [Ord α] (t : Impl α β) (a : α) (b : β a) :
+    (t.containsThenInsertIfNewSlow a b).2 = t.insertIfNewSlow a b:= by
+  rw [containsThenInsertIfNewSlow, insertIfNewSlow]
+  split <;> rfl
 
 end Impl
 

--- a/src/Std/Data/DTreeMap/Internal/Model.lean
+++ b/src/Std/Data/DTreeMap/Internal/Model.lean
@@ -402,11 +402,11 @@ theorem fst_containsThenInsertIfNew_eq_containsₘ [Ord α] [TransOrd α] (t : I
   split <;> next h => simp only [h]
 
 theorem snd_containsThenInsertIfNew_eq_insertIfNew [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
-    (t.containsThenInsertIfNew a b htb).2.impl = (t.insertIfNew a b htb).impl := by
+    (t.containsThenInsertIfNew a b htb).2 = (t.insertIfNew a b htb) := by
   rw [containsThenInsertIfNew, insertIfNew]
   split <;> rfl
 
-theorem fst_containsThenInsertIfNewSlow_eq_containsₘ [Ord α] [TransOrd α] (t : Impl α β) (htb : t.Balanced)
+theorem fst_containsThenInsertIfNewSlow_eq_containsₘ [Ord α] [TransOrd α] (t : Impl α β)
     (a : α) (b : β a) : (t.containsThenInsertIfNewSlow a b).1 = t.containsₘ a := by
   simp [containsThenInsertIfNewSlow, contains_eq_containsₘ]
   split <;> next h => simp only [h]

--- a/src/Std/Data/DTreeMap/Internal/WF.lean
+++ b/src/Std/Data/DTreeMap/Internal/WF.lean
@@ -770,6 +770,34 @@ theorem toListModel_insertIfNewSlow [Ord α] [TransOrd α] {k : α} {v : β k} {
   simpa [insertIfNew_eq_insertIfNewSlow] using toListModel_insertIfNew hlb hlo
 
 /-!
+### containsThenInsertIfNew
+-/
+
+theorem WF.containsThenInsertIfNew [Ord α] {k : α} {v : β k} {t : Impl α β}
+    (h : t.WF) : (t.containsThenInsertIfNew k v h.balanced).2.impl.WF := by
+  simpa only [snd_containsThenInsertIfNew_eq_insertIfNew, h.balanced] using h.insertIfNew
+
+theorem toListModel_containsThenInsertIfNew [Ord α] [TransOrd α] {k : α} {v : β k} {t : Impl α β} (htb : t.Balanced)
+    (hto : t.Ordered) :
+    (t.containsThenInsertIfNew k v htb).2.impl.toListModel.Perm (insertEntryIfNew k v t.toListModel) := by
+  rw [snd_containsThenInsertIfNew_eq_insertIfNew]
+  exact toListModel_insertIfNew htb hto
+
+/-!
+### containsThenInsertIfNewSlow
+-/
+
+theorem WF.containsThenInsertIfNewSlow [Ord α] {k : α} {v : β k} {t : Impl α β}
+    (h : t.WF) : (t.containsThenInsertIfNewSlow k v).2.WF := by
+  simpa only [snd_containsThenInsertIfNewSlow_eq_insertIfNewSlow, h.balanced] using h.insertIfNewSlow
+
+theorem toListModel_containsThenInsertIfNewSlow [Ord α] [TransOrd α] {k : α} {v : β k} {t : Impl α β} (htb : t.Balanced)
+    (hto : t.Ordered) :
+    (t.containsThenInsertIfNew k v htb).2.impl.toListModel.Perm (insertEntryIfNew k v t.toListModel) := by
+  rw [snd_containsThenInsertIfNew_eq_insertIfNew]
+  exact toListModel_insertIfNew htb hto
+
+/-!
 ## Deducing that well-formed trees are ordered
 -/
 

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -99,6 +99,16 @@ theorem containsThenInsert_snd [TransCmp cmp] {k : α} {v : β k} :
   ext <| congrArg Impl.TreeB.impl <| Impl.containsThenInsert_snd t.wf
 
 @[simp]
+theorem containsThenInsertIfNew_fst [TransCmp cmp] {k : α} {v : β k} :
+    (t.containsThenInsertIfNew k v).1 = t.contains k :=
+  Impl.containsThenInsertIfNew_fst t.wf
+
+@[simp]
+theorem containsThenInsertIfNew_snd [TransCmp cmp] {k : α} {v : β k} :
+    (t.containsThenInsertIfNew k v).2 = t.insertIfNew k v :=
+  ext <| congrArg Impl.TreeB.impl <| Impl.containsThenInsertIfNew_snd t.wf
+
+@[simp]
 theorem isEmpty_insertIfNew [TransCmp cmp] {k : α} {v : β k} :
     (t.insertIfNew k v).isEmpty = false :=
   Impl.isEmpty_insertIfNew t.wf

--- a/src/Std/Data/DTreeMap/Raw.lean
+++ b/src/Std/Data/DTreeMap/Raw.lean
@@ -162,6 +162,20 @@ returns the map unaltered.
 @[inline] def insertIfNew (t : Raw α β cmp) (a : α) (b : β a) : Raw α β cmp :=
     letI : Ord α := ⟨cmp⟩; ⟨t.inner.insertIfNewSlow a b⟩
 
+/--
+Checks whether a key is present in a map and inserts a value for the key if it was not found.
+
+If the returned `Bool` is `true`, then the returned map is unaltered. If the `Bool` is `false`, then
+the returned map has a new value inserted.
+
+Equivalent to (but potentially faster than) calling `contains` followed by `insertIfNew`.
+-/
+@[inline] def containsThenInsertIfNew (t : Raw α β cmp) (a : α) (b : β a) :
+    Bool × Raw α β cmp :=
+  letI : Ord α := ⟨cmp⟩
+  let p := t.inner.containsThenInsertIfNewSlow a b
+  (p.1, ⟨p.2⟩)
+
 instance : Membership α (Raw α β cmp) where
   mem m a := m.contains a
 

--- a/src/Std/Data/DTreeMap/RawLemmas.lean
+++ b/src/Std/Data/DTreeMap/RawLemmas.lean
@@ -99,6 +99,16 @@ theorem containsThenInsert_snd [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
   ext <| Impl.containsThenInsertSlow_snd h
 
 @[simp]
+theorem containsThenInsertIfNew_fst [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
+    (t.containsThenInsertIfNew k v).1 = t.contains k :=
+  Impl.containsThenInsertIfNewSlow_fst h
+
+@[simp]
+theorem containsThenInsertIfNew_snd [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
+    (t.containsThenInsertIfNew k v).2 = t.insertIfNew k v :=
+  ext <| Impl.containsThenInsertIfNewSlow_snd h
+
+@[simp]
 theorem isEmpty_insertIfNew [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
     (t.insertIfNew k v).isEmpty = false :=
   Impl.isEmpty_insertIfNewSlow h

--- a/src/Std/Data/TreeMap/Basic.lean
+++ b/src/Std/Data/TreeMap/Basic.lean
@@ -99,6 +99,12 @@ def containsThenInsert (t : TreeMap α β cmp) (a : α) (b : β) : Bool × TreeM
 def insertIfNew (t : TreeMap α β cmp) (a : α) (b : β) : TreeMap α β cmp :=
   ⟨t.inner.insertIfNew a b⟩
 
+@[inline, inherit_doc DTreeMap.containsThenInsertIfNew]
+def containsThenInsertIfNew [BEq α] [Hashable α] (t : TreeMap α β cmp) (a : α) (b : β) :
+    Bool × TreeMap α β cmp :=
+  let p := t.inner.containsThenInsertIfNew a b
+  (p.1, ⟨p.2⟩)
+
 instance : Membership α (TreeMap α β cmp) where
   mem m a := m.contains a
 

--- a/src/Std/Data/TreeMap/Basic.lean
+++ b/src/Std/Data/TreeMap/Basic.lean
@@ -100,7 +100,7 @@ def insertIfNew (t : TreeMap α β cmp) (a : α) (b : β) : TreeMap α β cmp :=
   ⟨t.inner.insertIfNew a b⟩
 
 @[inline, inherit_doc DTreeMap.containsThenInsertIfNew]
-def containsThenInsertIfNew [BEq α] [Hashable α] (t : TreeMap α β cmp) (a : α) (b : β) :
+def containsThenInsertIfNew (t : TreeMap α β cmp) (a : α) (b : β) :
     Bool × TreeMap α β cmp :=
   let p := t.inner.containsThenInsertIfNew a b
   (p.1, ⟨p.2⟩)

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -97,6 +97,16 @@ theorem containsThenInsert_snd [TransCmp cmp] {k : α} {v : β} :
   ext <| DTreeMap.containsThenInsert_snd
 
 @[simp]
+theorem containsThenInsertIfNew_fst [TransCmp cmp] {k : α} {v : β} :
+    (t.containsThenInsertIfNew k v).1 = t.contains k :=
+  DTreeMap.containsThenInsertIfNew_fst
+
+@[simp]
+theorem containsThenInsertIfNew_snd [TransCmp cmp] {k : α} {v : β} :
+    (t.containsThenInsertIfNew k v).2 = t.insertIfNew k v :=
+  ext <| DTreeMap.containsThenInsertIfNew_snd
+
+@[simp]
 theorem isEmpty_insertIfNew [TransCmp cmp] {k : α} {v : β} :
     (t.insertIfNew k v).isEmpty = false :=
   DTreeMap.isEmpty_insertIfNew

--- a/src/Std/Data/TreeMap/Raw.lean
+++ b/src/Std/Data/TreeMap/Raw.lean
@@ -119,6 +119,12 @@ def containsThenInsert (t : Raw α β cmp) (a : α) (b : β) : Bool × Raw α β
 def insertIfNew (t : Raw α β cmp) (a : α) (b : β) : Raw α β cmp :=
     letI : Ord α := ⟨cmp⟩; ⟨t.inner.insertIfNew a b⟩
 
+@[inline, inherit_doc DTreeMap.Raw.containsThenInsertIfNew]
+def containsThenInsertIfNew [BEq α] [Hashable α] (t : Raw α β cmp) (a : α) (b : β) :
+    Bool × Raw α β cmp :=
+  let p := t.inner.containsThenInsertIfNew a b
+  (p.1, ⟨p.2⟩)
+
 instance : Membership α (Raw α β cmp) where
   mem m a := m.contains a
 

--- a/src/Std/Data/TreeMap/Raw.lean
+++ b/src/Std/Data/TreeMap/Raw.lean
@@ -120,7 +120,7 @@ def insertIfNew (t : Raw α β cmp) (a : α) (b : β) : Raw α β cmp :=
     letI : Ord α := ⟨cmp⟩; ⟨t.inner.insertIfNew a b⟩
 
 @[inline, inherit_doc DTreeMap.Raw.containsThenInsertIfNew]
-def containsThenInsertIfNew [BEq α] [Hashable α] (t : Raw α β cmp) (a : α) (b : β) :
+def containsThenInsertIfNew (t : Raw α β cmp) (a : α) (b : β) :
     Bool × Raw α β cmp :=
   let p := t.inner.containsThenInsertIfNew a b
   (p.1, ⟨p.2⟩)

--- a/src/Std/Data/TreeMap/RawLemmas.lean
+++ b/src/Std/Data/TreeMap/RawLemmas.lean
@@ -97,6 +97,16 @@ theorem containsThenInsert_snd [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
   ext <| DTreeMap.Raw.containsThenInsert_snd h
 
 @[simp]
+theorem containsThenInsertIfNew_fst [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+    (t.containsThenInsertIfNew k v).1 = t.contains k :=
+  DTreeMap.Raw.containsThenInsertIfNew_fst h
+
+@[simp]
+theorem containsThenInsertIfNew_snd [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+    (t.containsThenInsertIfNew k v).2 = t.insertIfNew k v :=
+  ext <| DTreeMap.Raw.containsThenInsertIfNew_snd h
+
+@[simp]
 theorem isEmpty_insertIfNew [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
     (t.insertIfNew k v).isEmpty = false :=
   DTreeMap.Raw.isEmpty_insertIfNew h

--- a/src/Std/Data/TreeSet/Basic.lean
+++ b/src/Std/Data/TreeSet/Basic.lean
@@ -100,7 +100,7 @@ def insertIfNew (t : TreeSet α cmp) (a : α) : TreeSet α cmp :=
   ⟨t.inner.insertIfNew a ()⟩
 
 @[inline, inherit_doc Raw.containsThenInsertIfNew]
-def containsThenInsertIfNew [BEq α] [Hashable α] (t : TreeSet α cmp) (a : α) :
+def containsThenInsertIfNew (t : TreeSet α cmp) (a : α) :
     Bool × TreeSet α cmp :=
   let p := t.inner.containsThenInsertIfNew a ()
   (p.1, ⟨p.2⟩)

--- a/src/Std/Data/TreeSet/Basic.lean
+++ b/src/Std/Data/TreeSet/Basic.lean
@@ -99,6 +99,12 @@ def containsThenInsert (t : TreeSet α cmp) (a : α) : Bool × TreeSet α cmp :=
 def insertIfNew (t : TreeSet α cmp) (a : α) : TreeSet α cmp :=
   ⟨t.inner.insertIfNew a ()⟩
 
+@[inline, inherit_doc Raw.containsThenInsertIfNew]
+def containsThenInsertIfNew [BEq α] [Hashable α] (t : TreeSet α cmp) (a : α) :
+    Bool × TreeSet α cmp :=
+  let p := t.inner.containsThenInsertIfNew a ()
+  (p.1, ⟨p.2⟩)
+
 instance : Membership α (TreeSet α cmp) where
   mem m a := m.contains a
 

--- a/src/Std/Data/TreeSet/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Lemmas.lean
@@ -97,6 +97,16 @@ theorem containsThenInsert_snd [TransCmp cmp] {k : α} :
   ext <| TreeMap.containsThenInsert_snd
 
 @[simp]
+theorem containsThenInsertIfNew_fst [TransCmp cmp] {k : α} :
+    (t.containsThenInsertIfNew k).1 = t.contains k :=
+  TreeMap.containsThenInsertIfNew_fst
+
+@[simp]
+theorem containsThenInsertIfNew_snd [TransCmp cmp] {k : α} :
+    (t.containsThenInsertIfNew k).2 = t.insertIfNew k :=
+  ext <| TreeMap.containsThenInsertIfNew_snd
+
+@[simp]
 theorem isEmpty_insertIfNew [TransCmp cmp] {k : α} :
     (t.insertIfNew k).isEmpty = false :=
   DTreeMap.isEmpty_insertIfNew

--- a/src/Std/Data/TreeSet/Raw.lean
+++ b/src/Std/Data/TreeSet/Raw.lean
@@ -166,7 +166,7 @@ element, then the hash set is returned unchanged.
 Equivalent to (but potentially faster than) calling `contains` followed by `insert`.
 -/
 @[inline]
-def containsThenInsertIfNew [BEq α] [Hashable α] (t : Raw α cmp) (a : α) :
+def containsThenInsertIfNew (t : Raw α cmp) (a : α) :
     Bool × Raw α cmp :=
   letI : Ord α := ⟨cmp⟩
   let p := t.inner.containsThenInsertIfNew a ()

--- a/src/Std/Data/TreeSet/Raw.lean
+++ b/src/Std/Data/TreeSet/Raw.lean
@@ -158,6 +158,20 @@ differently: it will overwrite an existing mapping.
 def insertIfNew (t : Raw α cmp) (a : α) : Raw α cmp :=
     letI : Ord α := ⟨cmp⟩; ⟨t.inner.insertIfNew a ()⟩
 
+/--
+Checks whether an element is present in a set and inserts the element if it was not found.
+If the hash set already contains an element that is equal (with regard to `==`) to the given
+element, then the hash set is returned unchanged.
+
+Equivalent to (but potentially faster than) calling `contains` followed by `insert`.
+-/
+@[inline]
+def containsThenInsertIfNew [BEq α] [Hashable α] (t : Raw α cmp) (a : α) :
+    Bool × Raw α cmp :=
+  letI : Ord α := ⟨cmp⟩
+  let p := t.inner.containsThenInsertIfNew a ()
+  (p.1, ⟨p.2⟩)
+
 instance : Membership α (Raw α cmp) where
   mem m a := m.contains a
 

--- a/src/Std/Data/TreeSet/RawLemmas.lean
+++ b/src/Std/Data/TreeSet/RawLemmas.lean
@@ -97,6 +97,16 @@ theorem containsThenInsert_snd [TransCmp cmp] (h : t.WF) {k : α} :
   ext <| TreeMap.Raw.containsThenInsert_snd h
 
 @[simp]
+theorem containsThenInsertIfNew_fst [TransCmp cmp] (h : t.WF) {k : α} :
+    (t.containsThenInsertIfNew k).1 = t.contains k :=
+  DTreeMap.Raw.containsThenInsertIfNew_fst h
+
+@[simp]
+theorem containsThenInsertIfNew_snd [TransCmp cmp] (h : t.WF) {k : α} :
+    (t.containsThenInsertIfNew k).2 = t.insertIfNew k :=
+  ext <| TreeMap.Raw.containsThenInsertIfNew_snd h
+
+@[simp]
 theorem isEmpty_insertIfNew [TransCmp cmp] (h : t.WF) {k : α} :
     (t.insertIfNew k).isEmpty = false :=
   DTreeMap.Raw.isEmpty_insertIfNew h


### PR DESCRIPTION
This PR introduces the `containsThenInsertIfNew` function on the tree maps of the standard library.