### PR TITLE
chore: increase priority of instSMulOfMul

### DIFF
--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -1695,7 +1695,7 @@ instance [HomogeneousPow α] : Pow α α where
 instance instHSMul {α β} [SMul α β] : HSMul α β β where
   hSMul := SMul.smul
 
-instance (priority := 910) {α : Type u} [Mul α] : SMul α α where
+instance (priority := 1100) {α : Type u} [Mul α] : SMul α α where
   smul x y := Mul.mul x y
 
 @[default_instance]


### PR DESCRIPTION
This PR raises the priority of `instSMulOfMul` from 910 to 1100, so that a type's own
multiplication is found as its scalar action ahead of the general `SMul R M` instances rather
than after them.

The instance has the shape `[Mul α] → SMul α α`, so it applies only when both arguments of
`SMul` are the same type. It therefore rarely applies, and when it does it is essentially
always the intended instance, which is the profile for a priority above the default rather
than below it. The 910 is inherited from a Mathlib convention of lowering the priority of
instances that generalise, adopted under a typeclass inference algorithm that Lean 4 no longer
uses.

Mathlib raised the rest of this family of `Mul`-to-`SMul` instances in
https://github.com/leanprover-community/mathlib4/pull/38704, measuring a speedup of around 20%
in several of its slowest files, and currently re-declares this instance's priority from
`Mathlib/Algebra/Group/Action/Defs.lean` because it cannot edit core. Merging this lets that
override be removed, and gives the same default to downstream users who are not Mathlib.

🤖 Prepared with Claude Code
