### PR TITLE
fix: don't display CSS color picker in Lean files in VS Code

### DIFF
--- a/src/Lean/Data/Lsp/Capabilities.lean
+++ b/src/Lean/Data/Lsp/Capabilities.lean
@@ -111,6 +111,7 @@ structure ServerCapabilities where
   codeActionProvider?       : Option CodeActionOptions       := none
   inlayHintProvider?        : Option InlayHintOptions        := none
   signatureHelpProvider?    : Option SignatureHelpOptions    := none
+  colorProvider?            : Option DocumentColorOptions    := none
   experimental?             : Option LeanServerCapabilities  := none
   deriving ToJson, FromJson
 

--- a/src/Lean/Data/Lsp/LanguageFeatures.lean
+++ b/src/Lean/Data/Lsp/LanguageFeatures.lean
@@ -705,5 +705,24 @@ structure SignatureHelpOptions extends WorkDoneProgressOptions where
   retriggerCharacters? : Option (Array String) := none
   deriving FromJson, ToJson
 
+structure DocumentColorParams extends WorkDoneProgressParams, PartialResultParams where
+  textDocument : TextDocumentIdentifier
+  deriving FromJson, ToJson
+
+structure Color where
+  red : Float
+  green : Float
+  blue : Float
+  alpha : Float
+  deriving FromJson, ToJson
+
+structure ColorInformation where
+  range : Range
+  color : Color
+  deriving FromJson, ToJson
+
+structure DocumentColorOptions extends WorkDoneProgressOptions where
+  deriving FromJson, ToJson
+
 end Lsp
 end Lean

--- a/src/Lean/Server/FileSource.lean
+++ b/src/Lean/Server/FileSource.lean
@@ -120,6 +120,9 @@ instance : FileSource InlayHintParams where
 instance : FileSource SignatureHelpParams where
   fileSource p := fileSource p.textDocument
 
+instance : FileSource DocumentColorParams where
+  fileSource p := fileSource p.textDocument
+
 /--
 Yields the file source of `item` by attempting to obtain `mod : Name` from `item.data?`. \
 Panics if `item.data?` is not present or does not contain a `mod` field and the first element of a

--- a/src/Lean/Server/FileWorker/RequestHandling.lean
+++ b/src/Lean/Server/FileWorker/RequestHandling.lean
@@ -482,6 +482,16 @@ partial def handleWaitForDiagnostics (p : WaitForDiagnosticsParams)
     return doc.reporter.bindCheap (fun _ => doc.cmdSnaps.waitAll)
       |>.mapCheap fun _ => pure WaitForDiagnostics.mk
 
+def handleDocumentColor (_ : DocumentColorParams) :
+    RequestM (RequestTask (Array ColorInformation)) :=
+  -- By default, if no document color provider is registered, VS Code itself provides
+  -- a color picker decoration for all parts of the file that look like CSS colors.
+  -- Disabling this setting on the client-side is not possible because of
+  -- https://github.com/microsoft/vscode/issues/91533,
+  -- so we just provide an empty document color provider here that overrides the
+  -- VS Code one.
+  return .pure #[]
+
 builtin_initialize
   registerLspRequestHandler
     "textDocument/waitForDiagnostics"
@@ -539,6 +549,11 @@ builtin_initialize
     SignatureHelpParams
     (Option SignatureHelp)
     handleSignatureHelp
+  registerLspRequestHandler
+    "textDocument/documentColor"
+    DocumentColorParams
+    (Array ColorInformation)
+    handleDocumentColor
   registerLspRequestHandler
     "$/lean/plainGoal"
     PlainGoalParams

--- a/src/Lean/Server/Watchdog.lean
+++ b/src/Lean/Server/Watchdog.lean
@@ -1600,6 +1600,7 @@ def mkLeanServerCapabilities : ServerCapabilities := {
   signatureHelpProvider? := some {
     triggerCharacters? := some #[" "]
   }
+  colorProvider? := some {}
   experimental? := some {
     moduleHierarchyProvider? := some {}
     rpcProvider? := some {


### PR DESCRIPTION
This PR fixes a bug in combination with VS Code where Lean code that looks like CSS color codes would display a color picker decoration.

VS Code displays this decoration by default for all languages, not just CSS. Due to https://github.com/microsoft/vscode/issues/91533, this setting cannot be disabled in the client on a per-language basis. However, we can override the default behavior by providing a color provider of our own. This PR implements an empty color provider to override the VS Code one.
