### PR TITLE
fix: zetaDelta at `Sym/Pattern.lean`

### DIFF
--- a/src/Lean/Meta/Sym/Apply.lean
+++ b/src/Lean/Meta/Sym/Apply.lean
@@ -113,6 +113,6 @@ public def BackwardRule.apply (goal : Goal) (rule : BackwardRule) : SymM (List G
       let mvarId := result.args[i]!.mvarId!
       { goal with mvarId }
   else
-    throwError "rule is not applicable to goal{goal.mvarId}\nrule:{indentExpr rule.expr}"
+    throwError "rule is not applicable to goal{goal.mvarId}rule:{indentExpr rule.expr}"
 
 end Lean.Meta.Sym


### PR DESCRIPTION
This PR fixes missing zetaDelta support at the pattern matching/unification procedure in the new Sym framework.
