### PR TITLE
fix: guard libuv symbols in io.cpp for Emscripten WASM builds (#6817)

### DIFF
--- a/src/runtime/io.cpp
+++ b/src/runtime/io.cpp
@@ -256,7 +256,14 @@ extern "C" LEAN_EXPORT obj_res lean_decode_io_error(int errnum, b_lean_obj_arg f
 }
 
 extern "C" LEAN_EXPORT obj_res lean_decode_uv_error(int errnum, b_lean_obj_arg fname) {
+#if defined(LEAN_EMSCRIPTEN)
+    // uv_strerror is not available in Emscripten WASM builds
+    char buf[64];
+    snprintf(buf, sizeof(buf), "libuv error %d", errnum);
+    object * details = mk_string(buf);
+#else
     object * details = mk_string(uv_strerror(errnum));
+#endif
     // Keep in sync with lean_decode_io_error above
     switch (errnum) {
     case UV_EINTR:
@@ -1240,6 +1247,10 @@ extern "C" LEAN_EXPORT obj_res lean_io_hard_link(b_obj_arg orig, b_obj_arg link)
 
 /* createTempFile : IO (Handle × FilePath) */
 extern "C" LEAN_EXPORT obj_res lean_io_create_tempfile(lean_object * /* w */) {
+#if defined(LEAN_EMSCRIPTEN)
+    return io_result_mk_error(lean_mk_io_error_unsupported_operation(0,
+        mk_string("createTempFile is not supported in Emscripten")));
+#else
     char path[PATH_MAX];
     size_t base_len = PATH_MAX;
     int ret = uv_os_tmpdir(path, &base_len);
@@ -1282,10 +1293,15 @@ extern "C" LEAN_EXPORT obj_res lean_io_create_tempfile(lean_object * /* w */) {
         uv_fs_req_cleanup(&req);
         return lean_io_result_mk_ok(pair.steal());
     }
+#endif
 }
 
 /* createTempDir : IO FilePath */
 extern "C" LEAN_EXPORT obj_res lean_io_create_tempdir(lean_object * /* w */) {
+#if defined(LEAN_EMSCRIPTEN)
+    return io_result_mk_error(lean_mk_io_error_unsupported_operation(0,
+        mk_string("createTempDir is not supported in Emscripten")));
+#else
     char path[PATH_MAX];
     size_t base_len = PATH_MAX;
     int ret = uv_os_tmpdir(path, &base_len);
@@ -1327,6 +1343,7 @@ extern "C" LEAN_EXPORT obj_res lean_io_create_tempdir(lean_object * /* w */) {
         uv_fs_req_cleanup(&req);
         return res;
     }
+#endif
 }
 
 extern "C" LEAN_EXPORT obj_res lean_io_remove_file(b_obj_arg filename) {


### PR DESCRIPTION
This PR guards libuv symbols in `src/runtime/io.cpp` behind `#if defined(LEAN_EMSCRIPTEN)` to fix unresolved references to `uv_strerror`, `uv_os_tmpdir`, `uv_fs_mkstemp`, and `uv_fs_mkdtemp` in the `linux_wasm32` `libleanrt.a` release artifact (issue #6817).

## Details

Adds `#if defined(LEAN_EMSCRIPTEN)` guards following the same pattern already used in `src/runtime/uv/dns.cpp` (PR #9258):

- **`lean_decode_uv_error`**: provides a numeric fallback error string (`"libuv error %d"`) instead of calling `uv_strerror`. The rest of the function (error classification via `UV_*` constants from `uv.h`) is unchanged and works without linking libuv.
- **`lean_io_create_tempfile`**: returns an unsupported operation error in Emscripten (no filesystem temp directory in browser WASM).
- **`lean_io_create_tempdir`**: same treatment as `createTempFile`.

## How I know it works

I've been using an equivalent patch in a production project that builds a Lean module to WASM via Emscripten since v4.27.0. The fix eliminates the 4 unresolved symbols without affecting any other code paths.

## Context

Discussed on Zulip: [#lean4 > WASM build fixes: libuv symbol leakage (#6817) and unique_lock](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/WASM.20build.20fixes.3A.20libuv.20symbol.20leakage.20.28.236817.29.20and.20unique_lo/with/580836892)

Closes #6817