### PR TITLE
fix: global visibility attributes should be allowed on non-exposed definitions

### DIFF
--- a/src/Lean/ReducibilityAttrs.lean
+++ b/src/Lean/ReducibilityAttrs.lean
@@ -107,6 +107,9 @@ register_builtin_option allowUnsafeReducibility : Bool := {
 
 private def validate (declName : Name) (status : ReducibilityStatus) (attrKind : AttributeKind) : CoreM Unit := do
   let suffix := .note "Use `set_option allowUnsafeReducibility true` to override reducibility status validation"
+  -- Allow global visibility attributes even on non-exported definitions - they may be relevant for
+  -- downstream non-`module`s.
+  withoutExporting do
   unless allowUnsafeReducibility.get (← getOptions) do
     match (← getConstInfo declName) with
     | .defnInfo _ =>

--- a/tests/lean/run/12025.lean
+++ b/tests/lean/run/12025.lean
@@ -1,0 +1,6 @@
+module
+
+/-! Global visibility attributes should be allowed on non-exposed definitions. -/
+
+@[irreducible]
+public def x := 0


### PR DESCRIPTION
This PR fixes an issue where attributes like `@[irreducible]` would not be allowed under the module system unless combined with `@[exposed]`, but the former may be helpful without the latter to ensure downstream non-`module`s are also affected.

Fixes #12025 