### PR TITLE
perf: de-fuel some recursive definitions in Core

### DIFF
--- a/src/Init/Data/String/Basic.lean
+++ b/src/Init/Data/String/Basic.lean
@@ -66,6 +66,7 @@ not a sequence of Unicode scalar values.
 def ByteArray.utf8Decode? (b : ByteArray) : Option (Array Char) :=
   go 0 #[] (by simp)
 where
+  @[semireducible]
   go (i : Nat) (acc : Array Char) (hi : i ≤ b.size) : Option (Array Char) :=
     if i < b.size then
       match h : utf8DecodeChar? b i with
@@ -80,6 +81,7 @@ where
 def ByteArray.validateUTF8 (b : @& ByteArray) : Bool :=
   go 0 (by simp)
 where
+  @[semireducible]
   go (i : Nat) (hi : i ≤ b.size) : Bool :=
     if hi : i < b.size then
       match h : validateUTF8At b i with

--- a/src/Init/Grind/Ring/CommSolver.lean
+++ b/src/Init/Grind/Ring/CommSolver.lean
@@ -889,6 +889,7 @@ where
     | .num k' => acc.insert (k*k' % c) m
     | .add k' m' p => go p (acc.insert (k*k' % c) (m.mul_nc m'))
 
+@[semireducible]
 def Poly.combineC (p₁ p₂ : Poly) (c : Nat) : Poly := match p₁, p₂ with
   | .num k₁, .num k₂ => .num ((k₁ + k₂) % c)
   | .num k₁, .add k₂ m₂ p₂ => addConstC (.add k₂ m₂ p₂) k₁ c

--- a/tests/lean/run/letToHaveCleanup.lean
+++ b/tests/lean/run/letToHaveCleanup.lean
@@ -168,7 +168,7 @@ def fnWFRec (n : Nat) : let α := Nat; α :=
   | 0 => 0
   | n + 1 => id (let m := n + 1; m * fnWFRec (n / 2))
 /--
-info: def fnWFRec : Nat →
+info: @[irreducible] def fnWFRec : Nat →
   have α : Type := Nat;
   α :=
 WellFounded.Nat.fix (fun x => x) fun n a =>

--- a/tests/lean/run/mutwf2.lean
+++ b/tests/lean/run/mutwf2.lean
@@ -11,14 +11,14 @@ mutual
 end
 
 /--
-info: def Ex1.isEven : Nat → Bool :=
+info: @[irreducible] def Ex1.isEven : Nat → Bool :=
 fun a => isEven._mutual (PSum.inl a)
 -/
 #guard_msgs in
 #print isEven
 
 /--
-info: def Ex1.isOdd : Nat → Bool :=
+info: @[irreducible] def Ex1.isOdd : Nat → Bool :=
 fun a => isEven._mutual (PSum.inr a)
 -/
 #guard_msgs in

--- a/tests/pkg/module/Module/ImportedAll.lean
+++ b/tests/pkg/module/Module/ImportedAll.lean
@@ -77,7 +77,7 @@ info: private theorem f_struct.eq_unfold : f_struct = fun x =>
 -/
 #guard_msgs in #print sig f_struct.eq_unfold
 
-/-- info: @[defeq] private theorem f_wfrec.eq_1 : ∀ (x : Nat), f_wfrec 0 x = x -/
+/-- info: private theorem f_wfrec.eq_1 : ∀ (x : Nat), f_wfrec 0 x = x -/
 #guard_msgs(pass trace, all) in #print sig f_wfrec.eq_1
 
 /--

--- a/tests/pkg/module/Module/NonModule.lean
+++ b/tests/pkg/module/Module/NonModule.lean
@@ -26,7 +26,7 @@ info: theorem f_struct.eq_unfold : f_struct = fun x =>
 -/
 #guard_msgs in #print sig f_struct.eq_unfold
 
-/-- info: @[defeq] theorem f_wfrec.eq_1 : ∀ (x : Nat), f_wfrec 0 x = x -/
+/-- info: theorem f_wfrec.eq_1 : ∀ (x : Nat), f_wfrec 0 x = x -/
 #guard_msgs(pass trace, all) in #print sig f_wfrec.eq_1
 
 /--


### PR DESCRIPTION
This PR follows up on #7965 and avoids manual fuel constructions in some recursive definitions.