### PR TITLE
refactor: lake: use `InputVer` in `Dependency`

### DIFF
--- a/src/lake/Lake/CLI/Translate/Lean.lean
+++ b/src/lake/Lake/CLI/Translate/Lean.lean
@@ -260,14 +260,17 @@ def Dependency.mkRequire (cfg : Dependency) : RequireDecl := Unhygienic.run do
       `(fromSource|$(toLean dir):term)
     | .git url rev? subDir? =>
       `(fromSource|git $(toLean url) $[@ $(rev?.map toLean)]? $[/ $(subDir?.map toLean)]?)
-  let ver? ←
-    if let some ver := cfg.version? then
-      if ver.startsWith "git#" then
-        some <$> `(verSpec|git $(toLean <| ver.drop 4 |>.copy))
-      else
-        some <$> `(verSpec|$(toLean ver):term)
-    else
-      pure none
+  let ver? ← id do
+    match cfg.version with
+    | .none => return none
+    | .git rev =>
+      match cfg.src? with
+      | some (.git (rev := some gitRev) ..) =>
+        if gitRev == rev then
+          return none -- will be derived from the source above
+        else some <$> `(verSpec|git $(toLean rev))
+      | _ => some <$> `(verSpec|git $(toLean rev))
+    | .ver ver => some <$> `(verSpec|$(toLean ver.toString):term)
   let scope? := if cfg.scope.isEmpty then none else some (toLean cfg.scope)
   let opts? := if cfg.opts.isEmpty then none else some <| Unhygienic.run do
     cfg.opts.foldlM (init := mkCIdent ``NameMap.empty) fun stx opt val =>

--- a/src/lake/Lake/CLI/Translate/Toml.lean
+++ b/src/lake/Lake/CLI/Translate/Toml.lean
@@ -132,14 +132,24 @@ public protected def Dependency.toToml (dep : Dependency) (t : Table  := {}) : T
   let t := t
     |>.insert `name dep.name
     |>.insertD `scope dep.scope ""
-    |>.smartInsert `version dep.version?
+  let t :=
+    match dep.version with
+    | .none => t
+    | .git rev =>
+      match dep.src? with
+      | some (.git (rev := some gitRev) ..) =>
+        if gitRev == rev then
+          t -- `rev` will be set below
+        else t.insert `version s!"git#{rev}"
+      | _ => t.insert `rev rev
+    | .ver ver => t.insert `version ver.toString
   let t :=
     if let some src := dep.src? then
       match src with
       | .path dir => t.insert `path (toToml dir)
-      | .git url rev subDir? =>
+      | .git url rev? subDir? =>
         t.insert `git url
-        |>.smartInsert `rev rev
+        |>.smartInsert `rev rev?
         |>.smartInsert `subDir subDir?
     else
       t

--- a/src/lake/Lake/Config/Dependency.lean
+++ b/src/lake/Lake/Config/Dependency.lean
@@ -32,13 +32,13 @@ public inductive InputVer
 /--
 A Git revision to resolve to a commit hash.
 
-This is specified by an  `@ git <rev>`  clause in Lean or `rev = <rev>` field in TOML.
+This is specified by an `@ git <rev>` clause in Lean or `rev = <rev>` field in TOML.
 -/
 | protected git (rev : GitRev)
 /--
 A semantic version range of acceptable versions.
 
-This is specified by an `@ <ver>` clause in Lean or `verison = <ver>` field in TOML.
+This is specified by an `@ <ver>` clause in Lean or `version = <ver>` field in TOML.
 -/
 | protected ver (ver : VerRange)
 deriving Inhabited, Repr
@@ -110,7 +110,7 @@ public structure Dependency where
 
 namespace Dependency
 
-/-- Returns the directory name used for storing the materialized depedency. -/
+/-- Returns the directory name used for storing the materialized dependency. -/
 @[inline] public def dirName (dep : Dependency) : String :=
   dep.name.toString (escape := false)
 
@@ -122,12 +122,12 @@ namespace Dependency
 @[inline] public def reservoirName (dep : Dependency) : String :=
   dep.name.toString (escape := false)
 
-/-- Returns the full name of the dependency  (i.e., `<scope>/<name>`) formatted for printing. -/
+/-- Returns the full name of the dependency (i.e., `<scope>/<name>`) formatted for printing. -/
 @[inline] public def fullName (dep : Dependency) : String :=
   s!"{dep.scope}/{dep.prettyName}"
 
-/--  Returns a printable string which uniquely identifies this dependency for the resolver. -/
+/-- Returns a printable string which uniquely identifies this dependency for the resolver. -/
 @[inline] public def resolverDescr (dep : Dependency) : String :=
-  let name :=  dep.name.toString (escape := false)
+  let name := dep.name.toString (escape := false)
   let name := dep.version.toString?.elim name (s!"{name}@{·}")
   if dep.scope.isEmpty then name else s!"{dep.scope}/{name}"

--- a/src/lake/Lake/Config/Dependency.lean
+++ b/src/lake/Lake/Config/Dependency.lean
@@ -8,9 +8,11 @@ module
 prelude
 public import Init.Dynamic
 public import Init.System.FilePath
+public import Init.Data.ToString.Name
 public import Lean.Data.NameMap.Basic
 public import Lake.Util.Git
-import Init.Data.ToString.Name
+public import Lake.Util.Version
+import Init.Data.String.TakeDrop
 import Init.Data.ToString.Macro
 
 /- # Package Dependency Configuration
@@ -22,6 +24,44 @@ Lake package (i.e., the information contained in the `require` DSL syntax).
 open System Lean
 
 namespace Lake
+
+/-- A version targeted by a dependency (e.g., in a `require`). -/
+public inductive InputVer
+/-- No version was specified. -/
+| protected none
+/--
+A Git revision to resolve to a commit hash.
+
+This is specified by an  `@ git <rev>`  clause in Lean or `rev = <rev>` field in TOML.
+-/
+| protected git (rev : GitRev)
+/--
+A semantic version range of acceptable versions.
+
+This is specified by an `@ <ver>` clause in Lean or `verison = <ver>` field in TOML.
+-/
+| protected ver (ver : VerRange)
+deriving Inhabited, Repr
+
+namespace InputVer
+
+public def parse (ver : String) : Except String InputVer :=
+  if let some ver := ver.dropPrefix? "git#" then
+    return .git ver.toString
+  else
+    match VerRange.parse ver with
+    | .ok ver => return .ver ver
+    | .error e => throw e
+
+instance : DecodeVersion InputVer := ⟨InputVer.parse⟩
+
+public def toString? (self : InputVer) : Option String :=
+  match self with
+  | .none => none
+  | .git rev => some s!"git#{rev}"
+  | .ver ver => some ver.toString
+
+end InputVer
 
 /--
 The source of a `Dependency`.
@@ -54,9 +94,8 @@ public structure Dependency where
   scope : String
   /--
   The target version of the dependency.
-  A Git revision can be specified with the syntax `git#<rev>`.
   -/
-  version? : Option String
+  version : InputVer
   /--
   The source of a dependency.
   If none, looks up the dependency in the default registry (e.g., Reservoir).
@@ -69,6 +108,26 @@ public structure Dependency where
   opts : NameMap String
   deriving Inhabited, TypeName
 
-/-- The full name of a dependency (i.e., `<scope>/<name>`)-/
-public def Dependency.fullName (dep : Dependency) : String :=
-  s!"{dep.scope}/{dep.name.toString}"
+namespace Dependency
+
+/-- Returns the directory name used for storing the materialized depedency. -/
+@[inline] public def dirName (dep : Dependency) : String :=
+  dep.name.toString (escape := false)
+
+/-- Returns the name of the dependency formatted for printing. -/
+@[inline] public def prettyName (dep : Dependency) : String :=
+  dep.name.toString (escape := false)
+
+/-- Returns the name of the dependency formatted for lookup on Reservoir. -/
+@[inline] public def reservoirName (dep : Dependency) : String :=
+  dep.name.toString (escape := false)
+
+/-- Returns the full name of the dependency  (i.e., `<scope>/<name>`) formatted for printing. -/
+@[inline] public def fullName (dep : Dependency) : String :=
+  s!"{dep.scope}/{dep.prettyName}"
+
+/--  Returns a printable string which uniquely identifies this dependency for the resolver. -/
+@[inline] public def resolverDescr (dep : Dependency) : String :=
+  let name :=  dep.name.toString (escape := false)
+  let name := dep.version.toString?.elim name (s!"{name}@{·}")
+  if dep.scope.isEmpty then name else s!"{dep.scope}/{name}"

--- a/src/lake/Lake/Config/Package.lean
+++ b/src/lake/Lake/Config/Package.lean
@@ -161,7 +161,7 @@ public def id? (self : Package) : Option PkgId :=
   if self.bootstrap then none else some <| self.origName.toString (escape := false)
 
 /-- The package version. -/
-@[inline] public def version (self : Package) : LeanVer  :=
+@[inline] public def version (self : Package) : StdVer  :=
   self.config.version
 
 /-- The package's `versionTags` configuration. -/

--- a/src/lake/Lake/DSL/Require.lean
+++ b/src/lake/Lake/DSL/Require.lean
@@ -42,16 +42,20 @@ def expandDepSpec (stx : TSyntax ``depSpec) (doc? : Option DocComment) : MacroM 
   let ver ←
     if let some ver := ver? then withRef ver do
       match ver with
-      | `(verSpec|git $ver) => ``(some ("git#" ++ $ver))
-      | `(verSpec|$ver:term) => ``(some $ver)
+      | `(verSpec|git $rev) => ``(InputVer.git $rev)
+      | `(verSpec|$ver:term) => ``((eval_ver% $ver : InputVer))
       | _ => Macro.throwErrorAt ver "ill-formed version syntax"
+    else if let some src := src? then
+      match src with
+      | `(fromSource|git $_ @ $rev $[/ $_]?) => withRef rev ``(InputVer.git $rev)
+      | _ => ``(InputVer.none)
     else
-      ``(none)
+       ``(InputVer.none)
   let name := expandIdentOrStrAsIdent nameStx
   `($[$doc?:docComment]? @[package_dep] def $name : $(mkCIdent ``Dependency) := {
     name :=  $(quote name.getId),
     scope := $scope,
-    version? := $ver,
+    version := $ver,
     src? := $(← quoteOptTerm src?),
     opts := $(opts?.getD <| ← `({})),
   })

--- a/src/lake/Lake/DSL/Syntax.lean
+++ b/src/lake/Lake/DSL/Syntax.lean
@@ -402,6 +402,11 @@ scoped syntax (name := scriptDecl)
 Defines the `v!"<ver>"` syntax for version literals.
 -/
 
+/-- Helper gadget for decoding versions from arbitrary terms. -/
+scoped syntax:lead (name := evalVer)
+  "eval_ver%" term
+: term
+
 /-- A Lake version literal. -/
 scoped syntax:max (name := verLit)
   "v!" noWs interpolatedStr(term)

--- a/src/lake/Lake/DSL/VerLit.lean
+++ b/src/lake/Lake/DSL/VerLit.lean
@@ -89,7 +89,7 @@ def evalDecodeVersion (stx : Term) (expectedType : Expr) : TermElabM Expr := do
 @[builtin_term_elab evalVer]
 def elabEvalVersion : TermElab := fun stx expectedType? => do
   let `(eval_ver% $v) := stx
-    | throwError "ill-formed `decode_version%` syntax"
+    | throwError "ill-formed `eval_ver%` syntax"
   tryPostponeIfNoneOrMVar expectedType?
   let some expectedType := expectedType?
     | throwError "expected type is not known"

--- a/src/lake/Lake/DSL/VerLit.lean
+++ b/src/lake/Lake/DSL/VerLit.lean
@@ -8,6 +8,7 @@ module
 prelude
 public import Lean.ToExpr
 public import Lake.Util.Version
+public import Lake.Config.Dependency
 import Lake.DSL.Syntax
 import Lean.Meta.Eval
 
@@ -22,29 +23,81 @@ expected type and then applies it to the string literal.
 
 namespace Lake.DSL
 
+public protected def SemVerCore.toExpr (self : SemVerCore) : Expr :=
+  mkApp3 (mkConst ``SemVerCore.mk) (toExpr self.major) (toExpr self.minor) (toExpr self.patch)
+
 public instance : ToExpr SemVerCore where
-  toExpr ver := mkAppN (mkConst ``SemVerCore.mk)
-    #[toExpr ver.major, toExpr ver.minor, toExpr ver.patch]
+  toExpr := SemVerCore.toExpr
   toTypeExpr := mkConst ``SemVerCore
 
+public protected def StdVer.toExpr (self : StdVer) : Expr :=
+  mkApp2 (mkConst ``StdVer.mk) (toExpr self.toSemVerCore) (toExpr self.specialDescr)
+
 public instance : ToExpr StdVer where
-  toExpr ver := mkAppN (mkConst ``StdVer.mk)
-    #[toExpr ver.toSemVerCore, toExpr ver.specialDescr]
+  toExpr := StdVer.toExpr
   toTypeExpr := mkConst ``StdVer
+
+public protected def ComparatorOp.toExpr (self : ComparatorOp) : Expr :=
+  match self with
+  | .lt => mkConst ``ComparatorOp.lt
+  | .le => mkConst ``ComparatorOp.le
+  | .gt => mkConst ``ComparatorOp.gt
+  | .ge => mkConst ``ComparatorOp.ge
+  | .eq => mkConst ``ComparatorOp.eq
+  | .ne => mkConst ``ComparatorOp.ne
+
+public instance : ToExpr ComparatorOp where
+  toExpr := ComparatorOp.toExpr
+  toTypeExpr := mkConst ``ComparatorOp
+
+public protected def VerComparator.toExpr (self : VerComparator) : Expr :=
+  mkApp3 (mkConst ``VerComparator.mk) (toExpr self.ver) (toExpr self.op) (toExpr self.includeSuffixes)
+
+public instance : ToExpr VerComparator where
+  toExpr := VerComparator.toExpr
+  toTypeExpr := mkConst ``VerComparator
+
+public protected def VerRange.toExpr (self : VerRange) : Expr :=
+  mkApp2 (mkConst ``VerRange.mk) (toExpr self.toString) (toExpr self.clauses)
+
+public instance : ToExpr VerRange where
+  toExpr := VerRange.toExpr
+  toTypeExpr := mkConst ``VerRange
+
+public protected def InputVer.toExpr (self : InputVer) : Expr :=
+  match self with
+  | .none => mkConst ``InputVer.none
+  | .git rev => mkApp (mkConst ``InputVer.git) (toExpr rev)
+  | .ver ver => mkApp (mkConst ``InputVer.ver) (toExpr ver)
+
+public instance : ToExpr InputVer where
+  toExpr := InputVer.toExpr
+  toTypeExpr := mkConst ``InputVer
 
 public def toResultExpr [ToExpr α] (x : Except String α) : Except String Expr :=
   Functor.map toExpr x
 
-@[builtin_term_elab verLit]
-def elabVerLit : TermElab := fun stx expectedType? => do
-  let `(v!$v) := stx | throwUnsupportedSyntax
-  tryPostponeIfNoneOrMVar expectedType?
-  let some expectedType := expectedType?
-    | throwError "expected type is not known"
+def evalDecodeVersion (stx : Term) (expectedType : Expr) : TermElabM Expr := do
   let ofVerT? ← mkAppM ``Except #[mkConst ``String, expectedType]
-  let ofVerE ← elabTermEnsuringType (← ``(decodeVersion s!$v)) ofVerT?
+  let ofVerE ← elabTermEnsuringType (← ``(decodeVersion $stx)) ofVerT?
   let resT ← mkAppM ``Except #[mkConst ``String, mkConst ``Expr]
   let resE ← mkAppM ``toResultExpr #[ofVerE]
   match (← unsafe evalExpr (Except String Expr) resT resE) with
   | .ok ver => return ver
   | .error e => throwError e
+
+@[builtin_term_elab evalVer]
+def elabEvalVersion : TermElab := fun stx expectedType? => do
+  let `(eval_ver% $v) := stx
+    | throwError "ill-formed `decode_version%` syntax"
+  tryPostponeIfNoneOrMVar expectedType?
+  let some expectedType := expectedType?
+    | throwError "expected type is not known"
+  evalDecodeVersion v expectedType
+
+@[builtin_macro verLit]
+def expandVerLit : Macro := fun stx => do
+  if let `(v!$v) := stx then
+    `(eval_ver% s!$v)
+  else
+    Macro.throwError "ill-formed version literal"

--- a/src/lake/Lake/Load/Manifest.lean
+++ b/src/lake/Lake/Load/Manifest.lean
@@ -95,9 +95,6 @@ public structure PackageEntry where
 
 namespace PackageEntry
 
-@[inline] public def prettyName (entry : PackageEntry) : String :=
-  entry.name.toString (escape := false)
-
 public protected def toJson (entry : PackageEntry) : Json :=
   let fields := [
     ("name", toJson entry.name),
@@ -155,15 +152,31 @@ public protected def fromJson? (json : Json) : Except String PackageEntry := do
 
 public instance : FromJson PackageEntry := ⟨PackageEntry.fromJson?⟩
 
+@[inline] public def prettyName (entry : PackageEntry) : String :=
+  entry.name.toString (escape := false)
+
+/-- The directory name used to store the materialized dependency. -/
+@[inline] public def dirName (entry : PackageEntry) : String :=
+   entry.name.toString (escape := false)
+
+@[inline] public def inputRev? (entry : PackageEntry) : Option GitRev :=
+  match entry.src with
+  | .git (inputRev? := rev?) .. => rev?
+  | .path .. => none
+
+/-- **For internal use only.** -/
 @[inline] public def setInherited (entry : PackageEntry) : PackageEntry :=
   {entry with inherited := true}
 
+/-- **For internal use only.** -/
 @[inline] public def setConfigFile (path : FilePath) (entry : PackageEntry) : PackageEntry :=
   {entry with configFile := path}
 
+/-- **For internal use only.** -/
 @[inline] public def setManifestFile (path? : Option FilePath) (entry : PackageEntry) : PackageEntry :=
   {entry with manifestFile? := path?}
 
+/-- **For internal use only.** -/
 @[inline] public def inDirectory (pkgDir : FilePath) (entry : PackageEntry) : PackageEntry :=
   {entry with src := match entry.src with | .path dir => .path (pkgDir / dir) | s => s}
 

--- a/src/lake/Lake/Load/Materialize.lean
+++ b/src/lake/Lake/Load/Materialize.lean
@@ -147,28 +147,23 @@ public def fixedToolchain (self : MaterializedDep) : Bool :=
 
 end MaterializedDep
 
-inductive InputVer
-| none
-| git (rev : GitRev)
-| ver (ver : VerRange)
-
-def pkgNotIndexed (scope name : String) (ver : InputVer) : String :=
+def pkgNotIndexed (dep : Dependency) : String :=
   let (leanVer, tomlVer) :=
-    match ver with
+    match dep.version with
     | .none => ("", "")
     | .git rev => (s!" @ {repr rev}", s!"\n    rev = {repr rev}")
     | .ver ver => (s!" @ {repr ver.toString}", s!"\n    version = {repr ver.toString}")
-s!"{scope}/{name}: package not found on Reservoir.
+s!"{dep.fullName}: package not found on Reservoir.
 
   If the package is on GitHub, you can add a Git source. For example:
 
     require ...
-      from git \"https://github.com/{scope}/{name}\"{leanVer}
+      from git \"https://github.com/{dep.scope}/{dep.reservoirName}\"{leanVer}
 
   or, if using TOML:
 
     [[require]]
-    git = \"https://github.com/{scope}/{name}\"{tomlVer}
+    git = \"https://github.com/{dep.scope}/{dep.reservoirName}\"{tomlVer}
     ...
 "
 
@@ -181,54 +176,40 @@ public def Dependency.materialize
   (lakeEnv : Env) (wsDir relPkgsDir relParentDir : FilePath)
 : LoggerIO MaterializedDep := do
   if let some src := dep.src? then
-    let sname := dep.name.toString (escape := false)
     match src with
     | .path dir =>
       let relPkgDir := relParentDir / dir
-      mkDep sname relPkgDir "" (.path relPkgDir)
+      mkDep dep.prettyName relPkgDir "" (.path relPkgDir)
     | .git url inputRev? subDir? => do
-      let sname := dep.name.toString (escape := false)
       let repoUrl := Git.filterUrl? url |>.getD ""
-      materializeGit sname (relPkgsDir / sname) url repoUrl inputRev? subDir?
+      materializeGit dep.prettyName (relPkgsDir / dep.dirName) url repoUrl inputRev? subDir?
   else
     if dep.scope.isEmpty then
-      error s!"{dep.name}: ill-formed dependency: \
+      error s!"{dep.prettyName}: ill-formed dependency: \
         dependency is missing a source and is missing a scope for Reservoir"
-    let ver : InputVer ← id do
-      let some ver := dep.version?
-        | return .none
-      if let some ver := ver.dropPrefix? "git#" then
-        return .git ver.toString
-      else
-        match VerRange.parse ver with
-        | .ok ver => return .ver ver
-        | .error e =>  error s!"{dep.name}: invalid dependency version range: {e}"
-    let depName := dep.name.toString (escape := false)
-    let pkg ←
-      match (← Reservoir.fetchPkg? lakeEnv dep.scope depName |>.toLogT) with
-      | .ok (some pkg) => pure pkg
-      | .ok none => error <| pkgNotIndexed dep.scope depName ver
-      | .error .. =>
-          error s!"{dep.scope}/{depName}: could not materialize package: \
-            this may be a transient error or a bug in Lake or Reservoir"
+    let pkg ← id do
+      match (← Reservoir.fetchPkg? lakeEnv dep.scope dep.reservoirName |>.toLogT) with
+      | .ok (some pkg) => return pkg
+      | .ok none => error <| pkgNotIndexed dep
+      | .error .. => error s!"{dep.fullName}: could not materialize package: \
+        this may be a transient error or a bug in Lake or Reservoir"
     let relPkgDir := relPkgsDir / pkg.name
     match pkg.gitSrc? with
     | some (.git _ url githubUrl? defaultBranch? subDir?) =>
-      let rev? ←
-        match ver with
+      let rev? ← id do
+        match dep.version with
         | .none => defaultBranch?
         | .git rev => some rev
         | .ver ver =>
-          match (← Reservoir.fetchPkgVersions lakeEnv dep.scope depName |>.toLogT) with
+          match (← Reservoir.fetchPkgVersions lakeEnv dep.scope dep.reservoirName |>.toLogT) with
           | .ok vers =>
-              if let some ver := vers.find? (ver.test ·.version) then
-                logInfo s!"{dep.scope}/{depName}: using version `{ver.version}` at revision `{ver.revision}`"
-                pure ver.revision
-              else
-                error s!"{dep.scope}/{depName}: version `{ver}` not found on Reservoir"
-          | .error .. =>
-              error s!"{dep.scope}/{depName}: could not fetch package versions: \
-                this may be a transient error or a bug in Lake or Reservoir"
+            if let some ver := vers.find? (ver.test ·.version) then
+              logInfo s!"{dep.fullName}: using version `{ver.version}` at revision `{ver.revision}`"
+              return ver.revision
+            else
+              error s!"{dep.fullName}: version `{ver}` not found on Reservoir"
+          | .error .. => error s!"{dep.fullName}: could not fetch package versions: \
+            this may be a transient error or a bug in Lake or Reservoir"
       materializeGit pkg.fullName relPkgDir url (githubUrl?.getD "") rev? subDir?
     | _ => error s!"{pkg.fullName}: Git source not found on Reservoir"
 where
@@ -261,8 +242,8 @@ public def PackageEntry.materialize
   | .path (dir := relPkgDir) .. =>
     mkDep relPkgDir ""
   | .git (url := url) (rev := rev) (subDir? := subDir?) .. => do
-    let sname := manifestEntry.prettyName
-    let relGitDir := relPkgsDir / sname
+    let prettyName := manifestEntry.prettyName
+    let relGitDir := relPkgsDir / manifestEntry.dirName
     let gitDir := wsDir / relGitDir
     let repo := GitRepo.mk gitDir
     /-
@@ -274,13 +255,13 @@ public def PackageEntry.materialize
     if (← repo.dirExists) then
       if (← repo.getHeadRevision?) = rev then
         if (← repo.hasDiff) then
-          logWarning s!"{sname}: repository '{repo.dir}' has local changes"
+          logWarning s!"{prettyName}: repository '{repo.dir}' has local changes"
       else
         let url := lakeEnv.pkgUrlMap.find? manifestEntry.name |>.getD url
-        updateGitRepo sname repo url rev
+        updateGitRepo prettyName repo url rev
     else
       let url := lakeEnv.pkgUrlMap.find? manifestEntry.name |>.getD url
-      cloneGitPkg sname repo url rev
+      cloneGitPkg prettyName repo url rev
     let relPkgDir := match subDir? with | .some subDir => relGitDir / subDir | .none => relGitDir
     mkDep relPkgDir (Git.filterUrl? url |>.getD "")
 where

--- a/src/lake/Lake/Load/Toml.lean
+++ b/src/lake/Lake/Load/Toml.lean
@@ -298,6 +298,13 @@ public protected def DependencySrc.decodeToml (t : Table) (ref := Syntax.missing
 
 public instance : DecodeToml DependencySrc := ⟨fun v => do DependencySrc.decodeToml (← v.decodeTable) v.ref⟩
 
+public protected def InputVer.decodeToml (v : Value) : EDecodeM InputVer := do
+  match InputVer.parse (← v.decodeString) with
+  | .ok ver => return ver
+  | .error e =>  throwDecodeErrorAt v.ref s!"invalid dependency version constraint: {e}"
+
+public instance : DecodeToml InputVer := ⟨InputVer.decodeToml⟩
+
 public protected def Dependency.decodeToml (t : Table) (ref := Syntax.missing) : EDecodeM Dependency := ensureDecode do
   let name ← stringToLegalOrSimpleName <$> t.tryDecode `name ref
   let rev? ← t.tryDecode? `rev
@@ -316,10 +323,7 @@ public protected def Dependency.decodeToml (t : Table) (ref := Syntax.missing) :
   let scope ← t.tryDecodeD `scope ""
   let version : InputVer ← tryDecode do
     if let some val := t.find? `version then
-      let ver ← val.decodeString
-      match InputVer.parse ver with
-      | .ok ver => return ver
-      | .error e =>  throwDecodeErrorAt val.ref s!"invalid dependency version range: {e}"
+      decodeToml val
     else if let some rev := rev? then
       return .git rev
     else

--- a/src/lake/Lake/Load/Toml.lean
+++ b/src/lake/Lake/Load/Toml.lean
@@ -301,30 +301,31 @@ public instance : DecodeToml DependencySrc := ⟨fun v => do DependencySrc.decod
 public protected def Dependency.decodeToml (t : Table) (ref := Syntax.missing) : EDecodeM Dependency := ensureDecode do
   let name ← stringToLegalOrSimpleName <$> t.tryDecode `name ref
   let rev? ← t.tryDecode? `rev
-  let src? : Option DependencySrc ← id do
-    if let some dir ← t.tryDecode? `path then
+  let src? : Option DependencySrc ← tryDecode do
+    if let some dir ← t.decode? `path then
       return some <| .path dir
     else if let some g := t.find? `git then
       match g with
-      | .string _ url =>
+      | .string _ url => ensureDecode do
         return some <| .git url rev? (← t.tryDecode? `subDir)
-      | .table ref t =>
+      | .table ref t => ensureDecode do
         return some <| .git (← t.tryDecode `url ref) rev? (← t.tryDecode? `subDir)
-      | _ =>
-        modify (·.push <| .mk g.ref "expected string or table")
-        return default
+      | _ => throwDecodeErrorAt g.ref "expected string or table"
     else
-      t.tryDecode? `source
+      t.decode? `source
   let scope ← t.tryDecodeD `scope ""
-  let version? ← id do
-    if let some ver ← t.tryDecode? `version then
-      return some ver
+  let version : InputVer ← tryDecode do
+    if let some val := t.find? `version then
+      let ver ← val.decodeString
+      match InputVer.parse ver with
+      | .ok ver => return ver
+      | .error e =>  throwDecodeErrorAt val.ref s!"invalid dependency version range: {e}"
     else if let some rev := rev? then
-      return if src?.isSome then none else some s!"git#{rev}"
+      return .git rev
     else
-      return none
+      return .none
   let opts ← t.tryDecodeD `options {}
-  return {name, scope, version?, src?, opts}
+  return {name, scope, version, src?, opts}
 
 public instance : DecodeToml Dependency := ⟨fun v => do Dependency.decodeToml (← v.decodeTable) v.ref⟩
 

--- a/src/lake/Lake/Util/Version.lean
+++ b/src/lake/Lake/Util/Version.lean
@@ -401,10 +401,14 @@ public instance : ToString ComparatorOp := ⟨ComparatorOp.toString⟩
 end ComparatorOp
 
 public structure VerComparator where
-  private innerMk ::
-    private ver : StdVer
-    private op : ComparatorOp
-    private includeSuffixes : Bool := false
+ /-- **For internal use only.** -/
+  mk ::
+    /-- **For internal use only.** -/
+    ver : StdVer
+    /-- **For internal use only.** -/
+    op : ComparatorOp
+    /-- **For internal use only.** -/
+    includeSuffixes : Bool := false
     deriving Repr
 
 namespace VerComparator
@@ -470,7 +474,8 @@ public  instance : ToString VerComparator := ⟨VerComparator.toString⟩
 end VerComparator
 
 public structure VerRange where
-  private innerMk ::
+  /-- **For internal use only.** -/
+  mk ::
     toString : String
     clauses : Array (Array VerComparator)
     deriving Repr, Inhabited
@@ -632,6 +637,8 @@ where
 
 public def parse (s : String) : Except String VerRange := do
   runVerParse s parseM
+
+public instance : DecodeVersion VerRange := ⟨VerRange.parse⟩
 
 public def test (self : VerRange) (ver : StdVer) : Bool :=
   self.clauses.any (·.all (·.test ver))

--- a/tests/lake/tests/translateConfig/out.expected.toml
+++ b/tests/lake/tests/translateConfig/out.expected.toml
@@ -9,7 +9,7 @@ pp.unicode.fun = true
 [[require]]
 name = "baz"
 scope = "foo"
-version = "git#abcdef"
+rev = "abcdef"
 
 [[require]]
 name = "foo"

--- a/tests/lake/tests/translateConfig/test.sh
+++ b/tests/lake/tests/translateConfig/test.sh
@@ -5,31 +5,31 @@ source ../common.sh
 
 # Test Lean to TOML translation
 test_no_out translate-config -f source.lean toml out.produced.toml
-test_cmd diff --strip-trailing-cr out.expected.toml out.produced.toml
+diff -u --strip-trailing-cr out.expected.toml out.produced.toml
 test_cmd rm out.produced.toml
 
 # Test idempotency of TOML translation
 test_no_out translate-config -f out.expected.toml toml out.produced.toml
-test_cmd diff --strip-trailing-cr out.expected.toml out.produced.toml
+diff -u --strip-trailing-cr out.expected.toml out.produced.toml
 
 # Test TOML to Lean translation
 test_no_out translate-config -f source.toml lean out.produced.lean
-test_cmd diff --strip-trailing-cr out.expected.lean out.produced.lean
+diff -u --strip-trailing-cr out.expected.lean out.produced.lean
 test_cmd rm out.produced.lean
 
 # Test idempotency of Lean translation
 test_no_out translate-config -f out.expected.lean lean out.produced.lean
-test_cmd diff --strip-trailing-cr out.expected.lean out.produced.lean
+diff -u --strip-trailing-cr out.expected.lean out.produced.lean
 
 # Test produced TOML round-trips
 test_no_out translate-config -f out.produced.toml lean bridge.produced.lean
 test_no_out translate-config -f bridge.produced.lean toml roundtrip.produced.toml
-test_cmd diff --strip-trailing-cr out.produced.toml roundtrip.produced.toml
+diff -u --strip-trailing-cr out.produced.toml roundtrip.produced.toml
 
 # Test produced Lean round-trips
 test_no_out translate-config -f out.produced.lean toml bridge.produced.toml
 test_no_out translate-config -f bridge.produced.toml lean roundtrip.produced.lean
-test_cmd diff --strip-trailing-cr out.produced.lean roundtrip.produced.lean
+diff -u --strip-trailing-cr out.produced.lean roundtrip.produced.lean
 
 # Test source rename
 test_cmd cp source.lean lakefile.lean


### PR DESCRIPTION
This PR changes the `version` field of a `Dependency` to use the newly public `InputVer` type. As a result, the revision of a Git dependency will be used as the version constraint if no other version constraint is specified. 

This change in versioning is the desired behavior for multi-version workspaces (coming  in #11662) and has no practical effect on dependency resolution in non-multi-version workspaces (as packages are constrained to a specific version anyway).
