### PR TITLE
feat: add `instantiateRevBetaS`

### DIFF
--- a/src/Lean/Meta/Sym/InstantiateS.lean
+++ b/src/Lean/Meta/Sym/InstantiateS.lean
@@ -9,15 +9,15 @@ public import Lean.Meta.Sym.SymM
 import Lean.Meta.Sym.ReplaceS
 import Lean.Meta.Sym.LooseBVarsS
 import Init.Grind
-public section
 namespace Lean.Meta.Sym
+open Grind
 
 /--
 Similar to `Lean.Expr.instantiateRevRange`.
 It assumes the input is maximally shared, and ensures the output is too.
 It assumes `beginIdx ≤ endIdx` and `endIdx ≤ subst.size`
 -/
-def instantiateRevRangeS (e : Expr) (beginIdx endIdx : Nat) (subst : Array Expr) : SymM Expr :=
+public def instantiateRevRangeS (e : Expr) (beginIdx endIdx : Nat) (subst : Array Expr) : SymM Expr :=
   if _ : beginIdx > endIdx then unreachable! else
   if _ : endIdx > subst.size then unreachable! else
   let s := beginIdx
@@ -31,7 +31,7 @@ def instantiateRevRangeS (e : Expr) (beginIdx endIdx : Nat) (subst : Array Expr)
           let v := subst[n - (idx - offset) - 1]
           liftLooseBVarsS' v 0 offset
         else
-          Grind.mkBVarS (idx - n)
+          mkBVarS (idx - n)
       else
         return some e
     | .lit _ | .mvar _ | .fvar _ | .const _ _ | .sort _ =>
@@ -46,7 +46,7 @@ def instantiateRevRangeS (e : Expr) (beginIdx endIdx : Nat) (subst : Array Expr)
 Similar to `Lean.Expr.instantiateRev`.
 It assumes the input is maximally shared, and ensures the output is too.
 -/
-@[inline] def instantiateRevS (e : Expr) (subst : Array Expr) : SymM Expr :=
+@[inline] public def instantiateRevS (e : Expr) (subst : Array Expr) : SymM Expr :=
   instantiateRevRangeS e 0 subst.size subst
 
 /--
@@ -54,12 +54,12 @@ Similar to `Lean.Expr.instantiateRange`.
 It assumes the input is maximally shared, and ensures the output is too.
 It assumes `beginIdx ≤ endIdx` and `endIdx ≤ subst.size`
 -/
-def instantiateRangeS (e : Expr) (beginIdx endIdx : Nat) (subst : Array Expr) : SymM Expr :=
+def instantiateRangeS' (e : Expr) (beginIdx endIdx : Nat) (subst : Array Expr) : AlphaShareBuilderM Expr :=
   if _ : beginIdx > endIdx then unreachable! else
   if _ : endIdx > subst.size then unreachable! else
   let s := beginIdx
   let n := endIdx - beginIdx
-  replaceS e fun e offset => do
+  replaceS' e fun e offset => do
     let s₁ := s + offset
     match e with
     | .bvar idx =>
@@ -79,11 +79,134 @@ def instantiateRangeS (e : Expr) (beginIdx endIdx : Nat) (subst : Array Expr) : 
       else
         return none
 
+def instantiateS' (e : Expr) (subst : Array Expr) : AlphaShareBuilderM Expr :=
+  instantiateRangeS' e 0 subst.size subst
+
 /--
 Similar to `Lean.Expr.instantiate`.
 It assumes the input is maximally shared, and ensures the output is too.
 -/
-def instantiateS (e : Expr) (subst : Array Expr) : SymM Expr :=
-  instantiateRangeS e 0 subst.size subst
+public def instantiateS  (e : Expr) (subst : Array Expr) : SymM Expr :=
+  liftBuilderM <| instantiateS' e subst
+
+/-- `mkAppRevRangeS f b e args == mkAppRev f (revArgs.extract b e)` -/
+def mkAppRevRangeS (f : Expr) (beginIdx endIdx : Nat) (revArgs : Array Expr) : AlphaShareBuilderM Expr :=
+  loop revArgs beginIdx f endIdx
+where
+  loop (revArgs : Array Expr) (start : Nat) (b : Expr) (i : Nat) : AlphaShareBuilderM Expr := do
+  if i ≤ start then
+    return b
+  else
+    let i := i - 1
+    loop revArgs start (← mkAppS b revArgs[i]!) i
+
+/--
+Similar to `betaRev`, but ensures maximally shared terms.
+-/
+partial def betaRevS (f : Expr) (revArgs : Array Expr) : AlphaShareBuilderM Expr :=
+  if revArgs.size == 0 then
+    return f
+  else
+    let sz := revArgs.size
+    let rec go (e : Expr) (i : Nat) : AlphaShareBuilderM Expr := do
+      match e with
+      | .lam _ _ b _ =>
+        if i + 1 < sz then
+          go b (i+1)
+        else
+          instantiateS' b revArgs
+      | .mdata _ b => go b i
+      | _ =>
+        let n := sz - i
+        mkAppRevRangeS (← instantiateRangeS' e n sz revArgs) 0 n revArgs
+    go f 0
+
+abbrev M := StateT (Std.HashMap (ExprPtr × Nat) Expr) AlphaShareBuilderM
+
+def save (key : ExprPtr × Nat) (r : Expr) : M Expr := do
+  modify fun cache => cache.insert key r
+  return r
+
+partial def instantiateRevBetaS' (e : Expr) (subst : Array Expr) : AlphaShareBuilderM Expr := do
+  if subst.isEmpty || !e.hasLooseBVars then return e
+  visit e 0 |>.run' {}
+where
+  visitBVar (e : Expr) (bidx : Nat) (offset : Nat) : M Expr := do
+    let n := subst.size
+    if _h : bidx >= offset then
+      if _h : bidx < offset + n then
+        let v := subst[n - (bidx - offset) - 1]
+        liftLooseBVarsS' v 0 offset
+      else
+        mkBVarS (bidx - n)
+    else
+      return e
+
+  visitChild (e : Expr) (offset : Nat) : M Expr := do
+    if offset >= e.looseBVarRange then
+      return e
+    else
+      let key := (⟨e⟩, offset)
+      if let some r := (← get)[key]? then
+        return r
+      else match e with
+        | .bvar bidx => save key (← visitBVar e bidx offset)
+        | .lit _ | .mvar _ | .fvar _ | .const _ _ | .sort _ => save key e
+        | e => save key (← visit e offset)
+
+  visitAppDefault (e : Expr) (offset : Nat) : M Expr := do
+    match e with
+    | .app f a =>
+      let key := (⟨e⟩, offset)
+      if let some r := (← get)[key]? then
+        return r
+      else
+        save key (← mkAppS (← visitAppDefault f offset) (← visitChild a offset))
+    | e => visitChild e offset
+
+  visitAppBeta (f : Expr) (argsRev : Array Expr) (offset : Nat) : M Expr := do
+    match f with
+    | .app f a => visitAppBeta f (argsRev.push (← visitChild a offset)) offset
+    | .bvar bidx =>
+      let f ← visitBVar f bidx offset
+      betaRevS f argsRev
+    | _ => unreachable!
+
+  visitApp (f : Expr) (arg : Expr) (offset : Nat) : M Expr := do
+    let arg ← visitChild arg offset
+    if f.getAppFn.isBVar then
+      visitAppBeta f #[arg] offset
+    else
+      mkAppS (← visitAppDefault f offset) arg
+
+  visit (e : Expr) (offset : Nat) : M Expr := do
+    match e with
+    | .lit _ | .mvar _ | .fvar _ | .const _ _ | .sort _ => unreachable!
+    | .bvar bidx => visitBVar e bidx offset
+    | .app f a => visitApp f a offset
+    | .mdata m a => mkMDataS m (← visitChild a offset)
+    | .proj s i a => mkProjS s i (← visitChild a offset)
+    | .forallE n d b bi => mkForallS n bi (← visitChild d offset) (← visitChild b (offset+1))
+    | .lam n d b bi => mkLambdaS n bi (← visitChild d offset) (← visitChild b (offset+1))
+    | .letE n t v b d => mkLetS n (← visitChild t offset) (← visitChild v offset) (← visitChild b (offset+1)) (nondep := d)
+
+/--
+Similar to `instantiateRevS`, but beta-reduces nested applications whose function becomes a lambda
+after substitution.
+
+For example, if `e` contains a subterm `#0 a` and we apply the substitution `#0 := fun x => x + 1`,
+then `instantiateRevBetaS` produces `a + 1` instead of `(fun x => x + 1) a`.
+
+This is useful when applying theorems. For example, when applying `Exists.intro`:
+```
+Exists.intro.{u} {α : Sort u} {p : α → Prop} (w : α) (h : p w) : Exists p
+```
+to a goal of the form `∃ x : Nat, p x ∧ q x`, we create metavariables `?w` and `?h`.
+With `instantiateRevBetaS`, the type of `?h` becomes `p ?w ∧ q ?w` instead of
+`(fun x => p x ∧ q x) ?w`.
+-/
+public def instantiateRevBetaS (e : Expr) (subst : Array Expr) : SymM Expr := do
+  if !e.hasLooseBVars || subst.isEmpty then return e
+  else liftBuilderM <| instantiateRevBetaS' e subst
 
 end Lean.Meta.Sym

--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -200,7 +200,7 @@ def mkPreResult : UnifyM Unit := do
       let type := varTypes[i]!
       let type := type.instantiateLevelParams pattern.levelParams us
       let type ← shareCommon type
-      let type ← instantiateRevS type args
+      let type ← instantiateRevBetaS type args
       let mvar ← mkFreshExprSyntheticOpaqueMVar type
       let mvar ← shareCommon mvar
       args := args.push mvar

--- a/tests/lean/run/sym_pattern.lean
+++ b/tests/lean/run/sym_pattern.lean
@@ -22,7 +22,7 @@ info: @Exists.intro Nat (fun x => And (p x) (q x Nat.zero)) ?m.1 ?m.2
 ---
 info: ?m.1 : Nat
 ---
-info: ?m.2 : (fun x => And (p x) (q x Nat.zero)) ?m.1
+info: ?m.2 : And (p ?m.1) (q ?m.1 Nat.zero)
 -/
 #guard_msgs in
 set_option pp.explicit true in


### PR DESCRIPTION
This PR implements `instantiateRevBetaS`, which is similar to `instantiateRevS` but beta-reduces nested applications whose function becomes a lambda after substitution.

For example, if `e` contains a subterm `#0 a` and we apply the substitution `#0 := fun x => x + 1`, then `instantiateRevBetaS` produces `a + 1` instead of `(fun x => x + 1) a`.

This is useful when applying theorems. For example, when applying `Exists.intro`:
```lean
Exists.intro.{u} {α : Sort u} {p : α → Prop} (w : α) (h : p w) : Exists p
```
to a goal of the form `∃ x : Nat, p x ∧ q x`, we create metavariables `?w` and `?h`. With `instantiateRevBetaS`, the type of `?h` becomes `p ?w ∧ q ?w` instead of `(fun x => p x ∧ q x) ?w`.
