### PR TITLE
fix: allow level assignments in `wrapInstance` in `inferInstanceAs`

### DIFF
--- a/src/Lean/Elab/BuiltinTerm.lean
+++ b/src/Lean/Elab/BuiltinTerm.lean
@@ -337,7 +337,8 @@ private def mkSilentAnnotationIfHole (e : Expr) : TermElabM Expr := do
     -- Wrap instance so its type matches the expected type exactly.
     let logCompileErrors := !(← read).isNoncomputableSection && !(← read).declName?.any (Lean.isNoncomputable (← getEnv))
     let isMeta := (← read).declName?.any (isMarkedMeta (← getEnv))
-    withNewMCtxDepth <| wrapInstance inst expectedType (logCompileErrors := logCompileErrors) (isMeta := isMeta)
+    withNewMCtxDepth (allowLevelAssignments := true) <|
+      wrapInstance inst expectedType (logCompileErrors := logCompileErrors) (isMeta := isMeta)
   else
     pure inst
   ensureHasType expectedType? inst

--- a/src/Lean/Elab/BuiltinTerm.lean
+++ b/src/Lean/Elab/BuiltinTerm.lean
@@ -331,14 +331,14 @@ private def mkSilentAnnotationIfHole (e : Expr) : TermElabM Expr := do
   let type ← instantiateMVars type
   -- Rebuild type with fresh synthetic mvars for instance-implicit args, so that
   -- synthesis is not influenced by the expected type's instance choices.
-  withNewMCtxDepth do
   let type ← abstractInstImplicitArgs type
   let inst ← synthInstance type
   let inst ← if backward.inferInstanceAs.wrap.get (← getOptions) then
     -- Wrap instance so its type matches the expected type exactly.
     let logCompileErrors := !(← read).isNoncomputableSection && !(← read).declName?.any (Lean.isNoncomputable (← getEnv))
     let isMeta := (← read).declName?.any (isMarkedMeta (← getEnv))
-    wrapInstance inst expectedType (logCompileErrors := logCompileErrors) (isMeta := isMeta)
+    withNewMCtxDepth (allowLevelAssignments := true) <|
+      wrapInstance inst expectedType (logCompileErrors := logCompileErrors) (isMeta := isMeta)
   else
     pure inst
   ensureHasType expectedType? inst

--- a/src/Lean/Elab/BuiltinTerm.lean
+++ b/src/Lean/Elab/BuiltinTerm.lean
@@ -331,14 +331,14 @@ private def mkSilentAnnotationIfHole (e : Expr) : TermElabM Expr := do
   let type ← instantiateMVars type
   -- Rebuild type with fresh synthetic mvars for instance-implicit args, so that
   -- synthesis is not influenced by the expected type's instance choices.
+  withNewMCtxDepth do
   let type ← abstractInstImplicitArgs type
   let inst ← synthInstance type
   let inst ← if backward.inferInstanceAs.wrap.get (← getOptions) then
     -- Wrap instance so its type matches the expected type exactly.
     let logCompileErrors := !(← read).isNoncomputableSection && !(← read).declName?.any (Lean.isNoncomputable (← getEnv))
     let isMeta := (← read).declName?.any (isMarkedMeta (← getEnv))
-    withNewMCtxDepth (allowLevelAssignments := true) <|
-      wrapInstance inst expectedType (logCompileErrors := logCompileErrors) (isMeta := isMeta)
+    wrapInstance inst expectedType (logCompileErrors := logCompileErrors) (isMeta := isMeta)
   else
     pure inst
   ensureHasType expectedType? inst

--- a/src/Lean/Meta/WrapInstance.lean
+++ b/src/Lean/Meta/WrapInstance.lean
@@ -150,27 +150,25 @@ public partial def wrapInstance (inst expectedType : Expr) (compile : Bool := tr
 
   -- Try to reduce it to a constructor.
   (← whnf inst).withApp fun f args => do
-    let wrapInst := do
-      trace[Meta.wrapInstance] "did not reduce to constructor application, returning/wrapping as is: {inst}"
-      if backward.inferInstanceAs.wrap.instances.get (← getOptions) then
-        let instType ← inferType inst
-        if ← isDefEq expectedType instType then
-          return inst
+    let some (.ctorInfo ci) ← f.constName?.mapM getConstInfo
+      | do
+        trace[Meta.wrapInstance] "did not reduce to constructor application, returning/wrapping as is: {inst}"
+        if backward.inferInstanceAs.wrap.instances.get (← getOptions) then
+          let instType ← inferType inst
+          if ← isDefEq expectedType instType then
+            return inst
+          else
+            let name ← mkAuxDeclName
+            let wrapped ← mkAuxDefinition name expectedType inst (compile := false)
+            setReducibilityStatus name .implicitReducible
+            if isMeta then modifyEnv (markMeta · name)
+            if compile then
+              compileDecls (logErrors := logCompileErrors) #[name]
+            enableRealizationsForConst name
+            return wrapped
         else
-          let name ← mkAuxDeclName
-          let wrapped ← mkAuxDefinition name expectedType inst (compile := false)
-          setReducibilityStatus name .implicitReducible
-          if isMeta then modifyEnv (markMeta · name)
-          if compile then
-            compileDecls (logErrors := logCompileErrors) #[name]
-          enableRealizationsForConst name
-          return wrapped
-      else
-        return inst
-    let .const ctorName _ := f | wrapInst
-    let .ctorInfo ci ← getConstInfo ctorName | wrapInst
-    let ctor ← mkConstWithFreshMVarLevels ctorName
-    let (mvars, _, cls) ← forallMetaTelescope (← inferType ctor)
+          return inst
+    let (mvars, _, cls) ← forallMetaTelescope (← inferType f)
     if h₁ : args.size ≠ mvars.size then
       throwError "wrapInstance: incorrect number of arguments for \
         constructor application `{f}`: {args}"
@@ -242,4 +240,4 @@ public partial def wrapInstance (inst expectedType : Expr) (compile : Bool := tr
             enableRealizationsForConst name
         else
           mvarId.assign arg
-      instantiateMVars (mkAppN ctor mvars)
+      instantiateMVars (mkAppN f mvars)

--- a/src/Lean/Meta/WrapInstance.lean
+++ b/src/Lean/Meta/WrapInstance.lean
@@ -150,25 +150,27 @@ public partial def wrapInstance (inst expectedType : Expr) (compile : Bool := tr
 
   -- Try to reduce it to a constructor.
   (← whnf inst).withApp fun f args => do
-    let some (.ctorInfo ci) ← f.constName?.mapM getConstInfo
-      | do
-        trace[Meta.wrapInstance] "did not reduce to constructor application, returning/wrapping as is: {inst}"
-        if backward.inferInstanceAs.wrap.instances.get (← getOptions) then
-          let instType ← inferType inst
-          if ← isDefEq expectedType instType then
-            return inst
-          else
-            let name ← mkAuxDeclName
-            let wrapped ← mkAuxDefinition name expectedType inst (compile := false)
-            setReducibilityStatus name .implicitReducible
-            if isMeta then modifyEnv (markMeta · name)
-            if compile then
-              compileDecls (logErrors := logCompileErrors) #[name]
-            enableRealizationsForConst name
-            return wrapped
-        else
+    let wrapInst := do
+      trace[Meta.wrapInstance] "did not reduce to constructor application, returning/wrapping as is: {inst}"
+      if backward.inferInstanceAs.wrap.instances.get (← getOptions) then
+        let instType ← inferType inst
+        if ← isDefEq expectedType instType then
           return inst
-    let (mvars, _, cls) ← forallMetaTelescope (← inferType f)
+        else
+          let name ← mkAuxDeclName
+          let wrapped ← mkAuxDefinition name expectedType inst (compile := false)
+          setReducibilityStatus name .implicitReducible
+          if isMeta then modifyEnv (markMeta · name)
+          if compile then
+            compileDecls (logErrors := logCompileErrors) #[name]
+          enableRealizationsForConst name
+          return wrapped
+      else
+        return inst
+    let .const ctorName _ := f | wrapInst
+    let .ctorInfo ci ← getConstInfo ctorName | wrapInst
+    let ctor ← mkConstWithFreshMVarLevels ctorName
+    let (mvars, _, cls) ← forallMetaTelescope (← inferType ctor)
     if h₁ : args.size ≠ mvars.size then
       throwError "wrapInstance: incorrect number of arguments for \
         constructor application `{f}`: {args}"
@@ -240,4 +242,4 @@ public partial def wrapInstance (inst expectedType : Expr) (compile : Bool := tr
             enableRealizationsForConst name
         else
           mvarId.assign arg
-      return mkAppN f (← mvars.mapM instantiateMVars)
+      instantiateMVars (mkAppN ctor mvars)

--- a/tests/elab/inferInstanceAs.lean
+++ b/tests/elab/inferInstanceAs.lean
@@ -91,3 +91,13 @@ instance (x y : BitVec w) : Decidable (LE.le x y) :=
 
 instance (x y : BitVec w) : Decidable (LE.le x y) :=
   inferInstanceAs (Decidable (LE.le x.toNat y.toNat))
+
+/-! Universe test -/
+
+structure MyStruct where
+  x : PUnit.{u + 1} := ⟨⟩
+  y : PUnit.{v + 1} := ⟨⟩
+
+instance : Zero MyStruct.{u, max u v} := ⟨{}⟩
+
+instance : Zero MyStruct.{u, max u v} := inferInstanceAs <| Zero MyStruct.{u, max u v}


### PR DESCRIPTION
This PR fixes the universe handling in `inferInstanceAs`. The problem is that `inferInstance` may create postponed universe constraints. By using `allowLevelAssignments := true`, unification doesn't fail due to these universe metavariables.

