### PR TITLE
chore: revert #10111

### DIFF
--- a/src/Lean/Server/FileWorker.lean
+++ b/src/Lean/Server/FileWorker.lean
@@ -464,7 +464,7 @@ section Initialization
     let processor ← Language.mkIncrementalProcessor processor
     let initSnap ← processor doc.mkInputContext
     let _ ← ServerTask.IO.asTask do
-      let importClosure := getImportClosure? initSnap
+      let importClosure ← IO.lazyPure fun _ => getImportClosure? initSnap
       let importClosure ← importClosure.filterMapM (documentUriFromModule? ·)
       chanOut.send <| mkImportClosureNotification importClosure
     let ctx := {


### PR DESCRIPTION
Identical to #10052. #10116 fixed the underlying cause of test flakiness, so this PR should hopefully be good-to-go now.