### PR TITLE
feat: tree map lemmas for insertMany

### DIFF
--- a/src/Std/Classes/Ord.lean
+++ b/src/Std/Classes/Ord.lean
@@ -298,7 +298,9 @@ class LawfulBEqCmp {α : Type u} [BEq α] (cmp : α → α → Ordering) : Prop 
 theorem LawfulBEqCmp.not_compare_eq_iff_beq_eq_false {α : Type u} [BEq α] {cmp}
     [LawfulBEqCmp (α := α) cmp] {a b : α} : ¬ cmp a b = .eq ↔ (a == b) = false := by
   rw [Bool.eq_false_iff, ne_eq, not_congr]
-  exact LawfulBEqCmp.compare_eq_iff_beq
+  exact compare_eq_iff_beq
+
+export LawfulBEqCmp (compare_eq_iff_beq not_compare_eq_iff_beq_eq_false)
 
 /--
 A typeclass for types with a comparison function that satisfies `compare a b = .eq` if and only if
@@ -311,13 +313,13 @@ abbrev LawfulBEqOrd (α : Type u) [BEq α] [Ord α] := LawfulBEqCmp (compare : �
 
 variable {α : Type u} [BEq α] {cmp : α → α → Ordering}
 
-theorem LawfulBEqOrd.compare_eq_iff_beq {α : Type u} {_ : BEq α} {_ : Ord α}
+theorem LawfulBEqOrd.compare_eq_iff_beq {α : Type u} {_ : Ord α} {_ : BEq α}
     [LawfulBEqOrd α] {a b : α} : compare a b = .eq ↔ (a == b) = true :=
-  LawfulBEqCmp.compare_eq_iff_beq
+  Std.compare_eq_iff_beq
 
 theorem LawfulBEqOrd.not_compare_eq_iff_beq_eq_false {α : Type u} {_ : BEq α} {_ : Ord α}
     [LawfulBEqOrd α] {a b : α} : ¬ compare a b = .eq ↔ (a == b) = false :=
-  LawfulBEqCmp.not_compare_eq_iff_beq_eq_false
+  Std.not_compare_eq_iff_beq_eq_false
 
 instance [LawfulEqCmp cmp] [LawfulBEq α] :
     LawfulBEqCmp cmp where

--- a/src/Std/Classes/Ord.lean
+++ b/src/Std/Classes/Ord.lean
@@ -342,6 +342,13 @@ theorem LawfulBEqCmp.lawfulBEq [inst : LawfulBEqCmp cmp] [LawfulEqCmp cmp] : Law
 instance LawfulBEqOrd.lawfulBEq [Ord α] [LawfulBEqOrd α] [LawfulEqOrd α] : LawfulBEq α :=
   LawfulBEqCmp.lawfulBEq (cmp := compare)
 
+instance LawfulBEqCmp.lawfulBEqCmp [inst : LawfulBEqCmp cmp] [LawfulBEq α] : LawfulEqCmp cmp where
+  compare_self := by simp only [compare_eq_iff_beq, beq_self_eq_true, implies_true]
+  eq_of_compare := by simp only [compare_eq_iff_beq, beq_iff_eq, imp_self, implies_true]
+
+theorem LawfulBEqOrd.lawfulBEqOrd [Ord α] [LawfulBEqOrd α] [LawfulBEq α] : LawfulEqOrd α :=
+  LawfulBEqCmp.lawfulBEqCmp
+
 end LawfulBEq
 
 namespace Internal

--- a/src/Std/Classes/Ord.lean
+++ b/src/Std/Classes/Ord.lean
@@ -300,8 +300,6 @@ theorem LawfulBEqCmp.not_compare_eq_iff_beq_eq_false {α : Type u} [BEq α] {cmp
   rw [Bool.eq_false_iff, ne_eq, not_congr]
   exact compare_eq_iff_beq
 
-export LawfulBEqCmp (compare_eq_iff_beq not_compare_eq_iff_beq_eq_false)
-
 /--
 A typeclass for types with a comparison function that satisfies `compare a b = .eq` if and only if
 the boolean equality `a == b` holds.
@@ -315,11 +313,13 @@ variable {α : Type u} [BEq α] {cmp : α → α → Ordering}
 
 theorem LawfulBEqOrd.compare_eq_iff_beq {α : Type u} {_ : Ord α} {_ : BEq α}
     [LawfulBEqOrd α] {a b : α} : compare a b = .eq ↔ (a == b) = true :=
-  Std.compare_eq_iff_beq
+  LawfulBEqCmp.compare_eq_iff_beq
 
 theorem LawfulBEqOrd.not_compare_eq_iff_beq_eq_false {α : Type u} {_ : BEq α} {_ : Ord α}
     [LawfulBEqOrd α] {a b : α} : ¬ compare a b = .eq ↔ (a == b) = false :=
-  Std.not_compare_eq_iff_beq_eq_false
+  LawfulBEqCmp.not_compare_eq_iff_beq_eq_false
+
+export LawfulBEqOrd (compare_eq_iff_beq not_compare_eq_iff_beq_eq_false)
 
 instance [LawfulEqCmp cmp] [LawfulBEq α] :
     LawfulBEqCmp cmp where

--- a/src/Std/Classes/Ord.lean
+++ b/src/Std/Classes/Ord.lean
@@ -295,6 +295,11 @@ class LawfulBEqCmp {α : Type u} [BEq α] (cmp : α → α → Ordering) : Prop 
   /-- If two values compare equal, then they are logically equal. -/
   compare_eq_iff_beq {a b : α} : cmp a b = .eq ↔ a == b
 
+theorem LawfulBEqCmp.not_compare_eq_iff_beq_eq_false {α : Type u} [BEq α] {cmp}
+    [LawfulBEqCmp (α := α) cmp] {a b : α} : ¬ cmp a b = .eq ↔ (a == b) = false := by
+  rw [Bool.eq_false_iff, ne_eq, not_congr]
+  exact LawfulBEqCmp.compare_eq_iff_beq
+
 /--
 A typeclass for types with a comparison function that satisfies `compare a b = .eq` if and only if
 the boolean equality `a == b` holds.
@@ -305,6 +310,14 @@ logical equality (`=`).
 abbrev LawfulBEqOrd (α : Type u) [BEq α] [Ord α] := LawfulBEqCmp (compare : α → α → Ordering)
 
 variable {α : Type u} [BEq α] {cmp : α → α → Ordering}
+
+theorem LawfulBEqOrd.compare_eq_iff_beq {α : Type u} {_ : BEq α} {_ : Ord α}
+    [LawfulBEqOrd α] {a b : α} : compare a b = .eq ↔ (a == b) = true :=
+  LawfulBEqCmp.compare_eq_iff_beq
+
+theorem LawfulBEqOrd.not_compare_eq_iff_beq_eq_false {α : Type u} {_ : BEq α} {_ : Ord α}
+    [LawfulBEqOrd α] {a b : α} : ¬ compare a b = .eq ↔ (a == b) = false :=
+  LawfulBEqCmp.not_compare_eq_iff_beq_eq_false
 
 instance [LawfulEqCmp cmp] [LawfulBEq α] :
     LawfulBEqCmp cmp where
@@ -322,6 +335,13 @@ theorem LawfulBEqCmp.equivBEq [inst : LawfulBEqCmp cmp] [TransCmp cmp] : EquivBE
 instance LawfulBEqOrd.equivBEq [Ord α] [LawfulBEqOrd α] [TransOrd α] : EquivBEq α :=
   LawfulBEqCmp.equivBEq (cmp := compare)
 
+theorem LawfulBEqCmp.lawfulBEq [inst : LawfulBEqCmp cmp] [LawfulEqCmp cmp] : LawfulBEq α where
+  rfl := by simp [← inst.compare_eq_iff_beq, compare_eq_iff_eq]
+  eq_of_beq := by simp [← inst.compare_eq_iff_beq, compare_eq_iff_eq]
+
+instance LawfulBEqOrd.lawfulBEq [Ord α] [LawfulBEqOrd α] [LawfulEqOrd α] : LawfulBEq α :=
+  LawfulBEqCmp.lawfulBEq (cmp := compare)
+
 end LawfulBEq
 
 namespace Internal
@@ -335,6 +355,9 @@ verification machinery for tree maps to the verification machinery for hash maps
 @[local instance]
 def beqOfOrd [Ord α] : BEq α where
   beq a b := compare a b == .eq
+
+instance {_ : Ord α} : LawfulBEqOrd α where
+  compare_eq_iff_beq {a b} := by simp only [beqOfOrd, beq_iff_eq]
 
 @[local simp]
 theorem beq_eq [Ord α] {a b : α} : (a == b) = (compare a b == .eq) :=

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -1488,8 +1488,7 @@ theorem isEmpty_keys :
 
 theorem contains_keys [BEq α] [beqOrd : LawfulBEqOrd α] [TransOrd α] {k : α} (h : t.WF) :
     t.keys.contains k = t.contains k := by
-  rw [contains_eq_containsKey h.ordered, ← eq_beqOfOrd_of_lawfulBEqOrd]
-  simp_to_model using (List.containsKey_eq_keys_contains (a := k) (l := t.toListModel)).symm
+  simp_to_model using (List.containsKey_eq_keys_contains).symm
 
 theorem mem_keys [LawfulEqOrd α] [TransOrd α] {k : α} (h : t.WF) :
     k ∈ t.keys ↔ k ∈ t := by
@@ -1713,33 +1712,56 @@ theorem insertMany!_cons {l : List ((a : α) × β a)} {k : α} {v : β k} :
   · simp
 
 @[simp]
-theorem contains_insertMany_list [TransOrd α] (h : t.WF) {l : List ((a : α) × β a)} {k : α} :
+theorem contains_insertMany_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+    {l : List ((a : α) × β a)} {k : α} :
     (t.insertMany l h.balanced).1.contains k = (t.contains k || (l.map Sigma.fst).contains k) := by
   simp_to_model [insertMany] using List.containsKey_insertList
 
 @[simp]
-theorem contains_insertMany!_list [TransOrd α] (h : t.WF)
+theorem mem_insertMany_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+    {l : List ((a : α) × β a)} {k : α} :
+    k ∈ (t.insertMany l h.balanced).1 ↔ k ∈ t ∨ (l.map Sigma.fst).contains k := by
+  simp [mem_iff_contains, contains_insertMany_list h]
+
+@[simp]
+theorem contains_insertMany!_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} :
     (t.insertMany! l).1.contains k = (t.contains k || (l.map Sigma.fst).contains k) := by
   simp_to_model [insertMany!] using List.containsKey_insertList
 
-theorem contains_of_contains_insertMany_list [TransOrd α] (h : t.WF)
+@[simp]
+theorem mem_insertMany!_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+    {l : List ((a : α) × β a)} {k : α} :
+    k ∈ (t.insertMany! l).1 ↔ k ∈ t ∨ (l.map Sigma.fst).contains k := by
+  simp [mem_iff_contains, contains_insertMany!_list h]
+
+theorem contains_of_contains_insertMany_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} :
     (t.insertMany l h.balanced).1.contains k → (l.map Sigma.fst).contains k = false → t.contains k := by
   simp_to_model [insertMany] using List.containsKey_of_containsKey_insertList
 
-theorem contains_of_contains_insertMany!_list [TransOrd α] (h : t.WF)
+theorem mem_of_mem_insertMany_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+    {l : List ((a : α) × β a)} {k : α} :
+    k ∈ (t.insertMany l h.balanced).1 → (l.map Sigma.fst).contains k = false → k ∈ t := by
+  simpa [mem_iff_contains] using contains_of_contains_insertMany_list h
+
+theorem contains_of_contains_insertMany!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} :
     (t.insertMany! l).1.contains k → (l.map Sigma.fst).contains k = false → t.contains k := by
   simp_to_model [insertMany!] using List.containsKey_of_containsKey_insertList
 
-theorem get?_insertMany_list_of_contains_eq_false [TransOrd α] [LawfulEqOrd α] (h : t.WF)
+theorem mem_of_mem_insertMany!_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+    {l : List ((a : α) × β a)} {k : α} :
+    k ∈ (t.insertMany! l).1 → (l.map Sigma.fst).contains k = false → k ∈ t := by
+  simpa [mem_iff_contains] using contains_of_contains_insertMany!_list h
+
+theorem get?_insertMany_list_of_contains_eq_false [BEq α] [TransOrd α] [LawfulEqOrd α] [LawfulBEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α}
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l h.balanced).1.get? k = t.get? k := by
   simp_to_model [insertMany] using List.getValueCast?_insertList_of_contains_eq_false
 
-theorem get?_insertMany!_list_of_contains_eq_false [TransOrd α] [LawfulEqOrd α] (h : t.WF)
+theorem get?_insertMany!_list_of_contains_eq_false [BEq α] [TransOrd α] [LawfulEqOrd α] [LawfulBEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α}
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany! l).1.get? k = t.get? k := by
@@ -1761,13 +1783,12 @@ theorem get?_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : ⟨k, v⟩ ∈ l) :
     (t.insertMany! l).1.get? k' = some (cast (by congr; apply compare_eq_iff_eq.mp k_beq) v) := by
-  have := h.ordered.distinctKeys
-  revert mem distinct
-  simp only [← beq_iff, Bool.not_eq_true]
-  revert this k_beq
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany!] using List.getValueCast?_insertList_of_mem (toInsert := l) (k := k) (v := v) (k' := k')
 
-theorem get_insertMany_list_of_contains_eq_false [TransOrd α] [LawfulEqOrd α] (h : t.WF)
+theorem get_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
+    [LawfulEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α}
     (contains : (l.map Sigma.fst).contains k = false)
     {h'} :
@@ -1775,7 +1796,8 @@ theorem get_insertMany_list_of_contains_eq_false [TransOrd α] [LawfulEqOrd α] 
     t.get k (contains_of_contains_insertMany_list h h' contains) := by
   simp_to_model [insertMany] using List.getValueCast_insertList_of_contains_eq_false
 
-theorem get_insertMany!_list_of_contains_eq_false [TransOrd α] [LawfulEqOrd α] (h : t.WF)
+theorem get_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
+    [LawfulEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α}
     (contains : (l.map Sigma.fst).contains k = false)
     {h'} :
@@ -1784,80 +1806,93 @@ theorem get_insertMany!_list_of_contains_eq_false [TransOrd α] [LawfulEqOrd α]
   simp_to_model [insertMany!] using List.getValueCast_insertList_of_contains_eq_false
 
 theorem get_insertMany_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k k' : α} (k_beq : k == k') {v : β k}
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k}
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : ⟨k, v⟩ ∈ l)
     {h'} :
-    (t.insertMany l h.balanced).1.get k' h' = cast (by congr; apply LawfulBEq.eq_of_beq k_beq) v := by
+    (t.insertMany l h.balanced).1.get k' h' = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany] using List.getValueCast_insertList_of_mem
 
 theorem get_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k k' : α} (k_beq : k == k') {v : β k}
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k}
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : ⟨k, v⟩ ∈ l)
     {h'} :
-    (t.insertMany! l).1.get k' h' = cast (by congr; apply LawfulBEq.eq_of_beq k_beq) v := by
+    (t.insertMany! l).1.get k' h' = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany!] using List.getValueCast_insertList_of_mem
 
-theorem get!_insertMany_list_of_contains_eq_false [TransOrd α] [LawfulEqOrd α] (h : t.WF)
+theorem get!_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
+    [LawfulEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} [Inhabited (β k)]
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l h.balanced).1.get! k = t.get! k := by
   simp_to_model [insertMany] using List.getValueCast!_insertList_of_contains_eq_false
 
-theorem get!_insertMany!_list_of_contains_eq_false [TransOrd α] [LawfulEqOrd α] (h : t.WF)
+theorem get!_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [LawfulEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} [Inhabited (β k)]
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany! l).1.get! k = t.get! k := by
   simp_to_model [insertMany!] using List.getValueCast!_insertList_of_contains_eq_false
 
 theorem get!_insertMany_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k k' : α} (k_beq : k == k') {v : β k} [Inhabited (β k')]
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k} [Inhabited (β k')]
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : ⟨k, v⟩ ∈ l) :
-    (t.insertMany l h.balanced).1.get! k' = cast (by congr; apply LawfulBEq.eq_of_beq k_beq) v := by
+    (t.insertMany l h.balanced).1.get! k' = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany] using List.getValueCast!_insertList_of_mem
 
 theorem get!_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k k' : α} (k_beq : k == k') {v : β k} [Inhabited (β k')]
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k} [Inhabited (β k')]
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : ⟨k, v⟩ ∈ l) :
-    (t.insertMany! l).1.get! k' = cast (by congr; apply LawfulBEq.eq_of_beq k_beq) v := by
+    (t.insertMany! l).1.get! k' = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany!] using List.getValueCast!_insertList_of_mem
 
-theorem getD_insertMany_list_of_contains_eq_false [TransOrd α] [LawfulEqOrd α] (h : t.WF)
+theorem getD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [LawfulEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} {fallback : β k}
     (contains_eq_false : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l h.balanced).1.getD k fallback = t.getD k fallback := by
   simp_to_model [insertMany] using List.getValueCastD_insertList_of_contains_eq_false
 
-theorem getD_insertMany!_list_of_contains_eq_false [TransOrd α] [LawfulEqOrd α] (h : t.WF)
+theorem getD_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [LawfulEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} {fallback : β k}
     (contains_eq_false : (l.map Sigma.fst).contains k = false) :
     (t.insertMany! l).1.getD k fallback = t.getD k fallback := by
   simp_to_model [insertMany!] using List.getValueCastD_insertList_of_contains_eq_false
 
 theorem getD_insertMany_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k k' : α} (k_beq : k == k') {v : β k} {fallback : β k'}
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k} {fallback : β k'}
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : ⟨k, v⟩ ∈ l) :
-    (t.insertMany l h.balanced).1.getD k' fallback = cast (by congr; apply LawfulBEq.eq_of_beq k_beq) v := by
+    (t.insertMany l h.balanced).1.getD k' fallback = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany] using List.getValueCastD_insertList_of_mem
 
 theorem getD_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k k' : α} (k_beq : k == k') {v : β k} {fallback : β k'}
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k} {fallback : β k'}
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : ⟨k, v⟩ ∈ l) :
-    (t.insertMany! l).1.getD k' fallback = cast (by congr; apply LawfulBEq.eq_of_beq k_beq) v := by
+    (t.insertMany! l).1.getD k' fallback = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany!] using List.getValueCastD_insertList_of_mem
 
-theorem getKey?_insertMany_list_of_contains_eq_false [TransOrd α] (h : t.WF)
+theorem getKey?_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α}
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l h.balanced).1.getKey? k = t.getKey? k := by
   simp_to_model [insertMany] using List.getKey?_insertList_of_contains_eq_false
 
-theorem getKey?_insertMany!_list_of_contains_eq_false [TransOrd α] (h : t.WF)
+theorem getKey?_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α}
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany! l).1.getKey? k = t.getKey? k := by
@@ -1865,21 +1900,25 @@ theorem getKey?_insertMany!_list_of_contains_eq_false [TransOrd α] (h : t.WF)
 
 theorem getKey?_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)}
-    {k k' : α} (k_beq : k == k')
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {k k' : α} (k_beq : compare k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Sigma.fst) :
     (t.insertMany l h.balanced).1.getKey? k' = some k := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany] using List.getKey?_insertList_of_mem
 
 theorem getKey?_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)}
-    {k k' : α} (k_beq : k == k')
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {k k' : α} (k_beq : compare k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Sigma.fst) :
     (t.insertMany! l).1.getKey? k' = some k := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany!] using List.getKey?_insertList_of_mem
 
-theorem getKey_insertMany_list_of_contains_eq_false [TransOrd α] (h : t.WF)
+theorem getKey_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α}
     (h₁ : (l.map Sigma.fst).contains k = false)
     {h'} :
@@ -1887,7 +1926,7 @@ theorem getKey_insertMany_list_of_contains_eq_false [TransOrd α] (h : t.WF)
     t.getKey k (contains_of_contains_insertMany_list h h' h₁) := by
   simp_to_model [insertMany] using List.getKey_insertList_of_contains_eq_false
 
-theorem getKey_insertMany!_list_of_contains_eq_false [TransOrd α] (h : t.WF)
+theorem getKey_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α}
     (h₁ : (l.map Sigma.fst).contains k = false)
     {h'} :
@@ -1897,29 +1936,33 @@ theorem getKey_insertMany!_list_of_contains_eq_false [TransOrd α] (h : t.WF)
 
 theorem getKey_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)}
-    {k k' : α} (k_beq : k == k')
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {k k' : α} (k_beq : compare k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Sigma.fst)
     {h'} :
     (t.insertMany l h.balanced).1.getKey k' h' = k := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany] using List.getKey_insertList_of_mem
 
 theorem getKey_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)}
-    {k k' : α} (k_beq : k == k')
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {k k' : α} (k_beq : compare k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Sigma.fst)
     {h'} :
     (t.insertMany! l).1.getKey k' h' = k := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany!] using List.getKey_insertList_of_mem
 
-theorem getKey!_insertMany_list_of_contains_eq_false [TransOrd α] [Inhabited α]
+theorem getKey!_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [Inhabited α]
     (h : t.WF) {l : List ((a : α) × β a)} {k : α}
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l h.balanced).1.getKey! k = t.getKey! k := by
   simp_to_model [insertMany] using List.getKey!_insertList_of_contains_eq_false
 
-theorem getKey!_insertMany!_list_of_contains_eq_false [TransOrd α] [Inhabited α]
+theorem getKey!_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [Inhabited α]
     (h : t.WF) {l : List ((a : α) × β a)} {k : α}
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany! l).1.getKey! k = t.getKey! k := by
@@ -1927,27 +1970,31 @@ theorem getKey!_insertMany!_list_of_contains_eq_false [TransOrd α] [Inhabited �
 
 theorem getKey!_insertMany_list_of_mem [TransOrd α] [Inhabited α] (h : t.WF)
     {l : List ((a : α) × β a)}
-    {k k' : α} (k_beq : k == k')
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {k k' : α} (k_beq : compare k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Sigma.fst) :
     (t.insertMany l h.balanced).1.getKey! k' = k := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany] using List.getKey!_insertList_of_mem
 
 theorem getKey!_insertMany!_list_of_mem [TransOrd α] [Inhabited α] (h : t.WF)
     {l : List ((a : α) × β a)}
-    {k k' : α} (k_beq : k == k')
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {k k' : α} (k_beq : compare k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Sigma.fst) :
     (t.insertMany! l).1.getKey! k' = k := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany!] using List.getKey!_insertList_of_mem
 
-theorem getKeyD_insertMany_list_of_contains_eq_false [TransOrd α] (h : t.WF)
+theorem getKeyD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k fallback : α}
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l h.balanced).1.getKeyD k fallback = t.getKeyD k fallback := by
   simp_to_model [insertMany] using List.getKeyD_insertList_of_contains_eq_false
 
-theorem getKeyD_insertMany!_list_of_contains_eq_false [TransOrd α] (h : t.WF)
+theorem getKeyD_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k fallback : α}
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany! l).1.getKeyD k fallback = t.getKeyD k fallback := by
@@ -1955,30 +2002,36 @@ theorem getKeyD_insertMany!_list_of_contains_eq_false [TransOrd α] (h : t.WF)
 
 theorem getKeyD_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)}
-    {k k' fallback : α} (k_beq : k == k')
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {k k' fallback : α} (k_beq : compare k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Sigma.fst) :
     (t.insertMany l h.balanced).1.getKeyD k' fallback = k := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany] using List.getKeyD_insertList_of_mem
 
 theorem getKeyD_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)}
-    {k k' fallback : α} (k_beq : k == k')
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {k k' fallback : α} (k_beq : compare k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Sigma.fst) :
     (t.insertMany! l).1.getKeyD k' fallback = k := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany!] using List.getKeyD_insertList_of_mem
 
 theorem size_insertMany_list [TransOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false)) :
+    {l : List ((a : α) × β a)} (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) :
     (∀ (a : α), t.contains a → (l.map Sigma.fst).contains a = false) →
     (t.insertMany l h.balanced).1.size = t.size + l.length := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
   simp_to_model [insertMany] using List.length_insertList
 
-theorem size_insertMany!_list [TransOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false)) :
+theorem size_insertMany!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+    {l : List ((a : α) × β a)} (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) :
     (∀ (a : α), t.contains a → (l.map Sigma.fst).contains a = false) →
     (t.insertMany! l).1.size = t.size + l.length := by
+  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true] at distinct
   simp_to_model [insertMany!] using List.length_insertList
 
 theorem size_le_size_insertMany_list [TransOrd α] (h : t.WF)
@@ -2015,7 +2068,7 @@ theorem isEmpty_insertMany!_list [TransOrd α] (h : t.WF)
 
 namespace Const
 
-variable {β : Type v} (t : Impl α β)
+variable {β : Type v} {t : Impl α β}
 
 @[simp]
 theorem insertMany_nil (h : t.WF) :
@@ -2062,28 +2115,44 @@ theorem contains_insertMany_list [TransOrd α] (h : t.WF)
   simp_to_model [Const.insertMany] using List.containsKey_insertListConst
 
 @[simp]
-theorem contains_insertMany!_list [TransOrd α] (h : t.WF)
+theorem contains_insertMany!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k : α} :
     (Const.insertMany! t l).1.contains k = (t.contains k || (l.map Prod.fst).contains k) := by
   simp_to_model [Const.insertMany!] using List.containsKey_insertListConst
 
-theorem contains_of_contains_insertMany_list [TransOrd α] (h : t.WF)
+@[simp]
+theorem mem_insertMany!_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+    {l : List (α × β)} {k : α} :
+    k ∈ (insertMany! t l).1 ↔ k ∈ t ∨ (l.map Prod.fst).contains k := by
+  simp [mem_iff_contains, contains_insertMany!_list h]
+
+theorem contains_of_contains_insertMany_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k : α} :
     (insertMany t l h.balanced).1.contains k → (l.map Prod.fst).contains k = false → t.contains k := by
   simp_to_model [Const.insertMany] using List.containsKey_of_containsKey_insertListConst
 
-theorem contains_of_contains_insertMany!_list [TransOrd α] (h : t.WF)
+theorem mem_of_mem_insertMany_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+    {l : List (α × β)} {k : α} :
+    k ∈ (insertMany t l h.balanced).1 → (l.map Prod.fst).contains k = false → k ∈ t := by
+  simpa [mem_iff_contains] using contains_of_contains_insertMany_list h
+
+theorem contains_of_contains_insertMany!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List ( α × β )} {k : α} :
     (insertMany! t l).1.contains k → (l.map Prod.fst).contains k = false → t.contains k := by
   simp_to_model [Const.insertMany!] using List.containsKey_of_containsKey_insertListConst
 
-theorem getKey?_insertMany_list_of_contains_eq_false [TransOrd α] (h : t.WF)
+theorem mem_of_mem_insertMany!_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+    {l : List (α × β)} {k : α} :
+    k ∈ (insertMany! t l).1 → (l.map Prod.fst).contains k = false → k ∈ t := by
+  simpa [mem_iff_contains] using contains_of_contains_insertMany!_list h
+
+theorem getKey?_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k : α}
     (h' : (l.map Prod.fst).contains k = false) :
     (insertMany t l h.balanced).1.getKey? k = t.getKey? k := by
   simp_to_model [Const.insertMany] using List.getKey?_insertListConst_of_contains_eq_false
 
-theorem getKey?_insertMany!_list_of_contains_eq_false [TransOrd α] (h : t.WF)
+theorem getKey?_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k : α}
     (h' : (l.map Prod.fst).contains k = false) :
     (insertMany! t l).1.getKey? k = t.getKey? k := by
@@ -2091,61 +2160,69 @@ theorem getKey?_insertMany!_list_of_contains_eq_false [TransOrd α] (h : t.WF)
 
 theorem getKey?_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     {l : List  (α × β)}
-    {k k' : α} (k_beq : k == k')
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {k k' : α} (k_beq : compare k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Prod.fst) :
     (insertMany t l h.balanced).1.getKey? k' = some k := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany] using List.getKey?_insertListConst_of_mem
 
 theorem getKey?_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     {l : List  (α × β)}
-    {k k' : α} (k_beq : k == k')
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {k k' : α} (k_beq : compare k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Prod.fst) :
     (insertMany! t l).1.getKey? k' = some k := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany!] using List.getKey?_insertListConst_of_mem
 
-theorem getKey_insertMany_list_of_contains_eq_false [TransOrd α] (h : t.WF)
+theorem getKey_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k : α}
     (h₁ : (l.map Prod.fst).contains k = false)
     {h'} :
     (insertMany t l h.balanced).1.getKey k h' =
-    t.getKey k (contains_of_contains_insertMany_list _ h h' h₁) := by
+    t.getKey k (contains_of_contains_insertMany_list h h' h₁) := by
   simp_to_model [Const.insertMany] using List.getKey_insertListConst_of_contains_eq_false
 
-theorem getKey_insertMany!_list_of_contains_eq_false [TransOrd α] (h : t.WF)
+theorem getKey_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k : α}
     (h₁ : (l.map Prod.fst).contains k = false)
     {h'} :
     (insertMany! t l).1.getKey k h' =
-    t.getKey k (contains_of_contains_insertMany!_list _ h h' h₁) := by
+    t.getKey k (contains_of_contains_insertMany!_list h h' h₁) := by
   simp_to_model [Const.insertMany!] using List.getKey_insertListConst_of_contains_eq_false
 
 theorem getKey_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     {l : List (α × β)}
-    {k k' : α} (k_beq : k == k')
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {k k' : α} (k_beq : compare k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Prod.fst)
     {h'} :
     (insertMany t l h.balanced).1.getKey k' h' = k := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany] using List.getKey_insertListConst_of_mem
 
 theorem getKey_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     {l : List (α × β)}
-    {k k' : α} (k_beq : k == k')
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {k k' : α} (k_beq : compare k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Prod.fst)
     {h'} :
     (insertMany! t l).1.getKey k' h' = k := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany!] using List.getKey_insertListConst_of_mem
 
-theorem getKey!_insertMany_list_of_contains_eq_false [TransOrd α] [Inhabited α]
+theorem getKey!_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [Inhabited α]
     (h : t.WF) {l : List (α × β)} {k : α}
     (h' : (l.map Prod.fst).contains k = false) :
     (insertMany t l h.balanced).1.getKey! k = t.getKey! k := by
   simp_to_model [Const.insertMany] using List.getKey!_insertListConst_of_contains_eq_false
 
-theorem getKey!_insertMany!_list_of_contains_eq_false [TransOrd α] [Inhabited α]
+theorem getKey!_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [Inhabited α]
     (h : t.WF) {l : List (α × β)} {k : α}
     (h' : (l.map Prod.fst).contains k = false) :
     (insertMany! t l).1.getKey! k = t.getKey! k := by
@@ -2153,27 +2230,31 @@ theorem getKey!_insertMany!_list_of_contains_eq_false [TransOrd α] [Inhabited �
 
 theorem getKey!_insertMany_list_of_mem [TransOrd α] [Inhabited α] (h : t.WF)
     {l : List (α × β)}
-    {k k' : α} (k_beq : k == k')
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {k k' : α} (k_beq : compare k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Prod.fst) :
     (insertMany t l h.balanced).1.getKey! k' = k := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany] using List.getKey!_insertListConst_of_mem
 
 theorem getKey!_insertMany!_list_of_mem [TransOrd α] [Inhabited α] (h : t.WF)
     {l : List (α × β)}
-    {k k' : α} (k_beq : k == k')
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {k k' : α} (k_beq : compare k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Prod.fst) :
     (insertMany! t l).1.getKey! k' = k := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany!] using List.getKey!_insertListConst_of_mem
 
-theorem getKeyD_insertMany_list_of_contains_eq_false [TransOrd α] (h : t.WF)
+theorem getKeyD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k fallback : α}
     (h' : (l.map Prod.fst).contains k = false) :
     (insertMany t l h.balanced).1.getKeyD k fallback = t.getKeyD k fallback := by
   simp_to_model [Const.insertMany] using List.getKeyD_insertListConst_of_contains_eq_false
 
-theorem getKeyD_insertMany!_list_of_contains_eq_false [TransOrd α] (h : t.WF)
+theorem getKeyD_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k fallback : α}
     (h' : (l.map Prod.fst).contains k = false) :
     (insertMany! t l).1.getKeyD k fallback = t.getKeyD k fallback := by
@@ -2181,32 +2262,38 @@ theorem getKeyD_insertMany!_list_of_contains_eq_false [TransOrd α] (h : t.WF)
 
 theorem getKeyD_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     {l : List (α × β)}
-    {k k' fallback : α} (k_beq : k == k')
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {k k' fallback : α} (k_beq : compare k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Prod.fst) :
     (insertMany t l h.balanced).1.getKeyD k' fallback = k := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany] using List.getKeyD_insertListConst_of_mem
 
 theorem getKeyD_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     {l : List (α × β)}
-    {k k' fallback : α} (k_beq : k == k')
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    {k k' fallback : α} (k_beq : compare k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Prod.fst) :
     (insertMany! t l).1.getKeyD k' fallback = k := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany!] using List.getKeyD_insertListConst_of_mem
 
-theorem size_insertMany_list [TransOrd α] (h : t.WF)
+theorem size_insertMany_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List (α × β)}
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false)) :
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) :
     (∀ (a : α), t.contains a → (l.map Prod.fst).contains a = false) →
     (insertMany t l h.balanced).1.size = t.size + l.length := by
+  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true] at distinct
   simp_to_model [Const.insertMany] using List.length_insertListConst
 
-theorem size_insertMany!_list [TransOrd α] (h : t.WF)
+theorem size_insertMany!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List (α × β)}
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false)) :
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) :
     (∀ (a : α), t.contains a → (l.map Prod.fst).contains a = false) →
     (insertMany! t l).1.size = t.size + l.length := by
+  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true] at distinct
   simp_to_model [Const.insertMany!] using List.length_insertListConst
 
 theorem size_le_size_insertMany_list [TransOrd α] (h : t.WF)
@@ -2241,105 +2328,121 @@ theorem isEmpty_insertMany!_list [TransOrd α] (h : t.WF)
     (insertMany! t l).1.isEmpty = (t.isEmpty && l.isEmpty) := by
   simp_to_model [Const.insertMany!] using List.isEmpty_insertListConst
 
-theorem get?_insertMany_list_of_contains_eq_false [TransOrd α] (h : t.WF)
+theorem get?_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k : α}
     (h' : (l.map Prod.fst).contains k = false) :
     get? (insertMany t l h.balanced).1 k = get? t k := by
   simp_to_model [Const.insertMany] using List.getValue?_insertListConst_of_contains_eq_false
 
-theorem get?_insertMany!_list_of_contains_eq_false [TransOrd α] (h : t.WF)
+theorem get?_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k : α}
     (h' : (l.map Prod.fst).contains k = false) :
     get? (insertMany! t l).1 k = get? t k := by
   simp_to_model [Const.insertMany!] using List.getValue?_insertListConst_of_contains_eq_false
 
 theorem get?_insertMany_list_of_mem [TransOrd α] (h : t.WF)
-    {l : List (α × β)} {k k' : α} (k_beq : k == k') {v : β}
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false)) (mem : ⟨k, v⟩ ∈ l) :
+    {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v : β}
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
     get? (insertMany t l h.balanced).1 k' = v := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany] using List.getValue?_insertListConst_of_mem
 
 theorem get?_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
-    {l : List (α × β)} {k k' : α} (k_beq : k == k') {v : β}
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false)) (mem : ⟨k, v⟩ ∈ l) :
+    {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v : β}
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
     get? (insertMany! t l).1 k' = v := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany!] using List.getValue?_insertListConst_of_mem
 
-theorem get_insertMany_list_of_contains_eq_false [TransOrd α] (h : t.WF)
+theorem get_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k : α}
     (h₁ : (l.map Prod.fst).contains k = false)
     {h'} :
-    get (insertMany t l h.balanced).1 k h' = get t k (contains_of_contains_insertMany_list _ h h' h₁) := by
+    get (insertMany t l h.balanced).1 k h' = get t k (contains_of_contains_insertMany_list h h' h₁) := by
   simp_to_model [Const.insertMany] using List.getValue_insertListConst_of_contains_eq_false
 
-theorem get_insertMany!_list_of_contains_eq_false [TransOrd α] (h : t.WF)
+theorem get_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k : α}
     (h₁ : (l.map Prod.fst).contains k = false)
     {h'} :
-    get (insertMany! t l).1 k h' = get t k (contains_of_contains_insertMany!_list _ h h' h₁) := by
+    get (insertMany! t l).1 k h' = get t k (contains_of_contains_insertMany!_list h h' h₁) := by
   simp_to_model [Const.insertMany!] using List.getValue_insertListConst_of_contains_eq_false
 
 theorem get_insertMany_list_of_mem [TransOrd α] (h : t.WF)
-    {l : List (α × β)} {k k' : α} (k_beq : k == k') {v : β}
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false)) (mem : ⟨k, v⟩ ∈ l) {h'} :
+    {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v : β}
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) {h'} :
     get (insertMany t l h.balanced).1 k' h' = v := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany] using List.getValue_insertListConst_of_mem
 
 theorem get_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
-    {l : List (α × β)} {k k' : α} (k_beq : k == k') {v : β}
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false)) (mem : ⟨k, v⟩ ∈ l) {h'} :
+    {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v : β}
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) {h'} :
     get (insertMany! t l).1 k' h' = v := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany!] using List.getValue_insertListConst_of_mem
 
-theorem get!_insertMany_list_of_contains_eq_false [TransOrd α]
+theorem get!_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
     [Inhabited β]  (h : t.WF) {l : List (α × β)} {k : α}
     (h' : (l.map Prod.fst).contains k = false) :
     get! (insertMany t l h.balanced).1 k = get! t k := by
   simp_to_model [Const.insertMany] using List.getValue!_insertListConst_of_contains_eq_false
 
-theorem get!_insertMany!_list_of_contains_eq_false [TransOrd α]
+theorem get!_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
     [Inhabited β]  (h : t.WF) {l : List (α × β)} {k : α}
     (h' : (l.map Prod.fst).contains k = false) :
     get! (insertMany! t l).1 k = get! t k := by
   simp_to_model [Const.insertMany!] using List.getValue!_insertListConst_of_contains_eq_false
 
 theorem get!_insertMany_list_of_mem [TransOrd α] [Inhabited β] (h : t.WF)
-    {l : List (α × β)} {k k' : α} (k_beq : k == k') {v : β}
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false)) (mem : ⟨k, v⟩ ∈ l) :
+    {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v : β}
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
     get! (insertMany t l h.balanced).1 k' = v := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany] using List.getValue!_insertListConst_of_mem
 
 theorem get!_insertMany!_list_of_mem [TransOrd α] [Inhabited β] (h : t.WF)
-    {l : List (α × β)} {k k' : α} (k_beq : k == k') {v : β}
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false)) (mem : ⟨k, v⟩ ∈ l) :
+    {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v : β}
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
     get! (insertMany! t l).1 k' = v := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany!] using List.getValue!_insertListConst_of_mem
 
-theorem getD_insertMany_list_of_contains_eq_false [TransOrd α] (h : t.WF)
+theorem getD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k : α} {fallback : β}
     (h' : (l.map Prod.fst).contains k = false) :
     getD (insertMany t l h.balanced).1 k fallback = getD t k fallback := by
   simp_to_model [Const.insertMany] using List.getValueD_insertListConst_of_contains_eq_false
 
-theorem getD_insertMany!_list_of_contains_eq_false [TransOrd α] (h : t.WF)
+theorem getD_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k : α} {fallback : β}
     (h' : (l.map Prod.fst).contains k = false) :
     getD (insertMany! t l).1 k fallback = getD t k fallback := by
   simp_to_model [Const.insertMany!] using List.getValueD_insertListConst_of_contains_eq_false
 
 theorem getD_insertMany_list_of_mem [TransOrd α] (h : t.WF)
-    {l : List (α × β)} {k k' : α} (k_beq : k == k') {v fallback : β}
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false)) (mem : ⟨k, v⟩ ∈ l) :
+    {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v fallback : β}
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
     getD (insertMany t l h.balanced).1 k' fallback = v := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany] using List.getValueD_insertListConst_of_mem
 
 theorem getD_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
-    {l : List (α × β)} {k k' : α} (k_beq : k == k') {v fallback : β}
-    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false)) (mem : ⟨k, v⟩ ∈ l) :
+    {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v fallback : β}
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
     getD (insertMany! t l).1 k' fallback = v := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany!] using List.getValueD_insertListConst_of_mem
 
-variable (t : Impl α Unit)
+variable {t : Impl α Unit}
 
 @[simp]
 theorem insertManyIfNewUnit_nil (h : t.WF) :
@@ -2381,171 +2484,225 @@ theorem insertManyIfNewUnit!_cons {l : List α} {k : α} :
   · simp
 
 @[simp]
-theorem contains_insertManyIfNewUnit_list [TransOrd α] (h : t.WF)
+theorem contains_insertManyIfNewUnit_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List α} {k : α} :
     (insertManyIfNewUnit t l h.balanced).1.contains k = (t.contains k || l.contains k) := by
   simp_to_model [Const.insertManyIfNewUnit] using List.containsKey_insertListIfNewUnit
 
 @[simp]
-theorem contains_insertManyIfNewUnit!_list [TransOrd α] (h : t.WF)
+theorem contains_insertManyIfNewUnit!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List α} {k : α} :
     (insertManyIfNewUnit! t l).1.contains k = (t.contains k || l.contains k) := by
   simp_to_model [Const.insertManyIfNewUnit!] using List.containsKey_insertListIfNewUnit
 
-theorem contains_of_contains_insertManyIfNewUnit_list [TransOrd α] (h : t.WF)
+@[simp]
+theorem mem_insertManyIfNewUnit_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+    {l : List α} {k : α} :
+    k ∈ (insertManyIfNewUnit t l h.balanced).1 ↔ k ∈ t ∨ l.contains k := by
+  simp [mem_iff_contains, contains_insertManyIfNewUnit_list h]
+
+@[simp]
+theorem mem_insertManyIfNewUnit!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+    {l : List α} {k : α} :
+    k ∈ (insertManyIfNewUnit! t l).1 ↔ k ∈ t ∨ l.contains k := by
+  simp [mem_iff_contains, contains_insertManyIfNewUnit!_list h]
+
+theorem contains_of_contains_insertManyIfNewUnit_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List α} {k : α} (h₂ : l.contains k = false) :
     (insertManyIfNewUnit t l h.balanced).1.contains k → t.contains k := by
   simp_to_model [Const.insertManyIfNewUnit] using List.containsKey_of_containsKey_insertListIfNewUnit
 
-theorem contains_of_contains_insertManyIfNewUnit!_list [TransOrd α] (h : t.WF)
+theorem contains_of_contains_insertManyIfNewUnit!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List α} {k : α} (h₂ : l.contains k = false) :
     (insertManyIfNewUnit! t l).1.contains k → t.contains k := by
   simp_to_model [Const.insertManyIfNewUnit!] using List.containsKey_of_containsKey_insertListIfNewUnit
 
-theorem getKey?_insertManyIfNewUnit_list_of_contains_eq_false_of_contains_eq_false [TransOrd α]
+theorem mem_of_mem_insertManyIfNewUnit_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+    {l : List α} {k : α} (contains_eq_false : l.contains k = false) :
+    k ∈ (insertManyIfNewUnit t l h.balanced).1 → k ∈ t := by
+  simpa [mem_iff_contains] using contains_of_contains_insertManyIfNewUnit_list h contains_eq_false
+
+theorem mem_of_mem_insertManyIfNewUnit!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+    {l : List α} {k : α} (contains_eq_false : l.contains k = false) :
+    k ∈ (insertManyIfNewUnit! t l).1 → k ∈ t := by
+  simpa [mem_iff_contains] using contains_of_contains_insertManyIfNewUnit!_list h contains_eq_false
+
+theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
     (h : t.WF) {l : List α} {k : α} :
-    t.contains k = false → l.contains k = false → getKey? (insertManyIfNewUnit t l h.balanced).1 k = none := by
+    ¬ k ∈ t → l.contains k = false → getKey? (insertManyIfNewUnit t l h.balanced).1 k = none := by
+  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [Const.insertManyIfNewUnit] using List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
 
-theorem getKey?_insertManyIfNewUnit!_list_of_contains_eq_false_of_contains_eq_false [TransOrd α]
+theorem getKey?_insertManyIfNewUnit!_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
     (h : t.WF) {l : List α} {k : α} :
-    t.contains k = false → l.contains k = false → getKey? (insertManyIfNewUnit! t l).1 k = none := by
+    ¬ k ∈ t → l.contains k = false → getKey? (insertManyIfNewUnit! t l).1 k = none := by
+  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [Const.insertManyIfNewUnit!] using List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
 
-theorem getKey?_insertManyIfNewUnit_list_of_contains_eq_false_of_mem [TransOrd α]
-    (h : t.WF) {l : List α} {k k' : α} (k_beq : k == k') :
-    t.contains k = false → l.Pairwise (fun a b => (a == b) = false) → k ∈ l →
+theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_mem [TransOrd α]
+    (h : t.WF) {l : List α} {k k' : α} (k_beq : compare k k' = .eq) :
+    ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKey? (insertManyIfNewUnit t l h.balanced).1 k' = some k := by
+  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit] using List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_mem
 
-theorem getKey?_insertManyIfNewUnit!_list_of_contains_eq_false_of_mem [TransOrd α]
-    (h : t.WF) {l : List α} {k k' : α} (k_beq : k == k') :
-    t.contains k = false → l.Pairwise (fun a b => (a == b) = false) → k ∈ l →
+theorem getKey?_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
+    (h : t.WF) {l : List α} {k k' : α} (k_beq : compare k k' = .eq) :
+    ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKey? (insertManyIfNewUnit! t l).1 k' = some k := by
+  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit!] using List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_mem
 
-theorem getKey?_insertManyIfNewUnit_list_of_contains [TransOrd α]
+theorem getKey?_insertManyIfNewUnit_list_of_mem [TransOrd α]
     (h : t.WF) {l : List α} {k : α} :
-    t.contains k → getKey? (insertManyIfNewUnit t l h.balanced).1 k = getKey? t k := by
+    k ∈ t → getKey? (insertManyIfNewUnit t l h.balanced).1 k = getKey? t k := by
+  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit] using List.getKey?_insertListIfNewUnit_of_contains
 
-theorem getKey?_insertManyIfNewUnit!_list_of_contains [TransOrd α]
+theorem getKey?_insertManyIfNewUnit!_list_of_mem [TransOrd α]
     (h : t.WF) {l : List α} {k : α} :
-    t.contains k → getKey? (insertManyIfNewUnit! t l).1 k = getKey? t k := by
+    k ∈ t → getKey? (insertManyIfNewUnit! t l).1 k = getKey? t k := by
+  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit!] using List.getKey?_insertListIfNewUnit_of_contains
 
-theorem getKey_insertManyIfNewUnit_list_of_contains [TransOrd α]
-    (h : t.WF) {l : List α} {k : α} {h'} (contains : t.contains k) :
+theorem getKey_insertManyIfNewUnit_list_of_mem [TransOrd α]
+    (h : t.WF) {l : List α} {k : α} {h'} (contains : k ∈ t) :
     getKey (insertManyIfNewUnit t l h.balanced).1 k h' = getKey t k contains := by
   simp_to_model [Const.insertManyIfNewUnit] using List.getKey_insertListIfNewUnit_of_contains
 
-theorem getKey_insertManyIfNewUnit!_list_of_contains [TransOrd α]
-    (h : t.WF) {l : List α} {k : α} {h'} (contains : t.contains k) :
+theorem getKey_insertManyIfNewUnit!_list_of_mem [TransOrd α]
+    (h : t.WF) {l : List α} {k : α} {h'} (contains : k ∈ t) :
     getKey (insertManyIfNewUnit! t l).1 k h' = getKey t k contains := by
   simp_to_model [Const.insertManyIfNewUnit!] using List.getKey_insertListIfNewUnit_of_contains
 
-theorem getKey_insertManyIfNewUnit_list_of_contains_eq_false_of_mem [TransOrd α]
+theorem getKey_insertManyIfNewUnit_list_of_not_mem_of_mem [TransOrd α]
     (h : t.WF) {l : List α}
-    {k k' : α} (k_beq : k == k') {h'} :
-    t.contains k = false → l.Pairwise (fun a b => (a == b) = false) → k ∈ l →
+    {k k' : α} (k_beq : compare k k' = .eq) {h'} :
+    ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKey (insertManyIfNewUnit t l h.balanced).1 k' h' = k := by
+  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit] using List.getKey_insertListIfNewUnit_of_contains_eq_false_of_mem
 
-theorem getKey_insertManyIfNewUnit!_list_of_contains_eq_false_of_mem [TransOrd α]
+theorem getKey_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
     (h : t.WF) {l : List α}
-    {k k' : α} (k_beq : k == k') {h'} :
-    t.contains k = false → l.Pairwise (fun a b => (a == b) = false) → k ∈ l →
+    {k k' : α} (k_beq : compare k k' = .eq) {h'} :
+    ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKey (insertManyIfNewUnit! t l).1 k' h' = k := by
+  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit!] using List.getKey_insertListIfNewUnit_of_contains_eq_false_of_mem
 
-theorem getKey_insertManyIfNewUnit_list_mem_of_contains [TransOrd α]
-    (h : t.WF) {l : List α} {k : α} (contains : t.contains k) {h'} :
+theorem getKey_insertManyIfNewUnit_list_mem_of_mem [TransOrd α]
+    (h : t.WF) {l : List α} {k : α} (contains : k ∈ t) {h'} :
     getKey (insertManyIfNewUnit t l h.balanced).1 k h' = getKey t k contains := by
   simp_to_model [Const.insertManyIfNewUnit] using List.getKey_insertListIfNewUnit_of_contains
 
-theorem getKey_insertManyIfNewUnit!_list_mem_of_contains [TransOrd α]
-    (h : t.WF) {l : List α} {k : α} (contains : t.contains k) {h'} :
+theorem getKey_insertManyIfNewUnit!_list_mem_of_mem [TransOrd α]
+    (h : t.WF) {l : List α} {k : α} (contains : k ∈ t) {h'} :
     getKey (insertManyIfNewUnit! t l).1 k h' = getKey t k contains := by
   simp_to_model [Const.insertManyIfNewUnit!] using List.getKey_insertListIfNewUnit_of_contains
 
-theorem getKey!_insertManyIfNewUnit_list_of_contains_eq_false_of_contains_eq_false
+theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqOrd α]
     [TransOrd α] [Inhabited α] (h : t.WF) {l : List α} {k : α} :
-    t.contains k = false → l.contains k = false →
+    ¬ k ∈ t → l.contains k = false →
       getKey! (insertManyIfNewUnit t l h.balanced).1 k = default := by
+  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [Const.insertManyIfNewUnit] using List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
 
-theorem getKey!_insertManyIfNewUnit!_list_of_contains_eq_false_of_contains_eq_false
+theorem getKey!_insertManyIfNewUnit!_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqOrd α]
     [TransOrd α] [Inhabited α] (h : t.WF) {l : List α} {k : α} :
-    t.contains k = false → l.contains k = false →
+    ¬ k ∈ t → l.contains k = false →
       getKey! (insertManyIfNewUnit! t l).1 k = default := by
+  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [Const.insertManyIfNewUnit!] using List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
 
-theorem getKey!_insertManyIfNewUnit_list_of_contains_eq_false_of_mem [TransOrd α]
-    [Inhabited α] (h : t.WF) {l : List α} {k k' : α} (k_beq : k == k') :
-    t.contains k = false → l.Pairwise (fun a b => (a == b) = false) → k ∈ l →
+theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem [TransOrd α]
+    [Inhabited α] (h : t.WF) {l : List α} {k k' : α} (k_beq : compare k k' = .eq) :
+    ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKey! (insertManyIfNewUnit t l h.balanced).1 k' = k := by
+  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit] using List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_mem
 
-theorem getKey!_insertManyIfNewUnit!_list_of_contains_eq_false_of_mem [TransOrd α]
-    [Inhabited α] (h : t.WF) {l : List α} {k k' : α} (k_beq : k == k') :
-    t.contains k = false → l.Pairwise (fun a b => (a == b) = false) → k ∈ l →
+theorem getKey!_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
+    [Inhabited α] (h : t.WF) {l : List α} {k k' : α} (k_beq : compare k k' = .eq) :
+    ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKey! (insertManyIfNewUnit! t l).1 k' = k := by
+  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit!] using List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_mem
 
-theorem getKey!_insertManyIfNewUnit_list_of_contains [TransOrd α]
+theorem getKey!_insertManyIfNewUnit_list_of_mem [TransOrd α]
     [Inhabited α] (h : t.WF) {l : List α} {k : α} :
-    t.contains k → getKey! (insertManyIfNewUnit t l h.balanced).1 k = getKey! t k  := by
+    k ∈ t → getKey! (insertManyIfNewUnit t l h.balanced).1 k = getKey! t k  := by
+  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit] using List.getKey!_insertListIfNewUnit_of_contains
 
-theorem getKey!_insertManyIfNewUnit!_list_of_contains [TransOrd α]
+theorem getKey!_insertManyIfNewUnit!_list_of_mem [TransOrd α]
     [Inhabited α] (h : t.WF) {l : List α} {k : α} :
-    t.contains k → getKey! (insertManyIfNewUnit! t l).1 k = getKey! t k  := by
+    k ∈ t → getKey! (insertManyIfNewUnit! t l).1 k = getKey! t k  := by
+  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit!] using List.getKey!_insertListIfNewUnit_of_contains
 
-theorem getKeyD_insertManyIfNewUnit_list_of_contains_eq_false_of_contains_eq_false
+theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqOrd α]
     [TransOrd α] (h : t.WF) {l : List α} {k fallback : α} :
-    t.contains k = false → l.contains k = false → getKeyD (insertManyIfNewUnit t l h.balanced).1 k fallback = fallback := by
+    ¬ k ∈ t → l.contains k = false → getKeyD (insertManyIfNewUnit t l h.balanced).1 k fallback = fallback := by
+  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [Const.insertManyIfNewUnit] using List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
 
-theorem getKeyD_insertManyIfNewUnit!_list_of_contains_eq_false_of_contains_eq_false
+theorem getKeyD_insertManyIfNewUnit!_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqOrd α]
     [TransOrd α] (h : t.WF) {l : List α} {k fallback : α} :
-    t.contains k = false → l.contains k = false → getKeyD (insertManyIfNewUnit! t l).1 k fallback = fallback := by
+    ¬ k ∈ t → l.contains k = false → getKeyD (insertManyIfNewUnit! t l).1 k fallback = fallback := by
+  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [Const.insertManyIfNewUnit!] using List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
 
-theorem getKeyD_insertManyIfNewUnit_list_of_contains_eq_false_of_mem [TransOrd α]
-    (h : t.WF) {l : List α} {k k' fallback : α} (k_beq : k == k') :
-    t.contains k = false → l.Pairwise (fun a b => (a == b) = false) → k ∈ l →
+theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_mem [TransOrd α]
+    (h : t.WF) {l : List α} {k k' fallback : α} (k_beq : compare k k' = .eq) :
+    ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKeyD (insertManyIfNewUnit t l h.balanced).1 k' fallback = k := by
+  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit] using List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_mem
 
-theorem getKeyD_insertManyIfNewUnit!_list_of_contains_eq_false_of_mem [TransOrd α]
-    (h : t.WF) {l : List α} {k k' fallback : α} (k_beq : k == k') :
-    t.contains k = false → l.Pairwise (fun a b => (a == b) = false) → k ∈ l →
+theorem getKeyD_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
+    (h : t.WF) {l : List α} {k k' fallback : α} (k_beq : compare k k' = .eq) :
+    ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKeyD (insertManyIfNewUnit! t l).1 k' fallback = k := by
+  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
+  rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit!] using List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_mem
 
-theorem getKeyD_insertManyIfNewUnit_list_of_contains [TransOrd α]
+theorem getKeyD_insertManyIfNewUnit_list_of_mem [TransOrd α]
     (h : t.WF) {l : List α} {k fallback : α} :
-    t.contains k → getKeyD (insertManyIfNewUnit t l h.balanced).1 k fallback = getKeyD t k fallback := by
+    k ∈ t → getKeyD (insertManyIfNewUnit t l h.balanced).1 k fallback = getKeyD t k fallback := by
+  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit] using List.getKeyD_insertListIfNewUnit_of_contains
 
-theorem getKeyD_insertManyIfNewUnit!_list_of_contains [TransOrd α]
+theorem getKeyD_insertManyIfNewUnit!_list_of_mem [TransOrd α]
     (h : t.WF) {l : List α} {k fallback : α} :
-    t.contains k → getKeyD (insertManyIfNewUnit! t l).1 k fallback = getKeyD t k fallback := by
+    k ∈ t → getKeyD (insertManyIfNewUnit! t l).1 k fallback = getKeyD t k fallback := by
+  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit!] using List.getKeyD_insertListIfNewUnit_of_contains
 
-theorem size_insertManyIfNewUnit_list [TransOrd α] (h : t.WF)
+theorem size_insertManyIfNewUnit_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List α}
-    (distinct : l.Pairwise (fun a b => (a == b) = false)) :
-    (∀ (a : α), t.contains a → l.contains a = false) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a b = .eq)) :
+    (∀ (a : α), a ∈ t → l.contains a = false) →
     (insertManyIfNewUnit t l h.balanced).1.size = t.size + l.length := by
+  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true] at distinct
+  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit] using List.length_insertListIfNewUnit
 
-theorem size_insertManyIfNewUnit!_list [TransOrd α] (h : t.WF)
+theorem size_insertManyIfNewUnit!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List α}
-    (distinct : l.Pairwise (fun a b => (a == b) = false)) :
-    (∀ (a : α), t.contains a → l.contains a = false) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a b = .eq)) :
+    (∀ (a : α), a ∈ t → l.contains a = false) →
     (insertManyIfNewUnit! t l).1.size = t.size + l.length := by
+  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true] at distinct
+  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit!] using List.length_insertListIfNewUnit
 
 theorem size_le_size_insertManyIfNewUnit_list [TransOrd α] (h : t.WF)
@@ -2578,16 +2735,18 @@ theorem isEmpty_insertManyIfNewUnit!_list [TransOrd α] (h : t.WF) {l : List α}
     (insertManyIfNewUnit! t l).1.isEmpty = (t.isEmpty && l.isEmpty) := by
   simp_to_model [Const.insertManyIfNewUnit!] using List.isEmpty_insertListIfNewUnit
 
-theorem get?_insertManyIfNewUnit_list [TransOrd α] (h : t.WF)
+theorem get?_insertManyIfNewUnit_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List α} {k : α} :
     get? (insertManyIfNewUnit t l h.balanced).1 k =
-    if t.contains k ∨ l.contains k then some () else none := by
+      if k ∈ t ∨ l.contains k then some () else none := by
+  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit] using List.getValue?_insertListIfNewUnit
 
-theorem get?_insertManyIfNewUnit!_list [TransOrd α] (h : t.WF)
+theorem get?_insertManyIfNewUnit!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List α} {k : α} :
     get? (insertManyIfNewUnit! t l).1 k =
-    if t.contains k ∨ l.contains k then some () else none := by
+      if k ∈ t ∨ l.contains k then some () else none := by
+  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit!] using List.getValue?_insertListIfNewUnit
 
 theorem get_insertManyIfNewUnit_list (h : t.WF) {l : List α} {k : α} {h'} :
@@ -2643,32 +2802,21 @@ theorem insertMany_empty_list_cons {k : α} {v : β k}
       ((empty.insert k v WF.empty.balanced).impl.insertMany tl WF.empty.insert.balanced).1 := by
   rw [insertMany_cons WF.empty]
 
-theorem insertMany!_empty_list_cons {k : α} {v : β k}
+theorem insertMany_empty_list_cons_eq_insertMany! {k : α} {v : β k}
     {tl : List ((a : α) × (β a))} :
-    (insertMany! empty (⟨k, v⟩ :: tl)).1 = ((empty.insert! k v).insertMany! tl).1 := by
-  rw [insertMany!_cons]
+    (insertMany empty (⟨k, v⟩ :: tl) WF.empty.balanced).1 = ((empty.insert! k v).insertMany! tl).1 := by
+  rw [insertMany_cons WF.empty, insertMany_eq_insertMany!, insert_eq_insert!]
 
-theorem contains_insertMany_empty_list [TransOrd α]
+theorem contains_insertMany_empty_list [BEq α] [LawfulBEqOrd α] [TransOrd α]
     {l : List ((a : α) × β a)} {k : α} :
     (insertMany empty l WF.empty.balanced).1.contains k = (l.map Sigma.fst).contains k := by
   simp only [contains_insertMany_list WF.empty, contains_empty, Bool.false_or]
 
-theorem contains_insertMany!_empty_list [TransOrd α]
-    {l : List ((a : α) × β a)} {k : α} :
-    (insertMany! empty l).1.contains k = (l.map Sigma.fst).contains k := by
-  simp only [contains_insertMany!_list WF.empty, contains_empty, Bool.false_or]
-
-theorem get?_insertMany_empty_list_of_contains_eq_false [TransOrd α] [LawfulEqOrd α]
+theorem get?_insertMany_empty_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [LawfulEqOrd α]
     {l : List ((a : α) × β a)} {k : α}
     (h : (l.map Sigma.fst).contains k = false) :
     (insertMany empty l WF.empty.balanced).1.get? k = none := by
   simp only [get?_insertMany_list_of_contains_eq_false WF.empty h, get?_empty]
-
-theorem get?_insertMany!_empty_list_of_contains_eq_false [TransOrd α] [LawfulEqOrd α]
-    {l : List ((a : α) × β a)} {k : α}
-    (h : (l.map Sigma.fst).contains k = false) :
-    (insertMany! empty l).1.get? k = none := by
-  simp only [get?_insertMany!_list_of_contains_eq_false WF.empty h, get?_empty]
 
 theorem get?_insertMany_empty_list_of_mem [TransOrd α] [LawfulEqOrd α]
     {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k}
@@ -2677,43 +2825,19 @@ theorem get?_insertMany_empty_list_of_mem [TransOrd α] [LawfulEqOrd α]
     (insertMany empty l WF.empty.balanced).1.get? k' = some (cast (by congr; apply compare_eq_iff_eq.mp k_beq) v) := by
   rw [get?_insertMany_list_of_mem WF.empty k_beq distinct mem]
 
-theorem get?_insertMany!_empty_list_of_mem [TransOrd α] [LawfulEqOrd α]
-    {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k}
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : ⟨k, v⟩ ∈ l) :
-    (insertMany! empty l).1.get? k' = some (cast (by congr; apply compare_eq_iff_eq.mp k_beq) v) := by
-  rw [get?_insertMany!_list_of_mem WF.empty k_beq distinct mem]
-
 theorem get_insertMany_empty_list_of_mem [TransOrd α] [LawfulEqOrd α]
     {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k}
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : ⟨k, v⟩ ∈ l)
     {h} :
     (insertMany empty l WF.empty.balanced).1.get k' h = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
-  simp only [← beq_iff, Bool.not_eq_true] at k_beq distinct
   rw [get_insertMany_list_of_mem WF.empty k_beq distinct mem]
 
-theorem get_insertMany!_empty_list_of_mem [TransOrd α] [LawfulEqOrd α]
-    {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k}
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : ⟨k, v⟩ ∈ l)
-    {h} :
-    (insertMany! empty l).1.get k' h = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
-  simp only [← beq_iff, Bool.not_eq_true] at k_beq distinct
-  rw [get_insertMany!_list_of_mem WF.empty k_beq distinct mem]
-
-theorem get!_insertMany_empty_list_of_contains_eq_false [TransOrd α] [LawfulEqOrd α]
+theorem get!_insertMany_empty_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [LawfulEqOrd α]
     {l : List ((a : α) × β a)} {k : α} [Inhabited (β k)]
     (h : (l.map Sigma.fst).contains k = false) :
     (insertMany empty l WF.empty.balanced).1.get! k = default := by
   simp only [get!_insertMany_list_of_contains_eq_false WF.empty h]
-  apply get!_empty
-
-theorem get!_insertMany!_empty_list_of_contains_eq_false [TransOrd α] [LawfulEqOrd α]
-    {l : List ((a : α) × β a)} {k : α} [Inhabited (β k)]
-    (h : (l.map Sigma.fst).contains k = false) :
-    (insertMany! empty l).1.get! k = default := by
-  simp only [get!_insertMany!_list_of_contains_eq_false WF.empty h]
   apply get!_empty
 
 theorem get!_insertMany_empty_list_of_mem [TransOrd α] [LawfulEqOrd α]
@@ -2721,29 +2845,13 @@ theorem get!_insertMany_empty_list_of_mem [TransOrd α] [LawfulEqOrd α]
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : ⟨k, v⟩ ∈ l) :
     (insertMany empty l WF.empty.balanced).1.get! k' = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
-  simp only [← beq_iff, Bool.not_eq_true] at k_beq distinct
   rw [get!_insertMany_list_of_mem WF.empty k_beq distinct mem]
 
-theorem get!_insertMany!_empty_list_of_mem [TransOrd α] [LawfulEqOrd α]
-    {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k} [Inhabited (β k')]
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : ⟨k, v⟩ ∈ l) :
-    (insertMany! empty l).1.get! k' = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
-  simp only [← beq_iff, Bool.not_eq_true] at k_beq distinct
-  rw [get!_insertMany!_list_of_mem WF.empty k_beq distinct mem]
-
-theorem getD_insertMany_empty_list_of_contains_eq_false [TransOrd α] [LawfulEqOrd α]
+theorem getD_insertMany_empty_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [LawfulEqOrd α]
     {l : List ((a : α) × β a)} {k : α} {fallback : β k}
     (contains_eq_false : (l.map Sigma.fst).contains k = false) :
     (insertMany empty l WF.empty.balanced).1.getD k fallback = fallback := by
   rw [getD_insertMany_list_of_contains_eq_false WF.empty contains_eq_false]
-  apply getD_empty
-
-theorem getD_insertMany!_empty_list_of_contains_eq_false [TransOrd α] [LawfulEqOrd α]
-    {l : List ((a : α) × β a)} {k : α} {fallback : β k}
-    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
-    (insertMany! empty l).1.getD k fallback = fallback := by
-  rw [getD_insertMany!_list_of_contains_eq_false WF.empty contains_eq_false]
   apply getD_empty
 
 theorem getD_insertMany_empty_list_of_mem [TransOrd α] [LawfulEqOrd α]
@@ -2752,30 +2860,13 @@ theorem getD_insertMany_empty_list_of_mem [TransOrd α] [LawfulEqOrd α]
     (mem : ⟨k, v⟩ ∈ l) :
     (insertMany empty l WF.empty.balanced).1.getD k' fallback =
       cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
-  simp only [← beq_iff, Bool.not_eq_true] at k_beq distinct
   rw [getD_insertMany_list_of_mem WF.empty k_beq distinct mem]
 
-theorem getD_insertMany!_empty_list_of_mem [TransOrd α] [LawfulEqOrd α]
-    {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k} {fallback : β k'}
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : ⟨k, v⟩ ∈ l) :
-    (insertMany! empty l).1.getD k' fallback =
-      cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
-  simp only [← beq_iff, Bool.not_eq_true] at k_beq distinct
-  rw [getD_insertMany!_list_of_mem WF.empty k_beq distinct mem]
-
-theorem getKey?_insertMany_empty_list_of_contains_eq_false [TransOrd α]
+theorem getKey?_insertMany_empty_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
     {l : List ((a : α) × β a)} {k : α}
     (h : (l.map Sigma.fst).contains k = false) :
     (insertMany empty l WF.empty.balanced).1.getKey? k = none := by
   rw [getKey?_insertMany_list_of_contains_eq_false WF.empty h]
-  apply getKey?_empty
-
-theorem getKey?_insertMany!_empty_list_of_contains_eq_false [TransOrd α]
-    {l : List ((a : α) × β a)} {k : α}
-    (h : (l.map Sigma.fst).contains k = false) :
-    (insertMany! empty l).1.getKey? k = none := by
-  rw [getKey?_insertMany!_list_of_contains_eq_false WF.empty h]
   apply getKey?_empty
 
 theorem getKey?_insertMany_empty_list_of_mem [TransOrd α]
@@ -2784,17 +2875,7 @@ theorem getKey?_insertMany_empty_list_of_mem [TransOrd α]
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Sigma.fst) :
     (insertMany empty l WF.empty.balanced).1.getKey? k' = some k := by
-  simp only [← beq_iff, Bool.not_eq_true] at k_beq distinct
   rw [getKey?_insertMany_list_of_mem WF.empty k_beq distinct mem]
-
-theorem getKey?_insertMany!_empty_list_of_mem [TransOrd α]
-    {l : List ((a : α) × β a)}
-    {k k' : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Sigma.fst) :
-    (insertMany! empty l).1.getKey? k' = some k := by
-  simp only [← beq_iff, Bool.not_eq_true] at k_beq distinct
-  rw [getKey?_insertMany!_list_of_mem WF.empty k_beq distinct mem]
 
 theorem getKey_insertMany_empty_list_of_mem [TransOrd α]
     {l : List ((a : α) × β a)}
@@ -2803,31 +2884,13 @@ theorem getKey_insertMany_empty_list_of_mem [TransOrd α]
     (mem : k ∈ l.map Sigma.fst)
     {h'} :
     (insertMany empty l WF.empty.balanced).1.getKey k' h' = k := by
-  simp only [← beq_iff, Bool.not_eq_true] at k_beq distinct
   rw [getKey_insertMany_list_of_mem WF.empty k_beq distinct mem]
 
-theorem getKey_insertMany!_empty_list_of_mem [TransOrd α]
-    {l : List ((a : α) × β a)}
-    {k k' : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Sigma.fst)
-    {h'} :
-    (insertMany! empty l).1.getKey k' h' = k := by
-  simp only [← beq_iff, Bool.not_eq_true] at k_beq distinct
-  rw [getKey_insertMany!_list_of_mem WF.empty k_beq distinct mem]
-
-theorem getKey!_insertMany_empty_list_of_contains_eq_false [TransOrd α]
+theorem getKey!_insertMany_empty_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
     [Inhabited α] {l : List ((a : α) × β a)} {k : α}
     (h : (l.map Sigma.fst).contains k = false) :
     (insertMany empty l WF.empty.balanced).1.getKey! k = default := by
   rw [getKey!_insertMany_list_of_contains_eq_false WF.empty h]
-  apply getKey!_empty
-
-theorem getKey!_insertMany!_empty_list_of_contains_eq_false [TransOrd α]
-    [Inhabited α] {l : List ((a : α) × β a)} {k : α}
-    (h : (l.map Sigma.fst).contains k = false) :
-    (insertMany! empty l).1.getKey! k = default := by
-  rw [getKey!_insertMany!_list_of_contains_eq_false WF.empty h]
   apply getKey!_empty
 
 theorem getKey!_insertMany_empty_list_of_mem [TransOrd α] [Inhabited α]
@@ -2836,30 +2899,13 @@ theorem getKey!_insertMany_empty_list_of_mem [TransOrd α] [Inhabited α]
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Sigma.fst) :
     (insertMany empty l WF.empty.balanced).1.getKey! k' = k := by
-  simp only [← beq_iff, Bool.not_eq_true] at k_beq distinct
   rw [getKey!_insertMany_list_of_mem WF.empty k_beq distinct mem]
 
-theorem getKey!_insertMany!_empty_list_of_mem [TransOrd α] [Inhabited α]
-    {l : List ((a : α) × β a)}
-    {k k' : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Sigma.fst) :
-    (insertMany! empty l).1.getKey! k' = k := by
-  simp only [← beq_iff, Bool.not_eq_true] at k_beq distinct
-  rw [getKey!_insertMany!_list_of_mem WF.empty k_beq distinct mem]
-
-theorem getKeyD_insertMany_empty_list_of_contains_eq_false [TransOrd α]
+theorem getKeyD_insertMany_empty_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
     {l : List ((a : α) × β a)} {k fallback : α}
     (h : (l.map Sigma.fst).contains k = false) :
     (insertMany empty l WF.empty.balanced).1.getKeyD k fallback = fallback := by
   rw [getKeyD_insertMany_list_of_contains_eq_false WF.empty h]
-  apply getKeyD_empty
-
-theorem getKeyD_insertMany!_empty_list_of_contains_eq_false [TransOrd α]
-    {l : List ((a : α) × β a)} {k fallback : α}
-    (h : (l.map Sigma.fst).contains k = false) :
-    (insertMany! empty l).1.getKeyD k fallback = fallback := by
-  rw [getKeyD_insertMany!_list_of_contains_eq_false WF.empty h]
   apply getKeyD_empty
 
 theorem getKeyD_insertMany_empty_list_of_mem [TransOrd α]
@@ -2868,16 +2914,6 @@ theorem getKeyD_insertMany_empty_list_of_mem [TransOrd α]
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Sigma.fst) :
     (insertMany empty l WF.empty.balanced).1.getKeyD k' fallback = k := by
-  simp only [← beq_iff, Bool.not_eq_true] at k_beq distinct
   rw [getKeyD_insertMany_list_of_mem WF.empty k_beq distinct mem]
-
-theorem getKeyD_insertMany!_empty_list_of_mem [TransOrd α]
-    {l : List ((a : α) × β a)}
-    {k k' fallback : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Sigma.fst) :
-    (insertMany! empty l).1.getKeyD k' fallback = k := by
-  simp only [← beq_iff, Bool.not_eq_true] at k_beq distinct
-  rw [getKeyD_insertMany!_list_of_mem WF.empty k_beq distinct mem]
 
 end Std.DTreeMap.Internal.Impl

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -1673,26 +1673,6 @@ end Const
 
 end monadic
 
-@[simp]
-theorem insertMany_nil (h : t.WF) :
-    t.insertMany [] h.balanced = t := by
-  simp [insertMany, Id.run]
-
-@[simp]
-theorem insertMany!_nil :
-    t.insertMany! [] = t := by
-  simp [insertMany!, Id.run]
-
-@[simp]
-theorem insertMany_list_singleton (h : t.WF) {k : α} {v : β k} :
-    t.insertMany [⟨k, v⟩] h.balanced = (t.insert k v h.balanced).impl := by
-  simp [insertMany, Id.run]
-
-@[simp]
-theorem insertMany!_list_singleton {k : α} {v : β k} :
-    t.insertMany! [⟨k, v⟩] = t.insert! k v := by
-  simp [insertMany!, Id.run]
-
 theorem insertMany_cons (h : t.WF) {l : List ((a : α) × β a)} {k : α} {v : β k} :
     (t.insertMany (⟨k, v⟩ :: l) h.balanced).1 =
       ((t.insert k v h.balanced).impl.insertMany l h.insert.balanced).1 := by
@@ -2070,26 +2050,6 @@ namespace Const
 
 variable {β : Type v} {t : Impl α β}
 
-@[simp]
-theorem insertMany_nil (h : t.WF) :
-    insertMany t [] h.balanced = t := by
-  simp [insertMany, Id.run]
-
-@[simp]
-theorem insertMany!_nil :
-    insertMany! t [] = t := by
-  simp [insertMany!, Id.run]
-
-@[simp]
-theorem insertMany_list_singleton (h : t.WF) {k : α} {v : β} :
-    insertMany t [⟨k, v⟩] h.balanced = (t.insert k v h.balanced).impl := by
-  simp [insertMany, Id.run]
-
-@[simp]
-theorem insertMany!_list_singleton {k : α} {v : β} :
-    insertMany! t [⟨k, v⟩] = t.insert! k v := by
-  simp [insertMany!, Id.run]
-
 theorem insertMany_cons (h : t.WF) {l : List (α × β)} {k : α} {v : β} :
     (Const.insertMany t ((k, v) :: l) h.balanced).1 =
       (Const.insertMany (t.insert k v h.balanced).impl l h.insert.balanced).1 := by
@@ -2443,26 +2403,6 @@ theorem getD_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
   simp_to_model [Const.insertMany!] using List.getValueD_insertListConst_of_mem
 
 variable {t : Impl α Unit}
-
-@[simp]
-theorem insertManyIfNewUnit_nil (h : t.WF) :
-    insertManyIfNewUnit t [] h.balanced = t := by
-  simp [insertManyIfNewUnit, Id.run]
-
-@[simp]
-theorem insertManyIfNewUnit!_nil :
-    insertManyIfNewUnit! t [] = t := by
-  simp [insertManyIfNewUnit!, Id.run]
-
-@[simp]
-theorem insertManyIfNewUnit_list_singleton (h : t.WF) {k : α} :
-    insertManyIfNewUnit t [k] h.balanced = (t.insertIfNew k () h.balanced).impl := by
-  simp [insertManyIfNewUnit, Id.run]
-
-@[simp]
-theorem insertManyIfNewUnit!_list_singleton {k : α} :
-    insertManyIfNewUnit! t [k] = t.insertIfNew! k () := by
-  simp [insertManyIfNewUnit!, Id.run]
 
 theorem insertManyIfNewUnit_cons (h : t.WF) {l : List α} {k : α} :
     (insertManyIfNewUnit t (k :: l) h.balanced).1 =

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -51,7 +51,7 @@ scoped macro "empty" : tactic => `(tactic| { intros; simp_all [List.isEmpty_iff]
 open Lean
 
 private def helperLemmaNames : Array Name :=
-  #[``compare_eq_iff_beq]
+  #[``compare_eq_iff_beq, ``Bool.not_eq_true, `mem_iff_contains]
 
 private def queryNames : Array Name :=
   #[``isEmpty_eq_isEmpty, ``contains_eq_containsKey, ``size_eq_length,
@@ -110,6 +110,9 @@ macro_rules
 theorem isEmpty_empty : isEmpty (empty : Impl α β) := by
   simp [Impl.isEmpty_eq_isEmpty]
 
+theorem mem_iff_contains {k : α} : k ∈ t ↔ t.contains k :=
+  Iff.rfl
+
 theorem isEmpty_insert [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.insert k v h.balanced).impl.isEmpty = false := by
   simp_to_model [insert] using List.isEmpty_insertEntry
@@ -117,9 +120,6 @@ theorem isEmpty_insert [TransOrd α] (h : t.WF) {k : α} {v : β k} :
 theorem isEmpty_insert! [TransOrd α] (h : t.WF) {k : α} {v : β k} :
     (t.insert! k v).isEmpty = false := by
   simp_to_model [insert!] using List.isEmpty_insertEntry
-
-theorem mem_iff_contains {k : α} : k ∈ t ↔ t.contains k :=
-  Iff.rfl
 
 theorem contains_congr [TransOrd α] (h : t.WF) {k k' : α} (hab : compare k k' = .eq) :
     t.contains k = t.contains k' := by
@@ -411,12 +411,10 @@ theorem mem_of_mem_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
 
 theorem size_insertIfNew [TransOrd α] {k : α} (h : t.WF) {v : β k} :
     (t.insertIfNew k v h.balanced).impl.size = if k ∈ t then t.size else t.size + 1 := by
-  simp only [mem_iff_contains]
   simp_to_model [insertIfNew] using List.length_insertEntryIfNew
 
 theorem size_insertIfNew! [TransOrd α] {k : α} (h : t.WF) {v : β k} :
     (t.insertIfNew! k v).size = if k ∈ t then t.size else t.size + 1 := by
-  simp only [mem_iff_contains]
   simp_to_model [insertIfNew!] using List.length_insertEntryIfNew
 
 theorem size_le_size_insertIfNew [TransOrd α] (h : t.WF) {k : α} {v : β k} :
@@ -1193,7 +1191,6 @@ theorem mem_of_mem_insertIfNew' [TransOrd α] (h : t.WF) {k a : α}
     {v : β k} :
     a ∈ (t.insertIfNew k v h.balanced).impl →
       ¬ (compare k a = .eq ∧ ¬ k ∈ t) → a ∈ t := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew] using List.containsKey_of_containsKey_insertEntryIfNew'
 
 /-- This is a restatement of `contains_of_contains_insertIfNew!` that is written to exactly match the
@@ -1201,7 +1198,6 @@ proof obligation in the statement of `get_insertIfNew!`. -/
 theorem mem_of_mem_insertIfNew!' [TransOrd α] (h : t.WF) {k a : α}
     {v : β k} :
     a ∈ (t.insertIfNew! k v) → ¬ (compare k a = .eq ∧ ¬ k ∈ t) → a ∈ t := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew!] using List.containsKey_of_containsKey_insertEntryIfNew'
 
 theorem get?_insertIfNew [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {v : β k} :
@@ -1210,7 +1206,6 @@ theorem get?_insertIfNew [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {v
         some (cast (congrArg β (compare_eq_iff_eq.mp h.1)) v)
       else
         t.get? a := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew] using List.getValueCast?_insertEntryIfNew
 
 theorem get?_insertIfNew! [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {v : β k} :
@@ -1219,7 +1214,6 @@ theorem get?_insertIfNew! [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {
         some (cast (congrArg β (compare_eq_iff_eq.mp h.1)) v)
       else
         t.get? a := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew!] using List.getValueCast?_insertEntryIfNew
 
 theorem get_insertIfNew [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {v : β k} {h₁} :
@@ -1228,7 +1222,6 @@ theorem get_insertIfNew [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {v 
         cast (congrArg β (compare_eq_iff_eq.mp h₂.1)) v
       else
         t.get a (mem_of_mem_insertIfNew' h h₁ h₂) := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew] using List.getValueCast_insertEntryIfNew
 
 theorem get_insertIfNew! [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {v : β k} {h₁} :
@@ -1237,7 +1230,6 @@ theorem get_insertIfNew! [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {v
         cast (congrArg β (compare_eq_iff_eq.mp h₂.1)) v
       else
         t.get a (mem_of_mem_insertIfNew!' h h₁ h₂) := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew!] using List.getValueCast_insertEntryIfNew
 
 theorem get!_insertIfNew [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} [Inhabited (β a)] {v : β k} :
@@ -1246,7 +1238,6 @@ theorem get!_insertIfNew [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} [I
         cast (congrArg β (compare_eq_iff_eq.mp h.1)) v
       else
         t.get! a := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew] using List.getValueCast!_insertEntryIfNew
 
 theorem get!_insertIfNew! [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} [Inhabited (β a)] {v : β k} :
@@ -1255,7 +1246,6 @@ theorem get!_insertIfNew! [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} [
         cast (congrArg β (compare_eq_iff_eq.mp h.1)) v
       else
         t.get! a := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew!] using List.getValueCast!_insertEntryIfNew
 
 theorem getD_insertIfNew [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {fallback : β a} {v : β k} :
@@ -1264,7 +1254,6 @@ theorem getD_insertIfNew [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {f
         cast (congrArg β (compare_eq_iff_eq.mp h.1)) v
       else
         t.getD a fallback := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew] using List.getValueCastD_insertEntryIfNew
 
 theorem getD_insertIfNew! [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {fallback : β a} {v : β k} :
@@ -1273,7 +1262,6 @@ theorem getD_insertIfNew! [TransOrd α] [LawfulEqOrd α] (h : t.WF) {k a : α} {
         cast (congrArg β (compare_eq_iff_eq.mp h.1)) v
       else
         t.getD a fallback := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew!] using List.getValueCastD_insertEntryIfNew
 
 namespace Const
@@ -1286,7 +1274,6 @@ theorem get?_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β} :
         some v
       else
         get? t a := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew] using List.getValue?_insertEntryIfNew
 
 theorem get?_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {v : β} :
@@ -1295,7 +1282,6 @@ theorem get?_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {v : β} :
         some v
       else
         get? t a := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew!] using List.getValue?_insertEntryIfNew
 
 theorem get_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β} {h₁} :
@@ -1304,7 +1290,6 @@ theorem get_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β} {h₁} :
         v
       else
         get t a (mem_of_mem_insertIfNew' h h₁ h₂) := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew] using List.getValue_insertEntryIfNew
 
 theorem get_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {v : β} {h₁} :
@@ -1313,33 +1298,28 @@ theorem get_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {v : β} {h₁} :
         v
       else
         get t a (mem_of_mem_insertIfNew!' h h₁ h₂) := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew!] using List.getValue_insertEntryIfNew
 
 theorem get!_insertIfNew [TransOrd α] [Inhabited β] (h : t.WF) {k a : α}
     {v : β} :
     get! (t.insertIfNew k v h.balanced).impl a =
       if compare k a = .eq ∧ ¬ k ∈ t then v else get! t a := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew] using List.getValue!_insertEntryIfNew
 
 theorem get!_insertIfNew! [TransOrd α] [Inhabited β] (h : t.WF) {k a : α}
     {v : β} :
     get! (t.insertIfNew! k v) a =
       if compare k a = .eq ∧ ¬ k ∈ t then v else get! t a := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew!] using List.getValue!_insertEntryIfNew
 
 theorem getD_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {fallback v : β} :
     getD (t.insertIfNew k v h.balanced).impl a fallback =
       if compare k a = .eq ∧ ¬ k ∈ t then v else getD t a fallback := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew] using List.getValueD_insertEntryIfNew
 
 theorem getD_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {fallback v : β} :
     getD (t.insertIfNew! k v) a fallback =
       if compare k a = .eq ∧ ¬ k ∈ t then v else getD t a fallback := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew!] using List.getValueD_insertEntryIfNew
 
 end Const
@@ -1347,55 +1327,47 @@ end Const
 theorem getKey?_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
     (t.insertIfNew k v h.balanced).impl.getKey? a =
       if compare k a = .eq ∧ ¬ k ∈ t then some k else t.getKey? a := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew] using List.getKey?_insertEntryIfNew
 
 theorem getKey?_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {v : β k} :
     (t.insertIfNew! k v).getKey? a =
       if compare k a = .eq ∧ ¬ k ∈ t then some k else t.getKey? a := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew!] using List.getKey?_insertEntryIfNew
 
 theorem getKey_insertIfNew [TransOrd α] (h : t.WF) {k a : α} {v : β k} {h₁} :
     (t.insertIfNew k v h.balanced).impl.getKey a h₁ =
       if h₂ : compare k a = .eq ∧ ¬ k ∈ t then k
       else t.getKey a (mem_of_mem_insertIfNew' h h₁ h₂) := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew] using List.getKey_insertEntryIfNew
 
 theorem getKey_insertIfNew! [TransOrd α] (h : t.WF) {k a : α} {v : β k} {h₁} :
     (t.insertIfNew! k v).getKey a h₁ =
       if h₂ : compare k a = .eq ∧ ¬ k ∈ t then k
       else t.getKey a (mem_of_mem_insertIfNew!' h h₁ h₂) := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew!] using List.getKey_insertEntryIfNew
 
 theorem getKey!_insertIfNew [TransOrd α] [Inhabited α] (h : t.WF) {k a : α}
     {v : β k} :
     (t.insertIfNew k v h.balanced).impl.getKey! a =
       if compare k a = .eq ∧ ¬ k ∈ t then k else t.getKey! a := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew] using List.getKey!_insertEntryIfNew
 
 theorem getKey!_insertIfNew! [TransOrd α] [Inhabited α] (h : t.WF) {k a : α}
     {v : β k} :
     (t.insertIfNew! k v).getKey! a =
       if compare k a = .eq ∧ ¬ k ∈ t then k else t.getKey! a := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew!] using List.getKey!_insertEntryIfNew
 
 theorem getKeyD_insertIfNew [TransOrd α] (h : t.WF) {k a fallback : α}
     {v : β k} :
     (t.insertIfNew k v h.balanced).impl.getKeyD a fallback =
       if compare k a = .eq ∧ ¬ k ∈ t then k else t.getKeyD a fallback := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew] using List.getKeyD_insertEntryIfNew
 
 theorem getKeyD_insertIfNew! [TransOrd α] (h : t.WF) {k a fallback : α}
     {v : β k} :
     (t.insertIfNew! k v).getKeyD a fallback =
       if compare k a = .eq ∧ ¬ k ∈ t then k else t.getKeyD a fallback := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [insertIfNew!] using List.getKeyD_insertEntryIfNew
 
 /-!
@@ -1494,7 +1466,6 @@ theorem mem_keys [LawfulEqOrd α] [TransOrd α] {k : α} (h : t.WF) :
 
 theorem distinct_keys [TransOrd α] (h : t.WF) :
     t.keys.Pairwise (fun a b => ¬ compare a b = .eq) := by
-  simp only [← not_congr beq_iff_eq, ← beq_eq, Bool.not_eq_true]
   simp_to_model using h.ordered.distinctKeys.distinct
 
 theorem map_fst_toList_eq_keys :
@@ -1528,7 +1499,6 @@ theorem find?_toList_eq_none_iff_not_mem [TransOrd α] {k : α} (h : t.WF) :
 
 theorem distinct_keys_toList [TransOrd α] (h : t.WF) :
     t.toList.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq) := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true]
   simp_to_model using List.pairwise_fst_eq_false
 
 namespace Const
@@ -1575,7 +1545,6 @@ theorem find?_toList_eq_none_iff_not_mem [TransOrd α] {k : α} (h : t.WF) :
 
 theorem distinct_keys_toList [TransOrd α] (h : t.WF) :
     (toList t).Pairwise (fun a b => ¬ compare a.1 b.1 = .eq) := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true]
   simp_to_model using List.pairwise_fst_eq_false_map_toProd
 
 end Const
@@ -1738,20 +1707,18 @@ theorem get?_insertMany!_list_of_contains_eq_false [TransOrd α] [LawfulEqOrd α
   simp_to_model [insertMany!] using List.getValueCast?_insertList_of_contains_eq_false
 
 theorem get?_insertMany_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k}
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : ⟨k, v⟩ ∈ l) :
+    {l : List ((a : α) × β a)} {k k' : α} : (k_beq : compare k k' = .eq) → {v : β k} →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : ⟨k, v⟩ ∈ l) →
     (t.insertMany l h.balanced).1.get? k' =
       some (cast (by congr; apply compare_eq_iff_eq.mp k_beq) v) := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany] using List.getValueCast?_insertList_of_mem
 
 theorem get?_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k}
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : ⟨k, v⟩ ∈ l) :
+    {l : List ((a : α) × β a)} {k k' : α} : (k_beq : compare k k' = .eq) → {v : β k} →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : ⟨k, v⟩ ∈ l) →
     (t.insertMany! l).1.get? k' = some (cast (by congr; apply compare_eq_iff_eq.mp k_beq) v) := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany!] using List.getValueCast?_insertList_of_mem
 
 theorem get_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
@@ -1773,22 +1740,20 @@ theorem get_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [Lawful
   simp_to_model [insertMany!] using List.getValueCast_insertList_of_contains_eq_false
 
 theorem get_insertMany_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k}
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : ⟨k, v⟩ ∈ l)
-    {h'} :
+    {l : List ((a : α) × β a)} {k k' : α} : (k_beq : compare k k' = .eq) → {v : β k} →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : ⟨k, v⟩ ∈ l) →
+    {h' : _} →
     (t.insertMany l h.balanced).1.get k' h' =
       cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany] using List.getValueCast_insertList_of_mem
 
 theorem get_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k}
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : ⟨k, v⟩ ∈ l)
-    {h'} :
+    {l : List ((a : α) × β a)} {k k' : α} : (k_beq : compare k k' = .eq) → {v : β k} →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : ⟨k, v⟩ ∈ l) →
+    {h' : _} →
     (t.insertMany! l).1.get k' h' = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany!] using List.getValueCast_insertList_of_mem
 
 theorem get!_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
@@ -1805,20 +1770,20 @@ theorem get!_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [Lawfu
   simp_to_model [insertMany!] using List.getValueCast!_insertList_of_contains_eq_false
 
 theorem get!_insertMany_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k} [Inhabited (β k')]
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : ⟨k, v⟩ ∈ l) :
+    {l : List ((a : α) × β a)} {k k' : α} : (k_beq : compare k k' = .eq) → {v : β k} →
+    [Inhabited (β k')] →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : ⟨k, v⟩ ∈ l) →
     (t.insertMany l h.balanced).1.get! k' =
       cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany] using List.getValueCast!_insertList_of_mem
 
 theorem get!_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k} [Inhabited (β k')]
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : ⟨k, v⟩ ∈ l) :
+    {l : List ((a : α) × β a)} {k k' : α} : (k_beq : compare k k' = .eq) → {v : β k} →
+    [Inhabited (β k')] →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : ⟨k, v⟩ ∈ l) →
     (t.insertMany! l).1.get! k' = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany!] using List.getValueCast!_insertList_of_mem
 
 theorem getD_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
@@ -1834,20 +1799,20 @@ theorem getD_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [Lawfu
   simp_to_model [insertMany!] using List.getValueCastD_insertList_of_contains_eq_false
 
 theorem getD_insertMany_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k} {fallback : β k'}
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : ⟨k, v⟩ ∈ l) :
+    {l : List ((a : α) × β a)} {k k' : α} : (k_beq : compare k k' = .eq) → {v : β k} →
+    {fallback : β k'} →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : ⟨k, v⟩ ∈ l) →
     (t.insertMany l h.balanced).1.getD k' fallback =
       cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany] using List.getValueCastD_insertList_of_mem
 
 theorem getD_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k} {fallback : β k'}
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : ⟨k, v⟩ ∈ l) :
+    {l : List ((a : α) × β a)} {k k' : α} : (k_beq : compare k k' = .eq) → {v : β k} →
+    {fallback : β k'} →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : ⟨k, v⟩ ∈ l) →
     (t.insertMany! l).1.getD k' fallback = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany!] using List.getValueCastD_insertList_of_mem
 
 theorem getKey?_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
@@ -1864,20 +1829,18 @@ theorem getKey?_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [La
 
 theorem getKey?_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)}
-    {k k' : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Sigma.fst) :
+    {k k' : α} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : k ∈ l.map Sigma.fst) →
     (t.insertMany l h.balanced).1.getKey? k' = some k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany] using List.getKey?_insertList_of_mem
 
 theorem getKey?_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)}
-    {k k' : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Sigma.fst) :
+    {k k' : α} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : k ∈ l.map Sigma.fst) →
     (t.insertMany! l).1.getKey? k' = some k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany!] using List.getKey?_insertList_of_mem
 
 theorem getKey_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
@@ -1898,22 +1861,20 @@ theorem getKey_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [Law
 
 theorem getKey_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)}
-    {k k' : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Sigma.fst)
-    {h'} :
+    {k k' : α} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : k ∈ l.map Sigma.fst) →
+    {h' : _} →
     (t.insertMany l h.balanced).1.getKey k' h' = k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany] using List.getKey_insertList_of_mem
 
 theorem getKey_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)}
-    {k k' : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Sigma.fst)
-    {h'} :
+    {k k' : α} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : k ∈ l.map Sigma.fst) →
+    {h' : _} →
     (t.insertMany! l).1.getKey k' h' = k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany!] using List.getKey_insertList_of_mem
 
 theorem getKey!_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
@@ -1930,20 +1891,18 @@ theorem getKey!_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [La
 
 theorem getKey!_insertMany_list_of_mem [TransOrd α] [Inhabited α] (h : t.WF)
     {l : List ((a : α) × β a)}
-    {k k' : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Sigma.fst) :
+    {k k' : α} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : k ∈ l.map Sigma.fst) →
     (t.insertMany l h.balanced).1.getKey! k' = k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany] using List.getKey!_insertList_of_mem
 
 theorem getKey!_insertMany!_list_of_mem [TransOrd α] [Inhabited α] (h : t.WF)
     {l : List ((a : α) × β a)}
-    {k k' : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Sigma.fst) :
+    {k k' : α} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : k ∈ l.map Sigma.fst) →
     (t.insertMany! l).1.getKey! k' = k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany!] using List.getKey!_insertList_of_mem
 
 theorem getKeyD_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
@@ -1960,34 +1919,30 @@ theorem getKeyD_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [La
 
 theorem getKeyD_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)}
-    {k k' fallback : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Sigma.fst) :
+    {k k' fallback : α} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : k ∈ l.map Sigma.fst) →
     (t.insertMany l h.balanced).1.getKeyD k' fallback = k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany] using List.getKeyD_insertList_of_mem
 
 theorem getKeyD_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)}
-    {k k' fallback : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Sigma.fst) :
+    {k k' fallback : α} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : k ∈ l.map Sigma.fst) →
     (t.insertMany! l).1.getKeyD k' fallback = k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany!] using List.getKeyD_insertList_of_mem
 
 theorem size_insertMany_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) :
+    {l : List ((a : α) × β a)} : (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
     (∀ (a : α), t.contains a → (l.map Sigma.fst).contains a = false) →
     (t.insertMany l h.balanced).1.size = t.size + l.length := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct
   simp_to_model [insertMany] using List.length_insertList
 
 theorem size_insertMany!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) :
+    {l : List ((a : α) × β a)} : (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
     (∀ (a : α), t.contains a → (l.map Sigma.fst).contains a = false) →
     (t.insertMany! l).1.size = t.size + l.length := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct
   simp_to_model [insertMany!] using List.length_insertList
 
 theorem size_le_size_insertMany_list [TransOrd α] (h : t.WF)
@@ -2095,20 +2050,18 @@ theorem getKey?_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [La
 
 theorem getKey?_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     {l : List (α × β)}
-    {k k' : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Prod.fst) :
+    {k k' : α} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : k ∈ l.map Prod.fst) →
     (insertMany t l h.balanced).1.getKey? k' = some k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany] using List.getKey?_insertListConst_of_mem
 
 theorem getKey?_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     {l : List (α × β)}
-    {k k' : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Prod.fst) :
+    {k k' : α} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : k ∈ l.map Prod.fst) →
     (insertMany! t l).1.getKey? k' = some k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany!] using List.getKey?_insertListConst_of_mem
 
 theorem getKey_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
@@ -2129,22 +2082,20 @@ theorem getKey_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [Law
 
 theorem getKey_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     {l : List (α × β)}
-    {k k' : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Prod.fst)
-    {h'} :
+    {k k' : α} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : k ∈ l.map Prod.fst) →
+    {h' : _} →
     (insertMany t l h.balanced).1.getKey k' h' = k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany] using List.getKey_insertListConst_of_mem
 
 theorem getKey_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     {l : List (α × β)}
-    {k k' : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Prod.fst)
-    {h'} :
+    {k k' : α} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : k ∈ l.map Prod.fst) →
+    {h' : _} →
     (insertMany! t l).1.getKey k' h' = k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany!] using List.getKey_insertListConst_of_mem
 
 theorem getKey!_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
@@ -2161,20 +2112,18 @@ theorem getKey!_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [La
 
 theorem getKey!_insertMany_list_of_mem [TransOrd α] [Inhabited α] (h : t.WF)
     {l : List (α × β)}
-    {k k' : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Prod.fst) :
+    {k k' : α} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : k ∈ l.map Prod.fst) →
     (insertMany t l h.balanced).1.getKey! k' = k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany] using List.getKey!_insertListConst_of_mem
 
 theorem getKey!_insertMany!_list_of_mem [TransOrd α] [Inhabited α] (h : t.WF)
     {l : List (α × β)}
-    {k k' : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Prod.fst) :
+    {k k' : α} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : k ∈ l.map Prod.fst) →
     (insertMany! t l).1.getKey! k' = k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany!] using List.getKey!_insertListConst_of_mem
 
 theorem getKeyD_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
@@ -2191,36 +2140,32 @@ theorem getKeyD_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [La
 
 theorem getKeyD_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     {l : List (α × β)}
-    {k k' fallback : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Prod.fst) :
+    {k k' fallback : α} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : k ∈ l.map Prod.fst) →
     (insertMany t l h.balanced).1.getKeyD k' fallback = k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany] using List.getKeyD_insertListConst_of_mem
 
 theorem getKeyD_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     {l : List (α × β)}
-    {k k' fallback : α} (k_beq : compare k k' = .eq)
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
-    (mem : k ∈ l.map Prod.fst) :
+    {k k' fallback : α} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
+    (mem : k ∈ l.map Prod.fst) →
     (insertMany! t l).1.getKeyD k' fallback = k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany!] using List.getKeyD_insertListConst_of_mem
 
 theorem size_insertMany_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
-    {l : List (α × β)}
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) :
+    {l : List (α × β)} :
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
     (∀ (a : α), t.contains a → (l.map Prod.fst).contains a = false) →
     (insertMany t l h.balanced).1.size = t.size + l.length := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct
   simp_to_model [Const.insertMany] using List.length_insertListConst
 
 theorem size_insertMany!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
-    {l : List (α × β)}
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) :
+    {l : List (α × β)} :
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) →
     (∀ (a : α), t.contains a → (l.map Prod.fst).contains a = false) →
     (insertMany! t l).1.size = t.size + l.length := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct
   simp_to_model [Const.insertMany!] using List.length_insertListConst
 
 theorem size_le_size_insertMany_list [TransOrd α] (h : t.WF)
@@ -2268,17 +2213,15 @@ theorem get?_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [Lawfu
   simp_to_model [Const.insertMany!] using List.getValue?_insertListConst_of_contains_eq_false
 
 theorem get?_insertMany_list_of_mem [TransOrd α] (h : t.WF)
-    {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v : β}
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
+    {l : List (α × β)} {k k' : α} : (k_beq : compare k k' = .eq) → {v : β} →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) → (mem : ⟨k, v⟩ ∈ l) →
     get? (insertMany t l h.balanced).1 k' = v := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany] using List.getValue?_insertListConst_of_mem
 
 theorem get?_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
-    {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v : β}
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
+    {l : List (α × β)} {k k' : α} : (k_beq : compare k k' = .eq) → {v : β} →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) → (mem : ⟨k, v⟩ ∈ l) →
     get? (insertMany! t l).1 k' = v := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany!] using List.getValue?_insertListConst_of_mem
 
 theorem get_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
@@ -2297,17 +2240,15 @@ theorem get_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [Lawful
   simp_to_model [Const.insertMany!] using List.getValue_insertListConst_of_contains_eq_false
 
 theorem get_insertMany_list_of_mem [TransOrd α] (h : t.WF)
-    {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v : β}
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) {h'} :
+    {l : List (α × β)} {k k' : α} : (k_beq : compare k k' = .eq) → {v : β} →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) → (mem : ⟨k, v⟩ ∈ l) → {h' : _} →
     get (insertMany t l h.balanced).1 k' h' = v := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany] using List.getValue_insertListConst_of_mem
 
 theorem get_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
-    {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v : β}
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) {h'} :
+    {l : List (α × β)} {k k' : α} : (k_beq : compare k k' = .eq) → {v : β} →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) → (mem : ⟨k, v⟩ ∈ l) → {h' : _} →
     get (insertMany! t l).1 k' h' = v := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany!] using List.getValue_insertListConst_of_mem
 
 theorem get!_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
@@ -2323,17 +2264,15 @@ theorem get!_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [Lawfu
   simp_to_model [Const.insertMany!] using List.getValue!_insertListConst_of_contains_eq_false
 
 theorem get!_insertMany_list_of_mem [TransOrd α] [Inhabited β] (h : t.WF)
-    {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v : β}
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
+    {l : List (α × β)} {k k' : α} {v : β} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) → (mem : ⟨k, v⟩ ∈ l) →
     get! (insertMany t l h.balanced).1 k' = v := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany] using List.getValue!_insertListConst_of_mem
 
 theorem get!_insertMany!_list_of_mem [TransOrd α] [Inhabited β] (h : t.WF)
-    {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v : β}
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
+    {l : List (α × β)} {k k' : α} {v : β} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) → (mem : ⟨k, v⟩ ∈ l) →
     get! (insertMany! t l).1 k' = v := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany!] using List.getValue!_insertListConst_of_mem
 
 theorem getD_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
@@ -2349,17 +2288,15 @@ theorem getD_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [Lawfu
   simp_to_model [Const.insertMany!] using List.getValueD_insertListConst_of_contains_eq_false
 
 theorem getD_insertMany_list_of_mem [TransOrd α] (h : t.WF)
-    {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v fallback : β}
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
+    {l : List (α × β)} {k k' : α} {v fallback : β} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) → (mem : ⟨k, v⟩ ∈ l) →
     getD (insertMany t l h.balanced).1 k' fallback = v := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany] using List.getValueD_insertListConst_of_mem
 
 theorem getD_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
-    {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v fallback : β}
-    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
+    {l : List (α × β)} {k k' : α} {v fallback : β} : (k_beq : compare k k' = .eq) →
+    (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) → (mem : ⟨k, v⟩ ∈ l) →
     getD (insertMany! t l).1 k' fallback = v := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany!] using List.getValueD_insertListConst_of_mem
 
 variable {t : Impl α Unit}
@@ -2420,45 +2357,37 @@ theorem mem_of_mem_insertManyIfNewUnit!_list [TransOrd α] [BEq α] [LawfulBEqOr
 theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false [TransOrd α] [BEq α]
     [LawfulBEqOrd α] (h : t.WF) {l : List α} {k : α} :
     ¬ k ∈ t → l.contains k = false → getKey? (insertManyIfNewUnit t l h.balanced).1 k = none := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [Const.insertManyIfNewUnit] using
     List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
 
 theorem getKey?_insertManyIfNewUnit!_list_of_not_mem_of_contains_eq_false [TransOrd α] [BEq α]
     [LawfulBEqOrd α] (h : t.WF) {l : List α} {k : α} :
     ¬ k ∈ t → l.contains k = false → getKey? (insertManyIfNewUnit! t l).1 k = none := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [Const.insertManyIfNewUnit!] using
     List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
 
 theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_mem [TransOrd α]
-    (h : t.WF) {l : List α} {k k' : α} (k_beq : compare k k' = .eq) :
+    (h : t.WF) {l : List α} {k k' : α} : (k_beq : compare k k' = .eq) →
     ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKey? (insertManyIfNewUnit t l h.balanced).1 k' = some k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
-  rw [compare_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit] using
     List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_mem
 
 theorem getKey?_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
-    (h : t.WF) {l : List α} {k k' : α} (k_beq : compare k k' = .eq) :
+    (h : t.WF) {l : List α} {k k' : α} : (k_beq : compare k k' = .eq) →
     ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKey? (insertManyIfNewUnit! t l).1 k' = some k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
-  rw [compare_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit!] using
     List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_mem
 
 theorem getKey?_insertManyIfNewUnit_list_of_mem [TransOrd α]
     (h : t.WF) {l : List α} {k : α} :
     k ∈ t → getKey? (insertManyIfNewUnit t l h.balanced).1 k = getKey? t k := by
-  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit] using List.getKey?_insertListIfNewUnit_of_contains
 
 theorem getKey?_insertManyIfNewUnit!_list_of_mem [TransOrd α]
     (h : t.WF) {l : List α} {k : α} :
     k ∈ t → getKey? (insertManyIfNewUnit! t l).1 k = getKey? t k := by
-  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit!] using List.getKey?_insertListIfNewUnit_of_contains
 
 theorem getKey_insertManyIfNewUnit_list_of_mem [TransOrd α]
@@ -2473,21 +2402,17 @@ theorem getKey_insertManyIfNewUnit!_list_of_mem [TransOrd α]
 
 theorem getKey_insertManyIfNewUnit_list_of_not_mem_of_mem [TransOrd α]
     (h : t.WF) {l : List α}
-    {k k' : α} (k_beq : compare k k' = .eq) {h'} :
+    {k k' : α} : (k_beq : compare k k' = .eq) → {h' : _} →
     ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKey (insertManyIfNewUnit t l h.balanced).1 k' h' = k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
-  rw [compare_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit] using
     List.getKey_insertListIfNewUnit_of_contains_eq_false_of_mem
 
 theorem getKey_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
     (h : t.WF) {l : List α}
-    {k k' : α} (k_beq : compare k k' = .eq) {h'} :
+    {k k' : α} : (k_beq : compare k k' = .eq) → {h' : _} →
     ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKey (insertManyIfNewUnit! t l).1 k' h' = k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
-  rw [compare_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit!] using
     List.getKey_insertListIfNewUnit_of_contains_eq_false_of_mem
 
@@ -2505,7 +2430,6 @@ theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false [BEq α
     [TransOrd α] [Inhabited α] (h : t.WF) {l : List α} {k : α} :
     ¬ k ∈ t → l.contains k = false →
       getKey! (insertManyIfNewUnit t l h.balanced).1 k = default := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [Const.insertManyIfNewUnit] using
     List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
 
@@ -2513,100 +2437,81 @@ theorem getKey!_insertManyIfNewUnit!_list_of_not_mem_of_contains_eq_false [BEq �
     [TransOrd α] [Inhabited α] (h : t.WF) {l : List α} {k : α} :
     ¬ k ∈ t → l.contains k = false →
       getKey! (insertManyIfNewUnit! t l).1 k = default := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [Const.insertManyIfNewUnit!] using
     List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
 
 theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem [TransOrd α]
-    [Inhabited α] (h : t.WF) {l : List α} {k k' : α} (k_beq : compare k k' = .eq) :
+    [Inhabited α] (h : t.WF) {l : List α} {k k' : α} : (k_beq : compare k k' = .eq) →
     ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKey! (insertManyIfNewUnit t l h.balanced).1 k' = k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
-  rw [compare_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit] using
     List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_mem
 
 theorem getKey!_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
-    [Inhabited α] (h : t.WF) {l : List α} {k k' : α} (k_beq : compare k k' = .eq) :
+    [Inhabited α] (h : t.WF) {l : List α} {k k' : α} : (k_beq : compare k k' = .eq) →
     ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKey! (insertManyIfNewUnit! t l).1 k' = k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
-  rw [compare_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit!] using
     List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_mem
 
 theorem getKey!_insertManyIfNewUnit_list_of_mem [TransOrd α]
     [Inhabited α] (h : t.WF) {l : List α} {k : α} :
     k ∈ t → getKey! (insertManyIfNewUnit t l h.balanced).1 k = getKey! t k := by
-  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit] using List.getKey!_insertListIfNewUnit_of_contains
 
 theorem getKey!_insertManyIfNewUnit!_list_of_mem [TransOrd α]
     [Inhabited α] (h : t.WF) {l : List α} {k : α} :
     k ∈ t → getKey! (insertManyIfNewUnit! t l).1 k = getKey! t k := by
-  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit!] using List.getKey!_insertListIfNewUnit_of_contains
 
 theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqOrd α]
     [TransOrd α] (h : t.WF) {l : List α} {k fallback : α} :
     ¬ k ∈ t → l.contains k = false → getKeyD (insertManyIfNewUnit t l h.balanced).1 k fallback = fallback := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [Const.insertManyIfNewUnit] using
     List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
 
 theorem getKeyD_insertManyIfNewUnit!_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqOrd α]
     [TransOrd α] (h : t.WF) {l : List α} {k fallback : α} :
     ¬ k ∈ t → l.contains k = false → getKeyD (insertManyIfNewUnit! t l).1 k fallback = fallback := by
-  simp only [mem_iff_contains, Bool.not_eq_true]
   simp_to_model [Const.insertManyIfNewUnit!] using
     List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
 
 theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_mem [TransOrd α]
-    (h : t.WF) {l : List α} {k k' fallback : α} (k_beq : compare k k' = .eq) :
+    (h : t.WF) {l : List α} {k k' fallback : α} : (k_beq : compare k k' = .eq) →
     ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKeyD (insertManyIfNewUnit t l h.balanced).1 k' fallback = k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
-  rw [compare_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit] using
     List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_mem
 
 theorem getKeyD_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
-    (h : t.WF) {l : List α} {k k' fallback : α} (k_beq : compare k k' = .eq) :
+    (h : t.WF) {l : List α} {k k' fallback : α} : (k_beq : compare k k' = .eq) →
     ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKeyD (insertManyIfNewUnit! t l).1 k' fallback = k := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
-  rw [compare_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit!] using
     List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_mem
 
 theorem getKeyD_insertManyIfNewUnit_list_of_mem [TransOrd α]
     (h : t.WF) {l : List α} {k fallback : α} :
     k ∈ t → getKeyD (insertManyIfNewUnit t l h.balanced).1 k fallback = getKeyD t k fallback := by
-  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit] using List.getKeyD_insertListIfNewUnit_of_contains
 
 theorem getKeyD_insertManyIfNewUnit!_list_of_mem [TransOrd α]
     (h : t.WF) {l : List α} {k fallback : α} :
     k ∈ t → getKeyD (insertManyIfNewUnit! t l).1 k fallback = getKeyD t k fallback := by
-  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit!] using List.getKeyD_insertListIfNewUnit_of_contains
 
 theorem size_insertManyIfNewUnit_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
-    {l : List α}
-    (distinct : l.Pairwise (fun a b => ¬ compare a b = .eq)) :
+    {l : List α} :
+    (distinct : l.Pairwise (fun a b => ¬ compare a b = .eq)) →
     (∀ (a : α), a ∈ t → l.contains a = false) →
     (insertManyIfNewUnit t l h.balanced).1.size = t.size + l.length := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct
-  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit] using List.length_insertListIfNewUnit
 
 theorem size_insertManyIfNewUnit!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
-    {l : List α}
-    (distinct : l.Pairwise (fun a b => ¬ compare a b = .eq)) :
+    {l : List α} :
+    (distinct : l.Pairwise (fun a b => ¬ compare a b = .eq)) →
     (∀ (a : α), a ∈ t → l.contains a = false) →
     (insertManyIfNewUnit! t l).1.size = t.size + l.length := by
-  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct
-  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit!] using List.length_insertListIfNewUnit
 
 theorem size_le_size_insertManyIfNewUnit_list [TransOrd α] (h : t.WF)
@@ -2643,13 +2548,11 @@ theorem get?_insertManyIfNewUnit_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (
     {l : List α} {k : α} :
     get? (insertManyIfNewUnit t l h.balanced).1 k =
       if k ∈ t ∨ l.contains k then some () else none := by
-  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit] using List.getValue?_insertListIfNewUnit
 
 theorem get?_insertManyIfNewUnit!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List α} {k : α} :
     get? (insertManyIfNewUnit! t l).1 k = if k ∈ t ∨ l.contains k then some () else none := by
-  simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit!] using List.getValue?_insertListIfNewUnit
 
 theorem get_insertManyIfNewUnit_list (h : t.WF) {l : List α} {k : α} {h'} :

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -1692,57 +1692,58 @@ theorem insertMany!_cons {l : List ((a : α) × β a)} {k : α} {v : β k} :
   · simp
 
 @[simp]
-theorem contains_insertMany_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+theorem contains_insertMany_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} :
     (t.insertMany l h.balanced).1.contains k = (t.contains k || (l.map Sigma.fst).contains k) := by
   simp_to_model [insertMany] using List.containsKey_insertList
 
 @[simp]
-theorem mem_insertMany_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+theorem mem_insertMany_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} :
     k ∈ (t.insertMany l h.balanced).1 ↔ k ∈ t ∨ (l.map Sigma.fst).contains k := by
   simp [mem_iff_contains, contains_insertMany_list h]
 
 @[simp]
-theorem contains_insertMany!_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+theorem contains_insertMany!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} :
     (t.insertMany! l).1.contains k = (t.contains k || (l.map Sigma.fst).contains k) := by
   simp_to_model [insertMany!] using List.containsKey_insertList
 
 @[simp]
-theorem mem_insertMany!_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+theorem mem_insertMany!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} :
     k ∈ (t.insertMany! l).1 ↔ k ∈ t ∨ (l.map Sigma.fst).contains k := by
   simp [mem_iff_contains, contains_insertMany!_list h]
 
-theorem contains_of_contains_insertMany_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+theorem contains_of_contains_insertMany_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} :
-    (t.insertMany l h.balanced).1.contains k → (l.map Sigma.fst).contains k = false → t.contains k := by
+    (t.insertMany l h.balanced).1.contains k →
+      (l.map Sigma.fst).contains k = false → t.contains k := by
   simp_to_model [insertMany] using List.containsKey_of_containsKey_insertList
 
-theorem mem_of_mem_insertMany_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+theorem mem_of_mem_insertMany_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} :
     k ∈ (t.insertMany l h.balanced).1 → (l.map Sigma.fst).contains k = false → k ∈ t := by
   simpa [mem_iff_contains] using contains_of_contains_insertMany_list h
 
-theorem contains_of_contains_insertMany!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem contains_of_contains_insertMany!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} :
     (t.insertMany! l).1.contains k → (l.map Sigma.fst).contains k = false → t.contains k := by
   simp_to_model [insertMany!] using List.containsKey_of_containsKey_insertList
 
-theorem mem_of_mem_insertMany!_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+theorem mem_of_mem_insertMany!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} :
     k ∈ (t.insertMany! l).1 → (l.map Sigma.fst).contains k = false → k ∈ t := by
   simpa [mem_iff_contains] using contains_of_contains_insertMany!_list h
 
-theorem get?_insertMany_list_of_contains_eq_false [BEq α] [TransOrd α] [LawfulEqOrd α] [LawfulBEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k : α}
+theorem get?_insertMany_list_of_contains_eq_false [TransOrd α] [LawfulEqOrd α] [BEq α]
+    [LawfulBEqOrd α] (h : t.WF) {l : List ((a : α) × β a)} {k : α}
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l h.balanced).1.get? k = t.get? k := by
   simp_to_model [insertMany] using List.getValueCast?_insertList_of_contains_eq_false
 
-theorem get?_insertMany!_list_of_contains_eq_false [BEq α] [TransOrd α] [LawfulEqOrd α] [LawfulBEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k : α}
+theorem get?_insertMany!_list_of_contains_eq_false [TransOrd α] [LawfulEqOrd α] [BEq α]
+    [LawfulBEqOrd α] (h : t.WF) {l : List ((a : α) × β a)} {k : α}
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany! l).1.get? k = t.get? k := by
   simp_to_model [insertMany!] using List.getValueCast?_insertList_of_contains_eq_false
@@ -1751,12 +1752,11 @@ theorem get?_insertMany_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k}
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : ⟨k, v⟩ ∈ l) :
-    (t.insertMany l h.balanced).1.get? k' = some (cast (by congr; apply compare_eq_iff_eq.mp k_beq) v) := by
-  have := h.ordered.distinctKeys
-  revert mem distinct
-  simp only [← beq_iff, Bool.not_eq_true]
-  revert this k_beq
-  simp_to_model [insertMany] using List.getValueCast?_insertList_of_mem (toInsert := l) (k := k) (v := v) (k' := k')
+    (t.insertMany l h.balanced).1.get? k' =
+      some (cast (by congr; apply compare_eq_iff_eq.mp k_beq) v) := by
+  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  rw [compare_eq_eq_iff_beq] at k_beq
+  simp_to_model [insertMany] using List.getValueCast?_insertList_of_mem
 
 theorem get?_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k}
@@ -1765,9 +1765,9 @@ theorem get?_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
     (t.insertMany! l).1.get? k' = some (cast (by congr; apply compare_eq_iff_eq.mp k_beq) v) := by
   simp only [← beq_iff, Bool.not_eq_true] at distinct
   rw [compare_eq_eq_iff_beq] at k_beq
-  simp_to_model [insertMany!] using List.getValueCast?_insertList_of_mem (toInsert := l) (k := k) (v := v) (k' := k')
+  simp_to_model [insertMany!] using List.getValueCast?_insertList_of_mem
 
-theorem get_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
+theorem get_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
     [LawfulEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α}
     (contains : (l.map Sigma.fst).contains k = false)
@@ -1776,7 +1776,7 @@ theorem get_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [Tra
     t.get k (contains_of_contains_insertMany_list h h' contains) := by
   simp_to_model [insertMany] using List.getValueCast_insertList_of_contains_eq_false
 
-theorem get_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
+theorem get_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
     [LawfulEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α}
     (contains : (l.map Sigma.fst).contains k = false)
@@ -1790,7 +1790,8 @@ theorem get_insertMany_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : ⟨k, v⟩ ∈ l)
     {h'} :
-    (t.insertMany l h.balanced).1.get k' h' = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
+    (t.insertMany l h.balanced).1.get k' h' =
+      cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
   simp only [← beq_iff, Bool.not_eq_true] at distinct
   rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany] using List.getValueCast_insertList_of_mem
@@ -1805,15 +1806,15 @@ theorem get_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
   rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany!] using List.getValueCast_insertList_of_mem
 
-theorem get!_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
+theorem get!_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
     [LawfulEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} [Inhabited (β k)]
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l h.balanced).1.get! k = t.get! k := by
   simp_to_model [insertMany] using List.getValueCast!_insertList_of_contains_eq_false
 
-theorem get!_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [LawfulEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k : α} [Inhabited (β k)]
+theorem get!_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    [LawfulEqOrd α] (h : t.WF) {l : List ((a : α) × β a)} {k : α} [Inhabited (β k)]
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany! l).1.get! k = t.get! k := by
   simp_to_model [insertMany!] using List.getValueCast!_insertList_of_contains_eq_false
@@ -1822,7 +1823,8 @@ theorem get!_insertMany_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k} [Inhabited (β k')]
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : ⟨k, v⟩ ∈ l) :
-    (t.insertMany l h.balanced).1.get! k' = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
+    (t.insertMany l h.balanced).1.get! k' =
+      cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
   simp only [← beq_iff, Bool.not_eq_true] at distinct
   rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany] using List.getValueCast!_insertList_of_mem
@@ -1836,14 +1838,14 @@ theorem get!_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
   rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany!] using List.getValueCast!_insertList_of_mem
 
-theorem getD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [LawfulEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k : α} {fallback : β k}
+theorem getD_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    [LawfulEqOrd α] (h : t.WF) {l : List ((a : α) × β a)} {k : α} {fallback : β k}
     (contains_eq_false : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l h.balanced).1.getD k fallback = t.getD k fallback := by
   simp_to_model [insertMany] using List.getValueCastD_insertList_of_contains_eq_false
 
-theorem getD_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [LawfulEqOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k : α} {fallback : β k}
+theorem getD_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    [LawfulEqOrd α] (h : t.WF) {l : List ((a : α) × β a)} {k : α} {fallback : β k}
     (contains_eq_false : (l.map Sigma.fst).contains k = false) :
     (t.insertMany! l).1.getD k fallback = t.getD k fallback := by
   simp_to_model [insertMany!] using List.getValueCastD_insertList_of_contains_eq_false
@@ -1852,7 +1854,8 @@ theorem getD_insertMany_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k} {fallback : β k'}
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : ⟨k, v⟩ ∈ l) :
-    (t.insertMany l h.balanced).1.getD k' fallback = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
+    (t.insertMany l h.balanced).1.getD k' fallback =
+      cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
   simp only [← beq_iff, Bool.not_eq_true] at distinct
   rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany] using List.getValueCastD_insertList_of_mem
@@ -1866,14 +1869,14 @@ theorem getD_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
   rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany!] using List.getValueCastD_insertList_of_mem
 
-theorem getKey?_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k : α}
+theorem getKey?_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    (h : t.WF) {l : List ((a : α) × β a)} {k : α}
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l h.balanced).1.getKey? k = t.getKey? k := by
   simp_to_model [insertMany] using List.getKey?_insertList_of_contains_eq_false
 
-theorem getKey?_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k : α}
+theorem getKey?_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    (h : t.WF) {l : List ((a : α) × β a)} {k : α}
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany! l).1.getKey? k = t.getKey? k := by
   simp_to_model [insertMany!] using List.getKey?_insertList_of_contains_eq_false
@@ -1898,7 +1901,7 @@ theorem getKey?_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
   rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany!] using List.getKey?_insertList_of_mem
 
-theorem getKey_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem getKey_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α}
     (h₁ : (l.map Sigma.fst).contains k = false)
     {h'} :
@@ -1906,8 +1909,8 @@ theorem getKey_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [
     t.getKey k (contains_of_contains_insertMany_list h h' h₁) := by
   simp_to_model [insertMany] using List.getKey_insertList_of_contains_eq_false
 
-theorem getKey_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k : α}
+theorem getKey_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    (h : t.WF) {l : List ((a : α) × β a)} {k : α}
     (h₁ : (l.map Sigma.fst).contains k = false)
     {h'} :
     (t.insertMany! l).1.getKey k h' =
@@ -1936,14 +1939,14 @@ theorem getKey_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
   rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany!] using List.getKey_insertList_of_mem
 
-theorem getKey!_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [Inhabited α]
-    (h : t.WF) {l : List ((a : α) × β a)} {k : α}
+theorem getKey!_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    [Inhabited α] (h : t.WF) {l : List ((a : α) × β a)} {k : α}
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l h.balanced).1.getKey! k = t.getKey! k := by
   simp_to_model [insertMany] using List.getKey!_insertList_of_contains_eq_false
 
-theorem getKey!_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [Inhabited α]
-    (h : t.WF) {l : List ((a : α) × β a)} {k : α}
+theorem getKey!_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    [Inhabited α] (h : t.WF) {l : List ((a : α) × β a)} {k : α}
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany! l).1.getKey! k = t.getKey! k := by
   simp_to_model [insertMany!] using List.getKey!_insertList_of_contains_eq_false
@@ -1968,14 +1971,14 @@ theorem getKey!_insertMany!_list_of_mem [TransOrd α] [Inhabited α] (h : t.WF)
   rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany!] using List.getKey!_insertList_of_mem
 
-theorem getKeyD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k fallback : α}
+theorem getKeyD_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    (h : t.WF) {l : List ((a : α) × β a)} {k fallback : α}
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l h.balanced).1.getKeyD k fallback = t.getKeyD k fallback := by
   simp_to_model [insertMany] using List.getKeyD_insertList_of_contains_eq_false
 
-theorem getKeyD_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
-    {l : List ((a : α) × β a)} {k fallback : α}
+theorem getKeyD_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    (h : t.WF) {l : List ((a : α) × β a)} {k fallback : α}
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany! l).1.getKeyD k fallback = t.getKeyD k fallback := by
   simp_to_model [insertMany!] using List.getKeyD_insertList_of_contains_eq_false
@@ -2000,14 +2003,14 @@ theorem getKeyD_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
   rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany!] using List.getKeyD_insertList_of_mem
 
-theorem size_insertMany_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem size_insertMany_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) :
     (∀ (a : α), t.contains a → (l.map Sigma.fst).contains a = false) →
     (t.insertMany l h.balanced).1.size = t.size + l.length := by
   simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true] at distinct
   simp_to_model [insertMany] using List.length_insertList
 
-theorem size_insertMany!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem size_insertMany!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) :
     (∀ (a : α), t.contains a → (l.map Sigma.fst).contains a = false) →
     (t.insertMany! l).1.size = t.size + l.length := by
@@ -2069,57 +2072,59 @@ theorem insertMany!_cons {l : List (α × β)} {k : α} {v : β} :
   · simp
 
 @[simp]
-theorem contains_insertMany_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem contains_insertMany_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List (α × β)} {k : α} :
-    (Const.insertMany t l h.balanced).1.contains k = (t.contains k || (l.map Prod.fst).contains k) := by
+    (Const.insertMany t l h.balanced).1.contains k =
+      (t.contains k || (l.map Prod.fst).contains k) := by
   simp_to_model [Const.insertMany] using List.containsKey_insertListConst
 
 @[simp]
-theorem contains_insertMany!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem contains_insertMany!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List (α × β)} {k : α} :
     (Const.insertMany! t l).1.contains k = (t.contains k || (l.map Prod.fst).contains k) := by
   simp_to_model [Const.insertMany!] using List.containsKey_insertListConst
 
 @[simp]
-theorem mem_insertMany_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+theorem mem_insertMany_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List (α × β)} {k : α} :
     k ∈ (insertMany t l h.balanced).1 ↔ k ∈ t ∨ (l.map Prod.fst).contains k := by
   simp [mem_iff_contains, contains_insertMany_list h]
 
 @[simp]
-theorem mem_insertMany!_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+theorem mem_insertMany!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List (α × β)} {k : α} :
     k ∈ (insertMany! t l).1 ↔ k ∈ t ∨ (l.map Prod.fst).contains k := by
   simp [mem_iff_contains, contains_insertMany!_list h]
 
-theorem contains_of_contains_insertMany_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem contains_of_contains_insertMany_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List (α × β)} {k : α} :
-    (insertMany t l h.balanced).1.contains k → (l.map Prod.fst).contains k = false → t.contains k := by
+    (insertMany t l h.balanced).1.contains k →
+      (l.map Prod.fst).contains k = false → t.contains k := by
   simp_to_model [Const.insertMany] using List.containsKey_of_containsKey_insertListConst
 
-theorem mem_of_mem_insertMany_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+theorem mem_of_mem_insertMany_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List (α × β)} {k : α} :
     k ∈ (insertMany t l h.balanced).1 → (l.map Prod.fst).contains k = false → k ∈ t := by
   simpa [mem_iff_contains] using contains_of_contains_insertMany_list h
 
-theorem contains_of_contains_insertMany!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem contains_of_contains_insertMany!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List ( α × β )} {k : α} :
     (insertMany! t l).1.contains k → (l.map Prod.fst).contains k = false → t.contains k := by
   simp_to_model [Const.insertMany!] using List.containsKey_of_containsKey_insertListConst
 
-theorem mem_of_mem_insertMany!_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+theorem mem_of_mem_insertMany!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List (α × β)} {k : α} :
     k ∈ (insertMany! t l).1 → (l.map Prod.fst).contains k = false → k ∈ t := by
   simpa [mem_iff_contains] using contains_of_contains_insertMany!_list h
 
-theorem getKey?_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
-    {l : List (α × β)} {k : α}
+theorem getKey?_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    (h : t.WF) {l : List (α × β)} {k : α}
     (h' : (l.map Prod.fst).contains k = false) :
     (insertMany t l h.balanced).1.getKey? k = t.getKey? k := by
   simp_to_model [Const.insertMany] using List.getKey?_insertListConst_of_contains_eq_false
 
-theorem getKey?_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
-    {l : List (α × β)} {k : α}
+theorem getKey?_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    (h : t.WF) {l : List (α × β)} {k : α}
     (h' : (l.map Prod.fst).contains k = false) :
     (insertMany! t l).1.getKey? k = t.getKey? k := by
   simp_to_model [Const.insertMany!] using List.getKey?_insertListConst_of_contains_eq_false
@@ -2144,7 +2149,7 @@ theorem getKey?_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
   rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany!] using List.getKey?_insertListConst_of_mem
 
-theorem getKey_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem getKey_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List (α × β)} {k : α}
     (h₁ : (l.map Prod.fst).contains k = false)
     {h'} :
@@ -2152,8 +2157,8 @@ theorem getKey_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [
     t.getKey k (contains_of_contains_insertMany_list h h' h₁) := by
   simp_to_model [Const.insertMany] using List.getKey_insertListConst_of_contains_eq_false
 
-theorem getKey_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
-    {l : List (α × β)} {k : α}
+theorem getKey_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    (h : t.WF) {l : List (α × β)} {k : α}
     (h₁ : (l.map Prod.fst).contains k = false)
     {h'} :
     (insertMany! t l).1.getKey k h' =
@@ -2182,14 +2187,14 @@ theorem getKey_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
   rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany!] using List.getKey_insertListConst_of_mem
 
-theorem getKey!_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [Inhabited α]
-    (h : t.WF) {l : List (α × β)} {k : α}
+theorem getKey!_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    [Inhabited α] (h : t.WF) {l : List (α × β)} {k : α}
     (h' : (l.map Prod.fst).contains k = false) :
     (insertMany t l h.balanced).1.getKey! k = t.getKey! k := by
   simp_to_model [Const.insertMany] using List.getKey!_insertListConst_of_contains_eq_false
 
-theorem getKey!_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [Inhabited α]
-    (h : t.WF) {l : List (α × β)} {k : α}
+theorem getKey!_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    [Inhabited α] (h : t.WF) {l : List (α × β)} {k : α}
     (h' : (l.map Prod.fst).contains k = false) :
     (insertMany! t l).1.getKey! k = t.getKey! k := by
   simp_to_model [Const.insertMany!] using List.getKey!_insertListConst_of_contains_eq_false
@@ -2214,14 +2219,14 @@ theorem getKey!_insertMany!_list_of_mem [TransOrd α] [Inhabited α] (h : t.WF)
   rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany!] using List.getKey!_insertListConst_of_mem
 
-theorem getKeyD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
-    {l : List (α × β)} {k fallback : α}
+theorem getKeyD_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    (h : t.WF) {l : List (α × β)} {k fallback : α}
     (h' : (l.map Prod.fst).contains k = false) :
     (insertMany t l h.balanced).1.getKeyD k fallback = t.getKeyD k fallback := by
   simp_to_model [Const.insertMany] using List.getKeyD_insertListConst_of_contains_eq_false
 
-theorem getKeyD_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
-    {l : List (α × β)} {k fallback : α}
+theorem getKeyD_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    (h : t.WF) {l : List (α × β)} {k fallback : α}
     (h' : (l.map Prod.fst).contains k = false) :
     (insertMany! t l).1.getKeyD k fallback = t.getKeyD k fallback := by
   simp_to_model [Const.insertMany!] using List.getKeyD_insertListConst_of_contains_eq_false
@@ -2246,7 +2251,7 @@ theorem getKeyD_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
   rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany!] using List.getKeyD_insertListConst_of_mem
 
-theorem size_insertMany_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem size_insertMany_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List (α × β)}
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) :
     (∀ (a : α), t.contains a → (l.map Prod.fst).contains a = false) →
@@ -2254,7 +2259,7 @@ theorem size_insertMany_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
   simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true] at distinct
   simp_to_model [Const.insertMany] using List.length_insertListConst
 
-theorem size_insertMany!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem size_insertMany!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List (α × β)}
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) :
     (∀ (a : α), t.contains a → (l.map Prod.fst).contains a = false) →
@@ -2294,13 +2299,13 @@ theorem isEmpty_insertMany!_list [TransOrd α] (h : t.WF)
     (insertMany! t l).1.isEmpty = (t.isEmpty && l.isEmpty) := by
   simp_to_model [Const.insertMany!] using List.isEmpty_insertListConst
 
-theorem get?_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem get?_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List (α × β)} {k : α}
     (h' : (l.map Prod.fst).contains k = false) :
     get? (insertMany t l h.balanced).1 k = get? t k := by
   simp_to_model [Const.insertMany] using List.getValue?_insertListConst_of_contains_eq_false
 
-theorem get?_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem get?_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List (α × β)} {k : α}
     (h' : (l.map Prod.fst).contains k = false) :
     get? (insertMany! t l).1 k = get? t k := by
@@ -2322,14 +2327,15 @@ theorem get?_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
   rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany!] using List.getValue?_insertListConst_of_mem
 
-theorem get_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem get_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List (α × β)} {k : α}
     (h₁ : (l.map Prod.fst).contains k = false)
     {h'} :
-    get (insertMany t l h.balanced).1 k h' = get t k (contains_of_contains_insertMany_list h h' h₁) := by
+    get (insertMany t l h.balanced).1 k h' =
+      get t k (contains_of_contains_insertMany_list h h' h₁) := by
   simp_to_model [Const.insertMany] using List.getValue_insertListConst_of_contains_eq_false
 
-theorem get_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem get_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List (α × β)} {k : α}
     (h₁ : (l.map Prod.fst).contains k = false)
     {h'} :
@@ -2352,13 +2358,13 @@ theorem get_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
   rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany!] using List.getValue_insertListConst_of_mem
 
-theorem get!_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
+theorem get!_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
     [Inhabited β]  (h : t.WF) {l : List (α × β)} {k : α}
     (h' : (l.map Prod.fst).contains k = false) :
     get! (insertMany t l h.balanced).1 k = get! t k := by
   simp_to_model [Const.insertMany] using List.getValue!_insertListConst_of_contains_eq_false
 
-theorem get!_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
+theorem get!_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
     [Inhabited β]  (h : t.WF) {l : List (α × β)} {k : α}
     (h' : (l.map Prod.fst).contains k = false) :
     get! (insertMany! t l).1 k = get! t k := by
@@ -2380,13 +2386,13 @@ theorem get!_insertMany!_list_of_mem [TransOrd α] [Inhabited β] (h : t.WF)
   rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [Const.insertMany!] using List.getValue!_insertListConst_of_mem
 
-theorem getD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem getD_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List (α × β)} {k : α} {fallback : β}
     (h' : (l.map Prod.fst).contains k = false) :
     getD (insertMany t l h.balanced).1 k fallback = getD t k fallback := by
   simp_to_model [Const.insertMany] using List.getValueD_insertListConst_of_contains_eq_false
 
-theorem getD_insertMany!_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem getD_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List (α × β)} {k : α} {fallback : β}
     (h' : (l.map Prod.fst).contains k = false) :
     getD (insertMany! t l).1 k fallback = getD t k fallback := by
@@ -2430,60 +2436,62 @@ theorem insertManyIfNewUnit!_cons {l : List α} {k : α} :
   · simp
 
 @[simp]
-theorem contains_insertManyIfNewUnit_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem contains_insertManyIfNewUnit_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List α} {k : α} :
     (insertManyIfNewUnit t l h.balanced).1.contains k = (t.contains k || l.contains k) := by
   simp_to_model [Const.insertManyIfNewUnit] using List.containsKey_insertListIfNewUnit
 
 @[simp]
-theorem contains_insertManyIfNewUnit!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem contains_insertManyIfNewUnit!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List α} {k : α} :
     (insertManyIfNewUnit! t l).1.contains k = (t.contains k || l.contains k) := by
   simp_to_model [Const.insertManyIfNewUnit!] using List.containsKey_insertListIfNewUnit
 
 @[simp]
-theorem mem_insertManyIfNewUnit_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem mem_insertManyIfNewUnit_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List α} {k : α} :
     k ∈ (insertManyIfNewUnit t l h.balanced).1 ↔ k ∈ t ∨ l.contains k := by
   simp [mem_iff_contains, contains_insertManyIfNewUnit_list h]
 
 @[simp]
-theorem mem_insertManyIfNewUnit!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem mem_insertManyIfNewUnit!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List α} {k : α} :
     k ∈ (insertManyIfNewUnit! t l).1 ↔ k ∈ t ∨ l.contains k := by
   simp [mem_iff_contains, contains_insertManyIfNewUnit!_list h]
 
-theorem contains_of_contains_insertManyIfNewUnit_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
-    {l : List α} {k : α} (h₂ : l.contains k = false) :
+theorem contains_of_contains_insertManyIfNewUnit_list [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    (h : t.WF) {l : List α} {k : α} (h₂ : l.contains k = false) :
     (insertManyIfNewUnit t l h.balanced).1.contains k → t.contains k := by
   simp_to_model [Const.insertManyIfNewUnit] using List.containsKey_of_containsKey_insertListIfNewUnit
 
-theorem contains_of_contains_insertManyIfNewUnit!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
-    {l : List α} {k : α} (h₂ : l.contains k = false) :
+theorem contains_of_contains_insertManyIfNewUnit!_list [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    (h : t.WF) {l : List α} {k : α} (h₂ : l.contains k = false) :
     (insertManyIfNewUnit! t l).1.contains k → t.contains k := by
   simp_to_model [Const.insertManyIfNewUnit!] using List.containsKey_of_containsKey_insertListIfNewUnit
 
-theorem mem_of_mem_insertManyIfNewUnit_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem mem_of_mem_insertManyIfNewUnit_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List α} {k : α} (contains_eq_false : l.contains k = false) :
     k ∈ (insertManyIfNewUnit t l h.balanced).1 → k ∈ t := by
   simpa [mem_iff_contains] using contains_of_contains_insertManyIfNewUnit_list h contains_eq_false
 
-theorem mem_of_mem_insertManyIfNewUnit!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem mem_of_mem_insertManyIfNewUnit!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List α} {k : α} (contains_eq_false : l.contains k = false) :
     k ∈ (insertManyIfNewUnit! t l).1 → k ∈ t := by
   simpa [mem_iff_contains] using contains_of_contains_insertManyIfNewUnit!_list h contains_eq_false
 
-theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
-    (h : t.WF) {l : List α} {k : α} :
+theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false [TransOrd α] [BEq α]
+    [LawfulBEqOrd α] (h : t.WF) {l : List α} {k : α} :
     ¬ k ∈ t → l.contains k = false → getKey? (insertManyIfNewUnit t l h.balanced).1 k = none := by
   simp only [mem_iff_contains, Bool.not_eq_true]
-  simp_to_model [Const.insertManyIfNewUnit] using List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
+  simp_to_model [Const.insertManyIfNewUnit] using
+    List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
 
-theorem getKey?_insertManyIfNewUnit!_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
-    (h : t.WF) {l : List α} {k : α} :
+theorem getKey?_insertManyIfNewUnit!_list_of_not_mem_of_contains_eq_false [TransOrd α] [BEq α]
+    [LawfulBEqOrd α] (h : t.WF) {l : List α} {k : α} :
     ¬ k ∈ t → l.contains k = false → getKey? (insertManyIfNewUnit! t l).1 k = none := by
   simp only [mem_iff_contains, Bool.not_eq_true]
-  simp_to_model [Const.insertManyIfNewUnit!] using List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
+  simp_to_model [Const.insertManyIfNewUnit!] using
+    List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
 
 theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_mem [TransOrd α]
     (h : t.WF) {l : List α} {k k' : α} (k_beq : compare k k' = .eq) :
@@ -2491,7 +2499,8 @@ theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_mem [TransOrd α]
       getKey? (insertManyIfNewUnit t l h.balanced).1 k' = some k := by
   simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
   rw [compare_eq_eq_iff_beq] at k_beq
-  simp_to_model [Const.insertManyIfNewUnit] using List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_mem
+  simp_to_model [Const.insertManyIfNewUnit] using
+    List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_mem
 
 theorem getKey?_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
     (h : t.WF) {l : List α} {k k' : α} (k_beq : compare k k' = .eq) :
@@ -2499,7 +2508,8 @@ theorem getKey?_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
       getKey? (insertManyIfNewUnit! t l).1 k' = some k := by
   simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
   rw [compare_eq_eq_iff_beq] at k_beq
-  simp_to_model [Const.insertManyIfNewUnit!] using List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_mem
+  simp_to_model [Const.insertManyIfNewUnit!] using
+    List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_mem
 
 theorem getKey?_insertManyIfNewUnit_list_of_mem [TransOrd α]
     (h : t.WF) {l : List α} {k : α} :
@@ -2530,7 +2540,8 @@ theorem getKey_insertManyIfNewUnit_list_of_not_mem_of_mem [TransOrd α]
       getKey (insertManyIfNewUnit t l h.balanced).1 k' h' = k := by
   simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
   rw [compare_eq_eq_iff_beq] at k_beq
-  simp_to_model [Const.insertManyIfNewUnit] using List.getKey_insertListIfNewUnit_of_contains_eq_false_of_mem
+  simp_to_model [Const.insertManyIfNewUnit] using
+    List.getKey_insertListIfNewUnit_of_contains_eq_false_of_mem
 
 theorem getKey_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
     (h : t.WF) {l : List α}
@@ -2539,7 +2550,8 @@ theorem getKey_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
       getKey (insertManyIfNewUnit! t l).1 k' h' = k := by
   simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
   rw [compare_eq_eq_iff_beq] at k_beq
-  simp_to_model [Const.insertManyIfNewUnit!] using List.getKey_insertListIfNewUnit_of_contains_eq_false_of_mem
+  simp_to_model [Const.insertManyIfNewUnit!] using
+    List.getKey_insertListIfNewUnit_of_contains_eq_false_of_mem
 
 theorem getKey_insertManyIfNewUnit_list_mem_of_mem [TransOrd α]
     (h : t.WF) {l : List α} {k : α} (contains : k ∈ t) {h'} :
@@ -2556,14 +2568,16 @@ theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false [BEq α
     ¬ k ∈ t → l.contains k = false →
       getKey! (insertManyIfNewUnit t l h.balanced).1 k = default := by
   simp only [mem_iff_contains, Bool.not_eq_true]
-  simp_to_model [Const.insertManyIfNewUnit] using List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
+  simp_to_model [Const.insertManyIfNewUnit] using
+    List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
 
 theorem getKey!_insertManyIfNewUnit!_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqOrd α]
     [TransOrd α] [Inhabited α] (h : t.WF) {l : List α} {k : α} :
     ¬ k ∈ t → l.contains k = false →
       getKey! (insertManyIfNewUnit! t l).1 k = default := by
   simp only [mem_iff_contains, Bool.not_eq_true]
-  simp_to_model [Const.insertManyIfNewUnit!] using List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
+  simp_to_model [Const.insertManyIfNewUnit!] using
+    List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
 
 theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem [TransOrd α]
     [Inhabited α] (h : t.WF) {l : List α} {k k' : α} (k_beq : compare k k' = .eq) :
@@ -2571,7 +2585,8 @@ theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem [TransOrd α]
       getKey! (insertManyIfNewUnit t l h.balanced).1 k' = k := by
   simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
   rw [compare_eq_eq_iff_beq] at k_beq
-  simp_to_model [Const.insertManyIfNewUnit] using List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_mem
+  simp_to_model [Const.insertManyIfNewUnit] using
+    List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_mem
 
 theorem getKey!_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
     [Inhabited α] (h : t.WF) {l : List α} {k k' : α} (k_beq : compare k k' = .eq) :
@@ -2579,7 +2594,8 @@ theorem getKey!_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
       getKey! (insertManyIfNewUnit! t l).1 k' = k := by
   simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
   rw [compare_eq_eq_iff_beq] at k_beq
-  simp_to_model [Const.insertManyIfNewUnit!] using List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_mem
+  simp_to_model [Const.insertManyIfNewUnit!] using
+    List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_mem
 
 theorem getKey!_insertManyIfNewUnit_list_of_mem [TransOrd α]
     [Inhabited α] (h : t.WF) {l : List α} {k : α} :
@@ -2597,13 +2613,15 @@ theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false [BEq α
     [TransOrd α] (h : t.WF) {l : List α} {k fallback : α} :
     ¬ k ∈ t → l.contains k = false → getKeyD (insertManyIfNewUnit t l h.balanced).1 k fallback = fallback := by
   simp only [mem_iff_contains, Bool.not_eq_true]
-  simp_to_model [Const.insertManyIfNewUnit] using List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
+  simp_to_model [Const.insertManyIfNewUnit] using
+    List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
 
 theorem getKeyD_insertManyIfNewUnit!_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqOrd α]
     [TransOrd α] (h : t.WF) {l : List α} {k fallback : α} :
     ¬ k ∈ t → l.contains k = false → getKeyD (insertManyIfNewUnit! t l).1 k fallback = fallback := by
   simp only [mem_iff_contains, Bool.not_eq_true]
-  simp_to_model [Const.insertManyIfNewUnit!] using List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
+  simp_to_model [Const.insertManyIfNewUnit!] using
+    List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
 
 theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_mem [TransOrd α]
     (h : t.WF) {l : List α} {k k' fallback : α} (k_beq : compare k k' = .eq) :
@@ -2611,7 +2629,8 @@ theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_mem [TransOrd α]
       getKeyD (insertManyIfNewUnit t l h.balanced).1 k' fallback = k := by
   simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
   rw [compare_eq_eq_iff_beq] at k_beq
-  simp_to_model [Const.insertManyIfNewUnit] using List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_mem
+  simp_to_model [Const.insertManyIfNewUnit] using
+    List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_mem
 
 theorem getKeyD_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
     (h : t.WF) {l : List α} {k k' fallback : α} (k_beq : compare k k' = .eq) :
@@ -2619,7 +2638,8 @@ theorem getKeyD_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
       getKeyD (insertManyIfNewUnit! t l).1 k' fallback = k := by
   simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
   rw [compare_eq_eq_iff_beq] at k_beq
-  simp_to_model [Const.insertManyIfNewUnit!] using List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_mem
+  simp_to_model [Const.insertManyIfNewUnit!] using
+    List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_mem
 
 theorem getKeyD_insertManyIfNewUnit_list_of_mem [TransOrd α]
     (h : t.WF) {l : List α} {k fallback : α} :
@@ -2633,7 +2653,7 @@ theorem getKeyD_insertManyIfNewUnit!_list_of_mem [TransOrd α]
   simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit!] using List.getKeyD_insertListIfNewUnit_of_contains
 
-theorem size_insertManyIfNewUnit_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem size_insertManyIfNewUnit_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List α}
     (distinct : l.Pairwise (fun a b => ¬ compare a b = .eq)) :
     (∀ (a : α), a ∈ t → l.contains a = false) →
@@ -2642,7 +2662,7 @@ theorem size_insertManyIfNewUnit_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (
   simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit] using List.length_insertListIfNewUnit
 
-theorem size_insertManyIfNewUnit!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem size_insertManyIfNewUnit!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List α}
     (distinct : l.Pairwise (fun a b => ¬ compare a b = .eq)) :
     (∀ (a : α), a ∈ t → l.contains a = false) →
@@ -2681,17 +2701,16 @@ theorem isEmpty_insertManyIfNewUnit!_list [TransOrd α] (h : t.WF) {l : List α}
     (insertManyIfNewUnit! t l).1.isEmpty = (t.isEmpty && l.isEmpty) := by
   simp_to_model [Const.insertManyIfNewUnit!] using List.isEmpty_insertListIfNewUnit
 
-theorem get?_insertManyIfNewUnit_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem get?_insertManyIfNewUnit_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List α} {k : α} :
     get? (insertManyIfNewUnit t l h.balanced).1 k =
       if k ∈ t ∨ l.contains k then some () else none := by
   simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit] using List.getValue?_insertListIfNewUnit
 
-theorem get?_insertManyIfNewUnit!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
+theorem get?_insertManyIfNewUnit!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List α} {k : α} :
-    get? (insertManyIfNewUnit! t l).1 k =
-      if k ∈ t ∨ l.contains k then some () else none := by
+    get? (insertManyIfNewUnit! t l).1 k = if k ∈ t ∨ l.contains k then some () else none := by
   simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit!] using List.getValue?_insertListIfNewUnit
 
@@ -2750,16 +2769,17 @@ theorem insertMany_empty_list_cons {k : α} {v : β k}
 
 theorem insertMany_empty_list_cons_eq_insertMany! {k : α} {v : β k}
     {tl : List ((a : α) × (β a))} :
-    (insertMany empty (⟨k, v⟩ :: tl) WF.empty.balanced).1 = ((empty.insert! k v).insertMany! tl).1 := by
+    (insertMany empty (⟨k, v⟩ :: tl) WF.empty.balanced).1 =
+      ((empty.insert! k v).insertMany! tl).1 := by
   rw [insertMany_cons WF.empty, insertMany_eq_insertMany!, insert_eq_insert!]
 
-theorem contains_insertMany_empty_list [BEq α] [LawfulBEqOrd α] [TransOrd α]
+theorem contains_insertMany_empty_list [TransOrd α] [BEq α] [LawfulBEqOrd α]
     {l : List ((a : α) × β a)} {k : α} :
     (insertMany empty l WF.empty.balanced).1.contains k = (l.map Sigma.fst).contains k := by
   simp only [contains_insertMany_list WF.empty, contains_empty, Bool.false_or]
 
-theorem get?_insertMany_empty_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [LawfulEqOrd α]
-    {l : List ((a : α) × β a)} {k : α}
+theorem get?_insertMany_empty_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    [LawfulEqOrd α] {l : List ((a : α) × β a)} {k : α}
     (h : (l.map Sigma.fst).contains k = false) :
     (insertMany empty l WF.empty.balanced).1.get? k = none := by
   simp only [get?_insertMany_list_of_contains_eq_false WF.empty h, get?_empty]
@@ -2768,7 +2788,8 @@ theorem get?_insertMany_empty_list_of_mem [TransOrd α] [LawfulEqOrd α]
     {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k}
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : ⟨k, v⟩ ∈ l) :
-    (insertMany empty l WF.empty.balanced).1.get? k' = some (cast (by congr; apply compare_eq_iff_eq.mp k_beq) v) := by
+    (insertMany empty l WF.empty.balanced).1.get? k' =
+      some (cast (by congr; apply compare_eq_iff_eq.mp k_beq) v) := by
   rw [get?_insertMany_list_of_mem WF.empty k_beq distinct mem]
 
 theorem get_insertMany_empty_list_of_mem [TransOrd α] [LawfulEqOrd α]
@@ -2776,11 +2797,12 @@ theorem get_insertMany_empty_list_of_mem [TransOrd α] [LawfulEqOrd α]
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : ⟨k, v⟩ ∈ l)
     {h} :
-    (insertMany empty l WF.empty.balanced).1.get k' h = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
+    (insertMany empty l WF.empty.balanced).1.get k' h =
+      cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
   rw [get_insertMany_list_of_mem WF.empty k_beq distinct mem]
 
-theorem get!_insertMany_empty_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [LawfulEqOrd α]
-    {l : List ((a : α) × β a)} {k : α} [Inhabited (β k)]
+theorem get!_insertMany_empty_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    [LawfulEqOrd α] {l : List ((a : α) × β a)} {k : α} [Inhabited (β k)]
     (h : (l.map Sigma.fst).contains k = false) :
     (insertMany empty l WF.empty.balanced).1.get! k = default := by
   simp only [get!_insertMany_list_of_contains_eq_false WF.empty h]
@@ -2790,11 +2812,12 @@ theorem get!_insertMany_empty_list_of_mem [TransOrd α] [LawfulEqOrd α]
     {l : List ((a : α) × β a)} {k k' : α} (k_beq : compare k k' = .eq) {v : β k} [Inhabited (β k')]
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : ⟨k, v⟩ ∈ l) :
-    (insertMany empty l WF.empty.balanced).1.get! k' = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
+    (insertMany empty l WF.empty.balanced).1.get! k' =
+      cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
   rw [get!_insertMany_list_of_mem WF.empty k_beq distinct mem]
 
-theorem getD_insertMany_empty_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α] [LawfulEqOrd α]
-    {l : List ((a : α) × β a)} {k : α} {fallback : β k}
+theorem getD_insertMany_empty_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    [LawfulEqOrd α] {l : List ((a : α) × β a)} {k : α} {fallback : β k}
     (contains_eq_false : (l.map Sigma.fst).contains k = false) :
     (insertMany empty l WF.empty.balanced).1.getD k fallback = fallback := by
   rw [getD_insertMany_list_of_contains_eq_false WF.empty contains_eq_false]
@@ -2808,7 +2831,7 @@ theorem getD_insertMany_empty_list_of_mem [TransOrd α] [LawfulEqOrd α]
       cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
   rw [getD_insertMany_list_of_mem WF.empty k_beq distinct mem]
 
-theorem getKey?_insertMany_empty_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
+theorem getKey?_insertMany_empty_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
     {l : List ((a : α) × β a)} {k : α}
     (h : (l.map Sigma.fst).contains k = false) :
     (insertMany empty l WF.empty.balanced).1.getKey? k = none := by
@@ -2832,7 +2855,7 @@ theorem getKey_insertMany_empty_list_of_mem [TransOrd α]
     (insertMany empty l WF.empty.balanced).1.getKey k' h' = k := by
   rw [getKey_insertMany_list_of_mem WF.empty k_beq distinct mem]
 
-theorem getKey!_insertMany_empty_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
+theorem getKey!_insertMany_empty_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
     [Inhabited α] {l : List ((a : α) × β a)} {k : α}
     (h : (l.map Sigma.fst).contains k = false) :
     (insertMany empty l WF.empty.balanced).1.getKey! k = default := by
@@ -2847,7 +2870,7 @@ theorem getKey!_insertMany_empty_list_of_mem [TransOrd α] [Inhabited α]
     (insertMany empty l WF.empty.balanced).1.getKey! k' = k := by
   rw [getKey!_insertMany_list_of_mem WF.empty k_beq distinct mem]
 
-theorem getKeyD_insertMany_empty_list_of_contains_eq_false [BEq α] [LawfulBEqOrd α] [TransOrd α]
+theorem getKeyD_insertMany_empty_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
     {l : List ((a : α) × β a)} {k fallback : α}
     (h : (l.map Sigma.fst).contains k = false) :
     (insertMany empty l WF.empty.balanced).1.getKeyD k fallback = fallback := by

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -275,7 +275,7 @@ theorem mem_erase [TransOrd α] (h : t.WF) {k a : α} :
     using Bool.eq_iff_iff.mp <| contains_erase h
 
 theorem mem_erase! [TransOrd α] (h : t.WF) {k a : α} :
-    a ∈ t.erase! k ↔  compare k a ≠ .eq ∧ a ∈ t := by
+    a ∈ t.erase! k ↔ compare k a ≠ .eq ∧ a ∈ t := by
   simp [mem_iff_contains, contains_erase! h]
 
 theorem contains_of_contains_erase [TransOrd α] (h : t.WF) {k a : α} :
@@ -1483,7 +1483,7 @@ theorem length_keys [TransOrd α] (h : t.WF) :
   simp_to_model using List.length_keys_eq_length
 
 theorem isEmpty_keys :
-    t.keys.isEmpty = t.isEmpty  := by
+    t.keys.isEmpty = t.isEmpty := by
   simp_to_model using List.isEmpty_keys_eq_isEmpty
 
 theorem contains_keys [BEq α] [beqOrd : LawfulBEqOrd α] [TransOrd α] {k : α} (h : t.WF) :
@@ -2130,7 +2130,7 @@ theorem getKey?_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [La
   simp_to_model [Const.insertMany!] using List.getKey?_insertListConst_of_contains_eq_false
 
 theorem getKey?_insertMany_list_of_mem [TransOrd α] (h : t.WF)
-    {l : List  (α × β)}
+    {l : List (α × β)}
     {k k' : α} (k_beq : compare k k' = .eq)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Prod.fst) :
@@ -2140,7 +2140,7 @@ theorem getKey?_insertMany_list_of_mem [TransOrd α] (h : t.WF)
   simp_to_model [Const.insertMany] using List.getKey?_insertListConst_of_mem
 
 theorem getKey?_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
-    {l : List  (α × β)}
+    {l : List (α × β)}
     {k k' : α} (k_beq : compare k k' = .eq)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Prod.fst) :
@@ -2359,13 +2359,13 @@ theorem get_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
   simp_to_model [Const.insertMany!] using List.getValue_insertListConst_of_mem
 
 theorem get!_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
-    [Inhabited β]  (h : t.WF) {l : List (α × β)} {k : α}
+    [Inhabited β] (h : t.WF) {l : List (α × β)} {k : α}
     (h' : (l.map Prod.fst).contains k = false) :
     get! (insertMany t l h.balanced).1 k = get! t k := by
   simp_to_model [Const.insertMany] using List.getValue!_insertListConst_of_contains_eq_false
 
 theorem get!_insertMany!_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
-    [Inhabited β]  (h : t.WF) {l : List (α × β)} {k : α}
+    [Inhabited β] (h : t.WF) {l : List (α × β)} {k : α}
     (h' : (l.map Prod.fst).contains k = false) :
     get! (insertMany! t l).1 k = get! t k := by
   simp_to_model [Const.insertMany!] using List.getValue!_insertListConst_of_contains_eq_false
@@ -2599,13 +2599,13 @@ theorem getKey!_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
 
 theorem getKey!_insertManyIfNewUnit_list_of_mem [TransOrd α]
     [Inhabited α] (h : t.WF) {l : List α} {k : α} :
-    k ∈ t → getKey! (insertManyIfNewUnit t l h.balanced).1 k = getKey! t k  := by
+    k ∈ t → getKey! (insertManyIfNewUnit t l h.balanced).1 k = getKey! t k := by
   simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit] using List.getKey!_insertListIfNewUnit_of_contains
 
 theorem getKey!_insertManyIfNewUnit!_list_of_mem [TransOrd α]
     [Inhabited α] (h : t.WF) {l : List α} {k : α} :
-    k ∈ t → getKey! (insertManyIfNewUnit! t l).1 k = getKey! t k  := by
+    k ∈ t → getKey! (insertManyIfNewUnit! t l).1 k = getKey! t k := by
   simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit!] using List.getKey!_insertListIfNewUnit_of_contains
 

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -1676,20 +1676,11 @@ end monadic
 theorem insertMany_cons (h : t.WF) {l : List ((a : α) × β a)} {k : α} {v : β k} :
     (t.insertMany (⟨k, v⟩ :: l) h.balanced).1 =
       ((t.insert k v h.balanced).impl.insertMany l h.insert.balanced).1 := by
-  simp only [insertMany, Id.run, Id.pure_eq, Id.bind_eq, List.forIn_yield_eq_foldl, List.foldl_cons]
-  rw [← List.foldl_hom Subtype.val, ← List.foldl_hom Subtype.val]
-  · exact fun t e => t.insert! e.1 e.2
-  · simp [insert_eq_insert!]
-  · simp [insert_eq_insert!]
+  simp [insertMany_eq_foldl, insert_eq_insert!]
 
 theorem insertMany!_cons {l : List ((a : α) × β a)} {k : α} {v : β k} :
     (t.insertMany! (⟨k, v⟩ :: l)).1 = ((t.insert! k v).insertMany! l).1 := by
-  simp only [insertMany!, Id.run, Id.pure_eq, Id.bind_eq, List.forIn_yield_eq_foldl,
-    List.foldl_cons]
-  rw [← List.foldl_hom Subtype.val, ← List.foldl_hom Subtype.val]
-  · exact fun t e => t.insert! e.1 e.2
-  · simp
-  · simp
+  simp [insertMany!_eq_foldl]
 
 @[simp]
 theorem contains_insertMany_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -50,10 +50,8 @@ scoped macro "empty" : tactic => `(tactic| { intros; simp_all [List.isEmpty_iff]
 
 open Lean
 
-theorem compare_eq_eq_iff_beq {k a : α} : compare k a = .eq ↔ k == a := beq_iff_eq.symm
-
 private def helperLemmaNames : Array Name :=
-  #[``compare_eq_eq_iff_beq]
+  #[``compare_eq_iff_beq]
 
 private def queryNames : Array Name :=
   #[``isEmpty_eq_isEmpty, ``contains_eq_containsKey, ``size_eq_length,
@@ -1530,7 +1528,7 @@ theorem find?_toList_eq_none_iff_not_mem [TransOrd α] {k : α} (h : t.WF) :
 
 theorem distinct_keys_toList [TransOrd α] (h : t.WF) :
     t.toList.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq) := by
-  simp only [← beq_iff, Bool.not_eq_true]
+  simp only [compare_eq_iff_beq, Bool.not_eq_true]
   simp_to_model using List.pairwise_fst_eq_false
 
 namespace Const
@@ -1577,7 +1575,7 @@ theorem find?_toList_eq_none_iff_not_mem [TransOrd α] {k : α} (h : t.WF) :
 
 theorem distinct_keys_toList [TransOrd α] (h : t.WF) :
     (toList t).Pairwise (fun a b => ¬ compare a.1 b.1 = .eq) := by
-  simp only [← beq_iff, Bool.not_eq_true]
+  simp only [compare_eq_iff_beq, Bool.not_eq_true]
   simp_to_model using List.pairwise_fst_eq_false_map_toProd
 
 end Const
@@ -1745,8 +1743,7 @@ theorem get?_insertMany_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
     (mem : ⟨k, v⟩ ∈ l) :
     (t.insertMany l h.balanced).1.get? k' =
       some (cast (by congr; apply compare_eq_iff_eq.mp k_beq) v) := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany] using List.getValueCast?_insertList_of_mem
 
 theorem get?_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
@@ -1754,8 +1751,7 @@ theorem get?_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : ⟨k, v⟩ ∈ l) :
     (t.insertMany! l).1.get? k' = some (cast (by congr; apply compare_eq_iff_eq.mp k_beq) v) := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany!] using List.getValueCast?_insertList_of_mem
 
 theorem get_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
@@ -1783,8 +1779,7 @@ theorem get_insertMany_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
     {h'} :
     (t.insertMany l h.balanced).1.get k' h' =
       cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany] using List.getValueCast_insertList_of_mem
 
 theorem get_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
@@ -1793,8 +1788,7 @@ theorem get_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
     (mem : ⟨k, v⟩ ∈ l)
     {h'} :
     (t.insertMany! l).1.get k' h' = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany!] using List.getValueCast_insertList_of_mem
 
 theorem get!_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
@@ -1816,8 +1810,7 @@ theorem get!_insertMany_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
     (mem : ⟨k, v⟩ ∈ l) :
     (t.insertMany l h.balanced).1.get! k' =
       cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany] using List.getValueCast!_insertList_of_mem
 
 theorem get!_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
@@ -1825,8 +1818,7 @@ theorem get!_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : ⟨k, v⟩ ∈ l) :
     (t.insertMany! l).1.get! k' = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany!] using List.getValueCast!_insertList_of_mem
 
 theorem getD_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
@@ -1847,8 +1839,7 @@ theorem getD_insertMany_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
     (mem : ⟨k, v⟩ ∈ l) :
     (t.insertMany l h.balanced).1.getD k' fallback =
       cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany] using List.getValueCastD_insertList_of_mem
 
 theorem getD_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
@@ -1856,8 +1847,7 @@ theorem getD_insertMany!_list_of_mem [TransOrd α] [LawfulEqOrd α] (h : t.WF)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : ⟨k, v⟩ ∈ l) :
     (t.insertMany! l).1.getD k' fallback = cast (by congr; apply compare_eq_iff_eq.mp k_beq) v := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany!] using List.getValueCastD_insertList_of_mem
 
 theorem getKey?_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
@@ -1878,8 +1868,7 @@ theorem getKey?_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Sigma.fst) :
     (t.insertMany l h.balanced).1.getKey? k' = some k := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany] using List.getKey?_insertList_of_mem
 
 theorem getKey?_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
@@ -1888,8 +1877,7 @@ theorem getKey?_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Sigma.fst) :
     (t.insertMany! l).1.getKey? k' = some k := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany!] using List.getKey?_insertList_of_mem
 
 theorem getKey_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
@@ -1915,8 +1903,7 @@ theorem getKey_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     (mem : k ∈ l.map Sigma.fst)
     {h'} :
     (t.insertMany l h.balanced).1.getKey k' h' = k := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany] using List.getKey_insertList_of_mem
 
 theorem getKey_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
@@ -1926,8 +1913,7 @@ theorem getKey_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     (mem : k ∈ l.map Sigma.fst)
     {h'} :
     (t.insertMany! l).1.getKey k' h' = k := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany!] using List.getKey_insertList_of_mem
 
 theorem getKey!_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
@@ -1948,8 +1934,7 @@ theorem getKey!_insertMany_list_of_mem [TransOrd α] [Inhabited α] (h : t.WF)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Sigma.fst) :
     (t.insertMany l h.balanced).1.getKey! k' = k := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany] using List.getKey!_insertList_of_mem
 
 theorem getKey!_insertMany!_list_of_mem [TransOrd α] [Inhabited α] (h : t.WF)
@@ -1958,8 +1943,7 @@ theorem getKey!_insertMany!_list_of_mem [TransOrd α] [Inhabited α] (h : t.WF)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Sigma.fst) :
     (t.insertMany! l).1.getKey! k' = k := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany!] using List.getKey!_insertList_of_mem
 
 theorem getKeyD_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
@@ -1980,8 +1964,7 @@ theorem getKeyD_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Sigma.fst) :
     (t.insertMany l h.balanced).1.getKeyD k' fallback = k := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany] using List.getKeyD_insertList_of_mem
 
 theorem getKeyD_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
@@ -1990,22 +1973,21 @@ theorem getKeyD_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Sigma.fst) :
     (t.insertMany! l).1.getKeyD k' fallback = k := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [insertMany!] using List.getKeyD_insertList_of_mem
 
 theorem size_insertMany_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) :
     (∀ (a : α), t.contains a → (l.map Sigma.fst).contains a = false) →
     (t.insertMany l h.balanced).1.size = t.size + l.length := by
-  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true] at distinct
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct
   simp_to_model [insertMany] using List.length_insertList
 
 theorem size_insertMany!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) :
     (∀ (a : α), t.contains a → (l.map Sigma.fst).contains a = false) →
     (t.insertMany! l).1.size = t.size + l.length := by
-  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true] at distinct
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct
   simp_to_model [insertMany!] using List.length_insertList
 
 theorem size_le_size_insertMany_list [TransOrd α] (h : t.WF)
@@ -2047,20 +2029,11 @@ variable {β : Type v} {t : Impl α β}
 theorem insertMany_cons (h : t.WF) {l : List (α × β)} {k : α} {v : β} :
     (Const.insertMany t ((k, v) :: l) h.balanced).1 =
       (Const.insertMany (t.insert k v h.balanced).impl l h.insert.balanced).1 := by
-  simp only [insertMany, Id.run, Id.pure_eq, Id.bind_eq, List.forIn_yield_eq_foldl, List.foldl_cons]
-  rw [← List.foldl_hom Subtype.val, ← List.foldl_hom Subtype.val]
-  · exact fun t e => t.insert! e.1 e.2
-  · simp [insert_eq_insert!]
-  · simp [insert_eq_insert!]
+  simp [insertMany_eq_foldl, insert_eq_insert!]
 
 theorem insertMany!_cons {l : List (α × β)} {k : α} {v : β} :
     (Const.insertMany! t ((k, v) :: l)).1 = (Const.insertMany! (t.insert! k v) l).1 := by
-  simp only [insertMany!, Id.run, Id.pure_eq, Id.bind_eq, List.forIn_yield_eq_foldl,
-    List.foldl_cons]
-  rw [← List.foldl_hom Subtype.val, ← List.foldl_hom Subtype.val]
-  · exact fun t e => t.insert! e.1 e.2
-  · simp
-  · simp
+  simp [insertMany!_eq_foldl]
 
 @[simp]
 theorem contains_insertMany_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
@@ -2126,8 +2099,7 @@ theorem getKey?_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Prod.fst) :
     (insertMany t l h.balanced).1.getKey? k' = some k := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany] using List.getKey?_insertListConst_of_mem
 
 theorem getKey?_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
@@ -2136,8 +2108,7 @@ theorem getKey?_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Prod.fst) :
     (insertMany! t l).1.getKey? k' = some k := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany!] using List.getKey?_insertListConst_of_mem
 
 theorem getKey_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
@@ -2163,8 +2134,7 @@ theorem getKey_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     (mem : k ∈ l.map Prod.fst)
     {h'} :
     (insertMany t l h.balanced).1.getKey k' h' = k := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany] using List.getKey_insertListConst_of_mem
 
 theorem getKey_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
@@ -2174,8 +2144,7 @@ theorem getKey_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     (mem : k ∈ l.map Prod.fst)
     {h'} :
     (insertMany! t l).1.getKey k' h' = k := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany!] using List.getKey_insertListConst_of_mem
 
 theorem getKey!_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
@@ -2196,8 +2165,7 @@ theorem getKey!_insertMany_list_of_mem [TransOrd α] [Inhabited α] (h : t.WF)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Prod.fst) :
     (insertMany t l h.balanced).1.getKey! k' = k := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany] using List.getKey!_insertListConst_of_mem
 
 theorem getKey!_insertMany!_list_of_mem [TransOrd α] [Inhabited α] (h : t.WF)
@@ -2206,8 +2174,7 @@ theorem getKey!_insertMany!_list_of_mem [TransOrd α] [Inhabited α] (h : t.WF)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Prod.fst) :
     (insertMany! t l).1.getKey! k' = k := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany!] using List.getKey!_insertListConst_of_mem
 
 theorem getKeyD_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
@@ -2228,8 +2195,7 @@ theorem getKeyD_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Prod.fst) :
     (insertMany t l h.balanced).1.getKeyD k' fallback = k := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany] using List.getKeyD_insertListConst_of_mem
 
 theorem getKeyD_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
@@ -2238,8 +2204,7 @@ theorem getKeyD_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq))
     (mem : k ∈ l.map Prod.fst) :
     (insertMany! t l).1.getKeyD k' fallback = k := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany!] using List.getKeyD_insertListConst_of_mem
 
 theorem size_insertMany_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
@@ -2247,7 +2212,7 @@ theorem size_insertMany_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) :
     (∀ (a : α), t.contains a → (l.map Prod.fst).contains a = false) →
     (insertMany t l h.balanced).1.size = t.size + l.length := by
-  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true] at distinct
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct
   simp_to_model [Const.insertMany] using List.length_insertListConst
 
 theorem size_insertMany!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
@@ -2255,7 +2220,7 @@ theorem size_insertMany!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) :
     (∀ (a : α), t.contains a → (l.map Prod.fst).contains a = false) →
     (insertMany! t l).1.size = t.size + l.length := by
-  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true] at distinct
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct
   simp_to_model [Const.insertMany!] using List.length_insertListConst
 
 theorem size_le_size_insertMany_list [TransOrd α] (h : t.WF)
@@ -2306,16 +2271,14 @@ theorem get?_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v : β}
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
     get? (insertMany t l h.balanced).1 k' = v := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany] using List.getValue?_insertListConst_of_mem
 
 theorem get?_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v : β}
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
     get? (insertMany! t l).1 k' = v := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany!] using List.getValue?_insertListConst_of_mem
 
 theorem get_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
@@ -2337,16 +2300,14 @@ theorem get_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v : β}
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) {h'} :
     get (insertMany t l h.balanced).1 k' h' = v := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany] using List.getValue_insertListConst_of_mem
 
 theorem get_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v : β}
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) {h'} :
     get (insertMany! t l).1 k' h' = v := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany!] using List.getValue_insertListConst_of_mem
 
 theorem get!_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α]
@@ -2365,16 +2326,14 @@ theorem get!_insertMany_list_of_mem [TransOrd α] [Inhabited β] (h : t.WF)
     {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v : β}
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
     get! (insertMany t l h.balanced).1 k' = v := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany] using List.getValue!_insertListConst_of_mem
 
 theorem get!_insertMany!_list_of_mem [TransOrd α] [Inhabited β] (h : t.WF)
     {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v : β}
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
     get! (insertMany! t l).1 k' = v := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany!] using List.getValue!_insertListConst_of_mem
 
 theorem getD_insertMany_list_of_contains_eq_false [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
@@ -2393,16 +2352,14 @@ theorem getD_insertMany_list_of_mem [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v fallback : β}
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
     getD (insertMany t l h.balanced).1 k' fallback = v := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany] using List.getValueD_insertListConst_of_mem
 
 theorem getD_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k k' : α} (k_beq : compare k k' = .eq) {v fallback : β}
     (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
     getD (insertMany! t l).1 k' fallback = v := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct k_beq
   simp_to_model [Const.insertMany!] using List.getValueD_insertListConst_of_mem
 
 variable {t : Impl α Unit}
@@ -2410,21 +2367,11 @@ variable {t : Impl α Unit}
 theorem insertManyIfNewUnit_cons (h : t.WF) {l : List α} {k : α} :
     (insertManyIfNewUnit t (k :: l) h.balanced).1 =
       (insertManyIfNewUnit (t.insertIfNew k () h.balanced).impl l h.insertIfNew.balanced).1 := by
-  simp only [insertManyIfNewUnit, Id.run, Id.pure_eq, Id.bind_eq, List.forIn_yield_eq_foldl,
-    List.foldl_cons]
-  rw [← List.foldl_hom Subtype.val, ← List.foldl_hom Subtype.val]
-  · exact fun t e => t.insertIfNew! e ()
-  · simp [insertIfNew_eq_insertIfNew!]
-  · simp [insertIfNew_eq_insertIfNew!]
+  simp [insertManyIfNewUnit_eq_foldl, insertIfNew_eq_insertIfNew!]
 
 theorem insertManyIfNewUnit!_cons {l : List α} {k : α} :
     (insertManyIfNewUnit! t (k :: l)).1 = (insertManyIfNewUnit! (t.insertIfNew! k ()) l).1 := by
-  simp only [insertManyIfNewUnit!, Id.run, Id.pure_eq, Id.bind_eq, List.forIn_yield_eq_foldl,
-    List.foldl_cons]
-  rw [← List.foldl_hom Subtype.val, ← List.foldl_hom Subtype.val]
-  · exact fun t e => t.insertIfNew! e ()
-  · simp
-  · simp
+  simp [insertManyIfNewUnit!_eq_foldl]
 
 @[simp]
 theorem contains_insertManyIfNewUnit_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (h : t.WF)
@@ -2488,8 +2435,8 @@ theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_mem [TransOrd α]
     (h : t.WF) {l : List α} {k k' : α} (k_beq : compare k k' = .eq) :
     ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKey? (insertManyIfNewUnit t l h.balanced).1 k' = some k := by
-  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
+  rw [compare_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit] using
     List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_mem
 
@@ -2497,8 +2444,8 @@ theorem getKey?_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
     (h : t.WF) {l : List α} {k k' : α} (k_beq : compare k k' = .eq) :
     ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKey? (insertManyIfNewUnit! t l).1 k' = some k := by
-  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
+  rw [compare_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit!] using
     List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_mem
 
@@ -2529,8 +2476,8 @@ theorem getKey_insertManyIfNewUnit_list_of_not_mem_of_mem [TransOrd α]
     {k k' : α} (k_beq : compare k k' = .eq) {h'} :
     ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKey (insertManyIfNewUnit t l h.balanced).1 k' h' = k := by
-  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
+  rw [compare_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit] using
     List.getKey_insertListIfNewUnit_of_contains_eq_false_of_mem
 
@@ -2539,8 +2486,8 @@ theorem getKey_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
     {k k' : α} (k_beq : compare k k' = .eq) {h'} :
     ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKey (insertManyIfNewUnit! t l).1 k' h' = k := by
-  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
+  rw [compare_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit!] using
     List.getKey_insertListIfNewUnit_of_contains_eq_false_of_mem
 
@@ -2574,8 +2521,8 @@ theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem [TransOrd α]
     [Inhabited α] (h : t.WF) {l : List α} {k k' : α} (k_beq : compare k k' = .eq) :
     ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKey! (insertManyIfNewUnit t l h.balanced).1 k' = k := by
-  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
+  rw [compare_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit] using
     List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_mem
 
@@ -2583,8 +2530,8 @@ theorem getKey!_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
     [Inhabited α] (h : t.WF) {l : List α} {k k' : α} (k_beq : compare k k' = .eq) :
     ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKey! (insertManyIfNewUnit! t l).1 k' = k := by
-  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
+  rw [compare_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit!] using
     List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_mem
 
@@ -2618,8 +2565,8 @@ theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_mem [TransOrd α]
     (h : t.WF) {l : List α} {k k' fallback : α} (k_beq : compare k k' = .eq) :
     ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKeyD (insertManyIfNewUnit t l h.balanced).1 k' fallback = k := by
-  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
+  rw [compare_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit] using
     List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_mem
 
@@ -2627,8 +2574,8 @@ theorem getKeyD_insertManyIfNewUnit!_list_of_not_mem_of_mem [TransOrd α]
     (h : t.WF) {l : List α} {k k' fallback : α} (k_beq : compare k k' = .eq) :
     ¬ k ∈ t → l.Pairwise (fun a b => ¬ compare a b = .eq) → k ∈ l →
       getKeyD (insertManyIfNewUnit! t l).1 k' fallback = k := by
-  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
-  rw [compare_eq_eq_iff_beq] at k_beq
+  simp only [compare_eq_iff_beq, Bool.not_eq_true, mem_iff_contains]
+  rw [compare_eq_iff_beq] at k_beq
   simp_to_model [Const.insertManyIfNewUnit!] using
     List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_mem
 
@@ -2649,7 +2596,7 @@ theorem size_insertManyIfNewUnit_list [TransOrd α] [BEq α] [LawfulBEqOrd α] (
     (distinct : l.Pairwise (fun a b => ¬ compare a b = .eq)) :
     (∀ (a : α), a ∈ t → l.contains a = false) →
     (insertManyIfNewUnit t l h.balanced).1.size = t.size + l.length := by
-  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true] at distinct
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct
   simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit] using List.length_insertListIfNewUnit
 
@@ -2658,7 +2605,7 @@ theorem size_insertManyIfNewUnit!_list [TransOrd α] [BEq α] [LawfulBEqOrd α] 
     (distinct : l.Pairwise (fun a b => ¬ compare a b = .eq)) :
     (∀ (a : α), a ∈ t → l.contains a = false) →
     (insertManyIfNewUnit! t l).1.size = t.size + l.length := by
-  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true] at distinct
+  simp only [compare_eq_iff_beq, Bool.not_eq_true] at distinct
   simp only [mem_iff_contains]
   simp_to_model [Const.insertManyIfNewUnit!] using List.length_insertListIfNewUnit
 

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -72,7 +72,13 @@ private def modifyMap : Std.HashMap Name Name :=
      ⟨`insertIfNew, ``toListModel_insertIfNew⟩,
      ⟨`insertIfNew!, ``toListModel_insertIfNew!⟩,
      ⟨`erase, ``toListModel_erase⟩,
-     ⟨`erase!, ``toListModel_erase!⟩]
+     ⟨`erase!, ``toListModel_erase!⟩,
+     (`insertMany, ``toListModel_insertMany_list),
+     (`insertMany!, ``toListModel_insertMany!_list),
+     (`Const.insertMany, ``Const.toListModel_insertMany_list),
+     (`Const.insertMany!, ``Const.toListModel_insertMany!_list),
+     (`Const.insertManyIfNewUnit, ``Const.toListModel_insertManyIfNewUnit_list),
+     (`Const.insertManyIfNewUnit!, ``Const.toListModel_insertManyIfNewUnit!_list)]
 
 private def congrNames : MacroM (Array (TSyntax `term)) := do
   return #[← `(_root_.List.Perm.isEmpty_eq), ← `(containsKey_of_perm),
@@ -1664,5 +1670,609 @@ theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
 end Const
 
 end monadic
+
+@[simp]
+theorem insertMany_nil (h : t.WF) :
+    t.insertMany [] h.balanced = t := by
+  simp [insertMany, Id.run]
+
+@[simp]
+theorem insertMany!_nil :
+    t.insertMany! [] = t := by
+  simp [insertMany!, Id.run]
+
+@[simp]
+theorem insertMany_list_singleton {k : α} {v : β k} :
+    t.insertMany [⟨k, v⟩] = t.insert k v := by
+  simp [insertMany, Id.run]
+
+@[simp]
+theorem insertMany_list_singleton {k : α} {v : β k} :
+    t.insertMany [⟨k, v⟩] = t.insert k v := by
+  simp [insertMany, Id.run]
+
+theorem insertMany_cons {l : List ((a : α) × β a)} {k : α} {v : β k} :
+    (t.insertMany (⟨k, v⟩ :: l)).1 = ((t.insert k v).insertMany l).1 := by
+  simp only [insertMany_eq_insertListₘ]
+  cases l with
+  | nil => simp [insertListₘ]
+  | cons hd tl => simp [insertListₘ]
+
+@[simp]
+theorem contains_insertMany_list [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List ((a : α) × β a)} {k : α} :
+    (t.insertMany l).1.contains k = (t.contains k || (l.map Sigma.fst).contains k) := by
+  simp_to_model [insertMany] using List.containsKey_insertList
+
+theorem contains_of_contains_insertMany_list [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List ((a : α) × β a)} {k : α} :
+    (t.insertMany l).1.contains k → (l.map Sigma.fst).contains k = false → t.contains k := by
+  simp_to_model [insertMany] using List.containsKey_of_containsKey_insertList
+
+theorem get?_insertMany_list_of_contains_eq_false [LawfulBEq α] (h : t.1.WF)
+    {l : List ((a : α) × β a)} {k : α}
+    (h' : (l.map Sigma.fst).contains k = false) :
+    (t.insertMany l).1.get? k = t.get? k := by
+  simp_to_model [insertMany] using List.getValueCast?_insertList_of_contains_eq_false
+
+theorem get?_insertMany_list_of_mem [LawfulBEq α] (h : t.1.WF)
+    {l : List ((a : α) × β a)} {k k' : α} (k_beq : k == k') {v : β k}
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (t.insertMany l).1.get? k' = some (cast (by congr; apply LawfulBEq.eq_of_beq k_beq) v) := by
+  simp_to_model [insertMany] using List.getValueCast?_insertList_of_mem
+
+theorem get_insertMany_list_of_contains_eq_false [LawfulBEq α] (h : t.1.WF)
+    {l : List ((a : α) × β a)} {k : α}
+    (contains : (l.map Sigma.fst).contains k = false)
+    {h'} :
+    (t.insertMany l).1.get k h' =
+    t.get k (contains_of_contains_insertMany_list _ h h' contains) := by
+  simp_to_model [insertMany] using List.getValueCast_insertList_of_contains_eq_false
+
+theorem get_insertMany_list_of_mem [LawfulBEq α] (h : t.1.WF)
+    {l : List ((a : α) × β a)} {k k' : α} (k_beq : k == k') {v : β k}
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : ⟨k, v⟩ ∈ l)
+    {h'} :
+    (t.insertMany l).1.get k' h' = cast (by congr; apply LawfulBEq.eq_of_beq k_beq) v := by
+  simp_to_model [insertMany] using List.getValueCast_insertList_of_mem
+
+theorem get!_insertMany_list_of_contains_eq_false [LawfulBEq α] (h : t.1.WF)
+    {l : List ((a : α) × β a)} {k : α} [Inhabited (β k)]
+    (h' : (l.map Sigma.fst).contains k = false) :
+    (t.insertMany l).1.get! k = t.get! k := by
+  simp_to_model [insertMany] using List.getValueCast!_insertList_of_contains_eq_false
+
+theorem get!_insertMany_list_of_mem [LawfulBEq α] (h : t.1.WF)
+    {l : List ((a : α) × β a)} {k k' : α} (k_beq : k == k') {v : β k} [Inhabited (β k')]
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (t.insertMany l).1.get! k' = cast (by congr; apply LawfulBEq.eq_of_beq k_beq) v := by
+  simp_to_model [insertMany] using List.getValueCast!_insertList_of_mem
+
+theorem getD_insertMany_list_of_contains_eq_false [LawfulBEq α] (h : t.1.WF)
+    {l : List ((a : α) × β a)} {k : α} {fallback : β k}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (t.insertMany l).1.getD k fallback = t.getD k fallback := by
+  simp_to_model [insertMany] using List.getValueCastD_insertList_of_contains_eq_false
+
+theorem getD_insertMany_list_of_mem [LawfulBEq α] (h : t.1.WF)
+    {l : List ((a : α) × β a)} {k k' : α} (k_beq : k == k') {v : β k} {fallback : β k'}
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (t.insertMany l).1.getD k' fallback = cast (by congr; apply LawfulBEq.eq_of_beq k_beq) v := by
+  simp_to_model [insertMany] using List.getValueCastD_insertList_of_mem
+
+theorem getKey?_insertMany_list_of_contains_eq_false [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List ((a : α) × β a)} {k : α}
+    (h' : (l.map Sigma.fst).contains k = false) :
+    (t.insertMany l).1.getKey? k = t.getKey? k := by
+  simp_to_model [insertMany] using List.getKey?_insertList_of_contains_eq_false
+
+theorem getKey?_insertMany_list_of_mem [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List ((a : α) × β a)}
+    {k k' : α} (k_beq : k == k')
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : k ∈ l.map Sigma.fst) :
+    (t.insertMany l).1.getKey? k' = some k := by
+  simp_to_model [insertMany] using List.getKey?_insertList_of_mem
+
+theorem getKey_insertMany_list_of_contains_eq_false [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List ((a : α) × β a)} {k : α}
+    (h₁ : (l.map Sigma.fst).contains k = false)
+    {h'} :
+    (t.insertMany l).1.getKey k h' =
+    t.getKey k (contains_of_contains_insertMany_list _ h h' h₁) := by
+  simp_to_model [insertMany] using List.getKey_insertList_of_contains_eq_false
+
+theorem getKey_insertMany_list_of_mem [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List ((a : α) × β a)}
+    {k k' : α} (k_beq : k == k')
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : k ∈ l.map Sigma.fst)
+    {h'} :
+    (t.insertMany l).1.getKey k' h' = k := by
+  simp_to_model [insertMany] using List.getKey_insertList_of_mem
+
+theorem getKey!_insertMany_list_of_contains_eq_false [EquivBEq α] [LawfulHashable α] [Inhabited α]
+    (h : t.1.WF) {l : List ((a : α) × β a)} {k : α}
+    (h' : (l.map Sigma.fst).contains k = false) :
+    (t.insertMany l).1.getKey! k = t.getKey! k := by
+  simp_to_model [insertMany] using List.getKey!_insertList_of_contains_eq_false
+
+theorem getKey!_insertMany_list_of_mem [EquivBEq α] [LawfulHashable α] [Inhabited α] (h : t.1.WF)
+    {l : List ((a : α) × β a)}
+    {k k' : α} (k_beq : k == k')
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : k ∈ l.map Sigma.fst) :
+    (t.insertMany l).1.getKey! k' = k := by
+  simp_to_model [insertMany] using List.getKey!_insertList_of_mem
+
+theorem getKeyD_insertMany_list_of_contains_eq_false [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List ((a : α) × β a)} {k fallback : α}
+    (h' : (l.map Sigma.fst).contains k = false) :
+    (t.insertMany l).1.getKeyD k fallback = t.getKeyD k fallback := by
+  simp_to_model [insertMany] using List.getKeyD_insertList_of_contains_eq_false
+
+theorem getKeyD_insertMany_list_of_mem [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List ((a : α) × β a)}
+    {k k' fallback : α} (k_beq : k == k')
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : k ∈ l.map Sigma.fst) :
+    (t.insertMany l).1.getKeyD k' fallback = k := by
+  simp_to_model [insertMany] using List.getKeyD_insertList_of_mem
+
+theorem size_insertMany_list [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List ((a : α) × β a)} (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false)) :
+    (∀ (a : α), t.contains a → (l.map Sigma.fst).contains a = false) →
+    (t.insertMany l).1.1.size = t.1.size + l.length := by
+  simp_to_model [insertMany] using List.length_insertList
+
+theorem size_le_size_insertMany_list [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List ((a : α) × β a)} :
+    t.1.size ≤ (t.insertMany l).1.1.size := by
+  simp_to_model [insertMany] using List.length_le_length_insertList
+
+theorem size_insertMany_list_le [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List ((a : α) × β a)} :
+    (t.insertMany l).1.1.size ≤ t.1.size + l.length := by
+  simp_to_model [insertMany] using List.length_insertList_le
+
+@[simp]
+theorem isEmpty_insertMany_list [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List ((a : α) × β a)} :
+    (t.insertMany l).1.1.isEmpty = (t.1.isEmpty && l.isEmpty) := by
+  simp_to_model [insertMany] using List.isEmpty_insertList
+
+namespace Const
+
+variable {β : Type v} (t : Raw₀ α (fun _ => β))
+
+@[simp]
+theorem insertMany_nil :
+    insertMany t [] = t := by
+  simp [insertMany, Id.run]
+
+@[simp]
+theorem insertMany_list_singleton {k : α} {v : β} :
+    insertMany t [⟨k, v⟩] = t.insert k v := by
+  simp [insertMany, Id.run]
+
+theorem insertMany_cons {l : List (α × β)} {k : α} {v : β} :
+    (insertMany t (⟨k, v⟩ :: l)).1 = (insertMany (t.insert k v) l).1 := by
+  simp only [insertMany_eq_insertListₘ]
+  cases l with
+  | nil => simp [insertListₘ]
+  | cons hd tl => simp [insertListₘ]
+
+@[simp]
+theorem contains_insertMany_list [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List (α × β)} {k : α} :
+    (Const.insertMany t l).1.contains k = (t.contains k || (l.map Prod.fst).contains k) := by
+  simp_to_model [Const.insertMany] using List.containsKey_insertListConst
+
+theorem contains_of_contains_insertMany_list [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List ( α × β )} {k : α} :
+    (insertMany t l).1.contains k → (l.map Prod.fst).contains k = false → t.contains k := by
+  simp_to_model [Const.insertMany] using List.containsKey_of_containsKey_insertListConst
+
+theorem getKey?_insertMany_list_of_contains_eq_false [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List (α × β)} {k : α}
+    (h' : (l.map Prod.fst).contains k = false) :
+    (insertMany t l).1.getKey? k = t.getKey? k := by
+  simp_to_model [Const.insertMany] using List.getKey?_insertListConst_of_contains_eq_false
+
+theorem getKey?_insertMany_list_of_mem [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List  (α × β)}
+    {k k' : α} (k_beq : k == k')
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : k ∈ l.map Prod.fst) :
+    (insertMany t l).1.getKey? k' = some k := by
+  simp_to_model [Const.insertMany] using List.getKey?_insertListConst_of_mem
+
+theorem getKey_insertMany_list_of_contains_eq_false [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List (α × β)} {k : α}
+    (h₁ : (l.map Prod.fst).contains k = false)
+    {h'} :
+    (insertMany t l).1.getKey k h' =
+    t.getKey k (contains_of_contains_insertMany_list _ h h' h₁) := by
+  simp_to_model [Const.insertMany] using List.getKey_insertListConst_of_contains_eq_false
+
+theorem getKey_insertMany_list_of_mem [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List (α × β)}
+    {k k' : α} (k_beq : k == k')
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : k ∈ l.map Prod.fst)
+    {h'} :
+    (insertMany t l).1.getKey k' h' = k := by
+  simp_to_model [Const.insertMany] using List.getKey_insertListConst_of_mem
+
+theorem getKey!_insertMany_list_of_contains_eq_false [EquivBEq α] [LawfulHashable α] [Inhabited α]
+    (h : t.1.WF) {l : List (α × β)} {k : α}
+    (h' : (l.map Prod.fst).contains k = false) :
+    (insertMany t l).1.getKey! k = t.getKey! k := by
+  simp_to_model [Const.insertMany] using List.getKey!_insertListConst_of_contains_eq_false
+
+theorem getKey!_insertMany_list_of_mem [EquivBEq α] [LawfulHashable α] [Inhabited α] (h : t.1.WF)
+    {l : List (α × β)}
+    {k k' : α} (k_beq : k == k')
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : k ∈ l.map Prod.fst) :
+    (insertMany t l).1.getKey! k' = k := by
+  simp_to_model [Const.insertMany] using List.getKey!_insertListConst_of_mem
+
+theorem getKeyD_insertMany_list_of_contains_eq_false [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List (α × β)} {k fallback : α}
+    (h' : (l.map Prod.fst).contains k = false) :
+    (insertMany t l).1.getKeyD k fallback = t.getKeyD k fallback := by
+  simp_to_model [Const.insertMany] using List.getKeyD_insertListConst_of_contains_eq_false
+
+theorem getKeyD_insertMany_list_of_mem [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List (α × β)}
+    {k k' fallback : α} (k_beq : k == k')
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : k ∈ l.map Prod.fst) :
+    (insertMany t l).1.getKeyD k' fallback = k := by
+  simp_to_model [Const.insertMany] using List.getKeyD_insertListConst_of_mem
+
+theorem size_insertMany_list [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List (α × β)}
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false)) :
+    (∀ (a : α), t.contains a → (l.map Prod.fst).contains a = false) →
+    (insertMany t l).1.1.size = t.1.size + l.length := by
+  simp_to_model [Const.insertMany] using List.length_insertListConst
+
+theorem size_le_size_insertMany_list [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List (α × β)} :
+    t.1.size ≤ (insertMany t l).1.1.size := by
+  simp_to_model [Const.insertMany] using List.length_le_length_insertListConst
+
+theorem size_insertMany_list_le [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List (α × β)} :
+    (insertMany t l).1.1.size ≤ t.1.size + l.length := by
+  simp_to_model [Const.insertMany] using List.length_insertListConst_le
+
+@[simp]
+theorem isEmpty_insertMany_list [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List (α × β)} :
+    (insertMany t l).1.1.isEmpty = (t.1.isEmpty && l.isEmpty) := by
+  simp_to_model [Const.insertMany] using List.isEmpty_insertListConst
+
+theorem get?_insertMany_list_of_contains_eq_false [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List (α × β)} {k : α}
+    (h' : (l.map Prod.fst).contains k = false) :
+    get? (insertMany t l).1 k = get? t k := by
+  simp_to_model [Const.insertMany] using List.getValue?_insertListConst_of_contains_eq_false
+
+theorem get?_insertMany_list_of_mem [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List (α × β)} {k k' : α} (k_beq : k == k') {v : β}
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false)) (mem : ⟨k, v⟩ ∈ l) :
+    get? (insertMany t l).1 k' = v := by
+  simp_to_model [Const.insertMany] using List.getValue?_insertListConst_of_mem
+
+theorem get_insertMany_list_of_contains_eq_false [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List (α × β)} {k : α}
+    (h₁ : (l.map Prod.fst).contains k = false)
+    {h'} :
+    get (insertMany t l).1 k h' = get t k (contains_of_contains_insertMany_list _ h h' h₁) := by
+  simp_to_model [Const.insertMany] using List.getValue_insertListConst_of_contains_eq_false
+
+theorem get_insertMany_list_of_mem [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List (α × β)} {k k' : α} (k_beq : k == k') {v : β}
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false)) (mem : ⟨k, v⟩ ∈ l) {h'} :
+    get (insertMany t l).1 k' h' = v := by
+  simp_to_model [Const.insertMany] using List.getValue_insertListConst_of_mem
+
+theorem get!_insertMany_list_of_contains_eq_false [EquivBEq α] [LawfulHashable α]
+    [Inhabited β]  (h : t.1.WF) {l : List (α × β)} {k : α}
+    (h' : (l.map Prod.fst).contains k = false) :
+    get! (insertMany t l).1 k = get! t k := by
+  simp_to_model [Const.insertMany] using List.getValue!_insertListConst_of_contains_eq_false
+
+theorem get!_insertMany_list_of_mem [EquivBEq α] [LawfulHashable α] [Inhabited β] (h : t.1.WF)
+    {l : List (α × β)} {k k' : α} (k_beq : k == k') {v : β}
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false)) (mem : ⟨k, v⟩ ∈ l) :
+    get! (insertMany t l).1 k' = v := by
+  simp_to_model [Const.insertMany] using List.getValue!_insertListConst_of_mem
+
+theorem getD_insertMany_list_of_contains_eq_false [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List (α × β)} {k : α} {fallback : β}
+    (h' : (l.map Prod.fst).contains k = false) :
+    getD (insertMany t l).1 k fallback = getD t k fallback := by
+  simp_to_model [Const.insertMany] using List.getValueD_insertListConst_of_contains_eq_false
+
+theorem getD_insertMany_list_of_mem [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List (α × β)} {k k' : α} (k_beq : k == k') {v fallback : β}
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false)) (mem : ⟨k, v⟩ ∈ l) :
+    getD (insertMany t l).1 k' fallback = v := by
+  simp_to_model [Const.insertMany] using List.getValueD_insertListConst_of_mem
+
+variable (t : Raw₀ α (fun _ => Unit))
+
+@[simp]
+theorem insertManyIfNewUnit_nil :
+    insertManyIfNewUnit t [] = t := by
+  simp [insertManyIfNewUnit, Id.run]
+
+@[simp]
+theorem insertManyIfNewUnit_list_singleton {k : α} :
+    insertManyIfNewUnit t [k] = t.insertIfNew k () := by
+  simp [insertManyIfNewUnit, Id.run]
+
+theorem insertManyIfNewUnit_cons {l : List α} {k : α} :
+    (insertManyIfNewUnit t (k :: l)).1 = (insertManyIfNewUnit (t.insertIfNew k ()) l).1 := by
+  simp only [insertManyIfNewUnit_eq_insertListIfNewUnitₘ]
+  cases l with
+  | nil => simp [insertListIfNewUnitₘ]
+  | cons hd tl => simp [insertListIfNewUnitₘ]
+
+@[simp]
+theorem contains_insertManyIfNewUnit_list [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List α} {k : α} :
+    (insertManyIfNewUnit t l).1.contains k = (t.contains k || l.contains k) := by
+  simp_to_model [Const.insertManyIfNewUnit] using List.containsKey_insertListIfNewUnit
+
+theorem contains_of_contains_insertManyIfNewUnit_list [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List α} {k : α} (h₂ : l.contains k = false) :
+    (insertManyIfNewUnit t l).1.contains k → t.contains k := by
+  simp_to_model [Const.insertManyIfNewUnit] using List.containsKey_of_containsKey_insertListIfNewUnit
+
+theorem getKey?_insertManyIfNewUnit_list_of_contains_eq_false_of_contains_eq_false
+    [EquivBEq α] [LawfulHashable α]
+    (h : t.1.WF) {l : List α} {k : α} :
+    t.contains k = false → l.contains k = false → getKey? (insertManyIfNewUnit t l).1 k = none := by
+  simp_to_model [Const.insertManyIfNewUnit] using List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
+
+theorem getKey?_insertManyIfNewUnit_list_of_contains_eq_false_of_mem [EquivBEq α] [LawfulHashable α]
+    (h : t.1.WF) {l : List α} {k k' : α} (k_beq : k == k') :
+    t.contains k = false → l.Pairwise (fun a b => (a == b) = false) → k ∈ l →
+      getKey? (insertManyIfNewUnit t l).1 k' = some k := by
+  simp_to_model [Const.insertManyIfNewUnit] using List.getKey?_insertListIfNewUnit_of_contains_eq_false_of_mem
+
+theorem getKey?_insertManyIfNewUnit_list_of_contains [EquivBEq α] [LawfulHashable α]
+    (h : t.1.WF) {l : List α} {k : α} :
+    t.contains k → getKey? (insertManyIfNewUnit t l).1 k = getKey? t k := by
+  simp_to_model [Const.insertManyIfNewUnit] using List.getKey?_insertListIfNewUnit_of_contains
+
+theorem getKey_insertManyIfNewUnit_list_of_contains [EquivBEq α] [LawfulHashable α]
+    (h : t.1.WF) {l : List α} {k : α} {h'} (contains : t.contains k) :
+    getKey (insertManyIfNewUnit t l).1 k h' = getKey t k contains := by
+  simp_to_model [Const.insertManyIfNewUnit] using List.getKey_insertListIfNewUnit_of_contains
+
+theorem getKey_insertManyIfNewUnit_list_of_contains_eq_false_of_mem [EquivBEq α] [LawfulHashable α]
+    (h : t.1.WF) {l : List α}
+    {k k' : α} (k_beq : k == k') {h'} :
+    t.contains k = false → l.Pairwise (fun a b => (a == b) = false) → k ∈ l →
+      getKey (insertManyIfNewUnit t l).1 k' h' = k := by
+  simp_to_model [Const.insertManyIfNewUnit] using List.getKey_insertListIfNewUnit_of_contains_eq_false_of_mem
+
+theorem getKey_insertManyIfNewUnit_list_mem_of_contains [EquivBEq α] [LawfulHashable α]
+    (h : t.1.WF) {l : List α} {k : α} (contains : t.contains k) {h'} :
+    getKey (insertManyIfNewUnit t l).1 k h' = getKey t k contains := by
+  simp_to_model [Const.insertManyIfNewUnit] using List.getKey_insertListIfNewUnit_of_contains
+
+theorem getKey!_insertManyIfNewUnit_list_of_contains_eq_false_of_contains_eq_false
+    [EquivBEq α] [LawfulHashable α] [Inhabited α] (h : t.1.WF) {l : List α} {k : α} :
+    t.contains k = false → l.contains k = false →
+      getKey! (insertManyIfNewUnit t l).1 k = default := by
+  simp_to_model [Const.insertManyIfNewUnit] using List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
+
+theorem getKey!_insertManyIfNewUnit_list_of_contains_eq_false_of_mem [EquivBEq α] [LawfulHashable α]
+    [Inhabited α] (h : t.1.WF) {l : List α} {k k' : α} (k_beq : k == k') :
+    contains t k = false → l.Pairwise (fun a b => (a == b) = false) → k ∈ l →
+      getKey! (insertManyIfNewUnit t l).1 k' = k := by
+  simp_to_model [Const.insertManyIfNewUnit] using List.getKey!_insertListIfNewUnit_of_contains_eq_false_of_mem
+
+theorem getKey!_insertManyIfNewUnit_list_of_contains [EquivBEq α] [LawfulHashable α]
+    [Inhabited α] (h : t.1.WF) {l : List α} {k : α} :
+    t.contains k → getKey! (insertManyIfNewUnit t l).1 k = getKey! t k  := by
+  simp_to_model [Const.insertManyIfNewUnit] using List.getKey!_insertListIfNewUnit_of_contains
+
+theorem getKeyD_insertManyIfNewUnit_list_of_contains_eq_false_of_contains_eq_false
+    [EquivBEq α] [LawfulHashable α] (h : t.1.WF) {l : List α} {k fallback : α} :
+    t.contains k = false → l.contains k = false → getKeyD (insertManyIfNewUnit t l).1 k fallback = fallback := by
+  simp_to_model [Const.insertManyIfNewUnit] using List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_contains_eq_false
+
+theorem getKeyD_insertManyIfNewUnit_list_of_contains_eq_false_of_mem [EquivBEq α] [LawfulHashable α]
+    (h : t.1.WF) {l : List α} {k k' fallback : α} (k_beq : k == k') :
+    t.contains k = false → l.Pairwise (fun a b => (a == b) = false) → k ∈ l →
+      getKeyD (insertManyIfNewUnit t l).1 k' fallback = k := by
+  simp_to_model [Const.insertManyIfNewUnit] using List.getKeyD_insertListIfNewUnit_of_contains_eq_false_of_mem
+
+theorem getKeyD_insertManyIfNewUnit_list_of_contains [EquivBEq α] [LawfulHashable α]
+    (h : t.1.WF) {l : List α} {k fallback : α} :
+    t.contains k → getKeyD (insertManyIfNewUnit t l).1 k fallback = getKeyD t k fallback := by
+  simp_to_model [Const.insertManyIfNewUnit] using List.getKeyD_insertListIfNewUnit_of_contains
+
+theorem size_insertManyIfNewUnit_list [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List α}
+    (distinct : l.Pairwise (fun a b => (a == b) = false)) :
+    (∀ (a : α), t.contains a → l.contains a = false) →
+    (insertManyIfNewUnit t l).1.1.size = t.1.size + l.length := by
+  simp_to_model [Const.insertManyIfNewUnit] using List.length_insertListIfNewUnit
+
+theorem size_le_size_insertManyIfNewUnit_list [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List α} :
+    t.1.size ≤ (insertManyIfNewUnit t l).1.1.size := by
+  simp_to_model [Const.insertManyIfNewUnit] using List.length_le_length_insertListIfNewUnit
+
+theorem size_insertManyIfNewUnit_list_le [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List α} :
+    (insertManyIfNewUnit t l).1.1.size ≤ t.1.size + l.length := by
+  simp_to_model [Const.insertManyIfNewUnit] using List.length_insertListIfNewUnit_le
+
+@[simp]
+theorem isEmpty_insertManyIfNewUnit_list [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List α} :
+    (insertManyIfNewUnit t l).1.1.isEmpty = (t.1.isEmpty && l.isEmpty) := by
+  simp_to_model [Const.insertManyIfNewUnit] using List.isEmpty_insertListIfNewUnit
+
+theorem get?_insertManyIfNewUnit_list [EquivBEq α] [LawfulHashable α] (h : t.1.WF)
+    {l : List α} {k : α} :
+    get? (insertManyIfNewUnit t l).1 k =
+    if t.contains k ∨ l.contains k then some () else none := by
+  simp_to_model [Const.insertManyIfNewUnit] using List.getValue?_insertListIfNewUnit
+
+theorem get_insertManyIfNewUnit_list
+    {l : List α} {k : α} {h} :
+    get (insertManyIfNewUnit t l).1 k h = ()  := by
+  simp
+
+theorem get!_insertManyIfNewUnit_list
+    {l : List α} {k : α} :
+    get! (insertManyIfNewUnit t l).1 k = ()  := by
+  simp
+
+theorem getD_insertManyIfNewUnit_list
+    {l : List α} {k : α} {fallback : Unit} :
+    getD (insertManyIfNewUnit t l).1 k fallback = () := by
+  simp
+
+end Const
+
+@[simp]
+theorem insertMany_empty_list_nil :
+    (insertMany empty ([] : List ((a : α) × (β a)))).1 = empty := by
+  simp
+
+@[simp]
+theorem insertMany_empty_list_singleton {k : α} {v : β k} :
+    (insertMany empty [⟨k, v⟩]).1 = empty.insert k v := by
+  simp
+
+theorem insertMany_empty_list_cons {k : α} {v : β k}
+    {tl : List ((a : α) × (β a))} :
+    (insertMany empty (⟨k, v⟩ :: tl)).1 = ((empty.insert k v).insertMany tl).1 := by
+  rw [insertMany_cons]
+
+theorem contains_insertMany_empty_list [EquivBEq α] [LawfulHashable α]
+    {l : List ((a : α) × β a)} {k : α} :
+    (insertMany empty l).1.contains k = (l.map Sigma.fst).contains k := by
+  simp [contains_insertMany_list _ Raw.WF.empty₀]
+
+theorem get?_insertMany_empty_list_of_contains_eq_false [LawfulBEq α]
+    {l : List ((a : α) × β a)} {k : α}
+    (h : (l.map Sigma.fst).contains k = false) :
+    (insertMany empty l).1.get? k = none := by
+  simp [get?_insertMany_list_of_contains_eq_false _ Raw.WF.empty₀ h]
+
+theorem get?_insertMany_empty_list_of_mem [LawfulBEq α]
+    {l : List ((a : α) × β a)} {k k' : α} (k_beq : k == k') {v : β k}
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (insertMany empty l).1.get? k' = some (cast (by congr; apply LawfulBEq.eq_of_beq k_beq) v) := by
+  rw [get?_insertMany_list_of_mem _ Raw.WF.empty₀ k_beq distinct mem]
+
+theorem get_insertMany_empty_list_of_mem [LawfulBEq α]
+    {l : List ((a : α) × β a)} {k k' : α} (k_beq : k == k') {v : β k}
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : ⟨k, v⟩ ∈ l)
+    {h} :
+    (insertMany empty l).1.get k' h = cast (by congr; apply LawfulBEq.eq_of_beq k_beq) v := by
+  rw [get_insertMany_list_of_mem _ Raw.WF.empty₀ k_beq distinct mem]
+
+theorem get!_insertMany_empty_list_of_contains_eq_false [LawfulBEq α]
+    {l : List ((a : α) × β a)} {k : α} [Inhabited (β k)]
+    (h : (l.map Sigma.fst).contains k = false) :
+    (insertMany empty l).1.get! k = default := by
+  simp only [get!_insertMany_list_of_contains_eq_false _ Raw.WF.empty₀ h]
+  apply get!_empty
+
+theorem get!_insertMany_empty_list_of_mem [LawfulBEq α]
+    {l : List ((a : α) × β a)} {k k' : α} (k_beq : k == k') {v : β k} [Inhabited (β k')]
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (insertMany empty l).1.get! k' = cast (by congr; apply LawfulBEq.eq_of_beq k_beq) v := by
+  rw [get!_insertMany_list_of_mem _ Raw.WF.empty₀ k_beq distinct mem]
+
+theorem getD_insertMany_empty_list_of_contains_eq_false [LawfulBEq α]
+    {l : List ((a : α) × β a)} {k : α} {fallback : β k}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (insertMany empty l).1.getD k fallback = fallback := by
+  rw [getD_insertMany_list_of_contains_eq_false _ Raw.WF.empty₀ contains_eq_false]
+  apply getD_empty
+
+theorem getD_insertMany_empty_list_of_mem [LawfulBEq α]
+    {l : List ((a : α) × β a)} {k k' : α} (k_beq : k == k') {v : β k} {fallback : β k'}
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (insertMany empty l).1.getD k' fallback =
+      cast (by congr; apply LawfulBEq.eq_of_beq k_beq) v := by
+  rw [getD_insertMany_list_of_mem _ Raw.WF.empty₀ k_beq distinct mem]
+
+theorem getKey?_insertMany_empty_list_of_contains_eq_false [EquivBEq α] [LawfulHashable α]
+    {l : List ((a : α) × β a)} {k : α}
+    (h : (l.map Sigma.fst).contains k = false) :
+    (insertMany empty l).1.getKey? k = none := by
+  rw [getKey?_insertMany_list_of_contains_eq_false _ Raw.WF.empty₀ h]
+  apply getKey?_empty
+
+theorem getKey?_insertMany_empty_list_of_mem [EquivBEq α] [LawfulHashable α]
+    {l : List ((a : α) × β a)}
+    {k k' : α} (k_beq : k == k')
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : k ∈ l.map Sigma.fst) :
+    (insertMany empty l).1.getKey? k' = some k := by
+  rw [getKey?_insertMany_list_of_mem _ Raw.WF.empty₀ k_beq distinct mem]
+
+theorem getKey_insertMany_empty_list_of_mem [EquivBEq α] [LawfulHashable α]
+    {l : List ((a : α) × β a)}
+    {k k' : α} (k_beq : k == k')
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : k ∈ l.map Sigma.fst)
+    {h'} :
+    (insertMany empty l).1.getKey k' h' = k := by
+  rw [getKey_insertMany_list_of_mem _ Raw.WF.empty₀ k_beq distinct mem]
+
+theorem getKey!_insertMany_empty_list_of_contains_eq_false [EquivBEq α] [LawfulHashable α]
+    [Inhabited α] {l : List ((a : α) × β a)} {k : α}
+    (h : (l.map Sigma.fst).contains k = false) :
+    (insertMany empty l).1.getKey! k = default := by
+  rw [getKey!_insertMany_list_of_contains_eq_false _ Raw.WF.empty₀ h]
+  apply getKey!_empty
+
+theorem getKey!_insertMany_empty_list_of_mem [EquivBEq α] [LawfulHashable α] [Inhabited α]
+    {l : List ((a : α) × β a)}
+    {k k' : α} (k_beq : k == k')
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : k ∈ l.map Sigma.fst) :
+    (insertMany empty l).1.getKey! k' = k := by
+  rw [getKey!_insertMany_list_of_mem _ Raw.WF.empty₀ k_beq distinct mem]
+
+theorem getKeyD_insertMany_empty_list_of_contains_eq_false [EquivBEq α] [LawfulHashable α]
+    {l : List ((a : α) × β a)} {k fallback : α}
+    (h : (l.map Sigma.fst).contains k = false) :
+    (insertMany empty l).1.getKeyD k fallback = fallback := by
+  rw [getKeyD_insertMany_list_of_contains_eq_false _ Raw.WF.empty₀ h]
+  apply getKeyD_empty
+
+theorem getKeyD_insertMany_empty_list_of_mem [EquivBEq α] [LawfulHashable α]
+    {l : List ((a : α) × β a)}
+    {k k' fallback : α} (k_beq : k == k')
+    (distinct : l.Pairwise (fun a b => (a.1 == b.1) = false))
+    (mem : k ∈ l.map Sigma.fst) :
+    (insertMany empty l).1.getKeyD k' fallback = k := by
+  rw [getKeyD_insertMany_list_of_mem _ Raw.WF.empty₀ k_beq distinct mem]
 
 end Std.DTreeMap.Internal.Impl

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -2000,11 +2000,11 @@ theorem getKeyD_insertMany!_list_of_mem [TransOrd α] (h : t.WF)
   rw [compare_eq_eq_iff_beq] at k_beq
   simp_to_model [insertMany!] using List.getKeyD_insertList_of_mem
 
-theorem size_insertMany_list [TransOrd α] (h : t.WF)
+theorem size_insertMany_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List ((a : α) × β a)} (distinct : l.Pairwise (fun a b => ¬ compare a.1 b.1 = .eq)) :
     (∀ (a : α), t.contains a → (l.map Sigma.fst).contains a = false) →
     (t.insertMany l h.balanced).1.size = t.size + l.length := by
-  simp only [← beq_iff, Bool.not_eq_true] at distinct
+  simp only [LawfulBEqOrd.compare_eq_iff_beq, Bool.not_eq_true] at distinct
   simp_to_model [insertMany] using List.length_insertList
 
 theorem size_insertMany!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
@@ -2069,7 +2069,7 @@ theorem insertMany!_cons {l : List (α × β)} {k : α} {v : β} :
   · simp
 
 @[simp]
-theorem contains_insertMany_list [TransOrd α] (h : t.WF)
+theorem contains_insertMany_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : t.WF)
     {l : List (α × β)} {k : α} :
     (Const.insertMany t l h.balanced).1.contains k = (t.contains k || (l.map Prod.fst).contains k) := by
   simp_to_model [Const.insertMany] using List.containsKey_insertListConst
@@ -2079,6 +2079,12 @@ theorem contains_insertMany!_list [BEq α] [LawfulBEqOrd α] [TransOrd α] (h : 
     {l : List (α × β)} {k : α} :
     (Const.insertMany! t l).1.contains k = (t.contains k || (l.map Prod.fst).contains k) := by
   simp_to_model [Const.insertMany!] using List.containsKey_insertListConst
+
+@[simp]
+theorem mem_insertMany_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)
+    {l : List (α × β)} {k : α} :
+    k ∈ (insertMany t l h.balanced).1 ↔ k ∈ t ∨ (l.map Prod.fst).contains k := by
+  simp [mem_iff_contains, contains_insertMany_list h]
 
 @[simp]
 theorem mem_insertMany!_list [BEq α] [TransOrd α] [LawfulBEqOrd α] (h : t.WF)

--- a/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
@@ -342,9 +342,10 @@ theorem exists_cell_of_updateAtKey [Ord α] [TransOrd α] (l : Impl α β) (hlb 
       beq_eq_false_iff_ne, ne_eq]
     rintro a (⟨p, ⟨⟨-, hp⟩, rfl⟩⟩|⟨p, ⟨⟨-, hp⟩, rfl⟩⟩) <;> simp_all
 
-theorem Ordered.distinctKeys [Ord α] {l : Impl α β} (h : l.Ordered) :
+theorem Ordered.distinctKeys [BEq α] [Ord α] [LawfulBEqOrd α] {l : Impl α β} (h : l.Ordered) :
     DistinctKeys l.toListModel :=
-  ⟨by rw [keys_eq_map, List.pairwise_map]; exact h.imp (fun h => by simp_all)⟩
+  ⟨by rw [keys_eq_map, List.pairwise_map]; exact h.imp (fun h => by
+    simp [← LawfulBEqOrd.not_compare_eq_iff_beq_eq_false, h])⟩
 
 /-- This is the general theorem to show that modification operations are correct. -/
 theorem toListModel_updateAtKey_perm [Ord α] [TransOrd α]
@@ -541,8 +542,10 @@ theorem containsₘ_eq_containsKey [Ord α] [TransOrd α] {k : α} {l : Impl α 
   · exact fun l₁ l₂ h a hP => containsKey_of_perm hP
   · exact fun l₁ l₂ h h' => containsKey_append_of_not_contains_right h'
 
-theorem contains_eq_containsKey [Ord α] [TransOrd α] {k : α} {l : Impl α β} (hlo : l.Ordered) :
+theorem contains_eq_containsKey [instBEq : BEq α] [Ord α] [LawfulBEqOrd α] [TransOrd α] {k : α}
+    {l : Impl α β} (hlo : l.Ordered) :
     l.contains k = containsKey k l.toListModel := by
+  rw [eq_beqOfOrd_of_lawfulBEqOrd instBEq]
   rw [contains_eq_containsₘ, containsₘ_eq_containsKey hlo]
 
 /-!
@@ -560,8 +563,10 @@ theorem get?ₘ_eq_getValueCast? [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α
   · exact fun l₁ l₂ h => getValueCast?_of_perm
   · exact fun l₁ l₂ h => getValueCast?_append_of_containsKey_eq_false
 
-theorem get?_eq_getValueCast? [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {t : Impl α β}
+theorem get?_eq_getValueCast? [instBEq : BEq α] [Ord α] [i : LawfulBEqOrd α] [TransOrd α]
+    [LawfulEqOrd α] {k : α} {t : Impl α β}
     (hto : t.Ordered) : t.get? k = getValueCast? k t.toListModel := by
+  cases eq_beqOfOrd_of_lawfulBEqOrd instBEq
   rw [get?_eq_get?ₘ, get?ₘ_eq_getValueCast? hto]
 
 /-!
@@ -579,8 +584,9 @@ theorem getₘ_eq_getValueCast [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} 
   rw [get?ₘ_eq_getValueCast? hto]
   simp [getValueCast?_eq_some_getValueCast ‹_›]
 
-theorem get_eq_getValueCast [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} {t : Impl α β} {h}
+theorem get_eq_getValueCast [instBEq : BEq α] [Ord α] [LawfulBEqOrd α] [TransOrd α] [LawfulEqOrd α] {k : α} {t : Impl α β} {h}
     (hto : t.Ordered): t.get k h = getValueCast k t.toListModel (contains_eq_containsKey hto ▸ h) := by
+  cases eq_beqOfOrd_of_lawfulBEqOrd instBEq
   rw [get_eq_getₘ, getₘ_eq_getValueCast _ hto]
   exact contains_eq_isSome_get?ₘ hto ▸ h
 
@@ -592,8 +598,9 @@ theorem get!ₘ_eq_getValueCast! [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α
     {t : Impl α β} (hto : t.Ordered) : t.get!ₘ k = getValueCast! k t.toListModel := by
   simp [get!ₘ, get?ₘ_eq_getValueCast? hto, getValueCast!_eq_getValueCast?]
 
-theorem get!_eq_getValueCast! [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α} [Inhabited (β k)]
+theorem get!_eq_getValueCast! [instBEq : BEq α] [Ord α] [LawfulBEqOrd α] [TransOrd α] [LawfulEqOrd α] {k : α} [Inhabited (β k)]
     {t : Impl α β} (hto : t.Ordered) : t.get! k = getValueCast! k t.toListModel := by
+  cases eq_beqOfOrd_of_lawfulBEqOrd instBEq
   rw [get!_eq_get!ₘ, get!ₘ_eq_getValueCast! hto]
 
 /-!
@@ -605,9 +612,10 @@ theorem getDₘ_eq_getValueCastD [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α
     t.getDₘ k fallback = getValueCastD k t.toListModel fallback := by
   simp [getDₘ, get?ₘ_eq_getValueCast? hto, getValueCastD_eq_getValueCast?]
 
-theorem getD_eq_getValueCastD [Ord α] [TransOrd α] [LawfulEqOrd α] {k : α}
+theorem getD_eq_getValueCastD [Ord α] [instBEq : BEq α] [LawfulBEqOrd α] [TransOrd α] [LawfulEqOrd α] {k : α}
     {t : Impl α β} {fallback : β k} (hto : t.Ordered) :
     t.getD k fallback = getValueCastD k t.toListModel fallback := by
+  cases eq_beqOfOrd_of_lawfulBEqOrd instBEq
   rw [getD_eq_getDₘ, getDₘ_eq_getValueCastD hto]
 
 /-!
@@ -625,8 +633,9 @@ theorem getKey?ₘ_eq_getKey? [Ord α] [TransOrd α] {k : α} {t : Impl α β}
   · exact fun l₁ l₂ h => List.getKey?_of_perm
   · exact fun l₁ l₂ h => List.getKey?_append_of_containsKey_eq_false
 
-theorem getKey?_eq_getKey? [Ord α] [TransOrd α] {k : α} {t : Impl α β}
+theorem getKey?_eq_getKey? [Ord α] [TransOrd α] [instBEq : BEq α] [LawfulBEqOrd α] {k : α} {t : Impl α β}
     (hto : t.Ordered) : t.getKey? k = List.getKey? k t.toListModel := by
+  cases eq_beqOfOrd_of_lawfulBEqOrd instBEq
   rw [getKey?_eq_getKey?ₘ, getKey?ₘ_eq_getKey? hto]
 
 /-!
@@ -644,8 +653,9 @@ theorem getKeyₘ_eq_getKey [Ord α] [TransOrd α] {k : α} {t : Impl α β} (h)
   rw [getKey?ₘ_eq_getKey? hto]
   simp [getKey?_eq_some_getKey ‹_›]
 
-theorem getKey_eq_getKey [Ord α] [TransOrd α] {k : α} {t : Impl α β} {h}
+theorem getKey_eq_getKey [Ord α] [TransOrd α] [instBEq : BEq α] [LawfulBEqOrd α] {k : α} {t : Impl α β} {h}
     (hto : t.Ordered): t.getKey k h = List.getKey k t.toListModel (contains_eq_containsKey hto ▸ h) := by
+  cases eq_beqOfOrd_of_lawfulBEqOrd instBEq
   rw [getKey_eq_getKeyₘ, getKeyₘ_eq_getKey _ hto]
   exact contains_eq_isSome_getKey?ₘ hto ▸ h
 
@@ -657,8 +667,9 @@ theorem getKey!ₘ_eq_getKey! [Ord α] [TransOrd α] {k : α} [Inhabited α]
     {t : Impl α β} (hto : t.Ordered) : t.getKey!ₘ k = List.getKey! k t.toListModel := by
   simp [getKey!ₘ, getKey?ₘ_eq_getKey? hto, getKey!_eq_getKey?]
 
-theorem getKey!_eq_getKey! [Ord α] [TransOrd α] {k : α} [Inhabited α]
+theorem getKey!_eq_getKey! [Ord α] [TransOrd α] [instBEq : BEq α] [LawfulBEqOrd α] {k : α} [Inhabited α]
     {t : Impl α β} (hto : t.Ordered) : t.getKey! k = List.getKey! k t.toListModel := by
+  cases eq_beqOfOrd_of_lawfulBEqOrd instBEq
   rw [getKey!_eq_getKey!ₘ, getKey!ₘ_eq_getKey! hto]
 
 /-!
@@ -670,9 +681,10 @@ theorem getKeyDₘ_eq_getKeyD [Ord α] [TransOrd α] {k : α}
     t.getKeyDₘ k fallback = List.getKeyD k t.toListModel fallback := by
   simp [getKeyDₘ, getKey?ₘ_eq_getKey? hto, getKeyD_eq_getKey?]
 
-theorem getKeyD_eq_getKeyD [Ord α] [TransOrd α] {k : α}
+theorem getKeyD_eq_getKeyD [Ord α] [TransOrd α] [instBEq : BEq α] [LawfulBEqOrd α] {k : α}
     {t : Impl α β} {fallback : α} (hto : t.Ordered) :
     t.getKeyD k fallback = List.getKeyD k t.toListModel fallback := by
+  cases eq_beqOfOrd_of_lawfulBEqOrd instBEq
   rw [getKeyD_eq_getKeyDₘ, getKeyDₘ_eq_getKeyD hto]
 
 namespace Const
@@ -694,8 +706,9 @@ theorem get?ₘ_eq_getValue? [Ord α] [TransOrd α] {k : α} {t : Impl α (fun _
   · exact fun l₁ l₂ h => getValue?_of_perm
   · exact fun l₁ l₂ h => getValue?_append_of_containsKey_eq_false
 
-theorem get?_eq_getValue? [Ord α] [TransOrd α] {k : α} {t : Impl α (fun _ => β)} (hto : t.Ordered) :
+theorem get?_eq_getValue? [Ord α] [TransOrd α] [instBEq : BEq α] [LawfulBEqOrd α] {k : α} {t : Impl α (fun _ => β)} (hto : t.Ordered) :
     get? t k = getValue? k t.toListModel := by
+  cases eq_beqOfOrd_of_lawfulBEqOrd instBEq
   rw [get?_eq_get?ₘ, get?ₘ_eq_getValue? hto]
 
 /-!
@@ -713,8 +726,9 @@ theorem getₘ_eq_getValue [Ord α] [TransOrd α] {k : α} {t : Impl α β} (h) 
   rw [get?ₘ_eq_getValue? hto]
   simp [getValue?_eq_some_getValue ‹_›]
 
-theorem get_eq_getValue [Ord α] [TransOrd α] {k : α} {t : Impl α β} {h}
+theorem get_eq_getValue [Ord α] [TransOrd α] [instBEq : BEq α] [LawfulBEqOrd α] {k : α} {t : Impl α β} {h}
     (hto : t.Ordered): get t k h = getValue k t.toListModel (contains_eq_containsKey hto ▸ h) := by
+  cases eq_beqOfOrd_of_lawfulBEqOrd instBEq
   rw [get_eq_getₘ, getₘ_eq_getValue _ hto]
   exact contains_eq_isSome_get?ₘ hto ▸ h
 
@@ -726,8 +740,9 @@ theorem get!ₘ_eq_getValue! [Ord α] [TransOrd α] {k : α} [Inhabited β]
     {t : Impl α β} (hto : t.Ordered) : get!ₘ t k = getValue! k t.toListModel := by
   simp [get!ₘ, get?ₘ_eq_getValue? hto, getValue!_eq_getValue?]
 
-theorem get!_eq_getValue! [Ord α] [TransOrd α] {k : α} [Inhabited β]
+theorem get!_eq_getValue! [Ord α] [TransOrd α] [instBEq : BEq α] [LawfulBEqOrd α] {k : α} [Inhabited β]
     {t : Impl α β} (hto : t.Ordered) : get! t k = getValue! k t.toListModel := by
+  cases eq_beqOfOrd_of_lawfulBEqOrd instBEq
   rw [get!_eq_get!ₘ, get!ₘ_eq_getValue! hto]
 
 /-!
@@ -739,9 +754,10 @@ theorem getDₘ_eq_getValueD [Ord α] [TransOrd α] {k : α}
     getDₘ t k fallback = getValueD k t.toListModel fallback := by
   simp [getDₘ, get?ₘ_eq_getValue? hto, getValueD_eq_getValue?]
 
-theorem getD_eq_getValueD [Ord α] [TransOrd α] {k : α}
+theorem getD_eq_getValueD [Ord α] [TransOrd α] [instBEq : BEq α] [LawfulBEqOrd α] {k : α}
     {t : Impl α β} {fallback : β} (hto : t.Ordered) :
     getD t k fallback = getValueD k t.toListModel fallback := by
+  cases eq_beqOfOrd_of_lawfulBEqOrd instBEq
   rw [getD_eq_getDₘ, getDₘ_eq_getValueD hto]
 
 end Const
@@ -801,10 +817,10 @@ theorem WF.insert! {_ : Ord α} [TransOrd α] {k : α} {v : β k} {l : Impl α �
     (h : l.WF) : (l.insert! k v).WF := by
   simpa [insert_eq_insert!] using WF.insert (h := h.balanced) h
 
-theorem toListModel_insert! [Ord α] [TransOrd α] {k : α} {v : β k} {l : Impl α β}
+theorem toListModel_insert! [instBEq : BEq α] [Ord α] [LawfulBEqOrd α] [TransOrd α] {k : α} {v : β k} {l : Impl α β}
     (hlb : l.Balanced) (hlo : l.Ordered) :
     (l.insert! k v).toListModel.Perm (insertEntry k v l.toListModel) := by
-  rw [insert!_eq_insertₘ]
+  rw [insert!_eq_insertₘ, eq_beqOfOrd_of_lawfulBEqOrd instBEq]
   exact toListModel_insertₘ hlb hlo
 
 /-!
@@ -1477,7 +1493,8 @@ theorem insertMany_eq_foldl {_ : Ord α} [TransOrd α] {l : List ((a : α) × β
   rw [← List.foldl_hom Subtype.val]
   simp only [insert_eq_insert!, implies_true]
 
-theorem toListModel_insertMany_list {_ : Ord α} [TransOrd α] {l : List ((a : α) × β a)}
+theorem toListModel_insertMany_list {_ : Ord α} [BEq α] [LawfulBEqOrd α] [TransOrd α]
+    {l : List ((a : α) × β a)}
     {t : Impl α β} (h : t.WF) :
     List.Perm (t.insertMany l h.balanced).val.toListModel (t.toListModel.insertList l) := by
   simp only [insertMany_eq_foldl]
@@ -1503,8 +1520,8 @@ theorem insertMany_eq_foldl {_ : Ord α} [TransOrd α] {l : List (α × β)}
   rw [← List.foldl_hom Subtype.val]
   simp only [insert_eq_insert!, implies_true]
 
-theorem toListModel_insertMany_list {_ : Ord α} [TransOrd α] {l : List (α × β)}
-    {t : Impl α β} (h : t.WF) :
+theorem toListModel_insertMany_list {_ : Ord α} [BEq α] [TransOrd α] [LawfulBEqOrd α]
+    {l : List (α × β)} {t : Impl α β} (h : t.WF) :
     List.Perm (Const.insertMany t l h.balanced).val.toListModel (t.toListModel.insertListConst l) := by
   simp only [insertMany_eq_foldl]
   induction l generalizing t with
@@ -1521,9 +1538,10 @@ theorem insertManyIfNewUnit_eq_foldl {_ : Ord α} [TransOrd α] {l : List α}
   rw [← List.foldl_hom Subtype.val]
   simp only [insertIfNew_eq_insertIfNew!, implies_true]
 
-theorem toListModel_insertManyIfNewUnit_list {_ : Ord α} [TransOrd α] {l : List α}
+theorem toListModel_insertManyIfNewUnit_list {_ : Ord α} [TransOrd α] [instBEq : BEq α] [LawfulBEqOrd α] {l : List α}
     {t : Impl α Unit} (h : t.WF) :
     List.Perm (Const.insertManyIfNewUnit t l h.balanced).val.toListModel (t.toListModel.insertListIfNewUnit l) := by
+  cases eq_beqOfOrd_of_lawfulBEqOrd instBEq
   simp only [insertManyIfNewUnit_eq_foldl]
   induction l generalizing t with
   | nil => rfl
@@ -1538,7 +1556,7 @@ end Const
 ### `insertMany!`
 -/
 
-theorem insertMany_eq_insertMany! {_ : Ord α} [TransOrd α] {l : List ((a : α) × β a)}
+theorem insertMany_eq_insertMany! {_ : Ord α} {l : List ((a : α) × β a)}
     {t : Impl α β} (h : t.Balanced) :
     (t.insertMany l h).val = (t.insertMany! l).val := by
   simp only [insertMany, Id.run, Id.pure_eq, Id.bind_eq, List.forIn_yield_eq_foldl, insertMany!]
@@ -1547,8 +1565,8 @@ theorem insertMany_eq_insertMany! {_ : Ord α} [TransOrd α] {l : List ((a : α)
   · simp
   · simp [insert_eq_insert!]
 
-theorem toListModel_insertMany!_list {_ : Ord α} [TransOrd α] {l : List ((a : α) × β a)}
-    {t : Impl α β} (h : t.WF) :
+theorem toListModel_insertMany!_list {_ : Ord α} [TransOrd α] [BEq α] [LawfulBEqOrd α]
+    {l : List ((a : α) × β a)} {t : Impl α β} (h : t.WF) :
     List.Perm (t.insertMany! l).val.toListModel (t.toListModel.insertList l) := by
   simpa only [← insertMany_eq_insertMany! h.balanced] using toListModel_insertMany_list h
 
@@ -1577,8 +1595,8 @@ theorem insertMany_eq_insertMany! {_ : Ord α} [TransOrd α] {l : List (α × β
   · simp
   · simp [insert_eq_insert!]
 
-theorem toListModel_insertMany!_list {_ : Ord α} [TransOrd α] {l : List (α × β)}
-    {t : Impl α β} (h : t.WF) :
+theorem toListModel_insertMany!_list {_ : Ord α} [BEq α] [LawfulBEqOrd α] [TransOrd α]
+    {l : List (α × β)} {t : Impl α β} (h : t.WF) :
     List.Perm (Const.insertMany! t l).val.toListModel (t.toListModel.insertListConst l) := by
   simpa only [← insertMany_eq_insertMany! h.balanced] using toListModel_insertMany_list h
 
@@ -1592,7 +1610,7 @@ theorem insertManyIfNewUnit_eq_insertManyIfNewUnit! {_ : Ord α} [TransOrd α] {
   · simp
   · simp [insertIfNew_eq_insertIfNew!]
 
-theorem toListModel_insertManyIfNewUnit!_list {_ : Ord α} [TransOrd α] {l : List α}
+theorem toListModel_insertManyIfNewUnit!_list {_ : Ord α} [TransOrd α] [BEq α] [LawfulBEqOrd α] {l : List α}
     {t : Impl α Unit} (h : t.WF) :
     List.Perm (Const.insertManyIfNewUnit! t l).val.toListModel (t.toListModel.insertListIfNewUnit l) := by
   simpa only [← insertManyIfNewUnit_eq_insertManyIfNewUnit! h.balanced] using

--- a/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
@@ -1011,7 +1011,7 @@ theorem filter_eq_filterMap [Ord α] {t : Impl α β} {h} {f : (a : α) → β a
     t.filter f h = t.filterMap (fun k v => if f k v then some v else none) h := by
   induction t with
   | leaf => rfl
-  | inner  sz k v l r ihl ihr =>
+  | inner sz k v l r ihl ihr =>
     simp [filter, filterMap]
     cases hf : f k v <;> rw [ihl, ihr] <;> rfl
 
@@ -1120,7 +1120,7 @@ theorem ordered_mergeWith [Ord α] [TransOrd α] [LawfulEqOrd α] {t₁ t₂ : I
     (t₁.mergeWith f t₂ htb).impl.Ordered := by
   induction t₂ generalizing t₁ with
   | leaf => exact hto
-  | inner sz k v l r  ihl ihr => exact ihr _ (ordered_alter _ (ihl htb hto))
+  | inner sz k v l r ihl ihr => exact ihr _ (ordered_alter _ (ihl htb hto))
 
 /-!
 ### foldlM
@@ -1364,7 +1364,7 @@ theorem ordered_mergeWith [Ord α] [TransOrd α] {t₁ t₂ : Impl α β} {f}
     (mergeWith f t₁ t₂ htb).impl.Ordered := by
   induction t₂ generalizing t₁ with
   | leaf => exact hto
-  | inner sz k v l r  ihl ihr => exact ihr _ (ordered_alter _ (ihl htb hto))
+  | inner sz k v l r ihl ihr => exact ihr _ (ordered_alter _ (ihl htb hto))
 
 /-!
 ### toList

--- a/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
@@ -1566,7 +1566,7 @@ theorem WF.constInsertManyIfNewUnit! {_ : Ord α} [TransOrd α] {ρ} [ForIn Id �
 
 namespace Const
 
-variable {β : Type}
+variable {β : Type v}
 
 theorem insertMany_eq_insertMany! {_ : Ord α} [TransOrd α] {l : List (α × β)}
     {t : Impl α β} (h : t.Balanced) :

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -1508,8 +1508,8 @@ theorem insertManyIfNewUnit_list_singleton {k : α} :
   rfl
 
 theorem insertManyIfNewUnit_cons {l : List α} {k : α} :
-    (insertManyIfNewUnit t (k :: l)).1 = (insertManyIfNewUnit (t.insertIfNew k ()) l).1 :=
-  Impl.Const.insertManyIfNewUnit_cons t.wf
+    insertManyIfNewUnit t (k :: l) = insertManyIfNewUnit (t.insertIfNew k ()) l :=
+  ext <| Impl.Const.insertManyIfNewUnit_cons t.wf
 
 @[simp]
 theorem contains_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -1183,7 +1183,7 @@ theorem contains_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
 @[simp]
 theorem mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     {l : List ((a : α) × β a)} {k : α} :
-    k ∈ t.insertMany l ↔  k ∈ t ∨ (l.map Sigma.fst).contains k :=
+    k ∈ t.insertMany l ↔ k ∈ t ∨ (l.map Sigma.fst).contains k :=
   Impl.mem_insertMany_list t.wf
 
 theorem mem_of_mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
@@ -1371,7 +1371,7 @@ theorem getKey?_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [La
   Impl.Const.getKey?_insertMany_list_of_contains_eq_false t.wf contains_eq_false
 
 theorem getKey?_insertMany_list_of_mem [TransCmp cmp]
-    {l : List  (α × β)}
+    {l : List (α × β)}
     {k k' : α} (k_eq : cmp k k' = .eq)
     (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
     (mem : k ∈ l.map Prod.fst) :
@@ -1472,7 +1472,7 @@ theorem get_insertMany_list_of_mem [TransCmp cmp]
   Impl.Const.get_insertMany_list_of_mem t.wf k_eq distinct mem
 
 theorem get!_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
-    [Inhabited β]  {l : List (α × β)} {k : α}
+    [Inhabited β] {l : List (α × β)} {k : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false) :
     get! (insertMany t l) k = get! t k :=
   Impl.Const.get!_insertMany_list_of_contains_eq_false t.wf contains_eq_false
@@ -1570,7 +1570,7 @@ theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
 
 theorem getKey!_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
     [Inhabited α] {l : List α} {k : α} :
-    k ∈ t → getKey! (insertManyIfNewUnit t l) k = getKey! t k  :=
+    k ∈ t → getKey! (insertManyIfNewUnit t l) k = getKey! t k :=
   Impl.Const.getKey!_insertManyIfNewUnit_list_of_mem t.wf
 
 theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -1160,4 +1160,605 @@ end Const
 
 end monadic
 
+@[simp]
+theorem insertMany_nil :
+    t.insertMany [] = t :=
+  rfl
+
+@[simp]
+theorem insertMany_list_singleton {k : α} {v : β k} :
+    t.insertMany [⟨k, v⟩] = t.insert k v :=
+  rfl
+
+theorem insertMany_cons {l : List ((a : α) × β a)} {k : α} {v : β k} :
+    t.insertMany (⟨k, v⟩ :: l) = (t.insert k v).insertMany l :=
+  ext <| Impl.insertMany_cons t.wf
+
+@[simp]
+theorem contains_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List ((a : α) × β a)} {k : α} :
+    (t.insertMany l).contains k = (t.contains k || (l.map Sigma.fst).contains k) :=
+  Impl.contains_insertMany_list t.wf
+
+@[simp]
+theorem mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List ((a : α) × β a)} {k : α} :
+    k ∈ t.insertMany l ↔  k ∈ t ∨ (l.map Sigma.fst).contains k :=
+  Impl.mem_insertMany_list t.wf
+
+theorem mem_of_mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List ((a : α) × β a)} {k : α} :
+    k ∈ t.insertMany l → (l.map Sigma.fst).contains k = false → k ∈ t :=
+  Impl.mem_of_mem_insertMany_list t.wf
+
+theorem get?_insertMany_list_of_contains_eq_false [TransCmp cmp] [LawfulEqCmp cmp] [BEq α]
+    [LawfulBEqCmp cmp] {l : List ((a : α) × β a)} {k : α}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (t.insertMany l).get? k = t.get? k :=
+  Impl.get?_insertMany_list_of_contains_eq_false t.wf contains_eq_false
+
+theorem get?_insertMany_list_of_mem [TransCmp cmp] [LawfulEqCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List ((a : α) × β a)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β k}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
+    (t.insertMany l).get? k' = some (cast (by congr; apply compare_eq_iff_eq.mp k_eq) v) :=
+  Impl.get?_insertMany_list_of_mem t.wf k_eq distinct mem
+
+theorem get_insertMany_list_of_contains_eq_false [TransCmp cmp] [LawfulEqCmp cmp] [BEq α]
+    [LawfulBEqCmp cmp]
+    {l : List ((a : α) × β a)} {k : α}
+    (contains : (l.map Sigma.fst).contains k = false)
+    {h'} :
+    (t.insertMany l).get k h' =
+    t.get k (mem_of_mem_insertMany_list h' contains) :=
+  Impl.get_insertMany_list_of_contains_eq_false t.wf contains
+
+theorem get_insertMany_list_of_mem [TransCmp cmp] [LawfulEqCmp cmp]
+    {l : List ((a : α) × β a)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β k}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l)
+    {h'} :
+    (t.insertMany l).get k' h' = cast (by congr; apply compare_eq_iff_eq.mp k_eq) v :=
+  Impl.get_insertMany_list_of_mem t.wf k_eq distinct mem
+
+theorem get!_insertMany_list_of_contains_eq_false [TransCmp cmp]
+    [LawfulEqCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List ((a : α) × β a)} {k : α} [Inhabited (β k)]
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (t.insertMany l).get! k = t.get! k :=
+  Impl.get!_insertMany_list_of_contains_eq_false t.wf contains_eq_false
+
+theorem get!_insertMany_list_of_mem [TransCmp cmp] [LawfulEqCmp cmp]
+    {l : List ((a : α) × β a)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β k} [Inhabited (β k')]
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (t.insertMany l).get! k' = cast (by congr; apply compare_eq_iff_eq.mp k_eq) v :=
+  Impl.get!_insertMany_list_of_mem t.wf k_eq distinct mem
+
+theorem getD_insertMany_list_of_contains_eq_false [TransCmp cmp]
+    [LawfulEqCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List ((a : α) × β a)} {k : α} {fallback : β k}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (t.insertMany l).getD k fallback = t.getD k fallback :=
+  Impl.getD_insertMany_list_of_contains_eq_false t.wf contains_eq_false
+
+theorem getD_insertMany_list_of_mem [TransCmp cmp] [LawfulEqCmp cmp]
+    {l : List ((a : α) × β a)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β k} {fallback : β k'}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (t.insertMany l).getD k' fallback = cast (by congr; apply compare_eq_iff_eq.mp k_eq) v :=
+  Impl.getD_insertMany_list_of_mem t.wf k_eq distinct mem
+
+theorem getKey?_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List ((a : α) × β a)} {k : α}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (t.insertMany l).getKey? k = t.getKey? k :=
+  Impl.getKey?_insertMany_list_of_contains_eq_false t.wf contains_eq_false
+
+theorem getKey?_insertMany_list_of_mem [TransCmp cmp]
+    {l : List ((a : α) × β a)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Sigma.fst) :
+    (t.insertMany l).getKey? k' = some k :=
+  Impl.getKey?_insertMany_list_of_mem t.wf k_eq distinct mem
+
+theorem getKey_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List ((a : α) × β a)} {k : α}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false)
+    {h'} :
+    (t.insertMany l).getKey k h' =
+    t.getKey k (mem_of_mem_insertMany_list h' contains_eq_false) :=
+  Impl.getKey_insertMany_list_of_contains_eq_false t.wf contains_eq_false
+
+theorem getKey_insertMany_list_of_mem [TransCmp cmp]
+    {l : List ((a : α) × β a)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Sigma.fst)
+    {h'} :
+    (t.insertMany l).getKey k' h' = k :=
+  Impl.getKey_insertMany_list_of_mem t.wf k_eq distinct mem
+
+theorem getKey!_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    [Inhabited α] {l : List ((a : α) × β a)} {k : α}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (t.insertMany l).getKey! k = t.getKey! k :=
+  Impl.getKey!_insertMany_list_of_contains_eq_false t.wf contains_eq_false
+
+theorem getKey!_insertMany_list_of_mem [TransCmp cmp] [Inhabited α]
+    {l : List ((a : α) × β a)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Sigma.fst) :
+    (t.insertMany l).getKey! k' = k :=
+  Impl.getKey!_insertMany_list_of_mem t.wf k_eq distinct mem
+
+theorem getKeyD_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List ((a : α) × β a)} {k fallback : α}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (t.insertMany l).getKeyD k fallback = t.getKeyD k fallback :=
+  Impl.getKeyD_insertMany_list_of_contains_eq_false t.wf contains_eq_false
+
+theorem getKeyD_insertMany_list_of_mem [TransCmp cmp]
+    {l : List ((a : α) × β a)}
+    {k k' fallback : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Sigma.fst) :
+    (t.insertMany l).getKeyD k' fallback = k :=
+  Impl.getKeyD_insertMany_list_of_mem t.wf k_eq distinct mem
+
+theorem size_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List ((a : α) × β a)} (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) :
+    (∀ (a : α), a ∈ t → (l.map Sigma.fst).contains a = false) →
+    (t.insertMany l).size = t.size + l.length :=
+  Impl.size_insertMany_list t.wf distinct
+
+theorem size_le_size_insertMany_list [TransCmp cmp]
+    {l : List ((a : α) × β a)} :
+    t.size ≤ (t.insertMany l).size :=
+  Impl.size_le_size_insertMany_list t.wf
+
+theorem size_insertMany_list_le [TransCmp cmp]
+    {l : List ((a : α) × β a)} :
+    (t.insertMany l).size ≤ t.size + l.length :=
+  Impl.size_insertMany_list_le t.wf
+
+@[simp]
+theorem isEmpty_insertMany_list [TransCmp cmp]
+    {l : List ((a : α) × β a)} :
+    (t.insertMany l).isEmpty = (t.isEmpty && l.isEmpty) :=
+  Impl.isEmpty_insertMany_list t.wf
+
+namespace Const
+
+variable {β : Type v} {t : DTreeMap α β cmp}
+
+@[simp]
+theorem insertMany_nil :
+    insertMany t [] = t :=
+  rfl
+
+@[simp]
+theorem insertMany_list_singleton {k : α} {v : β} :
+    insertMany t [⟨k, v⟩] = t.insert k v :=
+  rfl
+
+theorem insertMany_cons {l : List (α × β)} {k : α} {v : β} :
+    Const.insertMany t ((k, v) :: l) = Const.insertMany (t.insert k v) l :=
+  ext <| Impl.Const.insertMany_cons t.wf
+
+@[simp]
+theorem contains_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List (α × β)} {k : α} :
+    (Const.insertMany t l).contains k = (t.contains k || (l.map Prod.fst).contains k) :=
+  Impl.Const.contains_insertMany_list t.wf
+
+@[simp]
+theorem mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List (α × β)} {k : α} :
+    k ∈ Const.insertMany t l ↔ k ∈ t ∨ (l.map Prod.fst).contains k :=
+  Impl.Const.mem_insertMany_list t.wf
+
+theorem mem_of_mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List ( α × β )} {k : α} :
+    k ∈ insertMany t l → (l.map Prod.fst).contains k = false → k ∈ t :=
+  Impl.Const.mem_of_mem_insertMany_list t.wf
+
+theorem getKey?_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    (insertMany t l).getKey? k = t.getKey? k :=
+  Impl.Const.getKey?_insertMany_list_of_contains_eq_false t.wf contains_eq_false
+
+theorem getKey?_insertMany_list_of_mem [TransCmp cmp]
+    {l : List  (α × β)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Prod.fst) :
+    (insertMany t l).getKey? k' = some k :=
+  Impl.Const.getKey?_insertMany_list_of_mem t.wf k_eq distinct mem
+
+theorem getKey_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false)
+    {h'} :
+    (insertMany t l).getKey k h' =
+    t.getKey k (mem_of_mem_insertMany_list h' contains_eq_false) :=
+  Impl.Const.getKey_insertMany_list_of_contains_eq_false t.wf contains_eq_false
+
+theorem getKey_insertMany_list_of_mem [TransCmp cmp]
+    {l : List (α × β)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Prod.fst)
+    {h'} :
+    (insertMany t l).getKey k' h' = k :=
+  Impl.Const.getKey_insertMany_list_of_mem t.wf k_eq distinct mem
+
+theorem getKey!_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    [Inhabited α] {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    (insertMany t l).getKey! k = t.getKey! k :=
+  Impl.Const.getKey!_insertMany_list_of_contains_eq_false t.wf contains_eq_false
+
+theorem getKey!_insertMany_list_of_mem [TransCmp cmp] [Inhabited α]
+    {l : List (α × β)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Prod.fst) :
+    (insertMany t l).getKey! k' = k :=
+  Impl.Const.getKey!_insertMany_list_of_mem t.wf k_eq distinct mem
+
+theorem getKeyD_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List (α × β)} {k fallback : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    (insertMany t l).getKeyD k fallback = t.getKeyD k fallback :=
+  Impl.Const.getKeyD_insertMany_list_of_contains_eq_false t.wf contains_eq_false
+
+theorem getKeyD_insertMany_list_of_mem [TransCmp cmp]
+    {l : List (α × β)}
+    {k k' fallback : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Prod.fst) :
+    (insertMany t l).getKeyD k' fallback = k :=
+  Impl.Const.getKeyD_insertMany_list_of_mem t.wf k_eq distinct mem
+
+theorem size_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List (α × β)}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) :
+    (∀ (a : α), a ∈ t → (l.map Prod.fst).contains a = false) →
+    (insertMany t l).size = t.size + l.length :=
+  Impl.Const.size_insertMany_list t.wf distinct
+
+theorem size_le_size_insertMany_list [TransCmp cmp]
+    {l : List (α × β)} :
+    t.size ≤ (insertMany t l).size :=
+  Impl.Const.size_le_size_insertMany_list t.wf
+
+theorem size_insertMany_list_le [TransCmp cmp]
+    {l : List (α × β)} :
+    (insertMany t l).size ≤ t.size + l.length :=
+  Impl.Const.size_insertMany_list_le t.wf
+
+@[simp]
+theorem isEmpty_insertMany_list [TransCmp cmp]
+    {l : List (α × β)} :
+    (insertMany t l).isEmpty = (t.isEmpty && l.isEmpty) :=
+  Impl.Const.isEmpty_insertMany_list t.wf
+
+theorem get?_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    get? (insertMany t l) k = get? t k :=
+  Impl.Const.get?_insertMany_list_of_contains_eq_false t.wf contains_eq_false
+
+theorem get?_insertMany_list_of_mem [TransCmp cmp]
+    {l : List (α × β)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
+    get? (insertMany t l) k' = v :=
+  Impl.Const.get?_insertMany_list_of_mem t.wf k_eq distinct mem
+
+theorem get_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false)
+    {h'} :
+    get (insertMany t l) k h' = get t k (mem_of_mem_insertMany_list h' contains_eq_false) :=
+  Impl.Const.get_insertMany_list_of_contains_eq_false t.wf contains_eq_false
+
+theorem get_insertMany_list_of_mem [TransCmp cmp]
+    {l : List (α × β)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) {h'} :
+    get (insertMany t l) k' h' = v :=
+  Impl.Const.get_insertMany_list_of_mem t.wf k_eq distinct mem
+
+theorem get!_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    [Inhabited β]  {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    get! (insertMany t l) k = get! t k :=
+  Impl.Const.get!_insertMany_list_of_contains_eq_false t.wf contains_eq_false
+
+theorem get!_insertMany_list_of_mem [TransCmp cmp] [Inhabited β]
+    {l : List (α × β)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
+    get! (insertMany t l) k' = v :=
+  Impl.Const.get!_insertMany_list_of_mem t.wf k_eq distinct mem
+
+theorem getD_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List (α × β)} {k : α} {fallback : β}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    getD (insertMany t l) k fallback = getD t k fallback :=
+  Impl.Const.getD_insertMany_list_of_contains_eq_false t.wf contains_eq_false
+
+theorem getD_insertMany_list_of_mem [TransCmp cmp]
+    {l : List (α × β)} {k k' : α} (k_eq : cmp k k' = .eq) {v fallback : β}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
+    getD (insertMany t l) k' fallback = v :=
+  Impl.Const.getD_insertMany_list_of_mem t.wf k_eq distinct mem
+
+variable {t : DTreeMap α Unit cmp}
+
+@[simp]
+theorem insertManyIfNewUnit_nil :
+    insertManyIfNewUnit t [] = t :=
+  rfl
+
+@[simp]
+theorem insertManyIfNewUnit_list_singleton {k : α} :
+    insertManyIfNewUnit t [k] = t.insertIfNew k () :=
+  rfl
+
+theorem insertManyIfNewUnit_cons {l : List α} {k : α} :
+    (insertManyIfNewUnit t (k :: l)).1 = (insertManyIfNewUnit (t.insertIfNew k ()) l).1 :=
+  Impl.Const.insertManyIfNewUnit_cons t.wf
+
+@[simp]
+theorem contains_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List α} {k : α} :
+    (insertManyIfNewUnit t l).contains k = (t.contains k || l.contains k) :=
+  Impl.Const.contains_insertManyIfNewUnit_list t.wf
+
+@[simp]
+theorem mem_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List α} {k : α} :
+    k ∈ insertManyIfNewUnit t l ↔ k ∈ t ∨ l.contains k :=
+  Impl.Const.mem_insertManyIfNewUnit_list t.wf
+
+theorem mem_of_mem_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List α} {k : α} (contains_eq_false : l.contains k = false) :
+    k ∈ insertManyIfNewUnit t l → k ∈ t :=
+  Impl.Const.mem_of_mem_insertManyIfNewUnit_list t.wf contains_eq_false
+
+theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] {l : List α} {k : α} :
+    ¬ k ∈ t → l.contains k = false → getKey? (insertManyIfNewUnit t l) k = none :=
+  Impl.Const.getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false t.wf
+
+theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
+    {l : List α} {k k' : α} (k_eq : cmp k k' = .eq) :
+    ¬ k ∈ t → l.Pairwise (fun a b => ¬ cmp a b = .eq) → k ∈ l →
+      getKey? (insertManyIfNewUnit t l) k' = some k :=
+  Impl.Const.getKey?_insertManyIfNewUnit_list_of_not_mem_of_mem t.wf k_eq
+
+theorem getKey?_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
+    {l : List α} {k : α} :
+    k ∈ t → getKey? (insertManyIfNewUnit t l) k = getKey? t k :=
+  Impl.Const.getKey?_insertManyIfNewUnit_list_of_mem t.wf
+
+theorem getKey_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
+    {l : List α} {k : α} {h'} (contains : k ∈ t) :
+    getKey (insertManyIfNewUnit t l) k h' = getKey t k contains :=
+  Impl.Const.getKey_insertManyIfNewUnit_list_of_mem t.wf contains
+
+theorem getKey_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
+    {l : List α}
+    {k k' : α} (k_eq : cmp k k' = .eq) {h'} :
+    ¬ k ∈ t → l.Pairwise (fun a b => ¬ cmp a b = .eq) → k ∈ l →
+      getKey (insertManyIfNewUnit t l) k' h' = k :=
+  Impl.Const.getKey_insertManyIfNewUnit_list_of_not_mem_of_mem t.wf k_eq
+
+theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] [Inhabited α] {l : List α} {k : α} :
+    ¬ k ∈ t → l.contains k = false →
+      getKey! (insertManyIfNewUnit t l) k = default :=
+  Impl.Const.getKey!_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false t.wf
+
+theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
+    [Inhabited α] {l : List α} {k k' : α} (k_eq : cmp k k' = .eq) :
+    ¬ k ∈ t → l.Pairwise (fun a b => ¬ cmp a b = .eq) → k ∈ l →
+      getKey! (insertManyIfNewUnit t l) k' = k :=
+  Impl.Const.getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem t.wf k_eq
+
+theorem getKey!_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
+    [Inhabited α] {l : List α} {k : α} :
+    k ∈ t → getKey! (insertManyIfNewUnit t l) k = getKey! t k  :=
+  Impl.Const.getKey!_insertManyIfNewUnit_list_of_mem t.wf
+
+theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] {l : List α} {k fallback : α} :
+    ¬ k ∈ t → l.contains k = false → getKeyD (insertManyIfNewUnit t l) k fallback = fallback :=
+  Impl.Const.getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false t.wf
+
+theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
+    {l : List α} {k k' fallback : α} (k_eq : cmp k k' = .eq) :
+    ¬ k ∈ t → l.Pairwise (fun a b => ¬ cmp a b = .eq) → k ∈ l →
+      getKeyD (insertManyIfNewUnit t l) k' fallback = k :=
+  Impl.Const.getKeyD_insertManyIfNewUnit_list_of_not_mem_of_mem t.wf k_eq
+
+theorem getKeyD_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
+    {l : List α} {k fallback : α} :
+    k ∈ t → getKeyD (insertManyIfNewUnit t l) k fallback = getKeyD t k fallback :=
+  Impl.Const.getKeyD_insertManyIfNewUnit_list_of_mem t.wf
+
+theorem size_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List α}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) :
+    (∀ (a : α), a ∈ t → l.contains a = false) →
+    (insertManyIfNewUnit t l).size = t.size + l.length :=
+  Impl.Const.size_insertManyIfNewUnit_list t.wf distinct
+
+theorem size_le_size_insertManyIfNewUnit_list [TransCmp cmp]
+    {l : List α} :
+    t.size ≤ (insertManyIfNewUnit t l).size :=
+  Impl.Const.size_le_size_insertManyIfNewUnit_list t.wf
+
+theorem size_insertManyIfNewUnit_list_le [TransCmp cmp]
+    {l : List α} :
+    (insertManyIfNewUnit t l).size ≤ t.size + l.length :=
+  Impl.Const.size_insertManyIfNewUnit_list_le t.wf
+
+@[simp]
+theorem isEmpty_insertManyIfNewUnit_list [TransCmp cmp] {l : List α} :
+    (insertManyIfNewUnit t l).isEmpty = (t.isEmpty && l.isEmpty) :=
+  Impl.Const.isEmpty_insertManyIfNewUnit_list t.wf
+
+@[simp]
+theorem get?_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List α} {k : α} :
+    get? (insertManyIfNewUnit t l) k =
+      if k ∈ t ∨ l.contains k then some () else none :=
+  Impl.Const.get?_insertManyIfNewUnit_list t.wf
+
+@[simp]
+theorem get_insertManyIfNewUnit_list {l : List α} {k : α} {h'} :
+    get (insertManyIfNewUnit t l) k h' = () :=
+  rfl
+
+@[simp]
+theorem get!_insertManyIfNewUnit_list {l : List α} {k : α} :
+    get! (insertManyIfNewUnit t l) k = () :=
+  rfl
+
+@[simp]
+theorem getD_insertManyIfNewUnit_list
+    {l : List α} {k : α} {fallback : Unit} :
+    getD (insertManyIfNewUnit t l) k fallback = () :=
+  rfl
+
+end Const
+
+@[simp]
+theorem ofList_nil :
+    ofList ([] : List ((a : α) × (β a))) cmp = ∅ :=
+  rfl
+
+@[simp]
+theorem ofList_singleton {k : α} {v : β k} :
+    ofList [⟨k, v⟩] cmp = (∅ : DTreeMap α β cmp).insert k v :=
+  rfl
+
+theorem ofList_cons {k : α} {v : β k} {tl : List ((a : α) × (β a))} :
+    ofList (⟨k, v⟩ :: tl) cmp = ((∅ : DTreeMap α β cmp).insert k v).insertMany tl :=
+  ext <| Impl.insertMany_empty_list_cons
+
+@[simp]
+theorem contains_ofList [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List ((a : α) × β a)} {k : α} :
+    (ofList l cmp).contains k = (l.map Sigma.fst).contains k := by
+  simp [ofList, contains, Impl.ofList]
+  exact Impl.contains_insertMany_empty_list (instOrd := ⟨cmp⟩) (k := k) (l := l)
+
+@[simp]
+theorem mem_ofList [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List ((a : α) × β a)} {k : α} :
+    k ∈ ofList l cmp ↔ (l.map Sigma.fst).contains k := by
+  simp [mem_iff_contains]
+
+theorem get?_ofList_of_contains_eq_false [TransCmp cmp] [LawfulEqCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List ((a : α) × β a)} {k : α}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (ofList l cmp).get? k = none :=
+  Impl.get?_insertMany_empty_list_of_contains_eq_false contains_eq_false
+
+theorem get?_ofList_of_mem [TransCmp cmp] [LawfulEqCmp cmp]
+    {l : List ((a : α) × β a)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β k}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (ofList l cmp).get? k' = some (cast (by congr; apply compare_eq_iff_eq.mp k_eq) v) :=
+  Impl.get?_insertMany_empty_list_of_mem k_eq distinct mem
+
+theorem get_ofList_of_mem [TransCmp cmp] [LawfulEqCmp cmp]
+    {l : List ((a : α) × β a)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β k}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l)
+    {h} :
+    (ofList l cmp).get k' h = cast (by congr; apply compare_eq_iff_eq.mp k_eq) v :=
+  Impl.get_insertMany_empty_list_of_mem k_eq distinct mem
+
+theorem get!_ofList_of_contains_eq_false [TransCmp cmp] [LawfulEqCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List ((a : α) × β a)} {k : α} [Inhabited (β k)]
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (ofList l cmp).get! k = default :=
+  Impl.get!_insertMany_empty_list_of_contains_eq_false contains_eq_false
+
+theorem get!_ofList_of_mem [TransCmp cmp] [LawfulEqCmp cmp]
+    {l : List ((a : α) × β a)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β k} [Inhabited (β k')]
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (ofList l cmp).get! k' = cast (by congr; apply compare_eq_iff_eq.mp k_eq) v :=
+  Impl.get!_insertMany_empty_list_of_mem k_eq distinct mem
+
+theorem getD_ofList_of_contains_eq_false [TransCmp cmp] [LawfulEqCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List ((a : α) × β a)} {k : α} {fallback : β k}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (ofList l cmp).getD k fallback = fallback :=
+  Impl.getD_insertMany_empty_list_of_contains_eq_false contains_eq_false
+
+theorem getD_ofList_of_mem [TransCmp cmp] [LawfulEqCmp cmp]
+    {l : List ((a : α) × β a)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β k} {fallback : β k'}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (ofList l cmp).getD k' fallback = cast (by congr; apply compare_eq_iff_eq.mp k_eq) v :=
+  Impl.getD_insertMany_empty_list_of_mem k_eq distinct mem
+
+theorem getKey?_ofList_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List ((a : α) × β a)} {k : α}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (ofList l cmp).getKey? k = none :=
+  Impl.getKey?_insertMany_empty_list_of_contains_eq_false contains_eq_false
+
+theorem getKey?_ofList_of_mem [TransCmp cmp]
+    {l : List ((a : α) × β a)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Sigma.fst) :
+    (ofList l cmp).getKey? k' = some k :=
+  Impl.getKey?_insertMany_empty_list_of_mem k_eq distinct mem
+
+theorem getKey_ofList_of_mem [TransCmp cmp]
+    {l : List ((a : α) × β a)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Sigma.fst)
+    {h'} :
+    (ofList l cmp).getKey k' h' = k :=
+  Impl.getKey_insertMany_empty_list_of_mem k_eq distinct mem
+
+theorem getKey!_ofList_of_contains_eq_false [TransCmp cmp] [Inhabited α] [BEq α] [LawfulBEqCmp cmp]
+    {l : List ((a : α) × β a)} {k : α}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (ofList l cmp).getKey! k = default :=
+  Impl.getKey!_insertMany_empty_list_of_contains_eq_false contains_eq_false
+
+theorem getKey!_ofList_of_mem [TransCmp cmp] [Inhabited α]
+    {l : List ((a : α) × β a)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Sigma.fst) :
+    (ofList l cmp).getKey! k' = k :=
+  Impl.getKey!_insertMany_empty_list_of_mem k_eq distinct mem
+
+theorem getKeyD_ofList_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List ((a : α) × β a)} {k fallback : α}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (ofList l cmp).getKeyD k fallback = fallback :=
+  Impl.getKeyD_insertMany_empty_list_of_contains_eq_false contains_eq_false
+
+theorem getKeyD_ofList_of_mem [TransCmp cmp]
+    {l : List ((a : α) × β a)}
+    {k k' fallback : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Sigma.fst) :
+    (ofList l cmp).getKeyD k' fallback = k :=
+  Impl.getKeyD_insertMany_empty_list_of_mem k_eq distinct mem
+
 end Std.DTreeMap

--- a/src/Std/Data/DTreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Raw/Lemmas.lean
@@ -1188,7 +1188,7 @@ theorem contains_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h :
 @[simp]
 theorem mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} :
-    k ∈ t.insertMany l ↔  k ∈ t ∨ (l.map Sigma.fst).contains k :=
+    k ∈ t.insertMany l ↔ k ∈ t ∨ (l.map Sigma.fst).contains k :=
   Impl.mem_insertMany!_list h
 
 theorem mem_of_mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
@@ -1376,7 +1376,7 @@ theorem getKey?_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [La
   Impl.Const.getKey?_insertMany!_list_of_contains_eq_false h contains_eq_false
 
 theorem getKey?_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
-    {l : List  (α × β)}
+    {l : List (α × β)}
     {k k' : α} (k_eq : cmp k k' = .eq)
     (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
     (mem : k ∈ l.map Prod.fst) :
@@ -1477,7 +1477,7 @@ theorem get_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
   Impl.Const.get_insertMany!_list_of_mem h k_eq distinct mem
 
 theorem get!_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
-    [Inhabited β]  (h : t.WF) {l : List (α × β)} {k : α}
+    [Inhabited β] (h : t.WF) {l : List (α × β)} {k : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false) :
     get! (insertMany t l) k = get! t k :=
   Impl.Const.get!_insertMany!_list_of_contains_eq_false h contains_eq_false
@@ -1575,7 +1575,7 @@ theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
 
 theorem getKey!_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
     [Inhabited α] (h : t.WF) {l : List α} {k : α} :
-    k ∈ t → getKey! (insertManyIfNewUnit t l) k = getKey! t k  :=
+    k ∈ t → getKey! (insertManyIfNewUnit t l) k = getKey! t k :=
   Impl.Const.getKey!_insertManyIfNewUnit!_list_of_mem h
 
 theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false

--- a/src/Std/Data/DTreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Raw/Lemmas.lean
@@ -1228,9 +1228,9 @@ theorem get_insertMany_list_of_mem [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF)
 theorem get!_insertMany_list_of_contains_eq_false [TransCmp cmp]
     [LawfulEqCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} [Inhabited (β k)]
-    (h' : (l.map Sigma.fst).contains k = false) :
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l).get! k = t.get! k :=
-  Impl.get!_insertMany!_list_of_contains_eq_false h h'
+  Impl.get!_insertMany!_list_of_contains_eq_false h contains_eq_false
 
 theorem get!_insertMany_list_of_mem [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF)
     {l : List ((a : α) × β a)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β k} [Inhabited (β k')]
@@ -1255,9 +1255,9 @@ theorem getD_insertMany_list_of_mem [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF)
 
 theorem getKey?_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     (h : t.WF) {l : List ((a : α) × β a)} {k : α}
-    (h' : (l.map Sigma.fst).contains k = false) :
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l).getKey? k = t.getKey? k :=
-  Impl.getKey?_insertMany!_list_of_contains_eq_false h h'
+  Impl.getKey?_insertMany!_list_of_contains_eq_false h contains_eq_false
 
 theorem getKey?_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
     {l : List ((a : α) × β a)}

--- a/src/Std/Data/DTreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Raw/Lemmas.lean
@@ -1165,4 +1165,606 @@ end Const
 
 end monadic
 
+@[simp]
+theorem insertMany_nil :
+    t.insertMany [] = t :=
+  -- TODO: remove in Internal
+  rfl
+
+@[simp]
+theorem insertMany_list_singleton {k : α} {v : β k} :
+    t.insertMany [⟨k, v⟩] = t.insert k v :=
+  rfl
+
+theorem insertMany_cons {l : List ((a : α) × β a)} {k : α} {v : β k} :
+    t.insertMany (⟨k, v⟩ :: l) = (t.insert k v).insertMany l :=
+  ext <| Impl.insertMany!_cons
+
+@[simp]
+theorem contains_insertMany_list [BEq α] [TransCmp cmp] [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List ((a : α) × β a)} {k : α} :
+    (t.insertMany l).contains k = (t.contains k || (l.map Sigma.fst).contains k) :=
+  Impl.contains_insertMany!_list h
+
+@[simp]
+theorem mem_insertMany_list [BEq α] [TransCmp cmp] [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List ((a : α) × β a)} {k : α} :
+    k ∈ t.insertMany l ↔  k ∈ t ∨ (l.map Sigma.fst).contains k :=
+  Impl.mem_insertMany!_list h
+
+theorem mem_of_mem_insertMany_list [BEq α] [TransCmp cmp] [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List ((a : α) × β a)} {k : α} :
+    k ∈ t.insertMany l → (l.map Sigma.fst).contains k = false → k ∈ t :=
+  Impl.mem_of_mem_insertMany!_list h
+
+theorem get?_insertMany_list_of_contains_eq_false [TransCmp cmp] [LawfulEqCmp cmp] [BEq α]
+    [LawfulBEqCmp cmp] (h : t.WF) {l : List ((a : α) × β a)} {k : α}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (t.insertMany l).get? k = t.get? k :=
+  Impl.get?_insertMany!_list_of_contains_eq_false h contains_eq_false
+
+theorem get?_insertMany_list_of_mem [TransCmp cmp] [LawfulEqCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    (h : t.WF) {l : List ((a : α) × β a)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β k}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
+    (t.insertMany l).get? k' = some (cast (by congr; apply compare_eq_iff_eq.mp k_eq) v) :=
+  Impl.get?_insertMany!_list_of_mem h k_eq distinct mem
+
+theorem get_insertMany_list_of_contains_eq_false [TransCmp cmp] [LawfulEqCmp cmp] [BEq α]
+    [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List ((a : α) × β a)} {k : α}
+    (contains : (l.map Sigma.fst).contains k = false)
+    {h'} :
+    (t.insertMany l).get k h' =
+    t.get k (mem_of_mem_insertMany_list h h' contains) :=
+  Impl.get_insertMany!_list_of_contains_eq_false h contains
+
+theorem get_insertMany_list_of_mem [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF)
+    {l : List ((a : α) × β a)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β k}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l)
+    {h'} :
+    (t.insertMany l).get k' h' = cast (by congr; apply compare_eq_iff_eq.mp k_eq) v :=
+  Impl.get_insertMany!_list_of_mem h k_eq distinct mem
+
+theorem get!_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+    [LawfulEqCmp cmp] (h : t.WF)
+    {l : List ((a : α) × β a)} {k : α} [Inhabited (β k)]
+    (h' : (l.map Sigma.fst).contains k = false) :
+    (t.insertMany l).get! k = t.get! k :=
+  Impl.get!_insertMany!_list_of_contains_eq_false h h'
+
+theorem get!_insertMany_list_of_mem [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF)
+    {l : List ((a : α) × β a)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β k} [Inhabited (β k')]
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (t.insertMany l).get! k' = cast (by congr; apply compare_eq_iff_eq.mp k_eq) v :=
+  Impl.get!_insertMany!_list_of_mem h k_eq distinct mem
+
+theorem getD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+    [LawfulEqCmp cmp] (h : t.WF)
+    {l : List ((a : α) × β a)} {k : α} {fallback : β k}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (t.insertMany l).getD k fallback = t.getD k fallback :=
+  Impl.getD_insertMany!_list_of_contains_eq_false h contains_eq_false
+
+theorem getD_insertMany_list_of_mem [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF)
+    {l : List ((a : α) × β a)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β k} {fallback : β k'}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (t.insertMany l).getD k' fallback = cast (by congr; apply compare_eq_iff_eq.mp k_eq) v :=
+  Impl.getD_insertMany!_list_of_mem h k_eq distinct mem
+
+theorem getKey?_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+    (h : t.WF) {l : List ((a : α) × β a)} {k : α}
+    (h' : (l.map Sigma.fst).contains k = false) :
+    (t.insertMany l).getKey? k = t.getKey? k :=
+  Impl.getKey?_insertMany!_list_of_contains_eq_false h h'
+
+theorem getKey?_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
+    {l : List ((a : α) × β a)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Sigma.fst) :
+    (t.insertMany l).getKey? k' = some k :=
+  Impl.getKey?_insertMany!_list_of_mem h k_eq distinct mem
+
+theorem getKey_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+    {l : List ((a : α) × β a)} {k : α}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false)
+    {h'} :
+    (t.insertMany l).getKey k h' =
+    t.getKey k (mem_of_mem_insertMany_list h h' contains_eq_false) :=
+  Impl.getKey_insertMany!_list_of_contains_eq_false h contains_eq_false
+
+theorem getKey_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
+    {l : List ((a : α) × β a)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Sigma.fst)
+    {h'} :
+    (t.insertMany l).getKey k' h' = k :=
+  Impl.getKey_insertMany!_list_of_mem h k_eq distinct mem
+
+theorem getKey!_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+    [Inhabited α] (h : t.WF) {l : List ((a : α) × β a)} {k : α}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (t.insertMany l).getKey! k = t.getKey! k :=
+  Impl.getKey!_insertMany!_list_of_contains_eq_false h contains_eq_false
+
+theorem getKey!_insertMany_list_of_mem [TransCmp cmp] [Inhabited α] (h : t.WF)
+    {l : List ((a : α) × β a)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Sigma.fst) :
+    (t.insertMany l).getKey! k' = k :=
+  Impl.getKey!_insertMany!_list_of_mem h k_eq distinct mem
+
+theorem getKeyD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+    {l : List ((a : α) × β a)} {k fallback : α}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (t.insertMany l).getKeyD k fallback = t.getKeyD k fallback :=
+  Impl.getKeyD_insertMany!_list_of_contains_eq_false h contains_eq_false
+
+theorem getKeyD_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
+    {l : List ((a : α) × β a)}
+    {k k' fallback : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Sigma.fst) :
+    (t.insertMany l).getKeyD k' fallback = k :=
+  Impl.getKeyD_insertMany!_list_of_mem h k_eq distinct mem
+
+theorem size_insertMany_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+    {l : List ((a : α) × β a)} (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) :
+    (∀ (a : α), a ∈ t → (l.map Sigma.fst).contains a = false) →
+    (t.insertMany l).size = t.size + l.length :=
+  Impl.size_insertMany!_list h distinct
+
+theorem size_le_size_insertMany_list [TransCmp cmp] (h : t.WF)
+    {l : List ((a : α) × β a)} :
+    t.size ≤ (t.insertMany l).size :=
+  Impl.size_le_size_insertMany!_list h
+
+theorem size_insertMany_list_le [TransCmp cmp] (h : t.WF)
+    {l : List ((a : α) × β a)} :
+    (t.insertMany l).size ≤ t.size + l.length :=
+  Impl.size_insertMany!_list_le h
+
+@[simp]
+theorem isEmpty_insertMany_list [TransCmp cmp] (h : t.WF)
+    {l : List ((a : α) × β a)} :
+    (t.insertMany l).isEmpty = (t.isEmpty && l.isEmpty) :=
+  Impl.isEmpty_insertMany!_list h
+
+namespace Const
+
+variable {β : Type v} {t : Raw α β cmp}
+
+@[simp]
+theorem insertMany_nil :
+    insertMany t [] = t :=
+  rfl
+
+@[simp]
+theorem insertMany_list_singleton {k : α} {v : β} :
+    insertMany t [⟨k, v⟩] = t.insert k v :=
+  rfl
+
+theorem insertMany_cons {l : List (α × β)} {k : α} {v : β} :
+    Const.insertMany t ((k, v) :: l) = Const.insertMany (t.insert k v) l :=
+  ext <| Impl.Const.insertMany!_cons
+
+@[simp]
+theorem contains_insertMany_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k : α} :
+    (Const.insertMany t l).contains k = (t.contains k || (l.map Prod.fst).contains k) :=
+  Impl.Const.contains_insertMany!_list h
+
+@[simp]
+theorem mem_insertMany_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k : α} :
+    k ∈ Const.insertMany t l ↔ k ∈ t ∨ (l.map Prod.fst).contains k :=
+  Impl.Const.mem_insertMany!_list h
+
+theorem mem_of_mem_insertMany_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+    {l : List ( α × β )} {k : α} :
+    k ∈ insertMany t l → (l.map Prod.fst).contains k = false → k ∈ t :=
+  Impl.Const.mem_of_mem_insertMany!_list h
+
+theorem getKey?_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    (insertMany t l).getKey? k = t.getKey? k :=
+  Impl.Const.getKey?_insertMany!_list_of_contains_eq_false h contains_eq_false
+
+theorem getKey?_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
+    {l : List  (α × β)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Prod.fst) :
+    (insertMany t l).getKey? k' = some k :=
+  Impl.Const.getKey?_insertMany!_list_of_mem h k_eq distinct mem
+
+theorem getKey_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false)
+    {h'} :
+    (insertMany t l).getKey k h' =
+    t.getKey k (mem_of_mem_insertMany_list h h' contains_eq_false) :=
+  Impl.Const.getKey_insertMany!_list_of_contains_eq_false h contains_eq_false
+
+theorem getKey_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Prod.fst)
+    {h'} :
+    (insertMany t l).getKey k' h' = k :=
+  Impl.Const.getKey_insertMany!_list_of_mem h k_eq distinct mem
+
+theorem getKey!_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] [Inhabited α]
+    (h : t.WF) {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    (insertMany t l).getKey! k = t.getKey! k :=
+  Impl.Const.getKey!_insertMany!_list_of_contains_eq_false h contains_eq_false
+
+theorem getKey!_insertMany_list_of_mem [TransCmp cmp] [Inhabited α] (h : t.WF)
+    {l : List (α × β)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Prod.fst) :
+    (insertMany t l).getKey! k' = k :=
+  Impl.Const.getKey!_insertMany!_list_of_mem h k_eq distinct mem
+
+theorem getKeyD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k fallback : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    (insertMany t l).getKeyD k fallback = t.getKeyD k fallback :=
+  Impl.Const.getKeyD_insertMany!_list_of_contains_eq_false h contains_eq_false
+
+theorem getKeyD_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)}
+    {k k' fallback : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Prod.fst) :
+    (insertMany t l).getKeyD k' fallback = k :=
+  Impl.Const.getKeyD_insertMany!_list_of_mem h k_eq distinct mem
+
+theorem size_insertMany_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) :
+    (∀ (a : α), a ∈ t → (l.map Prod.fst).contains a = false) →
+    (insertMany t l).size = t.size + l.length :=
+  Impl.Const.size_insertMany!_list h distinct
+
+theorem size_le_size_insertMany_list [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} :
+    t.size ≤ (insertMany t l).size :=
+  Impl.Const.size_le_size_insertMany!_list h
+
+theorem size_insertMany_list_le [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} :
+    (insertMany t l).size ≤ t.size + l.length :=
+  Impl.Const.size_insertMany!_list_le h
+
+@[simp]
+theorem isEmpty_insertMany_list [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} :
+    (insertMany t l).isEmpty = (t.isEmpty && l.isEmpty) :=
+  Impl.Const.isEmpty_insertMany!_list h
+
+theorem get?_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    get? (insertMany t l) k = get? t k :=
+  Impl.Const.get?_insertMany!_list_of_contains_eq_false h contains_eq_false
+
+theorem get?_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
+    get? (insertMany t l) k' = v :=
+  Impl.Const.get?_insertMany!_list_of_mem h k_eq distinct mem
+
+theorem get_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false)
+    {h'} :
+    get (insertMany t l) k h' = get t k (mem_of_mem_insertMany_list h h' contains_eq_false) :=
+  Impl.Const.get_insertMany!_list_of_contains_eq_false h contains_eq_false
+
+theorem get_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) {h'} :
+    get (insertMany t l) k' h' = v :=
+  Impl.Const.get_insertMany!_list_of_mem h k_eq distinct mem
+
+theorem get!_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+    [Inhabited β]  (h : t.WF) {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    get! (insertMany t l) k = get! t k :=
+  Impl.Const.get!_insertMany!_list_of_contains_eq_false h contains_eq_false
+
+theorem get!_insertMany_list_of_mem [TransCmp cmp] [Inhabited β] (h : t.WF)
+    {l : List (α × β)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
+    get! (insertMany t l) k' = v :=
+  Impl.Const.get!_insertMany!_list_of_mem h k_eq distinct mem
+
+theorem getD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k : α} {fallback : β}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    getD (insertMany t l) k fallback = getD t k fallback :=
+  Impl.Const.getD_insertMany!_list_of_contains_eq_false h contains_eq_false
+
+theorem getD_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k k' : α} (k_eq : cmp k k' = .eq) {v fallback : β}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
+    getD (insertMany t l) k' fallback = v :=
+  Impl.Const.getD_insertMany!_list_of_mem h k_eq distinct mem
+
+variable {t : Raw α Unit cmp}
+
+@[simp]
+theorem insertManyIfNewUnit_nil :
+    insertManyIfNewUnit t [] = t :=
+  rfl
+
+@[simp]
+theorem insertManyIfNewUnit_list_singleton {k : α} :
+    insertManyIfNewUnit t [k] = t.insertIfNew k () :=
+  rfl
+
+theorem insertManyIfNewUnit_cons {l : List α} {k : α} :
+    (insertManyIfNewUnit t (k :: l)).1 = (insertManyIfNewUnit (t.insertIfNew k ()) l).1 :=
+  Impl.Const.insertManyIfNewUnit!_cons
+
+@[simp]
+theorem contains_insertManyIfNewUnit_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+    {l : List α} {k : α} :
+    (insertManyIfNewUnit t l).contains k = (t.contains k || l.contains k) :=
+  Impl.Const.contains_insertManyIfNewUnit!_list h
+
+@[simp]
+theorem mem_insertManyIfNewUnit_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+    {l : List α} {k : α} :
+    k ∈ insertManyIfNewUnit t l ↔ k ∈ t ∨ l.contains k :=
+  Impl.Const.mem_insertManyIfNewUnit!_list h
+
+theorem mem_of_mem_insertManyIfNewUnit_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+    {l : List α} {k : α} (contains_eq_false : l.contains k = false) :
+    k ∈ insertManyIfNewUnit t l → k ∈ t :=
+  Impl.Const.mem_of_mem_insertManyIfNewUnit!_list h contains_eq_false
+
+theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+    (h : t.WF) {l : List α} {k : α} :
+    ¬ k ∈ t → l.contains k = false → getKey? (insertManyIfNewUnit t l) k = none :=
+  Impl.Const.getKey?_insertManyIfNewUnit!_list_of_not_mem_of_contains_eq_false h
+
+theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
+    (h : t.WF) {l : List α} {k k' : α} (k_eq : cmp k k' = .eq) :
+    ¬ k ∈ t → l.Pairwise (fun a b => ¬ cmp a b = .eq) → k ∈ l →
+      getKey? (insertManyIfNewUnit t l) k' = some k :=
+  Impl.Const.getKey?_insertManyIfNewUnit!_list_of_not_mem_of_mem h k_eq
+
+theorem getKey?_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
+    (h : t.WF) {l : List α} {k : α} :
+    k ∈ t → getKey? (insertManyIfNewUnit t l) k = getKey? t k :=
+  Impl.Const.getKey?_insertManyIfNewUnit!_list_of_mem h
+
+theorem getKey_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
+    (h : t.WF) {l : List α} {k : α} {h'} (contains : k ∈ t) :
+    getKey (insertManyIfNewUnit t l) k h' = getKey t k contains :=
+  Impl.Const.getKey_insertManyIfNewUnit!_list_of_mem h contains
+
+theorem getKey_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
+    (h : t.WF) {l : List α}
+    {k k' : α} (k_eq : cmp k k' = .eq) {h'} :
+    ¬ k ∈ t → l.Pairwise (fun a b => ¬ cmp a b = .eq) → k ∈ l →
+      getKey (insertManyIfNewUnit t l) k' h' = k :=
+  Impl.Const.getKey_insertManyIfNewUnit!_list_of_not_mem_of_mem h k_eq
+
+theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp]
+    [TransCmp cmp] [Inhabited α] (h : t.WF) {l : List α} {k : α} :
+    ¬ k ∈ t → l.contains k = false →
+      getKey! (insertManyIfNewUnit t l) k = default :=
+  Impl.Const.getKey!_insertManyIfNewUnit!_list_of_not_mem_of_contains_eq_false h
+
+theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
+    [Inhabited α] (h : t.WF) {l : List α} {k k' : α} (k_eq : cmp k k' = .eq) :
+    ¬ k ∈ t → l.Pairwise (fun a b => ¬ cmp a b = .eq) → k ∈ l →
+      getKey! (insertManyIfNewUnit t l) k' = k :=
+  Impl.Const.getKey!_insertManyIfNewUnit!_list_of_not_mem_of_mem h k_eq
+
+theorem getKey!_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
+    [Inhabited α] (h : t.WF) {l : List α} {k : α} :
+    k ∈ t → getKey! (insertManyIfNewUnit t l) k = getKey! t k  :=
+  Impl.Const.getKey!_insertManyIfNewUnit!_list_of_mem h
+
+theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp]
+    [TransCmp cmp] (h : t.WF) {l : List α} {k fallback : α} :
+    ¬ k ∈ t → l.contains k = false → getKeyD (insertManyIfNewUnit t l) k fallback = fallback :=
+  Impl.Const.getKeyD_insertManyIfNewUnit!_list_of_not_mem_of_contains_eq_false h
+
+theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
+    (h : t.WF) {l : List α} {k k' fallback : α} (k_eq : cmp k k' = .eq) :
+    ¬ k ∈ t → l.Pairwise (fun a b => ¬ cmp a b = .eq) → k ∈ l →
+      getKeyD (insertManyIfNewUnit t l) k' fallback = k :=
+  Impl.Const.getKeyD_insertManyIfNewUnit!_list_of_not_mem_of_mem h k_eq
+
+theorem getKeyD_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
+    (h : t.WF) {l : List α} {k fallback : α} :
+    k ∈ t → getKeyD (insertManyIfNewUnit t l) k fallback = getKeyD t k fallback :=
+  Impl.Const.getKeyD_insertManyIfNewUnit!_list_of_mem h
+
+theorem size_insertManyIfNewUnit_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+    {l : List α}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) :
+    (∀ (a : α), a ∈ t → l.contains a = false) →
+    (insertManyIfNewUnit t l).size = t.size + l.length :=
+  Impl.Const.size_insertManyIfNewUnit!_list h distinct
+
+theorem size_le_size_insertManyIfNewUnit_list [TransCmp cmp] (h : t.WF)
+    {l : List α} :
+    t.size ≤ (insertManyIfNewUnit t l).size :=
+  Impl.Const.size_le_size_insertManyIfNewUnit!_list h
+
+theorem size_insertManyIfNewUnit_list_le [TransCmp cmp] (h : t.WF)
+    {l : List α} :
+    (insertManyIfNewUnit t l).size ≤ t.size + l.length :=
+  Impl.Const.size_insertManyIfNewUnit!_list_le h
+
+@[simp]
+theorem isEmpty_insertManyIfNewUnit_list [TransCmp cmp] (h : t.WF) {l : List α} :
+    (insertManyIfNewUnit t l).isEmpty = (t.isEmpty && l.isEmpty) :=
+  Impl.Const.isEmpty_insertManyIfNewUnit!_list h
+
+@[simp]
+theorem get?_insertManyIfNewUnit_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+    {l : List α} {k : α} :
+    get? (insertManyIfNewUnit t l) k =
+      if k ∈ t ∨ l.contains k then some () else none :=
+  Impl.Const.get?_insertManyIfNewUnit!_list h
+
+@[simp]
+theorem get_insertManyIfNewUnit_list {l : List α} {k : α} {h'} :
+    get (insertManyIfNewUnit t l) k h' = () :=
+  rfl
+
+@[simp]
+theorem get!_insertManyIfNewUnit_list {l : List α} {k : α} :
+    get! (insertManyIfNewUnit t l) k = () :=
+  rfl
+
+@[simp]
+theorem getD_insertManyIfNewUnit_list
+    {l : List α} {k : α} {fallback : Unit} :
+    getD (insertManyIfNewUnit t l) k fallback = () :=
+  rfl
+
+end Const
+
+@[simp]
+theorem ofList_nil :
+    ofList ([] : List ((a : α) × (β a))) cmp = ∅ :=
+  rfl
+
+@[simp]
+theorem ofList_singleton {k : α} {v : β k} :
+    ofList [⟨k, v⟩] cmp = (∅ : Raw α β cmp).insert k v :=
+  rfl
+
+theorem ofList_cons {k : α} {v : β k} {tl : List ((a : α) × (β a))} :
+    ofList (⟨k, v⟩ :: tl) cmp = ((∅ : Raw α β cmp).insert k v).insertMany tl :=
+  ext <| Impl.insertMany_empty_list_cons_eq_insertMany!
+
+@[simp]
+theorem contains_ofList [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+    {l : List ((a : α) × β a)} {k : α} :
+    (ofList l cmp).contains k = (l.map Sigma.fst).contains k := by
+  simp [ofList, contains, Impl.ofList]
+  exact Impl.contains_insertMany_empty_list (instOrd := ⟨cmp⟩) (k := k) (l := l)
+
+@[simp]
+theorem mem_ofList [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+    {l : List ((a : α) × β a)} {k : α} :
+    k ∈ ofList l cmp ↔ (l.map Sigma.fst).contains k := by
+  simp [mem_iff_contains]
+
+theorem get?_ofList_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [LawfulEqCmp cmp] [TransCmp cmp]
+    {l : List ((a : α) × β a)} {k : α}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (ofList l cmp).get? k = none :=
+  Impl.get?_insertMany_empty_list_of_contains_eq_false contains_eq_false
+
+theorem get?_ofList_of_mem [TransCmp cmp] [LawfulEqCmp cmp]
+    {l : List ((a : α) × β a)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β k}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (ofList l cmp).get? k' = some (cast (by congr; apply compare_eq_iff_eq.mp k_eq) v) :=
+  Impl.get?_insertMany_empty_list_of_mem k_eq distinct mem
+
+theorem get_ofList_of_mem [TransCmp cmp] [LawfulEqCmp cmp]
+    {l : List ((a : α) × β a)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β k}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l)
+    {h} :
+    (ofList l cmp).get k' h = cast (by congr; apply compare_eq_iff_eq.mp k_eq) v :=
+  Impl.get_insertMany_empty_list_of_mem k_eq distinct mem
+
+theorem get!_ofList_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] [LawfulEqCmp cmp]
+    {l : List ((a : α) × β a)} {k : α} [Inhabited (β k)]
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (ofList l cmp).get! k = default :=
+  Impl.get!_insertMany_empty_list_of_contains_eq_false contains_eq_false
+
+theorem get!_ofList_of_mem [TransCmp cmp] [LawfulEqCmp cmp]
+    {l : List ((a : α) × β a)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β k} [Inhabited (β k')]
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (ofList l cmp).get! k' = cast (by congr; apply compare_eq_iff_eq.mp k_eq) v :=
+  Impl.get!_insertMany_empty_list_of_mem k_eq distinct mem
+
+theorem getD_ofList_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] [LawfulEqCmp cmp]
+    {l : List ((a : α) × β a)} {k : α} {fallback : β k}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (ofList l cmp).getD k fallback = fallback :=
+  Impl.getD_insertMany_empty_list_of_contains_eq_false contains_eq_false
+
+theorem getD_ofList_of_mem [TransCmp cmp] [LawfulEqCmp cmp]
+    {l : List ((a : α) × β a)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β k} {fallback : β k'}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (ofList l cmp).getD k' fallback = cast (by congr; apply compare_eq_iff_eq.mp k_eq) v :=
+  Impl.getD_insertMany_empty_list_of_mem k_eq distinct mem
+
+theorem getKey?_ofList_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+    {l : List ((a : α) × β a)} {k : α}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (ofList l cmp).getKey? k = none :=
+  Impl.getKey?_insertMany_empty_list_of_contains_eq_false contains_eq_false
+
+theorem getKey?_ofList_of_mem [TransCmp cmp]
+    {l : List ((a : α) × β a)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Sigma.fst) :
+    (ofList l cmp).getKey? k' = some k :=
+  Impl.getKey?_insertMany_empty_list_of_mem k_eq distinct mem
+
+theorem getKey_ofList_of_mem [TransCmp cmp]
+    {l : List ((a : α) × β a)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Sigma.fst)
+    {h'} :
+    (ofList l cmp).getKey k' h' = k :=
+  Impl.getKey_insertMany_empty_list_of_mem k_eq distinct mem
+
+theorem getKey!_ofList_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] [Inhabited α]
+    {l : List ((a : α) × β a)} {k : α}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (ofList l cmp).getKey! k = default :=
+  Impl.getKey!_insertMany_empty_list_of_contains_eq_false contains_eq_false
+
+theorem getKey!_ofList_of_mem [TransCmp cmp] [Inhabited α]
+    {l : List ((a : α) × β a)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Sigma.fst) :
+    (ofList l cmp).getKey! k' = k :=
+  Impl.getKey!_insertMany_empty_list_of_mem k_eq distinct mem
+
+theorem getKeyD_ofList_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+    {l : List ((a : α) × β a)} {k fallback : α}
+    (contains_eq_false : (l.map Sigma.fst).contains k = false) :
+    (ofList l cmp).getKeyD k fallback = fallback :=
+  Impl.getKeyD_insertMany_empty_list_of_contains_eq_false contains_eq_false
+
+theorem getKeyD_ofList_of_mem [TransCmp cmp]
+    {l : List ((a : α) × β a)}
+    {k k' fallback : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Sigma.fst) :
+    (ofList l cmp).getKeyD k' fallback = k :=
+  Impl.getKeyD_insertMany_empty_list_of_mem k_eq distinct mem
+
 end Std.DTreeMap.Raw

--- a/src/Std/Data/DTreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Raw/Lemmas.lean
@@ -1513,8 +1513,8 @@ theorem insertManyIfNewUnit_list_singleton {k : α} :
   rfl
 
 theorem insertManyIfNewUnit_cons {l : List α} {k : α} :
-    (insertManyIfNewUnit t (k :: l)).1 = (insertManyIfNewUnit (t.insertIfNew k ()) l).1 :=
-  Impl.Const.insertManyIfNewUnit!_cons
+    insertManyIfNewUnit t (k :: l) = insertManyIfNewUnit (t.insertIfNew k ()) l :=
+  ext <| Impl.Const.insertManyIfNewUnit!_cons
 
 @[simp]
 theorem contains_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)

--- a/src/Std/Data/DTreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Raw/Lemmas.lean
@@ -1168,7 +1168,6 @@ end monadic
 @[simp]
 theorem insertMany_nil :
     t.insertMany [] = t :=
-  -- TODO: remove in Internal
   rfl
 
 @[simp]
@@ -1268,8 +1267,8 @@ theorem getKey?_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
     (t.insertMany l).getKey? k' = some k :=
   Impl.getKey?_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem getKey_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
-    {l : List ((a : α) × β a)} {k : α}
+theorem getKey_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+    (h : t.WF) {l : List ((a : α) × β a)} {k : α}
     (contains_eq_false : (l.map Sigma.fst).contains k = false)
     {h'} :
     (t.insertMany l).getKey k h' =
@@ -1299,8 +1298,8 @@ theorem getKey!_insertMany_list_of_mem [TransCmp cmp] [Inhabited α] (h : t.WF)
     (t.insertMany l).getKey! k' = k :=
   Impl.getKey!_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem getKeyD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
-    {l : List ((a : α) × β a)} {k fallback : α}
+theorem getKeyD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+    (h : t.WF) {l : List ((a : α) × β a)} {k fallback : α}
     (contains_eq_false : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l).getKeyD k fallback = t.getKeyD k fallback :=
   Impl.getKeyD_insertMany!_list_of_contains_eq_false h contains_eq_false
@@ -1370,8 +1369,8 @@ theorem mem_of_mem_insertMany_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h
     k ∈ insertMany t l → (l.map Prod.fst).contains k = false → k ∈ t :=
   Impl.Const.mem_of_mem_insertMany!_list h
 
-theorem getKey?_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
-    {l : List (α × β)} {k : α}
+theorem getKey?_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+    (h : t.WF) {l : List (α × β)} {k : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false) :
     (insertMany t l).getKey? k = t.getKey? k :=
   Impl.Const.getKey?_insertMany!_list_of_contains_eq_false h contains_eq_false
@@ -1384,8 +1383,8 @@ theorem getKey?_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
     (insertMany t l).getKey? k' = some k :=
   Impl.Const.getKey?_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem getKey_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
-    {l : List (α × β)} {k : α}
+theorem getKey_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+    (h : t.WF) {l : List (α × β)} {k : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false)
     {h'} :
     (insertMany t l).getKey k h' =
@@ -1401,8 +1400,8 @@ theorem getKey_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
     (insertMany t l).getKey k' h' = k :=
   Impl.Const.getKey_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem getKey!_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] [Inhabited α]
-    (h : t.WF) {l : List (α × β)} {k : α}
+theorem getKey!_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+    [Inhabited α] (h : t.WF) {l : List (α × β)} {k : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false) :
     (insertMany t l).getKey! k = t.getKey! k :=
   Impl.Const.getKey!_insertMany!_list_of_contains_eq_false h contains_eq_false
@@ -1415,8 +1414,8 @@ theorem getKey!_insertMany_list_of_mem [TransCmp cmp] [Inhabited α] (h : t.WF)
     (insertMany t l).getKey! k' = k :=
   Impl.Const.getKey!_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem getKeyD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
-    {l : List (α × β)} {k fallback : α}
+theorem getKeyD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+    (h : t.WF) {l : List (α × β)} {k fallback : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false) :
     (insertMany t l).getKeyD k fallback = t.getKeyD k fallback :=
   Impl.Const.getKeyD_insertMany!_list_of_contains_eq_false h contains_eq_false
@@ -1452,8 +1451,8 @@ theorem isEmpty_insertMany_list [TransCmp cmp] (h : t.WF)
     (insertMany t l).isEmpty = (t.isEmpty && l.isEmpty) :=
   Impl.Const.isEmpty_insertMany!_list h
 
-theorem get?_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
-    {l : List (α × β)} {k : α}
+theorem get?_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+    (h : t.WF) {l : List (α × β)} {k : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false) :
     get? (insertMany t l) k = get? t k :=
   Impl.Const.get?_insertMany!_list_of_contains_eq_false h contains_eq_false
@@ -1464,8 +1463,8 @@ theorem get?_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
     get? (insertMany t l) k' = v :=
   Impl.Const.get?_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem get_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
-    {l : List (α × β)} {k : α}
+theorem get_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+    (h : t.WF) {l : List (α × β)} {k : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false)
     {h'} :
     get (insertMany t l) k h' = get t k (mem_of_mem_insertMany_list h h' contains_eq_false) :=
@@ -1489,8 +1488,8 @@ theorem get!_insertMany_list_of_mem [TransCmp cmp] [Inhabited β] (h : t.WF)
     get! (insertMany t l) k' = v :=
   Impl.Const.get!_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem getD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
-    {l : List (α × β)} {k : α} {fallback : β}
+theorem getD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+    (h : t.WF) {l : List (α × β)} {k : α} {fallback : β}
     (contains_eq_false : (l.map Prod.fst).contains k = false) :
     getD (insertMany t l) k fallback = getD t k fallback :=
   Impl.Const.getD_insertMany!_list_of_contains_eq_false h contains_eq_false
@@ -1534,8 +1533,8 @@ theorem mem_of_mem_insertManyIfNewUnit_list [BEq α] [LawfulBEqCmp cmp] [TransCm
     k ∈ insertManyIfNewUnit t l → k ∈ t :=
   Impl.Const.mem_of_mem_insertManyIfNewUnit!_list h contains_eq_false
 
-theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
-    (h : t.WF) {l : List α} {k : α} :
+theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp]
+    [TransCmp cmp] (h : t.WF) {l : List α} {k : α} :
     ¬ k ∈ t → l.contains k = false → getKey? (insertManyIfNewUnit t l) k = none :=
   Impl.Const.getKey?_insertManyIfNewUnit!_list_of_not_mem_of_contains_eq_false h
 

--- a/src/Std/Data/DTreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Raw/Lemmas.lean
@@ -288,7 +288,7 @@ theorem get?_erase_self [TransCmp cmp] (h : t.WF) {k : α} :
     get? (t.erase k) k = none :=
   Impl.Const.get?_erase!_self h
 
-theorem get?_eq_get? [LawfulEqCmp cmp] [TransCmp cmp] (h : t.WF) {a : α} : get? t a = t.get? a :=
+theorem get?_eq_get? [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF) {a : α} : get? t a = t.get? a :=
   Impl.Const.get?_eq_get? h
 
 theorem get?_congr [TransCmp cmp] (h : t.WF) {a b : α} (hab : cmp a b = .eq) :
@@ -1180,18 +1180,18 @@ theorem insertMany_cons {l : List ((a : α) × β a)} {k : α} {v : β k} :
   ext <| Impl.insertMany!_cons
 
 @[simp]
-theorem contains_insertMany_list [BEq α] [TransCmp cmp] [LawfulBEqCmp cmp] (h : t.WF)
+theorem contains_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} :
     (t.insertMany l).contains k = (t.contains k || (l.map Sigma.fst).contains k) :=
   Impl.contains_insertMany!_list h
 
 @[simp]
-theorem mem_insertMany_list [BEq α] [TransCmp cmp] [LawfulBEqCmp cmp] (h : t.WF)
+theorem mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} :
     k ∈ t.insertMany l ↔  k ∈ t ∨ (l.map Sigma.fst).contains k :=
   Impl.mem_insertMany!_list h
 
-theorem mem_of_mem_insertMany_list [BEq α] [TransCmp cmp] [LawfulBEqCmp cmp] (h : t.WF)
+theorem mem_of_mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} :
     k ∈ t.insertMany l → (l.map Sigma.fst).contains k = false → k ∈ t :=
   Impl.mem_of_mem_insertMany!_list h
@@ -1225,8 +1225,8 @@ theorem get_insertMany_list_of_mem [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF)
     (t.insertMany l).get k' h' = cast (by congr; apply compare_eq_iff_eq.mp k_eq) v :=
   Impl.get_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem get!_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
-    [LawfulEqCmp cmp] (h : t.WF)
+theorem get!_insertMany_list_of_contains_eq_false [TransCmp cmp]
+    [LawfulEqCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} [Inhabited (β k)]
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l).get! k = t.get! k :=
@@ -1239,8 +1239,8 @@ theorem get!_insertMany_list_of_mem [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF)
     (t.insertMany l).get! k' = cast (by congr; apply compare_eq_iff_eq.mp k_eq) v :=
   Impl.get!_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem getD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
-    [LawfulEqCmp cmp] (h : t.WF)
+theorem getD_insertMany_list_of_contains_eq_false [TransCmp cmp]
+    [LawfulEqCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
     {l : List ((a : α) × β a)} {k : α} {fallback : β k}
     (contains_eq_false : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l).getD k fallback = t.getD k fallback :=
@@ -1253,7 +1253,7 @@ theorem getD_insertMany_list_of_mem [TransCmp cmp] [LawfulEqCmp cmp] (h : t.WF)
     (t.insertMany l).getD k' fallback = cast (by congr; apply compare_eq_iff_eq.mp k_eq) v :=
   Impl.getD_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem getKey?_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+theorem getKey?_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     (h : t.WF) {l : List ((a : α) × β a)} {k : α}
     (h' : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l).getKey? k = t.getKey? k :=
@@ -1267,7 +1267,7 @@ theorem getKey?_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
     (t.insertMany l).getKey? k' = some k :=
   Impl.getKey?_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem getKey_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+theorem getKey_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     (h : t.WF) {l : List ((a : α) × β a)} {k : α}
     (contains_eq_false : (l.map Sigma.fst).contains k = false)
     {h'} :
@@ -1284,7 +1284,7 @@ theorem getKey_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
     (t.insertMany l).getKey k' h' = k :=
   Impl.getKey_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem getKey!_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+theorem getKey!_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     [Inhabited α] (h : t.WF) {l : List ((a : α) × β a)} {k : α}
     (contains_eq_false : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l).getKey! k = t.getKey! k :=
@@ -1298,7 +1298,7 @@ theorem getKey!_insertMany_list_of_mem [TransCmp cmp] [Inhabited α] (h : t.WF)
     (t.insertMany l).getKey! k' = k :=
   Impl.getKey!_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem getKeyD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+theorem getKeyD_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     (h : t.WF) {l : List ((a : α) × β a)} {k fallback : α}
     (contains_eq_false : (l.map Sigma.fst).contains k = false) :
     (t.insertMany l).getKeyD k fallback = t.getKeyD k fallback :=
@@ -1312,7 +1312,7 @@ theorem getKeyD_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
     (t.insertMany l).getKeyD k' fallback = k :=
   Impl.getKeyD_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem size_insertMany_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+theorem size_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
     {l : List ((a : α) × β a)} (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) :
     (∀ (a : α), a ∈ t → (l.map Sigma.fst).contains a = false) →
     (t.insertMany l).size = t.size + l.length :=
@@ -1353,23 +1353,23 @@ theorem insertMany_cons {l : List (α × β)} {k : α} {v : β} :
   ext <| Impl.Const.insertMany!_cons
 
 @[simp]
-theorem contains_insertMany_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+theorem contains_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
     {l : List (α × β)} {k : α} :
     (Const.insertMany t l).contains k = (t.contains k || (l.map Prod.fst).contains k) :=
   Impl.Const.contains_insertMany!_list h
 
 @[simp]
-theorem mem_insertMany_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+theorem mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
     {l : List (α × β)} {k : α} :
     k ∈ Const.insertMany t l ↔ k ∈ t ∨ (l.map Prod.fst).contains k :=
   Impl.Const.mem_insertMany!_list h
 
-theorem mem_of_mem_insertMany_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+theorem mem_of_mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
     {l : List ( α × β )} {k : α} :
     k ∈ insertMany t l → (l.map Prod.fst).contains k = false → k ∈ t :=
   Impl.Const.mem_of_mem_insertMany!_list h
 
-theorem getKey?_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+theorem getKey?_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     (h : t.WF) {l : List (α × β)} {k : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false) :
     (insertMany t l).getKey? k = t.getKey? k :=
@@ -1383,7 +1383,7 @@ theorem getKey?_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
     (insertMany t l).getKey? k' = some k :=
   Impl.Const.getKey?_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem getKey_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+theorem getKey_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     (h : t.WF) {l : List (α × β)} {k : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false)
     {h'} :
@@ -1400,7 +1400,7 @@ theorem getKey_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
     (insertMany t l).getKey k' h' = k :=
   Impl.Const.getKey_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem getKey!_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+theorem getKey!_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     [Inhabited α] (h : t.WF) {l : List (α × β)} {k : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false) :
     (insertMany t l).getKey! k = t.getKey! k :=
@@ -1414,7 +1414,7 @@ theorem getKey!_insertMany_list_of_mem [TransCmp cmp] [Inhabited α] (h : t.WF)
     (insertMany t l).getKey! k' = k :=
   Impl.Const.getKey!_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem getKeyD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+theorem getKeyD_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     (h : t.WF) {l : List (α × β)} {k fallback : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false) :
     (insertMany t l).getKeyD k fallback = t.getKeyD k fallback :=
@@ -1428,7 +1428,7 @@ theorem getKeyD_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
     (insertMany t l).getKeyD k' fallback = k :=
   Impl.Const.getKeyD_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem size_insertMany_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+theorem size_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
     {l : List (α × β)}
     (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) :
     (∀ (a : α), a ∈ t → (l.map Prod.fst).contains a = false) →
@@ -1451,7 +1451,7 @@ theorem isEmpty_insertMany_list [TransCmp cmp] (h : t.WF)
     (insertMany t l).isEmpty = (t.isEmpty && l.isEmpty) :=
   Impl.Const.isEmpty_insertMany!_list h
 
-theorem get?_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+theorem get?_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     (h : t.WF) {l : List (α × β)} {k : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false) :
     get? (insertMany t l) k = get? t k :=
@@ -1463,7 +1463,7 @@ theorem get?_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
     get? (insertMany t l) k' = v :=
   Impl.Const.get?_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem get_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+theorem get_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     (h : t.WF) {l : List (α × β)} {k : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false)
     {h'} :
@@ -1476,7 +1476,7 @@ theorem get_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
     get (insertMany t l) k' h' = v :=
   Impl.Const.get_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem get!_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+theorem get!_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     [Inhabited β]  (h : t.WF) {l : List (α × β)} {k : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false) :
     get! (insertMany t l) k = get! t k :=
@@ -1488,7 +1488,7 @@ theorem get!_insertMany_list_of_mem [TransCmp cmp] [Inhabited β] (h : t.WF)
     get! (insertMany t l) k' = v :=
   Impl.Const.get!_insertMany!_list_of_mem h k_eq distinct mem
 
-theorem getD_insertMany_list_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+theorem getD_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     (h : t.WF) {l : List (α × β)} {k : α} {fallback : β}
     (contains_eq_false : (l.map Prod.fst).contains k = false) :
     getD (insertMany t l) k fallback = getD t k fallback :=
@@ -1517,24 +1517,24 @@ theorem insertManyIfNewUnit_cons {l : List α} {k : α} :
   Impl.Const.insertManyIfNewUnit!_cons
 
 @[simp]
-theorem contains_insertManyIfNewUnit_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+theorem contains_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
     {l : List α} {k : α} :
     (insertManyIfNewUnit t l).contains k = (t.contains k || l.contains k) :=
   Impl.Const.contains_insertManyIfNewUnit!_list h
 
 @[simp]
-theorem mem_insertManyIfNewUnit_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+theorem mem_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
     {l : List α} {k : α} :
     k ∈ insertManyIfNewUnit t l ↔ k ∈ t ∨ l.contains k :=
   Impl.Const.mem_insertManyIfNewUnit!_list h
 
-theorem mem_of_mem_insertManyIfNewUnit_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+theorem mem_of_mem_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
     {l : List α} {k : α} (contains_eq_false : l.contains k = false) :
     k ∈ insertManyIfNewUnit t l → k ∈ t :=
   Impl.Const.mem_of_mem_insertManyIfNewUnit!_list h contains_eq_false
 
-theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp]
-    [TransCmp cmp] (h : t.WF) {l : List α} {k : α} :
+theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF) {l : List α} {k : α} :
     ¬ k ∈ t → l.contains k = false → getKey? (insertManyIfNewUnit t l) k = none :=
   Impl.Const.getKey?_insertManyIfNewUnit!_list_of_not_mem_of_contains_eq_false h
 
@@ -1561,8 +1561,8 @@ theorem getKey_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
       getKey (insertManyIfNewUnit t l) k' h' = k :=
   Impl.Const.getKey_insertManyIfNewUnit!_list_of_not_mem_of_mem h k_eq
 
-theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp]
-    [TransCmp cmp] [Inhabited α] (h : t.WF) {l : List α} {k : α} :
+theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] [Inhabited α] (h : t.WF) {l : List α} {k : α} :
     ¬ k ∈ t → l.contains k = false →
       getKey! (insertManyIfNewUnit t l) k = default :=
   Impl.Const.getKey!_insertManyIfNewUnit!_list_of_not_mem_of_contains_eq_false h
@@ -1578,8 +1578,8 @@ theorem getKey!_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
     k ∈ t → getKey! (insertManyIfNewUnit t l) k = getKey! t k  :=
   Impl.Const.getKey!_insertManyIfNewUnit!_list_of_mem h
 
-theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp]
-    [TransCmp cmp] (h : t.WF) {l : List α} {k fallback : α} :
+theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF) {l : List α} {k fallback : α} :
     ¬ k ∈ t → l.contains k = false → getKeyD (insertManyIfNewUnit t l) k fallback = fallback :=
   Impl.Const.getKeyD_insertManyIfNewUnit!_list_of_not_mem_of_contains_eq_false h
 
@@ -1594,7 +1594,7 @@ theorem getKeyD_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
     k ∈ t → getKeyD (insertManyIfNewUnit t l) k fallback = getKeyD t k fallback :=
   Impl.Const.getKeyD_insertManyIfNewUnit!_list_of_mem h
 
-theorem size_insertManyIfNewUnit_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+theorem size_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
     {l : List α}
     (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) :
     (∀ (a : α), a ∈ t → l.contains a = false) →
@@ -1617,7 +1617,7 @@ theorem isEmpty_insertManyIfNewUnit_list [TransCmp cmp] (h : t.WF) {l : List α}
   Impl.Const.isEmpty_insertManyIfNewUnit!_list h
 
 @[simp]
-theorem get?_insertManyIfNewUnit_list [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] (h : t.WF)
+theorem get?_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
     {l : List α} {k : α} :
     get? (insertManyIfNewUnit t l) k =
       if k ∈ t ∨ l.contains k then some () else none :=
@@ -1656,19 +1656,19 @@ theorem ofList_cons {k : α} {v : β k} {tl : List ((a : α) × (β a))} :
   ext <| Impl.insertMany_empty_list_cons_eq_insertMany!
 
 @[simp]
-theorem contains_ofList [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+theorem contains_ofList [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     {l : List ((a : α) × β a)} {k : α} :
     (ofList l cmp).contains k = (l.map Sigma.fst).contains k := by
   simp [ofList, contains, Impl.ofList]
   exact Impl.contains_insertMany_empty_list (instOrd := ⟨cmp⟩) (k := k) (l := l)
 
 @[simp]
-theorem mem_ofList [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+theorem mem_ofList [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     {l : List ((a : α) × β a)} {k : α} :
     k ∈ ofList l cmp ↔ (l.map Sigma.fst).contains k := by
   simp [mem_iff_contains]
 
-theorem get?_ofList_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [LawfulEqCmp cmp] [TransCmp cmp]
+theorem get?_ofList_of_contains_eq_false [TransCmp cmp] [LawfulEqCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     {l : List ((a : α) × β a)} {k : α}
     (contains_eq_false : (l.map Sigma.fst).contains k = false) :
     (ofList l cmp).get? k = none :=
@@ -1689,7 +1689,7 @@ theorem get_ofList_of_mem [TransCmp cmp] [LawfulEqCmp cmp]
     (ofList l cmp).get k' h = cast (by congr; apply compare_eq_iff_eq.mp k_eq) v :=
   Impl.get_insertMany_empty_list_of_mem k_eq distinct mem
 
-theorem get!_ofList_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] [LawfulEqCmp cmp]
+theorem get!_ofList_of_contains_eq_false [TransCmp cmp] [LawfulEqCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     {l : List ((a : α) × β a)} {k : α} [Inhabited (β k)]
     (contains_eq_false : (l.map Sigma.fst).contains k = false) :
     (ofList l cmp).get! k = default :=
@@ -1702,7 +1702,7 @@ theorem get!_ofList_of_mem [TransCmp cmp] [LawfulEqCmp cmp]
     (ofList l cmp).get! k' = cast (by congr; apply compare_eq_iff_eq.mp k_eq) v :=
   Impl.get!_insertMany_empty_list_of_mem k_eq distinct mem
 
-theorem getD_ofList_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] [LawfulEqCmp cmp]
+theorem getD_ofList_of_contains_eq_false [TransCmp cmp] [LawfulEqCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     {l : List ((a : α) × β a)} {k : α} {fallback : β k}
     (contains_eq_false : (l.map Sigma.fst).contains k = false) :
     (ofList l cmp).getD k fallback = fallback :=
@@ -1715,7 +1715,7 @@ theorem getD_ofList_of_mem [TransCmp cmp] [LawfulEqCmp cmp]
     (ofList l cmp).getD k' fallback = cast (by congr; apply compare_eq_iff_eq.mp k_eq) v :=
   Impl.getD_insertMany_empty_list_of_mem k_eq distinct mem
 
-theorem getKey?_ofList_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+theorem getKey?_ofList_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     {l : List ((a : α) × β a)} {k : α}
     (contains_eq_false : (l.map Sigma.fst).contains k = false) :
     (ofList l cmp).getKey? k = none :=
@@ -1738,7 +1738,7 @@ theorem getKey_ofList_of_mem [TransCmp cmp]
     (ofList l cmp).getKey k' h' = k :=
   Impl.getKey_insertMany_empty_list_of_mem k_eq distinct mem
 
-theorem getKey!_ofList_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp] [Inhabited α]
+theorem getKey!_ofList_of_contains_eq_false [TransCmp cmp] [Inhabited α] [BEq α] [LawfulBEqCmp cmp]
     {l : List ((a : α) × β a)} {k : α}
     (contains_eq_false : (l.map Sigma.fst).contains k = false) :
     (ofList l cmp).getKey! k = default :=
@@ -1752,7 +1752,7 @@ theorem getKey!_ofList_of_mem [TransCmp cmp] [Inhabited α]
     (ofList l cmp).getKey! k' = k :=
   Impl.getKey!_insertMany_empty_list_of_mem k_eq distinct mem
 
-theorem getKeyD_ofList_of_contains_eq_false [BEq α] [LawfulBEqCmp cmp] [TransCmp cmp]
+theorem getKeyD_ofList_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     {l : List ((a : α) × β a)} {k fallback : α}
     (contains_eq_false : (l.map Sigma.fst).contains k = false) :
     (ofList l cmp).getKeyD k fallback = fallback :=

--- a/src/Std/Data/HashMap/RawLemmas.lean
+++ b/src/Std/Data/HashMap/RawLemmas.lean
@@ -1068,7 +1068,7 @@ theorem mem_of_mem_insertManyIfNewUnit_list [EquivBEq α] [LawfulHashable α] (h
 
 theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
     [EquivBEq α] [LawfulHashable α] (h : m.WF) {l : List α} {k : α}
-    (not_mem : ¬ k ∈ m) (contains_eq_false: l.contains k = false) :
+    (not_mem : ¬ k ∈ m) (contains_eq_false : l.contains k = false) :
     getKey? (insertManyIfNewUnit m l) k = none :=
   DHashMap.Raw.Const.getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
     h.out not_mem contains_eq_false

--- a/src/Std/Data/Internal/List/Associative.lean
+++ b/src/Std/Data/Internal/List/Associative.lean
@@ -2384,8 +2384,8 @@ theorem getValueCast?_insertList_of_contains_eq_false [BEq α] [LawfulBEq α]
 
 theorem getValueCast?_insertList_of_mem [BEq α] [LawfulBEq α]
     {l toInsert : List ((a : α) × β a)}
-    {k k' : α} (k_beq : k == k') {v : β k}
     (distinct_l : DistinctKeys l)
+    {k k' : α} (k_beq : k == k') {v : β k}
     (distinct_toInsert : toInsert.Pairwise (fun a b => (a.1 == b.1) = false))
     (mem : ⟨k, v⟩ ∈ toInsert) :
     getValueCast? k' (insertList l toInsert) =
@@ -2412,15 +2412,15 @@ theorem getValueCast_insertList_of_contains_eq_false [BEq α] [LawfulBEq α]
 
 theorem getValueCast_insertList_of_mem [BEq α] [LawfulBEq α]
     {l toInsert : List ((a : α) × β a)}
-    {k k' : α} (k_beq : k == k') (v : β k)
     (distinct_l : DistinctKeys l)
+    {k k' : α} (k_beq : k == k') (v : β k)
     (distinct_toInsert : toInsert.Pairwise (fun a b => (a.1 == b.1) = false))
     (mem : ⟨k, v⟩ ∈ toInsert)
     {h} :
     getValueCast k' (insertList l toInsert) h =
     cast (by congr; exact LawfulBEq.eq_of_beq k_beq) v := by
   rw [← Option.some_inj, ← getValueCast?_eq_some_getValueCast,
-    getValueCast?_insertList_of_mem k_beq distinct_l distinct_toInsert mem]
+    getValueCast?_insertList_of_mem distinct_l k_beq distinct_toInsert mem]
 
 theorem getValueCast!_insertList_of_contains_eq_false [BEq α] [LawfulBEq α]
     {l toInsert : List ((a : α) × β a)} {k : α} [Inhabited (β k)]
@@ -2431,14 +2431,14 @@ theorem getValueCast!_insertList_of_contains_eq_false [BEq α] [LawfulBEq α]
 
 theorem getValueCast!_insertList_of_mem [BEq α] [LawfulBEq α]
     {l toInsert : List ((a : α) × β a)}
-    {k k' : α} (k_beq : k == k') (v : β k) [Inhabited (β k')]
     (distinct_l : DistinctKeys l)
+    {k k' : α} (k_beq : k == k') (v : β k) [Inhabited (β k')]
     (distinct_toInsert : toInsert.Pairwise (fun a b => (a.1 == b.1) = false))
     (mem : ⟨k, v⟩ ∈ toInsert) :
     getValueCast! k' (insertList l toInsert) =
     cast (by congr; exact LawfulBEq.eq_of_beq k_beq) v := by
   rw [getValueCast!_eq_getValueCast?,
-    getValueCast?_insertList_of_mem k_beq distinct_l distinct_toInsert mem, Option.get!_some]
+    getValueCast?_insertList_of_mem distinct_l k_beq distinct_toInsert mem, Option.get!_some]
 
 theorem getValueCastD_insertList_of_contains_eq_false [BEq α] [LawfulBEq α]
     {l toInsert : List ((a : α) × β a)} {k : α} {fallback : β k}
@@ -2449,14 +2449,14 @@ theorem getValueCastD_insertList_of_contains_eq_false [BEq α] [LawfulBEq α]
 
 theorem getValueCastD_insertList_of_mem [BEq α] [LawfulBEq α]
     {l toInsert : List ((a : α) × β a)}
-    {k k' : α} (k_beq : k == k') {v : β k} {fallback : β k'}
     (distinct_l : DistinctKeys l)
+    {k k' : α} (k_beq : k == k') {v : β k} {fallback : β k'}
     (distinct_toInsert : toInsert.Pairwise (fun a b => (a.1 == b.1) = false))
     (mem : ⟨k, v⟩ ∈ toInsert) :
     getValueCastD k' (insertList l toInsert) fallback =
     cast (by congr; exact LawfulBEq.eq_of_beq k_beq) v := by
   rw [getValueCastD_eq_getValueCast?,
-    getValueCast?_insertList_of_mem k_beq distinct_l distinct_toInsert mem, Option.getD_some]
+    getValueCast?_insertList_of_mem distinct_l k_beq distinct_toInsert mem, Option.getD_some]
 
 theorem getKey?_insertList_of_contains_eq_false [BEq α] [EquivBEq α]
     {l toInsert : List ((a : α) × β a)} {k : α}
@@ -2468,8 +2468,8 @@ theorem getKey?_insertList_of_contains_eq_false [BEq α] [EquivBEq α]
 
 theorem getKey?_insertList_of_mem [BEq α] [EquivBEq α]
     {l toInsert : List ((a : α) × β a)}
-    {k k' : α} (k_beq : k == k')
     (distinct_l : DistinctKeys l)
+    {k k' : α} (k_beq : k == k')
     (distinct_toInsert : toInsert.Pairwise (fun a b => (a.1 == b.1) = false))
     (mem : k ∈ toInsert.map Sigma.fst) :
     getKey? k' (insertList l toInsert) = some k := by
@@ -2489,14 +2489,14 @@ theorem getKey_insertList_of_contains_eq_false [BEq α] [EquivBEq α]
 
 theorem getKey_insertList_of_mem [BEq α] [EquivBEq α]
     {l toInsert : List ((a : α) × β a)}
-    {k k' : α} (k_beq : k == k')
     (distinct_l : DistinctKeys l)
+    {k k' : α} (k_beq : k == k')
     (distinct_toInsert : toInsert.Pairwise (fun a b => (a.1 == b.1) = false))
     (mem : k ∈ toInsert.map Sigma.fst)
     {h} :
     getKey k' (insertList l toInsert) h = k := by
   rw [← Option.some_inj, ← getKey?_eq_some_getKey,
-    getKey?_insertList_of_mem k_beq distinct_l distinct_toInsert mem]
+    getKey?_insertList_of_mem distinct_l k_beq distinct_toInsert mem]
 
 theorem getKey!_insertList_of_contains_eq_false [BEq α] [EquivBEq α] [Inhabited α]
     {l toInsert : List ((a : α) × β a)} {k : α}
@@ -2506,12 +2506,12 @@ theorem getKey!_insertList_of_contains_eq_false [BEq α] [EquivBEq α] [Inhabite
 
 theorem getKey!_insertList_of_mem [BEq α] [EquivBEq α] [Inhabited α]
     {l toInsert : List ((a : α) × β a)}
-    {k k' : α} (k_beq : k == k')
     (distinct_l : DistinctKeys l)
+    {k k' : α} (k_beq : k == k')
     (distinct_toInsert : toInsert.Pairwise (fun a b => (a.1 == b.1) = false))
     (mem : k ∈ toInsert.map Sigma.fst) :
     getKey! k' (insertList l toInsert) = k := by
-  rw [getKey!_eq_getKey?, getKey?_insertList_of_mem k_beq distinct_l distinct_toInsert mem,
+  rw [getKey!_eq_getKey?, getKey?_insertList_of_mem distinct_l k_beq distinct_toInsert mem,
     Option.get!_some]
 
 theorem getKeyD_insertList_of_contains_eq_false [BEq α] [EquivBEq α]
@@ -2522,12 +2522,12 @@ theorem getKeyD_insertList_of_contains_eq_false [BEq α] [EquivBEq α]
 
 theorem getKeyD_insertList_of_mem [BEq α] [EquivBEq α]
     {l toInsert : List ((a : α) × β a)}
-    {k k' fallback : α} (k_beq : k == k')
     (distinct_l : DistinctKeys l)
+    {k k' fallback : α} (k_beq : k == k')
     (distinct_toInsert : toInsert.Pairwise (fun a b => (a.1 == b.1) = false))
     (mem : k ∈ toInsert.map Sigma.fst) :
     getKeyD k' (insertList l toInsert) fallback = k := by
-  rw [getKeyD_eq_getKey?, getKey?_insertList_of_mem k_beq distinct_l distinct_toInsert mem,
+  rw [getKeyD_eq_getKey?, getKey?_insertList_of_mem distinct_l k_beq distinct_toInsert mem,
     Option.getD_some]
 
 theorem perm_insertList [BEq α] [EquivBEq α]
@@ -2627,13 +2627,13 @@ theorem getKey?_insertListConst_of_contains_eq_false [BEq α] [EquivBEq α]
 
 theorem getKey?_insertListConst_of_mem [BEq α] [EquivBEq α]
     {l : List ((_ : α) × β)} {toInsert : List (α × β)}
-    {k k' : α} (k_beq : k == k')
     (distinct_l : DistinctKeys l)
+    {k k' : α} (k_beq : k == k')
     (distinct_toInsert : toInsert.Pairwise (fun a b => (a.1 == b.1) = false))
     (mem : k ∈ toInsert.map Prod.fst) :
     getKey? k' (insertListConst l toInsert) = some k := by
   unfold insertListConst
-  apply getKey?_insertList_of_mem k_beq distinct_l
+  apply getKey?_insertList_of_mem distinct_l k_beq
   · simpa [List.pairwise_map]
   · simp only [List.map_map, Prod.fst_comp_toSigma]
     exact mem
@@ -2649,14 +2649,14 @@ theorem getKey_insertListConst_of_contains_eq_false [BEq α] [EquivBEq α]
 
 theorem getKey_insertListConst_of_mem [BEq α] [EquivBEq α]
     {l : List ((_ : α) × β)} {toInsert : List (α × β)}
-    {k k' : α} (k_beq : k == k')
     (distinct_l : DistinctKeys l)
+    {k k' : α} (k_beq : k == k')
     (distinct_toInsert : toInsert.Pairwise (fun a b => (a.1 == b.1) = false))
     (mem : k ∈ toInsert.map Prod.fst)
     {h} :
     getKey k' (insertListConst l toInsert) h = k := by
   rw [← Option.some_inj, ← getKey?_eq_some_getKey,
-    getKey?_insertListConst_of_mem k_beq distinct_l distinct_toInsert mem]
+    getKey?_insertListConst_of_mem distinct_l k_beq distinct_toInsert mem]
 
 theorem getKey!_insertListConst_of_contains_eq_false [BEq α] [EquivBEq α] [Inhabited α]
     {l : List ((_ : α) × β)} {toInsert : List (α × β)} {k : α}
@@ -2667,12 +2667,12 @@ theorem getKey!_insertListConst_of_contains_eq_false [BEq α] [EquivBEq α] [Inh
 
 theorem getKey!_insertListConst_of_mem [BEq α] [EquivBEq α] [Inhabited α]
     {l : List ((_ : α) × β)} {toInsert : List (α × β)}
-    {k k' : α} (k_beq : k == k')
     (distinct_l : DistinctKeys l)
+    {k k' : α} (k_beq : k == k')
     (distinct_toInsert : toInsert.Pairwise (fun a b => (a.1 == b.1) = false))
     (mem : k ∈ toInsert.map Prod.fst) :
     getKey! k' (insertListConst l toInsert) = k := by
-  rw [getKey!_eq_getKey?, getKey?_insertListConst_of_mem k_beq distinct_l distinct_toInsert mem,
+  rw [getKey!_eq_getKey?, getKey?_insertListConst_of_mem distinct_l k_beq distinct_toInsert mem,
     Option.get!_some]
 
 theorem getKeyD_insertListConst_of_contains_eq_false [BEq α] [EquivBEq α]
@@ -2684,12 +2684,12 @@ theorem getKeyD_insertListConst_of_contains_eq_false [BEq α] [EquivBEq α]
 
 theorem getKeyD_insertListConst_of_mem [BEq α] [EquivBEq α]
     {l : List ((_ : α) × β)} {toInsert : List (α × β)}
-    {k k' fallback : α} (k_beq : k == k')
     (distinct_l : DistinctKeys l)
+    {k k' fallback : α} (k_beq : k == k')
     (distinct_toInsert : toInsert.Pairwise (fun a b => (a.1 == b.1) = false))
     (mem : k ∈ toInsert.map Prod.fst) :
     getKeyD k' (insertListConst l toInsert) fallback = k := by
-  rw [getKeyD_eq_getKey?, getKey?_insertListConst_of_mem k_beq distinct_l distinct_toInsert mem,
+  rw [getKeyD_eq_getKey?, getKey?_insertListConst_of_mem distinct_l k_beq distinct_toInsert mem,
     Option.getD_some]
 
 theorem length_insertListConst [BEq α] [EquivBEq α]
@@ -2736,8 +2736,8 @@ theorem getValue?_insertListConst_of_contains_eq_false [BEq α] [PartialEquivBEq
 
 theorem getValue?_insertListConst_of_mem [BEq α] [EquivBEq α]
     {l : List ((_ : α) × β)} {toInsert : List (α × β)}
-    {k k' : α} (k_beq : k == k') {v : β}
     (distinct_l : DistinctKeys l)
+    {k k' : α} (k_beq : k == k') {v : β}
     (distinct_toInsert : toInsert.Pairwise (fun a b => (a.1 == b.1) = false))
     (mem : ⟨k, v⟩ ∈ toInsert) :
     getValue? k' (insertListConst l toInsert) = v := by
@@ -2772,14 +2772,14 @@ theorem getValue_insertListConst_of_contains_eq_false [BEq α] [PartialEquivBEq 
 
 theorem getValue_insertListConst_of_mem [BEq α] [EquivBEq α]
     {l : List ((_ : α) × β)} {toInsert : List (α × β)}
-    {k k' : α} (k_beq : k == k') {v : β}
     (distinct_l : DistinctKeys l)
+    {k k' : α} (k_beq : k == k') {v : β}
     (distinct_toInsert : toInsert.Pairwise (fun a b => (a.1 == b.1) = false))
     (mem : ⟨k, v⟩ ∈ toInsert)
     {h} :
     getValue k' (insertListConst l toInsert) h = v := by
   rw [← Option.some_inj, ← getValue?_eq_some_getValue,
-    getValue?_insertListConst_of_mem k_beq distinct_l distinct_toInsert mem]
+    getValue?_insertListConst_of_mem distinct_l k_beq distinct_toInsert mem]
 
 theorem getValue!_insertListConst_of_contains_eq_false [BEq α] [PartialEquivBEq α] [Inhabited β]
     {l : List ((_ : α) × β)} {toInsert : List (α × β)} {k : α}
@@ -2789,13 +2789,14 @@ theorem getValue!_insertListConst_of_contains_eq_false [BEq α] [PartialEquivBEq
   rw [getValue?_insertListConst_of_contains_eq_false not_contains]
 
 theorem getValue!_insertListConst_of_mem [BEq α] [EquivBEq α] [Inhabited β]
-    {l : List ((_ : α) × β)} {toInsert : List (α × β)} {k k' : α} {v: β} (k_beq : k == k')
+    {l : List ((_ : α) × β)} {toInsert : List (α × β)} {k k' : α} {v: β}
     (distinct_l : DistinctKeys l)
+    (k_beq : k == k')
     (distinct_toInsert : toInsert.Pairwise (fun a b => (a.1 == b.1) = false))
     (mem : ⟨k, v⟩ ∈ toInsert) :
     getValue! k' (insertListConst l toInsert) = v := by
   rw [getValue!_eq_getValue?,
-    getValue?_insertListConst_of_mem k_beq distinct_l distinct_toInsert mem, Option.get!_some]
+    getValue?_insertListConst_of_mem distinct_l k_beq distinct_toInsert mem, Option.get!_some]
 
 theorem getValueD_insertListConst_of_contains_eq_false [BEq α] [PartialEquivBEq α]
     {l : List ((_ : α) × β)} {toInsert : List (α × β)} {k : α} {fallback : β}
@@ -2805,13 +2806,14 @@ theorem getValueD_insertListConst_of_contains_eq_false [BEq α] [PartialEquivBEq
   rw [getValue?_insertListConst_of_contains_eq_false not_contains]
 
 theorem getValueD_insertListConst_of_mem [BEq α] [EquivBEq α]
-    {l : List ((_ : α) × β)} {toInsert : List (α × β)} {k k' : α} {v fallback: β} (k_beq : k == k')
+    {l : List ((_ : α) × β)} {toInsert : List (α × β)} {k k' : α} {v fallback: β}
     (distinct_l : DistinctKeys l)
+    (k_beq : k == k')
     (distinct_toInsert : toInsert.Pairwise (fun a b => (a.1 == b.1) = false))
     (mem : ⟨k, v⟩ ∈ toInsert) :
     getValueD k' (insertListConst l toInsert) fallback= v := by
   simp only [getValueD_eq_getValue?]
-  rw [getValue?_insertListConst_of_mem k_beq distinct_l distinct_toInsert mem, Option.getD_some]
+  rw [getValue?_insertListConst_of_mem distinct_l k_beq distinct_toInsert mem, Option.getD_some]
 
 /-- Internal implementation detail of the hash map -/
 def insertListIfNewUnit [BEq α] (l: List ((_ : α) × Unit)) (toInsert: List α) :

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -791,4 +791,316 @@ theorem forIn_eq_forIn_keys [Monad m] [LawfulMonad m] {f : α → δ → m (ForI
 
 end monadic
 
+@[simp]
+theorem insertMany_nil :
+    t.insertMany [] = t :=
+  rfl
+
+@[simp]
+theorem insertMany_list_singleton {k : α} {v : β} :
+    t.insertMany [⟨k, v⟩] = t.insert k v :=
+  rfl
+
+theorem insertMany_cons {l : List (α × β)} {k : α} {v : β} :
+    t.insertMany (⟨k, v⟩ :: l) = (t.insert k v).insertMany l :=
+  ext <| DTreeMap.Const.insertMany_cons
+
+@[simp]
+theorem contains_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List (α × β)} {k : α} :
+    (t.insertMany l).contains k = (t.contains k || (l.map Prod.fst).contains k) :=
+  DTreeMap.Const.contains_insertMany_list
+
+@[simp]
+theorem mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List (α × β)} {k : α} :
+    k ∈ t.insertMany l ↔  k ∈ t ∨ (l.map Prod.fst).contains k :=
+  DTreeMap.Const.mem_insertMany_list
+
+theorem mem_of_mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List (α × β)} {k : α} :
+    k ∈ t.insertMany l → (l.map Prod.fst).contains k = false → k ∈ t :=
+  DTreeMap.Const.mem_of_mem_insertMany_list
+
+theorem getKey?_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+     {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    (t.insertMany l).getKey? k = t.getKey? k :=
+  DTreeMap.Const.getKey?_insertMany_list_of_contains_eq_false contains_eq_false
+
+theorem getKey?_insertMany_list_of_mem [TransCmp cmp]
+    {l : List (α × β)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Prod.fst) :
+    (t.insertMany l).getKey? k' = some k :=
+  DTreeMap.Const.getKey?_insertMany_list_of_mem k_eq distinct mem
+
+theorem getKey_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+     {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false)
+    {h'} :
+    (t.insertMany l).getKey k h' =
+    t.getKey k (mem_of_mem_insertMany_list h' contains_eq_false) :=
+  DTreeMap.Const.getKey_insertMany_list_of_contains_eq_false contains_eq_false
+
+theorem getKey_insertMany_list_of_mem [TransCmp cmp]
+    {l : List (α × β)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Prod.fst)
+    {h'} :
+    (t.insertMany l).getKey k' h' = k :=
+  DTreeMap.Const.getKey_insertMany_list_of_mem k_eq distinct mem
+
+theorem getKey!_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    [Inhabited α]  {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    (t.insertMany l).getKey! k = t.getKey! k :=
+  DTreeMap.Const.getKey!_insertMany_list_of_contains_eq_false contains_eq_false
+
+theorem getKey!_insertMany_list_of_mem [TransCmp cmp] [Inhabited α]
+    {l : List (α × β)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Prod.fst) :
+    (t.insertMany l).getKey! k' = k :=
+  DTreeMap.Const.getKey!_insertMany_list_of_mem k_eq distinct mem
+
+theorem getKeyD_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+     {l : List (α × β)} {k fallback : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    (t.insertMany l).getKeyD k fallback = t.getKeyD k fallback :=
+  DTreeMap.Const.getKeyD_insertMany_list_of_contains_eq_false contains_eq_false
+
+theorem getKeyD_insertMany_list_of_mem [TransCmp cmp]
+    {l : List (α × β)}
+    {k k' fallback : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Prod.fst) :
+    (t.insertMany l).getKeyD k' fallback = k :=
+  DTreeMap.Const.getKeyD_insertMany_list_of_mem k_eq distinct mem
+
+theorem size_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List (α × β)} (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) :
+    (∀ (a : α), a ∈ t → (l.map Prod.fst).contains a = false) →
+    (t.insertMany l).size = t.size + l.length :=
+  DTreeMap.Const.size_insertMany_list distinct
+
+theorem size_le_size_insertMany_list [TransCmp cmp]
+    {l : List (α × β)} :
+    t.size ≤ (t.insertMany l).size :=
+  DTreeMap.Const.size_le_size_insertMany_list
+
+theorem size_insertMany_list_le [TransCmp cmp]
+    {l : List (α × β)} :
+    (t.insertMany l).size ≤ t.size + l.length :=
+  DTreeMap.Const.size_insertMany_list_le
+
+@[simp]
+theorem isEmpty_insertMany_list [TransCmp cmp]
+    {l : List (α × β)} :
+    (t.insertMany l).isEmpty = (t.isEmpty && l.isEmpty) :=
+  DTreeMap.Const.isEmpty_insertMany_list
+
+theorem getElem?_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α]
+    [LawfulBEqCmp cmp]  {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    (t.insertMany l)[k]? = t[k]? :=
+  DTreeMap.Const.get?_insertMany_list_of_contains_eq_false contains_eq_false
+
+theorem getElem?_insertMany_list_of_mem [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+     {l : List (α × β)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
+    (t.insertMany l)[k']? = some v :=
+  DTreeMap.Const.get?_insertMany_list_of_mem k_eq distinct mem
+
+theorem getElem_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α]
+    [LawfulBEqCmp cmp]
+    {l : List (α × β)} {k : α}
+    (contains : (l.map Prod.fst).contains k = false)
+    {h'} :
+    (t.insertMany l)[k]'h' =
+    t.get k (mem_of_mem_insertMany_list h' contains) :=
+  DTreeMap.Const.get_insertMany_list_of_contains_eq_false contains
+
+theorem getElem_insertMany_list_of_mem [TransCmp cmp]
+    {l : List (α × β)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l)
+    {h'} :
+    (t.insertMany l)[k']'h' = v :=
+  DTreeMap.Const.get_insertMany_list_of_mem k_eq distinct mem
+
+theorem getElem!_insertMany_list_of_contains_eq_false [TransCmp cmp]
+    [BEq α] [LawfulBEqCmp cmp]
+    {l : List (α × β)} {k : α} [Inhabited β]
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    (t.insertMany l)[k]! = t.get! k :=
+  DTreeMap.Const.get!_insertMany_list_of_contains_eq_false contains_eq_false
+
+theorem getElem!_insertMany_list_of_mem [TransCmp cmp]
+    {l : List (α × β)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β} [Inhabited β]
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (t.insertMany l)[k']! = v :=
+  DTreeMap.Const.get!_insertMany_list_of_mem k_eq distinct mem
+
+theorem getD_insertMany_list_of_contains_eq_false [TransCmp cmp]
+    [BEq α] [LawfulBEqCmp cmp]
+    {l : List (α × β)} {k : α} {fallback : β}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    (t.insertMany l).getD k fallback = t.getD k fallback :=
+  DTreeMap.Const.getD_insertMany_list_of_contains_eq_false contains_eq_false
+
+theorem getD_insertMany_list_of_mem [TransCmp cmp]
+    {l : List (α × β)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β} {fallback : β}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (t.insertMany l).getD k' fallback = v :=
+  DTreeMap.Const.getD_insertMany_list_of_mem k_eq distinct mem
+
+variable {t : TreeMap α Unit cmp}
+
+@[simp]
+theorem insertManyIfNewUnit_nil :
+    insertManyIfNewUnit t [] = t :=
+  rfl
+
+@[simp]
+theorem insertManyIfNewUnit_list_singleton {k : α} :
+    insertManyIfNewUnit t [k] = t.insertIfNew k () :=
+  rfl
+
+theorem insertManyIfNewUnit_cons {l : List α} {k : α} :
+    insertManyIfNewUnit t (k :: l) = insertManyIfNewUnit (t.insertIfNew k ()) l :=
+  ext <| DTreeMap.Const.insertManyIfNewUnit_cons
+
+@[simp]
+theorem contains_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List α} {k : α} :
+    (insertManyIfNewUnit t l).contains k = (t.contains k || l.contains k) :=
+  DTreeMap.Const.contains_insertManyIfNewUnit_list
+
+@[simp]
+theorem mem_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List α} {k : α} :
+    k ∈ insertManyIfNewUnit t l ↔ k ∈ t ∨ l.contains k :=
+  DTreeMap.Const.mem_insertManyIfNewUnit_list
+
+theorem mem_of_mem_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List α} {k : α} (contains_eq_false : l.contains k = false) :
+    k ∈ insertManyIfNewUnit t l → k ∈ t :=
+  DTreeMap.Const.mem_of_mem_insertManyIfNewUnit_list contains_eq_false
+
+theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]  {l : List α} {k : α}
+    (not_mem : ¬ k ∈ t) (contains_eq_false : l.contains k = false) :
+    getKey? (insertManyIfNewUnit t l) k = none :=
+  DTreeMap.Const.getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    not_mem contains_eq_false
+
+theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
+     {l : List α} {k k' : α} (k_eq : cmp k k' = .eq)
+    (not_mem : ¬ k ∈ t) (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
+    getKey? (insertManyIfNewUnit t l) k' = some k :=
+  DTreeMap.Const.getKey?_insertManyIfNewUnit_list_of_not_mem_of_mem k_eq not_mem distinct mem
+
+theorem getKey?_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
+     {l : List α} {k : α} (mem : k ∈ t) :
+    getKey? (insertManyIfNewUnit t l) k = getKey? t k :=
+  DTreeMap.Const.getKey?_insertManyIfNewUnit_list_of_mem mem
+
+theorem getKey_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
+     {l : List α} {k : α} {h'} (contains : k ∈ t) :
+    getKey (insertManyIfNewUnit t l) k h' = getKey t k contains :=
+  DTreeMap.Const.getKey_insertManyIfNewUnit_list_of_mem contains
+
+theorem getKey_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
+     {l : List α}
+    {k k' : α} (k_eq : cmp k k' = .eq) {h'} (not_mem : ¬ k ∈ t)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
+    getKey (insertManyIfNewUnit t l) k' h' = k :=
+  DTreeMap.Const.getKey_insertManyIfNewUnit_list_of_not_mem_of_mem k_eq not_mem distinct mem
+
+theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] [Inhabited α]  {l : List α} {k : α}
+    (not_mem : ¬ k ∈ t) (contains_eq_false : l.contains k = false) :
+    getKey! (insertManyIfNewUnit t l) k = default :=
+  DTreeMap.Const.getKey!_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    not_mem contains_eq_false
+
+theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
+    [Inhabited α]  {l : List α} {k k' : α} (k_eq : cmp k k' = .eq)
+    (not_mem : ¬ k ∈ t) (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
+    getKey! (insertManyIfNewUnit t l) k' = k :=
+  DTreeMap.Const.getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem k_eq not_mem distinct mem
+
+theorem getKey!_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
+    [Inhabited α]  {l : List α} {k : α} (mem : k ∈ t):
+    getKey! (insertManyIfNewUnit t l) k = getKey! t k  :=
+  DTreeMap.Const.getKey!_insertManyIfNewUnit_list_of_mem mem
+
+theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]  {l : List α} {k fallback : α}
+    (not_mem : ¬ k ∈ t) (contains_eq_false : l.contains k = false) :
+    getKeyD (insertManyIfNewUnit t l) k fallback = fallback :=
+  DTreeMap.Const.getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    not_mem contains_eq_false
+
+theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
+     {l : List α} {k k' fallback : α} (k_eq : cmp k k' = .eq)
+    (not_mem : ¬ k ∈ t) (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
+    getKeyD (insertManyIfNewUnit t l) k' fallback = k :=
+  DTreeMap.Const.getKeyD_insertManyIfNewUnit_list_of_not_mem_of_mem k_eq not_mem distinct mem
+
+theorem getKeyD_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
+     {l : List α} {k fallback : α} (mem : k ∈ t) :
+    getKeyD (insertManyIfNewUnit t l) k fallback = getKeyD t k fallback :=
+  DTreeMap.Const.getKeyD_insertManyIfNewUnit_list_of_mem mem
+
+theorem size_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List α}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) :
+    (∀ (a : α), a ∈ t → l.contains a = false) →
+    (insertManyIfNewUnit t l).size = t.size + l.length :=
+  DTreeMap.Const.size_insertManyIfNewUnit_list distinct
+
+theorem size_le_size_insertManyIfNewUnit_list [TransCmp cmp]
+    {l : List α} :
+    t.size ≤ (insertManyIfNewUnit t l).size :=
+  DTreeMap.Const.size_le_size_insertManyIfNewUnit_list
+
+theorem size_insertManyIfNewUnit_list_le [TransCmp cmp]
+    {l : List α} :
+    (insertManyIfNewUnit t l).size ≤ t.size + l.length :=
+  DTreeMap.Const.size_insertManyIfNewUnit_list_le
+
+@[simp]
+theorem isEmpty_insertManyIfNewUnit_list [TransCmp cmp]  {l : List α} :
+    (insertManyIfNewUnit t l).isEmpty = (t.isEmpty && l.isEmpty) :=
+  DTreeMap.Const.isEmpty_insertManyIfNewUnit_list
+
+@[simp]
+theorem getElem?_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List α} {k : α} :
+    (insertManyIfNewUnit t l)[k]? = if k ∈ t ∨ l.contains k then some () else none :=
+  DTreeMap.Const.get?_insertManyIfNewUnit_list
+
+@[simp]
+theorem getElem_insertManyIfNewUnit_list {l : List α} {k : α} {h'} :
+    (insertManyIfNewUnit t l)[k]'h' = () :=
+  rfl
+
+@[simp]
+theorem getElem!_insertManyIfNewUnit_list {l : List α} {k : α} :
+    (insertManyIfNewUnit t l)[k]! = () :=
+  rfl
+
+@[simp]
+theorem getD_insertManyIfNewUnit_list
+    {l : List α} {k : α} {fallback : Unit} :
+    getD (insertManyIfNewUnit t l) k fallback = () :=
+  rfl
+
 end Std.TreeMap

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -823,7 +823,7 @@ theorem mem_of_mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
   DTreeMap.Const.mem_of_mem_insertMany_list
 
 theorem getKey?_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
-     {l : List (α × β)} {k : α}
+    {l : List (α × β)} {k : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false) :
     (t.insertMany l).getKey? k = t.getKey? k :=
   DTreeMap.Const.getKey?_insertMany_list_of_contains_eq_false contains_eq_false
@@ -837,7 +837,7 @@ theorem getKey?_insertMany_list_of_mem [TransCmp cmp]
   DTreeMap.Const.getKey?_insertMany_list_of_mem k_eq distinct mem
 
 theorem getKey_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
-     {l : List (α × β)} {k : α}
+    {l : List (α × β)} {k : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false)
     {h'} :
     (t.insertMany l).getKey k h' =
@@ -868,7 +868,7 @@ theorem getKey!_insertMany_list_of_mem [TransCmp cmp] [Inhabited α]
   DTreeMap.Const.getKey!_insertMany_list_of_mem k_eq distinct mem
 
 theorem getKeyD_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
-     {l : List (α × β)} {k fallback : α}
+    {l : List (α × β)} {k fallback : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false) :
     (t.insertMany l).getKeyD k fallback = t.getKeyD k fallback :=
   DTreeMap.Const.getKeyD_insertMany_list_of_contains_eq_false contains_eq_false
@@ -910,7 +910,7 @@ theorem getElem?_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α]
   DTreeMap.Const.get?_insertMany_list_of_contains_eq_false contains_eq_false
 
 theorem getElem?_insertMany_list_of_mem [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
-     {l : List (α × β)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β}
+    {l : List (α × β)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β}
     (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
     (t.insertMany l)[k']? = some v :=
   DTreeMap.Const.get?_insertMany_list_of_mem k_eq distinct mem
@@ -1001,23 +1001,23 @@ theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
     not_mem contains_eq_false
 
 theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
-     {l : List α} {k k' : α} (k_eq : cmp k k' = .eq)
+    {l : List α} {k k' : α} (k_eq : cmp k k' = .eq)
     (not_mem : ¬ k ∈ t) (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
     getKey? (insertManyIfNewUnit t l) k' = some k :=
   DTreeMap.Const.getKey?_insertManyIfNewUnit_list_of_not_mem_of_mem k_eq not_mem distinct mem
 
 theorem getKey?_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
-     {l : List α} {k : α} (mem : k ∈ t) :
+    {l : List α} {k : α} (mem : k ∈ t) :
     getKey? (insertManyIfNewUnit t l) k = getKey? t k :=
   DTreeMap.Const.getKey?_insertManyIfNewUnit_list_of_mem mem
 
 theorem getKey_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
-     {l : List α} {k : α} {h'} (contains : k ∈ t) :
+    {l : List α} {k : α} {h'} (contains : k ∈ t) :
     getKey (insertManyIfNewUnit t l) k h' = getKey t k contains :=
   DTreeMap.Const.getKey_insertManyIfNewUnit_list_of_mem contains
 
 theorem getKey_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
-     {l : List α}
+    {l : List α}
     {k k' : α} (k_eq : cmp k k' = .eq) {h'} (not_mem : ¬ k ∈ t)
     (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
     getKey (insertManyIfNewUnit t l) k' h' = k :=
@@ -1049,13 +1049,13 @@ theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
     not_mem contains_eq_false
 
 theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
-     {l : List α} {k k' fallback : α} (k_eq : cmp k k' = .eq)
+    {l : List α} {k k' fallback : α} (k_eq : cmp k k' = .eq)
     (not_mem : ¬ k ∈ t) (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
     getKeyD (insertManyIfNewUnit t l) k' fallback = k :=
   DTreeMap.Const.getKeyD_insertManyIfNewUnit_list_of_not_mem_of_mem k_eq not_mem distinct mem
 
 theorem getKeyD_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
-     {l : List α} {k fallback : α} (mem : k ∈ t) :
+    {l : List α} {k fallback : α} (mem : k ∈ t) :
     getKeyD (insertManyIfNewUnit t l) k fallback = getKeyD t k fallback :=
   DTreeMap.Const.getKeyD_insertManyIfNewUnit_list_of_mem mem
 

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -814,7 +814,7 @@ theorem contains_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
 @[simp]
 theorem mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
     {l : List (α × β)} {k : α} :
-    k ∈ t.insertMany l ↔  k ∈ t ∨ (l.map Prod.fst).contains k :=
+    k ∈ t.insertMany l ↔ k ∈ t ∨ (l.map Prod.fst).contains k :=
   DTreeMap.Const.mem_insertMany_list
 
 theorem mem_of_mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
@@ -854,7 +854,7 @@ theorem getKey_insertMany_list_of_mem [TransCmp cmp]
   DTreeMap.Const.getKey_insertMany_list_of_mem k_eq distinct mem
 
 theorem getKey!_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
-    [Inhabited α]  {l : List (α × β)} {k : α}
+    [Inhabited α] {l : List (α × β)} {k : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false) :
     (t.insertMany l).getKey! k = t.getKey! k :=
   DTreeMap.Const.getKey!_insertMany_list_of_contains_eq_false contains_eq_false
@@ -904,7 +904,7 @@ theorem isEmpty_insertMany_list [TransCmp cmp]
   DTreeMap.Const.isEmpty_insertMany_list
 
 theorem getElem?_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α]
-    [LawfulBEqCmp cmp]  {l : List (α × β)} {k : α}
+    [LawfulBEqCmp cmp] {l : List (α × β)} {k : α}
     (contains_eq_false : (l.map Prod.fst).contains k = false) :
     (t.insertMany l)[k]? = t[k]? :=
   DTreeMap.Const.get?_insertMany_list_of_contains_eq_false contains_eq_false
@@ -994,7 +994,7 @@ theorem mem_of_mem_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCm
   DTreeMap.Const.mem_of_mem_insertManyIfNewUnit_list contains_eq_false
 
 theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
-    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]  {l : List α} {k : α}
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] {l : List α} {k : α}
     (not_mem : ¬ k ∈ t) (contains_eq_false : l.contains k = false) :
     getKey? (insertManyIfNewUnit t l) k = none :=
   DTreeMap.Const.getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
@@ -1024,25 +1024,25 @@ theorem getKey_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
   DTreeMap.Const.getKey_insertManyIfNewUnit_list_of_not_mem_of_mem k_eq not_mem distinct mem
 
 theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
-    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] [Inhabited α]  {l : List α} {k : α}
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] [Inhabited α] {l : List α} {k : α}
     (not_mem : ¬ k ∈ t) (contains_eq_false : l.contains k = false) :
     getKey! (insertManyIfNewUnit t l) k = default :=
   DTreeMap.Const.getKey!_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
     not_mem contains_eq_false
 
 theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
-    [Inhabited α]  {l : List α} {k k' : α} (k_eq : cmp k k' = .eq)
+    [Inhabited α] {l : List α} {k k' : α} (k_eq : cmp k k' = .eq)
     (not_mem : ¬ k ∈ t) (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
     getKey! (insertManyIfNewUnit t l) k' = k :=
   DTreeMap.Const.getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem k_eq not_mem distinct mem
 
 theorem getKey!_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
-    [Inhabited α]  {l : List α} {k : α} (mem : k ∈ t):
-    getKey! (insertManyIfNewUnit t l) k = getKey! t k  :=
+    [Inhabited α] {l : List α} {k : α} (mem : k ∈ t):
+    getKey! (insertManyIfNewUnit t l) k = getKey! t k :=
   DTreeMap.Const.getKey!_insertManyIfNewUnit_list_of_mem mem
 
 theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
-    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]  {l : List α} {k fallback : α}
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] {l : List α} {k fallback : α}
     (not_mem : ¬ k ∈ t) (contains_eq_false : l.contains k = false) :
     getKeyD (insertManyIfNewUnit t l) k fallback = fallback :=
   DTreeMap.Const.getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
@@ -1077,7 +1077,7 @@ theorem size_insertManyIfNewUnit_list_le [TransCmp cmp]
   DTreeMap.Const.size_insertManyIfNewUnit_list_le
 
 @[simp]
-theorem isEmpty_insertManyIfNewUnit_list [TransCmp cmp]  {l : List α} :
+theorem isEmpty_insertManyIfNewUnit_list [TransCmp cmp] {l : List α} :
     (insertManyIfNewUnit t l).isEmpty = (t.isEmpty && l.isEmpty) :=
   DTreeMap.Const.isEmpty_insertManyIfNewUnit_list
 

--- a/src/Std/Data/TreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Raw/Lemmas.lean
@@ -799,4 +799,316 @@ theorem forIn_eq_forIn_keys [Monad m] [LawfulMonad m]
 
 end monadic
 
+@[simp]
+theorem insertMany_nil :
+    t.insertMany [] = t :=
+  rfl
+
+@[simp]
+theorem insertMany_list_singleton {k : α} {v : β} :
+    t.insertMany [⟨k, v⟩] = t.insert k v :=
+  rfl
+
+theorem insertMany_cons {l : List (α × β)} {k : α} {v : β} :
+    t.insertMany (⟨k, v⟩ :: l) = (t.insert k v).insertMany l :=
+  ext <| DTreeMap.Raw.Const.insertMany_cons
+
+@[simp]
+theorem contains_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k : α} :
+    (t.insertMany l).contains k = (t.contains k || (l.map Prod.fst).contains k) :=
+  DTreeMap.Raw.Const.contains_insertMany_list h
+
+@[simp]
+theorem mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k : α} :
+    k ∈ t.insertMany l ↔  k ∈ t ∨ (l.map Prod.fst).contains k :=
+  DTreeMap.Raw.Const.mem_insertMany_list h
+
+theorem mem_of_mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k : α} :
+    k ∈ t.insertMany l → (l.map Prod.fst).contains k = false → k ∈ t :=
+  DTreeMap.Raw.Const.mem_of_mem_insertMany_list h
+
+theorem getKey?_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    (h : t.WF) {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    (t.insertMany l).getKey? k = t.getKey? k :=
+  DTreeMap.Raw.Const.getKey?_insertMany_list_of_contains_eq_false h contains_eq_false
+
+theorem getKey?_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Prod.fst) :
+    (t.insertMany l).getKey? k' = some k :=
+  DTreeMap.Raw.Const.getKey?_insertMany_list_of_mem h k_eq distinct mem
+
+theorem getKey_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    (h : t.WF) {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false)
+    {h'} :
+    (t.insertMany l).getKey k h' =
+    t.getKey k (mem_of_mem_insertMany_list h h' contains_eq_false) :=
+  DTreeMap.Raw.Const.getKey_insertMany_list_of_contains_eq_false h contains_eq_false
+
+theorem getKey_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Prod.fst)
+    {h'} :
+    (t.insertMany l).getKey k' h' = k :=
+  DTreeMap.Raw.Const.getKey_insertMany_list_of_mem h k_eq distinct mem
+
+theorem getKey!_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    [Inhabited α] (h : t.WF) {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    (t.insertMany l).getKey! k = t.getKey! k :=
+  DTreeMap.Raw.Const.getKey!_insertMany_list_of_contains_eq_false h contains_eq_false
+
+theorem getKey!_insertMany_list_of_mem [TransCmp cmp] [Inhabited α] (h : t.WF)
+    {l : List (α × β)}
+    {k k' : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Prod.fst) :
+    (t.insertMany l).getKey! k' = k :=
+  DTreeMap.Raw.Const.getKey!_insertMany_list_of_mem h k_eq distinct mem
+
+theorem getKeyD_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    (h : t.WF) {l : List (α × β)} {k fallback : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    (t.insertMany l).getKeyD k fallback = t.getKeyD k fallback :=
+  DTreeMap.Raw.Const.getKeyD_insertMany_list_of_contains_eq_false h contains_eq_false
+
+theorem getKeyD_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)}
+    {k k' fallback : α} (k_eq : cmp k k' = .eq)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : k ∈ l.map Prod.fst) :
+    (t.insertMany l).getKeyD k' fallback = k :=
+  DTreeMap.Raw.Const.getKeyD_insertMany_list_of_mem h k_eq distinct mem
+
+theorem size_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List (α × β)} (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) :
+    (∀ (a : α), a ∈ t → (l.map Prod.fst).contains a = false) →
+    (t.insertMany l).size = t.size + l.length :=
+  DTreeMap.Raw.Const.size_insertMany_list h distinct
+
+theorem size_le_size_insertMany_list [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} :
+    t.size ≤ (t.insertMany l).size :=
+  DTreeMap.Raw.Const.size_le_size_insertMany_list h
+
+theorem size_insertMany_list_le [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} :
+    (t.insertMany l).size ≤ t.size + l.length :=
+  DTreeMap.Raw.Const.size_insertMany_list_le h
+
+@[simp]
+theorem isEmpty_insertMany_list [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} :
+    (t.insertMany l).isEmpty = (t.isEmpty && l.isEmpty) :=
+  DTreeMap.Raw.Const.isEmpty_insertMany_list h
+
+theorem getElem?_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α]
+    [LawfulBEqCmp cmp] (h : t.WF) {l : List (α × β)} {k : α}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    (t.insertMany l)[k]? = t[k]? :=
+  DTreeMap.Raw.Const.get?_insertMany_list_of_contains_eq_false h contains_eq_false
+
+theorem getElem?_insertMany_list_of_mem [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    (h : t.WF) {l : List (α × β)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq)) (mem : ⟨k, v⟩ ∈ l) :
+    (t.insertMany l)[k']? = some v :=
+  DTreeMap.Raw.Const.get?_insertMany_list_of_mem h k_eq distinct mem
+
+theorem getElem_insertMany_list_of_contains_eq_false [TransCmp cmp] [BEq α]
+    [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k : α}
+    (contains : (l.map Prod.fst).contains k = false)
+    {h'} :
+    (t.insertMany l)[k]'h' =
+    t.get k (mem_of_mem_insertMany_list h h' contains) :=
+  DTreeMap.Raw.Const.get_insertMany_list_of_contains_eq_false h contains
+
+theorem getElem_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l)
+    {h'} :
+    (t.insertMany l)[k']'h' = v :=
+  DTreeMap.Raw.Const.get_insertMany_list_of_mem h k_eq distinct mem
+
+theorem getElem!_insertMany_list_of_contains_eq_false [TransCmp cmp]
+    [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k : α} [Inhabited β]
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    (t.insertMany l)[k]! = t.get! k :=
+  DTreeMap.Raw.Const.get!_insertMany_list_of_contains_eq_false h contains_eq_false
+
+theorem getElem!_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β} [Inhabited β]
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (t.insertMany l)[k']! = v :=
+  DTreeMap.Raw.Const.get!_insertMany_list_of_mem h k_eq distinct mem
+
+theorem getD_insertMany_list_of_contains_eq_false [TransCmp cmp]
+    [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k : α} {fallback : β}
+    (contains_eq_false : (l.map Prod.fst).contains k = false) :
+    (t.insertMany l).getD k fallback = t.getD k fallback :=
+  DTreeMap.Raw.Const.getD_insertMany_list_of_contains_eq_false h contains_eq_false
+
+theorem getD_insertMany_list_of_mem [TransCmp cmp] (h : t.WF)
+    {l : List (α × β)} {k k' : α} (k_eq : cmp k k' = .eq) {v : β} {fallback : β}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a.1 b.1 = .eq))
+    (mem : ⟨k, v⟩ ∈ l) :
+    (t.insertMany l).getD k' fallback = v :=
+  DTreeMap.Raw.Const.getD_insertMany_list_of_mem h k_eq distinct mem
+
+variable {t : Raw α Unit cmp}
+
+@[simp]
+theorem insertManyIfNewUnit_nil :
+    insertManyIfNewUnit t [] = t :=
+  rfl
+
+@[simp]
+theorem insertManyIfNewUnit_list_singleton {k : α} :
+    insertManyIfNewUnit t [k] = t.insertIfNew k () :=
+  rfl
+
+theorem insertManyIfNewUnit_cons {l : List α} {k : α} :
+    insertManyIfNewUnit t (k :: l) = insertManyIfNewUnit (t.insertIfNew k ()) l :=
+  ext <| DTreeMap.Raw.Const.insertManyIfNewUnit_cons
+
+@[simp]
+theorem contains_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List α} {k : α} :
+    (insertManyIfNewUnit t l).contains k = (t.contains k || l.contains k) :=
+  DTreeMap.Raw.Const.contains_insertManyIfNewUnit_list h
+
+@[simp]
+theorem mem_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List α} {k : α} :
+    k ∈ insertManyIfNewUnit t l ↔ k ∈ t ∨ l.contains k :=
+  DTreeMap.Raw.Const.mem_insertManyIfNewUnit_list h
+
+theorem mem_of_mem_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List α} {k : α} (contains_eq_false : l.contains k = false) :
+    k ∈ insertManyIfNewUnit t l → k ∈ t :=
+  DTreeMap.Raw.Const.mem_of_mem_insertManyIfNewUnit_list h contains_eq_false
+
+theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF) {l : List α} {k : α}
+    (not_mem : ¬ k ∈ t) (contains_eq_false : l.contains k = false) :
+    getKey? (insertManyIfNewUnit t l) k = none :=
+  DTreeMap.Raw.Const.getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    h not_mem contains_eq_false
+
+theorem getKey?_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
+    (h : t.WF) {l : List α} {k k' : α} (k_eq : cmp k k' = .eq)
+    (not_mem : ¬ k ∈ t) (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
+    getKey? (insertManyIfNewUnit t l) k' = some k :=
+  DTreeMap.Raw.Const.getKey?_insertManyIfNewUnit_list_of_not_mem_of_mem h k_eq not_mem distinct mem
+
+theorem getKey?_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
+    (h : t.WF) {l : List α} {k : α} (mem : k ∈ t) :
+    getKey? (insertManyIfNewUnit t l) k = getKey? t k :=
+  DTreeMap.Raw.Const.getKey?_insertManyIfNewUnit_list_of_mem h mem
+
+theorem getKey_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
+    (h : t.WF) {l : List α} {k : α} {h'} (contains : k ∈ t) :
+    getKey (insertManyIfNewUnit t l) k h' = getKey t k contains :=
+  DTreeMap.Raw.Const.getKey_insertManyIfNewUnit_list_of_mem h contains
+
+theorem getKey_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
+    (h : t.WF) {l : List α}
+    {k k' : α} (k_eq : cmp k k' = .eq) {h'} (not_mem : ¬ k ∈ t)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
+    getKey (insertManyIfNewUnit t l) k' h' = k :=
+  DTreeMap.Raw.Const.getKey_insertManyIfNewUnit_list_of_not_mem_of_mem h k_eq not_mem distinct mem
+
+theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] [Inhabited α] (h : t.WF) {l : List α} {k : α}
+    (not_mem : ¬ k ∈ t) (contains_eq_false : l.contains k = false) :
+    getKey! (insertManyIfNewUnit t l) k = default :=
+  DTreeMap.Raw.Const.getKey!_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    h not_mem contains_eq_false
+
+theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
+    [Inhabited α] (h : t.WF) {l : List α} {k k' : α} (k_eq : cmp k k' = .eq)
+    (not_mem : ¬ k ∈ t) (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
+    getKey! (insertManyIfNewUnit t l) k' = k :=
+  DTreeMap.Raw.Const.getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem h k_eq not_mem distinct mem
+
+theorem getKey!_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
+    [Inhabited α] (h : t.WF) {l : List α} {k : α} (mem : k ∈ t):
+    getKey! (insertManyIfNewUnit t l) k = getKey! t k  :=
+  DTreeMap.Raw.Const.getKey!_insertManyIfNewUnit_list_of_mem h mem
+
+theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF) {l : List α} {k fallback : α}
+    (not_mem : ¬ k ∈ t) (contains_eq_false : l.contains k = false) :
+    getKeyD (insertManyIfNewUnit t l) k fallback = fallback :=
+  DTreeMap.Raw.Const.getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    h not_mem contains_eq_false
+
+theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
+    (h : t.WF) {l : List α} {k k' fallback : α} (k_eq : cmp k k' = .eq)
+    (not_mem : ¬ k ∈ t) (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
+    getKeyD (insertManyIfNewUnit t l) k' fallback = k :=
+  DTreeMap.Raw.Const.getKeyD_insertManyIfNewUnit_list_of_not_mem_of_mem h k_eq not_mem distinct mem
+
+theorem getKeyD_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
+    (h : t.WF) {l : List α} {k fallback : α} (mem : k ∈ t) :
+    getKeyD (insertManyIfNewUnit t l) k fallback = getKeyD t k fallback :=
+  DTreeMap.Raw.Const.getKeyD_insertManyIfNewUnit_list_of_mem h mem
+
+theorem size_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List α}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) :
+    (∀ (a : α), a ∈ t → l.contains a = false) →
+    (insertManyIfNewUnit t l).size = t.size + l.length :=
+  DTreeMap.Raw.Const.size_insertManyIfNewUnit_list h distinct
+
+theorem size_le_size_insertManyIfNewUnit_list [TransCmp cmp] (h : t.WF)
+    {l : List α} :
+    t.size ≤ (insertManyIfNewUnit t l).size :=
+  DTreeMap.Raw.Const.size_le_size_insertManyIfNewUnit_list h
+
+theorem size_insertManyIfNewUnit_list_le [TransCmp cmp] (h : t.WF)
+    {l : List α} :
+    (insertManyIfNewUnit t l).size ≤ t.size + l.length :=
+  DTreeMap.Raw.Const.size_insertManyIfNewUnit_list_le h
+
+@[simp]
+theorem isEmpty_insertManyIfNewUnit_list [TransCmp cmp] (h : t.WF) {l : List α} :
+    (insertManyIfNewUnit t l).isEmpty = (t.isEmpty && l.isEmpty) :=
+  DTreeMap.Raw.Const.isEmpty_insertManyIfNewUnit_list h
+
+@[simp]
+theorem getElem?_insertManyIfNewUnit_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List α} {k : α} :
+    (insertManyIfNewUnit t l)[k]? = if k ∈ t ∨ l.contains k then some () else none :=
+  DTreeMap.Raw.Const.get?_insertManyIfNewUnit_list h
+
+@[simp]
+theorem getElem_insertManyIfNewUnit_list {l : List α} {k : α} {h'} :
+    (insertManyIfNewUnit t l)[k]'h' = () :=
+  rfl
+
+@[simp]
+theorem getElem!_insertManyIfNewUnit_list {l : List α} {k : α} :
+    (insertManyIfNewUnit t l)[k]! = () :=
+  rfl
+
+@[simp]
+theorem getD_insertManyIfNewUnit_list
+    {l : List α} {k : α} {fallback : Unit} :
+    getD (insertManyIfNewUnit t l) k fallback = () :=
+  rfl
+
 end Std.TreeMap.Raw

--- a/src/Std/Data/TreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Raw/Lemmas.lean
@@ -822,7 +822,7 @@ theorem contains_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h :
 @[simp]
 theorem mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
     {l : List (α × β)} {k : α} :
-    k ∈ t.insertMany l ↔  k ∈ t ∨ (l.map Prod.fst).contains k :=
+    k ∈ t.insertMany l ↔ k ∈ t ∨ (l.map Prod.fst).contains k :=
   DTreeMap.Raw.Const.mem_insertMany_list h
 
 theorem mem_of_mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
@@ -1046,7 +1046,7 @@ theorem getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem [TransCmp cmp]
 
 theorem getKey!_insertManyIfNewUnit_list_of_mem [TransCmp cmp]
     [Inhabited α] (h : t.WF) {l : List α} {k : α} (mem : k ∈ t):
-    getKey! (insertManyIfNewUnit t l) k = getKey! t k  :=
+    getKey! (insertManyIfNewUnit t l) k = getKey! t k :=
   DTreeMap.Raw.Const.getKey!_insertManyIfNewUnit_list_of_mem h mem
 
 theorem getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false

--- a/src/Std/Data/TreeSet/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Lemmas.lean
@@ -396,4 +396,123 @@ theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m] {f : α → δ → m (Fo
 
 end monadic
 
+@[simp]
+theorem insertMany_nil :
+    t.insertMany [] = t :=
+  rfl
+
+@[simp]
+theorem insertMany_list_singleton {k : α} :
+    t.insertMany [k] = t.insert k :=
+  rfl
+
+theorem insertMany_cons {l : List α} {k : α} :
+    t.insertMany (k :: l) = (t.insert k).insertMany l :=
+  ext TreeMap.insertManyIfNewUnit_cons
+
+@[simp]
+theorem contains_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List α} {k : α} :
+    (t.insertMany l).contains k = (t.contains k || l.contains k) :=
+  TreeMap.contains_insertManyIfNewUnit_list
+
+@[simp]
+theorem mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List α} {k : α} :
+    k ∈ insertMany t l ↔ k ∈ t ∨ l.contains k :=
+  TreeMap.mem_insertManyIfNewUnit_list
+
+theorem mem_of_mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List α} {k : α} (contains_eq_false : l.contains k = false) :
+    k ∈ insertMany t l → k ∈ t :=
+  TreeMap.mem_of_mem_insertManyIfNewUnit_list contains_eq_false
+
+theorem get?_insertMany_list_of_not_mem_of_contains_eq_false
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]  {l : List α} {k : α}
+    (not_mem : ¬ k ∈ t) (contains_eq_false : l.contains k = false) :
+    get? (insertMany t l) k = none :=
+  TreeMap.getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    not_mem contains_eq_false
+
+theorem get?_insertMany_list_of_not_mem_of_mem [TransCmp cmp]
+     {l : List α} {k k' : α} (k_eq : cmp k k' = .eq)
+    (not_mem : ¬ k ∈ t) (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
+    get? (insertMany t l) k' = some k :=
+  TreeMap.getKey?_insertManyIfNewUnit_list_of_not_mem_of_mem k_eq not_mem distinct mem
+
+theorem get?_insertMany_list_of_mem [TransCmp cmp]
+     {l : List α} {k : α} (mem : k ∈ t) :
+    get? (insertMany t l) k = get? t k :=
+  TreeMap.getKey?_insertManyIfNewUnit_list_of_mem mem
+
+theorem get_insertMany_list_of_mem [TransCmp cmp]
+     {l : List α} {k : α} {h'} (contains : k ∈ t) :
+    get (insertMany t l) k h' = get t k contains :=
+  TreeMap.getKey_insertManyIfNewUnit_list_of_mem contains
+
+theorem get_insertMany_list_of_not_mem_of_mem [TransCmp cmp]
+     {l : List α}
+    {k k' : α} (k_eq : cmp k k' = .eq) {h'} (not_mem : ¬ k ∈ t)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
+    get (insertMany t l) k' h' = k :=
+  TreeMap.getKey_insertManyIfNewUnit_list_of_not_mem_of_mem k_eq not_mem distinct mem
+
+theorem get!_insertMany_list_of_not_mem_of_contains_eq_false
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] [Inhabited α]  {l : List α} {k : α}
+    (not_mem : ¬ k ∈ t) (contains_eq_false : l.contains k = false) :
+    get! (insertMany t l) k = default :=
+  TreeMap.getKey!_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    not_mem contains_eq_false
+
+theorem get!_insertMany_list_of_not_mem_of_mem [TransCmp cmp]
+    [Inhabited α]  {l : List α} {k k' : α} (k_eq : cmp k k' = .eq)
+    (not_mem : ¬ k ∈ t) (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
+    get! (insertMany t l) k' = k :=
+  TreeMap.getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem k_eq not_mem distinct mem
+
+theorem get!_insertMany_list_of_mem [TransCmp cmp]
+    [Inhabited α]  {l : List α} {k : α} (mem : k ∈ t):
+    get! (insertMany t l) k = get! t k  :=
+  TreeMap.getKey!_insertManyIfNewUnit_list_of_mem mem
+
+theorem getD_insertMany_list_of_not_mem_of_contains_eq_false
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]  {l : List α} {k fallback : α}
+    (not_mem : ¬ k ∈ t) (contains_eq_false : l.contains k = false) :
+    getD (insertMany t l) k fallback = fallback :=
+  TreeMap.getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    not_mem contains_eq_false
+
+theorem getD_insertMany_list_of_not_mem_of_mem [TransCmp cmp]
+     {l : List α} {k k' fallback : α} (k_eq : cmp k k' = .eq)
+    (not_mem : ¬ k ∈ t) (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
+    getD (insertMany t l) k' fallback = k :=
+  TreeMap.getKeyD_insertManyIfNewUnit_list_of_not_mem_of_mem k_eq not_mem distinct mem
+
+theorem getD_insertMany_list_of_mem [TransCmp cmp]
+     {l : List α} {k fallback : α} (mem : k ∈ t) :
+    getD (insertMany t l) k fallback = getD t k fallback :=
+  TreeMap.getKeyD_insertManyIfNewUnit_list_of_mem mem
+
+theorem size_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
+    {l : List α}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) :
+    (∀ (a : α), a ∈ t → l.contains a = false) →
+    (insertMany t l).size = t.size + l.length :=
+  TreeMap.size_insertManyIfNewUnit_list distinct
+
+theorem size_le_size_insertMany_list [TransCmp cmp]
+    {l : List α} :
+    t.size ≤ (insertMany t l).size :=
+  TreeMap.size_le_size_insertManyIfNewUnit_list
+
+theorem size_insertMany_list_le [TransCmp cmp]
+    {l : List α} :
+    (insertMany t l).size ≤ t.size + l.length :=
+  TreeMap.size_insertManyIfNewUnit_list_le
+
+@[simp]
+theorem isEmpty_insertMany_list [TransCmp cmp]  {l : List α} :
+    (insertMany t l).isEmpty = (t.isEmpty && l.isEmpty) :=
+  TreeMap.isEmpty_insertManyIfNewUnit_list
+
 end Std.TreeSet

--- a/src/Std/Data/TreeSet/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Lemmas.lean
@@ -428,7 +428,7 @@ theorem mem_of_mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]
   TreeMap.mem_of_mem_insertManyIfNewUnit_list contains_eq_false
 
 theorem get?_insertMany_list_of_not_mem_of_contains_eq_false
-    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]  {l : List α} {k : α}
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] {l : List α} {k : α}
     (not_mem : ¬ k ∈ t) (contains_eq_false : l.contains k = false) :
     get? (insertMany t l) k = none :=
   TreeMap.getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
@@ -458,25 +458,25 @@ theorem get_insertMany_list_of_not_mem_of_mem [TransCmp cmp]
   TreeMap.getKey_insertManyIfNewUnit_list_of_not_mem_of_mem k_eq not_mem distinct mem
 
 theorem get!_insertMany_list_of_not_mem_of_contains_eq_false
-    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] [Inhabited α]  {l : List α} {k : α}
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] [Inhabited α] {l : List α} {k : α}
     (not_mem : ¬ k ∈ t) (contains_eq_false : l.contains k = false) :
     get! (insertMany t l) k = default :=
   TreeMap.getKey!_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
     not_mem contains_eq_false
 
 theorem get!_insertMany_list_of_not_mem_of_mem [TransCmp cmp]
-    [Inhabited α]  {l : List α} {k k' : α} (k_eq : cmp k k' = .eq)
+    [Inhabited α] {l : List α} {k k' : α} (k_eq : cmp k k' = .eq)
     (not_mem : ¬ k ∈ t) (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
     get! (insertMany t l) k' = k :=
   TreeMap.getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem k_eq not_mem distinct mem
 
 theorem get!_insertMany_list_of_mem [TransCmp cmp]
-    [Inhabited α]  {l : List α} {k : α} (mem : k ∈ t):
-    get! (insertMany t l) k = get! t k  :=
+    [Inhabited α] {l : List α} {k : α} (mem : k ∈ t):
+    get! (insertMany t l) k = get! t k :=
   TreeMap.getKey!_insertManyIfNewUnit_list_of_mem mem
 
 theorem getD_insertMany_list_of_not_mem_of_contains_eq_false
-    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp]  {l : List α} {k fallback : α}
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] {l : List α} {k fallback : α}
     (not_mem : ¬ k ∈ t) (contains_eq_false : l.contains k = false) :
     getD (insertMany t l) k fallback = fallback :=
   TreeMap.getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
@@ -511,7 +511,7 @@ theorem size_insertMany_list_le [TransCmp cmp]
   TreeMap.size_insertManyIfNewUnit_list_le
 
 @[simp]
-theorem isEmpty_insertMany_list [TransCmp cmp]  {l : List α} :
+theorem isEmpty_insertMany_list [TransCmp cmp] {l : List α} :
     (insertMany t l).isEmpty = (t.isEmpty && l.isEmpty) :=
   TreeMap.isEmpty_insertManyIfNewUnit_list
 

--- a/src/Std/Data/TreeSet/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Lemmas.lean
@@ -435,23 +435,23 @@ theorem get?_insertMany_list_of_not_mem_of_contains_eq_false
     not_mem contains_eq_false
 
 theorem get?_insertMany_list_of_not_mem_of_mem [TransCmp cmp]
-     {l : List α} {k k' : α} (k_eq : cmp k k' = .eq)
+    {l : List α} {k k' : α} (k_eq : cmp k k' = .eq)
     (not_mem : ¬ k ∈ t) (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
     get? (insertMany t l) k' = some k :=
   TreeMap.getKey?_insertManyIfNewUnit_list_of_not_mem_of_mem k_eq not_mem distinct mem
 
 theorem get?_insertMany_list_of_mem [TransCmp cmp]
-     {l : List α} {k : α} (mem : k ∈ t) :
+    {l : List α} {k : α} (mem : k ∈ t) :
     get? (insertMany t l) k = get? t k :=
   TreeMap.getKey?_insertManyIfNewUnit_list_of_mem mem
 
 theorem get_insertMany_list_of_mem [TransCmp cmp]
-     {l : List α} {k : α} {h'} (contains : k ∈ t) :
+    {l : List α} {k : α} {h'} (contains : k ∈ t) :
     get (insertMany t l) k h' = get t k contains :=
   TreeMap.getKey_insertManyIfNewUnit_list_of_mem contains
 
 theorem get_insertMany_list_of_not_mem_of_mem [TransCmp cmp]
-     {l : List α}
+    {l : List α}
     {k k' : α} (k_eq : cmp k k' = .eq) {h'} (not_mem : ¬ k ∈ t)
     (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
     get (insertMany t l) k' h' = k :=
@@ -483,13 +483,13 @@ theorem getD_insertMany_list_of_not_mem_of_contains_eq_false
     not_mem contains_eq_false
 
 theorem getD_insertMany_list_of_not_mem_of_mem [TransCmp cmp]
-     {l : List α} {k k' fallback : α} (k_eq : cmp k k' = .eq)
+    {l : List α} {k k' fallback : α} (k_eq : cmp k k' = .eq)
     (not_mem : ¬ k ∈ t) (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
     getD (insertMany t l) k' fallback = k :=
   TreeMap.getKeyD_insertManyIfNewUnit_list_of_not_mem_of_mem k_eq not_mem distinct mem
 
 theorem getD_insertMany_list_of_mem [TransCmp cmp]
-     {l : List α} {k fallback : α} (mem : k ∈ t) :
+    {l : List α} {k fallback : α} (mem : k ∈ t) :
     getD (insertMany t l) k fallback = getD t k fallback :=
   TreeMap.getKeyD_insertManyIfNewUnit_list_of_mem mem
 

--- a/src/Std/Data/TreeSet/Raw/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Raw/Lemmas.lean
@@ -468,7 +468,7 @@ theorem get!_insertMany_list_of_not_mem_of_mem [TransCmp cmp]
 
 theorem get!_insertMany_list_of_mem [TransCmp cmp]
     [Inhabited α] (h : t.WF) {l : List α} {k : α} (mem : k ∈ t):
-    get! (insertMany t l) k = get! t k  :=
+    get! (insertMany t l) k = get! t k :=
   TreeMap.Raw.getKey!_insertManyIfNewUnit_list_of_mem h mem
 
 theorem getD_insertMany_list_of_not_mem_of_contains_eq_false

--- a/src/Std/Data/TreeSet/Raw/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Raw/Lemmas.lean
@@ -392,4 +392,123 @@ theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m]
 
 end monadic
 
+@[simp]
+theorem insertMany_nil :
+    t.insertMany [] = t :=
+  rfl
+
+@[simp]
+theorem insertMany_list_singleton {k : α} :
+    t.insertMany [k] = t.insert k :=
+  rfl
+
+theorem insertMany_cons {l : List α} {k : α} :
+    t.insertMany (k :: l) = (t.insert k).insertMany l :=
+  ext TreeMap.Raw.insertManyIfNewUnit_cons
+
+@[simp]
+theorem contains_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List α} {k : α} :
+    (t.insertMany l).contains k = (t.contains k || l.contains k) :=
+  TreeMap.Raw.contains_insertManyIfNewUnit_list h
+
+@[simp]
+theorem mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List α} {k : α} :
+    k ∈ insertMany t l ↔ k ∈ t ∨ l.contains k :=
+  TreeMap.Raw.mem_insertManyIfNewUnit_list h
+
+theorem mem_of_mem_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List α} {k : α} (contains_eq_false : l.contains k = false) :
+    k ∈ insertMany t l → k ∈ t :=
+  TreeMap.Raw.mem_of_mem_insertManyIfNewUnit_list h contains_eq_false
+
+theorem get?_insertMany_list_of_not_mem_of_contains_eq_false
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF) {l : List α} {k : α}
+    (not_mem : ¬ k ∈ t) (contains_eq_false : l.contains k = false) :
+    get? (insertMany t l) k = none :=
+  TreeMap.Raw.getKey?_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    h not_mem contains_eq_false
+
+theorem get?_insertMany_list_of_not_mem_of_mem [TransCmp cmp]
+    (h : t.WF) {l : List α} {k k' : α} (k_eq : cmp k k' = .eq)
+    (not_mem : ¬ k ∈ t) (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
+    get? (insertMany t l) k' = some k :=
+  TreeMap.Raw.getKey?_insertManyIfNewUnit_list_of_not_mem_of_mem h k_eq not_mem distinct mem
+
+theorem get?_insertMany_list_of_mem [TransCmp cmp]
+    (h : t.WF) {l : List α} {k : α} (mem : k ∈ t) :
+    get? (insertMany t l) k = get? t k :=
+  TreeMap.Raw.getKey?_insertManyIfNewUnit_list_of_mem h mem
+
+theorem get_insertMany_list_of_mem [TransCmp cmp]
+    (h : t.WF) {l : List α} {k : α} {h'} (contains : k ∈ t) :
+    get (insertMany t l) k h' = get t k contains :=
+  TreeMap.Raw.getKey_insertManyIfNewUnit_list_of_mem h contains
+
+theorem get_insertMany_list_of_not_mem_of_mem [TransCmp cmp]
+    (h : t.WF) {l : List α}
+    {k k' : α} (k_eq : cmp k k' = .eq) {h'} (not_mem : ¬ k ∈ t)
+    (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
+    get (insertMany t l) k' h' = k :=
+  TreeMap.Raw.getKey_insertManyIfNewUnit_list_of_not_mem_of_mem h k_eq not_mem distinct mem
+
+theorem get!_insertMany_list_of_not_mem_of_contains_eq_false
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] [Inhabited α] (h : t.WF) {l : List α} {k : α}
+    (not_mem : ¬ k ∈ t) (contains_eq_false : l.contains k = false) :
+    get! (insertMany t l) k = default :=
+  TreeMap.Raw.getKey!_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    h not_mem contains_eq_false
+
+theorem get!_insertMany_list_of_not_mem_of_mem [TransCmp cmp]
+    [Inhabited α] (h : t.WF) {l : List α} {k k' : α} (k_eq : cmp k k' = .eq)
+    (not_mem : ¬ k ∈ t) (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
+    get! (insertMany t l) k' = k :=
+  TreeMap.Raw.getKey!_insertManyIfNewUnit_list_of_not_mem_of_mem h k_eq not_mem distinct mem
+
+theorem get!_insertMany_list_of_mem [TransCmp cmp]
+    [Inhabited α] (h : t.WF) {l : List α} {k : α} (mem : k ∈ t):
+    get! (insertMany t l) k = get! t k  :=
+  TreeMap.Raw.getKey!_insertManyIfNewUnit_list_of_mem h mem
+
+theorem getD_insertMany_list_of_not_mem_of_contains_eq_false
+    [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF) {l : List α} {k fallback : α}
+    (not_mem : ¬ k ∈ t) (contains_eq_false : l.contains k = false) :
+    getD (insertMany t l) k fallback = fallback :=
+  TreeMap.Raw.getKeyD_insertManyIfNewUnit_list_of_not_mem_of_contains_eq_false
+    h not_mem contains_eq_false
+
+theorem getD_insertMany_list_of_not_mem_of_mem [TransCmp cmp]
+    (h : t.WF) {l : List α} {k k' fallback : α} (k_eq : cmp k k' = .eq)
+    (not_mem : ¬ k ∈ t) (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) (mem : k ∈ l) :
+    getD (insertMany t l) k' fallback = k :=
+  TreeMap.Raw.getKeyD_insertManyIfNewUnit_list_of_not_mem_of_mem h k_eq not_mem distinct mem
+
+theorem getD_insertMany_list_of_mem [TransCmp cmp]
+    (h : t.WF) {l : List α} {k fallback : α} (mem : k ∈ t) :
+    getD (insertMany t l) k fallback = getD t k fallback :=
+  TreeMap.Raw.getKeyD_insertManyIfNewUnit_list_of_mem h mem
+
+theorem size_insertMany_list [TransCmp cmp] [BEq α] [LawfulBEqCmp cmp] (h : t.WF)
+    {l : List α}
+    (distinct : l.Pairwise (fun a b => ¬ cmp a b = .eq)) :
+    (∀ (a : α), a ∈ t → l.contains a = false) →
+    (insertMany t l).size = t.size + l.length :=
+  TreeMap.Raw.size_insertManyIfNewUnit_list h distinct
+
+theorem size_le_size_insertMany_list [TransCmp cmp] (h : t.WF)
+    {l : List α} :
+    t.size ≤ (insertMany t l).size :=
+  TreeMap.Raw.size_le_size_insertManyIfNewUnit_list h
+
+theorem size_insertMany_list_le [TransCmp cmp] (h : t.WF)
+    {l : List α} :
+    (insertMany t l).size ≤ t.size + l.length :=
+  TreeMap.Raw.size_insertManyIfNewUnit_list_le h
+
+@[simp]
+theorem isEmpty_insertMany_list [TransCmp cmp] (h : t.WF) {l : List α} :
+    (insertMany t l).isEmpty = (t.isEmpty && l.isEmpty) :=
+  TreeMap.Raw.isEmpty_insertManyIfNewUnit_list h
+
 end Std.TreeSet.Raw


### PR DESCRIPTION
This PR provides lemmas about the tree map function `insertMany` and its interaction with other functions for which lemmas already exist. Most lemmas about `ofList`, which is related to `insertMany`, are not included.