### PR TITLE
chore: make `simpCond` public

### DIFF
--- a/src/Lean/Meta/Sym/Simp/ControlFlow.lean
+++ b/src/Lean/Meta/Sym/Simp/ControlFlow.lean
@@ -85,7 +85,7 @@ def simpDIte : Simproc := fun e => do
 /--
 Simplifies a `cond` expression (aka Boolean `if-then-else`).
 -/
-def simpCond : Simproc := fun e => do
+public def simpCond : Simproc := fun e => do
   let numArgs := e.getAppNumArgs
   if numArgs < 4 then return .rfl (done := true)
   propagateOverApplied e (numArgs - 4) fun e => do


### PR DESCRIPTION
This PR makes `simpCond` public. It is needed to avoid code duplication in #12361