### PR TITLE
chore: add plausible as verso dependency in release_repos.yml

### DIFF
--- a/script/release_repos.yml
+++ b/script/release_repos.yml
@@ -14,13 +14,6 @@ repositories:
     bump-branch: true
     dependencies: []
 
-  - name: verso
-    url: https://github.com/leanprover/verso
-    toolchain-tag: true
-    stable-branch: false
-    branch: main
-    dependencies: []
-
   - name: lean4checker
     url: https://github.com/leanprover/lean4checker
     toolchain-tag: true
@@ -41,6 +34,14 @@ repositories:
     stable-branch: false
     branch: main
     dependencies: []
+
+  - name: verso
+    url: https://github.com/leanprover/verso
+    toolchain-tag: true
+    stable-branch: false
+    branch: main
+    dependencies:
+      - plausible
 
   - name: import-graph
     url: https://github.com/leanprover-community/import-graph


### PR DESCRIPTION
verso depends on plausible, but this wasn't recorded in release_repos.yml. This caused the release checklist to not properly track the dependency ordering.