### PR TITLE
fix: add `OfNat` instance for `LeanOptionValue`

### DIFF
--- a/src/Lean/Util/LeanOptions.lean
+++ b/src/Lean/Util/LeanOptions.lean
@@ -43,6 +43,9 @@ instance : Coe Bool LeanOptionValue where
 instance : Coe Nat LeanOptionValue where
   coe := LeanOptionValue.ofNat
 
+instance {n : Nat} : OfNat LeanOptionValue n where
+  ofNat := .ofNat n
+
 instance : FromJson LeanOptionValue where
   fromJson?
     | (s : String) => Except.ok s


### PR DESCRIPTION
This PR removes the need to write `.ofNat` for numeric options in `lakefile.lean`. Note that `lake translate-config` incorrectly assumed this was already legal in earlier revisions.

This replaces #11771.
