### PR TITLE
fix: statement of `eqRec_heq_iff`

### DIFF
--- a/src/Init/Core.lean
+++ b/src/Init/Core.lean
@@ -989,7 +989,7 @@ Heterogeneous equality with an `Eq.rec` application on the left is equivalent to
 equality on the original term.
 -/
 theorem eqRec_heq_iff {α : Sort u} {a : α} {motive : (b : α) → a = b → Sort v}
-    {b : α} {refl : motive a (Eq.refl a)} {h : a = b} {c : motive b h}
+    {b : α} {refl : motive a (Eq.refl a)} {h : a = b} {c : β}
     : @Eq.rec α a motive refl b h ≍ c ↔ refl ≍ c :=
   h.rec (fun _ => ⟨id, id⟩) c
 
@@ -998,7 +998,7 @@ Heterogeneous equality with an `Eq.rec` application on the right is equivalent t
 equality on the original term.
 -/
 theorem heq_eqRec_iff {α : Sort u} {a : α} {motive : (b : α) → a = b → Sort v}
-    {b : α} {refl : motive a (Eq.refl a)} {h : a = b} {c : motive b h} :
+    {b : α} {refl : motive a (Eq.refl a)} {h : a = b} {c : β} :
     c ≍ @Eq.rec α a motive refl b h ↔ c ≍ refl :=
   h.rec (fun _ => ⟨id, id⟩) c
 

--- a/src/Init/SimpLemmas.lean
+++ b/src/Init/SimpLemmas.lean
@@ -20,7 +20,7 @@ theorem eq_true (h : p) : p = True :=
   propext ⟨fun _ => trivial, fun _ => h⟩
 
 -- Adding this attribute needs `eq_true`.
-attribute [simp] cast_heq
+attribute [simp] cast_heq eqRec_heq_iff heq_eqRec_iff
 
 theorem eq_false (h : ¬ p) : p = False :=
   propext ⟨fun h' => absurd h' h, fun h' => False.elim h'⟩

--- a/src/Std/Data/Iterators/Lemmas/Equivalence/HetT.lean
+++ b/src/Std/Data/Iterators/Lemmas/Equivalence/HetT.lean
@@ -125,7 +125,7 @@ instance {α : Type v} {β : α → Type w} [Small.{u} α] [∀ a, Small.{u} (β
         ((a : USquash α) × (USquash (β a.inflate)))
         (fun x => ⟨x.1.inflate, x.2.inflate⟩)
         (fun b => ⟨⟨.deflate b.1, .deflate (USquash.inflate_deflate ▸ b.2)⟩,
-          (by rcases b with ⟨b₁, b₂⟩; simp [eqRec_heq])⟩)
+          (by rcases b with ⟨b₁, b₂⟩; simp)⟩)
 
 theorem Small.pbind {α : Type v} {β : Type w} (P : α → Prop) (Q : (a : α) → P a → β → Prop)
     (i₁ : Small.{u} { a // P a }) (i₂ : ∀ a h, Small.{u} { b // Q a h b }) :


### PR DESCRIPTION
This PR fixes a problem with the statement of `eqRec_heq_iff` and `heq_eqRec_iff`, which made them insufficiently general, and marks them as `simp`.