### PR TITLE
fix: improve "no library suggestions engine registered" error message

### DIFF
--- a/src/Lean/LibrarySuggestions/Basic.lean
+++ b/src/Lean/LibrarySuggestions/Basic.lean
@@ -403,9 +403,8 @@ opaque getSelector : MetaM (Option Selector)
 def select (m : MVarId) (c : Config := {}) : MetaM (Array Suggestion) := do
   let some selector ← getSelector |
     throwError "No library suggestions engine registered. \
-      (Note that Lean does not provide a default library suggestions engine, \
-      these must be provided by a downstream library, \
-      and configured using `set_library_suggestions`.)"
+      (Add `import Lean.LibrarySuggestions.Default` to use Lean's built-in engine, \
+      or use `set_library_suggestions` to configure a custom one.)"
   selector m c
 
 /-!

--- a/tests/lean/run/grind_suggestions.lean
+++ b/tests/lean/run/grind_suggestions.lean
@@ -1,7 +1,7 @@
 import Lean.LibrarySuggestions.Basic
 
 /--
-error: No library suggestions engine registered. (Note that Lean does not provide a default library suggestions engine, these must be provided by a downstream library, and configured using `set_library_suggestions`.)
+error: No library suggestions engine registered. (Add `import Lean.LibrarySuggestions.Default` to use Lean's built-in engine, or use `set_library_suggestions` to configure a custom one.)
 -/
 #guard_msgs in
 example : True := by


### PR DESCRIPTION
This PR improves the error message when no library suggestions engine is registered to recommend importing `Lean.LibrarySuggestions.Default` for the built-in engine.

**Before:**
```
No library suggestions engine registered. (Note that Lean does not provide a default library suggestions engine, these must be provided by a downstream library, and configured using `set_library_suggestions`.)
```

**After:**
```
No library suggestions engine registered. (Add `import Lean.LibrarySuggestions.Default` to use Lean's built-in engine, or use `set_library_suggestions` to configure a custom one.)
```

🤖 Prepared with Claude Code