### PR TITLE
fix: add missing import

### DIFF
--- a/src/Lean/ErrorExplanations.lean
+++ b/src/Lean/ErrorExplanations.lean
@@ -8,6 +8,7 @@ module
 prelude
 public import Lean.ErrorExplanations.CtorResultingTypeMismatch
 public import Lean.ErrorExplanations.DependsOnNoncomputable
+public import Lean.ErrorExplanations.InductionWithNoAlts
 public import Lean.ErrorExplanations.InductiveParamMismatch
 public import Lean.ErrorExplanations.InductiveParamMissing
 public import Lean.ErrorExplanations.InferBinderTypeFailed


### PR DESCRIPTION
This PR fixes an issue that prevented the manual from building due to the missing explanation of an error.
