### PR TITLE
fix: lakefile require syntax in `package not found on Reservoir` error

### DIFF
--- a/src/lake/Lake/Load/Materialize.lean
+++ b/src/lake/Lake/Load/Materialize.lean
@@ -121,7 +121,7 @@ def pkgNotIndexed (scope name : String) (ver : InputVer) : String :=
   let (leanVer, tomlVer) :=
     match ver with
     | .none => ("", "")
-    | .git rev => (s!" @ git {repr rev}", s!"\n    rev = {repr rev}")
+    | .git rev => (s!" @ {repr rev}", s!"\n    rev = {repr rev}")
     | .ver ver => (s!" @ {repr ver.toString}", s!"\n    version = {repr ver.toString}")
 s!"{scope}/{name}: package not found on Reservoir.
 


### PR DESCRIPTION
This PR fixes an error message in Lake which suggested incorrect lakefile syntax.

The error message (which was very helpful by the way) looked like this:
```
error: TwoFX/batteries: package not found on Reservoir.

  If the package is on GitHub, you can add a Git source. For example:

    require ...
      from git "https://github.com/TwoFX/batteries" @ git "main"

  or, if using TOML:

    [[require]]
    git = "https://github.com/TwoFX/batteries"
    rev = "main"
    ...
```

The suggested Lakefile syntax does not work. The correct syntax, according to the reference manual and according to my tests, is
```
    require ...
      from git "https://github.com/TwoFX/batteries" @ "main"
```
without the second `git`.