### PR TITLE
perf: add `PersistentHashMap.findKeyD` and `PersistentHashSet.findD`

### DIFF
--- a/src/Lean/Data/PersistentHashSet.lean
+++ b/src/Lean/Data/PersistentHashSet.lean
@@ -45,6 +45,9 @@ variable {_ : BEq α} {_ : Hashable α}
   | some (a, _) => some a
   | none        => none
 
+@[inline] def findD (s : PersistentHashSet α) (a : α) (a₀ : α) : α :=
+  s.set.findKeyD a a₀
+
 @[inline] def contains (s : PersistentHashSet α) (a : α) : Bool :=
   s.set.contains a
 


### PR DESCRIPTION
This PR implements `PersistentHashMap.findKeyD` and `PersistentHashSet.findD`. The motivation is avoid two memory allocations (`Prod.mk` and `Option.some`) when the collections contains the key.
