### PR TITLE
feat: add `Lean.doRepeat` elaborators for `repeat`/`while` loops

### DIFF
--- a/src/Init/While.lean
+++ b/src/Init/While.lean
@@ -32,7 +32,7 @@ partial def Loop.forIn {β : Type u} {m : Type u → Type v} [Monad m] (_ : Loop
 instance [Monad m] : ForIn m Loop Unit where
   forIn := Loop.forIn
 
-syntax "repeat " doSeq : doElem
+syntax (name := doRepeat) "repeat " doSeq : doElem
 
 macro_rules
   | `(doElem| repeat%$tk $seq) => `(doElem| for%$tk _ in Loop.mk do $seq)

--- a/src/Lean/Elab/BuiltinDo.lean
+++ b/src/Lean/Elab/BuiltinDo.lean
@@ -15,3 +15,4 @@ public import Lean.Elab.BuiltinDo.Jump
 public import Lean.Elab.BuiltinDo.Misc
 public import Lean.Elab.BuiltinDo.For
 public import Lean.Elab.BuiltinDo.TryCatch
+public import Lean.Elab.BuiltinDo.Repeat

--- a/src/Lean/Elab/BuiltinDo/Repeat.lean
+++ b/src/Lean/Elab/BuiltinDo/Repeat.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Graf
+-/
+module
+
+prelude
+public import Lean.Elab.BuiltinDo.Basic
+meta import Lean.Parser.Do
+import Lean.Elab.BuiltinDo.For
+
+public section
+
+namespace Lean.Elab.Do
+
+open Lean.Parser.Term
+
+/--
+Builtin do-element elaborator for `repeat` (syntax kind `Lean.doRepeat`).
+
+Expands to `for _ in Loop.mk do ...`. A follow-up PR will drop the fallback macro
+in `Init.While` (which currently preempts this elaborator) and extend this
+elaborator to choose between `Loop.mk` and a well-founded `Repeat.mk` based on a
+configuration option.
+-/
+@[builtin_doElem_elab Lean.doRepeat] def elabDoRepeat : DoElab := fun stx dec => do
+  let `(doElem| repeat $seq) := stx | throwUnsupportedSyntax
+  let expanded ← `(doElem| for _ in Loop.mk do $seq)
+  Term.withMacroExpansion stx expanded <|
+    withRef expanded <| elabDoElem ⟨expanded⟩ dec
+
+end Lean.Elab.Do

--- a/src/Lean/Elab/Do/Legacy.lean
+++ b/src/Lean/Elab/Do/Legacy.lean
@@ -1782,6 +1782,10 @@ mutual
             doIfToCode doElem doElems
           else if k == ``Parser.Term.doUnless then
             doUnlessToCode doElem doElems
+          else if k == `Lean.doRepeat then
+            let seq := doElem[1]
+            let expanded ← `(doElem| for _ in Loop.mk do $seq)
+            doSeqToCode (expanded :: doElems)
           else if k == ``Parser.Term.doFor then withFreshMacroScope do
             doForToCode doElem doElems
           else if k == ``Parser.Term.doMatch then

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -20,7 +20,8 @@ options get_default_options() {
     // changes to builtin parsers may also require toggling the following option if macros/syntax
     // with custom precheck hooks were affected
     opts = opts.update({"quotPrecheck"}, true);
-
+    // trigger stage0 update so a follow-up PR can drop the `Init.While` fallback
+    // macro and let the new `Lean.doRepeat` elaborators take over
     opts = opts.update({"pp", "rawOnError"}, true);
 
     // Temporary, core-only flags for editing (i.e. must be part of stage0/bin/lean). Must be synced


### PR DESCRIPTION
This PR names the `repeat` syntax (`doRepeat`) and installs dedicated elaborators for it in both the legacy and new do-elaborators. Both currently expand to `for _ in Loop.mk do ...`, identical to the existing fallback macro in `Init.While`.

The elaborators are dead code today because that fallback macro fires first. A follow-up PR will drop the macro (after this PR's stage0 update lands) and extend `elabDoRepeat` to choose between `Loop.mk` and a well-founded `Repeat.mk` based on a `backward.do.while` option.