### PR TITLE
fix: expose instance implementation functions

### DIFF
--- a/src/Lean/Elab/Deriving/BEq.lean
+++ b/src/Lean/Elab/Deriving/BEq.lean
@@ -192,7 +192,8 @@ def mkAuxFunction (ctx : Context) (i : Nat) : TermElabM Command := do
   if ctx.usePartial then
     `(partial def $(mkIdent auxFunName):ident $binders:bracketedBinder* : Bool := $body:term)
   else
-    `(def $(mkIdent auxFunName):ident $binders:bracketedBinder* : Bool := $body:term)
+    let attrs ← if (← hasPrivateCtors indVal.name) then pure none else some <$> `(attributes| @[expose])
+    `($[$attrs:attributes]? def $(mkIdent auxFunName):ident $binders:bracketedBinder* : Bool := $body:term)
 
 def mkMutualBlock (ctx : Context) : TermElabM Syntax := do
   let mut auxDefs := #[]

--- a/src/Lean/Elab/Deriving/DecEq.lean
+++ b/src/Lean/Elab/Deriving/DecEq.lean
@@ -183,8 +183,9 @@ def mkAuxFunction (ctx : Context) (auxFunName : Name) (indVal : InductiveVal): T
   let termSuffix ← if indVal.isRec
     then `(Parser.Termination.suffix|termination_by structural $target₁)
     else `(Parser.Termination.suffix|)
+  let attrs ← if (← hasPrivateCtors indVal.name) then pure none  else some <$> `(attributes| @[expose])
   let type    ← `(Decidable ($target₁ = $target₂))
-  `(def $(mkIdent auxFunName):ident $binders:bracketedBinder* : $type:term := $body:term
+  `($[$attrs:attributes]? def $(mkIdent auxFunName):ident $binders:bracketedBinder* : $type:term := $body:term
     $termSuffix:suffix)
 
 def mkAuxFunctions (ctx : Context) : TermElabM (TSyntax `command) := do

--- a/src/Lean/Elab/Deriving/Ord.lean
+++ b/src/Lean/Elab/Deriving/Ord.lean
@@ -148,7 +148,8 @@ def mkAuxFunction (ctx : Context) (i : Nat) : TermElabM Command := do
   if ctx.usePartial then
     `(partial def $(mkIdent auxFunName):ident $binders:bracketedBinder* : Ordering := $body:term)
   else
-    `(def $(mkIdent auxFunName):ident $binders:bracketedBinder* : Ordering := $body:term)
+    let attrs ← if (← hasPrivateCtors indVal.name) then pure none else some <$> `(attributes| @[expose])
+    `($[$attrs:attributes]? def $(mkIdent auxFunName):ident $binders:bracketedBinder* : Ordering := $body:term)
 
 def mkMutualBlock (ctx : Context) : TermElabM Syntax := do
   let mut auxDefs := #[]

--- a/tests/lean/decEqMutualInductives.lean.expected.out
+++ b/tests/lean/decEqMutualInductives.lean.expected.out
@@ -1,5 +1,6 @@
 [Elab.Deriving.decEq] 
     [mutual
+       @[expose✝]
        def instDecidableEqListTree.decEq_1 (x✝ : @A.Tree✝) (x✝¹ : @A.Tree✝) : Decidable✝ (x✝ = x✝¹) :=
          match x✝, x✝¹ with
          | @A.Tree.node a✝, @A.Tree.node b✝ =>
@@ -7,6 +8,7 @@
            if h✝ : @a✝ = @b✝ then by subst h✝; exact isTrue✝ rfl✝
            else isFalse✝ (by intro n✝; injection n✝; apply h✝ _; assumption)
        termination_by structural x✝
+       @[expose✝]
        def instDecidableEqListTree.decEq_2 (x✝² : @A.ListTree✝) (x✝³ : @A.ListTree✝) : Decidable✝ (x✝² = x✝³) :=
          match x✝², x✝³ with
          | @A.ListTree.nil, @A.ListTree.nil => isTrue✝¹ rfl✝¹
@@ -26,6 +28,7 @@
        instDecidableEqListTree.decEq_2]
 [Elab.Deriving.decEq] 
     [mutual
+       @[expose✝]
        def instDecidableEqFoo₁.decEq_1 (x✝ : @A.Foo₁✝) (x✝¹ : @A.Foo₁✝) : Decidable✝ (x✝ = x✝¹) :=
          match x✝, x✝¹ with
          | @A.Foo₁.foo₁₁, @A.Foo₁.foo₁₁ => isTrue✝ rfl✝
@@ -36,6 +39,7 @@
            if h✝¹ : @a✝ = @b✝ then by subst h✝¹; exact isTrue✝¹ rfl✝¹
            else isFalse✝¹ (by intro n✝; injection n✝; apply h✝¹ _; assumption)
        termination_by structural x✝
+       @[expose✝]
        def instDecidableEqFoo₁.decEq_2 (x✝² : @A.Foo₂✝) (x✝³ : @A.Foo₂✝) : Decidable✝ (x✝² = x✝³) :=
          match x✝², x✝³ with
          | @A.Foo₂.foo₂ a✝¹, @A.Foo₂.foo₂ b✝¹ =>
@@ -43,6 +47,7 @@
            if h✝² : @a✝¹ = @b✝¹ then by subst h✝²; exact isTrue✝² rfl✝²
            else isFalse✝² (by intro n✝¹; injection n✝¹; apply h✝² _; assumption)
        termination_by structural x✝²
+       @[expose✝]
        def instDecidableEqFoo₁.decEq_3 (x✝⁴ : @A.Foo₃✝) (x✝⁵ : @A.Foo₃✝) : Decidable✝ (x✝⁴ = x✝⁵) :=
          match x✝⁴, x✝⁵ with
          | @A.Foo₃.foo₃ a✝², @A.Foo₃.foo₃ b✝² =>
@@ -55,6 +60,7 @@
        instDecidableEqFoo₁.decEq_1]
 [Elab.Deriving.decEq] 
     [mutual
+       @[expose✝]
        def instDecidableEqListTree.decEq_1 (x✝ : @B.Tree✝) (x✝¹ : @B.Tree✝) : Decidable✝ (x✝ = x✝¹) :=
          B.Tree.match_on_same_ctor✝ x✝ x✝¹ rfl✝
            @fun a✝ b✝ =>
@@ -62,6 +68,7 @@
              if h✝ : @a✝ = @b✝ then by subst h✝; exact isTrue✝ rfl✝¹
              else isFalse✝ (by intro n✝; injection n✝; apply h✝ _; assumption)
        termination_by structural x✝
+       @[expose✝]
        def instDecidableEqListTree.decEq_2 (x✝² : @B.ListTree✝) (x✝³ : @B.ListTree✝) : Decidable✝ (x✝² = x✝³) :=
          match decEq✝ (B.ListTree.ctorIdx✝ x✝²) (B.ListTree.ctorIdx✝ x✝³) with
          | .isTrue✝¹ h✝¹ =>
@@ -81,6 +88,7 @@
        instDecidableEqListTree.decEq_2]
 [Elab.Deriving.decEq] 
     [mutual
+       @[expose✝]
        def instDecidableEqFoo₁.decEq_1 (x✝ : @B.Foo₁✝) (x✝¹ : @B.Foo₁✝) : Decidable✝ (x✝ = x✝¹) :=
          match decEq✝ (B.Foo₁.ctorIdx✝ x✝) (B.Foo₁.ctorIdx✝ x✝¹) with
          | .isTrue✝ h✝ =>
@@ -91,6 +99,7 @@
                else isFalse✝ (by intro n✝; injection n✝; apply h✝¹ _; assumption)
          | .isFalse✝¹ h✝ => isFalse✝¹ (fun h'✝ => h✝ (congrArg✝ B.Foo₁.ctorIdx✝ h'✝))
        termination_by structural x✝
+       @[expose✝]
        def instDecidableEqFoo₁.decEq_2 (x✝² : @B.Foo₂✝) (x✝³ : @B.Foo₂✝) : Decidable✝ (x✝² = x✝³) :=
          B.Foo₂.match_on_same_ctor✝ x✝² x✝³ rfl✝
            @fun a✝¹ b✝¹ =>
@@ -98,6 +107,7 @@
              if h✝² : @a✝¹ = @b✝¹ then by subst h✝²; exact isTrue✝² rfl✝²
              else isFalse✝² (by intro n✝¹; injection n✝¹; apply h✝² _; assumption)
        termination_by structural x✝²
+       @[expose✝]
        def instDecidableEqFoo₁.decEq_3 (x✝⁴ : @B.Foo₃✝) (x✝⁵ : @B.Foo₃✝) : Decidable✝ (x✝⁴ = x✝⁵) :=
          B.Foo₃.match_on_same_ctor✝ x✝⁴ x✝⁵ rfl✝
            @fun a✝² b✝² =>

--- a/tests/lean/run/decEq.lean
+++ b/tests/lean/run/decEq.lean
@@ -32,9 +32,7 @@ public inductive PubInd where
   | a (n : Nat) | b
 deriving DecidableEq
 
-/--
-info: Decidable.rec (fun h => false) (fun h => true) (instDecidableEqPubInd.decEq PubInd.b PubInd.b)
--/
+/-- info: true -/
 #guard_msgs in
 #with_exporting
 #reduce decide (PubInd.b = PubInd.b)

--- a/tests/lean/run/derivingBEqLinear.lean
+++ b/tests/lean/run/derivingBEqLinear.lean
@@ -134,7 +134,7 @@ def ex1 [BEq α] : BEq (Tree α) :=
 def ex2 [BEq α] : BEq (TreeList α) :=
   inferInstance
 
-/-! Private fields should yield public, no-expose instances. -/
+/-! Private fields should yield public, no-exposed instances. -/
 
 structure PrivField where
   private a : Nat

--- a/tests/lean/run/issue10513.lean
+++ b/tests/lean/run/issue10513.lean
@@ -1,0 +1,55 @@
+module
+
+public structure A where
+  a : Nat
+deriving DecidableEq, BEq
+
+-- should all be exposed
+
+/-- info: @[expose] def instDecidableEqA : DecidableEq A -/
+#guard_msgs in #with_exporting #print sig instDecidableEqA
+
+/-- info: @[expose] def instDecidableEqA.decEq : (x x_1 : A) → Decidable (x = x_1) -/
+#guard_msgs in #with_exporting #print sig instDecidableEqA.decEq
+
+/-- info: @[expose] def instBEqA : BEq A -/
+#guard_msgs in #with_exporting #print sig instBEqA
+
+/-- info: @[expose] def instBEqA.beq : A → A → Bool -/
+#guard_msgs in #with_exporting #print sig instBEqA.beq
+
+structure B where
+  a : Nat
+deriving DecidableEq, BEq
+
+-- Should not be visible with `#with_exporting` since `B` is private
+
+/-- error: Unknown constant `instDecidableEqB` -/
+#guard_msgs in #with_exporting #print sig instDecidableEqB
+
+/-- error: Unknown constant `instDecidableEqB.decEq` -/
+#guard_msgs in #with_exporting #print sig instDecidableEqB.decEq
+
+/-- error: Unknown constant `instBEqB` -/
+#guard_msgs in #with_exporting #print sig instBEqB
+
+/-- error: Unknown constant `instBEqB.beq` -/
+#guard_msgs in #with_exporting #print sig instBEqB.beq
+
+public structure C where
+  private a : Nat
+deriving DecidableEq, BEq
+
+-- Should not be visible with `#with_exporting` since `B` is private
+
+/-- info: @[expose] def instDecidableEqC : DecidableEq C -/
+#guard_msgs in #with_exporting #print sig instDecidableEqC
+
+/-- info: def instDecidableEqC.decEq : (x x_1 : C) → Decidable (x = x_1) -/
+#guard_msgs in #with_exporting #print sig instDecidableEqC.decEq
+
+/-- info: @[expose] def instBEqC : BEq C -/
+#guard_msgs in #with_exporting #print sig instBEqC
+
+/-- info: def instBEqC.beq : C → C → Bool -/
+#guard_msgs in #with_exporting #print sig instBEqC.beq

--- a/tests/lean/run/reduceBEqSimproc.lean
+++ b/tests/lean/run/reduceBEqSimproc.lean
@@ -65,13 +65,13 @@ end A
 
 namespace B
 public inductive L where | nil  : L | cons : Nat → L → L deriving BEq
--- NB: Instance is public and exposed, op and theorem are private
+-- NB: Instance is public and exposed, op is exposed, theorem is public
 /-- info: @[expose] def B.instBEqL : BEq L -/
 #guard_msgs in #print sig instBEqL
-/-- info: def B.instBEqL.beq : L → L → Bool -/
+/-- info: @[expose] def B.instBEqL.beq : L → L → Bool -/
 #guard_msgs in #print sig instBEqL.beq
 -- NB: Private theorem
-/-- info: private theorem B.instBEqL.beq_spec_1 : (L.nil == L.nil) = true -/
+/-- info: theorem B.instBEqL.beq_spec_1 : (L.nil == L.nil) = true -/
 #guard_msgs(pass trace, all) in #print sig instBEqL.beq_spec_1
 example : (L.cons n (L.nil : L) == L.cons m (L.nil : L)) ↔ n = m := by simp [reduceBEq]
 end B


### PR DESCRIPTION
This PR exposes the instance implementation function unless there are
private constructors. Fixes #10513.
