### PR TITLE
feat: lake: `JobAction.reuse` & `.unpack`

### DIFF
--- a/src/lake/Lake/Build/Common.lean
+++ b/src/lake/Lake/Build/Common.lean
@@ -235,7 +235,7 @@ public def checkHashUpToDate
 : JobM Bool := (·.isUpToDate) <$> checkHashUpToDate' info depTrace depHash oldTrace
 
 /--
-**Ror internal use only.**
+**For internal use only.**
 Checks whether `info` is up-to-date with the trace.
 If so, replays the log of the trace if available.
 -/
@@ -271,19 +271,23 @@ Returns `true` if the saved trace exists and its hash matches `inputHash`.
 
 If up-to-date, replays the saved log from the trace and sets the current
 build action to `replay`. Otherwise, if the log is empty and trace is synthetic,
-or if the trace is not up-to-date, the build action will be set to `fetch`.
+or if the trace is not up-to-date, the build action will be set to `reuse`.
 -/
-public def SavedTrace.replayOrFetchIfUpToDate (inputHash : Hash) (self : SavedTrace) : JobM Bool := do
+public def SavedTrace.replayCachedIfUpToDate (inputHash : Hash) (self : SavedTrace) : JobM Bool := do
   if let .ok data := self then
     if data.depHash == inputHash then
       if data.synthetic && data.log.isEmpty then
-        updateAction .fetch
+        updateAction .reuse
       else
         updateAction .replay
         data.log.replay
       return true
-  updateAction .fetch
+  updateAction .reuse
   return false
+
+@[deprecated replayCachedIfUpToDate (since := "2026-04-15")]
+public abbrev SavedTrace.replayOrFetchIfUpToDate (inputHash : Hash) (self : SavedTrace) : JobM Bool := do
+  self.replayCachedIfUpToDate inputHash
 
 /-- **For internal use only.** -/
 public class ToOutputJson (α : Type u) where
@@ -684,7 +688,7 @@ public def buildArtifactUnlessUpToDate
     let fetchArt? restore := do
       let some (art : XArtifact exe) ← getArtifacts? inputHash savedTrace pkg
         | return none
-      unless (← savedTrace.replayOrFetchIfUpToDate inputHash) do
+      unless (← savedTrace.replayCachedIfUpToDate inputHash) do
         removeFileIfExists file
         writeFetchTrace traceFile inputHash (toJson art.descr)
       if restore then

--- a/src/lake/Lake/Build/Job/Basic.lean
+++ b/src/lake/Lake/Build/Job/Basic.lean
@@ -29,11 +29,18 @@ namespace Lake
 public inductive JobAction
 /-- No information about this job's action is available. -/
 | unknown
-/-- Tried to replay a cached build action (set by `buildFileUnlessUpToDate`) -/
+/-- Tried to reuse a cached build (e.g., can be set by `replayCachedIfUpToDate`). -/
+| reuse
+/-- Tried to replay a completed build action (e.g., can be set by `replayIfUpToDate`). -/
 | replay
-/-- Tried to fetch a build from a store (can be set by `buildUnlessUpToDate?`) -/
+/-- Tried to unpack a build from an archive (e.g., unpacking a module `ltar`). -/
+| unpack
+/--
+Tried to fetch a build from a remote store (e.g., set when downloading an artifact
+on-demand from a cache service in `buildArtifactUnlessUpToDate`).
+-/
 | fetch
-/-- Tried to perform a build action (set by `buildUnlessUpToDate?`) -/
+/-- Tried to perform a build action (e.g., set by `buildAction`). -/
 | build
 deriving Inhabited, Repr, DecidableEq, Ord
 
@@ -45,11 +52,13 @@ public instance : Min JobAction := minOfLe
 public instance : Max JobAction := maxOfLe
 
 public def merge (a b : JobAction) : JobAction :=
-  max a b
+  max a b -- inlines `max`
 
-public def verb (failed : Bool) : JobAction → String
+public def verb (failed : Bool) : (self : JobAction) → String
 | .unknown => if failed then "Running" else "Ran"
+| .reuse => if failed then "Reusing" else "Reused"
 | .replay => if failed then "Replaying" else "Replayed"
+| .unpack => if failed then "Unpacking" else "Unpacked"
 | .fetch => if failed then "Fetching" else "Fetched"
 | .build => if failed then "Building" else "Built"
 

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -900,8 +900,9 @@ where
     let inputHash := (← getTrace).hash
     let some ltarOrArts ← getArtifacts? inputHash savedTrace mod.pkg
       | return .inr savedTrace
-    match (ltarOrArts : ModuleOutputs)  with
+    match (ltarOrArts : ModuleOutputs) with
     | .ltar ltar =>
+      updateAction .unpack
       mod.clearOutputArtifacts
       mod.unpackLtar ltar.path
       -- Note: This branch implies that only the ltar output is (validly) cached.
@@ -919,7 +920,7 @@ where
       else
         return .inr savedTrace
     | .arts arts =>
-      unless (← savedTrace.replayOrFetchIfUpToDate inputHash) do
+      unless (← savedTrace.replayCachedIfUpToDate inputHash) do
         mod.clearOutputArtifacts
         writeFetchTrace mod.traceFile inputHash (toJson arts.descrs)
       let arts ←

--- a/src/lake/Lake/Build/Package.lean
+++ b/src/lake/Lake/Build/Package.lean
@@ -153,7 +153,7 @@ private def Package.fetchBuildArchive
   let upToDate ← buildUnlessUpToDate? (action := .fetch) archiveFile depTrace traceFile do
     download url archiveFile headers
   unless upToDate && (← self.buildDir.pathExists) do
-    updateAction .fetch
+    updateAction .unpack
     untar archiveFile self.buildDir
 
 @[inline]

--- a/src/lake/Lake/Build/Run.lean
+++ b/src/lake/Lake/Build/Run.lean
@@ -210,7 +210,7 @@ def mkMonitorContext (cfg : BuildConfig) (jobs : JobQueue) : BaseIO MonitorConte
   let failLv := cfg.failLv
   let isVerbose := cfg.verbosity = .verbose
   let showProgress := cfg.showProgress
-  let minAction := if isVerbose then .unknown else .fetch
+  let minAction := if isVerbose then .unknown else .unpack
   let showOptional := isVerbose
   let showTime := isVerbose || !useAnsi
   let updateFrequency := 100

--- a/tests/lake/tests/cache/test.sh
+++ b/tests/lake/tests/cache/test.sh
@@ -102,16 +102,16 @@ test_run exe test
 touch Ignored.lean
 test_run -v build +Ignored
 
-# Verify that fetching from the cache can be disabled
+# Verify that using the cache can be disabled
 test_cmd rm -f .lake/build/lib/lean/Ignored.trace
 test_status $NO_BUILD_CODE -v -f disabled.toml build +Ignored --no-build
 LAKE_ARTIFACT_CACHE=false test_status $NO_BUILD_CODE -v \
   -f unset.toml build +Ignored --no-build
 
-# Verify that fetching from the cache creates a trace file that does not replay
-test_out "Fetched Ignored" -v build +Ignored
+# Verify that using the cache creates a trace file that does not replay
+test_out "Reused Ignored" -v build +Ignored
 test_exp -f .lake/build/lib/lean/Ignored.trace
-test_out "Fetched Ignored" -v build +Ignored
+test_out "Reused Ignored" -v build +Ignored
 
 # Verify that modifications invalidate the cache
 echo "def foo := ()" > Ignored.lean
@@ -162,7 +162,7 @@ check_diff .lake/backup-outputs.txt <(ls "$CACHE_DIR/outputs")
 test_cmd rm -f "$local_art"
 test_out "Replayed Test:c.o" build +Test:o -v --no-build
 test_cmd rm -f "$local_art.trace"
-test_out "Fetched Test:c.o" build +Test:o -v --no-build
+test_out "Reused Test:c.o" build +Test:o -v --no-build
 
 # Verify that if the input cache is missing,
 # the cached artifact is still used via the output hash in the trace


### PR DESCRIPTION
This PR adds `JobAction.reuse` and `JobAction.unpack` which provide more information captions for what a job is doing for the build monitor. `reuse` is set when using an artifact from the Lake cache, `unpack` is set when unpacking module `.ltar` archives and release (Reservoir or GitHub) archives.