### PR TITLE
feat: notify satellite solvers about asserted equalities in `grind`

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/Arith/Cutsat/EqCnstr.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Cutsat/EqCnstr.lean
@@ -758,6 +758,13 @@ def internalize (e : Expr) (parent? : Option Expr) : GoalM Unit := do
     Perhaps, we should have a `HasToInt` auxiliary class without output parameters.
     -/
     let_expr Eq α a b := e | return ()
+    unless (← alreadyInternalized e) do
+      /-
+      **Note**: Core invokes `Solver.internalize` for top-level equations that are not internalized.
+      There is no point of processing them since this module has handlers for `newEq` and
+      `newDiseq`.
+      -/
+      return ()
     unless (← getToIntId? α).isSome do return ()
     internalizeToIntTerm a α
     internalizeToIntTerm b α

--- a/src/Lean/Meta/Tactic/Grind/Core.lean
+++ b/src/Lean/Meta/Tactic/Grind/Core.lean
@@ -346,6 +346,18 @@ where
     else
       internalize lhs generation p
       internalize rhs generation p
+      /-
+      As an optimization, `p` itself is not internalized in the E-graph, but
+      we still notify satellite solvers about it. Some satellite solvers (e.g.,
+      the homomorphism extension) only see asserted equalities through this
+      notification; others (e.g., `cutsat`) use it to register `lhs` and `rhs`
+      as their internal terms when `α` is a supported type.
+
+      This must run **before** `addEqCore`: `Solvers.mergeTerms` (invoked by
+      `addEqCore`) only fires `processNewEq` for solvers that have already
+      registered both `lhs` and `rhs`.
+      -/
+      Solvers.internalize p none
       addEqCore lhs rhs proof isHEq
 
 set_option compiler.ignoreBorrowAnnotation true in

--- a/tests/pkg/homo/Homo.lean
+++ b/tests/pkg/homo/Homo.lean
@@ -3,7 +3,7 @@ import Homo.Init
 set_option warn.sorry false
 
 opaque TSpec (_ : Nat) : (α : Type) × α := ⟨Unit, ()⟩
-abbrev T (x : Nat) : Type := (TSpec x).1
+def T (x : Nat) : Type := (TSpec x).1
 instance : Inhabited (T x) := ⟨TSpec x |>.2⟩
 opaque toInt : T n → Int
 @[grind_homo_pred] axiom toInt_bounds (x : T n) : 0 <= toInt x ∧ toInt x < 2^n
@@ -27,4 +27,10 @@ set_option trace.homo.pred true
 -- set_option trace.grind.assert true
 example (b : T 7) : pos b → small b →
     small (f 7 (0 + d + a + 1)) → pos (f 7 (0 + d + a + 1)) → small c → pos c → let x := b; le b (add c (add x (f 7 (0 + d + a + 1)))) := by
+  grind
+
+example (x : Int) : 0 ≤ x → x < 2 → (2*x) % 128 = x → x = 0 := by
+  grind
+
+example (b : T 1) (h : add b b = b) : toInt b = 0 := by
   grind

--- a/tests/pkg/homo/Homo/Init.lean
+++ b/tests/pkg/homo/Homo/Init.lean
@@ -134,6 +134,16 @@ def internalize (e : Expr) (_ : Option Expr) : GoalM Unit := do
         addNewRawFact thm (← Meta.inferType thm) (← getGeneration e) .input
         return ()
   unless (← isTarget e) do return ()
+  if !(← alreadyInternalized e) then
+    /-
+    The `grind` core has an optimization: it does not internalize top-level equalities
+    since they can be merged immediately. A satellite solver may implement the `newEq` handler,
+    but this is too inconvenient. It is easier to force `e` to be internalized.
+    -/
+    let_expr Eq _ lhs rhs := e | return ()
+    let gen := max (← getGeneration lhs) (← getGeneration rhs)
+    Grind.internalize e gen
+    return ()
   let .step e₁ h₁ _ ← applyHomo e | return ()
   let r ← preprocess e₁
   let h ← mkEqTrans h₁ (← r.getProof)


### PR DESCRIPTION
This PR notifies satellite solvers about asserted equalities `lhs = rhs` even though `lhs = rhs` is not internalized in the E-graph (an existing optimization). The notification lets solvers that do not inspect equivalence classes (such as the homomorphism extension) react to asserted equalities directly. It fires before the equivalence-class merge so that solvers that mark `lhs` and `rhs` as their internal terms have them registered before `Solvers.mergeTerms` fires `processNewEq`.

`cutsat` opts out of the notification when the equality has not been internalized, since it already handles equalities through its `newEq` handler. The homomorphism demo opts in by forcing `e` to be internalized, enabling its rewrite rules to apply to asserted equalities (e.g., `add b b = b` rewrites via `a = b ↔ toInt a = toInt b`).