### PR TITLE
fix: pin `repeat`'s `numRegularExits` at `1` to match `for`

### DIFF
--- a/src/Lean/Elab/Do/InferControlInfo.lean
+++ b/src/Lean/Elab/Do/InferControlInfo.lean
@@ -132,17 +132,17 @@ partial def ofElem (stx : TSyntax `doElem) : TermElabM ControlInfo := do
   | `(doElem| unless $_ do $elseSeq) =>
     ControlInfo.alternative {} <$> ofSeq elseSeq
   -- For/Repeat
-  | `(doElem| for $[$[$_ :]? $_ in $_],* do $bodySeq) =>
+  | `(doElem| for $[$[$_ :]? $_ in $_],* do $bodySeq)
+  | `(doRepeat| repeat $bodySeq) =>
+    -- `numRegularExits := 1` unconditionally, matching `for ... in`. For break-less `repeat` the
+    -- loop never terminates normally, so `0` looks more accurate semantically. But the loop
+    -- expression still has type `m Unit`, and the do block's continuation after the loop is what
+    -- carries that type. Reporting `0` makes the elaborator flag that continuation as dead code,
+    -- yet the user has no way to remove it without breaking the type of the enclosing do block
+    -- (unless its monadic result type happens to be `Unit`). So we pin at `1`; see #13437.
     let info ← ofSeq bodySeq
     return { info with  -- keep only reassigns and earlyReturn
       numRegularExits := 1,
-      continues := false,
-      breaks := false
-    }
-  | `(doRepeat| repeat $bodySeq) =>
-    let info ← ofSeq bodySeq
-    return { info with
-      numRegularExits := if info.breaks then 1 else 0,
       continues := false,
       breaks := false
     }

--- a/tests/elab/doControlInfoAggregate.lean
+++ b/tests/elab/doControlInfoAggregate.lean
@@ -65,3 +65,18 @@ example : IO Nat := do
       pure ()
     return 42
   return 1
+
+-- Break-less `repeat` under both branches of an `if`. If `repeat` reported
+-- `numRegularExits := 0`, the if's combined info would have `numRegularExits = 0` too, and the
+-- dead-code warning would fire on `return 2`. The user cannot remove `return 2` though: the loop
+-- expression is `Id PUnit`, so without a trailing element the do block's result type can't be
+-- `Id Nat`. We therefore pin `repeat`'s `numRegularExits` at `1` (same as `for ... in`).
+#guard_msgs in
+example (x : Nat) : Id Nat := do
+  if x = 3 then
+    repeat
+      pure ()
+  else
+    repeat
+      pure ()
+  return 2


### PR DESCRIPTION
This PR stops the `repeat` inference handler from reporting `numRegularExits := 0` for break-less bodies. For break-less `repeat` the loop never terminates normally, so `0` looks more accurate semantically, but the loop expression still has type `m Unit` and the do block's continuation after the loop is what carries that type. Reporting `0` makes the elaborator flag that continuation as dead code, yet there is no way for the user to remove it that is also type correct — unless the enclosing do block's monadic result type happens to be `Unit`. Pinning `numRegularExits` at `1` (matching `for ... in`) eliminates those spurious warnings.