### PR TITLE
feat: completions for user `simp` options

### DIFF
--- a/src/Lean/Elab/ConfigEval/Extra.lean
+++ b/src/Lean/Elab/ConfigEval/Extra.lean
@@ -20,8 +20,7 @@ Assumes that `item` is shifted, with the rest of the item being the option name 
 -/
 def EvalConfigItem.evalSetOptions (optionPrefix : Name) (opts : Options) (item : ConfigItem) : TermElabM Options := do
   let optName := optionPrefix ++ item.getCurrOptionName
-  -- TODO(kmill): record `optionPrefix` so that LSP can make correct suggestions
-  addCompletionInfo <| CompletionInfo.option (mkNullNode #[item.prevRoot, mkNullNode item.optionComps.toArray])
+  addCompletionInfo <| CompletionInfo.option (mkNullNode #[item.prevRoot, mkNullNode item.optionComps.toArray]) optionPrefix
   let decl ← getOptionDecl optName
   pushInfoLeaf <| .ofOptionInfo { stx := item.option, optionName := optName, declName := decl.declName }
   let set (α : Type) [EvalTerm α] [EvalExpr α] [KVMap.Value α] : TermElabM Options := do

--- a/src/Lean/Elab/DocString/Builtin.lean
+++ b/src/Lean/Elab/DocString/Builtin.lean
@@ -1155,7 +1155,7 @@ def option (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
           -- Here it's important to get the partial syntax in order to add completion info,
           -- but then abort processing.
           let (stx, err) ← parseStrLit' (nodeFn nullKind identWithPartialTrailingDot.fn) s
-          addCompletionInfo <| CompletionInfo.option stx[0]
+          addCompletionInfo <| CompletionInfo.option stx[0] .anonymous
           if err then throw e1 else pure (Sum.inr stx[0])
         catch
         | e2 =>
@@ -1165,7 +1165,7 @@ def option (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
       let (id, val) ← optionNameAndVal stx
       -- For completion purposes, we discard `val` and any later arguments. We include the first
       -- argument (the keyword) for position information in case `id` is `missing`.
-      addCompletionInfo <| CompletionInfo.option (stx.setArgs (stx.getArgs[*...3]))
+      addCompletionInfo <| CompletionInfo.option (stx.setArgs (stx.getArgs[*...3])) .anonymous
       let optionName := id.getId.eraseMacroScopes
       try
         let decl ← getOptionDecl optionName
@@ -1283,7 +1283,7 @@ Sets the specified option to the specified value for the remainder of the commen
 -/
 @[builtin_doc_command]
 def «set_option» (option : Ident) (value : DataValue) : DocM (Block ElabInline ElabBlock) := do
-  addCompletionInfo <| CompletionInfo.option option
+  addCompletionInfo <| CompletionInfo.option option .anonymous
   let optionName := option.getId
   let decl ← withRef option <| getOptionDecl optionName
   pushInfoLeaf <| .ofOptionInfo { stx := option, optionName, declName := decl.declName }

--- a/src/Lean/Elab/InfoTree/Main.lean
+++ b/src/Lean/Elab/InfoTree/Main.lean
@@ -65,7 +65,7 @@ def CompletionInfo.stx : CompletionInfo → Syntax
   | dotId stx ..      => stx
   | fieldId stx ..    => stx
   | namespaceId stx   => stx
-  | option stx        => stx
+  | option stx ..     => stx
   | errorName stx ..  => stx
   | endSection stx .. => stx
   | tactic stx ..     => stx

--- a/src/Lean/Elab/InfoTree/Types.lean
+++ b/src/Lean/Elab/InfoTree/Types.lean
@@ -111,7 +111,10 @@ inductive CompletionInfo where
   | dotId (stx : Syntax) (id : Name) (lctx : LocalContext) (expectedType? : Option Expr)
   | fieldId (stx : Syntax) (id : Option Name) (lctx : LocalContext) (structName : Name)
   | namespaceId (stx : Syntax)
-  | option (stx : Syntax)
+  /-- Completion of global options. `stx[1]` is the option to complete and `stx[0]` is a keyword prefixing it.
+  The `optionPrefix` is generally `Name.anonymous`; setting `optionPrefix` restricts to the "namespace" of
+  those options beginning with the prefix. Completions will not include `optionPrefix` in the result. -/
+  | option (stx : Syntax) (optionPrefix : Name)
   | errorName (stx partialId : Syntax)
   | endSection (stx : Syntax) (id? : Option Name) (danglingDot : Bool) (scopeNames : List String)
   | tactic (stx : Syntax)

--- a/src/Lean/Elab/SetOption.lean
+++ b/src/Lean/Elab/SetOption.lean
@@ -60,7 +60,7 @@ def elabSetOption (id : Syntax) (val : Syntax) (addInfo := true) : m (Options ×
   let ref ← getRef
   -- For completion purposes, we discard `val` and any later arguments.
   -- We include the first argument (the keyword) for position information in case `id` is `missing`.
-  if addInfo then addCompletionInfo <| CompletionInfo.option (ref.setArgs (ref.getArgs[*...3]))
+  if addInfo then addCompletionInfo <| CompletionInfo.option (ref.setArgs (ref.getArgs[*...3])) .anonymous
   let optionName := id.getId.eraseMacroScopes
   let decl ← IO.toEIO (fun (ex : IO.Error) => Exception.error ref ex.toString) (getOptionDecl optionName)
   if addInfo then pushInfoLeaf <| .ofOptionInfo { stx := id, optionName, declName := decl.declName }

--- a/src/Lean/Server/Completion.lean
+++ b/src/Lean/Server/Completion.lean
@@ -52,8 +52,8 @@ partial def find?
           dotIdCompletion uri pos completionInfoPos i.ctx lctx id expectedType?
         | .fieldId _ id lctx structName =>
           fieldIdCompletion uri pos completionInfoPos i.ctx lctx id structName
-        | .option stx =>
-          optionCompletion uri pos completionInfoPos i.ctx stx caps
+        | .option stx optionPrefix =>
+          optionCompletion uri pos completionInfoPos i.ctx stx optionPrefix caps
         | .errorName _ partialId =>
           errorNameCompletion uri pos completionInfoPos i.ctx partialId caps
         | .endSection _ id? danglingDot scopeNames =>

--- a/src/Lean/Server/Completion/CompletionCollectors.lean
+++ b/src/Lean/Server/Completion/CompletionCollectors.lean
@@ -509,7 +509,8 @@ affect the set of eligible completion candidates.
 -/
 private def trailingDotCompletion [ForIn Id Coll (Name × α)]
     (entries : Coll) (stx : Syntax) (caps : ClientCapabilities) (ctx : ContextInfo)
-    (mkItem : Name → α → Option InsertReplaceEdit → ResolvableCompletionItem) :
+    (mkItem : Name → α → Option InsertReplaceEdit → ResolvableCompletionItem)
+    (filterMapName? : Name → Option Name := some) :
     Array ResolvableCompletionItem := Id.run do
   let (partialName, trailingDot) :=
     match stx.getSubstring? (withLeading := false) (withTrailing := false) with
@@ -522,17 +523,18 @@ private def trailingDotCompletion [ForIn Id Coll (Name × α)]
         (ss.toString, false)
   let mut items := #[]
   for (name, value) in entries do
-    if partialName.charactersIn name.toString then
-      let textEdit? :=
-        if !caps.textDocument?.any (·.completion?.any (·.completionItem?.any (·.insertReplaceSupport?.any (·)))) then
-          none -- InsertReplaceEdit not supported by client
-        else if let some ⟨start, stop⟩ := stx.getRange? then
-          let stop := if trailingDot then stop + ' ' else stop
-          let range := ⟨ctx.fileMap.utf8PosToLspPos start, ctx.fileMap.utf8PosToLspPos stop⟩
-          some { newText := name.toString, insert := range, replace := range : InsertReplaceEdit }
-        else
-          none
-      items := items.push (mkItem name value textEdit?)
+    if let some name' := filterMapName? name then
+      if partialName.charactersIn name'.toString then
+        let textEdit? :=
+          if !caps.textDocument?.any (·.completion?.any (·.completionItem?.any (·.insertReplaceSupport?.any (·)))) then
+            none -- InsertReplaceEdit not supported by client
+          else if let some ⟨start, stop⟩ := stx.getRange? then
+            let stop := if trailingDot then stop + ' ' else stop
+            let range := ⟨ctx.fileMap.utf8PosToLspPos start, ctx.fileMap.utf8PosToLspPos stop⟩
+            some { newText := name'.toString, insert := range, replace := range : InsertReplaceEdit }
+          else
+            none
+        items := items.push (mkItem name value textEdit?)
   return items
 
 def optionCompletion
@@ -541,14 +543,21 @@ def optionCompletion
     (completionInfoPos : Nat)
     (ctx               : ContextInfo)
     (stx               : Syntax)
+    (optionPrefix      : Name)
     (caps              : ClientCapabilities)
     : IO (Array ResolvableCompletionItem) :=
   ctx.runMetaM {} do
     -- HACK(WN): unfold the type so ForIn works
-    let (decls : Std.TreeMap _ _ _) ← getOptionDecls
+    let mut (decls : Std.TreeMap _ _ _) ← getOptionDecls
     let opts ← getOptions
+    let filterMap? := -- filter/map for `optionPrefix` feature
+      if optionPrefix.isAnonymous then some
+      else fun name : Name =>
+        if optionPrefix.isPrefixOf name then
+          name.replacePrefix optionPrefix .anonymous
+        else none
     -- `stx` is from `"set_option " >> ident`
-    return trailingDotCompletion decls stx[1] caps ctx fun name decl textEdit? => {
+    return trailingDotCompletion decls stx[1] caps ctx (fun name decl textEdit? => {
       label := name.toString
       detail? := s!"({opts.get name decl.defValue}), {decl.descr}"
       documentation? := none,
@@ -560,7 +569,7 @@ def optionCompletion
         cPos? := completionInfoPos
         id? := none : ResolvableCompletionItemData
       }
-    }
+    }) filterMap?
 
 def errorNameCompletion
     (uri               : DocumentUri)

--- a/src/Lean/Server/Completion/CompletionInfoSelection.lean
+++ b/src/Lean/Server/Completion/CompletionInfoSelection.lean
@@ -36,8 +36,8 @@ where
       stx₁.eqWithInfo stx₂ && id₁? == id₂? && structName₁ == structName₂
     | .namespaceId stx₁, .namespaceId stx₂ =>
       stx₁.eqWithInfo stx₂
-    | .option stx₁, .option stx₂ =>
-      stx₁.eqWithInfo stx₂
+    | .option stx₁ pre₁, .option stx₂ pre₂=>
+      stx₁.eqWithInfo stx₂ && pre₁ == pre₂
     | .errorName stx₁ .., .errorName stx₂ .. =>
       stx₁.eqWithInfo stx₂
     | .endSection stx₁ .., .endSection stx₂ .. =>
@@ -84,7 +84,7 @@ where
       return best
     return best.push { hoverInfo, ctx, info := completionInfo }
   containsHoverPos (i : CompletionInfo) : Bool := Id.run do
-    if let .option stx := i then
+    if let .option stx _ := i then
       if stx[1].isMissing then
         let some range := stx.getRangeWithTrailing? (canonicalOnly := true)
           | return false


### PR DESCRIPTION
This PR adds `CompletionInfo` support for option prefixes. This enables `+user.myOption` configuration items for `simp` to complete using only those global options that begin with `tactic.simp.user`. For example, on `+user.m`, if there is a global option `tactic.simp.user.myOption`, the LSP would suggest this option, and complete it to `+user.myOption`.

This is the LSP component of #13651.