### PR TITLE
fix: make classes appear as classes rather than structures in docs

### DIFF
--- a/src/Lean/Elab/Structure.lean
+++ b/src/Lean/Elab/Structure.lean
@@ -1536,25 +1536,6 @@ def elabStructureCommand : InductiveElabDescr where
                   mkRemainingProjections levelParams params view
               setStructureParents view.declName parentInfos
 
-              if let some (doc, isVerso) := view.docString? then
-                addDocStringOf isVerso view.declName view.binders doc
-              if let some (doc, isVerso) := view.ctor.modifiers.docString? then
-                addDocStringOf isVerso view.ctor.declName view.ctor.binders doc
-              for field in view.fields do
-                  -- may not exist if overriding inherited field
-                if (← getEnv).contains field.declName then
-                  if let some (doc, isVerso) := field.modifiers.docString? then
-                    addDocStringOf isVerso field.declName field.binders doc
-
-              withSaveInfoContext do  -- save new env
-                for field in view.fields do
-                  -- may not exist if overriding inherited field
-                  if (← getEnv).contains field.declName then
-                    Term.addTermInfo' field.ref (← mkConstWithLevelParams field.declName) (isBinder := true)
-                -- Add terminfo for parents now that all parent projections exist.
-                for parent in parents do
-                  if parent.addTermInfo then
-                    Term.addTermInfo' parent.ref (← mkConstWithLevelParams parent.declName) (isBinder := true)
               checkResolutionOrder view.declName
               return {
                 finalize := do
@@ -1565,6 +1546,23 @@ def elabStructureCommand : InductiveElabDescr where
                       enableRealizationsForConst fieldInfo.declName
                   if view.isClass then
                     addParentInstances parentInfos
+                  -- Add field docstrings here (after @[class] attribute is applied)
+                  -- so that Verso docstrings can use the class.
+                  for field in view.fields do
+                    -- may not exist if overriding inherited field
+                    if (← getEnv).contains field.declName then
+                      if let some (doc, isVerso) := field.modifiers.docString? then
+                        addDocStringOf isVerso field.declName field.binders doc
+                  -- Add terminfo after docstrings so hovers include the docstring.
+                  withSaveInfoContext do
+                    for field in view.fields do
+                      -- may not exist if overriding inherited field
+                      if (← getEnv).contains field.declName then
+                        Term.addTermInfo' field.ref (← mkConstWithLevelParams field.declName) (isBinder := true)
+                    -- Add terminfo for parents now that all parent projections exist.
+                    for parent in parents do
+                      if parent.addTermInfo then
+                        Term.addTermInfo' parent.ref (← mkConstWithLevelParams parent.declName) (isBinder := true)
               }
           }
     }

--- a/tests/lean/run/versoDocClass.lean
+++ b/tests/lean/run/versoDocClass.lean
@@ -1,0 +1,88 @@
+import Lean
+/-!
+Tests that Verso docstrings on `class` declarations can use the class as a type class.
+See https://github.com/leanprover/lean4/issues/11651
+-/
+set_option doc.verso true
+
+
+
+/--
+{name}`Foo` is a type class.
+
+```lean
+instance : Foo := ⟨0, 1⟩
+example [Foo] : Unit := ()
+example : Nat := Foo.x
+```
+-/
+class Foo where
+  /--
+  Docs!
+  ```lean
+
+  def x [Foo] : String := "abc"
+  /--
+  error: failed to synthesize instance of type class
+    Foo
+
+  Hint: Type class instance resolution failures can be inspected with the `set_option trace.Meta.synthInstance true` command.
+  -/
+  #guard_msgs (whitespace := lax) in
+  #eval x
+  /-- info: "abc" -/
+  #guard_msgs in
+  #eval have : Foo := .mk 0 1; x
+  ```
+  -/
+  mk ::
+  x : Nat
+  /--
+  Uses {name}`Foo` as a class:
+
+  ```lean
+  example [Foo] : Nat := Foo.y
+  ```
+  -/
+  y : Nat
+
+
+open Lean Elab Command in
+def printVersoDocstring (name : Name) : CommandElabM Unit := do
+  match (← findInternalDocString? (← getEnv) name) with
+  | none => IO.println s!"No docstring for {name}"
+  | some (.inl md) => IO.println s!"Markdown:\n{md}"
+  | some (.inr v) => IO.println (repr v.text); IO.println (repr v.subsections)
+
+/--
+info: #[Lean.Doc.Block.para
+    #[Lean.Doc.Inline.other
+        { name := `Lean.Doc.Data.Const val := Dynamic.mk `Lean.Doc.Data.Const _ }
+        #[Lean.Doc.Inline.code "Foo"],
+      Lean.Doc.Inline.text " is a type class."],
+  Lean.Doc.Block.other
+    { name := `Lean.Doc.Data.LeanBlock val := Dynamic.mk `Lean.Doc.Data.LeanBlock _ }
+    #[Lean.Doc.Block.code "instance : Foo := ⟨0, 1⟩\nexample [Foo] : Unit := ()\nexample : Nat := Foo.x\n"]]
+#[]
+-/
+#guard_msgs in
+#eval printVersoDocstring ``Foo
+
+/-- info: No docstring for Foo.x -/
+#guard_msgs in
+#eval printVersoDocstring ``Foo.x
+
+/--
+info: #[Lean.Doc.Block.para
+    #[Lean.Doc.Inline.text "Uses ",
+      Lean.Doc.Inline.other
+        { name := `Lean.Doc.Data.Const val := Dynamic.mk `Lean.Doc.Data.Const _ }
+        #[Lean.Doc.Inline.code "Foo"],
+      Lean.Doc.Inline.text " as a class:"],
+  Lean.Doc.Block.other
+    { name := `Lean.Doc.Data.LeanBlock val := Dynamic.mk `Lean.Doc.Data.LeanBlock _ }
+    #[Lean.Doc.Block.code "example [Foo] : Nat := Foo.y\n"]]
+#[]
+-/
+#guard_msgs in
+#eval printVersoDocstring ``Foo.y


### PR DESCRIPTION
This PR moves the elaboration of structure/class Verso docstrings until after the fact that it's a class is registered, so code samples in the docstring can use it as a class. Redundant addition of structure and constructor docstrings are also removed, because they're already handled in MutualInductive.lean.

Closes #11651
