### PR TITLE
test: regression tests for `do` issues fixed by the new elaborator

### DIFF
--- a/tests/elab/12229.lean
+++ b/tests/elab/12229.lean
@@ -1,0 +1,44 @@
+import Lean
+import Std
+
+open Lean Meta
+
+structure Foo (n : Nat) where
+  (l : List Nat)
+  (h : n = n)
+
+-- same as `foo` in #11337, except replacing `trace` by `logInfo`
+def foo' (n : Nat) : MetaM Unit := do
+  let mut result : Foo n := ⟨[7], rfl⟩
+  logInfo m!"Initial value of result: {result.l}"
+  result := ⟨List.range n, rfl⟩
+  logInfo m!"We have a new value of result {result.l}"
+  match n with
+  | _ => logInfo m!"Now we keep the new value {result.l}"
+
+/--
+info: Initial value of result: [7]
+---
+info: We have a new value of result [0, 1, 2, 3, 4]
+---
+info: Now we keep the new value [0, 1, 2, 3, 4]
+-/
+#guard_msgs in
+run_meta do
+  foo' 5
+
+local instance {α β cmp} [Append β] : Append (Std.TreeMap α β cmp) :=
+  ⟨.mergeWith (fun _ ↦ (· ++ ·))⟩
+
+def bar (hyp? : Option Unit) (a : α) : IO (Std.TreeMap Nat (Array α)) := do
+  let mut tree := {}
+  if true then
+    pure ()
+  tree := tree ++ (.insert {} 0 #[a])
+  if let some _ := hyp? then
+    tree := tree
+  return tree
+
+/-- info: Std.TreeMap.ofList [(0, #[3])] -/
+#guard_msgs in
+#eval bar none 3

--- a/tests/elab/12229.lean
+++ b/tests/elab/12229.lean
@@ -1,6 +1,8 @@
 import Lean
 import Std
 
+set_option backward.do.legacy false
+
 open Lean Meta
 
 structure Foo (n : Nat) where

--- a/tests/elab/doNotation7.lean
+++ b/tests/elab/doNotation7.lean
@@ -1,0 +1,54 @@
+-- #3126
+/-- error: Unknown identifier `IAmIgnored` -/
+#guard_msgs in
+example : IO Unit := do
+  let x : IAmIgnored ← do pure 1
+  return
+
+-- #2676
+example : IO Unit := do
+  let x ← return
+
+-- #2663
+example : Id Unit := do
+  let mut x ← if true then pure true else pure false
+  if let .true := x then
+    x := false
+
+-- #5607
+example : Id Unit := do
+  let mut val : Bool ← do
+    pure true
+  val := Bool.not val
+  return ()
+
+-- #6426
+example (arr : Array Nat) : Unit := Id.run do
+  let mut abc := 0
+  if 0 = 0 then
+    ()
+  for (i, j) in [(0, 0)] do
+    let a : Nat := i + 2
+    if h : arr.size ≤ 4 then
+      continue
+    else if h : arr[4] ≤ a then
+      continue
+    else
+      if 0 = 0 then
+        continue
+      abc := 0
+
+-- #8119
+/--
+error: Type mismatch
+  Nat
+has type
+  Type
+of sort `Type 1` but is expected to have type
+  Type u
+of sort `Type (u + 1)`
+-/
+#guard_msgs in
+def test8119.{u, v} {m : Type u → Type v} [Monad m] : m PUnit.{u + 1} := do
+  let mut i : Nat := 0
+  while true do i := i + 1

--- a/tests/elab/doNotation7.lean
+++ b/tests/elab/doNotation7.lean
@@ -38,6 +38,17 @@ example (arr : Array Nat) : Unit := Id.run do
         continue
       abc := 0
 
+-- #9037
+def test9037 (x : Option Nat) : Nat := Id.run do
+  let mut i ←
+    match x with
+    | .some v =>
+      pure v
+    | none =>
+      pure 0
+  i := i + 1
+  return i
+
 -- #8119
 /--
 error: Type mismatch

--- a/tests/elab/doNotation7.lean
+++ b/tests/elab/doNotation7.lean
@@ -1,3 +1,5 @@
+set_option backward.do.legacy false
+
 -- #3126
 /-- error: Unknown identifier `IAmIgnored` -/
 #guard_msgs in


### PR DESCRIPTION
This PR adds regression tests for `do`-notation issues that the new elaborator fixes:

* `tests/elab/doNotation7.lean` collects reproducers for #2663, #2676, #3126, #5607, #6426, and #8119.
* `tests/elab/12229.lean` covers the `logInfo` and `Std.TreeMap` reproducers from #12229.