### PR TITLE
feat: auto-generated congruence theorems for `Sym.simp`

### DIFF
--- a/src/Lean/Meta/Sym/Simp/SimpM.lean
+++ b/src/Lean/Meta/Sym/Simp/SimpM.lean
@@ -149,6 +149,7 @@ inductive Result where
   Simplified to `e'` with proof `proof : e = e'`.
   If `done = true`, skip recursive simplification of `e'`. -/
   | step (e' : Expr) (proof : Expr) (done : Bool := false)
+  deriving Inhabited
 
 private opaque MethodsRefPointed : NonemptyType.{0}
 def MethodsRef : Type := MethodsRefPointed.type

--- a/tests/lean/run/sym_simp_1.lean
+++ b/tests/lean/run/sym_simp_1.lean
@@ -31,3 +31,10 @@ example : ∀ x, 0 + x + 0 = x := by
 
 example : ∀ x, 0 + x + 0 = x := by
   sym_simp [Nat.add_zero, Nat.zero_add, eq_self, forall_true]
+
+example (p q : Prop) (hp : p) : if x + 0 = x then p else q := by
+  sym_simp [Nat.add_zero, eq_self, if_true]
+  exact hp
+
+example (as : Array Int) (i : Nat) (h : 0 + i < as.size) : as[0 + i] = as[i] := by
+  sym_simp [Nat.zero_add, eq_self]


### PR DESCRIPTION
This PR implements support for auto-generated congruence theorems in `Sym.simp`, enabling simplification of functions with complex argument dependencies such as proof arguments and `Decidable` instances.

Previously, `Sym.simp` used basic congruence lemmas (`congrArg`, `congrFun`, `congrFun'`, `congr`) to construct proofs when simplifying function arguments. This approach is efficient for simple cases but cannot handle functions with dependent proof arguments or `Decidable` instances that depend on earlier arguments.

The new `congrThm` function applies pre-generated congruence theorems (similar to the main simplifier) to handle these complex cases.
