### PR TITLE
feat: `BitVec.ofNat` in `grind ring`

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/Arith/CommRing/Reify.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/CommRing/Reify.lean
@@ -80,6 +80,9 @@ partial def reifyCore? (e : Expr) (skipVar : Bool) (gen : Nat) : m (Option RingE
     | OfNat.ofNat _ n _ =>
       let some k ← getNatValue? n | toVar e
       return .num k
+    | BitVec.ofNat _ n =>
+      let some k ← getNatValue? n | toVar e
+      return .num k
     | _ => toVar e
   let toTopVar (e : Expr) : m (Option RingExpr) := do
     if skipVar then

--- a/tests/lean/run/grind_ring_2.lean
+++ b/tests/lean/run/grind_ring_2.lean
@@ -178,3 +178,12 @@ example (x : Int) (h : x^2 = 0) : (if x > 0 then x else x)^3 = 0 := by
 example {xs ys zs : List α} : (xs ++ ys) ++ zs = xs ++ (ys ++ zs) := by
   fail_if_success grobner
   grind
+
+example (x : BitVec 8) : (x - 16)*(x + 272) = x^2 := by
+  grind
+
+example (x : BitVec 8) : (x - 16#8)*(x + 16#8) = x^2 := by
+  grind
+
+example (x : BitVec 8) : (x - 16)*(x + 272#8) = x^2 := by
+  grind


### PR DESCRIPTION
This PR adds support for `BitVec.ofNat` in `grind ring`. Example:

```lean
example (x : BitVec 8) : (x - 16#8)*(x + 272#8) = x^2 := by
  grind
```
