### PR TITLE
feat: extend `+locals` to include `import all`'d definitions

### DIFF
--- a/src/Lean/Meta/Tactic/Util.lean
+++ b/src/Lean/Meta/Tactic/Util.lean
@@ -184,11 +184,7 @@ def forLocalDefs (f : Name → ConstantInfo → MetaM Unit) : MetaM Unit := do
   let env ← getEnv
   -- Current module definitions
   for (name, ci) in env.constants.map₂.toList do
-    if name.isInternalDetail && !isPrivateName name then continue
-    if (← isInstanceReducible name) then continue
-    match ci with
-    | .defnInfo _ => f name ci
-    | _ => continue
+    processConst name ci
   -- Definitions from `import all`'d modules
   if env.header.isModule then
     for effImport in env.header.importAllModules do
@@ -197,10 +193,13 @@ def forLocalDefs (f : Name → ConstantInfo → MetaM Unit) : MetaM Unit := do
       for h : i in [:modData.constants.size] do
         let name := modData.constNames[i]!
         let ci := modData.constants[i]
-        if name.isInternalDetail && !isPrivateName name then continue
-        if (← isInstanceReducible name) then continue
-        match ci with
-        | .defnInfo _ => f name ci
-        | _ => continue
+        processConst name ci
+where
+  processConst (name : Name) (ci : ConstantInfo) : MetaM Unit := do
+    if name.isInternalDetail && !isPrivateName name then return
+    if (← isInstanceReducible name) then return
+    match ci with
+    | .defnInfo _ => f name ci
+    | _ => return
 
 end Lean.Meta

--- a/src/Lean/Meta/Tactic/Util.lean
+++ b/src/Lean/Meta/Tactic/Util.lean
@@ -194,9 +194,9 @@ def forLocalDefs (f : Name → ConstantInfo → MetaM Unit) : MetaM Unit := do
     for effImport in env.header.importAllModules do
       let some modIdx := env.getModuleIdx? effImport.module | continue
       let some modData := env.header.moduleData[modIdx]? | continue
-      for i in [:modData.constants.size] do
+      for h : i in [:modData.constants.size] do
         let name := modData.constNames[i]!
-        let ci := modData.constants[i]!
+        let ci := modData.constants[i]
         if name.isInternalDetail && !isPrivateName name then continue
         if (← isInstanceReducible name) then continue
         match ci with

--- a/tests/pkg/module/Module/Imported.lean
+++ b/tests/pkg/module/Module/Imported.lean
@@ -211,3 +211,16 @@ public meta def metaUsingNonMeta : Nat :=
 
 -- #11672
 example : instA = { instA with b := 0 } := rfl
+
+/-! `+locals` should NOT include definitions from regular imports (only `import all`). -/
+
+-- `f` is defined in Module.Basic as `def f := 1`, not exposed
+-- Without `import all`, `simp +locals` should NOT be able to unfold it
+example : f = 1 := by
+  fail_if_success simp +locals
+  native_decide
+
+-- Same for `grind +locals`
+example : f = 1 := by
+  fail_if_success grind +locals
+  native_decide

--- a/tests/pkg/module/Module/ImportedAll.lean
+++ b/tests/pkg/module/Module/ImportedAll.lean
@@ -166,3 +166,12 @@ error: Invalid `⟨...⟩` notation: Constructor for `StructWithPrivateField` is
 attribute [local grind] func in
 theorem stmt1 : func ctx op = ctx := by
   grind
+
+/-! `+locals` should include definitions from `import all`'d modules. -/
+
+-- `f` is defined in Module.Basic as `def f := 1`, not exposed
+-- With `import all`, `simp +locals` should be able to unfold it
+example : f = 1 := by simp +locals
+
+-- Same for `grind +locals`
+example : f = 1 := by grind +locals


### PR DESCRIPTION
This PR makes `simp +locals` and `grind +locals` also unfold definitions from
transitively `import all`'d modules, aligning with the semantics that `import all`
is "morally like putting the contents of the imported file in the current file".

The common iteration/filtering logic is factored out into `forLocalDefs` in
`Lean.Meta.Tactic.Util`.

🤖 Prepared with Claude Code