### PR TITLE
refactor: `String` functions `foldr`, `all`, `any`, `contains` to go trough `String.Slice`

### DIFF
--- a/src/Init/Data/String/Basic.lean
+++ b/src/Init/Data/String/Basic.lean
@@ -2594,8 +2594,6 @@ where
 def extract : (@& String) → (@& Pos.Raw) → (@& Pos.Raw) → String
   | s, b, e => Pos.Raw.extract s b e
 
-
-
 def Pos.Raw.offsetOfPosAux (s : String) (pos : Pos.Raw) (i : Pos.Raw) (offset : Nat) : Nat :=
   if i >= pos then offset
   else if h : i.atEnd s then
@@ -2631,83 +2629,6 @@ def offsetOfPos (s : String) (pos : Pos.Raw) : Nat :=
 @[export lean_string_offsetofpos]
 def Internal.offsetOfPosImpl (s : String) (pos : Pos.Raw) : Nat :=
   String.Pos.Raw.offsetOfPos s pos
-
-@[specialize] def foldrAux {α : Type u} (f : Char → α → α) (a : α) (s : String) (i begPos : Pos.Raw) : α :=
-  if h : begPos < i then
-    have := Pos.Raw.prev_lt_of_pos s i <| mt (congrArg String.Pos.Raw.byteIdx) <|
-      Ne.symm <| Nat.ne_of_lt <| Nat.lt_of_le_of_lt (Nat.zero_le _) h
-    let i := i.prev s
-    let a := f (i.get s) a
-    foldrAux f a s i begPos
-  else a
-termination_by i.1
-
-/--
-Folds a function over a string from the right, accumulating a value starting with `init`. The
-accumulated value is combined with each character in reverse order, using `f`.
-
-Examples:
- * `"coffee tea water".foldr (fun c n => if c.isWhitespace then n + 1 else n) 0 = 2`
- * `"coffee tea and water".foldr (fun c n => if c.isWhitespace then n + 1 else n) 0 = 3`
- * `"coffee tea water".foldr (fun c s => c.push s) "" = "retaw dna aet eeffoc"`
--/
-@[inline] def foldr {α : Type u} (f : Char → α → α) (init : α) (s : String) : α :=
-  foldrAux f init s s.rawEndPos 0
-
-@[specialize] def anyAux (s : String) (stopPos : Pos.Raw) (p : Char → Bool) (i : Pos.Raw) : Bool :=
-  if h : i < stopPos then
-    if p (i.get s) then true
-    else
-      have := Nat.sub_lt_sub_left h (Pos.Raw.lt_next s i)
-      anyAux s stopPos p (i.next s)
-  else false
-termination_by stopPos.1 - i.1
-
-/--
-Checks whether there is a character in a string for which the Boolean predicate `p` returns `true`.
-
-Short-circuits at the first character for which `p` returns `true`.
-
-Examples:
- * `"brown".any (·.isLetter) = true`
- * `"brown".any (·.isWhitespace) = false`
- * `"brown and orange".any (·.isLetter) = true`
- * `"".any (fun _ => false) = false`
--/
-@[inline] def any (s : String) (p : Char → Bool) : Bool :=
-  anyAux s s.rawEndPos p 0
-
-@[export lean_string_any]
-def Internal.anyImpl (s : String) (p : Char → Bool) :=
-  String.any s p
-
-/--
-Checks whether the Boolean predicate `p` returns `true` for every character in a string.
-
-Short-circuits at the first character for which `p` returns `false`.
-
-Examples:
- * `"brown".all (·.isLetter) = true`
- * `"brown and orange".all (·.isLetter) = false`
- * `"".all (fun _ => false) = true`
--/
-@[inline] def all (s : String) (p : Char → Bool) : Bool :=
-  !s.any (fun c => !p c)
-
-/--
-Checks whether a string contains the specified character.
-
-Examples:
-* `"green".contains 'e' = true`
-* `"green".contains 'x' = false`
-* `"".contains 'x' = false`
--/
-@[inline] def contains (s : String) (c : Char) : Bool :=
-  s.any (fun a => a == c)
-
-@[export lean_string_contains]
-def Internal.containsImpl (s : String) (c : Char) : Bool :=
-  String.contains s c
 
 theorem Pos.Raw.utf8SetAux_of_gt (c' : Char) : ∀ (cs : List Char) {i p : Pos.Raw}, i > p → utf8SetAux c' cs i p = cs
   | [],    _, _, _ => rfl

--- a/src/Init/Data/String/Search.lean
+++ b/src/Init/Data/String/Search.lean
@@ -293,6 +293,68 @@ Examples:
 def Internal.foldlImpl (f : String → Char → String) (init : String) (s : String) : String :=
   String.foldl f init s
 
+@[deprecated String.Slice.foldr (since := "2025-11-25")]
+def foldrAux {α : Type u} (f : Char → α → α) (a : α) (s : String) (i begPos : Pos.Raw) : α :=
+  s.slice! (s.pos! begPos) (s.pos! i) |>.foldr f a
+
+/--
+Folds a function over a string from the right, accumulating a value starting with {lean}`init`. The
+accumulated value is combined with each character in reverse order, using {lean}`f`.
+
+Examples:
+ * {lean}`"coffee tea water".foldr (fun c n => if c.isWhitespace then n + 1 else n) 0 = 2`
+ * {lean}`"coffee tea and water".foldr (fun c n => if c.isWhitespace then n + 1 else n) 0 = 3`
+ * {lean}`"coffee tea water".foldr (fun c s => s.push c) "" = "retaw aet eeffoc"`
+-/
+@[inline] def foldr {α : Type u} (f : Char → α → α) (init : α) (s : String) : α :=
+  s.toSlice.foldr f init
+
+@[deprecated String.Slice.any (since := "2025-11-25")]
+def anyAux (s : String) (stopPos : Pos.Raw) (p : Char → Bool) (i : Pos.Raw) : Bool :=
+  s.slice! (s.pos! i) (s.pos! stopPos) |>.any p
+
+
+/--
+Checks whether a string has a match of the pattern {name}`pat` anywhere.
+
+This function is generic over all currently supported patterns.
+
+Examples:
+ * {lean}`"coffee tea water".contains Char.isWhitespace = true`
+ * {lean}`"tea".contains (fun (c : Char) => c == 'X') = false`
+ * {lean}`"coffee tea water".contains "tea" = true`
+-/
+@[inline] def contains (s : String) (pat : ρ) [ToForwardSearcher pat σ] : Bool :=
+  s.toSlice.contains pat
+
+@[export lean_string_contains]
+def Internal.containsImpl (s : String) (c : Char) : Bool :=
+  String.contains s c
+
+@[inline, inherit_doc contains] def any (s : String) (pat : ρ) [ToForwardSearcher pat σ] : Bool :=
+  s.contains pat
+
+@[export lean_string_any]
+def Internal.anyImpl (s : String) (p : Char → Bool) :=
+  String.any s p
+
+/--
+Checks whether a slice only consists of matches of the pattern {name}`pat`.
+
+Short-circuits at the first pattern mis-match.
+
+This function is generic over all currently supported patterns.
+
+Examples:
+ * {lean}`"brown".all Char.isLower = true`
+ * {lean}`"brown and orange".all Char.isLower = false`
+ * {lean}`"aaaaaa".all 'a' = true`
+ * {lean}`"aaaaaa".all "aa" = true`
+ * {lean}`"aaaaaaa".all "aa" = false`
+-/
+@[inline] def all (s : String) (pat : ρ) [ForwardPattern pat] : Bool :=
+  s.toSlice.all pat
+
 /--
 Checks whether the string can be interpreted as the decimal representation of a natural number.
 

--- a/src/Init/Data/String/Slice.lean
+++ b/src/Init/Data/String/Slice.lean
@@ -529,7 +529,7 @@ def any (s : Slice) (pat : ρ) [ToForwardSearcher pat σ] : Bool :=
   s.contains pat
 
 /--
-Checks whether a slice only consists of matches of the pattern {name}`pat` anywhere.
+Checks whether a slice only consists of matches of the pattern {name}`pat`.
 
 Short-circuits at the first pattern mis-match.
 

--- a/src/Init/Data/String/Substring.lean
+++ b/src/Init/Data/String/Substring.lean
@@ -32,7 +32,7 @@ def ofSlice (s : String.Slice) : Substring.Raw where
 Converts a `Substring.Raw` into a `String.Slice`, returning `none` if the substring is invalid.
 -/
 @[inline]
-def toSlice (s : Substring.Raw) : Option String.Slice :=
+def toSlice? (s : Substring.Raw) : Option String.Slice :=
   if h : s.startPos.IsValid s.str ∧ s.stopPos.IsValid s.str ∧ s.startPos ≤ s.stopPos then
     some (String.Slice.mk s.str (s.str.pos s.startPos h.1) (s.str.pos s.stopPos h.2.1)
       (by simp [String.Pos.le_iff, h.2.2]))
@@ -155,7 +155,7 @@ Returns the substring-relative position of the first occurrence of `c` in `s`, o
 doesn't occur.
 -/
 @[inline] def posOf (s : Substring.Raw) (c : Char) : String.Pos.Raw :=
-  s.toSlice.map (·.find c |>.offset) |>.getD ⟨s.bsize⟩
+  s.toSlice?.map (·.find c |>.offset) |>.getD ⟨s.bsize⟩
 
 /--
 Removes the specified number of characters (Unicode code points) from the beginning of a substring
@@ -260,15 +260,14 @@ Folds a function over a substring from the left, accumulating a value starting w
 accumulated value is combined with each character in order, using `f`.
 -/
 @[inline] def foldl {α : Type u} (f : α → Char → α) (init : α) (s : Substring.Raw) : α :=
-  s.toSlice.get!.foldl f init
+  s.toSlice?.get!.foldl f init
 
 /--
 Folds a function over a substring from the right, accumulating a value starting with `init`. The
 accumulated value is combined with each character in reverse order, using `f`.
 -/
 @[inline] def foldr {α : Type u} (f : Char → α → α) (init : α) (s : Substring.Raw) : α :=
-  match s with
-  | ⟨s, b, e⟩ => String.foldrAux f init s e b
+  s.toSlice?.get!.foldr f init
 
 /--
 Checks whether the Boolean predicate `p` returns `true` for any character in a substring.
@@ -276,8 +275,7 @@ Checks whether the Boolean predicate `p` returns `true` for any character in a s
 Short-circuits at the first character for which `p` returns `true`.
 -/
 @[inline] def any (s : Substring.Raw) (p : Char → Bool) : Bool :=
-  match s with
-  | ⟨s, b, e⟩ => String.anyAux s e p b
+  s.toSlice?.get!.any p
 
 /--
 Checks whether the Boolean predicate `p` returns `true` for every character in a substring.
@@ -285,7 +283,7 @@ Checks whether the Boolean predicate `p` returns `true` for every character in a
 Short-circuits at the first character for which `p` returns `false`.
 -/
 @[inline] def all (s : Substring.Raw) (p : Char → Bool) : Bool :=
-  !s.any (fun c => !p c)
+  s.toSlice?.get!.all p
 
 @[export lean_substring_all]
 def Internal.allImpl (s : Substring.Raw) (p : Char → Bool) : Bool :=

--- a/src/Lean/Data/Lsp/Utf16.lean
+++ b/src/Lean/Data/Lsp/Utf16.lean
@@ -9,6 +9,7 @@ module
 prelude
 public import Lean.Data.Lsp.BasicAux
 public import Lean.DeclarationRange
+import Init.Data.String.Search
 
 public section
 

--- a/src/Lean/Data/Xml/Parser.lean
+++ b/src/Lean/Data/Xml/Parser.lean
@@ -8,6 +8,7 @@ module
 prelude
 public import Std.Internal.Parsec
 public import Lean.Data.Xml.Basic
+import Init.Data.String.Search
 
 public section
 

--- a/src/Lean/DocString/Markdown.lean
+++ b/src/Lean/DocString/Markdown.lean
@@ -183,7 +183,7 @@ where
   go : List (Inline i) → String × Inline i
     | [] => ("", .empty)
     | .text s :: more =>
-      if s.all (·.isWhitespace) then
+      if s.all Char.isWhitespace then
         let (pre, post) := go more
         (s ++ pre, post)
       else
@@ -198,7 +198,7 @@ where
   go : List (Inline i) → Inline i × String
     | [] => (.empty, "")
     | .text s :: more =>
-      if s.all (·.isWhitespace) then
+      if s.all Char.isWhitespace then
         let (pre, post) := go more
         (pre, post ++ s)
       else

--- a/src/Lean/Parser/Term/Doc.lean
+++ b/src/Lean/Parser/Term/Doc.lean
@@ -76,7 +76,7 @@ def getRecommendedSpellingString (env : Environment) (declName : Name) : String 
   else "\n\nConventions for notations in identifiers:\n\n" ++ String.join (spellings.toList.map bullet) |>.trimAsciiEnd |>.copy
 where
   indentLine (str : String) : String :=
-    (if str.all (·.isWhitespace) then str else "   " ++ str) ++ "\n"
+    (if str.all Char.isWhitespace then str else "   " ++ str) ++ "\n"
   bullet (spelling : RecommendedSpelling) : String :=
     let firstLine := s!" * The recommended spelling of `{spelling.«notation»}` in identifiers is `{spelling.recommendedSpelling}`"
     let additionalInfoLines := spelling.additionalInformation?.map (·.split '\n' |>.toStringList)


### PR DESCRIPTION
This PR updates the `foldr`, `all`, `any` and `contains` functions on `String` to be defined in terms of their `String.Slice` counterparts.

This is the last one in a long series of PRs. After this, all `String` operations are polymorphic in the pattern, and no `String` operation falls back to `String.Pos.Raw` internally (except those in the `String.Pos.Raw` and `String.Substring.Raw` namespaces of course, which still play a role in metaprogramming and will stay for the foreseeable future).