### PR TITLE
feat: check pointer equality in isDefEqQuick

### DIFF
--- a/src/Lean/Meta/ExprDefEq.lean
+++ b/src/Lean/Meta/ExprDefEq.lean
@@ -1656,6 +1656,8 @@ private partial def consumeLetIfZeta (e : Expr) : MetaM Expr := do
 mutual
 
 private partial def isDefEqQuick (t s : Expr) : MetaM LBool := do
+  if unsafe ptrEq t s then -- Safe because pointer-equal expressions are certainly defeq
+    return .true
   let t ← consumeLetIfZeta t
   let s ← consumeLetIfZeta s
   match t, s with


### PR DESCRIPTION
This PR optimizes isDefEqQuick with a pointer equality check.

Due to pervasive sharing, it's probably not uncommon for `isDefEq` to be called on pointer-equal expressions. In that case, we can very cheaply avoid all the work that `isDefEq` would otherwise perform just to establish structural equality.
