### PR TITLE
chore: remove the no-longer-referenced `ofReduceNat` axiom (or add tests for it, depending on feedback)

### DIFF
--- a/src/Init/Core.lean
+++ b/src/Init/Core.lean
@@ -2298,18 +2298,6 @@ So, you are mainly losing the capability of type checking your development using
 axiom ofReduceBool (a b : Bool) (h : reduceBool a = b) : a = b
 
 /--
-The axiom `ofReduceNat` is used to perform proofs by reflection. See `reduceBool`.
-
-Warning: by using this feature, the Lean compiler and interpreter become part of your trusted code base.
-This is extra 30k lines of code. More importantly, you will probably not be able to check your development using
-external type checkers that do not implement this feature.
-Keep in mind that if you are using Lean as programming language, you are already trusting the Lean compiler and interpreter.
-So, you are mainly losing the capability of type checking your development using external checkers.
--/
-axiom ofReduceNat (a b : Nat) (h : reduceNat a = b) : a = b
-
-
-/--
 The term `opaqueId x` will not be reduced by the kernel.
 -/
 opaque opaqueId {α : Sort u} (x : α) : α := x


### PR DESCRIPTION
As far as I can tell, `ofReduceNat` is no longer referenced or used anywhere in the codebase. A review of the commit history shows that its last reference was removed in 2021 (see 9f88ea8047b81c812221e616395a675faf61235f). Local testing also suggests that `ofReduceNat` is unused.

That said, the presence of an unused axiom is somewhat surprising, and since I’m new to this project there’s a chance I might be missing an indirect usage. If so, please let me know and I’ll either close this PR, or add a proper test for `ofReduceNat` depending on what is deemed the appropriate course of action.

I’m submitting it as a draft to ensure everything builds in CI across all configurations. The next step will be to confirm that it also builds Mathlib successfully. _Update: Seems to build Mathlib without problems._