### PR TITLE
chore: add `String.Pos.next`

### DIFF
--- a/src/Init/Data/String/Basic.lean
+++ b/src/Init/Data/String/Basic.lean
@@ -1599,6 +1599,10 @@ position is not the past-the-end position, which guarantees that such a position
 def ValidPos.next {s : String} (pos : s.ValidPos) (h : pos ≠ s.endValidPos) : s.ValidPos :=
   ((inline (Slice.Pos.next pos.toSlice (ne_of_apply_ne Slice.Pos.ofSlice (by simpa)))).ofSlice)
 
+@[expose, extern "lean_string_utf8_next_fast"]
+def Pos.next {s : String} (pos : s.ValidPos) (h : pos ≠ s.endValidPos) : s.ValidPos :=
+  ((inline (Slice.Pos.next pos.toSlice (ne_of_apply_ne Slice.Pos.ofSlice (by simpa)))).ofSlice)
+
 /-- Advances a valid position on a string to the next valid position, or returns `none` if the
 given position is the past-the-end position. -/
 @[inline, expose]


### PR DESCRIPTION
This PR is split from a future PR and adds the function `String.Pos.next`, an alias (and soon to be correct name) of `String.ValidPos.next`.

This is for boring bootstrapping reasons.