### PR TITLE
fix: ensure type/value compatibility in `mkValueTypeClosure`

### DIFF
--- a/src/Lean/Meta/Closure.lean
+++ b/src/Lean/Meta/Closure.lean
@@ -345,6 +345,11 @@ structure MkValueTypeClosureResult where
 
 def mkValueTypeClosureAux (type : Expr) (value : Expr) : ClosureM (Expr × Expr) := do
   withTrackingZetaDelta do
+    if !(← read).zetaDelta then
+      withTransparency .all do
+        let inferred ← inferType value
+        unless ← isDefEq type inferred do
+          throwError m!"{value} {← mkHasTypeButIsExpectedMsg inferred type}"
     let type  ← collectExpr type
     let value ← collectExpr value
     process

--- a/src/Lean/Meta/WrapInstance.lean
+++ b/src/Lean/Meta/WrapInstance.lean
@@ -159,7 +159,7 @@ public partial def wrapInstance (inst expectedType : Expr) (compile : Bool := tr
             return inst
           else
             let name ← mkAuxDeclName
-            let wrapped ← mkAuxDefinition name expectedType inst (compile := false)
+            let wrapped ← mkAuxDefinition name expectedType inst (zetaDelta := true) (compile := false)
             setReducibilityStatus name .implicitReducible
             if isMeta then modifyEnv (markMeta · name)
             if compile then
@@ -232,7 +232,7 @@ public partial def wrapInstance (inst expectedType : Expr) (compile : Bool := tr
             mvarId.assign arg
           else
             let name ← mkAuxDeclName
-            mvarId.assign (← mkAuxDefinition name argExpectedType arg (compile := false))
+            mvarId.assign (← mkAuxDefinition name argExpectedType arg (zetaDelta := true) (compile := false))
             setInlineAttribute name
             if isMeta then modifyEnv (markMeta · name)
             if compile then

--- a/src/Lean/Meta/WrapInstance.lean
+++ b/src/Lean/Meta/WrapInstance.lean
@@ -159,7 +159,7 @@ public partial def wrapInstance (inst expectedType : Expr) (compile : Bool := tr
             return inst
           else
             let name ← mkAuxDeclName
-            let wrapped ← mkAuxDefinition name expectedType inst (zetaDelta := true) (compile := false)
+            let wrapped ← mkAuxDefinition name expectedType inst (compile := false)
             setReducibilityStatus name .implicitReducible
             if isMeta then modifyEnv (markMeta · name)
             if compile then
@@ -232,7 +232,7 @@ public partial def wrapInstance (inst expectedType : Expr) (compile : Bool := tr
             mvarId.assign arg
           else
             let name ← mkAuxDeclName
-            mvarId.assign (← mkAuxDefinition name argExpectedType arg (zetaDelta := true) (compile := false))
+            mvarId.assign (← mkAuxDefinition name argExpectedType arg (compile := false))
             setInlineAttribute name
             if isMeta then modifyEnv (markMeta · name)
             if compile then

--- a/tests/elab/inferInstanceAs.lean
+++ b/tests/elab/inferInstanceAs.lean
@@ -76,6 +76,13 @@ deriving Foo, Bar, FooBar
 theorem zou : instFooBarMyNat.toBar = instBarMyNat := by
   with_reducible_and_instances rfl
 
+/-! `inferInstanceAs` works when the result type depends on a let declaration (see #13408) -/
+
+example : True := by
+  let E : Type := id Nat
+  let hE : Inhabited E := inferInstanceAs (Inhabited Nat)
+  trivial
+
 /-! Non-constructor instances should be used as is. -/
 
 @[macro_inline, implicit_reducible]
@@ -91,10 +98,3 @@ instance (x y : BitVec w) : Decidable (LE.le x y) :=
 
 instance (x y : BitVec w) : Decidable (LE.le x y) :=
   inferInstanceAs (Decidable (LE.le x.toNat y.toNat))
-
-/-! `inferInstanceAs` works when the result type depends on a let declaration (see #13408) -/
-
-example : True := by
-  let E : Type := id Nat
-  let hE : Inhabited E := inferInstanceAs (Inhabited Nat)
-  trivial

--- a/tests/elab/inferInstanceAs.lean
+++ b/tests/elab/inferInstanceAs.lean
@@ -91,3 +91,10 @@ instance (x y : BitVec w) : Decidable (LE.le x y) :=
 
 instance (x y : BitVec w) : Decidable (LE.le x y) :=
   inferInstanceAs (Decidable (LE.le x.toNat y.toNat))
+
+/-! `inferInstanceAs` works when the result type depends on a let declaration (see #13408) -/
+
+example : True := by
+  let E : Type := id Nat
+  let hE : Inhabited E := inferInstanceAs (Inhabited Nat)
+  trivial


### PR DESCRIPTION
This PR fixes `mkValueTypeClosure` to ensure that the type of `value` is definitionally equivalent to `type` to make sure that it doesn't erroneously convert a let declaration into a regular declaration when the result type depends on a let declaration. This also affects `inferInstanceAs`, removing kernel errors when the result type depends on a let declaration.

Closes #13408