### PR TITLE
perf: tune the behavior of and flattening in bv_decide

### DIFF
--- a/src/Lean/Elab/Tactic/BVDecide/Frontend/Normalize.lean
+++ b/src/Lean/Elab/Tactic/BVDecide/Frontend/Normalize.lean
@@ -40,7 +40,7 @@ def passPipeline : PreProcessM (List Pass) := do
   if cfg.acNf then
     passPipeline := passPipeline ++ [bvAcNormalizePass]
 
-  if cfg.andFlattening then
+  if cfg.embeddedConstraintSubst && cfg.andFlattening then
     passPipeline := passPipeline ++ [andFlatteningPass]
 
   if cfg.embeddedConstraintSubst then

--- a/src/Std/Tactic/BVDecide/Syntax.lean
+++ b/src/Std/Tactic/BVDecide/Syntax.lean
@@ -32,7 +32,9 @@ structure BVDecideConfig where
   acNf : Bool := false
   /--
   Split hypotheses of the form `h : (x && y) = true` into `h1 : x = true` and `h2 : y = true`.
-  This has synergy potential with embedded constraint substitution.
+  This has synergy potential with embedded constraint substitution. Because embedded constraint
+  subsitution is the only use case for this feature it is automatically disabled whenever embedded
+  constraint substitution is disabled.
   -/
   andFlattening : Bool := true
   /--


### PR DESCRIPTION
This PR improves the performance of and flattening in `bv_decide`.

The two main insights of this PR are:
1. When embedded constraint substitution is disabled it makes no sense to have and flattening on in
   the first place, given that we do not profit from it in any way.
2. The new fvars produced by and flattening can also be inserted into the rewriting caches of the
   preprocessing pipeline if the fvar they were derived from is already in the cache. This
   drastically decreases the amount of work we have to do in the second rewriting pass after running
   and flattening.
