### PR TITLE
fix: generate `SizeOf` spec theorems for inductives with private constructors

### DIFF
--- a/src/Lean/Meta/SizeOf.lean
+++ b/src/Lean/Meta/SizeOf.lean
@@ -451,16 +451,18 @@ private def mkSizeOfSpecTheorem (indInfo : InductiveVal) (sizeOfFns : Array Name
       let thmType ← mkForallFVars thmParams target
       trace[Meta.sizeOf] "sizeOf spec theorem name: {thmName}"
       trace[Meta.sizeOf] "sizeOf spec theorem type: {thmType}"
-      let thmValue ← if indInfo.isNested then
-        SizeOfSpecNested.main lhs rhs |>.run {
-          indInfo, sizeOfFns, ctorName, params, localInsts, recMap
-        }
-      else
-        mkEqRefl rhs
-      let thmValue ← mkLambdaFVars thmParams thmValue
-      trace[Meta.sizeOf] "sizeOf spec theorem value: {thmValue}"
-      unless (← isDefEq (← inferType thmValue) thmType) do
-        throwError "type mismatch"
+      let thmValue ← withoutExporting do
+        let thmValue ← if indInfo.isNested then
+          SizeOfSpecNested.main lhs rhs |>.run {
+            indInfo, sizeOfFns, ctorName, params, localInsts, recMap
+          }
+        else
+          mkEqRefl rhs
+        let thmValue ← mkLambdaFVars thmParams thmValue
+        trace[Meta.sizeOf] "sizeOf spec theorem value: {thmValue}"
+        unless (← isDefEq (← inferType thmValue) thmType) do
+          throwError "type mismatch"
+        pure thmValue
       addDecl <| Declaration.thmDecl {
         name        := thmName
         levelParams := ctorInfo.levelParams

--- a/tests/elab/issue13373.lean
+++ b/tests/elab/issue13373.lean
@@ -1,0 +1,10 @@
+module
+
+-- Issue #13373: SizeOf derivation fails for public inductive with private constructor
+public inductive Tag where
+  | provided
+  | private external
+
+/-- info: Tag.provided.sizeOf_spec : sizeOf Tag.provided = 1 -/
+#guard_msgs in
+#check @Tag.provided.sizeOf_spec


### PR DESCRIPTION
This PR fixes `SizeOf` instance generation for public inductive types that have
private constructors. The spec theorem proof construction needs to unfold
`_sizeOf` helper functions which may not be exposed in the public view, so
we use `withoutExporting` for the proof construction and type check.

Closes #13373