### PR TITLE
feat: detect further sub-instances in `wrapInstance`

### DIFF
--- a/src/Lean/Meta/WrapInstance.lean
+++ b/src/Lean/Meta/WrapInstance.lean
@@ -30,8 +30,10 @@ Given an instance `i : I` and expected type `I'` (where `I'` must be mvar-free),
    (controlled by `backward.inferInstanceAs.wrap.instances`).
 3. Reduce `i` to whnf.
 4. If `i` is not a constructor application: if `I` is already defeq to `I'`,
-   return `i`; otherwise wrap it in an auxiliary definition of type `I'` and return it
-   (controlled by `backward.inferInstanceAs.wrap.instances`).
+   return `i`; otherwise (if `backward.inferInstanceAs.wrap.reuseSubInstances` is set) try
+   (recursive) eta-expansion and wrapping of `i` to see if any sub-instances can be reused;
+   otherwise wrap `i` in an auxiliary definition of type `I'` and return it (controlled by
+   `backward.inferInstanceAs.wrap.instances`).
 5. Otherwise, if `i` is an application of `ctor` of class `C`:
    - Unify the conclusion of the type of `ctor` with `I'` to obtain adjusted field type `Fᵢ'` for
      each field.
@@ -115,12 +117,38 @@ def getParentStructType? (structName parentStructName : Name) (structType : Expr
       failure
     return projTy
 
+def etaStructExpand? (e : Expr) : MetaM (Option Expr) := OptionT.run do
+  guard <| (← liftM <| isConstructorApp? e).isNone
+  let eType ← instantiateMVars (← whnf (← inferType e))
+  let .const inductName us := eType.getAppFn | failure
+  let env ← getEnv
+  guard <| isStructure env inductName
+  guard <| isNonRecStructure env inductName
+  guard <| !(← isProp eType)
+  let iv ← getConstInfoInduct inductName
+  let some ctorName := iv.ctors.head? | failure
+  let ctorInfo ← getConstInfoCtor ctorName
+  let params := eType.getAppArgs.shrink ctorInfo.numParams
+  let structInfo? := getStructureInfo? env inductName
+  let mut result := mkAppN (mkConst ctorName us) params
+  for i in *...ctorInfo.numFields do
+    let proj := match structInfo?.bind (·.getProjFn? i) with
+      | some projFn => mkApp (mkAppN (mkConst projFn us) params) e
+      | none => mkProj inductName i e
+    result := mkApp result proj
+  return result
+
 /--
 Wrap an instance value so its type matches the expected type exactly.
 See the module docstring for the full algorithm specification.
 -/
 public partial def wrapInstance (inst expectedType : Expr) (compile : Bool := true)
-    (logCompileErrors : Bool := true) (isMeta : Bool := false) : MetaM Expr := withTransparency .instances do
+    (logCompileErrors : Bool := true) (isMeta : Bool := false) : MetaM Expr :=
+  withTransparency .instances do
+    return (← go (isEta := false) inst expectedType).get!
+-- If `isEta` is true, will return `none` if no sub-instance was found, i.e. eta-expansion had no
+-- effect.
+where go (inst expectedType : Expr) (isEta : Bool) : MetaM (Option Expr) := do
   withTraceNode `Meta.wrapInstance
       (fun _ => return m!"type: {expectedType}") do
   let some className ← isClass? expectedType
@@ -137,21 +165,26 @@ public partial def wrapInstance (inst expectedType : Expr) (compile : Bool := tr
   (← whnf inst).withApp fun f args => do
     let some (.ctorInfo ci) ← f.constName?.mapM getConstInfo
       | do
-        trace[Meta.wrapInstance] "did not reduce to constructor application, returning/wrapping as is: {inst}"
-        if backward.inferInstanceAs.wrap.instances.get (← getOptions) then
-          let instType ← inferType inst
-          if ← isDefEq expectedType instType then
-            return inst
-          else
-            let name ← mkAuxDeclName
-            let wrapped ← mkAuxDefinition name expectedType inst (compile := false)
-            if isMeta then modifyEnv (markMeta · name)
-            if compile then
-              compileDecls (logErrors := logCompileErrors) #[name]
-            enableRealizationsForConst name
-            return wrapped
-        else
+        trace[Meta.wrapInstance] "did not reduce to constructor application: {inst}"
+        let instType ← inferType inst
+        if ← isDefEq expectedType instType then
           return inst
+
+        if backward.inferInstanceAs.wrap.reuseSubInstances.get (← getOptions) then
+          if let some inst ← etaStructExpand? inst then
+            if let some inst ← go (isEta := true) inst expectedType then
+              return inst
+
+        if backward.inferInstanceAs.wrap.instances.get (← getOptions) then
+          let name ← mkAuxDeclName
+          let wrapped ← mkAuxDefinition name expectedType inst (compile := false)
+          if isMeta then modifyEnv (markMeta · name)
+          if compile then
+            compileDecls (logErrors := logCompileErrors) #[name]
+          enableRealizationsForConst name
+          return wrapped
+
+        return inst
     let (mvars, _, cls) ← forallMetaTelescope (← inferType f)
     if h₁ : args.size ≠ mvars.size then
       throwError "wrapInstance: incorrect number of arguments for \
@@ -160,6 +193,7 @@ public partial def wrapInstance (inst expectedType : Expr) (compile : Bool := tr
       unless ← isDefEq expectedType cls do
         throwError "wrapInstance: `{expectedType}` does not unify with the conclusion of \
           `{.ofConstName ci.name}`"
+      let mut isEta := isEta
       for h₂ : i in ci.numParams...args.size do
         have : i < mvars.size := by
           simp only [ne_eq, Decidable.not_not] at h₁
@@ -188,12 +222,24 @@ public partial def wrapInstance (inst expectedType : Expr) (compile : Bool := tr
               if let .some new ← trySynthInstance argExpectedType then
                 trace[Meta.wrapInstance] "using existing instance {new}"
                 mvarId.assign new
+                isEta := false
                 continue
             catch _ => pure ()
 
-          mvarId.assign (← wrapInstance arg argExpectedType (compile := compile)
-            (logCompileErrors := logCompileErrors) (isMeta := isMeta))
+          -- continue eta-expansion recursively so we know whether any sub-instance was found
+          if isEta then
+            if let some arg ← etaStructExpand? arg then
+              if let some inst ← go (isEta := true) arg argExpectedType then
+                mvarId.assign inst
+                isEta := false
+                continue
+
+          mvarId.assign (← go (isEta := false) arg argExpectedType).get!
           continue
+
+        -- If we hit a data field without having found any sub-instances, we can stop early
+        if isEta then
+          return none
 
         if backward.inferInstanceAs.wrap.reuseSubInstances.get (← getOptions) then
           let (baseClassName, fieldInfo) ← getFieldOrigin className mvarDecl.userName

--- a/src/Lean/Meta/WrapInstance.lean
+++ b/src/Lean/Meta/WrapInstance.lean
@@ -250,10 +250,11 @@ where go (inst expectedType : Expr) (isEta : Bool) : MetaM (Option Expr) := do
             if let some baseClassType ← getParentStructType? className baseClassName expectedType then
               try
                 if let .some existingBaseClassInst ← trySynthInstance baseClassType then
+                  let proj ← mkProjection existingBaseClassInst fieldInfo.fieldName
                   -- ignore instances from non-defeq diamonds
-                  if (← withDefault <| isDefEq existingBaseClassInst inst) then
+                  if (← withDefault <| isDefEq proj arg) then
                     trace[Meta.wrapInstance] "using projection of existing instance `{existingBaseClassInst}`"
-                    mvarId.assign (← mkProjection existingBaseClassInst fieldInfo.fieldName)
+                    mvarId.assign proj
                     continue
                 trace[Meta.wrapInstance] "did not find existing instance for `{baseClassName}`"
               catch e =>

--- a/src/Lean/Meta/WrapInstance.lean
+++ b/src/Lean/Meta/WrapInstance.lean
@@ -220,10 +220,12 @@ where go (inst expectedType : Expr) (isEta : Bool) : MetaM (Option Expr) := do
             -- semireducible transparency.
             try
               if let .some new ← trySynthInstance argExpectedType then
-                trace[Meta.wrapInstance] "using existing instance {new}"
-                mvarId.assign new
-                isEta := false
-                continue
+                -- ignore instances from non-defeq diamonds
+                if (← withDefault <| isDefEq new arg) then
+                  trace[Meta.wrapInstance] "using existing instance {new}"
+                  mvarId.assign new
+                  isEta := false
+                  continue
             catch _ => pure ()
 
           -- continue eta-expansion recursively so we know whether any sub-instance was found
@@ -248,9 +250,11 @@ where go (inst expectedType : Expr) (isEta : Bool) : MetaM (Option Expr) := do
             if let some baseClassType ← getParentStructType? className baseClassName expectedType then
               try
                 if let .some existingBaseClassInst ← trySynthInstance baseClassType then
-                  trace[Meta.wrapInstance] "using projection of existing instance `{existingBaseClassInst}`"
-                  mvarId.assign (← mkProjection existingBaseClassInst fieldInfo.fieldName)
-                  continue
+                  -- ignore instances from non-defeq diamonds
+                  if (← withDefault <| isDefEq existingBaseClassInst inst) then
+                    trace[Meta.wrapInstance] "using projection of existing instance `{existingBaseClassInst}`"
+                    mvarId.assign (← mkProjection existingBaseClassInst fieldInfo.fieldName)
+                    continue
                 trace[Meta.wrapInstance] "did not find existing instance for `{baseClassName}`"
               catch e =>
                 trace[Meta.wrapInstance] "error when attempting to reuse existing instance for `{baseClassName}`: {e.toMessageData}"

--- a/tests/elab/inferInstanceAs.lean
+++ b/tests/elab/inferInstanceAs.lean
@@ -101,3 +101,41 @@ structure MyStruct where
 instance : Zero MyStruct.{u, max u v} := ⟨{}⟩
 
 instance : Zero MyStruct.{u, max u v} := inferInstanceAs <| Zero MyStruct.{u, max u v}
+
+/-! Test reusing subinstances not encountered directly. -/
+
+class Base2 (α : Type) where
+  a : α
+
+class Main0 (α : Type) extends Base2 α where
+  b : α
+
+class Main1 (α : Type) extends Base2 α where
+  c : α
+
+class Super (α : Type) extends Main0 α, Main1 α where
+
+def MyCopy (α : Type) : Type := α
+
+instance iBase2 (α : Type) [Base2 α] : Base2 (MyCopy α) :=
+  inferInstanceAs <| Base2 α
+
+instance iMain0 (α : Type) [Main0 α] : Main0 (MyCopy α) :=
+  inferInstanceAs <| Main0 α
+
+instance iMain1 (α : Type) [Main1 α] : Main1 (MyCopy α) :=
+  inferInstanceAs <| Main1 α
+
+instance iSuper (α : Type) [Super α] : Super (MyCopy α) :=
+  inferInstanceAs <| Super α
+
+example (α : Type) [Super α] :
+    (iSuper α).toMain1 = iMain1 α := by
+  with_reducible_and_instances rfl
+
+/--
+info: @[implicit_reducible] private def iSuper : (α : Type) → [Super α] → Super (MyCopy α) :=
+fun α [Super α] => { toMain0 := iMain0 α, c := Main1.c }
+-/
+#guard_msgs in
+#print iSuper


### PR DESCRIPTION
This PR extends the procedure behind `inferInstanceAs`/`def ... deriving` to continue recursion through the class graph even when a (local) instance to wrap was found in order to re-use already-wrapped instance of subclasses.