### PR TITLE
refactor: introduce `Package.depPkgs`

### DIFF
--- a/src/lake/Lake/Build/Package.lean
+++ b/src/lake/Lake/Build/Package.lean
@@ -25,12 +25,8 @@ namespace Lake
 open Lean (Name)
 
 /-- Fetch the package's direct dependencies. -/
-def Package.recFetchDeps (self : Package) : FetchM (Job (Array Package)) := ensureJob do
-  (pure ·) <$> self.depConfigs.mapM fun cfg => do
-    let some dep ← findPackageByName? cfg.name
-      | error s!"{self.prettyName}: package not found for dependency '{cfg.name}' \
-        (this is likely a bug in Lake)"
-    return dep
+def Package.recFetchDeps (self : Package) : FetchM (Job (Array Package)) := do
+  return Job.pure self.depPkgs
 
 /-- The `PackageFacetConfig` for the builtin `depsFacet`. -/
 public def Package.depsFacetConfig : PackageFacetConfig depsFacet :=
@@ -38,10 +34,7 @@ public def Package.depsFacetConfig : PackageFacetConfig depsFacet :=
 
 /-- Compute a topological ordering of the package's transitive dependencies. -/
 def Package.recComputeTransDeps (self : Package) : FetchM (Job (Array Package)) := ensureJob do
-  (pure ·.toArray) <$> self.depConfigs.foldlM (init := OrdPackageSet.empty) fun deps cfg => do
-    let some dep ← findPackageByName? cfg.name
-      | error s!"{self.prettyName}: package not found for dependency '{cfg.name}' \
-        (this is likely a bug in Lake)"
+  (pure ·.toArray) <$> self.depPkgs.foldlM (init := OrdPackageSet.empty) fun deps dep => do
     let depDeps ← (← fetch <| dep.transDeps).await
     return depDeps.foldl (·.insert ·) deps |>.insert dep
 

--- a/src/lake/Lake/Config/Package.lean
+++ b/src/lake/Lake/Config/Package.lean
@@ -52,6 +52,8 @@ public structure Package where
   remoteUrl : String
   /-- Dependency configurations for the package. -/
   depConfigs : Array Dependency := #[]
+  /-- Resolved direct dependences of the package. -/
+  depPkgs : Array Package := #[]
   /-- Target configurations in the order declared by the package. -/
   targetDecls : Array (PConfigDecl keyName) := #[]
   /-- Name-declaration map of target configurations in the package. -/

--- a/src/lake/Lake/Config/Package.lean
+++ b/src/lake/Lake/Config/Package.lean
@@ -52,7 +52,7 @@ public structure Package where
   remoteUrl : String
   /-- Dependency configurations for the package. -/
   depConfigs : Array Dependency := #[]
-  /-- Resolved direct dependences of the package. -/
+  /-- **For internal use only.** Resolved direct dependences of the package. -/
   depPkgs : Array Package := #[]
   /-- Target configurations in the order declared by the package. -/
   targetDecls : Array (PConfigDecl keyName) := #[]

--- a/src/lake/Lake/Config/Workspace.lean
+++ b/src/lake/Lake/Config/Workspace.lean
@@ -33,14 +33,12 @@ public def computeLakeCache (pkg : Package) (lakeEnv : Lake.Env) : Cache :=
     lakeEnv.lakeCache?.getD ⟨pkg.lakeDir / "cache"⟩
 
 public structure Workspace.Raw : Type where
-  /-- The root package of the workspace. -/
-  root : Package
   /-- The detected {lean}`Lake.Env` of the workspace. -/
   lakeEnv : Lake.Env
   /-- The Lake configuration from the system configuration file. -/
   lakeConfig : LoadedLakeConfig
   /-- The Lake cache. -/
-  lakeCache : Cache := private_decl% computeLakeCache root lakeEnv
+  lakeCache : Cache
   /--
   The CLI arguments Lake was run with.
   Used by {lit}`lake update` to perform a restart of Lake on a toolchain update.
@@ -59,6 +57,7 @@ public structure Workspace.Raw : Type where
   deriving Nonempty
 
 public structure Workspace.Raw.WF (ws : Workspace.Raw) : Prop where
+  size_packages_pos : 0 < ws.packages.size
   packages_wsIdx : ∀ (h : i < ws.packages.size), (ws.packages[i]'h).wsIdx = i
 
 /-- A Lake workspace -- the top-level package directory. -/
@@ -67,8 +66,13 @@ public structure Workspace extends raw : Workspace.Raw, wf : raw.WF
 public instance : Nonempty Workspace := .intro {
   lakeEnv := default
   lakeConfig := Classical.ofNonempty
-  root := Classical.ofNonempty
-  packages_wsIdx h := by simp at h
+  lakeCache := Classical.ofNonempty
+  packages := #[{(Classical.ofNonempty : Package) with wsIdx := 0}]
+  size_packages_pos := by simp
+  packages_wsIdx {i} h := by
+    cases i with
+    | zero => simp
+    | succ => simp at h
 }
 
 public hydrate_opaque_type OpaqueWorkspace Workspace
@@ -85,9 +89,13 @@ public def Package.defaultTargetRoots (self : Package) : Array Lean.Name :=
 
 namespace Workspace
 
+/-- The root package of the workspace. -/
+@[inline] public def root (self : Workspace) : Package :=
+  self.packages[0]'self.size_packages_pos
+
 /-- **For internal use.** Whether this workspace is Lean itself.  -/
-@[inline] def bootstrap (ws : Workspace) : Bool :=
-  ws.root.bootstrap
+@[inline] def bootstrap (self : Workspace) : Bool :=
+  self.root.bootstrap
 
 /-- The path to the workspace's directory (i.e., the directory of the root package). -/
 @[inline] public def dir (self : Workspace) : FilePath :=
@@ -193,6 +201,7 @@ This is configured through {lit}`cache.service` entries in the system Lake confi
   {self with
     packages := self.packages.push pkg
     packageMap := self.packageMap.insert pkg.keyName pkg
+    size_packages_pos := by simp
     packages_wsIdx {i} i_lt := by
       cases Nat.lt_add_one_iff_lt_or_eq.mp <| Array.size_push .. ▸ i_lt with
       | inl i_lt => simpa [Array.getElem_push_lt i_lt] using self.packages_wsIdx i_lt

--- a/src/lake/Lake/Config/Workspace.lean
+++ b/src/lake/Lake/Config/Workspace.lean
@@ -208,6 +208,11 @@ This is configured through {lit}`cache.service` entries in the system Lake confi
       | inr i_eq => simpa [i_eq] using h
   }
 
+/-- **For internal use only.** -/
+public theorem packages_addPackage' :
+  (addPackage' pkg ws h).packages = ws.packages.push pkg
+:= by rfl
+
 /-- Add a package to the workspace. -/
 @[inline] public def addPackage (pkg : Package) (self : Workspace) : Workspace :=
   self.addPackage' {pkg with wsIdx := self.packages.size} rfl
@@ -286,6 +291,11 @@ public def findTargetDecl? (name : Name) (self : Workspace) : Option ((pkg : Pac
 /-- Add a facet to the workspace. -/
 @[inline] public def addFacetConfig {name} (cfg : FacetConfig name) (self : Workspace) : Workspace :=
   {self with facetConfigs := self.facetConfigs.insert cfg}
+
+/-- **For internal use only.** -/
+public theorem packages_addFacetConfig :
+  (addFacetConfig cfg ws).packages = ws.packages
+:= by rfl
 
 /-- Try to find a facet configuration in the workspace with the given name. -/
 @[inline] public def findFacetConfig? (name : Name) (self : Workspace) : Option (FacetConfig name) :=

--- a/src/lake/Lake/Load/Resolve.lean
+++ b/src/lake/Lake/Load/Resolve.lean
@@ -109,15 +109,13 @@ private def Workspace.setDepPkgs
   (self : Workspace) (wsIdx : Nat) (depPkgs : Array Package)
 : Workspace := {self with
   packages := self.packages.modify wsIdx ({· with depPkgs})
+  size_packages_pos := by simp [self.size_packages_pos]
   packages_wsIdx {i} := by
     if h : wsIdx = i then
       simp [h, Array.getElem_modify_self, self.packages_wsIdx]
     else
       simp [Array.getElem_modify_of_ne h, self.packages_wsIdx]
 }
-
-@[inline] private def Workspace.resetRoot (ws : Workspace) : Workspace :=
-  {ws with root := ws.packages[ws.root.wsIdx]!}
 
 /-
 Recursively visits each node in a package's dependency graph, starting from
@@ -395,11 +393,9 @@ def Workspace.updateAndMaterializeCore
     let stop := ws.packages.size
     let ws ← ws.packages.foldlM (init := ws) (start := start) fun ws pkg =>
       ws.resolveDepsCore updateAndAddDep pkg [ws.root.baseName] leanOpts true
-    let ws := ws.setDepPkgs ws.root.wsIdx <| (start...<stop).toArray.map (ws.packages[·]!)
-    return ws.resetRoot
+    return ws.setDepPkgs ws.root.wsIdx <| (start...<stop).toArray.map (ws.packages[·]!)
   else
-    let ws ← ws.resolveDepsCore updateAndAddDep (leanOpts := leanOpts) (reconfigure := true)
-    return ws.resetRoot
+    ws.resolveDepsCore updateAndAddDep (leanOpts := leanOpts) (reconfigure := true)
 where
   @[inline] updateAndAddDep pkg dep ws := do
     let matDep ← updateAndMaterializeDep ws pkg dep
@@ -496,7 +492,7 @@ public def Workspace.materializeDeps
   if pkgEntries.isEmpty && !ws.root.depConfigs.isEmpty then
     error "missing manifest; use `lake update` to generate one"
   -- Materialize all dependencies
-  let ws ← ws.resolveDepsCore (leanOpts := leanOpts) (reconfigure := reconfigure) fun pkg dep ws => do
+  ws.resolveDepsCore (leanOpts := leanOpts) (reconfigure := reconfigure) fun pkg dep ws => do
     if let some entry := pkgEntries.find? dep.name then
       entry.materialize ws.lakeEnv ws.dir relPkgsDir
     else
@@ -510,4 +506,3 @@ public def Workspace.materializeDeps
           this suggests that the manifest is corrupt; \
           use `lake update` to generate a new, complete file \
           (warning: this will update ALL workspace dependencies)"
-  return ws.resetRoot

--- a/src/lake/Lake/Load/Resolve.lean
+++ b/src/lake/Lake/Load/Resolve.lean
@@ -15,6 +15,8 @@ import Lake.Build.Topological
 import Lake.Load.Materialize
 import Lake.Load.Lean.Eval
 import Lake.Load.Package
+import Init.Data.Range.Polymorphic.Iterators
+import Init.TacticsExtra
 
 open System Lean
 
@@ -103,6 +105,20 @@ abbrev ResolveT m := DepStackT <| StateT Workspace m
     recFetchAcyclic (·.baseName) go root
   return ws
 
+private def Workspace.setDepPkgs
+  (self : Workspace) (wsIdx : Nat) (depPkgs : Array Package)
+: Workspace := {self with
+  packages := self.packages.modify wsIdx ({· with depPkgs})
+  packages_wsIdx {i} := by
+    if h : wsIdx = i then
+      simp [h, Array.getElem_modify_self, self.packages_wsIdx]
+    else
+      simp [Array.getElem_modify_of_ne h, self.packages_wsIdx]
+}
+
+@[inline] private def Workspace.resetRoot (ws : Workspace) : Workspace :=
+  {ws with root := ws.packages[ws.root.wsIdx]!}
+
 /-
 Recursively visits each node in a package's dependency graph, starting from
 the workspace package `root`. Each dependency missing from the workspace is
@@ -124,16 +140,18 @@ where
   @[specialize] go pkg recurse : ResolveT m Unit := do
     let start := (← getWorkspace).packages.size
     -- Materialize and load the missing direct dependencies of `pkg`
-    pkg.depConfigs.forRevM fun dep => do
-      let ws ← getWorkspace
-      if ws.packages.any (·.baseName == dep.name) then
-        return -- already handled in another branch
+    let depIdxs ← pkg.depConfigs.foldrM (init := Array.mkEmpty pkg.depConfigs.size) fun dep deps => do
+      if let some pkg ← findPackageByName? dep.name then
+        return deps.push pkg.wsIdx -- already handled in another branch
       if pkg.baseName = dep.name then
         error s!"{pkg.prettyName}: package requires itself (or a package with the same name)"
       let matDep ← resolve pkg dep (← getWorkspace)
-      discard <| addDepPackage matDep dep.opts leanOpts reconfigure
+      let depPkg ← addDepPackage matDep dep.opts leanOpts reconfigure
+      return deps.push depPkg.wsIdx
     -- Recursively load the dependencies' dependencies
     (← getWorkspace).packages.forM recurse start
+    -- Add the package's dependencies to the package
+    modifyThe Workspace fun ws => ws.setDepPkgs pkg.wsIdx <| depIdxs.map (ws.packages[·]!)
 
 /--
 Adds monad state used to update the manifest.
@@ -374,10 +392,14 @@ def Workspace.updateAndMaterializeCore
       addDependencyEntries matDep
       let (_, ws) ← addDepPackage matDep dep.opts leanOpts true ws
       return ws
-    ws.packages.foldlM (init := ws) (start := start) fun ws pkg =>
+    let stop := ws.packages.size
+    let ws ← ws.packages.foldlM (init := ws) (start := start) fun ws pkg =>
       ws.resolveDepsCore updateAndAddDep pkg [ws.root.baseName] leanOpts true
+    let ws := ws.setDepPkgs ws.root.wsIdx <| (start...<stop).toArray.map (ws.packages[·]!)
+    return ws.resetRoot
   else
-    ws.resolveDepsCore updateAndAddDep (leanOpts := leanOpts) (reconfigure := true)
+    let ws ← ws.resolveDepsCore updateAndAddDep (leanOpts := leanOpts) (reconfigure := true)
+    return ws.resetRoot
 where
   @[inline] updateAndAddDep pkg dep ws := do
     let matDep ← updateAndMaterializeDep ws pkg dep
@@ -474,7 +496,7 @@ public def Workspace.materializeDeps
   if pkgEntries.isEmpty && !ws.root.depConfigs.isEmpty then
     error "missing manifest; use `lake update` to generate one"
   -- Materialize all dependencies
-  ws.resolveDepsCore (leanOpts := leanOpts) (reconfigure := reconfigure) fun pkg dep ws => do
+  let ws ← ws.resolveDepsCore (leanOpts := leanOpts) (reconfigure := reconfigure) fun pkg dep ws => do
     if let some entry := pkgEntries.find? dep.name then
       entry.materialize ws.lakeEnv ws.dir relPkgsDir
     else
@@ -488,3 +510,4 @@ public def Workspace.materializeDeps
           this suggests that the manifest is corrupt; \
           use `lake update` to generate a new, complete file \
           (warning: this will update ALL workspace dependencies)"
+  return ws.resetRoot

--- a/src/lake/Lake/Load/Resolve.lean
+++ b/src/lake/Lake/Load/Resolve.lean
@@ -111,7 +111,7 @@ abbrev ResolveT m := DepStackT <| StateT Workspace m
     recFetchAcyclic (·.baseName) go root
   return ws
 
-private def Workspace.setDepPkgs
+def Workspace.setDepPkgs
   (self : Workspace) (wsIdx : Nat) (depPkgs : Array Package)
 : Workspace := {self with
   packages := self.packages.modify wsIdx ({· with depPkgs})

--- a/src/lake/Lake/Load/Resolve.lean
+++ b/src/lake/Lake/Load/Resolve.lean
@@ -47,23 +47,29 @@ namespace Lake
 def Workspace.addFacetDecls (decls : Array FacetDecl) (self : Workspace) : Workspace :=
   decls.foldl (·.addFacetConfig ·.config) self
 
+theorem Workspace.packages_addFacetDecls :
+  (addFacetDecls decls ws).packages = ws.packages
+:= by
+  simp only [addFacetDecls]
+  apply Array.foldl_induction (fun _ (s : Workspace) => s.packages = ws.packages) rfl
+  intro i s h
+  simp only [packages_addFacetConfig, h]
+
 /--
 Loads the package configuration of a materialized dependency.
 Adds the package and the facets defined within it to the `Workspace`.
 -/
-def addDepPackage
-  (dep : MaterializedDep)
-  (lakeOpts : NameMap String)
-  (leanOpts : Options) (reconfigure : Bool)
-: StateT Workspace LogIO Package := fun ws => do
+def Workspace.addDepPackage'
+  (ws : Workspace) (dep : MaterializedDep)
+  (lakeOpts : NameMap String) (leanOpts : Options) (reconfigure : Bool)
+: LogIO {ws' : Workspace // ws'.packages.size = ws.packages.size + 1} := do
   let wsIdx := ws.packages.size
   let loadCfg := mkDepLoadConfig ws dep lakeOpts leanOpts reconfigure
   let ⟨loadCfg, h⟩ ← resolveConfigFile dep.prettyName loadCfg
   let fileCfg ← loadConfigFile loadCfg h
   let pkg := mkPackage loadCfg fileCfg wsIdx
-  let ws := ws.addPackage' pkg wsIdx_mkPackage
-  let ws := ws.addFacetDecls fileCfg.facetDecls
-  return (pkg, ws)
+  let ws := ws.addPackage' pkg wsIdx_mkPackage |>.addFacetDecls fileCfg.facetDecls
+  return ⟨ws, by simp [ws, packages_addFacetDecls, packages_addPackage']⟩
 
 /--
 The resolver's call stack of dependencies.
@@ -117,6 +123,40 @@ private def Workspace.setDepPkgs
       simp [Array.getElem_modify_of_ne h, self.packages_wsIdx]
 }
 
+structure ResolveState where
+  ws : Workspace
+  depIdxs : Array Nat
+  lt_of_mem : ∀ i ∈ depIdxs, i < ws.packages.size
+
+namespace ResolveState
+
+@[inline] def init (ws : Workspace) (size : Nat) : ResolveState :=
+  {ws, depIdxs := Array.mkEmpty size, lt_of_mem := by simp}
+
+@[inline] def reuseDep (s : ResolveState) (wsIdx : Fin s.ws.packages.size) : ResolveState :=
+  have lt_of_mem := by
+    intro i i_mem
+    cases Array.mem_push.mp i_mem with
+    | inl i_mem => exact s.lt_of_mem i i_mem
+    | inr i_eq => simp only [i_eq, wsIdx.isLt]
+  {s with depIdxs := s.depIdxs.push wsIdx, lt_of_mem}
+
+@[inline] def newDep
+  (s : ResolveState) (dep : MaterializedDep)
+  (lakeOpts : NameMap String) (leanOpts : Options) (reconfigure : Bool)
+: LogIO ResolveState := do
+  let ⟨ws, depIdxs, lt_of_mem⟩ := s
+  let wsIdx := ws.packages.size
+  let ⟨ws', h⟩ ← ws.addDepPackage' dep lakeOpts leanOpts reconfigure
+  have lt_of_mem := by
+    intro i i_mem
+    cases Array.mem_push.mp i_mem with
+    | inl i_mem => exact h ▸ Nat.lt_add_one_of_lt (lt_of_mem i i_mem)
+    | inr i_eq => simp only [wsIdx, i_eq, h, Nat.lt_add_one]
+  return ⟨ws', depIdxs.push wsIdx, lt_of_mem⟩
+
+end ResolveState
+
 /-
 Recursively visits each node in a package's dependency graph, starting from
 the workspace package `root`. Each dependency missing from the workspace is
@@ -135,21 +175,31 @@ See `Workspace.updateAndMaterializeCore` for more details.
 : m Workspace := do
   ws.runResolveT go root stack
 where
-  @[specialize] go pkg recurse : ResolveT m Unit := do
-    let start := (← getWorkspace).packages.size
+  @[specialize] go pkg recurse : ResolveT m Unit := fun depStack ws => do
+    let start := ws.packages.size
     -- Materialize and load the missing direct dependencies of `pkg`
-    let depIdxs ← pkg.depConfigs.foldrM (init := Array.mkEmpty pkg.depConfigs.size) fun dep deps => do
-      if let some pkg ← findPackageByName? dep.name then
-        return deps.push pkg.wsIdx -- already handled in another branch
+    let s := ResolveState.init ws pkg.depConfigs.size
+    let ⟨ws, depIdxs, lt_of_mem⟩ ← pkg.depConfigs.foldrM (m := m) (init := s) fun dep s => do
+      if let some wsIdx := s.ws.packages.findFinIdx? (·.baseName == dep.name) then
+        return s.reuseDep wsIdx -- already handled in another branch
       if pkg.baseName = dep.name then
         error s!"{pkg.prettyName}: package requires itself (or a package with the same name)"
-      let matDep ← resolve pkg dep (← getWorkspace)
-      let depPkg ← addDepPackage matDep dep.opts leanOpts reconfigure
-      return deps.push depPkg.wsIdx
+      let matDep ← resolve pkg dep s.ws
+      s.newDep matDep dep.opts leanOpts reconfigure
+    let depsEnd := ws.packages.size
     -- Recursively load the dependencies' dependencies
-    (← getWorkspace).packages.forM recurse start
+    let ws ← ws.packages.foldlM (start := start) (init := ws) fun ws pkg =>
+      (·.2) <$> recurse pkg depStack ws
     -- Add the package's dependencies to the package
-    modifyThe Workspace fun ws => ws.setDepPkgs pkg.wsIdx <| depIdxs.map (ws.packages[·]!)
+    let ws :=
+      if h_le : depsEnd ≤ ws.packages.size then
+        ws.setDepPkgs pkg.wsIdx <| depIdxs.attach.map fun ⟨wsIdx, h_mem⟩ =>
+          ws.packages[wsIdx]'(Nat.lt_of_lt_of_le (lt_of_mem wsIdx h_mem) h_le)
+      else
+        have : Inhabited Workspace := ⟨ws⟩
+        panic! "workspace shrunk" -- should be unreachable
+    return ((), ws)
+
 
 /--
 Adds monad state used to update the manifest.
@@ -388,12 +438,14 @@ def Workspace.updateAndMaterializeCore
     let start := ws.packages.size
     let ws ← (deps.zip matDeps).foldlM (init := ws) fun ws (dep, matDep) => do
       addDependencyEntries matDep
-      let (_, ws) ← addDepPackage matDep dep.opts leanOpts true ws
+      let ⟨ws, _⟩ ← ws.addDepPackage' matDep dep.opts leanOpts true
       return ws
     let stop := ws.packages.size
     let ws ← ws.packages.foldlM (init := ws) (start := start) fun ws pkg =>
       ws.resolveDepsCore updateAndAddDep pkg [ws.root.baseName] leanOpts true
-    return ws.setDepPkgs ws.root.wsIdx <| (start...<stop).toArray.map (ws.packages[·]!)
+    -- Set dependency packages after `resolveDepsCore` so
+    -- that the dependencies' dependencies are also properly set
+    return ws.setDepPkgs ws.root.wsIdx ws.packages[start...<stop]
   else
     ws.resolveDepsCore updateAndAddDep (leanOpts := leanOpts) (reconfigure := true)
 where

--- a/src/lake/Lake/Load/Workspace.lean
+++ b/src/lake/Lake/Load/Workspace.lean
@@ -44,6 +44,7 @@ public def loadWorkspaceRoot (config : LoadConfig) : LogIO Workspace := do
     lakeArgs? := config.lakeArgs?
     facetConfigs
     packages := #[root]
+    packageMap := DNameMap.empty.insert root.keyName root
     size_packages_pos := by simp
     packages_wsIdx {i} h := by
       cases i with

--- a/src/lake/Lake/Load/Workspace.lean
+++ b/src/lake/Lake/Load/Workspace.lean
@@ -35,17 +35,21 @@ public def loadWorkspaceRoot (config : LoadConfig) : LogIO Workspace := do
   let ⟨config, h⟩ ← resolveConfigFile "[root]" config
   let fileCfg ← loadConfigFile config h
   let root := mkPackage config fileCfg 0
+  have wsIdx_root : root.wsIdx = 0 := wsIdx_mkPackage
   let facetConfigs := fileCfg.facetDecls.foldl (·.insert ·.config) initFacetConfigs
-  let ws : Workspace := {
-    root
+  return {
     lakeEnv := config.lakeEnv
+    lakeCache := computeLakeCache root config.lakeEnv
     lakeConfig
     lakeArgs? := config.lakeArgs?
     facetConfigs
-    packages_wsIdx h := by simp at h
+    packages := #[root]
+    size_packages_pos := by simp
+    packages_wsIdx {i} h := by
+      cases i with
+      | zero => simp [wsIdx_root]
+      | succ => simp at h
   }
-  let ws := ws.addPackage' root wsIdx_mkPackage
-  return ws
 
 /--
 Load a `Workspace` for a Lake package by


### PR DESCRIPTION
This PR adds `Pakcage.depPkgs` for internal use (namely in #11662). This field contains the list of the package's direct dependencies (as package objects). This is much more efficient than going through the old package `deps` facet.

As part of this refactor, the Workspace `root` is now derived from `packages` instead of being is own independent field.