### PR TITLE
doc: improve variable names and specify types in SMul doc

### DIFF
--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -1555,7 +1555,7 @@ class HomogeneousPow (α : Type u) where
 
 /-- Typeclass for types with a scalar multiplication operation, denoted `•` (`\bu`) -/
 class SMul (M : Type u) (α : Type v) where
-  /-- `a • b` computes the product of `a` and `b`. The meaning of this notation is type-dependent,
+  /-- `m • a : α` denotes the product of `m : M` and `a : α`. The meaning of this notation is type-dependent,
   but it is intended to be used for left actions. -/
   smul : M → α → α
 


### PR DESCRIPTION
When documenting smul : M → α → α, it is unintuitive and confusing to use variables a:M and b:α. It is better to use m:M and a:α. I also specified the types of all involved terms in the documentation text.