### PR TITLE
chore: create alias `String.Slice.any` for `String.Slice.contains`

### DIFF
--- a/src/Init/Data/String/Slice.lean
+++ b/src/Init/Data/String/Slice.lean
@@ -509,6 +509,10 @@ def contains [ToForwardSearcher ρ σ] (s : Slice) (pat : ρ) : Bool :=
   let searcher := ToForwardSearcher.toSearcher s pat
   searcher.any (· matches .matched ..)
 
+@[inline, inherit_doc contains]
+def any [ToForwardSearcher ρ σ] (s : Slice) (pat : ρ) : Bool :=
+  s.contains pat
+
 /--
 Checks whether a slice only consists of matches of the pattern {name}`pat` anywhere.
 


### PR DESCRIPTION
This PR adds the alias `String.Slice.any` for `String.Slice.contains`.

It would probably be even better to only have one, but we don't have a good mechanism for pointing people looking for one towards the other, so an alias it is for now.