### PR TITLE
perf: thunk the `Inhabited` argument for `getElem!`

### DIFF
--- a/src/Init/GetElem.lean
+++ b/src/Init/GetElem.lean
@@ -103,8 +103,12 @@ class GetElem? (coll : Type u) (idx : Type v) (elem : outParam (Type w))
   if it is present, and otherwise panics at runtime and returns the `default` term
   from `Inhabited elem`.
   -/
-  getElem! [Inhabited elem] (xs : coll) (i : idx) : elem :=
-    match getElem? xs i with | some e => e | none => outOfBounds
+  getElem! [inst : [UnitClass] → Inhabited elem] (xs : coll) (i : idx) : elem :=
+    match getElem? xs i with
+    | some e => e
+    | none =>
+      have := inst
+      outOfBounds
 
 export GetElem? (getElem? getElem!)
 
@@ -387,13 +391,13 @@ end List
 namespace Array
 
 instance : GetElem (Array α) Nat α fun xs i => i < xs.size where
-  getElem xs i h := xs.getInternal i h
+  getElem := getInternal
 
 -- We provide a `GetElem?` instance, rather than using the low priority instance,
 -- so that we use the `@[extern]` definition of `get!Internal`.
 instance : GetElem? (Array α) Nat α fun xs i => i < xs.size where
   getElem? xs i := decidableGetElem? xs i
-  getElem! xs i := xs.get!Internal i
+  getElem! := @get!Internal α -- avoid the implicit lambda feature
 
 instance : LawfulGetElem (Array α) Nat α fun xs i => i < xs.size where
   getElem?_def xs i h := by

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -3244,13 +3244,18 @@ Examples:
 @[inline] abbrev Array.getD (a : Array α) (i : Nat) (v₀ : α) : α :=
   dite (LT.lt i a.size) (fun h => a.getInternal i h) (fun _ => v₀)
 
+-- Just a hack to avoid a stage0 update, probably cleanre to allow `Unit → _` in `checkLocalInstanceParameters`
+/-- `Unit` as a class -/
+class UnitClass
+instance : UnitClass where
+
 /--
 Version of `Array.get!Internal` that does not increment the reference count of its result.
 
 This is only intended for direct use by the compiler.
 -/
 @[extern "lean_array_get_borrowed"]
-unsafe opaque Array.get!InternalBorrowed {α : Type u} [Inhabited α] (a : @& Array α) (i : @& Nat) : α
+unsafe opaque Array.get!InternalBorrowed {α : Type u} [[UnitClass] → Inhabited α] (a : @& Array α) (i : @& Nat) : α
 
 /--
 Use the indexing notation `a[i]!` instead.
@@ -3258,7 +3263,7 @@ Use the indexing notation `a[i]!` instead.
 Access an element from an array, or panic if the index is out of bounds.
 -/
 @[extern "lean_array_get"]
-def Array.get!Internal {α : Type u} [Inhabited α] (a : @& Array α) (i : @& Nat) : α :=
+def Array.get!Internal {α : Type u} [[UnitClass] → Inhabited α] (a : @& Array α) (i : @& Nat) : α :=
   Array.getD a i default
 
 /--

--- a/src/Lean/Elab/Binders.lean
+++ b/src/Lean/Elab/Binders.lean
@@ -202,7 +202,7 @@ private partial def checkLocalInstanceParameters (type : Expr) : TermElabM Unit 
   -- We allow instance arguments so that local instances of the form
   -- `variable [∀ (a : α) [P a], Q a]`
   -- are accepted, per https://github.com/leanprover/lean4/issues/2311
-  if bi != .instImplicit && !b.hasLooseBVar 0 then
+  if bi != .instImplicit && !b.hasLooseBVar 0 && !(d == .const ``Unit []) then
     throwError "invalid parametric local instance, parameter with type{indentExpr d}\ndoes not have forward dependencies, type class resolution cannot use this kind of local instance because it will not be able to infer a value for this parameter."
   withLocalDecl n bi d fun x => checkLocalInstanceParameters (b.instantiate1 x)
 

--- a/src/include/lean/lean.h
+++ b/src/include/lean/lean.h
@@ -844,7 +844,7 @@ static inline lean_object * lean_array_get(lean_obj_arg def_val, b_lean_obj_arg 
        i > LEAN_MAX_SMALL_NAT == MAX_UNSIGNED >> 1
        but each array entry is 8 bytes in 64-bit machines and 4 in 32-bit ones.
        In both cases, we would be out-of-memory. */
-    return lean_array_get_panic(def_val);
+    return lean_array_get_panic(lean_apply_1(def_val, lean_box(0)));
 }
 
 static inline lean_object * lean_array_get_borrowed(lean_obj_arg def_val, b_lean_obj_arg a, b_lean_obj_arg i) {
@@ -859,7 +859,7 @@ static inline lean_object * lean_array_get_borrowed(lean_obj_arg def_val, b_lean
        i > LEAN_MAX_SMALL_NAT == MAX_UNSIGNED >> 1
        but each array entry is 8 bytes in 64-bit machines and 4 in 32-bit ones.
        In both cases, we would be out-of-memory. */
-    return lean_array_get_panic(def_val);
+    return lean_array_get_panic(lean_apply_1(def_val, lean_box(0)));
 }
 
 LEAN_EXPORT lean_obj_res lean_copy_expand_array(lean_obj_arg a, bool expand);

--- a/tests/lean/run/getElemBangLazy.lean
+++ b/tests/lean/run/getElemBangLazy.lean
@@ -1,0 +1,36 @@
+inductive T (n : Nat) where
+| mk : Nat → T n
+deriving Repr
+
+instance : Inhabited (T n) where
+  default := dbg_trace "evaluated default instance for n = {n}"; .mk 0
+
+def arr : Array (T 4) := #[T.mk 1, T.mk 2, T.mk 3]
+
+-- set_option trace.compiler.ir.result true in
+def test1 : IO Unit := do
+  let x := Array.get!Internal arr 1
+  IO.println s!"Accessed element successfully: {repr x}"
+
+
+-- set_option trace.compiler.ir.result true in
+def test2 : IO Unit := do
+  let x := getElem! arr 1
+  -- this elaborates as expected
+  -- let x := getElem! (inst := @fun _ => @instInhabitedT 4) arr 1
+  IO.println s!"Accessed element successfully: {repr x}"
+
+def test3 : IO Unit := do
+  let x := arr[1]!
+  IO.println s!"Accessed element successfully: {repr x}"
+
+-- The output below should not indicate that the default instance is evaluated
+
+/-- info: Accessed element successfully: T.mk 2 -/
+#guard_msgs in #eval test1
+
+/-- info: Accessed element successfully: T.mk 2 -/
+#guard_msgs in #eval test2
+
+/-- info: Accessed element successfully: T.mk 2 -/
+#guard_msgs in #eval test3


### PR DESCRIPTION
This PR is an experiment like #12014.

The use of `[[UnitClass] → Inhabited α]` is just a
stage-rebuild-avoiding hack.
