### PR TITLE
fix: typo in `enableInitializersExecution` error message

### DIFF
--- a/src/Lean/Compiler/InitAttr.lean
+++ b/src/Lean/Compiler/InitAttr.lean
@@ -159,7 +159,7 @@ def declareBuiltin (forDecl : Name) (value : Expr) : CoreM Unit :=
 @[export lean_run_init_attrs]
 private unsafe def runInitAttrs (env : Environment) (opts : Options) : IO Unit := do
   if !(← isInitializerExecutionEnabled) then
-    throw <| IO.userError "`enableInitializerExecution` must be run before calling `importModules (loadExts := true)`"
+    throw <| IO.userError "`enableInitializersExecution` must be run before calling `importModules (loadExts := true)`"
   -- **Note**: `ModuleIdx` is not an abbreviation, and we don't have instances for it.
   -- Thus, we use `(modIdx : Nat)`
   for mod in env.header.modules, (modIdx : Nat) in 0...* do


### PR DESCRIPTION
This PR fixes a typo in the error message thrown by `runInitAttrs` when initializer execution has not been enabled. The message previously referred to `enableInitializerExecution` (singular), but the actual function is `enableInitializersExecution` (plural).

Reported on Zulip by Siddhartha Gadgil: https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Error.20in.20error.20message.20.28initializer.29/near/590973368

🤖 Prepared with Claude Code