### PR TITLE
feat: deprecated options

### DIFF
--- a/src/Lean/Meta/Eqns.lean
+++ b/src/Lean/Meta/Eqns.lean
@@ -296,3 +296,8 @@ builtin_initialize
     return false
 
 end Lean.Meta
+
+-- set at the end of this file, we don't want warnings from reading the options above
+
+attribute [deprecated "this backwards-compatibility option will be removed" (since := "2025-04-15")] Lean.Meta.backward.eqns.nonrecursive
+attribute [deprecated "this backwards-compatibility option will be removed" (since := "2025-04-15")] Lean.Meta.backward.eqns.deepRecursiveSplit

--- a/tests/lean/run/deprecatedOptions.lean
+++ b/tests/lean/run/deprecatedOptions.lean
@@ -1,0 +1,11 @@
+/-!
+This file tests that deprecation warnings on also work on built-in options.
+It may have to be adjusted as we deprecate different options, since
+we probably don't want to have a built-in option just for the sake of testing.
+-/
+
+-- This doesn't work yet, we do not have built-in deprecation warnings
+
+set_option backward.eqns.deepRecursiveSplit true
+
+set_option backward.eqns.nonrecursive true

--- a/tests/pkg/user_opt/UserOpt.lean
+++ b/tests/pkg/user_opt/UserOpt.lean
@@ -18,3 +18,7 @@ def tst2 : MetaM Unit := do
   pure ()
 
 #eval tst2
+
+/-- warning: `myDeprecatedOption` has been deprecated: This option is deprecated -/
+#guard_msgs in
+set_option myDeprecatedOption 20

--- a/tests/pkg/user_opt/UserOpt/Opts.lean
+++ b/tests/pkg/user_opt/UserOpt/Opts.lean
@@ -9,3 +9,10 @@ register_option myNatOpt : Nat := {
   defValue := 100
   descr    := "my Nat option"
 }
+
+register_option myDeprecatedOption : Nat := {
+  defValue := 100
+  descr    := "my Deprecated option"
+}
+
+attribute [deprecated  "This option is deprecated" (since := "2022-07-24")] myDeprecatedOption


### PR DESCRIPTION
This PR adds the ability to deprecate options.

---

I wanted to see if this I can easily add this ability, but it does not work yet for built-in options, and it seems to require more serious changes, so I’ll shelve this for now. Maybe someone who already knows how to do this properly can pick it up.