### PR TITLE
fix: prevent private default instances from leaking into public scope

### DIFF
--- a/src/Lean/Meta/Instances.lean
+++ b/src/Lean/Meta/Instances.lean
@@ -362,6 +362,10 @@ builtin_initialize defaultInstanceExtension : SimplePersistentEnvExtension Defau
   registerSimplePersistentEnvExtension {
     addEntryFn    := addDefaultInstanceEntry
     addImportedFn := fun es => (mkStateFromImportedEntries addDefaultInstanceEntry {} es)
+    exportEntriesFnEx? := some fun env _ entries =>
+      let all := entries.toArray
+      let exported := all.filter ((env.setExporting true).contains (skipRealize := false) ·.instanceName)
+      { exported, server := exported, «private» := all }
   }
 
 def addDefaultInstance (declName : Name) (prio : Nat := 0) : MetaM Unit := do
@@ -390,7 +394,13 @@ builtin_initialize
 def getDefaultInstancesPriorities [Monad m] [MonadEnv m] : m PrioritySet :=
   return defaultInstanceExtension.getState (← getEnv) |>.priorities
 
-def getDefaultInstances [Monad m] [MonadEnv m] (className : Name) : m (List (Name × Nat)) :=
-  return defaultInstanceExtension.getState (← getEnv) |>.defaultInstances.find? className |>.getD []
+def getDefaultInstances [Monad m] [MonadEnv m] (className : Name) : m (List (Name × Nat)) := do
+  let env ← getEnv
+  let insts := defaultInstanceExtension.getState env |>.defaultInstances.find? className |>.getD []
+  if env.isExporting then
+    -- private instances must not leak into public scope
+    return insts.filter fun (n, _) => env.contains n
+  else
+    return insts
 
 end Lean.Meta

--- a/tests/pkg/module/Module/Basic.lean
+++ b/tests/pkg/module/Module/Basic.lean
@@ -561,3 +561,12 @@ public def func (ctx : Nat) (operand : OpOperand2) : Nat :=
 
 /-- Setup for #12833. -/
 public def Namespaced.def := 0
+
+/-! Setup for the default-instance visibility test in `Module.PrivateImported`. -/
+
+public structure CustomMulT where
+  x : Nat
+
+@[default_instance]
+public instance instHMulNatCustom : HMul Nat CustomMulT CustomMulT where
+  hMul a b := { x := a + b.x }

--- a/tests/pkg/module/Module/PrivateImported.lean
+++ b/tests/pkg/module/Module/PrivateImported.lean
@@ -32,3 +32,12 @@ attribute [local simp] t
 
 /-- Setup for #12833. -/
 public def Namespaced.def2 := 0
+
+/-! Default instances from privately imported modules must not be applied during
+public-scope elaboration. Without the visibility filter on default instances, the
+priv-imported `instHMulNatCustom` would be tried before the core `instHMul` and
+fail with `Unknown constant` in this public theorem signature. -/
+
+public theorem hmulDefaultPrivacy (m : Nat) : ∀ n, m * n = m * n := by
+  intro n
+  rfl


### PR DESCRIPTION
This PR fixes private(ly imported) default instances from accidentally being used in public signatures, leading to follow-up errors.

As reported at https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Elaboration.20of.20heterogeneous.20mul.20with.20the.20module.20system