### PR TITLE
chore: make proof for `Char.toUpper` easier to typecheck

### DIFF
--- a/src/Init/Data/Char/Basic.lean
+++ b/src/Init/Data/Char/Basic.lean
@@ -168,6 +168,8 @@ def toUpper (c : Char) : Char :=
   else
     c
 where finally
+  -- This expression is a ground non-value; generalize for better
+  -- control on where it is evaluated.
   generalize hx : 'A'.val - 'a'.val = x
   have h₁ : 2^32 ≤ c.val.toNat + x.toNat :=
     @Nat.add_le_add 'a'.val.toNat _ (2^32 - 'a'.val.toNat) _ h.1 (by rw [← hx]; decide)


### PR DESCRIPTION
This PR changes the proof for `Char.toUpper` to make it easier to typecheck for external checkers (nanoda in particular).