### PR TITLE
test: create aux theorems for backward rules in SymM-based mvcgen

### DIFF
--- a/tests/bench/mvcgen/sym/add_sub_cancel.lean
+++ b/tests/bench/mvcgen/sym/add_sub_cancel.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Lean FRO LLC. All rights reserved.
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sebastian Graf
 -/
@@ -81,4 +81,5 @@ def runBenchUsingMeta (sizes : List Nat) : MetaM Unit := do
 set_option maxRecDepth 10000
 set_option maxHeartbeats 10000000
 
-#eval runBenchUsingMeta [100, 200, 300, 400, 500, 600, 700, 800]
+#eval runBenchUsingMeta [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
+-- #eval runBenchUsingMeta [1000]

--- a/tests/bench/mvcgen/sym/lakefile.lean
+++ b/tests/bench/mvcgen/sym/lakefile.lean
@@ -1,7 +1,8 @@
 import Lake
 open System Lake DSL
 
-package mvcgen_bench
+package mvcgen_bench where
+  precompileModules := true
 
 -- VCGen library (lib/VCGen.lean), built first and used by benchmarks
 lean_lib VCGen where
@@ -11,3 +12,4 @@ lean_lib VCGen where
 @[default_target]
 lean_lib MvcgenBench where
   roots := #[`add_sub_cancel]
+  moreLeanArgs := #["--tstack=100000000"]


### PR DESCRIPTION
This PR improves and simplifies the SymM-based mvcgen prototype by creating `BackwardRule.apply`-ready auxiliary theorems for spec theorems. These auxiliary theorems have types that have reducible definitions unfolded and shared, just like the rest of the SymM world assumes. Furthermore, in order to aid kernel checking times, definitional reductions leave behind expected type hints. With #12290, we get the following numbers:

```
goal_100: 100.671964 ms, kernel: 34.104676 ms
goal_200: 152.650808 ms, kernel: 70.653251 ms
goal_300: 222.973242 ms, kernel: 105.874266 ms
goal_400: 294.032333 ms, kernel: 150.025106 ms
goal_500: 366.748098 ms, kernel: 193.483843 ms
goal_600: 442.509542 ms, kernel: 236.845115 ms
goal_700: 517.527685 ms, kernel: 268.804230 ms
goal_800: 601.657910 ms, kernel: 310.765606 ms
goal_900: 681.020759 ms, kernel: 357.428032 ms
goal_1000: 762.212989 ms, kernel: 403.789517 ms
```

The baseline is `shallow_add_sub_cancel`:

```
goal_100: 62.721757 ms, kernel: 22.109237 ms
goal_200: 140.118652 ms, kernel: 45.219512 ms
goal_300: 241.077690 ms, kernel: 78.779379 ms
goal_400: 363.274462 ms, kernel: 128.951250 ms
goal_500: 517.350791 ms, kernel: 155.498217 ms
goal_600: 678.291416 ms, kernel: 212.325487 ms
goal_700: 881.479043 ms, kernel: 258.690695 ms
goal_800: 1092.357375 ms, kernel: 351.996079 ms
goal_900: 1247.759480 ms, kernel: 319.197608 ms
goal_1000: 1497.203628 ms, kernel: 364.532560 ms
```

The latter is with the main solving loop in interpreter mode, but the kernel checking times are still representative.
Earlier experiments suggest that the precompiled baseline performs at roughly 650ms for `goal_1000`, so the new mvcgen is getting close.