### PR TITLE
fix: use windows path separators in `System.Uri.fileUriToPath?`

### DIFF
--- a/src/Init/System/Uri.lean
+++ b/src/Init/System/Uri.lean
@@ -110,11 +110,13 @@ def fileUriToPath? (uri : String) : Option System.FilePath := Id.run do
   else
     let mut p := (unescapeUri uri).drop "file://".length |>.copy
     p := p.dropWhile (λ c => c != '/') |>.copy -- drop the hostname.
-    -- On Windows, the path "/c:/temp" needs to become "C:/temp"
-    if System.Platform.isWindows && p.length >= 2 &&
-        p.front == '/' && (String.Pos.Raw.get p ⟨1⟩).isAlpha && String.Pos.Raw.get p ⟨2⟩ == ':' then
-      -- see also `pathToUri`
-      p := String.Pos.Raw.modify (p.drop 1).copy 0 .toUpper
+    if System.Platform.isWindows then
+      -- On Windows, the path "/c:/temp" needs to become "C:/temp"
+      if p.length >= 2 &&
+          p.front == '/' && (String.Pos.Raw.get p ⟨1⟩).isAlpha && String.Pos.Raw.get p ⟨2⟩ == ':' then
+        -- see also `pathToUri`
+        p := String.Pos.Raw.modify (p.drop 1).copy 0 .toUpper
+      p := p.map (fun c => if c == '/' then '\\' else c)
     some p
 
 end Uri

--- a/src/Lean/Server/Test/Runner.lean
+++ b/src/Lean/Server/Test/Runner.lean
@@ -265,26 +265,26 @@ def ident : Parser Name := do
   return xs.foldl .str $ .mkSimple head
 
 def patchUri (s : String) : IO String := do
+  let patterns := #["/src/Init/", "/src/Lean/", "/src/Std/", "/tests/lean/interactive/"]
   let some path := System.Uri.fileUriToPath? s
     | return s
-  let path ←
-    try
-      IO.FS.realPath path
-    catch _ =>
-      return s
-  let c := path.components.toArray
-  if let some (_, srcIdx) := c.zipIdx.filter (·.1 == "src") |>.back? then
-    if ! c[srcIdx + 1]?.any (fun dir => dir == "Init" || dir == "Lean" || dir == "Std") then
-      return s
-    let c := c.drop <| srcIdx
-    let path := System.mkFilePath c.toList
-    return System.Uri.pathToUri path
-  if let some (_, testIdx) := c.zipIdx.filter (·.1 == "tests") |>.back? then
-    let c := c.drop <| testIdx
-    let path := System.mkFilePath c.toList
-    return System.Uri.pathToUri path
-  else
+  let path ← try
+    IO.FS.realPath path
+  catch _ =>
     return s
+  let path := String.intercalate "/" path.components |>.toSlice
+  let matchPositions := patterns.filterMap fun p =>
+    String.Slice.Pattern.ToForwardSearcher.toSearcher p path
+      |>.filterMap (fun | .matched startPos _ => some startPos | .rejected .. => none)
+      |>.toArray.back?
+  let deepestMatchPos := matchPositions.foldr (init := path.startPos) fun matchPos deepestMatchPos =>
+    if matchPos > deepestMatchPos then
+      matchPos
+    else
+      deepestMatchPos
+  let path := path.sliceFrom deepestMatchPos
+  let path := System.FilePath.mk path.toString |>.normalize
+  return System.Uri.pathToUri path
 
 partial def patchUris : Json → IO Json
   | .null =>


### PR DESCRIPTION
This PR fixes a bug in `System.Uri.fileUriToPath?` where it wouldn't use the default Windows path separator in the path it produces.

It also adjusts the URI patching in the interactive test runner to be more robust.