### PR TITLE
fix: `simp` should not pick up inaccessible definitional equations

### DIFF
--- a/src/Lean/Meta/Tactic/Simp/SimpTheorems.lean
+++ b/src/Lean/Meta/Tactic/Simp/SimpTheorems.lean
@@ -670,6 +670,16 @@ def mkSimpExt (name : Name := by exact decl_name%) : IO SimpExtension :=
     name     := name
     initial  := {}
     addEntry := fun d e => d.addSimpEntry e
+    exportEntry? := fun lvl e => do
+      -- export only annotations on public decls
+      let declName := match e with
+        | .thm t => match t.origin with
+          | .decl n _ _ => n
+          | _ => unreachable!
+        | .toUnfold n => n
+        | .toUnfoldThms n _ => n
+      guard (lvl == .private || !isPrivateName declName)
+      return e
   }
 
 abbrev SimpExtensionMap := Std.HashMap Name SimpExtension

--- a/tests/pkg/module/Module/Basic.lean
+++ b/tests/pkg/module/Module/Basic.lean
@@ -457,3 +457,5 @@ info: @[expose] meta def msecexp : Nat :=
 #guard_msgs in
 #with_exporting
 #print msecexp
+
+attribute [simp] f_struct

--- a/tests/pkg/module/Module/Imported.lean
+++ b/tests/pkg/module/Module/Imported.lean
@@ -153,3 +153,10 @@ info: f_exp_wfrec.induct_unfolding (motive : Nat → Nat → Nat → Prop) (case
 /-- error: Invalid definition `nonMeta`, may not access declaration `pubMeta` marked as `meta` -/
 #guard_msgs in
 def nonMeta := pubMeta
+
+/-! `simp` should not pick up inaccessible definitional equations. -/
+
+/-- error: `simp` made no progress -/
+#guard_msgs in
+theorem f_struct_eq : f_struct 0 = 0 := by
+  simp


### PR DESCRIPTION
Fixes #10671