### PR TITLE
perf: strip unneeded symbols from libleanshared*

### DIFF
--- a/src/stdlib.make.in
+++ b/src/stdlib.make.in
@@ -138,7 +138,6 @@ else
 	  -Wl,--whole-archive ${LIB}/temp/Lean.*o.export ${LIB}/temp/libleanshell.a -Wl,--no-whole-archive -Wl,--start-group -lInit -lStd -lLean -lleancpp -Wl,--end-group ${CMAKE_BINARY_DIR}/runtime/libleanrt_initial-exec.a ${LEANSHARED_LINKER_FLAGS} ${TOOLCHAIN_SHARED_LINKER_FLAGS} ${LEANC_OPTS}
 endif
 endif
-
 ifeq "${CMAKE_BUILD_TYPE}" "Release"
 ifeq "${CMAKE_SYSTEM_NAME}" "Linux"
 # We only strip like this on Linux for now as our other platforms already seem to exclude the


### PR DESCRIPTION
This PR strips unneeded symbol names from libleanshared.so on Linux. It appears that on other platforms the symbols names we are interested in here are already removed by the linker.