### PR TITLE
feat: adds `rawIdent` parser alias

### DIFF
--- a/src/Lean/Parser.lean
+++ b/src/Lean/Parser.lean
@@ -34,6 +34,7 @@ builtin_initialize
   register_parser_alias (kind := nameLitKind) "name" nameLit
   register_parser_alias (kind := scientificLitKind) "scientific" scientificLit
   register_parser_alias (kind := identKind) ident
+  register_parser_alias (kind := identKind) rawIdent
   register_parser_alias (kind := hygieneInfoKind) hygieneInfo
   register_parser_alias "colGt" checkColGt { stackSz? := some 0 }
   register_parser_alias "colGe" checkColGe { stackSz? := some 0 }


### PR DESCRIPTION
This PR adds a parser alias for the `rawIdent` parser, so that it can be used in `syntax` declarations in `Init`.