### PR TITLE
fix: spurious warning message in `grind`

### DIFF
--- a/tests/lean/run/grind_10670.lean
+++ b/tests/lean/run/grind_10670.lean
@@ -1,0 +1,11 @@
+inductive Foo : Nat → Prop
+  | one : Foo 1
+  | two : Foo 2
+
+attribute [grind ·] Foo.one
+
+#guard_msgs in
+example {l : Nat} (hl : Foo l) : Foo (3 - l) := by
+  induction hl with
+  | one => grind [Foo]
+  | two => grind


### PR DESCRIPTION
This PR fixes a spurious warning message in `grind`.

Closes #10670
