### PR TITLE
chore: check reference-manual release notes title in release checklist

### DIFF
--- a/script/release_checklist.py
+++ b/script/release_checklist.py
@@ -542,7 +542,11 @@ def check_reference_manual_release_title(repo_url, toolchain, pr_branch, github_
 
             if is_rc:
                 # For RC releases, title should contain the exact RC suffix (e.g., "-rc1")
-                if rc_suffix.lower() in line.lower():
+                # Use regex to match exact suffix followed by non-digit (to avoid -rc1 matching -rc10)
+                # Pattern matches the RC suffix followed by a non-digit or end-of-string context
+                # e.g., "-rc1" followed by space, quote, paren, or similar
+                exact_match = re.search(rf'{re.escape(rc_suffix)}(?![0-9])', line, re.IGNORECASE)
+                if exact_match:
                     print(f"  ✅ Release notes title correctly shows {rc_suffix}")
                     return True
                 elif has_rc_in_title:


### PR DESCRIPTION
This PR adds a check to the release checklist script that verifies the
reference-manual release notes title matches the release type:

- For RC releases (e.g., v4.27.0-rc1): verifies the title contains the exact
  RC suffix (e.g., "Lean 4.27.0-rc1")
- For final releases (e.g., v4.27.0): verifies the title does NOT contain
  any "-rc" suffix (e.g., "Lean 4.27.0")

The check looks at the PR branch (bump_to_vX.Y.Z) for the release notes file
at `Manual/Releases/v4_X_Y.lean` and parses the `#doc (Manual) "Lean ..."` line.

🤖 Prepared with Claude Code