### PR TITLE
feat: tree map lemmas for get, get! and getD

### DIFF
--- a/src/Std/Data/DTreeMap/Basic.lean
+++ b/src/Std/Data/DTreeMap/Basic.lean
@@ -634,7 +634,7 @@ def getThenInsertIfNew? (t : DTreeMap α β cmp) (a : α) (b : β) :
 
 @[inline, inherit_doc DTreeMap.get?]
 def get? (t : DTreeMap α β cmp) (a : α) : Option β :=
-  letI : Ord α := ⟨cmp⟩; Impl.Const.get? a t.inner
+  letI : Ord α := ⟨cmp⟩; Impl.Const.get? t.inner a
 
 @[inline, inherit_doc get?, deprecated get? (since := "2025-02-12")]
 def find? (t : DTreeMap α β cmp) (a : α) : Option β :=
@@ -642,11 +642,11 @@ def find? (t : DTreeMap α β cmp) (a : α) : Option β :=
 
 @[inline, inherit_doc DTreeMap.get]
 def get (t : DTreeMap α β cmp) (a : α) (h : a ∈ t) : β :=
-  letI : Ord α := ⟨cmp⟩; Impl.Const.get a t.inner h
+  letI : Ord α := ⟨cmp⟩; Impl.Const.get t.inner a h
 
 @[inline, inherit_doc DTreeMap.get!]
 def get! (t : DTreeMap α β cmp) (a : α) [Inhabited β] : β :=
-  letI : Ord α := ⟨cmp⟩; Impl.Const.get! a t.inner
+  letI : Ord α := ⟨cmp⟩; Impl.Const.get! t.inner a
 
 @[inline, inherit_doc get!, deprecated get! (since := "2025-02-12")]
 def find! (t : DTreeMap α β cmp) (a : α) [Inhabited β] : β :=
@@ -654,7 +654,7 @@ def find! (t : DTreeMap α β cmp) (a : α) [Inhabited β] : β :=
 
 @[inline, inherit_doc DTreeMap.getD]
 def getD (t : DTreeMap α β cmp) (a : α) (fallback : β) : β :=
-  letI : Ord α := ⟨cmp⟩; Impl.Const.getD a t.inner fallback
+  letI : Ord α := ⟨cmp⟩; Impl.Const.getD t.inner a fallback
 
 @[inline, inherit_doc getD, deprecated getD (since := "2025-02-12")]
 def findD (t : DTreeMap α β cmp) (a : α) (fallback : β) : β :=

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -627,9 +627,13 @@ theorem get!_insert_self [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} [Inh
     (t.insert a b h.balanced).impl.get! a = b := by
   simp_to_model [insert] using List.getValueCast!_insertEntry_self
 
-theorem get!_eq_default [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} [Inhabited (β a)] :
-    t.contains a = false → t.get! a = default := by
+theorem get!_eq_default_of_contains_eq_false [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α}
+    [Inhabited (β a)] : t.contains a = false → t.get! a = default := by
   simp_to_model using List.getValueCast!_eq_default
+
+theorem get!_eq_default [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} [Inhabited (β a)] :
+    ¬ a ∈ t → t.get! a = default := by
+  simpa [mem_iff_contains] using get!_eq_default_of_contains_eq_false h
 
 theorem get!_erase [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} [Inhabited (β a)] :
     (t.erase k h.balanced).impl.get! a = if compare k a = .eq then default else t.get! a := by
@@ -639,9 +643,13 @@ theorem get!_erase_self [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k : α} [Inha
     (t.erase k h.balanced).impl.get! k = default := by
   simp_to_model [erase] using List.getValueCast!_eraseKey_self
 
-theorem get?_eq_some_get! [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} [Inhabited (β a)] :
+theorem get?_eq_some_get!_of_contains [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} [Inhabited (β a)] :
     t.contains a = true → t.get? a = some (t.get! a) := by
   simp_to_model using List.getValueCast?_eq_some_getValueCast!
+
+theorem get?_eq_some_get! [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} [Inhabited (β a)] :
+    a ∈ t → t.get? a = some (t.get! a) := by
+  simpa [mem_iff_contains] using get?_eq_some_get!_of_contains h
 
 theorem get!_eq_get!_get? [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} [Inhabited (β a)] :
     t.get! a = (t.get? a).get! := by
@@ -671,9 +679,13 @@ theorem get!_insert_self [TransOrd α] [Inhabited β] (h : t.WF) {k : α}
     {v : β} : get! (t.insert k v h.balanced).impl k = v := by
   simp_to_model [insert] using List.getValue!_insertEntry_self
 
-theorem get!_eq_default [TransOrd α] [Inhabited β] (h : t.WF) {a : α} :
+theorem get!_eq_default_of_contains_eq_false [TransOrd α] [Inhabited β] (h : t.WF) {a : α} :
     t.contains a = false → get! t a = default := by
   simp_to_model using List.getValue!_eq_default
+
+theorem get!_eq_default [TransOrd α] [Inhabited β] (h : t.WF) {a : α} :
+    ¬ a ∈ t → get! t a = default := by
+  simpa [mem_iff_contains] using get!_eq_default_of_contains_eq_false h
 
 theorem get!_erase [TransOrd α] [Inhabited β] (h : t.WF) {k a : α} :
     get! (t.erase k h.balanced).impl a = if compare k a = .eq then default else get! t a := by
@@ -683,9 +695,13 @@ theorem get!_erase_self [TransOrd α] [Inhabited β] (h : t.WF) {k : α} :
     get! (t.erase k h.balanced).impl k = default := by
   simp_to_model [erase] using List.getValue!_eraseKey_self
 
-theorem get?_eq_some_get! [TransOrd α] [Inhabited β] (h : t.WF) {a : α} :
+theorem get?_eq_some_get!_of_contains [TransOrd α] [Inhabited β] (h : t.WF) {a : α} :
     t.contains a = true → get? t a = some (get! t a) := by
   simp_to_model using List.getValue?_eq_some_getValue!
+
+theorem get?_eq_some_get! [TransOrd α] [Inhabited β] (h : t.WF) {a : α} :
+    a ∈ t → get? t a = some (get! t a) := by
+  simpa [mem_iff_contains] using get?_eq_some_get!_of_contains h
 
 theorem get!_eq_get!_get? [TransOrd α] [Inhabited β] (h : t.WF) {a : α} :
     get! t a = (get? t a).get! := by
@@ -724,9 +740,13 @@ theorem getD_insert_self [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} {fal
     (t.insert a b h.balanced).impl.getD a fallback = b := by
   simp_to_model [insert] using List.getValueCastD_insertEntry_self
 
-theorem getD_eq_fallback [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} {fallback : β a} :
+theorem getD_eq_fallback_of_contains_eq_false [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} {fallback : β a} :
     t.contains a = false → t.getD a fallback = fallback := by
   simp_to_model using List.getValueCastD_eq_fallback
+
+theorem getD_eq_fallback [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} {fallback : β a} :
+    ¬ a ∈ t → t.getD a fallback = fallback := by
+  simpa [mem_iff_contains] using getD_eq_fallback_of_contains_eq_false h
 
 theorem getD_erase [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {fallback : β a} :
     (t.erase k h.balanced).impl.getD a fallback = if compare k a = .eq then fallback else t.getD a fallback := by
@@ -736,9 +756,13 @@ theorem getD_erase_self [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k : α} {fall
     (t.erase k h.balanced).impl.getD k fallback = fallback := by
   simp_to_model [erase] using List.getValueCastD_eraseKey_self
 
-theorem get?_eq_some_getD [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} {fallback : β a} :
+theorem get?_eq_some_getD_of_contains [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} {fallback : β a} :
     t.contains a = true → t.get? a = some (t.getD a fallback) := by
   simp_to_model using List.getValueCast?_eq_some_getValueCastD
+
+theorem get?_eq_some_getD [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} {fallback : β a} :
+    a ∈ t → t.get? a = some (t.getD a fallback) := by
+  simpa [mem_iff_contains] using get?_eq_some_getD_of_contains h
 
 theorem getD_eq_getD_get? [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} {fallback : β a} :
     t.getD a fallback = (t.get? a).getD fallback := by
@@ -772,9 +796,13 @@ theorem getD_insert_self [TransOrd α] (h : t.WF) {k : α} {fallback v : β} :
     getD (t.insert k v h.balanced).impl k fallback = v := by
   simp_to_model [insert] using List.getValueD_insertEntry_self
 
-theorem getD_eq_fallback [TransOrd α] (h : t.WF) {a : α} {fallback : β} :
+theorem getD_eq_fallback_of_contains_eq_false [TransOrd α] (h : t.WF) {a : α} {fallback : β} :
     t.contains a = false → getD t a fallback = fallback := by
   simp_to_model using List.getValueD_eq_fallback
+
+theorem getD_eq_fallback [TransOrd α] (h : t.WF) {a : α} {fallback : β} :
+    ¬ a ∈ t → getD t a fallback = fallback := by
+  simpa [mem_iff_contains] using getD_eq_fallback_of_contains_eq_false h
 
 theorem getD_erase [TransOrd α] (h : t.WF) {k a : α} {fallback : β} :
     getD (t.erase k h.balanced).impl a fallback = if compare k a = .eq then
@@ -787,9 +815,13 @@ theorem getD_erase_self [TransOrd α] (h : t.WF) {k : α} {fallback : β} :
     getD (t.erase k h.balanced).impl k fallback = fallback := by
   simp_to_model [erase] using List.getValueD_eraseKey_self
 
-theorem get?_eq_some_getD [TransOrd α] (h : t.WF) {a : α} {fallback : β} :
+theorem get?_eq_some_getD_of_contains [TransOrd α] (h : t.WF) {a : α} {fallback : β} :
     t.contains a = true → get? t a = some (getD t a fallback) := by
   simp_to_model using List.getValue?_eq_some_getValueD
+
+theorem get?_eq_some_getD [TransOrd α] (h : t.WF) {a : α} {fallback : β} :
+    a ∈ t → get? t a = some (getD t a fallback) := by
+  simpa [mem_iff_contains] using get?_eq_some_getD_of_contains h
 
 theorem getD_eq_getD_get? [TransOrd α] (h : t.WF) {a : α} {fallback : β} :
     getD t a fallback = (get? t a).getD fallback := by

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -490,68 +490,68 @@ namespace Const
 
 variable {β : Type v} {t : Impl α β}
 
-theorem get?_empty [TransOrd α] {a : α} : get? a (empty : Impl α β) = none := by
+theorem get?_empty [TransOrd α] {a : α} : get? (empty : Impl α β) a = none := by
   simp_to_model using List.getValue?_nil
 
 theorem get?_of_isEmpty [TransOrd α] (h : t.WF) {a : α} :
-    t.isEmpty = true → get? a t = none := by
+    t.isEmpty = true → get? t a = none := by
   simp_to_model; empty
 
 theorem get?_insert [TransOrd α] (h : t.WF) {a k : α} {v : β} :
-    get? a (t.insert k v h.balanced).impl =
-      if compare k a = .eq then some v else get? a t := by
+    get? (t.insert k v h.balanced).impl a =
+      if compare k a = .eq then some v else get? t a := by
   simp_to_model [insert] using List.getValue?_insertEntry
 
 theorem get?_insert! [TransOrd α] (h : t.WF) {a k : α} {v : β} :
-    get? a (t.insert! k v) =
-      if compare k a = .eq then some v else get? a t := by
+    get? (t.insert! k v) a =
+      if compare k a = .eq then some v else get? t a := by
   simp_to_model [insert!] using List.getValue?_insertEntry
 
 theorem get?_insert_self [TransOrd α] (h : t.WF) {k : α} {v : β} :
-    get? k (t.insert k v h.balanced).impl = some v := by
+    get? (t.insert k v h.balanced).impl k = some v := by
   simp_to_model [insert] using List.getValue?_insertEntry_self
 
 theorem get?_insert!_self [TransOrd α] (h : t.WF) {k : α} {v : β} :
-    get? k (t.insert! k v) = some v := by
+    get? (t.insert! k v) k = some v := by
   simp_to_model [insert!] using List.getValue?_insertEntry_self
 
 theorem contains_eq_isSome_get? [TransOrd α] (h : t.WF) {a : α} :
-    t.contains a = (get? a t).isSome := by
+    t.contains a = (get? t a).isSome := by
   simp_to_model using List.containsKey_eq_isSome_getValue?
 
 theorem mem_iff_isSome_get? [TransOrd α] (h : t.WF) {a : α} :
-    a ∈ t ↔ (get? a t).isSome := by
+    a ∈ t ↔ (get? t a).isSome := by
   simpa [mem_iff_contains] using contains_eq_isSome_get? h
 
 theorem get?_eq_none_of_contains_eq_false [TransOrd α] (h : t.WF) {a : α} :
-    t.contains a = false → get? a t = none := by
+    t.contains a = false → get? t a = none := by
   simp_to_model using List.getValue?_eq_none.mpr
 
 theorem get?_eq_none [TransOrd α] (h : t.WF) {a : α} :
-    ¬ a ∈ t → get? a t = none := by
+    ¬ a ∈ t → get? t a = none := by
   simpa [mem_iff_contains] using get?_eq_none_of_contains_eq_false h
 
 theorem get?_erase [TransOrd α] (h : t.WF) {k a : α} :
-    get? a (t.erase k h.balanced).impl = if compare k a = .eq then none else get? a t := by
+    get? (t.erase k h.balanced).impl a = if compare k a = .eq then none else get? t a := by
   simp_to_model [erase] using List.getValue?_eraseKey
 
 theorem get?_erase! [TransOrd α] (h : t.WF) {k a : α} :
-    get? a (t.erase! k) = if compare k a = .eq then none else get? a t := by
+    get? (t.erase! k) a = if compare k a = .eq then none else get? t a := by
   simp_to_model [erase!] using List.getValue?_eraseKey
 
 theorem get?_erase_self [TransOrd α] (h : t.WF) {k : α} :
-    get? k (t.erase k h.balanced).impl = none := by
+    get? (t.erase k h.balanced).impl k = none := by
   simp_to_model [erase] using List.getValue?_eraseKey_self
 
 theorem get?_erase!_self [TransOrd α] (h : t.WF) {k : α} :
-    get? k (t.erase! k) = none := by
+    get? (t.erase! k) k = none := by
   simp_to_model [erase!] using List.getValue?_eraseKey_self
 
-theorem get?_eq_get? [LawfulEqOrd α] [TransOrd α] (h : t.WF) {a : α} : get? a t = t.get? a := by
+theorem get?_eq_get? [LawfulEqOrd α] [TransOrd α] (h : t.WF) {a : α} : get? t a = t.get? a := by
   simp_to_model using List.getValue?_eq_getValueCast?
 
 theorem get?_congr [TransOrd α] (h : t.WF) {a b : α} (hab : compare a b = .eq) :
-    get? a t = get? b t := by
+    get? t a = get? t b := by
   revert hab
   simp_to_model using List.getValue?_congr
 
@@ -582,36 +582,36 @@ namespace Const
 variable {β : Type v} {t : Impl α β} (h : t.WF)
 
 theorem get_insert [TransOrd α] (h : t.WF) {k a : α} {v : β} {h₁} :
-    get a (t.insert k v h.balanced).impl h₁ =
+    get (t.insert k v h.balanced).impl a h₁ =
       if h₂ : compare k a = .eq then v
-      else get a t (contains_of_contains_insert h h₁ h₂) := by
+      else get t a (contains_of_contains_insert h h₁ h₂) := by
   simp_to_model [insert] using List.getValue_insertEntry
 
 theorem get_insert_self [TransOrd α] (h : t.WF) {k : α} {v : β} :
-    get k (t.insert k v h.balanced).impl (contains_insert_self h) = v := by
+    get (t.insert k v h.balanced).impl k (contains_insert_self h) = v := by
   simp_to_model [insert] using List.getValue_insertEntry_self
 
 @[simp]
 theorem get_erase [TransOrd α] (h : t.WF) {k a : α} {h'} :
-    get a (t.erase k h.balanced).impl h' = get a t (contains_of_contains_erase h h') := by
+    get (t.erase k h.balanced).impl a h' = get t a (contains_of_contains_erase h h') := by
   simp_to_model [erase] using List.getValue_eraseKey
 
 theorem get?_eq_some_get [TransOrd α] (h : t.WF) {a : α} {h} :
-    get? a t = some (get a t h) := by
+    get? t a = some (get t a h) := by
   simp_to_model using List.getValue?_eq_some_getValue
 
-theorem get_eq_get [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} {h} : get a t h = t.get a h := by
+theorem get_eq_get [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} {h} : get t a h = t.get a h := by
   simp_to_model using List.getValue_eq_getValueCast
 
 theorem get_congr [TransOrd α] (h : t.WF) {a b : α} (hab : compare a b = .eq) {h'} :
-    get a t h' = get b t ((contains_congr h hab).symm.trans h') := by
+    get t a h' = get t b ((contains_congr h hab).symm.trans h') := by
   revert hab h'
   simp_to_model using List.getValue_congr
 
 end Const
 
 theorem get!_empty [TransOrd α] [LawfulEqOrd α] {a : α} [Inhabited (β a)] :
-    get! a (empty : Impl α β) = default := by
+    get! (empty : Impl α β) a = default := by
   simp_to_model using List.getValueCast!_nil
 
 theorem get!_of_isEmpty [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} [Inhabited (β a)] :
@@ -656,51 +656,51 @@ namespace Const
 variable {β : Type v} (t : Impl α β) (h : t.WF)
 
 theorem get!_empty [TransOrd α] [Inhabited β] {a : α} :
-    get! a (empty : Impl α β) = default := by
+    get! (empty : Impl α β) a = default := by
   simp_to_model using List.getValue!_nil
 
 theorem get!_of_isEmpty [TransOrd α] [Inhabited β] (h : t.WF) {a : α} :
-    t.isEmpty = true → get! a t = default := by
+    t.isEmpty = true → get! t a = default := by
   simp_to_model; empty
 
 theorem get!_insert [TransOrd α] [Inhabited β] (h : t.WF) {k a : α} {v : β} :
-    get! a (t.insert k v h.balanced).impl = if compare k a = .eq then v else get! a t := by
+    get! (t.insert k v h.balanced).impl a = if compare k a = .eq then v else get! t a := by
   simp_to_model [insert] using List.getValue!_insertEntry
 
 theorem get!_insert_self [TransOrd α] [Inhabited β] (h : t.WF) {k : α}
-    {v : β} : get! k (t.insert k v h.balanced).impl = v := by
+    {v : β} : get! (t.insert k v h.balanced).impl k = v := by
   simp_to_model [insert] using List.getValue!_insertEntry_self
 
 theorem get!_eq_default [TransOrd α] [Inhabited β] (h : t.WF) {a : α} :
-    t.contains a = false → get! a t = default := by
+    t.contains a = false → get! t a = default := by
   simp_to_model using List.getValue!_eq_default
 
 theorem get!_erase [TransOrd α] [Inhabited β] (h : t.WF) {k a : α} :
-    get! a (t.erase k h.balanced).impl = if compare k a = .eq then default else get! a t := by
+    get! (t.erase k h.balanced).impl a = if compare k a = .eq then default else get! t a := by
   simp_to_model [erase] using List.getValue!_eraseKey
 
 theorem get!_erase_self [TransOrd α] [Inhabited β] (h : t.WF) {k : α} :
-    get! k (t.erase k h.balanced).impl = default := by
+    get! (t.erase k h.balanced).impl k = default := by
   simp_to_model [erase] using List.getValue!_eraseKey_self
 
 theorem get?_eq_some_get! [TransOrd α] [Inhabited β] (h : t.WF) {a : α} :
-    t.contains a = true → get? a t = some (get! a t) := by
+    t.contains a = true → get? t a = some (get! t a) := by
   simp_to_model using List.getValue?_eq_some_getValue!
 
 theorem get!_eq_get!_get? [TransOrd α] [Inhabited β] (h : t.WF) {a : α} :
-    get! a t = (get? a t).get! := by
+    get! t a = (get? t a).get! := by
   simp_to_model using List.getValue!_eq_getValue?
 
 theorem get_eq_get! [TransOrd α] [Inhabited β] (h : t.WF) {a : α} {h} :
-    get a t h = get! a t := by
+    get t a h = get! t a := by
   simp_to_model using List.getValue_eq_getValue!
 
 theorem get!_eq_get! [TransOrd α] [LawfulEqOrd α] [Inhabited β] (h : t.WF) {a : α} :
-    get! a t = t.get! a := by
+    get! t a = t.get! a := by
   simp_to_model using List.getValue!_eq_getValueCast!
 
 theorem get!_congr [TransOrd α] [Inhabited β] (h : t.WF) {a b : α}
-    (hab : compare a b = .eq) : get! a t = get! b t := by
+    (hab : compare a b = .eq) : get! t a = get! t b := by
   revert hab
   simp_to_model using List.getValue!_congr
 
@@ -757,58 +757,58 @@ namespace Const
 variable {β : Type v} (t : Impl α β) (h : t.WF)
 
 theorem getD_empty [TransOrd α] {a : α} {fallback : β} :
-    getD a (empty : Impl α β) fallback = fallback := by
+    getD (empty : Impl α β) a fallback = fallback := by
   simp_to_model using List.getValueD_nil
 
 theorem getD_of_isEmpty [TransOrd α] (h : t.WF) {a : α} {fallback : β} :
-    t.isEmpty = true → getD a t fallback = fallback := by
+    t.isEmpty = true → getD t a fallback = fallback := by
   simp_to_model; empty
 
 theorem getD_insert [TransOrd α] (h : t.WF) {k a : α} {fallback v : β} :
-    getD a (t.insert k v h.balanced).impl fallback = if compare k a = .eq then v else getD a t fallback := by
+    getD (t.insert k v h.balanced).impl a fallback = if compare k a = .eq then v else getD t a fallback := by
   simp_to_model [insert] using List.getValueD_insertEntry
 
 theorem getD_insert_self [TransOrd α] (h : t.WF) {k : α} {fallback v : β} :
-    getD k (t.insert k v h.balanced).impl fallback = v := by
+    getD (t.insert k v h.balanced).impl k fallback = v := by
   simp_to_model [insert] using List.getValueD_insertEntry_self
 
 theorem getD_eq_fallback [TransOrd α] (h : t.WF) {a : α} {fallback : β} :
-    t.contains a = false → getD a t fallback = fallback := by
+    t.contains a = false → getD t a fallback = fallback := by
   simp_to_model using List.getValueD_eq_fallback
 
 theorem getD_erase [TransOrd α] (h : t.WF) {k a : α} {fallback : β} :
-    getD a (t.erase k h.balanced).impl fallback = if compare k a = .eq then
+    getD (t.erase k h.balanced).impl a fallback = if compare k a = .eq then
       fallback
     else
-      getD a t fallback := by
+      getD t a fallback := by
   simp_to_model [erase] using List.getValueD_eraseKey
 
 theorem getD_erase_self [TransOrd α] (h : t.WF) {k : α} {fallback : β} :
-    getD k (t.erase k h.balanced).impl fallback = fallback := by
+    getD (t.erase k h.balanced).impl k fallback = fallback := by
   simp_to_model [erase] using List.getValueD_eraseKey_self
 
 theorem get?_eq_some_getD [TransOrd α] (h : t.WF) {a : α} {fallback : β} :
-    t.contains a = true → get? a t = some (getD a t fallback) := by
+    t.contains a = true → get? t a = some (getD t a fallback) := by
   simp_to_model using List.getValue?_eq_some_getValueD
 
 theorem getD_eq_getD_get? [TransOrd α] (h : t.WF) {a : α} {fallback : β} :
-    getD a t fallback = (get? a t).getD fallback := by
+    getD t a fallback = (get? t a).getD fallback := by
   simp_to_model using List.getValueD_eq_getValue?
 
 theorem get_eq_getD [TransOrd α] (h : t.WF) {a : α} {fallback : β} {h} :
-    get a t h = getD a t fallback := by
+    get t a h = getD t a fallback := by
   simp_to_model using List.getValue_eq_getValueD
 
 theorem get!_eq_getD_default [TransOrd α] [Inhabited β] (h : t.WF) {a : α} :
-    get! a t = getD a t default := by
+    get! t a = getD t a default := by
   simp_to_model using List.getValue!_eq_getValueD_default
 
 theorem getD_eq_getD [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} {fallback : β} :
-    getD a t fallback = t.getD a fallback := by
+    getD t a fallback = t.getD a fallback := by
   simp_to_model using List.getValueD_eq_getValueCastD
 
 theorem getD_congr [TransOrd α] (h : t.WF) {a b : α} {fallback : β}
-    (hab : compare a b = .eq) : getD a t fallback = getD b t fallback := by
+    (hab : compare a b = .eq) : getD t a fallback = getD t b fallback := by
   revert hab
   simp_to_model using List.getValueD_congr
 

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -565,14 +565,30 @@ theorem get_insert [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {v : β 
         t.get a (contains_of_contains_insert h h₁ h₂) := by
   simp_to_model [insert] using List.getValueCast_insertEntry
 
+theorem get_insert! [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {v : β k} {h₁} :
+    (t.insert! k v).get a h₁ =
+      if h₂ : compare k a = .eq then
+        cast (congrArg β (compare_eq_iff_eq.mp h₂)) v
+      else
+        t.get a (contains_of_contains_insert! h h₁ h₂) := by
+  simp_to_model [insert!] using List.getValueCast_insertEntry
+
 theorem get_insert_self [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.insert k v h.balanced).impl.get k (contains_insert_self h) = v := by
   simp_to_model [insert] using List.getValueCast_insertEntry_self
+
+theorem get_insert!_self [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k : α} {v : β k} :
+    (t.insert! k v).get k (contains_insert!_self h) = v := by
+  simp_to_model [insert!] using List.getValueCast_insertEntry_self
 
 @[simp]
 theorem get_erase [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {h'} :
     (t.erase k h.balanced).impl.get a h' = t.get a (contains_of_contains_erase h h') := by
   simp_to_model [erase] using List.getValueCast_eraseKey
+
+theorem get_erase! [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {h'} :
+    (t.erase! k).get a h' = t.get a (contains_of_contains_erase! h h') := by
+  simp_to_model [erase!] using List.getValueCast_eraseKey
 
 theorem get?_eq_some_get [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} {h'} : t.get? a = some (t.get a h') := by
   simp_to_model using List.getValueCast?_eq_some_getValueCast
@@ -587,14 +603,28 @@ theorem get_insert [TransOrd α] (h : t.WF) {k a : α} {v : β} {h₁} :
       else get t a (contains_of_contains_insert h h₁ h₂) := by
   simp_to_model [insert] using List.getValue_insertEntry
 
+theorem get_insert! [TransOrd α] (h : t.WF) {k a : α} {v : β} {h₁} :
+    get (t.insert! k v) a h₁ =
+      if h₂ : compare k a = .eq then v
+      else get t a (contains_of_contains_insert! h h₁ h₂) := by
+  simp_to_model [insert!] using List.getValue_insertEntry
+
 theorem get_insert_self [TransOrd α] (h : t.WF) {k : α} {v : β} :
     get (t.insert k v h.balanced).impl k (contains_insert_self h) = v := by
   simp_to_model [insert] using List.getValue_insertEntry_self
+
+theorem get_insert!_self [TransOrd α] (h : t.WF) {k : α} {v : β} :
+    get (t.insert! k v) k (contains_insert!_self h) = v := by
+  simp_to_model [insert!] using List.getValue_insertEntry_self
 
 @[simp]
 theorem get_erase [TransOrd α] (h : t.WF) {k a : α} {h'} :
     get (t.erase k h.balanced).impl a h' = get t a (contains_of_contains_erase h h') := by
   simp_to_model [erase] using List.getValue_eraseKey
+
+theorem get_erase! [TransOrd α] (h : t.WF) {k a : α} {h'} :
+    get (t.erase! k) a h' = get t a (contains_of_contains_erase! h h') := by
+  simp_to_model [erase!] using List.getValue_eraseKey
 
 theorem get?_eq_some_get [TransOrd α] (h : t.WF) {a : α} {h} :
     get? t a = some (get t a h) := by
@@ -623,9 +653,18 @@ theorem get!_insert [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} [Inhabi
       if h : compare k a = .eq then cast (congrArg β (compare_eq_iff_eq.mp h)) v else t.get! a := by
   simp_to_model [insert] using List.getValueCast!_insertEntry
 
+theorem get!_insert! [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} [Inhabited (β a)] {v : β k} :
+    (t.insert! k v).get! a =
+      if h : compare k a = .eq then cast (congrArg β (compare_eq_iff_eq.mp h)) v else t.get! a := by
+  simp_to_model [insert!] using List.getValueCast!_insertEntry
+
 theorem get!_insert_self [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} [Inhabited (β a)] {b : β a} :
     (t.insert a b h.balanced).impl.get! a = b := by
   simp_to_model [insert] using List.getValueCast!_insertEntry_self
+
+theorem get!_insert!_self [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} [Inhabited (β a)] {b : β a} :
+    (t.insert! a b).get! a = b := by
+  simp_to_model [insert!] using List.getValueCast!_insertEntry_self
 
 theorem get!_eq_default_of_contains_eq_false [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α}
     [Inhabited (β a)] : t.contains a = false → t.get! a = default := by
@@ -639,9 +678,17 @@ theorem get!_erase [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} [Inhabit
     (t.erase k h.balanced).impl.get! a = if compare k a = .eq then default else t.get! a := by
   simp_to_model [erase] using List.getValueCast!_eraseKey
 
+theorem get!_erase! [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} [Inhabited (β a)] :
+    (t.erase! k).get! a = if compare k a = .eq then default else t.get! a := by
+  simp_to_model [erase!] using List.getValueCast!_eraseKey
+
 theorem get!_erase_self [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k : α} [Inhabited (β k)] :
     (t.erase k h.balanced).impl.get! k = default := by
   simp_to_model [erase] using List.getValueCast!_eraseKey_self
+
+theorem get!_erase!_self [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k : α} [Inhabited (β k)] :
+    (t.erase! k).get! k = default := by
+  simp_to_model [erase!] using List.getValueCast!_eraseKey_self
 
 theorem get?_eq_some_get!_of_contains [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} [Inhabited (β a)] :
     t.contains a = true → t.get? a = some (t.get! a) := by
@@ -675,9 +722,17 @@ theorem get!_insert [TransOrd α] [Inhabited β] (h : t.WF) {k a : α} {v : β} 
     get! (t.insert k v h.balanced).impl a = if compare k a = .eq then v else get! t a := by
   simp_to_model [insert] using List.getValue!_insertEntry
 
+theorem get!_insert! [TransOrd α] [Inhabited β] (h : t.WF) {k a : α} {v : β} :
+    get! (t.insert! k v) a = if compare k a = .eq then v else get! t a := by
+  simp_to_model [insert!] using List.getValue!_insertEntry
+
 theorem get!_insert_self [TransOrd α] [Inhabited β] (h : t.WF) {k : α}
     {v : β} : get! (t.insert k v h.balanced).impl k = v := by
   simp_to_model [insert] using List.getValue!_insertEntry_self
+
+theorem get!_insert!_self [TransOrd α] [Inhabited β] (h : t.WF) {k : α}
+    {v : β} : get! (t.insert! k v) k = v := by
+  simp_to_model [insert!] using List.getValue!_insertEntry_self
 
 theorem get!_eq_default_of_contains_eq_false [TransOrd α] [Inhabited β] (h : t.WF) {a : α} :
     t.contains a = false → get! t a = default := by
@@ -691,9 +746,17 @@ theorem get!_erase [TransOrd α] [Inhabited β] (h : t.WF) {k a : α} :
     get! (t.erase k h.balanced).impl a = if compare k a = .eq then default else get! t a := by
   simp_to_model [erase] using List.getValue!_eraseKey
 
+theorem get!_erase! [TransOrd α] [Inhabited β] (h : t.WF) {k a : α} :
+    get! (t.erase! k) a = if compare k a = .eq then default else get! t a := by
+  simp_to_model [erase!] using List.getValue!_eraseKey
+
 theorem get!_erase_self [TransOrd α] [Inhabited β] (h : t.WF) {k : α} :
     get! (t.erase k h.balanced).impl k = default := by
   simp_to_model [erase] using List.getValue!_eraseKey_self
+
+theorem get!_erase!_self [TransOrd α] [Inhabited β] (h : t.WF) {k : α} :
+    get! (t.erase! k) k = default := by
+  simp_to_model [erase!] using List.getValue!_eraseKey_self
 
 theorem get?_eq_some_get!_of_contains [TransOrd α] [Inhabited β] (h : t.WF) {a : α} :
     t.contains a = true → get? t a = some (get! t a) := by
@@ -736,9 +799,20 @@ theorem getD_insert [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {fallba
       else t.getD a fallback := by
   simp_to_model [insert] using List.getValueCastD_insertEntry
 
+theorem getD_insert! [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {fallback : β a} {v : β k} :
+    (t.insert! k v).getD a fallback =
+      if h : compare k a = .eq then
+        cast (congrArg β (compare_eq_iff_eq.mp h)) v
+      else t.getD a fallback := by
+  simp_to_model [insert!] using List.getValueCastD_insertEntry
+
 theorem getD_insert_self [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} {fallback b : β a} :
     (t.insert a b h.balanced).impl.getD a fallback = b := by
   simp_to_model [insert] using List.getValueCastD_insertEntry_self
+
+theorem getD_insert!_self [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} {fallback b : β a} :
+    (t.insert! a b).getD a fallback = b := by
+  simp_to_model [insert!] using List.getValueCastD_insertEntry_self
 
 theorem getD_eq_fallback_of_contains_eq_false [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} {fallback : β a} :
     t.contains a = false → t.getD a fallback = fallback := by
@@ -752,9 +826,17 @@ theorem getD_erase [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {fallbac
     (t.erase k h.balanced).impl.getD a fallback = if compare k a = .eq then fallback else t.getD a fallback := by
   simp_to_model [erase] using List.getValueCastD_eraseKey
 
+theorem getD_erase! [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {fallback : β a} :
+    (t.erase! k).getD a fallback = if compare k a = .eq then fallback else t.getD a fallback := by
+  simp_to_model [erase!] using List.getValueCastD_eraseKey
+
 theorem getD_erase_self [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k : α} {fallback : β k} :
     (t.erase k h.balanced).impl.getD k fallback = fallback := by
   simp_to_model [erase] using List.getValueCastD_eraseKey_self
+
+theorem getD_erase!_self [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k : α} {fallback : β k} :
+    (t.erase! k).getD k fallback = fallback := by
+  simp_to_model [erase!] using List.getValueCastD_eraseKey_self
 
 theorem get?_eq_some_getD_of_contains [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} {fallback : β a} :
     t.contains a = true → t.get? a = some (t.getD a fallback) := by
@@ -792,9 +874,17 @@ theorem getD_insert [TransOrd α] (h : t.WF) {k a : α} {fallback v : β} :
     getD (t.insert k v h.balanced).impl a fallback = if compare k a = .eq then v else getD t a fallback := by
   simp_to_model [insert] using List.getValueD_insertEntry
 
+theorem getD_insert! [TransOrd α] (h : t.WF) {k a : α} {fallback v : β} :
+    getD (t.insert! k v) a fallback = if compare k a = .eq then v else getD t a fallback := by
+  simp_to_model [insert!] using List.getValueD_insertEntry
+
 theorem getD_insert_self [TransOrd α] (h : t.WF) {k : α} {fallback v : β} :
     getD (t.insert k v h.balanced).impl k fallback = v := by
   simp_to_model [insert] using List.getValueD_insertEntry_self
+
+theorem getD_insert!_self [TransOrd α] (h : t.WF) {k : α} {fallback v : β} :
+    getD (t.insert! k v) k fallback = v := by
+  simp_to_model [insert!] using List.getValueD_insertEntry_self
 
 theorem getD_eq_fallback_of_contains_eq_false [TransOrd α] (h : t.WF) {a : α} {fallback : β} :
     t.contains a = false → getD t a fallback = fallback := by
@@ -811,9 +901,20 @@ theorem getD_erase [TransOrd α] (h : t.WF) {k a : α} {fallback : β} :
       getD t a fallback := by
   simp_to_model [erase] using List.getValueD_eraseKey
 
+theorem getD_erase! [TransOrd α] (h : t.WF) {k a : α} {fallback : β} :
+    getD (t.erase! k) a fallback = if compare k a = .eq then
+      fallback
+    else
+      getD t a fallback := by
+  simp_to_model [erase!] using List.getValueD_eraseKey
+
 theorem getD_erase_self [TransOrd α] (h : t.WF) {k : α} {fallback : β} :
     getD (t.erase k h.balanced).impl k fallback = fallback := by
   simp_to_model [erase] using List.getValueD_eraseKey_self
+
+theorem getD_erase!_self [TransOrd α] (h : t.WF) {k : α} {fallback : β} :
+    getD (t.erase! k) k fallback = fallback := by
+  simp_to_model [erase!] using List.getValueD_eraseKey_self
 
 theorem get?_eq_some_getD_of_contains [TransOrd α] (h : t.WF) {a : α} {fallback : β} :
     t.contains a = true → get? t a = some (getD t a fallback) := by

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -632,7 +632,7 @@ theorem get!_eq_default [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} [Inha
   simp_to_model using List.getValueCast!_eq_default
 
 theorem get!_erase [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} [Inhabited (β a)] :
-    (t.erase k h.balanced).impl.get! a = if k == a then default else t.get! a := by
+    (t.erase k h.balanced).impl.get! a = if compare k a = .eq then default else t.get! a := by
   simp_to_model [erase] using List.getValueCast!_eraseKey
 
 theorem get!_erase_self [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k : α} [Inhabited (β k)] :
@@ -653,7 +653,7 @@ theorem get_eq_get! [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} [Inhabite
 
 namespace Const
 
-variable {β : Type v} (t : Impl α β) (h : t.WF)
+variable {β : Type v} {t : Impl α β} (h : t.WF)
 
 theorem get!_empty [TransOrd α] [Inhabited β] {a : α} :
     get! (empty : Impl α β) a = default := by
@@ -754,7 +754,7 @@ theorem get!_eq_getD_default [TransOrd α] [LawfulEqOrd α] (h : t.WF) {a : α} 
 
 namespace Const
 
-variable {β : Type v} (t : Impl α β) (h : t.WF)
+variable {β : Type v} {t : Impl α β} (h : t.WF)
 
 theorem getD_empty [TransOrd α] {a : α} {fallback : β} :
     getD (empty : Impl α β) a fallback = fallback := by

--- a/src/Std/Data/DTreeMap/Internal/Model.lean
+++ b/src/Std/Data/DTreeMap/Internal/Model.lean
@@ -202,38 +202,37 @@ def updateCell [Ord α] (k : α) (f : Cell α β (compare k) → Cell α β (com
 Model implementation of the `contains` function.
 Internal implementation detail of the tree map
 -/
-def containsₘ [Ord α] (k : α) (l : Impl α β) : Bool :=
+def containsₘ [Ord α] (l : Impl α β) (k : α) : Bool :=
   applyCell k l fun c _ => c.contains
 
 /--
 Model implementation of the `get?` function.
 Internal implementation detail of the tree map
 -/
-def get?ₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) (l : Impl α β) : Option (β k) :=
+def get?ₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (l : Impl α β) (k : α) : Option (β k) :=
   applyCell k l fun c _ => c.get?
 
 /--
 Model implementation of the `get` function.
 Internal implementation detail of the tree map
 -/
-def getₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) (l : Impl α β) (h : (get?ₘ k l).isSome) :
+def getₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (l : Impl α β) (k : α) (h : (get?ₘ l k).isSome) :
     β k :=
-  get?ₘ k l |>.get h
+  get?ₘ l k |>.get h
 
 /--
 Model implementation of the `get!` function.
 Internal implementation detail of the tree map
 -/
-def get!ₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) [Inhabited (β k)]
-    (l : Impl α β) : β k :=
-  get?ₘ k l |>.get!
+def get!ₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (l : Impl α β) (k : α) [Inhabited (β k)] : β k :=
+  get?ₘ l k |>.get!
 
 /--
 Model implementation of the `getD` function.
 Internal implementation detail of the tree map
 -/
 def getDₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) (l : Impl α β) (fallback : β k) : β k :=
-  get?ₘ k l |>.getD fallback
+  get?ₘ l k |>.getD fallback
 
 /--
 Model implementation of the `insert` function.
@@ -274,31 +273,30 @@ variable {β : Type v}
 Model implementation of the `get?` function.
 Internal implementation detail of the tree map
 -/
-def get?ₘ [Ord α] (k : α) (l : Impl α (fun _ => β)) : Option β :=
+def get?ₘ [Ord α] (l : Impl α (fun _ => β)) (k : α) : Option β :=
   applyCell k l fun c _ => Cell.Const.get? c
 
 /--
 Model implementation of the `get` function.
 Internal implementation detail of the tree map
 -/
-def getₘ [Ord α] (k : α) (l : Impl α (fun _ => β)) (h : (get?ₘ k l).isSome) :
+def getₘ [Ord α] (l : Impl α (fun _ => β)) (k : α) (h : (get?ₘ l k).isSome) :
     β :=
-  get?ₘ k l |>.get h
+  get?ₘ l k |>.get h
 
 /--
 Model implementation of the `get!` function.
 Internal implementation detail of the tree map
 -/
-def get!ₘ [Ord α] (k : α) [Inhabited β]
-    (l : Impl α (fun _ => β)) : β :=
-  get?ₘ k l |>.get!
+def get!ₘ [Ord α] (l : Impl α (fun _ => β)) (k : α) [Inhabited β] : β :=
+  get?ₘ l k |>.get!
 
 /--
 Model implementation of the `getD` function.
 Internal implementation detail of the tree map
 -/
-def getDₘ [Ord α] (k : α) (l : Impl α (fun _ => β)) (fallback : β) : β :=
-  get?ₘ k l |>.getD fallback
+def getDₘ [Ord α] (l : Impl α (fun _ => β)) (k : α) (fallback : β) : β :=
+  get?ₘ l k |>.getD fallback
 
 /--
 Model implementation of the `alter` function.
@@ -545,7 +543,7 @@ namespace Const
 variable {β : Type v}
 
 theorem get?_eq_get?ₘ [Ord α] (k : α) (l : Impl α (fun _ => β)) :
-    Const.get? k l = Const.get?ₘ k l := by
+    Const.get? l k = Const.get?ₘ l k := by
   simp only [Const.get?ₘ]
   induction l
   · simp only [applyCell, Const.get?]
@@ -554,19 +552,19 @@ theorem get?_eq_get?ₘ [Ord α] (k : α) (l : Impl α (fun _ => β)) :
   · simp [Const.get?, applyCell]
 
 theorem get_eq_get? [Ord α] (k : α) (l : Impl α (fun _ => β)) {h} :
-    get k l h = get? k l := by
+    get l k h = get? l k := by
   induction l
   · simp only [applyCell, get, get?]
     split <;> rename_i ihl ihr hcmp <;> simp_all
   · contradiction
 
 theorem get_eq_getₘ [Ord α] (k : α) (l : Impl α (fun _ => β)) {h} (h') :
-    get k l h = getₘ k l h' := by
+    get l k h = getₘ l k h' := by
   apply Option.some.inj
   simp [get_eq_get?, get?_eq_get?ₘ, getₘ]
 
 theorem get!_eq_get!ₘ [Ord α] (k : α) [Inhabited β] (l : Impl α (fun _ => β)) :
-    get! k l = get!ₘ k l := by
+    get! l k = get!ₘ l k := by
   simp only [get!ₘ, get?ₘ]
   induction l
   · simp only [applyCell, get!]
@@ -575,7 +573,7 @@ theorem get!_eq_get!ₘ [Ord α] (k : α) [Inhabited β] (l : Impl α (fun _ => 
   · simp only [get!, applyCell, Option.get!_none]; rfl
 
 theorem getD_eq_getDₘ [Ord α] (k : α) (l : Impl α (fun _ => β))
-    (fallback : β) : getD k l fallback = getDₘ k l fallback := by
+    (fallback : β) : getD l k fallback = getDₘ l k fallback := by
   simp only [getDₘ, get?ₘ]
   induction l
   · simp only [applyCell, getD]

--- a/src/Std/Data/DTreeMap/Internal/Model.lean
+++ b/src/Std/Data/DTreeMap/Internal/Model.lean
@@ -213,6 +213,29 @@ def get?ₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) (l : Impl α β)
   applyCell k l fun c _ => c.get?
 
 /--
+Model implementation of the `get?` function.
+Internal implementation detail of the tree map
+-/
+def getₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) (l : Impl α β) (h : (get?ₘ k l).isSome) :
+    β k :=
+  get?ₘ k l |>.get h
+
+/--
+Model implementation of the `get?` function.
+Internal implementation detail of the tree map
+-/
+def get!ₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) [Inhabited (β k)]
+    (l : Impl α β) : β k :=
+  get?ₘ k l |>.get!
+
+/--
+Model implementation of the `get?` function.
+Internal implementation detail of the tree map
+-/
+def getDₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) (l : Impl α β) (fallback : β k) : β k :=
+  get?ₘ k l |>.getD fallback
+
+/--
 Model implementation of the `insert` function.
 Internal implementation detail of the tree map
 -/
@@ -294,6 +317,15 @@ theorem contains_eq_containsₘ [Ord α] (k : α) (l : Impl α β) :
 
 theorem get?_eq_get?ₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) (l : Impl α β) :
     l.get? k = l.get?ₘ k := by
+  simp only [get?ₘ]
+  induction l
+  · simp only [applyCell, get?]
+    split <;> rename_i hcmp₁ <;> split <;> rename_i hcmp₂ <;> try (simp [hcmp₁] at hcmp₂; done)
+    all_goals simp_all [Cell.get?, Cell.ofEq]
+  · simp [get?, applyCell]
+
+theorem get_eq_getₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) (l : Impl α β) {h} :
+    l.get k h = l.getₘ k h := by
   simp only [get?ₘ]
   induction l
   · simp only [applyCell, get?]

--- a/src/Std/Data/DTreeMap/Internal/Model.lean
+++ b/src/Std/Data/DTreeMap/Internal/Model.lean
@@ -324,14 +324,35 @@ theorem get?_eq_get?ₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) (l :
     all_goals simp_all [Cell.get?, Cell.ofEq]
   · simp [get?, applyCell]
 
-theorem get_eq_getₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) (l : Impl α β) {h} :
-    l.get k h = l.getₘ k h := by
-  simp only [get?ₘ]
+theorem get_eq_get? [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) (l : Impl α β) {h} :
+    l.get k h = l.get? k := by
   induction l
-  · simp only [applyCell, get?]
+  · simp only [applyCell, get, get?]
+    split <;> rename_i ihl ihr hcmp <;> simp_all
+  · contradiction
+
+theorem get_eq_getₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) (l : Impl α β) {h} (h') :
+    l.get k h = l.getₘ k h' := by
+  apply Option.some.inj
+  simp [get_eq_get?, get?_eq_get?ₘ, getₘ]
+
+theorem get!_eq_get!ₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) [Inhabited (β k)] (l : Impl α β) :
+    l.get! k = l.get!ₘ k := by
+  simp only [get!ₘ, get?ₘ]
+  induction l
+  · simp only [applyCell, get!]
     split <;> rename_i hcmp₁ <;> split <;> rename_i hcmp₂ <;> try (simp [hcmp₁] at hcmp₂; done)
     all_goals simp_all [Cell.get?, Cell.ofEq]
-  · simp [get?, applyCell]
+  · simp only [get!, applyCell, Cell.get?_empty, Option.get!_none]; rfl
+
+theorem getD_eq_getDₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) (l : Impl α β)
+    (fallback : β k) : l.getD k fallback = l.getDₘ k fallback := by
+  simp only [getDₘ, get?ₘ]
+  induction l
+  · simp only [applyCell, getD]
+    split <;> rename_i hcmp₁ <;> split <;> rename_i hcmp₂ <;> try (simp [hcmp₁] at hcmp₂; done)
+    all_goals simp_all [Cell.get?, Cell.ofEq]
+  · simp only [getD, applyCell, Cell.get?_empty, Option.getD_none]
 
 theorem balanceL_eq_balance {k : α} {v : β k} {l r : Impl α β} {hlb hrb hlr} :
     balanceL k v l r hlb hrb hlr = balance k v l r hlb hrb (Or.inl hlr.erase) := by

--- a/src/Std/Data/DTreeMap/Internal/Model.lean
+++ b/src/Std/Data/DTreeMap/Internal/Model.lean
@@ -213,7 +213,7 @@ def get?ₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) (l : Impl α β)
   applyCell k l fun c _ => c.get?
 
 /--
-Model implementation of the `get?` function.
+Model implementation of the `get` function.
 Internal implementation detail of the tree map
 -/
 def getₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) (l : Impl α β) (h : (get?ₘ k l).isSome) :
@@ -221,7 +221,7 @@ def getₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) (l : Impl α β) 
   get?ₘ k l |>.get h
 
 /--
-Model implementation of the `get?` function.
+Model implementation of the `get!` function.
 Internal implementation detail of the tree map
 -/
 def get!ₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) [Inhabited (β k)]
@@ -229,7 +229,7 @@ def get!ₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) [Inhabited (β k
   get?ₘ k l |>.get!
 
 /--
-Model implementation of the `get?` function.
+Model implementation of the `getD` function.
 Internal implementation detail of the tree map
 -/
 def getDₘ [Ord α] [OrientedOrd α] [LawfulEqOrd α] (k : α) (l : Impl α β) (fallback : β k) : β k :=
@@ -276,6 +276,29 @@ Internal implementation detail of the tree map
 -/
 def get?ₘ [Ord α] (k : α) (l : Impl α (fun _ => β)) : Option β :=
   applyCell k l fun c _ => Cell.Const.get? c
+
+/--
+Model implementation of the `get` function.
+Internal implementation detail of the tree map
+-/
+def getₘ [Ord α] (k : α) (l : Impl α (fun _ => β)) (h : (get?ₘ k l).isSome) :
+    β :=
+  get?ₘ k l |>.get h
+
+/--
+Model implementation of the `get!` function.
+Internal implementation detail of the tree map
+-/
+def get!ₘ [Ord α] (k : α) [Inhabited β]
+    (l : Impl α (fun _ => β)) : β :=
+  get?ₘ k l |>.get!
+
+/--
+Model implementation of the `getD` function.
+Internal implementation detail of the tree map
+-/
+def getDₘ [Ord α] (k : α) (l : Impl α (fun _ => β)) (fallback : β) : β :=
+  get?ₘ k l |>.getD fallback
 
 /--
 Model implementation of the `alter` function.
@@ -529,6 +552,36 @@ theorem get?_eq_get?ₘ [Ord α] (k : α) (l : Impl α (fun _ => β)) :
     split <;> rename_i hcmp₁ <;> split <;> rename_i hcmp₂ <;> try (simp [hcmp₁] at hcmp₂; done)
     all_goals simp_all [Cell.Const.get?, Cell.ofEq]
   · simp [Const.get?, applyCell]
+
+theorem get_eq_get? [Ord α] (k : α) (l : Impl α (fun _ => β)) {h} :
+    get k l h = get? k l := by
+  induction l
+  · simp only [applyCell, get, get?]
+    split <;> rename_i ihl ihr hcmp <;> simp_all
+  · contradiction
+
+theorem get_eq_getₘ [Ord α] (k : α) (l : Impl α (fun _ => β)) {h} (h') :
+    get k l h = getₘ k l h' := by
+  apply Option.some.inj
+  simp [get_eq_get?, get?_eq_get?ₘ, getₘ]
+
+theorem get!_eq_get!ₘ [Ord α] (k : α) [Inhabited β] (l : Impl α (fun _ => β)) :
+    get! k l = get!ₘ k l := by
+  simp only [get!ₘ, get?ₘ]
+  induction l
+  · simp only [applyCell, get!]
+    split <;> rename_i hcmp₁ <;> split <;> rename_i hcmp₂ <;> try (simp [hcmp₁] at hcmp₂; done)
+    all_goals simp_all [Cell.Const.get?, Cell.ofEq]
+  · simp only [get!, applyCell, Option.get!_none]; rfl
+
+theorem getD_eq_getDₘ [Ord α] (k : α) (l : Impl α (fun _ => β))
+    (fallback : β) : getD k l fallback = getDₘ k l fallback := by
+  simp only [getDₘ, get?ₘ]
+  induction l
+  · simp only [applyCell, getD]
+    split <;> rename_i hcmp₁ <;> split <;> rename_i hcmp₂ <;> try (simp [hcmp₁] at hcmp₂; done)
+    all_goals simp_all [Cell.Const.get?, Cell.ofEq]
+  · simp only [getD, applyCell, Cell.Const.get?_empty, Option.getD_none]
 
 end Const
 

--- a/src/Std/Data/DTreeMap/Internal/Operations.lean
+++ b/src/Std/Data/DTreeMap/Internal/Operations.lean
@@ -606,7 +606,7 @@ variable {β : Type v}
 @[inline]
 def getThenInsertIfNew? [Ord α] (k : α) (v : β) (t : Impl α (fun _ => β))
     (ht : t.Balanced) : Option β × Impl α (fun _ => β) :=
-  match get? k t with
+  match get? t k with
   | none => (none, t.insertIfNew k v ht |>.impl)
   | some b => (some b, t)
 
@@ -617,7 +617,7 @@ information but still assumes the preconditions of `getThenInsertIfNew?`, otherw
 @[inline]
 def getThenInsertIfNew?! [Ord α] (k : α) (v : β) (t : Impl α (fun _ => β))
     : Option β × Impl α (fun _ => β) :=
-  match get? k t with
+  match get? t k with
   | none => (none, t.insertIfNew! k v)
   | some b => (some b, t)
 

--- a/src/Std/Data/DTreeMap/Internal/Queries.lean
+++ b/src/Std/Data/DTreeMap/Internal/Queries.lean
@@ -62,122 +62,122 @@ def isEmpty (t : Impl α β) : Bool :=
   | .inner _ _ _ _ _ => false
 
 /-- Returns the value for the key `k`, or `none` if such a key does not exist. -/
-def get? [Ord α] [LawfulEqOrd α] (k : α) (t : Impl α β) : Option (β k) :=
+def get? [Ord α] [LawfulEqOrd α] (t : Impl α β) (k : α) : Option (β k) :=
   match t with
   | .leaf => none
   | .inner _ k' v' l r =>
     match h : compare k k' with
-    | .lt => get? k l
-    | .gt => get? k r
+    | .lt => get? l k
+    | .gt => get? r k
     | .eq => some (cast (congrArg β (compare_eq_iff_eq.mp h).symm) v')
 
 /-- Returns the value for the key `k`. -/
-def get [Ord α] [LawfulEqOrd α] (k : α) (t : Impl α β) (hlk : t.contains k = true) : β k :=
+def get [Ord α] [LawfulEqOrd α] (t : Impl α β) (k : α) (hlk : t.contains k = true) : β k :=
   match t with
   | .inner _ k' v' l r =>
     match h : compare k k' with
-    | .lt => get k l (by simpa [contains, h] using hlk)
-    | .gt => get k r (by simpa [contains, h] using hlk)
+    | .lt => get l k (by simpa [contains, h] using hlk)
+    | .gt => get r k (by simpa [contains, h] using hlk)
     | .eq => cast (congrArg β (compare_eq_iff_eq.mp h).symm) v'
 
 /-- Returns the value for the key `k`, or panics if such a key does not exist. -/
-def get! [Ord α] [LawfulEqOrd α] (k : α) (t : Impl α β) [Inhabited (β k)] : β k :=
+def get! [Ord α] [LawfulEqOrd α] (t : Impl α β) (k : α) [Inhabited (β k)] : β k :=
   match t with
   | .leaf => panic! "Key is not present in map"
   | .inner _ k' v' l r =>
     match h : compare k k' with
-    | .lt => get! k l
-    | .gt => get! k r
+    | .lt => get! l k
+    | .gt => get! r k
     | .eq => cast (congrArg β (compare_eq_iff_eq.mp h).symm) v'
 
 /-- Returns the value for the key `k`, or `fallback` if such a key does not exist. -/
-def getD [Ord α] [LawfulEqOrd α] (k : α) (t : Impl α β) (fallback : β k) : β k :=
+def getD [Ord α] [LawfulEqOrd α] (t : Impl α β) (k : α) (fallback : β k) : β k :=
   match t with
   | .leaf => fallback
   | .inner _ k' v' l r =>
     match h : compare k k' with
-    | .lt => getD k l fallback
-    | .gt => getD k r fallback
+    | .lt => getD l k fallback
+    | .gt => getD r k fallback
     | .eq => cast (congrArg β (compare_eq_iff_eq.mp h).symm) v'
 
 /-- Implementation detail of the tree map -/
-def getKey? [Ord α] (k : α) (t : Impl α β) : Option α :=
+def getKey? [Ord α] (t : Impl α β) (k : α) : Option α :=
   match t with
   | .leaf => none
   | .inner _ k' _ l r =>
     match compare k k' with
-    | .lt => getKey? k l
-    | .gt => getKey? k r
+    | .lt => getKey? l k
+    | .gt => getKey? r k
     | .eq => some k'
 
 /-- Implementation detail of the tree map -/
-def getKey [Ord α] (k : α) (t : Impl α β) (hlk : t.contains k = true) : α :=
+def getKey [Ord α] (t : Impl α β) (k : α) (hlk : t.contains k = true) : α :=
   match t with
   | .inner _ k' _ l r =>
     match h : compare k k' with
-    | .lt => getKey k l (by simpa [contains, h] using hlk)
-    | .gt => getKey k r (by simpa [contains, h] using hlk)
+    | .lt => getKey l k (by simpa [contains, h] using hlk)
+    | .gt => getKey r k (by simpa [contains, h] using hlk)
     | .eq => k'
 
 /-- Implementation detail of the tree map -/
-def getKey! [Ord α] (k : α) (t : Impl α β) [Inhabited α] : α :=
+def getKey! [Ord α] (t : Impl α β) (k : α) [Inhabited α] : α :=
   match t with
   | .leaf => panic! "Key is not present in map"
   | .inner _ k' _ l r =>
     match compare k k' with
-    | .lt => getKey! k l
-    | .gt => getKey! k r
+    | .lt => getKey! l k
+    | .gt => getKey! r k
     | .eq => k'
 
 /-- Implementation detail of the tree map -/
-def getKeyD [Ord α] (k : α) (t : Impl α β) (fallback : α) : α :=
+def getKeyD [Ord α] (t : Impl α β) (k : α) (fallback : α) : α :=
   match t with
   | .leaf => fallback
   | .inner _ k' _ l r =>
     match compare k k' with
-    | .lt => getKeyD k l fallback
-    | .gt => getKeyD k r fallback
+    | .lt => getKeyD l k fallback
+    | .gt => getKeyD r k fallback
     | .eq => k'
 
 namespace Const
 
 /-- Returns the value for the key `k`, or `none` if such a key does not exist. -/
-def get? [Ord α] (k : α) (t : Impl α δ) : Option δ :=
+def get? [Ord α] (t : Impl α δ) (k : α) : Option δ :=
   match t with
   | .leaf => none
   | .inner _ k' v' l r =>
     match compare k k' with
-    | .lt => get? k l
-    | .gt => get? k r
+    | .lt => get? l k
+    | .gt => get? r k
     | .eq => some v'
 
 /-- Returns the value for the key `k`. -/
-def get [Ord α] (k : α) (t : Impl α δ) (hlk : t.contains k = true) : δ :=
+def get [Ord α] (t : Impl α δ) (k : α) (hlk : t.contains k = true) : δ :=
   match t with
   | .inner _ k' v' l r =>
     match h : compare k k' with
-    | .lt => get k l (by simpa [contains, h] using hlk)
-    | .gt => get k r (by simpa [contains, h] using hlk)
+    | .lt => get l k (by simpa [contains, h] using hlk)
+    | .gt => get r k (by simpa [contains, h] using hlk)
     | .eq => v'
 
 /-- Returns the value for the key `k`, or panics if such a key does not exist. -/
-def get! [Ord α] (k : α) (t : Impl α δ) [Inhabited δ] : δ :=
+def get! [Ord α] (t : Impl α δ) (k : α) [Inhabited δ] : δ :=
   match t with
   | .leaf => panic! "Key is not present in map"
   | .inner _ k' v' l r =>
     match compare k k' with
-    | .lt => get! k l
-    | .gt => get! k r
+    | .lt => get! l k
+    | .gt => get! r k
     | .eq => v'
 
 /-- Returns the value for the key `k`, or `fallback` if such a key does not exist. -/
-def getD [Ord α] (k : α) (t : Impl α δ) (fallback : δ) : δ :=
+def getD [Ord α] (t : Impl α δ) (k : α) (fallback : δ) : δ :=
   match t with
   | .leaf => fallback
   | .inner _ k' v' l r =>
     match compare k k' with
-    | .lt => getD k l fallback
-    | .gt => getD k r fallback
+    | .lt => getD l k fallback
+    | .gt => getD r k fallback
     | .eq => v'
 
 end Const

--- a/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
@@ -569,19 +569,32 @@ theorem get?_eq_getValueCast? [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {
 -/
 
 theorem contains_eq_get?ₘ_isSome [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {t : Impl α β}
-    (hto : t.Ordered) : containsKey k t.toListModel = (t.get?ₘ k).isSome := by
-  rw [get?ₘ_eq_getValueCast? hto, containsKey_eq_isSome_getValueCast?]
+    (hto : t.Ordered) : contains k t = (t.get?ₘ k).isSome := by
+  rw [get?ₘ_eq_getValueCast? hto, contains_eq_containsKey hto, containsKey_eq_isSome_getValueCast?]
 
 theorem getₘ_eq_getValueCast [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {t : Impl α β} (h) {h'}
     (hto : t.Ordered) : t.getₘ k h' = getValueCast k t.toListModel h := by
-  simp only [getₘ, get?ₘ_eq_getValueCast?]
+  simp only [getₘ]
   revert h'
   rw [get?ₘ_eq_getValueCast? hto]
-  · simp [getValueCast?_eq_some_getValueCast ‹_›]
+  simp [getValueCast?_eq_some_getValueCast ‹_›]
 
 theorem get_eq_getValueCast [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {t : Impl α β} {h}
     (hto : t.Ordered): t.get k h = getValueCast k t.toListModel (contains_eq_containsKey hto ▸ h) := by
-  rw [get_eq_getₘ, get?ₘ_eq_getValueCast? hto]
+  rw [get_eq_getₘ, getₘ_eq_getValueCast _ hto]
+  exact contains_eq_get?ₘ_isSome hto ▸ h
+
+/-!
+''' `get!`
+-/
+
+theorem get!ₘ_eq_getValueCast! [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} [Inhabited (β k)]
+    {t : Impl α β} (hto : t.Ordered) : t.get!ₘ k = getValueCast! k t.toListModel := by
+  simp [get!ₘ, get?ₘ_eq_getValueCast? hto, getValueCast!_eq_getValueCast?]
+
+theorem get!_eq_getValueCast! [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {t : Impl α β}
+    (hto : t.Ordered) : t.get! k = getValueCast! k t.toListModel := by
+  rw [get!_eq_get!ₘ, get!ₘ_eq_getValueCast! hto]
 
 namespace Const
 

--- a/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
@@ -564,6 +564,25 @@ theorem get?_eq_getValueCast? [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {
     (hto : t.Ordered) : t.get? k = getValueCast? k t.toListModel := by
   rw [get?_eq_get?ₘ, get?ₘ_eq_getValueCast? hto]
 
+/-!
+''' `get`
+-/
+
+theorem contains_eq_get?ₘ_isSome [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {t : Impl α β}
+    (hto : t.Ordered) : containsKey k t.toListModel = (t.get?ₘ k).isSome := by
+  rw [get?ₘ_eq_getValueCast? hto, containsKey_eq_isSome_getValueCast?]
+
+theorem getₘ_eq_getValueCast [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {t : Impl α β} (h) {h'}
+    (hto : t.Ordered) : t.getₘ k h' = getValueCast k t.toListModel h := by
+  simp only [getₘ, get?ₘ_eq_getValueCast?]
+  revert h'
+  rw [get?ₘ_eq_getValueCast? hto]
+  · simp [getValueCast?_eq_some_getValueCast ‹_›]
+
+theorem get_eq_getValueCast [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {t : Impl α β} {h}
+    (hto : t.Ordered): t.get k h = getValueCast k t.toListModel (contains_eq_containsKey hto ▸ h) := by
+  rw [get_eq_getₘ, get?ₘ_eq_getValueCast? hto]
+
 namespace Const
 
 variable {β : Type v}

--- a/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
@@ -568,7 +568,7 @@ theorem get?_eq_getValueCast? [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {
 ''' `get`
 -/
 
-theorem contains_eq_get?ₘ_isSome [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {t : Impl α β}
+theorem contains_eq_isSome_get?ₘ [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {t : Impl α β}
     (hto : t.Ordered) : contains k t = (t.get?ₘ k).isSome := by
   rw [get?ₘ_eq_getValueCast? hto, contains_eq_containsKey hto, containsKey_eq_isSome_getValueCast?]
 
@@ -582,7 +582,7 @@ theorem getₘ_eq_getValueCast [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} 
 theorem get_eq_getValueCast [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {t : Impl α β} {h}
     (hto : t.Ordered): t.get k h = getValueCast k t.toListModel (contains_eq_containsKey hto ▸ h) := by
   rw [get_eq_getₘ, getₘ_eq_getValueCast _ hto]
-  exact contains_eq_get?ₘ_isSome hto ▸ h
+  exact contains_eq_isSome_get?ₘ hto ▸ h
 
 /-!
 ''' `get!`
@@ -637,7 +637,7 @@ theorem get?_eq_getValue? [Ord α] [TransOrd α] {k : α} {t : Impl α (fun _ =>
 ''' `get`
 -/
 
-theorem contains_eq_get?ₘ_isSome [Ord α] [TransOrd α] {k : α} {t : Impl α β}
+theorem contains_eq_isSome_get?ₘ [Ord α] [TransOrd α] {k : α} {t : Impl α β}
     (hto : t.Ordered) : contains k t = (get?ₘ t k).isSome := by
   rw [get?ₘ_eq_getValue? hto, contains_eq_containsKey hto, containsKey_eq_isSome_getValue?]
 
@@ -651,7 +651,7 @@ theorem getₘ_eq_getValue [Ord α] [TransOrd α] {k : α} {t : Impl α β} (h) 
 theorem get_eq_getValue [Ord α] [TransOrd α] {k : α} {t : Impl α β} {h}
     (hto : t.Ordered): get t k h = getValue k t.toListModel (contains_eq_containsKey hto ▸ h) := by
   rw [get_eq_getₘ, getₘ_eq_getValue _ hto]
-  exact contains_eq_get?ₘ_isSome hto ▸ h
+  exact contains_eq_isSome_get?ₘ hto ▸ h
 
 /-!
 ''' `get!`
@@ -678,7 +678,6 @@ theorem getD_eq_getValueD [Ord α] [TransOrd α] {k : α}
     {t : Impl α β} {fallback : β} (hto : t.Ordered) :
     getD t k fallback = getValueD k t.toListModel fallback := by
   rw [getD_eq_getDₘ, getDₘ_eq_getValueD hto]
-
 
 end Const
 

--- a/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
@@ -619,7 +619,7 @@ variable {β : Type v}
 -/
 
 theorem get?ₘ_eq_getValue? [Ord α] [TransOrd α] {k : α} {t : Impl α (fun _ => β)} (hto : t.Ordered) :
-    get?ₘ k t = getValue? k t.toListModel := by
+    get?ₘ t k = getValue? k t.toListModel := by
   rw [get?ₘ, applyCell_eq_apply_toListModel hto (fun l _ => getValue? k l)]
   · rintro ⟨(_|p), hp⟩ -
     · simp [Cell.Const.get?]
@@ -630,7 +630,7 @@ theorem get?ₘ_eq_getValue? [Ord α] [TransOrd α] {k : α} {t : Impl α (fun _
   · exact fun l₁ l₂ h => getValue?_append_of_containsKey_eq_false
 
 theorem get?_eq_getValue? [Ord α] [TransOrd α] {k : α} {t : Impl α (fun _ => β)} (hto : t.Ordered) :
-    get? k t = getValue? k t.toListModel := by
+    get? t k = getValue? k t.toListModel := by
   rw [get?_eq_get?ₘ, get?ₘ_eq_getValue? hto]
 
 /-!
@@ -638,18 +638,18 @@ theorem get?_eq_getValue? [Ord α] [TransOrd α] {k : α} {t : Impl α (fun _ =>
 -/
 
 theorem contains_eq_get?ₘ_isSome [Ord α] [TransOrd α] {k : α} {t : Impl α β}
-    (hto : t.Ordered) : contains k t = (get?ₘ k t).isSome := by
+    (hto : t.Ordered) : contains k t = (get?ₘ t k).isSome := by
   rw [get?ₘ_eq_getValue? hto, contains_eq_containsKey hto, containsKey_eq_isSome_getValue?]
 
 theorem getₘ_eq_getValue [Ord α] [TransOrd α] {k : α} {t : Impl α β} (h) {h'}
-    (hto : t.Ordered) : getₘ k t h' = getValue k t.toListModel h := by
+    (hto : t.Ordered) : getₘ t k h' = getValue k t.toListModel h := by
   simp only [getₘ]
   revert h'
   rw [get?ₘ_eq_getValue? hto]
   simp [getValue?_eq_some_getValue ‹_›]
 
 theorem get_eq_getValue [Ord α] [TransOrd α] {k : α} {t : Impl α β} {h}
-    (hto : t.Ordered): get k t h = getValue k t.toListModel (contains_eq_containsKey hto ▸ h) := by
+    (hto : t.Ordered): get t k h = getValue k t.toListModel (contains_eq_containsKey hto ▸ h) := by
   rw [get_eq_getₘ, getₘ_eq_getValue _ hto]
   exact contains_eq_get?ₘ_isSome hto ▸ h
 
@@ -658,11 +658,11 @@ theorem get_eq_getValue [Ord α] [TransOrd α] {k : α} {t : Impl α β} {h}
 -/
 
 theorem get!ₘ_eq_getValue! [Ord α] [TransOrd α] {k : α} [Inhabited β]
-    {t : Impl α β} (hto : t.Ordered) : get!ₘ k t = getValue! k t.toListModel := by
+    {t : Impl α β} (hto : t.Ordered) : get!ₘ t k = getValue! k t.toListModel := by
   simp [get!ₘ, get?ₘ_eq_getValue? hto, getValue!_eq_getValue?]
 
 theorem get!_eq_getValue! [Ord α] [TransOrd α] {k : α} [Inhabited β]
-    {t : Impl α β} (hto : t.Ordered) : get! k t = getValue! k t.toListModel := by
+    {t : Impl α β} (hto : t.Ordered) : get! t k = getValue! k t.toListModel := by
   rw [get!_eq_get!ₘ, get!ₘ_eq_getValue! hto]
 
 /-!
@@ -671,12 +671,12 @@ theorem get!_eq_getValue! [Ord α] [TransOrd α] {k : α} [Inhabited β]
 
 theorem getDₘ_eq_getValueD [Ord α] [TransOrd α] {k : α}
     {t : Impl α β} {fallback : β} (hto : t.Ordered) :
-    getDₘ k t fallback = getValueD k t.toListModel fallback := by
+    getDₘ t k fallback = getValueD k t.toListModel fallback := by
   simp [getDₘ, get?ₘ_eq_getValue? hto, getValueD_eq_getValue?]
 
 theorem getD_eq_getValueD [Ord α] [TransOrd α] {k : α}
     {t : Impl α β} {fallback : β} (hto : t.Ordered) :
-    getD k t fallback = getValueD k t.toListModel fallback := by
+    getD t k fallback = getValueD k t.toListModel fallback := by
   rw [getD_eq_getDₘ, getDₘ_eq_getValueD hto]
 
 

--- a/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
@@ -546,7 +546,7 @@ theorem contains_eq_containsKey [Ord α] [TransOrd α] {k : α} {l : Impl α β}
   rw [contains_eq_containsₘ, containsₘ_eq_containsKey hlo]
 
 /-!
-''' `get?`
+### `get?`
 -/
 
 theorem get?ₘ_eq_getValueCast? [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {t : Impl α β}
@@ -565,7 +565,7 @@ theorem get?_eq_getValueCast? [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {
   rw [get?_eq_get?ₘ, get?ₘ_eq_getValueCast? hto]
 
 /-!
-''' `get`
+### `get`
 -/
 
 theorem contains_eq_isSome_get?ₘ [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {t : Impl α β}
@@ -585,7 +585,7 @@ theorem get_eq_getValueCast [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {t 
   exact contains_eq_isSome_get?ₘ hto ▸ h
 
 /-!
-''' `get!`
+### `get!`
 -/
 
 theorem get!ₘ_eq_getValueCast! [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} [Inhabited (β k)]
@@ -597,7 +597,7 @@ theorem get!_eq_getValueCast! [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} [
   rw [get!_eq_get!ₘ, get!ₘ_eq_getValueCast! hto]
 
 /-!
-''' `getD`
+### `getD`
 -/
 
 theorem getDₘ_eq_getValueCastD [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α}
@@ -615,7 +615,7 @@ namespace Const
 variable {β : Type v}
 
 /-!
-''' `get?`
+### `get?`
 -/
 
 theorem get?ₘ_eq_getValue? [Ord α] [TransOrd α] {k : α} {t : Impl α (fun _ => β)} (hto : t.Ordered) :
@@ -634,7 +634,7 @@ theorem get?_eq_getValue? [Ord α] [TransOrd α] {k : α} {t : Impl α (fun _ =>
   rw [get?_eq_get?ₘ, get?ₘ_eq_getValue? hto]
 
 /-!
-''' `get`
+### `get`
 -/
 
 theorem contains_eq_isSome_get?ₘ [Ord α] [TransOrd α] {k : α} {t : Impl α β}
@@ -654,7 +654,7 @@ theorem get_eq_getValue [Ord α] [TransOrd α] {k : α} {t : Impl α β} {h}
   exact contains_eq_isSome_get?ₘ hto ▸ h
 
 /-!
-''' `get!`
+### `get!`
 -/
 
 theorem get!ₘ_eq_getValue! [Ord α] [TransOrd α] {k : α} [Inhabited β]
@@ -666,7 +666,7 @@ theorem get!_eq_getValue! [Ord α] [TransOrd α] {k : α} [Inhabited β]
   rw [get!_eq_get!ₘ, get!ₘ_eq_getValue! hto]
 
 /-!
-''' `getD`
+### `getD`
 -/
 
 theorem getDₘ_eq_getValueD [Ord α] [TransOrd α] {k : α}

--- a/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
@@ -592,9 +592,23 @@ theorem get!ₘ_eq_getValueCast! [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α
     {t : Impl α β} (hto : t.Ordered) : t.get!ₘ k = getValueCast! k t.toListModel := by
   simp [get!ₘ, get?ₘ_eq_getValueCast? hto, getValueCast!_eq_getValueCast?]
 
-theorem get!_eq_getValueCast! [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {t : Impl α β}
-    (hto : t.Ordered) : t.get! k = getValueCast! k t.toListModel := by
+theorem get!_eq_getValueCast! [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} [Inhabited (β k)]
+    {t : Impl α β} (hto : t.Ordered) : t.get! k = getValueCast! k t.toListModel := by
   rw [get!_eq_get!ₘ, get!ₘ_eq_getValueCast! hto]
+
+/-!
+''' `getD`
+-/
+
+theorem getDₘ_eq_getValueCastD [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α}
+    {t : Impl α β} {fallback : β k} (hto : t.Ordered) :
+    t.getDₘ k fallback = getValueCastD k t.toListModel fallback := by
+  simp [getDₘ, get?ₘ_eq_getValueCast? hto, getValueCastD_eq_getValueCast?]
+
+theorem getD_eq_getValueCastD [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α}
+    {t : Impl α β} {fallback : β k} (hto : t.Ordered) :
+    t.getD k fallback = getValueCastD k t.toListModel fallback := by
+  rw [getD_eq_getDₘ, getDₘ_eq_getValueCastD hto]
 
 namespace Const
 
@@ -618,6 +632,53 @@ theorem get?ₘ_eq_getValue? [Ord α] [TransOrd α] {k : α} {t : Impl α (fun _
 theorem get?_eq_getValue? [Ord α] [TransOrd α] {k : α} {t : Impl α (fun _ => β)} (hto : t.Ordered) :
     get? k t = getValue? k t.toListModel := by
   rw [get?_eq_get?ₘ, get?ₘ_eq_getValue? hto]
+
+/-!
+''' `get`
+-/
+
+theorem contains_eq_get?ₘ_isSome [Ord α] [TransOrd α] {k : α} {t : Impl α β}
+    (hto : t.Ordered) : contains k t = (get?ₘ k t).isSome := by
+  rw [get?ₘ_eq_getValue? hto, contains_eq_containsKey hto, containsKey_eq_isSome_getValue?]
+
+theorem getₘ_eq_getValue [Ord α] [TransOrd α] {k : α} {t : Impl α β} (h) {h'}
+    (hto : t.Ordered) : getₘ k t h' = getValue k t.toListModel h := by
+  simp only [getₘ]
+  revert h'
+  rw [get?ₘ_eq_getValue? hto]
+  simp [getValue?_eq_some_getValue ‹_›]
+
+theorem get_eq_getValue [Ord α] [TransOrd α] {k : α} {t : Impl α β} {h}
+    (hto : t.Ordered): get k t h = getValue k t.toListModel (contains_eq_containsKey hto ▸ h) := by
+  rw [get_eq_getₘ, getₘ_eq_getValue _ hto]
+  exact contains_eq_get?ₘ_isSome hto ▸ h
+
+/-!
+''' `get!`
+-/
+
+theorem get!ₘ_eq_getValue! [Ord α] [TransOrd α] {k : α} [Inhabited β]
+    {t : Impl α β} (hto : t.Ordered) : get!ₘ k t = getValue! k t.toListModel := by
+  simp [get!ₘ, get?ₘ_eq_getValue? hto, getValue!_eq_getValue?]
+
+theorem get!_eq_getValue! [Ord α] [TransOrd α] {k : α} [Inhabited β]
+    {t : Impl α β} (hto : t.Ordered) : get! k t = getValue! k t.toListModel := by
+  rw [get!_eq_get!ₘ, get!ₘ_eq_getValue! hto]
+
+/-!
+''' `getD`
+-/
+
+theorem getDₘ_eq_getValueD [Ord α] [TransOrd α] {k : α}
+    {t : Impl α β} {fallback : β} (hto : t.Ordered) :
+    getDₘ k t fallback = getValueD k t.toListModel fallback := by
+  simp [getDₘ, get?ₘ_eq_getValue? hto, getValueD_eq_getValue?]
+
+theorem getD_eq_getValueD [Ord α] [TransOrd α] {k : α}
+    {t : Impl α β} {fallback : β} (hto : t.Ordered) :
+    getD k t fallback = getValueD k t.toListModel fallback := by
+  rw [getD_eq_getDₘ, getDₘ_eq_getValueD hto]
+
 
 end Const
 

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -347,6 +347,7 @@ theorem get_insert [TransCmp cmp] [LawfulEqCmp cmp] {k a : α} {v : β k} {h₁}
         t.get a (contains_of_contains_insert h₁ h₂) :=
   Impl.get_insert t.wf
 
+@[simp]
 theorem get_insert_self [TransCmp cmp] [LawfulEqCmp cmp] {k : α} {v : β k} :
     (t.insert k v).get k contains_insert_self = v :=
   Impl.get_insert_self t.wf
@@ -370,6 +371,7 @@ theorem get_insert [TransCmp cmp] {k a : α} {v : β} {h₁} :
       else get t a (contains_of_contains_insert h₁ h₂) :=
   Impl.Const.get_insert t.wf
 
+@[simp]
 theorem get_insert_self [TransCmp cmp] {k : α} {v : β} :
     get (t.insert k v) k (contains_insert_self) = v :=
   Impl.Const.get_insert_self t.wf
@@ -392,6 +394,7 @@ theorem get_congr [TransCmp cmp] {a b : α} (hab : cmp a b = .eq) {h'} :
 
 end Const
 
+@[simp]
 theorem get!_emptyc [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)] :
     get! (∅ : DTreeMap α β cmp) a = default :=
   Impl.get!_empty
@@ -405,6 +408,7 @@ theorem get!_insert [TransCmp cmp] [LawfulEqCmp cmp] {k a : α} [Inhabited (β a
       if h : cmp k a = .eq then cast (congrArg β (compare_eq_iff_eq.mp h)) v else t.get! a :=
   Impl.get!_insert t.wf
 
+@[simp]
 theorem get!_insert_self [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)] {b : β a} :
     (t.insert a b).get! a = b :=
   Impl.get!_insert_self t.wf
@@ -421,6 +425,7 @@ theorem get!_erase [TransCmp cmp] [LawfulEqCmp cmp] {k a : α} [Inhabited (β a)
     (t.erase k).get! a = if cmp k a = .eq then default else t.get! a :=
   Impl.get!_erase t.wf
 
+@[simp]
 theorem get!_erase_self [TransCmp cmp] [LawfulEqCmp cmp] {k : α} [Inhabited (β k)] :
     (t.erase k).get! k = default :=
   Impl.get!_erase_self t.wf
@@ -445,6 +450,7 @@ namespace Const
 
 variable {β : Type v} (t : DTreeMap α β cmp)
 
+@[simp]
 theorem get!_emptyc [TransCmp cmp] [Inhabited β] {a : α} :
     get! (∅ : DTreeMap α β cmp) a = default :=
   Impl.Const.get!_empty
@@ -457,6 +463,7 @@ theorem get!_insert [TransCmp cmp] [Inhabited β] {k a : α} {v : β} :
     get! (t.insert k v) a = if cmp k a = .eq then v else get! t a :=
   Impl.Const.get!_insert t.wf
 
+@[simp]
 theorem get!_insert_self [TransCmp cmp] [Inhabited β] {k : α}
     {v : β} : get! (t.insert k v) k = v :=
   Impl.Const.get!_insert_self t.wf
@@ -473,6 +480,7 @@ theorem get!_erase [TransCmp cmp] [Inhabited β] {k a : α} :
     get! (t.erase k) a = if cmp k a = .eq then default else get! t a :=
   Impl.Const.get!_erase t.wf
 
+@[simp]
 theorem get!_erase_self [TransCmp cmp] [Inhabited β] {k : α} :
     get! (t.erase k) k = default :=
   Impl.Const.get!_erase_self t.wf
@@ -503,6 +511,7 @@ theorem get!_congr [TransCmp cmp] [Inhabited β] {a b : α}
 
 end Const
 
+@[simp]
 theorem getD_emptyc [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} :
     (∅ : DTreeMap α β cmp).getD a fallback = fallback :=
   Impl.getD_empty
@@ -517,6 +526,7 @@ theorem getD_insert [TransCmp cmp] [LawfulEqCmp cmp] {k a : α} {fallback : β a
       else t.getD a fallback :=
   Impl.getD_insert t.wf
 
+@[simp]
 theorem getD_insert_self [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback b : β a} :
     (t.insert a b).getD a fallback = b :=
   Impl.getD_insert_self t.wf
@@ -533,6 +543,7 @@ theorem getD_erase [TransCmp cmp] [LawfulEqCmp cmp] {k a : α} {fallback : β a}
     (t.erase k).getD a fallback = if cmp k a = .eq then fallback else t.getD a fallback :=
   Impl.getD_erase t.wf
 
+@[simp]
 theorem getD_erase_self [TransCmp cmp] [LawfulEqCmp cmp] {k : α} {fallback : β k} :
     (t.erase k).getD k fallback = fallback :=
   Impl.getD_erase_self t.wf
@@ -561,6 +572,7 @@ namespace Const
 
 variable {β : Type v} (t : DTreeMap α β cmp)
 
+@[simp]
 theorem getD_empty [TransCmp cmp] {a : α} {fallback : β} :
     getD (empty : DTreeMap α β cmp) a fallback = fallback :=
   Impl.Const.getD_empty
@@ -573,6 +585,7 @@ theorem getD_insert [TransCmp cmp] {k a : α} {fallback v : β} :
     getD (t.insert k v) a fallback = if cmp k a = .eq then v else getD t a fallback :=
   Impl.Const.getD_insert t.wf
 
+@[simp]
 theorem getD_insert_self [TransCmp cmp] {k : α} {fallback v : β} :
     getD (t.insert k v) k fallback = v :=
   Impl.Const.getD_insert_self t.wf
@@ -592,6 +605,7 @@ theorem getD_erase [TransCmp cmp] {k a : α} {fallback : β} :
       getD t a fallback :=
   Impl.Const.getD_erase t.wf
 
+@[simp]
 theorem getD_erase_self [TransCmp cmp] {k : α} {fallback : β} :
     getD (t.erase k) k fallback = fallback :=
   Impl.Const.getD_erase_self t.wf

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -339,4 +339,258 @@ theorem get?_congr [TransCmp cmp] {a b : α} (hab : cmp a b = .eq) :
 
 end Const
 
+theorem get_insert [TransCmp cmp] [LawfulEqCmp cmp] {k a : α} {v : β k} {h₁} :
+    (t.insert k v).get a h₁ =
+      if h₂ : cmp k a = .eq then
+        cast (congrArg β (compare_eq_iff_eq.mp h₂)) v
+      else
+        t.get a (contains_of_contains_insert h₁ h₂) :=
+  Impl.get_insert t.wf
+
+theorem get_insert_self [TransCmp cmp] [LawfulEqCmp cmp] {k : α} {v : β k} :
+    (t.insert k v).get k contains_insert_self = v :=
+  Impl.get_insert_self t.wf
+
+@[simp]
+theorem get_erase [TransCmp cmp] [LawfulEqCmp cmp] {k a : α} {h'} :
+    (t.erase k).get a h' = t.get a (contains_of_contains_erase h') :=
+  Impl.get_erase t.wf
+
+theorem get?_eq_some_get [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {h'} : t.get? a = some (t.get a h') :=
+  Impl.get?_eq_some_get t.wf
+
+namespace Const
+
+variable {β : Type v} {t : DTreeMap α β cmp}
+
+theorem get_insert [TransCmp cmp] {k a : α} {v : β} {h₁} :
+    get (t.insert k v) a h₁ =
+      if h₂ : cmp k a = .eq then v
+      else get t a (contains_of_contains_insert h₁ h₂) :=
+  Impl.Const.get_insert t.wf
+
+theorem get_insert_self [TransCmp cmp] {k : α} {v : β} :
+    get (t.insert k v) k (contains_insert_self) = v :=
+  Impl.Const.get_insert_self t.wf
+
+@[simp]
+theorem get_erase [TransCmp cmp] {k a : α} {h'} :
+    get (t.erase k) a h' = get t a (contains_of_contains_erase h') :=
+  Impl.Const.get_erase t.wf
+
+theorem get?_eq_some_get [TransCmp cmp] {a : α} {h} :
+    get? t a = some (get t a h) :=
+  Impl.Const.get?_eq_some_get t.wf
+
+theorem get_eq_get [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {h} : get t a h = t.get a h :=
+  Impl.Const.get_eq_get t.wf
+
+theorem get_congr [TransCmp cmp] {a b : α} (hab : cmp a b = .eq) {h'} :
+    get t a h' = get t b ((contains_congr hab).symm.trans h') :=
+  Impl.Const.get_congr t.wf hab
+
+end Const
+
+theorem get!_empty [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)] :
+    get! (empty : DTreeMap α β cmp) a = default :=
+  Impl.get!_empty
+
+theorem get!_of_isEmpty [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)] :
+    t.isEmpty = true → t.get! a = default :=
+  Impl.get!_of_isEmpty t.wf
+
+theorem get!_insert [TransCmp cmp] [LawfulEqCmp cmp] {k a : α} [Inhabited (β a)] {v : β k} :
+    (t.insert k v).get! a =
+      if h : cmp k a = .eq then cast (congrArg β (compare_eq_iff_eq.mp h)) v else t.get! a :=
+  Impl.get!_insert t.wf
+
+theorem get!_insert_self [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)] {b : β a} :
+    (t.insert a b).get! a = b :=
+  Impl.get!_insert_self t.wf
+
+theorem get!_eq_default [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)] :
+    t.contains a = false → t.get! a = default :=
+  Impl.get!_eq_default t.wf
+
+theorem get!_erase [TransCmp cmp] [LawfulEqCmp cmp] {k a : α} [Inhabited (β a)] :
+    (t.erase k).get! a = if cmp k a = .eq then default else t.get! a :=
+  Impl.get!_erase t.wf
+
+theorem get!_erase_self [TransCmp cmp] [LawfulEqCmp cmp] {k : α} [Inhabited (β k)] :
+    (t.erase k).get! k = default :=
+  Impl.get!_erase_self t.wf
+
+theorem get?_eq_some_get! [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)] :
+    t.contains a = true → t.get? a = some (t.get! a) :=
+  Impl.get?_eq_some_get! t.wf
+
+theorem get!_eq_get!_get? [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)] :
+    t.get! a = (t.get? a).get! :=
+  Impl.get!_eq_get!_get? t.wf
+
+theorem get_eq_get! [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)] {h} :
+    t.get a h = t.get! a :=
+  Impl.get_eq_get! t.wf
+
+namespace Const
+
+variable {β : Type v} (t : DTreeMap α β cmp)
+
+theorem get!_empty [TransCmp cmp] [Inhabited β] {a : α} :
+    get! (empty : DTreeMap α β cmp) a = default :=
+  Impl.Const.get!_empty
+
+theorem get!_of_isEmpty [TransCmp cmp] [Inhabited β] {a : α} :
+    t.isEmpty = true → get! t a = default :=
+  Impl.Const.get!_of_isEmpty t.wf
+
+theorem get!_insert [TransCmp cmp] [Inhabited β] {k a : α} {v : β} :
+    get! (t.insert k v) a = if cmp k a = .eq then v else get! t a :=
+  Impl.Const.get!_insert t.wf
+
+theorem get!_insert_self [TransCmp cmp] [Inhabited β] {k : α}
+    {v : β} : get! (t.insert k v) k = v :=
+  Impl.Const.get!_insert_self t.wf
+
+theorem get!_eq_default [TransCmp cmp] [Inhabited β] {a : α} :
+    t.contains a = false → get! t a = default :=
+  Impl.Const.get!_eq_default t.wf
+
+theorem get!_erase [TransCmp cmp] [Inhabited β] {k a : α} :
+    get! (t.erase k) a = if cmp k a = .eq then default else get! t a :=
+  Impl.Const.get!_erase t.wf
+
+theorem get!_erase_self [TransCmp cmp] [Inhabited β] {k : α} :
+    get! (t.erase k) k = default :=
+  Impl.Const.get!_erase_self t.wf
+
+theorem get?_eq_some_get! [TransCmp cmp] [Inhabited β] {a : α} :
+    t.contains a = true → get? t a = some (get! t a) :=
+  Impl.Const.get?_eq_some_get! t.wf
+
+theorem get!_eq_get!_get? [TransCmp cmp] [Inhabited β] {a : α} :
+    get! t a = (get? t a).get! :=
+  Impl.Const.get!_eq_get!_get? t.wf
+
+theorem get_eq_get! [TransCmp cmp] [Inhabited β] {a : α} {h} :
+    get t a h = get! t a :=
+  Impl.Const.get_eq_get! t.wf
+
+theorem get!_eq_get! [TransCmp cmp] [LawfulEqCmp cmp] [Inhabited β] {a : α} :
+    get! t a = t.get! a :=
+  Impl.Const.get!_eq_get! t.wf
+
+theorem get!_congr [TransCmp cmp] [Inhabited β] {a b : α}
+    (hab : cmp a b = .eq) : get! t a = get! t b :=
+  Impl.Const.get!_congr t.wf hab
+
+end Const
+
+theorem getD_empty [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} :
+    (empty : DTreeMap α β cmp).getD a fallback = fallback :=
+  Impl.getD_empty
+
+theorem getD_of_isEmpty [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} : t.isEmpty = true → t.getD a fallback = fallback :=
+  Impl.getD_of_isEmpty t.wf
+
+theorem getD_insert [TransCmp cmp] [LawfulEqCmp cmp] {k a : α} {fallback : β a} {v : β k} :
+    (t.insert k v).getD a fallback =
+      if h : cmp k a = .eq then
+        cast (congrArg β (compare_eq_iff_eq.mp h)) v
+      else t.getD a fallback :=
+  Impl.getD_insert t.wf
+
+theorem getD_insert_self [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback b : β a} :
+    (t.insert a b).getD a fallback = b :=
+  Impl.getD_insert_self t.wf
+
+theorem getD_eq_fallback [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} :
+    t.contains a = false → t.getD a fallback = fallback :=
+  Impl.getD_eq_fallback t.wf
+
+theorem getD_erase [TransCmp cmp] [LawfulEqCmp cmp] {k a : α} {fallback : β a} :
+    (t.erase k).getD a fallback = if cmp k a = .eq then fallback else t.getD a fallback :=
+  Impl.getD_erase t.wf
+
+theorem getD_erase_self [TransCmp cmp] [LawfulEqCmp cmp] {k : α} {fallback : β k} :
+    (t.erase k).getD k fallback = fallback :=
+  Impl.getD_erase_self t.wf
+
+theorem get?_eq_some_getD [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} :
+    t.contains a = true → t.get? a = some (t.getD a fallback) :=
+  Impl.get?_eq_some_getD t.wf
+
+theorem getD_eq_getD_get? [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} :
+    t.getD a fallback = (t.get? a).getD fallback :=
+  Impl.getD_eq_getD_get? t.wf
+
+theorem get_eq_getD [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} {h} :
+    t.get a h = t.getD a fallback :=
+  Impl.get_eq_getD t.wf
+
+theorem get!_eq_getD_default [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)] :
+    t.get! a = t.getD a default :=
+  Impl.get!_eq_getD_default t.wf
+
+namespace Const
+
+variable {β : Type v} (t : DTreeMap α β cmp)
+
+theorem getD_empty [TransCmp cmp] {a : α} {fallback : β} :
+    getD (empty : DTreeMap α β cmp) a fallback = fallback :=
+  Impl.Const.getD_empty
+
+theorem getD_of_isEmpty [TransCmp cmp] {a : α} {fallback : β} :
+    t.isEmpty = true → getD t a fallback = fallback :=
+  Impl.Const.getD_of_isEmpty t.wf
+
+theorem getD_insert [TransCmp cmp] {k a : α} {fallback v : β} :
+    getD (t.insert k v) a fallback = if cmp k a = .eq then v else getD t a fallback :=
+  Impl.Const.getD_insert t.wf
+
+theorem getD_insert_self [TransCmp cmp] {k : α} {fallback v : β} :
+    getD (t.insert k v) k fallback = v :=
+  Impl.Const.getD_insert_self t.wf
+
+theorem getD_eq_fallback [TransCmp cmp] {a : α} {fallback : β} :
+    t.contains a = false → getD t a fallback = fallback :=
+  Impl.Const.getD_eq_fallback t.wf
+
+theorem getD_erase [TransCmp cmp] {k a : α} {fallback : β} :
+    getD (t.erase k) a fallback = if cmp k a = .eq then
+      fallback
+    else
+      getD t a fallback :=
+  Impl.Const.getD_erase t.wf
+
+theorem getD_erase_self [TransCmp cmp] {k : α} {fallback : β} :
+    getD (t.erase k) k fallback = fallback :=
+  Impl.Const.getD_erase_self t.wf
+
+theorem get?_eq_some_getD [TransCmp cmp] {a : α} {fallback : β} :
+    t.contains a = true → get? t a = some (getD t a fallback) :=
+  Impl.Const.get?_eq_some_getD t.wf
+
+theorem getD_eq_getD_get? [TransCmp cmp] {a : α} {fallback : β} :
+    getD t a fallback = (get? t a).getD fallback :=
+  Impl.Const.getD_eq_getD_get? t.wf
+
+theorem get_eq_getD [TransCmp cmp] {a : α} {fallback : β} {h} :
+    get t a h = getD t a fallback :=
+  Impl.Const.get_eq_getD t.wf
+
+theorem get!_eq_getD_default [TransCmp cmp] [Inhabited β] {a : α} :
+    get! t a = getD t a default :=
+  Impl.Const.get!_eq_getD_default t.wf
+
+theorem getD_eq_getD [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β} :
+    getD t a fallback = t.getD a fallback :=
+  Impl.Const.getD_eq_getD t.wf
+
+theorem getD_congr [TransCmp cmp] {a b : α} {fallback : β}
+    (hab : cmp a b = .eq) : getD t a fallback = getD t b fallback :=
+  Impl.Const.getD_congr t.wf hab
+
+end Const
+
 end Std.DTreeMap

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -142,7 +142,7 @@ theorem size_insert_le [TransCmp cmp] {k : α} {v : β k} :
 
 @[simp]
 theorem erase_emptyc {k : α} :
-    (∅ : DTreeMap α β cmp).erase k = empty :=
+    (∅ : DTreeMap α β cmp).erase k = ∅ :=
   ext <| Impl.erase_empty (instOrd := ⟨cmp⟩) (k := k)
 
 @[simp]
@@ -573,8 +573,8 @@ namespace Const
 variable {β : Type v} (t : DTreeMap α β cmp)
 
 @[simp]
-theorem getD_empty [TransCmp cmp] {a : α} {fallback : β} :
-    getD (empty : DTreeMap α β cmp) a fallback = fallback :=
+theorem getD_emptyc [TransCmp cmp] {a : α} {fallback : β} :
+    getD (∅ : DTreeMap α β cmp) a fallback = fallback :=
   Impl.Const.getD_empty
 
 theorem getD_of_isEmpty [TransCmp cmp] {a : α} {fallback : β} :

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -356,7 +356,8 @@ theorem get_erase [TransCmp cmp] [LawfulEqCmp cmp] {k a : α} {h'} :
     (t.erase k).get a h' = t.get a (contains_of_contains_erase h') :=
   Impl.get_erase t.wf
 
-theorem get?_eq_some_get [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {h'} : t.get? a = some (t.get a h') :=
+theorem get?_eq_some_get [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {h'} :
+    t.get? a = some (t.get a h') :=
   Impl.get?_eq_some_get t.wf
 
 namespace Const
@@ -391,8 +392,8 @@ theorem get_congr [TransCmp cmp] {a b : α} (hab : cmp a b = .eq) {h'} :
 
 end Const
 
-theorem get!_empty [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)] :
-    get! (empty : DTreeMap α β cmp) a = default :=
+theorem get!_emptyc [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)] :
+    get! (∅ : DTreeMap α β cmp) a = default :=
   Impl.get!_empty
 
 theorem get!_of_isEmpty [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)] :
@@ -408,8 +409,12 @@ theorem get!_insert_self [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (�
     (t.insert a b).get! a = b :=
   Impl.get!_insert_self t.wf
 
+theorem get!_eq_default_of_contains_eq_false [TransCmp cmp] [LawfulEqCmp cmp] {a : α}
+    [Inhabited (β a)] : t.contains a = false → t.get! a = default :=
+  Impl.get!_eq_default_of_contains_eq_false t.wf
+
 theorem get!_eq_default [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)] :
-    t.contains a = false → t.get! a = default :=
+    ¬ a ∈ t → t.get! a = default :=
   Impl.get!_eq_default t.wf
 
 theorem get!_erase [TransCmp cmp] [LawfulEqCmp cmp] {k a : α} [Inhabited (β a)] :
@@ -420,8 +425,12 @@ theorem get!_erase_self [TransCmp cmp] [LawfulEqCmp cmp] {k : α} [Inhabited (β
     (t.erase k).get! k = default :=
   Impl.get!_erase_self t.wf
 
-theorem get?_eq_some_get! [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)] :
+theorem get?_eq_some_get!_of_contains [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)] :
     t.contains a = true → t.get? a = some (t.get! a) :=
+  Impl.get?_eq_some_get!_of_contains t.wf
+
+theorem get?_eq_some_get! [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)] :
+    a ∈ t → t.get? a = some (t.get! a) :=
   Impl.get?_eq_some_get! t.wf
 
 theorem get!_eq_get!_get? [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)] :
@@ -436,8 +445,8 @@ namespace Const
 
 variable {β : Type v} (t : DTreeMap α β cmp)
 
-theorem get!_empty [TransCmp cmp] [Inhabited β] {a : α} :
-    get! (empty : DTreeMap α β cmp) a = default :=
+theorem get!_emptyc [TransCmp cmp] [Inhabited β] {a : α} :
+    get! (∅ : DTreeMap α β cmp) a = default :=
   Impl.Const.get!_empty
 
 theorem get!_of_isEmpty [TransCmp cmp] [Inhabited β] {a : α} :
@@ -452,8 +461,12 @@ theorem get!_insert_self [TransCmp cmp] [Inhabited β] {k : α}
     {v : β} : get! (t.insert k v) k = v :=
   Impl.Const.get!_insert_self t.wf
 
-theorem get!_eq_default [TransCmp cmp] [Inhabited β] {a : α} :
+theorem get!_eq_default_of_contains_eq_false [TransCmp cmp] [Inhabited β] {a : α} :
     t.contains a = false → get! t a = default :=
+  Impl.Const.get!_eq_default_of_contains_eq_false t.wf
+
+theorem get!_eq_default [TransCmp cmp] [Inhabited β] {a : α} :
+    ¬ a ∈ t → get! t a = default :=
   Impl.Const.get!_eq_default t.wf
 
 theorem get!_erase [TransCmp cmp] [Inhabited β] {k a : α} :
@@ -464,8 +477,12 @@ theorem get!_erase_self [TransCmp cmp] [Inhabited β] {k : α} :
     get! (t.erase k) k = default :=
   Impl.Const.get!_erase_self t.wf
 
-theorem get?_eq_some_get! [TransCmp cmp] [Inhabited β] {a : α} :
+theorem get?_eq_some_get!_of_contains [TransCmp cmp] [Inhabited β] {a : α} :
     t.contains a = true → get? t a = some (get! t a) :=
+  Impl.Const.get?_eq_some_get! t.wf
+
+theorem get?_eq_some_get! [TransCmp cmp] [Inhabited β] {a : α} :
+    a ∈ t → get? t a = some (get! t a) :=
   Impl.Const.get?_eq_some_get! t.wf
 
 theorem get!_eq_get!_get? [TransCmp cmp] [Inhabited β] {a : α} :
@@ -486,8 +503,8 @@ theorem get!_congr [TransCmp cmp] [Inhabited β] {a b : α}
 
 end Const
 
-theorem getD_empty [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} :
-    (empty : DTreeMap α β cmp).getD a fallback = fallback :=
+theorem getD_emptyc [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} :
+    (∅ : DTreeMap α β cmp).getD a fallback = fallback :=
   Impl.getD_empty
 
 theorem getD_of_isEmpty [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} : t.isEmpty = true → t.getD a fallback = fallback :=
@@ -504,8 +521,12 @@ theorem getD_insert_self [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback b :
     (t.insert a b).getD a fallback = b :=
   Impl.getD_insert_self t.wf
 
-theorem getD_eq_fallback [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} :
+theorem getD_eq_fallback_of_contains_eq_false [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} :
     t.contains a = false → t.getD a fallback = fallback :=
+  Impl.getD_eq_fallback_of_contains_eq_false t.wf
+
+theorem getD_eq_fallback [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} :
+    ¬ a ∈ t → t.getD a fallback = fallback :=
   Impl.getD_eq_fallback t.wf
 
 theorem getD_erase [TransCmp cmp] [LawfulEqCmp cmp] {k a : α} {fallback : β a} :
@@ -516,8 +537,12 @@ theorem getD_erase_self [TransCmp cmp] [LawfulEqCmp cmp] {k : α} {fallback : β
     (t.erase k).getD k fallback = fallback :=
   Impl.getD_erase_self t.wf
 
-theorem get?_eq_some_getD [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} :
+theorem get?_eq_some_getD_of_contains [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} :
     t.contains a = true → t.get? a = some (t.getD a fallback) :=
+  Impl.get?_eq_some_getD_of_contains t.wf
+
+theorem get?_eq_some_getD [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} :
+    a ∈ t → t.get? a = some (t.getD a fallback) :=
   Impl.get?_eq_some_getD t.wf
 
 theorem getD_eq_getD_get? [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} :
@@ -552,8 +577,12 @@ theorem getD_insert_self [TransCmp cmp] {k : α} {fallback v : β} :
     getD (t.insert k v) k fallback = v :=
   Impl.Const.getD_insert_self t.wf
 
-theorem getD_eq_fallback [TransCmp cmp] {a : α} {fallback : β} :
+theorem getD_eq_fallback_of_contains_eq_false [TransCmp cmp] {a : α} {fallback : β} :
     t.contains a = false → getD t a fallback = fallback :=
+  Impl.Const.getD_eq_fallback_of_contains_eq_false t.wf
+
+theorem getD_eq_fallback [TransCmp cmp] {a : α} {fallback : β} :
+    ¬ a ∈ t → getD t a fallback = fallback :=
   Impl.Const.getD_eq_fallback t.wf
 
 theorem getD_erase [TransCmp cmp] {k a : α} {fallback : β} :
@@ -567,8 +596,12 @@ theorem getD_erase_self [TransCmp cmp] {k : α} {fallback : β} :
     getD (t.erase k) k fallback = fallback :=
   Impl.Const.getD_erase_self t.wf
 
-theorem get?_eq_some_getD [TransCmp cmp] {a : α} {fallback : β} :
+theorem get?_eq_some_getD_of_contains [TransCmp cmp] {a : α} {fallback : β} :
     t.contains a = true → get? t a = some (getD t a fallback) :=
+  Impl.Const.get?_eq_some_getD_of_contains t.wf
+
+theorem get?_eq_some_getD [TransCmp cmp] {a : α} {fallback : β} :
+    a ∈ t → get? t a = some (getD t a fallback) :=
   Impl.Const.get?_eq_some_getD t.wf
 
 theorem getD_eq_getD_get? [TransCmp cmp] {a : α} {fallback : β} :

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -448,7 +448,7 @@ theorem get_eq_get! [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)]
 
 namespace Const
 
-variable {β : Type v} (t : DTreeMap α β cmp)
+variable {β : Type v} {t : DTreeMap α β cmp}
 
 @[simp]
 theorem get!_emptyc [TransCmp cmp] [Inhabited β] {a : α} :
@@ -570,7 +570,7 @@ theorem get!_eq_getD_default [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabite
 
 namespace Const
 
-variable {β : Type v} (t : DTreeMap α β cmp)
+variable {β : Type v} {t : DTreeMap α β cmp}
 
 @[simp]
 theorem getD_emptyc [TransCmp cmp] {a : α} {fallback : β} :

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -344,17 +344,17 @@ theorem get_insert [TransCmp cmp] [LawfulEqCmp cmp] {k a : α} {v : β k} {h₁}
       if h₂ : cmp k a = .eq then
         cast (congrArg β (compare_eq_iff_eq.mp h₂)) v
       else
-        t.get a (contains_of_contains_insert h₁ h₂) :=
+        t.get a (mem_of_mem_insert h₁ h₂) :=
   Impl.get_insert t.wf
 
 @[simp]
 theorem get_insert_self [TransCmp cmp] [LawfulEqCmp cmp] {k : α} {v : β k} :
-    (t.insert k v).get k contains_insert_self = v :=
+    (t.insert k v).get k mem_insert_self = v :=
   Impl.get_insert_self t.wf
 
 @[simp]
 theorem get_erase [TransCmp cmp] [LawfulEqCmp cmp] {k a : α} {h'} :
-    (t.erase k).get a h' = t.get a (contains_of_contains_erase h') :=
+    (t.erase k).get a h' = t.get a (mem_of_mem_erase h') :=
   Impl.get_erase t.wf
 
 theorem get?_eq_some_get [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {h'} :
@@ -368,17 +368,17 @@ variable {β : Type v} {t : DTreeMap α β cmp}
 theorem get_insert [TransCmp cmp] {k a : α} {v : β} {h₁} :
     get (t.insert k v) a h₁ =
       if h₂ : cmp k a = .eq then v
-      else get t a (contains_of_contains_insert h₁ h₂) :=
+      else get t a (mem_of_mem_insert h₁ h₂) :=
   Impl.Const.get_insert t.wf
 
 @[simp]
 theorem get_insert_self [TransCmp cmp] {k : α} {v : β} :
-    get (t.insert k v) k (contains_insert_self) = v :=
+    get (t.insert k v) k mem_insert_self = v :=
   Impl.Const.get_insert_self t.wf
 
 @[simp]
 theorem get_erase [TransCmp cmp] {k a : α} {h'} :
-    get (t.erase k) a h' = get t a (contains_of_contains_erase h') :=
+    get (t.erase k) a h' = get t a (mem_of_mem_erase h') :=
   Impl.Const.get_erase t.wf
 
 theorem get?_eq_some_get [TransCmp cmp] {a : α} {h} :
@@ -389,7 +389,7 @@ theorem get_eq_get [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {h} : get t a h = t
   Impl.Const.get_eq_get t.wf
 
 theorem get_congr [TransCmp cmp] {a b : α} (hab : cmp a b = .eq) {h'} :
-    get t a h' = get t b ((contains_congr hab).symm.trans h') :=
+    get t a h' = get t b ((mem_congr hab).mp h') :=
   Impl.Const.get_congr t.wf hab
 
 end Const

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -464,8 +464,7 @@ theorem get!_insert [TransCmp cmp] [Inhabited β] {k a : α} {v : β} :
   Impl.Const.get!_insert t.wf
 
 @[simp]
-theorem get!_insert_self [TransCmp cmp] [Inhabited β] {k : α}
-    {v : β} : get! (t.insert k v) k = v :=
+theorem get!_insert_self [TransCmp cmp] [Inhabited β] {k : α} {v : β} : get! (t.insert k v) k = v :=
   Impl.Const.get!_insert_self t.wf
 
 theorem get!_eq_default_of_contains_eq_false [TransCmp cmp] [Inhabited β] {a : α} :
@@ -505,8 +504,8 @@ theorem get!_eq_get! [TransCmp cmp] [LawfulEqCmp cmp] [Inhabited β] {a : α} :
     get! t a = t.get! a :=
   Impl.Const.get!_eq_get! t.wf
 
-theorem get!_congr [TransCmp cmp] [Inhabited β] {a b : α}
-    (hab : cmp a b = .eq) : get! t a = get! t b :=
+theorem get!_congr [TransCmp cmp] [Inhabited β] {a b : α} (hab : cmp a b = .eq) :
+    get! t a = get! t b :=
   Impl.Const.get!_congr t.wf hab
 
 end Const
@@ -516,7 +515,8 @@ theorem getD_emptyc [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} 
     (∅ : DTreeMap α β cmp).getD a fallback = fallback :=
   Impl.getD_empty
 
-theorem getD_of_isEmpty [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} : t.isEmpty = true → t.getD a fallback = fallback :=
+theorem getD_of_isEmpty [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} :
+    t.isEmpty = true → t.getD a fallback = fallback :=
   Impl.getD_of_isEmpty t.wf
 
 theorem getD_insert [TransCmp cmp] [LawfulEqCmp cmp] {k a : α} {fallback : β a} {v : β k} :
@@ -531,8 +531,8 @@ theorem getD_insert_self [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback b :
     (t.insert a b).getD a fallback = b :=
   Impl.getD_insert_self t.wf
 
-theorem getD_eq_fallback_of_contains_eq_false [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} :
-    t.contains a = false → t.getD a fallback = fallback :=
+theorem getD_eq_fallback_of_contains_eq_false [TransCmp cmp] [LawfulEqCmp cmp] {a : α}
+    {fallback : β a} : t.contains a = false → t.getD a fallback = fallback :=
   Impl.getD_eq_fallback_of_contains_eq_false t.wf
 
 theorem getD_eq_fallback [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} :
@@ -634,8 +634,8 @@ theorem getD_eq_getD [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β} :
     getD t a fallback = t.getD a fallback :=
   Impl.Const.getD_eq_getD t.wf
 
-theorem getD_congr [TransCmp cmp] {a b : α} {fallback : β}
-    (hab : cmp a b = .eq) : getD t a fallback = getD t b fallback :=
+theorem getD_congr [TransCmp cmp] {a b : α} {fallback : β} (hab : cmp a b = .eq) :
+    getD t a fallback = getD t b fallback :=
   Impl.Const.getD_congr t.wf hab
 
 end Const

--- a/src/Std/Data/DTreeMap/Raw.lean
+++ b/src/Std/Data/DTreeMap/Raw.lean
@@ -411,7 +411,7 @@ def getThenInsertIfNew? (t : Raw α β cmp) (a : α) (b : β) : Option β × Raw
 
 @[inline, inherit_doc DTreeMap.Const.get?]
 def get? (t : Raw α β cmp) (a : α) : Option β :=
-  letI : Ord α := ⟨cmp⟩; Impl.Const.get? a t.inner
+  letI : Ord α := ⟨cmp⟩; Impl.Const.get? t.inner a
 
 @[inline, inherit_doc get?, deprecated get? (since := "2025-02-12")]
 def find? (t : Raw α β cmp) (a : α) : Option β :=
@@ -419,11 +419,11 @@ def find? (t : Raw α β cmp) (a : α) : Option β :=
 
 @[inline, inherit_doc DTreeMap.Const.get]
 def get (t : Raw α β cmp) (a : α) (h : a ∈ t) : β :=
-  letI : Ord α := ⟨cmp⟩; Impl.Const.get a t.inner h
+  letI : Ord α := ⟨cmp⟩; Impl.Const.get t.inner a h
 
 @[inline, inherit_doc DTreeMap.Const.get!]
 def get! (t : Raw α β cmp) (a : α) [Inhabited β] : β :=
-  letI : Ord α := ⟨cmp⟩; Impl.Const.get! a t.inner
+  letI : Ord α := ⟨cmp⟩; Impl.Const.get! t.inner a
 
 @[inline, inherit_doc get!, deprecated get! (since := "2025-02-12")]
 def find! (t : Raw α β cmp) (a : α) [Inhabited β] : β :=
@@ -431,7 +431,7 @@ def find! (t : Raw α β cmp) (a : α) [Inhabited β] : β :=
 
 @[inline, inherit_doc DTreeMap.Const.getD]
 def getD (t : Raw α β cmp) (a : α) (fallback : β) : β :=
-  letI : Ord α := ⟨cmp⟩; Impl.Const.getD a t.inner fallback
+  letI : Ord α := ⟨cmp⟩; Impl.Const.getD t.inner a fallback
 
 @[inline, inherit_doc getD, deprecated getD (since := "2025-02-12")]
 def findD (t : Raw α β cmp) (a : α) (fallback : β) : β :=

--- a/src/Std/Data/DTreeMap/RawLemmas.lean
+++ b/src/Std/Data/DTreeMap/RawLemmas.lean
@@ -404,14 +404,14 @@ theorem get!_of_isEmpty [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} [In
     t.isEmpty = true → t.get! a = default :=
   Impl.get!_of_isEmpty h
 
-theorem get!_insert [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {k a : α} [Inhabited (β a)] {v : β k} :
-    (t.insert k v).get! a =
+theorem get!_insert [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {k a : α} [Inhabited (β a)]
+    {v : β k} : (t.insert k v).get! a =
       if h : cmp k a = .eq then cast (congrArg β (compare_eq_iff_eq.mp h)) v else t.get! a :=
   Impl.get!_insert! h
 
 @[simp]
-theorem get!_insert_self [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} [Inhabited (β a)] {b : β a} :
-    (t.insert a b).get! a = b :=
+theorem get!_insert_self [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} [Inhabited (β a)]
+    {b : β a} : (t.insert a b).get! a = b :=
   Impl.get!_insert!_self h
 
 theorem get!_eq_default_of_contains_eq_false [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α}
@@ -431,8 +431,8 @@ theorem get!_erase_self [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {k : α} [In
     (t.erase k).get! k = default :=
   Impl.get!_erase!_self h
 
-theorem get?_eq_some_get!_of_contains [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} [Inhabited (β a)] :
-    t.contains a = true → t.get? a = some (t.get! a) :=
+theorem get?_eq_some_get!_of_contains [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α}
+    [Inhabited (β a)] : t.contains a = true → t.get? a = some (t.get! a) :=
   Impl.get?_eq_some_get!_of_contains h
 
 theorem get?_eq_some_get! [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} [Inhabited (β a)] :
@@ -465,8 +465,8 @@ theorem get!_insert [TransCmp cmp] [Inhabited β] (h : t.WF) {k a : α} {v : β}
   Impl.Const.get!_insert! h
 
 @[simp]
-theorem get!_insert_self [TransCmp cmp] [Inhabited β] (h : t.WF) {k : α}
-    {v : β} : get! (t.insert k v) k = v :=
+theorem get!_insert_self [TransCmp cmp] [Inhabited β] (h : t.WF) {k : α} {v : β} :
+    get! (t.insert k v) k = v :=
   Impl.Const.get!_insert!_self h
 
 theorem get!_eq_default_of_contains_eq_false [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
@@ -506,8 +506,8 @@ theorem get!_eq_get! [TransCmp cmp] [LawfulEqCmp cmp] [Inhabited β] (h : t.WF) 
     get! t a = t.get! a :=
   Impl.Const.get!_eq_get! h
 
-theorem get!_congr [TransCmp cmp] [Inhabited β] (h : t.WF) {a b : α}
-    (hab : cmp a b = .eq) : get! t a = get! t b :=
+theorem get!_congr [TransCmp cmp] [Inhabited β] (h : t.WF) {a b : α} (hab : cmp a b = .eq) :
+    get! t a = get! t b :=
   Impl.Const.get!_congr h hab
 
 end Const
@@ -517,7 +517,8 @@ theorem getD_emptyc [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} 
     (∅ : DTreeMap α β cmp).getD a fallback = fallback :=
   Impl.getD_empty
 
-theorem getD_of_isEmpty [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} {fallback : β a} : t.isEmpty = true → t.getD a fallback = fallback :=
+theorem getD_of_isEmpty [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} {fallback : β a} :
+    t.isEmpty = true → t.getD a fallback = fallback :=
   Impl.getD_of_isEmpty h
 
 theorem getD_insert [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {k a : α} {fallback : β a} {v : β k} :
@@ -549,8 +550,8 @@ theorem getD_erase_self [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {k : α} {fa
     (t.erase k).getD k fallback = fallback :=
   Impl.getD_erase!_self h
 
-theorem get?_eq_some_getD_of_contains [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} {fallback : β a} :
-    t.contains a = true → t.get? a = some (t.getD a fallback) :=
+theorem get?_eq_some_getD_of_contains [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α}
+    {fallback : β a} : t.contains a = true → t.get? a = some (t.getD a fallback) :=
   Impl.get?_eq_some_getD_of_contains h
 
 theorem get?_eq_some_getD [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} {fallback : β a} :
@@ -635,8 +636,8 @@ theorem getD_eq_getD [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} {fallb
     getD t a fallback = t.getD a fallback :=
   Impl.Const.getD_eq_getD h
 
-theorem getD_congr [TransCmp cmp] (h : t.WF) {a b : α} {fallback : β}
-    (hab : cmp a b = .eq) : getD t a fallback = getD t b fallback :=
+theorem getD_congr [TransCmp cmp] (h : t.WF) {a b : α} {fallback : β} (hab : cmp a b = .eq) :
+    getD t a fallback = getD t b fallback :=
   Impl.Const.getD_congr h hab
 
 end Const

--- a/src/Std/Data/DTreeMap/RawLemmas.lean
+++ b/src/Std/Data/DTreeMap/RawLemmas.lean
@@ -449,7 +449,7 @@ theorem get_eq_get! [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} [Inhabi
 
 namespace Const
 
-variable {β : Type v} (t : Raw α β cmp)
+variable {β : Type v} {t : Raw α β cmp}
 
 @[simp]
 theorem get!_emptyc [TransCmp cmp] [Inhabited β] {a : α} :
@@ -571,7 +571,7 @@ theorem get!_eq_getD_default [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α
 
 namespace Const
 
-variable {β : Type v} (t : Raw α β cmp)
+variable {β : Type v} {t : Raw α β cmp}
 
 @[simp]
 theorem getD_emptyc [TransCmp cmp] {a : α} {fallback : β} :

--- a/src/Std/Data/DTreeMap/RawLemmas.lean
+++ b/src/Std/Data/DTreeMap/RawLemmas.lean
@@ -344,17 +344,17 @@ theorem get_insert [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {k a : α} {v : �
       if h₂ : cmp k a = .eq then
         cast (congrArg β (compare_eq_iff_eq.mp h₂)) v
       else
-        t.get a (contains_of_contains_insert h h₁ h₂) :=
+        t.get a (mem_of_mem_insert h h₁ h₂) :=
   Impl.get_insert! h
 
 @[simp]
 theorem get_insert_self [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {k : α} {v : β k} :
-    (t.insert k v).get k (contains_insert_self h) = v :=
+    (t.insert k v).get k (mem_insert_self h) = v :=
   Impl.get_insert!_self h
 
 @[simp]
 theorem get_erase [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {k a : α} {h'} :
-    (t.erase k).get a h' = t.get a (contains_of_contains_erase h h') :=
+    (t.erase k).get a h' = t.get a (mem_of_mem_erase h h') :=
   Impl.get_erase! h
 
 theorem get?_eq_some_get [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} {h'} :
@@ -368,17 +368,17 @@ variable {β : Type v} {t : Raw α β cmp}
 theorem get_insert [TransCmp cmp] (h : t.WF) {k a : α} {v : β} {h₁} :
     get (t.insert k v) a h₁ =
       if h₂ : cmp k a = .eq then v
-      else get t a (contains_of_contains_insert h h₁ h₂) :=
+      else get t a (mem_of_mem_insert h h₁ h₂) :=
   Impl.Const.get_insert! h
 
 @[simp]
 theorem get_insert_self [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
-    get (t.insert k v) k (contains_insert_self h) = v :=
+    get (t.insert k v) k (mem_insert_self h) = v :=
   Impl.Const.get_insert!_self h
 
 @[simp]
 theorem get_erase [TransCmp cmp] (h : t.WF) {k a : α} {h'} :
-    get (t.erase k) a h' = get t a (contains_of_contains_erase h h') :=
+    get (t.erase k) a h' = get t a (mem_of_mem_erase h h') :=
   Impl.Const.get_erase! h
 
 theorem get?_eq_some_get [TransCmp cmp] (h : t.WF) {a : α} {h'} :
@@ -390,7 +390,7 @@ theorem get_eq_get [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} {h'} :
   Impl.Const.get_eq_get h
 
 theorem get_congr [TransCmp cmp] (h : t.WF) {a b : α} (hab : cmp a b = .eq) {h'} :
-    get t a h' = get t b ((contains_congr h hab).symm.trans h') :=
+    get t a h' = get t b ((mem_congr h hab).mp h') :=
   Impl.Const.get_congr h hab
 
 end Const

--- a/src/Std/Data/DTreeMap/RawLemmas.lean
+++ b/src/Std/Data/DTreeMap/RawLemmas.lean
@@ -142,7 +142,7 @@ theorem size_insert_le [TransCmp cmp] (h : t.WF) {k : α} {v : β k} :
 
 @[simp]
 theorem erase_emptyc {k : α} :
-    (∅ : Raw α β cmp).erase k = empty :=
+    (∅ : Raw α β cmp).erase k = ∅ :=
   ext <| Impl.erase!_empty (instOrd := ⟨cmp⟩) (k := k)
 
 @[simp]
@@ -336,6 +336,308 @@ theorem get?_eq_get? [LawfulEqCmp cmp] [TransCmp cmp] (h : t.WF) {a : α} : get?
 theorem get?_congr [TransCmp cmp] (h : t.WF) {a b : α} (hab : cmp a b = .eq) :
     get? t a = get? t b :=
   Impl.Const.get?_congr h hab
+
+end Const
+
+theorem get_insert [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {k a : α} {v : β k} {h₁} :
+    (t.insert k v).get a h₁ =
+      if h₂ : cmp k a = .eq then
+        cast (congrArg β (compare_eq_iff_eq.mp h₂)) v
+      else
+        t.get a (contains_of_contains_insert h h₁ h₂) :=
+  Impl.get_insert! h
+
+@[simp]
+theorem get_insert_self [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {k : α} {v : β k} :
+    (t.insert k v).get k (contains_insert_self h) = v :=
+  Impl.get_insert!_self h
+
+@[simp]
+theorem get_erase [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {k a : α} {h'} :
+    (t.erase k).get a h' = t.get a (contains_of_contains_erase h h') :=
+  Impl.get_erase! h
+
+theorem get?_eq_some_get [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} {h'} :
+    t.get? a = some (t.get a h') :=
+  Impl.get?_eq_some_get h
+
+namespace Const
+
+variable {β : Type v} {t : Raw α β cmp}
+
+theorem get_insert [TransCmp cmp] (h : t.WF) {k a : α} {v : β} {h₁} :
+    get (t.insert k v) a h₁ =
+      if h₂ : cmp k a = .eq then v
+      else get t a (contains_of_contains_insert h h₁ h₂) :=
+  Impl.Const.get_insert! h
+
+@[simp]
+theorem get_insert_self [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+    get (t.insert k v) k (contains_insert_self h) = v :=
+  Impl.Const.get_insert!_self h
+
+@[simp]
+theorem get_erase [TransCmp cmp] (h : t.WF) {k a : α} {h'} :
+    get (t.erase k) a h' = get t a (contains_of_contains_erase h h') :=
+  Impl.Const.get_erase! h
+
+theorem get?_eq_some_get [TransCmp cmp] (h : t.WF) {a : α} {h'} :
+    get? t a = some (get t a h') :=
+  Impl.Const.get?_eq_some_get h
+
+theorem get_eq_get [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} {h'} :
+    get t a h' = t.get a h' :=
+  Impl.Const.get_eq_get h
+
+theorem get_congr [TransCmp cmp] (h : t.WF) {a b : α} (hab : cmp a b = .eq) {h'} :
+    get t a h' = get t b ((contains_congr h hab).symm.trans h') :=
+  Impl.Const.get_congr h hab
+
+end Const
+
+@[simp]
+theorem get!_emptyc [TransCmp cmp] [LawfulEqCmp cmp] {a : α} [Inhabited (β a)] :
+    get! (∅ : Raw α β cmp) a = default :=
+  Impl.get!_empty
+
+theorem get!_of_isEmpty [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} [Inhabited (β a)] :
+    t.isEmpty = true → t.get! a = default :=
+  Impl.get!_of_isEmpty h
+
+theorem get!_insert [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {k a : α} [Inhabited (β a)] {v : β k} :
+    (t.insert k v).get! a =
+      if h : cmp k a = .eq then cast (congrArg β (compare_eq_iff_eq.mp h)) v else t.get! a :=
+  Impl.get!_insert! h
+
+@[simp]
+theorem get!_insert_self [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} [Inhabited (β a)] {b : β a} :
+    (t.insert a b).get! a = b :=
+  Impl.get!_insert!_self h
+
+theorem get!_eq_default_of_contains_eq_false [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α}
+    [Inhabited (β a)] : t.contains a = false → t.get! a = default :=
+  Impl.get!_eq_default_of_contains_eq_false h
+
+theorem get!_eq_default [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} [Inhabited (β a)] :
+    ¬ a ∈ t → t.get! a = default :=
+  Impl.get!_eq_default h
+
+theorem get!_erase [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {k a : α} [Inhabited (β a)] :
+    (t.erase k).get! a = if cmp k a = .eq then default else t.get! a :=
+  Impl.get!_erase! h
+
+@[simp]
+theorem get!_erase_self [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {k : α} [Inhabited (β k)] :
+    (t.erase k).get! k = default :=
+  Impl.get!_erase!_self h
+
+theorem get?_eq_some_get!_of_contains [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} [Inhabited (β a)] :
+    t.contains a = true → t.get? a = some (t.get! a) :=
+  Impl.get?_eq_some_get!_of_contains h
+
+theorem get?_eq_some_get! [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} [Inhabited (β a)] :
+    a ∈ t → t.get? a = some (t.get! a) :=
+  Impl.get?_eq_some_get! h
+
+theorem get!_eq_get!_get? [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} [Inhabited (β a)] :
+    t.get! a = (t.get? a).get! :=
+  Impl.get!_eq_get!_get? h
+
+theorem get_eq_get! [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} [Inhabited (β a)] {h'} :
+    t.get a h' = t.get! a :=
+  Impl.get_eq_get! h
+
+namespace Const
+
+variable {β : Type v} (t : Raw α β cmp)
+
+@[simp]
+theorem get!_emptyc [TransCmp cmp] [Inhabited β] {a : α} :
+    get! (∅ : Raw α β cmp) a = default :=
+  Impl.Const.get!_empty
+
+theorem get!_of_isEmpty [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
+    t.isEmpty = true → get! t a = default :=
+  Impl.Const.get!_of_isEmpty h
+
+theorem get!_insert [TransCmp cmp] [Inhabited β] (h : t.WF) {k a : α} {v : β} :
+    get! (t.insert k v) a = if cmp k a = .eq then v else get! t a :=
+  Impl.Const.get!_insert! h
+
+@[simp]
+theorem get!_insert_self [TransCmp cmp] [Inhabited β] (h : t.WF) {k : α}
+    {v : β} : get! (t.insert k v) k = v :=
+  Impl.Const.get!_insert!_self h
+
+theorem get!_eq_default_of_contains_eq_false [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
+    t.contains a = false → get! t a = default :=
+  Impl.Const.get!_eq_default_of_contains_eq_false h
+
+theorem get!_eq_default [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
+    ¬ a ∈ t → get! t a = default :=
+  Impl.Const.get!_eq_default h
+
+theorem get!_erase [TransCmp cmp] [Inhabited β] (h : t.WF) {k a : α} :
+    get! (t.erase k) a = if cmp k a = .eq then default else get! t a :=
+  Impl.Const.get!_erase! h
+
+@[simp]
+theorem get!_erase_self [TransCmp cmp] [Inhabited β] (h : t.WF) {k : α} :
+    get! (t.erase k) k = default :=
+  Impl.Const.get!_erase!_self h
+
+theorem get?_eq_some_get!_of_contains [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
+    t.contains a = true → get? t a = some (get! t a) :=
+  Impl.Const.get?_eq_some_get! h
+
+theorem get?_eq_some_get! [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
+    a ∈ t → get? t a = some (get! t a) :=
+  Impl.Const.get?_eq_some_get! h
+
+theorem get!_eq_get!_get? [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
+    get! t a = (get? t a).get! :=
+  Impl.Const.get!_eq_get!_get? h
+
+theorem get_eq_get! [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} {h'} :
+    get t a h' = get! t a :=
+  Impl.Const.get_eq_get! h
+
+theorem get!_eq_get! [TransCmp cmp] [LawfulEqCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
+    get! t a = t.get! a :=
+  Impl.Const.get!_eq_get! h
+
+theorem get!_congr [TransCmp cmp] [Inhabited β] (h : t.WF) {a b : α}
+    (hab : cmp a b = .eq) : get! t a = get! t b :=
+  Impl.Const.get!_congr h hab
+
+end Const
+
+@[simp]
+theorem getD_emptyc [TransCmp cmp] [LawfulEqCmp cmp] {a : α} {fallback : β a} :
+    (∅ : DTreeMap α β cmp).getD a fallback = fallback :=
+  Impl.getD_empty
+
+theorem getD_of_isEmpty [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} {fallback : β a} : t.isEmpty = true → t.getD a fallback = fallback :=
+  Impl.getD_of_isEmpty h
+
+theorem getD_insert [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {k a : α} {fallback : β a} {v : β k} :
+    (t.insert k v).getD a fallback =
+      if h : cmp k a = .eq then
+        cast (congrArg β (compare_eq_iff_eq.mp h)) v
+      else t.getD a fallback :=
+  Impl.getD_insert! h
+
+@[simp]
+theorem getD_insert_self [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} {fallback b : β a} :
+    (t.insert a b).getD a fallback = b :=
+  Impl.getD_insert!_self h
+
+theorem getD_eq_fallback_of_contains_eq_false [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} {fallback : β a} :
+    t.contains a = false → t.getD a fallback = fallback :=
+  Impl.getD_eq_fallback_of_contains_eq_false h
+
+theorem getD_eq_fallback [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} {fallback : β a} :
+    ¬ a ∈ t → t.getD a fallback = fallback :=
+  Impl.getD_eq_fallback h
+
+theorem getD_erase [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {k a : α} {fallback : β a} :
+    (t.erase k).getD a fallback = if cmp k a = .eq then fallback else t.getD a fallback :=
+  Impl.getD_erase! h
+
+@[simp]
+theorem getD_erase_self [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {k : α} {fallback : β k} :
+    (t.erase k).getD k fallback = fallback :=
+  Impl.getD_erase!_self h
+
+theorem get?_eq_some_getD_of_contains [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} {fallback : β a} :
+    t.contains a = true → t.get? a = some (t.getD a fallback) :=
+  Impl.get?_eq_some_getD_of_contains h
+
+theorem get?_eq_some_getD [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} {fallback : β a} :
+    a ∈ t → t.get? a = some (t.getD a fallback) :=
+  Impl.get?_eq_some_getD h
+
+theorem getD_eq_getD_get? [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} {fallback : β a} :
+    t.getD a fallback = (t.get? a).getD fallback :=
+  Impl.getD_eq_getD_get? h
+
+theorem get_eq_getD [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} {fallback : β a} {h'} :
+    t.get a h' = t.getD a fallback :=
+  Impl.get_eq_getD h
+
+theorem get!_eq_getD_default [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} [Inhabited (β a)] :
+    t.get! a = t.getD a default :=
+  Impl.get!_eq_getD_default h
+
+namespace Const
+
+variable {β : Type v} (t : Raw α β cmp)
+
+@[simp]
+theorem getD_emptyc [TransCmp cmp] {a : α} {fallback : β} :
+    getD (∅ : Raw α β cmp) a fallback = fallback :=
+  Impl.Const.getD_empty
+
+theorem getD_of_isEmpty [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+    t.isEmpty = true → getD t a fallback = fallback :=
+  Impl.Const.getD_of_isEmpty h
+
+theorem getD_insert [TransCmp cmp] (h : t.WF) {k a : α} {fallback v : β} :
+    getD (t.insert k v) a fallback = if cmp k a = .eq then v else getD t a fallback :=
+  Impl.Const.getD_insert! h
+
+@[simp]
+theorem getD_insert_self [TransCmp cmp] (h : t.WF) {k : α} {fallback v : β} :
+    getD (t.insert k v) k fallback = v :=
+  Impl.Const.getD_insert!_self h
+
+theorem getD_eq_fallback_of_contains_eq_false [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+    t.contains a = false → getD t a fallback = fallback :=
+  Impl.Const.getD_eq_fallback_of_contains_eq_false h
+
+theorem getD_eq_fallback [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+    ¬ a ∈ t → getD t a fallback = fallback :=
+  Impl.Const.getD_eq_fallback h
+
+theorem getD_erase [TransCmp cmp] (h : t.WF) {k a : α} {fallback : β} :
+    getD (t.erase k) a fallback = if cmp k a = .eq then
+      fallback
+    else
+      getD t a fallback :=
+  Impl.Const.getD_erase! h
+
+@[simp]
+theorem getD_erase_self [TransCmp cmp] (h : t.WF) {k : α} {fallback : β} :
+    getD (t.erase k) k fallback = fallback :=
+  Impl.Const.getD_erase!_self h
+
+theorem get?_eq_some_getD_of_contains [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+    t.contains a = true → get? t a = some (getD t a fallback) :=
+  Impl.Const.get?_eq_some_getD_of_contains h
+
+theorem get?_eq_some_getD [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+    a ∈ t → get? t a = some (getD t a fallback) :=
+  Impl.Const.get?_eq_some_getD h
+
+theorem getD_eq_getD_get? [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+    getD t a fallback = (get? t a).getD fallback :=
+  Impl.Const.getD_eq_getD_get? h
+
+theorem get_eq_getD [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} {h'} :
+    get t a h' = getD t a fallback :=
+  Impl.Const.get_eq_getD h
+
+theorem get!_eq_getD_default [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
+    get! t a = getD t a default :=
+  Impl.Const.get!_eq_getD_default h
+
+theorem getD_eq_getD [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+    getD t a fallback = t.getD a fallback :=
+  Impl.Const.getD_eq_getD h
+
+theorem getD_congr [TransCmp cmp] (h : t.WF) {a b : α} {fallback : β}
+    (hab : cmp a b = .eq) : getD t a fallback = getD t b fallback :=
+  Impl.Const.getD_congr h hab
 
 end Const
 

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -139,7 +139,7 @@ theorem size_insert_le [TransCmp cmp] {k : α} {v : β} :
 
 @[simp]
 theorem erase_emptyc {k : α} :
-    (∅ : TreeMap α β cmp).erase k = empty :=
+    (∅ : TreeMap α β cmp).erase k = ∅ :=
   ext <| DTreeMap.erase_emptyc
 
 @[simp]

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -288,4 +288,145 @@ theorem getElem?_congr [TransCmp cmp] {a b : α} (hab : cmp a b = .eq) :
     t[a]? = t[b]? :=
   DTreeMap.Const.get?_congr hab
 
+theorem getElem_insert [TransCmp cmp] {k a : α} {v : β} {h₁} :
+    get (t.insert k v) a h₁ =
+      if h₂ : cmp k a = .eq then v
+      else get t a (contains_of_contains_insert h₁ h₂) :=
+  DTreeMap.Const.get_insert
+
+@[simp]
+theorem getElem_insert_self [TransCmp cmp] {k : α} {v : β} :
+    get (t.insert k v) k (contains_insert_self) = v :=
+  DTreeMap.Const.get_insert_self
+
+@[simp]
+theorem getElem_erase [TransCmp cmp] {k a : α} {h'} :
+    get (t.erase k) a h' = t[a]'(contains_of_contains_erase h') :=
+  DTreeMap.Const.get_erase
+
+theorem getElem?_eq_some_getElem [TransCmp cmp] {a : α} {h} :
+    t[a]? = some (t[a]'h) :=
+  DTreeMap.Const.get?_eq_some_get
+
+theorem getElem_congr [TransCmp cmp] {a b : α} (hab : cmp a b = .eq) {h'} :
+    t[a]'h' = t[b]'((contains_congr hab).symm.trans h') :=
+  DTreeMap.Const.get_congr hab
+
+@[simp]
+theorem getElem!_emptyc [TransCmp cmp] [Inhabited β] {a : α} :
+    get! (∅ : TreeMap α β cmp) a = default :=
+  DTreeMap.Const.get!_emptyc
+
+theorem getElem!_of_isEmpty [TransCmp cmp] [Inhabited β] {a : α} :
+    t.isEmpty = true → t[a]! = default :=
+  DTreeMap.Const.get!_of_isEmpty
+
+theorem getElem!_insert [TransCmp cmp] [Inhabited β] {k a : α} {v : β} :
+    get! (t.insert k v) a = if cmp k a = .eq then v else t[a]! :=
+  DTreeMap.Const.get!_insert
+
+@[simp]
+theorem getElem!_insert_self [TransCmp cmp] [Inhabited β] {k : α}
+    {v : β} : get! (t.insert k v) k = v :=
+  DTreeMap.Const.get!_insert_self
+
+theorem getElem!_eq_default_of_contains_eq_false [TransCmp cmp] [Inhabited β] {a : α} :
+    t.contains a = false → t[a]! = default :=
+  DTreeMap.Const.get!_eq_default_of_contains_eq_false
+
+theorem getElem!_eq_default [TransCmp cmp] [Inhabited β] {a : α} :
+    ¬ a ∈ t → t[a]! = default :=
+  DTreeMap.Const.get!_eq_default
+
+theorem getElem!_erase [TransCmp cmp] [Inhabited β] {k a : α} :
+    get! (t.erase k) a = if cmp k a = .eq then default else t[a]! :=
+  DTreeMap.Const.get!_erase
+
+@[simp]
+theorem getElem!_erase_self [TransCmp cmp] [Inhabited β] {k : α} :
+    get! (t.erase k) k = default :=
+  DTreeMap.Const.get!_erase_self
+
+theorem getElem?_eq_some_getElem!_of_contains [TransCmp cmp] [Inhabited β] {a : α} :
+    t.contains a = true → t[a]? = some t[a]! :=
+  DTreeMap.Const.get?_eq_some_get!
+
+theorem getElem?_eq_some_getElem! [TransCmp cmp] [Inhabited β] {a : α} :
+    a ∈ t → t[a]? = some t[a]! :=
+  DTreeMap.Const.get?_eq_some_get!
+
+theorem getElem!_eq_getElem!_getElem? [TransCmp cmp] [Inhabited β] {a : α} :
+    t[a]! = t[a]?.get! :=
+  DTreeMap.Const.get!_eq_get!_get?
+
+theorem getElem_eq_getElem! [TransCmp cmp] [Inhabited β] {a : α} {h} :
+    t[a]'h = t[a]! :=
+  DTreeMap.Const.get_eq_get!
+
+theorem getElem!_congr [TransCmp cmp] [Inhabited β] {a b : α}
+    (hab : cmp a b = .eq) : t[a]! = t[b]! :=
+  DTreeMap.Const.get!_congr hab
+
+@[simp]
+theorem getElemD_emptyc [TransCmp cmp] {a : α} {fallback : β} :
+    getD (∅ : TreeMap α β cmp) a fallback = fallback :=
+  DTreeMap.Const.getD_emptyc
+
+theorem getElemD_of_isEmpty [TransCmp cmp] {a : α} {fallback : β} :
+    t.isEmpty = true → getD t a fallback = fallback :=
+  DTreeMap.Const.getD_of_isEmpty
+
+theorem getElemD_insert [TransCmp cmp] {k a : α} {fallback v : β} :
+    getD (t.insert k v) a fallback = if cmp k a = .eq then v else getD t a fallback :=
+  DTreeMap.Const.getD_insert
+
+@[simp]
+theorem getElemD_insert_self [TransCmp cmp] {k : α} {fallback v : β} :
+    getD (t.insert k v) k fallback = v :=
+  DTreeMap.Const.getD_insert_self
+
+theorem getElemD_eq_fallback_of_contains_eq_false [TransCmp cmp] {a : α} {fallback : β} :
+    t.contains a = false → getD t a fallback = fallback :=
+  DTreeMap.Const.getD_eq_fallback_of_contains_eq_false
+
+theorem getElemD_eq_fallback [TransCmp cmp] {a : α} {fallback : β} :
+    ¬ a ∈ t → getD t a fallback = fallback :=
+  DTreeMap.Const.getD_eq_fallback
+
+theorem getElemD_erase [TransCmp cmp] {k a : α} {fallback : β} :
+    getD (t.erase k) a fallback = if cmp k a = .eq then
+      fallback
+    else
+      getD t a fallback :=
+  DTreeMap.Const.getD_erase
+
+@[simp]
+theorem getElemD_erase_self [TransCmp cmp] {k : α} {fallback : β} :
+    getD (t.erase k) k fallback = fallback :=
+  DTreeMap.Const.getD_erase_self
+
+theorem getElem?_eq_some_getElemD_of_contains [TransCmp cmp] {a : α} {fallback : β} :
+    t.contains a = true → get? t a = some (getD t a fallback) :=
+  DTreeMap.Const.get?_eq_some_getD_of_contains
+
+theorem getElem?_eq_some_getElemD [TransCmp cmp] {a : α} {fallback : β} :
+    a ∈ t → t[a]? = some (getD t a fallback) :=
+  DTreeMap.Const.get?_eq_some_getD
+
+theorem getElemD_eq_getElemD_getElem? [TransCmp cmp] {a : α} {fallback : β} :
+    getD t a fallback = t[a]?.getD fallback :=
+  DTreeMap.Const.getD_eq_getD_get?
+
+theorem getElem_eq_getElemD [TransCmp cmp] {a : α} {fallback : β} {h} :
+    t[a]'h = getD t a fallback :=
+  DTreeMap.Const.get_eq_getD
+
+theorem getElem!_eq_getElemD_default [TransCmp cmp] [Inhabited β] {a : α} :
+    t[a]! = getD t a default :=
+  DTreeMap.Const.get!_eq_getD_default
+
+theorem getElemD_congr [TransCmp cmp] {a b : α} {fallback : β}
+    (hab : cmp a b = .eq) : getD t a fallback = getD t b fallback :=
+  DTreeMap.Const.getD_congr hab
+
 end Std.TreeMap

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -289,19 +289,19 @@ theorem getElem?_congr [TransCmp cmp] {a b : α} (hab : cmp a b = .eq) :
   DTreeMap.Const.get?_congr hab
 
 theorem getElem_insert [TransCmp cmp] {k a : α} {v : β} {h₁} :
-    get (t.insert k v) a h₁ =
+    (t.insert k v)[a]'h₁ =
       if h₂ : cmp k a = .eq then v
       else get t a (contains_of_contains_insert h₁ h₂) :=
   DTreeMap.Const.get_insert
 
 @[simp]
 theorem getElem_insert_self [TransCmp cmp] {k : α} {v : β} :
-    get (t.insert k v) k (contains_insert_self) = v :=
+    (t.insert k v)[k]'(contains_insert_self) = v :=
   DTreeMap.Const.get_insert_self
 
 @[simp]
 theorem getElem_erase [TransCmp cmp] {k a : α} {h'} :
-    get (t.erase k) a h' = t[a]'(contains_of_contains_erase h') :=
+    (t.erase k)[a]'h' = t[a]'(contains_of_contains_erase h') :=
   DTreeMap.Const.get_erase
 
 theorem getElem?_eq_some_getElem [TransCmp cmp] {a : α} {h} :
@@ -314,20 +314,20 @@ theorem getElem_congr [TransCmp cmp] {a b : α} (hab : cmp a b = .eq) {h'} :
 
 @[simp]
 theorem getElem!_emptyc [TransCmp cmp] [Inhabited β] {a : α} :
-    get! (∅ : TreeMap α β cmp) a = default :=
-  DTreeMap.Const.get!_emptyc
+    (∅ : TreeMap α β cmp)[a]! = default :=
+  DTreeMap.Const.get!_emptyc (cmp := cmp) (a := a)
 
 theorem getElem!_of_isEmpty [TransCmp cmp] [Inhabited β] {a : α} :
     t.isEmpty = true → t[a]! = default :=
   DTreeMap.Const.get!_of_isEmpty
 
 theorem getElem!_insert [TransCmp cmp] [Inhabited β] {k a : α} {v : β} :
-    get! (t.insert k v) a = if cmp k a = .eq then v else t[a]! :=
+    (t.insert k v)[a]! = if cmp k a = .eq then v else t[a]! :=
   DTreeMap.Const.get!_insert
 
 @[simp]
 theorem getElem!_insert_self [TransCmp cmp] [Inhabited β] {k : α}
-    {v : β} : get! (t.insert k v) k = v :=
+    {v : β} : (t.insert k v)[k]! = v :=
   DTreeMap.Const.get!_insert_self
 
 theorem getElem!_eq_default_of_contains_eq_false [TransCmp cmp] [Inhabited β] {a : α} :
@@ -339,12 +339,12 @@ theorem getElem!_eq_default [TransCmp cmp] [Inhabited β] {a : α} :
   DTreeMap.Const.get!_eq_default
 
 theorem getElem!_erase [TransCmp cmp] [Inhabited β] {k a : α} :
-    get! (t.erase k) a = if cmp k a = .eq then default else t[a]! :=
+    (t.erase k)[a]! = if cmp k a = .eq then default else t[a]! :=
   DTreeMap.Const.get!_erase
 
 @[simp]
 theorem getElem!_erase_self [TransCmp cmp] [Inhabited β] {k : α} :
-    get! (t.erase k) k = default :=
+    (t.erase k)[k]! = default :=
   DTreeMap.Const.get!_erase_self
 
 theorem getElem?_eq_some_getElem!_of_contains [TransCmp cmp] [Inhabited β] {a : α} :
@@ -368,32 +368,32 @@ theorem getElem!_congr [TransCmp cmp] [Inhabited β] {a b : α}
   DTreeMap.Const.get!_congr hab
 
 @[simp]
-theorem getElemD_emptyc [TransCmp cmp] {a : α} {fallback : β} :
+theorem getD_emptyc [TransCmp cmp] {a : α} {fallback : β} :
     getD (∅ : TreeMap α β cmp) a fallback = fallback :=
   DTreeMap.Const.getD_emptyc
 
-theorem getElemD_of_isEmpty [TransCmp cmp] {a : α} {fallback : β} :
+theorem getD_of_isEmpty [TransCmp cmp] {a : α} {fallback : β} :
     t.isEmpty = true → getD t a fallback = fallback :=
   DTreeMap.Const.getD_of_isEmpty
 
-theorem getElemD_insert [TransCmp cmp] {k a : α} {fallback v : β} :
+theorem getD_insert [TransCmp cmp] {k a : α} {fallback v : β} :
     getD (t.insert k v) a fallback = if cmp k a = .eq then v else getD t a fallback :=
   DTreeMap.Const.getD_insert
 
 @[simp]
-theorem getElemD_insert_self [TransCmp cmp] {k : α} {fallback v : β} :
+theorem getD_insert_self [TransCmp cmp] {k : α} {fallback v : β} :
     getD (t.insert k v) k fallback = v :=
   DTreeMap.Const.getD_insert_self
 
-theorem getElemD_eq_fallback_of_contains_eq_false [TransCmp cmp] {a : α} {fallback : β} :
+theorem getD_eq_fallback_of_contains_eq_false [TransCmp cmp] {a : α} {fallback : β} :
     t.contains a = false → getD t a fallback = fallback :=
   DTreeMap.Const.getD_eq_fallback_of_contains_eq_false
 
-theorem getElemD_eq_fallback [TransCmp cmp] {a : α} {fallback : β} :
+theorem getD_eq_fallback [TransCmp cmp] {a : α} {fallback : β} :
     ¬ a ∈ t → getD t a fallback = fallback :=
   DTreeMap.Const.getD_eq_fallback
 
-theorem getElemD_erase [TransCmp cmp] {k a : α} {fallback : β} :
+theorem getD_erase [TransCmp cmp] {k a : α} {fallback : β} :
     getD (t.erase k) a fallback = if cmp k a = .eq then
       fallback
     else
@@ -401,31 +401,31 @@ theorem getElemD_erase [TransCmp cmp] {k a : α} {fallback : β} :
   DTreeMap.Const.getD_erase
 
 @[simp]
-theorem getElemD_erase_self [TransCmp cmp] {k : α} {fallback : β} :
+theorem getD_erase_self [TransCmp cmp] {k : α} {fallback : β} :
     getD (t.erase k) k fallback = fallback :=
   DTreeMap.Const.getD_erase_self
 
-theorem getElem?_eq_some_getElemD_of_contains [TransCmp cmp] {a : α} {fallback : β} :
+theorem getElem?_eq_some_getD_of_contains [TransCmp cmp] {a : α} {fallback : β} :
     t.contains a = true → get? t a = some (getD t a fallback) :=
   DTreeMap.Const.get?_eq_some_getD_of_contains
 
-theorem getElem?_eq_some_getElemD [TransCmp cmp] {a : α} {fallback : β} :
+theorem getElem?_eq_some_getD [TransCmp cmp] {a : α} {fallback : β} :
     a ∈ t → t[a]? = some (getD t a fallback) :=
   DTreeMap.Const.get?_eq_some_getD
 
-theorem getElemD_eq_getElemD_getElem? [TransCmp cmp] {a : α} {fallback : β} :
+theorem getD_eq_getD_getElem? [TransCmp cmp] {a : α} {fallback : β} :
     getD t a fallback = t[a]?.getD fallback :=
   DTreeMap.Const.getD_eq_getD_get?
 
-theorem getElem_eq_getElemD [TransCmp cmp] {a : α} {fallback : β} {h} :
+theorem getElem_eq_getD [TransCmp cmp] {a : α} {fallback : β} {h} :
     t[a]'h = getD t a fallback :=
   DTreeMap.Const.get_eq_getD
 
-theorem getElem!_eq_getElemD_default [TransCmp cmp] [Inhabited β] {a : α} :
+theorem getElem!_eq_getD_default [TransCmp cmp] [Inhabited β] {a : α} :
     t[a]! = getD t a default :=
   DTreeMap.Const.get!_eq_getD_default
 
-theorem getElemD_congr [TransCmp cmp] {a b : α} {fallback : β}
+theorem getD_congr [TransCmp cmp] {a b : α} {fallback : β}
     (hab : cmp a b = .eq) : getD t a fallback = getD t b fallback :=
   DTreeMap.Const.getD_congr hab
 

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -291,17 +291,17 @@ theorem getElem?_congr [TransCmp cmp] {a b : α} (hab : cmp a b = .eq) :
 theorem getElem_insert [TransCmp cmp] {k a : α} {v : β} {h₁} :
     (t.insert k v)[a]'h₁ =
       if h₂ : cmp k a = .eq then v
-      else get t a (contains_of_contains_insert h₁ h₂) :=
+      else get t a (mem_of_mem_insert h₁ h₂) :=
   DTreeMap.Const.get_insert
 
 @[simp]
 theorem getElem_insert_self [TransCmp cmp] {k : α} {v : β} :
-    (t.insert k v)[k]'(contains_insert_self) = v :=
+    (t.insert k v)[k]'mem_insert_self = v :=
   DTreeMap.Const.get_insert_self
 
 @[simp]
 theorem getElem_erase [TransCmp cmp] {k a : α} {h'} :
-    (t.erase k)[a]'h' = t[a]'(contains_of_contains_erase h') :=
+    (t.erase k)[a]'h' = t[a]'(mem_of_mem_erase h') :=
   DTreeMap.Const.get_erase
 
 theorem getElem?_eq_some_getElem [TransCmp cmp] {a : α} {h} :
@@ -309,7 +309,7 @@ theorem getElem?_eq_some_getElem [TransCmp cmp] {a : α} {h} :
   DTreeMap.Const.get?_eq_some_get
 
 theorem getElem_congr [TransCmp cmp] {a b : α} (hab : cmp a b = .eq) {h'} :
-    t[a]'h' = t[b]'((contains_congr hab).symm.trans h') :=
+    t[a]'h' = t[b]'((mem_congr hab).mp h') :=
   DTreeMap.Const.get_congr hab
 
 @[simp]

--- a/src/Std/Data/TreeMap/RawLemmas.lean
+++ b/src/Std/Data/TreeMap/RawLemmas.lean
@@ -289,17 +289,17 @@ theorem getElem?_congr [TransCmp cmp] (h : t.WF) {a b : α} (hab : cmp a b = .eq
 theorem getElem_insert [TransCmp cmp] (h : t.WF) {k a : α} {v : β} {h₁} :
     (t.insert k v)[a]'h₁ =
       if h₂ : cmp k a = .eq then v
-      else get t a (contains_of_contains_insert h h₁ h₂) :=
+      else t[a]'(mem_of_mem_insert h h₁ h₂) :=
   DTreeMap.Raw.Const.get_insert h
 
 @[simp]
 theorem getElem_insert_self [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
-    (t.insert k v)[k]'(contains_insert_self h) = v :=
+    (t.insert k v)[k]'(mem_insert_self h) = v :=
   DTreeMap.Raw.Const.get_insert_self h
 
 @[simp]
 theorem getElem_erase [TransCmp cmp] (h : t.WF) {k a : α} {h'} :
-    (t.erase k)[a]'h' = t[a]'(contains_of_contains_erase h h') :=
+    (t.erase k)[a]'h' = t[a]'(mem_of_mem_erase h h') :=
   DTreeMap.Raw.Const.get_erase h
 
 theorem getElem?_eq_some_getElem [TransCmp cmp] (h : t.WF) {a : α} {h'} :
@@ -307,7 +307,7 @@ theorem getElem?_eq_some_getElem [TransCmp cmp] (h : t.WF) {a : α} {h'} :
   DTreeMap.Raw.Const.get?_eq_some_get h
 
 theorem getElem_congr [TransCmp cmp] (h : t.WF) {a b : α} (hab : cmp a b = .eq) {h'} :
-    t[a]'h' = t[b]'((contains_congr h hab).symm.trans h') :=
+    t[a]'h' = t[b]'((mem_congr h hab).mp h') :=
   DTreeMap.Raw.Const.get_congr h hab
 
 @[simp]

--- a/src/Std/Data/TreeMap/RawLemmas.lean
+++ b/src/Std/Data/TreeMap/RawLemmas.lean
@@ -139,7 +139,7 @@ theorem size_insert_le [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
 
 @[simp]
 theorem erase_emptyc {k : α} :
-    (empty : Raw α β cmp).erase k = empty :=
+    (∅ : Raw α β cmp).erase k = ∅ :=
   ext <| DTreeMap.Raw.erase_emptyc
 
 @[simp]
@@ -366,32 +366,32 @@ theorem getElem!_congr [TransCmp cmp] [Inhabited β] (h : t.WF) {a b : α}
   DTreeMap.Raw.Const.get!_congr h hab
 
 @[simp]
-theorem getD_emptyc [TransCmp cmp] {a : α} {fallback : β} :
+theorem getElemD_emptyc [TransCmp cmp] {a : α} {fallback : β} :
     getD (∅ : Raw α β cmp) a fallback = fallback :=
   DTreeMap.Raw.Const.getD_emptyc
 
-theorem getD_of_isEmpty [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+theorem getElemD_of_isEmpty [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
     t.isEmpty = true → getD t a fallback = fallback :=
   DTreeMap.Raw.Const.getD_of_isEmpty h
 
-theorem getD_insert [TransCmp cmp] (h : t.WF) {k a : α} {fallback v : β} :
+theorem getElemD_insert [TransCmp cmp] (h : t.WF) {k a : α} {fallback v : β} :
     getD (t.insert k v) a fallback = if cmp k a = .eq then v else getD t a fallback :=
   DTreeMap.Raw.Const.getD_insert h
 
 @[simp]
-theorem getD_insert_self [TransCmp cmp] (h : t.WF) {k : α} {fallback v : β} :
+theorem getElemD_insert_self [TransCmp cmp] (h : t.WF) {k : α} {fallback v : β} :
     getD (t.insert k v) k fallback = v :=
   DTreeMap.Raw.Const.getD_insert_self h
 
-theorem getD_eq_fallback_of_contains_eq_false [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+theorem getElemD_eq_fallback_of_contains_eq_false [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
     t.contains a = false → getD t a fallback = fallback :=
   DTreeMap.Raw.Const.getD_eq_fallback_of_contains_eq_false h
 
-theorem getD_eq_fallback [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+theorem getElemD_eq_fallback [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
     ¬ a ∈ t → getD t a fallback = fallback :=
   DTreeMap.Raw.Const.getD_eq_fallback h
 
-theorem getD_erase [TransCmp cmp] (h : t.WF) {k a : α} {fallback : β} :
+theorem getElemD_erase [TransCmp cmp] (h : t.WF) {k a : α} {fallback : β} :
     getD (t.erase k) a fallback = if cmp k a = .eq then
       fallback
     else
@@ -399,15 +399,15 @@ theorem getD_erase [TransCmp cmp] (h : t.WF) {k a : α} {fallback : β} :
   DTreeMap.Raw.Const.getD_erase h
 
 @[simp]
-theorem getD_erase_self [TransCmp cmp] (h : t.WF) {k : α} {fallback : β} :
+theorem getElemD_erase_self [TransCmp cmp] (h : t.WF) {k : α} {fallback : β} :
     getD (t.erase k) k fallback = fallback :=
   DTreeMap.Raw.Const.getD_erase_self h
 
-theorem getElem?_eq_some_getD_of_contains [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+theorem getElem?_eq_some_getElemD_of_contains [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
     t.contains a = true → get? t a = some (getD t a fallback) :=
   DTreeMap.Raw.Const.get?_eq_some_getD_of_contains h
 
-theorem getElem?_eq_some_getD [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+theorem getElem?_eq_some_getElemD [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
     a ∈ t → t[a]? = some (getD t a fallback) :=
   DTreeMap.Raw.Const.get?_eq_some_getD h
 
@@ -415,15 +415,15 @@ theorem getD_eq_getD_getElem? [TransCmp cmp] (h : t.WF) {a : α} {fallback : β}
     getD t a fallback = t[a]?.getD fallback :=
   DTreeMap.Raw.Const.getD_eq_getD_get? h
 
-theorem getElem_eq_getD [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} {h'} :
+theorem getElem_eq_getElemD [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} {h'} :
     t[a]'h' = getD t a fallback :=
   DTreeMap.Raw.Const.get_eq_getD h
 
-theorem getElem!_eq_getD_default [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
+theorem getElem!_eq_getElemD_default [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
     t[a]! = getD t a default :=
   DTreeMap.Raw.Const.get!_eq_getD_default h
 
-theorem getD_congr [TransCmp cmp] (h : t.WF) {a b : α} {fallback : β}
+theorem getElemD_congr [TransCmp cmp] (h : t.WF) {a b : α} {fallback : β}
     (hab : cmp a b = .eq) : getD t a fallback = getD t b fallback :=
   DTreeMap.Raw.Const.getD_congr h hab
 

--- a/src/Std/Data/TreeMap/RawLemmas.lean
+++ b/src/Std/Data/TreeMap/RawLemmas.lean
@@ -287,19 +287,19 @@ theorem getElem?_congr [TransCmp cmp] (h : t.WF) {a b : α} (hab : cmp a b = .eq
   DTreeMap.Raw.Const.get?_congr h hab
 
 theorem getElem_insert [TransCmp cmp] (h : t.WF) {k a : α} {v : β} {h₁} :
-    get (t.insert k v) a h₁ =
+    (t.insert k v)[a]'h₁ =
       if h₂ : cmp k a = .eq then v
       else get t a (contains_of_contains_insert h h₁ h₂) :=
   DTreeMap.Raw.Const.get_insert h
 
 @[simp]
 theorem getElem_insert_self [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
-    get (t.insert k v) k (contains_insert_self h) = v :=
+    (t.insert k v)[k]'(contains_insert_self h) = v :=
   DTreeMap.Raw.Const.get_insert_self h
 
 @[simp]
 theorem getElem_erase [TransCmp cmp] (h : t.WF) {k a : α} {h'} :
-    get (t.erase k) a h' = t[a]'(contains_of_contains_erase h h') :=
+    (t.erase k)[a]'h' = t[a]'(contains_of_contains_erase h h') :=
   DTreeMap.Raw.Const.get_erase h
 
 theorem getElem?_eq_some_getElem [TransCmp cmp] (h : t.WF) {a : α} {h'} :
@@ -312,20 +312,20 @@ theorem getElem_congr [TransCmp cmp] (h : t.WF) {a b : α} (hab : cmp a b = .eq)
 
 @[simp]
 theorem getElem!_emptyc [TransCmp cmp] [Inhabited β] {a : α} :
-    get! (∅ : Raw α β cmp) a = default :=
-  DTreeMap.Raw.Const.get!_emptyc
+    (∅ : Raw α β cmp)[a]! = default :=
+  DTreeMap.Raw.Const.get!_emptyc (cmp := cmp) (a := a)
 
 theorem getElem!_of_isEmpty [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
     t.isEmpty = true → t[a]! = default :=
   DTreeMap.Raw.Const.get!_of_isEmpty h
 
 theorem getElem!_insert [TransCmp cmp] [Inhabited β] (h : t.WF) {k a : α} {v : β} :
-    get! (t.insert k v) a = if cmp k a = .eq then v else t[a]! :=
+    (t.insert k v)[a]! = if cmp k a = .eq then v else t[a]! :=
   DTreeMap.Raw.Const.get!_insert h
 
 @[simp]
 theorem getElem!_insert_self [TransCmp cmp] [Inhabited β] (h : t.WF) {k : α}
-    {v : β} : get! (t.insert k v) k = v :=
+    {v : β} : (t.insert k v)[k]! = v :=
   DTreeMap.Raw.Const.get!_insert_self h
 
 theorem getElem!_eq_default_of_contains_eq_false [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
@@ -337,12 +337,12 @@ theorem getElem!_eq_default [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
   DTreeMap.Raw.Const.get!_eq_default h
 
 theorem getElem!_erase [TransCmp cmp] [Inhabited β] (h : t.WF) {k a : α} :
-    get! (t.erase k) a = if cmp k a = .eq then default else t[a]! :=
+    (t.erase k)[a]! = if cmp k a = .eq then default else t[a]! :=
   DTreeMap.Raw.Const.get!_erase h
 
 @[simp]
 theorem getElem!_erase_self [TransCmp cmp] [Inhabited β] (h : t.WF) {k : α} :
-    get! (t.erase k) k = default :=
+    (t.erase k)[k]! = default :=
   DTreeMap.Raw.Const.get!_erase_self h
 
 theorem getElem?_eq_some_getElem!_of_contains [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
@@ -366,32 +366,32 @@ theorem getElem!_congr [TransCmp cmp] [Inhabited β] (h : t.WF) {a b : α}
   DTreeMap.Raw.Const.get!_congr h hab
 
 @[simp]
-theorem getElemD_emptyc [TransCmp cmp] {a : α} {fallback : β} :
+theorem getD_emptyc [TransCmp cmp] {a : α} {fallback : β} :
     getD (∅ : Raw α β cmp) a fallback = fallback :=
   DTreeMap.Raw.Const.getD_emptyc
 
-theorem getElemD_of_isEmpty [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+theorem getD_of_isEmpty [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
     t.isEmpty = true → getD t a fallback = fallback :=
   DTreeMap.Raw.Const.getD_of_isEmpty h
 
-theorem getElemD_insert [TransCmp cmp] (h : t.WF) {k a : α} {fallback v : β} :
+theorem getD_insert [TransCmp cmp] (h : t.WF) {k a : α} {fallback v : β} :
     getD (t.insert k v) a fallback = if cmp k a = .eq then v else getD t a fallback :=
   DTreeMap.Raw.Const.getD_insert h
 
 @[simp]
-theorem getElemD_insert_self [TransCmp cmp] (h : t.WF) {k : α} {fallback v : β} :
+theorem getD_insert_self [TransCmp cmp] (h : t.WF) {k : α} {fallback v : β} :
     getD (t.insert k v) k fallback = v :=
   DTreeMap.Raw.Const.getD_insert_self h
 
-theorem getElemD_eq_fallback_of_contains_eq_false [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+theorem getD_eq_fallback_of_contains_eq_false [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
     t.contains a = false → getD t a fallback = fallback :=
   DTreeMap.Raw.Const.getD_eq_fallback_of_contains_eq_false h
 
-theorem getElemD_eq_fallback [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+theorem getD_eq_fallback [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
     ¬ a ∈ t → getD t a fallback = fallback :=
   DTreeMap.Raw.Const.getD_eq_fallback h
 
-theorem getElemD_erase [TransCmp cmp] (h : t.WF) {k a : α} {fallback : β} :
+theorem getD_erase [TransCmp cmp] (h : t.WF) {k a : α} {fallback : β} :
     getD (t.erase k) a fallback = if cmp k a = .eq then
       fallback
     else
@@ -399,31 +399,31 @@ theorem getElemD_erase [TransCmp cmp] (h : t.WF) {k a : α} {fallback : β} :
   DTreeMap.Raw.Const.getD_erase h
 
 @[simp]
-theorem getElemD_erase_self [TransCmp cmp] (h : t.WF) {k : α} {fallback : β} :
+theorem getD_erase_self [TransCmp cmp] (h : t.WF) {k : α} {fallback : β} :
     getD (t.erase k) k fallback = fallback :=
   DTreeMap.Raw.Const.getD_erase_self h
 
-theorem getElem?_eq_some_getElemD_of_contains [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+theorem getElem?_eq_some_getD_of_contains [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
     t.contains a = true → get? t a = some (getD t a fallback) :=
   DTreeMap.Raw.Const.get?_eq_some_getD_of_contains h
 
-theorem getElem?_eq_some_getElemD [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+theorem getElem?_eq_some_getD [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
     a ∈ t → t[a]? = some (getD t a fallback) :=
   DTreeMap.Raw.Const.get?_eq_some_getD h
 
-theorem getElemD_eq_getElemD_getElem? [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+theorem getD_eq_getD_getElem? [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
     getD t a fallback = t[a]?.getD fallback :=
   DTreeMap.Raw.Const.getD_eq_getD_get? h
 
-theorem getElem_eq_getElemD [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} {h'} :
+theorem getElem_eq_getD [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} {h'} :
     t[a]'h' = getD t a fallback :=
   DTreeMap.Raw.Const.get_eq_getD h
 
-theorem getElem!_eq_getElemD_default [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
+theorem getElem!_eq_getD_default [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
     t[a]! = getD t a default :=
   DTreeMap.Raw.Const.get!_eq_getD_default h
 
-theorem getElemD_congr [TransCmp cmp] (h : t.WF) {a b : α} {fallback : β}
+theorem getD_congr [TransCmp cmp] (h : t.WF) {a b : α} {fallback : β}
     (hab : cmp a b = .eq) : getD t a fallback = getD t b fallback :=
   DTreeMap.Raw.Const.getD_congr h hab
 

--- a/src/Std/Data/TreeMap/RawLemmas.lean
+++ b/src/Std/Data/TreeMap/RawLemmas.lean
@@ -366,32 +366,32 @@ theorem getElem!_congr [TransCmp cmp] [Inhabited β] (h : t.WF) {a b : α}
   DTreeMap.Raw.Const.get!_congr h hab
 
 @[simp]
-theorem getElemD_emptyc [TransCmp cmp] {a : α} {fallback : β} :
+theorem getD_emptyc [TransCmp cmp] {a : α} {fallback : β} :
     getD (∅ : Raw α β cmp) a fallback = fallback :=
   DTreeMap.Raw.Const.getD_emptyc
 
-theorem getElemD_of_isEmpty [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+theorem getD_of_isEmpty [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
     t.isEmpty = true → getD t a fallback = fallback :=
   DTreeMap.Raw.Const.getD_of_isEmpty h
 
-theorem getElemD_insert [TransCmp cmp] (h : t.WF) {k a : α} {fallback v : β} :
+theorem getD_insert [TransCmp cmp] (h : t.WF) {k a : α} {fallback v : β} :
     getD (t.insert k v) a fallback = if cmp k a = .eq then v else getD t a fallback :=
   DTreeMap.Raw.Const.getD_insert h
 
 @[simp]
-theorem getElemD_insert_self [TransCmp cmp] (h : t.WF) {k : α} {fallback v : β} :
+theorem getD_insert_self [TransCmp cmp] (h : t.WF) {k : α} {fallback v : β} :
     getD (t.insert k v) k fallback = v :=
   DTreeMap.Raw.Const.getD_insert_self h
 
-theorem getElemD_eq_fallback_of_contains_eq_false [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+theorem getD_eq_fallback_of_contains_eq_false [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
     t.contains a = false → getD t a fallback = fallback :=
   DTreeMap.Raw.Const.getD_eq_fallback_of_contains_eq_false h
 
-theorem getElemD_eq_fallback [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+theorem getD_eq_fallback [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
     ¬ a ∈ t → getD t a fallback = fallback :=
   DTreeMap.Raw.Const.getD_eq_fallback h
 
-theorem getElemD_erase [TransCmp cmp] (h : t.WF) {k a : α} {fallback : β} :
+theorem getD_erase [TransCmp cmp] (h : t.WF) {k a : α} {fallback : β} :
     getD (t.erase k) a fallback = if cmp k a = .eq then
       fallback
     else
@@ -399,15 +399,15 @@ theorem getElemD_erase [TransCmp cmp] (h : t.WF) {k a : α} {fallback : β} :
   DTreeMap.Raw.Const.getD_erase h
 
 @[simp]
-theorem getElemD_erase_self [TransCmp cmp] (h : t.WF) {k : α} {fallback : β} :
+theorem getD_erase_self [TransCmp cmp] (h : t.WF) {k : α} {fallback : β} :
     getD (t.erase k) k fallback = fallback :=
   DTreeMap.Raw.Const.getD_erase_self h
 
-theorem getElem?_eq_some_getElemD_of_contains [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+theorem getElem?_eq_some_getD_of_contains [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
     t.contains a = true → get? t a = some (getD t a fallback) :=
   DTreeMap.Raw.Const.get?_eq_some_getD_of_contains h
 
-theorem getElem?_eq_some_getElemD [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+theorem getElem?_eq_some_getD [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
     a ∈ t → t[a]? = some (getD t a fallback) :=
   DTreeMap.Raw.Const.get?_eq_some_getD h
 
@@ -415,15 +415,15 @@ theorem getD_eq_getD_getElem? [TransCmp cmp] (h : t.WF) {a : α} {fallback : β}
     getD t a fallback = t[a]?.getD fallback :=
   DTreeMap.Raw.Const.getD_eq_getD_get? h
 
-theorem getElem_eq_getElemD [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} {h'} :
+theorem getElem_eq_getD [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} {h'} :
     t[a]'h' = getD t a fallback :=
   DTreeMap.Raw.Const.get_eq_getD h
 
-theorem getElem!_eq_getElemD_default [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
+theorem getElem!_eq_getD_default [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
     t[a]! = getD t a default :=
   DTreeMap.Raw.Const.get!_eq_getD_default h
 
-theorem getElemD_congr [TransCmp cmp] (h : t.WF) {a b : α} {fallback : β}
+theorem getD_congr [TransCmp cmp] (h : t.WF) {a b : α} {fallback : β}
     (hab : cmp a b = .eq) : getD t a fallback = getD t b fallback :=
   DTreeMap.Raw.Const.getD_congr h hab
 

--- a/src/Std/Data/TreeMap/RawLemmas.lean
+++ b/src/Std/Data/TreeMap/RawLemmas.lean
@@ -286,4 +286,145 @@ theorem getElem?_congr [TransCmp cmp] (h : t.WF) {a b : α} (hab : cmp a b = .eq
     t[a]? = t[b]? :=
   DTreeMap.Raw.Const.get?_congr h hab
 
+theorem getElem_insert [TransCmp cmp] (h : t.WF) {k a : α} {v : β} {h₁} :
+    get (t.insert k v) a h₁ =
+      if h₂ : cmp k a = .eq then v
+      else get t a (contains_of_contains_insert h h₁ h₂) :=
+  DTreeMap.Raw.Const.get_insert h
+
+@[simp]
+theorem getElem_insert_self [TransCmp cmp] (h : t.WF) {k : α} {v : β} :
+    get (t.insert k v) k (contains_insert_self h) = v :=
+  DTreeMap.Raw.Const.get_insert_self h
+
+@[simp]
+theorem getElem_erase [TransCmp cmp] (h : t.WF) {k a : α} {h'} :
+    get (t.erase k) a h' = t[a]'(contains_of_contains_erase h h') :=
+  DTreeMap.Raw.Const.get_erase h
+
+theorem getElem?_eq_some_getElem [TransCmp cmp] (h : t.WF) {a : α} {h'} :
+    t[a]? = some (t[a]'h') :=
+  DTreeMap.Raw.Const.get?_eq_some_get h
+
+theorem getElem_congr [TransCmp cmp] (h : t.WF) {a b : α} (hab : cmp a b = .eq) {h'} :
+    t[a]'h' = t[b]'((contains_congr h hab).symm.trans h') :=
+  DTreeMap.Raw.Const.get_congr h hab
+
+@[simp]
+theorem getElem!_emptyc [TransCmp cmp] [Inhabited β] {a : α} :
+    get! (∅ : Raw α β cmp) a = default :=
+  DTreeMap.Raw.Const.get!_emptyc
+
+theorem getElem!_of_isEmpty [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
+    t.isEmpty = true → t[a]! = default :=
+  DTreeMap.Raw.Const.get!_of_isEmpty h
+
+theorem getElem!_insert [TransCmp cmp] [Inhabited β] (h : t.WF) {k a : α} {v : β} :
+    get! (t.insert k v) a = if cmp k a = .eq then v else t[a]! :=
+  DTreeMap.Raw.Const.get!_insert h
+
+@[simp]
+theorem getElem!_insert_self [TransCmp cmp] [Inhabited β] (h : t.WF) {k : α}
+    {v : β} : get! (t.insert k v) k = v :=
+  DTreeMap.Raw.Const.get!_insert_self h
+
+theorem getElem!_eq_default_of_contains_eq_false [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
+    t.contains a = false → t[a]! = default :=
+  DTreeMap.Raw.Const.get!_eq_default_of_contains_eq_false h
+
+theorem getElem!_eq_default [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
+    ¬ a ∈ t → t[a]! = default :=
+  DTreeMap.Raw.Const.get!_eq_default h
+
+theorem getElem!_erase [TransCmp cmp] [Inhabited β] (h : t.WF) {k a : α} :
+    get! (t.erase k) a = if cmp k a = .eq then default else t[a]! :=
+  DTreeMap.Raw.Const.get!_erase h
+
+@[simp]
+theorem getElem!_erase_self [TransCmp cmp] [Inhabited β] (h : t.WF) {k : α} :
+    get! (t.erase k) k = default :=
+  DTreeMap.Raw.Const.get!_erase_self h
+
+theorem getElem?_eq_some_getElem!_of_contains [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
+    t.contains a = true → t[a]? = some t[a]! :=
+  DTreeMap.Raw.Const.get?_eq_some_get! h
+
+theorem getElem?_eq_some_getElem! [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
+    a ∈ t → t[a]? = some t[a]! :=
+  DTreeMap.Raw.Const.get?_eq_some_get! h
+
+theorem getElem!_eq_getElem!_getElem? [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
+    t[a]! = t[a]?.get! :=
+  DTreeMap.Raw.Const.get!_eq_get!_get? h
+
+theorem getElem_eq_getElem! [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} {h'} :
+    t[a]'h' = t[a]! :=
+  DTreeMap.Raw.Const.get_eq_get! h
+
+theorem getElem!_congr [TransCmp cmp] [Inhabited β] (h : t.WF) {a b : α}
+    (hab : cmp a b = .eq) : t[a]! = t[b]! :=
+  DTreeMap.Raw.Const.get!_congr h hab
+
+@[simp]
+theorem getElemD_emptyc [TransCmp cmp] {a : α} {fallback : β} :
+    getD (∅ : Raw α β cmp) a fallback = fallback :=
+  DTreeMap.Raw.Const.getD_emptyc
+
+theorem getElemD_of_isEmpty [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+    t.isEmpty = true → getD t a fallback = fallback :=
+  DTreeMap.Raw.Const.getD_of_isEmpty h
+
+theorem getElemD_insert [TransCmp cmp] (h : t.WF) {k a : α} {fallback v : β} :
+    getD (t.insert k v) a fallback = if cmp k a = .eq then v else getD t a fallback :=
+  DTreeMap.Raw.Const.getD_insert h
+
+@[simp]
+theorem getElemD_insert_self [TransCmp cmp] (h : t.WF) {k : α} {fallback v : β} :
+    getD (t.insert k v) k fallback = v :=
+  DTreeMap.Raw.Const.getD_insert_self h
+
+theorem getElemD_eq_fallback_of_contains_eq_false [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+    t.contains a = false → getD t a fallback = fallback :=
+  DTreeMap.Raw.Const.getD_eq_fallback_of_contains_eq_false h
+
+theorem getElemD_eq_fallback [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+    ¬ a ∈ t → getD t a fallback = fallback :=
+  DTreeMap.Raw.Const.getD_eq_fallback h
+
+theorem getElemD_erase [TransCmp cmp] (h : t.WF) {k a : α} {fallback : β} :
+    getD (t.erase k) a fallback = if cmp k a = .eq then
+      fallback
+    else
+      getD t a fallback :=
+  DTreeMap.Raw.Const.getD_erase h
+
+@[simp]
+theorem getElemD_erase_self [TransCmp cmp] (h : t.WF) {k : α} {fallback : β} :
+    getD (t.erase k) k fallback = fallback :=
+  DTreeMap.Raw.Const.getD_erase_self h
+
+theorem getElem?_eq_some_getElemD_of_contains [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+    t.contains a = true → get? t a = some (getD t a fallback) :=
+  DTreeMap.Raw.Const.get?_eq_some_getD_of_contains h
+
+theorem getElem?_eq_some_getElemD [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+    a ∈ t → t[a]? = some (getD t a fallback) :=
+  DTreeMap.Raw.Const.get?_eq_some_getD h
+
+theorem getElemD_eq_getElemD_getElem? [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} :
+    getD t a fallback = t[a]?.getD fallback :=
+  DTreeMap.Raw.Const.getD_eq_getD_get? h
+
+theorem getElem_eq_getElemD [TransCmp cmp] (h : t.WF) {a : α} {fallback : β} {h'} :
+    t[a]'h' = getD t a fallback :=
+  DTreeMap.Raw.Const.get_eq_getD h
+
+theorem getElem!_eq_getElemD_default [TransCmp cmp] [Inhabited β] (h : t.WF) {a : α} :
+    t[a]! = getD t a default :=
+  DTreeMap.Raw.Const.get!_eq_getD_default h
+
+theorem getElemD_congr [TransCmp cmp] (h : t.WF) {a b : α} {fallback : β}
+    (hab : cmp a b = .eq) : getD t a fallback = getD t b fallback :=
+  DTreeMap.Raw.Const.getD_congr h hab
+
 end Std.TreeMap.Raw

--- a/src/Std/Data/TreeSet/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Lemmas.lean
@@ -134,7 +134,7 @@ theorem size_insert_le [TransCmp cmp] {k : α} :
 
 @[simp]
 theorem erase_emptyc {k : α} :
-    (empty : TreeSet α cmp).erase k = empty :=
+    (∅ : TreeSet α cmp).erase k = ∅ :=
   ext <| TreeMap.erase_emptyc
 
 @[simp]

--- a/src/Std/Data/TreeSet/RawLemmas.lean
+++ b/src/Std/Data/TreeSet/RawLemmas.lean
@@ -134,7 +134,7 @@ theorem size_insert_le [TransCmp cmp] (h : t.WF) {k : α} :
 
 @[simp]
 theorem erase_emptyc {k : α} :
-    (empty : Raw α cmp).erase k = empty :=
+    (∅ : Raw α cmp).erase k = ∅ :=
   ext <| TreeMap.Raw.erase_emptyc
 
 @[simp]


### PR DESCRIPTION
This PR provides lemmas for the tree map functions `get`, `get!` and `getD` in relation to the other operations for which lemmas already exist.

Internally, the `simp_to_model` tactic was provided two new simp lemmas to eliminate some common complications that require `rw`'ing before using `simp_to_model`. However, it is still necessary to sometimes `revert` some hypotheses.