### PR TITLE
fix: improve performance of `mvcgen` by optimizing `try (mpure_intro; trivial)`

### DIFF
--- a/src/Lean/Elab/Tactic/Do/ProofMode/Cases.lean
+++ b/src/Lean/Elab/Tactic/Do/ProofMode/Cases.lean
@@ -6,8 +6,11 @@ Authors: Lars König, Mario Carneiro, Sebastian Graf
 module
 
 prelude
-public import Lean.Elab.Tactic.Do.ProofMode.Pure
-public import Lean.Elab.Tactic.Do.ProofMode.Intro
+public import Lean.Elab.Tactic.Do.ProofMode.MGoal
+public import Std.Tactic.Do.Syntax
+import Lean.Elab.Tactic.Do.ProofMode.Pure
+import Lean.Elab.Tactic.Do.ProofMode.Intro
+import Lean.Elab.Tactic.Do.ProofMode.Focus
 
 public section
 

--- a/src/Lean/Elab/Tactic/Do/ProofMode/Have.lean
+++ b/src/Lean/Elab/Tactic/Do/ProofMode/Have.lean
@@ -6,8 +6,11 @@ Authors: Sebastian Graf
 module
 
 prelude
-public import Lean.Elab.Tactic.Do.ProofMode.Cases
-public import Lean.Elab.Tactic.Do.ProofMode.Specialize
+public import Std.Tactic.Do.Syntax
+public import Lean.Elab.Tactic.Basic
+import Lean.Elab.Tactic.Do.ProofMode.Focus
+import Lean.Elab.Tactic.Do.ProofMode.Cases
+import Lean.Elab.Tactic.Do.ProofMode.Specialize
 
 public section
 

--- a/src/Lean/Elab/Tactic/Do/ProofMode/Specialize.lean
+++ b/src/Lean/Elab/Tactic/Do/ProofMode/Specialize.lean
@@ -6,9 +6,11 @@ Authors: Lars König, Mario Carneiro, Sebastian Graf
 module
 
 prelude
-public import Lean.Elab.Tactic.Do.ProofMode.Basic
-public import Lean.Elab.Tactic.Do.ProofMode.Pure
 public import Lean.Elab.Tactic.ElabTerm
+public import Lean.Elab.Tactic.Do.ProofMode.MGoal
+import Lean.Elab.Tactic.Do.ProofMode.Basic
+import Lean.Elab.Tactic.Do.ProofMode.Focus
+import Lean.Elab.Tactic.Do.ProofMode.Pure
 
 public section
 

--- a/src/Lean/Elab/Tactic/Do/Spec.lean
+++ b/src/Lean/Elab/Tactic/Do/Spec.lean
@@ -6,11 +6,15 @@ Authors: Lars König, Mario Carneiro, Sebastian Graf
 module
 
 prelude
+public import Lean.Elab.Tactic.Do.Attr
+public import Lean.Elab.Tactic.Do.ProofMode.MGoal
+
+-- All these should become private imports in the future:
+import Std.Tactic.Do.Syntax
 public import Lean.Elab.Tactic.Do.ProofMode.Intro
 public import Lean.Elab.Tactic.Do.ProofMode.Pure
 public import Lean.Elab.Tactic.Do.ProofMode.Frame
 public import Lean.Elab.Tactic.Do.ProofMode.Assumption
-public import Lean.Elab.Tactic.Do.Attr
 
 namespace Lean.Elab.Tactic.Do
 open Lean Elab Tactic Meta
@@ -69,7 +73,7 @@ mutual
 partial def dischargePostEntails (α : Expr) (ps : Expr) (Q : Expr) (Q' : Expr) (goalTag : Name) : n Expr := do
   -- Often, Q' is fully instantiated while Q contains metavariables. Try refl
   let u ← liftMetaM <| getLevel α >>= decLevel
-  if (← isDefEq Q Q') then
+  if (← withDefault <| isDefEqGuarded Q Q') then
     return mkApp3 (mkConst ``PostCond.entails.refl [u]) α ps Q'
   let Q ← whnfR Q
   let Q' ← whnfR Q'
@@ -91,11 +95,11 @@ partial def dischargePostEntails (α : Expr) (ps : Expr) (Q : Expr) (Q' : Expr) 
 partial def dischargeFailEntails (u : Level) (ps : Expr) (Q : Expr) (Q' : Expr) (goalTag : Name) : n Expr := do
   if ps.isAppOf ``PostShape.pure then
     return mkConst ``True.intro
-  if ← isDefEq Q Q' then
+  if ← withDefault <| isDefEqGuarded Q Q' then
     return mkApp2 (mkConst ``ExceptConds.entails.refl [u]) ps Q
-  if ← isDefEq Q (mkApp (mkConst ``ExceptConds.false [u]) ps) then
+  if ← withDefault <| isDefEqGuarded Q (mkApp (mkConst ``ExceptConds.false [u]) ps) then
     return mkApp2 (mkConst ``ExceptConds.entails_false [u]) ps Q'
-  if ← isDefEq Q' (mkApp (mkConst ``ExceptConds.true [u]) ps) then
+  if ← withDefault <| isDefEqGuarded Q' (mkApp (mkConst ``ExceptConds.true [u]) ps) then
     return mkApp2 (mkConst ``ExceptConds.entails_true [u]) ps Q
   -- the remaining cases are recursive.
   if let some (_σ, ps) := ps.app2? ``PostShape.arg then
@@ -116,18 +120,24 @@ partial def dischargeFailEntails (u : Level) (ps : Expr) (Q : Expr) (Q' : Expr) 
   mkFreshExprSyntheticOpaqueMVar (mkApp3 (mkConst ``ExceptConds.entails [u]) ps Q Q') goalTag
 end
 
-def dischargeMGoal (goal : MGoal) (goalTag : Name) : n Expr := do
+def dischargeMGoal (goal : MGoal) (goalTag : Name) (tryTrivial : Bool) : n Expr := do
   liftMetaM <| do trace[Elab.Tactic.Do.spec] "dischargeMGoal: {goal.target}"
   -- simply try one of the assumptions for now. Later on we might want to decompose conjunctions etc; full xsimpl
   -- The `withDefault` ensures that a hyp `⌜s = 4⌝` can be used to discharge `⌜s = 4⌝ s`.
   -- (Recall that `⌜s = 4⌝ s` is `SPred.pure (σs:=[Nat]) (s = 4) s` and `SPred.pure` is
   -- semi-reducible.)
-  -- We also try `mpure_intro; trivial` through `goal.triviallyPure` here because later on an
-  -- assignment like `⌜s = ?c⌝` becomes impossible to discharge because `?c` will get abstracted
-  -- over local bindings that depend on synthetic opaque MVars (such as loop invariants), and then
-  -- the type of the new `?c` will not be defeq to itself. A bug, but we need to work around it for
-  -- now.
-  let some prf ← liftMetaM (withDefault <| goal.assumption <|> goal.assumptionPure <|> goal.triviallyPure)
+  -- We also try `mpure_intro; trivial` through `goal.pureTrivial` here because later on an
+  -- assignment like `⌜s = ?c ∧ s₂ = ?d⌝` becomes impossible to discharge because `?c` will get
+  -- abstracted over local bindings that depend on synthetic opaque MVars (such as loop invariants),
+  -- and then the type of the new `?c` will not be defeq to itself. A bug, but we need to work
+  -- around it for now.
+  -- Even when we *do not* want to `tryTrivial`, we still use `goal.pureRflAndAndIntro` because
+  -- it might assign metavariables as above.
+  let some prf ← liftMetaM <| -- withDefault <|
+      if tryTrivial then
+        goal.pureTrivial <|> goal.assumption <|> goal.assumptionPure
+      else
+        goal.pureRflAndAndIntro
     | mkFreshExprSyntheticOpaqueMVar goal.toExpr goalTag
   liftMetaM <| do trace[Elab.Tactic.Do.spec] "proof: {prf}"
   return prf
@@ -135,7 +145,7 @@ def dischargeMGoal (goal : MGoal) (goalTag : Name) : n Expr := do
 /--
   Returns the proof and the list of new unassigned MVars.
 -/
-public def mSpec (goal : MGoal) (elabSpecAtWP : Expr → n SpecTheorem) (goalTag : Name) : n Expr := do
+public def mSpec (goal : MGoal) (elabSpecAtWP : Expr → n SpecTheorem) (goalTag : Name) (tryTrivial : Bool := true) : n Expr := do
   -- First instantiate `fun s => ...` in the target via repeated `mintro ∀s`.
   mIntroForallN goal goal.target.consumeMData.getNumHeadLambdas fun goal => do
   -- Elaborate the spec for the wp⟦e⟧ app in the target
@@ -176,7 +186,7 @@ public def mSpec (goal : MGoal) (elabSpecAtWP : Expr → n SpecTheorem) (goalTag
   let_expr f@Triple m ps instWP α prog P Q := specTy
     | liftMetaM <| throwError "target not a Triple application {specTy}"
   let wp' := mkApp5 (mkConst ``WP.wp f.constLevels!) m ps instWP α prog
-  unless (← withAssignableSyntheticOpaque <| isDefEq wp wp') do
+  unless (← withAssignableSyntheticOpaque <| isDefEqGuarded wp wp') do
     Term.throwTypeMismatchError none wp wp' spec
 
   -- Try synthesizing synthetic MVars. We don't have the convenience of `TermElabM`, hence
@@ -202,7 +212,7 @@ public def mSpec (goal : MGoal) (elabSpecAtWP : Expr → n SpecTheorem) (goalTag
   -- Often P or Q are schematic (i.e. an MVar app). Try to solve by rfl.
   -- We do `fullApproxDefEq` here so that `constApprox` is active; this is useful in
   -- `need_const_approx` of `doLogicTests.lean`.
-  let (HPRfl, QQ'Rfl) ← fullApproxDefEq <| do
+  let (HPRfl, QQ'Rfl) ← withDefault <| fullApproxDefEq <| do
     return (← isDefEqGuarded P goal.hyps, ← isDefEqGuarded Q Q')
 
   -- Discharge the validity proof for the spec if not rfl
@@ -211,7 +221,7 @@ public def mSpec (goal : MGoal) (elabSpecAtWP : Expr → n SpecTheorem) (goalTag
     -- let P := (← reduceProjBeta? P).getD P
     -- Try to avoid creating a longer name if the postcondition does not need to create a goal
     let tag := if !QQ'Rfl then goalTag ++ `pre else goalTag
-    let HPPrf ← dischargeMGoal { goal with target := P } tag
+    let HPPrf ← dischargeMGoal { goal with target := P } tag tryTrivial
     prePrf := mkApp6 (mkConst ``SPred.entails.trans [u]) goal.σs goal.hyps P goal.target HPPrf
 
   -- Discharge the entailment on postconditions if not rfl

--- a/src/Lean/Elab/Tactic/Do/VCGen.lean
+++ b/src/Lean/Elab/Tactic/Do/VCGen.lean
@@ -145,7 +145,7 @@ where
         -- This is so that `mSpec` can frame hypotheses involving uninstantiated loop invariants.
         -- It is absolutely crucial that we do not lose these hypotheses in the inductive step.
         collectFreshMVars <| mIntroForallN goal (← TypeList.length goal.σs) fun goal =>
-          withDefault <| mSpec goal (fun _wp  => return specThm) name
+          mSpec goal (fun _wp  => return specThm) name (tryTrivial := false)
       catch ex =>
         trace[Elab.Tactic.Do.vcgen] "Failed to find spec for {wp}. Trying simp. Reason: {ex.toMessageData}"
         -- Last resort: Simp and try again

--- a/src/Std/Do/SPred/DerivedLaws.lean
+++ b/src/Std/Do/SPred/DerivedLaws.lean
@@ -236,7 +236,7 @@ theorem Pure.thm {P Q T : SPred σs} {φ : Prop} [IsPure Q φ] (h : φ → P ⊢
   · intro hp
     exact and_elim_l.trans (h hp)
 /-- A generalization of `pure_intro` exploiting `IsPure`. -/
-theorem Pure.intro {P Q : SPred σs} {φ : Prop} [IsPure Q φ] (hp : φ) : P ⊢ₛ Q := (pure_intro hp).trans IsPure.to_pure.mpr
+theorem Pure.intro {P Q : SPred σs} {φ : Prop} [IsPure Q φ] (hφ : φ) : P ⊢ₛ Q := (pure_intro hφ).trans IsPure.to_pure.mpr
 theorem Revert.revert {P Q H T : SPred σs} (hfoc : P ⊣⊢ₛ Q ∧ H) (h : Q ⊢ₛ H → T) : P ⊢ₛ T := hfoc.mp.trans (imp_elim h)
 theorem Specialize.imp_stateful {P P' Q R : SPred σs}
     (hrefocus : P ∧ (Q → R) ⊣⊢ₛ P' ∧ Q) : P ∧ (Q → R) ⊢ₛ P ∧ R := by

--- a/src/Std/Tactic/Do/Syntax.lean
+++ b/src/Std/Tactic/Do/Syntax.lean
@@ -105,8 +105,7 @@ syntax (name := mleft) "mleft" : tactic
 syntax (name := mpure) "mpure" colGt ident : tactic
 
 @[tactic_alt Lean.Parser.Tactic.mpureIntroMacro]
-macro (name := mpureIntro) "mpure_intro" : tactic =>
-  `(tactic| apply $(mkIdent ``Std.Do.SPred.Tactic.Pure.intro))
+syntax (name := mpureIntro) "mpure_intro" : tactic
 
 @[tactic_alt Lean.Parser.Tactic.mrenameIMacro]
 syntax (name := mrenameI) "mrename_i" (ppSpace colGt binderIdent)+ : tactic

--- a/tests/lean/run/doLogicTests.lean
+++ b/tests/lean/run/doLogicTests.lean
@@ -429,6 +429,8 @@ theorem add_unfold [Monad m] [WPMonad m sh] :
 
 theorem mkFreshPair_triple : ⦃⌜True⌝⦄ mkFreshPair ⦃⇓ (a, b) => ⌜a ≠ b⌝⦄ := by
   mvcgen -elimLets +trivial [mkFreshPair]
+  -- this tests whether `mSpec` immediately discharges by `rfl` and `And.intro` and in the process
+  -- eagerly instantiates some schematic variables.
   simp_all
 
 theorem sum_loop_spec :


### PR DESCRIPTION
This PR improves the performance of `mvcgen` by an optimized implementation for `try (mpure_intro; trivial)`. This tactic sequence is used to eagerly discharge VCs and in the process instantiates schematic variables.
