### PR TITLE
feat: add `orElse` combinator to `Sym.Simp.Simproc`

### DIFF
--- a/src/Lean/Meta/Sym/Simp/Simproc.lean
+++ b/src/Lean/Meta/Sym/Simp/Simproc.lean
@@ -19,4 +19,13 @@ public abbrev Simproc.andThen (f g : Simproc) : Simproc := fun e₁ => do
 public instance : AndThen Simproc where
   andThen f g := Simproc.andThen f (g ())
 
+public abbrev Simproc.orElse (f g : Simproc) : Simproc := fun e₁ => do
+  let r ← f e₁
+  match r with
+  | .step _ _ _ | .rfl true  => return r
+  | .rfl false => g e₁
+
+public instance : OrElse Simproc where
+  orElse f g := Simproc.orElse f (g ())
+
 end Lean.Meta.Sym.Simp


### PR DESCRIPTION
This PR adds `orElse` combinator to simprocs of `Sym.Simp`.