### PR TITLE
fix: add missing `s!` in `UInt64.fromJson?`

### DIFF
--- a/src/Lean/Data/Json/FromToJson/Basic.lean
+++ b/src/Lean/Data/Json/FromToJson/Basic.lean
@@ -155,7 +155,7 @@ def bignumToJson (n : Nat) : Json :=
 protected def _root_.USize.fromJson? (j : Json) : Except String USize := do
   let n ← bignumFromJson? j
   if n ≥ USize.size then
-    throw "value '{j}' is too large for `USize`"
+    throw s!"value '{j}' is too large for `USize`"
   return USize.ofNat n
 
 instance : FromJson USize where
@@ -167,7 +167,7 @@ instance : ToJson USize where
 protected def _root_.UInt64.fromJson? (j : Json) : Except String UInt64 := do
   let n ← bignumFromJson? j
   if n ≥ UInt64.size then
-    throw "value '{j}' is too large for `UInt64`"
+    throw s!"value '{j}' is too large for `UInt64`"
   return UInt64.ofNat n
 
 instance : FromJson UInt64 where


### PR DESCRIPTION
This PR fixes the error thrown by `UInt64.fromJson?` and `USize.fromJson?` to use the missing `s!`.