### PR TITLE
fix: double optional in `binder_predicate` syntax

### DIFF
--- a/src/Lean/Parser/Syntax.lean
+++ b/src/Lean/Parser/Syntax.lean
@@ -135,7 +135,7 @@ binder_predicate x " > " y:term => `($x > $y)
 ```
 -/
 @[builtin_command_parser] def binderPredicate := leading_parser
-   optional docComment >>  optional Term.attributes >> Term.attrKind >>
+   optional docComment >> optional Term.attributes >> Term.attrKind >>
    "binder_predicate" >> optNamedName >> optNamedPrio >> ppSpace >> ident >> many (ppSpace >> macroArg) >> " => " >> termParser
 
 end Command


### PR DESCRIPTION
This PR fixes the parser for the `binder_predicate` command. `Term.attrKind` is already an `optional` so `optional Term.attrKind` doesn't behave any different than just `Term.attrKind` except antiquotation handling and the first token list. Because of this, previously, just writing `?` in a Lean file resulted in the confusing error message `unexpected token '?'; expected 'binder_predicate'`. After this PR, the error message is back to `unexpected token '?'; expected command`. This has been discovered in the context of leanprover-community/batteries#1672 where the `binder_predicate` command started showing up as
```
syntax "?"...[Lean.Parser.Command.binderPredicate]
```