### PR TITLE
chore: extract shared match splitting impl from FunInd and `mvcgen`

### DIFF
--- a/src/Lean/Elab/Tactic/Do/VCGen.lean
+++ b/src/Lean/Elab/Tactic/Do/VCGen.lean
@@ -196,8 +196,18 @@ where
     -- context = fun e => H ⊢ₛ wp⟦e⟧ Q
     let context ← withLocalDecl `e .default (mkApp m α) fun e => do
       mkLambdaFVars #[e] (goal.withNewProg e).toExpr
-    return ← info.splitWithConstantMotive goal.toExpr (useSplitter := true) fun altSuff idx params => do
+    return ← info.splitWith goal.toExpr (useSplitter := true) fun altSuff expAltType idx params => do
+      burnOne
+      let e ← mkFreshExprMVar (mkApp m α)
+      unless ← isDefEq (goal.withNewProg e).toExpr expAltType do
+        throwError "The alternative type {expAltType} returned by `splitWith` does not match {(goal.withNewProg e).toExpr}. This is a bug in `mvcgen`."
+      let e ← instantiateMVarsIfMVarApp e
       let res ← liftMetaM <| rwIfOrMatcher idx e
+      -- When `FunInd.rwMatcher` fails, it returns the original expression. We'd loop in that case,
+      -- so we rather throw an error.
+      if res.expr == e then
+        throwError "`rwMatcher` failed to rewrite {indentExpr e}\n\
+          Check the output of `trace.Elab.Tactic.Do.vcgen.split` for more info and submit a bug report."
       let goal' := goal.withNewProg res.expr
       let prf ← withAltCtx idx params <| onWPApp goal' (name ++ altSuff)
       let res ← Simp.mkCongrArg context res
@@ -243,7 +253,7 @@ where
       mkFreshExprSyntheticOpaqueMVar hypsTy (name.appendIndexAfter i)
 
     let (joinPrf, joinGoal) ← forallBoundedTelescope joinTy numJoinParams fun joinParams _body => do
-      let φ ← info.splitWithConstantMotive (mkSort .zero) fun _suff idx altParams =>
+      let φ ← info.splitWith (mkSort .zero) fun _suff _expAltType idx altParams =>
         return mkAppN hypsMVars[idx]! (joinParams ++ altParams)
       withLocalDecl (← mkFreshUserName `h) .default φ fun h => do
         -- NB: `mkJoinGoal` is not quite `goal.withNewProg` because we only take 4 args and clear

--- a/src/Lean/Elab/Tactic/Do/VCGen/Basic.lean
+++ b/src/Lean/Elab/Tactic/Do/VCGen/Basic.lean
@@ -16,6 +16,7 @@ namespace Lean.Elab.Tactic.Do
 open Lean Parser Elab Tactic Meta Do SpecAttr
 
 builtin_initialize registerTraceClass `Elab.Tactic.Do.vcgen
+builtin_initialize registerTraceClass `Elab.Tactic.Do.vcgen.split
 
 register_builtin_option mvcgen.warning : Bool := {
   defValue := true

--- a/src/Lean/Meta/Match/Rewrite.lean
+++ b/src/Lean/Meta/Match/Rewrite.lean
@@ -1,0 +1,149 @@
+/-
+Copyright (c) 2025 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Graf
+-/
+module
+
+prelude
+public import Lean.Meta.Tactic.Simp.Types
+import Lean.Meta.Match.MatcherApp.Transform
+import Lean.Meta.Tactic.Assumption
+import Lean.Meta.Tactic.Refl
+import Lean.Meta.Tactic.Simp.Rewrite
+
+public section
+
+namespace Lean.Meta
+
+/--
+Tries to rewrite the `ite`, `dite` or `cond` expression `e` with the hypothesis `hc`.
+If it fails, it returns a rewrite with `proof? := none` and unchaged expression.
+-/
+def rwIfWith (hc : Expr) (e : Expr) : MetaM Simp.Result := do
+  match_expr e with
+  | ite@ite α c h t f =>
+    let us := ite.constLevels!
+    if (← isDefEq c (← inferType hc)) then
+      return {
+        expr := t
+        proof? := (mkAppN (mkConst ``if_pos us) #[c, h, hc, α, t, f])
+      }
+    if (← isDefEq (mkNot c) (← inferType hc)) then
+      return {
+        expr := f
+        proof? := (mkAppN (mkConst ``if_neg us) #[c, h, hc, α, t, f])
+      }
+  | dite@dite α c h t f =>
+    let us := dite.constLevels!
+    if (← isDefEq c (← inferType hc)) then
+      return {
+        expr := t.beta #[hc]
+        proof? := (mkAppN (mkConst ``dif_pos us) #[c, h, hc, α, t, f])
+      }
+    if (← isDefEq (mkNot c) (← inferType hc)) then
+      return {
+        expr := f.beta #[hc]
+        proof? := (mkAppN (mkConst ``dif_neg us) #[c, h, hc, α, t, f])
+      }
+  | cond@cond α c t f =>
+    let us := cond.constLevels!
+    if (← isDefEq (← inferType hc) (← mkEq c (mkConst ``Bool.true))) then
+      return {
+        expr := t
+        proof? := (mkAppN (mkConst ``Bool.cond_pos us) #[α, c, t, f, hc])
+      }
+    if (← isDefEq (← inferType hc) (← mkEq c (mkConst ``Bool.false))) then
+      return {
+        expr := f
+        proof? := (mkAppN (mkConst ``Bool.cond_neg us) #[α, c, t, f, hc])
+      }
+  | _ => pure ()
+  return { expr := e }
+
+/--
+In the `onAlt` handler of a `MatcherApp.transform`, you can use this function on a properly
+substituted matcher application with the alternative `altIdx`.
+
+If it fails, it returns a rewrite with `proof? := none` and the unchanged expression.
+
+"Properly substituted" here means that the discriminants have been substituted according to the
+alternative; otherwise, the rewrite might fail because some hypothesis of the congruence
+equation theorem cannot be discharged by assumption or reflixivity.
+See `Lean.Meta.Tactic.FunInd.buildInductionBody` and `Lean.Elab.Tactic.Do.VCGen.Split` for examples
+of how to coerce `MatherApp.transform` into doing the substitution on the motive for you.
+-/
+def rwMatcher (altIdx : Nat) (e : Expr) : MetaM Simp.Result := do
+  if e.isAppOf ``PSum.casesOn || e.isAppOf ``PSigma.casesOn then
+    let mut e := e
+    while true do
+      if let some e' ← reduceRecMatcher? e then
+          e := e'.headBeta
+      else
+        let e' := e.headBeta
+        if e != e' then
+          e := e'
+        else
+          break
+    return { expr := e }
+  else
+    unless (← isMatcherApp e) do
+      trace[Meta.Match.debug] "Not a matcher application:{indentExpr e}"
+      return { expr := e }
+    let matcherDeclName := e.getAppFn.constName!
+    let eqns ← Match.genMatchCongrEqns matcherDeclName
+    unless altIdx < eqns.size do
+      trace[Meta.Match.debug] "When trying to reduce arm {altIdx}, only {eqns.size} equations for {.ofConstName matcherDeclName}"
+      return { expr := e }
+    let eqnThm := eqns[altIdx]!
+    try
+      withTraceNode `Meta.Match.debug (pure m!"{exceptEmoji ·} rewriting with {.ofConstName eqnThm} in{indentExpr e}") do
+      let eqProof := mkAppN (mkConst eqnThm e.getAppFn.constLevels!) e.getAppArgs
+      let (hyps, _, eqType) ← forallMetaTelescope (← inferType eqProof)
+      trace[Meta.Match.debug] "eqProof has type{indentExpr eqType}"
+      let proof := mkAppN eqProof hyps
+      let hyps := hyps.map (·.mvarId!)
+      let (isHeq, lhs, rhs) ← do
+        if let some (_, lhs, _, rhs) := eqType.heq? then pure (true, lhs, rhs) else
+        if let some (_, lhs, rhs) := eqType.eq? then pure (false, lhs, rhs) else
+        throwError m!"Type of `{.ofConstName eqnThm}` is not an equality"
+      if !(← isDefEq e lhs) then
+        throwError m!"Left-hand side `{lhs}` of `{.ofConstName eqnThm}` does not apply to `{e}`"
+      /-
+      Here we instantiate the hypotheses of the congruence equation theorem
+      There are two sets of hypotheses to instantiate:
+      - `Eq` or `HEq` that relate the discriminants to the patterns
+        Solving these should instantiate the pattern variables.
+      - Overlap hypotheses (`isEqnThmHypothesis`)
+      With more book keeping we could maybe do this very precisely, knowing exactly
+      which facts provided by the splitter should go where, but it's tedious.
+      So for now let's use heuristics and try `assumption` and `rfl`.
+      -/
+      for h in hyps do
+        unless (← h.isAssigned) do
+          let hType ← h.getType
+          if Simp.isEqnThmHypothesis hType then
+            -- Using unrestricted h.substVars here does not work well; it could
+            -- even introduce a dependency on the `oldIH` we want to eliminate
+            h.assumption <|> throwError "Failed to discharge `{h}`"
+          else if hType.isEq then
+            h.assumption <|> h.refl <|> throwError m!"Failed to resolve `{h}`"
+          else if hType.isHEq then
+            h.assumption <|> h.hrefl <|> throwError m!"Failed to resolve `{h}`"
+      let unassignedHyps ← hyps.filterM fun h => return !(← h.isAssigned)
+      unless unassignedHyps.isEmpty do
+        throwError m!"Not all hypotheses of `{.ofConstName eqnThm}` could be discharged: {unassignedHyps}"
+      let rhs ← instantiateMVars rhs
+      let proof ← instantiateMVars proof
+      let proof ← if isHeq then
+          try mkEqOfHEq proof
+          catch e => throwError m!"Could not un-HEq `{proof}`:{indentD e.toMessageData} "
+        else
+          pure proof
+      return {
+        expr := rhs
+        proof? := proof
+      }
+    catch ex =>
+      trace[Meta.Match.debug] "Failed to apply {.ofConstName eqnThm}:{indentD ex.toMessageData}"
+      return { expr := e }

--- a/src/Lean/Meta/Tactic/FunInd.lean
+++ b/src/Lean/Meta/Tactic/FunInd.lean
@@ -9,6 +9,7 @@ module
 prelude
 public import Lean.Meta.Tactic.Simp.Types
 import Lean.Meta.Match.MatcherApp.Transform
+import Lean.Meta.Match.Rewrite
 import Lean.Meta.Injective -- for elimOptParam
 import Lean.Meta.ArgsPacker
 import Lean.Elab.PreDefinition.WF.Eqns
@@ -18,7 +19,6 @@ import Lean.Meta.Tactic.ElimInfo
 import Lean.Meta.Tactic.FunIndInfo
 import Lean.Data.Array
 import Lean.Meta.Tactic.Simp.Rewrite
-import Lean.Meta.Tactic.Refl
 import Lean.Meta.Tactic.Replace
 
 /-!
@@ -582,50 +582,6 @@ partial def inProdLambdaLastArg (rw : Expr → MetaM Simp.Result) (goal : Expr) 
       let r ← inLastArg rw goal
       r.addLambdas xs
 
-public def rwIfWith (hc : Expr) (e : Expr) : MetaM Simp.Result := do
-  match_expr e with
-  | ite@ite α c h t f =>
-    let us := ite.constLevels!
-    if (← isDefEq c (← inferType hc)) then
-      return {
-        expr := t
-        proof? := (mkAppN (mkConst ``if_pos us) #[c, h, hc, α, t, f])
-      }
-    if (← isDefEq (mkNot c) (← inferType hc)) then
-      return {
-        expr := f
-        proof? := (mkAppN (mkConst ``if_neg us) #[c, h, hc, α, t, f])
-      }
-    return { expr := e}
-  | dite@dite α c h t f =>
-    let us := dite.constLevels!
-    if (← isDefEq c (← inferType hc)) then
-      return {
-        expr := t.beta #[hc]
-        proof? := (mkAppN (mkConst ``dif_pos us) #[c, h, hc, α, t, f])
-      }
-    if (← isDefEq (mkNot c) (← inferType hc)) then
-      return {
-        expr := f.beta #[hc]
-        proof? := (mkAppN (mkConst ``dif_neg us) #[c, h, hc, α, t, f])
-      }
-    return { expr := e }
-  | cond@cond α c t f =>
-    let us := cond.constLevels!
-    if (← isDefEq (← inferType hc) (← mkEq c (mkConst ``Bool.true))) then
-      return {
-        expr := t
-        proof? := (mkAppN (mkConst ``Bool.cond_pos us) #[α, c, t, f, hc])
-      }
-    if (← isDefEq (← inferType hc) (← mkEq c (mkConst ``Bool.false))) then
-      return {
-        expr := f
-        proof? := (mkAppN (mkConst ``Bool.cond_neg us) #[α, c, t, f, hc])
-      }
-    return { expr := e }
-  | _ =>
-    return { expr := e }
-
 def rwLetWith (h : Expr) (e : Expr) : MetaM Simp.Result := do
   if e.isLet then
     if (← isDefEq e.letValue! h) then
@@ -646,81 +602,6 @@ def rwFun (names : Array Name) (e : Expr) : MetaM Simp.Result := do
         | throwError "Not an equality: `{h}`"
       return { expr := rhs, proof? := h }
     else
-      return { expr := e }
-
-public def rwMatcher (altIdx : Nat) (e : Expr) : MetaM Simp.Result := do
-  if e.isAppOf ``PSum.casesOn || e.isAppOf ``PSigma.casesOn then
-    let mut e := e
-    while true do
-      if let some e' ← reduceRecMatcher? e then
-          e := e'.headBeta
-      else
-        let e' := e.headBeta
-        if e != e' then
-          e := e'
-        else
-          break
-    return { expr := e }
-  else
-    unless (← isMatcherApp e) do
-      trace[Meta.FunInd] "Not a matcher application:{indentExpr e}"
-      return { expr := e }
-    let matcherDeclName := e.getAppFn.constName!
-    let eqns ← Match.genMatchCongrEqns matcherDeclName
-    unless altIdx < eqns.size do
-      trace[Meta.FunInd] "When trying to reduce arm {altIdx}, only {eqns.size} equations for {.ofConstName matcherDeclName}"
-      return { expr := e }
-    let eqnThm := eqns[altIdx]!
-    try
-      withTraceNode `Meta.FunInd (pure m!"{exceptEmoji ·} rewriting with {.ofConstName eqnThm} in{indentExpr e}") do
-      let eqProof := mkAppN (mkConst eqnThm e.getAppFn.constLevels!) e.getAppArgs
-      let (hyps, _, eqType) ← forallMetaTelescope (← inferType eqProof)
-      trace[Meta.FunInd] "eqProof has type{indentExpr eqType}"
-      let proof := mkAppN eqProof hyps
-      let hyps := hyps.map (·.mvarId!)
-      let (isHeq, lhs, rhs) ← do
-        if let some (_, lhs, _, rhs) := eqType.heq? then pure (true, lhs, rhs) else
-        if let some (_, lhs, rhs) := eqType.eq? then pure (false, lhs, rhs) else
-        throwError m!"Type of `{.ofConstName eqnThm}` is not an equality"
-      if !(← isDefEq e lhs) then
-        throwError m!"Left-hand side `{lhs}` of `{.ofConstName eqnThm}` does not apply to `{e}`"
-      /-
-      Here we instantiate the hypotheses of the congruence equation theorem
-      There are two sets of hypotheses to instantiate:
-      - `Eq` or `HEq` that relate the discriminants to the patterns
-        Solving these should instantiate the pattern variables.
-      - Overlap hypotheses (`isEqnThmHypothesis`)
-      With more book keeping we could maybe do this very precisely, knowing exactly
-      which facts provided by the splitter should go where, but it's tedious.
-      So for now let's use heuristics and try `assumption` and `rfl`.
-      -/
-      for h in hyps do
-        unless (← h.isAssigned) do
-          let hType ← h.getType
-          if Simp.isEqnThmHypothesis hType then
-            -- Using unrestricted h.substVars here does not work well; it could
-            -- even introduce a dependency on the `oldIH` we want to eliminate
-            h.assumption <|> throwError "Failed to discharge `{h}`"
-          else if hType.isEq then
-            h.assumption <|> h.refl <|> throwError m!"Failed to resolve `{h}`"
-          else if hType.isHEq then
-            h.assumption <|> h.hrefl <|> throwError m!"Failed to resolve `{h}`"
-      let unassignedHyps ← hyps.filterM fun h => return !(← h.isAssigned)
-      unless unassignedHyps.isEmpty do
-        throwError m!"Not all hypotheses of `{.ofConstName eqnThm}` could be discharged: {unassignedHyps}"
-      let rhs ← instantiateMVars rhs
-      let proof ← instantiateMVars proof
-      let proof ← if isHeq then
-          try mkEqOfHEq proof
-          catch e => throwError m!"Could not un-HEq `{proof}`:{indentD e.toMessageData} "
-        else
-          pure proof
-      return {
-        expr := rhs
-        proof? := proof
-      }
-    catch ex =>
-      trace[Meta.FunInd] "Failed to apply {.ofConstName eqnThm}:{indentD ex.toMessageData}"
       return { expr := e }
 
 /--


### PR DESCRIPTION
This was an indepedently viable refactoring proposed by Joachim. It fixes a bug in `mvcgen` exposed by the now reverted #11696.