### PR TITLE
refactor: lake: CLI API overhaul

### DIFF
--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -769,3 +769,5 @@ public def help : (cmd : String) → String
 | "lean"                => helpLean
 | "translate-config"    => helpTranslateConfig
 | _                     => usage
+
+@[simp] public theorem help_empty : help "" = usage := by rfl

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -173,13 +173,18 @@ def takeArg (arg : String) : CliM String := do
   | none => throw <| CliError.missingArg arg
   | some arg => pure arg
 
-def takeOptArg (opt arg : String) : CliM String := do
-  match (← takeArg?) with
-  | none => throw <| CliError.missingOptArg opt arg
-  | some arg => pure arg
+def takeOptArg (optArg? : Option String.Slice) (opt argName : String) : CliM String := do
+  if let some arg := optArg? then
+    return arg.copy
+  else if let some arg ← takeArg? then
+    return arg
+  else
+    throw <| CliError.missingOptArg opt argName
 
-@[inline] def takeOptArg' (opt arg : String) (f : String → Option α)  : CliM α := do
-  if let some a :=  f (← takeOptArg opt arg) then return a
+@[inline] def takeOptArg'
+  (optArg? : Option String.Slice) (opt arg : String) (f : String → Option α)
+: CliM α := do
+  if let some a := f (← takeOptArg optArg? opt arg) then return a
   throw <| CliError.invalidOptArg opt arg
 
 /--
@@ -206,21 +211,22 @@ def setConfigOpt (kvPair : String) : CliM PUnit :=
   modifyThe LakeOptions fun opts =>
     {opts with configOpts := opts.configOpts.insert key val}
 
-def lakeShortOption : (opt : Char) → CliM PUnit
-| 'q' => modifyThe LakeOptions ({· with verbosity := .quiet})
-| 'v' => modifyThe LakeOptions ({· with verbosity := .verbose})
-| 'd' => do let rootDir ← takeOptArg "-d" "path"; modifyThe LakeOptions ({· with rootDir})
-| 'f' => do let configFile ← takeOptArg "-f" "path"; modifyThe LakeOptions ({· with configFile})
-| 'o' => do let outputsFile? ← takeOptArg "-o" "path"; modifyThe LakeOptions ({· with outputsFile?})
-| 'K' => do setConfigOpt <| ← takeOptArg "-K" "key-value pair"
-| 'U' => do
-  logWarning "the '-U' shorthand for '--update' is deprecated"
-  modifyThe LakeOptions ({· with updateDeps := true})
-| 'R' => modifyThe LakeOptions ({· with reconfigure := true})
-| 'h' => modifyThe LakeOptions ({· with wantsHelp := true})
-| 'H' => modifyThe LakeOptions ({· with trustHash := false})
-| 'J' => modifyThe LakeOptions ({· with outFormat := .json})
-| opt => throw <| CliError.unknownShortOption opt
+def lakeShortOption : ShortOptHandler CliM := .ofFn fun opt optArg? =>
+  match opt with
+  | 'q' => modifyThe LakeOptions ({· with verbosity := .quiet})
+  | 'v' => modifyThe LakeOptions ({· with verbosity := .verbose})
+  | 'd' => do let rootDir ← takeOptArg optArg? "-d" "path"; modifyThe LakeOptions ({· with rootDir})
+  | 'f' => do let configFile ← takeOptArg optArg? "-f" "path"; modifyThe LakeOptions ({· with configFile})
+  | 'o' => do let outputsFile? ← takeOptArg optArg? "-o" "path"; modifyThe LakeOptions ({· with outputsFile?})
+  | 'K' => do setConfigOpt <| ← takeOptArg optArg? "-K" "key-value pair"
+  | 'U' => do
+    logWarning "the '-U' shorthand for '--update' is deprecated"
+    modifyThe LakeOptions ({· with updateDeps := true})
+  | 'R' => modifyThe LakeOptions ({· with reconfigure := true})
+  | 'h' => modifyThe LakeOptions ({· with wantsHelp := true})
+  | 'H' => modifyThe LakeOptions ({· with trustHash := false})
+  | 'J' => modifyThe LakeOptions ({· with outFormat := .json})
+  | opt => throw <| CliError.unknownShortOption opt
 
 /-- Returns an error if the string is not valid GitHub repository name. -/
 -- Limitations derived from https://github.com/dead-claudia/github-limits
@@ -269,122 +275,129 @@ def parseLintersSpec (spec : String) : CliM PUnit := do
     { opts with runBuiltinLint := true, builtinLint.linterOverrides :=
         opts.builtinLint.linterOverrides ++ entries }
 
-def lakeLongOption : (opt : String) → CliM PUnit
-| "--quiet"       => modifyThe LakeOptions ({· with verbosity := .quiet})
-| "--verbose"     => modifyThe LakeOptions ({· with verbosity := .verbose})
-| "--update"      => modifyThe LakeOptions ({· with updateDeps := true})
-| "--keep-toolchain" => modifyThe LakeOptions ({· with updateToolchain := false})
-| "--reconfigure" => modifyThe LakeOptions ({· with reconfigure := true})
-| "--old"         => modifyThe LakeOptions ({· with oldMode := true})
-| "--text"        => modifyThe LakeOptions ({· with outFormat := .text})
-| "--json"        => modifyThe LakeOptions ({· with outFormat := .json})
-| "--allow-empty" => modifyThe LakeOptions ({· with allowEmpty := true})
-| "--no-build"    => modifyThe LakeOptions ({· with noBuild := true})
-| "--no-cache"    => modifyThe LakeOptions ({· with noCache := true})
-| "--try-cache"   => modifyThe LakeOptions ({· with noCache := false})
-| "--rehash"      => modifyThe LakeOptions ({· with trustHash := false})
-| "--offline"     => modifyThe LakeOptions ({· with offline := true})
-| "--wfail"       => modifyThe LakeOptions ({· with failLv := .warning})
-| "--iofail"      => modifyThe LakeOptions ({· with failLv := .info})
-| "--no-overwrite" => modifyThe LakeOptions ({· with overwrite? := some false})
-| "--force-overwrite" => modifyThe LakeOptions ({· with overwrite? := some true})
-| "--force-download" => modifyThe LakeOptions ({· with forceDownload := true})
-| "--download-arts" => modifyThe LakeOptions ({· with mappingsOnly := false})
-| "--mappings-only" => modifyThe LakeOptions ({· with mappingsOnly := true})
-| "--service" => do
-  let service ← takeOptArg "--service" "service name"
-  modifyThe LakeOptions ({· with service? := some service})
-| "--scope" => do
-  let scope ← takeOptArg "--scope" "cache scope"
-  modifyThe LakeOptions ({· with scope? := some (.ofString scope)})
-| "--repo" => do
-  let repo ← takeOptArg "--repo" "GitHub repository"
-  if let some e := validateRepo? repo then error e
-  modifyThe LakeOptions ({· with scope? := some (.ofRepo repo)})
-| "--platform" => do
-  let platform ← takeOptArg "--platform" "cache platform"
-  if platform.chars.length > 100 then
-    error "invalid platform; platform is expected to be at most 100 characters long"
-  modifyThe LakeOptions ({· with platform? := some <| .ofString platform})
-| "--toolchain" => do
-  let toolchain ← takeOptArg "--toolchain" "cache toolchain"
-  let toolchain := if toolchain.isEmpty then .none else .ofString toolchain
-  if toolchain.length > 256 then
-    error "invalid toolchain version; toolchain is expected to be at most 256 characters long"
-  modifyThe LakeOptions ({· with toolchain? := some toolchain})
-| "--rev" => do
-  let rev ← takeOptArg "--rev" "Git revision"
-  modifyThe LakeOptions ({· with rev? := some rev})
-| "--max-revs" => do
-  let some n ← (·.toNat?) <$> takeOptArg "--max-revs" "number of revisions"
-    | error "argument to `--max-revs` should be a natural number"
-  modifyThe LakeOptions ({· with maxRevs := n})
-| "--log-level"   => do
-  let outLv ← takeOptArg' "--log-level" "log level" LogLevel.ofString?
-  modifyThe LakeOptions ({· with outLv? := outLv})
-| "--fail-level"  => do
-  let failLv ← takeOptArg' "--fail-level" "log level" LogLevel.ofString?
-  modifyThe LakeOptions ({· with failLv})
-| "--ansi"        => modifyThe LakeOptions ({· with ansiMode := .ansi})
-| "--no-ansi"     => modifyThe LakeOptions ({· with ansiMode := .noAnsi})
-| "--packages"    => do
-  let file ← takeOptArg "--packages" "package overrides file"
-  let overrides ← Manifest.loadEntries file
-  modifyThe LakeOptions fun opts =>
-    {opts with packageOverrides := opts.packageOverrides ++ overrides}
-| "--dir"         => do
-  let rootDir ← takeOptArg "--dir" "path"
-  modifyThe LakeOptions ({· with rootDir})
-| "--file"        => do
-  let configFile ← takeOptArg "--file" "path"
-  modifyThe LakeOptions ({· with configFile})
-| "--help"        => modifyThe LakeOptions ({· with wantsHelp := true})
-| "--"            => do
-  let subArgs ← takeArgs
-  modifyThe LakeOptions ({· with subArgs})
--- Builtin lint options (using any of these implicitly enables --builtin-lint)
-| "--builtin-lint" => modifyThe LakeOptions ({· with runBuiltinLint := true})
-| "--builtin-only" => modifyThe LakeOptions ({· with runBuiltinLint := true, builtinOnly := true})
-| "--record-exceptions" =>
-  modifyThe LakeOptions ({· with runBuiltinLint := true, builtinLint.recordExceptions := true})
-| "--linters" => do
-  let opts ← getThe LakeOptions
-  if opts.builtinLint.lintOnly then
-    flushLinterOptions
-    modifyLintOnlyFlag false
-  let spec ← takeOptArg "--linters" "comma-separated linter spec"
-  parseLintersSpec spec
-| "--lint-only" => do
-  let opts ← getThe LakeOptions
-  if !opts.builtinLint.lintOnly then
-    flushLinterOptions
-    modifyLintOnlyFlag true
-  let spec ← takeOptArg "--lint-only" "comma-separated linter spec"
-  parseLintersSpec spec
+def lakeLongOption : LongOptHandler CliM := .ofFn fun opt optArg? =>
+  match opt with
+  | "--quiet"       => modifyThe LakeOptions ({· with verbosity := .quiet})
+  | "--verbose"     => modifyThe LakeOptions ({· with verbosity := .verbose})
+  | "--update"      => modifyThe LakeOptions ({· with updateDeps := true})
+  | "--keep-toolchain" => modifyThe LakeOptions ({· with updateToolchain := false})
+  | "--reconfigure" => modifyThe LakeOptions ({· with reconfigure := true})
+  | "--old"         => modifyThe LakeOptions ({· with oldMode := true})
+  | "--text"        => modifyThe LakeOptions ({· with outFormat := .text})
+  | "--json"        => modifyThe LakeOptions ({· with outFormat := .json})
+  | "--allow-empty" => modifyThe LakeOptions ({· with allowEmpty := true})
+  | "--no-build"    => modifyThe LakeOptions ({· with noBuild := true})
+  | "--no-cache"    => modifyThe LakeOptions ({· with noCache := true})
+  | "--try-cache"   => modifyThe LakeOptions ({· with noCache := false})
+  | "--rehash"      => modifyThe LakeOptions ({· with trustHash := false})
+  | "--offline"     => modifyThe LakeOptions ({· with offline := true})
+  | "--wfail"       => modifyThe LakeOptions ({· with failLv := .warning})
+  | "--iofail"      => modifyThe LakeOptions ({· with failLv := .info})
+  | "--no-overwrite" => modifyThe LakeOptions ({· with overwrite? := some false})
+  | "--force-overwrite" => modifyThe LakeOptions ({· with overwrite? := some true})
+  | "--force-download" => modifyThe LakeOptions ({· with forceDownload := true})
+  | "--download-arts" => modifyThe LakeOptions ({· with mappingsOnly := false})
+  | "--mappings-only" => modifyThe LakeOptions ({· with mappingsOnly := true})
+  | "--service" => do
+    let service ← takeOptArg optArg? "--service" "service name"
+    modifyThe LakeOptions ({· with service? := some service})
+  | "--scope" => do
+    let scope ← takeOptArg optArg? "--scope" "cache scope"
+    modifyThe LakeOptions ({· with scope? := some (.ofString scope)})
+  | "--repo" => do
+    let repo ← takeOptArg optArg? "--repo" "GitHub repository"
+    if let some e := validateRepo? repo then error e
+    modifyThe LakeOptions ({· with scope? := some (.ofRepo repo)})
+  | "--platform" => do
+    let platform ← takeOptArg optArg? "--platform" "cache platform"
+    if platform.chars.length > 100 then
+      error "invalid platform; platform is expected to be at most 100 characters long"
+    modifyThe LakeOptions ({· with platform? := some <| .ofString platform})
+  | "--toolchain" => do
+    let toolchain ← takeOptArg optArg? "--toolchain" "cache toolchain"
+    let toolchain := if toolchain.isEmpty then .none else .ofString toolchain
+    if toolchain.length > 256 then
+      error "invalid toolchain version; toolchain is expected to be at most 256 characters long"
+    modifyThe LakeOptions ({· with toolchain? := some toolchain})
+  | "--rev" => do
+    let rev ← takeOptArg optArg? "--rev" "Git revision"
+    modifyThe LakeOptions ({· with rev? := some rev})
+  | "--max-revs" => do
+    let some n ← (·.toNat?) <$> takeOptArg optArg? "--max-revs" "number of revisions"
+      | throw <| CliError.invalidOptArg "--max-revs" "natural number"
+    modifyThe LakeOptions ({· with maxRevs := n})
+  | "--log-level"   => do
+    let outLv ← takeOptArg' optArg? "--log-level" "log level" LogLevel.ofString?
+    modifyThe LakeOptions ({· with outLv? := outLv})
+  | "--fail-level"  => do
+    let failLv ← takeOptArg' optArg? "--fail-level" "log level" LogLevel.ofString?
+    modifyThe LakeOptions ({· with failLv})
+  | "--ansi"        => modifyThe LakeOptions ({· with ansiMode := .ansi})
+  | "--no-ansi"     => modifyThe LakeOptions ({· with ansiMode := .noAnsi})
+  | "--packages"    => do
+    let file ← takeOptArg optArg? "--packages" "package overrides file"
+    let overrides ← Manifest.loadEntries file
+    modifyThe LakeOptions fun opts =>
+      {opts with packageOverrides := opts.packageOverrides ++ overrides}
+  | "--dir"         => do
+    let rootDir ← takeOptArg optArg? "--dir" "path"
+    modifyThe LakeOptions ({· with rootDir})
+  | "--file"        => do
+    let configFile ← takeOptArg optArg? "--file" "path"
+    modifyThe LakeOptions ({· with configFile})
+  | "--help"        => modifyThe LakeOptions ({· with wantsHelp := true})
+  | "--"            => do
+    let subArgs ← takeArgs
+    modifyThe LakeOptions ({· with subArgs})
+  -- Builtin lint options (using any of these implicitly enables --builtin-lint)
+  | "--builtin-lint" => modifyThe LakeOptions ({· with runBuiltinLint := true})
+  | "--builtin-only" => modifyThe LakeOptions ({· with runBuiltinLint := true, builtinOnly := true})
+  | "--record-exceptions" =>
+    modifyThe LakeOptions ({· with runBuiltinLint := true, builtinLint.recordExceptions := true})
+  | "--linters" => do
+    let opts ← getThe LakeOptions
+    if opts.builtinLint.lintOnly then
+      flushLinterOptions
+      modifyLintOnlyFlag false
+    let spec ← takeOptArg optArg? "--linters" "comma-separated linter spec"
+    parseLintersSpec spec
+  | "--lint-only" => do
+    let opts ← getThe LakeOptions
+    if !opts.builtinLint.lintOnly then
+      flushLinterOptions
+      modifyLintOnlyFlag true
+    let spec ← takeOptArg optArg? "--lint-only" "comma-separated linter spec"
+    parseLintersSpec spec
 
--- Shared options
-| "--force" => modifyThe LakeOptions ({· with shake.force := true})
--- Shake options
-| "--keep-implied" => modifyThe LakeOptions ({· with shake.keepImplied := true})
-| "--keep-prefix" => modifyThe LakeOptions ({· with shake.keepPrefix := true})
-| "--keep-public" => modifyThe LakeOptions ({· with shake.keepPublic := true})
-| "--add-public" => modifyThe LakeOptions ({· with shake.addPublic := true})
-| "--gh-style" => modifyThe LakeOptions ({· with shake.githubStyle := true})
-| "--explain" => modifyThe LakeOptions ({· with shake.explain := true})
-| "--trace" => modifyThe LakeOptions ({· with shake.trace := true})
-| "--fix" => modifyThe LakeOptions ({· with shake.fix := true})
-| "--only" => do
-  let mod ← takeOptArg "--only" "minimize only this module"
-  modifyThe LakeOptions fun opts =>
-    {opts with shake.onlyMods := opts.shake.onlyMods.push mod.toName}
-| opt             =>  throw <| CliError.unknownLongOption opt
+  -- Shared options
+  | "--force" => modifyThe LakeOptions ({· with shake.force := true})
+  -- Shake options
+  | "--keep-implied" => modifyThe LakeOptions ({· with shake.keepImplied := true})
+  | "--keep-prefix" => modifyThe LakeOptions ({· with shake.keepPrefix := true})
+  | "--keep-public" => modifyThe LakeOptions ({· with shake.keepPublic := true})
+  | "--add-public" => modifyThe LakeOptions ({· with shake.addPublic := true})
+  | "--gh-style" => modifyThe LakeOptions ({· with shake.githubStyle := true})
+  | "--explain" => modifyThe LakeOptions ({· with shake.explain := true})
+  | "--trace" => modifyThe LakeOptions ({· with shake.trace := true})
+  | "--fix" => modifyThe LakeOptions ({· with shake.fix := true})
+  | "--only" => do
+    let mod ← takeOptArg optArg? "--only" "minimize only this module"
+    modifyThe LakeOptions fun opts =>
+      {opts with shake.onlyMods := opts.shake.onlyMods.push mod.toName}
+  | opt             =>  throw <| CliError.unknownLongOption opt.copy
 
-def lakeOption :=
+def lakeOption : OptHandler CliM :=
   option {
     short := lakeShortOption
     long := lakeLongOption
     longShort := shortOptionWithArg lakeShortOption
   }
+
+def processLakeOptions : CliM PUnit :=
+  processOptions lakeOption -- specializes `processOptions`
+
+def processLeadingLakeOptions : CliM PUnit :=
+  processLeadingOptions lakeOption -- specializes `processLeadingOptions`
 
 /-! ## Actions -/
 
@@ -463,7 +476,7 @@ def endpointDeprecation : String :=
    "configuring the cache service via environment variables is deprecated; use --service instead"
 
 protected def get : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   let mappings? ← takeArg?
   noArgsRem do
@@ -648,7 +661,7 @@ where
       return art
 
 protected def put : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let file ← takeArg "mappings"
   let opts ← getThe LakeOptions
   let some scope := opts.scope?
@@ -666,7 +679,7 @@ protected def put : CliM PUnit := do
   putCore rev file lakeCache.artifactDir service scope platform toolchain
 
 protected def add : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let file ← takeArg "mappings"
   let pkg? ← takeArg?
   let opts ← getThe LakeOptions
@@ -692,7 +705,7 @@ protected def add : CliM PUnit := do
 private def stagingOutputsFile := "outputs.jsonl"
 
 protected def stage : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   let mappingsFile ← FilePath.mk <$> takeArg "mappings"
   let stagingDir ← FilePath.mk <$> takeArg "staging directory"
@@ -729,7 +742,7 @@ protected def stage : CliM PUnit := do
     exit 1
 
 protected def unstage : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   let stagingDir ← FilePath.mk <$> takeArg "staging directory"
   let pkg? ← takeArg?
@@ -777,7 +790,7 @@ protected def unstage : CliM PUnit := do
   ws.lakeCache.writeMap localScope map service? opts.scope? overwrite
 
 protected def putStaged : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   let stagingDir ← FilePath.mk <$> takeArg "staging directory"
   let some scope := opts.scope?
@@ -793,7 +806,7 @@ protected def putStaged : CliM PUnit := do
   putCore rev outputsFile stagingDir service scope platform toolchain
 
 protected def services : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   noArgsRem do
   let lakeEnv ← opts.computeEnv
@@ -801,7 +814,7 @@ protected def services : CliM PUnit := do
   cfg.config.cache.services.forM (IO.println ·.name)
 
 protected def clean : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   noArgsRem do
   let cfg ← mkLoadConfig opts
@@ -836,7 +849,7 @@ def cacheCli : (cmd : String) → CliM PUnit
 namespace script
 
 protected def list : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let config ← mkLoadConfig (← getThe LakeOptions)
   noArgsRem do
     let ws ← loadWorkspace config
@@ -845,7 +858,7 @@ protected def list : CliM PUnit := do
         IO.println script.name
 
 protected nonrec def run : CliM PUnit := do
-  processLeadingOptions lakeOption  -- between `lake [script] run` and `<name>`
+  processLeadingLakeOptions  -- between `lake [script] run` and `<name>`
   let config ← mkLoadConfig (← getThe LakeOptions)
   let ws ← loadWorkspace config
   if let some spec ← takeArg? then
@@ -858,7 +871,7 @@ protected nonrec def run : CliM PUnit := do
     exit 0
 
 protected def doc : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let spec ← takeArg "script name"
   let config ← mkLoadConfig (← getThe LakeOptions)
   noArgsRem do
@@ -883,21 +896,21 @@ def scriptCli : (cmd : String) → CliM PUnit
 /-! ### `lake` CLI -/
 
 protected def new : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   let name ← takeArg "package name"
   let (tmp, lang) ← parseTemplateLangSpec <| ← takeArgD ""
   noArgsRem do new name tmp lang (← opts.computeEnv) opts.rootDir opts.offline
 
 protected def init : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   let name := ← takeArgD "."
   let (tmp, lang) ← parseTemplateLangSpec <| ← takeArgD ""
   noArgsRem do init name tmp lang (← opts.computeEnv) opts.rootDir opts.offline
 
 protected def build : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   let config ← mkLoadConfig opts
   let ws ← loadWorkspace config
@@ -916,12 +929,12 @@ protected def build : CliM PUnit := do
   ws.runBuild (buildSpecs specs) buildConfig
 
 protected def checkBuild : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let pkg ← loadPackage (← mkLoadConfig (← getThe LakeOptions))
   noArgsRem do exit <| if pkg.defaultTargets.isEmpty then 1 else 0
 
 protected def query : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   let config ← mkLoadConfig opts
   let ws ← loadWorkspace config
@@ -933,7 +946,7 @@ protected def query : CliM PUnit := do
   results.forM (IO.println ·)
 
 protected def queryKind : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   let config ← mkLoadConfig opts
   let ws ← loadWorkspace config
@@ -953,21 +966,21 @@ protected def queryKind : CliM PUnit := do
     | none => error "build failed"
 
 protected def resolveDeps : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   let config ← mkLoadConfig opts
   noArgsRem do
   discard <| loadWorkspace config
 
 protected def update : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   let config ← mkLoadConfig opts
   let toUpdate := (← getArgs).foldl (·.insert <| stringToLegalOrSimpleName ·) {}
   updateManifest config toUpdate
 
 protected def pack : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let file? ← takeArg?
   noArgsRem do
   let ws ← loadWorkspace (← mkLoadConfig (← getThe LakeOptions))
@@ -975,7 +988,7 @@ protected def pack : CliM PUnit := do
   ws.root.pack file
 
 protected def unpack : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let file? ← takeArg?
   noArgsRem do
   let ws ← loadWorkspace (← mkLoadConfig (← getThe LakeOptions))
@@ -983,7 +996,7 @@ protected def unpack : CliM PUnit := do
   ws.root.unpack file
 
 protected def upload : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let tag ← takeArg "release tag"
   noArgsRem do
   let ws ← loadWorkspace (← mkLoadConfig (← getThe LakeOptions))
@@ -991,7 +1004,7 @@ protected def upload : CliM PUnit := do
 
 protected def cache : CliM PUnit := do
   if let some cmd ← takeArg? then
-    processLeadingOptions lakeOption -- between `lake cache <cmd>` and args
+    processLeadingLakeOptions -- between `lake cache <cmd>` and args
     if (← getWantsHelp) then
       IO.println <| helpCache cmd
     else
@@ -1000,7 +1013,7 @@ protected def cache : CliM PUnit := do
     throw <| CliError.missingCommand
 
 protected def setupFile : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   let loadConfig ← mkLoadConfig opts
   let buildConfig := mkBuildConfig opts
@@ -1015,7 +1028,7 @@ protected def setupFile : CliM PUnit := do
   exit <| ← setupFile loadConfig filePath header buildConfig
 
 protected def test : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   let ws ← loadWorkspace (← mkLoadConfig opts)
   noArgsRem do
@@ -1023,7 +1036,7 @@ protected def test : CliM PUnit := do
   exit <| ← x.run (mkLakeContext ws)
 
 protected def checkTest : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let pkg ← loadPackage (← mkLoadConfig (← getThe LakeOptions))
   noArgsRem do exit <| if pkg.testDriver.isEmpty then 1 else 0
 
@@ -1055,7 +1068,7 @@ private def runBuiltinLint
   BuiltinLint.run args
 
 protected def lint : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   let ws ← loadWorkspace (← mkLoadConfig opts)
   let hasDriver := !ws.root.lintDriver.isEmpty && !opts.builtinOnly
@@ -1075,14 +1088,14 @@ protected def lint : CliM PUnit := do
   exit exitCode
 
 protected def checkLint : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let pkg ← loadPackage (← mkLoadConfig (← getThe LakeOptions))
   noArgsRem do
   let hasLint := !pkg.lintDriver.isEmpty || pkg.config.builtinLint? == some true
   exit <| if hasLint then 0 else 1
 
 protected def clean : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let config ← mkLoadConfig (← getThe LakeOptions)
   let ws ← loadWorkspace config
   let pkgSpecs ← takeArgs
@@ -1097,7 +1110,7 @@ protected def clean : CliM PUnit := do
 
 /-- The `lake shake` command: minimize imports in Lean source files. -/
 protected def shake : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   let config ← mkLoadConfig opts
   let ws ← loadWorkspace config
@@ -1121,7 +1134,7 @@ protected def shake : CliM PUnit := do
 
 protected def script : CliM PUnit := do
   if let some cmd ← takeArg? then
-    processLeadingOptions lakeOption -- between `lake script <cmd>` and args
+    processLeadingLakeOptions -- between `lake script <cmd>` and args
     if (← getWantsHelp) then
       IO.println <| helpScript cmd
     else
@@ -1130,7 +1143,7 @@ protected def script : CliM PUnit := do
     throw <| CliError.missingCommand
 
 protected def serve : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   let args := opts.subArgs.toArray
   let config ← mkLoadConfig opts
@@ -1162,7 +1175,7 @@ protected def exe : CliM PUnit := do
   exit <| ← (Lake.env exeFile.toString args.toArray).run <| mkLakeContext ws
 
 protected def lean : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let leanFile ← takeArg "Lean file"
   let opts ← getThe LakeOptions
   noArgsRem do
@@ -1171,7 +1184,7 @@ protected def lean : CliM PUnit := do
   exit rc
 
 protected def translateConfig : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   let cfg ← mkLoadConfig opts
   let lang ← parseLangSpec (← takeArg "configuration language")
@@ -1203,7 +1216,7 @@ structure ReservoirConfig where
   deriving Lean.ToJson
 
 protected def reservoirConfig : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   let cfg ← mkLoadConfig opts
   let _ ← id do
@@ -1235,7 +1248,7 @@ protected def reservoirConfig : CliM PUnit := do
   IO.println (toJson cfg).pretty
 
 protected def versionTags : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   let opts ← getThe LakeOptions
   let cfg ← mkLoadConfig opts
   noArgsRem do
@@ -1246,7 +1259,7 @@ protected def versionTags : CliM PUnit := do
       IO.println tag
 
 protected def selfCheck : CliM PUnit := do
-  processOptions lakeOption
+  processLakeOptions
   noArgsRem do verifyInstall (← getThe LakeOptions)
 
 protected def help : CliM PUnit := do
@@ -1297,9 +1310,9 @@ def lake : CliM PUnit := do
   | [] => IO.println usage
   | ["--version"] => IO.println uiVersionString
   | _ => -- normal CLI
-    processLeadingOptions lakeOption -- between `lake` and command
+    processLeadingLakeOptions -- between `lake` and command
     if let some cmd ← takeArg? then
-      processLeadingOptions lakeOption -- between `lake <cmd>` and args
+      processLeadingLakeOptions -- between `lake <cmd>` and args
       if (← getWantsHelp) then
         IO.println <| help cmd
       else

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -148,7 +148,7 @@ export LakeOptions (mkLoadConfig mkBuildConfig)
 
 abbrev CliMainM := ExceptT CliError MainM
 abbrev CliStateM := StateT LakeOptions CliMainM
-abbrev CliM := ArgsT CliStateM
+abbrev CliM := StateT ArgList CliStateM
 
 def CliM.run (self : CliM α) (args : List String) : BaseIO ExitCode := do
   let (elanInstall?, leanInstall?, lakeInstall?) ← findInstall?
@@ -171,10 +171,10 @@ instance (priority := low) : MonadLift LoggerIO CliStateM := ⟨CliStateM.runLog
 
 instance : MonadThrowExpectedArg CliM := ⟨throwMissingArg⟩
 
-@[inline] def throwMissingOptArg (arg : String) : OptT CliM α := do
+@[inline] def throwMissingOptArg (arg : String) : OptT CliStateM α := do
   throw <| CliError.missingOptArg (← getOpt).copy arg
 
-instance : MonadThrowExpectedArg (OptT CliM) := ⟨throwMissingOptArg⟩
+instance : MonadThrowExpectedArg (OptT CliStateM) := ⟨throwMissingOptArg⟩
 
 /-! ## Argument Parsing -/
 
@@ -183,16 +183,16 @@ instance [Pure m] : MonadParseArg FilePath m :=
 
 @[inline] def parseOptArgUsing
   (descr : String) (f : String.Slice → Option α) (arg : String.Slice)
-: OptT CliM α := do
+: OptT CliStateM α := do
   if let some a := f arg then
     return a
   else
     throw <| CliError.invalidOptArg (← getOpt).copy descr
 
-instance : MonadParseArg Nat (OptT CliM) where
+instance : MonadParseArg Nat (OptT CliStateM) where
   parseArg := parseOptArgUsing "natural number" (·.toNat?)
 
-instance : MonadParseArg LogLevel (OptT CliM) where
+instance : MonadParseArg LogLevel (OptT CliStateM) where
   parseArg := parseOptArgUsing "log level" LogLevel.ofString?
 
 /--
@@ -209,7 +209,7 @@ def noArgsRem (act : CliStateM α) : CliM α := do
 def getWantsHelp : CliStateM Bool :=
   (·.wantsHelp) <$> get
 
-def setConfigOpt (kvPair : String.Slice) : CliM PUnit :=
+def setConfigOpt (kvPair : String.Slice) : CliStateM PUnit :=
   let pos := kvPair.find '='
   let (key, val) :=
     if h : pos.IsAtEnd then
@@ -237,7 +237,7 @@ where
   isValidRepoChar (c : Char) : Bool :=
     c.isAlphanum || c == '-' || c == '_' || c == '.' || c == '/'
 
-def lakeShortOption : ShortOptHandler CliM := .ofM do
+def lakeShortOption : ShortOptHandler CliStateM := .ofM do
   match (← getOptChar) with
   | 'q' => modifyThe LakeOptions ({· with verbosity := .quiet})
   | 'v' => modifyThe LakeOptions ({· with verbosity := .verbose})
@@ -260,11 +260,11 @@ def lakeShortOption : ShortOptHandler CliM := .ofM do
   | 'J' => modifyThe LakeOptions ({· with outFormat := .json})
   | opt => throw <| CliError.unknownShortOption opt
 
-def flushLinterOptions : CliM PUnit := do
+def flushLinterOptions : CliStateM PUnit := do
   modifyThe LakeOptions fun opts =>
     { opts with builtinLint.linterOverrides := #[] }
 
-def modifyLintOnlyFlag (b : Bool) : CliM PUnit := do
+def modifyLintOnlyFlag (b : Bool) : CliStateM PUnit := do
   modifyThe LakeOptions fun opts =>
     { opts with builtinLint := {opts.builtinLint with lintOnly := b} }
 
@@ -273,7 +273,7 @@ Parses a comma-separated list of Boolean-valued `Lean.Option` names.
 If the name is prefixed with `-`, this means that option will be set to `false`.
 Otherwise, it will be `true`.
 -/
-def parseLintersSpec (spec : String) : CliM PUnit := do
+def parseLintersSpec (spec : String) : CliStateM PUnit := do
   let mut entries : Array (Lean.Name × Bool) := #[]
   for raw in spec.split (· == ',') do
     let mut s := raw.trimAscii
@@ -289,7 +289,7 @@ def parseLintersSpec (spec : String) : CliM PUnit := do
     { opts with runBuiltinLint := true, builtinLint.linterOverrides :=
         opts.builtinLint.linterOverrides ++ entries }
 
-def lakeLongOption : LongOptHandler CliM := .ofM do
+def lakeLongOption : LongOptHandler CliStateM := .ofM do
   match (← getOpt).copy with
   | "--quiet"       => modifyThe LakeOptions ({· with verbosity := .quiet})
   | "--verbose"     => modifyThe LakeOptions ({· with verbosity := .verbose})
@@ -400,18 +400,20 @@ def lakeLongOption : LongOptHandler CliM := .ofM do
       {opts with shake.onlyMods := opts.shake.onlyMods.push mod.toName}
   | opt             =>  throw <| CliError.unknownLongOption opt
 
-def lakeOption : OptHandler CliM :=
+def lakeOption : OptHandler CliStateM :=
   option {
     short := lakeShortOption
     long := lakeLongOption
     longShort := shortOptionWithArg lakeShortOption
   }
 
-def processLakeOptions : CliM PUnit :=
-  processOptions lakeOption -- specializes `processOptions`
+def processLakeOptions : CliM PUnit := fun args => do
+  let args ← collectArgs args lakeOption -- specializes `collectArgs`
+  return (⟨⟩, args.toList)
 
-def processLeadingLakeOptions : CliM PUnit :=
-  processLeadingOptions lakeOption -- specializes `processLeadingOptions`
+def processLeadingLakeOptions : CliM PUnit := fun args => do
+  let args ← processLeadingOptions args lakeOption -- specializes `processLeadingOptions`
+  return (⟨⟩, args)
 
 /-! ## Actions -/
 

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -173,19 +173,19 @@ def takeArg (arg : String) : CliM String := do
   | none => throw <| CliError.missingArg arg
   | some arg => pure arg
 
-def takeOptArg (optArg? : Option String.Slice) (opt argName : String) : CliM String := do
-  if let some arg := optArg? then
-    return arg.copy
-  else if let some arg ← takeArg? then
+@[inline] def takeOptArg (argName : String) : OptT CliM String.Slice := do
+  if let some arg ← takeOptArg? then
     return arg
   else
-    throw <| CliError.missingOptArg opt argName
+    throw <| CliError.missingOptArg (← getOpt).copy argName
 
 @[inline] def takeOptArg'
-  (optArg? : Option String.Slice) (opt arg : String) (f : String → Option α)
-: CliM α := do
-  if let some a := f (← takeOptArg optArg? opt arg) then return a
-  throw <| CliError.invalidOptArg opt arg
+  (argName : String) (f : String.Slice → Option α) (argTy := argName)
+: OptT CliM α := do
+  if let some a := f (← takeOptArg argName) then
+    return a
+  else
+    throw <| CliError.invalidOptArg (← getOpt).copy argTy
 
 /--
 Verify that there are no CLI arguments remaining
@@ -201,24 +201,30 @@ def noArgsRem (act : CliStateM α) : CliM α := do
 def getWantsHelp : CliStateM Bool :=
   (·.wantsHelp) <$> get
 
-def setConfigOpt (kvPair : String) : CliM PUnit :=
+def setConfigOpt (kvPair : String.Slice) : CliM PUnit :=
   let pos := kvPair.find '='
   let (key, val) :=
     if h : pos.IsAtEnd then
       (kvPair.toName, "")
     else
-      (kvPair.extract kvPair.startPos pos |>.toName, kvPair.extract (pos.next h) kvPair.endPos)
+      (kvPair.sliceTo pos |>.toName, kvPair.sliceFrom (pos.next h) |>.copy)
   modifyThe LakeOptions fun opts =>
     {opts with configOpts := opts.configOpts.insert key val}
 
-def lakeShortOption : ShortOptHandler CliM := .ofFn fun opt optArg? =>
-  match opt with
+def lakeShortOption : ShortOptHandler CliM := .ofM do
+  match (← getOptChar) with
   | 'q' => modifyThe LakeOptions ({· with verbosity := .quiet})
   | 'v' => modifyThe LakeOptions ({· with verbosity := .verbose})
-  | 'd' => do let rootDir ← takeOptArg optArg? "-d" "path"; modifyThe LakeOptions ({· with rootDir})
-  | 'f' => do let configFile ← takeOptArg optArg? "-f" "path"; modifyThe LakeOptions ({· with configFile})
-  | 'o' => do let outputsFile? ← takeOptArg optArg? "-o" "path"; modifyThe LakeOptions ({· with outputsFile?})
-  | 'K' => do setConfigOpt <| ← takeOptArg optArg? "-K" "key-value pair"
+  | 'd' => do
+    let rootDir ← takeOptArg "path"
+    modifyThe LakeOptions ({· with rootDir := FilePath.mk rootDir.copy})
+  | 'f' => do
+    let configFile ← takeOptArg "path"
+    modifyThe LakeOptions ({· with configFile := FilePath.mk configFile.copy})
+  | 'o' => do
+    let outputsFile ← takeOptArg "path"
+    modifyThe LakeOptions ({· with outputsFile? := some <| FilePath.mk outputsFile.copy})
+  | 'K' => do setConfigOpt (← takeOptArg "key-value pair")
   | 'U' => do
     logWarning "the '-U' shorthand for '--update' is deprecated"
     modifyThe LakeOptions ({· with updateDeps := true})
@@ -230,7 +236,7 @@ def lakeShortOption : ShortOptHandler CliM := .ofFn fun opt optArg? =>
 
 /-- Returns an error if the string is not valid GitHub repository name. -/
 -- Limitations derived from https://github.com/dead-claudia/github-limits
-def validateRepo? (repo : String) : Option String := Id.run do
+def validateRepo? (repo : String.Slice) : Option String := Id.run do
   unless repo.all isValidRepoChar do
     return "invalid characters in repository name"
   match repo.split '/' |>.toStringList with
@@ -275,8 +281,8 @@ def parseLintersSpec (spec : String) : CliM PUnit := do
     { opts with runBuiltinLint := true, builtinLint.linterOverrides :=
         opts.builtinLint.linterOverrides ++ entries }
 
-def lakeLongOption : LongOptHandler CliM := .ofFn fun opt optArg? =>
-  match opt with
+def lakeLongOption : LongOptHandler CliM := .ofM do
+  match (← getOpt).copy with
   | "--quiet"       => modifyThe LakeOptions ({· with verbosity := .quiet})
   | "--verbose"     => modifyThe LakeOptions ({· with verbosity := .verbose})
   | "--update"      => modifyThe LakeOptions ({· with updateDeps := true})
@@ -299,52 +305,52 @@ def lakeLongOption : LongOptHandler CliM := .ofFn fun opt optArg? =>
   | "--download-arts" => modifyThe LakeOptions ({· with mappingsOnly := false})
   | "--mappings-only" => modifyThe LakeOptions ({· with mappingsOnly := true})
   | "--service" => do
-    let service ← takeOptArg optArg? "--service" "service name"
-    modifyThe LakeOptions ({· with service? := some service})
+    let service ← takeOptArg "service name"
+    modifyThe LakeOptions ({· with service? := some service.copy})
   | "--scope" => do
-    let scope ← takeOptArg optArg? "--scope" "cache scope"
-    modifyThe LakeOptions ({· with scope? := some (.ofString scope)})
+    let scope ← takeOptArg "cache scope"
+    modifyThe LakeOptions ({· with scope? := some (.ofString scope.copy)})
   | "--repo" => do
-    let repo ← takeOptArg optArg? "--repo" "GitHub repository"
+    let repo ← takeOptArg "GitHub repository"
     if let some e := validateRepo? repo then error e
-    modifyThe LakeOptions ({· with scope? := some (.ofRepo repo)})
+    modifyThe LakeOptions ({· with scope? := some (.ofRepo repo.copy)})
   | "--platform" => do
-    let platform ← takeOptArg optArg? "--platform" "cache platform"
+    let platform ← takeOptArg "cache platform"
+    let platform := platform.copy
     if platform.chars.length > 100 then
       error "invalid platform; platform is expected to be at most 100 characters long"
     modifyThe LakeOptions ({· with platform? := some <| .ofString platform})
   | "--toolchain" => do
-    let toolchain ← takeOptArg optArg? "--toolchain" "cache toolchain"
-    let toolchain := if toolchain.isEmpty then .none else .ofString toolchain
+    let toolchain ← takeOptArg "cache toolchain"
+    let toolchain := if toolchain.isEmpty then .none else .ofString toolchain.copy
     if toolchain.length > 256 then
       error "invalid toolchain version; toolchain is expected to be at most 256 characters long"
     modifyThe LakeOptions ({· with toolchain? := some toolchain})
   | "--rev" => do
-    let rev ← takeOptArg optArg? "--rev" "Git revision"
-    modifyThe LakeOptions ({· with rev? := some rev})
+    let rev ← takeOptArg "Git revision"
+    modifyThe LakeOptions ({· with rev? := some rev.copy})
   | "--max-revs" => do
-    let some n ← (·.toNat?) <$> takeOptArg optArg? "--max-revs" "number of revisions"
-      | throw <| CliError.invalidOptArg "--max-revs" "natural number"
-    modifyThe LakeOptions ({· with maxRevs := n})
+    let maxRevs ← takeOptArg' "number of revisions" (·.toNat?) "natural number"
+    modifyThe LakeOptions ({· with maxRevs})
   | "--log-level"   => do
-    let outLv ← takeOptArg' optArg? "--log-level" "log level" LogLevel.ofString?
+    let outLv ← takeOptArg' "log level" LogLevel.ofString?
     modifyThe LakeOptions ({· with outLv? := outLv})
   | "--fail-level"  => do
-    let failLv ← takeOptArg' optArg? "--fail-level" "log level" LogLevel.ofString?
+    let failLv ← takeOptArg' "log level" LogLevel.ofString?
     modifyThe LakeOptions ({· with failLv})
   | "--ansi"        => modifyThe LakeOptions ({· with ansiMode := .ansi})
   | "--no-ansi"     => modifyThe LakeOptions ({· with ansiMode := .noAnsi})
   | "--packages"    => do
-    let file ← takeOptArg optArg? "--packages" "package overrides file"
-    let overrides ← Manifest.loadEntries file
+    let file ← takeOptArg "package overrides file"
+    let overrides ← Manifest.loadEntries (FilePath.mk file.copy)
     modifyThe LakeOptions fun opts =>
       {opts with packageOverrides := opts.packageOverrides ++ overrides}
   | "--dir"         => do
-    let rootDir ← takeOptArg optArg? "--dir" "path"
-    modifyThe LakeOptions ({· with rootDir})
+    let rootDir ← takeOptArg "path"
+    modifyThe LakeOptions ({· with rootDir := FilePath.mk rootDir.copy})
   | "--file"        => do
-    let configFile ← takeOptArg optArg? "--file" "path"
-    modifyThe LakeOptions ({· with configFile})
+    let configFile ← takeOptArg "path"
+    modifyThe LakeOptions ({· with configFile := FilePath.mk configFile.copy})
   | "--help"        => modifyThe LakeOptions ({· with wantsHelp := true})
   | "--"            => do
     let subArgs ← takeArgs
@@ -359,15 +365,15 @@ def lakeLongOption : LongOptHandler CliM := .ofFn fun opt optArg? =>
     if opts.builtinLint.lintOnly then
       flushLinterOptions
       modifyLintOnlyFlag false
-    let spec ← takeOptArg optArg? "--linters" "comma-separated linter spec"
-    parseLintersSpec spec
+    let spec ← takeOptArg "comma-separated linter spec"
+    parseLintersSpec spec.copy
   | "--lint-only" => do
     let opts ← getThe LakeOptions
     if !opts.builtinLint.lintOnly then
       flushLinterOptions
       modifyLintOnlyFlag true
-    let spec ← takeOptArg optArg? "--lint-only" "comma-separated linter spec"
-    parseLintersSpec spec
+    let spec ← takeOptArg "comma-separated linter spec"
+    parseLintersSpec spec.copy
 
   -- Shared options
   | "--force" => modifyThe LakeOptions ({· with shake.force := true})
@@ -381,10 +387,10 @@ def lakeLongOption : LongOptHandler CliM := .ofFn fun opt optArg? =>
   | "--trace" => modifyThe LakeOptions ({· with shake.trace := true})
   | "--fix" => modifyThe LakeOptions ({· with shake.fix := true})
   | "--only" => do
-    let mod ← takeOptArg optArg? "--only" "minimize only this module"
+    let mod ← takeOptArg "minimize only this module"
     modifyThe LakeOptions fun opts =>
       {opts with shake.onlyMods := opts.shake.onlyMods.push mod.toName}
-  | opt             =>  throw <| CliError.unknownLongOption opt.copy
+  | opt             =>  throw <| CliError.unknownLongOption opt
 
 def lakeOption : OptHandler CliM :=
   option {

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -148,13 +148,17 @@ export LakeOptions (mkLoadConfig mkBuildConfig)
 
 abbrev CliMainM := ExceptT CliError MainM
 abbrev CliStateM := StateT LakeOptions CliMainM
-abbrev CliM := StateT ArgList CliStateM
+abbrev CliM := ArgsT CliStateM
 
-def CliM.run (self : CliM α) (args : List String) : BaseIO ExitCode := do
+@[inline] def CliMainM.run (self : CliMainM α) : BaseIO ExitCode := do
+  MainM.run <| (ExceptT.run self) >>= fun | .ok a => pure a | .error e => error e.toString
+
+@[inline] def CliStateM.run (self : CliStateM α) (args : List String) : BaseIO ExitCode := do
   let (elanInstall?, leanInstall?, lakeInstall?) ← findInstall?
-  let main := self.run' args |>.run' {args, elanInstall?, leanInstall?, lakeInstall?}
-  let main := main.run >>= fun | .ok a => pure a | .error e => error e.toString
-  main.run
+  StateT.run' self {args, elanInstall?, leanInstall?, lakeInstall?} |>.run
+
+@[inline] def CliM.run (self : CliM α) (args : List String) : BaseIO ExitCode := do
+  StateT.run' self args |>.run args
 
 def CliStateM.runLogIO (x : LogIO α) : CliStateM α := do
   MainM.runLogIO x (← get).toLogConfig
@@ -165,6 +169,11 @@ def CliStateM.runLoggerIO (x : LoggerIO α) : CliStateM α := do
   MainM.runLoggerIO x (← get).toLogConfig
 
 instance (priority := low) : MonadLift LoggerIO CliStateM := ⟨CliStateM.runLoggerIO⟩
+
+def CliStateM.runIO (x : IO α) : CliStateM α := do
+  MainM.runLogIO x (← get).toLogConfig
+
+instance (priority := low) : MonadLift IO CliStateM := ⟨CliStateM.runIO⟩
 
 @[inline] def throwMissingArg (arg : String) : CliM α := do
   throw <| CliError.missingArg arg
@@ -206,7 +215,7 @@ def noArgsRem (act : CliStateM α) : CliM α := do
 
 /-! ## Option Parsing -/
 
-def getWantsHelp : CliStateM Bool :=
+@[inline] def getWantsHelp : CliStateM Bool :=
   (·.wantsHelp) <$> get
 
 def setConfigOpt (kvPair : String.Slice) : CliStateM PUnit :=
@@ -414,6 +423,10 @@ def processLakeOptions : CliM PUnit := fun args => do
 def processLeadingLakeOptions : CliM PUnit := fun args => do
   let args ← processLeadingOptions args lakeOption -- specializes `processLeadingOptions`
   return (⟨⟩, args)
+
+theorem run_processLeadingLakeOptions {as} :
+  StateT.run processLeadingLakeOptions as = (⟨(), ·⟩) <$> processLeadingOptions as lakeOption
+:= by rfl
 
 /-! ## Actions -/
 
@@ -1325,19 +1338,49 @@ def lake : CliM PUnit := do
   match (← getArgs) with
   | [] => IO.println usage
   | ["--version"] => IO.println uiVersionString
-  | _ => -- normal CLI
-    processLeadingLakeOptions -- between `lake` and command
-    if let some cmd ← takeArg? then
-      processLeadingLakeOptions -- between `lake <cmd>` and args
-      if (← getWantsHelp) then
-        IO.println <| help cmd
-      else
-        lakeCli cmd
+  | _ => go -- normal CLI
+where @[inline] go := do
+  processLeadingLakeOptions -- between `lake` and command
+  if let some cmd ← takeArg? then
+    processLeadingLakeOptions -- between `lake <cmd>` and args
+    if (← getWantsHelp) then
+      IO.println <| help cmd
     else
-      if (← getWantsHelp) then
-        IO.println usage
-      else
-        throw <| CliError.missingCommand
+      lakeCli cmd
+  else
+    if (← getWantsHelp) then
+      IO.println usage
+    else
+      throw <| CliError.missingCommand
 
 public def cli (args : List String) : BaseIO ExitCode :=
-  inline <| (lake).run args
+  (lake).run args
+
+/- CLI sanity check -/
+
+set_option backward.isDefEq.respectTransparency false in
+theorem run_lake_cons_of_ne_version (h : a ≠ "--version") :
+  StateT.run lake (a :: as) = StateT.run lake.go (a :: as)
+:= by
+  simp only [lake, StateT.run_bind, ArgsT.run_getArgs, pure_bind]
+  split
+  · contradiction
+  · next h_eq => simp [h] at h_eq
+  · rfl
+
+set_option backward.isDefEq.respectTransparency false in
+theorem cli_of_isArg (h : IsArg cmd) :
+  cli [cmd] = (StateT.run' (lakeCli cmd) []).run [cmd]
+:= by
+  have ne_version : cmd ≠ "--version" := h.ne_of_isOpt (by decide)
+  simp only [cli, CliM.run, CliStateM.run, StateT.run'_eq]
+  simp only [run_lake_cons_of_ne_version ne_version, lake.go, getWantsHelp]
+  simp [processLeadingOptions_cons_of_isArg h, run_processLeadingLakeOptions, parseArg]
+
+set_option backward.isDefEq.respectTransparency false in
+theorem cli_help :
+  cli ["help"] = (CliStateM.runIO <| IO.println usage).run ["help"]
+:= by
+  have isArg_help : IsArg "help" := by decide
+  have lakeCli_help : lakeCli "help" = lake.help := by rfl
+  simp [cli_of_isArg isArg_help, lakeCli_help, lake.help, monadLift, MonadLift.monadLift]

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -166,35 +166,43 @@ def CliStateM.runLoggerIO (x : LoggerIO α) : CliStateM α := do
 
 instance (priority := low) : MonadLift LoggerIO CliStateM := ⟨CliStateM.runLoggerIO⟩
 
+@[inline] def throwMissingArg (arg : String) : CliM α := do
+  throw <| CliError.missingArg arg
+
+instance : MonadThrowExpectedArg CliM := ⟨throwMissingArg⟩
+
+@[inline] def throwMissingOptArg (arg : String) : OptT CliM α := do
+  throw <| CliError.missingOptArg (← getOpt).copy arg
+
+instance : MonadThrowExpectedArg (OptT CliM) := ⟨throwMissingOptArg⟩
+
 /-! ## Argument Parsing -/
 
-def takeArg (arg : String) : CliM String := do
-  match (← takeArg?) with
-  | none => throw <| CliError.missingArg arg
-  | some arg => pure arg
+instance [Pure m] : MonadParseArg FilePath m :=
+  ⟨(pure <| FilePath.mk ·.copy)⟩
 
-@[inline] def takeOptArg (argName : String) : OptT CliM String.Slice := do
-  if let some arg ← takeOptArg? then
-    return arg
-  else
-    throw <| CliError.missingOptArg (← getOpt).copy argName
-
-@[inline] def takeOptArg'
-  (argName : String) (f : String.Slice → Option α) (argTy := argName)
+@[inline] def parseOptArgUsing
+  (descr : String) (f : String.Slice → Option α) (arg : String.Slice)
 : OptT CliM α := do
-  if let some a := f (← takeOptArg argName) then
+  if let some a := f arg then
     return a
   else
-    throw <| CliError.invalidOptArg (← getOpt).copy argTy
+    throw <| CliError.invalidOptArg (← getOpt).copy descr
+
+instance : MonadParseArg Nat (OptT CliM) where
+  parseArg := parseOptArgUsing "natural number" (·.toNat?)
+
+instance : MonadParseArg LogLevel (OptT CliM) where
+  parseArg := parseOptArgUsing "log level" LogLevel.ofString?
 
 /--
 Verify that there are no CLI arguments remaining
 before running the given action.
 -/
 def noArgsRem (act : CliStateM α) : CliM α := do
-  let args ← getArgs
-  if args.isEmpty then act else
-    throw <| CliError.unexpectedArguments args
+  match (← getArgs) with
+  | [] => act
+  | args => throw <| CliError.unexpectedArguments args
 
 /-! ## Option Parsing -/
 
@@ -211,19 +219,37 @@ def setConfigOpt (kvPair : String.Slice) : CliM PUnit :=
   modifyThe LakeOptions fun opts =>
     {opts with configOpts := opts.configOpts.insert key val}
 
+/-- Returns an error if the string is not valid GitHub repository name. -/
+-- Limitations derived from https://github.com/dead-claudia/github-limits
+def validateRepo? (repo : String.Slice) : Option String := Id.run do
+  unless repo.all isValidRepoChar do
+    return "invalid characters in repository name"
+  if let [owner, name] := repo.split '/' |>.toList then
+    if owner.chars.length > 39 then
+      return "invalid repository name; owner must be at most 39 characters long"
+    if name.chars.length > 100 then
+      return "invalid repository name; name must be at most 100 characters long"
+  else
+    return "invalid repository name; must contain exactly one '/'"
+  return none
+where
+  /-- Returns whether `c` is a valid character in GitHub repository name -/
+  isValidRepoChar (c : Char) : Bool :=
+    c.isAlphanum || c == '-' || c == '_' || c == '.' || c == '/'
+
 def lakeShortOption : ShortOptHandler CliM := .ofM do
   match (← getOptChar) with
   | 'q' => modifyThe LakeOptions ({· with verbosity := .quiet})
   | 'v' => modifyThe LakeOptions ({· with verbosity := .verbose})
   | 'd' => do
     let rootDir ← takeOptArg "path"
-    modifyThe LakeOptions ({· with rootDir := FilePath.mk rootDir.copy})
+    modifyThe LakeOptions ({· with rootDir})
   | 'f' => do
     let configFile ← takeOptArg "path"
-    modifyThe LakeOptions ({· with configFile := FilePath.mk configFile.copy})
+    modifyThe LakeOptions ({· with configFile})
   | 'o' => do
     let outputsFile ← takeOptArg "path"
-    modifyThe LakeOptions ({· with outputsFile? := some <| FilePath.mk outputsFile.copy})
+    modifyThe LakeOptions ({· with outputsFile? := some outputsFile})
   | 'K' => do setConfigOpt (← takeOptArg "key-value pair")
   | 'U' => do
     logWarning "the '-U' shorthand for '--update' is deprecated"
@@ -233,24 +259,6 @@ def lakeShortOption : ShortOptHandler CliM := .ofM do
   | 'H' => modifyThe LakeOptions ({· with trustHash := false})
   | 'J' => modifyThe LakeOptions ({· with outFormat := .json})
   | opt => throw <| CliError.unknownShortOption opt
-
-/-- Returns an error if the string is not valid GitHub repository name. -/
--- Limitations derived from https://github.com/dead-claudia/github-limits
-def validateRepo? (repo : String.Slice) : Option String := Id.run do
-  unless repo.all isValidRepoChar do
-    return "invalid characters in repository name"
-  match repo.split '/' |>.toStringList with
-  | [owner, name] =>
-    if owner.lengthAssumingAscii > 39 then
-      return "invalid repository name; owner must be at most 390 characters long"
-    if name.lengthAssumingAscii > 100 then
-      return "invalid repository name; owner must be at most 100 characters long"
-  | _ => return "invalid repository name; must contain exactly one '/'"
-  return none
-where
-  /-- Returns whether `c` is a valid character in GitHub repository name -/
-  isValidRepoChar (c : Char) : Bool :=
-    c.isAlphanum || c == '-' || c == '_' || c == '.' || c == '/'
 
 def flushLinterOptions : CliM PUnit := do
   modifyThe LakeOptions fun opts =>
@@ -330,13 +338,13 @@ def lakeLongOption : LongOptHandler CliM := .ofM do
     let rev ← takeOptArg "Git revision"
     modifyThe LakeOptions ({· with rev? := some rev.copy})
   | "--max-revs" => do
-    let maxRevs ← takeOptArg' "number of revisions" (·.toNat?) "natural number"
+    let maxRevs ← takeOptArg "number of revisions"
     modifyThe LakeOptions ({· with maxRevs})
   | "--log-level"   => do
-    let outLv ← takeOptArg' "log level" LogLevel.ofString?
-    modifyThe LakeOptions ({· with outLv? := outLv})
+    let outLv ← takeOptArg "log level"
+    modifyThe LakeOptions ({· with outLv? := some outLv})
   | "--fail-level"  => do
-    let failLv ← takeOptArg' "log level" LogLevel.ofString?
+    let failLv ← takeOptArg "log level"
     modifyThe LakeOptions ({· with failLv})
   | "--ansi"        => modifyThe LakeOptions ({· with ansiMode := .ansi})
   | "--no-ansi"     => modifyThe LakeOptions ({· with ansiMode := .noAnsi})
@@ -484,7 +492,7 @@ def endpointDeprecation : String :=
 protected def get : CliM PUnit := do
   processLakeOptions
   let opts ← getThe LakeOptions
-  let mappings? ← takeArg?
+  let mappings? : Option FilePath ← takeArg?
   noArgsRem do
   let cfg ← mkLoadConfig opts
   let ws ← loadWorkspace cfg
@@ -686,7 +694,7 @@ protected def put : CliM PUnit := do
 
 protected def add : CliM PUnit := do
   processLakeOptions
-  let file ← takeArg "mappings"
+  let file : FilePath ← takeArg "mappings"
   let pkg? ← takeArg?
   let opts ← getThe LakeOptions
   noArgsRem do

--- a/src/lake/Lake/Util/Cli.lean
+++ b/src/lake/Lake/Util/Cli.lean
@@ -53,25 +53,85 @@ public def ArgHandler (m : Type u → Type v) (α : Type u := PUnit) :=
 
 /-! ## Monadic Argument Utilities -/
 
-/-- Get the remaining argument list. -/
+/-- Gets the remaining argument list. -/
 @[inline] public def getArgs [MonadArgs m] : m (List String) :=
   get
 
-/-- Replace the argument list. -/
+/-- Replaces the argument list. -/
 @[inline] public def setArgs [MonadArgs m] (args : List String) : m PUnit :=
   set (σ := ArgList) args
 
-/-- Take the head of the remaining argument list (or {lean}`none` if empty). -/
-@[inline] public def takeArg? [MonadArgs m] : m (Option String) :=
+/-- Removes and returns the head of the remaining argument list (or {lean}`none` if empty). -/
+@[inline] def takeRawArg? [MonadArgs m] : m (Option String) :=
   modifyGet fun | [] => (none, []) | arg :: args => (some arg, args)
 
-/-- Take the head of the remaining argument list (or {lean}`default` if empty). -/
-@[inline] public def takeArgD [MonadArgs m] (default : String) : m String :=
+/-- Removes and returns  the head of the remaining argument list (or {lean}`default` if empty). -/
+@[inline] def takeRawArgD [MonadArgs m] (default : String) : m String :=
   modifyGet fun | [] => (default, []) | arg :: args => (arg, args)
 
-/-- Take the remaining argument list, leaving only an empty list. -/
+/-- Removes and returns  the remaining argument list, leaving only an empty list. -/
 @[inline] public def takeArgs [MonadArgs m] : m (List String) :=
   modifyGet fun args => (args, [])
+
+/-! ## Monadic Argument Parsing Utilities -/
+
+/-- Type class for parsing command line arguments. -/
+public class MonadParseArg (α : Type u) (m : Type u → Type v) where
+  /-- Parse a command line argument {lean}`arg` into the type {lean}`α`. -/
+  parseArg (arg : String.Slice) : m α
+
+export MonadParseArg (parseArg)
+
+public instance [MonadLift m n] [MonadParseArg α  m] : MonadParseArg α n where
+  parseArg arg := liftM (m := m) <| parseArg arg
+
+public instance [Pure m] : MonadParseArg String m := ⟨(pure ·.copy)⟩
+@[default_instance] public instance [Pure m] : MonadParseArg String.Slice m := ⟨(pure ·)⟩
+
+/-- Type class for indicating a missing argument. -/
+public class MonadThrowExpectedArg  (m : Type u → Type v) where
+  /-- Throw an error indicating a missing argument described by {lean}`descr`. -/
+  throwExpectedArg {α} (descr : String) : m α
+
+export MonadThrowExpectedArg (throwExpectedArg)
+
+public instance [MonadLift m n] [MonadThrowExpectedArg m] : MonadThrowExpectedArg n where
+  throwExpectedArg descr := liftM (m := m) <| throwExpectedArg descr
+
+/--
+Removes and returns the head of the remaining argument list, parsing the argument into {lean}`α`.
+
+If no argument is available, returns {lean}`none`.
+-/
+@[inline] public def takeArg?
+  [Monad m] [MonadArgs m] [MonadParseArg α m]
+: m (Option α) := do
+  if let some arg ← takeRawArg? then
+    return some (← parseArg arg)
+  else
+    return none
+
+/--
+Removes and returns the head of the remaining argument list, parsing the argument into {lean}`α`.
+
+If no argument is available, returns {lean}`default`.
+-/
+@[inline] public def takeArgD
+  [Monad m] [MonadArgs m] [MonadParseArg α m] (default : α)
+: m α := return (← takeArg?).getD default
+
+/--
+Removes and returns the head of the remaining argument list, parsing the argument into {lean}`α`.
+
+If no argument is available,, errors using {name}`throwExpectedArg` with {lean}`descr`.
+-/
+@[inline] public def takeArg
+  [Monad m] [MonadArgs m] [MonadParseArg α m] [MonadThrowExpectedArg m] (descr : String)
+: m α := do
+  if let some arg ← takeArg? then
+    parseArg arg
+  else
+    throwExpectedArg descr
 
 /-! ## Option-related Types -/
 
@@ -205,17 +265,27 @@ Get the character of the command line short option of the current context
   read
 
 /-- Get the option argument (if any). -/
-@[inline] public def getOptArg? [MonadOptArg m] : m (Option String.Slice) :=
+@[inline] def getOptArg? [MonadOptArg m] : m (Option String.Slice) :=
   read
 
-/-- Take the option argument or, if {lean}`none`, the head of the remaining argument list. -/
-@[inline] public def takeOptArg? [Monad m] [MonadOptArg m] [MonadArgs m] : m (Option String.Slice) := do
+/--
+Returns the option argument or, if {lean}`none`, removes and returns
+the head of the remaining argument list.
+
+Parses the argument into {lean}`α`.
+If no argument is available, errors using {name}`throwExpectedArg` with {lean}`descr`.
+-/
+@[inline] public def takeOptArg
+  [Monad m] [MonadOptArg m] [MonadArgs m]
+  [MonadParseArg α m] [MonadThrowExpectedArg m]
+  (descr : String)
+: m α := do
   if let some arg ← getOptArg? then
-    return some arg
+    parseArg arg
   else if let some arg ← takeArg? then
-    return some arg
+    parseArg arg
   else
-    return none
+    throwExpectedArg descr
 
 /-! ## Option Handler Types -/
 
@@ -254,7 +324,7 @@ Construct an long option handler from a monadic action.
 
 The name of the option (e.g., {lit}`-long` or {lit}`--long`) is available via {name}`getOpt`.
 An argument for the option (e.g., {lit}`arg` in {lit}`--long=arg` or {lit}`--long arg`) can be
-accessed through {name}`takeOptArg?`.
+accessed through {name}`takeArg?`.
 -/
 @[inline] public def LongOptHandler.ofM (x : OptT m α) : LongOptHandler m α := x
 
@@ -290,7 +360,7 @@ The name of the option (e.g., {lit}`-x`) is available via {name}`getOpt`, and
 the character of the option (e.g., {lit}`x` in {lit}`-x`) is available via {name}`getOptChar`,
 
 An argument for the option (e.g., {lit}`arg` in {lit}`-x=arg` or {lit}`-x arg`) can be accessed
-through  {name}`takeOptArg?`.
+through  {name}`takeOptArg`.
 -/
 @[inline] public def ShortOptHandler.ofM (x : ShortOptT m α) : ShortOptHandler m α := x
 
@@ -456,7 +526,7 @@ public partial def processLeadingOptions (handler : OptHandler m) : m PUnit := d
   (optHandler : OptHandler m) (argHandler : ArgHandler m)
 : m PUnit :=
   let rec @[specialize optHandler argHandler] loop := do
-    if let some arg ← takeArg? then
+    if let some arg ← takeRawArg? then
       if h0 : arg.startPos.IsAtEnd then -- skip empty args
         loop
       else if h : arg.startPos.get h0 = '-' ∧ ¬ (arg.startPos.next h0).IsAtEnd then -- `-(.+)`
@@ -471,7 +541,7 @@ public partial def processLeadingOptions (handler : OptHandler m) : m PUnit := d
 @[specialize handler] public partial def collectArgs
   (handler : OptHandler m) (args : Array String := #[])
 : m (Array String) := do
-  if let some arg ← takeArg? then
+  if let some arg ← takeRawArg? then
     if h0 : arg.startPos.IsAtEnd then -- skip empty args
       collectArgs handler args
     else if h : arg.startPos.get h0 = '-' ∧ ¬ (arg.startPos.next h0).IsAtEnd then -- `-(.+)`

--- a/src/lake/Lake/Util/Cli.lean
+++ b/src/lake/Lake/Util/Cli.lean
@@ -12,6 +12,7 @@ import Init.Data.String.TakeDrop
 import Init.Data.String.Termination
 import Init.Data.ToString.Macro
 import Init.Omega
+import Init.Control.Lawful.Instances
 import all Init.SizeOf
 
 set_option doc.verso true
@@ -34,7 +35,7 @@ public def Arg := String
 public abbrev MonadArg (m) := MonadReaderOf Arg m
 
 /-- A List of command line arguments. -/
-@[expose] public def ArgList := List Arg
+@[expose] public def ArgList := List String
 
 public noncomputable instance : SizeOf ArgList := inferInstanceAs (SizeOf (List String))
 
@@ -59,6 +60,35 @@ public instance  [MonadStateOf ArgList m] : MonadArgs m where
   getArgs := get
   takeArg? := modifyGet fun | [] => (none, []) | arg :: args => (some arg, args)
   takeArgs := modifyGet fun args => (args, [])
+
+/-- A monad transformer to equip a monad with a command-line argument list. -/
+public abbrev ArgsT := StateT ArgList
+
+namespace ArgsT
+
+/--
+Executes an action in the underlying monad {lean}`m` with the added state of a command-line
+argument list. It returns the monadic value paired with the final argument list.
+-/
+public abbrev run (self : ArgsT m α) (args : List String) : m (α × List String) :=
+  StateT.run self args
+
+/--
+Executes an action in the underlying monad {lean}`m` with the added state of a command-line
+argument list. It returns the monadic value, discarding any remaining arguments list.
+-/
+public abbrev run' [Functor m] (self : ArgsT m α) (args : List String) : m α :=
+  StateT.run' self args
+
+@[simp] public theorem run_getArgs {as : List String} [Monad m]  :
+  StateT.run (σ := ArgList) (m := m) getArgs as = pure (as, as)
+:= by rfl
+
+@[simp] public theorem run_takeArgs {as : List String} [Monad m] :
+  StateT.run (σ := ArgList) (m := m) takeArgs as = pure (as, [])
+:= by rfl
+
+end ArgsT
 
 /--
 A monad transformer to equip a monad with a state that
@@ -130,9 +160,9 @@ public protected def get [@Std.Refl σ r] [Pure m] : MonoStateT σ r m σ :=
 end MonoStateT
 
 set_option linter.missingDocs false in
-public def ArgsT.Rel : ArgList → ArgList → Prop := (sizeOf · ≥ sizeOf ·)
+public def MonoArgsT.Rel : ArgList → ArgList → Prop := (sizeOf · ≥ sizeOf ·)
 
-namespace ArgsT.Rel
+namespace MonoArgsT.Rel
 
 public protected theorem refl (as : ArgList) : Rel as as :=
   Nat.le_refl _
@@ -144,25 +174,25 @@ public protected theorem trans : Rel a b → Rel b c → Rel a c :=
 
 public instance : Trans Rel Rel Rel := ⟨Rel.trans⟩
 
-end ArgsT.Rel
+end MonoArgsT.Rel
 
-/-- A monad transformer to equip a monad with a monotonically decreasing argument list. -/
-public abbrev ArgsT (m : Type → Type v) := MonoStateT ArgList ArgsT.Rel m
+/-- A monad transformer to equip a monad with a monotonically non-increasing argument list. -/
+public abbrev MonoArgsT (m : Type → Type v) := MonoStateT ArgList MonoArgsT.Rel m
 
 /--
-Monotonicity relation for {name (scope := "Lake.Util.CLI")}`ArgsT`.
-Ensures the size of the argument list is monotonically decreasing.
+Monotonicity relation for {name (scope := "Lake.Util.CLI")}`MonoArgsT`.
+Ensures the size of the argument list is monotonically non-increasing.
 -/
-add_decl_doc ArgsT.Rel
+add_decl_doc MonoArgsT.Rel
 
-namespace ArgsT
+namespace MonoArgsT
 
 @[inline, always_inline, inherit_doc MonadArgs.getArgs]
-public protected def get [Pure m] : ArgsT m (List String) :=
+public protected def get [Pure m] : MonoArgsT m (List String) :=
   MonoStateT.get
 
 @[inline, always_inline, inherit_doc MonadArgs.takeArg?]
-public protected def takeArg? [Monad m] : ArgsT m (Option String) :=
+public protected def takeArg? [Monad m] : MonoArgsT m (Option String) :=
   MonoStateT.modifyGet fun
     | [] => (none, ⟨[], Nat.le_refl _⟩)
     | arg :: args => (some arg, ⟨args, mono_cons⟩)
@@ -170,7 +200,7 @@ where
   mono_cons {a} {as : List String} : sizeOf as ≤ sizeOf (a :: as) := by simp
 
 @[inline, always_inline, inherit_doc MonadArgs.takeArgs]
-public protected def takeArgs [Monad m] : ArgsT m (List String) :=
+public protected def takeArgs [Monad m] : MonoArgsT m (List String) :=
    MonoStateT.modifyGet fun args => (args, ⟨[], mono_nil⟩)
 where
   mono_nil {as : List String} : sizeOf ([] : List String) ≤ sizeOf as := by
@@ -179,12 +209,12 @@ where
     · simp only [List.nil.sizeOf_spec, List.cons.sizeOf_spec]
       omega
 
-public instance [Monad m] : MonadArgs (ArgsT m) where
-  getArgs := ArgsT.get
-  takeArg? := ArgsT.takeArg?
-  takeArgs :=  ArgsT.takeArgs
+public instance [Monad m] : MonadArgs (MonoArgsT m) where
+  getArgs := MonoArgsT.get
+  takeArg? := MonoArgsT.takeArg?
+  takeArgs :=  MonoArgsT.takeArgs
 
-end ArgsT
+end MonoArgsT
 
 /-! ## Monadic Argument Parsing Utilities -/
 
@@ -224,6 +254,19 @@ If no argument is available, returns {lean}`none`.
   else
     return none
 
+set_option backward.isDefEq.respectTransparency false in
+@[simp] public theorem ArgsT.run_takeArg?_nil
+  [Monad m] [LawfulMonad m] {_ : MonadParseArg α (ArgsT m)} :
+  StateT.run (σ := ArgList) (m := m) takeArg? [] = pure ((none : Option α), [])
+:= by simp [takeArg?, MonadArgs.takeArg?]
+
+set_option backward.isDefEq.respectTransparency false in
+@[simp] public theorem ArgsT.run_takeArg?_cons
+  [Monad m] [LawfulMonad m] [MonadParseArg α (ArgsT m)] :
+  StateT.run (σ := ArgList) (m := m) (α := Option α) takeArg? (a :: as) =
+  StateT.run (σ := ArgList) (some <$> parseArg a) as
+:= by simp [takeArg?, MonadArgs.takeArg?]
+
 /--
 Removes and returns the head of the remaining argument list, parsing the argument into {lean}`α`.
 
@@ -233,6 +276,11 @@ If no argument is available, returns {lean}`default`.
   [Monad m] [MonadArgs m] [MonadParseArg α m] (default : α)
 : m α := return (← takeArg?).getD default
 
+@[simp] public theorem takeArgD_eq_getD_takeArg?
+  [Monad m] [LawfulMonad m] [MonadArgs m] [MonadParseArg α m] :
+  takeArgD (α := α) (m := m) d = (·.getD d) <$> takeArg?
+:= by simp [takeArgD]
+
 /--
 Removes and returns the head of the remaining argument list, parsing the argument into {lean}`α`.
 
@@ -241,10 +289,24 @@ If no argument is available,, errors using {name}`throwExpectedArg` with {lean}`
 @[inline] public def takeArg
   [Monad m] [MonadArgs m] [MonadParseArg α m] [MonadThrowExpectedArg m] (descr : String)
 : m α := do
-  if let some arg ← takeArg? then
+  if let some arg ← MonadArgs.takeArg? then
     parseArg arg
   else
     throwExpectedArg descr
+
+set_option backward.isDefEq.respectTransparency false in
+@[simp] public theorem ArgsT.run_takeArg_nil
+  [Monad m] [LawfulMonad m] [MonadParseArg α (ArgsT m)] [MonadThrowExpectedArg m] :
+  StateT.run (σ := ArgList) (m := m) (α := α) (takeArg d) [] =
+  ((·, [])) <$> throwExpectedArg (m := m) d
+:= by simp [takeArg, MonadArgs.takeArg?, throwExpectedArg]
+
+set_option backward.isDefEq.respectTransparency false in
+@[simp] public theorem ArgsT.run_takeArg_cons
+  [Monad m] [LawfulMonad m] [MonadParseArg α (ArgsT m)] {_ : MonadThrowExpectedArg m} :
+  StateT.run (σ := ArgList) (m := m) (α := α) (takeArg d) (a :: as) =
+  StateT.run (σ := ArgList) (parseArg a) as
+:= by simp [takeArg, MonadArgs.takeArg?]
 
 /-! ## Argument Handler Type -/
 
@@ -258,7 +320,7 @@ public def ArgHandler (m : Type → Type v) :=
   read
 
 /-- A monad transformer to equip a monad with a command line argument. -/
-public abbrev ArgT (m) := ReaderT Arg <| ArgsT m
+public abbrev ArgT (m) := ReaderT Arg <| MonoArgsT m
 
 /--
 Construct an argument handler from a monadic action.
@@ -292,7 +354,7 @@ public structure IsArg (arg : String) : Prop where
 namespace IsOpt
 
 /-- A decision procedure for determining if {lean}`arg` is an option. -/
-public def dec (arg : String) : Decidable (IsOpt arg) :=
+@[reducible, expose] public def dec (arg : String) : Decidable (IsOpt arg) :=
   if h0 : arg.startPos = arg.endPos then
     isFalse fun ⟨_, _, _⟩ => by contradiction
   else
@@ -306,11 +368,14 @@ public def dec (arg : String) : Decidable (IsOpt arg) :=
 
 public instance instDecidable {arg : String} : Decidable (IsOpt arg) := dec arg
 
+public theorem ne_empty {arg} (h : IsOpt arg) : arg ≠ "" :=
+  String.startPos_eq_endPos_iff.subst h.startPos_ne_endPos
+
 public theorem not_isArg {arg} (h : IsOpt arg) : ¬ IsArg arg :=
   fun h' => h'.not_isOpt h
 
-public theorem ne_empty {arg} (h : IsOpt arg) : arg ≠ "" :=
-  String.startPos_eq_endPos_iff.subst h.startPos_ne_endPos
+public theorem ne_of_isArg (ha : IsOpt a) (hb : IsArg b) : a ≠ b :=
+  fun heq => ha.not_isArg.elim (heq ▸ hb)
 
 public theorem offset_next_startPos (h : IsOpt a) :
   (a.startPos.next h.startPos_ne_endPos).offset = ⟨1⟩
@@ -366,7 +431,7 @@ end IsOpt
 namespace IsArg
 
 /-- A decision procedure for determining if {lean}`arg` is an non-option command line argument. -/
-public def dec (arg : String) : Decidable (IsArg arg) :=
+@[reducible, expose] public def dec (arg : String) : Decidable (IsArg arg) :=
   if h0 : arg.startPos = arg.endPos then
     isFalse fun h => h.ne_empty (String.startPos_eq_endPos_iff.mp h0)
   else
@@ -380,6 +445,9 @@ public def dec (arg : String) : Decidable (IsArg arg) :=
       isTrue ⟨ne_empty, fun h => hc h.get_startPos⟩
 
 public instance instDecidable {arg : String} : Decidable (IsArg arg) := dec arg
+
+public theorem ne_of_isOpt (ha : IsArg a) (hb : IsOpt b) : a ≠ b :=
+  fun heq => ha.not_isOpt.elim (heq ▸ hb)
 
 public theorem startPos_ne_endPos (h : IsArg a) : a.startPos ≠ a.endPos :=
   String.startPos_eq_endPos_iff.symm.subst h.ne_empty
@@ -410,7 +478,7 @@ public def OptArg := Option String.Slice
 public abbrev MonadOptArg (m) := MonadReaderOf OptArg m
 
 /-- A monad transformer to equip a monad with a command line option and optional argument. -/
-public abbrev OptT (m) := ReaderT Opt <| ReaderT OptArg <| ArgsT m
+public abbrev OptT (m) := ReaderT Opt <| ReaderT OptArg <| MonoArgsT m
 
 /-- The character of a command line short option (e.g., {lit}`x` of {lit}`-x`). -/
 @[expose] -- for codegen
@@ -668,11 +736,11 @@ public def processLeadingOptions
     return args
 termination_by args
 
-public theorem processLeadingOptions_nil [Monad m] :
+@[simp] public theorem processLeadingOptions_nil [Monad m] :
   processLeadingOptions (m := m) [] f = pure []
 := by unfold processLeadingOptions; simp
 
-public theorem processLeadingOptions_cons_empty [Monad m] :
+@[simp] public theorem processLeadingOptions_cons_empty [Monad m] :
   processLeadingOptions (m := m) ("" :: as) f = processLeadingOptions as f
 := by conv => {lhs; unfold processLeadingOptions}; simp
 
@@ -706,11 +774,11 @@ public theorem processLeadingOptions_cons_of_isArg [Monad m] (h : IsArg a) :
   termination_by args
   loop args
 
-public theorem processArgs_nil [Monad m] :
+@[simp] public theorem processArgs_nil [Monad m] :
   processArgs (m := m) [] optH argH = pure ()
 := by unfold processArgs processArgs.loop; simp
 
-public theorem processArgs_cons_empty [Monad m] :
+@[simp] public theorem processArgs_cons_empty [Monad m] :
   processArgs (m := m) ("" :: as) optH argH = processArgs as optH argH
 := by
   unfold processArgs

--- a/src/lake/Lake/Util/Cli.lean
+++ b/src/lake/Lake/Util/Cli.lean
@@ -6,11 +6,13 @@ Authors: Mac Malone
 module
 
 prelude
-public import Init.Data.String.TakeDrop
-public import Init.Data.String.Search
-public import Init.Data.String.Length
+public import Init.Data.String.Slice
+import Init.Data.String.Search
+import Init.Data.String.TakeDrop
 import Init.Data.String.Termination
 import Init.Data.ToString.Macro
+import Init.Omega
+import all Init.SizeOf
 
 set_option doc.verso true
 set_option linter.missingDocs true
@@ -24,54 +26,165 @@ namespace Lake
 
 /-! ## Argument-related Types -/
 
-/-- A List of command line arguments. -/
+/-- A command line argument. -/
 @[expose] -- for codegen
-public def ArgList := List String
+public def Arg := String
+
+/-- Type class for monads equipped with an command line argument. -/
+public abbrev MonadArg (m) := MonadReaderOf Arg m
+
+/-- A List of command line arguments. -/
+@[expose] public def ArgList := List Arg
+
+public noncomputable instance : SizeOf ArgList := inferInstanceAs (SizeOf (List String))
 
 /-- Type class for monads equipped with a command line argument list. -/
-public abbrev MonadArgs (m) := MonadStateOf ArgList m
+public class MonadArgs (m : Type → Type v) where
+  /-- Returns the remaining argument list. -/
+  getArgs : m (List String)
+  /-- Removes and returns the head of the remaining argument list (or {lean}`none` if empty). -/
+  takeArg? : m (Option String)
+  /-- Removes and returns  the remaining argument list, leaving only an empty list. -/
+  takeArgs : m (List String)
 
-/-- A monad transformer to equip a monad with an argument list. -/
-public abbrev ArgsT := StateT ArgList
+export MonadArgs (getArgs takeArgs)
 
-/-- Run the monad with the command line arguments {lean}`args`. -/
-@[inline] public def ArgsT.run (args : List String) (self : ArgsT m α) : m (α × List String) :=
-  StateT.run self args
+public instance [MonadLift m n] [MonadArgs m] : MonadArgs n where
+  getArgs := liftM (m := m) getArgs
+  takeArg? := liftM (m := m) MonadArgs.takeArg?
+  takeArgs := liftM (m := m) takeArgs
 
-/-- Run the monad with the command line arguments {lean}`args` and discard any unprocessed arguments. -/
-@[inline] public def ArgsT.run' [Functor m] (args : List String) (self : ArgsT m α) : m α :=
-  StateT.run' self args
+@[always_inline]
+public instance  [MonadStateOf ArgList m] : MonadArgs m where
+  getArgs := get
+  takeArg? := modifyGet fun | [] => (none, []) | arg :: args => (some arg, args)
+  takeArgs := modifyGet fun args => (args, [])
 
-/-- A monadic callback for an arbitrary command line argument. -/
+/--
+A monad transformer to equip a monad with a state that
+is monotonically increasing over the preorder {lean}`r`.
+-/
 @[expose] -- for codegen
-public def ArgHandler (m : Type u → Type v) (α : Type u := PUnit) :=
-  (arg : String) → m α
+public def MonoStateT (σ : Type u) (r : σ → σ → Prop) (m : Type max u v → Type w) (α : Type v) :=
+  (s : σ) → m (α × {s' : σ // r s s'})
 
-/-- Constructs an argument handler from a monadic function operating on an arbitrary string. -/
-@[inline] public def ArgHandler.ofFn (fn : String → m α) : ArgHandler m α :=
-  fn
+namespace MonoStateT
 
-/-! ## Monadic Argument Utilities -/
+/-- Construct the monad transformer from its functional definition. -/
+@[inline] public def mk
+  (fn : (s : σ) → m (α × {s' : σ // r s s'}))
+: MonoStateT σ r m α := fn
 
-/-- Gets the remaining argument list. -/
-@[inline] public def getArgs [MonadArgs m] : m (List String) :=
-  get
+/--
+Executes an action from a monad with added state increasing monotonically in the
+underlying monad {lean}`m`. Given an initial state {lean}`init : σ`, it returns a
+value paired with the final state {given}`s : σ`, which is guaranteed to follow
+from {lean}`init` in the preorder {lean}`r` (i.e., {lean}`r init s`).
+-/
+@[inline] public def run
+  (init : σ) (self : MonoStateT σ r m α)
+: m (α × {s : σ // r init s}) := self init
 
-/-- Replaces the argument list. -/
-@[inline] public def setArgs [MonadArgs m] (args : List String) : m PUnit :=
-  set (σ := ArgList) args
+@[inline, always_inline, inherit_doc Pure.pure]
+public protected def pure [@Std.Refl σ r] [Pure m] (a : α) : MonoStateT σ r m α :=
+  fun args => pure ⟨a, ⟨args, Std.Refl.refl _⟩⟩
 
-/-- Removes and returns the head of the remaining argument list (or {lean}`none` if empty). -/
-@[inline] def takeRawArg? [MonadArgs m] : m (Option String) :=
-  modifyGet fun | [] => (none, []) | arg :: args => (some arg, args)
+public instance [@Std.Refl σ r] [Pure m] : Pure (MonoStateT σ r m) := ⟨MonoStateT.pure⟩
 
-/-- Removes and returns  the head of the remaining argument list (or {lean}`default` if empty). -/
-@[inline] def takeRawArgD [MonadArgs m] (default : String) : m String :=
-  modifyGet fun | [] => (default, []) | arg :: args => (arg, args)
+@[inline, always_inline, inherit_doc Bind.bind]
+public protected def bind
+  {r : σ → σ → Prop} [Trans r r r] [Monad m]
+  (x : MonoStateT σ r m α) (f : α → MonoStateT σ r m β)
+: MonoStateT σ r m β :=
+  fun si => bind (x si) fun ⟨a, ⟨sa, ha⟩⟩ => bind (f a sa) fun (b, ⟨sb, hb⟩) =>
+    pure ⟨b, ⟨sb, Trans.trans ha hb⟩⟩
 
-/-- Removes and returns  the remaining argument list, leaving only an empty list. -/
-@[inline] public def takeArgs [MonadArgs m] : m (List String) :=
-  modifyGet fun args => (args, [])
+public instance {r : σ → σ → Prop} [Trans r r r] [Monad m] : Bind (MonoStateT σ r m) := ⟨MonoStateT.bind⟩
+public instance [@Std.Refl σ r] [Trans r r r] [Monad m] : Monad (MonoStateT σ r  m) := {}
+
+/-- Runs an action from the underlying monad in the monad with state. The state is not modified. -/
+@[always_inline, inline]
+public protected def lift [@Std.Refl σ r] [Monad m] (t : m α) : MonoStateT σ r m α :=
+  fun s => do let a ← t; pure (a, ⟨s, Std.Refl.refl _⟩)
+
+public instance [@Std.Refl σ r] [Monad m] : MonadLift m (MonoStateT σ r m) := ⟨MonoStateT.lift⟩
+
+@[always_inline]
+public instance [@Std.Refl σ r] [Monad m] [MonadExceptOf ε m] : MonadExceptOf ε (MonoStateT σ r m) where
+  throw    := MonoStateT.lift ∘ throwThe ε
+  tryCatch := fun x c s => tryCatchThe ε (x s) (fun e => c e s)
+
+/--
+Applies a function to the current state that both computes a new state and
+a value. The new state replaces the current state, and the value is returned.
+-/
+public protected def modifyGet
+  [Monad m] (f : (s : σ) → (α × {s' : σ // r s s'}))
+: MonoStateT σ r m α := fun s => pure (f s)
+
+/-- Retrieves the current value of the monad's mutable state. -/
+@[inline, always_inline]
+public protected def get [@Std.Refl σ r] [Pure m] : MonoStateT σ r m σ :=
+  fun s => pure ⟨s, ⟨s, Std.Refl.refl _⟩⟩
+
+end MonoStateT
+
+set_option linter.missingDocs false in
+public def ArgsT.Rel : ArgList → ArgList → Prop := (sizeOf · ≥ sizeOf ·)
+
+namespace ArgsT.Rel
+
+public protected theorem refl (as : ArgList) : Rel as as :=
+  Nat.le_refl _
+
+public instance : Std.Refl Rel := ⟨Rel.refl⟩
+
+public protected theorem trans : Rel a b → Rel b c → Rel a c :=
+  fun h₁ h₂ => Nat.le_trans h₂ h₁
+
+public instance : Trans Rel Rel Rel := ⟨Rel.trans⟩
+
+end ArgsT.Rel
+
+/-- A monad transformer to equip a monad with a monotonically decreasing argument list. -/
+public abbrev ArgsT (m : Type → Type v) := MonoStateT ArgList ArgsT.Rel m
+
+/--
+Monotonicity relation for {name (scope := "Lake.Util.CLI")}`ArgsT`.
+Ensures the size of the argument list is monotonically decreasing.
+-/
+add_decl_doc ArgsT.Rel
+
+namespace ArgsT
+
+@[inline, always_inline, inherit_doc MonadArgs.getArgs]
+public protected def get [Pure m] : ArgsT m (List String) :=
+  MonoStateT.get
+
+@[inline, always_inline, inherit_doc MonadArgs.takeArg?]
+public protected def takeArg? [Monad m] : ArgsT m (Option String) :=
+  MonoStateT.modifyGet fun
+    | [] => (none, ⟨[], Nat.le_refl _⟩)
+    | arg :: args => (some arg, ⟨args, mono_cons⟩)
+where
+  mono_cons {a} {as : List String} : sizeOf as ≤ sizeOf (a :: as) := by simp
+
+@[inline, always_inline, inherit_doc MonadArgs.takeArgs]
+public protected def takeArgs [Monad m] : ArgsT m (List String) :=
+   MonoStateT.modifyGet fun args => (args, ⟨[], mono_nil⟩)
+where
+  mono_nil {as : List String} : sizeOf ([] : List String) ≤ sizeOf as := by
+    cases as
+    · simp
+    · simp only [List.nil.sizeOf_spec, List.cons.sizeOf_spec]
+      omega
+
+public instance [Monad m] : MonadArgs (ArgsT m) where
+  getArgs := ArgsT.get
+  takeArg? := ArgsT.takeArg?
+  takeArgs :=  ArgsT.takeArgs
+
+end ArgsT
 
 /-! ## Monadic Argument Parsing Utilities -/
 
@@ -106,7 +219,7 @@ If no argument is available, returns {lean}`none`.
 @[inline] public def takeArg?
   [Monad m] [MonadArgs m] [MonadParseArg α m]
 : m (Option α) := do
-  if let some arg ← takeRawArg? then
+  if let some arg ← MonadArgs.takeArg? then
     return some (← parseArg arg)
   else
     return none
@@ -133,7 +246,31 @@ If no argument is available,, errors using {name}`throwExpectedArg` with {lean}`
   else
     throwExpectedArg descr
 
-/-! ## Option-related Types -/
+/-! ## Argument Handler Type -/
+
+/-- A monadic callback for an arbitrary command line argument. -/
+@[expose] -- for codegen
+public def ArgHandler (m : Type → Type v) :=
+  (arg : String) → (args : List String) → m {remArgs : List String // sizeOf remArgs ≤ sizeOf args}
+
+/-- Get the current command line argument of the context (e.g., in an {name}`ArgHandler`). -/
+@[inline] public def getArg [MonadArg m] : m String :=
+  read
+
+/-- A monad transformer to equip a monad with a command line argument. -/
+public abbrev ArgT (m) := ReaderT Arg <| ArgsT m
+
+/--
+Construct an argument handler from a monadic action.
+
+The argument under analysis is available via {name}`getArg`. Further arguments are available
+through {name}`getArgs` and can be modify through the various {name}`MonadArgs` utilities
+(e.g., {name}`takeArg`).
+-/
+@[inline] public def ArgHandler.ofM [Monad m] (x : ArgT m Unit) : ArgHandler m :=
+  fun arg args => (·.2) <$> x arg args
+
+/-! ## Argument Predicates -/
 
 /--
 {lean}`IsOpt arg` holds if {lean}`arg` is an command line option.
@@ -144,25 +281,39 @@ public structure IsOpt (arg : String) : Prop where
   get_startPos : arg.startPos.get startPos_ne_endPos = '-'
   next_startPos_ne_endPos : arg.startPos.next startPos_ne_endPos ≠ arg.endPos
 
+/--
+{lean}`IsArg arg` holds if {lean}`arg` is a non-option command-line argument
+That is, it is not empty and is not of the form `-(.+)`.
+-/
+public structure IsArg (arg : String) : Prop where
+  ne_empty : arg ≠ ""
+  not_isOpt : ¬ IsOpt arg
+
 namespace IsOpt
 
 /-- A decision procedure for determining if {lean}`arg` is an option. -/
 public def dec (arg : String) : Decidable (IsOpt arg) :=
   if h0 : arg.startPos = arg.endPos then
-    isFalse (fun ⟨_, _, _⟩ => by contradiction)
+    isFalse fun ⟨_, _, _⟩ => by contradiction
   else
     if hc : arg.startPos.get h0 = '-' then
       if h1 : arg.startPos.next h0 = arg.endPos then
-        isFalse (fun ⟨_, _, _⟩ => by contradiction)
+        isFalse fun ⟨_, _, _⟩ => by contradiction
       else
         isTrue ⟨h0, hc, h1⟩
     else
-      isFalse (fun ⟨_, _, _⟩ => by contradiction)
+      isFalse fun ⟨_, _, _⟩ => by contradiction
 
 public instance instDecidable {arg : String} : Decidable (IsOpt arg) := dec arg
 
-public theorem offset_next_startPos (h : IsOpt arg) :
-  (arg.startPos.next h.startPos_ne_endPos).offset = ⟨1⟩
+public theorem not_isArg {arg} (h : IsOpt arg) : ¬ IsArg arg :=
+  fun h' => h'.not_isOpt h
+
+public theorem ne_empty {arg} (h : IsOpt arg) : arg ≠ "" :=
+  String.startPos_eq_endPos_iff.subst h.startPos_ne_endPos
+
+public theorem offset_next_startPos (h : IsOpt a) :
+  (a.startPos.next h.startPos_ne_endPos).offset = ⟨1⟩
 := by simp [String.Pos.Raw.ext_iff, h.get_startPos, Char.utf8Size]
 
 /--
@@ -212,19 +363,37 @@ public theorem shortTail_eq (h : IsOpt arg) :
 
 end IsOpt
 
-/-- An optional command line option argument. -/
-@[expose] -- for codegen
-public def OptArg := Option String.Slice
+namespace IsArg
 
-/-- A monad transformer to equip a monad with an optional command line option argument. -/
-public abbrev OptArgT := ReaderT OptArg
+/-- A decision procedure for determining if {lean}`arg` is an non-option command line argument. -/
+public def dec (arg : String) : Decidable (IsArg arg) :=
+  if h0 : arg.startPos = arg.endPos then
+    isFalse fun h => h.ne_empty (String.startPos_eq_endPos_iff.mp h0)
+  else
+    have ne_empty := String.startPos_eq_endPos_iff.subst h0
+    if hc : arg.startPos.get h0 = '-' then
+      if h1 : arg.startPos.next h0 = arg.endPos then
+        isTrue ⟨ne_empty, fun h => h.next_startPos_ne_endPos h1⟩
+      else
+        isFalse fun h => h.not_isOpt ⟨h0, hc, h1⟩
+    else
+      isTrue ⟨ne_empty, fun h => hc h.get_startPos⟩
 
-/-- Run the monad with the optional command line option argument {lean}`optArg?`. -/
-@[inline] public def OptArgT.run (optArg? : Option String.Slice) (self : OptArgT m α) : m α :=
-  ReaderT.run self optArg?
+public instance instDecidable {arg : String} : Decidable (IsArg arg) := dec arg
 
-/-- Type class for monads equipped with an optional command line option argument. -/
-public abbrev MonadOptArg (m) := MonadReaderOf OptArg m
+public theorem startPos_ne_endPos (h : IsArg a) : a.startPos ≠ a.endPos :=
+  String.startPos_eq_endPos_iff.symm.subst h.ne_empty
+
+theorem startPos_wf (h : IsArg a) :
+  ¬ (a.startPos.get h.startPos_ne_endPos = '-' ∧ ¬ a.startPos.next h.startPos_ne_endPos = a.endPos)
+:= by
+  intro h'
+  refine h.not_isOpt.elim ⟨?_, h'.1, h'.2⟩
+  simpa using h.ne_empty
+
+end IsArg
+
+/-! ## Option-related Types -/
 
 /-- A command line option. -/
 @[expose] -- for codegen
@@ -233,13 +402,15 @@ public def Opt := String.Slice
 /-- Type class for monads equipped with an command line option. -/
 public abbrev MonadOpt (m) := MonadReaderOf Opt m
 
-/-- A monad transformer to equip a monad with a command line option and optional argument. -/
-public abbrev OptT (m) := ReaderT Opt <| OptArgT m
+/-- An optional command line option argument. -/
+@[expose] -- for codegen
+public def OptArg := Option String.Slice
 
-/-- Run the monad with the command line option {lean}`opt` with optional argument {lean}`optArg?`. -/
-@[inline] public def OptT.run
-  (opt : String.Slice) (optArg? : Option String.Slice)  (self : OptT m α)
-: m α := self opt optArg?
+/-- Type class for monads equipped with an optional command line option argument. -/
+public abbrev MonadOptArg (m) := MonadReaderOf OptArg m
+
+/-- A monad transformer to equip a monad with a command line option and optional argument. -/
+public abbrev OptT (m) := ReaderT Opt <| ReaderT OptArg <| ArgsT m
 
 /-- The character of a command line short option (e.g., {lit}`x` of {lit}`-x`). -/
 @[expose] -- for codegen
@@ -247,9 +418,6 @@ public def OptChar := Char
 
 /-- Type class for monads equipped with a command line short option. -/
 public abbrev MonadOptChar (m) := MonadReaderOf OptChar m
-
-/-- A monad transformer to equip a monad with a short option and optional argument. -/
-public abbrev ShortOptT (m) := ReaderT OptChar <| OptT m
 
 /-! ## Monadic Option Utilities -/
 
@@ -291,33 +459,18 @@ If no argument is available, errors using {name}`throwExpectedArg` with {lean}`d
 
 /-- A monadic callback for an arbitrary option (e.g., short or long). -/
 @[expose] -- for codegen
-public def OptHandler (m : Type u → Type v) (α : Type u := PUnit) :=
-  (arg : String) → IsOpt arg → m α
+public def OptHandler (m : Type → Type v) :=
+  (arg : String) → IsOpt arg →
+  (args : List String) → m {remArgs : List String // sizeOf remArgs ≤ sizeOf args}
 
-/-- Constructs an option handler from a monadic function operating on an arbitrary string. -/
-@[inline] public def OptHandler.ofFn (fn : String → m α) : OptHandler m α :=
-  fun arg _ => fn arg
-
-/-- Constructs an option handler from a monadic function operating on an string known to be an option. -/
-@[inline] public def OptHandler.ofFn' (fn : (arg : String) → IsOpt arg → m α) : OptHandler m α :=
-  fn
+/-- A monad transformer to equip a monad with a long option and optional argument. -/
+public abbrev LongOptT (m) := OptT m
 
 /-- A monadic callback for a long option (e.g., {lit}`--long` or {lit}`--long=arg`). -/
 @[expose] -- for codegen
-public def LongOptHandler (m : Type u → Type v) (α : Type u := PUnit) :=
-  (opt : String.Slice) → (optArg? : Option String.Slice) → m α
-
-/--
-Construct an long option handler from a monadic function that takes the option and its argument.
-
-**Examples:**
-* {lit}`-long` => {lean}`fn "-long" none`
-* {lit}`--long=arg` => {lean}`fn "--long" (some "arg")`
-* {lit}`"--long foo bar"` => {lean}`fn "--long" (some "foo bar")`
--/
-@[inline] public def LongOptHandler.ofFn
-  (fn : (opt : String.Slice) → (optArg? : Option String.Slice) → m α)
-: LongOptHandler m α := fn
+public def LongOptHandler (m : Type → Type v) :=
+  (opt : String.Slice) → (optArg? : Option String.Slice) →
+  (args : List String) → m {remArgs : List String // sizeOf remArgs ≤ sizeOf args}
 
 /--
 Construct an long option handler from a monadic action.
@@ -326,32 +479,17 @@ The name of the option (e.g., {lit}`-long` or {lit}`--long`) is available via {n
 An argument for the option (e.g., {lit}`arg` in {lit}`--long=arg` or {lit}`--long arg`) can be
 accessed through {name}`takeArg?`.
 -/
-@[inline] public def LongOptHandler.ofM (x : OptT m α) : LongOptHandler m α := x
-
-/--
-Run the monad with the short option {lean}`opt` of character {lean}`optChar`
-with optional argument {lean}`optArg?`.
--/
-@[inline] public def ShortOptT.run
-  (optChar : Char) (opt : String.Slice) (optArg? : Option String.Slice) (self : ShortOptT m α)
-: m α := self optChar opt optArg?
+@[inline] public def LongOptHandler.ofM [Monad m] (x : LongOptT m Unit) : LongOptHandler m :=
+  fun opt optArg? args => (·.2) <$> x opt optArg? args
 
 /-- A monadic callback for a short option (e.g., {lit}`-x` or {lit}`-x=arg`). -/
 @[expose] -- for codegen
-public def ShortOptHandler (m : Type u → Type v) (α : Type u := PUnit) :=
-  (optChar : Char) → (opt : String.Slice) → (optArg? : Option String.Slice) → m α
+public def ShortOptHandler (m : Type → Type v) :=
+  (optChar : Char) → (opt : String.Slice) → (optArg? : Option String.Slice) →
+  (args : List String) → m {remArgs : List String // sizeOf remArgs ≤ sizeOf args}
 
-/--
-Constructs an short option handler from a monadic function that takes the option and its argument.
-
-**Examples:**
-* {lit}`-x` => {lean}`fn 'x' none`
-* {lit}`-x=arg` => {lean}`fn 'x' (some "arg")`
-* {lit}`"-x foo bar"` => {lean}`fn 'x' (some "foo bar")`
--/
-@[inline] public def ShortOptHandler.ofFn
-  (fn : (optChar : Char) → (optArg? : Option String.Slice) → m α)
-: ShortOptHandler m α := fun c _ a? => fn c a?
+/-- A monad transformer to equip a monad with a short option and optional argument. -/
+public abbrev ShortOptT (m) := ReaderT OptChar <| OptT m
 
 /--
 Construct an short option handler from a monadic action.
@@ -362,27 +500,28 @@ the character of the option (e.g., {lit}`x` in {lit}`-x`) is available via {name
 An argument for the option (e.g., {lit}`arg` in {lit}`-x=arg` or {lit}`-x arg`) can be accessed
 through  {name}`takeOptArg`.
 -/
-@[inline] public def ShortOptHandler.ofM (x : ShortOptT m α) : ShortOptHandler m α := x
+@[inline] public def ShortOptHandler.ofM [Monad m] (x : ShortOptT m Unit) : ShortOptHandler m :=
+  fun optChar opt optArg? args => (·.2) <$> x optChar opt optArg? args
 
 /-- A monadic callback for a long short option (e.g., {lit}`-long` or {lit}`-long=short`). -/
 @[expose] -- for codegen
-public def LongShortOptHandler (m : Type u → Type v) (α : Type u := PUnit) :=
-  (arg : String) → IsOpt arg → m α
+public def LongShortOptHandler (m : Type → Type v)  :=
+  OptHandler m
 
 /-- Constructs a long short option handler from a generic option handler. -/
-@[inline] public def LongShortOptHandler.ofOptHandler (handler : OptHandler m α) : LongShortOptHandler m α :=
+@[inline] public def LongShortOptHandler.ofOptHandler (handler : OptHandler m) : LongShortOptHandler m :=
   handler
 
-public instance : Coe (OptHandler m a) (LongShortOptHandler m a) := ⟨.ofOptHandler⟩
+public instance : Coe (OptHandler m) (LongShortOptHandler m) := ⟨.ofOptHandler⟩
 
 /-- Handlers for each kind of option. -/
-public structure OptHandlers (m : Type u → Type v) (α : Type u := PUnit) where
+public structure OptHandlers (m : Type → Type v) where
   /-- Process a long option (e.g., {lit}`--long` or {lit}`"--long foo bar"`). -/
-  long : LongOptHandler m α
+  long : LongOptHandler m
   /-- Process a short option (e.g., {lit}`-x` or {lit}`--`). -/
-  short : ShortOptHandler m α
+  short : ShortOptHandler m
   /-- Process a long short option (e.g., {lit}`-long`, {lit}`-xarg`, or {lit}`-xyz`). -/
-  longShort : LongShortOptHandler m α
+  longShort : LongShortOptHandler m
 
 /-! ## Option Handlers -/
 
@@ -391,7 +530,7 @@ Process a short option of the form {lit}`-xarg`.
 
 Can be used as the handler for {lean}`OptHandlers.longShort`.
 -/
-@[inline] public def shortOptionWithArg (handler : ShortOptHandler m α) : OptHandler m α := fun _ h =>
+@[inline] public def shortOptionWithArg (handler : ShortOptHandler m) : OptHandler m := fun _ h =>
   handler h.shortChar h.shortOpt (some h.shortTail)
 
 /--
@@ -402,11 +541,11 @@ Can be used as the handler for {lean}`OptHandlers.longShort`.
 -/
 @[inline] public def multiShortOption
   [SeqRight m] (handler : ShortOptHandler m)
-: OptHandler m := fun arg h =>
+: OptHandler m := fun arg h args =>
   let rec @[specialize handler] loop (p : arg.Pos) (h : ¬ p.IsAtEnd) :=
     let p' := p.next h
     let optChar := p.get h
-    let r := handler optChar s!"-{optChar}" none
+    let r := handler optChar s!"-{optChar}" none args
     if h' : p'.IsAtEnd then
       r
     else
@@ -415,16 +554,16 @@ Can be used as the handler for {lean}`OptHandlers.longShort`.
   loop h.shortPos h.shortPos_ne_endPos
 
 @[inline] def splitLongOption
-  {arg : String} (sepPos : arg.Pos)
-  (longHandler : LongOptHandler m α)
-  (noSepHandler : ArgHandler m α)
-: m α :=
+  {arg : String} (sepPos : arg.Pos) (args : List String)
+  (longHandler : LongOptHandler m)
+  (noSepHandler : ArgHandler m)
+: m {remArgs : List String // sizeOf remArgs ≤ sizeOf args} :=
   if h : sepPos = arg.endPos then
-    noSepHandler arg
+    noSepHandler arg args
   else
     let optArg := arg.sliceFrom (sepPos.next h)
     let opt := arg.sliceTo sepPos
-    longHandler opt (some optArg)
+    longHandler opt (some optArg) args
 
 /--
 Processes a command line argument as a long option with possible option argument after a ` `
@@ -440,8 +579,8 @@ Otherwise, the argument is passed to {lean}`handler` as an option with no option
 
 Can be used as the handler for {lean}`OptHandlers.longShort`.
 -/
-@[inline] public def longOptionOrSpace (handler : LongOptHandler m α) : OptHandler m α := fun arg _ =>
-  splitLongOption (arg.find ' ') handler fun arg => handler arg.toSlice none
+@[inline] public def longOptionOrSpace (handler : LongOptHandler m) : OptHandler m := fun arg _ args =>
+  splitLongOption (arg.find ' ') args handler fun arg => handler arg.toSlice none
 
 /--
 Processes a command line argument as a long option with possible option argument after an `=`
@@ -453,8 +592,8 @@ Otherwise, the argument is passed to {lean}`handler` as an option with no option
 
 Can be used as the handler for {lean}`OptHandlers.longShort`.
 -/
-@[inline] public def longOptionOrEq (handler : LongOptHandler m α) : OptHandler m α := fun arg _ =>
-  splitLongOption (arg.find '=') handler fun arg => handler arg.toSlice none
+@[inline] public def longOptionOrEq (handler : LongOptHandler m) : OptHandler m := fun arg _ args =>
+  splitLongOption (arg.find '=') args handler fun arg => handler arg.toSlice none
 
 /--
 Processes a command line argument as a long option with a possible option argument
@@ -462,15 +601,15 @@ Processes a command line argument as a long option with a possible option argume
 
 Can be used as the handler for {lean}`OptHandlers.longShort`.
 -/
-@[inline] def longOption (handler : LongOptHandler m α) : OptHandler m α := fun arg _ =>
-  splitLongOption (arg.find ' ') handler fun arg =>
-    splitLongOption (arg.find '=') handler fun arg =>
+@[inline] def longOption (handler : LongOptHandler m) : OptHandler m := fun arg _ args =>
+  splitLongOption (arg.find ' ') args handler fun arg args =>
+    splitLongOption (arg.find '=') args handler fun arg =>
       handler arg.toSlice none
 
 /-- Processes a short option of the form {lit}`-x`, {lit}`-x=arg`, {lit}`-x arg`, or {lit}`-long`. -/
 @[inline] def shortOption
-  (shortHandler : ShortOptHandler m α) (longHandler : LongShortOptHandler m α)
-: OptHandler m α := fun arg h =>
+  (shortHandler : ShortOptHandler m) (longHandler : LongShortOptHandler m)
+: OptHandler m := fun arg h =>
   if h' : h.afterShortPos.IsAtEnd then -- `-x`
     shortHandler h.shortChar h.shortOpt none
   else -- `-c(.+)`
@@ -489,7 +628,7 @@ Processes an option, short or long, using the given handlers.
 An option is an argument of length > 1 starting with a dash ({lit}`-`).
 An option may consume additional elements of the argument list.
 -/
-@[inline] public def option (handlers : OptHandlers m α) : OptHandler m α := fun arg h =>
+@[inline] public def option (handlers : OptHandlers m) : OptHandler m := fun arg h =>
   if h.shortChar = '-' then -- `--(.*)`
     longOption handlers.long arg h
   else
@@ -497,61 +636,110 @@ An option may consume additional elements of the argument list.
 
 /-! ## Argument Processors -/
 
-variable [MonadArgs m] [Monad m]
-
 /-- Process the head argument of the list using {lean}`handler` if it is an option. -/
-public def processLeadingOption (handler : OptHandler m) : m PUnit := do
-  if let arg :: args ← getArgs then
+@[inline] public def processLeadingOption
+  [Monad m] (args : List String) (handler : OptHandler m)
+: m (List String) :=
+  if let arg :: remArgs := args then
     if h : IsOpt arg then -- `-(.+)`
-      setArgs args
-      handler arg h
+      handler arg h remArgs
+    else
+      pure args
+  else
+    pure args
 
 /--
 Process the leading options of the remaining argument list.
 Consumes empty leading arguments in the argument list.
 -/
 @[specialize handler]
-public partial def processLeadingOptions (handler : OptHandler m) : m PUnit := do
-  if let arg :: args ← getArgs then
-    if h0 : arg.startPos.IsAtEnd then -- skip empty leading args
-      setArgs args
-      processLeadingOptions handler
-    else if h : arg.startPos.get h0 = '-' ∧ ¬ (arg.startPos.next h0).IsAtEnd then -- `-(.+)`
-      setArgs args
-      handler arg ⟨h0, h.1, h.2⟩
-      processLeadingOptions handler
-
-/-- Process every argument in the command line argument list. -/
-@[inline] public partial def processArgs
-  (optHandler : OptHandler m) (argHandler : ArgHandler m)
-: m PUnit :=
-  let rec @[specialize optHandler argHandler] loop := do
-    if let some arg ← takeRawArg? then
-      if h0 : arg.startPos.IsAtEnd then -- skip empty args
-        loop
-      else if h : arg.startPos.get h0 = '-' ∧ ¬ (arg.startPos.next h0).IsAtEnd then -- `-(.+)`
-        optHandler arg ⟨h0, h.1, h.2⟩
-        loop
-      else
-        argHandler arg
-        loop
-  loop
-
-/-- Process every option and collect the remaining arguments into an {name}`Array`. -/
-@[specialize handler] public partial def collectArgs
-  (handler : OptHandler m) (args : Array String := #[])
-: m (Array String) := do
-  if let some arg ← takeRawArg? then
-    if h0 : arg.startPos.IsAtEnd then -- skip empty args
-      collectArgs handler args
-    else if h : arg.startPos.get h0 = '-' ∧ ¬ (arg.startPos.next h0).IsAtEnd then -- `-(.+)`
-      handler arg ⟨h0, h.1, h.2⟩
-      collectArgs handler args
+public def processLeadingOptions
+  [Monad m] (args : List String) (handler : OptHandler m)
+: m (List String) := do
+  if let a :: as := args then
+    if h0 : a.startPos.IsAtEnd then -- skip empty leading args
+      processLeadingOptions as handler
+    else if h : a.startPos.get h0 = '-' ∧ ¬ (a.startPos.next h0).IsAtEnd then -- `-(.+)`
+      let ⟨as, _⟩ ← handler a ⟨h0, h.1, h.2⟩ as
+      processLeadingOptions as handler
     else
-      collectArgs handler (args.push arg)
+      return args
   else
     return args
+termination_by args
 
-/-- Process every option in the argument list. -/
-@[inline] public def processOptions (handler : OptHandler m) : m PUnit := do
-  setArgs (← collectArgs handler).toList
+public theorem processLeadingOptions_nil [Monad m] :
+  processLeadingOptions (m := m) [] f = pure []
+:= by unfold processLeadingOptions; simp
+
+public theorem processLeadingOptions_cons_empty [Monad m] :
+  processLeadingOptions (m := m) ("" :: as) f = processLeadingOptions as f
+:= by conv => {lhs; unfold processLeadingOptions}; simp
+
+public theorem processLeadingOptions_cons_of_isOpt [Monad m] (h : IsOpt a) :
+  processLeadingOptions (m := m) (a :: as) f =
+    f a h as >>= fun as => processLeadingOptions as f
+:= by
+  conv => lhs; unfold processLeadingOptions
+  simp [h.ne_empty, h.get_startPos, h.next_startPos_ne_endPos]
+
+public theorem processLeadingOptions_cons_of_isArg [Monad m] (h : IsArg a) :
+  processLeadingOptions (m := m) (a :: as) f = pure (a :: as)
+:= by
+  conv => lhs; unfold processLeadingOptions
+  simp [h.ne_empty, h.startPos_wf]
+
+/-- Process every argument in the command line argument list. -/
+@[inline] public def processArgs
+  [Monad m] (args : List String) (optHandler : OptHandler m) (argHandler : ArgHandler m)
+: m PUnit :=
+  let rec @[specialize optHandler argHandler] loop args := do
+    if let a :: as := args then
+      if h0 : a.startPos.IsAtEnd then -- skip empty args
+        loop as
+      else if h : a.startPos.get h0 = '-' ∧ ¬ (a.startPos.next h0).IsAtEnd then -- `-(.+)`
+        let ⟨as, _⟩ ← optHandler a ⟨h0, h.1, h.2⟩ as
+        loop as
+      else
+        let ⟨as, _⟩ ← argHandler a as
+        loop as
+  termination_by args
+  loop args
+
+public theorem processArgs_nil [Monad m] :
+  processArgs (m := m) [] optH argH = pure ()
+:= by unfold processArgs processArgs.loop; simp
+
+public theorem processArgs_cons_empty [Monad m] :
+  processArgs (m := m) ("" :: as) optH argH = processArgs as optH argH
+:= by
+  unfold processArgs
+  conv => lhs; unfold processArgs.loop
+  simp
+
+public theorem processArgs_cons_of_isOpt [Monad m] (h : IsOpt a) :
+  processArgs (m := m) (a :: as) optH argH =
+    optH a h as >>= fun as => processArgs as optH argH
+:= by
+  unfold processArgs
+  conv => lhs; unfold processArgs.loop
+  simp [h.ne_empty, h.get_startPos, h.next_startPos_ne_endPos]
+
+public theorem processArgs_cons_of_isArg [Monad m] (h : IsArg a) :
+  processArgs (m := m) (a :: as) optH argH =
+    argH a as >>= fun as => processArgs as optH argH
+:= by
+  unfold processArgs
+  conv => lhs; unfold processArgs.loop
+  simp [h.ne_empty, h.startPos_wf]
+
+@[inline] def OptHandler.lift [MonadLift m n] (self : OptHandler m) : OptHandler n :=
+  fun arg h args => liftM (self arg h args)
+
+/-- Process every option in {lean}`args` and collect the remaining arguments into an {name}`Array`. -/
+@[inline] public def collectArgs
+  [Monad m] (args : List String) (handler : OptHandler m)
+: m (Array String) :=
+  (·.2) <$> StateT.run (s := #[]) do
+    processArgs args handler.lift fun arg args s =>
+      pure (⟨args, Nat.le_refl ..⟩, s.push arg)

--- a/src/lake/Lake/Util/Cli.lean
+++ b/src/lake/Lake/Util/Cli.lean
@@ -9,39 +9,297 @@ prelude
 public import Init.Data.String.TakeDrop
 public import Init.Data.String.Search
 public import Init.Data.String.Length
+import Init.Data.String.Termination
+
+set_option doc.verso true
+set_option linter.missingDocs true
+
+/-! # Lake's CLI API
+
+The abstract API used by Lake to parse command line arguments.
+-/
 
 namespace Lake
 
-/-!
-Defines the abstract CLI interface for Lake.
+/-! ## Option-related Types -/
+
+/--
+{lean}`IsOpt arg` holds if {lean}`arg` is an command line option.
+That is, {lean}`arg` is of the form `-(.+)`.
 -/
+public structure IsOpt (arg : String) : Prop where
+  startPos_ne_endPos : arg.startPos ≠ arg.endPos
+  get_startPos : arg.startPos.get startPos_ne_endPos = '-'
+  next_startPos_ne_endPos : arg.startPos.next startPos_ne_endPos ≠ arg.endPos
 
-/-! # Types -/
+namespace IsOpt
 
-public abbrev ArgList := List String
+/-- A decision procedure for determining if {lean}`arg` is an option. -/
+public def dec (arg : String) : Decidable (IsOpt arg) :=
+  if h0 : arg.startPos = arg.endPos then
+    isFalse (fun ⟨_, _, _⟩ => by contradiction)
+  else
+    if hc : arg.startPos.get h0 = '-' then
+      if h1 : arg.startPos.next h0 = arg.endPos then
+        isFalse (fun ⟨_, _, _⟩ => by contradiction)
+      else
+        isTrue ⟨h0, hc, h1⟩
+    else
+      isFalse (fun ⟨_, _, _⟩ => by contradiction)
 
+public instance instDecidable {arg : String} : Decidable (IsOpt arg) := dec arg
+
+public theorem offset_next_startPos (h : IsOpt arg) :
+  (arg.startPos.next h.startPos_ne_endPos).offset = ⟨1⟩
+:= by simp [String.Pos.Raw.ext_iff, h.get_startPos, Char.utf8Size]
+
+/-- The position in {lean}`arg` after the initial {lit}`-`. -/
+@[inline] public def afterStartPos (h : IsOpt arg) : arg.Pos :=
+  arg.pos ⟨1⟩ <| by
+    rw [← h.offset_next_startPos]
+    apply String.Pos.isValid
+
+public theorem afterStartPos_eq (h : IsOpt arg) :
+  h.afterStartPos = arg.startPos.next h.startPos_ne_endPos
+:= by simp [afterStartPos, String.Pos.ext_iff, -String.Pos.offset_next, h.offset_next_startPos]
+
+public theorem afterStartPos_ne_endPos (h : IsOpt arg) : h.afterStartPos ≠ arg.endPos := by
+  rw [afterStartPos_eq]
+  exact h.next_startPos_ne_endPos
+
+/-- The character in {lean}`arg` after the initial {lit}`-`. -/
+@[inline] public def shortChar (h : IsOpt arg) : Char :=
+  h.afterStartPos.get h.afterStartPos_ne_endPos
+
+/-- The position in {lean}`arg` after {lean}`shortChar` (e.g., {lit}`y` in {lit}`-xy`). -/
+@[inline] public def afterShortPos (h : IsOpt arg) : arg.Pos :=
+  h.afterStartPos.next h.afterStartPos_ne_endPos
+
+public theorem afterShortPos_eq (h : IsOpt arg) :
+  h.afterShortPos = h.afterStartPos.next h.afterStartPos_ne_endPos
+:= by rfl
+
+/-- The remainder of {lean}`arg` after {lean}`shortChar` (e.g., {lit}`=arg` in {lit}`-x=arg`). -/
+@[inline] public def shortTail (h : IsOpt arg) : String.Slice :=
+  arg.sliceFrom h.afterShortPos
+
+public theorem shortTail_eq (h : IsOpt arg) :
+  h.shortTail = arg.sliceFrom h.afterShortPos
+:= by rfl
+
+end IsOpt
+
+/-- A monadic callback for an arbitrary command line argument. -/
+@[expose] -- for codegen
+public def ArgHandler (m : Type u → Type v) (α : Type u := PUnit) :=
+  (arg : String) → m α
+
+/-- Constructs an argument handler from a monadic function operating on an arbitrary string. -/
+@[inline] public def ArgHandler.ofFn (fn : String → m α) : ArgHandler m α :=
+  fn
+
+/-- A monadic callback for an arbitrary option (e.g., short or long). -/
+@[expose] -- for codegen
+public def OptHandler (m : Type u → Type v) (α : Type u := PUnit) :=
+  (arg : String) → IsOpt arg → m α
+
+/-- Constructs an option handler from a monadic function operating on an arbitrary string. -/
+@[inline] public def OptHandler.ofFn (fn : String → m α) : OptHandler m α :=
+  fun arg _ => fn arg
+
+/-- Constructs an option handler from a monadic function operating on an string known to be an option. -/
+@[inline] public def OptHandler.ofFn' (fn : (arg : String) → IsOpt arg → m α) : OptHandler m α :=
+  fn
+
+/-- A monadic callback for a long option (e.g., {lit}`--long` or {lit}`--long=arg`). -/
+@[expose] -- for codegen
+public def LongOptHandler (m : Type u → Type v) (α : Type u := PUnit) :=
+  (opt : String.Slice) → (optArg? : Option String.Slice) → m α
+
+/--
+Construct an long option handler from a monadic function that takes the option and its argument.
+
+**Examples:**
+* {lit}`-long` => {lean}`fn "-long" none`
+* {lit}`--long=arg` => {lean}`fn "--long" (some "arg")`
+* {lit}`"--long foo bar"` => {lean}`fn "--long" (some "foo bar")`
+-/
+@[inline] public def LongOptHandler.ofFn
+  (fn : (opt : String.Slice) → (optArg? : Option String.Slice) → m α)
+: LongOptHandler m α := fn
+
+/-- A monadic callback for a short option (e.g., {lit}`-x` or {lit}`-x=arg`). -/
+@[expose] -- for codegen
+public def ShortOptHandler (m : Type u → Type v) (α : Type u := PUnit) :=
+  (opt : Char) → (optArg? : Option String.Slice) → m α
+
+/--
+Constructs an short option handler from a monadic function that takes the option and its argument.
+
+**Examples:**
+* {lit}`-x` => {lean}`fn 'x' none`
+* {lit}`-x=arg` => {lean}`fn 'x' (some "arg")`
+* {lit}`"-x foo bar"` => {lean}`fn 'x' (some "foo bar")`
+-/
+@[inline] public def ShortOptHandler.ofFn
+  (fn : (opt : Char) → (optArg? : Option String.Slice) → m α)
+: ShortOptHandler m α := fn
+
+/-- A monadic callback for a long short option (e.g., {lit}`-long` or {lit}`-long=short`). -/
+@[expose] -- for codegen
+public def LongShortOptHandler (m : Type u → Type v) (α : Type u := PUnit) :=
+  (arg : String) → IsOpt arg → m α
+
+/-- Constructs a long short option handler from a generic option handler. -/
+@[inline] public def LongShortOptHandler.ofOptHandler (handler : OptHandler m α) : LongShortOptHandler m α :=
+  handler
+
+public instance : Coe (OptHandler m a) (LongShortOptHandler m a) := ⟨.ofOptHandler⟩
+
+/-- Handlers for each kind of option. -/
+public structure OptHandlers (m : Type u → Type v) (α : Type u := PUnit) where
+  /-- Process a long option (e.g., {lit}`--long` or {lit}`"--long foo bar"`). -/
+  long : LongOptHandler m α
+  /-- Process a short option (e.g., {lit}`-x` or {lit}`--`). -/
+  short : ShortOptHandler m α
+  /-- Process a long short option (e.g., {lit}`-long`, {lit}`-xarg`, or {lit}`-xyz`). -/
+  longShort : LongShortOptHandler m α
+
+/-! ## Option Handlers -/
+
+/--
+Process a short option of the form {lit}`-xarg`.
+
+Can be used as the handler for {lean}`OptHandlers.longShort`.
+-/
+@[inline] public def shortOptionWithArg (handler : ShortOptHandler m α) : OptHandler m α := fun _ h =>
+  handler h.shortChar (some h.shortTail)
+
+/--
+Process a multiple short options grouped together
+(e.g., {lit}`-xyz` as {lit}`x`, {lit}`y`, {lit}`z`).
+
+Can be used as the handler for {lean}`OptHandlers.longShort`.
+-/
+@[inline] public def multiShortOption
+  [Monad m] (handler : ShortOptHandler m)
+: OptHandler m := fun arg h => do
+  let rec @[specialize handler] loop (p : arg.Pos) := do
+    if h : p.IsAtEnd then
+      return
+    else
+      handler (p.get h) none
+      loop (p.next h)
+  termination_by p
+  loop h.afterStartPos
+
+@[inline] private def splitLongOption
+  {arg : String} (sepPos : arg.Pos)
+  (longHandler : LongOptHandler m α)
+  (noSepHandler : ArgHandler m α)
+: m α :=
+  if h : sepPos = arg.endPos then
+    noSepHandler arg
+  else
+    let optArg := arg.sliceFrom (sepPos.next h)
+    let opt := arg.sliceTo sepPos
+    longHandler opt (some optArg)
+
+/--
+Processes a command line argument as a long option with possible option argument after a ` `
+(e.g., {lit}`-long`, {lit}`--long`, or {lit}`"--long arg"`).
+
+
+Parses a command line argument of the form {lit}`"-opt foo bar"` into the long option
+{lit}`-opt` with the option argument {lit}`"foo bar"` and processes it with {lean}`handler`.
+
+If a space is present (e.g., {lit}`-opt foo  bar`), the argument will be split around it.
+{lean}`handler` will be invoked with the option {lit}`-opt` and the option argument {lit}`opt`.
+Otherwise, the argument is passed to {lean}`handler` as an option with no option argument.
+
+Can be used as the handler for {lean}`OptHandlers.longShort`.
+-/
+@[inline] public def longOptionOrSpace (handler : LongOptHandler m α) : OptHandler m α := fun arg _ =>
+  splitLongOption (arg.find ' ') handler fun arg => handler arg.toSlice none
+
+/--
+Processes a command line argument as a long option with possible option argument after an `=`
+(e.g., {lit}`-long`, {lit}`-long`, or {lit}`--long=arg`).
+
+If an equal sign is present (e.g., {lit}`-opt=foo bar`), the argument will be split around it.
+{lean}`handler` will be invoked with the option {lit}`-opt` and the option argument {lit}`foo bar`.
+Otherwise, the argument is passed to {lean}`handler` as an option with no option argument.
+
+Can be used as the handler for {lean}`OptHandlers.longShort`.
+-/
+@[inline] public def longOptionOrEq (handler : LongOptHandler m α) : OptHandler m α := fun arg _ =>
+  splitLongOption (arg.find '=') handler fun arg => handler arg.toSlice none
+
+/--
+Processes a command line argument as a long option with a possible option argument
+(e.g., {lit}`-long`, {lit}`--long`, {lit}`--long=arg`, or {lit}`"--long arg"`).
+
+Can be used as the handler for {lean}`OptHandlers.longShort`.
+-/
+@[inline] def longOption (handler : LongOptHandler m α) : OptHandler m α := fun arg _ =>
+  splitLongOption (arg.find ' ') handler fun arg =>
+    splitLongOption (arg.find '=') handler fun arg =>
+      handler arg.toSlice none
+
+/-- Processes a short option of the form {lit}`-x`, {lit}`-x=arg`, {lit}`-x arg`, or {lit}`-long`. -/
+@[inline] def shortOption
+  (shortHandler : ShortOptHandler m α) (longHandler : LongShortOptHandler m α)
+: OptHandler m α := fun arg h =>
+  if h' : h.afterShortPos.IsAtEnd then -- `-x`
+    shortHandler h.shortChar none
+  else -- `-c(.+)`
+    let c := h.afterShortPos.get h'
+    let nextPos := h.afterShortPos.next h'
+    match c with
+    | '=' => -- `-x=arg`
+      shortHandler h.shortChar (some <| arg.sliceFrom nextPos)
+    | ' ' => -- `"-x arg"`
+      shortHandler h.shortChar (some <| arg.sliceFrom nextPos |>.trimAsciiStart)
+    | _   => -- `-long`
+      longHandler arg h
+
+/--
+Processes an option, short or long, using the given handlers.
+An option is an argument of length > 1 starting with a dash ({lit}`-`).
+An option may consume additional elements of the argument list.
+-/
+@[inline] public def option (handlers : OptHandlers m α) : OptHandler m α := fun arg h =>
+  if h.shortChar = '-' then -- `--(.*)`
+    longOption handlers.long arg h
+  else
+    shortOption handlers.short handlers.longShort arg h
+
+/-! ## Argument-related Types -/
+
+/-- A List of command line arguments. -/
+@[expose] public def ArgList := List String
+
+/-- Treats a list of strings as an argument list. -/
 @[inline] public def ArgList.mk (args : List String) : ArgList :=
   args
 
+/-- A monad transformer to equip a monad with an argument list. -/
 public abbrev ArgsT := StateT ArgList
 
+/-- Run the monad with the command line arguments {lean}`args`. -/
 @[inline] public def ArgsT.run (args : List String) (self : ArgsT m α) : m (α × List String) :=
   StateT.run self args
 
+/-- Run the monad with the command line arguments {lean}`args` and discard any unprocessed arguments. -/
 @[inline] public def ArgsT.run' [Functor m] (args : List String) (self : ArgsT m α) : m α :=
   StateT.run' self args
 
-public structure OptionHandlers (m : Type u → Type v) (α : Type u) where
-  /-- Process a long option (ex. `--long` or `"--long foo bar"`). -/
-  long : String → m α
-  /-- Process a short option (ex. `-x` or `--`). -/
-  short : Char → m α
-  /-- Process a long short option (ex. `-long`, `-xarg`, `-xyz`). -/
-  longShort : String → m α
+/-- Type class for monads equipped with a command line argument list. -/
+public abbrev MonadArgs (m) := MonadStateOf ArgList m
 
-/-! # Utilities -/
+/-! ## Argument Utilities -/
 
-variable [Monad m] [MonadStateOf ArgList m]
+variable [Monad m] [MonadArgs m]
 
 /-- Get the remaining argument list. -/
 @[inline] public def getArgs : m (List String) :=
@@ -51,11 +309,11 @@ variable [Monad m] [MonadStateOf ArgList m]
 @[inline] public def setArgs (args : List String) : m PUnit :=
   set (ArgList.mk args)
 
-/-- Take the head of the remaining argument list (or none if empty). -/
+/-- Take the head of the remaining argument list (or {lean}`none` if empty). -/
 @[inline] public def takeArg? : m (Option String) :=
   modifyGet fun | [] => (none, []) | arg :: args => (some arg, args)
 
-/-- Take the head of the remaining argument list (or `default` if none). -/
+/-- Take the head of the remaining argument list (or {lean}`default` if empty). -/
 @[inline] public def takeArgD (default : String) : m String :=
   modifyGet fun | [] => (default, []) | arg :: args => (arg, args)
 
@@ -63,126 +321,61 @@ variable [Monad m] [MonadStateOf ArgList m]
 @[inline] public def takeArgs : m (List String) :=
   modifyGet fun args => (args, [])
 
-/-- Add a string to the head of the remaining argument list. -/
-@[inline] public def consArg (arg : String) : m PUnit :=
-  modify fun args => arg :: args
+/-! ## Argument Processors -/
 
-/-- Process a short option of the form `-x=arg`. -/
-@[inline] public def shortOptionWithEq (handle : Char → m α) (opt : String) : m α := do
-  consArg (opt.drop 3).copy; handle (String.Pos.Raw.get opt ⟨1⟩)
-
-/-- Process a short option of the form `"-x arg"`. -/
-@[inline] public def shortOptionWithSpace (handle : Char → m α) (opt : String) : m α := do
-  consArg <| opt.drop 2 |>.trimAsciiStart |>.copy; handle (String.Pos.Raw.get opt ⟨1⟩)
-
-/-- Process a short option of the form `-xarg`. -/
-@[inline] public def shortOptionWithArg (handle : Char → m α) (opt : String) : m α := do
-  consArg (opt.drop 2).copy; handle (String.Pos.Raw.get opt ⟨1⟩)
-
-/-- Process a multiple short options grouped together (ex. `-xyz` as `x`, `y`, `z`). -/
-@[inline] public def multiShortOption (handle : Char → m PUnit) (opt : String) : m PUnit := do
-  let rec loop (p : String.Pos.Raw) := do
-    if h : p.atEnd opt then
-      return
-    else
-      handle (p.get' opt h)
-      loop (p.next' opt h)
-  termination_by opt.utf8ByteSize - p.byteIdx
-  decreasing_by
-    simp [String.Pos.Raw.atEnd] at h
-    apply Nat.sub_lt_sub_left h
-    exact String.Pos.Raw.byteIdx_lt_byteIdx_next opt p
-  loop ⟨1⟩
-
-/-- Splits a long option of the form `"--long foo bar"` into `--long` and `"foo bar"`. -/
-@[inline] public def longOptionOrSpace (handle : String → m α) (opt : String) : m α :=
-  let pos := opt.find ' '
-  if h : pos = opt.endPos then
-    handle opt
-  else do
-    consArg <| opt.extract (pos.next h) opt.endPos
-    handle <| opt.extract opt.startPos pos
-
-/-- Splits a long option of the form `--long=arg` into `--long` and `arg`. -/
-@[inline] public def longOptionOrEq (handle : String → m α) (opt : String) : m α :=
-  let pos := opt.find '='
-  if h : pos = opt.endPos then
-    handle opt
-  else do
-    consArg <| opt.extract (pos.next h) opt.endPos
-    handle <| opt.extract opt.startPos pos
-
-/-- Process a long option  of the form `--long`, `--long=arg`, `"--long arg"`. -/
-@[inline] public def longOption (handle : String → m α) : String → m α :=
-  longOptionOrEq <| longOptionOrSpace handle
-
-/-- Process a short option of the form `-x`, `-x=arg`, `-x arg`, or `-long`. -/
-@[inline] public def shortOption
-  (shortHandle : Char → m α) (longHandle : String → m α)
-  (opt : String)
-: m α :=
-  if opt.chars.length == 2 then -- `-x`
-    shortHandle (String.Pos.Raw.get opt ⟨1⟩)
-  else -- `-c(.+)`
-    match String.Pos.Raw.get opt ⟨2⟩ with
-    | '=' => -- `-x=arg`
-      shortOptionWithEq shortHandle opt
-    | ' ' => -- `"-x arg"`
-      shortOptionWithSpace shortHandle opt
-    | _   => -- `-long`
-      longHandle opt
-
-/--
-Process an option, short or long, using the given handlers.
-An option is an argument of length > 1 starting with a dash (`-`).
-An option may consume additional elements of the argument list.
--/
-@[inline] public def option (handlers : OptionHandlers m α) (opt : String) : m α :=
-  if String.Pos.Raw.get opt ⟨1⟩ == '-' then -- `--(.*)`
-    longOption handlers.long opt
-  else
-    shortOption handlers.short handlers.longShort opt
-
-/-- Process the head argument of the list using `handle` if it is an option. -/
-public def processLeadingOption (handle : String → m PUnit) : m PUnit := do
-  match (← getArgs) with
-  | [] => pure ()
-  | arg :: args =>
-    if arg.chars.length > 1 && String.Pos.Raw.get arg 0 == '-' then -- `-(.+)`
+/-- Process the head argument of the list using {lean}`handler` if it is an option. -/
+public def processLeadingOption (handler : OptHandler m) : m PUnit := do
+  if let arg :: args ← getArgs then
+    if h : IsOpt arg then -- `-(.+)`
       setArgs args
-      handle arg
+      handler arg h
 
 /--
 Process the leading options of the remaining argument list.
 Consumes empty leading arguments in the argument list.
 -/
-public partial def processLeadingOptions (handle : String → m PUnit) : m PUnit := do
+@[specialize handler]
+public partial def processLeadingOptions (handler : OptHandler m) : m PUnit := do
   if let arg :: args ← getArgs then
-    let len := arg.chars.length
-    if len > 1 && String.Pos.Raw.get arg 0 == '-' then -- `-(.+)`
+    if h0 : arg.startPos.IsAtEnd then -- skip empty leading args
       setArgs args
-      handle arg
-      processLeadingOptions handle
-    else if len == 0 then -- skip empty leading args
+      processLeadingOptions handler
+    else if h : arg.startPos.get h0 = '-' ∧ ¬ (arg.startPos.next h0).IsAtEnd then -- `-(.+)`
       setArgs args
-      processLeadingOptions handle
+      handler arg ⟨h0, h.1, h.2⟩
+      processLeadingOptions handler
 
-/-- Process every option and collect the remaining arguments into an `Array`. -/
-public partial def collectArgs
-  (option : String → m PUnit) (args : Array String := #[])
+/-- Process every argument in the command line argument list. -/
+@[inline] public partial def processArgs
+  (optHandler : OptHandler m) (argHandler : ArgHandler m)
+: m PUnit :=
+  let rec @[specialize optHandler argHandler] loop := do
+    if let some arg ← takeArg? then
+      if h0 : arg.startPos.IsAtEnd then -- skip empty args
+        loop
+      else if h : arg.startPos.get h0 = '-' ∧ ¬ (arg.startPos.next h0).IsAtEnd then -- `-(.+)`
+        optHandler arg ⟨h0, h.1, h.2⟩
+        loop
+      else
+        argHandler arg
+        loop
+  loop
+
+/-- Process every option and collect the remaining arguments into an {name}`Array`. -/
+@[specialize handler] public partial def collectArgs
+  (handler : OptHandler m) (args : Array String := #[])
 : m (Array String) := do
   if let some arg ← takeArg? then
-    let len := arg.chars.length
-    if len > 1 && String.Pos.Raw.get arg 0 == '-' then -- `-(.+)`
-      option arg
-      collectArgs option args
-    else if len == 0 then -- skip empty args
-      collectArgs option args
+    if h0 : arg.startPos.IsAtEnd then -- skip empty args
+      collectArgs handler args
+    else if h : arg.startPos.get h0 = '-' ∧ ¬ (arg.startPos.next h0).IsAtEnd then -- `-(.+)`
+      handler arg ⟨h0, h.1, h.2⟩
+      collectArgs handler args
     else
-      collectArgs option (args.push arg)
+      collectArgs handler (args.push arg)
   else
-    pure args
+    return args
 
 /-- Process every option in the argument list. -/
-@[inline] public def processOptions (handle : String → m PUnit) : m PUnit := do
-  setArgs (← collectArgs handle).toList
+@[inline] public def processOptions (handler : OptHandler m) : m PUnit := do
+  setArgs (← collectArgs handler).toList

--- a/src/lake/Lake/Util/Cli.lean
+++ b/src/lake/Lake/Util/Cli.lean
@@ -10,6 +10,7 @@ public import Init.Data.String.TakeDrop
 public import Init.Data.String.Search
 public import Init.Data.String.Length
 import Init.Data.String.Termination
+import Init.Data.ToString.Macro
 
 set_option doc.verso true
 set_option linter.missingDocs true
@@ -20,6 +21,57 @@ The abstract API used by Lake to parse command line arguments.
 -/
 
 namespace Lake
+
+/-! ## Argument-related Types -/
+
+/-- A List of command line arguments. -/
+@[expose] -- for codegen
+public def ArgList := List String
+
+/-- Type class for monads equipped with a command line argument list. -/
+public abbrev MonadArgs (m) := MonadStateOf ArgList m
+
+/-- A monad transformer to equip a monad with an argument list. -/
+public abbrev ArgsT := StateT ArgList
+
+/-- Run the monad with the command line arguments {lean}`args`. -/
+@[inline] public def ArgsT.run (args : List String) (self : ArgsT m α) : m (α × List String) :=
+  StateT.run self args
+
+/-- Run the monad with the command line arguments {lean}`args` and discard any unprocessed arguments. -/
+@[inline] public def ArgsT.run' [Functor m] (args : List String) (self : ArgsT m α) : m α :=
+  StateT.run' self args
+
+/-- A monadic callback for an arbitrary command line argument. -/
+@[expose] -- for codegen
+public def ArgHandler (m : Type u → Type v) (α : Type u := PUnit) :=
+  (arg : String) → m α
+
+/-- Constructs an argument handler from a monadic function operating on an arbitrary string. -/
+@[inline] public def ArgHandler.ofFn (fn : String → m α) : ArgHandler m α :=
+  fn
+
+/-! ## Monadic Argument Utilities -/
+
+/-- Get the remaining argument list. -/
+@[inline] public def getArgs [MonadArgs m] : m (List String) :=
+  get
+
+/-- Replace the argument list. -/
+@[inline] public def setArgs [MonadArgs m] (args : List String) : m PUnit :=
+  set (σ := ArgList) args
+
+/-- Take the head of the remaining argument list (or {lean}`none` if empty). -/
+@[inline] public def takeArg? [MonadArgs m] : m (Option String) :=
+  modifyGet fun | [] => (none, []) | arg :: args => (some arg, args)
+
+/-- Take the head of the remaining argument list (or {lean}`default` if empty). -/
+@[inline] public def takeArgD [MonadArgs m] (default : String) : m String :=
+  modifyGet fun | [] => (default, []) | arg :: args => (arg, args)
+
+/-- Take the remaining argument list, leaving only an empty list. -/
+@[inline] public def takeArgs [MonadArgs m] : m (List String) :=
+  modifyGet fun args => (args, [])
 
 /-! ## Option-related Types -/
 
@@ -53,30 +105,41 @@ public theorem offset_next_startPos (h : IsOpt arg) :
   (arg.startPos.next h.startPos_ne_endPos).offset = ⟨1⟩
 := by simp [String.Pos.Raw.ext_iff, h.get_startPos, Char.utf8Size]
 
-/-- The position in {lean}`arg` after the initial {lit}`-`. -/
-@[inline] public def afterStartPos (h : IsOpt arg) : arg.Pos :=
+/--
+The position in {lean}`arg` after the initial {lit}`-`
+(e.g., {lit}`x` in {lit}`-x` or {lit}`-` in {lit}`--long`).
+-/
+@[inline] public def shortPos (h : IsOpt arg) : arg.Pos :=
   arg.pos ⟨1⟩ <| by
     rw [← h.offset_next_startPos]
     apply String.Pos.isValid
 
-public theorem afterStartPos_eq (h : IsOpt arg) :
-  h.afterStartPos = arg.startPos.next h.startPos_ne_endPos
-:= by simp [afterStartPos, String.Pos.ext_iff, -String.Pos.offset_next, h.offset_next_startPos]
+public theorem shortPos_eq (h : IsOpt arg) :
+  h.shortPos = arg.startPos.next h.startPos_ne_endPos
+:= by simp [shortPos, String.Pos.ext_iff, -String.Pos.offset_next, h.offset_next_startPos]
 
-public theorem afterStartPos_ne_endPos (h : IsOpt arg) : h.afterStartPos ≠ arg.endPos := by
-  rw [afterStartPos_eq]
+public theorem shortPos_ne_endPos (h : IsOpt arg) : h.shortPos ≠ arg.endPos := by
+  rw [shortPos_eq]
   exact h.next_startPos_ne_endPos
 
 /-- The character in {lean}`arg` after the initial {lit}`-`. -/
 @[inline] public def shortChar (h : IsOpt arg) : Char :=
-  h.afterStartPos.get h.afterStartPos_ne_endPos
+  h.shortPos.get h.shortPos_ne_endPos
 
 /-- The position in {lean}`arg` after {lean}`shortChar` (e.g., {lit}`y` in {lit}`-xy`). -/
 @[inline] public def afterShortPos (h : IsOpt arg) : arg.Pos :=
-  h.afterStartPos.next h.afterStartPos_ne_endPos
+  h.shortPos.next h.shortPos_ne_endPos
 
 public theorem afterShortPos_eq (h : IsOpt arg) :
-  h.afterShortPos = h.afterStartPos.next h.afterStartPos_ne_endPos
+  h.afterShortPos = h.shortPos.next h.shortPos_ne_endPos
+:= by rfl
+
+/-- The first two characters of {lean}`arg` (e.g., {lit}`-x` in {lit}`-x=arg`). -/
+@[inline] public def shortOpt (h : IsOpt arg) : String.Slice :=
+  arg.sliceTo h.afterShortPos
+
+public theorem shortOpt_eq (h : IsOpt arg) :
+  h.shortOpt = arg.sliceTo h.afterShortPos
 := by rfl
 
 /-- The remainder of {lean}`arg` after {lean}`shortChar` (e.g., {lit}`=arg` in {lit}`-x=arg`). -/
@@ -89,14 +152,72 @@ public theorem shortTail_eq (h : IsOpt arg) :
 
 end IsOpt
 
-/-- A monadic callback for an arbitrary command line argument. -/
+/-- An optional command line option argument. -/
 @[expose] -- for codegen
-public def ArgHandler (m : Type u → Type v) (α : Type u := PUnit) :=
-  (arg : String) → m α
+public def OptArg := Option String.Slice
 
-/-- Constructs an argument handler from a monadic function operating on an arbitrary string. -/
-@[inline] public def ArgHandler.ofFn (fn : String → m α) : ArgHandler m α :=
-  fn
+/-- A monad transformer to equip a monad with an optional command line option argument. -/
+public abbrev OptArgT := ReaderT OptArg
+
+/-- Run the monad with the optional command line option argument {lean}`optArg?`. -/
+@[inline] public def OptArgT.run (optArg? : Option String.Slice) (self : OptArgT m α) : m α :=
+  ReaderT.run self optArg?
+
+/-- Type class for monads equipped with an optional command line option argument. -/
+public abbrev MonadOptArg (m) := MonadReaderOf OptArg m
+
+/-- A command line option. -/
+@[expose] -- for codegen
+public def Opt := String.Slice
+
+/-- Type class for monads equipped with an command line option. -/
+public abbrev MonadOpt (m) := MonadReaderOf Opt m
+
+/-- A monad transformer to equip a monad with a command line option and optional argument. -/
+public abbrev OptT (m) := ReaderT Opt <| OptArgT m
+
+/-- Run the monad with the command line option {lean}`opt` with optional argument {lean}`optArg?`. -/
+@[inline] public def OptT.run
+  (opt : String.Slice) (optArg? : Option String.Slice)  (self : OptT m α)
+: m α := self opt optArg?
+
+/-- The character of a command line short option (e.g., {lit}`x` of {lit}`-x`). -/
+@[expose] -- for codegen
+public def OptChar := Char
+
+/-- Type class for monads equipped with a command line short option. -/
+public abbrev MonadOptChar (m) := MonadReaderOf OptChar m
+
+/-- A monad transformer to equip a monad with a short option and optional argument. -/
+public abbrev ShortOptT (m) := ReaderT OptChar <| OptT m
+
+/-! ## Monadic Option Utilities -/
+
+/-- Get the command line option of the current context (e.g., in an option handler). -/
+@[inline] public def getOpt [MonadOpt m] : m String.Slice :=
+  read
+
+/--
+Get the character of the command line short option of the current context
+(e.g., in an option handler).
+-/
+@[inline] public def getOptChar [MonadOptChar m] : m Char :=
+  read
+
+/-- Get the option argument (if any). -/
+@[inline] public def getOptArg? [MonadOptArg m] : m (Option String.Slice) :=
+  read
+
+/-- Take the option argument or, if {lean}`none`, the head of the remaining argument list. -/
+@[inline] public def takeOptArg? [Monad m] [MonadOptArg m] [MonadArgs m] : m (Option String.Slice) := do
+  if let some arg ← getOptArg? then
+    return some arg
+  else if let some arg ← takeArg? then
+    return some arg
+  else
+    return none
+
+/-! ## Option Handler Types -/
 
 /-- A monadic callback for an arbitrary option (e.g., short or long). -/
 @[expose] -- for codegen
@@ -128,10 +249,27 @@ Construct an long option handler from a monadic function that takes the option a
   (fn : (opt : String.Slice) → (optArg? : Option String.Slice) → m α)
 : LongOptHandler m α := fn
 
+/--
+Construct an long option handler from a monadic action.
+
+The name of the option (e.g., {lit}`-long` or {lit}`--long`) is available via {name}`getOpt`.
+An argument for the option (e.g., {lit}`arg` in {lit}`--long=arg` or {lit}`--long arg`) can be
+accessed through {name}`takeOptArg?`.
+-/
+@[inline] public def LongOptHandler.ofM (x : OptT m α) : LongOptHandler m α := x
+
+/--
+Run the monad with the short option {lean}`opt` of character {lean}`optChar`
+with optional argument {lean}`optArg?`.
+-/
+@[inline] public def ShortOptT.run
+  (optChar : Char) (opt : String.Slice) (optArg? : Option String.Slice) (self : ShortOptT m α)
+: m α := self optChar opt optArg?
+
 /-- A monadic callback for a short option (e.g., {lit}`-x` or {lit}`-x=arg`). -/
 @[expose] -- for codegen
 public def ShortOptHandler (m : Type u → Type v) (α : Type u := PUnit) :=
-  (opt : Char) → (optArg? : Option String.Slice) → m α
+  (optChar : Char) → (opt : String.Slice) → (optArg? : Option String.Slice) → m α
 
 /--
 Constructs an short option handler from a monadic function that takes the option and its argument.
@@ -142,8 +280,19 @@ Constructs an short option handler from a monadic function that takes the option
 * {lit}`"-x foo bar"` => {lean}`fn 'x' (some "foo bar")`
 -/
 @[inline] public def ShortOptHandler.ofFn
-  (fn : (opt : Char) → (optArg? : Option String.Slice) → m α)
-: ShortOptHandler m α := fn
+  (fn : (optChar : Char) → (optArg? : Option String.Slice) → m α)
+: ShortOptHandler m α := fun c _ a? => fn c a?
+
+/--
+Construct an short option handler from a monadic action.
+
+The name of the option (e.g., {lit}`-x`) is available via {name}`getOpt`, and
+the character of the option (e.g., {lit}`x` in {lit}`-x`) is available via {name}`getOptChar`,
+
+An argument for the option (e.g., {lit}`arg` in {lit}`-x=arg` or {lit}`-x arg`) can be accessed
+through  {name}`takeOptArg?`.
+-/
+@[inline] public def ShortOptHandler.ofM (x : ShortOptT m α) : ShortOptHandler m α := x
 
 /-- A monadic callback for a long short option (e.g., {lit}`-long` or {lit}`-long=short`). -/
 @[expose] -- for codegen
@@ -173,7 +322,7 @@ Process a short option of the form {lit}`-xarg`.
 Can be used as the handler for {lean}`OptHandlers.longShort`.
 -/
 @[inline] public def shortOptionWithArg (handler : ShortOptHandler m α) : OptHandler m α := fun _ h =>
-  handler h.shortChar (some h.shortTail)
+  handler h.shortChar h.shortOpt (some h.shortTail)
 
 /--
 Process a multiple short options grouped together
@@ -182,18 +331,20 @@ Process a multiple short options grouped together
 Can be used as the handler for {lean}`OptHandlers.longShort`.
 -/
 @[inline] public def multiShortOption
-  [Monad m] (handler : ShortOptHandler m)
-: OptHandler m := fun arg h => do
-  let rec @[specialize handler] loop (p : arg.Pos) := do
-    if h : p.IsAtEnd then
-      return
+  [SeqRight m] (handler : ShortOptHandler m)
+: OptHandler m := fun arg h =>
+  let rec @[specialize handler] loop (p : arg.Pos) (h : ¬ p.IsAtEnd) :=
+    let p' := p.next h
+    let optChar := p.get h
+    let r := handler optChar s!"-{optChar}" none
+    if h' : p'.IsAtEnd then
+      r
     else
-      handler (p.get h) none
-      loop (p.next h)
+      r *> loop p' h'
   termination_by p
-  loop h.afterStartPos
+  loop h.shortPos h.shortPos_ne_endPos
 
-@[inline] private def splitLongOption
+@[inline] def splitLongOption
   {arg : String} (sepPos : arg.Pos)
   (longHandler : LongOptHandler m α)
   (noSepHandler : ArgHandler m α)
@@ -251,15 +402,15 @@ Can be used as the handler for {lean}`OptHandlers.longShort`.
   (shortHandler : ShortOptHandler m α) (longHandler : LongShortOptHandler m α)
 : OptHandler m α := fun arg h =>
   if h' : h.afterShortPos.IsAtEnd then -- `-x`
-    shortHandler h.shortChar none
+    shortHandler h.shortChar h.shortOpt none
   else -- `-c(.+)`
     let c := h.afterShortPos.get h'
     let nextPos := h.afterShortPos.next h'
     match c with
     | '=' => -- `-x=arg`
-      shortHandler h.shortChar (some <| arg.sliceFrom nextPos)
+      shortHandler h.shortChar h.shortOpt (some <| arg.sliceFrom nextPos)
     | ' ' => -- `"-x arg"`
-      shortHandler h.shortChar (some <| arg.sliceFrom nextPos |>.trimAsciiStart)
+      shortHandler h.shortChar h.shortOpt (some <| arg.sliceFrom nextPos |>.trimAsciiStart)
     | _   => -- `-long`
       longHandler arg h
 
@@ -274,54 +425,9 @@ An option may consume additional elements of the argument list.
   else
     shortOption handlers.short handlers.longShort arg h
 
-/-! ## Argument-related Types -/
-
-/-- A List of command line arguments. -/
-@[expose] public def ArgList := List String
-
-/-- Treats a list of strings as an argument list. -/
-@[inline] public def ArgList.mk (args : List String) : ArgList :=
-  args
-
-/-- A monad transformer to equip a monad with an argument list. -/
-public abbrev ArgsT := StateT ArgList
-
-/-- Run the monad with the command line arguments {lean}`args`. -/
-@[inline] public def ArgsT.run (args : List String) (self : ArgsT m α) : m (α × List String) :=
-  StateT.run self args
-
-/-- Run the monad with the command line arguments {lean}`args` and discard any unprocessed arguments. -/
-@[inline] public def ArgsT.run' [Functor m] (args : List String) (self : ArgsT m α) : m α :=
-  StateT.run' self args
-
-/-- Type class for monads equipped with a command line argument list. -/
-public abbrev MonadArgs (m) := MonadStateOf ArgList m
-
-/-! ## Argument Utilities -/
-
-variable [Monad m] [MonadArgs m]
-
-/-- Get the remaining argument list. -/
-@[inline] public def getArgs : m (List String) :=
-  get
-
-/-- Replace the argument list. -/
-@[inline] public def setArgs (args : List String) : m PUnit :=
-  set (ArgList.mk args)
-
-/-- Take the head of the remaining argument list (or {lean}`none` if empty). -/
-@[inline] public def takeArg? : m (Option String) :=
-  modifyGet fun | [] => (none, []) | arg :: args => (some arg, args)
-
-/-- Take the head of the remaining argument list (or {lean}`default` if empty). -/
-@[inline] public def takeArgD (default : String) : m String :=
-  modifyGet fun | [] => (default, []) | arg :: args => (arg, args)
-
-/-- Take the remaining argument list, leaving only an empty list. -/
-@[inline] public def takeArgs : m (List String) :=
-  modifyGet fun args => (args, [])
-
 /-! ## Argument Processors -/
+
+variable [MonadArgs m] [Monad m]
 
 /-- Process the head argument of the list using {lean}`handler` if it is an option. -/
 public def processLeadingOption (handler : OptHandler m) : m PUnit := do

--- a/src/lake/Lake/Util/Date.lean
+++ b/src/lake/Lake/Util/Date.lean
@@ -8,6 +8,7 @@ module
 prelude
 public import Init.Data.Ord.Basic
 public import Lean.Data.Json
+public import Init.Data.String.Defs
 import Lake.Util.String
 import Init.Data.String.Search
 import Init.Data.Iterators.Consumers.Collect
@@ -59,10 +60,9 @@ public def ofValid? (year month day : Nat) : Option Date := do
   guard (IsValidMonth month ∧ IsValidDay year month day)
   return {year, month, day}
 
-public def ofString? (t : String) : Option Date := do
-  match t.split '-' |>.toList with
-  | [y,m,d] =>
-    ofValid? (← y.toNat?) (← m.toNat?) (← d.toNat?)
+public def ofString? (s : String.Slice) : Option Date := do
+  match s.split '-' |>.toList with
+  | [y,m,d] => ofValid? (← y.toNat?) (← m.toNat?) (← d.toNat?)
   | _ => none
 
 public protected def fromJson? (j : Json) : Except String Date := do

--- a/src/lake/Lake/Util/MainM.lean
+++ b/src/lake/Lake/Util/MainM.lean
@@ -8,6 +8,7 @@ module
 prelude
 public import Lake.Util.Log
 public import Lake.Util.Exit
+import all Init.System.ST
 
 namespace Lake
 
@@ -20,6 +21,16 @@ Supports IO, logging, and `exit`.
 public instance : Monad MainM := inferInstanceAs (Monad (EIO ExitCode))
 public instance : MonadFinally MainM := inferInstanceAs (MonadFinally (EIO ExitCode))
 public instance : MonadLift BaseIO MainM := inferInstanceAs (MonadLift BaseIO (EIO ExitCode))
+
+/- Adaption of `LawfulMonad` for `EST` from batteries. -/
+instance : LawfulMonad (EST ε σ) := .mk' _
+  (id_map := fun x => funext fun v => by dsimp [Functor.map, EST.bind]; cases x v <;> rfl)
+  (pure_bind := fun x f => rfl)
+  (bind_assoc := fun f g x => funext fun v => by dsimp [Bind.bind, EST.bind]; cases f v <;> rfl)
+
+instance : LawfulMonad (EIO ε) := inferInstanceAs (LawfulMonad (EST ε IO.RealWorld))
+
+public instance : LawfulMonad MainM := inferInstanceAs (LawfulMonad (EIO ExitCode))
 
 namespace MainM
 

--- a/src/lake/Lake/Util/Version.lean
+++ b/src/lake/Lake/Util/Version.lean
@@ -9,11 +9,12 @@ prelude
 public import Lean.Data.Json
 public import Lake.Util.Date
 public import Init.Control.Do
-import Init.Data.String.TakeDrop
 import Lean.Data.Trie
+import Init.Data.String.TakeDrop
 import Init.Data.String.Search
-import Init.Omega
 import Init.Data.String.Length
+import Init.Data.String.Lemmas.Order
+import Init.Data.String.OrderInstances
 
 /-! # Version
 
@@ -26,30 +27,30 @@ namespace Lake
 
 /-! ## Parser Utils -/
 
+abbrev ParseM (s : String.Slice) (α) :=
+   EStateM String s.Pos α
+
 /--
 Parses version components separated by a `.` from the head of the string.
 
 Components are composed of alphanumerics or a `*`.
 -/
-@[inline] def parseVerComponents
-  (s : String)
-: EStateM String s.Pos (Array String.Slice) :=
-  fun p => go #[] p p (String.Pos.le_refl _)
+@[inline] def parseVerComponents (s : String.Slice) : ParseM s (Array String.Slice) :=
+  fun p => go #[] p p p.le_refl
 where
   go cs iniPos p (iniPos_le : iniPos ≤ p) :=
-    if h : p = s.endPos then
-      let c := String.Slice.mk s iniPos p iniPos_le
+    if h : p.IsAtEnd then
+      let c := s.slice iniPos p iniPos_le
       .ok (cs.push c) p
     else
       let c := p.get h
       if c == '.' then
-        let c := String.Slice.mk s iniPos p iniPos_le
+        let c := s.slice iniPos p iniPos_le
         go (cs.push c) (p.next h) (p.next h) (Nat.le_refl _)
       else if c.isAlphanum || c == '*' then
-        go cs iniPos (p.next h)
-          (String.Pos.le_trans iniPos_le (String.Pos.le_of_lt p.lt_next))
+        go cs iniPos (p.next h) (Std.le_trans iniPos_le p.le_next)
       else
-        let c := String.Slice.mk s iniPos p iniPos_le
+        let c := s.slice iniPos p iniPos_le
         .ok (cs.push c) p
   termination_by p
 
@@ -80,47 +81,46 @@ def parseVerComponent {σ} (what : String) (s? : Option String.Slice) : EStateM 
       | throw s!"invalid {what} version: expected numeral or wildcard, got '{s.copy}'"
     return .nat n
 
-def parseSpecialDescr? (s : String) : EStateM String s.Pos (Option String) := do
+def parseSpecialDescr? (s : String.Slice) : ParseM s (Option String.Slice) := do
   let p ← get
-  if h : p = s.endPos then
+  if h : p.IsAtEnd then
     return none
   else
     let c := p.get h
     if c == '-' then
       let p := p.next h
-      let p' := nextUntilWhitespace p
+      let ⟨p', h⟩ := nextUntilWhitespace p p p.le_refl
       set p'
-      let specialDescr := s.extract p p'
+      let specialDescr := s.slice p p' h
       return some specialDescr
     else
       return none
 where
-  nextUntilWhitespace p :=
-    if h : p = s.endPos then
-      p
+  nextUntilWhitespace p iniPos (iniPos_le : iniPos ≤ p) :=
+    if h : p.IsAtEnd then
+      Subtype.mk p iniPos_le
     else if (p.get h).isWhitespace then
-      p
+      Subtype.mk p iniPos_le
     else
-      nextUntilWhitespace (p.next h)
+      nextUntilWhitespace (p.next h) iniPos (Std.le_trans iniPos_le p.le_next)
   termination_by p
 
-def parseSpecialDescr (s : String) : EStateM String s.Pos String := do
+def parseSpecialDescr (s : String.Slice) : ParseM s String := do
   let some specialDescr ← parseSpecialDescr? s
     | return ""
   if specialDescr.isEmpty then
     throw "invalid version: '-' suffix cannot be empty"
-  return specialDescr
+  return specialDescr.copy
 
 @[inline] def runVerParse
-  (s : String) (x : (s : String) → EStateM String s.Pos α)
-  (startPos := s.startPos) (endPos := s.endPos)
+  (s : String.Slice) (x : (s : String.Slice) → ParseM s α)
 : Except String α :=
-  match x s startPos with
+  match x s s.startPos with
   | .ok v p =>
-    if p = endPos then
+    if p.IsAtEnd then
       return v
     else
-      let tail := p.offset.extract s endPos.offset
+      let tail := s.sliceFrom p
       throw s!"unexpected characters at end of version: {tail}"
   | .error e _ => throw e
 
@@ -140,7 +140,7 @@ public instance : LE SemVerCore := leOfOrd
 public instance : Min SemVerCore := minOfLe
 public instance : Max SemVerCore := maxOfLe
 
-def parseM (s : String) : EStateM String s.Pos SemVerCore := do
+def parseM (s : String.Slice) : ParseM s SemVerCore := do
   try
     let cs ← parseVerComponents s
     if h : cs.size = 3 then
@@ -204,12 +204,12 @@ public instance : LE StdVer := leOfOrd
 public instance : Min StdVer := minOfLe
 public instance : Max StdVer := maxOfLe
 
-public def parseM (s : String) : EStateM String s.Pos StdVer := do
+def parseM (s : String.Slice) : ParseM s StdVer := do
   let core ← SemVerCore.parseM s
   let specialDescr ← parseSpecialDescr s
   return {toSemVerCore := core, specialDescr}
 
-public def parse (s : String) : Except String StdVer := do
+@[inline] public def parse (s : String.Slice) : Except String StdVer := do
   runVerParse s parseM
 
 public protected def toString (ver : StdVer) : String :=
@@ -220,7 +220,7 @@ public protected def toString (ver : StdVer) : String :=
 
 public instance : ToString StdVer := ⟨StdVer.toString⟩
 public instance : ToJson StdVer := ⟨(·.toString)⟩
-public instance : FromJson StdVer := ⟨(do StdVer.parse <| ← fromJson? ·)⟩
+public instance : FromJson StdVer := ⟨(StdVer.parse =<< String.toSlice <$> fromJson? ·)⟩
 
 end StdVer
 
@@ -254,28 +254,26 @@ namespace ToolchainVer
 
 public instance : Coe LeanVer ToolchainVer := ⟨ToolchainVer.release⟩
 
-public def ofString (ver : String) : ToolchainVer := Id.run do
+public def ofString (ver : String.Slice) : ToolchainVer := Id.run do
   let colonPos := ver.find ':'
   let (origin, tag) :=
     if h : ¬colonPos.IsAtEnd then
-      let pos := colonPos.next h
-      (ver.extract ver.startPos colonPos, ver.extract pos ver.endPos)
+      (ver.sliceTo colonPos, ver.sliceFrom <| colonPos.next h)
     else
       ("", ver)
   let noOrigin := origin.isEmpty
-  if tag.startsWith "v" then
-    if let .ok ver := StdVer.parse (tag.drop 1).copy then
-      if noOrigin|| origin == defaultOrigin then
+  if let some ver := tag.dropPrefix? "v" then
+    if let .ok ver := StdVer.parse ver then
+      if noOrigin || origin == defaultOrigin then
         return .release ver
   else if let some rest := tag.dropPrefix? "nightly-" then
-    let rest := rest.toString
     -- Dates are exactly 10 characters (YYYY-MM-DD); anything after must be a -revK suffix
-    if let some date := Date.ofString? (rest.take 10).toString then
+    if let some date := Date.ofString? (rest.take 10) then
       let rev? : Option Nat := do
         let suffix ← (rest.drop 10).dropPrefix? "-rev"
-        suffix.toString.toNat?
+        suffix.toNat?
       -- Accept if no suffix (plain nightly) or valid -revK suffix
-      if rest.chars.length ≤ 10 || rev?.isSome then
+      if (rest.drop 10).isEmpty || rev?.isSome then
         if noOrigin then
           return .nightly date rev?
         else if let some suffix := origin.dropPrefix? defaultOrigin then
@@ -288,7 +286,7 @@ public def ofString (ver : String) : ToolchainVer := Id.run do
   else if let .ok ver := StdVer.parse ver then
     if noOrigin || origin == defaultOrigin then
       return .release ver
-  return .other ver
+  return .other ver.copy
 
 /-- Parse a toolchain from a `lean-toolchain` file. -/
 public def ofFile? (toolchainFile : FilePath) : IO (Option ToolchainVer) := do
@@ -306,7 +304,7 @@ public def ofFile? (toolchainFile : FilePath) : IO (Option ToolchainVer) := do
 
 public instance : ToString ToolchainVer := ⟨ToolchainVer.toString⟩
 public instance : ToJson ToolchainVer := ⟨(·.toString)⟩
-public instance : FromJson ToolchainVer := ⟨(ToolchainVer.ofString <$> fromJson? ·)⟩
+public instance : FromJson ToolchainVer := ⟨(ToolchainVer.ofString <$> String.toSlice <$> fromJson? ·)⟩
 
 public def blt (a b : ToolchainVer) : Bool :=
   match a, b with
@@ -335,7 +333,7 @@ public instance decLe (a b : ToolchainVer) : Decidable (a ≤ b) :=
 end ToolchainVer
 
 /-- Converts a toolchain version to its normal form (e.g., with an origin). -/
-public def normalizeToolchain (s : String) : String :=
+public def normalizeToolchain (s : String.Slice) : String :=
   ToolchainVer.ofString s |>.toString
 
 /-! ## DecodeVersion -/
@@ -347,7 +345,7 @@ public class DecodeVersion (α : Type u) where
 export DecodeVersion (decodeVersion)
 
 public instance : DecodeVersion SemVerCore := ⟨SemVerCore.parse⟩
-@[default_instance] public instance : DecodeVersion StdVer := ⟨StdVer.parse⟩
+@[default_instance] public instance : DecodeVersion StdVer := ⟨(StdVer.parse ·)⟩
 public instance : DecodeVersion ToolchainVer := ⟨(pure <| ToolchainVer.ofString ·)⟩
 
 /-! ## VerRange -/
@@ -358,17 +356,19 @@ deriving Repr, Inhabited
 
 namespace ComparatorOp
 
-def parseM
-  (s : String)
-: EStateM String s.Pos ComparatorOp := fun p =>
-  if let some (tk, op) := trie.matchPrefix s p.offset then
+def parseM (s : String.Slice) : ParseM s ComparatorOp := do
+  let p ← get
+  let r? := trie.matchPrefix s.str p.offset s.endExclusive.offset.byteIdx <|
+    String.byteIdx_rawEndPos ▸ String.Pos.Raw.le_iff.mp s.endExclusive.isValid.le_rawEndPos
+  if let some (tk, op) := r? then
     let p' := p.offset + tk
-    if h : p'.IsValid s then
-      .ok op (.mk p' h)
+    if h : p'.IsValidForSlice s then
+      set (s.pos p' h)
+      return op
     else
-      .error "(internal) comparison operator parse produced invalid position" p
+      throw "(internal) comparison operator parse produced invalid position"
   else
-    .error "expected comparison operator" p
+    throw "expected comparison operator"
 where trie :=
   let add sym cmp t := t.insert sym (sym, cmp)
   (∅ : Lean.Data.Trie (String × ComparatorOp))
@@ -382,9 +382,9 @@ where trie :=
   |> add "!=" .ne
   |> add "≠"  .ne
 
-public def ofString? (s : String) : Option ComparatorOp :=
+public def ofString? (s : String.Slice) : Option ComparatorOp :=
   match parseM s s.startPos with
-  | .ok op p => if p = s.endPos then some op else none
+  | .ok op p => if p.IsAtEnd then some op else none
   | .error .. => none
 
 public protected def toString (self : ComparatorOp) : String :=
@@ -419,17 +419,17 @@ public def wild : VerComparator :=
 
 public instance : Inhabited VerComparator := ⟨.wild⟩
 
-def parseM (s : String) : EStateM String s.Pos VerComparator := do
+def parseM (s : String.Slice) : ParseM s VerComparator := do
   let iniPos ← get
   let op ← ComparatorOp.parseM s
   if (← get) = s.endPos then
     throw s!"invalid comparison: expected version after `{s.sliceFrom iniPos}`"
   let core ← SemVerCore.parseM s
   if let some specialDescr ← parseSpecialDescr? s then
-    if  specialDescr.isEmpty then
+    if specialDescr.isEmpty then
       return {ver := .ofSemVerCore core, op, includeSuffixes := true}
     else
-      return {ver := .mk core specialDescr, op}
+      return {ver := .mk core specialDescr.copy, op}
   else
     return {ver := .ofSemVerCore core, op}
 
@@ -500,79 +500,76 @@ where
       ands.foldl (init := ands[0].toString) (start := 1) fun s v =>
         s!"{s}, {v}"
 
-@[inline] partial def parseM (s : String) : EStateM String s.Pos VerRange := do
-  let clauses ← go true #[] #[]
-  return {toString := s, clauses}
+partial def parseM (s : String.Slice) : ParseM s (Array (Array VerComparator)) := do
+  go true #[] #[]
 where
-  go needsRange ors (ands : Array VerComparator) p :=
-    if h : p = s.endPos then
+  go needsRange ors (ands : Array VerComparator) := do
+    let p ← get
+    if h : p.IsAtEnd then
       if needsRange || ands.size == 0 then
-        .error "expected version range" p
+        throw "expected version range"
       else
-        .ok (ors.push ands) p
+        return ors.push ands
     else
       let c := p.get h
       if c.isAlphanum || c == '*' then
-        match parseWild s ands p with
-        | .ok ands p =>
-          go false ors ands p
-        | .error e p => .error e p
+        let cs ← parseVerComponents s
+        -- Components are parsed first so their errors take precedence (e.g., on `v1-rc1`)
+        let ands ← parseWildComponents cs ands
+        if (← get).get?.any (· == '-') then
+          throw s!"invalid wildcard range: wildcard versions do not support suffixes"
+        go false ors ands
       else if c == '^' then
         let p := p.next h
-        if p = s.endPos then
-          .error  "invalid caret range: expected version after `^`" p
+        if p.IsAtEnd then
+          throw "invalid caret range: expected version after `^`"
         else
-          match parseCaret s ands p with
-          | .ok ands p =>
-            go false ors ands p
-          | .error e p => .error e p
+          set p
+          let ands ← parseCaret s ands
+          go false ors ands
       else if c == '~' then
         let p := p.next h
-        if p = s.endPos then
-          .error "invalid tilde range: expected version after `~`" p
+        if p.IsAtEnd then
+          throw "invalid tilde range: expected version after `~`"
         else
-          match parseTilde s ands p with
-          | .ok ands p =>
-            go false ors ands p
-          | .error e p => .error e p
+          set p
+          let ands ← parseTilde s ands
+          go false ors ands
       else if c.isWhitespace then
-        go needsRange ors ands (p.next h)
+        set (p.next h)
+        go needsRange ors ands
       else if c == ',' then
         if needsRange then
-          .error "expected version range" p
+          throw "expected version range"
         else
-          go true ors ands (p.next h)
+          set (p.next h)
+          go true ors ands
       else if c == '|' then
-        let p := p.next h
-        if h : p = s.endPos then
-          .error "expected '|' after first '|'" p
-        else if p.get h = '|' then
+        let p' := p.next h; set p'
+        if h : p'.IsAtEnd then
+          throw "expected '|' after first '|'"
+        else if p'.get h = '|' then
           if ands.size = 0 then
-            .error "expected version range" p
+            throw "expected version range"
           else
-            go true (ors.push ands) #[] (p.next h)
+            set (p'.next h)
+            go true (ors.push ands) #[]
         else
-          .error "expected '|' after first '|'" p
+          throw "expected '|' after first '|'"
       else
-        match VerComparator.parseM s p with
-        | .ok cmp p =>
-          go false ors (ands.push cmp) p
-        | .error e p => .error e p
+        let cmp ← VerComparator.parseM s
+        go false ors (ands.push cmp)
   @[inline] appendRange ands minVer maxVer (specialDescr := "") :=
     let minVer := StdVer.mk minVer specialDescr
     let maxVer := StdVer.ofSemVerCore maxVer
     ands.push {op := .ge, ver := minVer} |>.push {op := .lt, ver := maxVer, includeSuffixes := true}
-  parseWild (s : String) ands : EStateM String s.Pos _ := do
-    let cs ← parseVerComponents s -- `cs.size ≠ 0` due to how `parseWild` is called
-    -- Parsed first so its error is seen on arbitrary alphanumeric versions (e.g., `v1`, `1.o`, `beta`)
-    let major? ← parseVerComponent "major" cs[0]?
-    let minor? ← parseVerComponent "minor" cs[1]?
-    let patch? ← parseVerComponent "patch" cs[2]?
-    if (← get).get?.any (· == '-') then
-      throw "invalid wildcard range: wildcard versions do not support suffixes"
-    else if cs.size > 3 then
+  parseWildComponents {σ} (cs : Array String.Slice) ands : EStateM String σ  _ := do
+    if cs.size = 0 ∨ cs.size > 3 then
       throw s!"invalid wildcard range: incorrect number of components: got {cs.size}, expected 1-3"
     else
+      let major? ← parseVerComponent "major" cs[0]?
+      let minor? ← parseVerComponent "minor" cs[1]?
+      let patch? ← parseVerComponent "patch" cs[2]?
       match major?, minor?, patch? with
       | .nat major, .nat minor, .wild =>
         return appendRange ands {major, minor} {major, minor := minor + 1}
@@ -588,7 +585,7 @@ where
           otherwise, use '≥' to support it and future versions"
       | _, _, _ =>
         return ands.push .wild
-  parseCaret (s : String) ands : EStateM String s.Pos _ := do
+  parseCaret (s : String.Slice) ands : ParseM s _ := do
     let cs ← parseVerComponents s
     let specialDescr ← parseSpecialDescr s
     if h : cs.size = 1 then
@@ -617,7 +614,7 @@ where
         return appendRange ands {major, minor, patch}  {major := major + 1} specialDescr
     else
       throw s!"invalid caret range: incorrect number of components: got {cs.size}, expected 1-3"
-  parseTilde (s : String) ands : EStateM String s.Pos _ := do
+  parseTilde (s : String.Slice) ands : ParseM s _ := do
     let cs ← parseVerComponents s
     let specialDescr ← parseSpecialDescr s
     if h : cs.size = 1 then
@@ -635,8 +632,9 @@ where
     else
       throw s!"invalid tilde range: incorrect number of components: got {cs.size}, expected 1-3"
 
-public def parse (s : String) : Except String VerRange := do
-  runVerParse s parseM
+@[inline] public def parse (s : String) : Except String VerRange := do
+  let clauses ← runVerParse s parseM
+  return {toString := s, clauses}
 
 public instance : DecodeVersion VerRange := ⟨VerRange.parse⟩
 

--- a/tests/lake/tests/api/vers.lean
+++ b/tests/lake/tests/api/vers.lean
@@ -14,11 +14,11 @@ def checkParse (ver expected : String) : IO Unit :=  do
 
 def checkMatch (range : String) (accepts rejects : Array String) : IO Unit :=  do
   let range ← IO.ofExcept <| VerRange.parse range
-  accepts.forM fun s => do
+  for s in accepts do
     let ver ← IO.ofExcept <| StdVer.parse s
     unless range.test ver do
       throw <| IO.userError s!"invalid reject: expected\n  '{range}'\nto accept\n  '{s}'"
-  rejects.forM fun s => do
+  for s in rejects do
     let ver ← IO.ofExcept <| StdVer.parse s
     if range.test ver then
       throw <| IO.userError s!"invalid accept: expected\n  '{range}'\nto reject\n  '{s}'"

--- a/tests/lake/tests/logLevel/lakefile.lean
+++ b/tests/lake/tests/logLevel/lakefile.lean
@@ -7,7 +7,7 @@ package test
 Test logging in Lake CLI
 -/
 
-def cfgLogLv? := (get_config? log).bind LogLevel.ofString?
+def cfgLogLv? := (get_config? log).bind (LogLevel.ofString? ·)
 
 meta if cfgLogLv?.isSome then
   run_cmd Lean.log "bar" cfgLogLv?.get!.toMessageSeverity


### PR DESCRIPTION
This PR refactors Lake's CLI API and related code to make more use of the new String Slice API. It also generally expands the scope of the CLI API to cover argument parsing and some basic verification.

This is mostly a quality-of-life improvement for my use of the API in Lake and for adding additional CLI code in the future.
