### PR TITLE
perf: cache `unfold_definition` in the kernel

### DIFF
--- a/src/kernel/type_checker.h
+++ b/src/kernel/type_checker.h
@@ -33,6 +33,7 @@ public:
         expr_map<expr>            m_whnf;
         equiv_manager             m_eqv_manager;
         expr_pair_set             m_failure;
+        expr_map<expr>            m_unfold;
         friend type_checker;
     public:
         state(environment const & env);


### PR DESCRIPTION
This PR ensures we cache the result of `unfold_definition` definition in the kernel type checker. We used to cache this information in a thread local storage, but it was deleted during the Lean 3 to Lean 4 transition.