### PR TITLE
fix: propagate parent cancel token to `asTask` subtasks via callbacks

### DIFF
--- a/src/Init/System/IO.lean
+++ b/src/Init/System/IO.lean
@@ -1676,26 +1676,41 @@ def mkRef (a : α) : BaseIO (IO.Ref α) :=
 Mutable cell that can be passed around for purposes of cooperative task cancellation: request
 cancellation with `CancelToken.set` and check for it with `CancelToken.isSet`.
 
+Callbacks registered with `CancelToken.onSet` run when the token is activated, allowing
+cancellation to propagate without polling.
+
 This is a more flexible alternative to `Task.cancel` as the token can be shared between multiple
 tasks.
 -/
 structure CancelToken where
-  private ref : IO.Ref Bool
+  -- `none` = set; `some cbs` = unset, with pending callbacks (in reverse registration order)
+  private ref : IO.Ref (Option (List (BaseIO Unit)))
 deriving Nonempty
 
 namespace CancelToken
 
 /-- Creates a new cancellation token. -/
 def new : BaseIO CancelToken :=
-  CancelToken.mk <$> IO.mkRef false
+  CancelToken.mk <$> IO.mkRef (some [])
 
-/-- Activates a cancellation token. Idempotent. -/
-def set (tk : CancelToken) : BaseIO Unit :=
-  tk.ref.set true
+/-- Activates a cancellation token. Runs any registered `onSet` callbacks. Idempotent. -/
+def set (tk : CancelToken) : BaseIO Unit := do
+  let cbs ← tk.ref.modifyGet fun s => (s.getD [], none)
+  cbs.forM id
 
 /-- Checks whether the cancellation token has been activated. -/
 def isSet (tk : CancelToken) : BaseIO Bool :=
-  tk.ref.get
+  Option.isNone <$> tk.ref.get
+
+/--
+Registers a callback to run when the cancellation token is activated. If the token is already
+set, the callback runs immediately. Callbacks run in the thread that calls `set`.
+-/
+def onSet (tk : CancelToken) (action : BaseIO Unit) : BaseIO Unit := do
+  let alreadySet ← tk.ref.modifyGet fun
+    | some cbs => (false, some (action :: cbs))
+    | none     => (true,  none)
+  if alreadySet then action
 
 -- separate definition as otherwise no unboxed version is generated
 @[export lean_io_cancel_token_is_set]

--- a/src/Init/Try.lean
+++ b/src/Init/Try.lean
@@ -52,6 +52,20 @@ namespace Lean.Parser.Tactic
 
 syntax (name := tryTrace) "try?" optConfig : tactic
 
+/--
+`try? => tac` runs `tac` through `try?`'s suggestion engine (`evalSuggest`) without the
+automatic tactic generation phase. This is useful for testing `evalSuggest` directly with
+explicit tactic scripts using `try?`'s internal combinators (`attempt_all`, `attempt_all_par`,
+`first_par`, etc.).
+
+Example:
+```
+example : 1 = 1 := by
+  try? => first | rfl | simp
+```
+-/
+syntax (name := tryTraceWith) "try?" optConfig " => " tacticSeq : tactic
+
 /-- Helper internal tactic for implementing the tactic `try?`. -/
 syntax (name := attemptAll) "attempt_all " withPosition((ppDedent(ppLine) colGe "| " tacticSeq)+) : tactic
 

--- a/src/Init/Try.lean
+++ b/src/Init/Try.lean
@@ -64,6 +64,7 @@ example : 1 = 1 := by
   try? => first | rfl | simp
 ```
 -/
+@[tactic_alt tryTrace]
 syntax (name := tryTraceWith) "try?" optConfig " => " tacticSeq : tactic
 
 /-- Helper internal tactic for implementing the tactic `try?`. -/

--- a/src/Lean/Elab/Tactic/Try.lean
+++ b/src/Lean/Elab/Tactic/Try.lean
@@ -1042,4 +1042,17 @@ private def evalAndSuggestWithBy (tk : Syntax) (tac : TSyntax `tactic) (original
         evalAndSuggest tk stx originalMaxHeartbeats config
   | _ => throwUnsupportedSyntax
 
+@[builtin_tactic Lean.Parser.Tactic.tryTraceWith] def evalTryTraceWith : Tactic := fun stx => do
+  match stx with
+  | `(tactic| try?%$tk $config:optConfig => $tac:tacticSeq) => Tactic.focus do withMainContext do
+    let config ← elabTryConfig config
+    let originalMaxHeartbeats ← getMaxHeartbeats
+    let tac ← `(tactic| ($tac:tacticSeq))
+    withUnlimitedHeartbeats do
+      if config.wrapWithBy then
+        evalAndSuggestWithBy tk tac originalMaxHeartbeats config
+      else
+        evalAndSuggest tk tac originalMaxHeartbeats config
+  | _ => throwUnsupportedSyntax
+
 end Lean.Elab.Tactic.Try

--- a/src/Lean/Elab/Task.lean
+++ b/src/Lean/Elab/Task.lean
@@ -51,6 +51,11 @@ def asTask (t : CoreM α) : CoreM (BaseIO Unit × Task (CoreM α)) := do
   -- but modify it to return both the result and state
   let wrappedAct ← Core.wrapAsync (fun () => do let a ← t; let s ← get; return (a, s)) (some cancelToken)
   let task ← (wrappedAct ()).asTask
+  -- Propagate parent cancel token to child: when the parent is cancelled,
+  -- the child token is set too. This ensures that subtasks spawned via `asTask`
+  -- respond to server-level cancellation (e.g. on re-elaboration).
+  if let some parentTk := (← read).cancelTk? then
+    parentTk.onSet cancelToken.set
   return (cancelToken.set, task.map (sync := true) fun result =>
     match result with
     | .ok (a, s) => do

--- a/src/Lean/Server/Test/Cancel.lean
+++ b/src/Lean/Server/Test/Cancel.lean
@@ -184,6 +184,44 @@ elab_rules : tactic
   dbg_trace "blocked!"
   log "blocked"
 
+/-! ## Helpers for end-to-end testing of parallel subtask cancellation -/
+
+meta initialize checkCancelRefs : IO.Ref (Std.HashMap String (Task Unit × IO.CancelToken)) ← IO.mkRef {}
+
+/--
+Tests whether the cancel token is properly set on re-elaboration. On first invocation with a
+given label, loops checking `Core.checkSystem` and waiting for a signal from the second
+invocation. If the loop completes without interruption (i.e. the cancel token was not propagated),
+prints `"{label}: leaked!"` to stderr. Second invocation signals the first and waits for it to
+complete (so the server doesn't exit prematurely).
+-/
+scoped syntax "check_cancel" ident : tactic
+elab_rules : tactic
+| `(tactic| check_cancel $id) => do
+  let label := id.getId.toString (escape := false)
+  let prom ← IO.Promise.new
+  let signal ← IO.CancelToken.new
+  let prior ← checkCancelRefs.modifyGet fun m =>
+    match m.get? label with
+    | some entry => (some entry, m)
+    | none       => (none, m.insert label (prom.result!, signal))
+  if let some (t, sig) := prior then
+    sig.set
+    IO.wait t
+    return
+  IO.eprintln s!"{label}: started!"
+  try
+    while true do
+      Core.checkSystem "check_cancel"
+      if (← signal.isSet) then break
+      IO.sleep 10
+    let ctx ← readThe Core.Context
+    let some cancelTk := ctx.cancelTk? | unreachable!
+    if !(← cancelTk.isSet) then
+      IO.eprintln s!"{label}: leaked!"
+  finally
+    prom.resolve ()
+
 meta initialize cmdOnceRef : IO.Ref (Option (Task Unit)) ← IO.mkRef none
 
 /--

--- a/src/Lean/Server/Test/Cancel.lean
+++ b/src/Lean/Server/Test/Cancel.lean
@@ -209,7 +209,6 @@ elab_rules : tactic
     sig.set
     IO.wait t
     return
-  IO.eprintln s!"{label}: started!"
   try
     while true do
       Core.checkSystem "check_cancel"

--- a/tests/elab/delabConst.lean
+++ b/tests/elab/delabConst.lean
@@ -223,7 +223,7 @@ The name `IO.CancelToken.ref✝` is a private imported name.
 -/
 /--
 info: def IO.CancelToken.isSet : IO.CancelToken → BaseIO Bool :=
-fun tk => ST.Ref.get (IO.CancelToken.ref✝ tk)
+fun tk => Option.isNone <$> ST.Ref.get (IO.CancelToken.ref✝ tk)
 -/
 #guard_msgs in #print IO.CancelToken.isSet
 /-!
@@ -231,6 +231,6 @@ Even if `IO` is opened, it won't print as `CancelToken.ref✝`, but the full nam
 -/
 /--
 info: def IO.CancelToken.isSet : CancelToken → BaseIO Bool :=
-fun tk => ST.Ref.get (IO.CancelToken.ref✝ tk)
+fun tk => Option.isNone <$> ST.Ref.get (IO.CancelToken.ref✝ tk)
 -/
 #guard_msgs in open IO in #print IO.CancelToken.isSet

--- a/tests/elab/printStructure.lean
+++ b/tests/elab/printStructure.lean
@@ -32,9 +32,9 @@ constructor:
 info: structure IO.CancelToken : Type
 number of parameters: 0
 fields:
-  private IO.CancelToken.ref✝ : IO.Ref Bool
+  private IO.CancelToken.ref✝ : IO.Ref (Option (List (BaseIO Unit)))
 constructor:
-  private IO.CancelToken.mk✝ (ref : IO.Ref Bool) : IO.CancelToken
+  private IO.CancelToken.mk✝ (ref : IO.Ref (Option (List (BaseIO Unit)))) : IO.CancelToken
 -/
 #guard_msgs in
 #print IO.CancelToken

--- a/tests/elab/try_eval_suggest.lean
+++ b/tests/elab/try_eval_suggest.lean
@@ -1,0 +1,51 @@
+/-!
+# Tests for `try? => tac` syntax
+
+These tests verify that the `try? => tac` syntax correctly runs a user-supplied tactic
+through `evalSuggest` and reports suggestions.
+-/
+
+/-- info: Try this:
+  [apply] rfl -/
+#guard_msgs (info) in
+example : 1 = 1 := by
+  try? => rfl
+
+/-- info: Try this:
+  [apply] rfl -/
+#guard_msgs (info) in
+example : 1 = 1 := by
+  try? => first | assumption | rfl
+
+/-- info: Try these:
+  [apply] rfl
+  [apply] simp_all -/
+#guard_msgs (info) in
+example : 1 = 1 := by
+  try? => attempt_all | rfl | simp_all
+
+/-- info: Try these:
+  [apply] rfl
+  [apply] simp_all -/
+#guard_msgs (info) in
+example : 1 = 1 := by
+  try? => attempt_all_par | rfl | simp_all
+
+-- first_par returns whichever finishes first; just test it doesn't error
+#guard_msgs (drop info) in
+example : 1 = 1 := by
+  try? => first_par | rfl | simp_all
+
+/-- info: Try these:
+  [apply] assumption
+  [apply] rfl -/
+#guard_msgs (info) in
+example (h : 1 = 1) : 1 = 1 := by
+  try? => attempt_all | assumption | rfl
+
+-- `max` config option should limit suggestions
+/-- info: Try this:
+  [apply] rfl -/
+#guard_msgs (info) in
+example : 1 = 1 := by
+  try? (max := 1) => attempt_all | rfl | simp_all

--- a/tests/server_interactive/cancellation_par.lean
+++ b/tests/server_interactive/cancellation_par.lean
@@ -1,0 +1,67 @@
+import Lean.Server.Test.Cancel
+open Lean.Server.Test.Cancel
+
+/-!
+Test contrasting cancellation behavior between sequential and parallel combinators.
+
+Each section uses `check_cancel <label>`: on first invocation it loops checking
+`Core.checkInterrupted`, waiting for the second invocation (triggered by re-elaboration) to
+signal it. If the cancel token was properly set, `checkInterrupted` fires first and the tactic
+is interrupted. Otherwise the signal arrives, the tactic finds `cancelTk` unset, and prints
+`"{label}: leaked!"`.
+
+**Sequential `first`** (section 1): runs on the main elaboration thread, sharing the command's
+cancel token. On re-elaboration, `checkInterrupted` fires — no leak.
+
+**Parallel `attempt_all_par`** (section 2): runs in a subtask via `asTask` with its own fresh
+cancel token. Nobody sets that token on re-elaboration — **leak**.
+
+**Parallel `first_par`** (section 3): same bug as `attempt_all_par`.
+-/
+
+/-! ## Sequential `first`: cancellation works -/
+
+example : True := by
+  trivial
+       --^ waitFor: blocked
+       --^ insert: "; skip"
+       --^ sync
+
+theorem t : True := by
+  wait_for_cancel_once_async
+  try? => first
+    | check_cancel first
+
+-- RESET
+import Lean.Server.Test.Cancel
+open Lean.Server.Test.Cancel
+
+/-! ## Parallel `attempt_all_par`: cancellation is broken -/
+
+example : True := by
+  trivial
+       --^ waitFor: blocked
+       --^ insert: "; skip"
+       --^ sync
+
+theorem t : True := by
+  wait_for_cancel_once_async
+  try? => attempt_all_par
+    | check_cancel attempt_all_par
+
+-- RESET
+import Lean.Server.Test.Cancel
+open Lean.Server.Test.Cancel
+
+/-! ## Parallel `first_par`: cancellation is broken -/
+
+example : True := by
+  trivial
+       --^ waitFor: blocked
+       --^ insert: "; skip"
+       --^ sync
+
+theorem t : True := by
+  wait_for_cancel_once_async
+  try? => first_par
+    | check_cancel first_par

--- a/tests/server_interactive/cancellation_par.lean.out.expected
+++ b/tests/server_interactive/cancellation_par.lean.out.expected
@@ -2,7 +2,5 @@ blocked!
 cancelled!
 blocked!
 cancelled!
-attempt_all_par: leaked!
 blocked!
 cancelled!
-first_par: leaked!

--- a/tests/server_interactive/cancellation_par.lean.out.expected
+++ b/tests/server_interactive/cancellation_par.lean.out.expected
@@ -1,0 +1,11 @@
+blocked!
+first: started!
+cancelled!
+blocked!
+attempt_all_par: started!
+cancelled!
+attempt_all_par: leaked!
+blocked!
+first_par: started!
+cancelled!
+first_par: leaked!

--- a/tests/server_interactive/cancellation_par.lean.out.expected
+++ b/tests/server_interactive/cancellation_par.lean.out.expected
@@ -1,11 +1,8 @@
 blocked!
-first: started!
 cancelled!
 blocked!
-attempt_all_par: started!
 cancelled!
 attempt_all_par: leaked!
 blocked!
-first_par: started!
 cancelled!
 first_par: leaked!


### PR DESCRIPTION
This PR fixes cancellation propagation for subtasks spawned via `CoreM.asTask` (and its `MetaM`/`TermElabM`/`TacticM` variants). When the server cancels elaboration on re-elaboration, parallel tactic combinators like `attempt_all_par` and `first_par` were leaking subtasks because their fresh cancel tokens were never linked to the parent.

Adds `IO.CancelToken.onSet`, a callback-registration API: calling `parentTk.onSet action` runs `action` when the parent is activated (or immediately if already set). `CoreM.asTask` uses this to propagate cancellation: `parentTk.onSet childTk.set`.

The callback list lives in the existing `IO.Ref` backing `CancelToken` — `modifyGet` gives us atomic check-and-append with no new primitives. No `Promise`, no `Task`, no GC dance.

This is an **alternative** to #13428, which uses a Promise-based `CancelToken` refactor (#13415) to get the same propagation via `BaseIO.bindTask`.

Depends on #13416 (cancellation test infrastructure).

Fixes #13300.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>