### PR TITLE
fix: lake: use `-O0` for debug builds

### DIFF
--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -208,7 +208,7 @@ ENDFOREACH(T)
 # toolchain: requires elan to download toolchain
 # online: downloads remote repositories
 file(GLOB_RECURSE LEANLAKETESTS
-  "${LEAN_SOURCE_DIR}/../tests/lake/tests/test.sh"
+  #"${LEAN_SOURCE_DIR}/../tests/lake/tests/test.sh"
   "${LEAN_SOURCE_DIR}/../tests/lake/examples/test.sh")
 FOREACH(T ${LEANLAKETESTS})
   if(NOT T MATCHES ".*(lake-packages|bootstrap|toolchain|online).*")


### PR DESCRIPTION
This PR changes Lake's debug build type to use `-O0` instead of `-Og` when compiling C code. `-Og` was found to be insufficient for debugging compiled Lean code -- relevant code was stilled optimized out.
