### PR TITLE
feat: deprecated find, fold, foldM, mergeBy functions for the tree map

### DIFF
--- a/src/Std/Data/DTreeMap/Basic.lean
+++ b/src/Std/Data/DTreeMap/Basic.lean
@@ -372,6 +372,11 @@ def mergeWith [LawfulEqCmp cmp] (mergeFn : (a : α) → β a → β a → β a) 
     DTreeMap α β cmp :=
   letI : Ord α := ⟨cmp⟩; ⟨t₁.inner.mergeWith mergeFn t₂.inner t₁.wf.balanced |>.impl, t₁.wf.mergeWith⟩
 
+@[inline, inherit_doc mergeWith, deprecated mergeWith (since := "2025-02-12")]
+def mergeBy [LawfulEqCmp cmp] (mergeFn : (a : α) → β a → β a → β a) (t₁ t₂ : DTreeMap α β cmp) :
+    DTreeMap α β cmp :=
+  mergeWith mergeFn t₁ t₂
+
 namespace Const
 
 variable {β : Type v}
@@ -388,6 +393,10 @@ def toArray (t : DTreeMap α β cmp) : Array (α × β) :=
 def mergeWith (mergeFn : α → β → β → β) (t₁ t₂ : DTreeMap α β cmp) : DTreeMap α β cmp :=
   letI : Ord α := ⟨cmp⟩;
   ⟨Impl.Const.mergeWith mergeFn t₁.inner t₂.inner t₁.wf.balanced |>.impl, t₁.wf.constMergeBy⟩
+
+@[inline, inherit_doc mergeWith, deprecated mergeWith (since := "2025-02-12")]
+def mergeBy (mergeFn : α → β → β → β) (t₁ t₂ : DTreeMap α β cmp) : DTreeMap α β cmp :=
+  mergeWith mergeFn t₁ t₂
 
 end Const
 

--- a/src/Std/Data/DTreeMap/Basic.lean
+++ b/src/Std/Data/DTreeMap/Basic.lean
@@ -246,8 +246,8 @@ def get (t : DTreeMap α β cmp) (a : α) (h : a ∈ t) : β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.get a t.inner h
 
 @[inline, inherit_doc get, deprecated get (since := "2025-02-12")]
-def find (t : DTreeMap α β cmp) (a : α) : Option β :=
-  get? t a
+def find (t : DTreeMap α β cmp) (a : α) (h : a ∈ t) : β :=
+  get t a h
 
 /--
 Tries to retrieve the mapping for the given key, panicking if no such mapping is present.

--- a/src/Std/Data/DTreeMap/Basic.lean
+++ b/src/Std/Data/DTreeMap/Basic.lean
@@ -289,7 +289,7 @@ def foldlM (f : δ → (a : α) → β a → m δ) (init : δ) (t : DTreeMap α 
 
 @[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-12")]
 def foldM (f : δ → (a : α) → β a → m δ) (init : δ) (t : DTreeMap α β cmp) : m δ :=
-  t.foldlM f init
+  foldlM f init t
 
 /--
 Folds the given function over the mappings in the map in ascending order.
@@ -300,7 +300,7 @@ def foldl (f : δ → (a : α) → β a → δ) (init : δ) (t : DTreeMap α β 
 
 @[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-12")]
 def fold (f : δ → (a : α) → β a → δ) (init : δ) (t : DTreeMap α β cmp) : δ :=
-  t.foldl f init
+  foldl f init t
 
 /-- Carries out a monadic action on each mapping in the tree map in ascending order. -/
 @[inline]

--- a/src/Std/Data/DTreeMap/Basic.lean
+++ b/src/Std/Data/DTreeMap/Basic.lean
@@ -192,10 +192,6 @@ Uses the `LawfulEqCmp` instance to cast the retrieved value to the correct type.
 def get [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) (h : a ∈ t) : β a :=
   letI : Ord α := ⟨cmp⟩; t.inner.get a h
 
-@[inline, inherit_doc get, deprecated get (since := "2025-02-12")]
-def find [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) (h : a ∈ t) : β a :=
-  t.get a h
-
 /--
 Tries to retrieve the mapping for the given key, panicking if no such mapping is present.
 
@@ -244,10 +240,6 @@ Given a proof that a mapping for the given key is present, retrieves the mapping
 @[inline]
 def get (t : DTreeMap α β cmp) (a : α) (h : a ∈ t) : β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.get a t.inner h
-
-@[inline, inherit_doc get, deprecated get (since := "2025-02-12")]
-def find (t : DTreeMap α β cmp) (a : α) (h : a ∈ t) : β :=
-  get t a h
 
 /--
 Tries to retrieve the mapping for the given key, panicking if no such mapping is present.

--- a/src/Std/Data/DTreeMap/Basic.lean
+++ b/src/Std/Data/DTreeMap/Basic.lean
@@ -289,7 +289,7 @@ def foldlM (f : δ → (a : α) → β a → m δ) (init : δ) (t : DTreeMap α 
 
 @[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-12")]
 def foldM (f : δ → (a : α) → β a → m δ) (init : δ) (t : DTreeMap α β cmp) : m δ :=
-  foldlM f init t
+  t.foldlM f init
 
 /--
 Folds the given function over the mappings in the map in ascending order.
@@ -300,7 +300,7 @@ def foldl (f : δ → (a : α) → β a → δ) (init : δ) (t : DTreeMap α β 
 
 @[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-12")]
 def fold (f : δ → (a : α) → β a → δ) (init : δ) (t : DTreeMap α β cmp) : δ :=
-  foldl f init t
+  t.foldl f init
 
 /-- Carries out a monadic action on each mapping in the tree map in ascending order. -/
 @[inline]

--- a/src/Std/Data/DTreeMap/Basic.lean
+++ b/src/Std/Data/DTreeMap/Basic.lean
@@ -179,7 +179,7 @@ Uses the `LawfulEqCmp` instance to cast the retrieved value to the correct type.
 def get? [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) : Option (β a) :=
   letI : Ord α := ⟨cmp⟩; t.inner.get? a
 
-@[inline, inherit_doc get?, deprecated get? (since := "2025-02-11")]
+@[inline, inherit_doc get?, deprecated get? (since := "2025-02-12")]
 def find? [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) : Option (β a) :=
   t.get? a
 
@@ -192,7 +192,7 @@ Uses the `LawfulEqCmp` instance to cast the retrieved value to the correct type.
 def get [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) (h : a ∈ t) : β a :=
   letI : Ord α := ⟨cmp⟩; t.inner.get a h
 
-@[inline, inherit_doc get, deprecated find (since := "2025-02-11")]
+@[inline, inherit_doc get, deprecated find (since := "2025-02-12")]
 def find [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) (h : a ∈ t) : β a :=
   t.get a h
 
@@ -205,7 +205,7 @@ Uses the `LawfulEqCmp` instance to cast the retrieved value to the correct type.
 def get! [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) [Inhabited (β a)]  : β a :=
   letI : Ord α := ⟨cmp⟩; t.inner.get! a
 
-@[inline, inherit_doc get!, deprecated get! (since := "2025-02-11")]
+@[inline, inherit_doc get!, deprecated get! (since := "2025-02-12")]
 def find! [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) [Inhabited (β a)]  : β a :=
   t.get! a
 
@@ -218,7 +218,7 @@ Uses the `LawfulEqCmp` instance to cast the retrieved value to the correct type.
 def getD [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) (fallback : β a) : β a :=
   letI : Ord α := ⟨cmp⟩; t.inner.getD a fallback
 
-@[inline, inherit_doc getD, deprecated getD (since := "2025-02-11")]
+@[inline, inherit_doc getD, deprecated getD (since := "2025-02-12")]
 def findD [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) (fallback : β a) : β a :=
   t.getD a fallback
 
@@ -234,7 +234,7 @@ Tries to retrieve the mapping for the given key, returning `none` if no such map
 def get? (t : DTreeMap α β cmp) (a : α) : Option β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.get? a t.inner
 
-@[inline, inherit_doc get?, deprecated get? (since := "2025-02-11")]
+@[inline, inherit_doc get?, deprecated get? (since := "2025-02-12")]
 def find? (t : DTreeMap α β cmp) (a : α) : Option β :=
   get? t a
 
@@ -245,7 +245,7 @@ Given a proof that a mapping for the given key is present, retrieves the mapping
 def get (t : DTreeMap α β cmp) (a : α) (h : a ∈ t) : β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.get a t.inner h
 
-@[inline, inherit_doc get, deprecated get (since := "2025-02-11")]
+@[inline, inherit_doc get, deprecated get (since := "2025-02-12")]
 def find (t : DTreeMap α β cmp) (a : α) : Option β :=
   get? t a
 
@@ -256,7 +256,7 @@ Tries to retrieve the mapping for the given key, panicking if no such mapping is
 def get! (t : DTreeMap α β cmp) (a : α) [Inhabited β] : β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.get! a t.inner
 
-@[inline, inherit_doc get!, deprecated get! (since := "2025-02-11")]
+@[inline, inherit_doc get!, deprecated get! (since := "2025-02-12")]
 def find! (t : DTreeMap α β cmp) (a : α) [Inhabited β] : β :=
   get! t a
 
@@ -267,7 +267,7 @@ Tries to retrieve the mapping for the given key, returning `fallback` if no such
 def getD (t : DTreeMap α β cmp) (a : α) (fallback : β) : β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.getD a t.inner fallback
 
-@[inline, inherit_doc getD, deprecated getD (since := "2025-02-11")]
+@[inline, inherit_doc getD, deprecated getD (since := "2025-02-12")]
 def findD (t : DTreeMap α β cmp) (a : α) (fallback : β) : β :=
   getD t a fallback
 
@@ -287,7 +287,7 @@ Folds the given monadic function over the mappings in the map in ascending order
 def foldlM (f : δ → (a : α) → β a → m δ) (init : δ) (t : DTreeMap α β cmp) : m δ :=
   t.inner.foldlM f init
 
-@[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-11")]
+@[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-12")]
 def foldM (f : δ → (a : α) → β a → m δ) (init : δ) (t : DTreeMap α β cmp) : m δ :=
   t.foldlM f init
 
@@ -298,7 +298,7 @@ Folds the given function over the mappings in the map in ascending order.
 def foldl (f : δ → (a : α) → β a → δ) (init : δ) (t : DTreeMap α β cmp) : δ :=
   t.inner.foldl f init
 
-@[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-11")]
+@[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-12")]
 def fold (f : δ → (a : α) → β a → δ) (init : δ) (t : DTreeMap α β cmp) : δ :=
   t.foldl f init
 

--- a/src/Std/Data/DTreeMap/Basic.lean
+++ b/src/Std/Data/DTreeMap/Basic.lean
@@ -179,6 +179,10 @@ Uses the `LawfulEqCmp` instance to cast the retrieved value to the correct type.
 def get? [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) : Option (β a) :=
   letI : Ord α := ⟨cmp⟩; t.inner.get? a
 
+@[inline, inherit_doc get?, deprecated get? (since := "2025-02-11")]
+def find? [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) : Option (β a) :=
+  t.get? a
+
 /--
 Given a proof that a mapping for the given key is present, retrieves the mapping for the given key.
 
@@ -187,6 +191,10 @@ Uses the `LawfulEqCmp` instance to cast the retrieved value to the correct type.
 @[inline]
 def get [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) (h : a ∈ t) : β a :=
   letI : Ord α := ⟨cmp⟩; t.inner.get a h
+
+@[inline, inherit_doc get, deprecated find (since := "2025-02-11")]
+def find [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) (h : a ∈ t) : β a :=
+  t.get a h
 
 /--
 Tries to retrieve the mapping for the given key, panicking if no such mapping is present.
@@ -197,6 +205,10 @@ Uses the `LawfulEqCmp` instance to cast the retrieved value to the correct type.
 def get! [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) [Inhabited (β a)]  : β a :=
   letI : Ord α := ⟨cmp⟩; t.inner.get! a
 
+@[inline, inherit_doc get!, deprecated get! (since := "2025-02-11")]
+def find! [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) [Inhabited (β a)]  : β a :=
+  t.get! a
+
 /--
 Tries to retrieve the mapping for the given key, returning `fallback` if no such mapping is present.
 
@@ -205,6 +217,10 @@ Uses the `LawfulEqCmp` instance to cast the retrieved value to the correct type.
 @[inline]
 def getD [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) (fallback : β a) : β a :=
   letI : Ord α := ⟨cmp⟩; t.inner.getD a fallback
+
+@[inline, inherit_doc getD, deprecated getD (since := "2025-02-11")]
+def findD [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) (fallback : β a) : β a :=
+  t.getD a fallback
 
 namespace Const
 open Internal (Impl)
@@ -218,12 +234,20 @@ Tries to retrieve the mapping for the given key, returning `none` if no such map
 def get? (t : DTreeMap α β cmp) (a : α) : Option β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.get? a t.inner
 
+@[inline, inherit_doc get?, deprecated get? (since := "2025-02-11")]
+def find? (t : DTreeMap α β cmp) (a : α) : Option β :=
+  get? t a
+
 /--
 Given a proof that a mapping for the given key is present, retrieves the mapping for the given key.
 -/
 @[inline]
 def get (t : DTreeMap α β cmp) (a : α) (h : a ∈ t) : β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.get a t.inner h
+
+@[inline, inherit_doc get, deprecated get (since := "2025-02-11")]
+def find (t : DTreeMap α β cmp) (a : α) : Option β :=
+  get? t a
 
 /--
 Tries to retrieve the mapping for the given key, panicking if no such mapping is present.
@@ -232,12 +256,20 @@ Tries to retrieve the mapping for the given key, panicking if no such mapping is
 def get! (t : DTreeMap α β cmp) (a : α) [Inhabited β] : β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.get! a t.inner
 
+@[inline, inherit_doc get!, deprecated get! (since := "2025-02-11")]
+def find! (t : DTreeMap α β cmp) (a : α) [Inhabited β] : β :=
+  get! t a
+
 /--
 Tries to retrieve the mapping for the given key, returning `fallback` if no such mapping is present.
 -/
 @[inline]
 def getD (t : DTreeMap α β cmp) (a : α) (fallback : β) : β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.getD a t.inner fallback
+
+@[inline, inherit_doc getD, deprecated getD (since := "2025-02-11")]
+def findD (t : DTreeMap α β cmp) (a : α) (fallback : β) : β :=
+  getD t a fallback
 
 end Const
 
@@ -255,12 +287,20 @@ Folds the given monadic function over the mappings in the map in ascending order
 def foldlM (f : δ → (a : α) → β a → m δ) (init : δ) (t : DTreeMap α β cmp) : m δ :=
   t.inner.foldlM f init
 
+@[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-11")]
+def foldM (f : δ → (a : α) → β a → m δ) (init : δ) (t : DTreeMap α β cmp) : m δ :=
+  t.foldlM f init
+
 /--
 Folds the given function over the mappings in the map in ascending order.
 -/
 @[inline]
 def foldl (f : δ → (a : α) → β a → δ) (init : δ) (t : DTreeMap α β cmp) : δ :=
   t.inner.foldl f init
+
+@[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-11")]
+def fold (f : δ → (a : α) → β a → δ) (init : δ) (t : DTreeMap α β cmp) : δ :=
+  t.foldl f init
 
 /-- Carries out a monadic action on each mapping in the tree map in ascending order. -/
 @[inline]

--- a/src/Std/Data/DTreeMap/Basic.lean
+++ b/src/Std/Data/DTreeMap/Basic.lean
@@ -192,7 +192,7 @@ Uses the `LawfulEqCmp` instance to cast the retrieved value to the correct type.
 def get [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) (h : a ∈ t) : β a :=
   letI : Ord α := ⟨cmp⟩; t.inner.get a h
 
-@[inline, inherit_doc get, deprecated find (since := "2025-02-12")]
+@[inline, inherit_doc get, deprecated get (since := "2025-02-12")]
 def find [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) (h : a ∈ t) : β a :=
   t.get a h
 

--- a/src/Std/Data/DTreeMap/Raw.lean
+++ b/src/Std/Data/DTreeMap/Raw.lean
@@ -158,10 +158,6 @@ def find? [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) : Option (β a) :=
 def get [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) (h : a ∈ t) : β a :=
   letI : Ord α := ⟨cmp⟩; t.inner.get a h
 
-@[inline, inherit_doc get, deprecated get (since := "2025-02-12")]
-def find [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) (h : a ∈ t) : β a :=
-  t.get a h
-
 @[inline, inherit_doc DTreeMap.get!]
 def get! [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) [Inhabited (β a)]  : β a :=
   letI : Ord α := ⟨cmp⟩; t.inner.get! a
@@ -194,10 +190,6 @@ def find? (t : Raw α β cmp) (a : α) : Option β :=
 @[inline, inherit_doc DTreeMap.get]
 def get (t : Raw α β cmp) (a : α) (h : a ∈ t) : β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.get a t.inner h
-
-@[inline, inherit_doc get, deprecated get (since := "2025-02-12")]
-def find (t : Raw α β cmp) (a : α) (h : a ∈ t) : β :=
-  get t a h
 
 @[inline, inherit_doc DTreeMap.get!]
 def get! (t : Raw α β cmp) (a : α) [Inhabited β] : β :=

--- a/src/Std/Data/DTreeMap/Raw.lean
+++ b/src/Std/Data/DTreeMap/Raw.lean
@@ -229,7 +229,7 @@ def foldlM (f : δ → (a : α) → β a → m δ) (init : δ) (t : Raw α β cm
 
 @[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-12")]
 def foldM (f : δ → (a : α) → β a → m δ) (init : δ) (t : Raw α β cmp) : m δ :=
-  foldlM f init t
+  t.foldlM f init
 
 @[inline, inherit_doc DTreeMap.foldl]
 def foldl (f : δ → (a : α) → β a → δ) (init : δ) (t : Raw α β cmp) : δ :=
@@ -237,7 +237,7 @@ def foldl (f : δ → (a : α) → β a → δ) (init : δ) (t : Raw α β cmp) 
 
 @[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-12")]
 def fold (f : δ → (a : α) → β a → δ) (init : δ) (t : Raw α β cmp) : δ :=
-  foldl f init t
+  t.foldl f init
 
 @[inline, inherit_doc DTreeMap.forM]
 def forM (f : (a : α) → β a → m PUnit) (t : Raw α β cmp) : m PUnit :=

--- a/src/Std/Data/DTreeMap/Raw.lean
+++ b/src/Std/Data/DTreeMap/Raw.lean
@@ -285,6 +285,11 @@ def toArray (t : Raw α β cmp) : Array ((a : α) × β a) :=
 def mergeWith [LawfulEqCmp cmp] (mergeFn : (a : α) → β a → β a → β a) (t₁ t₂ : Raw α β cmp) : Raw α β cmp :=
   letI : Ord α := ⟨cmp⟩; ⟨t₁.inner.mergeWith! mergeFn t₂.inner⟩
 
+@[inline, inherit_doc mergeWith, deprecated mergeWith (since := "2025-02-12")]
+def mergeBy [LawfulEqCmp cmp] (mergeFn : (a : α) → β a → β a → β a) (t₁ t₂ : Raw α β cmp) :
+    Raw α β cmp :=
+  mergeWith mergeFn t₁ t₂
+
 namespace Const
 open Internal (Impl)
 
@@ -301,6 +306,10 @@ def toArray (t : Raw α β cmp) : Array (α × β) :=
 @[inline, inherit_doc Raw.mergeWith]
 def mergeWith (mergeFn : α → β → β → β) (t₁ t₂ : Raw α β cmp) : Raw α β cmp :=
   letI : Ord α := ⟨cmp⟩; ⟨Impl.Const.mergeWith! mergeFn t₁.inner t₂.inner⟩
+
+@[inline, inherit_doc mergeWith, deprecated mergeWith (since := "2025-02-12")]
+def mergeBy (mergeFn : α → β → β → β) (t₁ t₂ : Raw α β cmp) : Raw α β cmp :=
+  mergeWith mergeFn t₁ t₂
 
 end Const
 

--- a/src/Std/Data/DTreeMap/Raw.lean
+++ b/src/Std/Data/DTreeMap/Raw.lean
@@ -150,37 +150,70 @@ def erase (t : Raw α β cmp) (a : α) : Raw α β cmp :=
 def get? [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) : Option (β a) :=
   letI : Ord α := ⟨cmp⟩; t.inner.get? a
 
+@[inline, inherit_doc get?, deprecated get? (since := "2025-02-11")]
+def find? [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) : Option (β a) :=
+  t.get? a
+
 @[inline, inherit_doc DTreeMap.get]
 def get [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) (h : a ∈ t) : β a :=
   letI : Ord α := ⟨cmp⟩; t.inner.get a h
+
+@[inline, inherit_doc get, deprecated find (since := "2025-02-11")]
+def find [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) (h : a ∈ t) : β a :=
+  t.get a h
 
 @[inline, inherit_doc DTreeMap.get!]
 def get! [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) [Inhabited (β a)]  : β a :=
   letI : Ord α := ⟨cmp⟩; t.inner.get! a
 
+@[inline, inherit_doc get!, deprecated get! (since := "2025-02-11")]
+def find! [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) [Inhabited (β a)]  : β a :=
+  t.get! a
+
 @[inline, inherit_doc DTreeMap.getD]
 def getD [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) (fallback : β a) : β a :=
   letI : Ord α := ⟨cmp⟩; t.inner.getD a fallback
+
+@[inline, inherit_doc getD, deprecated getD (since := "2025-02-11")]
+def findD [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) (fallback : β a) : β a :=
+  t.getD a fallback
 
 namespace Const
 open Internal (Impl)
 
 variable {β : Type v}
 
-@[inline, inherit_doc DTreeMap.get?] def get? (t : Raw α β cmp) (a : α) : Option β :=
+@[inline, inherit_doc DTreeMap.get?]
+def get? (t : Raw α β cmp) (a : α) : Option β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.get? a t.inner
+
+@[inline, inherit_doc get?, deprecated get? (since := "2025-02-11")]
+def find? (t : Raw α β cmp) (a : α) : Option β :=
+  get? t a
 
 @[inline, inherit_doc DTreeMap.get]
 def get (t : Raw α β cmp) (a : α) (h : a ∈ t) : β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.get a t.inner h
 
+@[inline, inherit_doc get, deprecated get (since := "2025-02-11")]
+def find (t : Raw α β cmp) (a : α) : Option β :=
+  get? t a
+
 @[inline, inherit_doc DTreeMap.get!]
 def get! (t : Raw α β cmp) (a : α) [Inhabited β] : β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.get! a t.inner
 
+@[inline, inherit_doc get!, deprecated get! (since := "2025-02-11")]
+def find! (t : Raw α β cmp) (a : α) [Inhabited β] : β :=
+  get! t a
+
 @[inline, inherit_doc DTreeMap.getD]
 def getD (t : Raw α β cmp) (a : α) (fallback : β) : β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.getD a t.inner fallback
+
+@[inline, inherit_doc getD, deprecated getD (since := "2025-02-11")]
+def findD (t : Raw α β cmp) (a : α) (fallback : β) : β :=
+  getD t a fallback
 
 end Const
 
@@ -194,9 +227,17 @@ def filter (f : (a : α) → β a → Bool) (t : Raw α β cmp) : Raw α β cmp 
 def foldlM (f : δ → (a : α) → β a → m δ) (init : δ) (t : Raw α β cmp) : m δ :=
   t.inner.foldlM f init
 
+@[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-11")]
+def foldM (f : δ → (a : α) → β a → m δ) (init : δ) (t : Raw α β cmp) : m δ :=
+  t.foldlM f init
+
 @[inline, inherit_doc DTreeMap.foldl]
 def foldl (f : δ → (a : α) → β a → δ) (init : δ) (t : Raw α β cmp) : δ :=
   t.inner.foldl f init
+
+@[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-11")]
+def fold (f : δ → (a : α) → β a → δ) (init : δ) (t : Raw α β cmp) : δ :=
+  t.foldl f init
 
 @[inline, inherit_doc DTreeMap.forM]
 def forM (f : (a : α) → β a → m PUnit) (t : Raw α β cmp) : m PUnit :=

--- a/src/Std/Data/DTreeMap/Raw.lean
+++ b/src/Std/Data/DTreeMap/Raw.lean
@@ -150,7 +150,7 @@ def erase (t : Raw α β cmp) (a : α) : Raw α β cmp :=
 def get? [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) : Option (β a) :=
   letI : Ord α := ⟨cmp⟩; t.inner.get? a
 
-@[inline, inherit_doc get?, deprecated get? (since := "2025-02-11")]
+@[inline, inherit_doc get?, deprecated get? (since := "2025-02-12")]
 def find? [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) : Option (β a) :=
   t.get? a
 
@@ -158,7 +158,7 @@ def find? [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) : Option (β a) :=
 def get [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) (h : a ∈ t) : β a :=
   letI : Ord α := ⟨cmp⟩; t.inner.get a h
 
-@[inline, inherit_doc get, deprecated find (since := "2025-02-11")]
+@[inline, inherit_doc get, deprecated find (since := "2025-02-12")]
 def find [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) (h : a ∈ t) : β a :=
   t.get a h
 
@@ -166,7 +166,7 @@ def find [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) (h : a ∈ t) : β a :=
 def get! [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) [Inhabited (β a)]  : β a :=
   letI : Ord α := ⟨cmp⟩; t.inner.get! a
 
-@[inline, inherit_doc get!, deprecated get! (since := "2025-02-11")]
+@[inline, inherit_doc get!, deprecated get! (since := "2025-02-12")]
 def find! [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) [Inhabited (β a)]  : β a :=
   t.get! a
 
@@ -174,7 +174,7 @@ def find! [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) [Inhabited (β a)]  : �
 def getD [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) (fallback : β a) : β a :=
   letI : Ord α := ⟨cmp⟩; t.inner.getD a fallback
 
-@[inline, inherit_doc getD, deprecated getD (since := "2025-02-11")]
+@[inline, inherit_doc getD, deprecated getD (since := "2025-02-12")]
 def findD [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) (fallback : β a) : β a :=
   t.getD a fallback
 
@@ -187,7 +187,7 @@ variable {β : Type v}
 def get? (t : Raw α β cmp) (a : α) : Option β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.get? a t.inner
 
-@[inline, inherit_doc get?, deprecated get? (since := "2025-02-11")]
+@[inline, inherit_doc get?, deprecated get? (since := "2025-02-12")]
 def find? (t : Raw α β cmp) (a : α) : Option β :=
   get? t a
 
@@ -195,7 +195,7 @@ def find? (t : Raw α β cmp) (a : α) : Option β :=
 def get (t : Raw α β cmp) (a : α) (h : a ∈ t) : β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.get a t.inner h
 
-@[inline, inherit_doc get, deprecated get (since := "2025-02-11")]
+@[inline, inherit_doc get, deprecated get (since := "2025-02-12")]
 def find (t : Raw α β cmp) (a : α) : Option β :=
   get? t a
 
@@ -203,7 +203,7 @@ def find (t : Raw α β cmp) (a : α) : Option β :=
 def get! (t : Raw α β cmp) (a : α) [Inhabited β] : β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.get! a t.inner
 
-@[inline, inherit_doc get!, deprecated get! (since := "2025-02-11")]
+@[inline, inherit_doc get!, deprecated get! (since := "2025-02-12")]
 def find! (t : Raw α β cmp) (a : α) [Inhabited β] : β :=
   get! t a
 
@@ -211,7 +211,7 @@ def find! (t : Raw α β cmp) (a : α) [Inhabited β] : β :=
 def getD (t : Raw α β cmp) (a : α) (fallback : β) : β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.getD a t.inner fallback
 
-@[inline, inherit_doc getD, deprecated getD (since := "2025-02-11")]
+@[inline, inherit_doc getD, deprecated getD (since := "2025-02-12")]
 def findD (t : Raw α β cmp) (a : α) (fallback : β) : β :=
   getD t a fallback
 
@@ -227,7 +227,7 @@ def filter (f : (a : α) → β a → Bool) (t : Raw α β cmp) : Raw α β cmp 
 def foldlM (f : δ → (a : α) → β a → m δ) (init : δ) (t : Raw α β cmp) : m δ :=
   t.inner.foldlM f init
 
-@[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-11")]
+@[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-12")]
 def foldM (f : δ → (a : α) → β a → m δ) (init : δ) (t : Raw α β cmp) : m δ :=
   t.foldlM f init
 
@@ -235,7 +235,7 @@ def foldM (f : δ → (a : α) → β a → m δ) (init : δ) (t : Raw α β cmp
 def foldl (f : δ → (a : α) → β a → δ) (init : δ) (t : Raw α β cmp) : δ :=
   t.inner.foldl f init
 
-@[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-11")]
+@[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-12")]
 def fold (f : δ → (a : α) → β a → δ) (init : δ) (t : Raw α β cmp) : δ :=
   t.foldl f init
 

--- a/src/Std/Data/DTreeMap/Raw.lean
+++ b/src/Std/Data/DTreeMap/Raw.lean
@@ -158,7 +158,7 @@ def find? [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) : Option (β a) :=
 def get [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) (h : a ∈ t) : β a :=
   letI : Ord α := ⟨cmp⟩; t.inner.get a h
 
-@[inline, inherit_doc get, deprecated find (since := "2025-02-12")]
+@[inline, inherit_doc get, deprecated get (since := "2025-02-12")]
 def find [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) (h : a ∈ t) : β a :=
   t.get a h
 
@@ -196,8 +196,8 @@ def get (t : Raw α β cmp) (a : α) (h : a ∈ t) : β :=
   letI : Ord α := ⟨cmp⟩; Impl.Const.get a t.inner h
 
 @[inline, inherit_doc get, deprecated get (since := "2025-02-12")]
-def find (t : Raw α β cmp) (a : α) : Option β :=
-  get? t a
+def find (t : Raw α β cmp) (a : α) (h : a ∈ t) : β :=
+  get t a h
 
 @[inline, inherit_doc DTreeMap.get!]
 def get! (t : Raw α β cmp) (a : α) [Inhabited β] : β :=

--- a/src/Std/Data/DTreeMap/Raw.lean
+++ b/src/Std/Data/DTreeMap/Raw.lean
@@ -229,7 +229,7 @@ def foldlM (f : δ → (a : α) → β a → m δ) (init : δ) (t : Raw α β cm
 
 @[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-12")]
 def foldM (f : δ → (a : α) → β a → m δ) (init : δ) (t : Raw α β cmp) : m δ :=
-  t.foldlM f init
+  foldlM f init t
 
 @[inline, inherit_doc DTreeMap.foldl]
 def foldl (f : δ → (a : α) → β a → δ) (init : δ) (t : Raw α β cmp) : δ :=
@@ -237,7 +237,7 @@ def foldl (f : δ → (a : α) → β a → δ) (init : δ) (t : Raw α β cmp) 
 
 @[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-12")]
 def fold (f : δ → (a : α) → β a → δ) (init : δ) (t : Raw α β cmp) : δ :=
-  t.foldl f init
+  foldl f init t
 
 @[inline, inherit_doc DTreeMap.forM]
 def forM (f : (a : α) → β a → m PUnit) (t : Raw α β cmp) : m PUnit :=

--- a/src/Std/Data/TreeMap/Basic.lean
+++ b/src/Std/Data/TreeMap/Basic.lean
@@ -174,7 +174,7 @@ def foldlM (f : δ → (a : α) → β → m δ) (init : δ) (t : TreeMap α β 
 
 @[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-12")]
 def foldM (f : δ → (a : α) → β → m δ) (init : δ) (t : TreeMap α β cmp) : m δ :=
-  foldlM f init t
+  t.foldlM f init
 
 @[inline, inherit_doc DTreeMap.foldl]
 def foldl (f : δ → (a : α) → β → δ) (init : δ) (t : TreeMap α β cmp) : δ :=
@@ -182,7 +182,7 @@ def foldl (f : δ → (a : α) → β → δ) (init : δ) (t : TreeMap α β cmp
 
 @[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-12")]
 def fold (f : δ → (a : α) → β → δ) (init : δ) (t : TreeMap α β cmp) : δ :=
-  foldl f init t
+  t.foldl f init
 
 @[inline, inherit_doc DTreeMap.forM]
 def forM (f : α → β → m PUnit) (t : TreeMap α β cmp) : m PUnit :=

--- a/src/Std/Data/TreeMap/Basic.lean
+++ b/src/Std/Data/TreeMap/Basic.lean
@@ -129,17 +129,33 @@ def erase (t : TreeMap α β cmp) (a : α) : TreeMap α β cmp :=
 def get? (t : TreeMap α β cmp) (a : α) : Option β :=
   DTreeMap.Const.get? t.inner a
 
+@[inline, inherit_doc get?, deprecated get? (since := "2025-02-11")]
+def find? (t : TreeMap α β cmp) (a : α) : Option β :=
+  get? t a
+
 @[inline, inherit_doc DTreeMap.get]
 def get (t : TreeMap α β cmp) (a : α) (h : a ∈ t) : β :=
    DTreeMap.Const.get t.inner a h
+
+@[inline, inherit_doc get, deprecated get (since := "2025-02-11")]
+def find (t : TreeMap α β cmp) (a : α) : Option β :=
+  get? t a
 
 @[inline, inherit_doc DTreeMap.get!]
 def get! (t : TreeMap α β cmp) (a : α) [Inhabited β]  : β :=
   DTreeMap.Const.get! t.inner a
 
+@[inline, inherit_doc get!, deprecated get! (since := "2025-02-11")]
+def find! (t : TreeMap α β cmp) (a : α) [Inhabited β] : β :=
+  get! t a
+
 @[inline, inherit_doc DTreeMap.getD]
 def getD (t : TreeMap α β cmp) (a : α) (fallback : β) : β :=
   DTreeMap.Const.getD t.inner a fallback
+
+@[inline, inherit_doc getD, deprecated getD (since := "2025-02-11")]
+def findD (t : TreeMap α β cmp) (a : α) (fallback : β) : β :=
+  getD t a fallback
 
 instance : GetElem? (TreeMap α β cmp) α β (fun m a => a ∈ m) where
   getElem m a h := m.get a h
@@ -156,9 +172,17 @@ def filter (f : α → β → Bool) (m : TreeMap α β cmp) : TreeMap α β cmp 
 def foldlM (f : δ → (a : α) → β → m δ) (init : δ) (t : TreeMap α β cmp) : m δ :=
   t.inner.foldlM f init
 
+@[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-11")]
+def foldM (f : δ → (a : α) → β → m δ) (init : δ) (t : TreeMap α β cmp) : m δ :=
+  t.foldlM f init
+
 @[inline, inherit_doc DTreeMap.foldl]
 def foldl (f : δ → (a : α) → β → δ) (init : δ) (t : TreeMap α β cmp) : δ :=
   t.inner.foldl f init
+
+@[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-11")]
+def fold (f : δ → (a : α) → β → δ) (init : δ) (t : TreeMap α β cmp) : δ :=
+  t.foldl f init
 
 @[inline, inherit_doc DTreeMap.forM]
 def forM (f : α → β → m PUnit) (t : TreeMap α β cmp) : m PUnit :=

--- a/src/Std/Data/TreeMap/Basic.lean
+++ b/src/Std/Data/TreeMap/Basic.lean
@@ -138,8 +138,8 @@ def get (t : TreeMap α β cmp) (a : α) (h : a ∈ t) : β :=
    DTreeMap.Const.get t.inner a h
 
 @[inline, inherit_doc get, deprecated get (since := "2025-02-12")]
-def find (t : TreeMap α β cmp) (a : α) : Option β :=
-  get? t a
+def find (t : TreeMap α β cmp) (a : α) (h : a ∈ t) : β :=
+  get t a h
 
 @[inline, inherit_doc DTreeMap.get!]
 def get! (t : TreeMap α β cmp) (a : α) [Inhabited β]  : β :=

--- a/src/Std/Data/TreeMap/Basic.lean
+++ b/src/Std/Data/TreeMap/Basic.lean
@@ -174,7 +174,7 @@ def foldlM (f : δ → (a : α) → β → m δ) (init : δ) (t : TreeMap α β 
 
 @[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-12")]
 def foldM (f : δ → (a : α) → β → m δ) (init : δ) (t : TreeMap α β cmp) : m δ :=
-  t.foldlM f init
+  foldlM f init t
 
 @[inline, inherit_doc DTreeMap.foldl]
 def foldl (f : δ → (a : α) → β → δ) (init : δ) (t : TreeMap α β cmp) : δ :=
@@ -182,7 +182,7 @@ def foldl (f : δ → (a : α) → β → δ) (init : δ) (t : TreeMap α β cmp
 
 @[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-12")]
 def fold (f : δ → (a : α) → β → δ) (init : δ) (t : TreeMap α β cmp) : δ :=
-  t.foldl f init
+  foldl f init t
 
 @[inline, inherit_doc DTreeMap.forM]
 def forM (f : α → β → m PUnit) (t : TreeMap α β cmp) : m PUnit :=

--- a/src/Std/Data/TreeMap/Basic.lean
+++ b/src/Std/Data/TreeMap/Basic.lean
@@ -226,6 +226,10 @@ def toArray (t : TreeMap α β cmp) : Array (α × β) :=
 def mergeWith (mergeFn : α → β → β → β) (t₁ t₂ : TreeMap α β cmp) : TreeMap α β cmp :=
   ⟨DTreeMap.Const.mergeWith mergeFn t₁.inner t₂.inner⟩
 
+@[inline, inherit_doc mergeWith, deprecated mergeWith (since := "2025-02-12")]
+def mergeBy (mergeFn : α → β → β → β) (t₁ t₂ : TreeMap α β cmp) : TreeMap α β cmp :=
+  mergeWith mergeFn t₁ t₂
+
 @[inline, inherit_doc DTreeMap.eraseMany]
 def eraseMany {ρ} [ForIn Id ρ α] (t : TreeMap α β cmp) (l : ρ) : TreeMap α β cmp :=
   ⟨t.inner.eraseMany l⟩

--- a/src/Std/Data/TreeMap/Basic.lean
+++ b/src/Std/Data/TreeMap/Basic.lean
@@ -137,10 +137,6 @@ def find? (t : TreeMap α β cmp) (a : α) : Option β :=
 def get (t : TreeMap α β cmp) (a : α) (h : a ∈ t) : β :=
    DTreeMap.Const.get t.inner a h
 
-@[inline, inherit_doc get, deprecated get (since := "2025-02-12")]
-def find (t : TreeMap α β cmp) (a : α) (h : a ∈ t) : β :=
-  get t a h
-
 @[inline, inherit_doc DTreeMap.get!]
 def get! (t : TreeMap α β cmp) (a : α) [Inhabited β]  : β :=
   DTreeMap.Const.get! t.inner a

--- a/src/Std/Data/TreeMap/Basic.lean
+++ b/src/Std/Data/TreeMap/Basic.lean
@@ -129,7 +129,7 @@ def erase (t : TreeMap α β cmp) (a : α) : TreeMap α β cmp :=
 def get? (t : TreeMap α β cmp) (a : α) : Option β :=
   DTreeMap.Const.get? t.inner a
 
-@[inline, inherit_doc get?, deprecated get? (since := "2025-02-11")]
+@[inline, inherit_doc get?, deprecated get? (since := "2025-02-12")]
 def find? (t : TreeMap α β cmp) (a : α) : Option β :=
   get? t a
 
@@ -137,7 +137,7 @@ def find? (t : TreeMap α β cmp) (a : α) : Option β :=
 def get (t : TreeMap α β cmp) (a : α) (h : a ∈ t) : β :=
    DTreeMap.Const.get t.inner a h
 
-@[inline, inherit_doc get, deprecated get (since := "2025-02-11")]
+@[inline, inherit_doc get, deprecated get (since := "2025-02-12")]
 def find (t : TreeMap α β cmp) (a : α) : Option β :=
   get? t a
 
@@ -145,7 +145,7 @@ def find (t : TreeMap α β cmp) (a : α) : Option β :=
 def get! (t : TreeMap α β cmp) (a : α) [Inhabited β]  : β :=
   DTreeMap.Const.get! t.inner a
 
-@[inline, inherit_doc get!, deprecated get! (since := "2025-02-11")]
+@[inline, inherit_doc get!, deprecated get! (since := "2025-02-12")]
 def find! (t : TreeMap α β cmp) (a : α) [Inhabited β] : β :=
   get! t a
 
@@ -153,7 +153,7 @@ def find! (t : TreeMap α β cmp) (a : α) [Inhabited β] : β :=
 def getD (t : TreeMap α β cmp) (a : α) (fallback : β) : β :=
   DTreeMap.Const.getD t.inner a fallback
 
-@[inline, inherit_doc getD, deprecated getD (since := "2025-02-11")]
+@[inline, inherit_doc getD, deprecated getD (since := "2025-02-12")]
 def findD (t : TreeMap α β cmp) (a : α) (fallback : β) : β :=
   getD t a fallback
 
@@ -172,7 +172,7 @@ def filter (f : α → β → Bool) (m : TreeMap α β cmp) : TreeMap α β cmp 
 def foldlM (f : δ → (a : α) → β → m δ) (init : δ) (t : TreeMap α β cmp) : m δ :=
   t.inner.foldlM f init
 
-@[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-11")]
+@[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-12")]
 def foldM (f : δ → (a : α) → β → m δ) (init : δ) (t : TreeMap α β cmp) : m δ :=
   t.foldlM f init
 
@@ -180,7 +180,7 @@ def foldM (f : δ → (a : α) → β → m δ) (init : δ) (t : TreeMap α β c
 def foldl (f : δ → (a : α) → β → δ) (init : δ) (t : TreeMap α β cmp) : δ :=
   t.inner.foldl f init
 
-@[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-11")]
+@[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-12")]
 def fold (f : δ → (a : α) → β → δ) (init : δ) (t : TreeMap α β cmp) : δ :=
   t.foldl f init
 

--- a/src/Std/Data/TreeMap/Raw.lean
+++ b/src/Std/Data/TreeMap/Raw.lean
@@ -244,6 +244,10 @@ def toArray (t : Raw α β cmp) : Array (α × β) :=
 def mergeWith (mergeFn : α → β → β → β) (t₁ t₂ : Raw α β cmp) : Raw α β cmp :=
   ⟨DTreeMap.Raw.Const.mergeWith mergeFn t₁.inner t₂.inner⟩
 
+@[inline, inherit_doc mergeWith, deprecated mergeWith (since := "2025-02-12")]
+def mergeBy (mergeFn : α → β → β → β) (t₁ t₂ : Raw α β cmp) : Raw α β cmp :=
+  mergeWith mergeFn t₁ t₂
+
 @[inline, inherit_doc DTreeMap.Raw.eraseMany]
 def eraseMany {ρ} [ForIn Id ρ α] (t : Raw α β cmp) (l : ρ) : Raw α β cmp :=
   ⟨t.inner.eraseMany l⟩

--- a/src/Std/Data/TreeMap/Raw.lean
+++ b/src/Std/Data/TreeMap/Raw.lean
@@ -192,7 +192,7 @@ def foldlM (f : δ → (a : α) → β → m δ) (init : δ) (t : Raw α β cmp)
 
 @[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-12")]
 def foldM (f : δ → (a : α) → β → m δ) (init : δ) (t : Raw α β cmp) : m δ :=
-  foldlM f init t
+  t.foldlM f init
 
 @[inline, inherit_doc DTreeMap.Raw.foldl]
 def foldl (f : δ → (a : α) → β → δ) (init : δ) (t : Raw α β cmp) : δ :=
@@ -200,7 +200,7 @@ def foldl (f : δ → (a : α) → β → δ) (init : δ) (t : Raw α β cmp) : 
 
 @[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-12")]
 def fold (f : δ → (a : α) → β → δ) (init : δ) (t : Raw α β cmp) : δ :=
-  foldl f init t
+  t.foldl f init
 
 @[inline, inherit_doc DTreeMap.Raw.forM]
 def forM (f : α → β → m PUnit) (t : Raw α β cmp) : m PUnit :=

--- a/src/Std/Data/TreeMap/Raw.lean
+++ b/src/Std/Data/TreeMap/Raw.lean
@@ -155,10 +155,6 @@ def find? (t : Raw α β cmp) (a : α) : Option β :=
 def get (t : Raw α β cmp) (a : α) (h : a ∈ t) : β :=
   DTreeMap.Raw.Const.get t.inner a h
 
-@[inline, inherit_doc get, deprecated get (since := "2025-02-12")]
-def find (t : Raw α β cmp) (a : α) (h : a ∈ t) : β :=
-  get t a h
-
 @[inline, inherit_doc DTreeMap.Raw.Const.get!]
 def get! (t : Raw α β cmp) (a : α) [Inhabited β]  : β :=
   DTreeMap.Raw.Const.get! t.inner a

--- a/src/Std/Data/TreeMap/Raw.lean
+++ b/src/Std/Data/TreeMap/Raw.lean
@@ -147,7 +147,7 @@ def erase (t : Raw α β cmp) (a : α) : Raw α β cmp :=
 def get? (t : Raw α β cmp) (a : α) : Option β :=
   DTreeMap.Raw.Const.get? t.inner a
 
-@[inline, inherit_doc get?, deprecated get? (since := "2025-02-11")]
+@[inline, inherit_doc get?, deprecated get? (since := "2025-02-12")]
 def find? (t : Raw α β cmp) (a : α) : Option β :=
   get? t a
 
@@ -155,7 +155,7 @@ def find? (t : Raw α β cmp) (a : α) : Option β :=
 def get (t : Raw α β cmp) (a : α) (h : a ∈ t) : β :=
   DTreeMap.Raw.Const.get t.inner a h
 
-@[inline, inherit_doc get, deprecated get (since := "2025-02-11")]
+@[inline, inherit_doc get, deprecated get (since := "2025-02-12")]
 def find (t : Raw α β cmp) (a : α) : Option β :=
   get? t a
 
@@ -163,7 +163,7 @@ def find (t : Raw α β cmp) (a : α) : Option β :=
 def get! (t : Raw α β cmp) (a : α) [Inhabited β]  : β :=
   DTreeMap.Raw.Const.get! t.inner a
 
-@[inline, inherit_doc get!, deprecated get! (since := "2025-02-11")]
+@[inline, inherit_doc get!, deprecated get! (since := "2025-02-12")]
 def find! (t : Raw α β cmp) (a : α) [Inhabited β] : β :=
   get! t a
 
@@ -171,7 +171,7 @@ def find! (t : Raw α β cmp) (a : α) [Inhabited β] : β :=
 def getD (t : Raw α β cmp) (a : α) (fallback : β) : β :=
   DTreeMap.Raw.Const.getD t.inner a fallback
 
-@[inline, inherit_doc getD, deprecated getD (since := "2025-02-11")]
+@[inline, inherit_doc getD, deprecated getD (since := "2025-02-12")]
 def findD (t : Raw α β cmp) (a : α) (fallback : β) : β :=
   getD t a fallback
 
@@ -190,7 +190,7 @@ def filter (f : α → β → Bool) (t : Raw α β cmp) : Raw α β cmp :=
 def foldlM (f : δ → (a : α) → β → m δ) (init : δ) (t : Raw α β cmp) : m δ :=
   t.inner.foldlM f init
 
-@[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-11")]
+@[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-12")]
 def foldM (f : δ → (a : α) → β → m δ) (init : δ) (t : Raw α β cmp) : m δ :=
   t.foldlM f init
 
@@ -198,7 +198,7 @@ def foldM (f : δ → (a : α) → β → m δ) (init : δ) (t : Raw α β cmp) 
 def foldl (f : δ → (a : α) → β → δ) (init : δ) (t : Raw α β cmp) : δ :=
   t.inner.foldl f init
 
-@[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-11")]
+@[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-12")]
 def fold (f : δ → (a : α) → β → δ) (init : δ) (t : Raw α β cmp) : δ :=
   t.foldl f init
 

--- a/src/Std/Data/TreeMap/Raw.lean
+++ b/src/Std/Data/TreeMap/Raw.lean
@@ -192,7 +192,7 @@ def foldlM (f : δ → (a : α) → β → m δ) (init : δ) (t : Raw α β cmp)
 
 @[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-12")]
 def foldM (f : δ → (a : α) → β → m δ) (init : δ) (t : Raw α β cmp) : m δ :=
-  t.foldlM f init
+  foldlM f init t
 
 @[inline, inherit_doc DTreeMap.Raw.foldl]
 def foldl (f : δ → (a : α) → β → δ) (init : δ) (t : Raw α β cmp) : δ :=
@@ -200,7 +200,7 @@ def foldl (f : δ → (a : α) → β → δ) (init : δ) (t : Raw α β cmp) : 
 
 @[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-12")]
 def fold (f : δ → (a : α) → β → δ) (init : δ) (t : Raw α β cmp) : δ :=
-  t.foldl f init
+  foldl f init t
 
 @[inline, inherit_doc DTreeMap.Raw.forM]
 def forM (f : α → β → m PUnit) (t : Raw α β cmp) : m PUnit :=

--- a/src/Std/Data/TreeMap/Raw.lean
+++ b/src/Std/Data/TreeMap/Raw.lean
@@ -147,17 +147,33 @@ def erase (t : Raw α β cmp) (a : α) : Raw α β cmp :=
 def get? (t : Raw α β cmp) (a : α) : Option β :=
   DTreeMap.Raw.Const.get? t.inner a
 
+@[inline, inherit_doc get?, deprecated get? (since := "2025-02-11")]
+def find? (t : Raw α β cmp) (a : α) : Option β :=
+  get? t a
+
 @[inline, inherit_doc DTreeMap.Raw.Const.get]
 def get (t : Raw α β cmp) (a : α) (h : a ∈ t) : β :=
   DTreeMap.Raw.Const.get t.inner a h
+
+@[inline, inherit_doc get, deprecated get (since := "2025-02-11")]
+def find (t : Raw α β cmp) (a : α) : Option β :=
+  get? t a
 
 @[inline, inherit_doc DTreeMap.Raw.Const.get!]
 def get! (t : Raw α β cmp) (a : α) [Inhabited β]  : β :=
   DTreeMap.Raw.Const.get! t.inner a
 
+@[inline, inherit_doc get!, deprecated get! (since := "2025-02-11")]
+def find! (t : Raw α β cmp) (a : α) [Inhabited β] : β :=
+  get! t a
+
 @[inline, inherit_doc DTreeMap.Raw.Const.getD]
 def getD (t : Raw α β cmp) (a : α) (fallback : β) : β :=
   DTreeMap.Raw.Const.getD t.inner a fallback
+
+@[inline, inherit_doc getD, deprecated getD (since := "2025-02-11")]
+def findD (t : Raw α β cmp) (a : α) (fallback : β) : β :=
+  getD t a fallback
 
 instance : GetElem? (Raw α β cmp) α β (fun m a => a ∈ m) where
   getElem m a h := m.get a h
@@ -174,9 +190,17 @@ def filter (f : α → β → Bool) (t : Raw α β cmp) : Raw α β cmp :=
 def foldlM (f : δ → (a : α) → β → m δ) (init : δ) (t : Raw α β cmp) : m δ :=
   t.inner.foldlM f init
 
+@[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-11")]
+def foldM (f : δ → (a : α) → β → m δ) (init : δ) (t : Raw α β cmp) : m δ :=
+  t.foldlM f init
+
 @[inline, inherit_doc DTreeMap.Raw.foldl]
 def foldl (f : δ → (a : α) → β → δ) (init : δ) (t : Raw α β cmp) : δ :=
   t.inner.foldl f init
+
+@[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-11")]
+def fold (f : δ → (a : α) → β → δ) (init : δ) (t : Raw α β cmp) : δ :=
+  t.foldl f init
 
 @[inline, inherit_doc DTreeMap.Raw.forM]
 def forM (f : α → β → m PUnit) (t : Raw α β cmp) : m PUnit :=

--- a/src/Std/Data/TreeMap/Raw.lean
+++ b/src/Std/Data/TreeMap/Raw.lean
@@ -156,8 +156,8 @@ def get (t : Raw α β cmp) (a : α) (h : a ∈ t) : β :=
   DTreeMap.Raw.Const.get t.inner a h
 
 @[inline, inherit_doc get, deprecated get (since := "2025-02-12")]
-def find (t : Raw α β cmp) (a : α) : Option β :=
-  get? t a
+def find (t : Raw α β cmp) (a : α) (h : a ∈ t) : β :=
+  get t a h
 
 @[inline, inherit_doc DTreeMap.Raw.Const.get!]
 def get! (t : Raw α β cmp) (a : α) [Inhabited β]  : β :=

--- a/src/Std/Data/TreeSet/Basic.lean
+++ b/src/Std/Data/TreeSet/Basic.lean
@@ -164,7 +164,7 @@ def foldlM {m δ} [Monad m] (f : δ → (a : α) → m δ) (init : δ) (t : Tree
 
 @[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-12")]
 def foldM (f : δ → (a : α) → m δ) (init : δ) (t : TreeSet α cmp) : m δ :=
-  t.foldlM f init
+  foldlM f init t
 
 /-- Folds the given function over the elements of the tree set in ascending order. -/
 @[inline]
@@ -173,7 +173,7 @@ def foldl (f : δ → (a : α) → δ) (init : δ) (t : TreeSet α cmp) : δ :=
 
 @[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-12")]
 def fold (f : δ → (a : α) → δ) (init : δ) (t : TreeSet α cmp) : δ :=
-  t.foldl f init
+  foldl f init t
 
 /-- Carries out a monadic action on each element in the tree set in ascending order. -/
 @[inline]

--- a/src/Std/Data/TreeSet/Basic.lean
+++ b/src/Std/Data/TreeSet/Basic.lean
@@ -162,7 +162,7 @@ ascending order.
 def foldlM {m δ} [Monad m] (f : δ → (a : α) → m δ) (init : δ) (t : TreeSet α cmp) : m δ :=
   t.inner.foldlM (fun c a _ => f c a) init
 
-@[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-11")]
+@[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-12")]
 def foldM (f : δ → (a : α) → m δ) (init : δ) (t : TreeSet α cmp) : m δ :=
   t.foldlM f init
 
@@ -171,7 +171,7 @@ def foldM (f : δ → (a : α) → m δ) (init : δ) (t : TreeSet α cmp) : m δ
 def foldl (f : δ → (a : α) → δ) (init : δ) (t : TreeSet α cmp) : δ :=
   t.inner.foldl (fun c a _ => f c a) init
 
-@[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-11")]
+@[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-12")]
 def fold (f : δ → (a : α) → δ) (init : δ) (t : TreeSet α cmp) : δ :=
   t.foldl f init
 

--- a/src/Std/Data/TreeSet/Basic.lean
+++ b/src/Std/Data/TreeSet/Basic.lean
@@ -162,10 +162,18 @@ ascending order.
 def foldlM {m δ} [Monad m] (f : δ → (a : α) → m δ) (init : δ) (t : TreeSet α cmp) : m δ :=
   t.inner.foldlM (fun c a _ => f c a) init
 
+@[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-11")]
+def foldM (f : δ → (a : α) → m δ) (init : δ) (t : TreeSet α cmp) : m δ :=
+  t.foldlM f init
+
 /-- Folds the given function over the elements of the tree set in ascending order. -/
 @[inline]
 def foldl (f : δ → (a : α) → δ) (init : δ) (t : TreeSet α cmp) : δ :=
   t.inner.foldl (fun c a _ => f c a) init
+
+@[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-11")]
+def fold (f : δ → (a : α) → δ) (init : δ) (t : TreeSet α cmp) : δ :=
+  t.foldl f init
 
 /-- Carries out a monadic action on each element in the tree set in ascending order. -/
 @[inline]

--- a/src/Std/Data/TreeSet/Basic.lean
+++ b/src/Std/Data/TreeSet/Basic.lean
@@ -164,7 +164,7 @@ def foldlM {m δ} [Monad m] (f : δ → (a : α) → m δ) (init : δ) (t : Tree
 
 @[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-12")]
 def foldM (f : δ → (a : α) → m δ) (init : δ) (t : TreeSet α cmp) : m δ :=
-  foldlM f init t
+  t.foldlM f init
 
 /-- Folds the given function over the elements of the tree set in ascending order. -/
 @[inline]
@@ -173,7 +173,7 @@ def foldl (f : δ → (a : α) → δ) (init : δ) (t : TreeSet α cmp) : δ :=
 
 @[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-12")]
 def fold (f : δ → (a : α) → δ) (init : δ) (t : TreeSet α cmp) : δ :=
-  foldl f init t
+  t.foldl f init
 
 /-- Carries out a monadic action on each element in the tree set in ascending order. -/
 @[inline]

--- a/src/Std/Data/TreeSet/Raw.lean
+++ b/src/Std/Data/TreeSet/Raw.lean
@@ -143,7 +143,7 @@ def filter (f : α → Bool) (t : Raw α cmp) : Raw α cmp :=
 def foldlM (f : δ → (a : α) → m δ) (init : δ) (t : Raw α cmp) : m δ :=
   t.inner.foldlM (fun c a _ => f c a) init
 
-@[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-11")]
+@[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-12")]
 def foldM (f : δ → (a : α) → m δ) (init : δ) (t : Raw α cmp) : m δ :=
   t.foldlM f init
 
@@ -151,7 +151,7 @@ def foldM (f : δ → (a : α) → m δ) (init : δ) (t : Raw α cmp) : m δ :=
 def foldl (f : δ → (a : α) → δ) (init : δ) (t : Raw α cmp) : δ :=
   t.inner.foldl (fun c a _ => f c a) init
 
-@[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-11")]
+@[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-12")]
 def fold (f : δ → (a : α) → δ) (init : δ) (t : Raw α cmp) : δ :=
   t.foldl f init
 

--- a/src/Std/Data/TreeSet/Raw.lean
+++ b/src/Std/Data/TreeSet/Raw.lean
@@ -143,9 +143,17 @@ def filter (f : α → Bool) (t : Raw α cmp) : Raw α cmp :=
 def foldlM (f : δ → (a : α) → m δ) (init : δ) (t : Raw α cmp) : m δ :=
   t.inner.foldlM (fun c a _ => f c a) init
 
+@[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-11")]
+def foldM (f : δ → (a : α) → m δ) (init : δ) (t : Raw α cmp) : m δ :=
+  t.foldlM f init
+
 @[inline, inherit_doc TreeSet.empty]
 def foldl (f : δ → (a : α) → δ) (init : δ) (t : Raw α cmp) : δ :=
   t.inner.foldl (fun c a _ => f c a) init
+
+@[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-11")]
+def fold (f : δ → (a : α) → δ) (init : δ) (t : Raw α cmp) : δ :=
+  t.foldl f init
 
 @[inline, inherit_doc TreeSet.empty]
 def forM (f : α → m PUnit) (t : Raw α cmp) : m PUnit :=

--- a/src/Std/Data/TreeSet/Raw.lean
+++ b/src/Std/Data/TreeSet/Raw.lean
@@ -145,7 +145,7 @@ def foldlM (f : δ → (a : α) → m δ) (init : δ) (t : Raw α cmp) : m δ :=
 
 @[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-12")]
 def foldM (f : δ → (a : α) → m δ) (init : δ) (t : Raw α cmp) : m δ :=
-  foldlM f init t
+  t.foldlM f init
 
 @[inline, inherit_doc TreeSet.empty]
 def foldl (f : δ → (a : α) → δ) (init : δ) (t : Raw α cmp) : δ :=
@@ -153,7 +153,7 @@ def foldl (f : δ → (a : α) → δ) (init : δ) (t : Raw α cmp) : δ :=
 
 @[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-12")]
 def fold (f : δ → (a : α) → δ) (init : δ) (t : Raw α cmp) : δ :=
-  foldl f init t
+  t.foldl f init
 
 @[inline, inherit_doc TreeSet.empty]
 def forM (f : α → m PUnit) (t : Raw α cmp) : m PUnit :=

--- a/src/Std/Data/TreeSet/Raw.lean
+++ b/src/Std/Data/TreeSet/Raw.lean
@@ -145,7 +145,7 @@ def foldlM (f : δ → (a : α) → m δ) (init : δ) (t : Raw α cmp) : m δ :=
 
 @[inline, inherit_doc foldlM, deprecated foldlM (since := "2025-02-12")]
 def foldM (f : δ → (a : α) → m δ) (init : δ) (t : Raw α cmp) : m δ :=
-  t.foldlM f init
+  foldlM f init t
 
 @[inline, inherit_doc TreeSet.empty]
 def foldl (f : δ → (a : α) → δ) (init : δ) (t : Raw α cmp) : δ :=
@@ -153,7 +153,7 @@ def foldl (f : δ → (a : α) → δ) (init : δ) (t : Raw α cmp) : δ :=
 
 @[inline, inherit_doc foldl, deprecated foldl (since := "2025-02-12")]
 def fold (f : δ → (a : α) → δ) (init : δ) (t : Raw α cmp) : δ :=
-  t.foldl f init
+  foldl f init t
 
 @[inline, inherit_doc TreeSet.empty]
 def forM (f : α → m PUnit) (t : Raw α cmp) : m PUnit :=


### PR DESCRIPTION
This PR adds some deprecated function aliases to the tree map in order to ease the transition from the `RBMap` to the tree map.