### PR TITLE
fix: lake: cache revision path

### DIFF
--- a/src/lake/Lake/Config/Cache.lean
+++ b/src/lake/Lake/Config/Cache.lean
@@ -482,7 +482,7 @@ public def downloadRevisionOutputs?
   (platform : String := "") (toolchain : String := "") (force := false)
 : LoggerIO (Option CacheMap) := do
   -- TODO: toolchain-scoped revision paths for system cache?
-  let path := cache.revisionPath rev localScope
+  let path := cache.revisionPath localScope rev
   if (← path.pathExists) && !force then
     return ← CacheMap.load path
   let url := service.revisionUrl rev remoteScope platform toolchain

--- a/tests/lake/tests/cache/online-test.sh
+++ b/tests/lake/tests/cache/online-test.sh
@@ -101,6 +101,9 @@ with_cdn_endpoints test_not_out "downloading" cache get .lake/outputs.jsonl --sc
 with_cdn_endpoints test_not_out "downloading artifact" cache get --scope='!/test'
 with_cdn_endpoints test_not_out "downloading" cache get --scope='!/test'
 
+# Test that the revision cache directory for the package is properly created
+test_exp -d $LAKE_CACHE_DIR/revisions/test
+
 # Test `--force-download`
 with_cdn_endpoints test_out "downloading" cache get --scope='!/test' --force-download
 


### PR DESCRIPTION
This PR fixes a bug with Lake's cache where revisions were stored at the incorrect path. Revisions were stored at `<rev>/<pkg>.jsonl` rather than the correct `<pkg>/<rev>.jsonl`.