### PR TITLE
feat: bitvec literal internalization in `grind`

### DIFF
--- a/tests/lean/run/grind_internalize_bitvec_lit.lean
+++ b/tests/lean/run/grind_internalize_bitvec_lit.lean
@@ -1,0 +1,7 @@
+attribute [grind? =] BitVec.sdiv_zero
+
+example {x : BitVec 32} : x.sdiv 0#32 = 0#32 := by
+  grind
+
+example {x : BitVec 32} : x.sdiv 0#32 = 0#32 := by
+  grind -ext


### PR DESCRIPTION
This PR fixes bitvector literal internalization in `grind`. The fix ensures theorems indexed by `BitVec.ofNat` are properly activated.
