### PR TITLE
feat: `grind +lax` ignores bad parameters

### DIFF
--- a/src/Init/Grind/Tactics.lean
+++ b/src/Init/Grind/Tactics.lean
@@ -16,6 +16,9 @@ Passed to `grind` using, for example, the `grind (config := { matchEqs := true }
 structure Config where
   /-- If `trace` is `true`, `grind` records used E-matching theorems and case-splits. -/
   trace : Bool := false
+  /-- If `lax` is `true`, `grind` will silently ignore any parameters referring to non-existent theorems
+  or for which no patterns can be generated. -/
+  lax : Bool := false
   /-- Maximum number of case-splits in a proof search branch. It does not include splits performed during normalization. -/
   splits : Nat := 9
   /-- Maximum number of E-matching (aka heuristic theorem instantiation) rounds before each case split. -/


### PR DESCRIPTION
This PR adds a `+lax` configuration option for `grind`, causing it to ignore parameters referring to non-existent theorems, or to theorems for which we can't generate a pattern. This allows throwing large sets of theorems (e.g. from a premise selection enginre) into `grind` to see what happens.