### PR TITLE
chore: add module/prelude guidance to CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -84,6 +84,21 @@ leading quantifiers are stripped when creating a pattern.
 
 If you're unsure which label applies, it's fine to omit the label and let reviewers add it.
 
+## Module System for `src/` Files
+
+Files in `src/Lean/`, `src/Std/`, and `src/lake/Lake/` must have both `module` and `prelude` (CI enforces `^prelude$` on its own line). With `prelude`, nothing is auto-imported — you must explicitly import `Init.*` modules for standard library features. Check existing files in the same directory for the pattern, e.g.:
+
+```lean
+module
+
+prelude
+import Init.While  -- needed for while/repeat
+import Init.Data.String.TakeDrop  -- needed for String.startsWith
+public import Lean.Compiler.NameMangling  -- public if types are used in public signatures
+```
+
+Files outside these directories (e.g. `tests/`, `script/`) use just `module`.
+
 ## CI Log Retrieval
 
 When CI jobs fail, investigate immediately - don't wait for other jobs to complete. Individual job logs are often available even while other jobs are still running. Try `gh run view <run-id> --log` or `gh run view <run-id> --log-failed`, or use `gh run view <run-id> --job=<job-id>` to target the specific failed job. Sleeping is fine when asked to monitor CI and no failures exist yet, but once any job fails, investigate that failure immediately.


### PR DESCRIPTION
This PR adds guidance to `.claude/CLAUDE.md` about the `module` + `prelude` convention required for files in `src/Lean/`, `src/Std/`, and `src/lake/Lake/`. CI enforces that these files contain `prelude`, but with `prelude` nothing is auto-imported, so explicit `Init.*` imports are needed for standard library features like `while`, `String.startsWith`, etc.

🤖 Prepared with Claude Code