### PR TITLE
feat: `clear_value` tactic

### DIFF
--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -145,12 +145,17 @@ Syntax for trying to clear the values of all local definitions.
 syntax clearValueStar := "*"
 /--
 * `clear_value x...` clears the values of the given local definitions.
-For example, a local definition `x : α := v` becomes a hypothesis `x : α`.
+  A local definition `x : α := v` becomes a hypothesis `x : α`.
 
 * `clear_value x with h` adds a hypothesis `h : x = v` before clearing the value of `x`.
+  This is short for `have h : x = v := rfl; clear_value x`, with the benefit of not needing to mention `v`.
 
 * `clear_value *` clears values of all hypotheses that can be cleared.
   Fails if none can be cleared.
+
+These syntaxes can be combined. For example, `clear_value x y *` ensures that `x` and `y` are cleared
+while trying to clear all other local definitions, and `clear_value x y * with hx` does the same,
+but adds the `hx : x = v` hypothesis first. Having a `with` binding associated to `*` is not allowed.
 -/
 syntax (name := clearValue) "clear_value" (ppSpace colGt (clearValueStar <|> term:max))+ (" with" (ppSpace colGt binderIdent)+)? : tactic
 

--- a/src/Lean/Meta/Tactic/Replace.lean
+++ b/src/Lean/Meta/Tactic/Replace.lean
@@ -230,6 +230,15 @@ def _root_.Lean.MVarId.clearValue (mvarId : MVarId) (fvarId : FVarId) : MetaM MV
       mvarId.withContext <|
         throwTacticEx `clear_value mvarId m!"hypothesis `{Expr.fvar fvarId}` is not a local definition."
     let tgt' := Expr.forallE tgt.letName! tgt.letType! tgt.letBody! .default
+    /-
+    Note: `isTypeCorrect` does not instantiate metavariables. Ideally this should not matter,
+    however delayed assigned metavariables assume that the arguments applied to them have the correct
+    definitional properties (e.g. an argument might be for the value of a `let` binding).
+    Instantiating the metavariables before `isTypeCorrect` lets examples like the one reported in
+    https://github.com/leanprover-community/mathlib4/issues/25053 go through.
+    (See `tests/lean/run/clear_value.lean`, 25053.)
+    -/
+    let tgt' ← instantiateMVars tgt'
     unless ← isTypeCorrect tgt' do
       mvarId.withContext <|
         throwTacticEx `clear_value mvarId


### PR DESCRIPTION
This PR upstreams and extends the Mathlib `clear_value` tactic. Given a local definition `x : T := v`, the tactic `clear_value x` replaces it with a hypothesis `x : T`, or throws an error if the goal does not depend on the value `v`. The syntax `clear_value x with h` creates a hypothesis `h : x = v` before clearing the value of `x`. Furthermore, `clear_value *` clears all values that can be cleared, or throws an error if none can be cleared.
