### PR TITLE
fix: handle 0 sized reads from handles correctly

### DIFF
--- a/src/runtime/io.cpp
+++ b/src/runtime/io.cpp
@@ -584,6 +584,10 @@ extern "C" LEAN_EXPORT obj_res lean_io_prim_handle_truncate(b_obj_arg h) {
 extern "C" LEAN_EXPORT obj_res lean_io_prim_handle_read(b_obj_arg h, usize nbytes) {
     FILE * fp = io_get_handle(h);
     obj_res res = lean_alloc_sarray(1, 0, nbytes);
+    if (nbytes == 0) {
+        // std::fread doesn't handle 0 reads well, see https://github.com/leanprover/lean4/issues/12138
+        return io_result_mk_ok(res);
+    }
     usize n = std::fread(lean_sarray_cptr(res), 1, nbytes, fp);
     if (n > 0) {
         lean_sarray_set_size(res, n);

--- a/tests/lean/run/12138.lean
+++ b/tests/lean/run/12138.lean
@@ -1,0 +1,15 @@
+module
+
+/-!
+This test asserts that upon reading 0 bytes from a handle we return an empty array instead of
+handling return codes from std::fread in a wrong fashion.
+-/
+
+def main : IO Unit := do
+  let stream ← IO.getStdin
+  let values ← stream.read 0
+  IO.println s!"values: {values.size}"
+
+/-- info: values: 0 -/
+#guard_msgs in
+#eval main


### PR DESCRIPTION
This PR handles zero-sized reads on handles correctly by returning an empty array before the syscall
is even attempted.

Closes: #12138
