### PR TITLE
doc: fix broken "quickstart" and "supported editors" link

### DIFF
--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -8,7 +8,7 @@ You should not edit the `stage0` directory except using the commands described i
 
 ## Development Setup
 
-You can use any of the [supported editors](https://docs.lean-lang.org/lean4/doc/setup.html#editing) for editing the Lean source code.
+You can use any of the [supported editors](https://lean-lang.org/install/manual/) for editing the Lean source code.
 Please see below for specific instructions for VS Code.
 
 ### Dev setup using elan

--- a/doc/make/index.md
+++ b/doc/make/index.md
@@ -1,6 +1,6 @@
 These are instructions to set up a working development environment for those who wish to make changes to Lean itself. It is part of the [Development Guide](../dev/index.md).
 
-We strongly suggest that new users instead follow the [Quickstart](https://docs.lean-lang.org/lean4/doc/quickstart.html) to get started using Lean, since this sets up an environment that can automatically manage multiple Lean toolchain versions, which is necessary when working within the Lean ecosystem.
+We strongly suggest that new users instead follow the [Installation Instructions](https://lean-lang.org/install/) to get started using Lean, since this sets up an environment that can automatically manage multiple Lean toolchain versions, which is necessary when working within the Lean ecosystem.
 
 Requirements
 ------------


### PR DESCRIPTION
The "supported editors" link in https://github.com/leanprover/lean4/blob/master/doc/dev/index.md is broken, as `setup.md` no longer exists in the repo. This PR changes the link to point to the live Lean docs setup page at https://docs.lean-lang.org/lean4/doc/setup.html#editing.

A similar fix for quickstart is included.