### PR TITLE
[Backport releases/v4.30.0] fix: lake: `meta import` transitive import artifacts (#13600)

### DIFF
--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -219,38 +219,61 @@ private def computeModuleDeps
     plugins := plugins.push (← getLakeInstall).sharedDynlib
   return {dynlibs, plugins}
 
+structure TransImportEntry where
+  mod : Module
+  /-- Whether to include all module artifacts and traverse the module's direct imports. -/
+  importAll : Bool
+  /-- Whether this module has been transitively imported by a `meta import`. -/
+  needsMeta : Bool
+
 private partial def fetchTransImportArts
   (directImports : Array ModuleImport) (directArts : NameMap ImportArtifacts) (nonModule : Bool)
 : FetchM (NameMap ImportArtifacts) := do
-  let q ← directImports.foldlM (init := #[]) fun q imp => do
+  let q ← directImports.foldrM (init := #[]) fun imp q => do
     let some mod := imp.module? | return q
     let input ← (← mod.input.fetch).await
     let importAll := strictOr nonModule imp.importAll
-    return enqueue importAll input q
-  walk directArts q
+    return enqueue importAll imp.isMeta input q
+  walk directArts {} q
 where
-  walk s q := do
+  walk s (metaVisited : NameSet) (q : Array TransImportEntry) := do
     if h : 0 < q.size then
-      let (mod, importAll) := q.back
+      let {mod, importAll, needsMeta} := q.back
       let q := q.pop
       if let some arts := s.find? mod.name then
-        -- may need to promote a module system `import` to an `import all`
-        -- size of 1 = non-module, 3 = module system `import`, 4 = `import all`
-        unless importAll && arts.size == 3 do
-          return ← walk s q
+        /-
+        A module system `import` may need to be promoted to a
+        wider import (`meta import`, `import all`) on another branch.
+
+        The size of import artifacts implies the following:
+        * `1`: non-module `import` (`.olean` only)
+        * `3`: module `import` (`.olean`, `.olean.server`, `.ir`)
+        * `4`: `import all` (module + `.olean.private`)
+
+        Sizes `1` and `4` imply all imports were already enqueued,
+        so re-visiting them for `meta import` or `import all` is redundant.
+        A module already visited with `needsMeta` need not be re-visited.
+        -/
+        let needsMeta := needsMeta && !metaVisited.contains mod.name
+        unless (importAll || needsMeta) && arts.size == 3 do
+          return ← walk s metaVisited q
       let info ← (← mod.exportInfo.fetch).await
       let arts := if importAll then info.allArts else info.arts
       let s := s.insert mod.name arts
+      let metaVisited := if importAll || needsMeta then metaVisited.insert mod.name else metaVisited
       let input ← (← mod.input.fetch).await
-      let q := enqueue importAll input q
-      walk s q
+      let q := enqueue importAll needsMeta input q
+      walk s metaVisited q
     else
       return s
-  enqueue importAll input q :=
+  enqueue importAll needsMeta input q :=
     input.imports.foldr (init := q) fun imp q =>
       if let some mod := imp.module? then
-        if importAll || imp.isExported then
-          q.push (mod, nonModule || (importAll && imp.importAll))
+        let reachable := importAll || imp.isExported
+        let importAll := nonModule || (importAll && imp.importAll)
+        let needsMeta := needsMeta || (reachable && imp.isMeta)
+        if reachable || needsMeta then
+          q.push {mod, importAll, needsMeta}
         else q
       else q
 

--- a/tests/lake/tests/module/Test/Module/MetaRevisit.lean
+++ b/tests/lake/tests/module/Test/Module/MetaRevisit.lean
@@ -1,0 +1,4 @@
+module
+
+import Test.Module.PublicImportImport
+public meta import Test.Module.ImportImport

--- a/tests/lake/tests/module/Test/Module/PromoteMetaImport.lean
+++ b/tests/lake/tests/module/Test/Module/PromoteMetaImport.lean
@@ -1,0 +1,4 @@
+module
+
+import all Test.Module.ImportImport
+meta import Test.Module.ImportImport

--- a/tests/lake/tests/module/Test/Module/PublicImportImport.lean
+++ b/tests/lake/tests/module/Test/Module/PublicImportImport.lean
@@ -1,0 +1,3 @@
+module
+
+public import Test.Module.Import

--- a/tests/lake/tests/module/test.sh
+++ b/tests/lake/tests/module/test.sh
@@ -41,6 +41,11 @@ test_run build Test.Module.PromoteImport
 test_cmd grep -F "Module.olean.private" .lake/build/ir/Test/Module/PromoteImport.setup.json
 test_run build Test.Module.PromoteTransImport
 test_cmd grep -F "Module.olean.private" .lake/build/ir/Test/Module/PromoteTransImport.setup.json
+# an `import all` should not be demoted by a `meta import`
+# and `meta import` should still propagate through transitive imports
+test_run build Test.Module.PromoteMetaImport
+test_cmd grep -F "ImportImport.olean.private" .lake/build/ir/Test/Module/PromoteMetaImport.setup.json
+test_cmd grep -F "Module.ir" .lake/build/ir/Test/Module/PromoteMetaImport.setup.json
 # should be imported by a non-module
 test_run build Test.NonModule.Import
 test_cmd grep -F "Module.olean.private" .lake/build/ir/Test/NonModule/Import.setup.json
@@ -54,6 +59,22 @@ test_cmd_fails grep -F "Module.olean.private" .lake/build/ir/Test/Module/ImportA
 # Tests that the transitive module import of a private import does not include its artifacts
 test_run build Test.Module.ImportImport
 test_cmd_fails grep -F "Module.olean" .lake/build/ir/Test/Module/ImportImport.setup.json
+
+# Tests that `meta import` properly includes transitive import artifacts
+# IR should be included for a transitive `public meta import`
+test_run build Test.Module.ImportPublicMetaImport
+test_cmd grep -F "Module.ir" .lake/build/ir/Test/Module/ImportPublicMetaImport.setup.json
+# IR should be included for private imports of a `meta import`ed module
+# https://github.com/leanprover/lean4/issues/13419
+test_run build Test.Module.MetaImportImport
+test_cmd grep -F "Module.ir" .lake/build/ir/Test/Module/MetaImportImport.setup.json
+# IR should be included when a module is re-visited with `needsMeta`
+# (reached via both a non-meta and a meta path)
+test_run build Test.Module.MetaRevisit
+test_cmd grep -F "Module.ir" .lake/build/ir/Test/Module/MetaRevisit.setup.json
+# IR should not be included for a transitive private `meta import`
+test_run build Test.Module.ImportMetaImport
+test_cmd_fails grep -F "Module.ir" .lake/build/ir/Test/Module/ImportMetaImport.setup.json
 
 # Build all tests before making an edit
 test_run build


### PR DESCRIPTION
This PR fixes a Lake issue where the IR for a `meta import`'s transitive imports was not included in the import artifacts Lake provided to Lean (e.g., via `--setup`). When using the Lake artifact cache, this could produce "missing data file" errors due to absent IR.

(cherry picked from commit 326f43aa3a4f79d9e40e94e8ea051a7163f05c08)