### PR TITLE
fix: call `delete []` on array allocations

### DIFF
--- a/src/runtime/mpz.cpp
+++ b/src/runtime/mpz.cpp
@@ -304,7 +304,7 @@ void display(std::ostream & out, __mpz_struct const * v) {
         mpz_get_str(buffer, 10, v);
         out << buffer;
     } else {
-        std::unique_ptr<char> buffer(new char[sz]);
+        std::unique_ptr<char[]> buffer(new char[sz]);
         mpz_get_str(buffer.get(), 10, v);
         out << buffer.get();
     }


### PR DESCRIPTION
This PR fixes undefined behavior where `delete` (instead of `delete[]`) is called on an object allocated with `new[]`.