### PR TITLE
perf: always zeta reduce let expressions in `cbv`

### DIFF
--- a/src/Lean/Meta/Tactic/Cbv/Main.lean
+++ b/src/Lean/Meta/Tactic/Cbv/Main.lean
@@ -145,7 +145,7 @@ def cbvPre : Simproc :=
       isBuiltinValue <|> isProofTerm <|> skipBinders
   >>  isOpaqueApp
   >>  simpControlCbv
-    <|> ((isOpaqueConst >> handleConst) <|> simplifyAppFn <|> handleProj)
+    <|> ((isOpaqueConst >> handleConst) <|> simplifyAppFn <|> handleProj) <|> zetaReduce
 
 def cbvPost : Simproc :=
       evalGround


### PR DESCRIPTION
This PR adds zeta reduction simproc to the pre step of `cbv`.