### PR TITLE
chore: backtick identifiers in Ext/Simpa messages

### DIFF
--- a/src/Lean/Elab/Tactic/Ext.lean
+++ b/src/Lean/Elab/Tactic/Ext.lean
@@ -135,9 +135,9 @@ def realizeExtTheorem (structName : Name) (flat : Bool) : Elab.Command.CommandEl
   return extName
 
 /--
-Given an 'ext' theorem, ensures that there is an iff version of the theorem (if possible),
+Given an `ext` theorem, ensures that there is an iff version of the theorem (if possible),
 without validating any pre-existing theorems.
-Returns the name of the 'ext_iff' theorem.
+Returns the name of the `ext_iff` theorem.
 -/
 def realizeExtIffTheorem (extName : Name) : Elab.Command.CommandElabM Name := do
   let extIffName : Name :=

--- a/src/Lean/Elab/Tactic/Simpa.lean
+++ b/src/Lean/Elab/Tactic/Simpa.lean
@@ -45,7 +45,7 @@ def getLinterUnnecessarySimpa (o : LinterOptions) : Bool :=
         let mkInfo ← mkInitialTacticInfo (mkNullNode #[tk, usingTk?.getD .missing])
         let (some (_, g), stats) ← simpGoal (← getMainGoal) ctx (simprocs := simprocs) (simplifyTarget := true) (discharge? := discharge?)
           | if getLinterUnnecessarySimpa (← getLinterOptions) then
-              logLint linter.unnecessarySimpa (← getRef) "try 'simp' instead of 'simpa'"
+              logLint linter.unnecessarySimpa (← getRef) "try `simp` instead of `simpa`"
             return {}
         -- Replace the goal; captured by `mkInfo` in `using` case below.
         replaceMainGoal [g]


### PR DESCRIPTION
This PR uses backticks instead of single quotes for identifiers in Ext and Simpa tactic messages, following Lean's convention for referring to identifiers in error messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)