### PR TITLE
fix: do not bump transparency to instances in eqn LHS whnf

### DIFF
--- a/src/Lean/Elab/PreDefinition/EqnsUtils.lean
+++ b/src/Lean/Elab/PreDefinition/EqnsUtils.lean
@@ -49,7 +49,7 @@ public def tryContradiction (mvarId : MVarId) : MetaM Bool := do
   mvarId.contradictionCore { genDiseq := true }
 
 partial def whnfAux (e : Expr) : MetaM Expr := do
-  let e ← whnfI e -- Must reduce instances too, otherwise it will not be able to reduce `(Nat.rec ... ... (OfNat.ofNat 0))`
+  let e ← whnfR e
   let f := e.getAppFn
   match f with
   | .proj _ _ s => return mkAppN (f.updateProj! (← whnfAux s)) e.getAppArgs


### PR DESCRIPTION
This PR changes `whnfAux` in the equation-theorem generation machinery to use
reducible transparency (`whnfR`) instead of instances transparency (`whnfI`).
Previously, the loop in `Eqns.go` would unfold instances on the LHS, which
interacts badly with users that mark `dite`/`ite` as `implicit_reducible`:
equation generation would reduce past the `dite` and get stuck instead of
committing to a branch. The original motivation for `whnfI` (reducing
`Nat.rec ... (OfNat.ofNat 0)` residuals from `match` on numeric literals) is
already covered by the surrounding `simpMatch?`/`simpIf?`/`simpTargetStar`
steps in `Eqns.go`, so the full test suite continues to pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
