### PR TITLE
feat: `try?` runs `grind +suggestions` with varying configs in parallel

### DIFF
--- a/src/Init/Grind/Config.lean
+++ b/src/Init/Grind/Config.lean
@@ -21,6 +21,8 @@ structure Config where
   /-- If `suggestions` is `true`, `grind` will invoke the currently configured library suggestion engine on the current goal,
   and add attempt to use the resulting suggestions as additional parameters to the `grind` tactic. -/
   suggestions : Bool := false
+  /-- Maximum number of library suggestions to request when `suggestions` is `true`. -/
+  maxSuggestions : Nat := 1024
   /-- Maximum number of case-splits in a proof search branch. It does not include splits performed during normalization. -/
   splits : Nat := 9
   /-- Maximum number of E-matching (aka heuristic theorem instantiation) rounds before each case split. -/

--- a/src/Init/Try.lean
+++ b/src/Init/Try.lean
@@ -11,6 +11,7 @@ public import Init.Tactics
 public section
 
 namespace Lean.Try
+
 /--
 Configuration for `try?`.
 -/
@@ -57,6 +58,9 @@ syntax (name := attemptAll) "attempt_all " withPosition((ppDedent(ppLine) colGe 
 
 /-- Helper internal tactic for implementing the tactic `try?` with parallel execution. -/
 syntax (name := attemptAllPar) "attempt_all_par " withPosition((ppDedent(ppLine) colGe "| " tacticSeq)+) : tactic
+
+/-- Helper internal tactic: runs tactics in parallel, returns first success, cancels rest. -/
+syntax (name := firstPar) "first_par " withPosition((ppDedent(ppLine) colGe "| " tacticSeq)+) : tactic
 
 /-- Helper internal tactic used to implement `evalSuggest` in `try?` -/
 syntax (name := tryResult) "try_suggestions " tactic* : tactic

--- a/tests/lean/run/try_library_suggestions.lean
+++ b/tests/lean/run/try_library_suggestions.lean
@@ -26,7 +26,10 @@ axiom special_7 : SpecialProperty 7
 -- Set up a premise selector that suggests special_7
 set_library_suggestions (fun _ _ => pure #[{ name := `special_7, score := 1.0 }])
 
--- Expected: try? should find grind only [special_7]
+-- Expected: try? should find grind with library suggestions
+-- Note: first_par runs multiple grind configs in parallel; the first to complete wins
+-- Config details are filtered from output for cleaner suggestions
+-- Plain `grind` is not suggested since it won't work without the library suggestions
 /--
 info: Try these:
   [apply] grind only [special_7]
@@ -45,7 +48,7 @@ axiom custom_comm : ∀ x y, CustomOp x y = CustomOp y x
 -- Set up a premise selector that suggests custom_comm
 set_library_suggestions (fun _ _ => pure #[{ name := `custom_comm, score := 1.0 }])
 
--- Expected: try? should find grind only [custom_comm]
+-- Expected: try? should find grind with custom_comm
 /--
 info: Try these:
   [apply] grind only [custom_comm]


### PR DESCRIPTION
This PR enhances `try?` to run multiple `grind +suggestions` configurations in parallel, returning the first successful result.

- Add `maxSuggestions` field to `Grind.Config` to control how many library suggestions are requested
- Add `first_par` tactic combinator that runs tactics in parallel and returns the first success (uses `TacticM.parFirst`)
- `try?` now runs three parallel grind configs with escalating suggestion counts (128, 1024, 8192) and correspondingly reduced gen/splits thresholds. None of this parameter choices are particularly carefully chosen. Ideally this would be data-driven, but is just intuition for now.

🤖 Prepared with Claude Code