### PR TITLE
fix: inherit correct docstring

### DIFF
--- a/src/Std/Data/HashMap/Basic.lean
+++ b/src/Std/Data/HashMap/Basic.lean
@@ -284,7 +284,7 @@ instance [BEq α] [Hashable α] : Inter (HashMap α β) := ⟨inter⟩
 
 instance [BEq α] [BEq β] : BEq (HashMap α β) := ⟨beq⟩
 
-@[inherit_doc DHashMap.inter, inline] def diff [BEq α] [Hashable α] (m₁ m₂ : HashMap α β) : HashMap α β :=
+@[inherit_doc DHashMap.diff, inline] def diff [BEq α] [Hashable α] (m₁ m₂ : HashMap α β) : HashMap α β :=
   ⟨DHashMap.diff m₁.inner m₂.inner⟩
 
 instance [BEq α] [Hashable α] : SDiff (HashMap α β) := ⟨diff⟩


### PR DESCRIPTION
This PR fixes the docstring of `HashMap.diff`.