### PR TITLE
perf: experiment: index recursor_rules by constructor index

### DIFF
--- a/src/Lean/Declaration.lean
+++ b/src/Lean/Declaration.lean
@@ -357,8 +357,8 @@ structure RecursorVal extends ConstantVal where
   numMotives : Nat
   /-- Number of minor premises -/
   numMinors : Nat
-  /-- A reduction for each Constructor -/
-  rules : List RecursorRule
+  /-- A reduction for each Constructor, indexed by constructor -/
+  rules : Array RecursorRule
   /-- It supports K-like reduction.
   A recursor is said to support K-like reduction if one can assume it behaves
   like `Eq` under axiom `K` --- that is, it has one constructor, the constructor has 0 arguments,
@@ -374,7 +374,7 @@ structure RecursorVal extends ConstantVal where
 
 @[export lean_mk_recursor_val]
 def mkRecursorValEx (name : Name) (levelParams : List Name) (type : Expr) (all : List Name) (numParams numIndices numMotives numMinors : Nat)
-    (rules : List RecursorRule) (k isUnsafe : Bool) : RecursorVal := {
+    (rules : Array RecursorRule) (k isUnsafe : Bool) : RecursorVal := {
   name, levelParams, type, all, numParams, numIndices,
   numMotives, numMinors, rules, k, isUnsafe
 }

--- a/src/kernel/declaration.h
+++ b/src/kernel/declaration.h
@@ -9,6 +9,7 @@ Author: Leonardo de Moura
 #include <string>
 #include <limits>
 #include "kernel/expr.h"
+#include "runtime/array_ref.h"
 
 namespace lean {
 /**
@@ -346,7 +347,7 @@ public:
     expr const & get_rhs() const { return static_cast<expr const &>(cnstr_get_ref(*this, 2)); }
 };
 
-typedef list_ref<recursor_rule> recursor_rules;
+typedef array_ref<recursor_rule> recursor_rules;
 
 /*
 structure RecursorVal extends ConstantVal where
@@ -355,7 +356,7 @@ structure RecursorVal extends ConstantVal where
   numIndices : Nat
   numMotives : Nat
   numMinors : Nat
-  rules : List RecursorRule
+  rules : Array RecursorRule
   k : Bool         -- It supports K-like reduction.
   isUnsafe : Bool
 */

--- a/src/kernel/inductive.h
+++ b/src/kernel/inductive.h
@@ -49,7 +49,7 @@ inline expr to_cnstr_when_K(environment const & env, recursor_val const & rval, 
     return *new_cnstr_app;
 }
 
-optional<recursor_rule> get_rec_rule_for(recursor_val const & rec_val, expr const & major);
+optional<recursor_rule> get_rec_rule_for(environment const & env, recursor_val const & rec_val, expr const & major);
 
 expr nat_lit_to_constructor(expr const & e);
 expr string_lit_to_constructor(expr const & e);
@@ -95,7 +95,7 @@ inline optional<expr> inductive_reduce_rec(environment const & env, expr const &
         major = whnf(string_lit_to_constructor(major));
     else
         major = to_cnstr_when_structure(env, rec_val.get_major_induct(), major, whnf, infer_type);
-    optional<recursor_rule> rule = get_rec_rule_for(rec_val, major);
+    optional<recursor_rule> rule = get_rec_rule_for(env, rec_val, major);
     if (!rule) return none_expr();
     buffer<expr> major_args;
     get_app_args(major, major_args);

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,5 +1,7 @@
 #include "util/options.h"
 
+// please update stage0
+
 namespace lean {
 options get_default_options() {
     options opts;


### PR DESCRIPTION
This PR is an experiment, I wonder if such an optimization would show up in our large-inductive benchmarks. (I assume not)