### PR TITLE
feat: add `simp +locals` to include local definitions

### DIFF
--- a/src/Init/MetaTypes.lean
+++ b/src/Init/MetaTypes.lean
@@ -132,6 +132,11 @@ structure Config where
   Unused `have`s are still removed if `zeta` or `zetaUnused` are true.
   -/
   zetaHave : Bool := true
+  /--
+  If `locals` is `true`, `dsimp` will unfold all definitions from the current file.
+  For local theorems, use `+suggestions` instead.
+  -/
+  locals : Bool := false
   deriving Inhabited, BEq
 
 end DSimp
@@ -297,6 +302,11 @@ structure Config where
   and attempt to use the resulting suggestions as parameters to the `simp` tactic.
   -/
   suggestions : Bool := false
+  /--
+  If `locals` is `true`, `simp` will unfold all definitions from the current file.
+  For local theorems, use `+suggestions` instead.
+  -/
+  locals : Bool := false
   deriving Inhabited, BEq
 
 -- Configuration object for `simp_all`

--- a/src/Lean/Elab/Tactic/SimpTrace.lean
+++ b/src/Lean/Elab/Tactic/SimpTrace.lean
@@ -21,19 +21,21 @@ The `simp?` tactic is a simple wrapper around the simp with trace behavior.
 namespace Lean.Elab.Tactic
 open Lean Elab Parser Tactic Meta Simp Tactic.TryThis
 
-/-- Filter out `+suggestions` from the config syntax -/
-def filterSuggestionsFromSimpConfig (cfg : TSyntax ``Lean.Parser.Tactic.optConfig) :
+/-- Filter out `+suggestions` and `+locals` from the config syntax -/
+def filterSuggestionsAndLocalsFromSimpConfig (cfg : TSyntax ``Lean.Parser.Tactic.optConfig) :
     MetaM (TSyntax ``Lean.Parser.Tactic.optConfig) := do
   -- The config has one arg: a null node containing configItem nodes
   let nullNode := cfg.raw.getArg 0
   let configItems := nullNode.getArgs
 
-  -- Filter out configItem nodes that contain +suggestions
+  -- Filter out configItem nodes that contain +suggestions or +locals
   let filteredItems := configItems.filter fun item =>
     match item[0]?, item.getKind with
     | some posConfigItem, ``Lean.Parser.Tactic.configItem =>
       match posConfigItem[1]?, posConfigItem.getKind with
-      | some ident, ``Lean.Parser.Tactic.posConfigItem => ident.getId != `suggestions
+      | some ident, ``Lean.Parser.Tactic.posConfigItem =>
+        let id := ident.getId
+        id != `suggestions && id != `locals
       | _, _ => true
     | _, _ => true
 
@@ -72,7 +74,7 @@ def mkSimpCallStx (stx : Syntax) (usedSimps : UsedSimps) : MetaM (TSyntax `tacti
     else
       `(tactic| simp%$tk $cfg:optConfig $[$discharger]? $[only%$o]? [$argsArray,*] $[$loc]?)
     -- Build syntax for suggestion (without +suggestions config)
-    let filteredCfg ← filterSuggestionsFromSimpConfig cfg
+    let filteredCfg ← filterSuggestionsAndLocalsFromSimpConfig cfg
     let stxForSuggestion ← if bang.isSome then
       `(tactic| simp!%$tk $filteredCfg:optConfig $[$discharger]? $[only%$o]? [$argsArray,*] $[$loc]?)
     else
@@ -118,7 +120,7 @@ def mkSimpCallStx (stx : Syntax) (usedSimps : UsedSimps) : MetaM (TSyntax `tacti
         else
           `(tactic| simp_all%$tk $cfg:optConfig $[$discharger]? $[only%$o]? [$argsArray,*])
     -- Build syntax for suggestion (without +suggestions config)
-    let filteredCfg ← filterSuggestionsFromSimpConfig cfg
+    let filteredCfg ← filterSuggestionsAndLocalsFromSimpConfig cfg
     let stxForSuggestion ←
       if argsArray.isEmpty then
         if bang.isSome then

--- a/src/Lean/Elab/Tactic/Try.lean
+++ b/src/Lean/Elab/Tactic/Try.lean
@@ -598,8 +598,8 @@ private def evalSuggestSimpAllTrace : TryTactic := fun tac => do
         | some mvarId => replaceMainGoal [mvarId]
         trace[try.debug] "`simp_all` succeeded"
         if (← read).config.only then
-          -- Remove +suggestions from config for the output (similar to SimpTrace.lean)
-          let filteredCfg ← filterSuggestionsFromSimpConfig configStx
+          -- Remove +suggestions and +locals from config for the output (similar to SimpTrace.lean)
+          let filteredCfg ← filterSuggestionsAndLocalsFromSimpConfig configStx
           -- Convert simp_all? to simp_all for mkSimpCallStx (similar to simpTraceToSimp)
           let tacWithoutTrace ← `(tactic| simp_all $filteredCfg:optConfig $[only%$_only]? $[[$_args,*]]?)
           let tac' ← mkSimpCallStx tacWithoutTrace stats.usedTheorems

--- a/tests/lean/run/simp_locals.lean
+++ b/tests/lean/run/simp_locals.lean
@@ -1,0 +1,44 @@
+/-!
+# Test for `simp +locals` flag
+
+This tests that `simp +locals` adds local definitions from the current file.
+-/
+
+-- A simple definition that provides an equation simp can use
+def foo (n : Nat) : Nat := n + 1
+
+-- Without +locals, simp shouldn't know about foo
+-- (This test verifies +locals is actually doing something)
+/--
+error: `simp` made no progress
+-/
+#guard_msgs in
+example (n : Nat) : foo n = n + 1 := by simp
+
+-- Test that simp +locals can use the equation `foo n = n + 1`
+example (n : Nat) : foo n = n + 1 := by simp +locals
+
+-- An irrelevant definition that should NOT appear in simp? suggestions
+def bar (n : Nat) : Nat := n * 2
+
+-- Test that simp? +locals suggests only the relevant definition (foo), not bar
+/--
+info: Try this:
+  [apply] simp only [foo, Nat.add_left_cancel_iff]
+-/
+#guard_msgs in
+example (n : Nat) : foo n = n + 1 := by simp? +locals
+
+-- Test with a definition that has multiple equations via pattern matching
+def isZero : Nat → Bool
+  | 0 => true
+  | _ + 1 => false
+
+example : isZero 0 = true := by simp +locals
+example (n : Nat) : isZero (n + 1) = false := by simp +locals
+
+-- Test simp_all +locals
+example (n : Nat) (h : n = 0) : isZero n = true := by simp_all +locals
+
+-- Test dsimp +locals
+example : foo 5 = 6 := by dsimp +locals

--- a/tests/lean/run/simp_locals_module.lean
+++ b/tests/lean/run/simp_locals_module.lean
@@ -1,0 +1,49 @@
+
+module
+/-!
+# Test for `simp +locals` flag (using the module system)
+
+This tests that `simp +locals` adds local definitions from the current file.
+
+We have a separate test here as the current semantics for `isImplementationDetail` are poorly specified,
+and we've had to work around it in deciding which declarations should be included via `+locals`.
+-/
+
+-- A simple definition that provides an equation simp can use
+def foo (n : Nat) : Nat := n + 1
+
+-- Without +locals, simp shouldn't know about foo
+-- (This test verifies +locals is actually doing something)
+/--
+error: `simp` made no progress
+-/
+#guard_msgs in
+example (n : Nat) : foo n = n + 1 := by simp
+
+-- Test that simp +locals can use the equation `foo n = n + 1`
+example (n : Nat) : foo n = n + 1 := by simp +locals
+
+-- An irrelevant definition that should NOT appear in simp? suggestions
+def bar (n : Nat) : Nat := n * 2
+
+-- Test that simp? +locals suggests only the relevant definition (foo), not bar
+/--
+info: Try this:
+  [apply] simp only [foo, Nat.add_left_cancel_iff]
+-/
+#guard_msgs in
+example (n : Nat) : foo n = n + 1 := by simp? +locals
+
+-- Test with a definition that has multiple equations via pattern matching
+def isZero : Nat → Bool
+  | 0 => true
+  | _ + 1 => false
+
+example : isZero 0 = true := by simp +locals
+example (n : Nat) : isZero (n + 1) = false := by simp +locals
+
+-- Test simp_all +locals
+example (n : Nat) (h : n = 0) : isZero n = true := by simp_all +locals
+
+-- Test dsimp +locals
+example : foo 5 = 6 := by dsimp +locals


### PR DESCRIPTION
This PR adds a `+locals` configuration option to the `simp`, `simp_all`, and `dsimp` tactics that automatically adds all definitions from the current file to unfold.

Example usage:
```lean
def foo (n : Nat) : Nat := n + 1

-- Without +locals, simp doesn't know about foo
example (n : Nat) : foo n = n + 1 := by simp  -- fails

-- With +locals, simp can unfold foo
example (n : Nat) : foo n = n + 1 := by simp +locals  -- succeeds
```

The implementation iterates over `env.constants.map₂` (which contains constants defined in the current module) and adds definitions to unfold. Instance definitions and internal details are filtered out.

**Note:** For local theorems, use `+suggestions` instead, which will include relevant local theorems via the library suggestion engine.

🤖 Prepared with [Claude Code](https://claude.com/claude-code)