### PR TITLE
feat: add more `MonoBind` instances for monad transformers

### DIFF
--- a/src/Init/Internal/Order/Basic.lean
+++ b/src/Init/Internal/Order/Basic.lean
@@ -10,7 +10,13 @@ prelude
 public import Init.ByCases
 public import Init.RCases
 public import Init.Control.Except  -- for `MonoBind` instance
+public import Init.Control.StateRef  -- for `MonoBind` instance
+public import Init.Control.Option  -- for `MonoBind` instance
+public import Init.System.IO  -- for `MonoBind` instance
 import all Init.Control.Except  -- for `MonoBind` instance
+import all Init.Control.StateRef  -- for `MonoBind` instance
+import all Init.Control.Option  -- for `MonoBind` instance
+import all Init.System.IO  -- for `MonoBind` instance
 
 public section
 
@@ -790,14 +796,14 @@ on `m` is monotone in both arguments with regard to that order.
 This is intended to be used in the construction of `partial_fixpoint`, and not meant to be used otherwise.
 -/
 class MonoBind (m : Type u → Type v) [Bind m] [∀ α, PartialOrder (m α)] where
-  bind_mono_left {a₁ a₂ : m α} {f : α → m b} (h : a₁ ⊑ a₂) : a₁ >>= f ⊑ a₂ >>= f
-  bind_mono_right {a : m α} {f₁ f₂ : α → m b} (h : ∀ x, f₁ x ⊑ f₂ x) : a >>= f₁ ⊑ a >>= f₂
+  bind_mono_left {a₁ a₂ : m α} {f : α → m β} (h : a₁ ⊑ a₂) : a₁ >>= f ⊑ a₂ >>= f
+  bind_mono_right {a : m α} {f₁ f₂ : α → m β} (h : ∀ x, f₁ x ⊑ f₂ x) : a >>= f₁ ⊑ a >>= f₂
 
 @[partial_fixpoint_monotone]
 theorem monotone_bind
     (m : Type u → Type v) [Bind m] [∀ α, PartialOrder (m α)] [MonoBind m]
     {α β : Type u}
-    {γ : Type w} [PartialOrder γ]
+    {γ : Sort w} [PartialOrder γ]
     (f : γ → m α) (g : γ → α → m β)
     (hmono₁ : monotone f)
     (hmono₂ : monotone g) :
@@ -823,9 +829,9 @@ theorem Option.admissible_eq_some (P : Prop) (y : α) :
     admissible (fun (x : Option α) => x = some y → P) := by
   apply admissible_flatOrder; simp
 
-instance [Monad m] [inst : ∀ α, PartialOrder (m α)] : PartialOrder (ExceptT ε m α) := inst _
-instance [Monad m] [∀ α, PartialOrder (m α)] [inst : ∀ α, CCPO (m α)] : CCPO (ExceptT ε m α) := inst _
-instance [Monad m] [∀ α, PartialOrder (m α)] [∀ α, CCPO (m α)] [MonoBind m] : MonoBind (ExceptT ε m) where
+instance [inst : ∀ α, PartialOrder (m α)] : PartialOrder (ExceptT ε m α) := inst _
+instance [inst : ∀ α, CCPO (m α)] : CCPO (ExceptT ε m α) := inst _
+instance [Monad m] [∀ α, PartialOrder (m α)] [MonoBind m] : MonoBind (ExceptT ε m) where
   bind_mono_left h₁₂ := by
     apply MonoBind.bind_mono_left (m := m)
     exact h₁₂
@@ -835,6 +841,112 @@ instance [Monad m] [∀ α, PartialOrder (m α)] [∀ α, CCPO (m α)] [MonoBind
     cases x
     · apply PartialOrder.rel_refl
     · apply h₁₂
+
+@[partial_fixpoint_monotone]
+theorem monotone_exceptTRun [PartialOrder γ]
+    [Monad m] [∀ α, PartialOrder (m α)]
+    (f : γ → ExceptT ε m α) (hmono : monotone f) :
+    monotone (fun (x : γ) => ExceptT.run (f x)) :=
+  hmono
+
+instance [inst : ∀ α, PartialOrder (m α)] : PartialOrder (OptionT m α) := inst _
+instance [inst : ∀ α, CCPO (m α)] : CCPO (OptionT m α) := inst _
+instance [Monad m] [∀ α, PartialOrder (m α)] [MonoBind m] : MonoBind (OptionT m) where
+  bind_mono_left h₁₂ := by
+    apply MonoBind.bind_mono_left (m := m)
+    exact h₁₂
+  bind_mono_right h₁₂ := by
+    apply MonoBind.bind_mono_right (m := m)
+    intro x
+    cases x
+    · apply PartialOrder.rel_refl
+    · apply h₁₂
+
+@[partial_fixpoint_monotone]
+theorem monotone_optionTRun [PartialOrder γ]
+    [Monad m] [∀ α, PartialOrder (m α)]
+    (f : γ → OptionT m α) (hmono : monotone f) :
+    monotone (fun (x : γ) => OptionT.run (f x)) :=
+  hmono
+
+instance [inst : PartialOrder (m α)] : PartialOrder (ReaderT ρ m α) := instOrderPi
+instance [inst : CCPO (m α)] : CCPO (ReaderT ρ m α) := instCCPOPi
+instance [Monad m] [∀ α, PartialOrder (m α)] [MonoBind m] : MonoBind (ReaderT ρ m) where
+  bind_mono_left h₁₂ := by
+    intro x
+    apply MonoBind.bind_mono_left (m := m)
+    exact h₁₂ x
+  bind_mono_right h₁₂ := by
+    intro x
+    apply MonoBind.bind_mono_right (m := m)
+    intro y
+    apply h₁₂
+
+@[partial_fixpoint_monotone]
+theorem monotone_readerTRun [PartialOrder γ]
+    [Monad m] [PartialOrder (m α)]
+    (f : γ → ReaderT σ m α) (hmono : monotone f) (s : σ) :
+    monotone (fun (x : γ) => ReaderT.run (f x) s) :=
+  monotone_apply s _ hmono
+
+instance [inst : PartialOrder (m α)] : PartialOrder (StateRefT' ω σ m α) := instOrderPi
+instance [inst : CCPO (m α)] : CCPO (StateRefT' ω σ m α) := instCCPOPi
+instance [Monad m] [∀ α, PartialOrder (m α)] [MonoBind m] : MonoBind (StateRefT' ω σ m) :=
+  inferInstanceAs (MonoBind (ReaderT _ _))
+
+@[partial_fixpoint_monotone]
+theorem monotone_stateRefT'Run [PartialOrder γ]
+    [Monad m] [MonadLiftT (ST ω) m] [∀ α, PartialOrder (m α)] [MonoBind m]
+    (f : γ → StateRefT' ω σ m α) (hmono : monotone f) (s : σ) :
+    monotone (fun (x : γ) => StateRefT'.run (f x) s) := by
+  apply monotone_bind
+  · apply monotone_const
+  · refine monotone_of_monotone_apply _ fun ref => ?_
+    apply monotone_bind
+    · exact monotone_apply _ _ hmono
+    · apply monotone_const
+
+instance [inst : ∀ α, PartialOrder (m α)] : PartialOrder (StateT σ m α) := instOrderPi
+instance [inst : ∀ α, CCPO (m α)] : CCPO (StateT σ m α) := instCCPOPi
+instance [Monad m] [∀ α, PartialOrder (m α)] [MonoBind m] : MonoBind (StateT ρ m) where
+  bind_mono_left h₁₂ := by
+    intro x
+    apply MonoBind.bind_mono_left (m := m)
+    exact h₁₂ x
+  bind_mono_right h₁₂ := by
+    intro x
+    apply MonoBind.bind_mono_right (m := m)
+    intro y
+    apply h₁₂
+
+@[partial_fixpoint_monotone]
+theorem monotone_stateTRun [PartialOrder γ]
+    [Monad m] [∀ α, PartialOrder (m α)]
+    (f : γ → StateT σ m α) (hmono : monotone f) (s : σ) :
+    monotone (fun (x : γ) => StateT.run (f x) s) :=
+  monotone_apply s _ hmono
+
+-- TODO: axiomatize these instances (ideally without `Nonempty ε`) when EIO is opaque
+noncomputable instance [Nonempty ε] : CCPO (EIO ε α) :=
+  inferInstanceAs (CCPO ((s : _) → FlatOrder (.error Classical.ofNonempty (Classical.choice ⟨s⟩))))
+
+noncomputable instance [Nonempty ε] : MonoBind (EIO ε) where
+  bind_mono_left {_ _ a₁ a₂ f} h₁₂ := by
+    intro s
+    specialize h₁₂ s
+    change FlatOrder.rel (a₁.bind f s) (a₂.bind f s)
+    simp only [EStateM.bind]
+    generalize a₁ s = a₁ at h₁₂; generalize a₂ s = a₂ at h₁₂
+    cases h₁₂
+    · exact .bot
+    · exact .refl
+  bind_mono_right {_ _ a f₁ f₂} h₁₂ := by
+    intro w
+    change FlatOrder.rel (a.bind f₁ w) (a.bind f₂ w)
+    simp only [EStateM.bind]
+    split
+    · apply h₁₂
+    · exact .refl
 
 end mono_bind
 

--- a/tests/lean/run/partial_fixpoint_monadic.lean
+++ b/tests/lean/run/partial_fixpoint_monadic.lean
@@ -1,0 +1,65 @@
+/-!
+Testing `partial_fixpoint` with monad transformers
+-/
+
+/-!
+Using an `Option`-based monad
+-/
+
+abbrev M1 := ReaderT String (StateT String.Pos Option)
+
+def parseAll1 (x : M1 α) : M1 (List α) := do
+  if (← read).atEnd (← get) then
+    return []
+  let val ← x
+  let list ← parseAll1 x
+  return val :: list
+partial_fixpoint
+
+/--
+info: equations:
+theorem parseAll1.eq_1 : ∀ {α : Type} (x : M1 α),
+  parseAll1 x = do
+    let __do_lift ← read
+    let __do_lift_1 ← get
+    have __do_jp : PUnit → M1 (List α) := fun y => do
+      let val ← x
+      let list ← parseAll1 x
+      pure (val :: list)
+    if __do_lift.atEnd __do_lift_1 = true then pure []
+      else do
+        let y ← pure PUnit.unit
+        __do_jp y
+-/
+#guard_msgs in #print equations parseAll1
+
+/-!
+Using an `IO`-based monad
+-/
+
+abbrev M2 := ReaderT String (StateRefT String.Pos IO)
+
+def parseAll2 (x : M2 α) : M2 (List α) := do
+  if (← read).atEnd (← get) then
+    return []
+  let val ← x
+  let list ← parseAll2 x
+  return val :: list
+partial_fixpoint
+
+/--
+info: equations:
+theorem parseAll2.eq_1 : ∀ {α : Type} (x : M2 α),
+  parseAll2 x = do
+    let __do_lift ← read
+    let __do_lift_1 ← get
+    have __do_jp : PUnit → M2 (List α) := fun y => do
+      let val ← x
+      let list ← parseAll2 x
+      pure (val :: list)
+    if __do_lift.atEnd __do_lift_1 = true then pure []
+      else do
+        let y ← pure PUnit.unit
+        __do_jp y
+-/
+#guard_msgs in #print equations parseAll2


### PR DESCRIPTION
This PR adds `MonoBind` for more monad transformers. This allows using `partial_fixpoint` for more complicated monads based on `Option` and `EIO`. Example:
```lean-4
abbrev M := ReaderT String (StateT String.Pos Option)

def parseAll (x : M α) : M (List α) := do
  if (← read).atEnd (← get) then
    return []
  let val ← x
  let list ← parseAll x
  return val :: list
partial_fixpoint
```