### PR TITLE
fix: pretty-printing of class abbrev syntax

### DIFF
--- a/src/Init/NotationExtra.lean
+++ b/src/Init/NotationExtra.lean
@@ -338,7 +338,7 @@ macro_rules
 -/
 syntax (name := Lean.Parser.Command.classAbbrev)
   declModifiers "class" ppSpace "abbrev" ppSpace declId ppSpace
-  (bracketedBinder ppSpace)* (":" ppSpace term)? ":=" ppSpace
+  (bracketedBinder ppSpace)* (":" ppSpace term ppSpace)? ":=" ppSpace
   withPosition(group(colGe term ("," ppSpace)?)*) : command
 
 macro_rules


### PR DESCRIPTION
This PR makes the pretty-printing of class abbrev syntax match its doc-string. The previous output was missing lots of intermediate spaces.

Found by using the pretty-printer for formatting linting in leanprover-community/mathlib4#30658.

Let me test this change first before asking for review.