### PR TITLE
fix: make `zero`/`succ` hoverable in `induction`/`cases`

### DIFF
--- a/tests/lean/interactive/hover.lean.expected.out
+++ b/tests/lean/interactive/hover.lean.expected.out
@@ -462,19 +462,18 @@
 {"textDocument": {"uri": "file:///hover.lean"},
  "position": {"line": 238, "character": 4}}
 {"range":
- {"start": {"line": 238, "character": 2}, "end": {"line": 238, "character": 8}},
+ {"start": {"line": 238, "character": 4}, "end": {"line": 238, "character": 8}},
  "contents":
  {"value":
-  "The left hand side of an induction arm, `| foo a b c` or `| @foo a b c`\nwhere `foo` is a constructor of the inductive type and `a b c` are the arguments\nto the constructor.\n",
+  "```lean\nNat.zero : ℕ\n```\n***\nZero, the smallest natural number.\n\nUsing `Nat.zero` explicitly should usually be avoided in favor of the literal `0`, which is the\n[simp normal form](REFERENCE/find/?domain=Verso.Genre.Manual.section&name=simp-normal-forms).\n\n***\n*import Init.Prelude*",
   "kind": "markdown"}}
 {"textDocument": {"uri": "file:///hover.lean"},
  "position": {"line": 241, "character": 4}}
 {"range":
- {"start": {"line": 241, "character": 2},
-  "end": {"line": 241, "character": 10}},
+ {"start": {"line": 241, "character": 4}, "end": {"line": 241, "character": 8}},
  "contents":
  {"value":
-  "The left hand side of an induction arm, `| foo a b c` or `| @foo a b c`\nwhere `foo` is a constructor of the inductive type and `a b c` are the arguments\nto the constructor.\n",
+  "```lean\nNat.succ (n : ℕ) : ℕ\n```\n***\nThe successor of a natural number `n`.\n\nUsing `Nat.succ n` should usually be avoided in favor of `n + 1`, which is the [simp normal\nform](REFERENCE/find/?domain=Verso.Genre.Manual.section&name=simp-normal-forms).\n\n***\n*import Init.Prelude*",
   "kind": "markdown"}}
 {"textDocument": {"uri": "file:///hover.lean"},
  "position": {"line": 241, "character": 9}}
@@ -496,10 +495,10 @@
 {"textDocument": {"uri": "file:///hover.lean"},
  "position": {"line": 249, "character": 4}}
 {"range":
- {"start": {"line": 249, "character": 2}, "end": {"line": 249, "character": 8}},
+ {"start": {"line": 249, "character": 4}, "end": {"line": 249, "character": 8}},
  "contents":
  {"value":
-  "The left hand side of an induction arm, `| foo a b c` or `| @foo a b c`\nwhere `foo` is a constructor of the inductive type and `a b c` are the arguments\nto the constructor.\n",
+  "```lean\nNat.zero : ℕ\n```\n***\nZero, the smallest natural number.\n\nUsing `Nat.zero` explicitly should usually be avoided in favor of the literal `0`, which is the\n[simp normal form](REFERENCE/find/?domain=Verso.Genre.Manual.section&name=simp-normal-forms).\n\n***\n*import Init.Prelude*",
   "kind": "markdown"}}
 {"textDocument": {"uri": "file:///hover.lean"},
  "position": {"line": 252, "character": 9}}


### PR DESCRIPTION
This PR restores the feature where in `induction`/`cases` for `Nat`, the `zero` and `succ` labels are hoverable. This was added in #1660, but broken in #3629 and #3655 when custom eliminators were added. In general, if a custom eliminator `T.elim` for an inductive type `T` has an alternative `foo`, and `T.foo` is a constant, then the `foo` label will have `T.foo` hover information.