### PR TITLE
fix: mark doc parser tests as eol=lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,9 @@ RELEASES.md merge=union
 stage0/** binary linguist-generated
 # The following file is often manually edited, so do show it in diffs
 stage0/src/stdlib_flags.h -binary -linguist-generated
+# These files should not have line endings translated on Windows, because
+# it throws off parser tests. Later lines override earlier ones, so the
+# runner code is still treated as ordinary text.
+tests/lean/docparse/* eol=lf
+tests/lean/docparse/*.lean eol=auto
+tests/lean/docparse/*.sh eol=auto


### PR DESCRIPTION
This PR sets the eol Git attribute on docstring parser tests. This is to stop them from failing on Windows due to line ending translation.
