### PR TITLE
fix: `grind` cast internalization order

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/Internalize.lean
+++ b/src/Lean/Meta/Tactic/Grind/Internalize.lean
@@ -610,7 +610,6 @@ where
         mkENode e generation (funCC := funCC)
         updateAppMap e
         checkAndAddSplitCandidate e
-        pushCastHEqs e
         addMatchEqns f generation
         if args.size == 2 && f.isConstOf ``Grind.nestedProof then
           -- We only internalize the proposition. We can skip the proof because of
@@ -656,6 +655,7 @@ where
               let arg := args[i]
               internalizeImpl arg generation e
               registerParent e arg
+        pushCastHEqs e
         addCongrTable e
         Solvers.internalize e parent?
         propagateUp e

--- a/tests/elab/grind_not_internalized.lean
+++ b/tests/elab/grind_not_internalized.lean
@@ -1,0 +1,7 @@
+module
+
+set_option grind.debug true in
+theorem test {β α} {γ : β → Sort v} {f : α → β} {g : β → α}
+    (h : Function.LeftInverse g f) (C : ∀ a : α, γ (f a)) (a : α) :
+    cast (congrArg (fun a ↦ γ (f a)) (h a)) (C (g (f a))) = C a := by
+  grind


### PR DESCRIPTION
This PR fixes a `grind` internal error triggered when `cast` (or `Eq.rec`, `Eq.ndrec`, `Eq.recOn`) is applied to an argument that has not yet been internalized. `pushCastHEqs` was emitting `e ≍ a` before internalizing the args of `e`, so the `rhs` of the heq had no enode and the debug sanity check tripped. The call now runs after the args are internalized.