### PR TITLE
feat: add `grind +locals` to include local definitions

### DIFF
--- a/src/Init/Grind/Config.lean
+++ b/src/Init/Grind/Config.lean
@@ -21,6 +21,8 @@ structure Config where
   /-- If `suggestions` is `true`, `grind` will invoke the currently configured library suggestion engine on the current goal,
   and add attempt to use the resulting suggestions as additional parameters to the `grind` tactic. -/
   suggestions : Bool := false
+  /-- If `locals` is `true`, `grind` will add all definitions from the current file. -/
+  locals : Bool := false
   /-- Maximum number of case-splits in a proof search branch. It does not include splits performed during normalization. -/
   splits : Nat := 9
   /-- Maximum number of E-matching (aka heuristic theorem instantiation) rounds before each case split. -/

--- a/src/Lean/Meta/Tactic/Grind.lean
+++ b/src/Lean/Meta/Tactic/Grind.lean
@@ -101,5 +101,7 @@ builtin_initialize registerTraceClass `grind.debug.proveEq
 builtin_initialize registerTraceClass `grind.debug.pushNewFact
 builtin_initialize registerTraceClass `grind.debug.appMap
 builtin_initialize registerTraceClass `grind.debug.ext
+builtin_initialize registerTraceClass `grind.debug.suggestions
+builtin_initialize registerTraceClass `grind.debug.locals
 
 end Lean

--- a/tests/lean/run/grind_ite.lean
+++ b/tests/lean/run/grind_ite.lean
@@ -145,14 +145,15 @@ def normalize (assign : Std.HashMap Nat Bool) : IfExpr → IfExpr
     | some b => normalize assign (ite (lit b) t e)
   termination_by e => e.normSize
 
--- We tell `grind` to unfold our definitions above.
-attribute [local grind] normalized hasNestedIf hasConstantIf hasRedundantIf disjoint vars eval List.disjoint
+-- We could tell `grind` to unfold our definitions above.
+-- attribute [local grind] normalized hasNestedIf hasConstantIf hasRedundantIf disjoint vars eval List.disjoint
+-- Instead we just rely on `grind +locals`, which tells `grind` it is allowed to unfold definitions in the current file.
 
 theorem normalize_spec (assign : Std.HashMap Nat Bool) (e : IfExpr) :
     (normalize assign e).normalized
     ∧ (∀ f, (normalize assign e).eval f = e.eval fun w => assign[w]?.getD (f w))
     ∧ ∀ (v : Nat), v ∈ vars (normalize assign e) → ¬ v ∈ assign := by
-  fun_induction normalize with grind
+  fun_induction normalize with grind +locals
 
 -- We can also prove other variations, where we spell "`v` is not in `assign`"
 -- different ways, and `grind` doesn't mind.
@@ -161,13 +162,13 @@ example (assign : Std.HashMap Nat Bool) (e : IfExpr) :
     (normalize assign e).normalized
     ∧ (∀ f, (normalize assign e).eval f = e.eval fun w => assign[w]?.getD (f w))
     ∧ ∀ (v : Nat), v ∈ vars (normalize assign e) → assign.contains v = false := by
-  fun_induction normalize with grind
+  fun_induction normalize with grind +locals
 
 example (assign : Std.HashMap Nat Bool) (e : IfExpr) :
     (normalize assign e).normalized
     ∧ (∀ f, (normalize assign e).eval f = e.eval fun w => assign[w]?.getD (f w))
     ∧ ∀ (v : Nat), v ∈ vars (normalize assign e) → assign[v]? = none := by
-  fun_induction normalize with grind
+  fun_induction normalize with grind +locals
 
 /--
 We recall the statement of the if-normalization problem.
@@ -203,18 +204,18 @@ theorem normalize'_spec (assign : Std.TreeMap Nat Bool) (e : IfExpr) :
     (normalize' assign e).normalized
     ∧ (∀ f, (normalize' assign e).eval f = e.eval fun w => assign[w]?.getD (f w))
     ∧ ∀ (v : Nat), v ∈ vars (normalize' assign e) → ¬ v ∈ assign := by
-  fun_induction normalize' with grind
+  fun_induction normalize' with grind +locals
 
 example (assign : Std.TreeMap Nat Bool) (e : IfExpr) :
     (normalize' assign e).normalized
     ∧ (∀ f, (normalize' assign e).eval f = e.eval fun w => assign[w]?.getD (f w))
     ∧ ∀ (v : Nat), v ∈ vars (normalize' assign e) → assign.contains v = false := by
-  fun_induction normalize' with grind
+  fun_induction normalize' with grind +locals
 
 example (assign : Std.TreeMap Nat Bool) (e : IfExpr) :
     (normalize' assign e).normalized
     ∧ (∀ f, (normalize' assign e).eval f = e.eval fun w => assign[w]?.getD (f w))
     ∧ ∀ (v : Nat), v ∈ vars (normalize' assign e) → assign[v]? = none := by
-  fun_induction normalize' with grind
+  fun_induction normalize' with grind +locals
 
 end IfExpr

--- a/tests/lean/run/grind_locals.lean
+++ b/tests/lean/run/grind_locals.lean
@@ -1,0 +1,51 @@
+/-!
+# Test for `grind +locals` flag
+
+This tests that `grind +locals` adds local definitions from the current file.
+-/
+
+-- A simple definition that provides an equation grind can use
+def foo (n : Nat) : Nat := n + 1
+
+-- Without +locals, grind shouldn't know about foo
+-- (This test verifies +locals is actually doing something)
+/--
+error: `grind` failed
+case grind
+n : Nat
+h : ¬foo n = n + 1
+⊢ False
+[grind] Goal diagnostics
+  [facts] Asserted facts
+    [prop] ¬foo n = n + 1
+  [eqc] False propositions
+    [prop] foo n = n + 1
+  [cutsat] Assignment satisfying linear constraints
+    [assign] n := 0
+    [assign] foo n := 2
+-/
+#guard_msgs in
+example (n : Nat) : foo n = n + 1 := by grind
+
+-- Test that grind +locals can use the equation `foo n = n + 1`
+example (n : Nat) : foo n = n + 1 := by grind +locals
+
+-- An irrelevant definition that should NOT appear in grind? suggestions
+def bar (n : Nat) : Nat := n * 2
+
+-- Test that grind? +locals suggests only the relevant definition (foo), not bar
+/--
+info: Try these:
+  [apply] grind only [foo]
+  [apply] grind => instantiate only [foo]
+-/
+#guard_msgs in
+example (n : Nat) : foo n = n + 1 := by grind? +locals
+
+-- Test with a definition that has multiple equations via pattern matching
+def isZero : Nat → Bool
+  | 0 => true
+  | _ + 1 => false
+
+example : isZero 0 = true := by grind +locals
+example (n : Nat) : isZero (n + 1) = false := by grind +locals

--- a/tests/lean/run/grind_locals_module.lean
+++ b/tests/lean/run/grind_locals_module.lean
@@ -1,0 +1,56 @@
+
+module
+/-!
+# Test for `grind +locals` flag (using the module system)
+
+This tests that `grind +locals` adds local definitions from the current file.
+
+We have a separate test here as the current semantics for `isImplementationDetail` are poorly specified,
+and we've had to work around it in deciding which declarations should be included via `+locals`.
+-/
+
+-- A simple definition that provides an equation grind can use
+def foo (n : Nat) : Nat := n + 1
+
+-- Without +locals, grind shouldn't know about foo
+-- (This test verifies +locals is actually doing something)
+/--
+error: `grind` failed
+case grind
+n : Nat
+h : ¬foo n = n + 1
+⊢ False
+[grind] Goal diagnostics
+  [facts] Asserted facts
+    [prop] ¬foo n = n + 1
+  [eqc] False propositions
+    [prop] foo n = n + 1
+  [cutsat] Assignment satisfying linear constraints
+    [assign] n := 0
+    [assign] foo n := 2
+-/
+#guard_msgs in
+example (n : Nat) : foo n = n + 1 := by grind
+
+-- Test that grind +locals can use the equation `foo n = n + 1`
+example (n : Nat) : foo n = n + 1 := by grind +locals
+
+-- An irrelevant definition that should NOT appear in grind? suggestions
+def bar (n : Nat) : Nat := n * 2
+
+-- Test that grind? +locals suggests only the relevant definition (foo), not bar
+/--
+info: Try these:
+  [apply] grind only [foo]
+  [apply] grind => instantiate only [foo]
+-/
+#guard_msgs in
+example (n : Nat) : foo n = n + 1 := by grind? +locals
+
+-- Test with a definition that has multiple equations via pattern matching
+def isZero : Nat → Bool
+  | 0 => true
+  | _ + 1 => false
+
+example : isZero 0 = true := by grind +locals
+example (n : Nat) : isZero (n + 1) = false := by grind +locals


### PR DESCRIPTION
This PR adds a `+locals` configuration option to the `grind` tactic that automatically adds all definitions from the current file as e-match theorems. This provides a convenient alternative to manually adding `[local grind]` attributes to each definition. In the form `grind? +locals`, it is also helpful for discovering which local declarations it may be useful to add `[local grind]` attributes to.

Example usage:
```lean
def foo (n : Nat) : Nat := n + 1

-- Without +locals, grind doesn't know about foo
example (n : Nat) : foo n = n + 1 := by grind  -- fails

-- With +locals, grind can use the equation
example (n : Nat) : foo n = n + 1 := by grind +locals  -- succeeds
```

Instance definitions and internal details are filtered out.

🤖 Prepared with [Claude Code](https://claude.com/claude-code)