### PR TITLE
perf: only instantiate mvars in RHS of simp theorem

### DIFF
--- a/src/Lean/Meta/Tactic/Simp/Rewrite.lean
+++ b/src/Lean/Meta/Tactic/Simp/Rewrite.lean
@@ -126,7 +126,7 @@ private def tryTheoremCore (lhs : Expr) (xs : Array Expr) (bis : Array BinderInf
           trace[Meta.Tactic.simp.rewrite] "{← ppSimpTheorem thm}, has unassigned metavariables after unification"
           return none
         pure <| some proof
-      let rhs := (← instantiateMVars type).appArg!
+      let rhs ← instantiateMVars type.appArg!
       /-
       We used to use `e == rhs` in the following test.
       However, it include unnecessary proof steps when `e` and `rhs`


### PR DESCRIPTION
This PR stops `simp` from running `instantiateMVars` on the LHS of a used theorem. We only care about instantiating metavariables in the RHS.

This may give a small performance improvement.
