### PR TITLE
fix: interaction between `simp` and `backward.whnf.reducibleClassField`

### DIFF
--- a/tests/lean/run/simp_reducibleClassField.lean
+++ b/tests/lean/run/simp_reducibleClassField.lean
@@ -1,0 +1,9 @@
+set_option backward.whnf.reducibleClassField true in
+example [Ord α] {a b : α} :
+    (letI : Ord α := ⟨fun a b => compare b a⟩; compare a b) = compare b a := by
+  simp only
+
+set_option backward.whnf.reducibleClassField true in
+example [Ord α] {a b : α} :
+    (letI : Ord α := ⟨fun a b => compare b a⟩; compare a b) = compare b a := by
+  simp


### PR DESCRIPTION
This PR fixes a bug where `simp` made no progress on class projection reductions when `backward.whnf.reducibleClassField` is `true`.

- In `reduceProjFn?`, for class projections applied to constructor instances (`Class.projFn (Class.mk ...)`), the code called `reduceProjCont? (← unfoldDefinitionAny? e)`. The helper `reduceProjCont?` expects the unfolded result to have a `.proj` head so it can apply `reduceProj?`. However, when `reducibleClassField` is enabled, `unfoldDefault` in WHNF.lean already reduces the `.proj` node during unfolding, so `reduceProjCont?` discards the fully-reduced result.
- The fix uses `unfoldDefinitionAny?` directly, bypassing `reduceProjCont?`. The dsimp traversal revisits the result (via `.visit`) and handles any remaining `.proj` nodes naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)