### PR TITLE
fix: goto-definition for binrel% operators

### DIFF
--- a/src/Lean/Elab/Extra.lean
+++ b/src/Lean/Elab/Extra.lean
@@ -541,7 +541,10 @@ def elabBinRelCore (noProp : Bool) (stx : Syntax) (expectedType? : Option Expr) 
       let rhs ← withRef rhsStx <| toBoolIfNecessary rhs
       let lhsType ← inferType lhs
       let rhs ← withRef rhsStx <| ensureHasType lhsType rhs
-      elabAppArgs f #[] #[Arg.expr lhs, Arg.expr rhs] expectedType? (explicit := false) (ellipsis := false) (resultIsOutParamSupport := false)
+      -- Wrap in TermInfo to match binop% behavior for goto-definition
+      withRef stx <|
+        withTermInfoContext' .anonymous stx do
+          elabAppArgs f #[] #[Arg.expr lhs, Arg.expr rhs] expectedType? (explicit := false) (ellipsis := false) (resultIsOutParamSupport := false)
     else
       let mut maxType := r.max?.get!
       /- If `noProp == true` and `maxType` is `Prop`, then set `maxType := Bool`. `See toBoolIfNecessary` -/


### PR DESCRIPTION
This PR fixes goto-definition for binary relation operators (`≥`, `≤`, `<`, `>`, `=`, `==`).

**Problem:** Goto-def on `≥` navigated to the `macro_rules` instead of `GE.ge`.

**Cause:** The "uncomparable types" path in `elabBinRelCore` called `elabAppArgs` directly without `withTermInfoContext'`, unlike `binop%` which creates nested TermInfo via `toExprCore`.

**Fix:** Wrap with `withTermInfoContext'` to match `binop%` behavior.

**Note:** Initially tried `resolveId? stx[1] (withInfo := true)`, but that creates TermInfo with the unapplied type (`{α : Type} → [LE α] → ...`) rather than the instantiated type (`Nat → Nat → Prop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)