### PR TITLE
feat: user-specified init fn when loading plugins

### DIFF
--- a/src/Lean/Elab/Frontend.lean
+++ b/src/Lean/Elab/Frontend.lean
@@ -143,7 +143,7 @@ def runFrontend
     (ileanFileName? : Option System.FilePath := none)
     (jsonOutput : Bool := false)
     (errorOnKinds : Array Name := #[])
-    (plugins : Array System.FilePath := #[])
+    (plugins : Array Plugin := #[])
     (printStats : Bool := false)
     (setup? : Option ModuleSetup := none)
     : IO (Option Environment) := do

--- a/src/Lean/Elab/Import.lean
+++ b/src/Lean/Elab/Import.lean
@@ -138,7 +138,7 @@ where
 def processHeaderCore
     (startPos : String.Pos.Raw) (imports : Array Import) (isModule : Bool)
     (opts : Options) (messages : MessageLog) (inputCtx : Parser.InputContext)
-    (trustLevel : UInt32 := 0) (plugins : Array System.FilePath := #[]) (leakEnv := false)
+    (trustLevel : UInt32 := 0) (plugins : Array Plugin := #[]) (leakEnv := false)
     (mainModule := Name.anonymous) (package? : Option PkgId := none)
     (arts : NameMap ImportArtifacts := {})
     (headerStx? : Option HeaderSyntax := none)
@@ -174,7 +174,7 @@ backwards compatibility measure not compatible with the module system.
 @[inline] def processHeader
     (header : HeaderSyntax)
     (opts : Options) (messages : MessageLog) (inputCtx : Parser.InputContext)
-    (trustLevel : UInt32 := 0) (plugins : Array System.FilePath := #[]) (leakEnv := false)
+    (trustLevel : UInt32 := 0) (plugins : Array Plugin := #[]) (leakEnv := false)
     (mainModule := Name.anonymous)
     : IO (Environment × MessageLog) := do
   processHeaderCore header.startPos header.imports header.isModule

--- a/src/Lean/Environment.lean
+++ b/src/Lean/Environment.lean
@@ -2377,14 +2377,14 @@ system and imports will be restricted accordingly. If it is `server`, the data f
 as if no `module` annotations were present in the imports.
 -/
 def importModules (imports : Array Import) (opts : Options) (trustLevel : UInt32 := 0)
-    (plugins : Array System.FilePath := #[]) (leakEnv := false) (loadExts := false)
+    (plugins : Array Plugin := #[]) (leakEnv := false) (loadExts := false)
     (level := OLeanLevel.private) (arts : NameMap ImportArtifacts := {})
     : IO Environment := profileitIO "import" opts do
   for imp in imports do
     if imp.module matches .anonymous then
       throw <| IO.userError "import failed, trying to import module with anonymous name"
   withImporting do
-    plugins.forM Lean.loadPlugin
+    plugins.forM fun {path, initFn?} => Lean.loadPlugin path initFn?
     let (_, s) ← importModulesCore (globalLevel := level) imports arts |>.run
     finalizeImport (leakEnv := leakEnv) (loadExts := loadExts) (level := level)
       s imports opts trustLevel

--- a/src/Lean/Language/Lean.lean
+++ b/src/Lean/Language/Lean.lean
@@ -298,7 +298,7 @@ structure SetupImportsResult where
   /-- Pre-resolved artifacts of transitively imported modules. -/
   importArts : NameMap ImportArtifacts := {}
   /-- Lean plugins to load as part of the environment setup. -/
-  plugins : Array System.FilePath := #[]
+  plugins : Array Plugin := #[]
 
 /--
 Parses an option value from a string and inserts it into `opts`.

--- a/src/Lean/LoadDynlib.lean
+++ b/src/Lean/LoadDynlib.lean
@@ -73,16 +73,18 @@ def loadDynlib (path : System.FilePath) : IO Unit := do
 /--
 Loads a Lean plugin and runs its initializers.
 
-A Lean plugin is a shared library built from a Lean module.
-This means it has an `initialize_<module-name>` symbol that runs the
-module's initializers (including its imports' initializers). Initializers
+A Lean plugin is a shared library with an initialization function. If
+no `initFn?` is explicitly provided, the initalization function will be
+derived from the library's name (as `initialize_<lib-name>`).
+
+Plugins built from a Lean module will have an initialization function that
+runs the module's initializers (including its imports' initializers). Initializers
 are declared with the `initialize` or `builtin_initialize` commands.
 
-This is similar to passing `--plugin=path` to `lean`.
-Lean environment initializers, such as definitions calling
-`registerEnvExtension`, also require `Lean.initializing` to be `true`.
-To enable them, use `loadPlugin` within a `withImporting` block. This will
-set  `Lean.initializing` (but not `IO.initializing`).
+This is similar to passing `--plugin=path` (or `--plugin=path:initFn`) to `lean`.
+Lean environment initializers, such as definitions calling `registerEnvExtension`,
+also require `Lean.initializing` to be `true`. To enable them, use `loadPlugin` within
+a `withImporting` block. This will set `Lean.initializing` (but not `IO.initializing`).
 
 **Lean never unloads plugins.** Attempting to load a plugin that defines
 symbols shared with a previously loaded plugin (including itself) will error.
@@ -90,16 +92,17 @@ If multiple plugins share common symbols (e.g., imports), those symbols
 should be linked and loaded separately.
 -/
 @[export lean_load_plugin]
-def loadPlugin (path : System.FilePath) : IO Unit := do
+def loadPlugin (path : System.FilePath) (initFn? : Option String := none) : IO Unit := do
   -- We never want to look up plugins using the system library search
   let path ← IO.FS.realPath path
-  let some name := path.fileStem
+  let name ← initFn?.getDM do
+    let some name := path.fileStem
     | throw <| IO.userError s!"error, plugin has invalid file name '{path}'"
+    -- Lean libraries can be prefixed with `lib` or suffixed with `_shared`
+    -- under some configurations. We strip these from the default initializer symbol.
+    let name := name.dropPrefix "lib" |>.dropSuffix "_shared"
+    return s!"initialize_{name}"
   let dynlib ← Dynlib.load path
-  -- Lean libraries can be prefixed with `lib` or suffixed with `_shared`
-  -- under some configurations. We strip these from the initializer symbol.
-  let name := name.dropPrefix "lib" |>.dropSuffix "_shared"
-  let name := s!"initialize_{name}"
   let some sym := dynlib.get? name
     | throw <| IO.userError s!"error loading plugin, initializer not found '{name}'"
   -- Lean never unloads plugins (once initialized).
@@ -109,7 +112,7 @@ def loadPlugin (path : System.FilePath) : IO Unit := do
   Safety:
   * As `dynlib` is marked persistent, there is no danger of garbage collection.
   * There is still no guarantee that `sym` has the proper signature, but this
-    is about as safe as it can be. The initializer naming convention helps
+    is about as safe as it can be. The default initializer naming convention helps
     avoid accidentally mistaking non-plugins as plugins.
   -/
   unsafe sym.runAsInit

--- a/src/Lean/Setup.lean
+++ b/src/Lean/Setup.lean
@@ -124,6 +124,43 @@ def ModuleArtifacts.oleanParts (arts : ModuleArtifacts) : Array System.FilePath 
         fnames := fnames.push pFile
   return fnames
 
+/-- A Lean plugin. Plugins are shared libraries with an initialization function. -/
+structure Plugin where
+  /-- The path to the plugin's shared library. -/
+  path : System.FilePath
+  /--
+  The name of the plugin initialization function symbol.
+  If {lean}`none`, the symbol is derived from the file name of the shared library.
+  -/
+  initFn? : Option String
+  deriving Repr, ToJson
+
+namespace Plugin
+
+/--
+Constructs a plugin from just a shared library's {lean}`path`,
+inferring the name of the initialization function from the library's name.
+-/
+def ofFilePath (path : System.FilePath) : Plugin :=
+  {path, initFn? := none}
+
+instance : Coe System.FilePath Plugin := ⟨ofFilePath⟩
+
+protected def fromJson? (data : Json) : Except String Plugin := do
+  match data with
+  | .str path =>
+    return .ofFilePath path
+  | data@(.obj _) =>
+    let path ← data.getObjValAs? _ "path"
+    let initFn? ← data.getObjValAs? _ "initFn"
+    return {path, initFn?}
+  | _ =>
+    throw "expected string or object"
+
+instance : FromJson Plugin := ⟨Plugin.fromJson?⟩
+
+end Plugin
+
 /--
 The type of module package identifiers.
 
@@ -154,7 +191,7 @@ structure ModuleSetup where
   /-- Dynamic libraries to load with the module. -/
   dynlibs : Array System.FilePath := #[]
   /-- Plugins to initialize with the module. -/
-  plugins : Array System.FilePath := #[]
+  plugins : Array Plugin := #[]
   /-- Additional options for the module. -/
   options : LeanOptions := {}
   deriving Repr, Inhabited, ToJson, FromJson

--- a/src/Lean/Shell.lean
+++ b/src/Lean/Shell.lean
@@ -166,7 +166,7 @@ def displayHelp (useStderr : Bool) : IO Unit := do
     out.putStrLn  "  -s, --tstack=num       thread stack size in Kb"
     out.putStrLn  "      --server           start lean in server mode"
     out.putStrLn  "      --worker           start lean in server-worker mode"
-  out.putStrLn    "      --plugin=file      load and initialize Lean shared library for registering linters etc."
+  out.putStrLn    "      --plugin=file[:fn] load and initialize Lean shared library for registering linters etc."
   out.putStrLn    "      --load-dynlib=file load shared library to make its symbols available to the interpreter"
   out.putStrLn    "      --setup=file       JSON file with module setup data (supersedes the file's header)"
   out.putStrLn    "      --json             report Lean output (e.g., messages) as JSON (one per line)"
@@ -410,9 +410,17 @@ def ShellOptions.process (opts : ShellOptions)
       Internal.enableDebug arg
       return opts
     -- if not `LEAN_DEBUG`, fall through to unknown option
-  | 'p' => -- `--plugin=file`
+  | 'p' => -- `--plugin=file[:fn]`
     let arg ← checkOptArg "p" optArg?
-    Lean.loadPlugin arg
+    let (path, fn?) :=
+      let pos := arg.find ':'
+      if h : pos.IsAtEnd then
+        (FilePath.mk arg, none)
+      else
+        let path := arg.sliceTo pos
+        let initFn := arg.sliceFrom (pos.next h)
+        (FilePath.mk path.copy, some initFn.copy)
+    Lean.loadPlugin path fn?
     let forwardedArgs := opts.forwardedArgs.push s!"-p{arg}"
     return {opts with forwardedArgs}
   | 'l' => -- `--load-dynlib=file`

--- a/src/library/dynlib.cpp
+++ b/src/library/dynlib.cpp
@@ -126,10 +126,10 @@ void load_dynlib(std::string path) {
     consume_io_result(lean_load_dynlib(mk_string(path)));
 }
 
-/* Lean.loadPlugin : System.FilePath -> IO Unit */
-extern "C" obj_res lean_load_plugin(obj_arg path);
+/* Lean.loadPlugin : System.FilePath -> Option String -> IO Unit */
+extern "C" obj_res lean_load_plugin(obj_arg path, obj_arg init_fn);
 
 void load_plugin(std::string path) {
-    consume_io_result(lean_load_plugin(mk_string(path)));
+    consume_io_result(lean_load_plugin(mk_string(path), box(0)));
 }
 }

--- a/tests/elab/frontend_meeting_2022_09_13.lean.out.expected
+++ b/tests/elab/frontend_meeting_2022_09_13.lean.out.expected
@@ -96,5 +96,5 @@ Lean.SourceInfo : Type
 str := "My command comment hello world "
 Lean.Elab.runFrontend (input : String) (opts : Lean.Options) (fileName : String) (mainModuleName : Lean.Name)
   (trustLevel : UInt32 := 0) (oleanFileName? ileanFileName? : Option System.FilePath := none)
-  (jsonOutput : Bool := false) (errorOnKinds : Array Lean.Name := #[]) (plugins : Array System.FilePath := #[])
+  (jsonOutput : Bool := false) (errorOnKinds : Array Lean.Name := #[]) (plugins : Array Lean.Plugin := #[])
   (printStats : Bool := false) (setup? : Option Lean.ModuleSetup := none) : IO (Option Lean.Environment)

--- a/tests/pkg/user_plugin/run_test.sh
+++ b/tests/pkg/user_plugin/run_test.sh
@@ -53,5 +53,12 @@ lean --run test.lean $ENV_PLUGIN >/dev/null 2>&1 && {
   fail "Loading environment plugin without importing succeeded unexpectedly."
 } || true
 
+# Test loading plugin with a provided initialization function
+echo "Testing plugin load with a provided initialization function ..."
+INIT_PLUGIN=.lake/libUserPlugin.$SHLIB_EXT
+INIT_PLUGIN_FN=initialize_${PKG}_UserPlugin
+cp $PLUGIN $INIT_PLUGIN
+echo | lean --plugin=$INIT_PLUGIN:$INIT_PLUGIN_FN --stdin 2>&1 | diff <(echo "$EXPECTED_OUT") -
+
 # Print success
 echo "Tests completed successfully."


### PR DESCRIPTION
This PR adds the ability to specify a name for the initialization function of a Lean plugin on load. 

* The `Lean.loadPlugin` API has gained a `initFn?` argument that defaults to `none`. When `none`, the initialization function name will be inferred from the shared library's name (as before). 
* The CLI `--plugin` option can  now have a initialization function specified via `--plugin=path:initFn`. 
* The `--setup` JSON configuration now also accepts`{"path": ..., "initFn": ...}` for plugins.