### PR TITLE
perf: update to cadical 3.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if(NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten")
       cadical
       PREFIX cadical
       GIT_REPOSITORY https://github.com/arminbiere/cadical
-      GIT_TAG rel-3.0.0
+      GIT_TAG rel-3.0.1
       CONFIGURE_COMMAND ""
       BUILD_COMMAND
         $(MAKE) -f ${CMAKE_SOURCE_DIR}/src/cadical.mk CMAKE_EXECUTABLE_SUFFIX=${CMAKE_EXECUTABLE_SUFFIX}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if(NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten")
       cadical
       PREFIX cadical
       GIT_REPOSITORY https://github.com/arminbiere/cadical
-      GIT_TAG rel-2.2.0-rc2
+      GIT_TAG rel-3.0.0
       CONFIGURE_COMMAND ""
       BUILD_COMMAND
         $(MAKE) -f ${CMAKE_SOURCE_DIR}/src/cadical.mk CMAKE_EXECUTABLE_SUFFIX=${CMAKE_EXECUTABLE_SUFFIX}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if(NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten")
       cadical
       PREFIX cadical
       GIT_REPOSITORY https://github.com/arminbiere/cadical
-      GIT_TAG rel-2.1.2
+      GIT_TAG rel-2.2.0-rc2
       CONFIGURE_COMMAND ""
       BUILD_COMMAND
         $(MAKE) -f ${CMAKE_SOURCE_DIR}/src/cadical.mk CMAKE_EXECUTABLE_SUFFIX=${CMAKE_EXECUTABLE_SUFFIX}

--- a/src/Lean/Meta/Tactic/BVDecide/External.lean
+++ b/src/Lean/Meta/Tactic/BVDecide/External.lean
@@ -156,6 +156,17 @@ public def satQuery (solverPath : System.FilePath) (problemPath : System.FilePat
     s!"--binary={binaryProofs}",
     "--quiet",
     /-
+    This sets the magic parameters of cadical to optimize for UNSAT search.
+    Given the fact that we are mostly interested in proving things and expect user goals to be
+    provable this is a fine value to set
+    -/
+    "--unsat",
+    /-
+    Ensure we don't produce proofs with BVA as our LRAT checker doesn't understand them yet.
+    See: https://github.com/arminbiere/cadical/issues/134
+    -/
+    "--no-factor",
+    /-
     Bitwuzla sets this option and it does improve performance practically:
     https://github.com/bitwuzla/bitwuzla/blob/0e81e616af4d4421729884f01928b194c3536c76/src/sat/cadical.cpp#L34
     -/

--- a/src/Lean/Meta/Tactic/BVDecide/External.lean
+++ b/src/Lean/Meta/Tactic/BVDecide/External.lean
@@ -156,11 +156,6 @@ public def satQuery (solverPath : System.FilePath) (problemPath : System.FilePat
     s!"--binary={binaryProofs}",
     "--quiet",
     /-
-    Ensure we don't produce proofs with BVA as our LRAT checker doesn't understand them yet.
-    See: https://github.com/arminbiere/cadical/issues/134
-    -/
-    "--no-factor",
-    /-
     Bitwuzla sets this option and it does improve performance practically:
     https://github.com/bitwuzla/bitwuzla/blob/0e81e616af4d4421729884f01928b194c3536c76/src/sat/cadical.cpp#L34
     -/

--- a/src/Lean/Meta/Tactic/BVDecide/External.lean
+++ b/src/Lean/Meta/Tactic/BVDecide/External.lean
@@ -156,12 +156,6 @@ public def satQuery (solverPath : System.FilePath) (problemPath : System.FilePat
     s!"--binary={binaryProofs}",
     "--quiet",
     /-
-    This sets the magic parameters of cadical to optimize for UNSAT search.
-    Given the fact that we are mostly interested in proving things and expect user goals to be
-    provable this is a fine value to set
-    -/
-    "--unsat",
-    /-
     Ensure we don't produce proofs with BVA as our LRAT checker doesn't understand them yet.
     See: https://github.com/arminbiere/cadical/issues/134
     -/

--- a/src/cadical.mk
+++ b/src/cadical.mk
@@ -3,5 +3,8 @@ CXX ?= c++
 %.o: src/%.cpp
 	$(CXX) -std=c++11 -O3 -DNDEBUG -DNBUILD $(CXXFLAGS) -c $< -o $@
 
-../../cadical$(CMAKE_EXECUTABLE_SUFFIX): $(patsubst src/%.cpp,%.o,$(shell ls src/*.cpp | grep -v mobical))
+%.o: src/%.c
+	$(CC) -O3 -DNDEBUG -DNBUILD $(CFLAGS) -c $< -o $@
+
+../../cadical$(CMAKE_EXECUTABLE_SUFFIX): $(patsubst src/%.cpp,%.o,$(shell ls src/*.cpp | grep -v mobical)) $(patsubst src/%.c,%.o,$(shell ls src/*.c))
 	$(CXX) -o $@ $^ $(LDFLAGS)

--- a/tests/elab/bv_counterexample.lean
+++ b/tests/elab/bv_counterexample.lean
@@ -77,8 +77,8 @@ error: The prover found a potentially spurious counterexample:
 - The following potentially relevant hypotheses could not be used:
   - x.toNat = y.toNat derived via assumption h
 Consider the following assignment:
-x = 4294967295#32
-y = 2147483647#32
+x = 0#32
+y = 2147483648#32
 -/
 #guard_msgs in
 example (x y : BitVec 32) (h : x.toNat = y.toNat) : x = y := by
@@ -91,8 +91,8 @@ error: The prover found a potentially spurious counterexample:
 - It abstracted the following unsupported expressions as opaque variables:
   - zeros 32
 Consider the following assignment:
-x = 4294967295#32
-zeros 32 = 4294967295#32
+x = 2147483648#32
+zeros 32 = 2147483648#32
 -/
 #guard_msgs in
 example (x : BitVec 32) (h : x = zeros 32) : x = 0 := by
@@ -105,9 +105,9 @@ error: The prover found a potentially spurious counterexample:
 - The following potentially relevant hypotheses could not be used:
   - x.toNat = y.toNat derived via assumption h1
 Consider the following assignment:
-x = 4294967295#32
-zeros 32 = 4294967295#32
-y = 4294967295#32
+x = 0#32
+zeros 32 = 0#32
+y = 2147483648#32
 -/
 #guard_msgs in
 example (x y : BitVec 32) (h1 : x.toNat = y.toNat) (h2 : x = zeros 32) : y = 0 := by
@@ -115,7 +115,7 @@ example (x y : BitVec 32) (h1 : x.toNat = y.toNat) (h2 : x = zeros 32) : y = 0 :
 
 /--
 error: The prover found a counterexample, consider the following assignment:
-x = 3#2
+x = 0#2
 -/
 #guard_msgs in
 example (x : BitVec 2) : (bif x.ult 1#2 then 1#2 else 2#2) == 3#2 := by

--- a/tests/elab/bv_decide_solver_modes.lean
+++ b/tests/elab/bv_decide_solver_modes.lean
@@ -3,8 +3,8 @@ import Std.Tactic.BVDecide
 
 /--
 error: The prover found a counterexample, consider the following assignment:
-x = 4294967295#32
-y = 4294967295#32
+x = 0#32
+y = 2147483648#32
 -/
 #guard_msgs in
 example (x y : BitVec 32) : x * y = y + x := by
@@ -12,8 +12,8 @@ example (x y : BitVec 32) : x * y = y + x := by
 
 /--
 error: The prover found a counterexample, consider the following assignment:
-x = 4294967295#32
-y = 4294967295#32
+x = 0#32
+y = 2147483648#32
 -/
 #guard_msgs in
 example (x y : BitVec 32) : x * y = y + x := by
@@ -21,8 +21,8 @@ example (x y : BitVec 32) : x * y = y + x := by
 
 /--
 error: The prover found a counterexample, consider the following assignment:
-x = 4294967295#32
-y = 4294967295#32
+x = 0#32
+y = 2147483648#32
 -/
 #guard_msgs in
 example (x y : BitVec 32) : x * y = y + x := by
@@ -30,8 +30,8 @@ example (x y : BitVec 32) : x * y = y + x := by
 
 /--
 error: The prover found a counterexample, consider the following assignment:
-x = 4294967295#32
-y = 4294967295#32
+x = 0#32
+y = 2147483648#32
 -/
 #guard_msgs in
 example (x y : BitVec 32) : x * y = y + x := by

--- a/tests/elab/bv_sint.lean
+++ b/tests/elab/bv_sint.lean
@@ -6,8 +6,8 @@ example (a b c : Int8) (h1 : a < b) (h2 : b < c) : a < c := by
 
 /--
 error: The prover found a counterexample, consider the following assignment:
-a = -1
-b = -1
+a = 0
+b = 0
 -/
 #guard_msgs in
 example (a b : Int8) : a + b > a := by
@@ -21,8 +21,8 @@ example (a b c : Int16) (h1 : a < b) (h2 : b < c) : a < c := by
 
 /--
 error: The prover found a counterexample, consider the following assignment:
-a = -1
-b = -1
+a = 0
+b = 0
 -/
 #guard_msgs in
 example (a b : Int16) : a + b > a := by
@@ -36,8 +36,8 @@ example (a b c : Int32) (h1 : a < b) (h2 : b < c) : a < c := by
 
 /--
 error: The prover found a counterexample, consider the following assignment:
-a = -1
-b = -1
+a = 0
+b = 0
 -/
 #guard_msgs in
 example (a b : Int32) : a + b > a := by
@@ -51,8 +51,8 @@ example (a b c : Int64) (h1 : a < b) (h2 : b < c) : a < c := by
 
 /--
 error: The prover found a counterexample, consider the following assignment:
-a = -1
-b = -1
+a = 0
+b = 0
 -/
 #guard_msgs in
 example (a b : Int64) : a + b > a := by

--- a/tests/elab/bv_sint.lean
+++ b/tests/elab/bv_sint.lean
@@ -66,8 +66,8 @@ example (a b c : ISize) (h1 : a < b) (h2 : b < c) : a < c := by
 
 /--
 error: The prover found a counterexample, consider the following assignment:
-a = -1
-b = -1
+a = 0
+b = 0
 -/
 #guard_msgs in
 example (a b : ISize) (h : System.Platform.numBits = 64) : a + b > a := by

--- a/tests/elab/bv_uint.lean
+++ b/tests/elab/bv_uint.lean
@@ -6,8 +6,8 @@ example (a b c : UInt8) (h1 : a < b) (h2 : b < c) : a < c := by
 
 /--
 error: The prover found a counterexample, consider the following assignment:
-a = 255
-b = 255
+a = 0
+b = 0
 -/
 #guard_msgs in
 example (a b : UInt8) : a + b > a := by
@@ -21,8 +21,8 @@ example (a b c : UInt16) (h1 : a < b) (h2 : b < c) : a < c := by
 
 /--
 error: The prover found a counterexample, consider the following assignment:
-a = 65535
-b = 65535
+a = 0
+b = 0
 -/
 #guard_msgs in
 example (a b : UInt16) : a + b > a := by
@@ -36,8 +36,8 @@ example (a b c : UInt32) (h1 : a < b) (h2 : b < c) : a < c := by
 
 /--
 error: The prover found a counterexample, consider the following assignment:
-a = 4294967295
-b = 4294967295
+a = 0
+b = 0
 -/
 #guard_msgs in
 example (a b : UInt32) : a + b > a := by
@@ -51,8 +51,8 @@ example (a b c : UInt64) (h1 : a < b) (h2 : b < c) : a < c := by
 
 /--
 error: The prover found a counterexample, consider the following assignment:
-a = 18446744073709551615
-b = 18446744073709551615
+a = 0
+b = 0
 -/
 #guard_msgs in
 example (a b : UInt64) : a + b > a := by

--- a/tests/elab/bv_uint.lean
+++ b/tests/elab/bv_uint.lean
@@ -66,8 +66,8 @@ example (a b c : USize) (h1 : a < b) (h2 : b < c) : a < c := by
 
 /--
 error: The prover found a counterexample, consider the following assignment:
-a = 18446744073709551615
-b = 18446744073709551615
+a = 0
+b = 0
 -/
 #guard_msgs in
 example (a b : USize) (h : System.Platform.numBits = 64) : a + b > a := by

--- a/tests/elab/bv_unused.lean
+++ b/tests/elab/bv_unused.lean
@@ -4,7 +4,7 @@ open BitVec
 
 /--
 error: The prover found a counterexample, consider the following assignment:
-y = 18446744073709551615#64
+y = 18446744071562067968#64
 -/
 #guard_msgs in
 example {y : BitVec 64} : zeroExtend 32 y = 0 := by


### PR DESCRIPTION
This PR updates to Cadical 2.2.0.

We are particularly interested in this release as it implements congruence closure which alleviates the need to detect and encode XOR and ITE specially ourselves. Preliminary tests on a few SMTLIB problems show significant speedups here, for example `Sage2/bench_8517.smt2` from 5:20 to 2:41.


TODO:
- [x] Wait for an actual release
- [ ] Upgrade Nix dependency
- [ ] Evaluate on our benchmarks
- [ ] Evaluate on SMTLIB