### PR TITLE
fix: add mem_eraseDups lemma for List deduplication

### DIFF
--- a/src/Init/Data/List/Lemmas.lean
+++ b/src/Init/Data/List/Lemmas.lean
@@ -3641,7 +3641,7 @@ termination_by as.length
 
 /-- Loop invariant for `eraseDupsBy.loop`: membership in the result equals
 membership in the remaining list or the accumulator. -/
-theorem mem_eraseDupsBy_loop [BEq α] [LawfulBEq α] {a : α} {l acc : List α} :
+private theorem mem_eraseDupsBy_loop [BEq α] [LawfulBEq α] {a : α} {l acc : List α} :
     a ∈ eraseDupsBy.loop (· == ·) l acc ↔ a ∈ l ∨ a ∈ acc := by
   induction l generalizing acc with
   | nil => simp [eraseDupsBy.loop]


### PR DESCRIPTION
This PR proves that membership is preserved by eraseDups: an element exists in the deduplicated list iff it was in the original.

Includes a helper lemma for the loop invariant of eraseDupsBy.loop to establish the relationship between membership in the result, remaining list, and accumulator.

The proof changed compared to the proposal discussed on Zulip: https://leanprover.zulipchat.com/#narrow/channel/348111-batteries/topic/Where.20should.20List.2Emem_eraseDup.20and.20List.2Emem_eraseDups.20l.2E.2E.2E

Specifically, I could not apply @Rob23oba 's short proof suggestion because it is located in `src/Init/Data`, a context where the `grind` strategy is not yet available.

In the Zulip thread, there is a discussion about the similarities/differences between Lean's `List.eraseDups` and Batteries' `List.eraseDup`; whether it makes sense to keep both (perhaps with a suitable renaming of Batterie's definition) or deprecate one (if any, it would be Batteries' since it is currently unused whereas Lean's is used across the board in Lean, Batteries, and Mathlib). See the Batteries PR: https://github.com/leanprover-community/batteries/pull/1580

changelog-library

Closes https://github.com/leanprover/lean4/issues/11786

