### PR TITLE
feat: focused error messages for named examples

### DIFF
--- a/src/Lean/Elab/MutualDef.lean
+++ b/src/Lean/Elab/MutualDef.lean
@@ -8,6 +8,7 @@ module
 prelude
 public import Lean.Elab.Deriving.Basic
 public import Lean.Elab.PreDefinition.Main
+import all Lean.Elab.ErrorUtils
 
 public section
 
@@ -139,10 +140,11 @@ private def registerFailedToInferDefTypeInfo (type : Expr) (view : DefView) :
   registerCustomErrorIfMVar type ref (m!"Failed to infer type of {msg}".tagWithErrorName failedToInferDefTypeErrorName)
 
 /--
-  Return `some [b, c]` if the given `views` are representing a declaration of the form
-  ```
-  opaque a b c : Nat
-  ```  -/
+Return `some [b, c]` if the given `views` are representing a declaration of the form
+```
+opaque a b c : Nat
+```
+-/
 private def isMultiConstant? (views : Array DefView) : Option (List Name) :=
   if views.size == 1 &&
      views[0]!.kind == .opaque &&
@@ -152,21 +154,40 @@ private def isMultiConstant? (views : Array DefView) : Option (List Name) :=
   else
     none
 
+/--
+Return `some [a, b, c]` if the given `views` are representing a declaration of the form
+```
+example a b c : Nat := ...
+```
+-/
+private def isExampleParams? (views : Array DefView) : Option (List Name) :=
+  if views.size == 1 &&
+     views[0]!.kind == .example &&
+     views[0]!.binders.getArgs.size > 0 &&
+     views[0]!.binders.getArgs.all (·.isIdent) then
+    some (views[0]!.binders.getArgs.toList.map (·.getId))
+  else
+    none
+
 private def getPendingMVarErrorMessage (views : Array DefView) : MessageData :=
-  match isMultiConstant? views with
-  | some ids =>
-    let idsStr := ", ".intercalate <| ids.map fun id => s!"`{id}`"
-    let paramsStr := ", ".intercalate <| ids.map fun id => s!"`({id} : _)`"
+  if let .some ids := isMultiConstant? views then
     MessageData.note m!"Multiple constants cannot be declared in a single declaration. \
-      The identifier(s) {idsStr} are being interpreted as parameters {paramsStr}."
-  | none =>
-    if views.all fun view => view.kind.isTheorem then
-      MessageData.note "All parameter types and holes (e.g., `_`) in the header of a theorem are resolved \
-        before the proof is processed; information from the proof cannot be used to infer what these values should be"
+      {interpretedAsParameters (ids)}"
+  else if views.all (·.kind.isTheorem) then
+    MessageData.note "All parameter types and holes (e.g., `_`) in the header of a theorem are resolved \
+      before the proof is processed; information from the proof cannot be used to infer what these values should be"
+  else if let .some ids := isExampleParams? views then
+    MessageData.note m!"Examples do not have names. {interpretedAsParameters ids}"
     else
       MessageData.note "Because this declaration's type has been explicitly provided, all parameter \
         types and holes (e.g., `_`) in its header are resolved before its body is processed; \
         information from the declaration body cannot be used to infer what these values should be"
+where
+  interpretedAsParameters (ids : List Name) : MessageData :=
+    let idsStr := ids.map (m!"`{.ofName ·}`") |>.toOxford
+    let paramsStr := ids.map (m!"`({.ofName ·} : _)`") |>.toOxford
+    m!"The identifier{ids.length.plural} {idsStr} {ids.length.plural "is" "are"} being interpreted \
+      as {ids.length.plural "a parameter" "parameters"} {paramsStr}."
 
 /--
 Convert terms of the form `OfNat <type> (OfNat.ofNat Nat <num> ..)` into `OfNat <type> <num>`.

--- a/tests/lean/multiConstantError.lean
+++ b/tests/lean/multiConstantError.lean
@@ -1,3 +1,22 @@
+opaque a b : Nat
+
 opaque a b c : Nat
 
+opaque a b c d : Nat
+
+opaque a b c d e: Nat
+
+opaque a b (c : _) : Nat
+
 opaque a α β : β → Bool
+set_option pp.rawOnError true
+
+example x : True := sorry
+
+example x y : True := sorry
+
+example x y z : True := sorry
+
+example α β γ : β → True := sorry
+
+example x y (c : True) : True := sorry

--- a/tests/lean/multiConstantError.lean.expected.out
+++ b/tests/lean/multiConstantError.lean.expected.out
@@ -1,9 +1,69 @@
-multiConstantError.lean:1:11-1:12: error(lean.inferBinderTypeFailed): Failed to infer type of binder `c`
-
-Note: Multiple constants cannot be declared in a single declaration. The identifier(s) `b`, `c` are being interpreted as parameters `(b : _)`, `(c : _)`.
 multiConstantError.lean:1:9-1:10: error(lean.inferBinderTypeFailed): Failed to infer type of binder `b`
 
-Note: Multiple constants cannot be declared in a single declaration. The identifier(s) `b`, `c` are being interpreted as parameters `(b : _)`, `(c : _)`.
-multiConstantError.lean:3:9-3:10: error(lean.inferBinderTypeFailed): Failed to infer type of binder `α`
+Note: Multiple constants cannot be declared in a single declaration. The identifier `b` is being interpreted as a parameter `(b : _)`.
+multiConstantError.lean:3:11-3:12: error(lean.inferBinderTypeFailed): Failed to infer type of binder `c`
 
-Note: Multiple constants cannot be declared in a single declaration. The identifier(s) `α`, `β` are being interpreted as parameters `(α : _)`, `(β : _)`.
+Note: Multiple constants cannot be declared in a single declaration. The identifiers `b` and `c` are being interpreted as parameters `(b : _)` and `(c : _)`.
+multiConstantError.lean:3:9-3:10: error(lean.inferBinderTypeFailed): Failed to infer type of binder `b`
+
+Note: Multiple constants cannot be declared in a single declaration. The identifiers `b` and `c` are being interpreted as parameters `(b : _)` and `(c : _)`.
+multiConstantError.lean:5:13-5:14: error(lean.inferBinderTypeFailed): Failed to infer type of binder `d`
+
+Note: Multiple constants cannot be declared in a single declaration. The identifiers `b`, `c`, and `d` are being interpreted as parameters `(b : _)`, `(c : _)`, and `(d : _)`.
+multiConstantError.lean:5:11-5:12: error(lean.inferBinderTypeFailed): Failed to infer type of binder `c`
+
+Note: Multiple constants cannot be declared in a single declaration. The identifiers `b`, `c`, and `d` are being interpreted as parameters `(b : _)`, `(c : _)`, and `(d : _)`.
+multiConstantError.lean:5:9-5:10: error(lean.inferBinderTypeFailed): Failed to infer type of binder `b`
+
+Note: Multiple constants cannot be declared in a single declaration. The identifiers `b`, `c`, and `d` are being interpreted as parameters `(b : _)`, `(c : _)`, and `(d : _)`.
+multiConstantError.lean:7:15-7:16: error(lean.inferBinderTypeFailed): Failed to infer type of binder `e`
+
+Note: Multiple constants cannot be declared in a single declaration. The identifiers `b`, `c`, `d`, and `e` are being interpreted as parameters `(b : _)`, `(c : _)`, `(d : _)`, and `(e : _)`.
+multiConstantError.lean:7:13-7:14: error(lean.inferBinderTypeFailed): Failed to infer type of binder `d`
+
+Note: Multiple constants cannot be declared in a single declaration. The identifiers `b`, `c`, `d`, and `e` are being interpreted as parameters `(b : _)`, `(c : _)`, `(d : _)`, and `(e : _)`.
+multiConstantError.lean:7:11-7:12: error(lean.inferBinderTypeFailed): Failed to infer type of binder `c`
+
+Note: Multiple constants cannot be declared in a single declaration. The identifiers `b`, `c`, `d`, and `e` are being interpreted as parameters `(b : _)`, `(c : _)`, `(d : _)`, and `(e : _)`.
+multiConstantError.lean:7:9-7:10: error(lean.inferBinderTypeFailed): Failed to infer type of binder `b`
+
+Note: Multiple constants cannot be declared in a single declaration. The identifiers `b`, `c`, `d`, and `e` are being interpreted as parameters `(b : _)`, `(c : _)`, `(d : _)`, and `(e : _)`.
+multiConstantError.lean:9:12-9:13: error(lean.inferBinderTypeFailed): Failed to infer type of binder `c`
+
+Note: Because this declaration's type has been explicitly provided, all parameter types and holes (e.g., `_`) in its header are resolved before its body is processed; information from the declaration body cannot be used to infer what these values should be
+multiConstantError.lean:9:9-9:10: error(lean.inferBinderTypeFailed): Failed to infer type of binder `b`
+
+Note: Because this declaration's type has been explicitly provided, all parameter types and holes (e.g., `_`) in its header are resolved before its body is processed; information from the declaration body cannot be used to infer what these values should be
+multiConstantError.lean:11:9-11:10: error(lean.inferBinderTypeFailed): Failed to infer type of binder `α`
+
+Note: Multiple constants cannot be declared in a single declaration. The identifiers `α` and `β` are being interpreted as parameters `(α : _)` and `(β : _)`.
+multiConstantError.lean:14:8-14:9: error(lean.inferBinderTypeFailed): Failed to infer type of binder `x`
+
+Note: Examples do not have names. The identifier `x` is being interpreted as a parameter `(x : _)`.
+multiConstantError.lean:16:10-16:11: error(lean.inferBinderTypeFailed): Failed to infer type of binder `y`
+
+Note: Examples do not have names. The identifiers `x` and `y` are being interpreted as parameters `(x : _)` and `(y : _)`.
+multiConstantError.lean:16:8-16:9: error(lean.inferBinderTypeFailed): Failed to infer type of binder `x`
+
+Note: Examples do not have names. The identifiers `x` and `y` are being interpreted as parameters `(x : _)` and `(y : _)`.
+multiConstantError.lean:18:12-18:13: error(lean.inferBinderTypeFailed): Failed to infer type of binder `z`
+
+Note: Examples do not have names. The identifiers `x`, `y`, and `z` are being interpreted as parameters `(x : _)`, `(y : _)`, and `(z : _)`.
+multiConstantError.lean:18:10-18:11: error(lean.inferBinderTypeFailed): Failed to infer type of binder `y`
+
+Note: Examples do not have names. The identifiers `x`, `y`, and `z` are being interpreted as parameters `(x : _)`, `(y : _)`, and `(z : _)`.
+multiConstantError.lean:18:8-18:9: error(lean.inferBinderTypeFailed): Failed to infer type of binder `x`
+
+Note: Examples do not have names. The identifiers `x`, `y`, and `z` are being interpreted as parameters `(x : _)`, `(y : _)`, and `(z : _)`.
+multiConstantError.lean:20:12-20:13: error(lean.inferBinderTypeFailed): Failed to infer type of binder `γ`
+
+Note: Examples do not have names. The identifiers `α`, `β`, and `γ` are being interpreted as parameters `(α : _)`, `(β : _)`, and `(γ : _)`.
+multiConstantError.lean:20:8-20:9: error(lean.inferBinderTypeFailed): Failed to infer type of binder `α`
+
+Note: Examples do not have names. The identifiers `α`, `β`, and `γ` are being interpreted as parameters `(α : _)`, `(β : _)`, and `(γ : _)`.
+multiConstantError.lean:22:10-22:11: error(lean.inferBinderTypeFailed): Failed to infer type of binder `y`
+
+Note: Because this declaration's type has been explicitly provided, all parameter types and holes (e.g., `_`) in its header are resolved before its body is processed; information from the declaration body cannot be used to infer what these values should be
+multiConstantError.lean:22:8-22:9: error(lean.inferBinderTypeFailed): Failed to infer type of binder `x`
+
+Note: Because this declaration's type has been explicitly provided, all parameter types and holes (e.g., `_`) in its header are resolved before its body is processed; information from the declaration body cannot be used to infer what these values should be


### PR DESCRIPTION
This PR gives a focused error message when a user tries to name an example, and tweaks error messages for attempts to define multiple opaque names at once.

## Example errors

```
example x : 1 == 1 := by grind
```

Current message:
```
Failed to infer type of binder `x`

Note: Because this declaration's type has been explicitly provided, all parameter types and holes (e.g., `_`) in its header are resolved before its body is processed; information from the declaration body cannot be used to infer what these values should be
```

New message:
```
Failed to infer type of binder `x`

Note: Examples don't have names. The identifier `x` is being interpreted as a parameter `(x : _)`.
```

## Plural-aware identifier lists

Both the example errors and opaque errors understand pluralization and use oxford commas.

```
opaque a b c : Nat
```

Current message:
```
Failed to infer type of binder `c`

Note: Multiple constants cannot be declared in a single declaration. The identifier(s) `b`, `c` are being interpreted as parameters `(b : _)`, `(c : _)`.
```

New message:
```
Failed to infer type of binder `c`

Note: Multiple constants cannot be declared in a single declaration. The identifiers `b` and `c` are being interpreted as parameters `(b : _)` and `(c : _)`.```