### PR TITLE
chore: remove redundant smod code

### DIFF
--- a/src/include/lean/lean.h
+++ b/src/include/lean/lean.h
@@ -2097,16 +2097,14 @@ static inline uint8_t lean_int8_xor(uint8_t a1, uint8_t a2) {
 
 static inline uint8_t lean_int8_shift_right(uint8_t a1, uint8_t a2) {
     int8_t lhs = (int8_t)a1;
-    int8_t rhs = (((int8_t)a2 % 8) + 8) % 8; // this is smod 8
 
-    return (uint8_t)(lhs >> rhs);
+    return (uint8_t)(lhs >> (a2 % 8));
 }
 
 static inline uint8_t lean_int8_shift_left(uint8_t a1, uint8_t a2) {
     int8_t lhs = (int8_t)a1;
-    int8_t rhs = (((int8_t)a2 % 8) + 8) % 8; // this is smod 8
 
-    return (uint8_t)(lhs << rhs);
+    return (uint8_t)(lhs << (a2 % 8));
 }
 
 static inline uint8_t lean_int8_complement(uint8_t a) {
@@ -2248,16 +2246,13 @@ static inline uint16_t lean_int16_xor(uint16_t a1, uint16_t a2) {
 
 static inline uint16_t lean_int16_shift_right(uint16_t a1, uint16_t a2) {
     int16_t lhs = (int16_t)a1;
-    int16_t rhs = (((int16_t)a2 % 16) + 16) % 16; // this is smod 16
-
-    return (uint16_t)(lhs >> rhs);
+    return (uint16_t)(lhs >> (a2 % 16));
 }
 
 static inline uint16_t lean_int16_shift_left(uint16_t a1, uint16_t a2) {
     int16_t lhs = (int16_t)a1;
-    int16_t rhs = (((int16_t)a2 % 16) + 16) % 16; // this is smod 16
 
-    return (uint16_t)(lhs << rhs);
+    return (uint16_t)(lhs << (a2 % 16));
 }
 
 static inline uint16_t lean_int16_complement(uint16_t a) {
@@ -2398,16 +2393,14 @@ static inline uint32_t lean_int32_xor(uint32_t a1, uint32_t a2) {
 
 static inline uint32_t lean_int32_shift_right(uint32_t a1, uint32_t a2) {
     int32_t lhs = (int32_t)a1;
-    int32_t rhs = (((int32_t)a2 % 32) + 32) % 32; // this is smod 32
 
-    return (uint32_t)(lhs >> rhs);
+    return (uint32_t)(lhs >> (a2 % 32));
 }
 
 static inline uint32_t lean_int32_shift_left(uint32_t a1, uint32_t a2) {
     int32_t lhs = (int32_t)a1;
-    int32_t rhs = (((int32_t)a2 % 32) + 32) % 32; // this is smod 32
 
-    return (uint32_t)(lhs << rhs);
+    return (uint32_t)(lhs << (a2 % 32)));
 }
 
 static inline uint32_t lean_int32_complement(uint32_t a) {
@@ -2550,16 +2543,14 @@ static inline uint64_t lean_int64_xor(uint64_t a1, uint64_t a2) {
 
 static inline uint64_t lean_int64_shift_right(uint64_t a1, uint64_t a2) {
     int64_t lhs = (int64_t)a1;
-    int64_t rhs = (((int64_t)a2 % 64) + 64) % 64; // this is smod 64
 
-    return (uint64_t)(lhs >> rhs);
+    return (uint64_t)(lhs >> (a2 % 64));
 }
 
 static inline uint64_t lean_int64_shift_left(uint64_t a1, uint64_t a2) {
     int64_t lhs = (int64_t)a1;
-    int64_t rhs = (((int64_t)a2 % 64) + 64) % 64; // this is smod 64
 
-    return (uint64_t)(lhs << rhs);
+    return (uint64_t)(lhs << (a2 % 64));
 }
 
 static inline uint64_t lean_int64_complement(uint64_t a) {
@@ -2699,17 +2690,15 @@ static inline size_t lean_isize_xor(size_t a1, size_t a2) {
 static inline size_t lean_isize_shift_right(size_t a1, size_t a2) {
     ptrdiff_t lhs = (ptrdiff_t)a1;
     ptrdiff_t size = sizeof(ptrdiff_t) * 8;
-    ptrdiff_t rhs = (((ptrdiff_t)a2 % size) + size) % size; // this is smod
 
-    return (size_t)(lhs >> rhs);
+    return (size_t)(lhs >> (a2 % size));
 }
 
 static inline size_t lean_isize_shift_left(size_t a1, size_t a2) {
     ptrdiff_t lhs = (ptrdiff_t)a1;
     ptrdiff_t size = sizeof(ptrdiff_t) * 8;
-    ptrdiff_t rhs = (((ptrdiff_t)a2 % size) + size) % size; // this is smod
 
-    return (size_t)(lhs << rhs);
+    return (size_t)(lhs << (a2 % size));
 }
 
 static inline size_t lean_isize_complement(size_t a) {


### PR DESCRIPTION
We get the desired modulo behavior for free by remaining in the unsigned type, since the modulo is a power of two.
