### PR TITLE
fix: lake: namespace in `Lake.Util.Opaque` (reapplied)

### DIFF
--- a/src/lake/Lake/Util/Opaque.lean
+++ b/src/lake/Lake/Util/Opaque.lean
@@ -9,6 +9,8 @@ prelude
 public import Init.Prelude
 import Init.Tactics
 
+namespace Lake
+
 opaque POpaque.nonemptyType.{u} : NonemptyType.{u}
 
 /-- An value of unknown type in a specific universe. -/


### PR DESCRIPTION
This PR reapplies #13516 which was reverted by #13517 due to a [failure](https://www.githubstatus.com/incidents/zsg1lk7w13cf) of GitHub's merge queue.