### PR TITLE
test: regression test for #9037

### DIFF
--- a/tests/elab/doNotation7.lean
+++ b/tests/elab/doNotation7.lean
@@ -38,6 +38,17 @@ example (arr : Array Nat) : Unit := Id.run do
         continue
       abc := 0
 
+-- #9037
+def test9037 (x : Option Nat) : Nat := Id.run do
+  let mut i ←
+    match x with
+    | .some v =>
+      pure v
+    | none =>
+      pure 0
+  i := i + 1
+  return i
+
 -- #8119
 /--
 error: Type mismatch


### PR DESCRIPTION
This PR adds a regression test for #9037 (`let mut i ← match …` followed by `i := i + 1`) to `tests/elab/doNotation7.lean`. The legacy `do` elaborator parsed the reassignment as part of the `match` body; the new elaborator scopes it correctly.

Stacked on top of #13541. Re-target to `master` if/when that lands first.