### PR TITLE
feat: expose `decidable_of_bool`

### DIFF
--- a/src/Init/PropLemmas.lean
+++ b/src/Init/PropLemmas.lean
@@ -600,7 +600,7 @@ instance [DecidablePred p] : DecidablePred (p ∘ f) :=
 
 /-- Prove that `a` is decidable by constructing a boolean `b` and a proof that `b ↔ a`.
 (This is sometimes taken as an alternate definition of decidability.) -/
-def decidable_of_bool : ∀ (b : Bool), (b ↔ a) → Decidable a
+@[expose] def decidable_of_bool : ∀ (b : Bool), (b ↔ a) → Decidable a
   | true, h => isTrue (h.1 rfl)
   | false, h => isFalse (mt h.2 Bool.noConfusion)
 


### PR DESCRIPTION
This PR adds `@[expose]` to `decidable_of_bool` so that proofs-by-`decide` elsewhere that reduce to `decidable_of_bool` continue to reduce.