### PR TITLE
feat: add `BitVec.getLsbD_false_of_clz`

### DIFF
--- a/src/Init/Data/BitVec/Lemmas.lean
+++ b/src/Init/Data/BitVec/Lemmas.lean
@@ -6154,6 +6154,18 @@ theorem getLsbD_false_of_clzAuxRec {x : BitVec w} (h : ∀ i, n < i → x.getLsb
         · specialize h i (by omega)
           exact h
 
+theorem getLsbD_false_of_clz {x : BitVec w} :
+    ∀ j, x.getLsbD (w - x.clz.toNat + j) = false := by
+  rw [BitVec.clz]
+  have h : ∀ i, (w - 1) < i → x.getLsbD i = false := by
+    intro i hi
+    by_cases hxi : x.getLsbD i
+    · have := BitVec.lt_of_getLsbD hxi
+      omega
+    · simp at hxi
+      exact hxi
+  exact getLsbD_false_of_clzAuxRec h
+
 theorem getLsbD_true_of_eq_clzAuxRec_of_ne_zero {x : BitVec w} (hx : ¬ x = 0#w) (hn : ∀ i, n < i → x.getLsbD i = false) :
     x.getLsbD (w - 1 - (x.clzAuxRec n).toNat) = true := by
   rcases w with _|w


### PR DESCRIPTION
This PR adds `BitVec.getLsbD_false_of_clz`, which states that the boolean value of any bit in the 'leading zero bits' of a BitVec is false. `BitVec.getLsbD_false_of_clzAuxRec` does already exist, but `BitVec.clzAuxRec` is really just an implementation detail of `BitVec.clz`, and it is more useful to have lemmas which directly state properties of `BitVec.clz`, rather than the auxiliary function which it uses internally.

