### PR TITLE
fix: typo in ExtractLetsConfig doc comment

### DIFF
--- a/src/Init/MetaTypes.lean
+++ b/src/Init/MetaTypes.lean
@@ -374,7 +374,7 @@ structure ExtractLetsConfig where
   /-- If true (default: false), eliminate unused lets rather than extract them. -/
   usedOnly : Bool := false
   /-- If true (default: true), reuse local declarations that have syntactically equal values.
-  Note that even when false, the caching strategy for `extract_let`s may result in fewer extracted let bindings than expected. -/
+  Note that even when false, the caching strategy for `extract_lets` may result in fewer extracted let bindings than expected. -/
   merge : Bool := true
   /-- When merging is enabled, if true (default: true), make use of pre-existing local definitions in the local context. -/
   useContext : Bool := true


### PR DESCRIPTION
This PR fixes a typo in `ExtractLetsConfig.merge` doc comment.

Reported on Zulip: https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Typo.20in.20Init.2FMetaTypes.2Elean/near/568698828

🤖 Prepared with Claude Code