### PR TITLE
perf: use IR type info to decide whether to insert RC ops

### DIFF
--- a/src/Lean/Compiler/IR/Basic.lean
+++ b/src/Lean/Compiler/IR/Basic.lean
@@ -100,6 +100,10 @@ def isObj : IRType → Bool
   | tobject => true
   | _       => false
 
+def isPossibleRef : IRType → Bool
+  | object | tobject => true
+  | _ => false
+
 def isErased : IRType → Bool
   | erased => true
   | _ => false

--- a/tests/lean/sint_basic.lean.expected.out
+++ b/tests/lean/sint_basic.lean.expected.out
@@ -77,7 +77,6 @@ true
       ret x_1
     def myId8._boxed (x_1 : tagged) : tagged :=
       let x_2 : u8 := unbox x_1;
-      dec x_1;
       let x_3 : u8 := myId8 x_2;
       let x_4 : tobj := box x_3;
       ret x_4
@@ -160,7 +159,6 @@ true
       ret x_1
     def myId16._boxed (x_1 : tagged) : tagged :=
       let x_2 : u16 := unbox x_1;
-      dec x_1;
       let x_3 : u16 := myId16 x_2;
       let x_4 : tobj := box x_3;
       ret x_4


### PR DESCRIPTION
This is mostly a refactoring that replaces other analyses with type information, but due to the introduction of `tagged` it also has the side effect of eliminating ref counting ops entirely for types that always have a tagged scalar representation, e.g. `Unit`.