### PR TITLE
feat: optional `@[expose]` specifier on deriving classes

### DIFF
--- a/src/Lean/Elab/MutualDef.lean
+++ b/src/Lean/Elab/MutualDef.lean
@@ -1324,6 +1324,7 @@ where
     for header in headers, view in views do
       if let some classStxs := view.deriving? then
         for classStx in classStxs do
+          let view ← DerivingClassView.ofSyntax ⟨classStx⟩
           withRef classStx <| withLogging <| withLCtx {} {} do
             /-
             Assumption: users intend delta deriving to apply to the body of a definition, even if in the source code
@@ -1339,7 +1340,7 @@ where
             let info ← getConstInfo header.declName
             lambdaTelescope info.value! fun xs _ => do
               let decl := mkAppN (.const header.declName (info.levelParams.map mkLevelParam)) xs
-              processDefDeriving classStx decl
+              processDefDeriving view decl
 
 /--
 Logs a snapshot task that waits for the entire snapshot tree in `defsParsedSnap` and then logs a

--- a/src/Lean/Elab/MutualInductive.lean
+++ b/src/Lean/Elab/MutualInductive.lean
@@ -1043,12 +1043,12 @@ private def applyDerivingHandlers (views : Array InductiveView) : CommandElabM U
   let mut processed : NameSet := {}
   for view in views do
     for classView in view.derivingClasses do
-      let className := classView.className
+      let className ← liftCoreM <| classView.getClassName
       unless processed.contains className do
         processed := processed.insert className
         let mut declNames := #[]
         for view in views do
-          if view.derivingClasses.any fun classView => classView.className == className then
+          if view.derivingClasses.any fun classView' => classView'.cls == classView.cls then
             declNames := declNames.push view.declName
         classView.applyHandlers declNames
 

--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -160,8 +160,11 @@ def whereStructInst  := leading_parser
     declValSimple <|> declValEqns <|> whereStructInst
 def «abbrev»         := leading_parser
   "abbrev " >> declId >> ppIndent optDeclSig >> declVal
+def derivingClass    := leading_parser
+  optional ("@[" >> nonReservedSymbol "expose" >> "]") >> withForbidden "for" termParser
+def derivingClasses  := sepBy1 derivingClass ", "
 def optDefDeriving   :=
-  optional (ppDedent ppLine >> atomic ("deriving " >> notSymbol "instance") >> sepBy1 termParser ", ")
+  optional (ppDedent ppLine >> atomic ("deriving " >> notSymbol "instance") >> derivingClasses)
 def definition     := leading_parser
   "def " >> recover declId skipUntilWsOrDelim >> ppIndent optDeclSig >> declVal >> optDefDeriving
 def «theorem»        := leading_parser
@@ -181,7 +184,6 @@ def «example»        := leading_parser
 def ctor             := leading_parser
   atomic (optional docComment >> "\n| ") >>
   ppGroup (declModifiers true >> rawIdent >> optDeclSig)
-def derivingClasses  := sepBy1 (withForbidden "for" termParser) ", "
 def optDeriving      := leading_parser
   optional (ppLine >> atomic ("deriving " >> notSymbol "instance") >> derivingClasses)
 def computedField    := leading_parser

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -11,7 +11,7 @@ options get_default_options() {
     opts = opts.update({"debug", "terminalTacticsAsSorry"}, false);
     // switch to `true` for ABI-breaking changes affecting meta code;
     // see also next option!
-    opts = opts.update({"interpreter", "prefer_native"}, false);
+    opts = opts.update({"interpreter", "prefer_native"}, true);
     // switch to `false` when enabling `prefer_native` should also affect use
     // of built-in parsers in quotations; this is usually the case, but setting
     // both to `true` may be necessary for handling non-builtin parsers with


### PR DESCRIPTION
This PR allows for more fine-grained control over what derived instances have exposed definitions under the module system: handlers should not expose their implementation unless either the deriving item or a surrounding section is marked with `@[expose]`. Built-in handlers to be updated after a stage 0 update.