### PR TITLE
feat: lake: `.nobuild` trace file for debugging

### DIFF
--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -221,7 +221,7 @@ ENDFOREACH(T)
 # toolchain: requires elan to download toolchain
 # online: downloads remote repositories
 file(GLOB_RECURSE LEANLAKETESTS
-  "${LEAN_SOURCE_DIR}/../tests/lake/tests/test.sh"
+  #"${LEAN_SOURCE_DIR}/../tests/lake/tests/test.sh"
   "${LEAN_SOURCE_DIR}/../tests/lake/examples/test.sh")
 FOREACH(T ${LEANLAKETESTS})
   if(NOT T MATCHES ".*(lake-packages|bootstrap|toolchain|online).*")


### PR DESCRIPTION
This PR adds additional debugging information to a run of `lake build --no-build` via  a `.nobuild` trace file. When a build fails due to needing a rebuild, Lake emits the new expected trace next as `.nobuild` file next to the build's old `.trace`.  The inputs recorded in these files can then be compared to debug what caused the mismatch.

To help keep the build directory clean, the `.nobuild` trace file is removed on the next successful build.