### PR TITLE
feat: make computed_fields respect inline

### DIFF
--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,5 +1,7 @@
 #include "util/options.h"
 
+// update thy
+
 namespace lean {
 options get_default_options() {
     options opts;


### PR DESCRIPTION
This PR makes `computed_field` respect the inline attributes on the function for computing the
field. This means we can inline the accessor for the field, allowing quicker access.
