### PR TITLE
refactor: deprecate `String.posOf` and variants in favor of unified `String.find`

### DIFF
--- a/src/Init/Data/String/Basic.lean
+++ b/src/Init/Data/String/Basic.lean
@@ -2539,95 +2539,6 @@ theorem Pos.Raw.prev_lt_of_pos (s : String) (i : Pos.Raw) (h : i ≠ 0) : (i.pre
 theorem prev_lt_of_pos (s : String) (i : Pos.Raw) (h : i ≠ 0) : (i.prev s).1 < i.1 :=
   Pos.Raw.prev_lt_of_pos s i h
 
-def posOfAux (s : String) (c : Char) (stopPos : Pos.Raw) (pos : Pos.Raw) : Pos.Raw :=
-  if h : pos < stopPos then
-    if pos.get s == c then pos
-    else
-      have := Nat.sub_lt_sub_left h (Pos.Raw.lt_next s pos)
-      posOfAux s c stopPos (pos.next s)
-  else pos
-termination_by stopPos.1 - pos.1
-
-/--
-Returns the position of the first occurrence of a character, `c`, in a string `s`. If `s` does not
-contain `c`, returns `s.rawEndPos`.
-
-Examples:
-* `"abcba".posOf 'a' = ⟨0⟩`
-* `"abcba".posOf 'z' = ⟨5⟩`
-* `"L∃∀N".posOf '∀' = ⟨4⟩`
--/
-@[inline] def posOf (s : String) (c : Char) : Pos.Raw :=
-  posOfAux s c s.rawEndPos 0
-
-@[export lean_string_posof]
-def Internal.posOfImpl (s : String) (c : Char) : Pos.Raw :=
-  String.posOf s c
-
-def revPosOfAux (s : String) (c : Char) (pos : Pos.Raw) : Option Pos.Raw :=
-  if h : pos = 0 then none
-  else
-    have := Pos.Raw.prev_lt_of_pos s pos h
-    let pos := pos.prev s
-    if pos.get s == c then some pos
-    else revPosOfAux s c pos
-termination_by pos.1
-
-/--
-Returns the position of the last occurrence of a character, `c`, in a string `s`. If `s` does not
-contain `c`, returns `none`.
-
-Examples:
-* `"abcabc".revPosOf 'a' = some ⟨3⟩`
-* `"abcabc".revPosOf 'z' = none`
-* `"L∃∀N".revPosOf '∀' = some ⟨4⟩`
--/
-@[inline] def revPosOf (s : String) (c : Char) : Option Pos.Raw :=
-  revPosOfAux s c s.rawEndPos
-
-def findAux (s : String) (p : Char → Bool) (stopPos : Pos.Raw) (pos : Pos.Raw) : Pos.Raw :=
-  if h : pos < stopPos then
-    if p (pos.get s) then pos
-    else
-      have := Nat.sub_lt_sub_left h (Pos.Raw.lt_next s pos)
-      findAux s p stopPos (pos.next s)
-  else pos
-termination_by stopPos.1 - pos.1
-
-/--
-Finds the position of the first character in a string for which the Boolean predicate `p` returns
-`true`. If there is no such character in the string, then the end position of the string is
-returned.
-
-Examples:
- * `"coffee tea water".find (·.isWhitespace) = ⟨6⟩`
- * `"tea".find (· == 'X') = ⟨3⟩`
- * `"".find (· == 'X') = ⟨0⟩`
--/
-@[inline] def find (s : String) (p : Char → Bool) : Pos.Raw :=
-  findAux s p s.rawEndPos 0
-
-def revFindAux (s : String) (p : Char → Bool) (pos : Pos.Raw) : Option Pos.Raw :=
-  if h : pos = 0 then none
-  else
-    have := Pos.Raw.prev_lt_of_pos s pos h
-    let pos := pos.prev s
-    if p (pos.get s) then some pos
-    else revFindAux s p pos
-termination_by pos.1
-
-/--
-Finds the position of the last character in a string for which the Boolean predicate `p` returns
-`true`. If there is no such character in the string, then `none` is returned.
-
-Examples:
- * `"coffee tea water".revFind (·.isWhitespace) = some ⟨10⟩`
- * `"tea".revFind (· == 'X') = none`
- * `"".revFind (· == 'X') = none`
--/
-@[inline] def revFind (s : String) (p : Char → Bool) : Option Pos.Raw :=
-  revFindAux s p s.rawEndPos
-
 /--
 Returns the first position where the two strings differ.
 
@@ -2834,17 +2745,6 @@ where
 @[deprecated Pos.Raw.substrEq (since := "2025-10-10")]
 def substrEq (s1 : String) (pos1 : String.Pos.Raw) (s2 : String) (pos2 : String.Pos.Raw) (sz : Nat) : Bool :=
   Pos.Raw.substrEq s1 pos1 s2 pos2 sz
-
-/--
-Returns the position of the beginning of the line that contains the position `pos`.
-
-Lines are ended by `'\n'`, and the returned position is either `0 : String.Pos` or immediately after
-a `'\n'` character.
--/
-def findLineStart (s : String) (pos : String.Pos.Raw) : String.Pos.Raw :=
-  match s.revFindAux (· = '\n') pos with
-  | none => 0
-  | some n => ⟨n.byteIdx + 1⟩
 
 end String
 

--- a/src/Init/Data/String/Slice.lean
+++ b/src/Init/Data/String/Slice.lean
@@ -489,10 +489,25 @@ Examples:
  * {lean}`"tea".toSlice.find? (fun (c : Char) => c == 'X') == none`
  * {lean}`("coffee tea water".toSlice.find? "tea").map (·.get!) == some 't'`
 -/
-@[specialize pat]
+@[inline]
 def find? (s : Slice) (pat : ρ) [ToForwardSearcher pat σ] : Option s.Pos :=
   let searcher := ToForwardSearcher.toSearcher pat s
   searcher.findSome? (fun | .matched startPos _ => some startPos | .rejected .. => none)
+
+/--
+Finds the position of the first match of the pattern {name}`pat` in a slice {name}`s`. If there
+is no match {lean}`s.endPos` is returned.
+
+This function is generic over all currently supported patterns.
+
+Examples:
+ * {lean}`("coffee tea water".toSlice.find Char.isWhitespace).get! == ' '`
+ * {lean}`"tea".toSlice.find (fun (c : Char) => c == 'X') == "tea".toSlice.endPos`
+ * {lean}`("coffee tea water".toSlice.find "tea").get! == 't'`
+-/
+@[inline]
+def find (s : Slice) (pat : ρ) [ToForwardSearcher pat σ] : s.Pos :=
+  s.find? pat |>.getD s.endPos
 
 /--
 Checks whether a slice has a match of the pattern {name}`pat` anywhere.
@@ -791,7 +806,7 @@ where
   termination_by curr.down
 
 /--
-Finds the position of the first match of the pattern {name}`pat` in a slice {name}`true`, starting
+Finds the position of the first match of the pattern {name}`pat` in a slice, starting
 from the end of the slice and traversing towards the start. If there is no match {name}`none` is
 returned.
 

--- a/src/Init/Data/String/Substring.lean
+++ b/src/Init/Data/String/Substring.lean
@@ -51,7 +51,7 @@ A substring is empty if its start and end positions are the same.
 def Internal.isEmptyImpl (ss : Substring.Raw) : Bool :=
   Substring.Raw.isEmpty ss
 
-/--
+/--{}
 Copies the region of the underlying string pointed to by a substring into a fresh string.
 -/
 @[inline] def toString : Substring.Raw → String
@@ -155,8 +155,7 @@ Returns the substring-relative position of the first occurrence of `c` in `s`, o
 doesn't occur.
 -/
 @[inline] def posOf (s : Substring.Raw) (c : Char) : String.Pos.Raw :=
-  match s with
-  | ⟨s, b, e⟩ => { byteIdx := (String.posOfAux s c e b).byteIdx - b.byteIdx }
+  s.toSlice.map (·.find c |>.offset) |>.getD ⟨s.bsize⟩
 
 /--
 Removes the specified number of characters (Unicode code points) from the beginning of a substring

--- a/src/Init/System/FilePath.lean
+++ b/src/Init/System/FilePath.lean
@@ -122,7 +122,7 @@ instance : HDiv FilePath String FilePath where
   hDiv p sub := FilePath.join p ⟨sub⟩
 
 private def posOfLastSep (p : FilePath) : Option String.Pos.Raw :=
-  p.toString.revFind pathSeparators.contains
+  p.toString.revFind? pathSeparators.contains |>.map String.ValidPos.offset
 
 /--
 Returns the parent directory of a path, if there is one.
@@ -173,7 +173,7 @@ Examples:
 -/
 def fileStem (p : FilePath) : Option String :=
   p.fileName.map fun fname =>
-    match fname.revPosOf '.' with
+    match fname.revFind? '.' |>.map String.ValidPos.offset with
     | some ⟨0⟩ => fname
     | some pos => String.Pos.Raw.extract fname 0 pos
     | none     => fname
@@ -192,7 +192,7 @@ Examples:
 -/
 def extension (p : FilePath) : Option String :=
   p.fileName.bind fun fname =>
-    match fname.revPosOf '.' with
+    match fname.revFind? '.' |>.map String.ValidPos.offset with
     | some 0   => none
     | some pos => some <| String.Pos.Raw.extract fname (pos + '.') fname.rawEndPos
     | none     => none

--- a/src/Lean/Elab/StructInstHint.lean
+++ b/src/Lean/Elab/StructInstHint.lean
@@ -148,7 +148,7 @@ where
   Counterpart of `String.findLineStart`.
   -/
   findLineEnd (s : String) (p : String.Pos.Raw) : String.Pos.Raw :=
-    s.findAux (· == '\n') s.rawEndPos p
+    (s.pos! p).find '\n' |>.offset
 
   /--
   Is the structure instance notation `stx` described by `view` using single-line styling?

--- a/src/Lean/Meta/Tactic/Grind/Intro.lean
+++ b/src/Lean/Meta/Tactic/Grind/Intro.lean
@@ -53,15 +53,16 @@ It ensures base name is a simple `Name` and does not have a `_<idx>` suffix
 -/
 private def mkBaseName (name : Name) (type : Expr) : MetaM Name := do
   if let .str _ s := name then
-    let pos := s.find (· == '_')
-    unless pos < s.rawEndPos do
+    let pos := s.find '_'
+    if h : pos.IsAtEnd then
       return Name.mkSimple s
-    let suffix := String.Pos.Raw.extract s (pos+'_') s.rawEndPos
-    unless suffix.isNat do
-      return Name.mkSimple s
-    let s := String.Pos.Raw.extract s ⟨0⟩ pos
-    unless s == "" do
-      return Name.mkSimple s
+    else
+      let suffix := s.sliceFrom (pos.next h)
+      unless suffix.isNat do
+        return Name.mkSimple s
+      let s := s.sliceTo pos
+      unless s.isEmpty do
+        return Name.mkSimple s.copy
   if (← isProp type) then return `h else return `x
 
 private def mkCleanName (name : Name) (type : Expr) : GoalM Name := do

--- a/src/Lean/Meta/TryThis.lean
+++ b/src/Lean/Meta/TryThis.lean
@@ -185,9 +185,13 @@ structure TryThisInfo : Type where
 of spaces by which the line that first includes `range` is initially indented, and `column` is the
 column `range` starts at in that line. -/
 def getIndentAndColumn (map : FileMap) (range : Lean.Syntax.Range) : Nat × Nat :=
-  let start := map.source.findLineStart range.start
-  let body := map.source.findAux (· ≠ ' ') range.start start
-  (start.byteDistance body, start.byteDistance range.start)
+  let rangeStart := map.source.pos! range.start
+  let start := findLineStart rangeStart
+  let body := (map.source.slice! start rangeStart).find (fun c => c != ' ') |>.str.offset
+  (start.offset.byteDistance body, start.offset.byteDistance range.start)
+where
+  findLineStart {s : String} (p : s.ValidPos) : s.ValidPos :=
+    p.revFind? '\n' |>.map (·.next!) |>.getD s.startValidPos
 
 /--
 An option allowing the user to customize the ideal input width. Defaults to 100.

--- a/src/Lean/PrettyPrinter/Formatter.lean
+++ b/src/Lean/PrettyPrinter/Formatter.lean
@@ -610,9 +610,9 @@ def continuation : String := " [...]"
 
 instance : Std.Format.MonadPrettyFormat M where
   pushOutput s := do
-    let lineEnd := s.find (· == '\n')
-    if lineEnd < s.rawEndPos then
-      let s := (String.Pos.Raw.extract s 0 lineEnd).trimAsciiEnd.copy ++ continuation
+    let lineEnd := s.find '\n'
+    if ¬lineEnd.IsAtEnd then
+      let s := (s.sliceTo lineEnd).trimAsciiEnd.copy ++ continuation
       modify fun st => { st with line := st.line.append s }
       throw ()
     else

--- a/src/Lean/Shell.lean
+++ b/src/Lean/Shell.lean
@@ -253,15 +253,15 @@ def shellMain
   ---TODO: make it extensible, and add `lean4md`
   let contents ←
     if contents.startsWith "#lang" then
-      let endLinePos := contents.posOf '\n'
-      let langId := String.Pos.Raw.extract contents ⟨6⟩ endLinePos |>.trimAscii
+      let endLinePos := contents.find '\n'
+      let langId := String.Pos.Raw.extract contents ⟨6⟩ endLinePos.offset |>.trimAscii
       if langId == "lean4".toSlice then
         pure () -- do nothing for now
       else
         IO.eprintln s!"unknown language '{langId}'\n";
         return 1
       -- Remove up to `\n`
-      pure <| String.Pos.Raw.extract contents endLinePos contents.rawEndPos
+      pure <| String.Pos.Raw.extract contents endLinePos.offset contents.rawEndPos
     else
       pure contents
   let setup? ← setupFileName?.mapM ModuleSetup.load

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -191,12 +191,12 @@ def getWantsHelp : CliStateM Bool :=
   (·.wantsHelp) <$> get
 
 def setConfigOpt (kvPair : String) : CliM PUnit :=
-  let pos := kvPair.posOf '='
+  let pos := kvPair.find '='
   let (key, val) :=
-    if pos = kvPair.rawEndPos then
+    if h : pos.IsAtEnd then
       (kvPair.toName, "")
     else
-      (String.Pos.Raw.extract kvPair 0 pos |>.toName, String.Pos.Raw.extract kvPair (pos.next kvPair) kvPair.rawEndPos)
+      (kvPair.startValidPos.extract pos |>.toName, (pos.next h).extract kvPair.endValidPos)
   modifyThe LakeOptions fun opts =>
     {opts with configOpts := opts.configOpts.insert key val}
 

--- a/src/lake/Lake/Config/Artifact.lean
+++ b/src/lake/Lake/Config/Artifact.lean
@@ -7,6 +7,7 @@ module
 
 prelude
 public import Lake.Build.Trace
+import Init.Data.String.Search
 
 open System Lean
 
@@ -49,15 +50,15 @@ public instance : ToJson ArtifactDescr := ⟨(toJson ·.relPath)⟩
 /-- Parse an output's relative file path into an `ArtifactDescr`. -/
 public def ofFilePath? (path : FilePath) : Except String ArtifactDescr := do
   let s := path.toString
-  let pos := s.posOf '.'
-  if h : pos.atEnd s then
+  let pos := s.find '.'
+  if h : pos.IsAtEnd then
     let some hash := Hash.ofString? s
       | throw "expected artifact file name to be a content hash"
     return {hash, ext := ""}
   else
-    let some hash := Hash.ofString? <| String.Pos.Raw.extract s 0 pos
+    let some hash := Hash.ofString? <| s.startValidPos.extract pos
       | throw "expected artifact file name to be a content hash"
-    let ext := String.Pos.Raw.extract s (pos.next' s h) s.rawEndPos
+    let ext := (pos.next h).extract s.endValidPos
     return {hash, ext}
 
 public protected def fromJson? (data : Json) : Except String ArtifactDescr := do

--- a/src/lake/Lake/Util/Cli.lean
+++ b/src/lake/Lake/Util/Cli.lean
@@ -9,6 +9,7 @@ prelude
 import Init.Data.Array.Basic
 public import Init.Data.String.TakeDrop
 import Init.Data.String.Slice
+public import Init.Data.String.Search
 
 namespace Lake
 
@@ -97,21 +98,21 @@ variable [Monad m] [MonadStateOf ArgList m]
 
 /-- Splits a long option of the form `"--long foo bar"` into `--long` and `"foo bar"`. -/
 @[inline] public def longOptionOrSpace (handle : String → m α) (opt : String) : m α :=
-  let pos := opt.posOf ' '
-  if pos = opt.rawEndPos then
+  let pos := opt.find ' '
+  if h : pos = opt.endValidPos then
     handle opt
   else do
-    consArg <| (pos.next opt).extract opt opt.rawEndPos
-    handle <| String.Pos.Raw.extract opt 0 pos
+    consArg <| (pos.next h).extract opt.endValidPos
+    handle <| opt.startValidPos.extract pos
 
 /-- Splits a long option of the form `--long=arg` into `--long` and `arg`. -/
 @[inline] public def longOptionOrEq (handle : String → m α) (opt : String) : m α :=
-  let pos := opt.posOf '='
-  if pos = opt.rawEndPos then
+  let pos := opt.find '='
+  if h : pos = opt.endValidPos then
     handle opt
   else do
-    consArg <| (pos.next opt).extract opt opt.rawEndPos
-    handle <| String.Pos.Raw.extract opt 0 pos
+    consArg <| (pos.next h).extract opt.endValidPos
+    handle <| opt.startValidPos.extract pos
 
 /-- Process a long option  of the form `--long`, `--long=arg`, `"--long arg"`. -/
 @[inline] public def longOption (handle : String → m α) : String → m α :=

--- a/src/lake/Lake/Util/Version.lean
+++ b/src/lake/Lake/Util/Version.lean
@@ -11,6 +11,7 @@ public import Lake.Util.Date
 import Init.Data.String.Slice
 import Init.Data.String.TakeDrop
 import Lean.Data.Trie
+import Init.Data.String.Search
 
 /-! # Version
 
@@ -251,11 +252,11 @@ namespace ToolchainVer
 public instance : Coe LeanVer ToolchainVer := ⟨ToolchainVer.release⟩
 
 public def ofString (ver : String) : ToolchainVer := Id.run do
-  let colonPos := ver.posOf ':'
+  let colonPos := ver.find ':'
   let (origin, tag) :=
-    if h : colonPos < ver.rawEndPos then
-      let pos := colonPos.next' ver (by simp_all [String.rawEndPos, String.Pos.Raw.atEnd, String.Pos.Raw.lt_iff])
-      (String.Pos.Raw.extract ver 0 colonPos, String.Pos.Raw.extract ver pos ver.rawEndPos)
+    if h : ¬colonPos.IsAtEnd then
+      let pos := colonPos.next h
+      (ver.startValidPos.extract colonPos, pos.extract ver.endValidPos)
     else
       ("", ver)
   let noOrigin := origin.isEmpty


### PR DESCRIPTION
This PR cleans up the API around `String.find` and moves it uniformly to the new position types `String.ValidPos` and `String.Slice.Pos`

Overview:

- To search for a character, character predicate, string or slice in a string or slice `s`, use `s.find?` or `s.find`.
- To do the same, but starting at a position `p` of a string or slice, use `p.find?` or `p.find`.
- To do the same but between two positions `p` and `q`, construct the slice from `p` to `q` and then use `find?` or `find` on that.
- To search backwards, all of the above applies, except that the function is called `revFind?`, there is no non-question-mark version (use `getD` if there is a sane default return value in your specific application), and that you can only search for characters and character predicates, not strings or slices.