### PR TITLE
feat: `grind` "silent" `have`

### DIFF
--- a/src/Init/Grind/Interactive.lean
+++ b/src/Init/Grind/Interactive.lean
@@ -198,5 +198,10 @@ syntax (name := exposeNames) "expose_names" : grind
 but it sets the option only within the tactics `tacs`. -/
 syntax (name := setOption) "set_option " (ident (noWs "." noWs ident)?) ppSpace optionValue " in " grindSeq : grind
 
+/--
+Proves `<term>` using the current `grind` state and default search strategy.
+-/
+syntax (name := haveSilent) "have" (ppSpace ident)? ppSpace ": " term : grind
+
 end Grind
 end Lean.Parser.Tactic

--- a/src/Lean/Elab/Tactic/Grind/Basic.lean
+++ b/src/Lean/Elab/Tactic/Grind/Basic.lean
@@ -176,12 +176,12 @@ Runs `x` with only the first unsolved goal as the goal.
 Fails if there are no goal to be solved.
 -/
 def focus (k : GrindTacticM α) : GrindTacticM α := do
-  let mvarId :: mvarIds ← getUnsolvedGoals
+  let goal :: goals ← getUnsolvedGoals
     | throwNoGoalsToBeSolved
-  setGoals [mvarId]
+  setGoals [goal]
   let a ← k
-  let mvarIds' ← getUnsolvedGoals
-  setGoals (mvarIds' ++ mvarIds)
+  let goals' ← getUnsolvedGoals
+  setGoals (goals' ++ goals)
   pure a
 
 /--

--- a/src/Lean/Meta/Tactic/Grind/RevertAll.lean
+++ b/src/Lean/Meta/Tactic/Grind/RevertAll.lean
@@ -21,6 +21,9 @@ def getOriginalName? (name : Name) : Option Name := do
   | .str p s => if s == grindMark then some p else none
   | _ => none
 
+def markGrindName (userName : Name) : Name :=
+  Name.str userName grindMark
+
 /--
 Helper tactic for marking accessible names in the local context.
 This is a trick used during `grind` preprocessing when `clean := false`.
@@ -41,7 +44,7 @@ def _root_.Lean.MVarId.markAccessible (mvarId : MVarId) : MetaM MVarId := mvarId
         continue
       if localDecl.userName.hasMacroScopes then
         continue
-      let markedName := Name.str localDecl.userName grindMark
+      let markedName := markGrindName localDecl.userName
       lctx := lctx.setUserName localDecl.fvarId markedName
   let mvarNew ← Meta.mkFreshExprMVarAt lctx mvarDecl.localInstances mvarDecl.type MetavarKind.syntheticOpaque mvarDecl.userName
   mvarId.assign mvarNew

--- a/tests/lean/run/grind_interactive.lean
+++ b/tests/lean/run/grind_interactive.lean
@@ -543,4 +543,27 @@ example : (a : Point Nat) → p a → x ≠ y → False := by
     cases #6ccb
     sorry
 
+opaque q : Nat → Nat → Prop
+axiom qax : x ≠ y → q x y
+
+example : x > y + 1 → q x y := by
+  grind =>
+    have h : x > y
+    have : x ≠ y
+    have : x > y := h
+    instantiate [qax]
+
+/--
+error: `finish` failed
+x y : Nat
+h✝² : y + 2 ≤ x
+h✝¹ : ¬q x y
+h✝ : x ≤ y + 2
+⊢ False
+-/
+#guard_msgs in
+example : x > y + 1 → q x y := by
+  grind -verbose =>
+    have h : x > y + 2
+
 end Ex1


### PR DESCRIPTION
This PR implements the `have <ident>? : <prop>` tactic for the `grind` interactive mode. The proposition is proved using the default `grind` search strategy. This tactic is also useful for inspecting or querying the current `grind` state.
