### PR TITLE
fix: use an unreachable default for cases with > 2 alts

### DIFF
--- a/src/Lean/Compiler/IR/SimpCase.lean
+++ b/src/Lean/Compiler/IR/SimpCase.lean
@@ -10,12 +10,10 @@ import Lean.Compiler.IR.Format
 namespace Lean.IR
 
 def ensureHasDefault (alts : Array Alt) : Array Alt :=
-  if alts.any Alt.isDefault then alts
-  else if alts.size < 2 then alts
+  if alts.any Alt.isDefault then
+    alts
   else
-    let last := alts.back!
-    let alts := alts.pop
-    alts.push (Alt.default last.body)
+    alts.push (Alt.default .unreachable)
 
 private def getOccsOf (alts : Array Alt) (i : Nat) : Nat := Id.run do
   let aBody := alts[i]!.body


### PR DESCRIPTION
This PR changes the codegen for non-if case expressions to add a default unreachable! rather than making the final alt the default. This should provide more latitude for optimization to LLVM, because it implies that any invalid constructor index is actually UB, rather than treating them all as the last index.

This fixes #2033.