### PR TITLE
feat: parser alias for `visibility`

### DIFF
--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -867,6 +867,7 @@ builtin_initialize
   register_parser_alias                                                 optDeclSig
   register_parser_alias                                                 openDecl
   register_parser_alias                                                 docComment
+  register_parser_alias                                                 visibility
 
 /--
 Registers an error explanation.


### PR DESCRIPTION
This PR registers a parser alias for `Lean.Parser.Command.visibility`. This avoids having to import `Lean.Parser.Command` in simple command macros that use visibilities.
