### PR TITLE
feat: `List` lemmas for `tail`/`dropLast` almost commuting with `take`/`drop`

### DIFF
--- a/src/Init/Data/List/Nat/TakeDrop.lean
+++ b/src/Init/Data/List/Nat/TakeDrop.lean
@@ -197,6 +197,11 @@ theorem dropLast_take {i : Nat} {l : List α} (h : i < l.length) :
     (l.take i).dropLast = l.take (i - 1) := by
   simp only [dropLast_eq_take, length_take, Nat.le_of_lt h, Nat.min_eq_left, take_take, sub_le]
 
+theorem dropLast_take_eq_take_dropLast {l : List α} {i : Nat} :
+    (l.take i).dropLast = l.dropLast.take (i - 1) := by
+  simp [dropLast_eq_take, take_take, Nat.sub_min_sub_right,
+    Nat.le_trans (sub_le ..) (Nat.min_le_left ..)]
+
 theorem take_eq_dropLast {l : List α} {i : Nat} (h : i + 1 = l.length) :
     l.take i = l.dropLast := by
   induction l generalizing i with
@@ -386,6 +391,14 @@ theorem drop_take : ∀ {i j : Nat} {l : List α}, drop i (take j l) = take (j -
 @[simp, grind =] theorem drop_take_self : drop i (take i l) = [] := by
   rw [drop_take]
   simp
+
+theorem tail_take_eq_take_tail {l : List α} {i : Nat} :
+    (l.take i).tail = l.tail.take (i - 1) := by
+  simp [← drop_one, drop_take]
+
+theorem dropLast_drop_eq_drop_dropLast {l : List α} {i : Nat} :
+    (l.drop i).dropLast = l.dropLast.drop i := by
+  simp [dropLast_eq_take, Nat.sub_right_comm, drop_take]
 
 set_option doc.verso true in
 /--

--- a/src/Init/Data/List/TakeDrop.lean
+++ b/src/Init/Data/List/TakeDrop.lean
@@ -126,6 +126,9 @@ theorem tail_drop {l : List α} {i : Nat} : (l.drop i).tail = l.drop (i + 1) := 
 theorem drop_tail {l : List α} {i : Nat} : l.tail.drop i = l.drop (i + 1) := by
   rw [Nat.add_comm, ← drop_drop, drop_one]
 
+theorem tail_drop_eq_drop_tail {l : List α} {i : Nat} : (l.drop i).tail = l.tail.drop i := by
+  simp
+
 @[simp]
 theorem drop_eq_nil_iff {l : List α} {i : Nat} : l.drop i = [] ↔ l.length ≤ i := by
   refine ⟨fun h => ?_, drop_eq_nil_of_le⟩


### PR DESCRIPTION
This PR adds `List` lemmas showing that `tail`/`dropLast` commute with `take`/`drop`, modulo decreasing the argument of `take`.

Closes #12910

[#Is there code for X? > List.tail/List.dropLast + List.take](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/List.2Etail.2FList.2EdropLast.20.2B.20List.2Etake/with/572294698)
[#PR reviews > lean#12976 - &#96;tail&#96;/&#96;dropLast&#96; + &#96;take&#96;/&#96;drop&#96; List lemmas](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/lean.2312976.20-.20.60tail.60.2F.60dropLast.60.20.2B.20.60take.60.2F.60drop.60.20List.20lemmas/with/581589659)