### PR TITLE
chore: remove batteries dependency from ProofWidgets4 in release_repos.yml

### DIFF
--- a/script/release_repos.yml
+++ b/script/release_repos.yml
@@ -84,8 +84,7 @@ repositories:
     toolchain-tag: false
     stable-branch: false
     branch: main
-    dependencies:
-      - batteries
+    dependencies: []
 
   - name: aesop
     url: https://github.com/leanprover-community/aesop


### PR DESCRIPTION
This PR removes the batteries dependency from ProofWidgets4 in `release_repos.yml`. ProofWidgets4 no longer has any `require` statements in its lakefile, so it doesn't depend on batteries.

🤖 Prepared with Claude Code