### PR TITLE
chore: add AGENTS.md symlink to CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.claude/CLAUDE.md


### PR DESCRIPTION
This PR adds an `AGENTS.md` symlink to `.claude/CLAUDE.md` so Codex-style repository instructions can resolve to the same checked-in guidance Claude Code already uses.

This keeps the repository's agent-facing instructions in one place instead of maintaining separate copies for different tools. Previous Codex runs did not automatically pick up the existing `.claude/CLAUDE.md` guidance, which caused avoidable drift in PR formatting and workflow behavior.
