### PR TITLE
chore: rename `String.Range` to `Lean.Syntax.Range`

### DIFF
--- a/src/Lean/Data/Lsp/Utf16.lean
+++ b/src/Lean/Data/Lsp/Utf16.lean
@@ -89,15 +89,15 @@ def leanPosToLspPos (text : FileMap) : Lean.Position → Lsp.Position
 def utf8PosToLspPos (text : FileMap) (pos : String.Pos.Raw) : Lsp.Position :=
   text.leanPosToLspPos (text.toPosition pos)
 
-/-- Gets the LSP range from a `String.Range`. -/
-def utf8RangeToLspRange (text : FileMap) (range : String.Range) : Lsp.Range :=
+/-- Gets the LSP range from a `Lean.Syntax.Range`. -/
+def utf8RangeToLspRange (text : FileMap) (range : Lean.Syntax.Range) : Lsp.Range :=
   { start := text.utf8PosToLspPos range.start, «end» := text.utf8PosToLspPos range.stop }
 
 /-- Gets the LSP range of syntax `stx`. -/
 def lspRangeOfStx? (text : FileMap) (stx : Syntax) (canonicalOnly := false) : Option Lsp.Range :=
   text.utf8RangeToLspRange <$> stx.getRange? canonicalOnly
 
-def lspRangeToUtf8Range (text : FileMap) (range : Lsp.Range) : String.Range :=
+def lspRangeToUtf8Range (text : FileMap) (range : Lsp.Range) : Lean.Syntax.Range :=
   { start := text.lspPosToUtf8Pos range.start, stop := text.lspPosToUtf8Pos range.end }
 
 end FileMap

--- a/src/Lean/DocString/Links.lean
+++ b/src/Lean/DocString/Links.lean
@@ -100,7 +100,7 @@ environment variable. If this environment variable is not set, a manual root pro
 built is used (typically this is the version corresponding to the current release). If no such root
 is available, the latest version of the manual is used.
 -/
-def rewriteManualLinksCore (s : String) : BaseIO (Array (String.Range × String) × String) := do
+def rewriteManualLinksCore (s : String) : BaseIO (Array (Lean.Syntax.Range × String) × String) := do
   let scheme := "lean-manual://"
   let mut out := ""
   let mut errors := #[]

--- a/src/Lean/Elab/DocString/Builtin.lean
+++ b/src/Lean/Elab/DocString/Builtin.lean
@@ -122,7 +122,7 @@ private def onlyCode [Monad m] [MonadError m] (xs : TSyntaxArray `inline) : m St
   else
     throwError "Expected precisely 1 code argument"
 
-private def strLitRange [Monad m] [MonadFileMap m] (s : StrLit) : m String.Range := do
+private def strLitRange [Monad m] [MonadFileMap m] (s : StrLit) : m Lean.Syntax.Range := do
   let pos := (s.raw.getPos? (canonicalOnly := true)).get!
   let endPos := s.raw.getTailPos? true |>.get!
   return ⟨pos, endPos⟩

--- a/src/Lean/Elab/DocString/Builtin/Parsing.lean
+++ b/src/Lean/Elab/DocString/Builtin/Parsing.lean
@@ -13,7 +13,7 @@ open Lean.Parser
 
 public section
 
-private def strLitRange [Monad m] [MonadFileMap m] (s : StrLit) : m String.Range := do
+private def strLitRange [Monad m] [MonadFileMap m] (s : StrLit) : m Lean.Syntax.Range := do
   let pos := (s.raw.getPos? (canonicalOnly := true)).get!
   let endPos := s.raw.getTailPos? true |>.get!
   return ⟨pos, endPos⟩

--- a/src/Lean/Elab/InfoTree/InlayHints.lean
+++ b/src/Lean/Elab/InfoTree/InlayHints.lean
@@ -16,7 +16,7 @@ open Lean
 
 structure InlayHintLinkLocation where
   module : Name
-  range  : String.Range
+  range  : Lean.Syntax.Range
 
 structure InlayHintLabelPart where
   value     : String
@@ -32,7 +32,7 @@ inductive InlayHintKind where
   | parameter
 
 structure InlayHintTextEdit where
-  range   : String.Range
+  range   : Lean.Syntax.Range
   newText : String
   deriving BEq
 

--- a/src/Lean/Language/Basic.lean
+++ b/src/Lean/Language/Basic.lean
@@ -74,7 +74,7 @@ inductive SnapshotTask.ReportingRange where
   /-- Inherit range from outer task if any, or else the entire file. -/
   | inherit
   /-- Use given range. -/
-  | protected some (range : String.Range)
+  | protected some (range : Lean.Syntax.Range)
   /-- Do not mark as being processed. Child nodes are still visited. -/
   | skip
 deriving Inhabited
@@ -83,7 +83,7 @@ deriving Inhabited
 Constructs a reporting range by replacing a missing range with `inherit`, which is a reasonable
 default to ensure that a range is shown in all cases.
 -/
-def SnapshotTask.ReportingRange.ofOptionInheriting : Option String.Range → SnapshotTask.ReportingRange
+def SnapshotTask.ReportingRange.ofOptionInheriting : Option Lean.Syntax.Range → SnapshotTask.ReportingRange
   | some range => .some range
   | none       => .inherit
 

--- a/src/Lean/Linter/ConstructorAsVariable.lean
+++ b/src/Lean/Linter/ConstructorAsVariable.lean
@@ -38,7 +38,7 @@ def constructorNameAsVariable : Linter where
       | return
 
     let infoTrees := (← get).infoState.trees.toArray
-    let warnings : IO.Ref (Std.HashMap String.Range (Syntax × Name × Name)) ← IO.mkRef {}
+    let warnings : IO.Ref (Std.HashMap Lean.Syntax.Range (Syntax × Name × Name)) ← IO.mkRef {}
 
     for tree in infoTrees do
       tree.visitM' (postNode := fun ci info _ => do

--- a/src/Lean/Linter/UnusedSimpArgs.lean
+++ b/src/Lean/Linter/UnusedSimpArgs.lean
@@ -46,7 +46,7 @@ def unusedSimpArgs : Linter where
     let some cmdStxRange := cmdStx.getRange?  | return
 
     let infoTrees := (← get).infoState.trees.toArray
-    let masksMap : IO.Ref (Std.HashMap String.Range (Syntax × Array Bool)) ← IO.mkRef {}
+    let masksMap : IO.Ref (Std.HashMap Lean.Syntax.Range (Syntax × Array Bool)) ← IO.mkRef {}
 
     for tree in infoTrees do
       tree.visitM' (postNode := fun ci info _ => do

--- a/src/Lean/Linter/UnusedVariables.lean
+++ b/src/Lean/Linter/UnusedVariables.lean
@@ -369,11 +369,11 @@ structure References where
   the spans for `foo`, `bar`, and `baz`. Global definitions are always treated as used.
   (It would be nice to be able to detect unused global definitions but this requires more
   information than the linter framework can provide.) -/
-  constDecls : Std.HashSet String.Range := ∅
+  constDecls : Std.HashSet Lean.Syntax.Range := ∅
   /-- The collection of all local declarations, organized by the span of the declaration.
   We collapse all declarations declared at the same position into a single record using
   `FVarDefinition.aliases`. -/
-  fvarDefs : Std.HashMap String.Range FVarDefinition := ∅
+  fvarDefs : Std.HashMap Lean.Syntax.Range FVarDefinition := ∅
   /-- The set of `FVarId`s that are used directly. These may or may not be aliases. -/
   fvarUses : Std.HashSet FVarId := ∅
   /-- A mapping from alias to original FVarId. We don't guarantee that the value is not itself
@@ -386,7 +386,7 @@ structure References where
 
 /-- Collect information from the `infoTrees` into `References`.
 See `References` for more information about the return value. -/
-partial def collectReferences (infoTrees : Array Elab.InfoTree) (cmdStxRange : String.Range)
+partial def collectReferences (infoTrees : Array Elab.InfoTree) (cmdStxRange : Lean.Syntax.Range)
     (linterSets : LinterSets) :
     StateRefT References IO Unit := ReaderT.run (r := false) <| go infoTrees none
 where

--- a/src/Lean/Linter/Util.lean
+++ b/src/Lean/Linter/Util.lean
@@ -22,7 +22,7 @@ The result is `some []` if no `MacroExpansionInfo` was found on the way and
 
 Return the result reversed, s.t. the macro expansion that would be applied to
 the original syntax first is the first element of the returned list. -/
-def collectMacroExpansions? {m} [Monad m] (range : String.Range) (tree : Elab.InfoTree) : m <| Option <| List Elab.MacroExpansionInfo := do
+def collectMacroExpansions? {m} [Monad m] (range : Lean.Syntax.Range) (tree : Elab.InfoTree) : m <| Option <| List Elab.MacroExpansionInfo := do
   if let .some <| .some result ← go then
     return some result.reverse
   else

--- a/src/Lean/Meta/TryThis.lean
+++ b/src/Lean/Meta/TryThis.lean
@@ -181,10 +181,10 @@ structure TryThisInfo : Type where
 
 /-! # Formatting -/
 
-/-- Yields `(indent, column)` given a `FileMap` and a `String.Range`, where `indent` is the number
+/-- Yields `(indent, column)` given a `FileMap` and a `Lean.Syntax.Range`, where `indent` is the number
 of spaces by which the line that first includes `range` is initially indented, and `column` is the
 column `range` starts at in that line. -/
-def getIndentAndColumn (map : FileMap) (range : String.Range) : Nat × Nat :=
+def getIndentAndColumn (map : FileMap) (range : Lean.Syntax.Range) : Nat × Nat :=
   let start := map.source.findLineStart range.start
   let body := map.source.findAux (· ≠ ' ') range.start start
   (start.byteDistance body, start.byteDistance range.start)
@@ -229,7 +229,7 @@ def Suggestion.pretty (s : Suggestion) (w : Option Nat := none) (indent column :
     CoreM String := do
   s.suggestion.prettyExtra w indent column
 
-def Suggestion.processEdit (s : Suggestion) (range : String.Range) : CoreM Lsp.TextEdit := do
+def Suggestion.processEdit (s : Suggestion) (range : Lean.Syntax.Range) : CoreM Lsp.TextEdit := do
   let map ← getFileMap
   -- FIXME: this produces incorrect results when `by` is at the beginning of the line, i.e.
   -- replacing `tac` in `by tac`, because the next line will only be 2 space indented

--- a/src/Lean/Server/CodeActions/Provider.lean
+++ b/src/Lean/Server/CodeActions/Provider.lean
@@ -79,7 +79,7 @@ This is a pure syntax pass, without regard to elaboration information.
 
 The return value is either a selected tactic, or a selected point in a tactic sequence.
 -/
-partial def findTactic? (preferred : String.Pos.Raw → Bool) (range : String.Range)
+partial def findTactic? (preferred : String.Pos.Raw → Bool) (range : Lean.Syntax.Range)
     (root : Syntax) : Option FindTacticResult := do _ ← visit root; ← go [] root
 where
   /-- Returns `none` if we should not visit this syntax at all, and `some false` if we only
@@ -148,7 +148,7 @@ Returns the info tree corresponding to a syntax, using `kind` and `range` for id
 (This is not foolproof, but it is a fairly accurate proxy for `Syntax` equality and a lot cheaper
 than deep comparison.)
 -/
-partial def findInfoTree? (kind : SyntaxNodeKind) (tgtRange : String.Range)
+partial def findInfoTree? (kind : SyntaxNodeKind) (tgtRange : Lean.Syntax.Range)
   (ctx? : Option ContextInfo) (t : InfoTree)
   (f : ContextInfo → Info → Bool) (canonicalOnly := false) :
     Option (ContextInfo × InfoTree) :=

--- a/src/Lean/Server/CodeActions/UnknownIdentifier.lean
+++ b/src/Lean/Server/CodeActions/UnknownIdentifier.lean
@@ -16,7 +16,7 @@ namespace Lean.Server.FileWorker
 open Lean.Lsp
 open Lean.Server.Completion
 
-private def compareRanges (r1 r2 : String.Range) : Ordering :=
+private def compareRanges (r1 r2 : Lean.Syntax.Range) : Ordering :=
   if r1.start < r2.start then
     .lt
   else if r1.start > r2.start then
@@ -28,8 +28,8 @@ private def compareRanges (r1 r2 : String.Range) : Ordering :=
   else
     .eq
 
-def waitUnknownIdentifierRanges (doc : EditableDocument) (requestedRange : String.Range)
-    : BaseIO (Array String.Range × Bool) := do
+def waitUnknownIdentifierRanges (doc : EditableDocument) (requestedRange : Lean.Syntax.Range)
+    : BaseIO (Array Lean.Syntax.Range × Bool) := do
   let text := doc.meta.text
   let some parsedSnap := RequestM.findCmdParsedSnap doc requestedRange.start |>.get
     | return (#[], false)
@@ -39,13 +39,13 @@ def waitUnknownIdentifierRanges (doc : EditableDocument) (requestedRange : Strin
   for msg in msgLog.unreported do
     if ! msg.data.hasTag (· == unknownIdentifierMessageTag) then
       continue
-    let msgRange : String.Range := ⟨text.ofPosition msg.pos, text.ofPosition <| msg.endPos.getD msg.pos⟩
+    let msgRange : Lean.Syntax.Range := ⟨text.ofPosition msg.pos, text.ofPosition <| msg.endPos.getD msg.pos⟩
     if ! msgRange.overlaps requestedRange
         (includeFirstStop := true) (includeSecondStop := true) then
       continue
     ranges := ranges.push msgRange
   let isAnyUnknownIdentifierMessage := ! ranges.isEmpty
-  let autoImplicitUsages : ServerTask (Std.TreeSet String.Range compareRanges) :=
+  let autoImplicitUsages : ServerTask (Std.TreeSet Lean.Syntax.Range compareRanges) :=
     tree.foldInfosInRange requestedRange ∅ fun ctx i acc => Id.run do
       let .ofTermInfo ti := i
         | return acc
@@ -61,7 +61,7 @@ def waitUnknownIdentifierRanges (doc : EditableDocument) (requestedRange : Strin
   return (ranges, isAnyUnknownIdentifierMessage)
 
 def waitAllUnknownIdentifierMessageRanges (doc : EditableDocument)
-    : BaseIO (Array String.Range) := do
+    : BaseIO (Array Lean.Syntax.Range) := do
   let text := doc.meta.text
   let snaps := Language.toSnapshotTree doc.initSnap |>.getAll
   let msgLog : MessageLog := snaps.map (·.diagnostics.msgLog) |>.foldl (· ++ ·) {}
@@ -69,11 +69,11 @@ def waitAllUnknownIdentifierMessageRanges (doc : EditableDocument)
   for msg in msgLog.unreported do
     if ! msg.data.hasTag (· == unknownIdentifierMessageTag) then
       continue
-    let msgRange : String.Range := ⟨text.ofPosition msg.pos, text.ofPosition <| msg.endPos.getD msg.pos⟩
+    let msgRange : Lean.Syntax.Range := ⟨text.ofPosition msg.pos, text.ofPosition <| msg.endPos.getD msg.pos⟩
     ranges := ranges.push msgRange
   let (cmdSnaps, _) := doc.cmdSnaps.waitAll.get
   for snap in cmdSnaps do
-    let autoImplicitUsages : Std.TreeSet String.Range compareRanges :=
+    let autoImplicitUsages : Std.TreeSet Lean.Syntax.Range compareRanges :=
       snap.infoTree.foldInfo (init := ∅) fun ctx i acc => Id.run do
         let .ofTermInfo ti := i
           | return acc
@@ -240,7 +240,7 @@ def importAllUnknownIdentifiersCodeAction (params : CodeActionParams) (kind : St
 def handleUnknownIdentifierCodeAction
     (id             : JsonRpc.RequestID)
     (params         : CodeActionParams)
-    (requestedRange : String.Range)
+    (requestedRange : Lean.Syntax.Range)
     (kind           : String)
     : RequestM (Array CodeAction) := do
   let rc ← read
@@ -315,7 +315,7 @@ def handleUnknownIdentifierCodeAction
 def handleResolveImportAllUnknownIdentifiersCodeAction?
     (id                      : JsonRpc.RequestID)
     (action                  : CodeAction)
-    (unknownIdentifierRanges : Array String.Range)
+    (unknownIdentifierRanges : Array Lean.Syntax.Range)
     : RequestM (Option CodeAction) := do
   let rc ← read
   let doc := rc.doc

--- a/src/Lean/Server/Completion/SyntheticCompletion.lean
+++ b/src/Lean/Server/Completion/SyntheticCompletion.lean
@@ -309,7 +309,7 @@ private def isSyntheticStructFieldCompletion
         stx.getTrailingTailPos? (canonicalOnly := true)
           <|> leadingToken.getTrailingTailPos? (canonicalOnly := true)
       | return false
-    let outerBounds : String.Range := ⟨outerBoundsStart, outerBoundsStop⟩
+    let outerBounds : Lean.Syntax.Range := ⟨outerBoundsStart, outerBoundsStop⟩
 
     let isCompletionInEmptyBlock :=
       fieldsAndSeps.isEmpty && outerBounds.contains hoverPos (includeStop := true)

--- a/src/Lean/Server/FileWorker/InlayHints.lean
+++ b/src/Lean/Server/FileWorker/InlayHints.lean
@@ -61,7 +61,7 @@ end Lean.Elab
 namespace Lean.Server.FileWorker
 open Lsp
 
-def applyEditToHint? (hintMod : Name) (ihi : Elab.InlayHintInfo) (range : String.Range) (newText : String) : Option Elab.InlayHintInfo := do
+def applyEditToHint? (hintMod : Name) (ihi : Elab.InlayHintInfo) (range : Lean.Syntax.Range) (newText : String) : Option Elab.InlayHintInfo := do
   let isLabelLocAffectedByEdit :=
     match ihi.label with
     | .name _ => false
@@ -85,7 +85,7 @@ def applyEditToHint? (hintMod : Name) (ihi : Elab.InlayHintInfo) (range : String
       p
     else -- `range.start <= p && p <= range.stop`
       panic! s!"Got position {p} that should have been invalidated by edit at range {range.start}-{range.stop}"
-  let shiftRange (r : String.Range) : String.Range := ⟨shift r.start, shift r.stop⟩
+  let shiftRange (r : Lean.Syntax.Range) : Lean.Syntax.Range := ⟨shift r.start, shift r.stop⟩
   return { ihi with
     position := shift ihi.position
     textEdits := ihi.textEdits.map fun edit => { edit with range := shiftRange edit.range }
@@ -164,7 +164,7 @@ def handleInlayHints (p : InlayHintParams) (s : InlayHintState) :
   -- so in addition to re-using old inlay hints from parts of the file that haven't been processed
   -- yet, we also re-use old inlay hints from parts of the file that have been processed already
   -- with the current state of the document.
-  let invalidOldInlayHintsRange : String.Range := {
+  let invalidOldInlayHintsRange : Lean.Syntax.Range := {
     start := snaps[oldFinishedSnaps - 1]?.map (·.endPos) |>.getD ⟨0⟩
     stop := snaps[finishedSnaps - 1]?.map (·.endPos) |>.getD ⟨0⟩
   }

--- a/src/Lean/Server/FileWorker/RequestHandling.lean
+++ b/src/Lean/Server/FileWorker/RequestHandling.lean
@@ -79,7 +79,7 @@ def handleHover (p : HoverParams)
     : RequestM (RequestTask (Option Hover)) := do
   let doc ← readDoc
   let text := doc.meta.text
-  let mkHover (s : String) (r : String.Range) : Hover :=
+  let mkHover (s : String) (r : Lean.Syntax.Range) : Hover :=
     let s := Hover.rewriteExamples s
     {
       contents := {
@@ -151,7 +151,7 @@ def findGoalsAt? (doc : EditableDocument) (hoverPos : String.Pos.Raw) : ServerTa
           | return .pure (oldGoals, .proceed (foldChildren := false))
         let some (pos, tailPos, trailingPos) := getPositions stx
           | return .pure (oldGoals, .proceed (foldChildren := true))
-        let snapRange : String.Range := ⟨pos, trailingPos⟩
+        let snapRange : Lean.Syntax.Range := ⟨pos, trailingPos⟩
         -- When there is no trailing whitespace, we also consider snapshots directly before the
         -- cursor.
         let hasNoTrailingWhitespace := tailPos == trailingPos
@@ -163,7 +163,7 @@ def findGoalsAt? (doc : EditableDocument) (hoverPos : String.Pos.Raw) : ServerTa
             | return (oldGoals, .proceed (foldChildren := true))
 
           let goals := infoTree.goalsAt? text hoverPos
-          let optimalSnapRange : String.Range := ⟨pos, tailPos⟩
+          let optimalSnapRange : Lean.Syntax.Range := ⟨pos, tailPos⟩
           let isOptimalGoalSet :=
             text.rangeContainsHoverPos optimalSnapRange hoverPos
                 (includeStop := hasNoTrailingWhitespace)

--- a/src/Lean/Server/InfoUtils.lean
+++ b/src/Lean/Server/InfoUtils.lean
@@ -202,7 +202,7 @@ def Info.pos? (i : Info) : Option String.Pos.Raw :=
 def Info.tailPos? (i : Info) : Option String.Pos.Raw :=
   i.stx.getTailPos? (canonicalOnly := true)
 
-def Info.range? (i : Info) : Option String.Range :=
+def Info.range? (i : Info) : Option Lean.Syntax.Range :=
   i.stx.getRange? (canonicalOnly := true)
 
 def Info.contains (i : Info) (pos : String.Pos.Raw) (includeStop := false) : Bool :=

--- a/src/Lean/Server/Requests.lean
+++ b/src/Lean/Server/Requests.lean
@@ -20,7 +20,7 @@ public import Std.Sync.Mutex
 public section
 
 /-- Checks whether `r` contains `hoverPos`, taking into account EOF according to `text`. -/
-def Lean.FileMap.rangeContainsHoverPos (text : Lean.FileMap) (r : String.Range)
+def Lean.FileMap.rangeContainsHoverPos (text : Lean.FileMap) (r : Lean.Syntax.Range)
     (hoverPos : String.Pos.Raw) (includeStop := false) : Bool :=
   -- When `hoverPos` is at the very end of the file, it is *after* the last position in `text`.
   -- However, for `includeStop = false`, all ranges stop at the last position in `text`,
@@ -32,8 +32,8 @@ def Lean.FileMap.rangeContainsHoverPos (text : Lean.FileMap) (r : String.Range)
 
 def Lean.FileMap.rangeOverlapsRequestedRange
     (text : Lean.FileMap)
-    (documentRange : String.Range)
-    (requestedRange : String.Range)
+    (documentRange : Lean.Syntax.Range)
+    (requestedRange : Lean.Syntax.Range)
     (includeDocumentRangeStop := false)
     (includeRequestedRangeStop := false)
     : Bool :=
@@ -44,8 +44,8 @@ def Lean.FileMap.rangeOverlapsRequestedRange
 
 def Lean.FileMap.rangeIncludesRequestedRange
     (text : Lean.FileMap)
-    (documentRange : String.Range)
-    (requestedRange : String.Range)
+    (documentRange : Lean.Syntax.Range)
+    (requestedRange : Lean.Syntax.Range)
     (includeDocumentRangeStop := false)
     (includeRequestedRangeStop := false)
     : Bool :=
@@ -117,7 +117,7 @@ partial def SnapshotTree.findInfoTreeAtPos (text : FileMap) (tree : SnapshotTree
         | return (none, .proceed (foldChildren := true))
       return (infoTree, .done)
 
-partial def SnapshotTree.foldInfosInRange (tree : SnapshotTree) (requestedRange : String.Range)
+partial def SnapshotTree.foldInfosInRange (tree : SnapshotTree) (requestedRange : Lean.Syntax.Range)
     (init : α) (f : Elab.ContextInfo → Elab.Info → α → α) : ServerTask α :=
   tree.foldSnaps (init := init) fun snap acc => Id.run do
     let some stx := snap.stx?
@@ -138,7 +138,7 @@ partial def SnapshotTree.foldInfosInRange (tree : SnapshotTree) (requestedRange 
       return (acc, .proceed (foldChildren := true))
 
 partial def SnapshotTree.collectMessagesInRange (tree : SnapshotTree)
-    (requestedRange : String.Range) : ServerTask MessageLog :=
+    (requestedRange : Lean.Syntax.Range) : ServerTask MessageLog :=
   tree.foldSnaps (init := .empty) fun snap log => Id.run do
     let some stx := snap.stx?
       | return .pure (log, .proceed (foldChildren := true))

--- a/src/Lean/Server/Utils.lean
+++ b/src/Lean/Server/Utils.lean
@@ -218,8 +218,8 @@ def moduleFromDocumentUri (uri : DocumentUri) : IO Name := do
 end Lean.Server
 
 /--
-Converts an UTF-8-based `String.range` in `text` to an equivalent LSP UTF-16-based `Lsp.Range`
+Converts an UTF-8-based `Lean.Syntax.Range` in `text` to an equivalent LSP UTF-16-based `Lsp.Range`
 in `text`.
 -/
-def String.Range.toLspRange (text : Lean.FileMap) (r : String.Range) : Lean.Lsp.Range :=
+def Lean.Syntax.Range.toLspRange (text : Lean.FileMap) (r : Lean.Syntax.Range) : Lean.Lsp.Range :=
   ⟨text.utf8PosToLspPos r.start, text.utf8PosToLspPos r.stop⟩

--- a/src/Lean/Syntax.lean
+++ b/src/Lean/Syntax.lean
@@ -14,15 +14,18 @@ public import Init.Data.Option.Coe
 public section
 
 /--
-A position range inside a string. This type is mostly in combination with syntax trees,
+A position range inside a string. This type is mostly used in combination with syntax trees,
 as there might not be a single underlying string in this case that could be used for a `Substring`.
 -/
-protected structure String.Range where
+protected structure Lean.Syntax.Range where
   start : String.Pos.Raw
   stop  : String.Pos.Raw
   deriving Inhabited, Repr, BEq, Hashable
 
-def String.Range.contains (r : String.Range) (pos : String.Pos.Raw) (includeStop := false) : Bool :=
+@[expose, deprecated Lean.Syntax.Range (since := "2025-10-20")]
+def String.Range := Lean.Syntax.Range
+
+def Lean.Syntax.Range.contains (r : Lean.Syntax.Range) (pos : String.Pos.Raw) (includeStop := false) : Bool :=
   r.start <= pos && (if includeStop then pos <= r.stop else pos < r.stop)
 
 /--
@@ -30,7 +33,7 @@ Checks whether `sub` is contained in `super`.
 `includeSuperStop` and `includeSubStop` control whether `super` and `sub` have
 an inclusive upper bound.
 -/
-def String.Range.includes (super sub : String.Range)
+def Lean.Syntax.Range.includes (super sub : Lean.Syntax.Range)
     (includeSuperStop := false) (includeSubStop := false) : Bool :=
   super.start <= sub.start && (
     if includeSuperStop && !includeSubStop then
@@ -41,13 +44,27 @@ def String.Range.includes (super sub : String.Range)
       sub.stop <= super.stop
   )
 
-def String.Range.overlaps (first second : String.Range)
+@[deprecated Lean.Syntax.Range.includes (since := "2025-10-20")]
+def String.Range.includes (super sub : Lean.Syntax.Range)
+    (includeSuperStop := false) (includeSubStop := false) : Bool :=
+  Lean.Syntax.Range.includes super sub includeSuperStop includeSubStop
+
+def Lean.Syntax.Range.overlaps (first second : Lean.Syntax.Range)
     (includeFirstStop := false) (includeSecondStop := false) : Bool :=
   (if includeFirstStop then second.start <= first.stop else second.start < first.stop) &&
     (if includeSecondStop then first.start <= second.stop else first.start < second.stop)
 
-def String.Range.bsize (r : String.Range) : Nat :=
+@[deprecated Lean.Syntax.Range.overlaps (since := "2025-10-20")]
+def String.Range.overlaps (first second : Lean.Syntax.Range)
+    (includeFirstStop := false) (includeSecondStop := false) : Bool :=
+  Lean.Syntax.Range.overlaps first second includeFirstStop includeSecondStop
+
+def Lean.Syntax.Range.bsize (r : Lean.Syntax.Range) : Nat :=
   r.stop.byteIdx - r.start.byteIdx
+
+@[deprecated Lean.Syntax.Range.bsize (since := "2025-10-20")]
+def String.Range.bsize (r : Lean.Syntax.Range) : Nat :=
+  Lean.Syntax.Range.bsize r
 
 namespace Lean
 
@@ -55,10 +72,10 @@ def SourceInfo.updateTrailing (trailing : Substring) : SourceInfo → SourceInfo
   | SourceInfo.original leading pos _ endPos => SourceInfo.original leading pos trailing endPos
   | info                                     => info
 
-def SourceInfo.getRange? (canonicalOnly := false) (info : SourceInfo) : Option String.Range :=
+def SourceInfo.getRange? (canonicalOnly := false) (info : SourceInfo) : Option Lean.Syntax.Range :=
   return ⟨(← info.getPos? canonicalOnly), (← info.getTailPos? canonicalOnly)⟩
 
-def SourceInfo.getRangeWithTrailing? (canonicalOnly := false) (info : SourceInfo) : Option String.Range :=
+def SourceInfo.getRangeWithTrailing? (canonicalOnly := false) (info : SourceInfo) : Option Lean.Syntax.Range :=
   return ⟨← info.getPos? canonicalOnly, ← info.getTrailingTailPos? canonicalOnly⟩
 
 /--
@@ -403,16 +420,16 @@ def hasMissing (stx : Syntax) : Bool := Id.run do
       return true
   return false
 
-def getRange? (stx : Syntax) (canonicalOnly := false) : Option String.Range :=
+def getRange? (stx : Syntax) (canonicalOnly := false) : Option Lean.Syntax.Range :=
   match stx.getPos? canonicalOnly, stx.getTailPos? canonicalOnly with
   | some start, some stop => some { start, stop }
   | _,          _         => none
 
-def getRangeWithTrailing? (stx : Syntax) (canonicalOnly := false) : Option String.Range :=
+def getRangeWithTrailing? (stx : Syntax) (canonicalOnly := false) : Option Lean.Syntax.Range :=
   return ⟨← stx.getPos? canonicalOnly, ← stx.getTrailingTailPos? canonicalOnly⟩
 
-/-- Returns a synthetic Syntax which has the specified `String.Range`. -/
-def ofRange (range : String.Range) (canonical := true) : Lean.Syntax :=
+/-- Returns a synthetic Syntax which has the specified `Lean.Syntax.Range`. -/
+def ofRange (range : Lean.Syntax.Range) (canonical := true) : Lean.Syntax :=
   .atom (.synthetic range.start range.stop canonical) ""
 
 /--

--- a/src/Lean/Widget/UserWidget.lean
+++ b/src/Lean/Widget/UserWidget.lean
@@ -308,7 +308,7 @@ def getWidgets (pos : Lean.Lsp.Position) : RequestM (RequestTask GetWidgetsRespo
           |>.mapM fun _ => do
             let uwd ← evalUserWidgetDefinition wi.id
             return uwd.name
-        return { wi with range? := String.Range.toLspRange filemap <$> Syntax.getRange? wi.stx, name? }
+        return { wi with range? := Lean.Syntax.Range.toLspRange filemap <$> Syntax.getRange? wi.stx, name? }
       return { widgets := ws' ++ ws }
     | _ => return ⟨∅⟩
 


### PR DESCRIPTION
This PR renames `String.Range` to `Lean.Syntax.Range`, to reflect that it is not part of the standard library.
