### PR TITLE
refactor: remove unnecessary use of `constNames` in `LazyDiscrTree`

### DIFF
--- a/src/Lean/Meta/LazyDiscrTree.lean
+++ b/src/Lean/Meta/LazyDiscrTree.lean
@@ -896,10 +896,9 @@ partial def loadImportedModule
     (mname : Name)
     (mdata : ModuleData)
     (i : Nat := 0) : BaseIO (PreDiscrTree α) := do
-  if h : i < mdata.constNames.size then
-    let name := mdata.constNames[i]
-    let constInfo  := mdata.constants[i]!
-    let tree ← addConstImportData cctx env mname d cacheRef tree act name constInfo
+  if h : i < mdata.constants.size then
+    let constInfo  := mdata.constants[i]
+    let tree ← addConstImportData cctx env mname d cacheRef tree act constInfo.name constInfo
     loadImportedModule cctx env act d cacheRef tree mname mdata (i+1)
   else
     pure tree


### PR DESCRIPTION
This PR bounds-checks `constants.size` directly instead of `constNames.size` in `LazyDiscrTree.loadImportedModule`, eliminating the unsafe `constants[i]!` access and the intermediate `constNames[i]` lookup. The constant name is obtained from `constInfo.name` instead.

🤖 Prepared with Claude Code