### PR TITLE
fix: perform severity overrides before counting errors

### DIFF
--- a/src/Lean/Language/Basic.lean
+++ b/src/Lean/Language/Basic.lean
@@ -317,15 +317,18 @@ private def reportMessages (msgLog : MessageLog) (opts : Options)
     (json : Bool) (severityOverrides : NameMap MessageSeverity) (numErrors : Nat) : IO Nat := do
   let includeEndPos := printMessageEndPos.get opts
   msgLog.unreported.foldlM (init := numErrors) fun numErrors msg => do
+    let msg : Message :=
+      if let some severity := severityOverrides.find? msg.kind then
+        {msg with severity}
+      else
+        msg
     let numErrors := numErrors + (if msg.severity matches .error then 1 else 0)
     let maxErrorsReached := maxErrors.get opts != 0 && numErrors > maxErrors.get opts
     let msg : Message :=
       if maxErrorsReached then { msg with
         data := s!"maximum number of errors ({maxErrors.get opts}; from option `maxErrors`) reached, exiting"
         severity := .error
-      } else if let some severity := severityOverrides.find? msg.kind then
-        {msg with severity}
-      else
+      } else
         msg
     unless msg.isSilent do
       if json then


### PR DESCRIPTION
This PR ensures that the `lean --error=tag` flag actually sets a non-zero exit code on promoted errors.

Closes #13588, fixing the feature introduced in #6362.