### PR TITLE
chore: mitigate noncomputable section issues in the code generator

### DIFF
--- a/src/Lean/Compiler/LCNF/InferBorrow.lean
+++ b/src/Lean/Compiler/LCNF/InferBorrow.lean
@@ -213,7 +213,7 @@ where
     | some ps => return ps
     | none =>
       let .decl fn := k | unreachable!
-      let some sig ← getImpureSignature? fn | unreachable!
+      let some sig ← getImpureSignature? fn | throwError "Failed to find LCNF signature for {fn}"
       return sig.params
 
   /-- For each ps[i], if ps[i] is owned, then mark args[i] as owned. -/


### PR DESCRIPTION
This is a mitigation for the fact that the upfront noncomputable checker currently doesn't error out early enough in certain situations so we violate invariants later on.