### PR TITLE
doc: add link to reference manual in `grind` docstring

### DIFF
--- a/src/Init/Grind/Tactics.lean
+++ b/src/Init/Grind/Tactics.lean
@@ -21,6 +21,8 @@ These engines work together to handle equality reasoning, apply known theorems,
 propagate new facts, perform case analysis, and run specialized solvers
 for domains like linear arithmetic and commutative rings.
 
+See [the reference manual's chapter on `grind`](lean-manual://section/grind-tactic) for more information.
+
 `grind` is *not* designed for goals whose search space explodes combinatorially,
 think large pigeonhole instances, graph‑coloring reductions, high‑order N‑queens boards,
 or a 200‑variable Sudoku encoded as Boolean constraints.  Such encodings require


### PR DESCRIPTION
This PR adds a link to the `grind` docstring. The link directs users to the section describing `grind` in the reference manual.

<img width="840" height="354" alt="image" src="https://github.com/user-attachments/assets/8efedc53-26cd-4f2c-8d47-a9d3a324e579" />
