### PR TITLE
fix: rendering of hygiene info nodes in Verso docstring code blocks

### DIFF
--- a/src/Lean/Elab/DocString/Builtin.lean
+++ b/src/Lean/Elab/DocString/Builtin.lean
@@ -786,6 +786,13 @@ where
     match stx with
     | .node info kind args =>
       emitLeading info
+      if kind == hygieneInfoKind then
+        -- hygieneInfo nodes contain no source text; skip content but preserve whitespace
+        for arg in args do
+          emitLeading arg.getHeadInfo
+          emitTrailing arg.getHeadInfo
+        emitTrailing info
+        return
       if isLitKind kind then
         match args with
         | #[.atom info' str] =>


### PR DESCRIPTION
This PR fixes a bug with rendering of hygiene info nodes in embedded Verso code examples. The embedded anonymous identifier was being rendered as [anonymous] instead of being omitted.
