### PR TITLE
feat: add doc-string to grind algebra typeclasses

### DIFF
--- a/src/Init/Grind/Module/Basic.lean
+++ b/src/Init/Grind/Module/Basic.lean
@@ -14,28 +14,60 @@ namespace Lean.Grind
 class AddRightCancel (M : Type u) [Add M] where
   add_right_cancel : ∀ a b c : M, a + c = b + c → a = b
 
+/--
+A module over the natural numbers, i.e. a type with zero, addition, and scalar multiplication by natural numbers,
+satisfying appropriate compatibilities.
+
+Equivalently, an additive commutative monoid.
+
+Use `IntModule` if the type has negation.
+-/
 class NatModule (M : Type u) extends Zero M, Add M, HMul Nat M M where
+  /-- Zero is the right identity for addition. -/
   add_zero : ∀ a : M, a + 0 = a
+  /-- Addition is commutative. -/
   add_comm : ∀ a b : M, a + b = b + a
+  /-- Addition is associative. -/
   add_assoc : ∀ a b c : M, a + b + c = a + (b + c)
+  /-- Scalar multiplication by zero is zero. -/
   zero_hmul : ∀ a : M, 0 * a = 0
+  /-- Scalar multiplication by one is the identity. -/
   one_hmul : ∀ a : M, 1 * a = a
+  /-- Scalar multiplication is distributive over addition in the natural numbers. -/
   add_hmul : ∀ n m : Nat, ∀ a : M, (n + m) * a = n * a + m * a
+  /-- Scalar multiplication of zero is zero. -/
   hmul_zero : ∀ n : Nat, n * (0 : M) = 0
+  /-- Scalar multiplication is distributive over addition in the module. -/
   hmul_add : ∀ n : Nat, ∀ a b : M, n * (a + b) = n * a + n * b
 
 attribute [instance 100] NatModule.toZero NatModule.toAdd NatModule.toHMul
 
+/--
+A module over the integers, i.e. a type with zero, addition, negation, subtraction, and scalar multiplication by integers,
+satisfying appropriate compatibilities.
+
+Equivalently, an additive commutative group.
+-/
 class IntModule (M : Type u) extends Zero M, Add M, Neg M, Sub M, HMul Int M M where
+  /-- Zero is the right identity for addition. -/
   add_zero : ∀ a : M, a + 0 = a
+  /-- Addition is commutative. -/
   add_comm : ∀ a b : M, a + b = b + a
+  /-- Addition is associative. -/
   add_assoc : ∀ a b c : M, a + b + c = a + (b + c)
+  /-- Scalar multiplication by zero is zero. -/
   zero_hmul : ∀ a : M, (0 : Int) * a = 0
+  /-- Scalar multiplication by one is the identity. -/
   one_hmul : ∀ a : M, (1 : Int) * a = a
+  /-- Scalar multiplication is distributive over addition in the integers. -/
   add_hmul : ∀ n m : Int, ∀ a : M, (n + m) * a = n * a + m * a
+  /-- Scalar multiplication of zero is zero. -/
   hmul_zero : ∀ n : Int, n * (0 : M) = 0
+  /-- Scalar multiplication is distributive over addition in the module. -/
   hmul_add : ∀ n : Int, ∀ a b : M, n * (a + b) = n * a + n * b
+  /-- Negation is the left inverse of addition. -/
   neg_add_cancel : ∀ a : M, -a + a = 0
+  /-- Subtraction is addition of the negative. -/
   sub_eq_add_neg : ∀ a b : M, a - b = a + -b
 
 namespace NatModule
@@ -155,7 +187,10 @@ theorem mul_hmul (n m : Int) (a : M) : (n * m) * a = n * (m * a) := by
 end IntModule
 
 /--
-Special case of Mathlib's `NoZeroSMulDivisors Nat α`.
+We say a module has no natural number zero divisors if
+`k * a = 0` implies `k = 0` or `a = 0` (here `k` is a natural number and `a` is an element of the module).
+
+This is a special case of Mathlib's `NoZeroSMulDivisors Nat α`.
 -/
 class NoNatZeroDivisors (α : Type u) [Zero α] [HMul Nat α α] where
   no_nat_zero_divisors : ∀ (k : Nat) (a : α), k ≠ 0 → k * a = 0 → a = 0

--- a/src/Init/Grind/Ordered/Order.lean
+++ b/src/Init/Grind/Ordered/Order.lean
@@ -12,9 +12,12 @@ namespace Lean.Grind
 
 /-- A preorder is a reflexive, transitive relation `≤` with `a < b` defined in the obvious way. -/
 class Preorder (α : Type u) extends LE α, LT α where
+  /-- The less-than-or-equal relation is reflexive. -/
   le_refl : ∀ a : α, a ≤ a
+  /-- The less-than-or-equal relation is transitive. -/
   le_trans : ∀ {a b c : α}, a ≤ b → b ≤ c → a ≤ c
   lt := fun a b => a ≤ b ∧ ¬b ≤ a
+  /-- The less-than relation is determined by the less-than-or-equal relation. -/
   lt_iff_le_not_le : ∀ {a b : α}, a < b ↔ a ≤ b ∧ ¬b ≤ a := by intros; rfl
 
 namespace Preorder
@@ -52,7 +55,9 @@ theorem not_gt_of_lt {a b : α} (h : a < b) : ¬a > b :=
 
 end Preorder
 
+/-- A partial order is a preorder with the additional property that `a ≤ b` and `b ≤ a` implies `a = b`. -/
 class PartialOrder (α : Type u) extends Preorder α where
+  /-- The less-than-or-equal relation is antisymmetric. -/
   le_antisymm : ∀ {a b : α}, a ≤ b → b ≤ a → a = b
 
 namespace PartialOrder
@@ -71,7 +76,9 @@ theorem le_iff_lt_or_eq {a b : α} : a ≤ b ↔ a < b ∨ a = b := by
 
 end PartialOrder
 
+/-- A linear order is a partial order with the additional property that every pair of elements is comparable. -/
 class LinearOrder (α : Type u) extends PartialOrder α where
+  /-- For every two elements `a` and `b`, either `a ≤ b` or `b ≤ a`. -/
   le_total : ∀ a b : α, a ≤ b ∨ b ≤ a
 
 namespace LinearOrder

--- a/src/Init/Grind/Ordered/Ring.lean
+++ b/src/Init/Grind/Ordered/Ring.lean
@@ -11,6 +11,10 @@ import Init.Grind.Ordered.Module
 
 namespace Lean.Grind
 
+/--
+A ring which is also equipped with a preorder is considered a strict ordered ring if addition, negation,
+and multiplication are compatible with the preorder, and `0 < 1`.
+-/
 class Ring.IsOrdered (R : Type u) [Ring R] [Preorder R] extends IntModule.IsOrdered R where
   /-- In a strict ordered semiring, we have `0 < 1`. -/
   zero_lt_one : (0 : R) < 1


### PR DESCRIPTION
This PR adds doc-strings to the `Lean.Grind` algebra typeclasses, as these will appear in the reference manual explaining how to extend `grind` algebra solvers to new types. Also removes some redundant fields.