### PR TITLE
feat: define `Squash` as a `Quotient`

### DIFF
--- a/src/Init/Core.lean
+++ b/src/Init/Core.lean
@@ -2331,7 +2331,8 @@ and its representation in compiled code is identical to that of `α`.
 Consequently, `Squash.lift` may extract an `α` value into any subsingleton type `β`, while
 `Nonempty.rec` can only do the same when `β` is a proposition.
 
-`Squash` is defined in terms of `Quotient`, so `Squash` can be used when a `Quotient` argument is expected.
+`Squash` is defined in terms of `Quotient`, so `Squash` can be used when a `Quotient` argument is
+expected.
 -/
 def Squash (α : Sort u) := Quotient (Setoid.trivial α)
 


### PR DESCRIPTION
This PR changes the definition of `Squash` to use `Quotient` by upstreaming [`true_equivalence`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Quot.html#true_equivalence) (now `equivalence_true`) and [`trueSetoid`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Quot.html#trueSetoid) (now `Setoid.trivial`). The new definition is def-eq to the old one, but ensures that `Squash` can be used whenever a `Quotient` argument is expected without having to explicitly provide the setoid.

Besides being useful functionality, this makes Mathlib's [`Trunc`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Quot.html#Trunc) completely equivalent to `Squash`. A future Mathlib PR will deprecate the former in favor of the latter.

Reopened from #6642.