### PR TITLE
chore: include free variables

### DIFF
--- a/tests/bench/sym/meta_simp_1.lean
+++ b/tests/bench/sym/meta_simp_1.lean
@@ -28,7 +28,7 @@ def simp (e : Expr) : MetaM (Simp.Result × Float) := Sym.SymM.run' do
 def mkTransitivityChain (n : Nat) : MetaM Expr := do
   withLocalDeclD `x (mkConst ``Nat) fun x => do
     let zero := mkNatLit 0
-    let mut e := zero
+    let mut e := x
     for _ in [:n] do
       e := mkApp (mkConst ``f) (mkNatAdd zero e)
     mkForallFVars #[x] e

--- a/tests/bench/sym/simp_1.lean
+++ b/tests/bench/sym/simp_1.lean
@@ -34,7 +34,7 @@ def simp (e : Expr) : MetaM (Sym.Simp.Result × Float) := Sym.SymM.run' do
 def mkTransitivityChain (n : Nat) : MetaM Expr := do
   withLocalDeclD `x (mkConst ``Nat) fun x => do
     let zero := mkNatLit 0
-    let mut e := zero
+    let mut e := x
     for _ in [:n] do
       e := mkApp (mkConst ``f) (mkNatAdd zero e)
     mkForallFVars #[x] e


### PR DESCRIPTION
This PR includes free variable in a `simp` benchmark to stress the default `simp` matching procedure.