### PR TITLE
fix: `IO.Process.spawn` empty env var on Windows

### DIFF
--- a/tests/lake/tests/env/test.sh
+++ b/tests/lake/tests/env/test.sh
@@ -45,9 +45,7 @@ LEAN_CC=foo test_eq "foo" env printenv LEAN_CC
 # Test `LAKE_ARTIFACT_CACHE` setting and default
 LAKE_ARTIFACT_CACHE=true test_eq "true" env printenv LAKE_ARTIFACT_CACHE
 LAKE_ARTIFACT_CACHE=false test_eq "false" env printenv LAKE_ARTIFACT_CACHE
-# FIXME: Currently fails on Windows due to a platform inconsistency in how
-# Lean configures the environments of spawned processes
-# LAKE_ARTIFACT_CACHE= test_eq "" env printenv LAKE_ARTIFACT_CACHE
+LAKE_ARTIFACT_CACHE= test_eq "" env printenv LAKE_ARTIFACT_CACHE
 LAKE_ARTIFACT_CACHE= test_eq "false" -d ../../examples/hello env printenv LAKE_ARTIFACT_CACHE
 LAKE_ARTIFACT_CACHE= test_eq "true" -f enableArtifactCache.toml env printenv LAKE_ARTIFACT_CACHE
 test_cmd rm lake-manifest.json

--- a/tests/lean/run/emptyEnvVar.lean
+++ b/tests/lean/run/emptyEnvVar.lean
@@ -1,0 +1,18 @@
+/--
+Tests that spawning a process with a environment variable configured to the
+empty string correctly sets the environment variable on the subprocess on
+all platforms. Previously, this was broken on Windows.
+-/
+def test : IO String := do
+  let var := "TEST_VAR"
+  let out ← IO.Process.output {
+    cmd := "printenv"
+    args := #[var]
+    env := #[(var, some "")]
+  }
+  unless out.exitCode == 0 do
+    throw <| .userError "environment variable not set"
+  return out.stdout.trimAsciiEnd.copy -- trim ending newline
+
+/-- info: "" -/
+#guard_msgs in #eval test


### PR DESCRIPTION
This PR fixes a bug on Windows with `IO.Process.spawn`  where setting an environment variable to the empty string would not set the environment variable on the subprocess.