### PR TITLE
chore: partially revert feat: abstract metavariables when generalizing `match` motives (#8099)

### DIFF
--- a/src/Init/Grind/Ring/CommSolver.lean
+++ b/src/Init/Grind/Ring/CommSolver.lean
@@ -766,7 +766,7 @@ def Poly.cancelVar (c : Int) (x : Var) (p : Poly) : Poly :=
           (fun _ _ _ _ => a.toPoly_k.pow k)
           (fun _ _ _ _ => a.toPoly_k.pow k)
           (fun _ _ _ => a.toPoly_k.pow k)
-          a) = match (generalizing := false) a with
+          a) = match (generalizing := false) a with -- `generalizing := false` blocks generalization of `ih`
             | num n => Poly.num (n ^ k)
             | .intCast n => .num (n^k)
             | .natCast n => .num (n^k)

--- a/src/Lean/Elab/Match.lean
+++ b/src/Lean/Elab/Match.lean
@@ -1119,11 +1119,11 @@ private def elabMatchAux (generalizing? : Option Bool) (discrStxs : Array Syntax
       withRef altLHS.ref do
         for d in altLHS.fvarDecls do
           if d.hasExprMVar then
-            -- This code path is a vestige prior to fixing #8099, but it is still appears to be
-            -- important for testcase 1300.lean.
             tryPostpone
             withExistingLocalDecls altLHS.fvarDecls do
               runPendingTacticsAt d.type
+              if (← instantiateMVars d.type).hasExprMVar then
+                throwMVarError m!"Invalid match expression: The type of pattern variable '{d.toExpr}' contains metavariables:{indentExpr d.type}"
         for p in altLHS.patterns do
           if (← Match.instantiatePatternMVars p).hasExprMVar then
             tryPostpone

--- a/src/Lean/Meta/Tactic/Congr.lean
+++ b/src/Lean/Meta/Tactic/Congr.lean
@@ -52,13 +52,6 @@ def MVarId.congr? (mvarId : MVarId) : MetaM (Option (List MVarId)) :=
     applyCongrThm? mvarId congrThm
 
 /--
-Try to apply a `simp` congruence theorem and throw an error if it fails.
--/
-def MVarId.congr (mvarId : MVarId) : MetaM (List MVarId) := do
-  let some mvarIds ← mvarId.congr? | throwError "Failed to apply `simp` congruence theorem"
-  return mvarIds
-
-/--
 Try to apply a `hcongr` congruence theorem, and then tries to close resulting goals
 using `Eq.refl`, `HEq.refl`, and assumption.
 -/

--- a/src/Lean/Meta/Tactic/Refl.lean
+++ b/src/Lean/Meta/Tactic/Refl.lean
@@ -62,13 +62,4 @@ def _root_.Lean.MVarId.hrefl (mvarId : MVarId) : MetaM Unit := do
     let some [] ← observing? do mvarId.apply (mkConst ``HEq.refl [← mkFreshLevelMVar])
       | throwTacticEx `hrefl mvarId
 
-/--
-Close given goal using `Subsingleton.helim`.
--/
-def _root_.Lean.MVarId.helim (mvarId : MVarId) : MetaM (List MVarId) :=
-  mvarId.withContext do
-    let some subGoals ← observing? do mvarId.apply (mkConst ``Subsingleton.helim [← mkFreshLevelMVar])
-      | throwTacticEx `hrefl mvarId
-    return subGoals
-
 end Lean.Meta

--- a/tests/lean/run/8099.lean
+++ b/tests/lean/run/8099.lean
@@ -1,10 +1,19 @@
-
+/--
+error: Invalid match expression: The type of pattern variable 'n' contains metavariables:
+  ?m.31
+-/
+#guard_msgs (error) in
 example : List Bool :=
   let s : String := "test"
   let l : List Nat := [1, 2, 3]
   let r := match 1 with | _ => l.map (fun n => let (x) := s; true)
   []
 
+/--
+error: Invalid match expression: The type of pattern variable 'n' contains metavariables:
+  ?m.38
+-/
+#guard_msgs (error) in
 example : List Bool :=
   let p : String × String := ("test", "test")
   let l : List Nat := [1, 2, 3]
@@ -22,6 +31,20 @@ example : List Bool :=
 example (a : Nat) (ha : a = 37) :=
   (match a with | 42 => by contradiction | n => n) = 37
 
+/--
+error: Invalid match expression: The type of pattern variable 'jp' contains metavariables:
+  ?m.11 0
+---
+error: Case tag `jmp1` not found.
+
+Hint: The only available case tag is `rhs`.
+  j̵m̵p̵1̵r̲h̲s̲
+-/
+#guard_msgs (error) in
+-- Accepting the following example would force the match compiler to cope with metavariables in
+-- discriminant types (i.e., `jp`). #11696 opened up the code path, but it became clear that the
+-- metavariables caused over eager generalization due to uninstantiated delayed assignments, hence
+-- we decided to revert and drop support for metavariables in discriminant types.
 example (n : Nat) : Id (Fin (n + 1)) :=
   have jp : ?m := ?rhs
   match n with

--- a/tests/lean/run/match1.lean
+++ b/tests/lean/run/match1.lean
@@ -225,8 +225,8 @@ match parity n with
 | Parity.odd  j => true  :: natToBin j
 
 /--
-error: Invalid match expression: This pattern contains metavariables:
-  (a, b)
+error: Invalid match expression: The type of pattern variable 'a' contains metavariables:
+  ?m.12
 ---
 info: fun x => ?m.3 : ?m.12 × ?m.13 → ?m.12
 -/


### PR DESCRIPTION
This PR partially reverts #11696. More specifically, we will keep properly abstracting metavariables when generalizing `match`, but we will revert to rejecting matches where discriminant types have metavariables, so that the match compiler does not see metavariables.

Reopens #8099.