### PR TITLE
feat: better error messages and more complete logic for `checkImpossibleInstance` and `checkNonClassInstance`

### DIFF
--- a/src/Lean/Meta/Instances.lean
+++ b/src/Lean/Meta/Instances.lean
@@ -8,56 +8,13 @@ prelude
 public import Init.Data.Range.Polymorphic.Stream
 public import Lean.Meta.DiscrTree.Main
 public import Lean.Meta.CollectMVars
+import Lean.Meta.PPBinder
+import Lean.Util.UnusedBinders
 import Lean.Meta.CollectFVars
 import Init.While
 import Lean.OriginalConstKind
 import Lean.ProjFns
 public section
-
-/-- Pretty-prints a local declaration and its type as a binder,
-using the appropriate brackets given its `BinderInfo`. Example output: `{α : Type}`.
-
-Returns `none` for let decls. -/
-protected def Lean.LocalDecl.ppAsBinder : LocalDecl → Option MessageData
-  | .ldecl .. => none
-  | .cdecl _ fvarId _ type binderInfo _ =>
-    let (lBracket, rBracket) : String × String := match binderInfo with
-      | .implicit       => ("{", "}")
-      | .strictImplicit => ("⦃", "⦄")
-      | .instImplicit   => ("[", "]")
-      | .default        => ("(", ")")
-    some <| .bracket lBracket m!"{mkFVar fvarId} : {type}" rBracket
-
-/-- Pretty-prints a free variable and its type as a binder,
-using the appropriate brackets given its `BinderInfo`. Example output: `{α : Type}`.
-
-Returns `none` for let decls. -/
-@[inline]
-protected def Lean.FVarId.ppAsBinder (fvarId : FVarId) : MetaM (Option MessageData) :=
-  return (← fvarId.getDecl).ppAsBinder
-
-
-
-/--
-Tests if any of the binders of `(x₀ : A₀) → (x₁ : A₁) → ⋯ → X` which satisfy `p Aᵢ bi` (with `bi`
-the `binderInfo`) are unused in the renainder of the type (i.e. in `(xᵢ₊₁ : Aᵢ₊₁) → ⋯ → X`).
-
-Note that the argument to `p` may have loose bvars. This is a performance optimization.
-
-This function runs `cleanupAnnotations` on each type suffix `(xᵢ₊₁ : Aᵢ₊₁) → ⋯ → X` before
-examining it.
-
-We see through `let`s, and do not report if any of them are unused.
--/
-@[specialize p]
-partial def Lean.Expr.hasUnusedForallBindersWhere (p : BinderInfo → Expr → Bool) (e : Expr) : Bool :=
-  match e.cleanupAnnotations with
-  | .forallE _ type body bi =>
-    p bi type && !(body.hasLooseBVar 0) || body.hasUnusedForallBindersWhere p
-  /- See through `letE` -/
-  | .letE _ _ _ body _ => body.hasUnusedForallBindersWhere p
-  | _ => false
-
 
 namespace Lean.Meta
 
@@ -277,11 +234,7 @@ private partial def computeSynthOrder (inst : Expr) (projInfo? : Option Projecti
 
   return synthed
 
-def checkImpossibleInstance (declName : Name) : MetaM Unit := do
-  let cinfo ← getConstInfo declName
-  /- If there is a sorry, we skip the `NonClassInstance` and `ImpossibleInstance` checks
-      completely -/
-  if cinfo.type.hasSorry then return
+def checkImpossibleInstance (cinfo : ConstantInfo): MetaM Unit := do
   -- Performantly check if any non-instance binder is unused.
   if cinfo.type.hasUnusedForallBindersWhere fun bi _ => !bi.isInstImplicit then do
     forallTelescope cinfo.type fun args ty => do
@@ -316,19 +269,18 @@ def checkImpossibleInstance (declName : Name) : MetaM Unit := do
 
 def checkNonClassInstance (c : Expr) : MetaM Unit := do
   let type ← inferType c
-  /- If there is a sorry, we skip the `NonClassInstance` and `ImpossibleInstance` checks
-     completely -/
-  if type.hasSorry then return
   forallTelescopeReducing type fun _ target => do
     unless (← isClass? target).isSome do
-      unless target.isSorry do
       throwError m!"The declaration `{c}` should not be an instance as its return type `{target}` \
       is not a type class."
 
 def addInstance (declName : Name) (attrKind : AttributeKind) (prio : Nat) : MetaM Unit := do
   let c ← mkConstWithLevelParams declName
-  checkNonClassInstance c
-  checkImpossibleInstance declName
+  let cinfo ← getConstInfo declName
+  -- If there is a sorry, we skip the `NonClassInstance` and `ImpossibleInstance` checks completely
+  unless cinfo.type.hasSorry do
+    checkNonClassInstance c
+    checkImpossibleInstance cinfo
   let keys ← mkInstanceKey c
   let status ← getReducibilityStatus declName
   unless status matches .reducible | .implicitReducible do

--- a/src/Lean/Meta/Instances.lean
+++ b/src/Lean/Meta/Instances.lean
@@ -8,10 +8,57 @@ prelude
 public import Init.Data.Range.Polymorphic.Stream
 public import Lean.Meta.DiscrTree.Main
 public import Lean.Meta.CollectMVars
+import Lean.Meta.CollectFVars
 import Init.While
 import Lean.OriginalConstKind
 import Lean.ProjFns
 public section
+
+/-- Pretty-prints a local declaration and its type as a binder,
+using the appropriate brackets given its `BinderInfo`. Example output: `{α : Type}`.
+
+Returns `none` for let decls. -/
+protected def Lean.LocalDecl.ppAsBinder : LocalDecl → Option MessageData
+  | .ldecl .. => none
+  | .cdecl _ fvarId _ type binderInfo _ =>
+    let (lBracket, rBracket) : String × String := match binderInfo with
+      | .implicit       => ("{", "}")
+      | .strictImplicit => ("⦃", "⦄")
+      | .instImplicit   => ("[", "]")
+      | .default        => ("(", ")")
+    some <| .bracket lBracket m!"{mkFVar fvarId} : {type}" rBracket
+
+/-- Pretty-prints a free variable and its type as a binder,
+using the appropriate brackets given its `BinderInfo`. Example output: `{α : Type}`.
+
+Returns `none` for let decls. -/
+@[inline]
+protected def Lean.FVarId.ppAsBinder (fvarId : FVarId) : MetaM (Option MessageData) :=
+  return (← fvarId.getDecl).ppAsBinder
+
+
+
+/--
+Tests if any of the binders of `(x₀ : A₀) → (x₁ : A₁) → ⋯ → X` which satisfy `p Aᵢ bi` (with `bi`
+the `binderInfo`) are unused in the renainder of the type (i.e. in `(xᵢ₊₁ : Aᵢ₊₁) → ⋯ → X`).
+
+Note that the argument to `p` may have loose bvars. This is a performance optimization.
+
+This function runs `cleanupAnnotations` on each type suffix `(xᵢ₊₁ : Aᵢ₊₁) → ⋯ → X` before
+examining it.
+
+We see through `let`s, and do not report if any of them are unused.
+-/
+@[specialize p]
+partial def Lean.Expr.hasUnusedForallBindersWhere (p : BinderInfo → Expr → Bool) (e : Expr) : Bool :=
+  match e.cleanupAnnotations with
+  | .forallE _ type body bi =>
+    p bi type && !(body.hasLooseBVar 0) || body.hasUnusedForallBindersWhere p
+  /- See through `letE` -/
+  | .letE _ _ _ body _ => body.hasUnusedForallBindersWhere p
+  | _ => false
+
+
 namespace Lean.Meta
 
 register_builtin_option synthInstance.checkSynthOrder : Bool := {
@@ -230,33 +277,58 @@ private partial def computeSynthOrder (inst : Expr) (projInfo? : Option Projecti
 
   return synthed
 
-def checkImpossibleInstance (c : Expr) : MetaM Unit := do
-  let cTy ← inferType c
-  forallTelescopeReducing cTy fun args ty => do
-    let argTys ← args.mapM inferType
-    let impossibleArgs ← args.zipIdx.filterMapM fun (arg, i) => do
-      let fv := arg.fvarId!
-      if (← fv.getDecl).binderInfo.isInstImplicit then return none
-      if ty.containsFVar fv then return none
-      if argTys[i+1:].any (·.containsFVar fv) then return none
-      return some m!"{arg} : {← inferType arg}"
-    if impossibleArgs.isEmpty then return
-    let impossibleArgs := MessageData.joinSep impossibleArgs.toList ", "
-    throwError m!"Instance {c} has arguments "
-      ++ impossibleArgs
-      ++ " that are impossible to infer. Those arguments are not instance-implicit and do not appear in another instance-implicit argument or the return type."
+def checkImpossibleInstance (declName : Name) : MetaM Unit := do
+  let cinfo ← getConstInfo declName
+  /- If there is a sorry, we skip the `NonClassInstance` and `ImpossibleInstance` checks
+      completely -/
+  if cinfo.type.hasSorry then return
+  -- Performantly check if any non-instance binder is unused.
+  if cinfo.type.hasUnusedForallBindersWhere fun bi _ => !bi.isInstImplicit then do
+    forallTelescope cinfo.type fun args ty => do
+      -- Find the fvars used in the type and any instance implicit argument, transitively.
+      let getInitialPossibleFVars := do
+        ty.collectFVars
+        for arg in args do
+          if (← arg.fvarId!.getBinderInfo).isInstImplicit then
+            /- The fvarIds in the `CollectFVars.State` should be our possible args. As such, we
+            start by adding the instance arguments to the state, rather than computing the
+            dependencies of their types. -/
+            modifyThe CollectFVars.State (·.add arg.fvarId!)
+      let possibleFVars ← (·.2) <$> getInitialPossibleFVars.run {}
+      -- Transitively include dependencies.
+      let possibleFVars ← possibleFVars.addDependencies
+      let mut impossibleArgMsgs := #[]
+      for arg in args, i in 1...* do
+        unless possibleFVars.fvarSet.contains arg.fvarId! do
+          let some binder ← arg.fvarId!.ppAsBinder | continue
+          impossibleArgMsgs := impossibleArgMsgs.push <|
+            indentD m!"argument {i}: `{binder}`"
+      if impossibleArgMsgs.isEmpty then return -- Should not be reachable.
+      let msg := m!"\
+        This instance has {impossibleArgMsgs.size} \
+        argument{if impossibleArgMsgs.size = 1 then "" else "s"} that cannot be \
+        inferred using typeclass synthesis. Specifically\n\
+        {.joinSep impossibleArgMsgs.toList .nil}\n\n\
+        These arguments are not instance-implicit and appear neither in another \
+        instance-implicit argument nor the return type, so they cannot be inferred using \
+        typeclass synthesis."
+      if cinfo.type.hasSorry then logWarning msg else throwError msg
 
-def checkNonClassInstance (declName : Name) (c : Expr) : MetaM Unit := do
+def checkNonClassInstance (c : Expr) : MetaM Unit := do
   let type ← inferType c
+  /- If there is a sorry, we skip the `NonClassInstance` and `ImpossibleInstance` checks
+     completely -/
+  if type.hasSorry then return
   forallTelescopeReducing type fun _ target => do
     unless (← isClass? target).isSome do
       unless target.isSorry do
-      throwError m!"instance `{declName}` target `{target}` is not a type class."
+      throwError m!"The declaration `{c}` should not be an instance as its return type `{target}` \
+      is not a type class."
 
 def addInstance (declName : Name) (attrKind : AttributeKind) (prio : Nat) : MetaM Unit := do
   let c ← mkConstWithLevelParams declName
-  checkImpossibleInstance c
-  checkNonClassInstance declName c
+  checkNonClassInstance c
+  checkImpossibleInstance declName
   let keys ← mkInstanceKey c
   let status ← getReducibilityStatus declName
   unless status matches .reducible | .implicitReducible do

--- a/src/Lean/Meta/PPBinder.lean
+++ b/src/Lean/Meta/PPBinder.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2026 Moritz Roos. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Moritz Roos
+-/
+module
+
+prelude
+public import Lean.Meta.Basic
+
+public section
+
+namespace Lean
+
+/--
+Pretty-prints a local declaration and its type as a binder,
+using the appropriate brackets given its `BinderInfo`. Example output: `{α : Type}`.
+
+Returns `none` for let decls.
+-/
+protected def LocalDecl.ppAsBinder : LocalDecl → Option MessageData
+  | .ldecl .. => none
+  | .cdecl _ fvarId _ type binderInfo _ =>
+    let (lBracket, rBracket) : String × String := match binderInfo with
+      | .implicit       => ("{", "}")
+      | .strictImplicit => ("⦃", "⦄")
+      | .instImplicit   => ("[", "]")
+      | .default        => ("(", ")")
+    some <| .bracket lBracket m!"{mkFVar fvarId} : {type}" rBracket
+
+/--
+Pretty-prints a free variable and its type as a binder,
+using the appropriate brackets given its `BinderInfo`. Example output: `{α : Type}`.
+
+Returns `none` for let decls.
+-/
+@[inline]
+protected def FVarId.ppAsBinder (fvarId : FVarId) : MetaM (Option MessageData) :=
+  return (← fvarId.getDecl).ppAsBinder
+
+end Lean

--- a/src/Lean/Util/UnusedBinders.lean
+++ b/src/Lean/Util/UnusedBinders.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Moritz Roos. All rights reserved.
+Copyright (c) 2026 Thomas Murrils. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Moritz Roos
+Authors: Thomas Murrils
 -/
 module
 

--- a/src/Lean/Util/UnusedBinders.lean
+++ b/src/Lean/Util/UnusedBinders.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2026 Moritz Roos. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Moritz Roos
+-/
+module
+
+prelude
+public import Lean.Expr
+
+public section
+
+namespace Lean.Expr
+
+/--
+Tests if any of the binders of `(x₀ : A₀) → (x₁ : A₁) → ⋯ → X` which satisfy `p Aᵢ bi` (with `bi`
+the `binderInfo`) are unused in the renainder of the type (i.e. in `(xᵢ₊₁ : Aᵢ₊₁) → ⋯ → X`).
+
+Note that the argument to `p` may have loose bvars. This is a performance optimization.
+
+This function runs `cleanupAnnotations` on each type suffix `(xᵢ₊₁ : Aᵢ₊₁) → ⋯ → X` before
+examining it.
+
+We see through `let`s, and do not report if any of them are unused.
+-/
+@[specialize p]
+partial def hasUnusedForallBindersWhere (p : BinderInfo → Expr → Bool) (e : Expr) : Bool :=
+  match e.cleanupAnnotations with
+  | .forallE _ type body bi =>
+    p bi type && !(body.hasLooseBVar 0) || body.hasUnusedForallBindersWhere p
+  /- See through `letE` -/
+  | .letE _ _ _ body _ => body.hasUnusedForallBindersWhere p
+  | _ => false
+
+end Lean.Expr

--- a/tests/elab/impossibleInstance.lean
+++ b/tests/elab/impossibleInstance.lean
@@ -49,7 +49,7 @@ instance bad3 {α β : Type} (b : Array β) (a : Array α) [Inhabited α]
     (usedA : Array α) (i : Fin usedA.size) (j : Fin i.val) :
     Nonempty { ar : Array α // ar.size = j.val } := sorry
 
--- The following checks that the error shows up at line containing `attibute`
+-- The following checks that the error shows up at line containing `attribute`
 -- (and not at line where the decl is defined).
 /-- warning: declaration uses `sorry` -/
 #guard_msgs in
@@ -65,3 +65,7 @@ These arguments are not instance-implicit and appear neither in another instance
 -/
 #guard_msgs in
 attribute [instance] bad4
+
+/-- warning: declaration uses `sorry` -/
+#guard_msgs in
+instance bad5 : sorry := sorry

--- a/tests/elab/impossibleInstance.lean
+++ b/tests/elab/impossibleInstance.lean
@@ -2,7 +2,11 @@ class MyClass (α : Type u) where
   point : α
 
 /--
-error: Instance @bad1 has arguments n : Nat that are impossible to infer. Those arguments are not instance-implicit and do not appear in another instance-implicit argument or the return type.
+error: This instance has 1 argument that cannot be inferred using typeclass synthesis. Specifically
+
+  argument 3: `(n : Nat)`
+
+These arguments are not instance-implicit and appear neither in another instance-implicit argument nor the return type, so they cannot be inferred using typeclass synthesis.
 ---
 warning: declaration uses `sorry`
 -/
@@ -10,7 +14,12 @@ warning: declaration uses `sorry`
 instance bad1 {α : Type} [Inhabited α] (n : Nat) : MyClass α := sorry
 
 /--
-error: Instance @bad2 has arguments n : Nat, m : Nat that are impossible to infer. Those arguments are not instance-implicit and do not appear in another instance-implicit argument or the return type.
+error: This instance has 2 arguments that cannot be inferred using typeclass synthesis. Specifically
+
+  argument 3: `(n : Nat)`
+  argument 4: `(m : Nat)`
+
+These arguments are not instance-implicit and appear neither in another instance-implicit argument nor the return type, so they cannot be inferred using typeclass synthesis.
 ---
 warning: declaration uses `sorry`
 -/
@@ -20,3 +29,39 @@ instance bad2 {α : Type} [Inhabited α] (n m : Nat) : MyClass α := sorry
 /-- warning: declaration uses `sorry` -/
 #guard_msgs in
 instance good {α : Type} [Inhabited α] : MyClass α := sorry
+
+/--
+error: This instance has 4 arguments that cannot be inferred using typeclass synthesis. Specifically
+
+  argument 2: `{β : Type}`
+  argument 3: `(b : Array β)`
+  argument 4: `(a : Array α)`
+  argument 6: `⦃h : b = b⦄`
+
+These arguments are not instance-implicit and appear neither in another instance-implicit argument nor the return type, so they cannot be inferred using typeclass synthesis.
+---
+warning: declaration uses `sorry`
+-/
+#guard_msgs in
+instance bad3 {α β : Type} (b : Array β) (a : Array α) [Inhabited α]
+    ⦃h : b = b⦄
+    -- Note: `usedA` is a dependency of a dependency of a dependency of the return type
+    (usedA : Array α) (i : Fin usedA.size) (j : Fin i.val) :
+    Nonempty { ar : Array α // ar.size = j.val } := sorry
+
+-- The following checks that the error shows up at line containing `attibute`
+-- (and not at line where the decl is defined).
+/-- warning: declaration uses `sorry` -/
+#guard_msgs in
+@[implicit_reducible]
+def bad4 {α : Type} [Inhabited α] (n : Nat) : MyClass α := sorry
+
+/--
+error: This instance has 1 argument that cannot be inferred using typeclass synthesis. Specifically
+
+  argument 3: `(n : Nat)`
+
+These arguments are not instance-implicit and appear neither in another instance-implicit argument nor the return type, so they cannot be inferred using typeclass synthesis.
+-/
+#guard_msgs in
+attribute [instance] bad4

--- a/tests/elab/nonClassInstance.lean
+++ b/tests/elab/nonClassInstance.lean
@@ -41,3 +41,7 @@ error: The declaration `instQux` should not be an instance as its return type `Q
 -/
 #guard_msgs in
 instance instQux : Qux Nat := ⟨0⟩
+
+/-- warning: declaration uses `sorry` -/
+#guard_msgs in
+instance bad : ∀ n : Nat, sorry := by sorry

--- a/tests/elab/nonClassInstance.lean
+++ b/tests/elab/nonClassInstance.lean
@@ -6,14 +6,18 @@ structure Foo where
 class Bar where
   x : Nat
 
-/-- error: instance `instFoo` target `Foo` is not a type class. -/
+/--
+error: The declaration `instFoo` should not be an instance as its return type `Foo` is not a type class.
+-/
 #guard_msgs in
 instance instFoo : Foo := ⟨0⟩
 
 -- Applying @[instance] to a non-class def should also warn
 def instFoo2 : Foo := ⟨1⟩
 
-/-- error: instance `instFoo2` target `Foo` is not a type class. -/
+/--
+error: The declaration `instFoo2` should not be an instance as its return type `Foo` is not a type class.
+-/
 #guard_msgs in
 attribute [instance] instFoo2
 
@@ -32,6 +36,8 @@ instance : Baz Nat := ⟨0⟩
 structure Qux (α : Type) where
   x : α
 
-/-- error: instance `instQux` target `Qux Nat` is not a type class. -/
+/--
+error: The declaration `instQux` should not be an instance as its return type `Qux Nat` is not a type class.
+-/
 #guard_msgs in
 instance instQux : Qux Nat := ⟨0⟩


### PR DESCRIPTION
This PR improves the logic and performance of the `checkImpossibleInstance` function to detect more arguments that are impossible to
infer for typeclass synthesis. It also improves the formatting of the error messages for `checkImpossibleInstance` and `checkNonClassInstance` to be more readable. 

This integrates [independent (temporarily merged) work](https://github.com/leanprover-community/batteries/pull/1717) on these former Batteries linters which has been reverted in Batteries because of the unprecedented upstreaming of these linters.

We also disable these checks (if the declaration contains any `sorry`s so that partially completing instances is still possible without being terrorized by obvious errors. We also swap the order of the checks, such that now `checkNonClassInstance` is called first - it would be wrong to warn for synthesis impossibility if the return type isn't even synthesizable because it is not class-valued.

Co-authored by: @thorimur 

