### PR TITLE
chore: rename `UInt8.ofNatTruncate` to `UInt8.ofNatClamp`

### DIFF
--- a/src/Init/Data/SInt/Basic.lean
+++ b/src/Init/Data/SInt/Basic.lean
@@ -192,7 +192,7 @@ abbrev Int8.minValue : Int8 := -128
 def Int8.ofIntLE (i : Int) (_hl : Int8.minValue.toInt ≤ i) (_hr : i ≤ Int8.maxValue.toInt) : Int8 :=
   Int8.ofInt i
 /-- Constructs an `Int8` from an `Int`, clamping if the value is too small or too large. -/
-def Int8.ofIntTruncate (i : Int) : Int8 :=
+def Int8.ofIntClamp (i : Int) : Int8 :=
   if hl : Int8.minValue.toInt ≤ i then
     if hr : i ≤ Int8.maxValue.toInt then
       Int8.ofIntLE i hl hr
@@ -200,6 +200,10 @@ def Int8.ofIntTruncate (i : Int) : Int8 :=
       Int8.minValue
   else
     Int8.minValue
+
+@[inherit_doc Int8.ofIntClamp, deprecated Int8.ofIntClamp (since := "2026-05-04")]
+def Int8.ofIntTruncate (i : Int) : Int8 :=
+  Int8.ofIntClamp i
 /--
 Adds two 8-bit signed integers, wrapping around on over- or underflow. Usually accessed via the `+`
 operator.
@@ -560,7 +564,7 @@ abbrev Int16.minValue : Int16 := -32768
 def Int16.ofIntLE (i : Int) (_hl : Int16.minValue.toInt ≤ i) (_hr : i ≤ Int16.maxValue.toInt) : Int16 :=
   Int16.ofInt i
 /-- Constructs an `Int16` from an `Int`, clamping if the value is too small or too large. -/
-def Int16.ofIntTruncate (i : Int) : Int16 :=
+def Int16.ofIntClamp (i : Int) : Int16 :=
   if hl : Int16.minValue.toInt ≤ i then
     if hr : i ≤ Int16.maxValue.toInt then
       Int16.ofIntLE i hl hr
@@ -568,6 +572,10 @@ def Int16.ofIntTruncate (i : Int) : Int16 :=
       Int16.minValue
   else
     Int16.minValue
+
+@[inherit_doc Int16.ofIntClamp, deprecated Int16.ofIntClamp (since := "2026-05-04")]
+def Int16.ofIntTruncate (i : Int) : Int16 :=
+  Int16.ofIntClamp i
 
 /--
 Adds two 16-bit signed integers, wrapping around on over- or underflow.  Usually accessed via the `+`
@@ -945,7 +953,7 @@ abbrev Int32.minValue : Int32 := -2147483648
 def Int32.ofIntLE (i : Int) (_hl : Int32.minValue.toInt ≤ i) (_hr : i ≤ Int32.maxValue.toInt) : Int32 :=
   Int32.ofInt i
 /-- Constructs an `Int32` from an `Int`, clamping if the value is too small or too large. -/
-def Int32.ofIntTruncate (i : Int) : Int32 :=
+def Int32.ofIntClamp (i : Int) : Int32 :=
   if hl : Int32.minValue.toInt ≤ i then
     if hr : i ≤ Int32.maxValue.toInt then
       Int32.ofIntLE i hl hr
@@ -953,6 +961,10 @@ def Int32.ofIntTruncate (i : Int) : Int32 :=
       Int32.minValue
   else
     Int32.minValue
+
+@[inherit_doc Int32.ofIntClamp, deprecated Int32.ofIntClamp (since := "2026-05-04")]
+def Int32.ofIntTruncate (i : Int) : Int32 :=
+  Int32.ofIntClamp i
 
 /--
 Adds two 32-bit signed integers, wrapping around on over- or underflow.  Usually accessed via the
@@ -1350,7 +1362,7 @@ abbrev Int64.minValue : Int64 := -9223372036854775808
 def Int64.ofIntLE (i : Int) (_hl : Int64.minValue.toInt ≤ i) (_hr : i ≤ Int64.maxValue.toInt) : Int64 :=
   Int64.ofInt i
 /-- Constructs an `Int64` from an `Int`, clamping if the value is too small or too large. -/
-def Int64.ofIntTruncate (i : Int) : Int64 :=
+def Int64.ofIntClamp (i : Int) : Int64 :=
   if hl : Int64.minValue.toInt ≤ i then
     if hr : i ≤ Int64.maxValue.toInt then
       Int64.ofIntLE i hl hr
@@ -1358,6 +1370,10 @@ def Int64.ofIntTruncate (i : Int) : Int64 :=
       Int64.minValue
   else
     Int64.minValue
+
+@[inherit_doc Int64.ofIntClamp, deprecated Int64.ofIntClamp (since := "2026-05-04")]
+def Int64.ofIntTruncate (i : Int) : Int64 :=
+  Int64.ofIntClamp i
 
 /--
 Adds two 64-bit signed integers, wrapping around on over- or underflow.  Usually accessed via the
@@ -1738,7 +1754,7 @@ abbrev ISize.minValue : ISize := .ofInt (-2 ^ (System.Platform.numBits - 1))
 def ISize.ofIntLE (i : Int) (_hl : ISize.minValue.toInt ≤ i) (_hr : i ≤ ISize.maxValue.toInt) : ISize :=
   ISize.ofInt i
 /-- Constructs an `ISize` from an `Int`, clamping if the value is too small or too large. -/
-def ISize.ofIntTruncate (i : Int) : ISize :=
+def ISize.ofIntClamp (i : Int) : ISize :=
   if hl : ISize.minValue.toInt ≤ i then
     if hr : i ≤ ISize.maxValue.toInt then
       ISize.ofIntLE i hl hr
@@ -1746,6 +1762,10 @@ def ISize.ofIntTruncate (i : Int) : ISize :=
       ISize.minValue
   else
     ISize.minValue
+
+@[inherit_doc ISize.ofIntClamp, deprecated ISize.ofIntClamp (since := "2026-05-04")]
+def ISize.ofIntTruncate (i : Int) : ISize :=
+  ISize.ofIntClamp i
 
 /--
 Adds two word-sized signed integers, wrapping around on over- or underflow.  Usually accessed via

--- a/src/Init/Data/SInt/Lemmas.lean
+++ b/src/Init/Data/SInt/Lemmas.lean
@@ -679,16 +679,16 @@ theorem ISize.ofIntLE_int64ToInt (x : Int64) {h₁ h₂} : ISize.ofIntLE x.toInt
   · apply Int.lt_of_le_sub_one
     simpa [ISize.toInt_maxValue] using h₂
 
-theorem Int8.ofIntLE_eq_ofIntTruncate {x : Int} {h₁ h₂} : (ofIntLE x h₁ h₂) = ofIntTruncate x := by
-  rw [ofIntTruncate, dif_pos h₁, dif_pos h₂]
-theorem Int16.ofIntLE_eq_ofIntTruncate {x : Int} {h₁ h₂} : (ofIntLE x h₁ h₂) = ofIntTruncate x := by
-  rw [ofIntTruncate, dif_pos h₁, dif_pos h₂]
-theorem Int32.ofIntLE_eq_ofIntTruncate {x : Int} {h₁ h₂} : (ofIntLE x h₁ h₂) = ofIntTruncate x := by
-  rw [ofIntTruncate, dif_pos h₁, dif_pos h₂]
-theorem Int64.ofIntLE_eq_ofIntTruncate {x : Int} {h₁ h₂} : (ofIntLE x h₁ h₂) = ofIntTruncate x := by
-  rw [ofIntTruncate, dif_pos h₁, dif_pos h₂]
-theorem ISize.ofIntLE_eq_ofIntTruncate {x : Int} {h₁ h₂} : (ofIntLE x h₁ h₂) = ofIntTruncate x := by
-  rw [ofIntTruncate, dif_pos h₁, dif_pos h₂]
+theorem Int8.ofIntLE_eq_ofIntClamp {x : Int} {h₁ h₂} : (ofIntLE x h₁ h₂) = ofIntClamp x := by
+  rw [ofIntClamp, dif_pos h₁, dif_pos h₂]
+theorem Int16.ofIntLE_eq_ofIntClamp {x : Int} {h₁ h₂} : (ofIntLE x h₁ h₂) = ofIntClamp x := by
+  rw [ofIntClamp, dif_pos h₁, dif_pos h₂]
+theorem Int32.ofIntLE_eq_ofIntClamp {x : Int} {h₁ h₂} : (ofIntLE x h₁ h₂) = ofIntClamp x := by
+  rw [ofIntClamp, dif_pos h₁, dif_pos h₂]
+theorem Int64.ofIntLE_eq_ofIntClamp {x : Int} {h₁ h₂} : (ofIntLE x h₁ h₂) = ofIntClamp x := by
+  rw [ofIntClamp, dif_pos h₁, dif_pos h₂]
+theorem ISize.ofIntLE_eq_ofIntClamp {x : Int} {h₁ h₂} : (ofIntLE x h₁ h₂) = ofIntClamp x := by
+  rw [ofIntClamp, dif_pos h₁, dif_pos h₂]
 
 theorem Int8.ofIntLE_eq_ofInt {n : Int} (h₁ h₂) : Int8.ofIntLE n h₁ h₂ = Int8.ofInt n := (rfl)
 theorem Int16.ofIntLE_eq_ofInt {n : Int} (h₁ h₂) : Int16.ofIntLE n h₁ h₂ = Int16.ofInt n := (rfl)
@@ -696,84 +696,84 @@ theorem Int32.ofIntLE_eq_ofInt {n : Int} (h₁ h₂) : Int32.ofIntLE n h₁ h₂
 theorem Int64.ofIntLE_eq_ofInt {n : Int} (h₁ h₂) : Int64.ofIntLE n h₁ h₂ = Int64.ofInt n := (rfl)
 theorem ISize.ofIntLE_eq_ofInt {n : Int} (h₁ h₂) : ISize.ofIntLE n h₁ h₂ = ISize.ofInt n := (rfl)
 
-theorem Int8.toInt_ofIntTruncate {x : Int} (h₁ : Int8.minValue.toInt ≤ x)
-    (h₂ : x ≤ Int8.maxValue.toInt) : (Int8.ofIntTruncate x).toInt = x := by
-  rw [← ofIntLE_eq_ofIntTruncate (h₁ := h₁) (h₂ := h₂), toInt_ofIntLE]
-theorem Int16.toInt_ofIntTruncate {x : Int} (h₁ : Int16.minValue.toInt ≤ x)
-    (h₂ : x ≤ Int16.maxValue.toInt) : (Int16.ofIntTruncate x).toInt = x := by
-  rw [← ofIntLE_eq_ofIntTruncate (h₁ := h₁) (h₂ := h₂), toInt_ofIntLE]
-theorem Int32.toInt_ofIntTruncate {x : Int} (h₁ : Int32.minValue.toInt ≤ x)
-    (h₂ : x ≤ Int32.maxValue.toInt) : (Int32.ofIntTruncate x).toInt = x := by
-  rw [← ofIntLE_eq_ofIntTruncate (h₁ := h₁) (h₂ := h₂), toInt_ofIntLE]
-theorem Int64.toInt_ofIntTruncate {x : Int} (h₁ : Int64.minValue.toInt ≤ x)
-    (h₂ : x ≤ Int64.maxValue.toInt) : (Int64.ofIntTruncate x).toInt = x := by
-  rw [← ofIntLE_eq_ofIntTruncate (h₁ := h₁) (h₂ := h₂), toInt_ofIntLE]
-theorem ISize.toInt_ofIntTruncate {x : Int} (h₁ : ISize.minValue.toInt ≤ x)
-    (h₂ : x ≤ ISize.maxValue.toInt) : (ISize.ofIntTruncate x).toInt = x := by
-  rw [← ofIntLE_eq_ofIntTruncate (h₁ := h₁) (h₂ := h₂), toInt_ofIntLE]
+theorem Int8.toInt_ofIntClamp {x : Int} (h₁ : Int8.minValue.toInt ≤ x)
+    (h₂ : x ≤ Int8.maxValue.toInt) : (Int8.ofIntClamp x).toInt = x := by
+  rw [← ofIntLE_eq_ofIntClamp (h₁ := h₁) (h₂ := h₂), toInt_ofIntLE]
+theorem Int16.toInt_ofIntClamp {x : Int} (h₁ : Int16.minValue.toInt ≤ x)
+    (h₂ : x ≤ Int16.maxValue.toInt) : (Int16.ofIntClamp x).toInt = x := by
+  rw [← ofIntLE_eq_ofIntClamp (h₁ := h₁) (h₂ := h₂), toInt_ofIntLE]
+theorem Int32.toInt_ofIntClamp {x : Int} (h₁ : Int32.minValue.toInt ≤ x)
+    (h₂ : x ≤ Int32.maxValue.toInt) : (Int32.ofIntClamp x).toInt = x := by
+  rw [← ofIntLE_eq_ofIntClamp (h₁ := h₁) (h₂ := h₂), toInt_ofIntLE]
+theorem Int64.toInt_ofIntClamp {x : Int} (h₁ : Int64.minValue.toInt ≤ x)
+    (h₂ : x ≤ Int64.maxValue.toInt) : (Int64.ofIntClamp x).toInt = x := by
+  rw [← ofIntLE_eq_ofIntClamp (h₁ := h₁) (h₂ := h₂), toInt_ofIntLE]
+theorem ISize.toInt_ofIntClamp {x : Int} (h₁ : ISize.minValue.toInt ≤ x)
+    (h₂ : x ≤ ISize.maxValue.toInt) : (ISize.ofIntClamp x).toInt = x := by
+  rw [← ofIntLE_eq_ofIntClamp (h₁ := h₁) (h₂ := h₂), toInt_ofIntLE]
 
-@[simp] theorem Int8.ofIntTruncate_toInt (x : Int8) : Int8.ofIntTruncate x.toInt = x :=
-  Int8.toInt.inj (toInt_ofIntTruncate x.minValue_le_toInt x.toInt_le)
-@[simp] theorem Int16.ofIntTruncate_toInt (x : Int16) : Int16.ofIntTruncate x.toInt = x :=
-  Int16.toInt.inj (toInt_ofIntTruncate x.minValue_le_toInt x.toInt_le)
-@[simp] theorem Int32.ofIntTruncate_toInt (x : Int32) : Int32.ofIntTruncate x.toInt = x :=
-  Int32.toInt.inj (toInt_ofIntTruncate x.minValue_le_toInt x.toInt_le)
-@[simp] theorem Int64.ofIntTruncate_toInt (x : Int64) : Int64.ofIntTruncate x.toInt = x :=
-  Int64.toInt.inj (toInt_ofIntTruncate x.minValue_le_toInt x.toInt_le)
-@[simp] theorem ISize.ofIntTruncate_toInt (x : ISize) : ISize.ofIntTruncate x.toInt = x :=
-  ISize.toInt.inj (toInt_ofIntTruncate x.minValue_le_toInt x.toInt_le)
+@[simp] theorem Int8.ofIntClamp_toInt (x : Int8) : Int8.ofIntClamp x.toInt = x :=
+  Int8.toInt.inj (toInt_ofIntClamp x.minValue_le_toInt x.toInt_le)
+@[simp] theorem Int16.ofIntClamp_toInt (x : Int16) : Int16.ofIntClamp x.toInt = x :=
+  Int16.toInt.inj (toInt_ofIntClamp x.minValue_le_toInt x.toInt_le)
+@[simp] theorem Int32.ofIntClamp_toInt (x : Int32) : Int32.ofIntClamp x.toInt = x :=
+  Int32.toInt.inj (toInt_ofIntClamp x.minValue_le_toInt x.toInt_le)
+@[simp] theorem Int64.ofIntClamp_toInt (x : Int64) : Int64.ofIntClamp x.toInt = x :=
+  Int64.toInt.inj (toInt_ofIntClamp x.minValue_le_toInt x.toInt_le)
+@[simp] theorem ISize.ofIntClamp_toInt (x : ISize) : ISize.ofIntClamp x.toInt = x :=
+  ISize.toInt.inj (toInt_ofIntClamp x.minValue_le_toInt x.toInt_le)
 
-@[simp] theorem Int16.ofIntTruncate_int8ToInt (x : Int8) : Int16.ofIntTruncate x.toInt = x.toInt16 :=
+@[simp] theorem Int16.ofIntClamp_int8ToInt (x : Int8) : Int16.ofIntClamp x.toInt = x.toInt16 :=
   Int16.toInt.inj (by
-    rw [toInt_ofIntTruncate, Int8.toInt_toInt16]
+    rw [toInt_ofIntClamp, Int8.toInt_toInt16]
     · exact Int.le_trans (by decide) x.minValue_le_toInt
     · exact Int.le_trans x.toInt_le (by decide))
-@[simp] theorem Int32.ofIntTruncate_int8ToInt (x : Int8) : Int32.ofIntTruncate x.toInt = x.toInt32 :=
+@[simp] theorem Int32.ofIntClamp_int8ToInt (x : Int8) : Int32.ofIntClamp x.toInt = x.toInt32 :=
   Int32.toInt.inj (by
-    rw [toInt_ofIntTruncate, Int8.toInt_toInt32]
+    rw [toInt_ofIntClamp, Int8.toInt_toInt32]
     · exact Int.le_trans (by decide) x.minValue_le_toInt
     · exact Int.le_trans x.toInt_le (by decide))
-@[simp] theorem Int64.ofIntTruncate_int8ToInt (x : Int8) : Int64.ofIntTruncate x.toInt = x.toInt64 :=
+@[simp] theorem Int64.ofIntClamp_int8ToInt (x : Int8) : Int64.ofIntClamp x.toInt = x.toInt64 :=
   Int64.toInt.inj (by
-    rw [toInt_ofIntTruncate, Int8.toInt_toInt64]
+    rw [toInt_ofIntClamp, Int8.toInt_toInt64]
     · exact Int.le_trans (by decide) x.minValue_le_toInt
     · exact Int.le_trans x.toInt_le (by decide))
-@[simp] theorem ISize.ofIntTruncate_int8ToInt (x : Int8) : ISize.ofIntTruncate x.toInt = x.toISize :=
+@[simp] theorem ISize.ofIntClamp_int8ToInt (x : Int8) : ISize.ofIntClamp x.toInt = x.toISize :=
   ISize.toInt.inj (by
-    rw [toInt_ofIntTruncate, Int8.toInt_toISize]
+    rw [toInt_ofIntClamp, Int8.toInt_toISize]
     · exact x.iSizeMinValue_le_toInt
     · exact x.toInt_le_iSizeMaxValue)
 
-@[simp] theorem Int32.ofIntTruncate_int16ToInt (x : Int16) : Int32.ofIntTruncate x.toInt = x.toInt32 :=
+@[simp] theorem Int32.ofIntClamp_int16ToInt (x : Int16) : Int32.ofIntClamp x.toInt = x.toInt32 :=
   Int32.toInt.inj (by
-    rw [toInt_ofIntTruncate, Int16.toInt_toInt32]
+    rw [toInt_ofIntClamp, Int16.toInt_toInt32]
     · exact Int.le_trans (by decide) x.minValue_le_toInt
     · exact Int.le_trans x.toInt_le (by decide))
-@[simp] theorem Int64.ofIntTruncate_int16ToInt (x : Int16) : Int64.ofIntTruncate x.toInt = x.toInt64 :=
+@[simp] theorem Int64.ofIntClamp_int16ToInt (x : Int16) : Int64.ofIntClamp x.toInt = x.toInt64 :=
   Int64.toInt.inj (by
-    rw [toInt_ofIntTruncate, Int16.toInt_toInt64]
+    rw [toInt_ofIntClamp, Int16.toInt_toInt64]
     · exact Int.le_trans (by decide) x.minValue_le_toInt
     · exact Int.le_trans x.toInt_le (by decide))
-@[simp] theorem ISize.ofIntTruncate_int16ToInt (x : Int16) : ISize.ofIntTruncate x.toInt = x.toISize :=
+@[simp] theorem ISize.ofIntClamp_int16ToInt (x : Int16) : ISize.ofIntClamp x.toInt = x.toISize :=
   ISize.toInt.inj (by
-    rw [toInt_ofIntTruncate, Int16.toInt_toISize]
+    rw [toInt_ofIntClamp, Int16.toInt_toISize]
     · exact x.iSizeMinValue_le_toInt
     · exact x.toInt_le_iSizeMaxValue)
 
-@[simp] theorem Int64.ofIntTruncate_int32ToInt (x : Int32) : Int64.ofIntTruncate x.toInt = x.toInt64 :=
+@[simp] theorem Int64.ofIntClamp_int32ToInt (x : Int32) : Int64.ofIntClamp x.toInt = x.toInt64 :=
   Int64.toInt.inj (by
-    rw [toInt_ofIntTruncate, Int32.toInt_toInt64]
+    rw [toInt_ofIntClamp, Int32.toInt_toInt64]
     · exact Int.le_trans (by decide) x.minValue_le_toInt
     · exact Int.le_trans x.toInt_le (by decide))
-@[simp] theorem ISize.ofIntTruncate_int32ToInt (x : Int32) : ISize.ofIntTruncate x.toInt = x.toISize :=
+@[simp] theorem ISize.ofIntClamp_int32ToInt (x : Int32) : ISize.ofIntClamp x.toInt = x.toISize :=
   ISize.toInt.inj (by
-    rw [toInt_ofIntTruncate, Int32.toInt_toISize]
+    rw [toInt_ofIntClamp, Int32.toInt_toISize]
     · exact x.iSizeMinValue_le_toInt
     · exact x.toInt_le_iSizeMaxValue)
 
-@[simp] theorem Int64.ofIntTruncate_iSizeToInt (x : ISize) : Int64.ofIntTruncate x.toInt = x.toInt64 :=
+@[simp] theorem Int64.ofIntClamp_iSizeToInt (x : ISize) : Int64.ofIntClamp x.toInt = x.toInt64 :=
   Int64.toInt.inj (by
-    rw [toInt_ofIntTruncate, ISize.toInt_toInt64]
+    rw [toInt_ofIntClamp, ISize.toInt_toInt64]
     · exact x.int64MinValue_le_toInt
     · exact x.toInt_le_int64MaxValue)
 
@@ -999,21 +999,21 @@ theorem USize.toISize_ofNatLT {n : Nat} (hn) : (USize.ofNatLT n hn).toISize = IS
 @[simp, int_toBitVec] theorem Int64.toBitVec_ofBitVec (b) : (Int64.ofBitVec b).toBitVec = b := (rfl)
 @[simp, int_toBitVec] theorem ISize.toBitVec_ofBitVec (b) : (ISize.ofBitVec b).toBitVec = b := (rfl)
 
-theorem Int8.toBitVec_ofIntTruncate {n : Int} (h₁ : Int8.minValue.toInt ≤ n) (h₂ : n ≤ Int8.maxValue.toInt) :
-    (Int8.ofIntTruncate n).toBitVec = BitVec.ofInt _ n := by
-  rw [← ofIntLE_eq_ofIntTruncate (h₁ := h₁) (h₂ := h₂), toBitVec_ofIntLE]
-theorem Int16.toBitVec_ofIntTruncate {n : Int} (h₁ : Int16.minValue.toInt ≤ n) (h₂ : n ≤ Int16.maxValue.toInt) :
-    (Int16.ofIntTruncate n).toBitVec = BitVec.ofInt _ n := by
-  rw [← ofIntLE_eq_ofIntTruncate (h₁ := h₁) (h₂ := h₂), toBitVec_ofIntLE]
-theorem Int32.toBitVec_ofIntTruncate {n : Int} (h₁ : Int32.minValue.toInt ≤ n) (h₂ : n ≤ Int32.maxValue.toInt) :
-    (Int32.ofIntTruncate n).toBitVec = BitVec.ofInt _ n := by
-  rw [← ofIntLE_eq_ofIntTruncate (h₁ := h₁) (h₂ := h₂), toBitVec_ofIntLE]
-theorem Int64.toBitVec_ofIntTruncate {n : Int} (h₁ : Int64.minValue.toInt ≤ n) (h₂ : n ≤ Int64.maxValue.toInt) :
-    (Int64.ofIntTruncate n).toBitVec = BitVec.ofInt _ n := by
-  rw [← ofIntLE_eq_ofIntTruncate (h₁ := h₁) (h₂ := h₂), toBitVec_ofIntLE]
-theorem ISize.toBitVec_ofIntTruncate {n : Int} (h₁ : ISize.minValue.toInt ≤ n) (h₂ : n ≤ ISize.maxValue.toInt) :
-    (ISize.ofIntTruncate n).toBitVec = BitVec.ofInt _ n := by
-  rw [← ofIntLE_eq_ofIntTruncate (h₁ := h₁) (h₂ := h₂), toBitVec_ofIntLE]
+theorem Int8.toBitVec_ofIntClamp {n : Int} (h₁ : Int8.minValue.toInt ≤ n) (h₂ : n ≤ Int8.maxValue.toInt) :
+    (Int8.ofIntClamp n).toBitVec = BitVec.ofInt _ n := by
+  rw [← ofIntLE_eq_ofIntClamp (h₁ := h₁) (h₂ := h₂), toBitVec_ofIntLE]
+theorem Int16.toBitVec_ofIntClamp {n : Int} (h₁ : Int16.minValue.toInt ≤ n) (h₂ : n ≤ Int16.maxValue.toInt) :
+    (Int16.ofIntClamp n).toBitVec = BitVec.ofInt _ n := by
+  rw [← ofIntLE_eq_ofIntClamp (h₁ := h₁) (h₂ := h₂), toBitVec_ofIntLE]
+theorem Int32.toBitVec_ofIntClamp {n : Int} (h₁ : Int32.minValue.toInt ≤ n) (h₂ : n ≤ Int32.maxValue.toInt) :
+    (Int32.ofIntClamp n).toBitVec = BitVec.ofInt _ n := by
+  rw [← ofIntLE_eq_ofIntClamp (h₁ := h₁) (h₂ := h₂), toBitVec_ofIntLE]
+theorem Int64.toBitVec_ofIntClamp {n : Int} (h₁ : Int64.minValue.toInt ≤ n) (h₂ : n ≤ Int64.maxValue.toInt) :
+    (Int64.ofIntClamp n).toBitVec = BitVec.ofInt _ n := by
+  rw [← ofIntLE_eq_ofIntClamp (h₁ := h₁) (h₂ := h₂), toBitVec_ofIntLE]
+theorem ISize.toBitVec_ofIntClamp {n : Int} (h₁ : ISize.minValue.toInt ≤ n) (h₂ : n ≤ ISize.maxValue.toInt) :
+    (ISize.ofIntClamp n).toBitVec = BitVec.ofInt _ n := by
+  rw [← ofIntLE_eq_ofIntClamp (h₁ := h₁) (h₂ := h₂), toBitVec_ofIntLE]
 
 @[simp] theorem Int8.toInt_ofBitVec (b) : (Int8.ofBitVec b).toInt = b.toInt := (rfl)
 @[simp] theorem Int16.toInt_ofBitVec (b) : (Int16.ofBitVec b).toInt = b.toInt := (rfl)
@@ -1056,54 +1056,54 @@ theorem ISize.toNatClampNeg_ofInt_of_two_pow_numBits {n : Int} (h₁ : -2 ^ (Sys
     (h₂ : n < 2 ^ (System.Platform.numBits - 1)) : (ISize.ofInt n).toNatClampNeg = n.toNat := by
   rw [toNatClampNeg, toInt_ofInt_of_two_pow_numBits_le h₁ h₂]
 
-theorem Int8.toNatClampNeg_ofIntTruncate_of_lt {n : Int} (h₁ : n < 2 ^ 7) :
-    (Int8.ofIntTruncate n).toNatClampNeg = n.toNat := by
-  rw [ofIntTruncate]
+theorem Int8.toNatClampNeg_ofIntClamp_of_lt {n : Int} (h₁ : n < 2 ^ 7) :
+    (Int8.ofIntClamp n).toNatClampNeg = n.toNat := by
+  rw [ofIntClamp]
   split
   · rw [dif_pos (by rw [toInt_maxValue]; omega), toNatClampNeg_ofIntLE]
   next h =>
     rw [toNatClampNeg_minValue, eq_comm, Int.toNat_eq_zero]
     rw [toInt_minValue] at h
     omega
-theorem Int16.toNatClampNeg_ofIntTruncate_of_lt {n : Int} (h₁ : n < 2 ^ 15) :
-    (Int16.ofIntTruncate n).toNatClampNeg = n.toNat := by
-  rw [ofIntTruncate]
+theorem Int16.toNatClampNeg_ofIntClamp_of_lt {n : Int} (h₁ : n < 2 ^ 15) :
+    (Int16.ofIntClamp n).toNatClampNeg = n.toNat := by
+  rw [ofIntClamp]
   split
   · rw [dif_pos (by rw [toInt_maxValue]; omega), toNatClampNeg_ofIntLE]
   next h =>
     rw [toNatClampNeg_minValue, eq_comm, Int.toNat_eq_zero]
     rw [toInt_minValue] at h
     omega
-theorem Int32.toNatClampNeg_ofIntTruncate_of_lt {n : Int} (h₁ : n < 2 ^ 31) :
-    (Int32.ofIntTruncate n).toNatClampNeg = n.toNat := by
-  rw [ofIntTruncate]
+theorem Int32.toNatClampNeg_ofIntClamp_of_lt {n : Int} (h₁ : n < 2 ^ 31) :
+    (Int32.ofIntClamp n).toNatClampNeg = n.toNat := by
+  rw [ofIntClamp]
   split
   · rw [dif_pos (by rw [toInt_maxValue]; omega), toNatClampNeg_ofIntLE]
   next h =>
     rw [toNatClampNeg_minValue, eq_comm, Int.toNat_eq_zero]
     rw [toInt_minValue] at h
     omega
-theorem Int64.toNatClampNeg_ofIntTruncate_of_lt {n : Int} (h₁ : n < 2 ^ 63) :
-    (Int64.ofIntTruncate n).toNatClampNeg = n.toNat := by
-  rw [ofIntTruncate]
+theorem Int64.toNatClampNeg_ofIntClamp_of_lt {n : Int} (h₁ : n < 2 ^ 63) :
+    (Int64.ofIntClamp n).toNatClampNeg = n.toNat := by
+  rw [ofIntClamp]
   split
   · rw [dif_pos (by rw [toInt_maxValue]; omega), toNatClampNeg_ofIntLE]
   next h =>
     rw [toNatClampNeg_minValue, eq_comm, Int.toNat_eq_zero]
     rw [toInt_minValue] at h
     omega
-theorem ISize.toNatClampNeg_ofIntTruncate_of_lt_two_pow_numBits {n : Int} (h₁ : n < 2 ^ (System.Platform.numBits - 1)) :
-    (ISize.ofIntTruncate n).toNatClampNeg = n.toNat := by
-  rw [ofIntTruncate]
+theorem ISize.toNatClampNeg_ofIntClamp_of_lt_two_pow_numBits {n : Int} (h₁ : n < 2 ^ (System.Platform.numBits - 1)) :
+    (ISize.ofIntClamp n).toNatClampNeg = n.toNat := by
+  rw [ofIntClamp]
   split
   · rw [dif_pos (by rw [toInt_maxValue]; omega), toNatClampNeg_ofIntLE]
   next h =>
     rw [toNatClampNeg_minValue, eq_comm, Int.toNat_eq_zero]
     rw [toInt_minValue] at h
     omega
-theorem ISize.toNatClampNeg_ofIntTruncate_of_lt {n : Int} (h₁ : n < 2 ^ 31) :
-    (ISize.ofIntTruncate n).toNatClampNeg = n.toNat := by
-  apply ISize.toNatClampNeg_ofIntTruncate_of_lt_two_pow_numBits (Int.lt_of_lt_of_le h₁ _)
+theorem ISize.toNatClampNeg_ofIntClamp_of_lt {n : Int} (h₁ : n < 2 ^ 31) :
+    (ISize.ofIntClamp n).toNatClampNeg = n.toNat := by
+  apply ISize.toNatClampNeg_ofIntClamp_of_lt_two_pow_numBits (Int.lt_of_lt_of_le h₁ _)
   cases System.Platform.numBits_eq <;> simp_all
 
 @[simp] theorem Int8.toUInt8_ofBitVec (b) : (Int8.ofBitVec b).toUInt8 = UInt8.ofBitVec b := (rfl)
@@ -1162,18 +1162,18 @@ theorem ISize.toInt8_ofIntLE {n} (h₁ h₂) : (ISize.ofIntLE n h₁ h₂).toInt
 @[simp] theorem Int64.toInt8_ofNat {n} : toInt8 (no_index (OfNat.ofNat n)) = OfNat.ofNat n := toInt8_ofNat'
 @[simp] theorem ISize.toInt8_ofNat {n} : toInt8 (no_index (OfNat.ofNat n)) = OfNat.ofNat n := toInt8_ofNat'
 
-theorem Int16.toInt8_ofIntTruncate {n : Int} (h₁ : -2 ^ 15 ≤ n) (h₂ : n < 2 ^ 15) :
-    (Int16.ofIntTruncate n).toInt8 = Int8.ofInt n := by
-  rw [← ofIntLE_eq_ofIntTruncate (h₁ := h₁) (h₂ := Int.le_of_lt_add_one h₂), toInt8_ofIntLE]
-theorem Int32.toInt8_ofIntTruncate {n : Int} (h₁ : -2 ^ 31 ≤ n) (h₂ : n < 2 ^ 31) :
-    (Int32.ofIntTruncate n).toInt8 = Int8.ofInt n := by
-  rw [← ofIntLE_eq_ofIntTruncate (h₁ := h₁) (h₂ := Int.le_of_lt_add_one h₂), toInt8_ofIntLE]
-theorem Int64.toInt8_ofIntTruncate {n : Int} (h₁ : -2 ^ 63 ≤ n) (h₂ : n < 2 ^ 63) :
-    (Int64.ofIntTruncate n).toInt8 = Int8.ofInt n := by
-  rw [← ofIntLE_eq_ofIntTruncate (h₁ := h₁) (h₂ := Int.le_of_lt_add_one h₂), toInt8_ofIntLE]
-theorem ISize.toInt8_ofIntTruncate {n : Int} (h₁ : -2 ^ (System.Platform.numBits - 1) ≤ n)
-    (h₂ : n < 2 ^ (System.Platform.numBits - 1)) : (ISize.ofIntTruncate n).toInt8 = Int8.ofInt n := by
-  rw [← ofIntLE_eq_ofIntTruncate, toInt8_ofIntLE]
+theorem Int16.toInt8_ofIntClamp {n : Int} (h₁ : -2 ^ 15 ≤ n) (h₂ : n < 2 ^ 15) :
+    (Int16.ofIntClamp n).toInt8 = Int8.ofInt n := by
+  rw [← ofIntLE_eq_ofIntClamp (h₁ := h₁) (h₂ := Int.le_of_lt_add_one h₂), toInt8_ofIntLE]
+theorem Int32.toInt8_ofIntClamp {n : Int} (h₁ : -2 ^ 31 ≤ n) (h₂ : n < 2 ^ 31) :
+    (Int32.ofIntClamp n).toInt8 = Int8.ofInt n := by
+  rw [← ofIntLE_eq_ofIntClamp (h₁ := h₁) (h₂ := Int.le_of_lt_add_one h₂), toInt8_ofIntLE]
+theorem Int64.toInt8_ofIntClamp {n : Int} (h₁ : -2 ^ 63 ≤ n) (h₂ : n < 2 ^ 63) :
+    (Int64.ofIntClamp n).toInt8 = Int8.ofInt n := by
+  rw [← ofIntLE_eq_ofIntClamp (h₁ := h₁) (h₂ := Int.le_of_lt_add_one h₂), toInt8_ofIntLE]
+theorem ISize.toInt8_ofIntClamp {n : Int} (h₁ : -2 ^ (System.Platform.numBits - 1) ≤ n)
+    (h₂ : n < 2 ^ (System.Platform.numBits - 1)) : (ISize.ofIntClamp n).toInt8 = Int8.ofInt n := by
+  rw [← ofIntLE_eq_ofIntClamp, toInt8_ofIntLE]
   · exact toInt_minValue ▸ h₁
   · rw [toInt_maxValue]
     omega
@@ -1209,15 +1209,15 @@ theorem ISize.toInt16_ofIntLE {n} (h₁ h₂) : (ISize.ofIntLE n h₁ h₂).toIn
 @[simp] theorem Int64.toInt16_ofNat {n} : toInt16 (no_index (OfNat.ofNat n)) = OfNat.ofNat n := toInt16_ofNat'
 @[simp] theorem ISize.toInt16_ofNat {n} : toInt16 (no_index (OfNat.ofNat n)) = OfNat.ofNat n := toInt16_ofNat'
 
-theorem Int32.toInt16_ofIntTruncate {n : Int} (h₁ : -2 ^ 31 ≤ n) (h₂ : n < 2 ^ 31) :
-    (Int32.ofIntTruncate n).toInt16 = Int16.ofInt n := by
-  rw [← ofIntLE_eq_ofIntTruncate (h₁ := h₁) (h₂ := Int.le_of_lt_add_one h₂), toInt16_ofIntLE]
-theorem Int64.toInt16_ofIntTruncate {n : Int} (h₁ : -2 ^ 63 ≤ n) (h₂ : n < 2 ^ 63) :
-    (Int64.ofIntTruncate n).toInt16 = Int16.ofInt n := by
-  rw [← ofIntLE_eq_ofIntTruncate (h₁ := h₁) (h₂ := Int.le_of_lt_add_one h₂), toInt16_ofIntLE]
-theorem ISize.toInt16_ofIntTruncate {n : Int} (h₁ : -2 ^ (System.Platform.numBits - 1) ≤ n)
-    (h₂ : n < 2 ^ (System.Platform.numBits - 1)) : (ISize.ofIntTruncate n).toInt16 = Int16.ofInt n := by
-  rw [← ofIntLE_eq_ofIntTruncate, toInt16_ofIntLE]
+theorem Int32.toInt16_ofIntClamp {n : Int} (h₁ : -2 ^ 31 ≤ n) (h₂ : n < 2 ^ 31) :
+    (Int32.ofIntClamp n).toInt16 = Int16.ofInt n := by
+  rw [← ofIntLE_eq_ofIntClamp (h₁ := h₁) (h₂ := Int.le_of_lt_add_one h₂), toInt16_ofIntLE]
+theorem Int64.toInt16_ofIntClamp {n : Int} (h₁ : -2 ^ 63 ≤ n) (h₂ : n < 2 ^ 63) :
+    (Int64.ofIntClamp n).toInt16 = Int16.ofInt n := by
+  rw [← ofIntLE_eq_ofIntClamp (h₁ := h₁) (h₂ := Int.le_of_lt_add_one h₂), toInt16_ofIntLE]
+theorem ISize.toInt16_ofIntClamp {n : Int} (h₁ : -2 ^ (System.Platform.numBits - 1) ≤ n)
+    (h₂ : n < 2 ^ (System.Platform.numBits - 1)) : (ISize.ofIntClamp n).toInt16 = Int16.ofInt n := by
+  rw [← ofIntLE_eq_ofIntClamp, toInt16_ofIntLE]
   · exact toInt_minValue ▸ h₁
   · rw [toInt_maxValue]
     omega
@@ -1246,12 +1246,12 @@ theorem ISize.toInt32_ofIntLE {n} (h₁ h₂) : (ISize.ofIntLE n h₁ h₂).toIn
 @[simp] theorem Int64.toInt32_ofNat {n} : toInt32 (no_index (OfNat.ofNat n)) = OfNat.ofNat n := toInt32_ofNat'
 @[simp] theorem ISize.toInt32_ofNat {n} : toInt32 (no_index (OfNat.ofNat n)) = OfNat.ofNat n := toInt32_ofNat'
 
-theorem Int64.toInt32_ofIntTruncate {n : Int} (h₁ : -2 ^ 63 ≤ n) (h₂ : n < 2 ^ 63) :
-    (Int64.ofIntTruncate n).toInt32 = Int32.ofInt n := by
-  rw [← ofIntLE_eq_ofIntTruncate (h₁ := h₁) (h₂ := Int.le_of_lt_add_one h₂), toInt32_ofIntLE]
-theorem ISize.toInt32_ofIntTruncate {n : Int} (h₁ : -2 ^ (System.Platform.numBits - 1) ≤ n)
-    (h₂ : n < 2 ^ (System.Platform.numBits - 1)) : (ISize.ofIntTruncate n).toInt32 = Int32.ofInt n := by
-  rw [← ofIntLE_eq_ofIntTruncate, toInt32_ofIntLE]
+theorem Int64.toInt32_ofIntClamp {n : Int} (h₁ : -2 ^ 63 ≤ n) (h₂ : n < 2 ^ 63) :
+    (Int64.ofIntClamp n).toInt32 = Int32.ofInt n := by
+  rw [← ofIntLE_eq_ofIntClamp (h₁ := h₁) (h₂ := Int.le_of_lt_add_one h₂), toInt32_ofIntLE]
+theorem ISize.toInt32_ofIntClamp {n : Int} (h₁ : -2 ^ (System.Platform.numBits - 1) ≤ n)
+    (h₂ : n < 2 ^ (System.Platform.numBits - 1)) : (ISize.ofIntClamp n).toInt32 = Int32.ofInt n := by
+  rw [← ofIntLE_eq_ofIntClamp, toInt32_ofIntLE]
   · exact toInt_minValue ▸ h₁
   · rw [toInt_maxValue]
     omega
@@ -1269,9 +1269,9 @@ theorem Int64.toISize_ofIntLE {n} (h₁ h₂) : (Int64.ofIntLE n h₁ h₂).toIS
 
 @[simp] theorem Int64.toISize_ofNat {n} : toISize (no_index (OfNat.ofNat n)) = OfNat.ofNat n := toISize_ofNat'
 
-theorem Int64.toISize_ofIntTruncate {n : Int} (h₁ : -2 ^ 63 ≤ n) (h₂ : n < 2 ^ 63) :
-    (Int64.ofIntTruncate n).toISize = ISize.ofInt n := by
-  rw [← ofIntLE_eq_ofIntTruncate (h₁ := h₁) (h₂ := Int.le_of_lt_add_one h₂), toISize_ofIntLE]
+theorem Int64.toISize_ofIntClamp {n : Int} (h₁ : -2 ^ 63 ≤ n) (h₂ : n < 2 ^ 63) :
+    (Int64.ofIntClamp n).toISize = ISize.ofInt n := by
+  rw [← ofIntLE_eq_ofIntClamp (h₁ := h₁) (h₂ := Int.le_of_lt_add_one h₂), toISize_ofIntLE]
 
 @[simp, int_toBitVec] theorem Int8.toBitVec_minValue : minValue.toBitVec = BitVec.intMin _ := (rfl)
 @[simp, int_toBitVec] theorem Int16.toBitVec_minValue : minValue.toBitVec = BitVec.intMin _ := (rfl)
@@ -1532,17 +1532,247 @@ theorem ISize.ofBitVec_ofNatLT (n : Nat) (hn) : ISize.ofBitVec (BitVec.ofNatLT n
 @[simp] theorem ISize.ofInt_bitVecToInt (n : BitVec System.Platform.numBits) : ISize.ofInt n.toInt = ISize.ofBitVec n :=
   ISize.toBitVec.inj (by simp)
 
-@[simp] theorem Int8.ofIntTruncate_bitVecToInt (n : BitVec 8) : Int8.ofIntTruncate n.toInt = Int8.ofBitVec n :=
-  Int8.toBitVec.inj (by simp [toBitVec_ofIntTruncate (n.le_toInt) (n.toInt_le)])
-@[simp] theorem Int16.ofIntTruncate_bitVecToInt (n : BitVec 16) : Int16.ofIntTruncate n.toInt = Int16.ofBitVec n :=
-  Int16.toBitVec.inj (by simp [toBitVec_ofIntTruncate (n.le_toInt) (n.toInt_le)])
-@[simp] theorem Int32.ofIntTruncate_bitVecToInt (n : BitVec 32) : Int32.ofIntTruncate n.toInt = Int32.ofBitVec n :=
-  Int32.toBitVec.inj (by simp [toBitVec_ofIntTruncate (n.le_toInt) (n.toInt_le)])
-@[simp] theorem Int64.ofIntTruncate_bitVecToInt (n : BitVec 64) : Int64.ofIntTruncate n.toInt = Int64.ofBitVec n :=
-  Int64.toBitVec.inj (by simp [toBitVec_ofIntTruncate (n.le_toInt) (n.toInt_le)])
-@[simp] theorem ISize.ofIntTruncate_bitVecToInt (n : BitVec System.Platform.numBits) : ISize.ofIntTruncate n.toInt = ISize.ofBitVec n :=
-  ISize.toBitVec.inj (by simp [toBitVec_ofIntTruncate (toInt_minValue ▸ n.le_toInt)
+@[simp] theorem Int8.ofIntClamp_bitVecToInt (n : BitVec 8) : Int8.ofIntClamp n.toInt = Int8.ofBitVec n :=
+  Int8.toBitVec.inj (by simp [toBitVec_ofIntClamp (n.le_toInt) (n.toInt_le)])
+@[simp] theorem Int16.ofIntClamp_bitVecToInt (n : BitVec 16) : Int16.ofIntClamp n.toInt = Int16.ofBitVec n :=
+  Int16.toBitVec.inj (by simp [toBitVec_ofIntClamp (n.le_toInt) (n.toInt_le)])
+@[simp] theorem Int32.ofIntClamp_bitVecToInt (n : BitVec 32) : Int32.ofIntClamp n.toInt = Int32.ofBitVec n :=
+  Int32.toBitVec.inj (by simp [toBitVec_ofIntClamp (n.le_toInt) (n.toInt_le)])
+@[simp] theorem Int64.ofIntClamp_bitVecToInt (n : BitVec 64) : Int64.ofIntClamp n.toInt = Int64.ofBitVec n :=
+  Int64.toBitVec.inj (by simp [toBitVec_ofIntClamp (n.le_toInt) (n.toInt_le)])
+@[simp] theorem ISize.ofIntClamp_bitVecToInt (n : BitVec System.Platform.numBits) : ISize.ofIntClamp n.toInt = ISize.ofBitVec n :=
+  ISize.toBitVec.inj (by simp [toBitVec_ofIntClamp (toInt_minValue ▸ n.le_toInt)
     (toInt_maxValue ▸ n.toInt_le) ])
+
+@[deprecated Int8.ofIntLE_eq_ofIntClamp (since := "2026-05-04")]
+theorem Int8.ofIntLE_eq_ofIntTruncate {x : Int} {h₁ h₂} : (ofIntLE x h₁ h₂) = ofIntClamp x :=
+  Int8.ofIntLE_eq_ofIntClamp
+
+@[deprecated Int16.ofIntLE_eq_ofIntClamp (since := "2026-05-04")]
+theorem Int16.ofIntLE_eq_ofIntTruncate {x : Int} {h₁ h₂} : (ofIntLE x h₁ h₂) = ofIntClamp x :=
+  Int16.ofIntLE_eq_ofIntClamp
+
+@[deprecated Int32.ofIntLE_eq_ofIntClamp (since := "2026-05-04")]
+theorem Int32.ofIntLE_eq_ofIntTruncate {x : Int} {h₁ h₂} : (ofIntLE x h₁ h₂) = ofIntClamp x :=
+  Int32.ofIntLE_eq_ofIntClamp
+
+@[deprecated Int64.ofIntLE_eq_ofIntClamp (since := "2026-05-04")]
+theorem Int64.ofIntLE_eq_ofIntTruncate {x : Int} {h₁ h₂} : (ofIntLE x h₁ h₂) = ofIntClamp x :=
+  Int64.ofIntLE_eq_ofIntClamp
+
+@[deprecated ISize.ofIntLE_eq_ofIntClamp (since := "2026-05-04")]
+theorem ISize.ofIntLE_eq_ofIntTruncate {x : Int} {h₁ h₂} : (ofIntLE x h₁ h₂) = ofIntClamp x :=
+  ISize.ofIntLE_eq_ofIntClamp
+
+@[deprecated Int8.toInt_ofIntClamp (since := "2026-05-04")]
+theorem Int8.toInt_ofIntTruncate {x : Int} (h₁ : Int8.minValue.toInt ≤ x)
+    (h₂ : x ≤ Int8.maxValue.toInt) : (Int8.ofIntClamp x).toInt = x :=
+  Int8.toInt_ofIntClamp h₁ h₂
+
+@[deprecated Int16.toInt_ofIntClamp (since := "2026-05-04")]
+theorem Int16.toInt_ofIntTruncate {x : Int} (h₁ : Int16.minValue.toInt ≤ x)
+    (h₂ : x ≤ Int16.maxValue.toInt) : (Int16.ofIntClamp x).toInt = x :=
+  Int16.toInt_ofIntClamp h₁ h₂
+
+@[deprecated Int32.toInt_ofIntClamp (since := "2026-05-04")]
+theorem Int32.toInt_ofIntTruncate {x : Int} (h₁ : Int32.minValue.toInt ≤ x)
+    (h₂ : x ≤ Int32.maxValue.toInt) : (Int32.ofIntClamp x).toInt = x :=
+  Int32.toInt_ofIntClamp h₁ h₂
+
+@[deprecated Int64.toInt_ofIntClamp (since := "2026-05-04")]
+theorem Int64.toInt_ofIntTruncate {x : Int} (h₁ : Int64.minValue.toInt ≤ x)
+    (h₂ : x ≤ Int64.maxValue.toInt) : (Int64.ofIntClamp x).toInt = x :=
+  Int64.toInt_ofIntClamp h₁ h₂
+
+@[deprecated ISize.toInt_ofIntClamp (since := "2026-05-04")]
+theorem ISize.toInt_ofIntTruncate {x : Int} (h₁ : ISize.minValue.toInt ≤ x)
+    (h₂ : x ≤ ISize.maxValue.toInt) : (ISize.ofIntClamp x).toInt = x :=
+  ISize.toInt_ofIntClamp h₁ h₂
+
+@[deprecated Int8.ofIntClamp_toInt (since := "2026-05-04")]
+theorem Int8.ofIntTruncate_toInt (x : Int8) : Int8.ofIntClamp x.toInt = x :=
+  Int8.ofIntClamp_toInt x
+
+@[deprecated Int16.ofIntClamp_toInt (since := "2026-05-04")]
+theorem Int16.ofIntTruncate_toInt (x : Int16) : Int16.ofIntClamp x.toInt = x :=
+  Int16.ofIntClamp_toInt x
+
+@[deprecated Int32.ofIntClamp_toInt (since := "2026-05-04")]
+theorem Int32.ofIntTruncate_toInt (x : Int32) : Int32.ofIntClamp x.toInt = x :=
+  Int32.ofIntClamp_toInt x
+
+@[deprecated Int64.ofIntClamp_toInt (since := "2026-05-04")]
+theorem Int64.ofIntTruncate_toInt (x : Int64) : Int64.ofIntClamp x.toInt = x :=
+  Int64.ofIntClamp_toInt x
+
+@[deprecated ISize.ofIntClamp_toInt (since := "2026-05-04")]
+theorem ISize.ofIntTruncate_toInt (x : ISize) : ISize.ofIntClamp x.toInt = x :=
+  ISize.ofIntClamp_toInt x
+
+@[deprecated Int16.ofIntClamp_int8ToInt (since := "2026-05-04")]
+theorem Int16.ofIntTruncate_int8ToInt (x : Int8) : Int16.ofIntClamp x.toInt = x.toInt16 :=
+  Int16.ofIntClamp_int8ToInt x
+
+@[deprecated Int32.ofIntClamp_int8ToInt (since := "2026-05-04")]
+theorem Int32.ofIntTruncate_int8ToInt (x : Int8) : Int32.ofIntClamp x.toInt = x.toInt32 :=
+  Int32.ofIntClamp_int8ToInt x
+
+@[deprecated Int64.ofIntClamp_int8ToInt (since := "2026-05-04")]
+theorem Int64.ofIntTruncate_int8ToInt (x : Int8) : Int64.ofIntClamp x.toInt = x.toInt64 :=
+  Int64.ofIntClamp_int8ToInt x
+
+@[deprecated ISize.ofIntClamp_int8ToInt (since := "2026-05-04")]
+theorem ISize.ofIntTruncate_int8ToInt (x : Int8) : ISize.ofIntClamp x.toInt = x.toISize :=
+  ISize.ofIntClamp_int8ToInt x
+
+@[deprecated Int32.ofIntClamp_int16ToInt (since := "2026-05-04")]
+theorem Int32.ofIntTruncate_int16ToInt (x : Int16) : Int32.ofIntClamp x.toInt = x.toInt32 :=
+  Int32.ofIntClamp_int16ToInt x
+
+@[deprecated Int64.ofIntClamp_int16ToInt (since := "2026-05-04")]
+theorem Int64.ofIntTruncate_int16ToInt (x : Int16) : Int64.ofIntClamp x.toInt = x.toInt64 :=
+  Int64.ofIntClamp_int16ToInt x
+
+@[deprecated ISize.ofIntClamp_int16ToInt (since := "2026-05-04")]
+theorem ISize.ofIntTruncate_int16ToInt (x : Int16) : ISize.ofIntClamp x.toInt = x.toISize :=
+  ISize.ofIntClamp_int16ToInt x
+
+@[deprecated Int64.ofIntClamp_int32ToInt (since := "2026-05-04")]
+theorem Int64.ofIntTruncate_int32ToInt (x : Int32) : Int64.ofIntClamp x.toInt = x.toInt64 :=
+  Int64.ofIntClamp_int32ToInt x
+
+@[deprecated ISize.ofIntClamp_int32ToInt (since := "2026-05-04")]
+theorem ISize.ofIntTruncate_int32ToInt (x : Int32) : ISize.ofIntClamp x.toInt = x.toISize :=
+  ISize.ofIntClamp_int32ToInt x
+
+@[deprecated Int64.ofIntClamp_iSizeToInt (since := "2026-05-04")]
+theorem Int64.ofIntTruncate_iSizeToInt (x : ISize) : Int64.ofIntClamp x.toInt = x.toInt64 :=
+  Int64.ofIntClamp_iSizeToInt x
+
+@[deprecated Int8.toBitVec_ofIntClamp (since := "2026-05-04")]
+theorem Int8.toBitVec_ofIntTruncate {n : Int} (h₁ : Int8.minValue.toInt ≤ n) (h₂ : n ≤ Int8.maxValue.toInt) :
+    (Int8.ofIntClamp n).toBitVec = BitVec.ofInt _ n :=
+  Int8.toBitVec_ofIntClamp h₁ h₂
+
+@[deprecated Int16.toBitVec_ofIntClamp (since := "2026-05-04")]
+theorem Int16.toBitVec_ofIntTruncate {n : Int} (h₁ : Int16.minValue.toInt ≤ n) (h₂ : n ≤ Int16.maxValue.toInt) :
+    (Int16.ofIntClamp n).toBitVec = BitVec.ofInt _ n :=
+  Int16.toBitVec_ofIntClamp h₁ h₂
+
+@[deprecated Int32.toBitVec_ofIntClamp (since := "2026-05-04")]
+theorem Int32.toBitVec_ofIntTruncate {n : Int} (h₁ : Int32.minValue.toInt ≤ n) (h₂ : n ≤ Int32.maxValue.toInt) :
+    (Int32.ofIntClamp n).toBitVec = BitVec.ofInt _ n :=
+  Int32.toBitVec_ofIntClamp h₁ h₂
+
+@[deprecated Int64.toBitVec_ofIntClamp (since := "2026-05-04")]
+theorem Int64.toBitVec_ofIntTruncate {n : Int} (h₁ : Int64.minValue.toInt ≤ n) (h₂ : n ≤ Int64.maxValue.toInt) :
+    (Int64.ofIntClamp n).toBitVec = BitVec.ofInt _ n :=
+  Int64.toBitVec_ofIntClamp h₁ h₂
+
+@[deprecated ISize.toBitVec_ofIntClamp (since := "2026-05-04")]
+theorem ISize.toBitVec_ofIntTruncate {n : Int} (h₁ : ISize.minValue.toInt ≤ n) (h₂ : n ≤ ISize.maxValue.toInt) :
+    (ISize.ofIntClamp n).toBitVec = BitVec.ofInt _ n :=
+  ISize.toBitVec_ofIntClamp h₁ h₂
+
+@[deprecated Int8.toNatClampNeg_ofIntClamp_of_lt (since := "2026-05-04")]
+theorem Int8.toNatClampNeg_ofIntTruncate_of_lt {n : Int} (h₁ : n < 2 ^ 7) :
+    (Int8.ofIntClamp n).toNatClampNeg = n.toNat :=
+  Int8.toNatClampNeg_ofIntClamp_of_lt h₁
+
+@[deprecated Int16.toNatClampNeg_ofIntClamp_of_lt (since := "2026-05-04")]
+theorem Int16.toNatClampNeg_ofIntTruncate_of_lt {n : Int} (h₁ : n < 2 ^ 15) :
+    (Int16.ofIntClamp n).toNatClampNeg = n.toNat :=
+  Int16.toNatClampNeg_ofIntClamp_of_lt h₁
+
+@[deprecated Int32.toNatClampNeg_ofIntClamp_of_lt (since := "2026-05-04")]
+theorem Int32.toNatClampNeg_ofIntTruncate_of_lt {n : Int} (h₁ : n < 2 ^ 31) :
+    (Int32.ofIntClamp n).toNatClampNeg = n.toNat :=
+  Int32.toNatClampNeg_ofIntClamp_of_lt h₁
+
+@[deprecated Int64.toNatClampNeg_ofIntClamp_of_lt (since := "2026-05-04")]
+theorem Int64.toNatClampNeg_ofIntTruncate_of_lt {n : Int} (h₁ : n < 2 ^ 63) :
+    (Int64.ofIntClamp n).toNatClampNeg = n.toNat :=
+  Int64.toNatClampNeg_ofIntClamp_of_lt h₁
+
+@[deprecated ISize.toNatClampNeg_ofIntClamp_of_lt_two_pow_numBits (since := "2026-05-04")]
+theorem ISize.toNatClampNeg_ofIntTruncate_of_lt_two_pow_numBits {n : Int} (h₁ : n < 2 ^ (System.Platform.numBits - 1)) :
+    (ISize.ofIntClamp n).toNatClampNeg = n.toNat :=
+  ISize.toNatClampNeg_ofIntClamp_of_lt_two_pow_numBits h₁
+
+@[deprecated ISize.toNatClampNeg_ofIntClamp_of_lt (since := "2026-05-04")]
+theorem ISize.toNatClampNeg_ofIntTruncate_of_lt {n : Int} (h₁ : n < 2 ^ 31) :
+    (ISize.ofIntClamp n).toNatClampNeg = n.toNat :=
+  ISize.toNatClampNeg_ofIntClamp_of_lt h₁
+
+@[deprecated Int16.toInt8_ofIntClamp (since := "2026-05-04")]
+theorem Int16.toInt8_ofIntTruncate {n : Int} (h₁ : -2 ^ 15 ≤ n) (h₂ : n < 2 ^ 15) :
+    (Int16.ofIntClamp n).toInt8 = Int8.ofInt n :=
+  Int16.toInt8_ofIntClamp h₁ h₂
+
+@[deprecated Int32.toInt8_ofIntClamp (since := "2026-05-04")]
+theorem Int32.toInt8_ofIntTruncate {n : Int} (h₁ : -2 ^ 31 ≤ n) (h₂ : n < 2 ^ 31) :
+    (Int32.ofIntClamp n).toInt8 = Int8.ofInt n :=
+  Int32.toInt8_ofIntClamp h₁ h₂
+
+@[deprecated Int64.toInt8_ofIntClamp (since := "2026-05-04")]
+theorem Int64.toInt8_ofIntTruncate {n : Int} (h₁ : -2 ^ 63 ≤ n) (h₂ : n < 2 ^ 63) :
+    (Int64.ofIntClamp n).toInt8 = Int8.ofInt n :=
+  Int64.toInt8_ofIntClamp h₁ h₂
+
+@[deprecated ISize.toInt8_ofIntClamp (since := "2026-05-04")]
+theorem ISize.toInt8_ofIntTruncate {n : Int} (h₁ : -2 ^ (System.Platform.numBits - 1) ≤ n)
+    (h₂ : n < 2 ^ (System.Platform.numBits - 1)) : (ISize.ofIntClamp n).toInt8 = Int8.ofInt n :=
+  ISize.toInt8_ofIntClamp h₁ h₂
+
+@[deprecated Int32.toInt16_ofIntClamp (since := "2026-05-04")]
+theorem Int32.toInt16_ofIntTruncate {n : Int} (h₁ : -2 ^ 31 ≤ n) (h₂ : n < 2 ^ 31) :
+    (Int32.ofIntClamp n).toInt16 = Int16.ofInt n :=
+  Int32.toInt16_ofIntClamp h₁ h₂
+
+@[deprecated Int64.toInt16_ofIntClamp (since := "2026-05-04")]
+theorem Int64.toInt16_ofIntTruncate {n : Int} (h₁ : -2 ^ 63 ≤ n) (h₂ : n < 2 ^ 63) :
+    (Int64.ofIntClamp n).toInt16 = Int16.ofInt n :=
+  Int64.toInt16_ofIntClamp h₁ h₂
+
+@[deprecated ISize.toInt16_ofIntClamp (since := "2026-05-04")]
+theorem ISize.toInt16_ofIntTruncate {n : Int} (h₁ : -2 ^ (System.Platform.numBits - 1) ≤ n)
+    (h₂ : n < 2 ^ (System.Platform.numBits - 1)) : (ISize.ofIntClamp n).toInt16 = Int16.ofInt n :=
+  ISize.toInt16_ofIntClamp h₁ h₂
+
+@[deprecated Int64.toInt32_ofIntClamp (since := "2026-05-04")]
+theorem Int64.toInt32_ofIntTruncate {n : Int} (h₁ : -2 ^ 63 ≤ n) (h₂ : n < 2 ^ 63) :
+    (Int64.ofIntClamp n).toInt32 = Int32.ofInt n :=
+  Int64.toInt32_ofIntClamp h₁ h₂
+
+@[deprecated ISize.toInt32_ofIntClamp (since := "2026-05-04")]
+theorem ISize.toInt32_ofIntTruncate {n : Int} (h₁ : -2 ^ (System.Platform.numBits - 1) ≤ n)
+    (h₂ : n < 2 ^ (System.Platform.numBits - 1)) : (ISize.ofIntClamp n).toInt32 = Int32.ofInt n :=
+  ISize.toInt32_ofIntClamp h₁ h₂
+
+@[deprecated Int64.toISize_ofIntClamp (since := "2026-05-04")]
+theorem Int64.toISize_ofIntTruncate {n : Int} (h₁ : -2 ^ 63 ≤ n) (h₂ : n < 2 ^ 63) :
+    (Int64.ofIntClamp n).toISize = ISize.ofInt n :=
+  Int64.toISize_ofIntClamp h₁ h₂
+
+@[deprecated Int8.ofIntClamp_bitVecToInt (since := "2026-05-04")]
+theorem Int8.ofIntTruncate_bitVecToInt (n : BitVec 8) : Int8.ofIntClamp n.toInt = Int8.ofBitVec n :=
+  Int8.ofIntClamp_bitVecToInt n
+
+@[deprecated Int16.ofIntClamp_bitVecToInt (since := "2026-05-04")]
+theorem Int16.ofIntTruncate_bitVecToInt (n : BitVec 16) : Int16.ofIntClamp n.toInt = Int16.ofBitVec n :=
+  Int16.ofIntClamp_bitVecToInt n
+
+@[deprecated Int32.ofIntClamp_bitVecToInt (since := "2026-05-04")]
+theorem Int32.ofIntTruncate_bitVecToInt (n : BitVec 32) : Int32.ofIntClamp n.toInt = Int32.ofBitVec n :=
+  Int32.ofIntClamp_bitVecToInt n
+
+@[deprecated Int64.ofIntClamp_bitVecToInt (since := "2026-05-04")]
+theorem Int64.ofIntTruncate_bitVecToInt (n : BitVec 64) : Int64.ofIntClamp n.toInt = Int64.ofBitVec n :=
+  Int64.ofIntClamp_bitVecToInt n
+
+@[deprecated ISize.ofIntClamp_bitVecToInt (since := "2026-05-04")]
+theorem ISize.ofIntTruncate_bitVecToInt (n : BitVec System.Platform.numBits) : ISize.ofIntClamp n.toInt = ISize.ofBitVec n :=
+  ISize.ofIntClamp_bitVecToInt n
 
 @[simp] theorem Int8.toInt_neg (n : Int8) : (-n).toInt = (-n.toInt).bmod (2 ^ 8) := BitVec.toInt_neg
 @[simp] theorem Int16.toInt_neg (n : Int16) : (-n).toInt = (-n.toInt).bmod (2 ^ 16) := BitVec.toInt_neg

--- a/src/Init/Data/UInt/BasicAux.lean
+++ b/src/Init/Data/UInt/BasicAux.lean
@@ -34,11 +34,15 @@ the number is too large.
 
 Returns `2^8 - 1` for natural numbers greater than or equal to `2^8`.
 -/
-def UInt8.ofNatTruncate (n : Nat) : UInt8 :=
+def UInt8.ofNatClamp (n : Nat) : UInt8 :=
   if h : n < UInt8.size then
     UInt8.ofNatLT n h
   else
     UInt8.ofNatLT (UInt8.size - 1) (by decide)
+
+@[inherit_doc UInt8.ofNatClamp, deprecated UInt8.ofNatClamp (since := "2026-05-04")]
+def UInt8.ofNatTruncate (n : Nat) : UInt8 :=
+  UInt8.ofNatClamp n
 
 /--
 Converts a natural number to an 8-bit unsigned integer, wrapping on overflow.
@@ -86,11 +90,15 @@ the number is too large.
 
 Returns `2^16 - 1` for natural numbers greater than or equal to `2^16`.
 -/
-def UInt16.ofNatTruncate (n : Nat) : UInt16 :=
+def UInt16.ofNatClamp (n : Nat) : UInt16 :=
   if h : n < UInt16.size then
     UInt16.ofNatLT n h
   else
     UInt16.ofNatLT (UInt16.size - 1) (by decide)
+
+@[inherit_doc UInt16.ofNatClamp, deprecated UInt16.ofNatClamp (since := "2026-05-04")]
+def UInt16.ofNatTruncate (n : Nat) : UInt16 :=
+  UInt16.ofNatClamp n
 
 /--
 Converts a natural number to a 16-bit unsigned integer, wrapping on overflow.
@@ -151,11 +159,15 @@ the number is too large.
 
 Returns `2^32 - 1` for natural numbers greater than or equal to `2^32`.
 -/
-def UInt32.ofNatTruncate (n : Nat) : UInt32 :=
+def UInt32.ofNatClamp (n : Nat) : UInt32 :=
   if h : n < UInt32.size then
     UInt32.ofNatLT n h
   else
     UInt32.ofNatLT (UInt32.size - 1) (by decide)
+
+@[inherit_doc UInt32.ofNatClamp, deprecated UInt32.ofNatClamp (since := "2026-05-04")]
+def UInt32.ofNatTruncate (n : Nat) : UInt32 :=
+  UInt32.ofNatClamp n
 /--
 Converts a natural number to a 32-bit unsigned integer, wrapping on overflow.
 
@@ -253,11 +265,15 @@ the number is too large.
 
 Returns `2^64 - 1` for natural numbers greater than or equal to `2^64`.
 -/
-def UInt64.ofNatTruncate (n : Nat) : UInt64 :=
+def UInt64.ofNatClamp (n : Nat) : UInt64 :=
   if h : n < UInt64.size then
     UInt64.ofNatLT n h
   else
     UInt64.ofNatLT (UInt64.size - 1) (by decide)
+
+@[inherit_doc UInt64.ofNatClamp, deprecated UInt64.ofNatClamp (since := "2026-05-04")]
+def UInt64.ofNatTruncate (n : Nat) : UInt64 :=
+  UInt64.ofNatClamp n
 /--
 Converts a natural number to a 64-bit unsigned integer, wrapping on overflow.
 
@@ -340,11 +356,15 @@ large.
 Returns `USize.size - 1`, which is  `2^64 - 1` or `2^32 - 1` depending on the platform, for natural
 numbers greater than or equal to `USize.size`.
 -/
-def USize.ofNatTruncate (n : Nat) : USize :=
+def USize.ofNatClamp (n : Nat) : USize :=
   if h : n < USize.size then
     USize.ofNatLT n h
   else
     USize.ofNatLT (USize.size - 1) (Nat.pred_lt (Nat.ne_zero_of_lt USize.size_pos))
+
+@[inherit_doc USize.ofNatClamp, deprecated USize.ofNatClamp (since := "2026-05-04")]
+def USize.ofNatTruncate (n : Nat) : USize :=
+  USize.ofNatClamp n
 @[inherit_doc USize.ofNat] abbrev Nat.toUSize := USize.ofNat
 /--
 Converts a word-sized unsigned integer to an arbitrary-precision natural number.

--- a/src/Init/Data/UInt/Lemmas.lean
+++ b/src/Init/Data/UInt/Lemmas.lean
@@ -643,66 +643,66 @@ theorem UInt64.ofNatLT_eq_ofNat (n : Nat) {h} : UInt64.ofNatLT n h = UInt64.ofNa
 theorem USize.ofNatLT_eq_ofNat (n : Nat) {h} : USize.ofNatLT n h = USize.ofNat n :=
   USize.toNat.inj (by simp [Nat.mod_eq_of_lt h])
 
-theorem UInt8.ofNatTruncate_eq_ofNat (n : Nat) (hn : n < UInt8.size) :
-    UInt8.ofNatTruncate n = UInt8.ofNat n := by
-  simp [ofNatTruncate, hn, UInt8.ofNatLT_eq_ofNat]
-theorem UInt16.ofNatTruncate_eq_ofNat (n : Nat) (hn : n < UInt16.size) :
-    UInt16.ofNatTruncate n = UInt16.ofNat n := by
-  simp [ofNatTruncate, hn, UInt16.ofNatLT_eq_ofNat]
-theorem UInt32.ofNatTruncate_eq_ofNat (n : Nat) (hn : n < UInt32.size) :
-    UInt32.ofNatTruncate n = UInt32.ofNat n := by
-  simp [ofNatTruncate, hn, UInt32.ofNatLT_eq_ofNat]
-theorem UInt64.ofNatTruncate_eq_ofNat (n : Nat) (hn : n < UInt64.size) :
-    UInt64.ofNatTruncate n = UInt64.ofNat n := by
-  simp [ofNatTruncate, hn, UInt64.ofNatLT_eq_ofNat]
-theorem USize.ofNatTruncate_eq_ofNat (n : Nat) (hn : n < USize.size) :
-    USize.ofNatTruncate n = USize.ofNat n := by
-  simp [ofNatTruncate, hn, USize.ofNatLT_eq_ofNat]
+theorem UInt8.ofNatClamp_eq_ofNat (n : Nat) (hn : n < UInt8.size) :
+    UInt8.ofNatClamp n = UInt8.ofNat n := by
+  simp [ofNatClamp, hn, UInt8.ofNatLT_eq_ofNat]
+theorem UInt16.ofNatClamp_eq_ofNat (n : Nat) (hn : n < UInt16.size) :
+    UInt16.ofNatClamp n = UInt16.ofNat n := by
+  simp [ofNatClamp, hn, UInt16.ofNatLT_eq_ofNat]
+theorem UInt32.ofNatClamp_eq_ofNat (n : Nat) (hn : n < UInt32.size) :
+    UInt32.ofNatClamp n = UInt32.ofNat n := by
+  simp [ofNatClamp, hn, UInt32.ofNatLT_eq_ofNat]
+theorem UInt64.ofNatClamp_eq_ofNat (n : Nat) (hn : n < UInt64.size) :
+    UInt64.ofNatClamp n = UInt64.ofNat n := by
+  simp [ofNatClamp, hn, UInt64.ofNatLT_eq_ofNat]
+theorem USize.ofNatClamp_eq_ofNat (n : Nat) (hn : n < USize.size) :
+    USize.ofNatClamp n = USize.ofNat n := by
+  simp [ofNatClamp, hn, USize.ofNatLT_eq_ofNat]
 
-@[simp] theorem UInt8.ofNatTruncate_toNat (n : UInt8) : UInt8.ofNatTruncate n.toNat = n := by
-  rw [UInt8.ofNatTruncate_eq_ofNat] <;> simp [n.toNat_lt]
+@[simp] theorem UInt8.ofNatClamp_toNat (n : UInt8) : UInt8.ofNatClamp n.toNat = n := by
+  rw [UInt8.ofNatClamp_eq_ofNat] <;> simp [n.toNat_lt]
 
-@[simp] theorem UInt16.ofNatTruncate_uInt8ToNat (n : UInt8) : UInt16.ofNatTruncate n.toNat = n.toUInt16 := by
-  rw [UInt16.ofNatTruncate_eq_ofNat, ofNat_uInt8ToNat]
+@[simp] theorem UInt16.ofNatClamp_uInt8ToNat (n : UInt8) : UInt16.ofNatClamp n.toNat = n.toUInt16 := by
+  rw [UInt16.ofNatClamp_eq_ofNat, ofNat_uInt8ToNat]
   exact Nat.lt_trans (n.toNat_lt) (by decide)
-@[simp] theorem UInt16.ofNatTruncate_toNat (n : UInt16) : UInt16.ofNatTruncate n.toNat = n := by
-  rw [UInt16.ofNatTruncate_eq_ofNat] <;> simp [n.toNat_lt]
+@[simp] theorem UInt16.ofNatClamp_toNat (n : UInt16) : UInt16.ofNatClamp n.toNat = n := by
+  rw [UInt16.ofNatClamp_eq_ofNat] <;> simp [n.toNat_lt]
 
-@[simp] theorem UInt32.ofNatTruncate_uInt8ToNat (n : UInt8) : UInt32.ofNatTruncate n.toNat = n.toUInt32 := by
-  rw [UInt32.ofNatTruncate_eq_ofNat, ofNat_uInt8ToNat]
+@[simp] theorem UInt32.ofNatClamp_uInt8ToNat (n : UInt8) : UInt32.ofNatClamp n.toNat = n.toUInt32 := by
+  rw [UInt32.ofNatClamp_eq_ofNat, ofNat_uInt8ToNat]
   exact Nat.lt_trans (n.toNat_lt) (by decide)
-@[simp] theorem UInt32.ofNatTruncate_uInt16ToNat (n : UInt16) : UInt32.ofNatTruncate n.toNat = n.toUInt32 := by
-  rw [UInt32.ofNatTruncate_eq_ofNat, ofNat_uInt16ToNat]
+@[simp] theorem UInt32.ofNatClamp_uInt16ToNat (n : UInt16) : UInt32.ofNatClamp n.toNat = n.toUInt32 := by
+  rw [UInt32.ofNatClamp_eq_ofNat, ofNat_uInt16ToNat]
   exact Nat.lt_trans (n.toNat_lt) (by decide)
-@[simp] theorem UInt32.ofNatTruncate_toNat (n : UInt32) : UInt32.ofNatTruncate n.toNat = n := by
-  rw [UInt32.ofNatTruncate_eq_ofNat] <;> simp [n.toNat_lt]
+@[simp] theorem UInt32.ofNatClamp_toNat (n : UInt32) : UInt32.ofNatClamp n.toNat = n := by
+  rw [UInt32.ofNatClamp_eq_ofNat] <;> simp [n.toNat_lt]
 
-@[simp] theorem UInt64.ofNatTruncate_uInt8ToNat (n : UInt8) : UInt64.ofNatTruncate n.toNat = n.toUInt64 := by
-  rw [UInt64.ofNatTruncate_eq_ofNat, ofNat_uInt8ToNat]
+@[simp] theorem UInt64.ofNatClamp_uInt8ToNat (n : UInt8) : UInt64.ofNatClamp n.toNat = n.toUInt64 := by
+  rw [UInt64.ofNatClamp_eq_ofNat, ofNat_uInt8ToNat]
   exact Nat.lt_trans (n.toNat_lt) (by decide)
-@[simp] theorem UInt64.ofNatTruncate_uInt16ToNat (n : UInt16) : UInt64.ofNatTruncate n.toNat = n.toUInt64 := by
-  rw [UInt64.ofNatTruncate_eq_ofNat, ofNat_uInt16ToNat]
+@[simp] theorem UInt64.ofNatClamp_uInt16ToNat (n : UInt16) : UInt64.ofNatClamp n.toNat = n.toUInt64 := by
+  rw [UInt64.ofNatClamp_eq_ofNat, ofNat_uInt16ToNat]
   exact Nat.lt_trans (n.toNat_lt) (by decide)
-@[simp] theorem UInt64.ofNatTruncate_uInt32ToNat (n : UInt32) : UInt64.ofNatTruncate n.toNat = n.toUInt64 := by
-  rw [UInt64.ofNatTruncate_eq_ofNat, ofNat_uInt32ToNat]
+@[simp] theorem UInt64.ofNatClamp_uInt32ToNat (n : UInt32) : UInt64.ofNatClamp n.toNat = n.toUInt64 := by
+  rw [UInt64.ofNatClamp_eq_ofNat, ofNat_uInt32ToNat]
   exact Nat.lt_trans (n.toNat_lt) (by decide)
-@[simp] theorem UInt64.ofNatTruncate_toNat (n : UInt64) : UInt64.ofNatTruncate n.toNat = n := by
-  rw [UInt64.ofNatTruncate_eq_ofNat] <;> simp [n.toNat_lt]
-@[simp] theorem UInt64.ofNatTruncate_uSizeToNat (n : USize) : UInt64.ofNatTruncate n.toNat = n.toUInt64 := by
-  rw [UInt64.ofNatTruncate_eq_ofNat, ofNat_uSizeToNat]
+@[simp] theorem UInt64.ofNatClamp_toNat (n : UInt64) : UInt64.ofNatClamp n.toNat = n := by
+  rw [UInt64.ofNatClamp_eq_ofNat] <;> simp [n.toNat_lt]
+@[simp] theorem UInt64.ofNatClamp_uSizeToNat (n : USize) : UInt64.ofNatClamp n.toNat = n.toUInt64 := by
+  rw [UInt64.ofNatClamp_eq_ofNat, ofNat_uSizeToNat]
   exact n.toNat_lt
 
-@[simp] theorem USize.ofNatTruncate_uInt8ToNat (n : UInt8) : USize.ofNatTruncate n.toNat = n.toUSize := by
-  rw [USize.ofNatTruncate_eq_ofNat, ofNat_uInt8ToNat]
+@[simp] theorem USize.ofNatClamp_uInt8ToNat (n : UInt8) : USize.ofNatClamp n.toNat = n.toUSize := by
+  rw [USize.ofNatClamp_eq_ofNat, ofNat_uInt8ToNat]
   exact n.toNat_lt_usizeSize
-@[simp] theorem USize.ofNatTruncate_uInt16ToNat (n : UInt16) : USize.ofNatTruncate n.toNat = n.toUSize := by
-  rw [USize.ofNatTruncate_eq_ofNat, ofNat_uInt16ToNat]
+@[simp] theorem USize.ofNatClamp_uInt16ToNat (n : UInt16) : USize.ofNatClamp n.toNat = n.toUSize := by
+  rw [USize.ofNatClamp_eq_ofNat, ofNat_uInt16ToNat]
   exact n.toNat_lt_usizeSize
-@[simp] theorem USize.ofNatTruncate_uInt32ToNat (n : UInt32) : USize.ofNatTruncate n.toNat = n.toUSize := by
-  rw [USize.ofNatTruncate_eq_ofNat, ofNat_uInt32ToNat]
+@[simp] theorem USize.ofNatClamp_uInt32ToNat (n : UInt32) : USize.ofNatClamp n.toNat = n.toUSize := by
+  rw [USize.ofNatClamp_eq_ofNat, ofNat_uInt32ToNat]
   exact n.toNat_lt_usizeSize
-@[simp] theorem USize.ofNatTruncate_toNat (n : USize) : USize.ofNatTruncate n.toNat = n := by
-  rw [USize.ofNatTruncate_eq_ofNat] <;> simp [n.toNat_lt_size]
+@[simp] theorem USize.ofNatClamp_toNat (n : USize) : USize.ofNatClamp n.toNat = n := by
+  rw [USize.ofNatClamp_eq_ofNat] <;> simp [n.toNat_lt_size]
 
 @[simp] theorem UInt8.toUInt8_toUInt16 (n : UInt8) : n.toUInt16.toUInt8 = n :=
   UInt8.toNat.inj (by simp)
@@ -871,27 +871,27 @@ theorem USize.ofNatTruncate_eq_ofNat (n : Nat) (hn : n < USize.size) :
 @[simp] theorem UInt64.toNat_ofFin (x : Fin UInt64.size) : (UInt64.ofFin x).toNat = x.val := (rfl)
 @[simp] theorem USize.toNat_ofFin (x : Fin USize.size) : (USize.ofFin x).toNat = x.val := (rfl)
 
-theorem UInt8.toNat_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt8.size) :
-    (UInt8.ofNatTruncate n).toNat = n := by rw [UInt8.ofNatTruncate, dif_pos hn, toNat_ofNatLT]
-theorem UInt16.toNat_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt16.size) :
-    (UInt16.ofNatTruncate n).toNat = n := by rw [UInt16.ofNatTruncate, dif_pos hn, toNat_ofNatLT]
-theorem UInt32.toNat_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt32.size) :
-    (UInt32.ofNatTruncate n).toNat = n := by rw [UInt32.ofNatTruncate, dif_pos hn, toNat_ofNatLT]
-theorem UInt64.toNat_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt64.size) :
-    (UInt64.ofNatTruncate n).toNat = n := by rw [UInt64.ofNatTruncate, dif_pos hn, toNat_ofNatLT]
-theorem USize.toNat_ofNatTruncate_of_lt {n : Nat} (hn : n < USize.size) :
-    (USize.ofNatTruncate n).toNat = n := by rw [USize.ofNatTruncate, dif_pos hn, toNat_ofNatLT]
+theorem UInt8.toNat_ofNatClamp_of_lt {n : Nat} (hn : n < UInt8.size) :
+    (UInt8.ofNatClamp n).toNat = n := by rw [UInt8.ofNatClamp, dif_pos hn, toNat_ofNatLT]
+theorem UInt16.toNat_ofNatClamp_of_lt {n : Nat} (hn : n < UInt16.size) :
+    (UInt16.ofNatClamp n).toNat = n := by rw [UInt16.ofNatClamp, dif_pos hn, toNat_ofNatLT]
+theorem UInt32.toNat_ofNatClamp_of_lt {n : Nat} (hn : n < UInt32.size) :
+    (UInt32.ofNatClamp n).toNat = n := by rw [UInt32.ofNatClamp, dif_pos hn, toNat_ofNatLT]
+theorem UInt64.toNat_ofNatClamp_of_lt {n : Nat} (hn : n < UInt64.size) :
+    (UInt64.ofNatClamp n).toNat = n := by rw [UInt64.ofNatClamp, dif_pos hn, toNat_ofNatLT]
+theorem USize.toNat_ofNatClamp_of_lt {n : Nat} (hn : n < USize.size) :
+    (USize.ofNatClamp n).toNat = n := by rw [USize.ofNatClamp, dif_pos hn, toNat_ofNatLT]
 
-theorem UInt8.toNat_ofNatTruncate_of_le {n : Nat} (hn : UInt8.size ≤ n) :
-    (UInt8.ofNatTruncate n).toNat = UInt8.size - 1 := by rw [ofNatTruncate, dif_neg (by omega), toNat_ofNatLT]
-theorem UInt16.toNat_ofNatTruncate_of_le {n : Nat} (hn : UInt16.size ≤ n) :
-    (UInt16.ofNatTruncate n).toNat = UInt16.size - 1 := by rw [ofNatTruncate, dif_neg (by omega), toNat_ofNatLT]
-theorem UInt32.toNat_ofNatTruncate_of_le {n : Nat} (hn : UInt32.size ≤ n) :
-    (UInt32.ofNatTruncate n).toNat = UInt32.size - 1 := by rw [ofNatTruncate, dif_neg (by omega), toNat_ofNatLT]
-theorem UInt64.toNat_ofNatTruncate_of_le {n : Nat} (hn : UInt64.size ≤ n) :
-    (UInt64.ofNatTruncate n).toNat = UInt64.size - 1 := by rw [ofNatTruncate, dif_neg (by omega), toNat_ofNatLT]
-theorem USize.toNat_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
-    (USize.ofNatTruncate n).toNat = USize.size - 1 := by rw [ofNatTruncate, dif_neg (by omega), toNat_ofNatLT]
+theorem UInt8.toNat_ofNatClamp_of_le {n : Nat} (hn : UInt8.size ≤ n) :
+    (UInt8.ofNatClamp n).toNat = UInt8.size - 1 := by rw [ofNatClamp, dif_neg (by omega), toNat_ofNatLT]
+theorem UInt16.toNat_ofNatClamp_of_le {n : Nat} (hn : UInt16.size ≤ n) :
+    (UInt16.ofNatClamp n).toNat = UInt16.size - 1 := by rw [ofNatClamp, dif_neg (by omega), toNat_ofNatLT]
+theorem UInt32.toNat_ofNatClamp_of_le {n : Nat} (hn : UInt32.size ≤ n) :
+    (UInt32.ofNatClamp n).toNat = UInt32.size - 1 := by rw [ofNatClamp, dif_neg (by omega), toNat_ofNatLT]
+theorem UInt64.toNat_ofNatClamp_of_le {n : Nat} (hn : UInt64.size ≤ n) :
+    (UInt64.ofNatClamp n).toNat = UInt64.size - 1 := by rw [ofNatClamp, dif_neg (by omega), toNat_ofNatLT]
+theorem USize.toNat_ofNatClamp_of_le {n : Nat} (hn : USize.size ≤ n) :
+    (USize.ofNatClamp n).toNat = USize.size - 1 := by rw [ofNatClamp, dif_neg (by omega), toNat_ofNatLT]
 
 @[simp] theorem UInt8.toFin_ofNatLT {n : Nat} (hn) : (UInt8.ofNatLT n hn).toFin = ⟨n, hn⟩ := (rfl)
 @[simp] theorem UInt16.toFin_ofNatLT {n : Nat} (hn) : (UInt16.ofNatLT n hn).toFin = ⟨n, hn⟩ := (rfl)
@@ -911,37 +911,37 @@ theorem USize.toNat_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
 @[simp] theorem UInt64.toFin_ofBitVec {b} : (UInt64.ofBitVec b).toFin = b.toFin := (rfl)
 @[simp] theorem USize.toFin_ofBitVec {b} : (USize.ofBitVec b).toFin = b.toFin := (rfl)
 
-theorem UInt8.toFin_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt8.size) :
-    (UInt8.ofNatTruncate n).toFin = ⟨n, hn⟩ :=
-  Fin.val_inj.1 (by simp [toNat_ofNatTruncate_of_lt hn])
-theorem UInt16.toFin_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt16.size) :
-    (UInt16.ofNatTruncate n).toFin = ⟨n, hn⟩ :=
-  Fin.val_inj.1 (by simp [toNat_ofNatTruncate_of_lt hn])
-theorem UInt32.toFin_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt32.size) :
-    (UInt32.ofNatTruncate n).toFin = ⟨n, hn⟩ :=
-  Fin.val_inj.1 (by simp [toNat_ofNatTruncate_of_lt hn])
-theorem UInt64.toFin_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt64.size) :
-    (UInt64.ofNatTruncate n).toFin = ⟨n, hn⟩ :=
-  Fin.val_inj.1 (by simp [toNat_ofNatTruncate_of_lt hn])
-theorem USize.toFin_ofNatTruncate_of_lt {n : Nat} (hn : n < USize.size) :
-    (USize.ofNatTruncate n).toFin = ⟨n, hn⟩ :=
-  Fin.val_inj.1 (by simp [toNat_ofNatTruncate_of_lt hn])
+theorem UInt8.toFin_ofNatClamp_of_lt {n : Nat} (hn : n < UInt8.size) :
+    (UInt8.ofNatClamp n).toFin = ⟨n, hn⟩ :=
+  Fin.val_inj.1 (by simp [toNat_ofNatClamp_of_lt hn])
+theorem UInt16.toFin_ofNatClamp_of_lt {n : Nat} (hn : n < UInt16.size) :
+    (UInt16.ofNatClamp n).toFin = ⟨n, hn⟩ :=
+  Fin.val_inj.1 (by simp [toNat_ofNatClamp_of_lt hn])
+theorem UInt32.toFin_ofNatClamp_of_lt {n : Nat} (hn : n < UInt32.size) :
+    (UInt32.ofNatClamp n).toFin = ⟨n, hn⟩ :=
+  Fin.val_inj.1 (by simp [toNat_ofNatClamp_of_lt hn])
+theorem UInt64.toFin_ofNatClamp_of_lt {n : Nat} (hn : n < UInt64.size) :
+    (UInt64.ofNatClamp n).toFin = ⟨n, hn⟩ :=
+  Fin.val_inj.1 (by simp [toNat_ofNatClamp_of_lt hn])
+theorem USize.toFin_ofNatClamp_of_lt {n : Nat} (hn : n < USize.size) :
+    (USize.ofNatClamp n).toFin = ⟨n, hn⟩ :=
+  Fin.val_inj.1 (by simp [toNat_ofNatClamp_of_lt hn])
 
-theorem UInt8.toFin_ofNatTruncate_of_le {n : Nat} (hn : UInt8.size ≤ n) :
-    (UInt8.ofNatTruncate n).toFin = ⟨UInt8.size - 1, by decide⟩ :=
-  Fin.val_inj.1 (by simp [toNat_ofNatTruncate_of_le hn])
-theorem UInt16.toFin_ofNatTruncate_of_le {n : Nat} (hn : UInt16.size ≤ n) :
-    (UInt16.ofNatTruncate n).toFin = ⟨UInt16.size - 1, by decide⟩ :=
-  Fin.val_inj.1 (by simp [toNat_ofNatTruncate_of_le hn])
-theorem UInt32.toFin_ofNatTruncate_of_le {n : Nat} (hn : UInt32.size ≤ n) :
-    (UInt32.ofNatTruncate n).toFin = ⟨UInt32.size - 1, by decide⟩ :=
-  Fin.val_inj.1 (by simp [toNat_ofNatTruncate_of_le hn])
-theorem UInt64.toFin_ofNatTruncate_of_le {n : Nat} (hn : UInt64.size ≤ n) :
-    (UInt64.ofNatTruncate n).toFin = ⟨UInt64.size - 1, by decide⟩ :=
-  Fin.val_inj.1 (by simp [toNat_ofNatTruncate_of_le hn])
-theorem USize.toFin_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
-    (USize.ofNatTruncate n).toFin = ⟨USize.size - 1, by cases USize.size_eq <;> simp_all⟩ :=
-  Fin.val_inj.1 (by simp [toNat_ofNatTruncate_of_le hn])
+theorem UInt8.toFin_ofNatClamp_of_le {n : Nat} (hn : UInt8.size ≤ n) :
+    (UInt8.ofNatClamp n).toFin = ⟨UInt8.size - 1, by decide⟩ :=
+  Fin.val_inj.1 (by simp [toNat_ofNatClamp_of_le hn])
+theorem UInt16.toFin_ofNatClamp_of_le {n : Nat} (hn : UInt16.size ≤ n) :
+    (UInt16.ofNatClamp n).toFin = ⟨UInt16.size - 1, by decide⟩ :=
+  Fin.val_inj.1 (by simp [toNat_ofNatClamp_of_le hn])
+theorem UInt32.toFin_ofNatClamp_of_le {n : Nat} (hn : UInt32.size ≤ n) :
+    (UInt32.ofNatClamp n).toFin = ⟨UInt32.size - 1, by decide⟩ :=
+  Fin.val_inj.1 (by simp [toNat_ofNatClamp_of_le hn])
+theorem UInt64.toFin_ofNatClamp_of_le {n : Nat} (hn : UInt64.size ≤ n) :
+    (UInt64.ofNatClamp n).toFin = ⟨UInt64.size - 1, by decide⟩ :=
+  Fin.val_inj.1 (by simp [toNat_ofNatClamp_of_le hn])
+theorem USize.toFin_ofNatClamp_of_le {n : Nat} (hn : USize.size ≤ n) :
+    (USize.ofNatClamp n).toFin = ⟨USize.size - 1, by cases USize.size_eq <;> simp_all⟩ :=
+  Fin.val_inj.1 (by simp [toNat_ofNatClamp_of_le hn])
 
 @[simp, int_toBitVec] theorem UInt8.toBitVec_ofNatLT {n : Nat} (hn : n < UInt8.size) :
     (UInt8.ofNatLT n hn).toBitVec = BitVec.ofNatLT n hn := (rfl)
@@ -966,37 +966,37 @@ theorem USize.toFin_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
 @[simp, int_toBitVec] theorem UInt64.toBitVec_ofBitVec (n) : (UInt64.ofBitVec n).toBitVec = n := (rfl)
 @[simp, int_toBitVec] theorem USize.toBitVec_ofBitVec (n) : (USize.ofBitVec n).toBitVec = n := (rfl)
 
-theorem UInt8.toBitVec_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt8.size) :
-    (UInt8.ofNatTruncate n).toBitVec = BitVec.ofNatLT n hn :=
-  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatTruncate_of_lt hn])
-theorem UInt16.toBitVec_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt16.size) :
-    (UInt16.ofNatTruncate n).toBitVec = BitVec.ofNatLT n hn :=
-  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatTruncate_of_lt hn])
-theorem UInt32.toBitVec_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt32.size) :
-    (UInt32.ofNatTruncate n).toBitVec = BitVec.ofNatLT n hn :=
-  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatTruncate_of_lt hn])
-theorem UInt64.toBitVec_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt64.size) :
-    (UInt64.ofNatTruncate n).toBitVec = BitVec.ofNatLT n hn :=
-  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatTruncate_of_lt hn])
-theorem USize.toBitVec_ofNatTruncate_of_lt {n : Nat} (hn : n < USize.size) :
-    (USize.ofNatTruncate n).toBitVec = BitVec.ofNatLT n hn :=
-  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatTruncate_of_lt hn])
+theorem UInt8.toBitVec_ofNatClamp_of_lt {n : Nat} (hn : n < UInt8.size) :
+    (UInt8.ofNatClamp n).toBitVec = BitVec.ofNatLT n hn :=
+  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatClamp_of_lt hn])
+theorem UInt16.toBitVec_ofNatClamp_of_lt {n : Nat} (hn : n < UInt16.size) :
+    (UInt16.ofNatClamp n).toBitVec = BitVec.ofNatLT n hn :=
+  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatClamp_of_lt hn])
+theorem UInt32.toBitVec_ofNatClamp_of_lt {n : Nat} (hn : n < UInt32.size) :
+    (UInt32.ofNatClamp n).toBitVec = BitVec.ofNatLT n hn :=
+  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatClamp_of_lt hn])
+theorem UInt64.toBitVec_ofNatClamp_of_lt {n : Nat} (hn : n < UInt64.size) :
+    (UInt64.ofNatClamp n).toBitVec = BitVec.ofNatLT n hn :=
+  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatClamp_of_lt hn])
+theorem USize.toBitVec_ofNatClamp_of_lt {n : Nat} (hn : n < USize.size) :
+    (USize.ofNatClamp n).toBitVec = BitVec.ofNatLT n hn :=
+  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatClamp_of_lt hn])
 
-theorem UInt8.toBitVec_ofNatTruncate_of_le {n : Nat} (hn : UInt8.size ≤ n) :
-    (UInt8.ofNatTruncate n).toBitVec = BitVec.ofNatLT (UInt8.size - 1) (by decide) :=
-  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatTruncate_of_le hn])
-theorem UInt16.toBitVec_ofNatTruncate_of_le {n : Nat} (hn : UInt16.size ≤ n) :
-    (UInt16.ofNatTruncate n).toBitVec = BitVec.ofNatLT (UInt16.size - 1) (by decide) :=
-  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatTruncate_of_le hn])
-theorem UInt32.toBitVec_ofNatTruncate_of_le {n : Nat} (hn : UInt32.size ≤ n) :
-    (UInt32.ofNatTruncate n).toBitVec = BitVec.ofNatLT (UInt32.size - 1) (by decide) :=
-  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatTruncate_of_le hn])
-theorem UInt64.toBitVec_ofNatTruncate_of_le {n : Nat} (hn : UInt64.size ≤ n) :
-    (UInt64.ofNatTruncate n).toBitVec = BitVec.ofNatLT (UInt64.size - 1) (by decide) :=
-  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatTruncate_of_le hn])
-theorem USize.toBitVec_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
-    (USize.ofNatTruncate n).toBitVec = BitVec.ofNatLT (USize.size - 1) (by cases USize.size_eq <;> simp_all) :=
-  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatTruncate_of_le hn])
+theorem UInt8.toBitVec_ofNatClamp_of_le {n : Nat} (hn : UInt8.size ≤ n) :
+    (UInt8.ofNatClamp n).toBitVec = BitVec.ofNatLT (UInt8.size - 1) (by decide) :=
+  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatClamp_of_le hn])
+theorem UInt16.toBitVec_ofNatClamp_of_le {n : Nat} (hn : UInt16.size ≤ n) :
+    (UInt16.ofNatClamp n).toBitVec = BitVec.ofNatLT (UInt16.size - 1) (by decide) :=
+  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatClamp_of_le hn])
+theorem UInt32.toBitVec_ofNatClamp_of_le {n : Nat} (hn : UInt32.size ≤ n) :
+    (UInt32.ofNatClamp n).toBitVec = BitVec.ofNatLT (UInt32.size - 1) (by decide) :=
+  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatClamp_of_le hn])
+theorem UInt64.toBitVec_ofNatClamp_of_le {n : Nat} (hn : UInt64.size ≤ n) :
+    (UInt64.ofNatClamp n).toBitVec = BitVec.ofNatLT (UInt64.size - 1) (by decide) :=
+  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatClamp_of_le hn])
+theorem USize.toBitVec_ofNatClamp_of_le {n : Nat} (hn : USize.size ≤ n) :
+    (USize.ofNatClamp n).toBitVec = BitVec.ofNatLT (USize.size - 1) (by cases USize.size_eq <;> simp_all) :=
+  BitVec.eq_of_toNat_eq (by simp [toNat_ofNatClamp_of_le hn])
 
 @[simp] theorem UInt16.toUInt8_ofNatLT {n : Nat} (hn) : (UInt16.ofNatLT n hn).toUInt8 = UInt8.ofNat n := (rfl)
 @[simp] theorem UInt32.toUInt8_ofNatLT {n : Nat} (hn) : (UInt32.ofNatLT n hn).toUInt8 = UInt8.ofNat n := (rfl)
@@ -1024,27 +1024,27 @@ theorem USize.toBitVec_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
 @[simp] theorem UInt64.toUInt8_ofNat {n : Nat} : toUInt8 (no_index (OfNat.ofNat n)) = OfNat.ofNat n := toUInt8_ofNat' _
 @[simp] theorem USize.toUInt8_ofNat {n : Nat} : toUInt8 (no_index (OfNat.ofNat n)) = OfNat.ofNat n := toUInt8_ofNat' _
 
-theorem UInt16.toUInt8_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt16.size) :
-    (UInt16.ofNatTruncate n).toUInt8 = UInt8.ofNat n := by rw [ofNatTruncate, dif_pos hn, toUInt8_ofNatLT]
-theorem UInt32.toUInt8_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt32.size) :
-    (UInt32.ofNatTruncate n).toUInt8 = UInt8.ofNat n := by rw [ofNatTruncate, dif_pos hn, toUInt8_ofNatLT]
-theorem UInt64.toUInt8_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt64.size) :
-    (UInt64.ofNatTruncate n).toUInt8 = UInt8.ofNat n := by rw [ofNatTruncate, dif_pos hn, toUInt8_ofNatLT]
-theorem USize.toUInt8_ofNatTruncate_of_lt {n : Nat} (hn : n < USize.size) :
-    (USize.ofNatTruncate n).toUInt8 = UInt8.ofNat n := by rw [ofNatTruncate, dif_pos hn, toUInt8_ofNatLT]
+theorem UInt16.toUInt8_ofNatClamp_of_lt {n : Nat} (hn : n < UInt16.size) :
+    (UInt16.ofNatClamp n).toUInt8 = UInt8.ofNat n := by rw [ofNatClamp, dif_pos hn, toUInt8_ofNatLT]
+theorem UInt32.toUInt8_ofNatClamp_of_lt {n : Nat} (hn : n < UInt32.size) :
+    (UInt32.ofNatClamp n).toUInt8 = UInt8.ofNat n := by rw [ofNatClamp, dif_pos hn, toUInt8_ofNatLT]
+theorem UInt64.toUInt8_ofNatClamp_of_lt {n : Nat} (hn : n < UInt64.size) :
+    (UInt64.ofNatClamp n).toUInt8 = UInt8.ofNat n := by rw [ofNatClamp, dif_pos hn, toUInt8_ofNatLT]
+theorem USize.toUInt8_ofNatClamp_of_lt {n : Nat} (hn : n < USize.size) :
+    (USize.ofNatClamp n).toUInt8 = UInt8.ofNat n := by rw [ofNatClamp, dif_pos hn, toUInt8_ofNatLT]
 
-theorem UInt16.toUInt8_ofNatTruncate_of_le {n : Nat} (hn : UInt16.size ≤ n) :
-    (UInt16.ofNatTruncate n).toUInt8 = UInt8.ofNatLT (UInt8.size - 1) (by decide) :=
-  UInt8.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
-theorem UInt32.toUInt8_ofNatTruncate_of_le {n : Nat} (hn : UInt32.size ≤ n) :
-    (UInt32.ofNatTruncate n).toUInt8 = UInt8.ofNatLT (UInt8.size - 1) (by decide) :=
-  UInt8.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
-theorem UInt64.toUInt8_ofNatTruncate_of_le {n : Nat} (hn : UInt64.size ≤ n) :
-    (UInt64.ofNatTruncate n).toUInt8 = UInt8.ofNatLT (UInt8.size - 1) (by decide) :=
-  UInt8.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
-theorem USize.toUInt8_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
-    (USize.ofNatTruncate n).toUInt8 = UInt8.ofNatLT (UInt8.size - 1) (by decide) :=
-  UInt8.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
+theorem UInt16.toUInt8_ofNatClamp_of_le {n : Nat} (hn : UInt16.size ≤ n) :
+    (UInt16.ofNatClamp n).toUInt8 = UInt8.ofNatLT (UInt8.size - 1) (by decide) :=
+  UInt8.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
+theorem UInt32.toUInt8_ofNatClamp_of_le {n : Nat} (hn : UInt32.size ≤ n) :
+    (UInt32.ofNatClamp n).toUInt8 = UInt8.ofNatLT (UInt8.size - 1) (by decide) :=
+  UInt8.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
+theorem UInt64.toUInt8_ofNatClamp_of_le {n : Nat} (hn : UInt64.size ≤ n) :
+    (UInt64.ofNatClamp n).toUInt8 = UInt8.ofNatLT (UInt8.size - 1) (by decide) :=
+  UInt8.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
+theorem USize.toUInt8_ofNatClamp_of_le {n : Nat} (hn : USize.size ≤ n) :
+    (USize.ofNatClamp n).toUInt8 = UInt8.ofNatLT (UInt8.size - 1) (by decide) :=
+  UInt8.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
 
 @[simp] theorem UInt32.toUInt16_ofNatLT {n : Nat} (hn) : (UInt32.ofNatLT n hn).toUInt16 = UInt16.ofNat n := (rfl)
 @[simp] theorem UInt64.toUInt16_ofNatLT {n : Nat} (hn) : (UInt64.ofNatLT n hn).toUInt16 = UInt16.ofNat n := (rfl)
@@ -1067,22 +1067,22 @@ theorem USize.toUInt8_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
 @[simp] theorem UInt64.toUInt16_ofNat {n : Nat} : toUInt16 (no_index (OfNat.ofNat n)) = OfNat.ofNat n := UInt64.toUInt16_ofNat' _
 @[simp] theorem USize.toUInt16_ofNat {n : Nat} : toUInt16 (no_index (OfNat.ofNat n)) = OfNat.ofNat n := USize.toUInt16_ofNat' _
 
-theorem UInt32.toUInt16_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt32.size) :
-    (UInt32.ofNatTruncate n).toUInt16 = UInt16.ofNat n := by rw [ofNatTruncate, dif_pos hn, toUInt16_ofNatLT]
-theorem UInt64.toUInt16_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt64.size) :
-    (UInt64.ofNatTruncate n).toUInt16 = UInt16.ofNat n := by rw [ofNatTruncate, dif_pos hn, toUInt16_ofNatLT]
-theorem USize.toUInt16_ofNatTruncate_of_lt {n : Nat} (hn : n < USize.size) :
-    (USize.ofNatTruncate n).toUInt16 = UInt16.ofNat n := by rw [ofNatTruncate, dif_pos hn, toUInt16_ofNatLT]
+theorem UInt32.toUInt16_ofNatClamp_of_lt {n : Nat} (hn : n < UInt32.size) :
+    (UInt32.ofNatClamp n).toUInt16 = UInt16.ofNat n := by rw [ofNatClamp, dif_pos hn, toUInt16_ofNatLT]
+theorem UInt64.toUInt16_ofNatClamp_of_lt {n : Nat} (hn : n < UInt64.size) :
+    (UInt64.ofNatClamp n).toUInt16 = UInt16.ofNat n := by rw [ofNatClamp, dif_pos hn, toUInt16_ofNatLT]
+theorem USize.toUInt16_ofNatClamp_of_lt {n : Nat} (hn : n < USize.size) :
+    (USize.ofNatClamp n).toUInt16 = UInt16.ofNat n := by rw [ofNatClamp, dif_pos hn, toUInt16_ofNatLT]
 
-theorem UInt32.toUInt16_ofNatTruncate_of_le {n : Nat} (hn : UInt32.size ≤ n) :
-    (UInt32.ofNatTruncate n).toUInt16 = UInt16.ofNatLT (UInt16.size - 1) (by decide) :=
-  UInt16.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
-theorem UInt64.toUInt16_ofNatTruncate_of_le {n : Nat} (hn : UInt64.size ≤ n) :
-    (UInt64.ofNatTruncate n).toUInt16 = UInt16.ofNatLT (UInt16.size - 1) (by decide) :=
-  UInt16.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
-theorem USize.toUInt16_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
-    (USize.ofNatTruncate n).toUInt16 = UInt16.ofNatLT (UInt16.size - 1) (by decide) :=
-  UInt16.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
+theorem UInt32.toUInt16_ofNatClamp_of_le {n : Nat} (hn : UInt32.size ≤ n) :
+    (UInt32.ofNatClamp n).toUInt16 = UInt16.ofNatLT (UInt16.size - 1) (by decide) :=
+  UInt16.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
+theorem UInt64.toUInt16_ofNatClamp_of_le {n : Nat} (hn : UInt64.size ≤ n) :
+    (UInt64.ofNatClamp n).toUInt16 = UInt16.ofNatLT (UInt16.size - 1) (by decide) :=
+  UInt16.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
+theorem USize.toUInt16_ofNatClamp_of_le {n : Nat} (hn : USize.size ≤ n) :
+    (USize.ofNatClamp n).toUInt16 = UInt16.ofNatLT (UInt16.size - 1) (by decide) :=
+  UInt16.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
 
 @[simp] theorem UInt64.toUInt32_ofNatLT {n : Nat} (hn) : (UInt64.ofNatLT n hn).toUInt32 = UInt32.ofNat n := (rfl)
 @[simp] theorem USize.toUInt32_ofNatLT {n : Nat} (hn) : (USize.ofNatLT n hn).toUInt32 = UInt32.ofNat n := (rfl)
@@ -1100,17 +1100,17 @@ theorem USize.toUInt16_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
 @[simp] theorem UInt64.toUInt32_ofNat {n : Nat} : toUInt32 (no_index (OfNat.ofNat n)) = OfNat.ofNat n := UInt64.toUInt32_ofNat' _
 @[simp] theorem USize.toUInt32_ofNat {n : Nat} : toUInt32 (no_index (OfNat.ofNat n)) = OfNat.ofNat n := USize.toUInt32_ofNat' _
 
-theorem UInt64.toUInt32_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt64.size) :
-    (UInt64.ofNatTruncate n).toUInt32 = UInt32.ofNat n := by rw [ofNatTruncate, dif_pos hn, toUInt32_ofNatLT]
-theorem USize.toUInt32_ofNatTruncate_of_lt {n : Nat} (hn : n < USize.size) :
-    (USize.ofNatTruncate n).toUInt32 = UInt32.ofNat n := by rw [ofNatTruncate, dif_pos hn, toUInt32_ofNatLT]
+theorem UInt64.toUInt32_ofNatClamp_of_lt {n : Nat} (hn : n < UInt64.size) :
+    (UInt64.ofNatClamp n).toUInt32 = UInt32.ofNat n := by rw [ofNatClamp, dif_pos hn, toUInt32_ofNatLT]
+theorem USize.toUInt32_ofNatClamp_of_lt {n : Nat} (hn : n < USize.size) :
+    (USize.ofNatClamp n).toUInt32 = UInt32.ofNat n := by rw [ofNatClamp, dif_pos hn, toUInt32_ofNatLT]
 
-theorem UInt64.toUInt32_ofNatTruncate_of_le {n : Nat} (hn : UInt64.size ≤ n) :
-    (UInt64.ofNatTruncate n).toUInt32 = UInt32.ofNatLT (UInt32.size - 1) (by decide) :=
-  UInt32.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
-theorem USize.toUInt32_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
-    (USize.ofNatTruncate n).toUInt32 = UInt32.ofNatLT (UInt32.size - 1) (by decide) :=
-  UInt32.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
+theorem UInt64.toUInt32_ofNatClamp_of_le {n : Nat} (hn : UInt64.size ≤ n) :
+    (UInt64.ofNatClamp n).toUInt32 = UInt32.ofNatLT (UInt32.size - 1) (by decide) :=
+  UInt32.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
+theorem USize.toUInt32_ofNatClamp_of_le {n : Nat} (hn : USize.size ≤ n) :
+    (USize.ofNatClamp n).toUInt32 = UInt32.ofNatLT (UInt32.size - 1) (by decide) :=
+  UInt32.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
 
 @[simp] theorem UInt64.toUSize_ofNatLT {n : Nat} (hn) : (UInt64.ofNatLT n hn).toUSize = USize.ofNat n := (rfl)
 
@@ -1123,12 +1123,12 @@ theorem USize.toUInt32_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
 
 @[simp] theorem UInt64.toUSize_ofNat {n : Nat} : toUSize (no_index (OfNat.ofNat n)) = OfNat.ofNat n := UInt64.toUSize_ofNat' _
 
-theorem UInt64.toUSize_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt64.size) :
-    (UInt64.ofNatTruncate n).toUSize = USize.ofNat n := by rw [ofNatTruncate, dif_pos hn, toUSize_ofNatLT]
+theorem UInt64.toUSize_ofNatClamp_of_lt {n : Nat} (hn : n < UInt64.size) :
+    (UInt64.ofNatClamp n).toUSize = USize.ofNat n := by rw [ofNatClamp, dif_pos hn, toUSize_ofNatLT]
 
-theorem UInt64.toUSize_ofNatTruncate_of_le {n : Nat} (hn : UInt64.size ≤ n) :
-    (UInt64.ofNatTruncate n).toUSize = USize.ofNatLT (USize.size - 1) (by cases USize.size_eq <;> simp_all) :=
-  USize.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
+theorem UInt64.toUSize_ofNatClamp_of_le {n : Nat} (hn : UInt64.size ≤ n) :
+    (UInt64.ofNatClamp n).toUSize = USize.ofNatLT (USize.size - 1) (by cases USize.size_eq <;> simp_all) :=
+  USize.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
 
 theorem UInt8.toUInt16_ofNatLT {n : Nat} (h) :
     (UInt8.ofNatLT n h).toUInt16 = UInt16.ofNatLT n (Nat.lt_of_lt_of_le h (by decide)) := (rfl)
@@ -1154,31 +1154,31 @@ theorem UInt8.toUSize_ofFin {n} :
 @[simp] theorem UInt8.toUSize_ofBitVec {b} : (UInt8.ofBitVec b).toUSize = USize.ofBitVec (b.setWidth _) :=
   USize.toBitVec_inj.1 (by simp)
 
-theorem UInt8.toUInt16_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt8.size) :
-    (UInt8.ofNatTruncate n).toUInt16 = UInt16.ofNatLT n (Nat.lt_of_lt_of_le hn (by decide)) :=
-  UInt16.toNat.inj (by simp [toNat_ofNatTruncate_of_lt hn])
-theorem UInt8.toUInt32_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt8.size) :
-    (UInt8.ofNatTruncate n).toUInt32 = UInt32.ofNatLT n (Nat.lt_of_lt_of_le hn (by decide)) :=
-  UInt32.toNat.inj (by simp [toNat_ofNatTruncate_of_lt hn])
-theorem UInt8.toUInt64_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt8.size) :
-    (UInt8.ofNatTruncate n).toUInt64 = UInt64.ofNatLT n (Nat.lt_of_lt_of_le hn (by decide)) :=
-  UInt64.toNat.inj (by simp [toNat_ofNatTruncate_of_lt hn])
-theorem UInt8.toUSize_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt8.size) :
-    (UInt8.ofNatTruncate n).toUSize = USize.ofNatLT n (Nat.lt_of_lt_of_le hn size_le_usizeSize) :=
-  USize.toNat.inj (by simp [toNat_ofNatTruncate_of_lt hn])
+theorem UInt8.toUInt16_ofNatClamp_of_lt {n : Nat} (hn : n < UInt8.size) :
+    (UInt8.ofNatClamp n).toUInt16 = UInt16.ofNatLT n (Nat.lt_of_lt_of_le hn (by decide)) :=
+  UInt16.toNat.inj (by simp [toNat_ofNatClamp_of_lt hn])
+theorem UInt8.toUInt32_ofNatClamp_of_lt {n : Nat} (hn : n < UInt8.size) :
+    (UInt8.ofNatClamp n).toUInt32 = UInt32.ofNatLT n (Nat.lt_of_lt_of_le hn (by decide)) :=
+  UInt32.toNat.inj (by simp [toNat_ofNatClamp_of_lt hn])
+theorem UInt8.toUInt64_ofNatClamp_of_lt {n : Nat} (hn : n < UInt8.size) :
+    (UInt8.ofNatClamp n).toUInt64 = UInt64.ofNatLT n (Nat.lt_of_lt_of_le hn (by decide)) :=
+  UInt64.toNat.inj (by simp [toNat_ofNatClamp_of_lt hn])
+theorem UInt8.toUSize_ofNatClamp_of_lt {n : Nat} (hn : n < UInt8.size) :
+    (UInt8.ofNatClamp n).toUSize = USize.ofNatLT n (Nat.lt_of_lt_of_le hn size_le_usizeSize) :=
+  USize.toNat.inj (by simp [toNat_ofNatClamp_of_lt hn])
 
-theorem UInt8.toUInt16_ofNatTruncate_of_le {n : Nat} (hn : UInt8.size ≤ n) :
-    (UInt8.ofNatTruncate n).toUInt16 = UInt16.ofNatLT (UInt8.size - 1) (by decide) :=
-  UInt16.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
-theorem UInt8.toUInt32_ofNatTruncate_of_le {n : Nat} (hn : UInt8.size ≤ n) :
-    (UInt8.ofNatTruncate n).toUInt32 = UInt32.ofNatLT (UInt8.size - 1) (by decide) :=
-  UInt32.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
-theorem UInt8.toUInt64_ofNatTruncate_of_le {n : Nat} (hn : UInt8.size ≤ n) :
-    (UInt8.ofNatTruncate n).toUInt64 = UInt64.ofNatLT (UInt8.size - 1) (by decide) :=
-  UInt64.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
-theorem UInt8.toUSize_ofNatTruncate_of_le {n : Nat} (hn : UInt8.size ≤ n) :
-    (UInt8.ofNatTruncate n).toUSize = USize.ofNatLT (UInt8.size - 1) (Nat.lt_of_lt_of_le (by decide) size_le_usizeSize) :=
-  USize.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
+theorem UInt8.toUInt16_ofNatClamp_of_le {n : Nat} (hn : UInt8.size ≤ n) :
+    (UInt8.ofNatClamp n).toUInt16 = UInt16.ofNatLT (UInt8.size - 1) (by decide) :=
+  UInt16.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
+theorem UInt8.toUInt32_ofNatClamp_of_le {n : Nat} (hn : UInt8.size ≤ n) :
+    (UInt8.ofNatClamp n).toUInt32 = UInt32.ofNatLT (UInt8.size - 1) (by decide) :=
+  UInt32.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
+theorem UInt8.toUInt64_ofNatClamp_of_le {n : Nat} (hn : UInt8.size ≤ n) :
+    (UInt8.ofNatClamp n).toUInt64 = UInt64.ofNatLT (UInt8.size - 1) (by decide) :=
+  UInt64.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
+theorem UInt8.toUSize_ofNatClamp_of_le {n : Nat} (hn : UInt8.size ≤ n) :
+    (UInt8.ofNatClamp n).toUSize = USize.ofNatLT (UInt8.size - 1) (Nat.lt_of_lt_of_le (by decide) size_le_usizeSize) :=
+  USize.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
 
 theorem UInt16.toUInt32_ofNatLT {n : Nat} (h) :
     (UInt16.ofNatLT n h).toUInt32 = UInt32.ofNatLT n (Nat.lt_of_lt_of_le h (by decide)) := (rfl)
@@ -1199,25 +1199,25 @@ theorem UInt16.toUSize_ofFin {n} :
 @[simp] theorem UInt16.toUSize_ofBitVec {b} : (UInt16.ofBitVec b).toUSize = USize.ofBitVec (b.setWidth _) :=
   USize.toBitVec_inj.1 (by simp)
 
-theorem UInt16.toUInt32_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt16.size) :
-    (UInt16.ofNatTruncate n).toUInt32 = UInt32.ofNatLT n (Nat.lt_of_lt_of_le hn (by decide)) :=
-  UInt32.toNat.inj (by simp [toNat_ofNatTruncate_of_lt hn])
-theorem UInt16.toUInt64_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt16.size) :
-    (UInt16.ofNatTruncate n).toUInt64 = UInt64.ofNatLT n (Nat.lt_of_lt_of_le hn (by decide)) :=
-  UInt64.toNat.inj (by simp [toNat_ofNatTruncate_of_lt hn])
-theorem UInt16.toUSize_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt16.size) :
-    (UInt16.ofNatTruncate n).toUSize = USize.ofNatLT n (Nat.lt_of_lt_of_le hn size_le_usizeSize) :=
-  USize.toNat.inj (by simp [toNat_ofNatTruncate_of_lt hn])
+theorem UInt16.toUInt32_ofNatClamp_of_lt {n : Nat} (hn : n < UInt16.size) :
+    (UInt16.ofNatClamp n).toUInt32 = UInt32.ofNatLT n (Nat.lt_of_lt_of_le hn (by decide)) :=
+  UInt32.toNat.inj (by simp [toNat_ofNatClamp_of_lt hn])
+theorem UInt16.toUInt64_ofNatClamp_of_lt {n : Nat} (hn : n < UInt16.size) :
+    (UInt16.ofNatClamp n).toUInt64 = UInt64.ofNatLT n (Nat.lt_of_lt_of_le hn (by decide)) :=
+  UInt64.toNat.inj (by simp [toNat_ofNatClamp_of_lt hn])
+theorem UInt16.toUSize_ofNatClamp_of_lt {n : Nat} (hn : n < UInt16.size) :
+    (UInt16.ofNatClamp n).toUSize = USize.ofNatLT n (Nat.lt_of_lt_of_le hn size_le_usizeSize) :=
+  USize.toNat.inj (by simp [toNat_ofNatClamp_of_lt hn])
 
-theorem UInt16.toUInt32_ofNatTruncate_of_le {n : Nat} (hn : UInt16.size ≤ n) :
-    (UInt16.ofNatTruncate n).toUInt32 = UInt32.ofNatLT (UInt16.size - 1) (by decide) :=
-  UInt32.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
-theorem UInt16.toUInt64_ofNatTruncate_of_le {n : Nat} (hn : UInt16.size ≤ n) :
-    (UInt16.ofNatTruncate n).toUInt64 = UInt64.ofNatLT (UInt16.size - 1) (by decide) :=
-  UInt64.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
-theorem UInt16.toUSize_ofNatTruncate_of_le {n : Nat} (hn : UInt16.size ≤ n) :
-    (UInt16.ofNatTruncate n).toUSize = USize.ofNatLT (UInt16.size - 1) (Nat.lt_of_lt_of_le (by decide) size_le_usizeSize) :=
-  USize.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
+theorem UInt16.toUInt32_ofNatClamp_of_le {n : Nat} (hn : UInt16.size ≤ n) :
+    (UInt16.ofNatClamp n).toUInt32 = UInt32.ofNatLT (UInt16.size - 1) (by decide) :=
+  UInt32.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
+theorem UInt16.toUInt64_ofNatClamp_of_le {n : Nat} (hn : UInt16.size ≤ n) :
+    (UInt16.ofNatClamp n).toUInt64 = UInt64.ofNatLT (UInt16.size - 1) (by decide) :=
+  UInt64.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
+theorem UInt16.toUSize_ofNatClamp_of_le {n : Nat} (hn : UInt16.size ≤ n) :
+    (UInt16.ofNatClamp n).toUSize = USize.ofNatLT (UInt16.size - 1) (Nat.lt_of_lt_of_le (by decide) size_le_usizeSize) :=
+  USize.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
 
 theorem UInt32.toUInt64_ofNatLT {n : Nat} (h) :
     (UInt32.ofNatLT n h).toUInt64 = UInt64.ofNatLT n (Nat.lt_of_lt_of_le h (by decide)) := (rfl)
@@ -1233,19 +1233,19 @@ theorem UInt32.toUSize_ofFin {n} :
 @[simp] theorem UInt32.toUSize_ofBitVec {b} : (UInt32.ofBitVec b).toUSize = USize.ofBitVec (b.setWidth _) :=
   USize.toBitVec_inj.1 (by simp)
 
-theorem UInt32.toUInt64_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt32.size) :
-    (UInt32.ofNatTruncate n).toUInt64 = UInt64.ofNatLT n (Nat.lt_of_lt_of_le hn (by decide)) :=
-  UInt64.toNat.inj (by simp [toNat_ofNatTruncate_of_lt hn])
-theorem UInt32.toUSize_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt32.size) :
-    (UInt32.ofNatTruncate n).toUSize = USize.ofNatLT n (Nat.lt_of_lt_of_le hn size_le_usizeSize) :=
-  USize.toNat.inj (by simp [toNat_ofNatTruncate_of_lt hn])
+theorem UInt32.toUInt64_ofNatClamp_of_lt {n : Nat} (hn : n < UInt32.size) :
+    (UInt32.ofNatClamp n).toUInt64 = UInt64.ofNatLT n (Nat.lt_of_lt_of_le hn (by decide)) :=
+  UInt64.toNat.inj (by simp [toNat_ofNatClamp_of_lt hn])
+theorem UInt32.toUSize_ofNatClamp_of_lt {n : Nat} (hn : n < UInt32.size) :
+    (UInt32.ofNatClamp n).toUSize = USize.ofNatLT n (Nat.lt_of_lt_of_le hn size_le_usizeSize) :=
+  USize.toNat.inj (by simp [toNat_ofNatClamp_of_lt hn])
 
-theorem UInt32.toUInt64_ofNatTruncate_of_le {n : Nat} (hn : UInt32.size ≤ n) :
-    (UInt32.ofNatTruncate n).toUInt64 = UInt64.ofNatLT (UInt32.size - 1) (by decide) :=
-  UInt64.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
-theorem UInt32.toUSize_ofNatTruncate_of_le {n : Nat} (hn : UInt32.size ≤ n) :
-    (UInt32.ofNatTruncate n).toUSize = USize.ofNatLT (UInt32.size - 1) (Nat.lt_of_lt_of_le (by decide) size_le_usizeSize) :=
-  USize.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
+theorem UInt32.toUInt64_ofNatClamp_of_le {n : Nat} (hn : UInt32.size ≤ n) :
+    (UInt32.ofNatClamp n).toUInt64 = UInt64.ofNatLT (UInt32.size - 1) (by decide) :=
+  UInt64.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
+theorem UInt32.toUSize_ofNatClamp_of_le {n : Nat} (hn : UInt32.size ≤ n) :
+    (UInt32.ofNatClamp n).toUSize = USize.ofNatLT (UInt32.size - 1) (Nat.lt_of_lt_of_le (by decide) size_le_usizeSize) :=
+  USize.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
 
 theorem USize.toUInt64_ofNatLT {n : Nat} (h) :
     (USize.ofNatLT n h).toUInt64 = UInt64.ofNatLT n (Nat.lt_of_lt_of_le h size_le_uint64Size) := (rfl)
@@ -1256,13 +1256,13 @@ theorem USize.toUInt64_ofFin {n} :
 @[simp] theorem USize.toUInt64_ofBitVec {b} : (USize.ofBitVec b).toUInt64 = UInt64.ofBitVec (b.setWidth _) :=
   UInt64.toBitVec_inj.1 (by simp)
 
-theorem USize.toUInt64_ofNatTruncate_of_lt {n : Nat} (hn : n < USize.size) :
-    (USize.ofNatTruncate n).toUInt64 = UInt64.ofNatLT n (Nat.lt_of_lt_of_le hn size_le_uint64Size) :=
-  UInt64.toNat.inj (by simp [toNat_ofNatTruncate_of_lt hn])
+theorem USize.toUInt64_ofNatClamp_of_lt {n : Nat} (hn : n < USize.size) :
+    (USize.ofNatClamp n).toUInt64 = UInt64.ofNatLT n (Nat.lt_of_lt_of_le hn size_le_uint64Size) :=
+  UInt64.toNat.inj (by simp [toNat_ofNatClamp_of_lt hn])
 
-theorem USize.toUInt64_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
-    (USize.ofNatTruncate n).toUInt64 = UInt64.ofNatLT (USize.size - 1) (by cases USize.size_eq <;> simp_all +decide) :=
-  UInt64.toNat.inj (by simp [toNat_ofNatTruncate_of_le hn])
+theorem USize.toUInt64_ofNatClamp_of_le {n : Nat} (hn : USize.size ≤ n) :
+    (USize.ofNatClamp n).toUInt64 = UInt64.ofNatLT (USize.size - 1) (by cases USize.size_eq <;> simp_all +decide) :=
+  UInt64.toNat.inj (by simp [toNat_ofNatClamp_of_le hn])
 
 @[simp] theorem UInt8.toUInt16_ofNat' {n : Nat} (hn : n < UInt8.size) : (UInt8.ofNat n).toUInt16 = UInt16.ofNat n := by
   rw [← UInt8.ofNatLT_eq_ofNat (h := hn), toUInt16_ofNatLT, UInt16.ofNatLT_eq_ofNat]
@@ -1346,27 +1346,502 @@ theorem USize.toUInt64_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
 @[simp] theorem USize.ofNat_bitVecToNat (n : BitVec System.Platform.numBits) : USize.ofNat n.toNat = USize.ofBitVec n := by
   rw [← ofNatLT_eq_ofNat (h := n.isLt), ofNatLT_bitVecToNat]
 
-@[simp] theorem UInt8.ofNatTruncate_finVal (n : Fin UInt8.size) : UInt8.ofNatTruncate n.val = UInt8.ofFin n := by
-  rw [ofNatTruncate_eq_ofNat _ n.isLt, UInt8.ofNat_finVal]
-@[simp] theorem UInt16.ofNatTruncate_finVal (n : Fin UInt16.size) : UInt16.ofNatTruncate n.val = UInt16.ofFin n := by
-  rw [ofNatTruncate_eq_ofNat _ n.isLt, UInt16.ofNat_finVal]
-@[simp] theorem UInt32.ofNatTruncate_finVal (n : Fin UInt32.size) : UInt32.ofNatTruncate n.val = UInt32.ofFin n := by
-  rw [ofNatTruncate_eq_ofNat _ n.isLt, UInt32.ofNat_finVal]
-@[simp] theorem UInt64.ofNatTruncate_finVal (n : Fin UInt64.size) : UInt64.ofNatTruncate n.val = UInt64.ofFin n := by
-  rw [ofNatTruncate_eq_ofNat _ n.isLt, UInt64.ofNat_finVal]
-@[simp] theorem USize.ofNatTruncate_finVal (n : Fin USize.size) : USize.ofNatTruncate n.val = USize.ofFin n := by
-  rw [ofNatTruncate_eq_ofNat _ n.isLt, USize.ofNat_finVal]
+@[simp] theorem UInt8.ofNatClamp_finVal (n : Fin UInt8.size) : UInt8.ofNatClamp n.val = UInt8.ofFin n := by
+  rw [ofNatClamp_eq_ofNat _ n.isLt, UInt8.ofNat_finVal]
+@[simp] theorem UInt16.ofNatClamp_finVal (n : Fin UInt16.size) : UInt16.ofNatClamp n.val = UInt16.ofFin n := by
+  rw [ofNatClamp_eq_ofNat _ n.isLt, UInt16.ofNat_finVal]
+@[simp] theorem UInt32.ofNatClamp_finVal (n : Fin UInt32.size) : UInt32.ofNatClamp n.val = UInt32.ofFin n := by
+  rw [ofNatClamp_eq_ofNat _ n.isLt, UInt32.ofNat_finVal]
+@[simp] theorem UInt64.ofNatClamp_finVal (n : Fin UInt64.size) : UInt64.ofNatClamp n.val = UInt64.ofFin n := by
+  rw [ofNatClamp_eq_ofNat _ n.isLt, UInt64.ofNat_finVal]
+@[simp] theorem USize.ofNatClamp_finVal (n : Fin USize.size) : USize.ofNatClamp n.val = USize.ofFin n := by
+  rw [ofNatClamp_eq_ofNat _ n.isLt, USize.ofNat_finVal]
 
-@[simp] theorem UInt8.ofNatTruncate_bitVecToNat (n : BitVec 8) : UInt8.ofNatTruncate n.toNat = UInt8.ofBitVec n := by
-  rw [ofNatTruncate_eq_ofNat _ n.isLt, ofNat_bitVecToNat]
-@[simp] theorem UInt16.ofNatTruncate_bitVecToNat (n : BitVec 16) : UInt16.ofNatTruncate n.toNat = UInt16.ofBitVec n := by
-  rw [ofNatTruncate_eq_ofNat _ n.isLt, ofNat_bitVecToNat]
-@[simp] theorem UInt32.ofNatTruncate_bitVecToNat (n : BitVec 32) : UInt32.ofNatTruncate n.toNat = UInt32.ofBitVec n := by
-  rw [ofNatTruncate_eq_ofNat _ n.isLt, ofNat_bitVecToNat]
-@[simp] theorem UInt64.ofNatTruncate_bitVecToNat (n : BitVec 64) : UInt64.ofNatTruncate n.toNat = UInt64.ofBitVec n := by
-  rw [ofNatTruncate_eq_ofNat _ n.isLt, ofNat_bitVecToNat]
-@[simp] theorem USize.ofNatTruncate_bitVecToNat (n : BitVec System.Platform.numBits) : USize.ofNatTruncate n.toNat = USize.ofBitVec n := by
-  rw [ofNatTruncate_eq_ofNat _ n.isLt, ofNat_bitVecToNat]
+@[simp] theorem UInt8.ofNatClamp_bitVecToNat (n : BitVec 8) : UInt8.ofNatClamp n.toNat = UInt8.ofBitVec n := by
+  rw [ofNatClamp_eq_ofNat _ n.isLt, ofNat_bitVecToNat]
+@[simp] theorem UInt16.ofNatClamp_bitVecToNat (n : BitVec 16) : UInt16.ofNatClamp n.toNat = UInt16.ofBitVec n := by
+  rw [ofNatClamp_eq_ofNat _ n.isLt, ofNat_bitVecToNat]
+@[simp] theorem UInt32.ofNatClamp_bitVecToNat (n : BitVec 32) : UInt32.ofNatClamp n.toNat = UInt32.ofBitVec n := by
+  rw [ofNatClamp_eq_ofNat _ n.isLt, ofNat_bitVecToNat]
+@[simp] theorem UInt64.ofNatClamp_bitVecToNat (n : BitVec 64) : UInt64.ofNatClamp n.toNat = UInt64.ofBitVec n := by
+  rw [ofNatClamp_eq_ofNat _ n.isLt, ofNat_bitVecToNat]
+@[simp] theorem USize.ofNatClamp_bitVecToNat (n : BitVec System.Platform.numBits) : USize.ofNatClamp n.toNat = USize.ofBitVec n := by
+  rw [ofNatClamp_eq_ofNat _ n.isLt, ofNat_bitVecToNat]
+
+@[deprecated UInt8.ofNatClamp_eq_ofNat (since := "2026-05-04")]
+theorem UInt8.ofNatTruncate_eq_ofNat (n : Nat) (hn : n < UInt8.size) :
+    UInt8.ofNatClamp n = UInt8.ofNat n :=
+  UInt8.ofNatClamp_eq_ofNat n hn
+
+@[deprecated UInt16.ofNatClamp_eq_ofNat (since := "2026-05-04")]
+theorem UInt16.ofNatTruncate_eq_ofNat (n : Nat) (hn : n < UInt16.size) :
+    UInt16.ofNatClamp n = UInt16.ofNat n :=
+  UInt16.ofNatClamp_eq_ofNat n hn
+
+@[deprecated UInt32.ofNatClamp_eq_ofNat (since := "2026-05-04")]
+theorem UInt32.ofNatTruncate_eq_ofNat (n : Nat) (hn : n < UInt32.size) :
+    UInt32.ofNatClamp n = UInt32.ofNat n :=
+  UInt32.ofNatClamp_eq_ofNat n hn
+
+@[deprecated UInt64.ofNatClamp_eq_ofNat (since := "2026-05-04")]
+theorem UInt64.ofNatTruncate_eq_ofNat (n : Nat) (hn : n < UInt64.size) :
+    UInt64.ofNatClamp n = UInt64.ofNat n :=
+  UInt64.ofNatClamp_eq_ofNat n hn
+
+@[deprecated USize.ofNatClamp_eq_ofNat (since := "2026-05-04")]
+theorem USize.ofNatTruncate_eq_ofNat (n : Nat) (hn : n < USize.size) :
+    USize.ofNatClamp n = USize.ofNat n :=
+  USize.ofNatClamp_eq_ofNat n hn
+
+@[deprecated UInt8.ofNatClamp_toNat (since := "2026-05-04")]
+theorem UInt8.ofNatTruncate_toNat (n : UInt8) : UInt8.ofNatClamp n.toNat = n :=
+  UInt8.ofNatClamp_toNat n
+
+@[deprecated UInt16.ofNatClamp_uInt8ToNat (since := "2026-05-04")]
+theorem UInt16.ofNatTruncate_uInt8ToNat (n : UInt8) : UInt16.ofNatClamp n.toNat = n.toUInt16 :=
+  UInt16.ofNatClamp_uInt8ToNat n
+
+@[deprecated UInt16.ofNatClamp_toNat (since := "2026-05-04")]
+theorem UInt16.ofNatTruncate_toNat (n : UInt16) : UInt16.ofNatClamp n.toNat = n :=
+  UInt16.ofNatClamp_toNat n
+
+@[deprecated UInt32.ofNatClamp_uInt8ToNat (since := "2026-05-04")]
+theorem UInt32.ofNatTruncate_uInt8ToNat (n : UInt8) : UInt32.ofNatClamp n.toNat = n.toUInt32 :=
+  UInt32.ofNatClamp_uInt8ToNat n
+
+@[deprecated UInt32.ofNatClamp_uInt16ToNat (since := "2026-05-04")]
+theorem UInt32.ofNatTruncate_uInt16ToNat (n : UInt16) : UInt32.ofNatClamp n.toNat = n.toUInt32 :=
+  UInt32.ofNatClamp_uInt16ToNat n
+
+@[deprecated UInt32.ofNatClamp_toNat (since := "2026-05-04")]
+theorem UInt32.ofNatTruncate_toNat (n : UInt32) : UInt32.ofNatClamp n.toNat = n :=
+  UInt32.ofNatClamp_toNat n
+
+@[deprecated UInt64.ofNatClamp_uInt8ToNat (since := "2026-05-04")]
+theorem UInt64.ofNatTruncate_uInt8ToNat (n : UInt8) : UInt64.ofNatClamp n.toNat = n.toUInt64 :=
+  UInt64.ofNatClamp_uInt8ToNat n
+
+@[deprecated UInt64.ofNatClamp_uInt16ToNat (since := "2026-05-04")]
+theorem UInt64.ofNatTruncate_uInt16ToNat (n : UInt16) : UInt64.ofNatClamp n.toNat = n.toUInt64 :=
+  UInt64.ofNatClamp_uInt16ToNat n
+
+@[deprecated UInt64.ofNatClamp_uInt32ToNat (since := "2026-05-04")]
+theorem UInt64.ofNatTruncate_uInt32ToNat (n : UInt32) : UInt64.ofNatClamp n.toNat = n.toUInt64 :=
+  UInt64.ofNatClamp_uInt32ToNat n
+
+@[deprecated UInt64.ofNatClamp_toNat (since := "2026-05-04")]
+theorem UInt64.ofNatTruncate_toNat (n : UInt64) : UInt64.ofNatClamp n.toNat = n :=
+  UInt64.ofNatClamp_toNat n
+
+@[deprecated UInt64.ofNatClamp_uSizeToNat (since := "2026-05-04")]
+theorem UInt64.ofNatTruncate_uSizeToNat (n : USize) : UInt64.ofNatClamp n.toNat = n.toUInt64 :=
+  UInt64.ofNatClamp_uSizeToNat n
+
+@[deprecated USize.ofNatClamp_uInt8ToNat (since := "2026-05-04")]
+theorem USize.ofNatTruncate_uInt8ToNat (n : UInt8) : USize.ofNatClamp n.toNat = n.toUSize :=
+  USize.ofNatClamp_uInt8ToNat n
+
+@[deprecated USize.ofNatClamp_uInt16ToNat (since := "2026-05-04")]
+theorem USize.ofNatTruncate_uInt16ToNat (n : UInt16) : USize.ofNatClamp n.toNat = n.toUSize :=
+  USize.ofNatClamp_uInt16ToNat n
+
+@[deprecated USize.ofNatClamp_uInt32ToNat (since := "2026-05-04")]
+theorem USize.ofNatTruncate_uInt32ToNat (n : UInt32) : USize.ofNatClamp n.toNat = n.toUSize :=
+  USize.ofNatClamp_uInt32ToNat n
+
+@[deprecated USize.ofNatClamp_toNat (since := "2026-05-04")]
+theorem USize.ofNatTruncate_toNat (n : USize) : USize.ofNatClamp n.toNat = n :=
+  USize.ofNatClamp_toNat n
+
+@[deprecated UInt8.toNat_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt8.toNat_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt8.size) :
+    (UInt8.ofNatClamp n).toNat = n :=
+  UInt8.toNat_ofNatClamp_of_lt hn
+
+@[deprecated UInt16.toNat_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt16.toNat_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt16.size) :
+    (UInt16.ofNatClamp n).toNat = n :=
+  UInt16.toNat_ofNatClamp_of_lt hn
+
+@[deprecated UInt32.toNat_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt32.toNat_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt32.size) :
+    (UInt32.ofNatClamp n).toNat = n :=
+  UInt32.toNat_ofNatClamp_of_lt hn
+
+@[deprecated UInt64.toNat_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt64.toNat_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt64.size) :
+    (UInt64.ofNatClamp n).toNat = n :=
+  UInt64.toNat_ofNatClamp_of_lt hn
+
+@[deprecated USize.toNat_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem USize.toNat_ofNatTruncate_of_lt {n : Nat} (hn : n < USize.size) :
+    (USize.ofNatClamp n).toNat = n :=
+  USize.toNat_ofNatClamp_of_lt hn
+
+@[deprecated UInt8.toNat_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt8.toNat_ofNatTruncate_of_le {n : Nat} (hn : UInt8.size ≤ n) :
+    (UInt8.ofNatClamp n).toNat = UInt8.size - 1 :=
+  UInt8.toNat_ofNatClamp_of_le hn
+
+@[deprecated UInt16.toNat_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt16.toNat_ofNatTruncate_of_le {n : Nat} (hn : UInt16.size ≤ n) :
+    (UInt16.ofNatClamp n).toNat = UInt16.size - 1 :=
+  UInt16.toNat_ofNatClamp_of_le hn
+
+@[deprecated UInt32.toNat_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt32.toNat_ofNatTruncate_of_le {n : Nat} (hn : UInt32.size ≤ n) :
+    (UInt32.ofNatClamp n).toNat = UInt32.size - 1 :=
+  UInt32.toNat_ofNatClamp_of_le hn
+
+@[deprecated UInt64.toNat_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt64.toNat_ofNatTruncate_of_le {n : Nat} (hn : UInt64.size ≤ n) :
+    (UInt64.ofNatClamp n).toNat = UInt64.size - 1 :=
+  UInt64.toNat_ofNatClamp_of_le hn
+
+@[deprecated USize.toNat_ofNatClamp_of_le (since := "2026-05-04")]
+theorem USize.toNat_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
+    (USize.ofNatClamp n).toNat = USize.size - 1 :=
+  USize.toNat_ofNatClamp_of_le hn
+
+@[deprecated UInt8.toFin_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt8.toFin_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt8.size) :
+    (UInt8.ofNatClamp n).toFin = ⟨n, hn⟩ :=
+  UInt8.toFin_ofNatClamp_of_lt hn
+
+@[deprecated UInt16.toFin_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt16.toFin_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt16.size) :
+    (UInt16.ofNatClamp n).toFin = ⟨n, hn⟩ :=
+  UInt16.toFin_ofNatClamp_of_lt hn
+
+@[deprecated UInt32.toFin_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt32.toFin_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt32.size) :
+    (UInt32.ofNatClamp n).toFin = ⟨n, hn⟩ :=
+  UInt32.toFin_ofNatClamp_of_lt hn
+
+@[deprecated UInt64.toFin_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt64.toFin_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt64.size) :
+    (UInt64.ofNatClamp n).toFin = ⟨n, hn⟩ :=
+  UInt64.toFin_ofNatClamp_of_lt hn
+
+@[deprecated USize.toFin_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem USize.toFin_ofNatTruncate_of_lt {n : Nat} (hn : n < USize.size) :
+    (USize.ofNatClamp n).toFin = ⟨n, hn⟩ :=
+  USize.toFin_ofNatClamp_of_lt hn
+
+@[deprecated UInt8.toFin_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt8.toFin_ofNatTruncate_of_le {n : Nat} (hn : UInt8.size ≤ n) :
+    (UInt8.ofNatClamp n).toFin = ⟨UInt8.size - 1, by decide⟩ :=
+  UInt8.toFin_ofNatClamp_of_le hn
+
+@[deprecated UInt16.toFin_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt16.toFin_ofNatTruncate_of_le {n : Nat} (hn : UInt16.size ≤ n) :
+    (UInt16.ofNatClamp n).toFin = ⟨UInt16.size - 1, by decide⟩ :=
+  UInt16.toFin_ofNatClamp_of_le hn
+
+@[deprecated UInt32.toFin_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt32.toFin_ofNatTruncate_of_le {n : Nat} (hn : UInt32.size ≤ n) :
+    (UInt32.ofNatClamp n).toFin = ⟨UInt32.size - 1, by decide⟩ :=
+  UInt32.toFin_ofNatClamp_of_le hn
+
+@[deprecated UInt64.toFin_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt64.toFin_ofNatTruncate_of_le {n : Nat} (hn : UInt64.size ≤ n) :
+    (UInt64.ofNatClamp n).toFin = ⟨UInt64.size - 1, by decide⟩ :=
+  UInt64.toFin_ofNatClamp_of_le hn
+
+@[deprecated USize.toFin_ofNatClamp_of_le (since := "2026-05-04")]
+theorem USize.toFin_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
+    (USize.ofNatClamp n).toFin = ⟨USize.size - 1, by cases USize.size_eq <;> simp_all⟩ :=
+  USize.toFin_ofNatClamp_of_le hn
+
+@[deprecated UInt8.toBitVec_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt8.toBitVec_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt8.size) :
+    (UInt8.ofNatClamp n).toBitVec = BitVec.ofNatLT n hn :=
+  UInt8.toBitVec_ofNatClamp_of_lt hn
+
+@[deprecated UInt16.toBitVec_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt16.toBitVec_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt16.size) :
+    (UInt16.ofNatClamp n).toBitVec = BitVec.ofNatLT n hn :=
+  UInt16.toBitVec_ofNatClamp_of_lt hn
+
+@[deprecated UInt32.toBitVec_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt32.toBitVec_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt32.size) :
+    (UInt32.ofNatClamp n).toBitVec = BitVec.ofNatLT n hn :=
+  UInt32.toBitVec_ofNatClamp_of_lt hn
+
+@[deprecated UInt64.toBitVec_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt64.toBitVec_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt64.size) :
+    (UInt64.ofNatClamp n).toBitVec = BitVec.ofNatLT n hn :=
+  UInt64.toBitVec_ofNatClamp_of_lt hn
+
+@[deprecated USize.toBitVec_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem USize.toBitVec_ofNatTruncate_of_lt {n : Nat} (hn : n < USize.size) :
+    (USize.ofNatClamp n).toBitVec = BitVec.ofNatLT n hn :=
+  USize.toBitVec_ofNatClamp_of_lt hn
+
+@[deprecated UInt8.toBitVec_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt8.toBitVec_ofNatTruncate_of_le {n : Nat} (hn : UInt8.size ≤ n) :
+    (UInt8.ofNatClamp n).toBitVec = BitVec.ofNatLT (UInt8.size - 1) (by decide) :=
+  UInt8.toBitVec_ofNatClamp_of_le hn
+
+@[deprecated UInt16.toBitVec_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt16.toBitVec_ofNatTruncate_of_le {n : Nat} (hn : UInt16.size ≤ n) :
+    (UInt16.ofNatClamp n).toBitVec = BitVec.ofNatLT (UInt16.size - 1) (by decide) :=
+  UInt16.toBitVec_ofNatClamp_of_le hn
+
+@[deprecated UInt32.toBitVec_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt32.toBitVec_ofNatTruncate_of_le {n : Nat} (hn : UInt32.size ≤ n) :
+    (UInt32.ofNatClamp n).toBitVec = BitVec.ofNatLT (UInt32.size - 1) (by decide) :=
+  UInt32.toBitVec_ofNatClamp_of_le hn
+
+@[deprecated UInt64.toBitVec_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt64.toBitVec_ofNatTruncate_of_le {n : Nat} (hn : UInt64.size ≤ n) :
+    (UInt64.ofNatClamp n).toBitVec = BitVec.ofNatLT (UInt64.size - 1) (by decide) :=
+  UInt64.toBitVec_ofNatClamp_of_le hn
+
+@[deprecated USize.toBitVec_ofNatClamp_of_le (since := "2026-05-04")]
+theorem USize.toBitVec_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
+    (USize.ofNatClamp n).toBitVec = BitVec.ofNatLT (USize.size - 1) (by cases USize.size_eq <;> simp_all) :=
+  USize.toBitVec_ofNatClamp_of_le hn
+
+@[deprecated UInt16.toUInt8_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt16.toUInt8_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt16.size) :
+    (UInt16.ofNatClamp n).toUInt8 = UInt8.ofNat n :=
+  UInt16.toUInt8_ofNatClamp_of_lt hn
+
+@[deprecated UInt32.toUInt8_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt32.toUInt8_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt32.size) :
+    (UInt32.ofNatClamp n).toUInt8 = UInt8.ofNat n :=
+  UInt32.toUInt8_ofNatClamp_of_lt hn
+
+@[deprecated UInt64.toUInt8_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt64.toUInt8_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt64.size) :
+    (UInt64.ofNatClamp n).toUInt8 = UInt8.ofNat n :=
+  UInt64.toUInt8_ofNatClamp_of_lt hn
+
+@[deprecated USize.toUInt8_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem USize.toUInt8_ofNatTruncate_of_lt {n : Nat} (hn : n < USize.size) :
+    (USize.ofNatClamp n).toUInt8 = UInt8.ofNat n :=
+  USize.toUInt8_ofNatClamp_of_lt hn
+
+@[deprecated UInt16.toUInt8_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt16.toUInt8_ofNatTruncate_of_le {n : Nat} (hn : UInt16.size ≤ n) :
+    (UInt16.ofNatClamp n).toUInt8 = UInt8.ofNatLT (UInt8.size - 1) (by decide) :=
+  UInt16.toUInt8_ofNatClamp_of_le hn
+
+@[deprecated UInt32.toUInt8_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt32.toUInt8_ofNatTruncate_of_le {n : Nat} (hn : UInt32.size ≤ n) :
+    (UInt32.ofNatClamp n).toUInt8 = UInt8.ofNatLT (UInt8.size - 1) (by decide) :=
+  UInt32.toUInt8_ofNatClamp_of_le hn
+
+@[deprecated UInt64.toUInt8_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt64.toUInt8_ofNatTruncate_of_le {n : Nat} (hn : UInt64.size ≤ n) :
+    (UInt64.ofNatClamp n).toUInt8 = UInt8.ofNatLT (UInt8.size - 1) (by decide) :=
+  UInt64.toUInt8_ofNatClamp_of_le hn
+
+@[deprecated USize.toUInt8_ofNatClamp_of_le (since := "2026-05-04")]
+theorem USize.toUInt8_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
+    (USize.ofNatClamp n).toUInt8 = UInt8.ofNatLT (UInt8.size - 1) (by decide) :=
+  USize.toUInt8_ofNatClamp_of_le hn
+
+@[deprecated UInt32.toUInt16_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt32.toUInt16_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt32.size) :
+    (UInt32.ofNatClamp n).toUInt16 = UInt16.ofNat n :=
+  UInt32.toUInt16_ofNatClamp_of_lt hn
+
+@[deprecated UInt64.toUInt16_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt64.toUInt16_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt64.size) :
+    (UInt64.ofNatClamp n).toUInt16 = UInt16.ofNat n :=
+  UInt64.toUInt16_ofNatClamp_of_lt hn
+
+@[deprecated USize.toUInt16_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem USize.toUInt16_ofNatTruncate_of_lt {n : Nat} (hn : n < USize.size) :
+    (USize.ofNatClamp n).toUInt16 = UInt16.ofNat n :=
+  USize.toUInt16_ofNatClamp_of_lt hn
+
+@[deprecated UInt32.toUInt16_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt32.toUInt16_ofNatTruncate_of_le {n : Nat} (hn : UInt32.size ≤ n) :
+    (UInt32.ofNatClamp n).toUInt16 = UInt16.ofNatLT (UInt16.size - 1) (by decide) :=
+  UInt32.toUInt16_ofNatClamp_of_le hn
+
+@[deprecated UInt64.toUInt16_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt64.toUInt16_ofNatTruncate_of_le {n : Nat} (hn : UInt64.size ≤ n) :
+    (UInt64.ofNatClamp n).toUInt16 = UInt16.ofNatLT (UInt16.size - 1) (by decide) :=
+  UInt64.toUInt16_ofNatClamp_of_le hn
+
+@[deprecated USize.toUInt16_ofNatClamp_of_le (since := "2026-05-04")]
+theorem USize.toUInt16_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
+    (USize.ofNatClamp n).toUInt16 = UInt16.ofNatLT (UInt16.size - 1) (by decide) :=
+  USize.toUInt16_ofNatClamp_of_le hn
+
+@[deprecated UInt64.toUInt32_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt64.toUInt32_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt64.size) :
+    (UInt64.ofNatClamp n).toUInt32 = UInt32.ofNat n :=
+  UInt64.toUInt32_ofNatClamp_of_lt hn
+
+@[deprecated USize.toUInt32_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem USize.toUInt32_ofNatTruncate_of_lt {n : Nat} (hn : n < USize.size) :
+    (USize.ofNatClamp n).toUInt32 = UInt32.ofNat n :=
+  USize.toUInt32_ofNatClamp_of_lt hn
+
+@[deprecated UInt64.toUInt32_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt64.toUInt32_ofNatTruncate_of_le {n : Nat} (hn : UInt64.size ≤ n) :
+    (UInt64.ofNatClamp n).toUInt32 = UInt32.ofNatLT (UInt32.size - 1) (by decide) :=
+  UInt64.toUInt32_ofNatClamp_of_le hn
+
+@[deprecated USize.toUInt32_ofNatClamp_of_le (since := "2026-05-04")]
+theorem USize.toUInt32_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
+    (USize.ofNatClamp n).toUInt32 = UInt32.ofNatLT (UInt32.size - 1) (by decide) :=
+  USize.toUInt32_ofNatClamp_of_le hn
+
+@[deprecated UInt64.toUSize_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt64.toUSize_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt64.size) :
+    (UInt64.ofNatClamp n).toUSize = USize.ofNat n :=
+  UInt64.toUSize_ofNatClamp_of_lt hn
+
+@[deprecated UInt64.toUSize_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt64.toUSize_ofNatTruncate_of_le {n : Nat} (hn : UInt64.size ≤ n) :
+    (UInt64.ofNatClamp n).toUSize = USize.ofNatLT (USize.size - 1) (by cases USize.size_eq <;> simp_all) :=
+  UInt64.toUSize_ofNatClamp_of_le hn
+
+@[deprecated UInt8.toUInt16_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt8.toUInt16_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt8.size) :
+    (UInt8.ofNatClamp n).toUInt16 = UInt16.ofNatLT n (Nat.lt_of_lt_of_le hn (by decide)) :=
+  UInt8.toUInt16_ofNatClamp_of_lt hn
+
+@[deprecated UInt8.toUInt32_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt8.toUInt32_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt8.size) :
+    (UInt8.ofNatClamp n).toUInt32 = UInt32.ofNatLT n (Nat.lt_of_lt_of_le hn (by decide)) :=
+  UInt8.toUInt32_ofNatClamp_of_lt hn
+
+@[deprecated UInt8.toUInt64_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt8.toUInt64_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt8.size) :
+    (UInt8.ofNatClamp n).toUInt64 = UInt64.ofNatLT n (Nat.lt_of_lt_of_le hn (by decide)) :=
+  UInt8.toUInt64_ofNatClamp_of_lt hn
+
+@[deprecated UInt8.toUSize_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt8.toUSize_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt8.size) :
+    (UInt8.ofNatClamp n).toUSize = USize.ofNatLT n (Nat.lt_of_lt_of_le hn size_le_usizeSize) :=
+  UInt8.toUSize_ofNatClamp_of_lt hn
+
+@[deprecated UInt8.toUInt16_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt8.toUInt16_ofNatTruncate_of_le {n : Nat} (hn : UInt8.size ≤ n) :
+    (UInt8.ofNatClamp n).toUInt16 = UInt16.ofNatLT (UInt8.size - 1) (by decide) :=
+  UInt8.toUInt16_ofNatClamp_of_le hn
+
+@[deprecated UInt8.toUInt32_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt8.toUInt32_ofNatTruncate_of_le {n : Nat} (hn : UInt8.size ≤ n) :
+    (UInt8.ofNatClamp n).toUInt32 = UInt32.ofNatLT (UInt8.size - 1) (by decide) :=
+  UInt8.toUInt32_ofNatClamp_of_le hn
+
+@[deprecated UInt8.toUInt64_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt8.toUInt64_ofNatTruncate_of_le {n : Nat} (hn : UInt8.size ≤ n) :
+    (UInt8.ofNatClamp n).toUInt64 = UInt64.ofNatLT (UInt8.size - 1) (by decide) :=
+  UInt8.toUInt64_ofNatClamp_of_le hn
+
+@[deprecated UInt8.toUSize_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt8.toUSize_ofNatTruncate_of_le {n : Nat} (hn : UInt8.size ≤ n) :
+    (UInt8.ofNatClamp n).toUSize = USize.ofNatLT (UInt8.size - 1) (Nat.lt_of_lt_of_le (by decide) size_le_usizeSize) :=
+  UInt8.toUSize_ofNatClamp_of_le hn
+
+@[deprecated UInt16.toUInt32_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt16.toUInt32_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt16.size) :
+    (UInt16.ofNatClamp n).toUInt32 = UInt32.ofNatLT n (Nat.lt_of_lt_of_le hn (by decide)) :=
+  UInt16.toUInt32_ofNatClamp_of_lt hn
+
+@[deprecated UInt16.toUInt64_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt16.toUInt64_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt16.size) :
+    (UInt16.ofNatClamp n).toUInt64 = UInt64.ofNatLT n (Nat.lt_of_lt_of_le hn (by decide)) :=
+  UInt16.toUInt64_ofNatClamp_of_lt hn
+
+@[deprecated UInt16.toUSize_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt16.toUSize_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt16.size) :
+    (UInt16.ofNatClamp n).toUSize = USize.ofNatLT n (Nat.lt_of_lt_of_le hn size_le_usizeSize) :=
+  UInt16.toUSize_ofNatClamp_of_lt hn
+
+@[deprecated UInt16.toUInt32_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt16.toUInt32_ofNatTruncate_of_le {n : Nat} (hn : UInt16.size ≤ n) :
+    (UInt16.ofNatClamp n).toUInt32 = UInt32.ofNatLT (UInt16.size - 1) (by decide) :=
+  UInt16.toUInt32_ofNatClamp_of_le hn
+
+@[deprecated UInt16.toUInt64_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt16.toUInt64_ofNatTruncate_of_le {n : Nat} (hn : UInt16.size ≤ n) :
+    (UInt16.ofNatClamp n).toUInt64 = UInt64.ofNatLT (UInt16.size - 1) (by decide) :=
+  UInt16.toUInt64_ofNatClamp_of_le hn
+
+@[deprecated UInt16.toUSize_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt16.toUSize_ofNatTruncate_of_le {n : Nat} (hn : UInt16.size ≤ n) :
+    (UInt16.ofNatClamp n).toUSize = USize.ofNatLT (UInt16.size - 1) (Nat.lt_of_lt_of_le (by decide) size_le_usizeSize) :=
+  UInt16.toUSize_ofNatClamp_of_le hn
+
+@[deprecated UInt32.toUInt64_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt32.toUInt64_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt32.size) :
+    (UInt32.ofNatClamp n).toUInt64 = UInt64.ofNatLT n (Nat.lt_of_lt_of_le hn (by decide)) :=
+  UInt32.toUInt64_ofNatClamp_of_lt hn
+
+@[deprecated UInt32.toUSize_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem UInt32.toUSize_ofNatTruncate_of_lt {n : Nat} (hn : n < UInt32.size) :
+    (UInt32.ofNatClamp n).toUSize = USize.ofNatLT n (Nat.lt_of_lt_of_le hn size_le_usizeSize) :=
+  UInt32.toUSize_ofNatClamp_of_lt hn
+
+@[deprecated UInt32.toUInt64_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt32.toUInt64_ofNatTruncate_of_le {n : Nat} (hn : UInt32.size ≤ n) :
+    (UInt32.ofNatClamp n).toUInt64 = UInt64.ofNatLT (UInt32.size - 1) (by decide) :=
+  UInt32.toUInt64_ofNatClamp_of_le hn
+
+@[deprecated UInt32.toUSize_ofNatClamp_of_le (since := "2026-05-04")]
+theorem UInt32.toUSize_ofNatTruncate_of_le {n : Nat} (hn : UInt32.size ≤ n) :
+    (UInt32.ofNatClamp n).toUSize = USize.ofNatLT (UInt32.size - 1) (Nat.lt_of_lt_of_le (by decide) size_le_usizeSize) :=
+  UInt32.toUSize_ofNatClamp_of_le hn
+
+@[deprecated USize.toUInt64_ofNatClamp_of_lt (since := "2026-05-04")]
+theorem USize.toUInt64_ofNatTruncate_of_lt {n : Nat} (hn : n < USize.size) :
+    (USize.ofNatClamp n).toUInt64 = UInt64.ofNatLT n (Nat.lt_of_lt_of_le hn size_le_uint64Size) :=
+  USize.toUInt64_ofNatClamp_of_lt hn
+
+@[deprecated USize.toUInt64_ofNatClamp_of_le (since := "2026-05-04")]
+theorem USize.toUInt64_ofNatTruncate_of_le {n : Nat} (hn : USize.size ≤ n) :
+    (USize.ofNatClamp n).toUInt64 = UInt64.ofNatLT (USize.size - 1) (by cases USize.size_eq <;> simp_all +decide) :=
+  USize.toUInt64_ofNatClamp_of_le hn
+
+@[deprecated UInt8.ofNatClamp_finVal (since := "2026-05-04")]
+theorem UInt8.ofNatTruncate_finVal (n : Fin UInt8.size) : UInt8.ofNatClamp n.val = UInt8.ofFin n :=
+  UInt8.ofNatClamp_finVal n
+
+@[deprecated UInt16.ofNatClamp_finVal (since := "2026-05-04")]
+theorem UInt16.ofNatTruncate_finVal (n : Fin UInt16.size) : UInt16.ofNatClamp n.val = UInt16.ofFin n :=
+  UInt16.ofNatClamp_finVal n
+
+@[deprecated UInt32.ofNatClamp_finVal (since := "2026-05-04")]
+theorem UInt32.ofNatTruncate_finVal (n : Fin UInt32.size) : UInt32.ofNatClamp n.val = UInt32.ofFin n :=
+  UInt32.ofNatClamp_finVal n
+
+@[deprecated UInt64.ofNatClamp_finVal (since := "2026-05-04")]
+theorem UInt64.ofNatTruncate_finVal (n : Fin UInt64.size) : UInt64.ofNatClamp n.val = UInt64.ofFin n :=
+  UInt64.ofNatClamp_finVal n
+
+@[deprecated USize.ofNatClamp_finVal (since := "2026-05-04")]
+theorem USize.ofNatTruncate_finVal (n : Fin USize.size) : USize.ofNatClamp n.val = USize.ofFin n :=
+  USize.ofNatClamp_finVal n
+
+@[deprecated UInt8.ofNatClamp_bitVecToNat (since := "2026-05-04")]
+theorem UInt8.ofNatTruncate_bitVecToNat (n : BitVec 8) : UInt8.ofNatClamp n.toNat = UInt8.ofBitVec n :=
+  UInt8.ofNatClamp_bitVecToNat n
+
+@[deprecated UInt16.ofNatClamp_bitVecToNat (since := "2026-05-04")]
+theorem UInt16.ofNatTruncate_bitVecToNat (n : BitVec 16) : UInt16.ofNatClamp n.toNat = UInt16.ofBitVec n :=
+  UInt16.ofNatClamp_bitVecToNat n
+
+@[deprecated UInt32.ofNatClamp_bitVecToNat (since := "2026-05-04")]
+theorem UInt32.ofNatTruncate_bitVecToNat (n : BitVec 32) : UInt32.ofNatClamp n.toNat = UInt32.ofBitVec n :=
+  UInt32.ofNatClamp_bitVecToNat n
+
+@[deprecated UInt64.ofNatClamp_bitVecToNat (since := "2026-05-04")]
+theorem UInt64.ofNatTruncate_bitVecToNat (n : BitVec 64) : UInt64.ofNatClamp n.toNat = UInt64.ofBitVec n :=
+  UInt64.ofNatClamp_bitVecToNat n
+
+@[deprecated USize.ofNatClamp_bitVecToNat (since := "2026-05-04")]
+theorem USize.ofNatTruncate_bitVecToNat (n : BitVec System.Platform.numBits) : USize.ofNatClamp n.toNat = USize.ofBitVec n :=
+  USize.ofNatClamp_bitVecToNat n
 
 @[simp] theorem UInt8.ofFin_mk {n : Nat} (hn) : UInt8.ofFin (Fin.mk n hn) = UInt8.ofNatLT n hn := (rfl)
 @[simp] theorem UInt16.ofFin_mk {n : Nat} (hn) : UInt16.ofFin (Fin.mk n hn) = UInt16.ofNatLT n hn := (rfl)

--- a/src/Lean/Meta/Tactic/Simp/Types.lean
+++ b/src/Lean/Meta/Tactic/Simp/Types.lean
@@ -70,7 +70,7 @@ structure Context where
   metaConfig        : ConfigWithKey := default
   indexConfig       : ConfigWithKey := default
   /-- `maxDischargeDepth` from `config` as an `UInt32`. -/
-  maxDischargeDepth : UInt32 := UInt32.ofNatTruncate config.maxDischargeDepth
+  maxDischargeDepth : UInt32 := UInt32.ofNatClamp config.maxDischargeDepth
   simpTheorems      : SimpTheoremsArray := {}
   congrTheorems     : SimpCongrTheorems := {}
   /--


### PR DESCRIPTION
This PR renames `UInt8.ofNatTruncate` to `UInt8.ofNatClamp`.

The new name is more consistent with the rest of the library (e.g., `Int8.toNatClampNeg`) and also more clear. See also [#lean4 > Name of UInt32.ofNatTruncate etc may be wrong](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Name.20of.20UInt32.2EofNatTruncate.20etc.20may.20be.20wrong/with/591873604).

Historical note: during prehistoric times (in January 2024), `UInt32.ofNatTruncate` (only the 32 bit version) was introduced for use in the `simp` configuration. When I looked at the `UIntX` API more properly later, I added the missing variants but didn't reconsider the name.