### PR TITLE
chore: adjust `pr-title` check to enforce capitalization

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -15,6 +15,6 @@ jobs:
           script: |
             const msg = context.payload.pull_request? context.payload.pull_request.title : context.payload.merge_group.head_commit.message;
             console.log(`Message: ${msg}`)
-            if (!/^(feat|fix|doc|style|refactor|test|chore|perf): .*[^.]($|\n\n)/.test(msg)) {
+            if (!/^(feat|fix|doc|style|refactor|test|chore|perf): (?![A-Z][a-z]).*[^.]($|\n\n)/.test(msg)) {
               core.setFailed('PR title does not follow the Commit Convention (https://leanprover.github.io/lean4/doc/dev/commit_convention.html).');
             }


### PR DESCRIPTION
This PR updates the `pr-title` CI check to enforce that the commit message does not start with a capital letter followed by a non-capital letter.

This should ensure that messages do not start with a capitalized word, but allow messages that start with an acronym.