### PR TITLE
fix: remove @[expose] when unnecessary, fixing stage2 warnings in #13823

### DIFF
--- a/src/Init/Control/Except.lean
+++ b/src/Init/Control/Except.lean
@@ -128,7 +128,7 @@ end Except
 /--
 Adds exceptions of type `ε` to a monad `m`.
 -/
-@[expose, implicit_reducible] def ExceptT (ε : Type u) (m : Type u → Type v) (α : Type u) : Type v :=
+@[implicit_reducible] def ExceptT (ε : Type u) (m : Type u → Type v) (α : Type u) : Type v :=
   m (Except ε α)
 
 /--

--- a/src/Init/Core.lean
+++ b/src/Init/Core.lean
@@ -1331,7 +1331,7 @@ def Subrelation {α : Sort u} (q r : α → α → Prop) :=
 The inverse image of `r : β → β → Prop` by a function `α → β` is the relation
 `s : α → α → Prop` defined by `s a b = r (f a) (f b)`.
 -/
-@[expose, implicit_reducible] def InvImage {α : Sort u} {β : Sort v} (r : β → β → Prop) (f : α → β) : α → α → Prop :=
+@[implicit_reducible] def InvImage {α : Sort u} {β : Sort v} (r : β → β → Prop) (f : α → β) : α → α → Prop :=
   fun a₁ a₂ => r (f a₁) (f a₂)
 
 /--
@@ -1478,7 +1478,7 @@ Examples:
  * `(1, 2).map (· + 1) (· * 3) = (2, 6)`
  * `(1, 2).map toString (· * 3) = ("1", 6)`
 -/
-@[expose, implicit_reducible] def Prod.map {α₁ : Type u₁} {α₂ : Type u₂} {β₁ : Type v₁} {β₂ : Type v₂}
+@[implicit_reducible] def Prod.map {α₁ : Type u₁} {α₂ : Type u₂} {β₁ : Type v₁} {β₂ : Type v₂}
     (f : α₁ → α₂) (g : β₁ → β₂) : α₁ × β₁ → α₂ × β₂
   | (a, b) => (f a, g b)
 

--- a/src/Init/Data/BitVec/Basic.lean
+++ b/src/Init/Data/BitVec/Basic.lean
@@ -559,7 +559,7 @@ As a numeric operation, this is equivalent to `x / 2^s`, rounding down.
 
 SMT-LIB name: `bvlshr` except this operator uses a `Nat` shift value.
 -/
-@[expose, implicit_reducible]
+@[implicit_reducible]
 def ushiftRight (x : BitVec n) (s : Nat) : BitVec n :=
   (x.toNat >>> s)#'(by
   let ⟨x, lt⟩ := x
@@ -577,7 +577,7 @@ As a numeric operation, this is equivalent to `x.toInt >>> s`.
 
 SMT-LIB name: `bvashr` except this operator uses a `Nat` shift value.
 -/
-@[expose, implicit_reducible]
+@[implicit_reducible]
 def sshiftRight (x : BitVec n) (s : Nat) : BitVec n := .ofInt n (x.toInt >>> s)
 
 instance {n} : HShiftLeft  (BitVec m) (BitVec n) (BitVec m) := ⟨fun x y => x <<< y.toNat⟩

--- a/src/Init/Data/Dyadic/Basic.lean
+++ b/src/Init/Data/Dyadic/Basic.lean
@@ -408,7 +408,7 @@ theorem ofIntWithPrec_shiftLeft_add {n : Nat} :
 
 /-- The "precision" of a dyadic number, i.e. in `n * 2^(-p)` with `n` odd the precision is `p`. -/
 -- TODO: If `WithBot` is upstreamed, replace this with `WithBot Int`.
-@[expose, implicit_reducible] def precision : Dyadic → Option Int
+@[implicit_reducible] def precision : Dyadic → Option Int
   | .zero => none
   | .ofOdd _ p _ => some p
 

--- a/src/Init/Data/Fin/Basic.lean
+++ b/src/Init/Data/Fin/Basic.lean
@@ -40,7 +40,7 @@ Examples:
  * `(2 : Fin 3).succ = (3 : Fin 4)`
  * `(2 : Fin 3) + 1 = (0 : Fin 3)`
 -/
-@[expose, instance_reducible] def succ : Fin n → Fin (n + 1)
+@[instance_reducible] def succ : Fin n → Fin (n + 1)
   | ⟨i, h⟩ => ⟨i+1, Nat.succ_lt_succ h⟩
 
 variable {n : Nat}
@@ -276,7 +276,7 @@ Examples:
  * `Fin.last 4 = (4 : Fin 5)`
  * `(Fin.last 0).val = (0 : Nat)`
 -/
-@[inline, implicit_reducible, expose] def last (n : Nat) : Fin (n + 1) := ⟨n, n.lt_succ_self⟩
+@[inline, implicit_reducible] def last (n : Nat) : Fin (n + 1) := ⟨n, n.lt_succ_self⟩
 
 /--
 Replaces the bound with another that is suitable for the value.
@@ -302,14 +302,14 @@ Coarsens a bound to one at least as large.
 See also `Fin.castAdd` for a version that represents the larger bound with addition rather than an
 explicit inequality proof.
 -/
-@[inline, expose, implicit_reducible] def castLE (h : n ≤ m) (i : Fin n) : Fin m := ⟨i, Nat.lt_of_lt_of_le i.2 h⟩
+@[inline, implicit_reducible] def castLE (h : n ≤ m) (i : Fin n) : Fin m := ⟨i, Nat.lt_of_lt_of_le i.2 h⟩
 
 /--
 Uses a proof that two bounds are equal to allow a value bounded by one to be used with the other.
 
 In other words, when `eq : n = m`, `Fin.cast eq i` converts `i : Fin n` into a `Fin m`.
 -/
-@[inline, expose, implicit_reducible] protected def cast (eq : n = m) (i : Fin n) : Fin m := ⟨i, eq ▸ i.2⟩
+@[inline, implicit_reducible] protected def cast (eq : n = m) (i : Fin n) : Fin m := ⟨i, eq ▸ i.2⟩
 
 /--
 Coarsens a bound to one at least as large.
@@ -317,13 +317,13 @@ Coarsens a bound to one at least as large.
 See also `Fin.natAdd` and `Fin.addNat` for addition functions that increase the bound, and
 `Fin.castLE` for a version that uses an explicit inequality proof.
 -/
-@[inline, expose, implicit_reducible] def castAdd (m) : Fin n → Fin (n + m) :=
+@[inline, implicit_reducible] def castAdd (m) : Fin n → Fin (n + m) :=
   castLE <| Nat.le_add_right n m
 
 /--
 Coarsens a bound by one.
 -/
-@[inline, expose, implicit_reducible] def castSucc : Fin n → Fin (n + 1) := castAdd 1
+@[inline, implicit_reducible] def castSucc : Fin n → Fin (n + 1) := castAdd 1
 
 /--
 Adds a natural number to a `Fin`, increasing the bound.

--- a/src/Init/Data/Int/Basic.lean
+++ b/src/Init/Data/Int/Basic.lean
@@ -157,7 +157,7 @@ Examples:
  * `(7 : Int) + (6 : Int) = 13`
  * `(6 : Int) + (-6 : Int) = 0`
 -/
-@[extern "lean_int_add", expose, implicit_reducible]
+@[extern "lean_int_add", implicit_reducible]
 protected def add (m n : @& Int) : Int :=
   match m, n with
   | ofNat m, ofNat n => ofNat (m + n)
@@ -323,7 +323,7 @@ Examples:
  * `(0 : Int).natAbs = 0`
  * `(-11 : Int).natAbs = 11`
 -/
-@[extern "lean_nat_abs", expose, implicit_reducible]
+@[extern "lean_nat_abs", implicit_reducible]
 def natAbs (m : @& Int) : Nat :=
   match m with
   | ofNat m => m

--- a/src/Init/Data/Option/Basic.lean
+++ b/src/Init/Data/Option/Basic.lean
@@ -58,7 +58,7 @@ deriving instance BEq for Option
 @[simp, grind =] theorem map_some (a) (f : α → β) : (some a).map f = some (f a) := rfl
 
 /-- Lifts an optional value to any `Alternative`, sending `none` to `failure`. -/
-@[implicit_reducible, expose] def getM [Alternative m] : Option α → m α
+@[implicit_reducible] def getM [Alternative m] : Option α → m α
   | none     => failure
   | some a   => pure a
 
@@ -66,7 +66,7 @@ deriving instance BEq for Option
 @[simp, grind =] theorem getM_some [Alternative m] {a : α} : getM (some a) = (pure a : m α) := rfl
 
 /-- Returns `true` on `some x` and `false` on `none`. -/
-@[inline, implicit_reducible, expose] def isSome : Option α → Bool
+@[inline, implicit_reducible] def isSome : Option α → Bool
   | some _ => true
   | none   => false
 
@@ -82,7 +82,7 @@ Examples:
  * `(none : Option Nat).isNone = true`
  * `(some Nat.add).isNone = false`
 -/
-@[inline, implicit_reducible, expose] def isNone : Option α → Bool
+@[inline, implicit_reducible] def isNone : Option α → Bool
   | some _ => false
   | none   => true
 
@@ -118,7 +118,7 @@ Examples:
  * `(some 2).bind (Option.guard (· > 2)) = none`
  * `(some 4).bind (Option.guard (· > 2)) = some 4`
 -/
-@[inline, expose, implicit_reducible] protected def bind : Option α → (α → Option β) → Option β
+@[inline, implicit_reducible] protected def bind : Option α → (α → Option β) → Option β
   | none,   _ => none
   | some a, f => f a
 
@@ -194,7 +194,7 @@ Examples:
  * `none.filter (fun x : Nat => x % 2 == 0) = none`
  * `none.filter (fun x : Nat => true) = none`
 -/
-@[always_inline, inline, expose, implicit_reducible] protected def filter (p : α → Bool) : Option α → Option α
+@[always_inline, inline, implicit_reducible] protected def filter (p : α → Bool) : Option α → Option α
   | some a => if p a then some a else none
   | none   => none
 
@@ -206,7 +206,7 @@ Examples:
  * `(some 22).all (· % 2 == 0) = true
  * `none.all (fun x : Nat => x % 2 == 0) = true
 -/
-@[always_inline, inline, expose, implicit_reducible] protected def all (p : α → Bool) : Option α → Bool
+@[always_inline, inline, implicit_reducible] protected def all (p : α → Bool) : Option α → Bool
   | some a => p a
   | none   => true
 
@@ -221,7 +221,7 @@ Examples:
  * `(some 22).any (· % 2 == 0) = true
  * `none.any (fun x : Nat => true) = false
 -/
-@[always_inline, inline, expose, implicit_reducible] protected def any (p : α → Bool) : Option α → Bool
+@[always_inline, inline, implicit_reducible] protected def any (p : α → Bool) : Option α → Bool
   | some a => p a
   | none   => false
 
@@ -393,7 +393,7 @@ Examples:
  * `Option.guard (· > 2) 1 = none`
  * `Option.guard (· > 2) 5 = some 5`
 -/
-@[inline, expose, implicit_reducible] def guard (p : α → Bool) (a : α) : Option α :=
+@[inline, implicit_reducible] def guard (p : α → Bool) (a : α) : Option α :=
   if p a then some a else none
 
 /--
@@ -436,7 +436,7 @@ Examples:
  * `(some none).join = none`
  * `(some (some v)).join = some v`
 -/
-@[inline, expose, implicit_reducible] def join (x : Option (Option α)) : Option α := x.bind id
+@[inline, implicit_reducible] def join (x : Option (Option α)) : Option α := x.bind id
 
 @[simp, grind =] theorem join_none : (none : Option (Option α)).join = none := rfl
 @[simp, grind =] theorem join_some : (some o).join = o := rfl

--- a/src/Init/Grind/Ring/Envelope.lean
+++ b/src/Init/Grind/Ring/Envelope.lean
@@ -35,7 +35,7 @@ local instance : Std.Associative (· * · : α → α → α) where
 @[local simp] def r : (α × α) → (α × α) → Prop
   | (a, b), (c, d) => ∃ k, a + d + k = b + c + k
 
-@[implicit_reducible, expose]
+@[implicit_reducible]
 def Q := Quot (r α)
 
 variable {α}

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -128,7 +128,7 @@ difference for typeclass inference, since `T` and `T'` may have different
 typeclass instances on them. `show T' from e` is sugar for an `@id T' e`
 expression.
 -/
-@[inline, implicit_reducible, expose] def id {α : Sort u} (a : α) : α := a
+@[inline, implicit_reducible] def id {α : Sort u} (a : α) : α := a
 
 /--
 Function composition, usually written with the infix operator `∘`. A new function is created from
@@ -314,7 +314,7 @@ so if your goal is `¬p` you can use `intro h` to turn the goal into
 and `(hn h).elim` will prove anything.
 For more information: [Propositional Logic](https://lean-lang.org/theorem_proving_in_lean4/propositions_and_proofs.html#propositional-logic)
 -/
-@[expose, implicit_reducible] def Not (a : Prop) : Prop := a → False
+@[implicit_reducible] def Not (a : Prop) : Prop := a → False
 
 /--
 `False.elim : False → C` says that from `False`, any desired proposition
@@ -2923,7 +2923,7 @@ Examples:
  * `(some "hello").getD "goodbye" = "hello"`
  * `none.getD "goodbye" = "goodbye"`
 -/
-@[macro_inline, expose, implicit_reducible] def Option.getD (opt : Option α) (dflt : α) : α :=
+@[macro_inline, implicit_reducible] def Option.getD (opt : Option α) (dflt : α) : α :=
   match opt with
   | some x => x
   | none => dflt
@@ -3610,7 +3610,7 @@ A UTF-8 byte position that points at the end of a string, just after the last ch
 * `"abc".rawEndPos = ⟨3⟩`
 * `"L∃∀N".rawEndPos = ⟨8⟩`
 -/
-@[inline, expose, implicit_reducible] def String.rawEndPos (s : String) : String.Pos.Raw where
+@[inline, implicit_reducible] def String.rawEndPos (s : String) : String.Pos.Raw where
   byteIdx := utf8ByteSize s
 
 /--
@@ -4101,7 +4101,7 @@ overridden by `withReader`, but it cannot be mutated.
 Actions in the resulting monad are functions that take the local value as a parameter, returning
 ordinary actions in `m`.
 -/
-@[expose, implicit_reducible] def ReaderT (ρ : Type u) (m : Type u → Type v) (α : Type u) : Type (max u v) :=
+@[implicit_reducible] def ReaderT (ρ : Type u) (m : Type u → Type v) (α : Type u) : Type (max u v) :=
   (a : @&ρ) → m α
 
 /--

--- a/src/Init/WF.lean
+++ b/src/Init/WF.lean
@@ -519,7 +519,7 @@ The `wfParam` gadget is used internally during the construction of recursive fun
 wellfounded recursion, to keep track of the parameter for which the automatic introduction
 of `List.attach` (or similar) is plausible.
 -/
-@[expose, implicit_reducible] def wfParam {α : Sort u} (a : α) : α := a
+@[implicit_reducible] def wfParam {α : Sort u} (a : α) : α := a
 
 /--
 Reverse direction of `dite_eq_ite`. Used by the well-founded definition preprocessor to extend the

--- a/src/Std/Data/Iterators/Lemmas/Equivalence/HetT.lean
+++ b/src/Std/Data/Iterators/Lemmas/Equivalence/HetT.lean
@@ -187,7 +187,7 @@ attribute [-simp] HetT.mk.injEq
 /--
 Converts `PostconditionT m α` to `HetT m α`, preserving the postcondition property.
 -/
-@[expose, implicit_reducible]
+@[implicit_reducible]
 noncomputable def HetT.ofPostconditionT [Monad m] (x : PostconditionT m α) : HetT m α :=
   ⟨x.Property, inferInstance, USquash.deflate <$> x.operation⟩
 
@@ -199,7 +199,7 @@ Lifts `x : m α` into `HetT m α` with the trivial postcondition.
 
 Caution: This is not a lawful monad lifting function
 -/
-@[expose, implicit_reducible]
+@[implicit_reducible]
 noncomputable def HetT.lift {α : Type w} {m : Type w → Type w'} [Monad m] (x : m α) :
     HetT m α :=
   x
@@ -208,14 +208,14 @@ noncomputable def HetT.lift {α : Type w} {m : Type w → Type w'} [Monad m] (x 
 A universe-heterogeneous version of `Pure.pure`. Given `a : α`, it returns an element of `HetT m α`
 with the postcondition `(a = ·)`.
 -/
-@[expose, implicit_reducible] protected noncomputable def HetT.pure {m : Type w → Type w'} [Pure m] {α : Type v}
+@[implicit_reducible] protected noncomputable def HetT.pure {m : Type w → Type w'} [Pure m] {α : Type v}
     (a : α) : HetT m α :=
   ⟨(a = ·), inferInstance, pure (.deflate ⟨a, rfl⟩)⟩
 
 /--
 A generalization of `HetT.map` that provides the postcondition property to the mapping function.
 -/
-@[expose, implicit_reducible] protected noncomputable def HetT.pmap {m : Type w → Type w'} [Functor m] {α : Type u} {β : Type v}
+@[implicit_reducible] protected noncomputable def HetT.pmap {m : Type w → Type w'} [Functor m] {α : Type u} {β : Type v}
     (x : HetT m α) (f : (a : α) → x.Property a → β) : HetT m β :=
   have : Small.{w} (Subtype x.Property) := x.small
   have := Small.map x.Property f
@@ -224,14 +224,14 @@ A generalization of `HetT.map` that provides the postcondition property to the m
 /--
 A universe-heterogeneous version of `Functor.map`.
 -/
-@[expose, implicit_reducible] protected noncomputable def HetT.map {m : Type w → Type w'} [Functor m] {α : Type u} {β : Type v}
+@[implicit_reducible] protected noncomputable def HetT.map {m : Type w → Type w'} [Functor m] {α : Type u} {β : Type v}
     (f : α → β) (x : HetT m α) : HetT m β :=
   x.pmap (fun a _ => f a)
 
 /--
 A generalization of `HetT.bind` that provides the postcondition property to the mapping function.
 -/
-@[expose, implicit_reducible]
+@[implicit_reducible]
 protected noncomputable def HetT.pbind {m : Type w → Type w'} [Monad m] {α : Type u} {β : Type v}
     (x : HetT m α) (f : (a : α) → x.Property a → HetT m β) : HetT m β :=
   have := x.small
@@ -244,7 +244,7 @@ protected noncomputable def HetT.pbind {m : Type w → Type w'} [Monad m] {α : 
 /--
 A universe-heterogeneous version of `Bind.bind`.
 -/
-@[expose, implicit_reducible] protected noncomputable def HetT.bind {m : Type w → Type w'} [Monad m] {α : Type u} {β : Type v}
+@[implicit_reducible] protected noncomputable def HetT.bind {m : Type w → Type w'} [Monad m] {α : Type u} {β : Type v}
     (x : HetT m α) (f : α → HetT m β) : HetT m β :=
   have := x.small
   have := fun a => (f a).small
@@ -293,7 +293,7 @@ theorem HetT.prun_ofPostconditionT [Monad m] [LawfulMonad m] {x : PostconditionT
 /--
 If the monad `m` is liftable to `n`, lifts `HetT m α` to `HetT n α`.
 -/
-@[expose, implicit_reducible]
+@[implicit_reducible]
 noncomputable def HetT.liftInner {m : Type w → Type w'} (n : Type w → Type w'') [MonadLiftT m n]
     (x : HetT m α) : HetT n α :=
   ⟨x.Property, x.small, x.operation⟩


### PR DESCRIPTION
This PR fixes some warnings in stage2 due to redundant `@[expose]`.