### PR TITLE
fix: instantiate mvars after synthesizing inductive type header

### DIFF
--- a/src/Lean/Elab/MutualInductive.lean
+++ b/src/Lean/Elab/MutualInductive.lean
@@ -306,6 +306,7 @@ private def elabHeadersAux (views : Array InductiveView) (i : Nat) (acc : Array 
           let typeStx ← view.type?.getDM `(Sort _)
           let type ← Term.elabType typeStx
           Term.synthesizeSyntheticMVarsNoPostponing
+          let type ← instantiateMVars type
           let inlayHintPos? := view.binders.getTailPos? (canonicalOnly := true)
             <|> view.declId.getTailPos? (canonicalOnly := true)
           let indices ← Term.addAutoBoundImplicits #[] inlayHintPos?

--- a/tests/lean/run/issue12543.lean
+++ b/tests/lean/run/issue12543.lean
@@ -1,0 +1,12 @@
+-- Test for issue #12543: `(kernel) declaration has metavariables` when
+-- an inductive type index refers to a previous index via `by`.
+
+axiom P : Prop
+axiom Q : P → Prop
+
+-- Previously gave: (kernel) declaration has metavariables 'Foo'
+inductive Foo : (h : P) → (Q (by exact h)) → Prop
+
+-- These always worked:
+inductive Foo' : (h : P) → (Q h) → Prop
+inductive Foo'' (h : P) : (Q (by exact h)) → Prop


### PR DESCRIPTION
This PR fixes a `(kernel) declaration has metavariables` error that occurred when a `by` tactic was used in a dependent inductive type index that refers to a previous index:

```lean
axiom P : Prop
axiom Q : P → Prop
-- Previously gave: (kernel) declaration has metavariables 'Foo'
inductive Foo : (h : P) → (Q (by exact h)) → Prop
```

The root cause: `elabDepArrow` calls `mkForallFVars [h_fvar] body` before the `by` tactic's metavariable `?m` is resolved. Since `h_fvar` is in `?m`'s local context, `elimMVarDeps` creates a delayed assignment `?newMVar #[h_fvar] := ?m`. After `synthesizeSyntheticMVarsNoPostponing` assigns `?m := h_fvar`, `instantiateMVars` can resolve the delayed assignment (substituting `h_fvar` with the actual argument, `bvar 0`, in the pending value), yielding the correct type `∀ (h : P), Q (bvar 0) → Prop`. The fix is to call `instantiateMVars` on the header type right after `synthesizeSyntheticMVarsNoPostponing` in `elabHeadersAux`.

Fixes #12543.

🤖 This PR was created with [Claude Code](https://claude.ai/claude-code).