### PR TITLE
perf: check universe defeq before unfolding in elaborator

### DIFF
--- a/src/Lean/Meta/ExprDefEq.lean
+++ b/src/Lean/Meta/ExprDefEq.lean
@@ -1897,6 +1897,10 @@ private def isDefEqDeltaStep (t s : Expr) : MetaM DeltaStepResult := do
         unfoldBoth t s
 where
   unfoldBoth (t s : Expr) : MetaM DeltaStepResult := do
+    -- Check universe equality for plain constants before unfolding (cf. kernel PR #12175)
+    if t.isConst && s.isConst then
+      if (← isListLevelDefEqAux t.constLevels! s.constLevels!) then
+        return .eq
     unfold t
       (unfold s (return .unknown) (k t ·))
       (fun t => unfold s (k t s) (k t ·))


### PR DESCRIPTION
This extends the kernel fix from #12175 to the elaborator.

In `isDefEqDeltaStep.unfoldBoth`, when comparing two plain constants with the same name but different universe parameters (e.g., `c.{max u v}` vs `c.{max v u}`), check if the universes are definitionally equal before unfolding. This avoids expensive unfolding when the terms are defeq modulo universe ordering.

## Performance

On the test case from #12102:

| Metric | Master | #12175 | This PR |
|--------|--------|--------|---------|
| `max u v` elab | 5,570 | 5,775 | 6,015 |
| `max v u` elab | 3,677,625 | 3,710,609 | **7,373** |
| `max u v` kernel | 97 | 97 | 98 |
| `max v u` kernel | 114,901 | 129 | 114,902 |

This reduces elaboration time for the slow case from **3.7M to 7.3K heartbeats (499x speedup)**.

Note: The kernel is still slow because this PR only fixes the elaborator. Combined with #12175, both elaboration and kernel would be fast.

Related: #12175 (kernel fix), #12102 (issue)

🤖 Prepared with Claude Code