### PR TITLE
fix: panic during the processing of generalized patterns in `grind`

### DIFF
--- a/tests/lean/run/grind_10983.lean
+++ b/tests/lean/run/grind_10983.lean
@@ -1,0 +1,14 @@
+structure Equiv (α : Type _) (β : Type _) where
+  toFun : α → β
+  invFun : β → α
+  left_inv : ∀ x, invFun (toFun x) = x
+
+def sumEquivSigmaBool (α β) : Equiv (α ⊕ β) (Σ b, bif b then β else α) where
+  toFun s := s.elim (fun x => ⟨false, x⟩) fun x => ⟨true, x⟩
+  invFun s :=
+    match s with
+    | ⟨false, a⟩ => .inl a
+    | ⟨true, b⟩ => .inr b
+  left_inv := fun s => by
+    fail_if_success grind
+    sorry


### PR DESCRIPTION
This PR fixes a panic that occurred during the processing of generalized E-matching patterns in `grind`.

Closes #10983