### PR TITLE
feat: add `simpTelescope` simproc for simplifying binders before intro

### DIFF
--- a/src/Lean/Meta/Sym/Simp.lean
+++ b/src/Lean/Meta/Sym/Simp.lean
@@ -22,3 +22,4 @@ public import Lean.Meta.Sym.Simp.EvalGround
 public import Lean.Meta.Sym.Simp.Discharger
 public import Lean.Meta.Sym.Simp.ControlFlow
 public import Lean.Meta.Sym.Simp.Goal
+public import Lean.Meta.Sym.Simp.Telescope

--- a/src/Lean/Meta/Sym/Simp/Lambda.lean
+++ b/src/Lean/Meta/Sym/Simp/Lambda.lean
@@ -46,12 +46,12 @@ def mkFunextFor (xs : Array Expr) (β : Expr) : MetaM Expr := do
   let result ← mkLambdaFVars #[f, g, h] result
   return result
 
-public def simpLambda (e : Expr) : SimpM Result := do
+public def simpLambda' (simpBody : Simproc) (e : Expr) : SimpM Result := do
   lambdaTelescope e fun xs b => withoutModifyingCacheIfNotWellBehaved do
     main xs (← shareCommon b)
 where
   main (xs : Array Expr) (b : Expr) : SimpM Result := do
-    match (← simp b) with
+    match (← simpBody b) with
     | .rfl _ => return .rfl
     | .step b' h _ =>
       let h ← mkLambdaFVars xs h
@@ -68,5 +68,8 @@ where
       let h ← mkFunextFor xs β
       modify fun s => { s with funext := s.funext.insert { expr := key } h }
       return h
+
+public def simpLambda : Simproc :=
+  simpLambda' simp
 
 end Lean.Meta.Sym.Simp

--- a/src/Lean/Meta/Sym/Simp/Telescope.lean
+++ b/src/Lean/Meta/Sym/Simp/Telescope.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+module
+prelude
+public import Lean.Meta.Sym.Simp.SimpM
+import Lean.Meta.Sym.Simp.Have
+import Lean.Meta.Sym.Simp.Forall
+namespace Lean.Meta.Sym.Simp
+/--
+Simplify telescope binders (`have`-expression values, and arrow hypotheses)
+but not the final body. This simproc is useful to simplify target before
+introducing.
+-/
+public partial def simpTelescope : Simproc := fun e => do
+  match e with
+  | .letE .. =>
+    simpLet' (simpLambda' simpTelescope) e
+  | .forallE .. =>
+    simpForall' (simpArrow := simpArrowTelescope simpTelescope) (simpBody := simpLambda' simpTelescope) e
+  | _ => return .rfl
+
+end Lean.Meta.Sym.Simp

--- a/tests/lean/run/sym_simp_5.lean
+++ b/tests/lean/run/sym_simp_5.lean
@@ -1,0 +1,33 @@
+import Lean
+open Lean Meta Elab Tactic
+
+elab "sym_simp" "[" declNames:ident,* "]" : tactic => do
+  let rewrite ← Sym.mkSimprocFor (← declNames.getElems.mapM fun s => realizeGlobalConstNoOverload s.raw) Sym.Simp.dischargeSimpSelf
+  let methods : Sym.Simp.Methods := {
+    pre  := Sym.Simp.simpTelescope
+    post := Sym.Simp.evalGround.andThen rewrite
+  }
+  liftMetaTactic1 fun mvarId => Sym.SymM.run do
+    let mvarId ← Sym.preprocessMVar mvarId
+    (← Sym.simpGoal mvarId methods).toOption
+
+set_option warn.sorry false
+
+/-!
+Recall that `simpTelescope` does not simplify the body of a telescope.
+This is why `0 + x = 0 + id x` is not simplified in the following example.
+-/
+/--
+trace: p q : Prop
+⊢ q →
+    ∀ (x : Nat),
+      p →
+        have x := x;
+        have y := x;
+        x = y → 0 + x = 0 + id x
+-/
+#guard_msgs in
+example (p q : Prop) : q → ∀ x : Nat, p ∧ True → have x := 0 + x; have y := x; True → x = 0 + 0 + id y → 0 + x = 0 + id x := by
+  sym_simp [and_true, Nat.zero_add, id_eq]
+  trace_state
+  admit


### PR DESCRIPTION
This PR adds `simpTelescope`, a simproc that simplifies telescope binders (`have`-expression values and arrow hypotheses) but not the final body. This is useful for simplifying targets before introducing hypotheses.
