### PR TITLE
fix: correct off-by-one in toSeconds and wrong day count in Year.days

### DIFF
--- a/src/Std/Time.lean
+++ b/src/Std/Time.lean
@@ -66,9 +66,9 @@ like `23:59:60` that is valid in ISO 8601.
 
 - Ordinal types:
   - `Day.Ordinal`: Ranges from 1 to 31.
-  - `Day.Ordinal.OfYear`: Ranges from 1 to (365 or 366).
+  - `Day.OfYear.Ordinal`: Ranges from 1 to (365 or 366).
   - `Month.Ordinal`: Ranges from 1 to 12.
-  - `WeekOfYear.Ordinal`: Ranges from 1 to 53.
+  - `Week.OfYear.Ordinal`: Ranges from 1 to 53.
   - `Hour.Ordinal`: Ranges from 0 to 23.
   - `Millisecond.Ordinal`: Ranges from 0 to 999.
   - `Minute.Ordinal`: Ranges from 0 to 59.

--- a/src/Std/Time/Date/PlainDate.lean
+++ b/src/Std/Time/Date/PlainDate.lean
@@ -310,7 +310,7 @@ Determines the week of the month for the given `PlainDate`. The week of the mont
 on the day of the month and the weekday. Each week starts on Monday because the entire library is
 based on the Gregorian Calendar.
 -/
-def alignedWeekOfMonth (date : PlainDate) : Week.Ordinal.OfMonth :=
+def alignedWeekOfMonth (date : PlainDate) : Week.Aligned.Ordinal :=
   let weekday := date.withDaysClip 1 |>.weekday |>.toOrdinal |>.sub 1
   let days := date.day |>.sub 1 |>.addBounds weekday
   days |>.ediv 7 (by decide) |>.add 1

--- a/src/Std/Time/Date/Unit/Month.lean
+++ b/src/Std/Time/Date/Unit/Month.lean
@@ -212,11 +212,13 @@ def ofFin (data : Fin 13) : Ordinal :=
   Bounded.LE.ofFin' data (by decide)
 
 /--
-Transforms `Month.Ordinal` into `Second.Offset`.
+Transforms `Month.Ordinal` into `Second.Offset`, representing the number of seconds elapsed since
+the beginning of the year up to the start of the given month. For example, January returns 0
+seconds since it is the first month of the year.
 -/
 def toSeconds (leap : Bool) (month : Ordinal) : Second.Offset :=
   let daysAcc := #[0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334]
-  let days : Day.Offset := daysAcc[month.toNat]!
+  let days : Day.Offset := daysAcc[month.toNat - 1]!
   let time := days.toSeconds
   if leap && month.toNat ≥ 2
     then time + 86400

--- a/src/Std/Time/Date/Unit/Month.lean
+++ b/src/Std/Time/Date/Unit/Month.lean
@@ -225,21 +225,27 @@ def toSeconds (leap : Bool) (month : Ordinal) : Second.Offset :=
     else time
 
 /--
-Transforms `Month.Ordinal` into `Minute.Offset`.
+Transforms `Month.Ordinal` into `Minute.Offset`, representing the number of minutes elapsed since
+the beginning of the year up to the start of the given month. For example, January returns 0
+minutes since it is the first month of the year.
 -/
 @[inline]
 def toMinutes (leap : Bool) (month : Ordinal) : Minute.Offset :=
   toSeconds leap month |>.toMinutes
 
 /--
-Transforms `Month.Ordinal` into `Hour.Offset`.
+Transforms `Month.Ordinal` into `Hour.Offset`, representing the number of hours elapsed since
+the beginning of the year up to the start of the given month. For example, January returns 0
+hours since it is the first month of the year.
 -/
 @[inline]
 def toHours (leap : Bool) (month : Ordinal) : Hour.Offset :=
   toMinutes leap month |>.toHours
 
 /--
-Transforms `Month.Ordinal` into `Day.Offset`.
+Transforms `Month.Ordinal` into `Day.Offset`, representing the number of days elapsed since
+the beginning of the year up to the start of the given month. For example, January returns 0
+days since it is the first month of the year.
 -/
 @[inline]
 def toDays (leap : Bool) (month : Ordinal) : Day.Offset :=

--- a/src/Std/Time/Date/Unit/Week.lean
+++ b/src/Std/Time/Date/Unit/Week.lean
@@ -71,13 +71,13 @@ def ofInt (data : Int) (h : 1 ≤ data ∧ data ≤ 53) : Ordinal :=
   Bounded.LE.mk data h
 
 /--
-`OfMonth` represents the number of weeks within a month. It ensures that the week is within the
-correct bounds—either 1 to 6, representing the possible weeks in a month.
+`OfMonth` represents the nth occurrence of a weekday within a month (1–5), as used in POSIX
+`Mm.w.d` rules. Week 5 means the last occurrence of that weekday in the month.
 -/
-@[expose] def OfMonth := Bounded.LE 1 6
+@[expose] def OfMonth := Bounded.LE 1 5
 deriving Repr, DecidableEq
 
-instance : OfNat OfMonth n := inferInstanceAs (OfNat (Bounded.LE 1 (1 + (5 : Nat))) n)
+instance : OfNat OfMonth n := inferInstanceAs (OfNat (Bounded.LE 1 (1 + (4 : Nat))) n)
 
 instance : Inhabited OfMonth where
   default := 1
@@ -110,6 +110,35 @@ def toOffset (ordinal : Ordinal) : Offset :=
   UnitVal.ofInt ordinal.val
 
 end Ordinal
+namespace Aligned
+
+/--
+`Ordinal` represents an aligned (calendar-grid) week within a month, ranging from 1 to 6.
+Week 1 contains the 1st of the month; subsequent weeks start on the following Sunday (or Monday,
+depending on locale). A month can span at most 6 calendar rows.
+-/
+@[expose] def Ordinal := Bounded.LE 1 6
+deriving Repr, DecidableEq, LE, LT
+
+instance : OfNat Ordinal n := inferInstanceAs (OfNat (Bounded.LE 1 (1 + (5 : Nat))) n)
+
+instance {x y : Ordinal} : Decidable (x ≤ y) :=
+  inferInstanceAs (Decidable (x.val ≤ y.val))
+
+instance {x y : Ordinal} : Decidable (x < y) :=
+  inferInstanceAs (Decidable (x.val < y.val))
+
+instance : Inhabited Ordinal where
+  default := 1
+
+instance : Ord Ordinal := inferInstanceAs <| Ord (Bounded.LE 1 _)
+
+instance : TransOrd Ordinal := inferInstanceAs <| TransOrd (Bounded.LE 1 _)
+
+instance : LawfulEqOrd Ordinal := inferInstanceAs <| LawfulEqOrd (Bounded.LE 1 _)
+
+end Aligned
+
 namespace Offset
 
 /--

--- a/src/Std/Time/Date/Unit/Year.lean
+++ b/src/Std/Time/Date/Unit/Year.lean
@@ -107,8 +107,8 @@ Calculates the number of days in the specified `year`.
 -/
 def days (year : Offset) : Bounded.LE 365 366 :=
   if year.isLeap
-    then .ofNatWrapping 366 (by decide)
-    else .ofNatWrapping 355 (by decide)
+    then Bounded.LE.mk 366 (by decide)
+    else Bounded.LE.mk 365 (by decide)
 
 /--
 Calculates the number of weeks in the specified `year`.

--- a/src/Std/Time/DateTime/PlainDateTime.lean
+++ b/src/Std/Time/DateTime/PlainDateTime.lean
@@ -507,7 +507,7 @@ on the day of the month and the weekday. Each week starts on Monday because the 
 based on the Gregorian Calendar.
 -/
 @[inline]
-def alignedWeekOfMonth (date : PlainDateTime) : Week.Ordinal.OfMonth :=
+def alignedWeekOfMonth (date : PlainDateTime) : Week.Aligned.Ordinal :=
   date.date.alignedWeekOfMonth
 
 /--

--- a/src/Std/Time/Duration.lean
+++ b/src/Std/Time/Duration.lean
@@ -143,8 +143,8 @@ Converts a `Duration` to a `Millisecond.Offset`
 @[inline]
 def toMilliseconds (duration : Duration) : Millisecond.Offset :=
   let secMillis := duration.second.mul 1000
-  let nanosMillis := duration.nano.ediv 1000000 (by decide)
-  let millis := secMillis + (.ofInt nanosMillis.val)
+  let nanosMillis := duration.nano.val.tdiv 1000000
+  let millis := secMillis + (.ofInt nanosMillis)
   millis
 
 /--

--- a/src/Std/Time/Format/Basic.lean
+++ b/src/Std/Time/Format/Basic.lean
@@ -1361,8 +1361,8 @@ private def build (builder : DateBuilder) (aw : Awareness) : Option aw.type :=
     isDST := false,
   }
 
-  let month := builder.MorL |>.getD 0
-  let day := builder.d |>.getD 0
+  let month := builder.MorL |>.getD 1
+  let day := builder.d |>.getD 1
   let era := (builder.G.getD .ce)
 
   let year
@@ -1381,7 +1381,8 @@ private def build (builder : DateBuilder) (aw : Awareness) : Option aw.type :=
     hour <|> (
       let one : Option (Bounded.LE 0 23) := builder.H
       let other : Option (Bounded.LE 0 23) := (Bounded.LE.sub · 1) <$> builder.k
-      (one <|> other))
+      let hNoMarker : Option (Bounded.LE 0 23) := HourMarker.am.toAbsolute <$> builder.h
+      (one <|> other <|> hNoMarker))
       |>.getD ⟨0, by decide⟩
 
   let minute := builder.m |>.getD 0

--- a/src/Std/Time/Format/Basic.lean
+++ b/src/Std/Time/Format/Basic.lean
@@ -779,7 +779,7 @@ def TypeFormat : Modifier → Type
   | .d _ => Day.Ordinal
   | .Qorq _ => Month.Quarter
   | .w _ => Week.Ordinal
-  | .W _ => Week.Ordinal.OfMonth
+  | .W _ => Week.Aligned.Ordinal
   | .E _ => Weekday
   | .eorc _ => Weekday
   | .F _ => Bounded.LE 1 5
@@ -1289,7 +1289,7 @@ private structure DateBuilder where
   d : Option Day.Ordinal := none
   Qorq : Option Month.Quarter := none
   w : Option Week.Ordinal := none
-  W : Option Week.Ordinal.OfMonth := none
+  W : Option Week.Aligned.Ordinal := none
   E : Option Weekday := none
   eorc : Option Weekday := none
   F : Option (Bounded.LE 1 5) := none

--- a/src/Std/Time/Time/PlainTime.lean
+++ b/src/Std/Time/Time/PlainTime.lean
@@ -233,8 +233,7 @@ def subNanoseconds (time : PlainTime) (nanosToSub : Nanosecond.Offset) : PlainTi
 Adds milliseconds to a `PlainTime`.
 -/
 def addMilliseconds (time : PlainTime) (millisToAdd : Millisecond.Offset) : PlainTime :=
-  let total := time.toMilliseconds + millisToAdd
-  ofMilliseconds total
+  ofNanoseconds (time.toNanoseconds + millisToAdd.toNanoseconds)
 
 /--
 Subtracts milliseconds from a `PlainTime`.
@@ -261,7 +260,7 @@ Creates a new `PlainTime` by adjusting the milliseconds component inside the `na
 -/
 @[inline]
 def withMilliseconds (pt : PlainTime) (millis : Millisecond.Ordinal) : PlainTime :=
-  let minorPart := pt.nanosecond.emod 1000 (by decide)
+  let minorPart := pt.nanosecond.emod 1000000 (by decide)
   let majorPart := millis.mul_pos 1000000 (by decide) |>.addBounds minorPart
   { pt with nanosecond := majorPart |>.expandTop (by decide) }
 

--- a/src/Std/Time/Zoned/Database/Basic.lean
+++ b/src/Std/Time/Zoned/Database/Basic.lean
@@ -103,11 +103,199 @@ def convertTZifV1 (tz : TZif.TZifV1) (id : String) : Except String ZoneRules := 
 
   .ok { transitions, initialLocalTimeType }
 
+-- POSIX TZ string parsing and future-transition generation.
+-- RFC 8536 §3.3: after all stored transitions, the POSIX TZ string (footer) defines the rule.
+
+private structure PosixTransRule where
+  month : Nat  -- 1-12
+  week  : Nat  -- 1-5 (5 = last occurrence)
+  day   : Nat  -- 0-6 (0 = Sunday, POSIX convention)
+  time  : Int  -- seconds from midnight; default 7200 (= 02:00:00)
+
+private structure PosixTzInfo where
+  stdName   : String
+  stdOffset : Int  -- seconds east of UTC (positive = east)
+  dstName   : String
+  dstOffset : Int  -- seconds east of UTC
+  start     : Option PosixTransRule
+  end_      : Option PosixTransRule
+
+private def posixParseNat (cs : Array Char) (i : Nat) : Nat × Nat :=
+  let rec go (i acc : Nat) : Nat × Nat :=
+    if hi : i < cs.size then
+      if cs[i]!.isDigit
+        then go (i + 1) (acc * 10 + cs[i]!.toNat - '0'.toNat)
+        else (acc, i)
+    else (acc, i)
+  termination_by cs.size - i
+  decreasing_by omega
+  go i 0
+
+-- Parse hh[:mm[:ss]] as total seconds.
+private def posixParseHMS (cs : Array Char) (i : Nat) : Int × Nat :=
+  let (h, i) := posixParseNat cs i
+  let (m, i) := if i < cs.size && cs[i]! == ':' then posixParseNat cs (i + 1) else (0, i)
+  let (s, i) := if i < cs.size && cs[i]! == ':' then posixParseNat cs (i + 1) else (0, i)
+  (Int.ofNat h * 3600 + Int.ofNat m * 60 + Int.ofNat s, i)
+
+-- Parse [+-]hh[:mm[:ss]] as east-positive seconds (POSIX offsets are west-positive, so we negate).
+private def posixParseOffset (cs : Array Char) (i : Nat) : Int × Nat :=
+  let (sign, i) :=
+    if i < cs.size && cs[i]! == '-' then (-1, i + 1)
+    else if i < cs.size && cs[i]! == '+' then (1, i + 1)
+    else (1, i)
+  let (secs, i) := posixParseHMS cs i
+  (-sign * secs, i)
+
+-- Parse a timezone name: letters only, or <...> for names with digits/signs.
+private def posixParseName (cs : Array Char) (i : Nat) : String × Nat :=
+  if i < cs.size && cs[i]! == '<' then
+    let rec goAngle (i : Nat) (acc : String) : String × Nat :=
+      if hi : i < cs.size then
+        if cs[i]! == '>' then (acc, i + 1) else goAngle (i + 1) (acc.push cs[i]!)
+      else (acc, i)
+    termination_by cs.size - i
+    decreasing_by omega
+    goAngle (i + 1) ""
+  else
+    let rec goAlpha (i : Nat) (acc : String) : String × Nat :=
+      if hi : i < cs.size then
+        if cs[i]!.isAlpha then goAlpha (i + 1) (acc.push cs[i]!) else (acc, i)
+      else (acc, i)
+    termination_by cs.size - i
+    decreasing_by omega
+    goAlpha i ""
+
+-- Parse Mm.w.d[/[+-]hh[:mm[:ss]]].
+private def posixParseMwd (cs : Array Char) (i : Nat) : Option (PosixTransRule × Nat) := do
+  if i >= cs.size || cs[i]! != 'M' then failure
+  let i := i + 1
+  let (m, i) := posixParseNat cs i
+  if i >= cs.size || cs[i]! != '.' then failure
+  let (w, i) := posixParseNat cs (i + 1)
+  if i >= cs.size || cs[i]! != '.' then failure
+  let (d, i) := posixParseNat cs (i + 1)
+  let (time, i) :=
+    if i < cs.size && cs[i]! == '/' then
+      let (sign, i) :=
+        if i + 1 < cs.size && cs[i + 1]! == '-' then (-1, i + 2)
+        else if i + 1 < cs.size && cs[i + 1]! == '+' then (1, i + 2)
+        else (1, i + 1)
+      let (t, i) := posixParseHMS cs i
+      (sign * t, i)
+    else (7200, i)
+  return ({ month := m, week := w, day := d, time }, i)
+
 /--
-Converts a `TZif.TZifV2` structure to a `ZoneRules` structure.
+Parses a POSIX TZ string (RFC 8536 §3.3) into a `PosixTzInfo`.
+Handles `std offset [dst [offset] [,Mm.w.d[/time],Mm.w.d[/time]]]`.
+-/
+private def parsePosixTz (s : String) : Option PosixTzInfo := do
+  let cs := s.toList.toArray
+  let (stdName, i) := posixParseName cs 0
+  if stdName.isEmpty then failure
+  let (stdOffset, i) := posixParseOffset cs i
+  if i >= cs.size then
+    return { stdName, stdOffset, dstName := "", dstOffset := stdOffset, start := none, end_ := none }
+  let (dstName, i) := posixParseName cs i
+  if dstName.isEmpty then
+    return { stdName, stdOffset, dstName := "", dstOffset := stdOffset, start := none, end_ := none }
+  -- DST offset: optional; default is stdOffset + 3600 (one hour ahead of standard).
+  let (dstOffset, i) :=
+    if i < cs.size && (cs[i]!.isDigit || cs[i]! == '+' || cs[i]! == '-')
+      then posixParseOffset cs i
+      else (stdOffset + 3600, i)
+  if i >= cs.size || cs[i]! != ',' then
+    return { stdName, stdOffset, dstName, dstOffset, start := none, end_ := none }
+  let (startRule, i) ← posixParseMwd cs (i + 1)
+  if i >= cs.size || cs[i]! != ',' then failure
+  let (endRule, _) ← posixParseMwd cs (i + 1)
+  return { stdName, stdOffset, dstName, dstOffset, start := some startRule, end_ := some endRule }
+
+-- Epoch day (days since 1970-01-01) of year `y`, month `m`, day 1.
+-- Uses the same algorithm as PlainDate.toEpochDay.
+private def firstOfMonthEpochDay (y : Int) (m : Nat) : Int :=
+  let m' : Int := Int.ofNat m
+  let y' := if m' > 2 then y else y - 1
+  let era := (if y' ≥ 0 then y' else y' - 399).tdiv 400
+  let yoe := y' - era * 400
+  let doy := (153 * (m' + (if m' > 2 then -3 else 9)) + 2).tdiv 5
+  let doe := yoe * 365 + yoe.tdiv 4 - yoe.tdiv 100 + doy
+  era * 146097 + doe - 719468
+
+-- Weekday of an epoch day: 1=Monday … 7=Sunday (same as PlainDate.weekday.toOrdinal).
+private def epochDayWeekday (d : Int) : Int :=
+  let r := (d + 4) % 7   -- 0-6, where 0 means Monday (epoch day 0 = Thursday → (0+4)%7=4)
+  ((r - 1) % 7 + 7) % 7 + 1  -- shift to [1,7]: 0→7(Sun), 1→1(Mon), …, 6→6(Sat)
+
+-- Epoch day of the Mm.w.d occurrence in year `year`.
+private def mwdEpochDay (year : Int) (rule : PosixTransRule) : Int :=
+  let epDay1 := firstOfMonthEpochDay year rule.month
+  let wd1    := epochDayWeekday epDay1
+  -- POSIX day 0=Sunday maps to library ordinal 7; days 1-6 map to 1-6.
+  let targetWd : Int := if rule.day == 0 then 7 else Int.ofNat rule.day
+  let diff      := (targetWd - wd1 + 7) % 7
+  let candidate := epDay1 + diff + (Int.ofNat rule.week - 1) * 7
+  -- If week=5 pushed past the end of the month, retreat one week.
+  let nextM  := if rule.month == 12 then 1  else rule.month + 1
+  let nextY  := if rule.month == 12 then year + 1 else year
+  let nextEp := firstOfMonthEpochDay nextY nextM
+  if candidate >= nextEp then candidate - 7 else candidate
+
+-- Transitions produced by the POSIX rule for a single calendar year.
+private def posixYearTransitions (year : Int) (p : PosixTzInfo) (identifier : String) : Array Transition :=
+  match p.start, p.end_ with
+  | some startRule, some endRule =>
+    -- Wall-clock at start is standard time → UTC = epochDay*86400 + wallTime - stdOffset
+    -- Wall-clock at end is DST time         → UTC = epochDay*86400 + wallTime - dstOffset
+    let startTs := Second.Offset.ofInt (mwdEpochDay year startRule * 86400 + startRule.time - p.stdOffset)
+    let endTs   := Second.Offset.ofInt (mwdEpochDay year endRule   * 86400 + endRule.time   - p.dstOffset)
+    let dstLTT : LocalTimeType :=
+      { gmtOffset := ⟨Second.Offset.ofInt p.dstOffset⟩, isDst := true,
+        abbreviation := p.dstName, wall := .wall, utLocal := .local, identifier }
+    let stdLTT : LocalTimeType :=
+      { gmtOffset := ⟨Second.Offset.ofInt p.stdOffset⟩, isDst := false,
+        abbreviation := p.stdName, wall := .wall, utLocal := .local, identifier }
+    -- Keep chronological order (reversed in Southern-Hemisphere zones where end < start).
+    if startTs.val ≤ endTs.val
+      then #[⟨startTs, dstLTT⟩, ⟨endTs, stdLTT⟩]
+      else #[⟨endTs, stdLTT⟩, ⟨startTs, dstLTT⟩]
+  | _, _ => #[]
+
+-- Recursive accumulator: appends POSIX transitions for `n` years starting at `firstYear`.
+private def extendForYears (posix : PosixTzInfo) (id : String) (firstYear lastTs : Int)
+    (i n : Nat) (acc : Array Transition) : Array Transition :=
+  if i >= n then acc
+  else
+    let year := firstYear + Int.ofNat i
+    let acc' := (posixYearTransitions year posix id).foldl
+      (fun a t => if t.time.val > lastTs then a.push t else a) acc
+    extendForYears posix id firstYear lastTs (i + 1) n acc'
+termination_by n - i
+decreasing_by omega
+
+-- Extend a transition array with POSIX-derived entries for all years beyond the last stored one.
+private def extendWithPosix (transitions : Array Transition) (posixStr : String) (id : String) : Array Transition :=
+  match parsePosixTz posixStr with
+  | none => transitions
+  | some posix =>
+    if posix.start.isNone then transitions
+    else
+      let lastTs   := if transitions.isEmpty then 0 else transitions.back!.time.val
+      let fromYear := lastTs / 31557600 + 1970
+      let numYears := (2200 - fromYear + 1).toNat
+      extendForYears posix id fromYear lastTs 0 numYears transitions
+
+/--
+Converts a `TZif.TZifV2` structure to a `ZoneRules` structure, extending transitions beyond
+the last stored entry using the POSIX TZ footer string when present.
 -/
 def convertTZifV2 (tz : TZif.TZifV2) (id : String) : Except String ZoneRules := do
-   convertTZifV1 tz.toTZifV1 id
+  let rules ← convertTZifV1 tz.toTZifV1 id
+  match tz.footer with
+  | none        => return rules
+  | some footer =>
+    return { rules with transitions := extendWithPosix rules.transitions footer id }
 
 /--
 Converts a `TZif.TZif` structure to a `ZoneRules` structure.

--- a/src/Std/Time/Zoned/Database/Basic.lean
+++ b/src/Std/Time/Zoned/Database/Basic.lean
@@ -8,6 +8,7 @@ module
 prelude
 public import Std.Time.Zoned.ZoneRules
 public import Std.Time.Zoned.Database.TzIf
+import Std.Time.Zoned.Database.PosixTz
 
 public section
 
@@ -32,6 +33,7 @@ protected class Database (α : Type) where
   getLocalZoneRules : α → IO TimeZone.ZoneRules
 
 namespace TimeZone
+open Internal
 
 /--
 Converts a Boolean value to a corresponding `StdWall` type.
@@ -106,184 +108,89 @@ def convertTZifV1 (tz : TZif.TZifV1) (id : String) : Except String ZoneRules := 
 -- POSIX TZ string parsing and future-transition generation.
 -- RFC 8536 §3.3: after all stored transitions, the POSIX TZ string (footer) defines the rule.
 
-private structure PosixTransRule where
-  month : Nat  -- 1-12
-  week  : Nat  -- 1-5 (5 = last occurrence)
-  day   : Nat  -- 0-6 (0 = Sunday, POSIX convention)
-  time  : Int  -- seconds from midnight; default 7200 (= 02:00:00)
-
-private structure PosixTzInfo where
-  stdName   : String
-  stdOffset : Int  -- seconds east of UTC (positive = east)
-  dstName   : String
-  dstOffset : Int  -- seconds east of UTC
-  start     : Option PosixTransRule
-  end_      : Option PosixTransRule
-
-private def posixParseNat (cs : Array Char) (i : Nat) : Nat × Nat :=
-  let rec go (i acc : Nat) : Nat × Nat :=
-    if hi : i < cs.size then
-      if cs[i]!.isDigit
-        then go (i + 1) (acc * 10 + cs[i]!.toNat - '0'.toNat)
-        else (acc, i)
-    else (acc, i)
-  termination_by cs.size - i
-  decreasing_by omega
-  go i 0
-
--- Parse hh[:mm[:ss]] as total seconds.
-private def posixParseHMS (cs : Array Char) (i : Nat) : Int × Nat :=
-  let (h, i) := posixParseNat cs i
-  let (m, i) := if i < cs.size && cs[i]! == ':' then posixParseNat cs (i + 1) else (0, i)
-  let (s, i) := if i < cs.size && cs[i]! == ':' then posixParseNat cs (i + 1) else (0, i)
-  (Int.ofNat h * 3600 + Int.ofNat m * 60 + Int.ofNat s, i)
-
--- Parse [+-]hh[:mm[:ss]] as east-positive seconds (POSIX offsets are west-positive, so we negate).
-private def posixParseOffset (cs : Array Char) (i : Nat) : Int × Nat :=
-  let (sign, i) :=
-    if i < cs.size && cs[i]! == '-' then (-1, i + 1)
-    else if i < cs.size && cs[i]! == '+' then (1, i + 1)
-    else (1, i)
-  let (secs, i) := posixParseHMS cs i
-  (-sign * secs, i)
-
--- Parse a timezone name: letters only, or <...> for names with digits/signs.
-private def posixParseName (cs : Array Char) (i : Nat) : String × Nat :=
-  if i < cs.size && cs[i]! == '<' then
-    let rec goAngle (i : Nat) (acc : String) : String × Nat :=
-      if hi : i < cs.size then
-        if cs[i]! == '>' then (acc, i + 1) else goAngle (i + 1) (acc.push cs[i]!)
-      else (acc, i)
-    termination_by cs.size - i
-    decreasing_by omega
-    goAngle (i + 1) ""
-  else
-    let rec goAlpha (i : Nat) (acc : String) : String × Nat :=
-      if hi : i < cs.size then
-        if cs[i]!.isAlpha then goAlpha (i + 1) (acc.push cs[i]!) else (acc, i)
-      else (acc, i)
-    termination_by cs.size - i
-    decreasing_by omega
-    goAlpha i ""
-
--- Parse Mm.w.d[/[+-]hh[:mm[:ss]]].
-private def posixParseMwd (cs : Array Char) (i : Nat) : Option (PosixTransRule × Nat) := do
-  if i >= cs.size || cs[i]! != 'M' then failure
-  let i := i + 1
-  let (m, i) := posixParseNat cs i
-  if i >= cs.size || cs[i]! != '.' then failure
-  let (w, i) := posixParseNat cs (i + 1)
-  if i >= cs.size || cs[i]! != '.' then failure
-  let (d, i) := posixParseNat cs (i + 1)
-  let (time, i) :=
-    if i < cs.size && cs[i]! == '/' then
-      let (sign, i) :=
-        if i + 1 < cs.size && cs[i + 1]! == '-' then (-1, i + 2)
-        else if i + 1 < cs.size && cs[i + 1]! == '+' then (1, i + 2)
-        else (1, i + 1)
-      let (t, i) := posixParseHMS cs i
-      (sign * t, i)
-    else (7200, i)
-  return ({ month := m, week := w, day := d, time }, i)
-
-/--
-Parses a POSIX TZ string (RFC 8536 §3.3) into a `PosixTzInfo`.
-Handles `std offset [dst [offset] [,Mm.w.d[/time],Mm.w.d[/time]]]`.
--/
-private def parsePosixTz (s : String) : Option PosixTzInfo := do
-  let cs := s.toList.toArray
-  let (stdName, i) := posixParseName cs 0
-  if stdName.isEmpty then failure
-  let (stdOffset, i) := posixParseOffset cs i
-  if i >= cs.size then
-    return { stdName, stdOffset, dstName := "", dstOffset := stdOffset, start := none, end_ := none }
-  let (dstName, i) := posixParseName cs i
-  if dstName.isEmpty then
-    return { stdName, stdOffset, dstName := "", dstOffset := stdOffset, start := none, end_ := none }
-  -- DST offset: optional; default is stdOffset + 3600 (one hour ahead of standard).
-  let (dstOffset, i) :=
-    if i < cs.size && (cs[i]!.isDigit || cs[i]! == '+' || cs[i]! == '-')
-      then posixParseOffset cs i
-      else (stdOffset + 3600, i)
-  if i >= cs.size || cs[i]! != ',' then
-    return { stdName, stdOffset, dstName, dstOffset, start := none, end_ := none }
-  let (startRule, i) ← posixParseMwd cs (i + 1)
-  if i >= cs.size || cs[i]! != ',' then failure
-  let (endRule, _) ← posixParseMwd cs (i + 1)
-  return { stdName, stdOffset, dstName, dstOffset, start := some startRule, end_ := some endRule }
-
--- Epoch day (days since 1970-01-01) of year `y`, month `m`, day 1.
--- Uses the same algorithm as PlainDate.toEpochDay.
-private def firstOfMonthEpochDay (y : Int) (m : Nat) : Int :=
-  let m' : Int := Int.ofNat m
-  let y' := if m' > 2 then y else y - 1
-  let era := (if y' ≥ 0 then y' else y' - 399).tdiv 400
-  let yoe := y' - era * 400
-  let doy := (153 * (m' + (if m' > 2 then -3 else 9)) + 2).tdiv 5
-  let doe := yoe * 365 + yoe.tdiv 4 - yoe.tdiv 100 + doy
-  era * 146097 + doe - 719468
-
--- Weekday of an epoch day: 1=Monday … 7=Sunday (same as PlainDate.weekday.toOrdinal).
-private def epochDayWeekday (d : Int) : Int :=
-  let r := (d + 4) % 7   -- 0-6, where 0 means Monday (epoch day 0 = Thursday → (0+4)%7=4)
-  ((r - 1) % 7 + 7) % 7 + 1  -- shift to [1,7]: 0→7(Sun), 1→1(Mon), …, 6→6(Sat)
-
 -- Epoch day of the Mm.w.d occurrence in year `year`.
-private def mwdEpochDay (year : Int) (rule : PosixTransRule) : Int :=
-  let epDay1 := firstOfMonthEpochDay year rule.month
-  let wd1    := epochDayWeekday epDay1
-  -- POSIX day 0=Sunday maps to library ordinal 7; days 1-6 map to 1-6.
-  let targetWd : Int := if rule.day == 0 then 7 else Int.ofNat rule.day
-  let diff      := (targetWd - wd1 + 7) % 7
-  let candidate := epDay1 + diff + (Int.ofNat rule.week - 1) * 7
-  -- If week=5 pushed past the end of the month, retreat one week.
-  let nextM  := if rule.month == 12 then 1  else rule.month + 1
-  let nextY  := if rule.month == 12 then year + 1 else year
-  let nextEp := firstOfMonthEpochDay nextY nextM
-  if candidate >= nextEp then candidate - 7 else candidate
+private def mwdEpochDay (year : Year.Offset) (month : Month.Ordinal) (week : Week.Ordinal) (day : Weekday.Ordinal) : Day.Offset :=
+  let date1 := PlainDate.ofYearMonthDayClip year month (Day.Ordinal.ofNat 1)
+  let epDay1 := date1.toEpochDay.toInt
+  let wd1 := date1.weekday.toOrdinal.val
+  let diff := (day.val - wd1 + 7) % 7
+  let candidate := epDay1 + diff + (week.val - 1) * 7
+  let nextMonthStart := epDay1 + (month.days year.isLeap).val
+  Day.Offset.ofInt (if candidate >= nextMonthStart then candidate - 7 else candidate)
+
+-- Epoch day for Jn (1–365): Feb 29 is never counted, so days ≥ 60 shift by 1 in leap years.
+private def julianEpochDay (year : Year.Offset) (day : Bounded.LE 1 365) : Day.Offset :=
+  let jan1 := (PlainDate.ofYearMonthDayClip year (Month.Ordinal.ofNat 1) (Day.Ordinal.ofNat 1)).toEpochDay
+  Day.Offset.ofInt (jan1.toInt + day.val - 1 + if year.isLeap && day.val ≥ 60 then 1 else 0)
+
+-- Epoch day for zero-based n (0–365): Feb 29 is counted in leap years.
+private def julian0EpochDay (year : Year.Offset) (day : Bounded.LE 0 365) : Day.Offset :=
+  (PlainDate.ofYearMonthDayClip year (Month.Ordinal.ofNat 1) (Day.Ordinal.ofNat 1)).toEpochDay + Day.Offset.ofInt day.val
+
+-- Epoch day for a PosixTransSpec in the given year.
+private def specEpochDay (year : Year.Offset) (spec : PosixTransSpec) : Day.Offset :=
+  match spec with
+  | .mwd month week day => mwdEpochDay year month week day
+  | .julian day => julianEpochDay year day
+  | .julian0 day => julian0EpochDay year day
 
 -- Transitions produced by the POSIX rule for a single calendar year.
-private def posixYearTransitions (year : Int) (p : PosixTzInfo) (identifier : String) : Array Transition :=
+private def posixYearTransitions (year : Year.Offset) (p : PosixTzInfo) (identifier : String) : Array Transition :=
   match p.start, p.end_ with
   | some startRule, some endRule =>
-    -- Wall-clock at start is standard time → UTC = epochDay*86400 + wallTime - stdOffset
-    -- Wall-clock at end is DST time         → UTC = epochDay*86400 + wallTime - dstOffset
-    let startTs := Second.Offset.ofInt (mwdEpochDay year startRule * 86400 + startRule.time - p.stdOffset)
-    let endTs   := Second.Offset.ofInt (mwdEpochDay year endRule   * 86400 + endRule.time   - p.dstOffset)
+    -- Convert a spec + wall-clock time to a UTC Second.Offset:
+    -- WallTime represents civil time; subtracting the UTC offset converts it to UTC.
+    let toUtc (spec : PosixTransSpec) (wallTime : Second.Offset) (offset : TimeZone.Offset) : Second.Offset :=
+      (WallTime.ofSeconds ((specEpochDay year spec).toSeconds + wallTime)).toSeconds - offset.second
+
+    let startTs := toUtc startRule.spec startRule.time p.stdOffset
+    let endTs := toUtc endRule.spec endRule.time p.dstOffset
+
     let dstLTT : LocalTimeType :=
-      { gmtOffset := ⟨Second.Offset.ofInt p.dstOffset⟩, isDst := true,
+      { gmtOffset := p.dstOffset, isDst := true,
         abbreviation := p.dstName, wall := .wall, utLocal := .local, identifier }
+
     let stdLTT : LocalTimeType :=
-      { gmtOffset := ⟨Second.Offset.ofInt p.stdOffset⟩, isDst := false,
+      { gmtOffset := p.stdOffset, isDst := false,
         abbreviation := p.stdName, wall := .wall, utLocal := .local, identifier }
+
     -- Keep chronological order (reversed in Southern-Hemisphere zones where end < start).
     if startTs.val ≤ endTs.val
       then #[⟨startTs, dstLTT⟩, ⟨endTs, stdLTT⟩]
       else #[⟨endTs, stdLTT⟩, ⟨startTs, dstLTT⟩]
   | _, _ => #[]
 
--- Recursive accumulator: appends POSIX transitions for `n` years starting at `firstYear`.
-private def extendForYears (posix : PosixTzInfo) (id : String) (firstYear lastTs : Int)
+/-
+appends POSIX transitions for `n` years starting at `firstYear`.
+-/
+private def extendForYears (posix : PosixTzInfo) (id : String) (firstYear : Year.Offset) (lastTs : Second.Offset)
     (i n : Nat) (acc : Array Transition) : Array Transition :=
-  if i >= n then acc
+  if i >= n then
+    acc
   else
-    let year := firstYear + Int.ofNat i
+    let year := firstYear + Year.Offset.ofNat i
     let acc' := (posixYearTransitions year posix id).foldl
-      (fun a t => if t.time.val > lastTs then a.push t else a) acc
+      (fun a t => if t.time.val > lastTs.val then a.push t else a) acc
     extendForYears posix id firstYear lastTs (i + 1) n acc'
-termination_by n - i
-decreasing_by omega
 
--- Extend a transition array with POSIX-derived entries for all years beyond the last stored one.
+/-
+Extend a transition array with POSIX-derived entries for all years beyond the last stored one.
+-/
 private def extendWithPosix (transitions : Array Transition) (posixStr : String) (id : String) : Array Transition :=
   match parsePosixTz posixStr with
-  | none => transitions
+  | none =>
+    transitions
   | some posix =>
-    if posix.start.isNone then transitions
+    if posix.start.isNone then
+      transitions
     else
-      let lastTs   := if transitions.isEmpty then 0 else transitions.back!.time.val
-      let fromYear := lastTs / 31557600 + 1970
-      let numYears := (2200 - fromYear + 1).toNat
+      let lastTs := if h : transitions.size > 0
+        then transitions[0]'h |>.time
+        else Second.Offset.ofInt 0
+
+      let fromYear := (PlainDate.ofEpochDay (Day.Offset.ofSeconds lastTs)).year
+      let numYears := (2200 - fromYear.toInt + 1).toNat
+
       extendForYears posix id fromYear lastTs 0 numYears transitions
 
 /--
@@ -293,7 +200,8 @@ the last stored entry using the POSIX TZ footer string when present.
 def convertTZifV2 (tz : TZif.TZifV2) (id : String) : Except String ZoneRules := do
   let rules ← convertTZifV1 tz.toTZifV1 id
   match tz.footer with
-  | none        => return rules
+  | none =>
+    return rules
   | some footer =>
     return { rules with transitions := extendWithPosix rules.transitions footer id }
 

--- a/src/Std/Time/Zoned/Database/Basic.lean
+++ b/src/Std/Time/Zoned/Database/Basic.lean
@@ -105,93 +105,6 @@ def convertTZifV1 (tz : TZif.TZifV1) (id : String) : Except String ZoneRules := 
 
   .ok { transitions, initialLocalTimeType }
 
--- POSIX TZ string parsing and future-transition generation.
--- RFC 8536 §3.3: after all stored transitions, the POSIX TZ string (footer) defines the rule.
-
--- Epoch day of the Mm.w.d occurrence in year `year`.
-private def mwdEpochDay (year : Year.Offset) (month : Month.Ordinal) (week : Week.Ordinal) (day : Weekday.Ordinal) : Day.Offset :=
-  let date1 := PlainDate.ofYearMonthDayClip year month (Day.Ordinal.ofNat 1)
-  let epDay1 := date1.toEpochDay.toInt
-  let wd1 := date1.weekday.toOrdinal.val
-  let diff := (day.val - wd1 + 7) % 7
-  let candidate := epDay1 + diff + (week.val - 1) * 7
-  let nextMonthStart := epDay1 + (month.days year.isLeap).val
-  Day.Offset.ofInt (if candidate >= nextMonthStart then candidate - 7 else candidate)
-
--- Epoch day for Jn (1–365): Feb 29 is never counted, so days ≥ 60 shift by 1 in leap years.
-private def julianEpochDay (year : Year.Offset) (day : Bounded.LE 1 365) : Day.Offset :=
-  let jan1 := (PlainDate.ofYearMonthDayClip year (Month.Ordinal.ofNat 1) (Day.Ordinal.ofNat 1)).toEpochDay
-  Day.Offset.ofInt (jan1.toInt + day.val - 1 + if year.isLeap && day.val ≥ 60 then 1 else 0)
-
--- Epoch day for zero-based n (0–365): Feb 29 is counted in leap years.
-private def julian0EpochDay (year : Year.Offset) (day : Bounded.LE 0 365) : Day.Offset :=
-  (PlainDate.ofYearMonthDayClip year (Month.Ordinal.ofNat 1) (Day.Ordinal.ofNat 1)).toEpochDay + Day.Offset.ofInt day.val
-
--- Epoch day for a PosixTransSpec in the given year.
-private def specEpochDay (year : Year.Offset) (spec : PosixTransSpec) : Day.Offset :=
-  match spec with
-  | .mwd month week day => mwdEpochDay year month week day
-  | .julian day => julianEpochDay year day
-  | .julian0 day => julian0EpochDay year day
-
--- Transitions produced by the POSIX rule for a single calendar year.
-private def posixYearTransitions (year : Year.Offset) (p : PosixTzInfo) (identifier : String) : Array Transition :=
-  match p.start, p.end_ with
-  | some startRule, some endRule =>
-    -- Convert a spec + wall-clock time to a UTC Second.Offset:
-    -- WallTime represents civil time; subtracting the UTC offset converts it to UTC.
-    let toUtc (spec : PosixTransSpec) (wallTime : Second.Offset) (offset : TimeZone.Offset) : Second.Offset :=
-      (WallTime.ofSeconds ((specEpochDay year spec).toSeconds + wallTime)).toSeconds - offset.second
-
-    let startTs := toUtc startRule.spec startRule.time p.stdOffset
-    let endTs := toUtc endRule.spec endRule.time p.dstOffset
-
-    let dstLTT : LocalTimeType :=
-      { gmtOffset := p.dstOffset, isDst := true,
-        abbreviation := p.dstName, wall := .wall, utLocal := .local, identifier }
-
-    let stdLTT : LocalTimeType :=
-      { gmtOffset := p.stdOffset, isDst := false,
-        abbreviation := p.stdName, wall := .wall, utLocal := .local, identifier }
-
-    -- Keep chronological order (reversed in Southern-Hemisphere zones where end < start).
-    if startTs.val ≤ endTs.val
-      then #[⟨startTs, dstLTT⟩, ⟨endTs, stdLTT⟩]
-      else #[⟨endTs, stdLTT⟩, ⟨startTs, dstLTT⟩]
-  | _, _ => #[]
-
-/-
-appends POSIX transitions for `n` years starting at `firstYear`.
--/
-private def extendForYears (posix : PosixTzInfo) (id : String) (firstYear : Year.Offset) (lastTs : Second.Offset)
-    (i n : Nat) (acc : Array Transition) : Array Transition :=
-  if i >= n then
-    acc
-  else
-    let year := firstYear + Year.Offset.ofNat i
-    let acc' := (posixYearTransitions year posix id).foldl
-      (fun a t => if t.time.val > lastTs.val then a.push t else a) acc
-    extendForYears posix id firstYear lastTs (i + 1) n acc'
-
-/-
-Extend a transition array with POSIX-derived entries for all years beyond the last stored one.
--/
-private def extendWithPosix (transitions : Array Transition) (posixStr : String) (id : String) : Array Transition :=
-  match parsePosixTz posixStr with
-  | none =>
-    transitions
-  | some posix =>
-    if posix.start.isNone then
-      transitions
-    else
-      let lastTs := if h : transitions.size > 0
-        then transitions[0]'h |>.time
-        else Second.Offset.ofInt 0
-
-      let fromYear := (PlainDate.ofEpochDay (Day.Offset.ofSeconds lastTs)).year
-      let numYears := (2200 - fromYear.toInt + 1).toNat
-
-      extendForYears posix id fromYear lastTs 0 numYears transitions
 
 /--
 Converts a `TZif.TZifV2` structure to a `ZoneRules` structure, extending transitions beyond
@@ -199,11 +112,17 @@ the last stored entry using the POSIX TZ footer string when present.
 -/
 def convertTZifV2 (tz : TZif.TZifV2) (id : String) : Except String ZoneRules := do
   let rules ← convertTZifV1 tz.toTZifV1 id
-  match tz.footer with
-  | none =>
-    return rules
-  | some footer =>
-    return { rules with transitions := extendWithPosix rules.transitions footer id }
+
+  let some footer := tz.footer
+    | return rules
+
+  -- TZif v3 files allow extended hour ranges (±0–167) in transition times (RFC 8536 §3.3).
+  let extended := tz.header.version == '3'.toUInt8
+
+  let some transitionRule := parsePosixTz footer extended
+    | throw "failed to parse tzif footer"
+
+  return { rules with transitionRule := some transitionRule }
 
 /--
 Converts a `TZif.TZif` structure to a `ZoneRules` structure.

--- a/src/Std/Time/Zoned/Database/PosixTz.lean
+++ b/src/Std/Time/Zoned/Database/PosixTz.lean
@@ -7,14 +7,10 @@ module
 
 prelude
 public import Std.Internal.Parsec
-public import Std.Time.Date.Unit.Month
-public import Std.Time.Date.Unit.Week
-public import Std.Time.Date.Unit.Weekday
-public import Std.Time.Zoned.Offset
+public import Std.Time.Zoned.ZoneRules
 
 /-!
 POSIX TZ string parser for RFC 8536 §3.3 footer strings.
-Used to extend stored TZif transitions into the far future.
 -/
 
 public section
@@ -24,123 +20,31 @@ open Internal
 
 set_option linter.all true
 
-/--
-Specifies how a DST transition date is expressed in a POSIX TZ string.
--/
-inductive PosixTransSpec where
-
-  /--
-  `Mm.w.d` form: month `m`, week `w` (1–5; 5 = last), ISO weekday `d`.
-  -/
-  | mwd (month : Month.Ordinal) (week : Week.Ordinal) (day : Weekday.Ordinal)
-
-  /--
-  `Jn` form: Julian day 1–365 (Feb 29 never counted, even in leap years).
-  -/
-  | julian (day : Bounded.LE 1 365)
-
-  /--
-  `n` form: zero-based day 0–365 (Feb 29 counted in leap years).
-  -/
-  | julian0 (day : Bounded.LE 0 365)
-deriving Repr
-
-/--
-A single DST transition rule: a date specification and a wall-clock time.
--/
-structure PosixTransRule where
-
-  /--
-  How the transition date is specified.
-  -/
-  spec : PosixTransSpec
-
-  /--
-  Time of day as seconds from midnight (default 7200 = 02:00).
-  -/
-  time : Second.Offset
-deriving Repr
-
-/--
-Parsed representation of a POSIX TZ string.
--/
-structure PosixTzInfo where
-
-  /--
-  Standard time abbreviation.
-  -/
-  stdName : String
-
-  /--
-  Standard UTC offset (east-positive).
-  -/
-  stdOffset : TimeZone.Offset
-
-  /--
-  DST abbreviation (empty when no DST).
-  -/
-  dstName : String := ""
-
-  /--
-  DST UTC offset (east-positive).
-  -/
-  dstOffset : TimeZone.Offset
-
-  /--
-  Rule for the start of DST, if any.
-  -/
-  start : Option PosixTransRule := none
-
-  /--
-  Rule for the end of DST, if any.
-  -/
-  end_ : Option PosixTransRule := none
-deriving Repr
-
 open Std.Internal.Parsec Std.Internal.Parsec.String
 
--- POSIX standard max hour for transition times (0–24); TZif v3 extended mode allows 0–167.
-private def posixMaxHour    : Nat := 24
-private def extendedMaxHour : Nat := 167
-
--- Hour bounded to the TZif v3 extended range; wider than `Hour.Ordinal` (0–23).
-private abbrev ExtendedHour := Bounded.LE 0 extendedMaxHour
-
--- Default transition wall-clock time when none is specified: 02:00:00 local (7200 s).
-private def defaultTransitionTime : Int := 7200
-
--- Default DST offset ahead of standard time when none is specified: +1 h (3600 s).
-private def defaultDstAheadSeconds : Int := 3600
-
--- POSIX weekday range: 0 (Sunday) … 6 (Saturday); ISO ordinal maps Sunday → 7.
-private def posixMaxWeekday : Nat := 6
-private def posixSundayIso  : Int := 7
-
--- Maximum week-in-month index accepted in Mm.w.d specs (5 = "last occurrence").
-private def maxWeekInMonth : Nat := 5
-
 -- Parse digits and validate them into a Bounded.LE type, with an optional extra predicate.
-private def parseBoundedNat {lo hi : Int} (name : String) (extra : Nat → Bool := fun _ => true) : Parser (Bounded.LE lo hi) := do
-  let n ← digits
+private def parseBoundedNat {lo hi : Int} (name : String) (extra : Int → Bool := fun _ => true) : Parser (Bounded.LE lo hi) := do
+  let n ← Int.ofNat <$> digits
   if !extra n then fail s!"{name} {n} out of range"
-  match (Bounded.LE.ofInt (Int.ofNat n) : Option (Bounded.LE lo hi)) with
+
+  match Bounded.LE.ofInt n with
   | some b => pure b
   | none => fail s!"{name} {n} out of range"
 
 private def posixParseSign : Parser Int :=
-  attempt (pchar '-' *> pure (-1 : Int)) <|>
-  attempt (pchar '+' *> pure 1) <|>
-  pure 1
+  attempt (pchar '-' *> pure (-1 : Int))
+  <|> attempt (pchar '+' *> pure 1)
+  <|> pure 1
 
 -- <time> ::= <hour> [":" <minute> [":" <second>]]
 -- `maxHour` caps the hour field; POSIX requires 0–24, extended mode allows 0–167.
-private def posixParseHMS (maxHour : Nat := posixMaxHour) : Parser Second.Offset := do
+private def posixParseHMS (maxHour : Nat := 24) : Parser Second.Offset := do
   let rawH ← digits
   if rawH > maxHour then fail s!"hour {rawH} out of range 0-{maxHour}"
 
-  let h : ExtendedHour ← match Bounded.LE.ofNat? rawH with
+  let h : Bounded.LE 0 167 ← match Bounded.LE.ofNat? rawH with
     | some b => pure b
-    | none   => fail s!"hour {rawH} out of range 0-{extendedMaxHour}"
+    | none   => fail s!"hour {rawH} out of range 0-{167}"
 
   let m : Minute.Ordinal ← attempt (pchar ':' *> parseBoundedNat "minute") <|> pure (Bounded.LE.mk 0 (by decide))
   let s : Second.Ordinal false ← attempt (pchar ':' *> parseBoundedNat "second") <|> pure (Bounded.LE.mk 0 (by decide))
@@ -165,29 +69,30 @@ private def posixParseName : Parser String := do
     else manyChars asciiLetter
 
 -- "M" <month> "." <week> "." <weekday>
-private def posixParseMwdSpec : Parser PosixTransSpec := do
+private def posixParseMwdSpec : Parser TransitionSpec := do
   skipChar 'M'
+
   let month ← parseBoundedNat "month" <* skipChar '.'
-  let week ← parseBoundedNat "week" (· ≤ maxWeekInMonth) <* skipChar '.'
+  let week ← parseBoundedNat "week" (· ≤ 5) <* skipChar '.'
 
   -- Convert POSIX day (0=Sunday … 6=Saturday) to ISO ordinal (1=Monday … 7=Sunday).
   let d ← digits
-  if d > posixMaxWeekday then fail s!"day {d} out of range 0-{posixMaxWeekday}"
+  if d > 6 then fail s!"day {d} out of range 0-6"
 
-  let day ← match (Bounded.LE.ofInt (if d == 0 then posixSundayIso else Int.ofNat d)) with
+  let day ← match (Bounded.LE.ofInt (if d == 0 then 7 else Int.ofNat d)) with
     | some wd => pure wd
-    | none => fail s!"day {d} out of range 0-{posixMaxWeekday}"
+    | none => fail s!"day {d} out of range 0-6"
 
   return .mwd month week day
 
 -- "J" <n> where n is 1–365; Feb 29 is never counted.
-private def posixParseJulianSpec : Parser PosixTransSpec := do
+private def posixParseJulianSpec : Parser TransitionSpec := do
   skipChar 'J'
   let day : Bounded.LE 1 365 ← parseBoundedNat "Julian day"
   return .julian day
 
 -- <n> where n is 0–365; Feb 29 is counted in leap years.
-private def posixParseJulian0Spec : Parser PosixTransSpec := do
+private def posixParseJulian0Spec : Parser TransitionSpec := do
   let day : Bounded.LE 0 365 ← parseBoundedNat "day"
   return .julian0 day
 
@@ -196,28 +101,34 @@ private def posixParseDstOffset (stdOffset : TimeZone.Offset) : Parser TimeZone.
   let c ← peek?
   if let some ch := c then
     if ch.isDigit || ch == '+' || ch == '-' then posixParseOffset
-    else pure ⟨Second.Offset.ofInt (stdOffset.second.val + defaultDstAheadSeconds)⟩
-  else pure ⟨Second.Offset.ofInt (stdOffset.second.val + defaultDstAheadSeconds)⟩
+    else pure ⟨Second.Offset.ofInt (stdOffset.second.val + 3600)⟩
+  else pure ⟨Second.Offset.ofInt (stdOffset.second.val + 3600)⟩
 
 -- <rule-spec> ::= "M" <month> "." <week> "." <weekday> | "J" <n> | <n>
-private def posixParseSpec : Parser PosixTransSpec :=
+private def posixParseSpec : Parser TransitionSpec :=
   attempt posixParseMwdSpec <|> attempt posixParseJulianSpec <|> posixParseJulian0Spec
 
 -- <rule> ::= <rule-spec> [ "/" <time> ]
 -- When `extended` is true, hours may range from -167 to 167 (TZif v3+).
-private def posixParseRule (extended : Bool := false) : Parser PosixTransRule := do
+private def posixParseRule (extended : Bool := false) : Parser TransitionRule := do
   let spec ← posixParseSpec
 
-  let time ← attempt (do
+  -- "The time has the same format as offset except that no leading sign ( '-' or '+' ) is allowed. The default, if time is not given, shall be 02:00:00."
+  -- $8.3 https://pubs.opengroup.org/onlinepubs/9699919799/
+  let defaultTime : Hour.Offset := 2
+
+  let parseTime := attempt <| do
     skipChar '/'
     let sign ← posixParseSign
-    let t ← posixParseHMS (maxHour := if extended then extendedMaxHour else posixMaxHour)
-    return Second.Offset.ofInt (sign * t.val)) <|> pure (Second.Offset.ofInt defaultTransitionTime)
+    let t ← posixParseHMS (maxHour := if extended then 167 else 24)
+    return Second.Offset.ofInt (sign * t.val)
+
+  let time ← parseTime <|> pure defaultTime.toSeconds
 
   return { spec, time }
 
--- <TZ> ::= <std> <offset> [ <dst> [ <offset> ] [ "," <rule> "," <rule> ] ]
-private def parsePosixTzP (extended : Bool := false) : Parser PosixTzInfo := do
+-- <TZ> ::= NL <std> <offset> [ <dst> [ <offset> ] [ "," <rule> "," <rule> ] ] NL
+private def parsePosixTzP (extended : Bool := false) : Parser RecurringRule := do
   let stdName ← posixParseName
 
   if stdName.isEmpty then
@@ -228,32 +139,30 @@ private def parsePosixTzP (extended : Bool := false) : Parser PosixTzInfo := do
   if (← isEof) then
     return { stdName, stdOffset, dstOffset := stdOffset }
 
-  -- <dst>
   let dstName ← posixParseName
 
   if dstName.isEmpty then
     return { stdName, stdOffset, dstOffset := stdOffset }
 
-  -- <dst>
   let dstOffset ← posixParseDstOffset stdOffset
 
-  -- [ <offset> ]
   if (← peek?) != some ',' then
     return { stdName, stdOffset, dstName, dstOffset }
 
-  -- [ "," <rule> "," <rule> ]
   let startRule ← skip *> posixParseRule extended
   let endRule ← skipChar ',' *> posixParseRule extended
 
   return { stdName, stdOffset, dstName, dstOffset, start := some startRule, end_ := some endRule }
 
 /--
-Parse a POSIX TZ footer string into a `PosixTzInfo`, returning `none` on failure.
+Parse a POSIX TZ footer string into a `RecurringRule`, returning `none` on failure.
 
 When `extended` is `true`, transition times accept signed hours in the range
--`extendedMaxHour` to `extendedMaxHour` instead of the POSIX-required 0 to `posixMaxHour` (TZif version 3+).
+-`167` to `167` instead of the POSIX-required 0 to `24` (TZif version 3+).
 -/
-def parsePosixTz (s : String) (extended : Bool := false) : Option PosixTzInfo :=
-  ((parsePosixTzP extended).run s).toOption
+def parsePosixTz (s : String) (extended : Bool := false) : Option RecurringRule :=
+  parsePosixTzP extended
+  |>.run s
+  |>.toOption
 
 end Std.Time.TimeZone

--- a/src/Std/Time/Zoned/Database/PosixTz.lean
+++ b/src/Std/Time/Zoned/Database/PosixTz.lean
@@ -1,0 +1,259 @@
+/-
+Copyright (c) 2024 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sofia Rodrigues
+-/
+module
+
+prelude
+public import Std.Internal.Parsec
+public import Std.Time.Date.Unit.Month
+public import Std.Time.Date.Unit.Week
+public import Std.Time.Date.Unit.Weekday
+public import Std.Time.Zoned.Offset
+
+/-!
+POSIX TZ string parser for RFC 8536 §3.3 footer strings.
+Used to extend stored TZif transitions into the far future.
+-/
+
+public section
+
+namespace Std.Time.TimeZone
+open Internal
+
+set_option linter.all true
+
+/--
+Specifies how a DST transition date is expressed in a POSIX TZ string.
+-/
+inductive PosixTransSpec where
+
+  /--
+  `Mm.w.d` form: month `m`, week `w` (1–5; 5 = last), ISO weekday `d`.
+  -/
+  | mwd (month : Month.Ordinal) (week : Week.Ordinal) (day : Weekday.Ordinal)
+
+  /--
+  `Jn` form: Julian day 1–365 (Feb 29 never counted, even in leap years).
+  -/
+  | julian (day : Bounded.LE 1 365)
+
+  /--
+  `n` form: zero-based day 0–365 (Feb 29 counted in leap years).
+  -/
+  | julian0 (day : Bounded.LE 0 365)
+deriving Repr
+
+/--
+A single DST transition rule: a date specification and a wall-clock time.
+-/
+structure PosixTransRule where
+
+  /--
+  How the transition date is specified.
+  -/
+  spec : PosixTransSpec
+
+  /--
+  Time of day as seconds from midnight (default 7200 = 02:00).
+  -/
+  time : Second.Offset
+deriving Repr
+
+/--
+Parsed representation of a POSIX TZ string.
+-/
+structure PosixTzInfo where
+
+  /--
+  Standard time abbreviation.
+  -/
+  stdName : String
+
+  /--
+  Standard UTC offset (east-positive).
+  -/
+  stdOffset : TimeZone.Offset
+
+  /--
+  DST abbreviation (empty when no DST).
+  -/
+  dstName : String := ""
+
+  /--
+  DST UTC offset (east-positive).
+  -/
+  dstOffset : TimeZone.Offset
+
+  /--
+  Rule for the start of DST, if any.
+  -/
+  start : Option PosixTransRule := none
+
+  /--
+  Rule for the end of DST, if any.
+  -/
+  end_ : Option PosixTransRule := none
+deriving Repr
+
+open Std.Internal.Parsec Std.Internal.Parsec.String
+
+-- POSIX standard max hour for transition times (0–24); TZif v3 extended mode allows 0–167.
+private def posixMaxHour    : Nat := 24
+private def extendedMaxHour : Nat := 167
+
+-- Hour bounded to the TZif v3 extended range; wider than `Hour.Ordinal` (0–23).
+private abbrev ExtendedHour := Bounded.LE 0 extendedMaxHour
+
+-- Default transition wall-clock time when none is specified: 02:00:00 local (7200 s).
+private def defaultTransitionTime : Int := 7200
+
+-- Default DST offset ahead of standard time when none is specified: +1 h (3600 s).
+private def defaultDstAheadSeconds : Int := 3600
+
+-- POSIX weekday range: 0 (Sunday) … 6 (Saturday); ISO ordinal maps Sunday → 7.
+private def posixMaxWeekday : Nat := 6
+private def posixSundayIso  : Int := 7
+
+-- Maximum week-in-month index accepted in Mm.w.d specs (5 = "last occurrence").
+private def maxWeekInMonth : Nat := 5
+
+-- Parse digits and validate them into a Bounded.LE type, with an optional extra predicate.
+private def parseBoundedNat {lo hi : Int} (name : String) (extra : Nat → Bool := fun _ => true) : Parser (Bounded.LE lo hi) := do
+  let n ← digits
+  if !extra n then fail s!"{name} {n} out of range"
+  match (Bounded.LE.ofInt (Int.ofNat n) : Option (Bounded.LE lo hi)) with
+  | some b => pure b
+  | none => fail s!"{name} {n} out of range"
+
+private def posixParseSign : Parser Int :=
+  attempt (pchar '-' *> pure (-1 : Int)) <|>
+  attempt (pchar '+' *> pure 1) <|>
+  pure 1
+
+-- <time> ::= <hour> [":" <minute> [":" <second>]]
+-- `maxHour` caps the hour field; POSIX requires 0–24, extended mode allows 0–167.
+private def posixParseHMS (maxHour : Nat := posixMaxHour) : Parser Second.Offset := do
+  let rawH ← digits
+  if rawH > maxHour then fail s!"hour {rawH} out of range 0-{maxHour}"
+
+  let h : ExtendedHour ← match Bounded.LE.ofNat? rawH with
+    | some b => pure b
+    | none   => fail s!"hour {rawH} out of range 0-{extendedMaxHour}"
+
+  let m : Minute.Ordinal ← attempt (pchar ':' *> parseBoundedNat "minute") <|> pure (Bounded.LE.mk 0 (by decide))
+  let s : Second.Ordinal false ← attempt (pchar ':' *> parseBoundedNat "second") <|> pure (Bounded.LE.mk 0 (by decide))
+  return (Hour.Offset.ofInt h.val).toSeconds + m.toOffset.toSeconds + s.toOffset
+
+-- <offset> ::= [ "+" | "-" ] <time>
+private def posixParseOffset : Parser TimeZone.Offset := do
+  let sign ← posixParseSign
+  let secs ← posixParseHMS
+
+  -- POSIX offsets are west-positive, so we negate
+  return ⟨Second.Offset.ofInt (-sign * secs.val)⟩
+
+-- <quoted-name> ::= "<" <quoted-char> { <quoted-char> } ">"
+private def quotedName : Parser String :=
+  manyChars (satisfy (fun c => Char.isAlphanum c ∨ c == '+' ∨ c == '-'))
+
+-- <tzname> ::= <alpha>{3,} | "<" <char>+ ">"
+private def posixParseName : Parser String := do
+  if (← peek?) == some '<'
+    then skip *> quotedName <* attempt (pchar '>')
+    else manyChars asciiLetter
+
+-- "M" <month> "." <week> "." <weekday>
+private def posixParseMwdSpec : Parser PosixTransSpec := do
+  skipChar 'M'
+  let month ← parseBoundedNat "month" <* skipChar '.'
+  let week ← parseBoundedNat "week" (· ≤ maxWeekInMonth) <* skipChar '.'
+
+  -- Convert POSIX day (0=Sunday … 6=Saturday) to ISO ordinal (1=Monday … 7=Sunday).
+  let d ← digits
+  if d > posixMaxWeekday then fail s!"day {d} out of range 0-{posixMaxWeekday}"
+
+  let day ← match (Bounded.LE.ofInt (if d == 0 then posixSundayIso else Int.ofNat d)) with
+    | some wd => pure wd
+    | none => fail s!"day {d} out of range 0-{posixMaxWeekday}"
+
+  return .mwd month week day
+
+-- "J" <n> where n is 1–365; Feb 29 is never counted.
+private def posixParseJulianSpec : Parser PosixTransSpec := do
+  skipChar 'J'
+  let day : Bounded.LE 1 365 ← parseBoundedNat "Julian day"
+  return .julian day
+
+-- <n> where n is 0–365; Feb 29 is counted in leap years.
+private def posixParseJulian0Spec : Parser PosixTransSpec := do
+  let day : Bounded.LE 0 365 ← parseBoundedNat "day"
+  return .julian0 day
+
+-- [ <offset> ] — optional DST offset; defaults to stdOffset + 1h when absent.
+private def posixParseDstOffset (stdOffset : TimeZone.Offset) : Parser TimeZone.Offset := do
+  let c ← peek?
+  if let some ch := c then
+    if ch.isDigit || ch == '+' || ch == '-' then posixParseOffset
+    else pure ⟨Second.Offset.ofInt (stdOffset.second.val + defaultDstAheadSeconds)⟩
+  else pure ⟨Second.Offset.ofInt (stdOffset.second.val + defaultDstAheadSeconds)⟩
+
+-- <rule-spec> ::= "M" <month> "." <week> "." <weekday> | "J" <n> | <n>
+private def posixParseSpec : Parser PosixTransSpec :=
+  attempt posixParseMwdSpec <|> attempt posixParseJulianSpec <|> posixParseJulian0Spec
+
+-- <rule> ::= <rule-spec> [ "/" <time> ]
+-- When `extended` is true, hours may range from -167 to 167 (TZif v3+).
+private def posixParseRule (extended : Bool := false) : Parser PosixTransRule := do
+  let spec ← posixParseSpec
+
+  let time ← attempt (do
+    skipChar '/'
+    let sign ← posixParseSign
+    let t ← posixParseHMS (maxHour := if extended then extendedMaxHour else posixMaxHour)
+    return Second.Offset.ofInt (sign * t.val)) <|> pure (Second.Offset.ofInt defaultTransitionTime)
+
+  return { spec, time }
+
+-- <TZ> ::= <std> <offset> [ <dst> [ <offset> ] [ "," <rule> "," <rule> ] ]
+private def parsePosixTzP (extended : Bool := false) : Parser PosixTzInfo := do
+  let stdName ← posixParseName
+
+  if stdName.isEmpty then
+    fail "empty timezone name"
+
+  let stdOffset ← posixParseOffset
+
+  if (← isEof) then
+    return { stdName, stdOffset, dstOffset := stdOffset }
+
+  -- <dst>
+  let dstName ← posixParseName
+
+  if dstName.isEmpty then
+    return { stdName, stdOffset, dstOffset := stdOffset }
+
+  -- <dst>
+  let dstOffset ← posixParseDstOffset stdOffset
+
+  -- [ <offset> ]
+  if (← peek?) != some ',' then
+    return { stdName, stdOffset, dstName, dstOffset }
+
+  -- [ "," <rule> "," <rule> ]
+  let startRule ← skip *> posixParseRule extended
+  let endRule ← skipChar ',' *> posixParseRule extended
+
+  return { stdName, stdOffset, dstName, dstOffset, start := some startRule, end_ := some endRule }
+
+/--
+Parse a POSIX TZ footer string into a `PosixTzInfo`, returning `none` on failure.
+
+When `extended` is `true`, transition times accept signed hours in the range
+-`extendedMaxHour` to `extendedMaxHour` instead of the POSIX-required 0 to `posixMaxHour` (TZif version 3+).
+-/
+def parsePosixTz (s : String) (extended : Bool := false) : Option PosixTzInfo :=
+  ((parsePosixTzP extended).run s).toOption
+
+end Std.Time.TimeZone

--- a/src/Std/Time/Zoned/DateTime.lean
+++ b/src/Std/Time/Zoned/DateTime.lean
@@ -382,7 +382,7 @@ Getter for the `Milliseconds` inside of a `DateTime`
 -/
 @[inline]
 def millisecond (dt : DateTime tz) : Millisecond.Ordinal :=
-  dt.date.get.time.nanosecond.emod 1000 (by decide)
+  dt.date.get.time.millisecond
 
 /--
 Getter for the `Nanosecond` inside of a `DateTime`

--- a/src/Std/Time/Zoned/DateTime.lean
+++ b/src/Std/Time/Zoned/DateTime.lean
@@ -441,7 +441,7 @@ on the day of the month and the weekday. Each week starts on Monday because the 
 based on the Gregorian Calendar.
 -/
 @[inline]
-def alignedWeekOfMonth (date : DateTime tz) : Week.Ordinal.OfMonth :=
+def alignedWeekOfMonth (date : DateTime tz) : Week.Aligned.Ordinal :=
   date.date.get.alignedWeekOfMonth
 
 /--

--- a/src/Std/Time/Zoned/RecurringRule.lean
+++ b/src/Std/Time/Zoned/RecurringRule.lean
@@ -1,0 +1,156 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sofia Rodrigues
+-/
+module
+
+prelude
+public import Std.Time.Date.Unit.Month
+public import Std.Time.Date.Unit.Week
+public import Std.Time.Date.Unit.Weekday
+public import Std.Time.Zoned.Offset
+public import Std.Time.DateTime
+
+/-!
+Types for recurring DST transition rules, used by `ZoneRules` and produced by POSIX TZ parsing.
+-/
+
+public section
+
+namespace Std.Time.TimeZone
+open Internal
+
+/--
+Specifies how a DST transition date is expressed.
+-/
+inductive TransitionSpec where
+
+  /--
+  `Mm.w.d` form: month `m`, week `w` (1–5; 5 = last), ISO weekday `d`.
+  -/
+  | mwd (month : Month.Ordinal) (week : Week.Ordinal.OfMonth) (day : Weekday.Ordinal)
+
+  /--
+  `Jn` form: Julian day 1–365 (Feb 29 never counted, even in leap years).
+  -/
+  | julian (day : Bounded.LE 1 365)
+
+  /--
+  `n` form: zero-based day 0–365 (Feb 29 counted in leap years).
+  -/
+  | julian0 (day : Bounded.LE 0 365)
+deriving Repr
+
+namespace TransitionSpec
+
+/--
+Returns the `Day.Offset` (days since epoch) for a `TransitionSpec.mwd` in the given year.
+
+`Mm.w.d`: month `m`, week `w` (1–5; 5 = last), ISO weekday `d` (1 = Monday, 7 = Sunday).
+Finds the `w`-th occurrence of weekday `d` in month `m`; if `w = 5`, returns the last occurrence.
+-/
+def toEpochDayMWD (year : Year.Offset) (month : Month.Ordinal) (week : Week.Ordinal.OfMonth) (day : Weekday.Ordinal) : Day.Offset :=
+  if week.val == 5 then
+    -- "week 5" means the last occurrence of `day` in `month`.
+    -- Start from the last day of the month and walk backwards to the desired weekday.
+    let lastDay := month.days year.isLeap
+    let lastOfMonth := PlainDate.ofYearMonthDayClip year month lastDay
+    let lastWday := lastOfMonth.weekday.toOrdinal -- 1 = Monday … 7 = Sunday
+    let diff : Bounded.LE 0 6 := (lastWday.subBounds day).emod 7 (by decide)
+    lastOfMonth.toEpochDay - Day.Offset.ofInt diff.val
+  else
+    let firstOfMonth := PlainDate.ofYearMonthDayClip year month 1 -- First day of the month
+    let firstWday := firstOfMonth.weekday.toOrdinal -- Weekday of the first day (1 = Monday … 7 = Sunday)
+    let diff : Bounded.LE 0 6 := (day.subBounds firstWday).emod 7 (by decide)
+    let firstOccurrence := firstOfMonth.toEpochDay + Day.Offset.ofInt diff.val
+    let extra : Bounded.LE 0 28 := ((week.sub 1).mul_pos 7 (by decide))
+    let extra := Day.Offset.ofInt extra.val
+    firstOccurrence + extra
+
+/--
+Returns the `Day.Offset` (days since epoch) for a `TransitionSpec.julian` in the given year.
+
+`Jn`: Julian day 1–365. Feb 29 is never counted, so in a leap year days ≥ 60 are shifted by one.
+-/
+def toEpochDayJulian (year : Year.Offset) (day : Bounded.LE 1 365) : Day.Offset :=
+  let jan1 := PlainDate.ofYearMonthDayClip year 1 1
+  let extra : Int := if year.isLeap && day.val >= 60 then 1 else 0
+  jan1.toEpochDay + Day.Offset.ofInt (day.val - 1 + extra)
+
+/--
+Returns the `Day.Offset` (days since epoch) for a `TransitionSpec.julian0` in the given year.
+
+`n`: zero-based day 0–365. Feb 29 is counted normally in leap years.
+-/
+def toEpochDayJulian0 (year : Year.Offset) (day : Bounded.LE 0 365) : Day.Offset :=
+  let jan1 := PlainDate.ofYearMonthDayClip year 1 1
+  jan1.toEpochDay + Day.Offset.ofInt day.val
+
+/--
+Returns the `Day.Offset` (days since epoch) for this `TransitionSpec` in the given year.
+-/
+def toEpochDay (spec : TransitionSpec) (year : Year.Offset) : Day.Offset :=
+  match spec with
+  | .mwd month week day => toEpochDayMWD year month week day
+  | .julian day => toEpochDayJulian year day
+  | .julian0 day => toEpochDayJulian0 year day
+
+end TransitionSpec
+
+/--
+A single DST transition rule: a date specification and a wall-clock time.
+-/
+structure TransitionRule where
+
+  /--
+  How the transition date is specified.
+  -/
+  spec : TransitionSpec
+
+  /--
+  Time of day as seconds from midnight (default 7200 = 02:00).
+
+  "The time has the same format as offset except that no leading sign ( '-' or '+' ) is allowed. The default, if time is not given, shall be 02:00:00."
+  $8.3 https://pubs.opengroup.org/onlinepubs/9699919799/
+  -/
+  time : Second.Offset := 7200
+deriving Repr
+
+/--
+Recurring rule describing standard and DST zones, as found in a POSIX TZ string or TZif footer.
+-/
+structure RecurringRule where
+
+  /--
+  Standard time abbreviation.
+  -/
+  stdName : String
+
+  /--
+  Standard UTC offset (east-positive).
+  -/
+  stdOffset : TimeZone.Offset
+
+  /--
+  DST abbreviation (empty when no DST).
+  -/
+  dstName : String := ""
+
+  /--
+  DST UTC offset (east-positive).
+  -/
+  dstOffset : TimeZone.Offset
+
+  /--
+  Rule for the start of DST, if any.
+  -/
+  start : Option TransitionRule := none
+
+  /--
+  Rule for the end of DST, if any.
+  -/
+  end_ : Option TransitionRule := none
+deriving Repr
+
+end Std.Time.TimeZone

--- a/src/Std/Time/Zoned/ZoneRules.lean
+++ b/src/Std/Time/Zoned/ZoneRules.lean
@@ -145,28 +145,26 @@ def createTimeZoneFromTransition (transition : Transition) : TimeZone :=
   TimeZone.mk offset name abbreviation transition.localTimeType.isDst
 
 /--
-Applies the transition to a Timestamp.
--/
-def apply (timestamp : Timestamp) (transition : Transition) : Timestamp :=
-  let offsetInSeconds := transition.localTimeType.gmtOffset.second
-  timestamp.addSeconds offsetInSeconds
-
-/--
-Finds the transition corresponding to a given timestamp in `Array Transition`.
-If the timestamp falls between two transitions, it returns the most recent transition before the timestamp.
+Finds the index of the transition in effect at a given timestamp in `Array Transition`.
+Returns the index of the most recent transition that started at or before the timestamp,
+or `none` if the timestamp precedes all transitions.
 -/
 def findTransitionIndexForTimestamp (transitions : Array Transition) (timestamp : Timestamp) : Option Nat :=
   let value := timestamp.toSecondsSinceUnixEpoch
-  transitions.findIdx? (fun t => t.time.val > value.val)
+  match transitions.findIdx? (fun t => t.time.val > value.val) with
+  | some 0 => none
+  | some i => some (i - 1)
+  | none => if transitions.isEmpty then none else some (transitions.size - 1)
 
 /--
-Finds the transition corresponding to a given timestamp in `Array Transition`.
-If the timestamp falls between two transitions, it returns the most recent transition before the timestamp.
+Finds the transition in effect at a given timestamp in `Array Transition`.
+Returns the most recent transition that started at or before the timestamp,
+or `none` if the timestamp precedes all transitions.
 -/
 def findTransitionForTimestamp (transitions : Array Transition) (timestamp : Timestamp) : Option Transition :=
   if let some idx := findTransitionIndexForTimestamp transitions timestamp
-    then if idx == 0 then none else transitions[idx - 1]?
-    else transitions.back?
+    then transitions[idx]?
+    else none
 
 /--
 Find the current `TimeZone` out of a `Transition` in a `Array Transition`

--- a/src/Std/Time/Zoned/ZoneRules.lean
+++ b/src/Std/Time/Zoned/ZoneRules.lean
@@ -148,7 +148,7 @@ def createTimeZoneFromTransition (transition : Transition) : TimeZone :=
 Applies the transition to a Timestamp.
 -/
 def apply (timestamp : Timestamp) (transition : Transition) : Timestamp :=
-  let offsetInSeconds := transition.localTimeType.gmtOffset.second |>.add transition.localTimeType.gmtOffset.second
+  let offsetInSeconds := transition.localTimeType.gmtOffset.second
   timestamp.addSeconds offsetInSeconds
 
 /--

--- a/src/Std/Time/Zoned/ZoneRules.lean
+++ b/src/Std/Time/Zoned/ZoneRules.lean
@@ -165,7 +165,7 @@ If the timestamp falls between two transitions, it returns the most recent trans
 -/
 def findTransitionForTimestamp (transitions : Array Transition) (timestamp : Timestamp) : Option Transition :=
   if let some idx := findTransitionIndexForTimestamp transitions timestamp
-    then transitions[idx - 1]?
+    then if idx == 0 then none else transitions[idx - 1]?
     else transitions.back?
 
 /--

--- a/src/Std/Time/Zoned/ZoneRules.lean
+++ b/src/Std/Time/Zoned/ZoneRules.lean
@@ -8,6 +8,7 @@ module
 prelude
 public import Std.Time.DateTime
 public import Std.Time.Zoned.TimeZone
+public import Std.Time.Zoned.RecurringRule
 
 public section
 
@@ -125,7 +126,11 @@ structure ZoneRules where
   -/
   transitions : Array Transition
 
-  deriving Repr, Inhabited
+  /--
+  Recurring rule from the TZif footer, used to extrapolate transitions beyond the last stored entry.
+  -/
+  transitionRule : Option RecurringRule := none
+deriving Repr, Inhabited
 
 namespace Transition
 
@@ -175,6 +180,44 @@ def timezoneAt (transitions : Array Transition) (tm : Timestamp) : Except String
     else .error "cannot find local timezone."
 
 end Transition
+namespace RecurringRule
+
+-- `wallOffset` is the offset in effect at the wall-clock moment of this transition:
+-- DST-start times are given in standard time; DST-end times are given in DST time.
+private def transitionUtcSeconds (rule : TransitionRule) (year : Year.Offset) (wallOffset : Offset) : Second.Offset :=
+  (TransitionSpec.toEpochDay rule.spec year).toSeconds + rule.time - wallOffset.second
+
+/--
+Returns the `TimeZone` in effect for this `RecurringRule` at the given `Timestamp`.
+
+If no DST transition rules are defined (`start` or `end_` is `none`), the standard zone is
+returned unconditionally. Otherwise the function computes the UTC timestamps at which DST starts
+and ends for the year containing `tm`, and returns the DST zone when the timestamp falls inside
+the DST interval (accounting for rules that wrap across a year boundary in the Southern Hemisphere).
+-/
+def timezoneAt (rule : RecurringRule) (tm : Timestamp) : TimeZone := Id.run do
+  let stdTz := TimeZone.mk rule.stdOffset rule.stdName rule.stdName false
+  let dstTz := TimeZone.mk rule.dstOffset rule.dstName rule.dstName true
+
+  let some startRule := rule.start | return stdTz
+  let some endRule   := rule.end_  | return stdTz
+
+  let secs := tm.toSecondsSinceUnixEpoch
+
+  let year  := PlainDate.ofEpochDay (Day.Offset.ofSeconds secs) |>.year
+
+  -- DST-start wall clock is standard time; DST-end wall clock is DST time (POSIX §8.3).
+  let dstStart := transitionUtcSeconds startRule year rule.stdOffset
+  let dstEnd   := transitionUtcSeconds endRule year rule.dstOffset
+
+  if dstStart ≤ dstEnd then
+    if dstStart ≤ secs && secs < dstEnd then dstTz else stdTz
+  else
+    -- Southern Hemisphere: DST spans the year boundary
+    if secs < dstEnd || dstStart ≤ secs then dstTz else stdTz
+
+end RecurringRule
+
 namespace ZoneRules
 
 /--
@@ -215,6 +258,10 @@ def findLocalTimeTypeForTimestamp (zr : ZoneRules) (timestamp : Timestamp) : Loc
 Finds the `LocalTimeType` for a given wall-clock time (seconds since 1970-01-01T00:00:00 in local time).
 Unlike `findLocalTimeTypeForTimestamp`, this compares each transition's UTC time adjusted by the
 previous offset — necessary when converting local time to UTC.
+
+When the wall time falls beyond all stored transitions and a `transitionRule` is present, the
+recurring rule is used to determine the timezone (converting the wall time to UTC via the last
+known offset before consulting the rule).
 -/
 def findLocalTimeTypeForWallTime (zr : ZoneRules) (wallTime : WallTime) : LocalTimeType := Id.run do
   let mut ltt := zr.initialLocalTimeType
@@ -224,6 +271,12 @@ def findLocalTimeTypeForWallTime (zr : ZoneRules) (wallTime : WallTime) : LocalT
     if wallTime < localTransitionTime then
       return ltt
     ltt := t.localTimeType
+
+  if let some rule := zr.transitionRule then
+    -- Convert wall time to an approximate UTC timestamp using the last known offset.
+    let approxUtc : Timestamp := wallTime.toTimestamp ltt.gmtOffset
+    let tz := rule.timezoneAt approxUtc
+    return { ltt with gmtOffset := tz.offset, isDst := tz.isDST, abbreviation := tz.abbreviation, identifier := tz.name }
 
   return ltt
 
@@ -242,6 +295,6 @@ Creates `ZoneRules` for the given `TimeZone`.
 @[inline]
 def ofTimeZone (tz : TimeZone) : ZoneRules :=
   let ltt :=  LocalTimeType.mk tz.offset tz.isDST tz.abbreviation .wall .local tz.name
-  ZoneRules.mk ltt #[]
+  ZoneRules.mk ltt #[] none
 
 end ZoneRules

--- a/src/Std/Time/Zoned/ZonedDateTime.lean
+++ b/src/Std/Time/Zoned/ZonedDateTime.lean
@@ -215,7 +215,7 @@ on the day of the month and the weekday. Each week starts on Monday because the 
 based on the Gregorian Calendar.
 -/
 @[inline]
-def alignedWeekOfMonth (date : ZonedDateTime) : Week.Ordinal.OfMonth :=
+def alignedWeekOfMonth (date : ZonedDateTime) : Week.Aligned.Ordinal :=
   date.date.get.alignedWeekOfMonth
 
 /--

--- a/tests/elab/timeIO.lean
+++ b/tests/elab/timeIO.lean
@@ -81,3 +81,52 @@ info: 2003-10-26T01:59:59.000000000-05:00
   println! "{ZonedDateTime.ofPlainDateTime datetime("2003-10-26T01:59:59") zr |>.toLeanDateTimeWithZoneString}"
   println! "{ZonedDateTime.ofPlainDateTime datetime("2003-10-26T02:00:00") zr |>.toLeanDateTimeWithZoneString}"
   println! "{ZonedDateTime.ofPlainDateTime datetime("2003-10-26T02:59:59") zr |>.toLeanDateTimeWithZoneString}"
+
+-- ZoneRules.findTransitionForTimestamp: a timestamp one second before the first transition
+-- uses initialLocalTimeType (LMT), not the first post-transition type.
+/--
+info: true
+-/
+#guard_msgs in
+#eval show IO Bool from do
+  let rules ← Database.defaultGetZoneRules "America/New_York"
+  if h : 0 < rules.transitions.size then
+    let first := rules.transitions[0]
+    let beforeFirst := Timestamp.ofSecondsSinceUnixEpoch ⟨first.time.val - 1⟩
+    let zdt := ZonedDateTime.ofTimestamp beforeFirst rules
+    return zdt.timezone.name == rules.initialLocalTimeType.identifier
+  else
+    return true
+
+-- ZonedDateTime.ofPlainDateTime resolves local wall-clock time using the correct offset sign.
+-- UTC+2 → UTC+3 spring-forward at UTC t=3600: gap is local 03:00–04:00.
+def bugZonePlus : TimeZone.ZoneRules :=
+  let before : TimeZone.LocalTimeType := {
+    gmtOffset := .ofSeconds 7200,
+    isDst := false, abbreviation := "TST2",
+    wall := .standard, utLocal := .ut, identifier := "Test/Plus2"
+  }
+  let after : TimeZone.LocalTimeType := {
+    gmtOffset := .ofSeconds 10800,
+    isDst := true, abbreviation := "TST3",
+    wall := .standard, utLocal := .ut, identifier := "Test/Plus3"
+  }
+  { initialLocalTimeType := before, transitions := #[⟨3600, after⟩] }
+
+/--
+info: "Test/Plus2"
+-/
+#guard_msgs in
+#eval
+  let pdt : PlainDateTime :=
+    ⟨PlainDate.ofYearMonthDayClip 1970 1 1, PlainTime.ofHourMinuteSecondsNano 2 30 0 0⟩
+  (ZonedDateTime.ofPlainDateTime pdt bugZonePlus).timezone.name
+
+/--
+info: "Test/Plus3"
+-/
+#guard_msgs in
+#eval
+  let pdt : PlainDateTime :=
+    ⟨PlainDate.ofYearMonthDayClip 1970 1 1, PlainTime.ofHourMinuteSecondsNano 4 30 0 0⟩
+  (ZonedDateTime.ofPlainDateTime pdt bugZonePlus).timezone.name

--- a/tests/elab/timeOperations.lean
+++ b/tests/elab/timeOperations.lean
@@ -317,3 +317,22 @@ info: 4
 -/
 #guard_msgs in
 #eval date("2024-01-22").alignedWeekOfMonth
+
+-- DateTime.millisecond delegates to PlainTime.millisecond (ediv 1000000), not emod 1000.
+/--
+info: 123
+-/
+#guard_msgs in
+#eval
+  let t := PlainTime.ofHourMinuteSecondsNano 10 30 ⟨0, by decide⟩ ⟨123456789, by decide⟩
+  let dt : DateTime .UTC := DateTime.ofPlainDateTime ⟨PlainDate.ofYearMonthDayClip 2024 .august 15, t⟩ .UTC
+  dt.millisecond.val
+
+-- PlainTime.addMilliseconds preserves sub-millisecond nanoseconds (uses nanosecond arithmetic).
+/--
+info: 501500000
+-/
+#guard_msgs in
+#eval
+  let t := PlainTime.ofHourMinuteSecondsNano 0 0 ⟨0, by decide⟩ ⟨500500000, by decide⟩
+  (t.addMilliseconds 1).nanosecond.val

--- a/tests/elab/timeParse.lean
+++ b/tests/elab/timeParse.lean
@@ -202,3 +202,31 @@ info: Except.error "offset 13: need a natural number in the interval of 1 to 12"
 #eval
     let t2 := Full12HourWrong.parse "05/10/1993 20:30:23 PM +03:00"
     (ISO8601UTC.format ·.toDateTime) <$> t2
+
+-- 12-hour clock (`h`) without AM/PM marker: the parsed hour is used as-is (AM assumed).
+def fmtH12NoAmPm : GenericFormat .any := datespec("hh:mm:ss")
+def fmtH12NoAmPmFull : GenericFormat .any := datespec("uuuu-MM-dd hh:mm:ss")
+
+/--
+info: "0000-01-01T05:30:00.000000000Z"
+-/
+#guard_msgs in
+#eval
+  let t : ZonedDateTime := fmtH12NoAmPm.parse! "05:30:00"
+  ISO8601UTC.format t.toDateTime
+
+/--
+info: "0000-01-01T11:45:20.000000000Z"
+-/
+#guard_msgs in
+#eval
+  let t : ZonedDateTime := fmtH12NoAmPm.parse! "11:45:20"
+  ISO8601UTC.format t.toDateTime
+
+/--
+info: "2024-08-15T09:15:00.000000000Z"
+-/
+#guard_msgs in
+#eval
+  let t : ZonedDateTime := fmtH12NoAmPmFull.parse! "2024-08-15 09:15:00"
+  ISO8601UTC.format t.toDateTime

--- a/tests/elab/timeParse.lean
+++ b/tests/elab/timeParse.lean
@@ -84,7 +84,7 @@ info: "2024-08-16T01:28:00.000000000Z"
     ISO8601UTC.format t.toDateTime
 
 /--
-info: "0000-12-31T22:28:12.000000000+09:00"
+info: "0000-01-01T22:28:12.000000000+09:00"
 -/
 #guard_msgs in
 #eval
@@ -92,7 +92,7 @@ info: "0000-12-31T22:28:12.000000000+09:00"
     ISO8601UTC.format (t.toDateTime.convertTimeZone jpTZ)
 
 /--
-info: "0000-12-31T00:00:00.000000000-03:00"
+info: "0000-01-01T00:00:00.000000000-03:00"
 -/
 #guard_msgs in
 #eval

--- a/tests/elab/timeSet.lean
+++ b/tests/elab/timeSet.lean
@@ -98,3 +98,13 @@ info: zoned("2014-06-16T10:03:03.000000002-03:00")
 -/
 #guard_msgs in
 #eval date₁.withNanoseconds 2
+
+-- PlainTime.withMilliseconds preserves microseconds (uses emod 1000000, not emod 1000).
+-- nanosecond=123456789 → 123 ms + 456 µs + 789 ns; setting millis=5 → 5456789 ns.
+/--
+info: 5456789
+-/
+#guard_msgs in
+#eval
+  let t := PlainTime.ofHourMinuteSecondsNano 10 30 ⟨0, by decide⟩ ⟨123456789, by decide⟩
+  (t.withMilliseconds ⟨5, by decide⟩).nanosecond.val

--- a/tests/elab/timeSub.lean
+++ b/tests/elab/timeSub.lean
@@ -53,3 +53,48 @@ info: true
 -/
 #guard_msgs in
 #eval (t + dur - dur) == t
+
+-- Duration.toMilliseconds uses truncation division (consistent with ofNanoseconds).
+-- Negative sub-millisecond values round toward zero, not toward negative infinity.
+
+/--
+info: 0
+-/
+#guard_msgs in
+#eval (Duration.ofNanoseconds (-999999)).toMilliseconds.val
+
+/--
+info: 0
+-/
+#guard_msgs in
+#eval (Duration.ofNanoseconds (-1)).toMilliseconds.val
+
+/--
+info: -1
+-/
+#guard_msgs in
+#eval (Duration.ofNanoseconds (-1000000)).toMilliseconds.val
+
+/--
+info: -1
+-/
+#guard_msgs in
+#eval (Duration.ofNanoseconds (-1999999)).toMilliseconds.val
+
+/--
+info: 0
+-/
+#guard_msgs in
+#eval (Duration.ofNanoseconds 999999).toMilliseconds.val
+
+/--
+info: 1
+-/
+#guard_msgs in
+#eval (Duration.ofNanoseconds 1000000).toMilliseconds.val
+
+/--
+info: 1
+-/
+#guard_msgs in
+#eval (Duration.ofNanoseconds 1999999).toMilliseconds.val

--- a/tests/elab/timeTzifParse.lean
+++ b/tests/elab/timeTzifParse.lean
@@ -140,11 +140,3 @@ def testTransitionApply : TimeZone.Transition :=
       wall := .standard, utLocal := .ut, identifier := "Test/Zone"
     }
   }
-
-/--
-info: 4600
--/
-#guard_msgs in
-#eval
-  let t := Timestamp.ofSecondsSinceUnixEpoch 1000
-  (TimeZone.Transition.apply t testTransitionApply).toSecondsSinceUnixEpoch.val

--- a/tests/elab/timeTzifParse.lean
+++ b/tests/elab/timeTzifParse.lean
@@ -108,3 +108,43 @@ info: zoned("2012-12-10T00:35:47.000000000-02:00")
 -/
 #guard_msgs in
 #eval ZonedDateTime.ofTimestamp (Timestamp.ofSecondsSinceUnixEpoch 1355106947) rules
+
+-- ZoneRules.findTransitionForTimestamp: a timestamp before the first transition uses initialLocalTimeType.
+def testZoneRulesInitialLTT : TimeZone.ZoneRules :=
+  let initLTT : TimeZone.LocalTimeType := {
+    gmtOffset := .ofSeconds 3600,
+    isDst := false, abbreviation := "TST1",
+    wall := .standard, utLocal := .ut, identifier := "Test/Zone1"
+  }
+  let transLTT : TimeZone.LocalTimeType := {
+    gmtOffset := .ofSeconds 7200,
+    isDst := false, abbreviation := "TST2",
+    wall := .standard, utLocal := .ut, identifier := "Test/Zone2"
+  }
+  { initialLocalTimeType := initLTT, transitions := #[⟨100, transLTT⟩] }
+
+/--
+info: "Test/Zone1"
+-/
+#guard_msgs in
+#eval
+  let tm := Timestamp.ofSecondsSinceUnixEpoch 50
+  (ZonedDateTime.ofTimestamp tm testZoneRulesInitialLTT).timezone.name
+
+-- Transition.apply adds the GMT offset exactly once to the timestamp.
+def testTransitionApply : TimeZone.Transition :=
+  { time := 0
+    localTimeType := {
+      gmtOffset := .ofSeconds 3600,
+      isDst := false, abbreviation := "TST",
+      wall := .standard, utLocal := .ut, identifier := "Test/Zone"
+    }
+  }
+
+/--
+info: 4600
+-/
+#guard_msgs in
+#eval
+  let t := Timestamp.ofSecondsSinceUnixEpoch 1000
+  (TimeZone.Transition.apply t testTransitionApply).toSecondsSinceUnixEpoch.val

--- a/tests/elab/timeZoneTransitionLookup.lean
+++ b/tests/elab/timeZoneTransitionLookup.lean
@@ -1,0 +1,94 @@
+import Std.Time
+open Std.Time TimeZone
+
+/-!
+Tests for `Transition.findTransitionIndexForTimestamp` and `findTransitionForTimestamp`,
+covering boundary conditions: timestamps exactly at a transition, one second before/after,
+before all transitions, after all transitions, and an empty array.
+-/
+
+private def mkLTT (abb : String) (offsetSecs : Int) : LocalTimeType :=
+  { gmtOffset := ⟨Second.Offset.ofInt offsetSecs⟩, isDst := false, abbreviation := abb,
+    wall := .standard, utLocal := .ut, identifier := abb }
+
+private def mkT (time : Int) (abb : String) (offsetSecs : Int) : Transition :=
+  { time := Second.Offset.ofInt time, localTimeType := mkLTT abb offsetSecs }
+
+-- Three transitions at t=100, t=200, t=300
+private def trans3 : Array Transition :=
+  #[mkT 100 "T0" 3600, mkT 200 "T1" 7200, mkT 300 "T2" 10800]
+
+private def ts (n : Int) : Timestamp :=
+  Timestamp.ofSecondsSinceUnixEpoch (Second.Offset.ofInt n)
+
+private def idxAt (n : Int) : Option Nat :=
+  Transition.findTransitionIndexForTimestamp trans3 (ts n)
+
+private def abbrevAt (n : Int) : Option String :=
+  (Transition.findTransitionForTimestamp trans3 (ts n)) |>.map (·.localTimeType.abbreviation)
+
+-- 1. Before all transitions → none
+/-- info: none -/
+#guard_msgs in #eval idxAt 50
+
+-- 2. One second before first transition → none
+/-- info: none -/
+#guard_msgs in #eval idxAt 99
+
+-- 3. Exactly at first transition → some 0
+/-- info: some 0 -/
+#guard_msgs in #eval idxAt 100
+
+-- 4. One second after first transition → some 0
+/-- info: some 0 -/
+#guard_msgs in #eval idxAt 101
+
+-- 5. One second before second transition → some 0
+/-- info: some 0 -/
+#guard_msgs in #eval idxAt 199
+
+-- 6. Exactly at second transition → some 1
+/-- info: some 1 -/
+#guard_msgs in #eval idxAt 200
+
+-- 7. Between second and third transition → some 1
+/-- info: some 1 -/
+#guard_msgs in #eval idxAt 250
+
+-- 8. Exactly at last transition → some 2
+/-- info: some 2 -/
+#guard_msgs in #eval idxAt 300
+
+-- 9. After all transitions → some 2 (last)
+/-- info: some 2 -/
+#guard_msgs in #eval idxAt 400
+
+-- 10. Empty array → none
+/-- info: none -/
+#guard_msgs in #eval Transition.findTransitionIndexForTimestamp #[] (ts 100)
+
+-- Verify the correct LocalTimeType is returned in each case
+
+-- Before all transitions → none
+/-- info: none -/
+#guard_msgs in #eval abbrevAt 50
+
+-- Exactly at first transition → "T0"
+/-- info: some "T0" -/
+#guard_msgs in #eval abbrevAt 100
+
+-- One second before second transition → "T0"
+/-- info: some "T0" -/
+#guard_msgs in #eval abbrevAt 199
+
+-- Exactly at second transition → "T1"
+/-- info: some "T1" -/
+#guard_msgs in #eval abbrevAt 200
+
+-- After all transitions → "T2"
+/-- info: some "T2" -/
+#guard_msgs in #eval abbrevAt 400
+
+-- Negative timestamp (pre-epoch): before first transition → none
+/-- info: none -/
+#guard_msgs in #eval Transition.findTransitionIndexForTimestamp trans3 (ts (-1))


### PR DESCRIPTION
This PR fixes a off-by-one in toSeconds and wrong day count in Year.days
