### PR TITLE
feat: print backtrace on stack overflow

### DIFF
--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -148,10 +148,7 @@ static void print_backtrace(bool force_stderr) {
 #endif
 }
 
-// Morally, `{msg, size}` is an `std::string_view`.
-static void lean_panic_impl(char const * msg, size_t size, bool force_stderr = false) {
-    if (g_panic_messages) {
-        panic_eprintln(msg, size, force_stderr);
+LEAN_EXPORT void maybe_print_backtrace(bool force_stderr) {
 #if LEAN_SUPPORTS_BACKTRACE
         char * bt_env = getenv("LEAN_BACKTRACE");
         if (!bt_env || strcmp(bt_env, "0") != 0) {
@@ -159,6 +156,13 @@ static void lean_panic_impl(char const * msg, size_t size, bool force_stderr = f
             print_backtrace(force_stderr);
         }
 #endif
+}
+
+// Morally, `{msg, size}` is an `std::string_view`.
+static void lean_panic_impl(char const * msg, size_t size, bool force_stderr = false) {
+    if (g_panic_messages) {
+        panic_eprintln(msg, size, force_stderr);
+        maybe_print_backtrace(force_stderr);
     }
 
     abort_on_panic();

--- a/src/runtime/object.h
+++ b/src/runtime/object.h
@@ -481,6 +481,8 @@ extern "C" LEAN_EXPORT obj_res lean_io_promise_resolve(obj_arg value, b_obj_arg 
 extern "C" LEAN_EXPORT obj_res lean_io_promise_result_opt(obj_arg promise);
 extern "C" LEAN_EXPORT obj_res lean_get_or_block(obj_arg opt);
 
+LEAN_EXPORT void maybe_print_backtrace(bool force_stderr);
+
 // =======================================
 // Module initialization/finalization
 void initialize_object();

--- a/src/runtime/stack_overflow.cpp
+++ b/src/runtime/stack_overflow.cpp
@@ -19,6 +19,7 @@ Port of the corresponding Rust code (see links below).
 #include <cstring>
 #include <lean/lean.h>
 #include <initializer_list>
+#include "runtime/object.h"
 #include "runtime/stack_overflow.h"
 
 namespace lean {
@@ -72,6 +73,7 @@ extern "C" LEAN_EXPORT void segv_handler(int signum, siginfo_t * info, void *) {
     if (is_within_stack_guard(info->si_addr)) {
         char const msg[] = "\nStack overflow detected. Aborting.\n";
         write(STDERR_FILENO, msg, sizeof(msg) - 1);
+        maybe_print_backtrace(/* force_stderr */ true);
         abort();
     } else {
         // reset signal handler and return; see comments in Rust code


### PR DESCRIPTION
This PR adjusts the stack overflow handler on Unix platforms to print the stack trace as well, if possible. Windows support remains to be done as for panics.