### PR TITLE
feat: lemmas around `BitVec.extractLsb'` and `BitVec.extractLsb`

### DIFF
--- a/src/Init/Data/BitVec/Lemmas.lean
+++ b/src/Init/Data/BitVec/Lemmas.lean
@@ -3356,7 +3356,8 @@ theorem extractLsb'_concat {x : BitVec (w + 1)} {y : Bool} :
   simp only [← getLsbD_eq_getElem, getLsbD_extractLsb', hi, decide_true, Nat.zero_add,
     getLsbD_concat, Bool.true_and]
   split
-  <;> simp
+  · simp
+  · simp [show i - 1 < t by omega]
 
 /-! ### shiftConcat -/
 


### PR DESCRIPTION
This PR introduces some additional lemmas around `BitVec.extractLsb'` and `BitVec.extractLsb`. 