### PR TITLE
feat: `grind_pattern natCast_nonneg`

### DIFF
--- a/src/Init/Grind/Ordered/Ring.lean
+++ b/src/Init/Grind/Ordered/Ring.lean
@@ -154,8 +154,6 @@ theorem natCast_le_natCast_of_le (a b : Nat) : a ≤ b → (a : R) ≤ (b : R) :
 theorem natCast_nonneg {a : Nat} : 0 ≤ (a : R) := by
   simpa [Semiring.natCast_zero] using natCast_le_natCast_of_le (R := R) _ _ (Nat.zero_le a)
 
-grind_pattern natCast_nonneg => (a : R)
-
 theorem natCast_lt_natCast_of_lt (a b : Nat) : a < b → (a : R) < (b : R) := by
   induction a generalizing b <;> cases b <;> simp
   next n =>


### PR DESCRIPTION
This PR adds a lemma that the cast of a natural number into any ordered ring is non-negative. We can't annotate this directly for `grind`, but will probably add this to `grind`'s linarith interrnals.