### PR TITLE
perf: macro_inline ctorIdx for single constructor inductives

### DIFF
--- a/src/Lean/Meta/Constructions/CtorIdx.lean
+++ b/src/Lean/Meta/Constructions/CtorIdx.lean
@@ -83,7 +83,7 @@ public def mkCtorIdx (indName : Name) : MetaM Unit :=
       modifyEnv fun env => addProtected env declName
       setReducibleAttribute declName
       if info.numCtors = 1 then
-        setInlineAttribute declName
+        setInlineAttribute declName .macroInline
       compileDecl decl
 
       -- Deprecated alias for enumeration types (which used to have `toCtorIdx`)


### PR DESCRIPTION
This PR sets `@[macro_inline]` on the (trivial) `.ctorIdx` for inductive types with one constructor, to reduce the number of symbols generated by the compiler.