### PR TITLE
fix: turn `meta import` into `import` in `Init.Data.ToString`

### DIFF
--- a/src/Init/Data/ToString.lean
+++ b/src/Init/Data/ToString.lean
@@ -8,4 +8,4 @@ module
 prelude
 public import Init.Data.ToString.Basic
 public import Init.Data.ToString.Macro
-public meta import Init.Data.ToString.Name
+public import Init.Data.ToString.Name


### PR DESCRIPTION
This PR makes sure that we always properly import `Init.Data.ToString.Name` when importing `Init`.
