### PR TITLE
feat: Simpler first-order implementation for pure `SPred`s

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Attr.lean
+++ b/src/Lean/Elab/Tactic/Do/Attr.lean
@@ -147,8 +147,7 @@ partial def computeMVarBetaPotentialForSPred (xs : Array Expr) (σs : Expr) (e :
     let s ← mkFreshExprMVar σ
     e := e.beta #[s]
     let (r, _) ← simp e ctx
-      -- In practice we only need to reduce `fun s => ...`, `SVal.curry` and functions that operate
-      -- on the state tuple bound by `SVal.curry`.
+      -- In practice we only need to reduce `fun s => ...` and `SPred.pure`.
       -- We could write a custom function should `simp` become a bottleneck.
     e := r.expr
     let count ← countBVarDependentMVars xs e

--- a/src/Lean/Elab/Tactic/Do/ProofMode/Exfalso.lean
+++ b/src/Lean/Elab/Tactic/Do/ProofMode/Exfalso.lean
@@ -20,7 +20,7 @@ open Lean Elab Tactic Meta
 -- set_option pp.all true in
 -- #check ⌜False⌝
 private def falseProp (u : Level) (σs : Expr) : Expr := -- ⌜False⌝ standing in for an empty conjunction of hypotheses
-  mkApp3 (mkConst ``SVal.curry [u]) (mkApp (mkConst ``ULift [u, 0]) (.sort .zero)) σs <| mkLambda `tuple .default (mkApp (mkConst ``SVal.StateTuple [u]) σs) (mkApp2 (mkConst ``ULift.up [u, 0]) (.sort .zero) (mkConst ``False))
+  SPred.mkPure u σs (mkConst ``False)
 
 @[builtin_tactic Lean.Parser.Tactic.mexfalso]
 def elabMExfalso : Tactic | _ => do

--- a/src/Lean/Elab/Tactic/Do/ProofMode/MGoal.lean
+++ b/src/Lean/Elab/Tactic/Do/ProofMode/MGoal.lean
@@ -41,13 +41,10 @@ def SPred.mkType (u : Level) (σs : Expr) : Expr :=
 -- set_option pp.all true in
 -- #check ⌜True⌝
 def SPred.mkPure (u : Level) (σs : Expr) (p : Expr) : Expr :=
-  mkApp3 (mkConst ``SVal.curry [u]) (mkApp (mkConst ``ULift [u, 0]) (.sort .zero)) σs <|
-    mkLambda `tuple .default (mkApp (mkConst ``SVal.StateTuple [u]) σs) <|
-      mkApp2 (mkConst ``ULift.up [u, 0]) (.sort .zero) (Expr.liftLooseBVars p 0 1)
+  mkApp2 (mkConst ``SPred.pure [u]) σs p
 
 def SPred.isPure? : Expr → Option (Level × Expr × Expr)
-  | mkApp3 (.const ``SVal.curry [u]) (mkApp (.const ``ULift _) (.sort .zero)) σs <|
-      .lam _ _ (mkApp2 (.const ``ULift.up _) _ p) _ => some (u, σs, (Expr.lowerLooseBVars p 0 1))
+  | mkApp2 (.const ``SPred.pure [u]) σs p => some (u, σs, p)
   | _ => none
 
 def emptyHypName := `emptyHyp

--- a/src/Lean/Elab/Tactic/Do/Spec.lean
+++ b/src/Lean/Elab/Tactic/Do/Spec.lean
@@ -124,7 +124,7 @@ def dischargeMGoal (goal : MGoal) (goalTag : Name) : n Expr := do
   liftMetaM <| do trace[Elab.Tactic.Do.spec] "dischargeMGoal: {goal.target}"
   -- simply try one of the assumptions for now. Later on we might want to decompose conjunctions etc; full xsimpl
   -- The `withDefault` ensures that a hyp `⌜s = 4⌝` can be used to discharge `⌜s = 4⌝ s`.
-  -- (Recall that `⌜s = 4⌝ s` is `SVal.curry (σs:=[Nat]) (fun _ => s = 4) s` and `SVal.curry` is
+  -- (Recall that `⌜s = 4⌝ s` is `SPred.pure (σs:=[Nat]) (s = 4) s` and `SPred.pure` is
   -- semi-reducible.)
   -- We also try `mpure_intro; trivial` through `goal.triviallyPure` here because later on an
   -- assignment like `⌜s = ?c⌝` becomes impossible to discharge because `?c` will get abstracted
@@ -156,11 +156,8 @@ def mSpec (goal : MGoal) (elabSpecAtWP : Expr → n SpecTheorem) (goalTag : Name
   let wp := T.getArg! 2
   let specThm ← elabSpecAtWP wp
 
-  -- The precondition of `specThm` might look like `⌜?n = ‹Nat›ₛ ∧ ?m = ‹Bool›ₛ⌝`, which expands to
-  -- `SVal.curry (fun tuple => ?n = SVal.uncurry (getThe Nat tuple) ∧ ?m = SVal.uncurry (getThe Bool tuple))`.
-  -- Note that the assignments for `?n` and `?m` depend on the bound variable `tuple`.
-  -- Here, we further eta expand and simplify according to `etaPotential` so that the solutions for
-  -- `?n` and `?m` do not depend on `tuple`.
+  -- The precondition of `specThm` might look like `⌜?n = nₛ ∧ ?m = b⌝`, which expands to
+  -- `SPred.pure (?n = n ∧ ?m = b)`.
   let residualEta := specThm.etaPotential - (T.getAppNumArgs - 4) -- 4 arguments expected for PredTrans.apply
   mIntroForallN goal residualEta fun goal => do
 

--- a/src/Std/Do/SPred/DerivedLaws.lean
+++ b/src/Std/Do/SPred/DerivedLaws.lean
@@ -196,6 +196,7 @@ instance (σs) : IsPure (σs:=σs) spred(⌜φ⌝ ∨ ⌜ψ⌝) (φ ∨ ψ) wher
 instance (σs) (P : α → Prop) : IsPure (σs:=σs) spred(∃ x, ⌜P x⌝) (∃ x, P x) where to_pure := pure_exists
 instance (σs) (P : α → Prop) : IsPure (σs:=σs) spred(∀ x, ⌜P x⌝) (∀ x, P x) where to_pure := pure_forall
 instance (σs) (P : SPred (σ::σs)) [inst : IsPure P φ] : IsPure (σs:=σs) spred(P s) φ where to_pure := (iff_of_eq bientails_cons).mp inst.to_pure s
+instance (σs) (P : SPred σs) [inst : IsPure P φ] : IsPure (σs:=σ::σs) (fun _ => P) φ where to_pure := (iff_of_eq bientails_cons).mpr (fun _ => inst.to_pure)
 instance (φ : Prop) : IsPure (σs:=[]) ⌜φ⌝ φ where to_pure := Iff.rfl
 instance (P : SPred []) : IsPure (σs:=[]) P P.down where to_pure := Iff.rfl
 
@@ -267,6 +268,7 @@ class HasFrame (P : SPred σs) (P' : outParam (SPred σs)) (φ : outParam Prop) 
   reassoc : P ⊣⊢ₛ P' ∧ ⌜φ⌝
 instance (σs) (P P' Q QP : SPred σs) [HasFrame P Q φ] [SimpAnd Q P' QP]: HasFrame (σs:=σs) spred(P ∧ P') QP φ where reassoc := ((and_congr_l HasFrame.reassoc).trans and_right_comm).trans (and_congr_l SimpAnd.simp_and)
 instance (σs) (P P' Q' PQ : SPred σs) [HasFrame P' Q' φ] [SimpAnd P Q' PQ]: HasFrame (σs:=σs) spred(P ∧ P') PQ φ where reassoc := ((and_congr_r HasFrame.reassoc).trans and_assoc.symm).trans (and_congr_l SimpAnd.simp_and)
+instance (σs) (P P' : Prop) (Q : SPred σs) [HasFrame spred(⌜P⌝ ∧ ⌜P'⌝) Q φ] : HasFrame (σs:=σs) ⌜P ∧ P'⌝ Q φ where reassoc := and_pure.symm.trans HasFrame.reassoc
 instance (σs) (P P' : SVal.StateTuple σs → Prop) (Q : SPred σs) [HasFrame spred(SVal.curry (fun t => ⟨P t⟩) ∧ SVal.curry (fun t => ⟨P' t⟩)) Q φ] : HasFrame (σs:=σs) (SVal.curry fun t => ⟨P t ∧ P' t⟩) Q φ where reassoc := and_curry.symm.trans HasFrame.reassoc
 instance (σs) (P : SPred σs) : HasFrame (σs:=σs) spred(⌜φ⌝ ∧ P) P φ where reassoc := and_comm
 instance (σs) (P : SPred σs) : HasFrame (σs:=σs) spred(P ∧ ⌜φ⌝) P φ where reassoc := .rfl

--- a/src/Std/Do/SPred/Laws.lean
+++ b/src/Std/Do/SPred/Laws.lean
@@ -76,15 +76,33 @@ theorem bientails.to_eq {P Q : SPred σs} (h : P ⊣⊢ₛ Q) : P = Q := by
 
 /-! # Pure -/
 
+@[simp, grind =] theorem down_pure {φ : Prop} : (⌜φ⌝ : SPred []).down = φ := rfl
+@[simp, grind =] theorem apply_pure {φ : Prop} : (⌜φ⌝ : SPred (σ::σs)) s = ⌜φ⌝ := rfl
+
 theorem pure_intro {φ : Prop} {P : SPred σs} : φ → P ⊢ₛ ⌜φ⌝ := by
-  induction σs <;> simp_all [entails, SVal.curry]
+  induction σs <;> simp_all [entails]
 
 theorem pure_elim' {φ : Prop} {P : SPred σs} : (φ → ⌜True⌝ ⊢ₛ P) → ⌜φ⌝ ⊢ₛ P := by
-  induction σs <;> simp_all [entails, SVal.curry]
+  induction σs <;> simp_all [entails]
 
 -- Ideally, we'd like to prove the following theorem:
 -- theorem pure_elim' {φ : Prop} : SPred.entails (σs:=σs) ⌜True⌝ ⌜φ⌝ → φ
 -- Unfortunately, this is only true if all `σs` are Inhabited.
+
+theorem and_pure {P Q : Prop} : ⌜P⌝ ∧ ⌜Q⌝ ⊣⊢ₛ (⌜P ∧ Q⌝ : SPred σs) := by
+  induction σs
+  case nil => rfl
+  case cons σ σs ih => intro s; simp only [and_cons]; exact ih
+
+theorem or_pure {P Q : Prop} : ⌜P⌝ ∨ ⌜Q⌝ ⊣⊢ₛ (⌜P ∨ Q⌝ : SPred σs) := by
+  induction σs
+  case nil => rfl
+  case cons σ σs ih => intro s; simp only [or_cons]; exact ih
+
+theorem imp_pure {P Q : Prop} : (⌜P⌝ → ⌜Q⌝) ⊣⊢ₛ (⌜P → Q⌝ : SPred σs) := by
+  induction σs
+  case nil => rfl
+  case cons σ σs ih => intro s; simp only [imp_cons]; exact ih
 
 /-! # Conjunction -/
 

--- a/src/Std/Do/SPred/Notation.lean
+++ b/src/Std/Do/SPred/Notation.lean
@@ -50,14 +50,8 @@ partial def SPred.Notation.unpack [Monad m] [MonadRef m] [MonadQuotation m] : Te
 
 /-! # Idiom notation -/
 
-/-- Embedding of pure Lean values into `SVal`. -/
+/-- Embedding of pure Lean values into `SVal`. An alias for `SPred.pure`. -/
 scoped syntax "⌜" term "⌝" : term
-/-- ‹t› in `SVal` idiom notation. Accesses the state of type `t`. -/
-scoped syntax "‹" term "›ₛ" : term
-/--
-  Use getter `t : SVal σs σ` in `SVal` idiom notation; sugar for `SVal.uncurry t (by assumption)`.
--/
-scoped syntax:max "#" term:max : term
 
 /-! # Sugar for `SPred` -/
 
@@ -69,9 +63,7 @@ scoped syntax:25 "⊢ₛ " term:25 : term
 scoped syntax:25 term:25 " ⊣⊢ₛ " term:25 : term
 
 macro_rules
-  | `(⌜$t⌝) => ``(SVal.curry (fun tuple => ULift.up $t))
-  | `(#$t) => `(SVal.uncurry $t (by assumption))
-  | `(‹$t›ₛ) => `(#(SVal.getThe $t))
+  | `(⌜$t⌝) => ``(SPred.pure $t)
   | `($P ⊢ₛ $Q) => ``(SPred.entails spred($P) spred($Q))
   | `(spred($P ∧ $Q)) => ``(SPred.and spred($P) spred($Q))
   | `(spred($P ∨ $Q)) => ``(SPred.or spred($P) spred($Q))
@@ -94,20 +86,10 @@ macro_rules
 
 namespace SPred.Notation
 
-@[app_unexpander SVal.curry]
-meta def unexpandCurry : Unexpander
+@[app_unexpander SPred.pure]
+meta def unexpandPure : Unexpander
   | `($_ $t $ts*) => do
-    match t with
-    | `(fun $_ => { down := $e }) => if ts.isEmpty then ``(⌜$e⌝) else ``(⌜$e⌝ $ts*)
-    | _ => throw ()
-  | _ => throw ()
-
-@[app_unexpander SVal.uncurry]
-meta def unexpandUncurry : Unexpander
-  | `($_ $f $ts*) => do
-    match f with
-    | `(SVal.getThe $t) => if ts.isEmpty then ``(‹$t›ₛ) else ``(‹$t›ₛ $ts*)
-    | `($t) => if ts.isEmpty then ``(#$t) else ``(#$t $ts*)
+    if ts.isEmpty then ``(⌜$t⌝) else ``(⌜$t⌝ $ts*)
   | _ => throw ()
 
 @[app_unexpander SPred.entails]

--- a/src/Std/Tactic/Do/Syntax.lean
+++ b/src/Std/Tactic/Do/Syntax.lean
@@ -126,6 +126,8 @@ syntax (name := mstop) "mstop" : tactic
 @[inherit_doc Lean.Parser.Tactic.mleaveMacro]
 macro (name := mleave) "mleave" : tactic =>
   `(tactic| (try simp only [
+              $(mkIdent ``Std.Do.SPred.down_pure):term,
+              $(mkIdent ``Std.Do.SPred.apply_pure):term,
               -- $(mkIdent ``Std.Do.SPred.entails_cons):term, -- Ineffective until #9015 lands
               $(mkIdent ``Std.Do.SPred.entails_1):term,
               $(mkIdent ``Std.Do.SPred.entails_2):term,
@@ -289,7 +291,7 @@ Like `mspec`, but does not attempt slight simplification and closing of trivial 
 ```
 mspec_no_simp $spec
 all_goals
-  ((try simp only [SPred.true_intro_simp, SVal.curry_cons, SVal.uncurry_nil, SVal.uncurry_cons, SVal.getThe_here, SVal.getThe_there]);
+  ((try simp only [SPred.true_intro_simp, SPred.apply_pure]);
    (try mpure_intro; trivial))
 ```
 -/
@@ -316,11 +318,7 @@ macro (name := mspec) "mspec" spec:(ppSpace colGt term)? : tactic =>
   `(tactic| (mspec_no_simp $[$spec]?
              all_goals ((try simp only [
                           $(mkIdent ``Std.Do.SPred.true_intro_simp):term,
-                          $(mkIdent ``Std.Do.SVal.curry_cons):term,
-                          $(mkIdent ``Std.Do.SVal.uncurry_nil):term,
-                          $(mkIdent ``Std.Do.SVal.uncurry_cons):term,
-                          $(mkIdent ``Std.Do.SVal.getThe_here):term,
-                          $(mkIdent ``Std.Do.SVal.getThe_there):term])
+                          $(mkIdent ``Std.Do.SPred.apply_pure):term])
                         (try mpure_intro; trivial))))
 
 @[inherit_doc Lean.Parser.Tactic.mvcgenMacro]

--- a/tests/lean/run/9365.lean
+++ b/tests/lean/run/9365.lean
@@ -6,15 +6,13 @@ set_option mvcgen.warning false
 
 abbrev SM := StateM (Array Nat)
 
-abbrev gns : SVal ((Array Nat)::[]) (Array Nat) := fun s => SVal.pure s
-
 noncomputable def setZeroHead : StateM (Array Nat) Unit := do
   modify fun _ => #[0, 1, 2, 3, 4, 5]
 
 theorem setZeroHead_spec :
    ⦃⌜True⌝⦄
    setZeroHead
-   ⦃⇓ _ => ⌜∃ ns', (#gns).toList = 0 :: ns'⌝⦄ := by
+   ⦃⇓ _ gns => ⌜∃ ns', gns.toList = 0 :: ns'⌝⦄ := by
   mvcgen [setZeroHead]
   -- We want to see and name the tuple `t` here in order for us not having to repeat its
   -- definition in t.2.toList.tail below

--- a/tests/lean/run/9474.lean
+++ b/tests/lean/run/9474.lean
@@ -4,8 +4,6 @@ open Std.Do
 
 set_option mvcgen.warning false
 
-abbrev gns : SVal ((List Nat)::[]) (List Nat) := fun s => SVal.pure s
-
 noncomputable def setZeroHead : StateM (List Nat) Unit := do
   modify fun _ => [1, 0, 1, 2, 3, 4, 5]
   pure ()
@@ -15,7 +13,7 @@ noncomputable def setZeroHead : StateM (List Nat) Unit := do
 theorem setZeroHead_spec :
    ⦃⌜True⌝⦄
    setZeroHead
-   ⦃⇓ _ => ⌜∃ ns', #gns = 0 :: ns'⌝⦄ := by
+   ⦃⇓ _ gns => ⌜∃ ns', gns = 0 :: ns'⌝⦄ := by
   mvcgen [setZeroHead] -- should mintro through let/have bindings
   mleave
   rename_i t

--- a/tests/lean/run/spredNotation.lean
+++ b/tests/lean/run/spredNotation.lean
@@ -26,22 +26,9 @@ variable
 #check P ⊣⊢ₛ Q
 
 
-/-- info: ⌜φ⌝ : SVal [Nat, Char, Bool] (ULift Prop) -/
+/-- info: ⌜φ⌝ : SPred [Nat, Char, Bool] -/
 #guard_msgs in
 #check (⌜φ⌝ : SPred [Nat,Char,Bool])
-
--- TODO: Figure out how to delaborate away tuple below
-/--
-info: ⌜7 + ‹Nat›ₛ tuple = if ‹Bool›ₛ tuple = true then 13 else 7⌝ : SVal [Nat, Char, Bool] (ULift Prop)
--/
-#guard_msgs in
-#check (⌜7 + ‹Nat›ₛ = if ‹Bool›ₛ then 13 else 7⌝ : SPred [Nat,Char,Bool])
-
-private abbrev theChar : SVal [Nat,Char,Bool] Char := fun _ c _ => c
-/-- info: ⌜#theChar tuple = 'a'⌝ : SVal [Nat, Char, Bool] (ULift Prop) -/
-#guard_msgs in
-#check ⌜#theChar = 'a'⌝
-
 
 /-- info: spred(P ∧ Q) : SPred [Nat, Char, Bool] -/
 #guard_msgs in
@@ -144,7 +131,7 @@ private abbrev theChar : SVal [Nat,Char,Bool] Char := fun _ c _ => c
 info: if true = true then
   match (1, 2) with
   | (x, y) => Φ x y
-else ⌜False⌝ : SVal [Nat, Char, Bool] (ULift Prop)
+else ⌜False⌝ : SPred [Nat, Char, Bool]
 -/
 #guard_msgs in
 #check spred(if true then term(match (1,2) with | (x,y) => Φ x y) else ⌜False⌝)
@@ -153,24 +140,5 @@ else ⌜False⌝ : SVal [Nat, Char, Bool] (ULift Prop)
 #guard_msgs in
 #check spred(Ψ (1 + 1))
 
-
-private abbrev theNat : SVal [Nat, Bool] Nat := fun n _ => n
 example (P Q : SPred [Nat, Bool]): SPred [Char, Nat, Bool] :=
-  spred(fun c => ((∀ y, if y = 4 then ⌜y = #theNat⌝ ∧ P else Q) ∧ Q) → (∃ x, P → if (x : Bool) then Q else P))
-
--- A bigger example testing unexpansion as well: (TODO: Figure out how to delaborate away tuple below)
-/--
-info: fun P Q n =>
-  spred((∀ y, if y = n then ⌜‹Nat›ₛ tuple + #theNat tuple = 4⌝ else Q) ∧ Q →
-      P → ∃ x, P → if x = true then Q else P) : SPred [Nat, Bool] → SPred [Nat, Bool] → Char → SPred [Nat, Bool]
--/
-#guard_msgs in
-#check fun P Q => spred(fun (n : Char) => ((∀ y, if y = n then ⌜‹Nat›ₛ + #theNat = 4⌝ else Q) ∧ Q) → P → (∃ x, P → if (x : Bool) then Q else P))
-
--- Unexpansion should work irrespective of binder name for `f`/`escape`:
-/--
-info: ∀ (a b n o : Nat) (s : Nat × Nat), ⌜a = n ∧ b = o⌝ ⊢ₛ ⌜s.fst = n ∧ a = n + 1 ∧ b = o⌝ : Prop
--/
-#guard_msgs in
-set_option linter.unusedVariables false in
-#check ∀ (a b n o : Nat) (s : Nat × Nat), (SVal.curry fun f => ULift.up (a = n ∧ b = o)) ⊢ₛ SVal.curry fun f => ULift.up (s.1 = n ∧ a = n + 1 ∧ b = o)
+  spred(fun _ => ((∀ y, if y = 4 then (fun theNat => ⌜y = theNat⌝) ∧ P else Q) ∧ Q) → (∃ x, P → if (x : Bool) then Q else P))


### PR DESCRIPTION
This PR migrates the ⌜p⌝ notation for embedding pure p : Prop into SPred σs to expand into a simple, first-order expression SPred.pure p that can be supported by e-matching in grind.

Doing so deprives ⌜p⌝ notation of its idiom-bracket-like support for #selector and ‹Nat›ₛ syntax which is thus removed.
