### PR TITLE
fix: wrap the new compiler in `withoutExporting`

### DIFF
--- a/src/Lean/CoreM.lean
+++ b/src/Lean/CoreM.lean
@@ -709,8 +709,9 @@ where doCompile := do
     return
   let opts ← getOptions
   if compiler.enableNew.get opts then
-    try compileDeclsNew decls catch e =>
-      if logErrors then throw e else return ()
+    withoutExporting
+      try compileDeclsNew decls catch e =>
+        if logErrors then throw e else return ()
   else
     let res ← withTraceNode `compiler (fun _ => return m!"compiling old: {decls}") do
       return compileDeclsOld (← getEnv) opts decls


### PR DESCRIPTION
This PR wraps the invocation of the new compiler in `withoutExporting`. This is not necessary for the old compiler because it uses more direct access to the kernel environment.