### PR TITLE
perf: improve performance of `String.ValidPos`

### DIFF
--- a/src/Init/Data/String/Basic.lean
+++ b/src/Init/Data/String/Basic.lean
@@ -1117,7 +1117,7 @@ theorem Pos.Raw.isValidForSlice_replaceEnd {s : Slice} {p : s.Pos} {off : Pos.Ra
   · simpa using h₁
   · simpa using h₃
 
-@[extern "lean_string_utf8_get", expose]
+@[extern "lean_string_utf8_get_fast", expose]
 def decodeChar (s : @& String) (byteIdx : @& Nat) (h : (s.bytes.utf8DecodeChar? byteIdx).isSome) : Char :=
   s.bytes.utf8DecodeChar byteIdx h
 
@@ -1595,9 +1595,9 @@ def Slice.pos! (s : Slice) (off : String.Pos.Raw) : s.Pos :=
 
 /-- Advances a valid position on a string to the next valid position, given a proof that the
 position is not the past-the-end position, which guarantees that such a position exists. -/
-@[inline, expose]
+@[expose, extern "lean_string_utf8_next_fast"]
 def ValidPos.next {s : String} (pos : s.ValidPos) (h : pos ≠ s.endValidPos) : s.ValidPos :=
-  (pos.toSlice.next (ne_of_apply_ne Slice.Pos.ofSlice (by simpa))).ofSlice
+  ((inline (Slice.Pos.next pos.toSlice (ne_of_apply_ne Slice.Pos.ofSlice (by simpa)))).ofSlice)
 
 /-- Advances a valid position on a string to the next valid position, or returns `none` if the
 given position is the past-the-end position. -/

--- a/src/Init/Data/String/Decode.lean
+++ b/src/Init/Data/String/Decode.lean
@@ -1430,7 +1430,7 @@ public theorem isUTF8FirstByte_getElem_zero_utf8EncodeChar {c : Char} :
     ((String.utf8EncodeChar c)[0]'(by simp [c.utf8Size_pos])).IsUTF8FirstByte := by
   simp
 
-@[expose]
+@[expose, inline]
 public def utf8ByteSize (c : UInt8) (_h : c.IsUTF8FirstByte) : Nat :=
   if c &&& 0x80 = 0 then
     1

--- a/src/Init/Data/String/Defs.lean
+++ b/src/Init/Data/String/Defs.lean
@@ -599,6 +599,7 @@ abbrev ValidPos.IsAtEnd {s : String} (pos : s.ValidPos) : Prop :=
 theorem ValidPos.isAtEnd_iff {s : String} {pos : s.ValidPos} :
     pos.IsAtEnd ↔ pos = s.endValidPos := Iff.rfl
 
+@[inline]
 instance {s : String} {pos : s.ValidPos} : Decidable pos.IsAtEnd :=
   decidable_of_iff _ ValidPos.isAtEnd_iff
 
@@ -612,6 +613,7 @@ abbrev Slice.Pos.IsAtEnd {s : Slice} (pos : s.Pos) : Prop :=
 theorem Slice.Pos.isAtEnd_iff {s : Slice} {pos : s.Pos} :
     pos.IsAtEnd ↔ pos = s.endPos := Iff.rfl
 
+@[inline]
 instance {s : Slice} {pos : s.Pos} : Decidable pos.IsAtEnd :=
   decidable_of_iff _ Slice.Pos.isAtEnd_iff
 


### PR DESCRIPTION
This PR aims to bring the performance of `String.ValidPos` closer to that of `String.Pos.Raw` by adding/correcting `extern` annotations as needed.

This is in response to a regression observed after #11127. The changes to the `String` `Parsec` module lead to different compiler behavior for functions like `strCore` and `natCore`. The new IR *looks* better than the old IR, but the [numbers](https://radar.lean-lang.org/repos/lean4/commits/1e438647bae47ea623cc12897010fd68f37d5884?reference=d1e19f2aa0eb4c9b9c8684d80389106c3d21db8b) are a bit mixed.