### PR TITLE
fix: correct name for `String.Pos.le_skipWhile`

### DIFF
--- a/src/Init/Data/String/Lemmas/Pattern/TakeDrop/Basic.lean
+++ b/src/Init/Data/String/Lemmas/Pattern/TakeDrop/Basic.lean
@@ -909,7 +909,7 @@ theorem Slice.Pos.skipWhile_copy {ρ : Type} {pat : ρ} [ForwardPattern pat] [Pa
   simp
 
 @[simp]
-theorem Pos.skipWhile_le {ρ : Type} {pat : ρ} [ForwardPattern pat] [PatternModel pat]
+theorem Pos.le_skipWhile {ρ : Type} {pat : ρ} [ForwardPattern pat] [PatternModel pat]
     [LawfulForwardPatternModel pat] {s : String} {pos : s.Pos} : pos ≤ pos.skipWhile pat := by
   simp [skipWhile_eq_skipWhile_toSlice, Pos.le_ofToSlice_iff]
 


### PR DESCRIPTION
This PR fixes the incorrect name `String.Pos.skipWhile_le` to be `String.Pos.le_skipWhile`.

No deprecation since this is not in any release yet (also no release candidate). `String.Slice.Pos.le_skipWhile` is correct, as are the `revSkipWhile` counterparts.