### PR TITLE
feat: add devcontainer support for GitHub Codespaces and VS Code

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,53 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+
+# Install build dependencies as specified in doc/make/ubuntu.md
+# Plus additional developer tools for better experience
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git \
+        libgmp-dev \
+        libuv1-dev \
+        cmake \
+        ccache \
+        clang \
+        pkgconf \
+        build-essential \
+        ca-certificates \
+        curl \
+        python3 \
+        python3-pip \
+        gdb \
+        rr \
+        valgrind \
+        time \
+        bash-completion \
+        htop \
+        ripgrep \
+        fd-find \
+        && rm -rf /var/lib/apt/lists/*
+
+# Create vscode user if it doesn't exist
+RUN if ! id -u vscode > /dev/null 2>&1; then \
+        useradd -m -s /bin/bash vscode && \
+        echo "vscode ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers; \
+    fi
+
+# Switch to vscode user
+USER vscode
+
+# Set up workspace directory
+RUN sudo mkdir -p /workspace/lean4 && \
+    sudo chown -R vscode:vscode /workspace
+
+# Pre-create elan directory
+RUN mkdir -p /home/vscode/.elan
+
+# Create symlinks for tools with different names on Ubuntu
+RUN sudo ln -s /usr/bin/fdfind /usr/local/bin/fd && \
+    sudo ln -s /usr/bin/rg /usr/local/bin/rg
+
+# Set working directory
+WORKDIR /workspace/lean4
+
+# Keep container running
+CMD ["/bin/bash"]

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,36 @@
+# Lean 4 DevContainer
+
+This configuration provides a development environment for Lean 4 in GitHub Codespaces or VS Code Remote Containers.
+
+## Quick Start
+
+1. Open in GitHub Codespaces or VS Code with Remote Containers extension
+2. Wait for container build (one-time setup)
+3. Start developing - toolchains are pre-configured
+
+## Common Commands
+
+```bash
+# Build Lean 4
+make -C build/release -j$(nproc)
+
+# Run tests
+make -C build/release test
+
+# Run specific test
+cd tests/lean && ./test_single.sh test_file.lean
+```
+
+## Key Features
+
+- Automatic toolchain switching based on directory (`lean4-stage0` in src/, `lean4` in tests/)
+- Pre-configured build tasks (Ctrl+Shift+B)
+- Debugging support with gdb and rr
+- Persistent ccache for faster rebuilds
+
+## Documentation
+
+- [Development Guide](../doc/dev/index.md)
+- [Building Lean](../doc/make/index.md)
+- [Testing](../doc/dev/testing.md)
+- [Debugging](../doc/dev/debugging.md)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,59 @@
+{
+  "name": "Lean 4 Development",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "leanprover.lean4",
+        "ms-vscode.cmake-tools",
+        "llvm-vs-code-extensions.vscode-clangd",
+        "ms-vscode.cpptools",
+        "github.vscode-pull-request-github",
+        "streetsidesoftware.code-spell-checker"
+      ],
+      "settings": {
+        "files.insertFinalNewline": true,
+        "files.trimTrailingWhitespace": true,
+        "cmake.buildDirectory": "${workspaceFolder}/build/release",
+        "cmake.generator": "Unix Makefiles",
+        "[markdown]": {
+          "rewrap.wrappingColumn": 70
+        },
+        "[lean4]": {
+          "editor.rulers": [100]
+        },
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "/bin/bash",
+            "icon": "terminal-bash"
+          }
+        }
+      }
+    }
+  },
+  "onCreateCommand": ".devcontainer/setup.sh",
+  "postStartCommand": "mkdir -p .vscode && cp .devcontainer/tasks.json .vscode/tasks.json && cp .devcontainer/launch.json .vscode/launch.json",
+  "remoteUser": "vscode",
+  "remoteEnv": {
+    "PATH": "${containerEnv:PATH}:/home/vscode/.elan/bin"
+  },
+  "mounts": [
+    "source=${localWorkspaceFolderBasename}-ccache,target=/home/vscode/.ccache,type=volume"
+  ],
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/lean4,type=bind",
+  "workspaceFolder": "/workspace/lean4",
+  "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
+  "containerEnv": {
+    "CCACHE_DIR": "/home/vscode/.ccache",
+    "CCACHE_MAXSIZE": "5G",
+    "LEAN_BACKTRACE": "1"
+  }
+}

--- a/.devcontainer/launch.json
+++ b/.devcontainer/launch.json
@@ -1,0 +1,73 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Lean",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/build/release/stage1/bin/lean",
+      "args": ["${file}"],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "miDebuggerPath": "/usr/bin/gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        }
+      ]
+    },
+    {
+      "name": "Debug Test",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/build/release/stage1/bin/lean",
+      "args": ["${input:testFile}"],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}/tests/lean",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "miDebuggerPath": "/usr/bin/gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        }
+      ]
+    },
+    {
+      "name": "Debug Lean Server",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/build/release/stage1/bin/lean",
+      "args": ["--server"],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "miDebuggerPath": "/usr/bin/gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        }
+      ]
+    }
+  ],
+  "inputs": [
+    {
+      "id": "testFile",
+      "type": "promptString",
+      "description": "Enter the test file path relative to tests/lean/",
+      "default": "test.lean"
+    }
+  ]
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Setting up Lean 4 development environment..."
+
+# Set stack size limit to match test suite
+ulimit -s 8192
+
+# Install elan (Lean version manager) without default toolchain
+if ! command -v elan &> /dev/null; then
+    echo "Installing elan..."
+    curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- --default-toolchain none -y
+fi
+
+# Add elan to PATH for this session
+export PATH="$HOME/.elan/bin:$PATH"
+
+# Create directory structure for toolchain links
+echo "Creating build directory structure..."
+mkdir -p /workspace/lean4/build/release/stage0/bin
+mkdir -p /workspace/lean4/build/release/stage1/bin
+
+# Create placeholder lean executables for elan
+# These will be replaced by actual builds later
+echo '#!/bin/bash' > /workspace/lean4/build/release/stage0/bin/lean
+echo 'echo "Stage 0 lean placeholder - run make to build"' >> /workspace/lean4/build/release/stage0/bin/lean
+chmod +x /workspace/lean4/build/release/stage0/bin/lean
+
+echo '#!/bin/bash' > /workspace/lean4/build/release/stage1/bin/lean
+echo 'echo "Stage 1 lean placeholder - run make to build"' >> /workspace/lean4/build/release/stage1/bin/lean
+chmod +x /workspace/lean4/build/release/stage1/bin/lean
+
+# Link toolchains - these will be used based on lean-toolchain files in each directory
+echo "Setting up elan toolchains..."
+elan toolchain link lean4-stage0 /workspace/lean4/build/release/stage0 || true
+elan toolchain link lean4 /workspace/lean4/build/release/stage1 || true
+
+# Install both toolchains so they're available
+# This ensures seamless switching based on directory context
+echo "Installing linked toolchains..."
+elan toolchain install lean4-stage0 || true
+elan toolchain install lean4 || true
+
+# Set up ccache
+echo "Configuring ccache..."
+ccache --set-config=max_size=5G
+ccache --set-config=compiler_check=content
+ccache --set-config=hash_dir=false
+
+# Configure git to handle lean4 directory
+git config --global --add safe.directory /workspace/lean4
+
+# Initial cmake configuration
+echo "Running initial cmake configuration..."
+cd /workspace/lean4
+cmake --preset release || true
+
+echo "Development environment setup complete!"
+echo ""
+echo "To build Lean 4, run:"
+echo "  make -C build/release -j\$(nproc)"
+echo ""
+echo "To run tests, run:"
+echo "  make -C build/release test"

--- a/.devcontainer/tasks.json
+++ b/.devcontainer/tasks.json
@@ -1,0 +1,37 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "type": "shell",
+      "command": "make -C build/release -j$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)",
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "test",
+      "type": "shell",
+      "command": "NPROC=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4); CTEST_OUTPUT_ON_FAILURE=1 make -C build/release test -j$NPROC ARGS=\"-j$NPROC\"",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "clean",
+      "type": "shell",
+      "command": "make -C build/release clean",
+      "problemMatcher": []
+    },
+    {
+      "label": "cmake configure",
+      "type": "shell",
+      "command": "cmake --preset release",
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds devcontainer configuration to enable contributors to develop Lean 4 in GitHub Codespaces or VS Code remote containers. This lowers the barrier to entry for new contributors by providing a pre-configured development environment.

## Motivation

Currently, setting up a Lean 4 development environment requires:
- Installing multiple system dependencies (cmake, ccache, clang, etc.)
- Configuring elan and understanding toolchain management
- Understanding the stage0/stage1 build process
- Setting up VS Code with the correct workspace configuration

This creates friction for new contributors who want to submit PRs or explore the codebase.

## User Experience

With this change, contributors can just open the repo in Github Codespaces and see the infoview.

## Beneficiaries

This feature benefits:
- **New contributors**: Can start contributing without local setup
- Occasional contributors: Don't need to maintain a local Lean build environment
- Core developers: Can quickly test PRs in a clean environment
- **Documentation writers**: Can verify documentation changes without full local setup

## Maintainability

This change:
- Uses the same dependencies as documented in `doc/make/ubuntu.md`
- Follows existing patterns (similar to gitpod configuration)
- Self-contained in `.devcontainer/` directory


### Implementation Details:

- Pre-links `lean4` and `lean4-stage0` toolchains
- Sets `ulimit -s 8192` to match test suite requirements
- Enables `LEAN_BACKTRACE=1` for better debugging experience
- Includes `rr` debugger as documented in debugging guide

---

This is a draft PR to gather feedback before finalizing. I'm happy to make any adjustments based on reviewer suggestions.