### PR TITLE
chore: bump default thread stack size to 16MB

### DIFF
--- a/src/runtime/thread.cpp
+++ b/src/runtime/thread.cpp
@@ -20,7 +20,7 @@ Author: Leonardo de Moura
 #include "runtime/stack_overflow.h"
 
 #ifndef LEAN_DEFAULT_THREAD_STACK_SIZE
-#define LEAN_DEFAULT_THREAD_STACK_SIZE 8*1024*1024 // 8Mb
+#define LEAN_DEFAULT_THREAD_STACK_SIZE 16*1024*1024 // 16MB
 #endif
 
 namespace lean {


### PR DESCRIPTION
We started running into new arch-specific stack overflows in tests and want to bump the limit anyway