### PR TITLE
fix: ensure `by` uses expected instead of given type for modsys aux decl

### DIFF
--- a/src/Lean/Elab/SyntheticMVars.lean
+++ b/src/Lean/Elab/SyntheticMVars.lean
@@ -523,7 +523,9 @@ mutual
             if !e.isFVar then
               e ← mvarId'.withContext do
                 withExporting (isExporting := wasExporting) do
-                  abstractProof e
+                  -- Like `abstractProof`, but use the expected and not given type here as
+                  -- the latter might not make sense outside the current module (#11672).
+                  mkAuxTheorem (cache := !e.hasSorry) (← mvarId.getType) e (zetaDelta := true)
             mvarId.assign e)
       fun ex => do
         if report then

--- a/tests/pkg/module/Module/Basic.lean
+++ b/tests/pkg/module/Module/Basic.lean
@@ -524,3 +524,23 @@ meta def FooBar2 := 4
 #guard_msgs in
 @[suggest_for Bar3 FooBar1 FooBar2]
 public def FooBar3 := 4
+
+/-- #11672: Check that `by` creates aux theorems with correct type in presence of opaque defs. -/
+
+@[no_expose] public def five : Nat := 5
+
+public class A where
+  a : five = 5
+  b : Nat
+
+public instance : A where
+  a := by rfl
+  b := 0
+
+-- should NOT be `five = five`, which is not a valid proof of `A.a` in the public scope
+/--
+info: theorem instA._proof_1 : five = 5 :=
+Eq.refl five
+-/
+#guard_msgs in
+#print instA._proof_1

--- a/tests/pkg/module/Module/Imported.lean
+++ b/tests/pkg/module/Module/Imported.lean
@@ -208,3 +208,6 @@ error: Invalid `meta` definition `metaUsingNonMeta`, `f` is not accessible here;
 #guard_msgs in
 public meta def metaUsingNonMeta : Nat :=
   f
+
+-- #11672
+example : instA = { instA with b := 0 } := rfl


### PR DESCRIPTION
This PR fixes an issue where a `by` in the public scope could create an auxiliary theorem for the proof whose type does not match the expected type in the public scope.

Fixes #11672