### PR TITLE
feat: `simp? +suggestions` handles ambiguity

### DIFF
--- a/src/Lean/Elab/Tactic/SimpTrace.lean
+++ b/src/Lean/Elab/Tactic/SimpTrace.lean
@@ -64,7 +64,7 @@ def mkSimpCallStx (stx : Syntax) (usedSimps : UsedSimps) : MetaM (TSyntax `tacti
         let ident := mkIdent sugg.name
         let candidates ← resolveGlobalConst ident
         for candidate in candidates do
-          let arg ← `(Parser.Tactic.simpLemma| $(mkIdent candidate):term)
+          let arg ← `(Parser.Tactic.simpLemma| $(mkCIdentFrom ident candidate (canonical := true)):term)
           argsArray := argsArray.push arg
     -- Build the simp syntax with the updated arguments
     let stxForExecution ← if bang.isSome then
@@ -103,8 +103,7 @@ def mkSimpCallStx (stx : Syntax) (usedSimps : UsedSimps) : MetaM (TSyntax `tacti
         let ident := mkIdent sugg.name
         let candidates ← resolveGlobalConst ident
         for candidate in candidates do
-          logInfo m!"suggestion: {sugg.name} candidate: {candidate}"
-          let arg ← `(Parser.Tactic.simpLemma| $(mkIdent candidate):term)
+          let arg ← `(Parser.Tactic.simpLemma| $(mkCIdentFrom ident candidate (canonical := true)):term)
           argsArray := argsArray.push arg
     -- Build the simp_all syntax with the updated arguments
     let stxForExecution ←

--- a/tests/lean/run/simp_suggestions.lean
+++ b/tests/lean/run/simp_suggestions.lean
@@ -73,10 +73,14 @@ theorem Foo.myCustomAdd_id (x : Nat) : myCustomAdd x 0 = x := by
 set_library_suggestions (fun _ _ => pure #[{ name := `myCustomAdd_id, score := 1.0 }])
 
 open Foo
-#check Nat
+
 -- This goal needs BOTH lemmas to solve:
 -- myCustomAdd 0 a simplifies to a (using root version)
 -- myCustomAdd b 0 simplifies to b (using Foo version)
+/--
+info: Try this:
+  [apply] simp_all only [_root_.myCustomAdd_id, Foo.myCustomAdd_id]
+-/
 #guard_msgs in
 example (a b : Nat) (h : myCustomAdd 0 a = myCustomAdd b 0) : a = b := by
   simp_all? +suggestions


### PR DESCRIPTION
This PR updates `simp? +suggestions` so that if a name is ambiguous (because of namespaces) all alternatives are used, rather than erroring.