### PR TITLE
feat: clean up binder annotations inside of `let rec` definitions

### DIFF
--- a/src/Lean/Elab/LetRec.lean
+++ b/src/Lean/Elab/LetRec.lean
@@ -95,7 +95,7 @@ private partial def withAuxLocalDecls {α} (views : Array LetRecDeclView) (k : A
 
 private def elabLetRecDeclValues (view : LetRecView) : TermElabM (Array Expr) :=
   view.decls.mapM fun view => do
-    forallBoundedTelescope view.type view.binderIds.size fun xs type => do
+    forallBoundedTelescope view.type view.binderIds.size (cleanupAnnotations := true) fun xs type => do
       -- Add new info nodes for new fvars. The server will detect all fvars of a binder by the binder's source location.
       for h : i in *...view.binderIds.size do
         addLocalVarInfo view.binderIds[i] xs[i]!

--- a/tests/lean/run/cleanupTypeAnnotations.lean
+++ b/tests/lean/run/cleanupTypeAnnotations.lean
@@ -9,7 +9,7 @@ set_option pp.mvars false
 Test definitions, theorems, and instances. (MutualDef elaborator)
 Both scope variables and header variables are handled.
 -/
-
+section
 variable (a := true)
 
 /--
@@ -115,3 +115,37 @@ f : optParam Nat 0 → Nat := fun x => x
 example : True :=
   let f (x : Nat := 0) := by trace_state; exact x
   by trace_state; trivial
+
+end
+
+/-!
+Let rec, both as `where` and as real `let rec`.
+-/
+/--
+trace: n✝ : Nat
+x : Bool
+n : Nat
+⊢ Nat
+-/
+#guard_msgs in
+def bar := go 1000
+where
+  go (n : Nat) (x := true) := match n with
+    | 0 => 0
+    | n+1 => by trace_state; exact go n + 1
+/--
+trace: n✝ : Nat
+x : Bool
+n : Nat
+⊢ Nat
+-/
+#guard_msgs in
+def bar' :=
+  let rec go (n : Nat) (x := true) := match n with
+    | 0 => 0
+    | n+1 => by trace_state; exact go n + 1
+  go 1000
+/-- info: bar.go (n : Nat) (x : Bool := true) : Nat -/
+#guard_msgs in #check bar.go
+/-- info: bar'.go (n : Nat) (x : Bool := true) : Nat -/
+#guard_msgs in #check bar'.go


### PR DESCRIPTION
This PR continues #9674, cleaning up binder annotations inside the bodies of `let rec` and `where` definitions.

Closes #11025