### PR TITLE
fix: make `mvcgen with tac` fail if `tac` fails on one of the VCs

### DIFF
--- a/src/Lean/Elab/Tactic/Do/VCGen.lean
+++ b/src/Lean/Elab/Tactic/Do/VCGen.lean
@@ -436,7 +436,7 @@ where
     let some tactic := tactic | return vcs
     let mut newVCs := #[]
     for vc in vcs do
-      let vcs ← try evalTacticAt tactic vc catch _ => pure [vc]
+      let vcs ← evalTacticAt tactic vc
       newVCs := newVCs ++ vcs
     return newVCs
 

--- a/tests/lean/run/mvcgenInvariantsWith.lean
+++ b/tests/lean/run/mvcgenInvariantsWith.lean
@@ -125,7 +125,7 @@ theorem test_with_pretac_cases {m : Option Nat} (h : m = some 4) :
   | none => set 0)
   ⦃⇓ _ s => ⌜s = 4⌝⦄ := by
   mvcgen
-  with simp -- `simp` is a no-op on some goals, but it should not fail
+  with try simp
   | vc1 => grind
   | vc2 => grind
 

--- a/tests/lean/run/mvcgenWithFail.lean
+++ b/tests/lean/run/mvcgenWithFail.lean
@@ -1,0 +1,41 @@
+import Std
+
+/-!
+  `mvcgen with grind` should behave like `induction ... with grind` and fail if `grind` fails on
+  one of the goals.
+-/
+
+open Std.Do
+
+set_option mvcgen.warning false
+set_option warn.sorry false
+
+variable {α : Type}
+
+@[grind]
+def List.last? (as : List α) : Option α :=
+  match as with
+  | [] => none
+  | [a] => some a
+  | _ :: bs => last? bs
+
+open List
+
+example (as bs : List α) (h : bs ≠ []) :
+  (as ++ bs).last? = bs.last? := by
+  fail_if_success induction bs generalizing as with simp
+  sorry
+
+def nodup (l : List Int) : Bool := Id.run do
+  let mut seen : Std.HashSet Int := ∅
+  for x in l do
+    if x ∈ seen then
+      return false
+    seen := seen.insert x
+  return true
+
+theorem nodup_correct_invariants_with_pretac (l : List Int) : nodup l ↔ l.Nodup := by
+  generalize h : nodup l = r
+  apply Id.of_wp_run_eq h
+  fail_if_success mvcgen with grind
+  sorry


### PR DESCRIPTION
This PR makes `mvcgen with tac` fail if `tac` fails on one of the VCs, just as `induction ... with tac` fails if `tac` fails on one of the goals. The old behavior can be recovered by writing `mvcgen with try tac` instead.