### PR TITLE
chore: restore #8656

### DIFF
--- a/src/lake/Lake/CLI/Init.lean
+++ b/src/lake/Lake/CLI/Init.lean
@@ -191,7 +191,6 @@ defaultTargets = [{repr libRoot}]
 
 [leanOptions]
 pp.unicode.fun = true # pretty-prints `fun a ↦ b`
-autoImplicit = false
 relaxedAutoImplicit = false
 weak.linter.mathlibStandardSet = true
 maxSynthPendingDepth = 3


### PR DESCRIPTION
This PR restores the change in #8656, which removed `autoImplicit = false` from the default lake template (per previous discussions linked there). This was accidentally reverted in #8866.