### PR TITLE
fix: missing nonlinear `/` and `%` in `grind cutsat`

### DIFF
--- a/src/Init/Data/Int/Linear.lean
+++ b/src/Init/Data/Int/Linear.lean
@@ -2193,6 +2193,9 @@ theorem mul_eq_zero_right (a b : Int) (h : b = 0) : a*b = 0 := by simp [*]
 theorem div_eq (a b k : Int) (h : b = k) : a / b = a / k := by simp [*]
 theorem mod_eq (a b k : Int) (h : b = k) : a % b = a % k := by simp [*]
 
+theorem div_eq' (a b b' k : Int) (h₁ : b = b') (h₂ : k == a/b') : a / b = k := by simp_all
+theorem mod_eq' (a b b' k : Int) (h₁ : b = b') (h₂ : k == a%b') : a % b = k := by simp_all
+
 end Int.Linear
 
 theorem Int.not_le_eq (a b : Int) : (¬a ≤ b) = (b + 1 ≤ a) := by

--- a/src/Lean/Meta/Tactic/Grind/Arith/Cutsat/Types.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Cutsat/Types.lean
@@ -103,8 +103,18 @@ inductive EqCnstrProof where
   | defnCommRing (e : Expr) (p : Poly) (re : CommRing.RingExpr) (rp : CommRing.Poly) (p' : Poly)
   | defnNatCommRing (h : Expr) (x : Var) (e' : Int.Linear.Expr) (p : Poly) (re : CommRing.RingExpr) (rp : CommRing.Poly) (p' : Poly)
   | mul (a? : Option Expr) (cs : Array (Expr × Int × EqCnstr))
-  | div (k : Int) (y : Var) (c : EqCnstr)
-  | mod (k : Int) (y : Var) (c : EqCnstr)
+  | /--
+    Linearization proof for `/`
+    - If `?y = some y`, then it is a proof for `a / b = y / k` where `c` is a proof that `b = k`
+    - If `?y = none`, then it is a proof for `a / b = a/k` where `c` is a proof that `b = k`. `a` is a numeral in this case.
+    -/
+    div (k : Int) (y? : Option Var) (c : EqCnstr)
+  | /--
+    Linearization proof for `%`
+    - If `?y = some y`, then it is a proof for `a % b = y%k` where `c` is a proof that `b = k`
+    - If `?y = none`, then it is a proof for `a % b = a%k` where `c` is a proof that `b = k`. `a` is a numeral in this case.
+    -/
+    mod (k : Int) (y? : Option Var) (c : EqCnstr)
 
 /-- A divisibility constraint and its justification/proof. -/
 structure DvdCnstr where

--- a/tests/lean/run/grind_linearize.lean
+++ b/tests/lean/run/grind_linearize.lean
@@ -63,3 +63,33 @@ example (a b c d : Nat) : b > 0 → d = 1 → b = d + 1 → a % b = 1 → a = 2 
 
 example (a b c d : Nat) : b > 1 → d = 1 → b ≤ d + 1 → a % b = 1 → a = 2 * c → False := by
   grind
+
+example (b : Int) : 4 % b = 1 → b = 2 → False := by
+  grind
+
+example (b : Int) : b = 2 → 4 % b = 1 → False := by
+  grind
+
+example (b : Nat) : 4 % b = 1 → b = 2 → False := by
+  grind
+
+example (b : Int) : 4 / b = 1 → b = 2 → False := by
+  grind
+
+example (b : Nat) : 4 / b = 1 → b = 2 → False := by
+  grind
+
+example (b : Int) : 4 % b = 1 → b ≤ 2 → 2 ≤ b → False := by
+  grind
+
+example (b : Int) : b ≤ 2 → 2 ≤ b → 4 % b = 1 → False := by
+  grind
+
+example (b : Nat) : 4 % b = 1 → b ≤ 2 → 2 ≤ b → False := by
+  grind
+
+example (b : Int) : 4 / b = 1 → b ≤ 2 → 2 ≤ b → False := by
+  grind
+
+example (b : Nat) : 4 / b = 1 → b ≤ 2 → 2 ≤ b → False := by
+  grind


### PR DESCRIPTION
This PR fixes a missing case for PR #10010. 