### PR TITLE
fix: textedit completions

### DIFF
--- a/src/Lean/Server/Completion/CompletionItemCompression.lean
+++ b/src/Lean/Server/Completion/CompletionItemCompression.lean
@@ -86,7 +86,7 @@ def compressItemFast (acc : String) (item : ResolvableCompletionItem) : String :
   if let some kind := item.kind? then
     acc := acc ++ ",\"kind\":" ++ (kind.ctorIdx + 1).repr
   if let some textEdit := item.textEdit? then
-    acc := acc ++ ",\"edit\":"
+    acc := acc ++ ",\"textEdit\":"
     acc := compressEditFast acc textEdit
   if let some sortText := item.sortText? then
     acc := acc ++ ",\"sortText\":"

--- a/tests/lean/interactive/completionOption.lean.expected.out
+++ b/tests/lean/interactive/completionOption.lean.expected.out
@@ -1,9 +1,7 @@
 {"textDocument": {"uri": "file:///completionOption.lean"},
  "position": {"line": 1, "character": 17}}
 {"items":
- [{"label": "format.unicode",
-   "kind": 10,
-   "edit":
+ [{"textEdit":
    {"replace":
     {"start": {"line": 1, "character": 11},
      "end": {"line": 1, "character": 17}},
@@ -11,11 +9,11 @@
     "insert":
     {"start": {"line": 1, "character": 11},
      "end": {"line": 1, "character": 17}}},
+   "label": "format.unicode",
+   "kind": 10,
    "detail": "(true), unicode characters",
    "data": ["«external:file:///completionOption.lean»", 1, 17, 0]},
-  {"label": "format.width",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 1, "character": 11},
      "end": {"line": 1, "character": 17}},
@@ -23,11 +21,11 @@
     "insert":
     {"start": {"line": 1, "character": 11},
      "end": {"line": 1, "character": 17}}},
+   "label": "format.width",
+   "kind": 10,
    "detail": "(120), indentation",
    "data": ["«external:file:///completionOption.lean»", 1, 17, 0]},
-  {"label": "format.inputWidth",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 1, "character": 11},
      "end": {"line": 1, "character": 17}},
@@ -35,11 +33,11 @@
     "insert":
     {"start": {"line": 1, "character": 11},
      "end": {"line": 1, "character": 17}}},
+   "label": "format.inputWidth",
+   "kind": 10,
    "detail": "(100), ideal input width",
    "data": ["«external:file:///completionOption.lean»", 1, 17, 0]},
-  {"label": "trace.PrettyPrinter.format.input",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 1, "character": 11},
      "end": {"line": 1, "character": 17}},
@@ -47,12 +45,12 @@
     "insert":
     {"start": {"line": 1, "character": 11},
      "end": {"line": 1, "character": 17}}},
+   "label": "trace.PrettyPrinter.format.input",
+   "kind": 10,
    "detail":
    "(false), enable/disable tracing for the given module and submodules",
    "data": ["«external:file:///completionOption.lean»", 1, 17, 0]},
-  {"label": "trace.PrettyPrinter.format",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 1, "character": 11},
      "end": {"line": 1, "character": 17}},
@@ -60,12 +58,12 @@
     "insert":
     {"start": {"line": 1, "character": 11},
      "end": {"line": 1, "character": 17}}},
+   "label": "trace.PrettyPrinter.format",
+   "kind": 10,
    "detail":
    "(false), enable/disable tracing for the given module and submodules",
    "data": ["«external:file:///completionOption.lean»", 1, 17, 0]},
-  {"label": "format.indent",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 1, "character": 11},
      "end": {"line": 1, "character": 17}},
@@ -73,11 +71,11 @@
     "insert":
     {"start": {"line": 1, "character": 11},
      "end": {"line": 1, "character": 17}}},
+   "label": "format.indent",
+   "kind": 10,
    "detail": "(2), indentation",
    "data": ["«external:file:///completionOption.lean»", 1, 17, 0]},
-  {"label": "trace.PrettyPrinter.format.backtrack",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 1, "character": 11},
      "end": {"line": 1, "character": 17}},
@@ -85,6 +83,8 @@
     "insert":
     {"start": {"line": 1, "character": 11},
      "end": {"line": 1, "character": 17}}},
+   "label": "trace.PrettyPrinter.format.backtrack",
+   "kind": 10,
    "detail":
    "(false), enable/disable tracing for the given module and submodules",
    "data": ["«external:file:///completionOption.lean»", 1, 17, 0]}],
@@ -92,9 +92,7 @@
 {"textDocument": {"uri": "file:///completionOption.lean"},
  "position": {"line": 4, "character": 20}}
 {"items":
- [{"label": "format.inputWidth",
-   "kind": 10,
-   "edit":
+ [{"textEdit":
    {"replace":
     {"start": {"line": 4, "character": 11},
      "end": {"line": 4, "character": 20}},
@@ -102,11 +100,11 @@
     "insert":
     {"start": {"line": 4, "character": 11},
      "end": {"line": 4, "character": 20}}},
+   "label": "format.inputWidth",
+   "kind": 10,
    "detail": "(100), ideal input width",
    "data": ["«external:file:///completionOption.lean»", 4, 20, 0]},
-  {"label": "trace.PrettyPrinter.format.input",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 4, "character": 11},
      "end": {"line": 4, "character": 20}},
@@ -114,12 +112,12 @@
     "insert":
     {"start": {"line": 4, "character": 11},
      "end": {"line": 4, "character": 20}}},
+   "label": "trace.PrettyPrinter.format.input",
+   "kind": 10,
    "detail":
    "(false), enable/disable tracing for the given module and submodules",
    "data": ["«external:file:///completionOption.lean»", 4, 20, 0]},
-  {"label": "format.indent",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 4, "character": 11},
      "end": {"line": 4, "character": 20}},
@@ -127,15 +125,15 @@
     "insert":
     {"start": {"line": 4, "character": 11},
      "end": {"line": 4, "character": 20}}},
+   "label": "format.indent",
+   "kind": 10,
    "detail": "(2), indentation",
    "data": ["«external:file:///completionOption.lean»", 4, 20, 0]}],
  "isIncomplete": false}
 {"textDocument": {"uri": "file:///completionOption.lean"},
  "position": {"line": 7, "character": 23}}
 {"items":
- [{"label": "trace.Compiler.specialize.candidate",
-   "kind": 10,
-   "edit":
+ [{"textEdit":
    {"replace":
     {"start": {"line": 7, "character": 11},
      "end": {"line": 7, "character": 23}},
@@ -143,12 +141,12 @@
     "insert":
     {"start": {"line": 7, "character": 11},
      "end": {"line": 7, "character": 23}}},
+   "label": "trace.Compiler.specialize.candidate",
+   "kind": 10,
    "detail":
    "(false), enable/disable tracing for the given module and submodules",
    "data": ["«external:file:///completionOption.lean»", 7, 23, 0]},
-  {"label": "trace.pp.analyze.error",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 7, "character": 11},
      "end": {"line": 7, "character": 23}},
@@ -156,12 +154,12 @@
     "insert":
     {"start": {"line": 7, "character": 11},
      "end": {"line": 7, "character": 23}}},
+   "label": "trace.pp.analyze.error",
+   "kind": 10,
    "detail":
    "(false), enable/disable tracing for the given module and submodules",
    "data": ["«external:file:///completionOption.lean»", 7, 23, 0]},
-  {"label": "trace.pp.analyze",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 7, "character": 11},
      "end": {"line": 7, "character": 23}},
@@ -169,12 +167,12 @@
     "insert":
     {"start": {"line": 7, "character": 11},
      "end": {"line": 7, "character": 23}}},
+   "label": "trace.pp.analyze",
+   "kind": 10,
    "detail":
    "(false), enable/disable tracing for the given module and submodules",
    "data": ["«external:file:///completionOption.lean»", 7, 23, 0]},
-  {"label": "trace.pp.analyze.tryUnify",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 7, "character": 11},
      "end": {"line": 7, "character": 23}},
@@ -182,12 +180,12 @@
     "insert":
     {"start": {"line": 7, "character": 11},
      "end": {"line": 7, "character": 23}}},
+   "label": "trace.pp.analyze.tryUnify",
+   "kind": 10,
    "detail":
    "(false), enable/disable tracing for the given module and submodules",
    "data": ["«external:file:///completionOption.lean»", 7, 23, 0]},
-  {"label": "trace.pp.analyze.annotate",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 7, "character": 11},
      "end": {"line": 7, "character": 23}},
@@ -195,6 +193,8 @@
     "insert":
     {"start": {"line": 7, "character": 11},
      "end": {"line": 7, "character": 23}}},
+   "label": "trace.pp.analyze.annotate",
+   "kind": 10,
    "detail":
    "(false), enable/disable tracing for the given module and submodules",
    "data": ["«external:file:///completionOption.lean»", 7, 23, 0]}],
@@ -202,9 +202,7 @@
 {"textDocument": {"uri": "file:///completionOption.lean"},
  "position": {"line": 10, "character": 27}}
 {"items":
- [{"label": "trace.pp.analyze.error",
-   "kind": 10,
-   "edit":
+ [{"textEdit":
    {"replace":
     {"start": {"line": 10, "character": 11},
      "end": {"line": 10, "character": 27}},
@@ -212,12 +210,12 @@
     "insert":
     {"start": {"line": 10, "character": 11},
      "end": {"line": 10, "character": 27}}},
+   "label": "trace.pp.analyze.error",
+   "kind": 10,
    "detail":
    "(false), enable/disable tracing for the given module and submodules",
    "data": ["«external:file:///completionOption.lean»", 10, 27, 0]},
-  {"label": "trace.pp.analyze",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 10, "character": 11},
      "end": {"line": 10, "character": 27}},
@@ -225,12 +223,12 @@
     "insert":
     {"start": {"line": 10, "character": 11},
      "end": {"line": 10, "character": 27}}},
+   "label": "trace.pp.analyze",
+   "kind": 10,
    "detail":
    "(false), enable/disable tracing for the given module and submodules",
    "data": ["«external:file:///completionOption.lean»", 10, 27, 0]},
-  {"label": "trace.pp.analyze.tryUnify",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 10, "character": 11},
      "end": {"line": 10, "character": 27}},
@@ -238,12 +236,12 @@
     "insert":
     {"start": {"line": 10, "character": 11},
      "end": {"line": 10, "character": 27}}},
+   "label": "trace.pp.analyze.tryUnify",
+   "kind": 10,
    "detail":
    "(false), enable/disable tracing for the given module and submodules",
    "data": ["«external:file:///completionOption.lean»", 10, 27, 0]},
-  {"label": "trace.pp.analyze.annotate",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 10, "character": 11},
      "end": {"line": 10, "character": 27}},
@@ -251,6 +249,8 @@
     "insert":
     {"start": {"line": 10, "character": 11},
      "end": {"line": 10, "character": 27}}},
+   "label": "trace.pp.analyze.annotate",
+   "kind": 10,
    "detail":
    "(false), enable/disable tracing for the given module and submodules",
    "data": ["«external:file:///completionOption.lean»", 10, 27, 0]}],
@@ -258,9 +258,7 @@
 {"textDocument": {"uri": "file:///completionOption.lean"},
  "position": {"line": 13, "character": 17}}
 {"items":
- [{"label": "format.unicode",
-   "kind": 10,
-   "edit":
+ [{"textEdit":
    {"replace":
     {"start": {"line": 13, "character": 11},
      "end": {"line": 13, "character": 17}},
@@ -268,11 +266,11 @@
     "insert":
     {"start": {"line": 13, "character": 11},
      "end": {"line": 13, "character": 17}}},
+   "label": "format.unicode",
+   "kind": 10,
    "detail": "(true), unicode characters",
    "data": ["«external:file:///completionOption.lean»", 13, 17, 0]},
-  {"label": "format.width",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 13, "character": 11},
      "end": {"line": 13, "character": 17}},
@@ -280,11 +278,11 @@
     "insert":
     {"start": {"line": 13, "character": 11},
      "end": {"line": 13, "character": 17}}},
+   "label": "format.width",
+   "kind": 10,
    "detail": "(120), indentation",
    "data": ["«external:file:///completionOption.lean»", 13, 17, 0]},
-  {"label": "format.inputWidth",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 13, "character": 11},
      "end": {"line": 13, "character": 17}},
@@ -292,11 +290,11 @@
     "insert":
     {"start": {"line": 13, "character": 11},
      "end": {"line": 13, "character": 17}}},
+   "label": "format.inputWidth",
+   "kind": 10,
    "detail": "(100), ideal input width",
    "data": ["«external:file:///completionOption.lean»", 13, 17, 0]},
-  {"label": "trace.PrettyPrinter.format.input",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 13, "character": 11},
      "end": {"line": 13, "character": 17}},
@@ -304,12 +302,12 @@
     "insert":
     {"start": {"line": 13, "character": 11},
      "end": {"line": 13, "character": 17}}},
+   "label": "trace.PrettyPrinter.format.input",
+   "kind": 10,
    "detail":
    "(false), enable/disable tracing for the given module and submodules",
    "data": ["«external:file:///completionOption.lean»", 13, 17, 0]},
-  {"label": "trace.PrettyPrinter.format",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 13, "character": 11},
      "end": {"line": 13, "character": 17}},
@@ -317,12 +315,12 @@
     "insert":
     {"start": {"line": 13, "character": 11},
      "end": {"line": 13, "character": 17}}},
+   "label": "trace.PrettyPrinter.format",
+   "kind": 10,
    "detail":
    "(false), enable/disable tracing for the given module and submodules",
    "data": ["«external:file:///completionOption.lean»", 13, 17, 0]},
-  {"label": "format.indent",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 13, "character": 11},
      "end": {"line": 13, "character": 17}},
@@ -330,11 +328,11 @@
     "insert":
     {"start": {"line": 13, "character": 11},
      "end": {"line": 13, "character": 17}}},
+   "label": "format.indent",
+   "kind": 10,
    "detail": "(2), indentation",
    "data": ["«external:file:///completionOption.lean»", 13, 17, 0]},
-  {"label": "trace.PrettyPrinter.format.backtrack",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 13, "character": 11},
      "end": {"line": 13, "character": 17}},
@@ -342,6 +340,8 @@
     "insert":
     {"start": {"line": 13, "character": 11},
      "end": {"line": 13, "character": 17}}},
+   "label": "trace.PrettyPrinter.format.backtrack",
+   "kind": 10,
    "detail":
    "(false), enable/disable tracing for the given module and submodules",
    "data": ["«external:file:///completionOption.lean»", 13, 17, 0]}],
@@ -349,9 +349,7 @@
 {"textDocument": {"uri": "file:///completionOption.lean"},
  "position": {"line": 16, "character": 18}}
 {"items":
- [{"label": "format.unicode",
-   "kind": 10,
-   "edit":
+ [{"textEdit":
    {"replace":
     {"start": {"line": 16, "character": 11},
      "end": {"line": 16, "character": 18}},
@@ -359,11 +357,11 @@
     "insert":
     {"start": {"line": 16, "character": 11},
      "end": {"line": 16, "character": 18}}},
+   "label": "format.unicode",
+   "kind": 10,
    "detail": "(true), unicode characters",
    "data": ["«external:file:///completionOption.lean»", 16, 18, 0]},
-  {"label": "format.width",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 16, "character": 11},
      "end": {"line": 16, "character": 18}},
@@ -371,11 +369,11 @@
     "insert":
     {"start": {"line": 16, "character": 11},
      "end": {"line": 16, "character": 18}}},
+   "label": "format.width",
+   "kind": 10,
    "detail": "(120), indentation",
    "data": ["«external:file:///completionOption.lean»", 16, 18, 0]},
-  {"label": "format.inputWidth",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 16, "character": 11},
      "end": {"line": 16, "character": 18}},
@@ -383,11 +381,11 @@
     "insert":
     {"start": {"line": 16, "character": 11},
      "end": {"line": 16, "character": 18}}},
+   "label": "format.inputWidth",
+   "kind": 10,
    "detail": "(100), ideal input width",
    "data": ["«external:file:///completionOption.lean»", 16, 18, 0]},
-  {"label": "trace.PrettyPrinter.format.input",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 16, "character": 11},
      "end": {"line": 16, "character": 18}},
@@ -395,12 +393,12 @@
     "insert":
     {"start": {"line": 16, "character": 11},
      "end": {"line": 16, "character": 18}}},
+   "label": "trace.PrettyPrinter.format.input",
+   "kind": 10,
    "detail":
    "(false), enable/disable tracing for the given module and submodules",
    "data": ["«external:file:///completionOption.lean»", 16, 18, 0]},
-  {"label": "format.indent",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 16, "character": 11},
      "end": {"line": 16, "character": 18}},
@@ -408,11 +406,11 @@
     "insert":
     {"start": {"line": 16, "character": 11},
      "end": {"line": 16, "character": 18}}},
+   "label": "format.indent",
+   "kind": 10,
    "detail": "(2), indentation",
    "data": ["«external:file:///completionOption.lean»", 16, 18, 0]},
-  {"label": "trace.PrettyPrinter.format.backtrack",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 16, "character": 11},
      "end": {"line": 16, "character": 18}},
@@ -420,6 +418,8 @@
     "insert":
     {"start": {"line": 16, "character": 11},
      "end": {"line": 16, "character": 18}}},
+   "label": "trace.PrettyPrinter.format.backtrack",
+   "kind": 10,
    "detail":
    "(false), enable/disable tracing for the given module and submodules",
    "data": ["«external:file:///completionOption.lean»", 16, 18, 0]}],

--- a/tests/lean/interactive/errorExplanationInteractive.lean.expected.out
+++ b/tests/lean/interactive/errorExplanationInteractive.lean.expected.out
@@ -1,9 +1,7 @@
 {"textDocument": {"uri": "file:///errorExplanationInteractive.lean"},
  "position": {"line": 28, "character": 30}}
 {"items":
- [{"label": "testPkg.foo2",
-   "kind": 10,
-   "edit":
+ [{"textEdit":
    {"replace":
     {"start": {"line": 28, "character": 23},
      "end": {"line": 28, "character": 30}},
@@ -11,12 +9,12 @@
     "insert":
     {"start": {"line": 28, "character": 23},
      "end": {"line": 28, "character": 30}}},
+   "label": "testPkg.foo2",
+   "kind": 10,
    "documentation": {"value": "(error) Error 2", "kind": "markdown"},
    "detail": "error name",
    "data": ["«external:file:///errorExplanationInteractive.lean»", 28, 30, 0]},
-  {"label": "testPkg.bar",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 28, "character": 23},
      "end": {"line": 28, "character": 30}},
@@ -24,12 +22,12 @@
     "insert":
     {"start": {"line": 28, "character": 23},
      "end": {"line": 28, "character": 30}}},
+   "label": "testPkg.bar",
+   "kind": 10,
    "documentation": {"value": "(error) Error 0", "kind": "markdown"},
    "detail": "error name",
    "data": ["«external:file:///errorExplanationInteractive.lean»", 28, 30, 0]},
-  {"label": "testPkg.foo1",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 28, "character": 23},
      "end": {"line": 28, "character": 30}},
@@ -37,6 +35,8 @@
     "insert":
     {"start": {"line": 28, "character": 23},
      "end": {"line": 28, "character": 30}}},
+   "label": "testPkg.foo1",
+   "kind": 10,
    "documentation": {"value": "(error) Error 1", "kind": "markdown"},
    "detail": "error name",
    "data": ["«external:file:///errorExplanationInteractive.lean»", 28, 30, 0]}],
@@ -44,9 +44,7 @@
 {"textDocument": {"uri": "file:///errorExplanationInteractive.lean"},
  "position": {"line": 30, "character": 31}}
 {"items":
- [{"label": "testPkg.foo2",
-   "kind": 10,
-   "edit":
+ [{"textEdit":
    {"replace":
     {"start": {"line": 30, "character": 23},
      "end": {"line": 30, "character": 31}},
@@ -54,12 +52,12 @@
     "insert":
     {"start": {"line": 30, "character": 23},
      "end": {"line": 30, "character": 31}}},
+   "label": "testPkg.foo2",
+   "kind": 10,
    "documentation": {"value": "(error) Error 2", "kind": "markdown"},
    "detail": "error name",
    "data": ["«external:file:///errorExplanationInteractive.lean»", 30, 31, 0]},
-  {"label": "testPkg.bar",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 30, "character": 23},
      "end": {"line": 30, "character": 31}},
@@ -67,12 +65,12 @@
     "insert":
     {"start": {"line": 30, "character": 23},
      "end": {"line": 30, "character": 31}}},
+   "label": "testPkg.bar",
+   "kind": 10,
    "documentation": {"value": "(error) Error 0", "kind": "markdown"},
    "detail": "error name",
    "data": ["«external:file:///errorExplanationInteractive.lean»", 30, 31, 0]},
-  {"label": "testPkg.foo1",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 30, "character": 23},
      "end": {"line": 30, "character": 31}},
@@ -80,6 +78,8 @@
     "insert":
     {"start": {"line": 30, "character": 23},
      "end": {"line": 30, "character": 31}}},
+   "label": "testPkg.foo1",
+   "kind": 10,
    "documentation": {"value": "(error) Error 1", "kind": "markdown"},
    "detail": "error name",
    "data": ["«external:file:///errorExplanationInteractive.lean»", 30, 31, 0]}],
@@ -87,9 +87,7 @@
 {"textDocument": {"uri": "file:///errorExplanationInteractive.lean"},
  "position": {"line": 32, "character": 32}}
 {"items":
- [{"label": "testPkg.foo2",
-   "kind": 10,
-   "edit":
+ [{"textEdit":
    {"replace":
     {"start": {"line": 32, "character": 23},
      "end": {"line": 32, "character": 32}},
@@ -97,12 +95,12 @@
     "insert":
     {"start": {"line": 32, "character": 23},
      "end": {"line": 32, "character": 32}}},
+   "label": "testPkg.foo2",
+   "kind": 10,
    "documentation": {"value": "(error) Error 2", "kind": "markdown"},
    "detail": "error name",
    "data": ["«external:file:///errorExplanationInteractive.lean»", 32, 32, 0]},
-  {"label": "testPkg.foo1",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 32, "character": 23},
      "end": {"line": 32, "character": 32}},
@@ -110,6 +108,8 @@
     "insert":
     {"start": {"line": 32, "character": 23},
      "end": {"line": 32, "character": 32}}},
+   "label": "testPkg.foo1",
+   "kind": 10,
    "documentation": {"value": "(error) Error 1", "kind": "markdown"},
    "detail": "error name",
    "data": ["«external:file:///errorExplanationInteractive.lean»", 32, 32, 0]}],
@@ -117,9 +117,7 @@
 {"textDocument": {"uri": "file:///errorExplanationInteractive.lean"},
  "position": {"line": 34, "character": 32}}
 {"items":
- [{"label": "testPkg.foo2",
-   "kind": 10,
-   "edit":
+ [{"textEdit":
    {"replace":
     {"start": {"line": 34, "character": 23},
      "end": {"line": 34, "character": 32}},
@@ -127,12 +125,12 @@
     "insert":
     {"start": {"line": 34, "character": 23},
      "end": {"line": 34, "character": 32}}},
+   "label": "testPkg.foo2",
+   "kind": 10,
    "documentation": {"value": "(error) Error 2", "kind": "markdown"},
    "detail": "error name",
    "data": ["«external:file:///errorExplanationInteractive.lean»", 34, 32, 0]},
-  {"label": "testPkg.foo1",
-   "kind": 10,
-   "edit":
+  {"textEdit":
    {"replace":
     {"start": {"line": 34, "character": 23},
      "end": {"line": 34, "character": 32}},
@@ -140,6 +138,8 @@
     "insert":
     {"start": {"line": 34, "character": 23},
      "end": {"line": 34, "character": 32}}},
+   "label": "testPkg.foo1",
+   "kind": 10,
    "documentation": {"value": "(error) Error 1", "kind": "markdown"},
    "detail": "error name",
    "data": ["«external:file:///errorExplanationInteractive.lean»", 34, 32, 0]}],


### PR DESCRIPTION
This PR fixes `textEdit`-based completions after they were accidentally broken by the new serialization procedure in #10249.