### PR TITLE
chore: rename `String.offsetOfPos` to `String.Pos.Raw.offsetOfPos`

### DIFF
--- a/src/Init/Data/String/Basic.lean
+++ b/src/Init/Data/String/Basic.lean
@@ -2564,7 +2564,7 @@ Examples:
   if sep == "" then [s] else splitOnAux s sep 0 0 0 []
 
 
-def offsetOfPosAux (s : String) (pos : Pos.Raw) (i : Pos.Raw) (offset : Nat) : Nat :=
+def Pos.Raw.offsetOfPosAux (s : String) (pos : Pos.Raw) (i : Pos.Raw) (offset : Nat) : Nat :=
   if i >= pos then offset
   else if h : i.atEnd s then
     offset
@@ -2589,12 +2589,16 @@ Examples:
 * `"L∃∀N".offsetOfPos ⟨5⟩ = 3`
 * `"L∃∀N".offsetOfPos ⟨50⟩ = 4`
 -/
-@[inline] def offsetOfPos (s : String) (pos : Pos.Raw) : Nat :=
+@[inline] def Pos.Raw.offsetOfPos (s : String) (pos : Pos.Raw) : Nat :=
   offsetOfPosAux s pos 0 0
+
+@[deprecated String.Pos.Raw.offsetOfPos (since := "2025-11-17")]
+def offsetOfPos (s : String) (pos : Pos.Raw) : Nat :=
+  pos.offsetOfPos s
 
 @[export lean_string_offsetofpos]
 def Internal.offsetOfPosImpl (s : String) (pos : Pos.Raw) : Nat :=
-  String.offsetOfPos s pos
+  String.Pos.Raw.offsetOfPos s pos
 
 @[specialize] def foldlAux {α : Type u} (f : α → Char → α) (s : String) (stopPos : Pos.Raw) (i : Pos.Raw) (a : α) : α :=
   if h : i < stopPos then


### PR DESCRIPTION
This PR renames `String.offsetOfPos` to `String.Pos.Raw.offsetOfPos` to align with the other `String.Pos.Raw` operations.