### PR TITLE
chore: lake: re-enable tests in CI

### DIFF
--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -48,6 +48,7 @@ structure LakeOptions where
   outLv? : Option LogLevel := .none
   ansiMode : AnsiMode := .auto
   outFormat : OutFormat := .text
+  offline : Bool := false
 
 def LakeOptions.outLv (opts : LakeOptions) : LogLevel :=
   opts.outLv?.getD opts.verbosity.minLogLv
@@ -195,6 +196,7 @@ def lakeLongOption : (opt : String) → CliM PUnit
 | "--no-cache"    => modifyThe LakeOptions ({· with noCache := true})
 | "--try-cache"   => modifyThe LakeOptions ({· with noCache := false})
 | "--rehash"      => modifyThe LakeOptions ({· with trustHash := false})
+| "--offline"     => modifyThe LakeOptions ({· with offline := true})
 | "--wfail"       => modifyThe LakeOptions ({· with failLv := .warning})
 | "--iofail"      => modifyThe LakeOptions ({· with failLv := .info})
 | "--log-level"   => do
@@ -340,14 +342,14 @@ protected def new : CliM PUnit := do
   let opts ← getThe LakeOptions
   let name ← takeArg "package name"
   let (tmp, lang) ← parseTemplateLangSpec <| ← takeArgD ""
-  noArgsRem do new name tmp lang (← opts.computeEnv) opts.rootDir
+  noArgsRem do new name tmp lang (← opts.computeEnv) opts.rootDir opts.offline
 
 protected def init : CliM PUnit := do
   processOptions lakeOption
   let opts ← getThe LakeOptions
   let name := ← takeArgD "."
   let (tmp, lang) ← parseTemplateLangSpec <| ← takeArgD ""
-  noArgsRem do init name tmp lang (← opts.computeEnv) opts.rootDir
+  noArgsRem do init name tmp lang (← opts.computeEnv) opts.rootDir opts.offline
 
 protected def build : CliM PUnit := do
   processOptions lakeOption

--- a/src/lake/tests/common.sh
+++ b/src/lake/tests/common.sh
@@ -209,7 +209,7 @@ test_maybe_err() {
   match_text "$expected" produced.out
 }
 
-check_diff() {
+check_diff_core() {
   expected=$1; actual=$2
   if diff -u --strip-trailing-cr "$expected" "$actual"; then
     cat "$actual"
@@ -220,11 +220,18 @@ check_diff() {
   fi
 }
 
+check_diff() {
+  expected=$1; actual=$2
+  cat "$actual" > produced.out
+  check_diff_core "$expected" produced.out
+}
+
 test_out_diff() {
   expected=$1; shift
+  cat "$expected" > produced.expected.out
   echo '$' lake "$@"
   if "$LAKE" "$@" >produced.out 2>&1; then rc=$?; else rc=$?; fi
-  if check_diff "$expected" produced.out; then
+  if check_diff_core produced.expected.out produced.out; then
     if [ $rc != 0 ]; then
       echo "FAILURE: Program exited with code $rc"
       return 1
@@ -239,9 +246,10 @@ test_out_diff() {
 
 test_err_diff() {
   expected=$1; shift
+  cat "$expected" > produced.expected.out
   echo '$' lake "$@"
   if "$LAKE" "$@" >produced.out 2>&1; then rc=$?; else rc=$?; fi
-  if check_diff "$expected" produced.out; then
+  if check_diff_core produced.expected.out produced.out; then
     if [ $rc != 1 ]; then
       echo "FAILURE: Lake unexpectedly succeeded"
       return 1

--- a/src/lake/tests/init/test.sh
+++ b/src/lake/tests/init/test.sh
@@ -67,14 +67,16 @@ rm -rf hello
 # Test math-lax template
 
 echo "# TEST: math-lax template"
-test_run new qed math-lax.lean || true # ignore toolchain download errors
-# Remove the require, since we do not wish to download mathlib during tests
+# Use `--offline` and remove the `require`,
+# since we do not wish to download mathlib during tests
+test_run new qed math-lax.lean --offline
 sed_i '/^require.*/{N;d;}' qed/lakefile.lean
 test_run -d qed build Qed
 test -f qed/.lake/build/lib/lean/Qed.olean
 rm -rf qed
-test_run new qed math-lax.toml || true # ignore toolchain download errors
-# Remove the require, since we do not wish to download mathlib during tests
+# Use `--offline` and remove the `require`,
+# since we do not wish to download mathlib during tests
+test_run new qed math-lax.toml --offline
 sed_i '/^\[\[require\]\]/{N;N;N;d;}' qed/lakefile.toml
 test_run -d qed build Qed
 test -f qed/.lake/build/lib/lean/Qed.olean

--- a/src/lake/tests/inputFile/clean.sh
+++ b/src/lake/tests/inputFile/clean.sh
@@ -1,2 +1,2 @@
-rm -rf .lake lake-manifest.json produced.out
-rm -rf inputs lakefile.produced.lean lakefileAlt.produced.toml
+rm -rf .lake lake-manifest.json inputs
+rm -f *produced*

--- a/src/lake/tests/inputFile/test.sh
+++ b/src/lake/tests/inputFile/test.sh
@@ -66,4 +66,4 @@ EOF
 ) -q exe test
 
 # Cleanup
-rm -f produced.out
+rm -f produced*

--- a/src/lake/tests/noRelease/clean.sh
+++ b/src/lake/tests/noRelease/clean.sh
@@ -1,1 +1,2 @@
-rm -rf produced.out .lake lake-manifest.json dep/.lake dep/.git
+rm -f produced*
+rm -rf .lake lake-manifest.json dep/.lake dep/.git

--- a/src/lake/tests/noRelease/test.sh
+++ b/src/lake/tests/noRelease/test.sh
@@ -94,4 +94,4 @@ test_run build dep:release
 
 # Cleanup
 rm -rf dep/.git
-rm -f prdouced.out
+rm -f produced*

--- a/src/lake/tests/reservoirConfig/clean.sh
+++ b/src/lake/tests/reservoirConfig/clean.sh
@@ -1,1 +1,2 @@
-rm -rf .lake lake-manifest.json .git produced.out
+rm -f produced*
+rm -rf .lake lake-manifest.json .git

--- a/src/lake/tests/reservoirConfig/test.sh
+++ b/src/lake/tests/reservoirConfig/test.sh
@@ -26,4 +26,4 @@ test_out_diff expected.json reservoir-config
 
 # Cleanup
 rm -rf .git
-rm -f produced.out
+rm -f produced*

--- a/src/lake/tests/versionTags/clean.sh
+++ b/src/lake/tests/versionTags/clean.sh
@@ -1,1 +1,2 @@
-rm -rf .lake lake-manifest.json .git produced.out
+rm -rf .lake lake-manifest.json .git
+rm -f produced*

--- a/src/lake/tests/versionTags/test.sh
+++ b/src/lake/tests/versionTags/test.sh
@@ -31,5 +31,5 @@ EOF
 ) version-tags
 
 # Cleanup
-rm -f produced.out
+rm -f produced*
 rm -rf .git

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -186,7 +186,7 @@ ENDFOREACH(T)
 # toolchain: requires elan to download toolchain
 # online: downloads remote repositories
 file(GLOB_RECURSE LEANLAKETESTS
-  #"${LEAN_SOURCE_DIR}/lake/tests/test.sh"
+  "${LEAN_SOURCE_DIR}/lake/tests/test.sh"
   "${LEAN_SOURCE_DIR}/lake/examples/test.sh")
 FOREACH(T ${LEANLAKETESTS})
   if(NOT T MATCHES ".*(lake-packages|bootstrap|toolchain|online).*")


### PR DESCRIPTION
This PR re-enables Lake tests in the CI. The most likely cause of the previous issues was memory limits that have since been fixed.

This also fixes some issues with the tests on macOS and corrects the properly avoids downloading Mathlib in the `init` test after changes to the `math-lax` template in #8866.