### PR TITLE
fix: `grind` congruence-table invariant for lazy `ite` branches

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/Inv.lean
+++ b/src/Lean/Meta/Tactic/Grind/Inv.lean
@@ -87,12 +87,7 @@ def checkParents (e : Expr) : GoalM Unit := do
           unless b.hasLooseBVars do
             if (← checkChild e b) then
               found := true
-        -- The `ite`/`dite` propagators (see `applyCongrFun` in `Propagate.lean`)
-        -- lazily internalize the active branch's body and register the `ite`/`dite`
-        -- as its parent to ensure the congruence-table re-hashing happens. Such a
-        -- child is not a structural argument of the parent, so the arg-based check
-        -- above does not see it. Skip the check in that case.
-        unless found || isIte parent || isDIte parent do
+        unless found do
           unless (← checkChild e parent.getAppFn) do
             throwError "e: {e}, parent: {parent}"
           assert! (← checkChild e parent.getAppFn)

--- a/src/Lean/Meta/Tactic/Grind/Inv.lean
+++ b/src/Lean/Meta/Tactic/Grind/Inv.lean
@@ -87,7 +87,12 @@ def checkParents (e : Expr) : GoalM Unit := do
           unless b.hasLooseBVars do
             if (← checkChild e b) then
               found := true
-        unless found do
+        -- The `ite`/`dite` propagators (see `applyCongrFun` in `Propagate.lean`)
+        -- lazily internalize the active branch's body and register the `ite`/`dite`
+        -- as its parent to ensure the congruence-table re-hashing happens. Such a
+        -- child is not a structural argument of the parent, so the arg-based check
+        -- above does not see it. Skip the check in that case.
+        unless found || isIte parent || isDIte parent do
           unless (← checkChild e parent.getAppFn) do
             throwError "e: {e}, parent: {parent}"
           assert! (← checkChild e parent.getAppFn)

--- a/src/Lean/Meta/Tactic/Grind/Propagate.lean
+++ b/src/Lean/Meta/Tactic/Grind/Propagate.lean
@@ -293,28 +293,33 @@ builtin_grind_propagator propagateHEqUp ↑HEq := fun e => do
     pushEqTrue e <| mkEqTrueCore e (← mkHEqProof a b)
 
 /--
-Helper function for propagating over-applied `ite` and `dite`-applications.
-`h` is a proof for the `e`'s prefix (of size `prefixSize`) that is equal to `rhs`.
-`args` contains all arguments of `e`.
-`prefixSize <= args.size`
+Pushes `e = rhs` (justified by `h`) for an `ite`/`dite`-application `e`, after the
+condition has become `True` or `False`. `args` are the arguments of `e`, and `h`
+proves that the `prefixSize`-prefix of `e` equals `rhs`; if `e` is over-applied,
+`rhs` is extended by the trailing arguments via `mkCongrFun`.
+
+Set `ite := true` iff `rhs` is a structural argument of `e` (the `then`/`else`
+branch of a non-over-applied `ite`). In that case we call `registerParent e rhs`
+because `Internalize.lean`'s `ite` special case skips the branches: `rhs` is being
+internalized here for the first time, and the explicit `registerParent` is the
+same one the standard `for arg in args` loop in `Internalize.lean` performs for
+ordinary application arguments. (`internalize` itself only forwards `parent?` to
+satellite solvers; it does not record a structural parent.) Without it, future
+merges of `rhs`'s equivalence class would skip re-hashing `e` in the congruence
+table, leaving an orphan entry whose `congr` chain no longer matches the table's
+representative.
+
+For `dite` (and any over-applied case), `rhs` is a *constructed* reduction (built
+via `mkApp` from `e`'s children, possibly post-`preprocess`), not a structural
+argument of `e`. Pass `ite := false` so we do not record a spurious parent
+relation. The lambda branches of a `dite` are themselves arguments of `e` and were
+already internalized as parents by `Internalize.lean`.
 -/
-private def applyCongrFun (e rhs : Expr) (h : Expr) (prefixSize : Nat) (args : Array Expr) : GoalM Unit := do
-  /-
-  **Note**: We must record `e` as the parent of `rhs` in two distinct ways:
-  1. Pass `e` as the `parent?` argument to `internalize`. Some solvers inspect the
-     parent to decide whether the term should be internalized in the solver.
-  2. Call `registerParent e rhs` to add `e` to `rhs`'s parent set in the e-graph.
-     Otherwise, future merges of `rhs`'s equivalence class will not trigger
-     re-hashing of `e` in the congruence table, leaving an orphaned entry whose
-     `congr` chain no longer matches the table's representative.
-  Note that `rhs` is *not* a structural argument of `e` (the active branch is wrapped
-  in a lambda); we are using `registerParent` here to express the *semantic* relation
-  established by the upcoming `pushEq e rhs h`. The debug invariant `checkParents`
-  has a corresponding case for this in `Inv.lean`.
-  -/
+private def applyCongrFun (e rhs : Expr) (h : Expr) (prefixSize : Nat) (args : Array Expr) (ite : Bool) : GoalM Unit := do
   if prefixSize == args.size then
     internalize rhs (← getGeneration e) e
-    registerParent e rhs
+    if ite then
+      registerParent e rhs
     pushEq e rhs h
   else
     go rhs h prefixSize
@@ -328,7 +333,8 @@ where
     else
       let rhs ← preprocessLight rhs
       internalize rhs (← getGeneration e) e
-      registerParent e rhs
+      if ite then
+        registerParent e rhs
       pushEq e rhs h
 
 /-- Propagates `ite` upwards -/
@@ -341,13 +347,13 @@ builtin_grind_propagator propagateIte ↑ite := fun e => do
     let args := e.getAppArgs
     let rhs := args[3]!
     let h := mkApp (mkAppRange (mkConst ``ite_cond_eq_true f.constLevels!) 0 5 args) (← mkEqTrueProof c)
-    applyCongrFun e rhs h 5 args
+    applyCongrFun e rhs h 5 args (ite := true)
   else if (← isEqFalse c) then
     let f := e.getAppFn
     let args := e.getAppArgs
     let rhs := args[4]!
     let h := mkApp (mkAppRange (mkConst ``ite_cond_eq_false f.constLevels!) 0 5 args) (← mkEqFalseProof c)
-    applyCongrFun e rhs h 5 args
+    applyCongrFun e rhs h 5 args (ite := true)
 
 /-- Propagates `dite` upwards -/
 builtin_grind_propagator propagateDIte ↑dite := fun e => do
@@ -363,7 +369,7 @@ builtin_grind_propagator propagateDIte ↑dite := fun e => do
     let r := p.expr
     let h₂ ← p.getProof
     let h := mkApp3 (mkAppRange (mkConst ``Grind.dite_cond_eq_true' f.constLevels!) 0 5 args) r h₁ h₂
-    applyCongrFun e r h 5 args
+    applyCongrFun e r h 5 args (ite := false)
   else if (← isEqFalse c) then
     let f := e.getAppFn
     let args := e.getAppArgs
@@ -373,7 +379,7 @@ builtin_grind_propagator propagateDIte ↑dite := fun e => do
     let r := p.expr
     let h₂ ← p.getProof
     let h := mkApp3 (mkAppRange (mkConst ``Grind.dite_cond_eq_false' f.constLevels!) 0 5 args) r h₁ h₂
-    applyCongrFun e r h 5 args
+    applyCongrFun e r h 5 args (ite := false)
 
 builtin_grind_propagator propagateDecideDown ↓decide := fun e => do
   let root ← getRootENode e

--- a/src/Lean/Meta/Tactic/Grind/Propagate.lean
+++ b/src/Lean/Meta/Tactic/Grind/Propagate.lean
@@ -305,10 +305,12 @@ private def applyCongrFun (e rhs : Expr) (h : Expr) (prefixSize : Nat) (args : A
      parent to decide whether the term should be internalized in the solver.
   2. Call `registerParent e rhs` to add `e` to `rhs`'s parent set in the e-graph.
      Otherwise, future merges of `rhs`'s equivalence class will not trigger
-     re-hashing of `e` in the congruence table. This is relevant for
-     `ite`/`dite`/`nestedProof`/`nestedDecidable` branches, which are internalized
-     lazily and so were not registered as parents when `e` itself was internalized.
-  Omitting either step has caused bugs in the past.
+     re-hashing of `e` in the congruence table, leaving an orphaned entry whose
+     `congr` chain no longer matches the table's representative.
+  Note that `rhs` is *not* a structural argument of `e` (the active branch is wrapped
+  in a lambda); we are using `registerParent` here to express the *semantic* relation
+  established by the upcoming `pushEq e rhs h`. The debug invariant `checkParents`
+  has a corresponding case for this in `Inv.lean`.
   -/
   if prefixSize == args.size then
     internalize rhs (← getGeneration e) e

--- a/src/Lean/Meta/Tactic/Grind/Propagate.lean
+++ b/src/Lean/Meta/Tactic/Grind/Propagate.lean
@@ -300,12 +300,19 @@ Helper function for propagating over-applied `ite` and `dite`-applications.
 -/
 private def applyCongrFun (e rhs : Expr) (h : Expr) (prefixSize : Nat) (args : Array Expr) : GoalM Unit := do
   /-
-  **Note**: We did not use to set `e` as the parent for `rhs`. This was incorrect because some
-  solvers will inspect the parent to decide whether the term should be internalized or not in the
-  solver.
+  **Note**: We must record `e` as the parent of `rhs` in two distinct ways:
+  1. Pass `e` as the `parent?` argument to `internalize`. Some solvers inspect the
+     parent to decide whether the term should be internalized in the solver.
+  2. Call `registerParent e rhs` to add `e` to `rhs`'s parent set in the e-graph.
+     Otherwise, future merges of `rhs`'s equivalence class will not trigger
+     re-hashing of `e` in the congruence table. This is relevant for
+     `ite`/`dite`/`nestedProof`/`nestedDecidable` branches, which are internalized
+     lazily and so were not registered as parents when `e` itself was internalized.
+  Omitting either step has caused bugs in the past.
   -/
   if prefixSize == args.size then
     internalize rhs (← getGeneration e) e
+    registerParent e rhs
     pushEq e rhs h
   else
     go rhs h prefixSize
@@ -319,6 +326,7 @@ where
     else
       let rhs ← preprocessLight rhs
       internalize rhs (← getGeneration e) e
+      registerParent e rhs
       pushEq e rhs h
 
 /-- Propagates `ite` upwards -/

--- a/tests/elab/grind_eqc_inv_issue.lean
+++ b/tests/elab/grind_eqc_inv_issue.lean
@@ -1,0 +1,5 @@
+module
+
+set_option grind.debug true in
+theorem mwe2 (n : Nat) : [d][n]?.getD d = d := by
+  grind


### PR DESCRIPTION
This PR fixes a `grind` congruence-table invariant violation that could panic
when an `ite` branch was internalized lazily (after the condition became `True`
or `False`) and that branch's equivalence class was later merged with another.

`Internalize.lean` has a special case for `ite` that internalizes only the
condition; the `then`/`else` branches are skipped and only internalized later
on demand by `propagateIte`. The on-demand path (`applyCongrFun`) called
`internalize` for the branch but never called `registerParent` to add the
parent `ite` to the branch's parent set in the e-graph. Subsequent merges of
the branch's equivalence class then skipped re-hashing the `ite` in the
congruence table, leaving an orphan entry whose `congr` chain no longer matched
the table's representative.

The fix adds the explicit `registerParent e rhs` that the standard
`for arg in args` loop in `Internalize.lean` would have made for an ordinary
application argument; we are simply mirroring that pattern lazily. The same
helper is reused by `propagateDIte`, but with parent registration disabled
(controlled by a new `ite : Bool` parameter): for `dite` the `rhs` propagated
upwards is a *constructed* reduction (built via `mkApp` from `e`'s children,
possibly post-`preprocess`), not a structural argument of `e`, so registering
`e` as its parent would be incorrect. The lambda branches of a `dite` are
already eagerly internalized as parents of `e` by `Internalize.lean`, so this
case does not need the fix.
