### PR TITLE
chore: export function needed to implement dead / unused code detection functions outside of Lean core by users

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,7 @@ project(LEAN CXX C)
 set(LEAN_VERSION_MAJOR 4 CACHE STRING "")
 set(LEAN_VERSION_MINOR 31 CACHE STRING "")
 set(LEAN_VERSION_PATCH 0 CACHE STRING "")
-set(LEAN_VERSION_IS_RELEASE 0 CACHE STRING "") # This number is 1 in the release revision, and 0 otherwise.
+set(LEAN_VERSION_IS_RELEASE 1 CACHE STRING "") # This number is 1 in the release revision, and 0 otherwise.
 set(LEAN_SPECIAL_VERSION_DESC "" CACHE STRING "Additional version description like 'nightly-2018-03-11'")
 # project(LEAN) above implicitly creates empty LEAN_VERSION_{MAJOR,MINOR,PATCH}
 # normal variables (CMake sets <PROJECT>_VERSION_* for the project name). These

--- a/src/Lean/ExtraModUses.lean
+++ b/src/Lean/ExtraModUses.lean
@@ -76,6 +76,10 @@ builtin_initialize extraModUses : SimplePersistentEnvExtension ExtraModUse (PHas
 public def getExtraModUses (env : Environment) (modIdx : ModuleIdx) : Array ExtraModUse :=
   extraModUses.getModuleEntries env modIdx
 
+/-- Returns additional recorded import dependencies of the module currently being elaborated. -/
+public def getExtraModUsesInEnv (env : Environment) : Array ExtraModUse :=
+  (extraModUses.getState (asyncMode := .local) env).fold (init := #[]) fun acc e => acc.push e
+
 /-- Copies additional recorded import dependencies from one environment to another. -/
 public def copyExtraModUses (src dest : Environment) : Environment := Id.run do
   let mut env := dest

--- a/src/lake/Lake/Config/Env.lean
+++ b/src/lake/Lake/Config/Env.lean
@@ -42,6 +42,8 @@ public structure Env where
   noCache : Bool
   /-- Whether the Lake artifact cache should be enabled by default (i.e., `LAKE_ARTIFACT_CACHE`). -/
   enableArtifactCache? : Option Bool
+  /-- Whether to restore all artifacts from the Lake cache by default (i.e., `LAKE_RESTORE_ARTIFACTS`). -/
+  restoreAllArtifacts? : Option Bool
   /-- Whether the system cache has been disabled (`LAKE_CACHE_DIR` is set but empty). -/
   noSystemCache : Bool := false
   /--
@@ -173,6 +175,7 @@ public def compute
     reservoirApiUrl := ← getUrlD "RESERVOIR_API_URL" s!"{reservoirBaseUrl}/v1"
     noCache := (noCache <|> (← IO.getEnv "LAKE_NO_CACHE").bind envToBool?).getD false
     enableArtifactCache? := (← IO.getEnv "LAKE_ARTIFACT_CACHE").bind envToBool?
+    restoreAllArtifacts? := (← IO.getEnv "LAKE_RESTORE_ARTIFACTS").bind envToBool?
     lakeConfig? := (← IO.getEnv "LAKE_CONFIG") <|> userHome?.map (· / ".lake" / "config.toml" |>.toString)
     cacheKey? := (← IO.getEnv "LAKE_CACHE_KEY").map (·.trimAscii.copy)
     cacheArtifactEndpoint? := (← IO.getEnv "LAKE_CACHE_ARTIFACT_ENDPOINT").map normalizeUrl
@@ -306,6 +309,7 @@ public def vars (env : Env) : Array (String × Option String)  :=
   let vars := env.baseVars ++ #[
     ("LAKE_CACHE_DIR", if let some cache := env.lakeCache? then cache.dir.toString else ""),
     ("LAKE_ARTIFACT_CACHE", if let some b := env.enableArtifactCache? then toString b else ""),
+    ("LAKE_RESTORE_ARTIFACTS", if let some b := env.restoreAllArtifacts? then toString b else ""),
     ("LEAN_PATH", some env.leanPath.toString),
     ("LEAN_SRC_PATH", some env.leanSrcPath.toString),
     ("LEAN_GITHASH", env.leanGithash),

--- a/src/lake/Lake/Config/Package.lean
+++ b/src/lake/Lake/Config/Package.lean
@@ -52,6 +52,8 @@ public structure Package where
   remoteUrl : String
   /-- Dependency configurations for the package. -/
   depConfigs : Array Dependency := #[]
+  /-- **For internal use only.** Workspace indices of the resolved direct dependencies of the package. -/
+  depIdxs : Array Nat := #[]
   /-- **For internal use only.** Resolved direct dependences of the package. -/
   depPkgs : Array Package := #[]
   /-- Target configurations in the order declared by the package. -/

--- a/src/lake/Lake/Config/PackageConfig.lean
+++ b/src/lake/Lake/Config/PackageConfig.lean
@@ -293,8 +293,10 @@ public configuration PackageConfig (p : Name) (n : Name) extends WorkspaceConfig
   artifacts into the build directory. This ensures the build results are available
   to external consumers who expect them in the build directory.
 
-  If `none` (the default), this will follow the workspace's `restoreAllArtifacts` configuration
-  (if set and this package is a dependency). If that is also unset, this will default to `false`.
+  If `none` (the default), this will fallback to (in order):
+  * The `LAKE_RESTORE_ARTIFACTS` environment variable (if set).
+  * The workspace root's `restoreAllArtifacts` configuration (if set and this package is a dependency).
+  * **Lake's default**: `false`.
   -/
   restoreAllArtifacts?, restoreAllArtifacts : Option Bool := none
 

--- a/src/lake/Lake/Config/Workspace.lean
+++ b/src/lake/Lake/Config/Workspace.lean
@@ -61,6 +61,7 @@ public structure Workspace.Raw : Type where
 public structure Workspace.Raw.WF (ws : Workspace.Raw) : Prop where
   size_packages_pos : 0 < ws.packages.size
   packages_wsIdx : ∀ (h : i < ws.packages.size), (ws.packages[i]'h).wsIdx = i
+  depIdxs_packages : ∀ pkg ∈ ws.packages, ∀ i ∈ pkg.depIdxs, i < ws.packages.size
 
 /-- A Lake workspace -- the top-level package directory. -/
 public structure Workspace extends raw : Workspace.Raw, wf : raw.WF
@@ -71,11 +72,12 @@ noncomputable def Workspace.ofSize (n : Nat) (h : 0 < n) : Workspace := {
   lakeConfig := Classical.ofNonempty
   lakeCache := Classical.ofNonempty
   packages := (0...<n).toArray.map fun i =>
-    {(Classical.ofNonempty : Package) with wsIdx := i}
+    {(Classical.ofNonempty : Package) with wsIdx := i, depIdxs := #[]}
   size_packages_pos := by
     simp [Std.Rco.size, Std.Rxo.HasSize.size, Std.Rxc.HasSize.size, h]
   packages_wsIdx {i} h := by
     simp [Std.Rco.getElem_toArray_eq, Std.PRange.succMany?]
+  depIdxs_packages := by simp
 }
 
 theorem Workspace.size_packages_ofSize :
@@ -211,25 +213,32 @@ This is configured through {lit}`cache.service` entries in the system Lake confi
   self.lakeDir / "package-overrides.json"
 
 /-- **For internal use only.** Add a well-formed package to the workspace. -/
-@[inline] public def addPackage' (pkg : Package) (self : Workspace) (h : pkg.wsIdx = self.packages.size) : Workspace :=
-  {self with
-    packages := self.packages.push pkg
-    packageMap := self.packageMap.insert pkg.keyName pkg
-    size_packages_pos := by simp
-    packages_wsIdx {i} i_lt := by
-      cases Nat.lt_add_one_iff_lt_or_eq.mp <| Array.size_push .. ▸ i_lt with
-      | inl i_lt => simpa [Array.getElem_push_lt i_lt] using self.packages_wsIdx i_lt
-      | inr i_eq => simpa [i_eq] using h
-  }
+@[inline] public def addPackage'
+  (pkg : Package) (self : Workspace)
+  (h_wsIdx : pkg.wsIdx = self.packages.size) (h_depIdxs : pkg.depIdxs = #[])
+: Workspace := {self with
+  packages := self.packages.push pkg
+  packageMap := self.packageMap.insert pkg.keyName pkg
+  size_packages_pos := by simp
+  packages_wsIdx {i} i_lt := by
+    cases Nat.lt_add_one_iff_lt_or_eq.mp <| Array.size_push .. ▸ i_lt with
+    | inl i_lt => simpa [Array.getElem_push_lt i_lt] using self.packages_wsIdx i_lt
+    | inr i_eq => simpa [i_eq] using h_wsIdx
+  depIdxs_packages {p} p_mem {i} i_mem := by
+    simp only [Array.size_push]
+    cases Array.mem_push.mp p_mem with
+    | inl p_mem => exact Nat.lt_add_one_of_lt <| self.depIdxs_packages p p_mem i i_mem
+    | inr p_eq => simp [p_eq, h_depIdxs] at i_mem
+}
 
 /-- **For internal use only.** -/
 public theorem packages_addPackage' :
-  (addPackage' pkg ws h).packages = ws.packages.push pkg
+  (addPackage' pkg ws h h').packages = ws.packages.push pkg
 := by rfl
 
 /-- Add a package to the workspace. -/
 @[inline] public def addPackage (pkg : Package) (self : Workspace) : Workspace :=
-  self.addPackage' {pkg with wsIdx := self.packages.size} rfl
+  self.addPackage' {pkg with wsIdx := self.packages.size, depIdxs := #[]} rfl rfl
 
 /-- Returns the unique package in the workspace (if any) that is identified by  {lean}`keyName`. -/
 @[inline] public protected def findPackageByKey? (keyName : Name) (self : Workspace) : Option (NPackage keyName) :=

--- a/src/lake/Lake/Config/Workspace.lean
+++ b/src/lake/Lake/Config/Workspace.lean
@@ -149,7 +149,7 @@ public abbrev isRootArtifactCacheEnabled (ws : Workspace) : Bool :=
 
 /-- Whether artifacts should be restored by default from the Lake cache for packages in the workspace. -/
 @[inline] public def restoreAllArtifacts? (ws : Workspace) : Option Bool :=
-  ws.root.restoreAllArtifacts?
+  ws.lakeEnv.restoreAllArtifacts? <|> ws.root.restoreAllArtifacts?
 
 /-- Returns the toolchain identifier for the Lake cache corresponding the workspace's toolchain. -/
 @[inline] public def cacheToolchain (ws : Workspace) : CacheToolchain :=
@@ -418,6 +418,7 @@ public def augmentedEnvVars (self : Workspace) : Array (String × Option String)
   let vars := self.lakeEnv.baseVars ++ #[
     ("LAKE_CACHE_DIR", some self.lakeCache.dir.toString),
     ("LAKE_ARTIFACT_CACHE", if let some b := self.enableArtifactCache? then toString b else ""),
+    ("LAKE_RESTORE_ARTIFACTS", if let some b := self.restoreAllArtifacts? then toString b else ""),
     ("LEAN_PATH", some self.augmentedLeanPath.toString),
     ("LEAN_SRC_PATH", some self.augmentedLeanSrcPath.toString),
     -- Allow the Lean version to change dynamically within core

--- a/src/lake/Lake/Load/Package.lean
+++ b/src/lake/Lake/Load/Package.lean
@@ -56,7 +56,8 @@ public def mkPackage
     postUpdateHooks
   }
 
-public theorem wsIdx_mkPackage : (mkPackage l f i).wsIdx = i := by rfl
+@[simp] public theorem wsIdx_mkPackage : (mkPackage l f i).wsIdx = i := by rfl
+@[simp] public theorem depIdxs_mkPackage : (mkPackage l f i).depIdxs = #[] := by rfl
 
 /--
 Return whether a configuration file with the given name

--- a/src/lake/Lake/Load/Resolve.lean
+++ b/src/lake/Lake/Load/Resolve.lean
@@ -14,7 +14,9 @@ import Lake.Config.Monad
 import Lake.Load.Materialize
 import Lake.Load.Lean.Eval
 import Lake.Load.Package
+import Init.Data.Vector.Lemmas
 import Init.Data.Range.Polymorphic.Iterators
+import Init.Data.Range.Polymorphic.Lemmas
 import Init.TacticsExtra
 import Lean.Runtime
 
@@ -68,17 +70,17 @@ def Workspace.addDepPackage'
   let ⟨loadCfg, h⟩ ← resolveConfigFile dep.prettyName loadCfg
   let fileCfg ← loadConfigFile loadCfg h
   let pkg := mkPackage loadCfg fileCfg wsIdx
-  let ws := ws.addPackage' pkg wsIdx_mkPackage |>.addFacetDecls fileCfg.facetDecls
+  let ws := ws.addPackage' pkg wsIdx_mkPackage depIdxs_mkPackage |>.addFacetDecls fileCfg.facetDecls
   return ⟨ws, by simp [ws, packages_addFacetDecls, packages_addPackage']⟩
 
 
-def Workspace.setDepPkgs
-  (self : Workspace) (pkg : Package) (depPkgs : Array Package)
-  (h : pkg.wsIdx < self.packages.size)
+def Workspace.setDepIdxs
+  (self : Workspace) (pkg : Package) (depIdxs : Array Nat)
+  (h_wsIdx : pkg.wsIdx < self.packages.size) (h_depIdxs : ∀ i ∈ depIdxs, i < self.packages.size)
 : Workspace :=
-  let pkg := {pkg with depPkgs}
+  let pkg := {pkg with depIdxs}
   {self with
-    packages := self.packages.set pkg.wsIdx pkg h
+    packages := self.packages.set pkg.wsIdx pkg h_wsIdx
     packageMap := self.packageMap.insert pkg.keyName pkg
     size_packages_pos := by simp [self.size_packages_pos]
     packages_wsIdx {i} := by
@@ -88,11 +90,45 @@ def Workspace.setDepPkgs
       split
       · assumption
       · rw [self.packages_wsIdx]
+    depIdxs_packages {p} p_mem {i} i_mem := by
+      simp only [Array.size_set]
+      cases Array.mem_or_eq_of_mem_set p_mem with
+      | inl p_mem => exact self.depIdxs_packages p p_mem i i_mem
+      | inr p_eq => apply h_depIdxs; simpa only [p_eq, pkg] using i_mem
   }
 
-theorem Workspace.size_packages_setDepPkgs :
-  (setDepPkgs ws pkg depPkgs h).packages.size = ws.packages.size
-:= by simp [setDepPkgs]
+@[local simp] theorem Workspace.size_packages_setDepIdxs :
+  (setDepIdxs ws pkg depIdxs h h').packages.size = ws.packages.size
+:= by simp [setDepIdxs]
+
+def Workspace.updateDepPkgs (self : Workspace) : Workspace :=
+  let s : {pkgs : Vector Package self.packages.size //
+    ∀ i, (h : i < pkgs.size) → pkgs[i].wsIdx = i ∧ ∀ j ∈ pkgs[i].depIdxs, j < pkgs.size} :=
+    ⟨self.packages.toVector, fun i i_lt => ⟨self.packages_wsIdx i_lt,
+      self.depIdxs_packages self.packages[i] (Array.getElem_mem ..)⟩⟩
+  -- Set `depPkgs` in reverse order (starting from a leaf package).
+  -- Since the workspace's packages are topologically sorted, no recursion is necessary.
+  let ⟨pkgs, h⟩ := self.packages.size.foldRev (init := s) fun i i_lt ⟨pkgs, h⟩ =>
+    let pkg := pkgs[i]'i_lt
+    let depPkgs := pkg.depIdxs.attach.map fun ⟨j, j_mem⟩ =>
+      pkgs[j]'(h i i_lt |>.2 j j_mem)
+    let pkgs' := pkgs.set i {pkg with depPkgs}
+    have h := by
+      intro j j_lt
+      simp only [Vector.getElem_set, Vector.size, pkgs', pkg]
+      split
+      · next i_eq => simpa [i_eq] using h j j_lt
+      · exact h j j_lt
+    ⟨pkgs', h⟩
+  {self with
+    packages := pkgs.toArray
+    packageMap := pkgs.foldl (fun map pkg => map.insert pkg.keyName pkg) {}
+    size_packages_pos := by simp [self.size_packages_pos]
+    packages_wsIdx {i} i_lt := h i (pkgs.size_toArray.subst i_lt) |>.1
+    depIdxs_packages p p_mem := by
+      have ⟨i, i_lt, p_eq⟩ := Array.mem_iff_getElem.mp p_mem
+      simpa [← p_eq] using h i (pkgs.size_toArray.subst i_lt) |>.2
+  }
 
 structure ResolveState (start : Nat) where
   ws : Workspace
@@ -130,11 +166,6 @@ namespace ResolveState
 
 end ResolveState
 
-abbrev MinWorkspace (ws : Workspace) :=
-  {ws' : Workspace // ws.packages.size ≤ ws'.packages.size}
-
-instance : Nonempty (MinWorkspace ws) := ⟨⟨ws, Nat.le_refl ..⟩⟩
-
 @[inline] unsafe def guardBySizeImpl [Pure m] [MonadError m] (as : Array α) : m (PLift (as.size ≤ Lean.maxSmallNat)) :=
   pure ⟨lcProof⟩
 
@@ -151,9 +182,9 @@ def guardBySize! [Pure m] [MonadError m] (as : Array α) : m (PLift (as.size ≤
   if h : as.size ≤ Lean.maxSmallNat then pure ⟨h⟩ else error "Array-bounded termination"
 
 /-
-Recursively visits each node in a package's dependency graph, starting from
-the workspace package `root`. Each dependency missing from the workspace is
-added to the workspace using the `resolve` function.
+Adds the package's dependencies to the workspace and then recursively vists
+each package in the dependency graph starting from `next`. Each dependency missing
+from the workspace is added to the workspace using the `resolve` function.
 
 Recursion occurs breadth-first. Each direct dependency of a package is
 resolved in reverse order before recursing to the dependencies' dependencies.
@@ -163,17 +194,18 @@ See `Workspace.updateAndMaterializeCore` for more details.
 @[inline] def Workspace.resolveDepsCore
   [Monad m] [MonadError m] [MonadLiftT LogIO m] (ws : Workspace)
   (resolve : Package → Dependency → Workspace → m MaterializedDep)
-  (root : Nat) (h : root < ws.packages.size)
+  (root : Nat) (root_lt : root < ws.packages.size)
+  (next := ws.packages.size) (next_lt : root < next)
   (leanOpts : Options := {}) (reconfigure := true)
-: m (MinWorkspace ws) := do
-  go ws root h
+: m Workspace := do
+  (·.updateDepPkgs) <$> go ws root root_lt next next_lt
 where
   @[specialize] go
-    (ws : Workspace) (wsIdx : Nat) (h : wsIdx < ws.packages.size)
-  : m (MinWorkspace ws) := do
+    (ws : Workspace) (i : Nat) (i_lt : i < ws.packages.size) (next : Nat) (lt_next : i < next)
+  : m Workspace := do
     let start := ws.packages.size
-    let pkg : Package := ws.packages[wsIdx]
-    have lt_start : pkg.wsIdx < start := ws.packages_wsIdx _ ▸ h
+    let pkg : Package := ws.packages[i]
+    have lt_start : pkg.wsIdx < start := ws.packages_wsIdx _ ▸ i_lt
     -- Materialize and load the missing direct dependencies of `pkg`
     let s := ResolveState.init ws pkg.depConfigs.size
     let ⟨ws, depIdxs, lt_of_mem, start_le⟩ ← pkg.depConfigs.foldrM (m := m) (init := s) fun dep s => do
@@ -183,31 +215,18 @@ where
         error s!"{pkg.prettyName}: package requires itself (or a package with the same name)"
       let matDep ← resolve pkg dep s.ws
       s.newDep matDep dep.opts leanOpts reconfigure
+    let ws := ws.setDepIdxs pkg depIdxs (Nat.lt_of_lt_of_le lt_start start_le) lt_of_mem
+    have start_le : start ≤ ws.packages.size := Nat.le_trans start_le (by simp [ws])
     -- Recursively load the dependencies' dependencies
-    let stop := ws.packages.size
-    let ⟨le_maxSmallNat⟩ ← guardBySize! ws.packages
-    let ⟨ws, stop_le⟩ ← id do
-      let mut ws' : {ws' : Workspace // stop ≤ ws'.packages.size} := ⟨ws, Nat.le_refl _⟩
-      for h_rco : wsIdx in (start...<stop) do
-        let ⟨ws, stop_le⟩ := ws'
-        have lt_stop := Std.Rco.lt_upper_of_mem h_rco
-        let ⟨ws, h⟩ ← go ws wsIdx <| Nat.lt_of_lt_of_le lt_stop stop_le
-        ws' := ⟨ws, Nat.le_trans stop_le h⟩
-      return ws'
-    have start_le := Nat.le_trans start_le stop_le
-    -- Add the package's dependencies to the package
-    let depPkgs := depIdxs.attach.map fun ⟨wsIdx, h_mem⟩ =>
-      ws.packages[wsIdx]'(Nat.lt_of_lt_of_le (lt_of_mem wsIdx h_mem) stop_le)
-    let ws := ws.setDepPkgs pkg depPkgs <| Nat.lt_of_lt_of_le lt_start start_le
-    have start_le := Nat.le_trans start_le <| by
-      simp [ws, Workspace.size_packages_setDepPkgs]
-    return ⟨ws, start_le⟩
-  termination_by Lean.maxSmallNat - wsIdx
+    if next_lt : next < ws.packages.size then
+      let ⟨le_maxSmallNat⟩ ← guardBySize! ws.packages
+      go ws next next_lt (next+1) (Nat.lt_add_one next)
+    else
+      return ws
+  termination_by Lean.maxSmallNat - i
   decreasing_by
-    have start_le := Std.Rco.lower_le_of_mem h_rco
-    have lt_wsIdx := Nat.lt_of_lt_of_le h start_le
-    refine Nat.sub_lt_sub_left (Nat.lt_of_lt_of_le lt_wsIdx ?_) lt_wsIdx
-    exact Nat.le_trans (Nat.le_of_lt lt_stop) le_maxSmallNat
+    refine Nat.sub_lt_sub_left ?_ lt_next
+    exact Nat.lt_of_lt_of_le i_lt (Nat.le_trans start_le le_maxSmallNat)
 
 /--
 Adds monad state used to update the manifest.
@@ -448,7 +467,7 @@ def Workspace.updateAndMaterializeCore
     ws.updateToolchain matDeps.toArray
     -- Load the top-level dependenciess
     let start := ws.packages.size
-    let ⟨ws, h⟩ ← id do
+    let ⟨ws, start_le⟩ ← id do
       let mut ws' : {ws : Workspace // start ≤ ws.packages.size} := ⟨ws, Nat.le_refl _⟩
       for h : i in 0...<numDeps do
         let matDep := matDeps[i]
@@ -458,22 +477,21 @@ def Workspace.updateAndMaterializeCore
         ws' := ⟨ws, Nat.le_trans ws'.property <| by simp [h]⟩
       return ws'
     let stop := ws.packages.size
-    have start_le_stop : start ≤ stop := h
-    -- Resolve the top-level dependencies' dependencies'
-    let ⟨ws, _⟩ ← id do
-      let mut ws' : {ws : Workspace // stop ≤ ws.packages.size} := ⟨ws, Nat.le_refl _⟩
-      for h : wsIdx in start...<stop do
-        let ⟨ws, stop_le⟩ := ws'
-        have h := Nat.lt_of_lt_of_le (Std.Rco.lt_upper_of_mem h) stop_le
-        let ⟨ws, h⟩ ← ws.resolveDepsCore updateAndAddDep wsIdx h
-          (leanOpts := leanOpts) (reconfigure := true)
-        ws' := ⟨ws, Nat.le_trans stop_le h⟩
-      return ws'
-    -- Set dependency packages after `resolveDepsCore` so
-    -- that the dependencies' dependencies are also properly set
-    return ws.setDepPkgs ws.root ws.packages[start...<stop] ws.wsIdx_root_lt
+    let ws := ws.setDepIdxs ws.root (start...<stop).toArray ws.wsIdx_root_lt <| by
+      simp [Std.Rco.mem_toArray_iff_mem, Std.Rco.mem_iff, stop]
+    if start_ne : start ≠ stop then
+      -- Resolve the top-level dependencies' dependencies'
+      have start_lt : start < ws.packages.size := by
+        simpa [ws] using Nat.lt_of_le_of_ne start_le start_ne
+      ws.resolveDepsCore updateAndAddDep
+        start start_lt (start+1) (Nat.lt_add_one start)
+        (leanOpts := leanOpts) (reconfigure := true)
+    else
+      return ws.updateDepPkgs
   else
-    ws.resolveDepsCore updateAndAddDep ws.root.wsIdx ws.wsIdx_root_lt leanOpts (reconfigure := true)
+    ws.resolveDepsCore updateAndAddDep
+      ws.root.wsIdx ws.wsIdx_root_lt ws.packages.size ws.wsIdx_root_lt
+      (leanOpts := leanOpts) (reconfigure := true)
 where
   @[inline] updateAndAddDep pkg dep ws := do
     let matDep ← updateAndMaterializeDep ws pkg dep
@@ -584,4 +602,6 @@ public def Workspace.materializeDeps
           this suggests that the manifest is corrupt; \
           use `lake update` to generate a new, complete file \
           (warning: this will update ALL workspace dependencies)"
-  ws.resolveDepsCore materialize ws.root.wsIdx ws.wsIdx_root_lt leanOpts reconfigure
+  ws.resolveDepsCore materialize
+    ws.root.wsIdx ws.wsIdx_root_lt ws.packages.size ws.wsIdx_root_lt
+    leanOpts reconfigure

--- a/src/lake/Lake/Load/Workspace.lean
+++ b/src/lake/Lake/Load/Workspace.lean
@@ -50,6 +50,7 @@ public def loadWorkspaceRoot (config : LoadConfig) : LogIO Workspace := do
       cases i with
       | zero => simp [wsIdx_root]
       | succ => simp at h
+    depIdxs_packages := by simp [root]
   }
 
 /--

--- a/src/lake/schemas/lakefile-toml-schema.json
+++ b/src/lake/schemas/lakefile-toml-schema.json
@@ -473,7 +473,7 @@
                 },
                 "restoreAllArtifacts": {
                     "type": "boolean",
-                    "description": "Whether, when the local artifact cache is enabled, Lake should copy all cached artifacts into the build directory. This ensures the build results are available to external consumers who expect them in the build directory."
+                    "description": "Whether, when the local artifact cache is enabled, Lake should copy all cached artifacts into the build directory. This ensures the build results are available to external consumers who expect them in the build directory.\n\nIf `none` (the default), this will fallback to (in order):\n* The `LAKE_RESTORE_ARTIFACTS` environment variable (if set).\n* The workspace root's `restoreAllArtifacts` configuration (if set and this package is a dependency).\n* **Lake's default**: `false`."
                 },
                 "srcDir": {
                     "type": "string",

--- a/tests/lake/run_test.sh
+++ b/tests/lake/run_test.sh
@@ -9,5 +9,4 @@ LAKE=${LAKE:-$(lake query lake)}
 
 # Run the test
 TEST_DIR="$1"; shift
-cd "$TEST_DIR"
-$LAKE env bash test.sh
+$LAKE env bash -c "cd "$TEST_DIR" && source test.sh"

--- a/tests/lake/tests/cache/lakefile.lean
+++ b/tests/lake/tests/cache/lakefile.lean
@@ -3,7 +3,7 @@ open System Lake DSL
 
 package test where
   enableArtifactCache := true
-  restoreAllArtifacts := get_config? restoreAll |>.isSome
+  restoreAllArtifacts := get_config? restoreAll |>.bind envToBool?
 
 lean_lib Test
 

--- a/tests/lake/tests/cache/test.sh
+++ b/tests/lake/tests/cache/test.sh
@@ -129,6 +129,13 @@ test_out "restored artifact from cache" -v build +Ignored --no-build
 test_run -v build Test.ImportIgnored
 test_run resolve-deps -R
 
+# Test that `LAKE_RESTORE_ARTIFACTS` overrides the
+# workspace's (unset) `restoreAllArtifacts` default.
+echo "def foo := ()" > Ignored.lean
+test_not_out "Ignored.olean" -v build +Ignored --no-build
+echo "def bar := ()" > Ignored.lean
+LAKE_RESTORE_ARTIFACTS=true test_out "Ignored.olean" -v build +Ignored --no-build
+
 # Test that outdated files are not stored in the cache with `--old`
 echo "def baz := ()" > Ignored.lean
 test_out "Built Ignored" -v build +Ignored --old

--- a/tests/lake/tests/env/noRestoreArtifacts.toml
+++ b/tests/lake/tests/env/noRestoreArtifacts.toml
@@ -1,0 +1,2 @@
+name = "test"
+restoreAllArtifacts = false

--- a/tests/lake/tests/env/restoreAllArtifacts.toml
+++ b/tests/lake/tests/env/restoreAllArtifacts.toml
@@ -1,0 +1,2 @@
+name = "test"
+restoreAllArtifacts = true

--- a/tests/lake/tests/env/test.sh
+++ b/tests/lake/tests/env/test.sh
@@ -53,6 +53,15 @@ LAKE_ARTIFACT_CACHE= test_eq "true" -f enableArtifactCache.toml env printenv LAK
 LAKE_ARTIFACT_CACHE= test_eq "false" -f disableArtifactCache.toml env printenv LAKE_ARTIFACT_CACHE
 test_cmd rm lake-manifest.json
 
+# Test `LAKE_RESTORE_ARTIFACTS` setting and default
+LAKE_RESTORE_ARTIFACTS=true test_eq "true" env printenv LAKE_RESTORE_ARTIFACTS
+LAKE_RESTORE_ARTIFACTS=false test_eq "false" env printenv LAKE_RESTORE_ARTIFACTS
+LAKE_RESTORE_ARTIFACTS= test_eq "" env printenv LAKE_RESTORE_ARTIFACTS
+LAKE_RESTORE_ARTIFACTS= test_eq "" -d hello env printenv LAKE_RESTORE_ARTIFACTS
+LAKE_RESTORE_ARTIFACTS= test_eq "true" -f restoreAllArtifacts.toml env printenv LAKE_RESTORE_ARTIFACTS
+LAKE_RESTORE_ARTIFACTS= test_eq "false" -f noRestoreArtifacts.toml env printenv LAKE_RESTORE_ARTIFACTS
+test_cmd rm lake-manifest.json
+
 # Test `LAKE_PKG_URL_MAP` setting and errors
 echo "# TEST: LAKE_PKG_URL_MAP"
 LAKE_PKG_URL_MAP='{"a":"a"}' test_eq '{"a":"a"}' env printenv LAKE_PKG_URL_MAP

--- a/tests/lake/tests/query/deepDep/lakefile.toml
+++ b/tests/lake/tests/query/deepDep/lakefile.toml
@@ -1,0 +1,1 @@
+name = "deepDep"

--- a/tests/lake/tests/query/dep/lakefile.toml
+++ b/tests/lake/tests/query/dep/lakefile.toml
@@ -1,1 +1,5 @@
 name = "dep"
+
+[[require]]
+name = "dupDep"
+path = "../dupDep"

--- a/tests/lake/tests/query/dupDep/lakefile.toml
+++ b/tests/lake/tests/query/dupDep/lakefile.toml
@@ -1,0 +1,5 @@
+name = "dupDep"
+
+[[require]]
+name = "deepDep"
+path = "../deepDep"

--- a/tests/lake/tests/query/lakefile.lean
+++ b/tests/lake/tests/query/lakefile.lean
@@ -3,6 +3,9 @@ open System Lake DSL
 
 package test
 
+-- used to test overriden transitive deps have
+-- their `depPkgs` fields properly instantiated
+require dupDep from "dupDep"
 require dep from "dep"
 
 lean_lib lib where

--- a/tests/lake/tests/query/test.sh
+++ b/tests/lake/tests/query/test.sh
@@ -21,8 +21,12 @@ test_eq "B" query +A:imports
 test_eq '["C","B"]' query +A:transImports --json
 
 # Test querying deps
-test_eq "dep" query :deps
-test_eq '["dep.1"]' query :transDeps --json
+$LAKE query :deps | diff -u --strip-trailing-cr <(cat << 'EOF'
+dep
+dupDep
+EOF
+) -
+test_eq '["deepDep.3","dupDep.2","dep.1"]' query :transDeps --json
 
 echo "# UNCOMMON TESTS"
 set -x


### PR DESCRIPTION

This PR makes a single function public so i can use it for dead code detection in a Lean linter I am working on. See the Lint rule at https://codeberg.org/wvhulle/heron/src/branch/main/Heron/Check/UnusedImport.lean

