### PR TITLE
feat: informative metavariable hovers, better delayed assignment pretty printing

### DIFF
--- a/src/Lean/Data/PPContext.lean
+++ b/src/Lean/Data/PPContext.lean
@@ -1,0 +1,26 @@
+/-
+Copyright (c) 2020 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Leonardo de Moura
+-/
+module
+
+prelude
+public import Lean.Data.OpenDecl
+public import Lean.Environment
+public import Lean.MetavarContext
+
+public section
+
+namespace Lean
+
+/-- Saved context for pretty printing. See `Lean.ppExt`. -/
+structure PPContext where
+  env           : Environment
+  mctx          : MetavarContext := {}
+  lctx          : LocalContext := {}
+  opts          : Options := {}
+  currNamespace : Name := Name.anonymous
+  openDecls     : List OpenDecl := []
+
+end Lean

--- a/src/Lean/Elab/InfoTree/Main.lean
+++ b/src/Lean/Elab/InfoTree/Main.lean
@@ -216,11 +216,21 @@ def FVarAliasInfo.format (info : FVarAliasInfo) : Format :=
 def FieldRedeclInfo.format (ctx : ContextInfo) (info : FieldRedeclInfo) : Format :=
   f!"[FieldRedecl] @ {formatStxRange ctx info.stx}"
 
+def DelabTermInfo.docString? (ppCtx : PPContext) (info : DelabTermInfo) : IO (Option String) := do
+  match info.mkDocString? with
+  | none => return none
+  | some act =>
+    try
+      act ppCtx
+    catch ex =>
+      return s!"[Error: {ex.toString}]"
+
 def DelabTermInfo.format (ctx : ContextInfo) (info : DelabTermInfo) : IO Format := do
   let loc := if let some loc := info.location? then f!"{loc.module} {loc.range.pos}-{loc.range.endPos}" else "none"
+  let docString? ← info.docString? (ctx.toPPContext info.lctx)
   return f!"[DelabTerm] @ {← TermInfo.format ctx info.toTermInfo}\n\
     Location: {loc}\n\
-    Docstring: {repr info.docString?}\n\
+    Docstring: {repr docString?}\n\
     Explicit: {info.explicit}"
 
 def ChoiceInfo.format (ctx : ContextInfo) (info : ChoiceInfo) : Format :=

--- a/src/Lean/Elab/InfoTree/Types.lean
+++ b/src/Lean/Elab/InfoTree/Types.lean
@@ -9,6 +9,7 @@ module
 prelude
 public import Lean.Data.DeclarationRange
 public import Lean.Data.OpenDecl
+public import Lean.Data.PPContext
 public import Lean.MetavarContext
 public import Lean.Environment
 public import Lean.Widget.Types
@@ -208,8 +209,10 @@ regular delaboration settings. Additionally, omissions come with a reason for om
 structure DelabTermInfo extends TermInfo where
   /-- A source position to use for "go to definition", to override the default. -/
   location? : Option DeclarationLocation := none
-  /-- Text to use to override the docstring. -/
-  docString? : Option String := none
+  /-- Text to use to override the docstring. The string may be dynamic text. It is an `IO` action
+  so that it can be computed only when it is used. The action receives a `PPContext` so that the
+  action does not need to create a closure with the meta state. -/
+  mkDocString? : Option (PPContext → IO String) := none
   /-- Whether to use explicit mode when pretty printing the term on hover. -/
   explicit : Bool := true
 

--- a/src/Lean/Meta/Basic.lean
+++ b/src/Lean/Meta/Basic.lean
@@ -2223,10 +2223,14 @@ def instantiateLambdaWithParamInfos (e : Expr) (args : Array Expr) (cleanupAnnot
     | _ => throwError "invalid `instantiateForallWithParams`, too many parameters{indentExpr e}"
   return (res, e)
 
+def getPPContext : MetaM PPContext := do
+  return { env := (← getEnv), mctx := (← getMCtx), lctx := (← getLCtx), opts := (← getOptions),
+           currNamespace := (← getCurrNamespace), openDecls := (← getOpenDecls) }
+
 /-- Pretty-print the given expression. -/
 def ppExprWithInfos (e : Expr) : MetaM FormatWithInfos := do
-  let ctxCore  ← readThe Core.Context
-  Lean.ppExprWithInfos { env := (← getEnv), mctx := (← getMCtx), lctx := (← getLCtx), opts := (← getOptions), currNamespace := ctxCore.currNamespace, openDecls := ctxCore.openDecls } e
+  let ctx ← getPPContext
+  Lean.ppExprWithInfos ctx e
 
 /-- Pretty-print the given expression. -/
 def ppExpr (e : Expr) : MetaM Format := (·.fmt) <$> ppExprWithInfos e

--- a/src/Lean/PrettyPrinter/Delaborator/Basic.lean
+++ b/src/Lean/PrettyPrinter/Delaborator/Basic.lean
@@ -48,6 +48,9 @@ structure Context where
   subExpr        : SubExpr
   /-- Current recursion depth during delaboration. Used by the `pp.deepTerms false` option. -/
   depth          : Nat := 0
+  /-- Initial state of `LocalContext.numIndices`, to keep track of which variables were introduced
+  during delaboration. -/
+  lctxInitIndices : Nat
 
 structure State where
   /-- The number of `delab` steps so far. Used by `pp.maxSteps` to stop delaboration. -/
@@ -514,7 +517,8 @@ def delabCore (e : Expr) (optionsPerPos : OptionsPerPos := {}) (delab : DelabM �
             currNamespace := (← getCurrNamespace)
             openDecls := (← getOpenDecls)
             subExpr := SubExpr.mkRoot e
-            inPattern := opts.getInPattern }
+            inPattern := opts.getInPattern
+            lctxInitIndices := (← getLCtx).numIndices }
           |>.run { : Delaborator.State })
         (fun _ => unreachable!)
     return (stx, infos)

--- a/src/Lean/PrettyPrinter/Delaborator/Basic.lean
+++ b/src/Lean/PrettyPrinter/Delaborator/Basic.lean
@@ -223,12 +223,21 @@ where
     stx := stx
   }
 
+/--
+Adds `DelabTermInfo` at the given position.
+
+Either `docString?` or `mkDocString?` can be provided. The `docString?` field is a convenient
+interface for `mkDocString?`.
+-/
 def addDelabTermInfo (pos : Pos) (stx : Syntax) (e : Expr) (isBinder : Bool := false)
-    (location? : Option DeclarationLocation := none) (docString? : Option String := none) (explicit : Bool := true) : DelabM Unit := do
+    (location? : Option DeclarationLocation := none)
+    (docString? : Option String := none)
+    (mkDocString? : Option (PPContext → IO String) := none)
+    (explicit : Bool := true) : DelabM Unit := do
   let info := Info.ofDelabTermInfo {
     toTermInfo := ← addTermInfo.mkTermInfo stx e (isBinder := isBinder)
     location?  := location?
-    docString? := docString?
+    mkDocString? := mkDocString? <|> docString?.map (fun _ => pure ·)
     explicit   := explicit
   }
   modify fun s => { s with infos := s.infos.insert pos info }

--- a/src/Lean/PrettyPrinter/Delaborator/Builtins.lean
+++ b/src/Lean/PrettyPrinter/Delaborator/Builtins.lean
@@ -165,8 +165,8 @@ private def describeMVar (mvarId : MVarId) (checkLCtx : Bool := false) (fromDela
         They can be solved for by unification during the elaboration process, \
         but the inferred expression and the synthesized instance must be definitionally equal."
     | .syntheticOpaque =>
-      msg := "A metavariable representing a tactic goal, or more generally an expression whose elaboration is pending, \
-        and they usually act like constants until they are completely solved for. \
+      msg := "A metavariable representing a tactic goal, or more generally an expression whose elaboration is pending. \
+        They usually act like constants until they are completely solved for. \
         They can be created using `?_` and `?n` synthetic placeholder syntax."
   if let some e ← getExprMVarAssignment? mvarId then
     if !fromDelayed then

--- a/src/Lean/PrettyPrinter/Delaborator/Builtins.lean
+++ b/src/Lean/PrettyPrinter/Delaborator/Builtins.lean
@@ -7,6 +7,7 @@ module
 
 prelude
 public import Lean.PrettyPrinter.Delaborator.Basic
+public import Lean.PrettyPrinter.Delaborator.Metavariable
 public import Lean.Meta.CoeAttr
 public import Lean.Meta.Structure
 public import Lean.PrettyPrinter.Formatter
@@ -61,176 +62,13 @@ def delabBVar : Delab := do
   let Expr.bvar idx ← getExpr | unreachable!
   pure $ mkIdent $ Name.mkSimple $ "#" ++ toString idx
 
-private def delabMVarAuxAux {α} (m : MVarId)
-    (mkMVarPlaceholder : DelabM α) (mkMVar : Name → DelabM α) (mkMVarDead : Nat → Name → DelabM α) :
-    DelabM α := do
-  if ← getPPOption getPPMVars then
-    if let some decl ← m.findDecl? then
-      match decl.userName with
-      | .anonymous =>
-        if ← getPPOption getPPMVarsAnonymous then
-          mkMVar <| Name.num `m (decl.index + 1)
-        else
-          mkMVarPlaceholder
-      | n =>
-        if let some m' := (← getMCtx).findUserName? n then
-          if m == m' then
-            return ← mkMVar n
-        mkMVarDead decl.index n
-    else
-      -- Undefined mvar, use internal name
-      mkMVar <| m.name.replacePrefix `_uniq `_mvar
-  else
-    mkMVarPlaceholder
-
-/-- Constructs a `?m` term using the name of `m` or its index. Does not add terminfo. -/
-private def delabMVarAux (m : MVarId) : DelabM Term := do
-  delabMVarAuxAux m `(?_) (fun n => `(?$(mkIdent n)))
-    (fun idx n =>
-      let n' := addMacroScope (Name.num `_delabMVar idx) n reservedMacroScope
-      `(?$(mkIdent n')))
-
-private def delabMVarAsStr (m : MVarId) : DelabM String := do
-  delabMVarAuxAux m (pure "?_") (fun n : Name => pure <| "?" ++ n.toString)
-    (fun _ n => pure <| "?" ++ n.toString ++ "(✝)") -- We can't properly sanitize the names as strings
-
-/--
-Approximate check that the application `?m a₁ … aₙ` of the delayed assignment metavariable `?m`
-can be pretty printed using the pending metavariable.
-
-Heuristic: we assume the ldecl arguments are correct, and for the cdecls we check that they are
-distinct fvars
--/
-private def checkDelayedMVarAssignment (e : Expr) (decl : DelayedMetavarAssignment) : MetaM Bool := do
-  unless e.getAppNumArgs == decl.fvars.size do
-    return false
-  let some mdecl ← decl.mvarIdPending.findDecl? | return false
-  let mut seenFVars : FVarIdHashSet := {}
-  for fvar in decl.fvars, arg in e.getAppArgs do
-    let fvarId := fvar.fvarId!
-    let some ldecl := mdecl.lctx.find? fvarId | return false
-    unless ldecl.hasValue do
-      let .fvar argFVarId := arg | return false
-      if seenFVars.contains argFVarId then
-        return false
-      seenFVars := seenFVars.insert argFVarId
-  return true
-
-/--
-Follows a chain of delayed assignments to find the pending metavariable.
--/
-private partial def getDelayedMVarIdPending (mvarIdPending : MVarId) : MetaM MVarId := do
-  let some e ← getExprMVarAssignment? mvarIdPending | return mvarIdPending
-  let e := e.consumeMData
-  unless e.getAppFn.isMVar do return mvarIdPending
-  let e := (← instantiateMVars e).consumeMData
-  let .mvar mvarId := e.getAppFn | return mvarIdPending
-  if e.isMVar then
-    return mvarId
-  else if let some decl ← getDelayedMVarAssignment? mvarId then
-    unless ← checkDelayedMVarAssignment e decl do return mvarIdPending
-    getDelayedMVarIdPending decl.mvarIdPending
-  else
-    return mvarIdPending
-
-private def describeMVar (mvarId : MVarId) (checkLCtx : Bool := false) (fromDelayed : Bool := false) : DelabM String := do
-  let delayedExpl :=
-    "Substitution is delayed until the metavariable's value contains no metavariables, \
-     since all occurrences of the variables from its local context will need to be \
-     replaced with expressions that are valid in the current context."
-  let some decl ← mvarId.findDecl? | return "[Error: This metavariable is not present in the metavariable context. Please report this issue.]"
-  let mut msg := ""
-  if let some { mvarIdPending, .. } ← getDelayedMVarAssignment? mvarId then
-    let mvarIdPending' ← getDelayedMVarIdPending mvarIdPending
-    if let some declPending' ← mvarIdPending'.findDecl? then
-      msg := s!"Part of the encoding of the *delayed assignment* mechanism. \
-        Represents the metavariable `{← delabMVarAsStr mvarIdPending'}`, \
-        which has additional local context variables. \
-        {delayedExpl}"
-      if let some e ← getExprMVarAssignment? mvarIdPending' then
-        msg := msg ++ (← collectAwaiting e)
-      msg := msg ++ (← extraLCtxVars declPending')
-    else
-      msg := "[Error: This delayed assignment refers to a metavariable not present in the metavariable context. Please report this issue.]"
-    return msg
-  else
-    match decl.kind with
-    | .natural =>
-      msg := "A metavariable, representing an expression that should be solved for \
-        by unification during the elaboration process. \
-        They are created during elaboration as placeholders for implicit arguments \
-        and by `_` placeholder syntax."
-    | .synthetic =>
-      msg := "A metavariable, representing a typeclass instance whose synthesis is still pending. \
-        They can be solved for by unification during the elaboration process, \
-        but the inferred expression and the synthesized instance must be definitionally equal."
-    | .syntheticOpaque =>
-      msg := "A metavariable representing a tactic goal, or more generally an expression whose elaboration is pending. \
-        They usually act like constants until they are completely solved for. \
-        They can be created using `?_` and `?n` synthetic placeholder syntax."
-  if let some e ← getExprMVarAssignment? mvarId then
-    if !fromDelayed then
-      msg := msg ++ "\n\nThis metavariable has been assigned."
-    else
-      msg := msg ++ "\n\nThis metavariable has been assigned, but it is a *delayed assignment*. " ++ delayedExpl
-      msg := msg ++ (← collectAwaiting e)
-  else if !(← mvarId.isAssignable) then
-    msg := msg ++ "\n\nThis metavariable cannot be assigned due to the current metavariable context depth."
-  else if fromDelayed then
-    msg := msg ++ "\n\nThis metavariable appears here via a *delayed assignment*. " ++ delayedExpl
-  let lctx ← getLCtx
-  if checkLCtx && !decl.lctx.isSubPrefixOf lctx then
-    msg := msg ++ (← extraLCtxVars decl)
-  else
-    msg := msg ++ (← absentLCtxVars decl)
-  return msg
-where
-  wrap (n : String) := s!"`{n}`"
-  namesToString (ns : List Name) : String :=
-    String.intercalate ", " <| ns.map fun n => wrap <|
-      if n.hasMacroScopes then
-        n.eraseMacroScopes.toString ++ "(✝)" -- We can't sanitize the names, so let's mark inaccessibles this way for now.
-      else
-        n.toString
-  extraLCtxVars (mdecl : MetavarDecl) : DelabM String := do
-    let lctx ← getLCtx
-    let ns := mdecl.lctx.foldr (init := []) fun decl ns =>
-      if lctx.contains decl.fvarId then ns else decl.userName :: ns
-    if ns.isEmpty then
-      return ""
-    else
-      return s!"\n\nAdditional {ns.length.plural "variable"} in this metavariable's local context: " ++ namesToString ns
-  absentLCtxVars (mdecl : MetavarDecl) : DelabM String := do
-    let lctx ← getLCtx
-    let lctxInitIndices := (← read).lctxInitIndices
-    let ns := lctx.foldr (init := []) fun decl ns =>
-      if decl.index ≥ lctxInitIndices || mdecl.lctx.contains decl.fvarId then ns else decl.userName :: ns
-    if ns.isEmpty then
-      return ""
-    else
-      return s!"\n\n{ns.length.plural "Variable"} absent from this metavariable's local context: " ++ namesToString ns
-  collectAwaiting (e : Expr) : DelabM String := do
-    -- Collect metavariables to diagnose why it is pending.
-    let awaitingMVars ← getMVarsNoDelayed e
-    -- Select the metavariables that refer to free variables not in the current context.
-    let lctx ← getLCtx
-    let awaitingMVars ← awaitingMVars.filterM fun mvar => do
-      let mdecl ← mvar.getDecl
-      return !mdecl.lctx.isSubPrefixOf lctx
-    if awaitingMVars.isEmpty then
-      return ""
-    else
-      let awaitingStrs ← awaitingMVars.mapM (wrap <$> delabMVarAsStr ·)
-      return s!" Substitution is awaiting assignment of the following {awaitingStrs.size.plural "metavariable"}: "
-        ++ String.intercalate ", " awaitingStrs.toList
-
 @[builtin_delab mvar]
 def delabMVar : Delab := do
   let Expr.mvar mvarId ← getExpr | unreachable!
   withTypeAscription (cond := ← getPPOption getPPMVarsWithType) do
     let stx ← annotateCurPos =<< delabMVarAux mvarId
-    let descr ← describeMVar mvarId
-    addDelabTermInfo (← getPos) stx (← getExpr) (docString? := descr) (explicit := true)
+    let descr ← mkDescribeMVar mvarId
+    addDelabTermInfo (← getPos) stx (← getExpr) (mkDocString? := some descr) (explicit := true)
     return stx
 
 @[builtin_delab sort]
@@ -744,13 +582,14 @@ def delabDelayedAssignedMVar : Delab := whenNotPPOption getPPMVarsDelayed do
   withOverApp decl.fvars.size do
     guard <| ← checkDelayedMVarAssignment (← getExpr) decl
     let mvarIdPending ← getDelayedMVarIdPending decl.mvarIdPending
-    let docString ← describeMVar mvarIdPending (checkLCtx := true) (fromDelayed := true)
+    let descr ← mkDescribeMVar mvarIdPending (fromDelayed := true)
     withTypeAscription (cond := ← getPPOption getPPMVarsWithType) do
       -- Delaborate the whole application as if it were a single metavariable.
       -- Hovering will show the underlying delayed assignment expression, and the type
-      -- will be the type of the application itself (valid in the current local context).
+      -- will be the type of the application itself (which is valid in the current local context,
+      -- unlike the type of `mvarIdPending`).
       let stx ← annotateCurPos =<< delabMVarAux mvarIdPending
-      addDelabTermInfo (← getPos) stx (← getExpr) (explicit := true) (docString? := docString)
+      addDelabTermInfo (← getPos) stx (← getExpr) (explicit := true) (mkDocString? := descr)
       return stx
 
 private partial def collectStructFields

--- a/src/Lean/PrettyPrinter/Delaborator/Builtins.lean
+++ b/src/Lean/PrettyPrinter/Delaborator/Builtins.lean
@@ -12,7 +12,6 @@ public import Lean.Meta.CoeAttr
 public import Lean.Meta.Structure
 public import Lean.PrettyPrinter.Formatter
 public import Lean.PrettyPrinter.Parenthesizer
-import all Lean.Elab.ErrorUtils
 meta import Lean.Parser.Command
 meta import Lean.PrettyPrinter.Delaborator.DeclWithSig
 

--- a/src/Lean/PrettyPrinter/Delaborator/Builtins.lean
+++ b/src/Lean/PrettyPrinter/Delaborator/Builtins.lean
@@ -11,6 +11,7 @@ public import Lean.Meta.CoeAttr
 public import Lean.Meta.Structure
 public import Lean.PrettyPrinter.Formatter
 public import Lean.PrettyPrinter.Parenthesizer
+import all Lean.Elab.ErrorUtils
 meta import Lean.Parser.Command
 meta import Lean.PrettyPrinter.Delaborator.DeclWithSig
 
@@ -60,29 +61,177 @@ def delabBVar : Delab := do
   let Expr.bvar idx ← getExpr | unreachable!
   pure $ mkIdent $ Name.mkSimple $ "#" ++ toString idx
 
-def delabMVarAux (m : MVarId) : DelabM Term := do
-  let mkMVarPlaceholder : DelabM Term := `(?_)
-  let mkMVar (n : Name) : DelabM Term := `(?$(mkIdent n))
-  withTypeAscription (cond := ← getPPOption getPPMVarsWithType) do
-    if ← getPPOption getPPMVars then
-      if let some decl ← m.findDecl? then
-        match decl.userName with
-        | .anonymous =>
-          if ← getPPOption getPPMVarsAnonymous then
-            mkMVar <| Name.num `m (decl.index + 1)
-          else
-            mkMVarPlaceholder
-        | n => mkMVar n
-      else
-        -- Undefined mvar, use internal name
-        mkMVar <| m.name.replacePrefix `_uniq `_mvar
+private def delabMVarAuxAux {α} (m : MVarId)
+    (mkMVarPlaceholder : DelabM α) (mkMVar : Name → DelabM α) (mkMVarDead : Nat → Name → DelabM α) :
+    DelabM α := do
+  if ← getPPOption getPPMVars then
+    if let some decl ← m.findDecl? then
+      match decl.userName with
+      | .anonymous =>
+        if ← getPPOption getPPMVarsAnonymous then
+          mkMVar <| Name.num `m (decl.index + 1)
+        else
+          mkMVarPlaceholder
+      | n =>
+        if let some m' := (← getMCtx).findUserName? n then
+          if m == m' then
+            return ← mkMVar n
+        mkMVarDead decl.index n
     else
-      mkMVarPlaceholder
+      -- Undefined mvar, use internal name
+      mkMVar <| m.name.replacePrefix `_uniq `_mvar
+  else
+    mkMVarPlaceholder
+
+/-- Constructs a `?m` term using the name of `m` or its index. Does not add terminfo. -/
+private def delabMVarAux (m : MVarId) : DelabM Term := do
+  delabMVarAuxAux m `(?_) (fun n => `(?$(mkIdent n)))
+    (fun idx n =>
+      let n' := addMacroScope (Name.num `_delabMVar idx) n reservedMacroScope
+      `(?$(mkIdent n')))
+
+private def delabMVarAsStr (m : MVarId) : DelabM String := do
+  delabMVarAuxAux m (pure "?_") (fun n : Name => pure <| "?" ++ n.toString)
+    (fun _ n => pure <| "?" ++ n.toString ++ "(✝)") -- We can't properly sanitize the names as strings
+
+/--
+Approximate check that the application `?m a₁ … aₙ` of the delayed assignment metavariable `?m`
+can be pretty printed using the pending metavariable.
+
+Heuristic: we assume the ldecl arguments are correct, and for the cdecls we check that they are
+distinct fvars
+-/
+private def checkDelayedMVarAssignment (e : Expr) (decl : DelayedMetavarAssignment) : MetaM Bool := do
+  unless e.getAppNumArgs == decl.fvars.size do
+    return false
+  let some mdecl ← decl.mvarIdPending.findDecl? | return false
+  let mut seenFVars : FVarIdHashSet := {}
+  for fvar in decl.fvars, arg in e.getAppArgs do
+    let fvarId := fvar.fvarId!
+    let some ldecl := mdecl.lctx.find? fvarId | return false
+    unless ldecl.hasValue do
+      let .fvar argFVarId := arg | return false
+      if seenFVars.contains argFVarId then
+        return false
+      seenFVars := seenFVars.insert argFVarId
+  return true
+
+/--
+Follows a chain of delayed assignments to find the pending metavariable.
+-/
+private partial def getDelayedMVarIdPending (mvarIdPending : MVarId) : MetaM MVarId := do
+  let some e ← getExprMVarAssignment? mvarIdPending | return mvarIdPending
+  let e := e.consumeMData
+  unless e.getAppFn.isMVar do return mvarIdPending
+  let e := (← instantiateMVars e).consumeMData
+  let .mvar mvarId := e.getAppFn | return mvarIdPending
+  if e.isMVar then
+    return mvarId
+  else if let some decl ← getDelayedMVarAssignment? mvarId then
+    unless ← checkDelayedMVarAssignment e decl do return mvarIdPending
+    getDelayedMVarIdPending decl.mvarIdPending
+  else
+    return mvarIdPending
+
+private def describeMVar (mvarId : MVarId) (checkLCtx : Bool := false) (fromDelayed : Bool := false) : DelabM String := do
+  let delayedExpl :=
+    "Substitution is delayed until the metavariable's value contains no metavariables, \
+     since all occurrences of the variables from its local context will need to be \
+     replaced with expressions that are valid in the current context."
+  let some decl ← mvarId.findDecl? | return "[Error: This metavariable is not present in the metavariable context. Please report this issue.]"
+  let mut msg := ""
+  if let some { mvarIdPending, .. } ← getDelayedMVarAssignment? mvarId then
+    let mvarIdPending' ← getDelayedMVarIdPending mvarIdPending
+    if let some declPending' ← mvarIdPending'.findDecl? then
+      msg := s!"Part of the encoding of the *delayed assignment* mechanism. \
+        Represents the metavariable `{← delabMVarAsStr mvarIdPending'}`, \
+        which has additional local context variables. \
+        {delayedExpl}"
+      if let some e ← getExprMVarAssignment? mvarIdPending' then
+        msg := msg ++ (← collectAwaiting e)
+      msg := msg ++ (← extraLCtxVars declPending')
+    else
+      msg := "[Error: This delayed assignment refers to a metavariable not present in the metavariable context. Please report this issue.]"
+    return msg
+  else
+    match decl.kind with
+    | .natural =>
+      msg := "A metavariable, representing an expression that should be solved for \
+        by unification during the elaboration process. \
+        They are created during elaboration as placeholders for implicit arguments \
+        and by `_` placeholder syntax."
+    | .synthetic =>
+      msg := "A metavariable, representing a typeclass instance whose synthesis is still pending. \
+        They can be solved for by unification during the elaboration process, \
+        but the inferred expression and the synthesized instance must be definitionally equal."
+    | .syntheticOpaque =>
+      msg := "A metavariable representing a tactic goal, or more generally an expression whose elaboration is pending, \
+        and they usually act like constants until they are completely solved for. \
+        They can be created using `?_` and `?n` synthetic placeholder syntax."
+  if let some e ← getExprMVarAssignment? mvarId then
+    if !fromDelayed then
+      msg := msg ++ "\n\nThis metavariable has been assigned."
+    else
+      msg := msg ++ "\n\nThis metavariable has been assigned, but it is a *delayed assignment*. " ++ delayedExpl
+      msg := msg ++ (← collectAwaiting e)
+  else if !(← mvarId.isAssignable) then
+    msg := msg ++ "\n\nThis metavariable cannot be assigned due to the current metavariable context depth."
+  else if fromDelayed then
+    msg := msg ++ "\n\nThis metavariable appears here via a *delayed assignment*. " ++ delayedExpl
+  let lctx ← getLCtx
+  if checkLCtx && !decl.lctx.isSubPrefixOf lctx then
+    msg := msg ++ (← extraLCtxVars decl)
+  else
+    msg := msg ++ (← absentLCtxVars decl)
+  return msg
+where
+  wrap (n : String) := s!"`{n}`"
+  namesToString (ns : List Name) : String :=
+    String.intercalate ", " <| ns.map fun n => wrap <|
+      if n.hasMacroScopes then
+        n.eraseMacroScopes.toString ++ "(✝)" -- We can't sanitize the names, so let's mark inaccessibles this way for now.
+      else
+        n.toString
+  extraLCtxVars (mdecl : MetavarDecl) : DelabM String := do
+    let lctx ← getLCtx
+    let ns := mdecl.lctx.foldr (init := []) fun decl ns =>
+      if lctx.contains decl.fvarId then ns else decl.userName :: ns
+    if ns.isEmpty then
+      return ""
+    else
+      return s!"\n\nAdditional {ns.length.plural "variable"} in this metavariable's local context: " ++ namesToString ns
+  absentLCtxVars (mdecl : MetavarDecl) : DelabM String := do
+    let lctx ← getLCtx
+    let lctxInitIndices := (← read).lctxInitIndices
+    let ns := lctx.foldr (init := []) fun decl ns =>
+      if decl.index ≥ lctxInitIndices || mdecl.lctx.contains decl.fvarId then ns else decl.userName :: ns
+    if ns.isEmpty then
+      return ""
+    else
+      return s!"\n\n{ns.length.plural "Variable"} absent from this metavariable's local context: " ++ namesToString ns
+  collectAwaiting (e : Expr) : DelabM String := do
+    -- Collect metavariables to diagnose why it is pending.
+    let awaitingMVars ← getMVarsNoDelayed e
+    -- Select the metavariables that refer to free variables not in the current context.
+    let lctx ← getLCtx
+    let awaitingMVars ← awaitingMVars.filterM fun mvar => do
+      let mdecl ← mvar.getDecl
+      return !mdecl.lctx.isSubPrefixOf lctx
+    if awaitingMVars.isEmpty then
+      return ""
+    else
+      let awaitingStrs ← awaitingMVars.mapM (wrap <$> delabMVarAsStr ·)
+      return s!" Substitution is awaiting assignment of the following {awaitingStrs.size.plural "metavariable"}: "
+        ++ String.intercalate ", " awaitingStrs.toList
 
 @[builtin_delab mvar]
 def delabMVar : Delab := do
-  let Expr.mvar n ← getExpr | unreachable!
-  delabMVarAux n
+  let Expr.mvar mvarId ← getExpr | unreachable!
+  withTypeAscription (cond := ← getPPOption getPPMVarsWithType) do
+    let stx ← annotateCurPos =<< delabMVarAux mvarId
+    let descr ← describeMVar mvarId
+    addDelabTermInfo (← getPos) stx (← getExpr) (docString? := descr) (explicit := true)
+    return stx
 
 @[builtin_delab sort]
 def delabSort : Delab := do
@@ -593,10 +742,16 @@ def delabDelayedAssignedMVar : Delab := whenNotPPOption getPPMVarsDelayed do
   let .mvar mvarId := (← getExpr).getAppFn | failure
   let some decl ← getDelayedMVarAssignment? mvarId | failure
   withOverApp decl.fvars.size do
-    let args := (← getExpr).getAppArgs
-    -- Only delaborate using decl.mvarIdPending if the delayed mvar is applied to fvars
-    guard <| args.all Expr.isFVar
-    delabMVarAux decl.mvarIdPending
+    guard <| ← checkDelayedMVarAssignment (← getExpr) decl
+    let mvarIdPending ← getDelayedMVarIdPending decl.mvarIdPending
+    let docString ← describeMVar mvarIdPending (checkLCtx := true) (fromDelayed := true)
+    withTypeAscription (cond := ← getPPOption getPPMVarsWithType) do
+      -- Delaborate the whole application as if it were a single metavariable.
+      -- Hovering will show the underlying delayed assignment expression, and the type
+      -- will be the type of the application itself (valid in the current local context).
+      let stx ← annotateCurPos =<< delabMVarAux mvarIdPending
+      addDelabTermInfo (← getPos) stx (← getExpr) (explicit := true) (docString? := docString)
+      return stx
 
 private partial def collectStructFields
     (structName : Name) (levels : List Level) (params : Array Expr)

--- a/src/Lean/PrettyPrinter/Delaborator/Metavariable.lean
+++ b/src/Lean/PrettyPrinter/Delaborator/Metavariable.lean
@@ -1,0 +1,205 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kyle Miller
+-/
+module
+
+prelude
+public import Lean.PrettyPrinter.Delaborator.Basic
+import all Lean.Elab.ErrorUtils
+
+public section
+
+namespace Lean.PrettyPrinter.Delaborator
+open Lean.Meta
+
+/-!
+# Utilities for pretty printing metavariables and generating dynamic docstrings
+-/
+
+private def delabMVarAuxAux {α} (m : MVarId)
+    (mkMVarPlaceholder : MetaM α) (mkMVar : Name → MetaM α) (mkMVarDead : Name → MetaM α)
+    (ppMVars : Bool)
+    (ppMVarsAnonymous : Bool) :
+    MetaM α := do
+  if ppMVars then
+    if let some decl ← m.findDecl? then
+      match decl.userName with
+      | .anonymous =>
+        if ppMVarsAnonymous then
+          mkMVar <| Name.num `m (decl.index + 1)
+        else
+          mkMVarPlaceholder
+      | n =>
+        if some m == (← getMCtx).findUserName? n then
+          mkMVar n
+        else
+          mkMVarDead n
+    else
+      -- Undefined mvar, use internal name
+      mkMVar <| m.name.replacePrefix `_uniq `_mvar
+  else
+    mkMVarPlaceholder
+
+/--
+Constructs a `?m` term using the name of `m` or its index. Does not add terminfo.
+The metavariable does not need to be type correct in the current local context.
+-/
+def delabMVarAux (m : MVarId) : DelabM Term := do
+  delabMVarAuxAux m `(?_) (fun n => `(?$(mkIdent n)))
+    (fun n =>
+      let n' := addMacroScope (`_delabMVar ++ m.name) n reservedMacroScope
+      `(?$(mkIdent n')))
+    (ppMVars := ← getPPOption getPPMVars)
+    (ppMVarsAnonymous := ← getPPOption getPPMVarsAnonymous)
+
+/-- String version of `delabMVarAux`, for use in dynamic docstrings. -/
+private def delabMVarAsStr (m : MVarId) : MetaM String := do
+  delabMVarAuxAux m (pure "?_") (fun n : Name => pure <| "?" ++ n.toString)
+    (fun n => pure <| "?" ++ n.toString ++ " (unreachable)")
+    (ppMVars := getPPMVars (← getOptions))
+    (ppMVarsAnonymous := getPPMVarsAnonymous (← getOptions))
+
+/--
+Approximate check that the application `?m a₁ … aₙ` of the delayed assignment metavariable `?m`
+can be pretty printed using the pending metavariable.
+
+Heuristic: we assume the ldecl arguments are correct, and for the cdecls we check that they are
+distinct fvars
+-/
+def checkDelayedMVarAssignment (e : Expr) (decl : DelayedMetavarAssignment) : MetaM Bool := do
+  unless e.getAppNumArgs == decl.fvars.size do
+    return false
+  let some mdecl ← decl.mvarIdPending.findDecl? | return false
+  let mut seenFVars : FVarIdHashSet := {}
+  for fvar in decl.fvars, arg in e.getAppArgs do
+    let fvarId := fvar.fvarId!
+    let some ldecl := mdecl.lctx.find? fvarId | return false
+    unless ldecl.hasValue do
+      let .fvar argFVarId := arg | return false
+      if seenFVars.contains argFVarId then
+        return false
+      seenFVars := seenFVars.insert argFVarId
+  return true
+
+/--
+Follows a chain of delayed assignments to find the pending metavariable.
+-/
+partial def getDelayedMVarIdPending (mvarIdPending : MVarId) : MetaM MVarId := do
+  let some e ← getExprMVarAssignment? mvarIdPending | return mvarIdPending
+  unless e.getAppFn'.isMVar do return mvarIdPending
+  let e := (← instantiateMVars e).consumeMData
+  if let .mvar mvarId := e then
+    return mvarId
+  let .mvar mvarId := e.getAppFn' | return mvarIdPending
+  if let some decl ← getDelayedMVarAssignment? mvarId then
+    unless ← checkDelayedMVarAssignment e decl do return mvarIdPending
+    getDelayedMVarIdPending decl.mvarIdPending
+  else
+    return mvarIdPending
+
+private def describeMVar (mvarId : MVarId) (lctxInitIndices : Nat) (fromDelayed : Bool := false) : MetaM String := do
+  let delayedExpl :=
+    "Substitution is delayed until the metavariable's value contains no metavariables, \
+     since all occurrences of the variables from its local context will need to be \
+     replaced with expressions that are valid in the current context."
+  let some decl ← mvarId.findDecl? | return "[Error: This metavariable is not present in the metavariable context. Please report this issue.]"
+  let mut msg := ""
+  if let some { mvarIdPending, .. } ← getDelayedMVarAssignment? mvarId then
+    let mvarIdPending' ← getDelayedMVarIdPending mvarIdPending
+    if let some declPending' ← mvarIdPending'.findDecl? then
+      msg := s!"Part of the encoding of the *delayed assignment* mechanism. \
+        Represents the metavariable {← wrap <$> delabMVarAsStr mvarIdPending'}, \
+        which has additional local context variables. \
+        {delayedExpl}"
+      if let some e ← getExprMVarAssignment? mvarIdPending' then
+        msg := msg ++ (← collectAwaiting e)
+      msg := msg ++ (← extraLCtxVars declPending')
+    else
+      msg := "[Error: This delayed assignment refers to a metavariable not present in the metavariable context. Please report this issue.]"
+    return msg
+  else
+    match decl.kind with
+    | .natural =>
+      msg := "A metavariable representing an expression that should be solved for \
+        by unification during the elaboration process. \
+        They are created during elaboration as placeholders for implicit arguments \
+        and by `_` placeholder syntax."
+    | .synthetic =>
+      msg := "A metavariable representing a typeclass instance whose synthesis is still pending. \
+        They can be solved for by unification during the elaboration process, \
+        but the inferred expression and the synthesized instance must be definitionally equal."
+    | .syntheticOpaque =>
+      msg := "A metavariable representing a tactic goal or an expression whose elaboration is still pending. \
+        They usually act like constants until they are completely solved for. \
+        They can be created using `?_` and `?n` synthetic placeholder syntax."
+  unless decl.userName.isAnonymous || some mvarId == (← getMCtx).findUserName? decl.userName do
+    msg := msg ++ "\n\nThis metavariable has a name but it is unreachable."
+  if let some e ← getExprMVarAssignment? mvarId then
+    if !fromDelayed then
+      msg := msg ++ "\n\nThis metavariable has been assigned."
+    else
+      msg := msg ++ "\n\nThis metavariable has been assigned, but it appears here via a *delayed assignment*. " ++ delayedExpl
+      msg := msg ++ (← collectAwaiting e)
+  else if !(← mvarId.isAssignable) then
+    msg := msg ++ "\n\nThis metavariable cannot be assigned due to the current metavariable context depth."
+  else if fromDelayed then
+    msg := msg ++ "\n\nThis metavariable appears here via a *delayed assignment*. " ++ delayedExpl
+  if fromDelayed && !decl.lctx.isSubPrefixOf (← getLCtx) then
+    msg := msg ++ (← extraLCtxVars decl)
+  else
+    msg := msg ++ (← absentLCtxVars decl)
+  return msg
+where
+  wrap (n : String) := s!"`{n}`"
+  namesToString (ns : List Name) : String :=
+    String.intercalate ", " <| ns.map fun n => wrap <|
+      if n.hasMacroScopes then
+        n.eraseMacroScopes.toString ++ " (unreachable)"
+      else
+        n.toString
+  extraLCtxVars (mdecl : MetavarDecl) : MetaM String := do
+    let lctx ← getLCtx
+    let ns := mdecl.lctx.foldr (init := []) fun decl ns =>
+      if lctx.contains decl.fvarId then ns else decl.userName :: ns
+    if ns.isEmpty then
+      return ""
+    else
+      return s!"\n\nAdditional {ns.length.plural "variable"} in this metavariable's local context: " ++ namesToString ns
+  absentLCtxVars (mdecl : MetavarDecl) : MetaM String := do
+    let lctx ← getLCtx
+    let lctxInitIndices := lctxInitIndices
+    let ns := lctx.foldr (init := []) fun decl ns =>
+      if decl.index ≥ lctxInitIndices || mdecl.lctx.contains decl.fvarId then ns else decl.userName :: ns
+    if ns.isEmpty then
+      return ""
+    else
+      return s!"\n\n{ns.length.plural "Variable"} absent from this metavariable's local context: " ++ namesToString ns
+  collectAwaiting (e : Expr) : MetaM String := do
+    -- Collect metavariables to diagnose why it is pending.
+    let mut awaitingMVars ← getMVarsNoDelayed e
+    -- Prefer reporting just the metavariables that refer to free variables not in the current context.
+    let lctx ← getLCtx
+    let awaitingMVars' ← awaitingMVars.filterM fun mvar => do
+      let mdecl ← mvar.getDecl
+      return !mdecl.lctx.isSubPrefixOf lctx
+    unless awaitingMVars'.isEmpty do
+      awaitingMVars := awaitingMVars'
+    if awaitingMVars.isEmpty then
+      return ""
+    else
+      let awaitingStrs ← awaitingMVars.mapM (wrap <$> delabMVarAsStr ·)
+      return s!" Substitution is awaiting assignment of the following {awaitingStrs.size.plural "metavariable"}: "
+        ++ String.intercalate ", " awaitingStrs.toList
+
+/--
+Creates an action that creates a description of the metavariable and its status in Markdown format,
+for use in the docstring in `DelabTermInfo`.
+-/
+def mkDescribeMVar (mvarId : MVarId) (fromDelayed : Bool := false) :
+    DelabM (PPContext → IO String) := do
+  let lctxInitIndices := (← read).lctxInitIndices
+  return fun ppCtx => ppCtx.runMetaM do describeMVar mvarId lctxInitIndices (fromDelayed := fromDelayed)
+
+end Lean.PrettyPrinter.Delaborator

--- a/src/Lean/Server/FileWorker/WidgetRequests.lean
+++ b/src/Lean/Server/FileWorker/WidgetRequests.lean
@@ -72,12 +72,14 @@ where
   maybeWithoutTopLevelHighlight : Bool → CodeWithInfos → CodeWithInfos
     | true, .tag _ tt => tt
     | _,    tt        => tt
-  ppExprForPopup (e : Expr) (explicit : Bool := false) : MetaM CodeWithInfos := do
-    let mut e := e
+  ppExprForPopup (e : Expr) (explicit : Bool) : MetaM CodeWithInfos := do
     -- When hovering over a metavariable, we want to see its value, even if `pp.instantiateMVars` is false.
-    if explicit && e.isMVar then
-      if let some e' ← getExprMVarAssignment? e.mvarId! then
-        e := e'
+    if explicit then
+      if let .mvar mvarId := e then
+        if let some e' ← getExprMVarAssignment? mvarId then
+          return ← ppExprForPopupAux e' false
+    ppExprForPopupAux e explicit
+  ppExprForPopupAux (e : Expr) (explicit : Bool) : MetaM CodeWithInfos := do
     -- When `explicit` is false, keep the top-level tag so that users can also see the explicit version of the term on an additional hover.
     maybeWithoutTopLevelHighlight explicit <$> ppExprTagged e do
       if explicit then

--- a/src/Lean/Server/InfoUtils.lean
+++ b/src/Lean/Server/InfoUtils.lean
@@ -328,10 +328,13 @@ def Info.type? (i : Info) : MetaM (Option Expr) :=
 def Info.docString? (i : Info) : MetaM (Option String) := do
   let env ← getEnv
   match i with
-  | .ofDelabTermInfo { docString? := some s, .. } => return s
-  | .ofTermInfo ti
-  | .ofDelabTermInfo ti =>
+  | .ofTermInfo ti =>
     if let some n := ti.expr.constName? then
+      return (← findDocString? env n)
+  | .ofDelabTermInfo ti =>
+    if let some doc ← ti.docString? (← Meta.getPPContext) then
+      return doc
+    else if let some n := ti.expr.constName? then
       return (← findDocString? env n)
   | .ofFieldInfo fi => return ← findDocString? env fi.projName
   | .ofOptionInfo oi =>

--- a/src/Lean/Util/PPExt.lean
+++ b/src/Lean/Util/PPExt.lean
@@ -29,14 +29,6 @@ register_builtin_option pp.rawOnError : Bool := {
   descr    := "(pretty printer) fallback to 'raw' printer when pretty printer fails"
 }
 
-structure PPContext where
-  env           : Environment
-  mctx          : MetavarContext := {}
-  lctx          : LocalContext := {}
-  opts          : Options := {}
-  currNamespace : Name := Name.anonymous
-  openDecls     : List OpenDecl := []
-
 abbrev PrettyPrinter.InfoPerPos := Std.TreeMap Nat Elab.Info
 /-- A format tree with `Elab.Info` annotations.
 Each `.tag n _` node is annotated with `infos[n]`.

--- a/tests/elab/474.lean.out.expected
+++ b/tests/elab/474.lean.out.expected
@@ -4,5 +4,5 @@ fun y_1 => y.add y_1
 fun y => Nat.add FREE y
 fun (y : Nat) => Nat.add y y
 Nat.add ?m y
-Nat.add (?m #0) #0
+Nat.add ?m #0
 fun y => (y.add y).add y

--- a/tests/elab/forInListSpecUnivPoly.lean.out.expected
+++ b/tests/elab/forInListSpecUnivPoly.lean.out.expected
@@ -621,57 +621,61 @@
         wp⟦pure (ForInStep.yield r✝)⟧
           (fun r =>
             match r with
-            | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
-            | ForInStep.done b' => Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-            Prod.snd ?inv),
+            | ForInStep.yield b' => Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+            | ForInStep.done b' =>
+              Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+            Prod.snd ?inv✝),
         (fun r =>
             match r with
-            | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
-            | ForInStep.done b' => Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-            Prod.snd ?inv).snd)
+            | ForInStep.yield b' => Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+            | ForInStep.done b' =>
+              Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+            Prod.snd ?inv✝).snd)
 [Elab.Tactic.Do.spec] pureRflAndAndIntro: wp⟦pure PUnit.unit⟧
       (fun a =>
         wp⟦pure (ForInStep.yield r✝)⟧
           (fun r =>
             match r with
-            | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
-            | ForInStep.done b' => Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-            Prod.snd ?inv),
+            | ForInStep.yield b' => Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+            | ForInStep.done b' =>
+              Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+            Prod.snd ?inv✝),
         (fun r =>
             match r with
-            | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
-            | ForInStep.done b' => Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-            Prod.snd ?inv).snd)
+            | ForInStep.yield b' => Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+            | ForInStep.done b' =>
+              Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+            Prod.snd ?inv✝).snd)
 [Elab.Tactic.Do.spec] discharge? (wp⟦pure PUnit.unit⟧
         (fun a =>
           wp⟦pure (ForInStep.yield r✝)⟧
             (fun r =>
               match r with
-              | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+              | ForInStep.yield b' => Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
               | ForInStep.done b' =>
-                Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-              Prod.snd ?inv),
+                Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+              Prod.snd ?inv✝),
           (fun r =>
               match r with
-              | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+              | ForInStep.yield b' => Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
               | ForInStep.done b' =>
-                Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-              Prod.snd ?inv).snd)).down
+                Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+              Prod.snd ?inv✝).snd)).down
 [Elab.Tactic.Do.spec] pure Prop: (wp⟦pure PUnit.unit⟧
         (fun a =>
           wp⟦pure (ForInStep.yield r✝)⟧
             (fun r =>
               match r with
-              | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+              | ForInStep.yield b' => Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
               | ForInStep.done b' =>
-                Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-              Prod.snd ?inv),
+                Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+              Prod.snd ?inv✝),
           (fun r =>
               match r with
-              | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+              | ForInStep.yield b' => Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
               | ForInStep.done b' =>
-                Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-              Prod.snd ?inv).snd)).down
+                Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+              Prod.snd ?inv✝).snd)).down
 [Elab.Tactic.Do.spec] Candidates for pure PUnit.unit: [SpecProof.global Std.Do.Spec.pure]
 [Elab.Tactic.Do.spec] SpecProof.global Std.Do.Spec.pure instantiates to ⦃Prod.fst ?Q ?a⦄ pure ?a ⦃?Q⦄
 [Elab.Tactic.Do.spec] Specs for pure PUnit.unit: [SpecProof.global Std.Do.Spec.pure]
@@ -679,88 +683,94 @@
           wp⟦pure (ForInStep.yield r✝)⟧
             (fun r =>
               match r with
-              | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+              | ForInStep.yield b' => Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
               | ForInStep.done b' =>
-                Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-              Prod.snd ?inv),
+                Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+              Prod.snd ?inv✝),
           (fun r =>
               match r with
-              | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+              | ForInStep.yield b' => Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
               | ForInStep.done b' =>
-                Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-              Prod.snd ?inv).snd).fst
+                Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+              Prod.snd ?inv✝).snd).fst
       PUnit.unit
 [Elab.Tactic.Do.spec] pureRflAndAndIntro: (fun a =>
           wp⟦pure (ForInStep.yield r✝)⟧
             (fun r =>
               match r with
-              | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+              | ForInStep.yield b' => Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
               | ForInStep.done b' =>
-                Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-              Prod.snd ?inv),
+                Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+              Prod.snd ?inv✝),
           (fun r =>
               match r with
-              | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+              | ForInStep.yield b' => Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
               | ForInStep.done b' =>
-                Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-              Prod.snd ?inv).snd).fst
+                Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+              Prod.snd ?inv✝).snd).fst
       PUnit.unit
 [Elab.Tactic.Do.spec] discharge? ((fun a =>
             wp⟦pure (ForInStep.yield r✝)⟧
               (fun r =>
                 match r with
-                | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+                | ForInStep.yield b' =>
+                  Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
                 | ForInStep.done b' =>
-                  Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-                Prod.snd ?inv),
+                  Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+                Prod.snd ?inv✝),
             (fun r =>
                 match r with
-                | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+                | ForInStep.yield b' =>
+                  Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
                 | ForInStep.done b' =>
-                  Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-                Prod.snd ?inv).snd).fst
+                  Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+                Prod.snd ?inv✝).snd).fst
         PUnit.unit).down
 [Elab.Tactic.Do.spec] pure Prop: ((fun a =>
             wp⟦pure (ForInStep.yield r✝)⟧
               (fun r =>
                 match r with
-                | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+                | ForInStep.yield b' =>
+                  Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
                 | ForInStep.done b' =>
-                  Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-                Prod.snd ?inv),
+                  Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+                Prod.snd ?inv✝),
             (fun r =>
                 match r with
-                | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+                | ForInStep.yield b' =>
+                  Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
                 | ForInStep.done b' =>
-                  Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-                Prod.snd ?inv).snd).fst
+                  Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+                Prod.snd ?inv✝).snd).fst
         PUnit.unit).down
 [Elab.Tactic.Do.spec] Candidates for pure (ForInStep.yield r✝): [SpecProof.global Std.Do.Spec.pure]
 [Elab.Tactic.Do.spec] SpecProof.global Std.Do.Spec.pure instantiates to ⦃Prod.fst ?Q ?a⦄ pure ?a ⦃?Q⦄
 [Elab.Tactic.Do.spec] Specs for pure (ForInStep.yield r✝): [SpecProof.global Std.Do.Spec.pure]
 [Elab.Tactic.Do.spec] dischargeMGoal: (fun r =>
           match r with
-          | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
-          | ForInStep.done b' => Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-          Prod.snd ?inv).fst
+          | ForInStep.yield b' => Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+          | ForInStep.done b' => Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+          Prod.snd ?inv✝).fst
       (ForInStep.yield r✝)
 [Elab.Tactic.Do.spec] pureRflAndAndIntro: (fun r =>
           match r with
-          | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
-          | ForInStep.done b' => Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-          Prod.snd ?inv).fst
+          | ForInStep.yield b' => Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+          | ForInStep.done b' => Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+          Prod.snd ?inv✝).fst
       (ForInStep.yield r✝)
 [Elab.Tactic.Do.spec] discharge? ((fun r =>
             match r with
-            | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
-            | ForInStep.done b' => Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-            Prod.snd ?inv).fst
+            | ForInStep.yield b' => Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+            | ForInStep.done b' =>
+              Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+            Prod.snd ?inv✝).fst
         (ForInStep.yield r✝)).down
 [Elab.Tactic.Do.spec] pure Prop: ((fun r =>
             match r with
-            | ForInStep.yield b' => Prod.fst ?inv ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
-            | ForInStep.done b' => Prod.fst ?inv ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
-            Prod.snd ?inv).fst
+            | ForInStep.yield b' => Prod.fst ?inv✝ ({ «prefix» := pref ++ [cur], suffix := suff, property := ⋯ }, b')
+            | ForInStep.done b' =>
+              Prod.fst ?inv✝ ({ «prefix» := List.range (n✝ - 1), suffix := [], property := ⋯ }, b'),
+            Prod.snd ?inv✝).fst
         (ForInStep.yield r✝)).down
 [Elab.Tactic.Do.spec] Candidates for pure r✝.toArray: [SpecProof.global Std.Do.Spec.pure]
 [Elab.Tactic.Do.spec] SpecProof.global Std.Do.Spec.pure instantiates to ⦃Prod.fst ?Q ?a⦄ pure ?a ⦃?Q⦄

--- a/tests/elab/ppMVarsDocstrings.lean
+++ b/tests/elab/ppMVarsDocstrings.lean
@@ -1,0 +1,170 @@
+import Lean
+/-!
+# Synthetic tests of the dynamic docstrings for metavariables
+-/
+
+set_option linter.unusedVariables false
+
+open Lean Elab Tactic
+
+elab "#delab_docstrings " t:term : command => Command.runTermElabM fun _ => do
+  let e ← Term.elabTerm t none
+  Term.synthesizeSyntheticMVars (postpone := .partial)
+  logInfo m!"Expression: {e}"
+  let { infos, .. } ← Meta.ppExprWithInfos e
+  let infos := Array.qsort infos.toArray (lt := fun (p, _) (p', _) => p < p')
+  for (p, info) in infos do
+    if let .ofDelabTermInfo ti := info then
+      if let some doc ← ti.docString? (← Meta.getPPContext) then
+        let header ← Meta.withLCtx ti.lctx {} do
+          addMessageContext m!"{ti.expr}"
+        logInfo m!"{p}. {header}\n{doc}"
+
+/-!
+Natural metavariable.
+-/
+/--
+info: Expression: ?m.2
+---
+info: 1. ?m.2
+A metavariable representing an expression that should be solved for by unification during the elaboration process. They are created during elaboration as placeholders for implicit arguments and by `_` placeholder syntax.
+-/
+#guard_msgs in #delab_docstrings _
+
+/-!
+Synthetic opaque metavariable.
+-/
+/--
+info: Expression: ?m.2
+---
+info: 1. ?m.2
+A metavariable representing a tactic goal or an expression whose elaboration is still pending. They usually act like constants until they are completely solved for. They can be created using `?_` and `?n` synthetic placeholder syntax.
+-/
+#guard_msgs in #delab_docstrings ?_
+
+/-!
+A synthetic metavariable and a natural metavariable.
+-/
+/--
+info: Expression: @default ?m.1 ?m.2
+---
+info: 5. ?m.2
+A metavariable representing a typeclass instance whose synthesis is still pending. They can be solved for by unification during the elaboration process, but the inferred expression and the synthesized instance must be definitionally equal.
+---
+info: 17. ?m.1
+A metavariable representing an expression that should be solved for by unification during the elaboration process. They are created during elaboration as placeholders for implicit arguments and by `_` placeholder syntax.
+-/
+#guard_msgs in set_option pp.explicit true in #delab_docstrings default
+
+/-!
+A delayed assignment pointing at a synthetic opaque metavariable.
+-/
+/--
+info: Expression: fun n => ?foo
+---
+info: 5. ?foo
+A metavariable representing a tactic goal or an expression whose elaboration is still pending. They usually act like constants until they are completely solved for. They can be created using `?_` and `?n` synthetic placeholder syntax.
+
+This metavariable appears here via a *delayed assignment*. Substitution is delayed until the metavariable's value contains no metavariables, since all occurrences of the variables from its local context will need to be replaced with expressions that are valid in the current context.
+
+Additional variable in this metavariable's local context: `n`
+-/
+#guard_msgs in #delab_docstrings fun (n : Nat) => ?foo
+
+/-!
+An assigned synthetic opaque metavariable that can't be instantiated due to a metavariable.
+-/
+/--
+info: Expression: let f := fun b => ?_;
+f true
+---
+info: 21. ?_
+A metavariable representing a tactic goal or an expression whose elaboration is still pending. They usually act like constants until they are completely solved for. They can be created using `?_` and `?n` synthetic placeholder syntax.
+
+This metavariable has been assigned, but it appears here via a *delayed assignment*. Substitution is delayed until the metavariable's value contains no metavariables, since all occurrences of the variables from its local context will need to be replaced with expressions that are valid in the current context. Substitution is awaiting assignment of the following metavariable: `?foo`
+
+Additional variable in this metavariable's local context: `b`
+-/
+#guard_msgs in
+set_option pp.mvars.anonymous false in
+#delab_docstrings
+  let f := fun (b : _) => if b then ?foo else true
+  f true
+
+elab "#delab_docstrings " t:term : tactic => withMainContext do
+  let e ← Tactic.elabTerm t none
+  logInfo m!"{e}"
+  let { infos, .. } ← Meta.ppExprWithInfos e
+  let infos := Array.qsort infos.toArray (lt := fun (p, _) (p', _) => p < p')
+  for (p, info) in infos do
+    if let .ofDelabTermInfo ti := info then
+      if let some doc ← ti.docString? (← Meta.getPPContext) then
+        let header ← Meta.withLCtx ti.lctx {} do
+          addMessageContext m!"{ti.expr}"
+        logInfo m!"{p}. {header}\n{doc}"
+
+/-!
+Metavariable shadowing. The `case'` tactic creates a new metavariablewith the same name.
+This causes the original one to print as `?foo✝` and to report that the name is unreachable.
+-/
+/--
+info: fun x => ?foo
+---
+info: 5. ?foo
+A metavariable representing a tactic goal or an expression whose elaboration is still pending. They usually act like constants until they are completely solved for. They can be created using `?_` and `?n` synthetic placeholder syntax.
+
+This metavariable appears here via a *delayed assignment*. Substitution is delayed until the metavariable's value contains no metavariables, since all occurrences of the variables from its local context will need to be replaced with expressions that are valid in the current context.
+
+Additional variable in this metavariable's local context: `x`
+---
+info: fun x => ?foo✝
+---
+info: 5. ?foo✝
+A metavariable representing a tactic goal or an expression whose elaboration is still pending. They usually act like constants until they are completely solved for. They can be created using `?_` and `?n` synthetic placeholder syntax.
+
+This metavariable has a name but it is unreachable.
+
+This metavariable has been assigned, but it appears here via a *delayed assignment*. Substitution is delayed until the metavariable's value contains no metavariables, since all occurrences of the variables from its local context will need to be replaced with expressions that are valid in the current context. Substitution is awaiting assignment of the following metavariable: `?foo`
+
+Additional variable in this metavariable's local context: `x`
+---
+info: fun x => 0 + 1
+-/
+#guard_msgs in
+example : True := by
+  let f : Nat → Nat := fun x => ?foo
+  #delab_docstrings value_of% f
+  case' foo => refine ?_ + 1
+  all_goals try #delab_docstrings value_of% f
+  exact 0
+  #delab_docstrings value_of% f
+  trivial
+
+/-!
+Checking that metavariables report which variables are absent from their local contexts.
+-/
+/--
+info: (?foo1, ?foo2, ?foo3)
+---
+info: 17. ?foo1
+A metavariable representing a tactic goal or an expression whose elaboration is still pending. They usually act like constants until they are completely solved for. They can be created using `?_` and `?n` synthetic placeholder syntax.
+
+Variables absent from this metavariable's local context: `x`, `y`, `z`
+---
+info: 21. ?foo3
+A metavariable representing a tactic goal or an expression whose elaboration is still pending. They usually act like constants until they are completely solved for. They can be created using `?_` and `?n` synthetic placeholder syntax.
+
+Variable absent from this metavariable's local context: `z`
+---
+info: 81. ?foo2
+A metavariable representing a tactic goal or an expression whose elaboration is still pending. They usually act like constants until they are completely solved for. They can be created using `?_` and `?n` synthetic placeholder syntax.
+
+Variables absent from this metavariable's local context: `y`, `z`
+-/
+#guard_msgs in
+example : True := by
+  let x : Nat := ?foo1
+  let y : Nat := ?foo2
+  let z : Nat := ?foo3
+  #delab_docstrings (value_of% x, value_of% y, value_of% z)
+  all_goals exact default


### PR DESCRIPTION
This PR improves metavariable pretty printing and their hovers in the InfoView. The hovers in the InfoView now include information about specific metavariables — it includes information such as the kind of the metavariable, whether it is a blocked delayed assignment and which metavariables it is blocked on, and the differences in what variables exist the metavariable's local context. Additionally, named metavariables now pretty print with tombstones if they are inaccessible. Delayed assignment pretty printing now more reliably follows chains of assignments to find the pending metavariable.

**Example hovers**

Hovering over a natural metavariable:
> `?m.7 : Sort ?u.14`
> A metavariable representing an expression that should be solved for by unification during the elaboration process. They are created during elaboration as placeholders for implicit arguments and by `_` placeholder syntax.
>
> Variables absent from this metavariable's local context: `a`, `b`, `y`

Hovering over `?baz`, a tactic goal:
> `?baz : ∀ (a : ?m.7) (a : ?m.8), True`
> A metavariable representing a tactic goal or an expression whose elaboration is still pending. They usually act like constants until they are completely solved for. They can be created using `?_` and `?n` synthetic placeholder syntax.
>
> Variables absent from this metavariable's local context: `a`, `b`, `y`

Hovering over `?refine_1`, which appears under a binder:
> `?m.4 x : Nat`
> A metavariable representing a tactic goal or an expression whose elaboration is still pending. They usually act like constants until they are completely solved for. They can be created using `?_` and `?n` synthetic placeholder syntax.
>
> This metavariable appears here via a *delayed assignment*. Substitution is delayed until the metavariable's value contains no metavariables, since all occurrences of the variables from its local context will need to be replaced with expressions that are valid in the current context.
>
> Additional variable in this metavariable's local context: `x`

Hovering over `?m.4`:
> `?m.4 : Nat → Nat`
> Part of the encoding of the *delayed assignment* mechanism. Represents the metavariable `?refine_1`, which has additional local context variables. Substitution is delayed until the metavariable's value contains no metavariables, since all occurrences of the variables from its local context will need to be replaced with expressions that are valid in the current context.
>
> Additional variable in this metavariable's local context: `x`

The middle paragraph for `?refine_1` when it has been partially assigned:
> This metavariable has been assigned, but it is a *delayed assignment*. Substitution is delayed until the metavariable's value contains no metavariables, since all occurrences of the variables from its local context will need to be replaced with expressions that are valid in the current context. Substitution is awaiting assignment of the following metavariable: `?foo`