### PR TITLE
feat: LCNF inc/dec instructions

### DIFF
--- a/src/Lean/Compiler/IR/ToIR.lean
+++ b/src/Lean/Compiler/IR/ToIR.lean
@@ -109,6 +109,12 @@ partial def lowerCode (c : LCNF.Code .impure) : M FnBody := do
     let .var y ← getFVarValue y | unreachable!
     let .var var ← getFVarValue var | unreachable!
     return .uset var i y (← lowerCode k)
+  | .inc fvarId n check persistent k _ =>
+    let .var var ← getFVarValue fvarId | unreachable!
+    return .inc var n check persistent (← lowerCode k)
+  | .dec fvarId n check persistent k _ =>
+    let .var var ← getFVarValue fvarId | unreachable!
+    return .dec var n check persistent (← lowerCode k)
   | .fun .. => panic! "all local functions should be λ-lifted"
 
 partial def lowerLet (decl : LCNF.LetDecl .impure) (k : LCNF.Code .impure) : M FnBody := do

--- a/src/Lean/Compiler/LCNF/AlphaEqv.lean
+++ b/src/Lean/Compiler/LCNF/AlphaEqv.lean
@@ -155,6 +155,18 @@ partial def eqv (code₁ code₂ : Code pu) : EqvM Bool := do
     eqvFVar var₁ var₂ <&&>
     eqvFVar y₁ y₂ <&&>
     eqv k₁ k₂
+  | .inc fvarId₁ n₁ c₁ p₁ k₁ _, .inc fvarId₂ n₂ c₂ p₂ k₂ _ =>
+    pure (n₁ == n₂) <&&>
+    pure (c₁ == c₂) <&&>
+    pure (p₁ == p₂) <&&>
+    eqvFVar fvarId₁ fvarId₂ <&&>
+    eqv k₁ k₂
+  | .dec fvarId₁ n₁ c₁ p₁ k₁ _, .dec fvarId₂ n₂ c₂ p₂ k₂ _ =>
+    pure (n₁ == n₂) <&&>
+    pure (c₁ == c₂) <&&>
+    pure (p₁ == p₂) <&&>
+    eqvFVar fvarId₁ fvarId₂ <&&>
+    eqv k₁ k₂
   | _, _ => return false
 
 end

--- a/src/Lean/Compiler/LCNF/Bind.lean
+++ b/src/Lean/Compiler/LCNF/Bind.lean
@@ -68,8 +68,8 @@ where
       eraseCode k
       eraseParam auxParam
       return .unreach typeNew
-    | .sset fvarId i offset y ty k _ => return .sset fvarId i offset y ty (← go k)
-    | .uset fvarId offset y k _ => return .uset fvarId offset y (← go k)
+    | .sset (k := k) .. | .uset (k := k) .. | .inc (k := k) .. | .dec (k := k) .. =>
+      return c.updateCont! (← go k)
 
 instance : MonadCodeBind CompilerM where
   codeBind := CompilerM.codeBind

--- a/src/Lean/Compiler/LCNF/CompilerM.lean
+++ b/src/Lean/Compiler/LCNF/CompilerM.lean
@@ -149,7 +149,7 @@ def eraseCodeDecl (decl : CodeDecl pu) : CompilerM Unit := do
   match decl with
   | .let decl => eraseLetDecl decl
   | .jp decl | .fun decl _ => eraseFunDecl decl
-  | .sset .. | .uset .. => return ()
+  | .sset .. | .uset .. | .inc .. | .dec .. => return ()
 
 /--
 Erase all free variables occurring in `decls` from the local context.
@@ -501,6 +501,12 @@ mutual
       withNormFVarResult (← normFVar fvarId) fun fvarId => do
       withNormFVarResult (← normFVar y) fun y => do
         return code.updateUset! fvarId offset y (← normCodeImp k)
+    | .inc fvarId n check persistent k _ =>
+      withNormFVarResult (← normFVar fvarId) fun fvarId => do
+        return code.updateInc! fvarId n check persistent (← normCodeImp k)
+    | .dec fvarId n check persistent k _ =>
+      withNormFVarResult (← normFVar fvarId) fun fvarId => do
+        return code.updateDec! fvarId n check persistent (← normCodeImp k)
 end
 
 @[inline] def normFunDecl [MonadLiftT CompilerM m] [Monad m] [MonadFVarSubst m pu t] (decl : FunDecl pu) : m (FunDecl pu) := do

--- a/src/Lean/Compiler/LCNF/DeclHash.lean
+++ b/src/Lean/Compiler/LCNF/DeclHash.lean
@@ -41,6 +41,10 @@ partial def hashCode (code : Code pu) : UInt64 :=
     mixHash (mixHash (hash fvarId) (hash i)) (mixHash (mixHash (hash offset) (hash y)) (mixHash (hash ty) (hashCode k)))
   | .uset fvarId offset y k _ =>
     mixHash (mixHash (hash fvarId) (hash offset)) (mixHash (hash y) (hashCode k))
+  | .inc fvarId n check persistent k _ =>
+    mixHash (mixHash (hash fvarId) (hash n)) (mixHash (mixHash (hash persistent) (hash check)) (hashCode k))
+  | .dec fvarId n check persistent k _ =>
+    mixHash (mixHash (hash fvarId) (hash n)) (mixHash (mixHash (hash persistent) (hash check)) (hashCode k))
 
 end
 

--- a/src/Lean/Compiler/LCNF/DependsOn.lean
+++ b/src/Lean/Compiler/LCNF/DependsOn.lean
@@ -47,6 +47,8 @@ private partial def depOn (c : Code pu) : M Bool :=
   | .return fvarId => fvarDepOn fvarId
   | .unreach _ => return false
   | .sset fv1 _ _ fv2 _ k _ | .uset fv1 _ fv2 k _ => fvarDepOn fv1 <||> fvarDepOn fv2 <||> depOn k
+  | .inc (fvarId := fvarId) (k := k) .. | .dec (fvarId := fvarId) (k := k) .. =>
+    fvarDepOn fvarId <||> depOn k
 
 @[inline] def Arg.dependsOn (arg : Arg pu) (s : FVarIdSet) :  Bool :=
   argDepOn arg s
@@ -64,8 +66,8 @@ def CodeDecl.dependsOn (decl : CodeDecl pu) (s : FVarIdSet) : Bool :=
   match decl with
   | .let decl => decl.dependsOn s
   | .jp decl | .fun decl _ => decl.dependsOn s
-  | .uset var _ y _ => s.contains var || s.contains y
-  | .sset var _ _ y ty _ => s.contains var || s.contains y || (typeDepOn ty s)
+  | .uset (var := var) (y := y) .. | .sset (var := var) (y := y) .. => s.contains var || s.contains y
+  | .inc (fvarId := fvarId) .. | .dec (fvarId := fvarId) .. => s.contains fvarId 
 
 /--
 Return `true` is `c` depends on a free variable in `s`.

--- a/src/Lean/Compiler/LCNF/ElimDead.lean
+++ b/src/Lean/Compiler/LCNF/ElimDead.lean
@@ -102,6 +102,10 @@ partial def Code.elimDead (code : Code pu) : M (Code pu) := do
       return code.updateCont! k
     else
       return k
+  | .inc (fvarId := fvarId) (k := k) .. | .dec (fvarId := fvarId) (k := k) .. =>
+    let k ← k.elimDead
+    collectFVarM fvarId
+    return code.updateCont! k
 
 end
 

--- a/src/Lean/Compiler/LCNF/ExplicitBoxing.lean
+++ b/src/Lean/Compiler/LCNF/ExplicitBoxing.lean
@@ -292,6 +292,7 @@ partial def Code.explicitBoxing (code : Code .impure) : BoxM (Code .impure) := d
     let some jpDecl ← findFunDecl? fvarId | unreachable!
     castArgsIfNeeded args jpDecl.params fun args => return code.updateJmp! fvarId args
   | .unreach .. => return code.updateUnreach! (← getResultType)
+  | .inc .. | .dec .. => unreachable!
 where
   /--
   Up to this point the type system of IR is quite loose so we can for example encounter situations
@@ -368,7 +369,7 @@ def run (decls : Array (Decl .impure)) : CompilerM (Array (Decl .impure)) := do
 public def explicitBoxing : Pass where
   phase := .impure
   phaseOut := .impure
-  name := `boxing
+  name := `explicitBoxing
   run := run
 
 builtin_initialize

--- a/src/Lean/Compiler/LCNF/InferBorrow.lean
+++ b/src/Lean/Compiler/LCNF/InferBorrow.lean
@@ -91,6 +91,7 @@ where
     | .cases cs => cs.alts.forM (·.forCodeM (goCode declName))
     | .let _ k | .uset _ _ _ k _ | .sset _ _ _ _ _ k _ => goCode declName k
     | .return .. | .jmp .. | .unreach .. => return ()
+    | .inc .. | .dec .. => unreachable!
 
 /--
 Apply the inferred borrow annotations from `map` to a SCC.
@@ -120,6 +121,7 @@ where
     | .cases cs => return code.updateAlts! <| ← cs.alts.mapM (·.mapCodeM (go declName))
     | .let _ k | .uset _ _ _ k _ | .sset _ _ _ _ _ k _ => return code.updateCont! (← go declName k)
     | .return .. | .jmp .. | .unreach .. => return code
+    | .inc .. | .dec .. => unreachable!
 
 structure Ctx where
   /--
@@ -298,6 +300,7 @@ where
     | .cases cs => cs.alts.forM (·.forCodeM collectCode)
     | .uset _ _ _ k _ | .sset _ _ _ _ _ k _ => collectCode k
     | .return .. | .unreach .. => return ()
+    | .inc .. | .dec .. => unreachable!
 
 
 public def inferBorrow : Pass where

--- a/src/Lean/Compiler/LCNF/Internalize.lean
+++ b/src/Lean/Compiler/LCNF/Internalize.lean
@@ -166,6 +166,12 @@ partial def internalizeCode (code : Code pu) : InternalizeM pu (Code pu) := do
     withNormFVarResult (← normFVar fvarId) fun fvarId => do
     withNormFVarResult (← normFVar y) fun y => do
       return .uset fvarId offset y (← internalizeCode k)
+  | .inc fvarId n check persistent k _ =>
+    withNormFVarResult (← normFVar fvarId) fun fvarId => do
+      return .inc fvarId n check persistent (← internalizeCode k)
+  | .dec fvarId n check persistent k _ =>
+    withNormFVarResult (← normFVar fvarId) fun fvarId => do
+      return .dec fvarId n check persistent (← internalizeCode k)
 
 end
 
@@ -184,6 +190,12 @@ partial def internalizeCodeDecl (decl : CodeDecl pu) : InternalizeM pu (CodeDecl
     let .fvar y ← normFVar y | unreachable!
     let ty ← normExpr ty
     return .sset var i offset y ty
+  | .inc fvarId n check offset _ =>
+    let .fvar fvarId ← normFVar fvarId | unreachable!
+    return .inc fvarId n check offset
+  | .dec fvarId n check offset _ =>
+    let .fvar fvarId ← normFVar fvarId | unreachable!
+    return .dec fvarId n check offset
 
 
 end Internalize

--- a/src/Lean/Compiler/LCNF/LCtx.lean
+++ b/src/Lean/Compiler/LCNF/LCtx.lean
@@ -77,8 +77,9 @@ mutual
     | .let decl k => eraseCode k <| lctx.eraseLetDecl decl
     | .jp decl k | .fun decl k _ => eraseCode k <| eraseFunDecl lctx decl
     | .cases c => eraseAlts c.alts lctx
-    | .uset _ _ _ k _ | .sset _ _ _ _ _ k _ => eraseCode k lctx
-    | _ => lctx
+    | .uset (k := k) .. | .sset (k := k) .. | .inc (k := k) .. | .dec (k := k) .. =>
+      eraseCode k lctx
+    | .return .. | .jmp .. | .unreach .. => lctx
 end
 
 @[inline]

--- a/src/Lean/Compiler/LCNF/LiveVars.lean
+++ b/src/Lean/Compiler/LCNF/LiveVars.lean
@@ -76,6 +76,8 @@ where
           go decl.value
     | .return var => visitVar var
     | .unreach .. => return false
+    | .inc (fvarId := fvarId) (k := k) .. | .dec (fvarId := fvarId) (k := k) .. =>
+      visitVar fvarId <||> go k
 
   @[inline]
   visitVar (x : FVarId) : LiveM Bool :=

--- a/src/Lean/Compiler/LCNF/PrettyPrinter.lean
+++ b/src/Lean/Compiler/LCNF/PrettyPrinter.lean
@@ -149,6 +149,16 @@ mutual
         return f!"sset {← ppFVar fvarId} [{i}, {offset}] := {← ppFVar y} " ++ ";" ++ .line ++ (← ppCode k)
     | .uset fvarId i y k _ =>
       return f!"uset {← ppFVar fvarId} [{i}] := {← ppFVar y} " ++ ";" ++ .line ++ (← ppCode k)
+    | .inc fvarId n _ _ k _ =>
+      if n != 1 then
+        return f!"inc[{n}] {← ppFVar fvarId};" ++ .line ++ (← ppCode k)
+      else
+        return f!"inc {← ppFVar fvarId};" ++ .line ++ (← ppCode k)
+    | .dec fvarId n _ _ k _ =>
+      if n != 1 then
+        return f!"dec[{n}] {← ppFVar fvarId};" ++ .line ++ (← ppCode k)
+      else
+        return f!"dec {← ppFVar fvarId};" ++ .line ++ (← ppCode k)
 
 
   partial def ppDeclValue (b : DeclValue pu) : M Format := do

--- a/src/Lean/Compiler/LCNF/PushProj.lean
+++ b/src/Lean/Compiler/LCNF/PushProj.lean
@@ -137,6 +137,10 @@ where
       go k (decls.push (.uset var i y))
     | .sset var i offset y ty k _ =>
       go k (decls.push (.sset var i offset y ty))
+    | .inc fvarId n check persistent k _ =>
+      go k (decls.push (.inc fvarId n check persistent))
+    | .dec fvarId n check persistent k _ =>
+      go k (decls.push (.dec fvarId n check persistent))
     | .cases c => c.pushProjs decls
     | .jmp .. | .return .. | .unreach .. =>
       return attachCodeDecls decls c

--- a/src/Lean/Compiler/LCNF/Renaming.lean
+++ b/src/Lean/Compiler/LCNF/Renaming.lean
@@ -53,10 +53,8 @@ partial def Code.applyRenaming (code : Code pu) (r : Renaming) : CompilerM (Code
       | .ctorAlt _ k _ => return alt.updateCode (← k.applyRenaming r)
     return code.updateAlts! alts
   | .jmp .. | .unreach .. | .return .. => return code
-  | .sset fvarId i offset y ty k _ =>
-    return code.updateSset! fvarId i offset y ty (← k.applyRenaming r)
-  | .uset fvarId offset y k _ =>
-    return code.updateUset! fvarId offset y (← k.applyRenaming r)
+  | .sset (k := k) .. | .uset (k := k) .. | .inc (k := k) .. | .dec (k := k) .. =>
+    return code.updateCont! (← k.applyRenaming r)
 end
 
 def Decl.applyRenaming (decl : Decl pu) (r : Renaming) : CompilerM (Decl pu) := do

--- a/src/Lean/Compiler/LCNF/ResetReuse.lean
+++ b/src/Lean/Compiler/LCNF/ResetReuse.lean
@@ -120,6 +120,7 @@ where
     | .return .. | .jmp .. | .unreach .. => return (c, false)
     | .sset _ _ _ _ _ k _ | .uset _ _ _ k _ | .let _ k =>
       goK k
+    | .inc .. | .dec .. => unreachable!
 
 def isCtorUsing (instr : CodeDecl .impure) (x : FVarId) : Bool :=
   match instr with
@@ -241,6 +242,7 @@ where
             return (c.updateCont! k, false)
     | .return .. | .jmp .. | .unreach .. =>
       return (c, ← c.isFVarLiveIn x)
+    | .inc .. | .dec .. => unreachable!
 
 end
 
@@ -273,6 +275,7 @@ partial def Code.insertResetReuse (c : Code .impure) : ReuseM (Code .impure) := 
   | .let _ k | .uset _ _ _ k _ | .sset _ _ _ _ _ k _  =>
     return c.updateCont! (← k.insertResetReuse)
   | .return .. | .jmp .. | .unreach .. => return c
+  | .inc .. | .dec .. => unreachable!
 
 partial def Decl.insertResetReuseCore (decl : Decl .impure) : ReuseM (Decl .impure) := do
   let value ← decl.value.mapCodeM fun code => do
@@ -295,6 +298,7 @@ where
     | .jp decl k => collectResets decl.value; collectResets k
     | .cases c => c.alts.forM (collectResets ·.getCode)
     | .unreach .. | .return .. | .jmp .. => return ()
+    | .inc .. | .dec .. => unreachable!
 
 
 def Decl.insertResetReuse (decl : Decl .impure) : CompilerM (Decl .impure) := do

--- a/src/Lean/Compiler/LCNF/SimpCase.lean
+++ b/src/Lean/Compiler/LCNF/SimpCase.lean
@@ -107,7 +107,7 @@ partial def Code.simpCase (code : Code .impure) : CompilerM (Code .impure) := do
     let decl ← decl.updateValue (← decl.value.simpCase)
     return code.updateFun! decl (← k.simpCase)
   | .return .. | .jmp .. | .unreach .. => return code
-  | .let _ k | .uset _ _ _ k _ | .sset _ _ _ _ _ k _ =>
+  | .let _ k | .uset (k := k) .. | .sset (k := k) .. | .inc (k := k) .. | .dec (k := k) .. =>
     return code.updateCont! (← k.simpCase)
 
 def Decl.simpCase (decl : Decl .impure) : CompilerM (Decl .impure) := do

--- a/src/Lean/Compiler/LCNF/SplitSCC.lean
+++ b/src/Lean/Compiler/LCNF/SplitSCC.lean
@@ -34,7 +34,8 @@ where
       goCode k
     | .cases cases => cases.alts.forM (·.forCodeM goCode)
     | .jmp .. | .return .. | .unreach .. => return ()
-    | .uset _ _ _ k _ | .sset _ _ _ _ _ k _ => goCode k
+    | .uset (k := k) .. | .sset (k := k) .. | .inc (k := k) .. | .dec (k := k) .. =>
+      goCode k
 
 end SplitScc
 

--- a/src/Lean/Compiler/LCNF/ToExpr.lean
+++ b/src/Lean/Compiler/LCNF/ToExpr.lean
@@ -120,6 +120,14 @@ partial def Code.toExprM (code : Code pu) : ToExprM Expr := do
     let value := mkApp3 (mkConst `uset) (.fvar fvarId) (toExpr offset) (.fvar y)
     let body ← withFVar fvarId k.toExprM
     return .letE `dummy (mkConst ``Unit) value body true
+  | .inc fvarId n check persistent k _ =>
+    let value := mkApp4 (mkConst `inc) (.fvar fvarId) (toExpr n) (toExpr check) (toExpr persistent)
+    let body ← withFVar fvarId k.toExprM
+    return .letE `dummy (mkConst ``Unit) value body true
+  | .dec fvarId n check persistent k _ =>
+    let body ← withFVar fvarId k.toExprM
+    let value := mkApp4 (mkConst `dec) (.fvar fvarId) (toExpr n) (toExpr check) (toExpr persistent)
+    return .letE `dummy (mkConst ``Unit) value body true
 end
 
 public def Code.toExpr (code : Code pu) (xs : Array FVarId := #[]) : Expr :=


### PR DESCRIPTION
This PR adds `inc`/`dec` instructions to LCNF. It should be a functional no-op.