### PR TITLE
test: teach SymM mvcgen to recognize specialized theorem applications

### DIFF
--- a/tests/bench/mvcgen/sym/add_sub_cancel.lean
+++ b/tests/bench/mvcgen/sym/add_sub_cancel.lean
@@ -81,8 +81,4 @@ def runBenchUsingMeta (sizes : List Nat) : MetaM Unit := do
 set_option maxRecDepth 10000
 set_option maxHeartbeats 10000000
 
-#eval runBenchUsingMeta [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
-
-#eval runBenchUsingMeta [50, 100, 150, 200, 250]
-
--- #eval runBenchUsingMeta [700, 1000]
+#eval runBenchUsingMeta [100, 200, 300, 400, 500, 600, 700, 800]


### PR DESCRIPTION
This PR recognizes certain kinds of composite proof terms of the form `hpre.trans hspec |> (wp prog).mono _ _ hpost` and abstracts them into bespoke theorems. This should yield smaller proof terms. Sadly, kernel checking time is unaffected, even regressing a bit. The number of shared terms stays almost the same (+- a constant). Hence I deactivate the code path in this patch. We keep the code, though, because it might be useful in the future, also there are a few other improvements.