### PR TITLE
fix: grind using congr equation of private imported matcher

### DIFF
--- a/src/Lean/Meta/Match/MatchEqs.lean
+++ b/src/Lean/Meta/Match/MatchEqs.lean
@@ -269,7 +269,11 @@ not always needed, so for now we live with the code duplication.
 -/
 @[export lean_get_congr_match_equations_for]
 def genMatchCongrEqnsImpl (matchDeclName : Name) : MetaM (Array Name) := do
-  let baseName := mkPrivateName (← getEnv) matchDeclName
+  let env ← getEnv
+  -- Preserve existing private prefix if any so that we can find `matchDeclName` again purely by
+  -- looking at an equation name. As realizable constants should behave as if they were defined in
+  -- the original module, this is fine here.
+  let baseName := if isPrivateName matchDeclName then matchDeclName else mkPrivateName env matchDeclName
   let firstEqnName := .str baseName congrEqn1ThmSuffix
   realizeConst matchDeclName firstEqnName (go baseName)
   return matchCongrEqnsExt.getState (asyncMode := .async .asyncEnv) (asyncDecl := firstEqnName) (← getEnv) |>.find! matchDeclName

--- a/tests/pkg/module/Module/Basic.lean
+++ b/tests/pkg/module/Module/Basic.lean
@@ -544,3 +544,13 @@ Eq.refl five
 -/
 #guard_msgs in
 #print instA._proof_1
+
+/-- Setup for #11715. -/
+
+public structure OpOperand2 where
+  nextUse : Option Nat
+
+public def func (ctx : Nat) (operand : OpOperand2) : Nat :=
+  match operand.nextUse with
+  | none => ctx
+  | some nextPtr => ctx

--- a/tests/pkg/module/Module/ImportedAll.lean
+++ b/tests/pkg/module/Module/ImportedAll.lean
@@ -2,7 +2,7 @@ module
 
 public import Module.Basic
 import all Module.Basic
-import Lean.CoreM
+import Lean
 
 /-! `import all` should import private information, privately. -/
 
@@ -160,3 +160,9 @@ error: Invalid `⟨...⟩` notation: Constructor for `StructWithPrivateField` is
 #guard_msgs in
 #with_exporting
 #check (⟨1⟩ : StructWithPrivateField)
+
+/-! #11715: `grind` should not fail to apply private matcher from imported module. -/
+
+attribute [local grind] func in
+theorem stmt1 : func ctx op = ctx := by
+  grind


### PR DESCRIPTION
This PR fixes an issue where `grind` fails when trying to unfold a definition by pattern matching imported by `import all` (or from a non-`module`).

Fixes #11715