### PR TITLE
fix: lake: namespace in `Lake.Util.Opaque`

### DIFF
--- a/src/lake/Lake/Util/Opaque.lean
+++ b/src/lake/Lake/Util/Opaque.lean
@@ -9,6 +9,8 @@ prelude
 public import Init.Prelude
 import Init.Tactics
 
+namespace Lake
+
 opaque POpaque.nonemptyType.{u} : NonemptyType.{u}
 
 /-- An value of unknown type in a specific universe. -/


### PR DESCRIPTION
This PR adds `namespace Lake` to `Lake.Util.Opaque`, which was missing it. This is technically a breaking change for any code which used `Opaque` without `open Lake`, but hopefully no one was doing that.
