### PR TITLE
fix: LCNF casesOnCtor can only act if type correct

### DIFF
--- a/src/Lean/Compiler/LCNF/Simp/Main.lean
+++ b/src/Lean/Compiler/LCNF/Simp/Main.lean
@@ -187,7 +187,9 @@ partial def simpCasesOnCtor? (cases : Cases .pure) : SimpM (Option (Code .pure))
     return some ret
   | .fvar discr =>
     let some ctorInfo ← findCtor? discr | return none
-    unless (← getType discr).isAppOf cases.typeName do return none
+    let some (.ctorInfo ctorVal) := (← getEnv).find? ctorInfo.getName | return none
+    unless cases.typeName == ctorVal.induct do
+      return none
     let (alt, cases) := cases.extractAlt! ctorInfo.getName
     eraseCode (.cases cases)
     markSimplified


### PR DESCRIPTION
This PR fixes an issue in LCNF simp where it would attempt to act on type incorrect `cases`
statements and look for a branch, otherwise panic. This issue did not yet manifest in production as
various other invariants upheld by LCNF simp help mask it but will start to become an issue with the
upcoming changes.

This is the proper fix for #6957.
