### PR TITLE
test: tidy `Util.lean` in the `mvcgen'` prototype

### DIFF
--- a/tests/bench/mvcgen/sym/lib/VCGen/RuleCache.lean
+++ b/tests/bench/mvcgen/sym/lib/VCGen/RuleCache.lean
@@ -15,6 +15,7 @@ public meta import VCGen.Util
 
 open Lean Meta Elab Tactic Sym
 open Lean.Elab.Tactic.Do.SpecAttr
+open VCGen
 open Std.Do
 
 /-!

--- a/tests/bench/mvcgen/sym/lib/VCGen/RuleCache.lean
+++ b/tests/bench/mvcgen/sym/lib/VCGen/RuleCache.lean
@@ -25,6 +25,14 @@ open Std.Do
 
 namespace VCGen
 
+@[inline]
+public meta def Std.HashMap.getDM [Monad m] [BEq α] [Hashable α]
+    (cache : Std.HashMap α β) (key : α) (fallback : m β) : m (β × Std.HashMap α β) := do
+  if let some b := cache.get? key then
+    return (b, cache)
+  let b ← fallback
+  return (b, cache.insert key b)
+
 public meta def SpecTheoremNew.global? (specThm : SpecTheoremNew) : Option Name :=
   match specThm.proof with | .global decl => some decl | _ => none
 

--- a/tests/bench/mvcgen/sym/lib/VCGen/Util.lean
+++ b/tests/bench/mvcgen/sym/lib/VCGen/Util.lean
@@ -23,17 +23,17 @@ generalization of `applyRflAndAndIntro`. None of these know anything about
 `SPred` entailment specifically.
 -/
 
+namespace VCGen
+
+open Sym Sym.Internal
+
 @[inline]
-public meta def _root_.Std.HashMap.getDM [Monad m] [BEq α] [Hashable α]
+public meta def Std.HashMap.getDM [Monad m] [BEq α] [Hashable α]
     (cache : Std.HashMap α β) (key : α) (fallback : m β) : m (β × Std.HashMap α β) := do
   if let some b := cache.get? key then
     return (b, cache)
   let b ← fallback
   return (b, cache.insert key b)
-
-namespace VCGen
-
-open Sym Sym.Internal
 
 public meta def simpTargetTelescope (mvarId : MVarId) : VCGenM (MVarId × Bool) := do
   let some methods := (← read).hypSimpMethods | return (mvarId, false)

--- a/tests/bench/mvcgen/sym/lib/VCGen/Util.lean
+++ b/tests/bench/mvcgen/sym/lib/VCGen/Util.lean
@@ -35,33 +35,6 @@ namespace VCGen
 
 open Sym Sym.Internal
 
--- The following function is vendored until it is made public:
-/-- `mkAppRevRangeS f b e args == mkAppRev f (revArgs.extract b e)` -/
-public meta def mkAppRevRangeS [Monad m] [Internal.MonadShareCommon m] (f : Expr) (beginIdx endIdx : Nat) (revArgs : Array Expr) : m Expr :=
-  loop revArgs beginIdx f endIdx
-where
-  loop (revArgs : Array Expr) (start : Nat) (b : Expr) (i : Nat) : m Expr := do
-  if i ≤ start then
-    return b
-  else
-    let i := i - 1
-    loop revArgs start (← mkAppS b revArgs[i]!) i
-
-public meta def mkAppRevS [Monad m] [Internal.MonadShareCommon m] (f : Expr) (revArgs : Array Expr) : m Expr :=
-  mkAppRevRangeS f 0 revArgs.size revArgs
-
-public meta def mkAppRangeS [Monad m] [Internal.MonadShareCommon m] (f : Expr) (beginIdx endIdx : Nat) (args : Array Expr) : m Expr :=
-  loop args endIdx f beginIdx
-where
-  loop (args : Array Expr) (end' : Nat) (b : Expr) (i : Nat) : m Expr := do
-  if end' ≤ i then
-    return b
-  else
-    loop args end' (← mkAppS b args[i]!) (i + 1)
-
-public meta def mkAppNS [Monad m] [Internal.MonadShareCommon m] (f : Expr) (args : Array Expr) : m Expr :=
-  mkAppRangeS f 0 args.size args
-
 public meta def simpTargetTelescope (mvarId : MVarId) : VCGenM (MVarId × Bool) := do
   let some methods := (← read).hypSimpMethods | return (mvarId, false)
   let target ← mvarId.getType

--- a/tests/bench/mvcgen/sym/lib/VCGen/Util.lean
+++ b/tests/bench/mvcgen/sym/lib/VCGen/Util.lean
@@ -27,14 +27,6 @@ namespace VCGen
 
 open Sym Sym.Internal
 
-@[inline]
-public meta def Std.HashMap.getDM [Monad m] [BEq α] [Hashable α]
-    (cache : Std.HashMap α β) (key : α) (fallback : m β) : m (β × Std.HashMap α β) := do
-  if let some b := cache.get? key then
-    return (b, cache)
-  let b ← fallback
-  return (b, cache.insert key b)
-
 public meta def simpTargetTelescope (mvarId : MVarId) : VCGenM (MVarId × Bool) := do
   let some methods := (← read).hypSimpMethods | return (mvarId, false)
   let target ← mvarId.getType


### PR DESCRIPTION
This PR cleans up `tests/bench/mvcgen/sym/lib/VCGen/Util.lean`.

- Drops the four `mkApp{Rev,RevRange,Range,N}S` helpers that were vendored locally; they are now public in `Lean.Meta.Sym.Internal` (`Lean.Meta.Sym.AlphaShareBuilder`).
- Moves `Std.HashMap.getDM` out of the root `Std.HashMap` namespace into `namespace VCGen` and relocates it to `RuleCache.lean`, where its only call sites live.