### PR TITLE
fix: remove transparency bumps from assignOutParams and checkTypesAndAssign

### DIFF
--- a/src/Lean/Meta/ExprDefEq.lean
+++ b/src/Lean/Meta/ExprDefEq.lean
@@ -413,14 +413,17 @@ private def checkTypesAndAssign (mvar : Expr) (v : Expr) : MetaM Bool :=
     else
       -- must check whether types are definitionally equal or not, before assigning and returning true
       let mvarType ← inferType mvar
-      -- **TODO**: avoid transparency bump. Let's fix other issues first
-      withInferTypeConfig do
+      let check := do
         let vType ← inferType v
         if (← Meta.isExprDefEqAux mvarType vType) then
           mvar.mvarId!.assign v
           pure true
         else
           pure false
+      if backward.isDefEq.respectTransparency.get (← getOptions) then
+        check
+      else
+        withInferTypeConfig check
 
 /--
 Auxiliary method for solving constraints of the form `?m xs := v`.

--- a/src/Lean/Meta/SynthInstance.lean
+++ b/src/Lean/Meta/SynthInstance.lean
@@ -785,18 +785,8 @@ private def assignOutParams (type : Expr) (result : Expr) : MetaM Bool := do
   Output parameters of local instances may be marked as `syntheticOpaque` by the application-elaborator.
   We use `withAssignableSyntheticOpaque` to make sure this kind of parameter can be assigned by the following `isDefEq`.
   TODO: rewrite this check to avoid `withAssignableSyntheticOpaque`.
-
-  **Note**: We tried to remove `withDefault` at the following `isDefEq` because it was a potential performance footgun. TC is supposed to unfold only `reducible` definitions and `instances`.
-  We reverted the change because it triggered thousands of failures related to the `OrderDual` type. Example:
-  ```
-  variable {ι : Type}
-  def OrderDual (α : Type) : Type := α
-  instance [I : DecidableEq ι] : DecidableEq (OrderDual ι) := inferInstance -- Failure
-  ```
-  Mathlib developers are currently trying to refactor the `OrderDual` declaration,
-  but it will take time. We will try to remove the `withDefault` again after the refactoring.
   -/
-  let defEq ← withDefault <| withAssignableSyntheticOpaque <| isDefEq type resultType
+  let defEq ← withAssignableSyntheticOpaque <| isDefEq type resultType
   unless defEq do
     trace[Meta.synthInstance] "{crossEmoji} result type{indentExpr resultType}\nis not definitionally equal to{indentExpr type}"
   return defEq


### PR DESCRIPTION
This PR combines two changes:

1. Remove `withDefault` from `assignOutParams` in TC synthesis (the change from https://github.com/leanprover/lean4/pull/12488).

2. Guard the `withInferTypeConfig` transparency bump in `checkTypesAndAssign` on `backward.isDefEq.respectTransparency`, matching the pattern already used for `isDefEqArgs` and `withProofIrrelTransparency`.

The `checkTypesAndAssign` bump was causing an inconsistency in TC synthesis: `tryResolve` would accept instance candidates at `.default` transparency (via `checkTypesAndAssign`'s `withInferTypeConfig`), but `assignOutParams` would later reject the result at `.instances` transparency. Since `assignOutParams` runs after the synthesis loop returns, there is no backtracking to try other candidates.

For example:

```lean
def MyCopy (α : Type) : Type := α

instance (α : Type) [h : DecidableEq α] : DecidableEq (MyCopy α) := h
example (α : Type) [h : DecidableEq α] : DecidableEq (MyCopy α) := by infer_instance -- fails
```

Here TC resolution finds two candidates `#[instDecidableEqMyCopy, h]`. The local `h` has higher priority and is tried first. `tryResolve` accepts `h` because `checkTypesAndAssign` bumps transparency to `.default` (unfolding `MyCopy`). The search terminates. Then `assignOutParams` rejects the result at `.instances` transparency. The declared instance `instDecidableEqMyCopy` is never tried.

With this PR, `checkTypesAndAssign` respects the ambient transparency, so `tryResolve` correctly rejects `h`, and the search continues to find `instDecidableEqMyCopy`.

🤖 Prepared with Claude Code