### PR TITLE
fix: lake: add `lake help cache`

### DIFF
--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -516,6 +516,7 @@ public def help : (cmd : String) → String
 | "pack"                => helpPack
 | "unpack"              => helpUnpack
 | "upload"              => helpUpload
+| "cache"               => helpCacheCli
 | "test"                => helpTest
 | "check-test"          => helpCheckTest
 | "lint"                => helpLint


### PR DESCRIPTION
This PR fixes an oversight where `lake cache help` existed but `lake help cache` (and by extension `lake cache --help`) did not.