### PR TITLE
feat: add BitVec.signExtend_extractLsb_setWidth theorem

### DIFF
--- a/src/Init/Data/BitVec/Lemmas.lean
+++ b/src/Init/Data/BitVec/Lemmas.lean
@@ -2572,6 +2572,9 @@ theorem msb_signExtend {x : BitVec w} :
   · simp [h, BitVec.msb, getMsbD_signExtend, show v - w = 0 by omega]
   · simp [h, BitVec.msb, getMsbD_signExtend, show ¬ (v - w = 0) by omega]
 
+/-- Sign-extending to `w + n` bits, extracting bits `[w - 1 + n..n]`, and setting width
+back to `w` is equivalent to arithmetic right shift by `n`, since both sides discard the `n`
+least significant bits and replicate the sign bit into the upper bits. -/
 @[simp]
 theorem signExtend_extractLsb_setWidth {x : BitVec w} {n : Nat} :
     ((x.signExtend (w + n)).extractLsb (w - 1 + n) n).setWidth w = x.sshiftRight n := by


### PR DESCRIPTION
This PR introduces the theorem `BitVec.sshiftRight_eq_setWidth_extractLsb_signExtend` theorem, proving `x.sshiftRight n` is equivalent to first sign-extending `x`, extracting the appropriate least significant bits, and then setting the width back to `w`.