### PR TITLE
doc: expand docstring for @[univ_out_params]

### DIFF
--- a/src/Init/Notation.lean
+++ b/src/Init/Notation.lean
@@ -662,7 +662,12 @@ occur in any input parameter type is an output parameter.
 
 ### Effect on typeclass resolution
 
-Universe output parameters are erased from typeclass resolution cache keys.
+When typeclass resolution begins, output universe parameters are replaced with fresh universe
+metavariables, similar to what is done for regular output parameters. This means the search
+proceeds without being constrained by the specific output universes in the query, and the
+actual output universes are determined by the instance that is found.
+
+As a consequence, output universe parameters are erased from typeclass resolution cache keys.
 Two queries that differ only in output universe parameters will share a cache entry,
 and the first result found will be reused for subsequent queries.
 


### PR DESCRIPTION
This PR expands the docstring for `@[univ_out_params]` to explain:

- How universe output parameters affect the typeclass resolution cache (they are erased from cache keys, so queries differing only in output universes share entries)
- When a universe parameter should be considered an output (determined by inputs) vs. not (part of the question being asked)

This came up while adapting Mathlib for lean4#12286 and lean4#12423. We needed `@[univ_out_params]` on ~19 classes (`Category`, `HasLimitsOfSize`, `PreservesLimitsOfSize`, `Functor.IsContinuous`, `UCompactlyGeneratedSpace`, etc.)

🤖 Prepared with Claude Code