### PR TITLE
fix: handle Verso docstrings that don't consume all the docstring

### DIFF
--- a/src/Lean/Parser/Term.lean
+++ b/src/Lean/Parser/Term.lean
@@ -30,7 +30,7 @@ def versoCommentBodyFn : ParserFn := fun c s =>
     let c' := c.setEndPos endPos (by unfold endPos; split <;> simp [*])
     let s := Doc.Parser.document {} c' (s.setPos startPos)
     let s :=
-      if !s.allErrors.isEmpty then
+      if !s.allErrors.isEmpty || !c'.atEnd s.pos then
         -- Docstring parsing must always succeed, or else later error messages are atrocious! Syntax
         -- errors in the docs should not cause verso-docstring-expecting commands to be removed from
         -- consideration. So, at this stage, we push an indication of the failure, and then later,

--- a/tests/lean/run/versoDocParseError.lean
+++ b/tests/lean/run/versoDocParseError.lean
@@ -43,3 +43,45 @@ Some mismatched *formatting_
 A b c d e f.
 -/
 def x := 5
+
+-- Unmatched closing bracket in docstring (issue #12118)
+/--
+@ +2:0...*
+error: '{'; expected %%% (at line beginning), '![', '$$', '$', '[', '[^', *, + or -
+-/
+#guard_msgs (positions := true) in
+/--
+}
+-/
+def z := 0
+
+-- Unmatched closing bracket in module docstring
+/--
+@ +2:0...*
+error: '{'; expected %%% (at line beginning), '![', '$$', '$', '[', '[^', *, + or -
+-/
+#guard_msgs (positions := true) in
+/-!
+}
+-/
+
+-- Unmatched closing square bracket in docstring
+/--
+@ +2:0...*
+error: '{'; expected %%% (at line beginning), '![', '$$', '$', '[', '[^', *, + or -
+-/
+#guard_msgs (positions := true) in
+/--
+]
+-/
+def w := 0
+
+-- Unmatched closing square bracket in module docstring
+/--
+@ +2:0...*
+error: '{'; expected %%% (at line beginning), '![', '$$', '$', '[', '[^', *, + or -
+-/
+#guard_msgs (positions := true) in
+/-!
+]
+-/


### PR DESCRIPTION
This PR fixes poor error reporting from Verso docstrings. Before, if the Verso parser didn't consume the whole docstring, then Lean would try to parse the closing -/ and fail; this would lead to backtracking and an assumption that the docstring must be non-Verso, with only the non-Verso commands like #guard_msgs as possibilities. Now, the input is always consumed.

Closes #12118.
