### PR TITLE
feat: simpler error message when sorries complicate universe inference

### DIFF
--- a/src/Lean/Elab/MutualInductive.lean
+++ b/src/Lean/Elab/MutualInductive.lean
@@ -614,6 +614,10 @@ private def collectUniverses (views : Array InductiveView) (r : Level) (rOffset 
   let (_, acc) ← go |>.run {}
   if !acc.badLevels.isEmpty then
     withViewTypeRef views do
+      if indTypes.any (·.ctors.any (·.type.hasSyntheticSorry)) then
+        throwError "Type cannot be determined: some part of the definition contains an error"
+      if indTypes.any (·.ctors.any (·.type.hasSorry)) then
+        throwError "Type cannot be determined: some part of the definition contains `sorry`"
       let goodPart := Level.addOffset (Level.mkNaryMax acc.levels.toList) rOffset
       let badPart := Level.mkNaryMax (acc.badLevels.toList.map fun (u, k) => Level.max (Level.ofNat rOffset) (Level.addOffset u (rOffset - k)))
       let inferred := (Level.max goodPart badPart).normalize

--- a/tests/lean/univInference.lean
+++ b/tests/lean/univInference.lean
@@ -90,3 +90,15 @@ def ex7 (h : Stx = Nat) : True :=
   trivial
 
 end Induct
+
+inductive Sorry1 where
+  | x (a : Bool)
+  | y (b : sorry)
+
+inductive Sorry2 where
+  | x (a : Array Sorry2)
+  | y (b : sorry)
+
+inductive Sorry3 where
+  | x (a : Array Sorry3)
+  | y {x} (b : x Err3)

--- a/tests/lean/univInference.lean.expected.out
+++ b/tests/lean/univInference.lean.expected.out
@@ -31,3 +31,26 @@ univInference.lean:81:48-81:62: error: Invalid universe polymorphic resulting ty
   Sort (max u v)
 
 Hint: A possible solution is to use levels of the form `max 1 _` or `_ + 1` to ensure the universe is of the form `Type _`
+univInference.lean:94:0-96:17: warning: declaration uses 'sorry'
+univInference.lean:94:0-96:17: warning: declaration uses 'sorry'
+univInference.lean:94:0-96:17: warning: declaration uses 'sorry'
+univInference.lean:94:0-96:17: warning: declaration uses 'sorry'
+univInference.lean:94:0-96:17: warning: declaration uses 'sorry'
+univInference.lean:94:0-96:17: warning: declaration uses 'sorry'
+univInference.lean:94:0-96:17: warning: declaration uses 'sorry'
+univInference.lean:94:0-96:17: warning: declaration uses 'sorry'
+univInference.lean:94:0-96:17: warning: declaration uses 'sorry'
+univInference.lean:94:0-96:17: warning: declaration uses 'sorry'
+univInference.lean:94:0-96:17: warning: declaration uses 'sorry'
+univInference.lean:94:0-96:17: warning: declaration uses 'sorry'
+univInference.lean:94:0-96:17: warning: declaration uses 'sorry'
+univInference.lean:94:0-96:17: warning: declaration uses 'sorry'
+univInference.lean:98:0-100:17: error: Type cannot be determined: some part of the definition contains `sorry`
+univInference.lean:104:15-104:21: error: Function expected at
+  x
+but this term has type
+  ?m
+
+Note: Expected a function because this term is being applied to the argument
+  Err3
+univInference.lean:102:0-104:22: error: Type cannot be determined: some part of the definition contains an error


### PR DESCRIPTION
This PR simplifies an error message encountered when universe resolution is ambiguous. The message is quite technical and can be triggered if an inductive definition includes a `sorry` or an error; in the event of a `sorry` a simpler error message almost certainly suffices.

## Example

```lean4
inductive Sorry2 where
  | x (a : Array Sorry2)
  | y (b : sorry)
```

Currently the error message is:
```
Resulting type is of the form
  Type ?u.5
but the universes of constructor arguments suggest that this could
accidentally be a higher universe than necessary. Explicitly providing a
resulting type will silence this error. Universe inference suggests using
  Sort (max 1 u_1)
if the resulting universe level should be at the above universe level or
higher.

Explanation: At this point in elaboration, universe level unification has
committed to using a resulting universe level of the form `?u.5+1`.
Constructor argument universe levels must be no greater than the resulting
universe level, and this condition implies the following constraint(s):
  u_1 ≤ ?u.5+1
However, such constraint(s) usually indicate that the resulting universe level
should have been in a different form. For example, if the resulting type is of
the form `Sort (_ + 1)` and a constructor argument is in universe `Sort u`,
then universe inference would yield `Sort (u + 1)`, but the resulting type
`Sort (max 1 u)` would avoid being in a higher universe than necessary.
```

With this PR, the error message is:
```
Type cannot be determined: some part of the definition contains `sorry`
```

which is really the heart of the matter. If the sorry is synthetic, the error message is:
```
Type cannot be determined: some part of the definition contains an error
```