### PR TITLE
chore: grind guard condition for `List.eq_or_mem_of_mem_cons`

### DIFF
--- a/src/Init/Data/List/Lemmas.lean
+++ b/src/Init/Data/List/Lemmas.lean
@@ -358,11 +358,8 @@ theorem getD_cons_succ : getD (x :: xs) (n + 1) d = getD xs n d := by simp
 theorem eq_or_mem_of_mem_cons {a b : α} {l : List α} :
     a ∈ b :: l → a = b ∨ a ∈ l := List.mem_cons.mp
 
--- This pattern may be excessively general:
--- it fires anytime we ae thinking about membership of lists,
--- and constructing a list via `cons`, even if the elements are unrelated.
--- Nevertheless in practice it is quite helpful!
-grind_pattern eq_or_mem_of_mem_cons => b :: l, a ∈ l
+grind_pattern List.eq_or_mem_of_mem_cons => b :: l, a ∈ l where
+  guard a ∈ b :: l
 
 theorem mem_cons_self {a : α} {l : List α} : a ∈ a :: l := .head ..
 

--- a/tests/elab/grind_9216.lean
+++ b/tests/elab/grind_9216.lean
@@ -31,6 +31,8 @@ introduce an auxiliary definition to make the pattern matching more effective.
 Example:
 -/
 @[grind] def IsAddInv (a b : Int) : Prop := a = -b
+
+local grind_pattern List.eq_or_mem_of_mem_cons => b :: l, a ∈ l in
 example (seen : HashSet Int) (xs : List Int) (x : Int) (h : ¬-x ∈ seen) :
     (∃ a, a ∈ seen.insert x ∧ ∃ b, b ∈ xs ∧ IsAddInv a b) ↔
     (∃ y, y ∈ xs ∧ IsAddInv x y) ∨ ∃ a, a ∈ seen ∧ ∃ b, b ∈ x :: xs ∧ IsAddInv a b := by

--- a/tests/elab/grind_countP.lean
+++ b/tests/elab/grind_countP.lean
@@ -12,7 +12,7 @@ grind_pattern List.countP_le_countP => l.countP P, l.countP Q
 
 theorem List.countP_lt_countP (hpq : ∀ x ∈ l, P x → Q x) (y:α) (hx: y ∈ l) (hxP : P y = false) (hxQ : Q y) :
     l.countP P < l.countP Q := by
-  induction l <;> grind
+  induction l <;> grind [List.mem_cons_of_mem]
 
 /--
 info: List.countP_nil: [@List.countP #1 #0 (@List.nil _)]


### PR DESCRIPTION
This PR restricts the `grind_pattern` for `List.eq_or_mem_of_mem_cons`, which currently fires often when it is not useful.