### PR TITLE
feat: add seek and tell to FS.Handle

### DIFF
--- a/src/Init/System/IO.lean
+++ b/src/Init/System/IO.lean
@@ -9,6 +9,7 @@ prelude
 public import Init.System.IOError
 public import Init.System.FilePath
 public import Init.Data.Ord.UInt
+public import Init.Data.SInt
 import Init.Data.String.TakeDrop
 import Init.Data.String.Search
 
@@ -829,6 +830,85 @@ cursor includes buffered writes. However, buffered writes followed by `IO.FS.Han
 `IO.FS.Handle.flush` before truncating.
 -/
 @[extern "lean_io_prim_handle_truncate"] opaque truncate (h : @& Handle) : IO Unit
+
+/--
+Specifies the reference point for a file seek operation.
+
+**Operating System Specifis:**
+* Windows: [`_fseeki64](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fseek-fseeki64?view=msvc-170)
+* Linux: [`fseeko`](https://linux.die.net/man/3/fseeko)
+-/
+inductive SeekMode where
+  /--
+  Seek from the beginning of the file.
+
+  The read/write cursor is positioned relative to the beginning of the file.
+  An offset of zero is the first byte of the file. Offsets should be
+  non-negative.
+
+  * `fseeko` / `_fseeki64` value: `SEEK_SET`
+  -/
+  | start
+  /--
+  Seek from the current file position.
+
+  The read/write cursor is positioned relative to the current file position.
+  An offset of zero is the current byte of the file. Negative offsets are
+  permitted.
+
+  * `fseek` / `_fseeki64` value: `SEEK_CUR`
+  -/
+  | cur
+  /--
+  Seek from the end of the file.
+
+  The read/write cursor is positioned relative to the end of the file. An
+  offset of zero is one byte past the end of the file, while an offset of
+  (-1) is the is the last byte of the file. Positive offsets will move
+  past the end of the file.
+
+  * `fseek` / `_fseeki64` value: `SEEK_END`
+  -/
+  | end
+  deriving Repr, BEq, Inhabited
+
+/--
+Moves the read/write cursor to a specific position (FFI definition).
+
+The FFI definition of `seek` requires `(offset : UInt64)` due to FFI
+limitations. However, in reality `(offset : Int64)` is the correct type.
+This function avoids that confusion.
+-/
+@[extern "lean_io_prim_handle_seek"]
+private opaque primSeek (h : @& Handle) (mode : SeekMode) (offset : UInt64) : IO Unit
+
+/--
+Moves the read/write cursor to a specific position in the file.
+
+The `offset` is a signed 64-bit value in bytes. It is interpreted relative to:
+* the beginning of the file if `mode = .start`,
+* the current position if `mode = .cur`,
+* the end of the file if `mode = .end`.
+
+**Operating System Specifis:**
+* Windows: [`_fseeki64`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fseek-fseeki64?view=msvc-170)
+* Linux: [`fseeko`](https://linux.die.net/man/3/fseeko)
+-/
+@[inline] def seek (h : Handle) (mode : SeekMode) (offset : Int64) : IO Unit :=
+  primSeek h mode offset.toUInt64
+
+/--
+Returns the current position of the read/write cursor in the file.
+
+The position is measured in bytes from the beginning of the file.
+
+**Operating System Specifis:**
+* Windows: [`_ftelli64`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/ftell-ftelli64?view=msvc-170)
+* Linux: [`ftello`](https://linux.die.net/man/3/ftello)
+-/
+@[extern "lean_io_prim_handle_tell"]
+opaque tell (h : @& Handle) : IO UInt64
+
 /--
 Reads up to the given number of bytes from the handle. If the returned array is empty, an
 end-of-file marker (EOF) has been reached.

--- a/tests/lean/run/ioHandleSeek.lean
+++ b/tests/lean/run/ioHandleSeek.lean
@@ -1,0 +1,97 @@
+/-!
+# File Seeking and Position Tests
+
+These are tests for
+  - `IO.FS.Handle.seek`
+  - `IO.FS.Handle.tell`
+
+These provide random access to file contents via the POSIX `fseek` and
+`ftell` functions. We assume that the underlying POSIX implementation
+is correct.
+-/
+
+/--
+Run `action` on a temporary file containing the text `"Seek Test"`.
+
+This function:
+* creates a temporary directory
+* writes `"Seek Test"` to a temporary file within the directory
+* re-opens the file in read mode and passes its handle to `action`
+
+The temporary directory and file are cleaned up automatically when
+`action` finishes.
+-/
+private def withSeekTestFile (action : IO.FS.Handle → IO α) : IO α :=
+  IO.FS.withTempDir fun tmpDir => do
+    -- Create the file in write mode
+    let fileName := tmpDir / "seek_test_file.txt"
+    let contents := "Seek Test"
+    IO.FS.withFile fileName .write fun h => h.putStr contents
+
+    -- Open the file in read mode to run the action
+    IO.FS.withFile fileName .read action
+
+/--
+Test that, on opening a file, the initial position is zero.
+-/
+def testTell0 : IO Unit :=
+  withSeekTestFile fun h => do
+    let pos0 ← h.tell
+    assert! (pos0 == 0)
+
+#eval testTell0
+
+/--
+Test seeking relative to the start location.
+-/
+def testSeekStart : IO Unit :=
+  withSeekTestFile fun h => do
+    -- Go to byte 5, which is 'T'
+    h.seek .start 5
+    let pos5 ← h.tell
+    let byteArr ← h.read 1
+    assert! (pos5 == 5)
+    assert! (byteArr == "T".toUTF8)
+
+#eval testSeekStart
+
+/--
+Test seeking relative to the end location.
+-/
+def testSeekEnd : IO Unit :=
+  withSeekTestFile fun h => do
+    -- Go to byte -4 from the end, which is 'T'
+    h.seek .end (-4)
+    let pos5 ← h.tell
+    let byteArr ← h.read 1
+    assert! (pos5 == 5)
+    assert! (byteArr == "T".toUTF8)
+
+#eval testSeekEnd
+
+/--
+Test seeking relative to the current location.
+
+Both positive and negative offsets are tested.
+-/
+def testSeekCur : IO Unit :=
+  withSeekTestFile fun h => do
+    -- Go to byte 5 from the current location, which is 'T'
+    h.seek .cur 5
+    let pos5 ← h.tell
+    let byteArr5 ← h.read 1
+    assert! (pos5 == 5)
+    assert! (byteArr5 == "T".toUTF8)
+
+    -- After reading a byte, the position is advanced by 1.
+    let pos6 ← h.tell
+    assert! (pos6 == 6)
+
+    -- Go to byte -3 from the current location, which is 'k'
+    h.seek .cur (-3)
+    let pos3 ← h.tell
+    let byteArr3 ← h.read 1
+    assert! (pos3 == 3)
+    assert! (byteArr3 == "k".toUTF8)
+
+#eval testSeekCur


### PR DESCRIPTION
This PR adds `IO.FS.Handle.seek` and `IO.FS.Handle.tell` functions, to allow positioning the file cursor and querying its location respectively.
