### PR TITLE
fix: `Inhabited` instance of `StdGen`

### DIFF
--- a/src/Init/Data/Random.lean
+++ b/src/Init/Data/Random.lean
@@ -36,7 +36,7 @@ structure StdGen where
   s1 : Nat
   s2 : Nat
 
-instance : Inhabited StdGen := ⟨{ s1 := 0, s2 := 0 }⟩
+instance : Inhabited StdGen := ⟨{ s1 := 1, s2 := 1 }⟩
 
 /-- The range of values returned by `StdGen` -/
 def stdRange := (1, 2147483562)

--- a/src/Init/Data/Random.lean
+++ b/src/Init/Data/Random.lean
@@ -36,7 +36,14 @@ structure StdGen where
   s1 : Nat
   s2 : Nat
 
-instance : Inhabited StdGen := ⟨{ s1 := 1, s2 := 1 }⟩
+/-- Returns a standard number generator. -/
+def mkStdGen (s : Nat := 0) : StdGen :=
+  let q  := s / 2147483562
+  let s1 := s % 2147483562
+  let s2 := q % 2147483398
+  ⟨s1 + 1, s2 + 1⟩
+
+instance : Inhabited StdGen := ⟨mkStdGen⟩
 
 /-- The range of values returned by `StdGen` -/
 def stdRange := (1, 2147483562)
@@ -76,13 +83,6 @@ instance : RandomGen StdGen := {
   next   := stdNext,
   split  := stdSplit
 }
-
-/-- Returns a standard number generator. -/
-def mkStdGen (s : Nat := 0) : StdGen :=
-  let q  := s / 2147483562
-  let s1 := s % 2147483562
-  let s2 := q % 2147483398
-  ⟨s1 + 1, s2 + 1⟩
 
 /--
 Auxiliary function for randomNatVal.


### PR DESCRIPTION
This PR corrects the `Inhabited` instance of `StdGen` to use a valid initial state for the pseudorandom number generator. Previously, the `default` generator had the property that `Prod.snd (stdNext default) = default`, so it would produce only constant sequences.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/inhabited.20instance.20for.20StdGen.20isn't.20very.20random/with/533247146)