### PR TITLE
doc: write a guideline for tactic docstrings

### DIFF
--- a/doc/style.md
+++ b/doc/style.md
@@ -1144,7 +1144,7 @@ the short summary should be a full sentence in which the subject
 is an example invocation of the tactic, written in present tense
 indicative. If the example tactic invocation names parameters, then the
 short summary may refer to them. For the example invocation, prefer the
-simplest representative example. Explain more complicated forms in the
+simplest or most typical example. Explain more complicated forms in the
 variants section. If needed, abbreviate the invocation by naming part of
 the syntax and expanding it in the next sentence. The summary should be
 written as a single paragraph.
@@ -1159,11 +1159,12 @@ explanatory examples that can’t necessarily be machine checked and
 don’t fit the format.
 
 If the tactic is extensible using `macro_rules`, mention this in the
-details and give a one-line example. If the tactic provides an attribute
-or a command that allows the user to extend its behavior, the
-documentation on how to extend the tactic belongs to that attribute or
-command. In the tactic docstring, use a single sentence to refer the
-reader to this further documentation.
+details, with a link to `lean-manual://section/tactic-macro-extension`
+and give a one-line example. If the tactic provides an attribute or a
+command that allows the user to extend its behavior, the documentation
+on how to extend the tactic belongs to that attribute or command. In the
+tactic docstring, use a single sentence to refer the reader to this
+further documentation.
 
 **Variants**, if needed, should be a bulleted list describing different
 options and forms of the same tactic. The reader should be able to parse


### PR DESCRIPTION
This PR covers tactic docstrings in the documentation style guide.

At the Mathlib Initiative we want to ensure that tactics have good documentation. Since this will involve adding documentation to tactics built into core Lean, I discussed with David that we should write a shared set of documentation guidelines that allow me to do my work both on the Lean and on the Mathlib repositories.

I have already shown an earlier version of this guideline to David who made some helpful suggestions but would be away for a few days. So to make sure the discussion doesn't get lost, I've made a PR with the version I ended up with after the first round of comments.