### PR TITLE
feat: improve simp and grind rules for `PredTrans.apply`

### DIFF
--- a/src/Std/Do/PredTrans.lean
+++ b/src/Std/Do/PredTrans.lean
@@ -131,42 +131,40 @@ instance : Monad (PredTrans ps) where
   pure := pure
   bind := bind
 
-@[simp]
-theorem pure_eq_pure {ps} {α} (a : α) :
-    PredTrans.pure (ps := ps) a = Pure.pure a := by rfl
-
-@[simp]
-theorem bind_eq_bind {ps} {α β} (x : PredTrans ps α) (f : α → PredTrans ps β) :
-    PredTrans.bind (ps := ps) x f = Bind.bind x f := by rfl
-
-@[simp]
-theorem pure_apply (a : α) (Q : PostCond α ps) :
+@[simp, grind =]
+theorem apply_Pure_pure (a : α) (Q : PostCond α ps) :
   (Pure.pure a : PredTrans ps α).apply Q = Q.1 a := by rfl
 
-@[simp]
-theorem map_apply (f : α → β) (x : PredTrans ps α) (Q : PostCond β ps) :
+@[simp, grind =]
+theorem apply_pure (a : α) (Q : PostCond α ps) :
+  (PredTrans.pure a).apply Q = Q.1 a := by rfl
+
+@[simp, grind =]
+theorem apply_Functor_map (f : α → β) (x : PredTrans ps α) (Q : PostCond β ps) :
   (f <$> x).apply Q = x.apply (fun a => Q.1 (f a), Q.2) := by rfl
 
-@[simp]
-theorem bind_apply (x : PredTrans ps α) (f : α → PredTrans ps β) (Q : PostCond β ps) :
+@[simp, grind =]
+theorem apply_bind (x : PredTrans ps α) (f : α → PredTrans ps β) (Q : PostCond β ps) :
+  (PredTrans.bind x f).apply Q = x.apply (fun a => (f a).apply Q, Q.2) := by rfl
+
+@[simp, grind =]
+theorem apply_Bind_bind (x : PredTrans ps α) (f : α → PredTrans ps β) (Q : PostCond β ps) :
   (x >>= f).apply Q = x.apply (fun a => (f a).apply Q, Q.2) := by rfl
 
 @[simp]
-theorem seq_apply (f : PredTrans ps (α → β)) (x : PredTrans ps α) (Q : PostCond β ps) :
+theorem apply_Seq_seq (f : PredTrans ps (α → β)) (x : PredTrans ps α) (Q : PostCond β ps) :
   (f <*> x).apply Q = f.apply (fun g => x.apply (fun a => Q.1 (g a), Q.2), Q.2) := by rfl
 
-@[simp]
-theorem const_apply (p : Assertion ps) (Q : PostCond α ps) :
+@[simp, grind =]
+theorem apply_const (p : Assertion ps) (Q : PostCond α ps) :
   (PredTrans.const p : PredTrans ps α).apply Q = p := by rfl
 
 theorem bind_mono {x y : PredTrans ps α} {f : α → PredTrans ps β}
   (h : x ≤ y) : x >>= f ≤ y >>= f := by intro Q; exact (h (_, Q.2))
 
-instance instLawfulMonad : LawfulMonad (PredTrans ps) :=
-  LawfulMonad.mk' (PredTrans ps)
-    (id_map := by simp +unfoldPartialApp [Functor.map, bind, pure, apply])
-    (pure_bind := by simp +unfoldPartialApp [Bind.bind, bind, Pure.pure, pure, apply])
-    (bind_assoc := by simp +unfoldPartialApp [Bind.bind, bind, apply])
+instance instLawfulMonad : LawfulMonad (PredTrans ps) := by
+  apply LawfulMonad.mk' _
+  all_goals (intros; ext Q; simp)
 
 /--
 Adds the ability to make assertions about a state of type `σ` to a predicate transformer with
@@ -222,20 +220,22 @@ def pushOption {ps : PostShape} {α} (x : OptionT (PredTrans ps) α) : PredTrans
     ext x
     cases x <;> simp
 
-@[simp]
-theorem pushArg_apply {ps} {α σ : Type u} {Q : PostCond α (.arg σ ps)} (f : σ → PredTrans ps (α × σ)) :
+@[simp, grind =]
+theorem apply_pushArg {ps} {α σ : Type u} {Q : PostCond α (.arg σ ps)} (f : σ → PredTrans ps (α × σ)) :
   (pushArg f).apply Q = fun s => (f s).apply (fun ⟨a, s⟩ => Q.1 a s, Q.2) := rfl
 
-@[simp]
-theorem pushExcept_apply {ps} {α ε : Type u} {Q : PostCond α (.except ε ps)} (x : PredTrans ps (Except ε α)) :
+@[simp, grind =]
+theorem apply_pushExcept {ps} {α ε : Type u} {Q : PostCond α (.except ε ps)} (x : PredTrans ps (Except ε α)) :
   (pushExcept x).apply Q = x.apply (fun | .ok a => Q.1 a | .error e => Q.2.1 e, Q.2.2) := rfl
 
-@[simp]
-theorem pushOption_apply {ps} {α : Type u} {Q : PostCond α (.except PUnit ps)} (x : PredTrans ps (Option α)) :
+@[simp, grind =]
+theorem apply_pushOption {ps} {α : Type u} {Q : PostCond α (.except PUnit ps)} (x : PredTrans ps (Option α)) :
   (pushOption x).apply Q = x.apply (fun | .some a => Q.1 a | .none => Q.2.1 ⟨⟩, Q.2.2) := rfl
 
-theorem dite_apply {ps} {Q : PostCond α ps} (c : Prop) [Decidable c] (t : c → PredTrans ps α) (e : ¬ c → PredTrans ps α) :
+@[simp]
+theorem apply_dite {ps} {Q : PostCond α ps} (c : Prop) [Decidable c] (t : c → PredTrans ps α) (e : ¬ c → PredTrans ps α) :
   (if h : c then t h else e h).apply Q = if h : c then (t h).apply Q else (e h).apply Q := by split <;> rfl
 
-theorem ite_apply {ps} {Q : PostCond α ps} (c : Prop) [Decidable c] (t : PredTrans ps α) (e : PredTrans ps α) :
+@[simp]
+theorem apply_ite {ps} {Q : PostCond α ps} (c : Prop) [Decidable c] (t : PredTrans ps α) (e : PredTrans ps α) :
   (if c then t else e).apply Q = if c then t.apply Q else e.apply Q := by split <;> rfl

--- a/src/Std/Do/WP/Basic.lean
+++ b/src/Std/Do/WP/Basic.lean
@@ -152,7 +152,7 @@ theorem Except.of_wp_eq {ε α : Type u} {x prog : Except ε α} (h : prog = x) 
     (⊢ₛ wp⟦prog⟧ post⟨fun a => ⌜P (.ok a)⌝, fun e => ⌜P (.error e)⌝⟩) → P x := by
   subst h
   intro hspec
-  simp only [wp, ExceptT.run, Id.run, PredTrans.pushExcept_apply, PredTrans.pure_apply] at hspec
+  simp only [wp, ExceptT.run, Id.run, PredTrans.apply_pushExcept, PredTrans.apply_Pure_pure] at hspec
   split at hspec <;> exact hspec True.intro
 
 /--
@@ -164,7 +164,7 @@ Useful if you want to prove a property about an expression `prog : Except ε α`
 theorem Except.of_wp {ε α : Type u} {prog : Except ε α} (P : Except ε α → Prop) :
     (⊢ₛ wp⟦prog⟧ post⟨fun a => ⌜P (.ok a)⌝, fun e => ⌜P (.error e)⌝⟩) → P prog := by
   intro hspec
-  simp only [wp, ExceptT.run, Id.run, PredTrans.pushExcept_apply, PredTrans.pure_apply] at hspec
+  simp only [wp, ExceptT.run, Id.run, PredTrans.apply_pushExcept, PredTrans.apply_Pure_pure] at hspec
   split at hspec <;> exact hspec True.intro
 
 /--
@@ -176,7 +176,7 @@ theorem Option.of_wp_eq {α : Type u} {x prog : Option α} (h : prog = x) (P : O
     (⊢ₛ wp⟦prog⟧ post⟨fun a => ⌜P (some a)⌝, fun _ => ⌜P none⌝⟩) → P x := by
   subst h
   intro hspec
-  simp only [wp, OptionT.run, Id.run, PredTrans.pushOption_apply, PredTrans.pure_apply] at hspec
+  simp only [wp, OptionT.run, Id.run, PredTrans.apply_pushOption, PredTrans.apply_Pure_pure] at hspec
   split at hspec <;> exact hspec True.intro
 
 /--

--- a/src/Std/Do/WP/Monad.lean
+++ b/src/Std/Do/WP/Monad.lean
@@ -66,7 +66,7 @@ instance ExceptT.instWPMonad [Monad m] [WPMonad m ps] : WPMonad (ExceptT ε m) (
   wp_pure a := by ext; simp [wp, wp_pure]
   wp_bind x f := by
     ext Q
-    simp only [wp, ExceptT.run_bind, wp_bind, PredTrans.pushExcept_apply, PredTrans.bind_apply]
+    simp only [wp, ExceptT.run_bind, wp_bind, PredTrans.apply_pushExcept, PredTrans.apply_Bind_bind]
     congr
     ext b
     cases b
@@ -77,7 +77,7 @@ instance OptionT.instWPMonad [Monad m] [WPMonad m ps] : WPMonad (OptionT m) (.ex
   wp_pure a := by ext; simp [wp, wp_pure]
   wp_bind x f := by
     ext Q
-    simp only [wp, OptionT.run_bind, Option.elimM, Option.elim, wp_bind, PredTrans.pushOption_apply, PredTrans.bind_apply]
+    simp only [wp, OptionT.run_bind, Option.elimM, Option.elim, wp_bind, PredTrans.apply_pushOption, PredTrans.apply_Bind_bind]
     congr
     ext b
     cases b
@@ -85,10 +85,10 @@ instance OptionT.instWPMonad [Monad m] [WPMonad m ps] : WPMonad (OptionT m) (.ex
     case some a => rfl
 
 instance EStateM.instWPMonad : WPMonad (EStateM ε σ) (.except ε (.arg σ .pure)) where
-  wp_pure a := by ext Q : 1; simp only [wp, EStateM.run_pure, PredTrans.pure_apply]; rfl
+  wp_pure a := by ext Q : 1; simp only [wp, EStateM.run_pure, PredTrans.apply_Pure_pure]; rfl
   wp_bind x f := by
     ext Q : 2
-    simp only [wp, EStateM.run_bind, PredTrans.bind_apply]
+    simp only [wp, EStateM.run_bind, PredTrans.apply_Bind_bind]
     simp only [PredTrans.apply]
     cases (x.run _) <;> rfl
 

--- a/src/Std/Do/WP/SimpLemmas.lean
+++ b/src/Std/Do/WP/SimpLemmas.lean
@@ -458,7 +458,7 @@ theorem throw_StateT [WP m sh] [Monad m] [MonadExceptOf ε m] :
 @[simp]
 theorem throw_lift_ExceptT [WP m sh] [Monad m] [MonadExceptOf ε m] :
     wp⟦MonadExceptOf.throw (ε:=ε) e : ExceptT ε' m α⟧ Q = wp⟦MonadExceptOf.throw (ε:=ε) e : m (Except ε' α)⟧ (fun e => e.casesOn Q.2.1 Q.1, Q.2.2) := by
-  simp only [wp, MonadExceptOf.throw, PredTrans.pushExcept_apply]
+  simp only [wp, MonadExceptOf.throw, PredTrans.apply_pushExcept]
   congr
   ext x
   split <;> rfl
@@ -468,7 +468,7 @@ theorem throw_lift_ExceptT [WP m sh] [Monad m] [MonadExceptOf ε m] :
 @[simp]
 theorem throw_lift_OptionT [WP m sh] [Monad m] [MonadExceptOf ε m] :
     wp⟦MonadExceptOf.throw (ε:=ε) e : OptionT m α⟧ Q = wp⟦MonadExceptOf.throw (ε:=ε) e : m (Option α)⟧ (fun o => o.casesOn (Q.2.1 ⟨⟩) Q.1, Q.2.2) := by
-  simp only [wp, MonadExceptOf.throw, PredTrans.pushOption_apply]
+  simp only [wp, MonadExceptOf.throw, PredTrans.apply_pushOption]
   congr
   ext x
   split <;> rfl
@@ -485,14 +485,14 @@ theorem tryCatchThe [MonadExceptOf ε m] [WP m ps] :
 theorem tryCatch_Except :
     wp⟦MonadExceptOf.tryCatch x h : Except ε α⟧ Q = wp⟦x⟧ (Q.1, fun e => wp⟦h e⟧ Q, Q.2.2) := by
   simp only [wp, ExceptT.run, Id.run, MonadExceptOf.tryCatch, Except.tryCatch,
-    PredTrans.pushExcept_apply]
+    PredTrans.apply_pushExcept]
   cases x <;> simp
 
 @[simp]
 theorem tryCatch_ExceptT [Monad m] [WPMonad m ps] :
     wp⟦MonadExceptOf.tryCatch x h : ExceptT ε m α⟧ Q = wp⟦x⟧ (Q.1, fun e => wp⟦h e⟧ Q, Q.2.2) := by
   simp only [wp, MonadExceptOf.tryCatch, ExceptT.tryCatch, ExceptT.run_mk,
-    PredTrans.pushExcept_apply, bind]
+    PredTrans.apply_pushExcept, bind]
   simp only [ExceptT.run]
   congr
   ext x
@@ -502,14 +502,14 @@ theorem tryCatch_ExceptT [Monad m] [WPMonad m ps] :
 theorem tryCatch_Option :
     wp⟦MonadExceptOf.tryCatch x h : Option α⟧ Q = wp⟦x⟧ (Q.1, fun e => wp⟦h e⟧ Q, Q.2.2) := by
   simp only [wp, Id.run, OptionT.run, MonadExceptOf.tryCatch, Option.tryCatch,
-    PredTrans.pushOption_apply]
+    PredTrans.apply_pushOption]
   cases x <;> simp
 
 @[simp]
 theorem tryCatch_OptionT [Monad m] [WPMonad m ps] :
     wp⟦MonadExceptOf.tryCatch x h : OptionT m α⟧ Q = wp⟦x⟧ (Q.1, fun e => wp⟦h e⟧ Q, Q.2.2) := by
   simp only [wp, MonadExceptOf.tryCatch, OptionT.tryCatch, OptionT.run_mk,
-    PredTrans.pushOption_apply, bind]
+    PredTrans.apply_pushOption, bind]
   simp only [OptionT.run]
   congr
   ext x
@@ -536,7 +536,7 @@ theorem tryCatch_StateT [WP m sh] [Monad m] [MonadExceptOf ε m] :
 @[simp]
 theorem tryCatch_lift_ExceptT [WP m sh] [Monad m] [MonadExceptOf ε m] :
     wp⟦MonadExceptOf.tryCatch (ε:=ε) x h : ExceptT ε' m α⟧ Q = wp⟦MonadExceptOf.tryCatch (ε:=ε) x h : m (Except ε' α)⟧ (fun e => e.casesOn Q.2.1 Q.1, Q.2.2) := by
-  simp only [wp, MonadExceptOf.tryCatch, PredTrans.pushExcept_apply, ExceptT.mk]
+  simp only [wp, MonadExceptOf.tryCatch, PredTrans.apply_pushExcept, ExceptT.mk]
   congr
   ext x
   split <;> rfl
@@ -544,7 +544,7 @@ theorem tryCatch_lift_ExceptT [WP m sh] [Monad m] [MonadExceptOf ε m] :
 @[simp]
 theorem tryCatch_lift_OptionT [WP m sh] [Monad m] [MonadExceptOf ε m] :
     wp⟦MonadExceptOf.tryCatch (ε:=ε) x h : OptionT m α⟧ Q = wp⟦MonadExceptOf.tryCatch (ε:=ε) x h : m (Option α)⟧ (fun o => o.casesOn (Q.2.1 ⟨⟩) Q.1, Q.2.2) := by
-  simp only [wp, MonadExceptOf.tryCatch, PredTrans.pushOption_apply, OptionT.mk]
+  simp only [wp, MonadExceptOf.tryCatch, PredTrans.apply_pushOption, OptionT.mk]
   congr
   ext x
   split <;> rfl
@@ -596,7 +596,7 @@ theorem orElse_Option  :
 theorem orElse_OptionT [Monad m] [WPMonad m ps] :
     wp⟦OrElse.orElse x h : OptionT m α⟧ Q = wp⟦x⟧ (Q.1, fun _ => wp⟦h ()⟧ Q, Q.2.2) := by
   simp only [wp, OrElse.orElse, Alternative.orElse, OptionT.orElse, OptionT.run_mk,
-    PredTrans.pushOption_apply, bind]
+    PredTrans.apply_pushOption, bind]
   simp only [OptionT.run]
   congr
   ext x

--- a/tests/lean/run/doLogicTests.lean
+++ b/tests/lean/run/doLogicTests.lean
@@ -571,12 +571,11 @@ instance Result.instWP : WP Result (.except Error .pure) where
   | .div => PredTrans.const ⌜False⌝
 
 instance Result.instWPMonad : WPMonad Result (.except Error .pure) where
-  wp_pure := by intros; ext Q; simp only [wp, ExceptT.run_pure, Id.run_pure,
-    PredTrans.pushExcept_apply, PredTrans.pure_apply]
+  wp_pure _ := by ext Q; simp [wp]
   wp_bind x f := by
-    simp only [wp, ExceptT.run_pure, Id.run_pure, ExceptT.run_throw, bind]
+    dsimp only [wp, bind]
     ext Q
-    cases x <;> simp
+    grind
 
 theorem Result.of_wp {α} {x : Result α} (P : Result α → Prop) :
   (⊢ₛ wp⟦x⟧ post⟨fun a => ⌜P (.ok a)⌝, fun e => ⌜P (.fail e)⌝⟩) → P x := by

--- a/tests/lean/run/mvcgenTutorial.lean
+++ b/tests/lean/run/mvcgenTutorial.lean
@@ -221,12 +221,13 @@ instance Result.instWP : WP Result (.except Error .pure) where
   | .div => PredTrans.const ⌜False⌝
 
 instance Result.instWPMonad : WPMonad Result (.except Error .pure) where
-  wp_pure := by intros; ext Q; simp only [wp, ExceptT.run_pure, Id.run_pure,
-    PredTrans.pushExcept_apply, PredTrans.pure_apply]
-  wp_bind x f := by
-    simp only [wp, ExceptT.run_pure, Id.run_pure, ExceptT.run_throw, bind]
+  wp_pure _ := by
     ext Q
-    cases x <;> simp
+    simp [wp]
+  wp_bind x f := by
+    dsimp only [wp, bind]
+    ext Q
+    grind
 
 theorem Result.of_wp {α} {x : Result α} (P : Result α → Prop) :
     (⊢ₛ wp⟦x⟧ post⟨fun a => ⌜P (.ok a)⌝, fun e => ⌜P (.fail e)⌝⟩) → P x := by


### PR DESCRIPTION
This PR improves the `simp` and `grind` rule framework for `PredTrans.apply` and also renames the respective lemmas according to convention.