### PR TITLE
chore: backtick identifiers in Lake eval messages

### DIFF
--- a/src/lake/Lake/Load/Lean/Eval.lean
+++ b/src/lake/Lake/Load/Lean/Eval.lean
@@ -169,7 +169,7 @@ public def Package.loadFromEnv
 
   -- Deprecation warnings
   unless self.config.manifestFile.isNone do
-    logWarning s!"{self.prettyName}: package configuration option 'manifestFile' is deprecated"
+    logWarning s!"{self.prettyName}: package configuration option `manifestFile` is deprecated"
 
   -- Fill in the Package
   return {self with


### PR DESCRIPTION
This PR uses backticks instead of single quotes for identifiers in Lake package evaluation messages, following Lean's convention for referring to identifiers in warning messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)