### PR TITLE
fix: equational theorem generation: avoid reducing at transparency all

### DIFF
--- a/src/Lean/Elab/PreDefinition/Eqns.lean
+++ b/src/Lean/Elab/PreDefinition/Eqns.lean
@@ -357,7 +357,7 @@ private partial def mkEqnProof (declName : Name) (type : Expr) (tryRefl : Bool) 
     -- For well-founded recursion this is disabled: The equation may hold
     -- definitionally as written, but not embedded in larger proofs
     if tryRefl then
-      if (← withAtLeastTransparency .all (tryURefl mvarId)) then
+      if (← tryURefl mvarId) then
         return ← instantiateMVars main
 
     go (← unfoldLHS declName mvarId)
@@ -372,7 +372,7 @@ private partial def mkEqnProof (declName : Name) (type : Expr) (tryRefl : Bool) 
   -/
   go (mvarId : MVarId) : MetaM Unit := do
     trace[Elab.definition.eqns] "step\n{MessageData.ofGoal mvarId}"
-    if ← withAtLeastTransparency .all (tryURefl mvarId) then
+    if (← tryURefl mvarId) then
       return ()
     else if (← tryContradiction mvarId) then
       return ()

--- a/tests/lean/run/issue10651.lean
+++ b/tests/lean/run/issue10651.lean
@@ -1,0 +1,36 @@
+-- set_option trace.Elab.definition.eqns true
+
+def f (x : Nat) : Nat :=
+  match x with
+  | 0    => 1
+  | 100  => 2
+  | 1000 => 3
+  | x+1  => f x
+termination_by x
+
+/--
+info: equations:
+theorem f.eq_1 : f 0 = 1
+theorem f.eq_2 : f 100 = 2
+theorem f.eq_3 : f 1000 = 3
+theorem f.eq_4 : ∀ (x_2 : Nat), (x_2 = 99 → False) → (x_2 = 999 → False) → f x_2.succ = f x_2
+-/
+#guard_msgs(pass trace, all) in
+#print equations f
+
+def g (x : Nat) : Nat :=
+  match x with
+  | 0    => 1
+  | 100  => 2
+  | 1000 => 3
+  | x+1  => x
+
+/--
+info: equations:
+@[defeq] theorem g.eq_1 : g 0 = 1
+@[defeq] theorem g.eq_2 : g 100 = 2
+@[defeq] theorem g.eq_3 : g 1000 = 3
+theorem g.eq_4 : ∀ (x_2 : Nat), (x_2 = 99 → False) → (x_2 = 999 → False) → g x_2.succ = x_2
+-/
+#guard_msgs(pass trace, all) in
+#print equations g


### PR DESCRIPTION
This PR avoid reducing at transparency all in equational theorem
generation. Fixes #10651.
