### PR TITLE
fix: update bump branch toolchain to nightly for all repos

### DIFF
--- a/script/release_checklist.py
+++ b/script/release_checklist.py
@@ -924,8 +924,8 @@ def main():
             
             print(f"  ✅ Bump branch {bump_branch} exists")
             
-            # For batteries and mathlib4, update the lean-toolchain to the latest nightly
-            if branch_created and name in ["batteries", "mathlib4"]:
+            # Update the lean-toolchain to the latest nightly for newly created bump branches
+            if branch_created:
                 latest_nightly = get_latest_nightly_tag(github_token)
                 if latest_nightly:
                     nightly_toolchain = f"leanprover/lean4:{latest_nightly}"


### PR DESCRIPTION
This PR fixes the release checklist to update the lean-toolchain to the latest
nightly on newly created bump branches for all repositories, not just batteries
and mathlib4. Previously cslib (and any future repos with `bump-branch: true`)
would inherit the toolchain from main, causing nightly testing warnings like
https://leanprover.zulipchat.com/#narrow/channel/428973-nightly-testing/topic/Cslib.20status.20updates/near/574648029

🤖 Prepared with Claude Code