### PR TITLE
chore: add CoreM.toIO'

### DIFF
--- a/src/Lean/CoreM.lean
+++ b/src/Lean/CoreM.lean
@@ -435,6 +435,9 @@ def mkFreshUserName (n : Name) : CoreM Name :=
   | Except.error (Exception.internal id _) => throw <| IO.userError <| "internal exception #" ++ toString id.idx
   | Except.ok a                            => return a
 
+@[inline] def CoreM.toIO' (x : CoreM α) (ctx : Context) (s : State) : IO α :=
+  (·.1) <$> x.toIO ctx s
+
 -- withIncRecDepth for a monad `m` such that `[MonadControlT CoreM n]`
 protected def withIncRecDepth [Monad m] [MonadControlT CoreM m] (x : m α) : m α :=
   controlAt CoreM fun runInBase => withIncRecDepth (runInBase x)


### PR DESCRIPTION
This PR adds `CoreM.toIO'`, the analogue of `CoreM.toIO` dropping the state from the return type, and similarly for `TermElabM.toIO'` and `MetaM.toIO'`.