### PR TITLE
fix: handle universe polymorphism in ground grind theorems

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/EMatch.lean
+++ b/src/Lean/Meta/Tactic/Grind/EMatch.lean
@@ -867,7 +867,8 @@ private def matchEqBwdPat (p : Expr) : M Unit := do
 
 def instantiateGroundTheorem (thm : EMatchTheorem) : M Unit := do
   if (← markTheoremInstance thm.proof #[]) then
-    addNewInstance thm thm.proof 0 []
+    let proof ← thm.getProofWithFreshMVarLevels
+    addNewInstance thm proof 0 []
 
 def ematchTheorem (thm : EMatchTheorem) : M Unit := do
   if (← checkMaxInstancesExceeded) then return ()

--- a/tests/lean/run/grind_universe_polymorphism.lean
+++ b/tests/lean/run/grind_universe_polymorphism.lean
@@ -1,0 +1,22 @@
+universe u v
+
+-- We use `ULift Nat` as our (artificial) universe polymorphic type
+def z : ULift.{u} Nat := ⟨0⟩
+def f : ULift.{u} Nat → ULift.{u} Nat := id
+
+-- replacing `.{v}` by `.{u}` makes the `grind` below succeed
+theorem foo : f z.{v} = z := rfl
+
+example : f z.{v} = z := by
+  grind [foo]
+
+example : f z.{u} = z := by
+  grind [foo.{u}]
+
+example : f z.{u} = z := by
+  grind [foo] -- used to fail before fix to instantiateGroundTheorem
+
+-- Test with @[grind =] annotation
+@[grind =] theorem foo' : f z.{v} = z := rfl
+
+theorem bar : f z.{u} = z := by grind


### PR DESCRIPTION
This PR fixes a bug where `grind [foo]` fails when the theorem `foo` has a different universe variable name than the goal, even though universe polymorphism should allow the universes to unify.

The issue was in `instantiateGroundTheorem` (used for theorems with no quantified parameters), which was passing `thm.proof` directly instead of calling `getProofWithFreshMVarLevels`. This meant ground theorems retained their original universe level params instead of getting fresh level metavariables that could unify with the goal's universe levels.

Fixes https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/grind.20fails.20because.20of.20universe.20variable.20name

🤖 Prepared with Claude Code