### PR TITLE
feat: hover information for `grind` anchors

### DIFF
--- a/tests/lean/run/grind_interactive.lean
+++ b/tests/lean/run/grind_interactive.lean
@@ -414,6 +414,11 @@ example : (∀ x, q x) → (∀ x, p x → p (f x)) → p x → p (f (f x)) := b
     show_thms
     instantiate #bfb8
 
+example : (∀ x, q x) → (∀ x, p x → p (f x)) → p x → p (f (f x)) := by
+  grind =>
+    show_thms
+    instantiate #bfb8
+
 /-- error: no local theorems -/
 #guard_msgs in
 example : (∀ x, q x) → (∀ x, p x → p (f x)) → p x → p (f (f x)) := by


### PR DESCRIPTION
This PR implements hover information for `grind` anchors. Anchors are stable hash codes for referencing terms in the grind state. The anchors will be used when auto generating tactic scripts. The hover display the following information:

1- In the `instantiate` tactic, it displays the type of the theorem being instantiated.
<img width="952" height="125" alt="image" src="https://github.com/user-attachments/assets/be949b87-cf9b-4f75-abe0-17751295de93" />

2- In the `cases` tactic, the hover information depends on the kind of case-split. 
  a) Proposition
<img width="1019" height="125" alt="image" src="https://github.com/user-attachments/assets/253e2927-f18e-49ab-a8fc-2144657406d8" />

  b) A hypotheses. In this case, you can opt to replace the anchor with the hypothesis' name if it is accessible.
<img width="1019" height="178" alt="image" src="https://github.com/user-attachments/assets/858b3751-4ef9-492d-a42f-c0743753a7de" />

  c) A term. The hover displays just the type, by `grind` logs a silent information with additional information
  
<img width="1376" height="148" alt="image" src="https://github.com/user-attachments/assets/30078ca4-a886-49d9-912e-866f3567b0da" />

  