### PR TITLE
refactor: make MatchEqs a leaf module

### DIFF
--- a/src/Lean/Elab/BuiltinEvalCommand.lean
+++ b/src/Lean/Elab/BuiltinEvalCommand.lean
@@ -8,6 +8,7 @@ module
 prelude
 public import Lean.Elab.MutualDef
 import Lean.Compiler.Options
+import Lean.Meta.Reduce
 
 public section
 

--- a/src/Lean/Elab/Match.lean
+++ b/src/Lean/Elab/Match.lean
@@ -12,6 +12,7 @@ public import Lean.Elab.BindersUtil
 public import Lean.Elab.PatternVar
 public import Lean.Elab.Quotation.Precheck
 public import Lean.Elab.SyntheticMVars
+import Lean.Meta.Match.NamedPatterns
 
 public section
 

--- a/src/Lean/Elab/PreDefinition/Eqns.lean
+++ b/src/Lean/Elab/PreDefinition/Eqns.lean
@@ -8,9 +8,11 @@ module
 prelude
 
 import Lean.Elab.PreDefinition.EqnsUtils
-import Lean.Meta.Match.MatchEqs
+import Lean.Meta.Match.MatchEqsExt
+import Lean.Meta.Match.NamedPatterns
 import Lean.Meta.Tactic.Simp.Main
 import Lean.Meta.Tactic.Split
+import Lean.Meta.Tactic.CasesOnStuckLHS
 
 /-!
 This module implements the generation of equational theorems, given unfolding theorems.

--- a/src/Lean/Elab/PreDefinition/EqnsUtils.lean
+++ b/src/Lean/Elab/PreDefinition/EqnsUtils.lean
@@ -9,7 +9,9 @@ module
 prelude
 public import Lean.Meta.Basic
 import Lean.Meta.Tactic.Split
-import Lean.Meta.Match.MatchEqs
+import Lean.Meta.Match.Match
+import Lean.Meta.Tactic.Refl
+import Lean.Meta.Tactic.Delta
 import Lean.Meta.Tactic.SplitIf
 
 /-!

--- a/src/Lean/Elab/PreDefinition/Structural/Eqns.lean
+++ b/src/Lean/Elab/PreDefinition/Structural/Eqns.lean
@@ -10,10 +10,8 @@ public import Lean.Elab.PreDefinition.FixedParams
 import Lean.Elab.PreDefinition.EqnsUtils
 import Lean.Meta.Tactic.Split
 import Lean.Meta.Tactic.Simp.Main
-import Lean.Elab.PreDefinition.Basic
-import Lean.Elab.PreDefinition.Structural.Basic
-import Lean.Meta.Match.MatchEqs
-import Lean.Meta.Tactic.Rewrite
+import Lean.Meta.Tactic.Delta
+import Lean.Meta.Tactic.CasesOnStuckLHS
 
 namespace Lean.Elab
 open Meta

--- a/src/Lean/Elab/PreDefinition/WF/GuessLex.lean
+++ b/src/Lean/Elab/PreDefinition/WF/GuessLex.lean
@@ -17,6 +17,7 @@ public import Lean.Elab.PreDefinition.TerminationMeasure
 public import Lean.Elab.PreDefinition.FixedParams
 public import Lean.Elab.PreDefinition.WF.Basic
 public import Lean.Data.Array
+import Lean.Meta.Tactic.Refl
 
 public section
 

--- a/src/Lean/Elab/Tactic/Do/VCGen/Split.lean
+++ b/src/Lean/Elab/Tactic/Do/VCGen/Split.lean
@@ -9,6 +9,7 @@ prelude
 public import Lean.Meta.Tactic.FunInd
 public import Lean.Meta.Match.MatcherApp.Transform
 import Lean.Meta.Tactic.Simp.Rewrite
+import Lean.Meta.Tactic.Assumption
 
 public section
 

--- a/src/Lean/Meta/Match/AltTelescopes.lean
+++ b/src/Lean/Meta/Match/AltTelescopes.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2021 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+module
+
+prelude
+public import Lean.Meta.Basic
+public import Lean.Meta.Match.MatcherInfo
+import Lean.Meta.Match.NamedPatterns
+import Lean.Meta.MatchUtil
+import Lean.Meta.AppBuilder
+
+public section
+
+/-!
+This module has telescope functions for macher alts. They are primariliy used
+in `Match.MatchEqs`, but also in `MatcherApp.Transform`, hence the sparate module.
+-/
+
+namespace Lean.Meta.Match
+/--
+  Similar to `forallTelescopeReducing`, but
+
+  1. Eliminates arguments for named parameters and the associated equation proofs.
+
+  2. Instantiate the `Unit` parameter of an otherwise argumentless alternative.
+
+  It does not handle the equality parameters associated with the `h : discr` notation.
+
+  The continuation `k` takes four arguments `ys args mask type`.
+  - `ys` are variables for the hypotheses that have not been eliminated.
+  - `args` are the arguments for the alternative `alt` that has type `altType`. `ys.size <= args.size`
+  - `mask[i]` is true if the hypotheses has not been eliminated. `mask.size == args.size`.
+  - `type` is the resulting type for `altType`.
+
+  We use the `mask` to build the splitter proof. See `mkSplitterProof`.
+
+  This can be used to use the alternative of a match expression in its splitter.
+-/
+public partial def forallAltVarsTelescope (altType : Expr) (altInfo : AltParamInfo)
+  (k : (patVars : Array Expr) → (args : Array Expr) → (mask : Array Bool) → (type : Expr) → MetaM α) : MetaM α := do
+  assert! altInfo.numOverlaps = 0
+  if altInfo.hasUnitThunk then
+    let type ← whnfForall altType
+    let type ← Match.unfoldNamedPattern type
+    let type ← instantiateForall type #[mkConst ``Unit.unit]
+    k #[] #[mkConst ``Unit.unit] #[false] type
+  else
+    go #[] #[] #[] 0 altType
+where
+  go (ys : Array Expr) (args : Array Expr) (mask : Array Bool) (i : Nat) (type : Expr) : MetaM α := do
+    let type ← whnfForall type
+
+    if i < altInfo.numFields then
+      let Expr.forallE n d b .. := type
+        | throwError "expecting {altInfo.numFields} parameters, but found type{indentExpr altType}"
+
+      let d ← Match.unfoldNamedPattern d
+      withLocalDeclD n d fun y => do
+        let typeNew := b.instantiate1 y
+        if let some (_, lhs, rhs) ← matchEq? d then
+          if lhs.isFVar && ys.contains lhs && args.contains lhs && isNamedPatternProof typeNew y then
+              let some j  := ys.finIdxOf? lhs | unreachable!
+              let ys      := ys.eraseIdx j
+              let some k  := args.idxOf? lhs | unreachable!
+              let mask    := mask.set! k false
+              let args    := args.map fun arg => if arg == lhs then rhs else arg
+              let arg     ← mkEqRefl rhs
+              let typeNew := typeNew.replaceFVar lhs rhs
+              return ← withReplaceFVarId lhs.fvarId! rhs do
+              withReplaceFVarId y.fvarId! arg do
+                go ys (args.push arg) (mask.push false) (i+1) typeNew
+        go (ys.push y) (args.push y) (mask.push true) (i+1) typeNew
+    else
+      let type ← Match.unfoldNamedPattern type
+      k ys args mask type
+
+  isNamedPatternProof (type : Expr) (h : Expr) : Bool :=
+    Option.isSome <| type.find? fun e =>
+      if let some e := Match.isNamedPattern? e then
+        e.appArg! == h
+      else
+        false
+
+
+/--
+  Extension of `forallAltTelescope` that continues further:
+
+  Equality parameters associated with the `h : discr` notation are replaced with `rfl` proofs.
+  Recall that this kind of parameter always occurs after the parameters corresponding to pattern
+  variables.
+
+  The continuation `k` takes four arguments `ys args mask type`.
+  - `ys` are variables for the hypotheses that have not been eliminated.
+  - `eqs` are variables for equality hypotheses associated with discriminants annotated with `h : discr`.
+  - `args` are the arguments for the alternative `alt` that has type `altType`. `ys.size <= args.size`
+  - `mask[i]` is true if the hypotheses has not been eliminated. `mask.size == args.size`.
+  - `type` is the resulting type for `altType`.
+
+  We use the `mask` to build the splitter proof. See `mkSplitterProof`.
+
+  This can be used to use the alternative of a match expression in its splitter.
+-/
+public partial def forallAltTelescope (altType : Expr) (altInfo : AltParamInfo) (numDiscrEqs : Nat)
+    (k : (ys : Array Expr) → (eqs : Array Expr) → (args : Array Expr) → (mask : Array Bool) → (type : Expr) → MetaM α)
+    : MetaM α := do
+  forallAltVarsTelescope altType altInfo fun ys args mask altType => do
+    go ys #[] args mask 0 altType
+where
+  go (ys : Array Expr) (eqs : Array Expr) (args : Array Expr) (mask : Array Bool) (i : Nat) (type : Expr) : MetaM α := do
+    let type ← whnfForall type
+    if i < numDiscrEqs then
+      let Expr.forallE n d b .. := type
+        | throwError "expecting {numDiscrEqs} equalities, but found type{indentExpr altType}"
+      let arg ← if let some (_, _, rhs) ← matchEq? d then
+        mkEqRefl rhs
+      else if let some (_, _, _, rhs) ← matchHEq? d then
+        mkHEqRefl rhs
+      else
+        throwError "unexpected match alternative type{indentExpr altType}"
+      withLocalDeclD n d fun eq => do
+        let typeNew := b.instantiate1 eq
+        go ys (eqs.push eq) (args.push arg) (mask.push false) (i+1) typeNew
+    else
+      let type ← unfoldNamedPattern type
+      k ys eqs args mask type

--- a/src/Lean/Meta/Match/Basic.lean
+++ b/src/Lean/Meta/Match/Basic.lean
@@ -8,24 +8,11 @@ module
 prelude
 public import Lean.Meta.CollectFVars
 public import Lean.Meta.Match.CaseArraySizes
+import Lean.Meta.Match.NamedPatterns
 
 public section
 
 namespace Lean.Meta.Match
-
-def mkNamedPattern (x h p : Expr) : MetaM Expr :=
-  mkAppM ``namedPattern #[x, p, h]
-
-def isNamedPattern (e : Expr) : Bool :=
-  let e := e.consumeMData
-  e.getAppNumArgs == 4 && e.getAppFn.consumeMData.isConstOf ``namedPattern
-
-def isNamedPattern? (e : Expr) : Option Expr :=
-  let e := e.consumeMData
-  if e.getAppNumArgs == 4 && e.getAppFn.consumeMData.isConstOf ``namedPattern then
-    some e
-  else
-    none
 
 inductive Pattern : Type where
   | inaccessible (e : Expr) : Pattern

--- a/src/Lean/Meta/Match/MatchEqsExt.lean
+++ b/src/Lean/Meta/Match/MatchEqsExt.lean
@@ -42,10 +42,18 @@ def registerMatchEqns (matchDeclName : Name) (matchEqns : MatchEqns) : CoreM Uni
   }
 
 /-
-  Forward definition. We want to use `getEquationsFor` in the simplifier,
- `getEquationsFor` depends on `mkEquationsFor` which uses the simplifier. -/
+Forward definition of `getEquationsForImpl`.
+We want to use `getEquationsFor` in the simplifier,
+getEquationsFor` depends on `mkEquationsFor` which uses the simplifier.
+-/
 @[extern "lean_get_match_equations_for"]
 opaque getEquationsFor (matchDeclName : Name) : MetaM MatchEqns
+
+/-
+Forward definition of `genMatchCongrEqnsImpl`.
+-/
+@[extern "lean_get_congr_match_equations_for"]
+opaque genMatchCongrEqns (matchDeclName : Name) : MetaM (Array Name)
 
 /--
 Returns `true` if `declName` is the name of a `match` equational theorem.

--- a/src/Lean/Meta/Match/MatcherApp/Transform.lean
+++ b/src/Lean/Meta/Match/MatcherApp/Transform.lean
@@ -7,8 +7,11 @@ Authors: Leonardo de Moura, Joachim Breitner
 module
 
 prelude
-public import Lean.Meta.Match
-public import Lean.Meta.Tactic.Split
+public import Lean.Meta.Match.MatcherApp.Basic
+public import Lean.Meta.Match.MatchEqsExt
+public import Lean.Meta.Match.AltTelescopes
+import Lean.Meta.Tactic.Split
+import Lean.Meta.Tactic.Refl
 
 public section
 

--- a/src/Lean/Meta/Match/NamedPatterns.lean
+++ b/src/Lean/Meta/Match/NamedPatterns.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2021 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+module
+
+prelude
+public import Lean.Meta.Basic
+import Lean.Meta.AppBuilder
+
+/-!
+Helper functions around named patterns
+-/
+
+namespace Lean.Meta.Match
+
+public def mkNamedPattern (x h p : Expr) : MetaM Expr :=
+  mkAppM ``namedPattern #[x, p, h]
+
+public def isNamedPattern (e : Expr) : Bool :=
+  let e := e.consumeMData
+  e.getAppNumArgs == 4 && e.getAppFn.consumeMData.isConstOf ``namedPattern
+
+public def isNamedPattern? (e : Expr) : Option Expr :=
+  let e := e.consumeMData
+  if e.getAppNumArgs == 4 && e.getAppFn.consumeMData.isConstOf ``namedPattern then
+    some e
+  else
+    none
+
+public def unfoldNamedPattern (e : Expr) : MetaM Expr := do
+  let visit (e : Expr) : MetaM TransformStep := do
+    if let some e := isNamedPattern? e then
+      if let some eNew ← unfoldDefinition? e then
+        return TransformStep.visit eNew
+    return .continue
+  Meta.transform e (pre := visit)

--- a/src/Lean/Meta/MatchUtil.lean
+++ b/src/Lean/Meta/MatchUtil.lean
@@ -44,6 +44,18 @@ def matchEqHEq? (e : Expr) : MetaM (Option (Expr × Expr × Expr)) := do
   else
     return none
 
+/--
+  Return `some (α, lhs)` if `e` is of the form `@Eq α lhs rhs` or `@HEq α lhs β rhs`
+-/
+def matchEqHEqLHS? (e : Expr) : MetaM (Option (Expr × Expr)) := do
+  if let some (α, lhs, _rhs) ← matchEq? e then
+    return some (α, lhs)
+  else if let some (α, lhs, _β, _rhs) ← matchHEq? e then
+    return some (α, lhs)
+  else
+    return none
+
+
 def matchFalse (e : Expr) : MetaM Bool := do
   testHelper e fun e => return e.isFalse
 

--- a/src/Lean/Meta/Tactic/CasesOnStuckLHS.lean
+++ b/src/Lean/Meta/Tactic/CasesOnStuckLHS.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2021 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+module
+
+prelude
+public import Lean.Meta.Basic
+import Lean.Meta.Tactic.SplitIf
+
+namespace Lean.Meta
+
+/-!
+This module provides the `casesOnStuckLHS` tactic, used by
+* match equation compilation
+* equation compilation for recursive functions
+-/
+
+/--
+  Helper method for `proveCondEqThm`. Given a goal of the form `C.rec ... xMajor = rhs`,
+  apply `cases xMajor`. -/
+public partial def casesOnStuckLHS (mvarId : MVarId) : MetaM (Array MVarId) := do
+  let target ← mvarId.getType
+  if let some (_, lhs) ← matchEqHEqLHS? target then
+    if let some fvarId ← findFVar? lhs then
+      return (←  mvarId.cases fvarId).map fun s => s.mvarId
+  throwError "'casesOnStuckLHS' failed"
+where
+  findFVar? (e : Expr) : MetaM (Option FVarId) := do
+    match e.getAppFn with
+    | Expr.proj _ _ e => findFVar? e
+    | f =>
+      if !f.isConst then
+        return none
+      else
+        let declName := f.constName!
+        let args := e.getAppArgs
+        match (← getProjectionFnInfo? declName) with
+        | some projInfo =>
+          if projInfo.numParams < args.size then
+            findFVar? args[projInfo.numParams]!
+          else
+            return none
+        | none =>
+          matchConstRec f (fun _ => return none) fun recVal _ => do
+            if recVal.getMajorIdx >= args.size then
+              return none
+            let major := args[recVal.getMajorIdx]!.consumeMData
+            if major.isFVar then
+              return some major.fvarId!
+            else
+              return none
+
+public def casesOnStuckLHS? (mvarId : MVarId) : MetaM (Option (Array MVarId)) := do
+  try casesOnStuckLHS mvarId catch _ => return none

--- a/src/Lean/Meta/Tactic/FunInd.lean
+++ b/src/Lean/Meta/Tactic/FunInd.lean
@@ -18,6 +18,8 @@ import Lean.Meta.Tactic.ElimInfo
 import Lean.Meta.Tactic.FunIndInfo
 import Lean.Data.Array
 import Lean.Meta.Tactic.Simp.Rewrite
+import Lean.Meta.Tactic.Refl
+import Lean.Meta.Tactic.Replace
 
 /-!
 This module contains code to derive, from the definition of a recursive function (structural or

--- a/src/Lean/Meta/Tactic/Grind/Internalize.lean
+++ b/src/Lean/Meta/Tactic/Grind/Internalize.lean
@@ -8,7 +8,7 @@ prelude
 public import Lean.Meta.Tactic.Grind.Types
 import Lean.Meta.Tactic.Grind.Arith.Cutsat.Types
 import Lean.Meta.Tactic.Grind.Arith.IsRelevant
-import Lean.Meta.Match.MatchEqs
+import Lean.Meta.Match.MatchEqsExt
 import Lean.Meta.Tactic.Grind.Util
 import Lean.Meta.Tactic.Grind.Beta
 import Lean.Meta.Tactic.Grind.MatchCond
@@ -17,6 +17,7 @@ import Lean.Meta.Tactic.Grind.Proof
 import Lean.Meta.Tactic.Grind.MarkNestedSubsingletons
 import Lean.Meta.Tactic.Grind.PropagateInj
 import Lean.Meta.Tactic.Grind.FunCC
+import Lean.Util.CollectLevelParams
 public section
 namespace Lean.Meta.Grind
 


### PR DESCRIPTION
This PR makes `Match.MatchEqs` a leaf module, to be less restricted in
which features we can use there.
