### PR TITLE
feat: experiment: well-founded recursion on `Nat` to be semireducible by default

### DIFF
--- a/src/Lean/Elab/PreDefinition/WF/Unfold.lean
+++ b/src/Lean/Elab/PreDefinition/WF/Unfold.lean
@@ -238,7 +238,7 @@ public def mkUnfoldEq (preDef : PreDefinition) (unaryPreDefName : Name) (wfPrepr
 
 /--
 Derives the equational theorem for the individual functions from the equational
-theorem of `foo._unary` or `foo._binary`.
+theorem of `foo._unary` or `foo._mutual`.
 
 It should just be a specialization of that one, due to defeq.
 -/


### PR DESCRIPTION
This PR follows up on #7965 and makes functions defined by well-founded recursion on  `Nat` measure semireducible by default.

I have extracted this from the other PR due to performance regressions; maybe `@[irreducible]` is the right default after all.