### PR TITLE
fix: `simp?` output order

### DIFF
--- a/src/Init/Data/Array/Basic.lean
+++ b/src/Init/Data/Array/Basic.lean
@@ -2149,7 +2149,7 @@ Examples:
 
 /-! ### Repr and ToString -/
 
-protected def Array.repr {α : Type u} [Repr α] (xs : Array α) : Std.Format :=
+protected def repr {α : Type u} [Repr α] (xs : Array α) : Std.Format :=
   let _ : Std.ToFormat α := ⟨repr⟩
   if xs.size == 0 then
     "#[]"

--- a/src/Lean/Elab/Tactic/Conv/Simp.lean
+++ b/src/Lean/Elab/Tactic/Conv/Simp.lean
@@ -33,7 +33,7 @@ def applySimpResult (result : Simp.Result) : TacticM Unit := do
     let (result, stats) ← dischargeWrapper.with fun d? =>
       simp lhs ctx (simprocs := simprocs) (discharge? := d?)
     applySimpResult result
-    let stx ← mkSimpCallStx stx stats.usedTheorems
+    let stx ← mkSimpCallStx stx ctx simprocs stats.usedTheorems
     addSuggestion tk stx (origSpan? := ← getRef)
   | _ => throwUnsupportedSyntax
 
@@ -41,17 +41,17 @@ def applySimpResult (result : Simp.Result) : TacticM Unit := do
   applySimpResult (← Split.simpMatch (← getLhs))
 
 @[builtin_tactic Lean.Parser.Tactic.Conv.dsimp] def evalDSimp : Tactic := fun stx => withMainContext do
-  let { ctx, .. } ← mkSimpContext stx (eraseLocal := false) (kind := .dsimp)
-  changeLhs (← Lean.Meta.dsimp (← getLhs) ctx).1
+  let { ctx, simprocs, .. } ← mkSimpContext stx (eraseLocal := false) (kind := .dsimp)
+  changeLhs (← Lean.Meta.dsimp (← getLhs) ctx simprocs).1
 
 @[builtin_tactic Lean.Parser.Tactic.Conv.dsimpTrace] def evalDSimpTrace : Tactic := fun stx => withMainContext do
   match stx with
   | `(conv| dsimp?%$tk $cfg:optConfig $[only%$o]? $[[$args,*]]?) =>
     let stx ← `(tactic| dsimp%$tk $cfg:optConfig $[only%$o]? $[[$args,*]]?)
-    let { ctx, .. } ← mkSimpContext stx (eraseLocal := false) (kind := .dsimp)
-    let (result, stats) ← Lean.Meta.dsimp (← getLhs) ctx
+    let { ctx, simprocs, .. } ← mkSimpContext stx (eraseLocal := false) (kind := .dsimp)
+    let (result, stats) ← Lean.Meta.dsimp (← getLhs) ctx simprocs
     changeLhs result
-    let stx ← mkSimpCallStx stx stats.usedTheorems
+    let stx ← mkSimpCallStx stx ctx simprocs stats.usedTheorems
     addSuggestion tk stx (origSpan? := ← getRef)
   | _ => throwUnsupportedSyntax
 

--- a/src/Lean/Elab/Tactic/Simpa.lean
+++ b/src/Lean/Elab/Tactic/Simpa.lean
@@ -96,7 +96,7 @@ deriving instance Repr for UseImplicitLambdaResult
         g.assumption; pure stats
       if tactic.simp.trace.get (← getOptions) || squeeze.isSome then
         let usingArg : Option Term := usingArg.map (⟨·.raw.unsetTrailing⟩)
-        let stx ← match ← mkSimpOnly stx.raw.unsetTrailing stats.usedTheorems with
+        let stx ← match ← mkSimpOnly stx.raw.unsetTrailing ctx simprocs stats.usedTheorems with
           | `(tactic| simp $cfg:optConfig $(disch)? $[only%$only]? $[[$args,*]]?) =>
             if unfold.isSome then
               `(tactic| simpa! $cfg:optConfig $(disch)? $[only%$only]? $[[$args,*]]? $[using $usingArg]?)

--- a/src/Lean/Elab/Tactic/Try.lean
+++ b/src/Lean/Elab/Tactic/Try.lean
@@ -398,10 +398,10 @@ private def evalSuggestSimpTrace : TryTactic := fun tac => do (← getMainGoal).
   | `(tactic| simp? $_:optConfig $[only%$only]? $[[$args,*]]? $(loc)?) =>
     let tac ← simpTraceToSimp tac
     let { ctx, simprocs, .. } ← mkSimpContext tac (eraseLocal := false)
-    let stats ← simpLocation ctx (simprocs := simprocs) none <| (loc.map expandLocation).getD (.targets #[] true)
+    let stats ← simpLocation ctx simprocs none <| (loc.map expandLocation).getD (.targets #[] true)
     trace[try.debug] "`simp` succeeded"
     if (← read).config.only then
-      let tac' ← mkSimpCallStx tac stats.usedTheorems
+      let tac' ← mkSimpCallStx tac ctx simprocs stats.usedTheorems
       mkTrySuggestions #[tac, tac']
     else
       return tac

--- a/src/Lean/Meta/Tactic/Simp.lean
+++ b/src/Lean/Meta/Tactic/Simp.lean
@@ -16,6 +16,7 @@ import Lean.Meta.Tactic.Simp.RegisterCommand
 import Lean.Meta.Tactic.Simp.Attr
 import Lean.Meta.Tactic.Simp.Diagnostics
 import Lean.Meta.Tactic.Simp.Arith
+import Lean.Meta.Tactic.Simp.UsedSimps
 
 namespace Lean
 

--- a/src/Lean/Meta/Tactic/Simp/LoopProtection.lean
+++ b/src/Lean/Meta/Tactic/Simp/LoopProtection.lean
@@ -37,7 +37,7 @@ def mkLoopWarningMsg (thm : SimpTheorem) : SimpM MessageData := do
   msg := msg ++ m!"Possibly looping simp theorem: `{← ppOrigin thm.origin}`"
 
   let mut others := #[]
-  for other in (← get).usedTheorems.toArray do
+  for (other, _) in (← get).usedTheorems.map do
     if other != thm.origin  then
       others := others.push other
   unless others.isEmpty do

--- a/src/Lean/Meta/Tactic/Simp/Rewrite.lean
+++ b/src/Lean/Meta/Tactic/Simp/Rewrite.lean
@@ -149,7 +149,7 @@ private def tryTheoremCore (lhs : Expr) (xs : Array Expr) (bis : Array BinderInf
           return none
       trace[Meta.Tactic.simp.rewrite] "{← ppSimpTheorem thm}:{indentExpr e}\n==>{indentExpr rhs}"
       let rhs ← if type.hasBinderNameHint then rhs.resolveBinderNameHint else pure rhs
-      recordSimpTheorem thm.origin
+      recordSimpTheorem thm.origin thm
       return some { expr := rhs, proof? }
     else
       unless lhs.isMVar do

--- a/src/Lean/Meta/Tactic/Simp/Simproc.lean
+++ b/src/Lean/Meta/Tactic/Simp/Simproc.lean
@@ -229,15 +229,15 @@ def simprocCore (post : Bool) (s : SimprocTree) (erased : PHashSet Name) (e : Ex
         match s with
         | .visit r =>
           trace[Debug.Meta.Tactic.simp] "simproc result {e} => {r.expr}"
-          recordSimpTheorem (.decl simprocEntry.declName post)
+          recordSimpTheorem (.decl simprocEntry.declName post) default
           return .visit (← mkEqTransOptProofResult proof? cache r)
         | .done r =>
           trace[Debug.Meta.Tactic.simp] "simproc result {e} => {r.expr}"
-          recordSimpTheorem (.decl simprocEntry.declName post)
+          recordSimpTheorem (.decl simprocEntry.declName post) default
           return .done (← mkEqTransOptProofResult proof? cache r)
         | .continue (some r) =>
           trace[Debug.Meta.Tactic.simp] "simproc result {e} => {r.expr}"
-          recordSimpTheorem (.decl simprocEntry.declName post)
+          recordSimpTheorem (.decl simprocEntry.declName post) default
           e := r.expr
           proof? ← mkEqTrans? proof? r.proof?
           cache := cache && r.cache
@@ -264,15 +264,15 @@ def dsimprocCore (post : Bool) (s : SimprocTree) (erased : PHashSet Name) (e : E
         match s with
         | .visit eNew =>
           trace[Debug.Meta.Tactic.simp] "simproc result {e} => {eNew}"
-          recordSimpTheorem (.decl simprocEntry.declName post)
+          recordSimpTheorem (.decl simprocEntry.declName post) default
           return .visit eNew
         | .done eNew =>
           trace[Debug.Meta.Tactic.simp] "simproc result {e} => {eNew}"
-          recordSimpTheorem (.decl simprocEntry.declName post)
+          recordSimpTheorem (.decl simprocEntry.declName post) default
           return .done eNew
         | .continue (some eNew) =>
           trace[Debug.Meta.Tactic.simp] "simproc result {e} => {eNew}"
-          recordSimpTheorem (.decl simprocEntry.declName post)
+          recordSimpTheorem (.decl simprocEntry.declName post) default
           e := eNew
           found := true
         | .continue none =>

--- a/src/Lean/Meta/Tactic/Simp/Types.lean
+++ b/src/Lean/Meta/Tactic/Simp/Types.lean
@@ -200,23 +200,29 @@ def Context.isDeclToUnfold (ctx : Context) (declName : Name) : Bool :=
   ctx.simpTheorems.isDeclToUnfold declName
 
 structure UsedSimps where
-  -- We should use `PHashMap` because we backtrack the contents of `UsedSimps`
-  -- The natural number tracks the insertion order
-  map  : PHashMap Origin Nat := {}
+  /-
+  We should use `PHashMap` because we backtrack the contents of `UsedSimps`
+  The natural number tracks the insertion order.
+  We also track the theorem in order to output it in the correct order.
+  For `simp`s without associated `SimpTheorem`s (e.g. local vars and simprocs), this value is
+  instead `(default : SimpTheorem)` which in particular has `keys := #[]`.
+
+  Note: The theorem may be ambiguous (e.g. for equation lemmas) but in that case they should all
+  share the same priority and should be closely together in the discrimination tree so it shouldn't
+  matter.
+  -/
+  map  : PHashMap Origin (Nat × SimpTheorem) := {}
   size : Nat := 0
   deriving Inhabited
 
 def UsedSimps.contains (s : UsedSimps) (thmId : Origin) : Bool :=
   s.map.contains thmId
 
-def UsedSimps.insert (s : UsedSimps) (thmId : Origin) : UsedSimps :=
-  if s.map.contains thmId then
+def UsedSimps.insert (s : UsedSimps) (origin : Origin) (thm : SimpTheorem) : UsedSimps :=
+  if s.map.contains origin then
     s
   else match s with
-    | { map, size } => { map := map.insert thmId size, size := size + 1 }
-
-def UsedSimps.toArray (s : UsedSimps) : Array Origin :=
-  s.map.toArray.qsort (·.2 < ·.2) |>.map (·.1)
+    | { map, size } => { map := map.insert origin (size, thm), size := size + 1 }
 
 structure Diagnostics where
   /-- Number of times each simp theorem has been used/applied. -/
@@ -489,7 +495,7 @@ def recordTriedSimpTheorem (thmId : Origin) : SimpM Unit := do
     let cNew := if let some c := s.triedThmCounter.find? thmId then c + 1 else 1
     { s with triedThmCounter := s.triedThmCounter.insert thmId cNew }
 
-def recordSimpTheorem (thmId : Origin) : SimpM Unit := do
+def recordSimpTheorem (thmId : Origin) (thm : SimpTheorem) : SimpM Unit := do
   modifyDiag fun s =>
     let cNew := if let some c := s.usedThmCounter.find? thmId then c + 1 else 1
     { s with usedThmCounter := s.usedThmCounter.insert thmId cNew }
@@ -508,7 +514,7 @@ def recordSimpTheorem (thmId : Origin) : SimpM Unit := do
       else
         pure thmId
     | _ => pure thmId
-  modify fun s => { s with usedTheorems := s.usedTheorems.insert thmId }
+  modify fun s => { s with usedTheorems := s.usedTheorems.insert thmId thm }
 
 def recordCongrTheorem (declName : Name) : SimpM Unit := do
   modifyDiag fun s =>
@@ -835,7 +841,7 @@ This also means that `usedZetaDelta` set might be reporting fvars in `zetaDeltaS
 private def updateUsedSimpsWithZetaDeltaCore (s : UsedSimps) (zetaDeltaSet : FVarIdSet) (usedZetaDelta : FVarIdSet) : UsedSimps :=
   zetaDeltaSet.fold (init := s) fun s fvarId =>
     if usedZetaDelta.contains fvarId then
-      s.insert <| .fvar fvarId
+      s.insert (.fvar fvarId) default
     else
       s
 

--- a/src/Lean/Meta/Tactic/Simp/UsedSimps.lean
+++ b/src/Lean/Meta/Tactic/Simp/UsedSimps.lean
@@ -47,16 +47,19 @@ private def insertLookupEntry [BEq α] [Inhabited α] (arr : Array Origin)
       (refs : Array (Nat × Nat)) (entries : Array α)
       (idx : Nat) (entry : α) (prio : α → Nat) :
     Array Origin × Array (Nat × Nat) :=
-  go arr (refs.push (idx, entries.idxOf entry)) (entries.idxOf entry) refs.size
+  let sz := refs.size
+  let eidx := entries.idxOf entry
+  let refs := refs.push (idx, eidx)
+  go arr refs eidx sz
 where
   -- insertion sort
   go (arr : Array Origin) (refs : Array (Nat × Nat)) (eidx : Nat) : Nat → Array Origin × Array (Nat × Nat)
   | 0 => (arr, refs)
   | k + 1 =>
     let (idx', eidx') := refs[k]!
-    let entry' := entries[eidx']!
+    let entry' := entries.getD eidx' default
     -- need to swap?
-    if prio entry' < prio entry ∨ (prio entry = prio entry' ∧ eidx < eidx') then
+    if (prio entry' < prio entry || (prio entry = prio entry' && eidx < eidx')) ^^ idx < idx' then
       go (arr.swapIfInBounds idx idx') (refs.swapIfInBounds k (k + 1)) eidx k
     else
       (arr, refs)

--- a/src/Lean/Meta/Tactic/Simp/UsedSimps.lean
+++ b/src/Lean/Meta/Tactic/Simp/UsedSimps.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2025 Robin Arnez. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Arnez
+-/
+prelude
+import Lean.Meta.Tactic.Simp.Types
+import Lean.Meta.Tactic.Simp.Simproc
+
+namespace Lean.Meta.Simp.UsedSimps
+
+/--
+Returns all entries with the exact provided key sequence, or `#[]` if the key sequence could not be
+found in the tree.
+-/
+private def traverseTree (keys : Array DiscrTree.Key) (d : DiscrTree α) : Array α :=
+  match d.root.find? keys[0]! with
+  | none => #[]
+  | some t => go t 1
+where
+  go (t : DiscrTree.Trie α) (i : Nat) : Array α :=
+    if _ : i < keys.size then
+      let next := t.2
+      match next.binSearch (keys[i], default) (fun a b => a.1 < b.1) with
+      | none => #[]
+      | some t => go t.2 (i + 1)
+    else
+      t.1
+
+/--
+List of references into the `result` array of theorems with equal keys with optional cached
+entries and entry indices.
+-/
+private inductive Lookup (α : Type) where
+  /-- Single entry, no duplicates -/
+  | simple (idx : Nat) (entry : α)
+  /--
+  `idxs` = array of `(index into result, index into entries)`.
+  Sorted by priority (if applicable) and index into entries.
+  -/
+  | collision (idxs : Array (Nat × Nat)) (entries : Array α)
+
+/--
+Inserts a reference entry and swaps it into the right place while adjust the result array order.
+-/
+private def insertLookupEntry [BEq α] [Inhabited α] (arr : Array Origin)
+      (refs : Array (Nat × Nat)) (entries : Array α)
+      (idx : Nat) (entry : α) (prio : α → Nat) :
+    Array Origin × Array (Nat × Nat) :=
+  go arr (refs.push (idx, entries.idxOf entry)) (entries.idxOf entry) refs.size
+where
+  -- insertion sort
+  go (arr : Array Origin) (refs : Array (Nat × Nat)) (eidx : Nat) : Nat → Array Origin × Array (Nat × Nat)
+  | 0 => (arr, refs)
+  | k + 1 =>
+    let (idx', eidx') := refs[k]!
+    let entry' := entries[eidx']!
+    -- need to swap?
+    if prio entry' < prio entry ∨ (prio entry = prio entry' ∧ eidx < eidx') then
+      go (arr.swapIfInBounds idx idx') (refs.swapIfInBounds k (k + 1)) eidx k
+    else
+      (arr, refs)
+
+/--
+Insert the reference `idx` into the lookup with the given keys and adjust the result array order.
+Entries may be accessed using `findAll` and priorities may be calculated using `prio`.
+-/
+private def mergeLookup [BEq α] [Inhabited α] (idx : Nat) (entry : α)
+    (keys : Array DiscrTree.Key) (prio : α → Nat) (findAll : Unit → Array α)
+    (arr : Array Origin) (map : Std.HashMap (Array DiscrTree.Key) (Lookup α)) :
+    Array Origin × Std.HashMap (Array DiscrTree.Key) (Lookup α) :=
+  let result := map[keys]?
+  match result with
+  | none => (arr, map.insert keys (.simple idx entry))
+  | some (.simple idx' e) =>
+    let entries := findAll ()
+    let (arr, refs) := insertLookupEntry arr #[(idx', entries.idxOf e)] entries idx entry prio
+    (arr, map.insert keys (.collision refs entries))
+  | some (.collision idxs entries) =>
+    let map := map.erase keys
+    let (arr, refs) := insertLookupEntry arr idxs entries idx entry prio
+    (arr, map.insert keys (.collision refs entries))
+
+/--
+Returns all used simplification theorems in the correct order to allow roundtripping.
+
+Note: The entries may still be in such an order that the resulting `simp only` differs in behavior
+from `simp`. This however should only occur when custom simp sets are involved.
+-/
+def getEntries (s : UsedSimps) (thms : SimpTheoremsArray) (simprocs : SimprocsArray := #[]) :
+    CoreM (Array Origin) := do
+  let mut result : Array Origin := Array.replicate s.size default
+  let mut pre : Std.HashMap (Array SimpTheoremKey) (Lookup SimpTheorem) := ∅
+  let mut post : Std.HashMap (Array SimpTheoremKey) (Lookup SimpTheorem) := ∅
+  let mut preSimprocs : Std.HashMap (Array SimpTheoremKey) (Lookup Name) := ∅
+  let mut postSimprocs : Std.HashMap (Array SimpTheoremKey) (Lookup Name) := ∅
+  for (origin, i, thm) in s.map do
+    result := result.set! i origin
+    if thm.keys.isEmpty then
+      let .decl nm isPost false := origin | continue
+      let some keys ← getSimprocDeclKeys? nm | continue
+      if isPost then
+        let (result', post') := mergeLookup i nm keys (fun _ => 0)
+          (fun _ => simprocs.flatMap (fun a => (traverseTree keys a.post).map (·.declName)))
+          result postSimprocs
+        result := result'; postSimprocs := post'
+      else
+        let (result', pre') := mergeLookup i nm keys (fun _ => 0)
+          (fun _ => simprocs.flatMap (fun a => (traverseTree keys a.pre).map (·.declName)))
+          result postSimprocs
+        result := result'; preSimprocs := pre'
+    else if thm.post then
+      let (result', post') := mergeLookup i thm thm.keys (·.priority)
+        (fun _ => thms.flatMap (fun a => traverseTree thm.keys a.post)) result post
+      result := result'; post := post'
+    else
+      let (result', pre') := mergeLookup i thm thm.keys (·.priority)
+        (fun _ => thms.flatMap (fun a => traverseTree thm.keys a.pre)) result pre
+      result := result'; pre := pre'
+  return result
+
+end Lean.Meta.Simp.UsedSimps

--- a/tests/lean/run/simpLoopProtection.lean
+++ b/tests/lean/run/simpLoopProtection.lean
@@ -285,7 +285,7 @@ example : c > 0 := by simp only [c, ac]
 /--
 warning: Possibly looping simp theorem: `dc`
 
-Note: Possibly caused by: `c` and `ac`
+Note: Possibly caused by: `ac` and `c`
 
 Hint: You can disable a simp theorem from the default simp set by passing `- theoremName` to `simp`.
 ---

--- a/tests/lean/run/simpTraceOrder.lean
+++ b/tests/lean/run/simpTraceOrder.lean
@@ -1,0 +1,92 @@
+/-!
+# `simp?` output order for roundtripping
+
+This test checks that `simp?` roundtrips when expected to (as fixed in #9117).
+-/
+
+/-!
+Collision of `not_imp` and `Classical.not_forall` (lemmas with different priority).
+(discr tree keys: `Not (∀ _)`)
+-/
+
+/--
+info: Try this: simp only [not_imp, Classical.not_forall]
+---
+error: unsolved goals
+⊢ ∃ x, x ≤ 1 ∧ ¬x = 1
+-/
+#guard_msgs in
+example : ¬∀ a : Nat, a ≤ 1 → a = 1 := by
+  simp?
+
+/--
+error: unsolved goals
+⊢ ∃ x, x ≤ 1 ∧ ¬x = 1
+-/
+#guard_msgs in
+example : ¬∀ a : Nat, a ≤ 1 → a = 1 := by
+  simp only [not_imp, Classical.not_forall]
+
+/-!
+Collision of multiple lemmas with the same priority: output in the order of being added to the simp
+set: `exists_and_left`, `exists_eq_right_right`, `exists_prop`.
+(discr tree keys: `Exists _ <other>`)
+-/
+
+/--
+info: Try this: simp only [exists_and_left, exists_eq_right_right, exists_prop]
+---
+error: unsolved goals
+x : Nat
+⊢ 1 < x ∧ 0 < x
+-/
+#guard_msgs in
+example (x : Nat) : ∃ (a : Nat) (_ : 0 < a) (_ : 1 < a), a = x := by
+  simp?
+
+/--
+error: unsolved goals
+x : Nat
+⊢ 1 < x ∧ 0 < x
+-/
+#guard_msgs in
+example (x : Nat) : ∃ (a : Nat) (_ : 0 < a) (_ : 1 < a), a = x := by
+  simp only [exists_and_left, exists_eq_right_right, exists_prop]
+
+/-!
+`simp` **does not** guarantee roundtripping when custom simp sets are involved.
+
+Explanation:
+- Custom simp sets are always tried after normal simp lemmas
+- Generalized lemmas are tried first
+- `Bool.and_eq_decide` here is more general, so should be tried first;
+  but it is in a custom simp set, so `eq_abc` takes priority
+- Without custom simp sets, `Bool.and_eq_decide` will be tried first though
+  and `eq_abc` will never get used
+-/
+
+def abc (x y : Bool) := x && !y
+
+theorem eq_abc (x y : Bool) : (x && !y) = abc x y := by
+  rfl
+
+/--
+info: Try this: simp only [eq_abc, Bool.and_eq_decide]
+---
+error: unsolved goals
+x y : Bool
+⊢ abc x y = decide (x = true ∧ y = true)
+-/
+#guard_msgs in
+example (x y : Bool) : (x && !y) = (x && y) := by
+  simp? only [bool_to_prop, eq_abc]
+
+set_option linter.unusedSimpArgs false in
+/--
+error: unsolved goals
+x y : Bool
+⊢ decide (x = true ∧ (!y) = true) = decide (x = true ∧ y = true)
+-/
+#guard_msgs in
+example (x y : Bool) : (x && !y) = (x && y) := by
+  simp only [eq_abc, Bool.and_eq_decide]


### PR DESCRIPTION
This PR fixes the output order of `simp?` and similar tactics to roundtrip more consistently.

**Breaking change:** many functions related to generating `simp only` calls (e.g. `mkSimpCallStx`) now require a `Simp.Context` and a `Simp.SimprocsArray` in order to reorder the lemmas correctly

Closes #4615
