### PR TITLE
fix: `grind` injection should not fail at `clear`

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/Injection.lean
+++ b/src/Lean/Meta/Tactic/Grind/Injection.lean
@@ -36,7 +36,11 @@ def injection? (mvarId : MVarId) (fvarId : FVarId) : MetaM (Option MVarId) := mv
     let tag ← mvarId.getTag
     let mvarNew ← mkFreshExprSyntheticOpaqueMVar targetNew tag
     mvarId.assign (mkApp val mvarNew)
-    return some (← mvarNew.mvarId!.clear fvarId)
+    /-
+    **Note**: The goal may depend on this hypothesis. So, we use `tryClear`.
+    Another possible solution is to construct a new proof using the new hypotheses.
+    -/
+    return some (← mvarNew.mvarId!.tryClear fvarId)
   | _, _ => return none
 
 end Lean.Meta.Grind

--- a/tests/lean/run/grind_inj_clear_issue.lean
+++ b/tests/lean/run/grind_inj_clear_issue.lean
@@ -1,0 +1,7 @@
+/-!
+`grind` injection step does not fail at `clear`.
+-/
+
+example (n m : Nat) (a : Fin n) (b : Fin m) (h : ∃ h : [n] = [m], (List.cons.inj h).1 ▸ a = b) :
+    (List.cons.inj h.1).1 ▸ a = b := by
+  grind


### PR DESCRIPTION
This PR ensures `grind` does not fail when applying `injection` to a hypothesis that cannot be cleared because of forward dependencies.
