### PR TITLE
feat: tree map lemmas about containsThenInsert(IfNew)

### DIFF
--- a/src/Std/Data/DHashMap/Lemmas.lean
+++ b/src/Std/Data/DHashMap/Lemmas.lean
@@ -181,19 +181,37 @@ theorem size_le_size_erase [EquivBEq α] [LawfulHashable α] {k : α} :
   Raw₀.size_le_size_erase ⟨m.1, _⟩ m.2
 
 @[simp]
+theorem fst_containsThenInsert {k : α} {v : β k} : (m.containsThenInsert k v).1 = m.contains k :=
+  Raw₀.containsThenInsert_fst _
+
+@[simp, deprecated fst_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_fst {k : α} {v : β k} : (m.containsThenInsert k v).1 = m.contains k :=
   Raw₀.containsThenInsert_fst _
 
 @[simp]
+theorem snd_containsThenInsert {k : α} {v : β k} : (m.containsThenInsert k v).2 = m.insert k v :=
+  Subtype.eq <| (congrArg Subtype.val (Raw₀.containsThenInsert_snd _ (k := k)) :)
+
+@[simp, deprecated snd_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_snd {k : α} {v : β k} : (m.containsThenInsert k v).2 = m.insert k v :=
   Subtype.eq <| (congrArg Subtype.val (Raw₀.containsThenInsert_snd _ (k := k)) :)
 
 @[simp]
+theorem fst_containsThenInsertIfNew {k : α} {v : β k} :
+    (m.containsThenInsertIfNew k v).1 = m.contains k :=
+  Raw₀.containsThenInsertIfNew_fst _
+
+@[simp, deprecated fst_containsThenInsertIfNew (since := "2025-02-20")]
 theorem containsThenInsertIfNew_fst {k : α} {v : β k} :
     (m.containsThenInsertIfNew k v).1 = m.contains k :=
   Raw₀.containsThenInsertIfNew_fst _
 
 @[simp]
+theorem snd_containsThenInsertIfNew {k : α} {v : β k} :
+    (m.containsThenInsertIfNew k v).2 = m.insertIfNew k v :=
+  Subtype.eq <| (congrArg Subtype.val (Raw₀.containsThenInsertIfNew_snd _ (k := k)) :)
+
+@[simp, deprecated snd_containsThenInsertIfNew (since := "2025-02-20")]
 theorem containsThenInsertIfNew_snd {k : α} {v : β k} :
     (m.containsThenInsertIfNew k v).2 = m.insertIfNew k v :=
   Subtype.eq <| (congrArg Subtype.val (Raw₀.containsThenInsertIfNew_snd _ (k := k)) :)

--- a/src/Std/Data/DHashMap/Lemmas.lean
+++ b/src/Std/Data/DHashMap/Lemmas.lean
@@ -181,37 +181,19 @@ theorem size_le_size_erase [EquivBEq α] [LawfulHashable α] {k : α} :
   Raw₀.size_le_size_erase ⟨m.1, _⟩ m.2
 
 @[simp]
-theorem fst_containsThenInsert {k : α} {v : β k} : (m.containsThenInsert k v).1 = m.contains k :=
-  Raw₀.containsThenInsert_fst _
-
-@[simp, deprecated fst_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_fst {k : α} {v : β k} : (m.containsThenInsert k v).1 = m.contains k :=
   Raw₀.containsThenInsert_fst _
 
 @[simp]
-theorem snd_containsThenInsert {k : α} {v : β k} : (m.containsThenInsert k v).2 = m.insert k v :=
-  Subtype.eq <| (congrArg Subtype.val (Raw₀.containsThenInsert_snd _ (k := k)) :)
-
-@[simp, deprecated snd_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_snd {k : α} {v : β k} : (m.containsThenInsert k v).2 = m.insert k v :=
   Subtype.eq <| (congrArg Subtype.val (Raw₀.containsThenInsert_snd _ (k := k)) :)
 
 @[simp]
-theorem fst_containsThenInsertIfNew {k : α} {v : β k} :
-    (m.containsThenInsertIfNew k v).1 = m.contains k :=
-  Raw₀.containsThenInsertIfNew_fst _
-
-@[simp, deprecated fst_containsThenInsertIfNew (since := "2025-02-20")]
 theorem containsThenInsertIfNew_fst {k : α} {v : β k} :
     (m.containsThenInsertIfNew k v).1 = m.contains k :=
   Raw₀.containsThenInsertIfNew_fst _
 
 @[simp]
-theorem snd_containsThenInsertIfNew {k : α} {v : β k} :
-    (m.containsThenInsertIfNew k v).2 = m.insertIfNew k v :=
-  Subtype.eq <| (congrArg Subtype.val (Raw₀.containsThenInsertIfNew_snd _ (k := k)) :)
-
-@[simp, deprecated snd_containsThenInsertIfNew (since := "2025-02-20")]
 theorem containsThenInsertIfNew_snd {k : α} {v : β k} :
     (m.containsThenInsertIfNew k v).2 = m.insertIfNew k v :=
   Subtype.eq <| (congrArg Subtype.val (Raw₀.containsThenInsertIfNew_snd _ (k := k)) :)

--- a/src/Std/Data/DHashMap/RawLemmas.lean
+++ b/src/Std/Data/DHashMap/RawLemmas.lean
@@ -251,24 +251,44 @@ theorem size_le_size_erase [EquivBEq α] [LawfulHashable α] (h : m.WF) {k : α}
   simp_to_raw using Raw₀.size_le_size_erase ⟨m, _⟩
 
 @[simp]
-theorem containsThenInsert_fst (h : m.WF) {k : α} {v : β k} :
+theorem fst_containsThenInsert (h : m.WF) {k : α} {v : β k} :
     (m.containsThenInsert k v).1 = m.contains k := by
   simp_to_raw using Raw₀.containsThenInsert_fst
 
+@[simp, deprecated fst_containsThenInsert (since := "2025-02-20")]
+theorem containsThenInsert_fst (h : m.WF) {k : α} {v : β k} :
+    (m.containsThenInsert k v).1 = m.contains k :=
+  fst_containsThenInsert h
+
 @[simp]
-theorem containsThenInsert_snd (h : m.WF) {k : α} {v : β k} :
+theorem snd_containsThenInsert (h : m.WF) {k : α} {v : β k} :
     (m.containsThenInsert k v).2 = m.insert k v := by
   simp_to_raw using congrArg Subtype.val (Raw₀.containsThenInsert_snd _)
 
+@[simp, deprecated snd_containsThenInsert (since := "2025-02-20")]
+theorem containsThenInsert_snd (h : m.WF) {k : α} {v : β k} :
+    (m.containsThenInsert k v).2 = m.insert k v :=
+  snd_containsThenInsert h
+
 @[simp]
-theorem containsThenInsertIfNew_fst (h : m.WF) {k : α} {v : β k} :
+theorem fst_containsThenInsertIfNew (h : m.WF) {k : α} {v : β k} :
     (m.containsThenInsertIfNew k v).1 = m.contains k := by
   simp_to_raw using Raw₀.containsThenInsertIfNew_fst
 
+@[simp, deprecated fst_containsThenInsertIfNew (since := "2025-02-20")]
+theorem containsThenInsertIfNew_fst (h : m.WF) {k : α} {v : β k} :
+    (m.containsThenInsertIfNew k v).1 = m.contains k :=
+  fst_containsThenInsertIfNew h
+
 @[simp]
-theorem containsThenInsertIfNew_snd (h : m.WF) {k : α} {v : β k} :
+theorem snd_containsThenInsertIfNew (h : m.WF) {k : α} {v : β k} :
     (m.containsThenInsertIfNew k v).2 = m.insertIfNew k v := by
   simp_to_raw using congrArg Subtype.val (Raw₀.containsThenInsertIfNew_snd _)
+
+@[simp, deprecated snd_containsThenInsertIfNew (since := "2025-02-20")]
+theorem containsThenInsertIfNew_snd (h : m.WF) {k : α} {v : β k} :
+    (m.containsThenInsertIfNew k v).2 = m.insertIfNew k v :=
+  snd_containsThenInsertIfNew h
 
 @[simp]
 theorem get?_empty [LawfulBEq α] {a : α} {c} : (empty c : Raw α β).get? a = none := by

--- a/src/Std/Data/DHashMap/RawLemmas.lean
+++ b/src/Std/Data/DHashMap/RawLemmas.lean
@@ -251,44 +251,24 @@ theorem size_le_size_erase [EquivBEq α] [LawfulHashable α] (h : m.WF) {k : α}
   simp_to_raw using Raw₀.size_le_size_erase ⟨m, _⟩
 
 @[simp]
-theorem fst_containsThenInsert (h : m.WF) {k : α} {v : β k} :
+theorem containsThenInsert_fst (h : m.WF) {k : α} {v : β k} :
     (m.containsThenInsert k v).1 = m.contains k := by
   simp_to_raw using Raw₀.containsThenInsert_fst
 
-@[simp, deprecated fst_containsThenInsert (since := "2025-02-20")]
-theorem containsThenInsert_fst (h : m.WF) {k : α} {v : β k} :
-    (m.containsThenInsert k v).1 = m.contains k :=
-  fst_containsThenInsert h
-
 @[simp]
-theorem snd_containsThenInsert (h : m.WF) {k : α} {v : β k} :
+theorem containsThenInsert_snd (h : m.WF) {k : α} {v : β k} :
     (m.containsThenInsert k v).2 = m.insert k v := by
   simp_to_raw using congrArg Subtype.val (Raw₀.containsThenInsert_snd _)
 
-@[simp, deprecated snd_containsThenInsert (since := "2025-02-20")]
-theorem containsThenInsert_snd (h : m.WF) {k : α} {v : β k} :
-    (m.containsThenInsert k v).2 = m.insert k v :=
-  snd_containsThenInsert h
-
 @[simp]
-theorem fst_containsThenInsertIfNew (h : m.WF) {k : α} {v : β k} :
+theorem containsThenInsertIfNew_fst (h : m.WF) {k : α} {v : β k} :
     (m.containsThenInsertIfNew k v).1 = m.contains k := by
   simp_to_raw using Raw₀.containsThenInsertIfNew_fst
 
-@[simp, deprecated fst_containsThenInsertIfNew (since := "2025-02-20")]
-theorem containsThenInsertIfNew_fst (h : m.WF) {k : α} {v : β k} :
-    (m.containsThenInsertIfNew k v).1 = m.contains k :=
-  fst_containsThenInsertIfNew h
-
 @[simp]
-theorem snd_containsThenInsertIfNew (h : m.WF) {k : α} {v : β k} :
+theorem containsThenInsertIfNew_snd (h : m.WF) {k : α} {v : β k} :
     (m.containsThenInsertIfNew k v).2 = m.insertIfNew k v := by
   simp_to_raw using congrArg Subtype.val (Raw₀.containsThenInsertIfNew_snd _)
-
-@[simp, deprecated snd_containsThenInsertIfNew (since := "2025-02-20")]
-theorem containsThenInsertIfNew_snd (h : m.WF) {k : α} {v : β k} :
-    (m.containsThenInsertIfNew k v).2 = m.insertIfNew k v :=
-  snd_containsThenInsertIfNew h
 
 @[simp]
 theorem get?_empty [LawfulBEq α] {a : α} {c} : (empty c : Raw α β).get? a = none := by

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -298,39 +298,39 @@ theorem size_le_size_erase! [TransOrd α] (h : t.WF) {k : α} :
     t.size ≤ (t.erase! k).size + 1 := by
   simp_to_model [erase!] using List.length_le_length_eraseKey
 
-theorem fst_containsThenInsert [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+theorem containsThenInsert_fst [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsert k v h.balanced).1 = t.contains k := by
-  rw [fst_containsThenInsert_eq_containsₘ, contains_eq_containsₘ]
+  rw [containsThenInsert_fst_eq_containsₘ, contains_eq_containsₘ]
   exact h.ordered
 
-theorem fst_containsThenInsert! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+theorem containsThenInsert_fst! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsert! k v).1 = t.contains k := by
-  rw [fst_containsThenInsert!_eq_fst_containsThenInsert, fst_containsThenInsert h]
+  rw [containsThenInsert_fst!_eq_containsThenInsert_fst, containsThenInsert_fst h]
 
-theorem snd_containsThenInsert [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+theorem containsThenInsert_snd [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsert k v h.balanced).2.impl = (t.insert k v h.balanced).impl := by
   rfl
 
-theorem snd_containsThenInsert! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+theorem containsThenInsert_snd! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsert! k v).2 = t.insert! k v := by
-  rw [snd_containsThenInsert!_eq_snd_containsThenInsert _ h.balanced, snd_containsThenInsert h,
+  rw [containsThenInsert_snd!_eq_containsThenInsert_snd _ h.balanced, containsThenInsert_snd h,
     insert_eq_insert!]
 
-theorem fst_containsThenInsertIfNew [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+theorem containsThenInsertIfNew_fst [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsertIfNew k v h.balanced).1 = t.contains k := by
-  rw [fst_containsThenInsertIfNew_eq_containsₘ, contains_eq_containsₘ]
+  rw [containsThenInsertIfNew_fst_eq_containsₘ, contains_eq_containsₘ]
 
-theorem fst_containsThenInsertIfNew! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+theorem containsThenInsertIfNew_fst! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsertIfNew! k v).1 = t.contains k := by
-  rw [fst_containsThenInsertIfNew!_eq_fst_containsThenInsertIfNew, fst_containsThenInsertIfNew h]
+  rw [containsThenInsertIfNew_fst!_eq_containsThenInsertIfNew_fst, containsThenInsertIfNew_fst h]
 
-theorem snd_containsThenInsertIfNew [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+theorem containsThenInsertIfNew_snd [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsertIfNew k v h.balanced).2.impl = (t.insertIfNew k v h.balanced).impl := by
-  rw [snd_containsThenInsertIfNew_eq_insertIfNew]
+  rw [containsThenInsertIfNew_snd_eq_insertIfNew]
 
-theorem snd_containsThenInsertIfNew! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+theorem containsThenInsertIfNew_snd! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsertIfNew! k v).2 = t.insertIfNew! k v := by
-  rw [snd_containsThenInsertIfNew!_eq_snd_containsThenInsertIfNew _ h.balanced, snd_containsThenInsertIfNew h,
+  rw [containsThenInsertIfNew_snd!_eq_containsThenInsertIfNew_snd _ h.balanced, containsThenInsertIfNew_snd h,
     insertIfNew_eq_insertIfNew!]
 
 theorem contains_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β k} :

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -303,34 +303,34 @@ theorem containsThenInsert_fst [TransOrd α] (h : t.WF) {k : α} {v : β k} :
   rw [containsThenInsert_fst_eq_containsₘ, contains_eq_containsₘ]
   exact h.ordered
 
-theorem containsThenInsert_fst! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+theorem containsThenInsert!_fst [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsert! k v).1 = t.contains k := by
-  rw [containsThenInsert_fst!_eq_containsThenInsert_fst, containsThenInsert_fst h]
+  rw [containsThenInsert!_fst_eq_containsThenInsert_fst, containsThenInsert_fst h]
 
 theorem containsThenInsert_snd [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsert k v h.balanced).2.impl = (t.insert k v h.balanced).impl := by
   rfl
 
-theorem containsThenInsert_snd! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+theorem containsThenInsert!_snd [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsert! k v).2 = t.insert! k v := by
-  rw [containsThenInsert_snd!_eq_containsThenInsert_snd _ h.balanced, containsThenInsert_snd h,
+  rw [containsThenInsert!_snd_eq_containsThenInsert_snd _ h.balanced, containsThenInsert_snd h,
     insert_eq_insert!]
 
 theorem containsThenInsertIfNew_fst [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsertIfNew k v h.balanced).1 = t.contains k := by
   rw [containsThenInsertIfNew_fst_eq_containsₘ, contains_eq_containsₘ]
 
-theorem containsThenInsertIfNew_fst! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+theorem containsThenInsertIfNew!_fst [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsertIfNew! k v).1 = t.contains k := by
-  rw [containsThenInsertIfNew_fst!_eq_containsThenInsertIfNew_fst, containsThenInsertIfNew_fst h]
+  rw [containsThenInsertIfNew!_fst_eq_containsThenInsertIfNew_fst, containsThenInsertIfNew_fst h]
 
 theorem containsThenInsertIfNew_snd [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsertIfNew k v h.balanced).2.impl = (t.insertIfNew k v h.balanced).impl := by
   rw [containsThenInsertIfNew_snd_eq_insertIfNew]
 
-theorem containsThenInsertIfNew_snd! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+theorem containsThenInsertIfNew!_snd [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsertIfNew! k v).2 = t.insertIfNew! k v := by
-  rw [containsThenInsertIfNew_snd!_eq_containsThenInsertIfNew_snd _ h.balanced, containsThenInsertIfNew_snd h,
+  rw [containsThenInsertIfNew!_snd_eq_containsThenInsertIfNew_snd _ h.balanced, containsThenInsertIfNew_snd h,
     insertIfNew_eq_insertIfNew!]
 
 theorem contains_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β k} :

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -298,6 +298,41 @@ theorem size_le_size_erase! [TransOrd α] (h : t.WF) {k : α} :
     t.size ≤ (t.erase! k).size + 1 := by
   simp_to_model [erase!] using List.length_le_length_eraseKey
 
+theorem fst_containsThenInsert [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.containsThenInsert k v h.balanced).1 = t.contains k := by
+  rw [fst_containsThenInsert_eq_containsₘ, contains_eq_containsₘ]
+  exact h.ordered
+
+theorem fst_containsThenInsert! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.containsThenInsert! k v).1 = t.contains k := by
+  rw [fst_containsThenInsert!_eq_fst_containsThenInsert, fst_containsThenInsert h]
+
+theorem snd_containsThenInsert [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.containsThenInsert k v h.balanced).2.impl = (t.insert k v h.balanced).impl := by
+  rfl
+
+theorem snd_containsThenInsert! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.containsThenInsert! k v).2 = t.insert! k v := by
+  rw [snd_containsThenInsert!_eq_snd_containsThenInsert _ h.balanced, snd_containsThenInsert h,
+    insert_eq_insert!]
+
+theorem fst_containsThenInsertIfNew [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.containsThenInsertIfNew k v h.balanced).1 = t.contains k := by
+  rw [fst_containsThenInsertIfNew_eq_containsₘ, contains_eq_containsₘ]
+
+theorem fst_containsThenInsertIfNew! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.containsThenInsertIfNew! k v).1 = t.contains k := by
+  rw [fst_containsThenInsertIfNew!_eq_fst_containsThenInsertIfNew, fst_containsThenInsertIfNew h]
+
+theorem snd_containsThenInsertIfNew [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.containsThenInsertIfNew k v h.balanced).2.impl = (t.insertIfNew k v h.balanced).impl := by
+  rw [snd_containsThenInsertIfNew_eq_insertIfNew]
+
+theorem snd_containsThenInsertIfNew! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.containsThenInsertIfNew! k v).2 = t.insertIfNew! k v := by
+  rw [snd_containsThenInsertIfNew!_eq_snd_containsThenInsertIfNew _ h.balanced, snd_containsThenInsertIfNew h,
+    insertIfNew_eq_insertIfNew!]
+
 theorem contains_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
     (t.insertIfNew k v h.balanced).impl.contains a = (k == a || t.contains a) := by
   simp_to_model [insertIfNew] using List.containsKey_insertEntryIfNew

--- a/src/Std/Data/DTreeMap/Internal/Model.lean
+++ b/src/Std/Data/DTreeMap/Internal/Model.lean
@@ -407,23 +407,23 @@ theorem erase!_eq_eraseₘ [Ord α] {k : α} {t : Impl α β} (h : t.Balanced) :
     erase! k t = eraseₘ k t h := by
   rw [← erase_eq_erase! (h := h), erase_eq_eraseₘ]
 
-theorem fst_containsThenInsert!_eq_containsThenInsert [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+theorem fst_containsThenInsert!_eq_fst_containsThenInsert [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
     (t.containsThenInsert! a b).1 = (t.containsThenInsert a b htb).1 := by
   cases t <;> simp [containsThenInsert, containsThenInsert.size,
     containsThenInsert!, containsThenInsert!.size, insert!_eq_insertₘ, insert_eq_insertₘ, htb]
 
-theorem snd_containsThenInsert!_eq_containsThenInsert [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+theorem snd_containsThenInsert!_eq_snd_containsThenInsert [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
     (t.containsThenInsert! a b).2 = (t.containsThenInsert a b htb).2.impl := by
   cases t <;> simp [containsThenInsert, containsThenInsert!, insert!_eq_insertₘ htb,
     insert_eq_insertₘ]
 
-theorem containsThenInsert_eq_insertₘ [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+theorem snd_containsThenInsert_eq_insertₘ [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
     (t.containsThenInsert a b htb).2.impl = t.insertₘ a b htb := by
   rw [containsThenInsert, insert_eq_insertₘ]
 
-theorem containsThenInsert!_eq_insertₘ [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+theorem snd_containsThenInsert!_eq_insertₘ [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
     (t.containsThenInsert! a b).2 = t.insertₘ a b htb := by
-  rw [snd_containsThenInsert!_eq_containsThenInsert, containsThenInsert_eq_insertₘ]
+  rw [snd_containsThenInsert!_eq_snd_containsThenInsert, snd_containsThenInsert_eq_insertₘ]
 
 theorem insertIfNew_eq_insertIfNew! [Ord α] {k : α} {v : β k} {l : Impl α β} {h} :
     (insertIfNew k v l h).impl = insertIfNew! k v l := by
@@ -432,12 +432,12 @@ theorem insertIfNew_eq_insertIfNew! [Ord α] {k : α} {v : β k} {l : Impl α β
   · rfl
   · simp [insert_eq_insert!]
 
-theorem fst_containsThenInsertIfNew!_eq_containsThenInsertIfNew [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+theorem fst_containsThenInsertIfNew!_eq_fst_containsThenInsertIfNew [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
     (t.containsThenInsertIfNew! a b).1 = (t.containsThenInsertIfNew a b htb).1 := by
   simp only [containsThenInsertIfNew!, containsThenInsertIfNew]
   split <;> rfl
 
-theorem snd_containsThenInsertIfNew!_eq_containsThenInsertIfNew [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+theorem snd_containsThenInsertIfNew!_eq_snd_containsThenInsertIfNew [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
     (t.containsThenInsertIfNew! a b).2 = (t.containsThenInsertIfNew a b htb).2.impl := by
   simp only [containsThenInsertIfNew!, containsThenInsertIfNew]
   split

--- a/src/Std/Data/DTreeMap/Internal/Model.lean
+++ b/src/Std/Data/DTreeMap/Internal/Model.lean
@@ -407,12 +407,12 @@ theorem erase!_eq_eraseₘ [Ord α] {k : α} {t : Impl α β} (h : t.Balanced) :
     erase! k t = eraseₘ k t h := by
   rw [← erase_eq_erase! (h := h), erase_eq_eraseₘ]
 
-theorem containsThenInsert_fst!_eq_containsThenInsert_fst [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+theorem containsThenInsert!_fst_eq_containsThenInsert_fst [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
     (t.containsThenInsert! a b).1 = (t.containsThenInsert a b htb).1 := by
   cases t <;> simp [containsThenInsert, containsThenInsert.size,
     containsThenInsert!, containsThenInsert!.size, insert!_eq_insertₘ, insert_eq_insertₘ, htb]
 
-theorem containsThenInsert_snd!_eq_containsThenInsert_snd [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+theorem containsThenInsert!_snd_eq_containsThenInsert_snd [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
     (t.containsThenInsert! a b).2 = (t.containsThenInsert a b htb).2.impl := by
   cases t <;> simp [containsThenInsert, containsThenInsert!, insert!_eq_insertₘ htb,
     insert_eq_insertₘ]
@@ -421,9 +421,9 @@ theorem containsThenInsert_snd_eq_insertₘ [Ord α] (t : Impl α β) (htb : t.B
     (t.containsThenInsert a b htb).2.impl = t.insertₘ a b htb := by
   rw [containsThenInsert, insert_eq_insertₘ]
 
-theorem containsThenInsert_snd!_eq_insertₘ [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+theorem containsThenInsert!_snd_eq_insertₘ [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
     (t.containsThenInsert! a b).2 = t.insertₘ a b htb := by
-  rw [containsThenInsert_snd!_eq_containsThenInsert_snd, containsThenInsert_snd_eq_insertₘ]
+  rw [containsThenInsert!_snd_eq_containsThenInsert_snd, containsThenInsert_snd_eq_insertₘ]
 
 theorem insertIfNew_eq_insertIfNew! [Ord α] {k : α} {v : β k} {l : Impl α β} {h} :
     (insertIfNew k v l h).impl = insertIfNew! k v l := by
@@ -432,12 +432,12 @@ theorem insertIfNew_eq_insertIfNew! [Ord α] {k : α} {v : β k} {l : Impl α β
   · rfl
   · simp [insert_eq_insert!]
 
-theorem containsThenInsertIfNew_fst!_eq_containsThenInsertIfNew_fst [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+theorem containsThenInsertIfNew!_fst_eq_containsThenInsertIfNew_fst [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
     (t.containsThenInsertIfNew! a b).1 = (t.containsThenInsertIfNew a b htb).1 := by
   simp only [containsThenInsertIfNew!, containsThenInsertIfNew]
   split <;> rfl
 
-theorem containsThenInsertIfNew_snd!_eq_containsThenInsertIfNew_snd [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+theorem containsThenInsertIfNew!_snd_eq_containsThenInsertIfNew_snd [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
     (t.containsThenInsertIfNew! a b).2 = (t.containsThenInsertIfNew a b htb).2.impl := by
   simp only [containsThenInsertIfNew!, containsThenInsertIfNew]
   split
@@ -454,12 +454,12 @@ theorem containsThenInsertIfNew_snd_eq_insertIfNew [Ord α] (t : Impl α β) (ht
   rw [containsThenInsertIfNew, insertIfNew]
   split <;> rfl
 
-theorem containsThenInsertIfNew_fst!_eq_containsₘ [Ord α] [TransOrd α] (t : Impl α β)
+theorem containsThenInsertIfNew!_fst_eq_containsₘ [Ord α] [TransOrd α] (t : Impl α β)
     (a : α) (b : β a) : (t.containsThenInsertIfNew! a b).1 = t.containsₘ a := by
   simp only [containsThenInsertIfNew!, contains_eq_containsₘ]
   split <;> next h => simp only [h]
 
-theorem containsThenInsertIfNew_snd!_eq_insertIfNew! [Ord α] (t : Impl α β) (a : α) (b : β a) :
+theorem containsThenInsertIfNew!_snd_eq_insertIfNew! [Ord α] (t : Impl α β) (a : α) (b : β a) :
     (t.containsThenInsertIfNew! a b).2 = t.insertIfNew! a b:= by
   rw [containsThenInsertIfNew!, insertIfNew!]
   split <;> rfl

--- a/src/Std/Data/DTreeMap/Internal/Model.lean
+++ b/src/Std/Data/DTreeMap/Internal/Model.lean
@@ -407,23 +407,23 @@ theorem erase!_eq_eraseₘ [Ord α] {k : α} {t : Impl α β} (h : t.Balanced) :
     erase! k t = eraseₘ k t h := by
   rw [← erase_eq_erase! (h := h), erase_eq_eraseₘ]
 
-theorem fst_containsThenInsert!_eq_fst_containsThenInsert [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+theorem containsThenInsert_fst!_eq_containsThenInsert_fst [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
     (t.containsThenInsert! a b).1 = (t.containsThenInsert a b htb).1 := by
   cases t <;> simp [containsThenInsert, containsThenInsert.size,
     containsThenInsert!, containsThenInsert!.size, insert!_eq_insertₘ, insert_eq_insertₘ, htb]
 
-theorem snd_containsThenInsert!_eq_snd_containsThenInsert [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+theorem containsThenInsert_snd!_eq_containsThenInsert_snd [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
     (t.containsThenInsert! a b).2 = (t.containsThenInsert a b htb).2.impl := by
   cases t <;> simp [containsThenInsert, containsThenInsert!, insert!_eq_insertₘ htb,
     insert_eq_insertₘ]
 
-theorem snd_containsThenInsert_eq_insertₘ [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+theorem containsThenInsert_snd_eq_insertₘ [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
     (t.containsThenInsert a b htb).2.impl = t.insertₘ a b htb := by
   rw [containsThenInsert, insert_eq_insertₘ]
 
-theorem snd_containsThenInsert!_eq_insertₘ [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+theorem containsThenInsert_snd!_eq_insertₘ [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
     (t.containsThenInsert! a b).2 = t.insertₘ a b htb := by
-  rw [snd_containsThenInsert!_eq_snd_containsThenInsert, snd_containsThenInsert_eq_insertₘ]
+  rw [containsThenInsert_snd!_eq_containsThenInsert_snd, containsThenInsert_snd_eq_insertₘ]
 
 theorem insertIfNew_eq_insertIfNew! [Ord α] {k : α} {v : β k} {l : Impl α β} {h} :
     (insertIfNew k v l h).impl = insertIfNew! k v l := by
@@ -432,34 +432,34 @@ theorem insertIfNew_eq_insertIfNew! [Ord α] {k : α} {v : β k} {l : Impl α β
   · rfl
   · simp [insert_eq_insert!]
 
-theorem fst_containsThenInsertIfNew!_eq_fst_containsThenInsertIfNew [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+theorem containsThenInsertIfNew_fst!_eq_containsThenInsertIfNew_fst [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
     (t.containsThenInsertIfNew! a b).1 = (t.containsThenInsertIfNew a b htb).1 := by
   simp only [containsThenInsertIfNew!, containsThenInsertIfNew]
   split <;> rfl
 
-theorem snd_containsThenInsertIfNew!_eq_snd_containsThenInsertIfNew [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+theorem containsThenInsertIfNew_snd!_eq_containsThenInsertIfNew_snd [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
     (t.containsThenInsertIfNew! a b).2 = (t.containsThenInsertIfNew a b htb).2.impl := by
   simp only [containsThenInsertIfNew!, containsThenInsertIfNew]
   split
   · rfl
   · simp [insert!_eq_insertₘ, insert_eq_insertₘ, htb]
 
-theorem fst_containsThenInsertIfNew_eq_containsₘ [Ord α] [TransOrd α] (t : Impl α β) (htb : t.Balanced)
+theorem containsThenInsertIfNew_fst_eq_containsₘ [Ord α] [TransOrd α] (t : Impl α β) (htb : t.Balanced)
     (a : α) (b : β a) : (t.containsThenInsertIfNew a b htb).1 = t.containsₘ a := by
   simp only [containsThenInsertIfNew, contains_eq_containsₘ]
   split <;> next h => simp only [h]
 
-theorem snd_containsThenInsertIfNew_eq_insertIfNew [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
+theorem containsThenInsertIfNew_snd_eq_insertIfNew [Ord α] (t : Impl α β) (htb : t.Balanced) (a : α) (b : β a) :
     (t.containsThenInsertIfNew a b htb).2 = (t.insertIfNew a b htb) := by
   rw [containsThenInsertIfNew, insertIfNew]
   split <;> rfl
 
-theorem fst_containsThenInsertIfNew!_eq_containsₘ [Ord α] [TransOrd α] (t : Impl α β)
+theorem containsThenInsertIfNew_fst!_eq_containsₘ [Ord α] [TransOrd α] (t : Impl α β)
     (a : α) (b : β a) : (t.containsThenInsertIfNew! a b).1 = t.containsₘ a := by
   simp only [containsThenInsertIfNew!, contains_eq_containsₘ]
   split <;> next h => simp only [h]
 
-theorem snd_containsThenInsertIfNew!_eq_insertIfNew! [Ord α] (t : Impl α β) (a : α) (b : β a) :
+theorem containsThenInsertIfNew_snd!_eq_insertIfNew! [Ord α] (t : Impl α β) (a : α) (b : β a) :
     (t.containsThenInsertIfNew! a b).2 = t.insertIfNew! a b:= by
   rw [containsThenInsertIfNew!, insertIfNew!]
   split <;> rfl

--- a/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
@@ -728,12 +728,12 @@ theorem toListModel_containsThenInsert [Ord α] [TransOrd α] {k : α} {v : β k
 
 theorem WF.containsThenInsert! [Ord α] [TransOrd α] {k : α} {v : β k} {t : Impl α β} (h : t.WF) :
     (t.containsThenInsert! k v).2.WF := by
-  simpa [containsThenInsert_snd!_eq_containsThenInsert_snd, h.balanced] using WF.containsThenInsert (h := h.balanced) h
+  simpa [containsThenInsert!_snd_eq_containsThenInsert_snd, h.balanced] using WF.containsThenInsert (h := h.balanced) h
 
 theorem toListModel_containsThenInsert! [Ord α] [TransOrd α] {k : α} {v : β k} {t : Impl α β}
     (htb : t.Balanced) (hto : t.Ordered) :
     (t.containsThenInsert! k v).2.toListModel.Perm (insertEntry k v t.toListModel) := by
-  rw [containsThenInsert_snd!_eq_insertₘ]
+  rw [containsThenInsert!_snd_eq_insertₘ]
   exact toListModel_insertₘ htb hto
 
 /-!
@@ -791,11 +791,11 @@ theorem toListModel_containsThenInsertIfNew [Ord α] [TransOrd α] {k : α} {v :
 
 theorem ordered_containsThenInsertIfNew! [Ord α] [TransOrd α] {k : α} {v : β k} {l : Impl α β}
     (h : l.Balanced) (ho : l.Ordered) : (l.containsThenInsertIfNew! k v).2.Ordered := by
-  simpa [containsThenInsertIfNew_snd!_eq_insertIfNew!] using ordered_insertIfNew! h ho
+  simpa [containsThenInsertIfNew!_snd_eq_insertIfNew!] using ordered_insertIfNew! h ho
 
 theorem WF.containsThenInsertIfNew! [Ord α] [TransOrd α] {k : α} {v : β k} {l : Impl α β}
     (h : l.WF) : (l.containsThenInsertIfNew! k v).2.WF := by
-  simpa [containsThenInsertIfNew_snd!_eq_insertIfNew!] using WF.insertIfNew! (h := h)
+  simpa [containsThenInsertIfNew!_snd_eq_insertIfNew!] using WF.insertIfNew! (h := h)
 
 theorem toListModel_containsThenInsertIfNew! [Ord α] [TransOrd α] {k : α} {v : β k} {t : Impl α β}
     (htb : t.Balanced) (hto : t.Ordered) :

--- a/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
@@ -704,7 +704,7 @@ theorem size_containsThenInsert_eq_size [Ord α] (t : Impl α β) :
     containsThenInsert.size t = t.size := by
   induction t <;> rfl
 
-theorem containsThenInsert_eq_containsₘ [Ord α] [TransOrd α] (t : Impl α β) (htb : t.Balanced)
+theorem fst_containsThenInsert_eq_containsₘ [Ord α] [TransOrd α] (t : Impl α β) (htb : t.Balanced)
     (ho : t.Ordered) (a : α) (b : β a) :
     (t.containsThenInsert a b htb).1 = t.containsₘ a := by
   simp [containsThenInsert, size_containsThenInsert_eq_size, size_eq_length, htb,
@@ -714,12 +714,12 @@ theorem containsThenInsert_eq_containsₘ [Ord α] [TransOrd α] (t : Impl α β
 
 theorem ordered_containsThenInsert [Ord α] [TransOrd α] {k : α} {v : β k} {t : Impl α β}
     (htb : t.Balanced) (hto : t.Ordered) : (t.containsThenInsert k v htb).2.impl.Ordered := by
-  simpa only [containsThenInsert_eq_insertₘ, hto] using ordered_insertₘ htb hto
+  simpa only [snd_containsThenInsert_eq_insertₘ, hto] using ordered_insertₘ htb hto
 
 theorem toListModel_containsThenInsert [Ord α] [TransOrd α] {k : α} {v : β k} {t : Impl α β}
     (htb : t.Balanced) (hto : t.Ordered) :
     (t.containsThenInsert k v htb).2.impl.toListModel.Perm (insertEntry k v t.toListModel) := by
-  rw [containsThenInsert_eq_insertₘ]
+  rw [snd_containsThenInsert_eq_insertₘ]
   exact toListModel_insertₘ htb hto
 
 /-!
@@ -728,12 +728,12 @@ theorem toListModel_containsThenInsert [Ord α] [TransOrd α] {k : α} {v : β k
 
 theorem WF.containsThenInsert! [Ord α] [TransOrd α] {k : α} {v : β k} {t : Impl α β} (h : t.WF) :
     (t.containsThenInsert! k v).2.WF := by
-  simpa [snd_containsThenInsert!_eq_containsThenInsert, h.balanced] using WF.containsThenInsert (h := h.balanced) h
+  simpa [snd_containsThenInsert!_eq_snd_containsThenInsert, h.balanced] using WF.containsThenInsert (h := h.balanced) h
 
 theorem toListModel_containsThenInsert! [Ord α] [TransOrd α] {k : α} {v : β k} {t : Impl α β}
     (htb : t.Balanced) (hto : t.Ordered) :
     (t.containsThenInsert! k v).2.toListModel.Perm (insertEntry k v t.toListModel) := by
-  rw [containsThenInsert!_eq_insertₘ]
+  rw [snd_containsThenInsert!_eq_insertₘ]
   exact toListModel_insertₘ htb hto
 
 /-!

--- a/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
@@ -704,7 +704,7 @@ theorem size_containsThenInsert_eq_size [Ord α] (t : Impl α β) :
     containsThenInsert.size t = t.size := by
   induction t <;> rfl
 
-theorem fst_containsThenInsert_eq_containsₘ [Ord α] [TransOrd α] (t : Impl α β) (htb : t.Balanced)
+theorem containsThenInsert_fst_eq_containsₘ [Ord α] [TransOrd α] (t : Impl α β) (htb : t.Balanced)
     (ho : t.Ordered) (a : α) (b : β a) :
     (t.containsThenInsert a b htb).1 = t.containsₘ a := by
   simp [containsThenInsert, size_containsThenInsert_eq_size, size_eq_length, htb,
@@ -714,12 +714,12 @@ theorem fst_containsThenInsert_eq_containsₘ [Ord α] [TransOrd α] (t : Impl �
 
 theorem ordered_containsThenInsert [Ord α] [TransOrd α] {k : α} {v : β k} {t : Impl α β}
     (htb : t.Balanced) (hto : t.Ordered) : (t.containsThenInsert k v htb).2.impl.Ordered := by
-  simpa only [snd_containsThenInsert_eq_insertₘ, hto] using ordered_insertₘ htb hto
+  simpa only [containsThenInsert_snd_eq_insertₘ, hto] using ordered_insertₘ htb hto
 
 theorem toListModel_containsThenInsert [Ord α] [TransOrd α] {k : α} {v : β k} {t : Impl α β}
     (htb : t.Balanced) (hto : t.Ordered) :
     (t.containsThenInsert k v htb).2.impl.toListModel.Perm (insertEntry k v t.toListModel) := by
-  rw [snd_containsThenInsert_eq_insertₘ]
+  rw [containsThenInsert_snd_eq_insertₘ]
   exact toListModel_insertₘ htb hto
 
 /-!
@@ -728,12 +728,12 @@ theorem toListModel_containsThenInsert [Ord α] [TransOrd α] {k : α} {v : β k
 
 theorem WF.containsThenInsert! [Ord α] [TransOrd α] {k : α} {v : β k} {t : Impl α β} (h : t.WF) :
     (t.containsThenInsert! k v).2.WF := by
-  simpa [snd_containsThenInsert!_eq_snd_containsThenInsert, h.balanced] using WF.containsThenInsert (h := h.balanced) h
+  simpa [containsThenInsert_snd!_eq_containsThenInsert_snd, h.balanced] using WF.containsThenInsert (h := h.balanced) h
 
 theorem toListModel_containsThenInsert! [Ord α] [TransOrd α] {k : α} {v : β k} {t : Impl α β}
     (htb : t.Balanced) (hto : t.Ordered) :
     (t.containsThenInsert! k v).2.toListModel.Perm (insertEntry k v t.toListModel) := by
-  rw [snd_containsThenInsert!_eq_insertₘ]
+  rw [containsThenInsert_snd!_eq_insertₘ]
   exact toListModel_insertₘ htb hto
 
 /-!
@@ -777,12 +777,12 @@ theorem toListModel_insertIfNew! [Ord α] [TransOrd α] {k : α} {v : β k} {l :
 
 theorem ordered_containsThenInsertIfNew [Ord α] [TransOrd α] {k : α} {v : β k} {l : Impl α β}
     (h : l.Balanced) (ho : l.Ordered) : (l.containsThenInsertIfNew k v h).2.impl.Ordered := by
-  simpa only [snd_containsThenInsertIfNew_eq_insertIfNew, h] using ordered_insertIfNew h ho
+  simpa only [containsThenInsertIfNew_snd_eq_insertIfNew, h] using ordered_insertIfNew h ho
 
 theorem toListModel_containsThenInsertIfNew [Ord α] [TransOrd α] {k : α} {v : β k} {t : Impl α β}
     (htb : t.Balanced) (hto : t.Ordered) :
     (t.containsThenInsertIfNew k v htb).2.impl.toListModel.Perm (insertEntryIfNew k v t.toListModel) := by
-  rw [snd_containsThenInsertIfNew_eq_insertIfNew]
+  rw [containsThenInsertIfNew_snd_eq_insertIfNew]
   exact toListModel_insertIfNew htb hto
 
 /-!
@@ -791,16 +791,16 @@ theorem toListModel_containsThenInsertIfNew [Ord α] [TransOrd α] {k : α} {v :
 
 theorem ordered_containsThenInsertIfNew! [Ord α] [TransOrd α] {k : α} {v : β k} {l : Impl α β}
     (h : l.Balanced) (ho : l.Ordered) : (l.containsThenInsertIfNew! k v).2.Ordered := by
-  simpa [snd_containsThenInsertIfNew!_eq_insertIfNew!] using ordered_insertIfNew! h ho
+  simpa [containsThenInsertIfNew_snd!_eq_insertIfNew!] using ordered_insertIfNew! h ho
 
 theorem WF.containsThenInsertIfNew! [Ord α] [TransOrd α] {k : α} {v : β k} {l : Impl α β}
     (h : l.WF) : (l.containsThenInsertIfNew! k v).2.WF := by
-  simpa [snd_containsThenInsertIfNew!_eq_insertIfNew!] using WF.insertIfNew! (h := h)
+  simpa [containsThenInsertIfNew_snd!_eq_insertIfNew!] using WF.insertIfNew! (h := h)
 
 theorem toListModel_containsThenInsertIfNew! [Ord α] [TransOrd α] {k : α} {v : β k} {t : Impl α β}
     (htb : t.Balanced) (hto : t.Ordered) :
     (t.containsThenInsertIfNew k v htb).2.impl.toListModel.Perm (insertEntryIfNew k v t.toListModel) := by
-  rw [snd_containsThenInsertIfNew_eq_insertIfNew]
+  rw [containsThenInsertIfNew_snd_eq_insertIfNew]
   exact toListModel_insertIfNew htb hto
 
 /-!

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -180,24 +180,24 @@ theorem size_le_size_erase [TransCmp cmp] {k : α} :
   Impl.size_le_size_erase t.wf
 
 @[simp]
-theorem fst_containsThenInsert [TransCmp cmp] {k : α} {v : β k} :
+theorem containsThenInsert_fst [TransCmp cmp] {k : α} {v : β k} :
     (t.containsThenInsert k v).1 = t.contains k :=
-  Impl.fst_containsThenInsert t.wf
+  Impl.containsThenInsert_fst t.wf
 
 @[simp]
-theorem snd_containsThenInsert [TransCmp cmp] {k : α} {v : β k} :
+theorem containsThenInsert_snd [TransCmp cmp] {k : α} {v : β k} :
     (t.containsThenInsert k v).2 = t.insert k v :=
-  ext <| Impl.snd_containsThenInsert t.wf
+  ext <| Impl.containsThenInsert_snd t.wf
 
 @[simp]
-theorem fst_containsThenInsertIfNew [TransCmp cmp] {k : α} {v : β k} :
+theorem containsThenInsertIfNew_fst [TransCmp cmp] {k : α} {v : β k} :
     (t.containsThenInsertIfNew k v).1 = t.contains k :=
-  Impl.fst_containsThenInsertIfNew t.wf
+  Impl.containsThenInsertIfNew_fst t.wf
 
 @[simp]
-theorem snd_containsThenInsertIfNew [TransCmp cmp] {k : α} {v : β k} :
+theorem containsThenInsertIfNew_snd [TransCmp cmp] {k : α} {v : β k} :
     (t.containsThenInsertIfNew k v).2 = t.insertIfNew k v :=
-  ext <| Impl.snd_containsThenInsertIfNew t.wf
+  ext <| Impl.containsThenInsertIfNew_snd t.wf
 
 @[simp]
 theorem contains_insertIfNew [TransCmp cmp] {k a : α} {v : β k} :

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -180,6 +180,26 @@ theorem size_le_size_erase [TransCmp cmp] {k : α} :
   Impl.size_le_size_erase t.wf
 
 @[simp]
+theorem fst_containsThenInsert [TransCmp cmp] {k : α} {v : β k} :
+    (t.containsThenInsert k v).1 = t.contains k :=
+  Impl.fst_containsThenInsert t.wf
+
+@[simp]
+theorem snd_containsThenInsert [TransCmp cmp] {k : α} {v : β k} :
+    (t.containsThenInsert k v).2 = t.insert k v :=
+  ext <| Impl.snd_containsThenInsert t.wf
+
+@[simp]
+theorem fst_containsThenInsertIfNew [TransCmp cmp] {k : α} {v : β k} :
+    (t.containsThenInsertIfNew k v).1 = t.contains k :=
+  Impl.fst_containsThenInsertIfNew t.wf
+
+@[simp]
+theorem snd_containsThenInsertIfNew [TransCmp cmp] {k : α} {v : β k} :
+    (t.containsThenInsertIfNew k v).2 = t.insertIfNew k v :=
+  ext <| Impl.snd_containsThenInsertIfNew t.wf
+
+@[simp]
 theorem contains_insertIfNew [TransCmp cmp] {k a : α} {v : β k} :
     (t.insertIfNew k v).contains a = (cmp k a == .eq || t.contains a) :=
   Impl.contains_insertIfNew t.wf

--- a/src/Std/Data/DTreeMap/RawLemmas.lean
+++ b/src/Std/Data/DTreeMap/RawLemmas.lean
@@ -180,6 +180,26 @@ theorem size_le_size_erase [TransCmp cmp] (h : t.WF) {k : α} :
   Impl.size_le_size_erase! h
 
 @[simp]
+theorem fst_containsThenInsert [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
+    (t.containsThenInsert k v).1 = t.contains k :=
+  Impl.fst_containsThenInsert! h
+
+@[simp]
+theorem snd_containsThenInsert [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
+    (t.containsThenInsert k v).2 = t.insert k v :=
+  ext <| Impl.snd_containsThenInsert! h
+
+@[simp]
+theorem fst_containsThenInsertIfNew [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
+    (t.containsThenInsertIfNew k v).1 = t.contains k :=
+  Impl.fst_containsThenInsertIfNew! h
+
+@[simp]
+theorem snd_containsThenInsertIfNew [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
+    (t.containsThenInsertIfNew k v).2 = t.insertIfNew k v :=
+  ext <| Impl.snd_containsThenInsertIfNew! h
+
+@[simp]
 theorem contains_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :
     (t.insertIfNew k v).contains a = (cmp k a == .eq || t.contains a) :=
   Impl.contains_insertIfNew! h

--- a/src/Std/Data/DTreeMap/RawLemmas.lean
+++ b/src/Std/Data/DTreeMap/RawLemmas.lean
@@ -182,22 +182,22 @@ theorem size_le_size_erase [TransCmp cmp] (h : t.WF) {k : α} :
 @[simp]
 theorem containsThenInsert_fst [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsert k v).1 = t.contains k :=
-  Impl.containsThenInsert_fst! h
+  Impl.containsThenInsert!_fst h
 
 @[simp]
 theorem containsThenInsert_snd [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsert k v).2 = t.insert k v :=
-  ext <| Impl.containsThenInsert_snd! h
+  ext <| Impl.containsThenInsert!_snd h
 
 @[simp]
 theorem containsThenInsertIfNew_fst [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsertIfNew k v).1 = t.contains k :=
-  Impl.containsThenInsertIfNew_fst! h
+  Impl.containsThenInsertIfNew!_fst h
 
 @[simp]
 theorem containsThenInsertIfNew_snd [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsertIfNew k v).2 = t.insertIfNew k v :=
-  ext <| Impl.containsThenInsertIfNew_snd! h
+  ext <| Impl.containsThenInsertIfNew!_snd h
 
 @[simp]
 theorem contains_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :

--- a/src/Std/Data/DTreeMap/RawLemmas.lean
+++ b/src/Std/Data/DTreeMap/RawLemmas.lean
@@ -180,24 +180,24 @@ theorem size_le_size_erase [TransCmp cmp] (h : t.WF) {k : α} :
   Impl.size_le_size_erase! h
 
 @[simp]
-theorem fst_containsThenInsert [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
+theorem containsThenInsert_fst [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsert k v).1 = t.contains k :=
-  Impl.fst_containsThenInsert! h
+  Impl.containsThenInsert_fst! h
 
 @[simp]
-theorem snd_containsThenInsert [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
+theorem containsThenInsert_snd [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsert k v).2 = t.insert k v :=
-  ext <| Impl.snd_containsThenInsert! h
+  ext <| Impl.containsThenInsert_snd! h
 
 @[simp]
-theorem fst_containsThenInsertIfNew [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
+theorem containsThenInsertIfNew_fst [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsertIfNew k v).1 = t.contains k :=
-  Impl.fst_containsThenInsertIfNew! h
+  Impl.containsThenInsertIfNew_fst! h
 
 @[simp]
-theorem snd_containsThenInsertIfNew [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
+theorem containsThenInsertIfNew_snd [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
     (t.containsThenInsertIfNew k v).2 = t.insertIfNew k v :=
-  ext <| Impl.snd_containsThenInsertIfNew! h
+  ext <| Impl.containsThenInsertIfNew_snd! h
 
 @[simp]
 theorem contains_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β k} :

--- a/src/Std/Data/HashMap/Lemmas.lean
+++ b/src/Std/Data/HashMap/Lemmas.lean
@@ -190,40 +190,22 @@ theorem size_le_size_erase [EquivBEq α] [LawfulHashable α] {k : α} :
   DHashMap.size_le_size_erase
 
 @[simp]
-theorem fst_containsThenInsert {k : α} {v : β} : (m.containsThenInsert k v).1 = m.contains k :=
-  DHashMap.fst_containsThenInsert
-
-@[simp, deprecated fst_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_fst {k : α} {v : β} : (m.containsThenInsert k v).1 = m.contains k :=
-  fst_containsThenInsert
+  DHashMap.containsThenInsert_fst
 
 @[simp]
-theorem snd_containsThenInsert {k : α} {v : β} : (m.containsThenInsert k v).2 = m.insert k v :=
-  ext (DHashMap.snd_containsThenInsert)
-
-@[simp, deprecated snd_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_snd {k : α} {v : β} : (m.containsThenInsert k v).2 = m.insert k v :=
-  snd_containsThenInsert
+  ext (DHashMap.containsThenInsert_snd)
 
 @[simp]
-theorem fst_containsThenInsertIfNew {k : α} {v : β} :
-    (m.containsThenInsertIfNew k v).1 = m.contains k :=
-  DHashMap.fst_containsThenInsertIfNew
-
-@[simp, deprecated fst_containsThenInsertIfNew (since := "2025-02-20")]
 theorem containsThenInsertIfNew_fst {k : α} {v : β} :
     (m.containsThenInsertIfNew k v).1 = m.contains k :=
-  fst_containsThenInsertIfNew
+  DHashMap.containsThenInsertIfNew_fst
 
 @[simp]
-theorem snd_containsThenInsertIfNew {k : α} {v : β} :
-    (m.containsThenInsertIfNew k v).2 = m.insertIfNew k v :=
-  ext DHashMap.snd_containsThenInsertIfNew
-
-@[simp, deprecated snd_containsThenInsertIfNew (since := "2025-02-20")]
 theorem containsThenInsertIfNew_snd {k : α} {v : β} :
     (m.containsThenInsertIfNew k v).2 = m.insertIfNew k v :=
-  snd_containsThenInsertIfNew
+  ext DHashMap.containsThenInsertIfNew_snd
 
 @[simp]
 theorem getElem?_empty {a : α} {c} : (empty c : HashMap α β)[a]? = none :=

--- a/src/Std/Data/HashMap/Lemmas.lean
+++ b/src/Std/Data/HashMap/Lemmas.lean
@@ -190,22 +190,40 @@ theorem size_le_size_erase [EquivBEq α] [LawfulHashable α] {k : α} :
   DHashMap.size_le_size_erase
 
 @[simp]
+theorem fst_containsThenInsert {k : α} {v : β} : (m.containsThenInsert k v).1 = m.contains k :=
+  DHashMap.fst_containsThenInsert
+
+@[simp, deprecated fst_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_fst {k : α} {v : β} : (m.containsThenInsert k v).1 = m.contains k :=
-  DHashMap.containsThenInsert_fst
+  fst_containsThenInsert
 
 @[simp]
+theorem snd_containsThenInsert {k : α} {v : β} : (m.containsThenInsert k v).2 = m.insert k v :=
+  ext (DHashMap.snd_containsThenInsert)
+
+@[simp, deprecated snd_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_snd {k : α} {v : β} : (m.containsThenInsert k v).2 = m.insert k v :=
-  ext (DHashMap.containsThenInsert_snd)
+  snd_containsThenInsert
 
 @[simp]
+theorem fst_containsThenInsertIfNew {k : α} {v : β} :
+    (m.containsThenInsertIfNew k v).1 = m.contains k :=
+  DHashMap.fst_containsThenInsertIfNew
+
+@[simp, deprecated fst_containsThenInsertIfNew (since := "2025-02-20")]
 theorem containsThenInsertIfNew_fst {k : α} {v : β} :
     (m.containsThenInsertIfNew k v).1 = m.contains k :=
-  DHashMap.containsThenInsertIfNew_fst
+  fst_containsThenInsertIfNew
 
 @[simp]
+theorem snd_containsThenInsertIfNew {k : α} {v : β} :
+    (m.containsThenInsertIfNew k v).2 = m.insertIfNew k v :=
+  ext DHashMap.snd_containsThenInsertIfNew
+
+@[simp, deprecated snd_containsThenInsertIfNew (since := "2025-02-20")]
 theorem containsThenInsertIfNew_snd {k : α} {v : β} :
     (m.containsThenInsertIfNew k v).2 = m.insertIfNew k v :=
-  ext DHashMap.containsThenInsertIfNew_snd
+  snd_containsThenInsertIfNew
 
 @[simp]
 theorem getElem?_empty {a : α} {c} : (empty c : HashMap α β)[a]? = none :=

--- a/src/Std/Data/HashMap/RawLemmas.lean
+++ b/src/Std/Data/HashMap/RawLemmas.lean
@@ -198,24 +198,44 @@ theorem size_le_size_erase [EquivBEq α] [LawfulHashable α] (h : m.WF) {k : α}
   DHashMap.Raw.size_le_size_erase h.out
 
 @[simp]
-theorem containsThenInsert_fst (h : m.WF) {k : α} {v : β} :
+theorem fst_containsThenInsert (h : m.WF) {k : α} {v : β} :
     (m.containsThenInsert k v).1 = m.contains k :=
   DHashMap.Raw.containsThenInsert_fst h.out
 
+@[simp, deprecated fst_containsThenInsert (since := "2025-02-20")]
+theorem containsThenInsert_fst (h : m.WF) {k : α} {v : β} :
+    (m.containsThenInsert k v).1 = m.contains k :=
+  fst_containsThenInsert h
+
 @[simp]
-theorem containsThenInsert_snd (h : m.WF) {k : α} {v : β} :
+theorem snd_containsThenInsert (h : m.WF) {k : α} {v : β} :
     (m.containsThenInsert k v).2 = m.insert k v :=
   ext (DHashMap.Raw.containsThenInsert_snd h.out)
 
+@[simp, deprecated snd_containsThenInsert (since := "2025-02-20")]
+theorem containsThenInsert_snd (h : m.WF) {k : α} {v : β} :
+    (m.containsThenInsert k v).2 = m.insert k v :=
+  snd_containsThenInsert h
+
 @[simp]
-theorem containsThenInsertIfNew_fst (h : m.WF) {k : α} {v : β} :
+theorem fst_containsThenInsertIfNew (h : m.WF) {k : α} {v : β} :
     (m.containsThenInsertIfNew k v).1 = m.contains k :=
   DHashMap.Raw.containsThenInsertIfNew_fst h.out
 
+@[simp, deprecated fst_containsThenInsertIfNew (since := "2025-02-20")]
+theorem containsThenInsertIfNew_fst (h : m.WF) {k : α} {v : β} :
+    (m.containsThenInsertIfNew k v).1 = m.contains k :=
+  fst_containsThenInsertIfNew h
+
 @[simp]
-theorem containsThenInsertIfNew_snd (h : m.WF) {k : α} {v : β} :
+theorem snd_containsThenInsertIfNew (h : m.WF) {k : α} {v : β} :
     (m.containsThenInsertIfNew k v).2 = m.insertIfNew k v :=
   ext (DHashMap.Raw.containsThenInsertIfNew_snd h.out)
+
+@[simp, deprecated snd_containsThenInsertIfNew (since := "2025-02-20")]
+theorem containsThenInsertIfNew_snd (h : m.WF) {k : α} {v : β} :
+    (m.containsThenInsertIfNew k v).2 = m.insertIfNew k v :=
+  snd_containsThenInsertIfNew h
 
 @[simp]
 theorem getElem?_empty {a : α} {c} : (empty c : Raw α β)[a]? = none :=

--- a/src/Std/Data/HashMap/RawLemmas.lean
+++ b/src/Std/Data/HashMap/RawLemmas.lean
@@ -198,44 +198,24 @@ theorem size_le_size_erase [EquivBEq α] [LawfulHashable α] (h : m.WF) {k : α}
   DHashMap.Raw.size_le_size_erase h.out
 
 @[simp]
-theorem fst_containsThenInsert (h : m.WF) {k : α} {v : β} :
-    (m.containsThenInsert k v).1 = m.contains k :=
-  DHashMap.Raw.fst_containsThenInsert h.out
-
-@[simp, deprecated fst_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_fst (h : m.WF) {k : α} {v : β} :
     (m.containsThenInsert k v).1 = m.contains k :=
-  fst_containsThenInsert h
+  DHashMap.Raw.containsThenInsert_fst h.out
 
 @[simp]
-theorem snd_containsThenInsert (h : m.WF) {k : α} {v : β} :
-    (m.containsThenInsert k v).2 = m.insert k v :=
-  ext (DHashMap.Raw.snd_containsThenInsert h.out)
-
-@[simp, deprecated snd_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_snd (h : m.WF) {k : α} {v : β} :
     (m.containsThenInsert k v).2 = m.insert k v :=
-  snd_containsThenInsert h
+  ext (DHashMap.Raw.containsThenInsert_snd h.out)
 
 @[simp]
-theorem fst_containsThenInsertIfNew (h : m.WF) {k : α} {v : β} :
-    (m.containsThenInsertIfNew k v).1 = m.contains k :=
-  DHashMap.Raw.fst_containsThenInsertIfNew h.out
-
-@[simp, deprecated fst_containsThenInsertIfNew (since := "2025-02-20")]
 theorem containsThenInsertIfNew_fst (h : m.WF) {k : α} {v : β} :
     (m.containsThenInsertIfNew k v).1 = m.contains k :=
-  fst_containsThenInsertIfNew h
+  DHashMap.Raw.containsThenInsertIfNew_fst h.out
 
 @[simp]
-theorem snd_containsThenInsertIfNew (h : m.WF) {k : α} {v : β} :
-    (m.containsThenInsertIfNew k v).2 = m.insertIfNew k v :=
-  ext (DHashMap.Raw.snd_containsThenInsertIfNew h.out)
-
-@[simp, deprecated snd_containsThenInsertIfNew (since := "2025-02-20")]
 theorem containsThenInsertIfNew_snd (h : m.WF) {k : α} {v : β} :
     (m.containsThenInsertIfNew k v).2 = m.insertIfNew k v :=
-  snd_containsThenInsertIfNew h
+  ext (DHashMap.Raw.containsThenInsertIfNew_snd h.out)
 
 @[simp]
 theorem getElem?_empty {a : α} {c} : (empty c : Raw α β)[a]? = none :=

--- a/src/Std/Data/HashMap/RawLemmas.lean
+++ b/src/Std/Data/HashMap/RawLemmas.lean
@@ -200,7 +200,7 @@ theorem size_le_size_erase [EquivBEq α] [LawfulHashable α] (h : m.WF) {k : α}
 @[simp]
 theorem fst_containsThenInsert (h : m.WF) {k : α} {v : β} :
     (m.containsThenInsert k v).1 = m.contains k :=
-  DHashMap.Raw.containsThenInsert_fst h.out
+  DHashMap.Raw.fst_containsThenInsert h.out
 
 @[simp, deprecated fst_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_fst (h : m.WF) {k : α} {v : β} :
@@ -210,7 +210,7 @@ theorem containsThenInsert_fst (h : m.WF) {k : α} {v : β} :
 @[simp]
 theorem snd_containsThenInsert (h : m.WF) {k : α} {v : β} :
     (m.containsThenInsert k v).2 = m.insert k v :=
-  ext (DHashMap.Raw.containsThenInsert_snd h.out)
+  ext (DHashMap.Raw.snd_containsThenInsert h.out)
 
 @[simp, deprecated snd_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_snd (h : m.WF) {k : α} {v : β} :
@@ -220,7 +220,7 @@ theorem containsThenInsert_snd (h : m.WF) {k : α} {v : β} :
 @[simp]
 theorem fst_containsThenInsertIfNew (h : m.WF) {k : α} {v : β} :
     (m.containsThenInsertIfNew k v).1 = m.contains k :=
-  DHashMap.Raw.containsThenInsertIfNew_fst h.out
+  DHashMap.Raw.fst_containsThenInsertIfNew h.out
 
 @[simp, deprecated fst_containsThenInsertIfNew (since := "2025-02-20")]
 theorem containsThenInsertIfNew_fst (h : m.WF) {k : α} {v : β} :
@@ -230,7 +230,7 @@ theorem containsThenInsertIfNew_fst (h : m.WF) {k : α} {v : β} :
 @[simp]
 theorem snd_containsThenInsertIfNew (h : m.WF) {k : α} {v : β} :
     (m.containsThenInsertIfNew k v).2 = m.insertIfNew k v :=
-  ext (DHashMap.Raw.containsThenInsertIfNew_snd h.out)
+  ext (DHashMap.Raw.snd_containsThenInsertIfNew h.out)
 
 @[simp, deprecated snd_containsThenInsertIfNew (since := "2025-02-20")]
 theorem containsThenInsertIfNew_snd (h : m.WF) {k : α} {v : β} :

--- a/src/Std/Data/HashSet/Lemmas.lean
+++ b/src/Std/Data/HashSet/Lemmas.lean
@@ -343,20 +343,12 @@ theorem get!_eq_getD_default [EquivBEq α] [LawfulHashable α] [Inhabited α] {a
   HashMap.getKey!_eq_getKeyD_default
 
 @[simp]
-theorem fst_containsThenInsert {k : α} : (m.containsThenInsert k).1 = m.contains k :=
-  HashMap.fst_containsThenInsertIfNew
-
-@[simp, deprecated fst_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_fst {k : α} : (m.containsThenInsert k).1 = m.contains k :=
-  fst_containsThenInsert
+  HashMap.containsThenInsertIfNew_fst
 
 @[simp]
-theorem snd_containsThenInsert {k : α} : (m.containsThenInsert k).2 = m.insert k :=
-  ext HashMap.snd_containsThenInsertIfNew
-
-@[simp, deprecated snd_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_snd {k : α} : (m.containsThenInsert k).2 = m.insert k :=
-  snd_containsThenInsert
+  ext HashMap.containsThenInsertIfNew_snd
 
 @[simp]
 theorem length_toList [EquivBEq α] [LawfulHashable α] :

--- a/src/Std/Data/HashSet/Lemmas.lean
+++ b/src/Std/Data/HashSet/Lemmas.lean
@@ -343,12 +343,20 @@ theorem get!_eq_getD_default [EquivBEq α] [LawfulHashable α] [Inhabited α] {a
   HashMap.getKey!_eq_getKeyD_default
 
 @[simp]
+theorem fst_containsThenInsert {k : α} : (m.containsThenInsert k).1 = m.contains k :=
+  HashMap.fst_containsThenInsertIfNew
+
+@[simp, deprecated fst_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_fst {k : α} : (m.containsThenInsert k).1 = m.contains k :=
-  HashMap.containsThenInsertIfNew_fst
+  fst_containsThenInsert
 
 @[simp]
+theorem snd_containsThenInsert {k : α} : (m.containsThenInsert k).2 = m.insert k :=
+  ext HashMap.snd_containsThenInsertIfNew
+
+@[simp, deprecated snd_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_snd {k : α} : (m.containsThenInsert k).2 = m.insert k :=
-  ext HashMap.containsThenInsertIfNew_snd
+  snd_containsThenInsert
 
 @[simp]
 theorem length_toList [EquivBEq α] [LawfulHashable α] :

--- a/src/Std/Data/HashSet/RawLemmas.lean
+++ b/src/Std/Data/HashSet/RawLemmas.lean
@@ -359,12 +359,20 @@ theorem get!_eq_getD_default [EquivBEq α] [LawfulHashable α] [Inhabited α] (h
   HashMap.Raw.getKey!_eq_getKeyD_default h.out
 
 @[simp]
+theorem fst_containsThenInsert (h : m.WF) {k : α} : (m.containsThenInsert k).1 = m.contains k :=
+  HashMap.Raw.fst_containsThenInsertIfNew h.out
+
+@[simp, deprecated fst_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_fst (h : m.WF) {k : α} : (m.containsThenInsert k).1 = m.contains k :=
-  HashMap.Raw.containsThenInsertIfNew_fst h.out
+  fst_containsThenInsert h
 
 @[simp]
+theorem snd_containsThenInsert (h : m.WF) {k : α} : (m.containsThenInsert k).2 = m.insert k :=
+  ext (HashMap.Raw.snd_containsThenInsertIfNew h.out)
+
+@[simp, deprecated snd_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_snd (h : m.WF) {k : α} : (m.containsThenInsert k).2 = m.insert k :=
-  ext (HashMap.Raw.containsThenInsertIfNew_snd h.out)
+  snd_containsThenInsert h
 
 @[simp]
 theorem length_toList [EquivBEq α] [LawfulHashable α] (h : m.WF) :

--- a/src/Std/Data/HashSet/RawLemmas.lean
+++ b/src/Std/Data/HashSet/RawLemmas.lean
@@ -359,20 +359,12 @@ theorem get!_eq_getD_default [EquivBEq α] [LawfulHashable α] [Inhabited α] (h
   HashMap.Raw.getKey!_eq_getKeyD_default h.out
 
 @[simp]
-theorem fst_containsThenInsert (h : m.WF) {k : α} : (m.containsThenInsert k).1 = m.contains k :=
-  HashMap.Raw.fst_containsThenInsertIfNew h.out
-
-@[simp, deprecated fst_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_fst (h : m.WF) {k : α} : (m.containsThenInsert k).1 = m.contains k :=
-  fst_containsThenInsert h
+  HashMap.Raw.containsThenInsertIfNew_fst h.out
 
 @[simp]
-theorem snd_containsThenInsert (h : m.WF) {k : α} : (m.containsThenInsert k).2 = m.insert k :=
-  ext (HashMap.Raw.snd_containsThenInsertIfNew h.out)
-
-@[simp, deprecated snd_containsThenInsert (since := "2025-02-20")]
 theorem containsThenInsert_snd (h : m.WF) {k : α} : (m.containsThenInsert k).2 = m.insert k :=
-  snd_containsThenInsert h
+  ext (HashMap.Raw.containsThenInsertIfNew_snd h.out)
 
 @[simp]
 theorem length_toList [EquivBEq α] [LawfulHashable α] (h : m.WF) :

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -178,6 +178,26 @@ theorem size_le_size_erase [TransCmp cmp] {k : α} :
   DTreeMap.size_le_size_erase
 
 @[simp]
+theorem fst_containsThenInsert [TransCmp cmp] {k : α} {v : β} :
+    (t.containsThenInsert k v).1 = t.contains k :=
+  DTreeMap.fst_containsThenInsert
+
+@[simp]
+theorem snd_containsThenInsert [TransCmp cmp] {k : α} {v : β} :
+    (t.containsThenInsert k v).2 = t.insert k v :=
+  ext <| DTreeMap.snd_containsThenInsert
+
+@[simp]
+theorem fst_containsThenInsertIfNew [TransCmp cmp] {k : α} {v : β} :
+    (t.containsThenInsertIfNew k v).1 = t.contains k :=
+  DTreeMap.fst_containsThenInsertIfNew
+
+@[simp]
+theorem snd_containsThenInsertIfNew [TransCmp cmp] {k : α} {v : β} :
+    (t.containsThenInsertIfNew k v).2 = t.insertIfNew k v :=
+  ext <| DTreeMap.snd_containsThenInsertIfNew
+
+@[simp]
 theorem contains_insertIfNew [TransCmp cmp] {k a : α} {v : β} :
     (t.insertIfNew k v).contains a = (cmp k a == .eq || t.contains a) :=
   DTreeMap.contains_insertIfNew

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -178,24 +178,24 @@ theorem size_le_size_erase [TransCmp cmp] {k : α} :
   DTreeMap.size_le_size_erase
 
 @[simp]
-theorem fst_containsThenInsert [TransCmp cmp] {k : α} {v : β} :
+theorem containsThenInsert_fst [TransCmp cmp] {k : α} {v : β} :
     (t.containsThenInsert k v).1 = t.contains k :=
-  DTreeMap.fst_containsThenInsert
+  DTreeMap.containsThenInsert_fst
 
 @[simp]
-theorem snd_containsThenInsert [TransCmp cmp] {k : α} {v : β} :
+theorem containsThenInsert_snd [TransCmp cmp] {k : α} {v : β} :
     (t.containsThenInsert k v).2 = t.insert k v :=
-  ext <| DTreeMap.snd_containsThenInsert
+  ext <| DTreeMap.containsThenInsert_snd
 
 @[simp]
-theorem fst_containsThenInsertIfNew [TransCmp cmp] {k : α} {v : β} :
+theorem containsThenInsertIfNew_fst [TransCmp cmp] {k : α} {v : β} :
     (t.containsThenInsertIfNew k v).1 = t.contains k :=
-  DTreeMap.fst_containsThenInsertIfNew
+  DTreeMap.containsThenInsertIfNew_fst
 
 @[simp]
-theorem snd_containsThenInsertIfNew [TransCmp cmp] {k : α} {v : β} :
+theorem containsThenInsertIfNew_snd [TransCmp cmp] {k : α} {v : β} :
     (t.containsThenInsertIfNew k v).2 = t.insertIfNew k v :=
-  ext <| DTreeMap.snd_containsThenInsertIfNew
+  ext <| DTreeMap.containsThenInsertIfNew_snd
 
 @[simp]
 theorem contains_insertIfNew [TransCmp cmp] {k a : α} {v : β} :

--- a/src/Std/Data/TreeMap/RawLemmas.lean
+++ b/src/Std/Data/TreeMap/RawLemmas.lean
@@ -178,6 +178,26 @@ theorem size_le_size_erase [TransCmp cmp] (h : t.WF) {k : α} :
   DTreeMap.Raw.size_le_size_erase h
 
 @[simp]
+theorem fst_containsThenInsert [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+    (t.containsThenInsert k v).1 = t.contains k :=
+  DTreeMap.Raw.fst_containsThenInsert h
+
+@[simp]
+theorem snd_containsThenInsert [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+    (t.containsThenInsert k v).2 = t.insert k v :=
+  ext <| DTreeMap.Raw.snd_containsThenInsert h
+
+@[simp]
+theorem fst_containsThenInsertIfNew [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+    (t.containsThenInsertIfNew k v).1 = t.contains k :=
+  DTreeMap.Raw.fst_containsThenInsertIfNew h
+
+@[simp]
+theorem snd_containsThenInsertIfNew [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+    (t.containsThenInsertIfNew k v).2 = t.insertIfNew k v :=
+  ext <| DTreeMap.Raw.snd_containsThenInsertIfNew h
+
+@[simp]
 theorem contains_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β} :
     (t.insertIfNew k v).contains a = (cmp k a == .eq || t.contains a) :=
   DTreeMap.Raw.contains_insertIfNew h

--- a/src/Std/Data/TreeMap/RawLemmas.lean
+++ b/src/Std/Data/TreeMap/RawLemmas.lean
@@ -178,24 +178,24 @@ theorem size_le_size_erase [TransCmp cmp] (h : t.WF) {k : α} :
   DTreeMap.Raw.size_le_size_erase h
 
 @[simp]
-theorem fst_containsThenInsert [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+theorem containsThenInsert_fst [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
     (t.containsThenInsert k v).1 = t.contains k :=
-  DTreeMap.Raw.fst_containsThenInsert h
+  DTreeMap.Raw.containsThenInsert_fst h
 
 @[simp]
-theorem snd_containsThenInsert [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+theorem containsThenInsert_snd [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
     (t.containsThenInsert k v).2 = t.insert k v :=
-  ext <| DTreeMap.Raw.snd_containsThenInsert h
+  ext <| DTreeMap.Raw.containsThenInsert_snd h
 
 @[simp]
-theorem fst_containsThenInsertIfNew [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+theorem containsThenInsertIfNew_fst [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
     (t.containsThenInsertIfNew k v).1 = t.contains k :=
-  DTreeMap.Raw.fst_containsThenInsertIfNew h
+  DTreeMap.Raw.containsThenInsertIfNew_fst h
 
 @[simp]
-theorem snd_containsThenInsertIfNew [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+theorem containsThenInsertIfNew_snd [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
     (t.containsThenInsertIfNew k v).2 = t.insertIfNew k v :=
-  ext <| DTreeMap.Raw.snd_containsThenInsertIfNew h
+  ext <| DTreeMap.Raw.containsThenInsertIfNew_snd h
 
 @[simp]
 theorem contains_insertIfNew [TransCmp cmp] (h : t.WF) {k a : α} {v : β} :

--- a/src/Std/Data/TreeSet/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Lemmas.lean
@@ -173,13 +173,13 @@ theorem size_le_size_erase [TransCmp cmp] {k : α} :
   TreeMap.size_le_size_erase
 
 @[simp]
-theorem fst_containsThenInsert [TransCmp cmp] {k : α} :
+theorem containsThenInsert_fst [TransCmp cmp] {k : α} :
     (t.containsThenInsert k).1 = t.contains k :=
-  TreeMap.fst_containsThenInsertIfNew
+  TreeMap.containsThenInsertIfNew_fst
 
 @[simp]
-theorem snd_containsThenInsert [TransCmp cmp] {k : α} :
+theorem containsThenInsert_snd [TransCmp cmp] {k : α} :
     (t.containsThenInsert k).2 = t.insert k :=
-  ext <| TreeMap.snd_containsThenInsertIfNew
+  ext <| TreeMap.containsThenInsertIfNew_snd
 
 end Std.TreeSet

--- a/src/Std/Data/TreeSet/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Lemmas.lean
@@ -172,4 +172,14 @@ theorem size_le_size_erase [TransCmp cmp] {k : α} :
     t.size ≤ (t.erase k).size + 1 :=
   TreeMap.size_le_size_erase
 
+@[simp]
+theorem fst_containsThenInsert [TransCmp cmp] {k : α} :
+    (t.containsThenInsert k).1 = t.contains k :=
+  TreeMap.fst_containsThenInsertIfNew
+
+@[simp]
+theorem snd_containsThenInsert [TransCmp cmp] {k : α} :
+    (t.containsThenInsert k).2 = t.insert k :=
+  ext <| TreeMap.snd_containsThenInsertIfNew
+
 end Std.TreeSet

--- a/src/Std/Data/TreeSet/RawLemmas.lean
+++ b/src/Std/Data/TreeSet/RawLemmas.lean
@@ -173,12 +173,12 @@ theorem size_le_size_erase [TransCmp cmp] (h : t.WF) {k : α} :
   TreeMap.Raw.size_le_size_erase h
 
 @[simp]
-theorem fst_containsThenInsert [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+theorem fst_containsThenInsert [TransCmp cmp] (h : t.WF) {k : α} :
     (t.containsThenInsert k).1 = t.contains k :=
   TreeMap.Raw.fst_containsThenInsertIfNew h
 
 @[simp]
-theorem snd_containsThenInsert [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+theorem snd_containsThenInsert [TransCmp cmp] (h : t.WF) {k : α} :
     (t.containsThenInsert k).2 = t.insert k :=
   ext <| TreeMap.Raw.snd_containsThenInsertIfNew h
 

--- a/src/Std/Data/TreeSet/RawLemmas.lean
+++ b/src/Std/Data/TreeSet/RawLemmas.lean
@@ -172,4 +172,14 @@ theorem size_le_size_erase [TransCmp cmp] (h : t.WF) {k : α} :
     t.size ≤ (t.erase k).size + 1 :=
   TreeMap.Raw.size_le_size_erase h
 
+@[simp]
+theorem fst_containsThenInsert [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+    (t.containsThenInsert k).1 = t.contains k :=
+  TreeMap.Raw.fst_containsThenInsertIfNew h
+
+@[simp]
+theorem snd_containsThenInsert [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+    (t.containsThenInsert k).2 = t.insert k :=
+  ext <| TreeMap.Raw.snd_containsThenInsertIfNew h
+
 end Std.TreeSet.Raw

--- a/src/Std/Data/TreeSet/RawLemmas.lean
+++ b/src/Std/Data/TreeSet/RawLemmas.lean
@@ -173,13 +173,13 @@ theorem size_le_size_erase [TransCmp cmp] (h : t.WF) {k : α} :
   TreeMap.Raw.size_le_size_erase h
 
 @[simp]
-theorem fst_containsThenInsert [TransCmp cmp] (h : t.WF) {k : α} :
+theorem containsThenInsert_fst [TransCmp cmp] (h : t.WF) {k : α} :
     (t.containsThenInsert k).1 = t.contains k :=
-  TreeMap.Raw.fst_containsThenInsertIfNew h
+  TreeMap.Raw.containsThenInsertIfNew_fst h
 
 @[simp]
-theorem snd_containsThenInsert [TransCmp cmp] (h : t.WF) {k : α} :
+theorem containsThenInsert_snd [TransCmp cmp] (h : t.WF) {k : α} :
     (t.containsThenInsert k).2 = t.insert k :=
-  ext <| TreeMap.Raw.snd_containsThenInsertIfNew h
+  ext <| TreeMap.Raw.containsThenInsertIfNew_snd h
 
 end Std.TreeSet.Raw


### PR DESCRIPTION
This PR provides tree map lemmas about the interaction of `containsThenInsert(IfNew)` with `contains` and `insert(IfNew)`.