### PR TITLE
feat: add chunking support to `par` and `par'` in `Lean.Elab.Parallel`

### DIFF
--- a/tests/lean/run/parallel_chunked.lean
+++ b/tests/lean/run/parallel_chunked.lean
@@ -1,0 +1,78 @@
+import Lean.Elab.Parallel
+
+/-!
+# Tests for chunked parallel execution
+
+Tests for the chunking support in `Lean.Elab.Parallel`.
+-/
+
+open Lean Core
+
+/-! ## CoreM tests -/
+
+/-- Test that par with maxTasks=0 (default) works like original -/
+def testCoreMParDefault : CoreM Unit := do
+  let jobs := (List.range 10).map fun i => pure i
+  let results ← CoreM.par jobs
+  let values := results.filterMap fun r =>
+    match r with
+    | .ok (v, _) => some v
+    | .error _ => none
+  assert! values == List.range 10
+
+/-- Test that par with chunking produces same results -/
+def testCoreMParChunked : CoreM Unit := do
+  let jobs := (List.range 20).map fun i => pure i
+  let results ← CoreM.par jobs (maxTasks := 4) (minChunkSize := 2)
+  let values := results.filterMap fun r =>
+    match r with
+    | .ok (v, _) => some v
+    | .error _ => none
+  -- Results should be in original order
+  assert! values == List.range 20
+
+/-- Test that par' with chunking works -/
+def testCoreMPar'Chunked : CoreM Unit := do
+  let jobs := (List.range 15).map fun i => pure (i * 2)
+  let results ← CoreM.par' jobs (maxTasks := 3) (minChunkSize := 2)
+  let values := results.filterMap fun r =>
+    match r with
+    | .ok v => some v
+    | .error _ => none
+  assert! values == (List.range 15).map (· * 2)
+
+/-- Test error handling in chunks -/
+def testCoreMParChunkedErrors : CoreM Unit := do
+  let jobs := (List.range 10).map fun i =>
+    if i == 5 then throwError "error at 5"
+    else pure i
+  let results ← CoreM.par' jobs (maxTasks := 3) (minChunkSize := 2)
+  -- Should have 9 successes and 1 error
+  let successes := results.filter fun r => match r with | .ok _ => true | .error _ => false
+  let errors := results.filter fun r => match r with | .ok _ => false | .error _ => true
+  assert! successes.length == 9
+  assert! errors.length == 1
+
+#eval do
+  let env ← importModules #[{ module := `Init }] {} 0
+  let (_, _) ← testCoreMParDefault.toIO { fileName := "", fileMap := default } { env }
+  IO.println "testCoreMParDefault passed"
+
+#eval do
+  let env ← importModules #[{ module := `Init }] {} 0
+  let (_, _) ← testCoreMParChunked.toIO { fileName := "", fileMap := default } { env }
+  IO.println "testCoreMParChunked passed"
+
+#eval do
+  let env ← importModules #[{ module := `Init }] {} 0
+  let (_, _) ← testCoreMPar'Chunked.toIO { fileName := "", fileMap := default } { env }
+  IO.println "testCoreMPar'Chunked passed"
+
+#eval do
+  let env ← importModules #[{ module := `Init }] {} 0
+  let (_, _) ← testCoreMParChunkedErrors.toIO { fileName := "", fileMap := default } { env }
+  IO.println "testCoreMParChunkedErrors passed"
+
+/-! ## All tests passed -/
+
+#eval IO.println "All parallel_chunked tests passed!"


### PR DESCRIPTION
This PR adds optional chunking support to the `par` and `par'` functions in `Lean.Elab.Parallel` for CoreM, MetaM, TermElabM, and TacticM. This reduces task creation overhead when there are many small jobs by grouping them into chunks that run sequentially within each parallel task.

## New optional parameters

- `maxTasks : Nat := 0` - Maximum number of parallel tasks (0 = no limit, original behavior)
- `minChunkSize : Nat := 1` - Minimum jobs per chunk

## Example

With 1000 jobs and `maxTasks := 128, minChunkSize := 8`:
- Chunk size = max(8, ceil(1000/128)) = 8
- Creates ~125 parallel tasks instead of 1000

## Backward compatibility

Default behavior (maxTasks = 0) is unchanged - one task per job. Existing code continues to work without modification.

🤖 Prepared with Claude Code