### PR TITLE
chore: use backticks for `sorry` in diagnostic messages

### DIFF
--- a/src/Lean/AddDecl.lean
+++ b/src/Lean/AddDecl.lean
@@ -68,7 +68,7 @@ def wasOriginallyTheorem (env : Environment) (declName : Name) : Bool :=
   getOriginalConstKind? env declName |>.map (· matches .thm) |>.getD false
 
 /-- If `warn.sorry` is set to true, then, so long as the message log does not already have any errors,
-declarations with `sorryAx` generate the "declaration uses 'sorry'" warning. -/
+declarations with `sorryAx` generate the "declaration uses `sorry`" warning. -/
 register_builtin_option warn.sorry : Bool := {
   defValue := true
   descr    := "warn about uses of `sorry` in declarations added to the environment"
@@ -81,7 +81,7 @@ logs a warning if the declaration uses `sorry`.
 def warnIfUsesSorry (decl : Declaration) : CoreM Unit := do
   if warn.sorry.get (← getOptions) then
     if !(← MonadLog.hasErrors) && decl.hasSorry then
-      -- Find an actual sorry expression to use for 'sorry'.
+      -- Find an actual sorry expression to use for `sorry`.
       -- That way the user can hover over it to see its type and use "go to definition" if it is a labeled sorry.
       let findSorry : StateRefT (Array (Bool × MessageData)) MetaM Unit := decl.forEachSorryM fun s => do
         let s' ← addMessageContext s
@@ -91,10 +91,10 @@ def warnIfUsesSorry (decl : Declaration) : CoreM Unit := do
       -- These can appear without logged errors if `decl` is referring to declarations with elaboration errors;
       -- that's where a user should direct their focus.
       if let some (_, s) := sorries.find? (·.1) <|> sorries[0]? then
-        logWarning <| .tagged `hasSorry m!"declaration uses '{s}'"
+        logWarning <| .tagged `hasSorry m!"declaration uses `{s}`"
       else
         -- This case should not happen, but it ensures a warning will get logged no matter what.
-        logWarning <| .tagged `hasSorry m!"declaration uses 'sorry'"
+        logWarning <| .tagged `hasSorry m!"declaration uses `sorry`"
 
 builtin_initialize
   registerTraceClass `addDecl

--- a/tests/lean/1007.lean.expected.out
+++ b/tests/lean/1007.lean.expected.out
@@ -1,11 +1,11 @@
-1007.lean:8:9-8:17: warning: declaration uses 'sorry'
-1007.lean:9:9-9:20: warning: declaration uses 'sorry'
-1007.lean:11:33-11:41: warning: declaration uses 'sorry'
-1007.lean:15:9-15:20: warning: declaration uses 'sorry'
-1007.lean:33:0-33:8: warning: declaration uses 'sorry'
-1007.lean:34:0-34:8: warning: declaration uses 'sorry'
-1007.lean:38:4-38:8: warning: declaration uses 'sorry'
-1007.lean:39:4-39:7: warning: declaration uses 'sorry'
+1007.lean:8:9-8:17: warning: declaration uses `sorry`
+1007.lean:9:9-9:20: warning: declaration uses `sorry`
+1007.lean:11:33-11:41: warning: declaration uses `sorry`
+1007.lean:15:9-15:20: warning: declaration uses `sorry`
+1007.lean:33:0-33:8: warning: declaration uses `sorry`
+1007.lean:34:0-34:8: warning: declaration uses `sorry`
+1007.lean:38:4-38:8: warning: declaration uses `sorry`
+1007.lean:39:4-39:7: warning: declaration uses `sorry`
 1007.lean:56:64-56:78: error(lean.synthInstanceFailed): failed to synthesize instance of type class
   IsLin fun x => sum fun i => norm x
 

--- a/tests/lean/1027.lean.expected.out
+++ b/tests/lean/1027.lean.expected.out
@@ -1,4 +1,4 @@
 x : Nat
 h : ¬x = 0
 ⊢ Unit
-1027.lean:1:0-1:7: warning: declaration uses 'sorry'
+1027.lean:1:0-1:7: warning: declaration uses `sorry`

--- a/tests/lean/1050.lean.expected.out
+++ b/tests/lean/1050.lean.expected.out
@@ -2,5 +2,5 @@
   Foo as bs → bs : Type (u + 1)
 and for `Foo.bar_aux` is
   bs : Type u
-1050.lean:24:8-24:12: warning: declaration uses 'sorry'
-1050.lean:24:8-24:12: warning: declaration uses 'sorry'
+1050.lean:24:8-24:12: warning: declaration uses `sorry`
+1050.lean:24:8-24:12: warning: declaration uses `sorry`

--- a/tests/lean/1163.lean.expected.out
+++ b/tests/lean/1163.lean.expected.out
@@ -1,9 +1,9 @@
-1163.lean:6:8-6:15: warning: declaration uses 'sorry'
-1163.lean:11:8-11:15: warning: declaration uses 'sorry'
+1163.lean:6:8-6:15: warning: declaration uses `sorry`
+1163.lean:11:8-11:15: warning: declaration uses `sorry`
 1163.lean:13:16-13:17: error: failed to synthesize
   OfNat Bool 0
 use `set_option diagnostics true` to get diagnostic information
-1163.lean:15:8-15:15: warning: declaration uses 'sorry'
+1163.lean:15:8-15:15: warning: declaration uses `sorry`
 1163.lean:18:18-18:19: error: failed to synthesize
   OfNat Bool 0
 use `set_option diagnostics true` to get diagnostic information

--- a/tests/lean/1235.lean.expected.out
+++ b/tests/lean/1235.lean.expected.out
@@ -1,4 +1,4 @@
 g : Nat → Nat
 h : f 1 = g
 ⊢ g 2 = f 2 1
-1235.lean:2:0-2:7: warning: declaration uses 'sorry'
+1235.lean:2:0-2:7: warning: declaration uses `sorry`

--- a/tests/lean/1377.lean.expected.out
+++ b/tests/lean/1377.lean.expected.out
@@ -1,2 +1,2 @@
-1377.lean:3:2-3:5: warning: declaration uses 'sorry'
+1377.lean:3:2-3:5: warning: declaration uses `sorry`
 foo.bar : Unit → {n : Nat} → Fin n → Fin n

--- a/tests/lean/1681.lean.expected.out
+++ b/tests/lean/1681.lean.expected.out
@@ -1,6 +1,6 @@
 x : Nat
 ⊢ Nat
-1681.lean:1:0-1:7: warning: declaration uses 'sorry'
+1681.lean:1:0-1:7: warning: declaration uses `sorry`
 x : Nat
 ⊢ Nat
-1681.lean:6:0-6:7: warning: declaration uses 'sorry'
+1681.lean:6:0-6:7: warning: declaration uses `sorry`

--- a/tests/lean/1856.lean.expected.out
+++ b/tests/lean/1856.lean.expected.out
@@ -6,4 +6,4 @@ i : α
 f : (j : α) → β j
 x : α
 ⊢ (if h : x = i then ⋯ ▸ f i else f x) = f x
-1856.lean:10:4-10:13: warning: declaration uses 'sorry'
+1856.lean:10:4-10:13: warning: declaration uses `sorry`

--- a/tests/lean/1891.lean.expected.out
+++ b/tests/lean/1891.lean.expected.out
@@ -1,3 +1,3 @@
-1891.lean:8:2-8:10: warning: declaration uses 'sorry'
+1891.lean:8:2-8:10: warning: declaration uses `sorry`
 FunLike.coe Bla.z ∘ id : Nat → Wrapper
 f ∘ id : Nat → Wrapper

--- a/tests/lean/2505.lean.expected.out
+++ b/tests/lean/2505.lean.expected.out
@@ -1,3 +1,3 @@
 target : A (OfNat.ofNat.{0} Nat 1 (instOfNatNat 1))
 target' : A (OfNat.ofNat.{0} Nat 1 (instOfNatNat 1))
-2505.lean:14:0-14:7: warning: declaration uses 'sorry'
+2505.lean:14:0-14:7: warning: declaration uses `sorry`

--- a/tests/lean/435.lean.expected.out
+++ b/tests/lean/435.lean.expected.out
@@ -1,4 +1,4 @@
-435.lean:3:0-3:7: warning: declaration uses 'sorry'
+435.lean:3:0-3:7: warning: declaration uses `sorry`
 435.lean:5:21-5:23: error: Unknown identifier `op` at quotation precheck
 
 Note: You can use `set_option quotPrecheck false` to disable this check.

--- a/tests/lean/690.lean.expected.out
+++ b/tests/lean/690.lean.expected.out
@@ -4,10 +4,10 @@ a b m✝ : Nat
 hStep : a.le m✝
 ih : a.le (m✝ + 1)
 ⊢ a.le (m✝.succ + 1)
-690.lean:6:0-6:7: warning: declaration uses 'sorry'
+690.lean:6:0-6:7: warning: declaration uses `sorry`
 case step
 a b x : Nat
 hStep : a.le x
 ih : a.le (x + 1)
 ⊢ a.le (x.succ + 1)
-690.lean:11:0-11:7: warning: declaration uses 'sorry'
+690.lean:11:0-11:7: warning: declaration uses `sorry`

--- a/tests/lean/815b.lean.expected.out
+++ b/tests/lean/815b.lean.expected.out
@@ -1,10 +1,10 @@
-815b.lean:1:4-1:13: warning: declaration uses 'sorry'
-815b.lean:6:9-6:17: warning: declaration uses 'sorry'
-815b.lean:7:9-7:14: warning: declaration uses 'sorry'
-815b.lean:8:9-8:13: warning: declaration uses 'sorry'
-815b.lean:9:9-9:13: warning: declaration uses 'sorry'
-815b.lean:10:9-10:13: warning: declaration uses 'sorry'
-815b.lean:11:9-11:13: warning: declaration uses 'sorry'
+815b.lean:1:4-1:13: warning: declaration uses `sorry`
+815b.lean:6:9-6:17: warning: declaration uses `sorry`
+815b.lean:7:9-7:14: warning: declaration uses `sorry`
+815b.lean:8:9-8:13: warning: declaration uses `sorry`
+815b.lean:9:9-9:13: warning: declaration uses `sorry`
+815b.lean:10:9-10:13: warning: declaration uses `sorry`
+815b.lean:11:9-11:13: warning: declaration uses `sorry`
 [Meta.synthInstance] ✅️ IsSmooth fun g a => f (g a) d
   [Meta.synthInstance] new goal IsSmooth fun g a => f (g a) d
     [Meta.synthInstance.instances] #[@identity, @const, @parm, @comp, @diag, @swap, inst✝]

--- a/tests/lean/906.lean.expected.out
+++ b/tests/lean/906.lean.expected.out
@@ -1,4 +1,4 @@
-906.lean:2:4-2:15: warning: declaration uses 'sorry'
+906.lean:2:4-2:15: warning: declaration uses `sorry`
 906.lean:14:2-14:28: error: Tactic `simp` failed with a nested error:
 maximum recursion depth has been reached
 use `set_option maxRecDepth <num>` to increase limit

--- a/tests/lean/973b.lean.expected.out
+++ b/tests/lean/973b.lean.expected.out
@@ -1,6 +1,6 @@
-973b.lean:5:8-5:10: warning: declaration uses 'sorry'
+973b.lean:5:8-5:10: warning: declaration uses `sorry`
 [Meta.Tactic.simp.discharge] ex discharge ❌️
       ?p x
 [Meta.Tactic.simp.discharge] ex discharge ❌️
       ?p (f x)
-973b.lean:9:8-9:11: warning: declaration uses 'sorry'
+973b.lean:9:8-9:11: warning: declaration uses `sorry`

--- a/tests/lean/PPInstances.lean.expected.out
+++ b/tests/lean/PPInstances.lean.expected.out
@@ -1,4 +1,4 @@
-PPInstances.lean:25:9-25:22: warning: declaration uses 'sorry'
+PPInstances.lean:25:9-25:22: warning: declaration uses `sorry`
 @Module R E _ _ : Type
 @Module R E (_ : Semiring R) (_ : AddCommMonoid E) : Type
 @Module R E (@Ring.toSemiring R R.Ring) (@SemiNormedGroup.toAddCommMonoid E instSNG) : Type

--- a/tests/lean/autoBoundImplicits1.lean.expected.out
+++ b/tests/lean/autoBoundImplicits1.lean.expected.out
@@ -1,6 +1,6 @@
 myid 10 : Nat
 myid true : Bool
-autoBoundImplicits1.lean:16:4-16:11: warning: declaration uses 'sorry'
+autoBoundImplicits1.lean:16:4-16:11: warning: declaration uses `sorry`
 autoBoundImplicits1.lean:20:25-20:29: error(lean.unknownIdentifier): Unknown identifier `size`
 
 Note: It is not possible to treat `size` as an implicitly bound variable here because it has multiple characters while the `relaxedAutoImplicit` option is set to `false`.

--- a/tests/lean/binrel_binop.lean.expected.out
+++ b/tests/lean/binrel_binop.lean.expected.out
@@ -1,6 +1,6 @@
-binrel_binop.lean:1:8-1:11: warning: declaration uses 'sorry'
+binrel_binop.lean:1:8-1:11: warning: declaration uses `sorry`
 ex1 (a : Int) (b c : Nat) : a = ↑b - ↑c
-binrel_binop.lean:5:8-5:11: warning: declaration uses 'sorry'
+binrel_binop.lean:5:8-5:11: warning: declaration uses `sorry`
 ex2 (a : Int) (b c : Nat) : a = ↑b - ↑c
-binrel_binop.lean:9:8-9:11: warning: declaration uses 'sorry'
+binrel_binop.lean:9:8-9:11: warning: declaration uses `sorry`
 ex3 (a : Int) (b c : Nat) : a = ↑(b - c)

--- a/tests/lean/bintreeGoal.lean.expected.out
+++ b/tests/lean/bintreeGoal.lean.expected.out
@@ -1,2 +1,2 @@
-bintreeGoal.lean:53:4-53:18: warning: declaration uses 'sorry'
-bintreeGoal.lean:60:8-60:27: warning: declaration uses 'sorry'
+bintreeGoal.lean:53:4-53:18: warning: declaration uses `sorry`
+bintreeGoal.lean:60:8-60:27: warning: declaration uses `sorry`

--- a/tests/lean/collectDepsIssue.lean.expected.out
+++ b/tests/lean/collectDepsIssue.lean.expected.out
@@ -3,4 +3,4 @@ context:
 α : Type
 a : α
 ⊢ List α
-collectDepsIssue.lean:8:8-8:11: warning: declaration uses 'sorry'
+collectDepsIssue.lean:8:8-8:11: warning: declaration uses `sorry`

--- a/tests/lean/consumePPHint.lean.expected.out
+++ b/tests/lean/consumePPHint.lean.expected.out
@@ -1,6 +1,6 @@
-consumePPHint.lean:8:8-8:14: warning: declaration uses 'sorry'
+consumePPHint.lean:8:8-8:14: warning: declaration uses `sorry`
 case a
 ⊢ q
     (have x := 0;
     x + 1)
-consumePPHint.lean:10:8-10:15: warning: declaration uses 'sorry'
+consumePPHint.lean:10:8-10:15: warning: declaration uses `sorry`

--- a/tests/lean/convInConv.lean.expected.out
+++ b/tests/lean/convInConv.lean.expected.out
@@ -17,4 +17,4 @@ y : Nat
 | (fun x => y + x = 0) = fun x => False
 y : Nat
 ⊢ (fun x => y + x = 0) = fun x => False
-convInConv.lean:15:8-15:12: warning: declaration uses 'sorry'
+convInConv.lean:15:8-15:12: warning: declaration uses `sorry`

--- a/tests/lean/doLetLoop.lean.expected.out
+++ b/tests/lean/doLetLoop.lean.expected.out
@@ -1,2 +1,2 @@
 doLetLoop.lean:4:0: error: unexpected end of input
-doLetLoop.lean:2:4-2:5: warning: declaration uses 'sorry'
+doLetLoop.lean:2:4-2:5: warning: declaration uses `sorry`

--- a/tests/lean/doSeqRightIssue.lean.expected.out
+++ b/tests/lean/doSeqRightIssue.lean.expected.out
@@ -1,3 +1,3 @@
 doSeqRightIssue.lean:5:23-5:24: error: unknown universe level `v`
-doSeqRightIssue.lean:7:0-8:40: warning: declaration uses 'sorry'
-doSeqRightIssue.lean:6:8-6:10: warning: declaration uses 'sorry'
+doSeqRightIssue.lean:7:0-8:40: warning: declaration uses `sorry`
+doSeqRightIssue.lean:6:8-6:10: warning: declaration uses `sorry`

--- a/tests/lean/indimpltarget.lean.expected.out
+++ b/tests/lean/indimpltarget.lean.expected.out
@@ -1,4 +1,4 @@
 indimpltarget.lean:6:2-6:45: error: Failed to infer implicit target `m`
 indimpltarget.lean:16:2-16:45: error: Failed to infer implicit target `n`
-indimpltarget.lean:26:0-26:7: warning: declaration uses 'sorry'
+indimpltarget.lean:26:0-26:7: warning: declaration uses `sorry`
 indimpltarget.lean:40:2-40:45: error: Failed to infer implicit target

--- a/tests/lean/inductionGen.lean.expected.out
+++ b/tests/lean/inductionGen.lean.expected.out
@@ -8,7 +8,7 @@ x : α
 xs : Vec α n
 h : Vec.cons x xs = ys
 ⊢ (Vec.cons x xs).head = ys.head
-inductionGen.lean:25:8-25:11: warning: declaration uses 'sorry'
+inductionGen.lean:25:8-25:11: warning: declaration uses `sorry`
 case natVal
 α : ExprType
 a✝ : Nat
@@ -40,6 +40,6 @@ a_ih✝ : ∀ (b : Expr ExprType.nat), a✝ = b → eval (constProp a✝) = eval
 b : Expr ExprType.nat
 h : a✝¹.add a✝ = b
 ⊢ eval (constProp (a✝¹.add a✝)) = eval b
-inductionGen.lean:64:8-64:11: warning: declaration uses 'sorry'
+inductionGen.lean:64:8-64:11: warning: declaration uses `sorry`
 inductionGen.lean:78:2-78:27: error: Invalid target: Target (or one of its indices) occurs more than once
   n

--- a/tests/lean/interactive/incrementalCombinator.lean.expected.out
+++ b/tests/lean/interactive/incrementalCombinator.lean.expected.out
@@ -9,7 +9,7 @@ c 2.5
    "severity": 2,
    "range":
    {"start": {"line": 1, "character": 4}, "end": {"line": 1, "character": 9}},
-   "message": "declaration uses 'sorry'",
+   "message": "declaration uses `sorry`",
    "fullRange":
    {"start": {"line": 1, "character": 4}, "end": {"line": 1, "character": 9}}}]}
 d 0
@@ -94,6 +94,6 @@ i 1.5
    "severity": 2,
    "range":
    {"start": {"line": 1, "character": 0}, "end": {"line": 1, "character": 7}},
-   "message": "declaration uses 'sorry'",
+   "message": "declaration uses `sorry`",
    "fullRange":
    {"start": {"line": 1, "character": 0}, "end": {"line": 1, "character": 7}}}]}

--- a/tests/lean/interactive/incrementalCommand.lean
+++ b/tests/lean/interactive/incrementalCommand.lean
@@ -41,7 +41,7 @@ wrap 1 def wrapped := by
   dbg_trace "w"
 
 /-!
-The example used to result in nothing but "declaration uses 'sorry'" (and using the downstream
+The example used to result in nothing but "declaration uses `sorry`" (and using the downstream
 "unreachable tactic" linter, the `simp` would be flagged) as `simp` among other elaborators
 accidentally swallowed the interrupt exception.
 -/

--- a/tests/lean/interactive/inlayHints.lean.expected.out
+++ b/tests/lean/interactive/inlayHints.lean.expected.out
@@ -5,14 +5,14 @@
    "severity": 2,
    "range":
    {"start": {"line": 6, "character": 4}, "end": {"line": 6, "character": 5}},
-   "message": "declaration uses 'sorry'",
+   "message": "declaration uses `sorry`",
    "fullRange":
    {"start": {"line": 6, "character": 4}, "end": {"line": 6, "character": 5}}},
   {"source": "Lean 4",
    "severity": 2,
    "range":
    {"start": {"line": 9, "character": 8}, "end": {"line": 9, "character": 9}},
-   "message": "declaration uses 'sorry'",
+   "message": "declaration uses `sorry`",
    "fullRange":
    {"start": {"line": 9, "character": 8}, "end": {"line": 9, "character": 9}}}]}
 {"textDocument": {"uri": "file:///inlayHints.lean"},

--- a/tests/lean/interactive/interactiveDiagnostics.lean.expected.out
+++ b/tests/lean/interactive/interactiveDiagnostics.lean.expected.out
@@ -5,7 +5,7 @@
    "severity": 2,
    "range":
    {"start": {"line": 0, "character": 4}, "end": {"line": 0, "character": 7}},
-   "message": "declaration uses 'sorry'",
+   "message": "declaration uses `sorry`",
    "fullRange":
    {"start": {"line": 0, "character": 4}, "end": {"line": 0, "character": 7}}},
   {"source": "Lean 4",
@@ -37,12 +37,12 @@
   {"start": {"line": 0, "character": 4}, "end": {"line": 0, "character": 7}},
   "message":
   {"append":
-   [{"tag": [{"expr": {"text": "declaration uses '"}}, {"text": ""}]},
+   [{"tag": [{"expr": {"text": "declaration uses `"}}, {"text": ""}]},
     {"tag":
      [{"expr":
        {"tag": [{"subexprPos": "/", "info": {"p": "0"}}, {"text": "sorry"}]}},
       {"text": ""}]},
-    {"tag": [{"expr": {"text": "'"}}, {"text": ""}]}]},
+    {"tag": [{"expr": {"text": "`"}}, {"text": ""}]}]},
   "fullRange":
   {"start": {"line": 0, "character": 4}, "end": {"line": 0, "character": 7}}},
  {"source": "Lean 4",

--- a/tests/lean/introLetBug.lean.expected.out
+++ b/tests/lean/introLetBug.lean.expected.out
@@ -6,4 +6,4 @@ k : Nat
 this : f 10 = 11
 ⊢ let x := 10;
   11 = k
-introLetBug.lean:2:0-2:7: warning: declaration uses 'sorry'
+introLetBug.lean:2:0-2:7: warning: declaration uses `sorry`

--- a/tests/lean/librarySearch.lean
+++ b/tests/lean/librarySearch.lean
@@ -374,7 +374,7 @@ info: Try this:
   -- Remaining subgoals:
   -- ⊢ 2 ≠ 0
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example {x : Int} (h : x ≠ 0) : 2 * x ≠ 0 := by

--- a/tests/lean/librarySearch.lean.expected.out
+++ b/tests/lean/librarySearch.lean.expected.out
@@ -1,3 +1,3 @@
-librarySearch.lean:395:0-395:7: warning: declaration uses 'sorry'
-librarySearch.lean:405:0-405:7: warning: declaration uses 'sorry'
-librarySearch.lean:493:0-493:7: warning: declaration uses 'sorry'
+librarySearch.lean:395:0-395:7: warning: declaration uses `sorry`
+librarySearch.lean:405:0-405:7: warning: declaration uses `sorry`
+librarySearch.lean:493:0-493:7: warning: declaration uses `sorry`

--- a/tests/lean/linterUnusedVariables.lean.expected.out
+++ b/tests/lean/linterUnusedVariables.lean.expected.out
@@ -83,8 +83,8 @@ linterUnusedVariables.lean:244:27-244:28: error: don't know how to synthesize pl
 context:
 a : Nat
 ⊢ Nat
-linterUnusedVariables.lean:245:0-245:7: warning: declaration uses 'sorry'
-linterUnusedVariables.lean:246:0-246:7: warning: declaration uses 'sorry'
+linterUnusedVariables.lean:245:0-245:7: warning: declaration uses `sorry`
+linterUnusedVariables.lean:246:0-246:7: warning: declaration uses `sorry`
 linterUnusedVariables.lean:247:29-248:7: error: unexpected token 'theorem'; expected '{' or tactic
 linterUnusedVariables.lean:247:27-247:29: error: unsolved goals
 a : Nat

--- a/tests/lean/renameI.lean.expected.out
+++ b/tests/lean/renameI.lean.expected.out
@@ -1,9 +1,9 @@
 x y : Nat
 ⊢ x = y
-renameI.lean:1:0-1:7: warning: declaration uses 'sorry'
+renameI.lean:1:0-1:7: warning: declaration uses `sorry`
 x a.b : Nat
 ⊢ x = a.b
-renameI.lean:7:0-7:7: warning: declaration uses 'sorry'
+renameI.lean:7:0-7:7: warning: declaration uses `sorry`
 x o✝ y a.b : Nat
 ⊢ x + y = a.b + o✝
-renameI.lean:13:0-13:7: warning: declaration uses 'sorry'
+renameI.lean:13:0-13:7: warning: declaration uses `sorry`

--- a/tests/lean/run/10196.lean
+++ b/tests/lean/run/10196.lean
@@ -9,10 +9,10 @@ It re-used the `g._proof_1` proof.
 -/
 
 def f (n : Nat) (_ : n ≠ 0) : Nat := n
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def g (m : Nat) := f m sorry
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def g' (m : Nat) := f m sorry
 
@@ -22,32 +22,32 @@ Examples from the issue. The `ByteString.Pos.next` definition did not use to hav
 structure ByteString where
 structure ByteString.Pos (s : ByteString) where
 structure ByteString.Slice where
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def ByteString.toSlice (s : ByteString) : ByteString.Slice :=
   sorry
 structure ByteString.Slice.Pos (s : ByteString.Slice) where
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def ByteString.Slice.endPos (s : ByteString.Slice) : s.Pos :=
   sorry
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def ByteString.Slice.Pos.get {s : ByteString.Slice} (pos : s.Pos) (h : pos ≠ s.endPos) : Char :=
   sorry
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def ByteString.Pos.toSlice {s : ByteString} (pos : s.Pos) : s.toSlice.Pos :=
   sorry
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def ByteString.Slice.Pos.next {s : ByteString.Slice} (pos : s.Pos) (h : pos ≠ s.endPos) : s.Pos :=
   sorry
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def ByteString.Pos.get {s : ByteString} (pos : s.Pos) : Char :=
   pos.toSlice.get sorry
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def ByteString.Pos.next {s : ByteString} (pos : s.Pos) (h : True) : s.toSlice.Pos :=
   pos.toSlice.next sorry

--- a/tests/lean/run/1234.lean
+++ b/tests/lean/run/1234.lean
@@ -11,7 +11,7 @@ set_option linter.unusedSimpArgs false
 set_option Elab.async false -- for stable message ordering in #guard_msgs
 
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 trace: [Meta.Tactic.simp.rewrite] h₁:1000:
       k ≤ v - 1
@@ -51,7 +51,7 @@ example (h₁: k ≤ v - 1) (h₂: 0 < v):
 -- it works
 
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 trace: [Meta.Tactic.simp.rewrite] h₁:1000:
       k ≤ v - 1
@@ -89,7 +89,7 @@ example (h₁: k ≤ v - 1) (h₂: 0 < v):
     ]
 
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 trace: [Meta.Tactic.simp.rewrite] h₁:1000:
       k ≤ v - 1

--- a/tests/lean/run/1697.lean
+++ b/tests/lean/run/1697.lean
@@ -12,7 +12,7 @@ error: aborting evaluation since the expression depends on the 'sorry' axiom, wh
 
 To attempt to evaluate anyway despite the risks, use the '#eval!' command.
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval #[1,2,3][2]'sorry
@@ -20,7 +20,7 @@ warning: declaration uses 'sorry'
 /--
 info: 3
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! #[1,2,3][2]'sorry
@@ -33,7 +33,7 @@ normal circumstances this actually works with the output below, but the `Linux D
 catches it and complains. Maybe too bold to have this in the test suite.
 
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 info: 3
 -/

--- a/tests/lean/run/2159.lean
+++ b/tests/lean/run/2159.lean
@@ -3,7 +3,7 @@ trace: ⊢ 1.2 < 2
 ---
 trace: ⊢ 1.2 < 2
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : 1.2 < 2 := by

--- a/tests/lean/run/2226.lean
+++ b/tests/lean/run/2226.lean
@@ -11,7 +11,7 @@ variable (A : Nat) (B : by skip)
 def foo :=
   A = B
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def boo :=
   B

--- a/tests/lean/run/2916.lean
+++ b/tests/lean/run/2916.lean
@@ -4,7 +4,7 @@ set_option pp.coercions false -- Show `OfNat.ofNat` when present for clarity
 trace: x : Nat
 ⊢ OfNat.ofNat 2 = x
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : nat_lit 2 = x := by
@@ -16,7 +16,7 @@ example : nat_lit 2 = x := by
 trace: x : Nat
 ⊢ OfNat.ofNat 2 = x
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : nat_lit 2 = x := by
@@ -30,7 +30,7 @@ f : (n : Nat) → α n
 x : α (OfNat.ofNat 2)
 ⊢ f (OfNat.ofNat 2) = x
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (α : Nat → Type) (f : (n : Nat) → α n) (x : α 2) : f (nat_lit 2) = x := by
@@ -67,7 +67,7 @@ f : (n : Nat) → α n
 x : α (OfNat.ofNat 2)
 ⊢ f 2 = x
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (α : Nat → Type) (f : (n : Nat) → α n) (x : α 2) : f 2 = x := by

--- a/tests/lean/run/343.lean
+++ b/tests/lean/run/343.lean
@@ -23,7 +23,7 @@ unif_hint (mvar : CatIsh) where
 structure CtxSyntaxLayerParamsObj where
   Ct : CatIsh
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def CtxSyntaxLayerParams : CatIsh :=
   {

--- a/tests/lean/run/3519.lean
+++ b/tests/lean/run/3519.lean
@@ -2,7 +2,7 @@
 info: Try this:
   [apply] simp only [x]
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example {P : Nat → Prop} : let x := 0; P x := by
@@ -14,7 +14,7 @@ example {P : Nat → Prop} : let x := 0; P x := by
 info: Try this:
   [apply] simp_all only [x]
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example {P : Nat → Prop} : let x := 0; P x := by

--- a/tests/lean/run/3922.lean
+++ b/tests/lean/run/3922.lean
@@ -28,7 +28,7 @@ info: found a partial proof, but the corresponding tactic failed:
 
 It may be possible to correct this proof by adding type annotations, explicitly specifying implicit arguments, or eliminating unnecessary function abstractions.
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs (ordering := sorted) in
 example (a b c : Nat) (h₁ : r b a) (h₂ : r b c) : r c a := by

--- a/tests/lean/run/4888.lean
+++ b/tests/lean/run/4888.lean
@@ -44,7 +44,7 @@ theorem kernel_declaration_meta_variables (x y z : Option Int) : (x = y) ↔ (x 
 /-!
 Regression test: `all_goals` still respects recovery state.
 -/
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 example (x y z : Option Int) : (x = y) ↔ (x = z) := by
   apply Iff.elim

--- a/tests/lean/run/5407.lean
+++ b/tests/lean/run/5407.lean
@@ -100,7 +100,7 @@ info: found a partial proof, but the corresponding tactic failed:
 
 It may be possible to correct this proof by adding type annotations, explicitly specifying implicit arguments, or eliminating unnecessary function abstractions.
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : E := by apply?
@@ -118,7 +118,7 @@ info: Try this:
   -- Remaining subgoals:
   -- ⊢ R a b
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : (b : B) → R a b := by

--- a/tests/lean/run/6123_mod_cast.lean
+++ b/tests/lean/run/6123_mod_cast.lean
@@ -174,7 +174,7 @@ end WithBot
 
 namespace WithBot
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem le_of_forall_lt_iff_le [LinearOrder α] [DenselyOrdered α]
     {x y : WithBot α} : (∀ z : α, x < z → y ≤ z) ↔ y ≤ x := by

--- a/tests/lean/run/6655.lean
+++ b/tests/lean/run/6655.lean
@@ -27,7 +27,7 @@ d : α → α := c
 e : α → α := d
 ⊢ d x = x
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example {α : Type} (c : α → α) (x : α) : c x = x := by
@@ -45,7 +45,7 @@ Example from #6655. This used to suggest `simp only [d]`.
 info: Try this:
   [apply] simp only
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example {α : Type} (c : α → α) (x : α) : c x = x := by
@@ -106,7 +106,7 @@ d : α → α := c
 e : α → α := d
 ⊢ d x = x
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example {α : Type} (b : α → α) (x : α) : b x = x := by

--- a/tests/lean/run/7475.lean
+++ b/tests/lean/run/7475.lean
@@ -17,7 +17,7 @@ def equal (a b : EFixedPoint) : Bool :=
   | Infinity s1, Infinity s2 => s1 = s2
   | _, _ => false
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem EFixedPoint_eq_refl (a : EFixedPoint) : a.equal a = true := by
   unfold EFixedPoint.equal

--- a/tests/lean/run/bv_decide_rewriter_ac_nf.lean
+++ b/tests/lean/run/bv_decide_rewriter_ac_nf.lean
@@ -19,7 +19,7 @@ elab "bv_ac_nf" : tactic =>
 /- NOTE: the expression in this test is used as an example in the `bv_ac_nf` tactic
 documentation. Any changes to the behaviour of this test should be reflected in
 that docstring also. -/
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem mul_mul_beq_mul_mul (x₁ x₂ y₁ y₂ z : BitVec 4) :
     (x₁ * (y₁ * z)) == (x₂ * (y₂ * z)) := by
@@ -27,7 +27,7 @@ theorem mul_mul_beq_mul_mul (x₁ x₂ y₁ y₂ z : BitVec 4) :
   guard_target =ₛ (z * (x₁ * y₁) == z * (x₂ * y₂)) = true
   sorry
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem ex_1 (x y z k₁ k₂ l₁ l₂ m₁ m₂ v : BitVec w) :
     m₁ * x * (y * l₁ * k₁) * z == v * (k₂ * l₂ * x * y) * z * m₂ := by
@@ -35,7 +35,7 @@ theorem ex_1 (x y z k₁ k₂ l₁ l₂ m₁ m₂ v : BitVec w) :
   guard_target =ₛ (x * y * z * (m₁ * l₁ * k₁) == x * y * z * (v * k₂ * l₂ * m₂)) = true
   sorry
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem ex_2 (x y : BitVec w) (h₁ : y = x) :
     x * x * x * x == y * x * x * y := by
@@ -44,7 +44,7 @@ theorem ex_2 (x y : BitVec w) (h₁ : y = x) :
   sorry
 
 -- This theorem is short-circuited and scales to standard bitwidths.
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem mul_beq_mul_eq_right (x y z : BitVec 64) (h : x = y) :
     x * z == y * z := by
@@ -53,7 +53,7 @@ theorem mul_beq_mul_eq_right (x y z : BitVec 64) (h : x = y) :
   sorry
 
 -- This theorem is short-circuited and scales to standard bitwidths.
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem mul_beq_mul_eq_left (x y z : BitVec 64) (h : x = y) :
     z * x == z * y := by
@@ -61,7 +61,7 @@ theorem mul_beq_mul_eq_left (x y z : BitVec 64) (h : x = y) :
   guard_target =ₛ (z * x == z * y) = true
   sorry
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem short_circuit_triple_mul (x x_1 x_2 : BitVec 32) (h : ¬x_2 &&& 4096#32 == 0#32) :
     (x_1 ||| 4096#32) * x * (x_1 ||| 4096#32) = (x_1 ||| x_2 &&& 4096#32) * x * (x_1 ||| 4096#32) := by
@@ -107,7 +107,7 @@ namespace Normalize
 local macro "bv_normalize" : tactic =>
   `(tactic| bv_normalize (config := {acNf := true, shortCircuit := true}))
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem mul_mul_eq_mul_mul (x₁ x₂ y₁ y₂ z : BitVec 4) (h₁ : x₁ = x₂) (h₂ : y₁ = y₂) :
     x₁ * (y₁ * z) = x₂ * (y₂ * z) := by
@@ -116,7 +116,7 @@ theorem mul_mul_eq_mul_mul (x₁ x₂ y₁ y₂ z : BitVec 4) (h₁ : x₁ = x�
   guard_hyp tgt :ₛ (!!(!x₁ * y₁ == x₂ * y₂ && !z * (x₁ * y₁) == z * (x₂ * y₂))) = true
   sorry
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem mul_eq_mul_eq_right (x y z : BitVec 64) (h : x = y) :
     x * z = y * z := by

--- a/tests/lean/run/bv_sint.lean
+++ b/tests/lean/run/bv_sint.lean
@@ -67,7 +67,7 @@ example (a b c : ISize) (h1 : a < b) (h2 : b < c) : a < c := by
 /--
 warning: Detected USize/ISize in the goal but no hypothesis about System.Platform.numBits, consider case splitting on System.Platform.numBits_eq
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (a b : ISize) : a + b > a := by

--- a/tests/lean/run/bv_uint.lean
+++ b/tests/lean/run/bv_uint.lean
@@ -67,7 +67,7 @@ example (a b c : USize) (h1 : a < b) (h2 : b < c) : a < c := by
 /--
 warning: Detected USize/ISize in the goal but no hypothesis about System.Platform.numBits, consider case splitting on System.Platform.numBits_eq
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (a b : USize) : a + b > a := by

--- a/tests/lean/run/byAsSorry.lean
+++ b/tests/lean/run/byAsSorry.lean
@@ -1,6 +1,6 @@
 set_option debug.byAsSorry true in
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 theorem ex1 (h : b = a) : a = b := by
@@ -20,7 +20,7 @@ def f (x : Nat) : Nat := by
 
 set_option debug.byAsSorry true in
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 def g (x : Nat) : { x : Nat // x > 0 } :=

--- a/tests/lean/run/clear_value.lean
+++ b/tests/lean/run/clear_value.lean
@@ -306,7 +306,7 @@ trace: α : Type := Nat
 x : α
 ⊢ x = 1
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : let α := Nat; let x : α := 1; @Eq α x 1 := by

--- a/tests/lean/run/compiler_proj_bug.lean
+++ b/tests/lean/run/compiler_proj_bug.lean
@@ -7,7 +7,7 @@ s.b - s.a
 /--
 info: 25
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! f {a := 5, b := 30, h := sorry }

--- a/tests/lean/run/dsimp_bv_simproc.lean
+++ b/tests/lean/run/dsimp_bv_simproc.lean
@@ -16,7 +16,7 @@ a x y : BitVec 64
 h : 128 = 128
 ⊢ write 16 a (x ++ y) s = aux
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (a x y : BitVec 64)

--- a/tests/lean/run/elabLet.lean
+++ b/tests/lean/run/elabLet.lean
@@ -57,7 +57,7 @@ trace: m : Nat := 1
 hyp : m = 1
 ⊢ True
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : True := by
@@ -73,7 +73,7 @@ trace: m : Nat
 hyp : m = 1
 ⊢ True
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : True := by
@@ -160,7 +160,7 @@ Testing `+generalize`
 trace: x y z : Nat
 ⊢ z = y + x
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (x y : Nat) : x + y = y + x := by

--- a/tests/lean/run/ext.lean
+++ b/tests/lean/run/ext.lean
@@ -155,7 +155,7 @@ error: Failed to generate an `ext_iff` theorem from `weird_prod_ext`: Argument `
 
 Hint: Try `@[ext (iff := false)]` to prevent generating an `ext_iff` theorem.
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 @[ext]

--- a/tests/lean/run/generalizeMany.lean
+++ b/tests/lean/run/generalizeMany.lean
@@ -10,7 +10,7 @@ h₁ : n + 1 = n'
 h₂ : v.succ ≍ v'
 ⊢ p n' v'
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (p : (n : Nat) → Fin n → Prop)

--- a/tests/lean/run/guard_msgs.lean
+++ b/tests/lean/run/guard_msgs.lean
@@ -19,16 +19,16 @@ error: Unknown identifier `x`
 example : α := x
 
 #guard_msgs in
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 example : α := sorry
 
 #guard_msgs in
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs(warning) in
 example : α := sorry
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 #guard_msgs(error) in
 example : α := sorry

--- a/tests/lean/run/issue7322.lean
+++ b/tests/lean/run/issue7322.lean
@@ -11,7 +11,7 @@ where type of `fix`’s induction hypothese change when being refined
 in a way that makes the resulting proof term type incorrect.
 -/
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem demo (distance : Nat) (idx : Nat) (a : Fin distance) (fuel : Nat) :
     a = if hidx : idx < distance then Fin.mk idx hidx else a := by
@@ -29,13 +29,13 @@ structure Ev (p : Prop) : Type where
   isTrue : p
 
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 def bar (distance : Nat) (idx : Nat) (a : Fin distance) (fuel : Nat) :
@@ -54,7 +54,7 @@ decreasing_by sorry
 /--
 info: bar.induct (motive : Nat → Prop) (case1 : ∀ (x : Nat), (∀ (n : Nat), motive n) → motive x) (fuel : Nat) : motive fuel
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #check bar.induct

--- a/tests/lean/run/kernelBacktrack.lean
+++ b/tests/lean/run/kernelBacktrack.lean
@@ -10,7 +10,7 @@ macro:max P:term noWs "[" term "]" : term => `(foo $P fun x => 0)
 
 /-! This used to give a kernel error even though there is a succeeding interpretation. -/
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem kernel_error
     (L : List Nat) (hL : L.length = 2 ∧ ∀ i : Fin L.length, L[i] = 0) (i : Nat) :

--- a/tests/lean/run/lazyListRotateUnfoldProof.lean
+++ b/tests/lean/run/lazyListRotateUnfoldProof.lean
@@ -61,7 +61,7 @@ a✝ : ∀ (h : t.get.length + 1 = R.length), (rotate t.get R nil h).length = t.
 ⊢ ∀ (h : (LazyList.delayed t).length + 1 = R.length),
     (rotate (LazyList.delayed t) R nil h).length = (LazyList.delayed t).length + R.length
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 theorem rotate_inv' {F : LazyList τ} {R : List τ} : (h : F.length + 1 = R.length) → (rotate F R nil h).length = F.length + R.length := by

--- a/tests/lean/run/library_search_all.lean
+++ b/tests/lean/run/library_search_all.lean
@@ -33,7 +33,7 @@ info: Try these:
   [apply] exact myTrue1
   [apply] exact myTrue2
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : MyTrue := by exact? +all
@@ -46,7 +46,7 @@ info: Try these:
   [apply] exact myTrue1
   [apply] exact myTrue2
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : MyTrue := by apply? +all
@@ -65,7 +65,7 @@ info: Try these:
   [apply] exact h.elim
   [apply] exact h.elim2
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example {α : Sort u} (h : Empty) : α := by exact? +all

--- a/tests/lean/run/pairsSumToZero.lean
+++ b/tests/lean/run/pairsSumToZero.lean
@@ -90,7 +90,7 @@ trace: l : List Int
       true ↔
     List.ExistsPair (fun a b => a + b = 0) l
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 theorem pairsSumToZero_correct_directly (l : List Int) : pairsSumToZero l ↔ l.ExistsPair (fun a b => a + b = 0) := by

--- a/tests/lean/run/partial_fixpoint_explicit.lean
+++ b/tests/lean/run/partial_fixpoint_explicit.lean
@@ -2,7 +2,7 @@
 Tests for `partial_fixpoint` with explicit proofs
 -/
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def nullary (x : Nat) : Option Unit := nullary (x + 1)
 partial_fixpoint monotonicity sorry

--- a/tests/lean/run/proofAsSorry.lean
+++ b/tests/lean/run/proofAsSorry.lean
@@ -12,7 +12,7 @@ but is expected to have type
 #guard_msgs in
 example : 2 + 2 = 5 := rfl -- This is not a theorem
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem ex : 2 + 2 = 5 := id rfl -- id rfl to avoid the rfl attribute kicking in
 
@@ -23,18 +23,18 @@ def data (w : Nat) : String := toString w
 #guard_msgs in
 #eval data 37
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem tst1 : 0 + x = 1*x + 0 := by
   simp
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem tst2 : ∀ x, 0 + x = 1*x + 0 := by
   intro x
   simp
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 theorem tst3 : x = 2*x + 1 := by
   rfl

--- a/tests/lean/run/reprove.lean
+++ b/tests/lean/run/reprove.lean
@@ -19,7 +19,7 @@ reprove List.append_nil by
 
 -- Test failed reprove - wrong tactic
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 reprove simpleTheorem by

--- a/tests/lean/run/safeExp.lean
+++ b/tests/lean/run/safeExp.lean
@@ -23,7 +23,7 @@ trace: k : Nat
 h : k = 2008 ^ 2 + 2 ^ 2008
 ⊢ ((4032064 + 2 ^ 2008) ^ 2 + 2 ^ (4032064 + 2 ^ 2008)) % 10 = 6
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 error: (kernel) deep recursion detected
 -/
@@ -38,7 +38,7 @@ trace: k : Nat
 h : k = 2008 ^ 2 + 2 ^ 2008
 ⊢ ((2008 ^ 2 + 2 ^ 2008) ^ 2 + 2 ^ (2008 ^ 2 + 2 ^ 2008)) % 10 = 6
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (k : Nat) (h : k = 2008^2 + 2^2008) : (k^2 + 2^k)%10 = 6 := by

--- a/tests/lean/run/sorry.lean
+++ b/tests/lean/run/sorry.lean
@@ -8,10 +8,10 @@ set_option pp.mvars false
 Basic usage.
 -/
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in example : False := sorry
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in example : False := by sorry
 
 /-!
@@ -31,13 +31,13 @@ Pretty printing
 Uniqueness
 -/
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 example : (sorry : Nat) = sorry := by
   fail_if_success rfl
   sorry
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 def f (n : Nat) : Nat → Nat := sorry
 
@@ -122,7 +122,7 @@ https://github.com/leanprover/lean4/issues/6715
 trace: n : Nat := sorry
 ⊢ True
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : True := by

--- a/tests/lean/run/tagged_return_2.lean
+++ b/tests/lean/run/tagged_return_2.lean
@@ -71,7 +71,7 @@ set_option trace.compiler.ir.result true in
 def test5 (a : String) := a.utf8ByteSize
 
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 trace: [Compiler.IR] [result]
     def test6 (x_1 : @& obj) (x_2 : @& tobj) : tobj :=
@@ -144,7 +144,7 @@ set_option trace.compiler.ir.result true in
 def test11 (a : Int16) := a.toInt
 
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 trace: [Compiler.IR] [result]
     def test12 (x_1 : @& obj) (x_2 : @& tobj) : tobj :=

--- a/tests/lean/run/treemap.lean
+++ b/tests/lean/run/treemap.lean
@@ -603,7 +603,7 @@ local instance : Inhabited ((_ : Nat) × Nat) where
 /--
 info: ⟨2, 4⟩
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! t.entryAtIdx 1 sorry
@@ -611,7 +611,7 @@ warning: declaration uses 'sorry'
 /--
 info: (2, 4)
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! DTreeMap.Const.entryAtIdx t 1 sorry
@@ -659,7 +659,7 @@ warning: declaration uses 'sorry'
 /--
 info: 2
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! t.keyAtIdx 1 sorry
@@ -836,7 +836,7 @@ Cannot test `getEntryLT` etc. as of writing (2025-03-25) because
 /--
 info: ⟨1, 2⟩
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! t.minEntry sorry
@@ -844,7 +844,7 @@ warning: declaration uses 'sorry'
 /--
 info: (1, 2)
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! DTreeMap.Const.minEntry t sorry
@@ -892,7 +892,7 @@ warning: declaration uses 'sorry'
 /--
 info: ⟨3, 6⟩
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! t.maxEntry sorry
@@ -900,7 +900,7 @@ warning: declaration uses 'sorry'
 /--
 info: (3, 6)
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! DTreeMap.Const.maxEntry t sorry
@@ -1493,7 +1493,7 @@ local instance : Inhabited ((_ : Nat) × Nat) where
 /--
 info: (2, 4)
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! t.entryAtIdx 1 sorry
@@ -1521,7 +1521,7 @@ warning: declaration uses 'sorry'
 /--
 info: 2
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! t.keyAtIdx 1 sorry
@@ -1641,7 +1641,7 @@ warning: declaration uses 'sorry'
 /--
 info: (1, 2)
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! t.minEntry sorry
@@ -1673,7 +1673,7 @@ warning: declaration uses 'sorry'
 /--
 info: (3, 6)
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! t.maxEntry sorry
@@ -2011,7 +2011,7 @@ def t : TreeSet Nat :=
 /--
 info: 2
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 #eval! t.atIdx 1 sorry

--- a/tests/lean/run/warnSorry.lean
+++ b/tests/lean/run/warnSorry.lean
@@ -2,10 +2,10 @@ import Lean
 /-!
 # `warn.sorry` tests
 
-When `warn.sorry` is false, don't log the "declaration uses 'sorry'" warning.
+When `warn.sorry` is false, don't log the "declaration uses `sorry`" warning.
 -/
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 example : True := sorry
 
@@ -27,7 +27,7 @@ So, for now we report them just like a user `sorry`.
 
 elab "synth_sorry" : term <= expectedType => Lean.Meta.mkSorry expectedType true
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs in
 example : True := synth_sorry
 

--- a/tests/lean/run/wf_preprocess.lean
+++ b/tests/lean/run/wf_preprocess.lean
@@ -145,7 +145,7 @@ structure MTree (α : Type u) where
 
 -- set_option trace.Elab.definition.wf true in
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 trace: α : Type u_1
 t : MTree α
@@ -243,7 +243,7 @@ inductive Expression where
 | object: List (String × Expression) → Expression
 
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 trace: L : List (String × Expression)
 x : String × Expression
@@ -284,7 +284,7 @@ inductive Expression where
 | object: List (String × Expression) → Expression
 
 /--
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 ---
 trace: L : List (String × Expression)
 x : String × Expression
@@ -325,7 +325,7 @@ namespace List
     (wfParam xs).zipWith f ys = xs.attach.unattach.zipWith f ys := by
   simp [wfParam]
 
-/-- warning: declaration uses 'sorry' -/
+/-- warning: declaration uses `sorry` -/
 #guard_msgs (warning) in
 @[wf_preprocess] theorem List.zipWith_unattach {P : α → Prop} {xs : List (Subtype P)} {ys : List β} {f : α → β → γ} :
     xs.unattach.zipWith f ys = xs.zipWith (fun ⟨x, h⟩ y =>

--- a/tests/lean/run/zetaDeltaTryThisIssue.lean
+++ b/tests/lean/run/zetaDeltaTryThisIssue.lean
@@ -4,7 +4,7 @@ opaque f : Nat → Nat
 info: Try this:
   [apply] simp only [h1, x]
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (a : Nat) : True := by
@@ -18,7 +18,7 @@ example (a : Nat) : True := by
 info: Try this:
   [apply] simp only [this, x]
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : True := by

--- a/tests/lean/run/zetaUnused.lean
+++ b/tests/lean/run/zetaUnused.lean
@@ -6,7 +6,7 @@ trace: b : Bool
     True
   else False
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (b : Bool) : if b then have unused := (); True else False := by
@@ -16,7 +16,7 @@ example (b : Bool) : if b then have unused := (); True else False := by
 trace: b : Bool
 ⊢ b = true
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (b : Bool) : if b then have unused := (); True else False := by
@@ -28,7 +28,7 @@ trace: b : Bool
     have unused := ();
     True
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (b : Bool) : if b then have unused := (); True else False := by
@@ -43,7 +43,7 @@ example (b : Bool) : if b then have unused := (); True else False := by
 trace: b : Bool
 ⊢ if b = true then True else False
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (b : Bool) : if b then have unused := (); True else False := by
@@ -54,7 +54,7 @@ example (b : Bool) : if b then have unused := (); True else False := by
 trace: b : Bool
 ⊢ if b = true then True else False
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (b : Bool) : if b then have unused := (); True else False := by
@@ -71,7 +71,7 @@ h✝ : b = true
 ⊢ have unused := ();
   True
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (b : Bool) : if b then have unused := (); True else False := by

--- a/tests/lean/rwWithoutOffsetCnstrs.lean.expected.out
+++ b/tests/lean/rwWithoutOffsetCnstrs.lean.expected.out
@@ -1,3 +1,3 @@
 m n : Nat
 ⊢ (n + 1).ble n = false
-rwWithoutOffsetCnstrs.lean:5:0-5:7: warning: declaration uses 'sorry'
+rwWithoutOffsetCnstrs.lean:5:0-5:7: warning: declaration uses `sorry`

--- a/tests/lean/simp_dsimp.lean.expected.out
+++ b/tests/lean/simp_dsimp.lean.expected.out
@@ -1,8 +1,8 @@
 x : Nat
 a : A (x + 0)
 ⊢ f x a = x
-simp_dsimp.lean:4:0-4:7: warning: declaration uses 'sorry'
+simp_dsimp.lean:4:0-4:7: warning: declaration uses `sorry`
 x : Nat
 a : A (x + 0)
 ⊢ f (x + 0) a = x
-simp_dsimp.lean:9:0-9:7: warning: declaration uses 'sorry'
+simp_dsimp.lean:9:0-9:7: warning: declaration uses `sorry`

--- a/tests/lean/simp_trace.lean.expected.out
+++ b/tests/lean/simp_trace.lean.expected.out
@@ -132,7 +132,7 @@ Try this: simp (discharger := sorry) only [Nat.sub_add_cancel]
       x = x
     ==>
       True
-simp_trace.lean:86:0-86:7: warning: declaration uses 'sorry'
+simp_trace.lean:86:0-86:7: warning: declaration uses `sorry`
 Try this: simp only [bla, h] at *
 [Meta.Tactic.simp.rewrite] unfold bla, bla x ==> match h x with
     | Sum.inl (y, z) => y + z

--- a/tests/lean/simp_trace_backtrack.lean.expected.out
+++ b/tests/lean/simp_trace_backtrack.lean.expected.out
@@ -1,3 +1,3 @@
-simp_trace_backtrack.lean:7:8-7:26: warning: declaration uses 'sorry'
+simp_trace_backtrack.lean:7:8-7:26: warning: declaration uses `sorry`
 Try this: simp only [Nat.succ_sub_succ_eq_sub]
-simp_trace_backtrack.lean:14:0-14:7: warning: declaration uses 'sorry'
+simp_trace_backtrack.lean:14:0-14:7: warning: declaration uses `sorry`

--- a/tests/lean/sorryWarning.lean.expected.out
+++ b/tests/lean/sorryWarning.lean.expected.out
@@ -1,1 +1,1 @@
-sorryWarning.lean:1:4-1:5: warning: declaration uses 'sorry'
+sorryWarning.lean:1:4-1:5: warning: declaration uses `sorry`

--- a/tests/lean/unfoldDefEq.lean.expected.out
+++ b/tests/lean/unfoldDefEq.lean.expected.out
@@ -6,9 +6,9 @@ n : Nat
 x : Fin n
 h : some_property x
 ⊢ True
-unfoldDefEq.lean:7:0-7:7: warning: declaration uses 'sorry'
+unfoldDefEq.lean:7:0-7:7: warning: declaration uses `sorry`
 n : Nat
 x : Fin n
 h : some_property x
 ⊢ True
-unfoldDefEq.lean:14:0-14:7: warning: declaration uses 'sorry'
+unfoldDefEq.lean:14:0-14:7: warning: declaration uses `sorry`

--- a/tests/lean/unfoldReduceMatch.lean.expected.out
+++ b/tests/lean/unfoldReduceMatch.lean.expected.out
@@ -1,3 +1,3 @@
 n : Nat
 ⊢ (zero.add n).succ = n.succ
-unfoldReduceMatch.lean:2:0-2:7: warning: declaration uses 'sorry'
+unfoldReduceMatch.lean:2:0-2:7: warning: declaration uses `sorry`

--- a/tests/lean/unknownCannotBeComplex.lean.expected.out
+++ b/tests/lean/unknownCannotBeComplex.lean.expected.out
@@ -1,4 +1,4 @@
-unknownCannotBeComplex.lean:3:0-3:7: warning: declaration uses 'sorry'
+unknownCannotBeComplex.lean:3:0-3:7: warning: declaration uses `sorry`
 unknownCannotBeComplex.lean:4:10-4:22: error: Function expected at
   Maybe
 but this term has type
@@ -45,7 +45,7 @@ Note: It is not possible to treat `MetaM` as an implicitly bound variable here b
 unknownCannotBeComplex.lean:13:10-13:18: error(lean.unknownIdentifier): Unknown identifier `Nonsense`
 
 Note: It is not possible to treat `Nonsense` as an implicitly bound variable here because it has multiple characters while the `relaxedAutoImplicit` option is set to `false`.
-unknownCannotBeComplex.lean:15:0-15:7: warning: declaration uses 'sorry'
+unknownCannotBeComplex.lean:15:0-15:7: warning: declaration uses `sorry`
 unknownCannotBeComplex.lean:16:68-16:74: error: invalid `▸` notation, argument
   h
 has type

--- a/tests/lean/withLocation.lean.expected.out
+++ b/tests/lean/withLocation.lean.expected.out
@@ -1,2 +1,2 @@
 t
-withLocation.lean:11:0-11:7: warning: declaration uses 'sorry'
+withLocation.lean:11:0-11:7: warning: declaration uses `sorry`


### PR DESCRIPTION
This PR changes the "declaration uses 'sorry'" warning to use backticks instead of single quotes, consistent with Lean's conventions for formatting code identifiers in diagnostic messages.