### PR TITLE
feat: `grind` handles local `Injective` hypotheses

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/Types.lean
+++ b/src/Lean/Meta/Tactic/Grind/Types.lean
@@ -863,10 +863,19 @@ structure InjectiveInfo where
   heq : Expr
   deriving Inhabited
 
+/-- Pending injective function that hasn't been initialized yet (no applications seen). -/
+structure PendingInjectiveInfo where
+  us : List Level
+  α  : Expr
+  β  : Expr
+  h  : Expr
+  deriving Inhabited
+
 /-- State for injective theorem support. -/
 structure Injective.State where
-  thms : InjectiveTheorems
-  fns  : PHashMap ExprPtr InjectiveInfo := {}
+  thms    : InjectiveTheorems
+  fns     : PHashMap ExprPtr InjectiveInfo := {}
+  pending : PHashMap ExprPtr PendingInjectiveInfo := {}
   deriving Inhabited
 
 /-- The `grind` goal. -/

--- a/tests/lean/run/grind_inj.lean
+++ b/tests/lean/run/grind_inj.lean
@@ -74,3 +74,5 @@ error: invalid `[grind inj]` theorem, theorem has universe levels, but no hypoth
 #guard_msgs in
 @[grind inj] theorem weird_inj : Function.Injective weird := by
   intro a b; simp
+
+example (f : α → β) (h : Function.Injective f) : f a = f b → a = b := by grind


### PR DESCRIPTION
This PR adds support in `grind` for `Injective` hypotheses. (There's already support for `@[grind inj]` lemmas, but currently if `grind` processes a `Injective f` local hypothesis before it first sees an application `f a`, the injectivity processing doesn't happen. Here we add a pending queue so these can be processed later once an application is observed.)

Closes #11088.