### PR TITLE
fix: distinguish recursive applications by source position

### DIFF
--- a/src/Lean/Elab/RecAppSyntax.lean
+++ b/src/Lean/Elab/RecAppSyntax.lean
@@ -13,13 +13,23 @@ public section
 namespace Lean
 
 private def recAppKey := `_recApp
+private def recAppPosKey := `_recAppPos
 
 /--
 We store the syntax at recursive applications to be able to generate better error messages
 when performing well-founded and structural recursion.
+
+We additionally store the source position as an extra key, so that two recursive applications
+that are structurally identical as `Syntax` but originate from different source positions
+still produce distinct `MData`. Otherwise hashconsing or simplification can merge them and
+attribute an error to the wrong call site (issue #13444).
 -/
 def mkRecAppWithSyntax (e : Expr) (stx : Syntax) : Expr :=
-  mkMData (KVMap.empty.insert recAppKey (.ofSyntax stx)) e
+  let m := KVMap.empty.insert recAppKey (.ofSyntax stx)
+  let m := match stx.getPos? with
+    | some p => m.insert recAppPosKey (.ofNat p.byteIdx)
+    | none   => m
+  mkMData m e
 
 /--
 Retrieve (if available) the syntax object attached to a recursive application.

--- a/tests/elab/issue13444.lean
+++ b/tests/elab/issue13444.lean
@@ -1,0 +1,32 @@
+module
+
+/-!
+The termination error should be reported at the second recursive call, not the first.
+The two calls `f heapsize (lCh i)` are structurally identical syntax; without recording
+the source position in the `_recApp` mdata, hashconsing/simplification merged them and
+the error was attributed to the wrong call.
+-/
+
+def lCh := (· * 2 + 1)
+
+/--
+@ +7:6...24
+error: failed to prove termination, possible solutions:
+  - Use `have`-expressions to prove the remaining goals
+  - Use `termination_by` to specify a different well-founded relation
+  - Use `decreasing_by` to specify your own tactic for discharging this kind of goal
+heapsize i : Nat
+h✝¹ : i < heapsize
+h✝ : ¬i = 0
+⊢ heapsize - lCh i < heapsize - i
+-/
+#guard_msgs (positions := true) in
+def f (heapsize i : Nat) : Nat :=
+  if i < heapsize then
+    if i = 0 then
+      have : i < lCh i := by simp [lCh]; omega
+      f heapsize (lCh i)
+    else
+      f heapsize (lCh i)
+  else 0
+termination_by heapsize - i

--- a/tests/elab_fail/guessLexDiff.lean.out.expected
+++ b/tests/elab_fail/guessLexDiff.lean.out.expected
@@ -27,12 +27,12 @@ The basic measures relate at each recursive call as follows:
             i #1 #2 i + 1 0 - i #3 i + i
 1) 85:26-38 =  =  =     =     =  =     =
 2) 85:58-76 ?  <  _     _     _  _     _
-3) 85:26-38 =  =  =     =     =  =     =
+3) 86:30-42 =  =  =     =     =  =     =
 4) 88:26-42 _  <  _     _     _  _     _
-5) 88:26-42 ?  ≤  ≤     ?     ≤  ≤     ?
-6) 88:26-42 _  <  _     _     _  _     _
-7) 88:26-42 _  <  _     _     _  _     _
-8) 88:26-42 _  <  _     _     _  _     _
+5) 89:20-36 ?  ≤  ≤     ?     ≤  ≤     ?
+6) 90:21-37 _  <  _     _     _  _     _
+7) 91:26-42 _  <  _     _     _  _     _
+8) 92:25-41 _  <  _     _     _  _     _
 9) 97:8-20  _  <  _     _     _  _     _
 
 #1: xs.size - i
@@ -65,7 +65,7 @@ Call from mutual_failure to mutual_failure2 at 104:52-78:
    i #1 #2 i + 1
 i  ?  _  _     =
 #3 _  <  _     _
-Call from mutual_failure to mutual_failure2 at 104:4-24:
+Call from mutual_failure to mutual_failure2 at 107:4-24:
    i #1 #2 i + 1
 i  _  _  _     <
 #3 _  =  _     _


### PR DESCRIPTION
This PR fixes the termination checker reporting errors at the wrong
recursive call site when a function contains structurally-identical
recursive calls at different source locations.

The `_recApp` `MData` attached to recursive applications carried the
attached `Syntax`, but two structurally-equal `MData` wrappers could be
merged by hashconsing/simplification, so the syntax of the first call
ended up associated with both call sites. We now also store the source
byte position as `_recAppPos`, which keeps the wrappers distinct.

Closes #13444.
