### PR TITLE
perf: JsonNumber comparison no longer eagerly aligns mantissa

### DIFF
--- a/src/Lean/Data/Json/Basic.lean
+++ b/src/Lean/Data/Json/Basic.lean
@@ -72,17 +72,18 @@ def lt (a b : JsonNumber) : Bool :=
         ((bm, be), (am, ae))
       else
         ((am, ae), (bm, be))
-    let amDigits := countDigits am
-    let bmDigits := countDigits bm
-    -- align the mantissas
-    let (am, bm) :=
-      if amDigits < bmDigits then
-        (am * 10^(bmDigits - amDigits), bm)
-      else
-        (am, bm * 10^(amDigits - bmDigits))
     if ae < be then true
     else if ae > be then false
-    else am < bm
+    else
+      -- align the mantissas
+      let amDigits := countDigits am
+      let bmDigits := countDigits bm
+      let (am, bm) :=
+        if amDigits < bmDigits then
+          (am * 10^(bmDigits - amDigits), bm)
+        else
+          (am, bm * 10^(amDigits - bmDigits))
+      am < bm
 
 instance ltProp : LT JsonNumber :=
   ⟨fun a b => lt a b = true⟩


### PR DESCRIPTION
I noticed this when reading the code, not when running it, so it's possible the compiler is already smart enough to perform this optimization, and probably this is not much of a bottleneck in practice.

