### PR TITLE
chore: align `cbv` tactic with `SymM` framework conventions

### DIFF
--- a/src/Lean/Meta/Tactic/Cbv/ControlFlow.lean
+++ b/src/Lean/Meta/Tactic/Cbv/ControlFlow.lean
@@ -10,7 +10,6 @@ import Lean.Meta.Sym.Simp.Result
 import Lean.Meta.Sym.Simp.Rewrite
 import Lean.Meta.Sym.Simp.ControlFlow
 import Lean.Meta.Sym.AlphaShareBuilder
-import Lean.Meta.Sym.Util
 import Lean.Meta.Sym.InstantiateS
 import Lean.Meta.Sym.InferType
 import Lean.Meta.Sym.Simp.App
@@ -314,13 +313,9 @@ builtin_cbv_simproc ↓ simpCbvCond (@cond _ _ _) := simpCond
 public def reduceRecMatcher : Simproc := fun e => do
   if let some e' ← withCbvOpaqueGuard <| reduceRecMatcher? e then
     trace[Meta.Tactic.cbv.rewrite] "recMatcher:{indentExpr e}\n==>{indentExpr e'}"
-    -- Iota-reduction may expose kernel `Expr.proj` terms via struct-eta,
-    -- which the structural simplifier cannot consume directly.
-    let mut e'' ← Sym.foldProjs e'
-    unless Sym.isSameExpr e' e'' do
-      e'' ← Sym.share e''
-    return .step e'' (← Sym.mkEqRefl e'')
-  return .rfl
+    return .step e' (← Sym.mkEqRefl e')
+  else
+    return .rfl
 
 builtin_cbv_simproc ↓ simpDecidableRec (@Decidable.rec _ _ _ _ _) :=
   (simpInterlaced · #[false,false,false,false,true]) >> reduceRecMatcher

--- a/src/Lean/Meta/Tactic/Cbv/ControlFlow.lean
+++ b/src/Lean/Meta/Tactic/Cbv/ControlFlow.lean
@@ -10,6 +10,7 @@ import Lean.Meta.Sym.Simp.Result
 import Lean.Meta.Sym.Simp.Rewrite
 import Lean.Meta.Sym.Simp.ControlFlow
 import Lean.Meta.Sym.AlphaShareBuilder
+import Lean.Meta.Sym.Util
 import Lean.Meta.Sym.InstantiateS
 import Lean.Meta.Sym.InferType
 import Lean.Meta.Sym.Simp.App
@@ -313,9 +314,13 @@ builtin_cbv_simproc ↓ simpCbvCond (@cond _ _ _) := simpCond
 public def reduceRecMatcher : Simproc := fun e => do
   if let some e' ← withCbvOpaqueGuard <| reduceRecMatcher? e then
     trace[Meta.Tactic.cbv.rewrite] "recMatcher:{indentExpr e}\n==>{indentExpr e'}"
-    return .step e' (← Sym.mkEqRefl e')
-  else
-    return .rfl
+    -- Iota-reduction may expose kernel `Expr.proj` terms via struct-eta,
+    -- which the structural simplifier cannot consume directly.
+    let mut e'' ← Sym.foldProjs e'
+    unless Sym.isSameExpr e' e'' do
+      e'' ← Sym.share e''
+    return .step e'' (← Sym.mkEqRefl e'')
+  return .rfl
 
 builtin_cbv_simproc ↓ simpDecidableRec (@Decidable.rec _ _ _ _ _) :=
   (simpInterlaced · #[false,false,false,false,true]) >> reduceRecMatcher

--- a/src/Lean/Meta/Tactic/Cbv/Main.lean
+++ b/src/Lean/Meta/Tactic/Cbv/Main.lean
@@ -275,6 +275,7 @@ def handleConst : Simproc := fun e => do
   if eType matches .forallE .. then return .rfl
   unless info.hasValue && info.levelParams.length == lvls.length do return .rfl
   let fBody ← instantiateValueLevelParams info lvls
+  let fBody ← Sym.unfoldReducible fBody
   let eNew ← Sym.share fBody
   trace[Meta.Tactic.cbv.unfold] "const `{n}`:{indentExpr e}\n==>{indentExpr eNew}"
   return .step eNew (← Sym.mkEqRefl eNew)

--- a/src/Lean/Meta/Tactic/Cbv/Main.lean
+++ b/src/Lean/Meta/Tactic/Cbv/Main.lean
@@ -249,13 +249,13 @@ def handleProj : Simproc := fun e => do
   -- We recursively simplify the projection
   let res ← simp struct
   match res with
-  | .rfl _ _ =>
+  | .rfl _ cd =>
     let some reduced ← withCbvOpaqueGuard <| reduceProj? <| .proj typeName idx struct | do
       return .rfl (done := true)
 
     -- TODO: Figure if we can share this term incrementally
     let reduced ← Sym.share reduced
-    return .step reduced (← Sym.mkEqRefl reduced)
+    return .step reduced (← Sym.mkEqRefl reduced) cd
   | .step e' proof _ cd =>
     let type ← Sym.inferType e'
     let congrArgFun := Lean.mkLambda `x .default type <| .proj typeName idx <| .bvar 0
@@ -279,7 +279,7 @@ def handleProj : Simproc := fun e => do
         unless (← Sym.isDefEqI struct e') do
           -- If we rewrote the projection body using something that holds up to propositional equality, then there is nothing we can do.
           -- TODO: Check if there is a need to report this to a user, or shall we fail silently.
-          return .rfl (done := true)
+          return .rfl (done := true) cd
         let hcongr ← mkHCongr congrArgFun
         let newProof := mkApp3 (hcongr.proof) struct e' proof
         -- We have already checked if `struct` and `e'` are defEq, so we can skip the check.

--- a/src/Lean/Meta/Tactic/Cbv/Main.lean
+++ b/src/Lean/Meta/Tactic/Cbv/Main.lean
@@ -256,7 +256,7 @@ def handleProj : Simproc := fun e => do
     -- TODO: Figure if we can share this term incrementally
     let reduced ← Sym.share reduced
     return .step reduced (← Sym.mkEqRefl reduced)
-  | .step e' proof _ _ =>
+  | .step e' proof _ cd =>
     let type ← Sym.inferType e'
     let congrArgFun := Lean.mkLambda `x .default type <| .proj typeName idx <| .bvar 0
     let congrArgFunType ← Sym.inferType congrArgFun
@@ -266,14 +266,14 @@ def handleProj : Simproc := fun e => do
       let u ← Sym.getLevel α
       let v ← Sym.getLevel β
       let newProof := mkApp6 (mkConst ``congrArg [u, v]) α β struct e' congrArgFun proof
-      return .step (← Lean.Expr.updateProjS! e e') newProof
+      return .step (← Lean.Expr.updateProjS! e e') newProof cd
     else
       -- If the type of the projection function is dependent, we first try to reduce the projection
       let reduced ← withCbvOpaqueGuard <| reduceProj? e
       match reduced with
       | .some reduced =>
         let reduced ← Sym.share reduced
-        return .step reduced (← Sym.mkEqRefl reduced)
+        return .step reduced (← Sym.mkEqRefl reduced) cd
       | .none =>
        -- If we failed to reduce it, we turn to a last resort; we try use heterogeneous congruence lemma that we then try to turn into an equality.
         unless (← Sym.isDefEqI struct e') do
@@ -284,7 +284,7 @@ def handleProj : Simproc := fun e => do
         let newProof := mkApp3 (hcongr.proof) struct e' proof
         -- We have already checked if `struct` and `e'` are defEq, so we can skip the check.
         let newProof ← mkEqOfHEq newProof (check := false)
-        return .step (← Lean.Expr.updateProjS! e e') newProof
+        return .step (← Lean.Expr.updateProjS! e e') newProof cd
 
 open Sym.Internal in
 /--
@@ -300,7 +300,7 @@ def simplifyAppFn : Simproc := fun e => do
     let res ← simp fn
     match res with
     | .rfl _ _ => return res
-    | .step e' proof _ _ =>
+    | .step e' proof _ cd =>
       let newType ← Sym.inferType e'
       let congrArgFun := Lean.mkLambda `x .default newType (mkAppN (.bvar 0) e.getAppArgs)
       let newValue ← mkAppNS e' e.getAppArgs
@@ -309,7 +309,7 @@ def simplifyAppFn : Simproc := fun e => do
       let v ← Sym.getLevel resultType
       let newProof := mkApp6 (mkConst ``congrArg [u, v]) newType resultType fn e' congrArgFun proof
       trace[Debug.Meta.Tactic.cbv.reduce] "simplifyAppFn:{indentExpr e}\n==>{indentExpr newValue}"
-      return .step newValue newProof
+      return .step newValue newProof cd
 
 def handleConst : Simproc := fun e => do
   let .const n lvls := e | return .rfl

--- a/src/Lean/Meta/Tactic/Cbv/Main.lean
+++ b/src/Lean/Meta/Tactic/Cbv/Main.lean
@@ -100,51 +100,6 @@ is marked done regardless of whether a rule fires. Otherwise it tries in order:
 namespace Lean.Meta.Tactic.Cbv
 open Lean.Meta.Sym.Simp
 
-/-- Like `Sym.unfoldReducibleStep` but skips `@[cbv_opaque]` declarations. -/
-private def unfoldReducibleStep (e : Expr) : MetaM TransformStep := do
-  let .const declName _ := e.getAppFn | return .continue
-  unless (← isReducible declName) do return .continue
-  if (← getEnv).isProjectionFn declName then return .continue
-  if (← isCbvOpaque declName) then return .continue
-  let some v ← unfoldDefinition? e | return .continue
-  return .visit v
-
-/-- Like `Sym.unfoldReducible` but skips `@[cbv_opaque]` declarations. -/
-private def unfoldReducible (e : Expr) : MetaM Expr := do
-  Meta.transform e (pre := unfoldReducibleStep)
-
-/-- Like `Sym.preprocessExpr` but skips `@[cbv_opaque]` declarations during unfolding. -/
-private def preprocessExpr (e : Expr) : Sym.SymM Expr := do
-  Sym.shareCommon (← unfoldReducible (← instantiateMVars e))
-
-/-- Like `Sym.preprocessMVar` but skips `@[cbv_opaque]` declarations during unfolding. -/
-private def preprocessMVar (mvarId : MVarId) : Sym.SymM MVarId := do
-  let mvarDecl ← mvarId.getDecl
-  let lctx ← preprocessLCtx mvarDecl.lctx
-  let type ← preprocessExpr mvarDecl.type
-  let mvarNew ← mkFreshExprMVarAt lctx mvarDecl.localInstances type .syntheticOpaque mvarDecl.userName
-  mvarId.assign mvarNew
-  return mvarNew.mvarId!
-where
-  preprocessLCtx (lctx : LocalContext) : Sym.SymM LocalContext := do
-    let auxDeclToFullName := lctx.auxDeclToFullName
-    let mut fvarIdToDecl := {}
-    let mut decls := {}
-    let mut index := 0
-    for decl in lctx do
-      let decl ← match decl with
-        | .cdecl _ fvarId userName type bi kind =>
-          let type ← preprocessExpr type
-          pure <| LocalDecl.cdecl index fvarId userName type bi kind
-        | .ldecl _ fvarId userName type value nondep kind =>
-          let type ← preprocessExpr type
-          let value ← preprocessExpr value
-          pure <| LocalDecl.ldecl index fvarId userName type value nondep kind
-      index := index + 1
-      decls := decls.push (some decl)
-      fvarIdToDecl := fvarIdToDecl.insert decl.fvarId decl
-    return { fvarIdToDecl, decls, auxDeclToFullName }
-
 public register_builtin_option cbv.warning : Bool := {
   defValue := false
   descr    := "When enabled, displays a warning that the `cbv` tactic is being used."
@@ -372,7 +327,7 @@ public def cbvEntry (e : Expr) : MetaM Result := do
   let simprocs ← getCbvSimprocs
   let config : Sym.Simp.Config := { maxSteps := cbv.maxSteps.get (← getOptions) }
   let methods := mkCbvMethods simprocs
-  let e ← unfoldReducible e
+  let e ← Sym.unfoldReducible e
   Sym.SymM.run do
     let e ← Sym.shareCommon e
     SimpM.run' (simp e) (methods := methods) (config := config)
@@ -394,7 +349,7 @@ After all reductions, attempts `refl` to close equation goals of the form `v = v
 public def cbvGoal (mvarId : MVarId) (simplifyTarget : Bool := true) (fvarIdsToSimp : Array FVarId := #[]) : MetaM (Option MVarId) := do
   let config : Sym.Simp.Config := { maxSteps := cbv.maxSteps.get (← getOptions) }
   Sym.SymM.run do
-    let mvarId ← preprocessMVar mvarId
+    let mvarId ← Sym.preprocessMVar mvarId
     mvarId.withContext do
       let mut mvarIdNew := mvarId
       let mut toAssert : Array Hypothesis := #[]
@@ -455,7 +410,7 @@ public def cbvDecideGoal (m : MVarId) : MetaM Unit := do
       | .error err => return m!"decide_cbv: {err.toMessageData}") do
   let config : Sym.Simp.Config := { maxSteps := cbv.maxSteps.get (← getOptions) }
   Sym.SymM.run do
-    let m ← preprocessMVar m
+    let m ← Sym.preprocessMVar m
     let mType ← m.getType
     let some (_, lhs, _) := mType.eq? |
       throwError "`decide_cbv`: expected goal of the form `decide _ = true`, got: {indentExpr mType}"
@@ -471,6 +426,5 @@ public def cbvDecideGoal (m : MVarId) : MetaM Unit := do
     match result with
     | .rfl _ _ => checkResult lhs (m.refl)
     | .step e' proof _ _ => checkResult e' (m.assign proof)
-
 
 end Lean.Meta.Tactic.Cbv

--- a/src/Lean/Meta/Tactic/Cbv/Main.lean
+++ b/src/Lean/Meta/Tactic/Cbv/Main.lean
@@ -206,9 +206,8 @@ def handleProj : Simproc := fun e => do
   match res with
   | .rfl _ cd =>
     let some reduced ← withCbvOpaqueGuard <| reduceProj? <| .proj typeName idx struct | do
-      return .rfl (done := true)
+      return .rfl (done := true) cd
 
-    -- TODO: Figure if we can share this term incrementally
     let reduced ← Sym.share reduced
     return .step reduced (← Sym.mkEqRefl reduced) cd
   | .step e' proof _ cd =>

--- a/src/Lean/Meta/Tactic/Cbv/Opaque.lean
+++ b/src/Lean/Meta/Tactic/Cbv/Opaque.lean
@@ -7,6 +7,7 @@ module
 
 prelude
 public import Lean.ScopedEnvExtension
+public import Lean.ReducibilityAttrs
 
 /-!
 # `@[cbv_opaque]` Attribute and Extension
@@ -34,7 +35,10 @@ builtin_initialize
     name  := `cbv_opaque
     descr := "Mark declarations that should not be unfolded by the `cbv` tactic"
     applicationTime := AttributeApplicationTime.afterCompilation
-    add   := fun declName _ kind =>
+    add   := fun declName _ kind => do
+      if (← isReducible declName) then
+        throwError "`@[cbv_opaque]` cannot be applied to a `@[reducible]` declaration: \
+          `{.ofConstName declName}` is reducible, so it is unfolded before `cbv` runs"
       cbvOpaqueExt.add declName kind
     erase := fun declName => do
       let s := cbvOpaqueExt.getState (← getEnv)

--- a/tests/elab/cbv_opaque_reducible.lean
+++ b/tests/elab/cbv_opaque_reducible.lean
@@ -1,0 +1,35 @@
+/-! Test that `@[cbv_opaque]` is rejected on `@[reducible]` declarations.
+
+The SymM framework eagerly unfolds reducible definitions during preprocessing, so
+marking a reducible definition as `@[cbv_opaque]` would have no effect — `cbv`
+never sees the constant by the time it runs. The attribute rejects this combination
+up front with a clear error rather than silently doing nothing. -/
+
+/-! ## Direct `@[reducible, cbv_opaque]` combination is rejected. -/
+
+/--
+error: `@[cbv_opaque]` cannot be applied to a `@[reducible]` declaration: `reducibleSecret` is reducible, so it is unfolded before `cbv` runs
+-/
+#guard_msgs in
+@[reducible, cbv_opaque] def reducibleSecret : Nat := 42
+
+/-! ## Post-hoc `attribute [cbv_opaque]` on a reducible definition is rejected. -/
+
+@[reducible] def alreadyReducible : Nat := 7
+
+/--
+error: `@[cbv_opaque]` cannot be applied to a `@[reducible]` declaration: `alreadyReducible` is reducible, so it is unfolded before `cbv` runs
+-/
+#guard_msgs in
+attribute [cbv_opaque] alreadyReducible
+
+/-! ## Non-reducible `@[cbv_opaque]` still works (sanity check). -/
+
+@[cbv_opaque] def nonReducibleSecret : Nat := 99
+
+/--
+error: unsolved goals
+⊢ nonReducibleSecret = 99
+-/
+#guard_msgs in
+example : nonReducibleSecret = 99 := by conv => lhs; cbv


### PR DESCRIPTION
This PR tightens how the `cbv` tactic interacts with the `Sym.Simp` framework. It propagates the `contextDependent` flag through cbv simprocs so cd-marked sub-results from `simp` are no longer dropped at congruence and projection sites, and rejects `@[cbv_opaque]` on `@[reducible]` declarations - `Sym` eliminates reducibles before `cbv` runs, so the combination has no consistent meaning. With that guarantee the cbv-specific `unfoldReducible`/`preprocessMVar` clones are removed in favor of their stock `Sym` counterparts.