### PR TITLE
fix: Add `Inhabited` instance for `OptionT`

### DIFF
--- a/src/Init/Control/Option.lean
+++ b/src/Init/Control/Option.lean
@@ -59,6 +59,9 @@ instance : Monad (OptionT m) where
   pure := OptionT.pure
   bind := OptionT.bind
 
+instance {m : Type u → Type v} [Pure m] : Inhabited (OptionT m α) where
+  default := pure (f:=m) default
+
 /--
 Recovers from failures. Typically used via the `<|>` operator.
 -/


### PR DESCRIPTION
This PR adds `instance [Pure f] : Inhabited (OptionT f α)`, so that `Inhabited (OptionT Id Empty)` synthesizes.