### PR TITLE
feat: add `values`/`valuesArray` lemmas for (D)HashMap

### DIFF
--- a/src/Std/Data/DHashMap/Internal/RawLemmas.lean
+++ b/src/Std/Data/DHashMap/Internal/RawLemmas.lean
@@ -1076,6 +1076,10 @@ theorem map_fst_toList_eq_keys [EquivBEq α] [LawfulHashable α] :
     (Raw.Const.toList m.1).map Prod.fst = m.1.keys := by
   simp_to_model [keys, Const.toList] using List.map_fst_map_toProd_eq_keys
 
+theorem map_snd_toList_eq_values [EquivBEq α] [LawfulHashable α] :
+    (Raw.Const.toList m.1).map Prod.snd = m.1.values := by
+  simp_to_model [values, Const.toList] using List.map_snd_map_toProd_eq_values
+
 theorem length_toList [EquivBEq α] [LawfulHashable α] (h : m.1.WF) :
     (Raw.Const.toList m.1).length = m.1.size := by
   simp_to_model [size, Const.toList] using List.length_map
@@ -1233,6 +1237,10 @@ theorem toList_toArray_eq_toList :
 theorem map_fst_toArray_eq_keysArray [EquivBEq α] [LawfulHashable α] :
     (Raw.Const.toArray m.1).map Prod.fst = m.1.keysArray := by
   simp [← toArray_toList_eq_toArray, List.map_toArray, ← toArray_keys_eq_keysArray, map_fst_toList_eq_keys]
+
+theorem map_snd_toArray_eq_valuesArray [EquivBEq α] [LawfulHashable α] :
+    (Raw.Const.toArray m.1).map Prod.snd = m.1.valuesArray := by
+  simp [← toArray_toList_eq_toArray, List.map_toArray, ← toArray_values_eq_valuesArray, map_snd_toList_eq_values]
 
 theorem size_toArray [EquivBEq α] [LawfulHashable α] (h : m.1.WF) :
     (Raw.Const.toArray m.1).size = m.1.size := by

--- a/src/Std/Data/DHashMap/Internal/RawLemmas.lean
+++ b/src/Std/Data/DHashMap/Internal/RawLemmas.lean
@@ -168,6 +168,7 @@ private meta def queryMap : Std.DHashMap Name (fun _ => Name × Array (MacroM (T
      ⟨`Const.beq, (``Raw₀.Const.beq_eq_beqModel, #[])⟩,
      ⟨`beq, (``beq_eq_beqModel, #[])⟩,
      ⟨`keys, (``Raw.keys_eq_keys_toListModel, #[`(perm_keys_congr_left)])⟩,
+     ⟨`values, (``Raw.values_eq_values_toListModel, #[])⟩,
      ⟨`Const.toList, (``Raw.Const.toList_eq_toListModel_map, #[`(perm_map_congr_left)])⟩,
      ⟨`foldM, (``Raw.foldM_eq_foldlM_toListModel, #[])⟩,
      ⟨`fold, (``Raw.fold_eq_foldl_toListModel, #[])⟩,
@@ -177,6 +178,7 @@ private meta def queryMap : Std.DHashMap Name (fun _ => Name × Array (MacroM (T
      ⟨`forM, (``Raw.forM_eq_forM_toListModel, #[])⟩,
      ⟨`toArray, (``Raw.toArray_eq_toArray_toListModel, #[])⟩,
      ⟨`keysArray, (``Raw.keysArray_eq_toArray_keys_toListModel, #[])⟩,
+     ⟨`valuesArray, (``Raw.valuesArray_eq_toArray_values_toListModel, #[])⟩,
      ⟨`Const.toArray, (``Raw.Const.toArray_eq_toArray_map_toListModel, #[])⟩,
      ⟨`Equiv, (``Raw.equiv_iff_toListModel_perm,
       #[`(_root_.List.Perm.congr_left), `(_root_.List.Perm.congr_right)])⟩]
@@ -1060,6 +1062,16 @@ namespace Const
 
 variable {β : Type v} (m : Raw₀ α (fun _ => β))
 
+@[simp]
+theorem length_values [EquivBEq α] [LawfulHashable α] (h : m.1.WF) :
+    m.1.values.length = m.1.size := by
+  simp_to_model [size, values] using List.length_values_eq_length
+
+@[simp]
+theorem isEmpty_values [EquivBEq α] [LawfulHashable α] (h : m.1.WF) :
+    m.1.values.isEmpty = m.1.isEmpty := by
+  simp_to_model [isEmpty, values] using List.isEmpty_values_eq_isEmpty
+
 theorem map_fst_toList_eq_keys [EquivBEq α] [LawfulHashable α] :
     (Raw.Const.toList m.1).map Prod.fst = m.1.keys := by
   simp_to_model [keys, Const.toList] using List.map_fst_map_toProd_eq_keys
@@ -1187,6 +1199,26 @@ theorem find?_toArray_eq_none_iff_contains_eq_false [EquivBEq α] [LawfulHashabl
 namespace Const
 
 variable {β : Type v} (m : Raw₀ α (fun _ => β))
+
+omit [Hashable α] [BEq α] in
+theorem toArray_values_eq_valuesArray :
+    m.1.values.toArray = m.1.valuesArray := by
+  simp_to_model
+
+omit [Hashable α] [BEq α] in
+theorem toList_valuesArray_eq_values :
+    m.1.valuesArray.toList = m.1.values := by
+  simp_to_model
+
+@[simp]
+theorem size_valuesArray [EquivBEq α] [LawfulHashable α] (h : m.1.WF) :
+    m.1.valuesArray.size = m.1.size := by
+  simp [← toArray_values_eq_valuesArray, h]
+
+@[simp]
+theorem isEmpty_valuesArray [EquivBEq α] [LawfulHashable α] (h : m.1.WF) :
+    m.1.valuesArray.isEmpty = m.1.isEmpty := by
+  simp [← toArray_values_eq_valuesArray, h]
 
 omit [Hashable α] [BEq α] in
 theorem toArray_toList_eq_toArray :

--- a/src/Std/Data/DHashMap/Internal/WF.lean
+++ b/src/Std/Data/DHashMap/Internal/WF.lean
@@ -153,6 +153,11 @@ theorem fold_push_key {l : Raw α β} {acc : Array α} :
       acc ++ (List.keys (toListModel l.buckets)).toArray := by
   simp [fold_push_apply, keys_eq_map]
 
+theorem fold_push_value {β : Type v} {l : Raw α (fun _ => β)} {acc : Array β} :
+    Raw.fold (fun acc _ v => acc.push v) acc l =
+      acc ++ (List.values (toListModel l.buckets)).toArray := by
+  simp [fold_push_apply, values_eq_map]
+
 theorem foldM_eq_foldlM_toListModel {δ : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
     {f : δ → (a : α) → β a → m δ} {init : δ} {b : Raw α β} :
     b.foldM f init = (toListModel b.buckets).foldlM (fun a b => f a b.1 b.2) init := by
@@ -239,6 +244,10 @@ theorem values_eq_values_toListModel {β : Type v}  {m : Raw α (fun _ => β)} :
 theorem keysArray_eq_toArray_keys_toListModel {m : Raw α β} :
     m.keysArray = (List.keys (toListModel m.buckets)).toArray := by
   simp [Raw.keysArray, fold_push_key]
+
+theorem valuesArray_eq_toArray_values_toListModel {β : Type v} {m : Raw α (fun _ => β)} :
+    m.valuesArray = (List.values (toListModel m.buckets)).toArray := by
+  simp [Raw.valuesArray, fold_push_value]
 
 theorem forM_eq_forM_toListModel {l: Raw α β} {m : Type w → Type w'} [Monad m] [LawfulMonad m]
     {f : (a : α) → β a → m PUnit} :

--- a/src/Std/Data/DHashMap/Lemmas.lean
+++ b/src/Std/Data/DHashMap/Lemmas.lean
@@ -1269,6 +1269,36 @@ namespace Const
 
 variable {β : Type v} {m : DHashMap α (fun _ => β)}
 
+@[simp, grind =]
+theorem length_values [EquivBEq α] [LawfulHashable α] :
+    m.values.length = m.size :=
+  Raw₀.Const.length_values ⟨m.1, m.2.size_buckets_pos⟩ m.2
+
+@[simp, grind =]
+theorem isEmpty_values [EquivBEq α] [LawfulHashable α] :
+    m.values.isEmpty = m.isEmpty :=
+  Raw₀.Const.isEmpty_values ⟨m.1, m.2.size_buckets_pos⟩ m.2
+
+@[simp]
+theorem toArray_values :
+    m.values.toArray = m.valuesArray :=
+  Raw₀.Const.toArray_values_eq_valuesArray ⟨m.1, m.2.size_buckets_pos⟩
+
+@[simp]
+theorem toList_valuesArray :
+    m.valuesArray.toList = m.values :=
+  Raw₀.Const.toList_valuesArray_eq_values ⟨m.1, m.2.size_buckets_pos⟩
+
+@[simp]
+theorem size_valuesArray [EquivBEq α] [LawfulHashable α] :
+    m.valuesArray.size = m.size :=
+  Raw₀.Const.size_valuesArray ⟨m.1, m.2.size_buckets_pos⟩ m.2
+
+@[simp]
+theorem isEmpty_valuesArray [EquivBEq α] [LawfulHashable α] :
+    m.valuesArray.isEmpty = m.isEmpty :=
+  Raw₀.Const.isEmpty_valuesArray ⟨m.1, m.2.size_buckets_pos⟩ m.2
+
 @[simp, grind _=_]
 theorem map_fst_toList_eq_keys [EquivBEq α] [LawfulHashable α] :
     (toList m).map Prod.fst = m.keys :=

--- a/src/Std/Data/DHashMap/Lemmas.lean
+++ b/src/Std/Data/DHashMap/Lemmas.lean
@@ -1304,6 +1304,11 @@ theorem map_fst_toList_eq_keys [EquivBEq α] [LawfulHashable α] :
     (toList m).map Prod.fst = m.keys :=
   Raw₀.Const.map_fst_toList_eq_keys ⟨m.1, m.2.size_buckets_pos⟩
 
+@[simp, grind _=_]
+theorem map_snd_toList_eq_values [EquivBEq α] [LawfulHashable α] :
+    (toList m).map Prod.snd = m.values :=
+  Raw₀.Const.map_snd_toList_eq_values ⟨m.1, m.2.size_buckets_pos⟩
+
 @[simp, grind =]
 theorem length_toList [EquivBEq α] [LawfulHashable α] :
     (toList m).length = m.size :=
@@ -1414,6 +1419,11 @@ theorem toList_toArray :
 theorem map_fst_toArray_eq_keysArray [EquivBEq α] [LawfulHashable α] :
     (DHashMap.Const.toArray m).map Prod.fst = m.keysArray :=
   Raw₀.Const.map_fst_toArray_eq_keysArray ⟨m.1, m.2.size_buckets_pos⟩
+
+@[simp]
+theorem map_snd_toArray_eq_valuesArray [EquivBEq α] [LawfulHashable α] :
+    (DHashMap.Const.toArray m).map Prod.snd = m.valuesArray :=
+  Raw₀.Const.map_snd_toArray_eq_valuesArray ⟨m.1, m.2.size_buckets_pos⟩
 
 @[simp]
 theorem size_toArray [EquivBEq α] [LawfulHashable α] :

--- a/src/Std/Data/DHashMap/Raw.lean
+++ b/src/Std/Data/DHashMap/Raw.lean
@@ -546,9 +546,6 @@ This function always iterates through the smaller map, so the expected runtime i
     m₂
 
 instance [BEq α] [Hashable α] : SDiff (Raw α β) := ⟨diff⟩
-section Unverified
-
-/-! We currently do not provide lemmas for the functions below. -/
 
 /-- Returns a list of all values present in the hash map in some order. -/
 @[inline] def values {β : Type v} (m : Raw α (fun _ => β)) : List β :=
@@ -557,6 +554,10 @@ section Unverified
 /-- Returns an array of all values present in the hash map in some order. -/
 @[inline] def valuesArray {β : Type v} (m : Raw α (fun _ => β)) : Array β :=
   m.fold (fun acc _ v => acc.push v) (.emptyWithCapacity m.size)
+
+section Unverified
+
+/-! We currently do not provide lemmas for the functions below. -/
 
 /--
 Inserts multiple mappings into the hash map by iterating over the given collection and calling

--- a/src/Std/Data/DHashMap/RawLemmas.lean
+++ b/src/Std/Data/DHashMap/RawLemmas.lean
@@ -1340,6 +1340,36 @@ namespace Const
 
 variable {β : Type v} {m : Raw α (fun _ => β)}
 
+@[simp, grind =]
+theorem length_values [EquivBEq α] [LawfulHashable α] (h : m.WF) :
+    m.values.length = m.size := by
+  simp_to_raw using Raw₀.Const.length_values ⟨m, h.size_buckets_pos⟩ h
+
+@[simp, grind =]
+theorem isEmpty_values [EquivBEq α] [LawfulHashable α] (h : m.WF) :
+    m.values.isEmpty = m.isEmpty := by
+  simp_to_raw using Raw₀.Const.isEmpty_values ⟨m, h.size_buckets_pos⟩ h
+
+@[simp]
+theorem toArray_values (h : m.WF) :
+    m.values.toArray = m.valuesArray :=
+  Raw₀.Const.toArray_values_eq_valuesArray ⟨m, h.size_buckets_pos⟩
+
+@[simp]
+theorem toList_valuesArray (h : m.WF) :
+    m.valuesArray.toList = m.values :=
+  Raw₀.Const.toList_valuesArray_eq_values ⟨m, h.size_buckets_pos⟩
+
+@[simp]
+theorem size_valuesArray [EquivBEq α] [LawfulHashable α] (h : m.WF) :
+    m.valuesArray.size = m.size :=
+  Raw₀.Const.size_valuesArray ⟨m, h.size_buckets_pos⟩ h
+
+@[simp]
+theorem isEmpty_valuesArray [EquivBEq α] [LawfulHashable α] (h : m.WF) :
+    m.valuesArray.isEmpty = m.isEmpty :=
+  Raw₀.Const.isEmpty_valuesArray ⟨m, h.size_buckets_pos⟩ h
+
 @[simp, grind _=_]
 theorem map_fst_toList_eq_keys [EquivBEq α] [LawfulHashable α] (h : m.WF) :
     (Raw.Const.toList m).map Prod.fst = m.keys := by

--- a/src/Std/Data/DHashMap/RawLemmas.lean
+++ b/src/Std/Data/DHashMap/RawLemmas.lean
@@ -1375,6 +1375,11 @@ theorem map_fst_toList_eq_keys [EquivBEq α] [LawfulHashable α] (h : m.WF) :
     (Raw.Const.toList m).map Prod.fst = m.keys := by
   apply Raw₀.Const.map_fst_toList_eq_keys ⟨m, h.size_buckets_pos⟩
 
+@[simp, grind _=_]
+theorem map_snd_toList_eq_values [EquivBEq α] [LawfulHashable α] (h : m.WF) :
+    (Raw.Const.toList m).map Prod.snd = m.values := by
+  apply Raw₀.Const.map_snd_toList_eq_values ⟨m, h.size_buckets_pos⟩
+
 @[simp, grind =]
 theorem length_toList [EquivBEq α] [LawfulHashable α] (h : m.WF) :
     (Raw.Const.toList m).length = m.size := by
@@ -1489,6 +1494,11 @@ theorem toList_toArray (h : m.WF) :
 theorem map_fst_toArray_eq_keysArray [EquivBEq α] [LawfulHashable α] (h : m.WF) :
     (Raw.Const.toArray m).map Prod.fst = m.keysArray :=
   Raw₀.Const.map_fst_toArray_eq_keysArray ⟨m, h.size_buckets_pos⟩
+
+@[simp]
+theorem map_snd_toArray_eq_valuesArray [EquivBEq α] [LawfulHashable α] (h : m.WF) :
+    (Raw.Const.toArray m).map Prod.snd = m.valuesArray := by
+  apply Raw₀.Const.map_snd_toArray_eq_valuesArray ⟨m, h.size_buckets_pos⟩
 
 @[simp]
 theorem size_toArray [EquivBEq α] [LawfulHashable α] (h : m.WF) :

--- a/src/Std/Data/HashMap/Lemmas.lean
+++ b/src/Std/Data/HashMap/Lemmas.lean
@@ -929,6 +929,36 @@ theorem contains_of_mem_keysArray [EquivBEq α] [LawfulHashable α] {k : α}
     (h' : k ∈ m.keysArray) : m.contains k :=
   DHashMap.contains_of_mem_keysArray h'
 
+@[simp, grind =]
+theorem length_values [EquivBEq α] [LawfulHashable α] :
+    m.values.length = m.size :=
+  DHashMap.Const.length_values
+
+@[simp, grind =]
+theorem isEmpty_values [EquivBEq α] [LawfulHashable α] :
+    m.values.isEmpty = m.isEmpty :=
+  DHashMap.Const.isEmpty_values
+
+@[simp]
+theorem toArray_values :
+    m.values.toArray = m.valuesArray :=
+  DHashMap.Const.toArray_values
+
+@[simp]
+theorem toList_valuesArray :
+    m.valuesArray.toList = m.values :=
+  DHashMap.Const.toList_valuesArray
+
+@[simp]
+theorem size_valuesArray [EquivBEq α] [LawfulHashable α] :
+    m.valuesArray.size = m.size :=
+  DHashMap.Const.size_valuesArray
+
+@[simp]
+theorem isEmpty_valuesArray [EquivBEq α] [LawfulHashable α] :
+    m.valuesArray.isEmpty = m.isEmpty :=
+  DHashMap.Const.isEmpty_valuesArray
+
 @[simp, grind _=_]
 theorem map_fst_toList_eq_keys [EquivBEq α] [LawfulHashable α] :
     m.toList.map Prod.fst = m.keys :=

--- a/src/Std/Data/HashMap/Lemmas.lean
+++ b/src/Std/Data/HashMap/Lemmas.lean
@@ -964,6 +964,11 @@ theorem map_fst_toList_eq_keys [EquivBEq α] [LawfulHashable α] :
     m.toList.map Prod.fst = m.keys :=
   DHashMap.Const.map_fst_toList_eq_keys
 
+@[simp, grind _=_]
+theorem map_snd_toList_eq_values [EquivBEq α] [LawfulHashable α] :
+    m.toList.map Prod.snd = m.values :=
+  DHashMap.Const.map_snd_toList_eq_values
+
 @[simp, grind =]
 theorem length_toList [EquivBEq α] [LawfulHashable α] :
     m.toList.length = m.size :=
@@ -1026,6 +1031,11 @@ theorem toList_toArray :
 theorem map_fst_toArray_eq_keysArray [EquivBEq α] [LawfulHashable α] :
     m.toArray.map Prod.fst = m.keysArray :=
   DHashMap.Const.map_fst_toArray_eq_keysArray
+
+@[simp]
+theorem map_snd_toArray_eq_valuesArray [EquivBEq α] [LawfulHashable α] :
+    m.toArray.map Prod.snd = m.valuesArray :=
+  DHashMap.Const.map_snd_toArray_eq_valuesArray
 
 @[simp]
 theorem size_toArray [EquivBEq α] [LawfulHashable α] :

--- a/src/Std/Data/HashMap/RawLemmas.lean
+++ b/src/Std/Data/HashMap/RawLemmas.lean
@@ -909,6 +909,36 @@ theorem contains_of_mem_keysArray [EquivBEq α] [LawfulHashable α] (h : m.WF) {
     (h' : k ∈ m.keysArray) : m.contains k :=
   DHashMap.Raw.contains_of_mem_keysArray h.out h'
 
+@[simp, grind =]
+theorem length_values [EquivBEq α] [LawfulHashable α] (h : m.WF) :
+    m.values.length = m.size :=
+  DHashMap.Raw.Const.length_values h.out
+
+@[simp, grind =]
+theorem isEmpty_values [EquivBEq α] [LawfulHashable α] (h : m.WF) :
+    m.values.isEmpty = m.isEmpty :=
+  DHashMap.Raw.Const.isEmpty_values h.out
+
+@[simp]
+theorem toArray_values (h : m.WF) :
+    m.values.toArray = m.valuesArray :=
+  DHashMap.Raw.Const.toArray_values h.out
+
+@[simp]
+theorem toList_valuesArray (h : m.WF) :
+    m.valuesArray.toList = m.values :=
+  DHashMap.Raw.Const.toList_valuesArray h.out
+
+@[simp]
+theorem size_valuesArray [EquivBEq α] [LawfulHashable α] (h : m.WF) :
+    m.valuesArray.size = m.size :=
+  DHashMap.Raw.Const.size_valuesArray h.out
+
+@[simp]
+theorem isEmpty_valuesArray [EquivBEq α] [LawfulHashable α] (h : m.WF) :
+    m.valuesArray.isEmpty = m.isEmpty :=
+  DHashMap.Raw.Const.isEmpty_valuesArray h.out
+
 @[simp, grind _=_]
 theorem map_fst_toList_eq_keys [EquivBEq α] [LawfulHashable α] (h : m.WF) :
     m.toList.map Prod.fst = m.keys :=

--- a/src/Std/Data/HashMap/RawLemmas.lean
+++ b/src/Std/Data/HashMap/RawLemmas.lean
@@ -944,6 +944,11 @@ theorem map_fst_toList_eq_keys [EquivBEq α] [LawfulHashable α] (h : m.WF) :
     m.toList.map Prod.fst = m.keys :=
   DHashMap.Raw.Const.map_fst_toList_eq_keys h.out
 
+@[simp, grind _=_]
+theorem map_snd_toList_eq_values [EquivBEq α] [LawfulHashable α] (h : m.WF) :
+    m.toList.map Prod.snd = m.values :=
+  DHashMap.Raw.Const.map_snd_toList_eq_values h.out
+
 @[simp, grind =]
 theorem length_toList [EquivBEq α] [LawfulHashable α] (h : m.WF) :
     m.toList.length = m.size :=
@@ -1006,6 +1011,11 @@ theorem toList_toArray (h : m.WF) :
 theorem map_fst_toArray_eq_keysArray [EquivBEq α] [LawfulHashable α] (h : m.WF) :
     m.toArray.map Prod.fst = m.keysArray :=
   DHashMap.Raw.Const.map_fst_toArray_eq_keysArray h.out
+
+@[simp]
+theorem map_snd_toArray_eq_valuesArray [EquivBEq α] [LawfulHashable α] (h : m.WF) :
+    m.toArray.map Prod.snd = m.valuesArray :=
+  DHashMap.Raw.Const.map_snd_toArray_eq_valuesArray h.out
 
 @[simp]
 theorem size_toArray [EquivBEq α] [LawfulHashable α] (h : m.WF) :

--- a/src/Std/Data/Internal/List/Associative.lean
+++ b/src/Std/Data/Internal/List/Associative.lean
@@ -418,11 +418,19 @@ theorem containsKey_eq_contains_map_fst [BEq α] [PartialEquivBEq α] {l : List 
 @[simp] theorem values_nil {β : Type v} : values ([] : List ((_ : α) × β )) = [] := (rfl)
 @[simp] theorem keys_cons {l : List ((a : α) × β a)} {k : α} {v : β k} :
     keys (⟨k, v⟩ :: l) = k :: keys l := (rfl)
+@[simp] theorem values_cons {β : Type v} {l : List ((_ : α) × β)} {k : α} {v : β} :
+    values (⟨k, v⟩ :: l) = v :: values l := (rfl)
 
 theorem length_keys_eq_length (l : List ((a : α) × β a)) : (keys l).length = l.length := by
   induction l using assoc_induction <;> simp_all
 
+theorem length_values_eq_length {β : Type v} (l : List ((_ : α) × β)) : (values l).length = l.length := by
+  induction l using assoc_induction <;> simp_all
+
 theorem isEmpty_keys_eq_isEmpty (l : List ((a : α) × β a)) : (keys l).isEmpty = l.isEmpty := by
+  induction l using assoc_induction <;> simp_all
+
+theorem isEmpty_values_eq_isEmpty {β : Type v} (l : List ((_ : α) × β)) : (values l).isEmpty = l.isEmpty := by
   induction l using assoc_induction <;> simp_all
 
 theorem containsKey_eq_keys_contains [BEq α] [PartialEquivBEq α] {l : List ((a : α) × β a)}

--- a/src/Std/Data/Internal/List/Associative.lean
+++ b/src/Std/Data/Internal/List/Associative.lean
@@ -2609,6 +2609,14 @@ theorem map_fst_map_toProd_eq_keys {β : Type v} {l : List ((_ : α) × β)} :
     simp only [List.map_cons, keys]
     congr
 
+theorem map_snd_map_toProd_eq_values {β : Type v} {l : List ((_ : α) × β)} :
+    List.map Prod.snd (List.map (fun x => (x.fst, x.snd)) l) = List.values l := by
+  induction l with
+  | nil => simp
+  | cons hd tl ih =>
+    simp only [List.map_cons, values]
+    congr
+
 theorem find?_map_eq_none_iff_containsKey_eq_false [BEq α] [PartialEquivBEq α]
     {β : Type v} {l : List ((_ : α) × β)} {k : α} :
     List.find? (fun x => x.fst == k) (l.map (fun x => (x.fst, x.snd))) = none ↔


### PR DESCRIPTION
This PR adds `values` and `valuesArray` lemmas mirroring the existing `keys` and `keysArray` lemmas, including length/emptiness and array/list conversion results.
