### PR TITLE
fix: add term info for `for` loop in new do elaborator

### DIFF
--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -166,6 +166,9 @@ open Lean.Meta
         mkPureApp newDoBlockResultType done
       }
     enterLoopBody breakCont continueCont returnCont do
+    Term.addTermInfo' (isBinder := true) x xh[0]!
+    if let some h := h? then
+      Term.addTermInfo' (isBinder := true) h xh[1]!
     -- Elaborate the loop body, which must have result type `PUnit`, just like the whole `for` loop.
     elabDoSeq body { dec with k := continueCont, kind := .duplicable }
 

--- a/tests/elab_fail/doNotation1.lean
+++ b/tests/elab_fail/doNotation1.lean
@@ -2,82 +2,89 @@ set_option backward.do.legacy false
 --
 
 def f1 (x : Nat) : IO Nat := do
-y := 1  -- error 'y' cannot be reassigned
+  y := 1  -- error 'y' cannot be reassigned
 
 def f2 (xs : List (Nat × Nat)) : Unit := Id.run <| do
-for (x, y) in xs do
-  (y, x) := (x, y) -- error 'y' (and 'x') cannot be reassigned
+  for (x, y) in xs do
+    (y, x) := (x, y) -- error 'y' (and 'x') cannot be reassigned
 
 def f3 (xs : List (Nat × Nat)) : Unit := Id.run <| do
-for p in xs do
-  p := (p.2, p.1) -- works. `forInMap` requires a variable
+  for p in xs do
+    p := (p.2, p.1) -- works. `forInMap` requires a variable
 
 inductive Vector' (α : Type) : Nat → Type
-| nil  : Vector' α 0
-| cons : α → {n : Nat} → Vector' α n → Vector' α (n+1)
+  | nil  : Vector' α 0
+  | cons : α → {n : Nat} → Vector' α n → Vector' α (n+1)
+
 def f4 (b : Bool) (n : Nat) (v : Vector' Nat n) : Vector' Nat (n+1) := Id.run <| do
-let mut v := v
-if b then
-  v := Vector'.cons 1 v
-Vector'.cons 1 v
+  let mut v := v
+  if b then
+    v := Vector'.cons 1 v
+  Vector'.cons 1 v
+
 def f5 (y : Nat) (xs : List Nat) : List Bool := Id.run <| do
-let mut y := y
-for x in xs do
-  y := true -- invalid reassigned
-return []
+  let mut y := y
+  for x in xs do
+    y := true -- invalid reassigned
+  return []
 
 def f6 (xs : List Nat) : IO (List Nat) := do
-for x in xs do -- type error
-  IO.println x
-return []
+  for x in xs do -- type error
+    IO.println x
+  return []
 
 def f7 (xs : List Nat) : IO Unit := do
-unless xs.isEmpty do
-  break -- error must be inside 'for'
+  unless xs.isEmpty do
+    break -- error must be inside 'for'
 
 def f8 (xs : List Nat) : IO Unit := do
-unless xs.isEmpty do
-  continue -- error must be inside 'for'
+  unless xs.isEmpty do
+    continue -- error must be inside 'for'
 
 def f9 (xs : List Nat) : IO (List Nat) := do
-return xs
-return xs -- warn unreachable
+  return xs
+  return xs -- warn unreachable
 
 def f10 (x : Nat) : IO Unit := do
-IO.println x
+  IO.println x
 
 #print f10 -- we do not generate an unnecessary bind
 
 def f11 (x : Nat) : IO Unit := do
-if x > 0 then
-  IO.println "x is not zero"
-IO.mkRef true -- error here as expected
+  if x > 0 then
+    IO.println "x is not zero"
+  IO.mkRef true -- error here as expected
+
 def f12 (x : Nat) : IO Bool := do
-let mut x := x
-if x > 0 then
-  pure true -- error here; the expected type is `IO Unit` because the `if` is non-terminal
-else
-  x := x + 1
-  IO.println "hello"
-if x > 0 then
-  pure true
-else
-  x := x + 1
-  IO.println "hello" -- error here; the expected type is `IO Bool`
+  let mut x := x
+  if x > 0 then
+    pure true -- error here; the expected type is `IO Unit` because the `if` is non-terminal
+  else
+    x := x + 1
+    IO.println "hello"
+  if x > 0 then
+    pure true
+  else
+    x := x + 1
+    IO.println "hello" -- error here; the expected type is `IO Bool`
 
 def f13 (xs : List Nat) : IO Bool := do
-if xs == [] then
-  return true
-else
+  if xs == [] then
+    return true
+  else
+    return false
+  IO.println "hello" -- warn unreachable
   return false
-IO.println "hello" -- warn unreachable
-return false
 
 def f14 (x : Nat) : IO Nat := do
-let y ← if x == 0 then return 100 else return 200
-IO.println ("y: " ++ toString y) -- warn unreachable
-return 0
+  let y ← if x == 0 then return 100 else return 200
+  IO.println ("y: " ++ toString y) -- warn unreachable
+  return 0
 
 example (xs : List (Nat × Nat)) : List (Nat × Nat) := Id.run <| do
-for _ in xs do -- error, `for` result type is PUnit but expected type is List (Nat × Nat)
-  pure ()
+  for _ in xs do -- error, `for` result type is PUnit but expected type is List (Nat × Nat)
+    pure ()
+
+def f15 (n : Nat) : IO Unit := do
+  for h : i in *...n do -- unused variable warning: we have term info
+    pure ()

--- a/tests/elab_fail/doNotation1.lean
+++ b/tests/elab_fail/doNotation1.lean
@@ -85,6 +85,7 @@ example (xs : List (Nat × Nat)) : List (Nat × Nat) := Id.run <| do
   for _ in xs do -- error, `for` result type is PUnit but expected type is List (Nat × Nat)
     pure ()
 
+set_option linter.unusedVariables true
 def f15 (n : Nat) : IO Unit := do
   for h : i in *...n do -- unused variable warning: we have term info
     pure ()

--- a/tests/elab_fail/doNotation1.lean.out.expected
+++ b/tests/elab_fail/doNotation1.lean.out.expected
@@ -64,3 +64,9 @@ has type
   PUnit
 but is expected to have type
   List (Nat × Nat)
+doNotation1.lean:90:6-90:7: warning: unused variable `h`
+
+Note: This linter can be disabled with `set_option linter.unusedVariables false`
+doNotation1.lean:90:10-90:11: warning: unused variable `i`
+
+Note: This linter can be disabled with `set_option linter.unusedVariables false`

--- a/tests/elab_fail/doNotation1.lean.out.expected
+++ b/tests/elab_fail/doNotation1.lean.out.expected
@@ -1,33 +1,33 @@
-doNotation1.lean:5:0-5:1: error: Variable `y` cannot be mutated. Only variables declared using `let mut` can be mutated.
+doNotation1.lean:5:2-5:3: error: Variable `y` cannot be mutated. Only variables declared using `let mut` can be mutated.
       If you did not intend to mutate but define `y`, consider using `let y` instead
-doNotation1.lean:9:3-9:4: error: Variable `y` cannot be mutated. Only variables declared using `let mut` can be mutated.
+doNotation1.lean:9:5-9:6: error: Variable `y` cannot be mutated. Only variables declared using `let mut` can be mutated.
       If you did not intend to mutate but define `y`, consider using `let y` instead
-doNotation1.lean:13:2-13:3: error: Variable `p` cannot be mutated. Only variables declared using `let mut` can be mutated.
+doNotation1.lean:13:4-13:5: error: Variable `p` cannot be mutated. Only variables declared using `let mut` can be mutated.
       If you did not intend to mutate but define `p`, consider using `let p` instead
-doNotation1.lean:21:7-21:23: error: Type mismatch
+doNotation1.lean:22:9-22:25: error: Type mismatch
   Vector'.cons 1 v
 has type
   Vector' Nat (n + 1)
 but is expected to have type
   Vector' Nat n
-doNotation1.lean:26:7-26:11: error: Type mismatch
+doNotation1.lean:28:9-28:13: error: Type mismatch
   true
 has type
   Bool
 but is expected to have type
   Nat
-doNotation1.lean:36:2-36:7: error: `break` must be nested inside a loop
-doNotation1.lean:40:2-40:10: error: `continue` must be nested inside a loop
-doNotation1.lean:44:0-44:9: warning: This `do` element and its control-flow region are dead code. Consider removing it.
+doNotation1.lean:38:4-38:9: error: `break` must be nested inside a loop
+doNotation1.lean:42:4-42:12: error: `continue` must be nested inside a loop
+doNotation1.lean:46:2-46:11: warning: This `do` element and its control-flow region are dead code. Consider removing it.
 def f10 : Nat → IO Unit :=
 fun x => IO.println x
-doNotation1.lean:54:0-54:13: error: Type mismatch
+doNotation1.lean:56:2-56:15: error: Type mismatch
   IO.mkRef true
 has type
   BaseIO (IO.Ref Bool)
 but is expected to have type
   IO Unit
-doNotation1.lean:58:7-58:11: error: Application type mismatch: The argument
+doNotation1.lean:61:9-61:13: error: Application type mismatch: The argument
   true
 has type
   Bool
@@ -35,22 +35,22 @@ but is expected to have type
   Unit
 in the application
   pure true
-doNotation1.lean:66:2-66:20: error: Type mismatch
+doNotation1.lean:69:4-69:22: error: Type mismatch
   IO.println "hello"
 has type
   IO Unit
 but is expected to have type
   IO Bool
-doNotation1.lean:73:0-73:18: warning: This `do` element and its control-flow region are dead code. Consider refactoring your code to remove it.
-doNotation1.lean:78:0-78:32: warning: This `do` element and its control-flow region are dead code. Consider refactoring your code to remove it.
-doNotation1.lean:78:21-78:31: error: typeclass instance problem is stuck
+doNotation1.lean:76:2-76:20: warning: This `do` element and its control-flow region are dead code. Consider refactoring your code to remove it.
+doNotation1.lean:81:2-81:34: warning: This `do` element and its control-flow region are dead code. Consider refactoring your code to remove it.
+doNotation1.lean:81:23-81:33: error: typeclass instance problem is stuck
   ToString ?m
 
 Note: Lean will not try to resolve this typeclass instance problem because the type argument to `ToString` is a metavariable. This argument must be fully determined before Lean will try to resolve the typeclass.
 
 Hint: Adding type annotations and supplying implicit arguments to functions can give Lean more information for typeclass resolution. For example, if you have a variable `x` that you intend to be a `Nat`, but Lean reports it as having an unresolved type like `?m`, replacing `x` with `(x : Nat)` can get typeclass resolution un-stuck.
-doNotation1.lean:82:0-83:9: error: Type mismatch. `for` loops have result type PUnit, but the rest of the `do` sequence expected List (Nat × Nat).
-doNotation1.lean:83:7-83:9: error: Application type mismatch: The argument
+doNotation1.lean:85:2-86:11: error: Type mismatch. `for` loops have result type PUnit, but the rest of the `do` sequence expected List (Nat × Nat).
+doNotation1.lean:86:9-86:11: error: Application type mismatch: The argument
   ()
 has type
   Unit
@@ -58,7 +58,7 @@ but is expected to have type
   List (Nat × Nat)
 in the application
   pure ()
-doNotation1.lean:82:0-83:9: error: Type mismatch
+doNotation1.lean:85:2-86:11: error: Type mismatch
   PUnit.unit
 has type
   PUnit


### PR DESCRIPTION
This PR adds term information for the binders in the new do `for` elaborator.

Closes #12827
