### PR TITLE
fix: make `Std.Do.Spec.forIn'_list` and friends more universe polymorphic

### DIFF
--- a/src/Lean/Elab/Tactic/Do/VCGen/SuggestInvariant.lean
+++ b/src/Lean/Elab/Tactic/Do/VCGen/SuggestInvariant.lean
@@ -369,7 +369,9 @@ public def suggestInvariant (vcs : Array MVarId) (inv : MVarId) : TacticM Term :
   let invType ← instantiateMVars (← inv.getType)
   let_expr c@Std.Do.Invariant α l letMutsTy _ps := invType
     | throwError "Expected invariant type, got {invType}"
-  let us := c.constLevels!
+  let us := c.constLevels!.take 1 -- This is the list of universe params for `List.Cursor`. It only
+                                  -- takes the level `u₁` for `α` in the type of `Invariant`, so
+                                  -- we drop the rest (i.e., `u₂` for `β`).
 
   -- Simplify the VCs a bit using `mleave`. Makes the job of the analysis below simpler.
   let vcs ← vcs.flatMapM fun vc =>

--- a/src/Std/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Do/Triple/SpecLemmas.lean
@@ -459,7 +459,15 @@ theorem Spec.tryCatch_ExceptT_lift [WP m ps] [MonadExceptOf ε m] (Q : PostCond 
 
 /-! # Lifting `OrElse` -/
 
+end Std.Do
+
 /-! # `ForIn` -/
+
+namespace Std.Do
+
+universe u₁ u₂ v
+variable {α : Type u₁} {β : Type (max u₁ u₂)} {m : Type (max u₁ u₂) → Type v} {ps : PostShape.{max u₁ u₂}}
+variable [Monad m] [WPMonad m ps]
 
 /--
 The type of loop invariants used by the specifications of `for ... in ...` loops.
@@ -476,7 +484,7 @@ After leaving the loop, the cursor's prefix is `xs` and the suffix is empty.
 During the induction step, the invariant holds for a suffix with head element `x`.
 After running the loop body, the invariant then holds after shifting `x` to the prefix.
 -/
-abbrev Invariant {α : Type u} (xs : List α) (β : Type u) (ps : PostShape) :=
+abbrev Invariant {α : Type u₁} (xs : List α) (β : Type u₂) (ps : PostShape.{max u₁ u₂}) :=
   PostCond (List.Cursor xs × β) ps
 
 /--
@@ -508,8 +516,7 @@ abbrev Invariant.withEarlyReturn
    onExcept⟩
 
 @[spec]
-theorem Spec.forIn'_list {α β : Type u}
-    [Monad m] [WPMonad m ps]
+theorem Spec.forIn'_list
     {xs : List α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
     (inv : Invariant xs β ps)
     (step : ∀ pref cur suff (h : xs = pref ++ cur :: suff) b,
@@ -544,8 +551,7 @@ theorem Spec.forIn'_list {α β : Type u}
         exact this
 
 -- using the postcondition as a constant invariant:
-theorem Spec.forIn'_list_const_inv {α β : Type u}
-    [Monad m] [WPMonad m ps]
+theorem Spec.forIn'_list_const_inv
     {xs : List α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
     {inv : PostCond β ps}
     (step : ∀ x (hx : x ∈ xs) b,
@@ -557,8 +563,7 @@ theorem Spec.forIn'_list_const_inv {α β : Type u}
   Spec.forIn'_list (fun p => inv.1 p.2, inv.2) (fun _p c _s h b => step c (by simp [h]) b)
 
 @[spec]
-theorem Spec.forIn_list {α β : Type u}
-    [Monad m] [WPMonad m ps]
+theorem Spec.forIn_list
     {xs : List α} {init : β} {f : α → β → m (ForInStep β)}
     (inv : Invariant xs β ps)
     (step : ∀ pref cur suff (h : xs = pref ++ cur :: suff) b,
@@ -573,8 +578,7 @@ theorem Spec.forIn_list {α β : Type u}
   exact Spec.forIn'_list inv step
 
 -- using the postcondition as a constant invariant:
-theorem Spec.forIn_list_const_inv {α β : Type u}
-    [Monad m] [WPMonad m ps]
+theorem Spec.forIn_list_const_inv
     {xs : List α} {init : β} {f : α → β → m (ForInStep β)}
     {inv : PostCond β ps}
     (step : ∀ hd b,
@@ -586,8 +590,7 @@ theorem Spec.forIn_list_const_inv {α β : Type u}
   Spec.forIn_list (fun p => inv.1 p.2, inv.2) (fun _p c _s _h b => step c b)
 
 @[spec]
-theorem Spec.foldlM_list {α β : Type u}
-    [Monad m] [WPMonad m ps]
+theorem Spec.foldlM_list
     {xs : List α} {init : β} {f : β → α → m β}
     (inv : Invariant xs β ps)
     (step : ∀ pref cur suff (h : xs = pref ++ cur :: suff) b,
@@ -604,8 +607,7 @@ theorem Spec.foldlM_list {α β : Type u}
   exact step
 
 -- using the postcondition as a constant invariant:
-theorem Spec.foldlM_list_const_inv {α β : Type u}
-    [Monad m] [WPMonad m ps]
+theorem Spec.foldlM_list_const_inv
     {xs : List α} {init : β} {f : β → α → m β}
     {inv : PostCond β ps}
     (step : ∀ hd b,
@@ -617,7 +619,7 @@ theorem Spec.foldlM_list_const_inv {α β : Type u}
     Spec.foldlM_list (fun p => inv.1 p.2, inv.2) (fun _p c _s _h b => step c b)
 
 @[spec]
-theorem Spec.forIn'_range {β : Type} {m : Type → Type v} {ps : PostShape}
+theorem Spec.forIn'_range {β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     {xs : Std.Range} {init : β} {f : (a : Nat) → a ∈ xs → β → m (ForInStep β)}
     (inv : Invariant xs.toList β ps)
@@ -633,7 +635,7 @@ theorem Spec.forIn'_range {β : Type} {m : Type → Type v} {ps : PostShape}
   apply Spec.forIn'_list inv (fun c hcur b => step c hcur b)
 
 @[spec]
-theorem Spec.forIn_range {β : Type} {m : Type → Type v} {ps : PostShape}
+theorem Spec.forIn_range {β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     {xs : Std.Range} {init : β} {f : Nat → β → m (ForInStep β)}
     (inv : Invariant xs.toList β ps)
@@ -650,7 +652,7 @@ theorem Spec.forIn_range {β : Type} {m : Type → Type v} {ps : PostShape}
 
 open Std.PRange in
 @[spec]
-theorem Spec.forIn'_rcc {α β : Type u}
+theorem Spec.forIn'_rcc {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
@@ -669,7 +671,7 @@ theorem Spec.forIn'_rcc {α β : Type u}
 
 open Std.PRange in
 @[spec]
-theorem Spec.forIn_rcc {α β : Type u}
+theorem Spec.forIn_rcc {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
@@ -688,7 +690,7 @@ theorem Spec.forIn_rcc {α β : Type u}
 
 open Std.PRange in
 @[spec]
-theorem Spec.forIn'_rco {α β : Type u}
+theorem Spec.forIn'_rco {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     [LE α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLT α]
@@ -707,7 +709,7 @@ theorem Spec.forIn'_rco {α β : Type u}
 
 open Std.PRange in
 @[spec]
-theorem Spec.forIn_rco {α β : Type u}
+theorem Spec.forIn_rco {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     [LE α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLT α]
@@ -726,7 +728,7 @@ theorem Spec.forIn_rco {α β : Type u}
 
 open Std.PRange in
 @[spec]
-theorem Spec.forIn'_rci {α β : Type u}
+theorem Spec.forIn'_rci {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     [LE α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
@@ -745,7 +747,7 @@ theorem Spec.forIn'_rci {α β : Type u}
 
 open Std.PRange in
 @[spec]
-theorem Spec.forIn_rci {α β : Type u}
+theorem Spec.forIn_rci {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     [LE α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
@@ -764,7 +766,7 @@ theorem Spec.forIn_rci {α β : Type u}
 
 open Std.PRange in
 @[spec]
-theorem Spec.forIn'_roc {α β : Type u}
+theorem Spec.forIn'_roc {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     [LE α] [DecidableLE α] [LT α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLT α]
@@ -783,7 +785,7 @@ theorem Spec.forIn'_roc {α β : Type u}
 
 open Std.PRange in
 @[spec]
-theorem Spec.forIn_roc {α β : Type u}
+theorem Spec.forIn_roc {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     [LE α] [DecidableLE α] [LT α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLT α]
@@ -802,7 +804,7 @@ theorem Spec.forIn_roc {α β : Type u}
 
 open Std.PRange in
 @[spec]
-theorem Spec.forIn'_roo {α β : Type u}
+theorem Spec.forIn'_roo {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
@@ -821,7 +823,7 @@ theorem Spec.forIn'_roo {α β : Type u}
 
 open Std.PRange in
 @[spec]
-theorem Spec.forIn_roo {α β : Type u}
+theorem Spec.forIn_roo {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
@@ -840,7 +842,7 @@ theorem Spec.forIn_roo {α β : Type u}
 
 open Std.PRange in
 @[spec]
-theorem Spec.forIn'_roi {α β : Type u}
+theorem Spec.forIn'_roi {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
@@ -859,7 +861,7 @@ theorem Spec.forIn'_roi {α β : Type u}
 
 open Std.PRange in
 @[spec]
-theorem Spec.forIn_roi {α β : Type u}
+theorem Spec.forIn_roi {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
@@ -878,7 +880,7 @@ theorem Spec.forIn_roi {α β : Type u}
 
 open Std.PRange in
 @[spec]
-theorem Spec.forIn'_ric {α β : Type u}
+theorem Spec.forIn'_ric {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     [Least? α] [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α] [LawfulUpwardEnumerableLE α]
@@ -897,7 +899,7 @@ theorem Spec.forIn'_ric {α β : Type u}
 
 open Std.PRange in
 @[spec]
-theorem Spec.forIn_ric {α β : Type u}
+theorem Spec.forIn_ric {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     [Least? α] [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α] [LawfulUpwardEnumerableLE α]
@@ -916,7 +918,7 @@ theorem Spec.forIn_ric {α β : Type u}
 
 open Std.PRange in
 @[spec]
-theorem Spec.forIn'_rio {α β : Type u}
+theorem Spec.forIn'_rio {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     [Least? α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α] [LawfulUpwardEnumerableLT α]
@@ -935,7 +937,7 @@ theorem Spec.forIn'_rio {α β : Type u}
 
 open Std.PRange in
 @[spec]
-theorem Spec.forIn_rio {α β : Type u}
+theorem Spec.forIn_rio {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     [Least? α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α] [LawfulUpwardEnumerableLT α]
@@ -954,7 +956,7 @@ theorem Spec.forIn_rio {α β : Type u}
 
 open Std.PRange in
 @[spec]
-theorem Spec.forIn'_rii {α β : Type u}
+theorem Spec.forIn'_rii {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     [Least? α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α]
@@ -973,7 +975,7 @@ theorem Spec.forIn'_rii {α β : Type u}
 
 open Std.PRange in
 @[spec]
-theorem Spec.forIn_rii {α β : Type u}
+theorem Spec.forIn_rii {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     [Least? α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α]
@@ -991,7 +993,7 @@ theorem Spec.forIn_rii {α β : Type u}
   apply Spec.forIn'_rii inv step
 
 @[spec]
-theorem Spec.forIn'_array {α β : Type u}
+theorem Spec.forIn'_array {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     {xs : Array α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
     (inv : Invariant xs.toList β ps)
@@ -1008,7 +1010,7 @@ theorem Spec.forIn'_array {α β : Type u}
   apply Spec.forIn'_list inv step
 
 @[spec]
-theorem Spec.forIn_array {α β : Type u}
+theorem Spec.forIn_array {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     {xs : Array α} {init : β} {f : α → β → m (ForInStep β)}
     (inv : Invariant xs.toList β ps)
@@ -1025,7 +1027,7 @@ theorem Spec.forIn_array {α β : Type u}
   apply Spec.forIn_list inv step
 
 @[spec]
-theorem Spec.foldlM_array {α β : Type u}
+theorem Spec.foldlM_array {α β : Type u} {m : Type u → Type v} {ps : PostShape}
     [Monad m] [WPMonad m ps]
     {xs : Array α} {init : β} {f : β → α → m β}
     (inv : Invariant xs.toList β ps)

--- a/tests/lean/run/forInListSpecUnivPoly.lean
+++ b/tests/lean/run/forInListSpecUnivPoly.lean
@@ -1,0 +1,27 @@
+import Std.Tactic.Do
+open Std.Do
+set_option mvcgen.warning false
+set_option warn.sorry false
+
+def BubbleSort {α} [LT α] [DecidableLT α] (a: Array α) : Array α := Id.run do
+  let n := a.size
+  let mut a : Vector α n := a.toVector
+  for i in List.range (n - 1) do
+    for hj : j in List.range (n - i - 1) do
+      have := List.mem_range.mp hj
+      if a[j] > a[j + 1] then
+        a := a.swap j (j+1)
+  return a.toArray
+
+theorem BubbleSortSameElements [LT α] [DecidableLT α] (A : Array α) : List.Perm A.toList (BubbleSort A).toList := by
+  generalize h : BubbleSort A = x
+  apply Id.of_wp_run_eq h
+  set_option trace.Elab.Tactic.Do.spec true in
+  mvcgen
+  -- This should be able to apply the universe polymorphic Spec.forIn_list so that we get to
+  -- provide invariant goals below. Back when the spec wasn't sufficiently universe polymorphic,
+  -- the defeq check after instantiation used to fail for this program, because the level of `Nat`
+  -- was not the same as the level of `α`.
+  case inv1 => sorry
+  case inv2 => sorry
+  all_goals sorry


### PR DESCRIPTION
This PR makes the spec `Std.Do.Spec.forIn'_list` and friends more universe polymorphic.

The regression test came from a dicussion on the public Zulip.
