### PR TITLE
fix: scope `FamilyOut.fam_eq` simp lemma to Lake namespace

### DIFF
--- a/src/lake/Lake/Util/Family.lean
+++ b/src/lake/Lake/Util/Family.lean
@@ -153,7 +153,7 @@ public class FamilyOut {α : Type u} {β : Type v} (f : α → β) (a : α) (b :
 
 -- Simplifies proofs involving open type families.
 -- Scoped to avoid slowing down `simp` in downstream projects (the discrimination
--- tree key is `@Eq _ _ _`, so it would be attempted on every equality goal).
+-- tree key is `_`, so it would be attempted on every goal).
 attribute [scoped simp] FamilyOut.fam_eq
 
 public instance [FamilyDef f a b] : FamilyOut f a b where


### PR DESCRIPTION
This PR scopes the `simp` attribute on `FamilyOut.fam_eq` to the `Lake` namespace. The lemma has a very permissive discrimination tree key (`_`), so when `Lake.Util.Family` is transitively imported into downstream projects, it causes `simp` to attempt this lemma on every goal, leading to timeouts.

See https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Lake.20.60FamilyOut.2Efam_eq.60.20leads.20to.20timeouts.3F

🤖 Prepared with Claude Code