### PR TITLE
perf: do not export environment extensions without entries

### DIFF
--- a/src/Lean/Environment.lean
+++ b/src/Lean/Environment.lean
@@ -1784,13 +1784,16 @@ private opaque getIRExtraConstNames (env : Environment) (level : OLeanLevel) (in
 def mkModuleData (env : Environment) (level : OLeanLevel := .private) : IO ModuleData := do
   let env := env.setExporting (level != .private)
   let pExts ← persistentEnvExtensionsRef.get
-  let entries := pExts.map fun pExt => Id.run do
+  let entries := pExts.filterMap fun pExt => do
     -- get state from `checked` at the end if `async`; it would otherwise panic
     let mut asyncMode := pExt.toEnvExtension.asyncMode
     if asyncMode matches .async _ then
       asyncMode := .sync
     let state := pExt.getState (asyncMode := asyncMode) env
-    (pExt.name, pExt.exportEntriesFn env state level)
+    let ents := pExt.exportEntriesFn env state level
+    -- no need to export empty entries
+    guard !ents.isEmpty
+    return (pExt.name, ents)
   let kenv := env.toKernelEnv
   let constNames := kenv.constants.foldStage2 (fun names name _ => names.push name) #[]
   -- not all kernel constants may be exported at `level < .private`


### PR DESCRIPTION
Avoids wasted work in `setImportedEntries`. This is still not ideal as exts that are set but never/rarely read still have a cost proportional to the number of imported modules but it's an easy step forward.