### PR TITLE
fix: eta-reduce patterns containing loose pattern variables

### DIFF
--- a/src/Lean/Meta/Sym/Eta.lean
+++ b/src/Lean/Meta/Sym/Eta.lean
@@ -9,19 +9,37 @@ public import Lean.Meta.Sym.ExprPtr
 public import Lean.Meta.Basic
 import Lean.Meta.Transform
 namespace Lean.Meta.Sym
+
+/--
+Returns `true` if `e` contains a loose bound variable with index in `[0, n)`
+This function assumes `n` is small. If this becomes a bottleneck, we should
+implement a version of `lean_expr_has_loose_bvar` that checks the range in one traversal.
+-/
+def hasLooseBVarsInRange (e : Expr) (n : Nat) : Bool :=
+  e.hasLooseBVars && go n
+where
+  go : Nat → Bool
+  | 0 => false
+  | i+1 => e.hasLooseBVar i || go i
+
 /--
 Checks if `body` is eta-expanded with `n` applications: `f (.bvar (n-1)) ... (.bvar 0)`.
-Returns `f` if so and `f` has no loose bvars; otherwise returns `default`.
+Returns `f` if so and `f` has no loose bvars with indices in the range `[0, n)`; otherwise returns `default`.
 - `n`: number of remaining applications to check
 - `i`: expected bvar index (starts at 0, increments with each application)
 - `default`: returned when not eta-reducible (enables pointer equality check)
 -/
-def etaReduceAux (body : Expr) (n : Nat) (i : Nat) (default : Expr) : Expr := Id.run do
-  match n with
-  | 0 => if body.hasLooseBVars then default else body
-  | n+1 =>
-    let .app f (.bvar j) := body | default
-    if j == i then etaReduceAux f n (i+1) default else default
+def etaReduceAux (body : Expr) (n : Nat) (i : Nat) (default : Expr) : Expr :=
+  go body n i
+where
+  go (body : Expr) (m : Nat) (i : Nat) : Expr := Id.run do
+    match m with
+    | 0 =>
+      if hasLooseBVarsInRange body n then default
+      else body.lowerLooseBVars n n
+    | m+1 =>
+      let .app f (.bvar j) := body | default
+      if j == i then go f m (i+1) else default
 
 /--
 If `e` is of the form `(fun x₁ ... xₙ => f x₁ ... xₙ)` and `f` does not contain `x₁`, ..., `xₙ`,

--- a/tests/elab/sym_eta_mwe.lean
+++ b/tests/elab/sym_eta_mwe.lean
@@ -1,0 +1,55 @@
+/-
+MWE: `Sym.DiscrTree.getMatch` misses an entry whose `Pattern.match?` succeeds.
+
+We insert patterns for `Spec.forIn_iterM_id` and `Spec.IterM.forIn_map` into a
+`Sym.DiscrTree`. Looking up `forIn (IterM.map ...) ...` via `getMatch` returns only
+`forIn_iterM_id`, but brute-force `Pattern.match?` also finds `IterM.forIn_map`.
+-/
+import Lean
+import Std
+
+open Lean Meta Sym Std Do
+
+/-- Extract the program from a `@[spec]` theorem `∀ ..., Triple prog P Q`. -/
+private def mkProgPattern (declName : Name) : MetaM Pattern := do
+  let ci ← getConstInfo declName
+  let expr ← mkExpectedTypeHint (← mkConstWithLevelParams declName) ci.type
+  Prod.fst <$> (mkPatternFromExprWithKey expr ci.levelParams fun type => do
+    let type ← whnfR type
+    let_expr Triple _m _ps _inst _α prog _P _Q := type
+      | throwError "not a Triple: {indentExpr type}"
+    return (prog, ())).run' {}
+
+/-- A `forIn` on a mapped iterator — the expression we want to look up. -/
+noncomputable def lookupTerm : Id Unit :=
+  forIn ((#[0].iterM Id).map id) () fun _ _ => pure (.yield ())
+
+/--
+info: getMatch:       [Std.Do.Spec.forIn_iterM_id, Std.Do.Spec.IterM.forIn_map]
+pattern.match?: [Std.Do.Spec.IterM.forIn_map, Std.Do.Spec.forIn_iterM_id]
+---
+info: GOOD: getMatch and brute-force agree
+-/
+#guard_msgs in
+#eval show MetaM Unit from do
+  let patMap ← mkProgPattern ``Spec.IterM.forIn_map
+  let patGeneric ← mkProgPattern ``Spec.forIn_iterM_id
+
+  let mut tree : DiscrTree Name := .empty
+  tree := insertPattern tree patMap ``Spec.IterM.forIn_map
+  tree := insertPattern tree patGeneric ``Spec.forIn_iterM_id
+
+  let e ← instantiateMVars (← getConstInfo ``lookupTerm).value?.get!
+  let e ← SymM.run (shareCommon e)
+
+  let treeResults := Sym.getMatch tree e
+  let mut bruteResults : Array Name := #[]
+  for (name, pat) in #[(``Spec.IterM.forIn_map, patMap), (``Spec.forIn_iterM_id, patGeneric)] do
+    if let some _ ← SymM.run (pat.match? e) then
+      bruteResults := bruteResults.push name
+
+  logInfo m!"getMatch:       {treeResults}\npattern.match?: {bruteResults}"
+  if treeResults.size < bruteResults.size then
+    logInfo "BUG: getMatch missed entries that pattern.match? finds"
+  else
+    logInfo "GOOD: getMatch and brute-force agree"

--- a/tests/elab/sym_pattern_2.lean
+++ b/tests/elab/sym_pattern_2.lean
@@ -111,7 +111,33 @@ info: [Std.HashMap.insertMany,
  *,
  *]
 ---
-info: [GetElem.getElem, Std.HashMap, *, *, *, *, *, *, ◾, *, Std.HashMap.insert, *, *, *, *, *, *, *, *, *]
+info: [GetElem.getElem,
+ Std.HashMap,
+ *,
+ *,
+ *,
+ *,
+ *,
+ *,
+ Membership.mem,
+ *,
+ Std.HashMap,
+ *,
+ *,
+ *,
+ *,
+ *,
+ *,
+ Std.HashMap.insert,
+ *,
+ *,
+ *,
+ *,
+ *,
+ *,
+ *,
+ *,
+ *]
 -/
 #guard_msgs in
 #eval SymM.run do

--- a/tests/elab/sym_simp_1.lean
+++ b/tests/elab/sym_simp_1.lean
@@ -137,3 +137,9 @@ def foo (x : Nat) :=
 
 example : foo 0 = true := by
   sym_simp [foo.eq_def, foo.match_1.eq_1, eq_self]
+
+theorem exists_eq_True (a : α) : (∃ x, a = x) = True := by
+  simp
+
+example (b : Nat) : ∃ x, b = x := by
+  sym_simp [exists_eq_True]


### PR DESCRIPTION
This PR fixes a regression in `Sym.simp` where rewrite rules whose LHS contains a lambda over a pattern variable (e.g. `∃ x, a = x`) failed to match targets with semantically equivalent structure.

`Sym.etaReduceAux` previously refused any eta-reduction whenever the body had loose bound variables, but patterns produced by stripping outer foralls always carry such loose bvars. The eta-reduction therefore skipped patterns while still firing on the target, producing mismatched discrimination tree keys and no match.

The fix narrows the check to loose bvars in the range `[0, n)` (those that would actually refer to the peeled binders) and lowers any remaining loose bvars by `n` so that pattern-variable references stay consistent in the reduced expression. The discrimination tree now classifies patterns like `exists_eq_True : (∃ x, a = x) = True` with their full structure rather than falling back to `.other`.

Includes a regression test (`sym_simp_1.lean`) and Sebastian Graf's MWE (`sym_eta_mwe.lean`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)