### PR TITLE
fix: pretty-printing of unification hints

### DIFF
--- a/src/Init/NotationExtra.lean
+++ b/src/Init/NotationExtra.lean
@@ -67,7 +67,7 @@ syntax unifConstraint := term patternIgnore(" =?= " <|> " ≟ ") term
 syntax unifConstraintElem := colGe unifConstraint ", "?
 
 syntax (docComment)? attrKind "unif_hint" (ppSpace ident)? (ppSpace bracketedBinder)*
-  " where " withPosition(unifConstraintElem*) patternIgnore(atomic("|" noWs "-") <|> "⊢") unifConstraint : command
+  " where " withPosition(unifConstraintElem*) patternIgnore(atomic("|" noWs "-") <|> "⊢") ppSpace unifConstraint : command
 
 macro_rules
   | `($[$doc?:docComment]? $kind:attrKind unif_hint $(n)? $bs* where $[$cs₁ ≟ $cs₂]* |- $t₁ ≟ $t₂) => do


### PR DESCRIPTION
This PR ensures that pretty-printing of unification hints inserts a space after |- resp. ⊢.

All uses in Lean core and mathlib add a space after the |- or ⊢ symbol; this makes the output match usage in practice.
This was discovered in leanprover-community/mathlib4#30658, adding a formatting linter using pretty-printing as initial guide.
