### PR TITLE
fix: `leanOptions` in lakefile.toml schema

### DIFF
--- a/src/lake/schemas/lakefile-toml-schema.json
+++ b/src/lake/schemas/lakefile-toml-schema.json
@@ -8,9 +8,13 @@
             "type": [
                 "string",
                 "boolean",
-                "integer"
+                "integer",
+                "object"
             ],
             "minimum": 0,
+            "additionalProperties": {
+                "$ref": "#/definitions/leanOptionValue"
+            },
             "description": "A `set_option` string / boolean / natural number configuration value."
         },
         "leanConfig": {


### PR DESCRIPTION
This PR fixes a bug in the `lakefile.toml` schema where it would issue an invalid validation for multi-layer `leanOptions` .