### PR TITLE
feat: extend `evalEq` to handle `Bool`

### DIFF
--- a/src/Init/Sym/Lemmas.lean
+++ b/src/Init/Sym/Lemmas.lean
@@ -114,6 +114,7 @@ theorem Fin.eq_eq_true (a b : Fin n) (h : decide (a = b) = true) : (a = b) = Tru
 theorem BitVec.eq_eq_true (a b : BitVec n) (h : decide (a = b) = true) : (a = b) = True := by simp_all
 theorem String.eq_eq_true (a b : String) (h : decide (a = b) = true) : (a = b) = True := by simp_all
 theorem Char.eq_eq_true (a b : Char) (h : decide (a = b) = true) : (a = b) = True := by simp_all
+theorem Bool.eq_eq_true (a b : Bool) (h : decide (a = b) = true) : (a = b) = True := by simp_all
 
 theorem Nat.eq_eq_false (a b : Nat) (h : decide (a = b) = false) : (a = b) = False := by simp_all
 theorem Int.eq_eq_false (a b : Int) (h : decide (a = b) = false) : (a = b) = False := by simp_all
@@ -130,6 +131,7 @@ theorem Fin.eq_eq_false (a b : Fin n) (h : decide (a = b) = false) : (a = b) = F
 theorem BitVec.eq_eq_false (a b : BitVec n) (h : decide (a = b) = false) : (a = b) = False := by simp_all
 theorem String.eq_eq_false (a b : String) (h : decide (a = b) = false) : (a = b) = False := by simp_all
 theorem Char.eq_eq_false (a b : Char) (h : decide (a = b) = false) : (a = b) = False := by simp_all
+theorem Bool.eq_eq_false (a b : Bool) (h : decide (a = b) = false) : (a = b) = False := by simp_all
 
 theorem Nat.dvd_eq_true (a b : Nat) (h : decide (a ∣ b) = true) : (a ∣ b) = True := by simp_all
 theorem Int.dvd_eq_true (a b : Int) (h : decide (a ∣ b) = true) : (a ∣ b) = True := by simp_all

--- a/src/Lean/Meta/Sym/LitValues.lean
+++ b/src/Lean/Meta/Sym/LitValues.lean
@@ -83,4 +83,10 @@ def getStringValue? (e : Expr) : Option String :=
   | .lit (.strVal s) => some s
   | _ => none
 
+def getBoolValue? (e : Expr) : Option Bool :=
+  match_expr e with
+  | Bool.true => true
+  | Bool.false => false
+  | _ => none
+
 end Lean.Meta.Sym

--- a/src/Lean/Meta/Sym/Simp/EvalGround.lean
+++ b/src/Lean/Meta/Sym/Simp/EvalGround.lean
@@ -437,6 +437,7 @@ def evalEq (α : Expr) (a b : Expr) : SimpM Result :=
   | BitVec n => evalBitVecPred n (mkConst ``BitVec.eq_eq_true) (mkConst ``BitVec.eq_eq_false) (. = .) a b
   | Char => evalBinPred getCharValue? (mkConst ``Char.eq_eq_true) (mkConst ``Char.eq_eq_false) (. = .) a b
   | String => evalBinPred getStringValue? (mkConst ``String.eq_eq_true) (mkConst ``String.eq_eq_false) (. = .) a b
+  | Bool => evalBinPred getBoolValue? (mkConst ``Bool.eq_eq_true) (mkConst ``Bool.eq_eq_false) (. = .) a b
   | _ => return .rfl
 
 def evalDvd (α : Expr) (a b : Expr) : SimpM Result :=


### PR DESCRIPTION
This PR extends `evalEq` used in `evalGround` to handle `Bool` as well.