### PR TITLE
perf: remove `grind` blockers

### DIFF
--- a/src/Lean/Meta/Match/MatchEqsExt.lean
+++ b/src/Lean/Meta/Match/MatchEqsExt.lean
@@ -7,6 +7,7 @@ module
 
 prelude
 public import Lean.Meta.Basic
+import Lean.Meta.Eqns
 
 public section
 
@@ -49,6 +50,10 @@ opaque getEquationsFor (matchDeclName : Name) : MetaM MatchEqns
 Returns `true` if `declName` is the name of a `match` equational theorem.
 -/
 def isMatchEqnTheorem (env : Environment) (declName : Name) : Bool := Id.run do
-  matchEqnsExt.findStateAsync env declName |>.eqns.contains declName
+  -- avoid blocking on async decls whose names look nothing like matchers
+  let .str _ s := declName.eraseMacroScopes | return false
+  if !isEqnLikeSuffix s then
+    return false
+  (matchEqnsExt.findStateAsync env declName).eqns.contains declName
 
 end Lean.Meta.Match

--- a/src/Lean/Meta/Match/MatcherInfo.lean
+++ b/src/Lean/Meta/Match/MatcherInfo.lean
@@ -94,7 +94,10 @@ def addMatcherInfo (env : Environment) (matcherName : Name) (info : MatcherInfo)
   assert! env.asyncMayContain matcherName
   extension.addEntry env { name := matcherName, info := info }
 
-def getMatcherInfo? (env : Environment) (declName : Name) : Option MatcherInfo :=
+def getMatcherInfo? (env : Environment) (declName : Name) : Option MatcherInfo := do
+  -- avoid blocking on async decls whose names look nothing like matchers
+  let .str _ s := declName.eraseMacroScopes | none
+  guard <| s.startsWith "match_"
   (extension.findStateAsync env declName).map.find? declName
 
 end Extension

--- a/src/Lean/Meta/Tactic/Grind/Cases.lean
+++ b/src/Lean/Meta/Tactic/Grind/Cases.lean
@@ -75,8 +75,8 @@ def isSplit (declName : Name) : CoreM Bool := do
   return (← getCasesTypes).isSplit declName
 
 partial def isCasesAttrCandidate? (declName : Name) (eager : Bool) : CoreM (Option Name) := do
-  match (← getConstInfo declName) with
-  | .inductInfo info => if !info.isRec || !eager then return some declName else return none
+  match (← isInductive? declName) with
+  | some info => if !info.isRec || !eager then return some declName else return none
   | _ => return none
 
 def isCasesAttrCandidate (declName : Name) (eager : Bool) : CoreM Bool := do

--- a/src/Lean/Meta/Tactic/Grind/EMatchTheorem.lean
+++ b/src/Lean/Meta/Tactic/Grind/EMatchTheorem.lean
@@ -465,7 +465,7 @@ def EMatchTheorems.find (s : EMatchTheorems) (origin : Origin) : List EMatchTheo
 def EMatchTheorem.getProofWithFreshMVarLevels (thm : EMatchTheorem) : MetaM Expr := do
   if thm.proof.isConst && thm.levelParams.isEmpty then
     let declName := thm.proof.constName!
-    let info ← getConstInfo declName
+    let info ← getConstVal declName
     if info.levelParams.isEmpty then
       return thm.proof
     else
@@ -881,7 +881,7 @@ def mkEMatchTheoremCore (origin : Origin) (levelParams : Array Name) (numParams 
   }
 
 private def getProofFor (declName : Name) : MetaM Expr := do
-  let info ← getConstInfo declName
+  let info ← getConstVal declName
   -- For theorems, `isProp` has already been checked at declaration time
   unless wasOriginallyTheorem (← getEnv) declName do
     unless (← isProp info.type) do

--- a/src/Lean/MonadEnv.lean
+++ b/src/Lean/MonadEnv.lean
@@ -98,6 +98,14 @@ def getAsyncConstInfo [Monad m] [MonadEnv m] [MonadError m] (constName : Name) (
   | some val => pure val
   | none     => throwUnknownConstant constName
 
+def isInductive? [Monad m] [MonadEnv m] (declName : Name) : m (Option InductiveVal) := do
+  match (← getEnv).findAsync? declName with
+  | some info@{ kind := .induct, .. } =>
+    match info.toConstantInfo with
+    | .inductInfo val => pure (some val)
+    | _ => unreachable!
+  | _ => pure none
+
 def mkConstWithLevelParams [Monad m] [MonadEnv m] [MonadError m] (constName : Name) : m Expr := do
   let info ← getConstVal constName
   return mkConst constName (info.levelParams.map mkLevelParam)


### PR DESCRIPTION
This PR removes all blocking waits in `grind_bitvec2.lean` that can be avoided by more fine-grained requests.