### PR TITLE
chore: add `isDebugEnabled` to `grind`

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/AC/Eq.lean
+++ b/src/Lean/Meta/Tactic/Grind/AC/Eq.lean
@@ -228,7 +228,7 @@ private def EqCnstr.superposeWithAC (c₁ : EqCnstr) : ACM Unit := do
     if lhs₁.sharesVar lhs₂ then
       assert! lhs₁ != lhs₂
       let some (r₁, c, r₂) := lhs₁.superposeAC? lhs₂ | unreachable!
-      if grind.debug.get (← getOptions) then
+      if (← isDebugEnabled) then
         assert! lhs₁ == r₁.union c
         assert! lhs₂ == r₂.union c
       let c ← mkEqCnstr (c₁.rhs.union r₂) (c₂.rhs.union r₁) (.superpose_ac r₁ c r₂ c₁ c₂)
@@ -239,7 +239,7 @@ private def EqCnstr.superposeA (c₁ c₂ : EqCnstr) : ACM Unit := do
   let lhs₂ := c₂.lhs
   assert! lhs₁ != lhs₂
   if let some (p, c, s) := lhs₁.superpose? lhs₂ then
-    if grind.debug.get (← getOptions) then
+    if (← isDebugEnabled) then
       assert! lhs₁ == p ++ c
       assert! lhs₂ == c ++ s
     let c ← mkEqCnstr (c₁.rhs ++ s) (p ++ c₂.rhs) (.superpose p c s c₁ c₂)

--- a/src/Lean/Meta/Tactic/Grind/AC/Inv.lean
+++ b/src/Lean/Meta/Tactic/Grind/AC/Inv.lean
@@ -53,7 +53,7 @@ def checkStructInvs : ACM Unit := do
   checkDiseqs
 
 public def checkInvariants : GoalM Unit := do
-  unless grind.debug.get (← getOptions) do return ()
+  if (← isDebugEnabled) then
   for opId in *...(← get').structs.size do
     ACM.run opId checkStructInvs
 

--- a/src/Lean/Meta/Tactic/Grind/Arith/CommRing/Inv.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/CommRing/Inv.lean
@@ -49,7 +49,7 @@ private def checkRingInvs : RingM Unit := do
   checkDiseqs
 
 def checkInvariants : GoalM Unit := do
-  unless grind.debug.get (← getOptions) do return ()
+  if (← isDebugEnabled) then
   for ringId in *...(← get').rings.size do
     RingM.run ringId do
       assert! (← getRingId) == ringId

--- a/src/Lean/Meta/Tactic/Grind/Arith/Linear/Inv.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Linear/Inv.lean
@@ -97,7 +97,7 @@ def checkStructInvs : LinearM Unit := do
   checkDiseqCnstrs
 
 public def checkInvariants : GoalM Unit := do
-  unless grind.debug.get (← getOptions) do return ()
+  if (← isDebugEnabled) then
   for structId in *...(← get').structs.size do
     LinearM.run structId do
       assert! (← getStructId) == structId

--- a/src/Lean/Meta/Tactic/Grind/Inv.lean
+++ b/src/Lean/Meta/Tactic/Grind/Inv.lean
@@ -119,7 +119,7 @@ def checkProofs : GoalM Unit := do
 
 /-- Checks invariants if `grind.debug` is enabled. -/
 public def checkInvariants (expensive := false) : GoalM Unit := do
-  if grind.debug.get (← getOptions) then
+  if (← isDebugEnabled) then
     for e in (← getExprs) do
       let node ← getENode e
       checkParents node.self

--- a/src/Lean/Meta/Tactic/Grind/Main.lean
+++ b/src/Lean/Meta/Tactic/Grind/Main.lean
@@ -119,9 +119,11 @@ def GrindM.run (x : GrindM α) (params : Params) (evalTactic? : Option EvalTacti
   let symPrios := params.symPrios
   let extensions := params.extensions
   let anchorRefs? := params.anchorRefs?
+  let debug := grind.debug.get (← getOptions)
   x (← mkMethods evalTactic?).toMethodsRef
     { config, anchorRefs?, simpMethods, simp, extensions, symPrios
-      trueExpr, falseExpr, natZExpr, btrueExpr, bfalseExpr, ordEqExpr, intExpr }
+      trueExpr, falseExpr, natZExpr, btrueExpr, bfalseExpr, ordEqExpr, intExpr
+      debug }
     |>.run' { scState }
 
 private def mkCleanState (mvarId : MVarId) : GrindM Clean.State := mvarId.withContext do

--- a/src/Lean/Meta/Tactic/Grind/Order/Internalize.lean
+++ b/src/Lean/Meta/Tactic/Grind/Order/Internalize.lean
@@ -206,7 +206,7 @@ where
 def internalizeCnstr (e : Expr) (kind : CnstrKind) (lhs rhs : Expr) : OrderM Unit := do
   let some c ← mkCnstr? e kind lhs rhs | return ()
   trace[grind.order.internalize] "{c.u}, {c.v}, {c.k}"
-  if grind.debug.get (← getOptions) then
+  if (← isDebugEnabled) then
     if let some h := c.h? then check h
   let u ← mkNode c.u
   let v ← mkNode c.v


### PR DESCRIPTION
This PR adds `isDebugEnabled` for checking whether `grind.debug` is set to `true` when `grind` was initialized.
