### PR TITLE
fix: prevent undefined behavior without `LEAN_MMAP`

### DIFF
--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -319,7 +319,7 @@ extern "C" LEAN_EXPORT object * lean_read_module_data_parts(b_obj_arg ofnames, o
 
     // if *any* file failed to mmap, read all of them into a single big allocation so that offsets
     // between them are unchanged
-    if (!is_mmap) {
+    if (!is_mmap && !files.empty()) {
         for (auto & file : files) {
             if (file.m_free_data) {
                 file.m_free_data();


### PR DESCRIPTION
This PR prevents undefined behavior in `readModuleDataParts #[]` on configurations without `LEAN_MMAP`. Previously this would lead to out-of-bounds indexing.
