### PR TITLE
fix: lake: ensure Lake versions are SemVer compatible

### DIFF
--- a/src/lake/Lake/Version.lean
+++ b/src/lake/Lake/Version.lean
@@ -16,7 +16,7 @@ def version.isRelease :=
   Lean.version.isRelease
 
 def version.specialDesc :=
-  if isRelease && !Lean.githash.isEmpty then Lean.githash.take 7 else "src"
+  if isRelease && !Lean.githash.isEmpty then s!"src+{Lean.githash.take 7}" else "src"
 
 def versionStringCore :=
   s!"{version.major}.{version.minor}.{version.patch}"


### PR DESCRIPTION
This PR changes the Lake version syntax (to `5.0.0-src+<commit>`) to ensure it is a well-formed SemVer,
