### PR TITLE
feat: abstract metavariables when generalizing `match` motives (#8099)

### DIFF
--- a/src/Init/Grind/Ring/CommSolver.lean
+++ b/src/Init/Grind/Ring/CommSolver.lean
@@ -766,7 +766,7 @@ def Poly.cancelVar (c : Int) (x : Var) (p : Poly) : Poly :=
           (fun _ _ _ _ => a.toPoly_k.pow k)
           (fun _ _ _ _ => a.toPoly_k.pow k)
           (fun _ _ _ => a.toPoly_k.pow k)
-          a) = match a with
+          a) = match (generalizing := false) a with
             | num n => Poly.num (n ^ k)
             | .intCast n => .num (n^k)
             | .natCast n => .num (n^k)

--- a/src/Lean/Elab/Match.lean
+++ b/src/Lean/Elab/Match.lean
@@ -886,7 +886,7 @@ private def generalize (discrs : Array Discr) (matchType : Expr) (altViews : Arr
       let matchType' ← forallBoundedTelescope matchType discrs.size fun ds type => do
         let type ← mkForallFVars ys type
         let (discrs', ds') := Array.unzip <| Array.zip discrExprs ds |>.filter fun (di, _) => di.isFVar
-        let type := type.replaceFVars discrs' ds'
+        let type ← type.replaceFVarsM discrs' ds'
         mkForallFVars ds type
       if (← isTypeCorrect matchType') then
         let discrs := discrs ++  ys.map fun y => { expr := y : Discr }
@@ -1119,11 +1119,11 @@ private def elabMatchAux (generalizing? : Option Bool) (discrStxs : Array Syntax
       withRef altLHS.ref do
         for d in altLHS.fvarDecls do
           if d.hasExprMVar then
+            -- This code path is a vestige prior to fixing #8099, but it is still appears to be
+            -- important for testcase 1300.lean.
             tryPostpone
             withExistingLocalDecls altLHS.fvarDecls do
               runPendingTacticsAt d.type
-              if (← instantiateMVars d.type).hasExprMVar then
-                throwMVarError m!"Invalid match expression: The type of pattern variable '{d.toExpr}' contains metavariables:{indentExpr d.type}"
         for p in altLHS.patterns do
           if (← Match.instantiatePatternMVars p).hasExprMVar then
             tryPostpone

--- a/src/Lean/Elab/Tactic/Do/VCGen.lean
+++ b/src/Lean/Elab/Tactic/Do/VCGen.lean
@@ -196,8 +196,18 @@ where
     -- context = fun e => H ⊢ₛ wp⟦e⟧ Q
     let context ← withLocalDecl `e .default (mkApp m α) fun e => do
       mkLambdaFVars #[e] (goal.withNewProg e).toExpr
-    return ← info.splitWithConstantMotive goal.toExpr (useSplitter := true) fun altSuff idx params => do
+    return ← info.splitWith goal.toExpr (useSplitter := true) fun altSuff expAltType idx params => do
+      burnOne
+      let e ← mkFreshExprMVar (mkApp m α)
+      unless ← isDefEq (goal.withNewProg e).toExpr expAltType do
+        throwError "The alternative type {expAltType} returned by `splitWith` does not match {(goal.withNewProg e).toExpr}. This is a bug in `mvcgen`."
+      let e ← instantiateMVarsIfMVarApp e
       let res ← liftMetaM <| rwIfOrMatcher idx e
+      -- When `FunInd.rwMatcher` fails, it returns the original expression. We'd loop in that case,
+      -- so we rather throw an error.
+      if res.expr == e then
+        throwError "`rwMatcher` failed to rewrite {indentExpr e}\n\
+          Check the output of `trace.Elab.Tactic.Do.vcgen.split` for more info and submit a bug report."
       let goal' := goal.withNewProg res.expr
       let prf ← withAltCtx idx params <| onWPApp goal' (name ++ altSuff)
       let res ← Simp.mkCongrArg context res
@@ -243,7 +253,7 @@ where
       mkFreshExprSyntheticOpaqueMVar hypsTy (name.appendIndexAfter i)
 
     let (joinPrf, joinGoal) ← forallBoundedTelescope joinTy numJoinParams fun joinParams _body => do
-      let φ ← info.splitWithConstantMotive (mkSort .zero) fun _suff idx altParams =>
+      let φ ← info.splitWith (mkSort .zero) fun _suff _expAltType idx altParams =>
         return mkAppN hypsMVars[idx]! (joinParams ++ altParams)
       withLocalDecl (← mkFreshUserName `h) .default φ fun h => do
         -- NB: `mkJoinGoal` is not quite `goal.withNewProg` because we only take 4 args and clear

--- a/src/Lean/Elab/Tactic/Do/VCGen/Basic.lean
+++ b/src/Lean/Elab/Tactic/Do/VCGen/Basic.lean
@@ -16,6 +16,7 @@ namespace Lean.Elab.Tactic.Do
 open Lean Parser Elab Tactic Meta Do SpecAttr
 
 builtin_initialize registerTraceClass `Elab.Tactic.Do.vcgen
+builtin_initialize registerTraceClass `Elab.Tactic.Do.vcgen.split
 
 register_builtin_option mvcgen.warning : Bool := {
   defValue := true

--- a/src/Lean/Meta/Basic.lean
+++ b/src/Lean/Meta/Basic.lean
@@ -1092,6 +1092,13 @@ def _root_.Lean.Expr.abstractM (e : Expr) (xs : Array Expr) : MetaM Expr :=
   e.abstractRangeM xs.size xs
 
 /--
+Replace occurrences of the free variables `fvars` in `e` with `vs`.
+Similar to `Expr.replaceFVars`, but handles metavariables correctly.
+-/
+def _root_.Lean.Expr.replaceFVarsM (e : Expr) (fvars : Array Expr) (vs : Array Expr) : MetaM Expr :=
+  return (← e.abstractM fvars).instantiateRev vs
+
+/--
 Collect forward dependencies for the free variables in `toRevert`.
 Recall that when reverting free variables `xs`, we must also revert their forward dependencies.
 

--- a/src/Lean/Meta/Match/Rewrite.lean
+++ b/src/Lean/Meta/Match/Rewrite.lean
@@ -1,0 +1,149 @@
+/-
+Copyright (c) 2025 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Graf
+-/
+module
+
+prelude
+public import Lean.Meta.Tactic.Simp.Types
+import Lean.Meta.Match.MatcherApp.Transform
+import Lean.Meta.Tactic.Assumption
+import Lean.Meta.Tactic.Refl
+import Lean.Meta.Tactic.Simp.Rewrite
+
+public section
+
+namespace Lean.Meta
+
+/--
+Tries to rewrite the `ite`, `dite` or `cond` expression `e` with the hypothesis `hc`.
+If it fails, it returns a rewrite with `proof? := none` and unchaged expression.
+-/
+def rwIfWith (hc : Expr) (e : Expr) : MetaM Simp.Result := do
+  match_expr e with
+  | ite@ite α c h t f =>
+    let us := ite.constLevels!
+    if (← isDefEq c (← inferType hc)) then
+      return {
+        expr := t
+        proof? := (mkAppN (mkConst ``if_pos us) #[c, h, hc, α, t, f])
+      }
+    if (← isDefEq (mkNot c) (← inferType hc)) then
+      return {
+        expr := f
+        proof? := (mkAppN (mkConst ``if_neg us) #[c, h, hc, α, t, f])
+      }
+  | dite@dite α c h t f =>
+    let us := dite.constLevels!
+    if (← isDefEq c (← inferType hc)) then
+      return {
+        expr := t.beta #[hc]
+        proof? := (mkAppN (mkConst ``dif_pos us) #[c, h, hc, α, t, f])
+      }
+    if (← isDefEq (mkNot c) (← inferType hc)) then
+      return {
+        expr := f.beta #[hc]
+        proof? := (mkAppN (mkConst ``dif_neg us) #[c, h, hc, α, t, f])
+      }
+  | cond@cond α c t f =>
+    let us := cond.constLevels!
+    if (← isDefEq (← inferType hc) (← mkEq c (mkConst ``Bool.true))) then
+      return {
+        expr := t
+        proof? := (mkAppN (mkConst ``Bool.cond_pos us) #[α, c, t, f, hc])
+      }
+    if (← isDefEq (← inferType hc) (← mkEq c (mkConst ``Bool.false))) then
+      return {
+        expr := f
+        proof? := (mkAppN (mkConst ``Bool.cond_neg us) #[α, c, t, f, hc])
+      }
+  | _ => pure ()
+  return { expr := e }
+
+/--
+In the `onAlt` handler of a `MatcherApp.transform`, you can use this function on a properly
+substituted matcher application with the alternative `altIdx`.
+
+If it fails, it returns a rewrite with `proof? := none` and the unchanged expression.
+
+"Properly substituted" here means that the discriminants have been substituted according to the
+alternative; otherwise, the rewrite might fail because some hypothesis of the congruence
+equation theorem cannot be discharged by assumption or reflixivity.
+See `Lean.Meta.Tactic.FunInd.buildInductionBody` and `Lean.Elab.Tactic.Do.VCGen.Split` for examples
+of how to coerce `MatherApp.transform` into doing the substitution on the motive for you.
+-/
+def rwMatcher (altIdx : Nat) (e : Expr) : MetaM Simp.Result := do
+  if e.isAppOf ``PSum.casesOn || e.isAppOf ``PSigma.casesOn then
+    let mut e := e
+    while true do
+      if let some e' ← reduceRecMatcher? e then
+          e := e'.headBeta
+      else
+        let e' := e.headBeta
+        if e != e' then
+          e := e'
+        else
+          break
+    return { expr := e }
+  else
+    unless (← isMatcherApp e) do
+      trace[Meta.Match.debug] "Not a matcher application:{indentExpr e}"
+      return { expr := e }
+    let matcherDeclName := e.getAppFn.constName!
+    let eqns ← Match.genMatchCongrEqns matcherDeclName
+    unless altIdx < eqns.size do
+      trace[Meta.Match.debug] "When trying to reduce arm {altIdx}, only {eqns.size} equations for {.ofConstName matcherDeclName}"
+      return { expr := e }
+    let eqnThm := eqns[altIdx]!
+    try
+      withTraceNode `Meta.Match.debug (pure m!"{exceptEmoji ·} rewriting with {.ofConstName eqnThm} in{indentExpr e}") do
+      let eqProof := mkAppN (mkConst eqnThm e.getAppFn.constLevels!) e.getAppArgs
+      let (hyps, _, eqType) ← forallMetaTelescope (← inferType eqProof)
+      trace[Meta.Match.debug] "eqProof has type{indentExpr eqType}"
+      let proof := mkAppN eqProof hyps
+      let hyps := hyps.map (·.mvarId!)
+      let (isHeq, lhs, rhs) ← do
+        if let some (_, lhs, _, rhs) := eqType.heq? then pure (true, lhs, rhs) else
+        if let some (_, lhs, rhs) := eqType.eq? then pure (false, lhs, rhs) else
+        throwError m!"Type of `{.ofConstName eqnThm}` is not an equality"
+      if !(← isDefEq e lhs) then
+        throwError m!"Left-hand side `{lhs}` of `{.ofConstName eqnThm}` does not apply to `{e}`"
+      /-
+      Here we instantiate the hypotheses of the congruence equation theorem
+      There are two sets of hypotheses to instantiate:
+      - `Eq` or `HEq` that relate the discriminants to the patterns
+        Solving these should instantiate the pattern variables.
+      - Overlap hypotheses (`isEqnThmHypothesis`)
+      With more book keeping we could maybe do this very precisely, knowing exactly
+      which facts provided by the splitter should go where, but it's tedious.
+      So for now let's use heuristics and try `assumption` and `rfl`.
+      -/
+      for h in hyps do
+        unless (← h.isAssigned) do
+          let hType ← h.getType
+          if Simp.isEqnThmHypothesis hType then
+            -- Using unrestricted h.substVars here does not work well; it could
+            -- even introduce a dependency on the `oldIH` we want to eliminate
+            h.assumption <|> throwError "Failed to discharge `{h}`"
+          else if hType.isEq then
+            h.assumption <|> h.refl <|> throwError m!"Failed to resolve `{h}`"
+          else if hType.isHEq then
+            h.assumption <|> h.hrefl <|> throwError m!"Failed to resolve `{h}`"
+      let unassignedHyps ← hyps.filterM fun h => return !(← h.isAssigned)
+      unless unassignedHyps.isEmpty do
+        throwError m!"Not all hypotheses of `{.ofConstName eqnThm}` could be discharged: {unassignedHyps}"
+      let rhs ← instantiateMVars rhs
+      let proof ← instantiateMVars proof
+      let proof ← if isHeq then
+          try mkEqOfHEq proof
+          catch e => throwError m!"Could not un-HEq `{proof}`:{indentD e.toMessageData} "
+        else
+          pure proof
+      return {
+        expr := rhs
+        proof? := proof
+      }
+    catch ex =>
+      trace[Meta.Match.debug] "Failed to apply {.ofConstName eqnThm}:{indentD ex.toMessageData}"
+      return { expr := e }

--- a/src/Lean/Meta/Tactic/Congr.lean
+++ b/src/Lean/Meta/Tactic/Congr.lean
@@ -52,6 +52,13 @@ def MVarId.congr? (mvarId : MVarId) : MetaM (Option (List MVarId)) :=
     applyCongrThm? mvarId congrThm
 
 /--
+Try to apply a `simp` congruence theorem and throw an error if it fails.
+-/
+def MVarId.congr (mvarId : MVarId) : MetaM (List MVarId) := do
+  let some mvarIds ← mvarId.congr? | throwError "Failed to apply `simp` congruence theorem"
+  return mvarIds
+
+/--
 Try to apply a `hcongr` congruence theorem, and then tries to close resulting goals
 using `Eq.refl`, `HEq.refl`, and assumption.
 -/

--- a/src/Lean/Meta/Tactic/FunInd.lean
+++ b/src/Lean/Meta/Tactic/FunInd.lean
@@ -9,6 +9,7 @@ module
 prelude
 public import Lean.Meta.Tactic.Simp.Types
 import Lean.Meta.Match.MatcherApp.Transform
+import Lean.Meta.Match.Rewrite
 import Lean.Meta.Injective -- for elimOptParam
 import Lean.Meta.ArgsPacker
 import Lean.Elab.PreDefinition.WF.Eqns
@@ -18,7 +19,6 @@ import Lean.Meta.Tactic.ElimInfo
 import Lean.Meta.Tactic.FunIndInfo
 import Lean.Data.Array
 import Lean.Meta.Tactic.Simp.Rewrite
-import Lean.Meta.Tactic.Refl
 import Lean.Meta.Tactic.Replace
 
 /-!
@@ -582,50 +582,6 @@ partial def inProdLambdaLastArg (rw : Expr → MetaM Simp.Result) (goal : Expr) 
       let r ← inLastArg rw goal
       r.addLambdas xs
 
-public def rwIfWith (hc : Expr) (e : Expr) : MetaM Simp.Result := do
-  match_expr e with
-  | ite@ite α c h t f =>
-    let us := ite.constLevels!
-    if (← isDefEq c (← inferType hc)) then
-      return {
-        expr := t
-        proof? := (mkAppN (mkConst ``if_pos us) #[c, h, hc, α, t, f])
-      }
-    if (← isDefEq (mkNot c) (← inferType hc)) then
-      return {
-        expr := f
-        proof? := (mkAppN (mkConst ``if_neg us) #[c, h, hc, α, t, f])
-      }
-    return { expr := e}
-  | dite@dite α c h t f =>
-    let us := dite.constLevels!
-    if (← isDefEq c (← inferType hc)) then
-      return {
-        expr := t.beta #[hc]
-        proof? := (mkAppN (mkConst ``dif_pos us) #[c, h, hc, α, t, f])
-      }
-    if (← isDefEq (mkNot c) (← inferType hc)) then
-      return {
-        expr := f.beta #[hc]
-        proof? := (mkAppN (mkConst ``dif_neg us) #[c, h, hc, α, t, f])
-      }
-    return { expr := e }
-  | cond@cond α c t f =>
-    let us := cond.constLevels!
-    if (← isDefEq (← inferType hc) (← mkEq c (mkConst ``Bool.true))) then
-      return {
-        expr := t
-        proof? := (mkAppN (mkConst ``Bool.cond_pos us) #[α, c, t, f, hc])
-      }
-    if (← isDefEq (← inferType hc) (← mkEq c (mkConst ``Bool.false))) then
-      return {
-        expr := f
-        proof? := (mkAppN (mkConst ``Bool.cond_neg us) #[α, c, t, f, hc])
-      }
-    return { expr := e }
-  | _ =>
-    return { expr := e }
-
 def rwLetWith (h : Expr) (e : Expr) : MetaM Simp.Result := do
   if e.isLet then
     if (← isDefEq e.letValue! h) then
@@ -646,81 +602,6 @@ def rwFun (names : Array Name) (e : Expr) : MetaM Simp.Result := do
         | throwError "Not an equality: `{h}`"
       return { expr := rhs, proof? := h }
     else
-      return { expr := e }
-
-public def rwMatcher (altIdx : Nat) (e : Expr) : MetaM Simp.Result := do
-  if e.isAppOf ``PSum.casesOn || e.isAppOf ``PSigma.casesOn then
-    let mut e := e
-    while true do
-      if let some e' ← reduceRecMatcher? e then
-          e := e'.headBeta
-      else
-        let e' := e.headBeta
-        if e != e' then
-          e := e'
-        else
-          break
-    return { expr := e }
-  else
-    unless (← isMatcherApp e) do
-      trace[Meta.FunInd] "Not a matcher application:{indentExpr e}"
-      return { expr := e }
-    let matcherDeclName := e.getAppFn.constName!
-    let eqns ← Match.genMatchCongrEqns matcherDeclName
-    unless altIdx < eqns.size do
-      trace[Meta.FunInd] "When trying to reduce arm {altIdx}, only {eqns.size} equations for {.ofConstName matcherDeclName}"
-      return { expr := e }
-    let eqnThm := eqns[altIdx]!
-    try
-      withTraceNode `Meta.FunInd (pure m!"{exceptEmoji ·} rewriting with {.ofConstName eqnThm} in{indentExpr e}") do
-      let eqProof := mkAppN (mkConst eqnThm e.getAppFn.constLevels!) e.getAppArgs
-      let (hyps, _, eqType) ← forallMetaTelescope (← inferType eqProof)
-      trace[Meta.FunInd] "eqProof has type{indentExpr eqType}"
-      let proof := mkAppN eqProof hyps
-      let hyps := hyps.map (·.mvarId!)
-      let (isHeq, lhs, rhs) ← do
-        if let some (_, lhs, _, rhs) := eqType.heq? then pure (true, lhs, rhs) else
-        if let some (_, lhs, rhs) := eqType.eq? then pure (false, lhs, rhs) else
-        throwError m!"Type of `{.ofConstName eqnThm}` is not an equality"
-      if !(← isDefEq e lhs) then
-        throwError m!"Left-hand side `{lhs}` of `{.ofConstName eqnThm}` does not apply to `{e}`"
-      /-
-      Here we instantiate the hypotheses of the congruence equation theorem
-      There are two sets of hypotheses to instantiate:
-      - `Eq` or `HEq` that relate the discriminants to the patterns
-        Solving these should instantiate the pattern variables.
-      - Overlap hypotheses (`isEqnThmHypothesis`)
-      With more book keeping we could maybe do this very precisely, knowing exactly
-      which facts provided by the splitter should go where, but it's tedious.
-      So for now let's use heuristics and try `assumption` and `rfl`.
-      -/
-      for h in hyps do
-        unless (← h.isAssigned) do
-          let hType ← h.getType
-          if Simp.isEqnThmHypothesis hType then
-            -- Using unrestricted h.substVars here does not work well; it could
-            -- even introduce a dependency on the `oldIH` we want to eliminate
-            h.assumption <|> throwError "Failed to discharge `{h}`"
-          else if hType.isEq then
-            h.assumption <|> h.refl <|> throwError m!"Failed to resolve `{h}`"
-          else if hType.isHEq then
-            h.assumption <|> h.hrefl <|> throwError m!"Failed to resolve `{h}`"
-      let unassignedHyps ← hyps.filterM fun h => return !(← h.isAssigned)
-      unless unassignedHyps.isEmpty do
-        throwError m!"Not all hypotheses of `{.ofConstName eqnThm}` could be discharged: {unassignedHyps}"
-      let rhs ← instantiateMVars rhs
-      let proof ← instantiateMVars proof
-      let proof ← if isHeq then
-          try mkEqOfHEq proof
-          catch e => throwError m!"Could not un-HEq `{proof}`:{indentD e.toMessageData} "
-        else
-          pure proof
-      return {
-        expr := rhs
-        proof? := proof
-      }
-    catch ex =>
-      trace[Meta.FunInd] "Failed to apply {.ofConstName eqnThm}:{indentD ex.toMessageData}"
       return { expr := e }
 
 /--

--- a/src/Lean/Meta/Tactic/Refl.lean
+++ b/src/Lean/Meta/Tactic/Refl.lean
@@ -62,4 +62,13 @@ def _root_.Lean.MVarId.hrefl (mvarId : MVarId) : MetaM Unit := do
     let some [] ← observing? do mvarId.apply (mkConst ``HEq.refl [← mkFreshLevelMVar])
       | throwTacticEx `hrefl mvarId
 
+/--
+Close given goal using `Subsingleton.helim`.
+-/
+def _root_.Lean.MVarId.helim (mvarId : MVarId) : MetaM (List MVarId) :=
+  mvarId.withContext do
+    let some subGoals ← observing? do mvarId.apply (mkConst ``Subsingleton.helim [← mkFreshLevelMVar])
+      | throwTacticEx `hrefl mvarId
+    return subGoals
+
 end Lean.Meta

--- a/tests/lean/run/4251.lean
+++ b/tests/lean/run/4251.lean
@@ -3,12 +3,27 @@ info: Try this:
   [apply] simp only [ha, Nat.reduceEqDiff, imp_self]
 -/
 #guard_msgs in
-theorem foo₁ (a : Nat) (ha : a = 37) :
-    (match h : a with | 42 => by simp_all | n => n) = 37 := by
+example (a : Nat) (ha : a = 37) :
+    (match (generalizing := false) h : a with | 42 => by simp_all | n => n) = 37 := by
   simp? [ha]
 
-theorem foo₂ (a : Nat) (ha : a = 37) (hb : b = 37)  :
-    (match h : a with | 42 => by simp_all | n => n) = b := by
+example (a : Nat) (ha : a = 37) (hb : b = 37)  :
+    (match (generalizing := false) h : a with | 42 => by simp_all | n => n) = b := by
   simp only [ha, Nat.reduceEqDiff, imp_self]
+  guard_target =ₛ 37 = b
+  rw [hb]
+
+/--
+info: Try this:
+  [apply] simp only [ha]
+-/
+#guard_msgs in
+example (a : Nat) (ha : a = 37) :
+    (match a with | 42 => by simp_all | n => n) = 37 := by
+  simp? [ha]
+
+example (a : Nat) (ha : a = 37) (hb : b = 37)  :
+    (match a with | 42 => by simp_all | n => n) = b := by
+  simp only [ha]
   guard_target =ₛ 37 = b
   rw [hb]

--- a/tests/lean/run/8099.lean
+++ b/tests/lean/run/8099.lean
@@ -1,0 +1,34 @@
+
+example : List Bool :=
+  let s : String := "test"
+  let l : List Nat := [1, 2, 3]
+  let r := match 1 with | _ => l.map (fun n => let (x) := s; true)
+  []
+
+example : List Bool :=
+  let p : String × String := ("test", "test")
+  let l : List Nat := [1, 2, 3]
+  let o : Option Nat := none
+  let r :=
+    match o with
+    | none => [false]
+    | some m => l.map (fun n => let (x, y) := p; true)
+  []
+
+-- Previously, the `contradiction` below would fail because the `match` would have been generalized.
+-- That was because the expected type of the `match` was a metavariable that was not properly
+-- abstracted over `a`; hence the `matchType` was type incorrect and generalization failed to
+-- re-introduce `ha : 42 = 37`.
+example (a : Nat) (ha : a = 37) :=
+  (match a with | 42 => by contradiction | n => n) = 37
+
+example (n : Nat) : Id (Fin (n + 1)) :=
+  have jp : ?m := ?rhs
+  match n with
+  | 0 => ?jmp1
+  | n + 1 => ?jmp2
+  where finally
+  case m => exact Fin (n + 1) → Id (Fin (n + 1))
+  case jmp1 => exact jp ⟨0, by decide⟩
+  case jmp2 => exact jp ⟨n, by omega⟩
+  case rhs => exact pure

--- a/tests/lean/run/doLogicTests.lean
+++ b/tests/lean/run/doLogicTests.lean
@@ -475,6 +475,14 @@ theorem unfold_to_expose_match_spec :
   -- and then apply the spec for `get`.
   mvcgen [unfold_to_expose_match, Option.getD]
 
+theorem test_match_splitting_nogeneralize {m : Option Nat} (h : m = some 4) :
+  ⦃⌜True⌝⦄
+  (match (generalizing := false) m with
+  | some n => (set n : StateM Nat PUnit)
+  | none => set 0)
+  ⦃⇓ r s => ⌜s = 4⌝⦄ := by
+  mvcgen <;> simp_all
+
 theorem test_match_splitting {m : Option Nat} (h : m = some 4) :
   ⦃⌜True⌝⦄
   (match m with

--- a/tests/lean/run/issue11211.lean
+++ b/tests/lean/run/issue11211.lean
@@ -89,7 +89,7 @@ def List_map (f : α → β) (l : List α) : List β := match _ : l with
 termination_by l
 
 def foo₁ (a : Nat) (ha : a = 37) :=
-    (match h : a with | 42 => 23 | n => n) = 37
+    (match (generalizing := false) h : a with | 42 => 23 | n => n) = 37
 
 /--
 info: private def foo₁.match_1.splitter.{u_1} : (motive : Nat → Sort u_1) →
@@ -97,3 +97,15 @@ info: private def foo₁.match_1.splitter.{u_1} : (motive : Nat → Sort u_1) �
 -/
 #guard_msgs in
 #print sig foo₁.match_1.splitter
+
+def foo₂ (a : Nat) (ha : a = 37) :=
+    (match h : a with | 42 => 23 | n => n) = 37
+
+/--
+info: private def foo₂.match_1.splitter.{u_1} : (motive : (a : Nat) → a = 37 → Sort u_1) →
+  (a : Nat) →
+    (ha : a = 37) →
+      ((ha : 42 = 37) → a = 42 → motive 42 ha) → ((n : Nat) → (ha : n = 37) → a = n → motive n ha) → motive a ha
+-/
+#guard_msgs in
+#print sig foo₂.match_1.splitter

--- a/tests/lean/run/match1.lean
+++ b/tests/lean/run/match1.lean
@@ -200,8 +200,8 @@ match parity n with
 | Parity.odd  j => true  :: natToBin j
 
 /--
-error: Invalid match expression: The type of pattern variable 'a' contains metavariables:
-  ?m.12
+error: Invalid match expression: This pattern contains metavariables:
+  (a, b)
 ---
 info: fun x => ?m.3 : ?m.12 × ?m.13 → ?m.12
 -/

--- a/tests/lean/run/mvcgenInvariantsWith.lean
+++ b/tests/lean/run/mvcgenInvariantsWith.lean
@@ -91,7 +91,7 @@ theorem nodup_correct_invariants_with_cases_error (l : List Int) : nodup l ↔ l
 
 theorem test_with_pretac {m : Option Nat} (h : m = some 4) :
   ⦃⌜True⌝⦄
-  (match m with
+  (match (generalizing := false) m with
   | some n => (set n : StateM Nat PUnit)
   | none => set 0)
   ⦃⇓ _ s => ⌜s = 4⌝⦄ := by
@@ -99,7 +99,7 @@ theorem test_with_pretac {m : Option Nat} (h : m = some 4) :
 
 theorem test_with_cases {m : Option Nat} (h : m = some 4) :
   ⦃⌜True⌝⦄
-  (match m with
+  (match (generalizing := false) m with
   | some n => (set n : StateM Nat PUnit)
   | none => set 0)
   ⦃⇓ _ s => ⌜s = 4⌝⦄ := by
@@ -108,9 +108,19 @@ theorem test_with_cases {m : Option Nat} (h : m = some 4) :
   | vc1 => grind
   | vc2 => grind
 
-theorem test_with_pretac_cases {m : Option Nat} (h : m = some 4) :
+theorem test_with_cases_generalizing {m : Option Nat} (h : m = some 4) :
   ⦃⌜True⌝⦄
   (match m with
+  | some n => (set n : StateM Nat PUnit)
+  | none => set 0)
+  ⦃⇓ _ s => ⌜s = 4⌝⦄ := by
+  mvcgen
+  with
+  | vc1 => grind
+
+theorem test_with_pretac_cases {m : Option Nat} (h : m = some 4) :
+  ⦃⌜True⌝⦄
+  (match (generalizing := false) m with
   | some n => (set n : StateM Nat PUnit)
   | none => set 0)
   ⦃⇓ _ s => ⌜s = 4⌝⦄ := by


### PR DESCRIPTION
This PR improves `match` generalization such that it abstracts metavariables in types of local variables and in the result type of the match over the match discriminants. Previously, a metavariable in the result type would silently default to the behavior of `generalizing := false`, and a metavariable in the type of a free variable would lead to an error (#8099). Example of a `match` that elaborates now but previously wouldn't:
```lean
example (a : Nat) (ha : a = 37) :=
    (match a with | 42 => by contradiction | n => n) = 37
```
This is because the result type of the `match` is a metavariable that was not abstracted over `a` and hence generalization failed; the result is that `contradiction` cannot pick up the proof `ha : 42 = 37`.
The old behavior can be recovered by passing `(generalizing := false)` to the `match`.

Furthermore, programs such as the following can now be elaborated:
```lean
example (n : Nat) : Id (Fin (n + 1)) :=
  have jp : ?m := ?rhs
  match n with
  | 0 => ?jmp1
  | n + 1 => ?jmp2
  where finally
  case m => exact Fin (n + 1) → Id (Fin (n + 1))
  case jmp1 => exact jp ⟨0, by decide⟩
  case jmp2 => exact jp ⟨n, by omega⟩
  case rhs => exact pure
```
This is useful for the `do` elaborator.

Fixes #8099.
