### PR TITLE
fix: modify `@[suggest_for]` to work with the Prelude

### DIFF
--- a/src/Lean/IdentifierSuggestion.lean
+++ b/src/Lean/IdentifierSuggestion.lean
@@ -43,9 +43,9 @@ builtin_initialize identifierSuggestionForAttr : PersistentEnvExtension
       unless kind == AttributeKind.global do throwAttrMustBeGlobal `suggest_for kind
       let altSyntaxIds : Array Syntax ← match stx with
         | -- Attributes parsed _after_ the suggest_for notation is added
-          .node _ ``suggest_for #[.atom _ "suggest_for", .node _ `null ids] => logInfo m!"Route 1"; pure ids
+          .node _ ``suggest_for #[.atom _ "suggest_for", .node _ `null ids] => pure ids
         | -- Attributes parsed _before the suggest_for notation is added
-          .node _ ``Parser.Attr.simple #[.ident _ _ `suggest_for [], .node _ `null #[id]] => logInfo m!"Route 2"; pure #[id]
+          .node _ ``Parser.Attr.simple #[.ident _ _ `suggest_for [], .node _ `null #[id]] => pure #[id]
         | _ => throwError "Invalid `[suggest_for]` attribute syntax {repr stx}"
       modifyEnv (ext.addEntry · (decl, altSyntaxIds.map (·.getId)))
   }

--- a/tests/lean/run/identifierSuggestions.lean
+++ b/tests/lean/run/identifierSuggestions.lean
@@ -22,8 +22,8 @@ error: Invalid field `test0`: The environment does not contain `String.test0`, s
   "abc"
 of type `String`
 
-Hint: Perhaps you meant one of these in place of `String.test0`:
-  [apply] `String.foo`: "abc".foo
+Hint: Perhaps you meant `String.foo` in place of `String.test0`:
+  "abc".t̵e̵s̵t̵0̵f̲o̲o̲
 -/
 #guard_msgs in
 #check "abc".test0
@@ -118,8 +118,8 @@ error: Invalid field `toNum`: The environment does not contain `Foo.Bar.toNum`, 
   Foo.Bar.three
 of type `Foo.Bar`
 
-Hint: Perhaps you meant one of these in place of `Foo.Bar.toNum`:
-  [apply] `Foo.Bar.toNat`: Foo.Bar.three.toNat
+Hint: Perhaps you meant `Foo.Bar.toNat` in place of `Foo.Bar.toNum`:
+  Foo.Bar.three.t̵o̵N̵u̵m̵t̲o̲N̲a̲t̲
 -/
 #guard_msgs in
 #eval Foo.Bar.three.toNum
@@ -129,8 +129,8 @@ error: Invalid field `toStr`: The environment does not contain `Foo.Bar.toStr`, 
   Foo.Bar.two
 of type `Foo.Bar`
 
-Hint: Perhaps you meant one of these in place of `Foo.Bar.toStr`:
-  [apply] `Foo.Bar.toString`: Foo.Bar.two.toString
+Hint: Perhaps you meant `Foo.Bar.toString` in place of `Foo.Bar.toStr`:
+  Foo.Bar.two.t̵o̵S̵t̵r̵t̲o̲S̲t̲r̲i̲n̲g̲
 -/
 #guard_msgs in
 #eval Foo.Bar.two.toStr
@@ -273,8 +273,8 @@ error: Invalid field `not`: The environment does not contain `MyBool.not`, so it
   MyBool.tt
 of type `MyBool`
 
-Hint: Perhaps you meant one of these in place of `MyBool.not`:
-  [apply] `MyBool.swap`: MyBool.tt.swap
+Hint: Perhaps you meant `MyBool.swap` in place of `MyBool.not`:
+  MyBool.tt.n̵o̵t̵s̲w̲a̲p̲
 -/
 #guard_msgs in
 example := MyBool.tt.not


### PR DESCRIPTION
This PR fixes a syntax-pattern-matching issue from #11367 that prevented the addition of suggestions in Init prior to Lean.Parser being introduced, which was a significant shortcoming. It preserves the ability to have multiple suggestions for one annotation later in the process.

Additionally, tweaks a (not-yet-user-visible) error message and modifies the attribute declaration to store a wrongIdentifier -> correctIdentifier mapping instead of a correctIdentifier -> wrongIdentifier mapping.