### PR TITLE
refactor: use Nat.decEq in derived BEq instances

### DIFF
--- a/src/Lean/Elab/Deriving/BEq.lean
+++ b/src/Lean/Elab/Deriving/BEq.lean
@@ -172,7 +172,7 @@ def mkMatchNew (header : Header) (indVal : InductiveVal) (auxFunName : Name) : T
   if indVal.numCtors == 1 then
     `( $(mkCIdent casesOnSameCtorName) $x1:term $x2:term rfl $alts:term* )
   else
-    `( match decEq ($(mkCIdent ctorIdxName) $x1:ident) ($(mkCIdent ctorIdxName) $x2:ident) with
+    `( match Nat.decEq ($(mkCIdent ctorIdxName) $x1:ident) ($(mkCIdent ctorIdxName) $x2:ident) with
       | .isTrue h => $(mkCIdent casesOnSameCtorName) $x1:term $x2:term h $alts:term*
       | .isFalse _ => false)
 

--- a/tests/elab/derivingBEqLinear.lean
+++ b/tests/elab/derivingBEqLinear.lean
@@ -35,7 +35,7 @@ inductive L (α : Type u) : Type u
 /--
 info: instBEqL.beq_spec.{u_1} {α✝ : Type u_1} [BEq α✝] (x✝ x✝¹ : L α✝) :
   (x✝ == x✝¹) =
-    match decEq x✝.ctorIdx x✝¹.ctorIdx with
+    match x✝.ctorIdx.decEq x✝¹.ctorIdx with
     | isTrue h =>
       match x✝, x✝¹, h with
       | L.nil, L.nil, ⋯ => true
@@ -66,7 +66,7 @@ info: @[implicit_reducible, expose] def InNamespace.instBEqL'.{u_1} : {α : Type
 /--
 info: theorem InNamespace.instBEqL'.beq_spec.{u_1} : ∀ {α : Type u_1} [inst : BEq α] (x x_1 : InNamespace.L' α),
   (x == x_1) =
-    match decEq x.ctorIdx x_1.ctorIdx with
+    match x.ctorIdx.decEq x_1.ctorIdx with
     | isTrue h =>
       match x, x_1, h with
       | InNamespace.L'.nil, InNamespace.L'.nil, ⋯ => true
@@ -83,7 +83,7 @@ inductive Vec (α : Type u) : Nat → Type u
 /--
 info: instBEqVec.beq_spec.{u_1} {α✝ : Type u_1} {a✝ : Nat} [BEq α✝] (x✝ x✝¹ : Vec α✝ a✝) :
   (x✝ == x✝¹) =
-    match decEq x✝.ctorIdx x✝¹.ctorIdx with
+    match x✝.ctorIdx.decEq x✝¹.ctorIdx with
     | isTrue h =>
       match a✝, x✝, x✝¹ with
       | 0, Vec.nil, Vec.nil, ⋯ => true

--- a/tests/elab/reduceBEqSimproc.lean
+++ b/tests/elab/reduceBEqSimproc.lean
@@ -30,7 +30,7 @@ deriving BEq
 /--
 info: Linear.instBEqL.beq.eq_1.{u_1} {α✝ : Type u_1} [BEq α✝] (x✝ x✝¹ : L α✝) :
   instBEqL.beq x✝ x✝¹ =
-    match decEq x✝.ctorIdx x✝¹.ctorIdx with
+    match x✝.ctorIdx.decEq x✝¹.ctorIdx with
     | isTrue h =>
       match x✝, x✝¹, h with
       | L.nil, L.nil, ⋯ => true


### PR DESCRIPTION
This PR changes the linear BEq derivation strategy to use `Nat.decEq` instead of `decEq` when comparing constructor indices. Since constructor indices are always `Nat`, using `Nat.decEq` directly is more appropriate because it is `@[reducible]`, whereas the generic `decEq` is only semireducible and does not unfold at `.reducible` transparency. This makes the generated code more transparent-friendly.