### PR TITLE
chore: include comparator and lean4export in release process

### DIFF
--- a/script/release_repos.yml
+++ b/script/release_repos.yml
@@ -142,3 +142,15 @@ repositories:
     branch: master
     dependencies:
       - verso-web-components
+
+  - name: comparator
+    url: https://github.com/leanprover/comparator
+    toolchain-tag: true
+    stable-branch: false
+    branch: master
+
+  - name: lean4export
+    url: https://github.com/leanprover/lean4export
+    toolchain-tag: true
+    stable-branch: false
+    branch: master


### PR DESCRIPTION
This PR includes https://github.com/leanprover/lean4export/ and https://github.com/leanprover/comparator/ in the monthly release workflow.