### PR TITLE
fix: prevent a hang in acLt

### DIFF
--- a/src/Lean/Meta/ACLt.lean
+++ b/src/Lean/Meta/ACLt.lean
@@ -175,6 +175,7 @@ where
     return !(← allChildrenLt a b)
 
   lpo (a b : Expr) : MetaM Bool := do
+    checkSystem "Lean.Meta.acLt"
     -- Case 1: `a < b` if for some child `b_i` of `b`, we have `b_i >= a`
     if (← someChildGe b a) then
       return true

--- a/tests/elab/acLt_timeout.lean
+++ b/tests/elab/acLt_timeout.lean
@@ -1,0 +1,17 @@
+axiom sumRange (n : Nat) (f : Nat → Nat) : Nat
+axiom sumRange_add (m n) (f : Nat → Nat) :
+  sumRange (m + n) f = sumRange m f + sumRange n (f <| m + ·)
+
+/--
+error: Tactic `simp` failed with a nested error:
+(deterministic) timeout at `«Lean.Meta.acLt»`, maximum number of heartbeats (200000) has been reached
+
+Note: Use `set_option maxHeartbeats <num>` to set the limit.
+
+Hint: Additional diagnostic information may be available using the `set_option diagnostics true` command.
+-/
+#guard_msgs in
+example (k : Nat) (a : Fin (1 + k + 1) → Nat) :
+    0 ≤ sumRange (1 + k + 1) (fun i =>
+        if h : i < 1 + k + 1 then a ⟨i, h⟩ else 0) := by
+  simp only [Nat.add_comm, sumRange_add]


### PR DESCRIPTION
This PR removes some cases where `simp` would significantly overrun a timeout.

This is a little tricky to test cleanly; using mathlib's `#count_heartbeats` as
```lean4
#count_heartbeats in
set_option maxHeartbeats 200000 in
example (k : Nat) (a : Fin (1 + k + 1) → Nat) :
    0 ≤ sumRange (1 + k + 1) (fun i =>
        if h : i < 1 + k + 1 then a ⟨i, h⟩ else 0) := by
  simp only [Nat.add_comm, sumRange_add]
```
I see 200010 heartbeats with this PR, and 1873870 (9x the requested limit) without.

This type of failure is wasteful in AI systems which try tactics with a short timeout.