### PR TITLE
feat: add warning for `cbv` and `decide_cbv` tactics

### DIFF
--- a/src/Lean/Elab/Tactic/Cbv.lean
+++ b/src/Lean/Elab/Tactic/Cbv.lean
@@ -13,11 +13,15 @@ public section
 
 namespace Lean.Elab.Tactic.Cbv
 
+open Lean.Meta.Tactic.Cbv
+
 @[builtin_tactic Lean.Parser.Tactic.cbv] def evalCbv : Tactic := fun stx =>
   match stx with
   | `(tactic| cbv) => withMainContext do
+    if cbv.warning.get (← getOptions) then
+      logWarningAt stx "The `cbv` tactic is experimental and still under development. Avoid using it in production projects"
     liftMetaTactic fun mvar => do
-      match (← Lean.Meta.Tactic.Cbv.cbvGoal mvar) with
+      match (← cbvGoal mvar) with
       | .none => return []
       | .some newGoal => return [newGoal]
   | _ => throwUnsupportedSyntax
@@ -25,9 +29,11 @@ namespace Lean.Elab.Tactic.Cbv
 @[builtin_tactic Lean.Parser.Tactic.decide_cbv] def evalDecideCbv : Tactic := fun stx =>
   match stx with
   | `(tactic| decide_cbv) => withMainContext do
+    if cbv.warning.get (← getOptions) then
+      logWarningAt stx "The `decide_cbv` tactic is experimental and still under development. Avoid using it in production projects"
     liftMetaFinishingTactic fun mvar => do
       let [mvar'] ← mvar.applyConst ``of_decide_eq_true | throwError "Could not apply `of_decide_eq_true`"
-      Lean.Meta.Tactic.Cbv.cbvDecideGoal mvar'
+      cbvDecideGoal mvar'
   | _ => throwUnsupportedSyntax
 
 end Lean.Elab.Tactic.Cbv

--- a/tests/lean/run/12457.lean
+++ b/tests/lean/run/12457.lean
@@ -1,1 +1,3 @@
+set_option cbv.warning false
+
 example : ("abc".pos ⟨1⟩ (by decide_cbv)).get (by decide_cbv) = 'b' := by decide_cbv

--- a/tests/lean/run/decide_cbv1.lean
+++ b/tests/lean/run/decide_cbv1.lean
@@ -1,4 +1,5 @@
 import Std
+set_option cbv.warning false
 
 example : 1 ∈ [1,2,3] := by decide_cbv
 

--- a/tests/lean/run/decide_cbv_errors.lean
+++ b/tests/lean/run/decide_cbv_errors.lean
@@ -1,3 +1,5 @@
+set_option cbv.warning false
+
 -- Success: proposition reduces to `Bool.true`
 example : 1 + 1 = 2 := by decide_cbv
 

--- a/tests/lean/run/string.lean
+++ b/tests/lean/run/string.lean
@@ -1,4 +1,5 @@
 module
+set_option cbv.warning false
 
 /-!
 # Tests for `String` functions


### PR DESCRIPTION
This PR adds a warning when using `cbv` or `decide_cbv` in tactic mode, matching the existing warning in conv mode (`src/Lean/Elab/Tactic/Conv/Cbv.lean`). The warning informs users that these tactics are experimental and still under development. It can be disabled with `set_option cbv.warning false`.