### PR TITLE
feat: add lemma `Acc.inv_of_transGen`

### DIFF
--- a/src/Init/WF.lean
+++ b/src/Init/WF.lean
@@ -209,7 +209,7 @@ theorem acc_transGen_iff : Acc (TransGen r) a ↔ Acc r a :=
 /--
 If `Acc r x` holds and `y` is transitively related to `x`, then `Acc r y` holds, too.
 -/
-theorem Acc.invTransGen {x y : α} (h₁ : Acc r x) (h₂ : Relation.TransGen r y x) : Acc r y := by
+theorem Acc.inv_of_transGen {x y : α} (h₁ : Acc r x) (h₂ : Relation.TransGen r y x) : Acc r y := by
   simpa [acc_transGen_iff] using h₁.transGen.inv h₂
 
 theorem WellFounded.transGen (h : WellFounded r) : WellFounded (TransGen r) :=


### PR DESCRIPTION
This PR adds the lemma `Acc.inv_of_transGen`, a generalization of `Acc.inv`. While `Acc.inv` shows that `Acc r x` implies `Acc r y` given that `r y x`, the new lemma shows that this also holds if `y` is only *transitively* related to `x`.