### PR TITLE
fix: add term info for `for` loop variables in new do elaborator

### DIFF
--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -153,6 +153,9 @@ open Lean.Meta
 
   let body ←
     withLocalDeclsD xh fun xh => do
+    Term.addLocalVarInfo x xh[0]!
+    if let some h := h? then
+      Term.addLocalVarInfo h xh[1]!
     withLocalDecl s .default σ (kind := .implDetail) fun loopS => do
     mkLambdaFVars (xh.push loopS) <| ← do
     bindMutVarsFromTuple loopMutVarNames loopS.fvarId! do

--- a/tests/server_interactive/hoverDoForIn.lean
+++ b/tests/server_interactive/hoverDoForIn.lean
@@ -1,0 +1,7 @@
+set_option backward.do.legacy false
+
+def test : IO Unit := do
+  for h : i in [1, 2, 3] do
+    --^ textDocument/hover
+        --^ textDocument/hover
+    pure ()

--- a/tests/server_interactive/hoverDoForIn.lean.out.expected
+++ b/tests/server_interactive/hoverDoForIn.lean.out.expected
@@ -1,0 +1,10 @@
+{"textDocument": {"uri": "file:///hoverDoForIn.lean"},
+ "position": {"line": 3, "character": 6}}
+{"range":
+ {"start": {"line": 3, "character": 6}, "end": {"line": 3, "character": 7}},
+ "contents": {"value": "```lean\nh : i ∈ [1, 2, 3]\n```", "kind": "markdown"}}
+{"textDocument": {"uri": "file:///hoverDoForIn.lean"},
+ "position": {"line": 3, "character": 10}}
+{"range":
+ {"start": {"line": 3, "character": 10}, "end": {"line": 3, "character": 11}},
+ "contents": {"value": "```lean\ni : Nat\n```", "kind": "markdown"}}


### PR DESCRIPTION
This PR fixes #12827, where hovering over `for` loop variables `x` and `h` in `for h : x in xs do` showed no type information in the new do elaborator. The fix adds `Term.addLocalVarInfo` calls for the loop variable and membership proof binder after they are introduced by `withLocalDeclsD` in `elabDoFor`.

Closes #12827