### PR TITLE
feat: add tactics to `grind` interactive mode

### DIFF
--- a/src/Init/Grind/Interactive.lean
+++ b/src/Init/Grind/Interactive.lean
@@ -27,6 +27,11 @@ syntax (name := skip) "skip" : grind
 syntax (name := lia) "lia" : grind
 /-- `ring` (commutative) rings and fields. -/
 syntax (name := ring) "ring" : grind
+/-- `ac` associativity and commutativity procedure. -/
+syntax (name := ac) "ac" : grind
+/-- `linarith` linear arithmetic. -/
+syntax (name := linarith) "linarith" : grind
+
 /-- The `sorry` tactic is a temporary placeholder for an incomplete tactic proof. -/
 syntax (name := «sorry») "sorry" : grind
 
@@ -122,5 +127,20 @@ macro:1 x:grind tk:" <;> " y:grind:2 : grind => `(grind|
     $x:grind
     with_annotate_state $tk skip
     all_goals $y:grind)
+
+/-- `first | tac | ...` runs each `tac` until one succeeds, or else fails. -/
+syntax (name := first) "first " withPosition((ppDedent(ppLine) colGe "| " grindSeq)+) : grind
+
+/-- `try tac` runs `tac` and succeeds even if `tac` failed. -/
+macro "try " t:grindSeq : grind => `(grind| first | $t | skip)
+
+/-- `fail_if_success t` fails if the tactic `t` succeeds. -/
+syntax (name := failIfSuccess) "fail_if_success " grindSeq : grind
+
+/-- `admit` is a synonym for `sorry`. -/
+macro "admit" : grind => `(grind| sorry)
+
+/-- `fail msg` is a tactic that always fails, and produces an error using the given message. -/
+syntax (name := fail) "fail" (ppSpace str)? : grind
 
 end Lean.Parser.Tactic.Grind

--- a/src/Lean/Elab/Tactic/Basic.lean
+++ b/src/Lean/Elab/Tactic/Basic.lean
@@ -363,6 +363,10 @@ instance : MonadExcept Exception TacticM where
 def withoutRecover (x : TacticM α) : TacticM α :=
   withReader (fun ctx => { ctx with recover := false }) x
 
+/-- Execute `x` with error recovery disabled -/
+def withRecover (recover : Bool) (x : TacticM α) : TacticM α :=
+  withReader (fun ctx => { ctx with recover }) x
+
 /--
 Like `throwErrorAt`, but, if recovery is enabled, logs the error instead.
 -/

--- a/tests/lean/run/grind_interactive.lean
+++ b/tests/lean/run/grind_interactive.lean
@@ -224,6 +224,24 @@ example : h bs = 1 → h as ≠ 0 := by
     focus instantiate
     instantiate
 
+/--
+error: Failed here
+case grind
+bs as : List Nat
+h : _root_.h bs = 1
+h_1 : _root_.h as = 0
+⊢ False
+-/
+#guard_msgs in
+example : h bs = 1 → h as ≠ 0 := by
+  grind [h.eq_def] =>
+    skip
+    try fail
+    fail_if_success fail
+    first | fail | done | skip
+    fail "Failed here"
+    done
+
 example : h bs = 1 → h as ≠ 0 := by
   grind [h.eq_def] =>
     instantiate
@@ -273,3 +291,21 @@ example : g bs = 1 → g as ≠ 0 := by
     tactic =>
       rw [h_2] at h_1
       simp [g] at h_1
+
+open Std
+example [IntModule α] [LE α] [LT α] [LawfulOrderLT α] [IsPreorder α] [OrderedAdd α] (a b c : α)
+    : (2:Int) • a + b < c + a + a → b = c → False := by
+  grind => linarith
+
+example {α : Sort u} (op : α → α → α) [Associative op] (a b c : α)
+    : op a (op b b) = c → op c c = op (op c a) (op b b) := by
+  grind => ac
+
+/--
+error: The tactic provided to `fail_if_success` succeeded but was expected to fail:
+  ac
+-/
+#guard_msgs in
+example {α : Sort u} (op : α → α → α) [Associative op] (a b c : α)
+    : op a (op b b) = c → op c c = op (op c a) (op b b) := by
+  grind => fail_if_success ac


### PR DESCRIPTION
This PR adds the tactics `linarith`, `ac`, `fail`, `first`, `try`, `fail_if_success`, and `admit` to `grind` interactive mode.

