### PR TITLE
try out MonadAttach

### DIFF
--- a/src/Init/Data/Iterators/Combinators/Monadic/Attach.lean
+++ b/src/Init/Data/Iterators/Combinators/Monadic/Attach.lean
@@ -86,7 +86,8 @@ instance Attach.instProductive {α β : Type w} {m : Type w → Type w'} [Monad 
     Productive (Attach α m P) m :=
   .of_productivenessRelation instProductivenessRelation
 
-instance Attach.instIteratorCollect {α β : Type w} {m : Type w → Type w'} [Monad m] [Monad n]
+instance Attach.instIteratorCollect {α β : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [Monad n] [MonadAttach n]
     {P : β → Prop} [Iterator α m β] :
     IteratorCollect (Attach α m P) m n :=
   .defaultImplementation

--- a/src/Init/Data/Iterators/Combinators/Monadic/FilterMap.lean
+++ b/src/Init/Data/Iterators/Combinators/Monadic/FilterMap.lean
@@ -215,7 +215,8 @@ instance Map.instProductive {α β γ : Type w} {m : Type w → Type w'}
   Productive.of_productivenessRelation Map.instProductivenessRelation
 
 instance {α β γ : Type w} {m : Type w → Type w'}
-    {n : Type w → Type w''} {o : Type w → Type x} [Monad n] [Monad o] [Iterator α m β]
+    {n : Type w → Type w''} {o : Type w → Type x}
+    [Monad n] [MonadAttach n] [Monad o] [MonadAttach o] [Iterator α m β]
     {lift : ⦃α : Type w⦄ → m α → n α}
     {f : β → PostconditionT n (Option γ)} :
     IteratorCollect (FilterMap α m n lift f) n o :=

--- a/src/Init/Data/Iterators/Combinators/Monadic/FlatMap.lean
+++ b/src/Init/Data/Iterators/Combinators/Monadic/FlatMap.lean
@@ -366,7 +366,8 @@ public instance [Monad m] [Iterator α m (IterM (α := α₂) m β)] [Iterator �
 
 end Productive
 
-public instance Flatten.instIteratorCollect [Monad m] [Monad n] [Iterator α m (IterM (α := α₂) m β)]
+public instance Flatten.instIteratorCollect
+    [Monad m] [MonadAttach m] [Monad n] [MonadAttach n] [Iterator α m (IterM (α := α₂) m β)]
     [Iterator α₂ m β] : IteratorCollect (Flatten α α₂ β m) m n :=
   .defaultImplementation
 

--- a/src/Init/Data/Iterators/Combinators/Monadic/ULift.lean
+++ b/src/Init/Data/Iterators/Combinators/Monadic/ULift.lean
@@ -128,7 +128,8 @@ instance Types.ULiftIterator.instIteratorLoop {o : Type x → Type x'} [Monad n]
     IteratorLoop (ULiftIterator α m n β lift) n o :=
   .defaultImplementation
 
-instance Types.ULiftIterator.instIteratorCollect [Monad n] [Monad o] [Iterator α m β] :
+instance Types.ULiftIterator.instIteratorCollect
+    [Monad n] [MonadAttach n] [Monad o] [MonadAttach o] [Iterator α m β] :
     IteratorCollect (ULiftIterator α m n β lift) n o :=
   .defaultImplementation
 

--- a/src/Init/Data/Iterators/Lemmas/Combinators/FlatMap.lean
+++ b/src/Init/Data/Iterators/Lemmas/Combinators/FlatMap.lean
@@ -167,8 +167,9 @@ public theorem Iter.step_flatMap {α : Type w} {β : Type w} {α₂ : Type w}
     | .done h => .done (.outerDone_flatMap_pure h)) := by
   simp [flatMap, step_flatMapAfter]
 
-public theorem Iter.toList_flatMapAfterM {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ] [Finite α Id] [Finite α₂ m]
+public theorem Iter.toList_flatMapAfterM {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Iterator α Id β] [Iterator α₂ m γ] [Finite α Id] [Finite α₂ m]
     [IteratorCollect α Id m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α Id m] [LawfulIteratorCollect α₂ m m]
     {f : β → m (IterM (α := α₂) m γ)}
@@ -186,8 +187,9 @@ public theorem Iter.toList_flatMapAfterM {α α₂ β γ : Type w} {m : Type w �
     simp only [mapM, IterM.toList_mapM_mapM, monadLift_self, bind_pure_comp, Functor.map_map]
     congr <;> simp
 
-public theorem Iter.toArray_flatMapAfterM {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ] [Finite α Id] [Finite α₂ m]
+public theorem Iter.toArray_flatMapAfterM {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Iterator α Id β] [Iterator α₂ m γ] [Finite α Id] [Finite α₂ m]
     [IteratorCollect α Id m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α Id m] [LawfulIteratorCollect α₂ m m]
     {f : β → m (IterM (α := α₂) m γ)}
@@ -205,8 +207,9 @@ public theorem Iter.toArray_flatMapAfterM {α α₂ β γ : Type w} {m : Type w 
     simp only [mapM, IterM.toArray_mapM_mapM, monadLift_self, bind_pure_comp, Functor.map_map]
     congr <;> simp
 
-public theorem Iter.toList_flatMapM {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ] [Finite α Id] [Finite α₂ m]
+public theorem Iter.toList_flatMapM {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Iterator α Id β] [Iterator α₂ m γ] [Finite α Id] [Finite α₂ m]
     [IteratorCollect α Id m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α Id m] [LawfulIteratorCollect α₂ m m]
     {f : β → m (IterM (α := α₂) m γ)}
@@ -214,8 +217,9 @@ public theorem Iter.toList_flatMapM {α α₂ β γ : Type w} {m : Type w → Ty
     (it₁.flatMapM f).toList = List.flatten <$> (it₁.mapM fun b => do (← f b).toList).toList := by
   simp [flatMapM, toList_flatMapAfterM]
 
-public theorem Iter.toArray_flatMapM {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ] [Finite α Id] [Finite α₂ m]
+public theorem Iter.toArray_flatMapM {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Iterator α Id β] [Iterator α₂ m γ] [Finite α Id] [Finite α₂ m]
     [IteratorCollect α Id m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α Id m] [LawfulIteratorCollect α₂ m m]
     {f : β → m (IterM (α := α₂) m γ)}

--- a/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/Attach.lean
+++ b/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/Attach.lean
@@ -22,10 +22,10 @@ theorem IterM.step_attachWith [Iterator α m β] [Monad m] {it : IterM (α := α
   rfl
 
 @[simp]
-theorem IterM.map_unattach_toList_attachWith [Iterator α m β] [Monad m]
-    {it : IterM (α := α) m β} {hP}
-    [Finite α m] [IteratorCollect α m m]
-    [LawfulMonad m] [LawfulIteratorCollect α m m] :
+theorem IterM.map_unattach_toList_attachWith [Iterator α m β]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
+    {it : IterM (α := α) m β} {hP} :
     List.unattach <$> (it.attachWith P hP).toList = it.toList := by
   induction it using IterM.inductSteps with | step it ihy ihs
   rw [IterM.toList_eq_match_step, IterM.toList_eq_match_step, step_attachWith]
@@ -42,19 +42,19 @@ theorem IterM.map_unattach_toList_attachWith [Iterator α m β] [Monad m]
   · simp [Types.Attach.Monadic.modifyStep]
 
 @[simp]
-theorem IterM.map_unattach_toListRev_attachWith [Iterator α m β] [Monad m] [Monad n]
-    {it : IterM (α := α) m β} {hP}
-    [Finite α m] [IteratorCollect α m m]
-    [LawfulMonad m] [LawfulIteratorCollect α m m] :
+theorem IterM.map_unattach_toListRev_attachWith [Iterator α m β]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m] [Monad n]
+    [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
+    {it : IterM (α := α) m β} {hP} :
     List.unattach <$> (it.attachWith P hP).toListRev = it.toListRev := by
   rw [toListRev_eq, toListRev_eq, ← map_unattach_toList_attachWith (it := it) (hP := hP)]
   simp [-map_unattach_toList_attachWith]
 
 @[simp]
-theorem IterM.map_unattach_toArray_attachWith [Iterator α m β] [Monad m] [Monad n]
-    {it : IterM (α := α) m β} {hP}
-    [Finite α m] [IteratorCollect α m m]
-    [LawfulMonad m] [LawfulIteratorCollect α m m] :
+theorem IterM.map_unattach_toArray_attachWith [Iterator α m β]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m] [Monad n]
+    [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
+    {it : IterM (α := α) m β} {hP} :
     (·.map Subtype.val) <$> (it.attachWith P hP).toArray = it.toArray := by
   rw [← toArray_toList, ← toArray_toList, ← map_unattach_toList_attachWith (it := it) (hP := hP)]
   simp [-map_unattach_toList_attachWith, -IterM.toArray_toList]

--- a/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/FilterMap.lean
+++ b/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/FilterMap.lean
@@ -235,7 +235,9 @@ section Lawful
 
 @[no_expose]
 instance {α β γ : Type w} {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type x}
-    [Monad m] [Monad n] [Monad o] [LawfulMonad n] [LawfulMonad o] [Iterator α m β] [Finite α m]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [LawfulMonadAttach o] [Iterator α m β] [Finite α m]
     [IteratorCollect α m o] [LawfulIteratorCollect α m o]
     {lift : ⦃δ : Type w⦄ -> m δ → n δ} {f : β → PostconditionT n γ} [LawfulMonadLiftFunction lift] :
     LawfulIteratorCollect (Map α m n lift f) n o where
@@ -274,7 +276,7 @@ end Lawful
 section ToList
 
 theorem IterM.InternalConsumers.toList_filterMap {α β γ: Type w} {m : Type w → Type w'}
-    [Monad m] [LawfulMonad m]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     [Iterator α m β] [IteratorCollect α m m] [LawfulIteratorCollect α m m] [Finite α m]
     {f : β → Option γ} (it : IterM (α := α) m β) :
     (it.filterMap f).toList = (fun x => x.filterMap f) <$> it.toList := by
@@ -293,7 +295,7 @@ theorem IterM.InternalConsumers.toList_filterMap {α β γ: Type w} {m : Type w 
   · simp
 
 theorem IterM.toList_map_eq_toList_mapM {α β γ : Type w}
-    {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+    {m : Type w → Type w'} [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → γ} {it : IterM (α := α) m β} :
     (it.map f).toList = (it.mapM fun b => pure (f b)).toList := by
@@ -304,7 +306,8 @@ theorem IterM.toList_map_eq_toList_mapM {α β γ : Type w}
 
 theorem IterM.toList_mapM_eq_toList_filterMapM {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [Monad m] [LawfulMonad m] [MonadAttach m] [LawfulMonadAttach m]
+    [Monad n] [LawfulMonad n] [MonadAttach n] [LawfulMonadAttach n]
     [MonadLiftT m n][LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorCollect α m n] [LawfulIteratorCollect α m n]
     {f : β → n γ} {it : IterM (α := α) m β} :
@@ -315,8 +318,8 @@ theorem IterM.toList_mapM_eq_toList_filterMapM {α β γ : Type w}
   apply bind_congr; intro step
   split <;> simp (discharger := assumption) [ihy, ihs]
 
-theorem IterM.toList_map_eq_toList_filterMapM {α β γ : Type w}
-    {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+theorem IterM.toList_map_eq_toList_filterMapM {α β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → γ} {it : IterM (α := α) m β} :
     (it.map f).toList = (it.filterMapM fun b => pure (some (f b))).toList := by
@@ -326,7 +329,9 @@ theorem IterM.toList_map_eq_toList_filterMapM {α β γ : Type w}
 @[simp]
 theorem IterM.toList_filterMapM_filterMapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [MonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [LawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → n (Option γ)} {g : γ → o (Option δ)}
@@ -358,7 +363,9 @@ theorem IterM.toList_filterMapM_filterMapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toList_filterMapM_mapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [MonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [LawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
     {f : β → n γ} {g : γ → o (Option δ)}
@@ -385,7 +392,8 @@ theorem IterM.toList_filterMapM_mapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toList_filterMapM_map {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [Monad m] [MonadAttach m] [LawfulMonad m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m]
     {f : β → γ} {g : γ → n (Option δ)}
@@ -407,7 +415,9 @@ theorem IterM.toList_filterMapM_map {α β γ δ : Type w}
 @[simp]
 theorem IterM.toList_mapM_filterMapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [MonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [LawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → n (Option γ)} {g : γ → o δ}
@@ -423,7 +433,9 @@ theorem IterM.toList_mapM_filterMapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toList_mapM_mapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [LawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m] [IteratorCollect α m o] [LawfulIteratorCollect α m o]
     {f : β → n γ} {g : γ → o δ}
@@ -437,7 +449,8 @@ theorem IterM.toList_mapM_mapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toList_mapM_map {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorCollect α m n] [LawfulIteratorCollect α m n]
     {f : β → γ} {g : γ → n δ}
@@ -447,7 +460,7 @@ theorem IterM.toList_mapM_map {α β γ δ : Type w}
   simp [toList_mapM_eq_toList_filterMapM]
 
 theorem IterM.toList_filterMap {α β γ : Type w} {m : Type w → Type w'}
-    [Monad m] [LawfulMonad m]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     [Iterator α m β] [IteratorCollect α m m] [LawfulIteratorCollect α m m] [Finite α m]
     {f : β → Option γ} (it : IterM (α := α) m β) :
     (it.filterMap f).toList = (fun x => x.filterMap f) <$> it.toList := by
@@ -474,7 +487,8 @@ theorem IterM.toList_filterMap {α β γ : Type w} {m : Type w → Type w'}
     assumption
   · simp
 
-theorem IterM.toList_map {α β β' : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+theorem IterM.toList_map {α β β' : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     [Iterator α m β] [IteratorCollect α m m] [LawfulIteratorCollect α m m] [Finite α m] {f : β → β'}
     (it : IterM (α := α) m β) :
     (it.map f).toList = (fun x => x.map f) <$> it.toList := by
@@ -497,7 +511,8 @@ theorem IterM.toList_map {α β β' : Type w} {m : Type w → Type w'} [Monad m]
     · simp [Map]
     · simp
 
-theorem IterM.toList_filter {α : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+theorem IterM.toList_filter {α : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     {β : Type w} [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → Bool} {it : IterM (α := α) m β} :
     (it.filter f).toList = List.filter f <$> it.toList := by
@@ -509,7 +524,8 @@ end ToList
 section ToListRev
 
 theorem IterM.toListRev_map_eq_toListRev_mapM {α β γ : Type w}
-    {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+    {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → γ} {it : IterM (α := α) m β} :
     (it.map f).toListRev = (it.mapM fun b => pure (f b)).toListRev := by
@@ -517,7 +533,8 @@ theorem IterM.toListRev_map_eq_toListRev_mapM {α β γ : Type w}
 
 theorem IterM.toListRev_mapM_eq_toListRev_filterMapM {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
     [MonadLiftT m n][LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorCollect α m n] [LawfulIteratorCollect α m n]
     {f : β → n γ} {it : IterM (α := α) m β} :
@@ -526,26 +543,29 @@ theorem IterM.toListRev_mapM_eq_toListRev_filterMapM {α β γ : Type w}
   simp [toListRev_eq, toList_mapM_eq_toList_filterMapM]
 
 theorem IterM.toListRev_map_eq_toListRev_filterMapM {α β γ : Type w}
-    {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+    {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → γ} {it : IterM (α := α) m β} :
     (it.map f).toListRev = (it.filterMapM fun b => pure (some (f b))).toListRev := by
   simp [toListRev_eq, toList_map_eq_toList_filterMapM]
 
 theorem IterM.toListRev_filterMap {α β γ : Type w} {m : Type w → Type w'}
-    [Monad m] [LawfulMonad m]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     [Iterator α m β] [IteratorCollect α m m] [LawfulIteratorCollect α m m] [Finite α m]
     {f : β → Option γ} (it : IterM (α := α) m β) :
     (it.filterMap f).toListRev = (fun x => x.filterMap f) <$> it.toListRev := by
   simp [toListRev_eq, toList_filterMap]
 
-theorem IterM.toListRev_map {α β γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+theorem IterM.toListRev_map {α β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     [Iterator α m β] [IteratorCollect α m m] [LawfulIteratorCollect α m m] [Finite α m] {f : β → γ}
     (it : IterM (α := α) m β) :
     (it.map f).toListRev = (fun x => x.map f) <$> it.toListRev := by
   simp [toListRev_eq, toList_map]
 
-theorem IterM.toListRev_filter {α β : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+theorem IterM.toListRev_filter {α β : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → Bool} {it : IterM (α := α) m β} :
     (it.filter f).toListRev = List.filter f <$> it.toListRev := by
@@ -554,7 +574,9 @@ theorem IterM.toListRev_filter {α β : Type w} {m : Type w → Type w'} [Monad 
 @[simp]
 theorem IterM.toListRev_filterMapM_filterMapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [MonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [LawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → n (Option γ)} {g : γ → o (Option δ)}
@@ -570,7 +592,9 @@ theorem IterM.toListRev_filterMapM_filterMapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toListRev_filterMapM_mapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [MonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [LawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → n γ} {g : γ → o (Option δ)}
@@ -583,7 +607,8 @@ theorem IterM.toListRev_filterMapM_mapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toListRev_filterMapM_map {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → γ} {g : γ → n (Option δ)}
@@ -595,7 +620,9 @@ theorem IterM.toListRev_filterMapM_map {α β γ δ : Type w}
 @[simp]
 theorem IterM.toListRev_mapM_filterMapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [MonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [LawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → n (Option γ)} {g : γ → o δ}
@@ -611,7 +638,9 @@ theorem IterM.toListRev_mapM_filterMapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toListRev_mapM_mapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [LawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
     {f : β → n γ} {g : γ → o δ}
@@ -625,7 +654,8 @@ theorem IterM.toListRev_mapM_mapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toListRev_mapM_map {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] {f : β → γ} {g : γ → n δ} {it : IterM (α := α) m β} :
     ((it.map f).mapM g).toListRev =
@@ -638,7 +668,8 @@ end ToListRev
 section ToArray
 
 theorem IterM.toArray_map_eq_toArray_mapM {α β γ : Type w}
-    {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+    {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → γ} {it : IterM (α := α) m β} :
     (it.map f).toArray = (it.mapM fun b => pure (f b)).toArray := by
@@ -646,7 +677,8 @@ theorem IterM.toArray_map_eq_toArray_mapM {α β γ : Type w}
 
 theorem IterM.toArray_mapM_eq_toArray_filterMapM {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
     [MonadLiftT m n][LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorCollect α m n] [LawfulIteratorCollect α m n]
     {f : β → n γ} {it : IterM (α := α) m β} :
@@ -654,26 +686,29 @@ theorem IterM.toArray_mapM_eq_toArray_filterMapM {α β γ : Type w}
   simp [← toArray_toList, toList_mapM_eq_toList_filterMapM]
 
 theorem IterM.toArray_map_eq_toArray_filterMapM {α β γ : Type w}
-    {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+    {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → γ} {it : IterM (α := α) m β} :
     (it.map f).toArray = (it.filterMapM fun b => pure (some (f b))).toArray := by
   simp [← toArray_toList, toList_map_eq_toList_filterMapM]
 
 theorem IterM.toArray_filterMap {α β γ : Type w} {m : Type w → Type w'}
-    [Monad m] [LawfulMonad m]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     [Iterator α m β] [IteratorCollect α m m] [LawfulIteratorCollect α m m] [Finite α m]
     {f : β → Option γ} (it : IterM (α := α) m β) :
     (it.filterMap f).toArray = (fun x => x.filterMap f) <$> it.toArray := by
   simp [← toArray_toList, toList_filterMap]
 
-theorem IterM.toArray_map {α β γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+theorem IterM.toArray_map {α β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     [Iterator α m β] [IteratorCollect α m m] [LawfulIteratorCollect α m m] [Finite α m] {f : β → γ}
     (it : IterM (α := α) m β) :
     (it.map f).toArray = (fun x => x.map f) <$> it.toArray := by
   simp [← toArray_toList, toList_map]
 
-theorem IterM.toArray_filter {α : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+theorem IterM.toArray_filter {α : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     {β : Type w} [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → Bool} {it : IterM (α := α) m β} :
     (it.filter f).toArray = Array.filter f <$> it.toArray := by
@@ -682,7 +717,9 @@ theorem IterM.toArray_filter {α : Type w} {m : Type w → Type w'} [Monad m] [L
 @[simp]
 theorem IterM.toArray_filterMapM_filterMapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [MonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [LawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → n (Option γ)} {g : γ → o (Option δ)}
@@ -698,7 +735,9 @@ theorem IterM.toArray_filterMapM_filterMapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toArray_filterMapM_mapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [MonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [LawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → n γ} {g : γ → o (Option δ)}
@@ -711,7 +750,8 @@ theorem IterM.toArray_filterMapM_mapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toArray_filterMapM_map {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [Monad m] [MonadAttach m] [LawfulMonad m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → γ} {g : γ → n (Option δ)}
@@ -723,7 +763,9 @@ theorem IterM.toArray_filterMapM_map {α β γ δ : Type w}
 @[simp]
 theorem IterM.toArray_mapM_filterMapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [MonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [LawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → n (Option γ)} {g : γ → o δ}
@@ -739,7 +781,9 @@ theorem IterM.toArray_mapM_filterMapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toArray_mapM_mapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [LawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m] [IteratorCollect α m o] [LawfulIteratorCollect α m o]
     {f : β → n γ} {g : γ → o δ}
@@ -752,7 +796,8 @@ theorem IterM.toArray_mapM_mapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toArray_mapM_map {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorCollect α m n] [LawfulIteratorCollect α m n]
     {f : β → γ} {g : γ → n δ}

--- a/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/FlatMap.lean
+++ b/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/FlatMap.lean
@@ -187,7 +187,8 @@ public theorem IterM.step_flatMap {α : Type w} {β : Type w} {α₂ : Type w}
     | .done h => return .deflate (.done (.outerDone_flatMap h))) := by
   simp [flatMap, step_flatMapAfter]
 
-theorem IterM.toList_flattenAfter {α α₂ β : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+theorem IterM.toList_flattenAfter {α α₂ β : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     [Iterator α m (IterM (α := α₂) m β)] [Iterator α₂ m β] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]
@@ -219,7 +220,8 @@ theorem IterM.toList_flattenAfter {α α₂ β : Type w} {m : Type w → Type w'
     · simp [ihs₂ ‹_›]
     · simp [hn]
 
-theorem IterM.toArray_flattenAfter {α α₂ β : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+theorem IterM.toArray_flattenAfter {α α₂ β : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     [Iterator α m (IterM (α := α₂) m β)] [Iterator α₂ m β] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]
@@ -251,8 +253,9 @@ theorem IterM.toArray_flattenAfter {α α₂ β : Type w} {m : Type w → Type w
     · simp [ihs₂ ‹_›]
     · simp [hn]
 
-public theorem IterM.toList_flatMapAfterM {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
+public theorem IterM.toList_flatMapAfterM {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]
     {f : β → m (IterM (α := α₂) m γ)}
@@ -264,8 +267,9 @@ public theorem IterM.toList_flatMapAfterM {α α₂ β γ : Type w} {m : Type w 
           (← List.flatten <$> (it₁.mapM fun b => do (← f b).toList).toList) := by
   simp [flatMapAfterM, toList_flattenAfter]; rfl
 
-public theorem IterM.toArray_flatMapAfterM {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
+public theorem IterM.toArray_flatMapAfterM {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]
     {f : β → m (IterM (α := α₂) m γ)}
@@ -277,8 +281,9 @@ public theorem IterM.toArray_flatMapAfterM {α α₂ β γ : Type w} {m : Type w
           (← Array.flatten <$> (it₁.mapM fun b => do (← f b).toArray).toArray) := by
   simp [flatMapAfterM, toArray_flattenAfter]; rfl
 
-public theorem IterM.toList_flatMapM {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
+public theorem IterM.toList_flatMapM {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]
     {f : β → m (IterM (α := α₂) m γ)}
@@ -286,8 +291,9 @@ public theorem IterM.toList_flatMapM {α α₂ β γ : Type w} {m : Type w → T
     (it₁.flatMapM f).toList = List.flatten <$> (it₁.mapM fun b => do (← f b).toList).toList := by
   simp [flatMapM, toList_flatMapAfterM]
 
-public theorem IterM.toArray_flatMapM {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
+public theorem IterM.toArray_flatMapM {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]
     {f : β → m (IterM (α := α₂) m γ)}
@@ -295,8 +301,9 @@ public theorem IterM.toArray_flatMapM {α α₂ β γ : Type w} {m : Type w → 
     (it₁.flatMapM f).toArray = Array.flatten <$> (it₁.mapM fun b => do (← f b).toArray).toArray := by
   simp [flatMapM, toArray_flatMapAfterM]
 
-public theorem IterM.toList_flatMapAfter {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
+public theorem IterM.toList_flatMapAfter {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]
     {f : β → IterM (α := α₂) m γ}
@@ -308,8 +315,9 @@ public theorem IterM.toList_flatMapAfter {α α₂ β γ : Type w} {m : Type w �
           (← List.flatten <$> (it₁.mapM fun b => (f b).toList).toList) := by
   simp [flatMapAfter, toList_flattenAfter]; rfl
 
-public theorem IterM.toArray_flatMapAfter {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
+public theorem IterM.toArray_flatMapAfter {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]
     {f : β → IterM (α := α₂) m γ}
@@ -321,8 +329,9 @@ public theorem IterM.toArray_flatMapAfter {α α₂ β γ : Type w} {m : Type w 
           (← Array.flatten <$> (it₁.mapM fun b => (f b).toArray).toArray) := by
   simp [flatMapAfter, toArray_flattenAfter]; rfl
 
-public theorem IterM.toList_flatMap {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
+public theorem IterM.toList_flatMap {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]
@@ -331,8 +340,9 @@ public theorem IterM.toList_flatMap {α α₂ β γ : Type w} {m : Type w → Ty
     (it₁.flatMap f).toList = List.flatten <$> (it₁.mapM fun b => (f b).toList).toList := by
   simp [flatMap, toList_flatMapAfter]
 
-public theorem IterM.toArray_flatMap {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
+public theorem IterM.toArray_flatMap {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]

--- a/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/ULift.lean
+++ b/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/ULift.lean
@@ -25,10 +25,12 @@ theorem IterM.step_uLift [Iterator α m β] [Monad n] {it : IterM (α := α) m �
   rfl
 
 @[simp]
-theorem IterM.toList_uLift [Iterator α m β] [Monad m] [Monad n] {it : IterM (α := α) m β}
+theorem IterM.toList_uLift [Iterator α m β]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
     [MonadLiftT m (ULiftT n)] [Finite α m] [IteratorCollect α m m]
-    [LawfulMonad m] [LawfulMonad n] [LawfulIteratorCollect α m m]
-    [LawfulMonadLiftT m (ULiftT n)] :
+    [LawfulIteratorCollect α m m] [LawfulMonadLiftT m (ULiftT n)]
+    {it : IterM (α := α) m β} :
     (it.uLift n).toList =
       (fun l => l.down.map ULift.up) <$> (monadLift it.toList : ULiftT n _).run := by
   induction it using IterM.inductSteps with | step it ihy ihs
@@ -44,20 +46,25 @@ theorem IterM.toList_uLift [Iterator α m β] [Monad m] [Monad n] {it : IterM (�
   · simp
 
 @[simp]
-theorem IterM.toListRev_uLift [Iterator α m β] [Monad m] [Monad n] {it : IterM (α := α) m β}
+theorem IterM.toListRev_uLift [Iterator α m β]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
     [MonadLiftT m (ULiftT n)] [Finite α m] [IteratorCollect α m m]
-    [LawfulMonad m] [LawfulMonad n] [LawfulIteratorCollect α m m]
-    [LawfulMonadLiftT m (ULiftT n)] :
+    [LawfulIteratorCollect α m m] [LawfulMonadLiftT m (ULiftT n)]
+    {it : IterM (α := α) m β} :
     (it.uLift n).toListRev =
       (fun l => l.down.map ULift.up) <$> (monadLift it.toListRev : ULiftT n _).run := by
   rw [toListRev_eq, toListRev_eq, toList_uLift, monadLift_map]
   simp
 
 @[simp]
-theorem IterM.toArray_uLift [Iterator α m β] [Monad m] [Monad n] {it : IterM (α := α) m β}
+theorem IterM.toArray_uLift [Iterator α m β] [Monad m] [Monad n]
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
     [MonadLiftT m (ULiftT n)] [Finite α m] [IteratorCollect α m m]
-    [LawfulMonad m] [LawfulMonad n] [LawfulIteratorCollect α m m]
-    [LawfulMonadLiftT m (ULiftT n)] :
+    [LawfulIteratorCollect α m m]
+    [LawfulMonadLiftT m (ULiftT n)]
+    {it : IterM (α := α) m β} :
     (it.uLift n).toArray =
       (fun l => l.down.map ULift.up) <$> (monadLift it.toArray : ULiftT n _).run := by
   rw [← toArray_toList, ← toArray_toList, toList_uLift, monadLift_map]

--- a/src/Init/Data/Iterators/Lemmas/Consumers/Monadic/Loop.lean
+++ b/src/Init/Data/Iterators/Lemmas/Consumers/Monadic/Loop.lean
@@ -324,8 +324,9 @@ theorem IterM.fold_hom {m : Type w → Type w'} [Iterator α m β] [Finite α m]
   · simp
 
 theorem IterM.toList_eq_fold {α β : Type w} {m : Type w → Type w'} [Iterator α m β]
-    [Finite α m] [Monad m] [LawfulMonad m] [IteratorLoop α m m] [LawfulIteratorLoop α m m]
-    [IteratorCollect α m m] [LawfulIteratorCollect α m m]
+    [Finite α m] [Monad m] [MonadAttach m] [LawfulMonadAttach m]
+    [LawfulMonad m] [IteratorLoop α m m]
+    [LawfulIteratorLoop α m m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {it : IterM (α := α) m β} :
     it.toList = it.fold (init := []) (fun l out => l ++ [out]) := by
   suffices h : ∀ l' : List β, (l' ++ ·) <$> it.toList =
@@ -347,7 +348,8 @@ theorem IterM.toList_eq_fold {α β : Type w} {m : Type w → Type w'} [Iterator
   · simp
 
 theorem IterM.toArray_eq_fold {α β : Type w} {m : Type w → Type w'} [Iterator α m β]
-    [Finite α m] [Monad m] [LawfulMonad m] [IteratorLoop α m m] [LawfulIteratorLoop α m m]
+    [Finite α m] [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [IteratorLoop α m m] [LawfulIteratorLoop α m m]
     [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {it : IterM (α := α) m β} :
     it.toArray = it.fold (init := #[]) (fun xs out => xs.push out) := by
@@ -382,7 +384,8 @@ theorem IterM.drain_eq_match_step {α β : Type w} {m : Type w → Type w'} [Ite
   simp [IterM.drain_eq_fold]
 
 theorem IterM.drain_eq_map_toList {α β : Type w} {m : Type w → Type w'} [Iterator α m β]
-    [Finite α m] [Monad m] [LawfulMonad m] [IteratorLoop α m m] [LawfulIteratorLoop α m m]
+    [Finite α m] [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [IteratorLoop α m m] [LawfulIteratorLoop α m m]
     [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {it : IterM (α := α) m β} :
     it.drain = (fun _ => .unit) <$> it.toList := by
@@ -399,14 +402,16 @@ theorem IterM.drain_eq_map_toList {α β : Type w} {m : Type w → Type w'} [Ite
   · simp
 
 theorem IterM.drain_eq_map_toListRev {α β : Type w} {m : Type w → Type w'} [Iterator α m β]
-    [Finite α m] [Monad m] [LawfulMonad m] [IteratorLoop α m m] [LawfulIteratorLoop α m m]
+    [Finite α m] [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [IteratorLoop α m m] [LawfulIteratorLoop α m m]
     [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {it : IterM (α := α) m β} :
     it.drain = (fun _ => .unit) <$> it.toListRev := by
   simp [IterM.drain_eq_map_toList, IterM.toListRev_eq]
 
 theorem IterM.drain_eq_map_toArray {α β : Type w} {m : Type w → Type w'} [Iterator α m β]
-    [Finite α m] [Monad m] [LawfulMonad m] [IteratorLoop α m m] [LawfulIteratorLoop α m m]
+    [Finite α m] [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [IteratorLoop α m m] [LawfulIteratorLoop α m m]
     [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {it : IterM (α := α) m β} :
     it.drain = (fun _ => .unit) <$> it.toList := by

--- a/src/Init/Data/Range/Polymorphic/RangeIterator.lean
+++ b/src/Init/Data/Range/Polymorphic/RangeIterator.lean
@@ -120,7 +120,7 @@ theorem Iterator.step_eq_step [UpwardEnumerable α] [LE α] [DecidableLE α]
   simp [Iter.step, step_eq_monadicStep, Monadic.step_eq_step, IterM.Step.toPure]
 
 instance Iterator.instIteratorCollect [UpwardEnumerable α] [LE α] [DecidableLE α]
-    {n : Type u → Type w} [Monad n] : IteratorCollect (Rxc.Iterator α) Id n :=
+    {n : Type u → Type w} [Monad n] [MonadAttach n] : IteratorCollect (Rxc.Iterator α) Id n :=
   .defaultImplementation
 
 theorem Iterator.Monadic.isPlausibleOutput_next {a}
@@ -700,7 +700,7 @@ theorem Iterator.step_eq_step [UpwardEnumerable α] [LT α] [DecidableLT α]
   simp [Iter.step, step_eq_monadicStep, Monadic.step_eq_step, IterM.Step.toPure]
 
 instance Iterator.instIteratorCollect [UpwardEnumerable α] [LT α] [DecidableLT α]
-    {n : Type u → Type w} [Monad n] : IteratorCollect (Rxo.Iterator α) Id n :=
+    {n : Type u → Type w} [Monad n] [MonadAttach n] : IteratorCollect (Rxo.Iterator α) Id n :=
   .defaultImplementation
 
 theorem Iterator.Monadic.isPlausibleOutput_next {a}
@@ -1266,7 +1266,7 @@ theorem Iterator.step_eq_step [UpwardEnumerable α]
   simp [Iter.step, step_eq_monadicStep, Monadic.step_eq_step, IterM.Step.toPure]
 
 instance Iterator.instIteratorCollect [UpwardEnumerable α]
-    {n : Type u → Type w} [Monad n] : IteratorCollect (Rxi.Iterator α) Id n :=
+    {n : Type u → Type w} [Monad n] [MonadAttach n] : IteratorCollect (Rxi.Iterator α) Id n :=
   .defaultImplementation
 
 theorem Iterator.Monadic.isPlausibleOutput_next {a} [UpwardEnumerable α]

--- a/src/Init/Data/String/Slice.lean
+++ b/src/Init/Data/String/Slice.lean
@@ -184,7 +184,7 @@ private def finitenessRelation [Std.Iterators.Finite (σ s) Id] :
 instance [Std.Iterators.Finite (σ s) Id] : Std.Iterators.Finite (SplitIterator ρ s) Id :=
   .of_finitenessRelation finitenessRelation
 
-instance [Monad n] : Std.Iterators.IteratorCollect (SplitIterator ρ s) Id n :=
+instance [Monad n] [MonadAttach n] : Std.Iterators.IteratorCollect (SplitIterator ρ s) Id n :=
   .defaultImplementation
 
 instance [Monad n] : Std.Iterators.IteratorLoop (SplitIterator ρ s) Id n :=
@@ -279,7 +279,7 @@ instance [Std.Iterators.Finite (σ s) Id] :
     Std.Iterators.Finite (SplitInclusiveIterator ρ s) Id :=
   .of_finitenessRelation finitenessRelation
 
-instance [Monad n] {s} :
+instance [Monad n] [MonadAttach n] {s} :
     Std.Iterators.IteratorCollect (SplitInclusiveIterator ρ s) Id n :=
   .defaultImplementation
 
@@ -603,7 +603,8 @@ private def finitenessRelation [Std.Iterators.Finite (σ s) Id] :
 instance [Std.Iterators.Finite (σ s) Id] : Std.Iterators.Finite (RevSplitIterator ρ s) Id :=
   .of_finitenessRelation finitenessRelation
 
-instance [Monad m] [Monad n] : Std.Iterators.IteratorCollect (RevSplitIterator ρ s) m n :=
+instance [Monad m] [MonadAttach m] [Monad n] [MonadAttach n] :
+    Std.Iterators.IteratorCollect (RevSplitIterator ρ s) m n :=
   .defaultImplementation
 
 instance [Monad m] [Monad n] : Std.Iterators.IteratorLoop (RevSplitIterator ρ s) m n :=
@@ -878,7 +879,8 @@ private def finitenessRelation [Pure m] :
 instance [Pure m] : Std.Iterators.Finite (PosIterator s) m :=
   .of_finitenessRelation finitenessRelation
 
-instance [Monad m] [Monad n] : Std.Iterators.IteratorCollect (PosIterator s) m n :=
+instance [Monad m] [MonadAttach m] [Monad n] [MonadAttach n] :
+    Std.Iterators.IteratorCollect (PosIterator s) m n :=
   .defaultImplementation
 
 instance [Monad m] [Monad n] : Std.Iterators.IteratorLoop (PosIterator s) m n :=
@@ -958,7 +960,8 @@ private def finitenessRelation [Pure m] :
 instance [Pure m] : Std.Iterators.Finite (RevPosIterator s) m :=
   .of_finitenessRelation finitenessRelation
 
-instance [Monad m] [Monad n] : Std.Iterators.IteratorCollect (RevPosIterator s) m n :=
+instance [Monad m] [MonadAttach m] [Monad n] [MonadAttach n] :
+    Std.Iterators.IteratorCollect (RevPosIterator s) m n :=
   .defaultImplementation
 
 instance [Monad m] [Monad n] : Std.Iterators.IteratorLoop (RevPosIterator s) m n :=
@@ -1038,7 +1041,8 @@ private def finitenessRelation [Pure m] :
 instance [Pure m] : Std.Iterators.Finite ByteIterator m :=
   .of_finitenessRelation finitenessRelation
 
-instance [Monad m] [Monad n] : Std.Iterators.IteratorCollect ByteIterator m n :=
+instance [Monad m] [MonadAttach m] [Monad n] [MonadAttach n] :
+    Std.Iterators.IteratorCollect ByteIterator m n :=
   .defaultImplementation
 
 instance [Monad m] [Monad n] : Std.Iterators.IteratorLoop ByteIterator m n :=
@@ -1119,7 +1123,8 @@ private def finitenessRelation [Pure m] :
 instance [Pure m] : Std.Iterators.Finite RevByteIterator m :=
   .of_finitenessRelation finitenessRelation
 
-instance [Monad m] [Monad n] : Std.Iterators.IteratorCollect RevByteIterator m n :=
+instance [Monad m] [MonadAttach m] [Monad n] [MonadAttach n] :
+    Std.Iterators.IteratorCollect RevByteIterator m n :=
   .defaultImplementation
 
 instance [Monad m] [Monad n] : Std.Iterators.IteratorLoop RevByteIterator m n :=

--- a/src/Init/Internal/MonadAttach.lean
+++ b/src/Init/Internal/MonadAttach.lean
@@ -20,13 +20,20 @@ public class LawfulMonadAttach (m : Type u → Type v) [Monad m] [MonadAttach m]
   -- ump {P : α → Prop} {x : m (Subtype P)} :
   --   (fun x => ⟨x.val, strongest x.property⟩) <$> MonadAttach.attach (Subtype.val <$> x) = x
 
-instance : MonadAttach IO where
+public instance : MonadAttach Id where
+  CanReturn x a := a = x.run
+  attach x := pure ⟨x.run, rfl⟩
+
+public instance : LawfulMonadAttach Id where
+  map_val_attach := rfl
+
+public instance : MonadAttach IO where
   CanReturn x a := ∃ world world', x world = .ok a world'
   attach x := fun world => match h : x world with
     | .ok a world' => .ok ⟨a, world, world', h⟩ world'
     | .error e world' => .error e world'
 
-instance : LawfulMonadAttach IO where
+public instance : LawfulMonadAttach IO where
   map_val_attach := by
     intro α x
     rw [funext_iff]

--- a/src/Std/Data/DHashMap/Internal/AssocList/Iterator.lean
+++ b/src/Std/Data/DHashMap/Internal/AssocList/Iterator.lean
@@ -47,7 +47,8 @@ def AssocListIterator.finitenessRelation :
 public instance : Finite (AssocListIterator α β) Id :=
   Finite.of_finitenessRelation AssocListIterator.finitenessRelation
 
-public instance {α : Type u} {β : α → Type v} {m : Type (max u v) → Type w''} [Monad m] :
+public instance {α : Type u} {β : α → Type v} {m : Type (max u v) → Type w''}
+    [Monad m] [MonadAttach m] :
     IteratorCollect (AssocListIterator α β) Id m :=
   .defaultImplementation
 

--- a/src/Std/Data/Iterators/Combinators/Monadic/Drop.lean
+++ b/src/Std/Data/Iterators/Combinators/Monadic/Drop.lean
@@ -152,7 +152,8 @@ instance Drop.instProductive [Iterator α m β] [Monad m] [Productive α m] :
     Productive (Drop α m β) m :=
   by exact Productive.of_productivenessRelation instProductivenessRelation
 
-instance Drop.instIteratorCollect {n : Type w → Type w'} [Monad m] [Monad n] [Iterator α m β] [Finite α m] :
+instance Drop.instIteratorCollect {n : Type w → Type w'}
+    [Monad m] [MonadAttach m] [Monad n] [MonadAttach n] [Iterator α m β] [Finite α m] :
     IteratorCollect (Drop α m β) m n :=
   .defaultImplementation
 

--- a/src/Std/Data/Iterators/Combinators/Monadic/DropWhile.lean
+++ b/src/Std/Data/Iterators/Combinators/Monadic/DropWhile.lean
@@ -271,7 +271,8 @@ instance DropWhile.instFinite [Monad m] [Iterator α m β] [Finite α m] {P} :
     Finite (DropWhile α m β P) m :=
   by exact Finite.of_finitenessRelation instFinitenessRelation
 
-instance DropWhile.instIteratorCollect [Monad m] [Monad n] [Iterator α m β] [Productive α m] {P} :
+instance DropWhile.instIteratorCollect
+    [Monad m] [MonadAttach m] [Monad n] [MonadAttach n] [Iterator α m β] [Productive α m] {P} :
     IteratorCollect (DropWhile α m β P) m n :=
   .defaultImplementation
 

--- a/src/Std/Data/Iterators/Combinators/Monadic/StepSize.lean
+++ b/src/Std/Data/Iterators/Combinators/Monadic/StepSize.lean
@@ -135,7 +135,7 @@ def IterM.stepSize [Iterator α m β] [IteratorAccess α m] [Monad m]
   ⟨⟨0, n - 1, it⟩⟩
 
 instance Types.StepSizeIterator.instIteratorCollect {m n} [Iterator α m β]
-    [IteratorAccess α m] [Monad m] [Monad n] :
+    [IteratorAccess α m] [Monad m] [MonadAttach m] [Monad n] [MonadAttach n] :
     IteratorCollect (Types.StepSizeIterator α m β) m n :=
   .defaultImplementation
 

--- a/src/Std/Data/Iterators/Combinators/Monadic/Take.lean
+++ b/src/Std/Data/Iterators/Combinators/Monadic/Take.lean
@@ -132,7 +132,8 @@ instance Take.instFinite [Monad m] [Iterator α m β] [Productive α m] :
     Finite (Take α m β) m :=
   by exact Finite.of_finitenessRelation instFinitenessRelation
 
-instance Take.instIteratorCollect {n : Type w → Type w'} [Monad m] [Monad n] [Iterator α m β] :
+instance Take.instIteratorCollect {n : Type w → Type w'}
+    [Monad m] [MonadAttach m] [Monad n] [MonadAttach n] [Iterator α m β] :
     IteratorCollect (Take α m β) m n :=
   .defaultImplementation
 

--- a/src/Std/Data/Iterators/Combinators/Monadic/TakeWhile.lean
+++ b/src/Std/Data/Iterators/Combinators/Monadic/TakeWhile.lean
@@ -226,7 +226,8 @@ instance TakeWhile.instProductive [Monad m] [Iterator α m β] [Productive α m]
     Productive (TakeWhile α m β P) m :=
   by exact Productive.of_productivenessRelation instProductivenessRelation
 
-instance TakeWhile.instIteratorCollect [Monad m] [Monad n] [Iterator α m β] [Productive α m] {P} :
+instance TakeWhile.instIteratorCollect
+    [Monad m] [MonadAttach m] [Monad n] [MonadAttach n] [Iterator α m β] [Productive α m] {P} :
     IteratorCollect (TakeWhile α m β P) m n :=
   .defaultImplementation
 

--- a/src/Std/Data/Iterators/Combinators/Monadic/Zip.lean
+++ b/src/Std/Data/Iterators/Combinators/Monadic/Zip.lean
@@ -311,7 +311,7 @@ instance Zip.instProductive [Monad m] [Productive α₁ m] [Productive α₂ m] 
     Productive (Zip α₁ m α₂ β₂) m :=
   Productive.of_productivenessRelation Zip.instProductivenessRelation
 
-instance Zip.instIteratorCollect [Monad m] [Monad n] :
+instance Zip.instIteratorCollect [Monad m] [MonadAttach m] [Monad n] [MonadAttach n] :
     IteratorCollect (Zip α₁ m α₂ β₂) m n :=
   .defaultImplementation
 

--- a/src/Std/Data/Iterators/Lemmas/Combinators/Monadic/Take.lean
+++ b/src/Std/Data/Iterators/Lemmas/Combinators/Monadic/Take.lean
@@ -30,9 +30,10 @@ theorem IterM.step_take {α m β} [Monad m] [Iterator α m β] {n : Nat}
     intro step
     cases step.inflate using PlausibleIterStep.casesOn <;> rfl
 
-theorem IterM.toList_take_zero {α m β} [Monad m] [LawfulMonad m] [Iterator α m β]
-    [Finite (Take α m β) m]
-    [IteratorCollect (Take α m β) m m] [LawfulIteratorCollect (Take α m β) m m]
+theorem IterM.toList_take_zero {α m β}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m] [Iterator α m β]
+    [Finite (Take α m β) m] [IteratorCollect (Take α m β) m m]
+    [LawfulIteratorCollect (Take α m β) m m]
     {it : IterM (α := α) m β} :
     (it.take 0).toList = pure [] := by
   rw [toList_eq_match_step]

--- a/src/Std/Data/Iterators/Lemmas/Consumers/Monadic/Collect.lean
+++ b/src/Std/Data/Iterators/Lemmas/Consumers/Monadic/Collect.lean
@@ -35,7 +35,8 @@ theorem IterM.Equiv.toListRev_eq [Monad m] [LawfulMonad m]
     exact BundledIterM.Equiv.exact _ _ h
   · simp
 
-theorem IterM.Equiv.toList_eq {α₁ α₂ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+theorem IterM.Equiv.toList_eq {α₁ α₂ β : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     [Iterator α₁ m β] [Iterator α₂ m β] [Finite α₁ m] [Finite α₂ m]
     [IteratorCollect α₁ m m] [LawfulIteratorCollect α₁ m m]
     [IteratorCollect α₂ m m] [LawfulIteratorCollect α₂ m m]
@@ -43,7 +44,8 @@ theorem IterM.Equiv.toList_eq {α₁ α₂ : Type w} {m : Type w → Type w'} [M
     ita.toList = itb.toList := by
   simp only [← IterM.reverse_toListRev, toListRev_eq h]
 
-theorem IterM.Equiv.toArray_eq [Monad m] [LawfulMonad m]
+theorem IterM.Equiv.toArray_eq {α₁ α₂ β : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
     [Iterator α₁ m β] [Iterator α₂ m β] [Finite α₁ m] [Finite α₂ m]
     [IteratorCollect α₁ m m] [LawfulIteratorCollect α₁ m m]
     [IteratorCollect α₂ m m] [LawfulIteratorCollect α₂ m m]

--- a/src/Std/Data/Iterators/Lemmas/Producers/Monadic/Array.lean
+++ b/src/Std/Data/Iterators/Lemmas/Producers/Monadic/Array.lean
@@ -122,36 +122,38 @@ theorem Array.iterM_equiv_iterM_toList {α : Type w} {array : Array α} {m : Typ
 end Equivalence
 
 @[simp]
-theorem _root_.Array.toList_iterFromIdxM [LawfulMonad m] {array : Array β}
-    {pos : Nat} :
+theorem _root_.Array.toList_iterFromIdxM [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    {array : Array β} {pos : Nat} :
     (array.iterFromIdxM m pos).toList = pure (array.toList.drop pos) := by
   simp [Array.iterFromIdxM_equiv_iterM_drop_toList.toList_eq]
 
 @[simp]
-theorem _root_.Array.toList_iterM [LawfulMonad m] {array : Array β} :
-    (array.iterM m).toList = pure array.toList := by
+theorem _root_.Array.toList_iterM [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    {array : Array β} : (array.iterM m).toList = pure array.toList := by
   simp [Array.iterM_eq_iterFromIdxM, Array.toList_iterFromIdxM]
 
 @[simp]
-theorem _root_.Array.toArray_iterFromIdxM [LawfulMonad m] {array : Array β} {pos : Nat} :
+theorem _root_.Array.toArray_iterFromIdxM [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    {array : Array β} {pos : Nat} :
     (array.iterFromIdxM m pos).toArray = pure (array.extract pos) := by
   simp [← IterM.toArray_toList, Array.toList_iterFromIdxM]
   rw (occs := [2]) [← Array.toArray_toList (xs := array)]
   rw [← List.toArray_drop]
 
 @[simp]
-theorem _root_.Array.toArray_toIterM [LawfulMonad m] {array : Array β} :
-    (array.iterM m).toArray = pure array := by
+theorem _root_.Array.toArray_toIterM [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    {array : Array β} : (array.iterM m).toArray = pure array := by
   simp [Array.iterM_eq_iterFromIdxM, Array.toArray_iterFromIdxM]
 
 @[simp]
-theorem _root_.Array.toListRev_iterFromIdxM [LawfulMonad m] {array : Array β} {pos : Nat} :
+theorem _root_.Array.toListRev_iterFromIdxM [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    {array : Array β} {pos : Nat} :
     (array.iterFromIdxM m pos).toListRev = pure (array.toList.drop pos).reverse := by
   simp [IterM.toListRev_eq, Array.toList_iterFromIdxM]
 
 @[simp]
-theorem _root_.Array.toListRev_toIterM [LawfulMonad m] {array : Array β} :
-    (array.iterM m).toListRev = pure array.toListRev := by
+theorem _root_.Array.toListRev_toIterM [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    {array : Array β} : (array.iterM m).toListRev = pure array.toListRev := by
   simp [Array.iterM_eq_iterFromIdxM, Array.toListRev_iterFromIdxM]
 
 end Std.Iterators

--- a/src/Std/Data/Iterators/Lemmas/Producers/Monadic/Empty.lean
+++ b/src/Std/Data/Iterators/Lemmas/Producers/Monadic/Empty.lean
@@ -19,7 +19,7 @@ theorem IterM.step_empty {m β} [Monad m] :
   rfl
 
 @[simp]
-theorem IterM.toList_empty {m β} [Monad m] [LawfulMonad m] :
+theorem IterM.toList_empty {m β} [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m] :
     (IterM.empty m β).toList = pure [] := by
   rw [toList_eq_match_step]
   simp
@@ -31,7 +31,7 @@ theorem IterM.toListRev_empty {m β} [Monad m] [LawfulMonad m] :
   simp
 
 @[simp]
-theorem IterM.toArray_empty {m β} [Monad m] [LawfulMonad m] :
+theorem IterM.toArray_empty {m β} [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m] :
     (IterM.empty m β).toArray = pure #[] := by
   rw [toArray_eq_match_step]
   simp

--- a/src/Std/Data/Iterators/Lemmas/Producers/Monadic/List.lean
+++ b/src/Std/Data/Iterators/Lemmas/Producers/Monadic/List.lean
@@ -40,7 +40,8 @@ theorem _root_.List.step_iterM {l : List β} :
       | x :: xs => pure (.deflate ⟨.yield (xs.iterM m) x, rfl⟩) := by
   cases l <;> simp [List.step_iterM_cons, List.step_iterM_nil]
 
-theorem ListIterator.toArrayMapped_iterM [Monad n] [LawfulMonad n]
+theorem ListIterator.toArrayMapped_iterM [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
     {β : Type w} {γ : Type w} {lift : ⦃δ : Type w⦄ → m δ → n δ}
     [LawfulMonadLiftFunction lift] {f : β → n γ} {l : List β} :
     IteratorCollect.toArrayMapped lift f (l.iterM m) (m := m) = List.toArray <$> l.mapM f := by
@@ -54,18 +55,19 @@ theorem ListIterator.toArrayMapped_iterM [Monad n] [LawfulMonad n]
     simp [List.step_iterM_cons, List.mapM_cons, pure_bind, ih, LawfulMonadLiftFunction.lift_pure]
 
 @[simp]
-theorem _root_.List.toArray_iterM [LawfulMonad m] {l : List β} :
-    (l.iterM m).toArray = pure l.toArray := by
+theorem _root_.List.toArray_iterM [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    {l : List β} : (l.iterM m).toArray = pure l.toArray := by
   simp only [IterM.toArray, ListIterator.toArrayMapped_iterM]
   rw [List.mapM_pure, map_pure, List.map_id']
 
 @[simp]
-theorem _root_.List.toList_iterM [LawfulMonad m] {l : List β} :
-    (l.iterM m).toList = pure l := by
+theorem _root_.List.toList_iterM [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    {l : List β} : (l.iterM m).toList = pure l := by
   rw [← IterM.toList_toArray, List.toArray_iterM, map_pure, List.toList_toArray]
 
 @[simp]
-theorem _root_.List.toListRev_iterM [LawfulMonad m] {l : List β} :
+theorem _root_.List.toListRev_iterM [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    {l : List β} :
     (l.iterM m).toListRev = pure l.reverse := by
   simp [IterM.toListRev_eq, List.toList_iterM]
 

--- a/src/Std/Data/Iterators/Producers/Monadic/Array.lean
+++ b/src/Std/Data/Iterators/Producers/Monadic/Array.lean
@@ -112,7 +112,7 @@ instance [Pure m] : Finite (ArrayIterator α) m := by
   exact Finite.of_finitenessRelation ArrayIterator.finitenessRelation
 
 @[always_inline, inline]
-instance {α : Type w} [Monad m] {n : Type w → Type w''} [Monad n] :
+instance {α : Type w} [Monad m] [MonadAttach m] {n : Type w → Type w''} [Monad n] [MonadAttach n] :
     IteratorCollect (ArrayIterator α) m n :=
   .defaultImplementation
 

--- a/src/Std/Data/Iterators/Producers/Monadic/Empty.lean
+++ b/src/Std/Data/Iterators/Producers/Monadic/Empty.lean
@@ -57,7 +57,8 @@ private def Empty.instFinitenessRelation [Monad m] :
 instance Empty.instFinite [Monad m] : Finite (Empty m β) m := by
   exact Finite.of_finitenessRelation instFinitenessRelation
 
-instance Empty.instIteratorCollect {n : Type w → Type w''} [Monad m] [Monad n] :
+instance Empty.instIteratorCollect {n : Type w → Type w''}
+    [Monad m] [MonadAttach m] [Monad n] [MonadAttach n] :
     IteratorCollect (Empty m β) m n :=
   .defaultImplementation
 

--- a/src/Std/Data/Iterators/Producers/Monadic/List.lean
+++ b/src/Std/Data/Iterators/Producers/Monadic/List.lean
@@ -68,7 +68,7 @@ instance [Pure m] : Finite (ListIterator α) m :=
   by exact Finite.of_finitenessRelation ListIterator.finitenessRelation
 
 @[always_inline, inline]
-instance {α : Type w} [Monad m] {n : Type w → Type w''} [Monad n] :
+instance {α : Type w} [Monad m] [MonadAttach m] {n : Type w → Type w''} [Monad n] [MonadAttach n] :
     IteratorCollect (ListIterator α) m n :=
   .defaultImplementation
 

--- a/src/Std/Data/Iterators/Producers/Repeat.lean
+++ b/src/Std/Data/Iterators/Producers/Repeat.lean
@@ -73,7 +73,7 @@ instance RepeatIterator.instIteratorLoop {α : Type w} {f : α → α} {n : Type
   .defaultImplementation
 
 instance RepeatIterator.instIteratorCollect {α : Type w} {f : α → α} {n : Type w → Type w'}
-    [Monad n] : IteratorCollect (RepeatIterator α f) Id n :=
+    [Monad n] [MonadAttach n] : IteratorCollect (RepeatIterator α f) Id n :=
   .defaultImplementation
 
 end Std.Iterators


### PR DESCRIPTION
* use `MonadAttach` in the definiton of `toList`/`toArray`/`ForIn` so that more termination proofs are possible in the presence of `takeWhileM`, `mapM` etc.
* add more instance parameters to lots of lemmas: they now need `MonadAttach` and `LawfulMonadAttach`