### PR TITLE
chore: ci: specify which Linux toolchain Grove should download

### DIFF
--- a/.github/workflows/grove.yml
+++ b/.github/workflows/grove.yml
@@ -64,7 +64,7 @@ jobs:
           commit: ${{ steps.workflow-info.outputs.sourceHeadSha }}
           workflow: ci.yml
           path: artifacts
-          name: build-Linux.*
+          name: "build-Linux release"
           name_is_regexp: true
 
       - name: Unpack toolchain


### PR DESCRIPTION
Since the old version of the workflow will run on PRs, we'll have to "test" this on master.