### PR TITLE
FreeBSD patches in src/runtime

### DIFF
--- a/src/runtime/io.cpp
+++ b/src/runtime/io.cpp
@@ -1365,7 +1365,13 @@ extern "C" LEAN_EXPORT obj_res lean_io_app_path() {
     char dest[PATH_MAX];
     memset(dest, 0, PATH_MAX);
     pid_t pid = getpid();
+#if defined(__linux__)
     snprintf(path, PATH_MAX, "/proc/%d/exe", pid);
+#elif defined(__FreeBSD__)
+    snprintf(path, PATH_MAX, "/proc/%d/file", pid);
+#else
+#   error "Unknown platform"
+#endif
     if (readlink(path, dest, PATH_MAX) == -1) {
         return io_result_mk_error("failed to locate application");
     } else {

--- a/src/runtime/process.cpp
+++ b/src/runtime/process.cpp
@@ -31,6 +31,10 @@ Author: Jared Roesch
 #include <sys/syscall.h>
 #endif
 
+#ifdef __FreeBSD__
+#include <pthread_np.h>
+#endif
+
 #include "runtime/object.h"
 #include "runtime/io.h"
 #include "runtime/array_ref.h"
@@ -342,6 +346,8 @@ extern "C" LEAN_EXPORT uint64_t lean_io_get_tid() {
     lean_always_assert(pthread_threadid_np(NULL, &tid) == 0);
 #elif defined(LEAN_EMSCRIPTEN)
     tid = 0;
+#elif defined(__FreeBSD__)
+    tid = (pid_t)pthread_getthreadid_np();
 #else
     // since Linux 2.4.11, our glibc 2.27 requires at least 3.2
     // glibc 2.30 would provide a wrapper

--- a/src/runtime/stack_overflow.cpp
+++ b/src/runtime/stack_overflow.cpp
@@ -21,6 +21,11 @@ Port of the corresponding Rust code (see links below).
 #include <initializer_list>
 #include "runtime/stack_overflow.h"
 
+#if defined(__FreeBSD__)
+#include <pthread_np.h>
+#define pthread_getattr_np pthread_attr_get_np
+#endif
+
 namespace lean {
 // stack guard of the main thread
 static stack_guard * g_stack_guard;


### PR DESCRIPTION
These are 3 patches from the  [patches from the lean4 FreeBSD port](https://cgit.freebsd.org/ports/tree/math/lean4/files).
All tests pass in the FreeBSD port.

stage0 patches should probably be submitted separately.