### PR TITLE
chore: begin development cycle for v4.30.0

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 include(ExternalProject)
 project(LEAN CXX C)
 set(LEAN_VERSION_MAJOR 4)
-set(LEAN_VERSION_MINOR 29)
+set(LEAN_VERSION_MINOR 30)
 set(LEAN_VERSION_PATCH 0)
 set(LEAN_VERSION_IS_RELEASE 0) # This number is 1 in the release revision, and 0 otherwise.
 set(LEAN_SPECIAL_VERSION_DESC "" CACHE STRING "Additional version description like 'nightly-2018-03-11'")


### PR DESCRIPTION
This PR begins the development cycle for v4.30.0 by updating `LEAN_VERSION_MINOR` to 30 in `src/CMakeLists.txt`.