### PR TITLE
fix: revert state on compilation failure (new compiler)

### DIFF
--- a/src/Lean/CoreM.lean
+++ b/src/Lean/CoreM.lean
@@ -718,9 +718,14 @@ where doCompile := do
     return
   let opts ← getOptions
   if compiler.enableNew.get opts then
-    withoutExporting
-      try compileDeclsNew decls catch e =>
-        if logErrors then throw e else return ()
+    withoutExporting do
+      let state ← Core.saveState
+      try
+        compileDeclsNew decls
+      catch e =>
+        state.restore
+        if logErrors then
+          throw e
   else
     let res ← withTraceNode `compiler (fun _ => return m!"compiling old: {decls}") do
       return compileDeclsOld (← getEnv) opts decls


### PR DESCRIPTION
This PR ensures that the state is reverted when compilation using the new compiler fails. This is especially important for noncomputable sections where the compiler might generate half-compiled functions which may then be erroneously used while compiling other functions.
