### PR TITLE
perf: more tweaks to injEq generation

### DIFF
--- a/src/Lean/Meta/Injective.lean
+++ b/src/Lean/Meta/Injective.lean
@@ -181,19 +181,22 @@ private def mkInjectiveEqTheoremValue (ctorName : Name) (targetType : Expr) : Me
       | _ => pure ()
       let (h, mvarId₂') ← mvarId₂.intro1
       mvarId₂ := mvarId₂'
+      /-
       let hType ← instantiateMVars (← mvarId₂.withContext h.getType)
       if hType.isEq then
         eqs := eqs.push h
       else if hType.isHEq then
         heqs := heqs.push h
       else throwError "unexpected hypothesis of type{inlineExpr hType}in\n{mvarId₂}"
+      -/
+      heqs := heqs.push h
     -- Then revert the `HEq`s together with their variables, from back to front.
     let mut introChunks : Array Nat := #[]
     for heq in heqs.reverse do
       let (n, mvarId₂') ← revertEq mvarId₂ heq
       introChunks := introChunks.push n
       mvarId₂ := mvarId₂'
-    trace[Meta.injective] "after reverting {heqs.size} HEqs:\n{mvarId₂}"
+    trace[Meta.injective] "after reverting {heqs.size} HEqs in blocks {introChunks}:\n{mvarId₂}"
     -- Now revert the other equalities, but without their variables
     (_, mvarId₂) ← mvarId₂.revert eqs
     trace[Meta.injective] "after reverting {eqs.size} Eqs:\n{mvarId₂}"

--- a/src/Lean/Meta/Injective.lean
+++ b/src/Lean/Meta/Injective.lean
@@ -152,9 +152,9 @@ private def mkInjectiveEqTheoremValue (ctorName : Name) (targetType : Expr) : Me
       let some (conj, body) := t.arrow?  | break
       match_expr conj with
       | And lhs rhs =>
-        let [mvarId₂'] ← mvarId₂.applyN (mkApp3 (mkConst `Lean.injEq_helper) lhs rhs body) 1
-            | throwError "unexpected number of goals after applying `Lean.and_imp`"
-        mvarId₂ := mvarId₂'
+        let e ← mkFreshExprSyntheticOpaqueMVar (← mkArrow lhs (← mkArrow rhs body))
+        mvarId₂.assign <| mkApp4 (mkConst `Lean.injEq_helper) lhs rhs body e
+        mvarId₂ := e.mvarId!
       | _ => pure ()
       let (h, mvarId₂') ← mvarId₂.intro1
       (_, mvarId₂) ← substEq mvarId₂' h

--- a/src/Lean/Meta/Injective.lean
+++ b/src/Lean/Meta/Injective.lean
@@ -181,15 +181,12 @@ private def mkInjectiveEqTheoremValue (ctorName : Name) (targetType : Expr) : Me
       | _ => pure ()
       let (h, mvarId₂') ← mvarId₂.intro1
       mvarId₂ := mvarId₂'
-      /-
       let hType ← instantiateMVars (← mvarId₂.withContext h.getType)
       if hType.isEq then
         eqs := eqs.push h
       else if hType.isHEq then
         heqs := heqs.push h
       else throwError "unexpected hypothesis of type{inlineExpr hType}in\n{mvarId₂}"
-      -/
-      heqs := heqs.push h
     -- Then revert the `HEq`s together with their variables, from back to front.
     let mut introChunks : Array Nat := #[]
     for heq in heqs.reverse do

--- a/src/Lean/Meta/Injective.lean
+++ b/src/Lean/Meta/Injective.lean
@@ -182,9 +182,10 @@ private def mkInjectiveEqTheoremValue (ctorName : Name) (targetType : Expr) : Me
       let (h, mvarId₂') ← mvarId₂.intro1
       mvarId₂ := mvarId₂'
       let hType ← instantiateMVars (← mvarId₂.withContext h.getType)
-      if hType.isEq then
+      -- The heq.isEmpty is a hack
+      if hType.isEq && heqs.isEmpty then
         eqs := eqs.push h
-      else if hType.isHEq then
+      else if hType.isEq || hType.isHEq then
         heqs := heqs.push h
       else throwError "unexpected hypothesis of type{inlineExpr hType}in\n{mvarId₂}"
     -- Then revert the `HEq`s together with their variables, from back to front.

--- a/tests/lean/run/issue12073.lean
+++ b/tests/lean/run/issue12073.lean
@@ -1,0 +1,12 @@
+-- set_option trace.Meta.injective true
+/-!
+A mix of propositional and dependent fields
+-/
+structure Tricky where
+  a : Nat
+  a' : Nat
+  b : 42 < a
+  c : Fin a
+  d : 23 < c.toNat
+  e : a = a'
+  f : Fin c.toNat

--- a/tests/lean/run/issue12073.lean
+++ b/tests/lean/run/issue12073.lean
@@ -1,5 +1,4 @@
 -- set_option trace.Meta.injective true
-
 /-!
 A mix of propositional and dependent fields
 -/

--- a/tests/lean/run/issue12073.lean
+++ b/tests/lean/run/issue12073.lean
@@ -1,4 +1,5 @@
 -- set_option trace.Meta.injective true
+
 /-!
 A mix of propositional and dependent fields
 -/

--- a/tests/lean/run/issue12073.lean
+++ b/tests/lean/run/issue12073.lean
@@ -1,4 +1,5 @@
 -- set_option trace.Meta.injective true
+
 /-!
 A mix of propositional and dependent fields
 -/
@@ -10,3 +11,15 @@ structure Tricky where
   d : 23 < c.toNat
   e : a = a'
   f : Fin c.toNat
+
+
+structure Tricky2 (α : Type u) where
+  le : LE α
+  decidableLE : DecidableLE α
+  lt : let := le; LT α
+  beq : let := le; let := decidableLE; BEq α
+  lt_iff : let := le; let := lt; ∀ a b : α, a < b ↔ a ≤ b ∧ ¬ b ≤ a
+  decidableLT : let := le; let := decidableLE; let := lt; haveI := lt_iff; have := lt_iff; DecidableLT α
+  beq_iff_le_and_ge : let := le; let := decidableLE; let := beq; ∀ a b : α, a == b ↔ a ≤ b ∧ b ≤ a
+  le_refl : let := le; ∀ a : α, a ≤ a
+  le_trans : let := le; ∀ a b c : α, a ≤ b → b ≤ c → a ≤ c


### PR DESCRIPTION
This PR attempts speed up the `injEq` generation even more (over https://github.com/leanprover/lean4/pull/11998), with a focus on dependent structs.