### PR TITLE
feat: custom evaluators for tactic configuration

### DIFF
--- a/src/Lean/Elab/Tactic/Config.lean
+++ b/src/Lean/Elab/Tactic/Config.lean
@@ -9,6 +9,7 @@ prelude
 public import Lean.Meta.Eval
 public import Lean.Elab.Tactic.Basic
 public import Lean.Elab.SyntheticMVars
+public import Lean.Elab.Command
 import Lean.Linter.MissingDocs
 meta import Lean.Parser.Tactic
 
@@ -16,6 +17,14 @@ public section
 
 namespace Lean.Elab.Tactic
 open Meta Parser.Tactic Command
+
+builtin_initialize
+  registerTraceClass `Elab.tacticConfig
+
+register_builtin_option debug.Elab.tacticConfig.forceEval : Bool := {
+  defValue := false
+  descr    := "force using the compiler to evaluate tactic configurations"
+}
 
 structure ConfigItemView where
   ref : Syntax
@@ -117,7 +126,161 @@ def elabConfig (recover : Bool) (structName : Name) (items : Array ConfigItemVie
           throw ex
     let stx : Term ← mkStructInst source? fields
     let e ← Term.withSynthesize <| Term.elabTermEnsuringType stx (mkConst structName)
-    instantiateMVars e
+    let e ← instantiateMVars e
+    if e.hasMVar then
+      throwError "Failed to evaluate configuration, it contains metavariables{indentExpr e}"
+    return e
+
+namespace EvalConfig
+/-!
+Configuration evaluation happens very frequently, and our default method is to use `Meta.evalExpr'`
+to turn the `Expr` representing the elaborated configuration into a run time value.
+
+That means hitting the compiler very frequently. To avoid this, we make a best-effort custom evaluator
+that recognizes configurations, using reduction if needed. If it comes across anything it does not recognize,
+it aborts and we fall back to `Meta.evalExpr'`.
+
+In the following evaluators, we do not validate expressions have the expected type.
+
+These functions are similar to those in `Lean.Meta.LitValues`, but the evaluators here do reductions.
+-/
+
+/--
+Evaluates `f` on both `e` and `whnf e`.
+-/
+@[inline] private def evalHelper {α : Type} (f : Expr → MetaM α) (e : Expr) : MetaM α := do
+  try
+    f e
+  catch _ =>
+    f (← whnf e)
+
+/-- Recognizes a boolean constant. -/
+def evalBool : Expr → MetaM Bool :=
+  evalHelper fun e =>
+    if e.isConstOf ``Bool.true then return true
+    else if e.isConstOf ``Bool.false then return false
+    else failure
+
+/-- Recognizes a natural number constant. -/
+def evalNat : Expr → MetaM Nat :=
+  evalHelper fun e => (e.nat? <|> e.rawNatLit?).getM
+
+/-- Recognizes an integer constant. -/
+def evalInt : Expr → MetaM Int :=
+  evalHelper fun e =>
+    e.int?.getM <|> do
+      if e.isAppOfArity ``Int.ofNat 1 then
+        Int.ofNat <$> evalNat e.appArg!
+      else if e.isAppOfArity ``Int.negSucc 1 then
+        Int.negSucc <$> evalNat e.appArg!
+      else
+        failure
+
+/-- If `e` is not a constant application of one of the given constants, put it into whnf. -/
+def whnfHelper (e : Expr) (consts : List Name) : MetaM Expr := do
+  if let .const c _ := e.getAppFn then
+    if consts.contains c then
+      return e
+  whnf e
+
+/-- Recognizes a list of constants, each recognized by `f`. -/
+def evalList {α : Type} (f : Expr → MetaM α) (e : Expr) : MetaM (List α) := do
+  let mut xsRev : List α := []
+  let mut e := e
+  repeat
+    e ← whnfHelper e [``List.nil, ``List.cons]
+    match_expr e with
+    | List.nil _ => break
+    | List.cons _ a as =>
+      xsRev := (← f a) :: xsRev
+      e := as
+    | _ => failure
+  return xsRev.reverse
+
+/--
+Recognizes an array of constants, each recognized by `f`.
+-/
+def evalArray {α : Type} (f : Expr → MetaM α) (e : Expr) : MetaM (Array α) := do
+  let_expr Array.mk _ e' := (← whnf e) | failure
+  List.toArray <$> evalList f e'
+
+private def evalSuffix := `_evalForConfig
+
+mutual
+/--
+Creates an evaluator for the inductive type, as a private declaration.
+Only non-recursive types with no parameters or indices are supported right now;
+this covers most tactic configurations.
+-/
+private partial def deriveEval (tyName : Name) : CommandElabM Name :=
+  withoutExporting <| withFreshMacroScope do
+    if isPrivateName tyName then
+      throwError "For `{.ofConstName tyName}`: Deriving evaluators for private types is not supported"
+    let evalName := mkPrivateName (← getEnv) (tyName ++ evalSuffix)
+    if (← getEnv).contains evalName then
+      -- An evaluator already exists
+      return evalName
+    let indVal ← getConstInfoInduct tyName
+    if indVal.all.length > 1 || indVal.isNested || indVal.isRec then
+      throwError "For `{.ofConstName tyName}`: Recursive, nested, and mutually recursive inductive types are not supported yet"
+    if indVal.numParams > 0 || indVal.numIndices > 0 then
+      throwError "For `{.ofConstName tyName}`: Parameters and indices are not supported yet"
+    if indVal.levelParams.length > 0 then
+      throwError "For `{.ofConstName tyName}`: Universe polymorphism is not supported"
+    let mkCmd : TermElabM Command := do
+      let mut alts : TSyntaxArray ``Parser.Term.matchAltExpr := #[]
+      for ctor in indVal.ctors do
+        let alt ← forallTelescopeReducing (← inferType (.const ctor [])) fun xs _ => do
+          let xs' ← xs.mapM (fun x => do mkIdent <$> mkFreshUserName (← x.fvarId!.getUserName))
+          let ctorPatt ← xs'.foldlM (init := ← ``(Expr.const $(quote ctor) _))
+            fun p x' => ``(Expr.app $p $x')
+          let vs : Array Term ← (xs.zip xs').mapM fun (x, x') => do
+            let f ← deriveEvalFor (← inferType x)
+            `($f $x')
+          let vs' : Array Term ← vs.mapM fun v => `(← $v)
+          let ctorVal ← `(return @$(mkCIdent ctor) $vs'*)
+          `(Parser.Term.matchAltExpr| | $ctorPatt => $ctorVal )
+        alts := alts.push alt
+      alts := alts.push <| ← `(Parser.Term.matchAltExpr| | _ => failure)
+      let evalId := mkIdent (rootNamespace ++ privateToUserName evalName)
+      let evalType ← ``(Expr → MetaM $(mkCIdent tyName))
+      let me ← `(match e with $alts:matchAlt*)
+      `(command|
+          private def $evalId : $evalType := fun e => do
+            let e ← $(mkCIdent ``whnfHelper):ident e $(quote indVal.ctors)
+            $me:term)
+    let cmd ← liftTermElabM mkCmd
+    elabCommand cmd
+    return evalName
+
+/--
+Try to derive an evaluator for the given expression.
+-/
+private partial def deriveEvalFor (e : Expr) : TermElabM Term := do
+  trace[Elab.tacticConfig] "deriving for {e}"
+  let e ← whnf e
+  match_expr e with
+  | Nat => ``(evalNat)
+  | Int => ``(evalInt)
+  | Bool => ``(evalBool)
+  | List t => let f ← deriveEvalFor t; ``(evalList $f)
+  | Array t => let f ← deriveEvalFor t; ``(evalArray $f)
+  | _ =>
+    let .const tyName' [] ← whnf e | throwError "Cannot derive evaluator for non-constant{indentExpr e}"
+    let f ← liftCommandElabM <| deriveEval tyName'
+    return mkCIdent f
+
+end
+
+private def mkEval? (typeName : Name) : CommandElabM (Option Term) := do
+  try pure <| some <| mkCIdent (← EvalConfig.deriveEval typeName)
+  catch ex =>
+    trace[Elab.tacticConfig] "Failed to create a custom evaluator for `{.ofConstName typeName}`. Error: {ex.toMessageData}"
+    pure none
+
+end EvalConfig
+
+open scoped EvalConfig
 
 section
 -- We automatically disable the following option for `macro`s but the subsequent `def` both contains
@@ -128,10 +291,15 @@ set_option internal.parseQuotWithCurrentStage false
 
 private def mkConfigElaborator
     (doc? : Option (TSyntax ``Parser.Command.docComment)) (elabName type monadName : Ident)
-    (adapt recover : Term) : MacroM (TSyntax `command) := do
+    (adapt recover : Term) (eval? : Option Term) : MacroM (TSyntax `command) := do
   let empty ← withRef type `({ : $type})
-  `(unsafe def evalUnsafe (e : Expr) : TermElabM $type :=
-      Meta.evalExpr' (safety := .unsafe) $type ``$type e
+  let mut evalExpr ← `(Meta.evalExpr' (safety := .unsafe) $type ``$type e)
+  if let some ev := eval? then
+    let ev' ← `(guard (!debug.Elab.tacticConfig.forceEval.get (← getOptions)) *> $ev e)
+    evalExpr ← `($ev' <|> do trace[Elab.tacticConfig] "Using compiler to evaluate{indentExpr e}"; $evalExpr:term)
+  `(unsafe def evalUnsafe (e : Expr) : TermElabM $type := do
+      profileitM Exception "tactic configuration interpretation" (← getOptions) do
+        ($evalExpr:term : MetaM $type)
     @[implemented_by evalUnsafe] opaque eval (e : Expr) : TermElabM $type
     $[$doc?:docComment]?
     def $elabName (optConfig : Syntax) : $monadName $type := $adapt do
@@ -162,6 +330,18 @@ private def mkConfigElaborator
 
 end
 
+open Parser Parser.Command
+
+@[builtin_command_elab configElab]
+def elabConfigElab : CommandElab := fun stx => do
+  let doc? : Option (TSyntax ``docComment) := TSyntax.mk <$> stx[0].getOptional?
+  let elabName : Ident := ⟨stx[2]⟩
+  let type : Ident := ⟨stx[3]⟩
+  let typeName ← liftCoreM <| realizeGlobalConstNoOverloadWithInfo type
+  let eval? ← EvalConfig.mkEval? typeName
+  elabCommand <| ← liftMacroM <| mkConfigElaborator doc? elabName type (mkCIdent ``TacticM) (mkCIdent ``id) (← `((← read).recover)) eval?
+
+-- TODO(kmill): remove
 /-!
 `declare_config_elab elabName TypeName` declares a function `elabName : Syntax → TacticM TypeName`
 that elaborates a tactic configuration.
@@ -172,13 +352,23 @@ The elaborator responds to the current recovery state.
 
 For defining elaborators for commands, use `declare_command_config_elab`.
 -/
-macro (name := configElab) doc?:(docComment)? "declare_config_elab" elabName:ident type:ident : command => do
-  mkConfigElaborator doc? elabName type (mkCIdent ``TacticM) (mkCIdent ``id) (← `((← read).recover))
+macro (name := configElab') (priority := low) doc?:(docComment)? "declare_config_elab" elabName:ident type:ident : command => do
+  mkConfigElaborator doc? elabName type (mkCIdent ``TacticM) (mkCIdent ``id) (← `((← read).recover)) none
 
 open Linter.MissingDocs in
-@[builtin_missing_docs_handler Elab.Tactic.configElab]
+@[builtin_missing_docs_handler Command.configElab, builtin_missing_docs_handler configElab']
 private def checkConfigElab : SimpleHandler := mkSimpleHandler "config elab"
 
+@[builtin_command_elab commandConfigElab]
+def elabCommandConfigElab : CommandElab := fun stx => do
+  let doc? : Option (TSyntax ``docComment) := TSyntax.mk <$> stx[0].getOptional?
+  let elabName : Ident := ⟨stx[2]⟩
+  let type : Ident := ⟨stx[3]⟩
+  let typeName ← liftCoreM <| realizeGlobalConstNoOverloadWithInfo type
+  let eval? ← EvalConfig.mkEval? typeName
+  elabCommand <| ← liftMacroM <| mkConfigElaborator doc? elabName type (mkCIdent ``CommandElabM) (mkCIdent ``liftTermElabM) (mkCIdent ``true) eval?
+
+-- TODO(kmill): remove
 /-!
 `declare_command_config_elab elabName TypeName` declares a function `elabName : Syntax → CommandElabM TypeName`
 that elaborates a command configuration.
@@ -187,11 +377,11 @@ and these can also be wrapped in null nodes (for example, from `(config)?`).
 
 The elaborator has error recovery enabled.
 -/
-macro (name := commandConfigElab) doc?:(docComment)? "declare_command_config_elab" elabName:ident type:ident : command => do
-  mkConfigElaborator doc? elabName type (mkCIdent ``CommandElabM) (mkCIdent ``liftTermElabM) (mkCIdent ``true)
+macro (name := commandConfigElab') (priority := low) doc?:(docComment)? "declare_command_config_elab" elabName:ident type:ident : command => do
+  mkConfigElaborator doc? elabName type (mkCIdent ``CommandElabM) (mkCIdent ``liftTermElabM) (mkCIdent ``true) none
 
 open Linter.MissingDocs in
-@[builtin_missing_docs_handler Elab.Tactic.commandConfigElab]
+@[builtin_missing_docs_handler Command.commandConfigElab, builtin_missing_docs_handler Elab.Tactic.commandConfigElab']
 private def checkCommandConfigElab : SimpleHandler := mkSimpleHandler "config elab"
 
 end Lean.Elab.Tactic

--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -756,6 +756,30 @@ def initializeKeyword := leading_parser
 @[builtin_command_parser] def «in»  := trailing_parser
   withOpen (ppDedent (" in " >> commandParser))
 
+/-!
+`declare_config_elab elabName TypeName` declares a function `elabName : Syntax → TacticM TypeName`
+that elaborates a tactic configuration.
+The tactic configuration can be from `Lean.Parser.Tactic.optConfig` or `Lean.Parser.Tactic.config`,
+and these can also be wrapped in null nodes (for example, from `(config)?`).
+
+The elaborator responds to the current recovery state.
+
+For defining elaborators for commands, use `declare_command_config_elab`.
+-/
+@[builtin_command_parser] def configElab := leading_parser
+  optional docComment >> "declare_config_elab" >> ident >> ident
+
+/-!
+`declare_command_config_elab elabName TypeName` declares a function `elabName : Syntax → CommandElabM TypeName`
+that elaborates a command configuration.
+The configuration can be from `Lean.Parser.Tactic.optConfig` or `Lean.Parser.Tactic.config`,
+and these can also be wrapped in null nodes (for example, from `(config)?`).
+
+The elaborator has error recovery enabled.
+-/
+@[builtin_command_parser] def commandConfigElab := leading_parser
+  optional docComment >> "declare_command_config_elab" >> ident >> ident
+
 /--
 Adds a docstring to an existing declaration, replacing any existing docstring.
 The provided docstring should be written as a docstring for the `add_decl_doc` command, as in

--- a/tests/lean/run/tactic_config.lean
+++ b/tests/lean/run/tactic_config.lean
@@ -5,12 +5,19 @@ import Lean
 
 open Lean
 
+-- For debugging:
+-- set_option trace.Elab.tacticConfig true
+-- set_option debug.Elab.tacticConfig.forceEval true
+-- set_option profiler true
+-- set_option profiler.threshold 0
+
 /-!
 Simple tactic configuration
 -/
 structure MyTacticConfig where
   x : Nat := 0
   y : Bool := false
+  z : List Nat := []
   deriving Repr
 
 declare_config_elab elabMyTacticConfig MyTacticConfig
@@ -19,24 +26,28 @@ elab "my_tactic" cfg:Parser.Tactic.optConfig : tactic => do
   let config ← elabMyTacticConfig cfg
   logInfo m!"config is {repr config}"
 
+-- Making this irreducible forces the compiler to be used to evaluate configurations using it.
+--@[irreducible]
+def aa : List Nat := [1,2,3]
+
 /--
-info: config is { x := 0, y := false }
+info: config is { x := 0, y := false, z := [] }
 ---
-info: config is { x := 0, y := true }
+info: config is { x := 0, y := true, z := [] }
 ---
-info: config is { x := 1, y := false }
+info: config is { x := 1, y := false, z := [1, 2, 3] }
 ---
-info: config is { x := 2, y := false }
+info: config is { x := 2, y := false, z := [] }
 ---
-info: config is { x := 1, y := true }
+info: config is { x := 1, y := true, z := [] }
 ---
-info: config is { x := 0, y := false }
+info: config is { x := 0, y := false, z := [] }
 -/
 #guard_msgs in
 example : True := by
   my_tactic
   my_tactic +y
-  my_tactic (x := 1)
+  my_tactic (x := 1) (z := aa)
   my_tactic -y (x := 2)
   my_tactic (config := {x := 1, y := true})
   my_tactic +y (config := {y := false})
@@ -49,7 +60,7 @@ Basic errors
 /--
 error: Option is not boolean-valued, so `(x := ...)` syntax must be used
 ---
-info: config is { x := 0, y := false }
+info: config is { x := 0, y := false, z := [] }
 ---
 error: unsolved goals
 ⊢ True
@@ -59,7 +70,7 @@ error: unsolved goals
 /--
 error: Structure `MyTacticConfig` does not have a field named `w`
 ---
-info: config is { x := 0, y := false }
+info: config is { x := 0, y := false, z := [] }
 ---
 error: unsolved goals
 ⊢ True
@@ -69,7 +80,7 @@ error: unsolved goals
 /--
 error: Field `x` of structure `MyTacticConfig` is not a structure
 ---
-info: config is { x := 0, y := false }
+info: config is { x := 0, y := false, z := [] }
 ---
 error: unsolved goals
 ⊢ True
@@ -91,17 +102,17 @@ elab "my_tactic'" cfg:Parser.Tactic.optConfig : tactic => do
   logInfo m!"config is {repr config}"
 
 /--
-info: config is { toMyTacticConfig := { x := 22, y := true } }
+info: config is { toMyTacticConfig := { x := 22, y := true, z := [] } }
 ---
-info: config is { toMyTacticConfig := { x := 22, y := true } }
+info: config is { toMyTacticConfig := { x := 22, y := true, z := [] } }
 ---
-info: config is { toMyTacticConfig := { x := 1, y := true } }
+info: config is { toMyTacticConfig := { x := 1, y := true, z := [] } }
 ---
-info: config is { toMyTacticConfig := { x := 2, y := false } }
+info: config is { toMyTacticConfig := { x := 2, y := false, z := [] } }
 ---
-info: config is { toMyTacticConfig := { x := 1, y := true } }
+info: config is { toMyTacticConfig := { x := 1, y := true, z := [] } }
 ---
-info: config is { toMyTacticConfig := { x := 22, y := false } }
+info: config is { toMyTacticConfig := { x := 22, y := false, z := [] } }
 -/
 #guard_msgs in
 example : True := by


### PR DESCRIPTION
This PR implements a feature where the tactic configuration command `declare_config_elab` will create a configuration elaborator that uses a custom reduction-based evaluator, rather than invoking the compiler with `Meta.evalExpr'`. It still uses `Meta.evalExpr'` as a fallback if recognition fails. The command generates configuration evaluators automatically for non-recursive inductive types with no indices or parameters.

New options: `trace.Elab.tacticConfig` for messages about configuration elaborator construction and configuration elaboration, and `debug.Elab.tacticConfig.forceEval` for forcing the use of `Meta.evalExpr'`.

TODO: measure the performance impact.