### PR TITLE
fix: remove incorrect assertion at `Sym/Simp/Have.lean`

### DIFF
--- a/src/Lean/Meta/Sym/Simp/Have.lean
+++ b/src/Lean/Meta/Sym/Simp/Have.lean
@@ -165,9 +165,9 @@ where
   go (e : Expr) (xs xs' args subst types : Array Expr) (varDeps : Array (Array Nat)) (fvarIdToPos : FVarIdMap Nat)
       : SymM ToBetaAppResult := do
     if let .letE n t v b (nondep := true) := e then
-      assert! !t.hasLooseBVars
-      withLocalDeclD n t fun x => do
+      let t := t.instantiateRev xs
       let v := v.instantiateRev xs
+      withLocalDeclD n t fun x => do
       let fvarIds := collectFVarIdsAt v fvarIdToPos
       let varPos := fvarIds.map (fvarIdToPos.getD · 0)
       let ys := fvarIds.map mkFVar


### PR DESCRIPTION
This PR fixes an assertion failure in `Sym.simp` when simplifying a `have`-expression whose binder type depends on a preceding binder in the telescope.

The simproc that beta-applies a chain of nested non-dependent `let`-expressions previously asserted that each binder type `t` contained no loose bound variables. This assumption is not valid: a later binder's type may refer to earlier `have`-binders. The fix instantiates `t` with the accumulated binders `xs` before introducing the new local declaration.