### PR TITLE
chore: improve bug report template instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 ### Prerequisites
 
-Please put an X between the brackets as you perform the following steps:
+<!-- Please put an X between the brackets as you perform the following steps: -->
 
 * [ ] Check that your issue is not already filed:
       https://github.com/leanprover/lean4/issues


### PR DESCRIPTION
This PR makes it so that in the issue template a line about how to check boxes is in comment form you can only see it when you are creating the issue and it does not need to be displayed to everyone.
