### PR TITLE
feat: more tree map lemmas about empty, isEmpty, contains, size, insert, erase

### DIFF
--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -175,21 +175,21 @@ theorem mem_insert!_self [TransOrd α] (h : t.WF) {k : α} {v : β k} :
   simpa [mem_iff_contains] using contains_insert!_self h
 
 theorem contains_of_contains_insert [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
-    (t.insert k v h.balanced).impl.contains a → ¬ compare k a = .eq → t.contains a := by
-  rw [← beq_iff_eq (b := Ordering.eq), ← beq_eq, Bool.not_eq_true]
+    (t.insert k v h.balanced).impl.contains a → compare k a ≠ .eq → t.contains a := by
+  rw [← beq_eq_false_iff_ne]
   simp_to_model [insert] using List.containsKey_of_containsKey_insertEntry
 
 theorem contains_of_contains_insert! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
-    (t.insert! k v).contains a → ¬ compare k a = .eq → t.contains a := by
-  rw [← beq_iff_eq (b := Ordering.eq), ← beq_eq, Bool.not_eq_true]
+    (t.insert! k v).contains a → compare k a ≠ .eq → t.contains a := by
+  rw [← beq_eq_false_iff_ne]
   simp_to_model [insert!] using List.containsKey_of_containsKey_insertEntry
 
 theorem mem_of_mem_insert [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
-    a ∈ (t.insert k v h.balanced).impl → ¬ compare k a = .eq → a ∈ t := by
+    a ∈ (t.insert k v h.balanced).impl → compare k a ≠ .eq → a ∈ t := by
   simpa [mem_iff_contains] using contains_of_contains_insert h
 
 theorem mem_of_mem_insert! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
-    a ∈ t.insert! k v → ¬ compare k a = .eq → a ∈ t := by
+    a ∈ t.insert! k v → compare k a ≠ .eq → a ∈ t := by
   simpa [mem_iff_contains] using contains_of_contains_insert! h
 
 theorem size_empty : (empty : Impl α β).size = 0 :=
@@ -250,12 +250,12 @@ theorem contains_erase! [TransOrd α] (h : t.WF) {k a : α} :
   simp_to_model [erase!] using List.containsKey_eraseKey
 
 theorem mem_erase [TransOrd α] (h : t.WF) {k a : α} :
-    a ∈ (t.erase k h.balanced).impl ↔ ¬ compare k a = .eq ∧ a ∈ t := by
+    a ∈ (t.erase k h.balanced).impl ↔ compare k a ≠ .eq ∧ a ∈ t := by
   simpa only [mem_iff_contains, Bool.and_eq_true, Bool.not_eq_true', beq_eq_false_iff_ne]
     using Bool.eq_iff_iff.mp <| contains_erase h
 
 theorem mem_erase! [TransOrd α] (h : t.WF) {k a : α} :
-    a ∈ t.erase! k ↔  ¬ compare k a = .eq ∧ a ∈ t := by
+    a ∈ t.erase! k ↔  compare k a ≠ .eq ∧ a ∈ t := by
   simp [mem_iff_contains, contains_erase! h]
 
 theorem contains_of_contains_erase [TransOrd α] (h : t.WF) {k a : α} :
@@ -307,12 +307,12 @@ theorem contains_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
   simp_to_model [insertIfNew!] using List.containsKey_insertEntryIfNew
 
 theorem mem_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
-    a ∈ (t.insertIfNew k v h.balanced).impl ↔ k == a ∨ a ∈ t := by
-  simp [mem_iff_contains, contains_insertIfNew, h]
+    a ∈ (t.insertIfNew k v h.balanced).impl ↔ compare k a = .eq ∨ a ∈ t := by
+  simp [mem_iff_contains, contains_insertIfNew, h, beq_eq]
 
 theorem mem_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
-    a ∈ t.insertIfNew! k v ↔ k == a ∨ a ∈ t := by
-  simp [mem_iff_contains, contains_insertIfNew!, h]
+    a ∈ t.insertIfNew! k v ↔ compare k a = .eq ∨ a ∈ t := by
+  simp [mem_iff_contains, contains_insertIfNew!, h, beq_eq]
 
 theorem contains_insertIfNew_self [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.insertIfNew k v h.balanced).impl.contains k := by
@@ -331,21 +331,21 @@ theorem mem_insertIfNew!_self [TransOrd α] (h : t.WF) {k : α} {v : β k} :
   simp [mem_insertIfNew!, h]
 
 theorem contains_of_contains_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
-    (t.insertIfNew k v h.balanced).impl.contains a → ¬ compare k a = .eq → t.contains a := by
-  rw [← ne_eq, ← beq_eq_false_iff_ne]
+    (t.insertIfNew k v h.balanced).impl.contains a → compare k a ≠ .eq → t.contains a := by
+  rw [← beq_eq_false_iff_ne]
   simp_to_model [insertIfNew] using List.containsKey_of_containsKey_insertEntryIfNew
 
 theorem contains_of_contains_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
-    (t.insertIfNew! k v).contains a → ¬ compare k a = .eq → t.contains a := by
-  rw [← ne_eq, ← beq_eq_false_iff_ne]
+    (t.insertIfNew! k v).contains a → compare k a ≠ .eq → t.contains a := by
+  rw [← beq_eq_false_iff_ne]
   simp_to_model [insertIfNew!] using List.containsKey_of_containsKey_insertEntryIfNew
 
 theorem mem_of_mem_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
-    a ∈ (t.insertIfNew k v h.balanced).impl → ¬ compare k a = .eq → a ∈ t := by
+    a ∈ (t.insertIfNew k v h.balanced).impl → compare k a ≠ .eq → a ∈ t := by
   simpa [mem_iff_contains] using contains_of_contains_insertIfNew h
 
 theorem mem_of_mem_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
-    a ∈ t.insertIfNew! k v → ¬ compare k a = .eq → a ∈ t := by
+    a ∈ t.insertIfNew! k v → compare k a ≠ .eq → a ∈ t := by
   simpa [mem_iff_contains] using contains_of_contains_insertIfNew! h
 
 theorem size_insertIfNew [TransOrd α] {k : α} (h : t.WF) {v : β k} :

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -112,4 +112,267 @@ theorem isEmpty_insertIfNew! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.insertIfNew! k v).isEmpty = false := by
   simp_to_model [insertIfNew!] using List.isEmpty_insertEntryIfNew
 
+theorem contains_empty {a : α} : (empty : Impl α β).contains a = false := by
+  simp [contains, empty]
+
+theorem not_mem_empty {a : α} : a ∉ (empty : Impl α β) := by
+  simp [mem_iff_contains, contains_empty]
+
+theorem contains_of_isEmpty [TransOrd α] (h : t.WF) {a : α} :
+    t.isEmpty → t.contains a = false := by
+  simp_to_model; empty
+
+theorem not_mem_of_isEmpty [TransOrd α] (h : t.WF) {a : α} :
+    t.isEmpty → a ∉ t := by
+  simpa [mem_iff_contains] using contains_of_isEmpty h
+
+theorem isEmpty_eq_false_iff_exists_contains_eq_true [TransOrd α] (h : t.WF) :
+    t.isEmpty = false ↔ ∃ a, t.contains a = true := by
+  simp_to_model using List.isEmpty_eq_false_iff_exists_containsKey
+
+theorem isEmpty_eq_false_iff_exists_mem [TransOrd α] (h : t.WF) :
+    t.isEmpty = false ↔ ∃ a, a ∈ t := by
+  simpa [mem_iff_contains] using isEmpty_eq_false_iff_exists_contains_eq_true h
+
+theorem isEmpty_iff_forall_contains [TransOrd α] (h : t.WF) :
+    t.isEmpty = true ↔ ∀ a, t.contains a = false := by
+  simp_to_model using List.isEmpty_iff_forall_containsKey
+
+theorem isEmpty_iff_forall_not_mem [TransOrd α] (h : t.WF) :
+    t.isEmpty = true ↔ ∀ a, ¬a ∈ t := by
+  simpa [mem_iff_contains] using isEmpty_iff_forall_contains h
+
+theorem contains_insert [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
+    (t.insert k v h.balanced).impl.contains a = (compare k a == .eq || t.contains a) := by
+  simp_to_model [insert] using List.containsKey_insertEntry
+
+theorem contains_insert! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
+    (t.insert! k v).contains a = (compare k a == .eq || t.contains a) := by
+  simp_to_model [insert!] using List.containsKey_insertEntry
+
+theorem mem_insert [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
+    a ∈ (t.insert k v h.balanced).impl ↔ compare k a = .eq ∨ a ∈ t := by
+  simp [mem_iff_contains, contains_insert h]
+
+theorem mem_insert! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
+    a ∈ t.insert! k v ↔ compare k a = .eq ∨ a ∈ t := by
+  simp [mem_iff_contains, contains_insert! h]
+
+theorem contains_insert_self [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.insert k v h.balanced).impl.contains k := by
+  simp_to_model [insert] using List.containsKey_insertEntry_self
+
+theorem contains_insert!_self [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.insert! k v).contains k := by
+  simp_to_model [insert!] using List.containsKey_insertEntry_self
+
+theorem mem_insert_self [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    k ∈ (t.insert k v h.balanced).impl := by
+  simpa [mem_iff_contains] using contains_insert_self h
+
+theorem mem_insert!_self [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    k ∈ t.insert! k v := by
+  simpa [mem_iff_contains] using contains_insert!_self h
+
+theorem contains_of_contains_insert [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
+    (t.insert k v h.balanced).impl.contains a → ¬ compare k a = .eq → t.contains a := by
+  rw [← beq_iff_eq (b := Ordering.eq), ← beq_eq, Bool.not_eq_true]
+  simp_to_model [insert] using List.containsKey_of_containsKey_insertEntry
+
+theorem contains_of_contains_insert! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
+    (t.insert! k v).contains a → ¬ compare k a = .eq → t.contains a := by
+  rw [← beq_iff_eq (b := Ordering.eq), ← beq_eq, Bool.not_eq_true]
+  simp_to_model [insert!] using List.containsKey_of_containsKey_insertEntry
+
+theorem mem_of_mem_insert [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
+    a ∈ (t.insert k v h.balanced).impl → ¬ compare k a = .eq → a ∈ t := by
+  simpa [mem_iff_contains] using contains_of_contains_insert h
+
+theorem mem_of_mem_insert! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
+    a ∈ t.insert! k v → ¬ compare k a = .eq → a ∈ t := by
+  simpa [mem_iff_contains] using contains_of_contains_insert! h
+
+theorem size_empty : (empty : Impl α β).size = 0 :=
+  rfl
+
+theorem isEmpty_eq_size_eq_zero (h : t.WF) :
+    letI : BEq Nat := instBEqOfDecidableEq
+    t.isEmpty = (t.size == 0) := by
+  simp_to_model
+  rw [Bool.eq_iff_iff, List.isEmpty_iff_length_eq_zero, Nat.beq_eq_true_eq]
+
+theorem size_insert [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.insert k v h.balanced).impl.size = if t.contains k then t.size else t.size + 1 := by
+  simp_to_model [insert] using List.length_insertEntry
+
+theorem size_insert! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.insert! k v).size = if t.contains k then t.size else t.size + 1 := by
+  simp_to_model [insert!] using List.length_insertEntry
+
+theorem size_le_size_insert [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    t.size ≤ (t.insert k v h.balanced).impl.size := by
+  simp_to_model [insert] using List.length_le_length_insertEntry
+
+theorem size_le_size_insert! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    t.size ≤ (t.insert! k v).size := by
+  simp_to_model [insert!] using List.length_le_length_insertEntry
+
+theorem size_insert_le [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.insert k v h.balanced).impl.size ≤ t.size + 1 := by
+  simp_to_model [insert] using List.length_insertEntry_le
+
+theorem size_insert!_le [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.insert! k v).size ≤ t.size + 1 := by
+  simp_to_model [insert!] using List.length_insertEntry_le
+
+theorem erase_empty {k : α} :
+    ((empty : Impl α β).erase k balanced_empty).impl = empty :=
+  rfl
+
+theorem erase!_empty {k : α} :
+    (empty : Impl α β).erase! k = empty :=
+  rfl
+
+theorem isEmpty_erase [TransOrd α] (h : t.WF) {k : α} :
+    (t.erase k h.balanced).impl.isEmpty = (t.isEmpty || (t.size = 1 && t.contains k)) := by
+  simp_to_model [erase] using List.isEmpty_eraseKey
+
+theorem isEmpty_erase! [TransOrd α] (h : t.WF) {k : α} :
+    (t.erase! k).isEmpty = (t.isEmpty || (t.size = 1 && t.contains k)) := by
+  simp_to_model [erase!] using List.isEmpty_eraseKey
+
+theorem contains_erase [TransOrd α] (h : t.WF) {k a : α} :
+    (t.erase k h.balanced).impl.contains a = (!(k == a) && t.contains a) := by
+  simp_to_model [erase] using List.containsKey_eraseKey
+
+theorem contains_erase! [TransOrd α] (h : t.WF) {k a : α} :
+    (t.erase! k).contains a = (!(k == a) && t.contains a) := by
+  simp_to_model [erase!] using List.containsKey_eraseKey
+
+theorem mem_erase [TransOrd α] (h : t.WF) {k a : α} :
+    a ∈ (t.erase k h.balanced).impl ↔  (k == a) = false ∧ a ∈ t := by
+  simp [mem_iff_contains, contains_erase h]
+
+theorem mem_erase! [TransOrd α] (h : t.WF) {k a : α} :
+    a ∈ t.erase! k ↔  (k == a) = false ∧ a ∈ t := by
+  simp [mem_iff_contains, contains_erase! h]
+
+theorem contains_of_contains_erase [TransOrd α] (h : t.WF) {k a : α} :
+    (t.erase k h.balanced).impl.contains a → t.contains a := by
+  simp_to_model [erase] using List.containsKey_of_containsKey_eraseKey
+
+theorem contains_of_contains_erase! [TransOrd α] (h : t.WF) {k a : α} :
+    (t.erase! k).contains a → t.contains a := by
+  simp_to_model [erase!] using List.containsKey_of_containsKey_eraseKey
+
+theorem mem_of_mem_erase [TransOrd α] (h : t.WF) {k a : α} :
+    a ∈ (t.erase k h.balanced).impl → a ∈ t := by
+  simpa [mem_iff_contains] using contains_of_contains_erase h
+
+theorem mem_of_mem_erase! [TransOrd α] (h : t.WF) {k a : α} :
+    a ∈ t.erase! k → a ∈ t := by
+  simpa [mem_iff_contains] using contains_of_contains_erase! h
+
+theorem size_erase [TransOrd α] (h : t.WF) {k : α} :
+    (t.erase k h.balanced).impl.size = if t.contains k then t.size - 1 else t.size := by
+  simp_to_model [erase] using List.length_eraseKey
+
+theorem size_erase! [TransOrd α] (h : t.WF) {k : α} :
+    (t.erase! k).size = if t.contains k then t.size - 1 else t.size := by
+  simp_to_model [erase!] using List.length_eraseKey
+
+theorem size_erase_le [TransOrd α] (h : t.WF) {k : α} :
+    (t.erase k h.balanced).impl.size ≤ t.size := by
+  simp_to_model [erase] using List.length_eraseKey_le
+
+theorem size_erase!_le [TransOrd α] (h : t.WF) {k : α} :
+    (t.erase! k).size ≤ t.size := by
+  simp_to_model [erase!] using List.length_eraseKey_le
+
+theorem size_le_size_erase [TransOrd α] (h : t.WF) {k : α} :
+    t.size ≤ (t.erase k h.balanced).impl.size + 1 := by
+  simp_to_model [erase] using List.length_le_length_eraseKey
+
+theorem size_le_size_erase! [TransOrd α] (h : t.WF) {k : α} :
+    t.size ≤ (t.erase! k).size + 1 := by
+  simp_to_model [erase!] using List.length_le_length_eraseKey
+
+@[simp]
+theorem contains_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
+    (t.insertIfNew k v h.balanced).impl.contains a = (k == a || t.contains a) := by
+  simp_to_model [insertIfNew] using List.containsKey_insertEntryIfNew
+
+@[simp]
+theorem contains_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
+    (t.insertIfNew! k v).contains a = (k == a || t.contains a) := by
+  simp_to_model [insertIfNew!] using List.containsKey_insertEntryIfNew
+
+@[simp]
+theorem mem_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
+    a ∈ (t.insertIfNew k v h.balanced).impl ↔ k == a ∨ a ∈ t := by
+  simp [mem_iff_contains, contains_insertIfNew, h]
+
+@[simp]
+theorem mem_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
+    a ∈ t.insertIfNew! k v ↔ k == a ∨ a ∈ t := by
+  simp [mem_iff_contains, contains_insertIfNew, h]
+
+theorem contains_insertIfNew_self [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.insertIfNew k v h.balanced).impl.contains k := by
+  simp [contains_insertIfNew, h]
+
+theorem contains_insertIfNew!_self [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.insertIfNew! k v).contains k := by
+  simp [contains_insertIfNew!, h]
+
+theorem mem_insertIfNew_self [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    k ∈ (t.insertIfNew k v h.balanced).impl := by
+  simp [contains_insertIfNew, h]
+
+theorem mem_insertIfNew!_self [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    k ∈ t.insertIfNew! k v := by
+  simp [contains_insertIfNew!, h]
+
+theorem contains_of_contains_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
+    (t.insertIfNew k v h.balanced).impl.contains a → (k == a) = false → t.contains a := by
+  simp_to_model [insertIfNew] using List.containsKey_of_containsKey_insertEntryIfNew
+
+theorem contains_of_contains_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
+    (t.insertIfNew! k v).contains a → (k == a) = false → t.contains a := by
+  simp_to_model [insertIfNew!] using List.containsKey_of_containsKey_insertEntryIfNew
+
+theorem mem_of_mem_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
+    a ∈ (t.insertIfNew k v h.balanced).impl → (k == a) = false → a ∈ t := by
+  simpa [mem_iff_contains] using contains_of_contains_insertIfNew h
+
+theorem mem_of_mem_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
+    a ∈ t.insertIfNew! k v → (k == a) = false → a ∈ t := by
+  simpa [mem_iff_contains] using contains_of_contains_insertIfNew! h
+
+theorem size_insertIfNew [TransOrd α] {k : α} (h : t.WF) {v : β k} :
+    (t.insertIfNew k v h.balanced).impl.size = if k ∈ t then t.size else t.size + 1 := by
+  simp only [mem_iff_contains]
+  simp_to_model [insertIfNew] using List.length_insertEntryIfNew
+
+theorem size_insertIfNew! [TransOrd α] {k : α} (h : t.WF) {v : β k} :
+    (t.insertIfNew! k v).size = if k ∈ t then t.size else t.size + 1 := by
+  simp only [mem_iff_contains]
+  simp_to_model [insertIfNew!] using List.length_insertEntryIfNew
+
+theorem size_le_size_insertIfNew [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    t.size ≤ (t.insertIfNew k v h.balanced).impl.size := by
+  simp_to_model [insertIfNew] using List.length_le_length_insertEntryIfNew
+
+theorem size_le_size_insertIfNew! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    t.size ≤ (t.insertIfNew! k v).size := by
+  simp_to_model [insertIfNew!] using List.length_le_length_insertEntryIfNew
+
+theorem size_insertIfNew_le [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.insertIfNew k v h.balanced).impl.size ≤ t.size + 1 := by
+  simp_to_model [insertIfNew] using List.length_insertEntryIfNew_le
+
+theorem size_insertIfNew!_le [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.insertIfNew! k v).size ≤ t.size + 1 := by
+  simp_to_model [insertIfNew!] using List.length_insertEntryIfNew_le
+
 end Std.DTreeMap.Internal.Impl

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -242,19 +242,20 @@ theorem isEmpty_erase! [TransOrd α] (h : t.WF) {k : α} :
   simp_to_model [erase!] using List.isEmpty_eraseKey
 
 theorem contains_erase [TransOrd α] (h : t.WF) {k a : α} :
-    (t.erase k h.balanced).impl.contains a = (!(k == a) && t.contains a) := by
+    (t.erase k h.balanced).impl.contains a = (!(compare k a == .eq) && t.contains a) := by
   simp_to_model [erase] using List.containsKey_eraseKey
 
 theorem contains_erase! [TransOrd α] (h : t.WF) {k a : α} :
-    (t.erase! k).contains a = (!(k == a) && t.contains a) := by
+    (t.erase! k).contains a = (!(compare k a == .eq) && t.contains a) := by
   simp_to_model [erase!] using List.containsKey_eraseKey
 
 theorem mem_erase [TransOrd α] (h : t.WF) {k a : α} :
-    a ∈ (t.erase k h.balanced).impl ↔  (k == a) = false ∧ a ∈ t := by
-  simp [mem_iff_contains, contains_erase h]
+    a ∈ (t.erase k h.balanced).impl ↔ ¬ compare k a = .eq ∧ a ∈ t := by
+  simpa only [mem_iff_contains, Bool.and_eq_true, Bool.not_eq_true', beq_eq_false_iff_ne]
+    using Bool.eq_iff_iff.mp <| contains_erase h
 
 theorem mem_erase! [TransOrd α] (h : t.WF) {k a : α} :
-    a ∈ t.erase! k ↔  (k == a) = false ∧ a ∈ t := by
+    a ∈ t.erase! k ↔  ¬ compare k a = .eq ∧ a ∈ t := by
   simp [mem_iff_contains, contains_erase! h]
 
 theorem contains_of_contains_erase [TransOrd α] (h : t.WF) {k a : α} :
@@ -330,19 +331,21 @@ theorem mem_insertIfNew!_self [TransOrd α] (h : t.WF) {k : α} {v : β k} :
   simp [mem_insertIfNew!, h]
 
 theorem contains_of_contains_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
-    (t.insertIfNew k v h.balanced).impl.contains a → (k == a) = false → t.contains a := by
+    (t.insertIfNew k v h.balanced).impl.contains a → ¬ compare k a = .eq → t.contains a := by
+  rw [← ne_eq, ← beq_eq_false_iff_ne]
   simp_to_model [insertIfNew] using List.containsKey_of_containsKey_insertEntryIfNew
 
 theorem contains_of_contains_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
-    (t.insertIfNew! k v).contains a → (k == a) = false → t.contains a := by
+    (t.insertIfNew! k v).contains a → ¬ compare k a = .eq → t.contains a := by
+  rw [← ne_eq, ← beq_eq_false_iff_ne]
   simp_to_model [insertIfNew!] using List.containsKey_of_containsKey_insertEntryIfNew
 
 theorem mem_of_mem_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
-    a ∈ (t.insertIfNew k v h.balanced).impl → (k == a) = false → a ∈ t := by
+    a ∈ (t.insertIfNew k v h.balanced).impl → ¬ compare k a = .eq → a ∈ t := by
   simpa [mem_iff_contains] using contains_of_contains_insertIfNew h
 
 theorem mem_of_mem_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
-    a ∈ t.insertIfNew! k v → (k == a) = false → a ∈ t := by
+    a ∈ t.insertIfNew! k v → ¬ compare k a = .eq → a ∈ t := by
   simpa [mem_iff_contains] using contains_of_contains_insertIfNew! h
 
 theorem size_insertIfNew [TransOrd α] {k : α} (h : t.WF) {v : β k} :

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -297,25 +297,21 @@ theorem size_le_size_erase! [TransOrd α] (h : t.WF) {k : α} :
     t.size ≤ (t.erase! k).size + 1 := by
   simp_to_model [erase!] using List.length_le_length_eraseKey
 
-@[simp]
 theorem contains_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
     (t.insertIfNew k v h.balanced).impl.contains a = (k == a || t.contains a) := by
   simp_to_model [insertIfNew] using List.containsKey_insertEntryIfNew
 
-@[simp]
 theorem contains_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
     (t.insertIfNew! k v).contains a = (k == a || t.contains a) := by
   simp_to_model [insertIfNew!] using List.containsKey_insertEntryIfNew
 
-@[simp]
 theorem mem_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
     a ∈ (t.insertIfNew k v h.balanced).impl ↔ k == a ∨ a ∈ t := by
   simp [mem_iff_contains, contains_insertIfNew, h]
 
-@[simp]
 theorem mem_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
     a ∈ t.insertIfNew! k v ↔ k == a ∨ a ∈ t := by
-  simp [mem_iff_contains, contains_insertIfNew, h]
+  simp [mem_iff_contains, contains_insertIfNew!, h]
 
 theorem contains_insertIfNew_self [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.insertIfNew k v h.balanced).impl.contains k := by
@@ -327,11 +323,11 @@ theorem contains_insertIfNew!_self [TransOrd α] (h : t.WF) {k : α} {v : β k} 
 
 theorem mem_insertIfNew_self [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     k ∈ (t.insertIfNew k v h.balanced).impl := by
-  simp [contains_insertIfNew, h]
+  simp [mem_insertIfNew, h]
 
 theorem mem_insertIfNew!_self [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     k ∈ t.insertIfNew! k v := by
-  simp [contains_insertIfNew!, h]
+  simp [mem_insertIfNew!, h]
 
 theorem contains_of_contains_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
     (t.insertIfNew k v h.balanced).impl.contains a → (k == a) = false → t.contains a := by

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -112,11 +112,11 @@ theorem mem_insert_self [TransCmp cmp] {k : α} {v : β k} :
   Impl.mem_insert_self t.wf
 
 theorem contains_of_contains_insert [TransCmp cmp] {k a : α} {v : β k} :
-    (t.insert k v).contains a → ¬ cmp k a = .eq → t.contains a :=
+    (t.insert k v).contains a → cmp k a ≠ .eq → t.contains a :=
   Impl.contains_of_contains_insert t.wf
 
 theorem mem_of_mem_insert [TransCmp cmp] {k a : α} {v : β k} :
-    a ∈ t.insert k v → ¬ cmp k a = .eq → a ∈ t :=
+    a ∈ t.insert k v → cmp k a ≠ .eq → a ∈ t :=
   Impl.mem_of_mem_insert t.wf
 
 @[simp]
@@ -156,7 +156,7 @@ theorem contains_erase [TransCmp cmp] {k a : α} :
 
 @[simp]
 theorem mem_erase [TransCmp cmp] {k a : α} :
-    a ∈ t.erase k ↔ ¬ cmp k a = .eq ∧ a ∈ t :=
+    a ∈ t.erase k ↔ cmp k a ≠ .eq ∧ a ∈ t :=
   Impl.mem_erase t.wf
 
 theorem contains_of_contains_erase [TransCmp cmp] {k a : α} :
@@ -186,7 +186,7 @@ theorem contains_insertIfNew [TransCmp cmp] {k a : α} {v : β k} :
 
 @[simp]
 theorem mem_insertIfNew [TransCmp cmp] {k a : α} {v : β k} :
-    a ∈ t.insertIfNew k v ↔ cmp k a == .eq ∨ a ∈ t :=
+    a ∈ t.insertIfNew k v ↔ cmp k a = .eq ∨ a ∈ t :=
   Impl.mem_insertIfNew t.wf
 
 theorem contains_insertIfNew_self [TransCmp cmp] {k : α} {v : β k} :
@@ -198,11 +198,11 @@ theorem mem_insertIfNew_self [TransCmp cmp] {k : α} {v : β k} :
   Impl.mem_insertIfNew_self t.wf
 
 theorem contains_of_contains_insertIfNew [TransCmp cmp] {k a : α} {v : β k} :
-    (t.insertIfNew k v).contains a → ¬ cmp k a = .eq → t.contains a :=
+    (t.insertIfNew k v).contains a → cmp k a ≠ .eq → t.contains a :=
   Impl.contains_of_contains_insertIfNew t.wf
 
 theorem mem_of_mem_insertIfNew [TransCmp cmp] {k a : α} {v : β k} :
-    a ∈ t.insertIfNew k v → ¬ cmp k a = .eq → a ∈ t :=
+    a ∈ t.insertIfNew k v → cmp k a ≠ .eq → a ∈ t :=
   Impl.contains_of_contains_insertIfNew t.wf
 
 theorem size_insertIfNew [TransCmp cmp] {k : α} {v : β k} :

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -25,6 +25,9 @@ namespace Std.DTreeMap
 
 variable {α : Type u} {β : α → Type v} {cmp : α → α → Ordering} {t : DTreeMap α β cmp}
 
+private theorem ext {t t' : DTreeMap α β cmp} : t.inner = t'.inner → t = t' := by
+  cases t; cases t'; rintro rfl; rfl
+
 @[simp]
 theorem isEmpty_emptyc : (∅ : DTreeMap α β cmp).isEmpty :=
   Impl.isEmpty_empty
@@ -48,5 +51,188 @@ theorem mem_congr [TransCmp cmp] {k k' : α} (hab : cmp k k' = .eq) : k ∈ t �
 theorem isEmpty_insertIfNew [TransCmp cmp] {k : α} {v : β k} :
     (t.insertIfNew k v).isEmpty = false :=
   Impl.isEmpty_insertIfNew t.wf
+
+@[simp]
+theorem contains_empty {k : α} : (empty : DTreeMap α β cmp).contains k = false :=
+  Impl.contains_empty
+
+@[simp]
+theorem not_mem_empty {k : α} : k ∉ (empty : DTreeMap α β cmp) :=
+  Impl.not_mem_empty
+
+@[simp]
+theorem contains_emptyc {k : α} : (∅ : DTreeMap α β cmp).contains k = false :=
+  Impl.contains_empty
+
+@[simp]
+theorem not_mem_emptyc {k : α} : k ∉ (∅ : DTreeMap α β cmp) :=
+  Impl.not_mem_empty
+
+theorem contains_of_isEmpty [TransCmp cmp] {a : α} :
+    t.isEmpty → t.contains a = false :=
+  Impl.contains_of_isEmpty t.wf
+
+theorem not_mem_of_isEmpty [TransCmp cmp] {a : α} :
+    t.isEmpty → a ∉ t :=
+  Impl.not_mem_of_isEmpty t.wf
+
+theorem isEmpty_eq_false_iff_exists_contains_eq_true [TransCmp cmp] :
+    t.isEmpty = false ↔ ∃ a, t.contains a = true :=
+  Impl.isEmpty_eq_false_iff_exists_contains_eq_true t.wf
+
+theorem isEmpty_eq_false_iff_exists_mem [TransCmp cmp] :
+    t.isEmpty = false ↔ ∃ a, a ∈ t :=
+  Impl.isEmpty_eq_false_iff_exists_mem t.wf
+
+theorem isEmpty_iff_forall_contains [TransCmp cmp] :
+    t.isEmpty = true ↔ ∀ a, t.contains a = false :=
+  Impl.isEmpty_iff_forall_contains t.wf
+
+theorem isEmpty_iff_forall_not_mem [TransCmp cmp] :
+    t.isEmpty = true ↔ ∀ a, ¬a ∈ t :=
+  Impl.isEmpty_iff_forall_not_mem t.wf
+
+@[simp]
+theorem insert_eq_insert {p : (a : α) × β a} : Insert.insert p t = t.insert p.1 p.2 :=
+  rfl
+
+@[simp]
+theorem singleton_eq_insert {p : (a : α) × β a} :
+    Singleton.singleton p = (∅ : DTreeMap α β cmp).insert p.1 p.2 :=
+  rfl
+
+@[simp]
+theorem contains_insert [TransCmp cmp] {k k' : α} {v : β k} :
+    (t.insert k v).contains k' = (cmp k k' == .eq || t.contains k') :=
+  Impl.contains_insert t.wf
+
+@[simp]
+theorem mem_insert [TransCmp cmp] {k a : α} {v : β k} :
+    a ∈ t.insert k v ↔ cmp k a = .eq ∨ a ∈ t :=
+  Impl.mem_insert t.wf
+
+theorem contains_insert_self [TransCmp cmp] {k : α} {v : β k} :
+    (t.insert k v).contains k :=
+  Impl.contains_insert_self t.wf
+
+theorem mem_insert_self [TransCmp cmp] {k : α} {v : β k} :
+    k ∈ t.insert k v :=
+  Impl.mem_insert_self t.wf
+
+theorem contains_of_contains_insert [TransCmp cmp] {k a : α} {v : β k} :
+    (t.insert k v).contains a → ¬ cmp k a = .eq → t.contains a :=
+  Impl.contains_of_contains_insert t.wf
+
+theorem mem_of_mem_insert [TransCmp cmp] {k a : α} {v : β k} :
+    a ∈ t.insert k v → ¬ cmp k a = .eq → a ∈ t :=
+  Impl.mem_of_mem_insert t.wf
+
+@[simp]
+theorem size_empty : (empty : DTreeMap α β cmp).size = 0 :=
+  Impl.size_empty
+
+@[simp]
+theorem size_emptyc : (∅ : DTreeMap α β cmp).size = 0 :=
+  Impl.size_empty
+
+theorem isEmpty_eq_size_eq_zero :
+    t.isEmpty = (t.size == 0) :=
+  Impl.isEmpty_eq_size_eq_zero t.wf
+
+theorem size_insert [TransCmp cmp] {k : α} {v : β k} :
+    (t.insert k v).size = if t.contains k then t.size else t.size + 1 :=
+  Impl.size_insert t.wf
+
+theorem size_le_size_insert [TransCmp cmp] {k : α} {v : β k} :
+    t.size ≤ (t.insert k v).size :=
+  Impl.size_le_size_insert t.wf
+
+theorem size_insert_le [TransCmp cmp] {k : α} {v : β k} :
+    (t.insert k v).size ≤ t.size + 1 :=
+  Impl.size_insert_le t.wf
+
+@[simp]
+theorem erase_empty {k : α} :
+    (empty : DTreeMap α β cmp).erase k = empty :=
+  ext <| Impl.erase_empty (instOrd := ⟨cmp⟩) (k := k)
+
+@[simp]
+theorem erase_emptyc {k : α} :
+    (∅ : DTreeMap α β cmp).erase k = empty :=
+  erase_empty
+
+@[simp]
+theorem isEmpty_erase [TransCmp cmp] {k : α} :
+    (t.erase k).isEmpty = (t.isEmpty || (t.size == 1 && t.contains k)) :=
+  Impl.isEmpty_erase t.wf
+
+@[simp]
+theorem contains_erase [TransCmp cmp] {k a : α} :
+    (t.erase k).contains a = (cmp k a != .eq && t.contains a) :=
+  Impl.contains_erase t.wf
+
+@[simp]
+theorem mem_erase [TransCmp cmp] {k a : α} :
+    a ∈ t.erase k ↔  (cmp k a == .eq) = false ∧ a ∈ t :=
+  Impl.mem_erase t.wf
+
+theorem contains_of_contains_erase [TransCmp cmp] {k a : α} :
+    (t.erase k).contains a → t.contains a :=
+  Impl.contains_of_contains_erase t.wf
+
+theorem mem_of_mem_erase [TransCmp cmp] {k a : α} :
+    a ∈ t.erase k → a ∈ t :=
+  Impl.mem_of_mem_erase t.wf
+
+theorem size_erase [TransCmp cmp] {k : α} :
+    (t.erase k).size = if t.contains k then t.size - 1 else t.size :=
+  Impl.size_erase t.wf
+
+theorem size_erase_le [TransCmp cmp] {k : α} :
+    (t.erase k).size ≤ t.size :=
+  Impl.size_erase_le t.wf
+
+theorem size_le_size_erase [TransCmp cmp] {k : α} :
+    t.size ≤ (t.erase k).size + 1 :=
+  Impl.size_le_size_erase t.wf
+
+@[simp]
+theorem contains_insertIfNew [TransCmp cmp] {k a : α} {v : β k} :
+    (t.insertIfNew k v).contains a = (cmp k a == .eq || t.contains a) :=
+  Impl.contains_insertIfNew t.wf
+
+@[simp]
+theorem mem_insertIfNew [TransCmp cmp] {k a : α} {v : β k} :
+    a ∈ t.insertIfNew k v ↔ cmp k a == .eq ∨ a ∈ t :=
+  Impl.mem_insertIfNew t.wf
+
+@[simp]
+theorem contains_insertIfNew_self [TransCmp cmp] {k : α} {v : β k} :
+    (t.insertIfNew k v).contains k :=
+  Impl.contains_insertIfNew_self t.wf
+
+theorem mem_insertIfNew_self [TransCmp cmp] {k : α} {v : β k} :
+    k ∈ t.insertIfNew k v :=
+  Impl.mem_insertIfNew_self t.wf
+
+theorem contains_of_contains_insertIfNew [TransCmp cmp] {k a : α} {v : β k} :
+    (t.insertIfNew k v).contains a → (cmp k a == .eq) = false → t.contains a :=
+  Impl.contains_of_contains_insertIfNew t.wf
+
+theorem mem_of_mem_insertIfNew [TransCmp cmp] {k a : α} {v : β k} :
+    a ∈ t.insertIfNew k v → (cmp k a == .eq) = false → a ∈ t :=
+  Impl.contains_of_contains_insertIfNew t.wf
+
+theorem size_insertIfNew [TransCmp cmp] {k : α} {v : β k} :
+    (t.insertIfNew k v).size = if k ∈ t then t.size else t.size + 1 :=
+  Impl.size_insertIfNew t.wf
+
+theorem size_le_size_insertIfNew [TransCmp cmp] {k : α} {v : β k} :
+    t.size ≤ (t.insertIfNew k v).size :=
+  Impl.size_le_size_insertIfNew t.wf
+
+theorem size_insertIfNew_le [TransCmp cmp] {k : α} {v : β k} :
+    (t.insertIfNew k v).size ≤ t.size + 1 :=
+  Impl.size_insertIfNew_le t.wf
 
 end Std.DTreeMap

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -94,8 +94,8 @@ theorem singleton_eq_insert {p : (a : α) × β a} :
   rfl
 
 @[simp]
-theorem contains_insert [TransCmp cmp] {k k' : α} {v : β k} :
-    (t.insert k v).contains k' = (cmp k k' == .eq || t.contains k') :=
+theorem contains_insert [TransCmp cmp] {k a : α} {v : β k} :
+    (t.insert k v).contains a = (cmp k a == .eq || t.contains a) :=
   Impl.contains_insert t.wf
 
 @[simp]
@@ -156,7 +156,7 @@ theorem contains_erase [TransCmp cmp] {k a : α} :
 
 @[simp]
 theorem mem_erase [TransCmp cmp] {k a : α} :
-    a ∈ t.erase k ↔  (cmp k a == .eq) = false ∧ a ∈ t :=
+    a ∈ t.erase k ↔ ¬ cmp k a = .eq ∧ a ∈ t :=
   Impl.mem_erase t.wf
 
 theorem contains_of_contains_erase [TransCmp cmp] {k a : α} :
@@ -189,7 +189,6 @@ theorem mem_insertIfNew [TransCmp cmp] {k a : α} {v : β k} :
     a ∈ t.insertIfNew k v ↔ cmp k a == .eq ∨ a ∈ t :=
   Impl.mem_insertIfNew t.wf
 
-@[simp]
 theorem contains_insertIfNew_self [TransCmp cmp] {k : α} {v : β k} :
     (t.insertIfNew k v).contains k :=
   Impl.contains_insertIfNew_self t.wf
@@ -199,11 +198,11 @@ theorem mem_insertIfNew_self [TransCmp cmp] {k : α} {v : β k} :
   Impl.mem_insertIfNew_self t.wf
 
 theorem contains_of_contains_insertIfNew [TransCmp cmp] {k a : α} {v : β k} :
-    (t.insertIfNew k v).contains a → (cmp k a == .eq) = false → t.contains a :=
+    (t.insertIfNew k v).contains a → ¬ cmp k a = .eq → t.contains a :=
   Impl.contains_of_contains_insertIfNew t.wf
 
 theorem mem_of_mem_insertIfNew [TransCmp cmp] {k a : α} {v : β k} :
-    a ∈ t.insertIfNew k v → (cmp k a == .eq) = false → a ∈ t :=
+    a ∈ t.insertIfNew k v → ¬ cmp k a = .eq → a ∈ t :=
   Impl.contains_of_contains_insertIfNew t.wf
 
 theorem size_insertIfNew [TransCmp cmp] {k : α} {v : β k} :

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -53,14 +53,6 @@ theorem isEmpty_insertIfNew [TransCmp cmp] {k : α} {v : β k} :
   Impl.isEmpty_insertIfNew t.wf
 
 @[simp]
-theorem contains_empty {k : α} : (empty : DTreeMap α β cmp).contains k = false :=
-  Impl.contains_empty
-
-@[simp]
-theorem not_mem_empty {k : α} : k ∉ (empty : DTreeMap α β cmp) :=
-  Impl.not_mem_empty
-
-@[simp]
 theorem contains_emptyc {k : α} : (∅ : DTreeMap α β cmp).contains k = false :=
   Impl.contains_empty
 
@@ -128,10 +120,6 @@ theorem mem_of_mem_insert [TransCmp cmp] {k a : α} {v : β k} :
   Impl.mem_of_mem_insert t.wf
 
 @[simp]
-theorem size_empty : (empty : DTreeMap α β cmp).size = 0 :=
-  Impl.size_empty
-
-@[simp]
 theorem size_emptyc : (∅ : DTreeMap α β cmp).size = 0 :=
   Impl.size_empty
 
@@ -152,14 +140,9 @@ theorem size_insert_le [TransCmp cmp] {k : α} {v : β k} :
   Impl.size_insert_le t.wf
 
 @[simp]
-theorem erase_empty {k : α} :
-    (empty : DTreeMap α β cmp).erase k = empty :=
-  ext <| Impl.erase_empty (instOrd := ⟨cmp⟩) (k := k)
-
-@[simp]
 theorem erase_emptyc {k : α} :
     (∅ : DTreeMap α β cmp).erase k = empty :=
-  erase_empty
+  ext <| Impl.erase_empty (instOrd := ⟨cmp⟩) (k := k)
 
 @[simp]
 theorem isEmpty_erase [TransCmp cmp] {k : α} :

--- a/src/Std/Data/DTreeMap/RawLemmas.lean
+++ b/src/Std/Data/DTreeMap/RawLemmas.lean
@@ -112,11 +112,11 @@ theorem mem_insert_self [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
   Impl.mem_insert!_self h
 
 theorem contains_of_contains_insert [TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :
-    (t.insert k v).contains a → ¬ cmp k a = .eq → t.contains a :=
+    (t.insert k v).contains a → cmp k a ≠ .eq → t.contains a :=
   Impl.contains_of_contains_insert! h
 
 theorem mem_of_mem_insert [TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :
-    a ∈ t.insert k v → ¬ cmp k a = .eq → a ∈ t :=
+    a ∈ t.insert k v → cmp k a ≠ .eq → a ∈ t :=
   Impl.mem_of_mem_insert! h
 
 @[simp]
@@ -156,7 +156,7 @@ theorem contains_erase [TransCmp cmp] (h : t.WF) {k a : α} :
 
 @[simp]
 theorem mem_erase [TransCmp cmp] (h : t.WF) {k a : α} :
-    a ∈ t.erase k ↔ ¬ cmp k a = .eq ∧ a ∈ t :=
+    a ∈ t.erase k ↔ cmp k a ≠ .eq ∧ a ∈ t :=
   Impl.mem_erase! h
 
 theorem contains_of_contains_erase [TransCmp cmp] (h : t.WF) {k a : α} :
@@ -186,7 +186,7 @@ theorem contains_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :
 
 @[simp]
 theorem mem_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :
-    a ∈ t.insertIfNew k v ↔ cmp k a == .eq ∨ a ∈ t :=
+    a ∈ t.insertIfNew k v ↔ cmp k a = .eq ∨ a ∈ t :=
   Impl.mem_insertIfNew! h
 
 theorem contains_insertIfNew_self [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
@@ -198,11 +198,11 @@ theorem mem_insertIfNew_self [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
   Impl.mem_insertIfNew!_self h
 
 theorem contains_of_contains_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :
-    (t.insertIfNew k v).contains a → ¬ cmp k a = .eq → t.contains a :=
+    (t.insertIfNew k v).contains a → cmp k a ≠ .eq → t.contains a :=
   Impl.contains_of_contains_insertIfNew! h
 
 theorem mem_of_mem_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :
-    a ∈ t.insertIfNew k v → ¬ cmp k a = .eq → a ∈ t :=
+    a ∈ t.insertIfNew k v → cmp k a ≠ .eq → a ∈ t :=
   Impl.contains_of_contains_insertIfNew! h
 
 theorem size_insertIfNew [TransCmp cmp] {k : α} (h : t.WF) {v : β k} :

--- a/src/Std/Data/DTreeMap/RawLemmas.lean
+++ b/src/Std/Data/DTreeMap/RawLemmas.lean
@@ -25,6 +25,9 @@ namespace Std.DTreeMap.Raw
 
 variable {α : Type u} {β : α → Type v} {cmp : α → α → Ordering} {t : DTreeMap.Raw α β cmp}
 
+private theorem ext {t t' : Raw α β cmp} : t.inner = t'.inner → t = t' := by
+  cases t; cases t'; rintro rfl; rfl
+
 @[simp]
 theorem isEmpty_emptyc : (∅ : DTreeMap.Raw α β cmp).isEmpty :=
   Impl.isEmpty_empty
@@ -48,5 +51,187 @@ theorem mem_congr [TransCmp cmp] (h : t.WF) {k k' : α} (hab : cmp k k' = .eq) :
 theorem isEmpty_insertIfNew [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
     (t.insertIfNew k v).isEmpty = false :=
   Impl.isEmpty_insertIfNew! h
+
+@[simp]
+theorem contains_empty {k : α} : (empty : Raw α β cmp).contains k = false :=
+  Impl.contains_empty
+
+@[simp]
+theorem not_mem_empty {k : α} : k ∉ (empty : Raw α β cmp) :=
+  Impl.not_mem_empty
+
+@[simp]
+theorem contains_emptyc {k : α} : (∅ : Raw α β cmp).contains k = false :=
+  Impl.contains_empty
+
+@[simp]
+theorem not_mem_emptyc {k : α} : k ∉ (∅ : Raw α β cmp) :=
+  Impl.not_mem_empty
+
+theorem contains_of_isEmpty [TransCmp cmp] (h : t.WF) {a : α} :
+    t.isEmpty → t.contains a = false :=
+  Impl.contains_of_isEmpty h
+
+theorem not_mem_of_isEmpty [TransCmp cmp] (h : t.WF) {a : α} :
+    t.isEmpty → a ∉ t :=
+  Impl.not_mem_of_isEmpty h
+
+theorem isEmpty_eq_false_iff_exists_contains_eq_true [TransCmp cmp] (h : t.WF) :
+    t.isEmpty = false ↔ ∃ a, t.contains a = true :=
+  Impl.isEmpty_eq_false_iff_exists_contains_eq_true h
+
+theorem isEmpty_eq_false_iff_exists_mem [TransCmp cmp] (h : t.WF) :
+    t.isEmpty = false ↔ ∃ a, a ∈ t :=
+  Impl.isEmpty_eq_false_iff_exists_mem h
+
+theorem isEmpty_iff_forall_contains [TransCmp cmp] (h : t.WF) :
+    t.isEmpty = true ↔ ∀ a, t.contains a = false :=
+  Impl.isEmpty_iff_forall_contains h
+
+theorem isEmpty_iff_forall_not_mem [TransCmp cmp] (h : t.WF) :
+    t.isEmpty = true ↔ ∀ a, ¬a ∈ t :=
+  Impl.isEmpty_iff_forall_not_mem h
+
+@[simp]
+theorem insert_eq_insert {p : (a : α) × β a} : Insert.insert p t = t.insert p.1 p.2 :=
+  rfl
+
+@[simp]
+theorem singleton_eq_insert {p : (a : α) × β a} :
+    Singleton.singleton p = (∅ : Raw α β cmp).insert p.1 p.2 :=
+  rfl
+
+@[simp]
+theorem contains_insert [h : TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :
+    (t.insert k v).contains a = (cmp k a == .eq || t.contains a) :=
+  Impl.contains_insert! h
+
+@[simp]
+theorem mem_insert [TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :
+    a ∈ t.insert k v ↔ cmp k a = .eq ∨ a ∈ t :=
+  Impl.mem_insert! h
+
+theorem contains_insert_self [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
+    (t.insert k v).contains k :=
+  Impl.contains_insert!_self h
+
+theorem mem_insert_self [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
+    k ∈ t.insert k v :=
+  Impl.mem_insert!_self h
+
+theorem contains_of_contains_insert [TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :
+    (t.insert k v).contains a → ¬ cmp k a = .eq → t.contains a :=
+  Impl.contains_of_contains_insert! h
+
+theorem mem_of_mem_insert [TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :
+    a ∈ t.insert k v → ¬ cmp k a = .eq → a ∈ t :=
+  Impl.mem_of_mem_insert! h
+
+@[simp]
+theorem size_empty : (empty : Raw α β cmp).size = 0 :=
+  Impl.size_empty
+
+@[simp]
+theorem size_emptyc : (∅ : Raw α β cmp).size = 0 :=
+  Impl.size_empty
+
+theorem isEmpty_eq_size_eq_zero (h : t.WF) :
+    t.isEmpty = (t.size == 0) :=
+  Impl.isEmpty_eq_size_eq_zero h.out
+
+theorem size_insert [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
+    (t.insert k v).size = if t.contains k then t.size else t.size + 1 :=
+  Impl.size_insert! h
+
+theorem size_le_size_insert [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
+    t.size ≤ (t.insert k v).size :=
+  Impl.size_le_size_insert! h
+
+theorem size_insert_le [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
+    (t.insert k v).size ≤ t.size + 1 :=
+  Impl.size_insert!_le h
+
+@[simp]
+theorem erase_empty {k : α} :
+    (empty : Raw α β cmp).erase k = empty :=
+  ext <| Impl.erase!_empty (instOrd := ⟨cmp⟩) (k := k)
+
+@[simp]
+theorem erase_emptyc {k : α} :
+    (∅ : Raw α β cmp).erase k = empty :=
+  erase_empty
+
+@[simp]
+theorem isEmpty_erase [TransCmp cmp] (h : t.WF) {k : α} :
+    (t.erase k).isEmpty = (t.isEmpty || (t.size == 1 && t.contains k)) :=
+  Impl.isEmpty_erase! h
+
+@[simp]
+theorem contains_erase [TransCmp cmp] (h : t.WF) {k a : α} :
+    (t.erase k).contains a = (cmp k a != .eq && t.contains a) :=
+  Impl.contains_erase! h
+
+@[simp]
+theorem mem_erase [TransCmp cmp] (h : t.WF) {k a : α} :
+    a ∈ t.erase k ↔  (cmp k a == .eq) = false ∧ a ∈ t :=
+  Impl.mem_erase! h
+
+theorem contains_of_contains_erase [TransCmp cmp] (h : t.WF) {k a : α} :
+    (t.erase k).contains a → t.contains a :=
+  Impl.contains_of_contains_erase! h
+
+theorem mem_of_mem_erase [TransCmp cmp] (h : t.WF) {k a : α} :
+    a ∈ t.erase k → a ∈ t :=
+  Impl.mem_of_mem_erase! h
+
+theorem size_erase [TransCmp cmp] (h : t.WF) {k : α} :
+    (t.erase k).size = if t.contains k then t.size - 1 else t.size :=
+  Impl.size_erase! h
+
+theorem size_erase_le [TransCmp cmp] (h : t.WF) {k : α} :
+    (t.erase k).size ≤ t.size :=
+  Impl.size_erase!_le h
+
+theorem size_le_size_erase [TransCmp cmp] (h : t.WF) {k : α} :
+    t.size ≤ (t.erase k).size + 1 :=
+  Impl.size_le_size_erase! h
+
+@[simp]
+theorem contains_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :
+    (t.insertIfNew k v).contains a = (cmp k a == .eq || t.contains a) :=
+  Impl.contains_insertIfNew! h
+
+@[simp]
+theorem mem_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :
+    a ∈ t.insertIfNew k v ↔ cmp k a == .eq ∨ a ∈ t :=
+  Impl.mem_insertIfNew! h
+
+theorem contains_insertIfNew_self [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
+    (t.insertIfNew k v).contains k :=
+  Impl.contains_insertIfNew!_self h
+
+theorem mem_insertIfNew_self [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
+    k ∈ t.insertIfNew k v :=
+  Impl.mem_insertIfNew!_self h
+
+theorem contains_of_contains_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :
+    (t.insertIfNew k v).contains a → (cmp k a == .eq) = false → t.contains a :=
+  Impl.contains_of_contains_insertIfNew! h
+
+theorem mem_of_mem_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :
+    a ∈ t.insertIfNew k v → (cmp k a == .eq) = false → a ∈ t :=
+  Impl.contains_of_contains_insertIfNew! h
+
+theorem size_insertIfNew [TransCmp cmp] {k : α} (h : t.WF) {v : β k} :
+    (t.insertIfNew k v).size = if k ∈ t then t.size else t.size + 1 :=
+  Impl.size_insertIfNew! h
+
+theorem size_le_size_insertIfNew [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
+    t.size ≤ (t.insertIfNew k v).size :=
+  Impl.size_le_size_insertIfNew! h
+
+theorem size_insertIfNew_le [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
+    (t.insertIfNew k v).size ≤ t.size + 1 :=
+  Impl.size_insertIfNew!_le h
 
 end Std.DTreeMap.Raw

--- a/src/Std/Data/DTreeMap/RawLemmas.lean
+++ b/src/Std/Data/DTreeMap/RawLemmas.lean
@@ -53,14 +53,6 @@ theorem isEmpty_insertIfNew [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
   Impl.isEmpty_insertIfNew! h
 
 @[simp]
-theorem contains_empty {k : α} : (empty : Raw α β cmp).contains k = false :=
-  Impl.contains_empty
-
-@[simp]
-theorem not_mem_empty {k : α} : k ∉ (empty : Raw α β cmp) :=
-  Impl.not_mem_empty
-
-@[simp]
 theorem contains_emptyc {k : α} : (∅ : Raw α β cmp).contains k = false :=
   Impl.contains_empty
 
@@ -128,10 +120,6 @@ theorem mem_of_mem_insert [TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :
   Impl.mem_of_mem_insert! h
 
 @[simp]
-theorem size_empty : (empty : Raw α β cmp).size = 0 :=
-  Impl.size_empty
-
-@[simp]
 theorem size_emptyc : (∅ : Raw α β cmp).size = 0 :=
   Impl.size_empty
 
@@ -152,14 +140,9 @@ theorem size_insert_le [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
   Impl.size_insert!_le h
 
 @[simp]
-theorem erase_empty {k : α} :
-    (empty : Raw α β cmp).erase k = empty :=
-  ext <| Impl.erase!_empty (instOrd := ⟨cmp⟩) (k := k)
-
-@[simp]
 theorem erase_emptyc {k : α} :
     (∅ : Raw α β cmp).erase k = empty :=
-  erase_empty
+  ext <| Impl.erase!_empty (instOrd := ⟨cmp⟩) (k := k)
 
 @[simp]
 theorem isEmpty_erase [TransCmp cmp] (h : t.WF) {k : α} :

--- a/src/Std/Data/DTreeMap/RawLemmas.lean
+++ b/src/Std/Data/DTreeMap/RawLemmas.lean
@@ -156,7 +156,7 @@ theorem contains_erase [TransCmp cmp] (h : t.WF) {k a : α} :
 
 @[simp]
 theorem mem_erase [TransCmp cmp] (h : t.WF) {k a : α} :
-    a ∈ t.erase k ↔  (cmp k a == .eq) = false ∧ a ∈ t :=
+    a ∈ t.erase k ↔ ¬ cmp k a = .eq ∧ a ∈ t :=
   Impl.mem_erase! h
 
 theorem contains_of_contains_erase [TransCmp cmp] (h : t.WF) {k a : α} :
@@ -198,11 +198,11 @@ theorem mem_insertIfNew_self [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
   Impl.mem_insertIfNew!_self h
 
 theorem contains_of_contains_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :
-    (t.insertIfNew k v).contains a → (cmp k a == .eq) = false → t.contains a :=
+    (t.insertIfNew k v).contains a → ¬ cmp k a = .eq → t.contains a :=
   Impl.contains_of_contains_insertIfNew! h
 
 theorem mem_of_mem_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :
-    a ∈ t.insertIfNew k v → (cmp k a == .eq) = false → a ∈ t :=
+    a ∈ t.insertIfNew k v → ¬ cmp k a = .eq → a ∈ t :=
   Impl.contains_of_contains_insertIfNew! h
 
 theorem size_insertIfNew [TransCmp cmp] {k : α} (h : t.WF) {v : β k} :

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -23,6 +23,9 @@ namespace Std.TreeMap
 
 variable {α : Type u} {β : Type v} {cmp : α → α → Ordering} {t : TreeMap α β cmp}
 
+private theorem ext {t t' : TreeMap α β cmp} : t.inner = t'.inner → t = t' := by
+  cases t; cases t'; rintro rfl; rfl
+
 @[simp]
 theorem isEmpty_emptyc : (∅ : TreeMap α β cmp).isEmpty :=
   DTreeMap.isEmpty_emptyc
@@ -46,5 +49,189 @@ theorem mem_congr [TransCmp cmp] {k k' : α} (hab : cmp k k' = .eq) : k ∈ t �
 theorem isEmpty_insertIfNew [TransCmp cmp] {k : α} {v : β} :
     (t.insertIfNew k v).isEmpty = false :=
   DTreeMap.isEmpty_insertIfNew
+
+@[simp]
+theorem contains_empty {k : α} : (empty : TreeMap α β cmp).contains k = false :=
+  DTreeMap.contains_empty
+
+@[simp]
+theorem not_mem_empty {k : α} : k ∉ (empty : TreeMap α β cmp) :=
+  DTreeMap.not_mem_empty
+
+@[simp]
+theorem contains_emptyc {k : α} : (∅ : TreeMap α β cmp).contains k = false :=
+  DTreeMap.contains_empty
+
+@[simp]
+theorem not_mem_emptyc {k : α} : k ∉ (∅ : TreeMap α β cmp) :=
+  DTreeMap.not_mem_empty
+
+theorem contains_of_isEmpty [TransCmp cmp] {a : α} :
+    t.isEmpty → t.contains a = false :=
+  DTreeMap.contains_of_isEmpty
+
+theorem not_mem_of_isEmpty [TransCmp cmp] {a : α} :
+    t.isEmpty → a ∉ t :=
+  DTreeMap.not_mem_of_isEmpty
+
+theorem isEmpty_eq_false_iff_exists_contains_eq_true [TransCmp cmp] :
+    t.isEmpty = false ↔ ∃ a, t.contains a = true :=
+  DTreeMap.isEmpty_eq_false_iff_exists_contains_eq_true
+
+theorem isEmpty_eq_false_iff_exists_mem [TransCmp cmp] :
+    t.isEmpty = false ↔ ∃ a, a ∈ t :=
+  DTreeMap.isEmpty_eq_false_iff_exists_mem
+
+theorem isEmpty_iff_forall_contains [TransCmp cmp] :
+    t.isEmpty = true ↔ ∀ a, t.contains a = false :=
+  DTreeMap.isEmpty_iff_forall_contains
+
+theorem isEmpty_iff_forall_not_mem [TransCmp cmp] :
+    t.isEmpty = true ↔ ∀ a, ¬a ∈ t :=
+  DTreeMap.isEmpty_iff_forall_not_mem
+
+@[simp]
+theorem insert_eq_insert {p : α × β} : Insert.insert p t = t.insert p.1 p.2 :=
+  rfl
+
+@[simp]
+theorem singleton_eq_insert {p : α × β} :
+    Singleton.singleton p = (∅ : TreeMap α β cmp).insert p.1 p.2 :=
+  rfl
+
+@[simp]
+theorem contains_insert [h : TransCmp cmp] {k a : α} {v : β} :
+    (t.insert k v).contains a = (cmp k a == .eq || t.contains a) :=
+  DTreeMap.contains_insert
+
+@[simp]
+theorem mem_insert [TransCmp cmp] {k a : α} {v : β} :
+    a ∈ t.insert k v ↔ cmp k a = .eq ∨ a ∈ t :=
+  DTreeMap.mem_insert
+
+theorem contains_insert_self [TransCmp cmp] {k : α} {v : β} :
+    (t.insert k v).contains k :=
+  DTreeMap.contains_insert_self
+
+theorem mem_insert_self [TransCmp cmp] {k : α} {v : β} :
+    k ∈ t.insert k v :=
+  DTreeMap.mem_insert_self
+
+theorem contains_of_contains_insert [TransCmp cmp] {k a : α} {v : β} :
+    (t.insert k v).contains a → ¬ cmp k a = .eq → t.contains a :=
+  DTreeMap.contains_of_contains_insert
+
+theorem mem_of_mem_insert [TransCmp cmp] {k a : α} {v : β} :
+    a ∈ t.insert k v → ¬ cmp k a = .eq → a ∈ t :=
+  DTreeMap.mem_of_mem_insert
+
+@[simp]
+theorem size_empty : (empty : TreeMap α β cmp).size = 0 :=
+  DTreeMap.size_empty
+
+@[simp]
+theorem size_emptyc : (∅ : TreeMap α β cmp).size = 0 :=
+  DTreeMap.size_empty
+
+theorem isEmpty_eq_size_eq_zero :
+    t.isEmpty = (t.size == 0) :=
+  DTreeMap.isEmpty_eq_size_eq_zero
+
+theorem size_insert [TransCmp cmp] {k : α} {v : β} :
+    (t.insert k v).size = if t.contains k then t.size else t.size + 1 :=
+  DTreeMap.size_insert
+
+theorem size_le_size_insert [TransCmp cmp] {k : α} {v : β} :
+    t.size ≤ (t.insert k v).size :=
+  DTreeMap.size_le_size_insert
+
+theorem size_insert_le [TransCmp cmp] {k : α} {v : β} :
+    (t.insert k v).size ≤ t.size + 1 :=
+  DTreeMap.size_insert_le
+
+@[simp]
+theorem erase_empty {k : α} :
+    (empty : TreeMap α β cmp).erase k = empty :=
+  ext <| DTreeMap.erase_empty
+
+@[simp]
+theorem erase_emptyc {k : α} :
+    (∅ : TreeMap α β cmp).erase k = empty :=
+  erase_empty
+
+@[simp]
+theorem isEmpty_erase [TransCmp cmp] {k : α} :
+    (t.erase k).isEmpty = (t.isEmpty || (t.size == 1 && t.contains k)) :=
+  DTreeMap.isEmpty_erase
+
+@[simp]
+theorem contains_erase [TransCmp cmp] {k a : α} :
+    (t.erase k).contains a = (cmp k a != .eq && t.contains a) :=
+  DTreeMap.contains_erase
+
+@[simp]
+theorem mem_erase [TransCmp cmp] {k a : α} :
+    a ∈ t.erase k ↔  (cmp k a == .eq) = false ∧ a ∈ t :=
+  DTreeMap.mem_erase
+
+theorem contains_of_contains_erase [TransCmp cmp] {k a : α} :
+    (t.erase k).contains a → t.contains a :=
+  DTreeMap.contains_of_contains_erase
+
+theorem mem_of_mem_erase [TransCmp cmp] {k a : α} :
+    a ∈ t.erase k → a ∈ t :=
+  DTreeMap.mem_of_mem_erase
+
+theorem size_erase [TransCmp cmp] {k : α} :
+    (t.erase k).size = if t.contains k then t.size - 1 else t.size :=
+  DTreeMap.size_erase
+
+theorem size_erase_le [TransCmp cmp] {k : α} :
+    (t.erase k).size ≤ t.size :=
+  DTreeMap.size_erase_le
+
+theorem size_le_size_erase [TransCmp cmp] {k : α} :
+    t.size ≤ (t.erase k).size + 1 :=
+  DTreeMap.size_le_size_erase
+
+@[simp]
+theorem contains_insertIfNew [TransCmp cmp] {k a : α} {v : β} :
+    (t.insertIfNew k v).contains a = (cmp k a == .eq || t.contains a) :=
+  DTreeMap.contains_insertIfNew
+
+@[simp]
+theorem mem_insertIfNew [TransCmp cmp] {k a : α} {v : β} :
+    a ∈ t.insertIfNew k v ↔ cmp k a == .eq ∨ a ∈ t :=
+  DTreeMap.mem_insertIfNew
+
+@[simp]
+theorem contains_insertIfNew_self [TransCmp cmp] {k : α} {v : β} :
+    (t.insertIfNew k v).contains k :=
+  DTreeMap.contains_insertIfNew_self
+
+@[simp]
+theorem mem_insertIfNew_self [TransCmp cmp] {k : α} {v : β} :
+    k ∈ t.insertIfNew k v :=
+  DTreeMap.mem_insertIfNew_self
+
+theorem contains_of_contains_insertIfNew [TransCmp cmp] {k a : α} {v : β} :
+    (t.insertIfNew k v).contains a → (cmp k a == .eq) = false → t.contains a :=
+  DTreeMap.contains_of_contains_insertIfNew
+
+theorem mem_of_mem_insertIfNew [TransCmp cmp] {k a : α} {v : β} :
+    a ∈ t.insertIfNew k v → (cmp k a == .eq) = false → a ∈ t :=
+  DTreeMap.contains_of_contains_insertIfNew
+
+theorem size_insertIfNew [TransCmp cmp] {k : α} {v : β} :
+    (t.insertIfNew k v).size = if k ∈ t then t.size else t.size + 1 :=
+  DTreeMap.size_insertIfNew
+
+theorem size_le_size_insertIfNew [TransCmp cmp] {k : α} {v : β} :
+    t.size ≤ (t.insertIfNew k v).size :=
+  DTreeMap.size_le_size_insertIfNew
+
+theorem size_insertIfNew_le [TransCmp cmp] {k : α} {v : β} :
+    (t.insertIfNew k v).size ≤ t.size + 1 :=
+  DTreeMap.size_insertIfNew_le
 
 end Std.TreeMap

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -58,14 +58,6 @@ theorem contains_empty {k : α} : (empty : TreeMap α β cmp).contains k = false
 theorem not_mem_empty {k : α} : k ∉ (empty : TreeMap α β cmp) :=
   DTreeMap.not_mem_empty
 
-@[simp]
-theorem contains_emptyc {k : α} : (∅ : TreeMap α β cmp).contains k = false :=
-  DTreeMap.contains_empty
-
-@[simp]
-theorem not_mem_emptyc {k : α} : k ∉ (∅ : TreeMap α β cmp) :=
-  DTreeMap.not_mem_empty
-
 theorem contains_of_isEmpty [TransCmp cmp] {a : α} :
     t.isEmpty → t.contains a = false :=
   DTreeMap.contains_of_isEmpty
@@ -126,10 +118,6 @@ theorem mem_of_mem_insert [TransCmp cmp] {k a : α} {v : β} :
   DTreeMap.mem_of_mem_insert
 
 @[simp]
-theorem size_empty : (empty : TreeMap α β cmp).size = 0 :=
-  DTreeMap.size_empty
-
-@[simp]
 theorem size_emptyc : (∅ : TreeMap α β cmp).size = 0 :=
   DTreeMap.size_empty
 
@@ -150,14 +138,9 @@ theorem size_insert_le [TransCmp cmp] {k : α} {v : β} :
   DTreeMap.size_insert_le
 
 @[simp]
-theorem erase_empty {k : α} :
-    (empty : TreeMap α β cmp).erase k = empty :=
-  ext <| DTreeMap.erase_empty
-
-@[simp]
 theorem erase_emptyc {k : α} :
     (∅ : TreeMap α β cmp).erase k = empty :=
-  erase_empty
+  ext <| DTreeMap.erase_empty
 
 @[simp]
 theorem isEmpty_erase [TransCmp cmp] {k : α} :

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -51,12 +51,12 @@ theorem isEmpty_insertIfNew [TransCmp cmp] {k : α} {v : β} :
   DTreeMap.isEmpty_insertIfNew
 
 @[simp]
-theorem contains_empty {k : α} : (empty : TreeMap α β cmp).contains k = false :=
-  DTreeMap.contains_empty
+theorem contains_emptyc {k : α} : (∅ : TreeMap α β cmp).contains k = false :=
+  DTreeMap.contains_emptyc
 
 @[simp]
-theorem not_mem_empty {k : α} : k ∉ (empty : TreeMap α β cmp) :=
-  DTreeMap.not_mem_empty
+theorem not_mem_emptyc {k : α} : k ∉ (∅ : TreeMap α β cmp) :=
+  DTreeMap.not_mem_emptyc
 
 theorem contains_of_isEmpty [TransCmp cmp] {a : α} :
     t.isEmpty → t.contains a = false :=
@@ -119,7 +119,7 @@ theorem mem_of_mem_insert [TransCmp cmp] {k a : α} {v : β} :
 
 @[simp]
 theorem size_emptyc : (∅ : TreeMap α β cmp).size = 0 :=
-  DTreeMap.size_empty
+  DTreeMap.size_emptyc
 
 theorem isEmpty_eq_size_eq_zero :
     t.isEmpty = (t.size == 0) :=
@@ -140,7 +140,7 @@ theorem size_insert_le [TransCmp cmp] {k : α} {v : β} :
 @[simp]
 theorem erase_emptyc {k : α} :
     (∅ : TreeMap α β cmp).erase k = empty :=
-  ext <| DTreeMap.erase_empty
+  ext <| DTreeMap.erase_emptyc
 
 @[simp]
 theorem isEmpty_erase [TransCmp cmp] {k : α} :

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -110,11 +110,11 @@ theorem mem_insert_self [TransCmp cmp] {k : α} {v : β} :
   DTreeMap.mem_insert_self
 
 theorem contains_of_contains_insert [TransCmp cmp] {k a : α} {v : β} :
-    (t.insert k v).contains a → ¬ cmp k a = .eq → t.contains a :=
+    (t.insert k v).contains a → cmp k a ≠ .eq → t.contains a :=
   DTreeMap.contains_of_contains_insert
 
 theorem mem_of_mem_insert [TransCmp cmp] {k a : α} {v : β} :
-    a ∈ t.insert k v → ¬ cmp k a = .eq → a ∈ t :=
+    a ∈ t.insert k v → cmp k a ≠ .eq → a ∈ t :=
   DTreeMap.mem_of_mem_insert
 
 @[simp]
@@ -154,7 +154,7 @@ theorem contains_erase [TransCmp cmp] {k a : α} :
 
 @[simp]
 theorem mem_erase [TransCmp cmp] {k a : α} :
-    a ∈ t.erase k ↔ ¬ cmp k a = .eq ∧ a ∈ t :=
+    a ∈ t.erase k ↔ cmp k a ≠ .eq ∧ a ∈ t :=
   DTreeMap.mem_erase
 
 theorem contains_of_contains_erase [TransCmp cmp] {k a : α} :
@@ -184,7 +184,7 @@ theorem contains_insertIfNew [TransCmp cmp] {k a : α} {v : β} :
 
 @[simp]
 theorem mem_insertIfNew [TransCmp cmp] {k a : α} {v : β} :
-    a ∈ t.insertIfNew k v ↔ cmp k a == .eq ∨ a ∈ t :=
+    a ∈ t.insertIfNew k v ↔ cmp k a = .eq ∨ a ∈ t :=
   DTreeMap.mem_insertIfNew
 
 @[simp]
@@ -198,11 +198,11 @@ theorem mem_insertIfNew_self [TransCmp cmp] {k : α} {v : β} :
   DTreeMap.mem_insertIfNew_self
 
 theorem contains_of_contains_insertIfNew [TransCmp cmp] {k a : α} {v : β} :
-    (t.insertIfNew k v).contains a → ¬ cmp k a = .eq → t.contains a :=
+    (t.insertIfNew k v).contains a → cmp k a ≠ .eq → t.contains a :=
   DTreeMap.contains_of_contains_insertIfNew
 
 theorem mem_of_mem_insertIfNew [TransCmp cmp] {k a : α} {v : β} :
-    a ∈ t.insertIfNew k v → ¬ cmp k a = .eq → a ∈ t :=
+    a ∈ t.insertIfNew k v → cmp k a ≠ .eq → a ∈ t :=
   DTreeMap.contains_of_contains_insertIfNew
 
 theorem size_insertIfNew [TransCmp cmp] {k : α} {v : β} :

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -154,7 +154,7 @@ theorem contains_erase [TransCmp cmp] {k a : α} :
 
 @[simp]
 theorem mem_erase [TransCmp cmp] {k a : α} :
-    a ∈ t.erase k ↔  (cmp k a == .eq) = false ∧ a ∈ t :=
+    a ∈ t.erase k ↔ ¬ cmp k a = .eq ∧ a ∈ t :=
   DTreeMap.mem_erase
 
 theorem contains_of_contains_erase [TransCmp cmp] {k a : α} :
@@ -198,11 +198,11 @@ theorem mem_insertIfNew_self [TransCmp cmp] {k : α} {v : β} :
   DTreeMap.mem_insertIfNew_self
 
 theorem contains_of_contains_insertIfNew [TransCmp cmp] {k a : α} {v : β} :
-    (t.insertIfNew k v).contains a → (cmp k a == .eq) = false → t.contains a :=
+    (t.insertIfNew k v).contains a → ¬ cmp k a = .eq → t.contains a :=
   DTreeMap.contains_of_contains_insertIfNew
 
 theorem mem_of_mem_insertIfNew [TransCmp cmp] {k a : α} {v : β} :
-    a ∈ t.insertIfNew k v → (cmp k a == .eq) = false → a ∈ t :=
+    a ∈ t.insertIfNew k v → ¬ cmp k a = .eq → a ∈ t :=
   DTreeMap.contains_of_contains_insertIfNew
 
 theorem size_insertIfNew [TransCmp cmp] {k : α} {v : β} :

--- a/src/Std/Data/TreeMap/RawLemmas.lean
+++ b/src/Std/Data/TreeMap/RawLemmas.lean
@@ -154,7 +154,7 @@ theorem contains_erase [TransCmp cmp] (h : t.WF) {k a : α} :
 
 @[simp]
 theorem mem_erase [TransCmp cmp] (h : t.WF) {k a : α} :
-    a ∈ t.erase k ↔  (cmp k a == .eq) = false ∧ a ∈ t :=
+    a ∈ t.erase k ↔ ¬ cmp k a = .eq ∧ a ∈ t :=
   DTreeMap.Raw.mem_erase h
 
 theorem contains_of_contains_erase [TransCmp cmp] (h : t.WF) {k a : α} :
@@ -196,11 +196,11 @@ theorem mem_insertIfNew_self [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
   DTreeMap.Raw.mem_insertIfNew_self h
 
 theorem contains_of_contains_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β} :
-    (t.insertIfNew k v).contains a → (cmp k a == .eq) = false → t.contains a :=
+    (t.insertIfNew k v).contains a → ¬ cmp k a = .eq → t.contains a :=
   DTreeMap.Raw.contains_of_contains_insertIfNew h
 
 theorem mem_of_mem_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β} :
-    a ∈ t.insertIfNew k v → (cmp k a == .eq) = false → a ∈ t :=
+    a ∈ t.insertIfNew k v → ¬ cmp k a = .eq → a ∈ t :=
   DTreeMap.Raw.contains_of_contains_insertIfNew h
 
 theorem size_insertIfNew [TransCmp cmp] {k : α} (h : t.WF) {v : β} :

--- a/src/Std/Data/TreeMap/RawLemmas.lean
+++ b/src/Std/Data/TreeMap/RawLemmas.lean
@@ -23,6 +23,9 @@ namespace Std.TreeMap.Raw
 
 variable {α : Type u} {β : Type v} {cmp : α → α → Ordering} {t : TreeMap.Raw α β cmp}
 
+private theorem ext {t t' : Raw α β cmp} : t.inner = t'.inner → t = t' := by
+  cases t; cases t'; rintro rfl; rfl
+
 @[simp]
 theorem isEmpty_emptyc : (∅ : TreeMap.Raw α β cmp).isEmpty :=
   DTreeMap.Raw.isEmpty_emptyc
@@ -46,5 +49,189 @@ theorem mem_congr [TransCmp cmp] (h : t.WF) {k k' : α} (hab : cmp k k' = .eq) :
 theorem isEmpty_insertIfNew [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
     (t.insertIfNew k v).isEmpty = false :=
   DTreeMap.Raw.isEmpty_insertIfNew h
+
+@[simp]
+theorem contains_empty {k : α} : (empty : Raw α β cmp).contains k = false :=
+  DTreeMap.Raw.contains_empty
+
+@[simp]
+theorem not_mem_empty {k : α} : k ∉ (empty : Raw α β cmp) :=
+  DTreeMap.Raw.not_mem_empty
+
+@[simp]
+theorem contains_emptyc {k : α} : (∅ : Raw α β cmp).contains k = false :=
+  DTreeMap.Raw.contains_empty
+
+@[simp]
+theorem not_mem_emptyc {k : α} : k ∉ (∅ : Raw α β cmp) :=
+  DTreeMap.Raw.not_mem_empty
+
+theorem contains_of_isEmpty [TransCmp cmp] (h : t.WF) {a : α} :
+    t.isEmpty → t.contains a = false :=
+  DTreeMap.Raw.contains_of_isEmpty h
+
+theorem not_mem_of_isEmpty [TransCmp cmp] (h : t.WF) {a : α} :
+    t.isEmpty → a ∉ t :=
+  DTreeMap.Raw.not_mem_of_isEmpty h
+
+theorem isEmpty_eq_false_iff_exists_contains_eq_true [TransCmp cmp] (h : t.WF) :
+    t.isEmpty = false ↔ ∃ a, t.contains a = true :=
+  DTreeMap.Raw.isEmpty_eq_false_iff_exists_contains_eq_true h
+
+theorem isEmpty_eq_false_iff_exists_mem [TransCmp cmp] (h : t.WF) :
+    t.isEmpty = false ↔ ∃ a, a ∈ t :=
+  DTreeMap.Raw.isEmpty_eq_false_iff_exists_mem h
+
+theorem isEmpty_iff_forall_contains [TransCmp cmp] (h : t.WF) :
+    t.isEmpty = true ↔ ∀ a, t.contains a = false :=
+  DTreeMap.Raw.isEmpty_iff_forall_contains h
+
+theorem isEmpty_iff_forall_not_mem [TransCmp cmp] (h : t.WF) :
+    t.isEmpty = true ↔ ∀ a, ¬a ∈ t :=
+  DTreeMap.Raw.isEmpty_iff_forall_not_mem h
+
+@[simp]
+theorem insert_eq_insert {p : α × β} : Insert.insert p t = t.insert p.1 p.2 :=
+  rfl
+
+@[simp]
+theorem singleton_eq_insert {p : α × β} :
+    Singleton.singleton p = (∅ : Raw α β cmp).insert p.1 p.2 :=
+  rfl
+
+@[simp]
+theorem contains_insert [h : TransCmp cmp] (h : t.WF) {k a : α} {v : β} :
+    (t.insert k v).contains a = (cmp k a == .eq || t.contains a) :=
+  DTreeMap.Raw.contains_insert h
+
+@[simp]
+theorem mem_insert [TransCmp cmp] (h : t.WF) {k a : α} {v : β} :
+    a ∈ t.insert k v ↔ cmp k a = .eq ∨ a ∈ t :=
+  DTreeMap.Raw.mem_insert h
+
+theorem contains_insert_self [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+    (t.insert k v).contains k :=
+  DTreeMap.Raw.contains_insert_self h
+
+theorem mem_insert_self [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+    k ∈ t.insert k v :=
+  DTreeMap.Raw.mem_insert_self h
+
+theorem contains_of_contains_insert [TransCmp cmp] (h : t.WF) {k a : α} {v : β} :
+    (t.insert k v).contains a → ¬ cmp k a = .eq → t.contains a :=
+  DTreeMap.Raw.contains_of_contains_insert h
+
+theorem mem_of_mem_insert [TransCmp cmp] (h : t.WF) {k a : α} {v : β} :
+    a ∈ t.insert k v → ¬ cmp k a = .eq → a ∈ t :=
+  DTreeMap.Raw.mem_of_mem_insert h
+
+@[simp]
+theorem size_empty : (empty : Raw α β cmp).size = 0 :=
+  DTreeMap.Raw.size_empty
+
+@[simp]
+theorem size_emptyc : (∅ : Raw α β cmp).size = 0 :=
+  DTreeMap.Raw.size_empty
+
+theorem isEmpty_eq_size_eq_zero (h : t.WF) :
+    t.isEmpty = (t.size == 0) :=
+  DTreeMap.Raw.isEmpty_eq_size_eq_zero h.out
+
+theorem size_insert [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+    (t.insert k v).size = if t.contains k then t.size else t.size + 1 :=
+  DTreeMap.Raw.size_insert h
+
+theorem size_le_size_insert [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+    t.size ≤ (t.insert k v).size :=
+  DTreeMap.Raw.size_le_size_insert h
+
+theorem size_insert_le [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+    (t.insert k v).size ≤ t.size + 1 :=
+  DTreeMap.Raw.size_insert_le h
+
+@[simp]
+theorem erase_empty {k : α} :
+    (empty : Raw α β cmp).erase k = empty :=
+  ext <| DTreeMap.Raw.erase_empty
+
+@[simp]
+theorem erase_emptyc {k : α} :
+    (empty : Raw α β cmp).erase k = empty :=
+  erase_empty
+
+@[simp]
+theorem isEmpty_erase [TransCmp cmp] (h : t.WF) {k : α} :
+    (t.erase k).isEmpty = (t.isEmpty || (t.size == 1 && t.contains k)) :=
+  DTreeMap.Raw.isEmpty_erase h
+
+@[simp]
+theorem contains_erase [TransCmp cmp] (h : t.WF) {k a : α} :
+    (t.erase k).contains a = (cmp k a != .eq && t.contains a) :=
+  DTreeMap.Raw.contains_erase h
+
+@[simp]
+theorem mem_erase [TransCmp cmp] (h : t.WF) {k a : α} :
+    a ∈ t.erase k ↔  (cmp k a == .eq) = false ∧ a ∈ t :=
+  DTreeMap.Raw.mem_erase h
+
+theorem contains_of_contains_erase [TransCmp cmp] (h : t.WF) {k a : α} :
+    (t.erase k).contains a → t.contains a :=
+  DTreeMap.Raw.contains_of_contains_erase h
+
+theorem mem_of_mem_erase [TransCmp cmp] (h : t.WF) {k a : α} :
+    a ∈ t.erase k → a ∈ t :=
+  DTreeMap.Raw.mem_of_mem_erase h
+
+theorem size_erase [TransCmp cmp] (h : t.WF) {k : α} :
+    (t.erase k).size = if t.contains k then t.size - 1 else t.size :=
+  DTreeMap.Raw.size_erase h
+
+theorem size_erase_le [TransCmp cmp] (h : t.WF) {k : α} :
+    (t.erase k).size ≤ t.size :=
+  DTreeMap.Raw.size_erase_le h
+
+theorem size_le_size_erase [TransCmp cmp] (h : t.WF) {k : α} :
+    t.size ≤ (t.erase k).size + 1 :=
+  DTreeMap.Raw.size_le_size_erase h
+
+@[simp]
+theorem contains_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β} :
+    (t.insertIfNew k v).contains a = (cmp k a == .eq || t.contains a) :=
+  DTreeMap.Raw.contains_insertIfNew h
+
+@[simp]
+theorem mem_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β} :
+    a ∈ t.insertIfNew k v ↔ cmp k a == .eq ∨ a ∈ t :=
+  DTreeMap.Raw.mem_insertIfNew h
+
+theorem contains_insertIfNew_self [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+    (t.insertIfNew k v).contains k :=
+  DTreeMap.Raw.contains_insertIfNew_self h
+
+theorem mem_insertIfNew_self [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+    k ∈ t.insertIfNew k v :=
+  DTreeMap.Raw.mem_insertIfNew_self h
+
+theorem contains_of_contains_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β} :
+    (t.insertIfNew k v).contains a → (cmp k a == .eq) = false → t.contains a :=
+  DTreeMap.Raw.contains_of_contains_insertIfNew h
+
+theorem mem_of_mem_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β} :
+    a ∈ t.insertIfNew k v → (cmp k a == .eq) = false → a ∈ t :=
+  DTreeMap.Raw.contains_of_contains_insertIfNew h
+
+theorem size_insertIfNew [TransCmp cmp] {k : α} (h : t.WF) {v : β} :
+    (t.insertIfNew k v).size = if k ∈ t then t.size else t.size + 1 :=
+  DTreeMap.Raw.size_insertIfNew h
+
+theorem size_le_size_insertIfNew [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+    t.size ≤ (t.insertIfNew k v).size :=
+  DTreeMap.Raw.size_le_size_insertIfNew h
+
+theorem size_insertIfNew_le [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+    (t.insertIfNew k v).size ≤ t.size + 1 :=
+  DTreeMap.Raw.size_insertIfNew_le h
+
+
 
 end Std.TreeMap.Raw

--- a/src/Std/Data/TreeMap/RawLemmas.lean
+++ b/src/Std/Data/TreeMap/RawLemmas.lean
@@ -110,11 +110,11 @@ theorem mem_insert_self [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
   DTreeMap.Raw.mem_insert_self h
 
 theorem contains_of_contains_insert [TransCmp cmp] (h : t.WF) {k a : α} {v : β} :
-    (t.insert k v).contains a → ¬ cmp k a = .eq → t.contains a :=
+    (t.insert k v).contains a → cmp k a ≠ .eq → t.contains a :=
   DTreeMap.Raw.contains_of_contains_insert h
 
 theorem mem_of_mem_insert [TransCmp cmp] (h : t.WF) {k a : α} {v : β} :
-    a ∈ t.insert k v → ¬ cmp k a = .eq → a ∈ t :=
+    a ∈ t.insert k v → cmp k a ≠ .eq → a ∈ t :=
   DTreeMap.Raw.mem_of_mem_insert h
 
 @[simp]
@@ -154,7 +154,7 @@ theorem contains_erase [TransCmp cmp] (h : t.WF) {k a : α} :
 
 @[simp]
 theorem mem_erase [TransCmp cmp] (h : t.WF) {k a : α} :
-    a ∈ t.erase k ↔ ¬ cmp k a = .eq ∧ a ∈ t :=
+    a ∈ t.erase k ↔ cmp k a ≠ .eq ∧ a ∈ t :=
   DTreeMap.Raw.mem_erase h
 
 theorem contains_of_contains_erase [TransCmp cmp] (h : t.WF) {k a : α} :
@@ -184,7 +184,7 @@ theorem contains_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β} :
 
 @[simp]
 theorem mem_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β} :
-    a ∈ t.insertIfNew k v ↔ cmp k a == .eq ∨ a ∈ t :=
+    a ∈ t.insertIfNew k v ↔ cmp k a = .eq ∨ a ∈ t :=
   DTreeMap.Raw.mem_insertIfNew h
 
 theorem contains_insertIfNew_self [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
@@ -196,11 +196,11 @@ theorem mem_insertIfNew_self [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
   DTreeMap.Raw.mem_insertIfNew_self h
 
 theorem contains_of_contains_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β} :
-    (t.insertIfNew k v).contains a → ¬ cmp k a = .eq → t.contains a :=
+    (t.insertIfNew k v).contains a → cmp k a ≠ .eq → t.contains a :=
   DTreeMap.Raw.contains_of_contains_insertIfNew h
 
 theorem mem_of_mem_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β} :
-    a ∈ t.insertIfNew k v → ¬ cmp k a = .eq → a ∈ t :=
+    a ∈ t.insertIfNew k v → cmp k a ≠ .eq → a ∈ t :=
   DTreeMap.Raw.contains_of_contains_insertIfNew h
 
 theorem size_insertIfNew [TransCmp cmp] {k : α} (h : t.WF) {v : β} :
@@ -214,7 +214,5 @@ theorem size_le_size_insertIfNew [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
 theorem size_insertIfNew_le [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
     (t.insertIfNew k v).size ≤ t.size + 1 :=
   DTreeMap.Raw.size_insertIfNew_le h
-
-
 
 end Std.TreeMap.Raw

--- a/src/Std/Data/TreeMap/RawLemmas.lean
+++ b/src/Std/Data/TreeMap/RawLemmas.lean
@@ -51,14 +51,6 @@ theorem isEmpty_insertIfNew [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
   DTreeMap.Raw.isEmpty_insertIfNew h
 
 @[simp]
-theorem contains_empty {k : α} : (empty : Raw α β cmp).contains k = false :=
-  DTreeMap.Raw.contains_empty
-
-@[simp]
-theorem not_mem_empty {k : α} : k ∉ (empty : Raw α β cmp) :=
-  DTreeMap.Raw.not_mem_empty
-
-@[simp]
 theorem contains_emptyc {k : α} : (∅ : Raw α β cmp).contains k = false :=
   DTreeMap.Raw.contains_empty
 
@@ -126,10 +118,6 @@ theorem mem_of_mem_insert [TransCmp cmp] (h : t.WF) {k a : α} {v : β} :
   DTreeMap.Raw.mem_of_mem_insert h
 
 @[simp]
-theorem size_empty : (empty : Raw α β cmp).size = 0 :=
-  DTreeMap.Raw.size_empty
-
-@[simp]
 theorem size_emptyc : (∅ : Raw α β cmp).size = 0 :=
   DTreeMap.Raw.size_empty
 
@@ -150,14 +138,9 @@ theorem size_insert_le [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
   DTreeMap.Raw.size_insert_le h
 
 @[simp]
-theorem erase_empty {k : α} :
-    (empty : Raw α β cmp).erase k = empty :=
-  ext <| DTreeMap.Raw.erase_empty
-
-@[simp]
 theorem erase_emptyc {k : α} :
     (empty : Raw α β cmp).erase k = empty :=
-  erase_empty
+  ext <| DTreeMap.Raw.erase_empty
 
 @[simp]
 theorem isEmpty_erase [TransCmp cmp] (h : t.WF) {k : α} :

--- a/src/Std/Data/TreeMap/RawLemmas.lean
+++ b/src/Std/Data/TreeMap/RawLemmas.lean
@@ -52,11 +52,11 @@ theorem isEmpty_insertIfNew [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
 
 @[simp]
 theorem contains_emptyc {k : α} : (∅ : Raw α β cmp).contains k = false :=
-  DTreeMap.Raw.contains_empty
+  DTreeMap.Raw.contains_emptyc
 
 @[simp]
 theorem not_mem_emptyc {k : α} : k ∉ (∅ : Raw α β cmp) :=
-  DTreeMap.Raw.not_mem_empty
+  DTreeMap.Raw.not_mem_emptyc
 
 theorem contains_of_isEmpty [TransCmp cmp] (h : t.WF) {a : α} :
     t.isEmpty → t.contains a = false :=
@@ -119,7 +119,7 @@ theorem mem_of_mem_insert [TransCmp cmp] (h : t.WF) {k a : α} {v : β} :
 
 @[simp]
 theorem size_emptyc : (∅ : Raw α β cmp).size = 0 :=
-  DTreeMap.Raw.size_empty
+  DTreeMap.Raw.size_emptyc
 
 theorem isEmpty_eq_size_eq_zero (h : t.WF) :
     t.isEmpty = (t.size == 0) :=
@@ -140,7 +140,7 @@ theorem size_insert_le [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
 @[simp]
 theorem erase_emptyc {k : α} :
     (empty : Raw α β cmp).erase k = empty :=
-  ext <| DTreeMap.Raw.erase_empty
+  ext <| DTreeMap.Raw.erase_emptyc
 
 @[simp]
 theorem isEmpty_erase [TransCmp cmp] (h : t.WF) {k : α} :

--- a/src/Std/Data/TreeSet/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Lemmas.lean
@@ -47,11 +47,11 @@ theorem mem_congr [TransCmp cmp] {k k' : α} (hab : cmp k k' = .eq) : k ∈ t �
 
 @[simp]
 theorem contains_emptyc {k : α} : (∅ : TreeSet α cmp).contains k = false :=
-  TreeMap.contains_empty
+  TreeMap.contains_emptyc
 
 @[simp]
 theorem not_mem_emptyc {k : α} : k ∉ (∅ : TreeSet α cmp) :=
-  TreeMap.not_mem_empty
+  TreeMap.not_mem_emptyc
 
 theorem contains_of_isEmpty [TransCmp cmp] {a : α} :
     t.isEmpty → t.contains a = false :=
@@ -114,7 +114,7 @@ theorem mem_of_mem_insert [TransCmp cmp] {k a : α} :
 
 @[simp]
 theorem size_emptyc : (∅ : TreeSet α cmp).size = 0 :=
-  TreeMap.size_empty
+  TreeMap.size_emptyc
 
 theorem isEmpty_eq_size_eq_zero :
     t.isEmpty = (t.size == 0) :=
@@ -135,7 +135,7 @@ theorem size_insert_le [TransCmp cmp] {k : α} :
 @[simp]
 theorem erase_emptyc {k : α} :
     (empty : TreeSet α cmp).erase k = empty :=
-  ext <| TreeMap.erase_empty
+  ext <| TreeMap.erase_emptyc
 
 @[simp]
 theorem isEmpty_erase [TransCmp cmp] {k : α} :

--- a/src/Std/Data/TreeSet/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Lemmas.lean
@@ -105,11 +105,11 @@ theorem mem_insert_self [TransCmp cmp] {k : α} :
   TreeMap.mem_insertIfNew_self
 
 theorem contains_of_contains_insert [TransCmp cmp] {k a : α} :
-    (t.insert k).contains a → (cmp k a == .eq) = false → t.contains a :=
+    (t.insert k).contains a → ¬ cmp k a = .eq → t.contains a :=
   TreeMap.contains_of_contains_insertIfNew
 
 theorem mem_of_mem_insert [TransCmp cmp] {k a : α} :
-    a ∈ t.insert k → (cmp k a == .eq) = false → a ∈ t :=
+    a ∈ t.insert k → ¬ cmp k a = .eq → a ∈ t :=
   TreeMap.mem_of_mem_insertIfNew
 
 @[simp]
@@ -146,6 +146,11 @@ theorem isEmpty_erase [TransCmp cmp] {k : α} :
 theorem contains_erase [TransCmp cmp] {k a : α} :
     (t.erase k).contains a = (cmp k a != .eq && t.contains a) :=
   TreeMap.contains_erase
+
+@[simp]
+theorem mem_erase [TransCmp cmp] {k a : α} :
+    a ∈ t.erase k ↔ ¬ cmp k a = .eq ∧ a ∈ t :=
+  TreeMap.mem_erase
 
 theorem contains_of_contains_erase [TransCmp cmp] {k a : α} :
     (t.erase k).contains a → t.contains a :=

--- a/src/Std/Data/TreeSet/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Lemmas.lean
@@ -23,6 +23,9 @@ namespace Std.TreeSet
 
 variable {α : Type u} {cmp : α → α → Ordering} {t : TreeSet α cmp}
 
+private theorem ext {t t' : TreeSet α cmp} : t.inner = t'.inner → t = t' := by
+  cases t; cases t'; rintro rfl; rfl
+
 @[simp]
 theorem isEmpty_emptyc : (∅ : TreeSet α cmp).isEmpty :=
   TreeMap.isEmpty_emptyc
@@ -41,5 +44,144 @@ theorem contains_congr [TransCmp cmp] {k k' : α} (hab : cmp k k' = .eq) :
 
 theorem mem_congr [TransCmp cmp] {k k' : α} (hab : cmp k k' = .eq) : k ∈ t ↔ k' ∈ t :=
   TreeMap.mem_congr hab
+
+@[simp]
+theorem contains_empty {k : α} : (empty : TreeSet α cmp).contains k = false :=
+  TreeMap.contains_empty
+
+@[simp]
+theorem not_mem_empty {k : α} : k ∉ (empty : TreeSet α cmp) :=
+  TreeMap.not_mem_empty
+
+@[simp]
+theorem contains_emptyc {k : α} : (∅ : TreeSet α cmp).contains k = false :=
+  TreeMap.contains_empty
+
+@[simp]
+theorem not_mem_emptyc {k : α} : k ∉ (∅ : TreeSet α cmp) :=
+  TreeMap.not_mem_empty
+
+theorem contains_of_isEmpty [TransCmp cmp] {a : α} :
+    t.isEmpty → t.contains a = false :=
+  DTreeMap.contains_of_isEmpty
+
+theorem not_mem_of_isEmpty [TransCmp cmp] {a : α} :
+    t.isEmpty → a ∉ t :=
+  DTreeMap.not_mem_of_isEmpty
+
+theorem isEmpty_eq_false_iff_exists_contains_eq_true [TransCmp cmp] :
+    t.isEmpty = false ↔ ∃ a, t.contains a = true :=
+  DTreeMap.isEmpty_eq_false_iff_exists_contains_eq_true
+
+theorem isEmpty_eq_false_iff_exists_mem [TransCmp cmp] :
+    t.isEmpty = false ↔ ∃ a, a ∈ t :=
+  DTreeMap.isEmpty_eq_false_iff_exists_mem
+
+theorem isEmpty_iff_forall_contains [TransCmp cmp] :
+    t.isEmpty = true ↔ ∀ a, t.contains a = false :=
+  DTreeMap.isEmpty_iff_forall_contains
+
+theorem isEmpty_iff_forall_not_mem [TransCmp cmp] :
+    t.isEmpty = true ↔ ∀ a, ¬a ∈ t :=
+  DTreeMap.isEmpty_iff_forall_not_mem
+
+@[simp]
+theorem insert_eq_insert {p : α} : Insert.insert p t = t.insert p :=
+  rfl
+
+@[simp]
+theorem singleton_eq_insert {p : α} :
+    Singleton.singleton p = (∅ : TreeSet α cmp).insert p :=
+  rfl
+
+@[simp]
+theorem contains_insert [h : TransCmp cmp] {k a : α} :
+    (t.insert k).contains a = (cmp k a == .eq || t.contains a) :=
+  TreeMap.contains_insertIfNew
+
+@[simp]
+theorem mem_insert [TransCmp cmp] {k a : α} :
+    a ∈ t.insert k ↔ cmp k a == .eq ∨ a ∈ t :=
+  TreeMap.mem_insertIfNew
+
+theorem contains_insert_self [TransCmp cmp] {k : α} :
+    (t.insert k).contains k :=
+  TreeMap.contains_insertIfNew_self
+
+theorem mem_insert_self [TransCmp cmp] {k : α} :
+    k ∈ t.insert k :=
+  TreeMap.mem_insertIfNew_self
+
+theorem contains_of_contains_insert [TransCmp cmp] {k a : α} :
+    (t.insert k).contains a → (cmp k a == .eq) = false → t.contains a :=
+  TreeMap.contains_of_contains_insertIfNew
+
+theorem mem_of_mem_insert [TransCmp cmp] {k a : α} :
+    a ∈ t.insert k → (cmp k a == .eq) = false → a ∈ t :=
+  TreeMap.mem_of_mem_insertIfNew
+
+@[simp]
+theorem size_empty : (empty : TreeSet α cmp).size = 0 :=
+  TreeMap.size_empty
+
+@[simp]
+theorem size_emptyc : (∅ : TreeSet α cmp).size = 0 :=
+  TreeMap.size_empty
+
+theorem isEmpty_eq_size_eq_zero :
+    t.isEmpty = (t.size == 0) :=
+  TreeMap.isEmpty_eq_size_eq_zero
+
+theorem size_insert [TransCmp cmp] {k : α} :
+    (t.insert k).size = if t.contains k then t.size else t.size + 1 :=
+  TreeMap.size_insertIfNew
+
+theorem size_le_size_insert [TransCmp cmp] {k : α} :
+    t.size ≤ (t.insert k).size :=
+  TreeMap.size_le_size_insertIfNew
+
+theorem size_insert_le [TransCmp cmp] {k : α} :
+    (t.insert k).size ≤ t.size + 1 :=
+  TreeMap.size_insertIfNew_le
+
+@[simp]
+theorem erase_empty {k : α} :
+    (empty : TreeSet α cmp).erase k = empty :=
+  ext <| TreeMap.erase_empty
+
+@[simp]
+theorem erase_emptyc {k : α} :
+    (empty : TreeSet α cmp).erase k = empty :=
+  erase_empty
+
+@[simp]
+theorem isEmpty_erase [TransCmp cmp] {k : α} :
+    (t.erase k).isEmpty = (t.isEmpty || (t.size == 1 && t.contains k)) :=
+  TreeMap.isEmpty_erase
+
+@[simp]
+theorem contains_erase [TransCmp cmp] {k a : α} :
+    (t.erase k).contains a = (cmp k a != .eq && t.contains a) :=
+  TreeMap.contains_erase
+
+theorem contains_of_contains_erase [TransCmp cmp] {k a : α} :
+    (t.erase k).contains a → t.contains a :=
+  TreeMap.contains_of_contains_erase
+
+theorem mem_of_mem_erase [TransCmp cmp] {k a : α} :
+    (t.erase k).contains a → t.contains a :=
+  TreeMap.mem_of_mem_erase
+
+theorem size_erase [TransCmp cmp] {k : α} :
+    (t.erase k).size = if t.contains k then t.size - 1 else t.size :=
+  TreeMap.size_erase
+
+theorem size_erase_le [TransCmp cmp] {k : α} :
+    (t.erase k).size ≤ t.size :=
+  TreeMap.size_erase_le
+
+theorem size_le_size_erase [TransCmp cmp] {k : α} :
+    t.size ≤ (t.erase k).size + 1 :=
+  TreeMap.size_le_size_erase
 
 end Std.TreeSet

--- a/src/Std/Data/TreeSet/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Lemmas.lean
@@ -93,7 +93,7 @@ theorem contains_insert [h : TransCmp cmp] {k a : α} :
 
 @[simp]
 theorem mem_insert [TransCmp cmp] {k a : α} :
-    a ∈ t.insert k ↔ cmp k a == .eq ∨ a ∈ t :=
+    a ∈ t.insert k ↔ cmp k a = .eq ∨ a ∈ t :=
   TreeMap.mem_insertIfNew
 
 theorem contains_insert_self [TransCmp cmp] {k : α} :
@@ -105,11 +105,11 @@ theorem mem_insert_self [TransCmp cmp] {k : α} :
   TreeMap.mem_insertIfNew_self
 
 theorem contains_of_contains_insert [TransCmp cmp] {k a : α} :
-    (t.insert k).contains a → ¬ cmp k a = .eq → t.contains a :=
+    (t.insert k).contains a → cmp k a ≠ .eq → t.contains a :=
   TreeMap.contains_of_contains_insertIfNew
 
 theorem mem_of_mem_insert [TransCmp cmp] {k a : α} :
-    a ∈ t.insert k → ¬ cmp k a = .eq → a ∈ t :=
+    a ∈ t.insert k → cmp k a ≠ .eq → a ∈ t :=
   TreeMap.mem_of_mem_insertIfNew
 
 @[simp]
@@ -149,7 +149,7 @@ theorem contains_erase [TransCmp cmp] {k a : α} :
 
 @[simp]
 theorem mem_erase [TransCmp cmp] {k a : α} :
-    a ∈ t.erase k ↔ ¬ cmp k a = .eq ∧ a ∈ t :=
+    a ∈ t.erase k ↔ cmp k a ≠ .eq ∧ a ∈ t :=
   TreeMap.mem_erase
 
 theorem contains_of_contains_erase [TransCmp cmp] {k a : α} :

--- a/src/Std/Data/TreeSet/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Lemmas.lean
@@ -46,14 +46,6 @@ theorem mem_congr [TransCmp cmp] {k k' : α} (hab : cmp k k' = .eq) : k ∈ t �
   TreeMap.mem_congr hab
 
 @[simp]
-theorem contains_empty {k : α} : (empty : TreeSet α cmp).contains k = false :=
-  TreeMap.contains_empty
-
-@[simp]
-theorem not_mem_empty {k : α} : k ∉ (empty : TreeSet α cmp) :=
-  TreeMap.not_mem_empty
-
-@[simp]
 theorem contains_emptyc {k : α} : (∅ : TreeSet α cmp).contains k = false :=
   TreeMap.contains_empty
 
@@ -121,10 +113,6 @@ theorem mem_of_mem_insert [TransCmp cmp] {k a : α} :
   TreeMap.mem_of_mem_insertIfNew
 
 @[simp]
-theorem size_empty : (empty : TreeSet α cmp).size = 0 :=
-  TreeMap.size_empty
-
-@[simp]
 theorem size_emptyc : (∅ : TreeSet α cmp).size = 0 :=
   TreeMap.size_empty
 
@@ -145,14 +133,9 @@ theorem size_insert_le [TransCmp cmp] {k : α} :
   TreeMap.size_insertIfNew_le
 
 @[simp]
-theorem erase_empty {k : α} :
-    (empty : TreeSet α cmp).erase k = empty :=
-  ext <| TreeMap.erase_empty
-
-@[simp]
 theorem erase_emptyc {k : α} :
     (empty : TreeSet α cmp).erase k = empty :=
-  erase_empty
+  ext <| TreeMap.erase_empty
 
 @[simp]
 theorem isEmpty_erase [TransCmp cmp] {k : α} :

--- a/src/Std/Data/TreeSet/RawLemmas.lean
+++ b/src/Std/Data/TreeSet/RawLemmas.lean
@@ -93,7 +93,7 @@ theorem contains_insert [h : TransCmp cmp] (h : t.WF) {k a : α} :
 
 @[simp]
 theorem mem_insert [TransCmp cmp] (h : t.WF) {k a : α} :
-    a ∈ t.insert k ↔ cmp k a == .eq ∨ a ∈ t :=
+    a ∈ t.insert k ↔ cmp k a = .eq ∨ a ∈ t :=
   TreeMap.Raw.mem_insertIfNew h
 
 theorem contains_insert_self [TransCmp cmp] (h : t.WF) {k : α} :
@@ -105,11 +105,11 @@ theorem mem_insert_self [TransCmp cmp] (h : t.WF) {k : α} :
   TreeMap.Raw.mem_insertIfNew_self h
 
 theorem contains_of_contains_insert [TransCmp cmp] (h : t.WF) {k a : α} :
-    (t.insert k).contains a → ¬ cmp k a = .eq → t.contains a :=
+    (t.insert k).contains a → cmp k a ≠ .eq → t.contains a :=
   TreeMap.Raw.contains_of_contains_insertIfNew h
 
 theorem mem_of_mem_insert [TransCmp cmp] (h : t.WF) {k a : α} :
-    a ∈ t.insert k → ¬ cmp k a = .eq → a ∈ t :=
+    a ∈ t.insert k → cmp k a ≠ .eq → a ∈ t :=
   TreeMap.Raw.mem_of_mem_insertIfNew h
 
 @[simp]
@@ -149,7 +149,7 @@ theorem contains_erase [TransCmp cmp] (h : t.WF) {k a : α} :
 
 @[simp]
 theorem mem_erase [TransCmp cmp] (h : t.WF) {k a : α} :
-    a ∈ t.erase k ↔ ¬ cmp k a = .eq ∧ a ∈ t :=
+    a ∈ t.erase k ↔ cmp k a ≠ .eq ∧ a ∈ t :=
   TreeMap.Raw.mem_erase h
 
 theorem contains_of_contains_erase [TransCmp cmp] (h : t.WF) {k a : α} :
@@ -171,7 +171,5 @@ theorem size_erase_le [TransCmp cmp] (h : t.WF) {k : α} :
 theorem size_le_size_erase [TransCmp cmp] (h : t.WF) {k : α} :
     t.size ≤ (t.erase k).size + 1 :=
   TreeMap.Raw.size_le_size_erase h
-
-
 
 end Std.TreeSet.Raw

--- a/src/Std/Data/TreeSet/RawLemmas.lean
+++ b/src/Std/Data/TreeSet/RawLemmas.lean
@@ -47,11 +47,11 @@ theorem mem_congr [TransCmp cmp] (h : t.WF) {k k' : α} (hab : cmp k k' = .eq) :
 
 @[simp]
 theorem contains_emptyc {k : α} : (∅ : Raw α cmp).contains k = false :=
-  TreeMap.Raw.contains_empty
+  TreeMap.Raw.contains_emptyc
 
 @[simp]
 theorem not_mem_emptyc {k : α} : k ∉ (∅ : Raw α cmp) :=
-  TreeMap.Raw.not_mem_empty
+  TreeMap.Raw.not_mem_emptyc
 
 theorem contains_of_isEmpty [TransCmp cmp] (h : t.WF) {a : α} :
     t.isEmpty → t.contains a = false :=
@@ -114,7 +114,7 @@ theorem mem_of_mem_insert [TransCmp cmp] (h : t.WF) {k a : α} :
 
 @[simp]
 theorem size_emptyc : (∅ : Raw α cmp).size = 0 :=
-  TreeMap.Raw.size_empty
+  TreeMap.Raw.size_emptyc
 
 theorem isEmpty_eq_size_eq_zero (h : t.WF) :
     t.isEmpty = (t.size == 0) :=
@@ -135,7 +135,7 @@ theorem size_insert_le [TransCmp cmp] (h : t.WF) {k : α} :
 @[simp]
 theorem erase_emptyc {k : α} :
     (empty : Raw α cmp).erase k = empty :=
-  ext <| TreeMap.Raw.erase_empty
+  ext <| TreeMap.Raw.erase_emptyc
 
 @[simp]
 theorem isEmpty_erase [TransCmp cmp] (h : t.WF) {k : α} :

--- a/src/Std/Data/TreeSet/RawLemmas.lean
+++ b/src/Std/Data/TreeSet/RawLemmas.lean
@@ -105,11 +105,11 @@ theorem mem_insert_self [TransCmp cmp] (h : t.WF) {k : α} :
   TreeMap.Raw.mem_insertIfNew_self h
 
 theorem contains_of_contains_insert [TransCmp cmp] (h : t.WF) {k a : α} :
-    (t.insert k).contains a → (cmp k a == .eq) = false → t.contains a :=
+    (t.insert k).contains a → ¬ cmp k a = .eq → t.contains a :=
   TreeMap.Raw.contains_of_contains_insertIfNew h
 
 theorem mem_of_mem_insert [TransCmp cmp] (h : t.WF) {k a : α} :
-    a ∈ t.insert k → (cmp k a == .eq) = false → a ∈ t :=
+    a ∈ t.insert k → ¬ cmp k a = .eq → a ∈ t :=
   TreeMap.Raw.mem_of_mem_insertIfNew h
 
 @[simp]
@@ -149,7 +149,7 @@ theorem contains_erase [TransCmp cmp] (h : t.WF) {k a : α} :
 
 @[simp]
 theorem mem_erase [TransCmp cmp] (h : t.WF) {k a : α} :
-    a ∈ t.erase k ↔  (cmp k a == .eq) = false ∧ a ∈ t :=
+    a ∈ t.erase k ↔ ¬ cmp k a = .eq ∧ a ∈ t :=
   TreeMap.Raw.mem_erase h
 
 theorem contains_of_contains_erase [TransCmp cmp] (h : t.WF) {k a : α} :

--- a/src/Std/Data/TreeSet/RawLemmas.lean
+++ b/src/Std/Data/TreeSet/RawLemmas.lean
@@ -46,14 +46,6 @@ theorem mem_congr [TransCmp cmp] (h : t.WF) {k k' : α} (hab : cmp k k' = .eq) :
   TreeMap.Raw.mem_congr h hab
 
 @[simp]
-theorem contains_empty {k : α} : (empty : Raw α cmp).contains k = false :=
-  TreeMap.Raw.contains_empty
-
-@[simp]
-theorem not_mem_empty {k : α} : k ∉ (empty : Raw α cmp) :=
-  TreeMap.Raw.not_mem_empty
-
-@[simp]
 theorem contains_emptyc {k : α} : (∅ : Raw α cmp).contains k = false :=
   TreeMap.Raw.contains_empty
 
@@ -121,10 +113,6 @@ theorem mem_of_mem_insert [TransCmp cmp] (h : t.WF) {k a : α} :
   TreeMap.Raw.mem_of_mem_insertIfNew h
 
 @[simp]
-theorem size_empty : (empty : Raw α cmp).size = 0 :=
-  TreeMap.Raw.size_empty
-
-@[simp]
 theorem size_emptyc : (∅ : Raw α cmp).size = 0 :=
   TreeMap.Raw.size_empty
 
@@ -145,14 +133,9 @@ theorem size_insert_le [TransCmp cmp] (h : t.WF) {k : α} :
   TreeMap.Raw.size_insertIfNew_le h
 
 @[simp]
-theorem erase_empty {k : α} :
-    (empty : Raw α cmp).erase k = empty :=
-  ext <| TreeMap.Raw.erase_empty
-
-@[simp]
 theorem erase_emptyc {k : α} :
     (empty : Raw α cmp).erase k = empty :=
-  erase_empty
+  ext <| TreeMap.Raw.erase_empty
 
 @[simp]
 theorem isEmpty_erase [TransCmp cmp] (h : t.WF) {k : α} :

--- a/src/Std/Data/TreeSet/RawLemmas.lean
+++ b/src/Std/Data/TreeSet/RawLemmas.lean
@@ -23,6 +23,9 @@ namespace Std.TreeSet.Raw
 
 variable {α : Type u} {β : Type v} {cmp : α → α → Ordering} {t : TreeSet.Raw α cmp}
 
+private theorem ext {t t' : Raw α cmp} : t.inner = t'.inner → t = t' := by
+  cases t; cases t'; rintro rfl; rfl
+
 @[simp]
 theorem isEmpty_emptyc : (∅ : Raw α cmp).isEmpty :=
   TreeMap.Raw.isEmpty_emptyc
@@ -41,5 +44,151 @@ theorem contains_congr [TransCmp cmp] (h : t.WF) {k k' : α} (hab : cmp k k' = .
 
 theorem mem_congr [TransCmp cmp] (h : t.WF) {k k' : α} (hab : cmp k k' = .eq) : k ∈ t ↔ k' ∈ t :=
   TreeMap.Raw.mem_congr h hab
+
+@[simp]
+theorem contains_empty {k : α} : (empty : Raw α cmp).contains k = false :=
+  TreeMap.Raw.contains_empty
+
+@[simp]
+theorem not_mem_empty {k : α} : k ∉ (empty : Raw α cmp) :=
+  TreeMap.Raw.not_mem_empty
+
+@[simp]
+theorem contains_emptyc {k : α} : (∅ : Raw α cmp).contains k = false :=
+  TreeMap.Raw.contains_empty
+
+@[simp]
+theorem not_mem_emptyc {k : α} : k ∉ (∅ : Raw α cmp) :=
+  TreeMap.Raw.not_mem_empty
+
+theorem contains_of_isEmpty [TransCmp cmp] (h : t.WF) {a : α} :
+    t.isEmpty → t.contains a = false :=
+  DTreeMap.Raw.contains_of_isEmpty h
+
+theorem not_mem_of_isEmpty [TransCmp cmp] (h : t.WF) {a : α} :
+    t.isEmpty → a ∉ t :=
+  DTreeMap.Raw.not_mem_of_isEmpty h
+
+theorem isEmpty_eq_false_iff_exists_contains_eq_true [TransCmp cmp] (h : t.WF) :
+    t.isEmpty = false ↔ ∃ a, t.contains a = true :=
+  DTreeMap.Raw.isEmpty_eq_false_iff_exists_contains_eq_true h
+
+theorem isEmpty_eq_false_iff_exists_mem [TransCmp cmp] (h : t.WF) :
+    t.isEmpty = false ↔ ∃ a, a ∈ t :=
+  DTreeMap.Raw.isEmpty_eq_false_iff_exists_mem h
+
+theorem isEmpty_iff_forall_contains [TransCmp cmp] (h : t.WF) :
+    t.isEmpty = true ↔ ∀ a, t.contains a = false :=
+  DTreeMap.Raw.isEmpty_iff_forall_contains h
+
+theorem isEmpty_iff_forall_not_mem [TransCmp cmp] (h : t.WF) :
+    t.isEmpty = true ↔ ∀ a, ¬a ∈ t :=
+  DTreeMap.Raw.isEmpty_iff_forall_not_mem h
+
+@[simp]
+theorem insert_eq_insert {p : α} : Insert.insert p t = t.insert p :=
+  rfl
+
+@[simp]
+theorem singleton_eq_insert {p : α} :
+    Singleton.singleton p = (∅ : Raw α cmp).insert p :=
+  rfl
+
+@[simp]
+theorem contains_insert [h : TransCmp cmp] (h : t.WF) {k a : α} :
+    (t.insert k).contains a = (cmp k a == .eq || t.contains a) :=
+  TreeMap.Raw.contains_insertIfNew h
+
+@[simp]
+theorem mem_insert [TransCmp cmp] (h : t.WF) {k a : α} :
+    a ∈ t.insert k ↔ cmp k a == .eq ∨ a ∈ t :=
+  TreeMap.Raw.mem_insertIfNew h
+
+theorem contains_insert_self [TransCmp cmp] (h : t.WF) {k : α} :
+    (t.insert k).contains k :=
+  TreeMap.Raw.contains_insertIfNew_self h
+
+theorem mem_insert_self [TransCmp cmp] (h : t.WF) {k : α} :
+    k ∈ t.insert k :=
+  TreeMap.Raw.mem_insertIfNew_self h
+
+theorem contains_of_contains_insert [TransCmp cmp] (h : t.WF) {k a : α} :
+    (t.insert k).contains a → (cmp k a == .eq) = false → t.contains a :=
+  TreeMap.Raw.contains_of_contains_insertIfNew h
+
+theorem mem_of_mem_insert [TransCmp cmp] (h : t.WF) {k a : α} :
+    a ∈ t.insert k → (cmp k a == .eq) = false → a ∈ t :=
+  TreeMap.Raw.mem_of_mem_insertIfNew h
+
+@[simp]
+theorem size_empty : (empty : Raw α cmp).size = 0 :=
+  TreeMap.Raw.size_empty
+
+@[simp]
+theorem size_emptyc : (∅ : Raw α cmp).size = 0 :=
+  TreeMap.Raw.size_empty
+
+theorem isEmpty_eq_size_eq_zero (h : t.WF) :
+    t.isEmpty = (t.size == 0) :=
+  TreeMap.Raw.isEmpty_eq_size_eq_zero h.out
+
+theorem size_insert [TransCmp cmp] (h : t.WF) {k : α} :
+    (t.insert k).size = if t.contains k then t.size else t.size + 1 :=
+  TreeMap.Raw.size_insertIfNew h
+
+theorem size_le_size_insert [TransCmp cmp] (h : t.WF) {k : α} :
+    t.size ≤ (t.insert k).size :=
+  TreeMap.Raw.size_le_size_insertIfNew h
+
+theorem size_insert_le [TransCmp cmp] (h : t.WF) {k : α} :
+    (t.insert k).size ≤ t.size + 1 :=
+  TreeMap.Raw.size_insertIfNew_le h
+
+@[simp]
+theorem erase_empty {k : α} :
+    (empty : Raw α cmp).erase k = empty :=
+  ext <| TreeMap.Raw.erase_empty
+
+@[simp]
+theorem erase_emptyc {k : α} :
+    (empty : Raw α cmp).erase k = empty :=
+  erase_empty
+
+@[simp]
+theorem isEmpty_erase [TransCmp cmp] (h : t.WF) {k : α} :
+    (t.erase k).isEmpty = (t.isEmpty || (t.size == 1 && t.contains k)) :=
+  TreeMap.Raw.isEmpty_erase h
+
+@[simp]
+theorem contains_erase [TransCmp cmp] (h : t.WF) {k a : α} :
+    (t.erase k).contains a = (cmp k a != .eq && t.contains a) :=
+  TreeMap.Raw.contains_erase h
+
+@[simp]
+theorem mem_erase [TransCmp cmp] (h : t.WF) {k a : α} :
+    a ∈ t.erase k ↔  (cmp k a == .eq) = false ∧ a ∈ t :=
+  TreeMap.Raw.mem_erase h
+
+theorem contains_of_contains_erase [TransCmp cmp] (h : t.WF) {k a : α} :
+    (t.erase k).contains a → t.contains a :=
+  TreeMap.Raw.contains_of_contains_erase h
+
+theorem mem_of_mem_erase [TransCmp cmp] (h : t.WF) {k a : α} :
+    a ∈ t.erase k → a ∈ t :=
+  TreeMap.Raw.mem_of_mem_erase h
+
+theorem size_erase [TransCmp cmp] (h : t.WF) {k : α} :
+    (t.erase k).size = if t.contains k then t.size - 1 else t.size :=
+  TreeMap.Raw.size_erase h
+
+theorem size_erase_le [TransCmp cmp] (h : t.WF) {k : α} :
+    (t.erase k).size ≤ t.size :=
+  TreeMap.Raw.size_erase_le h
+
+theorem size_le_size_erase [TransCmp cmp] (h : t.WF) {k : α} :
+    t.size ≤ (t.erase k).size + 1 :=
+  TreeMap.Raw.size_le_size_erase h
+
+
 
 end Std.TreeSet.Raw

--- a/tests/lean/run/treemap.lean
+++ b/tests/lean/run/treemap.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Paul Reichert
 -/
 import Std.Data.TreeSet.Basic
+import Std.Data.TreeSet.Lemmas
 
 open Std
 
@@ -29,3 +30,12 @@ example [TransOrd α] [LawfulEqOrd α] (a : α) (b : β) : Option β :=
 
 example [TransOrd α] [LawfulEqOrd α] (a : α) (b : β) : Option β :=
   (mkTreeMapSingleton a b)[a]?
+
+example [TransOrd α] (a : α) (b : β) : (mkTreeMapSingleton a b).contains a := by
+  simp [mkTreeMapSingleton, Id.run]
+
+example [TransOrd α] (a : α) (b : β) : (mkDTreeMapSingleton a b).contains a := by
+  simp [mkDTreeMapSingleton, Id.run]
+
+example [TransOrd α] (a : α) : (mkTreeSetSingleton a).contains a := by
+  simp [mkTreeSetSingleton, Id.run]


### PR DESCRIPTION
This PR adds all missing tree map lemmas about the interactions of the functions `empty`, `isEmpty`, `contains`, `size`, `insert(IfNew)` and `erase`.