### PR TITLE
fix: missing `processNewFacts` at solver tactics

### DIFF
--- a/src/Lean/Elab/Tactic/Grind/BuiltinTactic.lean
+++ b/src/Lean/Elab/Tactic/Grind/BuiltinTactic.lean
@@ -102,6 +102,7 @@ def evalCheck (tacticName : Name) (k : GoalM Bool)
     let progress ← k
     unless progress do
       throwError "`{tacticName}` failed"
+    processNewFacts
     unless (← Grind.getConfig).verbose do
       return ()
     if (← get).inconsistent then


### PR DESCRIPTION
This PR ensures solver `grind` tactics (e.g., `ac`, `ring`, `lia`, etc) process pending facts after making progress.

