### PR TITLE
doc: note TransparencyMode and ReducibilityStatus constructors are not in unfolding order

### DIFF
--- a/src/Init/MetaTypes.lean
+++ b/src/Init/MetaTypes.lean
@@ -73,6 +73,9 @@ became a performance bottleneck in Mathlib. The option `backward.isDefEq.respect
 See also: `ReducibilityStatus`, `backward.isDefEq.respectTransparency`,
 `backward.whnf.reducibleClassField`.
 -/
+-- Note: the constructors below are not in the `none < reducible < instances < default < all`
+-- order described in the docstring above. Reordering them induces a bootstrap problem that is
+-- non-trivial to repair.
 inductive TransparencyMode where
   /-- Unfolds all constants, even those tagged as `@[irreducible]`. -/
   | all

--- a/src/Lean/Meta/Basic.lean
+++ b/src/Lean/Meta/Basic.lean
@@ -1288,7 +1288,7 @@ or type class instances are unfolded.
 
 /--
 Execute `x` ensuring the transparency setting is at least `mode`.
-Recall that `.all > .default > .instances > .reducible`.
+Recall that `.none < .reducible < .instances < .default < .all`.
 -/
 @[inline] def withAtLeastTransparency (mode : TransparencyMode) : n α → n α :=
   mapMetaM <| withReader fun ctx =>

--- a/src/Lean/ReducibilityAttrs.lean
+++ b/src/Lean/ReducibilityAttrs.lean
@@ -30,6 +30,8 @@ See `TransparencyMode` for the full design rationale.
 - **`irreducible`**: Only unfolded at `TransparencyMode.all`. The definition body is effectively
   hidden from `isDefEq` in normal usage.
 -/
+-- Note: `implicitReducible` appears last for the same reason `TransparencyMode`'s constructors
+-- are not in unfolding order: reordering them causes a non-trivial bootstrapping problem.
 inductive ReducibilityStatus where
   | reducible | semireducible | irreducible | implicitReducible
   deriving Inhabited, Repr, BEq


### PR DESCRIPTION
This PR adds source-level comments noting that the constructors of `Lean.Meta.TransparencyMode` and `Lean.ReducibilityStatus` are not laid out in the unfolding-amount order suggested by their docstrings, and that reordering them induces a non-trivial bootstrap problem.

Also rewrites a stale comment in `Lean.Meta.Basic` that listed the hierarchy in descending order without `.none`.

🤖 Prepared with Claude Code