### PR TITLE
chore: make doc-gen4 release depend on mathlib4

### DIFF
--- a/script/release_repos.yml
+++ b/script/release_repos.yml
@@ -65,13 +65,6 @@ repositories:
     branch: master
     dependencies: [lean4-unicode-basic]
 
-  - name: doc-gen4
-    url: https://github.com/leanprover/doc-gen4
-    toolchain-tag: true
-    stable-branch: false
-    branch: main
-    dependencies: [lean4-cli, BibtexQuery]
-
   - name: reference-manual
     url: https://github.com/leanprover/reference-manual
     toolchain-tag: true
@@ -107,9 +100,15 @@ repositories:
       - lean4checker
       - batteries
       - lean4-cli
-      - doc-gen4
       - import-graph
       - plausible
+
+  - name: doc-gen4
+    url: https://github.com/leanprover/doc-gen4
+    toolchain-tag: true
+    stable-branch: false
+    branch: main
+    dependencies: [lean4-cli, BibtexQuery, mathlib4]
 
   - name: cslib
     url: https://github.com/leanprover/cslib


### PR DESCRIPTION
This PR reorders doc-gen4 after mathlib4 in the release process. Previously doc-gen4 was processed before mathlib4, but its benchmarks reference the mathlib tag which doesn't exist yet at that point, causing CI failures (https://lean-fro.zulipchat.com/#narrow/channel/530199-rss/topic/Significant.20commits.20to.20doc-gen4/near/574125422).

🤖 Prepared with Claude Code