### PR TITLE
fix: missing proof hints in `grind` propagators

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/Ctor.lean
+++ b/src/Lean/Meta/Tactic/Grind/Ctor.lean
@@ -23,12 +23,14 @@ private partial def propagateInjEqs (eqs : Expr) (proof : Expr) (generation : Na
     let rhs ← preprocessLight rhs
     internalize lhs generation
     internalize rhs generation
+    let proof := mkExpectedPropHint proof (← mkEq lhs rhs)
     pushEq lhs rhs proof
   | HEq _ lhs _ rhs =>
     let lhs ← preprocessLight lhs
     let rhs ← preprocessLight rhs
     internalize lhs generation
     internalize rhs generation
+    let proof := mkExpectedPropHint proof (← mkHEq lhs rhs)
     pushHEq lhs rhs proof
   | _ =>
    reportIssue! "unexpected injectivity theorem result type{indentExpr eqs}"

--- a/src/Lean/Meta/Tactic/Grind/Proj.lean
+++ b/src/Lean/Meta/Tactic/Grind/Proj.lean
@@ -45,6 +45,8 @@ def propagateProjEq (parent : Expr) : GoalM Unit := do
   let idx := info.numParams + info.i
   unless idx < ctor.getAppNumArgs do return ()
   let v := ctor.getArg! idx
-  pushEq parentNew v (← mkEqRefl v)
+  let h ← mkEqRefl v
+  let h := mkExpectedPropHint h (← mkEq parentNew v)
+  pushEq parentNew v h
 
 end Lean.Meta.Grind

--- a/tests/elab/grind_def_eq_inv_issue.lean
+++ b/tests/elab/grind_def_eq_inv_issue.lean
@@ -1,5 +1,5 @@
 namespace Sigma
-
+set_option warn.sorry false
 def map (f₁ : α₁ → α₂) (f₂ : ∀ a, β₁ a → β₂ (f₁ a)) (x : Sigma β₁) : Sigma β₂ :=
   ⟨f₁ x.1, f₂ x.1 x.2⟩
 

--- a/tests/elab/grind_def_eq_inv_issue.lean
+++ b/tests/elab/grind_def_eq_inv_issue.lean
@@ -1,0 +1,38 @@
+namespace Sigma
+
+def map (f₁ : α₁ → α₂) (f₂ : ∀ a, β₁ a → β₂ (f₁ a)) (x : Sigma β₁) : Sigma β₂ :=
+  ⟨f₁ x.1, f₂ x.1 x.2⟩
+
+end Sigma
+
+public section
+
+namespace List
+
+variable {α : Type} {α' : Type} {β : α → Type} {β' : α' → Type} {l l₁ l₂ : List (Sigma β)}
+
+def keys : List (Sigma β) → List α :=
+  sorry
+
+variable [DecidableEq α] [DecidableEq α']
+
+/--
+error: `grind` failed
+case grind
+α : Type
+β β' : α → Type
+f : (a : α) → β a → β' a
+head : (a : α) × β a
+tail : List ((a : α) × β a)
+tail_ih : (map (Sigma.map id f) tail).keys = tail.keys
+h : ¬(map (Sigma.map id f) (head :: tail)).keys = (head :: tail).keys
+⊢ False
+-/
+#guard_msgs in
+set_option grind.debug true in
+omit [DecidableEq α] in
+theorem map₂_keys {β β' : α → Type} (f : (a : α) → β a → β' a) (l : List (Σ a, β a)) :
+    (l.map (.map id f)).keys = l.keys := by
+  induction l
+  · sorry
+  · grind -verbose [Sigma.map]

--- a/tests/elab/grind_def_eq_inv_issue.lean
+++ b/tests/elab/grind_def_eq_inv_issue.lean
@@ -1,5 +1,4 @@
 namespace Sigma
-set_option warn.sorry false
 def map (f₁ : α₁ → α₂) (f₂ : ∀ a, β₁ a → β₂ (f₁ a)) (x : Sigma β₁) : Sigma β₂ :=
   ⟨f₁ x.1, f₂ x.1 x.2⟩
 
@@ -11,8 +10,7 @@ namespace List
 
 variable {α : Type} {α' : Type} {β : α → Type} {β' : α' → Type} {l l₁ l₂ : List (Sigma β)}
 
-def keys : List (Sigma β) → List α :=
-  sorry
+opaque keys : List (Sigma β) → List α
 
 variable [DecidableEq α] [DecidableEq α']
 

--- a/tests/elab/noConfusionCtorInjection.lean
+++ b/tests/elab/noConfusionCtorInjection.lean
@@ -43,11 +43,12 @@ fun {α} {x} {xs} {y} {ys} h =>
       fun h_1 =>
       id
         (Eq.mp
-          (Eq.trans (Eq.symm (eq_true (L.cons.inj (id h)).1))
+          (Eq.trans (Eq.symm (eq_true (id (L.cons.inj (id h)).1)))
             (Lean.Grind.eq_false_of_not_eq_true
               (Eq.trans
                 (Eq.symm
-                  (Lean.Grind.or_eq_of_eq_false_right (Lean.Grind.not_eq_of_eq_true (eq_true (L.cons.inj (id h)).2))))
+                  (Lean.Grind.or_eq_of_eq_false_right
+                    (Lean.Grind.not_eq_of_eq_true (eq_true (id (L.cons.inj (id h)).2)))))
                 (eq_true h_1))))
           True.intro))
 -/


### PR DESCRIPTION
This PR fixes proof construction issues in the `grind` projection propagators.
