### PR TITLE
feat: allow `System.FilePath.walkDir` to not follow symlinks

### DIFF
--- a/src/runtime/io.cpp
+++ b/src/runtime/io.cpp
@@ -1130,7 +1130,7 @@ extern "C" LEAN_EXPORT obj_res lean_io_symlink_metadata(b_obj_arg filename) {
         return mk_embedded_nul_error(filename);
     }
     struct stat st;
-    if (lstat(string_cstr(filename), &st) != 0) {
+    if (lstat(fname, &st) != 0) {
         return io_result_mk_error(decode_io_error(errno, filename));
     }
     return metadata_core(st);


### PR DESCRIPTION
This PR introduces a new argument to `System.FilePath.walkDir` - `followLinks` - which allows the callers to not follow symbolic links and is set to `false` as default.

---

Closes #10972

---

Rationale:

`System.FilePath.metadata` action follows symlinks, therefore the branch `| ok { type := .symlink, .. }` was in fact unreachable. We can leverage the `symlinkMetadata` action introduced in add3e1ae1247e101f696b211e6c1f8a8e3e5e321 which uses the `lstat(2)` system call and does not follow symlinks.

This gives us the option to not follow symlinks and expose ourselves to an infinite recursion when traversing a directory structure containing a cycle - a situation that is currently unavoidable.

---

Rationale for setting the `followLinks := false` default:

I realize that setting the default as `false` is a breaking change, and I don't know the internal usage of `walkDir` well enough to see if it breaks anything - from grepping and glancing at the code, not following symlinks seems OK.

I consulted implementations of `walkDir` in other languages and

* Python stdlib `os.walk` - https://docs.python.org/3/library/os.html#os.walk does not follow links by default
* Rust crate `walkdir` - https://docs.rs/walkdir/latest/walkdir/struct.WalkDir.html#method.follow_links does not follow links by default
* Go stdlib `filepath/WalkDir` - https://pkg.go.dev/path/filepath#WalkDir does not follow links at all.