### PR TITLE
feat: add @[reducible_proj] for selective projection unfolding

### DIFF
--- a/src/Lean/Meta/Sym/Canon.lean
+++ b/src/Lean/Meta/Sym/Canon.lean
@@ -215,7 +215,7 @@ def reduceProjFn? (info : ProjectionFunctionInfo) (e : Expr) : SymM (Option Expr
     return none
   let some e ← unfoldDefinition? e | return none
   match (← reduceProj? e.getAppFn) with
-  | some f => return some <| mkAppN f e.getAppArgs
+  | some f => return some <| (mkAppN f e.getAppArgs).headBeta
   | none   => return none
 
 def isNat (e : Expr) := e.isConstOf ``Nat

--- a/src/Lean/Meta/WHNF.lean
+++ b/src/Lean/Meta/WHNF.lean
@@ -571,14 +571,67 @@ def projectCore? (e : Expr) (i : Nat) : MetaM (Option Expr) := do
     else
       return none
 
+/--
+Tag attribute `@[reducible_proj]` for structure projection functions.
+
+When reducing a projection `s.field` whose projection function `field` is tagged
+`@[reducible_proj]`, projection reduction retries the structure-argument WHNF at a
+transparency of at least `.default` if the configured projection strategy fails to
+expose a constructor. This lets a `[semireducible]` definition that produces the
+structure unfold just enough for the projection to reduce, without making the whole
+definition behave as `[implicit_reducible]` everywhere.
+
+The implementation lives in `tryReducibleProjBump?`, called from both `reduceProj?`
+and the `.proj` arm of `whnfCore`.
+
+Class-field projections are rejected by the validator: they already have orthogonal
+support via `unfoldProjInst?` and `backward.whnf.reducibleClassField`.
+-/
+builtin_initialize reducibleProjAttr : TagAttribute ←
+  registerTagAttribute `reducible_proj
+    "When reducing this structure projection, retry the structure-argument WHNF at \
+     a transparency of at least `.default` to expose the constructor."
+    (validate := fun declName => do
+      let env ← getEnv
+      let some info := env.getProjectionFnInfo? declName |
+        throwError m!"`@[reducible_proj]` can only be applied to structure projection functions, \
+          but `{.ofConstName declName}` is not one"
+      if info.fromClass then
+        throwError m!"`@[reducible_proj]` does not apply to class-field projections; \
+          mark the underlying instance `[implicit_reducible]` or rely on the existing \
+          `unfoldProjInst?` / `backward.whnf.reducibleClassField` mechanism")
+
+/--
+If the projection function for field `i` of `structName` is tagged `@[reducible_proj]`,
+re-whnf the structure argument `c` at a transparency of at least `.default` and retry
+the projection. Returns `none` if the projection is not tagged or if the bumped WHNF
+still does not expose a constructor.
+
+This is the shared implementation of the `@[reducible_proj]` mechanism, called from
+both `reduceProj?` and the `.proj` arm of `whnfCore`. Using `withAtLeastTransparency`
+(rather than `withTransparency .default`) ensures the bump only raises transparency,
+never lowers it when invoked under e.g. `.all`.
+-/
+private def tryReducibleProjBump? (structName : Name) (i : Nat) (c : Expr) :
+    MetaM (Option Expr) := do
+  let env ← getEnv
+  let some sinfo := getStructureInfo? env structName | return none
+  let some projFn := sinfo.getProjFn? i | return none
+  unless reducibleProjAttr.hasTag env projFn do return none
+  withAtLeastTransparency .default do
+    projectCore? (← whnf c) i
+
 def project? (e : Expr) (i : Nat) : MetaM (Option Expr) := do
   projectCore? (← whnf e) i
 
 /-- Reduce kernel projection `Expr.proj ..` expression. -/
 def reduceProj? (e : Expr) : MetaM (Option Expr) := do
   match e with
-  | .proj _ i c => project? c i
-  | _           => return none
+  | .proj structName i c =>
+    match (← project? c i) with
+    | some r => return some r
+    | none   => tryReducibleProjBump? structName i c
+  | _ => return none
 
 /--
   Auxiliary method for reducing terms of the form `?m t_1 ... t_n` where `?m` is delayed assigned.
@@ -642,26 +695,6 @@ partial def consumeUnusedLet (e : Expr) (consumeNondep : Bool := false) : Expr :
   | _ => e
 
 /--
-Tag attribute `@[reducible_proj]` for structure projection functions.
-
-When reducing a projection `s.field` whose projection function `field` is tagged
-`@[reducible_proj]`, `whnfCore` bumps transparency to `.default` for the structure
-argument `s`. This lets a `[semireducible]` definition that produces the structure
-unfold just enough for the projection to reduce, without making the whole definition
-behave as `[implicit_reducible]` everywhere.
-
-See the `.proj` arm of `whnfCore` for the implementation.
--/
-builtin_initialize reducibleProjAttr : TagAttribute ←
-  registerTagAttribute `reducible_proj
-    "When reducing this structure projection, bump transparency to `.default` to expose the constructor."
-    (validate := fun declName => do
-      let env ← getEnv
-      unless (env.getProjectionFnInfo? declName).isSome do
-        throwError m!"`@[reducible_proj]` can only be applied to structure projection functions, but \
-          `{.ofConstName declName}` is not one")
-
-/--
 Apply beta-reduction, zeta-reduction (i.e., unfold let local-decls), iota-reduction,
 expand let-expressions, expand assigned meta-variables, unfold aux declarations.
 -/
@@ -722,29 +755,17 @@ where
             | .axiomInfo val => recordUnfoldAxiom val.name; return e
             | _ => return e
       | .proj structName i c =>
-        /- Per-projection opt-in: if the projection function is tagged
-           `@[reducible_proj]`, retry the structure-argument reduction
-           at `.default` transparency when the configured projection
-           reduction strategy fails to expose a constructor. This lets
-           a `[semireducible]` definition that produces the structure
-           unfold just enough for the projection to reduce. -/
+        /- If the configured projection strategy fails to expose a constructor and
+           the projection function is tagged `@[reducible_proj]`,
+           `tryReducibleProjBump?` retries at a transparency of at least `.default`.
+           See the docstring of `reducibleProjAttr` for the rationale. -/
         let k (c : Expr) := do
           match (← projectCore? c i) with
           | some e => go e
           | none =>
-            let env ← getEnv
-            let isTagged := match getStructureInfo? env structName with
-              | some info => match info.getProjFn? i with
-                | some projFn => reducibleProjAttr.hasTag env projFn
-                | none => false
-              | none => false
-            if isTagged then
-              let c' ← withTransparency .default <| whnf c
-              match (← projectCore? c' i) with
-              | some e => go e
-              | none => return e
-            else
-              return e
+            match (← tryReducibleProjBump? structName i c) with
+            | some e => go e
+            | none   => return e
         match (← getConfig).proj with
         | .no => return e
         | .yes => k (← go c)

--- a/src/Lean/Meta/WHNF.lean
+++ b/src/Lean/Meta/WHNF.lean
@@ -642,6 +642,26 @@ partial def consumeUnusedLet (e : Expr) (consumeNondep : Bool := false) : Expr :
   | _ => e
 
 /--
+Tag attribute `@[reducible_proj]` for structure projection functions.
+
+When reducing a projection `s.field` whose projection function `field` is tagged
+`@[reducible_proj]`, `whnfCore` bumps transparency to `.default` for the structure
+argument `s`. This lets a `[semireducible]` definition that produces the structure
+unfold just enough for the projection to reduce, without making the whole definition
+behave as `[implicit_reducible]` everywhere.
+
+See the `.proj` arm of `whnfCore` for the implementation.
+-/
+builtin_initialize reducibleProjAttr : TagAttribute ←
+  registerTagAttribute `reducible_proj
+    "When reducing this structure projection, bump transparency to `.default` to expose the constructor."
+    (validate := fun declName => do
+      let env ← getEnv
+      unless (env.getProjectionFnInfo? declName).isSome do
+        throwError m!"`@[reducible_proj]` can only be applied to structure projection functions, but \
+          `{.ofConstName declName}` is not one")
+
+/--
 Apply beta-reduction, zeta-reduction (i.e., unfold let local-decls), iota-reduction,
 expand let-expressions, expand assigned meta-variables, unfold aux declarations.
 -/
@@ -701,11 +721,30 @@ where
                 return e
             | .axiomInfo val => recordUnfoldAxiom val.name; return e
             | _ => return e
-      | .proj _ i c =>
+      | .proj structName i c =>
+        /- Per-projection opt-in: if the projection function is tagged
+           `@[reducible_proj]`, retry the structure-argument reduction
+           at `.default` transparency when the configured projection
+           reduction strategy fails to expose a constructor. This lets
+           a `[semireducible]` definition that produces the structure
+           unfold just enough for the projection to reduce. -/
         let k (c : Expr) := do
           match (← projectCore? c i) with
           | some e => go e
-          | none => return e
+          | none =>
+            let env ← getEnv
+            let isTagged := match getStructureInfo? env structName with
+              | some info => match info.getProjFn? i with
+                | some projFn => reducibleProjAttr.hasTag env projFn
+                | none => false
+              | none => false
+            if isTagged then
+              let c' ← withTransparency .default <| whnf c
+              match (← projectCore? c' i) with
+              | some e => go e
+              | none => return e
+            else
+              return e
         match (← getConfig).proj with
         | .no => return e
         | .yes => k (← go c)

--- a/tests/elab/reducibleProj.lean
+++ b/tests/elab/reducibleProj.lean
@@ -1,0 +1,101 @@
+/-!
+# `@[reducible_proj]` attribute
+
+When a structure projection is tagged `@[reducible_proj]`, `whnfCore` bumps
+transparency to `.default` for the structure-argument WHNF if the configured
+projection strategy fails to expose a constructor. This lets a `[semireducible]`
+definition that produces the structure unfold just enough for the projection to
+reduce, without making the whole definition behave as `[implicit_reducible]`
+everywhere.
+-/
+
+namespace ReducibleProjTest
+
+class Quiver (V : Type) where
+  Hom : V → V → Type
+
+infixr:10 " ⟶ " => Quiver.Hom
+
+class Category (obj : Type) extends Quiver obj where
+  id : ∀ X : obj, X ⟶ X
+  comp : ∀ {X Y Z : obj}, (X ⟶ Y) → (Y ⟶ Z) → (X ⟶ Z)
+
+structure Func (C : Type) [Category C] (D : Type) [Category D] where
+  obj : C → D
+  map : ∀ {X Y : C}, (X ⟶ Y) → (obj X ⟶ obj Y)
+
+infixr:26 " ⥤ " => Func
+
+variable {C D E : Type} [Category C] [Category D] [Category E]
+
+def Func.comp (F : C ⥤ D) (G : D ⥤ E) : C ⥤ E where
+  obj X := G.obj (F.obj X)
+  map f := G.map (F.map f)
+
+infixr:80 " ⋙ " => Func.comp
+
+variable (F : C ⥤ D) (G : D ⥤ E)
+
+-- Without the attribute, projection through `Func.comp` fails at `.instances`.
+/--
+error: Tactic `rfl` failed: The left-hand side
+  (F ⋙ G).obj X
+is not definitionally equal to the right-hand side
+  G.obj (F.obj X)
+
+C D E : Type
+inst✝² : Category C
+inst✝¹ : Category D
+inst✝ : Category E
+F : C ⥤ D
+G : D ⥤ E
+X : C
+⊢ (F ⋙ G).obj X = G.obj (F.obj X)
+-/
+#guard_msgs in
+example (X : C) : (F ⋙ G).obj X = G.obj (F.obj X) := by
+  with_reducible_and_instances rfl
+
+-- After tagging `Func.obj`, the projection reduces.
+attribute [reducible_proj] Func.obj
+
+example (X : C) : (F ⋙ G).obj X = G.obj (F.obj X) := by
+  with_reducible_and_instances rfl
+
+-- Tagging `.obj` does not affect `.map`.
+/--
+error: Tactic `rfl` failed: The left-hand side
+  (F ⋙ G).map f
+is not definitionally equal to the right-hand side
+  G.map (F.map f)
+
+C D E : Type
+inst✝² : Category C
+inst✝¹ : Category D
+inst✝ : Category E
+F : C ⥤ D
+G : D ⥤ E
+X Y : C
+f : X ⟶ Y
+⊢ (F ⋙ G).map f = G.map (F.map f)
+-/
+#guard_msgs in
+example {X Y : C} (f : X ⟶ Y) : (F ⋙ G).map f = G.map (F.map f) := by
+  with_reducible_and_instances rfl
+
+-- Tagging `.map` too makes that projection reduce as well.
+attribute [reducible_proj] Func.map
+
+example {X Y : C} (f : X ⟶ Y) : (F ⋙ G).map f = G.map (F.map f) := by
+  with_reducible_and_instances rfl
+
+end ReducibleProjTest
+
+-- The attribute rejects non-projection functions.
+def notAProjection : Nat := 0
+
+/--
+error: `@[reducible_proj]` can only be applied to structure projection functions, but `notAProjection` is not one
+-/
+#guard_msgs in
+attribute [reducible_proj] notAProjection

--- a/tests/elab/reducibleProj.lean
+++ b/tests/elab/reducibleProj.lean
@@ -91,6 +91,76 @@ example {X Y : C} (f : X ⟶ Y) : (F ⋙ G).map f = G.map (F.map f) := by
 
 end ReducibleProjTest
 
+-- Regression for the `reduceProj?` path used by `grind` canonicalization (and
+-- by `simp`, `cbv`, vcgen, `unfoldProjInst?`). The bump must fire here too, not
+-- just in `whnfCore`'s `.proj` arm.
+--
+-- Without the bump being routed through `reduceProj?`, `grind` cannot discharge
+-- naturality below: ematch produces `(F ⋙ H).obj X = H.obj (F.obj X)` but
+-- canon collapses both sides without recording the eqc edge, and
+-- `NatTrans.naturality` never matches against `(F ⋙ H).map f ≫ β.app _`.
+
+namespace ReducibleProjGrindTest
+
+class Category (obj : Type) : Type 1 where
+  Hom : obj → obj → Type
+  comp : ∀ {X Y Z : obj}, Hom X Y → Hom Y Z → Hom X Z
+  assoc : ∀ {W X Y Z : obj} (f : Hom W X) (g : Hom X Y) (h : Hom Y Z),
+    comp (comp f g) h = comp f (comp g h)
+
+scoped infixr:10 " ⟶ " => Category.Hom
+scoped infixr:80 " ≫ " => Category.comp
+attribute [grind _=_] Category.assoc
+
+structure Functor (C : Type) [Category C] (D : Type) [Category D] : Type where
+  obj : C → D
+  map : ∀ {X Y : C}, (X ⟶ Y) → ((obj X) ⟶ (obj Y))
+  map_comp : ∀ {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z),
+    map (f ≫ g) = map f ≫ map g := by grind
+
+scoped infixr:26 " ⥤ " => Functor
+
+attribute [grind _=_] Functor.map_comp
+
+variable {C : Type} [Category C] {D : Type} [Category D] {E : Type} [Category E]
+
+def Functor.comp (F : C ⥤ D) (G : D ⥤ E) : C ⥤ E where
+  obj X := G.obj (F.obj X)
+  map f := G.map (F.map f)
+
+scoped infixr:80 " ⋙ " => Functor.comp
+
+@[grind =]
+theorem Functor.comp_obj (F : C ⥤ D) (G : D ⥤ E) (X : C) :
+    (F ⋙ G).obj X = G.obj (F.obj X) := rfl
+
+@[grind =]
+theorem Functor.comp_map (F : C ⥤ D) (G : D ⥤ E) {X Y : C} (f : X ⟶ Y) :
+    (F ⋙ G).map f = G.map (F.map f) := rfl
+
+structure NatTrans (F G : C ⥤ D) : Type where
+  app (X : C) : F.obj X ⟶ G.obj X
+  naturality ⦃X Y : C⦄ (f : X ⟶ Y) :
+    F.map f ≫ app Y = app X ≫ G.map f := by grind
+
+attribute [grind _=_] NatTrans.naturality
+
+attribute [reducible_proj] Functor.obj
+
+variable {F G : C ⥤ D}
+
+-- This `grind` call exercises the `Sym.canon` → `reduceProjFn?` → `reduceProj?`
+-- chain, which prior to this PR's fix bypassed the `[reducible_proj]` bump.
+-- Without the fix, ematch produces `(F ⋙ H).obj _ = H.obj (F.obj _)`
+-- equalities but canon collapses them silently, so `NatTrans.naturality` never
+-- fires on terms like `(F ⋙ H).map f ≫ β.app (F.obj Y)` and grind fails.
+def hcomp {H I : D ⥤ E} (α : NatTrans F G) (β : NatTrans H I) :
+    NatTrans (F ⋙ H) (G ⋙ I) where
+  app := fun X : C => β.app (F.obj X) ≫ I.map (α.app X)
+  naturality := by grind
+
+end ReducibleProjGrindTest
+
 -- The attribute rejects non-projection functions.
 def notAProjection : Nat := 0
 
@@ -99,3 +169,14 @@ error: `@[reducible_proj]` can only be applied to structure projection functions
 -/
 #guard_msgs in
 attribute [reducible_proj] notAProjection
+
+-- The attribute rejects class-field projections (they have orthogonal support
+-- via `unfoldProjInst?` and `backward.whnf.reducibleClassField`).
+class MyClass (α : Type) where
+  field : α
+
+/--
+error: `@[reducible_proj]` does not apply to class-field projections; mark the underlying instance `[implicit_reducible]` or rely on the existing `unfoldProjInst?` / `backward.whnf.reducibleClassField` mechanism
+-/
+#guard_msgs in
+attribute [reducible_proj] MyClass.field


### PR DESCRIPTION
When `whnfCore` reduces a projection `s.field` at low transparency (e.g. `.instances`, used during implicit-arg `isDefEq` when `backward.isDefEq.respectTransparency = true`), it can get stuck if `s` is produced by a `[semireducible]` definition.

Concrete case in Mathlib (`CategoryTheory.Whiskering`, `CategoryTheory.EssentialImage`, and ~588 other CategoryTheory files):

```lean
-- Func.comp is [semireducible]; doesn't unfold at .instances.
example (X : C) : (F ⋙ G).obj X = G.obj (F.obj X) := by
  with_reducible_and_instances rfl  -- fails
```

Currently the only workarounds are:
- Mark the producing definition (e.g. `Functor.comp`) `[implicit_reducible]` — heavy hammer; affects all uses.
- Set `backward.isDefEq.respectTransparency false` locally — restores old globally permissive behavior.

`@[reducible_proj]` opts a single projection function (e.g. `Functor.obj`) into a one-time transparency bump for the structure-argument WHNF when the configured projection strategy fails to expose a constructor. The bump is local to the projection reduction; it does not change the transparency of surrounding `isDefEq` work.

This is the structure-projection analogue of the existing class-field machinery (`unfoldProjInst?` / `backward.whnf.reducibleClassField`), which does exactly the same thing for `[reducible]` class fields whose underlying instance is `[implicit_reducible]`.

🤖 Prepared with Claude Code