### PR TITLE
fix: `rcases`: avoid inflating case names with single constructor names

### DIFF
--- a/src/Lean/Meta/Tactic/Induction.lean
+++ b/src/Lean/Meta/Tactic/Induction.lean
@@ -83,6 +83,7 @@ private partial def finalize
         match recursorType with
         | Expr.forallE n d _ c =>
           let d := d.headBeta
+          let tag' := if numMinors == 1 then tag else tag ++ n
           -- Remark is givenNames is not empty, then user provided explicit alternatives for each minor premise
           if c.isInstImplicit && givenNames.isEmpty then
             match (← synthInstance? d) with
@@ -92,7 +93,7 @@ private partial def finalize
               loop (pos+1) (minorIdx+1) recursor recursorType consumedMajor subgoals
             | none => do
               -- Add newSubgoal if type class resolution failed
-              let mvar ← mkFreshExprSyntheticOpaqueMVar d (tag ++ n)
+              let mvar ← mkFreshExprSyntheticOpaqueMVar d tag'
               let recursor := mkApp recursor mvar
               let recursorType ← getTypeBody mvarId recursorType mvar
               loop (pos+1) (minorIdx+1) recursor recursorType consumedMajor (subgoals.push { mvarId := mvar.mvarId! })
@@ -102,7 +103,7 @@ private partial def finalize
             let nparams := arity - initialArity -- number of fields due to minor premise
             let nextra  := reverted.size - indices.size - 1 -- extra dependencies that have been reverted
             let minorGivenNames := if h : minorIdx < givenNames.size then givenNames[minorIdx] else {}
-            let mvar ← mkFreshExprSyntheticOpaqueMVar d (tag ++ n)
+            let mvar ← mkFreshExprSyntheticOpaqueMVar d tag'
             let recursor := mkApp recursor mvar
             let recursorType ← getTypeBody mvarId recursorType mvar
             -- Try to clear major premise from new goal

--- a/tests/lean/interactive/5659.lean.expected.out
+++ b/tests/lean/interactive/5659.lean.expected.out
@@ -6,7 +6,7 @@
    "range":
    {"start": {"line": 7, "character": 17}, "end": {"line": 7, "character": 18}},
    "message":
-   "Tactic `introN` failed: There are no additional binders or `let` bindings in the goal to introduce\n\ncase intro\nn : Nat\nhn : n < 0\n⊢ False",
+   "Tactic `introN` failed: There are no additional binders or `let` bindings in the goal to introduce\n\nn : Nat\nhn : n < 0\n⊢ False",
    "fullRange":
    {"start": {"line": 7, "character": 17},
     "end": {"line": 7, "character": 18}}},

--- a/tests/lean/run/issue6550.lean
+++ b/tests/lean/run/issue6550.lean
@@ -1,0 +1,104 @@
+
+-- This used to have
+-- `case intro.intro.intro.intro.intro.intro.intro.inl`
+
+/--
+error: unsolved goals
+case inl
+a b c d e f g : Nat
+h : False
+⊢ False
+
+case inr
+a b c d e f g : Nat
+h : False
+⊢ False
+-/
+#guard_msgs in
+example (h : ∃ a b c d e f g : Nat, False ∨ False) : False := by
+  obtain ⟨a, b, c, d, e, f, g, h | h⟩ := h
+
+/--
+error: unsolved goals
+case inl
+a b c d e f g : Nat
+h : False
+⊢ False
+
+case inr
+a b c d e f g : Nat
+h : False
+⊢ False
+-/
+#guard_msgs in
+example (h : ∃ a b c d e f g : Nat, False ∨ False) : False := by
+  rcases h with ⟨a, b, c, d, e, f, g, h | h⟩
+
+/--
+error: unsolved goals
+case left.inl
+a b c d e f g : Nat
+h : False
+⊢ False
+
+case left.inr
+a b c d e f g : Nat
+h : False
+⊢ False
+-/
+#guard_msgs in
+example (h : ∃ a b c d e f g : Nat, False ∨ False) : False ∧ False := by
+  constructor
+  · obtain ⟨a, b, c, d, e, f, g, h | h⟩ := h
+  · sorry
+
+-- We still get case names for `cases`
+
+/--
+error: unsolved goals
+case intro
+w✝ : Nat
+h✝ : ∃ b c d e f g, False ∨ False
+⊢ False
+-/
+#guard_msgs in
+example (h : ∃ a b c d e f g : Nat, False ∨ False) : False := by
+  cases h
+
+/--
+error: unsolved goals
+case intro.intro.intro.intro.intro.intro.intro
+a b c d e f g : Nat
+h : False ∨ False
+⊢ False
+-/
+#guard_msgs in
+example (h : ∃ a b c d e f g : Nat, False ∨ False) : False := by
+  cases h with | _ a h =>
+  cases h with | _ b h =>
+  cases h with | _ c h =>
+  cases h with | _ d h =>
+  cases h with | _ e h =>
+  cases h with | intro f h =>
+  cases h with | _ g h =>
+  skip
+
+-- And induction
+
+/--
+error: unsolved goals
+case intro.intro.intro.intro.intro.intro.intro
+a b c d e f g : Nat
+h : False ∨ False
+⊢ False
+-/
+#guard_msgs in
+example (h : ∃ a b c d e f g : Nat, False ∨ False) : False := by
+  induction h with | _ a h =>
+  induction h with | _ b h =>
+  induction h with | _ c h =>
+  induction h with | _ d h =>
+  induction h with | _ e h =>
+  induction h with | intro f h =>
+  induction h with | _ g h =>
+  skip


### PR DESCRIPTION
This PR prevents `rcases` and `obtain` from creating absurdly long case tag names when taking single constructor types (like `Exists`) apart. Fixes #6550

The change does not affect `cases` and `induction`, it seems (where the user might be surprised to not address the single goal with a name), because I make the change in Lean/`Meta/Tactic/Induction.lean`, not `Lean/Elab/Tactic/Induction.lean`. Yes, that's confusing.
