### PR TITLE
feat: `fold` definitions for bitvectors

### DIFF
--- a/src/Init/Data/BitVec/Basic.lean
+++ b/src/Init/Data/BitVec/Basic.lean
@@ -1023,7 +1023,12 @@ def foldIntR' {s : Type} (x : BitVec w) (start k : Nat) (acc : s)
   to the user: -/
 
 /-- Recursively add `l`-long chunks of `x`, treating the chunks as natural numbers. -/
-def foldAddNat (l : Nat) (x : BitVec w) : BitVec l := foldNatR x 0 l 0#l BitVec.add
+def foldAddNat (l : Nat) (x : BitVec w) : BitVec l :=
+  if h : l = 0 then
+    (0#0).cast (by omega)
+  else
+    let k := if w % l = 0 then  w / l else w / l + 1
+    foldNatR x 0 k 0#l BitVec.add
 
 /-- Recursively add `l`-long chunks of `x`, treating the chunks as integer numbers. -/
 def foldAddInt (l : Nat) (x : BitVec w) : BitVec l := foldIntR x 0 l 0#l BitVec.add


### PR DESCRIPTION
This PR introduces a folding operation over bitvectors and poses the bases to represent (and bitblast) vector operations, such as LLVM's vector intrinsics. 

We want to treat a `BitVec w` as a flattened, concatenated list of bitvectors, which we extract in `l`-long chunks and to which we apply an arbitrary `BitVec` function `f`. We do this in a tail-recursive fashion, using an accumulator `acc` that is updated at every function call (`acc' := f acc ...`). The initial value of the accumulator is typically `0#l`.

In this PR, we consider treating these chunks of bitvectors as either naturals (i.e., zero-extending when necessary) or integers (i.e., sign-extending when necessary). 
Note that this sign- or zero-extension is only necessary (potentially!) at the _very last_ step of the iteration. Consider the following `x : BitVec 5` and `l = 3`, where `x = 0 0 1 0 1`. 
At the very first iteration `foldNat` applies `f` to the accumulator and to`BitVec.extractLsb' x 0 3` (the first 3 bits), and at the second it will try to do the same with the next chunk `BitVec.extractLsb' x 3 3`. In this case, the `extractLsb'` will also zero-extend, given that we are interested in treating these `3`-long words as a natural number. Conversely, `foldInt` performs sign-extension in these cases, meaning that we interpret the chunks as integers. 

For some operations we also would like to _not_ have the accumulator be `0#l` at the very first iteration, e.g. if we want to recursively divide chunks of the bitvector. To account for this, we specialize the general `foldNat` and `foldInt` to `foldUdiv` and `foldSdiv`, which call the general definitions using the first `l`-long chunk as initial accumulator (and consequently start extracting from the second chunk). 
