### PR TITLE
fix: allow `exact?` to suggest local private declarations (part 2)

### DIFF
--- a/tests/lean/run/exact_private.lean
+++ b/tests/lean/run/exact_private.lean
@@ -3,10 +3,17 @@ module
 /-!
 # Tests for `exact?` with private declarations
 
-This tests that `exact?` can suggest private theorems defined locally in the same module.
+This tests that `exact?` can suggest private theorems.
+
+## Accessibility rules for private declarations in `exact?`:
+- Local private declarations (defined in current file/module): always suggested
+- Imported private declarations:
+  - In module system with `import all`: suggested
+  - In module system without `import all`: not suggested
+  - Outside module system: not suggested
 -/
 
--- Test that exact? suggests private declarations
+-- Test that exact? suggests local private declarations
 axiom P : Prop
 private axiom p : P
 


### PR DESCRIPTION
This PR contains changes that were meant to be part of #11736, but I accidentally merged without pushing my final local changes.