### PR TITLE
doc: add link to reference manual in stack overflow message

### DIFF
--- a/src/runtime/exception.cpp
+++ b/src/runtime/exception.cpp
@@ -9,6 +9,7 @@ Author: Leonardo de Moura
 #include "runtime/exception.h"
 #include "runtime/thread.h"
 #include "runtime/sstream.h"
+#include <lean/version.h>
 
 namespace lean {
 throwable::throwable(char const * msg):m_msg(msg) {}
@@ -18,7 +19,7 @@ throwable::~throwable() noexcept {}
 char const * throwable::what() const noexcept { return m_msg.c_str(); }
 
 stack_space_exception::stack_space_exception(char const * component_name):
-    m_msg((sstream() << "deep recursion was detected at '" << component_name << "' (potential solution: increase elaboration stack size using `lean` `--tstack` flag)").str()) {
+    m_msg((sstream() << "deep recursion was detected at '" << component_name << "' (potential solution: increase elaboration stack size using the `lean --tstack` flag). This flag can be set in the `weakLeanArgs` field of the Lake configuration. Further details are available in the Lean reference manual at " << LEAN_MANUAL_ROOT << "find/?domain=Verso.Genre.Manual.section&name=lake-config-toml").str()) {
 }
 
 memory_exception::memory_exception(char const * component_name):


### PR DESCRIPTION
This PR updates #12137 with a link to the Lean reference manual.