### PR TITLE
chore: add grind test for future improvements to non-linear arithmetic

### DIFF
--- a/tests/lean/run/grind_ordered_ring.lean
+++ b/tests/lean/run/grind_ordered_ring.lean
@@ -1,0 +1,4 @@
+example {R : Type} [Lean.Grind.CommRing R] [LE R] [LT R]
+    [Std.LawfulOrderLT R] [Std.IsLinearOrder R] [Lean.Grind.OrderedRing R]
+    (x y z : R) (k l : Nat) :
+    x * y * z^(k + l) ≤ x * y * z^ k * z^l := by grind


### PR DESCRIPTION
This PR adds a test about `grind` on ordered rings, that was working, but now (nightly-2025-10-26) doesn't due to intentional changes. Minimized from Mathlib. This will not be supported until we improve support for nonlinear arithmetic in grind.