### PR TITLE
chore: mark `Pure.pure` as `match_pattern`

### DIFF
--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -3704,6 +3704,8 @@ class Pure (f : Type u → Type v) where
 
 export Pure (pure)
 
+attribute [match_pattern] Pure.pure
+
 /--
 A functor in the sense used in functional programming, which means a function `f : Type u → Type v`
 has a way of mapping a function over its contents. This `map` operator is written `<$>`, and

--- a/tests/elab/Reparen.lean.out.expected
+++ b/tests/elab/Reparen.lean.out.expected
@@ -3650,6 +3650,8 @@ class Pure (f : Type u → Type v) where
 
 export Pure (pure)
 
+attribute [match_pattern] Pure.pure
+
 /--
 A functor in the sense used in functional programming, which means a function `f : Type u → Type v`
 has a way of mapping a function over its contents. This `map` operator is written `<$>`, and


### PR DESCRIPTION
This is useful when working with `Option` in a monadic context, or when working with FreeM from CSLib.

Ideally it would be possible to attach this attribute in downstream libraries.
