### PR TITLE
feat: tree map lemmas for foldlM, foldl, foldrM and foldr

### DIFF
--- a/src/Std/Data/DHashMap/Basic.lean
+++ b/src/Std/Data/DHashMap/Basic.lean
@@ -210,6 +210,26 @@ instance [BEq α] [Hashable α] : ForM m (DHashMap α β) ((a : α) × β a) whe
 instance [BEq α] [Hashable α] : ForIn m (DHashMap α β) ((a : α) × β a) where
   forIn m init f := m.forIn (fun a b acc => f ⟨a, b⟩ acc) init
 
+namespace Const
+
+variable {β : Type v}
+
+/-!
+We do not define `ForM` and `ForIn` instances that are specialized to constant `β`. Instead, we
+define uncurried versions of `forM` and `forIn` that will be used in the `Const` lemmas and to
+define the `ForM` and `ForIn` instances for `HashMap`.
+-/
+
+@[inline, inherit_doc forM] def forMUncurried (f : α × β → m PUnit)
+    (b : DHashMap α (fun _ => β)) : m PUnit :=
+  b.forM fun a b => f ⟨a, b⟩
+
+@[inline, inherit_doc forIn] def forInUncurried
+    (f : α × β → δ → m (ForInStep δ)) (init : δ) (b : DHashMap α (fun _ => β)) : m δ :=
+  b.forIn (init := init) fun a b d => f ⟨a, b⟩ d
+
+end Const
+
 section Unverified
 
 /-! We currently do not provide lemmas for the functions below. -/

--- a/src/Std/Data/DHashMap/Internal/RawLemmas.lean
+++ b/src/Std/Data/DHashMap/Internal/RawLemmas.lean
@@ -987,11 +987,11 @@ theorem fold_eq_foldl_toList {f : δ → (a : α) → β → δ} {init : δ} :
 theorem foldRevM_eq_foldrM_toList [Monad m'] [LawfulMonad m']
     {f : δ → (a : α) → β → m' δ} {init : δ} :
     m.1.foldRevM f init = (Raw.Const.toList m.1).foldrM (fun a b => f b a.1 a.2) init := by
-  simp_to_model using List.foldrM_eq_foldrM_toProd
+  simp_to_model using List.foldrM_eq_foldrM_toProd'
 
 theorem foldRev_eq_foldr_toList {f : δ → (a : α) → β → δ} {init : δ} :
     m.1.foldRev f init = (Raw.Const.toList m.1).foldr (fun a b => f b a.1 a.2) init := by
-  simp_to_model using List.foldr_eq_foldr_toProd
+  simp_to_model using List.foldr_eq_foldr_toProd'
 
 theorem forM_eq_forM_toList [Monad m'] [LawfulMonad m'] {f : (a : α) → β → m' PUnit} :
     m.1.forM f = (Raw.Const.toList m.1).forM (fun a => f a.1 a.2) := by

--- a/src/Std/Data/DHashMap/Internal/RawLemmas.lean
+++ b/src/Std/Data/DHashMap/Internal/RawLemmas.lean
@@ -971,6 +971,33 @@ theorem forIn_eq_forIn_toList [Monad m'] [LawfulMonad m']
     m.1.forIn f init = ForIn.forIn m.1.toList init (fun a b => f a.1 a.2 b) := by
   simp_to_model
 
+theorem foldM_eq_foldlM_keys [Monad m'] [LawfulMonad m']
+    {f : δ → α → m' δ} {init : δ} :
+    m.1.foldM (fun d a _ => f d a) init = m.1.keys.foldlM f init := by
+  simp_to_model using List.foldlM_eq_foldlM_keys
+
+theorem fold_eq_foldl_keys {f : δ → α → δ} {init : δ} :
+    m.1.fold (fun d a _ => f d a) init = m.1.keys.foldl f init := by
+  simp_to_model using List.foldl_eq_foldl_keys
+
+theorem foldRevM_eq_foldrM_keys [Monad m'] [LawfulMonad m']
+    {f : δ → (a : α) → m' δ} {init : δ} :
+    m.1.foldRevM (fun d a _ => f d a) init = m.1.keys.foldrM (fun a b => f b a) init := by
+  simp_to_model using List.foldrM_eq_foldrM_keys'
+
+theorem foldRev_eq_foldr_keys {f : δ → (a : α) → δ} {init : δ} :
+    m.1.foldRev (fun d a _ => f d a) init = m.1.keys.foldr (fun a b => f b a) init := by
+  simp_to_model using List.foldr_eq_foldr_keys'
+
+theorem forM_eq_forM_keys [Monad m'] [LawfulMonad m'] {f : α → m' PUnit} :
+    m.1.forM (fun a _ => f a) = m.1.keys.forM f := by
+  simp_to_model using List.forM_eq_forM_keys
+
+theorem forIn_eq_forIn_keys [Monad m'] [LawfulMonad m']
+    {f : α → δ → m' (ForInStep δ)} {init : δ} :
+    m.1.forIn (fun a _ d => f a d) init = ForIn.forIn m.1.keys init f := by
+  simp_to_model using List.forIn_eq_forIn_keys
+
 namespace Const
 
 variable {β : Type v} (m : Raw₀ α (fun _ => β))
@@ -1001,35 +1028,6 @@ theorem forIn_eq_forIn_toList [Monad m'] [LawfulMonad m']
     {f : (a : α) → β → δ → m' (ForInStep δ)} {init : δ} :
     m.1.forIn f init = ForIn.forIn (Raw.Const.toList m.1) init (fun a b => f a.1 a.2 b) := by
   simp_to_model using List.forIn_eq_forIn_toProd
-
-variable (m : Raw₀ α (fun _ => Unit))
-
-theorem foldM_eq_foldlM_keys [Monad m'] [LawfulMonad m']
-    {f : δ → α → m' δ} {init : δ} :
-    m.1.foldM (fun d a _ => f d a) init = m.1.keys.foldlM f init := by
-  simp_to_model using List.foldlM_eq_foldlM_keys
-
-theorem fold_eq_foldl_keys {f : δ → α → δ} {init : δ} :
-    m.1.fold (fun d a _ => f d a) init = m.1.keys.foldl f init := by
-  simp_to_model using List.foldl_eq_foldl_keys
-
-theorem foldRevM_eq_foldrM_keys [Monad m'] [LawfulMonad m']
-    {f : δ → (a : α) → m' δ} {init : δ} :
-    m.1.foldRevM (fun d a _ => f d a) init = m.1.keys.foldrM (fun a b => f b a) init := by
-  simp_to_model using List.foldrM_eq_foldrM_keys
-
-theorem foldRev_eq_foldr_keys {f : δ → (a : α) → δ} {init : δ} :
-    m.1.foldRev (fun d a _ => f d a) init = m.1.keys.foldr (fun a b => f b a) init := by
-  simp_to_model using List.foldr_eq_foldr_keys
-
-theorem forM_eq_forM_keys [Monad m'] [LawfulMonad m'] {f : α → m' PUnit} :
-    m.1.forM (fun a _ => f a) = m.1.keys.forM f := by
-  simp_to_model using List.forM_eq_forM_keys
-
-theorem forIn_eq_forIn_keys [Monad m'] [LawfulMonad m']
-    {f : α → δ → m' (ForInStep δ)} {init : δ} :
-    m.1.forIn (fun a _ d => f a d) init = ForIn.forIn m.1.keys init f := by
-  simp_to_model using List.forIn_eq_forIn_keys
 
 end Const
 

--- a/src/Std/Data/DHashMap/Lemmas.lean
+++ b/src/Std/Data/DHashMap/Lemmas.lean
@@ -1116,12 +1116,12 @@ theorem fold_eq_foldl_keys {f : δ → α → δ} {init : δ} :
   Raw₀.fold_eq_foldl_keys ⟨m.1, m.2.size_buckets_pos⟩
 
 theorem forM_eq_forM_keys [Monad m'] [LawfulMonad m'] {f : α → m' PUnit} :
-    m.forM (fun a _ => f a) = m.keys.forM f :=
+    ForM.forM m (fun a => f a.1) = m.keys.forM f :=
   Raw₀.forM_eq_forM_keys ⟨m.1, m.2.size_buckets_pos⟩
 
 theorem forIn_eq_forIn_keys [Monad m'] [LawfulMonad m'] {f : α → δ → m' (ForInStep δ)}
     {init : δ} :
-    m.forIn (fun a _ d => f a d) init = ForIn.forIn m.keys init f :=
+    ForIn.forIn m init (fun a d => f a.1 d) = ForIn.forIn m.keys init f :=
   Raw₀.forIn_eq_forIn_keys ⟨m.1, m.2.size_buckets_pos⟩
 
 namespace Const
@@ -1137,13 +1137,37 @@ theorem fold_eq_foldl_toList {f : δ → (a : α) → β → δ} {init : δ} :
     m.fold f init = (Const.toList m).foldl (fun a b => f a b.1 b.2) init :=
   Raw₀.Const.fold_eq_foldl_toList ⟨m.1, m.2.size_buckets_pos⟩
 
-theorem forM_eq_forM_toList [Monad m'] [LawfulMonad m'] {f : (a : α) → β → m' PUnit} :
-    m.forM f = (Const.toList m).forM (fun a => f a.1 a.2) :=
+theorem forM_eq_forMUncurried [Monad m'] [LawfulMonad m'] {f : α → β → m' PUnit} :
+    DHashMap.forM f m = forMUncurried (fun a => f a.1 a.2) m := rfl
+
+theorem forMUncurried_eq_forM_toList [Monad m'] [LawfulMonad m'] {f : α × β → m' PUnit} :
+    Const.forMUncurried f m = (Const.toList m).forM f :=
   Raw₀.Const.forM_eq_forM_toList ⟨m.1, m.2.size_buckets_pos⟩
 
+/--
+Deprecated, use `forMUncurried_eq_forM_toList` together with `forM_eq_forMUncurried` instead.
+-/
+@[deprecated forMUncurried_eq_forM_toList (since := "2025-03-02")]
+theorem forM_eq_forM_toList [Monad m'] [LawfulMonad m'] {f : α → β → m' PUnit} :
+    DHashMap.forM f m = (Const.toList m).forM (fun a => f a.1 a.2) :=
+  Raw₀.Const.forM_eq_forM_toList ⟨m.1, m.2.size_buckets_pos⟩
+
+theorem forIn_eq_forInUncurried [Monad m'] [LawfulMonad m']
+    {f : α → β → δ → m' (ForInStep δ)} {init : δ} :
+    DHashMap.forIn f init m = forInUncurried (fun a b => f a.1 a.2 b) init m := rfl
+
+theorem forInUncurried_eq_forIn_toList [Monad m'] [LawfulMonad m']
+    {f : α × β → δ → m' (ForInStep δ)} {init : δ} :
+    Const.forInUncurried f init m = ForIn.forIn (Const.toList m) init f :=
+  Raw₀.Const.forIn_eq_forIn_toList ⟨m.1, m.2.size_buckets_pos⟩
+
+/--
+Deprecated, use `forInUncurried_eq_forIn_toList` together with `forIn_eq_forInUncurried` instead.
+-/
+@[deprecated forMUncurried_eq_forM_toList (since := "2025-03-02")]
 theorem forIn_eq_forIn_toList [Monad m'] [LawfulMonad m']
-    {f : (a : α) → β → δ → m' (ForInStep δ)} {init : δ} :
-    m.forIn f init = ForIn.forIn (Const.toList m) init (fun a b => f a.1 a.2 b) :=
+    {f : α × β → δ → m' (ForInStep δ)} {init : δ} :
+    Const.forInUncurried f init m = ForIn.forIn (Const.toList m) init f :=
   Raw₀.Const.forIn_eq_forIn_toList ⟨m.1, m.2.size_buckets_pos⟩
 
 variable {m : DHashMap α (fun _ => Unit)}

--- a/src/Std/Data/DHashMap/Lemmas.lean
+++ b/src/Std/Data/DHashMap/Lemmas.lean
@@ -1107,6 +1107,23 @@ theorem forIn_eq_forIn_toList [Monad m'] [LawfulMonad m']
     ForIn.forIn m init f = ForIn.forIn m.toList init f :=
   Raw₀.forIn_eq_forIn_toList ⟨m.1, m.2.size_buckets_pos⟩
 
+theorem foldM_eq_foldlM_keys [Monad m'] [LawfulMonad m'] {f : δ → α → m' δ} {init : δ} :
+    m.foldM (fun d a _ => f d a) init = m.keys.foldlM f init :=
+  Raw₀.foldM_eq_foldlM_keys ⟨m.1, m.2.size_buckets_pos⟩
+
+theorem fold_eq_foldl_keys {f : δ → α → δ} {init : δ} :
+    m.fold (fun d a _ => f d a) init = m.keys.foldl f init :=
+  Raw₀.fold_eq_foldl_keys ⟨m.1, m.2.size_buckets_pos⟩
+
+theorem forM_eq_forM_keys [Monad m'] [LawfulMonad m'] {f : α → m' PUnit} :
+    m.forM (fun a _ => f a) = m.keys.forM f :=
+  Raw₀.forM_eq_forM_keys ⟨m.1, m.2.size_buckets_pos⟩
+
+theorem forIn_eq_forIn_keys [Monad m'] [LawfulMonad m'] {f : α → δ → m' (ForInStep δ)}
+    {init : δ} :
+    m.forIn (fun a _ d => f a d) init = ForIn.forIn m.keys init f :=
+  Raw₀.forIn_eq_forIn_keys ⟨m.1, m.2.size_buckets_pos⟩
+
 namespace Const
 
 variable {β : Type v} {m : DHashMap α (fun _ => β)}
@@ -1131,23 +1148,27 @@ theorem forIn_eq_forIn_toList [Monad m'] [LawfulMonad m']
 
 variable {m : DHashMap α (fun _ => Unit)}
 
+@[deprecated DHashMap.foldM_eq_foldlM_keys (since := "2025-02-28")]
 theorem foldM_eq_foldlM_keys [Monad m'] [LawfulMonad m']
     {f : δ → α → m' δ} {init : δ} :
     m.foldM (fun d a _ => f d a) init = m.keys.foldlM f init :=
-  Raw₀.Const.foldM_eq_foldlM_keys ⟨m.1, m.2.size_buckets_pos⟩
+  Raw₀.foldM_eq_foldlM_keys ⟨m.1, m.2.size_buckets_pos⟩
 
+@[deprecated DHashMap.fold_eq_foldl_keys (since := "2025-02-28")]
 theorem fold_eq_foldl_keys {f : δ → α → δ} {init : δ} :
     m.fold (fun d a _ => f d a) init = m.keys.foldl f init :=
-  Raw₀.Const.fold_eq_foldl_keys ⟨m.1, m.2.size_buckets_pos⟩
+  Raw₀.fold_eq_foldl_keys ⟨m.1, m.2.size_buckets_pos⟩
 
+@[deprecated DHashMap.forM_eq_forM_keys (since := "2025-02-28")]
 theorem forM_eq_forM_keys [Monad m'] [LawfulMonad m'] {f : α → m' PUnit} :
     m.forM (fun a _ => f a) = m.keys.forM f :=
-  Raw₀.Const.forM_eq_forM_keys ⟨m.1, m.2.size_buckets_pos⟩
+  Raw₀.forM_eq_forM_keys ⟨m.1, m.2.size_buckets_pos⟩
 
+@[deprecated DHashMap.forIn_eq_forIn_keys (since := "2025-02-28")]
 theorem forIn_eq_forIn_keys [Monad m'] [LawfulMonad m']
     {f : α → δ → m' (ForInStep δ)} {init : δ} :
     m.forIn (fun a _ d => f a d) init = ForIn.forIn m.keys init f :=
-  Raw₀.Const.forIn_eq_forIn_keys ⟨m.1, m.2.size_buckets_pos⟩
+  Raw₀.forIn_eq_forIn_keys ⟨m.1, m.2.size_buckets_pos⟩
 
 end Const
 

--- a/src/Std/Data/DHashMap/Lemmas.lean
+++ b/src/Std/Data/DHashMap/Lemmas.lean
@@ -1164,7 +1164,7 @@ theorem forInUncurried_eq_forIn_toList [Monad m'] [LawfulMonad m']
 /--
 Deprecated, use `forInUncurried_eq_forIn_toList` together with `forIn_eq_forInUncurried` instead.
 -/
-@[deprecated forMUncurried_eq_forM_toList (since := "2025-03-02")]
+@[deprecated forInUncurried_eq_forIn_toList (since := "2025-03-02")]
 theorem forIn_eq_forIn_toList [Monad m'] [LawfulMonad m']
     {f : α × β → δ → m' (ForInStep δ)} {init : δ} :
     Const.forInUncurried f init m = ForIn.forIn (Const.toList m) init f :=

--- a/src/Std/Data/DHashMap/Raw.lean
+++ b/src/Std/Data/DHashMap/Raw.lean
@@ -373,6 +373,26 @@ instance : ForM m (Raw α β) ((a : α) × β a) where
 instance : ForIn m (Raw α β) ((a : α) × β a) where
   forIn m init f := m.forIn (fun a b acc => f ⟨a, b⟩ acc) init
 
+namespace Const
+
+variable {β : Type v}
+
+/-!
+We do not define `ForM` and `ForIn` instances that are specialized to constant `β`. Instead, we
+define uncurried versions of `forM` and `forIn` that will be used in the `Const` lemmas and to
+define the `ForM` and `ForIn` instances for `HashMap.Raw`.
+-/
+
+@[inline, inherit_doc forM] def forMUncurried (f : α × β → m PUnit)
+    (b : Raw α (fun _ => β)) : m PUnit :=
+  b.forM fun a b => f ⟨a, b⟩
+
+@[inline, inherit_doc forIn] def forInUncurried
+    (f : α × β → δ → m (ForInStep δ)) (init : δ) (b : Raw α (fun _ => β)) : m δ :=
+  b.forIn (init := init) fun a b d => f ⟨a, b⟩ d
+
+end Const
+
 section Unverified
 
 /-! We currently do not provide lemmas for the functions below. -/

--- a/src/Std/Data/DHashMap/RawLemmas.lean
+++ b/src/Std/Data/DHashMap/RawLemmas.lean
@@ -1202,6 +1202,24 @@ theorem forIn_eq_forIn_toList [Monad m'] [LawfulMonad m']
     ForIn.forIn m init f = ForIn.forIn m.toList init f :=
   Raw₀.forIn_eq_forIn_toList ⟨m, h.size_buckets_pos⟩
 
+theorem foldM_eq_foldlM_keys [Monad m'] [LawfulMonad m'] (h : m.WF)
+    {f : δ → α → m' δ} {init : δ} :
+    m.foldM (fun d a _ => f d a) init = m.keys.foldlM f init :=
+  Raw₀.foldM_eq_foldlM_keys ⟨m, h.size_buckets_pos⟩
+
+theorem fold_eq_foldl_keys (h : m.WF) {f : δ → α → δ} {init : δ} :
+    m.fold (fun d a _ => f d a) init = m.keys.foldl f init :=
+  Raw₀.fold_eq_foldl_keys ⟨m, h.size_buckets_pos⟩
+
+theorem forM_eq_forM_keys [Monad m'] [LawfulMonad m'] (h : m.WF) {f : α → m' PUnit} :
+    m.forM (fun a _ => f a) = m.keys.forM f :=
+  Raw₀.forM_eq_forM_keys ⟨m, h.size_buckets_pos⟩
+
+theorem forIn_eq_forIn_keys [Monad m'] [LawfulMonad m'] (h : m.WF)
+    {f : α → δ → m' (ForInStep δ)} {init : δ} :
+    m.forIn (fun a _ d => f a d) init = ForIn.forIn m.keys init f :=
+  Raw₀.forIn_eq_forIn_keys ⟨m, h.size_buckets_pos⟩
+
 namespace Const
 
 variable {β : Type v} {m : Raw α (fun _ => β)}
@@ -1226,23 +1244,27 @@ theorem forIn_eq_forIn_toList [Monad m'] [LawfulMonad m'] (h : m.WF)
 
 variable {m : Raw α (fun _ => Unit)}
 
+@[deprecated Raw.foldM_eq_foldlM_keys (since := "2025-02-28")]
 theorem foldM_eq_foldlM_keys [Monad m'] [LawfulMonad m'] (h : m.WF)
     {f : δ → α → m' δ} {init : δ} :
     m.foldM (fun d a _ => f d a) init = m.keys.foldlM f init :=
-  Raw₀.Const.foldM_eq_foldlM_keys ⟨m, h.size_buckets_pos⟩
+  Raw₀.foldM_eq_foldlM_keys ⟨m, h.size_buckets_pos⟩
 
+@[deprecated Raw.fold_eq_foldl_keys (since := "2025-02-28")]
 theorem fold_eq_foldl_keys (h : m.WF) {f : δ → α → δ} {init : δ} :
     m.fold (fun d a _ => f d a) init = m.keys.foldl f init :=
-  Raw₀.Const.fold_eq_foldl_keys ⟨m, h.size_buckets_pos⟩
+  Raw₀.fold_eq_foldl_keys ⟨m, h.size_buckets_pos⟩
 
+@[deprecated Raw.forM_eq_forM_keys (since := "2025-02-28")]
 theorem forM_eq_forM_keys [Monad m'] [LawfulMonad m'] (h : m.WF) {f : α → m' PUnit} :
     m.forM (fun a _ => f a) = m.keys.forM f :=
-  Raw₀.Const.forM_eq_forM_keys ⟨m, h.size_buckets_pos⟩
+  Raw₀.forM_eq_forM_keys ⟨m, h.size_buckets_pos⟩
 
+@[deprecated Raw.forIn_eq_forIn_keys (since := "2025-02-28")]
 theorem forIn_eq_forIn_keys [Monad m'] [LawfulMonad m'] (h : m.WF)
     {f : α → δ → m' (ForInStep δ)} {init : δ} :
     m.forIn (fun a _ d => f a d) init = ForIn.forIn m.keys init f :=
-  Raw₀.Const.forIn_eq_forIn_keys ⟨m, h.size_buckets_pos⟩
+  Raw₀.forIn_eq_forIn_keys ⟨m, h.size_buckets_pos⟩
 
 end Const
 

--- a/src/Std/Data/DHashMap/RawLemmas.lean
+++ b/src/Std/Data/DHashMap/RawLemmas.lean
@@ -1212,12 +1212,12 @@ theorem fold_eq_foldl_keys (h : m.WF) {f : δ → α → δ} {init : δ} :
   Raw₀.fold_eq_foldl_keys ⟨m, h.size_buckets_pos⟩
 
 theorem forM_eq_forM_keys [Monad m'] [LawfulMonad m'] (h : m.WF) {f : α → m' PUnit} :
-    m.forM (fun a _ => f a) = m.keys.forM f :=
+    ForM.forM m (fun a => f a.1) = m.keys.forM f :=
   Raw₀.forM_eq_forM_keys ⟨m, h.size_buckets_pos⟩
 
 theorem forIn_eq_forIn_keys [Monad m'] [LawfulMonad m'] (h : m.WF)
     {f : α → δ → m' (ForInStep δ)} {init : δ} :
-    m.forIn (fun a _ d => f a d) init = ForIn.forIn m.keys init f :=
+    ForIn.forIn m init (fun a d => f a.1 d) = ForIn.forIn m.keys init f :=
   Raw₀.forIn_eq_forIn_keys ⟨m, h.size_buckets_pos⟩
 
 namespace Const
@@ -1233,10 +1233,39 @@ theorem fold_eq_foldl_toList (h : m.WF) {f : δ → (a : α) → β → δ} {ini
     m.fold f init = (Raw.Const.toList m).foldl (fun a b => f a b.1 b.2) init :=
   Raw₀.Const.fold_eq_foldl_toList ⟨m, h.size_buckets_pos⟩
 
+omit [BEq α] [Hashable α] in
+theorem forM_eq_forMUncurried [Monad m'] [LawfulMonad m']
+    {f : α → β → m' PUnit} :
+    Raw.forM f m = Const.forMUncurried (fun a => f a.1 a.2) m := rfl
+
+theorem forMUncurried_eq_forM_toList [Monad m'] [LawfulMonad m'] (h : m.WF)
+    {f : α × β → m' PUnit} :
+    forMUncurried f m = (toList m).forM f :=
+  Raw₀.Const.forM_eq_forM_toList ⟨m, h.size_buckets_pos⟩
+
+/--
+Deprecated, use `forMUncurried_eq_forM_toList` together with `forM_eq_forMUncurried` instead.
+-/
+@[deprecated forMUncurried_eq_forM_toList (since := "2025-03-02")]
 theorem forM_eq_forM_toList [Monad m'] [LawfulMonad m'] (h : m.WF) {f : (a : α) → β → m' PUnit} :
     m.forM f = (Raw.Const.toList m).forM (fun a => f a.1 a.2) :=
   Raw₀.Const.forM_eq_forM_toList ⟨m, h.size_buckets_pos⟩
 
+omit [BEq α] [Hashable α] in
+@[simp]
+theorem forIn_eq_forInUncurried [Monad m'] [LawfulMonad m']
+    {f : α → β → δ → m' (ForInStep δ)} {init : δ} :
+    forIn f init m = forInUncurried (fun a b => f a.1 a.2 b) init m := rfl
+
+theorem forInUncurried_eq_forIn_toList [Monad m'] [LawfulMonad m'] (h : m.WF)
+    {f : α × β → δ → m' (ForInStep δ)} {init : δ} :
+    forInUncurried f init m = ForIn.forIn (toList m) init f :=
+  Raw₀.Const.forIn_eq_forIn_toList ⟨m, h.size_buckets_pos⟩
+
+/--
+Deprecated, use `forInUncurried_eq_forIn_toList` together with `forIn_eq_forInUncurried` instead.
+-/
+@[deprecated forMUncurried_eq_forM_toList (since := "2025-03-02")]
 theorem forIn_eq_forIn_toList [Monad m'] [LawfulMonad m'] (h : m.WF)
     {f : (a : α) → β → δ → m' (ForInStep δ)} {init : δ} :
     m.forIn f init = ForIn.forIn (Raw.Const.toList m) init (fun a b => f a.1 a.2 b) :=

--- a/src/Std/Data/DHashMap/RawLemmas.lean
+++ b/src/Std/Data/DHashMap/RawLemmas.lean
@@ -1265,7 +1265,7 @@ theorem forInUncurried_eq_forIn_toList [Monad m'] [LawfulMonad m'] (h : m.WF)
 /--
 Deprecated, use `forInUncurried_eq_forIn_toList` together with `forIn_eq_forInUncurried` instead.
 -/
-@[deprecated forMUncurried_eq_forM_toList (since := "2025-03-02")]
+@[deprecated forInUncurried_eq_forIn_toList (since := "2025-03-02")]
 theorem forIn_eq_forIn_toList [Monad m'] [LawfulMonad m'] (h : m.WF)
     {f : (a : α) → β → δ → m' (ForInStep δ)} {init : δ} :
     m.forIn f init = ForIn.forIn (Raw.Const.toList m) init (fun a b => f a.1 a.2 b) :=

--- a/src/Std/Data/DTreeMap/Basic.lean
+++ b/src/Std/Data/DTreeMap/Basic.lean
@@ -820,7 +820,7 @@ def forM (f : (a : α) → β a → m PUnit) (t : DTreeMap α β cmp) : m PUnit 
 /-- Support for the `for` loop construct in `do` blocks. Iteration happens in ascending order. -/
 @[inline]
 def forIn (f : (a : α) → β a → δ → m (ForInStep δ)) (init : δ) (t : DTreeMap α β cmp) : m δ :=
-  t.inner.forIn (fun c a b => f a b c) init
+  t.inner.forIn (fun a b acc => f a b acc) init
 
 instance : ForM m (DTreeMap α β cmp) ((a : α) × β a) where
   forM t f := t.forM (fun a b => f ⟨a, b⟩)

--- a/src/Std/Data/DTreeMap/Basic.lean
+++ b/src/Std/Data/DTreeMap/Basic.lean
@@ -820,13 +820,33 @@ def forM (f : (a : α) → β a → m PUnit) (t : DTreeMap α β cmp) : m PUnit 
 /-- Support for the `for` loop construct in `do` blocks. Iteration happens in ascending order. -/
 @[inline]
 def forIn (f : (a : α) → β a → δ → m (ForInStep δ)) (init : δ) (t : DTreeMap α β cmp) : m δ :=
-  t.inner.forIn (fun a b acc => f a b acc) init
+  t.inner.forIn f init
 
 instance : ForM m (DTreeMap α β cmp) ((a : α) × β a) where
   forM t f := t.forM (fun a b => f ⟨a, b⟩)
 
 instance : ForIn m (DTreeMap α β cmp) ((a : α) × β a) where
   forIn m init f := m.forIn (fun a b acc => f ⟨a, b⟩ acc) init
+
+namespace Const
+
+variable {β : Type v}
+
+/-!
+We do not define `ForM` and `ForIn` instances that are specialized to constant `β`. Instead, we
+define uncurried versions of `forM` and `forIn` that will be used in the `Const` lemmas and to
+define the `ForM` and `ForIn` instances for `DTreeMap`.
+-/
+
+@[inline, inherit_doc DTreeMap.forM]
+def forMUncurried (f : α × β → m PUnit) (t : DTreeMap α β cmp) : m PUnit :=
+  t.inner.forM fun a b => f ⟨a, b⟩
+
+@[inline, inherit_doc DTreeMap.forIn]
+def forInUncurried (f : α × β → δ → m (ForInStep δ)) (init : δ) (t : DTreeMap α β cmp) : m δ :=
+  t.inner.forIn (fun a b acc => f ⟨a, b⟩ acc) init
+
+end Const
 
 /-- Check if any element satisfes the predicate, short-circuiting if a predicate fails. -/
 @[inline]

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -61,7 +61,9 @@ private def queryNames : Array Name :=
     ``getKey?_eq_getKey?, ``getKey_eq_getKey,
     ``getKey!_eq_getKey!, ``getKeyD_eq_getKeyD,
     ``keys_eq_keys, ``toList_eq_toListModel, ``Const.toList_eq_toListModel_map,
-    ``foldlM_eq_foldlM, ``foldl_eq_foldl]
+    ``foldlM_eq_foldlM_toListModel, ``foldl_eq_foldl,
+    ``foldrM_eq_foldrM, ``foldr_eq_foldr,
+    ``forM_eq_forM, ``forIn_eq_forIn_toListModel]
 
 private def modifyMap : Std.HashMap Name Name :=
   .ofList
@@ -1585,66 +1587,84 @@ theorem foldl_eq_foldl_toList {f : δ → (a : α) → β a → δ} {init : δ} 
     t.foldl f init = t.toList.foldl (fun a b => f a b.1 b.2) init := by
   simp_to_model
 
-@[simp]
-theorem forM_eq_forM [Monad m] [LawfulMonad m] {f : (a : α) → β a → m PUnit} :
-    t.forM f = ForM.forM t (fun a => f a.1 a.2) := rfl
+theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
+    {f : (a : α) → β a → δ → m δ} {init : δ} :
+    t.foldrM f init = t.toList.foldrM (fun a b => f a.1 a.2 b) init := by
+  simp_to_model
+
+theorem foldr_eq_foldr_toList {f : (a : α) → β a → δ → δ} {init : δ} :
+    t.foldr f init = t.toList.foldr (fun a b => f a.1 a.2 b) init := by
+  simp_to_model
+
+-- @[simp]
+-- theorem forM_eq_forM [Monad m] [LawfulMonad m] {f : (a : α) → β a → m PUnit} :
+--     t.forM f = ForM.forM t (fun a => f a.1 a.2) := rfl
 
 theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : (a : α) × β a → m PUnit} :
-    ForM.forM t f = ForM.forM t.toList f := by
-  rw [ForM.forM, instForMSigma]
-  simp_to_mode
+    t.forM (fun k v => f ⟨k, v⟩) = ForM.forM t.toList f := by
+  simp_to_model using rfl
 
-@[simp]
-theorem forIn_eq_forIn [Monad m] [LawfulMonad m]
-    {f : (a : α) → β a → δ → m (ForInStep δ)} {init : δ} :
-    DHashMap.forIn f init t = ForIn.forIn t init (fun a b => f a.1 a.2 b) := rfl
+-- @[simp]
+-- theorem forIn_eq_forIn [Monad m] [LawfulMonad m]
+--     {f : (a : α) → β a → δ → m (ForInStep δ)} {init : δ} :
+--     t.forIn f init = ForIn.forIn t init (fun a b => f a.1 a.2 b) := rfl
 
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
     {f : (a : α) × β a → δ → m (ForInStep δ)} {init : δ} :
-    ForIn.forIn t init f = ForIn.forIn t.toList init f :=
-  Raw₀.forIn_eq_forIn_toList ⟨t.1, t.2.size_buckets_pos⟩
+    ForIn.forIn t init f = ForIn.forIn t.toList init f := by
+  rw [ForIn.forIn, instForInSigma]
+  simp_to_model
 
 namespace Const
 
-variable {β : Type v} {t : DHashMap α (fun _ => β)}
+variable {β : Type v} {t : Impl α β}
 
-theorem foldM_eq_foldlM_toList [Monad m] [LawfulMonad m]
+theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m]
     {f : δ → (a : α) → β → m δ} {init : δ} :
-    t.foldM f init = (Const.toList t).foldlM (fun a b => f a b.1 b.2) init :=
-  Raw₀.Const.foldM_eq_foldlM_toList ⟨t.1, t.2.size_buckets_pos⟩
+    t.foldlM f init = (Const.toList t).foldlM (fun a b => f a b.1 b.2) init := by
+  simp_to_model using List.foldlM_eq_foldlM_toProd
 
-theorem fold_eq_foldl_toList {f : δ → (a : α) → β → δ} {init : δ} :
-    t.fold f init = (Const.toList t).foldl (fun a b => f a b.1 b.2) init :=
-  Raw₀.Const.fold_eq_foldl_toList ⟨t.1, t.2.size_buckets_pos⟩
+theorem foldl_eq_foldl_toList {f : δ → (a : α) → β → δ} {init : δ} :
+    t.foldl f init = (Const.toList t).foldl (fun a b => f a b.1 b.2) init := by
+  simp_to_model using List.foldl_eq_foldl_toProd
+
+theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
+    {f : (a : α) → β → δ → m δ} {init : δ} :
+    t.foldrM f init = (Const.toList t).foldrM (fun a b => f a.1 a.2 b) init := by
+  simp_to_model using List.foldrM_eq_foldrM_toProd
+
+theorem foldr_eq_foldr_toList {f : δ → (a : α) → β → δ} {init : δ} :
+    t.foldr f init = (Const.toList t).foldr (fun a b => f a b.1 b.2) init := by
+  simp_to_model using List.foldr_eq_foldr_toProd
 
 theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : (a : α) → β → m PUnit} :
-    t.forM f = (Const.toList t).forM (fun a => f a.1 a.2) :=
-  Raw₀.Const.forM_eq_forM_toList ⟨t.1, t.2.size_buckets_pos⟩
+    t.forM f = (Const.toList t).forM (fun a => f a.1 a.2) := by
+  simp_to_model using List.forM_eq_forM_toProd
 
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
-    {f : (a : α) → β → δ → m (ForInStep δ)} {init : δ} :
-    t.forIn f init = ForIn.forIn (Const.toList t) init (fun a b => f a.1 a.2 b) :=
-  Raw₀.Const.forIn_eq_forIn_toList ⟨t.1, t.2.size_buckets_pos⟩
+    {f : α → β → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn f init = ForIn.forIn (Const.toList t) init (fun a b => f a.1 a.2 b) := by
+  simp_to_model using List.forIn_eq_forIn_toProd
 
-variable {t : DHashMap α (fun _ => Unit)}
+variable {t : Impl α Unit}
 
-theorem foldM_eq_foldlM_keys [Monad m] [LawfulMonad m]
+theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m]
     {f : δ → α → m δ} {init : δ} :
-    t.foldM (fun d a _ => f d a) init = t.keys.foldlM f init :=
-  Raw₀.Const.foldM_eq_foldlM_keys ⟨t.1, t.2.size_buckets_pos⟩
+    t.foldlM (fun d a _ => f d a) init = t.keys.foldlM f init := by
+  simp_to_model using List.foldlM_eq_foldlM_keys
 
-theorem fold_eq_foldl_keys {f : δ → α → δ} {init : δ} :
-    t.fold (fun d a _ => f d a) init = t.keys.foldl f init :=
-  Raw₀.Const.fold_eq_foldl_keys ⟨t.1, t.2.size_buckets_pos⟩
+theorem foldl_eq_foldl_keys {f : δ → α → δ} {init : δ} :
+    t.foldl (fun d a _ => f d a) init = t.keys.foldl f init := by
+  simp_to_model using List.foldl_eq_foldl_keys
 
 theorem forM_eq_forM_keys [Monad m] [LawfulMonad m] {f : α → m PUnit} :
-    t.forM (fun a _ => f a) = t.keys.forM f :=
-  Raw₀.Const.forM_eq_forM_keys ⟨t.1, t.2.size_buckets_pos⟩
+    t.forM (fun a _ => f a) = t.keys.forM f := by
+  simp_to_model using List.forM_eq_forM_keys
 
 theorem forIn_eq_forIn_keys [Monad m] [LawfulMonad m]
     {f : α → δ → m (ForInStep δ)} {init : δ} :
-    t.forIn (fun a _ d => f a d) init = ForIn.forIn t.keys init f :=
-  Raw₀.Const.forIn_eq_forIn_keys ⟨t.1, t.2.size_buckets_pos⟩
+    t.forIn (fun a _ d => f a d) init = ForIn.forIn t.keys init f := by
+  simp_to_model using List.forIn_eq_forIn_keys
 
 end Const
 

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -1611,8 +1611,7 @@ theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : (a : α) × β a → 
 
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
     {f : (a : α) × β a → δ → m (ForInStep δ)} {init : δ} :
-    ForIn.forIn t init f = ForIn.forIn t.toList init f := by
-  rw [ForIn.forIn, instForInSigma]
+    t.forIn (fun k v => f ⟨k, v⟩) init = ForIn.forIn t.toList init f := by
   simp_to_model
 
 namespace Const
@@ -1633,8 +1632,8 @@ theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
     t.foldrM f init = (Const.toList t).foldrM (fun a b => f a.1 a.2 b) init := by
   simp_to_model using List.foldrM_eq_foldrM_toProd
 
-theorem foldr_eq_foldr_toList {f : δ → (a : α) → β → δ} {init : δ} :
-    t.foldr f init = (Const.toList t).foldr (fun a b => f a b.1 b.2) init := by
+theorem foldr_eq_foldr_toList {f : (a : α) → β → δ → δ} {init : δ} :
+    t.foldr f init = (Const.toList t).foldr (fun a b => f a.1 a.2 b) init := by
   simp_to_model using List.foldr_eq_foldr_toProd
 
 theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : (a : α) → β → m PUnit} :

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -1596,23 +1596,39 @@ theorem foldr_eq_foldr_toList {f : (a : α) → β a → δ → δ} {init : δ} 
     t.foldr f init = t.toList.foldr (fun a b => f a.1 a.2 b) init := by
   simp_to_model
 
--- @[simp]
--- theorem forM_eq_forM [Monad m] [LawfulMonad m] {f : (a : α) → β a → m PUnit} :
---     t.forM f = ForM.forM t (fun a => f a.1 a.2) := rfl
-
 theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : (a : α) × β a → m PUnit} :
     t.forM (fun k v => f ⟨k, v⟩) = ForM.forM t.toList f := by
   simp_to_model using rfl
-
--- @[simp]
--- theorem forIn_eq_forIn [Monad m] [LawfulMonad m]
---     {f : (a : α) → β a → δ → m (ForInStep δ)} {init : δ} :
---     t.forIn f init = ForIn.forIn t init (fun a b => f a.1 a.2 b) := rfl
 
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
     {f : (a : α) × β a → δ → m (ForInStep δ)} {init : δ} :
     t.forIn (fun k v => f ⟨k, v⟩) init = ForIn.forIn t.toList init f := by
   simp_to_model
+
+theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m] {f : δ → α → m δ} {init : δ} :
+    t.foldlM (fun d a _ => f d a) init = t.keys.foldlM f init := by
+  simp_to_model using List.foldlM_eq_foldlM_keys
+
+theorem foldl_eq_foldl_keys {f : δ → α → δ} {init : δ} :
+    t.foldl (fun d a _ => f d a) init = t.keys.foldl f init := by
+  simp_to_model using List.foldl_eq_foldl_keys
+
+theorem foldrM_eq_foldrM_keys [Monad m] [LawfulMonad m] {f : α → δ → m δ} {init : δ} :
+    t.foldrM (fun a _ d => f a d) init = t.keys.foldrM f init := by
+  simp_to_model using List.foldrM_eq_foldrM_keys
+
+theorem foldr_eq_foldr_keys {f : α → δ → δ} {init : δ} :
+    t.foldr (fun a _ d => f a d) init = t.keys.foldr f init := by
+  simp_to_model using List.foldr_eq_foldr_keys
+
+theorem forM_eq_forM_keys [Monad m] [LawfulMonad m] {f : α → m PUnit} :
+    t.forM (fun a _ => f a) = t.keys.forM f := by
+  simp_to_model using List.forM_eq_forM_keys
+
+theorem forIn_eq_forIn_keys [Monad m] [LawfulMonad m] {f : α → δ → m (ForInStep δ)}
+    {init : δ} :
+    t.forIn (fun a _ d => f a d) init = ForIn.forIn t.keys init f := by
+  simp_to_model using List.forIn_eq_forIn_keys
 
 namespace Const
 
@@ -1644,26 +1660,6 @@ theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
     {f : α → β → δ → m (ForInStep δ)} {init : δ} :
     t.forIn f init = ForIn.forIn (Const.toList t) init (fun a b => f a.1 a.2 b) := by
   simp_to_model using List.forIn_eq_forIn_toProd
-
-variable {t : Impl α Unit}
-
-theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m]
-    {f : δ → α → m δ} {init : δ} :
-    t.foldlM (fun d a _ => f d a) init = t.keys.foldlM f init := by
-  simp_to_model using List.foldlM_eq_foldlM_keys
-
-theorem foldl_eq_foldl_keys {f : δ → α → δ} {init : δ} :
-    t.foldl (fun d a _ => f d a) init = t.keys.foldl f init := by
-  simp_to_model using List.foldl_eq_foldl_keys
-
-theorem forM_eq_forM_keys [Monad m] [LawfulMonad m] {f : α → m PUnit} :
-    t.forM (fun a _ => f a) = t.keys.forM f := by
-  simp_to_model using List.forM_eq_forM_keys
-
-theorem forIn_eq_forIn_keys [Monad m] [LawfulMonad m]
-    {f : α → δ → m (ForInStep δ)} {init : δ} :
-    t.forIn (fun a _ d => f a d) init = ForIn.forIn t.keys init f := by
-  simp_to_model using List.forIn_eq_forIn_keys
 
 end Const
 

--- a/src/Std/Data/DTreeMap/Internal/Queries.lean
+++ b/src/Std/Data/DTreeMap/Internal/Queries.lean
@@ -217,29 +217,23 @@ def forM {m} [Monad m] (f : (a : α) → β a → m PUnit) (t : Impl α β) : m 
 
 /-- Implementation detail. -/
 @[specialize]
-def forInStep {m} [Monad m] (f : δ → (a : α) → β a → m (ForInStep δ)) (init : δ) :
+def forInStep {m} [Monad m] (f : (a : α) → β a → δ → m (ForInStep δ)) (init : δ) :
     Impl α β → m (ForInStep δ)
   | .leaf => pure (.yield init)
   | .inner _ k v l r => do
     match ← forInStep f init l with
     | ForInStep.done d => return (.done d)
     | ForInStep.yield d =>
-      match ← f d k v with
+      match ← f k v d with
       | ForInStep.done d => return (.done d)
       | ForInStep.yield d => forInStep f d r
 
 /-- Support for the `for` construct in `do` blocks. -/
 @[inline]
-def forIn {m} [Monad m] (f : δ → (a : α) → β a → m (ForInStep δ)) (init : δ) (t : Impl α β) : m δ := do
+def forIn {m} [Monad m] (f : (a : α) → β a → δ → m (ForInStep δ)) (init : δ) (t : Impl α β) : m δ := do
   match ← forInStep f init t with
   | ForInStep.done d => return d
   | ForInStep.yield d => return d
-
-instance : ForM m (Impl α β) ((a : α) × β a) where
-  forM m f := m.forM (fun a b => f ⟨a, b⟩)
-
-instance : ForIn m (Impl α β) ((a : α) × β a) where
-  forIn m init f := m.forIn (fun acc a b => f ⟨a, b⟩ acc) init
 
 /-- Returns a `List` of the keys in order. -/
 @[inline] def keys (t : Impl α β) : List α :=

--- a/src/Std/Data/DTreeMap/Internal/Queries.lean
+++ b/src/Std/Data/DTreeMap/Internal/Queries.lean
@@ -235,6 +235,12 @@ def forIn {m} [Monad m] (f : δ → (a : α) → β a → m (ForInStep δ)) (ini
   | ForInStep.done d => return d
   | ForInStep.yield d => return d
 
+instance : ForM m (Impl α β) ((a : α) × β a) where
+  forM m f := m.forM (fun a b => f ⟨a, b⟩)
+
+instance : ForIn m (Impl α β) ((a : α) × β a) where
+  forIn m init f := m.forIn (fun acc a b => f ⟨a, b⟩ acc) init
+
 /-- Returns a `List` of the keys in order. -/
 @[inline] def keys (t : Impl α β) : List α :=
   t.foldr (init := []) fun k _ l => k :: l

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -1072,7 +1072,7 @@ theorem forIn_eq_forIn [Monad m] [LawfulMonad m]
 
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
     {f : (a : α) × β a → δ → m (ForInStep δ)} {init : δ} :
-    t.forIn (fun k v => f ⟨k, v⟩) init = ForIn.forIn t.toList init f :=
+    ForIn.forIn t init f = ForIn.forIn t.toList init f :=
   Impl.forIn_eq_forIn_toList (f := f)
 
 theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m] {f : δ → α → m δ} {init : δ} :
@@ -1093,12 +1093,12 @@ theorem foldr_eq_foldr_keys {f : α → δ → δ} {init : δ} :
   Impl.foldr_eq_foldr_keys
 
 theorem forM_eq_forM_keys [Monad m] [LawfulMonad m] {f : α → m PUnit} :
-    t.forM (fun a _ => f a) = t.keys.forM f :=
+    ForM.forM t (fun a => f a.1) = t.keys.forM f :=
   Impl.forM_eq_forM_keys
 
 theorem forIn_eq_forIn_keys [Monad m] [LawfulMonad m]
     {f : α → δ → m (ForInStep δ)} {init : δ} :
-    t.forIn (fun a _ d => f a d) init = ForIn.forIn t.keys init f :=
+    ForIn.forIn t init (fun a d => f a.1 d) = ForIn.forIn t.keys init f :=
   Impl.forIn_eq_forIn_keys
 
 namespace Const
@@ -1123,10 +1123,33 @@ theorem foldr_eq_foldr_toList {f : α → β → δ → δ} {init : δ} :
     t.foldr f init = (Const.toList t).foldr (fun a b => f a.1 a.2 b) init :=
   Impl.Const.foldr_eq_foldr_toList
 
+theorem forM_eq_forMUncurried [Monad m] [LawfulMonad m] {f : α → β → m PUnit} :
+    t.forM f = forMUncurried (fun a => f a.1 a.2) t := rfl
+
+theorem forMUncurried_eq_forM_toList [Monad m] [LawfulMonad m] {f : α × β → m PUnit} :
+    forMUncurried f t = (Const.toList t).forM f :=
+  Impl.Const.forM_eq_forM_toList
+
+/--
+Deprecated, use `forMUncurried_eq_forM_toList` together with `forM_eq_forMUncurried` instead.
+-/
+@[deprecated forMUncurried_eq_forM_toList (since := "2025-03-02")]
 theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : α → β → m PUnit} :
     t.forM f = (Const.toList t).forM (fun a => f a.1 a.2) :=
-  Impl.Const.forM_eq_forM_toList (f := f)
+  Impl.Const.forM_eq_forM_toList
 
+theorem forIn_eq_forInUncurried [Monad m] [LawfulMonad m]
+    {f : α → β → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn f init = forInUncurried (fun a b => f a.1 a.2 b) init t := rfl
+
+theorem forInUncurried_eq_forIn_toList [Monad m] [LawfulMonad m]
+    {f : α × β → δ → m (ForInStep δ)} {init : δ} :
+    forInUncurried f init t = ForIn.forIn (Const.toList t) init f :=
+  Impl.Const.forIn_eq_forIn_toList
+
+/--
+Deprecated, use `forMUncurried_eq_forM_toList` together with `forM_eq_forMUncurried` instead.
+-/
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
     {f : α → β → δ → m (ForInStep δ)} {init : δ} :
     t.forIn f init = ForIn.forIn (Const.toList t) init (fun a b => f a.1 a.2 b) :=

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -1148,8 +1148,9 @@ theorem forInUncurried_eq_forIn_toList [Monad m] [LawfulMonad m]
   Impl.Const.forIn_eq_forIn_toList
 
 /--
-Deprecated, use `forMUncurried_eq_forM_toList` together with `forM_eq_forMUncurried` instead.
+Deprecated, use `forInUncurried_eq_forIn_toList` together with `forIn_eq_forInUncurried` instead.
 -/
+@[deprecated forInUncurried_eq_forIn_toList (since := "2025-03-02")]
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
     {f : α → β → δ → m (ForInStep δ)} {init : δ} :
     t.forIn f init = ForIn.forIn (Const.toList t) init (fun a b => f a.1 a.2 b) :=

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -1076,39 +1076,6 @@ theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
     t.forIn (fun k v => f ⟨k, v⟩) init = ForIn.forIn t.toList init f :=
   Impl.forIn_eq_forIn_toList (f := f)
 
-namespace Const
-
-variable {β : Type v} {t : DTreeMap α β cmp}
-
-theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m]
-    {f : δ → (a : α) → β → m δ} {init : δ} :
-    t.foldlM f init = (Const.toList t).foldlM (fun a b => f a b.1 b.2) init :=
-  Impl.Const.foldlM_eq_foldlM_toList
-
-theorem foldl_eq_foldl_toList {f : δ → (a : α) → β → δ} {init : δ} :
-    t.foldl f init = (Const.toList t).foldl (fun a b => f a b.1 b.2) init :=
-  Impl.Const.foldl_eq_foldl_toList
-
-theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
-    {f : (a : α) → β → δ → m δ} {init : δ} :
-    t.foldrM f init = (Const.toList t).foldrM (fun a b => f a.1 a.2 b) init :=
-  Impl.Const.foldrM_eq_foldrM_toList
-
-theorem foldr_eq_foldr_toList {f : (a : α) → β → δ → δ} {init : δ} :
-    t.foldr f init = (Const.toList t).foldr (fun a b => f a.1 a.2 b) init :=
-  Impl.Const.foldr_eq_foldr_toList
-
-theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : (a : α) → β → m PUnit} :
-    t.forM f = (Const.toList t).forM (fun a => f a.1 a.2) :=
-  Impl.Const.forM_eq_forM_toList (f := f)
-
-theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
-    {f : α → β → δ → m (ForInStep δ)} {init : δ} :
-    t.forIn f init = ForIn.forIn (Const.toList t) init (fun a b => f a.1 a.2 b) :=
-  Impl.Const.forIn_eq_forIn_toList
-
-variable {t : Impl α Unit}
-
 theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m]
     {f : δ → α → m δ} {init : δ} :
     t.foldlM (fun d a _ => f d a) init = t.keys.foldlM f init :=
@@ -1118,6 +1085,15 @@ theorem foldl_eq_foldl_keys {f : δ → α → δ} {init : δ} :
     t.foldl (fun d a _ => f d a) init = t.keys.foldl f init :=
   Impl.foldl_eq_foldl_keys
 
+theorem foldrM_eq_foldrM_keys [Monad m] [LawfulMonad m]
+    {f : α → δ → m δ} {init : δ} :
+    t.foldrM (fun a _ d => f a d) init = t.keys.foldrM f init :=
+  Impl.foldrM_eq_foldrM_keys
+
+theorem foldr_eq_foldr_keys {f : α → δ → δ} {init : δ} :
+    t.foldr (fun a _ d => f a d) init = t.keys.foldr f init :=
+  Impl.foldr_eq_foldr_keys
+
 theorem forM_eq_forM_keys [Monad m] [LawfulMonad m] {f : α → m PUnit} :
     t.forM (fun a _ => f a) = t.keys.forM f :=
   Impl.forM_eq_forM_keys
@@ -1126,6 +1102,37 @@ theorem forIn_eq_forIn_keys [Monad m] [LawfulMonad m]
     {f : α → δ → m (ForInStep δ)} {init : δ} :
     t.forIn (fun a _ d => f a d) init = ForIn.forIn t.keys init f :=
   Impl.forIn_eq_forIn_keys
+
+namespace Const
+
+variable {β : Type v} {t : DTreeMap α β cmp}
+
+theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m]
+    {f : δ → α → β → m δ} {init : δ} :
+    t.foldlM f init = (Const.toList t).foldlM (fun a b => f a b.1 b.2) init :=
+  Impl.Const.foldlM_eq_foldlM_toList
+
+theorem foldl_eq_foldl_toList {f : δ → α → β → δ} {init : δ} :
+    t.foldl f init = (Const.toList t).foldl (fun a b => f a b.1 b.2) init :=
+  Impl.Const.foldl_eq_foldl_toList
+
+theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
+    {f : α → β → δ → m δ} {init : δ} :
+    t.foldrM f init = (Const.toList t).foldrM (fun a b => f a.1 a.2 b) init :=
+  Impl.Const.foldrM_eq_foldrM_toList
+
+theorem foldr_eq_foldr_toList {f : α → β → δ → δ} {init : δ} :
+    t.foldr f init = (Const.toList t).foldr (fun a b => f a.1 a.2 b) init :=
+  Impl.Const.foldr_eq_foldr_toList
+
+theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : α → β → m PUnit} :
+    t.forM f = (Const.toList t).forM (fun a => f a.1 a.2) :=
+  Impl.Const.forM_eq_forM_toList (f := f)
+
+theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
+    {f : α → β → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn f init = ForIn.forIn (Const.toList t) init (fun a b => f a.1 a.2 b) :=
+  Impl.Const.forIn_eq_forIn_toList
 
 end Const
 

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -1049,8 +1049,7 @@ theorem foldl_eq_foldl_toList {f : δ → (a : α) → β a → δ} {init : δ} 
     t.foldl f init = t.toList.foldl (fun a b => f a b.1 b.2) init :=
   Impl.foldl_eq_foldl_toList
 
-theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
-    {f : (a : α) → β a → δ → m δ} {init : δ} :
+theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m] {f : (a : α) → β a → δ → m δ} {init : δ} :
     t.foldrM f init = t.toList.foldrM (fun a b => f a.1 a.2 b) init :=
   Impl.foldrM_eq_foldrM_toList
 
@@ -1076,8 +1075,7 @@ theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
     t.forIn (fun k v => f ⟨k, v⟩) init = ForIn.forIn t.toList init f :=
   Impl.forIn_eq_forIn_toList (f := f)
 
-theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m]
-    {f : δ → α → m δ} {init : δ} :
+theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m] {f : δ → α → m δ} {init : δ} :
     t.foldlM (fun d a _ => f d a) init = t.keys.foldlM f init :=
   Impl.foldlM_eq_foldlM_keys
 

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -19,7 +19,7 @@ open Std.DTreeMap.Internal
 set_option linter.missingDocs true
 set_option autoImplicit false
 
-universe u v
+universe u v w
 
 namespace Std.DTreeMap
 
@@ -1035,5 +1035,100 @@ theorem distinct_keys_toList [TransCmp cmp] :
   Impl.Const.distinct_keys_toList t.wf
 
 end Const
+
+section monadic
+
+variable {δ : Type w} {m : Type w → Type w}
+
+theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m]
+    {f : δ → (a : α) → β a → m δ} {init : δ} :
+    t.foldlM f init = t.toList.foldlM (fun a b => f a b.1 b.2) init :=
+  Impl.foldlM_eq_foldlM_toList
+
+theorem foldl_eq_foldl_toList {f : δ → (a : α) → β a → δ} {init : δ} :
+    t.foldl f init = t.toList.foldl (fun a b => f a b.1 b.2) init :=
+  Impl.foldl_eq_foldl_toList
+
+theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
+    {f : (a : α) → β a → δ → m δ} {init : δ} :
+    t.foldrM f init = t.toList.foldrM (fun a b => f a.1 a.2 b) init :=
+  Impl.foldrM_eq_foldrM_toList
+
+theorem foldr_eq_foldr_toList {f : (a : α) → β a → δ → δ} {init : δ} :
+    t.foldr f init = t.toList.foldr (fun a b => f a.1 a.2 b) init :=
+  Impl.foldr_eq_foldr_toList
+
+@[simp]
+theorem forM_eq_forM [Monad m] [LawfulMonad m] {f : (a : α) → β a → m PUnit} :
+    t.forM f = ForM.forM t (fun a => f a.1 a.2) := rfl
+
+theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : (a : α) × β a → m PUnit} :
+    ForM.forM t f = ForM.forM t.toList f :=
+  Impl.forM_eq_forM_toList
+
+@[simp]
+theorem forIn_eq_forIn [Monad m] [LawfulMonad m]
+    {f : (a : α) → β a → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn f init = ForIn.forIn t init (fun a b => f a.1 a.2 b) := rfl
+
+theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
+    {f : (a : α) × β a → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn (fun k v => f ⟨k, v⟩) init = ForIn.forIn t.toList init f :=
+  Impl.forIn_eq_forIn_toList (f := f)
+
+namespace Const
+
+variable {β : Type v} {t : DTreeMap α β cmp}
+
+theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m]
+    {f : δ → (a : α) → β → m δ} {init : δ} :
+    t.foldlM f init = (Const.toList t).foldlM (fun a b => f a b.1 b.2) init :=
+  Impl.Const.foldlM_eq_foldlM_toList
+
+theorem foldl_eq_foldl_toList {f : δ → (a : α) → β → δ} {init : δ} :
+    t.foldl f init = (Const.toList t).foldl (fun a b => f a b.1 b.2) init :=
+  Impl.Const.foldl_eq_foldl_toList
+
+theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
+    {f : (a : α) → β → δ → m δ} {init : δ} :
+    t.foldrM f init = (Const.toList t).foldrM (fun a b => f a.1 a.2 b) init :=
+  Impl.Const.foldrM_eq_foldrM_toList
+
+theorem foldr_eq_foldr_toList {f : (a : α) → β → δ → δ} {init : δ} :
+    t.foldr f init = (Const.toList t).foldr (fun a b => f a.1 a.2 b) init :=
+  Impl.Const.foldr_eq_foldr_toList
+
+theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : (a : α) → β → m PUnit} :
+    t.forM f = (Const.toList t).forM (fun a => f a.1 a.2) :=
+  Impl.Const.forM_eq_forM_toList (f := f)
+
+theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
+    {f : α → β → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn f init = ForIn.forIn (Const.toList t) init (fun a b => f a.1 a.2 b) :=
+  Impl.Const.forIn_eq_forIn_toList
+
+variable {t : Impl α Unit}
+
+theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m]
+    {f : δ → α → m δ} {init : δ} :
+    t.foldlM (fun d a _ => f d a) init = t.keys.foldlM f init :=
+  Impl.foldlM_eq_foldlM_keys
+
+theorem foldl_eq_foldl_keys {f : δ → α → δ} {init : δ} :
+    t.foldl (fun d a _ => f d a) init = t.keys.foldl f init :=
+  Impl.foldl_eq_foldl_keys
+
+theorem forM_eq_forM_keys [Monad m] [LawfulMonad m] {f : α → m PUnit} :
+    t.forM (fun a _ => f a) = t.keys.forM f :=
+  Impl.forM_eq_forM_keys
+
+theorem forIn_eq_forIn_keys [Monad m] [LawfulMonad m]
+    {f : α → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn (fun a _ d => f a d) init = ForIn.forIn t.keys init f :=
+  Impl.forIn_eq_forIn_keys
+
+end Const
+
+end monadic
 
 end Std.DTreeMap

--- a/src/Std/Data/DTreeMap/Raw/Basic.lean
+++ b/src/Std/Data/DTreeMap/Raw/Basic.lean
@@ -584,7 +584,7 @@ def forM (f : (a : α) → β a → m PUnit) (t : Raw α β cmp) : m PUnit :=
 
 @[inline, inherit_doc DTreeMap.forIn]
 def forIn (f : (a : α) → β a → δ → m (ForInStep δ)) (init : δ) (t : Raw α β cmp) : m δ :=
-  t.inner.forIn (fun c a b => f a b c) init
+  t.inner.forIn (fun a b acc => f a b acc) init
 
 instance : ForM m (Raw α β cmp) ((a : α) × β a) where
   forM t f := t.forM (fun a b => f ⟨a, b⟩)

--- a/src/Std/Data/DTreeMap/Raw/Basic.lean
+++ b/src/Std/Data/DTreeMap/Raw/Basic.lean
@@ -584,13 +584,33 @@ def forM (f : (a : α) → β a → m PUnit) (t : Raw α β cmp) : m PUnit :=
 
 @[inline, inherit_doc DTreeMap.forIn]
 def forIn (f : (a : α) → β a → δ → m (ForInStep δ)) (init : δ) (t : Raw α β cmp) : m δ :=
-  t.inner.forIn (fun a b acc => f a b acc) init
+  t.inner.forIn f init
 
 instance : ForM m (Raw α β cmp) ((a : α) × β a) where
   forM t f := t.forM (fun a b => f ⟨a, b⟩)
 
 instance : ForIn m (Raw α β cmp) ((a : α) × β a) where
   forIn t init f := t.forIn (fun a b acc => f ⟨a, b⟩ acc) init
+
+namespace Const
+
+variable {β : Type v}
+
+/-!
+We do not define `ForM` and `ForIn` instances that are specialized to constant `β`. Instead, we
+define uncurried versions of `forM` and `forIn` that will be used in the `Const` lemmas and to
+define the `ForM` and `ForIn` instances for `DTreeMap.Raw`.
+-/
+
+@[inline, inherit_doc Raw.forM]
+def forMUncurried (f : α × β → m PUnit) (t : Raw α β cmp) : m PUnit :=
+  t.inner.forM fun a b => f ⟨a, b⟩
+
+@[inline, inherit_doc Raw.forIn]
+def forInUncurried (f : α × β → δ → m (ForInStep δ)) (init : δ) (t : Raw α β cmp) : m δ :=
+  t.inner.forIn (fun a b d => f ⟨a, b⟩ d) init
+
+end Const
 
 @[inline, inherit_doc DTreeMap.any]
 def any (t : Raw α β cmp) (p : (a : α) → β a → Bool) : Bool := Id.run $ do

--- a/src/Std/Data/DTreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Raw/Lemmas.lean
@@ -1049,8 +1049,7 @@ section monadic
 
 variable {δ : Type w} {m : Type w → Type w}
 
-theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m]
-    {f : δ → (a : α) → β a → m δ} {init : δ} :
+theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m] {f : δ → (a : α) → β a → m δ} {init : δ} :
     t.foldlM f init = t.toList.foldlM (fun a b => f a b.1 b.2) init :=
   Impl.foldlM_eq_foldlM_toList
 
@@ -1058,8 +1057,7 @@ theorem foldl_eq_foldl_toList {f : δ → (a : α) → β a → δ} {init : δ} 
     t.foldl f init = t.toList.foldl (fun a b => f a b.1 b.2) init :=
   Impl.foldl_eq_foldl_toList
 
-theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
-    {f : (a : α) → β a → δ → m δ} {init : δ} :
+theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m] {f : (a : α) → β a → δ → m δ} {init : δ} :
     t.foldrM f init = t.toList.foldrM (fun a b => f a.1 a.2 b) init :=
   Impl.foldrM_eq_foldrM_toList
 
@@ -1085,8 +1083,7 @@ theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
     t.forIn (fun k v => f ⟨k, v⟩) init = ForIn.forIn t.toList init f :=
   Impl.forIn_eq_forIn_toList (f := f)
 
-theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m]
-    {f : δ → α → m δ} {init : δ} :
+theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m] {f : δ → α → m δ} {init : δ} :
     t.foldlM (fun d a _ => f d a) init = t.keys.foldlM f init :=
   Impl.foldlM_eq_foldlM_keys
 
@@ -1115,8 +1112,7 @@ namespace Const
 
 variable {β : Type v} {t : Raw α β cmp}
 
-theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m]
-    {f : δ → α → β → m δ} {init : δ} :
+theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m] {f : δ → α → β → m δ} {init : δ} :
     t.foldlM f init = (Const.toList t).foldlM (fun a b => f a b.1 b.2) init :=
   Impl.Const.foldlM_eq_foldlM_toList
 
@@ -1124,8 +1120,7 @@ theorem foldl_eq_foldl_toList {f : δ → α → β → δ} {init : δ} :
     t.foldl f init = (Const.toList t).foldl (fun a b => f a b.1 b.2) init :=
   Impl.Const.foldl_eq_foldl_toList
 
-theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
-    {f : α → β → δ → m δ} {init : δ} :
+theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m] {f : α → β → δ → m δ} {init : δ} :
     t.foldrM f init = (Const.toList t).foldrM (fun a b => f a.1 a.2 b) init :=
   Impl.Const.foldrM_eq_foldrM_toList
 

--- a/src/Std/Data/DTreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Raw/Lemmas.lean
@@ -1080,7 +1080,7 @@ theorem forIn_eq_forIn [Monad m] [LawfulMonad m]
 
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
     {f : (a : α) × β a → δ → m (ForInStep δ)} {init : δ} :
-    t.forIn (fun k v => f ⟨k, v⟩) init = ForIn.forIn t.toList init f :=
+    ForIn.forIn t init f = ForIn.forIn t.toList init f :=
   Impl.forIn_eq_forIn_toList (f := f)
 
 theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m] {f : δ → α → m δ} {init : δ} :
@@ -1100,12 +1100,12 @@ theorem foldr_eq_foldr_keys {f : α → δ → δ} {init : δ} :
   Impl.foldr_eq_foldr_keys
 
 theorem forM_eq_forM_keys [Monad m] [LawfulMonad m] {f : α → m PUnit} :
-    t.forM (fun a _ => f a) = t.keys.forM f :=
+    ForM.forM t (fun a => f a.1) = t.keys.forM f :=
   Impl.forM_eq_forM_keys
 
 theorem forIn_eq_forIn_keys [Monad m] [LawfulMonad m]
     {f : α → δ → m (ForInStep δ)} {init : δ} :
-    t.forIn (fun a _ d => f a d) init = ForIn.forIn t.keys init f :=
+    ForIn.forIn t init (fun a d => f a.1 d) = ForIn.forIn t.keys init f :=
   Impl.forIn_eq_forIn_keys
 
 namespace Const
@@ -1128,10 +1128,33 @@ theorem foldr_eq_foldr_toList {f : α → β → δ → δ} {init : δ} :
     t.foldr f init = (Const.toList t).foldr (fun a b => f a.1 a.2 b) init :=
   Impl.Const.foldr_eq_foldr_toList
 
+theorem forM_eq_forMUncurried [Monad m] [LawfulMonad m] {f : α → β → m PUnit} :
+    t.forM f = forMUncurried (fun a => f a.1 a.2) t := rfl
+
+theorem forMUncurried_eq_forM_toList [Monad m] [LawfulMonad m] {f : α × β → m PUnit} :
+    forMUncurried f t = (Const.toList t).forM f :=
+  Impl.Const.forM_eq_forM_toList
+
+/--
+Deprecated, use `forMUncurried_eq_forM_toList` together with `forM_eq_forMUncurried` instead.
+-/
+@[deprecated forMUncurried_eq_forM_toList (since := "2025-03-02")]
 theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : α → β → m PUnit} :
     t.forM f = (Const.toList t).forM (fun a => f a.1 a.2) :=
-  Impl.Const.forM_eq_forM_toList (f := f)
+  Impl.Const.forM_eq_forM_toList
 
+theorem forIn_eq_forInUncurried [Monad m] [LawfulMonad m]
+    {f : α → β → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn f init = forInUncurried (fun a b => f a.1 a.2 b) init t := rfl
+
+theorem forInUncurried_eq_forIn_toList [Monad m] [LawfulMonad m]
+    {f : α × β → δ → m (ForInStep δ)} {init : δ} :
+    forInUncurried f init t = ForIn.forIn (Const.toList t) init f :=
+  Impl.Const.forIn_eq_forIn_toList
+
+/--
+Deprecated, use `forMUncurried_eq_forM_toList` together with `forM_eq_forMUncurried` instead.
+-/
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
     {f : α → β → δ → m (ForInStep δ)} {init : δ} :
     t.forIn f init = ForIn.forIn (Const.toList t) init (fun a b => f a.1 a.2 b) :=

--- a/src/Std/Data/DTreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Raw/Lemmas.lean
@@ -1153,8 +1153,9 @@ theorem forInUncurried_eq_forIn_toList [Monad m] [LawfulMonad m]
   Impl.Const.forIn_eq_forIn_toList
 
 /--
-Deprecated, use `forMUncurried_eq_forM_toList` together with `forM_eq_forMUncurried` instead.
+Deprecated, use `forInUncurried_eq_forIn_toList` together with `forIn_eq_forInUncurried` instead.
 -/
+@[deprecated forInUncurried_eq_forIn_toList (since := "2025-03-02")]
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
     {f : α → β → δ → m (ForInStep δ)} {init : δ} :
     t.forIn f init = ForIn.forIn (Const.toList t) init (fun a b => f a.1 a.2 b) :=

--- a/src/Std/Data/DTreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Raw/Lemmas.lean
@@ -20,7 +20,7 @@ set_option autoImplicit false
 
 open Std.DTreeMap.Internal
 
-universe u v
+universe u v w
 
 namespace Std.DTreeMap.Raw
 
@@ -1044,5 +1044,100 @@ theorem distinct_keys_toList [TransCmp cmp] (h : t.WF) :
   Impl.Const.distinct_keys_toList h.out
 
 end Const
+
+section monadic
+
+variable {δ : Type w} {m : Type w → Type w}
+
+theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m]
+    {f : δ → (a : α) → β a → m δ} {init : δ} :
+    t.foldlM f init = t.toList.foldlM (fun a b => f a b.1 b.2) init :=
+  Impl.foldlM_eq_foldlM_toList
+
+theorem foldl_eq_foldl_toList {f : δ → (a : α) → β a → δ} {init : δ} :
+    t.foldl f init = t.toList.foldl (fun a b => f a b.1 b.2) init :=
+  Impl.foldl_eq_foldl_toList
+
+theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
+    {f : (a : α) → β a → δ → m δ} {init : δ} :
+    t.foldrM f init = t.toList.foldrM (fun a b => f a.1 a.2 b) init :=
+  Impl.foldrM_eq_foldrM_toList
+
+theorem foldr_eq_foldr_toList {f : (a : α) → β a → δ → δ} {init : δ} :
+    t.foldr f init = t.toList.foldr (fun a b => f a.1 a.2 b) init :=
+  Impl.foldr_eq_foldr_toList
+
+@[simp]
+theorem forM_eq_forM [Monad m] [LawfulMonad m] {f : (a : α) → β a → m PUnit} :
+    t.forM f = ForM.forM t (fun a => f a.1 a.2) := rfl
+
+theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : (a : α) × β a → m PUnit} :
+    ForM.forM t f = ForM.forM t.toList f :=
+  Impl.forM_eq_forM_toList
+
+@[simp]
+theorem forIn_eq_forIn [Monad m] [LawfulMonad m]
+    {f : (a : α) → β a → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn f init = ForIn.forIn t init (fun a b => f a.1 a.2 b) := rfl
+
+theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
+    {f : (a : α) × β a → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn (fun k v => f ⟨k, v⟩) init = ForIn.forIn t.toList init f :=
+  Impl.forIn_eq_forIn_toList (f := f)
+
+namespace Const
+
+variable {β : Type v} {t : Raw α β cmp}
+
+theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m]
+    {f : δ → (a : α) → β → m δ} {init : δ} :
+    t.foldlM f init = (Const.toList t).foldlM (fun a b => f a b.1 b.2) init :=
+  Impl.Const.foldlM_eq_foldlM_toList
+
+theorem foldl_eq_foldl_toList {f : δ → (a : α) → β → δ} {init : δ} :
+    t.foldl f init = (Const.toList t).foldl (fun a b => f a b.1 b.2) init :=
+  Impl.Const.foldl_eq_foldl_toList
+
+theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
+    {f : (a : α) → β → δ → m δ} {init : δ} :
+    t.foldrM f init = (Const.toList t).foldrM (fun a b => f a.1 a.2 b) init :=
+  Impl.Const.foldrM_eq_foldrM_toList
+
+theorem foldr_eq_foldr_toList {f : (a : α) → β → δ → δ} {init : δ} :
+    t.foldr f init = (Const.toList t).foldr (fun a b => f a.1 a.2 b) init :=
+  Impl.Const.foldr_eq_foldr_toList
+
+theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : (a : α) → β → m PUnit} :
+    t.forM f = (Const.toList t).forM (fun a => f a.1 a.2) :=
+  Impl.Const.forM_eq_forM_toList (f := f)
+
+theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
+    {f : α → β → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn f init = ForIn.forIn (Const.toList t) init (fun a b => f a.1 a.2 b) :=
+  Impl.Const.forIn_eq_forIn_toList
+
+variable {t : Impl α Unit}
+
+theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m]
+    {f : δ → α → m δ} {init : δ} :
+    t.foldlM (fun d a _ => f d a) init = t.keys.foldlM f init :=
+  Impl.foldlM_eq_foldlM_keys
+
+theorem foldl_eq_foldl_keys {f : δ → α → δ} {init : δ} :
+    t.foldl (fun d a _ => f d a) init = t.keys.foldl f init :=
+  Impl.foldl_eq_foldl_keys
+
+theorem forM_eq_forM_keys [Monad m] [LawfulMonad m] {f : α → m PUnit} :
+    t.forM (fun a _ => f a) = t.keys.forM f :=
+  Impl.forM_eq_forM_keys
+
+theorem forIn_eq_forIn_keys [Monad m] [LawfulMonad m]
+    {f : α → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn (fun a _ d => f a d) init = ForIn.forIn t.keys init f :=
+  Impl.forIn_eq_forIn_keys
+
+end Const
+
+end monadic
 
 end Std.DTreeMap.Raw

--- a/src/Std/Data/DTreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Raw/Lemmas.lean
@@ -1085,39 +1085,6 @@ theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
     t.forIn (fun k v => f ⟨k, v⟩) init = ForIn.forIn t.toList init f :=
   Impl.forIn_eq_forIn_toList (f := f)
 
-namespace Const
-
-variable {β : Type v} {t : Raw α β cmp}
-
-theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m]
-    {f : δ → (a : α) → β → m δ} {init : δ} :
-    t.foldlM f init = (Const.toList t).foldlM (fun a b => f a b.1 b.2) init :=
-  Impl.Const.foldlM_eq_foldlM_toList
-
-theorem foldl_eq_foldl_toList {f : δ → (a : α) → β → δ} {init : δ} :
-    t.foldl f init = (Const.toList t).foldl (fun a b => f a b.1 b.2) init :=
-  Impl.Const.foldl_eq_foldl_toList
-
-theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
-    {f : (a : α) → β → δ → m δ} {init : δ} :
-    t.foldrM f init = (Const.toList t).foldrM (fun a b => f a.1 a.2 b) init :=
-  Impl.Const.foldrM_eq_foldrM_toList
-
-theorem foldr_eq_foldr_toList {f : (a : α) → β → δ → δ} {init : δ} :
-    t.foldr f init = (Const.toList t).foldr (fun a b => f a.1 a.2 b) init :=
-  Impl.Const.foldr_eq_foldr_toList
-
-theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : (a : α) → β → m PUnit} :
-    t.forM f = (Const.toList t).forM (fun a => f a.1 a.2) :=
-  Impl.Const.forM_eq_forM_toList (f := f)
-
-theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
-    {f : α → β → δ → m (ForInStep δ)} {init : δ} :
-    t.forIn f init = ForIn.forIn (Const.toList t) init (fun a b => f a.1 a.2 b) :=
-  Impl.Const.forIn_eq_forIn_toList
-
-variable {t : Impl α Unit}
-
 theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m]
     {f : δ → α → m δ} {init : δ} :
     t.foldlM (fun d a _ => f d a) init = t.keys.foldlM f init :=
@@ -1127,6 +1094,14 @@ theorem foldl_eq_foldl_keys {f : δ → α → δ} {init : δ} :
     t.foldl (fun d a _ => f d a) init = t.keys.foldl f init :=
   Impl.foldl_eq_foldl_keys
 
+theorem foldrM_eq_foldrM_keys [Monad m] [LawfulMonad m] {f : α → δ → m δ} {init : δ} :
+    t.foldrM (fun a _ d => f a d) init = t.keys.foldrM f init :=
+  Impl.foldrM_eq_foldrM_keys
+
+theorem foldr_eq_foldr_keys {f : α → δ → δ} {init : δ} :
+    t.foldr (fun a _ d => f a d) init = t.keys.foldr f init :=
+  Impl.foldr_eq_foldr_keys
+
 theorem forM_eq_forM_keys [Monad m] [LawfulMonad m] {f : α → m PUnit} :
     t.forM (fun a _ => f a) = t.keys.forM f :=
   Impl.forM_eq_forM_keys
@@ -1135,6 +1110,37 @@ theorem forIn_eq_forIn_keys [Monad m] [LawfulMonad m]
     {f : α → δ → m (ForInStep δ)} {init : δ} :
     t.forIn (fun a _ d => f a d) init = ForIn.forIn t.keys init f :=
   Impl.forIn_eq_forIn_keys
+
+namespace Const
+
+variable {β : Type v} {t : Raw α β cmp}
+
+theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m]
+    {f : δ → α → β → m δ} {init : δ} :
+    t.foldlM f init = (Const.toList t).foldlM (fun a b => f a b.1 b.2) init :=
+  Impl.Const.foldlM_eq_foldlM_toList
+
+theorem foldl_eq_foldl_toList {f : δ → α → β → δ} {init : δ} :
+    t.foldl f init = (Const.toList t).foldl (fun a b => f a b.1 b.2) init :=
+  Impl.Const.foldl_eq_foldl_toList
+
+theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
+    {f : α → β → δ → m δ} {init : δ} :
+    t.foldrM f init = (Const.toList t).foldrM (fun a b => f a.1 a.2 b) init :=
+  Impl.Const.foldrM_eq_foldrM_toList
+
+theorem foldr_eq_foldr_toList {f : α → β → δ → δ} {init : δ} :
+    t.foldr f init = (Const.toList t).foldr (fun a b => f a.1 a.2 b) init :=
+  Impl.Const.foldr_eq_foldr_toList
+
+theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : α → β → m PUnit} :
+    t.forM f = (Const.toList t).forM (fun a => f a.1 a.2) :=
+  Impl.Const.forM_eq_forM_toList (f := f)
+
+theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
+    {f : α → β → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn f init = ForIn.forIn (Const.toList t) init (fun a b => f a.1 a.2 b) :=
+  Impl.Const.forIn_eq_forIn_toList
 
 end Const
 

--- a/src/Std/Data/HashMap/Lemmas.lean
+++ b/src/Std/Data/HashMap/Lemmas.lean
@@ -787,25 +787,23 @@ theorem forIn_eq_forIn_toList [Monad m'] [LawfulMonad m']
     ForIn.forIn m init f = ForIn.forIn m.toList init f :=
   DHashMap.Const.forIn_eq_forIn_toList
 
-variable {m : DHashMap α (fun _ => Unit)}
-
 theorem foldM_eq_foldlM_keys [Monad m'] [LawfulMonad m']
     {f : δ → α → m' δ} {init : δ} :
     m.foldM (fun d a _ => f d a) init = m.keys.foldlM f init :=
-  DHashMap.Const.foldM_eq_foldlM_keys
+  DHashMap.foldM_eq_foldlM_keys
 
 theorem fold_eq_foldl_keys {f : δ → α → δ} {init : δ} :
     m.fold (fun d a _ => f d a) init = m.keys.foldl f init :=
-  DHashMap.Const.fold_eq_foldl_keys
+  DHashMap.fold_eq_foldl_keys
 
 theorem forM_eq_forM_keys [Monad m'] [LawfulMonad m'] {f : α → m' PUnit} :
     m.forM (fun a _ => f a) = m.keys.forM f :=
-  DHashMap.Const.forM_eq_forM_keys
+  DHashMap.forM_eq_forM_keys
 
 theorem forIn_eq_forIn_keys [Monad m'] [LawfulMonad m']
     {f : α → δ → m' (ForInStep δ)} {init : δ} :
     m.forIn (fun a _ d => f a d) init = ForIn.forIn m.keys init f :=
-  DHashMap.Const.forIn_eq_forIn_keys
+  DHashMap.forIn_eq_forIn_keys
 
 end monadic
 

--- a/src/Std/Data/HashMap/Lemmas.lean
+++ b/src/Std/Data/HashMap/Lemmas.lean
@@ -775,7 +775,7 @@ theorem forM_eq_forM [Monad m'] [LawfulMonad m'] {f : (a : α) → β → m' PUn
 
 theorem forM_eq_forM_toList [Monad m'] [LawfulMonad m'] {f : α × β → m' PUnit} :
     ForM.forM m f = ForM.forM m.toList f :=
-  DHashMap.Const.forM_eq_forM_toList
+  DHashMap.Const.forMUncurried_eq_forM_toList
 
 @[simp]
 theorem forIn_eq_forIn [Monad m'] [LawfulMonad m']
@@ -785,7 +785,7 @@ theorem forIn_eq_forIn [Monad m'] [LawfulMonad m']
 theorem forIn_eq_forIn_toList [Monad m'] [LawfulMonad m']
     {f : α × β → δ → m' (ForInStep δ)} {init : δ} :
     ForIn.forIn m init f = ForIn.forIn m.toList init f :=
-  DHashMap.Const.forIn_eq_forIn_toList
+  DHashMap.Const.forInUncurried_eq_forIn_toList
 
 theorem foldM_eq_foldlM_keys [Monad m'] [LawfulMonad m']
     {f : δ → α → m' δ} {init : δ} :
@@ -797,12 +797,12 @@ theorem fold_eq_foldl_keys {f : δ → α → δ} {init : δ} :
   DHashMap.fold_eq_foldl_keys
 
 theorem forM_eq_forM_keys [Monad m'] [LawfulMonad m'] {f : α → m' PUnit} :
-    m.forM (fun a _ => f a) = m.keys.forM f :=
+    ForM.forM m (fun a => f a.1) = m.keys.forM f :=
   DHashMap.forM_eq_forM_keys
 
 theorem forIn_eq_forIn_keys [Monad m'] [LawfulMonad m']
     {f : α → δ → m' (ForInStep δ)} {init : δ} :
-    m.forIn (fun a _ d => f a d) init = ForIn.forIn m.keys init f :=
+    ForIn.forIn m init (fun a d => f a.1 d) = ForIn.forIn m.keys init f :=
   DHashMap.forIn_eq_forIn_keys
 
 end monadic

--- a/src/Std/Data/HashMap/RawLemmas.lean
+++ b/src/Std/Data/HashMap/RawLemmas.lean
@@ -796,25 +796,23 @@ theorem forIn_eq_forIn_toList [Monad m'] [LawfulMonad m'] (h : m.WF)
     ForIn.forIn m init f = ForIn.forIn m.toList init f :=
   DHashMap.Raw.Const.forIn_eq_forIn_toList h.out
 
-variable {m : Raw α Unit}
-
 theorem foldM_eq_foldlM_keys [Monad m'] [LawfulMonad m'] (h : m.WF)
     {f : δ → α → m' δ} {init : δ} :
     m.foldM (fun d a _ => f d a) init = m.keys.foldlM f init :=
-  DHashMap.Raw.Const.foldM_eq_foldlM_keys h.out
+  DHashMap.Raw.foldM_eq_foldlM_keys h.out
 
 theorem fold_eq_foldl_keys (h : m.WF) {f : δ → α → δ} {init : δ} :
     m.fold (fun d a _ => f d a) init = m.keys.foldl f init :=
-  DHashMap.Raw.Const.fold_eq_foldl_keys h.out
+  DHashMap.Raw.fold_eq_foldl_keys h.out
 
 theorem forM_eq_forM_keys [Monad m'] [LawfulMonad m'] (h : m.WF) {f : α → m' PUnit} :
     m.forM (fun a _ => f a) = m.keys.forM f :=
-  DHashMap.Raw.Const.forM_eq_forM_keys h.out
+  DHashMap.Raw.forM_eq_forM_keys h.out
 
 theorem forIn_eq_forIn_keys [Monad m'] [LawfulMonad m'] (h : m.WF)
     {f : α → δ → m' (ForInStep δ)} {init : δ} :
     m.forIn (fun a _ d => f a d) init = ForIn.forIn m.keys init f :=
-  DHashMap.Raw.Const.forIn_eq_forIn_keys h.out
+  DHashMap.Raw.forIn_eq_forIn_keys h.out
 
 end monadic
 

--- a/src/Std/Data/HashMap/RawLemmas.lean
+++ b/src/Std/Data/HashMap/RawLemmas.lean
@@ -783,7 +783,7 @@ theorem forM_eq_forM [Monad m'] [LawfulMonad m'] {f : (a : α) → β → m' PUn
 
 theorem forM_eq_forM_toList [Monad m'] [LawfulMonad m'] (h : m.WF) {f : α × β → m' PUnit} :
     ForM.forM m f = ForM.forM m.toList f :=
-  DHashMap.Raw.Const.forM_eq_forM_toList h.out
+  DHashMap.Raw.Const.forMUncurried_eq_forM_toList h.out
 
 omit [BEq α] [Hashable α] in
 @[simp]
@@ -794,7 +794,7 @@ theorem forIn_eq_forIn [Monad m'] [LawfulMonad m']
 theorem forIn_eq_forIn_toList [Monad m'] [LawfulMonad m'] (h : m.WF)
     {f : α × β → δ → m' (ForInStep δ)} {init : δ} :
     ForIn.forIn m init f = ForIn.forIn m.toList init f :=
-  DHashMap.Raw.Const.forIn_eq_forIn_toList h.out
+  DHashMap.Raw.Const.forInUncurried_eq_forIn_toList h.out
 
 theorem foldM_eq_foldlM_keys [Monad m'] [LawfulMonad m'] (h : m.WF)
     {f : δ → α → m' δ} {init : δ} :
@@ -806,12 +806,12 @@ theorem fold_eq_foldl_keys (h : m.WF) {f : δ → α → δ} {init : δ} :
   DHashMap.Raw.fold_eq_foldl_keys h.out
 
 theorem forM_eq_forM_keys [Monad m'] [LawfulMonad m'] (h : m.WF) {f : α → m' PUnit} :
-    m.forM (fun a _ => f a) = m.keys.forM f :=
+    ForM.forM m (fun a => f a.1) = m.keys.forM f :=
   DHashMap.Raw.forM_eq_forM_keys h.out
 
 theorem forIn_eq_forIn_keys [Monad m'] [LawfulMonad m'] (h : m.WF)
     {f : α → δ → m' (ForInStep δ)} {init : δ} :
-    m.forIn (fun a _ d => f a d) init = ForIn.forIn m.keys init f :=
+    ForIn.forIn m init (fun a d => f a.1 d) = ForIn.forIn m.keys init f :=
   DHashMap.Raw.forIn_eq_forIn_keys h.out
 
 end monadic

--- a/src/Std/Data/HashSet/Lemmas.lean
+++ b/src/Std/Data/HashSet/Lemmas.lean
@@ -398,7 +398,7 @@ theorem forM_eq_forM_toList [Monad m'] [LawfulMonad m'] {f : α → m' PUnit} :
 @[simp]
 theorem forIn_eq_forIn [Monad m'] [LawfulMonad m']
     {f : α → δ → m' (ForInStep δ)} {init : δ} :
-    m.forIn f init = ForIn.forIn m init f := rfl
+    ForIn.forIn m init f = ForIn.forIn m init f := rfl
 
 theorem forIn_eq_forIn_toList [Monad m'] [LawfulMonad m']
     {f : α → δ → m' (ForInStep δ)} {init : δ} :

--- a/src/Std/Data/Internal/List/Associative.lean
+++ b/src/Std/Data/Internal/List/Associative.lean
@@ -2153,7 +2153,7 @@ theorem forIn_eq_forIn_toProd {β : Type v} {δ : Type w} {m' : Type w → Type 
   | cons hd tl => simp
 
 theorem foldlM_eq_foldlM_keys {δ : Type w} {m' : Type w → Type w} [Monad m'] [LawfulMonad m']
-    {l : List ((_ : α) × Unit)} {f : δ → α → m' δ} {init : δ} :
+    {l : List ((a : α) × β a)} {f : δ → α → m' δ} {init : δ} :
     l.foldlM (fun a b => f a b.1) init = (keys l).foldlM f init := by
   induction l generalizing init with
   | nil => simp
@@ -2163,14 +2163,22 @@ theorem foldlM_eq_foldlM_keys {δ : Type w} {m' : Type w → Type w} [Monad m'] 
     simp [ih]
 
 theorem foldl_eq_foldl_keys {δ : Type w}
-    {l : List ((_ : α) × Unit)} {f : δ → α → δ} {init : δ} :
+    {l : List ((a : α) × β a)} {f : δ → α → δ} {init : δ} :
     l.foldl (fun a b => f a b.1) init = (keys l).foldl f init := by
   induction l generalizing init with
   | nil => simp
   | cons hd tl ih => simp [List.foldlM_cons, keys, ih]
 
 theorem foldrM_eq_foldrM_keys {δ : Type w} {m' : Type w → Type w} [Monad m'] [LawfulMonad m']
-    {l : List ((_ : α) × Unit)} {f : δ → α → m' δ} {init : δ} :
+    {l : List ((a : α) × β a)} {f : α → δ → m' δ} {init : δ} :
+    l.foldrM (fun a b => f a.1 b) init = (keys l).foldrM f init := by
+  induction l generalizing init with
+  | nil => simp
+  | cons hd tl ih =>
+    simp [keys, ih]
+
+theorem foldrM_eq_foldrM_keys' {δ : Type w} {m' : Type w → Type w} [Monad m'] [LawfulMonad m']
+    {l : List ((a : α) × β a)} {f : δ → α → m' δ} {init : δ} :
     l.foldrM (fun a b => f b a.1) init = (keys l).foldrM (fun a b => f b a) init := by
   induction l generalizing init with
   | nil => simp
@@ -2178,14 +2186,21 @@ theorem foldrM_eq_foldrM_keys {δ : Type w} {m' : Type w → Type w} [Monad m'] 
     simp [keys, ih]
 
 theorem foldr_eq_foldr_keys {δ : Type w}
-    {l : List ((_ : α) × Unit)} {f : δ → α → δ} {init : δ} :
+    {l : List ((a : α) × β a)} {f : α → δ → δ} {init : δ} :
+    l.foldr (fun a b => f a.1 b) init = (keys l).foldr f init := by
+  induction l generalizing init with
+  | nil => simp
+  | cons hd tl ih => simp [keys, ih]
+
+theorem foldr_eq_foldr_keys' {δ : Type w}
+    {l : List ((a : α) × β a)} {f : δ → α → δ} {init : δ} :
     l.foldr (fun a b => f b a.1) init = (keys l).foldr (fun a b => f b a) init := by
   induction l generalizing init with
   | nil => simp
   | cons hd tl ih => simp [keys, ih]
 
 theorem forM_eq_forM_keys {m' : Type w → Type w} [Monad m'] [LawfulMonad m']
-    {l : List ((_ : α) × Unit)} {f : α → m' PUnit} :
+    {l : List ((a : α) × β a)} {f : α → m' PUnit} :
     l.forM (fun a => f a.1) = (keys l).forM f := by
   induction l with
   | nil => simp
@@ -2196,7 +2211,7 @@ theorem forM_eq_forM_keys {m' : Type w → Type w} [Monad m'] [LawfulMonad m']
     apply ih
 
 theorem forIn_eq_forIn_keys {δ : Type w} {m' : Type w → Type w} [Monad m'] [LawfulMonad m']
-    {f : α → δ → m' (ForInStep δ)} {init : δ} {l : List ((_ : α) × Unit)} :
+    {f : α → δ → m' (ForInStep δ)} {init : δ} {l : List ((a : α) × β a)} :
     ForIn.forIn l init (fun a d => f a.fst d) = ForIn.forIn (keys l) init f := by
   induction l generalizing init with
   | nil => simp

--- a/src/Std/Data/Internal/List/Associative.lean
+++ b/src/Std/Data/Internal/List/Associative.lean
@@ -2106,6 +2106,14 @@ theorem foldl_eq_foldl_toProd {β : Type v} {δ : Type w}
   | cons hd tl ih => simp [ih]
 
 theorem foldrM_eq_foldrM_toProd {β : Type v} {δ : Type w} {m' : Type w → Type w} [Monad m']
+    [LawfulMonad m'] {l : List ((_ : α) × β)} {f : (a : α) → β → δ → m' δ} {init : δ} :
+    l.foldrM (fun a b => f a.1 a.2 b) init =
+      (l.map fun x => (x.1, x.2)).foldrM (fun a b => f a.1 a.2 b) init := by
+  induction l generalizing init with
+  | nil => simp
+  | cons hd tl ih => simp [ih]
+
+theorem foldrM_eq_foldrM_toProd' {β : Type v} {δ : Type w} {m' : Type w → Type w} [Monad m']
     [LawfulMonad m'] {l : List ((_ : α) × β)} {f : δ → (a : α) → β → m' δ} {init : δ} :
     l.foldrM (fun a b => f b a.1 a.2) init =
       (l.map fun x => (x.1, x.2)).foldrM (fun a b => f b a.1 a.2) init := by
@@ -2114,6 +2122,14 @@ theorem foldrM_eq_foldrM_toProd {β : Type v} {δ : Type w} {m' : Type w → Typ
   | cons hd tl ih => simp [ih]
 
 theorem foldr_eq_foldr_toProd {β : Type v} {δ : Type w}
+    {l : List ((_ : α) × β)} {f : (a : α) → β → δ → δ} {init : δ} :
+    l.foldr (fun a b => f a.1 a.2 b) init =
+      (l.map fun x => (x.1, x.2)).foldr (fun a b => f a.1 a.2 b) init := by
+  induction l generalizing init with
+  | nil => simp
+  | cons hd tl ih => simp [ih]
+
+theorem foldr_eq_foldr_toProd' {β : Type v} {δ : Type w}
     {l : List ((_ : α) × β)} {f : δ → (a : α) → β → δ} {init : δ} :
     l.foldr (fun a b => f b a.1 a.2) init =
       (l.map fun x => (x.1, x.2)).foldr (fun a b => f b a.1 a.2) init := by

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -17,7 +17,7 @@ This file contains lemmas about `Std.Data.TreeMap`. Most of the lemmas require
 set_option linter.missingDocs true
 set_option autoImplicit false
 
-universe u v
+universe u v w
 
 namespace Std.TreeMap
 
@@ -726,5 +726,64 @@ theorem find?_toList_eq_none_iff_not_mem [TransCmp cmp] {k : α} :
 theorem distinct_keys_toList [TransCmp cmp] :
     (toList t).Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq) :=
   DTreeMap.Const.distinct_keys_toList
+
+section monadic
+
+variable {δ : Type w} {m : Type w → Type w}
+
+theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m]
+    {f : δ → α → m δ} {init : δ} :
+    t.foldlM (fun d a _ => f d a) init = t.keys.foldlM f init :=
+  DTreeMap.foldlM_eq_foldlM_keys
+
+theorem foldl_eq_foldl_keys {f : δ → α → δ} {init : δ} :
+    t.foldl (fun d a _ => f d a) init = t.keys.foldl f init :=
+  DTreeMap.foldl_eq_foldl_keys
+
+theorem foldrM_eq_foldrM_keys [Monad m] [LawfulMonad m] {f : α → δ → m δ} {init : δ} :
+    t.foldrM (fun a _ d => f a d) init = t.keys.foldrM f init :=
+  DTreeMap.foldrM_eq_foldrM_keys
+
+theorem foldr_eq_foldr_keys {f : α → δ → δ} {init : δ} :
+    t.foldr (fun a _ d => f a d) init = t.keys.foldr f init :=
+  DTreeMap.foldr_eq_foldr_keys
+
+theorem forM_eq_forM_keys [Monad m] [LawfulMonad m] {f : α → m PUnit} :
+    t.forM (fun a _ => f a) = t.keys.forM f :=
+  DTreeMap.forM_eq_forM_keys
+
+theorem forIn_eq_forIn_keys [Monad m] [LawfulMonad m]
+    {f : α → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn (fun a _ d => f a d) init = ForIn.forIn t.keys init f :=
+  DTreeMap.forIn_eq_forIn_keys
+
+theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m]
+    {f : δ → α → β → m δ} {init : δ} :
+    t.foldlM f init = t.toList.foldlM (fun a b => f a b.1 b.2) init :=
+  DTreeMap.Const.foldlM_eq_foldlM_toList
+
+theorem foldl_eq_foldl_toList {f : δ → α → β → δ} {init : δ} :
+    t.foldl f init = t.toList.foldl (fun a b => f a b.1 b.2) init :=
+  DTreeMap.Const.foldl_eq_foldl_toList
+
+theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
+    {f : α → β → δ → m δ} {init : δ} :
+    t.foldrM f init = t.toList.foldrM (fun a b => f a.1 a.2 b) init :=
+  DTreeMap.Const.foldrM_eq_foldrM_toList
+
+theorem foldr_eq_foldr_toList {f : α → β → δ → δ} {init : δ} :
+    t.foldr f init = t.toList.foldr (fun a b => f a.1 a.2 b) init :=
+  DTreeMap.Const.foldr_eq_foldr_toList
+
+theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : α → β → m PUnit} :
+    t.forM f = t.toList.forM (fun a => f a.1 a.2) :=
+  DTreeMap.Const.forM_eq_forM_toList (f := f)
+
+theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
+    {f : α → β → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn f init = ForIn.forIn t.toList init (fun a b => f a.1 a.2 b) :=
+  DTreeMap.Const.forIn_eq_forIn_toList
+
+end monadic
 
 end Std.TreeMap

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -751,9 +751,9 @@ theorem foldr_eq_foldr_toList {f : α → β → δ → δ} {init : δ} :
 theorem forM_eq_forM [Monad m] [LawfulMonad m] {f : α → β → m PUnit} :
     t.forM f = ForM.forM t (fun a => f a.1 a.2) := rfl
 
-theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : α → β → m PUnit} :
-    t.forM f = t.toList.forM (fun a => f a.1 a.2) :=
-  DTreeMap.Const.forM_eq_forM_toList (f := f)
+theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : α × β → m PUnit} :
+    ForM.forM t f = ForM.forM t.toList f :=
+  DTreeMap.Const.forMUncurried_eq_forM_toList (f := f)
 
 @[simp]
 theorem forIn_eq_forIn [Monad m] [LawfulMonad m]
@@ -761,8 +761,8 @@ theorem forIn_eq_forIn [Monad m] [LawfulMonad m]
     t.forIn f init = ForIn.forIn t init (fun a d => f a.1 a.2 d) := rfl
 
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
-    {f : α → β → δ → m (ForInStep δ)} {init : δ} :
-    t.forIn f init = ForIn.forIn t.toList init (fun a b => f a.1 a.2 b) :=
+    {f : α × β → δ → m (ForInStep δ)} {init : δ} :
+    ForIn.forIn t init f = ForIn.forIn t.toList init f :=
   DTreeMap.Const.forIn_eq_forIn_toList
 
 theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m] {f : δ → α → m δ} {init : δ} :
@@ -782,11 +782,11 @@ theorem foldr_eq_foldr_keys {f : α → δ → δ} {init : δ} :
   DTreeMap.foldr_eq_foldr_keys
 
 theorem forM_eq_forM_keys [Monad m] [LawfulMonad m] {f : α → m PUnit} :
-    t.forM (fun a _ => f a) = t.keys.forM f :=
+    ForM.forM t (fun a => f a.1) = t.keys.forM f :=
   DTreeMap.forM_eq_forM_keys
 
 theorem forIn_eq_forIn_keys [Monad m] [LawfulMonad m] {f : α → δ → m (ForInStep δ)} {init : δ} :
-    t.forIn (fun a _ d => f a d) init = ForIn.forIn t.keys init f :=
+    ForIn.forIn t init (fun a d => f a.1 d) = ForIn.forIn t.keys init f :=
   DTreeMap.forIn_eq_forIn_keys
 
 end monadic

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -763,7 +763,7 @@ theorem forIn_eq_forIn [Monad m] [LawfulMonad m]
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
     {f : α × β → δ → m (ForInStep δ)} {init : δ} :
     ForIn.forIn t init f = ForIn.forIn t.toList init f :=
-  DTreeMap.Const.forIn_eq_forIn_toList
+  DTreeMap.Const.forInUncurried_eq_forIn_toList
 
 theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m] {f : δ → α → m δ} {init : δ} :
     t.foldlM (fun d a _ => f d a) init = t.keys.foldlM f init :=

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -731,8 +731,41 @@ section monadic
 
 variable {δ : Type w} {m : Type w → Type w}
 
-theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m]
-    {f : δ → α → m δ} {init : δ} :
+theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m] {f : δ → α → β → m δ} {init : δ} :
+    t.foldlM f init = t.toList.foldlM (fun a b => f a b.1 b.2) init :=
+  DTreeMap.Const.foldlM_eq_foldlM_toList
+
+theorem foldl_eq_foldl_toList {f : δ → α → β → δ} {init : δ} :
+    t.foldl f init = t.toList.foldl (fun a b => f a b.1 b.2) init :=
+  DTreeMap.Const.foldl_eq_foldl_toList
+
+theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m] {f : α → β → δ → m δ} {init : δ} :
+    t.foldrM f init = t.toList.foldrM (fun a b => f a.1 a.2 b) init :=
+  DTreeMap.Const.foldrM_eq_foldrM_toList
+
+theorem foldr_eq_foldr_toList {f : α → β → δ → δ} {init : δ} :
+    t.foldr f init = t.toList.foldr (fun a b => f a.1 a.2 b) init :=
+  DTreeMap.Const.foldr_eq_foldr_toList
+
+@[simp]
+theorem forM_eq_forM [Monad m] [LawfulMonad m] {f : α → β → m PUnit} :
+    t.forM f = ForM.forM t (fun a => f a.1 a.2) := rfl
+
+theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : α → β → m PUnit} :
+    t.forM f = t.toList.forM (fun a => f a.1 a.2) :=
+  DTreeMap.Const.forM_eq_forM_toList (f := f)
+
+@[simp]
+theorem forIn_eq_forIn [Monad m] [LawfulMonad m]
+    {f : α → β → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn f init = ForIn.forIn t init (fun a d => f a.1 a.2 d) := rfl
+
+theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
+    {f : α → β → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn f init = ForIn.forIn t.toList init (fun a b => f a.1 a.2 b) :=
+  DTreeMap.Const.forIn_eq_forIn_toList
+
+theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m] {f : δ → α → m δ} {init : δ} :
     t.foldlM (fun d a _ => f d a) init = t.keys.foldlM f init :=
   DTreeMap.foldlM_eq_foldlM_keys
 
@@ -752,37 +785,9 @@ theorem forM_eq_forM_keys [Monad m] [LawfulMonad m] {f : α → m PUnit} :
     t.forM (fun a _ => f a) = t.keys.forM f :=
   DTreeMap.forM_eq_forM_keys
 
-theorem forIn_eq_forIn_keys [Monad m] [LawfulMonad m]
-    {f : α → δ → m (ForInStep δ)} {init : δ} :
+theorem forIn_eq_forIn_keys [Monad m] [LawfulMonad m] {f : α → δ → m (ForInStep δ)} {init : δ} :
     t.forIn (fun a _ d => f a d) init = ForIn.forIn t.keys init f :=
   DTreeMap.forIn_eq_forIn_keys
-
-theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m]
-    {f : δ → α → β → m δ} {init : δ} :
-    t.foldlM f init = t.toList.foldlM (fun a b => f a b.1 b.2) init :=
-  DTreeMap.Const.foldlM_eq_foldlM_toList
-
-theorem foldl_eq_foldl_toList {f : δ → α → β → δ} {init : δ} :
-    t.foldl f init = t.toList.foldl (fun a b => f a b.1 b.2) init :=
-  DTreeMap.Const.foldl_eq_foldl_toList
-
-theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
-    {f : α → β → δ → m δ} {init : δ} :
-    t.foldrM f init = t.toList.foldrM (fun a b => f a.1 a.2 b) init :=
-  DTreeMap.Const.foldrM_eq_foldrM_toList
-
-theorem foldr_eq_foldr_toList {f : α → β → δ → δ} {init : δ} :
-    t.foldr f init = t.toList.foldr (fun a b => f a.1 a.2 b) init :=
-  DTreeMap.Const.foldr_eq_foldr_toList
-
-theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : α → β → m PUnit} :
-    t.forM f = t.toList.forM (fun a => f a.1 a.2) :=
-  DTreeMap.Const.forM_eq_forM_toList (f := f)
-
-theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
-    {f : α → β → δ → m (ForInStep δ)} {init : δ} :
-    t.forIn f init = ForIn.forIn t.toList init (fun a b => f a.1 a.2 b) :=
-  DTreeMap.Const.forIn_eq_forIn_toList
 
 end monadic
 

--- a/src/Std/Data/TreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Raw/Lemmas.lean
@@ -18,7 +18,7 @@ These proofs can be obtained from `Std.Data.TreeMap.Raw.WF`.
 set_option linter.missingDocs true
 set_option autoImplicit false
 
-universe u v
+universe u v w
 
 namespace Std.TreeMap.Raw
 
@@ -734,5 +734,64 @@ theorem find?_toList_eq_none_iff_not_mem [TransCmp cmp] (h : t.WF) {k : α} :
 theorem distinct_keys_toList [TransCmp cmp] (h : t.WF) :
     (toList t).Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq) :=
   DTreeMap.Raw.Const.distinct_keys_toList h
+
+section monadic
+
+variable {δ : Type w} {m : Type w → Type w}
+
+theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m]
+    {f : δ → α → m δ} {init : δ} :
+    t.foldlM (fun d a _ => f d a) init = t.keys.foldlM f init :=
+  DTreeMap.Raw.foldlM_eq_foldlM_keys
+
+theorem foldl_eq_foldl_keys {f : δ → α → δ} {init : δ} :
+    t.foldl (fun d a _ => f d a) init = t.keys.foldl f init :=
+  DTreeMap.Raw.foldl_eq_foldl_keys
+
+theorem foldrM_eq_foldrM_keys [Monad m] [LawfulMonad m] {f : α → δ → m δ} {init : δ} :
+    t.foldrM (fun a _ d => f a d) init = t.keys.foldrM f init :=
+  DTreeMap.Raw.foldrM_eq_foldrM_keys
+
+theorem foldr_eq_foldr_keys {f : α → δ → δ} {init : δ} :
+    t.foldr (fun a _ d => f a d) init = t.keys.foldr f init :=
+  DTreeMap.Raw.foldr_eq_foldr_keys
+
+theorem forM_eq_forM_keys [Monad m] [LawfulMonad m] {f : α → m PUnit} :
+    t.forM (fun a _ => f a) = t.keys.forM f :=
+  DTreeMap.Raw.forM_eq_forM_keys
+
+theorem forIn_eq_forIn_keys [Monad m] [LawfulMonad m]
+    {f : α → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn (fun a _ d => f a d) init = ForIn.forIn t.keys init f :=
+  DTreeMap.Raw.forIn_eq_forIn_keys
+
+theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m]
+    {f : δ → α → β → m δ} {init : δ} :
+    t.foldlM f init = t.toList.foldlM (fun a b => f a b.1 b.2) init :=
+  DTreeMap.Raw.Const.foldlM_eq_foldlM_toList
+
+theorem foldl_eq_foldl_toList {f : δ → α → β → δ} {init : δ} :
+    t.foldl f init = t.toList.foldl (fun a b => f a b.1 b.2) init :=
+  DTreeMap.Raw.Const.foldl_eq_foldl_toList
+
+theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
+    {f : α → β → δ → m δ} {init : δ} :
+    t.foldrM f init = t.toList.foldrM (fun a b => f a.1 a.2 b) init :=
+  DTreeMap.Raw.Const.foldrM_eq_foldrM_toList
+
+theorem foldr_eq_foldr_toList {f : α → β → δ → δ} {init : δ} :
+    t.foldr f init = t.toList.foldr (fun a b => f a.1 a.2 b) init :=
+  DTreeMap.Raw.Const.foldr_eq_foldr_toList
+
+theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : α → β → m PUnit} :
+    t.forM f = t.toList.forM (fun a => f a.1 a.2) :=
+  DTreeMap.Raw.Const.forM_eq_forM_toList (f := f)
+
+theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
+    {f : α → β → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn f init = ForIn.forIn t.toList init (fun a b => f a.1 a.2 b) :=
+  DTreeMap.Raw.Const.forIn_eq_forIn_toList
+
+end monadic
 
 end Std.TreeMap.Raw

--- a/src/Std/Data/TreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Raw/Lemmas.lean
@@ -770,7 +770,7 @@ theorem forIn_eq_forIn [Monad m] [LawfulMonad m] {f : α → β → δ → m (Fo
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
     {f : α × β → δ → m (ForInStep δ)} {init : δ} :
     ForIn.forIn t init f = ForIn.forIn t.toList init f :=
-  DTreeMap.Raw.Const.forIn_eq_forIn_toList
+  DTreeMap.Raw.Const.forInUncurried_eq_forIn_toList
 
 theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m] {f : δ → α → m δ} {init : δ} :
     t.foldlM (fun d a _ => f d a) init = t.keys.foldlM f init :=

--- a/src/Std/Data/TreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Raw/Lemmas.lean
@@ -739,8 +739,40 @@ section monadic
 
 variable {δ : Type w} {m : Type w → Type w}
 
-theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m]
-    {f : δ → α → m δ} {init : δ} :
+theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m] {f : δ → α → β → m δ} {init : δ} :
+    t.foldlM f init = t.toList.foldlM (fun a b => f a b.1 b.2) init :=
+  DTreeMap.Raw.Const.foldlM_eq_foldlM_toList
+
+theorem foldl_eq_foldl_toList {f : δ → α → β → δ} {init : δ} :
+    t.foldl f init = t.toList.foldl (fun a b => f a b.1 b.2) init :=
+  DTreeMap.Raw.Const.foldl_eq_foldl_toList
+
+theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m] {f : α → β → δ → m δ} {init : δ} :
+    t.foldrM f init = t.toList.foldrM (fun a b => f a.1 a.2 b) init :=
+  DTreeMap.Raw.Const.foldrM_eq_foldrM_toList
+
+theorem foldr_eq_foldr_toList {f : α → β → δ → δ} {init : δ} :
+    t.foldr f init = t.toList.foldr (fun a b => f a.1 a.2 b) init :=
+  DTreeMap.Raw.Const.foldr_eq_foldr_toList
+
+@[simp]
+theorem forM_eq_forM [Monad m] [LawfulMonad m] {f : α → β → m PUnit} :
+    t.forM f = ForM.forM t (fun a => f a.1 a.2) := rfl
+
+theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : α → β → m PUnit} :
+    t.forM f = t.toList.forM (fun a => f a.1 a.2) :=
+  DTreeMap.Raw.Const.forM_eq_forM_toList (f := f)
+
+@[simp]
+theorem forIn_eq_forIn [Monad m] [LawfulMonad m] {f : α → β → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn f init = ForIn.forIn t init (fun a d => f a.1 a.2 d) := rfl
+
+theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
+    {f : α → β → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn f init = ForIn.forIn t.toList init (fun a b => f a.1 a.2 b) :=
+  DTreeMap.Raw.Const.forIn_eq_forIn_toList
+
+theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m] {f : δ → α → m δ} {init : δ} :
     t.foldlM (fun d a _ => f d a) init = t.keys.foldlM f init :=
   DTreeMap.Raw.foldlM_eq_foldlM_keys
 
@@ -764,33 +796,6 @@ theorem forIn_eq_forIn_keys [Monad m] [LawfulMonad m]
     {f : α → δ → m (ForInStep δ)} {init : δ} :
     t.forIn (fun a _ d => f a d) init = ForIn.forIn t.keys init f :=
   DTreeMap.Raw.forIn_eq_forIn_keys
-
-theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m]
-    {f : δ → α → β → m δ} {init : δ} :
-    t.foldlM f init = t.toList.foldlM (fun a b => f a b.1 b.2) init :=
-  DTreeMap.Raw.Const.foldlM_eq_foldlM_toList
-
-theorem foldl_eq_foldl_toList {f : δ → α → β → δ} {init : δ} :
-    t.foldl f init = t.toList.foldl (fun a b => f a b.1 b.2) init :=
-  DTreeMap.Raw.Const.foldl_eq_foldl_toList
-
-theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
-    {f : α → β → δ → m δ} {init : δ} :
-    t.foldrM f init = t.toList.foldrM (fun a b => f a.1 a.2 b) init :=
-  DTreeMap.Raw.Const.foldrM_eq_foldrM_toList
-
-theorem foldr_eq_foldr_toList {f : α → β → δ → δ} {init : δ} :
-    t.foldr f init = t.toList.foldr (fun a b => f a.1 a.2 b) init :=
-  DTreeMap.Raw.Const.foldr_eq_foldr_toList
-
-theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : α → β → m PUnit} :
-    t.forM f = t.toList.forM (fun a => f a.1 a.2) :=
-  DTreeMap.Raw.Const.forM_eq_forM_toList (f := f)
-
-theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
-    {f : α → β → δ → m (ForInStep δ)} {init : δ} :
-    t.forIn f init = ForIn.forIn t.toList init (fun a b => f a.1 a.2 b) :=
-  DTreeMap.Raw.Const.forIn_eq_forIn_toList
 
 end monadic
 

--- a/src/Std/Data/TreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Raw/Lemmas.lean
@@ -759,17 +759,17 @@ theorem foldr_eq_foldr_toList {f : α → β → δ → δ} {init : δ} :
 theorem forM_eq_forM [Monad m] [LawfulMonad m] {f : α → β → m PUnit} :
     t.forM f = ForM.forM t (fun a => f a.1 a.2) := rfl
 
-theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : α → β → m PUnit} :
-    t.forM f = t.toList.forM (fun a => f a.1 a.2) :=
-  DTreeMap.Raw.Const.forM_eq_forM_toList (f := f)
+theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : α × β → m PUnit} :
+    ForM.forM t f = t.toList.forM f :=
+  DTreeMap.Raw.Const.forMUncurried_eq_forM_toList (f := f)
 
 @[simp]
 theorem forIn_eq_forIn [Monad m] [LawfulMonad m] {f : α → β → δ → m (ForInStep δ)} {init : δ} :
     t.forIn f init = ForIn.forIn t init (fun a d => f a.1 a.2 d) := rfl
 
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
-    {f : α → β → δ → m (ForInStep δ)} {init : δ} :
-    t.forIn f init = ForIn.forIn t.toList init (fun a b => f a.1 a.2 b) :=
+    {f : α × β → δ → m (ForInStep δ)} {init : δ} :
+    ForIn.forIn t init f = ForIn.forIn t.toList init f :=
   DTreeMap.Raw.Const.forIn_eq_forIn_toList
 
 theorem foldlM_eq_foldlM_keys [Monad m] [LawfulMonad m] {f : δ → α → m δ} {init : δ} :
@@ -789,12 +789,12 @@ theorem foldr_eq_foldr_keys {f : α → δ → δ} {init : δ} :
   DTreeMap.Raw.foldr_eq_foldr_keys
 
 theorem forM_eq_forM_keys [Monad m] [LawfulMonad m] {f : α → m PUnit} :
-    t.forM (fun a _ => f a) = t.keys.forM f :=
+    ForM.forM t (fun a => f a.1) = t.keys.forM f :=
   DTreeMap.Raw.forM_eq_forM_keys
 
 theorem forIn_eq_forIn_keys [Monad m] [LawfulMonad m]
     {f : α → δ → m (ForInStep δ)} {init : δ} :
-    t.forIn (fun a _ d => f a d) init = ForIn.forIn t.keys init f :=
+    ForIn.forIn t init (fun a d => f a.1 d) = ForIn.forIn t.keys init f :=
   DTreeMap.Raw.forIn_eq_forIn_keys
 
 end monadic

--- a/src/Std/Data/TreeSet/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Lemmas.lean
@@ -17,7 +17,7 @@ This file contains lemmas about `Std.Data.TreeSet`. Most of the lemmas require
 set_option linter.missingDocs true
 set_option autoImplicit false
 
-universe u v
+universe u v w
 
 namespace Std.TreeSet
 
@@ -357,5 +357,38 @@ theorem mem_toList [LawfulEqCmp cmp] [TransCmp cmp] {k : α} :
 theorem distinct_toList [TransCmp cmp] :
     t.toList.Pairwise (fun a b => ¬ cmp a b = .eq) :=
   DTreeMap.distinct_keys
+
+section monadic
+
+variable {δ : Type w} {m : Type w → Type w}
+
+theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m]
+    {f : δ → α → m δ} {init : δ} :
+    t.foldlM f init = t.toList.foldlM f init :=
+  TreeMap.foldlM_eq_foldlM_keys
+
+theorem foldl_eq_foldl_toList {f : δ → α → δ} {init : δ} :
+    t.foldl f init = t.toList.foldl f init :=
+  TreeMap.foldl_eq_foldl_keys
+
+theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
+    {f : α → δ → m δ} {init : δ} :
+    t.foldrM f init = t.toList.foldrM f init :=
+  TreeMap.foldrM_eq_foldrM_keys
+
+theorem foldr_eq_foldr_toList {f : α → δ → δ} {init : δ} :
+    t.foldr f init = t.toList.foldr f init :=
+  TreeMap.foldr_eq_foldr_keys
+
+theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : α → m PUnit} :
+    t.forM f = t.toList.forM f :=
+  TreeMap.forM_eq_forM_keys
+
+theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
+    {f : α → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn f init = ForIn.forIn t.toList init f :=
+  TreeMap.forIn_eq_forIn_keys
+
+end monadic
 
 end Std.TreeSet

--- a/src/Std/Data/TreeSet/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Lemmas.lean
@@ -383,7 +383,7 @@ theorem forM_eq_forM [Monad m] [LawfulMonad m] {f : α → m PUnit} :
     t.forM f = ForM.forM t f := rfl
 
 theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : α → m PUnit} :
-    t.forM f = t.toList.forM f :=
+    ForM.forM t f = t.toList.forM f :=
   TreeMap.forM_eq_forM_keys
 
 @[simp]
@@ -391,7 +391,7 @@ theorem forIn_eq_forIn [Monad m] [LawfulMonad m] {f : α → δ → m (ForInStep
     t.forIn f init = ForIn.forIn t init f := rfl
 
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m] {f : α → δ → m (ForInStep δ)} {init : δ} :
-    t.forIn f init = ForIn.forIn t.toList init f :=
+    ForIn.forIn t init f = ForIn.forIn t.toList init f :=
   TreeMap.forIn_eq_forIn_keys
 
 end monadic

--- a/src/Std/Data/TreeSet/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Lemmas.lean
@@ -362,8 +362,7 @@ section monadic
 
 variable {δ : Type w} {m : Type w → Type w}
 
-theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m]
-    {f : δ → α → m δ} {init : δ} :
+theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m] {f : δ → α → m δ} {init : δ} :
     t.foldlM f init = t.toList.foldlM f init :=
   TreeMap.foldlM_eq_foldlM_keys
 
@@ -371,8 +370,7 @@ theorem foldl_eq_foldl_toList {f : δ → α → δ} {init : δ} :
     t.foldl f init = t.toList.foldl f init :=
   TreeMap.foldl_eq_foldl_keys
 
-theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
-    {f : α → δ → m δ} {init : δ} :
+theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m] {f : α → δ → m δ} {init : δ} :
     t.foldrM f init = t.toList.foldrM f init :=
   TreeMap.foldrM_eq_foldrM_keys
 
@@ -380,12 +378,19 @@ theorem foldr_eq_foldr_toList {f : α → δ → δ} {init : δ} :
     t.foldr f init = t.toList.foldr f init :=
   TreeMap.foldr_eq_foldr_keys
 
+@[simp]
+theorem forM_eq_forM [Monad m] [LawfulMonad m] {f : α → m PUnit} :
+    t.forM f = ForM.forM t f := rfl
+
 theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : α → m PUnit} :
     t.forM f = t.toList.forM f :=
   TreeMap.forM_eq_forM_keys
 
-theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
-    {f : α → δ → m (ForInStep δ)} {init : δ} :
+@[simp]
+theorem forIn_eq_forIn [Monad m] [LawfulMonad m] {f : α → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn f init = ForIn.forIn t init f := rfl
+
+theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m] {f : α → δ → m (ForInStep δ)} {init : δ} :
     t.forIn f init = ForIn.forIn t.toList init f :=
   TreeMap.forIn_eq_forIn_keys
 

--- a/src/Std/Data/TreeSet/Raw/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Raw/Lemmas.lean
@@ -382,12 +382,12 @@ theorem foldr_eq_foldr_toList {f : α → δ → δ} {init : δ} :
   TreeMap.Raw.foldr_eq_foldr_keys
 
 theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : α → m PUnit} :
-    t.forM f = t.toList.forM f :=
+    ForM.forM t f = t.toList.forM f :=
   TreeMap.Raw.forM_eq_forM_keys
 
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
     {f : α → δ → m (ForInStep δ)} {init : δ} :
-    t.forIn f init = ForIn.forIn t.toList init f :=
+    ForIn.forIn t init f = ForIn.forIn t.toList init f :=
   TreeMap.Raw.forIn_eq_forIn_keys
 
 end monadic

--- a/src/Std/Data/TreeSet/Raw/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Raw/Lemmas.lean
@@ -18,7 +18,7 @@ These proofs can be obtained from `Std.Data.TreeSet.Raw.WF`.
 set_option linter.missingDocs true
 set_option autoImplicit false
 
-universe u v
+universe u v w
 
 namespace Std.TreeSet.Raw
 
@@ -358,5 +358,38 @@ theorem mem_toList [LawfulEqCmp cmp] [TransCmp cmp] (h : t.WF) {k : α} :
 theorem distinct_toList [TransCmp cmp] (h : t.WF) :
     t.toList.Pairwise (fun a b => ¬ cmp a b = .eq) :=
   DTreeMap.Raw.distinct_keys h
+
+section monadic
+
+variable {δ : Type w} {m : Type w → Type w}
+
+theorem foldlM_eq_foldlM_toList [Monad m] [LawfulMonad m]
+    {f : δ → α → m δ} {init : δ} :
+    t.foldlM f init = t.toList.foldlM f init :=
+  TreeMap.Raw.foldlM_eq_foldlM_keys
+
+theorem foldl_eq_foldl_toList {f : δ → α → δ} {init : δ} :
+    t.foldl f init = t.toList.foldl f init :=
+  TreeMap.Raw.foldl_eq_foldl_keys
+
+theorem foldrM_eq_foldrM_toList [Monad m] [LawfulMonad m]
+    {f : α → δ → m δ} {init : δ} :
+    t.foldrM f init = t.toList.foldrM f init :=
+  TreeMap.Raw.foldrM_eq_foldrM_keys
+
+theorem foldr_eq_foldr_toList {f : α → δ → δ} {init : δ} :
+    t.foldr f init = t.toList.foldr f init :=
+  TreeMap.Raw.foldr_eq_foldr_keys
+
+theorem forM_eq_forM_toList [Monad m] [LawfulMonad m] {f : α → m PUnit} :
+    t.forM f = t.toList.forM f :=
+  TreeMap.Raw.forM_eq_forM_keys
+
+theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
+    {f : α → δ → m (ForInStep δ)} {init : δ} :
+    t.forIn f init = ForIn.forIn t.toList init f :=
+  TreeMap.Raw.forIn_eq_forIn_keys
+
+end monadic
 
 end Std.TreeSet.Raw


### PR DESCRIPTION
This PR provides lemmas about the tree map functions `foldlM`, `foldl`, `foldrM` and `foldr` and their interactions with other functions for which lemmas already exist. Additionally, it generalizes the `fold*`/`keys` lemmas to arbitrary tree maps, which were previously stated only for the `DTreeMap α Unit` case.

A later PR will make the hash map functions `fold` and `revFold` internal and also update their signature to conform to the tree map and list API. This is out of scope for this PR.