### PR TITLE
doc: warning for wf_preprocess

### DIFF
--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -2318,7 +2318,7 @@ by well-founded recursion. They are applied to the function's body to add additi
 such as replacing `if c then _ else _` with `if h : c then _ else _` or `xs.map` with
 `xs.attach.map`. Also see `wfParam`.
 
-Warning: These rewrites are only applied to the declaration only for the purpose of the logical
+Warning: These rewrites are only applied to the declaration for the purpose of the logical
 definition, but do not affect the compiled code. In particular they can cause a function definition
 that diverges as compiled to be accepted without an explicit `partial` keyword, for example if they
 remove irrelevant subterms or change the evaluation order by hiding terms under binders. Therefore


### PR DESCRIPTION
This PR adds a warning to `wf_preproces` that these lemmas can be used to introduce hidden partiality.

