### PR TITLE
fix: ctor visibility in mutual public inductives

### DIFF
--- a/tests/lean/run/11115.lean
+++ b/tests/lean/run/11115.lean
@@ -1,0 +1,18 @@
+module
+
+/-! Used to crash in codegen -/
+
+mutual
+public inductive B where
+  | bar
+end
+
+/-! Used to declare a private ctor. -/
+mutual
+public inductive Term where
+  | A (args : List Term)
+end
+
+/-- info: constructor Term.A : List Term → Term -/
+#guard_msgs in
+#print Term.A


### PR DESCRIPTION
This PR fixes module system visibiltity issues when trying to declare a public inductive inside a mutual block.

Fixes #11115