### PR TITLE
chore: fix repeated cmake calls breaking the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,13 +70,7 @@ if(NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten")
       BUILD_IN_SOURCE ON
       INSTALL_COMMAND ""
     )
-    set(
-      CADICAL
-      ${CMAKE_BINARY_DIR}/cadical/cadical${CMAKE_EXECUTABLE_SUFFIX}
-      CACHE FILEPATH
-      "path to cadical binary"
-      FORCE
-    )
+    set(CADICAL ${CMAKE_BINARY_DIR}/cadical/cadical${CMAKE_EXECUTABLE_SUFFIX})
     list(APPEND EXTRA_DEPENDS cadical)
   endif()
   list(APPEND CL_ARGS -DCADICAL=${CADICAL})


### PR DESCRIPTION
Cmake only builds cadical if it isn't already installed on the user's system. However, it then force-updates the cache variable with the new path to the built cadical binary, leading subsequent cmake calls to believe cadical is already installed on the user's system.

This only becomes a problem when cmake is called more than once before the first call to make, which apparently happens roughly never.