### PR TITLE
fix: allow checked self-references in Verso docstring module role

### DIFF
--- a/src/Lean/Elab/DocString/Builtin.lean
+++ b/src/Lean/Elab/DocString/Builtin.lean
@@ -254,7 +254,7 @@ def module (checked : flag true) (xs : TSyntaxArray `inline) : DocM (Inline Elab
   let n := mkIdentFrom' s x
   if checked then
     let env ← getEnv
-    if x ∉ env.header.moduleNames then
+    if x != env.mainModule && x ∉ env.header.moduleNames then
       let ss := similarNames x env.header.moduleNames
       let ref ← getRef
       let unchecked : Option Meta.Hint.Suggestion ←

--- a/tests/lean/run/versoDocs.lean
+++ b/tests/lean/run/versoDocs.lean
@@ -626,3 +626,9 @@ Hint: `lit` shadows a role. Use the full name of the shadowed role:
 end Inner
 
 end DoubleShadowed
+
+/-!
+Self-module references should work without `-checked`.
+-/
+
+/-! {module}`lean.run.versoDocs` -/


### PR DESCRIPTION
This PR allows the `module` role in Verso docstrings to refer to the current module without requiring the `-checked` flag.