### PR TITLE
fix: preserve more information through `liftCommandElabM`

### DIFF
--- a/src/Lean/Elab/Command.lean
+++ b/src/Lean/Elab/Command.lean
@@ -818,6 +818,7 @@ private def liftCommandElabMCore (cmd : CommandElabM α) (throwOnError : Bool) :
       fileMap := ctx.fileMap
       currRecDepth := ctx.currRecDepth
       currMacroScope := ctx.currMacroScope
+      quotContext? := ctx.quotContext
       ref := ctx.ref
       snap? := none
       cancelTk? := ctx.cancelTk?
@@ -828,7 +829,12 @@ private def liftCommandElabMCore (cmd : CommandElabM α) (throwOnError : Bool) :
       maxRecDepth := ctx.maxRecDepth
       ngen := s.ngen
       auxDeclNGen := s.auxDeclNGen
-      scopes := [{ header := "", opts := ctx.options }]
+      scopes := [{
+        header := ""
+        opts := ctx.options
+        currNamespace := ctx.currNamespace
+        openDecls := ctx.openDecls
+      }]
       infoState.enabled := s.infoState.enabled
     }
   modify fun coreState => { coreState with

--- a/tests/lean/run/issue10674.lean
+++ b/tests/lean/run/issue10674.lean
@@ -1,0 +1,14 @@
+import Lean
+
+def Foo.ExampleDL := 42
+
+elab "s3(" dl:ident ")" : term => do
+  -- remove the `Lean.liftCommandElabM` to remove error below
+  let _ ← Lean.liftCommandElabM (Lean.resolveGlobalConstNoOverload dl)
+  return .const ``Nat []
+
+#check s3(Foo.ExampleDL)
+
+namespace Foo
+-- "Unknown constant `ExampleDL`". Reproducible in https://live.lean-lang.org/
+#check s3(ExampleDL)


### PR DESCRIPTION
This PR changes `liftCommandElabM` to preserve `quotContext`, `currNamespace` and `openDecls` when running the `CommandElabM` action.

Fixes #10674