### PR TITLE
feat: add internal `skip` do-element parser

### DIFF
--- a/src/Lean/Parser/Do.lean
+++ b/src/Lean/Parser/Do.lean
@@ -66,6 +66,14 @@ def notFollowedByRedefinedTermToken :=
       "do" <|> "dbg_trace" <|> "idbg" <|> "assert!" <|> "debug_assert!" <|> "for" <|> "unless" <|> "return" <|> symbol "try")
     "token at 'do' element"
 
+namespace InternalSyntax
+/--
+Internal syntax used in the `if` and `unless` elaborators. Behaves like `pure PUnit.unit` but
+uses `()` if possible and gives better error messages.
+-/
+scoped syntax (name := doSkip) "skip" : doElem
+end InternalSyntax
+
 @[builtin_doElem_parser] def doLet      := leading_parser
   "let " >> optional "mut " >> letConfig >> letDecl
 @[builtin_doElem_parser] def doLetElse  := leading_parser withPosition <|

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -20,7 +20,7 @@ options get_default_options() {
     // changes to builtin parsers may also require toggling the following option if macros/syntax
     // with custom precheck hooks were affected
     opts = opts.update({"quotPrecheck"}, true);
-
+    // trigger stage0 update for doSkip parser addition
     opts = opts.update({"pp", "rawOnError"}, true);
 
     // Temporary, core-only flags for editing (i.e. must be part of stage0/bin/lean). Must be synced


### PR DESCRIPTION
This PR adds an internal `skip` syntax for do blocks, intended for use by the `if` and `unless` elaborators to replace `pure PUnit.unit` in implicit else branches. This gives the elaborator a dedicated syntax node to attach better error messages and location info to, rather than synthesizing `pure PUnit.unit` which leaks internal details into user-facing errors.

Includes a stage0 trigger comment so that the new parser is available during bootstrapping.