### PR TITLE
feat: `#print T.rec` to show more information

### DIFF
--- a/src/Lean/Elab/Print.lean
+++ b/src/Lean/Elab/Print.lean
@@ -96,6 +96,19 @@ private def printInduct (id : Name) (levelParams : List Name) (numParams : Nat) 
     m := m ++ Format.line ++ ctor ++ " : " ++ cinfo.type
   logInfo m
 
+private def printRecursor (recInfo : RecursorVal) : CommandElabM Unit := do
+  let mut m ← mkHeader "recursor" recInfo.name recInfo.levelParams recInfo.type (if recInfo.isUnsafe then .unsafe else .safe)
+  m := m ++ Format.line ++ m!"number of parameters: {recInfo.numParams}"
+  m := m ++ Format.line ++ m!"number of indices: {recInfo.numIndices}"
+  m := m ++ Format.line ++ m!"number of motives: {recInfo.numMotives}"
+  m := m ++ Format.line ++ m!"number of minors: {recInfo.numMinors}"
+  if recInfo.k then
+    m := m ++ Format.line ++ m!"supports k-like reduction"
+  m := m ++ Format.line ++ "rules:"
+  for rule in recInfo.rules do
+    m := m ++ Format.line ++ m!"for {rule.ctor} ({rule.nfields} fields): {rule.rhs}"
+  logInfo m
+
 /--
 Computes the origin of a field. Returns its `StructureFieldInfo` at the origin.
 Multiple parents could be the origin of a field, but we say the first parent that provides it is the one that determines the origin.
@@ -196,7 +209,7 @@ private def printIdCore (sigOnly : Bool) (id : Name) : CommandElabM Unit := do
   | ConstantInfo.opaqueInfo  { levelParams := us, type := t, isUnsafe := u, .. } => printAxiomLike "opaque" id us t (if u then .unsafe else .safe)
   | ConstantInfo.quotInfo  { levelParams := us, type := t, .. } => printQuot id us t
   | ConstantInfo.ctorInfo { levelParams := us, type := t, isUnsafe := u, .. } => printAxiomLike "constructor" id us t (if u then .unsafe else .safe)
-  | ConstantInfo.recInfo { levelParams := us, type := t, isUnsafe := u, .. } => printAxiomLike "recursor" id us t (if u then .unsafe else .safe)
+  | ConstantInfo.recInfo recInfo => printRecursor recInfo
   | ConstantInfo.inductInfo { levelParams := us, numParams, type := t, ctors, isUnsafe := u, .. } =>
     if isStructure env id then
       printStructure id us numParams t ctors[0]! u

--- a/tests/lean/run/print_cmd.lean
+++ b/tests/lean/run/print_cmd.lean
@@ -46,8 +46,29 @@ Nat.succ : Nat → Nat
 /--
 info: recursor Nat.rec.{u} : {motive : Nat → Sort u} →
   motive Nat.zero → ((n : Nat) → motive n → motive n.succ) → (t : Nat) → motive t
+number of parameters: 0
+number of indices: 0
+number of motives: 1
+number of minors: 2
+rules:
+for Nat.zero (0 fields): fun motive zero succ => zero
+for Nat.succ (1 fields): fun motive zero succ n => succ n (Nat.rec zero succ n)
 -/
 #guard_msgs in #print Nat.rec
+/--
+info: recursor Acc.rec.{u_1, u} : {α : Sort u} →
+  {r : α → α → Prop} →
+    {motive : (a : α) → Acc r a → Sort u_1} →
+      ((x : α) → (h : ∀ (y : α), r y x → Acc r y) → ((y : α) → (a : r y x) → motive y ⋯) → motive x ⋯) →
+        {a : α} → (t : Acc r a) → motive a t
+number of parameters: 2
+number of indices: 1
+number of motives: 1
+number of minors: 1
+rules:
+for Acc.intro (2 fields): fun {α} r motive intro x h => intro x h fun y a => Acc.rec intro ⋯
+-/
+#guard_msgs in #print Acc.rec
 /--
 info: @[reducible] def Nat.casesOn.{u} : {motive : Nat → Sort u} →
   (t : Nat) → motive Nat.zero → ((n : Nat) → motive n.succ) → motive t :=


### PR DESCRIPTION
This PR lets `#print T.rec` show more information about a recursor, in
particular it's reduction rules.
