### PR TITLE
fix: avoid panic in `TagDeclarationExtension.tag` on partial elaboration

### DIFF
--- a/src/Lean/EnvExtension.lean
+++ b/src/Lean/EnvExtension.lean
@@ -105,9 +105,13 @@ instance : Inhabited TagDeclarationExtension :=
   inferInstanceAs (Inhabited (SimplePersistentEnvExtension Name NameSet))
 
 def tag (ext : TagDeclarationExtension) (env : Environment) (declName : Name) : Environment :=
-  have : Inhabited Environment := ⟨env⟩
-  assert! env.getModuleIdxFor? declName |>.isNone -- See comment at `TagDeclarationExtension`
-  ext.addEntry (asyncDecl := declName) env declName
+  if declName.isAnonymous then
+    -- This case might happen on partial elaboration; ignore instead of triggering any panics below
+    env
+  else
+    have : Inhabited Environment := ⟨env⟩
+    assert! env.getModuleIdxFor? declName |>.isNone -- See comment at `TagDeclarationExtension`
+    ext.addEntry (asyncDecl := declName) env declName
 
 def isTagged (ext : TagDeclarationExtension) (env : Environment) (declName : Name)
     (asyncMode := ext.toEnvExtension.asyncMode) : Bool :=


### PR DESCRIPTION
This PR adds a guard to `TagDeclarationExtension.tag` to check if the declaration name is anonymous and return early if so. This prevents a panic that could occur when modifiers like `meta` or `noncomputable` are used in combination with syntax errors.

Reproducer:
```lean
public meta section
def private
```

Previously this would panic with:
```
PANIC at Lean.EnvExtension.modifyState: called on `async` extension,
must set `asyncDecl` in that case
```

This follows the same pattern as the fix in #10131 for `addDocString` and the existing guard in `markNotMeta`.

See https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/panic.20on.20doc-string/near/566110399

🤖 Prepared with Claude Code