### PR TITLE
fix: lake: `meta import` transitive import artifacts

### DIFF
--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -234,9 +234,9 @@ partial def fetchTransImportArts
     let input ← (← mod.input.fetch).await
     let importAll := strictOr nonModule imp.importAll
     return enqueue importAll imp.isMeta input q
-  walk directArts q
+  walk directArts {} q
 where
-  walk s (q : Array TransImportEntry) := do
+  walk s (metaVisited : NameSet) (q : Array TransImportEntry) := do
     if h : 0 < q.size then
       let {mod, importAll, needsMeta} := q.back
       let q := q.pop
@@ -252,15 +252,18 @@ where
 
         Sizes `1` and `4` imply all imports were already enqueued,
         so re-visiting them for `meta import` or `import all` is redundant.
+        A module already visited with `needsMeta` need not be re-visited.
         -/
+        let needsMeta := needsMeta && !metaVisited.contains mod.name
         unless (importAll || needsMeta) && arts.size == 3 do
-          return ← walk s q
+          return ← walk s metaVisited q
       let info ← (← mod.exportInfo.fetch).await
       let arts := if importAll then info.allArts else info.arts
       let s := s.insert mod.name arts
+      let metaVisited := if importAll || needsMeta then metaVisited.insert mod.name else metaVisited
       let input ← (← mod.input.fetch).await
       let q := enqueue importAll needsMeta input q
-      walk s q
+      walk s metaVisited q
     else
       return s
   enqueue importAll needsMeta input q :=

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -242,7 +242,8 @@ where
       if let some arts := s.find? mod.name then
         -- may need to promote a module system `import` to an `import all`
         -- size of 1 = non-module, 3 = module system `import`, 4 = `import all`
-        unless importAll && arts.size == 3 do
+        -- or re-visit with `needsMeta` to enqueue previously skipped imports
+        unless (importAll && arts.size == 3) || needsMeta do
           return ← walk s q
       let info ← (← mod.exportInfo.fetch).await
       let arts := if importAll then info.allArts else info.arts

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -240,10 +240,19 @@ where
       let {mod, importAll, needsMeta} := q.back
       let q := q.pop
       if let some arts := s.find? mod.name then
-        -- may need to promote a module system `import` to an `import all`
-        -- size of 1 = non-module, 3 = module system `import`, 4 = `import all`
-        -- or re-visit with `needsMeta` to enqueue previously skipped imports
-        unless (importAll && arts.size == 3) || needsMeta do
+        /-
+        A module system `import` may need to be promoted to a
+        wider import (`meta import`, `import all`) on another branch.
+
+        The size of import artifacts implies the following:
+        * `1`: non-module `import` (`.olean` only)
+        * `3`: module `import` (`.olean`, `.olean.server`, `.olean.ir`)
+        * `4`: `import all` (module + `.olean.private`)
+
+        Sizes `1` and `4` imply all imports were already enqueued,
+        so re-visiting them for `meta import` or `import all` is redundant.
+        -/
+        unless (importAll || needsMeta) && arts.size == 3 do
           return ← walk s q
       let info ← (← mod.exportInfo.fetch).await
       let arts := if importAll then info.allArts else info.arts

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -219,6 +219,12 @@ def computeModuleDeps
     plugins := plugins.push (← getLakeInstall).sharedDynlib
   return {dynlibs, plugins}
 
+structure TransImportEntry where
+  mod : Module
+  importAll : Bool
+  /-- Whether `needsIRTrans` is set for this module (per Lean's meta import rules). -/
+  needsMeta : Bool
+
 partial def fetchTransImportArts
   (directImports : Array ModuleImport) (directArts : NameMap ImportArtifacts) (nonModule : Bool)
 : FetchM (NameMap ImportArtifacts) := do
@@ -226,12 +232,12 @@ partial def fetchTransImportArts
     let some mod := imp.module? | return q
     let input ← (← mod.input.fetch).await
     let importAll := strictOr nonModule imp.importAll
-    return enqueue importAll input q
+    return enqueue importAll imp.isMeta input q
   walk directArts q
 where
-  walk s q := do
+  walk s (q : Array TransImportEntry) := do
     if h : 0 < q.size then
-      let (mod, importAll) := q.back
+      let {mod, importAll, needsMeta} := q.back
       let q := q.pop
       if let some arts := s.find? mod.name then
         -- may need to promote a module system `import` to an `import all`
@@ -242,15 +248,18 @@ where
       let arts := if importAll then info.allArts else info.arts
       let s := s.insert mod.name arts
       let input ← (← mod.input.fetch).await
-      let q := enqueue importAll input q
+      let q := enqueue importAll needsMeta input q
       walk s q
     else
       return s
-  enqueue importAll input q :=
+  enqueue importAll needsMeta input q :=
     input.imports.foldr (init := q) fun imp q =>
       if let some mod := imp.module? then
-        if importAll || imp.isExported then
-          q.push (mod, nonModule || (importAll && imp.importAll))
+        let reachable := importAll || imp.isExported
+        let importAll := nonModule || (importAll && imp.importAll)
+        let needsMeta := needsMeta || (reachable && imp.isMeta)
+        if reachable || needsMeta then
+          q.push {mod, importAll, needsMeta}
         else q
       else q
 

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -228,7 +228,7 @@ structure TransImportEntry where
 partial def fetchTransImportArts
   (directImports : Array ModuleImport) (directArts : NameMap ImportArtifacts) (nonModule : Bool)
 : FetchM (NameMap ImportArtifacts) := do
-  let q ← directImports.foldlM (init := #[]) fun q imp => do
+  let q ← directImports.foldrM (init := #[]) fun imp q => do
     let some mod := imp.module? | return q
     let input ← (← mod.input.fetch).await
     let importAll := strictOr nonModule imp.importAll

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -221,8 +221,9 @@ def computeModuleDeps
 
 structure TransImportEntry where
   mod : Module
+  /-- Whether to include all module artifacts and traverse the module's direct imports. -/
   importAll : Bool
-  /-- Whether `needsIRTrans` is set for this module (per Lean's meta import rules). -/
+  /-- Whether this module has been transitively imported by a `meta import`. -/
   needsMeta : Bool
 
 partial def fetchTransImportArts
@@ -246,7 +247,7 @@ where
 
         The size of import artifacts implies the following:
         * `1`: non-module `import` (`.olean` only)
-        * `3`: module `import` (`.olean`, `.olean.server`, `.olean.ir`)
+        * `3`: module `import` (`.olean`, `.olean.server`, `.ir`)
         * `4`: `import all` (module + `.olean.private`)
 
         Sizes `1` and `4` imply all imports were already enqueued,

--- a/tests/lake/tests/module/Test/Module/MetaRevisit.lean
+++ b/tests/lake/tests/module/Test/Module/MetaRevisit.lean
@@ -1,0 +1,4 @@
+module
+
+import Test.Module.PublicImportImport
+public meta import Test.Module.ImportImport

--- a/tests/lake/tests/module/Test/Module/PromoteMetaImport.lean
+++ b/tests/lake/tests/module/Test/Module/PromoteMetaImport.lean
@@ -1,4 +1,4 @@
 module
 
-import all Test.Generated.Module
+import all Test.Module.ImportImport
 meta import Test.Module.ImportImport

--- a/tests/lake/tests/module/Test/Module/PromoteMetaImport.lean
+++ b/tests/lake/tests/module/Test/Module/PromoteMetaImport.lean
@@ -1,0 +1,4 @@
+module
+
+import all Test.Generated.Module
+meta import Test.Module.ImportImport

--- a/tests/lake/tests/module/Test/Module/PublicImportImport.lean
+++ b/tests/lake/tests/module/Test/Module/PublicImportImport.lean
@@ -1,0 +1,3 @@
+module
+
+public import Test.Module.Import

--- a/tests/lake/tests/module/test.sh
+++ b/tests/lake/tests/module/test.sh
@@ -63,6 +63,11 @@ test_cmd grep -F "Module.ir" .lake/build/ir/Test/Module/ImportPublicMetaImport.s
 # https://github.com/leanprover/lean4/issues/13419
 test_run build Test.Module.MetaImportImport
 test_cmd grep -F "Module.ir" .lake/build/ir/Test/Module/MetaImportImport.setup.json
+# IR should be included when a module is re-visited with `needsMeta`
+# (reached via both a non-meta and a meta path)
+# TODO: currently broken, flip to `test_cmd` after fix
+test_run build Test.Module.MetaRevisit
+test_cmd_fails grep -F "Module.ir" .lake/build/ir/Test/Module/MetaRevisit.setup.json
 # IR should not be included for a transitive private `meta import`
 test_run build Test.Module.ImportMetaImport
 test_cmd_fails grep -F "Module.ir" .lake/build/ir/Test/Module/ImportMetaImport.setup.json

--- a/tests/lake/tests/module/test.sh
+++ b/tests/lake/tests/module/test.sh
@@ -65,9 +65,8 @@ test_run build Test.Module.MetaImportImport
 test_cmd grep -F "Module.ir" .lake/build/ir/Test/Module/MetaImportImport.setup.json
 # IR should be included when a module is re-visited with `needsMeta`
 # (reached via both a non-meta and a meta path)
-# TODO: currently broken, flip to `test_cmd` after fix
 test_run build Test.Module.MetaRevisit
-test_cmd_fails grep -F "Module.ir" .lake/build/ir/Test/Module/MetaRevisit.setup.json
+test_cmd grep -F "Module.ir" .lake/build/ir/Test/Module/MetaRevisit.setup.json
 # IR should not be included for a transitive private `meta import`
 test_run build Test.Module.ImportMetaImport
 test_cmd_fails grep -F "Module.ir" .lake/build/ir/Test/Module/ImportMetaImport.setup.json

--- a/tests/lake/tests/module/test.sh
+++ b/tests/lake/tests/module/test.sh
@@ -60,10 +60,9 @@ test_cmd_fails grep -F "Module.olean" .lake/build/ir/Test/Module/ImportImport.se
 test_run build Test.Module.ImportPublicMetaImport
 test_cmd grep -F "Module.ir" .lake/build/ir/Test/Module/ImportPublicMetaImport.setup.json
 # IR should be included for private imports of a `meta import`ed module
-# TODO: currently broken, flip to `test_cmd` after fix
 # https://github.com/leanprover/lean4/issues/13419
 test_run build Test.Module.MetaImportImport
-test_cmd_fails grep -F "Module.ir" .lake/build/ir/Test/Module/MetaImportImport.setup.json
+test_cmd grep -F "Module.ir" .lake/build/ir/Test/Module/MetaImportImport.setup.json
 # IR should not be included for a transitive private `meta import`
 test_run build Test.Module.ImportMetaImport
 test_cmd_fails grep -F "Module.ir" .lake/build/ir/Test/Module/ImportMetaImport.setup.json

--- a/tests/lake/tests/module/test.sh
+++ b/tests/lake/tests/module/test.sh
@@ -41,6 +41,9 @@ test_run build Test.Module.PromoteImport
 test_cmd grep -F "Module.olean.private" .lake/build/ir/Test/Module/PromoteImport.setup.json
 test_run build Test.Module.PromoteTransImport
 test_cmd grep -F "Module.olean.private" .lake/build/ir/Test/Module/PromoteTransImport.setup.json
+# an `import all` should not be demoted by a `meta import`
+test_run build Test.Module.PromoteMetaImport
+test_cmd grep -F "Module.olean.private" .lake/build/ir/Test/Module/PromoteMetaImport.setup.json
 # should be imported by a non-module
 test_run build Test.NonModule.Import
 test_cmd grep -F "Module.olean.private" .lake/build/ir/Test/NonModule/Import.setup.json

--- a/tests/lake/tests/module/test.sh
+++ b/tests/lake/tests/module/test.sh
@@ -42,8 +42,10 @@ test_cmd grep -F "Module.olean.private" .lake/build/ir/Test/Module/PromoteImport
 test_run build Test.Module.PromoteTransImport
 test_cmd grep -F "Module.olean.private" .lake/build/ir/Test/Module/PromoteTransImport.setup.json
 # an `import all` should not be demoted by a `meta import`
+# and `meta import` should still propagate through transitive imports
 test_run build Test.Module.PromoteMetaImport
-test_cmd grep -F "Module.olean.private" .lake/build/ir/Test/Module/PromoteMetaImport.setup.json
+test_cmd grep -F "ImportImport.olean.private" .lake/build/ir/Test/Module/PromoteMetaImport.setup.json
+test_cmd grep -F "Module.ir" .lake/build/ir/Test/Module/PromoteMetaImport.setup.json
 # should be imported by a non-module
 test_run build Test.NonModule.Import
 test_cmd grep -F "Module.olean.private" .lake/build/ir/Test/NonModule/Import.setup.json

--- a/tests/lake/tests/module/test.sh
+++ b/tests/lake/tests/module/test.sh
@@ -55,6 +55,19 @@ test_cmd_fails grep -F "Module.olean.private" .lake/build/ir/Test/Module/ImportA
 test_run build Test.Module.ImportImport
 test_cmd_fails grep -F "Module.olean" .lake/build/ir/Test/Module/ImportImport.setup.json
 
+# Tests that `meta import` properly includes transitive import artifacts
+# IR should be included for a transitive `public meta import`
+test_run build Test.Module.ImportPublicMetaImport
+test_cmd grep -F "Module.ir" .lake/build/ir/Test/Module/ImportPublicMetaImport.setup.json
+# IR should be included for private imports of a `meta import`ed module
+# TODO: currently broken, flip to `test_cmd` after fix
+# https://github.com/leanprover/lean4/issues/13419
+test_run build Test.Module.MetaImportImport
+test_cmd_fails grep -F "Module.ir" .lake/build/ir/Test/Module/MetaImportImport.setup.json
+# IR should not be included for a transitive private `meta import`
+test_run build Test.Module.ImportMetaImport
+test_cmd_fails grep -F "Module.ir" .lake/build/ir/Test/Module/ImportMetaImport.setup.json
+
 # Build all tests before making an edit
 test_run build
 


### PR DESCRIPTION
This PR fixes a Lake issue where the IR for a `meta import`'s transitive imports was not included in the import artifacts Lake provided to Lean (e.g., via `--setup`). When using the Lake artifact cache, this could produce "missing data file" errors due to absent IR.

Closes #13419
