### PR TITLE
feat: bv_decide can handle structure fields with parametric width

### DIFF
--- a/tests/lean/run/bv_parametric_struct.lean
+++ b/tests/lean/run/bv_parametric_struct.lean
@@ -1,0 +1,20 @@
+import Std.Tactic.BVDecide
+
+/--
+The `Byte` type can have any bitwidth `w`. It carries a two's complement integer
+value of width `w` and a per-bit poison mask modeling bitwise delayed undefined
+behavior.
+-/
+structure Byte (w : Nat) where
+  /-- A two's complement integer value of width `w`. -/
+  val : BitVec w
+  /-- A per-bit poison mask of width `w`. -/
+  poison : BitVec w
+
+def or {w : Nat} (x y : Byte w) : Byte w :=
+  ⟨x.val ||| y.val, x.poison ||| y.poison⟩
+
+example (x y : Byte 8) : or x y = or y x := by
+  unfold _root_.or
+  bv_decide
+


### PR DESCRIPTION
This PR changes `bv_decide`'s heuristic for what kinds of structures to split on to also allow
splitting on structures where the fields have dependently typed widths. For example:
```lean
structure Byte (w : Nat) where
  /-- A two's complement integer value of width `w`. -/
  val : BitVec w
  /-- A per-bit poison mask of width `w`. -/
  poison : BitVec w
```
This is to allow handling situations such as `(x : Byte 8)` where the width becomes concrete after
splitting is done.
