### PR TITLE
fix: power internalization in `grind linarith`

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/Arith/CommRing/Reify.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/CommRing/Reify.lean
@@ -97,7 +97,7 @@ partial def reifyCore? (e : Expr) (skipVar : Bool) (gen : Nat) : m (Option RingE
   | HSub.hSub _ _ _ i a b =>
     if (← isSubInst i) then return some (.sub (← go a) (← go b)) else asTopVar e
   | HPow.hPow _ _ _ i a b =>
-    let some k ← getNatValue? b | return none
+    let some k ← getNatValue? b | asTopVar e
     if (← isPowInst i) then return some (.pow (← go a) k) else asTopVar e
   | Neg.neg _ i a =>
     if (← isNegInst i) then return some (.neg (← go a)) else asTopVar e

--- a/tests/lean/run/grind_11597.lean
+++ b/tests/lean/run/grind_11597.lean
@@ -1,0 +1,7 @@
+instance : HPow Rat Rat Rat := sorry
+
+example (b p : Rat) (_ : 0 < b^p) (_ : ¬ 0 ≤ b^p) : False := by
+  grind
+
+example (b : Rat) (n : Nat) (_ : 0 < b^n) (_ : ¬ 0 ≤ b^n) : False := by
+  grind -- this one also used to fai


### PR DESCRIPTION
This PR fixes a bug in the internalizer of `a^p` terms in `grind linarith`.

Closes #11597
