### PR TITLE
fix: pretty-printing of the `extract_lets` tactic

### DIFF
--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -546,7 +546,7 @@ introducing new local definitions.
 For example, given a local hypotheses if the form `h : let x := v; b x`, then `extract_lets z at h`
 introduces a new local definition `z := v` and changes `h` to be `h : b z`.
 -/
-syntax (name := extractLets) "extract_lets " optConfig (ppSpace colGt (ident <|> hole))* (location)? : tactic
+syntax (name := extractLets) "extract_lets" ppSpace optConfig (ppSpace colGt (ident <|> hole))* (location)? : tactic
 
 /--
 Lifts `let` and `have` expressions within a term as far out as possible.


### PR DESCRIPTION
This PR fixes the pretty-printing of the `extract_lets` tactic. Previously, the pretty-printer would expect a space after the `extract_lets` tactic, when it was followed by another tactic on the same line: for example,
`extract_lets; exact foo`
would be changed to
`extract_lets ; exact foo`.

This PR fixes this oversight. Found by using the pretty-printer for formatting linting in leanprover-community/mathlib4#30658.
