### PR TITLE
feat: add `try? => tac` syntax and parallel cancellation test

### DIFF
--- a/src/Init/Try.lean
+++ b/src/Init/Try.lean
@@ -52,6 +52,20 @@ namespace Lean.Parser.Tactic
 
 syntax (name := tryTrace) "try?" optConfig : tactic
 
+/--
+`try? => tac` runs `tac` through `try?`'s suggestion engine (`evalSuggest`) without the
+automatic tactic generation phase. This is useful for testing `evalSuggest` directly with
+explicit tactic scripts using `try?`'s internal combinators (`attempt_all`, `attempt_all_par`,
+`first_par`, etc.).
+
+Example:
+```
+example : 1 = 1 := by
+  try? => first | rfl | simp
+```
+-/
+syntax (name := tryTraceWith) "try?" optConfig " => " tacticSeq : tactic
+
 /-- Helper internal tactic for implementing the tactic `try?`. -/
 syntax (name := attemptAll) "attempt_all " withPosition((ppDedent(ppLine) colGe "| " tacticSeq)+) : tactic
 

--- a/src/Init/Try.lean
+++ b/src/Init/Try.lean
@@ -52,18 +52,6 @@ namespace Lean.Parser.Tactic
 
 syntax (name := tryTrace) "try?" optConfig : tactic
 
-/--
-`try? => tac` runs `tac` through `try?`'s suggestion engine (`evalSuggest`) without the
-automatic tactic generation phase. This is useful for testing `evalSuggest` directly with
-explicit tactic scripts using `try?`'s internal combinators (`attempt_all`, `attempt_all_par`,
-`first_par`, etc.).
-
-Example:
-```
-example : 1 = 1 := by
-  try? => first | rfl | simp
-```
--/
 @[tactic_alt tryTrace]
 syntax (name := tryTraceWith) "try?" optConfig " => " tacticSeq : tactic
 

--- a/src/Init/Try.lean
+++ b/src/Init/Try.lean
@@ -64,6 +64,7 @@ example : 1 = 1 := by
   try? => first | rfl | simp
 ```
 -/
+@[tactic_alt tryTrace]
 syntax (name := tryTraceWith) "try?" optConfig " => " tacticSeq : tactic
 
 /-- Helper internal tactic for implementing the tactic `try?`. -/

--- a/src/Lean/Elab/Tactic/Try.lean
+++ b/src/Lean/Elab/Tactic/Try.lean
@@ -1042,4 +1042,17 @@ private def evalAndSuggestWithBy (tk : Syntax) (tac : TSyntax `tactic) (original
         evalAndSuggest tk stx originalMaxHeartbeats config
   | _ => throwUnsupportedSyntax
 
+@[builtin_tactic Lean.Parser.Tactic.tryTraceWith] def evalTryTraceWith : Tactic := fun stx => do
+  match stx with
+  | `(tactic| try?%$tk $config:optConfig => $tac:tacticSeq) => Tactic.focus do withMainContext do
+    let config ← elabTryConfig config
+    let originalMaxHeartbeats ← getMaxHeartbeats
+    let tac ← `(tactic| ($tac:tacticSeq))
+    withUnlimitedHeartbeats do
+      if config.wrapWithBy then
+        evalAndSuggestWithBy tk tac originalMaxHeartbeats config
+      else
+        evalAndSuggest tk tac originalMaxHeartbeats config
+  | _ => throwUnsupportedSyntax
+
 end Lean.Elab.Tactic.Try

--- a/src/Lean/Server/Test/Cancel.lean
+++ b/src/Lean/Server/Test/Cancel.lean
@@ -184,6 +184,44 @@ elab_rules : tactic
   dbg_trace "blocked!"
   log "blocked"
 
+/-! ## Helpers for end-to-end testing of parallel subtask cancellation -/
+
+meta initialize checkCancelRefs : IO.Ref (Std.HashMap String (Task Unit × IO.CancelToken)) ← IO.mkRef {}
+
+/--
+Tests whether the cancel token is properly set on re-elaboration. On first invocation with a
+given label, loops checking `Core.checkSystem` and waiting for a signal from the second
+invocation. If the loop completes without interruption (i.e. the cancel token was not propagated),
+prints `"{label}: leaked!"` to stderr. Second invocation signals the first and waits for it to
+complete (so the server doesn't exit prematurely).
+-/
+scoped syntax "check_cancel" ident : tactic
+elab_rules : tactic
+| `(tactic| check_cancel $id) => do
+  let label := id.getId.toString (escape := false)
+  let prom ← IO.Promise.new
+  let signal ← IO.CancelToken.new
+  let prior ← checkCancelRefs.modifyGet fun m =>
+    match m.get? label with
+    | some entry => (some entry, m)
+    | none       => (none, m.insert label (prom.result!, signal))
+  if let some (t, sig) := prior then
+    sig.set
+    IO.wait t
+    return
+  IO.eprintln s!"{label}: started!"
+  try
+    while true do
+      Core.checkSystem "check_cancel"
+      if (← signal.isSet) then break
+      IO.sleep 10
+    let ctx ← readThe Core.Context
+    let some cancelTk := ctx.cancelTk? | unreachable!
+    if !(← cancelTk.isSet) then
+      IO.eprintln s!"{label}: leaked!"
+  finally
+    prom.resolve ()
+
 meta initialize cmdOnceRef : IO.Ref (Option (Task Unit)) ← IO.mkRef none
 
 /--

--- a/src/Lean/Server/Test/Cancel.lean
+++ b/src/Lean/Server/Test/Cancel.lean
@@ -209,7 +209,6 @@ elab_rules : tactic
     sig.set
     IO.wait t
     return
-  IO.eprintln s!"{label}: started!"
   try
     while true do
       Core.checkSystem "check_cancel"

--- a/tests/elab/try_eval_suggest.lean
+++ b/tests/elab/try_eval_suggest.lean
@@ -1,0 +1,51 @@
+/-!
+# Tests for `try? => tac` syntax
+
+These tests verify that the `try? => tac` syntax correctly runs a user-supplied tactic
+through `evalSuggest` and reports suggestions.
+-/
+
+/-- info: Try this:
+  [apply] rfl -/
+#guard_msgs (info) in
+example : 1 = 1 := by
+  try? => rfl
+
+/-- info: Try this:
+  [apply] rfl -/
+#guard_msgs (info) in
+example : 1 = 1 := by
+  try? => first | assumption | rfl
+
+/-- info: Try these:
+  [apply] rfl
+  [apply] simp_all -/
+#guard_msgs (info) in
+example : 1 = 1 := by
+  try? => attempt_all | rfl | simp_all
+
+/-- info: Try these:
+  [apply] rfl
+  [apply] simp_all -/
+#guard_msgs (info) in
+example : 1 = 1 := by
+  try? => attempt_all_par | rfl | simp_all
+
+-- first_par returns whichever finishes first; just test it doesn't error
+#guard_msgs (drop info) in
+example : 1 = 1 := by
+  try? => first_par | rfl | simp_all
+
+/-- info: Try these:
+  [apply] assumption
+  [apply] rfl -/
+#guard_msgs (info) in
+example (h : 1 = 1) : 1 = 1 := by
+  try? => attempt_all | assumption | rfl
+
+-- `max` config option should limit suggestions
+/-- info: Try this:
+  [apply] rfl -/
+#guard_msgs (info) in
+example : 1 = 1 := by
+  try? (max := 1) => attempt_all | rfl | simp_all

--- a/tests/server_interactive/cancellation_par.lean
+++ b/tests/server_interactive/cancellation_par.lean
@@ -1,0 +1,67 @@
+import Lean.Server.Test.Cancel
+open Lean.Server.Test.Cancel
+
+/-!
+Test contrasting cancellation behavior between sequential and parallel combinators.
+
+Each section uses `check_cancel <label>`: on first invocation it loops checking
+`Core.checkInterrupted`, waiting for the second invocation (triggered by re-elaboration) to
+signal it. If the cancel token was properly set, `checkInterrupted` fires first and the tactic
+is interrupted. Otherwise the signal arrives, the tactic finds `cancelTk` unset, and prints
+`"{label}: leaked!"`.
+
+**Sequential `first`** (section 1): runs on the main elaboration thread, sharing the command's
+cancel token. On re-elaboration, `checkInterrupted` fires — no leak.
+
+**Parallel `attempt_all_par`** (section 2): runs in a subtask via `asTask` with its own fresh
+cancel token. Nobody sets that token on re-elaboration — **leak**.
+
+**Parallel `first_par`** (section 3): same bug as `attempt_all_par`.
+-/
+
+/-! ## Sequential `first`: cancellation works -/
+
+example : True := by
+  trivial
+       --^ waitFor: blocked
+       --^ insert: "; skip"
+       --^ sync
+
+theorem t : True := by
+  wait_for_cancel_once_async
+  try? => first
+    | check_cancel first
+
+-- RESET
+import Lean.Server.Test.Cancel
+open Lean.Server.Test.Cancel
+
+/-! ## Parallel `attempt_all_par`: cancellation is broken -/
+
+example : True := by
+  trivial
+       --^ waitFor: blocked
+       --^ insert: "; skip"
+       --^ sync
+
+theorem t : True := by
+  wait_for_cancel_once_async
+  try? => attempt_all_par
+    | check_cancel attempt_all_par
+
+-- RESET
+import Lean.Server.Test.Cancel
+open Lean.Server.Test.Cancel
+
+/-! ## Parallel `first_par`: cancellation is broken -/
+
+example : True := by
+  trivial
+       --^ waitFor: blocked
+       --^ insert: "; skip"
+       --^ sync
+
+theorem t : True := by
+  wait_for_cancel_once_async
+  try? => first_par
+    | check_cancel first_par

--- a/tests/server_interactive/cancellation_par.lean.out.expected
+++ b/tests/server_interactive/cancellation_par.lean.out.expected
@@ -1,0 +1,11 @@
+blocked!
+first: started!
+cancelled!
+blocked!
+attempt_all_par: started!
+cancelled!
+attempt_all_par: leaked!
+blocked!
+first_par: started!
+cancelled!
+first_par: leaked!

--- a/tests/server_interactive/cancellation_par.lean.out.expected
+++ b/tests/server_interactive/cancellation_par.lean.out.expected
@@ -1,11 +1,8 @@
 blocked!
-first: started!
 cancelled!
 blocked!
-attempt_all_par: started!
 cancelled!
 attempt_all_par: leaked!
 blocked!
-first_par: started!
 cancelled!
 first_par: leaked!


### PR DESCRIPTION
This PR adds a `try? => tac` syntax that runs `evalSuggest` directly on a given tactic, useful for testing the `try?` machinery in isolation. It also adds a server_interactive test (`cancellation_par.lean`) that demonstrates a cancellation bug with parallel tactic combinators.

The test contrasts three combinators:
- **`first`** (sequential): cancellation works correctly — the tactic runs on the main elaboration thread and shares its cancel token.
- **`attempt_all_par`** (parallel): cancellation is broken — the subtask spawned via `asTask` gets a fresh cancel token that is never set on re-elaboration.
- **`first_par`** (parallel): same bug as `attempt_all_par`.

The test uses a `check_cancel <label>` helper tactic that detects leaked cancel tokens without any timing dependency: the second invocation (from re-elaboration) signals the first, which then checks whether its cancel token was set.

Related issue: #13300