### PR TITLE
perf: improve proof-over-applied cases in `ToLCNF`

### DIFF
--- a/src/Lean/Compiler/LCNF/ToLCNF.lean
+++ b/src/Lean/Compiler/LCNF/ToLCNF.lean
@@ -452,6 +452,40 @@ private def checkComputable (ref : Name) : M Unit := do
     throwNamedError lean.dependsOnNoncomputable f!"`{ref}` not supported by code generator; consider marking definition as `noncomputable`"
 
 /--
+Given a motive `fun ... => ∀ (h₁ : p₁) ... (hₙ : pₙ), ...` where all `pᵢ` are propositions,
+returns `min maxArgs n`.
+-/
+def countProofOverApp (motive : Expr) (maxArgs : Nat) : MetaM Nat := do
+  Meta.lambdaTelescope motive fun vars body => do
+    Meta.forallTelescope body fun forallVars _ => do
+      let n := min maxArgs forallVars.size
+      for h : i in *...n do
+        have h : i < min maxArgs forallVars.size := h
+        unless ← Meta.isProof forallVars[i] do
+          return i
+      return n
+
+/--
+Given `e : ∀ (h₁ : p₁) ... (hₙ : pₙ), b h₁ ... hₙ`, returns `e (lcProof p₁) ... (lcProof pₙ)`.
+-/
+def mkProofOverApp (e : Expr) (n : Nat) : MetaM Expr := do
+  let mut type ← Meta.inferType e
+  if type.getNumHeadForalls < n then
+    type ← Meta.forallBoundedTelescope type n Meta.mkForallFVars
+  go type n #[]
+where
+  go (type : Expr) (n : Nat) (vars : Array Expr) : MetaM Expr :=
+    match n with
+    | 0 => return e.beta vars
+    | k + 1 =>
+      match type with
+      | .forallE _ t b _ =>
+        let t := t.instantiateRev vars
+        go b k (vars.push (mkLcProof t))
+      | .mdata _ type => go type n vars
+      | _ => Meta.throwFunctionExpected (e.beta vars)
+
+/--
 Eta reduce implicits. We use this function to eliminate introduced by the implicit lambda feature,
 where it generates terms such as `fun {α} => ReaderT.pure`
 -/
@@ -581,11 +615,11 @@ where
   /--
   Visit a `matcher`/`casesOn` alternative.
   -/
-  visitAlt (casesAltInfo : CasesAltInfo) (e : Expr) : M (Expr × (Alt .pure)) := do
+  visitAlt (casesAltInfo : CasesAltInfo) (e : Expr) (nproofs : Nat) : M (Expr × (Alt .pure)) := do
     withNewScope do
     match casesAltInfo with
     | .default numHyps =>
-      let c ← toCode (← visit (mkAppN e (Array.replicate numHyps erasedExpr)))
+      let c ← toCode (← visit (← liftMetaM <| mkProofOverApp e (numHyps + nproofs)))
       let altType ← c.inferType
       return (altType, .default c)
     | .ctor ctorName numParams =>
@@ -614,14 +648,16 @@ where
         not occur in the type of `as : List α`.
         -/
         p.update (← applyToAny p.type)
-      let c ← toCode (← visit e)
+      let c ← toCode (← visit (← liftMetaM <| mkProofOverApp e nproofs))
       let altType ← c.inferType
       return (altType, .alt ctorName ps c)
 
   visitCases (casesInfo : CasesInfo) (e : Expr) : M (Arg .pure) :=
     etaIfUnderApplied e casesInfo.arity do
       let args := e.getAppArgs
-      let mut resultType ← toLCNFType (← liftMetaM do Meta.inferType (mkAppN e.getAppFn args[*...casesInfo.arity]))
+      let nproofs ← liftMetaM <| countProofOverApp args[casesInfo.motivePos]! (args.size - casesInfo.arity)
+      let arity := casesInfo.arity + nproofs
+      let mut resultType ← toLCNFType (← liftMetaM do Meta.inferType (mkAppN e.getAppFn args[*...arity]))
       let typeName := casesInfo.indName
       let .inductInfo indVal ← getConstInfo typeName | unreachable!
       if casesInfo.numAlts == 0 then
@@ -651,13 +687,12 @@ where
               fieldArgs := fieldArgs.push fieldArg
             return fieldArgs
         let f := args[casesInfo.altsRange.lower]!
-        let arity := casesInfo.arity
-        if args.size == arity then
+        if args.size == casesInfo.arity then
           visit (mkAppN f fieldArgs)
         else
           withoutExpectedType do
-            let result ← visit (mkAppN f fieldArgs)
-            mkOverApplication result args casesInfo.arity
+            let result ← visit (← liftMetaM <| mkProofOverApp (mkAppN f fieldArgs) nproofs)
+            mkOverApplication result args arity
       else
         let mut alts := #[]
         let discr ← withoutExpectedType do
@@ -666,7 +701,7 @@ where
           | .fvar discrFVarId => pure discrFVarId
           | .erased | .type .. => mkAuxLetDecl .erased
         for i in casesInfo.altsRange, numParams in casesInfo.altNumParams do
-          let (altType, alt) ← visitAlt numParams args[i]!
+          let (altType, alt) ← visitAlt numParams args[i]! nproofs
           resultType := joinTypes altType resultType
           alts := alts.push alt
         let cases := ⟨typeName, resultType, discrFVarId, alts⟩
@@ -674,7 +709,7 @@ where
         pushElement (.cases auxDecl cases)
         let result := .fvar auxDecl.fvarId
         withoutExpectedType do
-          mkOverApplication result args casesInfo.arity
+          mkOverApplication result args arity
 
   visitCtor (arity : Nat) (e : Expr) : M (Arg .pure) :=
     withoutExpectedType do

--- a/src/Lean/Compiler/LCNF/ToLCNF.lean
+++ b/src/Lean/Compiler/LCNF/ToLCNF.lean
@@ -459,8 +459,8 @@ def countProofOverApp (motive : Expr) (maxArgs : Nat) : MetaM Nat := do
   Meta.lambdaTelescope motive fun _ body => do
     Meta.forallTelescope body fun forallVars _ => do
       let n := min maxArgs forallVars.size
-      for h : i in *...n do
-        have h : i < min maxArgs forallVars.size := h
+      for h : i in 0...n do
+        have h : i < min maxArgs forallVars.size := h.2
         unless ← Meta.isProof forallVars[i] do
           return i
       return n

--- a/src/Lean/Compiler/LCNF/ToLCNF.lean
+++ b/src/Lean/Compiler/LCNF/ToLCNF.lean
@@ -456,7 +456,7 @@ Given a motive `fun ... => ∀ (h₁ : p₁) ... (hₙ : pₙ), ...` where all `
 returns `min maxArgs n`.
 -/
 def countProofOverApp (motive : Expr) (maxArgs : Nat) : MetaM Nat := do
-  Meta.lambdaTelescope motive fun vars body => do
+  Meta.lambdaTelescope motive fun _ body => do
     Meta.forallTelescope body fun forallVars _ => do
       let n := min maxArgs forallVars.size
       for h : i in *...n do

--- a/src/Lean/Compiler/LCNF/ToLCNF.lean
+++ b/src/Lean/Compiler/LCNF/ToLCNF.lean
@@ -466,7 +466,8 @@ def countProofOverApp (motive : Expr) (maxArgs : Nat) : MetaM Nat := do
       return n
 
 /--
-Given `e : ∀ (h₁ : p₁) ... (hₙ : pₙ), b h₁ ... hₙ`, returns `e (lcProof p₁) ... (lcProof pₙ)`.
+Given `e : ∀ (h₁ : p₁) ... (hₙ : pₙ), b h₁ ... hₙ`,
+returns the beta reduced `e (lcProof p₁) ... (lcProof pₙ)`.
 -/
 def mkProofOverApp (e : Expr) (n : Nat) : MetaM Expr := do
   let mut type ← Meta.inferType e

--- a/src/Lean/Meta/CasesInfo.lean
+++ b/src/Lean/Meta/CasesInfo.lean
@@ -47,6 +47,7 @@ public structure CasesInfo where
   indName      : Name
   arity        : Nat
   discrPos     : Nat
+  motivePos    : Nat
   altsRange    : Std.Rco Nat
   altNumParams : Array CasesAltInfo
 
@@ -63,6 +64,7 @@ public def getCasesInfo? (declName : Name) : CoreM (Option CasesInfo) := do
       assert! r.appArg!.isFVar  -- major argument
       assert! r.getAppFn.isFVar -- motive
       let some discrPos := xs.idxOf? r.appArg! | unreachable!
+      let some motivePos := xs.idxOf? r.getAppFn | unreachable!
       let some indName := (← inferType xs[discrPos]!).getAppFn.constName? | unreachable!
       -- We recognize the per-ctor elims side condition here
       let xsTys ← (xs.extract (discrPos+1)).mapM inferType
@@ -82,6 +84,6 @@ public def getCasesInfo? (declName : Name) : CoreM (Option CasesInfo) := do
             let some ctorName := motiveArg.getAppFn.constName? | unreachable!
             let ctorVal ← getConstInfoCtor ctorName
             return .ctor ctorName ctorVal.numFields
-      return some { declName, indName, arity, discrPos, altsRange, altNumParams }
+      return some { declName, indName, arity, discrPos, motivePos, altsRange, altNumParams }
 
 end Lean

--- a/tests/elab/12814.lean
+++ b/tests/elab/12814.lean
@@ -1,0 +1,72 @@
+/-!
+Regression test for #12814: when we pattern match on a discriminant that occurs in a local
+hypothesis, ToLCNF previously used a very generalized mechanism to handle this situation. However,
+after a round of simplification all of the generated overhead just disappears. Thus, we special
+cased this situation to generate code that is much closer to what we would have generated if no
+dependent hypotheses were in scope.
+-/
+
+@[noinline]
+def hole {P : Prop} (n : Nat) (_h : P) : Nat := n
+
+/--
+trace: [Compiler.init] size: 9
+    def ex1 n h : Nat :=
+      fun _f.1 h : Nat :=
+        let _x.2 := @hole ◾ n ◾;
+        return _x.2;
+      let _alt.3 := _f.1;
+      fun _f.4 k h : Nat :=
+        let _x.5 := @hole ◾ k ◾;
+        return _x.5;
+      let _alt.6 := _f.4;
+      cases n : Nat
+      | Nat.zero =>
+        let _x.7 := _alt.3 ◾;
+        return _x.7
+      | Nat.succ n.8 =>
+        let _x.9 := _alt.6 n.8 ◾;
+        return _x.9
+-/
+#guard_msgs in
+set_option trace.Compiler.init true in
+def ex1 (n : Nat) (h : n = n) : Nat :=
+  match n with
+  | 0 => hole n h
+  | k + 1 => hole k h
+
+/--
+trace: [Compiler.init] size: 19
+    def ex2 n h1 h2 : Nat :=
+      fun _f.1 h1 h2 : Nat :=
+        let _x.2 := instAddNat;
+        let _x.3 := @instHAdd _ _x.2;
+        let _x.4 := _x.3 # 0;
+        let _x.5 := @hole ◾ n ◾;
+        let _x.6 := @hole ◾ n ◾;
+        let _x.7 := _x.4 _x.5 _x.6;
+        return _x.7;
+      let _alt.8 := _f.1;
+      fun _f.9 k h1 h2 : Nat :=
+        let _x.10 := instAddNat;
+        let _x.11 := @instHAdd _ _x.10;
+        let _x.12 := _x.11 # 0;
+        let _x.13 := @hole ◾ n ◾;
+        let _x.14 := @hole ◾ k ◾;
+        let _x.15 := _x.12 _x.13 _x.14;
+        return _x.15;
+      let _alt.16 := _f.9;
+      cases n : Nat
+      | Nat.zero =>
+        let _x.17 := _alt.8 ◾ ◾;
+        return _x.17
+      | Nat.succ n.18 =>
+        let _x.19 := _alt.16 n.18 ◾ ◾;
+        return _x.19
+-/
+#guard_msgs in
+set_option trace.Compiler.init true in
+def ex2 (n : Nat) (h1 : n ≠ 5) (h2 : 0 < n + 1) : Nat :=
+  match n with
+  | 0 => hole n h1 + hole n h2
+  | k + 1 => hole n h1 + hole k h2

--- a/tests/elab/sparseCasesOn.lean
+++ b/tests/elab/sparseCasesOn.lean
@@ -47,7 +47,7 @@ trace: [Compiler.saveBase] size: 7
         let _x.3 := sort u;
         return _x.3
       | _ =>
-        let _x.4 := else.1 _;
+        let _x.4 := else.1 ◾;
         return _x.4
 -/
 #guard_msgs in


### PR DESCRIPTION
This PR changes the handling of proof-over-applied cases expressions in `ToLCNF` to avoid generating function declarations that are called immediately. This is a less invasive version of #12284 (which has since been reverted) that only affects proof overapplications, not all overapplications. However, this is also the only case we really need for #8309 (and other occasions like `match h : _`).