### PR TITLE
fix: replace the `compare_self` simp lemma with a less generic one

### DIFF
--- a/src/Std/Classes/Ord.lean
+++ b/src/Std/Classes/Ord.lean
@@ -31,10 +31,9 @@ class ReflCmp {α : Type u} (cmp : α → α → Ordering) : Prop where
 /-- A typeclasses for ordered types for which `compare a a = .eq` for all `a`. -/
 abbrev ReflOrd (α : Type u) [Ord α] := ReflCmp (compare : α → α → Ordering)
 
+@[simp]
 theorem ReflOrd.compare_self {α : Type u} [Ord α] [ReflOrd α] {a : α} : compare a a = .eq :=
     ReflCmp.compare_self
-
-attribute [simp] ReflOrd.compare_self
 
 export ReflOrd (compare_self)
 

--- a/src/Std/Classes/Ord.lean
+++ b/src/Std/Classes/Ord.lean
@@ -28,12 +28,15 @@ class ReflCmp {α : Type u} (cmp : α → α → Ordering) : Prop where
   /-- Comparison is reflexive. -/
   compare_self {a : α} : cmp a a = .eq
 
-export ReflCmp (compare_self)
-
 /-- A typeclasses for ordered types for which `compare a a = .eq` for all `a`. -/
 abbrev ReflOrd (α : Type u) [Ord α] := ReflCmp (compare : α → α → Ordering)
 
-attribute [simp] compare_self
+theorem ReflOrd.compare_self {α : Type u} [Ord α] [ReflOrd α] {a : α} : compare a a = .eq :=
+    ReflCmp.compare_self
+
+attribute [simp] ReflOrd.compare_self
+
+export ReflOrd (compare_self)
 
 end Refl
 
@@ -266,7 +269,7 @@ variable {α : Type u} {cmp : α → α → Ordering} [LawfulEqCmp cmp]
 
 @[simp]
 theorem compare_eq_iff_eq {a b : α} : cmp a b = .eq ↔ a = b :=
-  ⟨LawfulEqCmp.eq_of_compare, by rintro rfl; simp⟩
+  ⟨LawfulEqCmp.eq_of_compare, by rintro rfl; exact ReflCmp.compare_self⟩
 
 @[simp]
 theorem compare_beq_iff_eq {a b : α} : cmp a b == .eq ↔ a = b :=
@@ -293,7 +296,7 @@ theorem beq_eq [Ord α] {a b : α} : (a == b) = (compare a b == .eq) :=
 theorem equivBEq_of_transOrd [Ord α] [TransOrd α] : EquivBEq α where
   symm {a b} h := by simp_all [OrientedCmp.eq_comm]
   trans h₁ h₂ := by simp_all only [beq_eq, beq_iff_eq]; exact TransCmp.eq_trans h₁ h₂
-  refl := by simp
+  refl := by simp only [beq_eq, beq_iff_eq]; exact compare_self
 
 theorem lawfulBEq_of_lawfulEqOrd [Ord α] [LawfulEqOrd α] : LawfulBEq α where
   eq_of_beq hbeq := by simp_all

--- a/src/Std/Data/DTreeMap/Internal/Cell.lean
+++ b/src/Std/Data/DTreeMap/Internal/Cell.lean
@@ -43,7 +43,7 @@ def ofEq [Ord α] {k : α → Ordering} (k' : α) (v' : β k') (hcmp : ∀ [Orie
 
 /-- Create a cell with a matching key. Internal implementation detail of the tree map -/
 def of [Ord α] (k : α) (v : β k) : Cell α β (compare k) :=
-  .ofEq k v (by intro; simp)
+  .ofEq k v compare_self
 
 @[simp]
 theorem ofEq_inner [Ord α] {k : α → Ordering} {k' : α} {v' : β k'} {h} :


### PR DESCRIPTION
This PR removes the `simp` attribute from `ReflCmp.compare_self` because it matches arbitrary function applications. Instead, a new `simp` lemma `ReflOrd.compare_self` is introduced, which only matches applications of `compare`.