### PR TITLE
chore: set temci tags for the radar bench script

### DIFF
--- a/tests/bench/speedcenter.exec.velcom.yaml
+++ b/tests/bench/speedcenter.exec.velcom.yaml
@@ -1,6 +1,6 @@
 - attributes:
     description: stdlib
-    tags: [slow]
+    tags: [stdlib]
     time: &time
       #runner: time
       # alternative config: use `perf stat` for extended properties
@@ -31,7 +31,7 @@
       bash -c 'make -C ${BUILD:-../build/release} stage3 -j$(nproc)'
 - attributes:
     description: stdlib size
-    tags: [deterministic, fast]
+    tags: [stdlib]
   run_config:
     cwd: ../../
     cmd: |
@@ -56,7 +56,7 @@
     runner: output
 - attributes:
     description: Init size
-    tags: [deterministic, fast]
+    tags: [stdlib]
   run_config:
     cwd: ../../
     cmd: |
@@ -71,7 +71,7 @@
     runner: output
 - attributes:
     description: libleanshared.so
-    tags: [deterministic, fast]
+    tags: [stdlib]
   run_config:
     cmd: |
       set -eu
@@ -81,35 +81,35 @@
     runner: output
 - attributes:
     description: Init.Prelude async
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cwd: ../../src
     cmd: lean -Dexperimental.module=true Init/Prelude.lean
 - attributes:
     description: Init.Data.List.Sublist async
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cwd: ../../src
     cmd: lean -Dexperimental.module=true Init/Data/List/Sublist.lean
 - attributes:
     description: Std.Data.Internal.List.Associative
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cwd: ../../src
     cmd: lean -Dexperimental.module=true Std/Data/Internal/List/Associative.lean
 - attributes:
     description: Std.Data.DHashMap.Internal.RawLemmas
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cwd: ../../src
     cmd: lean -Dexperimental.module=true Std/Data/DHashMap/Internal/RawLemmas.lean
 - attributes:
     description: Init.Data.BitVec.Lemmas
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cwd: ../../src
@@ -130,14 +130,14 @@
     max_runs: 2
 - attributes:
     description: import Lean
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cwd: ../../src
     cmd: lean Lean.lean
 - attributes:
     description: tests/compiler
-    tags: [deterministic, slow]
+    tags: [other]
   run_config:
     cwd: ../compiler/
     cmd: |
@@ -148,7 +148,7 @@
     runner: output
 - attributes:
     description: tests/bench/ interpreted
-    tags: [slow]
+    tags: [other]
   run_config:
     <<: *time
     cmd: |
@@ -162,7 +162,7 @@
     max_runs: 2
 - attributes:
     description: binarytrees
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./binarytrees.lean.out 21
@@ -170,7 +170,7 @@
     cmd: ./compile.sh binarytrees.lean
 - attributes:
     description: binarytrees.st
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./binarytrees.st.lean.out 21
@@ -178,7 +178,7 @@
     cmd: ./compile.sh binarytrees.st.lean
 - attributes:
     description: const_fold
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: bash -c "ulimit -s unlimited && ./const_fold.lean.out 23"
@@ -186,7 +186,7 @@
     cmd: ./compile.sh const_fold.lean
 - attributes:
     description: deriv
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./deriv.lean.out 10
@@ -194,7 +194,7 @@
     cmd: ./compile.sh deriv.lean
 - attributes:
     description: lake build clean
-    tags: [slow]
+    tags: [other]
   run_config:
     <<: *time
     cmd: |
@@ -218,7 +218,7 @@
       "
 - attributes:
     description: lake build no-op
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: |
@@ -239,7 +239,7 @@
       "
 - attributes:
     description: lake config elab
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: |
@@ -252,7 +252,7 @@
     cmd: cp inundation/lakefile.lean inundation/lakefile-rc.lean
 - attributes:
     description: lake config import
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: |
@@ -270,7 +270,7 @@
       "
 - attributes:
     description: lake config tree
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: |
@@ -285,7 +285,7 @@
       lake -dinundation/test/tree update
 - attributes:
     description: lake env
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: |
@@ -298,7 +298,7 @@
     cmd: lake -dinundation env true
 - attributes:
     description: lake startup
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: |
@@ -309,13 +309,13 @@
       "
 - attributes:
     description: language server startup
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean -Dlinter.all=false --run server_startup.lean
 - attributes:
     description: ilean roundtrip
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./ilean_roundtrip.lean.out 200000
@@ -324,14 +324,14 @@
     cmd: ./compile.sh ilean_roundtrip.lean
 - attributes:
     description: identifier auto-completion
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean -Dlinter.all=false --run identifier_completion_runner.lean
     parse_output: true
 - attributes:
     description: liasolver
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./liasolver.lean.out ex-50-50-1.leq
@@ -339,7 +339,7 @@
     cmd: ./compile.sh liasolver.lean
 - attributes:
     description: parser
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./parser.lean.out ../../src/Init/Prelude.lean 50
@@ -347,7 +347,7 @@
     cmd: ./compile.sh parser.lean
 - attributes:
     description: qsort
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./qsort.lean.out 400
@@ -355,7 +355,7 @@
     cmd: ./compile.sh qsort.lean
 - attributes:
     description: rbmap
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./rbmap.lean.out 2000000
@@ -363,7 +363,7 @@
     cmd: ./compile.sh rbmap.lean
 - attributes:
     description: rbmap_1
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./rbmap_checkpoint.lean.out 2000000 1
@@ -371,7 +371,7 @@
     cmd: ./compile.sh rbmap_checkpoint.lean
 - attributes:
     description: rbmap_10
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./rbmap_checkpoint.lean.out 2000000 10
@@ -379,7 +379,7 @@
     cmd: ./compile.sh rbmap_checkpoint.lean
 - attributes:
     description: rbmap_fbip
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./rbmap_fbip.lean.out 2000000
@@ -387,7 +387,7 @@
     cmd: ./compile.sh rbmap_fbip.lean
 - attributes:
     description: rbmap_library
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./rbmap_library.lean.out 2000000
@@ -395,79 +395,79 @@
     cmd: ./compile.sh rbmap_library.lean
 - attributes:
     description: reduceMatch
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean reduceMatch.lean
 - attributes:
     description: simp_arith1
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean simp_arith1.lean
 - attributes:
     description: simp_bubblesort_256
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean simp_bubblesort_256.lean
 - attributes:
     description: simp_local
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean simp_local.lean
 - attributes:
     description: simp_subexpr
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean simp_subexpr.lean
 - attributes:
     description: simp_congr
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean --tstack=16384 simp_congr.lean
 - attributes:
     description: mut_rec_wf
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean mut_rec_wf.lean
 - attributes:
     description: big_match
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean big_match.lean
 - attributes:
     description: big_beq
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean big_beq.lean
 - attributes:
     description: big_beq_rec
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean big_beq_rec.lean
 - attributes:
     description: big_deceq
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean big_deceq.lean
 - attributes:
     description: big_deceq_rec
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean big_deceq_rec.lean
 - attributes:
     description: nat_repr
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./nat_repr.lean.out 5000
@@ -475,7 +475,7 @@
     cmd: ./compile.sh nat_repr.lean
 - attributes:
     description: unionfind
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./unionfind.lean.out 3000000
@@ -483,33 +483,33 @@
     cmd: ./compile.sh unionfind.lean
 - attributes:
     description: workspaceSymbols
-    tags: [fast, suite]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean workspaceSymbols.lean
     max_runs: 2
 - attributes:
     description: bv_decide_realworld
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean bv_decide_realworld.lean
 - attributes:
     description: bv_decide_mul
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean bv_decide_mul.lean
 - attributes:
     description: bv_decide_mod
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean bv_decide_mod.lean
     max_runs: 2
 - attributes:
     description: bv_decide_inequality.lean
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean bv_decide_inequality.lean
@@ -517,43 +517,43 @@
     max_runs: 2
 - attributes:
     description: bv_decide_large_aig.lean
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean bv_decide_large_aig.lean
 - attributes:
     description: bv_decide_rewriter.lean
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean bv_decide_rewriter.lean
 - attributes:
     description: big_do
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean big_do.lean
 - attributes:
     description: big_omega.lean
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean big_omega.lean
 - attributes:
     description: big_omega.lean MT
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean big_omega.lean -Dinternal.cmdlineSnapshots=false
 - attributes:
     description: omega_stress.lean async
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean omega_stress.lean
 - attributes:
     description: channel.lean
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./channel.lean.out
@@ -562,14 +562,14 @@
     cmd: ./compile.sh channel.lean
 - attributes:
     description: riscv-ast.lean
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean riscv-ast.lean
     max_runs: 2
 - attributes:
     description: iterators (compiled)
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./iterators.lean.out
@@ -577,19 +577,19 @@
     cmd: ./compile.sh iterators.lean
 - attributes:
     description: iterators (interpreted)
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean --run iterators.lean
 - attributes:
     description: iterators (elab)
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean iterators.lean
 - attributes:
     description: workspaceSymbols with new ranges
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./workspaceSymbolsNewRanges.lean.out
@@ -597,7 +597,7 @@
     cmd: ./compile.sh workspaceSymbolsNewRanges.lean
 - attributes:
     description: hashmap.lean
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./hashmap.lean.out 11 10000
@@ -606,7 +606,7 @@
     cmd: ./compile.sh hashmap.lean
 - attributes:
     description: treemap.lean
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./treemap.lean.out 11 10000
@@ -615,7 +615,7 @@
     cmd: ./compile.sh treemap.lean
 - attributes:
     description: phashmap.lean
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: ./phashmap.lean.out 11 10000
@@ -624,19 +624,19 @@
     cmd: ./compile.sh phashmap.lean
 - attributes:
     description: grind_bitvec2.lean
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean -Dexperimental.module=true ../lean/run/grind_bitvec2.lean
 - attributes:
     description: grind_list2.lean
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean -Dexperimental.module=true ../lean/run/grind_list2.lean
 - attributes:
     description: grind_ring_5.lean
-    tags: [fast]
+    tags: [other]
   run_config:
     <<: *time
     cmd: lean -Dexperimental.module=true ../lean/run/grind_ring_5.lean


### PR DESCRIPTION
The radar bench scripts at https://github.com/leanprover/radar-bench-lean4/ split up the benchmarks between the two runners based on the tags: One runner filters by the tag `stdlib` while the other filters by the tag `other`. Only benchmarks using one of these tags will be run, and any benchmark tagged with both will waste electricity.

As far as I know, the tags are unused otherwise, so I just replaced all the old tags.