### PR TITLE
fix: add depth guard to map_map grind_pattern

### DIFF
--- a/src/Init/Data/List/Lemmas.lean
+++ b/src/Init/Data/List/Lemmas.lean
@@ -1244,6 +1244,8 @@ theorem getLastD_map {f : α → β} {l : List α} {a : α} : (map f l).getLastD
 grind_pattern map_map => map g (map f l) where
   g =/= List.reverse
   f =/= List.reverse
+  depth g < 4
+  depth f < 4
 
 /-! ### filter -/
 


### PR DESCRIPTION
This PR adds `depth g < 4` and `depth f < 4` guards to the `map_map` `grind_pattern`.

When the e-graph contains `l ≡ map (fun x => x) l`, the `map_map` pattern fires repeatedly, generating unbounded `(fun x => x) ∘ (fun x => x) ∘ ...` composition chains. The ideal guard `g =/= fun x => x` doesn't work because `g : β → γ` while `fun x => x : β → β` — a type mismatch when `β ≠ γ`. The depth guard limits how deep the matched function arguments can be, which effectively caps the composition chain and breaks the loop.

🤖 Prepared with Claude Code