### PR TITLE
chore: use backticks instead of single quotes for identifiers in messages

### DIFF
--- a/src/Init/Data/Random.lean
+++ b/src/Init/Data/Random.lean
@@ -27,7 +27,7 @@ class RandomGen (g : Type u) where
      and a new generator. -/
   next  : g → Nat × g
   /--
-    The 'split' operation allows one to obtain two distinct random number
+    The `split` operation allows one to obtain two distinct random number
     generators. This is very useful in functional programs (for example, when
     passing a random number generator down to recursive calls). -/
   split : g → g × g

--- a/src/Init/MetaTypes.lean
+++ b/src/Init/MetaTypes.lean
@@ -367,7 +367,7 @@ structure ExtractLetsConfig where
   useContext : Bool := true
   /-- If true (default: false), then once `givenNames` is exhausted, stop extracting lets. Otherwise continue extracting lets. -/
   onlyGivenNames : Bool := false
-  /-- If true (default: false), then when no name is provided for a 'let' expression, the name is used as-is without making it be inaccessible.
+  /-- If true (default: false), then when no name is provided for a `let` expression, the name is used as-is without making it be inaccessible.
   The name still might be inaccessible if the binder name was. -/
   preserveBinderNames : Bool := false
   /-- If true (default: false), lift non-extractable `let`s as far out as possible. -/

--- a/src/Init/Notation.lean
+++ b/src/Init/Notation.lean
@@ -803,7 +803,7 @@ By default, the command captures all messages, but the filter condition can be a
 For example, we can select only warnings:
 ```lean
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs(warning) in
 example : α := sorry

--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -1364,7 +1364,7 @@ Trying to prove a false proposition:
 ```lean
 example : 1 ≠ 1 := by decide
 /-
-tactic 'decide' proved that the proposition
+Tactic `decide` proved that the proposition
   1 ≠ 1
 is false
 -/
@@ -1377,11 +1377,11 @@ opaque unknownProp : Prop
 open scoped Classical in
 example : unknownProp := by decide
 /-
-tactic 'decide' failed for proposition
+Tactic `decide` failed for proposition
   unknownProp
-since its 'Decidable' instance reduced to
-  Classical.choice ⋯
-rather than to the 'isTrue' constructor.
+because its `Decidable` instance
+  ...
+did not reduce to `isTrue` or `isFalse`.
 -/
 ```
 

--- a/src/Lean/AddDecl.lean
+++ b/src/Lean/AddDecl.lean
@@ -68,7 +68,7 @@ def wasOriginallyTheorem (env : Environment) (declName : Name) : Bool :=
   getOriginalConstKind? env declName |>.map (· matches .thm) |>.getD false
 
 /-- If `warn.sorry` is set to true, then, so long as the message log does not already have any errors,
-declarations with `sorryAx` generate the "declaration uses 'sorry'" warning. -/
+declarations with `sorryAx` generate the "declaration uses `sorry`" warning. -/
 register_builtin_option warn.sorry : Bool := {
   defValue := true
   descr    := "warn about uses of `sorry` in declarations added to the environment"
@@ -81,7 +81,7 @@ logs a warning if the declaration uses `sorry`.
 def warnIfUsesSorry (decl : Declaration) : CoreM Unit := do
   if warn.sorry.get (← getOptions) then
     if !(← MonadLog.hasErrors) && decl.hasSorry then
-      -- Find an actual sorry expression to use for 'sorry'.
+      -- Find an actual sorry expression to use for `sorry`.
       -- That way the user can hover over it to see its type and use "go to definition" if it is a labeled sorry.
       let findSorry : StateRefT (Array (Bool × MessageData)) MetaM Unit := decl.forEachSorryM fun s => do
         let s' ← addMessageContext s
@@ -91,10 +91,10 @@ def warnIfUsesSorry (decl : Declaration) : CoreM Unit := do
       -- These can appear without logged errors if `decl` is referring to declarations with elaboration errors;
       -- that's where a user should direct their focus.
       if let some (_, s) := sorries.find? (·.1) <|> sorries[0]? then
-        logWarning <| .tagged `hasSorry m!"declaration uses '{s}'"
+        logWarning <| .tagged `hasSorry m!"declaration uses `{s}`"
       else
         -- This case should not happen, but it ensures a warning will get logged no matter what.
-        logWarning <| .tagged `hasSorry m!"declaration uses 'sorry'"
+        logWarning <| .tagged `hasSorry m!"declaration uses `sorry`"
 
 builtin_initialize
   registerTraceClass `addDecl

--- a/src/Lean/Attributes.lean
+++ b/src/Lean/Attributes.lean
@@ -30,7 +30,7 @@ structure AttributeImplCore where
   applicationTime := AttributeApplicationTime.afterTypeChecking
   deriving Inhabited
 
-/-- You can tag attributes with the 'local' or 'scoped' kind.
+/-- You can tag attributes with the `local` or `scoped` kind.
 For example: `attribute [local myattr, scoped yourattr, theirattr]`.
 
 This is used to indicate how an attribute should be scoped.

--- a/src/Lean/Class.lean
+++ b/src/Lean/Class.lean
@@ -155,11 +155,11 @@ Recall that all structures are inductive datatypes.
 -/
 def addClass (env : Environment) (clsName : Name) : Except MessageData Environment := do
   if isClass env clsName then
-    throw m!"class has already been declared '{.ofConstName clsName true}'"
+    throw m!"class has already been declared `{.ofConstName clsName true}`"
   let some decl := env.find? clsName
-    | throw m!"unknown declaration '{clsName}'"
+    | throw m!"unknown declaration `{clsName}`"
   unless decl matches .inductInfo .. | .axiomInfo .. do
-    throw m!"invalid 'class', declaration '{.ofConstName clsName}' must be inductive datatype, structure, or constant"
+    throw m!"invalid `class`, declaration `{.ofConstName clsName}` must be inductive datatype, structure, or constant"
   let outParams ← checkOutParam 0 #[] #[] decl.type
   return classExtension.addEntry env { name := clsName, outParams }
 

--- a/src/Lean/Compiler/CSimpAttr.lean
+++ b/src/Lean/Compiler/CSimpAttr.lean
@@ -50,7 +50,7 @@ def add (declName : Name) (kind : AttributeKind) : CoreM Unit := do
   if let some entry ← isConstantReplacement? declName then
     ext.add entry kind
   else
-    throwError "invalid 'csimp' theorem, only constant replacement theorems (e.g., `@f = @g`) are currently supported."
+    throwError "invalid `csimp` theorem, only constant replacement theorems (e.g., `@f = @g`) are currently supported."
 
 /--
 Tags compiler simplification theorems, which allow one value to be replaced by another equal value

--- a/src/Lean/Compiler/IR/Checker.lean
+++ b/src/Lean/Compiler/IR/Checker.lean
@@ -57,7 +57,7 @@ def markJP (j : JoinPointId) : M Unit :=
 def getDecl (c : Name) : M Decl := do
   let ctx ← read
   match findEnvDecl' (← getEnv) c ctx.decls with
-  | none   => throwCheckerError s!"depends on declaration '{c}', which has no executable code; consider marking definition as 'noncomputable'"
+  | none   => throwCheckerError s!"depends on declaration `{c}`, which has no executable code; consider marking definition as `noncomputable`"
   | some d => pure d
 
 def checkVar (x : VarId) : M Unit := do

--- a/src/Lean/Compiler/IR/EmitLLVM.lean
+++ b/src/Lean/Compiler/IR/EmitLLVM.lean
@@ -1067,7 +1067,7 @@ def emitSSet (builder : LLVM.Builder llvmctx) (x : VarId) (n : Nat) (offset : Na
   | IRType.uint16  => pure ("lean_ctor_set_uint16", ← LLVM.i16Type llvmctx)
   | IRType.uint32  => pure ("lean_ctor_set_uint32", ← LLVM.i32Type llvmctx)
   | IRType.uint64  => pure ("lean_ctor_set_uint64", ← LLVM.i64Type llvmctx)
-  | _              => throw s!"invalid type for 'lean_ctor_set': '{t}'"
+  | _              => throw s!"invalid type for `lean_ctor_set`: `{t}`"
   let argtys := #[ ← LLVM.voidPtrType llvmctx, ← LLVM.unsignedType llvmctx, setty]
   let retty  ← LLVM.voidType llvmctx
   let fn ← getOrCreateFunctionPrototype (← getLLVMModule) retty fnName argtys
@@ -1489,9 +1489,9 @@ def emitMainFn (mod : LLVM.Module llvmctx) (builder : LLVM.Builder llvmctx) : M 
   let d ← getDecl `main
   let xs ← match d with
    | .fdecl (xs := xs) .. => pure xs
-   | _ =>  throw "Function declaration expected for 'main'"
+   | _ =>  throw "Function declaration expected for `main`"
 
-  unless xs.size == 2 || xs.size == 1 do throw s!"Invalid main function, main expected to have '2' or '1' arguments, found '{xs.size}' arguments"
+  unless xs.size == 2 || xs.size == 1 do throw s!"Invalid main function, main expected to have `2` or `1` arguments, found `{xs.size}` arguments"
   let env ← getEnv
   let usesLeanAPI := usesModuleFrom env `Lean
   let mainTy ← LLVM.functionType (← LLVM.i64Type llvmctx)

--- a/src/Lean/Compiler/IR/ToIR.lean
+++ b/src/Lean/Compiler/IR/ToIR.lean
@@ -252,7 +252,7 @@ partial def lowerLet (decl : LCNF.LetDecl) (k : LCNF.Code) : M FnBody := do
     | some (.axiomInfo ..) | .some (.quotInfo ..) | .some (.inductInfo ..) | .some (.thmInfo ..) =>
       throwNamedError lean.dependsOnNoncomputable f!"`{name}` not supported by code generator; consider marking definition as `noncomputable`"
     | some (.recInfo ..) =>
-      throwError f!"code generator does not support recursor `{name}` yet, consider using 'match ... with' and/or structural recursion"
+      throwError f!"code generator does not support recursor `{name}` yet, consider using `match ... with` and/or structural recursion"
     | none => panic! "reference to unbound name"
   | .fvar fvarId args =>
     match (← getFVarValue fvarId) with

--- a/src/Lean/Compiler/LCNF/ToMono.lean
+++ b/src/Lean/Compiler/LCNF/ToMono.lean
@@ -26,7 +26,7 @@ def Param.toMono (param : Param) : ToMonoM Param := do
   param.update (← toMonoType param.type)
 
 def throwNoncomputableError {α : Type} (declName : Name) : ToMonoM α :=
-  throwNamedError lean.dependsOnNoncomputable m!"failed to compile definition, consider marking it as 'noncomputable' because it depends on '{.ofConstName declName}', which is 'noncomputable'"
+  throwNamedError lean.dependsOnNoncomputable m!"failed to compile definition, consider marking it as `noncomputable` because it depends on `{.ofConstName declName}`, which is `noncomputable`"
 
 def checkFVarUse (fvarId : FVarId) : ToMonoM Unit := do
   if let some declName := (← get).noncomputableVars.get? fvarId then

--- a/src/Lean/Data/Json/FromToJson/Basic.lean
+++ b/src/Lean/Data/Json/FromToJson/Basic.lean
@@ -191,7 +191,7 @@ protected def _root_.Float.fromJson? : Json → Except String Float
   | (Json.str "-Infinity") => Except.ok (-1.0 / 0.0)
   | (Json.str "NaN") => Except.ok (0.0 / 0.0)
   | (Json.num jn) => Except.ok jn.toFloat
-  | _ => Except.error "Expected a number or a string 'Infinity', '-Infinity', 'NaN'."
+  | _ => Except.error "Expected a number or a string `Infinity`, `-Infinity`, `NaN`."
 
 instance : FromJson Float where
   fromJson? := Float.fromJson?

--- a/src/Lean/DocString/Parser.lean
+++ b/src/Lean/DocString/Parser.lean
@@ -25,7 +25,7 @@ private partial def atLeastAux (n : Nat) (p : ParserFn) : ParserFn := fun c s =>
   if s.hasError then
     return if iniPos == s.pos && n == 0 then s.restore iniSz iniPos else s
   if iniPos == s.pos then
-    return s.mkUnexpectedError "invalid 'atLeast' parser combinator application, parser did not consume anything"
+    return s.mkUnexpectedError "invalid `atLeast` parser combinator application, parser did not consume anything"
   if s.stackSize > iniSz + 1 then
     s := s.mkNode nullKind iniSz
   atLeastAux (n - 1) p c s
@@ -64,7 +64,7 @@ private partial def atMostAux (n : Nat) (p : ParserFn) (msg : String) : ParserFn
     if s.hasError then
       return if iniPos == s.pos then s.restore iniSz iniPos else s
     if iniPos == s.pos then
-      return s.mkUnexpectedError "invalid 'atMost' parser combinator application, parser did not \
+      return s.mkUnexpectedError "invalid `atMost` parser combinator application, parser did not \
         consume anything"
     if s.stackSize > iniSz + 1 then
       s := s.mkNode nullKind iniSz

--- a/src/Lean/Elab/Binders.lean
+++ b/src/Lean/Elab/Binders.lean
@@ -854,7 +854,7 @@ def elabLetDeclAux (id : Syntax) (binders : Array Syntax) (typeStx : Syntax) (va
       let valResult ← elabTermEnsuringType valStx type
       let valResult ← mkLambdaFVars xs valResult (usedLetOnly := false)
       unless (← isDefEq val valResult) do
-        throwError "unexpected error when elaborating 'let'"
+        throwError "unexpected error when elaborating `let`"
   pure result
 
 structure LetIdDeclView where

--- a/src/Lean/Elab/BuiltinCommand.lean
+++ b/src/Lean/Elab/BuiltinCommand.lean
@@ -286,7 +286,7 @@ private partial def elabChoiceAux (cmds : Array Syntax) (i : Nat) : CommandElabM
   let `(export $ns ($ids*)) := stx | throwUnsupportedSyntax
   let nss ← resolveNamespace ns
   let currNamespace ← getCurrNamespace
-  if nss == [currNamespace] then throwError "invalid 'export', self export"
+  if nss == [currNamespace] then throwError "invalid `export`, self export"
   let mut aliases := #[]
   for idStx in ids do
     let id := idStx.getId
@@ -515,7 +515,7 @@ open Lean.Parser.Command.InternalSyntax in
   | `($doc:docComment add_decl_doc $id) =>
     let declName ← liftCoreM <| realizeGlobalConstNoOverloadWithInfo id
     unless ((← getEnv).getModuleIdxFor? declName).isNone do
-      throwError "invalid 'add_decl_doc', declaration is in an imported module"
+      throwError "invalid `add_decl_doc`, declaration is in an imported module"
     if let .none ← findDeclarationRangesCore? declName then
       -- this is only relevant for declarations added without a declaration range
       -- in particular `Quot.mk` et al which are added by `init_quot`
@@ -532,7 +532,7 @@ open Lean.Parser.Command.InternalSyntax in
       if let some idx := vars.findIdx? (· == id.getId) then
         uids := uids.push sc.varUIds[idx]!
       else
-        throwError "invalid 'include', variable `{id}` has not been declared in the current scope"
+        throwError "invalid `include`, variable `{id}` has not been declared in the current scope"
     modifyScope fun sc => { sc with
       includedVars := sc.includedVars ++ uids.toList
       omittedVars := sc.omittedVars.filter (!uids.contains ·) }
@@ -571,7 +571,7 @@ open Lean.Parser.Command.InternalSyntax in
             omittedVars := omittedVars.push uid
             omitsUsed := omitsUsed.set! idx true
           else
-            throwError "invalid 'omit', `{ldecl.userName}` has not been declared in the current scope"
+            throwError "invalid `omit`, `{ldecl.userName}` has not been declared in the current scope"
       for o in omits, used in omitsUsed do
         unless used do
           throwError "`{o}` did not match any variables in the current scope"
@@ -592,10 +592,10 @@ open Lean.Parser.Command.InternalSyntax in
   logInfo m!"Lean {Lean.versionString}\nTarget: {target}{String.join platforms}"
 
 @[builtin_command_elab Parser.Command.exit] def elabExit : CommandElab := fun _ =>
-  logWarning "using 'exit' to interrupt Lean"
+  logWarning "using `exit` to interrupt Lean"
 
 @[builtin_command_elab Parser.Command.import] def elabImport : CommandElab := fun _ =>
-  throwError "invalid 'import' command, it must be used in the beginning of the file"
+  throwError "invalid `import` command, it must be used in the beginning of the file"
 
 @[builtin_command_elab Parser.Command.eoi] def elabEoi : CommandElab := fun _ =>
   return

--- a/src/Lean/Elab/BuiltinEvalCommand.lean
+++ b/src/Lean/Elab/BuiltinEvalCommand.lean
@@ -101,9 +101,9 @@ private def addAndCompileExprForEval (declName : Name) (value : Expr) (allowSorr
     let axioms ← collectAxioms declName
     if axioms.contains ``sorryAx then
       throwError "\
-        aborting evaluation since the expression depends on the 'sorry' axiom, \
+        aborting evaluation since the expression depends on the `sorry` axiom, \
         which can lead to runtime instability and crashes.\n\n\
-        To attempt to evaluate anyway despite the risks, use the '#eval!' command."
+        To attempt to evaluate anyway despite the risks, use the `#eval!` command."
   return declName
 
 /--

--- a/src/Lean/Elab/BuiltinTerm.lean
+++ b/src/Lean/Elab/BuiltinTerm.lean
@@ -167,7 +167,7 @@ private def getMVarFromUserName (ident : Syntax) : MetaM Expr := do
     mkTacticMVar expectedType stx .term (delayOnMVars := (← getEnv).isExporting && !(← backward.proofsInPublic.getM))
   | none =>
     tryPostpone
-    throwError ("invalid 'by' tactic, expected type has not been provided")
+    throwError ("invalid `by` tactic, expected type has not been provided")
 
 @[builtin_term_elab noImplicitLambda] def elabNoImplicitLambda : TermElab := fun stx expectedType? =>
   elabTerm stx[1] (mkNoImplicitLambdaAnnotation <$> expectedType?)

--- a/src/Lean/Elab/Calc.lean
+++ b/src/Lean/Elab/Calc.lean
@@ -45,9 +45,9 @@ def mkCalcTrans (result resultType step stepType : Expr) : MetaM (Expr × Expr) 
     let result := mkAppN (Lean.mkConst ``Trans.trans [u, v, w, u_1, u_2, u_3]) #[α, β, γ, r, s, t, self, a, b, c, result, step]
     let resultType := (← instantiateMVars (← inferType result)).headBeta
     unless (← getCalcRelation? resultType).isSome do
-      throwError "invalid 'calc' step, step result is not a relation{indentExpr resultType}"
+      throwError "invalid `calc` step, step result is not a relation{indentExpr resultType}"
     return (result, resultType)
-  | _ => throwError "invalid 'calc' step, failed to synthesize `Trans` instance{indentExpr selfType}{useDiagnosticMsg}"
+  | _ => throwError "invalid `calc` step, failed to synthesize `Trans` instance{indentExpr selfType}{useDiagnosticMsg}"
 
 /--
 Adds a type annotation to a hole that occurs immediately at the beginning of the term.
@@ -111,11 +111,11 @@ def elabCalcSteps (steps : Array CalcStepView) : TermElabM (Expr × Expr) := do
       else
         pure step.term
     let some (_, lhs, rhs) ← getCalcRelation? type |
-      throwErrorAt step.term "invalid 'calc' step, relation expected{indentExpr type}"
+      throwErrorAt step.term "invalid `calc` step, relation expected{indentExpr type}"
     if let some prevRhs := prevRhs? then
       unless (← isDefEqGuarded lhs prevRhs) do
         throwErrorAt step.term "\
-          invalid 'calc' step, left-hand side is{indentD m!"{lhs} : {← inferType lhs}"}\n\
+          invalid `calc` step, left-hand side is{indentD m!"{lhs} : {← inferType lhs}"}\n\
           but previous right-hand side is{indentD m!"{prevRhs} : {← inferType prevRhs}"}"
     let proof ← withFreshMacroScope do elabTermEnsuringType step.proof type
     result? := some <| ← do
@@ -138,19 +138,19 @@ def throwCalcFailure (steps : Array CalcStepView) (expectedType result : Expr) :
         let (lhs, elhs) ← addPPExplicitToExposeDiff lhs elhs
         let (lhsTy, elhsTy) ← addPPExplicitToExposeDiff (← inferType lhs) (← inferType elhs)
         logErrorAt steps[0]!.term m!"\
-          invalid 'calc' step, left-hand side is{indentD m!"{lhs} : {lhsTy}"}\n\
+          invalid `calc` step, left-hand side is{indentD m!"{lhs} : {lhsTy}"}\n\
           but is expected to be{indentD m!"{elhs} : {elhsTy}"}"
         failed := true
       unless ← isDefEqGuarded rhs erhs do
         let (rhs, erhs) ← addPPExplicitToExposeDiff rhs erhs
         let (rhsTy, erhsTy) ← addPPExplicitToExposeDiff (← inferType rhs) (← inferType erhs)
         logErrorAt steps.back!.term m!"\
-          invalid 'calc' step, right-hand side is{indentD m!"{rhs} : {rhsTy}"}\n\
+          invalid `calc` step, right-hand side is{indentD m!"{rhs} : {rhsTy}"}\n\
           but is expected to be{indentD m!"{erhs} : {erhsTy}"}"
         failed := true
       if failed then
         throwAbortTerm
-  throwTypeMismatchError "'calc' expression" expectedType resultType result
+  throwTypeMismatchError "`calc` expression" expectedType resultType result
 
 /-!
 Warning! It is *very* tempting to try to improve `calc` so that it makes use of the expected type

--- a/src/Lean/Elab/DeclModifiers.lean
+++ b/src/Lean/Elab/DeclModifiers.lean
@@ -235,7 +235,7 @@ def mkDeclName (currNamespace : Name) (modifiers : Modifiers) (shortName : Name)
   let name := view.name
   let isRootName := (`_root_).isPrefixOf name
   if name == `_root_ then
-    throwError "invalid declaration name `_root_`, `_root_` is a prefix used to refer to the 'root' namespace"
+    throwError "invalid declaration name `_root_`, `_root_` is a prefix used to refer to the `root` namespace"
   let declName := if isRootName then { view with name := name.replacePrefix `_root_ Name.anonymous }.review else currNamespace ++ shortName
   if isRootName then
     let .str p s := name | throwError "invalid declaration name `{name}`"

--- a/src/Lean/Elab/Deriving/Repr.lean
+++ b/src/Lean/Elab/Deriving/Repr.lean
@@ -31,7 +31,7 @@ def mkBodyForStruct (header : Header) (indVal : InductiveVal) : TermElabM Term :
   forallTelescopeReducing ctorVal.type fun xs _ => do
     let mut fields ← `(Format.nil)
     if xs.size != numParams + fieldNames.size then
-      throwError "'deriving Repr' failed, unexpected number of fields in structure"
+      throwError "`deriving Repr` failed, unexpected number of fields in structure"
     for h : i in *...fieldNames.size do
       let fieldName := fieldNames[i]
       let fieldNameLit := Syntax.mkStrLit (toString fieldName)

--- a/src/Lean/Elab/Do/Legacy.lean
+++ b/src/Lean/Elab/Do/Legacy.lean
@@ -33,7 +33,7 @@ private def getDoSeq (doStx : Syntax) : Syntax :=
   doStx[1]
 
 def elabLiftMethod : TermElab := fun stx _ =>
-  throwErrorAt stx "invalid use of `(<- ...)`, must be nested inside a 'do' expression"
+  throwErrorAt stx "invalid use of `(<- ...)`, must be nested inside a `do` expression"
 
 /-- Return true if we should not lift `(<- ...)` actions nested in the syntax nodes with the given kind. -/
 private def liftMethodDelimiter (k : SyntaxNodeKind) : Bool :=

--- a/src/Lean/Elab/Extra.lean
+++ b/src/Lean/Elab/Extra.lean
@@ -38,7 +38,7 @@ private def throwForInFailure (forInInstance : Expr) : TermElabM Expr :=
         let forInInstance ← try
           mkAppM ``ForIn #[m, colType, elemType]
         catch _ =>
-          tryPostpone; throwError "failed to construct 'ForIn' instance for collection{indentExpr colType}\nand monad{indentExpr m}"
+          tryPostpone; throwError "failed to construct `ForIn` instance for collection{indentExpr colType}\nand monad{indentExpr m}"
         match (← trySynthInstance forInInstance) with
         | .some inst =>
           let forInFn ← mkConst ``forIn

--- a/src/Lean/Elab/LetRec.lean
+++ b/src/Lean/Elab/LetRec.lean
@@ -38,11 +38,11 @@ private def mkLetRecDeclView (letRec : Syntax) : TermElabM LetRecView := do
     let attrs ← if attrOptStx.isNone then pure #[] else elabDeclAttrs attrOptStx[0]
     let decl := attrDeclStx[2][0]
     if decl.isOfKind `Lean.Parser.Term.letPatDecl then
-      throwErrorAt decl "patterns are not allowed in 'let rec' expressions"
+      throwErrorAt decl "patterns are not allowed in `let rec` expressions"
     else if decl.isOfKind ``Lean.Parser.Term.letIdDecl || decl.isOfKind ``Lean.Parser.Term.letEqnsDecl then
       let declId := decl[0][0]
       unless declId.isIdent do
-        throwErrorAt declId "'let rec' expressions must be named"
+        throwErrorAt declId "`let rec` expressions must be named"
       let shortDeclName := declId.getId
       let parentName? ← getDeclName?
       let declName := parentName?.getD Name.anonymous ++ shortDeclName
@@ -58,7 +58,7 @@ private def mkLetRecDeclView (letRec : Syntax) : TermElabM LetRecView := do
       let typeStx := expandOptType declId decl[2]
       let (type, binderIds) ← elabBindersEx binders fun xs => do
           let type ← elabType typeStx
-          registerCustomErrorIfMVar type typeStx "failed to infer 'let rec' declaration type"
+          registerCustomErrorIfMVar type typeStx "failed to infer `let rec` declaration type"
           let (binderIds, xs) := xs.unzip
           let type ← mkForallFVars xs type
           pure (type, binderIds)

--- a/src/Lean/Elab/Match.lean
+++ b/src/Lean/Elab/Match.lean
@@ -506,7 +506,7 @@ partial def normalize (e : Expr) : M Expr := do
         let p := e.getArg! 2
         let h := e.getArg! 3
         unless x.consumeMData.isFVar && h.consumeMData.isFVar do
-          throwError "Unexpected occurrence of auxiliary declaration 'namedPattern'"
+          throwError "Unexpected occurrence of auxiliary declaration `namedPattern`"
         addVar x
         let p ← normalize p
         addVar h
@@ -608,7 +608,7 @@ private partial def toPattern (e : Expr) : MetaM Pattern := do
         let p ← toPattern <| e.getArg! 2
         match e.getArg! 1, e.getArg! 3 with
         | Expr.fvar x, Expr.fvar h => return Pattern.as x p h
-        | _,           _           => throwError "Unexpected occurrence of auxiliary declaration 'namedPattern'"
+        | _,           _           => throwError "Unexpected occurrence of auxiliary declaration `namedPattern`"
       else if (← isMatchValue e) then
         return Pattern.val (← normLitValue e)
       else if e.isFVar then
@@ -1068,7 +1068,7 @@ private def elabMatchAux (generalizing? : Option Bool) (discrStxs : Array Syntax
   let mut generalizing? := generalizing?
   if !matchOptMotive.isNone then
     if generalizing? == some true then
-      throwError "The '(generalizing := true)' parameter is not supported when the 'match' motive is explicitly provided"
+      throwError "The `(generalizing := true)` parameter is not supported when the `match` motive is explicitly provided"
     generalizing? := some false
   let (discrs, matchType, altLHSS, isDep, rhss) ← commitIfDidNotPostpone do
     let ⟨discrs, matchType, isDep, altViews⟩ ← elabMatchTypeAndDiscrs discrStxs matchOptMotive altViews expectedType

--- a/src/Lean/Elab/MutualDef.lean
+++ b/src/Lean/Elab/MutualDef.lean
@@ -90,17 +90,17 @@ private def checkKinds (k₁ k₂ : DefKind) : TermElabM Unit := do
 
 private def check (prevHeaders : Array DefViewElabHeader) (newHeader : DefViewElabHeader) : TermElabM Unit := do
   if newHeader.kind.isTheorem && newHeader.modifiers.isUnsafe then
-    throwError "'unsafe' theorems are not allowed"
+    throwError "`unsafe` theorems are not allowed"
   if newHeader.kind.isTheorem && newHeader.modifiers.isPartial then
-    throwError "'partial' theorems are not allowed, 'partial' is a code generation directive"
+    throwError "`partial` theorems are not allowed, `partial` is a code generation directive"
   if newHeader.kind.isTheorem && newHeader.modifiers.isMeta then
-    throwError "'meta' theorems are not allowed, 'meta' is a code generation directive"
+    throwError "`meta` theorems are not allowed, `meta` is a code generation directive"
   if newHeader.kind.isTheorem && newHeader.modifiers.isNoncomputable then
-    throwError "'theorem' subsumes 'noncomputable', code is not generated for theorems"
+    throwError "`theorem` subsumes `noncomputable`, code is not generated for theorems"
   if newHeader.modifiers.isNoncomputable && newHeader.modifiers.isPartial then
-    throwError "'noncomputable partial' is not allowed"
+    throwError "`noncomputable partial` is not allowed"
   if newHeader.modifiers.isPartial && newHeader.modifiers.isUnsafe then
-    throwError "'unsafe' subsumes 'partial'"
+    throwError "`unsafe` subsumes `partial`"
   if h : 0 < prevHeaders.size then
     let firstHeader := prevHeaders[0]
     try
@@ -1461,7 +1461,7 @@ def elabMutualDef (ds : Array Syntax) : CommandElabM Unit := do
     let d := ds[i]
     let modifiers ← elabModifiers ⟨d[0]⟩
     if ds.size > 1 && modifiers.isNonrec then
-      throwErrorAt d "invalid use of 'nonrec' modifier in 'mutual' block"
+      throwErrorAt d "invalid use of `nonrec` modifier in `mutual` block"
     let mut view ←
       withExporting (isExporting := modifiers.visibility.isInferredPublic (← getEnv)) do
         mkDefView modifiers d[1]

--- a/src/Lean/Elab/PreDefinition/Main.lean
+++ b/src/Lean/Elab/PreDefinition/Main.lean
@@ -27,7 +27,7 @@ private def addAndCompilePartial
       let value ← if useSorry then
         mkLambdaFVars xs (← withRef preDef.ref <| mkLabeledSorry type (synthetic := true) (unique := true))
       else
-        let msg := m!"failed to compile 'partial' definition `{preDef.declName}`"
+        let msg := m!"failed to compile `partial` definition `{preDef.declName}`"
         liftM <| mkInhabitantFor msg xs type
       addNonRec docCtx { preDef with
         kind  := DefKind.«opaque»

--- a/src/Lean/Elab/PreDefinition/MkInhabitant.lean
+++ b/src/Lean/Elab/PreDefinition/MkInhabitant.lean
@@ -70,7 +70,7 @@ def mkInhabitantFor (failedToMessage : MessageData) (xs : Array Expr) (type : Ex
           instances for the return type, while making every parameter into a local '{.ofConstName ``Inhabited}' instance.\n\
         - It tries unfolding the return type.\n\
         \n\
-        If the return type is defined using the 'structure' or 'inductive' command, \
-        you can try adding a 'deriving Nonempty' clause to it."
+        If the return type is defined using the `structure` or `inductive` command, \
+        you can try adding a `deriving Nonempty` clause to it."
 
 end Lean.Elab

--- a/src/Lean/Elab/Quotation.lean
+++ b/src/Lean/Elab/Quotation.lean
@@ -549,7 +549,7 @@ private partial def compileStxMatch (discrs : List Term) (alts : List Alt) : Ter
   match discrs, alts with
   | [],            ([], rhs)::_ => pure rhs  -- nothing left to match
   | _,             []           =>
-   logError "non-exhaustive 'match' (syntax)"
+   logError "non-exhaustive `match` (syntax)"
    pure Syntax.missing
   | discr::discrs, alt::alts    => do
     let info ← getHeadInfo alt

--- a/src/Lean/Elab/Tactic/Change.lean
+++ b/src/Lean/Elab/Tactic/Change.lean
@@ -79,7 +79,7 @@ the main goal. -/
         let (tgt', mvars) ← withCollectingNewGoalsFrom (elabChange (← getMainTarget) newType) (← getMainTag) `change
         liftMetaTactic fun mvarId => do
           return (← mvarId.replaceTargetDefEq tgt') :: mvars)
-      (failed := fun _ => throwError "'change' tactic failed")
+      (failed := fun _ => throwError "`change` tactic failed")
   | _ => throwUnsupportedSyntax
 
 end Lean.Elab.Tactic

--- a/src/Lean/Elab/Tactic/Conv/Congr.lean
+++ b/src/Lean/Elab/Tactic/Conv/Congr.lean
@@ -33,7 +33,7 @@ private partial def mkCongrThm (origTag : Name) (f : Expr) (args : Array Expr) (
     MetaM (Expr × Array (Option MVarId) × Array (Option MVarId)) := do
   let funInfo ← getFunInfoNArgs f args.size
   let some congrThm ← mkCongrSimpCore? f funInfo (← getCongrSimpKinds f funInfo) (subsingletonInstImplicitRhs := false)
-    | throwError "'congr' conv tactic failed to create congruence theorem"
+    | throwError "`congr` conv tactic failed to create congruence theorem"
   let mut eNew := f
   let mut proof := congrThm.proof
   let mut mvarIdsNew := #[]
@@ -68,7 +68,7 @@ private partial def mkCongrThm (origTag : Name) (f : Expr) (args : Array Expr) (
     | .heq | .fixedNoParam => unreachable!
   if congrThm.argKinds.size < args.size then
     if congrThm.argKinds.size == 0 then
-      throwError "'congr' conv tactic failed to create congruence theorem"
+      throwError "`congr` conv tactic failed to create congruence theorem"
     let (proof', mvarIdsNew', mvarIdsNewInsts') ←
       mkCongrThm origTag eNew args[funInfo.getArity...*] addImplicitArgs nameSubgoals
     for arg in args[funInfo.getArity...*] do
@@ -100,7 +100,7 @@ def congr (mvarId : MVarId) (addImplicitArgs := false) (nameSubgoals := true) :
     mvarId.assign proof
     return mvarIdsNew.toList ++ mvarIdsNewInsts.toList
   else
-    throwError "invalid 'congr' conv tactic, application or implication expected{indentExpr lhs}"
+    throwError "invalid `congr` conv tactic, application or implication expected{indentExpr lhs}"
 
 @[builtin_tactic Lean.Parser.Tactic.Conv.congr] def evalCongr : Tactic := fun _ => do
   replaceMainGoal <| List.filterMap id (← congr (← getMainGoal))
@@ -110,7 +110,7 @@ def congrFunN (mvarId : MVarId) : MetaM MVarId := mvarId.withContext do
   let (lhs, rhs) ← getLhsRhsCore mvarId
   let lhs := (← instantiateMVars lhs).cleanupAnnotations
   unless lhs.isApp do
-    throwError "invalid 'arg 0' conv tactic, application expected{indentExpr lhs}"
+    throwError "invalid `arg 0` conv tactic, application expected{indentExpr lhs}"
   lhs.withApp fun f xs => do
     let (g, mvarNew) ← mkConvGoalFor f
     mvarId.assign (← xs.foldlM (init := mvarNew) Meta.mkCongrFun)
@@ -250,7 +250,7 @@ def evalArg (tacticName : String) (i : Int) (explicit : Bool) : TacticM Unit := 
     let (lhs, rhs) ← getLhsRhsCore mvarId
     let lhs := (← instantiateMVars lhs).cleanupAnnotations
     let .app f a := lhs
-      | throwError "invalid 'fun' conv tactic, application expected{indentExpr lhs}"
+      | throwError "invalid `fun` conv tactic, application expected{indentExpr lhs}"
     let (g, mvarNew) ← mkConvGoalFor f
     mvarId.assign (← Meta.mkCongrFun mvarNew a)
     resolveRhs "fun" rhs (.app g a)
@@ -307,8 +307,8 @@ private def extCore (mvarId : MVarId) (userName? : Option Name) : MetaM MVarId :
     else
       let lhsType ← whnfD (← inferType lhs)
       unless lhsType.isForall do
-        throwError "invalid 'ext' conv tactic, function or arrow expected{indentD m!"{lhs} : {lhsType}"}"
-      let [mvarId] ← mvarId.apply (← mkConstWithFreshMVarLevels ``funext) | throwError "'apply funext' unexpected result"
+        throwError "invalid `ext` conv tactic, function or arrow expected{indentD m!"{lhs} : {lhsType}"}"
+      let [mvarId] ← mvarId.apply (← mkConstWithFreshMVarLevels ``funext) | throwError "`apply funext` unexpected result"
       let userNames := if let some userName := userName? then [userName] else []
       let (_, mvarId) ← mvarId.introN 1 userNames
       markAsConvGoal mvarId

--- a/src/Lean/Elab/Tactic/Conv/Pattern.lean
+++ b/src/Lean/Elab/Tactic/Conv/Pattern.lean
@@ -132,11 +132,11 @@ private def pre (pattern : AbstractMVarsResult) (state : IO.Ref PatternMatchStat
     let (result, _) ← Simp.main lhs ctx (methods := { pre := pre patternA state })
     let subgoals ← match ← state.get with
     | .all #[] | .occs _ 0 _ =>
-      throwError "'pattern' conv tactic failed, pattern was not found{indentExpr patternA.expr}"
+      throwError "`pattern` conv tactic failed, pattern was not found{indentExpr patternA.expr}"
     | .all subgoals => pure subgoals
     | .occs subgoals idx remaining =>
       if let some (i, _) := remaining.getLast? then
-        throwError "'pattern' conv tactic failed, pattern was found only {idx} times but {i+1} expected"
+        throwError "`pattern` conv tactic failed, pattern was found only {idx} times but {i+1} expected"
       pure <| (subgoals.qsort (·.1 < ·.1)).map (·.2)
     (← getRhs).mvarId!.assign result.expr
     (← getMainGoal).assign (← result.getProof)

--- a/src/Lean/Elab/Tactic/Do/Attr.lean
+++ b/src/Lean/Elab/Tactic/Do/Attr.lean
@@ -160,7 +160,7 @@ private def mkSpecTheorem (type : Expr) (proof : SpecProof) (prio : Nat) : MetaM
   -- cf. mkSimpTheoremCore
   let type ← instantiateMVars type
   unless (← isProp type) do
-    throwError "invalid 'spec', proposition expected{indentExpr type}"
+    throwError "invalid `spec`, proposition expected{indentExpr type}"
   withNewMCtxDepth do
   let (xs, _, type) ← withSimpGlobalConfig (forallMetaTelescopeReducing type)
   let type ← whnfR type
@@ -185,7 +185,7 @@ def mkSpecTheoremFromConst (declName : Name) (prio : Nat := eval_prio default) :
   mkSpecTheorem type (.global declName) prio
 
 def mkSpecTheoremFromLocal (fvar : FVarId) (prio : Nat := eval_prio default) : MetaM SpecTheorem := do
-  let some decl ← fvar.findDecl? | throwError "invalid 'spec', local constant not found"
+  let some decl ← fvar.findDecl? | throwError "invalid `spec`, local constant not found"
   mkSpecTheorem decl.type (.local fvar) prio
 
 def mkSpecTheoremFromStx (ref : Syntax) (proof : Expr) (prio : Nat := eval_prio default) : MetaM SpecTheorem := do
@@ -225,7 +225,7 @@ def mkSpecAttr (ext : SpecExtension) : AttributeImpl where
         impl.add declName stx attrKind
       catch e =>
       trace[Elab.Tactic.Do.specAttr] "Reason for failure to apply spec attribute: {e.toMessageData}"
-      throwError "Invalid 'spec': target was neither a Hoare triple specification nor a 'simp' lemma"
+      throwError "Invalid `spec`: target was neither a Hoare triple specification nor a `simp` lemma"
     discard <| go.run {} {}
 
 builtin_initialize registerBuiltinAttribute (mkSpecAttr specAttr)

--- a/src/Lean/Elab/Tactic/Doc.lean
+++ b/src/Lean/Elab/Tactic/Doc.lean
@@ -35,7 +35,7 @@ open Lean.Parser.Command
   | `(«register_tactic_tag»|$[$doc:docComment]? register_tactic_tag $tag:ident $user:str) => do
     let docstring ← doc.mapM getDocStringText
     modifyEnv (knownTacticTagExt.addEntry · (tag.getId, user.getString, docstring))
-  | _ => throwError "Malformed 'register_tactic_tag' command"
+  | _ => throwError "Malformed `register_tactic_tag` command"
 
 /--
 Gets the first string token in a parser description. For example, for a declaration like

--- a/src/Lean/Elab/Tactic/ElabTerm.lean
+++ b/src/Lean/Elab/Tactic/ElabTerm.lean
@@ -242,7 +242,7 @@ def refineCore (stx : Syntax) (tagSuffix : Name) (allowNaturalHoles : Bool) : Ta
       let mvarId ← mvarId.tryClear h.fvarId!
       replaceMainGoal (mvarIds' ++ [mvarId])
     else
-      throwError "'specialize' requires a term of the form `h x_1 .. x_n` where `h` appears in the local context"
+      throwError "`specialize` requires a term of the form `h x_1 .. x_n` where `h` appears in the local context"
   | _ => throwUnsupportedSyntax
 
 /--

--- a/src/Lean/Elab/Tactic/Ext.lean
+++ b/src/Lean/Elab/Tactic/Ext.lean
@@ -135,9 +135,9 @@ def realizeExtTheorem (structName : Name) (flat : Bool) : Elab.Command.CommandEl
   return extName
 
 /--
-Given an 'ext' theorem, ensures that there is an iff version of the theorem (if possible),
+Given an `ext` theorem, ensures that there is an iff version of the theorem (if possible),
 without validating any pre-existing theorems.
-Returns the name of the 'ext_iff' theorem.
+Returns the name of the `ext_iff` theorem.
 -/
 def realizeExtIffTheorem (extName : Name) : Elab.Command.CommandElabM Name := do
   let extIffName : Name :=

--- a/src/Lean/Elab/Tactic/Induction.lean
+++ b/src/Lean/Elab/Tactic/Induction.lean
@@ -19,8 +19,8 @@ public section
 
 register_builtin_option tactic.customEliminators : Bool := {
   defValue := true
-  descr    := "enable using custom eliminators in the 'induction' and 'cases' tactics \
-    defined using the '@[induction_eliminator]' and '@[cases_eliminator]' attributes"
+  descr    := "enable using custom eliminators in the `induction` and `cases` tactics \
+    defined using the `@[induction_eliminator]` and `@[cases_eliminator]` attributes"
 }
 
 end
@@ -1006,11 +1006,11 @@ def evalInduction : Tactic := fun stx =>
 
 register_builtin_option tactic.fun_induction.unfolding : Bool := {
   defValue := true
-  descr    := "if set to 'true', then 'fun_induction' and 'fun_cases' will use the “unfolding \
-    functional induction (resp. cases) principle” ('….induct_unfolding'/'….fun_cases_unfolding'), \
+  descr    := "if set to `true`, then `fun_induction` and `fun_cases` will use the \"unfolding \
+    functional induction (resp. cases) principle\" (`….induct_unfolding`/`….fun_cases_unfolding`), \
     which will attempt to replace the function goal of interest in the goal with the appropriate \
-    right-hand-side in each case. If 'false', the regular “functional induction principle” \
-    ('….induct'/'….fun_cases') is used."
+    right-hand-side in each case. If `false`, the regular \"functional induction principle\" \
+    (`….induct`/`….fun_cases`) is used."
 }
 
 /--

--- a/src/Lean/Elab/Tactic/Lets.lean
+++ b/src/Lean/Elab/Tactic/Lets.lean
@@ -55,7 +55,7 @@ declare_config_elab elabExtractLetsConfig ExtractLetsConfig
           let ((fvars, _), mvarId) ← mvarId.extractLets givenNames config
           return (fvars, [mvarId])
         extractLetsAddVarInfo ids fvars)
-      (failed := fun _ => throwError "'extract_lets' tactic failed")
+      (failed := fun _ => throwError "`extract_lets` tactic failed")
   | _ => throwUnsupportedSyntax
 
 /-!
@@ -70,7 +70,7 @@ declare_config_elab elabLiftLetsConfig LiftLetsConfig
     withLocation (expandOptLocation (Lean.mkOptionalNode loc?))
       (atLocal := fun h => liftMetaTactic1 fun mvarId => mvarId.liftLetsLocalDecl h config)
       (atTarget := liftMetaTactic1 fun mvarId => mvarId.liftLets config)
-      (failed := fun _ => throwError "'lift_lets' tactic failed")
+      (failed := fun _ => throwError "`lift_lets` tactic failed")
   | _ => throwUnsupportedSyntax
 
 /-!
@@ -82,7 +82,7 @@ declare_config_elab elabLiftLetsConfig LiftLetsConfig
     withLocation (expandOptLocation (Lean.mkOptionalNode loc?))
       (atLocal := fun h => liftMetaTactic1 fun mvarId => mvarId.letToHaveLocalDecl h)
       (atTarget := liftMetaTactic1 fun mvarId => mvarId.letToHave)
-      (failed := fun _ => throwError "'let_to_have' tactic failed")
+      (failed := fun _ => throwError "`let_to_have` tactic failed")
   | _ => throwUnsupportedSyntax
 
 end Lean.Elab.Tactic

--- a/src/Lean/Elab/Tactic/Omega/Frontend.lean
+++ b/src/Lean/Elab/Tactic/Omega/Frontend.lean
@@ -248,7 +248,7 @@ where
       let (lc, prf, facts) ← asLinearCombo rhs
       let prf' : OmegaM Expr := do mkEqTrans rw (← prf)
       pure (lc, prf', facts)
-    | none => panic! "Invalid rewrite rule in 'asLinearCombo'"
+    | none => panic! "Invalid rewrite rule in `asLinearCombo`"
   handleNatCast (e i n : Expr) : OmegaM (LinearCombo × OmegaM Expr × List Expr) := do
     match n with
     | .fvar h =>

--- a/src/Lean/Elab/Tactic/Show.lean
+++ b/src/Lean/Elab/Tactic/Show.lean
@@ -55,11 +55,11 @@ where
       setGoals newGoals
   simpleError (p tgt : Expr) : MetaM MessageData := do
     return m!"\
-      'show' tactic failed, pattern{indentExpr p}\n\
+      `show` tactic failed, pattern{indentExpr p}\n\
       is not definitionally equal to target{indentExpr tgt}"
   manyError (p tgt : Expr) : MetaM MessageData := do
     return m!"\
-      'show' tactic failed, no goals unify with the given pattern.\n\
+      `show` tactic failed, no goals unify with the given pattern.\n\
       \n\
       In the first goal, the pattern{indentExpr p}\n\
       is not definitionally equal to the target{indentExpr tgt}\n\

--- a/src/Lean/Elab/Tactic/Simpa.lean
+++ b/src/Lean/Elab/Tactic/Simpa.lean
@@ -45,7 +45,7 @@ def getLinterUnnecessarySimpa (o : LinterOptions) : Bool :=
         let mkInfo ← mkInitialTacticInfo (mkNullNode #[tk, usingTk?.getD .missing])
         let (some (_, g), stats) ← simpGoal (← getMainGoal) ctx (simprocs := simprocs) (simplifyTarget := true) (discharge? := discharge?)
           | if getLinterUnnecessarySimpa (← getLinterOptions) then
-              logLint linter.unnecessarySimpa (← getRef) "try 'simp' instead of 'simpa'"
+              logLint linter.unnecessarySimpa (← getRef) "try `simp` instead of `simpa`"
             return {}
         -- Replace the goal; captured by `mkInfo` in `using` case below.
         replaceMainGoal [g]

--- a/src/Lean/Elab/Tactic/Try.lean
+++ b/src/Lean/Elab/Tactic/Try.lean
@@ -273,7 +273,7 @@ builtin_initialize registerBuiltinAttribute {
     let prio ← match stx with
       | `(attr| try_suggestion $n:num) => pure n.getNat
       | `(attr| try_suggestion) => pure 1000  -- Default priority
-      | _ => throwError "invalid 'try_suggestion' attribute syntax"
+      | _ => throwError "invalid `try_suggestion` attribute syntax"
     let attrKind := if kind == AttributeKind.local then AttributeKind.local else AttributeKind.global
     trySuggestionExtension.add {
       name := declName,

--- a/src/Lean/Environment.lean
+++ b/src/Lean/Environment.lean
@@ -2383,7 +2383,7 @@ def displayStats (env : Environment) : IO Unit := do
   IO.println ("trust level:                           " ++ toString env.header.trustLevel);
   IO.println ("number of extensions:                  " ++ toString env.base.private.extensions.size);
   pExtDescrs.forM fun extDescr => do
-    IO.println ("extension '" ++ toString extDescr.name ++ "'")
+    IO.println ("extension `" ++ toString extDescr.name ++ "`")
     -- get state from `checked` at the end if `async`; it would otherwise panic
     let mut asyncMode := extDescr.toEnvExtension.asyncMode
     if asyncMode matches .async _ then
@@ -2416,7 +2416,7 @@ such as in `#eval`.
   evalConstCore α env opts constName
 
 private def throwUnexpectedType {α} (typeName : Name) (constName : Name) : ExceptT String Id α :=
-  throw ("unexpected type at '" ++ toString constName ++ "', `" ++ toString typeName ++ "` expected")
+  throw ("unexpected type at `" ++ toString constName ++ "`, `" ++ toString typeName ++ "` expected")
 
 /--
 Replays the difference between `newEnv` and `oldEnv` onto `dest`: the set of constants in `newEnv`

--- a/src/Lean/ErrorExplanation.lean
+++ b/src/Lean/ErrorExplanation.lean
@@ -220,7 +220,7 @@ where
     if (matchHeader 1 "Examples" line).isSome then
       return
     else
-      fail s!"Expected level-1 'Examples' header, but found `{line}`"
+      fail s!"Expected level-1 `Examples` header, but found `{line}`"
 
   -- We needn't `attempt` examples because they never appear in a location where backtracking is
   -- possible, and persisting the line index allows better error message placement

--- a/src/Lean/ErrorExplanations/DependsOnNoncomputable.lean
+++ b/src/Lean/ErrorExplanations/DependsOnNoncomputable.lean
@@ -63,7 +63,7 @@ def endsOrDefault (ns : List Nat) : Nat × Nat :=
   (head, tail)
 ```
 ```output
-failed to compile definition, consider marking it as 'noncomputable' because it depends on 'getOrDefault', which is 'noncomputable'
+failed to compile definition, consider marking it as `noncomputable` because it depends on `getOrDefault`, which is `noncomputable`
 ```
 ```lean fixed (title := "Fixed (computable)")
 def getOrDefault [Inhabited α] : Option α → α
@@ -96,7 +96,7 @@ def fromImage (f : Nat → Nat) (y : Nat) :=
     f 0
 ```
 ```output
-failed to compile definition, consider marking it as 'noncomputable' because it depends on 'propDecidable', which is 'noncomputable'
+failed to compile definition, consider marking it as `noncomputable` because it depends on `propDecidable`, which is `noncomputable`
 ```
 ```lean fixed
 open Classical in

--- a/src/Lean/InternalExceptionId.lean
+++ b/src/Lean/InternalExceptionId.lean
@@ -28,7 +28,7 @@ This method is usually invoked using the `initialize` command.
 -/
 def registerInternalExceptionId (name : Name) : IO InternalExceptionId := do
   let exs ← internalExceptionsRef.get
-  if exs.contains name then throw <| IO.userError s!"invalid internal exception id, '{name}' has already been used"
+  if exs.contains name then throw <| IO.userError s!"invalid internal exception id, `{name}` has already been used"
   let nextIdx := exs.size
   internalExceptionsRef.modify fun a => a.push name
   pure { idx := nextIdx }

--- a/src/Lean/Meta/AbstractNestedProofs.lean
+++ b/src/Lean/Meta/AbstractNestedProofs.lean
@@ -23,7 +23,7 @@ def abstractProof [Monad m] [MonadLiftT MetaM m] [MonadEnv m] [MonadOptions m] [
   let type ← postprocessType type
   /- https://github.com/leanprover/lean4/issues/10196
      If we use the cache when the proof contains `sorry`,
-     then we may fail to get a "declaration contains 'sorry'" warning for the current declaration. -/
+     then we may fail to get a "declaration uses `sorry`" warning for the current declaration. -/
   let cache := cache && !proof.hasSorry
   /- We turn on zetaDelta-expansion to make sure we don't need to perform an expensive `check` step to
     identify which let-decls can be abstracted. If we design a more efficient test, we can avoid the eager zetaDelta expansion step.

--- a/src/Lean/Meta/AppBuilder.lean
+++ b/src/Lean/Meta/AppBuilder.lean
@@ -559,7 +559,7 @@ partial def mkProjection (s : Expr) (fieldName : Name) : MetaM Expr := do
           pure none
       match r? with
       | some r => pure r
-      | none   => throwAppBuilderException `mkProjection ("invalid field name '" ++ toString fieldName ++ "' for" ++ hasTypeMsg s type)
+      | none   => throwAppBuilderException `mkProjection ("invalid field name `" ++ toString fieldName ++ "` for" ++ hasTypeMsg s type)
   | _ => throwAppBuilderException `mkProjection ("structure expected" ++ hasTypeMsg s type)
 
 private def mkListLitAux (nil : Expr) (cons : Expr) : List Expr → Expr

--- a/src/Lean/Meta/Match/Basic.lean
+++ b/src/Lean/Meta/Match/Basic.lean
@@ -290,7 +290,7 @@ partial def toPattern (e : Expr) : MetaM Pattern := do
         let p ← toPattern <| e.getArg! 2
         match e.getArg! 1, e.getArg! 3 with
         | Expr.fvar x, Expr.fvar h => return Pattern.as x p h
-        | _,           _   => throwError "Unexpected occurrence of auxiliary declaration 'namedPattern'"
+        | _,           _   => throwError "Unexpected occurrence of auxiliary declaration `namedPattern`"
       else if (← isMatchValue e) then
         return Pattern.val e
       else if e.isFVar then

--- a/src/Lean/Meta/SizeOf.lean
+++ b/src/Lean/Meta/SizeOf.lean
@@ -191,7 +191,7 @@ def mkSizeOfSpecLemmaName (ctorName : Name) : Name :=
   ctorName ++ `sizeOf_spec
 
 def mkSizeOfSpecLemmaInstance (ctorApp : Expr) : MetaM Expr :=
-  matchConstCtor ctorApp.getAppFn (fun _ => throwError "failed to apply 'sizeOf' spec, constructor expected{indentExpr ctorApp}") fun ctorInfo _ => do
+  matchConstCtor ctorApp.getAppFn (fun _ => throwError "failed to apply `sizeOf` spec, constructor expected{indentExpr ctorApp}") fun ctorInfo _ => do
     let ctorArgs     := ctorApp.getAppArgs
     let ctorParams   := ctorArgs[*...ctorInfo.numParams]
     let ctorFields   := ctorArgs[ctorInfo.numParams...*]

--- a/src/Lean/Meta/Tactic/CasesOnStuckLHS.lean
+++ b/src/Lean/Meta/Tactic/CasesOnStuckLHS.lean
@@ -25,7 +25,7 @@ public partial def casesOnStuckLHS (mvarId : MVarId) : MetaM (Array MVarId) := d
   if let some (_, lhs) ← matchEqHEqLHS? target then
     if let some fvarId ← findFVar? lhs then
       return (←  mvarId.cases fvarId).map fun s => s.mvarId
-  throwError "'casesOnStuckLHS' failed"
+  throwError "`casesOnStuckLHS` failed"
 where
   findFVar? (e : Expr) : MetaM (Option FVarId) := do
     match e.getAppFn with

--- a/src/Lean/Meta/Tactic/Grind/Util.lean
+++ b/src/Lean/Meta/Tactic/Grind/Util.lean
@@ -173,7 +173,7 @@ def foldProjs (e : Expr) : MetaM Expr := do
       In the test `grind_cat.lean`, the following operation fails if we are not using default
       transparency. We get the following error.
       ```
-      error: AppBuilder for 'mkProjection', structure expected
+      error: AppBuilder for `mkProjection`, structure expected
         T
       has type
         F ⟶ G

--- a/src/Lean/Meta/Tactic/Rewrite.lean
+++ b/src/Lean/Meta/Tactic/Rewrite.lean
@@ -66,10 +66,10 @@ def _root_.Lean.MVarId.rewrite (mvarId : MVarId) (e : Expr) (heq : Expr)
               Third, we observe that '{.ofConstName ``congrArg}' implies that 'm a = m b', which can be used with lemmas such as '{.ofConstName ``Eq.mpr}' to change the goal. \
               However, if 'e' depends on specific properties of 'a', then the motive 'm' might not typecheck.\
               \n\n\
-              Possible solutions: use rewrite's 'occs' configuration option to limit which occurrences are rewritten, \
-              or use 'simp' or 'conv' mode, which have strategies for certain kinds of dependencies \
+              Possible solutions: use rewrite's `occs` configuration option to limit which occurrences are rewritten, \
+              or use `simp` or `conv` mode, which have strategies for certain kinds of dependencies \
               (these tactics can handle proofs and '{.ofConstName ``Decidable}' instances whose types depend on the rewritten term, \
-              and 'simp' can apply user-defined '@[congr]' theorems as well)."
+              and `simp` can apply user-defined `@[congr]` theorems as well)."
           unless (← withLocalDeclD `_a α fun a => do isDefEq (← inferType (eAbst.instantiate1 a)) eType) do
             -- NB: using motive.arrow? would disallow motives where the dependency
             -- can be reduced away

--- a/src/Lean/MetavarContext.lean
+++ b/src/Lean/MetavarContext.lean
@@ -931,9 +931,9 @@ instance : ToString Exception where
   toString
     | Exception.revertFailure _ lctx toRevert varName =>
       "failed to revert "
-      ++ toString (toRevert.map (fun x => "'" ++ toString (lctx.getFVar! x).userName ++ "'"))
-      ++ ", '" ++ toString varName ++ "' depends on them, and it is an auxiliary declaration created by the elaborator"
-      ++ " (possible solution: use tactic 'clear' to remove '" ++ toString varName ++ "' from local context)"
+      ++ toString (toRevert.map (fun x => "`" ++ toString (lctx.getFVar! x).userName ++ "`"))
+      ++ ", `" ++ toString varName ++ "` depends on them, and it is an auxiliary declaration created by the elaborator"
+      ++ " (possible solution: use tactic `clear` to remove `" ++ toString varName ++ "` from local context)"
 
 /--
  `MkBinding` and `elimMVarDepsAux` are mutually recursive, but `cache` is only used at `elimMVarDepsAux`.

--- a/src/Lean/Parser/Basic.lean
+++ b/src/Lean/Parser/Basic.lean
@@ -415,7 +415,7 @@ partial def manyAux (p : ParserFn) : ParserFn := fun c s => Id.run do
   if s.hasError then
     return if iniPos == s.pos then s.restore iniSz iniPos else s
   if iniPos == s.pos then
-    return s.mkUnexpectedError "invalid 'many' parser combinator application, parser did not consume anything"
+    return s.mkUnexpectedError "invalid `many` parser combinator application, parser did not consume anything"
   if s.stackSize > iniSz + 1 then
     s := s.mkNode nullKind iniSz
   manyAux p c s

--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -505,7 +505,7 @@ causes an error if the universe has not been declared previously.
 ```lean
 def L₁.{u} := List (Type u)
 
--- def L₂ := List (Type u) -- error: `unknown universe level 'u'`
+-- def L₂ := List (Type u) -- error: unknown universe level `u`
 
 universe u
 def L₃ := List (Type u)

--- a/src/Lean/Parser/Do.lean
+++ b/src/Lean/Parser/Do.lean
@@ -64,7 +64,7 @@ def notFollowedByRedefinedTermToken :=
   -- If we don't add `do`, then users would have to indent `do` blocks or use `{ ... }`.
   notFollowedBy ("set_option" <|> "open" <|> "if" <|> "match" <|> "match_expr" <|> "let" <|> "let_expr" <|> "have" <|>
       "do" <|> "dbg_trace" <|> "assert!" <|> "debug_assert!" <|> "for" <|> "unless" <|> "return" <|> symbol "try")
-    "token at 'do' element"
+    "token at `do` element"
 
 @[builtin_doElem_parser] def doLet      := leading_parser
   "let " >> optional "mut " >> letDecl
@@ -152,9 +152,9 @@ def doIfCond    :=
 -- current category call)
 @[builtin_doElem_parser] def doIf := leading_parser withResetCache <| withPositionAfterLinebreak <| ppRealGroup <|
   ppRealFill (ppIndent ("if " >> doIfCond >> " then") >> ppSpace >> doSeq) >>
-  many (checkColGe "'else if' in 'do' must be indented" >>
+  many (checkColGe "`else if` in `do` must be indented" >>
     group (ppDedent ppSpace >> ppRealFill (elseIf >> doIfCond >> " then " >> doSeq))) >>
-  optional (checkColGe "'else' in 'do' must be indented" >>
+  optional (checkColGe "`else` in `do` must be indented" >>
     ppDedent ppSpace >> ppRealFill ("else " >> doSeq))
 @[builtin_doElem_parser] def doUnless := leading_parser
   "unless " >> withForbidden "do" termParser >> " do " >> doSeq
@@ -243,7 +243,7 @@ The second `notFollowedBy` prevents this problem.
 @[builtin_doElem_parser] def doExpr   := leading_parser
   notFollowedByRedefinedTermToken >> termParser >>
   notFollowedBy (symbol ":=" <|> leftArrow)
-    "unexpected token after 'expr' in 'do' block"
+    "unexpected token after `expr` in `do` block"
 @[builtin_doElem_parser] def doNested := leading_parser
   "do " >> doSeq
 

--- a/src/Lean/Parser/Extension.lean
+++ b/src/Lean/Parser/Extension.lean
@@ -419,7 +419,7 @@ def categoryParserFnImpl (catName : Name) : ParserFn := fun ctx s =>
   match getCategory categories catName with
   | some cat =>
     prattParser catName cat.tables cat.behavior (mkCategoryAntiquotParserFn catName) ctx s
-  | none     => s.mkUnexpectedError ("unknown parser category '" ++ toString catName ++ "'")
+  | none     => s.mkUnexpectedError ("unknown parser category `" ++ toString catName ++ "`")
 
 builtin_initialize
   categoryParserFnRef.set categoryParserFnImpl

--- a/src/Lean/PrettyPrinter/Delaborator/Options.lean
+++ b/src/Lean/PrettyPrinter/Delaborator/Options.lean
@@ -39,11 +39,11 @@ register_builtin_option pp.unicode.fun : Bool := {
 }
 register_builtin_option pp.match : Bool := {
   defValue := true
-  descr    := "(pretty printer) disable/enable 'match' notation"
+  descr    := "(pretty printer) disable/enable `match` notation"
 }
 register_builtin_option pp.sorrySource : Bool := {
   defValue := false
-  descr    := "(pretty printer) if true, pretty print 'sorry' with its originating source position, if available"
+  descr    := "(pretty printer) if true, pretty print `sorry` with its originating source position, if available"
 }
 register_builtin_option pp.coercions : Bool := {
   defValue := true

--- a/src/Lean/PrettyPrinter/Delaborator/TopDownAnalyze.lean
+++ b/src/Lean/PrettyPrinter/Delaborator/TopDownAnalyze.lean
@@ -50,17 +50,17 @@ register_builtin_option pp.analyze.typeAscriptions : Bool := {
 
 register_builtin_option pp.analyze.trustSubst : Bool := {
   defValue := false
-  descr    := "(pretty printer analyzer) always 'pretend' applications that can delab to ▸ are 'regular'"
+  descr    := "(pretty printer analyzer) always \"pretend\" applications that can delab to ▸ are \"regular\""
 }
 
 register_builtin_option pp.analyze.trustOfNat : Bool := {
   defValue := true
-  descr    := "(pretty printer analyzer) always 'pretend' `OfNat.ofNat` applications can elab bottom-up"
+  descr    := "(pretty printer analyzer) always \"pretend\" `OfNat.ofNat` applications can elab bottom-up"
 }
 
 register_builtin_option pp.analyze.trustOfScientific : Bool := {
   defValue := true
-  descr    := "(pretty printer analyzer) always 'pretend' `OfScientific.ofScientific` applications can elab bottom-up"
+  descr    := "(pretty printer analyzer) always \"pretend\" `OfScientific.ofScientific` applications can elab bottom-up"
 }
 
 -- TODO: this is an arbitrary special case of a more general principle.

--- a/src/Lean/Shell.lean
+++ b/src/Lean/Shell.lean
@@ -147,7 +147,7 @@ def displayHelp (useStderr : Bool) : IO Unit := do
   out.putStrLn    "  -v, --version          display version information"
   out.putStrLn    "  -V, --short-version    display short version number"
   out.putStrLn    "  -g, --githash          display the git commit hash number used to build this binary"
-  out.putStrLn    "      --run <file>       call the 'main' definition in the given file with the remaining arguments"
+  out.putStrLn    "      --run <file>       call the `main` definition in the given file with the remaining arguments"
   out.putStrLn    "  -o, --o=oname          create olean file"
   out.putStrLn    "  -i, --i=iname          create ilean file"
   out.putStrLn    "  -c, --c=fname          name of the C output file"

--- a/src/Lean/SubExpr.lean
+++ b/src/Lean/SubExpr.lean
@@ -81,7 +81,7 @@ def all (pred : Nat → Bool) (p : Pos) : Bool :=
 
 def append : Pos → Pos → Pos := foldl push
 
-/-- Creates a subexpression `Pos` from an array of 'coordinates'.
+/-- Creates a subexpression `Pos` from an array of `coordinates`.
 Each coordinate is a number {0,1,2} expressing which child subexpression should be explored.
 The first coordinate in the array corresponds to the root of the expression tree.  -/
 def ofArray (ps : Array Nat) : Pos :=

--- a/src/Lean/Util/PPExt.lean
+++ b/src/Lean/Util/PPExt.lean
@@ -25,7 +25,7 @@ register_builtin_option pp.raw.maxDepth : Nat := {
 }
 register_builtin_option pp.rawOnError : Bool := {
   defValue := false
-  descr    := "(pretty printer) fallback to 'raw' printer when pretty printer fails"
+  descr    := "(pretty printer) fallback to \"raw\" printer when pretty printer fails"
 }
 
 structure PPContext where

--- a/src/lake/Lake/Load/Lean/Eval.lean
+++ b/src/lake/Lake/Load/Lean/Eval.lean
@@ -169,7 +169,7 @@ public def Package.loadFromEnv
 
   -- Deprecation warnings
   unless self.config.manifestFile.isNone do
-    logWarning s!"{self.prettyName}: package configuration option 'manifestFile' is deprecated"
+    logWarning s!"{self.prettyName}: package configuration option `manifestFile` is deprecated"
 
   -- Fill in the Package
   return {self with

--- a/tests/lean/interactive/incrementalCommand.lean
+++ b/tests/lean/interactive/incrementalCommand.lean
@@ -41,7 +41,7 @@ wrap 1 def wrapped := by
   dbg_trace "w"
 
 /-!
-The example used to result in nothing but "declaration uses 'sorry'" (and using the downstream
+The example used to result in nothing but "declaration uses `sorry`" (and using the downstream
 "unreachable tactic" linter, the `simp` would be flagged) as `simp` among other elaborators
 accidentally swallowed the interrupt exception.
 -/

--- a/tests/lean/librarySearch.lean
+++ b/tests/lean/librarySearch.lean
@@ -354,7 +354,7 @@ info: Try this:
   -- Remaining subgoals:
   -- ⊢ 2 ≠ 0
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example {x : Int} (h : x ≠ 0) : 2 * x ≠ 0 := by

--- a/tests/lean/run/10196.lean
+++ b/tests/lean/run/10196.lean
@@ -9,10 +9,10 @@ It re-used the `g._proof_1` proof.
 -/
 
 def f (n : Nat) (_ : n ≠ 0) : Nat := n
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def g (m : Nat) := f m sorry
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def g' (m : Nat) := f m sorry
 
@@ -22,32 +22,32 @@ Examples from the issue. The `ByteString.Pos.next` definition did not use to hav
 structure ByteString where
 structure ByteString.Pos (s : ByteString) where
 structure ByteString.Slice where
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def ByteString.toSlice (s : ByteString) : ByteString.Slice :=
   sorry
 structure ByteString.Slice.Pos (s : ByteString.Slice) where
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def ByteString.Slice.endPos (s : ByteString.Slice) : s.Pos :=
   sorry
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def ByteString.Slice.Pos.get {s : ByteString.Slice} (pos : s.Pos) (h : pos ≠ s.endPos) : Char :=
   sorry
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def ByteString.Pos.toSlice {s : ByteString} (pos : s.Pos) : s.toSlice.Pos :=
   sorry
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def ByteString.Slice.Pos.next {s : ByteString.Slice} (pos : s.Pos) (h : pos ≠ s.endPos) : s.Pos :=
   sorry
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def ByteString.Pos.get {s : ByteString} (pos : s.Pos) : Char :=
   pos.toSlice.get sorry
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def ByteString.Pos.next {s : ByteString} (pos : s.Pos) (h : True) : s.toSlice.Pos :=
   pos.toSlice.next sorry

--- a/tests/lean/run/1234.lean
+++ b/tests/lean/run/1234.lean
@@ -11,7 +11,7 @@ set_option linter.unusedSimpArgs false
 set_option Elab.async false -- for stable message ordering in #guard_msgs
 
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 trace: [Meta.Tactic.simp.rewrite] h₁:1000:
       k ≤ v - 1
@@ -51,7 +51,7 @@ example (h₁: k ≤ v - 1) (h₂: 0 < v):
 -- it works
 
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 trace: [Meta.Tactic.simp.rewrite] h₁:1000:
       k ≤ v - 1
@@ -89,7 +89,7 @@ example (h₁: k ≤ v - 1) (h₂: 0 < v):
     ]
 
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 trace: [Meta.Tactic.simp.rewrite] h₁:1000:
       k ≤ v - 1

--- a/tests/lean/run/1697.lean
+++ b/tests/lean/run/1697.lean
@@ -12,7 +12,7 @@ error: aborting evaluation since the expression depends on the 'sorry' axiom, wh
 
 To attempt to evaluate anyway despite the risks, use the '#eval!' command.
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval #[1,2,3][2]'sorry
@@ -20,7 +20,7 @@ warning: declaration uses 'sorry'
 /--
 info: 3
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! #[1,2,3][2]'sorry
@@ -33,7 +33,7 @@ normal circumstances this actually works with the output below, but the `Linux D
 catches it and complains. Maybe too bold to have this in the test suite.
 
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 info: 3
 -/

--- a/tests/lean/run/2159.lean
+++ b/tests/lean/run/2159.lean
@@ -3,7 +3,7 @@ trace: ⊢ 1.2 < 2
 ---
 trace: ⊢ 1.2 < 2
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : 1.2 < 2 := by

--- a/tests/lean/run/2226.lean
+++ b/tests/lean/run/2226.lean
@@ -11,7 +11,7 @@ variable (A : Nat) (B : by skip)
 def foo :=
   A = B
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def boo :=
   B

--- a/tests/lean/run/2916.lean
+++ b/tests/lean/run/2916.lean
@@ -4,7 +4,7 @@ set_option pp.coercions false -- Show `OfNat.ofNat` when present for clarity
 trace: x : Nat
 ⊢ OfNat.ofNat 2 = x
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : nat_lit 2 = x := by
@@ -16,7 +16,7 @@ example : nat_lit 2 = x := by
 trace: x : Nat
 ⊢ OfNat.ofNat 2 = x
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : nat_lit 2 = x := by
@@ -30,7 +30,7 @@ f : (n : Nat) → α n
 x : α (OfNat.ofNat 2)
 ⊢ f (OfNat.ofNat 2) = x
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (α : Nat → Type) (f : (n : Nat) → α n) (x : α 2) : f (nat_lit 2) = x := by
@@ -67,7 +67,7 @@ f : (n : Nat) → α n
 x : α (OfNat.ofNat 2)
 ⊢ f 2 = x
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (α : Nat → Type) (f : (n : Nat) → α n) (x : α 2) : f 2 = x := by

--- a/tests/lean/run/343.lean
+++ b/tests/lean/run/343.lean
@@ -23,7 +23,7 @@ unif_hint (mvar : CatIsh) where
 structure CtxSyntaxLayerParamsObj where
   Ct : CatIsh
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def CtxSyntaxLayerParams : CatIsh :=
   {

--- a/tests/lean/run/3519.lean
+++ b/tests/lean/run/3519.lean
@@ -2,7 +2,7 @@
 info: Try this:
   [apply] simp only [x]
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example {P : Nat → Prop} : let x := 0; P x := by
@@ -14,7 +14,7 @@ example {P : Nat → Prop} : let x := 0; P x := by
 info: Try this:
   [apply] simp_all only [x]
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example {P : Nat → Prop} : let x := 0; P x := by

--- a/tests/lean/run/3922.lean
+++ b/tests/lean/run/3922.lean
@@ -28,7 +28,7 @@ info: found a partial proof, but the corresponding tactic failed:
 
 It may be possible to correct this proof by adding type annotations, explicitly specifying implicit arguments, or eliminating unnecessary function abstractions.
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs (ordering := sorted) in
 example (a b c : Nat) (h₁ : r b a) (h₂ : r b c) : r c a := by

--- a/tests/lean/run/4888.lean
+++ b/tests/lean/run/4888.lean
@@ -44,7 +44,7 @@ theorem kernel_declaration_meta_variables (x y z : Option Int) : (x = y) ↔ (x 
 /-!
 Regression test: `all_goals` still respects recovery state.
 -/
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 example (x y z : Option Int) : (x = y) ↔ (x = z) := by
   apply Iff.elim

--- a/tests/lean/run/5407.lean
+++ b/tests/lean/run/5407.lean
@@ -100,7 +100,7 @@ info: found a partial proof, but the corresponding tactic failed:
 
 It may be possible to correct this proof by adding type annotations, explicitly specifying implicit arguments, or eliminating unnecessary function abstractions.
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : E := by apply?
@@ -118,7 +118,7 @@ info: Try this:
   -- Remaining subgoals:
   -- ⊢ R a b
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : (b : B) → R a b := by

--- a/tests/lean/run/6123_mod_cast.lean
+++ b/tests/lean/run/6123_mod_cast.lean
@@ -174,7 +174,7 @@ end WithBot
 
 namespace WithBot
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem le_of_forall_lt_iff_le [LinearOrder α] [DenselyOrdered α]
     {x y : WithBot α} : (∀ z : α, x < z → y ≤ z) ↔ y ≤ x := by

--- a/tests/lean/run/6655.lean
+++ b/tests/lean/run/6655.lean
@@ -27,7 +27,7 @@ d : α → α := c
 e : α → α := d
 ⊢ d x = x
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example {α : Type} (c : α → α) (x : α) : c x = x := by
@@ -45,7 +45,7 @@ Example from #6655. This used to suggest `simp only [d]`.
 info: Try this:
   [apply] simp only
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example {α : Type} (c : α → α) (x : α) : c x = x := by
@@ -106,7 +106,7 @@ d : α → α := c
 e : α → α := d
 ⊢ d x = x
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example {α : Type} (b : α → α) (x : α) : b x = x := by

--- a/tests/lean/run/7475.lean
+++ b/tests/lean/run/7475.lean
@@ -17,7 +17,7 @@ def equal (a b : EFixedPoint) : Bool :=
   | Infinity s1, Infinity s2 => s1 = s2
   | _, _ => false
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem EFixedPoint_eq_refl (a : EFixedPoint) : a.equal a = true := by
   unfold EFixedPoint.equal

--- a/tests/lean/run/bv_decide_rewriter_ac_nf.lean
+++ b/tests/lean/run/bv_decide_rewriter_ac_nf.lean
@@ -19,7 +19,7 @@ elab "bv_ac_nf" : tactic =>
 /- NOTE: the expression in this test is used as an example in the `bv_ac_nf` tactic
 documentation. Any changes to the behaviour of this test should be reflected in
 that docstring also. -/
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem mul_mul_beq_mul_mul (x₁ x₂ y₁ y₂ z : BitVec 4) :
     (x₁ * (y₁ * z)) == (x₂ * (y₂ * z)) := by
@@ -27,7 +27,7 @@ theorem mul_mul_beq_mul_mul (x₁ x₂ y₁ y₂ z : BitVec 4) :
   guard_target =ₛ (z * (x₁ * y₁) == z * (x₂ * y₂)) = true
   sorry
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem ex_1 (x y z k₁ k₂ l₁ l₂ m₁ m₂ v : BitVec w) :
     m₁ * x * (y * l₁ * k₁) * z == v * (k₂ * l₂ * x * y) * z * m₂ := by
@@ -35,7 +35,7 @@ theorem ex_1 (x y z k₁ k₂ l₁ l₂ m₁ m₂ v : BitVec w) :
   guard_target =ₛ (x * y * z * (m₁ * l₁ * k₁) == x * y * z * (v * k₂ * l₂ * m₂)) = true
   sorry
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem ex_2 (x y : BitVec w) (h₁ : y = x) :
     x * x * x * x == y * x * x * y := by
@@ -44,7 +44,7 @@ theorem ex_2 (x y : BitVec w) (h₁ : y = x) :
   sorry
 
 -- This theorem is short-circuited and scales to standard bitwidths.
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem mul_beq_mul_eq_right (x y z : BitVec 64) (h : x = y) :
     x * z == y * z := by
@@ -53,7 +53,7 @@ theorem mul_beq_mul_eq_right (x y z : BitVec 64) (h : x = y) :
   sorry
 
 -- This theorem is short-circuited and scales to standard bitwidths.
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem mul_beq_mul_eq_left (x y z : BitVec 64) (h : x = y) :
     z * x == z * y := by
@@ -61,7 +61,7 @@ theorem mul_beq_mul_eq_left (x y z : BitVec 64) (h : x = y) :
   guard_target =ₛ (z * x == z * y) = true
   sorry
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem short_circuit_triple_mul (x x_1 x_2 : BitVec 32) (h : ¬x_2 &&& 4096#32 == 0#32) :
     (x_1 ||| 4096#32) * x * (x_1 ||| 4096#32) = (x_1 ||| x_2 &&& 4096#32) * x * (x_1 ||| 4096#32) := by
@@ -107,7 +107,7 @@ namespace Normalize
 local macro "bv_normalize" : tactic =>
   `(tactic| bv_normalize (config := {acNf := true, shortCircuit := true}))
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem mul_mul_eq_mul_mul (x₁ x₂ y₁ y₂ z : BitVec 4) (h₁ : x₁ = x₂) (h₂ : y₁ = y₂) :
     x₁ * (y₁ * z) = x₂ * (y₂ * z) := by
@@ -116,7 +116,7 @@ theorem mul_mul_eq_mul_mul (x₁ x₂ y₁ y₂ z : BitVec 4) (h₁ : x₁ = x�
   guard_hyp tgt :ₛ (!!(!x₁ * y₁ == x₂ * y₂ && !z * (x₁ * y₁) == z * (x₂ * y₂))) = true
   sorry
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem mul_eq_mul_eq_right (x y z : BitVec 64) (h : x = y) :
     x * z = y * z := by

--- a/tests/lean/run/bv_sint.lean
+++ b/tests/lean/run/bv_sint.lean
@@ -67,7 +67,7 @@ example (a b c : ISize) (h1 : a < b) (h2 : b < c) : a < c := by
 /--
 warning: Detected USize/ISize in the goal but no hypothesis about System.Platform.numBits, consider case splitting on System.Platform.numBits_eq
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (a b : ISize) : a + b > a := by

--- a/tests/lean/run/bv_uint.lean
+++ b/tests/lean/run/bv_uint.lean
@@ -67,7 +67,7 @@ example (a b c : USize) (h1 : a < b) (h2 : b < c) : a < c := by
 /--
 warning: Detected USize/ISize in the goal but no hypothesis about System.Platform.numBits, consider case splitting on System.Platform.numBits_eq
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (a b : USize) : a + b > a := by

--- a/tests/lean/run/byAsSorry.lean
+++ b/tests/lean/run/byAsSorry.lean
@@ -1,6 +1,6 @@
 set_option debug.byAsSorry true in
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 theorem ex1 (h : b = a) : a = b := by
@@ -20,7 +20,7 @@ def f (x : Nat) : Nat := by
 
 set_option debug.byAsSorry true in
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 def g (x : Nat) : { x : Nat // x > 0 } :=

--- a/tests/lean/run/clear_value.lean
+++ b/tests/lean/run/clear_value.lean
@@ -306,7 +306,7 @@ trace: α : Type := Nat
 x : α
 ⊢ x = 1
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : let α := Nat; let x : α := 1; @Eq α x 1 := by

--- a/tests/lean/run/compiler_proj_bug.lean
+++ b/tests/lean/run/compiler_proj_bug.lean
@@ -7,7 +7,7 @@ s.b - s.a
 /--
 info: 25
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! f {a := 5, b := 30, h := sorry }

--- a/tests/lean/run/dsimp_bv_simproc.lean
+++ b/tests/lean/run/dsimp_bv_simproc.lean
@@ -16,7 +16,7 @@ a x y : BitVec 64
 h : 128 = 128
 ⊢ write 16 a (x ++ y) s = aux
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (a x y : BitVec 64)

--- a/tests/lean/run/elabLet.lean
+++ b/tests/lean/run/elabLet.lean
@@ -57,7 +57,7 @@ trace: m : Nat := 1
 hyp : m = 1
 ⊢ True
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : True := by
@@ -73,7 +73,7 @@ trace: m : Nat
 hyp : m = 1
 ⊢ True
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : True := by
@@ -160,7 +160,7 @@ Testing `+generalize`
 trace: x y z : Nat
 ⊢ z = y + x
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (x y : Nat) : x + y = y + x := by

--- a/tests/lean/run/ext.lean
+++ b/tests/lean/run/ext.lean
@@ -155,7 +155,7 @@ error: Failed to generate an `ext_iff` theorem from `weird_prod_ext`: Argument `
 
 Hint: Try `@[ext (iff := false)]` to prevent generating an `ext_iff` theorem.
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 @[ext]

--- a/tests/lean/run/generalizeMany.lean
+++ b/tests/lean/run/generalizeMany.lean
@@ -10,7 +10,7 @@ h₁ : n + 1 = n'
 h₂ : v.succ ≍ v'
 ⊢ p n' v'
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (p : (n : Nat) → Fin n → Prop)

--- a/tests/lean/run/guard_msgs.lean
+++ b/tests/lean/run/guard_msgs.lean
@@ -19,16 +19,16 @@ error: Unknown identifier `x`
 example : α := x
 
 #guard_msgs in
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 example : α := sorry
 
 #guard_msgs in
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs(warning) in
 example : α := sorry
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 #guard_msgs(error) in
 example : α := sorry

--- a/tests/lean/run/issue7322.lean
+++ b/tests/lean/run/issue7322.lean
@@ -11,7 +11,7 @@ where type of `fix`’s induction hypothese change when being refined
 in a way that makes the resulting proof term type incorrect.
 -/
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem demo (distance : Nat) (idx : Nat) (a : Fin distance) (fuel : Nat) :
     a = if hidx : idx < distance then Fin.mk idx hidx else a := by
@@ -29,13 +29,13 @@ structure Ev (p : Prop) : Type where
   isTrue : p
 
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 def bar (distance : Nat) (idx : Nat) (a : Fin distance) (fuel : Nat) :
@@ -54,7 +54,7 @@ decreasing_by sorry
 /--
 info: bar.induct (motive : Nat → Prop) (case1 : ∀ (x : Nat), (∀ (n : Nat), motive n) → motive x) (fuel : Nat) : motive fuel
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #check bar.induct

--- a/tests/lean/run/kernelBacktrack.lean
+++ b/tests/lean/run/kernelBacktrack.lean
@@ -10,7 +10,7 @@ macro:max P:term noWs "[" term "]" : term => `(foo $P fun x => 0)
 
 /-! This used to give a kernel error even though there is a succeeding interpretation. -/
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem kernel_error
     (L : List Nat) (hL : L.length = 2 ∧ ∀ i : Fin L.length, L[i] = 0) (i : Nat) :

--- a/tests/lean/run/lazyListRotateUnfoldProof.lean
+++ b/tests/lean/run/lazyListRotateUnfoldProof.lean
@@ -61,7 +61,7 @@ a✝ : ∀ (h : t.get.length + 1 = R.length), (rotate t.get R nil h).length = t.
 ⊢ ∀ (h : (LazyList.delayed t).length + 1 = R.length),
     (rotate (LazyList.delayed t) R nil h).length = (LazyList.delayed t).length + R.length
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 theorem rotate_inv' {F : LazyList τ} {R : List τ} : (h : F.length + 1 = R.length) → (rotate F R nil h).length = F.length + R.length := by

--- a/tests/lean/run/pairsSumToZero.lean
+++ b/tests/lean/run/pairsSumToZero.lean
@@ -90,7 +90,7 @@ trace: l : List Int
       true ↔
     List.ExistsPair (fun a b => a + b = 0) l
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 theorem pairsSumToZero_correct_directly (l : List Int) : pairsSumToZero l ↔ l.ExistsPair (fun a b => a + b = 0) := by

--- a/tests/lean/run/partial_fixpoint_explicit.lean
+++ b/tests/lean/run/partial_fixpoint_explicit.lean
@@ -2,7 +2,7 @@
 Tests for `partial_fixpoint` with explicit proofs
 -/
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def nullary (x : Nat) : Option Unit := nullary (x + 1)
 partial_fixpoint monotonicity sorry

--- a/tests/lean/run/proofAsSorry.lean
+++ b/tests/lean/run/proofAsSorry.lean
@@ -12,7 +12,7 @@ but is expected to have type
 #guard_msgs in
 example : 2 + 2 = 5 := rfl -- This is not a theorem
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem ex : 2 + 2 = 5 := id rfl -- id rfl to avoid the rfl attribute kicking in
 
@@ -23,18 +23,18 @@ def data (w : Nat) : String := toString w
 #guard_msgs in
 #eval data 37
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem tst1 : 0 + x = 1*x + 0 := by
   simp
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem tst2 : ∀ x, 0 + x = 1*x + 0 := by
   intro x
   simp
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem tst3 : x = 2*x + 1 := by
   rfl

--- a/tests/lean/run/reprove.lean
+++ b/tests/lean/run/reprove.lean
@@ -19,7 +19,7 @@ reprove List.append_nil by
 
 -- Test failed reprove - wrong tactic
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 reprove simpleTheorem by

--- a/tests/lean/run/safeExp.lean
+++ b/tests/lean/run/safeExp.lean
@@ -23,7 +23,7 @@ trace: k : Nat
 h : k = 2008 ^ 2 + 2 ^ 2008
 ⊢ ((4032064 + 2 ^ 2008) ^ 2 + 2 ^ (4032064 + 2 ^ 2008)) % 10 = 6
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 error: (kernel) deep recursion detected
 -/
@@ -38,7 +38,7 @@ trace: k : Nat
 h : k = 2008 ^ 2 + 2 ^ 2008
 ⊢ ((2008 ^ 2 + 2 ^ 2008) ^ 2 + 2 ^ (2008 ^ 2 + 2 ^ 2008)) % 10 = 6
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (k : Nat) (h : k = 2008^2 + 2^2008) : (k^2 + 2^k)%10 = 6 := by

--- a/tests/lean/run/sorry.lean
+++ b/tests/lean/run/sorry.lean
@@ -8,10 +8,10 @@ set_option pp.mvars false
 Basic usage.
 -/
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in example : False := sorry
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in example : False := by sorry
 
 /-!
@@ -31,13 +31,13 @@ Pretty printing
 Uniqueness
 -/
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 example : (sorry : Nat) = sorry := by
   fail_if_success rfl
   sorry
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def f (n : Nat) : Nat → Nat := sorry
 
@@ -122,7 +122,7 @@ https://github.com/leanprover/lean4/issues/6715
 trace: n : Nat := sorry
 ⊢ True
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : True := by

--- a/tests/lean/run/tagged_return_2.lean
+++ b/tests/lean/run/tagged_return_2.lean
@@ -71,7 +71,7 @@ set_option trace.compiler.ir.result true in
 def test5 (a : String) := a.utf8ByteSize
 
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 trace: [Compiler.IR] [result]
     def test6 (x_1 : @& obj) (x_2 : @& tobj) : tobj :=
@@ -144,7 +144,7 @@ set_option trace.compiler.ir.result true in
 def test11 (a : Int16) := a.toInt
 
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 trace: [Compiler.IR] [result]
     def test12 (x_1 : @& obj) (x_2 : @& tobj) : tobj :=

--- a/tests/lean/run/treemap.lean
+++ b/tests/lean/run/treemap.lean
@@ -603,7 +603,7 @@ local instance : Inhabited ((_ : Nat) × Nat) where
 /--
 info: ⟨2, 4⟩
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! t.entryAtIdx 1 sorry
@@ -611,7 +611,7 @@ warning: declaration uses 'sorry'
 /--
 info: (2, 4)
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! DTreeMap.Const.entryAtIdx t 1 sorry
@@ -659,7 +659,7 @@ warning: declaration uses 'sorry'
 /--
 info: 2
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! t.keyAtIdx 1 sorry
@@ -836,7 +836,7 @@ Cannot test `getEntryLT` etc. as of writing (2025-03-25) because
 /--
 info: ⟨1, 2⟩
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! t.minEntry sorry
@@ -844,7 +844,7 @@ warning: declaration uses 'sorry'
 /--
 info: (1, 2)
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! DTreeMap.Const.minEntry t sorry
@@ -892,7 +892,7 @@ warning: declaration uses 'sorry'
 /--
 info: ⟨3, 6⟩
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! t.maxEntry sorry
@@ -900,7 +900,7 @@ warning: declaration uses 'sorry'
 /--
 info: (3, 6)
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! DTreeMap.Const.maxEntry t sorry
@@ -1493,7 +1493,7 @@ local instance : Inhabited ((_ : Nat) × Nat) where
 /--
 info: (2, 4)
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! t.entryAtIdx 1 sorry
@@ -1521,7 +1521,7 @@ warning: declaration uses 'sorry'
 /--
 info: 2
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! t.keyAtIdx 1 sorry
@@ -1641,7 +1641,7 @@ warning: declaration uses 'sorry'
 /--
 info: (1, 2)
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! t.minEntry sorry
@@ -1673,7 +1673,7 @@ warning: declaration uses 'sorry'
 /--
 info: (3, 6)
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! t.maxEntry sorry
@@ -2011,7 +2011,7 @@ def t : TreeSet Nat :=
 /--
 info: 2
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! t.atIdx 1 sorry

--- a/tests/lean/run/warnSorry.lean
+++ b/tests/lean/run/warnSorry.lean
@@ -2,10 +2,10 @@ import Lean
 /-!
 # `warn.sorry` tests
 
-When `warn.sorry` is false, don't log the "declaration uses 'sorry'" warning.
+When `warn.sorry` is false, don't log the "declaration uses `sorry`" warning.
 -/
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 example : True := sorry
 
@@ -27,7 +27,7 @@ So, for now we report them just like a user `sorry`.
 
 elab "synth_sorry" : term <= expectedType => Lean.Meta.mkSorry expectedType true
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 example : True := synth_sorry
 

--- a/tests/lean/run/wf_preprocess.lean
+++ b/tests/lean/run/wf_preprocess.lean
@@ -145,7 +145,7 @@ structure MTree (α : Type u) where
 
 -- set_option trace.Elab.definition.wf true in
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 trace: α : Type u_1
 t : MTree α
@@ -243,7 +243,7 @@ inductive Expression where
 | object: List (String × Expression) → Expression
 
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 trace: L : List (String × Expression)
 x : String × Expression
@@ -284,7 +284,7 @@ inductive Expression where
 | object: List (String × Expression) → Expression
 
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 trace: L : List (String × Expression)
 x : String × Expression
@@ -325,7 +325,7 @@ namespace List
     (wfParam xs).zipWith f ys = xs.attach.unattach.zipWith f ys := by
   simp [wfParam]
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs (warning) in
 @[wf_preprocess] theorem List.zipWith_unattach {P : α → Prop} {xs : List (Subtype P)} {ys : List β} {f : α → β → γ} :
     xs.unattach.zipWith f ys = xs.zipWith (fun ⟨x, h⟩ y =>

--- a/tests/lean/run/zetaDeltaTryThisIssue.lean
+++ b/tests/lean/run/zetaDeltaTryThisIssue.lean
@@ -4,7 +4,7 @@ opaque f : Nat → Nat
 info: Try this:
   [apply] simp only [h1, x]
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (a : Nat) : True := by
@@ -18,7 +18,7 @@ example (a : Nat) : True := by
 info: Try this:
   [apply] simp only [this, x]
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : True := by

--- a/tests/lean/run/zetaUnused.lean
+++ b/tests/lean/run/zetaUnused.lean
@@ -6,7 +6,7 @@ trace: b : Bool
     True
   else False
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (b : Bool) : if b then have unused := (); True else False := by
@@ -16,7 +16,7 @@ example (b : Bool) : if b then have unused := (); True else False := by
 trace: b : Bool
 ⊢ b = true
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (b : Bool) : if b then have unused := (); True else False := by
@@ -28,7 +28,7 @@ trace: b : Bool
     have unused := ();
     True
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (b : Bool) : if b then have unused := (); True else False := by
@@ -43,7 +43,7 @@ example (b : Bool) : if b then have unused := (); True else False := by
 trace: b : Bool
 ⊢ if b = true then True else False
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (b : Bool) : if b then have unused := (); True else False := by
@@ -54,7 +54,7 @@ example (b : Bool) : if b then have unused := (); True else False := by
 trace: b : Bool
 ⊢ if b = true then True else False
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (b : Bool) : if b then have unused := (); True else False := by
@@ -71,7 +71,7 @@ h✝ : b = true
 ⊢ have unused := ();
   True
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (b : Bool) : if b then have unused := (); True else False := by


### PR DESCRIPTION
## Summary

This PR standardizes the formatting of identifiers in error messages, warnings, diagnostics, and documentation to use backticks instead of single quotes. For example, `'sorry'` becomes `` `sorry` ``.

Originally I was just going to change the `'sorry'` warning to `` `sorry` ``, but since I saw some other PRs making code more consistent, I let Claude go through more of the codebase to standardize this pattern.

If this PR is too large, I'm happy to revert most of it and just keep the `sorry` warning change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)