### PR TITLE
feat: add `claude` tactic for AI-assisted proof suggestions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,6 +2,22 @@ To build Lean you should use `make -j -C build/release`.
 
 To run a test you should use `cd tests/lean/run && ./test_single.sh example_test.lean`.
 
+## Using CI Artifacts (Fast Path)
+
+When you only need a working Lean build for a commit (not actively developing):
+- Use `script/build_artifact.py` to download pre-built CI artifacts (~30s vs 2-5min build)
+- Artifacts are cached in `~/.cache/lean_build_artifact/`
+- Falls back gracefully if no artifact available (old commit, CI failed, etc.)
+
+**When to use artifacts:**
+- Checking out a branch/PR to test or review
+- Bisecting to find a regression
+- Getting a reference build to compare against
+
+**When to build locally:**
+- Actively developing/modifying Lean source
+- Working on commits not yet in CI (your local changes)
+
 ## New features
 
 When asked to implement new features:

--- a/src/Lean/Elab/Tactic.lean
+++ b/src/Lean/Elab/Tactic.lean
@@ -54,3 +54,4 @@ public import Lean.Elab.Tactic.SimpArith
 public import Lean.Elab.Tactic.Show
 public import Lean.Elab.Tactic.Lets
 public import Lean.Elab.Tactic.Do
+public import Lean.Elab.Tactic.Claude

--- a/src/Lean/Elab/Tactic/Basic.lean
+++ b/src/Lean/Elab/Tactic/Basic.lean
@@ -369,6 +369,33 @@ def withoutRecover (x : TacticM α) : TacticM α :=
 def withRecover (recover : Bool) (x : TacticM α) : TacticM α :=
   withReader (fun ctx => { ctx with recover }) x
 
+/-! ## Message log utilities -/
+
+/-- Execute an action while suppressing any new messages it generates.
+    Restores the original message log after the action completes.
+    Useful for trying tactics without polluting the message log with errors from failed attempts. -/
+def withSuppressedMessages (action : TacticM α) : TacticM α := do
+  let initialLog ← Core.getMessageLog
+  try
+    action
+  finally
+    Core.setMessageLog initialLog
+
+/-- Execute an action and return any new messages it generates.
+    Restores the original message log afterward.
+    Useful for inspecting messages produced by a tactic without committing them. -/
+def withCapturedMessages (action : TacticM α) : TacticM (α × List Message) := do
+  let initialLog ← Core.getMessageLog
+  let initialMsgCount := initialLog.toList.length
+  let result ← action
+  let newMsgs := (← Core.getMessageLog).toList.drop initialMsgCount
+  Core.setMessageLog initialLog
+  return (result, newMsgs)
+
+/-- Check if any messages in the list are errors. -/
+def hasErrorMessages (msgs : List Message) : Bool :=
+  msgs.any (·.severity == .error)
+
 /--
 Like `throwErrorAt`, but, if recovery is enabled, logs the error instead.
 -/

--- a/src/Lean/Elab/Tactic/Claude.lean
+++ b/src/Lean/Elab/Tactic/Claude.lean
@@ -35,7 +35,7 @@ The tactic requires one of the following environment variable configurations:
 
 ## Options
 
-- `set_option tactic.claude.model "claude-opus-4-20250514"` - Choose model (default: Opus)
+- `set_option tactic.claude.model "claude-sonnet-4"` - Choose model (default: Opus)
 - `set_option tactic.claude.template "/path/to/template.txt"` - Custom prompt template
 - `set_option trace.claude.prompt true` - Show the prompt sent to Claude
 

--- a/src/Lean/Elab/Tactic/Claude.lean
+++ b/src/Lean/Elab/Tactic/Claude.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+module
+
+prelude
+public import Lean.Elab.Tactic.Claude.Basic
+public import Lean.Elab.Tactic.Claude.Template
+public import Lean.Elab.Tactic.Claude.API
+public import Lean.Elab.Tactic.Claude.CLI
+meta import Lean.Parser.Tactic
+
+public section
+
+namespace Lean.Elab.Tactic
+
+open Lean Meta Elab.Tactic Claude
+
+/-! ## Claude Tactic -/
+
+/--
+Calls Claude AI to suggest tactics for the current goal.
+
+Claude analyzes the goal, current declaration, and file context, then suggests
+tactics that are tested for validity before being presented as "Try this:" suggestions.
+
+## Activation
+
+The tactic requires one of the following environment variable configurations:
+
+- **API backend**: Set `ANTHROPIC_API_KEY` and `ENABLE_LEAN_CLAUDE_API=true`
+- **CLI backend**: Set `ENABLE_LEAN_CLAUDE_CODE=true` (requires Claude Code CLI)
+
+## Options
+
+- `set_option tactic.claude.model "claude-sonnet-4-20250514"` - Choose model (default: Sonnet)
+- `set_option tactic.claude.template "/path/to/template.txt"` - Custom prompt template
+- `set_option trace.claude.prompt true` - Show the prompt sent to Claude
+
+## Usage Notes
+
+This tactic is primarily intended for automation (e.g., as a fallback in `try?`).
+For interactive proof development, running a Claude Code session alongside your editor
+provides a more effective workflow with full conversation context.
+-/
+syntax (name := claude) "claude" : tactic
+
+/-- Main tactic implementation. -/
+@[builtin_tactic Lean.Elab.Tactic.claude]
+def evalClaude : Tactic := fun _ => do
+  -- 1. Load config
+  let config ← Claude.getConfig
+
+  -- 2. Select backend (mock/API/CLI)
+  let backend ← Claude.selectBackend config
+
+  -- 3. Get current goal
+  let goal ← getMainGoal
+
+  -- 4. Load and interpolate template
+  let templateContent ← Claude.loadTemplateContent config.templatePath
+  let template := Claude.parseTemplate templateContent
+  let ctx ← Claude.buildTemplateContext goal
+  let prompt ← Claude.interpolateTemplate template ctx
+
+  -- 5. Trace if enabled
+  if config.tracePrompt then
+    logInfo m!"Claude prompt:\n{prompt}"
+
+  -- 6. Call backend
+  let (response, tokenInfo?) ← match backend with
+    | .mock resp =>
+      pure (resp, none)
+    | .api =>
+      let (content, inTokens, outTokens) ← Claude.API.callClaudeAPI prompt config.model
+      pure (content, some (inTokens, outTokens))
+    | .cli =>
+      let content ← Claude.CLI.callClaudeCLI prompt
+      pure (content, none)
+
+  -- 7. Parse JSON response
+  let tacticResp ← match Claude.parseTacticResponse response with
+    | .ok resp => pure resp
+    | .error err =>
+      throwError s!"Failed to parse Claude response: {err}\n\nResponse:\n{response}"
+
+  -- 8. Evaluate tactics
+  let successful ← Claude.evaluateTactics tacticResp.tactics
+
+  -- 9. Generate "Try this:" suggestions
+  Claude.generateSuggestions successful
+
+  -- 10. Show usage info
+  if let some (inTokens, outTokens) := tokenInfo? then
+    logInfo m!"API usage: {inTokens} input tokens, {outTokens} output tokens"
+  else if backend == .cli then
+    logInfo "Run /usage in Claude Code to check usage"
+
+end Lean.Elab.Tactic

--- a/src/Lean/Elab/Tactic/Claude.lean
+++ b/src/Lean/Elab/Tactic/Claude.lean
@@ -30,8 +30,8 @@ tactics that are tested for validity before being presented as "Try this:" sugge
 
 The tactic requires one of the following environment variable configurations:
 
-- **API backend**: Set `ANTHROPIC_API_KEY` and `ENABLE_LEAN_CLAUDE_API=true`
-- **CLI backend**: Set `ENABLE_LEAN_CLAUDE_CODE=true` (requires Claude Code CLI)
+- **API backend**: Set `ANTHROPIC_API_KEY` and `LEAN_CLAUDE_API=true`
+- **CLI backend**: Set `LEAN_CLAUDE_CODE=true` (requires Claude Code CLI)
 
 ## Options
 

--- a/src/Lean/Elab/Tactic/Claude.lean
+++ b/src/Lean/Elab/Tactic/Claude.lean
@@ -37,6 +37,7 @@ The tactic requires one of the following environment variable configurations:
 
 - `set_option tactic.claude.model "claude-sonnet-4-20250514"` - Choose model (default: Opus)
 - `set_option tactic.claude.template "/path/to/template.txt"` - Custom prompt template
+- `set_option tactic.claude.timeout 60` - Timeout in seconds (default: 60, 0 = no timeout)
 - `set_option trace.claude.prompt true` - Show the prompt sent to Claude
 
 ## Usage Notes
@@ -74,10 +75,10 @@ def evalClaude : Tactic := fun _ => do
     | .mock resp =>
       pure (resp, none)
     | .api =>
-      let (content, inTokens, outTokens) ← Claude.API.callClaudeAPI prompt config.model
+      let (content, inTokens, outTokens) ← Claude.API.callClaudeAPI prompt config.model config.timeout
       pure (content, some (inTokens, outTokens))
     | .cli =>
-      let content ← Claude.CLI.callClaudeCLI prompt
+      let content ← Claude.CLI.callClaudeCLI prompt config.timeout
       pure (content, none)
 
   -- 7. Parse JSON response

--- a/src/Lean/Elab/Tactic/Claude.lean
+++ b/src/Lean/Elab/Tactic/Claude.lean
@@ -35,7 +35,7 @@ The tactic requires one of the following environment variable configurations:
 
 ## Options
 
-- `set_option tactic.claude.model "claude-sonnet-4-20250514"` - Choose model (default: Sonnet)
+- `set_option tactic.claude.model "claude-opus-4-20250514"` - Choose model (default: Opus)
 - `set_option tactic.claude.template "/path/to/template.txt"` - Custom prompt template
 - `set_option trace.claude.prompt true` - Show the prompt sent to Claude
 

--- a/src/Lean/Elab/Tactic/Claude.lean
+++ b/src/Lean/Elab/Tactic/Claude.lean
@@ -35,7 +35,7 @@ The tactic requires one of the following environment variable configurations:
 
 ## Options
 
-- `set_option tactic.claude.model "claude-sonnet-4"` - Choose model (default: Opus)
+- `set_option tactic.claude.model "claude-sonnet-4-20250514"` - Choose model (default: Opus)
 - `set_option tactic.claude.template "/path/to/template.txt"` - Custom prompt template
 - `set_option trace.claude.prompt true` - Show the prompt sent to Claude
 

--- a/src/Lean/Elab/Tactic/Claude/API.lean
+++ b/src/Lean/Elab/Tactic/Claude/API.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+module
+
+prelude
+public import Init.System.IO
+public import Lean.Data.Json
+
+public section
+
+namespace Lean.Elab.Tactic.Claude.API
+
+open Lean
+
+/-! ## Anthropic API Backend -/
+
+/-- Call Anthropic Messages API and return (content, inputTokens, outputTokens) -/
+def callClaudeAPI (prompt : String) (model : String) : IO (String × Nat × Nat) := do
+  let some apiKey ← IO.getEnv "ANTHROPIC_API_KEY"
+    | throw <| .userError "ANTHROPIC_API_KEY not set"
+
+  -- Build JSON request
+  let requestBody := Json.mkObj [
+    ("model", Json.str model),
+    ("max_tokens", Json.num 1024),
+    ("messages", Json.arr #[
+      Json.mkObj [
+        ("role", Json.str "user"),
+        ("content", Json.str prompt)
+      ]
+    ])
+  ]
+
+  -- Call curl
+  let output ← IO.Process.output {
+    cmd := "curl"
+    args := #[
+      "-s", "-X", "POST",
+      "https://api.anthropic.com/v1/messages",
+      "-H", s!"x-api-key: {apiKey}",
+      "-H", "anthropic-version: 2023-06-01",
+      "-H", "content-type: application/json",
+      "-d", toString requestBody
+    ]
+  }
+
+  if output.exitCode != 0 then
+    throw <| .userError s!"curl failed: {output.stderr}"
+
+  -- Parse response
+  let json ← match Json.parse output.stdout with
+    | .ok j => pure j
+    | .error err => throw <| IO.userError s!"Failed to parse API response: {err}"
+
+  -- Extract content from response
+  let content ← match json.getObjVal? "content" with
+    | .ok c => pure c
+    | .error err => throw <| IO.userError s!"No 'content' field in response: {err}\n\nFull response:\n{json}"
+
+  let contentArr ← match content.getArr? with
+    | .ok arr => pure arr
+    | .error err => throw <| IO.userError s!"Content is not an array: {err}"
+
+  let firstContent ← match contentArr[0]? with
+    | some c => pure c
+    | none => throw <| IO.userError "Content array is empty"
+
+  let text ← match firstContent.getObjVal? "text" with
+    | .ok t => pure t
+    | .error err => throw <| IO.userError s!"No 'text' field in content: {err}"
+
+  let textStr ← match text.getStr? with
+    | .ok s => pure s
+    | .error err => throw <| IO.userError s!"Text is not a string: {err}"
+
+  -- Extract token counts
+  let usage ← match json.getObjVal? "usage" with
+    | .ok u => pure u
+    | .error _ => pure <| Json.mkObj []  -- If no usage, use empty object
+
+  let inputTokens ← match usage.getObjVal? "input_tokens" with
+    | .ok t => match t.getNat? with
+      | .ok n => pure n
+      | .error _ => pure 0
+    | .error _ => pure 0
+
+  let outputTokens ← match usage.getObjVal? "output_tokens" with
+    | .ok t => match t.getNat? with
+      | .ok n => pure n
+      | .error _ => pure 0
+    | .error _ => pure 0
+
+  return (textStr, inputTokens, outputTokens)
+
+end Lean.Elab.Tactic.Claude.API

--- a/src/Lean/Elab/Tactic/Claude/Basic.lean
+++ b/src/Lean/Elab/Tactic/Claude/Basic.lean
@@ -47,8 +47,8 @@ register_builtin_option tactic.claude.template : String := {
 
 /-- Claude model to use for API requests -/
 register_builtin_option tactic.claude.model : String := {
-  defValue := "claude-opus-4-20250514"
-  descr := "Claude model to use (e.g., claude-opus-4-20250514, claude-sonnet-4-20250514)"
+  defValue := "claude-opus-4"
+  descr := "Claude model to use (e.g., claude-opus-4, claude-sonnet-4)"
 }
 
 /-- Mock JSON response for testing -/

--- a/src/Lean/Elab/Tactic/Claude/Basic.lean
+++ b/src/Lean/Elab/Tactic/Claude/Basic.lean
@@ -34,8 +34,8 @@ Templates support the following variables (computed lazily):
 ## Environment Variables
 
 Backend selection is controlled by environment variables:
-- API backend: Set `ANTHROPIC_API_KEY` and `ENABLE_LEAN_CLAUDE_API=true`
-- CLI backend: Set `ENABLE_LEAN_CLAUDE_CODE=true`
+- API backend: Set `ANTHROPIC_API_KEY` and `LEAN_CLAUDE_API=true`
+- CLI backend: Set `LEAN_CLAUDE_CODE=true`
 
 -/
 
@@ -96,18 +96,18 @@ def selectBackend (config : Config) : IO Backend := do
 
   -- Check for API backend
   let apiKey? ← IO.getEnv "ANTHROPIC_API_KEY"
-  let apiEnabled? ← IO.getEnv "ENABLE_LEAN_CLAUDE_API"
+  let apiEnabled? ← IO.getEnv "LEAN_CLAUDE_API"
 
   if apiKey?.isSome && apiEnabled? == some "true" then
     return .api
 
   -- Check for CLI backend
-  let cliEnabled? ← IO.getEnv "ENABLE_LEAN_CLAUDE_CODE"
+  let cliEnabled? ← IO.getEnv "LEAN_CLAUDE_CODE"
   if cliEnabled? == some "true" then
     return .cli
 
   -- No backend available
-  throw <| .userError "Claude tactic requires either (ANTHROPIC_API_KEY + ENABLE_LEAN_CLAUDE_API=true) or ENABLE_LEAN_CLAUDE_CODE=true"
+  throw <| .userError "Claude tactic requires either (ANTHROPIC_API_KEY + LEAN_CLAUDE_API=true) or LEAN_CLAUDE_CODE=true"
 
 /-! ## Response Parsing -/
 

--- a/src/Lean/Elab/Tactic/Claude/Basic.lean
+++ b/src/Lean/Elab/Tactic/Claude/Basic.lean
@@ -47,8 +47,8 @@ register_builtin_option tactic.claude.template : String := {
 
 /-- Claude model to use for API requests -/
 register_builtin_option tactic.claude.model : String := {
-  defValue := "claude-opus-4"
-  descr := "Claude model to use (e.g., claude-opus-4, claude-sonnet-4)"
+  defValue := "claude-opus-4-20250514"
+  descr := "Claude model to use (e.g., claude-opus-4-20250514, claude-sonnet-4-20250514)"
 }
 
 /-- Mock JSON response for testing -/

--- a/src/Lean/Elab/Tactic/Claude/Basic.lean
+++ b/src/Lean/Elab/Tactic/Claude/Basic.lean
@@ -1,0 +1,203 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+module
+
+prelude
+public import Lean.Elab.Tactic.Basic
+public import Lean.Meta.Tactic.TryThis
+public import Init.System.IO
+
+public section
+
+namespace Lean.Elab.Tactic.Claude
+
+open Lean Meta Elab.Tactic
+
+/-!
+# Claude Tactic
+
+The `claude` tactic calls Claude AI (via API or CLI) to suggest tactics for the current goal.
+
+## Template Variables
+
+Templates support the following variables (computed lazily):
+- `{goal}` - Pretty-printed current goal
+- `{declaration}` - Current declaration source text
+- `{file_prefix}` - File content before current position
+- `{suggestions}` - Library suggestion names and scores
+- `{suggestions_types}` - Library suggestions with their types
+- `{lean_version}` - Lean version string
+
+## Environment Variables
+
+Backend selection is controlled by environment variables:
+- API backend: Set `ANTHROPIC_API_KEY` and `ENABLE_LEAN_CLAUDE_API=true`
+- CLI backend: Set `ENABLE_LEAN_CLAUDE_CODE=true`
+
+-/
+
+/-- Path to custom template file (empty = use default template) -/
+register_builtin_option tactic.claude.template : String := {
+  defValue := ""
+  descr := "Path to custom template file (empty = use default)"
+}
+
+/-- Claude model to use for API requests -/
+register_builtin_option tactic.claude.model : String := {
+  defValue := "claude-sonnet-4-20250514"
+  descr := "Claude model to use (e.g., claude-sonnet-4-20250514, claude-opus-4-20250514)"
+}
+
+/-- Mock JSON response for testing -/
+register_builtin_option tactic.claude.mock : String := {
+  defValue := ""
+  descr := "Mock JSON response for testing"
+}
+
+/-- Trace the prompt sent to Claude -/
+register_builtin_option trace.claude.prompt : Bool := {
+  defValue := false
+  descr := "Trace the prompt sent to Claude"
+}
+
+/-! ## Configuration -/
+
+structure Config where
+  templatePath : String
+  model : String
+  mock : String
+  tracePrompt : Bool
+  deriving Inhabited
+
+def getConfig : TacticM Config := do
+  let opts ← getOptions
+  return {
+    templatePath := tactic.claude.template.get opts
+    model := tactic.claude.model.get opts
+    mock := tactic.claude.mock.get opts
+    tracePrompt := trace.claude.prompt.get opts
+  }
+
+/-! ## Backend Selection -/
+
+inductive Backend where
+  | api
+  | cli
+  | mock (response : String)
+  deriving Repr, BEq
+
+def selectBackend (config : Config) : IO Backend := do
+  -- Priority: mock > API > CLI
+  if config.mock != "" then
+    return .mock config.mock
+
+  -- Check for API backend
+  let apiKey? ← IO.getEnv "ANTHROPIC_API_KEY"
+  let apiEnabled? ← IO.getEnv "ENABLE_LEAN_CLAUDE_API"
+
+  if apiKey?.isSome && apiEnabled? == some "true" then
+    return .api
+
+  -- Check for CLI backend
+  let cliEnabled? ← IO.getEnv "ENABLE_LEAN_CLAUDE_CODE"
+  if cliEnabled? == some "true" then
+    return .cli
+
+  -- No backend available
+  throw <| .userError "Claude tactic requires either (ANTHROPIC_API_KEY + ENABLE_LEAN_CLAUDE_API=true) or ENABLE_LEAN_CLAUDE_CODE=true"
+
+/-! ## Response Parsing -/
+
+structure TacticResponse where
+  tactics : Array String
+  deriving Inhabited
+
+/-- Strip markdown code block wrapper if present (simple fallback in case Claude adds them) -/
+def stripMarkdownCodeBlock (response : String) : String := Id.run do
+  -- Very simple approach: if response contains ```, try to extract JSON from between fences
+  if !response.contains "```" then
+    return response
+
+  -- Split response into lines
+  let lines := (response.split (· == '\n')).toArray
+  -- Find line with opening ```
+  let mut inBlock := false
+  let mut jsonLines := #[]
+
+  for line in lines do
+    let lineStr := line.toString.trimAscii.toString
+    if lineStr.startsWith "```" && !inBlock then
+      -- Start of code block
+      inBlock := true
+    else if lineStr.startsWith "```" && inBlock then
+      -- End of code block
+      break
+    else if inBlock then
+      -- Inside code block
+      jsonLines := jsonLines.push line.toString
+
+  if jsonLines.isEmpty then
+    return response
+  else
+    return "\n".intercalate jsonLines.toList
+
+/-- Parse JSON response: `{"tactics": ["tactic1", "tactic2", ...]}` -/
+def parseTacticResponse (response : String) : Except String TacticResponse := do
+  -- Strip markdown code block if present
+  let cleanResponse := stripMarkdownCodeBlock response
+  let json ← Lean.Json.parse cleanResponse
+  let tacticsJson ← json.getObjVal? "tactics"
+  let tacticsArr ← tacticsJson.getArr?
+  let tactics ← tacticsArr.mapM (·.getStr?)
+  return { tactics := tactics }
+
+/-! ## Tactic Evaluation -/
+
+/-- Try a tactic and return whether it succeeded (without committing changes) -/
+def tryTactic (stx : Syntax) : TacticM Bool := do
+  let savedState ← saveState
+  try
+    evalTactic stx
+    savedState.restore
+    return true
+  catch _ =>
+    savedState.restore
+    return false
+
+/-- Evaluate tactics from strings, returning those that succeed -/
+def evaluateTactics (tactics : Array String) : TacticM (Array (TSyntax `tactic)) := do
+  let env ← getEnv
+  let mut successful := #[]
+
+  for tacStr in tactics do
+    -- Parse tactic string (may contain newlines for multi-step sequences)
+    match Parser.runParserCategory env `tactic tacStr with
+    | .ok stx =>
+      -- Try the tactic
+      if ← tryTactic stx then
+        successful := successful.push ⟨stx⟩
+    | .error _ =>
+      -- Skip invalid tactics
+      continue
+
+  return successful
+
+/-! ## Suggestion Generation -/
+
+/-- Generate "Try this:" suggestions -/
+def generateSuggestions (successful : Array (TSyntax `tactic)) : TacticM Unit := do
+  if successful.isEmpty then
+    throwError "Claude suggested no working tactics"
+
+  -- Show suggestions
+  let suggestionObjs : Array Tactic.TryThis.Suggestion :=
+    successful.map fun (s : TSyntax `tactic) => { suggestion := .tsyntax s }
+  if suggestionObjs.size == 1 then
+    Tactic.TryThis.addSuggestion (← getRef) suggestionObjs[0]!
+  else
+    Tactic.TryThis.addSuggestions (← getRef) suggestionObjs
+
+end Lean.Elab.Tactic.Claude

--- a/src/Lean/Elab/Tactic/Claude/Basic.lean
+++ b/src/Lean/Elab/Tactic/Claude/Basic.lean
@@ -64,6 +64,12 @@ register_builtin_option trace.claude.prompt : Bool := {
   descr := "Trace the prompt sent to Claude"
 }
 
+/-- Timeout in seconds for API/CLI calls (0 = no timeout) -/
+register_builtin_option tactic.claude.timeout : Nat := {
+  defValue := 60
+  descr := "Timeout in seconds for API/CLI calls (0 = no timeout)"
+}
+
 /-! ## Configuration -/
 
 structure Config where
@@ -71,6 +77,7 @@ structure Config where
   model : String
   mock : String
   tracePrompt : Bool
+  timeout : Nat
   deriving Inhabited
 
 def getConfig : TacticM Config := do
@@ -80,6 +87,7 @@ def getConfig : TacticM Config := do
     model := tactic.claude.model.get opts
     mock := tactic.claude.mock.get opts
     tracePrompt := trace.claude.prompt.get opts
+    timeout := tactic.claude.timeout.get opts
   }
 
 /-! ## Backend Selection -/

--- a/src/Lean/Elab/Tactic/Claude/Basic.lean
+++ b/src/Lean/Elab/Tactic/Claude/Basic.lean
@@ -47,8 +47,8 @@ register_builtin_option tactic.claude.template : String := {
 
 /-- Claude model to use for API requests -/
 register_builtin_option tactic.claude.model : String := {
-  defValue := "claude-sonnet-4-20250514"
-  descr := "Claude model to use (e.g., claude-sonnet-4-20250514, claude-opus-4-20250514)"
+  defValue := "claude-opus-4-20250514"
+  descr := "Claude model to use (e.g., claude-opus-4-20250514, claude-sonnet-4-20250514)"
 }
 
 /-- Mock JSON response for testing -/

--- a/src/Lean/Elab/Tactic/Claude/CLI.lean
+++ b/src/Lean/Elab/Tactic/Claude/CLI.lean
@@ -28,7 +28,8 @@ def callClaudeCLI (prompt : String) : IO String := do
   }
 
   if output.exitCode != 0 then
-    throw <| .userError s!"claude CLI failed: {output.stderr}"
+    let errorMsg := if output.stderr.isEmpty then output.stdout else output.stderr
+    throw <| .userError s!"claude CLI failed (exit code {output.exitCode}): {errorMsg}"
 
   return output.stdout
 

--- a/src/Lean/Elab/Tactic/Claude/CLI.lean
+++ b/src/Lean/Elab/Tactic/Claude/CLI.lean
@@ -16,18 +16,41 @@ open Lean
 
 /-! ## Claude CLI Backend -/
 
-/-- Call Claude CLI and return response -/
-def callClaudeCLI (prompt : String) : IO String := do
-  -- Call: claude -p "prompt"
+/-- Check if a command exists in PATH -/
+private def commandExists (cmd : String) : IO Bool := do
   let output ← IO.Process.output {
-    cmd := "claude"
-    args := #["-p", prompt]
+    cmd := "which"
+    args := #[cmd]
+  }
+  return output.exitCode == 0
+
+/-- Call Claude CLI and return response.
+    The timeout parameter specifies the maximum time in seconds (0 = no timeout). -/
+def callClaudeCLI (prompt : String) (timeout : Nat := 60) : IO String := do
+  -- Try to use timeout command if available and timeout > 0
+  let (cmd, args) ← if timeout > 0 then do
+    -- Try `timeout` (Linux, some macOS), then `gtimeout` (macOS via homebrew)
+    if ← commandExists "timeout" then
+      pure ("timeout", #[toString timeout, "claude", "-p", prompt])
+    else if ← commandExists "gtimeout" then
+      pure ("gtimeout", #[toString timeout, "claude", "-p", prompt])
+    else
+      pure ("claude", #["-p", prompt])
+  else
+    pure ("claude", #["-p", prompt])
+
+  let output ← IO.Process.output {
+    cmd := cmd
+    args := args
     stdin := .null
     stdout := .piped
     stderr := .piped
   }
 
   if output.exitCode != 0 then
+    -- Exit code 124 is timeout's signal that the command timed out
+    if output.exitCode == 124 then
+      throw <| .userError s!"claude CLI timed out after {timeout} seconds"
     let errorMsg := if output.stderr.isEmpty then output.stdout else output.stderr
     throw <| .userError s!"claude CLI failed (exit code {output.exitCode}): {errorMsg}"
 

--- a/src/Lean/Elab/Tactic/Claude/CLI.lean
+++ b/src/Lean/Elab/Tactic/Claude/CLI.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+module
+
+prelude
+public import Init.System.IO
+
+public section
+
+namespace Lean.Elab.Tactic.Claude.CLI
+
+open Lean
+
+/-! ## Claude CLI Backend -/
+
+/-- Call Claude CLI and return response -/
+def callClaudeCLI (prompt : String) : IO String := do
+  -- Call: claude -p "prompt"
+  let output ← IO.Process.output {
+    cmd := "claude"
+    args := #["-p", prompt]
+    stdin := .null
+    stdout := .piped
+    stderr := .piped
+  }
+
+  if output.exitCode != 0 then
+    throw <| .userError s!"claude CLI failed: {output.stderr}"
+
+  return output.stdout
+
+end Lean.Elab.Tactic.Claude.CLI

--- a/src/Lean/Elab/Tactic/Claude/Template.lean
+++ b/src/Lean/Elab/Tactic/Claude/Template.lean
@@ -1,0 +1,227 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+module
+
+prelude
+public import Lean.Elab.Tactic.Basic
+public import Lean.LibrarySuggestions.Basic
+public import Init.System.IO
+
+public section
+
+namespace Lean.Elab.Tactic.Claude
+
+open Lean Meta Elab.Tactic
+
+/-! ## Template Parsing and Interpolation -/
+
+structure Template where
+  content : String
+  variables : Array String  -- Variables referenced in template
+  deriving Inhabited
+
+/-- Extract variable names from template (e.g., `{goal}` → "goal") -/
+def extractVariables (content : String) : Array String :=
+  -- Check for each known variable
+  let knownVars := #["goal", "declaration", "file_prefix", "suggestions", "suggestions_types", "lean_version"]
+  knownVars.filter fun varName =>
+    content.contains s!"\{{varName}}"
+
+/-- Parse template to identify referenced variables -/
+def parseTemplate (content : String) : Template :=
+  { content := content, variables := extractVariables content }
+
+/-- Default template embedded at compile time (with code fences) -/
+def defaultTemplateContent : String :=
+  include_str "default_template.txt"
+
+/-- Load template from file or use default -/
+def loadTemplateContent (templatePath : String) : IO String := do
+  if templatePath.isEmpty then
+    -- Use embedded default template
+    return defaultTemplateContent
+  else
+    -- Use custom template
+    let path : System.FilePath := ⟨templatePath⟩
+    if ← path.pathExists then
+      IO.FS.readFile templatePath
+    else
+      throw <| IO.userError s!"Template file not found: {templatePath}"
+
+/-! ## Template Variable Computation -/
+
+/-- Context for template variable evaluation (lazy) -/
+structure TemplateContext where
+  goal : Unit → TacticM String
+  declaration : Unit → TacticM String
+  filePrefix : Unit → TacticM String
+  suggestions : Unit → TacticM String
+  suggestionsTypes : Unit → TacticM String
+  leanVersion : Unit → TacticM String
+
+/-- Get pretty-printed goal -/
+def getGoalString (mvarId : MVarId) : TacticM String := do
+  return toString (← Meta.ppGoal mvarId)
+
+/-- Find start of declaration by searching backwards for keywords -/
+def findDeclStart (source : String) (posIdx : Nat) : Nat := Id.run do
+  let declKeywords := #["theorem", "lemma", "def", "example", "instance", "structure", "inductive", "class", "abbrev"]
+  let bytes := source.toUTF8
+  let posIdx := min posIdx bytes.size
+  let mut searchIdx := posIdx
+  let mut declStart : Nat := 0
+
+  while searchIdx > 0 do
+    -- Find start of current line (scan backwards for newline byte 0x0A)
+    let mut lineStart := searchIdx
+    while lineStart > 0 && bytes.get! (lineStart - 1) != 0x0A do
+      lineStart := lineStart - 1
+
+    -- Check if line starts with a declaration keyword (possibly after whitespace)
+    let endIdx := min (lineStart + 50) bytes.size
+    let linePrefix := (String.Pos.Raw.extract source ⟨lineStart⟩ ⟨endIdx⟩).trimAscii.toString
+    let foundDecl := declKeywords.any fun kw =>
+      linePrefix.startsWith kw &&
+        (linePrefix.length == kw.length ||
+         (kw.length < linePrefix.length && !(linePrefix.get! ⟨kw.length⟩).isAlphanum))
+
+    if foundDecl then
+      declStart := lineStart
+      break
+
+    if lineStart > 0 then
+      searchIdx := lineStart - 1
+    else
+      break
+
+  return declStart
+
+/-- Get current declaration source text -/
+def getDeclarationString : TacticM String := do
+  let fileMap ← getFileMap
+  let ref ← getRef
+  let some pos := ref.getPos?
+    | return ""
+
+  let source := fileMap.source
+  let posIdx := pos.byteIdx
+  let declStart := findDeclStart source posIdx
+
+  if declStart < posIdx then
+    return String.Pos.Raw.extract source ⟨declStart⟩ ⟨posIdx⟩
+  else
+    return ""
+
+/-- Maximum number of lines for file prefix -/
+def maxFilePrefixLines : Nat := 1000
+
+/-- Find the start position to include at most n lines before endIdx -/
+def findLineStart (source : String) (endIdx : Nat) (maxLines : Nat) : Nat := Id.run do
+  if endIdx == 0 then return 0
+  -- Use raw bytes for safe access (newline is always a single byte 0x0A in UTF-8)
+  let bytes := source.toUTF8
+  let endIdx := min endIdx bytes.size
+  if endIdx == 0 then return 0
+
+  let mut idx := endIdx
+  let mut linesFound : Nat := 0
+
+  -- Move backwards counting newlines (0x0A = '\n')
+  while idx > 0 && linesFound < maxLines do
+    idx := idx - 1
+    if bytes.get! idx == 0x0A then
+      linesFound := linesFound + 1
+
+  -- If we hit the start, return 0; otherwise return position after the newline we stopped at
+  if idx == 0 then 0 else idx + 1
+
+/-- Get file content before current declaration (bounded by line count) -/
+def getFilePrefixString : TacticM String := do
+  let fileMap ← getFileMap
+  let ref ← getRef
+  let some pos := ref.getPos?
+    | return ""
+
+  let source := fileMap.source
+  let posIdx := pos.byteIdx
+
+  -- Find where the current declaration starts
+  let declStart := findDeclStart source posIdx
+
+  -- If declaration is at start of file, no prefix
+  if declStart == 0 then
+    return ""
+
+  -- Get content before declaration, limited to maxFilePrefixLines
+  let startIdx := findLineStart source declStart maxFilePrefixLines
+
+  let content := String.Pos.Raw.extract source ⟨startIdx⟩ ⟨declStart⟩
+
+  -- Trim trailing whitespace (blank lines before declaration)
+  return content.trimAsciiEnd.toString
+
+/-- Get library suggestions as formatted string -/
+def getLibrarySuggestionsString (mvarId : MVarId) : TacticM String := do
+  try
+    let suggestions ← LibrarySuggestions.select mvarId {}
+    if suggestions.isEmpty then
+      return ""
+    let mut result := ""
+    for s in suggestions do
+      result := result ++ s!"- {s.name} (score: {s.score})\n"
+    return result
+  catch _ =>
+    -- If library suggestions fail, return empty
+    return ""
+
+/-- Get library suggestions with types -/
+def getLibrarySuggestionsWithTypes (mvarId : MVarId) : TacticM String := do
+  try
+    let suggestions ← LibrarySuggestions.select mvarId {}
+    if suggestions.isEmpty then
+      return ""
+    let mut result := ""
+    for s in suggestions do
+      try
+        let info ← getConstInfo s.name
+        result := result ++ s!"- {s.name} : {info.type} (score: {s.score})\n"
+      catch _ =>
+        result := result ++ s!"- {s.name} (score: {s.score})\n"
+    return result
+  catch _ =>
+    return ""
+
+/-- Build template context with lazy evaluation -/
+def buildTemplateContext (mvarId : MVarId) : TacticM TemplateContext := do
+  return {
+    goal := fun () => getGoalString mvarId
+    declaration := fun () => getDeclarationString
+    filePrefix := fun () => getFilePrefixString
+    suggestions := fun () => getLibrarySuggestionsString mvarId
+    suggestionsTypes := fun () => getLibrarySuggestionsWithTypes mvarId
+    leanVersion := fun () => pure Lean.versionString
+  }
+
+/-- Interpolate template with context (only evaluates referenced variables) -/
+def interpolateTemplate (template : Template) (ctx : TemplateContext) : TacticM String := do
+  let mut result := template.content
+
+  for varName in template.variables do
+    let value ← match varName with
+      | "goal" => ctx.goal ()
+      | "declaration" => ctx.declaration ()
+      | "file_prefix" => ctx.filePrefix ()
+      | "suggestions" => ctx.suggestions ()
+      | "suggestions_types" => ctx.suggestionsTypes ()
+      | "lean_version" => ctx.leanVersion ()
+      | _ => pure ""  -- Unknown variable, ignore
+
+    -- Replace {varName} with value
+    result := result.replace s!"\{{varName}}" value
+
+  return result
+
+end Lean.Elab.Tactic.Claude

--- a/src/Lean/Elab/Tactic/Claude/Template.lean
+++ b/src/Lean/Elab/Tactic/Claude/Template.lean
@@ -99,7 +99,7 @@ def findDeclStart (source : String) (posIdx : Nat) : Nat := Id.run do
 
   return declStart
 
-/-- Get current declaration source text -/
+/-- Get current declaration source text, with `sorry` replacing the current tactic position -/
 def getDeclarationString : TacticM String := do
   let fileMap ← getFileMap
   let ref ← getRef
@@ -111,7 +111,9 @@ def getDeclarationString : TacticM String := do
   let declStart := findDeclStart source posIdx
 
   if declStart < posIdx then
-    return String.Pos.Raw.extract source ⟨declStart⟩ ⟨posIdx⟩
+    -- Extract declaration up to the current position, then append `sorry`
+    let declPrefix := String.Pos.Raw.extract source ⟨declStart⟩ ⟨posIdx⟩
+    return declPrefix ++ "sorry"
   else
     return ""
 

--- a/src/Lean/Elab/Tactic/Claude/Template.lean
+++ b/src/Lean/Elab/Tactic/Claude/Template.lean
@@ -86,7 +86,7 @@ def findDeclStart (source : String) (posIdx : Nat) : Nat := Id.run do
     let foundDecl := declKeywords.any fun kw =>
       linePrefix.startsWith kw &&
         (linePrefix.length == kw.length ||
-         (kw.length < linePrefix.length && !(linePrefix.get! ⟨kw.length⟩).isAlphanum))
+         (kw.length < linePrefix.length && !(String.Pos.Raw.get linePrefix ⟨kw.length⟩).isAlphanum))
 
     if foundDecl then
       declStart := lineStart

--- a/src/Lean/Elab/Tactic/Claude/default_template.txt
+++ b/src/Lean/Elab/Tactic/Claude/default_template.txt
@@ -1,0 +1,26 @@
+You are a Lean 4 proof assistant. Given the current proof goal, suggest tactics that could help make progress.
+
+File context (preceding the current declaration):
+```lean
+{file_prefix}
+```
+
+Declaration being proven:
+```lean
+{declaration}
+```
+
+Current goal:
+```lean
+{goal}
+```
+
+Provide your response as ONLY the raw JSON, with no explanation, no markdown code fences, no backticks:
+{"tactics": ["tactic1", "tactic2", "tactic3"]}
+
+Requirements:
+- Suggest 1-5 tactics, ordered by likelihood of success
+- Each tactic must be valid Lean 4 syntax
+- Tactics should be concrete and actionable
+- Prefer simpler tactics when applicable
+- You may include newlines in a tactic string for multi-step sequences (e.g., "intro x\napply foo")

--- a/src/Lean/Elab/Tactic/Claude/default_template.txt
+++ b/src/Lean/Elab/Tactic/Claude/default_template.txt
@@ -1,16 +1,16 @@
-You are a Lean 4 proof assistant. Given the current proof goal, suggest tactics that could help make progress.
+You are a Lean 4 proof assistant. Your task is to suggest tactics to replace the `sorry` placeholder in the proof below.
 
 File context (preceding the current declaration):
 ```lean
 {file_prefix}
 ```
 
-Declaration being proven:
+Declaration with proof so far (replace the sorry):
 ```lean
 {declaration}
 ```
 
-Current goal:
+Current goal at sorry:
 ```lean
 {goal}
 ```
@@ -19,7 +19,7 @@ Provide your response as ONLY the raw JSON, with no explanation, no markdown cod
 {"tactics": ["tactic1", "tactic2", "tactic3"]}
 
 Requirements:
-- Suggest 1-5 tactics, ordered by likelihood of success
+- Suggest 1-5 tactics to replace the sorry, ordered by likelihood of success
 - Each tactic must be valid Lean 4 syntax
 - Tactics should be concrete and actionable
 - Prefer simpler tactics when applicable

--- a/src/Lean/Meta/Tactic/LibrarySearch.lean
+++ b/src/Lean/Meta/Tactic/LibrarySearch.lean
@@ -83,9 +83,8 @@ def tryDischarger (mvarId : MVarId) : MetaM (Option (List MVarId)) := do
     let tacStx ← `(tactic| try?)
     let remainingGoals ← Elab.Term.TermElabM.run' <| Elab.Tactic.run subgoal do
       -- Suppress info messages from try?
-      let initialLog ← Core.getMessageLog
-      Elab.Tactic.evalTactic tacStx
-      Core.setMessageLog initialLog
+      Elab.Tactic.withSuppressedMessages do
+        Elab.Tactic.evalTactic tacStx
     if remainingGoals.isEmpty then
       return some []
     else

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,5 +1,5 @@
 #include "util/options.h"
-
+// CI: please update-stage0
 namespace lean {
 options get_default_options() {
     options opts;

--- a/tests/lean/claudeTemplateTest.lean
+++ b/tests/lean/claudeTemplateTest.lean
@@ -1,0 +1,18 @@
+/-
+Test that the claude tactic works with template variable extraction.
+-/
+import Lean -- remove after update-stage0
+
+-- Use mock to avoid actually calling Claude
+set_option tactic.claude.mock "{\"tactics\": [\"rfl\"]}"
+
+-- Enable prompt tracing to verify template variables
+set_option trace.claude.prompt true
+
+-- A helper definition to test file context capture
+def helper : Nat := 42
+
+-- Test that claude tactic runs and extracts context
+theorem myTheorem (n : Nat) : n = n := by
+  claude
+  rfl

--- a/tests/lean/claudeTemplateTest.lean
+++ b/tests/lean/claudeTemplateTest.lean
@@ -1,10 +1,11 @@
 /-
-Test that the claude tactic works with template variable extraction.
+Test that the claude tactic works with template variable extraction,
+including tactic steps before the claude call.
 -/
 import Lean -- remove after update-stage0
 
 -- Use mock to avoid actually calling Claude
-set_option tactic.claude.mock "{\"tactics\": [\"rfl\"]}"
+set_option tactic.claude.mock "{\"tactics\": [\"omega\"]}"
 
 -- Enable prompt tracing to verify template variables
 set_option trace.claude.prompt true
@@ -12,7 +13,8 @@ set_option trace.claude.prompt true
 -- A helper definition to test file context capture
 def helper : Nat := 42
 
--- Test that claude tactic runs and extracts context
-theorem myTheorem (n : Nat) : n = n := by
+-- Test that claude tactic includes prior tactic steps in the declaration
+theorem myTheorem (n m : Nat) : n + m = m + n := by
+  have h : n = n := rfl
   claude
-  rfl
+  omega

--- a/tests/lean/claudeTemplateTest.lean.expected.out
+++ b/tests/lean/claudeTemplateTest.lean.expected.out
@@ -1,15 +1,16 @@
 Claude prompt:
-You are a Lean 4 proof assistant. Given the current proof goal, suggest tactics that could help make progress.
+You are a Lean 4 proof assistant. Your task is to suggest tactics to replace the `sorry` placeholder in the proof below.
 
 File context (preceding the current declaration):
 ```lean
 /-
-Test that the claude tactic works with template variable extraction.
+Test that the claude tactic works with template variable extraction,
+including tactic steps before the claude call.
 -/
 import Lean -- remove after update-stage0
 
 -- Use mock to avoid actually calling Claude
-set_option tactic.claude.mock "{\"tactics\": [\"rfl\"]}"
+set_option tactic.claude.mock "{\"tactics\": [\"omega\"]}"
 
 -- Enable prompt tracing to verify template variables
 set_option trace.claude.prompt true
@@ -17,29 +18,31 @@ set_option trace.claude.prompt true
 -- A helper definition to test file context capture
 def helper : Nat := 42
 
--- Test that claude tactic runs and extracts context
+-- Test that claude tactic includes prior tactic steps in the declaration
 ```
 
-Declaration being proven:
+Declaration with proof so far (replace the sorry):
 ```lean
-theorem myTheorem (n : Nat) : n = n := by
-  
+theorem myTheorem (n m : Nat) : n + m = m + n := by
+  have h : n = n := rfl
+  sorry
 ```
 
-Current goal:
+Current goal at sorry:
 ```lean
-n : Nat
-⊢ n = n
+n m : Nat
+h : n = n
+⊢ n + m = m + n
 ```
 
 Provide your response as ONLY the raw JSON, with no explanation, no markdown code fences, no backticks:
 {"tactics": ["tactic1", "tactic2", "tactic3"]}
 
 Requirements:
-- Suggest 1-5 tactics, ordered by likelihood of success
+- Suggest 1-5 tactics to replace the sorry, ordered by likelihood of success
 - Each tactic must be valid Lean 4 syntax
 - Tactics should be concrete and actionable
 - Prefer simpler tactics when applicable
 - You may include newlines in a tactic string for multi-step sequences (e.g., "intro x\napply foo")
 Try this:
-  [apply] rfl
+  [apply] omega

--- a/tests/lean/claudeTemplateTest.lean.expected.out
+++ b/tests/lean/claudeTemplateTest.lean.expected.out
@@ -1,0 +1,45 @@
+Claude prompt:
+You are a Lean 4 proof assistant. Given the current proof goal, suggest tactics that could help make progress.
+
+File context (preceding the current declaration):
+```lean
+/-
+Test that the claude tactic works with template variable extraction.
+-/
+import Lean -- remove after update-stage0
+
+-- Use mock to avoid actually calling Claude
+set_option tactic.claude.mock "{\"tactics\": [\"rfl\"]}"
+
+-- Enable prompt tracing to verify template variables
+set_option trace.claude.prompt true
+
+-- A helper definition to test file context capture
+def helper : Nat := 42
+
+-- Test that claude tactic runs and extracts context
+```
+
+Declaration being proven:
+```lean
+theorem myTheorem (n : Nat) : n = n := by
+  
+```
+
+Current goal:
+```lean
+n : Nat
+⊢ n = n
+```
+
+Provide your response as ONLY the raw JSON, with no explanation, no markdown code fences, no backticks:
+{"tactics": ["tactic1", "tactic2", "tactic3"]}
+
+Requirements:
+- Suggest 1-5 tactics, ordered by likelihood of success
+- Each tactic must be valid Lean 4 syntax
+- Tactics should be concrete and actionable
+- Prefer simpler tactics when applicable
+- You may include newlines in a tactic string for multi-step sequences (e.g., "intro x\napply foo")
+Try this:
+  [apply] rfl

--- a/tests/lean/run/claudeAPITest.lean
+++ b/tests/lean/run/claudeAPITest.lean
@@ -10,7 +10,7 @@ To run this test manually:
 2. Set the environment variables:
    ```bash
    export ANTHROPIC_API_KEY="your-api-key-here"
-   export ENABLE_LEAN_CLAUDE_API=true
+   export LEAN_CLAUDE_API=true
    ```
 3. Uncomment the test code below
 4. Run with:
@@ -20,7 +20,7 @@ To run this test manually:
    ```
    Or from the lean4 root:
    ```bash
-   ANTHROPIC_API_KEY="..." ENABLE_LEAN_CLAUDE_API=true \
+   ANTHROPIC_API_KEY="..." LEAN_CLAUDE_API=true \
      build/release/stage1/bin/lean --root=. -Dlinter.all=false \
      tests/lean/run/claudeAPITest.lean
    ```

--- a/tests/lean/run/claudeAPITest.lean
+++ b/tests/lean/run/claudeAPITest.lean
@@ -1,0 +1,72 @@
+/-
+Manual test for the claude tactic with Anthropic API
+
+This file is commented out because it requires an Anthropic API key
+which won't be available in CI.
+
+To run this test manually:
+
+1. Get an API key from https://console.anthropic.com/
+2. Set the environment variables:
+   ```bash
+   export ANTHROPIC_API_KEY="your-api-key-here"
+   export ENABLE_LEAN_CLAUDE_API=true
+   ```
+3. Uncomment the test code below
+4. Run with:
+   ```bash
+   cd tests/lean/run
+   lake env lean --run claudeAPITest.lean
+   ```
+   Or from the lean4 root:
+   ```bash
+   ANTHROPIC_API_KEY="..." ENABLE_LEAN_CLAUDE_API=true \
+     build/release/stage1/bin/lean --root=. -Dlinter.all=false \
+     tests/lean/run/claudeAPITest.lean
+   ```
+
+Expected behavior:
+- Claude will suggest tactics like `rfl`, `decide`, `simp` for simple goals
+- You should see "Try these:" suggestions with working tactics
+- The tactic prints token usage: "API usage: N input tokens, M output tokens"
+
+You can also test with different models:
+```lean
+set_option tactic.claude.model "claude-sonnet-4-20250514"  -- Default, fast
+set_option tactic.claude.model "claude-opus-4-20250514"    -- Most capable
+```
+
+And enable prompt tracing:
+```lean
+set_option trace.claude.prompt true
+```
+-/
+
+module
+public import Lean -- remove after update-stage0
+
+/-
+-- Simple test: prove 2 + 2 = 4 (uses default Sonnet 4)
+example : 2 + 2 = 4 := by
+  claude
+  sorry
+
+-- Test with a slightly harder proof
+example (x : Nat) : x + 0 = x := by
+  claude
+  sorry
+
+-- Test with Opus 4 for more capability
+set_option tactic.claude.model "claude-opus-4-20250514"
+
+example (n : Nat) : n = n := by
+  claude
+  sorry
+
+-- Test with prompt tracing
+set_option trace.claude.prompt true
+
+example : True := by
+  claude
+  sorry
+-/

--- a/tests/lean/run/claudeCodeTest.lean
+++ b/tests/lean/run/claudeCodeTest.lean
@@ -1,0 +1,45 @@
+/-
+Manual test for the claude tactic with real Claude Code CLI
+
+This file is commented out because it requires the Claude Code CLI to be available
+and the environment variable to be set, which won't be true in CI.
+
+To run this test manually:
+
+1. Ensure you have Claude Code CLI installed and in your PATH
+2. Set the environment variable:
+   ```bash
+   export ENABLE_LEAN_CLAUDE_CODE=true
+   ```
+3. Uncomment the test code below
+4. Run with:
+   ```bash
+   cd tests/lean/run
+   lake env lean --run claudeCodeTest.lean
+   ```
+   Or from the lean4 root:
+   ```bash
+   ENABLE_LEAN_CLAUDE_CODE=true build/release/stage1/bin/lean \
+     --root=. -Dlinter.all=false tests/lean/run/claudeCodeTest.lean
+   ```
+
+Expected behavior:
+- Claude will suggest tactics like `rfl`, `decide`, `simp` for simple goals
+- You should see "Try these:" suggestions with working tactics
+- The tactic prints "Run /usage in Claude Code to check usage"
+-/
+
+module
+public import Lean -- remove after update-stage0
+
+/-
+-- Simple test: prove 2 + 2 = 4
+example : 2 + 2 = 4 := by
+  claude
+  sorry  -- We'll see what Claude suggests
+
+-- Test with a slightly harder proof
+example (x : Nat) : x + 0 = x := by
+  claude
+  sorry
+-/

--- a/tests/lean/run/claudeCodeTest.lean
+++ b/tests/lean/run/claudeCodeTest.lean
@@ -9,7 +9,7 @@ To run this test manually:
 1. Ensure you have Claude Code CLI installed and in your PATH
 2. Set the environment variable:
    ```bash
-   export ENABLE_LEAN_CLAUDE_CODE=true
+   export LEAN_CLAUDE_CODE=true
    ```
 3. Uncomment the test code below
 4. Run with:
@@ -19,7 +19,7 @@ To run this test manually:
    ```
    Or from the lean4 root:
    ```bash
-   ENABLE_LEAN_CLAUDE_CODE=true build/release/stage1/bin/lean \
+   LEAN_CLAUDE_CODE=true build/release/stage1/bin/lean \
      --root=. -Dlinter.all=false tests/lean/run/claudeCodeTest.lean
    ```
 

--- a/tests/lean/run/claudeTactic.lean
+++ b/tests/lean/run/claudeTactic.lean
@@ -253,3 +253,87 @@ error: unsolved goals
 #guard_msgs in
 example : True := by
   claude
+
+-- Test 19: Optional string argument with period
+set_option tactic.claude.mock "{\"tactics\": [\"trivial\"]}"
+
+/--
+info: Try this:
+  [apply] trivial
+---
+error: unsolved goals
+⊢ True
+-/
+#guard_msgs in
+example : True := by
+  claude "Use trivial here."
+
+-- Test 20: Optional string argument with exclamation mark
+set_option tactic.claude.mock "{\"tactics\": [\"rfl\"]}"
+
+/--
+info: Try this:
+  [apply] rfl
+---
+error: unsolved goals
+⊢ 1 = 1
+-/
+#guard_msgs in
+example : 1 = 1 := by
+  claude "This should be reflexivity!"
+
+-- Test 21: Optional string argument with question mark
+set_option tactic.claude.mock "{\"tactics\": [\"simp\"]}"
+
+/--
+info: Try this:
+  [apply] simp
+---
+error: unsolved goals
+n : Nat
+⊢ n + 0 = n
+-/
+#guard_msgs in
+example (n : Nat) : n + 0 = n := by
+  claude "Can you simplify this?"
+
+-- Test 22: Missing punctuation - should warn and skip
+set_option tactic.claude.mock "{\"tactics\": [\"trivial\"]}"
+
+/--
+warning: Instruction should end with punctuation (., !, or ?). Skipping Claude query.
+---
+error: unsolved goals
+⊢ True
+-/
+#guard_msgs in
+example : True := by
+  claude "No punctuation here"
+
+-- Test 23: Empty string - should proceed normally (no instruction appended)
+set_option tactic.claude.mock "{\"tactics\": [\"trivial\"]}"
+
+/--
+info: Try this:
+  [apply] trivial
+---
+error: unsolved goals
+⊢ True
+-/
+#guard_msgs in
+example : True := by
+  claude ""
+
+-- Test 24: Whitespace-only string - should proceed normally
+set_option tactic.claude.mock "{\"tactics\": [\"rfl\"]}"
+
+/--
+info: Try this:
+  [apply] rfl
+---
+error: unsolved goals
+⊢ 2 = 2
+-/
+#guard_msgs in
+example : 2 = 2 := by
+  claude "   "

--- a/tests/lean/run/claudeTactic.lean
+++ b/tests/lean/run/claudeTactic.lean
@@ -96,3 +96,20 @@ Response:
 #guard_msgs in
 example : True := by
   claude
+
+-- Test 8: Multi-line tactic sequence (newline-separated tactics)
+-- This tests that "have h : Nat := 1\nomega" is correctly parsed as two tactics
+set_option tactic.claude.mock "{\"tactics\": [\"have h : Nat := 1\\nomega\"]}"
+
+/--
+info: Try this:
+  [apply] have h : Nat := 1
+  omega
+---
+error: unsolved goals
+n : Nat
+⊢ n + 1 > n
+-/
+#guard_msgs in
+example (n : Nat) : n + 1 > n := by
+  claude

--- a/tests/lean/run/claudeTactic.lean
+++ b/tests/lean/run/claudeTactic.lean
@@ -1,0 +1,98 @@
+/-
+Tests for the `claude` tactic
+-/
+module
+public import Lean -- remove after update-stage0
+
+-- Test 1: Mock response - tactic that solves goal
+set_option tactic.claude.mock "{\"tactics\": [\"rfl\"]}"
+
+/--
+info: Try this:
+  [apply] rfl
+---
+error: unsolved goals
+⊢ 2 + 2 = 4
+-/
+#guard_msgs in
+example : 2 + 2 = 4 := by
+  claude
+
+-- Test 2: Mock response - multiple tactics, some bad
+set_option tactic.claude.mock "{\"tactics\": [\"invalid_tactic\", \"trivial\", \"also_invalid\"]}"
+
+/--
+info: Try this:
+  [apply] trivial
+---
+error: unsolved goals
+⊢ True
+-/
+#guard_msgs in
+example : True := by
+  claude
+
+-- Test 3: Mock response - no working tactics
+set_option tactic.claude.mock "{\"tactics\": [\"bad_tactic1\", \"bad_tactic2\"]}"
+
+/--
+error: Claude suggested no working tactics
+-/
+#guard_msgs in
+example : True := by
+  claude
+
+-- Test 4: Mock response - multiple tactics (only one works)
+set_option tactic.claude.mock "{\"tactics\": [\"rfl\", \"trivial\"]}"
+
+/--
+info: Try this:
+  [apply] trivial
+---
+error: unsolved goals
+⊢ True
+-/
+#guard_msgs in
+example : True := by
+  claude  -- rfl doesn't work on True, only trivial does
+
+-- Test 5: Test with actual proof
+set_option tactic.claude.mock "{\"tactics\": [\"simp\"]}"
+
+/--
+info: Try this:
+  [apply] simp
+---
+error: unsolved goals
+x : Nat
+⊢ x + 0 = x
+-/
+#guard_msgs in
+example (x : Nat) : x + 0 = x := by
+  claude
+
+-- Test 6: JSON parse error
+set_option tactic.claude.mock "not valid json"
+
+/--
+error: Failed to parse Claude response: offset 0: expected: null
+
+Response:
+not valid json
+-/
+#guard_msgs in
+example : True := by
+  claude
+
+-- Test 7: Wrong JSON format
+set_option tactic.claude.mock "{\"wrong_field\": [\"rfl\"]}"
+
+/--
+error: Failed to parse Claude response: property not found: tactics
+
+Response:
+{"wrong_field": ["rfl"]}
+-/
+#guard_msgs in
+example : True := by
+  claude

--- a/tests/lean/run/claudeTactic.lean
+++ b/tests/lean/run/claudeTactic.lean
@@ -238,3 +238,18 @@ error: unsolved goals
 #guard_msgs in
 example : 1 = 1 := by
   claude
+
+-- Test 18: JSON with braces inside tactic strings (tests extractJsonObject)
+-- The tactic contains `}` which should not break JSON extraction
+set_option tactic.claude.mock "{\"tactics\": [\"sorry } this has braces { inside\", \"trivial\"]}"
+
+/--
+info: Try this:
+  [apply] trivial
+---
+error: unsolved goals
+⊢ True
+-/
+#guard_msgs in
+example : True := by
+  claude


### PR DESCRIPTION
This PR adds a `claude` tactic that calls Claude AI to suggest tactics for the current goal.

**The tactic is inactive by default.** It requires explicit activation via environment variables:

- **API backend**: Set `ANTHROPIC_API_KEY` and `LEAN_CLAUDE_API=true`
- **CLI backend**: Set `LEAN_CLAUDE_CODE=true` (requires Claude Code CLI installed)

Without these environment variables, the tactic will error with a message explaining how to activate it. This ensures no unexpected network calls or API usage.

## Features

- Analyzes the current goal, declaration context, and file content
- Sends a prompt to Claude asking for tactic suggestions
- Tests each suggested tactic for validity before presenting it
- Shows "Try this:" suggestions using the standard `TryThis` API
- Supports custom prompt templates via `set_option tactic.claude.template`
- Configurable model via `set_option tactic.claude.model`

## Usage Notes

This tactic is primarily intended for automation (e.g., as a fallback in `try?`). For interactive proof development, running a Claude Code session alongside your editor provides a more effective workflow with full conversation context.

🤖 Prepared with Claude Code