### PR TITLE
fix: panic during equality propagation in `grind ring`

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/Arith/CommRing/EqCnstr.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/CommRing/EqCnstr.lean
@@ -523,6 +523,11 @@ where
             modify fun (propagated, map) => (propagated, map.insert (k, d.p) (a, ra))
             return ()
         trace_goal[grind.ring.impEq] "{← mkEq a b}, {k}, {← d.p.denoteExpr}"
+        /-
+        **Note**: If max number of steps has been reached, then `d.p` is not fully simplified.
+        Recall that `propagateEq` assumes that it is.
+        -/
+        if (← checkMaxSteps) then return ()
         propagateEq a b ra rb d
         modify fun s => (true, s.2)
     else


### PR DESCRIPTION
This PR fixes a panic during equality propagation in the `grind ring` module. If the maximum number of steps has been reached, the polynomials may not be fully simplified. 

Closes #11073

