### PR TITLE
feat: allow short config syntax (`+opt` / `-opt`) for several parsers

### DIFF
--- a/src/Init/Ext.lean
+++ b/src/Init/Ext.lean
@@ -16,14 +16,24 @@ namespace Lean
 namespace Parser.Attr
 
 /--
-The flag `(iff := false)` prevents `ext` from generating an `ext_iff` lemma.
+The flag `iff` determines whether `ext` should generate an `ext_iff` lemma (default `true`).
 -/
-syntax extIff := atomic("(" &"iff" " := " &"false" ")")
+syntax extOptIff := &"iff"
 
 /--
-The flag `(flat := false)` causes `ext` to not flatten parents' fields when generating an `ext` lemma.
+The flag `flat` determines whether `ext` should flatten parents' fields when generating an `ext` lemma (default `true`).
 -/
-syntax extFlat := atomic("(" &"flat" " := " &"false" ")")
+syntax extOptFlat := &"flat"
+
+set_option linter.missingDocs false in
+syntax extOpts := extOptIff <|> extOptFlat
+
+set_option linter.missingDocs false in
+syntax extConfigItem := atomic((" +" <|> " -") noWs extOpts) <|> atomic(" (" extOpts " := " (&"true" <|> &"false") ")")
+
+set_option linter.missingDocs false in
+syntax extConfig := extConfigItem*
+
 
 /--
 Registers an extensionality theorem.
@@ -37,12 +47,12 @@ Registers an extensionality theorem.
 * An optional natural number argument, e.g. `@[ext 9000]`, specifies a priority for the `ext` lemma.
   Higher-priority lemmas are chosen first, and the default is `1000`.
 
-* The flag `@[ext (iff := false)]` disables generating an `ext_iff` theorem.
+* The flag `@[ext -iff]` disables generating an `ext_iff` theorem.
 
-* The flag `@[ext (flat := false)]` causes generated structure extensionality theorems to show inherited fields based on their representation,
+* The flag `@[ext -flat]` causes generated structure extensionality theorems to show inherited fields based on their representation,
   rather than flattening the parents' fields into the lemma's equality hypotheses.
 -/
-syntax (name := ext) "ext" (ppSpace extIff)? (ppSpace extFlat)? (ppSpace prio)? : attr
+syntax (name := ext) "ext" extConfig (ppSpace prio)? : attr
 end Parser.Attr
 
 -- TODO: rename this namespace?

--- a/src/Init/Notation.lean
+++ b/src/Init/Notation.lean
@@ -689,11 +689,30 @@ This is the same as `#eval show MetaM Unit from do discard doSeq`.
 syntax (name := runMeta) "run_meta " doSeq : command
 
 /--
+The flag `proofs` determines whether proofs should be reduced (default `false`).
+-/
+syntax reduceOptProofs := &"proofs"
+
+/--
+The flag `types` determines whether types (including propositions) should be reduced (default `false`).
+-/
+syntax reduceOptTypes := &"types"
+
+set_option linter.missingDocs false in
+syntax reduceOpts := reduceOptProofs <|> reduceOptTypes
+
+set_option linter.missingDocs false in
+syntax reduceConfigItem := atomic((" +" <|> " -") noWs reduceOpts) <|> atomic(" (" reduceOpts " := " (&"true" <|> &"false") ")")
+
+set_option linter.missingDocs false in
+syntax reduceConfig := reduceConfigItem*
+
+/--
 `#reduce <expression>` reduces the expression `<expression>` to its normal form. This
 involves applying reduction rules until no further reduction is possible.
 
 By default, proofs and types within the expression are not reduced. Use modifiers
-`(proofs := true)`  and `(types := true)` to reduce them.
+`+proofs` and `+types` to reduce them.
 Recall that propositions are types in Lean.
 
 **Warning:** This can be a computationally expensive operation,
@@ -702,7 +721,7 @@ especially for complex expressions.
 Consider using `#eval <expression>` for simple evaluation/execution
 of expressions.
 -/
-syntax (name := reduceCmd) "#reduce " (atomic("(" &"proofs" " := " &"true" ")"))? (atomic("(" &"types" " := " &"true" ")"))? term : command
+syntax (name := reduceCmd) "#reduce" reduceConfig ppSpace term : command
 
 set_option linter.missingDocs false in
 syntax guardMsgsFilterAction := &"check" <|> &"drop" <|> &"pass"

--- a/src/Lean/Elab/Match.lean
+++ b/src/Lean/Elab/Match.lean
@@ -151,9 +151,13 @@ def expandMacrosInPatterns (matchAlts : Array MatchAltView) : MacroM (Array Matc
     let patterns ← matchAlt.patterns.mapM expandMacros
     pure { matchAlt with patterns := patterns }
 
+-- TODO: enable new variants after stage0 update
 private def getMatchGeneralizing? : Syntax → Option Bool
-  | `(match (generalizing := true)  $[$motive]? $_discrs,* with $_alts:matchAlt*) => some true
-  | `(match (generalizing := false) $[$motive]? $_discrs,* with $_alts:matchAlt*) => some false
+  | `(match $g:generalizingParam $[$motive]? $_discrs,* with $_alts:matchAlt*) =>
+    match g with
+    | `(generalizingParam| (generalizing := true)) => some true
+    | `(generalizingParam| (generalizing := false)) => some false
+    | _ => none
   | _ => none
 
 /-- Given the `stx` of a single match alternative, return a corresponding `MatchAltView`. -/

--- a/src/Lean/Parser/Term.lean
+++ b/src/Lean/Parser/Term.lean
@@ -422,9 +422,12 @@ def matchAlts (rhsParser : Parser := termParser) : Parser :=
 @[builtin_doc] def matchDiscr := leading_parser
   optional (atomic (binderIdent >> " : ")) >> termParser
 
+def posPrefix := leading_parser "+"
+def negPrefix := leading_parser "-"
 def trueVal  := leading_parser nonReservedSymbol "true"
 def falseVal := leading_parser nonReservedSymbol "false"
 def generalizingParam := leading_parser
+  atomic ((posPrefix <|> negPrefix) >> checkNoWsBefore >> "generalizing") <|>
   atomic ("(" >> nonReservedSymbol "generalizing") >> " := " >>
     (trueVal <|> falseVal)  >> ")" >> ppSpace
 
@@ -442,7 +445,7 @@ If used as `match h : e, ... with | p, ... => f | ...`, `h : e = p` is available
 within `f`.
 
 When not constructing a proof, `match` does not automatically substitute variables
-matched on in dependent variables' types. Use `match (generalizing := true) ...` to
+matched on in dependent variables' types. Use `match +generalizing ...` to
 enforce this.
 
 Syntax quotations can also be used in a pattern match.

--- a/src/Std/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Do/Triple/SpecLemmas.lean
@@ -9,6 +9,8 @@ prelude
 public import Std.Do.Triple.Basic
 public import Std.Do.WP
 
+set_option interpreter.prefer_native false -- bootstrapping workaround
+
 @[expose] public section
 
 /-!

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -11,7 +11,7 @@ options get_default_options() {
     opts = opts.update({"debug", "terminalTacticsAsSorry"}, false);
     // switch to `true` for ABI-breaking changes affecting meta code;
     // see also next option!
-    opts = opts.update({"interpreter", "prefer_native"}, false);
+    opts = opts.update({"interpreter", "prefer_native"}, true);
     // switch to `false` when enabling `prefer_native` should also affect use
     // of built-in parsers in quotations; this is usually the case, but setting
     // both to `true` may be necessary for handling non-builtin parsers with


### PR DESCRIPTION
This PR changes the parsers of `#reduce`, the `ext` attribute, and `match` to allow the use of the `+opt` and `-opt` syntax for configuration in a similar way to how they are handled in `let`. Additionally, `#reduce` and the `ext` attribute can now receive both options in any order (e.g. `@[ext -iff -flat]`, `@[ext -flat -iff]`, `@[ext -iff -flat +iff]`).
Examples of new syntax:
```lean-4
#reduce +types +proofs xyz
@[ext -flat -iff]
match -generalizing xyz ...
```