### PR TITLE
feat: `[expose equations]`

### DIFF
--- a/src/Lean/DefEqAttrib.lean
+++ b/src/Lean/DefEqAttrib.lean
@@ -97,7 +97,7 @@ For automatically generated theorems (equational theorems etc.), we want to set 
 if the proof is `rfl`, essentially reproducing the behavior before the introduction of the `defeq`
 attribute. This function infers the `defeq` attribute based on the declaration value.
 -/
-def inferDefEqAttr (declName : Name) : MetaM Unit := do
+def inferDefEqAttr (declName : Name) (throwOnInvalid := false) : MetaM Unit := do
   withoutExporting do
     let info ← getConstInfo declName
     let isRfl ←
@@ -110,6 +110,8 @@ def inferDefEqAttr (declName : Name) : MetaM Unit := do
         withExporting (isExporting := !isPrivateName declName) do
           validateDefEqAttr declName -- sanity-check: would we have accepted `@[defeq]` on this?
       catch e =>
-        logError m!"Theorem {declName} has a `rfl`-proof and was thus inferred to be `@[defeq]`, \
-          but validating that attribute failed:{indentD e.toMessageData}"
+        if throwOnInvalid then
+          logError m!"Theorem {declName} has a `rfl`-proof and was thus inferred to be `@[defeq]`, \
+            but validating that attribute failed:{indentD e.toMessageData}"
+        return
       defeqAttr.setTag declName

--- a/src/Lean/Parser/Attr.lean
+++ b/src/Lean/Parser/Attr.lean
@@ -72,6 +72,9 @@ Tags should be applied to the canonical names for tactics.
 @[builtin_attr_parser] def «tactic_tag» := leading_parser
   "tactic_tag" >> many1 (ppSpace >> ident)
 
+@[builtin_attr_parser] def expose := leading_parser
+  nonReservedSymbol "expose" >> optional (nonReservedSymbol "equations")
+
 end Attr
 
 end Lean.Parser

--- a/tests/pkg/module/Module/Basic.lean
+++ b/tests/pkg/module/Module/Basic.lean
@@ -24,6 +24,25 @@ info: @[expose] def fexp : Nat :=
 #guard_msgs in
 #print fexp
 
+/-- A definition (equations exposed) -/
+@[expose equations] public def fexpeqns := 1
+
+/--
+info: def fexpeqns : Nat :=
+<not imported>
+-/
+#guard_msgs in
+#with_exporting
+#print fexpeqns
+
+/--
+info: theorem fexpeqns.eq_def : fexpeqns = 1 :=
+<not imported>
+-/
+#guard_msgs in
+#with_exporting
+#print fexpeqns.eq_def
+
 /-- An abbrev (auto-exposed). -/
 public abbrev fabbrev := 1
 


### PR DESCRIPTION
This PR adds the attribute variant `[expose equations]` that exposes the equations but not the body of a definition under the module system.