### PR TITLE
doc: correct grammar error in array indexing panic message

### DIFF
--- a/src/Init/GetElem.lean
+++ b/src/Init/GetElem.lean
@@ -116,7 +116,7 @@ macro:max x:term noWs "[" i:term "]" noWs "?" : term => `(getElem? $x $i)
 
 /--
 The syntax `arr[i]!` gets the `i`'th element of the collection `arr` and
-panics `i` is out of bounds.
+panics if `i` is out of bounds.
 -/
 macro:max x:term noWs "[" i:term "]" noWs "!" : term => `(getElem! $x $i)
 


### PR DESCRIPTION
This PR corrects a grammar error in a docstring in the GetElem file for array indexing.
