### PR TITLE
doc: fix "the same as the same as" in the description of |>

### DIFF
--- a/src/Init/Notation.lean
+++ b/src/Init/Notation.lean
@@ -549,7 +549,7 @@ macro_rules
       `($f $a)
 
 /--
-Haskell-like pipe operator `|>`. `x |> f` means the same as the same as `f x`,
+Haskell-like pipe operator `|>`. `x |> f` means the same as `f x`,
 and it chains such that `x |> f |> g` is interpreted as `g (f x)`.
 -/
 syntax:min term " |> " term:min1 : term


### PR DESCRIPTION


This PR fixes the documentation of the pipe operator |>, which is currently (emphasis mine):

> Haskell-like pipe operator `|>`. `x |> f` means **the same as the same as** `f x`,
> and it chains such that `x |> f |> g` is interpreted as `g (f x)`.

