### PR TITLE
test: speed up `bench/mvcgen/sym` ctest entry

### DIFF
--- a/tests/bench/mvcgen/sym/run_test.sh
+++ b/tests/bench/mvcgen/sym/run_test.sh
@@ -1,2 +1,1 @@
-# Limit threads to avoid exhausting memory with the large thread stack.
-LEAN_NUM_THREADS=1 lake test
+lake test


### PR DESCRIPTION
This PR drops `LEAN_NUM_THREADS=1` from the `run_test.sh` of `bench/mvcgen/sym`. The single-threaded restriction was originally there to get reproducible benchmark timings, but `run_test.sh` runs as a test rather than a benchmark, and we do not care about timing reproducibility for tests. Allowing the default thread count cuts the wall time of what was the slowest ctest entry from ~30s to ~20s.