### PR TITLE
feat: make `try?` find induction proofs for forall-quantified goals

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,6 +11,15 @@ When asked to implement new features:
 
 All new tests should go in `tests/lean/run/`. These tests don't have expected output; we just check there are no errors. You should use `#guard_msgs` to check for specific messages.
 
+## Writing tests for bugs/features
+
+**A test for a bug must FAIL (non-zero exit code) until the bug is fixed.**
+
+- Write the test showing what SHOULD work
+- The test file should fail to compile/run until you implement the fix
+- Do NOT use `#guard_msgs` to capture expected errors - that makes the test pass
+- Do NOT add workarounds - that also makes the test pass
+
 ## Success Criteria
 
 *Never* report success on a task unless you have verified both a clean build without errors, and that the relevant tests pass.

--- a/tests/lean/run/try_forall_induction.lean
+++ b/tests/lean/run/try_forall_induction.lean
@@ -1,0 +1,31 @@
+/-!
+# Tests for `try?` with forall-quantified goals
+
+When the goal has leading foralls, `try?` should still find induction-based proofs
+by collecting candidates from under the forall binders.
+
+These examples require function induction to solve. With n in context, try?
+finds `fun_induction fib/double`. With ∀ n, try? should also find the proof
+(by doing intro first, then function induction).
+-/
+
+-- A recursive function where proofs require function induction
+def fib : Nat → Nat
+  | 0 => 0
+  | 1 => 1
+  | n + 2 => fib n + fib (n + 1)
+
+-- Another simple recursive function
+def double : Nat → Nat
+  | 0 => 0
+  | n + 1 => double n + 2
+
+/-! ## Baseline tests: n in context (these already work) -/
+
+example (n : Nat) : n ≤ fib n + 1 := by try?
+example (n : Nat) : double n = 2 * n := by try?
+
+/-! ## Forall tests: these should also work (after intro + function induction) -/
+
+example : ∀ n, n ≤ fib n + 1 := by try?
+example : ∀ n, double n = 2 * n := by try?

--- a/tests/lean/run/try_forall_induction.lean
+++ b/tests/lean/run/try_forall_induction.lean
@@ -29,3 +29,14 @@ example (n : Nat) : double n = 2 * n := by try?
 
 example : ∀ n, n ≤ fib n + 1 := by try?
 example : ∀ n, double n = 2 * n := by try?
+
+/-! ## Multiple function induction candidates under forall -/
+
+-- When there are multiple calls to the same function, fun_induction needs to specify which call
+example : ∀ n m, fib n + fib m = fib m + fib n := by try?
+
+/-! ## Regular induction under forall (not just function induction) -/
+
+inductive MyNat where | zero | succ : MyNat → MyNat
+
+example : ∀ n : MyNat, n = MyNat.zero ∨ ∃ m, n = MyNat.succ m := by try?


### PR DESCRIPTION
This PR enables `try?` to find induction-based proofs for goals with leading foralls (e.g., `∀ n, n ≤ fib n + 1`) by collecting candidates after temporarily stripping the foralls and generating tactics prefixed with `intro`.

Previously, `try?` could find `fun_induction fib` for `(n : Nat) : n ≤ fib n + 1` but not for `∀ n, n ≤ fib n + 1` because the candidate collector skipped expressions with loose bound variables. Rather than modifying the collector, this change uses `forallTelescope` during tactic generation to collect under the foralls and wraps the resulting tactics with `intro <names>;`.

Example:
```lean
def fib : Nat → Nat
  | 0 => 0
  | 1 => 1
  | n + 2 => fib n + fib (n + 1)

-- Previously worked:
example (n : Nat) : n ≤ fib n + 1 := by try?

-- Now also works:
example : ∀ n, n ≤ fib n + 1 := by try?
-- Suggests: intro n; fun_induction fib <;> grind [= fib]
```

🤖 Prepared with Claude Code and OpenAI Codex