### PR TITLE
chore: ci: bump `grove-action` to v0.5

### DIFF
--- a/.github/workflows/grove.yml
+++ b/.github/workflows/grove.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Fetch upstream invalidated facts
         if: ${{ steps.should-run.outputs.should-run == 'true' && steps.workflow-info.outputs.pullRequestNumber != '' }}
         id: fetch-upstream
-        uses: TwoFx/grove-action/fetch-upstream@v0.4
+        uses: TwoFx/grove-action/fetch-upstream@v0.5
         with:
           artifact-name: grove-invalidated-facts
           base-ref: master
@@ -96,7 +96,7 @@ jobs:
       - name: Build
         if: ${{ steps.should-run.outputs.should-run == 'true' }}
         id: build
-        uses: TwoFx/grove-action/build@v0.4
+        uses: TwoFx/grove-action/build@v0.5
         with:
           project-path: doc/std/grove
           script-name: grove-stdlib


### PR DESCRIPTION
This PR bumps `grove-action` to version 0.5, which fixes a bug in the handling of upstream invalidated facts.
