### PR TITLE
chore: rename SpecTheorems.add to SpecTheorems.insert, add SpecProof.getProof

### DIFF
--- a/src/Lean/Elab/Tactic/Do/VCGen/Basic.lean
+++ b/src/Lean/Elab/Tactic/Do/VCGen/Basic.lean
@@ -230,14 +230,14 @@ def mkSpecContext (optConfig : Syntax) (lemmas : Syntax) (ignoreStarArg := false
         let info ← getConstInfo declName
         try
           let thm ← mkSpecTheoremFromConst declName
-          specThms := specThms.add thm
+          specThms := specThms.insert thm
         catch _ =>
           simpStuff := simpStuff.push ⟨arg⟩
       | some (.fvar fvar) =>
         let decl ← getFVarLocalDecl (.fvar fvar)
         try
           let thm ← mkSpecTheoremFromLocal fvar
-          specThms := specThms.add thm
+          specThms := specThms.insert thm
         catch _ =>
           simpStuff := simpStuff.push ⟨arg⟩
       | _ => withRef term <| throwError "Could not resolve spec theorem `{term}`"
@@ -260,7 +260,7 @@ def mkSpecContext (optConfig : Syntax) (lemmas : Syntax) (ignoreStarArg := false
       unless specThms.isErased (.local fvar) do
         try
           let thm ← mkSpecTheoremFromLocal fvar
-          specThms := specThms.add thm
+          specThms := specThms.insert thm
         catch _ => continue
   return {
     config,
@@ -278,7 +278,7 @@ def withLocalSpecs [Monad m] [MonadControlT VCGenM m] (xs : Array Expr) (k : m �
         try
           let thm ← mkSpecTheoremFromLocal x.fvarId! (eval_prio low)
           trace[Elab.Tactic.Do.vcgen] "adding {thm.proof}"
-          withReader (fun ctx => { ctx with specThms := ctx.specThms.add thm }) (loop (i + 1))
+          withReader (fun ctx => { ctx with specThms := ctx.specThms.insert thm }) (loop (i + 1))
         catch ex =>
           match ex with
           | .internal .. => throw ex

--- a/tests/bench/mvcgen/sym/lib/VCGen.lean
+++ b/tests/bench/mvcgen/sym/lib/VCGen.lean
@@ -546,14 +546,14 @@ meta def mkSpecContext (lemmas : Syntax) (ignoreStarArg := false) : TacticM VCGe
         let info ← getConstInfo declName
         try
           let thm ← mkSpecTheoremFromConst declName
-          specThms := specThms.add thm
+          specThms := specThms.insert thm
         catch _ =>
           simpStuff := simpStuff.push ⟨arg⟩
       | some (.fvar fvar) =>
         let decl ← getFVarLocalDecl (.fvar fvar)
         try
           let thm ← mkSpecTheoremFromLocal fvar
-          specThms := specThms.add thm
+          specThms := specThms.insert thm
         catch _ =>
           simpStuff := simpStuff.push ⟨arg⟩
       | _ => withRef term <| throwError "Could not resolve {repr term}"
@@ -576,7 +576,7 @@ meta def mkSpecContext (lemmas : Syntax) (ignoreStarArg := false) : TacticM VCGe
       unless specThms.isErased (.local fvar) do
         try
           let thm ← mkSpecTheoremFromLocal fvar
-          specThms := specThms.add thm
+          specThms := specThms.insert thm
         catch _ => continue
   let entailsConsIntroRule ← mkBackwardRuleFromDecl ``SPred.entails_cons_intro
   return { specThms, entailsConsIntroRule }


### PR DESCRIPTION
This PR renames `SpecTheorems.add` to `SpecTheorems.insert`