### PR TITLE
feat: `pre` and `post` may return "done" in `Sym.simp`

### DIFF
--- a/src/Lean/Meta/Sym/Simp/Congr.lean
+++ b/src/Lean/Meta/Sym/Simp/Congr.lean
@@ -48,17 +48,16 @@ def mkCongr (e : Expr) (f a : Expr) (fr : Result) (ar : Result) (_ : e = .app f 
     let v ← getLevel β
     return mkApp2 (mkConst declName [u, v]) α β
   match fr, ar with
-  | .rfl,  .rfl =>
-    return .rfl
-  | .step f' hf, .rfl =>
+  | .rfl _,  .rfl _ => return .rfl
+  | .step f' hf _, .rfl _ =>
     let e' ← mkAppS f' a
     let h := mkApp4 (← mkCongrPrefix ``congrFun') f f' hf a
     return .step e' h
-  | .rfl, .step a' ha =>
+  | .rfl _, .step a' ha _ =>
     let e' ← mkAppS f a'
     let h := mkApp4 (← mkCongrPrefix ``congrArg) a a' f ha
     return .step e' h
-  | .step f' hf, .step a' ha =>
+  | .step f' hf _, .step a' ha _ =>
     let e' ← mkAppS f' a'
     let h := mkApp6 (← mkCongrPrefix ``congr) f f' a a' hf ha
     return .step e' h
@@ -131,8 +130,8 @@ where
         if rewritable[i - 1] then
           mkCongr e f a fr (← simp a) h
         else match fr with
-          | .rfl => return .rfl
-          | .step f' hf => mkCongrFun e f a f' hf h
+          | .rfl _ => return .rfl
+          | .step f' hf _ => mkCongrFun e f a f' hf h
       | _ => unreachable!
 
 /--

--- a/src/Lean/Meta/Sym/Simp/Result.lean
+++ b/src/Lean/Meta/Sym/Simp/Result.lean
@@ -19,7 +19,7 @@ public def mkEqTrans (e₁ : Expr) (e₂ : Expr) (h₁ : Expr) (e₃ : Expr) (h�
 
 public abbrev mkEqTransResult (e₁ : Expr) (e₂ : Expr) (h₁ : Expr) (r₂ : Result) : SymM Result :=
   match r₂ with
-  | .rfl => return .step e₂ h₁
-  | .step e₃ h₂ => return .step e₃ (← mkEqTrans e₁ e₂ h₁ e₃ h₂)
+  | .rfl done => return .step e₂ h₁ done
+  | .step e₃ h₂ done => return .step e₃ (← mkEqTrans e₁ e₂ h₁ e₃ h₂) done
 
 end Lean.Meta.Sym.Simp

--- a/src/Lean/Meta/Sym/Simp/Simproc.lean
+++ b/src/Lean/Meta/Sym/Simp/Simproc.lean
@@ -13,8 +13,9 @@ open Grind
 public abbrev Simproc.andThen (f g : Simproc) : Simproc := fun e₁ => do
   let r ← f e₁
   match r with
-  | .rfl => g e₁
-  | .step e₂ h₁ => mkEqTransResult e₁ e₂ h₁ (← g e₂)
+  | .step _ _ true | .rfl true  => return r
+  | .rfl false => g e₁
+  | .step e₂ h₁ false => mkEqTransResult e₁ e₂ h₁ (← g e₂)
 
 public instance : AndThen Simproc where
   andThen f g := Simproc.andThen f (g ())

--- a/tests/bench/sym/simp_1.lean
+++ b/tests/bench/sym/simp_1.lean
@@ -9,8 +9,8 @@ namespace SimpBench
 
 def getProofSize (r : Sym.Simp.Result) : MetaM Nat :=
   match r with
-  | .rfl => return 0
-  | .step _ p => p.numObjs
+  | .rfl _ => return 0
+  | .step _ p _ => p.numObjs
 
 def mkSimpMethods : MetaM Sym.Simp.Methods := do
   let thms : Sym.Simp.Theorems := {}

--- a/tests/bench/sym/simp_2.lean
+++ b/tests/bench/sym/simp_2.lean
@@ -9,8 +9,8 @@ namespace SimpBench
 
 def getProofSize (r : Sym.Simp.Result) : MetaM Nat :=
   match r with
-  | .rfl => return 0
-  | .step _ p => p.numObjs
+  | .rfl _ => return 0
+  | .step _ p _ => p.numObjs
 
 def mkSimpMethods : MetaM Sym.Simp.Methods := do
   let thms : Sym.Simp.Theorems := {}


### PR DESCRIPTION
This PR adds a `done` flag to the result returned by `Simproc`s in `Sym.simp`.

The `done` flag controls whether simplification should continue after the result:
- `done = false` (default): Continue with subsequent simplification steps
- `done = true`: Stop processing, return this result as final

## Use cases for `done = true`

### In `pre` simprocs
Skip simplification of certain subterms entirely:
```
def skipLambdas : Simproc := fun e =>
  if e.isLambda then return .rfl (done := true)
  else return .rfl
```

### In `post` simprocs
Perform single-pass normalization without recursive simplification:
```
def singlePassNormalize : Simproc := fun e =>
  if let some (e', h) ← tryNormalize e then
    return .step e' h (done := true)
  else return .rfl
```
With `done = true`, the result `e'` won't be recursively simplified.

