### PR TITLE
feat: run `try? +harder` at an empty `by`

### DIFF
--- a/src/Init/Try.lean
+++ b/src/Init/Try.lean
@@ -50,6 +50,9 @@ namespace Lean.Parser.Tactic
 
 syntax (name := tryTrace) "try?" optConfig : tactic
 
+/-- Helper tactic for empty `by` blocks: runs `try?` and then reports unsolved goals. -/
+syntax (name := tryAndFail) "tryAndFail!" : tactic
+
 /-- Helper internal tactic for implementing the tactic `try?`. -/
 syntax (name := attemptAll) "attempt_all " withPosition((ppDedent(ppLine) colGe "| " tacticSeq)+) : tactic
 

--- a/src/Lean/Meta/Tactic/Try/Collect.lean
+++ b/src/Lean/Meta/Tactic/Try/Collect.lean
@@ -35,7 +35,7 @@ def OrdSet.isEmpty {_ : Hashable α} {_ : BEq α} (s : OrdSet α) : Bool :=
   s.elems.isEmpty
 
 structure Result where
-  /-- All constant symbols occurring in the gal. -/
+  /-- All constant symbols occurring in the goal. -/
   allConsts : OrdSet Name  := {}
   /-- Unfolding candidates. -/
   unfoldCandidates : OrdSet Name  := {}

--- a/src/Lean/Parser/Term/Basic.lean
+++ b/src/Lean/Parser/Term/Basic.lean
@@ -88,7 +88,7 @@ The strict indentation requirement only apply to *nested* `by`s, as top-level `b
 position set. -/
 @[builtin_doc, run_builtin_parser_attribute_hooks]
 def tacticSeqIndentGt := withAntiquot (mkAntiquot "tacticSeq" ``tacticSeq) <| node ``tacticSeq <|
-  tacticSeqBracketed <|> (checkColGt "indented tactic sequence" >> tacticSeq1Indented)
+  tacticSeqBracketed <|> (checkColGt "indented tactic sequence" >> tacticSeq1Indented) <|> sepByIndentSemicolon tacticParser
 
 /- Raw sequence for quotation and grouping -/
 @[run_builtin_parser_attribute_hooks]

--- a/tests/lean/run/empty_by.lean
+++ b/tests/lean/run/empty_by.lean
@@ -1,0 +1,84 @@
+import Std
+
+/--
+info: Try these:
+  [apply] simp
+  [apply] simp only
+  [apply] grind
+  [apply] grind only
+  [apply] simp_all
+-/
+#guard_msgs in
+example : True := by try?
+
+/--
+info: Try these:
+  [apply] by simp
+  [apply] by simp only
+  [apply] by grind
+  [apply] by grind only
+  [apply] by simp_all
+---
+error: unsolved goals
+⊢ True
+-/
+#guard_msgs in
+example : True := by
+
+/--
+info: Try these:
+  [apply] by simp
+  [apply] by simp only [List.append_assoc]
+  [apply] by grind
+  [apply] by grind only
+  [apply] by simp_all
+---
+error: unsolved goals
+x y z : List Nat
+⊢ x ++ (y ++ z) = x ++ y ++ z
+-/
+#guard_msgs in
+example {x y z : List Nat} : x ++ (y ++ z) = (x ++ y) ++ z := by
+
+/--
+info: Try these:
+  [apply] by exact Int.emod_add_mul_ediv a b
+---
+error: unsolved goals
+a b : Int
+⊢ a % b + b * (a / b) = a
+-/
+#guard_msgs in
+example {a b : Int} : a % b + b * (a / b) = a := by
+
+/--
+info: Try these:
+  [apply] by grind
+  [apply] by grind only [= Std.ExtHashMap.getKey_erase, = Std.ExtHashMap.contains_erase,
+    = Std.ExtHashMap.mem_erase, = Std.ExtHashMap.contains_insert, = Std.ExtHashMap.getElem?_insert,
+    = getElem?_pos, = Std.ExtHashMap.getElem?_erase, = Std.ExtHashMap.getKey_eq, = getElem?_neg,
+    =_ Std.ExtHashMap.contains_iff_mem, = Std.ExtHashMap.mem_insert]
+---
+error: unsolved goals
+m : Std.ExtHashMap Nat Int
+⊢ (m.insert 37 5).erase 37 = m.erase 37
+-/
+#guard_msgs in
+example {m : Std.ExtHashMap Nat Int} : (m.insert 37 5).erase 37 = m.erase 37 := by
+
+def fib : Nat → Nat
+  | 0 => 0
+  | 1 => 1
+  | n + 2 => fib n + fib (n + 1)
+
+/--
+info: Try these:
+  [apply] by grind [= fib]
+  [apply] by grind only [fib]
+---
+error: unsolved goals
+n : Nat
+⊢ fib (n + 8) % 3 = fib n % 3
+-/
+#guard_msgs in
+example : fib (n + 8) % 3 = fib n % 3 := by


### PR DESCRIPTION
This PR runs automatically automation at an empty `by` (which is no longer a syntax error). The automation run is controlled by the configuration of `try?`, which we'll separately provide extension points for soon.