### PR TITLE
test: share benchmark driver for Sym mvcgen; don't measure unfolding

### DIFF
--- a/tests/bench/mvcgen/sym/baseline_add_sub_cancel.lean
+++ b/tests/bench/mvcgen/sym/baseline_add_sub_cancel.lean
@@ -1,36 +1,25 @@
-import SymDirectly
+import Baseline
 import Lean
+import Driver
 
 open Lean Meta Sym
 
-/-- Helper function for executing a tactic `k` for solving `Goal n`. -/
-def driver (n : Nat) (check := true) (k : MVarId → MetaM Unit) : MetaM Unit := do
-  let some goal ← unfoldDefinition? (mkApp (mkConst ``Goal) (mkNatLit n)) | throwError "UNFOLD FAILED!"
-  let mvar ← mkFreshExprMVar goal
-  let startTime ← IO.monoNanosNow
-  k mvar.mvarId!
-  let endTime ← IO.monoNanosNow
-  let ms := (endTime - startTime).toFloat / 1000000.0
-  if check then
-    let startTime ← IO.monoNanosNow
-    checkWithKernel (← instantiateExprMVars mvar)
-    let endTime ← IO.monoNanosNow
-    let kernelMs := (endTime - startTime).toFloat / 1000000.0
-    IO.println s!"goal_{n}: {ms} ms, kernel: {kernelMs} ms"
-  else
-    IO.println s!"goal_{n}: {ms} ms"
+def step (v : Nat) : StateM Nat Unit := do
+  let s ← get
+  set (s + v)
+  let s ← get
+  set (s - v)
 
-def solveUsingSym (n : Nat) (check := true) : MetaM Unit := do
-  driver n check fun mvarId => SymM.run do solve mvarId
+def loop (n : Nat) : StateM Nat Unit := do
+  match n with
+  | 0 => pure ()
+  | n+1 => step n; loop n
 
-def runBenchUsingSym : MetaM Unit := do
-  IO.println "=== Symbolic Simulation Tests ==="
-  IO.println ""
-  for n in [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000] do
-    solveUsingSym n
+def Goal (n : Nat) : Prop := ∀ s post, post () s → Exec s (loop n) post
 
 set_option maxRecDepth 10000
 set_option maxHeartbeats 10000000
 
--- #eval runBenchUsingSym
-#eval solveUsingSym 1000
+#eval runBenchUsingSym ``Goal [``loop, ``step] solve
+  [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
+  -- [1000]

--- a/tests/bench/mvcgen/sym/lakefile.lean
+++ b/tests/bench/mvcgen/sym/lakefile.lean
@@ -10,6 +10,9 @@ lean_lib VCGen where
 lean_lib Baseline where
   srcDir := "lib"
 
+lean_lib Driver where
+  srcDir := "lib"
+
 @[default_target]
 lean_lib VCGenBench where
   roots := #[`vcgen_add_sub_cancel, `vcgen_deep_add_sub_cancel, `vcgen_get_throw_set]

--- a/tests/bench/mvcgen/sym/lib/Driver.lean
+++ b/tests/bench/mvcgen/sym/lib/Driver.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Graf
+-/
+module
+public import Lean.Meta
+import Lean.Elab
+
+open Lean Parser Meta Elab Tactic Sym
+
+/-- Helper function for executing a tactic `k` for solving `$(goal) n`. -/
+def driver (goal : Name) (unfold : List Name) (n : Nat) (check := true) (k : MVarId → MetaM Unit) : MetaM Unit := do
+  let mvar ← mkFreshExprMVar (mkApp (mkConst goal) (mkNatLit n))
+-- The following code uses `Sym.simp`, but it balloons in the kernel. TODO: Investigate with new semantic
+-- foundations. Use regular simp for now.
+--  let mvarId ← SymM.run do
+--    let mvarId ← preprocessMVar mvar.mvarId!
+--    match (← Sym.simpGoal mvarId (← Sym.mkMethods "equational theorems of names in unfold as array")) with
+--    | .goal mvarId => return mvarId
+--    | .noProgress => throwError "SIMP NO PROGRESS on {mvarId}!"
+--    | .closed => throwError "SIMP CLOSED!"
+--  let unfold := Syntax.SepArray.ofElems (unfold.toArray |>.map (Lean.mkIdent ·))
+  let lemmas ← unfold.toArray |>.push goal |>.mapM fun n => `(simpLemma| $(Lean.mkIdent n):term)
+  let unfold := Syntax.TSepArray.ofElems (sep := ",") lemmas
+  let ([mvarId], _) ← Lean.Elab.runTactic mvar.mvarId! (← `(tactic| simp only [$unfold,*])).raw {} {}
+    | throwError "FAILED!"
+  let startTime ← IO.monoNanosNow
+  k mvarId
+  let endTime ← IO.monoNanosNow
+  let ms := (endTime - startTime).toFloat / 1000000.0
+  if check then
+    let startTime ← IO.monoNanosNow
+    checkWithKernel (← instantiateExprMVars mvar)
+    let endTime ← IO.monoNanosNow
+    let kernelMs := (endTime - startTime).toFloat / 1000000.0
+    IO.println s!"goal_{n}: {ms} ms, kernel: {kernelMs} ms"
+  else
+    IO.println s!"goal_{n}: {ms} ms"
+
+def solveUsingTactic (goal : Name) (unfold : List Name) (n : Nat) (solve : MetaM (TSyntax `tactic)) (check := true) : MetaM Unit := do
+  driver goal unfold n check fun mvarId => do
+    let ([], _) ← Lean.Elab.runTactic mvarId (← solve).raw {} {} | throwError "FAILED!"
+
+/--
+Solves a goal of the form `goal n` using the given tactic, where `n` ranges over `sizes`.
+`unfold` is a list of `simp` lemmas to apply in order to unfold `goal n`.
+For many benchmarks, this is `[step, loop]`.
+-/
+public def runBenchUsingTactic (goal : Name) (unfold : List Name) (solve : MetaM (TSyntax `tactic)) (sizes : List Nat) : MetaM Unit := do
+  IO.println "=== VCGen tests ==="
+  IO.println ""
+  for n in sizes do
+    solveUsingTactic goal unfold n solve
+
+def solveUsingSym (goal : Name) (unfold : List Name) (n : Nat) (solve : MVarId → SymM Unit) (check := true) : MetaM Unit := do
+  driver goal unfold n check fun mvarId => SymM.run do solve mvarId
+
+/--
+Solves a goal of the form `goal n` using a `SymM` procedure, where `n` ranges over `sizes`.
+`unfold` is a list of `simp` lemmas to apply in order to unfold `goal n`.
+For many benchmarks, this is `[step, loop]`.
+-/
+public def runBenchUsingSym (goal : Name) (unfold : List Name) (solve : MVarId → SymM Unit) (sizes : List Nat) : MetaM Unit := do
+  IO.println "=== Symbolic Simulation Tests ==="
+  IO.println ""
+  for n in sizes do
+    solveUsingSym goal unfold n solve

--- a/tests/bench/mvcgen/sym/vcgen_add_sub_cancel.lean
+++ b/tests/bench/mvcgen/sym/vcgen_add_sub_cancel.lean
@@ -5,6 +5,7 @@ Authors: Sebastian Graf
 -/
 import Lean
 import VCGen
+import Driver
 
 open Lean Parser Meta Elab Tactic Sym Std Do SpecAttr
 
@@ -32,53 +33,9 @@ def loop (n : Nat) : StateM Nat Unit := do
 
 def Goal (n : Nat) : Prop := ∀ post, ⦃post⦄ loop n ⦃⇓_ => post⦄
 
-open Lean Meta Elab
-
-/-- Helper function for executing a tactic `k` for solving `Goal n`. -/
-def driver (n : Nat) (check := true) (k : MVarId → MetaM Unit) : MetaM Unit := do
-  let some goal ← unfoldDefinition? (mkApp (mkConst ``Goal) (mkNatLit n)) | throwError "UNFOLD FAILED!"
-  let mvar ← mkFreshExprMVar goal
-  let startTime ← IO.monoNanosNow
-  k mvar.mvarId!
-  let endTime ← IO.monoNanosNow
-  let ms := (endTime - startTime).toFloat / 1000000.0
-  if check then
-    let startTime ← IO.monoNanosNow
-    checkWithKernel (← instantiateExprMVars mvar)
-    let endTime ← IO.monoNanosNow
-    let kernelMs := (endTime - startTime).toFloat / 1000000.0
-    IO.println s!"goal_{n}: {ms} ms, kernel: {kernelMs} ms"
-  else
-    IO.println s!"goal_{n}: {ms} ms"
-
-/-!
-`MetaM` Solution
--/
-
-/-
-A tactic for solving goal `Goal n`
--/
-macro "solve" : tactic => `(tactic| {
-  intro post
-  simp only [loop, step]
-  mvcgen' <;> grind
-})
-
-/--
-Solves a goal of the form `Goal n` using the `solve` tactic.
--/
-def solveUsingMeta (n : Nat) (check := true) : MetaM Unit := do
-  driver n check fun mvarId => do
-    let ([], _) ← Lean.Elab.runTactic mvarId (← `(tactic| solve)).raw {} {} | throwError "FAILED!"
-
-def runBenchUsingMeta (sizes : List Nat) : MetaM Unit := do
-  IO.println "=== VCGen tests ==="
-  IO.println ""
-  for n in sizes do
-    solveUsingMeta n
-
 set_option maxRecDepth 10000
 set_option maxHeartbeats 10000000
 
--- #eval runBenchUsingMeta [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
-#eval runBenchUsingMeta [1000]
+#eval runBenchUsingTactic ``Goal [``loop, ``step] `(tactic| mvcgen' <;> sorry)
+  [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
+  -- [1000]

--- a/tests/bench/mvcgen/sym/vcgen_deep_add_sub_cancel.lean
+++ b/tests/bench/mvcgen/sym/vcgen_deep_add_sub_cancel.lean
@@ -5,6 +5,7 @@ Authors: Sebastian Graf
 -/
 import Lean
 import VCGen
+import Driver
 
 open Lean Parser Meta Elab Tactic Sym Std Do SpecAttr
 
@@ -47,51 +48,6 @@ theorem Spec.M_set_Nat (n : Nat) :
     ⦃fun s₁ _ => Q.fst ⟨⟩ s₁ n⦄ set (m := M) n ⦃Q⦄ := by
   mvcgen
 
-open Lean Meta Elab
-
-/-- Helper function for executing a tactic `k` for solving `Goal n`. -/
-def driver (n : Nat) (check := true) (k : MVarId → MetaM Unit) : MetaM Unit := do
-  let some goal ← unfoldDefinition? (mkApp (mkConst ``Goal) (mkNatLit n)) | throwError "UNFOLD FAILED!"
-  let mvar ← mkFreshExprMVar goal
-  let startTime ← IO.monoNanosNow
-  k mvar.mvarId!
-  let endTime ← IO.monoNanosNow
-  let ms := (endTime - startTime).toFloat / 1000000.0
-  if check then
-    let startTime ← IO.monoNanosNow
-    checkWithKernel (← instantiateExprMVars mvar)
-    let endTime ← IO.monoNanosNow
-    let kernelMs := (endTime - startTime).toFloat / 1000000.0
-    IO.println s!"goal_{n}: {ms} ms, kernel: {kernelMs} ms"
-  else
-    IO.println s!"goal_{n}: {ms} ms"
-
-/-!
-`MetaM` Solution
--/
-
-/-
-A tactic for solving goal `Goal n`
--/
-macro "solve" : tactic => `(tactic| {
-  intro post
-  simp only [loop, step]
-  mvcgen' <;> grind
-})
-
-/--
-Solves a goal of the form `Goal n` using the `solve` tactic.
--/
-def solveUsingMeta (n : Nat) (check := true) : MetaM Unit := do
-  driver n check fun mvarId => do
-    let ([], _) ← Lean.Elab.runTactic mvarId (← `(tactic| solve)).raw {} {} | throwError "FAILED!"
-
-def runBenchUsingMeta (sizes : List Nat) : MetaM Unit := do
-  IO.println "=== VCGen tests ==="
-  IO.println ""
-  for n in sizes do
-    solveUsingMeta n
-
 set_option maxRecDepth 10000
 set_option maxHeartbeats 10000000
 
@@ -101,5 +57,6 @@ example : Goal 20 := by
   mvcgen' <;> grind
 -/
 
-#eval runBenchUsingMeta [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
--- #eval runBenchUsingMeta [1000]
+#eval runBenchUsingTactic ``Goal [``loop, ``step] `(tactic| mvcgen' <;> sorry)
+  [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
+  -- [1000]

--- a/tests/bench/mvcgen/sym/vcgen_get_throw_set.lean
+++ b/tests/bench/mvcgen/sym/vcgen_get_throw_set.lean
@@ -5,6 +5,7 @@ Authors: Sebastian Graf
 -/
 import Lean
 import VCGen
+import Driver
 
 open Lean Parser Meta Elab Tactic Sym Std Do SpecAttr
 
@@ -26,46 +27,6 @@ def loop (n : Nat) : ExceptT String (StateM Nat) Unit := do
 
 def Goal (n : Nat) : Prop := ⦃fun s => ⌜s = 0⌝⦄ loop n ⦃⇓_ s => ⌜s = n⌝⦄
 
-/-- Helper function for executing a tactic `k` for solving `Goal n`. -/
-def driver (n : Nat) (check := true) (k : MVarId → MetaM Unit) : MetaM Unit := do
-  let some goal ← unfoldDefinition? (mkApp (mkConst ``Goal) (mkNatLit n)) | throwError "UNFOLD FAILED!"
-  let mvar ← mkFreshExprMVar goal
-  let startTime ← IO.monoNanosNow
-  k mvar.mvarId!
-  let endTime ← IO.monoNanosNow
-  let ms := (endTime - startTime).toFloat / 1000000.0
-  if check then
-    let startTime ← IO.monoNanosNow
-    checkWithKernel (← instantiateExprMVars mvar)
-    let endTime ← IO.monoNanosNow
-    let kernelMs := (endTime - startTime).toFloat / 1000000.0
-    IO.println s!"goal_{n}: {ms} ms, kernel: {kernelMs} ms"
-  else
-    IO.println s!"goal_{n}: {ms} ms"
-
-/-
-A tactic for solving goal `Goal n`
--/
-macro "solve" : tactic => `(tactic| {
-  simp only [loop, step]
-  mvcgen'
-  all_goals sorry
-  -- all_goals grind
-})
-
-/--
-Solves a goal of the form `Goal n` using the `solve` tactic.
--/
-def solveUsingMeta (n : Nat) (check := true) : MetaM Unit := do
-  driver n check fun mvarId => do
-    let ([], _) ← Lean.Elab.runTactic mvarId (← `(tactic| solve)).raw {} {} | throwError "FAILED!"
-
-def runBenchUsingMeta (sizes : List Nat) : MetaM Unit := do
-  IO.println "=== VCGen tests ==="
-  IO.println ""
-  for n in sizes do
-    solveUsingMeta n
-
 set_option maxRecDepth 10000
 set_option maxHeartbeats 10000000
 
@@ -76,5 +37,6 @@ example : Goal 20 := by
   all_goals sorry
 -/
 
-#eval runBenchUsingMeta [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
--- #eval runBenchUsingMeta [1000]
+#eval runBenchUsingTactic ``Goal [``loop, ``step] `(tactic| mvcgen' <;> sorry)
+  [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
+  -- [1000]


### PR DESCRIPTION
This PR shares the driver code from the Sym-based mvcgen benchmarks. It also moves the `simp only [loop, step]` call out of the measured section, so that we measure purely the overhead of VC generation.

The new benchmark results are as follows. All measurements for n=1000:

```
baseline_add_sub_cancel:   719.318425 ms, kernel: 382.708178 ms
vcgen_add_sub_cancel:      306.883079 ms, kernel: 455.050825 ms
vcgen_deep_add_sub_cancel: 543.350543 ms, kernel: 896.926298 ms
vcgen_get_throw_set:       669.566541 ms, kernel: 60754.202714 ms
```

Note that `vcgen_add_sub_cancel` sped up by 100% because we no longer measure unfolding `loop` and `step`. The baseline didn't speed up as much because it unfolded in the same `Sym.simp` call that also does other rewrites, so there was no `simp` pass that could be eliminated.