### PR TITLE
fix: use IR decls in `toIR` for applications without mono decls

### DIFF
--- a/src/Lean/Compiler/IR/ToIR.lean
+++ b/src/Lean/Compiler/IR/ToIR.lean
@@ -153,6 +153,8 @@ partial def lowerLet (decl : LCNF.LetDecl) (k : LCNF.Code) : M FnBody := do
       lowerCode k
   | .const name _ args =>
     let irArgs ← args.mapM lowerArg
+    if let some decl ← findDecl name then
+      return (← mkApplication name decl.params.size irArgs)
     if let some decl ← LCNF.getMonoDecl? name then
       return (← mkApplication name decl.params.size irArgs)
     let env ← Lean.getEnv

--- a/tests/lean/run/10181.lean
+++ b/tests/lean/run/10181.lean
@@ -1,0 +1,15 @@
+import Lean.CoreM
+
+open Lean Meta Core
+
+def asTask {α} (t : CoreM α) : CoreM (BaseIO Unit × Task (CoreM α)) := do
+  let task ← (t.toIO (← read) (← get)).asTask
+  return (IO.cancel task, task.map (prio := .max) fun
+  | .ok (a, s) => do set s; pure a
+  | .error e => throwError m!"Task failed:\n{e}")
+
+def asTask' {α} (t : CoreM α) : CoreM (Task (CoreM α)) := (·.2) <$> asTask t
+
+def f : CoreM Name := do
+  let t1 ← asTask' do mkFreshUserName `f
+  t1.get


### PR DESCRIPTION
This PR corrects a mistake in `toIR` where it could over-apply a function that has an IR decl but no mono decl.

Fixes #10181.