### PR TITLE
fix: add missing `.ofNat`s in `lake translate-config`

### DIFF
--- a/src/lake/Lake/CLI/Translate/Lean.lean
+++ b/src/lake/Lake/CLI/Translate/Lean.lean
@@ -141,7 +141,7 @@ instance : ToLean Backend := ⟨Backend.toLean⟩
 def quoteLeanOptionValue : LeanOptionValue → Term
 | .ofString v => toLean v
 | .ofBool v => toLean v
-| .ofNat v => toLean v
+| .ofNat v => Unhygienic.run `(.ofNat $(toLean v))
 
 instance : ToLean LeanOptionValue := ⟨quoteLeanOptionValue⟩
 


### PR DESCRIPTION
This PR prevents the output of `lake translate-config`, on numeric options, complaining with
```
failed to synthesize
  OfNat Lean.LeanOptionValue 3
```

The alternative would be to add the missing instance.