### PR TITLE
perf: add inline annotation to `String.Slice.subslice!`

### DIFF
--- a/src/Init/Data/String/Slice.lean
+++ b/src/Init/Data/String/Slice.lean
@@ -69,7 +69,7 @@ def beq (s1 s2 : Slice) : Bool :=
 instance : BEq Slice where
   beq := beq
 
-@[inherit_doc Slice.copy]
+@[inline, inherit_doc Slice.copy]
 def toString (s : Slice) : String :=
   s.copy
 

--- a/src/Init/Data/String/Subslice.lean
+++ b/src/Init/Data/String/Subslice.lean
@@ -104,6 +104,7 @@ theorem endExclusive_subslice {s : Slice} {newStart newEnd : s.Pos} {h} :
 Constructs a subslice of {name}`s` given the bounds of the subslice. If the subslice would be
 degenerate, this function panics.
 -/
+@[inline]
 def subslice! (s : Slice) (newStart newEnd : s.Pos) : s.Subslice :=
   if h : newStart ≤ newEnd then
     s.subslice _ _ h


### PR DESCRIPTION
This PR marks `String.Slice.subslice!` as inline, which should avoid an allocation in the inner loop of `String.split`.
