### PR TITLE
doc: add test suite documentation to .claude/CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,29 @@
 To build Lean you should use `make -j -C build/release`.
 
-To run a test you should use `cd tests/lean/run && ./test_single.sh example_test.lean`.
+## Running Tests
+
+See `doc/dev/testing.md` for full documentation. Quick reference:
+
+```bash
+# Full test suite (use after builds to verify correctness)
+make -j -C build/release test ARGS="-j$(nproc)"
+
+# Specific test by name (supports regex via ctest -R)
+make -j -C build/release test ARGS='-R grind_ematch --output-on-failure'
+
+# Rerun only previously failed tests
+make -j -C build/release test ARGS='--rerun-failed --output-on-failure'
+
+# Single test from tests/lean/run/ (quick check during development)
+cd tests/lean/run && ./test_single.sh example_test.lean
+
+# ctest directly (from stage1 build dir)
+cd build/release/stage1 && ctest -j$(nproc) --output-on-failure --timeout 300
+```
+
+The full test suite includes `tests/lean/`, `tests/lean/run/`, `tests/lean/interactive/`,
+`tests/compiler/`, `tests/pkg/`, Lake tests, and more. Using `make test` or `ctest` runs
+all of them; `test_single.sh` in `tests/lean/run/` only covers that one directory.
 
 ## New features
 


### PR DESCRIPTION
This PR adds comprehensive test running instructions to `.claude/CLAUDE.md`,
replacing the single `test_single.sh` example with the full range of test
commands documented in `doc/dev/testing.md`: full suite, filtered by name,
rerun failures, and direct ctest usage.

🤖 Prepared with Claude Code