### PR TITLE
feat: add `[grind norm]` and `[grind unfold]` attributes

### DIFF
--- a/src/Init/Grind/Attr.lean
+++ b/src/Init/Grind/Attr.lean
@@ -198,6 +198,55 @@ Given an application `f a₁ a₂ … aₙ`, when `funCC := true`,
 -/
 syntax grindFunCC  := &"funCC"
 /--
+The `norm` modifier instructs `grind` to use a theorem as a normalization rule. That is,
+the theorem is applied during the preprocessing step.
+This feature is meant for advanced users who understand how the preprocessor and `grind`'s search
+procedure interact with each other.
+New users can still benefit from this feature by restricting its use to theorems that completely
+eliminate a symbol from the goal. Example:
+```
+theorem max_def : max n m = if n ≤ m then m else n
+```
+For a negative example, consider:
+```
+opaque f : Int → Int → Int → Int
+theorem fax1 : f x 0 1 = 1 := sorry
+theorem fax2 : f 1 x 1 = 1 := sorry
+attribute [grind norm] fax1
+attribute [grind =] fax2
+
+example (h : c = 1) : f c 0 c = 1 := by
+  grind -- fails
+```
+In this example, `fax1` is a normalization rule, but it is not applicable to the input goal since
+`f c 0 c` is not an instance of `f x 0 1`. However, `f c 0 c` matches the pattern `f 1 x 1` modulo
+the equality `c = 1`. Thus, `grind` instantiates `fax2` with `x := 0`, producing the equality
+`f 1 0 1 = 1`, which the normalizer simplifies to `True`. As a result, nothing useful is learned.
+In the future, we plan to include linters to automatically detect issues like these.
+Example:
+```
+opaque f : Nat → Nat
+opaque g : Nat → Nat
+
+@[grind norm] axiom fax : f x = x + 2
+@[grind norm ←] axiom fg : f x = g x
+
+example : f x ≥ 2 := by grind
+example : f x ≥ g x := by grind
+example : f x + g x ≥ 4 := by grind
+```
+-/
+syntax grindNorm  := &"norm" (Tactic.simpPre <|> Tactic.simpPost)? patternIgnore("← " <|> "<- ")?
+/--
+The `unfold` modifier instructs `grind` to unfold the given definition during the preprocessing step.
+Example:
+```
+@[grind unfold] def h (x : Nat) := 2 * x
+example : 6 ∣ 3*h x := by grind
+```
+-/
+syntax grindUnfold := &"unfold"
+/--
 `symbol <prio>` sets the priority of a constant for `grind`’s pattern-selection
 procedure. `grind` prefers patterns that contain higher-priority symbols.
 Example:
@@ -224,7 +273,7 @@ syntax grindMod :=
     grindEqBoth <|> grindEqRhs <|> grindEq <|> grindEqBwd <|> grindBwd
     <|> grindFwd <|> grindRL <|> grindLR <|> grindUsr <|> grindCasesEager
     <|> grindCases <|> grindIntro <|> grindExt <|> grindGen <|> grindSym <|> grindInj
-    <|> grindFunCC <|> grindDef
+    <|> grindFunCC <|> grindNorm <|> grindUnfold <|> grindDef
 
 /--
 Marks a theorem or definition for use by the `grind` tactic.

--- a/src/Lean/Elab/Tactic/Grind/BuiltinTactic.lean
+++ b/src/Lean/Elab/Tactic/Grind/BuiltinTactic.lean
@@ -245,7 +245,7 @@ where
         elabEMatchTheorem declName (.default false) minIndexable
       else
         return thms.toArray
-    | .cases _ | .intro | .inj | .ext | .symbol _ | .funCC =>
+    | .cases _ | .intro | .inj | .ext | .symbol _ | .funCC | .norm .. | .unfold =>
       throwError "invalid modifier"
 
 def logAnchor (c : SplitInfo) : TermElabM Unit := do

--- a/src/Lean/Elab/Tactic/Grind/Param.lean
+++ b/src/Lean/Elab/Tactic/Grind/Param.lean
@@ -151,7 +151,7 @@ def processTermParam (params : Grind.Params)
   checkNoRevert params
   let kind ← if let some mod := mod? then Grind.getAttrKindCore mod else pure .infer
   let kind ← match kind with
-    | .ematch .user | .cases _ | .intro | .inj | .ext | .symbol _ | .funCC =>
+    | .ematch .user | .cases _ | .intro | .inj | .ext | .symbol _ | .funCC | .norm .. | .unfold =>
       throwError "invalid `grind` parameter, only global declarations are allowed with this kind of modifier"
     | .ematch kind => pure kind
     | .infer => pure <| .default false
@@ -266,6 +266,8 @@ def processParam (params : Grind.Params)
     params := { params with symPrios := params.symPrios.insert declName prio }
   | .funCC =>
     params := params.insertFunCC declName
+  | .norm .. => throwError "normalization theorems should be registered using the `@[grind norm]` attribute"
+  | .unfold => throwError "declarations to be unfolded during normalization should be registered using the `@[grind unfold]` attribute"
   return params
 
 /--

--- a/src/Lean/Meta/Tactic/Grind/SimpUtil.lean
+++ b/src/Lean/Meta/Tactic/Grind/SimpUtil.lean
@@ -18,11 +18,6 @@ import Init.Grind.Norm
 public section
 namespace Lean.Meta.Grind
 
-/-
-TODO: group into a `grind` extension object
--/
-builtin_initialize normExt : SimpExtension ← mkSimpExt
-
 def registerNormTheorems (preDeclNames : Array Name) (postDeclNames : Array Name) : MetaM Unit := do
   let thms ← normExt.getTheorems
   unless thms.lemmaNames.isEmpty do

--- a/tests/lean/run/grind_norm.lean
+++ b/tests/lean/run/grind_norm.lean
@@ -1,0 +1,13 @@
+opaque f : Nat → Nat
+opaque g : Nat → Nat
+
+@[grind norm] axiom fax : f x = x + 2
+@[grind norm ←] axiom fg : f x = g x
+
+example : f x ≥ 2 := by grind
+example : f x ≥ g x := by grind
+example : f x + g x ≥ 4 := by grind
+
+@[grind unfold] def h (x : Nat) := 2 * x
+
+example : 2 ∣ h x := by grind


### PR DESCRIPTION
This PR adds the attributes `[grind norm]` and `[grind unfold]` for controlling the `grind` normalizer/preprocessor.

The `norm` modifier instructs `grind` to use a theorem as a normalization rule. That is, the theorem is applied during the preprocessing step. This feature is meant for advanced users who understand how the preprocessor and `grind`'s search procedure interact with each other.
New users can still benefit from this feature by restricting its use to theorems that completely eliminate a symbol from the goal. Example:
```lean
theorem max_def : max n m = if n ≤ m then m else n
```
For a negative example, consider:
```lean
opaque f : Int → Int → Int → Int
theorem fax1 : f x 0 1 = 1 := sorry
theorem fax2 : f 1 x 1 = 1 := sorry
attribute [grind norm] fax1
attribute [grind =] fax2

example (h : c = 1) : f c 0 c = 1 := by
  grind -- fails
```
In this example, `fax1` is a normalization rule, but it is not applicable to the input goal since `f c 0 c` is not an instance of `f x 0 1`. However, `f c 0 c` matches the pattern `f 1 x 1` modulo the equality `c = 1`. Thus, `grind` instantiates `fax2` with `x := 0`, producing the equality `f 1 0 1 = 1`, which the normalizer simplifies to `True`. As a result, nothing useful is learned. In the future, we plan to include linters to automatically detect issues like these. Example:
```lean
opaque f : Nat → Nat
opaque g : Nat → Nat

@[grind norm] axiom fax : f x = x + 2
@[grind norm ←] axiom fg : f x = g x

example : f x ≥ 2 := by grind
example : f x ≥ g x := by grind
example : f x + g x ≥ 4 := by grind
```

The `unfold` modifier instructs `grind` to unfold the given definition during the preprocessing step. Example:
```lean
@[grind unfold] def h (x : Nat) := 2 * x
example : 6 ∣ 3*h x := by grind
```
