### PR TITLE
feat: rename `cutsat` to `lia` with deprecation warning

### DIFF
--- a/src/Init/Grind/Tactics.lean
+++ b/src/Init/Grind/Tactics.lean
@@ -299,8 +299,18 @@ syntax (name := grindTrace)
 
 It is a implemented as a thin wrapper around the `grind` tactic, enabling only the `cutsat` solver.
 Please use `grind` instead if you need additional capabilities.
+
+**Deprecated**: Use `lia` instead.
 -/
 syntax (name := cutsat) "cutsat" optConfig : tactic
+
+/--
+`lia` solves linear integer arithmetic goals.
+
+It is a implemented as a thin wrapper around the `grind` tactic, enabling only the `cutsat` solver.
+Please use `grind` instead if you need additional capabilities.
+-/
+syntax (name := lia) "lia" optConfig : tactic
 
 /--
 `grobner` solves goals that can be phrased as polynomial equations (with further polynomial equations as hypotheses)

--- a/src/Lean/Elab/Tactic/Grind/Main.lean
+++ b/src/Lean/Elab/Tactic/Grind/Main.lean
@@ -310,8 +310,19 @@ def evalGrindTraceCore (stx : Syntax) (trace := true) (verbose := true) (useSorr
   else
     Tactic.TryThis.addSuggestions stx <| tacs.map fun tac => { suggestion := .tsyntax tac }
 
+@[builtin_tactic Lean.Parser.Tactic.lia] def evalLia : Tactic := fun stx => do
+  let `(tactic| lia $config:optConfig) := stx | throwUnsupportedSyntax
+  let config ← elabCutsatConfig config
+  evalGrindCore stx { config with } none none none
+
 @[builtin_tactic Lean.Parser.Tactic.cutsat] def evalCutsat : Tactic := fun stx => do
   let `(tactic| cutsat $config:optConfig) := stx | throwUnsupportedSyntax
+  -- Emit deprecation warning
+  logWarning "`cutsat` has been deprecated, use `lia` instead"
+  -- Emit a "try this:" suggestion to replace `cutsat` with `lia`
+  let liaTac ← `(tactic| lia $config:optConfig)
+  Tactic.TryThis.addSuggestion stx { suggestion := .tsyntax liaTac }
+  -- Execute the same logic as lia
   let config ← elabCutsatConfig config
   evalGrindCore stx { config with } none none none
 

--- a/tests/lean/run/cutsat_lia_deprecation.lean
+++ b/tests/lean/run/cutsat_lia_deprecation.lean
@@ -1,0 +1,32 @@
+/-!
+# cutsat deprecation test
+
+Tests that `cutsat` suggests replacing with `lia`.
+-/
+
+/--
+warning: `cutsat` has been deprecated, use `lia` instead
+---
+info: Try this:
+  [apply] lia
+-/
+#guard_msgs in
+example {x y : Int} : 2 * x + 4 * y ≠ 5 := by
+  cutsat
+
+/--
+warning: `cutsat` has been deprecated, use `lia` instead
+---
+info: Try this:
+  [apply] lia
+-/
+#guard_msgs in
+example {x y : Int} :  2 * x + 3 * y = 0 → 1 ≤ x → y < 1 := by
+  cutsat
+
+-- Test that lia works the same way
+example {x y : Int} : 2 * x + 4 * y ≠ 5 := by
+  lia
+
+example {x y : Int} : 2 * x + 3 * y = 0 → 1 ≤ x → y < 1 := by
+  lia


### PR DESCRIPTION
This PR renames the `cutsat` tactic to `lia` for better alignment with standard terminology in the theorem proving community.

`cutsat` still works but now emits a deprecation warning and suggests using `lia` instead via "Try this:". Both tactics have identical behavior.