### PR TITLE
feat: ToStream instance for ranges

### DIFF
--- a/src/Init/Data/Iterators/Consumers/Access.lean
+++ b/src/Init/Data/Iterators/Consumers/Access.lean
@@ -6,6 +6,7 @@ Authors: Paul Reichert
 module
 
 prelude
+import Init.Data.Stream
 import Init.Data.Iterators.Consumers.Partial
 import Init.Data.Iterators.Consumers.Loop
 import Init.Data.Iterators.Consumers.Monadic.Access
@@ -60,5 +61,16 @@ def Iter.atIdx? {α β} [Iterator α Id β] [Productive α Id] [IteratorAccess �
   | .yield _ out => some out
   | .skip _ => none
   | .done => none
+
+instance {α β} [Iterator α Id β] [Productive α Id] [IteratorAccess α Id] :
+    Stream (Iter (α := α) β) β where
+  next? it := match (it.toIterM.nextAtIdx? 0).run with
+    | .yield it' out _ => some (out, it'.toIter)
+    | .skip _ h => False.elim ?noskip
+    | .done _ => none
+  where finally
+    case noskip =>
+      revert h
+      exact IterM.not_isPlausibleNthOutputStep_yield
 
 end Std.Iterators

--- a/src/Init/Data/Iterators/Consumers/Monadic/Access.lean
+++ b/src/Init/Data/Iterators/Consumers/Monadic/Access.lean
@@ -41,6 +41,17 @@ inductive IterM.IsPlausibleNthOutputStep {α β : Type w} {m : Type w → Type w
   | skip {it it' : IterM (α := α) m β} {step} : it.IsPlausibleStep (.skip it') →
       it'.IsPlausibleNthOutputStep n step → it.IsPlausibleNthOutputStep n step
 
+theorem IterM.not_isPlausibleNthOutputStep_yield {α β : Type w} {m : Type w → Type w'} [Iterator α m β]
+    {n : Nat} {it it' : IterM (α := α) m β} :
+    ¬ it.IsPlausibleNthOutputStep n (.skip it') := by
+  intro h
+  generalize h' : IterStep.skip it' = step at h
+  induction h
+  · cases h'
+  · cases h'
+  · simp_all
+  · simp_all
+
 /--
 `IteratorAccess α m` provides efficient implementations for random access or iterators that support
 it. `it.nextAtIdx? n` either returns the step in which the `n`-th value of `it` is emitted

--- a/src/Init/Data/Range/Polymorphic.lean
+++ b/src/Init/Data/Range/Polymorphic.lean
@@ -7,6 +7,7 @@ module
 
 prelude
 import Init.Data.Range.Polymorphic.Basic
+import Init.Data.Range.Polymorphic.Iterators
 import Init.Data.Range.Polymorphic.Lemmas
 import Init.Data.Range.Polymorphic.Nat
 import Init.Data.Range.Polymorphic.NatLemmas

--- a/src/Init/Data/Range/Polymorphic/Iterators.lean
+++ b/src/Init/Data/Range/Polymorphic/Iterators.lean
@@ -9,6 +9,7 @@ prelude
 import Init.Data.Range.Polymorphic.RangeIterator
 import Init.Data.Range.Polymorphic.Basic
 import Init.Data.Iterators.Combinators.Attach
+import Init.Data.Stream
 
 open Std.Iterators
 
@@ -22,6 +23,10 @@ Use `PRange.iter` instead, which requires importing `Std.Data.Iterators`.
 def Internal.iter {sl su α} [UpwardEnumerable α] [BoundedUpwardEnumerable sl α]
     (r : PRange ⟨sl, su⟩ α) : Iter (α := RangeIterator su α) α :=
   ⟨⟨BoundedUpwardEnumerable.init? r.lower, r.upper⟩⟩
+
+instance {sl su α} [UpwardEnumerable α] [BoundedUpwardEnumerable sl α] :
+    ToStream (PRange ⟨sl, su⟩ α) (Iter (α := RangeIterator su α) α) where
+  toStream r := Internal.iter r
 
 /--
 Returns the elements of the given range as a list in ascending order, given that ranges of the given

--- a/src/Init/Data/Range/Polymorphic/RangeIterator.lean
+++ b/src/Init/Data/Range/Polymorphic/RangeIterator.lean
@@ -277,6 +277,27 @@ instance RangeIterator.instFinite {su} [UpwardEnumerable α] [SupportsUpperBound
     Finite (RangeIterator su α) Id :=
   .of_finitenessRelation instFinitenessRelation
 
+private def RangeIterator.instProductivenessRelation [UpwardEnumerable α] [SupportsUpperBound su α]
+    [LawfulUpwardEnumerable α] :
+    ProductivenessRelation (RangeIterator su α) Id where
+  rel := emptyWf.rel
+  wf := emptyWf.wf
+  subrelation {it it'} h := by
+    exfalso
+    simp only [IterM.IsPlausibleSkipSuccessorOf, IterM.IsPlausibleStep,
+      Iterator.IsPlausibleStep, Monadic.step] at h
+    split at h
+    · cases h
+    · split at h
+      · cases h
+      · cases h
+
+@[no_expose]
+instance RangeIterator.instProductive {su} [UpwardEnumerable α] [SupportsUpperBound su α]
+    [LawfulUpwardEnumerable α] :
+    Productive (RangeIterator su α) Id :=
+  .of_productivenessRelation instProductivenessRelation
+
 instance RangeIterator.instIteratorAccess {su} [UpwardEnumerable α] [SupportsUpperBound su α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableUpperBound su α] :
     IteratorAccess (RangeIterator su α) Id where

--- a/tests/lean/run/rangePolymorphic.lean
+++ b/tests/lean/run/rangePolymorphic.lean
@@ -52,3 +52,17 @@ def g (xs : Array Nat) : Nat := Id.run do
 /-- info: 6 -/
 #guard_msgs in
 #eval g #[1, 2, 3]
+
+def h (n : Nat) : IO Unit := do
+  for i in *...n, j in 2...* do
+    IO.println s!"i={i}, j={j}"
+
+/--
+info: i=0, j=2
+i=1, j=3
+i=2, j=4
+i=3, j=5
+i=4, j=6
+-/
+#guard_msgs in
+#eval h 5


### PR DESCRIPTION
This PR provides a `ToStream` instance for slices so that they can be used in `for i in xs, j in ys do` notation.