### PR TITLE
feat: add `mkBackwardRuleFromExpr`

### DIFF
--- a/src/Lean/Meta/Sym/Apply.lean
+++ b/src/Lean/Meta/Sym/Apply.lean
@@ -88,6 +88,21 @@ public def mkBackwardRuleFromDecl (declName : Name) (num? : Option Nat := none) 
   return { expr := mkConst declName, pattern, resultPos }
 
 /--
+Creates a `BackwardRule` from an expression.
+
+`levelParams` is not `[]` if the expression is supposed to be
+universe polymorphic.
+
+The `num?` parameter optionally limits how many arguments are included in the pattern
+(useful for partially applying theorems).
+-/
+public def mkBackwardRuleFromExpr (e : Expr) (levelParams : List Name := []) (num? : Option Nat := none) : MetaM BackwardRule := do
+  let pattern ← mkPatternFromExpr e levelParams num?
+  let resultPos := mkResultPos pattern
+  let e := e.instantiateLevelParams levelParams (pattern.levelParams.map mkLevelParam)
+  return { expr := e, pattern, resultPos }
+
+/--
 Creates a value to assign to input goal metavariable using unification result.
 
 Handles both constant expressions (common case, avoids `instantiateLevelParams`)


### PR DESCRIPTION
This PR adds `mkBackwardRuleFromExpr` to create backward rules from expressions, complementing the existing `mkBackwardRuleFromDecl` which only works with declaration names.

The new function enables creating backward rules from partially applied terms. For example, `mkBackwardRuleFromExpr (mkApp (mkConst ``Exists.intro [1]) Nat.mkType)` creates a rule for `Exists.intro` with the type parameter fixed to `Nat`, leaving only the witness and proof as subgoals.

The `levelParams` parameter supports universe polymorphism: when creating a rule like `Prod.mk Nat` that should work at multiple universe levels, the caller specifies which level parameters remain polymorphic. The pattern's universe variables are then instantiated appropriately at each application site.

Also refactors `Pattern.lean` to share code between declaration-based and expression-based pattern creation, extracting `mkPatternFromType` and `mkEqPatternFromType` as common helpers.
