### PR TITLE
feat: add pp.memoize option for compact pretty-printing with shared subexpressions

### DIFF
--- a/src/Lean/Elab.lean
+++ b/src/Lean/Elab.lean
@@ -38,6 +38,7 @@ public import Lean.Elab.DeclarationRange
 public import Lean.Elab.Extra
 public import Lean.Elab.GenInjective
 public import Lean.Elab.BuiltinTerm
+public import Lean.Elab.MemoizedTerm
 public import Lean.Elab.Arg
 public import Lean.Elab.PatternVar
 public import Lean.Elab.ElabRules

--- a/src/Lean/Elab/MemoizedTerm.lean
+++ b/src/Lean/Elab/MemoizedTerm.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+module
+
+prelude
+public import Lean.Elab.Term
+import Init.Syntax
+
+public section
+
+/-!
+# `memoized%` and `memo` syntax
+
+`memoized%` provides a compact representation of expressions with shared subexpressions.
+At each first DFS occurrence of a shared subexpression, `(memo _s0 := expr)` names it;
+subsequent occurrences use the bare name `_s0`.
+
+```
+memoized% @Nat.add (memo _s0 := @Nat.mul (memo _s1 := @Nat.succ @Nat.zero) _s1) _s0
+```
+
+This elaborates by floating all `memo` bindings to `let` declarations:
+```
+let _s1 := @Nat.succ @Nat.zero; let _s0 := @Nat.mul _s1 _s1; @Nat.add _s0 _s0
+```
+
+The output of `set_option pp.memoize true` uses this format, enabling round-tripping.
+-/
+
+namespace Lean.Elab.Term.Memoized
+
+open Lean Elab Term
+
+syntax (name := memoBind) "memo " ident " := " term : term
+syntax (name := memoBlock) "memoized%" term : term
+
+private partial def extractBindings (stx : Syntax) :
+    StateM (Array (Ident × Syntax)) Syntax := do
+  if stx.isOfKind ``memoBind then
+    let name := stx[1]
+    let val ← extractBindings stx[3]
+    modify (·.push (⟨name⟩, val))
+    return name
+  else if stx.isOfKind ``memoBlock then
+    return stx
+  else
+    let args := stx.getArgs
+    if args.size == 0 then return stx
+    let mut newArgs := args
+    for i in [:args.size] do
+      newArgs := newArgs.set! i (← extractBindings args[i]!)
+    return stx.setArgs newArgs
+
+@[builtin_term_elab memoBlock]
+def elabMemoBlock : TermElab := fun stx expectedType? => do
+  let inner := stx[1]
+  let (rewritten, bindings) := (extractBindings inner).run #[]
+  if bindings.isEmpty then
+    elabTerm inner expectedType?
+  else
+    let mut result : Term := ⟨rewritten⟩
+    for (name, val) in bindings.reverse do
+      let valTerm : Term := ⟨val⟩
+      result ← `(let $name := $valTerm; $result)
+    elabTerm result expectedType?
+
+@[builtin_term_elab memoBind]
+def elabMemoBind : TermElab := fun _stx _expectedType? =>
+  throwError "`memo` must appear inside a `memoized%` block"
+
+end Lean.Elab.Term.Memoized

--- a/src/Lean/PrettyPrinter.lean
+++ b/src/Lean/PrettyPrinter.lean
@@ -12,6 +12,7 @@ public import Lean.Parser.Module
 public import Lean.ParserCompiler
 public import Lean.Util.NumObjs
 public import Lean.Util.ShareCommon
+public import Lean.PrettyPrinter.Memoize
 
 public section
 
@@ -48,6 +49,9 @@ def ppExpr (e : Expr) : MetaM Format := do
 to `Elab.Info` nodes produced by the delaborator at various subexpressions of `e`. -/
 def ppExprWithInfos (e : Expr) (optsPerPos : Delaborator.OptionsPerPos := {}) (delab := Delaborator.delab)
     : MetaM FormatWithInfos := do
+  if getPPMemoize (← getOptions) then
+    let s ← ppMemoized e
+    return ⟨.text s, ∅⟩
   let lctx := (← getLCtx).sanitizeNames.run' { options := (← getOptions) }
   Meta.withLCtx' lctx do
     let (stx, infos) ← delabCore e optsPerPos delab

--- a/src/Lean/PrettyPrinter/Delaborator/Options.lean
+++ b/src/Lean/PrettyPrinter/Delaborator/Options.lean
@@ -196,6 +196,11 @@ register_builtin_option pp.instanceTypes : Bool := {
   defValue := false
   descr    := "(pretty printer) when printing explicit applications, show the types of inst-implicit arguments"
 }
+register_builtin_option pp.memoize : Bool := {
+  defValue := false
+  descr    := "(pretty printer) display expressions with shared subexpression memoization, " ++
+              "using `memoized%` and `memo` syntax for compact representation"
+}
 register_builtin_option pp.deepTerms : Bool := {
   defValue := false
   descr    := "(pretty printer) display deeply nested terms, replacing them with `⋯` if set to false"
@@ -289,5 +294,6 @@ def getPPInstances (o : Options) : Bool := o.get pp.instances.name pp.instances.
 def getPPInstanceTypes (o : Options) : Bool := o.get pp.instanceTypes.name pp.instanceTypes.defValue
 def getPPDeepTerms (o : Options) : Bool := o.get pp.deepTerms.name (pp.deepTerms.defValue || getPPAll o)
 def getPPDeepTermsThreshold (o : Options) : Nat := o.get pp.deepTerms.threshold.name pp.deepTerms.threshold.defValue
+def getPPMemoize (o : Options) : Bool := o.get pp.memoize.name pp.memoize.defValue
 
 end Lean

--- a/src/Lean/PrettyPrinter/Memoize.lean
+++ b/src/Lean/PrettyPrinter/Memoize.lean
@@ -323,7 +323,7 @@ private partial def ppBinderBody (ctx : PPCtx) (body : Expr) (bvars : Array Name
     binderNames := ctx.binderNames
     names := ← IO.mkRef ∅
     emitted := ← IO.mkRef ∅
-    nextId := ← IO.mkRef 0
+    nextId := ctx.nextId  -- share counter with outer to avoid name collisions
     outer? := some ctx
   }
   let bodyStr ← ppExpr childCtx body bvars

--- a/src/Lean/PrettyPrinter/Memoize.lean
+++ b/src/Lean/PrettyPrinter/Memoize.lean
@@ -1,0 +1,341 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+module
+
+prelude
+import Lean.PrettyPrinter.Delaborator.Options
+import Lean.Util.ShareCommon
+import Lean.Data.SMap
+public import Lean.Expr
+import Init.While
+
+public section
+
+/-!
+# Memoized pretty-printing
+
+Pretty-prints `Expr` values with shared subexpression identification using
+`memoized%`/`memo` syntax. When `pp.memoize` is `true`, shared closed subexpressions
+are printed once with `(memo _s0 := ...)` and referenced by name thereafter.
+
+The output is designed to round-trip: `memoized%` elaborates the expression back
+by floating `memo` bindings to `let` declarations.
+-/
+
+namespace Lean.PrettyPrinter
+
+private def isTrivial (e : Expr) : Bool :=
+  e.isFVar || e.isBVar || e.isLit || e.isConst || e.isSort || e.isMVar
+
+private partial def exprWeight (e : Expr) : Nat :=
+  match e with
+  | .app f a => 1 + exprWeight f + exprWeight a
+  | .lam _ t b _ => 1 + exprWeight t + exprWeight b
+  | .forallE _ t b _ => 1 + exprWeight t + exprWeight b
+  | .letE _ t v b _ => 1 + exprWeight t + exprWeight v + exprWeight b
+  | .mdata _ e => exprWeight e
+  | .proj _ _ e => 1 + exprWeight e
+  | _ => 1
+
+/-- Zeta-reduce all `letE` bindings and beta-reduce all redexes. -/
+partial def zetaBetaReduce (e : Expr) : Expr :=
+  match e with
+  | .letE _ _ v b _ =>
+    zetaBetaReduce (b.instantiate1 (zetaBetaReduce v))
+  | .app f a =>
+    let f' := zetaBetaReduce f
+    let a' := zetaBetaReduce a
+    match f' with
+    | .lam _ _ b _ => zetaBetaReduce (b.instantiate1 a')
+    | _ => .app f' a'
+  | .lam n t b bi => .lam n (zetaBetaReduce t) (zetaBetaReduce b) bi
+  | .forallE n t b bi => .forallE n (zetaBetaReduce t) (zetaBetaReduce b) bi
+  | .mdata m e => .mdata m (zetaBetaReduce e)
+  | .proj s i e => .proj s i (zetaBetaReduce e)
+  | _ => e
+
+-- ── Subexpression counting ──
+
+private partial def countSubexprs (e : Expr)
+    (counts : IO.Ref (Std.HashMap Expr Nat)) : IO Unit := do
+  if isTrivial e then return
+  let c ← counts.get
+  let prev := c.getD e 0
+  counts.set (c.insert e (prev + 1))
+  if prev == 0 then
+    match e with
+    | .app f a => countSubexprs f counts; countSubexprs a counts
+    | .lam _ t b _ => countSubexprs t counts; countSubexprs b counts
+    | .forallE _ t b _ => countSubexprs t counts; countSubexprs b counts
+    | .letE _ t v b _ =>
+      countSubexprs t counts; countSubexprs v counts; countSubexprs b counts
+    | .mdata _ e => countSubexprs e counts
+    | .proj _ _ e => countSubexprs e counts
+    | _ => pure ()
+
+-- ── Printing ──
+
+private def escapeString (s : String) : String :=
+  s.toList.foldl (fun acc c =>
+    acc ++ match c with
+    | '\\' => "\\\\"
+    | '"' => "\\\""
+    | '\n' => "\\n"
+    | '\t' => "\\t"
+    | '\r' => "\\r"
+    | c => c.toString) ""
+
+private def hasSpace (s : String) : Bool :=
+  s.toList.any (· == ' ')
+
+private def strStartsWith (s prefix_ : String) : Bool :=
+  s.toList.take prefix_.data.length == prefix_.data
+
+private def wrapParens (s : String) : String :=
+  if hasSpace s && !strStartsWith s "(" && !strStartsWith s "(memo " then
+    "(" ++ s ++ ")"
+  else s
+
+private partial def ppLevel : Level → String
+  | .zero => "0"
+  | .succ .zero => "1"
+  | .succ (.param n) => toString n ++ " + 1"
+  | .succ l => "(" ++ ppLevel l ++ ") + 1"
+  | .max l1 l2 => "max (" ++ ppLevel l1 ++ ") (" ++ ppLevel l2 ++ ")"
+  | .imax l1 l2 => "imax (" ++ ppLevel l1 ++ ") (" ++ ppLevel l2 ++ ")"
+  | .param name => toString name
+  | .mvar id => "?u." ++ toString id.name
+
+/-- Pretty-print a level for use after `Sort`, wrapping in parens only when needed. -/
+private def ppLevelAtom (l : Level) : String :=
+  match l with
+  | .zero => "0"
+  | .succ .zero => "1"
+  | _ => "(" ++ ppLevel l ++ ")"
+
+/-- Pretty-print a level for Sort, using `_` for universe params to let Lean infer them. -/
+private partial def ppLevelInfer : Level → String
+  | .zero => "0"
+  | .succ .zero => "1"
+  | .succ l => "(" ++ ppLevelInfer l ++ " + 1)"
+  | .param _ => "_"
+  | .mvar _ => "_"
+  | .max l1 l2 => "(max (" ++ ppLevelInfer l1 ++ ") (" ++ ppLevelInfer l2 ++ "))"
+  | .imax l1 l2 => "(imax (" ++ ppLevelInfer l1 ++ ") (" ++ ppLevelInfer l2 ++ "))"
+
+/-- Pretty-print a Sort level for round-tripping — uses `_` for params. -/
+private def ppSortLevel (l : Level) : String :=
+  if l.hasParam then ppLevelInfer l else ppLevelAtom l
+
+private def binderOpen : BinderInfo → String
+  | .default => "("
+  | .implicit => "{"
+  | .strictImplicit => "⦃"
+  | .instImplicit => "["
+
+private def binderClose : BinderInfo → String
+  | .default => ")"
+  | .implicit => "}"
+  | .strictImplicit => "⦄"
+  | .instImplicit => "]"
+
+/-- Format a name for use in syntax, quoting with «» if needed. -/
+private def quoteName (n : Name) : String :=
+  match n with
+  | .str .anonymous s =>
+    match Name.escapePart s (needsEscape s) with
+    | some escaped => escaped
+    | none => toString n
+  | _ => toString n
+where
+  needsEscape (s : String) : Bool :=
+    -- Keywords and reserved words that conflict with binder position
+    s == "let" || s == "if" || s == "then" || s == "else" || s == "do" || s == "return" ||
+    s == "match" || s == "fun" || s == "where" || s == "have" || s == "show" || s == "by" ||
+    s == "in" || s == "for" || s == "with" || s == "def" || s == "theorem" || s == "class" ||
+    s == "instance" || s == "structure" || s == "inductive" || s == "section" || s == "namespace" ||
+    s == "end" || s == "import" || s == "open" || s == "variable" || s == "set_option" ||
+    s == "mutual" || s == "noncomputable" || s == "unsafe" || s == "private" || s == "protected" ||
+    s == "abbrev" || s == "opaque" || s == "axiom" || s == "example" || s == "macro" ||
+    s == "syntax" || s == "notation" || s == "prefix" || s == "infix" || s == "infixl" ||
+    s == "infixr" || s == "postfix"
+
+/-- Sanitize a binder name: strip macro scopes and avoid shadowing existing bvars. -/
+private partial def freshBinderName (n : Name) (bvars : Array Name) : Name :=
+  let base := if n.isAnonymous then `_a else n.eraseMacroScopes
+  if !bvars.contains base then base
+  else go base 1
+where
+  go (base : Name) (i : Nat) : Name :=
+    let candidate := Name.mkSimple (toString base ++ "_" ++ toString i)
+    if !bvars.contains candidate then candidate else go base (i + 1)
+
+private def ppAtom (e : Expr) (bvars : Array Name) : String :=
+  match e with
+  | .bvar n =>
+    if n < bvars.size then quoteName bvars[bvars.size - 1 - n]!
+    else "#bound" ++ toString n
+  | .fvar id => toString id.name
+  | .mvar id => "?m." ++ toString id.name
+  | .sort .zero => "Prop"
+  | .sort (.succ .zero) => "Type"
+  | .sort l => "Sort " ++ ppSortLevel l
+  | .const name [] => "@" ++ toString name
+  | .const name us =>
+    let lvls := ", ".intercalate (us.map ppLevelInfer)
+    "@" ++ toString name ++ ".{" ++ lvls ++ "}"
+  | .lit (.natVal n) => toString n
+  | .lit (.strVal s) => "\"" ++ escapeString s ++ "\""
+  | _ => "<expr>"
+
+private structure PPCtx where
+  sharedSet : Std.HashSet Expr
+  names : IO.Ref (Std.HashMap Expr Name)
+  emitted : IO.Ref (Std.HashSet Expr)
+  nextId : IO.Ref Nat
+  binderNames : Std.HashSet Name
+
+private def PPCtx.nameFor (ctx : PPCtx) (e : Expr) : IO Name := do
+  let names ← ctx.names.get
+  match names.get? e with
+  | some name => return name
+  | none =>
+    let mut id ← ctx.nextId.get
+    let mut name := Name.mkSimple ("s" ++ toString id)
+    while ctx.binderNames.contains name do
+      id := id + 1
+      name := Name.mkSimple ("s" ++ toString id)
+    ctx.nextId.set (id + 1)
+    ctx.names.modify (·.insert e name)
+    return name
+
+private def PPCtx.markFirstEmit (ctx : PPCtx) (e : Expr) : IO Bool := do
+  let s ← ctx.emitted.get
+  if s.contains e then return false
+  ctx.emitted.modify (·.insert e)
+  return true
+
+mutual
+
+private partial def ppExpr (ctx : PPCtx) (e : Expr) (bvars : Array Name)
+    (allowMemo : Bool := true) : IO String := do
+  if isTrivial e then return ppAtom e bvars
+  if allowMemo && ctx.sharedSet.contains e then
+    let name ← ctx.nameFor e
+    if ← ctx.markFirstEmit e then
+      let val ← ppExprInner ctx e bvars
+      return "(memo " ++ toString name ++ " := " ++ val ++ ")"
+    else
+      return toString name
+  else
+    ppExprInner ctx e bvars
+
+private partial def ppExprInner (ctx : PPCtx) (e : Expr) (bvars : Array Name) : IO String := do
+  match e with
+  | .app .. =>
+    let fn := e.getAppFn
+    let args := e.getAppArgs
+    let fnStr ← ppExpr ctx fn bvars
+    if args.isEmpty then return fnStr
+    let fnStr := if strStartsWith fnStr "fun " || strStartsWith fnStr "∀ " || strStartsWith fnStr "let "
+      then "(" ++ fnStr ++ ")" else fnStr
+    let mut parts := #[fnStr]
+    for arg in args do
+      parts := parts.push (wrapParens (← ppExpr ctx arg bvars))
+    return " ".intercalate parts.toList
+  | .lam n t b bi =>
+    let tStr ← ppExpr ctx t bvars (allowMemo := false)
+    let name := freshBinderName n bvars
+    let bStr ← ppExpr ctx b (bvars.push name)
+    return "fun " ++ binderOpen bi ++ quoteName name ++ " : " ++ tStr
+      ++ binderClose bi ++ " => " ++ bStr
+  | .forallE n t b bi =>
+    let tStr ← ppExpr ctx t bvars (allowMemo := false)
+    if !b.hasLooseBVar 0 && bi == .default then
+      let bStr ← ppExpr ctx b (bvars.push `_)
+      return wrapParens tStr ++ " → " ++ bStr
+    else
+      let name := freshBinderName n bvars
+      let bStr ← ppExpr ctx b (bvars.push name)
+      return "∀ " ++ binderOpen bi ++ quoteName name ++ " : " ++ tStr
+        ++ binderClose bi ++ ", " ++ bStr
+  | .letE n t v b _ =>
+    let tStr ← ppExpr ctx t bvars (allowMemo := false)
+    let vStr ← ppExpr ctx v bvars
+    let bStr ← ppExpr ctx b (bvars.push (freshBinderName n bvars))
+    return "let " ++ quoteName (freshBinderName n bvars) ++ " : " ++ tStr ++ " := " ++ vStr ++ "; " ++ bStr
+  | .mdata _ inner => ppExpr ctx inner bvars
+  | .proj typeName idx struct =>
+    let sStr ← ppExpr ctx struct bvars
+    return "@" ++ toString typeName ++ "." ++ toString (idx + 1) ++ " " ++ wrapParens sStr
+  | _ => return ppAtom e bvars
+
+end
+
+-- ── Binder name collection ──
+
+private partial def collectBinderNames (e : Expr) (acc : Std.HashSet Name := ∅) :
+    Std.HashSet Name :=
+  match e with
+  | .lam n t b _ => collectBinderNames b (collectBinderNames t (acc.insert n))
+  | .forallE n t b _ => collectBinderNames b (collectBinderNames t (acc.insert n))
+  | .letE n t v b _ =>
+    collectBinderNames b (collectBinderNames v (collectBinderNames t (acc.insert n)))
+  | .app f a => collectBinderNames a (collectBinderNames f acc)
+  | .mdata _ e => collectBinderNames e acc
+  | .proj _ _ e => collectBinderNames e acc
+  | _ => acc
+
+-- ── Level parameter collection ──
+
+private partial def collectLevelParams (e : Expr) (acc : Std.HashSet Name := ∅) :
+    Std.HashSet Name :=
+  match e with
+  | .sort l => collectLevelParamsLevel l acc
+  | .const _ us => us.foldl (fun acc l => collectLevelParamsLevel l acc) acc
+  | .app f a => collectLevelParams a (collectLevelParams f acc)
+  | .lam _ t b _ => collectLevelParams b (collectLevelParams t acc)
+  | .forallE _ t b _ => collectLevelParams b (collectLevelParams t acc)
+  | .letE _ t v b _ => collectLevelParams b (collectLevelParams v (collectLevelParams t acc))
+  | .mdata _ e => collectLevelParams e acc
+  | .proj _ _ e => collectLevelParams e acc
+  | _ => acc
+where
+  collectLevelParamsLevel (l : Level) (acc : Std.HashSet Name) : Std.HashSet Name :=
+    match l with
+    | .param n => acc.insert n
+    | .succ l => collectLevelParamsLevel l acc
+    | .max l1 l2 => collectLevelParamsLevel l2 (collectLevelParamsLevel l1 acc)
+    | .imax l1 l2 => collectLevelParamsLevel l2 (collectLevelParamsLevel l1 acc)
+    | _ => acc
+
+-- ── Public API ──
+
+/-- Pretty-print an expression with memoized subexpression sharing.
+    Zeta+beta reduces first, then identifies shared closed subexpressions and
+    emits `memoized% ... (memo _s0 := ...) _s0` format. -/
+def ppMemoized (e : Expr) (minWeight : Nat := 3) : IO String := do
+  let e := zetaBetaReduce e
+  let e := ShareCommon.shareCommon e
+  let countsRef ← IO.mkRef (∅ : Std.HashMap Expr Nat)
+  countSubexprs e countsRef
+  let counts ← countsRef.get
+  let sharedSet : Std.HashSet Expr := counts.fold (fun acc expr count =>
+    if count > 1 && exprWeight expr >= minWeight && !expr.hasLooseBVars
+    then acc.insert expr else acc) ∅
+  let ctx : PPCtx := {
+    sharedSet
+    binderNames := collectBinderNames e
+    names := ← IO.mkRef ∅
+    emitted := ← IO.mkRef ∅
+    nextId := ← IO.mkRef 0
+  }
+  let body ← ppExpr ctx e #[]
+  let names ← ctx.names.get
+  if names.isEmpty then return body
+  else return "memoized% " ++ body
+
+end Lean.PrettyPrinter

--- a/src/Lean/PrettyPrinter/Memoize.lean
+++ b/src/Lean/PrettyPrinter/Memoize.lean
@@ -92,7 +92,7 @@ private def hasSpace (s : String) : Bool :=
   s.toList.any (· == ' ')
 
 private def strStartsWith (s prefix_ : String) : Bool :=
-  s.toList.take prefix_.data.length == prefix_.data
+  s.toList.take prefix_.toList.length == prefix_.toList
 
 private def wrapParens (s : String) : String :=
   if hasSpace s && !strStartsWith s "(" && !strStartsWith s "(memo " then
@@ -197,6 +197,16 @@ private structure PPCtx where
   emitted : IO.Ref (Std.HashSet Expr)
   nextId : IO.Ref Nat
   binderNames : Std.HashSet Name
+  outer? : Option PPCtx := none  -- outer scope for closed sharing
+
+/-- Check if `e` is shared in this context or any outer context. -/
+private partial def PPCtx.isShared (ctx : PPCtx) (e : Expr) : Bool :=
+  ctx.sharedSet.contains e || (match ctx.outer? with | some o => o.isShared e | none => false)
+
+/-- Get the context that owns a shared expression (innermost first). -/
+private partial def PPCtx.ownerOf? (ctx : PPCtx) (e : Expr) : Option PPCtx :=
+  if ctx.sharedSet.contains e then some ctx
+  else match ctx.outer? with | some o => o.ownerOf? e | none => none
 
 private def PPCtx.nameFor (ctx : PPCtx) (e : Expr) : IO Name := do
   let names ← ctx.names.get
@@ -218,20 +228,39 @@ private def PPCtx.markFirstEmit (ctx : PPCtx) (e : Expr) : IO Bool := do
   ctx.emitted.modify (·.insert e)
   return true
 
+/-- Count open (has loose bvars) subexpr occurrences within a binder body. -/
+private partial def countBodySubexprs (e : Expr)
+    (counts : IO.Ref (Std.HashMap Expr Nat)) : IO Unit := do
+  if isTrivial e then return
+  if !e.hasLooseBVars then return
+  let c ← counts.get
+  let prev := c.getD e 0
+  counts.set (c.insert e (prev + 1))
+  if prev == 0 then
+    match e with
+    | .app f a => countBodySubexprs f counts; countBodySubexprs a counts
+    | .lam _ t b _ => countBodySubexprs t counts; countBodySubexprs b counts
+    | .forallE _ t b _ => countBodySubexprs t counts; countBodySubexprs b counts
+    | .letE _ t v b _ =>
+      countBodySubexprs t counts; countBodySubexprs v counts; countBodySubexprs b counts
+    | .mdata _ e => countBodySubexprs e counts
+    | .proj _ _ e => countBodySubexprs e counts
+    | _ => pure ()
+
 mutual
 
 private partial def ppExpr (ctx : PPCtx) (e : Expr) (bvars : Array Name)
     (allowMemo : Bool := true) : IO String := do
   if isTrivial e then return ppAtom e bvars
-  if allowMemo && ctx.sharedSet.contains e then
-    let name ← ctx.nameFor e
-    if ← ctx.markFirstEmit e then
-      let val ← ppExprInner ctx e bvars
-      return "(memo " ++ toString name ++ " := " ++ val ++ ")"
-    else
-      return toString name
-  else
-    ppExprInner ctx e bvars
+  if allowMemo then
+    if let some owner := ctx.ownerOf? e then
+      let name ← owner.nameFor e
+      if ← owner.markFirstEmit e then
+        let val ← ppExprInner ctx e bvars
+        return "(memo " ++ toString name ++ " := " ++ val ++ ")"
+      else
+        return toString name
+  ppExprInner ctx e bvars
 
 private partial def ppExprInner (ctx : PPCtx) (e : Expr) (bvars : Array Name) : IO String := do
   match e with
@@ -249,7 +278,7 @@ private partial def ppExprInner (ctx : PPCtx) (e : Expr) (bvars : Array Name) : 
   | .lam n t b bi =>
     let tStr ← ppExpr ctx t bvars (allowMemo := false)
     let name := freshBinderName n bvars
-    let bStr ← ppExpr ctx b (bvars.push name)
+    let bStr ← ppBinderBody ctx b (bvars.push name)
     return "fun " ++ binderOpen bi ++ quoteName name ++ " : " ++ tStr
       ++ binderClose bi ++ " => " ++ bStr
   | .forallE n t b bi =>
@@ -259,19 +288,48 @@ private partial def ppExprInner (ctx : PPCtx) (e : Expr) (bvars : Array Name) : 
       return wrapParens tStr ++ " → " ++ bStr
     else
       let name := freshBinderName n bvars
-      let bStr ← ppExpr ctx b (bvars.push name)
+      let bStr ← ppBinderBody ctx b (bvars.push name)
       return "∀ " ++ binderOpen bi ++ quoteName name ++ " : " ++ tStr
         ++ binderClose bi ++ ", " ++ bStr
   | .letE n t v b _ =>
     let tStr ← ppExpr ctx t bvars (allowMemo := false)
     let vStr ← ppExpr ctx v bvars
-    let bStr ← ppExpr ctx b (bvars.push (freshBinderName n bvars))
-    return "let " ++ quoteName (freshBinderName n bvars) ++ " : " ++ tStr ++ " := " ++ vStr ++ "; " ++ bStr
+    let name := freshBinderName n bvars
+    let bStr ← ppBinderBody ctx b (bvars.push name)
+    return "let " ++ quoteName name ++ " : " ++ tStr ++ " := " ++ vStr ++ "; " ++ bStr
   | .mdata _ inner => ppExpr ctx inner bvars
   | .proj typeName idx struct =>
     let sStr ← ppExpr ctx struct bvars
     return "@" ++ toString typeName ++ "." ++ toString (idx + 1) ++ " " ++ wrapParens sStr
   | _ => return ppAtom e bvars
+
+/-- Print a binder body with scope-local open sharing detection.
+    If the body has repeated open subexprs, wraps output in `memoized%`. -/
+private partial def ppBinderBody (ctx : PPCtx) (body : Expr) (bvars : Array Name)
+    (minWeight : Nat := 3) : IO String := do
+  if !body.hasLooseBVars then
+    return ← ppExpr ctx body bvars
+  let countsRef ← IO.mkRef (∅ : Std.HashMap Expr Nat)
+  countBodySubexprs body countsRef
+  let counts ← countsRef.get
+  let bodyShared : Std.HashSet Expr := counts.fold (fun acc expr count =>
+    if count > 1 && exprWeight expr >= minWeight
+    then acc.insert expr else acc) ∅
+  if bodyShared.isEmpty then
+    return ← ppExpr ctx body bvars
+  -- Create a child context with open sharing, linked to outer for closed sharing
+  let childCtx : PPCtx := {
+    sharedSet := bodyShared
+    binderNames := ctx.binderNames
+    names := ← IO.mkRef ∅
+    emitted := ← IO.mkRef ∅
+    nextId := ← IO.mkRef 0
+    outer? := some ctx
+  }
+  let bodyStr ← ppExpr childCtx body bvars
+  let localNames ← childCtx.names.get
+  if localNames.isEmpty then return bodyStr
+  else return "memoized% " ++ bodyStr
 
 end
 

--- a/tests/lean/pp_memoize.lean
+++ b/tests/lean/pp_memoize.lean
@@ -1,0 +1,182 @@
+import Lean
+
+-- ═══════════════════════════════════════════════════════════════
+-- Manual round-trip: memoized%/memo syntax elaborates correctly
+-- ═══════════════════════════════════════════════════════════════
+
+example : memoized% @Nat.add
+    (memo s0 := @Nat.mul (memo s1 := @Nat.succ @Nat.zero) s1)
+    s0 = 2 := rfl
+
+example : memoized% @Nat.add
+    (memo s0 := @Nat.mul
+      (memo s1 := @Nat.add (memo s2 := @Nat.succ @Nat.zero) (@Nat.succ s2))
+      s1)
+    s0 = 18 := rfl
+
+-- ═══════════════════════════════════════════════════════════════
+-- pp.memoize output via #print
+-- ═══════════════════════════════════════════════════════════════
+
+noncomputable def test_shared :=
+  @Nat.add (@Nat.mul (@Nat.succ @Nat.zero) (@Nat.succ @Nat.zero))
+           (@Nat.mul (@Nat.succ @Nat.zero) (@Nat.succ @Nat.zero))
+
+set_option pp.memoize true in
+/--
+info: def test_shared : @Nat :=
+memoized% @Nat.add (memo s0 := @Nat.mul (memo s1 := @Nat.succ @Nat.zero) s1) s0
+-/
+#guard_msgs in
+#print test_shared
+
+-- ═══════════════════════════════════════════════════════════════
+-- Automated round-trip: ppMemoized → parse → re-elaborate → isDefEq
+-- ═══════════════════════════════════════════════════════════════
+
+open Lean Meta Elab Term in
+elab "#roundtrip " id:ident : command => do
+  Command.liftTermElabM do
+    let name ← resolveGlobalConstNoOverload id
+    let info ← getConstInfo name
+    let origVal ← match info with
+      | .defnInfo v => pure v.value
+      | .thmInfo v => pure v.value
+      | _ => throwError s!"{name}: not a def/theorem"
+    let origType ← inferType origVal
+    let s ← Lean.PrettyPrinter.ppMemoized origVal
+    let env ← getEnv
+    let stx ← match Parser.runParserCategory env `term s with
+      | .ok stx => pure stx
+      | .error err => throwError "parse failed for {name}: {err}\nOutput was:\n{s}"
+    let newVal ← elabTermEnsuringType stx origType
+    unless ← isDefEq origVal newVal do
+      throwError "round-trip FAILED for {name}\nPP output: {s}"
+    logInfo m!"{s}"
+
+open Lean Meta Elab Term in
+elab "#roundtrip_type " id:ident : command => do
+  Command.liftTermElabM do
+    let name ← resolveGlobalConstNoOverload id
+    let info ← getConstInfo name
+    let origType := info.type
+    let s ← Lean.PrettyPrinter.ppMemoized origType
+    let env ← getEnv
+    let stx ← match Parser.runParserCategory env `term s with
+      | .ok stx => pure stx
+      | .error err => throwError "parse failed for type of {name}: {err}\nOutput was:\n{s}"
+    let newType ← elabTerm stx none
+    unless ← isDefEq origType newType do
+      throwError "round-trip FAILED for type of {name}\nPP output: {s}"
+    logInfo m!"{s}"
+
+-- Stdlib definitions
+
+/-- info: fun (x : @Nat) => fun (x_1 : @Nat) => @Nat.brecOn.{1} (fun (x_2 : @Nat) => @Nat → @Nat) x_1 @Nat.add._f x -/
+#guard_msgs in #roundtrip Nat.add
+/-- info: fun {α : Sort (_ + 1)} => fun {β : Sort (_ + 1)} => fun (f : α → β) => fun (x : @List.{_} α) => @List.brecOn.{(_ + 1), _} α (fun (x_1 : @List.{_} α) => @List.{_} β) x (@List.map._f.{_, _} α β f) -/
+#guard_msgs in #roundtrip List.map
+/-- info: fun (x : @Bool) => fun (y : @Bool) => @Bool.and.match_1.{1} (fun (x_1 : @Bool) => @Bool) x (fun (_ : @Unit) => @Bool.false) (fun (_ : @Unit) => y) -/
+#guard_msgs in #roundtrip Bool.and
+/-- info: fun {α : Sort _} => fun {β : Sort _} => fun {δ : Sort _} => fun (f : β → δ) => fun (g : α → β) => fun (x : α) => f (g x) -/
+#guard_msgs in #roundtrip Function.comp
+/-- info: fun {α : Sort (_ + 1)} => fun {β : Sort (_ + 1)} => fun (f : α → β) => fun (x : @Option.{_} α) => @Option.getD.match_1.{_, (_ + 1)} α (fun (x_1 : @Option.{_} α) => @Option.{_} β) x (fun (x_1 : α) => @Option.some.{_} β (f x_1)) (fun (_ : @Unit) => @Option.none.{_} β) -/
+#guard_msgs in #roundtrip Option.map
+
+-- Theorems
+
+/-- info: fun (x : @Nat) => fun (x_1 : @Nat) => @Nat.brecOn.{0} (fun (x_2 : @Nat) => ∀ (x_3 : @Nat), @Eq.{1} @Nat (@HAdd.hAdd.{0, 0, 0} @Nat @Nat @Nat (@instHAdd.{0} @Nat @instAddNat) x_3 x_2) (@HAdd.hAdd.{0, 0, 0} @Nat @Nat @Nat (@instHAdd.{0} @Nat @instAddNat) x_2 x_3)) x_1 @Nat.add_comm._f x -/
+#guard_msgs in #roundtrip Nat.add_comm
+/-- info: fun (n : @Nat) => @rfl.{1} @Nat (@HAdd.hAdd.{0, 0, 0} @Nat @Nat @Nat (@instHAdd.{0} @Nat @instAddNat) n (@OfNat.ofNat.{0} @Nat 0 (@instOfNatNat 0))) -/
+#guard_msgs in #roundtrip Nat.add_zero
+/-- info: fun (x : @Nat) => @Nat.brecOn.{0} (fun (x_1 : @Nat) => @Eq.{1} @Nat (@HAdd.hAdd.{0, 0, 0} @Nat @Nat @Nat (@instHAdd.{0} @Nat @instAddNat) (@OfNat.ofNat.{0} @Nat 0 (@instOfNatNat 0)) x_1) x_1) x @Nat.zero_add._f -/
+#guard_msgs in #roundtrip Nat.zero_add
+
+-- Types of stdlib functions
+
+/-- info: @Nat → @Nat → @Nat -/
+#guard_msgs in #roundtrip_type Nat.add
+/-- info: ∀ {α : Sort (_ + 1)}, ∀ {β : Sort (_ + 1)}, (α → β) → (@List.{_} α) → @List.{_} β -/
+#guard_msgs in #roundtrip_type List.map
+/-- info: ∀ {α : Sort (_ + 1)}, (@List.{_} α) → (@List.{_} α) → @List.{_} α -/
+#guard_msgs in #roundtrip_type List.append
+/-- info: ∀ {α : Sort _}, ∀ {β : Sort _}, ∀ {δ : Sort _}, (β → δ) → (α → β) → α → δ -/
+#guard_msgs in #roundtrip_type Function.comp
+/-- info: ∀ {α : Sort (_ + 1)}, ∀ {β : Sort (_ + 1)}, (α → β) → (@Option.{_} α) → @Option.{_} β -/
+#guard_msgs in #roundtrip_type Option.map
+/-- info: ∀ {a : Prop}, ∀ {b : Prop}, a → b → @And a b -/
+#guard_msgs in #roundtrip_type And.intro
+/-- info: ∀ {a : Prop}, ∀ {b : Prop}, a → @Or a b -/
+#guard_msgs in #roundtrip_type Or.inl
+/-- info: ∀ {α : Sort _}, ∀ {motive : α → Prop}, ∀ {a : α}, ∀ {b : α}, (@Eq.{_} α a b) → (motive a) → motive b -/
+#guard_msgs in #roundtrip_type Eq.subst
+/-- info: ∀ {α : Sort (_ + 1)}, (@List.{_} α) → (@List.{_} α) → @List.{_} α -/
+#guard_msgs in #roundtrip_type List.reverseAux
+
+-- Instances
+
+/-- info: @Inhabited.mk.{1} @Nat @Nat.zero -/
+#guard_msgs in #roundtrip instInhabitedNat
+
+-- User definitions with sharing
+
+noncomputable def rt_shared :=
+  @Nat.add (@Nat.mul (@Nat.succ @Nat.zero) (@Nat.succ @Nat.zero))
+           (@Nat.mul (@Nat.succ @Nat.zero) (@Nat.succ @Nat.zero))
+noncomputable def rt_deep :=
+  let a := @Nat.succ @Nat.zero
+  let b := @Nat.succ (@Nat.succ @Nat.zero)
+  let ab := @Nat.add a b
+  let sq := @Nat.mul ab ab
+  @Nat.add sq sq
+noncomputable def rt_lam2 := fun (x y : Nat) => Nat.add (Nat.mul x y) (Nat.mul x y)
+noncomputable def rt_ho := @Function.comp Nat Nat Nat (· + 1) (· * 2)
+noncomputable def rt_str := @List.cons String "hello" (@List.cons String "hello" (@List.nil String))
+noncomputable def rt_pair := @Prod.mk Nat Nat (@Nat.succ @Nat.zero) (@Nat.succ @Nat.zero)
+noncomputable def rt_nested :=
+  @Nat.add (@Nat.add (@Nat.succ @Nat.zero) (@Nat.succ @Nat.zero))
+           (@Nat.add (@Nat.succ @Nat.zero) (@Nat.succ @Nat.zero))
+theorem rt_proof : 1 + 1 = 2 ∧ 1 + 1 = 2 := ⟨rfl, rfl⟩
+
+/-- info: memoized% @Nat.add (memo s0 := @Nat.mul (memo s1 := @Nat.succ @Nat.zero) s1) s0 -/
+#guard_msgs in #roundtrip rt_shared
+/-- info: memoized% @Nat.add (memo s0 := @Nat.mul (memo s1 := @Nat.add (memo s2 := @Nat.succ @Nat.zero) (@Nat.succ s2)) s1) s0 -/
+#guard_msgs in #roundtrip rt_deep
+/-- info: fun (x : @Nat) => fun (y : @Nat) => @Nat.add (@Nat.mul x y) (@Nat.mul x y) -/
+#guard_msgs in #roundtrip rt_lam2
+/-- info: @Function.comp.{1, 1, 1} @Nat @Nat @Nat (fun (x : @Nat) => @HAdd.hAdd.{0, 0, 0} @Nat @Nat @Nat (@instHAdd.{0} @Nat @instAddNat) x (@OfNat.ofNat.{0} @Nat 1 (@instOfNatNat 1))) (fun (x : @Nat) => @HMul.hMul.{0, 0, 0} @Nat @Nat @Nat (@instHMul.{0} @Nat @instMulNat) x (@OfNat.ofNat.{0} @Nat 2 (@instOfNatNat 2))) -/
+#guard_msgs in #roundtrip rt_ho
+/-- info: @List.cons.{0} @String "hello" (@List.cons.{0} @String "hello" (@List.nil.{0} @String)) -/
+#guard_msgs in #roundtrip rt_str
+/-- info: memoized% @Prod.mk.{0, 0} @Nat @Nat (memo s0 := @Nat.succ @Nat.zero) s0 -/
+#guard_msgs in #roundtrip rt_pair
+/-- info: memoized% @Nat.add (memo s0 := @Nat.add (memo s1 := @Nat.succ @Nat.zero) s1) s0 -/
+#guard_msgs in #roundtrip rt_nested
+/-- info: memoized% @And.intro (memo s0 := @Eq.{1} @Nat (memo s1 := @HAdd.hAdd.{0, 0, 0} @Nat @Nat @Nat (@instHAdd.{0} @Nat @instAddNat) (memo s2 := @OfNat.ofNat.{0} @Nat 1 (@instOfNatNat 1)) s2) (@OfNat.ofNat.{0} @Nat 2 (@instOfNatNat 2))) s0 (memo s3 := @rfl.{1} @Nat s1) s3 -/
+#guard_msgs in #roundtrip rt_proof
+
+-- String escaping
+
+def rt_str_quote := "\""
+def rt_str_backslash := "\\"
+def rt_str_newline := "\n"
+def rt_str_mix := "a\"b\\c\nd"
+
+/-- info: "\"" -/
+#guard_msgs in #roundtrip rt_str_quote
+/-- info: "\\" -/
+#guard_msgs in #roundtrip rt_str_backslash
+/-- info: "\n" -/
+#guard_msgs in #roundtrip rt_str_newline
+/-- info: "a\"b\\c\nd" -/
+#guard_msgs in #roundtrip rt_str_mix
+
+-- Keyword binder names
+
+def rt_kw_let := fun («let» : Nat) => «let»
+def rt_kw_match := fun («match» : Nat) => «match»
+
+/-- info: fun («let» : @Nat) => «let» -/
+#guard_msgs in #roundtrip rt_kw_let
+/-- info: fun («match» : @Nat) => «match» -/
+#guard_msgs in #roundtrip rt_kw_match

--- a/tests/lean/pp_memoize.lean
+++ b/tests/lean/pp_memoize.lean
@@ -142,7 +142,7 @@ theorem rt_proof : 1 + 1 = 2 ∧ 1 + 1 = 2 := ⟨rfl, rfl⟩
 #guard_msgs in #roundtrip rt_shared
 /-- info: memoized% @Nat.add (memo s0 := @Nat.mul (memo s1 := @Nat.add (memo s2 := @Nat.succ @Nat.zero) (@Nat.succ s2)) s1) s0 -/
 #guard_msgs in #roundtrip rt_deep
-/-- info: fun (x : @Nat) => fun (y : @Nat) => @Nat.add (@Nat.mul x y) (@Nat.mul x y) -/
+/-- info: fun (x : @Nat) => fun (y : @Nat) => memoized% @Nat.add (memo s0 := @Nat.mul x y) s0 -/
 #guard_msgs in #roundtrip rt_lam2
 /-- info: @Function.comp.{1, 1, 1} @Nat @Nat @Nat (fun (x : @Nat) => @HAdd.hAdd.{0, 0, 0} @Nat @Nat @Nat (@instHAdd.{0} @Nat @instAddNat) x (@OfNat.ofNat.{0} @Nat 1 (@instOfNatNat 1))) (fun (x : @Nat) => @HMul.hMul.{0, 0, 0} @Nat @Nat @Nat (@instHMul.{0} @Nat @instMulNat) x (@OfNat.ofNat.{0} @Nat 2 (@instOfNatNat 2))) -/
 #guard_msgs in #roundtrip rt_ho
@@ -180,3 +180,14 @@ def rt_kw_match := fun («match» : Nat) => «match»
 #guard_msgs in #roundtrip rt_kw_let
 /-- info: fun («match» : @Nat) => «match» -/
 #guard_msgs in #roundtrip rt_kw_match
+
+-- Scoped sharing under binders (nested memoized%)
+
+noncomputable def rt_open_sharing := fun (x : Nat) => Nat.add (Nat.mul x x) (Nat.mul x x)
+noncomputable def rt_nested_open := fun (x : Nat) => fun (y : Nat) =>
+  Nat.add (Nat.mul x y) (Nat.mul x y)
+
+/-- info: fun (x : @Nat) => memoized% @Nat.add (memo s0 := @Nat.mul x x) s0 -/
+#guard_msgs in #roundtrip rt_open_sharing
+/-- info: fun (x : @Nat) => fun (y : @Nat) => memoized% @Nat.add (memo s0 := @Nat.mul x y) s0 -/
+#guard_msgs in #roundtrip rt_nested_open

--- a/tests/lean/pp_memoize.lean
+++ b/tests/lean/pp_memoize.lean
@@ -191,3 +191,38 @@ noncomputable def rt_nested_open := fun (x : Nat) => fun (y : Nat) =>
 #guard_msgs in #roundtrip rt_open_sharing
 /-- info: fun (x : @Nat) => fun (y : @Nat) => memoized% @Nat.add (memo s0 := @Nat.mul x y) s0 -/
 #guard_msgs in #roundtrip rt_nested_open
+
+-- Sibling lambdas: same raw Expr `g #0` under different binders gets independent sharing
+noncomputable def rt_sibling_lam :=
+  @Prod.mk (Nat → Nat) (Nat → Nat)
+    (fun x => Nat.add (Nat.mul x x) (Nat.mul x x))
+    (fun y => Nat.add (Nat.mul y y) (Nat.mul y y))
+
+/-- info: memoized% @Prod.mk.{0, 0} (memo s0 := @Nat → @Nat) s0 (memo s1 := fun (x : @Nat) => memoized% @Nat.add (memo s2 := @Nat.mul x x) s2) s1 -/
+#guard_msgs in #roundtrip rt_sibling_lam
+
+-- Sharing at nested depth with closed+open mix
+noncomputable def rt_depth2 := fun (x : Nat) => fun (y : Nat) =>
+  Nat.add (Nat.add (Nat.mul x y) (Nat.mul x y))
+          (Nat.add (Nat.mul x y) (Nat.mul x y))
+
+/-- info: fun (x : @Nat) => fun (y : @Nat) => memoized% @Nat.add (memo s0 := @Nat.add (memo s1 := @Nat.mul x y) s1) s0 -/
+#guard_msgs in #roundtrip rt_depth2
+
+-- Name collision avoidance: outer and inner scopes use distinct names
+noncomputable def rt_outer_sharing := fun (x : Nat) =>
+  @Prod.mk (Nat → Nat) (Nat → Nat)
+    (fun y => Nat.add x y)
+    (fun z => Nat.add x z)
+
+/-- info: memoized% fun (x : @Nat) => memoized% @Prod.mk.{0, 0} (memo s0 := @Nat → @Nat) s0 (memo s1 := fun (y : @Nat) => @Nat.add x y) s1 -/
+#guard_msgs in #roundtrip rt_outer_sharing
+
+-- Sharing across let value and body under binder (zeta-reduced)
+noncomputable def rt_let_cross := fun (x : Nat) =>
+  let a := Nat.mul x x
+  let b := Nat.mul x x
+  Nat.add a b
+
+/-- info: fun (x : @Nat) => memoized% @Nat.add (memo s0 := @Nat.mul x x) s0 -/
+#guard_msgs in #roundtrip rt_let_cross


### PR DESCRIPTION
This PR adds a `pp.memoize` pretty-printer option that identifies shared
subexpressions and emits them using `memoized%`/`memo` syntax. When enabled,
`set_option pp.memoize true` makes all expression printing (via `#print`,
`#check`, error messages, etc.) use this compact format.

```lean
noncomputable def test :=
  @Nat.add (@Nat.mul (@Nat.succ @Nat.zero) (@Nat.succ @Nat.zero))
           (@Nat.mul (@Nat.succ @Nat.zero) (@Nat.succ @Nat.zero))

set_option pp.memoize true in
#print test
-- def test : @Nat :=
-- memoized% @Nat.add (memo s0 := @Nat.mul (memo s1 := @Nat.succ @Nat.zero) s1) s0
```

The output round-trips: the `memoized%` elaborator floats `memo` bindings to
`let` declarations, producing a term that is definitionally equal to the
original. The test suite verifies round-tripping for stdlib definitions
(`Nat.add`, `List.map`, `Function.comp`, `Option.map`), theorems
(`Nat.add_comm`, `Nat.add_zero`, `Nat.zero_add`), types of 9 stdlib
functions, instances, and user definitions with various sharing patterns.

The intended use case is AI consumption: showing full detail with
sub-expression sharing, so that large terms remain compact and readable.

Implementation:
- `pp.memoize` option registered in `Delaborator/Options.lean`
- `PrettyPrinter/Memoize.lean`: custom string-based printer that zeta+beta
  reduces, runs `shareCommon`, counts subexpr occurrences, and emits `memo`
  at first DFS occurrence of shared closed subexpressions
- `Elab/MemoizedTerm.lean`: `memoized%`/`memo` syntax and elaborator
- 3-line hook in `PrettyPrinter.ppExprWithInfos`

Known limitations:
- String-based printer (not the delaborator), so no hover/go-to-def info
- Instance-implicit binder types with shared subexpressions may not
  round-trip via `isDefEq` in all cases
- Universe parameters are inferred (`_`) rather than preserved

🤖 Prepared with Claude Code