### PR TITLE
feat: add `BitVec.toFin_(sdiv, smod, srem)` and `BitVec.toNat_srem`

### DIFF
--- a/src/Init/Data/BitVec/Lemmas.lean
+++ b/src/Init/Data/BitVec/Lemmas.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Lean FRO, LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Joe Hendrix, Harun Khan, Alex Keizer, Abdalrhman M Mohamed, Siddharth Bhat
+Authors: Joe Hendrix, Harun Khan, Alex Keizer, Abdalrhman M Mohamed, Siddharth Bhat, Luisa Cicolini
 -/
 module
 


### PR DESCRIPTION
This PR adds `BitVec.toFin_(sdiv, smod, srem)` and `BitVec.toNat_srem`. The strategy for the `rhs` of the `toFin_*` lemmas is to consider what the corresponding `toNat_*` theorems do and push the `toFin` closerto the operands. For the `rhs` of `BitVec.toNat_srem` I used the same strategy as `BitVec.toNat_smod`.