### PR TITLE
feat: add option for simplifying `have` decls in two passes

### DIFF
--- a/src/Lean/Meta/Tactic/Simp/Main.lean
+++ b/src/Lean/Meta/Tactic/Simp/Main.lean
@@ -389,8 +389,9 @@ def simpForall (e : Expr) : SimpM Result := withParent e do
 
 /-- Adapter for `Meta.simpHaveTelescope` -/
 def simpHaveTelescope (e : Expr) : SimpM Result := do
-  let zetaUnused := (← getConfig).zetaUnused
-  match (← Meta.simpHaveTelescope e zetaUnused) with
+  -- **Note**: Eliminating unused-let declarations in a single pass may produce O(n^2) proofs.
+  let zetaUnusedMode := if (← getConfig).zetaUnused then .singlePass else .no
+  match (← Meta.simpHaveTelescope e zetaUnusedMode) with
   | .rfl => return { expr := e }
   | .step e' h =>
     if debug.simp.check.have.get (← getOptions) then

--- a/tests/bench/sym/simp_3.lean
+++ b/tests/bench/sym/simp_3.lean
@@ -24,11 +24,17 @@ def simp (e : Expr) : MetaM (Sym.Simp.Result × Float) := Sym.SymM.run do
   let startTime ← IO.monoNanosNow
   let r ← Sym.simp e methods { maxSteps := 100000000 }
   let endTime ← IO.monoNanosNow
+  let timeMs := (endTime - startTime).toFloat / 1000000.0
   -- logInfo e
   -- match r with
   -- | .rfl _ => logInfo "rfl"
-  -- | .step e' h _ => logInfo e'; logInfo h; check h
-  let timeMs := (endTime - startTime).toFloat / 1000000.0
+  -- | .step e' h _ =>
+  --   logInfo e'; logInfo h
+  --   let startTime ← IO.monoNanosNow
+  --   checkWithKernel h
+  --   let endTime ← IO.monoNanosNow
+  --   let timeMs := (endTime - startTime).toFloat / 1000000.0
+  --   logInfo s!"kernel time {timeMs} ms"
   return (r, timeMs)
 
 def mkLetBench (n : Nat) (includeUnused : Bool) : MetaM Expr := do


### PR DESCRIPTION
This PR adds a new option to the function `simpHaveTelescope` in which the `have` telescope is simplified in two passes:

* In the first pass, only the values and the body are simplified.
* In the second pass, unused declarations are eliminated.

This new mode eliminates **superlinear** behavior in the benchmark `simp_3.lean`. Note that the kernel type checker still **exhibits** quadratic behavior in this example, because it **does not have support** for expanding a `have`/`let` telescope in a single step.
