### PR TITLE
feat: suggestions don't included deprecated theorems

### DIFF
--- a/src/Lean/LibrarySuggestions/Basic.lean
+++ b/src/Lean/LibrarySuggestions/Basic.lean
@@ -300,13 +300,13 @@ def isDeniedPremise (env : Environment) (name : Name) : Bool := Id.run do
   if name == ``sorryAx then return true
   if name.isInternalDetail then return true
   if Lean.Meta.isInstanceCore env name then return true
+  if Lean.Linter.isDeprecated env name then return false
   if (nameDenyListExt.getState env).any (fun p => name.anyS (· == p)) then return true
   if let some moduleIdx := env.getModuleIdxFor? name then
     let moduleName := env.header.moduleNames[moduleIdx.toNat]!
     if isDeniedModule env moduleName then
       return true
   let some ci := env.find? name | return true
-  if Lean.Linter.isDeprecated env name then return false
   if let .const fnName _ := ci.type.getForallBody.getAppFn then
     if (typePrefixDenyListExt.getState env).any (fun p => p.isPrefixOf fnName) then return true
   return false


### PR DESCRIPTION
This PR adds a filter for premise selectors to ensure deprecated theorems are not returned.