### PR TITLE
fix: support compiling `casesOn` recursors of subsingleton predicates

### DIFF
--- a/tests/lean/run/9963.lean
+++ b/tests/lean/run/9963.lean
@@ -1,0 +1,7 @@
+def Set (A : Type _) := A → Prop
+
+inductive Thing (s : V → Prop) : Set V
+| basic : ∀ x, s x → Thing s x
+
+def foo := @Thing.casesOn
+def bar := @Acc.casesOn


### PR DESCRIPTION
This PR adds support for compilation of `casesOn` recursors of subsingleton predicates.

Fixes #9963.