### PR TITLE
fix: use naming context in `grind` pattern suggestions

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/EMatchTheorem.lean
+++ b/src/Lean/Meta/Tactic/Grind/EMatchTheorem.lean
@@ -1544,6 +1544,10 @@ private def save (ref : Syntax) (thm : EMatchTheorem) (isParam : Bool) (minIndex
   if (← get).thms.all fun thm' => thm.patterns != thm'.patterns then
     let pats ← thm.patterns.mapM fun p => do
       let pats ← addMessageContextFull (ppPattern p)
+      -- **Note**: Add function for adding naming context, or store `MessageData` directly in the suggestion.
+      let currNamespace ← getCurrNamespace
+      let openDecls ← getOpenDecls
+      let pats := MessageData.withNamingContext {currNamespace, openDecls} pats
       pats.format
     let openBracket  := if isParam then "" else "["
     let closeBracket := if isParam then "" else "]"

--- a/tests/lean/run/grind_pattern2.lean
+++ b/tests/lean/run/grind_pattern2.lean
@@ -60,3 +60,15 @@ trace: [grind.ematch.pattern] arrEx: [@HAdd.hAdd #6 _ _ _ (@getElem (Array _) `[
 -/
 #guard_msgs in
 grind_pattern arrEx => as[i]+as[j]'(h₂▸h₁)
+
+namespace Foo.Bla
+set_option trace.grind.ematch false
+set_option trace.grind.ematch.pattern false
+opaque P : {n : Nat} → Fin (n+1) → Prop
+/--
+info: Try this:
+  [apply] [grind .] for pattern: [@P #0 (@OfNat.ofNat (Fin _) `[0] _)]
+-/
+#guard_msgs in
+@[grind] axiom Pax : @P n 0
+end Foo.Bla


### PR DESCRIPTION
This PR adds `MessageData.withNamingContext` when generating pattern suggestions at `@[grind]`. It fixes another issue reported during ItaLean.
