### PR TITLE
fix: propagate memory errors when allocating for libuv

### DIFF
--- a/src/runtime/uv/dns.cpp
+++ b/src/runtime/uv/dns.cpp
@@ -45,10 +45,13 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_dns_get_info(b_obj_arg name, b_obj_a
         return lean_io_result_mk_error(lean_mk_io_error_invalid_argument(EINVAL, mk_string("service is not ASCII")));
     }
 
+    uv_getaddrinfo_t* resolver = (uv_getaddrinfo_t*)malloc(sizeof(uv_getaddrinfo_t));
+    if (resolver == nullptr) {
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
+
     lean_object* promise = lean_promise_new();
     mark_mt(promise);
-
-    uv_getaddrinfo_t* resolver = (uv_getaddrinfo_t*)malloc(sizeof(uv_getaddrinfo_t));
     resolver->data = promise;
 
 
@@ -123,10 +126,13 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_dns_get_info(b_obj_arg name, b_obj_a
 
 // Std.Internal.IO.Async.DNS.getNameInfo (host : @& SocketAddress) : IO (IO.Promise (Except IO.Error (String × String)))
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_dns_get_name(b_obj_arg addr) {
+    uv_getnameinfo_t* req = (uv_getnameinfo_t*)malloc(sizeof(uv_getnameinfo_t));
+    if (req == nullptr) {
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
+
     lean_object* promise = lean_promise_new();
     mark_mt(promise);
-
-    uv_getnameinfo_t* req = (uv_getnameinfo_t*)malloc(sizeof(uv_getnameinfo_t));
     req->data = promise;
 
     sockaddr_storage addr_ptr;

--- a/src/runtime/uv/dns.cpp
+++ b/src/runtime/uv/dns.cpp
@@ -47,7 +47,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_dns_get_info(b_obj_arg name, b_obj_a
 
     uv_getaddrinfo_t* resolver = (uv_getaddrinfo_t*)malloc(sizeof(uv_getaddrinfo_t));
     if (resolver == nullptr) {
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
 
     lean_object* promise = lean_promise_new();
@@ -128,7 +128,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_dns_get_info(b_obj_arg name, b_obj_a
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_dns_get_name(b_obj_arg addr) {
     uv_getnameinfo_t* req = (uv_getnameinfo_t*)malloc(sizeof(uv_getnameinfo_t));
     if (req == nullptr) {
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
 
     lean_object* promise = lean_promise_new();

--- a/src/runtime/uv/signal.cpp
+++ b/src/runtime/uv/signal.cpp
@@ -101,7 +101,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_signal_mk(uint32_t signum_obj, uint8
 
     lean_uv_signal_object * signal = (lean_uv_signal_object*)malloc(sizeof(lean_uv_signal_object));
     if (signal == nullptr) {
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
     signal->m_signum = signum;
     signal->m_repeating = repeating;
@@ -111,7 +111,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_signal_mk(uint32_t signum_obj, uint8
     uv_signal_t * uv_signal = (uv_signal_t*)malloc(sizeof(uv_signal_t));
     if (uv_signal == nullptr) {
         free(signal);
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
 
     event_loop_lock(&global_ev);

--- a/src/runtime/uv/signal.cpp
+++ b/src/runtime/uv/signal.cpp
@@ -100,12 +100,19 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_signal_mk(uint32_t signum_obj, uint8
     }
 
     lean_uv_signal_object * signal = (lean_uv_signal_object*)malloc(sizeof(lean_uv_signal_object));
+    if (signal == nullptr) {
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
     signal->m_signum = signum;
     signal->m_repeating = repeating;
     signal->m_state = SIGNAL_STATE_INITIAL;
     signal->m_promise = NULL;
 
     uv_signal_t * uv_signal = (uv_signal_t*)malloc(sizeof(uv_signal_t));
+    if (uv_signal == nullptr) {
+        free(signal);
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
 
     event_loop_lock(&global_ev);
     int result = uv_signal_init(global_ev.loop, uv_signal);

--- a/src/runtime/uv/system.cpp
+++ b/src/runtime/uv/system.cpp
@@ -423,18 +423,16 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_hrtime() {
 
 // Std.Internal.UV.System.random : UInt64 → IO (IO.Promise (Except IO.Error (Array UInt8)))
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_random(uint64_t size) {
-    lean_object* promise = lean_promise_new();
-    mark_mt(promise);
-
-    lean_object* byte_array = lean_alloc_sarray(1, 0, size);
-
     random_req_t* req = (random_req_t*)malloc(sizeof(random_req_t));
     if (req == nullptr) {
-        lean_dec(byte_array);
-        lean_dec(promise);
         return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
+
+    lean_object* promise = lean_promise_new();
+    mark_mt(promise);
     req->promise = promise;
+
+    lean_object* byte_array = lean_alloc_sarray(1, 0, size);
     req->byte_array = byte_array;
 
     req->req.data = req;

--- a/src/runtime/uv/system.cpp
+++ b/src/runtime/uv/system.cpp
@@ -286,6 +286,9 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_os_getenv(b_obj_arg name) {
         return lean_io_result_mk_ok(lean_box(0));
     } else if (result == UV_ENOBUFS) {
         char* heap_buffer = static_cast<char*>(malloc(size));
+        if (heap_buffer == nullptr) {
+            return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        }
 
         result = uv_os_getenv(name_str, heap_buffer, &size);
 
@@ -426,6 +429,11 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_random(uint64_t size) {
     lean_object* byte_array = lean_alloc_sarray(1, 0, size);
 
     random_req_t* req = (random_req_t*)malloc(sizeof(random_req_t));
+    if (req == nullptr) {
+        lean_dec(byte_array);
+        lean_dec(promise);
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
     req->promise = promise;
     req->byte_array = byte_array;
 

--- a/src/runtime/uv/system.cpp
+++ b/src/runtime/uv/system.cpp
@@ -287,7 +287,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_os_getenv(b_obj_arg name) {
     } else if (result == UV_ENOBUFS) {
         char* heap_buffer = static_cast<char*>(malloc(size));
         if (heap_buffer == nullptr) {
-            return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+            return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
         }
 
         result = uv_os_getenv(name_str, heap_buffer, &size);
@@ -432,7 +432,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_random(uint64_t size) {
     if (req == nullptr) {
         lean_dec(byte_array);
         lean_dec(promise);
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
     req->promise = promise;
     req->byte_array = byte_array;

--- a/src/runtime/uv/tcp.cpp
+++ b/src/runtime/uv/tcp.cpp
@@ -83,6 +83,9 @@ void initialize_libuv_tcp_socket() {
 /* Std.Internal.UV.TCP.Socket.new : IO Socket */
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_new() {
     lean_uv_tcp_socket_object* tcp_socket = (lean_uv_tcp_socket_object*)malloc(sizeof(lean_uv_tcp_socket_object));
+    if (tcp_socket == nullptr) {
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
 
     tcp_socket->m_promise_accept = nullptr;
     tcp_socket->m_promise_shutdown = nullptr;
@@ -91,6 +94,10 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_new() {
     tcp_socket->m_client = nullptr;
 
     uv_tcp_t* uv_tcp = (uv_tcp_t*)malloc(sizeof(uv_tcp_t));
+    if (uv_tcp == nullptr) {
+        free(tcp_socket);
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
 
     event_loop_lock(&global_ev);
     int result = uv_tcp_init(global_ev.loop, uv_tcp);
@@ -124,7 +131,16 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_connect(b_obj_arg socket, b_obj_
     lean_socket_address_to_sockaddr_storage(addr, &addr_struct);
 
     uv_connect_t* uv_connect = (uv_connect_t*)malloc(sizeof(uv_connect_t));
+    if (uv_connect == nullptr) {
+        lean_dec(promise);
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
     tcp_connect_data* connect_data = (tcp_connect_data*)malloc(sizeof(tcp_connect_data));
+    if (connect_data == nullptr) {
+        free(uv_connect);
+        lean_dec(promise);
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
 
     connect_data->promise = promise;
     connect_data->socket = socket;
@@ -186,6 +202,10 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_send(b_obj_arg socket, obj_arg d
         return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
     uv_buf_t* bufs = (uv_buf_t*)malloc(array_len * sizeof(uv_buf_t));
+    if (bufs == nullptr) {
+        lean_dec(data_array);
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
 
     for (size_t i = 0; i < array_len; i++) {
         lean_object* byte_array = lean_array_get_core(data_array, i);
@@ -198,7 +218,20 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_send(b_obj_arg socket, obj_arg d
     mark_mt(promise);
 
     uv_write_t* write_uv = (uv_write_t*)malloc(sizeof(uv_write_t));
+    if (write_uv == nullptr) {
+        lean_dec(data_array);
+        lean_dec(promise);
+        free(bufs);
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
     write_uv->data = (tcp_send_data*)malloc(sizeof(tcp_send_data));
+    if (write_uv->data == nullptr) {
+        lean_dec(data_array);
+        lean_dec(promise);
+        free(bufs);
+        free(write_uv);
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
 
     tcp_send_data* send_data = (tcp_send_data*)write_uv->data;
     send_data->promise = promise;
@@ -608,6 +641,12 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_shutdown(b_obj_arg socket) {
 
 
     uv_shutdown_t* shutdown_req = (uv_shutdown_t*)malloc(sizeof(uv_shutdown_t));
+    if (shutdown_req == nullptr) {
+        lean_dec(tcp_socket->m_promise_shutdown);
+        tcp_socket->m_promise_shutdown = nullptr;
+        event_loop_unlock(&global_ev);
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
     shutdown_req->data = (void*)socket;
 
     lean_inc(socket);

--- a/src/runtime/uv/tcp.cpp
+++ b/src/runtime/uv/tcp.cpp
@@ -84,7 +84,7 @@ void initialize_libuv_tcp_socket() {
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_new() {
     lean_uv_tcp_socket_object* tcp_socket = (lean_uv_tcp_socket_object*)malloc(sizeof(lean_uv_tcp_socket_object));
     if (tcp_socket == nullptr) {
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
 
     tcp_socket->m_promise_accept = nullptr;
@@ -96,7 +96,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_new() {
     uv_tcp_t* uv_tcp = (uv_tcp_t*)malloc(sizeof(uv_tcp_t));
     if (uv_tcp == nullptr) {
         free(tcp_socket);
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
 
     event_loop_lock(&global_ev);
@@ -133,13 +133,13 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_connect(b_obj_arg socket, b_obj_
     uv_connect_t* uv_connect = (uv_connect_t*)malloc(sizeof(uv_connect_t));
     if (uv_connect == nullptr) {
         lean_dec(promise);
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
     tcp_connect_data* connect_data = (tcp_connect_data*)malloc(sizeof(tcp_connect_data));
     if (connect_data == nullptr) {
         free(uv_connect);
         lean_dec(promise);
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
 
     connect_data->promise = promise;
@@ -204,7 +204,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_send(b_obj_arg socket, obj_arg d
     uv_buf_t* bufs = (uv_buf_t*)malloc(array_len * sizeof(uv_buf_t));
     if (bufs == nullptr) {
         lean_dec(data_array);
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
 
     for (size_t i = 0; i < array_len; i++) {
@@ -222,7 +222,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_send(b_obj_arg socket, obj_arg d
         lean_dec(data_array);
         lean_dec(promise);
         free(bufs);
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
     write_uv->data = (tcp_send_data*)malloc(sizeof(tcp_send_data));
     if (write_uv->data == nullptr) {
@@ -230,7 +230,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_send(b_obj_arg socket, obj_arg d
         lean_dec(promise);
         free(bufs);
         free(write_uv);
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
 
     tcp_send_data* send_data = (tcp_send_data*)write_uv->data;
@@ -645,7 +645,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_shutdown(b_obj_arg socket) {
         lean_dec(tcp_socket->m_promise_shutdown);
         tcp_socket->m_promise_shutdown = nullptr;
         event_loop_unlock(&global_ev);
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
     shutdown_req->data = (void*)socket;
 

--- a/src/runtime/uv/tcp.cpp
+++ b/src/runtime/uv/tcp.cpp
@@ -124,23 +124,21 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_new() {
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_connect(b_obj_arg socket, b_obj_arg addr) {
     lean_uv_tcp_socket_object* tcp_socket = lean_to_uv_tcp_socket(socket);
 
-    lean_object* promise = lean_promise_new();
-    mark_mt(promise);
-
     sockaddr_storage addr_struct;
     lean_socket_address_to_sockaddr_storage(addr, &addr_struct);
 
     uv_connect_t* uv_connect = (uv_connect_t*)malloc(sizeof(uv_connect_t));
     if (uv_connect == nullptr) {
-        lean_dec(promise);
         return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
     tcp_connect_data* connect_data = (tcp_connect_data*)malloc(sizeof(tcp_connect_data));
     if (connect_data == nullptr) {
         free(uv_connect);
-        lean_dec(promise);
         return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
+
+    lean_object* promise = lean_promise_new();
+    mark_mt(promise);
 
     connect_data->promise = promise;
     connect_data->socket = socket;
@@ -199,6 +197,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_send(b_obj_arg socket, obj_arg d
 
     // Allocate buffer array for uv_write
     if (lean_usize_mul_would_overflow(array_len, sizeof(uv_buf_t))) {
+        lean_dec(data_array);
         return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
     uv_buf_t* bufs = (uv_buf_t*)malloc(array_len * sizeof(uv_buf_t));
@@ -214,24 +213,22 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_send(b_obj_arg socket, obj_arg d
         bufs[i] = uv_buf_init(data_str, data_len);
     }
 
-    lean_object* promise = lean_promise_new();
-    mark_mt(promise);
-
     uv_write_t* write_uv = (uv_write_t*)malloc(sizeof(uv_write_t));
     if (write_uv == nullptr) {
         lean_dec(data_array);
-        lean_dec(promise);
         free(bufs);
         return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
     write_uv->data = (tcp_send_data*)malloc(sizeof(tcp_send_data));
     if (write_uv->data == nullptr) {
         lean_dec(data_array);
-        lean_dec(promise);
         free(bufs);
         free(write_uv);
         return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
+
+    lean_object* promise = lean_promise_new();
+    mark_mt(promise);
 
     tcp_send_data* send_data = (tcp_send_data*)write_uv->data;
     send_data->promise = promise;
@@ -633,21 +630,17 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_shutdown(b_obj_arg socket) {
         return lean_io_result_mk_error(lean_decode_uv_error(UV_EALREADY, mk_string("shutdown already in progress")));
     }
 
-    lean_object* promise = lean_promise_new();
-    mark_mt(promise);
-
-    tcp_socket->m_promise_shutdown = promise;
-    lean_inc(promise);
-
-
     uv_shutdown_t* shutdown_req = (uv_shutdown_t*)malloc(sizeof(uv_shutdown_t));
     if (shutdown_req == nullptr) {
-        lean_dec(tcp_socket->m_promise_shutdown);
-        tcp_socket->m_promise_shutdown = nullptr;
         event_loop_unlock(&global_ev);
         return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
     shutdown_req->data = (void*)socket;
+
+    lean_object* promise = lean_promise_new();
+    mark_mt(promise);
+    tcp_socket->m_promise_shutdown = promise;
+    lean_inc(promise);
 
     lean_inc(socket);
 

--- a/src/runtime/uv/timer.cpp
+++ b/src/runtime/uv/timer.cpp
@@ -78,7 +78,7 @@ void handle_timer_event(uv_timer_t* handle) {
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_timer_mk(uint64_t timeout, uint8_t repeating) {
     lean_uv_timer_object * timer = (lean_uv_timer_object*)malloc(sizeof(lean_uv_timer_object));
     if (timer == nullptr) {
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
     timer->m_timeout = timeout;
     timer->m_repeating = repeating;
@@ -88,7 +88,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_timer_mk(uint64_t timeout, uint8_t r
     uv_timer_t * uv_timer = (uv_timer_t*)malloc(sizeof(uv_timer_t));
     if (uv_timer == nullptr) {
         free(timer);
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
 
     event_loop_lock(&global_ev);

--- a/src/runtime/uv/timer.cpp
+++ b/src/runtime/uv/timer.cpp
@@ -77,12 +77,19 @@ void handle_timer_event(uv_timer_t* handle) {
 /* Std.Internal.UV.Timer.mk (timeout : UInt64) (repeating : Bool) : IO Timer */
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_timer_mk(uint64_t timeout, uint8_t repeating) {
     lean_uv_timer_object * timer = (lean_uv_timer_object*)malloc(sizeof(lean_uv_timer_object));
+    if (timer == nullptr) {
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
     timer->m_timeout = timeout;
     timer->m_repeating = repeating;
     timer->m_state = TIMER_STATE_INITIAL;
     timer->m_promise = NULL;
 
     uv_timer_t * uv_timer = (uv_timer_t*)malloc(sizeof(uv_timer_t));
+    if (uv_timer == nullptr) {
+        free(timer);
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
 
     event_loop_lock(&global_ev);
     int result = uv_timer_init(global_ev.loop, uv_timer);

--- a/src/runtime/uv/udp.cpp
+++ b/src/runtime/uv/udp.cpp
@@ -63,7 +63,7 @@ void initialize_libuv_udp_socket() {
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_new() {
     lean_uv_udp_socket_object* udp_socket = (lean_uv_udp_socket_object*)malloc(sizeof(lean_uv_udp_socket_object));
     if (udp_socket == nullptr) {
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
 
     udp_socket->m_promise_read = nullptr;
@@ -72,7 +72,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_new() {
     uv_udp_t* uv_udp = (uv_udp_t*)malloc(sizeof(uv_udp_t));
     if (uv_udp == nullptr) {
         free(udp_socket);
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
 
     event_loop_lock(&global_ev);
@@ -153,7 +153,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_send(b_obj_arg socket, obj_arg d
     uv_buf_t* bufs = (uv_buf_t*)malloc(array_len * sizeof(uv_buf_t));
     if (bufs == nullptr) {
         lean_dec(data_array);
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
 
     for (size_t i = 0; i < array_len; i++) {
@@ -171,7 +171,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_send(b_obj_arg socket, obj_arg d
         lean_dec(data_array);
         lean_dec(promise);
         free(bufs);
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
     send_uv->data = (udp_send_data*)malloc(sizeof(udp_send_data));
     if (send_uv->data == nullptr) {
@@ -179,7 +179,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_send(b_obj_arg socket, obj_arg d
         lean_dec(promise);
         free(bufs);
         free(send_uv);
-        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
 
     udp_send_data* send_data = (udp_send_data*)send_uv->data;
@@ -205,7 +205,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_send(b_obj_arg socket, obj_arg d
             free(bufs);
             free(send_uv->data);
             free(send_uv);
-            return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+            return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
         }
         lean_socket_address_to_sockaddr_storage(addr, addr_ptr);
     }

--- a/src/runtime/uv/udp.cpp
+++ b/src/runtime/uv/udp.cpp
@@ -62,11 +62,18 @@ void initialize_libuv_udp_socket() {
 /* Std.Internal.UV.UDP.Socket.new : IO Socket */
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_new() {
     lean_uv_udp_socket_object* udp_socket = (lean_uv_udp_socket_object*)malloc(sizeof(lean_uv_udp_socket_object));
+    if (udp_socket == nullptr) {
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
 
     udp_socket->m_promise_read = nullptr;
     udp_socket->m_byte_array = nullptr;
 
     uv_udp_t* uv_udp = (uv_udp_t*)malloc(sizeof(uv_udp_t));
+    if (uv_udp == nullptr) {
+        free(udp_socket);
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
 
     event_loop_lock(&global_ev);
     int result = uv_udp_init(global_ev.loop, uv_udp);
@@ -144,6 +151,10 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_send(b_obj_arg socket, obj_arg d
         return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
     uv_buf_t* bufs = (uv_buf_t*)malloc(array_len * sizeof(uv_buf_t));
+    if (bufs == nullptr) {
+        lean_dec(data_array);
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
 
     for (size_t i = 0; i < array_len; i++) {
         lean_object* byte_array = lean_array_get_core(data_array, i);
@@ -156,7 +167,20 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_send(b_obj_arg socket, obj_arg d
     mark_mt(promise);
 
     uv_udp_send_t* send_uv = (uv_udp_send_t*)malloc(sizeof(uv_udp_send_t));
+    if (send_uv == nullptr) {
+        lean_dec(data_array);
+        lean_dec(promise);
+        free(bufs);
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
     send_uv->data = (udp_send_data*)malloc(sizeof(udp_send_data));
+    if (send_uv->data == nullptr) {
+        lean_dec(data_array);
+        lean_dec(promise);
+        free(bufs);
+        free(send_uv);
+        return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+    }
 
     udp_send_data* send_data = (udp_send_data*)send_uv->data;
     send_data->promise = promise;
@@ -173,6 +197,16 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_send(b_obj_arg socket, obj_arg d
     if (lean_obj_tag(opt_addr) == 1) {
         lean_object* addr = lean_ctor_get(opt_addr, 0);
         addr_ptr = (sockaddr_storage*)malloc(sizeof(sockaddr_storage));
+        if (addr_ptr == nullptr) {
+            lean_dec(promise);
+            lean_dec(promise);
+            lean_dec(socket);
+            lean_dec(data_array);
+            free(bufs);
+            free(send_uv->data);
+            free(send_uv);
+            return lean_io_result_mk_error(decode_io_error(errno, nullptr));
+        }
         lean_socket_address_to_sockaddr_storage(addr, addr_ptr);
     }
 


### PR DESCRIPTION
This PR prevents memory exhaustion turning into segfaults when using Lean functions which call into libuv

`malloc` can return `NULL`, in which case this code would previously go on to dereference a null pointer.
Instead, it now returns a suitable `IO.Error`.

Calling `lean_internal_panic_out_of_memory` would also be an option here, since the adjacent `lean_promise_new` calls would fail in this way.
