### PR TITLE
perf: use pointer equality in Name.quickCmp

### DIFF
--- a/src/Lean/Data/Name.lean
+++ b/src/Lean/Data/Name.lean
@@ -96,6 +96,15 @@ def quickCmpAux : Name → Name → Ordering
     | Ordering.eq => n.quickCmpAux n'
     | ord => ord
 
+private def quickCmpImpl (n₁ n₂ : Name) : Ordering :=
+  if unsafe ptrEq n₁ n₂ then
+    Ordering.eq
+  else
+    match compare n₁.hash n₂.hash with
+    | Ordering.eq => quickCmpAux n₁ n₂
+    | ord => ord
+
+@[implemented_by quickCmpImpl]
 def quickCmp (n₁ n₂ : Name) : Ordering :=
   match compare n₁.hash n₂.hash with
   | Ordering.eq => quickCmpAux n₁ n₂


### PR DESCRIPTION
This PR uses a `ptrEq` fast path for `Name.quickCmp`. It is particularly effective at speeding up
`quickCmp` calls in `TreeMap`'s indexed by `FVarId` as usually there is only one pointer per `FVarId`
so equality is always instantly detected without traversing the linked list of `Name` components.

I had to use an `implemented_by` instead of just changing the definition as lake proves things about
`quickCmp` for use in a `DTreeMap`.
