### PR TITLE
chore: ci: check for changes to src/stdlib_flags.h

### DIFF
--- a/src/stdlib_flags.h
+++ b/src/stdlib_flags.h
@@ -1,7 +1,5 @@
 #include "util/options.h"
 
-// Please update stage0 from the wrong file
-
 namespace lean {
 options get_default_options() {
     options opts;


### PR DESCRIPTION
This PR adds a CI step that fails if the `src/stdlib_flags.h` file was modified, to alert PR authors that they most likely wanted to modify `stage0/src/stdlib_flags.h` instead.