### PR TITLE
feat: Switch from "math" to "mathlib" in the `lake new <project> <template>` syntax

### DIFF
--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -80,7 +80,7 @@ The initial configuration and starter files are based on the template:
   std                   library and executable; default
   exe                   executable only
   lib                   library only
-  math                  library only with a mathlib dependency
+  mathlib               library only with a mathlib dependency
 
 Templates can be suffixed with `.lean` or `.toml` to produce a Lean or TOML
 version of the configuration file, respectively. The default is TOML."

--- a/src/lake/Lake/CLI/Init.lean
+++ b/src/lake/Lake/CLI/Init.lean
@@ -194,6 +194,7 @@ def InitTemplate.ofString? : String → Option InitTemplate
 | "exe" => some .exe
 | "lib" => some .lib
 | "math" => some .math
+| "mathlib" => some .math
 | _ => none
 
 def escapeIdent (id : String) : String :=


### PR DESCRIPTION
This PR switches the default template name from "math" to "mathlib" in the `lake new <project> <template>` command, while continuing to support "math" for backward compatibility. This clarifies the intended use and avoids ambiguity in naming.