### PR TITLE
fix: make delta-derived instances respect enclosing meta sections

### DIFF
--- a/src/Lean/AddDecl.lean
+++ b/src/Lean/AddDecl.lean
@@ -9,6 +9,7 @@ prelude
 public import Lean.Meta.Sorry
 public import Lean.Util.CollectAxioms
 public import Lean.OriginalConstKind
+public import Lean.Compiler.MetaAttr
 import all Lean.OriginalConstKind  -- for accessing `privateConstKindsExt`
 
 public section
@@ -208,8 +209,12 @@ where
       catch _ => pure ()
 
 
-def addAndCompile (decl : Declaration) (logCompileErrors : Bool := true) : CoreM Unit := do
+def addAndCompile (decl : Declaration) (logCompileErrors : Bool := true)
+    (markMeta : Bool := false) : CoreM Unit := do
   addDecl decl
+  if markMeta then
+    for n in decl.getNames do
+      modifyEnv (Lean.markMeta · n)
   compileDecl decl (logErrors := logCompileErrors)
 
 end Lean

--- a/src/Lean/AddDecl.lean
+++ b/src/Lean/AddDecl.lean
@@ -9,7 +9,7 @@ prelude
 public import Lean.Meta.Sorry
 public import Lean.Util.CollectAxioms
 public import Lean.OriginalConstKind
-public import Lean.Compiler.MetaAttr
+import Lean.Compiler.MetaAttr
 import all Lean.OriginalConstKind  -- for accessing `privateConstKindsExt`
 
 public section

--- a/src/Lean/Elab/Deriving/Basic.lean
+++ b/src/Lean/Elab/Deriving/Basic.lean
@@ -220,7 +220,7 @@ def processDefDeriving (view : DerivingClassView) (decl : Expr) (isNoncomputable
             instName ← liftMacroM <| mkUnusedBaseName instName
             if isPrivateName declName then
               instName := mkPrivateName env instName
-            let isMeta := (← read).declName?.any (isMarkedMeta (← getEnv))
+            let isMeta := (← read).isMetaSection || isMarkedMeta (← getEnv) declName
             let inst ← if backward.inferInstanceAs.wrap.get (← getOptions) then
               withDeclNameForAuxNaming instName <| withNewMCtxDepth <|
                 wrapInstance result.instVal result.instType
@@ -255,11 +255,14 @@ def processDefDeriving (view : DerivingClassView) (decl : Expr) (isNoncomputable
             logInfoAt cmdRef m!"Try this: {newText}"
         throwError "failed to derive instance because it depends on \
           `{.ofConstName noncompRef}`, which is noncomputable"
+    let isMeta := (← read).isMetaSection || isMarkedMeta (← getEnv) declName
     if isNoncomputable || (← read).isNoncomputableSection then
       addDecl <| Declaration.defnDecl decl
+      if isMeta then
+        modifyEnv (markMeta · instName)
       modifyEnv (addNoncomputable · instName)
     else
-      addAndCompile <| Declaration.defnDecl decl
+      addAndCompile (Declaration.defnDecl decl) (markMeta := isMeta)
   trace[Elab.Deriving] "Derived instance `{.ofConstName instName}`"
   -- For Prop-typed instances (theorems), skip `implicit_reducible` since reducibility hints are
   -- irrelevant for theorems. This matches the behavior of the handwritten `instance` command

--- a/src/Lean/Elab/Deriving/Basic.lean
+++ b/src/Lean/Elab/Deriving/Basic.lean
@@ -258,8 +258,6 @@ def processDefDeriving (view : DerivingClassView) (decl : Expr) (isNoncomputable
     let isMeta := (← read).isMetaSection || isMarkedMeta (← getEnv) declName
     if isNoncomputable || (← read).isNoncomputableSection then
       addDecl <| Declaration.defnDecl decl
-      if isMeta then
-        modifyEnv (markMeta · instName)
       modifyEnv (addNoncomputable · instName)
     else
       addAndCompile (Declaration.defnDecl decl) (markMeta := isMeta)

--- a/src/Lean/ParserCompiler.lean
+++ b/src/Lean/ParserCompiler.lean
@@ -110,9 +110,7 @@ partial def compileParserExpr (e : Expr) : MetaM Expr := do
         }
         -- usually `meta` is inferred during compilation for auxiliary definitions, but as
         -- `ctx.combinatorAttr` may enforce correct use of the modifier, infer now.
-        if isMarkedMeta (← getEnv) c then
-          modifyEnv (markMeta · c')
-        addAndCompile decl
+        addAndCompile decl (markMeta := isMarkedMeta (← getEnv) c)
         modifyEnv (ctx.combinatorAttr.setDeclFor · c c')
         if cinfo.type.isConst then
           if let some kind ← parserNodeKind? cinfo.value! then

--- a/tests/elab/13313.lean
+++ b/tests/elab/13313.lean
@@ -1,0 +1,34 @@
+module
+
+-- Test that `deriving` inside a `public meta section` produces meta instances
+
+public meta section
+
+-- Delta deriving for definitions
+@[expose] def Foo := Nat
+deriving BEq
+
+-- Meta definitions should be able to use the derived instance
+def test (a b : Foo) : Bool := a == b
+
+-- Standalone deriving instance for definitions
+@[expose] def Bar := Nat
+deriving instance Hashable for Bar
+
+def testBar (a : Bar) : UInt64 := hash a
+
+-- Handler-based deriving for inductives
+inductive Baz where
+  | a | b
+deriving BEq, Repr, Hashable
+
+def testBaz (x y : Baz) : Bool := x == y
+
+-- DecidableEq for meta enums
+inductive Qux where
+  | x | y | z
+deriving DecidableEq
+
+def testDecEq (a b : Qux) : Bool := a == b
+
+end

--- a/tests/elab/13313.lean
+++ b/tests/elab/13313.lean
@@ -32,3 +32,14 @@ deriving DecidableEq
 def testDecEq (a b : Qux) : Bool := a == b
 
 end
+
+-- Outside any `meta section`: explicit `meta def` should also produce meta delta-derived instances.
+-- This exercises the `isMarkedMeta (← getEnv) declName` branch in `processDefDeriving`.
+public section
+
+@[expose] meta def Quux := Nat
+deriving BEq
+
+meta def testQuux (a b : Quux) : Bool := a == b
+
+end


### PR DESCRIPTION
This PR fixes `processDefDeriving` to propagate the `meta` attribute to instances derived via delta deriving, so that `deriving BEq` inside a `public meta section` produces a meta instance. Previously the derived `instBEqFoo` was not marked meta, and the LCNF visibility checker rejected meta definitions that used `==` on the alias — this came up while bumping verso to v4.30.0-rc1.

`processDefDeriving` now computes `isMeta` from two sources:
1. `(← read).isMetaSection` — true inside a `public meta section`, covering the original issue #13313.
2. `isMarkedMeta (← getEnv) declName` — true when the type being derived for was individually marked `meta` (e.g. `meta def Foo := Nat`), via `elabMutualDef` in `src/Lean/Elab/MutualDef.lean`.

This value is passed to `wrapInstance` for aux declarations and to the new `addAndCompile (markMeta := ...)` parameter from #13311, matching how the regular command elaboration pipeline handles meta definitions.

Existing regression tests `tests/elab/13043.lean` and `tests/elab/12897.lean` already cover meta-section + `wrapInstance` aux def interaction. The new `tests/elab/13313.lean` specifically covers the delta-derived `BEq` + LCNF-use case (the original issue) and an explicit `meta def ... deriving BEq` outside a meta section (motivating the second disjunct).

- [ ] depends on: #13311

Closes #13313

🤖 Prepared with Claude Code