### PR TITLE
fix: enforce `Grind.genPattern` and `Grind.getHEqPattern` assumptions

### DIFF
--- a/tests/lean/run/grind_11633.lean
+++ b/tests/lean/run/grind_11633.lean
@@ -1,0 +1,9 @@
+inductive MyBool where
+| i0
+| other
+
+theorem ex (b: MyBool)
+       (h: b = .i0)
+: match b with | .i0 => True | _ => False
+:= by
+  grind


### PR DESCRIPTION
This PR ensures the pattern normalizer used in `grind` does violate assumptions made by the gadgets `Grind.genPattern` and `Grind.getHEqPattern`.

Closes #11633
