### PR TITLE
fix: RC dec insertion for unused variables

### DIFF
--- a/src/Lean/Compiler/IR/RC.lean
+++ b/src/Lean/Compiler/IR/RC.lean
@@ -349,6 +349,10 @@ private def addDecIfNeeded (ctx : Context) (x : VarId) (b : FnBody) (bLiveVars :
   else b
 
 private def processVDecl (ctx : Context) (z : VarId) (t : IRType) (v : Expr) (b : FnBody) (bLiveVars : LiveVars) : FnBody × LiveVars :=
+  -- `z` can be unused in `b` so we might have to drop it. Note that we do not remove the let
+  -- because we are in the impure phase of the compiler so `v` can have side effects that we don't
+  -- want to loose.
+  let b := addDecIfNeeded ctx z b bLiveVars
   let b := match v with
     | .ctor _ ys | .reuse _ _ _ ys | .pap _ ys =>
       addIncBeforeConsumeAll ctx ys (.vdecl z t v b) bLiveVars


### PR DESCRIPTION
This PR fixes an oversight in the RC insertion phase in the code generator.

If the code generator encounters a `let` that is unused (which is perfectly reasonable as at this
phase we are in an impure IR and as such allow for side effects to happen so we cannot remove all
unused `let`) it didn't insert a `dec` instruction for this variable. This has previously gone
unnoticed because at this point in the compiler basically all unused lets are removed already
anyways. However with the `IO`/`ST` token erasure coming up they will be very frequent.
