### PR TITLE
fix: behavior of `String.prev`

### DIFF
--- a/src/Init/Data/String/Basic.lean
+++ b/src/Init/Data/String/Basic.lean
@@ -220,22 +220,22 @@ If both the replacement character and the replaced character are 7-bit ASCII cha
 string is not shared, then it is updated in-place and not copied.
 
 Examples:
-* `abc.modify ⟨1⟩ Char.toUpper = "aBc"`
-* `abc.modify ⟨3⟩ Char.toUpper = "abc"`
+* `"abc".modify ⟨1⟩ Char.toUpper = "aBc"`
+* `"abc".modify ⟨3⟩ Char.toUpper = "abc"`
 -/
 def modify (s : String) (i : Pos) (f : Char → Char) : String :=
   s.set i <| f <| s.get i
 
 /--
-Returns the next position in a string after position `p`. The result is unspecified if `p` is not a
-valid position or if `p = s.endPos`.
+Returns the next position in a string after position `p`. If `p` is not a valid position or
+`p = s.endPos`, returns the position one byte after `p`.
 
 A run-time bounds check is performed to determine whether `p` is at the end of the string. If a
 bounds check has already been performed, use `String.next'` to avoid a repeated check.
 
-Some examples where the result is unspecified:
-* `"abc".next ⟨3⟩`, since `3 = "abc".endPos`
-* `"L∃∀N".next ⟨2⟩`, since `2` points into the middle of a multi-byte UTF-8 character
+Some examples of edge cases:
+* `"abc".next ⟨3⟩ = ⟨4⟩`, since `3 = "abc".endPos`
+* `"L∃∀N".next ⟨2⟩ = ⟨3⟩`, since `2` points into the middle of a multi-byte UTF-8 character
 
 Examples:
 * `"abc".get ("abc".next 0) = 'b'`
@@ -247,17 +247,18 @@ def next (s : @& String) (p : @& Pos) : Pos :=
   p + c
 
 def utf8PrevAux : List Char → Pos → Pos → Pos
-  | [],    _, _ => 0
+  | [],    _, p => ⟨p.byteIdx - 1⟩
   | c::cs, i, p =>
     let i' := i + c
-    if i' = p then i else utf8PrevAux cs i' p
+    if p ≤ i' then i else utf8PrevAux cs i' p
 
 /--
 Returns the position in a string before a specified position, `p`. If `p = ⟨0⟩`, returns `0`. If `p`
-is not a valid position, the result is unspecified.
+is out of bounds, returns the position one byte before `p`. Otherwise, if `p` occurs in the middle
+of a multi-byte character, returns the beginning position of that character.
 
-For example, `"L∃∀N".prev ⟨3⟩` is unspecified, since byte 3 occurs in the middle of the multi-byte
-character `'∃'`.
+For example, `"L∃∀N".prev ⟨3⟩` is `⟨1⟩`, since byte 3 occurs in the middle of the multi-byte
+character `'∃'` that starts at byte 1.
 
 Examples:
 * `"abc".get ("abc".endPos |> "abc".prev) = 'c'`
@@ -265,7 +266,7 @@ Examples:
 -/
 @[extern "lean_string_utf8_prev", expose]
 def prev : (@& String) → (@& Pos) → Pos
-  | ⟨s⟩, p => if p = 0 then 0 else utf8PrevAux s 0 p
+  | ⟨s⟩, p => utf8PrevAux s 0 p
 
 /--
 Returns the first character in `s`. If `s = ""`, returns `(default : Char)`.
@@ -339,7 +340,7 @@ Requires evidence, `h`, that `p` is within bounds. No run-time bounds check is p
 A typical pattern combines `String.next'` with a dependent `if`-expression to avoid the overhead of
 an additional bounds check. For example:
 ```
-def next? (s: String) (p : String.Pos) : Option Char :=
+def next? (s : String) (p : String.Pos) : Option Char :=
   if h : s.atEnd p then none else s.get (s.next' p h)
 ```
 
@@ -369,20 +370,17 @@ protected theorem Pos.ne_zero_of_lt : {a b : Pos} → a < b → b ≠ 0
 theorem lt_next (s : String) (i : Pos) : i.1 < (s.next i).1 :=
   Nat.add_lt_add_left (Char.utf8Size_pos _) _
 
-theorem utf8PrevAux_lt_of_pos : ∀ (cs : List Char) (i p : Pos), p ≠ 0 →
+theorem utf8PrevAux_lt_of_pos : ∀ (cs : List Char) (i p : Pos), i < p → p ≠ 0 →
     (utf8PrevAux cs i p).1 < p.1
-  | [], _, _, h =>
-    Nat.lt_of_le_of_lt (Nat.zero_le _)
-      (Nat.zero_lt_of_ne_zero (mt (congrArg Pos.mk) h))
-  | c::cs, i, p, h => by
+  | [], _, _, _, h => Nat.sub_one_lt (mt (congrArg Pos.mk) h)
+  | c::cs, i, p, h, h' => by
     simp [utf8PrevAux]
-    apply iteInduction (motive := (Pos.byteIdx · < _)) <;> intro h'
-    next => exact h' ▸ Nat.add_lt_add_left (Char.utf8Size_pos _) _
-    next => exact utf8PrevAux_lt_of_pos _ _ _ h
+    apply iteInduction (motive := (Pos.byteIdx · < _)) <;> intro h''
+    next => exact h
+    next => exact utf8PrevAux_lt_of_pos _ _ _ (Nat.lt_of_not_le h'') h'
 
-theorem prev_lt_of_pos (s : String) (i : Pos) (h : i ≠ 0) : (s.prev i).1 < i.1 := by
-  simp [prev, h]
-  exact utf8PrevAux_lt_of_pos _ _ _ h
+theorem prev_lt_of_pos (s : String) (i : Pos) (h : i ≠ 0) : (s.prev i).1 < i.1 :=
+  utf8PrevAux_lt_of_pos _ _ _ (Nat.zero_lt_of_ne_zero (mt (congrArg Pos.mk) h)) h
 
 def posOfAux (s : String) (c : Char) (stopPos : Pos) (pos : Pos) : Pos :=
   if h : pos < stopPos then
@@ -419,7 +417,7 @@ Returns the position of the last occurrence of a character, `c`, in a string `s`
 contain `c`, returns `none`.
 
 Examples:
-* `"abcabc".refPosOf 'a' = some ⟨3⟩`
+* `"abcabc".revPosOf 'a' = some ⟨3⟩`
 * `"abcabc".revPosOf 'z' = none`
 * `"L∃∀N".revPosOf '∀' = some ⟨4⟩`
 -/
@@ -2068,7 +2066,11 @@ end Pos
 
 theorem lt_next' (s : String) (p : Pos) : p < next s p := lt_next ..
 
-@[simp] theorem prev_zero (s : String) : prev s 0 = 0 := rfl
+@[simp] theorem prev_zero (s : String) : prev s 0 = 0 := by
+  cases s with | mk cs
+  cases cs
+  next => rfl
+  next => simp [prev, utf8PrevAux, Pos.le_iff]
 
 @[simp] theorem get'_eq (s : String) (p : Pos) (h) : get' s p h = get s p := rfl
 

--- a/src/Init/Data/String/Basic.lean
+++ b/src/Init/Data/String/Basic.lean
@@ -254,8 +254,8 @@ def utf8PrevAux : List Char → Pos → Pos → Pos
 
 /--
 Returns the position in a string before a specified position, `p`. If `p = ⟨0⟩`, returns `0`. If `p`
-is out of bounds, returns the position one byte before `p`. Otherwise, if `p` occurs in the middle
-of a multi-byte character, returns the beginning position of that character.
+is greater than `endPos`, returns the position one byte before `p`. Otherwise, if `p` occurs in the
+middle of a multi-byte character, returns the beginning position of that character.
 
 For example, `"L∃∀N".prev ⟨3⟩` is `⟨1⟩`, since byte 3 occurs in the middle of the multi-byte
 character `'∃'` that starts at byte 1.

--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -2301,7 +2301,8 @@ extern "C" LEAN_EXPORT obj_res lean_string_utf8_prev(b_obj_arg s, b_obj_arg i0) 
     }
     usize i  = lean_unbox(i0);
     usize sz = lean_string_size(s) - 1;
-    if (i == 0 || i > sz) return lean_box(0);
+    if (i == 0) return lean_box(0);
+    else if (i > sz) return lean_box(i - 1);
     i--;
     char const * str = lean_string_cstr(s);
     while (!is_utf8_first_byte(str[i])) {

--- a/tests/lean/run/string.lean
+++ b/tests/lean/run/string.lean
@@ -1,37 +1,123 @@
 /-!
-# Examples from documentation added in https://github.com/leanprover/lean4/pull/4166
+# Tests for `String` functions
 -/
 def abc : String := "abc"
 def lean : String := "L∃∀N"
 
-#guard abc.get (0 |> abc.next) = 'b'
-#guard lean.get (0 |> lean.next |> lean.next) = '∀'
-#guard abc.get (abc.endPos |> abc.prev) = 'c'
-#guard lean.get (lean.endPos |> lean.prev |> lean.prev |> lean.prev) = '∃'
-#guard "abc".front = 'a'
-#guard "".front = (default : Char)
-#guard "abc".back = 'c'
-#guard "".back = (default : Char)
-#guard (0 |> abc.next |> abc.next |> abc.atEnd) = false
-#guard (0 |> abc.next |> abc.next |> abc.next |> abc.next |> abc.atEnd) = true
-#guard (0 |> lean.next |> lean.next |> lean.next |> lean.next |> lean.atEnd) = true
+macro tk:"#test " t:term : command =>
+  `(#guard%$tk $t
+    example : $t := by decide)
+
+/-!
+Examples from documentation (added in https://github.com/leanprover/lean4/pull/4166)
+-/
+
+-- List.asString
+#test ['L', '∃', '∀', 'N'].asString = "L∃∀N"
+#test [].asString = ""
+#test ['a', 'a', 'a'].asString = "aaa"
+
+-- length
+#test "".length = 0
+#test "abc".length = 3
+#test "L∃∀N".length = 4
+
+-- push
+#test "abc".push 'd' = "abcd"
+#test "".push 'a' = "a"
+
+-- append
+#test "abc".append "def" = "abcdef"
+#test "abc" ++ "def" = "abcdef"
+#test "" ++ "" = ""
+
+-- toList
+#test "abc".toList = ['a', 'b', 'c']
+#test "".toList = []
+#test "\n".toList = ['\n']
+
+-- Pos.isValid
+#test String.Pos.isValid "abc" ⟨0⟩ = true
+#test String.Pos.isValid "abc" ⟨1⟩ = true
+#test String.Pos.isValid "abc" ⟨3⟩ = true
+#test String.Pos.isValid "abc" ⟨4⟩ = false
+#test String.Pos.isValid "𝒫(A)" ⟨0⟩ = true
+#test String.Pos.isValid "𝒫(A)" ⟨1⟩ = false
+#test String.Pos.isValid "𝒫(A)" ⟨2⟩ = false
+#test String.Pos.isValid "𝒫(A)" ⟨3⟩ = false
+#test String.Pos.isValid "𝒫(A)" ⟨4⟩ = true
+
+-- get
+#test "abc".get ⟨1⟩ = 'b'
+#test "abc".get ⟨3⟩ = (default : Char)
+#test "L∃∀N".get ⟨2⟩ = (default : Char)
+
+-- get?
+#test "abc".get? ⟨1⟩ = some 'b'
+#test "abc".get? ⟨3⟩ = none
+#test "L∃∀N".get? ⟨1⟩ = some '∃'
+#test "L∃∀N".get? ⟨2⟩ = none
+
+-- get!
+#test "abc".get! ⟨1⟩ = 'b'
+
+-- set
+#test "abc".set ⟨1⟩ 'B' = "aBc"
+#test "abc".set ⟨3⟩ 'D' = "abc"
+#test "L∃∀N".set ⟨4⟩ 'X' = "L∃XN"
+#test "L∃∀N".set ⟨2⟩ 'X' = "L∃∀N"
+
+-- modify
+#test abc.modify ⟨1⟩ Char.toUpper = "aBc"
+#test abc.modify ⟨3⟩ Char.toUpper = "abc"
+
+-- next
+#test abc.next ⟨3⟩ = ⟨4⟩
+#test "L∃∀N".next ⟨2⟩ = ⟨3⟩
+#test abc.get (0 |> abc.next) = 'b'
+#test lean.get (0 |> lean.next |> lean.next) = '∀'
+
+-- prev
+#test abc.get (abc.endPos |> abc.prev) = 'c'
+#test lean.get (lean.endPos |> lean.prev |> lean.prev |> lean.prev) = '∃'
+
+-- front
+#test "abc".front = 'a'
+#test "".front = (default : Char)
+
+-- back
+#test "abc".back = 'c'
+#test "".back = (default : Char)
+
+-- atEnd
+#test (0 |> abc.next |> abc.next |> abc.atEnd) = false
+#test (0 |> abc.next |> abc.next |> abc.next |> abc.next |> abc.atEnd) = true
+#test (0 |> lean.next |> lean.next |> lean.next |> lean.atEnd) = false
+#test (0 |> lean.next |> lean.next |> lean.next |> lean.next |> lean.atEnd) = true
+#test abc.atEnd ⟨4⟩ = true
+#test lean.atEnd ⟨7⟩ = false
+#test lean.atEnd ⟨8⟩ = true
 
 -- get'
-#guard "abc".get' 0 (by decide) = 'a'
-#guard let lean := "L∃∀N"; lean.get' (0 |> lean.next |> lean.next) (by decide) = '∀'
-def getInBounds? (s : String) (p: String.Pos) : Option Char :=
+def getInBounds? (s : String) (p : String.Pos) : Option Char :=
   if h : s.atEnd p then none else some (s.get' p h)
-#guard getInBounds? abc ⟨1⟩ = some 'b'
-#guard getInBounds? abc ⟨5⟩ = none
-#guard getInBounds? lean ⟨4⟩ = some '∀'
-#guard "L∃∀N".get' ⟨2⟩ (by decide) = (default : Char)
+
+#test "L∃∀N".get' ⟨2⟩ (by decide) = (default : Char)
+#test "abc".get' 0 (by decide) = 'a'
+#test let lean := "L∃∀N"; lean.get' (0 |> lean.next |> lean.next) (by decide) = '∀'
+
+#test getInBounds? abc ⟨1⟩ = some 'b'
+#test getInBounds? abc ⟨5⟩ = none
+#test getInBounds? lean ⟨4⟩ = some '∀'
 
 -- next'
-#guard let abc := "abc"; abc.get (abc.next' 0 (by decide)) = 'b'
-def next? (s: String) (p: String.Pos) : Option Char :=
+def next? (s : String) (p : String.Pos) : Option Char :=
   if h : s.atEnd p then none else s.get (s.next' p h)
-#guard next? abc ⟨1⟩ = some 'c'
-#guard next? abc ⟨5⟩ = none
+
+#test let abc := "abc"; abc.get (abc.next' 0 (by decide)) = 'b'
+
+#test next? abc ⟨1⟩ = some 'c'
+#test next? abc ⟨5⟩ = none
 
 -- posOf
 #guard "abba".posOf 'a' = ⟨0⟩
@@ -42,3 +128,22 @@ def next? (s: String) (p: String.Pos) : Option Char :=
 #guard "abba".revPosOf 'a' = some ⟨3⟩
 #guard "abba".revPosOf 'z' = none
 #guard "L∃∀N".revPosOf '∀' = some ⟨4⟩
+
+/-!
+Behavior of `String.prev` (`lean_string_utf8_prev`) in special cases (see issue #9439).
+-/
+
+#test "L∃∀N".prev ⟨0⟩ = ⟨0⟩
+#test "L∃∀N".prev ⟨1⟩ = ⟨0⟩
+#test "L∃∀N".prev ⟨2⟩ = ⟨1⟩
+#test "L∃∀N".prev ⟨3⟩ = ⟨1⟩
+#test "L∃∀N".prev ⟨4⟩ = ⟨1⟩
+#test "L∃∀N".prev ⟨5⟩ = ⟨4⟩
+#test "L∃∀N".prev ⟨6⟩ = ⟨4⟩
+#test "L∃∀N".prev ⟨7⟩ = ⟨4⟩
+#test "L∃∀N".prev ⟨8⟩ = ⟨7⟩ -- endPos
+#test "L∃∀N".prev ⟨9⟩ = ⟨8⟩
+#test "L∃∀N".prev ⟨100⟩ = ⟨99⟩ -- small value out of bounds
+#test "L∃∀N".prev ⟨2 ^ 128⟩ = ⟨2 ^ 128 - 1⟩ -- large non-scalar
+#test "L∃∀N".prev ⟨2 ^ 63⟩ = ⟨2 ^ 63 - 1⟩ -- scalar boundary (64-bit)
+#test "L∃∀N".prev ⟨2 ^ 31⟩ = ⟨2 ^ 31 - 1⟩ -- scalar boundary (32-bit)


### PR DESCRIPTION
This PR fixes the behavior of `String.prev`, aligning the runtime implementation with the reference implementation. In particular, the following statements hold now:
- `(s.prev p).byteIdx` is at least `p.byteIdx - 4` and at most `p.byteIdx - 1`
- `s.prev 0 = 0`
- `s.prev` is monotone

Closes #9439