### PR TITLE
perf: introduce thread local reference type for StateRefT

### DIFF
--- a/src/Init/Control/Lawful/Instances.lean
+++ b/src/Init/Control/Lawful/Instances.lean
@@ -357,7 +357,7 @@ end ReaderT
 /-! # StateRefT -/
 
 instance [Monad m] [LawfulMonad m] : LawfulMonad (StateRefT' ω σ m) :=
-  inferInstanceAs (LawfulMonad (ReaderT (ST.Ref ω σ) m))
+  inferInstanceAs (LawfulMonad (ReaderT _ m))
 
 /-! # StateT -/
 

--- a/src/Init/Control/Lawful/MonadAttach/Instances.lean
+++ b/src/Init/Control/Lawful/MonadAttach/Instances.lean
@@ -72,11 +72,11 @@ public instance [Monad m] [LawfulMonad m] [MonadAttach m] [LawfulMonadAttach m] 
 
 public instance [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAttach m] :
     WeaklyLawfulMonadAttach (StateRefT' ω σ m) :=
-  inferInstanceAs (WeaklyLawfulMonadAttach (ReaderT (ST.Ref ω σ) m))
+  inferInstanceAs (WeaklyLawfulMonadAttach (ReaderT _ m))
 
 public instance [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m] :
     LawfulMonadAttach (StateRefT' ω σ m) :=
-  inferInstanceAs (LawfulMonadAttach (ReaderT (ST.Ref ω σ) m))
+  inferInstanceAs (LawfulMonadAttach (ReaderT _ m))
 
 section
 

--- a/src/Init/Control/StateRef.lean
+++ b/src/Init/Control/StateRef.lean
@@ -20,7 +20,7 @@ A state monad that uses an actual mutable reference cell (i.e. an `ST.Ref ω σ`
 
 The macro `StateRefT σ m α` infers `ω` from `m`. It should normally be used instead.
 -/
-@[expose] def StateRefT' (ω : Type) (σ : Type) (m : Type → Type) (α : Type) : Type := ReaderT (ST.Ref ω σ) m α
+@[expose] def StateRefT' (ω : Type) (σ : Type) (m : Type → Type) (α : Type) : Type := ReaderT (ST.ThreadLocalRef ω σ) m α
 
 /-! Recall that `StateRefT` is a macro that infers `ω` from the `m`. -/
 
@@ -32,7 +32,7 @@ The monad `m` must support `ST` effects in order to create and mutate reference 
 -/
 @[always_inline, inline]
 def StateRefT'.run {ω σ : Type} {m : Type → Type} [Monad m] [MonadLiftT (ST ω) m] {α : Type} (x : StateRefT' ω σ m α) (s : σ) : m (α × σ) := do
-  let ref ← ST.mkRef s
+  let ref ← liftM <| ST.mkThreadLocalRef s
   let a ← x ref
   let s ← ref.get
   pure (a, s)

--- a/src/Init/Internal/Order/Basic.lean
+++ b/src/Init/Internal/Order/Basic.lean
@@ -954,7 +954,7 @@ theorem monotone_readerTRun [PartialOrder γ]
 instance [inst : PartialOrder (m α)] : PartialOrder (StateRefT' ω σ m α) := instOrderPi
 instance [inst : CCPO (m α)] : CCPO (StateRefT' ω σ m α) := instCCPOPi
 instance [Monad m] [∀ α, PartialOrder (m α)] [MonoBind m] : MonoBind (StateRefT' ω σ m) :=
-  inferInstanceAs (MonoBind (ReaderT (ST.Ref ω σ) m))
+  inferInstanceAs (MonoBind (ReaderT _ m))
 
 @[partial_fixpoint_monotone]
 theorem monotone_stateRefT'Run [PartialOrder γ]

--- a/src/Init/Internal/Order/MonadTail.lean
+++ b/src/Init/Internal/Order/MonadTail.lean
@@ -135,6 +135,6 @@ instance : MonadTail IO :=
 
 instance {ω : Type} {σ : Type} {m : Type → Type} [Monad m] [MonadTail m] :
     MonadTail (StateRefT' ω σ m) :=
-  inferInstanceAs (MonadTail (ReaderT (ST.Ref ω σ) m))
+  inferInstanceAs (MonadTail (ReaderT (ST.ThreadLocalRef ω σ) m))
 
 end Lean.Order

--- a/src/Init/System/ST.lean
+++ b/src/Init/System/ST.lean
@@ -162,8 +162,11 @@ instance {ε σ} : MonadLift (ST σ) (EST ε σ) := ⟨fun x s =>
 
 namespace ST
 
-/-- References -/
+/-! References -/
+
 opaque RefPointed : NonemptyType.{0}
+
+opaque ThreadLocalRefPointed : NonemptyType.{0}
 
 /--
 Mutable reference cells that contain values of type `α`. These cells can read from and mutated in
@@ -173,8 +176,20 @@ structure Ref (σ : Type) (α : Type) : Type where
   ref : RefPointed.type
   h   : Nonempty α
 
+/--
+Thread local variant of `ST.Ref`. Whenever a thread local reference gets shared between threads,
+the program will crash. This is used internally by `StateRefT` and should be used with caution
+otherwise.
+-/
+structure ThreadLocalRef (σ : Type) (α : Type) : Type where
+  ref : ThreadLocalRefPointed.type
+  h   : Nonempty α
+
 instance {σ α} [s : Nonempty α] : Nonempty (Ref σ α) :=
   Nonempty.intro { ref := Classical.choice RefPointed.property, h := s }
+
+instance {σ α} [s : Nonempty α] : Nonempty (ThreadLocalRef σ α) :=
+  Nonempty.intro { ref := Classical.choice ThreadLocalRefPointed.property, h := s }
 
 namespace Prim
 
@@ -219,6 +234,42 @@ def Ref.modifyGet {σ α β : Type} (r : Ref σ α) (f : α → β × α) : ST �
   pure b
 
 end Prim
+
+/-- Auxiliary definition for showing that `ST σ α` is inhabited when we have a `ThreadLocalRef σ α` -/
+private noncomputable def inhabitedFromThreadLocalRef {σ α} (r : ThreadLocalRef σ α) : ST σ α :=
+  let _ : Inhabited α := Classical.inhabited_of_nonempty r.h
+  pure default
+
+@[extern "lean_st_mk_local_ref"]
+opaque mkThreadLocalRef {σ α} (a : α) : ST σ (ThreadLocalRef σ α) := pure { ref := Classical.choice ThreadLocalRefPointed.property, h := Nonempty.intro a }
+@[extern "lean_st_local_ref_get"]
+opaque ThreadLocalRef.get {σ α} (r : @& ThreadLocalRef σ α) : ST σ α := inhabitedFromThreadLocalRef r
+@[extern "lean_st_local_ref_set"]
+opaque ThreadLocalRef.set {σ α} (r : @& ThreadLocalRef σ α) (a : α) : ST σ Unit
+@[extern "lean_st_local_ref_swap"]
+opaque ThreadLocalRef.swap {σ α} (r : @& ThreadLocalRef σ α) (a : α) : ST σ α := inhabitedFromThreadLocalRef r
+
+@[inline] unsafe def ThreadLocalRef.modifyUnsafe {σ α : Type} (r : ThreadLocalRef σ α) (f : α → α) : ST σ Unit := do
+  let v ← r.swap (unsafeCast ())
+  r.set (f v)
+
+@[inline] unsafe def ThreadLocalRef.modifyGetUnsafe {σ α β : Type} (r : ThreadLocalRef σ α) (f : α → β × α) : ST σ β := do
+  let v ← r.swap (unsafeCast ())
+  let (b, a) := f v
+  r.set a
+  pure b
+
+@[implemented_by ThreadLocalRef.modifyUnsafe]
+def ThreadLocalRef.modify {σ α : Type} (r : ThreadLocalRef σ α) (f : α → α) : ST σ Unit := do
+  let v ← r.get
+  r.set (f v)
+
+@[implemented_by ThreadLocalRef.modifyGetUnsafe]
+def ThreadLocalRef.modifyGet {σ α β : Type} (r : ThreadLocalRef σ α) (f : α → β × α) : ST σ β := do
+  let v ← r.get
+  let (b, a) := f v
+  r.set a
+  pure b
 
 section
 variable {σ : Type} {m : Type → Type} [Monad m] [MonadLiftT (ST σ) m]

--- a/src/Lean/Elab/DocString.lean
+++ b/src/Lean/Elab/DocString.lean
@@ -124,8 +124,6 @@ The monad in which documentation is elaborated.
 -/
 abbrev DocM := ReaderT Context (StateRefT InternalState (StateRefT Lean.Doc.State TermElabM))
 
-private def DocM.mk (act : Context → IO.Ref InternalState → IO.Ref State → TermElabM α) : DocM α := act
-
 instance : MonadStateOf InternalState DocM :=
   inferInstanceAs <| MonadStateOf InternalState (ReaderT Context (StateRefT InternalState (StateRefT Lean.Doc.State TermElabM)))
 
@@ -134,8 +132,8 @@ instance : MonadStateOf State DocM :=
 
 
 instance : MonadLift TermElabM DocM where
-  monadLift act := private DocM.mk fun _ _ st' => do
-    let {openDecls, lctx, options, localInstances, ..} := (← st'.get)
+  monadLift act := do
+    let {openDecls, lctx, options, localInstances, ..} ← get
     let v ←
       withTheReader Core.Context (fun ρ => { ρ with openDecls, options }) <|
       withTheReader Meta.Context (fun ρ => { ρ with lctx, localInstances }) <|

--- a/src/Lean/Language/Lean.lean
+++ b/src/Lean/Language/Lean.lean
@@ -754,7 +754,7 @@ where
     let ctx ← read
     let scope := cmdState.scopes.head!
     -- reset per-command state
-    let cmdStateRef ← IO.mkRef { cmdState with
+    let cmdStateRef ← liftM <| ST.mkThreadLocalRef { cmdState with
       messages := .empty, traceState := {}, snapshotTasks := #[] }
     let cmdCtx : Elab.Command.Context := { ctx with
       cmdPos       := beginPos

--- a/src/Std/Sync/Basic.lean
+++ b/src/Std/Sync/Basic.lean
@@ -14,9 +14,35 @@ namespace Std
 
 /--
 `AtomicT α m` is the monad that can be atomically executed inside mutual exclusion primitives like
-`Mutex α` with outside monad `m`.
+`Mutex α` with outside monad `m`. It can be seen as an atomic variant of `StateRefT`.
 The action has access to the state `α` of the mutex (via `get` and `set`).
 -/
-abbrev AtomicT := StateRefT' IO.RealWorld
+def AtomicT (α : Type) (m : Type → Type) := ReaderT (IO.Ref α) m
+
+@[inline]
+nonrec def AtomicT.run [Monad m] [MonadLiftT (ST IO.RealWorld) m] (x : AtomicT α m β) (s : α) : m (β × α) := do
+  let ref ← ST.mkRef s
+  let result ← ReaderT.run x ref
+  let state ← ref.get
+  return (result, state)
+
+@[inline]
+nonrec def AtomicT.run' [Monad m] [MonadLiftT (ST IO.RealWorld) m] (x : AtomicT α m β) (s : α) : m β := do
+  let ref ← ST.mkRef s
+  ReaderT.run x ref
+
+instance [Monad m] : Monad (AtomicT α m) := inferInstanceAs (Monad (ReaderT _ _))
+instance : MonadLift m (AtomicT α m) := inferInstanceAs (MonadLift m (ReaderT _ _))
+instance : MonadFunctor m (AtomicT α m) := inferInstanceAs (MonadFunctor m (ReaderT _ _))
+instance [Alternative m] [Monad m] : Alternative (AtomicT α m) := inferInstanceAs (Alternative (ReaderT _ _))
+instance [Monad m] [MonadAttach m] : MonadAttach (AtomicT α m) := inferInstanceAs (MonadAttach (ReaderT _ _))
+instance : MonadControl m (AtomicT α m) := inferInstanceAs (MonadControl m (ReaderT _ _))
+instance [MonadFinally m] : MonadFinally (AtomicT α m) := inferInstanceAs (MonadFinally (ReaderT _ _))
+instance [MonadExceptOf ε m] : MonadExceptOf ε (AtomicT α m) := inferInstanceAs (MonadExceptOf ε (ReaderT _ _))
+
+instance [MonadLiftT (ST IO.RealWorld) m] : MonadStateOf α (AtomicT α m) where
+  get := .mk fun ref => ref.get
+  set val := .mk fun ref => ref.set val
+  modifyGet f := .mk fun ref => ref.modifyGet f
 
 end Std

--- a/src/include/lean/lean.h
+++ b/src/include/lean/lean.h
@@ -89,7 +89,8 @@ void lean_notify_assert(const char * fileName, int line, const char * condition)
 
 #define LEAN_BYTE(Var, Index) *(((uint8_t*)&Var)+Index)
 
-#define LeanMaxCtorTag  243
+#define LeanMaxCtorTag  242
+#define LeanLocalRef    243
 #define LeanPromise     244
 #define LeanClosure     245
 #define LeanArray       246
@@ -593,6 +594,7 @@ static inline bool lean_is_task(lean_object * o) { return lean_ptr_tag(o) == Lea
 static inline bool lean_is_promise(lean_object * o) { return lean_ptr_tag(o) == LeanPromise; }
 static inline bool lean_is_external(lean_object * o) { return lean_ptr_tag(o) == LeanExternal; }
 static inline bool lean_is_ref(lean_object * o) { return lean_ptr_tag(o) == LeanRef; }
+static inline bool lean_is_local_ref(lean_object * o) { return lean_ptr_tag(o) == LeanLocalRef; }
 
 static inline unsigned lean_obj_tag(lean_object * o) {
     if (lean_is_scalar(o)) return lean_unbox(o); else return lean_ptr_tag(o);
@@ -607,6 +609,7 @@ static inline lean_thunk_object * lean_to_thunk(lean_object * o) { assert(lean_i
 static inline lean_task_object * lean_to_task(lean_object * o) { assert(lean_is_task(o)); return (lean_task_object*)(o); }
 static inline lean_promise_object * lean_to_promise(lean_object * o) { assert(lean_is_promise(o)); return (lean_promise_object*)(o); }
 static inline lean_ref_object * lean_to_ref(lean_object * o) { assert(lean_is_ref(o)); return (lean_ref_object*)(o); }
+static inline lean_ref_object * lean_to_local_ref(lean_object * o) { assert(lean_is_local_ref(o)); return (lean_ref_object*)(o); }
 static inline lean_external_object * lean_to_external(lean_object * o) { assert(lean_is_external(o)); return (lean_external_object*)(o); }
 
 static inline bool lean_is_exclusive(lean_object * o) {
@@ -2993,6 +2996,32 @@ LEAN_EXPORT lean_obj_res lean_st_ref_get(b_lean_obj_arg);
 LEAN_EXPORT lean_obj_res lean_st_ref_set(b_lean_obj_arg, lean_obj_arg);
 LEAN_EXPORT lean_obj_res lean_st_ref_reset(b_lean_obj_arg);
 LEAN_EXPORT lean_obj_res lean_st_ref_swap(b_lean_obj_arg, lean_obj_arg);
+
+/* ST ThreadLocalRef primitives */
+static inline lean_obj_res lean_st_mk_local_ref(lean_obj_arg value) {
+    lean_ref_object * o = (lean_ref_object*)lean_alloc_small_object(sizeof(lean_ref_object));
+    lean_set_st_header((lean_object*)o, LeanLocalRef, 0);
+    o->m_value = value;
+    return (lean_object*)o;
+}
+
+static inline lean_obj_res lean_st_local_ref_get(b_lean_obj_arg ref) {
+    lean_object * value = lean_to_local_ref(ref)->m_value;
+    lean_inc(value);
+    return value;
+}
+
+static inline lean_obj_res lean_st_local_ref_set(b_lean_obj_arg ref, lean_obj_arg value) {
+    lean_dec(lean_to_local_ref(ref)->m_value);
+    lean_to_local_ref(ref)->m_value = value;
+    return lean_box(0);
+}
+
+static inline lean_obj_res lean_st_local_ref_swap(b_lean_obj_arg ref, lean_obj_arg value) {
+    lean_object * prev = lean_to_local_ref(ref)->m_value;
+    lean_to_local_ref(ref)->m_value = value;
+    return prev;
+}
 
 /* pointer address unsafe primitive  */
 static inline size_t lean_ptr_addr(b_lean_obj_arg a) { return (size_t)a; }

--- a/src/lake/Lake/Build/Fetch.lean
+++ b/src/lake/Lake/Build/Fetch.lean
@@ -12,6 +12,7 @@ public import Lake.Build.Context
 public import Lake.Config.Module
 public import Lake.Util.EquipT
 public import Lake.Util.Cycle
+public import Std.Sync.Basic
 import Lake.Build.Infos
 
 /-! # Recursive Building
@@ -44,7 +45,7 @@ A recursive build of a Lake build store that may encounter a cycle.
 An internal monad. **Not intended for user use.**
 -/
 public abbrev RecBuildT (m : Type → Type) :=
-  ReaderT CurrPackage <| CallStackT BuildKey <| StateRefT' IO.RealWorld BuildStore <| BuildT m
+  ReaderT CurrPackage <| CallStackT BuildKey <| Std.AtomicT BuildStore <| BuildT m
 
 /-- Build cycle error message. -/
 public def buildCycleError (cycle : Cycle BuildKey) : String :=

--- a/src/lake/Lake/Util/StoreInsts.lean
+++ b/src/lake/Lake/Util/StoreInsts.lean
@@ -11,6 +11,7 @@ public import Lean.Data.NameMap.Basic
 public import Lake.Util.RBArray
 public import Lake.Util.Family
 public import Lake.Util.Store
+public import Std.Sync.Basic
 
 open Lean
 namespace Lake
@@ -21,6 +22,10 @@ public instance {cmp : κ → κ → Ordering} [Monad m] [Std.LawfulEqCmp cmp] :
 
 public instance {cmp : κ → κ → Ordering} [MonadLiftT (ST ω) m] [Monad m] [Std.LawfulEqCmp cmp] : MonadDStore κ β (StateRefT' ω (Std.DTreeMap κ β cmp) m) where
   fetch? k := modifyGet fun m => (m.get? k, m)
+  store k a := modify (·.insert k a)
+
+public instance {cmp : κ → κ → Ordering} [MonadLiftT (ST IO.RealWorld) m] [Monad m] [Std.LawfulEqCmp cmp] : MonadDStore κ β (Std.AtomicT (Std.DTreeMap κ β cmp) m) where
+  fetch? k := return (← get).get? k
   store k a := modify (·.insert k a)
 
 public instance [Monad m] : MonadStore κ α (StateT (RBArray κ α cmp) m) where
@@ -37,6 +42,10 @@ public instance [Monad m] : MonadStore Name α (StateT (NameMap α) m) where
 
 public instance [MonadLiftT (ST ω) m] [Monad m] : MonadStore Name α (StateRefT' ω (NameMap α) m) where
   fetch? k := modifyGet fun m => (m.find? k, m)
+  store k a := modify (·.insert k a)
+
+public instance [MonadLiftT (ST IO.RealWorld) m] [Monad m] : MonadStore Name α (Std.AtomicT (NameMap α) m) where
+  fetch? k := return (← get).find? k
   store k a := modify (·.insert k a)
 
 public instance [MonadDStore κ β m] [t : FamilyOut β k α] : MonadStore1Of k α m where

--- a/src/runtime/compact.cpp
+++ b/src/runtime/compact.cpp
@@ -511,6 +511,7 @@ void object_compactor::operator()(object * o) {
             case LeanTask:            r = insert_task(curr); break;
             case LeanPromise:         r = insert_promise(curr); break;
             case LeanRef:             r = insert_ref(curr); break;
+            case LeanLocalRef:        throw exception("thread local references cannot be compacted");
             case LeanExternal:        throw exception("external objects cannot be compacted");
             case LeanReserved:        lean_unreachable();
             default:                  r = insert_constructor(curr); break;
@@ -731,6 +732,7 @@ object * compacted_region::read() {
             case LeanTask:            fix_task(curr); break;
             case LeanPromise:         fix_promise(curr); break;
             case LeanExternal:        lean_unreachable();
+            case LeanLocalRef:        lean_unreachable();
             default:                  lean_unreachable();
             }
         }

--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -413,6 +413,10 @@ static void lean_del_core_other(object * o, uint8 tag, object * & todo) {
         if (object * v = lean_to_ref(o)->m_value) dec(v, todo);
         lean_free_small_object(o);
         break;
+    case LeanLocalRef:
+        if (object * v = lean_to_local_ref(o)->m_value) dec(v, todo);
+        lean_free_small_object(o);
+        break;
     case LeanTask:
         deactivate_task(lean_to_task(o));
         break;
@@ -610,6 +614,9 @@ extern "C" LEAN_EXPORT void lean_mark_persistent(object * o) {
                 case LeanRef:
                     if (object * v = lean_to_ref(o)->m_value) todo.push_back(v);
                     break;
+                case LeanLocalRef:
+                    lean_internal_panic("Attempted to mark thread local reference as persistent");
+                    break;
                 default:
                     lean_unreachable();
                     break;
@@ -684,6 +691,9 @@ extern "C" LEAN_EXPORT void lean_mark_mt(object * o) {
                     break;
                 case LeanRef:
                     if (object * v = lean_to_ref(o)->m_value) todo.push_back(v);
+                    break;
+                case LeanLocalRef:
+                    lean_internal_panic("Attempted to mark thread local reference as multi-threaded");
                     break;
                 default:
                     lean_unreachable();

--- a/src/runtime/sharecommon.cpp
+++ b/src/runtime/sharecommon.cpp
@@ -127,7 +127,7 @@ class sharecommon_fn {
         case LeanThunk:
         case LeanTask:     case LeanRef:
         case LeanExternal: case LeanClosure:
-        case LeanPromise:
+        case LeanPromise:  case LeanLocalRef:
             m_children.push_back(a);
             return true;
         default:
@@ -267,6 +267,7 @@ public:
             case LeanTask:            lean_unreachable();
             case LeanPromise:         lean_unreachable();
             case LeanRef:             lean_unreachable();
+            case LeanLocalRef:        lean_unreachable();
             case LeanExternal:        lean_unreachable();
             case LeanReserved:        lean_unreachable();
             default:                  visit_ctor(curr); break;
@@ -429,6 +430,7 @@ lean_object * sharecommon_quick_fn::visit(lean_object * a) {
     case LeanTask:            lean_inc_ref(a); return a;
     case LeanPromise:         lean_inc_ref(a); return a;
     case LeanRef:             lean_inc_ref(a); return a;
+    case LeanLocalRef:        lean_inc_ref(a); return a;
     case LeanExternal:        lean_inc_ref(a); return a;
     case LeanReserved:        lean_inc_ref(a); return a;
     case LeanMPZ:             return visit_terminal(a);

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -11,7 +11,7 @@ options get_default_options() {
     opts = opts.update({"debug", "terminalTacticsAsSorry"}, false);
     // switch to `true` for ABI-breaking changes affecting meta code;
     // see also next option!
-    opts = opts.update({"interpreter", "prefer_native"}, false);
+    opts = opts.update({"interpreter", "prefer_native"}, true);
     // switch to `false` when enabling `prefer_native` should also affect use
     // of built-in parsers in quotations; this is usually the case, but setting
     // both to `true` may be necessary for handling non-builtin parsers with

--- a/tests/elab/lcnfTypes.lean.out.expected
+++ b/tests/elab/lcnfTypes.lean.out.expected
@@ -17,16 +17,22 @@ MonadControl.restoreM : {m : Type u → Type v} → {n : Type u → Type w} → 
 Decidable.casesOn : {p : Prop} → {motive : Decidable ◾ → Sort u} → Decidable ◾ → (◾ → motive lcAny) → (◾ → motive lcAny) → motive lcAny
 Lean.getConstInfo : {m : Type → Type} → [Monad m] → [MonadEnv m] → [MonadError m] → Name → m ConstantInfo
 Lean.Meta.instMonadMetaM : Monad fun α =>
-  Context → ST.Ref lcAny State → Core.Context → ST.Ref lcAny Core.State → lcVoid → EST.Out Exception lcAny α
-Lean.Meta.inferType : Expr → Context → ST.Ref lcAny State → Core.Context → ST.Ref lcAny Core.State → lcVoid → EST.Out Exception lcAny Expr
+  Context →
+    ST.ThreadLocalRef lcAny State →
+      Core.Context → ST.ThreadLocalRef lcAny Core.State → lcVoid → EST.Out Exception lcAny α
+Lean.Meta.inferType : Expr →
+  Context →
+    ST.ThreadLocalRef lcAny State →
+      Core.Context → ST.ThreadLocalRef lcAny Core.State → lcVoid → EST.Out Exception lcAny Expr
 Lean.Elab.Term.elabTerm : Syntax →
   Option Expr →
     Bool →
       Bool →
         Elab.Term.Context →
-          ST.Ref lcAny Elab.Term.State →
+          ST.ThreadLocalRef lcAny Elab.Term.State →
             Context →
-              ST.Ref lcAny State → Core.Context → ST.Ref lcAny Core.State → lcVoid → EST.Out Exception lcAny Expr
+              ST.ThreadLocalRef lcAny State →
+                Core.Context → ST.ThreadLocalRef lcAny Core.State → lcVoid → EST.Out Exception lcAny Expr
 Nat.add : Nat → Nat → Nat
 Magma.mul : Magma → lcAny → lcAny → lcAny
 weird1 : Bool → lcAny


### PR DESCRIPTION
This PR adds a thread local variant of `ST.Ref` that crashes the program if used multi-threaded and uses it to optimize `StateRefT`.