### PR TITLE
fix: `simp_all?` and `simp_all?!`

### DIFF
--- a/src/Lean/Elab/Tactic/SimpTrace.lean
+++ b/src/Lean/Elab/Tactic/SimpTrace.lean
@@ -47,10 +47,10 @@ def mkSimpCallStx (stx : Syntax) (usedSimps : UsedSimps) : MetaM (TSyntax `tacti
       `(tactic| simp_all!%$tk $cfg:optConfig $(discharger)? $[only%$o]? $[[$args,*]]?)
     else
       `(tactic| simp_all%$tk $cfg:optConfig $(discharger)? $[only%$o]? $[[$args,*]]?)
-    let { ctx, .. } ← mkSimpContext stx (eraseLocal := true)
+    let { ctx, simprocs, .. } ← mkSimpContext stx (eraseLocal := true)
       (kind := .simpAll) (ignoreStarArg := true)
     let ctx := if bang.isSome then ctx.setAutoUnfold else ctx
-    let (result?, stats) ← simpAll (← getMainGoal) ctx
+    let (result?, stats) ← simpAll (← getMainGoal) ctx (simprocs := simprocs)
     match result? with
     | none => replaceMainGoal []
     | some mvarId => replaceMainGoal [mvarId]

--- a/tests/lean/run/issue8490.lean
+++ b/tests/lean/run/issue8490.lean
@@ -1,0 +1,18 @@
+inductive Aexp where
+  | val : Int → Aexp
+  | plus : Aexp → Aexp → Aexp
+
+@[simp]
+def asimp_const : Aexp -> Aexp
+  | .val x    => .val x
+  | .plus x y => .plus x y
+
+@[simp]
+def optimal' (a : Aexp) : Prop :=
+  optimal' a ∧ True
+least_fixpoint
+
+/-- info: Try this: simp_all only [asimp_const, reduceCtorEq] -/
+#guard_msgs in
+example (x y : Aexp) (k : Int) (h : asimp_const (.val k) = x.plus y) : optimal' x := by
+  simp_all?


### PR DESCRIPTION
This PR fixes the behavior of `simp_all?` and `simp_all?!`, aligning them with `simp_all` and `simp_all!` respectively.

Closes #8490
