### PR TITLE
perf: avoid superliniear overhead in closed term extraction

### DIFF
--- a/src/Lean/Compiler/LCNF/ExtractClosed.lean
+++ b/src/Lean/Compiler/LCNF/ExtractClosed.lean
@@ -53,7 +53,7 @@ structure Context where
 structure State where
   decls : Array Decl := {}
   /--
-  Cache for `shouldExtractLetValue` in order to avoid superlinear behavior.
+  Cache for `shouldExtractFVar` in order to avoid superlinear behavior.
   -/
   fvarDecisionCache : Std.HashMap FVarId Bool := {}
 


### PR DESCRIPTION
This PR fixe a superliniear behavior in the closed subterm extractor.

Consider an LCNF of the shape:
```
let x1 := f arg
let x2 := f x1
let x3 := f x2
let x4 := f x3
...
```
In this case the previous closed term extraction algorithm would visit `x1`, then `x2` and `x1`,
then `x3`,`x2`,`x1` and so on, failing each time. We now introduce a cache to avoid this behavior.
