### PR TITLE
feat: `MonadAttach`

### DIFF
--- a/src/Init/Control.lean
+++ b/src/Init/Control.lean
@@ -16,3 +16,4 @@ public import Init.Control.Option
 public import Init.Control.Lawful
 public import Init.Control.StateCps
 public import Init.Control.ExceptCps
+public import Init.Control.MonadAttach

--- a/src/Init/Control/EState.lean
+++ b/src/Init/Control/EState.lean
@@ -25,6 +25,12 @@ instance [Repr ε] [Repr α] : Repr (Result ε σ α) where
     | Result.error e _, prec => Repr.addAppParen ("EStateM.Result.error " ++ reprArg e) prec
     | Result.ok a _, prec    => Repr.addAppParen ("EStateM.Result.ok " ++ reprArg a) prec
 
+instance : MonadAttach (EStateM ε σ) where
+  CanReturn x a := Exists fun s => Exists fun s' => x.run s = .ok a s'
+  attach x s := match h : x s with
+    | .ok a s' => .ok ⟨a, s, s', h⟩ s'
+    | .error e s' => .error e s'
+
 end EStateM
 
 namespace EStateM

--- a/src/Init/Control/Except.lean
+++ b/src/Init/Control/Except.lean
@@ -329,3 +329,8 @@ instance ExceptT.finally {m : Type u → Type v} {ε : Type u} [MonadFinally m] 
     | (.ok a,    .ok b)    => pure (.ok (a, b))
     | (_,        .error e) => pure (.error e)  -- second error has precedence
     | (.error e, _)        => pure (.error e)
+
+instance [Monad m] [MonadAttach m] : MonadAttach (ExceptT ε m) where
+  CanReturn x a := MonadAttach.CanReturn (m := m) x (.ok a)
+  attach x := show m (Except ε _) from
+      (fun ⟨a, h⟩ => match a with | .ok a => .ok ⟨a, h⟩ | .error e => .error e) <$> MonadAttach.attach (m := m) x

--- a/src/Init/Control/ExceptCps.lean
+++ b/src/Init/Control/ExceptCps.lean
@@ -75,6 +75,13 @@ instance [Monad m] : MonadLift m (ExceptCpsT σ m) where
 instance [Inhabited ε] : Inhabited (ExceptCpsT ε m α) where
   default := fun _ _ k₂ => k₂ default
 
+/--
+For continuation monads, it is not possible to provide a computable `MonadAttach` instance that
+actually adds information about the return value. Therefore, this instance always attaches a proof
+of `True`.
+-/
+instance : MonadAttach (ExceptCpsT ε m) := .trivial
+
 @[simp] theorem run_pure [Monad m] : run (pure x : ExceptCpsT ε m α) = pure (Except.ok x) := rfl
 
 @[simp] theorem run_lift {α ε : Type u} [Monad m] (x : m α) : run (ExceptCpsT.lift x : ExceptCpsT ε m α) = (x >>= fun a => pure (Except.ok a) : m (Except ε α)) := rfl

--- a/src/Init/Control/Id.lean
+++ b/src/Init/Control/Id.lean
@@ -9,6 +9,7 @@ module
 
 prelude
 public import Init.Core
+public import Init.Control.MonadAttach
 
 public section
 
@@ -66,5 +67,16 @@ instance [OfNat α n] : OfNat (Id α) n :=
 
 instance {m : Type u → Type v} [Pure m] : MonadLiftT Id m where
   monadLift x := pure x.run
+
+instance : MonadAttach Id where
+  CanReturn x a := x.run = a
+  attach x := pure ⟨x.run, rfl⟩
+
+instance : LawfulMonadAttach Id where
+  map_attach := rfl
+  canReturn_map_imp := by
+    intro _ _ x _ h
+    cases h
+    exact x.run.2
 
 end Id

--- a/src/Init/Control/Lawful.lean
+++ b/src/Init/Control/Lawful.lean
@@ -10,3 +10,4 @@ public import Init.Control.Lawful.Basic
 public import Init.Control.Lawful.Instances
 public import Init.Control.Lawful.Lemmas
 public import Init.Control.Lawful.MonadLift
+public import Init.Control.Lawful.MonadAttach

--- a/src/Init/Control/Lawful/MonadAttach.lean
+++ b/src/Init/Control/Lawful/MonadAttach.lean
@@ -1,0 +1,10 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Reichert
+-/
+module
+
+prelude
+public import Init.Control.Lawful.MonadAttach.Lemmas
+public import Init.Control.Lawful.MonadAttach.Instances

--- a/src/Init/Control/Lawful/MonadAttach/Instances.lean
+++ b/src/Init/Control/Lawful/MonadAttach/Instances.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Reichert
+-/
+module
+
+prelude
+public import Init.Control.Reader
+public import Init.Control.Lawful.Instances
+import Init.Control.Lawful.MonadAttach.Lemmas
+
+public instance [Monad m] [LawfulMonad m] [MonadAttach m] [WeaklyLawfulMonadAttach m] :
+    WeaklyLawfulMonadAttach (ReaderT ρ m) where
+  map_attach := by
+    simp only [Functor.map, MonadAttach.attach, Functor.map_map, WeaklyLawfulMonadAttach.map_attach]
+    intros; rfl
+
+public instance [Monad m] [LawfulMonad m] [MonadAttach m] [LawfulMonadAttach m] :
+    LawfulMonadAttach (ReaderT ρ m) where
+  canReturn_map_imp := by
+    simp only [Functor.map, MonadAttach.CanReturn, ReaderT.run]
+    rintro _ _ x a ⟨r, h⟩
+    apply LawfulMonadAttach.canReturn_map_imp h
+
+public instance [Monad m] [LawfulMonad m] [MonadAttach m] [WeaklyLawfulMonadAttach m] :
+    WeaklyLawfulMonadAttach (StateT σ m) where
+  map_attach := by
+    intro α x
+    simp only [Functor.map, StateT, funext_iff, StateT.map, bind_pure_comp, MonadAttach.attach,
+      Functor.map_map]
+    exact fun s => WeaklyLawfulMonadAttach.map_attach
+
+public instance [Monad m] [LawfulMonad m] [MonadAttach m] [LawfulMonadAttach m] :
+    LawfulMonadAttach (StateT σ m) where
+  canReturn_map_imp := by
+    simp only [Functor.map, MonadAttach.CanReturn, StateT.run, StateT.map, bind_pure_comp]
+    rintro _ _ x a ⟨s, s', h⟩
+    obtain ⟨a, h, h'⟩ := LawfulMonadAttach.canReturn_map_imp' h
+    cases h'
+    exact a.1.2
+
+public instance [Monad m] [LawfulMonad m] [MonadAttach m] [WeaklyLawfulMonadAttach m] :
+    WeaklyLawfulMonadAttach (ExceptT ε m) where
+  map_attach {α} x := by
+    simp only [Functor.map, MonadAttach.attach, ExceptT.map]
+    simp
+    conv => rhs; rw [← WeaklyLawfulMonadAttach.map_attach (m := m) (x := x)]
+    simp only [map_eq_pure_bind]
+    apply bind_congr; intro a
+    match a with
+    | ⟨.ok _, _⟩ => simp
+    | ⟨.error _, _⟩ => simp
+
+public instance [Monad m] [LawfulMonad m] [MonadAttach m] [LawfulMonadAttach m] :
+    LawfulMonadAttach (ExceptT ε m) where
+  canReturn_map_imp {α P x a} := by
+    simp only [Functor.map, MonadAttach.CanReturn, ExceptT.map, ExceptT.mk]
+    let x' := (fun a => show Subtype (fun a : Except _ _ => match a with | .ok a => P a | .error e => True) from ⟨match a with | .ok a => .ok a.1 | .error e => .error e, by cases a <;> simp [Subtype.property]⟩) <$> show m _ from x
+    have := LawfulMonadAttach.canReturn_map_imp (m := m) (x := x') (a := .ok a)
+    simp only at this
+    intro h
+    apply this
+    simp only [x', map_eq_pure_bind, bind_assoc]
+    refine cast ?_ h
+    congr 1
+    apply bind_congr; intro a
+    split <;> simp
+
+public instance [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m] :
+    WeaklyLawfulMonadAttach (StateRefT' ω σ m) :=
+  inferInstanceAs (WeaklyLawfulMonadAttach (ReaderT _ _))
+
+public instance [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m] :
+    LawfulMonadAttach (StateRefT' ω σ m) :=
+  inferInstanceAs (LawfulMonadAttach (ReaderT _ _))
+
+section
+
+attribute [local instance] MonadAttach.trivial
+
+public instance [Monad m] [LawfulMonad m] :
+    WeaklyLawfulMonadAttach m where
+  map_attach := by simp [MonadAttach.attach]
+
+end

--- a/src/Init/Control/Lawful/MonadAttach/Lemmas.lean
+++ b/src/Init/Control/Lawful/MonadAttach/Lemmas.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Reichert
+-/
+module
+
+prelude
+public import Init.Control.MonadAttach
+import all Init.Control.MonadAttach
+public import Init.Control.Lawful.Lemmas
+public import Init.Control.Lawful.MonadLift.Lemmas
+
+public theorem LawfulMonadAttach.canReturn_bind_imp' [Monad m] [LawfulMonad m]
+    [MonadAttach m] [LawfulMonadAttach m]
+    {x : m α} {f : α → m β} :
+    MonadAttach.CanReturn (x >>= f) b → Exists fun a => MonadAttach.CanReturn x a ∧ MonadAttach.CanReturn (f a) b := by
+  intro h
+  let P (b : β) := Exists fun a => MonadAttach.CanReturn x a ∧ MonadAttach.CanReturn (f a) b
+  have h' : (x >>= f) = Subtype.val <$> (MonadAttach.attach x >>= (fun a => (do
+      let b ← MonadAttach.attach (f a)
+      return ⟨b.1, a.1, a.2, b.2⟩ : m (Subtype P)))) := by
+    simp only [map_bind, map_pure]
+    simp only [bind_pure_comp, WeaklyLawfulMonadAttach.map_attach]
+    rw (occs := [1]) [← WeaklyLawfulMonadAttach.map_attach (x := x)]
+    simp
+  rw [h'] at h
+  have := LawfulMonadAttach.canReturn_map_imp h
+  exact this
+
+public theorem LawfulMonadAttach.eq_of_canReturn_pure [Monad m] [MonadAttach m]
+    [LawfulMonad m] [LawfulMonadAttach m] {a b : α}
+    (h : MonadAttach.CanReturn (m := m) (pure a) b) :
+    a = b := by
+  let x : m (Subtype (a = ·)) := pure ⟨a, rfl⟩
+  have : pure a = Subtype.val <$> x := by simp [x]
+  rw [this] at h
+  exact LawfulMonadAttach.canReturn_map_imp h
+
+public theorem LawfulMonadAttach.canReturn_map_imp' [Monad m] [LawfulMonad m]
+    [MonadAttach m] [LawfulMonadAttach m]
+    {x : m α} {f : α → β} :
+    MonadAttach.CanReturn (f <$> x) b → Exists fun a => MonadAttach.CanReturn x a ∧ f a = b := by
+  rw [map_eq_pure_bind]
+  intro h
+  obtain ⟨a, h, h'⟩ := canReturn_bind_imp' h
+  exact ⟨a, h, eq_of_canReturn_pure h'⟩
+
+public theorem LawfulMonadAttach.canReturn_liftM_imp'
+    [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [LawfulMonadAttach n]
+    [MonadLiftT m n] [LawfulMonadLiftT m n] {x : m α} {a : α} :
+    MonadAttach.CanReturn (liftM (n := n) x) a → MonadAttach.CanReturn x a := by
+  intro h
+  simp only [← WeaklyLawfulMonadAttach.map_attach (x := x), liftM_map] at h
+  exact canReturn_map_imp h
+
+public theorem WeaklyLawfulMonadAttach.attach_bind_val
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    {x : m α} {f : α → m β} :
+    MonadAttach.attach x >>= (fun a => f a.val) = x >>= f := by
+  conv => rhs; simp only [← map_attach (x := x), bind_map_left]
+
+public theorem WeaklyLawfulMonadAttach.bind_attach_of_nonempty
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m] [Nonempty (m β)]
+    {x : m α} {f : Subtype (MonadAttach.CanReturn x) → m β} :
+    open scoped Classical in
+    MonadAttach.attach x >>= f = x >>= (fun a => if ha : MonadAttach.CanReturn x a then f ⟨a, ha⟩ else Classical.ofNonempty) := by
+  conv => rhs; simp +singlePass only [← map_attach (x := x)]
+  simp [Subtype.property]
+
+public theorem MonadAttach.attach_bind_eq_pbind
+    [Monad m] [MonadAttach m]
+    {x : m α} {f : Subtype (MonadAttach.CanReturn x) → m β} :
+    MonadAttach.attach x >>= f = MonadAttach.pbind x (fun a ha => f ⟨a, ha⟩) := by
+  simp [MonadAttach.pbind]
+
+public theorem WeaklyLawfulMonadAttach.pbind_eq_bind
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    {x : m α} {f : α → m β} :
+    MonadAttach.pbind x (fun a _ => f a) = x >>= f := by
+  conv => rhs; rw [← map_attach (x := x)]
+  simp [MonadAttach.pbind]
+
+public theorem WeaklyLawfulMonadAttach.pbind_eq_bind'
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    {x : m α} {f : α → m β} :
+    MonadAttach.pbind x (fun a _ => f a) = x >>= f := by
+  conv => rhs; rw [← map_attach (x := x)]
+  simp [MonadAttach.pbind]

--- a/src/Init/Control/Lawful/MonadLift/Lemmas.lean
+++ b/src/Init/Control/Lawful/MonadLift/Lemmas.lean
@@ -6,12 +6,21 @@ Authors: Quang Dao
 module
 
 prelude
+public import Init.Control.Id
 public import Init.Control.Lawful.Basic
 public import Init.Control.Lawful.MonadLift.Basic
 
 public section
 
 universe u v w
+
+theorem instMonadLiftTOfMonadLift_instMonadLiftTOfPure [Monad m] [Monad n] {_ : MonadLift m n}
+    [LawfulMonadLift m n] : instMonadLiftTOfMonadLift Id m n = Id.instMonadLiftTOfPure := by
+  have hext {a b : MonadLiftT Id n} (h : @a.monadLift = @b.monadLift) : a = b := by
+    cases a <;> cases b <;> simp_all
+  apply hext
+  ext α x
+  simp [monadLift, LawfulMonadLift.monadLift_pure]
 
 variable {m : Type u → Type v} {n : Type u → Type w} [Monad m] [Monad n] [MonadLiftT m n]
   [LawfulMonadLiftT m n] {α β : Type u}

--- a/src/Init/Control/MonadAttach.lean
+++ b/src/Init/Control/MonadAttach.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Reichert
+-/
+module
+
+prelude
+public import Init.Control.Basic
+
+set_option linter.all true
+
+set_option doc.verso true
+
+/-!
+# {name (scope := "Init.Control.MonadAttach")}`MonadAttach`
+
+This module provides a mechanism for attaching proofs to the return values of monadic computations,
+producing a new monadic computation returning a {name}`Subtype`.
+
+This function is primarily used to allow definitions by [well-founded
+recursion](lean-manual://section/well-founded-recursion) that sequence computations using
+{name}`Bind.bind` (`>>=`) to prove properties about the return values of prior computations when
+a recursive call happens.
+This allows the well-founded recursion mechanism to prove that the function terminates.
+-/
+
+-- verso docstring is added below
+set_option linter.missingDocs false in
+public class MonadAttach (m : Type u → Type v) where
+  /--
+  A predicate that can be assumed to be true for all return values {name}`a` of actions {name}`x`
+  in {name}`m`, in all situations.
+  -/
+  CanReturn {α : Type u} : (x : m α) → (a : α) → Prop
+  /--
+  Attaches a proof of {name}`MonadAttach.CanReturn` to the return value of {name}`x`. This proof
+  can be used to prove the termination of well-founded recursive functions.
+  -/
+  attach {α : Type u} (x : m α) : m (Subtype (CanReturn x))
+
+-- verso docstring is added below
+set_option linter.missingDocs false in
+public class WeaklyLawfulMonadAttach (m : Type u → Type v) [Monad m] [MonadAttach m] where
+  map_attach {α : Type u} {x : m α} : Subtype.val <$> MonadAttach.attach x = x
+
+/--
+This type class ensures that {name}`MonadAttach.CanReturn` is the unique strongest possible
+postcondition.
+-/
+public class LawfulMonadAttach (m : Type u → Type v) [Monad m] [MonadAttach m] extends
+    WeaklyLawfulMonadAttach m where
+  canReturn_map_imp {α : Type u} {P : α → Prop} {x : m (Subtype P)} {a : α} :
+      MonadAttach.CanReturn (Subtype.val <$> x) a → P a
+
+/--
+Like {name}`Bind.bind`, {name}`pbind` sequences two computations {lean}`x : m α` and {lean}`f`,
+allowing the second to depend on the value computed by the first.
+But other than with {name}`Bind.bind`, the second computation can also depend on a proof that
+the return value {given}`a` of {name}`x` satisfies {lean}`MonadAttach.CanReturn x a`.
+-/
+public def MonadAttach.pbind [Monad m] [MonadAttach m]
+    (x : m α) (f : (a : α) → MonadAttach.CanReturn x a → m β) : m β :=
+  MonadAttach.attach x >>= (fun ⟨a, ha⟩ => f a ha)
+
+/--
+A {lean}`MonadAttach` instance where all return values are possible and {name}`attach` adds no
+information to the return value, except a trivial proof of {name}`True`.
+
+This instance is used whenever no more useful {name}`MonadAttach` instance can be implemented.
+It always has a {name}`WeaklyLawfulMonadAttach`, but usually no {name}`LawfulMonadAttach` instance.
+-/
+@[expose]
+public protected def MonadAttach.trivial {m : Type u → Type v} [Monad m] : MonadAttach m where
+  CanReturn _ _ := True
+  attach x := (⟨·, .intro⟩) <$> x
+
+section
+
+variable (α : Type u) [∀ m, Monad m] [∀ m, MonadAttach m]
+
+set_option doc.verso true
+
+/--
+For every {given}`x : m α`, this type class provides a predicate {lean}`MonadAttach.CanReturn x`
+and a way to attach a proof of this predicate to the return values of {name}`x` by providing
+an element {lean}`MonadAttach.attach x` of {lean}`m { a : α // MonadAttach.CanReturn x a }`.
+
+Instances should abide the law {lean}`Subtype.val <$> MonadAttach.attach x = x`, which is encoded by
+the {name}`WeaklyLawfulMonadAttach` type class. The stronger type class {name}`LawfulMonadAttach`
+ensures that {lean}`MonadAttach.CanReturn x` is the _unique_ strongest possible predicate.
+
+Similarly to {name (scope := "Init.Data.List.Attach")}`List.attach`, the purpose of
+{name}`MonadAttach` is to attach proof terms necessary for well-founded termination proofs.
+The iterator library relies on {name}`MonadAttach` for combinators such as
+{name (scope := "Init.Data.Iterators")}`Std.Iter.filterM` in order to automatically attach
+information about the monadic predicate's behavior that could be relevant for the termination
+behavior of the iterator.
+
+*Limitations*:
+
+For many monads, there is a strongly lawful {lean}`MonadAttach` instance, but there are exceptions.
+For example, there is no way to provide a computable {lean}`MonadAttach` instance for the CPS monad
+transformers
+{name (scope := "Init.Control.StateCps")}`StateCpsT` and
+{name (scope := "Init.Control.StateCps")}`ExceptCpsT` with a predicate that is not always
+{name}`True`. Therefore, such CPS monads only provide the trivial {lean}`MonadAttach` instance
+{lean}`MonadAttach.trivial` together with {name}`WeaklyLawfulMonadAttach`, but without
+{name}`LawfulMonadAttach`.
+
+For most monads with side effects, {lean}`MonadAttach` is too weak to fully capture the behavior of
+computations because the postcondition represented by {name}`MonadAttach.CanReturn` neither depends
+on the prior internal state of the monad, nor does it contain information about how the state of the
+monad changes with the computation.
+-/
+add_decl_doc MonadAttach
+
+/--
+This type class ensures that every monadic action {given}`x : m α` can be recovered by stripping the
+proof component from the subtypes returned by
+{lean}`(MonadAttach.attach x) : m { a : α // MonadAttach.CanReturn x a }` . In other words,
+the type class ensures that {lean}`Subtype.val <$> MonadAttach.attach x = x`.
+-/
+add_decl_doc WeaklyLawfulMonadAttach
+
+end

--- a/src/Init/Control/Option.lean
+++ b/src/Init/Control/Option.lean
@@ -112,6 +112,12 @@ instance (ε : Type u) [MonadExceptOf ε m] : MonadExceptOf ε (OptionT m) where
   throw e           := OptionT.mk <| throwThe ε e
   tryCatch x handle := OptionT.mk <| tryCatchThe ε x handle
 
+instance [MonadAttach m] : MonadAttach (OptionT m) where
+  CanReturn x a := MonadAttach.CanReturn x.run (some a)
+  attach x := .mk ((fun
+      | ⟨some a, h⟩ => some ⟨a, h⟩
+      | ⟨none, _⟩ => none) <$> MonadAttach.attach x.run)
+
 end OptionT
 
 instance [Monad m] : MonadControl m (OptionT m) where

--- a/src/Init/Control/Reader.lean
+++ b/src/Init/Control/Reader.lean
@@ -51,3 +51,7 @@ A monad with access to a read-only value of type `ρ`. The value can be locally 
 `withReader`, but it cannot be mutated.
 -/
 abbrev ReaderM (ρ : Type u) := ReaderT ρ Id
+
+instance [Monad m] [MonadAttach m] : MonadAttach (ReaderT ρ m) where
+  CanReturn x a := Exists (fun r => MonadAttach.CanReturn (x.run r) a)
+  attach x := fun r => (fun ⟨a, h⟩ => ⟨a, r, h⟩) <$> MonadAttach.attach (x.run r)

--- a/src/Init/Control/State.lean
+++ b/src/Init/Control/State.lean
@@ -204,3 +204,7 @@ instance StateT.tryFinally {m : Type u → Type v} {σ : Type u} [MonadFinally m
       | some (a, s') => h (some a) s'
       | none         => h none s
     pure ((a, b), s'')
+
+instance [Monad m] [MonadAttach m] : MonadAttach (StateT σ m) where
+  CanReturn x a := Exists fun s => Exists fun s' => MonadAttach.CanReturn (x.run s) (a, s')
+  attach x := fun s => (fun ⟨⟨a, s'⟩, h⟩ => ⟨⟨a, s, s', h⟩, s'⟩) <$> MonadAttach.attach (x.run s)

--- a/src/Init/Control/StateCps.lean
+++ b/src/Init/Control/StateCps.lean
@@ -69,6 +69,13 @@ instance : MonadStateOf σ (StateCpsT σ m) where
   modifyGet f := fun _ s k => let (a, s) := f s; k a s
 
 /--
+For continuation monads, it is not possible to provide a computable `MonadAttach` instance that
+actually adds information about the return value. Therefore, this instance always attaches a proof
+of `True`.
+-/
+instance : MonadAttach (StateCpsT ε m) := .trivial
+
+/--
 Runs an action from the underlying monad in the monad with state. The state is not modified.
 
 This function is typically implicitly accessed via a `MonadLiftT` instance as part of [automatic

--- a/src/Init/Control/StateRef.lean
+++ b/src/Init/Control/StateRef.lean
@@ -64,6 +64,7 @@ instance [Monad m] : Monad (StateRefT' ω σ m) := inferInstanceAs (Monad (Reade
 instance : MonadLift m (StateRefT' ω σ m) := ⟨StateRefT'.lift⟩
 instance (σ m) : MonadFunctor m (StateRefT' ω σ m) := inferInstanceAs (MonadFunctor m (ReaderT _ _))
 instance [Alternative m] [Monad m] : Alternative (StateRefT' ω σ m) := inferInstanceAs (Alternative (ReaderT _ _))
+instance [Monad m] [MonadAttach m] : MonadAttach (StateRefT' ω σ m) := inferInstanceAs (MonadAttach (ReaderT _ _))
 
 /--
 Retrieves the current value of the monad's mutable state.

--- a/src/Init/Data/Iterators/Basic.lean
+++ b/src/Init/Data/Iterators/Basic.lean
@@ -292,6 +292,11 @@ theorem IterStep.mapIterator_id {step : IterStep α β} :
     step.mapIterator id = step := by
   cases step <;> rfl
 
+@[simp]
+theorem IterStep.mapIterator_id' {step : IterStep α β} :
+    step.mapIterator (fun x => x) = step := by
+  cases step <;> rfl
+
 /--
 A variant of `IterStep` that bundles the step together with a proof that it is "plausible".
 The plausibility predicate will later be chosen to assert that a state is a plausible successor

--- a/src/Init/Data/Iterators/Combinators/FilterMap.lean
+++ b/src/Init/Data/Iterators/Combinators/FilterMap.lean
@@ -198,12 +198,8 @@ it.filterMapM     ---a'-----c'-------⊥
 For certain mapping functions `f`, the resulting iterator will be finite (or productive) even though
 no `Finite` (or `Productive`) instance is provided. For example, if `f` never returns `none`, then
 this combinator will preserve productiveness. If `f` is an `ExceptT` monad and will always fail,
-then `it.filterMapM` will be finite even if `it` isn't. In the first case, consider
-using the `map`/`mapM`/`mapWithPostcondition` combinators instead, which provide more instances out
-of the box.
-
-If that does not help, the more general combinator `it.filterMapWithPostcondition f` makes it
-possible to manually prove `Finite` and `Productive` instances depending on the concrete choice of `f`.
+then `it.filterMapM` will be finite even if `it` isn't. In such cases, the termination proof needs
+to be done manually.
 
 **Performance:**
 
@@ -212,7 +208,7 @@ returned `Option` value.
 -/
 @[always_inline, inline, expose]
 def Iter.filterMapM {α β γ : Type w} [Iterator α Id β] {m : Type w → Type w'}
-    [Monad m] (f : β → m (Option γ)) (it : Iter (α := α) β) :=
+    [Monad m] [MonadAttach m] (f : β → m (Option γ)) (it : Iter (α := α) β) :=
   (letI : MonadLift Id m := ⟨pure⟩; it.toIterM.filterMapM f : IterM m γ)
 
 /--
@@ -238,10 +234,7 @@ it.filterM     ---a-----c-------⊥
 For certain mapping functions `f`, the resulting iterator will be finite (or productive) even though
 no `Finite` (or `Productive`) instance is provided. For example, if `f` is an `ExceptT` monad and
 will always fail, then `it.filterWithPostcondition` will be finite -- and productive -- even if `it`
-isn't.
-
-In such situations, the more general combinator `it.filterWithPostcondition f` makes it possible to
-manually prove `Finite` and `Productive` instances depending on the concrete choice of `f`.
+isn't. In such cases, the termination proof needs to be done manually.
 
 **Performance:**
 
@@ -249,7 +242,7 @@ For each value emitted by the base iterator `it`, this combinator calls `f`.
 -/
 @[always_inline, inline, expose]
 def Iter.filterM {α β : Type w} [Iterator α Id β] {m : Type w → Type w'}
-    [Monad m] (f : β → m (ULift Bool)) (it : Iter (α := α) β) :=
+    [Monad m] [MonadAttach m] (f : β → m (ULift Bool)) (it : Iter (α := α) β) :=
   (letI : MonadLift Id m := ⟨pure⟩; it.toIterM.filterM f : IterM m β)
 
 /--
@@ -277,10 +270,8 @@ it.mapM     ---a'--b'--c'--d'-e'----⊥
 
 For certain mapping functions `f`, the resulting iterator will be finite (or productive) even though
 no `Finite` (or `Productive`) instance is provided. For example, if `f` is an `ExceptT` monad and
-will always fail, then `it.mapM` will be finite even if `it` isn't.
-
-If that does not help, the more general combinator `it.mapWithPostcondition f` makes it possible to
-manually prove `Finite` and `Productive` instances depending on the concrete choice of `f`.
+will always fail, then `it.mapM` will be finite even if `it` isn't. In such cases, the termination
+proof needs to be done manually.
 
 **Performance:**
 
@@ -288,7 +279,7 @@ For each value emitted by the base iterator `it`, this combinator calls `f`.
 -/
 @[always_inline, inline, expose]
 def Iter.mapM {α β γ : Type w} [Iterator α Id β] {m : Type w → Type w'}
-    [Monad m] (f : β → m γ) (it : Iter (α := α) β) :=
+    [Monad m] [MonadAttach m] (f : β → m γ) (it : Iter (α := α) β) :=
   (letI : MonadLift Id m := ⟨pure⟩; it.toIterM.mapM f : IterM m γ)
 
 @[always_inline, inline, inherit_doc IterM.filterMap, expose]

--- a/src/Init/Data/Iterators/Combinators/FlatMap.lean
+++ b/src/Init/Data/Iterators/Combinators/FlatMap.lean
@@ -28,13 +28,13 @@ namespace Std
 
 @[always_inline, inherit_doc IterM.flatMapAfterM]
 public def Iter.flatMapAfterM {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [Iterator α Id β] [Iterator α₂ m γ]
+    {γ : Type w} {m : Type w → Type w'} [Monad m] [MonadAttach m] [Iterator α Id β] [Iterator α₂ m γ]
     (f : β → m (IterM (α := α₂) m γ)) (it₁ : Iter (α := α) β) (it₂ : Option (IterM (α := α₂) m γ)) :=
-  ((it₁.mapM pure).flatMapAfterM f it₂ : IterM m γ)
+  ((it₁.mapWithPostcondition pure).flatMapAfterM f it₂ : IterM m γ)
 
 @[always_inline, expose, inherit_doc IterM.flatMapM]
 public def Iter.flatMapM {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [Iterator α Id β] [Iterator α₂ m γ]
+    {γ : Type w} {m : Type w → Type w'} [Monad m] [MonadAttach m] [Iterator α Id β] [Iterator α₂ m γ]
     (f : β → m (IterM (α := α₂) m γ)) (it : Iter (α := α) β) :=
   (it.flatMapAfterM f none : IterM m γ)
 

--- a/src/Init/Data/Iterators/Combinators/Monadic/FilterMap.lean
+++ b/src/Init/Data/Iterators/Combinators/Monadic/FilterMap.lean
@@ -123,7 +123,7 @@ returned `Option` value.
 def IterM.filterMapWithPostcondition {α β γ : Type w} {m : Type w → Type w'} {n : Type w → Type w''}
     [MonadLiftT m n] [Iterator α m β] (f : β → PostconditionT n (Option γ))
     (it : IterM (α := α) m β) : IterM (α := FilterMap α m n (fun ⦃_⦄ => monadLift) f) n γ :=
-  IterM.InternalCombinators.filterMap (fun ⦃_⦄ => monadLift) f it
+  IterM.InternalCombinators.filterMap (n := n) (fun ⦃_⦄ => monadLift) f it
 
 namespace Iterators.Types
 
@@ -382,12 +382,8 @@ it.filterMapM     ---a'-----c'-------⊥
 For certain mapping functions `f`, the resulting iterator will be finite (or productive) even though
 no `Finite` (or `Productive`) instance is provided. For example, if `f` never returns `none`, then
 this combinator will preserve productiveness. If `f` is an `ExceptT` monad and will always fail,
-then `it.filterMapM` will be finite even if `it` isn't. In the first case, consider
-using the `map`/`mapM`/`mapWithPostcondition` combinators instead, which provide more instances out of
-the box.
-
-If that does not help, the more general combinator `it.filterMapWithPostcondition f` makes it
-possible to manually prove `Finite` and `Productive` instances depending on the concrete choice of `f`.
+then `it.filterMapM` will be finite even if `it` isn't. In such cases, the termination proof needs
+to be done manually.
 
 **Performance:**
 
@@ -396,9 +392,9 @@ returned `Option` value.
 -/
 @[inline, expose]
 def IterM.filterMapM {α β γ : Type w} {m : Type w → Type w'} {n : Type w → Type w''}
-    [Iterator α m β] [Monad n] [MonadLiftT m n]
+    [Iterator α m β] [Monad n] [MonadAttach n] [MonadLiftT m n]
     (f : β → n (Option γ)) (it : IterM (α := α) m β) :=
-  (it.filterMapWithPostcondition (fun b => PostconditionT.lift (f b)) : IterM n γ)
+  (it.filterMapWithPostcondition (fun b => PostconditionT.attachLift (f b)) : IterM n γ)
 
 /--
 If `it` is an iterator, then `it.mapM f` is another iterator that applies a monadic
@@ -425,10 +421,8 @@ it.mapM     ---a'--b'--c'--d'-e'----⊥
 
 For certain mapping functions `f`, the resulting iterator will be finite (or productive) even though
 no `Finite` (or `Productive`) instance is provided. For example, if `f` is an `ExceptT` monad and
-will always fail, then `it.mapM` will be finite even if `it` isn't.
-
-If that does not help, the more general combinator `it.mapWithPostcondition f` makes it possible to
-manually prove `Finite` and `Productive` instances depending on the concrete choice of `f`.
+will always fail, then `it.mapM` will be finite even if `it` isn't. In such cases, the termination
+proof needs to be done manually.
 
 **Performance:**
 
@@ -436,8 +430,8 @@ For each value emitted by the base iterator `it`, this combinator calls `f`.
 -/
 @[inline, expose]
 def IterM.mapM {α β γ : Type w} {m : Type w → Type w'} {n : Type w → Type w''} [Iterator α m β]
-    [Monad n] [MonadLiftT m n] (f : β → n γ) (it : IterM (α := α) m β) :=
-  (it.mapWithPostcondition (fun b => PostconditionT.lift (f b)) : IterM n γ)
+    [Monad n] [MonadAttach n] [MonadLiftT m n] (f : β → n γ) (it : IterM (α := α) m β) :=
+  (it.mapWithPostcondition (fun b => PostconditionT.attachLift (f b)) : IterM n γ)
 
 /--
 If `it` is an iterator, then `it.filterM f` is another iterator that applies a monadic
@@ -465,10 +459,7 @@ it.filterM     ---a-----c-------⊥
 For certain mapping functions `f`, the resulting iterator will be finite (or productive) even though
 no `Finite` (or `Productive`) instance is provided. For example, if `f` is an `ExceptT` monad and
 will always fail, then `it.filterWithPostcondition` will be finite -- and productive -- even if `it`
-isn't.
-
-In such situations, the more general combinator `it.filterWithPostcondition f` makes it possible to
-manually prove `Finite` and `Productive` instances depending on the concrete choice of `f`.
+isn't. In such cases, the termination proof needs to be done manually.
 
 **Performance:**
 
@@ -476,9 +467,9 @@ For each value emitted by the base iterator `it`, this combinator calls `f`.
 -/
 @[inline, expose]
 def IterM.filterM {α β : Type w} {m : Type w → Type w'} {n : Type w → Type w''} [Iterator α m β]
-    [Monad n] [MonadLiftT m n] (f : β → n (ULift Bool)) (it : IterM (α := α) m β) :=
+    [Monad n] [MonadAttach n] [MonadLiftT m n] (f : β → n (ULift Bool)) (it : IterM (α := α) m β) :=
   (it.filterMapWithPostcondition
-    (fun b => (PostconditionT.lift (f b)).map (if ·.down = true then some b else none)) : IterM n β)
+    (fun b => (PostconditionT.attachLift (f b)).map (if ·.down = true then some b else none)) : IterM n β)
 
 /--
 If `it` is an iterator, then `it.filterMap f` is another iterator that applies a function `f` to all

--- a/src/Init/Data/Iterators/Combinators/Monadic/FlatMap.lean
+++ b/src/Init/Data/Iterators/Combinators/Monadic/FlatMap.lean
@@ -78,7 +78,7 @@ For each value emitted by the outer iterator `it₁`, this combinator calls `f`.
 -/
 @[always_inline, inline]
 public def IterM.flatMapAfterM {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [Iterator α m β] [Iterator α₂ m γ]
+    {γ : Type w} {m : Type w → Type w'} [Monad m] [MonadAttach m] [Iterator α m β] [Iterator α₂ m γ]
     (f : β → m (IterM (α := α₂) m γ)) (it₁ : IterM (α := α) m β) (it₂ : Option (IterM (α := α₂) m γ)) :=
   ((it₁.mapM f).flattenAfter it₂ : IterM m γ)
 
@@ -117,7 +117,7 @@ For each value emitted by the outer iterator `it`, this combinator calls `f`.
 -/
 @[always_inline, inline, expose]
 public def IterM.flatMapM {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [Iterator α m β] [Iterator α₂ m γ]
+    {γ : Type w} {m : Type w → Type w'} [Monad m] [MonadAttach m] [Iterator α m β] [Iterator α₂ m γ]
     (f : β → m (IterM (α := α₂) m γ)) (it : IterM (α := α) m β) :=
   (it.flatMapAfterM f none : IterM m γ)
 

--- a/src/Init/Data/Iterators/Lemmas/Combinators/FlatMap.lean
+++ b/src/Init/Data/Iterators/Lemmas/Combinators/FlatMap.lean
@@ -10,6 +10,7 @@ import Init.Data.Iterators.Lemmas.Combinators.FilterMap
 public import Init.Data.Iterators.Combinators.FlatMap
 import all Init.Data.Iterators.Combinators.FlatMap
 public import Init.Data.Iterators.Lemmas.Combinators.Monadic.FlatMap
+import Init.Control.Lawful.MonadAttach.Lemmas
 
 namespace Std
 open Std.Internal Std.Iterators
@@ -17,43 +18,51 @@ open Std.Internal Std.Iterators
 namespace Iterators.Types
 
 public theorem Flatten.IsPlausibleStep.outerYield_flatMapM_pure {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ]
+    {γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m] [Iterator α Id β]
+    [Iterator α₂ m γ]
     {f : β → m (IterM (α := α₂) m γ)} {it₁ it₁' : Iter (α := α) β} {it₂' b}
-    (h : it₁.IsPlausibleStep (.yield it₁' b)) :
+    (h : it₁.IsPlausibleStep (.yield it₁' b)) (h' : MonadAttach.CanReturn (f b) it₂') :
     (it₁.flatMapAfterM f none).IsPlausibleStep (.skip (it₁'.flatMapAfterM f (some it₂'))) := by
-  apply outerYield_flatMapM
-  exact .yieldSome h (out' := b) (by simp [PostconditionT.lift, PostconditionT.bind])
+  apply outerYield_flatMapM (b := b)
+  · exact FilterMap.PlausibleStep.yieldSome h (by simp)
+  · exact h'
 
 public theorem Flatten.IsPlausibleStep.outerSkip_flatMapM_pure {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ]
+    {γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ]
     {f : β → m (IterM (α := α₂) m γ)} {it₁ it₁' : Iter (α := α) β}
     (h : it₁.IsPlausibleStep (.skip it₁')) :
     (it₁.flatMapAfterM f none).IsPlausibleStep (.skip (it₁'.flatMapAfterM f none)) :=
   outerSkip_flatMapM (.skip h)
 
 public theorem Flatten.IsPlausibleStep.outerDone_flatMapM_pure {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ]
+    {γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ]
     {f : β → m (IterM (α := α₂) m γ)} {it₁ : Iter (α := α) β}
     (h : it₁.IsPlausibleStep .done) :
     (it₁.flatMapAfterM f none).IsPlausibleStep .done :=
   outerDone_flatMapM (.done h)
 
 public theorem Flatten.IsPlausibleStep.innerYield_flatMapM_pure {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ]
+    {γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ]
     {f : β → m (IterM (α := α₂) m γ)} {it₁ : Iter (α := α) β} {it₂ it₂' b}
     (h : it₂.IsPlausibleStep (.yield it₂' b)) :
     (it₁.flatMapAfterM f (some it₂)).IsPlausibleStep (.yield (it₁.flatMapAfterM f (some it₂')) b) :=
   innerYield_flatMapM h
 
 public theorem Flatten.IsPlausibleStep.innerSkip_flatMapM_pure {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ]
+    {γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ]
     {f : β → m (IterM (α := α₂) m γ)} {it₁ : Iter (α := α) β} {it₂ it₂'}
     (h : it₂.IsPlausibleStep (.skip it₂')) :
     (it₁.flatMapAfterM f (some it₂)).IsPlausibleStep (.skip (it₁.flatMapAfterM f (some it₂'))) :=
   innerSkip_flatMapM h
 
 public theorem Flatten.IsPlausibleStep.innerDone_flatMapM_pure {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ]
+    {γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ]
     {f : β → m (IterM (α := α₂) m γ)} {it₁ : Iter (α := α) β} {it₂}
     (h : it₂.IsPlausibleStep .done) :
     (it₁.flatMapAfterM f (some it₂)).IsPlausibleStep (.skip (it₁.flatMapAfterM f none)) :=
@@ -104,14 +113,16 @@ public theorem Flatten.IsPlausibleStep.innerDone_flatMap_pure {α : Type w} {β 
 end Iterators.Types
 
 public theorem Iter.step_flatMapAfterM {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ]
+    {γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m] [Iterator α Id β] [Iterator α₂ m γ]
     {f : β → m (IterM (α := α₂) m γ)} {it₁ : Iter (α := α) β} {it₂ : Option (IterM (α := α₂) m γ)} :
   (it₁.flatMapAfterM f it₂).step = (do
     match it₂ with
     | none =>
       match it₁.step with
       | .yield it₁' b h =>
-        return .deflate (.skip (it₁'.flatMapAfterM f (some (← f b))) (.outerYield_flatMapM_pure h))
+        let fx ← MonadAttach.attach (f b)
+        return .deflate (.skip (it₁'.flatMapAfterM f (some fx.val)) (.outerYield_flatMapM_pure h fx.property))
       | .skip it₁' h => return .deflate (.skip (it₁'.flatMapAfterM f none) (.outerSkip_flatMapM_pure h))
       | .done h => return .deflate (.done (.outerDone_flatMapM_pure h))
     | some it₂ =>
@@ -122,18 +133,22 @@ public theorem Iter.step_flatMapAfterM {α : Type w} {β : Type w} {α₂ : Type
         return .deflate (.skip (it₁.flatMapAfterM f (some it₂')) (.innerSkip_flatMapM_pure h))
       | .done h =>
         return .deflate (.skip (it₁.flatMapAfterM f none) (.innerDone_flatMapM_pure h))) := by
-  simp only [flatMapAfterM, IterM.step_flatMapAfterM, Iter.step_mapM]
+  simp only [flatMapAfterM, IterM.step_flatMapAfterM, Iter.step_mapWithPostcondition,
+    PostconditionT.operation_pure]
   split
   · split <;> simp [*]
   · rfl
 
 public theorem Iter.step_flatMapM {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ]
+    {γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α Id β] [Iterator α₂ m γ]
     {f : β → m (IterM (α := α₂) m γ)} {it₁ : Iter (α := α) β} :
   (it₁.flatMapM f).step = (do
     match it₁.step with
     | .yield it₁' b h =>
-      return .deflate (.skip (it₁'.flatMapAfterM f (some (← f b))) (.outerYield_flatMapM_pure h))
+      let fx ← MonadAttach.attach (f b)
+      return .deflate (.skip (it₁'.flatMapAfterM f (some fx.val)) (.outerYield_flatMapM_pure h fx.property))
     | .skip it₁' h => return .deflate (.skip (it₁'.flatMapAfterM f none) (.outerSkip_flatMapM_pure h))
     | .done h => return .deflate (.done (.outerDone_flatMapM_pure h))) := by
   simp [flatMapM, step_flatMapAfterM]
@@ -171,8 +186,9 @@ public theorem Iter.step_flatMap {α : Type w} {β : Type w} {α₂ : Type w}
     | .done h => .done (.outerDone_flatMap_pure h)) := by
   simp [flatMap, step_flatMapAfter]
 
-public theorem Iter.toList_flatMapAfterM {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ] [Finite α Id] [Finite α₂ m]
+public theorem Iter.toList_flatMapAfterM {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α Id β] [Iterator α₂ m γ] [Finite α Id] [Finite α₂ m]
     [IteratorCollect α Id m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α Id m] [LawfulIteratorCollect α₂ m m]
     {f : β → m (IterM (α := α₂) m γ)}
@@ -183,15 +199,12 @@ public theorem Iter.toList_flatMapAfterM {α α₂ β γ : Type w} {m : Type w �
       | some it₂ => return (← it₂.toList) ++
           (← List.flatten <$> (it₁.mapM fun b => do (← f b).toList).toList) := by
   simp only [flatMapAfterM, IterM.toList_flatMapAfterM]
-  split
-  · simp only [mapM, IterM.toList_mapM_mapM, monadLift_self]
-    congr <;> simp
-  · apply bind_congr; intro step
-    simp only [mapM, IterM.toList_mapM_mapM, monadLift_self, bind_pure_comp, Functor.map_map]
-    congr <;> simp
+  letI : IteratorCollect α Id Id := .defaultImplementation
+  split <;> simp [IterM.toList_mapM_eq_toList_mapWithPostcondition]
 
-public theorem Iter.toArray_flatMapAfterM {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ] [Finite α Id] [Finite α₂ m]
+public theorem Iter.toArray_flatMapAfterM {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α Id β] [Iterator α₂ m γ] [Finite α Id] [Finite α₂ m]
     [IteratorCollect α Id m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α Id m] [LawfulIteratorCollect α₂ m m]
     {f : β → m (IterM (α := α₂) m γ)}
@@ -202,15 +215,12 @@ public theorem Iter.toArray_flatMapAfterM {α α₂ β γ : Type w} {m : Type w 
       | some it₂ => return (← it₂.toArray) ++
           (← Array.flatten <$> (it₁.mapM fun b => do (← f b).toArray).toArray) := by
   simp only [flatMapAfterM, IterM.toArray_flatMapAfterM]
-  split
-  · simp only [mapM, IterM.toArray_mapM_mapM, monadLift_self]
-    congr <;> simp
-  · apply bind_congr; intro step
-    simp only [mapM, IterM.toArray_mapM_mapM, monadLift_self, bind_pure_comp, Functor.map_map]
-    congr <;> simp
+  letI : IteratorCollect α Id Id := .defaultImplementation
+  split <;> simp [IterM.toArray_mapM_eq_toArray_mapWithPostcondition]
 
-public theorem Iter.toList_flatMapM {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ] [Finite α Id] [Finite α₂ m]
+public theorem Iter.toList_flatMapM {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α Id β] [Iterator α₂ m γ] [Finite α Id] [Finite α₂ m]
     [IteratorCollect α Id m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α Id m] [LawfulIteratorCollect α₂ m m]
     {f : β → m (IterM (α := α₂) m γ)}
@@ -218,8 +228,9 @@ public theorem Iter.toList_flatMapM {α α₂ β γ : Type w} {m : Type w → Ty
     (it₁.flatMapM f).toList = List.flatten <$> (it₁.mapM fun b => do (← f b).toList).toList := by
   simp [flatMapM, toList_flatMapAfterM]
 
-public theorem Iter.toArray_flatMapM {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α Id β] [Iterator α₂ m γ] [Finite α Id] [Finite α₂ m]
+public theorem Iter.toArray_flatMapM {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α Id β] [Iterator α₂ m γ] [Finite α Id] [Finite α₂ m]
     [IteratorCollect α Id m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α Id m] [LawfulIteratorCollect α₂ m m]
     {f : β → m (IterM (α := α₂) m γ)}
@@ -236,7 +247,7 @@ public theorem Iter.toList_flatMapAfter {α α₂ β γ : Type w} [Iterator α I
       | some it₂ => it₂.toList ++
           (it₁.map fun b => (f b).toList).toList.flatten := by
   simp only [flatMapAfter, Iter.toList, toIterM_toIter, IterM.toList_flatMapAfter]
-  cases it₂ <;> simp [map, IterM.toList_map_eq_toList_mapM]
+  cases it₂ <;> simp [map]
 
 public theorem Iter.toArray_flatMapAfter {α α₂ β γ : Type w} [Iterator α Id β] [Iterator α₂ Id γ]
     [Finite α Id] [Finite α₂ Id] [IteratorCollect α Id Id] [IteratorCollect α₂ Id Id]

--- a/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/FilterMap.lean
+++ b/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/FilterMap.lean
@@ -9,6 +9,8 @@ prelude
 public import Init.Data.Iterators.Combinators.Monadic.FilterMap
 public import Init.Data.Iterators.Lemmas.Consumers.Monadic
 import all Init.Data.Iterators.Consumers.Monadic.Collect
+import Init.Control.Lawful.MonadAttach.Lemmas
+import Init.Data.Array.Monadic
 
 public section
 
@@ -92,15 +94,15 @@ theorem IterM.step_mapWithPostcondition {γ : Type w} {f : β → PostconditionT
   | .done h => rfl
 
 theorem IterM.step_filterMapM {f : β → n (Option β')}
-    [Monad n] [LawfulMonad n] [MonadLiftT m n] :
+    [Monad n] [MonadAttach n] [LawfulMonad n] [MonadLiftT m n] :
   (it.filterMapM f).step = (do
     match (← it.step).inflate with
     | .yield it' out h => do
-      match ← f out with
-      | none =>
-        pure <| .deflate <| .skip (it'.filterMapM f) (.yieldNone (out := out) h .intro)
-      | some out' =>
-        pure <| .deflate <| .yield (it'.filterMapM f) out' (.yieldSome (out := out) h .intro)
+      match ← MonadAttach.attach (f out) with
+      | ⟨none, hf⟩ =>
+        pure <| .deflate <| .skip (it'.filterMapM f) (.yieldNone (out := out) h hf)
+      | ⟨some out', hf⟩ =>
+        pure <| .deflate <| .yield (it'.filterMapM f) out' (.yieldSome (out := out) h hf)
     | .skip it' h =>
       pure <| .deflate <| .skip (it'.filterMapM f) (.skip h)
     | .done h =>
@@ -109,7 +111,6 @@ theorem IterM.step_filterMapM {f : β → n (Option β')}
   intro step
   match step.inflate with
   | .yield it' out h =>
-    simp only [PostconditionT.lift, bind_map_left]
     apply bind_congr
     intro step
     rcases step with _ | _ <;> rfl
@@ -117,15 +118,15 @@ theorem IterM.step_filterMapM {f : β → n (Option β')}
   | .done h => rfl
 
 theorem IterM.step_filterM {f : β → n (ULift Bool)}
-    [Monad n] [LawfulMonad n] [MonadLiftT m n] :
+    [Monad n] [MonadAttach n] [LawfulMonad n] [MonadLiftT m n] :
   (it.filterM f).step = (do
     match (← it.step).inflate with
     | .yield it' out h => do
-      match ← f out with
-      | .up false =>
-        pure <| .deflate <| .skip (it'.filterM f) (.yieldNone (out := out) h ⟨⟨.up false, .intro⟩, rfl⟩)
-      | .up true =>
-        pure <| .deflate <| .yield (it'.filterM f) out (.yieldSome (out := out) h ⟨⟨.up true, .intro⟩, rfl⟩)
+      match ← MonadAttach.attach (f out) with
+      | ⟨.up false, hf⟩ =>
+        pure <| .deflate <| .skip (it'.filterM f) (.yieldNone (out := out) h ⟨⟨.up false, hf⟩, rfl⟩)
+      | ⟨.up true, hf⟩ =>
+        pure <| .deflate <| .yield (it'.filterM f) out (.yieldSome (out := out) h ⟨⟨.up true, hf⟩, rfl⟩)
     | .skip it' h =>
       pure <| .deflate <| .skip (it'.filterM f) (.skip h)
     | .done h =>
@@ -134,8 +135,8 @@ theorem IterM.step_filterM {f : β → n (ULift Bool)}
   intro step
   match step.inflate with
   | .yield it' out h =>
-    simp only [PostconditionT.lift, PostconditionT.operation_map, Functor.map_map,
-      PlausibleIterStep.skip, PlausibleIterStep.yield, bind_map_left]
+    simp only [PostconditionT.operation_map, PlausibleIterStep.skip, PlausibleIterStep.yield,
+      bind_map_left]
     apply bind_congr
     intro step
     rcases step with _ | _ <;> rfl
@@ -143,12 +144,12 @@ theorem IterM.step_filterM {f : β → n (ULift Bool)}
   | .done h => rfl
 
 theorem IterM.step_mapM {γ : Type w} {f : β → n γ}
-    [Monad n] [LawfulMonad n] [MonadLiftT m n] :
+    [Monad n] [MonadAttach n] [LawfulMonad n] [MonadLiftT m n] :
   (it.mapM f).step = (do
     match (← it.step).inflate with
     | .yield it' out h => do
-      let out' ← f out
-      pure <| .deflate <| .yield (it'.mapM f) out' (.yieldSome h ⟨⟨out', True.intro⟩, rfl⟩)
+      let out' ← MonadAttach.attach (f out)
+      pure <| .deflate <| .yield (it'.mapM f) out'.val (.yieldSome h ⟨out', rfl⟩)
     | .skip it' h =>
       pure <| .deflate <| .skip (it'.mapM f) (.skip h)
     | .done h =>
@@ -158,8 +159,7 @@ theorem IterM.step_mapM {γ : Type w} {f : β → n γ}
   match step.inflate with
   | .yield it' out h =>
     simp only [bind_pure_comp]
-    simp only [PostconditionT.lift]
-    simp only [PostconditionT.operation_map, Functor.map_map, PlausibleIterStep.skip,
+    simp only [PostconditionT.operation_map, PlausibleIterStep.skip,
       PlausibleIterStep.yield, bind_map_left, bind_pure_comp]
     rfl
   | .skip it' h => rfl
@@ -293,19 +293,80 @@ theorem IterM.InternalConsumers.toList_filterMap {α β γ: Type w} {m : Type w 
   · simp [ihs ‹_›]
   · simp
 
-theorem IterM.toList_map_eq_toList_mapM {α β γ : Type w}
-    {m : Type w → Type w'} [Monad m] [LawfulMonad m]
-    [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
-    {f : β → γ} {it : IterM (α := α) m β} :
-    (it.map f).toList = (it.mapM fun b => pure (f b)).toList := by
-  induction it using IterM.inductSteps with | step it ihy ihs
-  rw [toList_eq_match_step, toList_eq_match_step, step_map, step_mapM, bind_assoc, bind_assoc]
-  apply bind_congr; intro step
-  split <;> simp (discharger := assumption) [ihy, ihs]
+namespace Internal
+
+/-- A variant of `Subtype.casesOn` that is not reduced by `simp`. -/
+@[elab_as_elim]
+private def subtypeCasesOn' := @Subtype.casesOn
+
+private def optionPelim' {α : Type u_1} (t : Option α) {β :  Sort u_2}
+    (n : t = none → β) (s : (val : α) → t = some val → β) : β :=
+  match t with
+  | some a => s a rfl
+  | none => n rfl
+
+/--
+Inserts an `Option` case distinction after the first computation of a call to `MonadAttach.pbind`.
+This lemma is useful for simplifying the second computation, which often involes `match` expressions
+that use `pbind`'s proof term.
+-/
+private theorem pbind_eq_pbind_if_isSome [Monad m] [MonadAttach m] (x : m (Option α)) (f : (_ : _) → _ → m β) :
+    MonadAttach.pbind x f = MonadAttach.pbind x
+        (fun a ha => optionPelim' a (fun _ => f none (by simp_all)) (fun a _ => f (some a) (by simp_all))) := by
+  intros; congr; ext
+  simp only [optionPelim']
+  split <;> simp
+
+private theorem bind_subtypeCasesOn'_eq_map_bind [Monad m] [LawfulMonad m] {P : α → Prop}
+    (x : m (Subtype P)) (f : α → m β) :
+    x >>= (fun a => subtypeCasesOn' a fun a _ => f a) = (Subtype.val <$> x) >>= f := by
+  simp [subtypeCasesOn']
+
+private theorem bind_eq_bind_subtypeCasesOn'_optionPelim' [Monad m] [LawfulMonad m]
+    {P : Option α → Prop} (x : m (Subtype P)) (f : Subtype P → m β) :
+    x >>= f = x >>= (fun a => subtypeCasesOn' a fun (a : Option α) ha => optionPelim' a (fun h =>
+          f ⟨none, by simp_all⟩) (fun a h => f ⟨some a, by simp_all⟩)) := by
+  apply bind_congr; intro x
+  rcases x with ⟨_ | ⟨a⟩⟩
+  all_goals simp [subtypeCasesOn', optionPelim']
+
+end Internal
+
+open Internal
+
+theorem IterM.toList_mapWithPostcondition_eq_toList_filterMapWithPostcondition {α β γ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''}
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [MonadLiftT m n][LawfulMonadLiftT m n]
+    [Iterator α m β] [Finite α m] [IteratorCollect α m n] [LawfulIteratorCollect α m n]
+    {f : β → PostconditionT n γ} {it : IterM (α := α) m β} :
+    (it.mapWithPostcondition f).toList =
+      (it.filterMapWithPostcondition (PostconditionT.map some <| f ·)).toList := by
+  simp only [toList_eq_toList_defaultImplementation]; rfl
+
+theorem IterM.toList_filterMapM_eq_toList_filterMapWithPostcondition {α β γ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''}
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [MonadLiftT m n][LawfulMonadLiftT m n]
+    [Iterator α m β] [Finite α m]
+    {f : β → n (Option γ)} {it : IterM (α := α) m β} :
+    (it.filterMapM f).toList =
+      (it.filterMapWithPostcondition fun b => .attachLift (f b)).toList := by
+  rfl
+
+theorem IterM.toList_mapM_eq_toList_mapWithPostcondition {α β γ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''}
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [MonadLiftT m n][LawfulMonadLiftT m n]
+    [Iterator α m β] [Finite α m] [IteratorCollect α m n] [LawfulIteratorCollect α m n]
+    {f : β → n γ} {it : IterM (α := α) m β} :
+    (it.mapM f).toList =
+      (it.mapWithPostcondition fun b => .attachLift (f b)).toList := by
+  rfl
 
 theorem IterM.toList_mapM_eq_toList_filterMapM {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n][LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorCollect α m n] [LawfulIteratorCollect α m n]
     {f : β → n γ} {it : IterM (α := α) m β} :
@@ -314,20 +375,155 @@ theorem IterM.toList_mapM_eq_toList_filterMapM {α β γ : Type w}
   induction it using IterM.inductSteps with | step it ihy ihs
   rw [toList_eq_match_step, toList_eq_match_step, step_mapM, step_filterMapM, bind_assoc, bind_assoc]
   apply bind_congr; intro step
-  split <;> simp (discharger := assumption) [ihy, ihs]
+  split
+  · conv =>
+      rhs
+      simp only [bind_pure_comp, bind_assoc]
+      simp only [MonadAttach.attach_bind_eq_pbind]
+      rw [pbind_eq_pbind_if_isSome]
+    simp [MonadAttach.attach_bind_eq_pbind, WeaklyLawfulMonadAttach.pbind_eq_bind, optionPelim', ihy ‹_›]
+  · simp [ihs ‹_›]
+  · simp
 
-theorem IterM.toList_map_eq_toList_filterMapM {α β γ : Type w}
-    {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+theorem IterM.toList_map_eq_toList_mapM {α β γ : Type w}
+    {m : Type w → Type w'} [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
+    {f : β → γ} {it : IterM (α := α) m β} :
+    (it.map f).toList = (it.mapM fun b => pure (f b)).toList := by
+  induction it using IterM.inductSteps with | step it ihy ihs
+  rw [toList_eq_match_step, toList_eq_match_step, step_map, step_mapM, bind_assoc, bind_assoc]
+  apply bind_congr; intro step
+  split
+  · simp only [PlausibleIterStep.yield, bind_pure_comp, pure_bind, Shrink.inflate_deflate,
+      bind_map_left]
+    conv => rhs; rhs; ext a; rw [← pure_bind (x := a.val) (f := fun _ => _ <$> _)]
+    simp only [← bind_assoc, bind_pure_comp, WeaklyLawfulMonadAttach.map_attach]
+    simp [ihy ‹_›]
+  · simp [ihs ‹_›]
+  · simp
+
+theorem IterM.toList_map_eq_toList_filterMapM {α β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → γ} {it : IterM (α := α) m β} :
     (it.map f).toList = (it.filterMapM fun b => pure (some (f b))).toList := by
   simp [toList_map_eq_toList_mapM, toList_mapM_eq_toList_filterMapM]
   congr <;> simp
 
+/--
+Variant of `toList_filterMapWithPostcondition_filterMapWithPostcondition` that is intended to be
+used with the `apply` tactic. Because neither the LHS nor the RHS determine all implicit parameters,
+it cannot be used easily with `rw` or `simp`.
+-/
+private theorem IterM.toList_filterMapWithPostcondition_filterMapWithPostcondition'
+    {α β γ δ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
+    [Iterator α m β] [Finite α m]
+    {f : β → PostconditionT n (Option γ)} {g : γ → PostconditionT o (Option δ)}
+    {fg : β → PostconditionT o (Option δ)}
+    {it : IterM (α := α) m β}
+    (h : ∀ b, (fg b).run = do match ← (f b).run with | none => return none | some fb => (g fb).run) :
+    letI : MonadLift n o := ⟨monadLift⟩
+    ((it.filterMapWithPostcondition f).filterMapWithPostcondition g).toList =
+      (it.filterMapWithPostcondition (n := o) fg).toList := by
+  induction it using IterM.inductSteps with | step it ihy ihs
+  letI : MonadLift n o := ⟨monadLift⟩
+  haveI : LawfulMonadLift n o := ⟨by simp [this], by simp [this]⟩
+  rw [toList_eq_match_step, toList_eq_match_step, step_filterMapWithPostcondition,
+    bind_assoc, step_filterMapWithPostcondition, step_filterMapWithPostcondition]
+  simp only [bind_assoc, liftM_bind]
+  apply bind_congr; intro step
+  split
+  · simp only [bind_assoc, liftM_bind]
+    rw [PostconditionT.operation_eq_map_mk_operation, liftM_map, bind_map_left]
+    simp
+    conv =>
+      rhs
+      rw [bind_eq_bind_subtypeCasesOn'_optionPelim' (x := (fg _).operation)]
+      simp only [pure_bind, Shrink.inflate_deflate]
+      rw [bind_subtypeCasesOn'_eq_map_bind]
+    conv =>
+      lhs
+      rw [bind_eq_bind_subtypeCasesOn'_optionPelim']
+      simp only [liftM_pure, pure_bind, Shrink.inflate_deflate, bind_assoc]
+      simp +singlePass only [bind_eq_bind_subtypeCasesOn'_optionPelim' (x := (g _).operation)]
+      simp only [pure_bind, Shrink.inflate_deflate]
+      simp only [bind_subtypeCasesOn'_eq_map_bind]
+      rw [← liftM_map]
+    simp only [← PostconditionT.run_eq_map, h, bind_assoc, optionPelim']
+    apply bind_congr; intro fx
+    split <;> simp [ihy ‹_›]
+  · simp [ihs ‹_›]
+  · simp
+
+@[simp]
+theorem IterM.toList_filterMapWithPostcondition_filterMapWithPostcondition {α β γ δ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
+    [Iterator α m β] [Finite α m]
+    {f : β → PostconditionT n (Option γ)} {g : γ → PostconditionT o (Option δ)}
+    {it : IterM (α := α) m β} :
+    haveI : MonadLift n o := ⟨monadLift⟩
+    ((it.filterMapWithPostcondition f).filterMapWithPostcondition g).toList =
+      (it.filterMapWithPostcondition (n := o) (fun b => do
+        match ← (f b) with
+        | none => return none
+        | some fb => g fb)).toList := by
+  apply toList_filterMapWithPostcondition_filterMapWithPostcondition'
+  intro b
+  simp only [PostconditionT.run_bind']
+  simp only [liftM, monadLift, MonadLift.monadLift, monadLift_self, PostconditionT.run_eq_map,
+    bind_map_left, liftM_map]
+  apply bind_congr; intro fx
+  split <;> simp [*]
+
+@[simp]
+theorem IterM.toList_mapWithPostcondition_mapWithPostcondition {α β γ δ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
+    [Iterator α m β] [Finite α m] [IteratorCollect α m n] [LawfulIteratorCollect α m n]
+    [IteratorCollect α m o] [LawfulIteratorCollect α m o]
+    {f : β → PostconditionT n γ} {g : γ → PostconditionT o δ}
+    {it : IterM (α := α) m β} :
+    haveI : MonadLift n o := ⟨monadLift⟩
+    ((it.mapWithPostcondition f).mapWithPostcondition g).toList =
+      (it.mapWithPostcondition (n := o) (f · >>= g)).toList := by
+  simp only [toList_mapWithPostcondition_eq_toList_filterMapWithPostcondition]
+  apply toList_filterMapWithPostcondition_filterMapWithPostcondition'
+  intro b
+  simp [liftM, monadLift, MonadLift.monadLift, PostconditionT.run_eq_map, PostconditionT.operation_bind']
+
+@[simp]
+theorem IterM.toList_filterMapM_filterMapWithPostcondition {α β γ δ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
+    [Monad m] [LawfulMonad m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [WeaklyLawfulMonadAttach o]
+    [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
+    [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
+    {f : β → PostconditionT n (Option γ)} {g : γ → o (Option δ)}
+    {it : IterM (α := α) m β} :
+    haveI : MonadLift n o := ⟨monadLift⟩
+    ((it.filterMapWithPostcondition f).filterMapM g).toList =
+      (it.filterMapM (n := o) (fun b => do
+        match ← (f b).run with
+        | none => return none
+        | some fb => g fb)).toList := by
+  apply toList_filterMapWithPostcondition_filterMapWithPostcondition'
+  intro b
+  simp only [PostconditionT.attachLift, PostconditionT.run_eq_map, WeaklyLawfulMonadAttach.map_attach]
+  rfl
+
 @[simp]
 theorem IterM.toList_filterMapM_filterMapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [LawfulMonad m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [WeaklyLawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → n (Option γ)} {g : γ → o (Option δ)}
@@ -338,28 +534,16 @@ theorem IterM.toList_filterMapM_filterMapM {α β γ δ : Type w}
         match ← f b with
         | none => return none
         | some fb => g fb)).toList := by
-  induction it using IterM.inductSteps with | step it ihy ihs
-  letI : MonadLift n o := ⟨monadLift⟩
-  haveI : LawfulMonadLift n o := ⟨by simp [this], by simp [this]⟩
-  rw [toList_eq_match_step, toList_eq_match_step, step_filterMapM,
-    bind_assoc, step_filterMapM, step_filterMapM]
-  simp only [bind_assoc, liftM_bind]
-  apply bind_congr; intro step
-  split
-  · simp only [bind_assoc, liftM_bind]
-    apply bind_congr; intro fx
-    split
-    · simp [ihy ‹_›]
-    · simp only [liftM_pure, PlausibleIterStep.skip, pure_bind, bind_assoc, Shrink.inflate_deflate]
-      apply bind_congr; intro gx
-      split <;> simp [ihy ‹_›]
-  · simp [ihs ‹_›]
-  · simp
+  apply toList_filterMapWithPostcondition_filterMapWithPostcondition'
+  intro b
+  simp only [PostconditionT.attachLift, PostconditionT.run_eq_map, WeaklyLawfulMonadAttach.map_attach]
+  rfl
 
 @[simp]
 theorem IterM.toList_filterMapM_mapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [WeaklyLawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
     {f : β → n γ} {g : γ → o (Option δ)}
@@ -367,26 +551,17 @@ theorem IterM.toList_filterMapM_mapM {α β γ δ : Type w}
     haveI : MonadLift n o := ⟨monadLift⟩
     ((it.mapM f).filterMapM g).toList =
       (it.filterMapM (n := o) (fun b => do g (← f b))).toList := by
-  induction it using IterM.inductSteps with | step it ihy ihs
-  letI : MonadLift n o := ⟨monadLift⟩
-  haveI : LawfulMonadLift n o := ⟨by simp [this], by simp [this]⟩
-  rw [toList_eq_match_step, toList_eq_match_step, step_filterMapM,
-    bind_assoc, step_filterMapM, step_mapM]
-  simp only [bind_assoc, liftM_bind]
-  apply bind_congr; intro step
-  split
-  · simp only [bind_assoc, liftM_bind]
-    apply bind_congr; intro fx
-    simp only [liftM_pure, pure_bind, bind_assoc, Shrink.inflate_deflate]
-    apply bind_congr; intro gx
-    split <;> simp [ihy ‹_›]
-  · simp [ihs ‹_›]
-  · simp
+  apply toList_filterMapWithPostcondition_filterMapWithPostcondition'
+  intro b
+  simp only [PostconditionT.attachLift, PostconditionT.run_eq_map, WeaklyLawfulMonadAttach.map_attach,
+    PostconditionT.operation_map]
+  conv => lhs; simp only [← WeaklyLawfulMonadAttach.map_attach (x := f _)]
+  simp
 
 @[simp]
 theorem IterM.toList_filterMapM_map {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m]
     {f : β → γ} {g : γ → n (Option δ)}
@@ -408,7 +583,8 @@ theorem IterM.toList_filterMapM_map {α β γ δ : Type w}
 @[simp]
 theorem IterM.toList_mapM_filterMapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [WeaklyLawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → n (Option γ)} {g : γ → o δ}
@@ -424,7 +600,8 @@ theorem IterM.toList_mapM_filterMapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toList_mapM_mapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [WeaklyLawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m] [IteratorCollect α m o] [LawfulIteratorCollect α m o]
     {f : β → n γ} {g : γ → o δ}
@@ -438,7 +615,7 @@ theorem IterM.toList_mapM_mapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toList_mapM_map {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorCollect α m n] [LawfulIteratorCollect α m n]
     {f : β → γ} {g : γ → n δ}
@@ -447,6 +624,89 @@ theorem IterM.toList_mapM_map {α β γ δ : Type w}
       (it.mapM (n := n) (fun b => g (f b))).toList := by
   simp [toList_mapM_eq_toList_filterMapM]
 
+@[simp]
+theorem IterM.toList_map_mapM {α β γ δ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''}
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [MonadLiftT m n] [LawfulMonadLiftT m n]
+    [Iterator α m β] [Finite α m] [IteratorCollect α m n] [LawfulIteratorCollect α m n]
+    {f : β → n γ} {g : γ → δ}
+    {it : IterM (α := α) m β} :
+    ((it.mapM f).map g).toList =
+      (it.mapM (n := n) (fun b => return g (← f b))).toList := by
+  simp only [toList_mapM_eq_toList_filterMapM, toList_map_eq_toList_filterMapM,
+    toList_filterMapM_mapM]
+  congr <;> simp
+
+@[simp]
+theorem IterM.toList_filterMapWithPostcondition {α β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [LawfulMonad m]
+    [Iterator α Id β] [IteratorCollect α Id m] [LawfulIteratorCollect α Id m] [Finite α Id]
+    [IteratorCollect α Id Id] [LawfulIteratorCollect α Id Id]
+    {f : β → PostconditionT m (Option γ)} (it : IterM (α := α) Id β) :
+    (it.filterMapWithPostcondition f).toList = it.toList.run.filterMapM (fun x => (f x).run) := by
+  induction it using IterM.inductSteps
+  rename_i it ihy ihs
+  rw [IterM.toList_eq_match_step, IterM.toList_eq_match_step]
+  simp only [step_filterMapWithPostcondition]
+  simp only [liftM, monadLift, pure_bind]
+  split <;> rename_i heq
+  · have := congrArg (fun x => pure (f := Id) (Shrink.deflate x)) heq
+    simp only [Shrink.deflate_inflate, Id.pure_run] at this
+    simp only [bind_pure_comp, bind_assoc, PostconditionT.run_eq_map, this, pure_bind,
+      Shrink.inflate_deflate, Id.run_map, List.filterMapM_cons, bind_map_left]
+    apply bind_congr; intro a
+    split
+    · simp [ihy ‹_›, PostconditionT.run_eq_map]
+    · simp [ihy ‹_›, PostconditionT.run_eq_map]
+  · simp [ihs ‹_›, heq]
+  · simp [heq]
+
+@[simp]
+theorem IterM.toList_mapWithPostcondition {α β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [LawfulMonad m] [Iterator α Id β] [IteratorCollect α Id m]
+    [LawfulIteratorCollect α Id m] [Finite α Id]
+    [IteratorCollect α Id Id] [LawfulIteratorCollect α Id Id]
+    {f : β → PostconditionT m γ} (it : IterM (α := α) Id β) :
+    (it.mapWithPostcondition f).toList = it.toList.run.mapM (fun x => (f x).run) := by
+  induction it using IterM.inductSteps
+  rename_i it ihy ihs
+  rw [IterM.toList_eq_match_step, IterM.toList_eq_match_step]
+  simp only [step_mapWithPostcondition]
+  simp only [liftM, monadLift, pure_bind]
+  split <;> rename_i heq
+  · have := congrArg (fun x => pure (f := Id) (Shrink.deflate x)) heq
+    simp only [Shrink.deflate_inflate, Id.pure_run] at this
+    simp only [bind_pure_comp, PostconditionT.run_eq_map, this, pure_bind,
+      Shrink.inflate_deflate, Id.run_map, bind_map_left, List.mapM_cons]
+    apply bind_congr; intro a
+    simp [ihy ‹_›, PostconditionT.run_eq_map]
+  · simp [ihs ‹_›, heq]
+  · simp [heq]
+
+@[simp]
+theorem IterM.toList_filterMapM {α β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α Id β] [IteratorCollect α Id m]
+    [LawfulIteratorCollect α Id m] [Finite α Id]
+    [IteratorCollect α Id Id] [LawfulIteratorCollect α Id Id]
+    {f : β → m (Option γ)} (it : IterM (α := α) Id β) :
+    (it.filterMapM f).toList = it.toList.run.filterMapM f := by
+  simp [toList_filterMapM_eq_toList_filterMapWithPostcondition, toList_filterMapWithPostcondition,
+    PostconditionT.attachLift, PostconditionT.run_eq_map, WeaklyLawfulMonadAttach.map_attach]
+
+@[simp]
+theorem IterM.toList_mapM {α β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α Id β] [IteratorCollect α Id m]
+    [LawfulIteratorCollect α Id m] [Finite α Id]
+    [IteratorCollect α Id Id] [LawfulIteratorCollect α Id Id]
+    {f : β → m γ} (it : IterM (α := α) Id β) :
+    (it.mapM f).toList = it.toList.run.mapM f := by
+  simp [toList_mapM_eq_toList_mapWithPostcondition, toList_mapWithPostcondition,
+    PostconditionT.attachLift, PostconditionT.run_eq_map, WeaklyLawfulMonadAttach.map_attach]
+
+@[simp]
 theorem IterM.toList_filterMap {α β γ : Type w} {m : Type w → Type w'}
     [Monad m] [LawfulMonad m]
     [Iterator α m β] [IteratorCollect α m m] [LawfulIteratorCollect α m m] [Finite α m]
@@ -475,6 +735,7 @@ theorem IterM.toList_filterMap {α β γ : Type w} {m : Type w → Type w'}
     assumption
   · simp
 
+@[simp]
 theorem IterM.toList_map {α β β' : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
     [Iterator α m β] [IteratorCollect α m m] [LawfulIteratorCollect α m m] [Finite α m] {f : β → β'}
     (it : IterM (α := α) m β) :
@@ -498,6 +759,7 @@ theorem IterM.toList_map {α β β' : Type w} {m : Type w → Type w'} [Monad m]
     · simp [Map]
     · simp
 
+@[simp]
 theorem IterM.toList_filter {α : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
     {β : Type w} [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → Bool} {it : IterM (α := α) m β} :
@@ -509,55 +771,120 @@ end ToList
 
 section ToListRev
 
-theorem IterM.toListRev_map_eq_toListRev_mapM {α β γ : Type w}
-    {m : Type w → Type w'} [Monad m] [LawfulMonad m]
-    [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
-    {f : β → γ} {it : IterM (α := α) m β} :
-    (it.map f).toListRev = (it.mapM fun b => pure (f b)).toListRev := by
-  simp [toListRev_eq, toList_map_eq_toList_mapM]
-
-theorem IterM.toListRev_mapM_eq_toListRev_filterMapM {α β γ : Type w}
+theorem IterM.toListRev_mapWithPostcondition_eq_toListRev_filterMapWithPostcondition {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
     [MonadLiftT m n][LawfulMonadLiftT m n]
-    [Iterator α m β] [Finite α m] [IteratorCollect α m n] [LawfulIteratorCollect α m n]
+    [Iterator α m β] [Finite α m]
+    {f : β → PostconditionT n γ} {it : IterM (α := α) m β} :
+    (it.mapWithPostcondition f).toListRev =
+      (it.filterMapWithPostcondition (PostconditionT.map some <| f ·)).toListRev := by
+  rfl
+
+theorem IterM.toListRev_filterMapM_eq_toListRev_filterMapWithPostcondition {α β γ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''}
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [MonadLiftT m n][LawfulMonadLiftT m n]
+    [Iterator α m β] [Finite α m]
+    {f : β → n (Option γ)} {it : IterM (α := α) m β} :
+    (it.filterMapM f).toListRev =
+      (it.filterMapWithPostcondition fun b => .attachLift (f b)).toListRev := by
+  rfl
+
+theorem IterM.toListRev_mapM_eq_toListRev_mapWithPostcondition {α β γ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''}
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [MonadLiftT m n][LawfulMonadLiftT m n]
+    [Iterator α m β] [Finite α m] {f : β → n γ} {it : IterM (α := α) m β} :
+    (it.mapM f).toListRev =
+      (it.mapWithPostcondition fun b => .attachLift (f b)).toListRev := by
+  rfl
+
+theorem IterM.toListRev_mapM_eq_toListRev_filterMapM {α β γ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''}
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [MonadLiftT m n][LawfulMonadLiftT m n]
+    [Iterator α m β] [Finite α m]
     {f : β → n γ} {it : IterM (α := α) m β} :
     (it.mapM f).toListRev =
       (it.filterMapM fun b => some <$> f b).toListRev := by
+  letI : IteratorCollect α m n := .defaultImplementation
   simp [toListRev_eq, toList_mapM_eq_toList_filterMapM]
 
+theorem IterM.toListRev_map_eq_toListRev_mapM {α β γ : Type w}
+    {m : Type w → Type w'} [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α m β] [Finite α m]
+    {f : β → γ} {it : IterM (α := α) m β} :
+    (it.map f).toListRev = (it.mapM fun b => pure (f b)).toListRev := by
+  letI : IteratorCollect α m m := .defaultImplementation
+  simp [toListRev_eq, toList_map_eq_toList_mapM, - toList_map]
+
 theorem IterM.toListRev_map_eq_toListRev_filterMapM {α β γ : Type w}
-    {m : Type w → Type w'} [Monad m] [LawfulMonad m]
-    [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
+    {m : Type w → Type w'} [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α m β] [Finite α m]
     {f : β → γ} {it : IterM (α := α) m β} :
     (it.map f).toListRev = (it.filterMapM fun b => pure (some (f b))).toListRev := by
-  simp [toListRev_eq, toList_map_eq_toList_filterMapM]
+  letI : IteratorCollect α m m := .defaultImplementation
+  simp [toListRev_eq, toList_map_eq_toList_filterMapM, - toList_map]
 
-theorem IterM.toListRev_filterMap {α β γ : Type w} {m : Type w → Type w'}
+@[simp]
+theorem IterM.toListRev_filterMapWithPostcondition_filterMapWithPostcondition {α β γ δ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
+    [Iterator α m β] [Finite α m]
+    {f : β → PostconditionT n (Option γ)} {g : γ → PostconditionT o (Option δ)}
+    {it : IterM (α := α) m β} :
+    haveI : MonadLift n o := ⟨monadLift⟩
+    ((it.filterMapWithPostcondition f).filterMapWithPostcondition g).toListRev =
+      (it.filterMapWithPostcondition (n := o) (fun b => do
+        match ← (f b) with
+        | none => return none
+        | some fb => g fb)).toListRev := by
+  simp [toListRev_eq]
+
+@[simp]
+theorem IterM.toListRev_mapWithPostcondition_mapWithPostcondition {α β γ δ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
+    [Iterator α m β] [Finite α m]
+    {f : β → PostconditionT n γ} {g : γ → PostconditionT o δ}
+    {it : IterM (α := α) m β} :
+    haveI : MonadLift n o := ⟨monadLift⟩
+    ((it.mapWithPostcondition f).mapWithPostcondition g).toListRev =
+      (it.mapWithPostcondition (n := o) (f · >>= g)).toListRev := by
+  letI : IteratorCollect α m n := .defaultImplementation
+  letI : IteratorCollect α m o := .defaultImplementation
+  simp [toListRev_eq]
+
+@[simp]
+theorem IterM.toListRev_filterMapM_filterMapWithPostcondition {α β γ δ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     [Monad m] [LawfulMonad m]
-    [Iterator α m β] [IteratorCollect α m m] [LawfulIteratorCollect α m m] [Finite α m]
-    {f : β → Option γ} (it : IterM (α := α) m β) :
-    (it.filterMap f).toListRev = (fun x => x.filterMap f) <$> it.toListRev := by
-  simp [toListRev_eq, toList_filterMap]
-
-theorem IterM.toListRev_map {α β γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
-    [Iterator α m β] [IteratorCollect α m m] [LawfulIteratorCollect α m m] [Finite α m] {f : β → γ}
-    (it : IterM (α := α) m β) :
-    (it.map f).toListRev = (fun x => x.map f) <$> it.toListRev := by
-  simp [toListRev_eq, toList_map]
-
-theorem IterM.toListRev_filter {α β : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
-    [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
-    {f : β → Bool} {it : IterM (α := α) m β} :
-    (it.filter f).toListRev = List.filter f <$> it.toListRev := by
-  simp [toListRev_eq, toList_filter]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [WeaklyLawfulMonadAttach o]
+    [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
+    [Iterator α m β] [Finite α m]
+    {f : β → PostconditionT n (Option γ)} {g : γ → o (Option δ)}
+    {it : IterM (α := α) m β} :
+    haveI : MonadLift n o := ⟨monadLift⟩
+    ((it.filterMapWithPostcondition f).filterMapM g).toListRev =
+      (it.filterMapM (n := o) (fun b => do
+        match ← (f b).run with
+        | none => return none
+        | some fb => g fb)).toListRev := by
+  letI : IteratorCollect α m m := .defaultImplementation
+  simp [toListRev_eq]
 
 @[simp]
 theorem IterM.toListRev_filterMapM_filterMapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [LawfulMonad m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [WeaklyLawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
-    [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
+    [Iterator α m β] [Finite α m]
     {f : β → n (Option γ)} {g : γ → o (Option δ)}
     {it : IterM (α := α) m β} :
     haveI : MonadLift n o := ⟨monadLift⟩
@@ -566,14 +893,17 @@ theorem IterM.toListRev_filterMapM_filterMapM {α β γ δ : Type w}
         match ← f b with
         | none => return none
         | some fb => g fb)).toListRev := by
+  letI : IteratorCollect α m m := .defaultImplementation
   simp [toListRev_eq]
 
 @[simp]
 theorem IterM.toListRev_filterMapM_mapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [LawfulMonad m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [WeaklyLawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
-    [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
+    [Iterator α m β] [Finite α m]
     {f : β → n γ} {g : γ → o (Option δ)}
     {it : IterM (α := α) m β} :
     haveI : MonadLift n o := ⟨monadLift⟩
@@ -584,9 +914,9 @@ theorem IterM.toListRev_filterMapM_mapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toListRev_filterMapM_map {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
-    [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
+    [Iterator α m β] [Finite α m]
     {f : β → γ} {g : γ → n (Option δ)}
     {it : IterM (α := α) m β} :
     ((it.map f).filterMapM g).toListRev =
@@ -596,9 +926,11 @@ theorem IterM.toListRev_filterMapM_map {α β γ δ : Type w}
 @[simp]
 theorem IterM.toListRev_mapM_filterMapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [LawfulMonad m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [WeaklyLawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
-    [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
+    [Iterator α m β] [Finite α m]
     {f : β → n (Option γ)} {g : γ → o δ}
     {it : IterM (α := α) m β} :
     haveI : MonadLift n o := ⟨monadLift⟩
@@ -607,12 +939,14 @@ theorem IterM.toListRev_mapM_filterMapM {α β γ δ : Type w}
         match ← f b with
         | none => return none
         | some fb => some <$> g fb)).toListRev := by
+  letI : IteratorCollect α m m := .defaultImplementation
   simp [toListRev_eq]
 
 @[simp]
 theorem IterM.toListRev_mapM_mapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [WeaklyLawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
     {f : β → n γ} {g : γ → o δ}
@@ -626,7 +960,7 @@ theorem IterM.toListRev_mapM_mapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toListRev_mapM_map {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] {f : β → γ} {g : γ → n δ} {it : IterM (α := α) m β} :
     ((it.map f).mapM g).toListRev =
@@ -634,56 +968,195 @@ theorem IterM.toListRev_mapM_map {α β γ δ : Type w}
   letI : IteratorCollect α m n := .defaultImplementation
   simp [toListRev_eq]
 
+@[simp]
+theorem IterM.toListRev_map_mapM {α β γ δ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''}
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [MonadLiftT m n] [LawfulMonadLiftT m n]
+    [Iterator α m β] [Finite α m]
+    {f : β → n γ} {g : γ → δ}
+    {it : IterM (α := α) m β} :
+    ((it.mapM f).map g).toListRev =
+      (it.mapM (n := n) (fun b => return g (← f b))).toListRev := by
+  letI : IteratorCollect α m n := .defaultImplementation
+  simp [toListRev_eq, - toList_map]
+
+@[simp]
+theorem IterM.toListRev_filterMapWithPostcondition {α β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [LawfulMonad m]
+    [Iterator α Id β] [IteratorCollect α Id Id] [LawfulIteratorCollect α Id Id] [Finite α Id]
+    {f : β → PostconditionT m (Option γ)} (it : IterM (α := α) Id β) :
+    (it.filterMapWithPostcondition f).toListRev =
+      List.reverse <$> it.toList.run.filterMapM (fun x => (f x).run) := by
+  letI : IteratorCollect α Id m := .defaultImplementation
+  simp [toListRev_eq]
+
+@[simp]
+theorem IterM.toListRev_mapWithPostcondition {α β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [LawfulMonad m] [Iterator α Id β] [Finite α Id]
+    [IteratorCollect α Id Id] [LawfulIteratorCollect α Id Id]
+    {f : β → PostconditionT m γ} (it : IterM (α := α) Id β) :
+    (it.mapWithPostcondition f).toListRev = List.reverse <$> it.toList.run.mapM (fun x => (f x).run) := by
+  letI : IteratorCollect α Id m := .defaultImplementation
+  simp [toListRev_eq]
+
+@[simp]
+theorem IterM.toListRev_filterMapM {α β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α Id β] [Finite α Id]
+    [IteratorCollect α Id Id] [LawfulIteratorCollect α Id Id]
+    {f : β → m (Option γ)} (it : IterM (α := α) Id β) :
+    (it.filterMapM f).toListRev = List.reverse <$> it.toList.run.filterMapM f := by
+  letI : IteratorCollect α Id m := .defaultImplementation
+  simp [toListRev_eq]
+
+@[simp]
+theorem IterM.toListRev_mapM {α β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α Id β] [Finite α Id]
+    [IteratorCollect α Id Id] [LawfulIteratorCollect α Id Id]
+    {f : β → m γ} (it : IterM (α := α) Id β) :
+    (it.mapM f).toListRev = List.reverse <$> it.toList.run.mapM f := by
+  letI : IteratorCollect α Id m := .defaultImplementation
+  simp [toListRev_eq]
+
+@[simp]
+theorem IterM.toListRev_filterMap {α β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [LawfulMonad m]
+    [Iterator α m β] [Finite α m]
+    {f : β → Option γ} (it : IterM (α := α) m β) :
+    (it.filterMap f).toListRev = (fun x => x.filterMap f) <$> it.toListRev := by
+  letI : IteratorCollect α m m := .defaultImplementation
+  simp [toListRev_eq]
+
+@[simp]
+theorem IterM.toListRev_map {α β γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+    [Iterator α m β] [Finite α m] {f : β → γ}
+    (it : IterM (α := α) m β) :
+    (it.map f).toListRev = (fun x => x.map f) <$> it.toListRev := by
+  letI : IteratorCollect α m m := .defaultImplementation
+  simp [toListRev_eq]
+
+@[simp]
+theorem IterM.toListRev_filter {α β : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+    [Iterator α m β] [Finite α m]
+    {f : β → Bool} {it : IterM (α := α) m β} :
+    (it.filter f).toListRev = List.filter f <$> it.toListRev := by
+  letI : IteratorCollect α m m := .defaultImplementation
+  simp [toListRev_eq]
+
 end ToListRev
 
 section ToArray
 
-theorem IterM.toArray_map_eq_toArray_mapM {α β γ : Type w}
-    {m : Type w → Type w'} [Monad m] [LawfulMonad m]
-    [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
-    {f : β → γ} {it : IterM (α := α) m β} :
-    (it.map f).toArray = (it.mapM fun b => pure (f b)).toArray := by
-  simp [← toArray_toList, toList_map_eq_toList_mapM]
+theorem IterM.toArray_mapWithPostcondition_eq_toArray_filterMapWithPostcondition {α β γ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''}
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [MonadLiftT m n][LawfulMonadLiftT m n]
+    [Iterator α m β] [Finite α m] [IteratorCollect α m n] [LawfulIteratorCollect α m n]
+    {f : β → PostconditionT n γ} {it : IterM (α := α) m β} :
+    (it.mapWithPostcondition f).toArray =
+      (it.filterMapWithPostcondition (PostconditionT.map some <| f ·)).toArray := by
+  simp only [toArray_eq_toArray_defaultImplementation]; rfl
+
+theorem IterM.toArray_filterMapM_eq_toArray_filterMapWithPostcondition {α β γ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''}
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [MonadLiftT m n][LawfulMonadLiftT m n]
+    [Iterator α m β] [Finite α m]
+    {f : β → n (Option γ)} {it : IterM (α := α) m β} :
+    (it.filterMapM f).toArray =
+      (it.filterMapWithPostcondition fun b => .attachLift (f b)).toArray := by
+  rfl
+
+theorem IterM.toArray_mapM_eq_toArray_mapWithPostcondition {α β γ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''}
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [MonadLiftT m n][LawfulMonadLiftT m n]
+    [Iterator α m β] [Finite α m] [IteratorCollect α m n] [LawfulIteratorCollect α m n]
+    {f : β → n γ} {it : IterM (α := α) m β} :
+    (it.mapM f).toArray =
+      (it.mapWithPostcondition fun b => .attachLift (f b)).toArray := by
+  rfl
 
 theorem IterM.toArray_mapM_eq_toArray_filterMapM {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [Monad m] [LawfulMonad m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n][LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorCollect α m n] [LawfulIteratorCollect α m n]
     {f : β → n γ} {it : IterM (α := α) m β} :
     (it.mapM f).toArray = (it.filterMapM fun b => some <$> f b).toArray := by
   simp [← toArray_toList, toList_mapM_eq_toList_filterMapM]
 
+theorem IterM.toArray_map_eq_toArray_mapM {α β γ : Type w}
+    {m : Type w → Type w'} [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
+    {f : β → γ} {it : IterM (α := α) m β} :
+    (it.map f).toArray = (it.mapM fun b => pure (f b)).toArray := by
+  simp [← toArray_toList, toList_map_eq_toList_mapM, - toList_map]
+
 theorem IterM.toArray_map_eq_toArray_filterMapM {α β γ : Type w}
-    {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+    {m : Type w → Type w'} [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → γ} {it : IterM (α := α) m β} :
     (it.map f).toArray = (it.filterMapM fun b => pure (some (f b))).toArray := by
-  simp [← toArray_toList, toList_map_eq_toList_filterMapM]
+  simp [← toArray_toList, toList_map_eq_toList_filterMapM, - toList_map]
 
-theorem IterM.toArray_filterMap {α β γ : Type w} {m : Type w → Type w'}
+@[simp]
+theorem IterM.toArray_filterMapWithPostcondition_filterMapWithPostcondition {α β γ δ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
+    [Iterator α m β] [Finite α m]
+    {f : β → PostconditionT n (Option γ)} {g : γ → PostconditionT o (Option δ)}
+    {it : IterM (α := α) m β} :
+    haveI : MonadLift n o := ⟨monadLift⟩
+    ((it.filterMapWithPostcondition f).filterMapWithPostcondition g).toArray =
+      (it.filterMapWithPostcondition (n := o) (fun b => do
+        match ← (f b) with
+        | none => return none
+        | some fb => g fb)).toArray := by
+  simp [← toArray_toList]
+
+@[simp]
+theorem IterM.toArray_mapWithPostcondition_mapWithPostcondition {α β γ δ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
+    [Iterator α m β] [Finite α m] [IteratorCollect α m n] [LawfulIteratorCollect α m n]
+    [IteratorCollect α m o] [LawfulIteratorCollect α m o]
+    {f : β → PostconditionT n γ} {g : γ → PostconditionT o δ}
+    {it : IterM (α := α) m β} :
+    haveI : MonadLift n o := ⟨monadLift⟩
+    ((it.mapWithPostcondition f).mapWithPostcondition g).toArray =
+      (it.mapWithPostcondition (n := o) (f · >>= g)).toArray := by
+  simp [← toArray_toList]
+
+@[simp]
+theorem IterM.toArray_filterMapM_filterMapWithPostcondition {α β γ δ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     [Monad m] [LawfulMonad m]
-    [Iterator α m β] [IteratorCollect α m m] [LawfulIteratorCollect α m m] [Finite α m]
-    {f : β → Option γ} (it : IterM (α := α) m β) :
-    (it.filterMap f).toArray = (fun x => x.filterMap f) <$> it.toArray := by
-  simp [← toArray_toList, toList_filterMap]
-
-theorem IterM.toArray_map {α β γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
-    [Iterator α m β] [IteratorCollect α m m] [LawfulIteratorCollect α m m] [Finite α m] {f : β → γ}
-    (it : IterM (α := α) m β) :
-    (it.map f).toArray = (fun x => x.map f) <$> it.toArray := by
-  simp [← toArray_toList, toList_map]
-
-theorem IterM.toArray_filter {α : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
-    {β : Type w} [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
-    {f : β → Bool} {it : IterM (α := α) m β} :
-    (it.filter f).toArray = Array.filter f <$> it.toArray := by
-  simp [← toArray_toList, toList_filter]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [WeaklyLawfulMonadAttach o]
+    [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
+    [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
+    {f : β → PostconditionT n (Option γ)} {g : γ → o (Option δ)}
+    {it : IterM (α := α) m β} :
+    haveI : MonadLift n o := ⟨monadLift⟩
+    ((it.filterMapWithPostcondition f).filterMapM g).toArray =
+      (it.filterMapM (n := o) (fun b => do
+        match ← (f b).run with
+        | none => return none
+        | some fb => g fb)).toArray := by
+  simp [← toArray_toList]
 
 @[simp]
 theorem IterM.toArray_filterMapM_filterMapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [LawfulMonad m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [WeaklyLawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → n (Option γ)} {g : γ → o (Option δ)}
@@ -699,9 +1172,11 @@ theorem IterM.toArray_filterMapM_filterMapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toArray_filterMapM_mapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [LawfulMonad m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [WeaklyLawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
-    [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
+    [Iterator α m β] [Finite α m]
     {f : β → n γ} {g : γ → o (Option δ)}
     {it : IterM (α := α) m β} :
     haveI : MonadLift n o := ⟨monadLift⟩
@@ -712,7 +1187,7 @@ theorem IterM.toArray_filterMapM_mapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toArray_filterMapM_map {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → γ} {g : γ → n (Option δ)}
@@ -724,7 +1199,8 @@ theorem IterM.toArray_filterMapM_map {α β γ δ : Type w}
 @[simp]
 theorem IterM.toArray_mapM_filterMapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [WeaklyLawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
     {f : β → n (Option γ)} {g : γ → o δ}
@@ -740,7 +1216,8 @@ theorem IterM.toArray_mapM_filterMapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toArray_mapM_mapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [Monad o] [MonadAttach o] [LawfulMonad o] [WeaklyLawfulMonadAttach o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m] [IteratorCollect α m o] [LawfulIteratorCollect α m o]
     {f : β → n γ} {g : γ → o δ}
@@ -753,13 +1230,82 @@ theorem IterM.toArray_mapM_mapM {α β γ δ : Type w}
 @[simp]
 theorem IterM.toArray_mapM_map {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorCollect α m n] [LawfulIteratorCollect α m n]
     {f : β → γ} {g : γ → n δ}
     {it : IterM (α := α) m β} :
     ((it.map f).mapM g).toArray =
       (it.mapM (n := n) (fun b => g (f b))).toArray := by
+  simp [← toArray_toList]
+
+@[simp]
+theorem IterM.toArray_map_mapM {α β γ δ : Type w}
+    {m : Type w → Type w'} {n : Type w → Type w''}
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [MonadLiftT m n] [LawfulMonadLiftT m n]
+    [Iterator α m β] [Finite α m] [IteratorCollect α m n] [LawfulIteratorCollect α m n]
+    {f : β → n γ} {g : γ → δ}
+    {it : IterM (α := α) m β} :
+    ((it.mapM f).map g).toArray =
+      (it.mapM (n := n) (fun b => return g (← f b))).toArray := by
+  simp only [toArray_mapM_eq_toArray_filterMapM, toArray_map_eq_toArray_filterMapM,
+    toArray_filterMapM_mapM]
+  congr <;> simp
+
+@[simp]
+theorem IterM.toArray_filterMapWithPostcondition {α β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [LawfulMonad m]
+    [Iterator α Id β] [IteratorCollect α Id m] [LawfulIteratorCollect α Id m] [Finite α Id]
+    [IteratorCollect α Id Id] [LawfulIteratorCollect α Id Id]
+    {f : β → PostconditionT m (Option γ)} (it : IterM (α := α) Id β) :
+    (it.filterMapWithPostcondition f).toArray = it.toArray.run.filterMapM (fun x => (f x).run) := by
+  simp [← toArray_toList]
+
+theorem IterM.toArray_mapWithPostcondition {α β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [LawfulMonad m] [Iterator α Id β] [IteratorCollect α Id m]
+    [LawfulIteratorCollect α Id m] [Finite α Id]
+    [IteratorCollect α Id Id] [LawfulIteratorCollect α Id Id]
+    {f : β → PostconditionT m γ} (it : IterM (α := α) Id β) :
+    (it.mapWithPostcondition f).toArray = it.toArray.run.mapM (fun x => (f x).run) := by
+  simp [← toArray_toList]
+
+@[simp]
+theorem IterM.toArray_filterMapM {α β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α Id β] [IteratorCollect α Id m]
+    [LawfulIteratorCollect α Id m] [Finite α Id]
+    [IteratorCollect α Id Id] [LawfulIteratorCollect α Id Id]
+    {f : β → m (Option γ)} (it : IterM (α := α) Id β) :
+    (it.filterMapM f).toArray = it.toArray.run.filterMapM f := by
+  simp [← toArray_toList]
+
+theorem IterM.toArray_mapM {α β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α Id β] [IteratorCollect α Id m]
+    [LawfulIteratorCollect α Id m] [Finite α Id]
+    [IteratorCollect α Id Id] [LawfulIteratorCollect α Id Id]
+    {f : β → m γ} (it : IterM (α := α) Id β) :
+    (it.mapM f).toArray = it.toArray.run.mapM f := by
+  simp [← toArray_toList]
+
+theorem IterM.toArray_filterMap {α β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [LawfulMonad m]
+    [Iterator α m β] [IteratorCollect α m m] [LawfulIteratorCollect α m m] [Finite α m]
+    {f : β → Option γ} (it : IterM (α := α) m β) :
+    (it.filterMap f).toArray = (fun x => x.filterMap f) <$> it.toArray := by
+  simp [← toArray_toList]
+
+theorem IterM.toArray_map {α β γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+    [Iterator α m β] [IteratorCollect α m m] [LawfulIteratorCollect α m m] [Finite α m] {f : β → γ}
+    (it : IterM (α := α) m β) :
+    (it.map f).toArray = (fun x => x.map f) <$> it.toArray := by
+  simp [← toArray_toList]
+
+theorem IterM.toArray_filter {α : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+    {β : Type w} [Iterator α m β] [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m]
+    {f : β → Bool} {it : IterM (α := α) m β} :
+    (it.filter f).toArray = Array.filter f <$> it.toArray := by
   simp [← toArray_toList]
 
 end ToArray
@@ -769,7 +1315,9 @@ section Fold
 theorem IterM.foldM_filterMapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     [Iterator α m β] [Finite α m]
-    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o]
+    [Monad m] [LawfulMonad m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [Monad o] [LawfulMonad o]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -785,6 +1333,7 @@ theorem IterM.foldM_filterMapM {α β γ δ : Type w}
   apply bind_congr; intro step
   cases step.inflate using PlausibleIterStep.casesOn
   · simp only [PlausibleIterStep.skip, PlausibleIterStep.yield, liftM_bind, bind_assoc]
+    conv => rhs; rw [← WeaklyLawfulMonadAttach.map_attach (x := f _), liftM_map, bind_map_left]
     apply bind_congr; intro c?
     split <;> simp [ihy ‹_›]
   · simp [ihs ‹_›]
@@ -793,7 +1342,9 @@ theorem IterM.foldM_filterMapM {α β γ δ : Type w}
 theorem IterM.foldM_mapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     [Iterator α m β] [Finite α m]
-    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o]
+    [Monad m] [LawfulMonad m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [Monad o] [LawfulMonad o]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -806,7 +1357,9 @@ theorem IterM.foldM_mapM {α β γ δ : Type w}
   rw [foldM_eq_match_step, foldM_eq_match_step, step_mapM, liftM_bind, bind_assoc]
   apply bind_congr; intro step
   cases step.inflate using PlausibleIterStep.casesOn
-  · simp [ihy ‹_›]
+  · simp only [bind_pure_comp, liftM_map, bind_map_left, Shrink.inflate_deflate, bind_assoc]
+    conv => rhs; rw [← WeaklyLawfulMonadAttach.map_attach (x := f _)]
+    simp [ihy ‹_›]
   · simp [ihs ‹_›]
   · simp
 
@@ -846,7 +1399,9 @@ theorem IterM.foldM_map {α β γ δ : Type w} {m : Type w → Type w'} {n : Typ
   · simp
 
 theorem IterM.fold_filterMapM {α β γ δ : Type w} {m : Type w → Type w'} {n : Type w → Type w''}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [LawfulMonad n]
+    [Iterator α m β] [Finite α m]
+    [Monad m] [LawfulMonad m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
     [IteratorLoop α m m] [IteratorLoop α m n]
     [LawfulIteratorLoop α m m] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
@@ -858,7 +1413,9 @@ theorem IterM.fold_filterMapM {α β γ δ : Type w} {m : Type w → Type w'} {n
   simp [fold_eq_foldM, foldM_filterMapM]
 
 theorem IterM.fold_mapM {α β γ δ : Type w} {m : Type w → Type w'} {n : Type w → Type w''}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [LawfulMonad n]
+    [Iterator α m β] [Finite α m]
+    [Monad m] [LawfulMonad m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
     [IteratorLoop α m m] [IteratorLoop α m n]
     [LawfulIteratorLoop α m m] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
@@ -910,8 +1467,9 @@ end Count
 section AnyAll
 
 theorem IterM.anyM_filterMapM {α β β' : Type w} {m : Type w → Type w'} {n : Type w → Type w''}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [MonadLiftT m n]
-    [LawfulMonad m] [LawfulMonad n]
+    [Iterator α m β] [Finite α m] [MonadLiftT m n]
+    [Monad m] [LawfulMonad m]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
     {it : IterM (α := α) m β} {f : β → n (Option β')} {p : β' → n (ULift Bool)} :
     (it.filterMapM f).anyM p = (it.mapM (pure (f := n))).anyM (fun x => do
       match ← f x with
@@ -921,7 +1479,16 @@ theorem IterM.anyM_filterMapM {α β β' : Type w} {m : Type w → Type w'} {n :
   rw [anyM_eq_match_step, anyM_eq_match_step, step_filterMapM, step_mapM, bind_assoc, bind_assoc]
   apply bind_congr; intro step
   split
-  · simp only [bind_assoc, pure_bind, Shrink.inflate_deflate]
+  · rename_i out _ _
+    simp only [bind_assoc, pure_bind, Shrink.inflate_deflate]
+    have {x : n (ULift Bool)} : x = MonadAttach.attach (pure out) >>= (fun _ => x) := by
+      rw (occs := [1]) [show x = pure out >>= (fun _ => x) by simp]
+      conv => lhs; rw [← WeaklyLawfulMonadAttach.map_attach (x := pure out)]
+      simp
+    refine Eq.trans this ?_
+    simp only [WeaklyLawfulMonadAttach.bind_attach_of_nonempty (x := pure out), pure_bind]
+    split; rotate_left; rfl
+    conv => rhs; rw [← WeaklyLawfulMonadAttach.map_attach (x := f _), bind_map_left]
     apply bind_congr; intro fx
     split
     · simp [ihy ‹_›]
@@ -933,15 +1500,24 @@ theorem IterM.anyM_filterMapM {α β β' : Type w} {m : Type w → Type w'} {n :
   · simp
 
 theorem IterM.anyM_mapM {α β β' : Type w} {m : Type w → Type w'} {n : Type w → Type w''}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [MonadLiftT m n]
-    [LawfulMonad m] [LawfulMonad n]
+    [Iterator α m β] [Finite α m] [MonadLiftT m n]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
     {it : IterM (α := α) m β} {f : β → n β'} {p : β' → n (ULift Bool)} :
     (it.mapM f).anyM p = (it.mapM (pure (f := n))).anyM (fun x => do p (← f x)) := by
   induction it using IterM.inductSteps with | step it ihy ihs
   rw [anyM_eq_match_step, anyM_eq_match_step, step_mapM, step_mapM, bind_assoc, bind_assoc]
   apply bind_congr; intro step
   split
-  · simp only [bind_assoc, pure_bind, Shrink.inflate_deflate]
+  · rename_i out _ _
+    simp only [bind_assoc, pure_bind, Shrink.inflate_deflate]
+    have {x : n (ULift Bool)} : x = MonadAttach.attach (pure out) >>= (fun _ => x) := by
+      rw (occs := [1]) [show x = pure out >>= (fun _ => x) by simp]
+      conv => lhs; rw [← WeaklyLawfulMonadAttach.map_attach (x := pure out)]
+      simp
+    refine Eq.trans this ?_
+    simp only [WeaklyLawfulMonadAttach.bind_attach_of_nonempty (x := pure out), pure_bind]
+    split; rotate_left; rfl
+    conv => rhs; rw [← WeaklyLawfulMonadAttach.map_attach (x := f _), bind_map_left]
     apply bind_congr; intro fx
     simp [ihy ‹_›]
   · simp only [PlausibleIterStep.skip, pure_bind, bind_assoc]
@@ -949,8 +1525,8 @@ theorem IterM.anyM_mapM {α β β' : Type w} {m : Type w → Type w'} {n : Type 
   · simp
 
 theorem IterM.anyM_filterM {α β : Type w} {m : Type w → Type w'} {n : Type w → Type w''}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [MonadLiftT m n]
-    [LawfulMonad m] [LawfulMonad n]
+    [Iterator α m β] [Finite α m] [MonadLiftT m n]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
     {it : IterM (α := α) m β} {f : β → n (ULift Bool)} {p : β → n (ULift Bool)} :
     (it.filterM f).anyM p = (it.mapM (pure (f := n))).anyM (fun x => do
         if (← f x).down then
@@ -961,7 +1537,16 @@ theorem IterM.anyM_filterM {α β : Type w} {m : Type w → Type w'} {n : Type w
   rw [anyM_eq_match_step, anyM_eq_match_step, step_mapM, step_filterM, bind_assoc, bind_assoc]
   apply bind_congr; intro step
   split
-  · simp only [bind_assoc, pure_bind, Shrink.inflate_deflate]
+  · rename_i out _ _
+    simp only [bind_assoc, pure_bind, Shrink.inflate_deflate]
+    have {x : n (ULift Bool)} : x = MonadAttach.attach (pure out) >>= (fun _ => x) := by
+      rw (occs := [1]) [show x = pure out >>= (fun _ => x) by simp]
+      conv => lhs; rw [← WeaklyLawfulMonadAttach.map_attach (x := pure out)]
+      simp
+    refine Eq.trans this ?_
+    simp only [WeaklyLawfulMonadAttach.bind_attach_of_nonempty (x := pure out), pure_bind]
+    split; rotate_left; rfl
+    conv => rhs; rw [← WeaklyLawfulMonadAttach.map_attach (x := f _), bind_map_left]
     apply bind_congr; intro fx
     split <;> simp [ihy ‹_›]
   · simp only [PlausibleIterStep.skip, pure_bind, bind_assoc]
@@ -1024,8 +1609,9 @@ theorem IterM.anyM_filter {α β : Type w} {m : Type w → Type w'}
   · simp
 
 theorem IterM.any_filterMapM {α β β' : Type w} {m : Type w → Type w'} {n : Type w → Type w''}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [MonadLiftT m n] [IteratorLoop α m m]
-    [LawfulMonad m] [LawfulMonad n] [LawfulMonadLiftT m n] [LawfulIteratorLoop α m m]
+    [Iterator α m β] [Finite α m] [MonadLiftT m n] [IteratorLoop α m m]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [LawfulMonadLiftT m n] [LawfulIteratorLoop α m m]
     {it : IterM (α := α) m β} {f : β → n (Option β')} {p : β' → Bool} :
     (it.filterMapM f).any p = (it.mapM (pure (f := n))).anyM (fun x => do
       match ← f x with
@@ -1034,15 +1620,17 @@ theorem IterM.any_filterMapM {α β β' : Type w} {m : Type w → Type w'} {n : 
   simp [any_eq_anyM, anyM_filterMapM]
 
 theorem IterM.any_mapM {α β β' : Type w} {m : Type w → Type w'} {n : Type w → Type w''}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [MonadLiftT m n] [IteratorLoop α m m]
-    [LawfulMonad m] [LawfulMonad n] [LawfulMonadLiftT m n] [LawfulIteratorLoop α m m]
+    [Iterator α m β] [Finite α m] [MonadLiftT m n] [IteratorLoop α m m]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [LawfulMonadLiftT m n] [LawfulIteratorLoop α m m]
     {it : IterM (α := α) m β} {f : β → n β'} {p : β' → Bool} :
     (it.mapM f).any p = (it.mapM (pure (f := n))).anyM (fun x => (.up <| p ·) <$> (f x)) := by
   simp [any_eq_anyM, anyM_mapM]
 
 theorem IterM.any_filterM {α β : Type w} {m : Type w → Type w'} {n : Type w → Type w''}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [MonadLiftT m n] [IteratorLoop α m m]
-    [LawfulMonad m] [LawfulMonad n] [LawfulMonadLiftT m n] [LawfulIteratorLoop α m m]
+    [Iterator α m β] [Finite α m] [MonadLiftT m n] [IteratorLoop α m m]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [LawfulMonadLiftT m n] [LawfulIteratorLoop α m m]
     {it : IterM (α := α) m β} {f : β → n (ULift Bool)} {p : β → Bool} :
     (it.filterM f).any p = (it.mapM (pure (f := n))).anyM (fun x => do
         if (← f x).down then
@@ -1086,63 +1674,41 @@ theorem IterM.any_map {α β β' : Type w} {m : Type w → Type w'}
   · simp
 
 theorem IterM.allM_filterMapM {α β β' : Type w} {m : Type w → Type w'} {n : Type w → Type w''}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [MonadLiftT m n]
-    [LawfulMonad m] [LawfulMonad n] [LawfulMonadLiftT m n]
+    [Iterator α m β] [Finite α m] [MonadLiftT m n]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [LawfulMonadLiftT m n]
     {it : IterM (α := α) m β} {f : β → n (Option β')} {p : β' → n (ULift Bool)} :
     (it.filterMapM f).allM p = (it.mapM (pure (f := n))).allM (fun x => do
       match ← f x with
       | some fx => p fx
       | none => return .up true) := by
-  induction it using IterM.inductSteps with | step it ihy ihs
-  rw [allM_eq_match_step, allM_eq_match_step, step_filterMapM, step_mapM, bind_assoc, bind_assoc]
-  apply bind_congr; intro step
-  split
-  · simp only [bind_assoc, pure_bind, Shrink.inflate_deflate]
-    apply bind_congr; intro fx
-    split
-    · simp [ihy ‹_›]
-    · simp only [PlausibleIterStep.yield, pure_bind, Shrink.inflate_deflate]
-      apply bind_congr; intro px
-      split <;> simp [ihy ‹_›]
-  · simp only [PlausibleIterStep.skip, pure_bind, bind_assoc]
-    simp [ihs ‹_›]
-  · simp
+  rw [allM_eq_not_anyM_not, anyM_filterMapM, allM_eq_not_anyM_not]
+  congr 2; ext x
+  simp only [map_eq_pure_bind, bind_assoc]
+  apply bind_congr; intro y
+  split <;> simp
 
 theorem IterM.allM_mapM {α β β' : Type w} {m : Type w → Type w'} {n : Type w → Type w''}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [MonadLiftT m n]
-    [LawfulMonad m] [LawfulMonad n] [LawfulMonadLiftT m n]
-    {it : IterM (α := α) m β} {f : β → n β'} {p : β' → n (ULift Bool)} :
+    [Iterator α m β] [Finite α m] [MonadLiftT m n]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [LawfulMonadLiftT m n] {it : IterM (α := α) m β} {f : β → n β'} {p : β' → n (ULift Bool)} :
     (it.mapM f).allM p = (it.mapM (pure (f := n))).allM (fun x => do p (← f x)) := by
-  induction it using IterM.inductSteps with | step it ihy ihs
-  rw [allM_eq_match_step, allM_eq_match_step, step_mapM, step_mapM, bind_assoc, bind_assoc]
-  apply bind_congr; intro step
-  split
-  · simp only [bind_assoc, pure_bind, Shrink.inflate_deflate]
-    apply bind_congr; intro fx
-    simp [ihy ‹_›]
-  · simp only [PlausibleIterStep.skip, pure_bind, bind_assoc]
-    simp [ihs ‹_›]
-  · simp
+  simp [allM_eq_not_anyM_not, anyM_mapM]
 
 theorem IterM.allM_filterM {α β : Type w} {m : Type w → Type w'} {n : Type w → Type w''}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [MonadLiftT m n]
-    [LawfulMonad m] [LawfulMonad n] [LawfulMonadLiftT m n]
+    [Iterator α m β] [Finite α m] [MonadLiftT m n]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [LawfulMonadLiftT m n]
     {it : IterM (α := α) m β} {f : β → n (ULift Bool)} {p : β → n (ULift Bool)} :
     (it.filterM f).allM p = (it.mapM (pure (f := n))).allM (fun x => do
         if (← f x).down then
           p x
         else
           return .up true) := by
-  induction it using IterM.inductSteps with | step it ihy ihs
-  rw [allM_eq_match_step, allM_eq_match_step, step_mapM, step_filterM, bind_assoc, bind_assoc]
-  apply bind_congr; intro step
-  split
-  · simp only [bind_assoc, pure_bind, Shrink.inflate_deflate]
-    apply bind_congr; intro fx
-    split <;> simp [ihy ‹_›]
-  · simp only [PlausibleIterStep.skip, pure_bind, bind_assoc]
-    simp [ihs ‹_›]
-  · simp
+  simp only [allM_eq_not_anyM_not, anyM_filterM, map_bind]
+  congr; ext a
+  apply bind_congr; intro b
+  split <;> simp
 
 theorem IterM.allM_filterMap {α β β' : Type w} {m : Type w → Type w'}
     [Iterator α m β] [Finite α m] [Monad m] [IteratorLoop α m m]
@@ -1152,33 +1718,16 @@ theorem IterM.allM_filterMap {α β β' : Type w} {m : Type w → Type w'}
       match f x with
       | some fx => p fx
       | none => return .up true) := by
-  induction it using IterM.inductSteps with | step it ihy ihs
-  rw [allM_eq_match_step, allM_eq_match_step, step_filterMap, bind_assoc]
-  apply bind_congr; intro step
-  cases step.inflate using PlausibleIterStep.casesOn
-  · simp only
-    split
-    · simp [*, ihy ‹_›]
-    · simp only [*, PlausibleIterStep.yield, pure_bind, Shrink.inflate_deflate]
-      apply bind_congr; intro px
-      split <;> simp [ihy ‹_›]
-  · simp [PlausibleIterStep.skip, pure_bind, ihs ‹_›]
-  · simp
+  simp only [allM_eq_not_anyM_not, anyM_filterMap]
+  congr; ext a
+  split <;> simp
 
 theorem IterM.allM_map {α β β' : Type w} {m : Type w → Type w'}
     [Iterator α m β] [Finite α m] [Monad m] [IteratorLoop α m m]
     [LawfulMonad m] [LawfulIteratorLoop α m m]
     {it : IterM (α := α) m β} {f : β → β'} {p : β' → m (ULift Bool)} :
     (it.map f).allM p = it.allM (fun x => p (f x)) := by
-  induction it using IterM.inductSteps with | step it ihy ihs
-  rw [allM_eq_match_step, allM_eq_match_step, step_map, bind_assoc]
-  apply bind_congr; intro step
-  cases step.inflate using PlausibleIterStep.casesOn
-  · simp only [pure_bind, Shrink.inflate_deflate]
-    apply bind_congr; intro fx
-    simp [ihy ‹_›]
-  · simp [PlausibleIterStep.skip, pure_bind, ihs ‹_›]
-  · simp
+  simp [allM_eq_not_anyM_not, anyM_map]
 
 theorem IterM.allM_filter {α β : Type w} {m : Type w → Type w'}
     [Iterator α m β] [Finite α m] [Monad m][IteratorLoop α m m]
@@ -1189,19 +1738,14 @@ theorem IterM.allM_filter {α β : Type w} {m : Type w → Type w'}
           p x
         else
           return .up true) := by
-  induction it using IterM.inductSteps with | step it ihy ihs
-  rw [allM_eq_match_step, allM_eq_match_step, step_filter, bind_assoc]
-  apply bind_congr; intro step
-  cases step.inflate using PlausibleIterStep.casesOn
-  · simp only
-    split <;> simp [ihy ‹_›]
-  · simp only [PlausibleIterStep.skip, pure_bind]
-    simp [ihs ‹_›]
-  · simp
+  simp only [allM_eq_not_anyM_not, anyM_filter]
+  congr; ext a
+  split <;> simp
 
 theorem IterM.all_filterMapM {α β β' : Type w} {m : Type w → Type w'} {n : Type w → Type w''}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [MonadLiftT m n] [IteratorLoop α m m]
-    [LawfulMonad m] [LawfulMonad n] [LawfulMonadLiftT m n] [LawfulIteratorLoop α m m]
+    [Iterator α m β] [Finite α m] [MonadLiftT m n] [IteratorLoop α m m]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [LawfulMonadLiftT m n] [LawfulIteratorLoop α m m]
     {it : IterM (α := α) m β} {f : β → n (Option β')} {p : β' → Bool} :
     (it.filterMapM f).all p = (it.mapM (pure (f := n))).allM (fun x => do
       match ← f x with
@@ -1210,15 +1754,17 @@ theorem IterM.all_filterMapM {α β β' : Type w} {m : Type w → Type w'} {n : 
   simp [all_eq_allM, allM_filterMapM]
 
 theorem IterM.all_mapM {α β β' : Type w} {m : Type w → Type w'} {n : Type w → Type w''}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [MonadLiftT m n] [IteratorLoop α m m]
-    [LawfulMonad m] [LawfulMonad n] [LawfulMonadLiftT m n] [LawfulIteratorLoop α m m]
+    [Iterator α m β] [Finite α m] [MonadLiftT m n] [IteratorLoop α m m]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [LawfulMonadLiftT m n] [LawfulIteratorLoop α m m]
     {it : IterM (α := α) m β} {f : β → n β'} {p : β' → Bool} :
     (it.mapM f).all p = (it.mapM (pure (f := n))).allM (fun x => (.up <| p ·) <$> (f x)) := by
   simp [all_eq_allM, allM_mapM]
 
 theorem IterM.all_filterM {α β : Type w} {m : Type w → Type w'} {n : Type w → Type w''}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [MonadLiftT m n] [IteratorLoop α m m]
-    [LawfulMonad m] [LawfulMonad n] [LawfulMonadLiftT m n] [LawfulIteratorLoop α m m]
+    [Iterator α m β] [Finite α m] [MonadLiftT m n] [IteratorLoop α m m]
+    [Monad m] [LawfulMonad m] [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
+    [LawfulMonadLiftT m n] [LawfulIteratorLoop α m m]
     {it : IterM (α := α) m β} {f : β → n (ULift Bool)} {p : β → Bool} :
     (it.filterM f).all p = (it.mapM (pure (f := n))).allM (fun x => do
         if (← f x).down then
@@ -1235,31 +1781,16 @@ theorem IterM.all_filterMap {α β β' : Type w} {m : Type w → Type w'}
       match f x with
       | some fx => (p fx)
       | none => true) := by
-  induction it using IterM.inductSteps with | step it ihy ihs
-  rw [all_eq_match_step, all_eq_match_step, step_filterMap, bind_assoc]
-  apply bind_congr; intro step
-  cases step.inflate using PlausibleIterStep.casesOn
-  · simp only
-    split
-    · simp [*, ihy ‹_›]
-    · simp only [*, PlausibleIterStep.yield, pure_bind, Shrink.inflate_deflate]
-      split <;> simp [ihy ‹_›]
-  · simp [PlausibleIterStep.skip, pure_bind, ihs ‹_›]
-  · simp
+  simp only [all_eq_not_any_not, any_filterMap]
+  congr; ext
+  split <;> simp
 
 theorem IterM.all_map {α β β' : Type w} {m : Type w → Type w'}
     [Iterator α m β] [Finite α m] [Monad m] [IteratorLoop α m m]
     [LawfulMonad m] [LawfulIteratorLoop α m m]
     {it : IterM (α := α) m β} {f : β → β'} {p : β' → Bool} :
     (it.map f).all p = it.all (fun x => p (f x)) := by
-  induction it using IterM.inductSteps with | step it ihy ihs
-  rw [all_eq_match_step, all_eq_match_step, step_map, bind_assoc]
-  apply bind_congr; intro step
-  cases step.inflate using PlausibleIterStep.casesOn
-  · simp only [pure_bind]
-    simp [ihy ‹_›]
-  · simp [PlausibleIterStep.skip, pure_bind, ihs ‹_›]
-  · simp
+  simp [all_eq_not_any_not, any_map]
 
 end AnyAll
 

--- a/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/FlatMap.lean
+++ b/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/FlatMap.lean
@@ -37,43 +37,43 @@ theorem IterM.step_flattenAfter {α α₂ β : Type w} {m : Type w → Type w'} 
 namespace Iterators.Types
 
 public theorem Flatten.IsPlausibleStep.outerYield_flatMapM {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ]
+    {γ : Type w} {m : Type w → Type w'} [Monad m] [MonadAttach m] [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ]
     {f : β → m (IterM (α := α₂) m γ)} {it₁ it₁' : IterM (α := α) m β} {it₂' b}
-    (h : it₁.IsPlausibleStep (.yield it₁' b)) :
+    (h : it₁.IsPlausibleStep (.yield it₁' b)) (h' : MonadAttach.CanReturn (f b) it₂') :
     (it₁.flatMapAfterM f none).IsPlausibleStep (.skip (it₁'.flatMapAfterM f (some it₂'))) :=
-  .outerYield (.yieldSome h ⟨⟨_, trivial⟩, rfl⟩)
+  .outerYield (.yieldSome h ⟨⟨_, h'⟩, rfl⟩)
 
 public theorem Flatten.IsPlausibleStep.outerSkip_flatMapM {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ]
-    {f : β → m (IterM (α := α₂) m γ)} {it₁ it₁' : IterM (α := α) m β}
+    {γ : Type w} {m : Type w → Type w'} [Monad m] [MonadAttach m] [LawfulMonad m] [Iterator α m β]
+    [Iterator α₂ m γ] {f : β → m (IterM (α := α₂) m γ)} {it₁ it₁' : IterM (α := α) m β}
     (h : it₁.IsPlausibleStep (.skip it₁')) :
     (it₁.flatMapAfterM f none).IsPlausibleStep (.skip (it₁'.flatMapAfterM f none)) :=
   .outerSkip (.skip h)
 
 public theorem Flatten.IsPlausibleStep.outerDone_flatMapM {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ]
-    {f : β → m (IterM (α := α₂) m γ)} {it₁ : IterM (α := α) m β}
+    {γ : Type w} {m : Type w → Type w'} [Monad m] [MonadAttach m] [LawfulMonad m] [Iterator α m β]
+    [Iterator α₂ m γ] {f : β → m (IterM (α := α₂) m γ)} {it₁ : IterM (α := α) m β}
     (h : it₁.IsPlausibleStep .done) :
     (it₁.flatMapAfterM f none).IsPlausibleStep .done :=
   .outerDone (.done h)
 
 public theorem Flatten.IsPlausibleStep.innerYield_flatMapM {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ]
-    {f : β → m (IterM (α := α₂) m γ)} {it₁ : IterM (α := α) m β} {it₂ it₂' b}
+    {γ : Type w} {m : Type w → Type w'} [Monad m] [MonadAttach m] [LawfulMonad m] [Iterator α m β]
+    [Iterator α₂ m γ] {f : β → m (IterM (α := α₂) m γ)} {it₁ : IterM (α := α) m β} {it₂ it₂' b}
     (h : it₂.IsPlausibleStep (.yield it₂' b)) :
     (it₁.flatMapAfterM f (some it₂)).IsPlausibleStep (.yield (it₁.flatMapAfterM f (some it₂')) b) :=
   .innerYield h
 
 public theorem Flatten.IsPlausibleStep.innerSkip_flatMapM {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ]
-    {f : β → m (IterM (α := α₂) m γ)} {it₁ : IterM (α := α) m β} {it₂ it₂'}
+    {γ : Type w} {m : Type w → Type w'} [Monad m] [MonadAttach m] [LawfulMonad m] [Iterator α m β]
+    [Iterator α₂ m γ] {f : β → m (IterM (α := α₂) m γ)} {it₁ : IterM (α := α) m β} {it₂ it₂'}
     (h : it₂.IsPlausibleStep (.skip it₂')) :
     (it₁.flatMapAfterM f (some it₂)).IsPlausibleStep (.skip (it₁.flatMapAfterM f (some it₂'))) :=
   .innerSkip h
 
 public theorem Flatten.IsPlausibleStep.innerDone_flatMapM {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ]
-    {f : β → m (IterM (α := α₂) m γ)} {it₁ : IterM (α := α) m β} {it₂}
+    {γ : Type w} {m : Type w → Type w'} [Monad m] [MonadAttach m] [LawfulMonad m] [Iterator α m β]
+    [Iterator α₂ m γ] {f : β → m (IterM (α := α₂) m γ)} {it₁ : IterM (α := α) m β} {it₂}
     (h : it₂.IsPlausibleStep .done) :
     (it₁.flatMapAfterM f (some it₂)).IsPlausibleStep (.skip (it₁.flatMapAfterM f none)) :=
   .innerDone h
@@ -123,14 +123,16 @@ public theorem Flatten.IsPlausibleStep.innerDone_flatMap {α : Type w} {β : Typ
 end Iterators.Types
 
 public theorem IterM.step_flatMapAfterM {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ]
-    {f : β → m (IterM (α := α₂) m γ)} {it₁ : IterM (α := α) m β} {it₂ : Option (IterM (α := α₂) m γ)} :
+    {γ : Type w} {m : Type w → Type w'} [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α m β] [Iterator α₂ m γ] {f : β → m (IterM (α := α₂) m γ)} {it₁ : IterM (α := α) m β}
+    {it₂ : Option (IterM (α := α₂) m γ)} :
   (it₁.flatMapAfterM f it₂).step = (do
     match it₂ with
     | none =>
       match (← it₁.step).inflate with
       | .yield it₁' b h =>
-        return .deflate (.skip (it₁'.flatMapAfterM f (some (← f b))) (.outerYield_flatMapM h))
+        let fx ← MonadAttach.attach (f b)
+        return .deflate (.skip (it₁'.flatMapAfterM f (some fx.val)) (.outerYield_flatMapM h fx.property))
       | .skip it₁' h => return .deflate (.skip (it₁'.flatMapAfterM f none) (.outerSkip_flatMapM h))
       | .done h => return .deflate (.done (.outerDone_flatMapM h))
     | some it₂ =>
@@ -142,17 +144,22 @@ public theorem IterM.step_flatMapAfterM {α : Type w} {β : Type w} {α₂ : Typ
   split
   · simp only [bind_assoc]
     apply bind_congr; intro step
-    cases step.inflate using PlausibleIterStep.casesOn <;> simp
+    cases step.inflate using PlausibleIterStep.casesOn
+    · simp only [bind_pure_comp, bind_map_left, Shrink.inflate_deflate]
+    · simp
+    · simp
   · rfl
 
 public theorem IterM.step_flatMapM {α : Type w} {β : Type w} {α₂ : Type w}
-    {γ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ]
-    {f : β → m (IterM (α := α₂) m γ)} {it₁ : IterM (α := α) m β} :
+    {γ : Type w} {m : Type w → Type w'} [Monad m] [MonadAttach m] [LawfulMonad m]
+    [WeaklyLawfulMonadAttach m] [Iterator α m β] [Iterator α₂ m γ] {f : β → m (IterM (α := α₂) m γ)}
+    {it₁ : IterM (α := α) m β} :
   (it₁.flatMapM f).step = (do
     match (← it₁.step).inflate with
     | .yield it₁' b h =>
-      return .deflate (.skip (it₁'.flatMapAfterM f (some (← f b)))
-        (.outerYield_flatMapM h))
+      let fx ← MonadAttach.attach (f b)
+      return .deflate (.skip (it₁'.flatMapAfterM f (some fx.val))
+        (.outerYield_flatMapM h fx.property))
     | .skip it₁' h => return .deflate (.skip (it₁'.flatMapAfterM f none) (.outerSkip_flatMapM h))
     | .done h => return .deflate (.done (.outerDone_flatMapM h))) := by
   simp [flatMapM, step_flatMapAfterM]
@@ -191,7 +198,8 @@ public theorem IterM.step_flatMap {α : Type w} {β : Type w} {α₂ : Type w}
     | .done h => return .deflate (.done (.outerDone_flatMap h))) := by
   simp [flatMap, step_flatMapAfter]
 
-theorem IterM.toList_flattenAfter {α α₂ β : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+theorem IterM.toList_flattenAfter {α α₂ β : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
     [Iterator α m (IterM (α := α₂) m β)] [Iterator α₂ m β] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]
@@ -207,7 +215,10 @@ theorem IterM.toList_flattenAfter {α α₂ β : Type w} {m : Type w → Type w'
     simp only [bind_assoc, map_eq_pure_bind]
     apply bind_congr; intro step
     cases step.inflate using PlausibleIterStep.casesOn
-    · simp [ihy₁ ‹_›]
+    · simp only [bind_pure_comp, pure_bind, Shrink.inflate_deflate,
+        bind_map_left, Functor.map_map, List.flatten_cons, ihy₁ ‹_›]
+      conv => lhs; rw [← WeaklyLawfulMonadAttach.map_attach (x := IterM.toList _)]
+      simp
     · simp [ihs₁ ‹_›]
     · simp
   cases it₂
@@ -223,7 +234,8 @@ theorem IterM.toList_flattenAfter {α α₂ β : Type w} {m : Type w → Type w'
     · simp [ihs₂ ‹_›]
     · simp [hn]
 
-theorem IterM.toArray_flattenAfter {α α₂ β : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
+theorem IterM.toArray_flattenAfter {α α₂ β : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
     [Iterator α m (IterM (α := α₂) m β)] [Iterator α₂ m β] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]
@@ -232,31 +244,23 @@ theorem IterM.toArray_flattenAfter {α α₂ β : Type w} {m : Type w → Type w
       match it₂ with
       | none => Array.flatten <$> (it₁.mapM fun it₂ => it₂.toArray).toArray
       | some it₂ => return (← it₂.toArray) ++ (← Array.flatten <$> (it₁.mapM fun it₂ => it₂.toArray).toArray) := by
-  induction it₁ using IterM.inductSteps generalizing it₂ with | step it₁ ihy₁ ihs₁ =>
-  have hn : (it₁.flattenAfter none).toArray =
-      Array.flatten <$> (it₁.mapM fun it₂ => it₂.toArray).toArray := by
-    rw [toArray_eq_match_step, toArray_eq_match_step, step_flattenAfter, step_mapM]
-    simp only [bind_assoc, map_eq_pure_bind]
-    apply bind_congr; intro step
-    cases step.inflate using PlausibleIterStep.casesOn
-    · simp [ihy₁ ‹_›]
-    · simp [ihs₁ ‹_›]
-    · simp
-  cases it₂
-  · exact hn
-  · rename_i ih₂
-    induction ih₂ using IterM.inductSteps with | step it₂ ihy₂ ihs₂ =>
-    rw [toArray_eq_match_step, step_flattenAfter, bind_assoc]
-    simp only
-    rw [toArray_eq_match_step, bind_assoc]
-    apply bind_congr; intro step
-    cases step.inflate using PlausibleIterStep.casesOn
-    · simp [ihy₂ ‹_›]
-    · simp [ihs₂ ‹_›]
-    · simp [hn]
+  simp only [← IterM.toArray_toList, toList_flattenAfter]
+  split
+  · simp only [Functor.map_map]
+    simp only [← Array.flatten_map_toArray_toArray, ← Functor.map_map]
+    rw [IterM.toArray_toList, IterM.toArray_toList, ← IterM.toArray_map, IterM.toArray_map_mapM]
+    apply congrArg (it₁.mapM · |>.toArray |> Functor.map Array.flatten); ext it₂
+    simp
+  · simp only [bind_pure_comp, Functor.map_map, map_bind, Array.flatten_toArray, bind_map_left,
+      List.append_toArray]
+    apply bind_congr; intro bs
+    simp only [← Functor.map_map, ← IterM.toList_map, IterM.toList_map_mapM]
+    apply congrArg (fun f => List.toArray <$> HAppend.hAppend bs <$> List.flatten <$> (mapM f it₁).toList)
+    simp
 
-public theorem IterM.toList_flatMapAfterM {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
+public theorem IterM.toList_flatMapAfterM {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]
     {f : β → m (IterM (α := α₂) m γ)}
@@ -268,8 +272,9 @@ public theorem IterM.toList_flatMapAfterM {α α₂ β γ : Type w} {m : Type w 
           (← List.flatten <$> (it₁.mapM fun b => do (← f b).toList).toList) := by
   simp [flatMapAfterM, toList_flattenAfter]; rfl
 
-public theorem IterM.toArray_flatMapAfterM {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
+public theorem IterM.toArray_flatMapAfterM {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]
     {f : β → m (IterM (α := α₂) m γ)}
@@ -281,8 +286,9 @@ public theorem IterM.toArray_flatMapAfterM {α α₂ β γ : Type w} {m : Type w
           (← Array.flatten <$> (it₁.mapM fun b => do (← f b).toArray).toArray) := by
   simp [flatMapAfterM, toArray_flattenAfter]; rfl
 
-public theorem IterM.toList_flatMapM {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
+public theorem IterM.toList_flatMapM {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]
     {f : β → m (IterM (α := α₂) m γ)}
@@ -290,8 +296,9 @@ public theorem IterM.toList_flatMapM {α α₂ β γ : Type w} {m : Type w → T
     (it₁.flatMapM f).toList = List.flatten <$> (it₁.mapM fun b => do (← f b).toList).toList := by
   simp [flatMapM, toList_flatMapAfterM]
 
-public theorem IterM.toArray_flatMapM {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
+public theorem IterM.toArray_flatMapM {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]
     {f : β → m (IterM (α := α₂) m γ)}
@@ -299,8 +306,9 @@ public theorem IterM.toArray_flatMapM {α α₂ β γ : Type w} {m : Type w → 
     (it₁.flatMapM f).toArray = Array.flatten <$> (it₁.mapM fun b => do (← f b).toArray).toArray := by
   simp [flatMapM, toArray_flatMapAfterM]
 
-public theorem IterM.toList_flatMapAfter {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
+public theorem IterM.toList_flatMapAfter {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]
     {f : β → IterM (α := α₂) m γ}
@@ -312,8 +320,9 @@ public theorem IterM.toList_flatMapAfter {α α₂ β γ : Type w} {m : Type w �
           (← List.flatten <$> (it₁.mapM fun b => (f b).toList).toList) := by
   simp [flatMapAfter, toList_flattenAfter]; rfl
 
-public theorem IterM.toArray_flatMapAfter {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
+public theorem IterM.toArray_flatMapAfter {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]
     {f : β → IterM (α := α₂) m γ}
@@ -325,8 +334,9 @@ public theorem IterM.toArray_flatMapAfter {α α₂ β γ : Type w} {m : Type w 
           (← Array.flatten <$> (it₁.mapM fun b => (f b).toArray).toArray) := by
   simp [flatMapAfter, toArray_flattenAfter]; rfl
 
-public theorem IterM.toList_flatMap {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
+public theorem IterM.toList_flatMap {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]
@@ -335,8 +345,9 @@ public theorem IterM.toList_flatMap {α α₂ β γ : Type w} {m : Type w → Ty
     (it₁.flatMap f).toList = List.flatten <$> (it₁.mapM fun b => (f b).toList).toList := by
   simp [flatMap, toList_flatMapAfter]
 
-public theorem IterM.toArray_flatMap {α α₂ β γ : Type w} {m : Type w → Type w'} [Monad m]
-    [LawfulMonad m] [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
+public theorem IterM.toArray_flatMap {α α₂ β γ : Type w} {m : Type w → Type w'}
+    [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m]
+    [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [Iterator α m β] [Iterator α₂ m γ] [Finite α m] [Finite α₂ m]
     [IteratorCollect α m m] [IteratorCollect α₂ m m]
     [LawfulIteratorCollect α m m] [LawfulIteratorCollect α₂ m m]

--- a/src/Init/Data/Iterators/Lemmas/Consumers/Monadic/Collect.lean
+++ b/src/Init/Data/Iterators/Lemmas/Consumers/Monadic/Collect.lean
@@ -83,6 +83,11 @@ theorem IterM.toArray_ensureTermination [Monad m] [Iterator α m β] [Finite α 
     it.ensureTermination.toArray = it.toArray :=
   (rfl)
 
+theorem IterM.toArray_eq_toArray_defaultImplementation [Monad m] [LawfulMonad m] [Iterator α m β]
+    [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m] {it : IterM (α := α) m β} :
+    it.toArray = (haveI : IteratorCollect α m m := .defaultImplementation; it.toArray) := by
+  simp only [IterM.toArray, LawfulIteratorCollect.toArrayMapped_eq]
+
 theorem IterM.toArray_eq_match_step [Monad m] [LawfulMonad m] [Iterator α m β] [Finite α m]
     [IteratorCollect α m m] [LawfulIteratorCollect α m m] :
     it.toArray = (do
@@ -130,6 +135,11 @@ theorem IterM.toArray_toList_ensureTermination [Monad m] [LawfulMonad m] [Iterat
     [IteratorCollect α m m] {it : IterM (α := α) m β} :
     List.toArray <$> it.ensureTermination.toList = it.toArray := by
   rw [toList_ensureTermination, toArray_toList]
+
+theorem IterM.toList_eq_toList_defaultImplementation [Monad m] [LawfulMonad m] [Iterator α m β]
+    [Finite α m] [IteratorCollect α m m] [LawfulIteratorCollect α m m] {it : IterM (α := α) m β} :
+    it.toList = (haveI : IteratorCollect α m m := .defaultImplementation; it.toList) := by
+  simp only [IterM.toList, toArray_eq_toArray_defaultImplementation]
 
 theorem IterM.toList_eq_match_step [Monad m] [LawfulMonad m] [Iterator α m β] [Finite α m]
     [IteratorCollect α m m] [LawfulIteratorCollect α m m] {it : IterM (α := α) m β} :

--- a/src/Init/System/IO.lean
+++ b/src/Init/System/IO.lean
@@ -33,6 +33,7 @@ An `IO` monad that cannot throw exceptions.
 
 instance : Monad BaseIO := inferInstanceAs (Monad (ST IO.RealWorld))
 instance : MonadFinally BaseIO := inferInstanceAs (MonadFinally (ST IO.RealWorld))
+instance : MonadAttach BaseIO := inferInstanceAs (MonadAttach (ST IO.RealWorld))
 
 @[always_inline, inline]
 def BaseIO.map (f : α → β) (x : BaseIO α) : BaseIO β :=
@@ -88,6 +89,7 @@ def EIO.catchExceptions (act : EIO ε α) (h : ε → BaseIO α) : BaseIO α :=
 
 instance : Monad (EIO ε) := inferInstanceAs (Monad (EST ε IO.RealWorld))
 instance : MonadFinally (EIO ε) := inferInstanceAs (MonadFinally (EST ε IO.RealWorld))
+instance : MonadAttach (EIO ε) := inferInstanceAs (MonadAttach (EST ε IO.RealWorld))
 instance : MonadExceptOf ε (EIO ε) := inferInstanceAs (MonadExceptOf ε (EST ε IO.RealWorld))
 instance : OrElse (EIO ε α) := ⟨MonadExcept.orElse⟩
 instance [Inhabited ε] : Inhabited (EIO ε α) := inferInstanceAs (Inhabited (EST ε IO.RealWorld α))

--- a/src/Std/Data/Iterators/Lemmas/Combinators/Monadic/FilterMap.lean
+++ b/src/Std/Data/Iterators/Lemmas/Combinators/Monadic/FilterMap.lean
@@ -151,7 +151,7 @@ theorem IterM.Equiv.mapWithPostcondition {α₁ α₂ β γ : Type w}
 
 theorem IterM.Equiv.filterMapM {α₁ α₂ β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} [Monad m] [LawfulMonad m]
-    [Monad n] [LawfulMonad n] [Iterator α₁ m β] [Iterator α₂ m β]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [Iterator α₁ m β] [Iterator α₂ m β]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → n (Option γ)} {ita : IterM (α := α₁) m β} {itb : IterM (α := α₂) m β}
     (h : IterM.Equiv ita itb) :
@@ -160,7 +160,7 @@ theorem IterM.Equiv.filterMapM {α₁ α₂ β γ : Type w}
 
 theorem IterM.Equiv.filterM {α₁ α₂ β : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} [Monad m] [LawfulMonad m]
-    [Monad n] [LawfulMonad n] [Iterator α₁ m β] [Iterator α₂ m β]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [Iterator α₁ m β] [Iterator α₂ m β]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → n (ULift Bool)} {ita : IterM (α := α₁) m β} {itb : IterM (α := α₂) m β}
     (h : IterM.Equiv ita itb) :
@@ -169,7 +169,7 @@ theorem IterM.Equiv.filterM {α₁ α₂ β : Type w}
 
 theorem IterM.Equiv.mapM {α₁ α₂ β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} [Monad m] [LawfulMonad m]
-    [Monad n] [LawfulMonad n] [Iterator α₁ m β] [Iterator α₂ m β]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [Iterator α₁ m β] [Iterator α₂ m β]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → n γ} {ita : IterM (α := α₁) m β} {itb : IterM (α := α₂) m β}
     (h : IterM.Equiv ita itb) :

--- a/tests/lean/run/iterators.lean
+++ b/tests/lean/run/iterators.lean
@@ -254,6 +254,7 @@ example {α : Type} {m n o : Type → Type} [Monad m] [Monad n] [Monad o]
     [Std.IteratorLoop α m o]
     [Std.LawfulIteratorLoop α m n] [Std.LawfulIteratorLoop α m o]
     [Std.LawfulIteratorLoop α m o]
+    [MonadAttach n] [WeaklyLawfulMonadAttach n]
     (it : Std.IterM (α := α) m Nat) (f : Nat → n Nat) (g : Nat → Nat → o Nat) :
     (it.mapM f).foldM g init = it.foldM (fun b a => do g b (← f a)) init := by
   rw [Std.IterM.foldM_mapM]


### PR DESCRIPTION
This PR adds the new operation `MonadAttach.attach` that attaches a proof that a postcondition holds to the return value of a monadic operation. Most non-CPS monads in the standard library support this operation in a nontrivial way. The PR also changes the `filterMapM`, `mapM` and `flatMapM` combinators so that they attach postconditions to the user-provided monadic functions passed to them. This makes it possible to prove termination for some of these for which it wasn't possible before. Additionally, the PR adds many missing lemmas about `filterMap(M)` and `map(M)` that were needed in the course of this PR.