### PR TITLE
fix: kernel projection panic in `Sym.simp` match reduction

### DIFF
--- a/src/Lean/Meta/Sym/ProofInstInfo.lean
+++ b/src/Lean/Meta/Sym/ProofInstInfo.lean
@@ -18,8 +18,7 @@ public def preprocessType (type : Expr) : MetaM Expr := do
   let type ← Sym.unfoldReducible type
   let type ← Core.betaReduce type
   let type ← zetaReduce type
-  let type ← etaReduceAll type
-  foldProjs type
+  etaReduceAll type
 
 /--
 Analyzes whether the given free variables (aka arguments) are proofs or instances.

--- a/src/Lean/Meta/Sym/ProofInstInfo.lean
+++ b/src/Lean/Meta/Sym/ProofInstInfo.lean
@@ -18,7 +18,8 @@ public def preprocessType (type : Expr) : MetaM Expr := do
   let type ← Sym.unfoldReducible type
   let type ← Core.betaReduce type
   let type ← zetaReduce type
-  etaReduceAll type
+  let type ← etaReduceAll type
+  foldProjs type
 
 /--
 Analyzes whether the given free variables (aka arguments) are proofs or instances.

--- a/src/Lean/Meta/Sym/Simp/ControlFlow.lean
+++ b/src/Lean/Meta/Sym/Simp/ControlFlow.lean
@@ -9,6 +9,7 @@ public import Lean.Meta.Sym.Simp.SimpM
 import Lean.Meta.Sym.AlphaShareBuilder
 import Lean.Meta.Sym.InferType
 import Lean.Meta.Sym.Simp.App
+import Lean.Meta.Sym.Util
 import Lean.Meta.WHNF
 import Lean.Meta.AppBuilder
 import Init.Sym.Lemmas
@@ -121,7 +122,12 @@ Simplifies a `match`-expression.
 -/
 def simpMatch (declName : Name) : Simproc := fun e => do
   if let some e' ← reduceRecMatcher? e then
-    return .step e' (← mkEqRefl e')
+    -- Iota-reduction may expose kernel `Expr.proj` terms via struct-eta,
+    -- which the structural simplifier cannot consume directly.
+    let mut e'' ← Sym.foldProjs e'
+    unless isSameExpr e' e'' do
+      e'' ← share e''
+    return .step e'' (← mkEqRefl e'')
   let some info ← getMatcherInfo? declName
     | return .rfl
   -- **Note**: Simplify only the discriminants

--- a/src/Lean/Meta/Sym/Util.lean
+++ b/src/Lean/Meta/Sym/Util.lean
@@ -9,6 +9,7 @@ public import Lean.Meta.Sym.SymM
 public import Lean.Meta.Transform
 import Init.Grind.Util
 import Lean.Meta.WHNF
+import Lean.Meta.AppBuilder
 import Lean.Util.ForEachExpr
 namespace Lean.Meta.Sym
 
@@ -50,6 +51,39 @@ This is meant as a preprocessing step. It does **not** guarantee maximally share
 public def unfoldReducible (e : Expr) : MetaM Expr := do
   if !(← isUnfoldReducibleTarget e) then return e
   Meta.transform e (pre := unfoldReducibleStep)
+
+/--
+Converts nested `Expr.proj`s into projection applications if possible.
+The structural simplifier and pattern matcher do not handle kernel projection
+terms; this preprocessing step folds them into projection function applications.
+-/
+public def foldProjs (e : Expr) : MetaM Expr := do
+  if Option.isNone <| e.find? fun e => e.isProj then return e
+  let post (e : Expr) := do
+    let .proj structName idx s := e | return .done e
+    let some info := getStructureInfo? (← getEnv) structName |
+      trace[sym.issues] "found `Expr.proj` but `{structName}` is not marked as structure{indentExpr e}"
+      return .done e
+    if h : idx < info.fieldNames.size then
+      let fieldName := info.fieldNames[idx]
+      /-
+      In the test `grind_cat.lean`, the following operation fails if we are not using default
+      transparency. We get the following error.
+      ```
+      error: AppBuilder for 'mkProjection', structure expected
+        T
+      has type
+        F ⟶ G
+      ```
+      We should make `mkProjection` more robust.
+
+      The `mkProjection` function may create new kernel projections. So, we must use `.visit`.
+      -/
+      return .visit (← withDefault <| mkProjection s fieldName)
+    else
+      trace[sym.issues] "found `Expr.proj` with invalid field index `{idx}`{indentExpr e}"
+      return .done e
+  Meta.transform e (post := post)
 
 /--
 Instantiates metavariables, unfold reducible, and applies `shareCommon`.

--- a/src/Lean/Meta/Tactic/Grind/Util.lean
+++ b/src/Lean/Meta/Tactic/Grind/Util.lean
@@ -125,33 +125,8 @@ def eraseIrrelevantMData (e : Expr) : CoreM Expr := do
 /--
 Converts nested `Expr.proj`s into projection applications if possible.
 -/
-def foldProjs (e : Expr) : MetaM Expr := do
-  if Option.isNone <| e.find? fun e => e.isProj then return e
-  let post (e : Expr) := do
-    let .proj structName idx s := e | return .done e
-    let some info := getStructureInfo? (← getEnv) structName |
-      trace[sym.issues] "found `Expr.proj` but `{structName}` is not marked as structure{indentExpr e}"
-      return .done e
-    if h : idx < info.fieldNames.size then
-      let fieldName := info.fieldNames[idx]
-      /-
-      In the test `grind_cat.lean`, the following operation fails if we are not using default
-      transparency. We get the following error.
-      ```
-      error: AppBuilder for 'mkProjection', structure expected
-        T
-      has type
-        F ⟶ G
-      ```
-      We should make `mkProjection` more robust.
-
-      The `mkProjection` function may create new kernel projections. So, we must use `.visit`.
-      -/
-      return .visit (← withDefault <| mkProjection s fieldName)
-    else
-      trace[sym.issues] "found `Expr.proj` with invalid field index `{idx}`{indentExpr e}"
-      return .done e
-  Meta.transform e (post := post)
+def foldProjs (e : Expr) : MetaM Expr :=
+  Sym.foldProjs e
 
 set_option compiler.ignoreBorrowAnnotation true in
 /--

--- a/tests/elab/sym_proj_issue.lean
+++ b/tests/elab/sym_proj_issue.lean
@@ -1,0 +1,19 @@
+import Lean
+
+set_option linter.unusedVariables false in
+def loopy : Option Nat := do
+  let mut x  : Nat  := 0
+  let mut y  : Nat  := 0
+  let mut ok : Bool := false
+  for _ in [:1] do
+    x  := x + 1
+    y  := y + 1
+    ok := true
+  return x
+
+/-- warning: declaration uses `sorry` -/
+#guard_msgs in
+example : loopy = some 0 := by
+  sym =>
+    simp [loopy.eq_1]
+    sorry


### PR DESCRIPTION
This PR fixes a `Sym.simp` panic ("unexpected kernel projection term
during simplification") that triggered when matcher iota-reduction
exposed kernel `Expr.proj` terms via struct-eta. For example, a `do`
block with a `for` loop whose state is a tuple, where `Sym.simp`
unfolds the equational lemma and then descends into a destructuring
match.
