### PR TITLE
feat: add pretty printer flag to instantiate non-ground delayed assignments

### DIFF
--- a/src/Lean/PrettyPrinter/Delaborator/Builtins.lean
+++ b/src/Lean/PrettyPrinter/Delaborator/Builtins.lean
@@ -568,7 +568,14 @@ def delabDelayedAssignedMVar : Delab := whenNotPPOption getPPMVarsDelayed do
     let args := (← getExpr).getAppArgs
     -- Only delaborate using decl.mvarIdPending if the delayed mvar is applied to fvars
     guard <| args.all Expr.isFVar
-    delabMVarAux decl.mvarIdPending
+    if ← getPPOption getPPMVarsDelayedNonGround then
+      if let some e ← getExprMVarAssignment? decl.mvarIdPending then
+        decl.mvarIdPending.withContext do
+        withTheReader SubExpr (fun cfg => { cfg with expr := e }) delab
+      else
+        delabMVarAux decl.mvarIdPending
+    else
+      delabMVarAux decl.mvarIdPending
 
 private partial def collectStructFields
     (structName : Name) (levels : List Level) (params : Array Expr)

--- a/src/Lean/PrettyPrinter/Delaborator/Options.lean
+++ b/src/Lean/PrettyPrinter/Delaborator/Options.lean
@@ -126,6 +126,10 @@ register_builtin_option pp.mvars.delayed : Bool := {
   defValue := false
   descr    := "(pretty printer) display delayed assigned metavariables when true, otherwise display what they are assigned to"
 }
+register_builtin_option pp.mvars.delayedNonGround : Bool := {
+  defValue := false
+  descr    := "(pretty printer) when 'pp.mvars.delayed' is false and a delayed assigned metavariable has a non-ground assignment, pretty-print that assignment instead of the metavariable."
+}
 register_builtin_option pp.beta : Bool := {
   defValue := false
   descr    := "(pretty printer) apply beta-reduction when pretty printing"
@@ -266,6 +270,7 @@ def getPPMVarsAnonymous (o : Options) : Bool := o.get pp.mvars.anonymous.name (p
 def getPPMVarsLevels (o : Options) : Bool := o.get pp.mvars.levels.name (pp.mvars.levels.defValue && getPPMVarsAnonymous o)
 def getPPMVarsWithType (o : Options) : Bool := o.get pp.mvars.withType.name pp.mvars.withType.defValue
 def getPPMVarsDelayed (o : Options) : Bool := o.get pp.mvars.delayed.name (pp.mvars.delayed.defValue || getPPAll o)
+def getPPMVarsDelayedNonGround (o : Options) : Bool := o.get pp.mvars.delayedNonGround.name pp.mvars.delayedNonGround.defValue
 def getPPBeta (o : Options) : Bool := o.get pp.beta.name pp.beta.defValue
 def getPPSafeShadowing (o : Options) : Bool := o.get pp.safeShadowing.name pp.safeShadowing.defValue
 def getPPProofs (o : Options) : Bool := o.get pp.proofs.name (pp.proofs.defValue || getPPAll o)

--- a/tests/lean/run/ppDelayedNonGround.lean
+++ b/tests/lean/run/ppDelayedNonGround.lean
@@ -1,0 +1,81 @@
+/-!
+This test case tests the flag `pp.mvars.delayedNonGround`.
+It is an extract of the test cases `funParen.lean`, `4144.lean`, `match1.lean` and
+`anonymous_constructor_error_msg.lean`, the output of which differs when the flag is on.
+By default it is off, so as long as that is the case we should keep this test case.
+
+Note that the difference in output is simply that more metavariables show up as `sorry` instead
+of random synthetic opaque metavariables (with `pp.mvars.delayed` set to true) or their
+randomly named root synthetic opaque metavariables (with `pp.mvars.delayed` set to false).
+Witness by setting the flag below to `false`.
+-/
+
+set_option pp.mvars.delayedNonGround true
+
+/--
+error: Invalid match expression: The type of pattern variable 'a' contains metavariables:
+  ?m.12
+---
+info: fun x => sorry : ?m.12 × ?m.13 → ?m.12
+-/
+#guard_msgs in
+#check fun (a, b) => a
+
+/--
+error: Invalid pattern: Expected a constructor or constant marked with `[match_pattern]`
+---
+info: fun x => sorry : (x : ?m.1) → ?m.4 x
+-/
+#guard_msgs in
+#check fun (x id) => x
+
+/--
+error: Invalid projection: Type of
+  x✝
+is not known; cannot resolve projection `1`
+---
+error: unsolved goals
+case refine'_1
+⊢ Sort ?u.104
+
+case refine'_2
+⊢ Sort ?u.103
+
+case refine'_3
+⊢ ?refine'_1
+
+case refine'_4
+⊢ ?refine'_1
+
+case refine'_5
+⊢ ¬(fun x => sorry) ?refine'_3 = (fun x => sorry) ?refine'_4
+-/
+#guard_msgs in
+example : False := by
+  refine' absurd (congrArg (·.1) sorry) _
+
+structure Foo := (n : Nat)
+
+def Foo.sum (xs : List Foo) : Foo :=
+xs.foldl (λ s x => ⟨s.n + x.n⟩) ⟨0⟩
+
+/--
+error: Invalid `⟨...⟩` notation: The expected type of this term could not be determined
+---
+info: let x1 := { n := 1 };
+let x2 := { n := 2 };
+let x3 := { n := 3 };
+let x4 := sorry;
+let x5 := { n := 5 };
+let x6 := { n := 6 };
+Foo.sum [x1, x2, x3, x5, x6] : Foo
+-/
+#guard_msgs in
+#check
+let x1 := ⟨1⟩
+let x2 := ⟨2⟩
+let x3 := ⟨3⟩
+let x4 := ⟨4⟩; -- If this line is uncommented we get the error at `⟨`
+let x5 := ⟨5⟩
+let x6 := ⟨6⟩
+Foo.sum [x1, x2, x3, x5, x6]


### PR DESCRIPTION
This PR adds an opt-in pretty printing flag `pp.mvars.delayedNonGround` that takes effect when `pp.mvars.delayed` is false.
Recall that `instantiateMVars` does not instantiate a delayed assigned MVar if the assignment is non-ground (i.e., contains metavariables itself). This flag opts into doing the instantiation while pretty printing. Example:

```lean
set_option pp.mvars.delayedNonGround false in -- the default
/--
error: Invalid match expression: The type of pattern variable 'a' contains metavariables:
  ?m.12
---
info: fun x => ?m.3 : ?m.12 × ?m.13 → ?m.12
-/
#guard_msgs in
#check fun (a, b) => a

set_option pp.mvars.delayedNonGround true in -- opt in
/--
error: Invalid match expression: The type of pattern variable 'a' contains metavariables:
  ?m.12
---
info: fun x => sorry : ?m.12 × ?m.13 → ?m.12
-/
#guard_msgs in
#check fun (a, b) => a
```

This flag is most useful for debugging metaprograms that create synthetic opaque metavariables and assign those to non-ground solutions. It happens regularly that incomplete instantiation leads debugging sessions down the wrong path.