### PR TITLE
fix: make `tactic .. at *` save info contexts

### DIFF
--- a/src/Lean/Elab/Tactic/Location.lean
+++ b/src/Lean/Elab/Tactic/Location.lean
@@ -64,7 +64,7 @@ def withLocation (loc : Location) (atLocal : FVarId → TacticM Unit) (atTarget 
     if type then
       withMainContext atTarget
   | Location.wildcard =>
-    let worked ← tryTactic <| withMainContext <| atTarget
+    let worked ← tryTactic <| withSaveInfoContext <| withMainContext <| atTarget
     let g ← try getMainGoal catch _ => return () -- atTarget closed the goal
     g.withContext do
       let mut worked := worked
@@ -72,7 +72,7 @@ def withLocation (loc : Location) (atLocal : FVarId → TacticM Unit) (atTarget 
       for fvarId in (← getLCtx).getFVarIds.reverse do
         if (← fvarId.getDecl).isImplementationDetail then
           continue
-        worked := worked || (← tryTactic <| withMainContext <| atLocal fvarId)
+        worked := worked || (← tryTactic <| withSaveInfoContext <| withMainContext <| atLocal fvarId)
       unless worked do
         failed (← getMainGoal)
 

--- a/tests/lean/interactive/10898.lean
+++ b/tests/lean/interactive/10898.lean
@@ -1,0 +1,9 @@
+/-!
+# `rw .. at *` should save metacontext
+-/
+
+example (h : 1 + 2 = 3) : True := by
+  rewrite [Nat.add_comm _] at *
+                      --^ $/lean/plainGoal
+                      --^ $/lean/plainTermGoal
+  trivial

--- a/tests/lean/interactive/10898.lean.expected.out
+++ b/tests/lean/interactive/10898.lean.expected.out
@@ -1,0 +1,9 @@
+{"textDocument": {"uri": "file:///10898.lean"},
+ "position": {"line": 5, "character": 24}}
+{"rendered": "```lean\nh : 2 + 1 = 3\n⊢ True\n```",
+ "goals": ["h : 2 + 1 = 3\n⊢ True"]}
+{"textDocument": {"uri": "file:///10898.lean"},
+ "position": {"line": 5, "character": 24}}
+{"range":
+ {"start": {"line": 5, "character": 24}, "end": {"line": 5, "character": 25}},
+ "goal": "h : 1 + 2 = 3\n⊢ Nat"}


### PR DESCRIPTION
This PR fixes an issue where `withLocation` wasn't saving the info context, which meant that tactics that use `at *` location syntax and do term elaboration would save infotrees but revert the metacontext, leading to Infoview messages like "Error updating: Error fetching goals: Rpc error: InternalError: unknown metavariable" if the tactic failed at some locations but succeeded at others.

Closes #10898