### PR TITLE
feat: `Std.Iter.isEmpty`

### DIFF
--- a/src/Init/Data/Iterators/Consumers/Loop.lean
+++ b/src/Init/Data/Iterators/Consumers/Loop.lean
@@ -668,6 +668,42 @@ def Iter.Total.first? {α β : Type w} [Iterator α Id β] [IteratorLoop α Id I
   it.it.first?
 
 /--
+Returns `true` if the iterator yields no values.
+
+`O(|it|)` since the iterator may skip an unknown number of times before returning a result.
+Short-circuits upon encountering the first result. Only the first element of `it` is examined.
+
+If the iterator is not productive, this function might run forever. The variant
+`it.ensureTermination.isEmpty` always terminates after finitely many steps.
+
+Examples:
+* `[].iter.isEmpty = true`
+* `[1].iter.isEmpty = false`
+-/
+@[inline]
+def Iter.isEmpty {α β : Type w} [Iterator α Id β] [IteratorLoop α Id Id]
+    (it : Iter (α := α) β) : Bool :=
+  it.toIterM.isEmpty.run.down
+
+/--
+Returns `true` if the iterator yields no values.
+
+`O(|it|)` since the iterator may skip an unknown number of times before returning a result.
+Short-circuits upon encountering the first result. Only the first element of `it` is examined.
+
+This variant terminates after finitely many steps and requires a proof that the iterator is
+productive. If such a proof is not available, consider using `Iter.isEmpty`.
+
+Examples:
+* `[].iter.isEmpty = true`
+* `[1].iter.isEmpty = false`
+-/
+@[inline]
+def Iter.Total.isEmpty {α β : Type w} [Iterator α Id β] [IteratorLoop α Id Id] [Productive α Id]
+    (it : Iter.Total (α := α) β) : Bool :=
+  it.it.isEmpty
+
+/--
 Steps through the whole iterator, counting the number of outputs emitted.
 
 **Performance**:

--- a/src/Init/Data/Iterators/Consumers/Monadic/Loop.lean
+++ b/src/Init/Data/Iterators/Consumers/Monadic/Loop.lean
@@ -402,39 +402,6 @@ def IterM.Total.drain {α : Type w} {m : Type w → Type w'} [Monad m] {β : Typ
 
 set_option doc.verso true in
 /--
-Returns {lean}`ULift.up true` if the iterator {name}`it` yields no values.
-
-{lit}`O(|it|)`. More precisely, steps through the iterator until, short-circuiting upon encountering
-the first output. The worst-case linear cost is attained if the iterator skips many times.
-The outputs of {name}`it` are examined in order of iteration.
-
-If the iterator is not productive, this function might run forever. The variant
-`it.ensureTermination.findSomeM?` always terminates after finitely many steps.
--/
-@[always_inline]
-def IterM.isEmpty {α β : Type w} {m : Type w → Type w'} [Monad m] [Iterator α m β]
-    [IteratorLoop α m m] (it : IterM (α := α) m β) : m (ULift Bool) :=
-  IteratorLoop.
-
-set_option doc.verso true in
-/--
-Returns {lean}`ULift.up true` if the iterator {name}`it` yields no values.
-
-{lit}`O(|it|)`. More precisely, steps through the iterator until, short-circuiting upon encountering
-the first output. The worst-case linear cost is attained if the iterator skips many times.
-The outputs of {name}`it` are examined in order of iteration.
-
-This variant terminates after finitely many steps and requires a proof that the iterator is
-finite. If such a proof is not available, consider using {name}`IterM.isEmpty`.
--/
-@[always_inline, inline]
-def IterM.Total.isEmpty {α β : Type w} {m : Type w → Type w'} [Monad m]
-    [Iterator α m β] [IteratorLoop α m m] [Productive α m] (it : IterM.Total (α := α) m β) :
-    m (ULift Bool) :=
-  it.it.isEmpty
-
-set_option doc.verso true in
-/--
 Returns {lean}`ULift.up true` if the monadic predicate {name}`p` returns {lean}`ULift.up true` for
 any element emitted by the iterator {name}`it`.
 
@@ -982,6 +949,38 @@ Examples:
 def IterM.Total.first? {α β : Type w} {m : Type w → Type w'} [Monad m] [Iterator α m β]
     [IteratorLoop α m m] [Productive α m] (it : IterM.Total (α := α) m β) : m (Option β) :=
   it.it.first?
+
+set_option doc.verso true in
+/--
+Returns {lean}`ULift.up true` if the iterator {name}`it` yields no values.
+
+{lit}`O(|it|)` since the iterator may skip an unknown number of times before returning a result.
+Short-circuits upon encountering the first result. Only the first element of {name}`it` is examined.
+
+If the iterator is not productive, this function might run forever. The variant
+{lit}`it.ensureTermination.isEmpty` always terminates after finitely many steps.
+-/
+@[always_inline]
+def IterM.isEmpty {α β : Type w} {m : Type w → Type w'} [Monad m] [Iterator α m β]
+    [IteratorLoop α m m] (it : IterM (α := α) m β) : m (ULift Bool) :=
+  IteratorLoop.forIn (fun _ _ => flip Bind.bind) _ (fun _ _ s => s = ForInStep.done (.up false)) it
+    (.up true) (fun _ _ _ => pure ⟨ForInStep.done (.up false), rfl⟩)
+
+set_option doc.verso true in
+/--
+Returns {lean}`ULift.up true` if the iterator {name}`it` yields no values.
+
+{lit}`O(|it|)` since the iterator may skip an unknown number of times before returning a result.
+Short-circuits upon encountering the first result. Only the first element of {name}`it` is examined.
+
+This variant terminates after finitely many steps and requires a proof that the iterator is
+finite. If such a proof is not available, consider using {name}`IterM.isEmpty`.
+-/
+@[always_inline, inline]
+def IterM.Total.isEmpty {α β : Type w} {m : Type w → Type w'} [Monad m]
+    [Iterator α m β] [IteratorLoop α m m] [Productive α m] (it : IterM.Total (α := α) m β) :
+    m (ULift Bool) :=
+  it.it.isEmpty
 
 section Count
 

--- a/src/Init/Data/Iterators/Lemmas/Consumers/Loop.lean
+++ b/src/Init/Data/Iterators/Lemmas/Consumers/Loop.lean
@@ -930,11 +930,35 @@ theorem Iter.first?_eq_match_step {α β : Type w} [Iterator α Id β] [Iterator
   generalize it.toIterM.step.run.inflate = s
   rcases s with ⟨_|_|_, _⟩ <;> simp [Iter.first?_eq_first?_toIterM]
 
-theorem Iter.first?_eq_head?_toList {α β : Type w} [Iterator α Id β] [IteratorLoop α Id Id]
+@[simp, grind =]
+theorem Iter.head?_toList {α β : Type w} [Iterator α Id β] [IteratorLoop α Id Id]
     [Finite α Id] [LawfulIteratorLoop α Id Id] {it : Iter (α := α) β} :
-    it.first? = it.toList.head? := by
+    it.toList.head? = it.first? := by
   induction it using Iter.inductSteps with | step it ihy ihs
   rw [first?_eq_match_step, toList_eq_match_step]
+  cases it.step using PlausibleIterStep.casesOn <;> simp [*]
+
+theorem Iter.isEmpty_eq_isEmpty_toIterM {α β : Type w} [Iterator α Id β] [IteratorLoop α Id Id]
+    {it : Iter (α := α) β} :
+  it.isEmpty = it.toIterM.isEmpty.run.down := (rfl)
+
+theorem Iter.isEmpty_eq_match_step {α β : Type w} [Iterator α Id β] [IteratorLoop α Id Id]
+    [Productive α Id] [LawfulIteratorLoop α Id Id] {it : Iter (α := α) β} :
+    it.isEmpty = match it.step.val with
+      | .yield _ _ => false
+      | .skip it' => it'.isEmpty
+      | .done => true := by
+  rw [Iter.isEmpty_eq_isEmpty_toIterM, IterM.isEmpty_eq_match_step]
+  simp only [Id.run_bind, step]
+  generalize it.toIterM.step.run.inflate = s
+  rcases s with ⟨_|_|_, _⟩ <;> simp [Iter.isEmpty_eq_isEmpty_toIterM]
+
+@[simp, grind =]
+theorem Iter.isEmpty_toList {α β : Type w} [Iterator α Id β] [IteratorLoop α Id Id]
+    [Finite α Id] [LawfulIteratorLoop α Id Id] {it : Iter (α := α) β} :
+    it.toList.isEmpty = it.isEmpty := by
+  induction it using Iter.inductSteps with | step it ihy ihs
+  rw [isEmpty_eq_match_step, toList_eq_match_step]
   cases it.step using PlausibleIterStep.casesOn <;> simp [*]
 
 end Std

--- a/src/Init/Data/Iterators/Lemmas/Consumers/Monadic/Loop.lean
+++ b/src/Init/Data/Iterators/Lemmas/Consumers/Monadic/Loop.lean
@@ -861,4 +861,24 @@ theorem IterM.first?_eq_match_step {α β : Type w} {m : Type w → Type w'} [Mo
   simp only [DefaultConsumers.forIn_eq, *]
   exact IterM.DefaultConsumers.forIn'_eq_forIn' _ this (by simp)
 
+theorem IterM.isEmpty_eq_match_step {α β : Type w} {m : Type w → Type w'} [Monad m]
+    [Iterator α m β] [IteratorLoop α m m] [LawfulMonad m] [Productive α m]
+    [LawfulIteratorLoop α m m] {it : IterM (α := α) m β} :
+    it.isEmpty = (do
+      match (← it.step).inflate.val with
+      | .yield _ _ => return .up false
+      | .skip it' => it'.isEmpty
+      | .done => return .up true) := by
+  simp only [isEmpty]
+  have := IteratorLoop.wellFounded_of_productive (α := α) (β := β) (m := m)
+    (P := fun _ _ s => s = ForInStep.done (ULift.up false)) (by simp)
+  simp only [LawfulIteratorLoop.lawful _ _ _ _ _ this]
+  rw [IterM.DefaultConsumers.forIn_eq, IterM.DefaultConsumers.forIn'_eq_match_step _ this]
+  simp only [flip, pure_bind]
+  congr
+  ext s
+  split <;> try (simp [*]; done)
+  simp only [DefaultConsumers.forIn_eq, *]
+  exact IterM.DefaultConsumers.forIn'_eq_forIn' _ this (by simp)
+
 end Std


### PR DESCRIPTION
This PR adds the function `Std.Iter.isEmpty` and proves the specification lemmas `Std.Iter.isEmpty_eq_match_step` and `Std.Iter.isEmpty_toList` if the iterator is productive.

The monadic variant on `Std.IterM` is also provided.