### PR TITLE
fix: restore monad-polymorphism to some docstring functions

### DIFF
--- a/src/Lean/DocString/Add.lean
+++ b/src/Lean/DocString/Add.lean
@@ -34,8 +34,9 @@ This is intended to be used before saving a docstring that is later subject to r
 `rewriteManualLinks`.
 -/
 def validateDocComment
+    [Monad m] [MonadLiftT IO m] [MonadLog m] [AddMessageContext m] [MonadOptions m]
     (docstring : TSyntax `Lean.Parser.Command.docComment) :
-    TermElabM Unit := do
+    m Unit := do
   let str := docstring.getDocString
   let pos? := docstring.raw[1].getHeadInfo? >>= (·.getPos?)
 
@@ -55,6 +56,12 @@ open Parser in
 /--
 Adds a Verso docstring to the specified declaration, which should already be present in the
 environment.
+
+`binders` should be the syntax of the parameters to the constant that is being documented, as a null
+node that contains a sequence of bracketed binders. It is used to allow interactive features such as
+document highlights and “find references” to work for documented parameters. If no parameter binders
+are available, pass `Syntax.missing` or an empty null node.
+
 -/
 def versoDocString
     (declName : Name) (binders : Syntax) (docComment : TSyntax `Lean.Parser.Command.docComment) :
@@ -105,14 +112,16 @@ def versoDocString
 /--
 Adds a Markdown docstring to the environment, validating documentation links.
 -/
-def addMarkdownDocString (declName : Name) (docComment : TSyntax `Lean.Parser.Command.docComment) : TermElabM Unit := do
+def addMarkdownDocString
+    [Monad m] [MonadLiftT IO m] [MonadOptions m] [MonadEnv m]
+    [MonadError m] [MonadLog m] [AddMessageContext m]
+    (declName : Name) (docComment : TSyntax `Lean.Parser.Command.docComment) :
+    m Unit := do
   if declName.isAnonymous then
     -- This case might happen on partial elaboration; ignore instead of triggering any panics below
     return
-  let throwImported {α} : TermElabM α :=
-    throwError m!"invalid doc string, declaration `{.ofConstName declName}` is in an imported module"
   unless (← getEnv).getModuleIdxFor? declName |>.isNone do
-    throwImported
+    throwError m!"invalid doc string, declaration `{.ofConstName declName}` is in an imported module"
   validateDocComment docComment
   let docString : String ← getDocStringText docComment
   modifyEnv fun env => docStringExt.insert env declName docString.removeLeadingSpaces
@@ -127,13 +136,19 @@ def addVersoDocStringCore [Monad m] [MonadEnv m] [MonadLiftT BaseIO m] [MonadErr
   unless (← getEnv).getModuleIdxFor? declName |>.isNone do
     throwImported
   modifyEnv fun env =>
-    versoDocStringExt.insert env declName docs --addEntry (asyncMode := .async .asyncEnv)
-      --env (declName, p) -- Using .insert env declName ⟨blocks, parts⟩ leads to panics
+    versoDocStringExt.insert env declName docs
 
 /--
 Adds a Verso docstring to the environment.
+
+`binders` should be the syntax of the parameters to the constant that is being documented, as a null
+node that contains a sequence of bracketed binders. It is used to allow interactive features such as
+document highlights and “find references” to work for documented parameters. If no parameter binders
+are available, pass `Syntax.missing` or an empty null node.
 -/
-def addVersoDocString (declName : Name) (binders : Syntax) (docComment : TSyntax `Lean.Parser.Command.docComment) : TermElabM Unit := do
+def addVersoDocString
+    (declName : Name) (binders : Syntax) (docComment : TSyntax `Lean.Parser.Command.docComment) :
+    TermElabM Unit := do
   unless (← getEnv).getModuleIdxFor? declName |>.isNone do
     throwError s!"invalid doc string, declaration '{declName}' is in an imported module"
   let (blocks, parts) ← versoDocString declName binders docComment
@@ -144,7 +159,8 @@ Adds a docstring to the environment. If `isVerso` is `false`, then the docstring
 Markdown.
 -/
 def addDocStringOf
-    (isVerso : Bool) (declName : Name) (binders : Syntax) (docComment : TSyntax `Lean.Parser.Command.docComment) :
+    (isVerso : Bool) (declName : Name) (binders : Syntax)
+    (docComment : TSyntax `Lean.Parser.Command.docComment) :
     TermElabM Unit := do
   if isVerso then
     addVersoDocString declName binders docComment
@@ -154,9 +170,15 @@ def addDocStringOf
 /--
 Adds a docstring to the environment.
 
-If the option `doc.verso` is `true`, the docstring is processed as a Verso docstring.
+If the option `doc.verso` is `true`, the docstring is processed as a Verso docstring. Otherwise, it
+is considered a Markdown docstring, and documentation links are validated. To explicitly control
+whether the docstring is in Verso format, use `addDocStringOf` instead.
 
-Otherwise, it is considered a Markdown docstring, and documentation links are validated.
+For Verso docstrings, `binders` should be the syntax of the parameters to the constant that is being
+documented, as a null node that contains a sequence of bracketed binders. It is used to allow
+interactive features such as document highlights and “find references” to work for documented
+parameters. If no parameter binders are available, pass `Syntax.missing` or an empty null node.
+`binders` is not used for Markdown docstrings.
 -/
 def addDocString
     (declName : Name) (binders : Syntax) (docComment : TSyntax `Lean.Parser.Command.docComment) :
@@ -167,9 +189,16 @@ def addDocString
 Adds a docstring to the environment, if it is provided. If no docstring is provided, nothing
 happens.
 
-If the option `doc.verso` is `true`, the docstring is processed as a Verso docstring.
+If the option `doc.verso` is `true`, the docstring is processed as a Verso docstring. Otherwise, it
+is considered a Markdown docstring, and documentation links are validated. To explicitly control
+whether the docstring is in Verso format, use `addDocStringOf` instead.
 
-Otherwise, it is considered a Markdown docstring, and documentation links are validated.
+For Verso docstrings, `binders` should be the syntax of the parameters to the constant that is being
+documented, as a null node that contains a sequence of bracketed binders. It is used to allow
+interactive features such as document highlights and “find references” to work for documented
+parameters. If no parameter binders are available, pass `Syntax.missing` or an empty null node.
+`binders` is not used for Markdown docstrings.
+
 -/
 def addDocString'
     (declName : Name) (binders : Syntax) (docString? : Option (TSyntax `Lean.Parser.Command.docComment)) :

--- a/src/Lean/Elab/DeclModifiers.lean
+++ b/src/Lean/Elab/DeclModifiers.lean
@@ -85,6 +85,9 @@ inductive ComputeKind where
 structure Modifiers where
   /-- Input syntax, used for adjusting declaration range (unless missing) -/
   stx             : TSyntax ``Parser.Command.declModifiers := ⟨.missing⟩
+  /--
+  The docstring, if present, and whether it's Verso.
+  -/
   docString?      : Option (TSyntax ``Parser.Command.docComment × Bool) := none
   visibility      : Visibility := Visibility.regular
   isProtected     : Bool := false


### PR DESCRIPTION
This PR makes the Markdown docstring functions monad-polymorphic again, and improves documentation for the internal docstring API.