### PR TITLE
refactor: promote `repeat`/`while` builtin parsers to default priority

### DIFF
--- a/src/Init/While.lean
+++ b/src/Init/While.lean
@@ -10,13 +10,14 @@ public import Init.Core
 
 public section
 
-/-!
-# Notation for `while` and `repeat` loops.
--/
-
 namespace Lean
 
-/-! # `repeat` and `while` notation -/
+/-!
+# `while` and `repeat` loop support
+
+The parsers for `repeat`, `while`, and `repeat ... until` are
+`@[builtin_doElem_parser]` definitions in `Lean.Parser.Do`.
+-/
 
 inductive Loop where
   | mk
@@ -32,23 +33,20 @@ partial def Loop.forIn {β : Type u} {m : Type u → Type v} [Monad m] (_ : Loop
 instance [Monad m] : ForIn m Loop Unit where
   forIn := Loop.forIn
 
-syntax (name := doRepeat) "repeat " doSeq : doElem
+-- The canonical parsers for `repeat`/`while`/`repeat ... until` live in `Lean.Parser.Do`
+-- as `@[builtin_doElem_parser]` definitions. We register the expansion macros here so
+-- they are available to `prelude` files in `Init`, which do not import `Lean.Elab`.
 
 macro_rules
   | `(doElem| repeat%$tk $seq) => `(doElem| for%$tk _ in Loop.mk do $seq)
-
-syntax "while " ident " : " termBeforeDo " do " doSeq : doElem
 
 macro_rules
   | `(doElem| while%$tk $h : $cond do $seq) =>
     `(doElem| repeat%$tk if $h:ident : $cond then $seq else break)
 
-syntax "while " termBeforeDo " do " doSeq : doElem
-
 macro_rules
-  | `(doElem| while%$tk $cond do $seq) => `(doElem| repeat%$tk if $cond then $seq else break)
-
-syntax "repeat " doSeq ppDedent(ppLine) "until " term : doElem
+  | `(doElem| while%$tk $cond do $seq) =>
+    `(doElem| repeat%$tk if $cond then $seq else break)
 
 macro_rules
   | `(doElem| repeat%$tk $seq until $cond) =>

--- a/src/Lean/Parser/Do.lean
+++ b/src/Lean/Parser/Do.lean
@@ -273,16 +273,13 @@ with debug assertions enabled (see the `debugAssertions` option).
 @[builtin_doElem_parser] def doDebugAssert := leading_parser:leadPrec
   "debug_assert! " >> termParser
 
--- Lower priority than the bootstrapping `syntax` declarations in `Init.While` so that, during the
--- transition period where both exist, only the `Init.While` parser fires (no `choice` ambiguity).
--- After the next stage0 update, `Init.While` syntax will be removed and these become sole parsers.
-@[builtin_doElem_parser low] def doRepeat      := leading_parser
+@[builtin_doElem_parser] def doRepeat      := leading_parser
   "repeat " >> doSeq
-@[builtin_doElem_parser low] def doWhileH      := leading_parser
+@[builtin_doElem_parser] def doWhileH      := leading_parser
   "while " >> ident >> " : " >> withForbidden "do" termParser >> " do " >> doSeq
-@[builtin_doElem_parser low] def doWhile       := leading_parser
+@[builtin_doElem_parser] def doWhile       := leading_parser
   "while " >> withForbidden "do" termParser >> " do " >> doSeq
-@[builtin_doElem_parser low] def doRepeatUntil := leading_parser
+@[builtin_doElem_parser] def doRepeatUntil := leading_parser
   "repeat " >> doSeq >> ppDedent ppLine >> "until " >> termParser
 
 /-


### PR DESCRIPTION
This PR removes the transitional `syntax` declarations for `repeat`, `while`, and `repeat ... until` from `Init.While` and promotes the corresponding `@[builtin_doElem_parser]` defs in `Lean.Parser.Do` from `low` to default priority, making them the canonical parsers.

The `macro_rules` in `Init.While` are kept as a bootstrap: they expand `repeat`/`while`/`until` directly to `for _ in Loop.mk do ...`, which is what any `prelude` Init file needs. The `@[builtin_macro]` / `@[builtin_doElem_elab]` in `Lean.Elab.BuiltinDo.Repeat` are only visible once `Lean.Elab.*` is transitively imported, so they cannot serve Init bootstrap. The duplication will be removed in a follow-up after the next stage0 update.