### PR TITLE
feat: getKey functions for the tree map

### DIFF
--- a/src/Std/Data/DTreeMap/Basic.lean
+++ b/src/Std/Data/DTreeMap/Basic.lean
@@ -219,6 +219,36 @@ def findD [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) (fallback : β a) 
   t.getD a fallback
 
 /--
+Checks if a mapping for the given key exists and returns the key if it does, otherwise `none`.
+The result in the `some` case is guaranteed to be pointer equal to the key in the map.
+-/
+@[inline] def getKey? (t : DTreeMap α β cmp) (a : α) : Option α :=
+  letI : Ord α := ⟨cmp⟩; t.inner.getKey? a
+
+/--
+Retrieves the key from the mapping that matches `a`. Ensures that such a mapping exists by
+requiring a proof of `a ∈ m`. The result is guaranteed to be pointer equal to the key in the map.
+-/
+@[inline] def getKey (t : DTreeMap α β cmp) (a : α) (h : a ∈ t) : α :=
+  letI : Ord α := ⟨cmp⟩; t.inner.getKey a h
+
+
+/--
+Checks if a mapping for the given key exists and returns the key if it does, otherwise `fallback`.
+If a mapping exists the result is guaranteed to be pointer equal to the key in the map.
+-/
+@[inline] def getKey! [Inhabited α] (t : DTreeMap α β cmp) (a : α) : α :=
+  letI : Ord α := ⟨cmp⟩; t.inner.getKey! a
+
+
+/--
+Checks if a mapping for the given key exists and returns the key if it does, otherwise panics.
+If no panic occurs the result is guaranteed to be pointer equal to the key in the map.
+-/
+@[inline] def getKeyD (t : DTreeMap α β cmp) (a : α) (fallback : α) : α :=
+  letI : Ord α := ⟨cmp⟩; t.inner.getKeyD a fallback
+
+/--
 Tries to retrieve the key-value pair with the smallest key in the tree map, returning `none` if the
 map is empty.
 -/

--- a/src/Std/Data/DTreeMap/Basic.lean
+++ b/src/Std/Data/DTreeMap/Basic.lean
@@ -222,30 +222,32 @@ def findD [LawfulEqCmp cmp] (t : DTreeMap α β cmp) (a : α) (fallback : β a) 
 Checks if a mapping for the given key exists and returns the key if it does, otherwise `none`.
 The result in the `some` case is guaranteed to be pointer equal to the key in the map.
 -/
-@[inline] def getKey? (t : DTreeMap α β cmp) (a : α) : Option α :=
+@[inline]
+def getKey? (t : DTreeMap α β cmp) (a : α) : Option α :=
   letI : Ord α := ⟨cmp⟩; t.inner.getKey? a
 
 /--
 Retrieves the key from the mapping that matches `a`. Ensures that such a mapping exists by
 requiring a proof of `a ∈ m`. The result is guaranteed to be pointer equal to the key in the map.
 -/
-@[inline] def getKey (t : DTreeMap α β cmp) (a : α) (h : a ∈ t) : α :=
+@[inline]
+def getKey (t : DTreeMap α β cmp) (a : α) (h : a ∈ t) : α :=
   letI : Ord α := ⟨cmp⟩; t.inner.getKey a h
-
-
-/--
-Checks if a mapping for the given key exists and returns the key if it does, otherwise `fallback`.
-If a mapping exists the result is guaranteed to be pointer equal to the key in the map.
--/
-@[inline] def getKey! [Inhabited α] (t : DTreeMap α β cmp) (a : α) : α :=
-  letI : Ord α := ⟨cmp⟩; t.inner.getKey! a
-
 
 /--
 Checks if a mapping for the given key exists and returns the key if it does, otherwise panics.
 If no panic occurs the result is guaranteed to be pointer equal to the key in the map.
 -/
-@[inline] def getKeyD (t : DTreeMap α β cmp) (a : α) (fallback : α) : α :=
+@[inline]
+def getKey! [Inhabited α] (t : DTreeMap α β cmp) (a : α) : α :=
+  letI : Ord α := ⟨cmp⟩; t.inner.getKey! a
+
+/--
+Checks if a mapping for the given key exists and returns the key if it does, otherwise `fallback`.
+If a mapping exists the result is guaranteed to be pointer equal to the key in the map.
+-/
+@[inline]
+def getKeyD (t : DTreeMap α β cmp) (a : α) (fallback : α) : α :=
   letI : Ord α := ⟨cmp⟩; t.inner.getKeyD a fallback
 
 /--

--- a/src/Std/Data/DTreeMap/Internal/Queries.lean
+++ b/src/Std/Data/DTreeMap/Internal/Queries.lean
@@ -124,7 +124,7 @@ def getKey! [Ord α] (k : α) (t : Impl α β) [Inhabited α] : α :=
   match t with
   | .leaf => panic! "Key is not present in map"
   | .inner _ k' _ l r =>
-    match h : compare k k' with
+    match compare k k' with
     | .lt => getKey! k l
     | .gt => getKey! k r
     | .eq => k'
@@ -134,7 +134,7 @@ def getKeyD [Ord α] (k : α) (t : Impl α β) (fallback : α) : α :=
   match t with
   | .leaf => fallback
   | .inner _ k' _ l r =>
-    match h : compare k k' with
+    match compare k k' with
     | .lt => getKeyD k l fallback
     | .gt => getKeyD k r fallback
     | .eq => k'

--- a/src/Std/Data/DTreeMap/Internal/Queries.lean
+++ b/src/Std/Data/DTreeMap/Internal/Queries.lean
@@ -100,6 +100,45 @@ def getD [Ord α] [LawfulEqOrd α] (k : α) (t : Impl α β) (fallback : β k) :
     | .gt => getD k r fallback
     | .eq => cast (congrArg β (compare_eq_iff_eq.mp h).symm) v'
 
+/-- Implementation detail of the tree map -/
+def getKey? [Ord α] (k : α) (t : Impl α β) : Option α :=
+  match t with
+  | .leaf => none
+  | .inner _ k' _ l r =>
+    match compare k k' with
+    | .lt => getKey? k l
+    | .gt => getKey? k r
+    | .eq => some k'
+
+/-- Implementation detail of the tree map -/
+def getKey [Ord α] (k : α) (t : Impl α β) (hlk : t.contains k = true) : α :=
+  match t with
+  | .inner _ k' _ l r =>
+    match h : compare k k' with
+    | .lt => getKey k l (by simpa [contains, h] using hlk)
+    | .gt => getKey k r (by simpa [contains, h] using hlk)
+    | .eq => k'
+
+/-- Implementation detail of the tree map -/
+def getKey! [Ord α] (k : α) (t : Impl α β) [Inhabited α] : α :=
+  match t with
+  | .leaf => panic! "Key is not present in map"
+  | .inner _ k' _ l r =>
+    match h : compare k k' with
+    | .lt => getKey! k l
+    | .gt => getKey! k r
+    | .eq => k'
+
+/-- Implementation detail of the tree map -/
+def getKeyD [Ord α] (k : α) (t : Impl α β) (fallback : α) : α :=
+  match t with
+  | .leaf => fallback
+  | .inner _ k' _ l r =>
+    match h : compare k k' with
+    | .lt => getKeyD k l fallback
+    | .gt => getKeyD k r fallback
+    | .eq => k'
+
 namespace Const
 
 /-- Returns the value for the key `k`, or `none` if such a key does not exist. -/

--- a/src/Std/Data/DTreeMap/Raw.lean
+++ b/src/Std/Data/DTreeMap/Raw.lean
@@ -176,6 +176,22 @@ def getD [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) (fallback : β a) : β a
 def findD [LawfulEqCmp cmp] (t : Raw α β cmp) (a : α) (fallback : β a) : β a :=
   t.getD a fallback
 
+@[inline, inherit_doc DTreeMap.getKey?]
+def getKey? (t : Raw α β cmp) (a : α) : Option α :=
+  letI : Ord α := ⟨cmp⟩; t.inner.getKey? a
+
+@[inline, inherit_doc DTreeMap.getKey]
+def getKey (t : Raw α β cmp) (a : α) (h : a ∈ t) : α :=
+  letI : Ord α := ⟨cmp⟩; t.inner.getKey a h
+
+@[inline, inherit_doc DTreeMap.getKey!]
+def getKey! [Inhabited α] (t : Raw α β cmp) (a : α) : α :=
+  letI : Ord α := ⟨cmp⟩; t.inner.getKey! a
+
+@[inline, inherit_doc DTreeMap.getKeyD]
+def getKeyD (t : Raw α β cmp) (a : α) (fallback : α) : α :=
+  letI : Ord α := ⟨cmp⟩; t.inner.getKeyD a fallback
+
 @[inline, inherit_doc DTreeMap.min?]
 def min? (t : Raw α β cmp) : Option ((a : α) × β a) :=
   letI : Ord α := ⟨cmp⟩; t.inner.min?

--- a/src/Std/Data/TreeMap/Basic.lean
+++ b/src/Std/Data/TreeMap/Basic.lean
@@ -158,6 +158,22 @@ instance : GetElem? (TreeMap α β cmp) α β (fun m a => a ∈ m) where
   getElem? m a := m.get? a
   getElem! m a := m.get! a
 
+@[inline, inherit_doc DTreeMap.getKey?]
+def getKey? (t : TreeMap α β cmp) (a : α) : Option α :=
+  t.inner.getKey? a
+
+@[inline, inherit_doc DTreeMap.getKey]
+def getKey (t : TreeMap α β cmp) (a : α) (h : a ∈ t) : α :=
+  t.inner.getKey a h
+
+@[inline, inherit_doc DTreeMap.getKey!]
+def getKey! [Inhabited α] (t : TreeMap α β cmp) (a : α) : α :=
+  t.inner.getKey! a
+
+@[inline, inherit_doc DTreeMap.getKeyD]
+def getKeyD (t : TreeMap α β cmp) (a : α) (fallback : α) : α :=
+  t.inner.getKeyD a fallback
+
 @[inline, inherit_doc DTreeMap.Const.min?]
 def min? (t : TreeMap α β cmp) : Option (α × β) :=
   DTreeMap.Const.min? t.inner

--- a/src/Std/Data/TreeMap/Raw.lean
+++ b/src/Std/Data/TreeMap/Raw.lean
@@ -176,6 +176,22 @@ instance : GetElem? (Raw α β cmp) α β (fun m a => a ∈ m) where
   getElem? m a := m.get? a
   getElem! m a := m.get! a
 
+@[inline, inherit_doc DTreeMap.Raw.getKey?]
+def getKey? (t : Raw α β cmp) (a : α) : Option α :=
+  t.inner.getKey? a
+
+@[inline, inherit_doc DTreeMap.Raw.getKey]
+def getKey (t : Raw α β cmp) (a : α) (h : a ∈ t) : α :=
+  t.inner.getKey a h
+
+@[inline, inherit_doc DTreeMap.Raw.getKey!]
+def getKey! [Inhabited α] (t : Raw α β cmp) (a : α) : α :=
+  t.inner.getKey! a
+
+@[inline, inherit_doc DTreeMap.Raw.getKeyD]
+def getKeyD (t : Raw α β cmp) (a : α) (fallback : α) : α :=
+  t.inner.getKeyD a fallback
+
 @[inline, inherit_doc DTreeMap.Raw.Const.min?]
 def min? (t : Raw α β cmp) : Option (α × β) :=
   DTreeMap.Raw.Const.min? t.inner

--- a/src/Std/Data/TreeSet/Basic.lean
+++ b/src/Std/Data/TreeSet/Basic.lean
@@ -148,6 +148,38 @@ def erase (t : TreeSet α cmp) (a : α) : TreeSet α cmp :=
   ⟨t.inner.erase a⟩
 
 /--
+Checks if given key is contained and returns the key if it is, otherwise `none`.
+The result in the `some` case is guaranteed to be pointer equal to the key in the map.
+-/
+@[inline]
+def get? (t : TreeSet α cmp) (a : α) : Option α :=
+  t.inner.getKey? a
+
+/--
+Retrieves the key from the set that matches `a`. Ensures that such a key exists by requiring a proof
+of `a ∈ m`. The result is guaranteed to be pointer equal to the key in the set.
+-/
+@[inline]
+def get (t : TreeSet α cmp) (a : α) (h : a ∈ t) : α :=
+  t.inner.getKey a h
+
+/--
+Checks if given key is contained and returns the key if it is, otherwise panics.
+If no panic occurs the result is guaranteed to be pointer equal to the key in the set.
+-/
+@[inline]
+def get! [Inhabited α] (t : TreeSet α cmp) (a : α) : α :=
+  t.inner.getKey! a
+
+/--
+Checks if given key is contained and returns the key if it is, otherwise `fallback`.
+If they key is contained the result is guaranteed to be pointer equal to the key in the set.
+-/
+@[inline]
+def getD (t : TreeSet α cmp) (a : α) (fallback : α) : α :=
+  t.inner.getKeyD a fallback
+
+/--
 Tries to retrieve the smallest element of the tree set, returning `none` if the set is empty.
 -/
 @[inline]
@@ -205,22 +237,22 @@ def maxD (t : TreeSet α cmp) (fallback : α) : α :=
 
 /-- Returns the `n`-th smallest element, or `none` if `n` is at least `t.size`. -/
 @[inline]
-def entryAtIdx? (t : TreeSet α cmp) (n : Nat) : Option α :=
+def atIdx? (t : TreeSet α cmp) (n : Nat) : Option α :=
   TreeMap.keyAtIndex? t.inner n
 
 /-- Returns the `n`-th smallest element. -/
 @[inline]
-def entryAtIdx (t : TreeSet α cmp) (n : Nat) (h : n < t.size) : α :=
+def atIdx (t : TreeSet α cmp) (n : Nat) (h : n < t.size) : α :=
   TreeMap.keyAtIndex t.inner n h
 
 /-- Returns the `n`-th smallest element, or panics if `n` is at least `t.size`. -/
 @[inline]
-def entryAtIdx! [Inhabited α] (t : TreeSet α cmp) (n : Nat) : α :=
+def atIdx! [Inhabited α] (t : TreeSet α cmp) (n : Nat) : α :=
   TreeMap.keyAtIndex! t.inner n
 
 /-- Returns the `n`-th smallest element, or `fallback` if `n` is at least `t.size`. -/
 @[inline]
-def entryAtIdxD (t : TreeSet α cmp) (n : Nat) (fallback : α) : α :=
+def atIdxD (t : TreeSet α cmp) (n : Nat) (fallback : α) : α :=
   TreeMap.keyAtIndexD t.inner n fallback
 
 /--

--- a/src/Std/Data/TreeSet/Raw.lean
+++ b/src/Std/Data/TreeSet/Raw.lean
@@ -133,6 +133,22 @@ def isEmpty (t : Raw α cmp) : Bool :=
 def erase (t : Raw α cmp) (a : α) : Raw α cmp :=
   ⟨t.inner.erase a⟩
 
+@[inline, inherit_doc TreeSet.get?]
+def get? (t : TreeSet α cmp) (a : α) : Option α :=
+  t.inner.getKey? a
+
+@[inline, inherit_doc TreeSet.get]
+def get (t : TreeSet α cmp) (a : α) (h : a ∈ t) : α :=
+  t.inner.getKey a h
+
+@[inline, inherit_doc TreeSet.get!]
+def get! [Inhabited α] (t : TreeSet α cmp) (a : α) : α :=
+  t.inner.getKey! a
+
+@[inline, inherit_doc TreeSet.getD]
+def getD (t : TreeSet α cmp) (a : α) (fallback : α) : α :=
+  t.inner.getKeyD a fallback
+
 @[inline, inherit_doc TreeSet.min?]
 def min? (t : Raw α cmp) : Option α :=
   TreeMap.Raw.minKey? t.inner
@@ -165,20 +181,20 @@ def max! [Inhabited α] (t : Raw α cmp) : α :=
 def maxD (t : Raw α cmp) (fallback : α) : α :=
   TreeMap.Raw.maxKeyD t.inner fallback
 
-@[inline, inherit_doc TreeSet.entryAtIdx?]
-def entryAtIdx? (t : Raw α cmp) (n : Nat) : Option α :=
+@[inline, inherit_doc TreeSet.atIdx?]
+def atIdx? (t : Raw α cmp) (n : Nat) : Option α :=
   TreeMap.Raw.keyAtIndex? t.inner n
 
 /-!
 We do not provide `entryAtIdx` for the raw trees.
 -/
 
-@[inline, inherit_doc TreeSet.entryAtIdx!]
-def entryAtIdx! [Inhabited α] (t : Raw α cmp) (n : Nat) : α :=
+@[inline, inherit_doc TreeSet.atIdx!]
+def atIdx! [Inhabited α] (t : Raw α cmp) (n : Nat) : α :=
   TreeMap.Raw.keyAtIndex! t.inner n
 
-@[inline, inherit_doc TreeSet.entryAtIdxD]
-def entryAtIdxD (t : Raw α cmp) (n : Nat) (fallback : α) : α :=
+@[inline, inherit_doc TreeSet.atIdxD]
+def atIdxD (t : Raw α cmp) (n : Nat) (fallback : α) : α :=
   TreeMap.Raw.keyAtIndexD t.inner n fallback
 
 @[inline, inherit_doc TreeSet.getGE?]

--- a/src/Std/Data/TreeSet/Raw.lean
+++ b/src/Std/Data/TreeSet/Raw.lean
@@ -134,19 +134,19 @@ def erase (t : Raw α cmp) (a : α) : Raw α cmp :=
   ⟨t.inner.erase a⟩
 
 @[inline, inherit_doc TreeSet.get?]
-def get? (t : TreeSet α cmp) (a : α) : Option α :=
+def get? (t : Raw α cmp) (a : α) : Option α :=
   t.inner.getKey? a
 
 @[inline, inherit_doc TreeSet.get]
-def get (t : TreeSet α cmp) (a : α) (h : a ∈ t) : α :=
+def get (t : Raw α cmp) (a : α) (h : a ∈ t) : α :=
   t.inner.getKey a h
 
 @[inline, inherit_doc TreeSet.get!]
-def get! [Inhabited α] (t : TreeSet α cmp) (a : α) : α :=
+def get! [Inhabited α] (t : Raw α cmp) (a : α) : α :=
   t.inner.getKey! a
 
 @[inline, inherit_doc TreeSet.getD]
-def getD (t : TreeSet α cmp) (a : α) (fallback : α) : α :=
+def getD (t : Raw α cmp) (a : α) (fallback : α) : α :=
   t.inner.getKeyD a fallback
 
 @[inline, inherit_doc TreeSet.min?]


### PR DESCRIPTION
This PR implements the `getKey` functions on the tree map. It also fixes the naming of the `entryAtIdx` function on the tree set, which should have been called `atIdx`.