### PR TITLE
fix: tactic completion in empty `by` blocks

### DIFF
--- a/src/Lean/Server/Completion/SyntheticCompletion.lean
+++ b/src/Lean/Server/Completion/SyntheticCompletion.lean
@@ -117,12 +117,13 @@ private partial def isSyntheticTacticCompletion
     (cmdStx   : Syntax)
     : Bool := Id.run do
   let hoverFilePos := fileMap.toPosition hoverPos
-  go hoverFilePos cmdStx 0
+  go hoverFilePos cmdStx 0 none
 where
   go
-      (hoverFilePos : Position)
-      (stx : Syntax)
-      (leadingWs : Nat)
+      (hoverFilePos         : Position)
+      (stx                  : Syntax)
+      (leadingWs            : Nat)
+      (leadingTokenTailPos? : Option String.Pos.Raw)
       : Bool := Id.run do
     match stx.getPos?, stx.getTailPos? with
     | some startPos, some endPos =>
@@ -132,8 +133,9 @@ where
       if ! isCursorInCompletionRange then
         return false
       let mut wsBeforeArg := leadingWs
+      let mut lastArgTailPos? := leadingTokenTailPos?
       for arg in stx.getArgs do
-        if go hoverFilePos arg wsBeforeArg then
+        if go hoverFilePos arg wsBeforeArg lastArgTailPos? then
           return true
         -- We must account for the whitespace before an argument because the syntax nodes we use
         -- to identify tactic blocks only start *after* the whitespace following a `by`, and we
@@ -141,7 +143,12 @@ where
         -- This method of computing whitespace assumes that there are no syntax nodes without tokens
         -- after `by` and before the first proper tactic syntax.
         wsBeforeArg := arg.getTrailingSize
-      return isCompletionInEmptyTacticBlock stx
+        -- Track the tail position of the most recent preceding sibling that has a position so
+        -- that empty tactic blocks (which lack positions) can locate their opening token (e.g.
+        -- the `by` keyword) for indentation checking. The tail position lets us distinguish
+        -- cursors before and after the opener on the opener's line.
+        lastArgTailPos? := arg.getTailPos? <|> lastArgTailPos?
+      return isCompletionInEmptyTacticBlock stx lastArgTailPos?
         || isCompletionAfterSemicolon stx
         || isCompletionOnTacticBlockIndentation hoverFilePos stx
     | _, _ =>
@@ -150,7 +157,7 @@ where
       -- tactic blocks always occur within other syntax with ranges that let us narrow down the
       -- search to the degree that we can be sure that the cursor is indeed in this empty tactic
       -- block.
-      return isCompletionInEmptyTacticBlock stx
+      return isCompletionInEmptyTacticBlock stx leadingTokenTailPos?
 
   isCompletionOnTacticBlockIndentation
       (hoverFilePos : Position)
@@ -190,8 +197,47 @@ where
     else
       none
 
-  isCompletionInEmptyTacticBlock (stx : Syntax) : Bool :=
-    isCursorInProperWhitespace fileMap hoverPos && isEmptyTacticBlock stx
+  isCompletionInEmptyTacticBlock (stx : Syntax) (leadingTokenTailPos? : Option String.Pos.Raw) : Bool := Id.run do
+    if ! isCursorInProperWhitespace fileMap hoverPos then
+      return false
+    if ! isEmptyTacticBlock stx then
+      return false
+    -- Bracketed tactic blocks `{ ... }` are delimited by the braces themselves, so tactics
+    -- inserted in an empty bracketed block can appear at any column between the braces
+    -- (`withoutPosition` disables indentation constraints inside `tacticSeqBracketed`).
+    if stx.getKind == ``Parser.Tactic.tacticSeqBracketed then
+      let some openEndPos := stx[0].getTailPos?
+        | return false
+      let some closeStartPos := stx[2].getPos?
+        | return false
+      return openEndPos.byteIdx <= hoverPos.byteIdx && hoverPos.byteIdx <= closeStartPos.byteIdx
+    return isAtExpectedTacticIndentation leadingTokenTailPos?
+
+  -- After an empty tactic opener like `by`, tactics on a subsequent line must be inserted at an
+  -- increased indentation level (two spaces past the indentation of the line containing the
+  -- opener token). We mirror that here so that tactic completions are not offered in positions
+  -- where a tactic could not actually be inserted. On the same line as the opener, completions
+  -- are allowed only in the trailing whitespace past the opener — cursors earlier on the line
+  -- belong to the surrounding term, not to the tactic block.
+  isAtExpectedTacticIndentation (leadingTokenTailPos? : Option String.Pos.Raw) : Bool := Id.run do
+    let some tokenTailPos := leadingTokenTailPos?
+      | return true
+    let hoverFilePos := fileMap.toPosition hoverPos
+    let tokenTailFilePos := fileMap.toPosition tokenTailPos
+    if hoverFilePos.line == tokenTailFilePos.line then
+      return hoverPos.byteIdx >= tokenTailPos.byteIdx
+    let expectedColumn := countLeadingSpaces (fileMap.lineStart tokenTailFilePos.line) + 2
+    return hoverFilePos.column == expectedColumn
+
+  countLeadingSpaces (pos : String.Pos.Raw) : Nat := Id.run do
+    let mut p := pos
+    let mut n : Nat := 0
+    while ! p.atEnd fileMap.source do
+      if p.get fileMap.source != ' ' then
+        break
+      p := p.next fileMap.source
+      n := n + 1
+    return n
 
   isEmptyTacticBlock (stx : Syntax) : Bool :=
     stx.getKind == ``Parser.Tactic.tacticSeq && isEmpty stx

--- a/tests/server_interactive/completionEmptyBy.lean
+++ b/tests/server_interactive/completionEmptyBy.lean
@@ -28,6 +28,26 @@ example : True := id <|
   have : True := by
                  --^ completion
 
+-- ===== Cursor before `by` on the same line (no completions expected) =====
+
+-- Only the trailing whitespace past an opener token (here `by`) should offer completions. A
+-- cursor in whitespace that precedes the opener on the same line must not — that whitespace is
+-- part of the surrounding term, not the tactic block.
+
+-- column 18 between `:=` and `by` (cursor is before `by` on the same line)
+example : True :=      by
+                --^ completion
+
+-- column 4 in leading indent of a line whose only token is `by`
+example : True :=
+     by
+  --^ completion
+
+-- column 18 before nested `by`, on the same line as `by`
+example : True := id <|
+  have : True :=      by
+                --^ completion
+
 -- ===== Top-level `by`, non-indented content following =====
 
 -- column 21 on line below `by`

--- a/tests/server_interactive/completionEmptyByBracketed.lean
+++ b/tests/server_interactive/completionEmptyByBracketed.lean
@@ -1,0 +1,63 @@
+prelude
+import Init.Notation
+
+/-
+Tests for tactic completion in empty *bracketed* tactic blocks `by { ... }`.
+
+`tacticSeqBracketed` is special: its body has no position information but the
+enclosing braces do. Tactics inserted into an empty bracketed block can appear
+at any column between the braces (the parser uses `withoutPosition` internally
+to disable the usual `checkColGt` constraint that applies to the non-bracketed
+form `by <newline>\n  ...`). The completion engine must therefore bypass its
+standard "canonical column" indentation check when the cursor is inside an
+empty `{ ... }` block.
+
+Other tactic block openers (`·`, `focus`, `case`, `decreasing_by`, `finally`)
+are not exercised here: they either share the same `tacticSeqIndentGt` parser
+as `by` (and thus share behavior with `completionEmptyBy.lean`) or use a plain
+`tacticSeq` (where the regular canonical-column check from `by` applies
+correctly).
+-/
+
+/-- A docstring -/
+syntax (name := skip) "skip" : tactic
+/-- A docstring -/
+syntax (name := refine) "refine " term : tactic
+/-- A docstring -/
+syntax (name := intro) "intro " term : tactic
+
+-- ===== Bracketed tactic block inside `by` =====
+
+-- Aligned braces at col 2. Cursor at canonical col 4.
+example : True := by
+  {
+     -- below
+  --^ completion
+  }
+
+-- Aligned braces at col 2. Cursor at col 6 (deeper than canonical).
+example : True := by
+  {
+       -- below
+    --^ completion
+  }
+
+-- Aligned braces at col 2. Cursor at col 0.
+example : True := by
+  {
+     -- below
+--⬑ completion
+  }
+
+-- Misaligned braces: opener at col 2, closer at col 6. Cursor at col 4.
+example : True := by
+  {
+     -- below
+  --^ completion
+      }
+
+-- Opener inline after by on the example line. Closer at col 0. Cursor at col 2.
+example : True := by {
+   -- below
+--^ completion
+}

--- a/tests/server_interactive/completionEmptyByBracketed.lean.out.expected
+++ b/tests/server_interactive/completionEmptyByBracketed.lean.out.expected
@@ -1,26 +1,5 @@
-{"textDocument": {"uri": "file:///completionEmptyBy.lean"},
- "position": {"line": 22, "character": 20}}
-{"items": [], "isIncomplete": true}
-{"textDocument": {"uri": "file:///completionEmptyBy.lean"},
- "position": {"line": 27, "character": 19}}
-{"items": [], "isIncomplete": true}
-{"textDocument": {"uri": "file:///completionEmptyBy.lean"},
- "position": {"line": 37, "character": 18}}
-{"items": [], "isIncomplete": true}
-{"textDocument": {"uri": "file:///completionEmptyBy.lean"},
- "position": {"line": 42, "character": 4}}
-{"items": [], "isIncomplete": true}
-{"textDocument": {"uri": "file:///completionEmptyBy.lean"},
- "position": {"line": 47, "character": 18}}
-{"items": [], "isIncomplete": true}
-{"textDocument": {"uri": "file:///completionEmptyBy.lean"},
- "position": {"line": 54, "character": 21}}
-{"items": [], "isIncomplete": true}
-{"textDocument": {"uri": "file:///completionEmptyBy.lean"},
- "position": {"line": 60, "character": 0}}
-{"items": [], "isIncomplete": true}
-{"textDocument": {"uri": "file:///completionEmptyBy.lean"},
- "position": {"line": 66, "character": 2}}
+{"textDocument": {"uri": "file:///completionEmptyByBracketed.lean"},
+ "position": {"line": 33, "character": 4}}
 {"items":
  [{"label": "open",
    "kind": 14,
@@ -28,31 +7,35 @@
    {"value":
     "`open Foo in tacs` (the tactic) acts like `open Foo` at command level,\nbut it opens a namespace only within the tactics `tacs`. ",
     "kind": "markdown"},
-   "data": ["file:///completionEmptyBy.lean", 66, 2, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 33, 4, 0]},
   {"label": "match",
    "kind": 14,
    "documentation":
    {"value":
     "`match` performs case analysis on one or more expressions.\nSee [Induction and Recursion][tpil4].\nThe syntax for the `match` tactic is the same as term-mode `match`, except that\nthe match arms are tactics instead of expressions.\n```\nexample (n : Nat) : n = n := by\n  match n with\n  | 0 => rfl\n  | i+1 => simp\n```\n\n[tpil4]: https://lean-lang.org/theorem_proving_in_lean4/induction_and_recursion.html\n",
     "kind": "markdown"},
-   "data": ["file:///completionEmptyBy.lean", 66, 2, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 33, 4, 0]},
   {"label": "set_option",
    "kind": 14,
    "documentation":
    {"value":
     "`set_option opt val in tacs` (the tactic) acts like `set_option opt val` at the command level,\nbut it sets the option only within the tactics `tacs`. ",
     "kind": "markdown"},
-   "data": ["file:///completionEmptyBy.lean", 66, 2, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 33, 4, 0]},
   {"label": "skip",
    "kind": 14,
    "documentation": {"value": "A docstring ", "kind": "markdown"},
-   "data": ["file:///completionEmptyBy.lean", 66, 2, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 33, 4, 0]},
+  {"label": "refine",
+   "kind": 14,
+   "documentation": {"value": "A docstring ", "kind": "markdown"},
+   "data": ["file:///completionEmptyByBracketed.lean", 33, 4, 0]},
   {"label": "ident",
    "kind": 14,
-   "data": ["file:///completionEmptyBy.lean", 66, 2, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 33, 4, 0]},
   {"label": "intro",
    "kind": 14,
-   "data": ["file:///completionEmptyBy.lean", 66, 2, 0]}],
+   "data": ["file:///completionEmptyByBracketed.lean", 33, 4, 0]}],
  "isIncomplete": true}
 Resolution of open:
 {"label": "open",
@@ -61,7 +44,7 @@ Resolution of open:
  {"value":
   "`open Foo in tacs` (the tactic) acts like `open Foo` at command level,\nbut it opens a namespace only within the tactics `tacs`. ",
   "kind": "markdown"},
- "data": ["file:///completionEmptyBy.lean", 66, 2, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 33, 4, 0]}
 Resolution of match:
 {"label": "match",
  "kind": 14,
@@ -69,7 +52,7 @@ Resolution of match:
  {"value":
   "`match` performs case analysis on one or more expressions.\nSee [Induction and Recursion][tpil4].\nThe syntax for the `match` tactic is the same as term-mode `match`, except that\nthe match arms are tactics instead of expressions.\n```\nexample (n : Nat) : n = n := by\n  match n with\n  | 0 => rfl\n  | i+1 => simp\n```\n\n[tpil4]: https://lean-lang.org/theorem_proving_in_lean4/induction_and_recursion.html\n",
   "kind": "markdown"},
- "data": ["file:///completionEmptyBy.lean", 66, 2, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 33, 4, 0]}
 Resolution of set_option:
 {"label": "set_option",
  "kind": 14,
@@ -77,28 +60,27 @@ Resolution of set_option:
  {"value":
   "`set_option opt val in tacs` (the tactic) acts like `set_option opt val` at the command level,\nbut it sets the option only within the tactics `tacs`. ",
   "kind": "markdown"},
- "data": ["file:///completionEmptyBy.lean", 66, 2, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 33, 4, 0]}
 Resolution of skip:
 {"label": "skip",
  "kind": 14,
  "documentation": {"value": "A docstring ", "kind": "markdown"},
- "data": ["file:///completionEmptyBy.lean", 66, 2, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 33, 4, 0]}
+Resolution of refine:
+{"label": "refine",
+ "kind": 14,
+ "documentation": {"value": "A docstring ", "kind": "markdown"},
+ "data": ["file:///completionEmptyByBracketed.lean", 33, 4, 0]}
 Resolution of ident:
 {"label": "ident",
  "kind": 14,
- "data": ["file:///completionEmptyBy.lean", 66, 2, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 33, 4, 0]}
 Resolution of intro:
 {"label": "intro",
  "kind": 14,
- "data": ["file:///completionEmptyBy.lean", 66, 2, 0]}
-{"textDocument": {"uri": "file:///completionEmptyBy.lean"},
- "position": {"line": 74, "character": 21}}
-{"items": [], "isIncomplete": true}
-{"textDocument": {"uri": "file:///completionEmptyBy.lean"},
- "position": {"line": 79, "character": 0}}
-{"items": [], "isIncomplete": true}
-{"textDocument": {"uri": "file:///completionEmptyBy.lean"},
- "position": {"line": 84, "character": 2}}
+ "data": ["file:///completionEmptyByBracketed.lean", 33, 4, 0]}
+{"textDocument": {"uri": "file:///completionEmptyByBracketed.lean"},
+ "position": {"line": 40, "character": 6}}
 {"items":
  [{"label": "open",
    "kind": 14,
@@ -106,31 +88,35 @@ Resolution of intro:
    {"value":
     "`open Foo in tacs` (the tactic) acts like `open Foo` at command level,\nbut it opens a namespace only within the tactics `tacs`. ",
     "kind": "markdown"},
-   "data": ["file:///completionEmptyBy.lean", 84, 2, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 40, 6, 0]},
   {"label": "match",
    "kind": 14,
    "documentation":
    {"value":
     "`match` performs case analysis on one or more expressions.\nSee [Induction and Recursion][tpil4].\nThe syntax for the `match` tactic is the same as term-mode `match`, except that\nthe match arms are tactics instead of expressions.\n```\nexample (n : Nat) : n = n := by\n  match n with\n  | 0 => rfl\n  | i+1 => simp\n```\n\n[tpil4]: https://lean-lang.org/theorem_proving_in_lean4/induction_and_recursion.html\n",
     "kind": "markdown"},
-   "data": ["file:///completionEmptyBy.lean", 84, 2, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 40, 6, 0]},
   {"label": "set_option",
    "kind": 14,
    "documentation":
    {"value":
     "`set_option opt val in tacs` (the tactic) acts like `set_option opt val` at the command level,\nbut it sets the option only within the tactics `tacs`. ",
     "kind": "markdown"},
-   "data": ["file:///completionEmptyBy.lean", 84, 2, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 40, 6, 0]},
   {"label": "skip",
    "kind": 14,
    "documentation": {"value": "A docstring ", "kind": "markdown"},
-   "data": ["file:///completionEmptyBy.lean", 84, 2, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 40, 6, 0]},
+  {"label": "refine",
+   "kind": 14,
+   "documentation": {"value": "A docstring ", "kind": "markdown"},
+   "data": ["file:///completionEmptyByBracketed.lean", 40, 6, 0]},
   {"label": "ident",
    "kind": 14,
-   "data": ["file:///completionEmptyBy.lean", 84, 2, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 40, 6, 0]},
   {"label": "intro",
    "kind": 14,
-   "data": ["file:///completionEmptyBy.lean", 84, 2, 0]}],
+   "data": ["file:///completionEmptyByBracketed.lean", 40, 6, 0]}],
  "isIncomplete": true}
 Resolution of open:
 {"label": "open",
@@ -139,7 +125,7 @@ Resolution of open:
  {"value":
   "`open Foo in tacs` (the tactic) acts like `open Foo` at command level,\nbut it opens a namespace only within the tactics `tacs`. ",
   "kind": "markdown"},
- "data": ["file:///completionEmptyBy.lean", 84, 2, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 40, 6, 0]}
 Resolution of match:
 {"label": "match",
  "kind": 14,
@@ -147,7 +133,7 @@ Resolution of match:
  {"value":
   "`match` performs case analysis on one or more expressions.\nSee [Induction and Recursion][tpil4].\nThe syntax for the `match` tactic is the same as term-mode `match`, except that\nthe match arms are tactics instead of expressions.\n```\nexample (n : Nat) : n = n := by\n  match n with\n  | 0 => rfl\n  | i+1 => simp\n```\n\n[tpil4]: https://lean-lang.org/theorem_proving_in_lean4/induction_and_recursion.html\n",
   "kind": "markdown"},
- "data": ["file:///completionEmptyBy.lean", 84, 2, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 40, 6, 0]}
 Resolution of set_option:
 {"label": "set_option",
  "kind": 14,
@@ -155,25 +141,27 @@ Resolution of set_option:
  {"value":
   "`set_option opt val in tacs` (the tactic) acts like `set_option opt val` at the command level,\nbut it sets the option only within the tactics `tacs`. ",
   "kind": "markdown"},
- "data": ["file:///completionEmptyBy.lean", 84, 2, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 40, 6, 0]}
 Resolution of skip:
 {"label": "skip",
  "kind": 14,
  "documentation": {"value": "A docstring ", "kind": "markdown"},
- "data": ["file:///completionEmptyBy.lean", 84, 2, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 40, 6, 0]}
+Resolution of refine:
+{"label": "refine",
+ "kind": 14,
+ "documentation": {"value": "A docstring ", "kind": "markdown"},
+ "data": ["file:///completionEmptyByBracketed.lean", 40, 6, 0]}
 Resolution of ident:
 {"label": "ident",
  "kind": 14,
- "data": ["file:///completionEmptyBy.lean", 84, 2, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 40, 6, 0]}
 Resolution of intro:
 {"label": "intro",
  "kind": 14,
- "data": ["file:///completionEmptyBy.lean", 84, 2, 0]}
-{"textDocument": {"uri": "file:///completionEmptyBy.lean"},
- "position": {"line": 92, "character": 21}}
-{"items": [], "isIncomplete": true}
-{"textDocument": {"uri": "file:///completionEmptyBy.lean"},
- "position": {"line": 99, "character": 4}}
+ "data": ["file:///completionEmptyByBracketed.lean", 40, 6, 0]}
+{"textDocument": {"uri": "file:///completionEmptyByBracketed.lean"},
+ "position": {"line": 47, "character": 0}}
 {"items":
  [{"label": "open",
    "kind": 14,
@@ -181,31 +169,35 @@ Resolution of intro:
    {"value":
     "`open Foo in tacs` (the tactic) acts like `open Foo` at command level,\nbut it opens a namespace only within the tactics `tacs`. ",
     "kind": "markdown"},
-   "data": ["file:///completionEmptyBy.lean", 99, 4, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 47, 0, 0]},
   {"label": "match",
    "kind": 14,
    "documentation":
    {"value":
     "`match` performs case analysis on one or more expressions.\nSee [Induction and Recursion][tpil4].\nThe syntax for the `match` tactic is the same as term-mode `match`, except that\nthe match arms are tactics instead of expressions.\n```\nexample (n : Nat) : n = n := by\n  match n with\n  | 0 => rfl\n  | i+1 => simp\n```\n\n[tpil4]: https://lean-lang.org/theorem_proving_in_lean4/induction_and_recursion.html\n",
     "kind": "markdown"},
-   "data": ["file:///completionEmptyBy.lean", 99, 4, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 47, 0, 0]},
   {"label": "set_option",
    "kind": 14,
    "documentation":
    {"value":
     "`set_option opt val in tacs` (the tactic) acts like `set_option opt val` at the command level,\nbut it sets the option only within the tactics `tacs`. ",
     "kind": "markdown"},
-   "data": ["file:///completionEmptyBy.lean", 99, 4, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 47, 0, 0]},
   {"label": "skip",
    "kind": 14,
    "documentation": {"value": "A docstring ", "kind": "markdown"},
-   "data": ["file:///completionEmptyBy.lean", 99, 4, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 47, 0, 0]},
+  {"label": "refine",
+   "kind": 14,
+   "documentation": {"value": "A docstring ", "kind": "markdown"},
+   "data": ["file:///completionEmptyByBracketed.lean", 47, 0, 0]},
   {"label": "ident",
    "kind": 14,
-   "data": ["file:///completionEmptyBy.lean", 99, 4, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 47, 0, 0]},
   {"label": "intro",
    "kind": 14,
-   "data": ["file:///completionEmptyBy.lean", 99, 4, 0]}],
+   "data": ["file:///completionEmptyByBracketed.lean", 47, 0, 0]}],
  "isIncomplete": true}
 Resolution of open:
 {"label": "open",
@@ -214,7 +206,7 @@ Resolution of open:
  {"value":
   "`open Foo in tacs` (the tactic) acts like `open Foo` at command level,\nbut it opens a namespace only within the tactics `tacs`. ",
   "kind": "markdown"},
- "data": ["file:///completionEmptyBy.lean", 99, 4, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 47, 0, 0]}
 Resolution of match:
 {"label": "match",
  "kind": 14,
@@ -222,7 +214,7 @@ Resolution of match:
  {"value":
   "`match` performs case analysis on one or more expressions.\nSee [Induction and Recursion][tpil4].\nThe syntax for the `match` tactic is the same as term-mode `match`, except that\nthe match arms are tactics instead of expressions.\n```\nexample (n : Nat) : n = n := by\n  match n with\n  | 0 => rfl\n  | i+1 => simp\n```\n\n[tpil4]: https://lean-lang.org/theorem_proving_in_lean4/induction_and_recursion.html\n",
   "kind": "markdown"},
- "data": ["file:///completionEmptyBy.lean", 99, 4, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 47, 0, 0]}
 Resolution of set_option:
 {"label": "set_option",
  "kind": 14,
@@ -230,31 +222,27 @@ Resolution of set_option:
  {"value":
   "`set_option opt val in tacs` (the tactic) acts like `set_option opt val` at the command level,\nbut it sets the option only within the tactics `tacs`. ",
   "kind": "markdown"},
- "data": ["file:///completionEmptyBy.lean", 99, 4, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 47, 0, 0]}
 Resolution of skip:
 {"label": "skip",
  "kind": 14,
  "documentation": {"value": "A docstring ", "kind": "markdown"},
- "data": ["file:///completionEmptyBy.lean", 99, 4, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 47, 0, 0]}
+Resolution of refine:
+{"label": "refine",
+ "kind": 14,
+ "documentation": {"value": "A docstring ", "kind": "markdown"},
+ "data": ["file:///completionEmptyByBracketed.lean", 47, 0, 0]}
 Resolution of ident:
 {"label": "ident",
  "kind": 14,
- "data": ["file:///completionEmptyBy.lean", 99, 4, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 47, 0, 0]}
 Resolution of intro:
 {"label": "intro",
  "kind": 14,
- "data": ["file:///completionEmptyBy.lean", 99, 4, 0]}
-{"textDocument": {"uri": "file:///completionEmptyBy.lean"},
- "position": {"line": 106, "character": 0}}
-{"items": [], "isIncomplete": true}
-{"textDocument": {"uri": "file:///completionEmptyBy.lean"},
- "position": {"line": 113, "character": 6}}
-{"items": [], "isIncomplete": true}
-{"textDocument": {"uri": "file:///completionEmptyBy.lean"},
- "position": {"line": 122, "character": 21}}
-{"items": [], "isIncomplete": true}
-{"textDocument": {"uri": "file:///completionEmptyBy.lean"},
- "position": {"line": 128, "character": 4}}
+ "data": ["file:///completionEmptyByBracketed.lean", 47, 0, 0]}
+{"textDocument": {"uri": "file:///completionEmptyByBracketed.lean"},
+ "position": {"line": 54, "character": 4}}
 {"items":
  [{"label": "open",
    "kind": 14,
@@ -262,31 +250,35 @@ Resolution of intro:
    {"value":
     "`open Foo in tacs` (the tactic) acts like `open Foo` at command level,\nbut it opens a namespace only within the tactics `tacs`. ",
     "kind": "markdown"},
-   "data": ["file:///completionEmptyBy.lean", 128, 4, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 54, 4, 0]},
   {"label": "match",
    "kind": 14,
    "documentation":
    {"value":
     "`match` performs case analysis on one or more expressions.\nSee [Induction and Recursion][tpil4].\nThe syntax for the `match` tactic is the same as term-mode `match`, except that\nthe match arms are tactics instead of expressions.\n```\nexample (n : Nat) : n = n := by\n  match n with\n  | 0 => rfl\n  | i+1 => simp\n```\n\n[tpil4]: https://lean-lang.org/theorem_proving_in_lean4/induction_and_recursion.html\n",
     "kind": "markdown"},
-   "data": ["file:///completionEmptyBy.lean", 128, 4, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 54, 4, 0]},
   {"label": "set_option",
    "kind": 14,
    "documentation":
    {"value":
     "`set_option opt val in tacs` (the tactic) acts like `set_option opt val` at the command level,\nbut it sets the option only within the tactics `tacs`. ",
     "kind": "markdown"},
-   "data": ["file:///completionEmptyBy.lean", 128, 4, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 54, 4, 0]},
   {"label": "skip",
    "kind": 14,
    "documentation": {"value": "A docstring ", "kind": "markdown"},
-   "data": ["file:///completionEmptyBy.lean", 128, 4, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 54, 4, 0]},
+  {"label": "refine",
+   "kind": 14,
+   "documentation": {"value": "A docstring ", "kind": "markdown"},
+   "data": ["file:///completionEmptyByBracketed.lean", 54, 4, 0]},
   {"label": "ident",
    "kind": 14,
-   "data": ["file:///completionEmptyBy.lean", 128, 4, 0]},
+   "data": ["file:///completionEmptyByBracketed.lean", 54, 4, 0]},
   {"label": "intro",
    "kind": 14,
-   "data": ["file:///completionEmptyBy.lean", 128, 4, 0]}],
+   "data": ["file:///completionEmptyByBracketed.lean", 54, 4, 0]}],
  "isIncomplete": true}
 Resolution of open:
 {"label": "open",
@@ -295,7 +287,7 @@ Resolution of open:
  {"value":
   "`open Foo in tacs` (the tactic) acts like `open Foo` at command level,\nbut it opens a namespace only within the tactics `tacs`. ",
   "kind": "markdown"},
- "data": ["file:///completionEmptyBy.lean", 128, 4, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 54, 4, 0]}
 Resolution of match:
 {"label": "match",
  "kind": 14,
@@ -303,7 +295,7 @@ Resolution of match:
  {"value":
   "`match` performs case analysis on one or more expressions.\nSee [Induction and Recursion][tpil4].\nThe syntax for the `match` tactic is the same as term-mode `match`, except that\nthe match arms are tactics instead of expressions.\n```\nexample (n : Nat) : n = n := by\n  match n with\n  | 0 => rfl\n  | i+1 => simp\n```\n\n[tpil4]: https://lean-lang.org/theorem_proving_in_lean4/induction_and_recursion.html\n",
   "kind": "markdown"},
- "data": ["file:///completionEmptyBy.lean", 128, 4, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 54, 4, 0]}
 Resolution of set_option:
 {"label": "set_option",
  "kind": 14,
@@ -311,23 +303,103 @@ Resolution of set_option:
  {"value":
   "`set_option opt val in tacs` (the tactic) acts like `set_option opt val` at the command level,\nbut it sets the option only within the tactics `tacs`. ",
   "kind": "markdown"},
- "data": ["file:///completionEmptyBy.lean", 128, 4, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 54, 4, 0]}
 Resolution of skip:
 {"label": "skip",
  "kind": 14,
  "documentation": {"value": "A docstring ", "kind": "markdown"},
- "data": ["file:///completionEmptyBy.lean", 128, 4, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 54, 4, 0]}
+Resolution of refine:
+{"label": "refine",
+ "kind": 14,
+ "documentation": {"value": "A docstring ", "kind": "markdown"},
+ "data": ["file:///completionEmptyByBracketed.lean", 54, 4, 0]}
 Resolution of ident:
 {"label": "ident",
  "kind": 14,
- "data": ["file:///completionEmptyBy.lean", 128, 4, 0]}
+ "data": ["file:///completionEmptyByBracketed.lean", 54, 4, 0]}
 Resolution of intro:
 {"label": "intro",
  "kind": 14,
- "data": ["file:///completionEmptyBy.lean", 128, 4, 0]}
-{"textDocument": {"uri": "file:///completionEmptyBy.lean"},
- "position": {"line": 134, "character": 0}}
-{"items": [], "isIncomplete": true}
-{"textDocument": {"uri": "file:///completionEmptyBy.lean"},
- "position": {"line": 140, "character": 6}}
-{"items": [], "isIncomplete": true}
+ "data": ["file:///completionEmptyByBracketed.lean", 54, 4, 0]}
+{"textDocument": {"uri": "file:///completionEmptyByBracketed.lean"},
+ "position": {"line": 60, "character": 2}}
+{"items":
+ [{"label": "open",
+   "kind": 14,
+   "documentation":
+   {"value":
+    "`open Foo in tacs` (the tactic) acts like `open Foo` at command level,\nbut it opens a namespace only within the tactics `tacs`. ",
+    "kind": "markdown"},
+   "data": ["file:///completionEmptyByBracketed.lean", 60, 2, 0]},
+  {"label": "match",
+   "kind": 14,
+   "documentation":
+   {"value":
+    "`match` performs case analysis on one or more expressions.\nSee [Induction and Recursion][tpil4].\nThe syntax for the `match` tactic is the same as term-mode `match`, except that\nthe match arms are tactics instead of expressions.\n```\nexample (n : Nat) : n = n := by\n  match n with\n  | 0 => rfl\n  | i+1 => simp\n```\n\n[tpil4]: https://lean-lang.org/theorem_proving_in_lean4/induction_and_recursion.html\n",
+    "kind": "markdown"},
+   "data": ["file:///completionEmptyByBracketed.lean", 60, 2, 0]},
+  {"label": "set_option",
+   "kind": 14,
+   "documentation":
+   {"value":
+    "`set_option opt val in tacs` (the tactic) acts like `set_option opt val` at the command level,\nbut it sets the option only within the tactics `tacs`. ",
+    "kind": "markdown"},
+   "data": ["file:///completionEmptyByBracketed.lean", 60, 2, 0]},
+  {"label": "skip",
+   "kind": 14,
+   "documentation": {"value": "A docstring ", "kind": "markdown"},
+   "data": ["file:///completionEmptyByBracketed.lean", 60, 2, 0]},
+  {"label": "refine",
+   "kind": 14,
+   "documentation": {"value": "A docstring ", "kind": "markdown"},
+   "data": ["file:///completionEmptyByBracketed.lean", 60, 2, 0]},
+  {"label": "ident",
+   "kind": 14,
+   "data": ["file:///completionEmptyByBracketed.lean", 60, 2, 0]},
+  {"label": "intro",
+   "kind": 14,
+   "data": ["file:///completionEmptyByBracketed.lean", 60, 2, 0]}],
+ "isIncomplete": true}
+Resolution of open:
+{"label": "open",
+ "kind": 14,
+ "documentation":
+ {"value":
+  "`open Foo in tacs` (the tactic) acts like `open Foo` at command level,\nbut it opens a namespace only within the tactics `tacs`. ",
+  "kind": "markdown"},
+ "data": ["file:///completionEmptyByBracketed.lean", 60, 2, 0]}
+Resolution of match:
+{"label": "match",
+ "kind": 14,
+ "documentation":
+ {"value":
+  "`match` performs case analysis on one or more expressions.\nSee [Induction and Recursion][tpil4].\nThe syntax for the `match` tactic is the same as term-mode `match`, except that\nthe match arms are tactics instead of expressions.\n```\nexample (n : Nat) : n = n := by\n  match n with\n  | 0 => rfl\n  | i+1 => simp\n```\n\n[tpil4]: https://lean-lang.org/theorem_proving_in_lean4/induction_and_recursion.html\n",
+  "kind": "markdown"},
+ "data": ["file:///completionEmptyByBracketed.lean", 60, 2, 0]}
+Resolution of set_option:
+{"label": "set_option",
+ "kind": 14,
+ "documentation":
+ {"value":
+  "`set_option opt val in tacs` (the tactic) acts like `set_option opt val` at the command level,\nbut it sets the option only within the tactics `tacs`. ",
+  "kind": "markdown"},
+ "data": ["file:///completionEmptyByBracketed.lean", 60, 2, 0]}
+Resolution of skip:
+{"label": "skip",
+ "kind": 14,
+ "documentation": {"value": "A docstring ", "kind": "markdown"},
+ "data": ["file:///completionEmptyByBracketed.lean", 60, 2, 0]}
+Resolution of refine:
+{"label": "refine",
+ "kind": 14,
+ "documentation": {"value": "A docstring ", "kind": "markdown"},
+ "data": ["file:///completionEmptyByBracketed.lean", 60, 2, 0]}
+Resolution of ident:
+{"label": "ident",
+ "kind": 14,
+ "data": ["file:///completionEmptyByBracketed.lean", 60, 2, 0]}
+Resolution of intro:
+{"label": "intro",
+ "kind": 14,
+ "data": ["file:///completionEmptyByBracketed.lean", 60, 2, 0]}

--- a/tests/server_interactive/completionTactics.lean
+++ b/tests/server_interactive/completionTactics.lean
@@ -94,7 +94,7 @@ example : True :=
 
 example : True :=
   let foo := by
-      -- All tactic completions expected
+      -- No completions expected
 --^ completion
 
 example : True :=
@@ -131,4 +131,5 @@ syntax  "let " letDecl : tactic
 syntax (name := letrec) "let " &"rec" letRecDecls : tactic
 
 example : True := by
-                   --^ completion
+    -- All tactic completions expected
+--^ completion

--- a/tests/server_interactive/completionTactics.lean.out.expected
+++ b/tests/server_interactive/completionTactics.lean.out.expected
@@ -1143,85 +1143,7 @@ Resolution of intro:
  "data": ["file:///completionTactics.lean", 91, 4, 0]}
 {"textDocument": {"uri": "file:///completionTactics.lean"},
  "position": {"line": 96, "character": 2}}
-{"items":
- [{"label": "open",
-   "kind": 14,
-   "documentation":
-   {"value":
-    "`open Foo in tacs` (the tactic) acts like `open Foo` at command level,\nbut it opens a namespace only within the tactics `tacs`. ",
-    "kind": "markdown"},
-   "data": ["file:///completionTactics.lean", 96, 2, 0]},
-  {"label": "match",
-   "kind": 14,
-   "documentation":
-   {"value":
-    "`match` performs case analysis on one or more expressions.\nSee [Induction and Recursion][tpil4].\nThe syntax for the `match` tactic is the same as term-mode `match`, except that\nthe match arms are tactics instead of expressions.\n```\nexample (n : Nat) : n = n := by\n  match n with\n  | 0 => rfl\n  | i+1 => simp\n```\n\n[tpil4]: https://lean-lang.org/theorem_proving_in_lean4/induction_and_recursion.html\n",
-    "kind": "markdown"},
-   "data": ["file:///completionTactics.lean", 96, 2, 0]},
-  {"label": "set_option",
-   "kind": 14,
-   "documentation":
-   {"value":
-    "`set_option opt val in tacs` (the tactic) acts like `set_option opt val` at the command level,\nbut it sets the option only within the tactics `tacs`. ",
-    "kind": "markdown"},
-   "data": ["file:///completionTactics.lean", 96, 2, 0]},
-  {"label": "skip",
-   "kind": 14,
-   "documentation": {"value": "A docstring ", "kind": "markdown"},
-   "data": ["file:///completionTactics.lean", 96, 2, 0]},
-  {"label": "ident",
-   "kind": 14,
-   "data": ["file:///completionTactics.lean", 96, 2, 0]},
-  {"label": "exact",
-   "kind": 14,
-   "documentation": {"value": "Another docstring ", "kind": "markdown"},
-   "data": ["file:///completionTactics.lean", 96, 2, 0]},
-  {"label": "intro",
-   "kind": 14,
-   "data": ["file:///completionTactics.lean", 96, 2, 0]}],
- "isIncomplete": true}
-Resolution of open:
-{"label": "open",
- "kind": 14,
- "documentation":
- {"value":
-  "`open Foo in tacs` (the tactic) acts like `open Foo` at command level,\nbut it opens a namespace only within the tactics `tacs`. ",
-  "kind": "markdown"},
- "data": ["file:///completionTactics.lean", 96, 2, 0]}
-Resolution of match:
-{"label": "match",
- "kind": 14,
- "documentation":
- {"value":
-  "`match` performs case analysis on one or more expressions.\nSee [Induction and Recursion][tpil4].\nThe syntax for the `match` tactic is the same as term-mode `match`, except that\nthe match arms are tactics instead of expressions.\n```\nexample (n : Nat) : n = n := by\n  match n with\n  | 0 => rfl\n  | i+1 => simp\n```\n\n[tpil4]: https://lean-lang.org/theorem_proving_in_lean4/induction_and_recursion.html\n",
-  "kind": "markdown"},
- "data": ["file:///completionTactics.lean", 96, 2, 0]}
-Resolution of set_option:
-{"label": "set_option",
- "kind": 14,
- "documentation":
- {"value":
-  "`set_option opt val in tacs` (the tactic) acts like `set_option opt val` at the command level,\nbut it sets the option only within the tactics `tacs`. ",
-  "kind": "markdown"},
- "data": ["file:///completionTactics.lean", 96, 2, 0]}
-Resolution of skip:
-{"label": "skip",
- "kind": 14,
- "documentation": {"value": "A docstring ", "kind": "markdown"},
- "data": ["file:///completionTactics.lean", 96, 2, 0]}
-Resolution of ident:
-{"label": "ident",
- "kind": 14,
- "data": ["file:///completionTactics.lean", 96, 2, 0]}
-Resolution of exact:
-{"label": "exact",
- "kind": 14,
- "documentation": {"value": "Another docstring ", "kind": "markdown"},
- "data": ["file:///completionTactics.lean", 96, 2, 0]}
-Resolution of intro:
-{"label": "intro",
- "kind": 14,
- "data": ["file:///completionTactics.lean", 96, 2, 0]}
+{"items": [], "isIncomplete": true}
 {"textDocument": {"uri": "file:///completionTactics.lean"},
  "position": {"line": 102, "character": 4}}
 {"items":
@@ -1469,7 +1391,7 @@ Resolution of intro:
  "kind": 14,
  "data": ["file:///completionTactics.lean", 118, 4, 0]}
 {"textDocument": {"uri": "file:///completionTactics.lean"},
- "position": {"line": 132, "character": 21}}
+ "position": {"line": 133, "character": 2}}
 {"items":
  [{"label": "open",
    "kind": 14,
@@ -1477,43 +1399,43 @@ Resolution of intro:
    {"value":
     "`open Foo in tacs` (the tactic) acts like `open Foo` at command level,\nbut it opens a namespace only within the tactics `tacs`. ",
     "kind": "markdown"},
-   "data": ["file:///completionTactics.lean", 132, 21, 0]},
+   "data": ["file:///completionTactics.lean", 133, 2, 0]},
   {"label": "match",
    "kind": 14,
    "documentation":
    {"value":
     "`match` performs case analysis on one or more expressions.\nSee [Induction and Recursion][tpil4].\nThe syntax for the `match` tactic is the same as term-mode `match`, except that\nthe match arms are tactics instead of expressions.\n```\nexample (n : Nat) : n = n := by\n  match n with\n  | 0 => rfl\n  | i+1 => simp\n```\n\n[tpil4]: https://lean-lang.org/theorem_proving_in_lean4/induction_and_recursion.html\n",
     "kind": "markdown"},
-   "data": ["file:///completionTactics.lean", 132, 21, 0]},
+   "data": ["file:///completionTactics.lean", 133, 2, 0]},
   {"label": "set_option",
    "kind": 14,
    "documentation":
    {"value":
     "`set_option opt val in tacs` (the tactic) acts like `set_option opt val` at the command level,\nbut it sets the option only within the tactics `tacs`. ",
     "kind": "markdown"},
-   "data": ["file:///completionTactics.lean", 132, 21, 0]},
+   "data": ["file:///completionTactics.lean", 133, 2, 0]},
   {"label": "skip",
    "kind": 14,
    "documentation": {"value": "A docstring ", "kind": "markdown"},
-   "data": ["file:///completionTactics.lean", 132, 21, 0]},
+   "data": ["file:///completionTactics.lean", 133, 2, 0]},
   {"label": "ident",
    "kind": 14,
-   "data": ["file:///completionTactics.lean", 132, 21, 0]},
+   "data": ["file:///completionTactics.lean", 133, 2, 0]},
   {"label": "let rec",
    "kind": 14,
    "documentation": {"value": "Local recursive def ", "kind": "markdown"},
-   "data": ["file:///completionTactics.lean", 132, 21, 0]},
+   "data": ["file:///completionTactics.lean", 133, 2, 0]},
   {"label": "exact",
    "kind": 14,
    "documentation": {"value": "Another docstring ", "kind": "markdown"},
-   "data": ["file:///completionTactics.lean", 132, 21, 0]},
+   "data": ["file:///completionTactics.lean", 133, 2, 0]},
   {"label": "intro",
    "kind": 14,
-   "data": ["file:///completionTactics.lean", 132, 21, 0]},
+   "data": ["file:///completionTactics.lean", 133, 2, 0]},
   {"label": "let",
    "kind": 14,
    "documentation": {"value": "Local def ", "kind": "markdown"},
-   "data": ["file:///completionTactics.lean", 132, 21, 0]}],
+   "data": ["file:///completionTactics.lean", 133, 2, 0]}],
  "isIncomplete": true}
 Resolution of open:
 {"label": "open",
@@ -1522,7 +1444,7 @@ Resolution of open:
  {"value":
   "`open Foo in tacs` (the tactic) acts like `open Foo` at command level,\nbut it opens a namespace only within the tactics `tacs`. ",
   "kind": "markdown"},
- "data": ["file:///completionTactics.lean", 132, 21, 0]}
+ "data": ["file:///completionTactics.lean", 133, 2, 0]}
 Resolution of match:
 {"label": "match",
  "kind": 14,
@@ -1530,7 +1452,7 @@ Resolution of match:
  {"value":
   "`match` performs case analysis on one or more expressions.\nSee [Induction and Recursion][tpil4].\nThe syntax for the `match` tactic is the same as term-mode `match`, except that\nthe match arms are tactics instead of expressions.\n```\nexample (n : Nat) : n = n := by\n  match n with\n  | 0 => rfl\n  | i+1 => simp\n```\n\n[tpil4]: https://lean-lang.org/theorem_proving_in_lean4/induction_and_recursion.html\n",
   "kind": "markdown"},
- "data": ["file:///completionTactics.lean", 132, 21, 0]}
+ "data": ["file:///completionTactics.lean", 133, 2, 0]}
 Resolution of set_option:
 {"label": "set_option",
  "kind": 14,
@@ -1538,32 +1460,32 @@ Resolution of set_option:
  {"value":
   "`set_option opt val in tacs` (the tactic) acts like `set_option opt val` at the command level,\nbut it sets the option only within the tactics `tacs`. ",
   "kind": "markdown"},
- "data": ["file:///completionTactics.lean", 132, 21, 0]}
+ "data": ["file:///completionTactics.lean", 133, 2, 0]}
 Resolution of skip:
 {"label": "skip",
  "kind": 14,
  "documentation": {"value": "A docstring ", "kind": "markdown"},
- "data": ["file:///completionTactics.lean", 132, 21, 0]}
+ "data": ["file:///completionTactics.lean", 133, 2, 0]}
 Resolution of ident:
 {"label": "ident",
  "kind": 14,
- "data": ["file:///completionTactics.lean", 132, 21, 0]}
+ "data": ["file:///completionTactics.lean", 133, 2, 0]}
 Resolution of let rec:
 {"label": "let rec",
  "kind": 14,
  "documentation": {"value": "Local recursive def ", "kind": "markdown"},
- "data": ["file:///completionTactics.lean", 132, 21, 0]}
+ "data": ["file:///completionTactics.lean", 133, 2, 0]}
 Resolution of exact:
 {"label": "exact",
  "kind": 14,
  "documentation": {"value": "Another docstring ", "kind": "markdown"},
- "data": ["file:///completionTactics.lean", 132, 21, 0]}
+ "data": ["file:///completionTactics.lean", 133, 2, 0]}
 Resolution of intro:
 {"label": "intro",
  "kind": 14,
- "data": ["file:///completionTactics.lean", 132, 21, 0]}
+ "data": ["file:///completionTactics.lean", 133, 2, 0]}
 Resolution of let:
 {"label": "let",
  "kind": 14,
  "documentation": {"value": "Local def ", "kind": "markdown"},
- "data": ["file:///completionTactics.lean", 132, 21, 0]}
+ "data": ["file:///completionTactics.lean", 133, 2, 0]}


### PR DESCRIPTION
This PR fixes a bug where tactic auto-completion would produce tactic completion items in the entire trailing whitespace of an empty tactic block. Since #13229 further restricted top-level `by` blocks to be indentation- sensitive, this PR adjusts the logic to only display completion items at a "proper" indentation level.