### PR TITLE
fix: cancellation of non-incremental commands

### DIFF
--- a/src/Lean/Elab/Command.lean
+++ b/src/Lean/Elab/Command.lean
@@ -390,6 +390,10 @@ Disables incremental command reuse *and* reporting for `act` if `cond` is true b
 -/
 def withoutCommandIncrementality (cond : Bool) (act : CommandElabM α) : CommandElabM α := do
   let opts ← getOptions
+  -- Cancel old elaboration when discarding it (for commands without incrementality support)
+  if cond then
+    if let some old := (← read).snap?.bind (·.old?) then
+      old.val.cancelRec
   withReader (fun ctx => { ctx with snap? := ctx.snap?.filter fun snap => Id.run do
     if let some old := snap.old? then
       if cond && opts.getBool `trace.Elab.reuse then

--- a/tests/lean/interactive/cancellation.lean
+++ b/tests/lean/interactive/cancellation.lean
@@ -183,3 +183,15 @@ theorem t1 : True := (by
     -- (should never print "blocked")
   wait_for_main_cancel_once_async
   trivial)
+
+-- RESET
+import Lean.Server.Test.Cancel
+open Lean.Server.Test.Cancel
+
+/-! Changes in a command should cancel non-incremental `elab_rules` elaboration. -/
+
+wait_for_cancel_once_command 1
+                           --^ waitFor: blocked
+                           --^ change: "1" "2"
+                           --^ collectDiagnostics
+                           -- (should print "cancelled!" exactly once)

--- a/tests/lean/interactive/cancellation.lean.expected.out
+++ b/tests/lean/interactive/cancellation.lean.expected.out
@@ -217,3 +217,5 @@ cancelled!
    "fullRange":
    {"start": {"line": 6, "character": 0},
     "end": {"line": 13, "character": 10}}}]}
+cancelled!
+{"version": 2, "uri": "file:///cancellation.lean", "diagnostics": []}


### PR DESCRIPTION
This PR fixes an issue where commands that do not support incrementality did not have their elaboration interrupted when a relevant edit is made by the user. As all built-in variants of def/theorem share a common incremental elaborator, this likely had negligible impact on standard Lean files but could affect other use cases heavily relying on custom commands such as Verso.