### PR TITLE
feat: add `[no_fallback]` attribute for tactic elaborators and macros

### DIFF
--- a/src/Lean/Elab/Tactic/Basic.lean
+++ b/src/Lean/Elab/Tactic/Basic.lean
@@ -147,6 +147,15 @@ directly.
 unsafe builtin_initialize tacticElabAttribute : KeyedDeclsAttribute Tactic ←
   mkElabAttribute Tactic `builtin_tactic `tactic `Lean.Parser.Tactic `Lean.Elab.Tactic.Tactic "tactic"
 
+/--
+Disables automatic fallback of this tactic macro/elaborator to other macros/elaborators of the same
+syntax on failure. An elaborator that does not handle the given syntax should still signal this by
+throwing `unsupportedSyntax`, which is not affected by this attribute.
+-/
+@[builtin_doc]
+builtin_initialize noFallbackAttr : TagAttribute ←
+  registerTagAttribute `no_fallback "disables automatic fallback on tactic macro/elab failure"
+
 def mkTacticInfo (mctxBefore : MetavarContext) (goalsBefore : List MVarId) (stx : Syntax) : TacticM Info :=
   return Info.ofTacticInfo {
     elaborator    := (← read).elaborator
@@ -212,17 +221,22 @@ where
      else
        throwErrorAt stx "Unexpected syntax{indentD stx}"
 
-    @[inline] handleEx (s : SavedState) (failures : Array EvalTacticFailure) (ex : Exception) (k : Array EvalTacticFailure → TacticM Unit) := do
+    @[inline] handleEx (declName : Name) (s : SavedState) (failures : Array EvalTacticFailure) (ex : Exception) (k : Array EvalTacticFailure → TacticM Unit) := do
+      let noFallback := noFallbackAttr.hasTag (← getEnv) declName
       match ex with
       | .error .. =>
+        if noFallback then throw ex
         trace[Elab.tactic.backtrack] ex.toMessageData
         let failures := failures.push ⟨ex, ← Tactic.saveState⟩
         s.restore (restoreInfo := true); k failures
       | .internal id _ =>
         if id == unsupportedSyntaxExceptionId then
           -- We do not store `unsupportedSyntaxExceptionId`, see throwExs
+          -- `unsupportedSyntax` is the elaborator declining the syntax before any commit, so
+          -- `[no_fallback]` does not apply here.
           s.restore (restoreInfo := true); k failures
         else if id == abortTacticExceptionId then
+          if noFallback then throw ex
           for msg in (← Core.getMessageLog).toList do
             trace[Elab.tactic.backtrack] msg.data
           let failures := failures.push ⟨ex, ← Tactic.saveState⟩
@@ -280,7 +294,7 @@ where
                     evalTactic stx'
                   return
               evalTactic stx'
-        catch ex => handleEx s failures ex (expandEval s ms evalFns)
+        catch ex => handleEx m.declName s failures ex (expandEval s ms evalFns)
 
     eval (s : SavedState) (evalFns : List _) (failures : Array EvalTacticFailure) : TacticM Unit := do
       match evalFns with
@@ -294,7 +308,7 @@ where
             evalFn.value stx
             if !evalFn.isBuiltin then
               recordExtraModUseFromDecl (isMeta := true) evalFn.declName
-        catch ex => handleEx s failures ex (eval s evalFns)
+        catch ex => handleEx evalFn.declName s failures ex (eval s evalFns)
 
 def throwNoGoalsToBeSolved : TacticM α :=
   throwError "No goals to be solved"

--- a/tests/elab/noFallbackAttr.lean
+++ b/tests/elab/noFallbackAttr.lean
@@ -1,0 +1,89 @@
+import Lean
+
+/-!  Tests for `@[no_fallback]` on tactic elaborators and macros. -/
+
+open Lean Elab Tactic
+
+/-! ## Default behavior: fallback on error -/
+
+syntax "myTac1" : tactic
+
+elab_rules : tactic
+  | `(tactic| myTac1) => logInfo "fallback"
+
+elab_rules : tactic
+  | `(tactic| myTac1) => throwError "first"
+
+/-- info: fallback -/
+#guard_msgs in
+example : True := by myTac1; trivial
+
+/-! ## `@[no_fallback]` prevents fallback on `.error` -/
+
+syntax "myTac2" : tactic
+
+elab_rules : tactic
+  | `(tactic| myTac2) => logInfo "unreached"
+
+@[no_fallback]
+elab_rules : tactic
+  | `(tactic| myTac2) => throwError "committed"
+
+/-- error: committed -/
+#guard_msgs in
+example : True := by myTac2; trivial
+
+/-! ## `@[no_fallback]` prevents fallback on `abortTactic` -/
+
+syntax "myTac3" : tactic
+
+elab_rules : tactic
+  | `(tactic| myTac3) => logInfo "unreached"
+
+@[no_fallback]
+elab_rules : tactic
+  | `(tactic| myTac3) => do
+    logError "aborted"
+    throwAbortTactic
+
+/--
+error: aborted
+---
+error: unsolved goals
+⊢ True
+-/
+#guard_msgs in
+example : True := by myTac3; trivial
+
+/-! ## `@[no_fallback]` still allows `unsupportedSyntax` to fall back -/
+
+syntax "myTac4" (ident)? : tactic
+
+elab_rules : tactic
+  | `(tactic| myTac4) => logInfo "without ident"
+
+@[no_fallback]
+elab_rules : tactic
+  | `(tactic| myTac4 $_:ident) => logInfo "with ident"
+
+/-- info: without ident -/
+#guard_msgs in
+example : True := by myTac4; trivial
+
+/-! ## `@[no_fallback]` on a macro -/
+
+syntax "myTac5" : tactic
+
+elab_rules : tactic
+  | `(tactic| myTac5) => logInfo "unreached"
+
+@[no_fallback]
+macro_rules
+  | `(tactic| myTac5) => `(tactic| fail "macro expansion committed")
+
+/--
+error: macro expansion committed
+⊢ True
+-/
+#guard_msgs in
+example : True := by myTac5; trivial


### PR DESCRIPTION
This PR allows tactic macros and elaborators to opt out of automatic fallback to previous macros/elabs on failure. `throwUnsupportedSyntax` is unaffected.