### PR TITLE
refactor: use `eq_unfold` instead of `eq_def` in `cbv`

### DIFF
--- a/src/Lean/Meta/Sym/Simp/Main.lean
+++ b/src/Lean/Meta/Sym/Simp/Main.lean
@@ -35,6 +35,7 @@ abbrev cacheResult (e : Expr) (r : Result) : SimpM Result := do
 
 @[export lean_sym_simp]
 def simpImpl (e₁ : Expr) : SimpM Result := withIncRecDepth do
+  trace[Meta.Tactic] "Looking at {e₁}"
   let numSteps := (← get).numSteps
   if numSteps >= (← getConfig).maxSteps then
     throwError "`simp` failed: maximum number of steps exceeded"

--- a/src/Lean/Meta/Tactic/Cbv/TheoremsLookup.lean
+++ b/src/Lean/Meta/Tactic/Cbv/TheoremsLookup.lean
@@ -57,7 +57,8 @@ public def getUnfoldTheorem (fnName : Name) : MetaM (Option Theorem) := do
   if let some thm := cache.unfoldTheorems.find? fnName then
     return some thm
   else
-    let some unfoldEqn ← getConstUnfoldEqnFor? fnName | return none
+    let some unfoldEqn ← getUnfoldEqnFor? fnName (nonRec := true) | return none
+    --let some unfoldEqn ← getConstUnfoldEqnFor? fnName | return none
     let thm ← mkTheoremFromDecl unfoldEqn
 
     modifyEnv fun env =>

--- a/tests/lean/run/cbv1.lean
+++ b/tests/lean/run/cbv1.lean
@@ -172,12 +172,20 @@ example : Nat.brazilianFactorial 7 = 125411328000 := by
     lhs
     cbv
 
+--set_option trace.Meta.Tactic true
+example : ((Std.DHashMap.emptyWithCapacity : Std.DHashMap Nat (fun _ => Nat)).insert 5 3).contains 5 = true := by
+  conv =>
+    lhs
+    cbv
+
 attribute [cbv_opaque] Std.DHashMap.emptyWithCapacity
 attribute [cbv_opaque] Std.DHashMap.insert
 attribute [cbv_opaque] Std.DHashMap.getEntry
 attribute [cbv_opaque] Std.DHashMap.contains
 attribute [cbv_eval Std.DHashMap.contains] Std.DHashMap.contains_emptyWithCapacity
 attribute [cbv_eval Std.DHashMap.contains] Std.DHashMap.contains_insert
+
+#check System.Platform.numBits.eq_def
 
 example : ((Std.DHashMap.emptyWithCapacity : Std.DHashMap Nat (fun _ => Nat)).insert 5 3).contains 5 = true := by
   conv =>


### PR DESCRIPTION
This PR changes the behaviour of `getUnfoldTheorem` to rely on `eq_unfold` instead of `eq_def`. If a constant has an exposed `eq_unfold`, then the simproc trying to unfold it will always succeed.