### PR TITLE
feat: add Array and Vector set! lemmas

### DIFF
--- a/src/Init/Data/Array/Lemmas.lean
+++ b/src/Init/Data/Array/Lemmas.lean
@@ -4715,15 +4715,6 @@ theorem getElem!_set!_ne [Inhabited α] (xs : Array α) (i j : Nat) (x : α) (hi
     (xs.set! i x).toList = xs.toList.set i x := by
   simp [set!_eq_setIfInBounds]
 
-theorem getElem!_le_set!_incr (xs : Array Nat) (k i : Nat) (hk : k < xs.size) :
-    xs[i]! ≤ (xs.set! k (xs[k]! + 1))[i]! := by
-  by_cases h : k = i
-  · subst h
-    rw [getElem!_set!_self xs _ _ hk]
-    omega
-  · rw [getElem!_set!_ne xs _ _ _ h]
-    omega
-
 end Array
 
 namespace List

--- a/src/Init/Data/Array/Lemmas.lean
+++ b/src/Init/Data/Array/Lemmas.lean
@@ -4692,6 +4692,38 @@ theorem toList_fst_unzip {xs : Array (α × β)} :
 theorem toList_snd_unzip {xs : Array (α × β)} :
     xs.unzip.2.toList = xs.toList.unzip.2 := by simp
 
+theorem getElem?_eq_some_getElem! [Inhabited α] (xs : Array α) (i : Nat)
+    (h : i < xs.size) : xs[i]? = some xs[i]! := by
+  rw [getElem!_pos xs i h]
+  exact getElem?_pos xs i h
+
+theorem size_set! (xs : Array α) (i : Nat) (x : α) :
+    (xs.set! i x).size = xs.size := by
+  simp only [set!_eq_setIfInBounds, size_setIfInBounds]
+
+theorem getElem!_set!_self [Inhabited α] (xs : Array α) (i : Nat) (x : α) (hi : i < xs.size) :
+    (xs.set! i x)[i]! = x := by
+  simp only [set!_eq_setIfInBounds, getElem!_eq_getD, getD_eq_getD_getElem?,
+    getElem?_setIfInBounds_self_of_lt hi, Option.getD_some]
+
+theorem getElem!_set!_ne [Inhabited α] (xs : Array α) (i j : Nat) (x : α) (hij : i ≠ j) :
+    (xs.set! i x)[j]! = xs[j]! := by
+  simp only [set!_eq_setIfInBounds, getElem!_eq_getD, getD_eq_getD_getElem?,
+    getElem?_setIfInBounds_ne hij]
+
+@[simp] theorem toList_set! {xs : Array α} {i : Nat} {x : α} :
+    (xs.set! i x).toList = xs.toList.set i x := by
+  simp [set!_eq_setIfInBounds]
+
+theorem getElem!_le_set!_incr (xs : Array Nat) (k i : Nat) (hk : k < xs.size) :
+    xs[i]! ≤ (xs.set! k (xs[k]! + 1))[i]! := by
+  by_cases h : k = i
+  · subst h
+    rw [getElem!_set!_self xs _ _ hk]
+    omega
+  · rw [getElem!_set!_ne xs _ _ _ h]
+    omega
+
 end Array
 
 namespace List

--- a/src/Init/Data/Vector/Lemmas.lean
+++ b/src/Init/Data/Vector/Lemmas.lean
@@ -3180,3 +3180,48 @@ theorem prod_eq_foldl [One α] [Mul α]
     {xs : Vector α n} :
     xs.prod = xs.foldl (b := 1) (· * ·) := by
   simp [← prod_toList, List.prod_eq_foldl]
+
+@[simp] theorem toList_set! {xs : Vector α n} {i : Nat} {x : α} :
+    (xs.set! i x).toList = xs.toList.set i x := by
+  cases xs
+  simp [Array.set!_eq_setIfInBounds]
+
+theorem set!_eq_setIfInBounds {xs : Vector α n} {i : Nat} {x : α} :
+    xs.set! i x = xs.setIfInBounds i x := by
+  cases xs
+  simp [Array.set!_eq_setIfInBounds]
+
+@[grind =] theorem getElem_set! {xs : Vector α n} {x : α} (hj : j < n) :
+    (xs.set! i x)[j] = if i = j then x else xs[j] := by
+  rw [set!_eq_setIfInBounds]
+  simp [getElem_setIfInBounds]
+
+@[simp] theorem getElem_set!_self {xs : Vector α n} {x : α} (hi : i < n) :
+    (xs.set! i x)[i] = x := by
+  rw [set!_eq_setIfInBounds]
+  simp [getElem_setIfInBounds_self]
+
+@[simp] theorem getElem_set!_ne {xs : Vector α n} {x : α} (hj : j < n) (h : i ≠ j) :
+    (xs.set! i x)[j] = xs[j] := by
+  rw [set!_eq_setIfInBounds]
+  simp [getElem_setIfInBounds_ne, h]
+
+@[grind =] theorem getElem?_set! {xs : Vector α n} {x : α} :
+    (xs.set! i x)[j]? = if i = j then if i < n then some x else none else xs[j]? := by
+  rw [set!_eq_setIfInBounds]
+  simp [getElem?_setIfInBounds]
+
+theorem getElem?_set!_self {xs : Vector α n} {x : α} :
+    (xs.set! i x)[i]? = if i < n then some x else none := by
+  rw [set!_eq_setIfInBounds]
+  simp [getElem?_setIfInBounds_self]
+
+@[simp] theorem getElem?_set!_self_of_lt {xs : Vector α n} {x : α} (h : i < n) :
+    (xs.set! i x)[i]? = some x := by
+  rw [set!_eq_setIfInBounds]
+  simp [h]
+
+@[simp] theorem getElem?_set!_ne {xs : Vector α n} {x : α} (h : i ≠ j) :
+    (xs.set! i x)[j]? = xs[j]? := by
+  rw [set!_eq_setIfInBounds]
+  simp [getElem?_setIfInBounds_ne, h]


### PR DESCRIPTION
This PR adds some missing `Array` and `Vector` `set!` convenience lemmas.

It adds the general `set!`, `getElem!`, `getElem?`, and `toList` convenience layer for `Array` and `Vector` on top of the existing `setIfInBounds` API. 