### PR TITLE
chore: refactor match elaborator to be used from the do elaborator

### DIFF
--- a/src/Lean/Elab/Binders.lean
+++ b/src/Lean/Elab/Binders.lean
@@ -574,7 +574,7 @@ private def checkMatchAltPatternCounts (matchAlts : Syntax) (numDiscrs : Nat) (e
   let sepPats (pats : List Syntax) := MessageData.joinSep (pats.map toMessageData) ", "
   let maxDiscrs? ← forallTelescopeReducing expectedType fun xs e =>
     if e.getAppFn.isMVar then pure none else pure (some xs.size)
-  let matchAltViews := matchAlts[0].getArgs.filterMap getMatchAlt
+  let matchAltViews := matchAlts[0].getArgs.filterMap (getMatchAlt `term)
   let numPatternsStr (n : Nat) := s!"{n} {if n == 1 then "pattern" else "patterns"}"
   if h : matchAltViews.size > 0 then
     if let some maxDiscrs := maxDiscrs? then

--- a/src/Lean/Elab/MatchAltView.lean
+++ b/src/Lean/Elab/MatchAltView.lean
@@ -21,11 +21,11 @@ def «match» := leading_parser:leadPrec "match " >> sepBy1 matchDiscr ", " >> o
 ```
 -/
 
-structure MatchAltView where
+structure MatchAltView (k : SyntaxNodeKinds) where
   ref      : Syntax
   patterns : Array Syntax
   lhs      : Syntax
-  rhs      : Syntax
+  rhs      : TSyntax k
   deriving Inhabited
 
 end Lean.Elab.Term

--- a/src/Lean/Elab/PatternVar.lean
+++ b/src/Lean/Elab/PatternVar.lean
@@ -415,7 +415,7 @@ where
       else
         throwCtorExpected (some fId)
 
-def main (alt : MatchAltView) : M MatchAltView := do
+def main (alt : MatchAltView k) : M (MatchAltView k) := do
   let patterns ← alt.patterns.mapM fun p => do
     trace[Elab.match] "collecting variables at pattern: {p}"
     collect p
@@ -427,7 +427,7 @@ end CollectPatternVars
 Collect pattern variables occurring in the `match`-alternative object views.
 It also returns the updated views.
 -/
-def collectPatternVars (alt : MatchAltView) : TermElabM (Array PatternVar × MatchAltView) := do
+def collectPatternVars (alt : MatchAltView k) : TermElabM (Array PatternVar × MatchAltView k) := do
   let (alt, s) ← (CollectPatternVars.main alt).run {}
   return (s.vars, alt)
 


### PR DESCRIPTION
This PR provides the necessary hooks for the new do elaborator to call into the let and match elaborator.

The `do match` elaborator needs access to a couple of functions from the term `match` elaborator to implement its own `elabMatchAlt`. In particular, `withEqs`, `withPatternVars` and `checkNumPatterns` need to be exposed. Furthermore, I think it makes sense to share `instantiateAltLHSs`.
