### PR TITLE
fix: lake: race condition in monitor queue

### DIFF
--- a/src/lake/Lake/Build/Run.lean
+++ b/src/lake/Lake/Build/Run.lean
@@ -96,7 +96,9 @@ namespace Monitor
 @[inline] nonrec def flush : MonitorM PUnit := do
   flush (← read).out
 
-def renderProgress (running unfinished : Array OpaqueJob) (h : 0 < unfinished.size) : MonitorM PUnit := do
+def renderProgress
+  (running unfinished : Array OpaqueJob) (h : 0 < unfinished.size)
+: MonitorM PUnit := do
   let {jobNo, totalJobs, ..} ← get
   let {useAnsi, showProgress, ..} ← read
   if showProgress ∧ useAnsi then
@@ -153,9 +155,12 @@ where
     else if ms > 1000 then s!"{(ms) / 1000}.{(ms+50) / 100 % 10}s"
     else s!"{ms}ms"
 
-def poll (unfinished : Array OpaqueJob) : MonitorM (Array OpaqueJob × Array OpaqueJob) := do
+def drainQueue : MonitorM (Array OpaqueJob) := do
   let newJobs ← (← read).jobs.modifyGet ((·, #[]))
   modify fun s => {s with totalJobs := s.totalJobs + newJobs.size}
+  return newJobs
+
+def scanJobs (new unfinished : Array OpaqueJob) : MonitorM (Array OpaqueJob × Array OpaqueJob) := do
   let pollJobs := fun (running, unfinished) job => do
     match (← IO.getTaskState job.task) with
     | .finished =>
@@ -167,7 +172,7 @@ def poll (unfinished : Array OpaqueJob) : MonitorM (Array OpaqueJob × Array Opa
     | .waiting =>
       return (running, unfinished.push job)
   let r ← unfinished.foldlM pollJobs (#[], #[])
-  newJobs.foldlM pollJobs r
+  new.foldlM pollJobs r
 
 def sleep : MonitorM PUnit := do
   let now ← IO.monoMsNow
@@ -178,15 +183,25 @@ def sleep : MonitorM PUnit := do
   let now ← IO.monoMsNow
   modify fun s => {s with lastUpdate := now}
 
- partial def loop (unfinished : Array OpaqueJob) : MonitorM PUnit := do
-  let (running, unfinished) ← poll unfinished
+ partial def loop
+  (new unfinished : Array OpaqueJob)
+: MonitorM PUnit := do
+  let (running, unfinished) ← scanJobs new unfinished
   if h : 0 < unfinished.size then
     renderProgress running unfinished h
     sleep
-    loop unfinished
+    let new ← drainQueue
+    loop new unfinished
+  else
+    -- Must recheck queue for new tasks before terminating the loop.
+    -- Finished tasks may have registered new tasks.
+    let new ← drainQueue
+    if 0 < new.size then
+      loop new unfinished
 
 def main (init : Array OpaqueJob) : MonitorM PUnit := do
-  loop init
+  let new ← drainQueue
+  loop new init
   let resetCtrl ← modifyGet fun s => (s.resetCtrl, {s with resetCtrl := ""})
   unless resetCtrl.isEmpty do
     print resetCtrl


### PR DESCRIPTION
This PR fixes a race condition in the Lake build monitor's draining of the job queue.

Previously, the monitor drained the registered-jobs queue before checking task states. A finished job in that scan may have registered new jobs in its body just before terminating. Those jobs landed in the queue after the drain, so when no other unfinished jobs remained the monitor exited without ever observing them. If one of the missed jobs errors, this could produce an "uncaught top-level build failure" message alongside "Build completed successfully".

To fix this, the monitor loop is restructured so the queue is drained *after* task states are scanned, with an additional drain before the loop terminates. `drainQueue` and `scanJobs` are split out from `poll`, and `Monitor.main` performs an initial drain to capture any jobs registered before the monitor starts iterating. Finishing jobs cannot register further work once their state transitions, so a single post-scan drain is sufficient to close the window.

🤖 Prepared with Claude Code