### PR TITLE
fix: check exponent in `grind lia` and `grind ring`

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/Arith/CommRing/EqCnstr.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/CommRing/EqCnstr.lean
@@ -351,7 +351,7 @@ def processNewEq (a b : Expr) : GoalM Unit := do
     trace_goal[grind.ring.assert] "{← mkEq a b}"
     let some ra ← toRingExpr? a | return ()
     let some rb ← toRingExpr? b | return ()
-    let p ← (ra.sub rb).toPolyM
+    let some p ← (ra.sub rb).toPolyM? | return ()
     addNewEq (← mkEqCnstr p (.core a b ra rb))
   else if let some semiringId ← inSameSemiring? a b then SemiringM.run semiringId do
     trace_goal[grind.ring.assert] "{← mkEq a b}"
@@ -362,7 +362,7 @@ def processNewEq (a b : Expr) : GoalM Unit := do
     RingM.run (← getCommSemiring).ringId do
       let some ra ← reify? lhs (skipVar := false) (gen := (← getGeneration a)) | return ()
       let some rb ← reify? rhs (skipVar := false) (gen := (← getGeneration b)) | return ()
-      let p ← (ra.sub rb).toPolyM
+      let some p ← (ra.sub rb).toPolyM? | return ()
       addNewEq (← mkEqCnstr p (.coreS a b sa sb ra rb))
 
 private def pre (e : Expr) : GoalM Expr := do
@@ -399,7 +399,7 @@ private def processNewDiseqCommRing (a b : Expr) : RingM Unit := do
   trace_goal[grind.ring.assert] "{mkNot (← mkEq a b)}"
   let some ra ← toRingExpr? a | return ()
   let some rb ← toRingExpr? b | return ()
-  let p ← (ra.sub rb).toPolyM
+  let some p ← (ra.sub rb).toPolyM? | return ()
   if (← isField) then
     if !(p matches .num _) || !(← hasChar) then
       if rb matches .num 0 then
@@ -424,7 +424,7 @@ private def processNewDiseqCommSemiring (a b : Expr) : SemiringM Unit := do
     RingM.run (← getCommSemiring).ringId do
       let some ra ← reify? lhs (skipVar := false) (gen := (← getGeneration a)) | return ()
       let some rb ← reify? rhs (skipVar := false) (gen := (← getGeneration b)) | return ()
-      let p ← (ra.sub rb).toPolyM
+      let some p ← (ra.sub rb).toPolyM? | return ()
       addNewDiseq {
         lhs := a, rhs := b
         rlhs := ra, rrhs := rb
@@ -505,14 +505,15 @@ private def propagateEqs : RingM Bool := do
   return propagated
 where
   process (a : Expr) (ra : RingExpr) : StateT (Bool × PropagateEqMap) RingM Unit := do
-    let d : PolyDerivation := .input (← ra.toPolyM)
+    let some p ← ra.toPolyM? | return ()
+    let d : PolyDerivation := .input p
     let d ← d.simplify
     let k := d.getMultiplier
     trace_goal[grind.debug.ring.impEq] "{a}, {k}, {← d.p.denoteExpr}"
     if let some (b, rb) :=  (← get).2[(k, d.p)]? then
       -- TODO: use `isEqv` more effectively
       unless (← isEqv a b) do
-        let p ← (ra.sub rb).toPolyM
+        let some p ← (ra.sub rb).toPolyM? | return ()
         let d : PolyDerivation := .input p
         let d ← d.simplify
         if d.getMultiplier != 1 then

--- a/src/Lean/Meta/Tactic/Grind/Arith/Cutsat/EqCnstr.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Cutsat/EqCnstr.lean
@@ -15,6 +15,7 @@ import Lean.Meta.Tactic.Grind.Arith.Cutsat.LeCnstr
 import Lean.Meta.Tactic.Grind.Arith.Cutsat.Nat
 import Lean.Meta.Tactic.Grind.Arith.Cutsat.CommRing
 import Lean.Meta.Tactic.Grind.Arith.Cutsat.Norm
+import Lean.Meta.Tactic.Grind.Arith.EvalNum
 import Lean.Meta.NatInstTesters
 public section
 namespace Lean.Meta.Grind.Arith.Cutsat
@@ -269,6 +270,7 @@ private def propagateNonlinearPow (x : Var) : GoalM Bool := do
       pure (kb.toNat, some cb)
     else
       return false
+  if (← checkExp kb |>.run).isNone then return false
   let c' ← pure { p := .add 1 x (.num (-(ka^kb))), h := .pow ka ca? kb cb? : EqCnstr }
   c'.assert
   return true

--- a/src/Lean/Meta/Tactic/Grind/Arith/EvalNum.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/EvalNum.lean
@@ -20,7 +20,7 @@ We considered `evalExpr` as an alternative, but it introduces considerable overh
  many `grind` calls. We may still use `evalExpr` as a fallback in the future.
 -/
 
-private def checkExp (k : Nat) : OptionT GrindM Unit := do
+def checkExp (k : Nat) : OptionT GrindM Unit := do
   if k > (← getConfig).exp then
     reportIssue! "exponent {k} exceeds threshold for exponentiation `(exp := {(← getConfig).exp})`"
     failure

--- a/src/Lean/Meta/Tactic/Grind/Order/Internalize.lean
+++ b/src/Lean/Meta/Tactic/Grind/Order/Internalize.lean
@@ -111,7 +111,7 @@ def mkCommRingCnstr? (s : Struct) (kind : CnstrKind) (lhs rhs : Expr) : RingM (O
     return some { u := lhs, v := rhs, k := 0, e, kind, h? := some (mkCnstrNorm0 s (← getRing).ringInst kind lhs rhs)  }
   let some lhs ← reify? lhs (skipVar := false) | return none
   let some rhs ← reify? rhs (skipVar := false) | return none
-  let p ← lhs.sub rhs |>.toPolyM
+  let some p ← lhs.sub rhs |>.toPolyM? | return none
   let (lhs', rhs', k) := split p
   let lhs' := lhs'.toExpr
   let rhs' := rhs'.toExpr
@@ -245,7 +245,7 @@ structure OffsetTermResult where
 
 def toOffsetTermCommRing? (e : Expr) : RingM (Option OffsetTermResult) := do
   let some e ← reify? e (skipVar := false) | return none
-  let p ← e.toPolyM
+  let some p ← e.toPolyM? | return none
   let k := p.getConst
   let p := p.addConst (-k)
   let a ← shareCommon (← p.denoteExpr)

--- a/tests/lean/run/grind_11130.lean
+++ b/tests/lean/run/grind_11130.lean
@@ -1,0 +1,42 @@
+section Mathlib.Order.Monotone.Defs
+
+variable {α β : Type} [LT α] [LE α] [LE β] {f : α → β} {a b : α}
+
+def Monotone (f : α → β) : Prop := ∀ ⦃a b⦄, a ≤ b → f a ≤ f b
+
+theorem Monotone.imp (hf : Monotone f) (h : a ≤ b) : f a ≤ f b := sorry
+
+theorem monotone_iff_forall_lt : Monotone f ↔ ∀ ⦃a b⦄, a < b → f a ≤ f b := sorry
+
+end Mathlib.Order.Monotone.Defs
+
+/--
+error: `grind` failed
+case grind.1.1.1.1.1.1.1.1.1
+h : ¬Monotone fun n => n ^ n
+w : Nat
+h_2 : ¬∀ ⦃b : Nat⦄, w + 1 ≤ b → w ^ w ≤ b ^ b
+w_1 : Nat
+h_4 : ¬(w + 1 ≤ w_1 → w ^ w ≤ w_1 ^ w_1)
+h_5 : ((w_1 + 1) ^ (w_1 + 1)) ^ (w_1 + 1) ^ (w_1 + 1) = ((w_1 ^ w_1) ^ w_1 ^ w_1) ^ (w_1 ^ w_1) ^ w_1 ^ w_1
+h_6 : (w_1 ^ w_1) ^ w_1 ^ w_1 = ((w + 1) ^ (w + 1)) ^ (w + 1) ^ (w + 1)
+h_7 : (w ^ w) ^ w ^ w = (((w + 1) ^ (w + 1)) ^ (w + 1) ^ (w + 1)) ^ ((w + 1) ^ (w + 1)) ^ (w + 1) ^ (w + 1)
+h_8 :
+  (w_1 ^ w_1 + 1) ^ w_1 ^ w_1 * (w_1 ^ w_1 + 1) =
+    (((w + 1) ^ (w + 1)) ^ (w + 1) ^ (w + 1)) ^ ((w + 1) ^ (w + 1)) ^ (w + 1) ^ (w + 1)
+h_9 :
+  (w ^ w + 1) ^ w ^ w * (w ^ w + 1) =
+    (((w_1 ^ w_1) ^ w_1 ^ w_1) ^ (w_1 ^ w_1) ^ w_1 ^ w_1) ^ ((w_1 ^ w_1) ^ w_1 ^ w_1) ^ (w_1 ^ w_1) ^ w_1 ^ w_1
+h_10 : (w_1 + 1) ^ w_1 * (w_1 + 1) = w ^ w
+h_11 : (w_1 ^ w_1) ^ w_1 ^ w_1 + 1 = (((w + 1) ^ (w + 1)) ^ (w + 1) ^ (w + 1)) ^ ((w + 1) ^ (w + 1)) ^ (w + 1) ^ (w + 1)
+h_12 : (w ^ w) ^ w ^ w + 1 = ((w ^ w) ^ w ^ w) ^ (w ^ w) ^ w ^ w
+h_13 : (w + 1) ^ (w + 1) + 1 = ((w + 1) ^ (w + 1)) ^ (w + 1) ^ (w + 1)
+⊢ False
+-/
+#guard_msgs in
+theorem pow_self_mono : Monotone fun n : Nat ↦ n ^ n := by
+  grind -verbose [
+    monotone_iff_forall_lt,
+    Monotone.imp,
+    Nat.lt_pow_self
+  ]

--- a/tests/lean/run/grind_9427.lean
+++ b/tests/lean/run/grind_9427.lean
@@ -32,6 +32,7 @@ example (x y z : BitVec 100000) : x * y - z*z = 0 → z*z = y * x := by
 /--
 trace: [grind.issues] exponent 1024 exceeds threshold for exponentiation `(exp := 16)`
 [grind.issues] exponent 1024 exceeds threshold for exponentiation `(exp := 16)`
+[grind.issues] exponent 1024 exceeds threshold for exponentiation `(exp := 16)`
 -/
 #guard_msgs in
 set_option trace.grind.issues true in


### PR DESCRIPTION
This PR ensures that `checkExp` is used in `grind lia` (formerly known as `grind cutsat`) and `grind ring` to prevent stack overflows.

closes #11130
