### PR TITLE
feat: add `EmptyCollection MessageLog` instance

### DIFF
--- a/src/Lean/Message.lean
+++ b/src/Lean/Message.lean
@@ -570,6 +570,8 @@ structure MessageLog where
 namespace MessageLog
 def empty : MessageLog := {}
 
+instance : EmptyCollection MessageLog := ⟨empty⟩
+
 -- Despite having been deprecated, the archived `LeanInk` project (which CI still uses)
 -- relies on this name.
 @[deprecated "renamed to `unreported`; direct access should in general be avoided in favor of \


### PR DESCRIPTION
This PR adds an `EmptyCollection` instance for `MessageLog`, allowing
the use of `{}` syntax in contexts that require an empty message log.

🤖 Prepared with Claude Code