### PR TITLE
test: add regression test for #12172 instance synthesis with dependent Prop

### DIFF
--- a/tests/lean/12172.lean
+++ b/tests/lean/12172.lean
@@ -20,6 +20,7 @@ This pattern is used in Mathlib's MeasureTheory.Function.ConditionalExpectation.
 -/
 
 set_option autoImplicit false
+set_option linter.unusedVariables false
 
 universe u
 

--- a/tests/lean/12172.lean.expected.out
+++ b/tests/lean/12172.lean.expected.out
@@ -1,6 +1,0 @@
-12172.lean:50:18: warning: unused variable `hs`
-
-Note: This linter can be disabled with `set_option linter.unusedVariables false`
-12172.lean:58:26: warning: unused variable `hs`
-
-Note: This linter can be disabled with `set_option linter.unusedVariables false`


### PR DESCRIPTION
This PR adds a regression test that **will fail under the current version of #12172**.

The test captures a pattern from Mathlib's `MeasureTheory.Function.ConditionalExpectation.CondexpL1` where a typeclass instance depends on a Prop argument that's implicit.

The pattern:
1. A structure uses `[MeasurableSpace α]` as an instance argument
2. `Measure.trim` takes a proof `(hm : m ≤ m0)` and returns a measure with a different `MeasurableSpace` instance: `μ.trim hm : @Measure α m`
3. A typeclass depends on this: `[SigmaFinite (μ.trim hm)]`
4. A section variable makes the Prop `hm` implicit
5. A lemma uses this and is called via `simp only [myFun_eq μ hs]`

**Before #12172:** `simp` could infer `hm` before attempting instance synthesis → works

**After #12172:** Instance synthesis happens before `hm` is inferred → fails with:
```
failed to synthesize instance SigmaFinite (μ.trim ?m.XX)
```

This regression affects Mathlib and requires workarounds like adding explicit `(hm := hm)` arguments in ~20 places across conditional expectation and stopping time code.

## Verification

```bash
# On nightly (passes):
~/.elan/toolchains/leanprover--lean4-nightly---nightly-2026-01-25/bin/lean tests/lean/12172.lean

# On PR #12172 (fails):
~/.elan/toolchains/leanprover--lean4-pr-releases---pr-release-12172-9ac14e4/bin/lean tests/lean/12172.lean
# Error: failed to synthesize instance SigmaFinite (μ.trim ?m.37)
```

🤖 Prepared with Claude Code