### PR TITLE
feat: improve `ac`, `linarith`, `lia`, and `ring` in `grind` interactive mode

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/PP.lean
+++ b/src/Lean/Meta/Tactic/Grind/PP.lean
@@ -213,31 +213,31 @@ private def ppOffset : M Unit := do
     ms := ms.push <| .trace { cls := `assign } m!"{Arith.quoteIfArithTerm e} := {val}" #[]
   pushMsg <| .trace { cls := `offset } "Assignment satisfying offset constraints" ms
 
-private def ppCutsat : M Unit := do
-  let goal ← read
+def Arith.Cutsat.pp? (goal : Goal) : MetaM (Option MessageData) := do
   let s ← Arith.Cutsat.cutsatExt.getStateCore goal
   let nodes := s.varMap
-  if nodes.isEmpty then return ()
+  if nodes.isEmpty then return none
   let model ← Arith.Cutsat.mkModel goal
-  if model.isEmpty then return ()
+  if model.isEmpty then return none
   let mut ms := #[]
   for (e, val) in model do
     ms := ms.push <| .trace { cls := `assign } m!"{Arith.quoteIfArithTerm e} := {val}" #[]
-  pushMsg <| .trace { cls := `cutsat } "Assignment satisfying linear constraints" ms
+  return some <| .trace { cls := `cutsat } "Assignment satisfying linear constraints" ms
+
+private def ppCutsat : M Unit := do
+  let some msg ← Arith.Cutsat.pp? (← read) | return ()
+  pushMsg msg
 
 private def ppCommRing : M Unit := do
-  let goal ← read
-  let some msg ← Arith.CommRing.pp? goal | return ()
+  let some msg ← Arith.CommRing.pp? (← read) | return ()
   pushMsg msg
 
 private def ppLinarith : M Unit := do
-  let goal ← read
-  let some msg ← Arith.Linear.pp? goal | return ()
+  let some msg ← Arith.Linear.pp? (← read) | return ()
   pushMsg msg
 
 private def ppAC : M Unit := do
-  let goal ← read
-  let some msg ← AC.pp? goal | return ()
+  let some msg ← AC.pp? (← read) | return ()
   pushMsg msg
 
 private def ppThresholds (c : Grind.Config) : M Unit := do

--- a/tests/lean/run/grind_interactive.lean
+++ b/tests/lean/run/grind_interactive.lean
@@ -309,3 +309,41 @@ error: The tactic provided to `fail_if_success` succeeded but was expected to fa
 example {α : Sort u} (op : α → α → α) [Associative op] (a b c : α)
     : op a (op b b) = c → op c c = op (op c a) (op b b) := by
   grind => fail_if_success ac
+
+example {α : Sort u} (op : α → α → α) [Associative op] (a b c : α)
+    : op a (op b b) = c → op c c = op (op c a) (op b b) := by
+  grind =>
+    fail_if_success linarith
+    ac
+
+/--
+trace: [cutsat] Assignment satisfying linear constraints
+  [assign] y := 3
+  [assign] z := 0
+  [assign] x := 4
+-/
+#guard_msgs in
+example : y > (z+1)*2 → x > y → x > 10 := by
+  grind =>
+    lia
+    sorry
+
+/--
+trace: [ring] Ring `Int`
+  [basis] Basis
+    [_] 2 * (z * x) + 2 * x + -1 = 0
+    [_] y + -2 * z + -2 = 0
+  [diseqs] Disequalities
+    [_] ¬x = 0
+-/
+#guard_msgs in
+example {y z x : Int} : y = (z+1)*2 → x*y = 1 → x = 0 := by
+  grind =>
+    ring
+    sorry
+
+#guard_msgs in
+example {y z x : Int} : y = (z+1)*2 → x*y = 1 → x = 0 := by
+  grind -verbose =>
+    ring
+    sorry


### PR DESCRIPTION
This PR improves the tactics `ac`, `linarith`, `lia`, `ring` tactics in `grind` interactive mode. They now fail if no progress has been made. They also generate an info message with counterexample/basis if the goal was not closed.
