### PR TITLE
fix: make `register_try?_tactic` auxiliary definitions internal

### DIFF
--- a/src/Lean/Elab/Tactic/Try.lean
+++ b/src/Lean/Elab/Tactic/Try.lean
@@ -295,7 +295,7 @@ meta def elabRegisterTryTactic : Command.CommandElab := fun stx => do
 
   -- Generate a unique name based on a hash of the tactic syntax
   let tacHash := hash tacStx.prettyPrint.pretty
-  let name := Name.mkSimple s!"auxTryTactic{tacHash}"
+  let name := Name.mkSimple s!"_auxTryTactic{tacHash}"
 
   -- Generate code that parses the tactic at runtime
   let prioStx := Syntax.mkNumLit (toString prio)


### PR DESCRIPTION
This PR ensures the auxiliary definitions created by `register_try?_tactic` are internal implementation details that should not be visible to user-facing linters.

🤖 Generated with Claude Code