### PR TITLE
chore: use CMake build type in Lake core build

### DIFF
--- a/src/lakefile.toml.in
+++ b/src/lakefile.toml.in
@@ -10,6 +10,9 @@ bootstrap = true
 
 defaultTargets = ["Init", "Std", "Lean", "Lake", "LakeMain", "Leanc"]
 
+# Ensure that Lake and CMake agree on the build type (e.g., `Release`, `Debug`)
+buildType = "${CMAKE_BUILD_TYPE}"
+
 # The root of all the compiler output directories
 buildDir = "${CMAKE_BINARY_DIR}"
 


### PR DESCRIPTION
This PR alters the core build Lake configuration file to use the `CMAKE_BUILD_TYPE` for Lake's `buildType`.