### PR TITLE
fix: make all VCs emitted by `mvcgen` synthetic opaque

### DIFF
--- a/src/Lean/Elab/Tactic/Do/VCGen.lean
+++ b/src/Lean/Elab/Tactic/Do/VCGen.lean
@@ -47,10 +47,10 @@ partial def genVCs (goal : MVarId) (ctx : Context) (fuel : Fuel) : MetaM Result 
   mvar.withContext <| withReducible do
     let (prf, state) ← StateRefT'.run (ReaderT.run (onGoal goal (← mvar.getTag)) ctx) { fuel }
     mvar.assign prf
-    for h : idx in [:state.invariants.size] do
+    for h : idx in *...state.invariants.size do
       let mv := state.invariants[idx]
       mv.setTag (Name.mkSimple ("inv" ++ toString (idx + 1)))
-    for h : idx in [:state.vcs.size] do
+    for h : idx in *...state.vcs.size do
       let mv := state.vcs[idx]
       mv.setTag (Name.mkSimple ("vc" ++ toString (idx + 1)) ++ (← mv.getTag).eraseMacroScopes)
     return { invariants := state.invariants, vcs := state.vcs }

--- a/tests/run/12048.lean
+++ b/tests/run/12048.lean
@@ -1,0 +1,27 @@
+import Std.Tactic.Do
+open Std.Do
+
+set_option mvcgen.warning false
+
+axiom myfun : Except String Unit
+
+@[spec]
+axiom myfun_spec (h : True) :
+  ⦃ ⌜ True ⌝ ⦄
+  myfun
+  ⦃ ⇓ _ => ⌜ True ⌝ ⦄
+
+@[spec]
+def anotherfun : Except String Unit :=
+  if true then pure () else pure ()
+
+noncomputable def program : Except String Unit := do
+  anotherfun
+  myfun
+
+@[spec]
+theorem spec :
+  ⦃ ⌜ True ⌝ ⦄
+  program
+  ⦃ ⇓ _ => ⌜ True ⌝ ⦄ := by
+  mvcgen [program]


### PR DESCRIPTION
This PR fixes a bug where `mvcgen`  loses VCs, resulting in unassigned metavariables. It is fixed by making all emitted VCs synthetic opaque.

The bug was reported by [Alexander Bentkamp on the community Zulip](https://leanprover.zulipchat.com/#narrow/channel/236449-Program-verification/topic/mvcgen.20bug.3F.20.22declaration.20has.20metavariables.22).