### PR TITLE
refactor: no public section in Elab.Induction 

### DIFF
--- a/src/Lean/Elab/Tactic/Ext.lean
+++ b/src/Lean/Elab/Tactic/Ext.lean
@@ -246,7 +246,6 @@ def applyExtTheoremAt (goal : MVarId) : MetaM (List MVarId) := goal.withContext 
 @[builtin_tactic applyExtTheorem] def evalApplyExtTheorem : Tactic := fun _ => do
   liftMetaTactic applyExtTheoremAt
 
-open TSyntax.Compat in
 /--
 Postprocessor for `withExt` which runs `rintro` with the given patterns when the target is a
 pi type.

--- a/src/Lean/Elab/Tactic/Induction.lean
+++ b/src/Lean/Elab/Tactic/Induction.lean
@@ -1036,7 +1036,7 @@ def elabFunTarget (cases : Bool) (stx : Syntax) : TacticM (ElimInfo × Array Exp
       | .param => params := params.push a
       | .target => targets := targets.push a
     if cases then
-      trace[Elab.cases] "us: {us}\nparams: {params}\ntargets: {targets}"Ok
+      trace[Elab.cases] "us: {us}\nparams: {params}\ntargets: {targets}"
     else
       trace[Elab.induction] "us: {us}\nparams: {params}\ntargets: {targets}"
 

--- a/src/Lean/Elab/Tactic/RCases.lean
+++ b/src/Lean/Elab/Tactic/RCases.lean
@@ -24,13 +24,13 @@ public register_option linter.unusedRCasesPattern : Bool := {
   descr := "enable the 'unused rcases pattern' linter"
 }
 
-instance : Coe Ident (TSyntax `rcasesPat) where
+public instance : Coe Ident (TSyntax `rcasesPat) where
   coe stx := Unhygienic.run `(rcasesPat| $stx:ident)
-instance : Coe (TSyntax `rcasesPat) (TSyntax ``rcasesPatMed) where
+public instance : Coe (TSyntax `rcasesPat) (TSyntax ``rcasesPatMed) where
   coe stx := Unhygienic.run `(rcasesPatMed| $stx:rcasesPat)
-instance : Coe (TSyntax ``rcasesPatMed) (TSyntax ``rcasesPatLo) where
+public instance : Coe (TSyntax ``rcasesPatMed) (TSyntax ``rcasesPatLo) where
   coe stx := Unhygienic.run `(rcasesPatLo| $stx:rcasesPatMed)
-instance : Coe (TSyntax `rcasesPat) (TSyntax `rintroPat) where
+public instance : Coe (TSyntax `rcasesPat) (TSyntax `rintroPat) where
   coe stx := Unhygienic.run `(rintroPat| $stx:rcasesPat)
 
 -- These frequently cause bootstrapping issues. Commented out for now, using `List/-Σ-/` and `List/-Π-/` instead.


### PR DESCRIPTION
This PR removes `public section` in `Elab.Induction`.