### PR TITLE
perf: turn more bv_normalize rules into simprocs

### DIFF
--- a/src/Std/Tactic/BVDecide/Normalize/BitVec.lean
+++ b/src/Std/Tactic/BVDecide/Normalize/BitVec.lean
@@ -24,8 +24,6 @@ namespace Normalize
 
 section Reduce
 
-attribute [bv_normalize] BitVec.sub_eq_add_neg
-
 @[bv_normalize]
 theorem BitVec.le_ult (x y : BitVec w) : (x ≤ y) ↔ ((!y.ult x) = true) := by
   have : x ≤ y ↔ (x.ule y = true) := by

--- a/src/Std/Tactic/BVDecide/Normalize/Canonicalize.lean
+++ b/src/Std/Tactic/BVDecide/Normalize/Canonicalize.lean
@@ -80,10 +80,8 @@ theorem BitVec.lt_ult (x y : BitVec w) : (x < y) = (BitVec.ult x y = true) := by
   simp only [(· < ·)]
   simp
 
-@[bv_normalize]
 theorem Bool.or_elim : ∀ (a b : Bool), (a || b) = !(!a && !b) := by decide
 
-@[bv_normalize]
 theorem BitVec.or_elim (x y : BitVec w) : x ||| y = ~~~(~~~x &&& ~~~y) := by
   ext
   simp


### PR DESCRIPTION
This PR improves the performance of `bv_decide`'s rewriter on large problems.

The baseline for this PR is `QF_BV/sage/app7/bench_1222.smt2` on `chonk3` at 8 minutes. After this
PR it takes about 1min and 23 seconds. This improvement is achieved by turning frequently used simp
rules into simprocs in order to avoid spending time performing unification to see if they are
applicable.
