### PR TITLE
feat: do not have `meta` imply `partial`

### DIFF
--- a/src/Lean/Elab/DeclModifiers.lean
+++ b/src/Lean/Elab/DeclModifiers.lean
@@ -103,15 +103,6 @@ def Modifiers.isPartial : Modifiers → Bool
   | { recKind := .partial, .. }  => true
   | _                            => false
 
-/--
-Whether the declaration is explicitly `partial` or should be considered as such via `meta`. In the
-latter case, elaborators should not produce an error if partiality is unnecessary.
--/
-def Modifiers.isInferredPartial : Modifiers → Bool
-  | { recKind := .partial, .. }  => true
-  | { computeKind := .meta, .. } => true
-  | _                            => false
-
 def Modifiers.isNonrec : Modifiers → Bool
   | { recKind := .nonrec, .. } => true
   | _                          => false


### PR DESCRIPTION
This PR adjusts the new `meta` keyword of the experimental module system not to imply `partial` for general consistency.

As the previous behavior can create confusion return types that are not known to be `Nonempty` and few `def`s should be `meta` in the first case, this special case does not appear to be worth the minor convenience.