### PR TITLE
feat: check if `addInstance` target type is class

### DIFF
--- a/src/Lean/Meta/Instances.lean
+++ b/src/Lean/Meta/Instances.lean
@@ -231,6 +231,10 @@ private partial def computeSynthOrder (inst : Expr) (projInfo? : Option Projecti
 
 def addInstance (declName : Name) (attrKind : AttributeKind) (prio : Nat) : MetaM Unit := do
   let c ← mkConstWithLevelParams declName
+  let type ← inferType c
+  forallTelescopeReducing type fun _ target => do
+    unless (← isClass? target).isSome do
+      logWarning m!"instance `{declName}` target `{target}` is not a type class"
   let keys ← mkInstanceKey c
   let status ← getReducibilityStatus declName
   unless status matches .reducible | .implicitReducible do

--- a/src/Lean/Meta/Instances.lean
+++ b/src/Lean/Meta/Instances.lean
@@ -240,6 +240,7 @@ def addInstance (declName : Name) (attrKind : AttributeKind) (prio : Nat) : Meta
     let type ← inferType c
     forallTelescopeReducing type fun _ target => do
       unless (← isClass? target).isSome do
+        unless target.isSorry do
         logWarning m!"instance `{declName}` target `{target}` is not a type class. \n\n\
         Disable `warning.nonClassInstance` to silence this warning."
   let keys ← mkInstanceKey c

--- a/src/Lean/Meta/Instances.lean
+++ b/src/Lean/Meta/Instances.lean
@@ -19,6 +19,11 @@ register_builtin_option synthInstance.checkSynthOrder : Bool := {
   descr := "check that instances do not introduce metavariable in non-out-params"
 }
 
+register_builtin_option warning.nonClassInstance : Bool := {
+  defValue := true
+  descr := "checks if any declaration whose type is not a class is marked as an instance"
+}
+
 /-
 Note: we want to use iota reduction when indexing instances. Otherwise,
 we cannot elaborate examples such as
@@ -231,10 +236,12 @@ private partial def computeSynthOrder (inst : Expr) (projInfo? : Option Projecti
 
 def addInstance (declName : Name) (attrKind : AttributeKind) (prio : Nat) : MetaM Unit := do
   let c ← mkConstWithLevelParams declName
-  let type ← inferType c
-  forallTelescopeReducing type fun _ target => do
-    unless (← isClass? target).isSome do
-      logWarning m!"instance `{declName}` target `{target}` is not a type class"
+  if warning.nonClassInstance.get (← getOptions) then
+    let type ← inferType c
+    forallTelescopeReducing type fun _ target => do
+      unless (← isClass? target).isSome do
+        logWarning m!"instance `{declName}` target `{target}` is not a type class. \n\n\
+        Disable `warning.nonClassInstance` to silence this warning."
   let keys ← mkInstanceKey c
   let status ← getReducibilityStatus declName
   unless status matches .reducible | .implicitReducible do

--- a/tests/compile/large_closure_bug.lean
+++ b/tests/compile/large_closure_bug.lean
@@ -68,9 +68,11 @@ def ExtractNonDet.bind :
     dsimp [Bind.bind, NonDetT.bind]; constructor
     intro y; apply ExtractNonDet.bind <;> solve_by_elim
 
+set_option warning.nonClassInstance false in
 instance ExtractNonDet.pure' : ExtractNonDet (Pure.pure (f := NonDetT m) x) := by
   dsimp [Pure.pure, NonDetT.pure]; constructor
 
+set_option warning.nonClassInstance false in
 instance ExtractNonDet.liftM (x : m α) :
   ExtractNonDet (liftM (n := NonDetT m) x) := by
     dsimp [_root_.liftM, monadLift, MonadLift.monadLift]; constructor

--- a/tests/elab/derivingReflBEq.lean
+++ b/tests/elab/derivingReflBEq.lean
@@ -64,6 +64,7 @@ error: failed to synthesize instance of type class
 Hint: Adding the command `deriving instance BEq for RegularBEq.Foo` may allow Lean to derive the missing instance.
 -/
 #guard_msgs in
+set_option warning.nonClassInstance false in
 structure Foo where
   deriving ReflBEq
 
@@ -165,6 +166,7 @@ error: failed to synthesize instance of type class
 Hint: Adding the command `deriving instance BEq for LinearBEq.Foo` may allow Lean to derive the missing instance.
 -/
 #guard_msgs in
+set_option warning.nonClassInstance false in
 structure Foo where
   deriving ReflBEq
 

--- a/tests/elab/nonClassInstance.lean
+++ b/tests/elab/nonClassInstance.lean
@@ -6,7 +6,11 @@ structure Foo where
 class Bar where
   x : Nat
 
-/-- warning: instance `instFoo` target `Foo` is not a type class -/
+/--
+warning: instance `instFoo` target `Foo` is not a type class. ⏎
+
+Disable `warning.nonClassInstance` to silence this warning.
+-/
 #guard_msgs in
 instance instFoo : Foo := ⟨0⟩
 
@@ -14,7 +18,9 @@ instance instFoo : Foo := ⟨0⟩
 def instFoo2 : Foo := ⟨1⟩
 
 /--
-warning: instance `instFoo2` target `Foo` is not a type class
+warning: instance `instFoo2` target `Foo` is not a type class. ⏎
+
+Disable `warning.nonClassInstance` to silence this warning.
 ---
 warning: instance `instFoo2` must be marked with `@[reducible]` or `@[implicit_reducible]`
 -/
@@ -36,6 +42,10 @@ instance : Baz Nat := ⟨0⟩
 structure Qux (α : Type) where
   x : α
 
-/-- warning: instance `instQux` target `Qux Nat` is not a type class -/
+/--
+warning: instance `instQux` target `Qux Nat` is not a type class. ⏎
+
+Disable `warning.nonClassInstance` to silence this warning.
+-/
 #guard_msgs in
 instance instQux : Qux Nat := ⟨0⟩

--- a/tests/elab/nonClassInstance.lean
+++ b/tests/elab/nonClassInstance.lean
@@ -1,0 +1,41 @@
+/-! Registering an instance whose target type is not a class should warn. -/
+
+structure Foo where
+  x : Nat
+
+class Bar where
+  x : Nat
+
+/-- warning: instance `instFoo` target `Foo` is not a type class -/
+#guard_msgs in
+instance instFoo : Foo := ⟨0⟩
+
+-- Applying @[instance] to a non-class def should also warn
+def instFoo2 : Foo := ⟨1⟩
+
+/--
+warning: instance `instFoo2` target `Foo` is not a type class
+---
+warning: instance `instFoo2` must be marked with `@[reducible]` or `@[implicit_reducible]`
+-/
+#guard_msgs in
+attribute [instance] instFoo2
+
+-- No warning for a proper class instance
+#guard_msgs in
+instance : Bar := ⟨0⟩
+
+-- No warning for a class instance with parameters
+class Baz (α : Type) where
+  x : α
+
+#guard_msgs in
+instance : Baz Nat := ⟨0⟩
+
+-- Warning for non-class with parameters
+structure Qux (α : Type) where
+  x : α
+
+/-- warning: instance `instQux` target `Qux Nat` is not a type class -/
+#guard_msgs in
+instance instQux : Qux Nat := ⟨0⟩

--- a/tests/elab/simp_proj_transparency_issue.lean
+++ b/tests/elab/simp_proj_transparency_issue.lean
@@ -1,13 +1,11 @@
-structure Foo where
+class Foo where
   x : Nat
   y : Nat := 10
 
-set_option warning.nonClassInstance false in
 @[instance]
 def f (x : Nat) : Foo :=
   { x := x + x }
 
-set_option warning.nonClassInstance false in
 @[instance]
 def g (x : Nat) : Foo :=
   { x := x + x }

--- a/tests/elab/simp_proj_transparency_issue.lean
+++ b/tests/elab/simp_proj_transparency_issue.lean
@@ -2,10 +2,12 @@ structure Foo where
   x : Nat
   y : Nat := 10
 
+set_option warning.nonClassInstance false in
 @[instance]
 def f (x : Nat) : Foo :=
   { x := x + x }
 
+set_option warning.nonClassInstance false in
 @[instance]
 def g (x : Nat) : Foo :=
   { x := x + x }

--- a/tests/elab/simp_proj_transparency_issue.lean.out.expected
+++ b/tests/elab/simp_proj_transparency_issue.lean.out.expected
@@ -1,2 +1,4 @@
-simp_proj_transparency_issue.lean:6:2-6:10: warning: instance `f` must be marked with `@[reducible]` or `@[implicit_reducible]`
-simp_proj_transparency_issue.lean:11:2-11:10: warning: instance `g` must be marked with `@[reducible]` or `@[implicit_reducible]`
+simp_proj_transparency_issue.lean:5:2-5:10: warning: instance `f` must be marked with `@[reducible]` or `@[implicit_reducible]`
+simp_proj_transparency_issue.lean:5:0-7:16: warning: Definition `f` of class type must be marked with `@[reducible]` or `@[implicit_reducible]`
+simp_proj_transparency_issue.lean:9:2-9:10: warning: instance `g` must be marked with `@[reducible]` or `@[implicit_reducible]`
+simp_proj_transparency_issue.lean:9:0-11:16: warning: Definition `g` of class type must be marked with `@[reducible]` or `@[implicit_reducible]`

--- a/tests/elab/simp_proj_transparency_issue.lean.out.expected
+++ b/tests/elab/simp_proj_transparency_issue.lean.out.expected
@@ -1,2 +1,2 @@
-simp_proj_transparency_issue.lean:5:2-5:10: warning: instance `f` must be marked with `@[reducible]` or `@[implicit_reducible]`
-simp_proj_transparency_issue.lean:9:2-9:10: warning: instance `g` must be marked with `@[reducible]` or `@[implicit_reducible]`
+simp_proj_transparency_issue.lean:6:2-6:10: warning: instance `f` must be marked with `@[reducible]` or `@[implicit_reducible]`
+simp_proj_transparency_issue.lean:11:2-11:10: warning: instance `g` must be marked with `@[reducible]` or `@[implicit_reducible]`

--- a/tests/elab_fail/structSorryBug.lean
+++ b/tests/elab_fail/structSorryBug.lean
@@ -1,4 +1,5 @@
 set_option relaxedAutoImplicit false
+set_option warning.nonClassInstance false in
 instance has_arr : HasArr Preorder := { Arr := Function }
 
 def foo : Nat := { first := 10 }

--- a/tests/elab_fail/structSorryBug.lean
+++ b/tests/elab_fail/structSorryBug.lean
@@ -1,5 +1,4 @@
 set_option relaxedAutoImplicit false
-set_option warning.nonClassInstance false in
 instance has_arr : HasArr Preorder := { Arr := Function }
 
 def foo : Nat := { first := 10 }

--- a/tests/elab_fail/structSorryBug.lean.out.expected
+++ b/tests/elab_fail/structSorryBug.lean.out.expected
@@ -1,5 +1,5 @@
-structSorryBug.lean:3:19-3:25: error(lean.unknownIdentifier): Unknown identifier `HasArr`
+structSorryBug.lean:2:19-2:25: error(lean.unknownIdentifier): Unknown identifier `HasArr`
 
 Note: It is not possible to treat `HasArr` as an implicitly bound variable here because it has multiple characters while the `relaxedAutoImplicit` option is set to `false`.
-structSorryBug.lean:5:17-5:32: error: invalid {...} notation, structure type expected
+structSorryBug.lean:4:17-4:32: error: invalid {...} notation, structure type expected
   Nat

--- a/tests/elab_fail/structSorryBug.lean.out.expected
+++ b/tests/elab_fail/structSorryBug.lean.out.expected
@@ -1,5 +1,5 @@
-structSorryBug.lean:2:19-2:25: error(lean.unknownIdentifier): Unknown identifier `HasArr`
+structSorryBug.lean:3:19-3:25: error(lean.unknownIdentifier): Unknown identifier `HasArr`
 
 Note: It is not possible to treat `HasArr` as an implicitly bound variable here because it has multiple characters while the `relaxedAutoImplicit` option is set to `false`.
-structSorryBug.lean:4:17-4:32: error: invalid {...} notation, structure type expected
+structSorryBug.lean:5:17-5:32: error: invalid {...} notation, structure type expected
   Nat


### PR DESCRIPTION
This PR adds a warning when `addInstance` is called on a declaration whose target type is not a type class. This catches a common mistake where users accidentally write `instance` for a plain structure instead of a `class`, which would silently register a useless instance.

This was previously handled by the `nonClassInstance` linter in Batteries (`Batteries.Tactic.Lint.TypeClass`). Moving the check into `addInstance` itself provides earlier feedback at declaration time rather than requiring a separate linting pass.