### PR TITLE
perf: add performance comparison tests for `SymM` vs `MetaM`

### DIFF
--- a/tests/lean/sym/perf_sym_apply.lean
+++ b/tests/lean/sym/perf_sym_apply.lean
@@ -5,18 +5,23 @@ open Lean Meta Sym
 def profileM {α : Type} (k : MetaM α) (msg : String := "experiment") : MetaM α :=
   profileitM Exception msg ({ : Options }.setBool `profiler true |>.setNat `profiler.threshold 0)  k
 
-macro "gen_term" n:num : term => do
-  let mut stx ← `(True)
-  for _ in 0...n.getNat do
-    stx := ← `(let z : Nat := x + y; forall x : Nat, exists y : Nat, y = z+x /\ $stx)
-  `(let z : Nat := 0 ; forall x : Nat, exists y : Nat, y = z+x ∧ $stx)
+def genTerm (n : Nat) : Expr := Id.run do
+  let mut e := mkConst ``True
+  let nat := mkConst ``Nat
+  for _ in 0...n do
+    let eq := mkApp3 (mkConst ``Eq [1]) nat (mkBVar 0) (mkNatAdd (mkBVar 2) (mkBVar 1))
+    e := mkApp2 (mkConst ``And) eq e
+    e := mkApp2 (mkConst ``Exists [1]) nat (mkLambda `y .default nat e)
+    e := mkForall `x .default nat e
+    e := mkLet `z nat (mkNatAdd (mkBVar 1) (mkBVar 0)) e
+  let eq := mkApp3 (mkConst ``Eq [1]) nat (mkBVar 0) (mkNatAdd (mkBVar 2) (mkBVar 1))
+  e := mkApp2 (mkConst ``And) eq e
+  e := mkApp2 (mkConst ``Exists [1]) nat (mkLambda `y .default nat e)
+  e := mkForall `x .default nat e
+  e := mkLet `z nat (mkNatLit 0) e
+  return e
 
 set_option maxRecDepth 10000000
-axiom ex1000 : gen_term 1000
-axiom ex2000 : gen_term 2000
-axiom ex3000 : gen_term 3000
-axiom ex4000 : gen_term 4000
-axiom ex5000 : gen_term 5000
 
 def tryIntros? (goals : List Goal) : SymM (Option (List Goal)) := do
   try
@@ -43,8 +48,7 @@ def tryApplyAny? (rules : List BackwardRule) (goals : List Goal) : SymM (Option 
     else
       tryApplyAny? rules goals
 
-def solve (declName : Name) : MetaM Unit := profileM (msg := declName.toString) <| SymM.run' do
-  let type := (← getConstInfo declName).type
+def solve (n : Nat) (type : Expr) : MetaM Unit := profileM (msg := s!"size {n}") <| SymM.run' do
   let mvarId := (← mkFreshExprMVar type).mvarId!
   let rules ← [``Exists.intro, ``And.intro, ``Eq.refl, ``True.intro].mapM fun declName => mkBackwardRuleFromDecl declName
   let goal ← mkGoal mvarId
@@ -64,8 +68,16 @@ where
       else
         throwError "Stuck at {goal.mvarId}"
 
-#eval solve ``ex1000
-#eval solve ``ex2000
-#eval solve ``ex3000
-#eval solve ``ex4000
-#eval solve ``ex5000
+def test (n : Nat) : MetaM Unit := do
+  let e := genTerm n
+  solve n e
+
+-- We are solving problems of the following form
+#eval logInfo (genTerm 2)
+
+#eval test 1000
+#eval test 2000
+#eval test 3000
+#eval test 4000
+#eval test 5000
+#eval test 6000


### PR DESCRIPTION
This PR adds performance comparison tests between the new `SymM` monad and the standard `MetaM` for `intros`/`apply` operations.

The tests solve problems of the form:
```lean
let z := 0; ∀ x, ∃ y, x = z + y ∧ let z := z + x; ∀ x, ∃ y, x = z + y ∧ ... ∧ True
```
using repeated `intros` and `apply` with `Exists.intro`, `And.intro`, `Eq.refl`, and `True.intro`.

**Results show 10-20x speedup:**

| Size | MetaM | SymM | Speedup |
|------|-------|------|---------|
| 1000 | 226ms | 21ms | 10.8x |
| 2000 | 582ms | 44ms | 13.2x |
| 3000 | 1.08s | 72ms | 15.0x |
| 4000 | 1.72s | 101ms | 17.0x |
| 5000 | 2.49s | 125ms | 19.9x |
| 6000 | 3.45s | 157ms | 22.0x |
