### PR TITLE
refactor: `grind linarith` as solver extension

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/Arith/Internalize.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Internalize.lean
@@ -17,6 +17,5 @@ namespace Lean.Meta.Grind.Arith
 def internalizeImpl (e : Expr) (parent? : Option Expr) : GoalM Unit := do
   Offset.internalize e parent?
   Cutsat.internalize e parent?
-  Linear.internalize e parent?
 
 end Lean.Meta.Grind.Arith

--- a/src/Lean/Meta/Tactic/Grind/Arith/Inv.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Inv.lean
@@ -8,7 +8,6 @@ module
 prelude
 public import Lean.Meta.Tactic.Grind.Arith.Offset
 public import Lean.Meta.Tactic.Grind.Arith.Cutsat.Inv
-public import Lean.Meta.Tactic.Grind.Arith.Linear.Inv
 
 public section
 
@@ -17,6 +16,5 @@ namespace Lean.Meta.Grind.Arith
 def checkInvariants : GoalM Unit := do
   Offset.checkInvariants
   Cutsat.checkInvariants
-  Linear.checkInvariants
 
 end Lean.Meta.Grind.Arith

--- a/src/Lean/Meta/Tactic/Grind/Arith/Linear.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Linear.lean
@@ -20,12 +20,12 @@ public import Lean.Meta.Tactic.Grind.Arith.Linear.PropagateEq
 public import Lean.Meta.Tactic.Grind.Arith.Linear.Internalize
 public import Lean.Meta.Tactic.Grind.Arith.Linear.Model
 public import Lean.Meta.Tactic.Grind.Arith.Linear.PP
+public import Lean.Meta.Tactic.Grind.Arith.Linear.Inv
 public import Lean.Meta.Tactic.Grind.Arith.Linear.MBTC
 public import Lean.Meta.Tactic.Grind.Arith.Linear.VarRename
 public import Lean.Meta.Tactic.Grind.Arith.Linear.OfNatModule
 public section
-namespace Lean
-
+namespace Lean.Meta.Grind.Arith.Linear
 builtin_initialize registerTraceClass `grind.linarith
 builtin_initialize registerTraceClass `grind.linarith.internalize
 builtin_initialize registerTraceClass `grind.linarith.assert
@@ -42,4 +42,13 @@ builtin_initialize registerTraceClass `grind.debug.linarith.search.split (inheri
 builtin_initialize registerTraceClass `grind.debug.linarith.search.backtrack (inherited := true)
 builtin_initialize registerTraceClass `grind.debug.linarith.subst
 
-end Lean
+builtin_initialize
+  linearExt.setMethods
+    (internalize := Linear.internalize)
+    (newEq       := Linear.processNewEq)
+    (newDiseq    := Linear.processNewDiseq)
+    (check       := Linear.check)
+    (checkInv    := Linear.checkInvariants)
+    (mbtc        := Linear.mbtc)
+
+end Lean.Meta.Grind.Arith.Linear

--- a/src/Lean/Meta/Tactic/Grind/Arith/Linear/Internalize.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Linear/Internalize.lean
@@ -92,11 +92,11 @@ def internalize (e : Expr) (parent? : Option Expr) : GoalM Unit := do
   if isForbiddenParent parent? then return ()
   if let some structId ← getStructId? type then LinearM.run structId do
     setTermStructId e
-    markAsLinarithTerm e
+    linearExt.markTerm e
     markVars e
   else if let some natStructId ← getNatStructId? type then OfNatModuleM.run natStructId do
     let (e', _) ← ofNatModule e
     trace[grind.linarith.internalize] "{e} ==> {e'}"
-    markAsLinarithTerm e
+    linearExt.markTerm e
 
 end Lean.Meta.Grind.Arith.Linear

--- a/src/Lean/Meta/Tactic/Grind/Arith/Linear/LinearM.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Linear/LinearM.lean
@@ -5,16 +5,16 @@ Authors: Leonardo de Moura
 -/
 module
 prelude
-public import Lean.Meta.Tactic.Grind.Types
+public import Lean.Meta.Tactic.Grind.Arith.Linear.Types
 public import Lean.Meta.Tactic.Grind.Arith.CommRing.RingM
 public section
 namespace Lean.Meta.Grind.Arith.Linear
 
 def get' : GoalM State := do
-  return (← get).arith.linear
+  linearExt.getState
 
 @[inline] def modify' (f : State → State) : GoalM Unit := do
-  modify fun s => { s with arith.linear := f s.arith.linear }
+  linearExt.modifyState f
 
 structure LinearM.Context where
   structId : Nat

--- a/src/Lean/Meta/Tactic/Grind/Arith/Linear/MBTC.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Linear/MBTC.lean
@@ -36,7 +36,7 @@ private def getAssignmentExt? (s : Struct) (a : Expr) : Option Rat := do
     toRatValue? a
 
 private def hasTheoryVar (e : Expr) : GoalM Bool := do
-  return (← getRootENode e).linarith?.isSome || (toRatValue? e).isSome
+  return (← linearExt.hasTerm e) || (toRatValue? e).isSome
 
 private def isInterpreted (e : Expr) : GoalM Bool := do
   if isInterpretedTerm e then return true
@@ -44,10 +44,10 @@ private def isInterpreted (e : Expr) : GoalM Bool := do
   return f.isConstOf ``LE.le || f.isConstOf ``LT.lt || f.isConstOf ``Dvd.dvd
 
 private def eqAssignment (a b : Expr) : GoalM Bool := do
-  let structId₁? := (← get).arith.linear.exprToStructId.find? { expr := a }
-  let structId₂? := (← get).arith.linear.exprToStructId.find? { expr := b }
+  let structId₁? := (← get').exprToStructId.find? { expr := a }
+  let structId₂? := (← get').exprToStructId.find? { expr := b }
   let some structId := structId₁? <|> structId₂? | return false
-  let s := (← get).arith.linear.structs[structId]!
+  let s := (← get').structs[structId]!
   -- It is pointless to generate case-splits unless we have support for disequality.
   unless s.isLinearInst?.isSome do return false
   let some v₁ := getAssignmentExt? s a | return false

--- a/src/Lean/Meta/Tactic/Grind/Arith/Linear/Model.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Linear/Model.lean
@@ -5,7 +5,7 @@ Authors: Leonardo de Moura
 -/
 module
 prelude
-public import Lean.Meta.Tactic.Grind.Types
+public import Lean.Meta.Tactic.Grind.Arith.Linear.Types
 import Lean.Meta.Tactic.Grind.Arith.ModelUtil
 import Init.Grind.Module.Envelope
 public section
@@ -34,7 +34,7 @@ It also assigns values to (integer) terms that have not been internalized by the
 -/
 def mkModel (goal : Goal) (structId : Nat) : MetaM (Array (Expr × Rat)) := do
   let mut model := {}
-  let s := goal.arith.linear.structs[structId]!
+  let s := (← linearExt.getStateCore goal).structs[structId]!
   -- Assign on expressions associated with cutsat terms or interpreted terms
   for e in goal.exprs do
     let node ← goal.getENode e

--- a/src/Lean/Meta/Tactic/Grind/Arith/Linear/OfNatModule.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Linear/OfNatModule.lean
@@ -73,7 +73,7 @@ private def mkOfNatModuleVar (e : Expr) : OfNatModuleM (Expr × Expr) := do
     let r := (toQe, h)
     modifyNatStruct fun s => { s with termMap := s.termMap.insert { expr := e } r }
     setTermNatStructId e
-    markAsLinarithTerm e
+    linearExt.markTerm e
     return r
 
 private def isAddInst (natStruct : NatStruct) (inst : Expr) : Bool :=

--- a/src/Lean/Meta/Tactic/Grind/Arith/Linear/PP.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Linear/PP.lean
@@ -5,7 +5,7 @@ Authors: Leonardo de Moura
 -/
 module
 prelude
-public import Lean.Meta.Tactic.Grind.Types
+public import Lean.Meta.Tactic.Grind.Arith.Linear.Types
 import Lean.Meta.Tactic.Grind.Arith.Linear.Model
 public section
 namespace Lean.Meta.Grind.Arith.Linear
@@ -20,7 +20,7 @@ def ppStruct? (goal : Goal) (s : Struct) : MetaM (Option MessageData) := do
 
 def pp? (goal : Goal) : MetaM (Option MessageData) := do
   let mut msgs := #[]
-  for struct in goal.arith.linear.structs do
+  for struct in (← linearExt.getStateCore goal).structs do
     let some msg ← ppStruct? goal struct | pure ()
     msgs := msgs.push msg
   if msgs.isEmpty then

--- a/src/Lean/Meta/Tactic/Grind/Arith/Linear/Types.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Linear/Types.lean
@@ -7,8 +7,7 @@ module
 prelude
 public import Init.Grind.Ring.Poly
 public import Init.Grind.Ordered.Linarith
-public import Lean.Data.PersistentArray
-public import Lean.Meta.Tactic.Grind.ExprPtr
+public import Lean.Meta.Tactic.Grind.Types
 public import Init.Data.Rat.Basic
 public section
 namespace Lean.Meta.Grind.Arith.Linear
@@ -259,5 +258,7 @@ structure State where
   /- Mapping from expressions/terms to their nat structure ids. -/
   exprToNatStructId : PHashMap ExprPtr Nat := {}
   deriving Inhabited
+
+builtin_initialize linearExt : SolverExtension State ← registerSolverExtension (return {})
 
 end Lean.Meta.Grind.Arith.Linear

--- a/src/Lean/Meta/Tactic/Grind/Arith/Linear/Var.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Linear/Var.lean
@@ -26,7 +26,7 @@ def mkVar (e : Expr) (mark := true) : LinearM Var := do
   }
   setTermStructId e
   if mark then
-    markAsLinarithTerm e
+    linearExt.markTerm e
   return var
 
 end Lean.Meta.Grind.Arith.Linear

--- a/src/Lean/Meta/Tactic/Grind/Arith/Main.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Main.lean
@@ -53,8 +53,7 @@ builtin_grind_propagator propagateLT ↓LT.lt := fun e => do
 
 def check : GoalM Bool := do
   let c₁ ← Cutsat.check
-  let c₃ ← Linear.check
-  if c₁ || c₃ then
+  if c₁ then
     processNewFacts
     return true
   else

--- a/src/Lean/Meta/Tactic/Grind/Arith/Types.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Types.lean
@@ -7,7 +7,6 @@ module
 prelude
 public import Lean.Meta.Tactic.Grind.Arith.Offset.Types
 public import Lean.Meta.Tactic.Grind.Arith.Cutsat.Types
-public import Lean.Meta.Tactic.Grind.Arith.Linear.Types
 public section
 namespace Lean.Meta.Grind.Arith
 
@@ -15,7 +14,6 @@ namespace Lean.Meta.Grind.Arith
 structure State where
   offset : Offset.State := {}
   cutsat : Cutsat.State := {}
-  linear : Linear.State := {}
   deriving Inhabited
 
 end Lean.Meta.Grind.Arith

--- a/src/Lean/Meta/Tactic/Grind/Propagate.lean
+++ b/src/Lean/Meta/Tactic/Grind/Propagate.lean
@@ -184,7 +184,6 @@ builtin_grind_propagator propagateEqDown ↓Eq := fun e => do
     if α.isConstOf ``Bool then
       propagateBoolDiseq e lhs rhs
     propagateCutsatDiseq lhs rhs
-    propagateLinarithDiseq lhs rhs
     Solvers.propagateDiseqs lhs rhs
     let thms ← getExtTheorems α
     if !thms.isEmpty then


### PR DESCRIPTION
This PR uses the new solver extension framework to implement `grind linarith`.