### PR TITLE
chore: CI: run stage0 update on faster runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  labels:
+    - nscloud-ubuntu-22.04-amd64-4x16
+    - nscloud-ubuntu-22.04-amd64-8x16
+    - nscloud-macos-sonoma-arm64-6x14

--- a/.github/workflows/update-stage0.yml
+++ b/.github/workflows/update-stage0.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   update-stage0:
-    runs-on: ubuntu-latest
+    runs-on: nscloud-ubuntu-22.04-amd64-8x16
     steps:
     # This action should push to an otherwise protected branch, so it
     # uses a deploy key with write permissions, as suggested at


### PR DESCRIPTION
To avoid it losing races against the merge queue.
