### PR TITLE
perf: lake: use `List` for `BuildTrace.inputs`

### DIFF
--- a/src/lake/Lake/Build/Common.lean
+++ b/src/lake/Lake/Build/Common.lean
@@ -126,8 +126,9 @@ public def BuildMetadata.parse (contents : String) : Except String BuildMetadata
 public def BuildMetadata.ofFetch (inputHash : Hash) (outputs : Json) : BuildMetadata :=
   {depHash := inputHash, outputs? := outputs, synthetic := true, inputs := #[], log := {}}
 
-partial def serializeInputs (inputs : Array BuildTrace) : Array (String × Json) :=
-  inputs.foldl (init := {}) fun r trace =>
+partial def serializeInputs (inputs : List BuildTrace) : Array (String × Json) :=
+  -- `foldr` restores mix order, since `inputs` is stored reversed (see `BuildTrace.inputs`)
+  inputs.foldr (init := {}) fun trace r =>
     let val :=
       if trace.inputs.isEmpty then
         toJson trace.hash

--- a/src/lake/Lake/Build/Trace.lean
+++ b/src/lake/Lake/Build/Trace.lean
@@ -317,7 +317,8 @@ That is, check if the info is newer than `self`.
 /-- Trace used for common Lake targets. Combines `Hash` and `MTime`. -/
 public structure BuildTrace where
   caption : String := ""
-  inputs : Array BuildTrace := #[]
+  /-- Stored in reverse order so that `mix` is O(1), then reversed on serialization. -/
+  inputs : List BuildTrace := []
   hash : Hash
   mtime : MTime
   deriving Repr
@@ -333,7 +334,7 @@ Clear the inputs of the build trace.
 This is used to remove unnecessary repetition of trace trees across multiple trace files.
 -/
 @[inline] public def withoutInputs (self : BuildTrace) : BuildTrace :=
-  {self with inputs := #[]}
+  {self with inputs := []}
 
 @[inline] public def ofHash (hash : Hash) (caption := "<hash>") : BuildTrace :=
   {caption, hash, mtime := 0}
@@ -365,7 +366,7 @@ public instance
 
 public def mix (t1 t2 : BuildTrace) : BuildTrace where
   caption := t1.caption
-  inputs := t1.inputs.push t2
+  inputs := t2 :: t1.inputs
   hash := Hash.mix t1.hash t2.hash
   mtime := max t1.mtime t2.mtime
 


### PR DESCRIPTION
This PR refactors `Lake.BuildTrace.inputs`  into a `List` in reverse order. Profiling indicated that significant time in a no-op build was spent copying the `inputs` array (due to its use across threads). A `List` avoids this cost.
