### PR TITLE
fix: constant fold Char.ofNat in LCNF simp

### DIFF
--- a/src/Lean/Compiler/LCNF/Simp/ConstantFold.lean
+++ b/src/Lean/Compiler/LCNF/Simp/ConstantFold.lean
@@ -391,6 +391,7 @@ def conversionFolders : List (Name × Folder) := [
   (``UInt32.ofNat, Folder.ofNat (fun v => .uint32 (UInt32.ofNat v))),
   (``UInt64.ofNat, Folder.ofNat (fun v => .uint64 (UInt64.ofNat v))),
   (``USize.ofNat, Folder.ofNat (fun v => .usize (UInt64.ofNat v))),
+  (``Char.ofNat, Folder.ofNat (fun v => .uint32 (Char.ofNat v).val)),
   (``UInt8.toNat, Folder.toNat),
   (``UInt16.toNat, Folder.toNat),
   (``UInt32.toNat, Folder.toNat),


### PR DESCRIPTION
This PR adds constant folding for Char.ofNat in LCNF simp. This implicitly relies on the representation of `Char` as `UInt32` rather than making a separate `.char` literal type, which seems reasonable as `Char` is erased by the trivial structure optimization in `toMono`.