### PR TITLE
perf: implement jumping to native `[export]` decls in the interpreter

### DIFF
--- a/src/Lean/Compiler/ExportAttr.lean
+++ b/src/Lean/Compiler/ExportAttr.lean
@@ -62,6 +62,7 @@ builtin_initialize exportAttr : ParametricAttribute Name ←
       return exportName
   }
 
+@[export lean_get_export_name_for]
 def getExportNameFor? (env : Environment) (n : Name) : Option Name :=
   exportAttr.getParam? env n
 


### PR DESCRIPTION
This PR allows the interpreter to jump to native code of `[export]` declarations, which can increase performance as well as the effectiveness of `interpreter.prefer_native=true` during bootstrapping.