### PR TITLE
chore: fix typo "Unkown" -> "Unknown" in role error message

### DIFF
--- a/src/Lean/Elab/DocString.lean
+++ b/src/Lean/Elab/DocString.lean
@@ -1301,7 +1301,7 @@ public partial def elabInline (stx : TSyntax `inline) : DocM (Inline ElabInline)
             continue
           else throw e
         | e => throw e
-    throwErrorAt name "Unkown role `{name}`"
+    throwErrorAt name "Unknown role `{name}`"
   | other =>
     throwErrorAt other "Unsupported syntax {other}"
 where


### PR DESCRIPTION
Fix a typo in the error message when an unknown role is used in a docstring.

- Changes "Unkown role" to "Unknown role" in `src/Lean/Elab/DocString.lean`