### PR TITLE
feat: basic equality propagation for `IntModule` in `grind`

### DIFF
--- a/src/Init/Grind/Ordered/Linarith.lean
+++ b/src/Init/Grind/Ordered/Linarith.lean
@@ -554,4 +554,13 @@ theorem eq_eq_subst {α} [IntModule α] (ctx : Context α) (x : Var) (p₁ p₂ 
     : eq_eq_subst_cert x p₁ p₂ p₃ → p₁.denote' ctx = 0 → p₂.denote' ctx = 0 → p₃.denote' ctx = 0 := by
   simp [eq_eq_subst_cert]; intro _ h₁ h₂; subst p₃; simp [h₁, h₂]
 
+def imp_eq_cert (p : Poly) (x y : Var) : Bool :=
+  p == .add 1 x (.add (-1) y .nil)
+
+theorem imp_eq {α} [IntModule α] (ctx : Context α) (p : Poly) (x y : Var)
+    : imp_eq_cert p x y → p.denote' ctx = 0 → x.denote ctx = y.denote ctx := by
+  simp [imp_eq_cert]; intro; subst p; simp [Poly.denote]
+  rw [neg_zsmul, ← sub_eq_add_neg, one_zsmul, sub_eq_zero_iff]
+  simp
+
 end Lean.Grind.Linarith

--- a/src/Lean/Meta/Tactic/Grind/Arith/Linear/Proof.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Linear/Proof.lean
@@ -486,6 +486,16 @@ def setInconsistent (h : UnsatProof) : LinearM Unit := do
     let h ← h.toExprProof
     closeGoal h
 
+def propagateImpEq (c : EqCnstr) : LinearM Unit := do
+  let .add 1 x (.add (-1) y .nil) := c.p | unreachable!
+  let a ← getVar x
+  let b ← getVar y
+  let h ← withProofContext do
+    let h ← mkIntModThmPrefix ``Grind.Linarith.imp_eq
+    return mkApp5 h (← mkPolyDecl c.p) (← mkVarDecl x) (← mkVarDecl y) eagerReflBoolTrue (← c.toExprProof)
+  let h := mkExpectedPropHint h (← mkEq a b)
+  pushEq a b h
+
 /-!
 A linarith proof may depend on decision variables.
 We collect them and perform non chronological backtracking.

--- a/tests/lean/run/grind_intmodule_eq_prop.lean
+++ b/tests/lean/run/grind_intmodule_eq_prop.lean
@@ -1,0 +1,11 @@
+example {W : Type} [Lean.Grind.IntModule W] (f : W → Nat)
+    (_ : ∀ (a : Int) (x : W), f (a • x) = a.natAbs * f x)
+    (_ : a ≠ 1) (_ : a ≠ -1) (x : W) (_ : f x = 1) :
+    ¬ x - a • x = 0 := by
+  grind
+
+example {W : Type} [Lean.Grind.IntModule W] (f : W → Nat)
+    (_ : ∀ (a : Int) (x : W), f (a • x) = a.natAbs * f x)
+    (_ : a ≠ 1) (_ : a ≠ -1) (x y : W) (_ : f x = 1) :
+    y ≠ x → ¬ x - a • x = 0 := by
+  grind


### PR DESCRIPTION
This PR adds basic support for equality propagation in `grind linarith` for the `IntModule` case. This covers only the basic case. See note in the code.
We remark this feature is irrelevant for `CommRing` since `grind ring` already has much better support for equality propagation.

