### PR TITLE
feat: add prefix and suffix map injectivity lemmas

### DIFF
--- a/src/Init/Data/List/Nat/Sublist.lean
+++ b/src/Init/Data/List/Nat/Sublist.lean
@@ -131,11 +131,11 @@ theorem suffix_iff_eq_drop : l₁ <:+ l₂ ↔ l₁ = drop (length l₂ - length
   ⟨fun h => append_cancel_left <| (suffix_iff_eq_append.1 h).trans (take_append_drop _ _).symm,
     fun e => e.symm ▸ drop_suffix _ _⟩
 
-theorem prefix_map_iff_inj {f : α → β} (hf : Function.Injective f) :
+theorem prefix_map_iff_of_injective {f : α → β} (hf : Function.Injective f) :
     l₁.map f <+: l₂.map f ↔ l₁ <+: l₂ := by
   simp [prefix_iff_eq_take, ← map_take, map_inj_right hf]
 
-theorem suffix_map_iff_inj {f : α → β} (hf : Function.Injective f) :
+theorem suffix_map_iff_of_injective {f : α → β} (hf : Function.Injective f) :
     l₁.map f <:+ l₂.map f ↔ l₁ <:+ l₂ := by
   simp [suffix_iff_eq_drop, ← map_drop, map_inj_right hf]
 


### PR DESCRIPTION
This PR adds `prefix_map_iff_of_injective` and `suffix_map_iff_of_injective` lemmas to Init.Data.List.Nat.Sublist.

These lemmas establish that if a function `f` is injective, then the prefix and suffix relations are preserved under mapping (e.g., `l₁.map f <+: l₂.map f ↔ l₁ <+: l₂`). These additions complement the existing index-based lemmas in this file and allow for simpler structural proofs without resorting to `take`, `drop`, or manual index manipulation.