### PR TITLE
fix: include `Lake.Load` in core build

### DIFF
--- a/src/lakefile.toml.in
+++ b/src/lakefile.toml.in
@@ -63,7 +63,7 @@ globs = [
   # Lake API imported by configuration files
   "Lake",
   # API only imported by `LakeMain` and the `lake` CLI
-  "Lake.CLI",
+  "Lake.CLI", "Lake.Load",
 ]
 libName = "${LAKE_LIB_PREFIX}Lake"
 defaultFacets = ["static", "static.export"]


### PR DESCRIPTION
This PR adds `Lake.Load` to core's Lake configuration to ensure it is built. With the module system port, it was no longer transitively imported.
