### PR TITLE
feat: `∎` macro for `try?`

### DIFF
--- a/src/Init/Try.lean
+++ b/src/Init/Try.lean
@@ -42,6 +42,8 @@ structure Config where
   ```
   -/
   merge := true
+  /-- If `wrapWithBy` is `true`, suggestions are wrapped with `by` for term mode usage. -/
+  wrapWithBy := false
   deriving Inhabited
 
 end Lean.Try
@@ -70,3 +72,10 @@ syntax (name := registerTryTactic) (docComment)?
   "register_try?_tactic" ("(" &"priority" ":=" num ")")? tacticSeq : command
 
 end Lean.Parser.Command
+
+/-- `∎` (typed as `\qed`) is a macro that expands to `try?` in tactic mode. -/
+macro "∎" : tactic => `(tactic| try?)
+
+/-- `∎` (typed as `\qed`) is a macro that expands to `by try? (wrapWithBy := true)` in term mode.
+    The `wrapWithBy` config option causes suggestions to be prefixed with `by`. -/
+macro "∎" : term => `(by try? (wrapWithBy := true))

--- a/tests/lean/run/qed_macro.lean
+++ b/tests/lean/run/qed_macro.lean
@@ -1,0 +1,56 @@
+/-
+Test file for the ∎ (QED) macro which expands to `try?`
+-/
+
+import Lean.Elab.Tactic.Try
+
+-- Basic tactic mode usage - should suggest tactics
+/--
+info: Try these:
+  [apply] rfl
+  [apply] simp
+  [apply] simp only [Nat.reduceAdd]
+  [apply] grind
+  [apply] grind only
+  [apply] simp_all
+-/
+#guard_msgs in
+example : 1 + 1 = 2 := by
+  ∎
+
+-- Term mode usage - should suggest terms with "by"
+/--
+info: Try these:
+  [apply] by rfl
+  [apply] by simp
+  [apply] by simp only [Nat.reduceAdd]
+  [apply] by grind
+  [apply] by grind only
+  [apply] by simp_all
+-/
+#guard_msgs in
+example : 1 + 1 = 2 :=
+  ∎
+
+-- With hypotheses in term mode
+/--
+info: Try these:
+  [apply] by simp [*]
+  [apply] by simp only [h]
+  [apply] by grind
+  [apply] by grind only
+  [apply] by simp_all
+-/
+#guard_msgs in
+example (a b : Nat) (h : a = b) : b = a :=
+  ∎
+
+-- Check that error messages are appropriate when try? fails
+/--
+error: Tactic `try?` failed: consider using `grind` manually, or `try? +missing` for partial proofs containing `sorry`
+
+⊢ False
+-/
+#guard_msgs in
+example : False := by
+  ∎


### PR DESCRIPTION
This PR adds tactic and term mode macros for `∎` (typed `\qed`) which expand to `try?`. The term mode version captures any produced suggestions and prepends `by`.