### PR TITLE
perf: use `MVarId.assign` instead of `isDefEq` in type class search

### DIFF
--- a/src/Lean/Meta/SynthInstance.lean
+++ b/src/Lean/Meta/SynthInstance.lean
@@ -367,8 +367,8 @@ def tryResolve (mvar : Expr) (inst : Instance) : MetaM (Option (MetavarContext �
       we would start getting terms such as `fun x => (fun x => inst x) x` when using the equational theorem.
       -/
       let instVal ← mkLambdaFVars xs instVal (etaReduce := true)
-      if (← isDefEq mvar instVal) then
-        return some ((← getMCtx), subgoals)
+      mvar.mvarId!.assign instVal
+      return some ((← getMCtx), subgoals)
     return none
 
 /--

--- a/tests/lean/run/grind_ematch_gen_pattern.lean
+++ b/tests/lean/run/grind_ematch_gen_pattern.lean
@@ -53,8 +53,6 @@ trace: [grind.ematch.instance] pbind_some': ∀ (h : b = some a), (b.pbind fun a
       (b.pbind fun a h => some (a + f b ⋯)) = some (a + 4 * f b ⋯ + f b ⋯)
 [grind.ematch.instance] pbind_some': ∀ (h_3 : b = some (a + 5 * f b ⋯)),
       (b.pbind fun a h => some (a + f b ⋯)) = some (a + 5 * f b ⋯ + f b ⋯)
-[grind.ematch.instance] pbind_some': ∀ (h_3 : b = some (2 * a + f b ⋯)),
-      (b.pbind fun a h => some (a + f b ⋯)) = some (2 * a + f b ⋯ + f b ⋯)
 [grind.ematch.instance] pbind_some': ∀ (h_3 : b = some (a + 6 * f b ⋯)),
       (b.pbind fun a h => some (a + f b ⋯)) = some (a + 6 * f b ⋯ + f b ⋯)
 [grind.ematch.instance] pbind_some': ∀ (h_3 : b = some (a + 7 * f b ⋯)),


### PR DESCRIPTION
This PR replaces a use of `isDefEq` with `MVarId.assign` in type class search, to get a speedup.
