### PR TITLE
fix: set `data?` field in all unknown identifier code actions

### DIFF
--- a/src/Lean/Server/CodeActions/UnknownIdentifier.lean
+++ b/src/Lean/Server/CodeActions/UnknownIdentifier.lean
@@ -224,17 +224,22 @@ def computeQueries
       break
   return queries
 
-def importAllUnknownIdentifiersProvider : Name := `unknownIdentifiers
+def importAllUnknownIdentifiersProvider : Name := `allUnknownIdentifiers
+def importUnknownIdentifiersProvider : Name := `unknownIdentifiers
+
+def mkUnknownIdentifierCodeActionData (params : CodeActionParams)
+    (name := importUnknownIdentifiersProvider) : CodeActionResolveData := {
+  params,
+  providerName := name
+  providerResultIndex := 0
+  : CodeActionResolveData
+}
 
 def importAllUnknownIdentifiersCodeAction (params : CodeActionParams) (kind : String) : CodeAction := {
   title := "Import all unambiguous unknown identifiers"
   kind? := kind
-  data? := some <| toJson {
-    params,
-    providerName := importAllUnknownIdentifiersProvider
-    providerResultIndex := 0
-    : CodeActionResolveData
-  }
+  data? := some <| toJson <|
+    mkUnknownIdentifierCodeActionData params importAllUnknownIdentifiersProvider
 }
 
 private def mkImportText (ctx : Elab.ContextInfo) (mod : Name) :
@@ -311,6 +316,7 @@ def handleUnknownIdentifierCodeAction
               insertion.edit
             ]
           }
+          data? := some <| toJson <| mkUnknownIdentifierCodeActionData params
         }
         if isExactMatch then
           hasUnambiguousImportCodeAction := true
@@ -322,6 +328,7 @@ def handleUnknownIdentifierCodeAction
             textDocument := doc.versionedIdentifier
             edits := #[insertion.edit]
           }
+          data? := some <| toJson <| mkUnknownIdentifierCodeActionData params
         }
   if hasUnambiguousImportCodeAction then
     unknownIdentifierCodeActions := unknownIdentifierCodeActions.push <|

--- a/tests/lean/interactive/unknownIdentifierCodeActions.lean.expected.out
+++ b/tests/lean/interactive/unknownIdentifierCodeActions.lean.expected.out
@@ -16,7 +16,16 @@
       {"range":
        {"start": {"line": 5, "character": 7},
         "end": {"line": 5, "character": 34}},
-       "newText": "Lean.Server.Test.Refs.Test1"}]}]}},
+       "newText": "Lean.Server.Test.Refs.Test1"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 5, "character": 34},
+     "end": {"line": 5, "character": 34}},
+    "context": {"diagnostics": []}}}},
  {"title": "Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs",
   "kind": "quickfix",
   "edit":
@@ -31,7 +40,64 @@
       {"range":
        {"start": {"line": 5, "character": 7},
         "end": {"line": 5, "character": 34}},
-       "newText": "Lean.Server.Test.Refs.test10"}]}]}}]
+       "newText": "Lean.Server.Test.Refs.test10"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 5, "character": 34},
+     "end": {"line": 5, "character": 34}},
+    "context": {"diagnostics": []}}}}]
+Resolution of Import Lean.Server.Test.Refs.Test1 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.Test1 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 5, "character": 7},
+       "end": {"line": 5, "character": 34}},
+      "newText": "Lean.Server.Test.Refs.Test1"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 5, "character": 34}, "end": {"line": 5, "character": 34}},
+   "context": {"diagnostics": []}}}}
+Resolution of Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 5, "character": 7},
+       "end": {"line": 5, "character": 34}},
+      "newText": "Lean.Server.Test.Refs.test10"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 5, "character": 34}, "end": {"line": 5, "character": 34}},
+   "context": {"diagnostics": []}}}}
 {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
  "range":
  {"start": {"line": 8, "character": 33}, "end": {"line": 8, "character": 33}},
@@ -50,7 +116,16 @@
       {"range":
        {"start": {"line": 8, "character": 10},
         "end": {"line": 8, "character": 33}},
-       "newText": "LeanServerTestRefsTest0"}]}]}},
+       "newText": "LeanServerTestRefsTest0"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 8, "character": 33},
+     "end": {"line": 8, "character": 33}},
+    "context": {"diagnostics": []}}}},
  {"title":
   "Import Lean.Server.Test.LeanServerTestRefsTest0' from Lean.Server.Test.Refs",
   "kind": "refactor",
@@ -66,7 +141,16 @@
       {"range":
        {"start": {"line": 8, "character": 10},
         "end": {"line": 8, "character": 33}},
-       "newText": "Lean.Server.Test.LeanServerTestRefsTest0'"}]}]}},
+       "newText": "Lean.Server.Test.LeanServerTestRefsTest0'"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 8, "character": 33},
+     "end": {"line": 8, "character": 33}},
+    "context": {"diagnostics": []}}}},
  {"title": "Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs",
   "kind": "refactor",
   "edit":
@@ -81,9 +165,7 @@
       {"range":
        {"start": {"line": 8, "character": 10},
         "end": {"line": 8, "character": 33}},
-       "newText": "Lean.Server.Test.Refs.test10"}]}]}},
- {"title": "Import all unambiguous unknown identifiers",
-  "kind": "quickfix",
+       "newText": "Lean.Server.Test.Refs.test10"}]}]},
   "data":
   {"providerResultIndex": 0,
    "providerName": "unknownIdentifiers",
@@ -92,7 +174,91 @@
     "range":
     {"start": {"line": 8, "character": 33},
      "end": {"line": 8, "character": 33}},
+    "context": {"diagnostics": []}}}},
+ {"title": "Import all unambiguous unknown identifiers",
+  "kind": "quickfix",
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "allUnknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 8, "character": 33},
+     "end": {"line": 8, "character": 33}},
     "context": {"diagnostics": []}}}}]
+Resolution of Import LeanServerTestRefsTest0 from Lean.Server.Test.Refs:
+{"title": "Import LeanServerTestRefsTest0 from Lean.Server.Test.Refs",
+ "kind": "refactor",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 8, "character": 10},
+       "end": {"line": 8, "character": 33}},
+      "newText": "LeanServerTestRefsTest0"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 8, "character": 33}, "end": {"line": 8, "character": 33}},
+   "context": {"diagnostics": []}}}}
+Resolution of Import Lean.Server.Test.LeanServerTestRefsTest0' from Lean.Server.Test.Refs:
+{"title":
+ "Import Lean.Server.Test.LeanServerTestRefsTest0' from Lean.Server.Test.Refs",
+ "kind": "refactor",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 8, "character": 10},
+       "end": {"line": 8, "character": 33}},
+      "newText": "Lean.Server.Test.LeanServerTestRefsTest0'"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 8, "character": 33}, "end": {"line": 8, "character": 33}},
+   "context": {"diagnostics": []}}}}
+Resolution of Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs",
+ "kind": "refactor",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 8, "character": 10},
+       "end": {"line": 8, "character": 33}},
+      "newText": "Lean.Server.Test.Refs.test10"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 8, "character": 33}, "end": {"line": 8, "character": 33}},
+   "context": {"diagnostics": []}}}}
 Resolution of Import all unambiguous unknown identifiers:
 {"title": "Import all unambiguous unknown identifiers",
  "kind": "quickfix",
@@ -135,7 +301,7 @@ Resolution of Import all unambiguous unknown identifiers:
       "newText": "LeanServerTestRefsTest0"}]}]},
  "data":
  {"providerResultIndex": 0,
-  "providerName": "unknownIdentifiers",
+  "providerName": "allUnknownIdentifiers",
   "params":
   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
    "range":
@@ -159,7 +325,16 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 12, "character": 7},
         "end": {"line": 12, "character": 34}},
-       "newText": "Test1"}]}]}},
+       "newText": "Test1"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 12, "character": 34},
+     "end": {"line": 12, "character": 34}},
+    "context": {"diagnostics": []}}}},
  {"title": "Import test10 from Lean.Server.Test.Refs",
   "kind": "quickfix",
   "edit":
@@ -174,7 +349,66 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 12, "character": 7},
         "end": {"line": 12, "character": 34}},
-       "newText": "test10"}]}]}}]
+       "newText": "test10"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 12, "character": 34},
+     "end": {"line": 12, "character": 34}},
+    "context": {"diagnostics": []}}}}]
+Resolution of Import Test1 from Lean.Server.Test.Refs:
+{"title": "Import Test1 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 12, "character": 7},
+       "end": {"line": 12, "character": 34}},
+      "newText": "Test1"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 12, "character": 34},
+    "end": {"line": 12, "character": 34}},
+   "context": {"diagnostics": []}}}}
+Resolution of Import test10 from Lean.Server.Test.Refs:
+{"title": "Import test10 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 12, "character": 7},
+       "end": {"line": 12, "character": 34}},
+      "newText": "test10"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 12, "character": 34},
+    "end": {"line": 12, "character": 34}},
+   "context": {"diagnostics": []}}}}
 {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
  "range":
  {"start": {"line": 21, "character": 34}, "end": {"line": 21, "character": 34}},
@@ -193,7 +427,16 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 21, "character": 7},
         "end": {"line": 21, "character": 34}},
-       "newText": "Lean.Server.Test.Refs.Test1"}]}]}},
+       "newText": "Lean.Server.Test.Refs.Test1"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 21, "character": 34},
+     "end": {"line": 21, "character": 34}},
+    "context": {"diagnostics": []}}}},
  {"title": "Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs",
   "kind": "quickfix",
   "edit":
@@ -208,7 +451,66 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 21, "character": 7},
         "end": {"line": 21, "character": 34}},
-       "newText": "Lean.Server.Test.Refs.test10"}]}]}}]
+       "newText": "Lean.Server.Test.Refs.test10"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 21, "character": 34},
+     "end": {"line": 21, "character": 34}},
+    "context": {"diagnostics": []}}}}]
+Resolution of Import Lean.Server.Test.Refs.Test1 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.Test1 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 21, "character": 7},
+       "end": {"line": 21, "character": 34}},
+      "newText": "Lean.Server.Test.Refs.Test1"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 21, "character": 34},
+    "end": {"line": 21, "character": 34}},
+   "context": {"diagnostics": []}}}}
+Resolution of Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 21, "character": 7},
+       "end": {"line": 21, "character": 34}},
+      "newText": "Lean.Server.Test.Refs.test10"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 21, "character": 34},
+    "end": {"line": 21, "character": 34}},
+   "context": {"diagnostics": []}}}}
 {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
  "range":
  {"start": {"line": 24, "character": 33}, "end": {"line": 24, "character": 33}},
@@ -227,7 +529,16 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 24, "character": 7},
         "end": {"line": 24, "character": 33}},
-       "newText": "Lean.Server.Test.Refs.test9"}]}]}},
+       "newText": "Lean.Server.Test.Refs.test9"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 24, "character": 33},
+     "end": {"line": 24, "character": 33}},
+    "context": {"diagnostics": []}}}},
  {"title": "Import Lean.Server.Test.Refs.test8 from Lean.Server.Test.Refs",
   "kind": "quickfix",
   "edit":
@@ -242,7 +553,16 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 24, "character": 7},
         "end": {"line": 24, "character": 33}},
-       "newText": "Lean.Server.Test.Refs.test8"}]}]}},
+       "newText": "Lean.Server.Test.Refs.test8"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 24, "character": 33},
+     "end": {"line": 24, "character": 33}},
+    "context": {"diagnostics": []}}}},
  {"title": "Import Lean.Server.Test.Refs.test7 from Lean.Server.Test.Refs",
   "kind": "quickfix",
   "edit":
@@ -257,7 +577,16 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 24, "character": 7},
         "end": {"line": 24, "character": 33}},
-       "newText": "Lean.Server.Test.Refs.test7"}]}]}},
+       "newText": "Lean.Server.Test.Refs.test7"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 24, "character": 33},
+     "end": {"line": 24, "character": 33}},
+    "context": {"diagnostics": []}}}},
  {"title": "Import Lean.Server.Test.Refs.Test6 from Lean.Server.Test.Refs",
   "kind": "quickfix",
   "edit":
@@ -272,7 +601,16 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 24, "character": 7},
         "end": {"line": 24, "character": 33}},
-       "newText": "Lean.Server.Test.Refs.Test6"}]}]}},
+       "newText": "Lean.Server.Test.Refs.Test6"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 24, "character": 33},
+     "end": {"line": 24, "character": 33}},
+    "context": {"diagnostics": []}}}},
  {"title": "Import Lean.Server.Test.Refs.Test5 from Lean.Server.Test.Refs",
   "kind": "quickfix",
   "edit":
@@ -287,7 +625,16 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 24, "character": 7},
         "end": {"line": 24, "character": 33}},
-       "newText": "Lean.Server.Test.Refs.Test5"}]}]}},
+       "newText": "Lean.Server.Test.Refs.Test5"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 24, "character": 33},
+     "end": {"line": 24, "character": 33}},
+    "context": {"diagnostics": []}}}},
  {"title": "Import Lean.Server.Test.Refs.Test4 from Lean.Server.Test.Refs",
   "kind": "quickfix",
   "edit":
@@ -302,7 +649,16 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 24, "character": 7},
         "end": {"line": 24, "character": 33}},
-       "newText": "Lean.Server.Test.Refs.Test4"}]}]}},
+       "newText": "Lean.Server.Test.Refs.Test4"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 24, "character": 33},
+     "end": {"line": 24, "character": 33}},
+    "context": {"diagnostics": []}}}},
  {"title": "Import Lean.Server.Test.Refs.Test3 from Lean.Server.Test.Refs",
   "kind": "quickfix",
   "edit":
@@ -317,7 +673,16 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 24, "character": 7},
         "end": {"line": 24, "character": 33}},
-       "newText": "Lean.Server.Test.Refs.Test3"}]}]}},
+       "newText": "Lean.Server.Test.Refs.Test3"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 24, "character": 33},
+     "end": {"line": 24, "character": 33}},
+    "context": {"diagnostics": []}}}},
  {"title": "Import Lean.Server.Test.Refs.Test2 from Lean.Server.Test.Refs",
   "kind": "quickfix",
   "edit":
@@ -332,7 +697,16 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 24, "character": 7},
         "end": {"line": 24, "character": 33}},
-       "newText": "Lean.Server.Test.Refs.Test2"}]}]}},
+       "newText": "Lean.Server.Test.Refs.Test2"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 24, "character": 33},
+     "end": {"line": 24, "character": 33}},
+    "context": {"diagnostics": []}}}},
  {"title": "Import Lean.Server.Test.Refs.Test1 from Lean.Server.Test.Refs",
   "kind": "quickfix",
   "edit":
@@ -347,7 +721,16 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 24, "character": 7},
         "end": {"line": 24, "character": 33}},
-       "newText": "Lean.Server.Test.Refs.Test1"}]}]}},
+       "newText": "Lean.Server.Test.Refs.Test1"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 24, "character": 33},
+     "end": {"line": 24, "character": 33}},
+    "context": {"diagnostics": []}}}},
  {"title": "Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs",
   "kind": "quickfix",
   "edit":
@@ -362,7 +745,266 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 24, "character": 7},
         "end": {"line": 24, "character": 33}},
-       "newText": "Lean.Server.Test.Refs.test10"}]}]}}]
+       "newText": "Lean.Server.Test.Refs.test10"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 24, "character": 33},
+     "end": {"line": 24, "character": 33}},
+    "context": {"diagnostics": []}}}}]
+Resolution of Import Lean.Server.Test.Refs.test9 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.test9 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 24, "character": 7},
+       "end": {"line": 24, "character": 33}},
+      "newText": "Lean.Server.Test.Refs.test9"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 24, "character": 33},
+    "end": {"line": 24, "character": 33}},
+   "context": {"diagnostics": []}}}}
+Resolution of Import Lean.Server.Test.Refs.test8 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.test8 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 24, "character": 7},
+       "end": {"line": 24, "character": 33}},
+      "newText": "Lean.Server.Test.Refs.test8"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 24, "character": 33},
+    "end": {"line": 24, "character": 33}},
+   "context": {"diagnostics": []}}}}
+Resolution of Import Lean.Server.Test.Refs.test7 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.test7 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 24, "character": 7},
+       "end": {"line": 24, "character": 33}},
+      "newText": "Lean.Server.Test.Refs.test7"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 24, "character": 33},
+    "end": {"line": 24, "character": 33}},
+   "context": {"diagnostics": []}}}}
+Resolution of Import Lean.Server.Test.Refs.Test6 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.Test6 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 24, "character": 7},
+       "end": {"line": 24, "character": 33}},
+      "newText": "Lean.Server.Test.Refs.Test6"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 24, "character": 33},
+    "end": {"line": 24, "character": 33}},
+   "context": {"diagnostics": []}}}}
+Resolution of Import Lean.Server.Test.Refs.Test5 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.Test5 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 24, "character": 7},
+       "end": {"line": 24, "character": 33}},
+      "newText": "Lean.Server.Test.Refs.Test5"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 24, "character": 33},
+    "end": {"line": 24, "character": 33}},
+   "context": {"diagnostics": []}}}}
+Resolution of Import Lean.Server.Test.Refs.Test4 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.Test4 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 24, "character": 7},
+       "end": {"line": 24, "character": 33}},
+      "newText": "Lean.Server.Test.Refs.Test4"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 24, "character": 33},
+    "end": {"line": 24, "character": 33}},
+   "context": {"diagnostics": []}}}}
+Resolution of Import Lean.Server.Test.Refs.Test3 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.Test3 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 24, "character": 7},
+       "end": {"line": 24, "character": 33}},
+      "newText": "Lean.Server.Test.Refs.Test3"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 24, "character": 33},
+    "end": {"line": 24, "character": 33}},
+   "context": {"diagnostics": []}}}}
+Resolution of Import Lean.Server.Test.Refs.Test2 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.Test2 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 24, "character": 7},
+       "end": {"line": 24, "character": 33}},
+      "newText": "Lean.Server.Test.Refs.Test2"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 24, "character": 33},
+    "end": {"line": 24, "character": 33}},
+   "context": {"diagnostics": []}}}}
+Resolution of Import Lean.Server.Test.Refs.Test1 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.Test1 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 24, "character": 7},
+       "end": {"line": 24, "character": 33}},
+      "newText": "Lean.Server.Test.Refs.Test1"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 24, "character": 33},
+    "end": {"line": 24, "character": 33}},
+   "context": {"diagnostics": []}}}}
+Resolution of Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 24, "character": 7},
+       "end": {"line": 24, "character": 33}},
+      "newText": "Lean.Server.Test.Refs.test10"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 24, "character": 33},
+    "end": {"line": 24, "character": 33}},
+   "context": {"diagnostics": []}}}}
 {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
  "range":
  {"start": {"line": 28, "character": 34}, "end": {"line": 28, "character": 34}},
@@ -381,7 +1023,16 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 28, "character": 7},
         "end": {"line": 28, "character": 34}},
-       "newText": "Test1"}]}]}},
+       "newText": "Test1"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 28, "character": 34},
+     "end": {"line": 28, "character": 34}},
+    "context": {"diagnostics": []}}}},
  {"title": "Import test10 from Lean.Server.Test.Refs",
   "kind": "quickfix",
   "edit":
@@ -396,9 +1047,7 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 28, "character": 7},
         "end": {"line": 28, "character": 34}},
-       "newText": "test10"}]}]}},
- {"title": "Import all unambiguous unknown identifiers",
-  "kind": "quickfix",
+       "newText": "test10"}]}]},
   "data":
   {"providerResultIndex": 0,
    "providerName": "unknownIdentifiers",
@@ -407,7 +1056,68 @@ Resolution of Import all unambiguous unknown identifiers:
     "range":
     {"start": {"line": 28, "character": 34},
      "end": {"line": 28, "character": 34}},
+    "context": {"diagnostics": []}}}},
+ {"title": "Import all unambiguous unknown identifiers",
+  "kind": "quickfix",
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "allUnknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 28, "character": 34},
+     "end": {"line": 28, "character": 34}},
     "context": {"diagnostics": []}}}}]
+Resolution of Import Test1 from Lean.Server.Test.Refs:
+{"title": "Import Test1 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 28, "character": 7},
+       "end": {"line": 28, "character": 34}},
+      "newText": "Test1"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 28, "character": 34},
+    "end": {"line": 28, "character": 34}},
+   "context": {"diagnostics": []}}}}
+Resolution of Import test10 from Lean.Server.Test.Refs:
+{"title": "Import test10 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 28, "character": 7},
+       "end": {"line": 28, "character": 34}},
+      "newText": "test10"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 28, "character": 34},
+    "end": {"line": 28, "character": 34}},
+   "context": {"diagnostics": []}}}}
 Resolution of Import all unambiguous unknown identifiers:
 {"title": "Import all unambiguous unknown identifiers",
  "kind": "quickfix",
@@ -450,7 +1160,7 @@ Resolution of Import all unambiguous unknown identifiers:
       "newText": "LeanServerTestRefsTest0"}]}]},
  "data":
  {"providerResultIndex": 0,
-  "providerName": "unknownIdentifiers",
+  "providerName": "allUnknownIdentifiers",
   "params":
   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
    "range":
@@ -471,7 +1181,16 @@ Resolution of Import all unambiguous unknown identifiers:
      [{"range":
        {"start": {"line": 46, "character": 7},
         "end": {"line": 46, "character": 40}},
-       "newText": "veryLongAndHopefullyVeryUniqueFoo0"}]}]}},
+       "newText": "veryLongAndHopefullyVeryUniqueFoo0"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 46, "character": 40},
+     "end": {"line": 46, "character": 40}},
+    "context": {"diagnostics": []}}}},
  {"title": "Change to veryLongAndHopefullyVeryUniqueFoobar0",
   "kind": "quickfix",
   "edit":
@@ -482,7 +1201,58 @@ Resolution of Import all unambiguous unknown identifiers:
      [{"range":
        {"start": {"line": 46, "character": 7},
         "end": {"line": 46, "character": 40}},
-       "newText": "veryLongAndHopefullyVeryUniqueFoobar0"}]}]}}]
+       "newText": "veryLongAndHopefullyVeryUniqueFoobar0"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 46, "character": 40},
+     "end": {"line": 46, "character": 40}},
+    "context": {"diagnostics": []}}}}]
+Resolution of Change to veryLongAndHopefullyVeryUniqueFoo0:
+{"title": "Change to veryLongAndHopefullyVeryUniqueFoo0",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 46, "character": 7},
+       "end": {"line": 46, "character": 40}},
+      "newText": "veryLongAndHopefullyVeryUniqueFoo0"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 46, "character": 40},
+    "end": {"line": 46, "character": 40}},
+   "context": {"diagnostics": []}}}}
+Resolution of Change to veryLongAndHopefullyVeryUniqueFoobar0:
+{"title": "Change to veryLongAndHopefullyVeryUniqueFoobar0",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 46, "character": 7},
+       "end": {"line": 46, "character": 40}},
+      "newText": "veryLongAndHopefullyVeryUniqueFoobar0"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 46, "character": 40},
+    "end": {"line": 46, "character": 40}},
+   "context": {"diagnostics": []}}}}
 {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
  "range":
  {"start": {"line": 49, "character": 65}, "end": {"line": 49, "character": 65}},
@@ -497,7 +1267,37 @@ Resolution of Import all unambiguous unknown identifiers:
      [{"range":
        {"start": {"line": 49, "character": 32},
         "end": {"line": 49, "character": 65}},
-       "newText": "veryLongAndHopefullyVeryUniqueBar0"}]}]}}]
+       "newText": "veryLongAndHopefullyVeryUniqueBar0"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 49, "character": 65},
+     "end": {"line": 49, "character": 65}},
+    "context": {"diagnostics": []}}}}]
+Resolution of Change to Foobar.veryLongAndHopefullyVeryUniqueBar0:
+{"title": "Change to Foobar.veryLongAndHopefullyVeryUniqueBar0",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 49, "character": 32},
+       "end": {"line": 49, "character": 65}},
+      "newText": "veryLongAndHopefullyVeryUniqueBar0"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 49, "character": 65},
+    "end": {"line": 49, "character": 65}},
+   "context": {"diagnostics": []}}}}
 {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
  "range":
  {"start": {"line": 52, "character": 57}, "end": {"line": 52, "character": 57}},
@@ -512,7 +1312,37 @@ Resolution of Import all unambiguous unknown identifiers:
      [{"range":
        {"start": {"line": 52, "character": 21},
         "end": {"line": 52, "character": 57}},
-       "newText": "veryLongAndHopefullyVeryUniqueFoobar0"}]}]}}]
+       "newText": "veryLongAndHopefullyVeryUniqueFoobar0"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 52, "character": 57},
+     "end": {"line": 52, "character": 57}},
+    "context": {"diagnostics": []}}}}]
+Resolution of Change to Foobar.veryLongAndHopefullyVeryUniqueFoobar0:
+{"title": "Change to Foobar.veryLongAndHopefullyVeryUniqueFoobar0",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 52, "character": 21},
+       "end": {"line": 52, "character": 57}},
+      "newText": "veryLongAndHopefullyVeryUniqueFoobar0"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 52, "character": 57},
+    "end": {"line": 52, "character": 57}},
+   "context": {"diagnostics": []}}}}
 {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
  "range":
  {"start": {"line": 55, "character": 47}, "end": {"line": 55, "character": 47}},
@@ -531,7 +1361,16 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 55, "character": 20},
         "end": {"line": 55, "character": 47}},
-       "newText": "Lean.Server.Test.Refs.Test1"}]}]}},
+       "newText": "Lean.Server.Test.Refs.Test1"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 55, "character": 47},
+     "end": {"line": 55, "character": 47}},
+    "context": {"diagnostics": []}}}},
  {"title": "Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs",
   "kind": "quickfix",
   "edit":
@@ -546,9 +1385,7 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 55, "character": 20},
         "end": {"line": 55, "character": 47}},
-       "newText": "Lean.Server.Test.Refs.test10"}]}]}},
- {"title": "Import all unambiguous unknown identifiers",
-  "kind": "quickfix",
+       "newText": "Lean.Server.Test.Refs.test10"}]}]},
   "data":
   {"providerResultIndex": 0,
    "providerName": "unknownIdentifiers",
@@ -557,7 +1394,68 @@ Resolution of Import all unambiguous unknown identifiers:
     "range":
     {"start": {"line": 55, "character": 47},
      "end": {"line": 55, "character": 47}},
+    "context": {"diagnostics": []}}}},
+ {"title": "Import all unambiguous unknown identifiers",
+  "kind": "quickfix",
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "allUnknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 55, "character": 47},
+     "end": {"line": 55, "character": 47}},
     "context": {"diagnostics": []}}}}]
+Resolution of Import Lean.Server.Test.Refs.Test1 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.Test1 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "public import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 55, "character": 20},
+       "end": {"line": 55, "character": 47}},
+      "newText": "Lean.Server.Test.Refs.Test1"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 55, "character": 47},
+    "end": {"line": 55, "character": 47}},
+   "context": {"diagnostics": []}}}}
+Resolution of Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "public import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 55, "character": 20},
+       "end": {"line": 55, "character": 47}},
+      "newText": "Lean.Server.Test.Refs.test10"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 55, "character": 47},
+    "end": {"line": 55, "character": 47}},
+   "context": {"diagnostics": []}}}}
 Resolution of Import all unambiguous unknown identifiers:
 {"title": "Import all unambiguous unknown identifiers",
  "kind": "quickfix",
@@ -600,7 +1498,7 @@ Resolution of Import all unambiguous unknown identifiers:
       "newText": "LeanServerTestRefsTest0"}]}]},
  "data":
  {"providerResultIndex": 0,
-  "providerName": "unknownIdentifiers",
+  "providerName": "allUnknownIdentifiers",
   "params":
   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
    "range":
@@ -625,7 +1523,16 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 57, "character": 5},
         "end": {"line": 57, "character": 32}},
-       "newText": "Lean.Server.Test.Refs.Test1"}]}]}},
+       "newText": "Lean.Server.Test.Refs.Test1"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 57, "character": 32},
+     "end": {"line": 57, "character": 32}},
+    "context": {"diagnostics": []}}}},
  {"title": "Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs",
   "kind": "quickfix",
   "edit":
@@ -640,9 +1547,7 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 57, "character": 5},
         "end": {"line": 57, "character": 32}},
-       "newText": "Lean.Server.Test.Refs.test10"}]}]}},
- {"title": "Import all unambiguous unknown identifiers",
-  "kind": "quickfix",
+       "newText": "Lean.Server.Test.Refs.test10"}]}]},
   "data":
   {"providerResultIndex": 0,
    "providerName": "unknownIdentifiers",
@@ -651,7 +1556,68 @@ Resolution of Import all unambiguous unknown identifiers:
     "range":
     {"start": {"line": 57, "character": 32},
      "end": {"line": 57, "character": 32}},
+    "context": {"diagnostics": []}}}},
+ {"title": "Import all unambiguous unknown identifiers",
+  "kind": "quickfix",
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "allUnknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 57, "character": 32},
+     "end": {"line": 57, "character": 32}},
     "context": {"diagnostics": []}}}}]
+Resolution of Import Lean.Server.Test.Refs.Test1 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.Test1 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 57, "character": 5},
+       "end": {"line": 57, "character": 32}},
+      "newText": "Lean.Server.Test.Refs.Test1"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 57, "character": 32},
+    "end": {"line": 57, "character": 32}},
+   "context": {"diagnostics": []}}}}
+Resolution of Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 57, "character": 5},
+       "end": {"line": 57, "character": 32}},
+      "newText": "Lean.Server.Test.Refs.test10"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 57, "character": 32},
+    "end": {"line": 57, "character": 32}},
+   "context": {"diagnostics": []}}}}
 Resolution of Import all unambiguous unknown identifiers:
 {"title": "Import all unambiguous unknown identifiers",
  "kind": "quickfix",
@@ -694,7 +1660,7 @@ Resolution of Import all unambiguous unknown identifiers:
       "newText": "LeanServerTestRefsTest0"}]}]},
  "data":
  {"providerResultIndex": 0,
-  "providerName": "unknownIdentifiers",
+  "providerName": "allUnknownIdentifiers",
   "params":
   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
    "range":
@@ -719,7 +1685,16 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 60, "character": 26},
         "end": {"line": 60, "character": 53}},
-       "newText": "Lean.Server.Test.Refs.Test1"}]}]}},
+       "newText": "Lean.Server.Test.Refs.Test1"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 60, "character": 53},
+     "end": {"line": 60, "character": 53}},
+    "context": {"diagnostics": []}}}},
  {"title": "Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs",
   "kind": "quickfix",
   "edit":
@@ -734,9 +1709,7 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 60, "character": 26},
         "end": {"line": 60, "character": 53}},
-       "newText": "Lean.Server.Test.Refs.test10"}]}]}},
- {"title": "Import all unambiguous unknown identifiers",
-  "kind": "quickfix",
+       "newText": "Lean.Server.Test.Refs.test10"}]}]},
   "data":
   {"providerResultIndex": 0,
    "providerName": "unknownIdentifiers",
@@ -745,7 +1718,68 @@ Resolution of Import all unambiguous unknown identifiers:
     "range":
     {"start": {"line": 60, "character": 53},
      "end": {"line": 60, "character": 53}},
+    "context": {"diagnostics": []}}}},
+ {"title": "Import all unambiguous unknown identifiers",
+  "kind": "quickfix",
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "allUnknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 60, "character": 53},
+     "end": {"line": 60, "character": 53}},
     "context": {"diagnostics": []}}}}]
+Resolution of Import Lean.Server.Test.Refs.Test1 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.Test1 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "public meta import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 60, "character": 26},
+       "end": {"line": 60, "character": 53}},
+      "newText": "Lean.Server.Test.Refs.Test1"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 60, "character": 53},
+    "end": {"line": 60, "character": 53}},
+   "context": {"diagnostics": []}}}}
+Resolution of Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "public meta import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 60, "character": 26},
+       "end": {"line": 60, "character": 53}},
+      "newText": "Lean.Server.Test.Refs.test10"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 60, "character": 53},
+    "end": {"line": 60, "character": 53}},
+   "context": {"diagnostics": []}}}}
 Resolution of Import all unambiguous unknown identifiers:
 {"title": "Import all unambiguous unknown identifiers",
  "kind": "quickfix",
@@ -788,7 +1822,7 @@ Resolution of Import all unambiguous unknown identifiers:
       "newText": "LeanServerTestRefsTest0"}]}]},
  "data":
  {"providerResultIndex": 0,
-  "providerName": "unknownIdentifiers",
+  "providerName": "allUnknownIdentifiers",
   "params":
   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
    "range":
@@ -813,7 +1847,16 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 62, "character": 5},
         "end": {"line": 62, "character": 32}},
-       "newText": "Lean.Server.Test.Refs.Test1"}]}]}},
+       "newText": "Lean.Server.Test.Refs.Test1"}]}]},
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "unknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 62, "character": 32},
+     "end": {"line": 62, "character": 32}},
+    "context": {"diagnostics": []}}}},
  {"title": "Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs",
   "kind": "quickfix",
   "edit":
@@ -828,9 +1871,7 @@ Resolution of Import all unambiguous unknown identifiers:
       {"range":
        {"start": {"line": 62, "character": 5},
         "end": {"line": 62, "character": 32}},
-       "newText": "Lean.Server.Test.Refs.test10"}]}]}},
- {"title": "Import all unambiguous unknown identifiers",
-  "kind": "quickfix",
+       "newText": "Lean.Server.Test.Refs.test10"}]}]},
   "data":
   {"providerResultIndex": 0,
    "providerName": "unknownIdentifiers",
@@ -839,7 +1880,68 @@ Resolution of Import all unambiguous unknown identifiers:
     "range":
     {"start": {"line": 62, "character": 32},
      "end": {"line": 62, "character": 32}},
+    "context": {"diagnostics": []}}}},
+ {"title": "Import all unambiguous unknown identifiers",
+  "kind": "quickfix",
+  "data":
+  {"providerResultIndex": 0,
+   "providerName": "allUnknownIdentifiers",
+   "params":
+   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+    "range":
+    {"start": {"line": 62, "character": 32},
+     "end": {"line": 62, "character": 32}},
     "context": {"diagnostics": []}}}}]
+Resolution of Import Lean.Server.Test.Refs.Test1 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.Test1 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "public meta import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 62, "character": 5},
+       "end": {"line": 62, "character": 32}},
+      "newText": "Lean.Server.Test.Refs.Test1"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 62, "character": 32},
+    "end": {"line": 62, "character": 32}},
+   "context": {"diagnostics": []}}}}
+Resolution of Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs:
+{"title": "Import Lean.Server.Test.Refs.test10 from Lean.Server.Test.Refs",
+ "kind": "quickfix",
+ "edit":
+ {"documentChanges":
+  [{"textDocument":
+    {"version": 1, "uri": "file:///unknownIdentifierCodeActions.lean"},
+    "edits":
+    [{"range":
+      {"start": {"line": 1, "character": 0},
+       "end": {"line": 1, "character": 0}},
+      "newText": "public meta import Lean.Server.Test.Refs\n"},
+     {"range":
+      {"start": {"line": 62, "character": 5},
+       "end": {"line": 62, "character": 32}},
+      "newText": "Lean.Server.Test.Refs.test10"}]}]},
+ "data":
+ {"providerResultIndex": 0,
+  "providerName": "unknownIdentifiers",
+  "params":
+  {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
+   "range":
+   {"start": {"line": 62, "character": 32},
+    "end": {"line": 62, "character": 32}},
+   "context": {"diagnostics": []}}}}
 Resolution of Import all unambiguous unknown identifiers:
 {"title": "Import all unambiguous unknown identifiers",
  "kind": "quickfix",
@@ -882,7 +1984,7 @@ Resolution of Import all unambiguous unknown identifiers:
       "newText": "LeanServerTestRefsTest0"}]}]},
  "data":
  {"providerResultIndex": 0,
-  "providerName": "unknownIdentifiers",
+  "providerName": "allUnknownIdentifiers",
   "params":
   {"textDocument": {"uri": "file:///unknownIdentifierCodeActions.lean"},
    "range":


### PR DESCRIPTION
This PR fixes a bug where the unknown identifier code actions were broken in NeoVim due to the language server not properly setting the `data?` field for all code action items that it yields.