### PR TITLE
fix: deriving Ord with indexed data type

### DIFF
--- a/src/Lean/Elab/Deriving/Ord.lean
+++ b/src/Lean/Elab/Deriving/Ord.lean
@@ -74,7 +74,7 @@ where
         let rPat ← `(@$(mkIdent ctorName):ident $ctorArgs2:term*)
         let patterns := indPatterns ++ #[lPat, rPat]
         let ltPatterns := indPatterns ++ #[lPat, ←`(_)]
-        let gtPatterns := indPatterns ++ #[←`(_), rPat]
+        let gtPatterns := indPatterns ++ #[←`(_), lPat] -- Use the lPat again, we don’t want the `.(a)` pattern here
         let rhs ← rhsCont (← `(Ordering.eq))
         pure #[←`(matchAltExpr| | $[$(patterns):term],* => $rhs:term),
                ←`(matchAltExpr| | $[$(ltPatterns):term],* => Ordering.lt),
@@ -88,7 +88,7 @@ def mkMatchNew (header : Header) (indVal : InductiveVal) : TermElabM Term := do
   let x1 := mkIdent header.targetNames[0]!
   let x2 := mkIdent header.targetNames[1]!
   let ctorIdxName := mkCtorIdxName indVal.name
-  -- NB: the getMatcherInfo? assumes all mathcers are called `match_`
+  -- NB: the getMatcherInfo? assumes all matchers are called `match_`
   let casesOnSameCtorName ← mkFreshUserName (indVal.name ++ `match_on_same_ctor)
   mkCasesOnSameCtor casesOnSameCtorName indVal.name
   let alts ← Array.ofFnM (n := indVal.numCtors) fun ⟨ctorIdx, _⟩ => do

--- a/tests/lean/run/issue12240.lean
+++ b/tests/lean/run/issue12240.lean
@@ -1,0 +1,9 @@
+inductive InContext : Nat → List Nat → Type
+  | here {x : Nat} {xs : List Nat} : InContext x (x::xs)
+  | there {x y : Nat} {xs : List Nat} : InContext x xs → InContext x (y::xs)
+deriving Ord
+
+inductive Foo : Nat → Nat → Type
+  | left {n : Nat} : Foo 0 n
+  | right {n : Nat} : Foo n 0
+deriving Ord


### PR DESCRIPTION
This PR fixes #12240, where `deriving Ord` failed with `Unknown identifier a✝`.
