### PR TITLE
feat: add ControlInfo handler for `doRepeat`

### DIFF
--- a/src/Lean/Elab/Do/InferControlInfo.lean
+++ b/src/Lean/Elab/Do/InferControlInfo.lean
@@ -129,10 +129,18 @@ partial def ofElem (stx : TSyntax `doElem) : TermElabM ControlInfo := do
     return thenInfo.alternative info
   | `(doElem| unless $_ do $elseSeq) =>
     ControlInfo.alternative {} <$> ofSeq elseSeq
+  -- For/Repeat
   | `(doElem| for $[$[$_ :]? $_ in $_],* do $bodySeq) =>
     let info ← ofSeq bodySeq
     return { info with  -- keep only reassigns and earlyReturn
       numRegularExits := 1,
+      continues := false,
+      breaks := false
+    }
+  | `(doRepeat| repeat $bodySeq) =>
+    let info ← ofSeq bodySeq
+    return { info with
+      numRegularExits := if info.breaks then 1 else 0,
       continues := false,
       breaks := false
     }

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,5 +1,6 @@
 #include "util/options.h"
 
+// bump for ControlInfo handler
 namespace lean {
 options get_default_options() {
     options opts;


### PR DESCRIPTION
This PR adds a builtin `doElem_control_info` handler for `doRepeat`. It is ineffective as long as we have the macro for `repeat`.