### PR TITLE
doc: fix example parenthesis in natAbs docstring

### DIFF
--- a/src/Init/Data/Int/Basic.lean
+++ b/src/Init/Data/Int/Basic.lean
@@ -310,7 +310,7 @@ the logical model.
 Examples:
  * `(7 : Int).natAbs = 7`
  * `(0 : Int).natAbs = 0`
- * `((-11 : Int).natAbs = 11`
+ * `(-11 : Int).natAbs = 11`
 -/
 @[extern "lean_nat_abs"]
 def natAbs (m : @& Int) : Nat :=


### PR DESCRIPTION
This PR fixes an incorrect parenthesis in the `natAbs` docstring in `src/Init/Data/Int/Basic.lean`.