### PR TITLE
feat: `#grind_lint check` produces a "Try this:" suggestion with `#grind_list inspect` commands

### DIFF
--- a/src/Init/Data/List/Lemmas.lean
+++ b/src/Init/Data/List/Lemmas.lean
@@ -2490,7 +2490,10 @@ theorem flatten_reverse {L : List (List α)} :
 @[grind =] theorem reverse_flatMap {β} {l : List α} {f : α → List β} : (l.flatMap f).reverse = l.reverse.flatMap (reverse ∘ f) := by
   induction l <;> simp_all
 
-@[grind =] theorem flatMap_reverse {β} {l : List α} {f : α → List β} : (l.reverse.flatMap f) = (l.flatMap (reverse ∘ f)).reverse := by
+grind_pattern reverse_flatMap => (l.flatMap f).reverse where
+  f =/= List.reverse ∘ _
+
+@[grind =] theorem flatMap_reverse {β} {l : List α} {f : α → List β} : l.reverse.flatMap f = (l.flatMap (reverse ∘ f)).reverse := by
   induction l <;> simp_all
 
 @[simp] theorem reverseAux_eq {as bs : List α} : reverseAux as bs = reverse as ++ bs :=

--- a/src/Lean/Elab/Tactic/Grind/Lint.lean
+++ b/src/Lean/Elab/Tactic/Grind/Lint.lean
@@ -11,6 +11,7 @@ import Lean.Meta.Tactic.Grind.EMatchTheorem
 import Lean.EnvExtension
 import Lean.Elab.Tactic.Grind.Config
 import Lean.Meta.Tactic.TryThis
+import Lean.PrettyPrinter
 namespace Lean.Elab.Tactic.Grind
 
 builtin_initialize skipExt : SimplePersistentEnvExtension Name NameSet ←
@@ -171,10 +172,20 @@ def elabGrindLintCheck : CommandElab := fun stx => liftTermElabM <| withTheReade
   let inModule := m? matches some (some _)
   let decls ← getTheorems prefixes? inModule
   let decls := decls.toArray.qsort Name.lt
+  let mut problematicTheorems := #[]
   for declName in decls do
     try
-      discard <| analyzeEMatchTheorem declName params
+      if (← analyzeEMatchTheorem declName params) then
+        problematicTheorems := problematicTheorems.push declName
     catch e =>
       logError m!"{declName} failed with {e.toMessageData}"
+  if !problematicTheorems.isEmpty then
+    -- Build the "Try this:" suggestion
+    let checkCmd ← PrettyPrinter.ppCategory `command stx
+    let mut suggestion := Format.pretty checkCmd
+    suggestion := suggestion ++ "\n"
+    for declName in problematicTheorems do
+      suggestion := suggestion ++ s!"#grind_lint inspect {declName}\n"
+    Tactic.TryThis.addSuggestion stx { suggestion := .string suggestion }
 
 end Lean.Elab.Tactic.Grind

--- a/tests/lean/run/grind_lint.lean
+++ b/tests/lean/run/grind_lint.lean
@@ -1,0 +1,57 @@
+-- Already working:
+
+-- #grind_lint check (min := 20) in Array
+
+-- In progress:
+
+#grind_lint check  (min := 20) in List
+#grind_lint inspect List.getLast?_concat
+#grind_lint inspect List.getLast?_pmap
+#grind_lint inspect List.getLast_filter
+#grind_lint inspect List.head_filter
+#grind_lint inspect List.length_modifyTailIdx
+#grind_lint inspect List.replicate_sublist_iff
+#grind_lint inspect List.reverse_concat
+#grind_lint inspect List.reverse_flatMap
+#grind_lint inspect List.Sublist.append
+#grind_lint inspect List.Sublist.middle
+
+
+/--
+info: instantiating `Vector.extract_reverse` triggers 22 additional `grind` theorem instantiations
+---
+info: instantiating `Vector.range'_one` triggers more than 100 additional `grind` theorem instantiations
+---
+info: Vector.range'_one
+[thm] instances
+  [thm] Vector.append_assoc ↦ 29
+  [thm] Vector.range'_append ↦ 15
+  [thm] Vector.append_assoc_symm ↦ 12
+  [thm] Vector.empty_append ↦ 11
+  [thm] List.size_toArray ↦ 8
+  [thm] Vector.range'_one ↦ 8
+  [thm] Vector.range'_zero ↦ 7
+  [thm] List.length_cons ↦ 6
+  [thm] Array.size_empty ↦ 1
+  [thm] List.length_nil ↦ 1
+  [thm] Vector.append_empty ↦ 1
+  [thm] Vector.toArray_empty ↦ 1
+---
+info: instantiating `Vector.reverse_extract` triggers 22 additional `grind` theorem instantiations
+---
+info: Try this:
+  [apply] #grind_lint check  (min := 20) in Vector
+  #grind_lint inspect Vector.extract_reverse
+  #grind_lint inspect Vector.range'_one
+  #grind_lint inspect Vector.reverse_extract
+-/
+#guard_msgs in
+#grind_lint check (min := 20) in Vector
+
+-- TODO:
+
+-- #grind_lint check (min := 20) in Option
+-- #grind_lint check (min := 20) in Nat Int Rat Dyadic
+-- #grind_lint check (min := 20) in Prod Sum
+-- #grind_lint check (min := 20) in module Std
+-- #grind_lint check (min := 20)


### PR DESCRIPTION
This PR has `#grind_list check` produce a "Try this:" suggestion with `#grind_list inspect` commands, as this is usually the next step in dealing with problematic cases. We also fix the grind pattern for one theorem, as part of testing the workflow. More to follow.