### PR TITLE
fix: print mathlib toolchain URL properly

### DIFF
--- a/src/lake/Lake/CLI/Init.lean
+++ b/src/lake/Lake/CLI/Init.lean
@@ -491,7 +491,7 @@ def initPkg
     try
       download mathToolchainBlobUrl toolchainFile
     catch errPos =>
-      logError "failed to download mathlib 'lean-toolchain' file; \
+      logError s!"failed to download mathlib 'lean-toolchain' file; \
         you can manually copy it from:\n  {mathToolchainUrl}"
       throw errPos
     -- Create a manifest file based on the dependencies.


### PR DESCRIPTION
This PR makes lake print the error message it intended for when fetching the mathlib toolchain
fails.
