### PR TITLE
chore: revert reducibility change to HasSSubset for now

### DIFF
--- a/src/Init/Core.lean
+++ b/src/Init/Core.lean
@@ -509,8 +509,6 @@ class HasSSubset (α : Type u) where
   SSubset : α → α → Prop
 export HasSSubset (SSubset)
 
-attribute [reducible] HasSSubset.SSubset
-
 /-- Superset relation: `a ⊇ b`  -/
 abbrev Superset [HasSubset α] (a b : α) := Subset b a
 


### PR DESCRIPTION
This PR reverts `attribute [reducible] HasSSubset.SSubset` from #12368, as it is not immediately needed, and causes breakages in Mathlib.