### PR TITLE
fix: add syntax to recommended_spelling for inv

### DIFF
--- a/src/Init/Notation.lean
+++ b/src/Init/Notation.lean
@@ -360,7 +360,7 @@ recommended_spelling "smul" for "•" in [HSMul.hSMul, «term_•_»]
 recommended_spelling "append" for "++" in [HAppend.hAppend, «term_++_»]
 /-- when used as a unary operator -/
 recommended_spelling "neg" for "-" in [Neg.neg, «term-_»]
-recommended_spelling "inv" for "⁻¹" in [Inv.inv]
+recommended_spelling "inv" for "⁻¹" in [Inv.inv, «term_⁻¹»]
 recommended_spelling "dvd" for "∣" in [Dvd.dvd, «term_∣_»]
 recommended_spelling "shiftLeft" for "<<<" in [HShiftLeft.hShiftLeft, «term_<<<_»]
 recommended_spelling "shiftRight" for ">>>" in [HShiftRight.hShiftRight, «term_>>>_»]


### PR DESCRIPTION
This PR adds `«term_⁻¹»` to the `recommended_spelling` for `inv`, matching
the pattern used by all other operators which include both the function
and the syntax in their spelling lists.

Reported at https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/.60recommended_spelling.60.20for.20.60.C2.ABterm_.E2.81.BB.C2.B9.C2.BB.60

🤖 Prepared with Claude Code