### PR TITLE
fix: handling of EmitC for small hex string literals

### DIFF
--- a/src/Lean/Compiler/LCNF/EmitC.lean
+++ b/src/Lean/Compiler/LCNF/EmitC.lean
@@ -207,7 +207,7 @@ def emitLns [EmitToString α] (as : List α) : EmitM Unit :=
   emitLn "}"
   return ret
 
-def toHexDigit (c : Nat) : String :=
+def toDigit (c : Nat) : String :=
   String.singleton c.digitChar
 
 def quoteString (s : String) : String :=
@@ -221,7 +221,11 @@ def quoteString (s : String) : String :=
       else if c == '\"' then "\\\""
       else if c == '?' then "\\?" -- avoid trigraphs
       else if c.toNat <= 31 then
-        "\\x" ++ toHexDigit (c.toNat / 16) ++ toHexDigit (c.toNat % 16)
+        -- Use octal escapes instead of hex escapes because C hex escapes are
+        -- greedy: "\x01abc" would be parsed as the single escape \x01abc rather
+        -- than \x01 followed by "abc".  Octal escapes consume at most 3 digits.
+        let n := c.toNat
+        "\\" ++ toDigit (n / 64) ++ toDigit ((n / 8) % 8) ++ toDigit (n % 8)
       -- TODO(Leo): we should use `\unnnn` for escaping unicode characters.
       else String.singleton c)
     q;

--- a/tests/compile/char_escape.lean
+++ b/tests/compile/char_escape.lean
@@ -1,0 +1,12 @@
+module
+
+def badString : String := "\x01abc"
+
+public def main : IO Unit := do
+  IO.println s!"length   = {badString.length}"
+  IO.println s!"utf8Size = {badString.utf8ByteSize}"
+  let ba := badString.toUTF8
+  IO.println s!"toUTF8.size = {ba.size}"
+  IO.print "bytes:"
+  for i in 0...ba.size do IO.print s!" {ba[i]!}"
+  IO.println ""

--- a/tests/compile/char_escape.lean.out.expected
+++ b/tests/compile/char_escape.lean.out.expected
@@ -1,0 +1,4 @@
+length   = 4
+utf8Size = 4
+toUTF8.size = 4
+bytes: 1 97 98 99


### PR DESCRIPTION
This PR fixes a bug in EmitC that can be caused by working with the string literal `"\x01abc"` in
Lean and causes a C compiler error.

The error is as follows:
```
run.c:29:189: error: hex escape sequence out of range
   29 | static const lean_string_object l_badString___closed__0_value = {.m_header = {.m_rc = 0, .m_cs_sz = 0, .m_other = 0, .m_tag = 249}, .m_size = 5, .m_capacity = 5, .m_length = 4, .m_data = "\x01abc"};
      |                                                                                                                                                                                             ^~~~~~~
1 error generated.
```
This happens as hex escape sequences can be arbitrarily long while lean expects them to cut off
after two chars. Thus, the C compiler parses the string as one large hex escape sequence `01abc` and
subsequently notices this is too large.

Discovered by @datokrat
