### PR TITLE
feat: allow numeric literals to be coerced to option type

### DIFF
--- a/src/Init/Data/Option/Coe.lean
+++ b/src/Init/Data/Option/Coe.lean
@@ -7,6 +7,7 @@ module
 
 prelude
 public import Init.Coe
+public import Init.Data.OfScientific
 
 public section
 
@@ -20,3 +21,24 @@ is enforced by the test `importStructure.lean`).
 
 instance optionCoe {α : Type u} : Coe α (Option α) where
   coe := some
+
+/--
+The coercion-to-option-type behavior provided by `optionCoe` does not work for natural number
+literals or floating point literals because of the automatic insertion of `OfNat` and `OfScientific`
+coercions around these literals.
+
+This instance provides the corresponding coercion for natural number literals.
+-/
+instance natOptionCoe {α : Type u} {n : Nat} [OfNat α n] : OfNat (Option α) n where
+  ofNat := some (OfNat.ofNat n)
+
+/--
+The coercion-to-option-type behavior provided by `optionCoe` does not work for natural number
+literals or floating point literals because of the automatic insertion of `OfNat` and `OfScientific`
+coercions around these literals.
+
+This instance provides the corresponding coercion for scientific number literals.
+-/
+instance scientificOptionCoe {α : Type u} [OfScientific α] : OfScientific (Option α) where
+  ofScientific (mantissa : Nat) (exponentSign : Bool) (decimalExponent : Nat) :=
+    some (OfScientific.ofScientific mantissa exponentSign decimalExponent)

--- a/src/Init/Data/Option/Coe.lean
+++ b/src/Init/Data/Option/Coe.lean
@@ -29,9 +29,9 @@ the literal `5` to the syntax `OfNat.ofNat (α := _) (nat_lit 5)` unless it's pr
 
 Without the following typeclass instances, `(5 : Option Nat)` fails at typeclass inference, even
 though `(OfNat.ofNat (α := Nat) (nat_lit 5) : Option Nat)` would succeed, with the help of a type
-coercion, via the `optionCoe` instance and inserting a type coercion. While these definitions do
-not involve type coercion, they result in Lean behaving more uniformly in the presence of
-`optionCoe`.
+coercion, via the `optionCoe` instance and inserting a type coercion. While these instances do not
+directly involve type coercion, they result in Lean behaving more uniformly in the presence of
+`optionCoe`, so they are added alongside `optionCoe` and likewise banned in `Init` and `Std`.
 -/
 
 /--
@@ -45,6 +45,6 @@ instance {α : Type u} {n : Nat} [OfNat α n] : OfNat (Option α) n where
 If an scientific number can be used as an expression of α via `OfScientific.ofScientific`, then it
 can also be used an expression of type `Option α`.
 -/
-instance scientificOptionCoe {α : Type u} [OfScientific α] : OfScientific (Option α) where
+instance {α : Type u} [OfScientific α] : OfScientific (Option α) where
   ofScientific (mantissa : Nat) (exponentSign : Bool) (decimalExponent : Nat) :=
     some (OfScientific.ofScientific mantissa exponentSign decimalExponent)

--- a/src/Init/Data/Option/Coe.lean
+++ b/src/Init/Data/Option/Coe.lean
@@ -22,22 +22,28 @@ is enforced by the test `importStructure.lean`).
 instance optionCoe {α : Type u} : Coe α (Option α) where
   coe := some
 
-/--
-The coercion-to-option-type behavior provided by `optionCoe` does not work for natural number
-literals or floating point literals because of the automatic insertion of `OfNat` and `OfScientific`
-coercions around these literals.
+/-!
+The coercion to `Option` types provided by `optionCoe` does not work for numeric literals because
+of the way numeric literals are automatically wrapped in a call to `OfNat.ofNat`: Lean expands the
+the literal `5` to the syntax `OfNat.ofNat (α := _) (nat_lit 5)` unless it's preceded by `nat_lit`.
 
-This instance provides the corresponding coercion for natural number literals.
+Without the following typeclass instances, `(5 : Option Nat)` fails at typeclass inference, even
+though `(OfNat.ofNat (α := Nat) (nat_lit 5) : Option Nat)` would succeed, with the help of a type
+coercion, via the `optionCoe` instance and inserting a type coercion. While these definitions do
+not involve type coercion, they result in Lean behaving more uniformly in the presence of
+`optionCoe`.
 -/
-instance natOptionCoe {α : Type u} {n : Nat} [OfNat α n] : OfNat (Option α) n where
+
+/--
+If the natural number n can be used as an expression of α via `OfNat.ofNat`, then it can also be
+used an expression of type `Option α`.
+-/
+instance {α : Type u} {n : Nat} [OfNat α n] : OfNat (Option α) n where
   ofNat := some (OfNat.ofNat n)
 
 /--
-The coercion-to-option-type behavior provided by `optionCoe` does not work for natural number
-literals or floating point literals because of the automatic insertion of `OfNat` and `OfScientific`
-coercions around these literals.
-
-This instance provides the corresponding coercion for scientific number literals.
+If an scientific number can be used as an expression of α via `OfScientific.ofScientific`, then it
+can also be used an expression of type `Option α`.
 -/
 instance scientificOptionCoe {α : Type u} [OfScientific α] : OfScientific (Option α) where
   ofScientific (mantissa : Nat) (exponentSign : Bool) (decimalExponent : Nat) :=

--- a/tests/lean/interactive/completionPrefixIssue.lean.expected.out
+++ b/tests/lean/interactive/completionPrefixIssue.lean.expected.out
@@ -4,7 +4,7 @@
  [{"label": "veryLongDefinitionName",
    "kind": 6,
    "data":
-   ["«external:file:///completionPrefixIssue.lean»", 1, 64, 0, "f_uniq.35"]},
+   ["«external:file:///completionPrefixIssue.lean»", 1, 64, 0, "f_uniq.44"]},
   {"label": "veryLongDefinitionNameVeryLongDefinitionName",
    "kind": 21,
    "data":

--- a/tests/lean/interactive/completionPrefixIssue.lean.expected.out
+++ b/tests/lean/interactive/completionPrefixIssue.lean.expected.out
@@ -19,7 +19,7 @@ Resolution of veryLongDefinitionName:
  "kind": 6,
  "detail": "Nat",
  "data":
- ["«external:file:///completionPrefixIssue.lean»", 1, 64, 0, "f_uniq.35"]}
+ ["«external:file:///completionPrefixIssue.lean»", 1, 64, 0, "f_uniq.44"]}
 Resolution of veryLongDefinitionNameVeryLongDefinitionName:
 {"label": "veryLongDefinitionNameVeryLongDefinitionName",
  "kind": 21,

--- a/tests/lean/run/10585.lean
+++ b/tests/lean/run/10585.lean
@@ -1,0 +1,32 @@
+def s : String := "4"
+example : Option String := s
+example : Option String := ("3" : String)
+example : Option String := "3"
+
+def n : Nat := 4
+example : Option Nat := n
+example : Option Nat := (3 : Nat)
+example : Option Nat := 3
+
+def d : Float := 4.
+example : Option Float := d
+example : Option Float := (3. : Float)
+example : Option Float := 3.
+
+example : Option (Option (Option Int)) := 7
+example : Option UInt8 := 3
+example : Option String.Pos := 0
+
+/--
+error: failed to synthesize
+  OfNat (Option String.Pos) 1
+numerals are polymorphic in Lean, but the numeral `1` cannot be used in a context where the expected type is
+  Option String.Pos
+due to the absence of the instance above
+
+Hint: Additional diagnostic information may be available using the `set_option diagnostics true` command.
+-/
+#guard_msgs in
+example : Option String.Pos := 1
+
+example : Option (Id (Option (Id ISize))) := 6_000

--- a/tests/lean/run/info_trees.lean
+++ b/tests/lean/run/info_trees.lean
@@ -60,7 +60,7 @@ info: • [Command] @ ⟨77, 0⟩-⟨77, 40⟩ @ Lean.Elab.Command.elabDeclarati
                   ⊢ 0 ≤ n
                   after no goals
                   • [Term] Nat.zero_le n : 0 ≤ n @ ⟨1, 1⟩†-⟨1, 1⟩† @ Lean.Elab.Term.elabApp
-                    • [Completion-Id] Nat.zero_le : some LE.le.{0} Nat instLENat (OfNat.ofNat.{0} Nat 0 (instOfNatNat 0)) _uniq.37 @ ⟨1, 0⟩†-⟨1, 0⟩†
+                    • [Completion-Id] Nat.zero_le : some LE.le.{0} Nat instLENat (OfNat.ofNat.{0} Nat 0 (instOfNatNat 0)) _uniq.46 @ ⟨1, 0⟩†-⟨1, 0⟩†
                     • [Term] Nat.zero_le : ∀ (n : Nat), 0 ≤ n @ ⟨1, 0⟩†-⟨1, 0⟩†
                     • [Term] n : Nat @ ⟨1, 5⟩†-⟨1, 5⟩† @ Lean.Elab.Term.elabIdent
                       • [Completion-Id] n : some Nat @ ⟨1, 5⟩†-⟨1, 5⟩†


### PR DESCRIPTION
This PR allows adds new instances for the `OfNat` and `OfScientific` typeclass that allow numeric literals to be treated as having `Option` type.

This change fixes an _apparent_ asymmetry between numerals and other Lean expressions. Thanks to the optionCoe typeclass, an expression that synthesizes the type `α` can be coerced to `Option α`. However, a numeral like `5` or `4.2e3` does not synthesize the type `Nat` or `Float` because it expands to e.g. `OfNat.ofNat (α := _) (nat_lit 5)`, and typeclass inference will fail to find an instance that lets `α` be an `Option` type.

Comparing this with the behavior of String makes the apparent asymmetry particularly egregious, because string literals don't get a similar typeclass wrapper.

```
def s : String := "4"
example : Option String := s
example : Option String := ("3" : String)
example : Option String := "3"

def n : Nat := 4
example : Option Nat := n
example : Option Nat := (3 : Nat)
example : Option Nat := 3 -- Fails currently, succeeds under this PR

def d : Float := 4.
example : Option Float := d
example : Option Float := (3. : Float)
example : Option Float := 3. -- Fails currently, succeeds under this PR
```

Despite these instances not being coercions, the effect is quite similar to the `optionCoe` typeclass that defines the coercion `α → Option α`, so by putting them in `Init.Data.Option.Core` we ensure that these instances are similarly banned inside `Init` and `Std`.

https://live.lean-lang.org/#codez=CYUwZgBAzhBcEGUAuAnAlgOwOZwLwQCIAWAgKBAA8BDAWwAcAbEOCAeTqTQHsNFVMcsfFHLV6TFu048+6bHggAKAgGYCLZHKwBKUbUbN4U7r00CFqsqVCRe8AHJUkConvGG2HExEfOhEDDcDSS8ZXwVFFRZfXUp9CSNQ3nD/KIBaNIgAMSo0BhgAYwBXFBQQDCQGAE8AGmgigoKQEGAYIoxQFAgkAAs0GAAFACVSa3AIYBYshi4nFwA6IITPaV5p2b98YCWPYxl1uf9I+amZp1ixYMTV7LPNiBUTjOzc/Ihi0vLK2vrG5taIO1Ot0+oMhkA