### PR TITLE
fix: missing case in `processLevel` at `SymM`

### DIFF
--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -331,7 +331,55 @@ def assignLevel (uidx : Nat) (u : Level) : UnifyM Bool := do
     modify fun s => { s with uAssignment := s.uAssignment.set! uidx (some u) }
     return true
 
-def processLevel (u : Level) (v : Level) : UnifyM Bool :=
+/-- Returns `true` is `u` has assigned uvars. -/
+def hasAssignedUVars (assignment : Array (Option Level)) (u : Level) : Bool :=
+  go u
+where
+  go (u : Level) : Bool := Id.run do
+    unless u.hasParam do return false
+    match u with
+    | .succ u₁ => go u₁
+    | .max u₁ u₂ | .imax u₁ u₂ => go u₁ || go u₂
+    | .param name =>
+      let some uidx := isUVar? name | return false
+      if h : uidx < assignment.size then return assignment[uidx].isSome
+      return false
+    | _ => false
+
+/-- Substitutes uvars in `u` with their assignments. -/
+def substAssignedUVars (assignment : Array (Option Level)) (u : Level) : Level :=
+  go u
+where
+  go (u : Level) : Level := Id.run do
+    match u with
+    | .succ u₁    => return .succ (go u₁)
+    | .max u₁ u₂  => return .max (go u₁) (go u₂)
+    | .imax u₁ u₂ => return .imax (go u₁) (go u₂)
+    | .param name =>
+      let some uidx := isUVar? name | return u
+      if h : uidx < assignment.size then
+        let some v := assignment[uidx] | return u
+        return v
+      else
+        return u
+    | _ => return u
+
+/-- Substitutes uvars in `u` with their assignments, and then normalize. -/
+def substAssignedUVarsAndNormalize (u : Level) : UnifyM Level := do
+  let assignment := (← get).uAssignment
+  unless hasAssignedUVars assignment u do return u
+  let v := substAssignedUVars assignment u
+  return v.normalize
+
+def processLevel (u : Level) (v : Level) : UnifyM Bool := do
+  /-
+  **Note**: If new uvars in `u` have been assigned, we continue replace them, and
+  continue the search. The motivation for using `substAssignedUVarsAndNormalize` is
+  `processLevels [_uvar.0, max _uvar.0 _uvar.1] [0, u_1]`
+  which invokes `processLevel _uvar.0 0` and assigns `_uvar.0` before we invoke
+  `processLevel (max _uvar.0 _uvar.1) u_1`
+  -/
+  let u ← substAssignedUVarsAndNormalize u
   go u v.normalize
 where
   go (u : Level) (v : Level) : UnifyM Bool := do

--- a/tests/elab/sym_pattern_universe_issue.lean
+++ b/tests/elab/sym_pattern_universe_issue.lean
@@ -1,0 +1,58 @@
+/-
+Standalone reproducer for universe level matching bug in Sym.Pattern.match?.
+
+When matching `Spec.get_StateT` pattern against `MonadStateOf.get`, the pattern
+has universe levels `[_uvar.0, max _uvar.0 _uvar.1]` while the expression has
+`[0, u_1]`. The match fails because `processLevel` has no case for
+`.max u₁ u₂` vs `.param _` — it falls through to `| _, _ => return false`.
+
+The fix should substitute already-assigned uvars before the fallthrough, or add
+a case that handles `.max` vs non-`.max` by trying to assign the remaining uvars.
+-/
+module
+
+import Lean
+import Std
+
+open Lean Meta Sym Std Do
+
+/--
+info: Expression: MonadStateOf.get
+---
+info: Expr fn levels: [0, u_1]
+---
+info: Match SUCCEEDED: 2 levels, 6 args
+-/
+#guard_msgs in
+#eval show MetaM Unit from do
+  -- 1. Build the pattern from the spec theorem, keyed on the program
+  let info ← getConstInfo ``Spec.get_StateT
+  let levelParams := info.levelParams
+  let proof := mkConst ``Spec.get_StateT (levelParams.map mkLevelParam)
+  let (pat, _) ← Sym.mkPatternFromExprWithKey proof levelParams fun type => do
+    let_expr Triple _m _ps _inst _α prog _P _Q := type
+      | throwError "not a Triple: {type}"
+    return (prog, ())
+
+  -- 2. Build target: @MonadStateOf.get (Nat × Nat) (StateT (Nat × Nat) m) inst
+  let u1 := Level.param `u_1
+  let mTy ← mkArrow (mkSort 1) (mkSort u1.succ)
+  withLocalDeclD `m mTy fun m => do
+  let instMonadTy ← mkAppM ``Monad #[m]
+  withLocalDeclD `inst_Monad instMonadTy fun _instMonad => do
+    let σ := mkApp2 (mkConst ``Prod [.zero, .zero]) (mkConst ``Nat) (mkConst ``Nat)
+    let stateT := mkApp2 (mkConst ``StateT [.zero, u1]) σ m
+    let instMSO ← synthInstance (mkApp2 (mkConst ``MonadStateOf [.zero, u1]) σ stateT)
+    let e := mkApp3 (mkConst ``MonadStateOf.get [.zero, u1]) σ stateT instMSO
+    logInfo m!"Expression: {e}"
+    logInfo m!"Expr fn levels: {e.getAppFn.constLevels!}"
+
+    -- 3. Try pattern matching
+    let result ← SymM.run (pat.match? e)
+    match result with
+    | some res =>
+      logInfo m!"Match SUCCEEDED: {res.us.length} levels, {res.args.size} args"
+    | none =>
+      logInfo m!"Match FAILED — this is the bug"
+      logInfo m!"  Pattern fn levels: {pat.pattern.getAppFn.constLevels!}"
+      logInfo m!"  Expression fn levels: {e.getAppFn.constLevels!}"


### PR DESCRIPTION
This PR improves the universe unifier used by `SymM`.
