### PR TITLE
feat: add guillemet escape code action for parser errors

### DIFF
--- a/src/Lean/Server/CodeActions/GuillemetsEscape.lean
+++ b/src/Lean/Server/CodeActions/GuillemetsEscape.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alok Singh
+-/
+module
+
+prelude
+public import Lean.Server.CodeActions.Basic
+public import Lean.Server.FileWorker.Utils
+public import Lean.Parser.Module
+
+public section
+
+namespace Lean.Server
+
+open Lean Lsp Server RequestM
+
+/--
+Code action provider that offers to wrap keywords in guillemets when they're used
+where an identifier is expected.
+-/
+@[builtin_code_action_provider] def guillemetsEscapeCodeActionProvider : CodeActionProvider := fun params _snap => do
+  let doc ← readDoc
+  let text := doc.meta.text
+  let startPos := text.lspPosToUtf8Pos params.range.start
+  let endPos := text.lspPosToUtf8Pos params.range.end
+  let requestedRange : Lean.Syntax.Range := ⟨startPos, endPos⟩
+
+  -- Collect messages from all snapshots
+  let snaps := Language.toSnapshotTree doc.initSnap |>.getAll
+  let msgLog : MessageLog := snaps.map (·.diagnostics.msgLog) |>.foldl (· ++ ·) {}
+
+  let mut codeActions : Array LazyCodeAction := #[]
+
+  for msg in msgLog.unreported do
+    -- Check if this message has the guillemets-fixable tag
+    if !msg.data.hasTag (· == Lean.Parser.guillemetsFixableMessageTag) then
+      continue
+
+    -- Check if the message range overlaps with the requested range
+    let msgRange : Lean.Syntax.Range := ⟨text.ofPosition msg.pos, text.ofPosition <| msg.endPos.getD msg.pos⟩
+    if !msgRange.overlaps requestedRange (includeFirstStop := true) (includeSecondStop := true) then
+      continue
+
+    -- Extract the token from the source text at the message position
+    let tokenText : String := String.Pos.Raw.extract text.source msgRange.start msgRange.stop
+
+    -- Skip if empty or already escaped
+    if tokenText.isEmpty || tokenText.front == '«' then
+      continue
+
+    -- Create the fix: wrap in guillemets
+    let escapedText := s!"{idBeginEscape}{tokenText}{idEndEscape}"
+    let lspRange := text.utf8RangeToLspRange msgRange
+
+    let codeAction : CodeAction := {
+      title := s!"Escape `{tokenText}` with guillemets"
+      kind? := "quickfix"
+      edit? := WorkspaceEdit.ofTextDocumentEdit {
+        textDocument := doc.versionedIdentifier
+        edits := #[{ range := lspRange, newText := escapedText }]
+      }
+    }
+    codeActions := codeActions.push codeAction
+
+  return codeActions
+
+end Lean.Server

--- a/src/Lean/Server/FileWorker.lean
+++ b/src/Lean/Server/FileWorker.lean
@@ -20,6 +20,7 @@ public import Lean.Server.FileWorker.WidgetRequests
 public import Lean.Server.FileWorker.SetupFile
 public import Lean.Server.Completion.ImportCompletion
 public import Lean.Server.CodeActions.UnknownIdentifier
+public import Lean.Server.CodeActions.GuillemetsEscape
 
 public section
 

--- a/tests/lean/guillemet_hint.lean
+++ b/tests/lean/guillemet_hint.lean
@@ -1,0 +1,14 @@
+/-!
+  # Guillemet hint for using keywords as identifiers
+
+  When a keyword/token is used where an identifier is expected, the error
+  message should suggest wrapping it in guillemets («»).
+-/
+
+-- Using reserved word as function parameter (shows guillemet hint)
+def bar (if : Nat) : Nat := 0  -- 'if' is a keyword
+
+-- This should work (guillemets escape the keyword)
+def good1 («if» : Nat) : Nat := «if»
+
+#check good1

--- a/tests/lean/guillemet_hint.lean.expected.out
+++ b/tests/lean/guillemet_hint.lean.expected.out
@@ -1,0 +1,2 @@
+guillemet_hint.lean:9:9: error: unexpected token `if`; if you intended to use it as an identifier, use `«if»`; expected '_' or identifier
+good1 («if» : Nat) : Nat


### PR DESCRIPTION
This PR adds a code action (quick fix) that wraps keywords in guillemets when they're used where an identifier is expected.

## Summary

When a keyword is used where an identifier is expected, the parser now:
- Shows an improved error message suggesting guillemet escaping
- Tags the error so a code action provider can offer a quick fix
- The code action wraps the keyword in guillemets (e.g., `if` → `«if»`)

The error message format is:
```
unexpected token `if`; if you intended to use it as an identifier, use `«if»`
```

This helps users who accidentally use reserved keywords as identifiers by providing both a clear explanation and an automated fix.

## Changes

1. **`src/Lean/Parser/Module.lean`**: Added `guillemetsFixableMessageTag` and modified `mkErrorMessage` to tag parser errors where guillemet escaping would fix the issue
2. **`src/Lean/Server/CodeActions/GuillemetsEscape.lean`**: New code action provider that offers to wrap keywords in guillemets
3. **`src/Lean/Server/FileWorker.lean`**: Import the new code action module
4. **`tests/lean/guillemet_hint.lean`**: Test case for the error message

## Test plan

- [x] Build succeeds
- [x] Error message displays correctly with guillemet suggestion
- [x] Test file output matches expected output
- [ ] Manual testing of code action in VS Code (needs LSP integration testing)

---
**Suggested label:** `changelog-server`