### PR TITLE
feat: add `with_unfolding_none` tactic

### DIFF
--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -369,6 +369,12 @@ In this setting all definitions that are not opaque are unfolded.
 -/
 syntax (name := withUnfoldingAll) "with_unfolding_all " tacticSeq : tactic
 
+/--
+`with_unfolding_none tacs` executes `tacs` using the `.none` transparency setting.
+In this setting no definitions are unfolded.
+-/
+syntax (name := withUnfoldingNone) "with_unfolding_none " tacticSeq : tactic
+
 /-- `first | tac | ...` runs each `tac` until one succeeds, or else fails. -/
 syntax (name := first) "first " withPosition((ppDedent(ppLine) colGe "| " tacticSeq)+) : tactic
 

--- a/src/Lean/Elab/Tactic/ElabTerm.lean
+++ b/src/Lean/Elab/Tactic/ElabTerm.lean
@@ -320,6 +320,9 @@ def evalApplyLikeTactic (tac : MVarId → Expr → MetaM (List MVarId)) (e : Syn
 @[builtin_tactic Lean.Parser.Tactic.withUnfoldingAll] def evalWithUnfoldingAll : Tactic := fun stx =>
   withTransparency TransparencyMode.all <| evalTactic stx[1]
 
+@[builtin_tactic Lean.Parser.Tactic.withUnfoldingNone] def evalWithUnfoldingNone : Tactic := fun stx =>
+  withTransparency TransparencyMode.none <| evalTactic stx[1]
+
 /--
   Elaborate `stx`. If it is a free variable, return it. Otherwise, assert it, and return the free variable.
   Note that, the main goal is updated when `Meta.assert` is used in the second case. -/

--- a/tests/lean/run/with_unfolding_none.lean
+++ b/tests/lean/run/with_unfolding_none.lean
@@ -1,0 +1,25 @@
+/-!
+# Tests for `with_unfolding_none` tactic
+
+The `.none` transparency mode prevents unfolding of all definitions, including reducible ones.
+This is stricter than `.reducible`, which unfolds `@[reducible]` definitions.
+-/
+
+-- A reducible definition: unfolded by `.reducible` but not by `.none`
+@[reducible] def myId (x : Nat) : Nat := x
+
+-- Default transparency can see through myId
+example : myId 42 = 42 := by rfl
+
+-- with_unfolding_none blocks even reducible definitions
+/--
+error: Tactic `rfl` failed: The left-hand side
+  myId 42
+is not definitionally equal to the right-hand side
+  42
+
+⊢ myId 42 = 42
+-/
+#guard_msgs in
+example : myId 42 = 42 := by
+  with_unfolding_none rfl


### PR DESCRIPTION
This PR adds a `with_unfolding_none` tactic that sets the transparency mode to `.none`, in which no definitions are unfolded. This complements the existing `with_unfolding_all` tactic and provides tactic-level access to the `TransparencyMode.none` added in https://github.com/leanprover/lean4/pull/11810.

🤖 Prepared with Claude Code