### PR TITLE
chore: tactics using library suggestions set the caller field

### DIFF
--- a/src/Lean/Elab/Tactic/Grind/Main.lean
+++ b/src/Lean/Elab/Tactic/Grind/Main.lean
@@ -124,7 +124,7 @@ def mkGrindParams
   let casesTypes ← Grind.getCasesTypes
   let params := { params with ematch, casesTypes, inj }
   let suggestions ← if config.suggestions then
-    LibrarySuggestions.select mvarId
+    LibrarySuggestions.select mvarId { caller := some "grind" }
   else
     pure #[]
   let mut params ← elabGrindParamsAndSuggestions params ps suggestions (only := only) (lax := config.lax)

--- a/src/Lean/Elab/Tactic/SimpTrace.lean
+++ b/src/Lean/Elab/Tactic/SimpTrace.lean
@@ -57,7 +57,7 @@ def mkSimpCallStx (stx : Syntax) (usedSimps : UsedSimps) : MetaM (TSyntax `tacti
       if let some a := args then a.getElems else #[]
     if config.suggestions then
       -- Get premise suggestions from the premise selector
-      let suggestions ← Lean.LibrarySuggestions.select (← getMainGoal)
+      let suggestions ← Lean.LibrarySuggestions.select (← getMainGoal) { caller := some "simp" }
       -- Convert suggestions to simp argument syntax and add them to the args
       -- If a name is ambiguous, we add ALL interpretations
       for sugg in suggestions do
@@ -96,7 +96,7 @@ def mkSimpCallStx (stx : Syntax) (usedSimps : UsedSimps) : MetaM (TSyntax `tacti
       if let some a := args then a.getElems else #[]
     if config.suggestions then
       -- Get premise suggestions from the premise selector
-      let suggestions ← Lean.LibrarySuggestions.select (← getMainGoal)
+      let suggestions ← Lean.LibrarySuggestions.select (← getMainGoal) { caller := some "simp_all" }
       -- Convert suggestions to simp argument syntax and add them to the args
       -- If a name is ambiguous, we add ALL interpretations
       for sugg in suggestions do

--- a/src/Lean/LibrarySuggestions/Basic.lean
+++ b/src/Lean/LibrarySuggestions/Basic.lean
@@ -147,7 +147,7 @@ structure Config where
   The tactic that is calling the premise selection, e.g. `simp`, `grind`, or `aesop`.
   This may be used to adjust the score of the suggestions
   -/
-  caller : Option Name := none
+  caller : Option String := none
   /--
   A filter on suggestions; only suggestions returning `true` should be returned.
   (It can be better to filter on the premise selection side, to ensure that enough suggestions are returned.)


### PR DESCRIPTION
This PR ensures that tactics using library suggestions set the caller field, so the premise selection engine has access to this. We'll later use this to filter out some modules for grind, which we know have already been fully annotated.