### PR TITLE
fix: ensure padding bytes for `lean::mpz` objects in olean files are zero

### DIFF
--- a/src/runtime/compact.cpp
+++ b/src/runtime/compact.cpp
@@ -290,7 +290,12 @@ void object_compactor::insert_mpz(object * o) {
     size_t data_sz = sizeof(mpn_digit) * to_mpz(o)->m_value.m_size;
     size_t sz      = sizeof(mpz_object) + data_sz;
     mpz_object * new_o = (mpz_object *)alloc(sz);
-    memcpy(new_o, to_mpz(o), sizeof(mpz_object));
+    // Manually copy the `mpz_object` to ensure `mpz` struct padding is left as
+    // zero as prepared by `object_compactor::alloc`. `memcpy` would copy the
+    // padding and lead to non-deterministic outputs.
+    new_o->m_header = to_mpz(o)->m_header;
+    new_o->m_value.m_sign = to_mpz(o)->m_value.m_sign;
+    new_o->m_value.m_size = to_mpz(o)->m_value.m_size;
     lean_set_non_heap_header((lean_object*)new_o, sz, LeanMPZ, 0);
     void * data = reinterpret_cast<char*>(new_o) + sizeof(mpz_object);
     memcpy(data, to_mpz(o)->m_value.m_digits, data_sz);

--- a/src/runtime/compact.h
+++ b/src/runtime/compact.h
@@ -53,6 +53,7 @@ public:
     void operator()(object * o);
     size_t size() const { return static_cast<char*>(m_end) - static_cast<char*>(m_begin); }
     void const * data() const { return m_begin; }
+    // Allocate `sz` bytes of zeroed memory.
     void * alloc(size_t sz);
 };
 


### PR DESCRIPTION
This PR ensures that `Nat`s in `.olean` files use a deterministic serialization in the case where `LEAN_USE_GMP` is not set.

This is a simplified version of https://github.com/leanprover/lean4/pull/2908.