### PR TITLE
chore: prune imports in Try.Collect

### DIFF
--- a/src/Lean/Meta/Tactic/Try/Collect.lean
+++ b/src/Lean/Meta/Tactic/Try/Collect.lean
@@ -7,8 +7,6 @@ module
 prelude
 public import Init.Try
 public import Lean.Meta.Tactic.LibrarySearch
-public import Lean.Meta.Tactic.Grind.Cases
-public import Lean.Meta.Tactic.Grind.EMatchTheorem
 public import Lean.Meta.Tactic.FunIndCollect
 import Lean.Meta.Eqns
 public section


### PR DESCRIPTION
This PR removed unused imports from Try.Collect
