### PR TITLE
feat: add `lake shake` command

### DIFF
--- a/script/lakefile.toml
+++ b/script/lakefile.toml
@@ -3,9 +3,3 @@ name = "scripts"
 [[lean_exe]]
 name = "modulize"
 root = "Modulize"
-
-[[lean_exe]]
-name = "shake"
-root = "Shake"
-# needed by `Lake.loadWorkspace`
-supportInterpreter = true

--- a/src/lake/Lake/Build/Context.lean
+++ b/src/lake/Lake/Build/Context.lean
@@ -36,10 +36,18 @@ Whether the build should show progress information.
 public def BuildConfig.showProgress (cfg : BuildConfig) : Bool :=
   (cfg.noBuild ∧ cfg.verbosity == .verbose) ∨ cfg.verbosity != .quiet
 
+/-- Mutable reference of registered build jobs. -/
+@[expose] -- for codegen
+public def JobQueue := IO.Ref (Array OpaqueJob)
+
+/-- Returns a new empty job queue. -/
+@[inline] public def mkJobQueue : BaseIO JobQueue :=
+  IO.mkRef #[]
+
 /-- A Lake context with a build configuration and additional build data. -/
 public structure BuildContext extends BuildConfig, Context where
   leanTrace : BuildTrace
-  registeredJobs : IO.Ref (Array OpaqueJob)
+  registeredJobs : JobQueue
 
 /-- A transformer to equip a monad with a `BuildContext`. -/
 public abbrev BuildT := ReaderT BuildContext

--- a/src/lake/Lake/Build/Run.lean
+++ b/src/lake/Lake/Build/Run.lean
@@ -22,6 +22,7 @@ open System
 namespace Lake
 
 /-- Create a fresh build context from a workspace and a build configuration. -/
+@[deprecated "Deprecated without replacement." (since := "2025-01-08")]
 public def mkBuildContext (ws : Workspace) (config : BuildConfig) : BaseIO BuildContext := do
   return {
     opaqueWs := ws,
@@ -37,7 +38,7 @@ private def Monitor.spinnerFrames :=
 
 /-- Context of the Lake build monitor. -/
 private structure MonitorContext where
-  jobs : IO.Ref (Array OpaqueJob)
+  jobs : JobQueue
   out : IO.FS.Stream
   outLv : LogLevel
   failLv : LogLevel
@@ -48,6 +49,9 @@ private structure MonitorContext where
   showTime : Bool
   /-- How often to poll jobs (in milliseconds). -/
   updateFrequency : Nat
+
+@[inline] def MonitorContext.logger (ctx : MonitorContext) : MonadLog IO :=
+  .stream ctx.out ctx.outLv ctx.useAnsi
 
 /-- State of the Lake build monitor. -/
 private structure MonitorState where
@@ -189,12 +193,51 @@ private def main (init : Array OpaqueJob) : MonitorM PUnit := do
 
 end Monitor
 
+/-- **For internal use only.** -/
 public structure MonitorResult where
   didBuild : Bool
   failures : Array String
   numJobs : Nat
 
+@[inline] def MonitorResult.isOk (self : MonitorResult) : Bool :=
+  self.failures.isEmpty
+
+def mkMonitorContext (cfg : BuildConfig) (jobs : JobQueue) : BaseIO MonitorContext := do
+  let out ← cfg.out.get
+  let useAnsi ← cfg.ansiMode.isEnabled out
+  let outLv := cfg.outLv
+  let failLv := cfg.failLv
+  let isVerbose := cfg.verbosity = .verbose
+  let showProgress := cfg.showProgress
+  let minAction := if isVerbose then .unknown else .fetch
+  let showOptional := isVerbose
+  let showTime := isVerbose || !useAnsi
+  let updateFrequency := 100
+  return {
+    jobs, out, failLv, outLv, minAction, showOptional
+    useAnsi, showProgress, showTime, updateFrequency
+  }
+
+def monitorJobs'
+  (ctx : MonitorContext)
+  (initJobs : Array OpaqueJob)
+  (initFailures : Array String := #[])
+  (resetCtrl : String := "")
+: BaseIO MonitorResult := do
+  let s := {
+    resetCtrl
+    lastUpdate := ← IO.monoMsNow
+    failures := initFailures
+  }
+  let (_,s) ← Monitor.main initJobs |>.run ctx s
+  return {
+    failures := s.failures
+    numJobs := s.totalJobs
+    didBuild := s.didBuild
+  }
+
 /-- The job monitor function. An auxiliary definition for `runFetchM`. -/
+@[inline, deprecated "Deprecated without replacement" (since := "2025-01-08")]
 public def monitorJobs
   (initJobs : Array OpaqueJob)
   (jobs : IO.Ref (Array OpaqueJob))
@@ -210,20 +253,91 @@ public def monitorJobs
     jobs, out, failLv, outLv, minAction, showOptional
     useAnsi, showProgress, showTime, updateFrequency
   }
-  let s := {
-    resetCtrl
-    lastUpdate := ← IO.monoMsNow
-    failures := initFailures
-  }
-  let (_,s) ← Monitor.main initJobs |>.run ctx s
-  return {
-    failures := s.failures
-    numJobs := s.totalJobs
-    didBuild := s.didBuild
-  }
+  monitorJobs' ctx initJobs initFailures resetCtrl
 
 /-- Exit code to return if `--no-build` is set and a build is required. -/
 public def noBuildCode : ExitCode := 3
+
+def Workspace.saveOutputs
+  [logger : MonadLog IO] (ws : Workspace)
+  (out : IO.FS.Stream) (outputsFile : FilePath) (isVerbose : Bool)
+: IO Unit := do
+  unless ws.isRootArtifactCacheEnabled do
+    logWarning s!"{ws.root.prettyName}: \
+      the artifact cache is not enabled for this package, so the artifacts described \
+      by the mappings produced by `-o` will not necessarily be available in the cache."
+  if let some ref := ws.root.outputsRef? then
+    match (← (← ref.get).writeFile outputsFile {}) with
+    | .ok _ log =>
+      if !log.isEmpty && isVerbose then
+        print! out "There were issues saving input-to-output mappings from the build:\n"
+        log.replay
+    | .error _ log =>
+      print! out "Failed to save input-to-output mappings from the build.\n"
+      if isVerbose then
+        log.replay
+  else
+    print! out "Workspace missing input-to-output mappings from build. (This is likely a bug in Lake.)\n"
+
+def reportResult (cfg : BuildConfig) (out : IO.FS.Stream) (result : MonitorResult) : BaseIO Unit := do
+  if result.failures.isEmpty then
+    if cfg.showProgress && cfg.showSuccess then
+      let numJobs := result.numJobs
+      let jobs := if numJobs == 1 then "1 job" else s!"{numJobs} jobs"
+      if cfg.noBuild then
+        print! out s!"All targets up-to-date ({jobs}).\n"
+      else
+        print! out s!"Build completed successfully ({jobs}).\n"
+  else
+    print! out "Some required targets logged failures:\n"
+    result.failures.forM (print! out s!"- {·}\n")
+    flush out
+
+structure BuildResult (α : Type u) extends MonitorResult where
+  out : Except String α
+
+instance : CoeOut (BuildResult α) MonitorResult := ⟨BuildResult.toMonitorResult⟩
+
+@[inline] def BuildResult.isOk (self : BuildResult α) : Bool :=
+  self.out.isOk
+
+def monitorJob (ctx : MonitorContext) (job : Job α) : BaseIO (BuildResult α) := do
+  let result ← monitorJobs' ctx #[job]
+  if result.isOk then
+    if let some a ← job.wait? then
+      return {toMonitorResult := result, out := .ok a}
+    else
+      -- Computation job failed but was unreported in the monitor. This should be impossible.
+      return {toMonitorResult := result, out := .error <|
+        "uncaught top-level build failure (this is likely a bug in Lake)"}
+  else
+    return {toMonitorResult := result, out := .error "build failed"}
+
+def monitorFetchM
+  (mctx : MonitorContext) (bctx : BuildContext) (build : FetchM α)
+  (caption := "job computation")
+: BaseIO (BuildResult α) := do
+  let compute := Job.async build (caption := caption)
+  let job ← compute.run.run'.run bctx |>.run nilTrace
+  monitorJob mctx job
+
+def Workspace.finalizeBuild
+  (ws : Workspace) (cfg : BuildConfig) (ctx : MonitorContext) (result : BuildResult α)
+: IO α := do
+  reportResult cfg ctx.out result
+  if let some outputsFile := cfg.outputsFile? then
+    ws.saveOutputs (logger := ctx.logger) ctx.out outputsFile (cfg.verbosity matches .verbose)
+  if cfg.noBuild && result.didBuild then
+    IO.Process.exit noBuildCode.toUInt8
+  else
+    IO.ofExcept result.out
+
+def mkBuildContext' (ws : Workspace) (cfg : BuildConfig) (jobs : JobQueue) : BuildContext where
+  opaqueWs := ws
+  toBuildConfig := cfg
+  registeredJobs := jobs
+  leanTrace := .ofHash (pureHash ws.lakeEnv.leanGithash)
+    s!"Lean {Lean.versionStringCore}, commit {ws.lakeEnv.leanGithash}"
 
 /--
 Run a build function in the Workspace's context using the provided configuration.
@@ -231,78 +345,56 @@ Reports incremental build progress and build logs. In quiet mode, only reports
 failing build jobs (e.g., when using `-q` or non-verbose `--no-build`).
 -/
 public def Workspace.runFetchM
-  (ws : Workspace) (build : FetchM α) (cfg : BuildConfig := {})
+  (ws : Workspace) (build : FetchM α) (cfg : BuildConfig := {}) (caption := "job computation")
 : IO α := do
-  -- Configure
-  let out ← cfg.out.get
-  let useAnsi ← cfg.ansiMode.isEnabled out
-  let outLv := cfg.outLv
-  let failLv := cfg.failLv
-  let isVerbose := cfg.verbosity = .verbose
-  let showProgress := cfg.showProgress
-  let showSuccess := cfg.showSuccess
-  let ctx ← mkBuildContext ws cfg
-  -- Job Computation
-  let caption := "job computation"
-  let compute := Job.async build (caption := caption)
-  let job ← compute.run.run'.run ctx |>.run nilTrace
-  -- Job Monitor
-  let minAction := if isVerbose then .unknown else .fetch
-  let showOptional := isVerbose
-  let showTime := isVerbose || !useAnsi
-  let {failures, numJobs, didBuild} ← monitorJobs #[job] ctx.registeredJobs
-    out failLv outLv minAction showOptional useAnsi showProgress showTime
-  -- Save input-to-output mappings
-  if let some outputsFile := cfg.outputsFile? then
-    let logger := .stream out outLv useAnsi
-    unless ws.isRootArtifactCacheEnabled do
-      logger.logEntry <| .warning s!"{ws.root.prettyName}: \
-        the artifact cache is not enabled for this package, so the artifacts described \
-        by the mappings produced by `-o` will not necessarily be available in the cache."
-    if let some ref := ws.root.outputsRef? then
-      match (← (← ref.get).writeFile outputsFile {}) with
-      | .ok _ log =>
-        if !log.isEmpty && isVerbose then
-          print! out "There were issues saving input-to-output mappings from the build:\n"
-          log.replay (logger := logger)
-      | .error _ log =>
-        print! out "Failed to save input-to-output mappings from the build.\n"
-        if isVerbose then
-          log.replay (logger := logger)
+  let jobs ← mkJobQueue
+  let mctx ← mkMonitorContext cfg jobs
+  let bctx := mkBuildContext' ws cfg jobs
+  let result ← monitorFetchM mctx bctx build caption
+  ws.finalizeBuild cfg mctx result
+
+def monitorBuild
+  (mctx : MonitorContext) (bctx : BuildContext) (build : FetchM (Job α))
+  (caption := "job computation")
+: BaseIO (BuildResult α) := do
+  let result ← monitorFetchM mctx bctx build caption
+   match result.out with
+  | .ok job =>
+    if let some a ← job.wait? then
+      return {result with out := .ok a}
     else
-      print! out "Workspace missing input-to-output mappings from build. (This is likely a bug in Lake.)\n"
-  -- Report
-  let isNoBuild := cfg.noBuild
-  if failures.isEmpty then
-    let some a ← job.wait?
-      | print! out "Uncaught top-level build failure (this is likely a bug in Lake).\n"
-        error "build failed"
-    if showProgress && showSuccess then
-      let jobs := if numJobs == 1 then "1 job" else s!"{numJobs} jobs"
-      if isNoBuild then
-        print! out s!"All targets up-to-date ({jobs}).\n"
-      else
-        print! out s!"Build completed successfully ({jobs}).\n"
-    return a
-  else
-    print! out "Some required targets logged failures:\n"
-    failures.forM (print! out s!"- {·}\n")
-    flush out
-    if isNoBuild && didBuild then
-      IO.Process.exit noBuildCode.toUInt8
-    else
-      error "build failed"
+      -- Job failed but was unreported in the monitor. It was likely not properly registered.
+      return {result with out := .error <|
+        "uncaught top-level build failure (this is likely a bug in the build script)"}
+  | .error e =>
+    return {result with out := .error e}
+
+/--
+Returns whether a build is needed to validate `build`. Does not report on the attempted build.
+
+This is equivalent to checking whether `lake build --no-build` exits with code 0.
+-/
+@[inline] public def Workspace.checkNoBuild
+  (ws : Workspace) (build : FetchM (Job α))
+: BaseIO Bool := do
+  let jobs ← mkJobQueue
+  let cfg := {noBuild := true}
+  let mctx ← mkMonitorContext cfg jobs
+  let bctx := mkBuildContext' ws cfg jobs
+  let result ← monitorBuild mctx bctx build
+  return result.isOk && !result.didBuild
 
 /-- Run a build function in the Workspace's context and await the result. -/
 @[inline] public def Workspace.runBuild
   (ws : Workspace) (build : FetchM (Job α)) (cfg : BuildConfig := {})
 : IO α := do
-  let job ← ws.runFetchM build cfg
-  let some a ← job.wait? | error "build failed"
-  return a
+  let jobs ← mkJobQueue
+  let mctx ← mkMonitorContext cfg jobs
+  let bctx := mkBuildContext' ws cfg jobs
+  let result ← monitorBuild mctx bctx build
+  ws.finalizeBuild cfg mctx result
 
 /-- Produce a build job in the Lake monad's workspace and await the result. -/
 @[inline] public def runBuild
   (build : FetchM (Job α)) (cfg : BuildConfig := {})
-: LakeT IO α := do
-  (← getWorkspace).runBuild build cfg
+: LakeT IO α := do (← getWorkspace).runBuild build cfg

--- a/src/lake/Lake/CLI.lean
+++ b/src/lake/Lake/CLI.lean
@@ -13,6 +13,7 @@ public import Lake.CLI.Help
 public import Lake.CLI.Init
 public import Lake.CLI.Main
 public import Lake.CLI.Serve
+public import Lake.CLI.Shake
 public import Lake.CLI.Translate
 public import Lake.CLI.Translate.Lean
 public import Lake.CLI.Translate.Toml

--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -30,6 +30,7 @@ COMMANDS:
   lint                  lint the package using the configured lint driver
   check-lint            check if there is a properly configured lint driver
   clean                 remove build outputs
+  shake                 minimize imports in source files
   env <cmd> <args>...   execute a command in Lake's environment
   lean <file>           elaborate a Lean file in Lake's context
   update                update dependencies and save them to the manifest
@@ -310,6 +311,44 @@ USAGE:
 If no package is specified, deletes the build directories of every package in
 the workspace. Otherwise, just deletes those of the specified packages."
 
+def helpShake :=
+"Minimize imports in Lean source files
+
+USAGE:
+  lake shake [OPTIONS] [<MODULE>...]
+
+Checks the current project for unused imports by analyzing generated `.olean`
+files to deduce required imports and ensuring that every import contributes
+some constant or other elaboration dependency.
+
+ARGUMENTS:
+  <MODULE>              A module path like `Mathlib`. All files transitively
+                        reachable from the provided module(s) will be checked.
+                        If not specified, uses the package's default targets.
+
+OPTIONS:
+  --force               Skip the `lake build --no-build` sanity check
+  --keep-implied        Preserve imports implied by other imports
+  --keep-prefix         Prefer parent module imports over specific submodules
+  --keep-public         Preserve all `public` imports for API stability
+  --add-public          Add new imports as `public` if they were in the
+                        original public closure
+  --explain             Show which constants require each import
+  --fix                 Apply suggested fixes directly to source files
+  --gh-style            Output in GitHub problem matcher format
+
+ANNOTATIONS:
+  Source files can contain special comments to control shake behavior:
+
+  * `module -- shake: keep-downstream`
+    Preserves this module in all downstream modules
+
+  * `module -- shake: keep-all`
+    Preserves all existing imports in this module
+
+  * `import X -- shake: keep`
+    Preserves this specific import"
+
 def helpCacheCli :=
 "Manage the Lake cache
 
@@ -557,6 +596,7 @@ public def help : (cmd : String) → String
 | "lint"                => helpLint
 | "check-lint"          => helpCheckLint
 | "clean"               => helpClean
+| "shake"               => helpShake
 | "script"              => helpScriptCli
 | "scripts"             => helpScriptList
 | "run"                 => helpScriptRun

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -786,7 +786,7 @@ protected def shake : CliM PUnit := do
         error "there are out of date oleans; run `lake build` or fetch them from a cache first"
     -- Run shake with workspace search paths
     Lean.searchPathRef.set ws.augmentedLeanPath
-    let exitCode ← Shake.run' args h ws.augmentedLeanSrcPath
+    let exitCode ← Shake.run args h ws.augmentedLeanSrcPath
     if exitCode != 0 then
       exit exitCode
   else

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -779,8 +779,14 @@ protected def shake : CliM PUnit := do
   let mods := if mods.isEmpty then ws.defaultTargetRoots else mods
   if h : 0 < mods.size then
     let args := {opts.shake with mods}
+    unless args.force do
+      let specs ← parseTargetSpecs ws []
+      let upToDate ← ws.checkNoBuild (buildSpecs specs)
+      unless upToDate do
+        error "there are out of date oleans; run `lake build` or fetch them from a cache first"
     -- Run shake with workspace search paths
-    let exitCode ← Shake.run' args h ws.augmentedLeanPath ws.augmentedLeanSrcPath
+    Lean.searchPathRef.set ws.augmentedLeanPath
+    let exitCode ← Shake.run' args h ws.augmentedLeanSrcPath
     if exitCode != 0 then
       exit exitCode
   else

--- a/src/lake/Lake/CLI/Shake.lean
+++ b/src/lake/Lake/CLI/Shake.lean
@@ -637,6 +637,8 @@ public def run (args : Args) (h : 0 < args.mods.size)
   let (_, s) ← importModulesCore imps (isExported := true) |>.run
   let s := s.markAllExported
   let mut env ← finalizeImport s (isModule := true) imps {} (leakEnv := false) (loadExts := false)
+  if env.header.moduleData.any (!·.isModule) then
+    throw <| .userError "`lake shake` only works with `module`s currently"
   -- the one env ext we want to initialize
   let is := indirectModUseExt.toEnvExtension.getState env
   let newState ← indirectModUseExt.addImportedFn is.importedEntries { env := env, opts := {} }

--- a/src/lake/Lake/CLI/Shake.lean
+++ b/src/lake/Lake/CLI/Shake.lean
@@ -699,7 +699,10 @@ public def run (args : Args) (defaultTargetModules : Array Name)
     let mut seen : Std.HashSet Import := {}
     for stx in imports do
       let mod := decodeImport stx
-      if remove.contains mod || seen.contains mod then
+      -- Compare by module name only, ignoring isExported which may differ between
+      -- olean analysis and source file parsing
+      let shouldRemove := remove.any fun r => r.module == mod.module && r.isMeta == mod.isMeta
+      if shouldRemove || seen.contains mod then
         out := out ++ text.extract pos (text.pos! stx.raw.getPos?.get!)
         -- We use the end position of the syntax, but include whitespace up to the first newline
         pos := text.pos! stx.raw.getTailPos?.get! |>.find '\n' |>.next!

--- a/src/lake/Lake/CLI/Shake.lean
+++ b/src/lake/Lake/CLI/Shake.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro, Sebastian Ullrich
 -/
 module
 
+prelude
 import Lean.Environment
 import Lean.ExtraModUses
 import Lean.Parser.Module

--- a/src/lake/Lake/Config/Workspace.lean
+++ b/src/lake/Lake/Config/Workspace.lean
@@ -52,6 +52,16 @@ public instance : Nonempty Workspace :=
 
 public hydrate_opaque_type OpaqueWorkspace Workspace
 
+/-- Returns the names of the root modules of the package's default targets. -/
+public def Package.defaultTargetRoots (self : Package) : Array Lean.Name :=
+  self.defaultTargets.flatMap fun target =>
+    if let some lib := self.findLeanLib? target then
+      lib.roots
+    else if let some exe := self.findLeanExe? target then
+      #[exe.root.name]
+    else
+      #[]
+
 namespace Workspace
 
 /-- **For internal use.** Whether this workspace is Lean itself.  -/
@@ -101,6 +111,10 @@ public def isRootArtifactCacheEnabled (ws : Workspace) : Bool :=
 /-- Options to pass to the Lean server when editing Lean files outside a library. -/
 @[inline] public def serverOptions (self : Workspace) : LeanOptions :=
   self.root.moreServerOptions
+
+/-- Returns the names of the root modules of the workpace root's default targets. -/
+@[inline] public def defaultTargetRoots (self : Workspace) : Array Lean.Name :=
+  self.root.defaultTargetRoots
 
 /-- The workspace's Lake manifest. -/
 @[inline] public def manifestFile (self : Workspace) : FilePath :=

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -221,7 +221,7 @@ ENDFOREACH(T)
 # toolchain: requires elan to download toolchain
 # online: downloads remote repositories
 file(GLOB_RECURSE LEANLAKETESTS
-  #"${LEAN_SOURCE_DIR}/../tests/lake/tests/test.sh"
+  "${LEAN_SOURCE_DIR}/../tests/lake/tests/test.sh"
   "${LEAN_SOURCE_DIR}/../tests/lake/examples/test.sh")
 FOREACH(T ${LEANLAKETESTS})
   if(NOT T MATCHES ".*(lake-packages|bootstrap|toolchain|online).*")

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -221,7 +221,7 @@ ENDFOREACH(T)
 # toolchain: requires elan to download toolchain
 # online: downloads remote repositories
 file(GLOB_RECURSE LEANLAKETESTS
-  "${LEAN_SOURCE_DIR}/../tests/lake/tests/test.sh"
+  #"${LEAN_SOURCE_DIR}/../tests/lake/tests/test.sh"
   "${LEAN_SOURCE_DIR}/../tests/lake/examples/test.sh")
 FOREACH(T ${LEANLAKETESTS})
   if(NOT T MATCHES ".*(lake-packages|bootstrap|toolchain|online).*")

--- a/tests/lake/tests/shake/.gitignore
+++ b/tests/lake/tests/shake/.gitignore
@@ -1,0 +1,8 @@
+.lake/
+lake-manifest.json
+lake-packages/
+produced.out
+# Working files copied from input/
+lakefile.toml
+Main.lean
+Lib/

--- a/tests/lake/tests/shake/clean.sh
+++ b/tests/lake/tests/shake/clean.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+rm -rf .lake lake-manifest.json lake-packages
+rm -f lakefile.toml Main.lean
+rm -rf Lib

--- a/tests/lake/tests/shake/expected/Main.lean
+++ b/tests/lake/tests/shake/expected/Main.lean
@@ -1,4 +1,6 @@
+module
+
 import Lib.A
 
--- Only uses valueA, so Lib.B should be removed by shake
+-- Does not use Lib.B, uses Lib.A privately only
 def myValue : Nat := valueA

--- a/tests/lake/tests/shake/expected/Main.lean
+++ b/tests/lake/tests/shake/expected/Main.lean
@@ -1,0 +1,4 @@
+import Lib.A
+
+-- Only uses valueA, so Lib.B should be removed by shake
+def myValue : Nat := valueA

--- a/tests/lake/tests/shake/input/Lib/A.lean
+++ b/tests/lake/tests/shake/input/Lib/A.lean
@@ -1,1 +1,3 @@
-def valueA : Nat := 42
+module
+
+public def valueA : Nat := 42

--- a/tests/lake/tests/shake/input/Lib/A.lean
+++ b/tests/lake/tests/shake/input/Lib/A.lean
@@ -1,0 +1,1 @@
+def valueA : Nat := 42

--- a/tests/lake/tests/shake/input/Lib/B.lean
+++ b/tests/lake/tests/shake/input/Lib/B.lean
@@ -1,1 +1,3 @@
-def valueB : Nat := 99
+module
+
+public def valueB : Nat := 99

--- a/tests/lake/tests/shake/input/Lib/B.lean
+++ b/tests/lake/tests/shake/input/Lib/B.lean
@@ -1,0 +1,1 @@
+def valueB : Nat := 99

--- a/tests/lake/tests/shake/input/Main.lean
+++ b/tests/lake/tests/shake/input/Main.lean
@@ -1,5 +1,7 @@
-import Lib.A
-import Lib.B
+module
 
--- Only uses valueA, so Lib.B should be removed by shake
+public import Lib.A
+public import Lib.B
+
+-- Does not use Lib.B, uses Lib.A privately only
 def myValue : Nat := valueA

--- a/tests/lake/tests/shake/input/Main.lean
+++ b/tests/lake/tests/shake/input/Main.lean
@@ -1,0 +1,5 @@
+import Lib.A
+import Lib.B
+
+-- Only uses valueA, so Lib.B should be removed by shake
+def myValue : Nat := valueA

--- a/tests/lake/tests/shake/input/lakefile.toml
+++ b/tests/lake/tests/shake/input/lakefile.toml
@@ -1,0 +1,10 @@
+name = "test"
+version = "0.1.0"
+defaultTargets = ["Main"]
+
+[[lean_lib]]
+name = "Lib"
+globs = ["Lib.**"]
+
+[[lean_lib]]
+name = "Main"

--- a/tests/lake/tests/shake/test.sh
+++ b/tests/lake/tests/shake/test.sh
@@ -3,8 +3,6 @@ source ../common.sh
 
 ./clean.sh
 
-TEST_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
-
 # Test the `lake shake` command
 
 # Copy input project to working directory
@@ -13,16 +11,16 @@ cp -r input/* .
 # Build the project first (shake needs .olean files)
 test_run build
 
-# Run shake to check for unused imports (using --force to skip the lake build --no-build check)
+# Run shake to check for unused imports
 # Shake exits with code 1 when issues are found, which is expected here
-lake_out shake --force Main || true
+lake_out shake Main || true
 match_pat 'remove.*Lib.B' produced.out
 
 # Test --fix mode: apply the fixes and verify the result
 ./clean.sh
 cp -r input/* .
 test_run build
-test_run shake --force --fix Main
+test_run shake --fix Main
 
 # Verify Main.lean matches expected (Lib.B import removed)
-check_diff "$TEST_DIR/expected/Main.lean" Main.lean
+check_diff expected/Main.lean Main.lean

--- a/tests/lake/tests/shake/test.sh
+++ b/tests/lake/tests/shake/test.sh
@@ -17,3 +17,12 @@ test_run build
 # Shake exits with code 1 when issues are found, which is expected here
 lake_out shake --force Main || true
 match_pat 'remove.*Lib.B' produced.out
+
+# Test --fix mode: apply the fixes and verify the result
+./clean.sh
+cp -r input/* .
+test_run build
+test_run shake --force --fix Main
+
+# Verify Main.lean matches expected (Lib.B import removed)
+check_diff "$TEST_DIR/expected/Main.lean" Main.lean

--- a/tests/lake/tests/shake/test.sh
+++ b/tests/lake/tests/shake/test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+TEST_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+
+# Test the `lake shake` command
+
+# Copy input project to working directory
+cp -r input/* .
+
+# Build the project first (shake needs .olean files)
+test_run build
+
+# Run shake to check for unused imports (using --force to skip the lake build --no-build check)
+# Shake exits with code 1 when issues are found, which is expected here
+lake_out shake --force Main || true
+match_pat 'remove.*Lib.B' produced.out


### PR DESCRIPTION
This PR adds `lake shake` as a built-in Lake command, moving the shake functionality from `script/Shake.lean` into the Lake CLI.

## Motivation

Per discussion with @Kha and @tydeu, having shake as a top-level Lake command is preferable to `lake exe shake` because:
- Avoids the awkwardness of accessing core tools via `lake exe`
- Compiles shake into the Lake binary, avoiding lakefile issues
- No benefit to lazy compilation on user machines for this tool

## Changes

- Move shake logic from `script/Shake.lean` to `src/lake/Lake/CLI/Shake.lean`
- Add `lake shake` command dispatch in `Lake/CLI/Main.lean`
- Add help text in `Lake/CLI/Help.lean`
- Remove the standalone shake executable from `script/lakefile.toml`

## Usage

```
lake shake [OPTIONS] [<MODULE>...]
```

See `lake shake --help` for full documentation.

🤖 Prepared with Claude Code