### PR TITLE
chore: add code action test back in

### DIFF
--- a/tests/lean/interactive/dottedIdentNotation.lean
+++ b/tests/lean/interactive/dottedIdentNotation.lean
@@ -66,3 +66,17 @@ example : MyNat → MyNat := .succ
                               --^ textDocument/completion
 open MyLib in
 example : MyNat → MyNat := .succ' -- it successfully elaborates
+
+/-!
+The missing import code action works.
+-/
+--^ waitForILeans
+
+example : IO.FS.Stream := .chainLef
+                           --^ codeAction
+
+example : outParam IO.FS.Stream := .chainLef
+                                   --^ codeAction
+
+example : Nat → IO.FS.Stream := .chainLef
+                                --^ codeAction

--- a/tests/lean/interactive/dottedIdentNotation.lean.expected.out
+++ b/tests/lean/interactive/dottedIdentNotation.lean.expected.out
@@ -85,3 +85,45 @@
     "id": {"const": {"declName": "MyNat.succ"}},
     "cPos": 0}}],
  "isIncomplete": false}
+{"title": "Import IO.FS.Stream.chainLeft from Lean.Server.Utils",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument": {"version": 1, "uri": "file:///dottedIdentNotation.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 0, "character": 0},
+       "end": {"line": 0, "character": 0}},
+      "newText": "import Lean.Server.Utils\n"},
+     {"range":
+      {"start": {"line": 74, "character": 27},
+       "end": {"line": 74, "character": 35}},
+      "newText": "chainLeft"}]}]}}
+{"title": "Import IO.FS.Stream.chainLeft from Lean.Server.Utils",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument": {"version": 1, "uri": "file:///dottedIdentNotation.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 0, "character": 0},
+       "end": {"line": 0, "character": 0}},
+      "newText": "import Lean.Server.Utils\n"},
+     {"range":
+      {"start": {"line": 77, "character": 36},
+       "end": {"line": 77, "character": 44}},
+      "newText": "chainLeft"}]}]}}
+{"title": "Import IO.FS.Stream.chainLeft from Lean.Server.Utils",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument": {"version": 1, "uri": "file:///dottedIdentNotation.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 0, "character": 0},
+       "end": {"line": 0, "character": 0}},
+      "newText": "import Lean.Server.Utils\n"},
+     {"range":
+      {"start": {"line": 80, "character": 33},
+       "end": {"line": 80, "character": 41}},
+      "newText": "chainLeft"}]}]}}


### PR DESCRIPTION
This PR re-adds the code action test that was reverted in 5b18ea15457255a9db8a3c92fde7d55003f0cff9, now with more robustness.