### PR TITLE
fix: Rewriting in `mvcgen` when there are excess arguments to `wp`

### DIFF
--- a/src/Std/Do/Triple/Basic.lean
+++ b/src/Std/Do/Triple/Basic.lean
@@ -66,8 +66,4 @@ theorem bind [Monad m] [WPMonad m ps] {α β : Type u} {P : Assertion ps} {Q : �
 theorem and [WP m ps] (x : m α) (h₁ : Triple x P₁ Q₁) (h₂ : Triple x P₂ Q₂) : Triple x spred(P₁ ∧ P₂) (Q₁ ∧ₚ Q₂) :=
   (SPred.and_mono h₁ h₂).trans ((wp x).conjunctive Q₁ Q₂).mpr
 
-theorem rewrite_program [WP m ps] {prog₁ prog₂ : m α}
-  (heq : prog₁ = prog₂) (hprf : Triple prog₂ P Q) :
-  Triple prog₁ P Q := heq ▸ hprf
-
 end Triple


### PR DESCRIPTION
This PR fixes a bug in `mvcgen` triggered by excess state arguments to the `wp` application, a situation which arises when working with `StateT` primitives.
