### PR TITLE
chore: move omega internals to a namespace

### DIFF
--- a/src/Lean/Elab/Tactic/Omega/MinNatAbs.lean
+++ b/src/Lean/Elab/Tactic/Omega/MinNatAbs.lean
@@ -24,6 +24,9 @@ so we keep it in the `Lean/Elab/Tactic/Omega` directory
 
 -/
 
+open List
+
+namespace Lean.Elab.Tactic.Omega
 
 namespace List
 
@@ -37,22 +40,22 @@ def nonzeroMinimum (xs : List Nat) : Nat := xs.filter (· ≠ 0) |>.min? |>.getD
 
 open Classical in
 @[simp] theorem nonzeroMinimum_eq_zero_iff {xs : List Nat} :
-    xs.nonzeroMinimum = 0 ↔ ∀ x ∈ xs, x = 0 := by
+    nonzeroMinimum xs = 0 ↔ ∀ x ∈ xs, x = 0 := by
   simp [nonzeroMinimum, Option.getD_eq_iff, min?_eq_none_iff, min?_eq_some_iff,
     filter_eq_nil_iff, mem_filter]
 
-theorem nonzeroMinimum_mem {xs : List Nat} (w : xs.nonzeroMinimum ≠ 0) :
-    xs.nonzeroMinimum ∈ xs := by
+theorem nonzeroMinimum_mem {xs : List Nat} (w : nonzeroMinimum xs ≠ 0) :
+    nonzeroMinimum xs ∈ xs := by
   dsimp [nonzeroMinimum] at *
   generalize h : (xs.filter (· ≠ 0) |>.min?) = m at *
   match m, w with
   | some (m+1), _ => simp_all [min?_eq_some_iff, mem_filter]
 
-theorem nonzeroMinimum_pos {xs : List Nat} (m : a ∈ xs) (h : a ≠ 0) : 0 < xs.nonzeroMinimum :=
+theorem nonzeroMinimum_pos {xs : List Nat} (m : a ∈ xs) (h : a ≠ 0) : 0 < nonzeroMinimum xs :=
   Nat.pos_iff_ne_zero.mpr fun w => h (nonzeroMinimum_eq_zero_iff.mp w _ m)
 
-theorem nonzeroMinimum_le {xs : List Nat} (m : a ∈ xs) (h : a ≠ 0) : xs.nonzeroMinimum ≤ a := by
-  have : (xs.filter (· ≠ 0) |>.min?) = some xs.nonzeroMinimum := by
+theorem nonzeroMinimum_le {xs : List Nat} (m : a ∈ xs) (h : a ≠ 0) : nonzeroMinimum xs ≤ a := by
+  have : (xs.filter (· ≠ 0) |>.min?) = some (nonzeroMinimum xs) := by
     have w := nonzeroMinimum_pos m h
     dsimp [nonzeroMinimum] at *
     generalize h : (xs.filter (· ≠ 0) |>.min?) = m? at *
@@ -64,7 +67,7 @@ theorem nonzeroMinimum_le {xs : List Nat} (m : a ∈ xs) (h : a ≠ 0) : xs.nonz
   exact ⟨m, h⟩
 
 theorem nonzeroMinimum_eq_nonzero_iff {xs : List Nat} {y : Nat} (h : y ≠ 0) :
-    xs.nonzeroMinimum = y ↔ y ∈ xs ∧ (∀ x ∈ xs, y ≤ x ∨ x = 0) := by
+    nonzeroMinimum xs = y ↔ y ∈ xs ∧ (∀ x ∈ xs, y ≤ x ∨ x = 0) := by
   constructor
   · rintro rfl
     constructor
@@ -76,7 +79,7 @@ theorem nonzeroMinimum_eq_nonzero_iff {xs : List Nat} {y : Nat} (h : y ≠ 0) :
   · rintro ⟨m, w⟩
     apply Nat.le_antisymm
     · exact nonzeroMinimum_le m h
-    · have nz : xs.nonzeroMinimum ≠ 0 := by
+    · have nz : nonzeroMinimum xs ≠ 0 := by
         apply Nat.pos_iff_ne_zero.mp
         apply nonzeroMinimum_pos m h
       specialize w (nonzeroMinimum xs) (nonzeroMinimum_mem nz)
@@ -84,18 +87,18 @@ theorem nonzeroMinimum_eq_nonzero_iff {xs : List Nat} {y : Nat} (h : y ≠ 0) :
       | inl h => exact h
       | inr h => exact False.elim (nz h)
 
-theorem nonzeroMinimum_eq_of_nonzero {xs : List Nat} (h : xs.nonzeroMinimum ≠ 0) :
-    ∃ x ∈ xs, xs.nonzeroMinimum = x :=
-  ⟨xs.nonzeroMinimum, ((nonzeroMinimum_eq_nonzero_iff h).mp rfl).1, rfl⟩
+theorem nonzeroMinimum_eq_of_nonzero {xs : List Nat} (h : nonzeroMinimum xs ≠ 0) :
+    ∃ x ∈ xs, nonzeroMinimum xs = x :=
+  ⟨nonzeroMinimum xs, ((nonzeroMinimum_eq_nonzero_iff h).mp rfl).1, rfl⟩
 
 theorem nonzeroMinimum_le_iff {xs : List Nat} {y : Nat} :
-    xs.nonzeroMinimum ≤ y ↔ xs.nonzeroMinimum = 0 ∨ ∃ x ∈ xs, x ≤ y ∧ x ≠ 0 := by
+    nonzeroMinimum xs ≤ y ↔ nonzeroMinimum xs = 0 ∨ ∃ x ∈ xs, x ≤ y ∧ x ≠ 0 := by
   refine ⟨fun h => ?_, fun h => ?_⟩
   · rw [Classical.or_iff_not_imp_right]
     simp only [ne_eq, not_exists, not_and, Classical.not_not, nonzeroMinimum_eq_zero_iff]
     intro w
     apply nonzeroMinimum_eq_zero_iff.mp
-    if p : xs.nonzeroMinimum = 0 then
+    if p : nonzeroMinimum xs = 0 then
       exact p
     else
       exact w _ (nonzeroMinimum_mem p) h
@@ -106,9 +109,9 @@ theorem nonzeroMinimum_le_iff {xs : List Nat} {y : Nat} :
 theorem nonzeroMinimum_map_le_nonzeroMinimum (f : α → β) (p : α → Nat) (q : β → Nat) (xs : List α)
     (h : ∀ a, a ∈ xs → (p a = 0 ↔ q (f a) = 0))
     (w : ∀ a, a ∈ xs → p a ≠ 0 → q (f a) ≤ p a) :
-    ((xs.map f).map q).nonzeroMinimum ≤ (xs.map p).nonzeroMinimum := by
+    nonzeroMinimum ((xs.map f).map q) ≤ nonzeroMinimum (xs.map p) := by
   rw [nonzeroMinimum_le_iff]
-  if z : (xs.map p).nonzeroMinimum = 0 then
+  if z : nonzeroMinimum (xs.map p) = 0 then
     rw [nonzeroMinimum_eq_zero_iff]
     simp_all
   else
@@ -126,16 +129,20 @@ The minimum absolute value of a nonzero entry, or zero if all entries are zero.
 We completely characterize the function via
 `minNatAbs_eq_zero_iff` and `minNatAbs_eq_nonzero_iff` below.
 -/
-def minNatAbs (xs : List Int) : Nat := xs.map Int.natAbs |>.nonzeroMinimum
+def minNatAbs (xs : List Int) : Nat := xs.map Int.natAbs |> nonzeroMinimum
 
-@[simp] theorem minNatAbs_eq_zero_iff {xs : List Int} : xs.minNatAbs = 0 ↔ ∀ y ∈ xs, y = 0 := by
+@[simp] theorem minNatAbs_eq_zero_iff {xs : List Int} : minNatAbs xs = 0 ↔ ∀ y ∈ xs, y = 0 := by
   simp [minNatAbs]
 
 theorem minNatAbs_eq_nonzero_iff (xs : List Int) (w : z ≠ 0) :
-    xs.minNatAbs = z ↔ (∃ y ∈ xs, y.natAbs = z) ∧ (∀ y ∈ xs, z ≤ y.natAbs ∨ y = 0) := by
+    minNatAbs xs = z ↔ (∃ y ∈ xs, y.natAbs = z) ∧ (∀ y ∈ xs, z ≤ y.natAbs ∨ y = 0) := by
   simp [minNatAbs, nonzeroMinimum_eq_nonzero_iff w]
 
-@[simp] theorem minNatAbs_nil : ([] : List Int).minNatAbs = 0 := (rfl)
+@[simp] theorem minNatAbs_nil : minNatAbs ([] : List Int) = 0 := (rfl)
 
 /-- The maximum absolute value in a list of integers. -/
 def maxNatAbs (xs : List Int) : Nat := xs.map Int.natAbs |>.max? |>.getD 0
+
+end List
+
+end Lean.Elab.Tactic.Omega


### PR DESCRIPTION
This PR moves some internal implementation details of `omega` out of the `List` namespace. See [#mathlib4 > Naming: ne_zero vs nonzero @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Naming.3A.20ne_zero.20vs.20nonzero/near/537424328).