### PR TITLE
fix: include all of `Lake.Util` in core build

### DIFF
--- a/src/lakefile.toml.in
+++ b/src/lakefile.toml.in
@@ -64,6 +64,8 @@ globs = [
   "Lake",
   # API only imported by `LakeMain` and the `lake` CLI
   "Lake.CLI", "Lake.Load",
+  # Additional utilities which may not be imported
+  "Lake.Util.+",
 ]
 libName = "${LAKE_LIB_PREFIX}Lake"
 defaultFacets = ["static", "static.export"]


### PR DESCRIPTION
This PR adds the modules in `Lake.Util` to core's Lake configuration to ensure all utilities are built. With the module system port, they were no longer all transitively imported.

Specifically, `Lake.Util.Lock` is unused because Lake does not currently use a lock file for the build.
