### PR TITLE
feat: move trace emoji from storage to rendering

### DIFF
--- a/src/Lean/Message.lean
+++ b/src/Lean/Message.lean
@@ -84,6 +84,12 @@ inductive TraceResult where
   | error
   deriving Inhabited, BEq, Repr
 
+/-- Convert a `TraceResult` to its emoji representation. -/
+def TraceResult.toEmoji : TraceResult → String
+  | .success => "✅️"
+  | .failure => "❌️"
+  | .error   => "💥️"
+
 structure TraceData where
   /-- Trace class, e.g. `Elab.step`. -/
   cls       : Name
@@ -371,7 +377,11 @@ partial def formatAux : NamingContext → Option MessageDataContext → MessageD
     let mut msg := f!"[{data.cls}]"
     if data.startTime != 0 then
       msg := f!"{msg} [{data.stopTime - data.startTime}]"
-    msg := f!"{msg} {(← formatAux nCtx ctx header).nest 2}"
+    let headerFmt ← formatAux nCtx ctx header
+    let headerFmt := match data.result? with
+      | some r => f!"{r.toEmoji} {headerFmt}"
+      | none => headerFmt
+    msg := f!"{msg} {headerFmt.nest 2}"
     let mut children := children
     if let some maxNum := ctx.map (maxTraceChildren.get ·.opts) then
       if maxNum > 0 && children.size > maxNum then

--- a/src/Lean/Util/Trace.lean
+++ b/src/Lean/Util/Trace.lean
@@ -275,12 +275,6 @@ def bombEmoji := "💥️"
 def checkEmoji := "✅️"
 def crossEmoji := "❌️"
 
-/-- Convert a `TraceResult` to its emoji representation. -/
-def TraceResult.toEmoji : TraceResult → String
-  | .success => checkEmoji
-  | .failure => crossEmoji
-  | .error   => bombEmoji
-
 /-- Convert an `Except` result to a `TraceResult`.
 `Except.error` always maps to `.error`.
 For `Bool`, `.ok false` maps to `.failure`. For `Option`, `.ok none` maps to `.failure`. -/
@@ -321,8 +315,9 @@ then `Lean.withTraceNode'` can be used instead.
 If profiling is enabled, this will also log the runtime of `k`.
 
 The class `ExceptToTraceResult` is used to convert the result produced by `k` into a `TraceResult`
-(success/failure/error), which is stored in `TraceData.result?` and also used to select the
-emoji prefix (✅️/❌️/💥️). A typical invocation might be:
+(success/failure/error), which is stored in `TraceData.result?`. The rendering layer uses
+`TraceResult.toEmoji` to prepend the appropriate emoji (✅️/❌️/💥️) when displaying the trace.
+A typical invocation might be:
 ```lean4
 withTraceNode `isPosTrace
     (msg := fun _ => return m!"checking positivity") do
@@ -356,7 +351,6 @@ where
     let ref ← getRef
     let mut m ← try msg res catch _ => pure m!"<exception thrown while producing trace node message>"
     let result := res.toTraceResult
-    m := m!"{result.toEmoji} {m}"
     let mut data : TraceData := { cls, collapsed, tag, result? := some result }
     if trace.profiler.get opts then
       data := { data with startTime := start, stopTime := stop }
@@ -409,7 +403,8 @@ Similar to `withTraceNode`, but msg is constructed **before** executing `k`.
 This is important when debugging methods such as `isDefEq`, and we want to generate the message
 before `k` updates the metavariable assignment. The class `ExceptToTraceResult` is used to convert
 the result produced by `k` into a `TraceResult` (success/failure/error), which is stored in
-`TraceData.result?` and also used to select the emoji prefix (✅️/❌️/💥️).
+`TraceData.result?`. The rendering layer uses `TraceResult.toEmoji` to prepend the appropriate
+emoji (✅️/❌️/💥️) when displaying the trace.
 
 TODO: find better name for this function.
 -/
@@ -439,7 +434,7 @@ where
       modifyTraces (oldTraces ++ ·)
       return (← MonadExcept.ofExcept res)
     let result := res.toTraceResult
-    let mut msg := m!"{result.toEmoji} {msg}"
+    let mut msg := msg
     let mut data : TraceData := { cls, collapsed, tag, result? := some result }
     if trace.profiler.get opts then
       data := { data with startTime := start, stopTime := stop }

--- a/src/Lean/Widget/InteractiveDiagnostic.lean
+++ b/src/Lean/Widget/InteractiveDiagnostic.lean
@@ -161,6 +161,9 @@ where
       return .join (← children.mapM (go nCtx ctx)).toList
 
     let mut header := (← go nCtx ctx header).nest 4
+    header := match data.result? with
+      | some r => f!"{r.toEmoji} {header}"
+      | none => header
     if data.startTime != 0 then
       header := f!"[{data.stopTime - data.startTime}] {header}"
     let nodes ←

--- a/tests/server_interactive/highlightMatches.lean.out.expected
+++ b/tests/server_interactive/highlightMatches.lean.out.expected
@@ -17,9 +17,7 @@
   [{"trace":
     {"msg":
      {"append":
-      [{"tag": [{"expr": {"text": "✅️"}}, {"text": ""}]},
-       {"tag": [{"expr": {"text": " "}}, {"text": ""}]},
-       {"tag": [{"expr": {"text": "root"}}, {"text": ""}]}]},
+      [{"text": "✅️ "}, {"tag": [{"expr": {"text": "root"}}, {"text": ""}]}]},
      "indent": 0,
      "collapsed": true,
      "cls": "Meta.debug",
@@ -29,9 +27,7 @@
  [{"trace":
    {"msg":
     {"append":
-     [{"tag": [{"expr": {"text": "✅️"}}, {"text": ""}]},
-      {"tag": [{"expr": {"text": " "}}, {"text": ""}]},
-      {"tag": [{"expr": {"text": "root"}}, {"text": ""}]}]},
+     [{"text": "✅️ "}, {"tag": [{"expr": {"text": "root"}}, {"text": ""}]}]},
     "indent": 0,
     "collapsed": false,
     "cls": "Meta.debug",
@@ -41,8 +37,7 @@
        [{"trace":
          {"msg":
           {"append":
-           [{"tag": [{"expr": {"text": "✅️"}}, {"text": ""}]},
-            {"tag": [{"expr": {"text": " "}}, {"text": ""}]},
+           [{"text": "✅️ "},
             {"tag":
              [{"expr": {"tag": ["highlighted", {"text": "child1"}]}},
               {"text": ""}]}]},
@@ -98,8 +93,7 @@
        [{"trace":
          {"msg":
           {"append":
-           [{"tag": [{"expr": {"text": "✅️"}}, {"text": ""}]},
-            {"tag": [{"expr": {"text": " "}}, {"text": ""}]},
+           [{"text": "✅️ "},
             {"tag": [{"expr": {"text": "child2"}}, {"text": ""}]}]},
           "indent": 2,
           "collapsed": true,
@@ -110,8 +104,7 @@
        [{"trace":
          {"msg":
           {"append":
-           [{"tag": [{"expr": {"text": "✅️"}}, {"text": ""}]},
-            {"tag": [{"expr": {"text": " "}}, {"text": ""}]},
+           [{"text": "✅️ "},
             {"tag": [{"expr": {"text": "child3"}}, {"text": ""}]}]},
           "indent": 2,
           "collapsed": true,

--- a/tests/server_interactive/interactiveTraces.lean.out.expected
+++ b/tests/server_interactive/interactiveTraces.lean.out.expected
@@ -20,9 +20,7 @@
    [{"trace":
      {"msg":
       {"append":
-       [{"tag": [{"expr": {"text": "✅️"}}, {"text": ""}]},
-        {"tag": [{"expr": {"text": " "}}, {"text": ""}]},
-        {"tag": [{"expr": {"text": "root"}}, {"text": ""}]}]},
+       [{"text": "✅️ "}, {"tag": [{"expr": {"text": "root"}}, {"text": ""}]}]},
       "indent": 0,
       "collapsed": false,
       "cls": "Meta.debug",
@@ -32,8 +30,7 @@
          [{"trace":
            {"msg":
             {"append":
-             [{"tag": [{"expr": {"text": "✅️"}}, {"text": ""}]},
-              {"tag": [{"expr": {"text": " "}}, {"text": ""}]},
+             [{"text": "✅️ "},
               {"tag": [{"expr": {"text": "child1"}}, {"text": ""}]}]},
             "indent": 2,
             "collapsed": false,
@@ -69,8 +66,7 @@
          [{"trace":
            {"msg":
             {"append":
-             [{"tag": [{"expr": {"text": "✅️"}}, {"text": ""}]},
-              {"tag": [{"expr": {"text": " "}}, {"text": ""}]},
+             [{"text": "✅️ "},
               {"tag": [{"expr": {"text": "child2"}}, {"text": ""}]}]},
             "indent": 2,
             "collapsed": false,
@@ -98,8 +94,7 @@
          [{"trace":
            {"msg":
             {"append":
-             [{"tag": [{"expr": {"text": "✅️"}}, {"text": ""}]},
-              {"tag": [{"expr": {"text": " "}}, {"text": ""}]},
+             [{"text": "✅️ "},
               {"tag": [{"expr": {"text": "child3"}}, {"text": ""}]}]},
             "indent": 2,
             "collapsed": false,


### PR DESCRIPTION
This PR moves the status emoji from the stored trace header to the rendering layer. `withTraceNode`/`withTraceNodeBefore` no longer prepend `TraceResult.toEmoji` to the header `MessageData`; instead, `formatAux` and `InteractiveDiagnostic` prepend it when rendering. `TraceResult.toEmoji` is moved from `Lean.Util.Trace` to `Lean.Message` (next to the `TraceResult` definition) so that both rendering paths can use it.

Rendered output is unchanged. Programmatic consumers (e.g. mathlib's `#defeq_abuse`) can now compare headers across trace runs without string manipulation.

Closes https://github.com/leanprover/lean4/issues/13069

🤖 Prepared with Claude Code