### PR TITLE
fix: simplify Nat.ble

### DIFF
--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -1831,8 +1831,7 @@ Examples:
 -/
 @[extern "lean_nat_dec_le"]
 def Nat.ble : @& Nat → @& Nat → Bool
-  | zero,   zero   => true
-  | zero,   succ _ => true
+  | zero,   _      => true
   | succ _, zero   => false
   | succ n, succ m => ble n m
 


### PR DESCRIPTION
This PR changes `Nat.ble` by joining the two `Nat.ble Nat.zero _` cases into one, allowing `decide (0 <= x) = true` and `decide (0 < succ x) = true` to be solvable by `rfl`.