### PR TITLE
feat: more Int lemmas in preparation for dyadics

### DIFF
--- a/src/Init/Data/BitVec/Lemmas.lean
+++ b/src/Init/Data/BitVec/Lemmas.lean
@@ -2194,8 +2194,7 @@ theorem sshiftRight_eq_of_msb_false {x : BitVec w} {s : Nat} (h : x.msb = false)
   apply BitVec.eq_of_toNat_eq
   rw [BitVec.sshiftRight_eq, BitVec.toInt_eq_toNat_cond]
   have hxbound : 2 * x.toNat < 2 ^ w := BitVec.msb_eq_false_iff_two_mul_lt.mp h
-  simp only [hxbound, ↓reduceIte, Int.natCast_shiftRight, ofInt_natCast,
-    toNat_ofNat, toNat_ushiftRight]
+  simp only [hxbound, ↓reduceIte, toNat_ushiftRight]
   replace hxbound : x.toNat >>> s < 2 ^ w := by
     rw [Nat.shiftRight_eq_div_pow]
     exact Nat.lt_of_le_of_lt (Nat.div_le_self ..) x.isLt

--- a/src/Init/Data/Int/Bitwise/Lemmas.lean
+++ b/src/Init/Data/Int/Bitwise/Lemmas.lean
@@ -17,8 +17,8 @@ namespace Int
 
 theorem shiftRight_eq (n : Int) (s : Nat) : n >>> s = Int.shiftRight n s := rfl
 
-@[simp]
-theorem natCast_shiftRight (n s : Nat) : (n : Int) >>> s = n >>> s := rfl
+@[simp, norm_cast]
+theorem natCast_shiftRight (n s : Nat) : n >>> s = (n : Int) >>> s := rfl
 
 @[simp]
 theorem negSucc_shiftRight (m n : Nat) :
@@ -68,7 +68,7 @@ theorem shiftRight_le_of_nonneg {n : Int} {s : Nat} (h : 0 ≤ n) : n >>> s ≤ 
     by_cases hm : m = 0
     · simp [hm]
     · have := Nat.shiftRight_le m s
-      simp
+      rw [ofNat_eq_coe]
       omega
   case _ _ _ m =>
     omega
@@ -89,6 +89,14 @@ theorem shiftRight_le_of_nonpos {n : Int} {s : Nat} (h : n ≤ 0) : (n >>> s) �
     have rl : n / 2 ^ s ≤ 0 := Int.ediv_nonpos_of_nonpos_of_neg (by omega) (by norm_cast at *; omega)
     norm_cast at *
 
+@[simp, norm_cast]
+theorem natCast_shiftLeft (n s : Nat) : n <<< s = (n : Int) <<< s := rfl
+
+@[simp, grind =]
+theorem zero_shiftLeft (n : Nat) : (0 : Int) <<< n = 0 := by
+  change ((0 <<< n : Nat) : Int) = 0
+  simp
+
 @[simp, grind =]
 theorem shiftLeft_zero (n : Int) : n <<< 0 = n := by
   change Int.shiftLeft _ _ = _
@@ -100,13 +108,16 @@ theorem shiftLeft_succ (m : Int) (n : Nat) : m <<< (n + 1) = (m <<< n) * 2 := by
   change Int.shiftLeft _ _ = Int.shiftLeft _ _ * 2
   match m with
   | (m : Nat) =>
-    dsimp [Int.shiftLeft]
+    dsimp only [Int.shiftLeft, Int.ofNat_eq_coe]
     rw [Nat.shiftLeft_succ, Nat.mul_comm, natCast_mul, ofNat_two]
   | Int.negSucc m =>
-    dsimp [Int.shiftLeft]
+    dsimp only [Int.shiftLeft]
     rw [Nat.shiftLeft_succ, Nat.mul_comm, Int.negSucc_eq]
     have := Nat.le_shiftLeft (a := m + 1) (b := n)
     omega
+
+theorem shiftLeft_succ' (m : Int) (n : Nat) : m <<< (n + 1) = 2 * (m <<< n) := by
+  rw [shiftLeft_succ, Int.mul_comm]
 
 theorem shiftLeft_eq (a : Int) (b : Nat) : a <<< b = a * 2 ^ b := by
   induction b with
@@ -116,5 +127,56 @@ theorem shiftLeft_eq (a : Int) (b : Nat) : a <<< b = a * 2 ^ b := by
 
 theorem shiftLeft_eq' (a : Int) (b : Nat) : a <<< b = a * (2 ^ b : Nat) := by
   simp [shiftLeft_eq]
+
+theorem shiftLeft_add (a : Int) (b c : Nat) : a <<< (b + c) = a <<< b <<< c := by
+  simp [shiftLeft_eq, Int.pow_add, Int.mul_assoc]
+
+@[simp]
+theorem shiftLeft_shiftRight_cancel (a : Int) (b : Nat) : a <<< b >>> b = a := by
+  simp [shiftLeft_eq, shiftRight_eq_div_pow, mul_ediv_cancel _ (NeZero.ne _)]
+
+theorem shiftLeft_shiftRight_eq_shiftLeft_of_le {b c : Nat} (h : c ≤ b) (a : Int) :
+    a <<< b >>> c = a <<< (b - c) := by
+  obtain ⟨b, rfl⟩ := h.dest
+  simp [shiftLeft_eq, Int.pow_add, shiftRight_eq_div_pow, Int.mul_left_comm a,
+    Int.mul_ediv_cancel_left _ (NeZero.ne _)]
+
+theorem shiftLeft_shiftRight_eq_shiftRight_of_le {b c : Nat} (h : b ≤ c) (a : Int) :
+    a <<< b >>> c = a >>> (c - b) := by
+  obtain ⟨c, rfl⟩ := h.dest
+  simp [shiftRight_add]
+
+theorem shiftLeft_shiftRight_eq (a : Int) (b c : Nat) :
+    a <<< b >>> c = a <<< (b - c) >>> (c - b) := by
+  rcases Nat.le_total b c with h | h
+  · simp [shiftLeft_shiftRight_eq_shiftRight_of_le h, Nat.sub_eq_zero_of_le h]
+  · simp [shiftLeft_shiftRight_eq_shiftLeft_of_le h, Nat.sub_eq_zero_of_le h]
+
+@[simp]
+theorem shiftRight_shiftLeft_cancel {a : Int} {b : Nat} (h : 2 ^ b ∣ a) : a >>> b <<< b = a := by
+  simp [shiftLeft_eq, shiftRight_eq_div_pow, Int.ediv_mul_cancel h]
+
+theorem add_shiftLeft (a b : Int) (n : Nat) : (a + b) <<< n = a <<< n + b <<< n := by
+  simp [shiftLeft_eq, Int.add_mul]
+
+theorem neg_shiftLeft (a : Int) (n : Nat) : (-a) <<< n = -a <<< n := by
+  simp [Int.shiftLeft_eq, Int.neg_mul]
+
+theorem shiftLeft_mul (a b : Int) (n : Nat) : a <<< n * b = (a * b) <<< n := by
+  simp [shiftLeft_eq, Int.mul_right_comm]
+
+theorem mul_shiftLeft (a b : Int) (n : Nat) : a * b <<< n = (a * b) <<< n := by
+  simp [shiftLeft_eq, Int.mul_assoc]
+
+theorem shiftLeft_mul_shiftLeft (a b : Int) (m n : Nat) :
+    a <<< m * b <<< n = (a * b) <<< (m + n) := by
+  simp [shiftLeft_mul, mul_shiftLeft, shiftLeft_add]
+
+@[simp]
+theorem shiftLeft_eq_zero_iff {a : Int} {n : Nat} : a <<< n = 0 ↔ a = 0 := by
+  simp [shiftLeft_eq, Int.mul_eq_zero, NeZero.ne]
+
+instance {a : Int} {n : Nat} [NeZero a] : NeZero (a <<< n) :=
+  ⟨mt shiftLeft_eq_zero_iff.mp (NeZero.ne _)⟩
 
 end Int

--- a/src/Init/Data/Int/DivMod/Lemmas.lean
+++ b/src/Init/Data/Int/DivMod/Lemmas.lean
@@ -26,6 +26,10 @@ namespace Int
 
 @[simp high] theorem natCast_eq_zero {n : Nat} : (n : Int) = 0 ↔ n = 0 := by omega
 
+instance {n : Nat} [NeZero n] : NeZero (n : Int) := ⟨mt Int.natCast_eq_zero.mp (NeZero.ne _)⟩
+instance {n : Nat} [NeZero n] : NeZero (no_index (OfNat.ofNat n) : Int) :=
+  ⟨mt Int.natCast_eq_zero.mp (NeZero.ne _)⟩
+
 protected theorem exists_add_of_le {a b : Int} (h : a ≤ b) : ∃ (c : Nat), b = a + c :=
   ⟨(b - a).toNat, by omega⟩
 
@@ -1217,6 +1221,26 @@ theorem not_dvd_iff_lt_mul_succ (m : Int) (hn : 0 < n) :
     replace h2k := lt_of_mul_lt_mul_left h2k (by omega)
     rw [Int.lt_add_one_iff, ← Int.not_lt] at h2k
     exact h2k h1k
+
+private theorem ediv_ediv_of_pos {x y z : Int} (hy : 0 < y) (hz : 0 < z) :
+    x / y / z = x / (y * z) := by
+  rw [eq_comm, Int.ediv_eq_iff_of_pos (Int.mul_pos hy hz)]
+  constructor
+  · rw [Int.mul_comm y, ← Int.mul_assoc]
+    exact Int.le_trans
+      (Int.mul_le_mul_of_nonneg_right (Int.ediv_mul_le _ (Int.ne_of_gt hz)) (Int.le_of_lt hy))
+      (Int.ediv_mul_le x (Int.ne_of_gt hy))
+  · rw [Int.mul_comm y, ← Int.mul_assoc, ← Int.add_mul, Int.mul_comm _ z]
+    exact Int.lt_mul_of_ediv_lt hy (Int.lt_mul_ediv_self_add hz)
+
+theorem ediv_ediv {x y z : Int} (hy : 0 ≤ y) : x / y / z = x / (y * z) := by
+  rcases y with (_ | a) | a
+  · simp
+  · rcases z with (_ | b) | b
+    · simp
+    · simp [ediv_ediv_of_pos]
+    · simp [Int.negSucc_eq, Int.mul_neg, ediv_ediv_of_pos]
+  · simp at hy
 
 /-! ### tdiv -/
 

--- a/src/Init/Data/Int/Lemmas.lean
+++ b/src/Init/Data/Int/Lemmas.lean
@@ -566,6 +566,9 @@ protected theorem mul_eq_zero {a b : Int} : a * b = 0 ↔ a = 0 ∨ b = 0 := by
 protected theorem mul_ne_zero {a b : Int} (a0 : a ≠ 0) (b0 : b ≠ 0) : a * b ≠ 0 :=
   Or.rec a0 b0 ∘ Int.mul_eq_zero.mp
 
+instance {a b : Int} [NeZero a] [NeZero b] : NeZero (a * b) :=
+  ⟨Int.mul_ne_zero (NeZero.ne _) (NeZero.ne _)⟩
+
 @[simp] protected theorem mul_ne_zero_iff {a b : Int} : a * b ≠ 0 ↔ a ≠ 0 ∧ b ≠ 0 := by
   rw [ne_eq, Int.mul_eq_zero, not_or, ne_eq]
 

--- a/src/Init/Data/Int/Pow.lean
+++ b/src/Init/Data/Int/Pow.lean
@@ -48,6 +48,8 @@ protected theorem pow_ne_zero {n : Int} {m : Nat} : n ≠ 0 → n ^ m ≠ 0 := b
   | zero => simp
   | succ m ih => exact fun h => Int.mul_ne_zero (ih h) h
 
+instance {n : Int} {m : Nat} [NeZero n] : NeZero (n ^ m) := ⟨Int.pow_ne_zero (NeZero.ne _)⟩
+
 @[deprecated Nat.pow_le_pow_left (since := "2025-02-17")]
 abbrev pow_le_pow_of_le_left := @Nat.pow_le_pow_left
 

--- a/src/Init/Data/Nat/Bitwise/Lemmas.lean
+++ b/src/Init/Data/Nat/Bitwise/Lemmas.lean
@@ -845,6 +845,12 @@ theorem shiftLeft_add_eq_or_of_lt {b : Nat} (b_lt : b < 2^i) (a : Nat) :
   rw [shiftLeft_eq, Nat.mul_comm]
   rw [two_pow_add_eq_or_of_lt b_lt]
 
+@[simp]
+theorem shiftLeft_eq_zero_iff {a n : Nat} : a <<< n = 0 ↔ a = 0 := by
+  simp [shiftLeft_eq, mul_eq_zero]
+
+instance {a n : Nat} [NeZero a] : NeZero (a <<< n) := ⟨mt shiftLeft_eq_zero_iff.mp (NeZero.ne _)⟩
+
 /-! ### le -/
 
 theorem le_of_testBit {n m : Nat} (h : ∀ i, n.testBit i = true → m.testBit i = true) : n ≤ m := by


### PR DESCRIPTION
This PR contains lemmas about `Int` (minor amendments for BitVec and Nat) that are being used in preparing the dyadics. This is all work of @Rob23oba, which I'm pulling out of #9993 early to keep that one manageable.