### PR TITLE
chore: enable leanprover/skills plugin for Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "leanprover": {
+      "source": {
+        "source": "github",
+        "repo": "leanprover/skills"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "lean@leanprover": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ compile_commands.json
 *.idea
 tasks.json
 settings.json
+!.claude/settings.json
 .gdb_history
 .vscode/*
 script/__pycache__


### PR DESCRIPTION
This PR registers the [leanprover/skills](https://github.com/leanprover/skills) plugin marketplace in `.claude/settings.json` so that Claude Code users working on lean4 are automatically prompted to install it.

Also un-ignores `.claude/settings.json` in `.gitignore` — the blanket `settings.json` rule was blocking it from being tracked.

🤖 Prepared with Claude Code