### PR TITLE
fix: allow private proof-valued structure fields in library suggestions

### DIFF
--- a/src/Lean/LibrarySuggestions/SineQuaNon.lean
+++ b/src/Lean/LibrarySuggestions/SineQuaNon.lean
@@ -74,7 +74,7 @@ def prepareTriggers (names : Array Name) (maxTolerance : Float := 3.0) : MetaM (
   let mut map := {}
   let env ← getEnv
   let names := names.filter fun n =>
-    !isDeniedPremise env n && Lean.wasOriginallyTheorem env n
+    !isDeniedPremise env n && wasOriginallyTheorem env n
   for name in names do
     let triggers ← triggerSymbols (← getConstInfo name) maxTolerance
     for (trigger, tolerance) in triggers do

--- a/src/Lean/LibrarySuggestions/SymbolFrequency.lean
+++ b/src/Lean/LibrarySuggestions/SymbolFrequency.lean
@@ -28,7 +28,7 @@ skipping instance arguments and proofs.
 public def localSymbolFrequencyMap : MetaM (NameMap Nat) := do
   let env := (← getEnv)
   env.constants.map₂.foldlM (init := ∅) (fun acc m ci => do
-    if isDeniedPremise env m || !Lean.wasOriginallyTheorem env m then
+    if isDeniedPremise env m || !wasOriginallyTheorem env m then
       pure acc
     else
       ci.type.foldRelevantConstants (init := acc) fun n' acc => return acc.alter n' fun i? => some (i?.getD 0 + 1))

--- a/tests/lean/run/library_suggestions_deprecated.lean
+++ b/tests/lean/run/library_suggestions_deprecated.lean
@@ -17,8 +17,8 @@ set_library_suggestions Lean.LibrarySuggestions.currentFile
 -- Expected: deprecatedTheorem should NOT appear in suggestions
 /--
 info: Library suggestions:
-  anotherNormalTheorem
   normalTheorem
+  anotherNormalTheorem
 -/
 #guard_msgs in
 example : True := by

--- a/tests/lean/run/library_suggestions_local.lean
+++ b/tests/lean/run/library_suggestions_local.lean
@@ -32,8 +32,8 @@ def myFunction (x : Nat) : Nat := x + 1
 -- Second test: should show only the two theorems (not myFunction)
 /--
 info: Library suggestions:
-  anotherTheorem
   myLocalTheorem
+  anotherTheorem
 -/
 #guard_msgs in
 example : False → True := by

--- a/tests/lean/run/library_suggestions_private.lean
+++ b/tests/lean/run/library_suggestions_private.lean
@@ -1,0 +1,31 @@
+import Lean.LibrarySuggestions.Basic
+
+/-!
+# Test: Private theorems should appear in currentFile suggestions
+
+Private theorems (declared with `private theorem`) have mangled names starting with
+`_private.` which would normally be filtered by `isInternalDetail`. However, since
+they're accessible from the current module, `currentFile` should include them.
+-/
+
+-- A public theorem for comparison
+theorem publicTheorem : True := trivial
+
+-- A private theorem that should still appear in currentFile suggestions
+private theorem privateTheorem : 1 + 1 = 2 := rfl
+
+-- Test the currentFile selector
+set_library_suggestions Lean.LibrarySuggestions.currentFile
+
+-- Both public and private theorems should appear.
+-- The private theorem has a mangled name like `_private.library_suggestions_private.0.privateTheorem`
+-- but should still be suggested since currentFile uses allowPrivate := true.
+/--
+info: Library suggestions:
+  publicTheorem
+  privateTheorem
+-/
+#guard_msgs in
+example : True := by
+  suggestions
+  trivial


### PR DESCRIPTION
This PR fixes library suggestions to include private proof-valued structure fields.

Private proof-valued structure fields (like `private size_keys' : keys.size = values.size`) generate projections with `_private.*` mangled names. These were being filtered out by `isDeniedPremise` because `isInternalDetail` returns true for names starting with `_`.

The fix allows private names through by checking `!isPrivateName name`, following the pattern from #11946. This enables `grind +suggestions` to discover and use private proof-valued structure fields from the current module.

Soon I would like to fix the semantics of `isInternalDetail`, as the current behaviour is clearly wrong, but as there are many call sites, I would like to get the behaviour of tactics correct first.

Also switches `currentFile` to use `wasOriginallyTheorem` instead of matching on `.thmInfo`, which correctly identifies both theorems and proof-valued projections.

🤖 Prepared with Claude Code