### PR TITLE
feat: `grind cutsat` equations in solved form

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/Arith/Cutsat.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Cutsat.lean
@@ -45,5 +45,6 @@ builtin_initialize registerTraceClass `grind.debug.cutsat.internalize
 builtin_initialize registerTraceClass `grind.debug.cutsat.toInt
 builtin_initialize registerTraceClass `grind.debug.cutsat.search.cnstrs
 builtin_initialize registerTraceClass `grind.debug.cutsat.search.reorder
+builtin_initialize registerTraceClass `grind.debug.cutsat.elimEq
 
 end Lean


### PR DESCRIPTION
This PR ensures that equations in the `grind cutsat` module are maintained in solved form. That is, given an equation `a*x + p = 0` used to eliminate `x`, the linear polynomial `p` must not contain other eliminated  variables. Before this PR, equations were maintained in triangular form. We are going to use the solved form to linearize nonlinear terms.
