### PR TITLE
feat: suggest guillemet escaping in parser error

### DIFF
--- a/src/Lean/Parser/Module.lean
+++ b/src/Lean/Parser/Module.lean
@@ -59,7 +59,12 @@ private partial def mkErrorMessage (c : InputContext) (pos : String.Pos.Raw) (st
       endPos? := some r.stop
     let unexpected := match e.unexpectedTk with
       | .ident .. => "unexpected identifier"
-      | .atom _ v => s!"unexpected token '{v}'"
+      | .atom _ v =>
+        -- If expecting an identifier but got a keyword/token, suggest guillemets
+        if e.expected.contains "identifier" && !v.isEmpty && !v.any isIdEndEscape then
+          s!"unexpected token `{v}`; if you want to use it as an identifier, use `{idBeginEscape}{v}{idEndEscape}`"
+        else
+          s!"unexpected token `{v}`"
       | _         => "unexpected token"  -- TODO: categorize (custom?) literals as well?
     e := { e with unexpected }
     -- if there is an unexpected token, include preceding whitespace as well as the expected token could

--- a/tests/lean/guillemet_hint.lean
+++ b/tests/lean/guillemet_hint.lean
@@ -1,0 +1,6 @@
+-- Test that using a keyword where an identifier is expected shows guillemet hint
+
+def good1 («if» : Nat) : Nat := «if»
+
+-- error below
+def bad1 (if : Nat) : Nat := if

--- a/tests/lean/guillemet_hint.lean.expected.out
+++ b/tests/lean/guillemet_hint.lean.expected.out
@@ -1,0 +1,1 @@
+guillemet_hint.lean:6:10: error: unexpected token `if`; if you want to use it as an identifier, use `«if»`; expected '_' or identifier


### PR DESCRIPTION
This PR improves the parser error message when a keyword/token is used where an identifier is expected.

Before: `unexpected token 'if'`
After: `unexpected token \`if\`; if you intended to use it as an identifier, use \`«if»\``

Only shows the hint when an identifier is expected and the token is valid for escaping.

---
**Suggested label:** `changelog-language`