### PR TITLE
fix: implemented_by Array.foldlM behavior when stop > start

### DIFF
--- a/src/Init/Data/ByteArray/Basic.lean
+++ b/src/Init/Data/ByteArray/Basic.lean
@@ -270,7 +270,7 @@ unsafe def foldlMUnsafe {β : Type v} {m : Type v → Type w} [Monad m] (f : β 
     if stop ≤ as.size then
       fold (USize.ofNat start) (USize.ofNat stop) init
     else
-      pure init
+      fold (USize.ofNat start) (USize.ofNat as.size) init
   else
     pure init
 

--- a/src/Init/Data/FloatArray/Basic.lean
+++ b/src/Init/Data/FloatArray/Basic.lean
@@ -145,7 +145,7 @@ unsafe def foldlMUnsafe {β : Type v} {m : Type v → Type w} [Monad m] (f : β 
     if stop ≤ as.size then
       fold (USize.ofNat start) (USize.ofNat stop) init
     else
-      pure init
+      fold (USize.ofNat start) (USize.ofNat as.size) init
   else
     pure init
 

--- a/tests/lean/run/11773.lean
+++ b/tests/lean/run/11773.lean
@@ -1,0 +1,29 @@
+/-! This is a regression test for an issue with the implemented_by of Array.foldlM -/
+
+/--
+error: Tactic `native_decide` evaluated that the proposition
+  foldl (fun x1 x2 => x1 + x2) 0 #[1, 2, 3] 0 5 = 0
+is false
+-/
+#guard_msgs in
+theorem Array.foldl_broken : False := by
+  let x := #[1,2,3].foldl (. + .) 0 (stop := 5)
+  have : x = 6 := by rfl
+  have : x = 0 := by native_decide
+  contradiction
+
+example : #[1,2,3].foldl (. + .) 0 (stop := 5) = 6 := by native_decide
+
+/--
+error: Tactic `native_decide` evaluated that the proposition
+  foldl (fun x1 x2 => x1 + x2) 0 { data := #[1, 2, 3] } 0 5 = 0
+is false
+-/
+#guard_msgs in
+theorem ByteArray.foldl_broken : False := by
+  let x := (ByteArray.mk #[1,2,3]).foldl (. + .) 0 (stop := 5)
+  have : x = 6 := by rfl
+  have : x = 0 := by native_decide
+  grind
+
+example : (ByteArray.mk #[1,2,3]).foldl (. + .) 0 (stop := 5) = 6 := by native_decide


### PR DESCRIPTION
This PR fixes a mismatch between the behavior of `foldlM` and `foldlMUnsafe` in the three array
types. This mismatch is only exposed when manually specifying a `stop` value greater than the size
of the array and only exploitable through `native_decide`.

The mismatch was introduced as part of 4ba21ea10c63ca3b97563a5916309bd92418d7be which introduced
`foldlMUnsafe` and thus likely a mistake when building the `unsafe` implementation instead of a
specification mistake.

Closes #11773
