### PR TITLE
doc: fix typo in `List.finIdxOf?`

### DIFF
--- a/src/Init/Data/Array/Basic.lean
+++ b/src/Init/Data/Array/Basic.lean
@@ -1295,7 +1295,7 @@ decreasing_by simp_wf; decreasing_trivial_pre_omega
 
 
 /--
-Returns the index of the first element equal to `a`, or the size of the array if no element is equal
+Returns the index of the first element equal to `a`, or `none` if no element is equal
 to `a`. The index is returned as a `Fin`, which guarantees that it is in bounds.
 
 Examples:


### PR DESCRIPTION
This PR fixes a typo in the doc string of `List.finIdxOf?`. The first line of the doc string previously says the function returns the size of the list if no element equal to `a`, but both the examples in the doc string and real run-time behavior indicate it returns `none` in this case.

Closes #11110
