### PR TITLE
fix: Wake up throttled workers on shutdown

### DIFF
--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -755,6 +755,8 @@ class task_manager {
             m_idle_std_workers++;
             while (true) {
                 if (m_queues_size == 0 && m_shutting_down) {
+                    // Wake any throttled workers so they can exit.
+                    m_queue_cv.notify_all();
                     break;
                 }
                 if (m_queues_size == 0 ||


### PR DESCRIPTION
This PR fixes a deadlock that occurs on the task manager shutdown.

During shutdown we notify all workers once, but a worker can still `wait()` because of the `m_max_std_workers` throttle. No further notify occurs after shutdown, so those throttled workers never wake and `join()` hangs.

Example: 
- m_max_std_workers = 1, m_std_workers.size() = 2, and the queue still has tasks.
- Finalizer sets m_shutting_down = true and calls notify_all() while a worker is running a task (outside of the mutex).
- Worker finishes a task, re-enters the loop, sees work, and "should wait" because active >= max.
- Worker then calls wait() after the notify and never wakes, so join() in the finalizer hangs.


Notify all right before breaking on (shutting_down && empty queue) so any throttled waiters can exit once the queue drains.

