### PR TITLE
perf: improve specializer cache keys

### DIFF
--- a/src/Lean/Compiler/LCNF/Specialize.lean
+++ b/src/Lean/Compiler/LCNF/Specialize.lean
@@ -238,6 +238,7 @@ def mkKey (params : Array Param) (decls : Array CodeDecl) (body : LetValue) : Co
   let key := ToExpr.run do
     ToExpr.withParams params do
       ToExpr.mkLambdaM params (← ToExpr.abstractM body)
+  let key ← Meta.MetaM.run' <| Meta.transform (usedLetOnly := true) key
   return normLevelParams key
 
 open Internalize in


### PR DESCRIPTION
This PR makes the specializer (correctly) share more cache keys across invocations, causing us to produce less code bloat.

We observed that in functions with lots of specialization, sometimes cache keys are defeq but not BEq because one has unused let decls (introduced by specialization) that the other doesn't. This PR resolves this conflict by erasing unused let decls from specializer cache keys.