### PR TITLE
feat: `Runtime.hold`

### DIFF
--- a/src/Init/System/IO.lean
+++ b/src/Init/System/IO.lean
@@ -1880,3 +1880,12 @@ lead to undefined behavior.
 -/
 @[extern "lean_runtime_forget"]
 def Runtime.forget (a : α) : BaseIO Unit := return
+
+set_option linter.unusedVariables false in
+/--
+Ensures `a` remains alive until the callsite by a holding a reference to `a`. This can be useful
+for unsafe code (such as ab FFI) that relies on a Lean object not being freed until after some point
+in the program. At runtime, this will be a no-op as C will optimize away this call.
+-/
+@[extern "lean_runtime_hold"]
+def Runtime.hold (a : @& α) : BaseIO Unit := return

--- a/src/Init/System/IO.lean
+++ b/src/Init/System/IO.lean
@@ -1883,9 +1883,9 @@ def Runtime.forget (a : α) : BaseIO Unit := return
 
 set_option linter.unusedVariables false in
 /--
-Ensures `a` remains alive until the callsite by holding a reference to `a`. This can be useful
+Ensures `a` remains at least alive until the call site by holding a reference to `a`. This can be useful
 for unsafe code (such as an FFI) that relies on a Lean object not being freed until after some point
-in the program. At runtime, this will be a no-op as C will optimize away this call.
+in the program. At runtime, this will be a no-op as the C compiler will optimize away this call.
 -/
 @[extern "lean_runtime_hold"]
 def Runtime.hold (a : @& α) : BaseIO Unit := return

--- a/src/Init/System/IO.lean
+++ b/src/Init/System/IO.lean
@@ -1883,8 +1883,8 @@ def Runtime.forget (a : α) : BaseIO Unit := return
 
 set_option linter.unusedVariables false in
 /--
-Ensures `a` remains alive until the callsite by a holding a reference to `a`. This can be useful
-for unsafe code (such as ab FFI) that relies on a Lean object not being freed until after some point
+Ensures `a` remains alive until the callsite by holding a reference to `a`. This can be useful
+for unsafe code (such as an FFI) that relies on a Lean object not being freed until after some point
 in the program. At runtime, this will be a no-op as C will optimize away this call.
 -/
 @[extern "lean_runtime_hold"]

--- a/src/include/lean/lean.h
+++ b/src/include/lean/lean.h
@@ -3161,6 +3161,10 @@ static inline lean_obj_res lean_manual_get_root(lean_obj_arg _unit) {
     return lean_mk_string(LEAN_MANUAL_ROOT);
 }
 
+static inline lean_obj_res lean_runtime_hold(b_lean_obj_arg a) {
+    return lean_box(0);
+}
+
 #ifdef LEAN_EMSCRIPTEN
 #define LEAN_SCALAR_PTR_LITERAL(b1, b2, b3, b4, b5, b6, b7, b8) (lean_object*)((uint32_t)b1 | ((uint32_t)b2 << 8) | ((uint32_t)b3 << 16) | ((uint32_t)b4 << 24)), (lean_object*)((uint32_t)b5 | ((uint32_t)b6 << 8) | ((uint32_t)b7 << 16) | ((uint32_t)b8 << 24))
 #else


### PR DESCRIPTION
This PR adds `Runtime.hold`, which ensures its argument remains alive until the callsite by holding a reference to it. This can be useful for unsafe code (such as an FFI) that relies on a Lean object not being freed until after some point in the program. 

It is implemented via a  `static inline` function in `lean.h` so that C will optimize away the call.