### PR TITLE
fix: module docstring header nesting in Verso format

### DIFF
--- a/src/Lean/Elab/DocString.lean
+++ b/src/Lean/Elab/DocString.lean
@@ -1491,6 +1491,7 @@ private def elabModSnippet'
           logErrorAt b m!"Incorrect header nesting: expected at most `{"#".pushn '#' maxLevel}` \
             but got `{"#".pushn '#' n}`"
         else
+          maxLevel := n + 1
           let title ←
             liftM <| withInfoContext (mkInfo := pure <| .ofDocInfo {elaborator := `no_elab, stx := b}) <|
               name.mapM elabInline

--- a/tests/lean/run/versoDocMarkdown.lean
+++ b/tests/lean/run/versoDocMarkdown.lean
@@ -8,6 +8,9 @@ set_option doc.verso true
 This module tests the Markdown rendering of all the builtin Verso docstring operators.
 
 Each section begins with a command that will fail when a new, untested operator is added.
+
+## Helpers
+
 -/
 
 section

--- a/tests/lean/run/versoDocNesting.lean
+++ b/tests/lean/run/versoDocNesting.lean
@@ -1,0 +1,58 @@
+set_option doc.verso true
+
+/-!
+This test checks that header nesting rules are enforced within and across Verso module docs.
+
+First, within.
+
+# A
+## B
+### C
+-/
+
+
+/-- error: Incorrect header nesting: expected at most `###` but got `####` -/
+#guard_msgs in
+/-!
+# A
+## B
+#### C
+-/
+
+/-- error: Incorrect header nesting: expected at most `##` but got `###` -/
+#guard_msgs in
+/-!
+# A
+## B
+### C
+#### D
+# E
+### F
+-/
+
+/-!
+Now, check between blocks.
+
+# A
+## B
+-/
+
+/-!
+### C
+-/
+
+/-- error: Incorrect header nesting: expected at most `####` but got `#####` -/
+#guard_msgs in
+/-!
+##### D
+-/
+
+/-!
+# A
+-/
+
+/-- error: Incorrect header nesting: expected at most `##` but got `#####` -/
+#guard_msgs in
+/-!
+##### B
+-/


### PR DESCRIPTION
This PR fixes an issue where header nesting levels were properly tracked between, but not within, moduledocs.
