### PR TITLE
chore: add .vscode/settings.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ tasks.json
 settings.json
 .gdb_history
 .vscode/*
-!.vscode/settings.json
 script/__pycache__
 *.produced.out
 CMakeSettings.json


### PR DESCRIPTION
This PR adds `.vscode/settings.json` to our `.gitignore`, which allows Lean 4 developers to set local workspace settings. We already use the the workspace file for settings in core, so this shouldn't cause any problems.