### PR TITLE
fix: lake: await `needs` before processing module headers

### DIFF
--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -497,9 +497,20 @@ Recursively build a module's dependencies, including:
 * `extraDepTargets` of its library
 -/
 def Module.recFetchSetup (mod : Module) : FetchM (Job ModuleSetup) := ensureJob do
-  let extraDepJob ← mod.lib.extraDep.fetch
-  let headerJob ← mod.header.fetch
+  /-
+  Remark: Await extra target dependencies (e.g., cloud releases, `needs`) before any
+  other module processing. This both enables the dependencies to effect these elements
+  and prevents them from racing with the processing here ([1]).
 
+  An `await` is used here rather than `bindM` because keeping import graph processing on
+  a single thread is simpler and the build would need to block on this regardless.
+
+  [1]: https://github.com/leanprover/lean4/issues/13598
+  -/
+  let extraDepJob ← mod.lib.extraDep.fetch
+  discard extraDepJob.await
+
+  let headerJob ← mod.header.fetch
   /-
   Remark: We must build direct imports before we fetch the transitive
   precompiled imports so that errors in the import block of transitive imports
@@ -523,7 +534,6 @@ def Module.recFetchSetup (mod : Module) : FetchM (Job ModuleSetup) := ensureJob 
   let pluginsJob ← mod.plugins.fetchIn mod.pkg "module plugins"
 
   headerJob.bindM (sync := true) fun header => do
-  extraDepJob.bindM (sync := true) fun _ => do
   impInfoJob.bindM (sync := true) fun info => do
   newTrace
   impLibsJob.bindM (sync := true) fun impLibs => do


### PR DESCRIPTION
This PR changes Lake's module import graph processing to await the completion of any `needs` targets or other extra dependencies (such as cloud releases). This both enables the `needs` targets to influence header processing and prevents them from racing with said processing.

**Known Limitation:** This PR currently blocks on the `needs` targets rather than running the import processing in a callback. This is done to keep import processing simple and in a single thread. If this proves to be a performance issue, this can be restructured in a future PR with a more sophisticated refactor.

Closes #13598