### PR TITLE
fix: use gh release create instead of action-gh-release

### DIFF
--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -72,9 +72,22 @@ jobs:
           gh release delete --repo ${{ github.repository_owner }}/lean4-pr-releases pr-release-${{ steps.workflow-info.outputs.pullRequestNumber }}-${{ env.SHORT_SHA }} -y || true
         env:
           GH_TOKEN: ${{ secrets.PR_RELEASES_TOKEN }}
+      # Verify artifacts were downloaded (equivalent to fail_on_unmatched_files in the old action).
+      - name: Verify release artifacts exist
+        if: ${{ steps.workflow-info.outputs.pullRequestNumber != '' }}
+        run: |
+          shopt -s nullglob
+          files=(artifacts/*/*)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No artifacts found matching artifacts/*/*"
+            exit 1
+          fi
+          echo "Found ${#files[@]} artifacts to upload:"
+          printf '%s\n' "${files[@]}"
       # We use `gh release create` instead of `softprops/action-gh-release` because
       # the latter enumerates all releases to check for existing ones, which fails
       # when the repository has more than 10000 releases (GitHub API pagination limit).
+      # Upstream fix: https://github.com/softprops/action-gh-release/pull/725
       - name: Release (short format)
         if: ${{ steps.workflow-info.outputs.pullRequestNumber != '' }}
         run: |


### PR DESCRIPTION
This PR switches the PR release workflow from `softprops/action-gh-release` to `gh release create`.

The `softprops/action-gh-release` action enumerates all releases to check for existing ones, which fails when the repository has more than 10000 releases due to GitHub API pagination limits. The `lean4-pr-releases` repository has accumulated over 10000 releases, causing the PR release workflow to fail with:

```
Only the first 10000 results are available.
```

This is currently blocking all PR toolchain releases, including https://github.com/leanprover/lean4/pull/12175.

🤖 Prepared with Claude Code