### PR TITLE
chore: fix Sym benchmarks using stale `run'` API

### DIFF
--- a/tests/bench/sym/add_sub_cancel.lean
+++ b/tests/bench/sym/add_sub_cancel.lean
@@ -402,7 +402,7 @@ partial def solveReusingCache (mvarId : MVarId) : SymM Unit := do
   return
 
 def solveUsingCSym (n : Nat) (check := true) : MetaM Unit := do
-  driver n check fun mvarId => SymM.run do solveReusingCache mvarId |>.run' {}
+  driver n check fun mvarId => SymM.run do solveReusingCache mvarId |>.run {}
 
 def runBenchUsingCSym : MetaM Unit := do
   IO.println "=== Symbolic Simulation Tests ==="

--- a/tests/bench/sym/meta_simp_1.lean
+++ b/tests/bench/sym/meta_simp_1.lean
@@ -14,7 +14,7 @@ def mkSimpContext (config : Simp.Config := {}) : MetaM Simp.Context := do
   let config := { config with implicitDefEqProofs := false }
   Simp.mkContext config #[s] {}
 
-def simp (e : Expr) : MetaM (Simp.Result × Float) := Sym.SymM.run' do
+def simp (e : Expr) : MetaM (Simp.Result × Float) := Sym.SymM.run do
   -- let e ← Grind.shareCommon e
   let startTime ← IO.monoNanosNow
   let (r, _) ← Meta.simp e (← mkSimpContext)


### PR DESCRIPTION
This PR updates two Sym benchmarks (`add_sub_cancel.lean` and `meta_simp_1.lean`) to use the current `SymM.run` API. Both files still referenced `run'`, which no longer exists, so they failed to elaborate.