### PR TITLE
perf: reduce redundant `inc`/`dec` using "implied borrows" from projections and liveness

### DIFF
--- a/src/Lean/Compiler/IR/RC.lean
+++ b/src/Lean/Compiler/IR/RC.lean
@@ -8,7 +8,6 @@ module
 prelude
 public import Lean.Runtime
 public import Lean.Compiler.IR.CompilerM
-public import Lean.Compiler.IR.LiveVars
 
 public section
 
@@ -19,18 +18,99 @@ This transformation is applied before lower level optimizations
 that introduce the instructions `release` and `set`
 -/
 
+structure VarProjInfo where
+  parent? : Option VarId
+  children : VarIdSet
+  deriving Inhabited
+
+abbrev VarProjMap := Std.HashMap VarId VarProjInfo
+
+namespace CollectProjInfo
+
+structure State where
+  varMap : VarProjMap := {}
+  borrowedParams : VarIdSet := {}
+
+abbrev M := StateM State
+
+private def visitParam (p : Param) : M Unit :=
+  modify fun s => { s with
+    varMap := s.varMap.insert p.x {
+      parent? := none
+      children := {}
+    }
+    borrowedParams :=
+      if p.borrow && p.ty.isPossibleRef then
+        s.borrowedParams.insert p.x
+      else s.borrowedParams
+  }
+
+private partial def visitFnBody (b : FnBody) : M Unit := do
+  match b with
+  | .vdecl x _ e b =>
+    match e with
+    | .proj _ parent =>
+      modify fun s => { s with
+        varMap := s.varMap.modify parent fun info =>
+          { info with children := info.children.insert x }
+      }
+      modify fun s => { s with
+        varMap := s.varMap.insert x {
+          parent? := some parent
+          children := {}
+        }
+      }
+    | .reset _ x =>
+      if let some (some parent) := (← get).varMap.get? x |>.map (·.parent?) then
+        modify fun s => { s with
+          varMap := s.varMap.modify parent fun info =>
+            { info with children := info.children.erase x }
+        }
+    | _ => pure ()
+    visitFnBody b
+  | .jdecl _ ps v b =>
+    ps.forM visitParam
+    visitFnBody v
+    visitFnBody b
+  | .case _ _ _ alts => alts.forM (visitFnBody ·.body)
+  | _ => if !b.isTerminal then visitFnBody b.body
+
+private partial def collectProjInfo (ps : Array Param) (b : FnBody)
+    : VarProjMap × VarIdSet := Id.run do
+  let ⟨_, { varMap, borrowedParams }⟩ := go |>.run { }
+  return ⟨varMap, borrowedParams⟩
+where go : M Unit := do
+  ps.forM visitParam
+  visitFnBody b
+
+end CollectProjInfo
+
 structure VarInfo where
   isPossibleRef : Bool
   isDefiniteRef: Bool
   persistent : Bool
-  inheritsBorrowFromParam : Bool
   deriving Inhabited
 
 abbrev VarMap := Std.TreeMap VarId VarInfo (fun x y => compare x.idx y.idx)
 
+structure LiveVars where
+  vars : VarIdSet
+  borrows : VarIdSet := {}
+  deriving Inhabited
+
+@[inline]
+def LiveVars.merge (liveVars1 liveVars2 : LiveVars) : LiveVars :=
+  let vars := liveVars1.vars.merge liveVars2.vars
+  let borrows := liveVars1.borrows.merge liveVars2.borrows
+  { vars, borrows }
+
+abbrev JPLiveVarMap := Std.TreeMap JoinPointId LiveVars (fun x y => compare x.idx y.idx)
+
 structure Context where
   env            : Environment
   decls          : Array Decl
+  borrowedParams : VarIdSet
+  varProjMap     : VarProjMap
   varMap         : VarMap := {}
   jpLiveVarMap   : JPLiveVarMap := {} -- map: join point => live variables
   localCtx       : LocalContext := {} -- we use it to store the join point declarations
@@ -44,12 +124,63 @@ def getVarInfo (ctx : Context) (x : VarId) : VarInfo :=
 def getJPParams (ctx : Context) (j : JoinPointId) : Array Param :=
   ctx.localCtx.getJPParams j |>.get!
 
-def getJPLiveVars (ctx : Context) (j : JoinPointId) : LiveVarSet :=
+@[specialize]
+private partial def addDescendants (ctx : Context) (x : VarId) (s : VarIdSet)
+    (shouldAdd : VarId → Bool := fun _ => true) : VarIdSet :=
+  if let some info := ctx.varProjMap.get? x then
+    info.children.foldl (init := s) fun s child =>
+      let s := if shouldAdd child then s.insert child else s
+      addDescendants ctx child s shouldAdd
+  else s
+
+private def mkRetLiveVars (ctx : Context) : LiveVars :=
+  let borrows := ctx.borrowedParams.foldl (init := {}) fun borrows x =>
+    addDescendants ctx x (borrows.insert x)
+  { vars := {}, borrows }
+
+def getJPLiveVars (ctx : Context) (j : JoinPointId) : LiveVars :=
   ctx.jpLiveVarMap.get! j
 
-def mustConsume (ctx : Context) (x : VarId) : Bool :=
-  let info := getVarInfo ctx x
-  info.isPossibleRef && !info.inheritsBorrowFromParam
+@[specialize]
+private def useVar (ctx : Context) (x : VarId) (liveVars : LiveVars)
+    (shouldBorrow : VarId → Bool := fun _ => true) : LiveVars := Id.run do
+  let ⟨contains, vars⟩ := liveVars.vars.containsThenInsert x
+  let borrows := if contains then
+      liveVars.borrows
+    else
+      addDescendants ctx x liveVars.borrows fun y =>
+        !liveVars.vars.contains y && shouldBorrow y
+  return { vars, borrows }
+
+@[inline]
+private def bindVar (x : VarId) (liveVars : LiveVars) : LiveVars :=
+  let vars := liveVars.vars.erase x
+  let borrows := liveVars.borrows.erase x
+  { vars, borrows }
+
+@[inline]
+private def useArg (ctx : Context) (args : Array Arg) (arg : Arg) (liveVars : LiveVars) : LiveVars :=
+  match arg with
+  | .var x => useVar ctx x liveVars fun y =>
+    args.all fun arg =>
+      match arg with
+      | .var z => y != z
+      | .erased => true
+  | .erased => liveVars
+
+private def useArgs (ctx : Context) (args : Array Arg) (liveVars : LiveVars) : LiveVars :=
+  args.foldl (init := liveVars) fun liveVars arg => useArg ctx args arg liveVars
+
+private def useExpr (ctx : Context) (e : Expr) (liveVars : LiveVars) : LiveVars :=
+  match e with
+  | .proj _ x | .uproj _ x | .sproj _ _ x | .box _ x | .unbox x | .reset _ x | .isShared x =>
+    useVar ctx x liveVars
+  | .ctor _ ys | .fap _ ys | .pap _ ys =>
+    useArgs ctx ys liveVars
+  | .ap x ys | .reuse x _ _ ys =>
+    let liveVars := useVar ctx x liveVars
+    useArgs ctx ys liveVars
+  | .lit _ => liveVars
 
 @[inline] def addInc (ctx : Context) (x : VarId) (b : FnBody) (n := 1) : FnBody :=
   let info := getVarInfo ctx x
@@ -70,9 +201,16 @@ private def updateRefUsingCtorInfo (ctx : Context) (x : VarId) (c : CtorInfo) : 
     | none => m
   }
 
-private def addDecForAlt (ctx : Context) (caseLiveVars altLiveVars : LiveVarSet) (b : FnBody) : FnBody :=
-  caseLiveVars.foldl (init := b) fun b x =>
-    if !altLiveVars.contains x && mustConsume ctx x then addDec ctx x b else b
+private def addDecForAlt (ctx : Context) (caseLiveVars altLiveVars : LiveVars) (b : FnBody) : FnBody :=
+  caseLiveVars.vars.foldl (init := b) fun b x =>
+    let info := getVarInfo ctx x
+    if !altLiveVars.vars.contains x then
+      if info.isPossibleRef && !caseLiveVars.borrows.contains x then
+        addDec ctx x b
+      else b
+    else if caseLiveVars.borrows.contains x && !altLiveVars.borrows.contains x then
+      addInc ctx x b
+    else b
 
 /-- `isFirstOcc xs x i = true` if `xs[i]` is the first occurrence of `xs[i]` in `xs` -/
 private def isFirstOcc (xs : Array Arg) (i : Nat) : Bool :=
@@ -103,7 +241,7 @@ private def getNumConsumptions (x : VarId) (ys : Array Arg) (consumeParamPred : 
     | .erased => n
     | .var y  => if x == y && consumeParamPred i then n+1 else n
 
-private def addIncBeforeAux (ctx : Context) (xs : Array Arg) (consumeParamPred : Nat → Bool) (b : FnBody) (liveVarsAfter : LiveVarSet) : FnBody :=
+private def addIncBeforeAux (ctx : Context) (xs : Array Arg) (consumeParamPred : Nat → Bool) (b : FnBody) (liveVarsAfter : LiveVars) : FnBody :=
   xs.size.fold (init := b) fun i _ b =>
     let x := xs[i]
     match x with
@@ -114,18 +252,18 @@ private def addIncBeforeAux (ctx : Context) (xs : Array Arg) (consumeParamPred :
       else
         let numConsumptions := getNumConsumptions x xs consumeParamPred
         let numIncs :=
-          if info.inheritsBorrowFromParam ||
-             liveVarsAfter.contains x ||          -- `x` is live after executing instruction
+          if liveVarsAfter.vars.contains x ||          -- `x` is live after executing instruction
+             liveVarsAfter.borrows.contains x ||
              isBorrowParamAux x xs consumeParamPred  -- `x` is used in a position that is passed as a borrow reference
           then numConsumptions
           else numConsumptions - 1
         addInc ctx x b numIncs
 
-private def addIncBefore (ctx : Context) (xs : Array Arg) (ps : Array Param) (b : FnBody) (liveVarsAfter : LiveVarSet) : FnBody :=
+private def addIncBefore (ctx : Context) (xs : Array Arg) (ps : Array Param) (b : FnBody) (liveVarsAfter : LiveVars) : FnBody :=
   addIncBeforeAux ctx xs (fun i => ! ps[i]!.borrow) b liveVarsAfter
 
 /-- See `addIncBeforeAux`/`addIncBefore` for the procedure that inserts `inc` operations before an application.  -/
-private def addDecAfterFullApp (ctx : Context) (xs : Array Arg) (ps : Array Param) (b : FnBody) (bLiveVars : LiveVarSet) : FnBody :=
+private def addDecAfterFullApp (ctx : Context) (xs : Array Arg) (ps : Array Param) (b : FnBody) (bLiveVars : LiveVars) : FnBody :=
   xs.size.fold (init := b) fun i _ b =>
     match xs[i] with
     | .erased => b
@@ -134,22 +272,27 @@ private def addDecAfterFullApp (ctx : Context) (xs : Array Arg) (ps : Array Para
         and it has been borrowed by the application.
         Remark: `x` may occur multiple times in the application (e.g., `f x y x`).
         This is why we check whether it is the first occurrence. -/
-      if mustConsume ctx x && isFirstOcc xs i && isBorrowParam x xs ps && !bLiveVars.contains x then
+      let info := getVarInfo ctx x
+      if info.isPossibleRef &&
+         isFirstOcc xs i &&
+         isBorrowParam x xs ps &&
+         !bLiveVars.vars.contains x &&
+         !bLiveVars.borrows.contains x then
         addDec ctx x b
       else b
 
-private def addIncBeforeConsumeAll (ctx : Context) (xs : Array Arg) (b : FnBody) (liveVarsAfter : LiveVarSet) : FnBody :=
+private def addIncBeforeConsumeAll (ctx : Context) (xs : Array Arg) (b : FnBody) (liveVarsAfter : LiveVars) : FnBody :=
   addIncBeforeAux ctx xs (fun _ => true) b liveVarsAfter
 
 /-- Add `dec` instructions for parameters that are references, are not alive in `b`, and are not borrow.
    That is, we must make sure these parameters are consumed. -/
-private def addDecForDeadParams (ctx : Context) (ps : Array Param) (b : FnBody) (bLiveVars : LiveVarSet) : FnBody × LiveVarSet :=
+private def addDecForDeadParams (ctx : Context) (ps : Array Param) (b : FnBody) (bLiveVars : LiveVars) : FnBody × LiveVars :=
   ps.foldl (init := ⟨b, bLiveVars⟩) fun ⟨b, bLiveVars⟩ p =>
     let b :=
-      if !p.borrow && p.ty.isPossibleRef && !bLiveVars.contains p.x then
+      if !p.borrow && p.ty.isPossibleRef && !bLiveVars.vars.contains p.x then
         addDec ctx p.x b
       else b
-    let bLiveVars := bLiveVars.erase p.x
+    let bLiveVars := bindVar p.x bLiveVars
     ⟨b, bLiveVars⟩
 
 private def isPersistent : Expr → Bool
@@ -170,12 +313,6 @@ private def typeForScalarBoxedInTaggedPtr? (v : Expr) : Option IRType :=
   | _ => none
 
 private def updateVarInfo (ctx : Context) (x : VarId) (t : IRType) (v : Expr) : Context :=
-  let inheritsBorrowFromParam :=
-    match v with
-    | .proj _ x => match ctx.varMap.get? x with
-      | some info => info.inheritsBorrowFromParam
-      | none => false
-    | _ => false
   let type := typeForScalarBoxedInTaggedPtr? v |>.getD t
   let isPossibleRef := type.isPossibleRef
   let isDefiniteRef := type.isDefiniteRef
@@ -184,20 +321,24 @@ private def updateVarInfo (ctx : Context) (x : VarId) (t : IRType) (v : Expr) : 
         isPossibleRef
         isDefiniteRef
         persistent := isPersistent v,
-        inheritsBorrowFromParam
     }
   }
 
-private def addDecIfNeeded (ctx : Context) (x : VarId) (b : FnBody) (bLiveVars : LiveVarSet) : FnBody :=
-  if mustConsume ctx x && !bLiveVars.contains x then addDec ctx x b else b
+private def addDecIfNeeded (ctx : Context) (x : VarId) (b : FnBody) (bLiveVars : LiveVars) : FnBody :=
+  let info := getVarInfo ctx x
+  if info.isPossibleRef &&
+     !bLiveVars.vars.contains x &&
+     !bLiveVars.borrows.contains x then
+    addDec ctx x b
+  else b
 
-private def processVDecl (ctx : Context) (z : VarId) (t : IRType) (v : Expr) (b : FnBody) (bLiveVars : LiveVarSet) : FnBody × LiveVarSet :=
+private def processVDecl (ctx : Context) (z : VarId) (t : IRType) (v : Expr) (b : FnBody) (bLiveVars : LiveVars) : FnBody × LiveVars :=
   let b := match v with
     | .ctor _ ys | .reuse _ _ _ ys | .pap _ ys =>
       addIncBeforeConsumeAll ctx ys (.vdecl z t v b) bLiveVars
     | .proj _ x =>
       let b := addDecIfNeeded ctx x b bLiveVars
-      let b := if !(getVarInfo ctx x).inheritsBorrowFromParam then addInc ctx z b else b
+      let b := if !bLiveVars.borrows.contains z then addInc ctx z b else b
       .vdecl z t v b
     | .uproj _ x | .sproj _ _ x | .unbox x =>
       .vdecl z t v (addDecIfNeeded ctx x b bLiveVars)
@@ -211,8 +352,8 @@ private def processVDecl (ctx : Context) (z : VarId) (t : IRType) (v : Expr) (b 
       addIncBeforeConsumeAll ctx ysx (.vdecl z t v b) bLiveVars
     | .lit _ | .box .. | .reset .. | .isShared _ =>
       .vdecl z t v b
-  let liveVars := updateLiveVars v bLiveVars
-  let liveVars := liveVars.erase z
+  let liveVars := useExpr ctx v bLiveVars
+  let liveVars := bindVar z liveVars
   ⟨b, liveVars⟩
 
 def updateVarInfoWithParams (ctx : Context) (ps : Array Param) : Context :=
@@ -220,11 +361,10 @@ def updateVarInfoWithParams (ctx : Context) (ps : Array Param) : Context :=
     m.insert p.x {
       isPossibleRef := p.ty.isPossibleRef
       isDefiniteRef := p.ty.isDefiniteRef
-      persistent := false
-      inheritsBorrowFromParam := p.borrow }
+      persistent := false }
   { ctx with varMap := m }
 
-partial def visitFnBody (b : FnBody) (ctx : Context) : FnBody × LiveVarSet :=
+partial def visitFnBody (b : FnBody) (ctx : Context) : FnBody × LiveVars :=
   match b with
   | .vdecl x t v b =>
     let ctx := updateVarInfo ctx x t v
@@ -243,15 +383,15 @@ partial def visitFnBody (b : FnBody) (ctx : Context) : FnBody × LiveVarSet :=
   | .uset x i y b =>
     let ⟨b, s⟩ := visitFnBody b ctx
     -- We don't need to insert `y` since we only need to track live variables that are references at runtime
-    let s      := s.insert x
+    let s := useVar ctx x s
     ⟨.uset x i y b, s⟩
   | .sset x i o y t b =>
     let ⟨b, s⟩ := visitFnBody b ctx
     -- We don't need to insert `y` since we only need to track live variables that are references at runtime
-    let s      := s.insert x
+    let s := useVar ctx x s
     ⟨.sset x i o y t b, s⟩
   | .case tid x xType alts =>
-    let alts : Array (Alt × LiveVarSet) := alts.map fun alt => match alt with
+    let alts : Array (Alt × LiveVars) := alts.map fun alt => match alt with
       | .ctor c b =>
         let ctx := updateRefUsingCtorInfo ctx x c
         let ⟨b, altLiveVars⟩ := visitFnBody b ctx
@@ -259,9 +399,10 @@ partial def visitFnBody (b : FnBody) (ctx : Context) : FnBody × LiveVarSet :=
       | .default b =>
         let ⟨b, altLiveVars⟩ := visitFnBody b ctx
         ⟨.default b, altLiveVars⟩
-    let caseLiveVars : LiveVarSet := alts.foldl (init := {}) fun liveVars ⟨_, altLiveVars⟩ =>
-      liveVars.merge altLiveVars
-    let caseLiveVars := caseLiveVars.insert x
+    let caseLiveVars := alts.foldl (init := { vars := {}, borrows := {} })
+      fun liveVars ⟨_, altLiveVars⟩ =>
+        liveVars.merge altLiveVars
+    let caseLiveVars := useVar ctx x caseLiveVars
     let alts := alts.map fun ⟨alt, altLiveVars⟩ => match alt with
       | .ctor c b =>
         let ctx := updateRefUsingCtorInfo ctx x c
@@ -271,29 +412,32 @@ partial def visitFnBody (b : FnBody) (ctx : Context) : FnBody × LiveVarSet :=
         let b := addDecForAlt ctx caseLiveVars altLiveVars b
         .default b
     ⟨.case tid x xType alts, caseLiveVars⟩
-  | .ret x =>
-    match x with
-    | .var x =>
-      let info := getVarInfo ctx x
-      let b :=
-        if info.isPossibleRef && info.inheritsBorrowFromParam then
-          addInc ctx x b
-        else b
-      ⟨b, mkLiveVarSet x⟩
-    | .erased => ⟨b, {}⟩
   | .jmp j xs =>
     let jLiveVars := getJPLiveVars ctx j
     let ps        := getJPParams ctx j
     let b         := addIncBefore ctx xs ps b jLiveVars
-    let bLiveVars := collectLiveVars b ctx.jpLiveVarMap
+    let bLiveVars := useArgs ctx xs jLiveVars
     ⟨b, bLiveVars⟩
-  | .unreachable => ⟨.unreachable, {}⟩
+  | .ret x =>
+    let liveVars := mkRetLiveVars ctx
+    match x with
+    | .var x =>
+      let info := ctx.varMap.get! x
+      let liveVars := useVar ctx x liveVars
+      let b :=
+        if info.isPossibleRef && liveVars.borrows.contains x then
+          addInc ctx x b
+        else b
+      ⟨b, liveVars⟩
+    | .erased => ⟨b, liveVars⟩
+  | .unreachable => ⟨.unreachable, mkRetLiveVars ctx⟩
   | .set .. | .setTag .. | .inc .. | .dec .. | .del .. => unreachable!
 
 partial def visitDecl (env : Environment) (decls : Array Decl) (d : Decl) : Decl :=
   match d with
   | .fdecl (xs := xs) (body := b) .. =>
-    let ctx := updateVarInfoWithParams { env, decls } xs
+    let ⟨varProjMap, borrowedParams⟩ := CollectProjInfo.collectProjInfo xs b
+    let ctx := updateVarInfoWithParams { env, decls, borrowedParams, varProjMap } xs
     let ⟨b, bLiveVars⟩ := visitFnBody b ctx
     let ⟨b, _⟩ := addDecForDeadParams ctx xs b bLiveVars
     d.updateBody! b


### PR DESCRIPTION
This PR changes the IR RC pass to take "implied borrows" from projections into account. If a projected value's lifetime is contained in that of its parent (or any projection ancestor), then it does not need its reference count incremented (or later decremented). 

I believe that this same technique should generalize to both the reset/reuse and borrow signature inference passes.