### PR TITLE
chore: add missing `.run` and `.mk`s in monad transformers

### DIFF
--- a/src/Init/Control/Except.lean
+++ b/src/Init/Control/Except.lean
@@ -236,14 +236,14 @@ This is the `ExceptT` version of `Except.mapError`.
 -/
 @[always_inline, inline]
 protected def adapt {ε' α : Type u} (f : ε → ε') : ExceptT ε m α → ExceptT ε' m α := fun x =>
-  ExceptT.mk <| Except.mapError f <$> x
+  ExceptT.mk <| Except.mapError f <$> x.run
 
 end ExceptT
 
 @[always_inline]
 instance (m : Type u → Type v) (ε₁ : Type u) (ε₂ : Type u) [MonadExceptOf ε₁ m] : MonadExceptOf ε₁ (ExceptT ε₂ m) where
   throw e := ExceptT.mk <| throwThe ε₁ e
-  tryCatch x handle := ExceptT.mk <| tryCatchThe ε₁ x handle
+  tryCatch x handle := ExceptT.mk <| tryCatchThe ε₁ x.run (handle · |>.run)
 
 @[always_inline]
 instance (m : Type u → Type v) (ε : Type u) [Monad m] : MonadExceptOf ε (ExceptT ε m) where

--- a/src/Init/Control/Lawful/MonadLift/Instances.lean
+++ b/src/Init/Control/Lawful/MonadLift/Instances.lean
@@ -63,8 +63,7 @@ variable [Monad m] [LawfulMonad m]
 @[simp]
 theorem lift_bind {α β : Type u} (ma : m α) (f : α → m β) :
     OptionT.lift (ma >>= f) = OptionT.lift ma >>= (fun a => OptionT.lift (f a)) := by
-  simp only [instMonad, OptionT.bind, OptionT.mk, OptionT.lift, bind_pure_comp, bind_map_left,
-    map_bind]
+  simp only [OptionT.lift, bind_pure_comp, map_bind, instMonad, OptionT.bind, run_mk, bind_map_left]
 
 instance : LawfulMonadLift m (OptionT m) where
   monadLift_pure := lift_pure
@@ -98,14 +97,8 @@ end ExceptT
 namespace StateRefT'
 
 instance {ω σ : Type} {m : Type → Type} [Monad m] : LawfulMonadLift m (StateRefT' ω σ m) where
-  monadLift_pure _ := by
-    simp only [MonadLift.monadLift, pure]
-    unfold StateRefT'.lift ReaderT.pure
-    simp only
-  monadLift_bind _ _ := by
-    simp only [MonadLift.monadLift, bind]
-    unfold StateRefT'.lift ReaderT.bind
-    simp only
+  monadLift_pure _ := rfl
+  monadLift_bind _ _ := rfl
 
 end StateRefT'
 

--- a/src/Init/Control/Reader.lean
+++ b/src/Init/Control/Reader.lean
@@ -39,12 +39,12 @@ end ReaderT
 
 instance : MonadControl m (ReaderT ρ m) where
   stM      := id
-  liftWith f ctx := f fun x => x ctx
+  liftWith f := .mk fun ctx => f fun x => x.run ctx
   restoreM x _ := x
 
 @[always_inline]
 instance ReaderT.tryFinally [MonadFinally m] : MonadFinally (ReaderT ρ m) where
-  tryFinally' x h ctx := tryFinally' (x ctx) (fun a? => h a? ctx)
+  tryFinally' x h := .mk fun ctx => tryFinally' (x.run ctx) (fun a? => h a? |>.run ctx)
 
 /--
 A monad with access to a read-only value of type `ρ`. The value can be locally overridden by

--- a/src/Init/Control/StateRef.lean
+++ b/src/Init/Control/StateRef.lean
@@ -58,7 +58,7 @@ lifting](lean-manual://section/monad-lifting).
 -/
 @[always_inline, inline]
 protected def lift (x : m α) : StateRefT' ω σ m α :=
-  fun _ => x
+  .mk fun _ => x
 
 instance [Monad m] : Monad (StateRefT' ω σ m) := inferInstanceAs (Monad (ReaderT _ _))
 instance : MonadLift m (StateRefT' ω σ m) := ⟨StateRefT'.lift⟩
@@ -72,14 +72,14 @@ This increments the reference count of the state, which may inhibit in-place upd
 -/
 @[inline]
 protected def get [MonadLiftT (ST ω) m] : StateRefT' ω σ m σ :=
-  fun ref => ref.get
+  .mk fun ref => ref.get
 
 /--
 Replaces the mutable state with a new value.
 -/
 @[inline]
 protected def set [MonadLiftT (ST ω) m] (s : σ) : StateRefT' ω σ m PUnit :=
-  fun ref => ref.set s
+  .mk fun ref => ref.set s
 
 /--
 Applies a function to the current state that both computes a new state and a value. The new state
@@ -101,7 +101,7 @@ instance [MonadLiftT (ST ω) m] : MonadStateOf σ (StateRefT' ω σ m) where
 @[always_inline]
 instance (ε) [MonadExceptOf ε m] : MonadExceptOf ε (StateRefT' ω σ m) where
   throw    := StateRefT'.lift ∘ throwThe ε
-  tryCatch := fun x c s => tryCatchThe ε (x s) (fun e => c e s)
+  tryCatch := fun x c => .mk fun s => tryCatchThe ε (ReaderT.run x s) (fun e => ReaderT.run (c e) s)
 
 end StateRefT'
 

--- a/src/Std/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Do/Triple/SpecLemmas.lean
@@ -227,18 +227,18 @@ attribute [spec] liftM instMonadLiftTOfMonadLift instMonadLiftT
 @[spec]
 theorem Spec.monadMap_StateT [Monad m] [WP m ps]
     (f : ∀{β}, m β → m β) {α} (x : StateT σ m α) (Q : PostCond α (.arg σ ps)) :
-    Triple (MonadFunctor.monadMap (m:=m) f x) (spred(fun s => wp⟦f (x.run s)⟧ (fun (a, s) => Q.1 a s, Q.2))) spred(Q) := .rfl
+    Triple (monadMap (m:=m) f x) (spred(fun s => wp⟦f (x.run s)⟧ (fun (a, s) => Q.1 a s, Q.2))) spred(Q) := .rfl
 
 @[spec]
 theorem Spec.monadMap_ReaderT [Monad m] [WP m ps]
     (f : ∀{β}, m β → m β) {α} (x : ReaderT ρ m α) (Q : PostCond α (.arg ρ ps)) :
-    Triple (MonadFunctor.monadMap (m:=m) f x) (spred(fun s => wp⟦f (x.run s)⟧ (fun a => Q.1 a s, Q.2))) spred(Q) := .rfl
+    Triple (monadMap (m:=m) f x) (spred(fun s => wp⟦f (x.run s)⟧ (fun a => Q.1 a s, Q.2))) spred(Q) := .rfl
 
 @[spec]
 theorem Spec.monadMap_ExceptT [Monad m] [WP m ps]
     (f : ∀{β}, m β → m β) {α} (x : ExceptT ε m α) (Q : PostCond α (.except ε ps)) :
   Triple (ps:=.except ε ps)
-    (MonadFunctor.monadMap (m:=m) f x)
+    (monadMap (m:=m) f x)
     (wp⟦f x.run⟧ (fun e => e.casesOn Q.2.1 Q.1, Q.2.2))
     Q := by simp [Triple]
 
@@ -246,7 +246,7 @@ theorem Spec.monadMap_ExceptT [Monad m] [WP m ps]
 theorem Spec.monadMap_OptionT [Monad m] [WP m ps]
     (f : ∀{β}, m β → m β) {α} (x : OptionT m α) (Q : PostCond α (.except PUnit ps)) :
   Triple (ps:=.except PUnit ps)
-    (MonadFunctor.monadMap (m:=m) f x)
+    (monadMap (m:=m) f x)
     (wp⟦f x.run⟧ (fun o => o.casesOn (Q.2.1 ⟨⟩) Q.1, Q.2.2))
     Q := by simp [Triple]
 

--- a/src/Std/Do/WP/Monad.lean
+++ b/src/Std/Do/WP/Monad.lean
@@ -55,24 +55,23 @@ instance Id.instWPMonad : WPMonad Id .pure where
   wp_bind x f := by simp only [wp, PredTrans.pure, Bind.bind, Id.run, PredTrans.bind]
 
 instance StateT.instWPMonad [Monad m] [WPMonad m ps] : WPMonad (StateT σ m) (.arg σ ps) where
-  wp_pure a := by ext; simp only [wp, pure, StateT.pure, WPMonad.wp_pure, PredTrans.pure,
+  wp_pure a := by ext; simp only [wp, StateT.run_mk, StateT.run_pure, WPMonad.wp_pure, PredTrans.Pure_pure_apply,
     PredTrans.pushArg_apply]
-  wp_bind x f := by ext; simp only [wp, bind, StateT.bind, WPMonad.wp_bind, PredTrans.bind,
+  wp_bind x f := by ext; simp only [wp, StateT.run_mk, StateT.run_bind, WPMonad.wp_bind, PredTrans.bind_apply,
     PredTrans.pushArg_apply]
 
 instance ReaderT.instWPMonad [Monad m] [WPMonad m ps] : WPMonad (ReaderT ρ m) (.arg ρ ps) where
-  wp_pure a := by ext; simp only [wp, pure, ReaderT.pure, WPMonad.wp_pure, PredTrans.pure,
+  wp_pure a := by ext; simp only [wp, StateT.run_mk, ReaderT.run_pure, WPMonad.wp_pure, PredTrans.Pure_pure_apply,
     PredTrans.pushArg_apply, PredTrans.map_apply]
-  wp_bind x f := by ext; simp only [wp, bind, ReaderT.bind, WPMonad.wp_bind, PredTrans.bind,
+  wp_bind x f := by ext; simp only [wp, StateT.run_mk, ReaderT.run_bind, WPMonad.wp_bind, PredTrans.bind_apply,
     PredTrans.pushArg_apply, PredTrans.map_apply]
 
 instance ExceptT.instWPMonad [Monad m] [WPMonad m ps] : WPMonad (ExceptT ε m) (.except ε ps) where
-  wp_pure a := by ext; simp only [wp, pure, ExceptT.pure, ExceptT.mk, WPMonad.wp_pure,
-    PredTrans.pure, PredTrans.pushExcept_apply]
+  wp_pure a := by ext; simp only [wp, ExceptT.run_mk, ExceptT.run_pure, WPMonad.wp_pure, PredTrans.Pure_pure_apply,
+    PredTrans.pushExcept_apply]
   wp_bind x f := by
     ext Q
-    simp only [wp, bind, ExceptT.bind, ExceptT.mk, WPMonad.wp_bind, PredTrans.bind,
-      ExceptT.bindCont, PredTrans.pushExcept_apply]
+    simp only [wp, ExceptT.run_mk, ExceptT.run_bind, WPMonad.wp_bind, PredTrans.bind_apply, PredTrans.pushExcept_apply]
     congr
     ext b
     cases b
@@ -80,24 +79,24 @@ instance ExceptT.instWPMonad [Monad m] [WPMonad m ps] : WPMonad (ExceptT ε m) (
     case ok a => rfl
 
 instance OptionT.instWPMonad [Monad m] [WPMonad m ps] : WPMonad (OptionT m) (.except PUnit ps) where
-  wp_pure a := by ext; simp only [wp, pure, OptionT.pure, OptionT.mk, WPMonad.wp_pure,
-    PredTrans.pure, PredTrans.pushOption_apply]
+  wp_pure a := by ext; simp only [wp, OptionT.run_pure, OptionT.run_mk, WPMonad.wp_pure,
+    PredTrans.Pure_pure_apply, PredTrans.pushOption_apply]
   wp_bind x f := by
     ext Q
-    simp only [wp, bind, OptionT.bind, OptionT.mk, WPMonad.wp_bind, PredTrans.bind, PredTrans.pushOption_apply]
+    simp only [wp, OptionT.run_bind, OptionT.run_mk, Option.elimM, WPMonad.wp_bind, PredTrans.bind_apply, PredTrans.pushOption_apply]
     congr
     ext b
     cases b
-    case none => simp [wp_pure]
+    case none => simp [wp_pure, Option.elim]
     case some a => rfl
 
 instance EStateM.instWPMonad : WPMonad (EStateM ε σ) (.except ε (.arg σ .pure)) where
-  wp_pure a := by simp only [wp, pure, EStateM.pure, PredTrans.pure]
+  wp_pure a := by simp only [wp, EStateM.run_mk, pure, EStateM.pure, PredTrans.pure]
   wp_bind x f := by
     ext Q : 2
-    simp only [wp, bind, EStateM.bind, PredTrans.bind]
+    simp only [wp, bind, EStateM.bind, PredTrans.bind, EStateM.run_mk]
     ext s : 1
-    cases (x s) <;> rfl
+    cases x.run s <;> rfl
 
 instance Except.instWPMonad : WPMonad (Except ε) (.except ε .pure) where
   wp_pure a := rfl


### PR DESCRIPTION
This PR allows unfolding of monadic operations without ending up in a `simp` dead end.
