### PR TITLE
feat: enforce that public definitions have explicit types under the module system

### DIFF
--- a/src/Lean/Elab/BuiltinEvalCommand.lean
+++ b/src/Lean/Elab/BuiltinEvalCommand.lean
@@ -90,7 +90,7 @@ private def addAndCompileExprForEval (declName : Name) (value : Expr) (allowSorr
   -- such as "failed to infer definition type" can surface.
   let defView := mkDefViewOfDef { isUnsafe := true, visibility := .public }
     (← `(Parser.Command.definition|
-          def $(mkIdent <| `_root_ ++ declName) := $(← Term.exprToSyntax value)))
+          def $(mkIdent <| `_root_ ++ declName) : $(← Term.exprToSyntax (← inferType value)) := $(← Term.exprToSyntax value)))
   Term.elabMutualDef #[] { header := "" } #[defView]
   unless allowSorry do
     let axioms ← collectAxioms declName

--- a/src/Lean/Environment.lean
+++ b/src/Lean/Environment.lean
@@ -615,7 +615,7 @@ structure Environment where
   /--
   Indicates whether the environment is being used in an exported context, i.e. whether it should
   provide access to only the data to be imported by other modules participating in the module
-  system.
+  system. Always `false` outside of `module`s.
   -/
   isExporting : Bool := false
 deriving Nonempty

--- a/tests/pkg/module/Module/Basic.lean
+++ b/tests/pkg/module/Module/Basic.lean
@@ -5,7 +5,7 @@ public axiom testSorry : α
 /-! Module docstring -/
 
 /-- A definition (not exposed). -/
-public def f := 1
+public def f : Nat := 1
 
 /--
 info: def f : Nat :=
@@ -15,7 +15,7 @@ info: def f : Nat :=
 #print f
 
 /-- A definition (exposed) -/
-@[expose] public def fexp := 1
+@[expose] public def fexp : Nat := 1
 
 /--
 info: @[expose] def fexp : Nat :=
@@ -25,7 +25,7 @@ info: @[expose] def fexp : Nat :=
 #print fexp
 
 /-- An abbrev (auto-exposed). -/
-public abbrev fabbrev := 1
+public abbrev fabbrev : Nat := 1
 
 /--
 info: @[reducible, expose] def fabbrev : Nat :=
@@ -132,7 +132,7 @@ def priv := 2
 
 /-- error: Unknown identifier `priv` -/
 #guard_msgs in
-public abbrev h := priv
+public abbrev h : Nat := priv
 
 
 /-! Equational theorems tests. -/

--- a/tests/pkg/module/Module/ImportedAll.lean
+++ b/tests/pkg/module/Module/ImportedAll.lean
@@ -127,8 +127,8 @@ info: theorem f_exp_wfrec.induct_unfolding : ∀ (motive : Nat → Nat → Nat �
 
 /-! `import all` should allow access to private defs, privately. -/
 
-public def pub := priv
+public def pub : Nat := priv
 
 /-- error: Unknown identifier `priv` -/
 #guard_msgs in
-@[expose] public def pub' := priv
+@[expose] public def pub' : Nat := priv

--- a/tests/pkg/module/Module/PrivateImported.lean
+++ b/tests/pkg/module/Module/PrivateImported.lean
@@ -4,7 +4,7 @@ import Module.Basic
 
 /-! `private import` should allow only private access to imported decls. -/
 
-public def g := f
+public def g : Nat := f
 
 /--
 error: Unknown identifier `f`
@@ -21,4 +21,10 @@ error: Unknown identifier `f`
 Note: A private declaration `f` exists but is not accessible in the current context.
 -/
 #guard_msgs in
-@[expose] public def h : True := f
+@[expose] public def pexp : True := f
+
+/-! Private references should not be allowed to escape via the inferred type. -/
+
+/-- error: Type must be specified explicitly for public definition `inferredType` -/
+#guard_msgs in
+public def inferredType := Eq.refl f

--- a/tests/pkg/rebuild/test.sh
+++ b/tests/pkg/rebuild/test.sh
@@ -13,7 +13,7 @@ module
 
 set_option compiler.small 0
 
-public def hello := "world"
+public def hello : String := "world"
 
 public def testSpec (xs : List Nat) : List Nat := xs.map (fun x => x + 1)
 EOF


### PR DESCRIPTION
This PR adjusts the module system to error on a public definition without a syntactic type, clarifying the public interface of the module to human users and avoiding a potential leak of private references via inference.