### PR TITLE
fix: docstring errors

### DIFF
--- a/src/Init/Data/Char/Basic.lean
+++ b/src/Init/Data/Char/Basic.lean
@@ -98,7 +98,7 @@ return `('\r', U+000D)`, or a newline `('\n', U+000A)`.
   c = ' ' || c = '\t' || c = '\r' || c = '\n'
 
 /--
-Returns `true` if the character is a uppercase ASCII letter.
+Returns `true` if the character is an uppercase ASCII letter.
 
 The uppercase ASCII letters are the following: `ABCDEFGHIJKLMNOPQRSTUVWXYZ`.
 -/

--- a/src/Init/Meta/Defs.lean
+++ b/src/Init/Meta/Defs.lean
@@ -904,7 +904,7 @@ def mkNameLit (val : String) (info := SourceInfo.none) : NameLit :=
   mkLit nameLitKind val info
 
 /-! Recall that we don't have special Syntax constructors for storing numeric and string atoms.
-   The idea is to have an extensible approach where embedded DSLs may have new kind of atoms and/or
+   The idea is to have an extensible approach where embedded DSLs may have new kinds of atoms and/or
    different ways of representing them. So, our atoms contain just the parsed string.
    The main Lean parser uses the kind `numLitKind` for storing natural numbers that can be encoded
    in binary, octal, decimal and hexadecimal format. `isNatLit` implements a "decoder"

--- a/src/Init/Meta/Defs.lean
+++ b/src/Init/Meta/Defs.lean
@@ -731,7 +731,7 @@ def mkCIdentFrom (src : Syntax) (c : Name) (canonical := false) : Ident :=
 Creates an identifier referring to a constant `c`. The identifier's position is copied from the
 syntax returned by `getRef`.
 
-This variant of `mkIdentFrom` makes sure that the identifier cannot accidentally be captured.
+This variant of `mkIdentFromRef` makes sure that the identifier cannot accidentally be captured.
 -/
 def mkCIdentFromRef [Monad m] [MonadRef m] (c : Name) (canonical := false) : m Syntax := do
   return mkCIdentFrom (← getRef) c canonical

--- a/src/Init/Meta/Defs.lean
+++ b/src/Init/Meta/Defs.lean
@@ -797,7 +797,7 @@ def mkSep (a : Array Syntax) (sep : Syntax) : Syntax :=
   mkNullNode <| mkSepArray a sep
 
 /--
-Constructs a typed separated array from elements by adding suitable separators.
+Constructs an untyped separated array from elements by adding suitable separators.
 The provided array should not include the separators.
 
 Like `Syntax.TSepArray.ofElems` but for untyped syntax.
@@ -806,7 +806,7 @@ def SepArray.ofElems {sep} (elems : Array Syntax) : SepArray sep :=
 ⟨mkSepArray elems (if String.Internal.isEmpty sep then mkNullNode else mkAtom sep)⟩
 
 /--
-Constructs a typed separated array from elements by adding suitable separators.
+Constructs an untyped separated array from elements by adding suitable separators.
 The provided array should not include the separators.
 The generated separators' source location is that of the syntax returned by `getRef`.
 -/

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -5939,8 +5939,8 @@ The `List String` in each alternative is the deduced list of projections
 (which are ambiguous with name components).
 
 Remark: it will not trigger actions associated with reserved names. Recall that Lean
-has reserved names. For example, a definition `foo` has a reserved name `foo.def` for a theorem
-stating that `foo` is equal to its definition. The action associated with `foo.def`
+has reserved names. For example, a definition `foo` has a reserved name `foo.eq_def` for a theorem
+stating that `foo` is equal to its definition. The action associated with `foo.eq_def`
 automatically proves the theorem. At the macro level, the name is resolved, but the action is not
 executed. The actions are executed by the elaborator when converting `Syntax` into `Expr`.
 -/

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -5375,7 +5375,7 @@ inductive ParserDescr where
   /-- Like `node` but for trailing parsers (which start with a nonterminal).
   Assumes the lhs is already on the stack, and parses using `p`, then pops the
   stack including the lhs to create a new node with kind `kind`.
-  The precedence `prec` and `lhsPrec` are used to determine whether the parser
+  The precedences `prec` and `lhsPrec` are used to determine whether the parser
   should apply. -/
   | trailingNode (kind : SyntaxNodeKind) (prec lhsPrec : Nat) (p : ParserDescr)
   /--

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -525,8 +525,7 @@ Lean's type theory includes a [definitional reduction](lean-manual://section/typ
  * `Quot.mk` places elements of the underlying type `α` into the quotient.
  * `Quot.sound` asserts the equality of elements related by `r`
  * `Quot.ind` is used to write proofs about quotients by assuming that all elements are constructed
-   with `Quot.mk`; it is analogous to the [recursor](lean-manual://section/recursors) for a
-   structure.
+   with `Quot.mk`.
 -/
 add_decl_doc Quot.lift
 

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -5450,8 +5450,8 @@ abbrev TrailingParserDescr := ParserDescr
 
 /-!
 Runtime support for making quotation terms auto-hygienic, by mangling identifiers
-introduced by them with a "macro scope" supplied by the context. Details to appear in a
-paper soon.
+introduced by them with a "macro scope" supplied by the context. Details available
+in the paper [Beyond Notations: Hygienic Macro Expansion for Theorem Proving Languages](https://arxiv.org/pdf/2001.10490).
 -/
 
 /--

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -5383,7 +5383,7 @@ inductive ParserDescr where
 
   The symbol is automatically included in the set of reserved tokens ("keywords").
   Keywords cannot be used as identifiers, unless the identifier is otherwise escaped.
-  For example, `"fun"` reserves `fun` as a keyword; to refer an identifier named `fun` one can write `«fun»`.
+  For example, `"fun"` reserves `fun` as a keyword; to refer to an identifier named `fun` one can write `«fun»`.
   Adding a `&` prefix prevents it from being reserved, for example `&"true"`.
 
   Whitespace before or after the atom is used as a pretty printing hint.

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -5628,7 +5628,7 @@ A `MacroScopesView` represents a parsed hygienic name. `extractMacroScopes`
 will decode it from a `Name`, and `.review` will re-encode it. The grammar of a
 hygienic name is:
 ```
-<name>._@.(<module_name>.<scopes>)*.<mainModule>._hyg.<scopes>
+<name>._@.(<module_name>.<scopes>)*.<mainModule>.<uniq>._hygCtx._hyg.<scopes>
 ```
 -/
 structure MacroScopesView where

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -354,7 +354,7 @@ Lean by `rfl`, because both sides are the same up to definitional equality.
 @[simp] theorem id_eq (a : α) : Eq (id a) a := rfl
 
 /--
-The substitution principle for equality. If `a = b ` and `P a` holds,
+The substitution principle for equality. If `a = b` and `P a` holds,
 then `P b` also holds. We conventionally use the name `motive` for `P` here,
 so that you can specify it explicitly using e.g.
 `Eq.subst (motive := fun x => x < 5)` if it is not otherwise inferred correctly.

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -4912,7 +4912,7 @@ end SourceInfo
 Specifies the interpretation of a `Syntax.node` value. An abbreviation for `Name`.
 
 Node kinds may be any name, and do not need to refer to declarations in the environment.
-Conventionally, however, a node's kind corresponds to the `Parser` or `ParserDesc` declaration that
+Conventionally, however, a node's kind corresponds to the `Parser` or `ParserDescr` declaration that
 produces it. There are also a number of built-in node kinds that are used by the parsing
 infrastructure, such as `nullKind` and `choiceKind`; these do not correspond to parser declarations.
 -/

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -939,7 +939,7 @@ Lifts a type or proposition to a higher universe level.
 `ULift` that allows lifting values whose type may live in `Sort s`.
 It also subsumes `PLift`.
 -/
--- The universe variable `r` is written first so that `ULift.{r} α` can be used
+-- The universe variable `r` is written first so that `PULift.{r} α` can be used
 -- when `s` can be inferred from the type of `α`.
 structure PULift.{r, s} (α : Sort s) : Sort (max s r 1) where
   /-- Wraps a value to increase its type's universe level. -/

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -5940,8 +5940,8 @@ The `List String` in each alternative is the deduced list of projections
 (which are ambiguous with name components).
 
 Remark: it will not trigger actions associated with reserved names. Recall that Lean
-has reserved names. For example, a definition `foo` has a reserved name `foo.def` for theorem
-containing stating that `foo` is equal to its definition. The action associated with `foo.def`
+has reserved names. For example, a definition `foo` has a reserved name `foo.def` for a theorem
+stating that `foo` is equal to its definition. The action associated with `foo.def`
 automatically proves the theorem. At the macro level, the name is resolved, but the action is not
 executed. The actions are executed by the elaborator when converting `Syntax` into `Expr`.
 -/

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -5379,7 +5379,7 @@ inductive ParserDescr where
   should apply. -/
   | trailingNode (kind : SyntaxNodeKind) (prec lhsPrec : Nat) (p : ParserDescr)
   /--
-  Parses the literal symbol.
+  Parses an atomic symbol.
 
   The symbol is automatically included in the set of reserved tokens ("keywords").
   Keywords cannot be used as identifiers, unless the identifier is otherwise escaped.
@@ -5392,7 +5392,7 @@ inductive ParserDescr where
   -/
   | symbol (val : String)
   /--
-  Parses a literal symbol. The `&` prefix prevents it from being included in the set of reserved tokens ("keywords").
+  Parses an atomic symbol. The `&` prefix prevents it from being included in the set of reserved tokens ("keywords").
   This means that the symbol can still be recognized as an identifier by other parsers.
 
   Some syntax categories, such as `tactic`, automatically apply `&` to the first symbol.

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -5579,7 +5579,6 @@ file.
 foo.bla._@.Init.Data.List.Basic.2.1.Init.Lean.Expr._hyg.4
 ```
 
-The delimiter `_hyg` is used just to improve the `hasMacroScopes` performance.
 In practice, we further specify the context name down to be unique per declaration so that the
 numeric scopes are not influenced by the elaboration of preceding declarations. This helps both with
 ensuring declaration names are more stable so that `prefer_native` can find the correct native

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -5413,7 +5413,7 @@ inductive ParserDescr where
   | parser (declName : Name)
   /-- Like `node`, but also declares that the body can be matched using an antiquotation
   with name `name`. For example, `def $id:declId := 1` uses an antiquotation with
-  name `declId` in the place where a `declId` is expected. -/
+  name `id` in the place where a `declId` is expected. -/
   | nodeWithAntiquot (name : String) (kind : SyntaxNodeKind) (p : ParserDescr)
   /-- A `sepBy(p, sep)` parses 0 or more occurrences of `p` separated by `sep`.
   `psep` is usually the same as `symbol sep`, but it can be overridden.

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -936,7 +936,7 @@ instance [Inhabited α] : Inhabited (ULift α) where
 Lifts a type or proposition to a higher universe level.
 
 `PULift α` wraps a value of type `α`. It is a generalization of
-`PLift` that allows lifting values whose type may live in `Sort s`.
+`ULift` that allows lifting values whose type may live in `Sort s`.
 It also subsumes `PLift`.
 -/
 -- The universe variable `r` is written first so that `ULift.{r} α` can be used

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -5245,7 +5245,7 @@ partial def getHeadInfo? : Syntax → Option SourceInfo
   | node info _ _ => some info
   | _             => none
 
-/-- Retrieve the left-most leaf's info in the Syntax tree, or `none` if there is no token. -/
+/-- Retrieve the left-most node or leaf's info in the Syntax tree, or `none` if there is no token. -/
 partial def getHeadInfo (stx : Syntax) : SourceInfo :=
   match stx.getHeadInfo? with
   | some info => info

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -514,7 +514,7 @@ Lifts a function from an underlying type to a function on a quotient, requiring 
 quotient's relation.
 
 Given a relation `r : α → α → Prop` and a quotient `Quot r`, applying a function `f : α → β`
-requires a proof `a` that `f` respects `r`. In this case, `Quot.lift f a : Quot r → β` computes the
+requires a proof `h` that `f` respects `r`. In this case, `Quot.lift f h : Quot r → β` computes the
 same values as `f`.
 
 Lean's type theory includes a [definitional reduction](lean-manual://section/type-theory) from

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -87,7 +87,7 @@ type, and casting `a` across the equality yields `b`, and vice versa.
 You should avoid using this type if you can. Heterogeneous equality does not
 have all the same properties as `Eq`, because the assumption that the types of
 `a` and `b` are equal is often too weak to prove theorems of interest. One
-public important non-theorem is the analogue of `congr`: If `f ≍ g` and `x ≍ y`
+important non-theorem is the analogue of `congr`: If `f ≍ g` and `x ≍ y`
 and `f x` and `g y` are well typed it does not follow that `f x ≍ g y`.
 (This does follow if you have `f = g` instead.) However if `a` and `b` have
 the same type then `a = b` and `a ≍ b` are equivalent.
@@ -100,7 +100,7 @@ inductive HEq : {α : Sort u} → α → {β : Sort u} → β → Prop where
 The Boolean values, `true` and `false`.
 
 Logically speaking, this is equivalent to `Prop` (the type of propositions). The distinction is
-public important for programming: both propositions and their proofs are erased in the code generator,
+important for programming: both propositions and their proofs are erased in the code generator,
 while `Bool` corresponds to the Boolean type in most programming languages and carries precisely one
 bit of run-time information.
 -/

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -4852,7 +4852,7 @@ inductive SourceInfo where
   binders, as in the macro expansion for dependent if:
   ```
   `(if $h : $cond then $t else $e) ~>
-  `(dite $cond (fun $h => $t) (fun $h => $t))
+  `(dite $cond (fun $h => $t) (fun $h => $e))
   ```
   In these cases, if the user hovers over `h` they will see information about both binding sites.
   -/

--- a/src/Init/System/IO.lean
+++ b/src/Init/System/IO.lean
@@ -212,7 +212,7 @@ causing the side effect to occur at initialization time, even if it would otherw
 /--
 Times the execution of an `IO` action.
 
-The provided message `msg` and the time take are printed to the current standard error as a side
+The provided message `msg` and the time taken are printed to the current standard error as a side
 effect.
 -/
 @[extern "lean_io_timeit"] opaque timeit (msg : @& String) (fn : IO α) : IO α

--- a/src/Init/System/IO.lean
+++ b/src/Init/System/IO.lean
@@ -173,7 +173,7 @@ Runs an `IO` action in some other `EIO` monad, using `f` to translate `IO` excep
    the "extract closed terms" optimization. -/
 set_option compiler.extract_closed false in
 /--
-Executes arbitrary side effects in a pure context. This a **dangerous** operation that can easily
+Executes arbitrary side effects in a pure context. This is a **dangerous** operation that can easily
 undermine important assumptions about the meaning of Lean programs, and it should only be used with
 great care and a thorough understanding of compiler internals, and even then only to implement
 observationally pure operations.
@@ -190,7 +190,7 @@ causing the side effect to occur at initialization time, even if it would otherw
   | .mk a _ => a
 
 /--
-Executes arbitrary side effects in a pure context, with exceptions indicated via `Except`. This a
+Executes arbitrary side effects in a pure context, with exceptions indicated via `Except`. This is a
 **dangerous** operation that can easily undermine important assumptions about the meaning of Lean
 programs, and it should only be used with great care and a thorough understanding of compiler
 internals, and even then only to implement observationally pure operations.

--- a/src/Lean/Declaration.lean
+++ b/src/Lean/Declaration.lean
@@ -248,15 +248,15 @@ def Declaration.getNames : Declaration → List Name
 @[inline] def Declaration.forExprM {m : Type → Type} [Monad m] (d : Declaration) (f : Expr → m Unit) : m Unit :=
   d.foldExprM (fun _ a => f a) ()
 
-/-- The kernel compiles (mutual) inductive declarations (see `inductiveDecls`) into a set of
-    - `Declaration.inductDecl` (for each inductive datatype in the mutual Declaration),
-    - `Declaration.ctorDecl` (for each Constructor in the mutual Declaration),
-    - `Declaration.recDecl` (automatically generated recursors).
+/-- The kernel compiles (mutual) inductive declarations (see `Declaration.inductDecl`) into a set of
+    - `InductiveVal` (for each inductive datatype in the mutual declaration),
+    - `ConstructorVal` (for each constructor in the mutual declaration),
+    - `RecursorVal` (automatically generated recursors).
 
     This data is used to implement iota-reduction efficiently and compile nested inductive
     declarations.
 
-    A series of checks are performed by the kernel to check whether a `inductiveDecls`
+    A series of checks are performed by the kernel to check whether a `Declaration.inductDecl`
     is valid or not. -/
 structure InductiveVal extends ConstantVal where
   /-- Number of parameters. A parameter is an argument to the defined type that is fixed over constructors.

--- a/src/Lean/Declaration.lean
+++ b/src/Lean/Declaration.lean
@@ -272,7 +272,7 @@ structure InductiveVal extends ConstantVal where
   An example of this is the `n : Nat` argument in the vector constructor `cons : α → Vector α n → Vector α (n+1)`.
   -/
   numIndices : Nat
-  /-- List of all (including this one) inductive datatypes in the mutual declaration containing this one -/
+  /-- List of all (including this one) inductive datatypes in the mutual declaration containing this one. -/
   all : List Name
   /-- List of the names of the constructors for this inductive datatype. -/
   ctors : List Name

--- a/src/Lean/Meta/AppBuilder.lean
+++ b/src/Lean/Meta/AppBuilder.lean
@@ -411,7 +411,7 @@ private partial def mkAppOptMAux (f : Expr) (xs : Array (Option Expr)) : Nat →
   ```
   mkAppOptM `Pure.pure #[m, none, none, a]
   ```
-  returns a `Pure.pure` application if the instance `Pure m` can be synthesized, and the universe match.
+  returns a `Pure.pure` application if the instance `Pure m` can be synthesized and the universes match.
   Note that,
   ```
   mkAppM `Pure.pure #[a]

--- a/src/Lean/ReducibilityAttrs.lean
+++ b/src/Lean/ReducibilityAttrs.lean
@@ -118,7 +118,7 @@ Recall that the discrimination trees unfold `[reducible]` declarations while ind
 
 register_builtin_option allowUnsafeReducibility : Bool := {
   defValue := false
-  descr    := "enables users to modify the reducibility settings for declarations even when such changes are deemed potentially hazardous. For example, `simp` and type class resolution maintain term indices where reducible declarations are expanded."
+  descr    := "Enables users to modify the reducibility settings for declarations even when such changes are deemed potentially hazardous. For example, `simp` and type class resolution maintain term indices where reducible declarations are expanded."
 }
 
 private def validate (declName : Name) (status : ReducibilityStatus) (attrKind : AttributeKind) : CoreM Unit := do

--- a/src/Lean/ResolveName.lean
+++ b/src/Lean/ResolveName.lean
@@ -241,13 +241,13 @@ def resolveNamespaceUsingOpenDecls (env : Environment) (n : Name) : List OpenDec
 /--
 Given a name `id` try to find namespaces it may refer to. The resolution procedure works as follows
 
-1- If `id` is in the scope of `namespace` commands the namespace `s_1. ... . s_n`,
-   then we include `s_1 . ... . s_i ++ n` in the result if it is the name of an existing namespace.
-   We search "backwards", and include at most one of the in the list of resulting namespaces.
+1- If `id` is in the scope of nested `namespace` commands making up the namespace `s_1 . ... . s_n`,
+   then we include `s_1 . ... . s_i . id` in the result if it is the name of an existing namespace.
+   We search "backwards", and include at most one of the matches in the list of resulting namespaces.
 
-2- If `id` is the exact name of an existing namespace, then include `id`
+2- If `id` is the exact name of an existing namespace, then include `id`.
 
-3- Finally, for each command `open N`, include in the result `N ++ n` if it is the name of an existing namespace.
+3- Finally, for each command `open N`, include in the result `N . id` if it is the name of an existing namespace.
    We only consider simple `open` commands. -/
 def resolveNamespace (env : Environment) (ns : Name) (openDecls : List OpenDecl) (id : Name) : List Name :=
   match resolveNamespaceUsingScope? env id ns with

--- a/src/Lean/ResolveName.lean
+++ b/src/Lean/ResolveName.lean
@@ -20,7 +20,7 @@ Reserved names.
 We use reserved names for automatically generated theorems (e.g., equational theorems).
 Automation may register new reserved name predicates.
 In this module, we just check the registered predicates, but do not trigger actions associated with them.
-For example, give a definition `foo`, we flag `foo.def` as reserved symbol.
+For example, give a definition `foo`, we flag `foo.eq_def` as reserved symbol.
 -/
 
 def throwReservedNameNotAvailable [Monad m] [MonadError m] (declName : Name) (reservedName : Name) : m Unit := do
@@ -186,8 +186,8 @@ private def resolveOpenDecls (env : Environment) (opts : Options) (id : Name) : 
 
 /--
 Primitive global name resolution procedure. It does not trigger actions associated with reserved names.
-Recall that Lean has reserved names. For example, a definition `foo` has a reserved name `foo.def` for a theorem
-stating that `foo` is equal to its definition. The action associated with `foo.def`
+Recall that Lean has reserved names. For example, a definition `foo` has a reserved name `foo.eq_def` for a theorem
+stating that `foo` is equal to its definition. The action associated with `foo.eq_def`
 automatically proves the theorem. At the macro level, the name is resolved, but the action is not
 executed.
 -/

--- a/src/Lean/ResolveName.lean
+++ b/src/Lean/ResolveName.lean
@@ -186,8 +186,8 @@ private def resolveOpenDecls (env : Environment) (opts : Options) (id : Name) : 
 
 /--
 Primitive global name resolution procedure. It does not trigger actions associated with reserved names.
-Recall that Lean has reserved names. For example, a definition `foo` has a reserved name `foo.def` for theorem
-containing stating that `foo` is equal to its definition. The action associated with `foo.def`
+Recall that Lean has reserved names. For example, a definition `foo` has a reserved name `foo.def` for a theorem
+stating that `foo` is equal to its definition. The action associated with `foo.def`
 automatically proves the theorem. At the macro level, the name is resolved, but the action is not
 executed.
 -/

--- a/src/Lean/Server/Watchdog.lean
+++ b/src/Lean/Server/Watchdog.lean
@@ -26,7 +26,7 @@ For general server architecture, see `README.md`. This module implements the wat
 Most LSP clients only send us file diffs, so to facilitate sending entire file contents to freshly
 restarted workers, the watchdog needs to maintain the current state of each file. It can also use
 this state to detect changes to the header and thus restart the corresponding worker, freeing its
-public imports.
+imports.
 
 TODO(WN):
 We may eventually want to keep track of approximately (since this isn't knowable exactly) where in

--- a/src/Std/Tactic/Do.lean
+++ b/src/Std/Tactic/Do.lean
@@ -14,5 +14,5 @@ public import Std.Tactic.Do.Syntax
 /-!
 This directory contains the syntax definition for tactics related to the proof mode of `Std.Do.SPred`.
 Their builtin implementation lives in `Lean.Elab.Tactic.Do` to enable using the tactics without
-public importing `Lean`.
+importing `Lean`.
 -/


### PR DESCRIPTION
This PR fixes a series of errors in docstrings.

This includes:
- incorrect grammar
- references to incorrect identifiers
- up-to-date description of macro scope grammar
- more clear identifier for example hypothesis
- consistency in Quot docs
- some erroneous find and replace all errors for words with "import" as a prefix
- a new link to the hygienic macros paper
- incorrect description of a function's behavior
- better description of `resolveNamespace`
- removing redundant lines
- updating the `InductiveVal` docstring to use correct references