### PR TITLE
fix: respect @[cbv_opaque] in reduceRecMatcher and reduceProj

### DIFF
--- a/src/Lean/Meta/Tactic/Cbv/ControlFlow.lean
+++ b/src/Lean/Meta/Tactic/Cbv/ControlFlow.lean
@@ -18,6 +18,7 @@ import Lean.Meta.WHNF
 import Lean.Meta.AppBuilder
 import Init.Sym.Lemmas
 import Lean.Meta.Tactic.Cbv.TheoremsLookup
+import Lean.Meta.Tactic.Cbv.Opaque
 namespace Lean.Meta.Sym.Simp
 open Internal
 
@@ -146,12 +147,36 @@ end Lean.Meta.Sym.Simp
 namespace Lean.Meta.Tactic.Cbv
 open Lean.Meta.Sym.Simp
 
+/--
+Run a `MetaM` computation with `whnf` blocked from unfolding `@[cbv_opaque]` definitions.
+This prevents kernel-level reduction (used by `reduceRecMatcher?` and `reduceProj?`)
+from bypassing the `@[cbv_opaque]` attribute.
+-/
+public def withCbvOpaqueGuard (x : MetaM α) : MetaM α := do
+  let prev := (← readThe Meta.Context).canUnfold?
+  withCanUnfoldPred (fun cfg info => do
+    if (← isCbvOpaque info.name) then return false
+    match prev with
+    | some f => f cfg info
+    | none =>
+      -- Duplicates `canUnfoldDefault` from `Lean.Meta.GetUnfoldableConst` (private).
+      match cfg.transparency with
+      | .none => return false
+      | .all  => return true
+      | .default => return !(← isIrreducible info.name)
+      | m =>
+        let status ← getReducibilityStatus info.name
+        if status == .reducible then return true
+        else if m == .instances && status == .implicitReducible then return true
+        else return false
+  ) x
+
 def tryMatchEquations (appFn : Name) : Simproc := fun e => do
   let thms ← getMatchTheorems appFn
   thms.rewrite (d := dischargeNone) e
 
 public def reduceRecMatcher : Simproc := fun e => do
-  if let some e' ← reduceRecMatcher? e then
+  if let some e' ← withCbvOpaqueGuard <| reduceRecMatcher? e then
     return .step e' (← Sym.mkEqRefl e')
   else
     return .rfl

--- a/src/Lean/Meta/Tactic/Cbv/Main.lean
+++ b/src/Lean/Meta/Tactic/Cbv/Main.lean
@@ -95,7 +95,7 @@ def handleProj : Simproc := fun e => do
   let res ← simp struct
   match res with
   | .rfl _ =>
-    let some reduced ← reduceProj? <| .proj typeName idx struct | do
+    let some reduced ← withCbvOpaqueGuard <| reduceProj? <| .proj typeName idx struct | do
       return .rfl (done := true)
 
     -- TODO: Figure if we can share this term incrementally
@@ -111,7 +111,7 @@ def handleProj : Simproc := fun e => do
       return .step (← Lean.Expr.updateProjS! e e') newProof
     else
       -- If the type of the projection function is dependent, we first try to reduce the projection
-      let reduced ← reduceProj? e
+      let reduced ← withCbvOpaqueGuard <| reduceProj? e
       match reduced with
       | .some reduced =>
         let reduced ← Sym.share reduced

--- a/tests/lean/run/cbv_opaque_guard.lean
+++ b/tests/lean/run/cbv_opaque_guard.lean
@@ -1,0 +1,95 @@
+set_option cbv.warning false
+
+/-! Test that `@[cbv_opaque]` is respected by `reduceRecMatcher` and `reduceProj`. -/
+
+/-! `@[cbv_opaque]` constants are not unfolded. -/
+
+@[cbv_opaque] def secret : Nat := 42
+
+/--
+error: unsolved goals
+⊢ secret = 42
+-/
+#guard_msgs in
+example : secret = 42 := by conv => lhs; cbv
+
+/-! Equation theorems fire but `@[cbv_opaque]` arguments stay intact. -/
+
+def addOne (n : Nat) : Nat := n + 1
+
+/--
+error: unsolved goals
+⊢ secret.succ = 43
+-/
+#guard_msgs in
+example : addOne secret = 43 := by conv => lhs; cbv
+
+/-! Pattern matching on a `@[cbv_opaque]` discriminant gets stuck. -/
+
+def isZero (n : Nat) : Bool :=
+  match n with
+  | 0 => true
+  | _ + 1 => false
+
+/--
+error: unsolved goals
+⊢ (match secret with
+    | 0 => true
+    | n.succ => false) =
+    false
+-/
+#guard_msgs in
+example : isZero secret = false := by conv => lhs; cbv
+
+/-! Recursive functions with `@[cbv_opaque]` arguments get stuck at the match. -/
+
+def myLength : List Nat → Nat
+  | [] => 0
+  | _ :: xs => 1 + myLength xs
+
+@[cbv_opaque] def secretList : List Nat := [1, 2, 3]
+
+/--
+error: unsolved goals
+⊢ (match secretList with
+    | [] => 0
+    | head :: xs => 1 + myLength xs) =
+    3
+-/
+#guard_msgs in
+example : myLength secretList = 3 := by conv => lhs; cbv
+
+/-! Projections on `@[cbv_opaque]` structures are not reduced. -/
+
+@[cbv_opaque] def secretPair : Nat × Nat := (10, 20)
+
+/--
+error: unsolved goals
+⊢ secretPair.1 = 10
+-/
+#guard_msgs in
+example : secretPair.1 = 10 := by conv => lhs; cbv
+
+/--
+error: unsolved goals
+⊢ secretPair.2 = 20
+-/
+#guard_msgs in
+example : secretPair.2 = 20 := by conv => lhs; cbv
+
+/-! Non `@[cbv_opaque]` values still reduce normally. -/
+
+def normalVal : Nat := 42
+
+example : normalVal + 1 = 43 := by cbv
+example : isZero normalVal = false := by cbv
+
+def normalPair : Nat × Nat := (10, 20)
+
+example : normalPair.1 = 10 := by cbv
+example : normalPair.2 = 20 := by cbv
+
+/-! The kernel's `isDefEq` in `cbvGoalCore` still closes `@[cbv_opaque]` goals. -/
+
+example : secret = 42 := by cbv
+example : secretPair.1 = 10 := by cbv


### PR DESCRIPTION
This PR fixes a bug where `reduceRecMatcher?` and `reduceProj?` bypassed the `@[cbv_opaque]` attribute. These kernel-level reduction functions use `whnf` internally, which does not know about `@[cbv_opaque]`. This meant `@[cbv_opaque]` values were unfolded when they appeared as match discriminants, recursor major premises, or projection targets. The fix introduces `withCbvOpaqueGuard`, which wraps these calls with `withCanUnfoldPred` to prevent `whnf` from unfolding `@[cbv_opaque]` definitions.