### PR TITLE
fix: better performance for `@[suggest_for]`

### DIFF
--- a/src/Init/Notation.lean
+++ b/src/Init/Notation.lean
@@ -634,7 +634,7 @@ syntax (name := deprecated) "deprecated" (ppSpace ident)? (ppSpace str)?
     (" (" &"since" " := " str ")")? : attr
 
 /--
-The attribute `@[suggest_for]` on a declaration suggests likely ways in which
+The attribute `@[suggest_for ..]` on a declaration suggests likely ways in which
 someone might **incorrectly** refer to a definition.
 
 * `@[suggest_for String.endPos]` on the definition of `String.rawEndPos` suggests that `"str".endPos` might be correctable to `"str".rawEndPos`.
@@ -644,6 +644,10 @@ The namespace of the suggestions is always relative to the root namespace. In th
 adding an annotation `@[suggest_for Z.bar]` to `def Z.foo` will suggest `X.Y.Z.foo` only as a
 replacement for `Z.foo`. If your intent is to suggest `X.Y.Z.foo` as a replacement for
 `X.Y.Z.bar`, you must instead use the annotation `@[suggest_for X.Y.Z.bar]`.
+
+Suggestions can be defined for structure fields or inductive branches with the
+`attribute [suggest_for Exception] Except` syntax, and these attributes do not have to be added
+in the same module where the actual identifier was defined.
 -/
 syntax (name := suggest_for) "suggest_for" (ppSpace ident)+ : attr
 

--- a/src/stdlib_flags.h
+++ b/src/stdlib_flags.h
@@ -1,5 +1,6 @@
 #include "util/options.h"
 
+// this comment has been updated 1 time(s)
 namespace lean {
 options get_default_options() {
     options opts;

--- a/tests/lean/run/idSuggestPostHoc.lean
+++ b/tests/lean/run/idSuggestPostHoc.lean
@@ -1,0 +1,24 @@
+-- test extending suggestions in a different module
+
+/--
+error: Invalid field `some`: The environment does not contain `String.some`, so it is not possible to project the field `some` from an expression
+  x
+of type `String`
+
+Hint: Perhaps you meant `String.contains` in place of `String.some`:
+  .s̵o̵m̵e̵c̲o̲n̲t̲a̲i̲n̲s̲
+-/
+#guard_msgs in example (x : String) := x.some fun _ => true
+
+attribute [suggest_for String.some] String.any
+
+/--
+error: Invalid field `some`: The environment does not contain `String.some`, so it is not possible to project the field `some` from an expression
+  x
+of type `String`
+
+Hint: Perhaps you meant one of these in place of `String.some`:
+  [apply] `String.contains`
+  [apply] `String.any`
+-/
+#guard_msgs in example (x : String) := x.some fun _ => true


### PR DESCRIPTION
This PR fixes a performance issue resulting from misusing persistent environment extensions that was introduced in #11554.