### PR TITLE
fix: expose `reduceOption`

### DIFF
--- a/src/Init/Data/List/Impl.lean
+++ b/src/Init/Data/List/Impl.lean
@@ -123,7 +123,7 @@ Example:
 /-! ### reduceOption -/
 
 /-- Drop `none`s from a list, and replace each remaining `some a` with `a`. -/
-@[inline] def reduceOption {α} : List (Option α) → List α :=
+@[inline, expose] def reduceOption {α} : List (Option α) → List α :=
   List.filterMap id
 
 /-! ### foldr -/


### PR DESCRIPTION
This PR tags `List.reduceOption` with `@[expose]`. #12348 accidentally moved the definition out of an `@[expose] section` which caused problems in mathlib because `List.reduceOption` was expected to be exposed.