### PR TITLE
fix: correct `alternative`-fold base in do `match`

### DIFF
--- a/src/Lean/Elab/BuiltinDo/Match.lean
+++ b/src/Lean/Elab/BuiltinDo/Match.lean
@@ -203,7 +203,8 @@ private def compileMatch (discrs : Array Term.Discr) (matchType : Expr) (lhss : 
 
 private def elabDoMatchCore (discrs : TSyntaxArray ``matchDiscr) (alts : Array DoMatchAltView)
     (nondupDec : DoElemCont) : DoElabM Expr := do
-  let info ← alts.foldlM (fun info alt => info.alternative <$> inferControlInfoSeq alt.rhs) ControlInfo.pure
+  let info ← alts.foldlM (fun info alt => info.alternative <$> inferControlInfoSeq alt.rhs)
+    ControlInfo.empty
   nondupDec.withDuplicableCont info fun dec => do
   trace[Elab.do.match] "discrs: {discrs}, nondupDec.resultType: {nondupDec.resultType}, may postpone: {(← readThe Term.Context).mayPostpone}"
   tryPostponeIfDiscrTypeIsMVar discrs

--- a/src/Lean/Elab/Do/InferControlInfo.lean
+++ b/src/Lean/Elab/Do/InferControlInfo.lean
@@ -58,6 +58,12 @@ structure ControlInfo where
 
 def ControlInfo.pure : ControlInfo := {}
 
+/--
+The identity of `ControlInfo.alternative`: a `ControlInfo` describing a block with no branches
+at all (so no regular exits and the next element is trivially unreachable).
+-/
+def ControlInfo.empty : ControlInfo := { numRegularExits := 0, noFallthrough := true }
+
 def ControlInfo.sequence (a b : ControlInfo) : ControlInfo := {
     -- Syntactic fields aggregate unconditionally; the elaborator keeps visiting `b` unless `a` is
     -- a syntactically-terminal element (only top-level `return`/`break`/`continue` are, via
@@ -141,7 +147,7 @@ partial def ofElem (stx : TSyntax `doElem) : TermElabM ControlInfo := do
     ofLetOrReassignArrow true decl
   -- match
   | `(doElem| match $[(dependent := $_)]? $[(generalizing := $_)]? $(_)? $_,* with $alts:matchAlt*) =>
-    let mut info := {}
+    let mut info := ControlInfo.empty
     for alt in alts do
       let `(matchAltExpr| | $[$_,*]|* => $rhs) := alt | throwUnsupportedSyntax
       let rhsInfo ← ofSeq ⟨rhs⟩

--- a/tests/elab/doControlInfoAggregate.lean
+++ b/tests/elab/doControlInfoAggregate.lean
@@ -28,6 +28,9 @@ example (cond : Bool) : IO Nat := do
     return 42
   return 1
 
+/--
+warning: This `do` element and its control-flow region are dead code. Consider refactoring your code to remove it.
+-/
 #guard_msgs in
 example (i : Nat) : IO Nat := do
   for _ in [1, 2] do


### PR DESCRIPTION
This PR fixes the `ControlInfo` inference for a do-block `match`: the fold over the match arms started from `ControlInfo.pure` (defaults to `numRegularExits := 1`, `noFallthrough := false`), but `alternative` sums `numRegularExits` and ANDs `noFallthrough`, so the fold identity is `{ numRegularExits := 0, noFallthrough := true }`. With the wrong base, a `match` whose arms all `break`/`continue`/`return` reported `numRegularExits = 1` and `noFallthrough = false`, suppressing the dead-code warning on the continuation after the match. The fix corrects both the inference handler in `InferControlInfo.lean` and the fold in `elabDoMatchCore`.