### PR TITLE
fix: handle delayed mvar assignments in `grind` when hypotheses contain mvars

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/Internalize.lean
+++ b/src/Lean/Meta/Tactic/Grind/Internalize.lean
@@ -590,8 +590,6 @@ where
       mkENode e generation
       activateTheorems declName generation
     | .mvar .. =>
-      if (← reportMVarInternalization) then
-        reportIssue! "unexpected metavariable during internalization{indentExpr e}\n`grind` is not supposed to be used in goals containing metavariables."
       mkENode' e generation
     | .mdata .. =>
       reportIssue! "unexpected metadata found during internalization{indentExpr e}\n`grind` uses a pre-processing step that eliminates metadata"

--- a/src/Lean/Meta/Tactic/Grind/Main.lean
+++ b/src/Lean/Meta/Tactic/Grind/Main.lean
@@ -305,13 +305,56 @@ def main (mvarId : MVarId) (params : Params) : MetaM Result := do profileitM Exc
     mkResult params failure?
 
 /--
-A helper combinator for executing a `grind`-based terminal tactic.
-Given an input goal `mvarId`, it first abstracts meta-variables, cleans up local hypotheses
-corresponding to internal details, creates an auxiliary meta-variable `mvarId'`, and executes `k mvarId'`.
-The execution is performed in a new meta-variable context depth to ensure that universe meta-variables
-cannot be accidentally assigned by `grind`. If `k` fails, it admits the input goal.
+Resolves delayed metavariable assignments created inside the current `withNewMCtxDepth` block.
+`instantiateMVars` only resolves a delayed assignment `?m #[xs] := ?pending` when `?pending`'s
+assignment is ground (no unassigned expression metavariables). This ground restriction exists
+because `val` may contain metavariables that have `fvars` in their scope. For example, if
+`fvars = #[x]` and `val = ?m + x` where `x` is in the scope of `?m`, then `mkLambda` creates
+`fun x => ?m + x`. If `?m` is later assigned to `f x`, the term becomes ill-formed with a
+dangling free variable.
 
-See issue #11806 for a motivating example.
+This scenario cannot occur here: metavariables created before `withNewMCtxDepth` cannot contain
+free variables created by `grind`, so the conversion is safe. Only metavariables at the current
+depth are processed; pre-existing delayed assignments are left untouched as they are meant to
+be resolved by other tactics.
+
+We do not need to erase the delayed assignments from `dAssignment` because they will be
+discarded when `withNewMCtxDepth` restores the metavariable context.
+-/
+private partial def resolveDelayedMVarAssignments (e : Expr) : MetaM Expr := do
+  if !e.hasMVar then return e
+  let e ← go e
+  -- Ensure no metavariables at the current depth remain. They would become
+  -- dangling references after `withNewMCtxDepth` restores the metavariable context.
+  let mctx ← getMCtx
+  for mvarId in (e.collectMVars {}).result do
+    if let some decl := mctx.findDecl? mvarId then
+      if decl.depth == mctx.depth then
+        throwError "`grind` failed, proof contains unresolved internal metavariable {Expr.mvar mvarId}"
+  return e
+where
+  go (e : Expr) : MetaM Expr := do
+    let mctx ← getMCtx
+    let mvars := (e.collectMVars {}).result
+    for mvarId in mvars do
+      if let some decl := mctx.findDecl? mvarId then
+        if decl.depth == mctx.depth then
+          if let some { fvars, mvarIdPending } ← getDelayedMVarAssignment? mvarId then
+            if let some val ← getExprMVarAssignment? mvarIdPending then
+              let pendingDecl ← mvarIdPending.getDecl
+              let val ← go (← instantiateMVars val)
+              mvarId.assign (pendingDecl.lctx.mkLambda fvars val)
+    instantiateMVars e
+
+/--
+A helper combinator for executing a `grind`-based terminal tactic.
+Given an input goal `mvarId`, it cleans up local hypotheses corresponding to internal details,
+creates an auxiliary meta-variable `mvarId'`, and executes `k mvarId'`.
+`withNewMCtxDepth` is used to prevent metavariables from being accidentally assigned by
+`grind`'s `isDefEq` calls. After `grind` finishes, delayed metavariable assignments are
+resolved, and the resulting proof is assigned to the original goal.
+
+See issue #11806 and issue #12242 for motivating examples.
 -/
 def withProtectedMCtx [Monad m] [MonadControlT MetaM m] [MonadLiftT MetaM m]
     [MonadExcept Exception m] [MonadRuntimeException m]
@@ -321,13 +364,6 @@ def withProtectedMCtx [Monad m] [MonadControlT MetaM m] [MonadLiftT MetaM m]
   This is particularly important when using `grind -revert`.
   -/
   let mut mvarId ← mvarId.instantiateGoalMVars
-  /-
-  **TODO**: It would be nice to remove the following step, but
-  some tests break with unknown metavariable error when this
-  step is removed. The main issue is the `withNewMCtxDepth` step at
-  `main`.
-  -/
-  mvarId ← mvarId.abstractMVars
   if config.revert then
     /-
     **Note**: We now skip implementation details at `addHypotheses`
@@ -343,6 +379,7 @@ where
       let mvar' ← mkFreshExprSyntheticOpaqueMVar type
       let a ← k mvar'.mvarId!
       let val ← instantiateMVarsProfiling mvar'
+      let val ← resolveDelayedMVarAssignments val
       return (a, val)
     let val ← finalize val
     (mvarId.assign val : MetaM _)

--- a/tests/lean/run/grind_mvar_hyps.lean
+++ b/tests/lean/run/grind_mvar_hyps.lean
@@ -1,0 +1,47 @@
+/-!
+# Issue #12242: grind fails when hypotheses contain metavariables
+
+When `refine` introduces metavariables that appear in both hypotheses and the target,
+`grind` should be able to close the goal. Previously, `abstractMVars` only abstracted
+metavariables in the target, creating a disconnect between the target (using an fvar)
+and hypotheses (still using the mvar).
+-/
+
+-- Original example from the issue
+theorem grind_mvar_fail_2 (a res : Int) :
+    ∃ x : Int,
+      (a = x) →
+      (x = res) →
+      (x = res) := by
+  refine ⟨?_, ?_⟩
+  rotate_left
+  intro h h2
+  grind
+  repeat constructor
+
+-- Simpler version: mvar in hypothesis directly proves goal
+theorem grind_mvar_simple (a : Nat) :
+    ∃ x : Nat, (x = a) → (x = a) := by
+  refine ⟨?_, ?_⟩
+  rotate_left
+  intro h
+  grind
+  exact a
+
+-- Multiple hypotheses sharing the same mvar
+theorem grind_mvar_chain (a b c : Nat) :
+    ∃ x : Nat, (a = x) → (x = b) → (a = b) := by
+  refine ⟨?_, ?_⟩
+  rotate_left
+  intro h1 h2
+  grind
+  exact a
+
+-- Mvar in a more complex expression
+theorem grind_mvar_complex (a b : Int) :
+    ∃ x : Int, (a = x) → (x = b) → (a = b) := by
+  refine ⟨?_, ?_⟩
+  rotate_left
+  intro h1 h2
+  grind
+  exact a


### PR DESCRIPTION
This PR fixes `grind` failing when hypotheses contain metavariables (e.g., after `refine`). The root cause was that `abstractMVars` in `withProtectedMCtx` only abstracted metavariables in the target, not in hypotheses, creating a disconnect in grind's e-graph.

The fix removes `abstractMVars` and instead resolves delayed metavariable assignments before exiting `withNewMCtxDepth`. `instantiateMVars` refuses to resolve a delayed assignment when the pending assignment is non-ground (contains unassigned expression metavariables). This function converts such delayed assignments to regular ones using `LocalContext.mkLambda`, allowing `instantiateMVars` to resolve them via beta reduction. The mvar internalization warning is also removed since grind now handles mvars.

Closes #12242
