### PR TITLE
fix: `[local simp]` on privately imported theorem

### DIFF
--- a/src/Lean/Meta/Tactic/Simp/SimpTheorems.lean
+++ b/src/Lean/Meta/Tactic/Simp/SimpTheorems.lean
@@ -652,7 +652,7 @@ def SimpExtension.getTheorems (ext : SimpExtension) : CoreM SimpTheorems :=
 Adds a simp theorem to a simp extension
 -/
 def addSimpTheorem (ext : SimpExtension) (declName : Name) (post : Bool) (inv : Bool) (attrKind : AttributeKind) (prio : Nat) : MetaM Unit := do
-  let simpThms ← withExporting (isExporting := !isPrivateName declName) do mkSimpTheoremFromConst declName post inv prio
+  let simpThms ← withExporting (isExporting := attrKind != .local && !isPrivateName declName) do mkSimpTheoremFromConst declName post inv prio
   for simpThm in simpThms do
     ext.add (SimpEntry.thm simpThm) attrKind
 

--- a/tests/pkg/module/Module/PrivateImported.lean
+++ b/tests/pkg/module/Module/PrivateImported.lean
@@ -25,3 +25,7 @@ Note: A public declaration `f` exists but is imported privately; consider adding
 /-! `initialize` should be run even if imported IR-only. -/
 
 public def publicDefOfPrivatelyInitialized := initialized
+
+/-! #12198: `local simp` should be accepted on privately imported theorem -/
+
+attribute [local simp] t


### PR DESCRIPTION
This PR fixes an issue where `attribute [local simp]` was incorrectly rejected on a theorem from a private import

Fixes #12198