### PR TITLE
fix: report Verso docsring parse errors

### DIFF
--- a/src/Lean/Elab/BuiltinCommand.lean
+++ b/src/Lean/Elab/BuiltinCommand.lean
@@ -27,8 +27,13 @@ namespace Lean.Elab.Command
     else
       throwError m!"Can't add Markdown-format module docs because there is already Verso-format content present."
   | Syntax.node _ ``Lean.Parser.Command.versoCommentBody args =>
-    runTermElabM fun _ => do
-      addVersoModDocString range ⟨args.getD 0 .missing⟩
+    let docSyntax := args.getD 0 .missing
+    if docSyntax.getKind == `Lean.Doc.Syntax.parseFailure then
+      -- Report parser errors without attempting elaboration
+      runTermElabM fun _ => reportVersoParseFailure docSyntax
+    else
+      runTermElabM fun _ => do
+        addVersoModDocString range ⟨docSyntax⟩
   | _ => throwErrorAt stx "unexpected module doc string{indentD <| stx}"
 
 private def addScope (isNewNamespace : Bool) (header : String) (newNamespace : Name)

--- a/tests/lean/run/versoDocParseError.lean
+++ b/tests/lean/run/versoDocParseError.lean
@@ -1,0 +1,45 @@
+import Lean
+
+set_option doc.verso true
+
+/-!
+This test ensures that syntax errors in Verso docs are appropriately reported.
+-/
+
+-- Syntax error in module docstring should report actual error location
+/--
+error: '}'
+---
+error: unexpected end of input; expected '![', '$$', '$', '[' or '[^'
+-/
+#guard_msgs in
+/-!
+Here is text with an unclosed role {name`Nat
+-/
+
+-- Syntax error with specific position (not at end of docstring)
+/--
+@ +2:27...*
+error: '*'
+-/
+#guard_msgs (positions := true) in
+/-!
+Some mismatched *formatting_
+
+A b c d e f.
+
+```
+-/
+
+-- Syntax error in a normal docstring
+/--
+@ +2:27...*
+error: '*'
+-/
+#guard_msgs (positions := true) in
+/--
+Some mismatched *formatting_
+
+A b c d e f.
+-/
+def x := 5


### PR DESCRIPTION
This PR fixes a problem where Verso docstring parse errors were being swallowed in some circumstances.

Closes #12062.
