### PR TITLE
feat: make unit RpcEncodable

### DIFF
--- a/src/Lean/Server/Rpc/Basic.lean
+++ b/src/Lean/Server/Rpc/Basic.lean
@@ -205,6 +205,12 @@ instance [RpcEncodable α] : RpcEncodable (Option α) where
   rpcEncode v := toJson <$> v.mapM rpcEncode
   rpcDecode j := do Option.mapM rpcDecode (← fromJson? j)
 
+instance : RpcEncodable Unit where
+  rpcEncode _ := pure .null
+  rpcDecode
+    | .null => return ()
+    | json => .error s!"expected null to decode Unit, got {json}"
+
 -- TODO(WN): instance [RpcEncodable α β] [Traversable t] : RpcEncodable (t α) (t β)
 
 instance [RpcEncodable α] : RpcEncodable (Array α) where


### PR DESCRIPTION
This PR adds an instance of RpcEncodable for `Unit`

@Vtec234 — this occurred to me after our conversation Friday. I can see an argument for not making Unit ToJson/FromJson, especially given that downstream libraries may have added (possibly incompatable, like `{}` not `null`) definitions. Would just making it RpcEncodable be a reasonable alternative, or should we bite the bullet and add to/from Json instances?