### PR TITLE
fix: enable custom CCPO when using module system

### DIFF
--- a/src/Init/Internal/Order/Basic.lean
+++ b/src/Init/Internal/Order/Basic.lean
@@ -62,9 +62,9 @@ A chain is a totally ordered set (representing a set as a predicate).
 
 This is intended to be used in the construction of `partial_fixpoint`, and not meant to be used otherwise.
 -/
-def chain (c : α → Prop) : Prop := ∀ x y , c x → c y → x ⊑ y ∨ y ⊑ x
+@[expose] def chain (c : α → Prop) : Prop := ∀ x y , c x → c y → x ⊑ y ∨ y ⊑ x
 
-def is_sup {α : Sort u} [PartialOrder α] (c : α → Prop) (s : α) : Prop :=
+@[expose] def is_sup {α : Sort u} [PartialOrder α] (c : α → Prop) (s : α) : Prop :=
   ∀ x, s ⊑ x ↔ (∀ y, c y → y ⊑ x)
 
 theorem is_sup_unique {α} [PartialOrder α] {c : α → Prop} {s₁ s₂ : α}

--- a/tests/lean/run/partial_fixpoint_probability.lean
+++ b/tests/lean/run/partial_fixpoint_probability.lean
@@ -1,3 +1,5 @@
+module
+
 -- Since we do not have ENNReal in core, we just axiomatize it all for this test
 
 opaque ENNReal : Type


### PR DESCRIPTION
This PR exposes the chain and is_sup definitions such that other modules can declare custom CCPO instances.

Resolves the issue discussed [on Zulip: ](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/How.20to.20define.20CCPO.20with.20module.20system.20enabled.3F/with/571855195)[#general > How to define CCPO with module system enabled?](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/How.20to.20define.20CCPO.20with.20module.20system.20enabled.3F/with/571855195).