### PR TITLE
fix: another `grind` AC invariant

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/AC/Inv.lean
+++ b/src/Lean/Meta/Tactic/Grind/AC/Inv.lean
@@ -29,9 +29,9 @@ Recall that we only (fully) simplify them when adding them to the basis.
 def checkSeq (s : AC.Seq) (simplified : Bool) : ACM Unit := do
   if (← isCommutative) then
     assert! s.isSorted
-  if (← hasNeutral) then
-    assert! !s.contains 0 || s == .var 0
   if simplified then
+    if (← hasNeutral) then
+      assert! !s.contains 0 || s == .var 0
     if (← isIdempotent) then
       assert! s.noAdjacentDuplicates
 

--- a/tests/elab/grind_ac_inv_issue_2.lean
+++ b/tests/elab/grind_ac_inv_issue_2.lean
@@ -1,0 +1,10 @@
+module
+
+open List
+
+set_option grind.debug true in
+theorem getLast_getLast_eq_getLast_flatten {l : List (List α)}
+    (hl : l ≠ []) (hl' : l.getLast hl ≠ []) :
+    (l.getLast hl).getLast hl' =
+      l.flatten.getLast (flatten_ne_nil_iff.2 ⟨_, getLast_mem hl, hl'⟩) := by
+  cases eq_nil_or_concat l with grind


### PR DESCRIPTION
This PR fixes another issue in the `grind` AC invariant checker.
