### PR TITLE
fix: mvcgen support for match splitting on excess state args

### DIFF
--- a/tests/lean/run/mvcgenSplitState.lean
+++ b/tests/lean/run/mvcgenSplitState.lean
@@ -1,0 +1,27 @@
+import Std.Tactic.Do
+
+open Std.Do
+
+/-!
+Tests that `mvcgen` is able to split the goal
+```
+⊢ₛ
+wp⟦match s with
+    | none => pure 0
+    | some x => pure x⟧
+  (PostCond.noThrow fun x => ⌜True⌝) s
+```
+Note that `s` is an excess state variable that does not only occur in the program, but also in the
+application of the predicate transformer.
+-/
+
+set_option mvcgen.warning false in
+example :
+  ⦃⌜True⌝⦄
+  (do
+    let s ← get (m := StateM (Option Nat))
+    match s with
+    | none => pure 0
+    | some x => pure x)
+  ⦃⇓_ => ⌜True⌝⦄ := by
+  mvcgen


### PR DESCRIPTION
This PR fixes a bug in `mvcgen` caused by incomplete `match` splitting. 

In particular, if a program `match s with ...` matches on a state variable `s` (presumably the result of a call to `get`), then `s` will also occur in the stateful goal `H ⊢ₛ wp⟦match s with ...⟧ Q s` *outside* the program expression; this was not anticipated before.
