### PR TITLE
fix: nonstandard `Nat` and `Int` instances

### DIFF
--- a/tests/lean/run/grind_arith_nonstd_insts.lean
+++ b/tests/lean/run/grind_arith_nonstd_insts.lean
@@ -1,0 +1,31 @@
+class Distrib (R : Type _) extends Mul R where
+
+namespace Nat
+
+instance instDistrib : Distrib Nat where
+  mul := (· * ·)
+
+theorem odd_iff.extracted_1_4 {n : Nat} (m : Nat)
+  (hm : n =
+    @HMul.hMul _ _ _ (@instHMul Nat instDistrib.toMul)
+      2 m + 1) :
+    n % 2 = 1 := by
+  grind
+
+end Nat
+
+namespace Int
+
+instance instDistrib : Distrib Int where
+  mul := (· * ·)
+
+theorem four_dvd_add_or_sub_of_odd.extracted_1_1 (m n : Int) :
+    4 ∣ ((@HMul.hMul Int Int Int (@instHMul Int Int.instDistrib.toMul)
+          2 m) + 1) +
+        ((@HMul.hMul Int Int Int (@instHMul Int Int.instDistrib.toMul)
+          2 n) + 1) ∨
+    4 ∣ ((@HMul.hMul Int Int Int (@instHMul Int Int.instDistrib.toMul)
+          2 m) + 1) -
+        ((@HMul.hMul Int Int Int (@instHMul Int Int.instDistrib.toMul)
+          2 n) + 1) := by
+  grind

--- a/tests/lean/run/grind_canon_insts.lean
+++ b/tests/lean/run/grind_canon_insts.lean
@@ -52,7 +52,18 @@ def fallback : Fallback := do
 
 set_option trace.Meta.debug true
 
-/-- trace: [Meta.debug] [a * (b * c), b * c, d * (b * c)] -/
+/--
+trace: [Meta.debug] [↑a * ↑b,
+     ↑a * (↑b * ↑c),
+     ↑b * ↑c,
+     ↑d * (↑b * ↑c),
+     -1 * (↑b * ↑c * ↑d),
+     ↑a * ↑b * ↑c,
+     ↑b * ↑c * ↑d,
+     a * (b * c),
+     b * c,
+     d * (b * c)]
+-/
 #guard_msgs (trace) in
 example (a b c d : Nat) : b * (a * c) = d * (b * c) → False := by
   rw [left_comm] -- Introduces a new (non-canonical) instance for `Mul Nat`


### PR DESCRIPTION
This PR adds normalizers for nonstandard arithmetic instances. The types `Nat` and `Int` have built-in support in `grind`, which uses the standard instances for these types and assumes they are the ones in use. However, users may define their own alternative instances that are definitionally equal to the standard ones. This PR normalizes such instances using simprocs. This situation actually occurs in Mathlib. Example:

```lean
class Distrib (R : Type _) extends Mul R where

namespace Nat

instance instDistrib : Distrib Nat where
  mul := (· * ·)

theorem odd_iff.extracted_1_4 {n : Nat} (m : Nat)
  (hm : n =
    @HMul.hMul _ _ _ (@instHMul Nat instDistrib.toMul)
      2 m + 1) :
    n % 2 = 1 := by
  grind

end Nat
```
