### PR TITLE
fix: eliminate infinite loop in `toLCNF`'s `expandNoConfusionMajor`

### DIFF
--- a/tests/lean/run/9971.lean
+++ b/tests/lean/run/9971.lean
@@ -1,0 +1,17 @@
+abbrev Sequent : Type := List Nat
+abbrev History : Type := List Sequent
+def rep (H : History) (N : Sequent) : Prop := N ∈ H
+def Sequent.basic (N : Sequent) := N = [1,2,3]
+def LocalTableau (X : Sequent) : Type := Subtype (· = X.sum)
+def endNodesOf {X} : LocalTableau X → List Sequent := fun _ => [X,X]
+
+inductive Tableau : History → Sequent → Type
+  | loc {Hist X} (nrep : ¬ rep Hist X) (nbas : ¬ X.basic) (lt : LocalTableau X)
+            (next : ∀ Y ∈ endNodesOf lt, Tableau (X :: Hist) Y) : Tableau Hist X
+
+set_option maxHeartbeats 2000 in
+inductive PathIn : ∀ {Hist X}, Tableau Hist X → Type
+| nil : PathIn _
+| loc {nrep nbas lt next Y} (Y_in : Y ∈ endNodesOf lt) (tail : PathIn (next Y Y_in))
+    : PathIn (Tableau.loc nrep nbas lt next)
+deriving DecidableEq


### PR DESCRIPTION
This PR fixes the compilation of `noConfusion` by repairing an oversight made when porting this code from the old compiler. The old compiler only repeatedly expanded the major for each non-`Prop` field of the inductive under consideration, mirroring the construction of `noConfusion` itself, whereas the new compiler erroneously counted all fields.

Fixes #9971.