### PR TITLE
refactor: don't use shared_timed_mutex when not required anymore

### DIFF
--- a/src/runtime/mutex.cpp
+++ b/src/runtime/mutex.cpp
@@ -101,20 +101,18 @@ extern "C" LEAN_EXPORT obj_res lean_io_baserecmutex_unlock(b_obj_arg mtx) {
     return box(0);
 }
 
-// We use a `shared_timed_mutex` instead of a `shared_mutex` for now as the latter is only available
-// in C++ 17 and we are currently on C++ 14.
 static lean_external_class * g_basesharedmutex_external_class = nullptr;
 static void basesharedmutex_finalizer(void * h) {
-    delete static_cast<shared_timed_mutex *>(h);
+    delete static_cast<shared_mutex *>(h);
 }
 static void basesharedmutex_foreach(void *, b_obj_arg) {}
 
-static shared_timed_mutex * basesharedmutex_get(lean_object * mtx) {
-    return static_cast<shared_timed_mutex *>(lean_get_external_data(mtx));
+static shared_mutex * basesharedmutex_get(lean_object * mtx) {
+    return static_cast<shared_mutex *>(lean_get_external_data(mtx));
 }
 
 extern "C" LEAN_EXPORT obj_res lean_io_basesharedmutex_new() {
-    return lean_alloc_external(g_basesharedmutex_external_class, new shared_timed_mutex);
+    return lean_alloc_external(g_basesharedmutex_external_class, new shared_mutex);
 }
 
 extern "C" LEAN_EXPORT obj_res lean_io_basesharedmutex_write(b_obj_arg mtx) {

--- a/src/runtime/thread.h
+++ b/src/runtime/thread.h
@@ -30,7 +30,7 @@ namespace lean {
 using std::thread;
 using std::mutex;
 using std::recursive_mutex;
-using std::shared_timed_mutex;
+using std::shared_mutex;
 using std::atomic;
 using std::atomic_bool;
 using std::atomic_ushort;
@@ -156,7 +156,7 @@ public:
     bool try_lock() { return true; }
     void unlock() {}
 };
-class shared_timed_mutex {
+class shared_mutex {
 public:
     void lock() {}
     bool try_lock() { return true; }


### PR DESCRIPTION
This PR removes the uses of `shared_timed_mutex` that were introduced because we were stuck on C++14
with the `shared_mutex` available from C++17 and above.
