### PR TITLE
fix: codegen should not inspect private ctor of public type

### DIFF
--- a/src/Lean/Compiler/LCNF/Irrelevant.lean
+++ b/src/Lean/Compiler/LCNF/Irrelevant.lean
@@ -15,11 +15,19 @@ namespace Lean.Compiler.LCNF
 
 /--
 Given a constructor, return a bitmask `m` s.t. `m[i]` is true if field `i` is
-computationally relevant.
+computationally relevant. Returns `none` if the constructor is not sufficiently public for the
+result to be stable across modules.
 -/
-def getRelevantCtorFields (ctorName : Name) (trivialType : Expr → MetaM Bool) :
-    CoreM (Array Bool) := do
+def getRelevantCtorFields? (ctorName : Name) (trivialType : Expr → MetaM Bool) :
+    CoreM (Option (Array Bool)) := do
   let .ctorInfo info ← getConstInfo ctorName | unreachable!
+  if !isPrivateName info.induct && isPrivateName ctorName then
+    try
+      withExporting do
+      go info
+    catch _ => return none
+  else go info
+where go info :=
   Meta.MetaM.run' do
     Meta.forallTelescopeReducing info.type fun xs _ => do
       let mut result := #[]
@@ -43,6 +51,8 @@ Computes `some fieldIdx` if `declName` is the name of an inductive datatype s.t.
 - It does not have builtin support in the runtime.
 - It has only one constructor.
 - This constructor has only one computationally relevant field.
+- This information is stable across modules, i.e. the type is private or that field does not
+  access private information.
 -/
 def Irrelevant.computeHasTrivialStructure?
     (trivialType : Expr → MetaM Bool) (declName : Name) : CoreM (Option TrivialStructureInfo) := do
@@ -52,7 +62,8 @@ def Irrelevant.computeHasTrivialStructure?
   let [ctorName] := info.ctors | return none
   let ctorType ← getOtherDeclBaseType ctorName []
   if ctorType.isErased then return none
-  let mask ← getRelevantCtorFields ctorName trivialType
+  let some mask ← getRelevantCtorFields? ctorName trivialType
+    | return none
   let mut result := none
   for h : i in *...mask.size do
     if mask[i] then

--- a/tests/pkg/module/Module/Basic.lean
+++ b/tests/pkg/module/Module/Basic.lean
@@ -52,6 +52,10 @@ This is a current compiler limitation for `module`s that may be lifted in the fu
 #guard_msgs in
 public def Fun.mk (f : Nat → Nat) : Fun := f
 
+public structure UInt8Struct where
+  x : UInt8
+deriving Inhabited
+
 #guard_msgs(drop warning) in
 /-- A theorem. -/
 public theorem t : f = 1 := testSorry

--- a/tests/pkg/module/Module/ImportedPrivateImported.lean
+++ b/tests/pkg/module/Module/ImportedPrivateImported.lean
@@ -15,3 +15,20 @@ public import Module.PrivateImported
 
 /-! #12833: namespaces privately imported but publicly used must be re-exported. -/
 open Namespaced
+
+/-! Re-check `mkSwpift` invariants. -/
+
+/--
+trace: [Compiler.result] size: 1
+    def _private.Module.ImportedPrivateImported.0.mkSwpift2 n : obj :=
+      let _x.1 := mkSwpift n;
+      return _x.1
+[Compiler.result] size: 2
+    def _private.Module.ImportedPrivateImported.0.mkSwpift2._boxed n : obj :=
+      let n.boxed := unbox n;
+      let res := _private.Module.ImportedPrivateImported.0.mkSwpift2 n.boxed;
+      return res
+-/
+#guard_msgs in
+set_option trace.Compiler.result true in
+def mkSwpift2 (n : UInt8) : StructWithPrivImportedFieldType := mkSwpift n

--- a/tests/pkg/module/Module/PrivateImported.lean
+++ b/tests/pkg/module/Module/PrivateImported.lean
@@ -41,3 +41,29 @@ fail with `Unknown constant` in this public theorem signature. -/
 public theorem hmulDefaultPrivacy (m : Nat) : ∀ n, m * n = m * n := by
   intro n
   rfl
+
+public structure StructWithPrivImportedFieldType where
+  private field : UInt8Struct
+deriving Inhabited
+
+/-!
+Construct and extract values of a public type whose only field's type is privately imported.
+The defining module is the only place that sees the private field type, so trivial structure
+optimizations (eliding constructor, unboxing type) should be disabled.
+-/
+
+/--
+trace: [Compiler.result] size: 2
+    def mkSwpift n : obj :=
+      let _x.1 := ctor_0.0.1[_private.Module.PrivateImported.0.StructWithPrivImportedFieldType.mk];
+      sset _x.1[0, 0] := n;
+      return _x.1
+[Compiler.result] size: 2
+    def mkSwpift._boxed n : obj :=
+      let n.boxed := unbox n;
+      let res := mkSwpift n.boxed;
+      return res
+-/
+#guard_msgs in
+set_option trace.Compiler.result true in
+public def mkSwpift (n : UInt8) : StructWithPrivImportedFieldType := ⟨⟨n⟩⟩


### PR DESCRIPTION
This PR fixes an issue where code generation broke when using structures with private fields and types inaccessible in the current scope.

## Breaking change

In rare cases, this may lead to an observable change in FFI representation. The reference manual is updated to not recommend direct access to fields for this reason.