### PR TITLE
feat: handle over/under-applied functions in `Sym.simp`

### DIFF
--- a/tests/lean/run/sym_simp_1.lean
+++ b/tests/lean/run/sym_simp_1.lean
@@ -111,3 +111,15 @@ example (as : Array (Nat → Nat)) (i : Nat) (_ : i < as.size) (h : as[i] a = b)
   sym_simp [Nat.zero_add]
   trace_state
   exact h
+
+/--
+trace: c a : Nat
+g : Nat → Nat
+h : ite (c > 0) a = g
+⊢ ite (c > 0) a = g
+-/
+#guard_msgs in
+example (h : ite (c > 0) a = g) : ite (c > 0) (0 + a) = g := by
+  sym_simp [Nat.zero_add]
+  trace_state
+  exact h


### PR DESCRIPTION
This PR adds support for simplifying the arguments of over-applied and under-applied function application terms in `Sym.simp`, completing the implementation for all three congruence strategies (fixed prefix, interlaced, and congruence theorems).