### PR TITLE
fix: add missing release() to single-thread unique_lock stub

### DIFF
--- a/src/runtime/thread.h
+++ b/src/runtime/thread.h
@@ -184,6 +184,7 @@ public:
     ~unique_lock() {}
     void lock() {}
     void unlock() {}
+    T* release() { return nullptr; }
 };
 inline unsigned hardware_concurrency() { return 1; }
 }


### PR DESCRIPTION
This PR adds the missing `release()` method to the single-thread `unique_lock<T>` stub in `src/runtime/thread.h`, fixing a compile error when building with `-DMULTI_THREAD=OFF` (required for Emscripten WASM builds).

## Details

The stub `unique_lock<T>` provides `lock()`, `unlock()`, and a destructor, but is missing `release()`. The runtime calls `release()` on `unique_lock` instances, causing a compile error in single-threaded configurations. The fix adds `T* release() { return nullptr; }`, matching `std::unique_lock`'s interface. The single-threaded stub does not hold a real mutex, so returning `nullptr` is the correct behavior.

## Context

Discussed on Zulip: [#lean4 > WASM build fixes: libuv symbol leakage (#6817) and unique_lock](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/WASM.20build.20fixes.3A.20libuv.20symbol.20leakage.20.28.236817.29.20and.20unique_lo/with/580836892)

@hargoniX (Henrik Böving) confirmed he is the relevant person for this component and invited the PR.