### PR TITLE
feat: `pp.mdata`

### DIFF
--- a/src/Lean/Parser/Term.lean
+++ b/src/Lean/Parser/Term.lean
@@ -1016,6 +1016,14 @@ string or a `MessageData` term.
 @[builtin_term_parser] def logNamedWarningAtMacro := leading_parser
   "logNamedWarningAt " >> termParser maxPrec >> ppSpace >> identWithPartialTrailingDot >> ppSpace >> (interpolatedStr termParser <|> termParser maxPrec)
 
+/--
+Representation of an expression with metadata used during pretty printing for the `pp.mdata` option.
+-/
+@[run_builtin_parser_attribute_hooks]
+def mdataDiagnostic := leading_parser
+  group ("[" >> "mdata" >> many (group <| ppSpace >> ident >> optional (":" >> termParser)) >> "]") >>
+  ppSpace >> termParser
+
 end Term
 
 @[builtin_term_parser default+1] def Tactic.quot : Parser := leading_parser

--- a/src/Lean/PrettyPrinter/Delaborator/Options.lean
+++ b/src/Lean/PrettyPrinter/Delaborator/Options.lean
@@ -98,6 +98,10 @@ register_builtin_option pp.numericTypes : Bool := {
   defValue := false
   descr    := "(pretty printer) display types of numeric literals"
 }
+register_builtin_option pp.mdata : Bool := {
+  defValue := false
+  descr    := "(pretty printer) displays a representation of mdata annotations"
+}
 register_builtin_option pp.instantiateMVars : Bool := {
   defValue := true
   descr    := "(pretty printer) instantiate mvars before delaborating"
@@ -260,6 +264,7 @@ def getPPTagAppFns (o : Options) : Bool := o.get pp.tagAppFns.name (getPPAll o)
 def getPPUniverses (o : Options) : Bool := o.get pp.universes.name (getPPAll o)
 def getPPFullNames (o : Options) : Bool := o.get pp.fullNames.name (getPPAll o)
 def getPPPrivateNames (o : Options) : Bool := o.get pp.privateNames.name (getPPAll o)
+def getPPMData (o : Options) : Bool := o.get pp.mdata.name pp.mdata.defValue
 def getPPInstantiateMVars (o : Options) : Bool := o.get pp.instantiateMVars.name pp.instantiateMVars.defValue
 def getPPMVars (o : Options) : Bool := o.get pp.mvars.name pp.mvars.defValue
 def getPPMVarsAnonymous (o : Options) : Bool := o.get pp.mvars.anonymous.name (pp.mvars.anonymous.defValue && getPPMVars o)

--- a/tests/lean/run/ppMData.lean
+++ b/tests/lean/run/ppMData.lean
@@ -1,0 +1,64 @@
+import Lean.Meta.Basic
+/-!
+# Tests of `pp.mdata`
+-/
+
+open Lean
+
+set_option pp.mdata true
+
+/-!
+Having mdata on the head constant, partially applied, and fully applied.
+-/
+/--
+info: ([mdata n:1 z:-1 b:true s:"str" x:_ m:foo.bar] @id) 3
+---
+info: ([mdata n:1 z:-1 b:true s:"str" x:_ m:foo.bar] id) 3
+---
+info: [mdata n:1 z:-1 b:true s:"str" x:_ m:foo.bar] id 3
+-/
+#guard_msgs in
+run_meta
+  let d : KVMap := KVMap.empty
+    |>.insert `n (1 : Nat)
+    |>.insert `z (-1 : Int)
+    |>.insert `b true
+    |>.insert `s "str"
+    |>.insert `x (Unhygienic.run `(1+1))
+    |>.insert `m `foo.bar
+  Lean.logInfo <| mkApp2 (.mdata d <| .const ``id [1]) (mkConst ``Nat) (.lit (.natVal 3))
+  Lean.logInfo <| Expr.app (.mdata d <| Expr.app (.const ``id [1]) (mkConst ``Nat)) (.lit (.natVal 3))
+  Lean.logInfo <| Expr.mdata d <| mkApp2 (.const ``id [1]) (mkConst ``Nat) (.lit (.natVal 3))
+
+/-!
+`noindex`
+-/
+/-- info: [mdata noindex:true] 2 : Nat -/
+#guard_msgs in #check no_index 2
+
+/-!
+Metadata blocks unexpanders
+-/
+/-- info: ([mdata noindex:true] HAdd.hAdd) 2 3 : Nat -/
+#guard_msgs in #check (no_index HAdd.hAdd) 2 3
+/-- info: 2 + 3 : Nat -/
+#guard_msgs in #check HAdd.hAdd 2 3
+
+/-!
+Metadata blocks dot notation, both in implicit and explicit mode
+-/
+/-- info: ([mdata noindex:true] Nat.add) x y : Nat -/
+#guard_msgs in variable (x y : Nat) in #check (no_index Nat.add) x y
+/-- info: x.add y : Nat -/
+#guard_msgs in variable (x y : Nat) in #check Nat.add x y
+/-- info: [mdata noindex:true] x.add y : Nat -/
+#guard_msgs in variable (x y : Nat) in #check no_index (Nat.add x y)
+section
+set_option pp.explicit true
+/-- info: ([mdata noindex:true] Nat.add) x y : Nat -/
+#guard_msgs in variable (x y : Nat) in #check (no_index Nat.add) x y
+/-- info: x.add y : Nat -/
+#guard_msgs in variable (x y : Nat) in #check Nat.add x y
+/-- info: [mdata noindex:true] x.add y : Nat -/
+#guard_msgs in variable (x y : Nat) in #check no_index (Nat.add x y)
+end


### PR DESCRIPTION
This PR adds the pretty printer option `pp.mdata`, which causes the pretty printer to annotate terms with any metadata that is present. For example,
```lean
set_option pp.mdata true
/-- info: [mdata noindex:true] 2 : Nat -/
#guard_msgs in #check no_index 2
```
The `[mdata ...] e` syntax is only for pretty printing.

Thanks to @Rob23oba for an initial version.

Closes #10929