### PR TITLE
perf: pre-reserve `replace_rec_fn` cache to avoid early rehashing

### DIFF
--- a/src/kernel/replace_fn.cpp
+++ b/src/kernel/replace_fn.cpp
@@ -75,7 +75,9 @@ class replace_rec_fn {
     }
 public:
     template<typename F>
-    replace_rec_fn(F const & f, bool use_cache):m_f(f), m_use_cache(use_cache) {}
+    replace_rec_fn(F const & f, bool use_cache):m_f(f), m_use_cache(use_cache) {
+        if (use_cache) m_cache.reserve(128);
+    }
 
     expr operator()(expr const & e) { return apply(e, 0); }
 };


### PR DESCRIPTION
This PR pre-reserves 128 buckets in the `replace_rec_fn` cache when caching is enabled. The default `std::unordered_map` starts very small and rehashes several times during a typical traversal, and the resulting bucket-array churn dominated cache-miss stalls in the hot kernel traversal. Reserving up front shaves another ~4% off the wall-clock of `leanchecker --fresh Init.Data.List.Lemmas` on top of the previous `try_emplace` change, for a combined ~8% wall-clock improvement (with a small ~1.5% increase in retired instructions that is more than offset by the improved IPC).