### PR TITLE
feat: Deterministic case labels in `mvcgen`

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Spec.lean
+++ b/src/Lean/Elab/Tactic/Do/Spec.lean
@@ -136,17 +136,10 @@ def dischargeMGoal (goal : MGoal) (goalTag : Name) : n Expr := do
   liftMetaM <| do trace[Elab.Tactic.Do.spec] "proof: {prf}"
   return prf
 
-def mkPreTag (goalTag : Name) : Name := Id.run do
-  let dflt := goalTag ++ `pre1
-  let .str p s := goalTag | return dflt
-  unless "pre".isPrefixOf s do return dflt
-  let some n := (s.toSubstring.drop 3).toString.toNat? | return dflt
-  return .str p ("pre" ++ toString (n + 1))
-
 /--
   Returns the proof and the list of new unassigned MVars.
 -/
-def mSpec (goal : MGoal) (elabSpecAtWP : Expr → n SpecTheorem) (goalTag : Name) (mkPreTag := mkPreTag) : n Expr := do
+def mSpec (goal : MGoal) (elabSpecAtWP : Expr → n SpecTheorem) (goalTag : Name) : n Expr := do
   -- First instantiate `fun s => ...` in the target via repeated `mintro ∀s`.
   mIntroForallN goal goal.target.consumeMData.getNumHeadLambdas fun goal => do
   -- Elaborate the spec for the wp⟦e⟧ app in the target
@@ -198,7 +191,7 @@ def mSpec (goal : MGoal) (elabSpecAtWP : Expr → n SpecTheorem) (goalTag : Name
   if !HPRfl then
     -- let P := (← reduceProjBeta? P).getD P
     -- Try to avoid creating a longer name if the postcondition does not need to create a goal
-    let tag := if !QQ'Rfl then mkPreTag goalTag else goalTag
+    let tag := if !QQ'Rfl then goalTag ++ `pre else goalTag
     let HPPrf ← dischargeMGoal { goal with target := P } tag
     prePrf := mkApp6 (mkConst ``SPred.entails.trans [u]) goal.σs goal.hyps P goal.target HPPrf
 

--- a/src/Lean/Elab/Tactic/Do/VCGen.lean
+++ b/src/Lean/Elab/Tactic/Do/VCGen.lean
@@ -45,7 +45,13 @@ partial def genVCs (goal : MVarId) (ctx : Context) (fuel : Fuel) : MetaM (Array 
   mvar.withContext <| withReducible do
     let (prf, state) ← StateRefT'.run (ReaderT.run (onGoal goal (← mvar.getTag)) ctx) { fuel }
     mvar.assign prf
-    return state.vcs
+    for h : idx in [:state.invariants.size] do
+      let mv := state.invariants[idx]
+      mv.setTag (Name.mkSimple ("inv" ++ toString (idx + 1)))
+    for h : idx in [:state.vcs.size] do
+      let mv := state.vcs[idx]
+      mv.setTag (Name.mkSimple ("vc" ++ toString (idx + 1)) ++ (← mv.getTag))
+    return state.invariants ++ state.vcs
 where
   onFail (goal : MGoal) (name : Name) : VCGenM Expr := do
     -- trace[Elab.Tactic.Do.vcgen] "fail {goal.toExpr}"

--- a/tests/lean/run/9581.lean
+++ b/tests/lean/run/9581.lean
@@ -15,7 +15,7 @@ theorem F_spec :
    ⦃⇓ _ => ⌜1 < 2⌝⦄ := by
   mvcgen [F]
 
-  case inv => exact ⇓ _ => ⌜1 < 2⌝
+  case inv1 => exact ⇓ _ => ⌜1 < 2⌝
   -- it would be nice if we had a tactic wrapper around `case inv => exact ...` that does `mleave`
   -- on all subgoals afterwards.
 

--- a/tests/lean/run/bhaviksSampler.lean
+++ b/tests/lean/run/bhaviksSampler.lean
@@ -152,19 +152,8 @@ theorem sampler_correct {m : Type → Type u} {k h} [Monad m] [WPMonad m ps] :
   sampler (m:=m) n k h
   ⦃⇓ xs => ⌜xs.toList.Nodup⌝⦄ := by
   mvcgen -leave [sampler]
-  case inv => exact (⇓ (xs, midway) => ⌜Midway.valid midway xs.rpref.length⌝)
-  -- case step => simp_all
-  case post.success =>
-    dsimp
-    mrename_i h
-    mpure h
-    mpure_intro
-    have h := h.nodup_take
-    simp at h
-    -- prove List.take k r.snd.toList = r.snd.toList for r.snd : Vector (Fin n) k
-    sorry
-  case post.except => simp
-  case step.success rpref x _ _ _ _ _ _ r _ _ =>
+  case inv1 => exact (⇓ (xs, midway) => ⌜Midway.valid midway xs.rpref.length⌝)
+  case vc1 rpref x _ _ _ _ _ _ r _ _ =>
     dsimp
     mintro ∀s
     mframe
@@ -174,5 +163,16 @@ theorem sampler_correct {m : Type → Type u} {k h} [Monad m] [WPMonad m ps] :
     have : x = rpref.length := sorry -- by grind -- wishful thinking :(
     subst this
     apply Midway.valid_next _ rpref.length _ r.val r.property.1 r.property.2 hinv
-  mpure_intro
-  exact valid_init
+  case vc2 =>
+    mpure_intro
+    exact valid_init
+  case vc3 =>
+    dsimp
+    mrename_i h
+    mpure h
+    mpure_intro
+    have h := h.nodup_take
+    simp at h
+    -- prove List.take k r.snd.toList = r.snd.toList for r.snd : Vector (Fin n) k
+    sorry
+  case vc4 => simp

--- a/tests/lean/run/pairsSumToZero.lean
+++ b/tests/lean/run/pairsSumToZero.lean
@@ -71,7 +71,7 @@ theorem pairsSumToZero_correct (l : List Int) : pairsSumToZero l ↔ l.ExistsPai
 
   mvcgen
 
-  case inv =>
+  case inv1 =>
     exact Invariant.withEarlyReturn
       (onReturn := fun r b => ⌜r = true ∧ l.ExistsPair (fun a b => a + b = 0)⌝)
       (onContinue := fun traversalState seen =>


### PR DESCRIPTION
This PR makes `mvcgen` produce deterministic case labels for the generated VCs. Invariants will be named `inv<n>` and every other VC will be named `vc<n>.*`, where the `*` part serves as a loose indication of provenance.
