### PR TITLE
chore: add guidance to not merge PRs autonomously in release command

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -39,6 +39,7 @@ These comments explain the scripts' behavior, which repositories get special han
 
 ## Important Notes
 
+- **NEVER merge PRs autonomously** - always wait for the user to merge PRs themselves
 - The `release_steps.py` script is idempotent - it's safe to rerun
 - The `release_checklist.py` script is idempotent - it's safe to rerun
 - Some repositories depend on others (e.g., mathlib4 depends on batteries, aesop, etc.)


### PR DESCRIPTION
This PR adds explicit guidance to the `/release` command that Claude should never merge PRs autonomously during the release process - always wait for the user to do it.

🤖 Prepared with Claude Code