### PR TITLE
fix: `grind lia` distracted by nonlinearity

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/Arith/Cutsat/CommRing.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Cutsat/CommRing.lean
@@ -50,8 +50,10 @@ def _root_.Int.Linear.Poly.normCommRing? (p : Poly) : GoalM (Option (CommRing.Ri
     let some p' ← re.toPolyM? | return none
     let e' ← p'.denoteExpr
     let e' ← preprocessLight e'
-    -- Remark: we are reusing the `IntModule` virtual parent.
-    -- TODO: Investigate whether we should have a custom virtual parent for cutsat
+    /-
+    **Note**: We are reusing the `IntModule` virtual parent.
+    **TODO**: Investigate whether we should have a custom virtual parent for cutsat
+    -/
     internalize e' gen (some getIntModuleVirtualParent)
     let p'' ← toPoly e'
     if p == p'' then return none

--- a/src/Lean/Meta/Tactic/Grind/Arith/Cutsat/Var.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Cutsat/Var.lean
@@ -42,7 +42,7 @@ private partial def registerNonlinearOccsAt (e : Expr) (x : Var) : GoalM Unit :=
   | HPow.hPow _ _ _ _ a b =>
     if (← getIntValue? a).isNone then
       registerNonlinearOcc a x
-    if (← getIntValue? b).isNone then
+    if (← getIntValue? b).isNone && (← getNatValue? b).isNone then
       -- Recall that `b : Nat`, we must create `NatCast.natCast b` and watch it.
       let (b', _) ← mkNatVar b
       internalize b' (← getGeneration b)

--- a/tests/lean/run/grind_9427.lean
+++ b/tests/lean/run/grind_9427.lean
@@ -32,7 +32,6 @@ example (x y z : BitVec 100000) : x * y - z*z = 0 → z*z = y * x := by
 /--
 trace: [grind.issues] exponent 1024 exceeds threshold for exponentiation `(exp := 16)`
 [grind.issues] exponent 1024 exceeds threshold for exponentiation `(exp := 16)`
-[grind.issues] exponent 1024 exceeds threshold for exponentiation `(exp := 16)`
 -/
 #guard_msgs in
 set_option trace.grind.issues true in

--- a/tests/lean/run/grind_nonlinear_occ_issue.lean
+++ b/tests/lean/run/grind_nonlinear_occ_issue.lean
@@ -1,0 +1,15 @@
+/-!
+Test for a bug at `registerNonlinearOccsAt`.
+-/
+
+example {a : Nat} (ha : 1 ≤ a) (H : a ^ 2 = 2 ^ a) : a = 1 ∨ a = 2 ∨ 3 ≤ a := by
+  grind
+
+example {a : Nat} (ha : 1 ≤ a) (H : a ^ 2 = 2 ^ a) : a = 1 ∨ 2 ≤ a := by grind
+
+example {a : Nat} (ha : 2 ≤ a) (H : a ^ 2 = 2 ^ a) : a = 2 ∨ 3 ≤ a := by grind
+
+example {a : Nat} (ha : 1 ≤ a) (_ : a ≤ 2) (_ : ¬ a = 1) (_ : ¬ a = 2) (H : a ^ 2 = 2 ^ a) : False := by
+  grind
+
+example {a : Nat} (ha : 1 ≤ a) : a = 1 ∨ a = 2 ∨ 3 ≤ a := by grind


### PR DESCRIPTION
This PR fixes a bug in `registerNonlinearOccsAt` used to implement `grind lia`. This issue was originally reported at: https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/Weirdness.20with.20cutsat/near/562099515

Example that was failing:
```lean
example {a : Nat} (ha : 1 ≤ a) (H : a ^ 2 = 2 ^ a)
    : a = 1 ∨ a = 2 ∨ 3 ≤ a := by
  grind
```
