### PR TITLE
chore: enable `let rec` tactic completion and docs

### DIFF
--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -910,7 +910,7 @@ The syntax is the same as term-mode `let rec`.
 
 The tactic supports all the same syntax variants and options as the `let` term.
 -/
--- Uncomment after stage0 update: @[tactic_name "let rec"]
+@[tactic_name "let rec"]
 syntax (name := letrec) withPosition(atomic("let " &"rec ") letRecDecls) : tactic
 macro_rules
   | `(tactic| let rec $d) => `(tactic| refine_lift let rec $d; ?_)

--- a/tests/lean/run/tacticDocUserName.lean
+++ b/tests/lean/run/tacticDocUserName.lean
@@ -20,10 +20,6 @@ This test ensures that user-facing tactic names shipped with Lean are kept unamb
     let kindsForToken ← kindsForToken.filterM fun k => do
       pure <| (Parser.Tactic.Doc.alternativeOfTactic (← getEnv) k).isNone
 
-    -- Until a stage0 update allows let rec to have a custom name, ignore it. Then update this test.
-    let kindsForToken := kindsForToken.filter (· ≠ ``Lean.Parser.Tactic.letrec)
-    if firstTok.contains ' ' then throwError "Test needs updating after stage0 update (see comment)"
-
     -- If it's ambiguous, log an error.
     if kindsForToken.length > 1 then
       let kinds := MessageData.andList <| kindsForToken.map (m!"`{.ofConstName ·}`")
@@ -45,12 +41,13 @@ This test ensures that user-facing tactic names are found for all the tactics th
 This test spot-checks tactics defined in a few ways to make sure they all have user-facing names:
  * Defined using `syntax ... : tactic`, both leading and trailing (`intros` and `<;>`)
  * Defined using `declare_simp_like_tactic` (`simpAutoUnfold`)
- * Defined with custom user-facing names (`Lean.Parser.Tactic.letrec`) (after stage0 update)
+ * Defined with custom user-facing names (`Lean.Parser.Tactic.letrec`)
 -/
 /--
 info: (some intro)
 (some <;>)
 (some simp!)
+(some (let rec))
 -/
 #guard_msgs in
 #eval show MetaM Unit from do
@@ -58,4 +55,4 @@ info: (some intro)
   IO.println (firsts.get? ``Lean.Parser.Tactic.intro)
   IO.println (firsts.get? ``Lean.Parser.Tactic.«tactic_<;>_»)
   IO.println (firsts.get? ``Lean.Parser.Tactic.simpAutoUnfold)
-  --IO.println (firsts.get? ``Lean.Parser.Tactic.letrec)
+  IO.println (firsts.get? ``Lean.Parser.Tactic.letrec)


### PR DESCRIPTION
This PR enables tactic completion and docs for the `let rec` tactic, which required a stage0 update after #12047.
