### PR TITLE
fix: bring lengthTR lemma back into scope at toArray

### DIFF
--- a/src/Init/Data/List/ToArrayImpl.lean
+++ b/src/Init/Data/List/ToArrayImpl.lean
@@ -7,6 +7,7 @@ module
 
 prelude
 public import Init.Prelude
+import Init.Data.List.Basic
 
 public section
 

--- a/tests/lean/run/to_array_csimp.lean
+++ b/tests/lean/run/to_array_csimp.lean
@@ -1,0 +1,5 @@
+/-! regression test against missing csimp lemmas in Init -/
+
+/-- info: 300000 -/
+#guard_msgs in
+#eval (List.range (3 * 10 ^ 5)).toArray.size


### PR DESCRIPTION
This PR brings the `length = lengthTR` lemma back into scope after shake mistakenly removed it.