### PR TITLE
chore: pin test-summary action to v2.4 SHA to unblock CI

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -252,7 +252,7 @@ jobs:
           time ctest --preset ${{ matrix.CMAKE_PRESET || 'release' }} --test-dir build/$TARGET_STAGE -j$NPROC --output-junit test-results.xml ${{ matrix.CTEST_OPTIONS }}
         if: matrix.test
       - name: Test Summary
-        uses: test-summary/action@v2
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4
         with:
           paths: build/${{ env.TARGET_STAGE }}/test-results.xml
         # prefix `if` above with `always` so it's run even if tests failed


### PR DESCRIPTION
This PR pins the `test-summary/action` GitHub Action to the immutable commit SHA for `v2.4` to work around a broken upstream `v2` tag. Upstream retagged `v2` to point at `v2.5`, which ships without the bundled `index.js`, causing every job using the shared build template to fail in the `Test Summary` post-step with `File not found: '/home/runner/work/_actions/test-summary/action/v2/index.js'`, even when all tests pass.

Pinning to the SHA (rather than another floating tag like `@v2.4`) matches GitHub's [security guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions) for third-party actions and avoids a repeat of this exact incident if `v2.4` is later retagged. Dependabot is already configured for `github-actions` updates in `.github/dependabot.yml`, so version bumps remain low-cost.

Verification:
- `curl -sI https://raw.githubusercontent.com/test-summary/action/v2/index.js` returns 404
- `curl -sI https://raw.githubusercontent.com/test-summary/action/31493c76ec9e7aa675f1585d3ed6f1da69269a86/index.js` returns 200

The summary action is shared across every workflow that includes `build-template.yml`, so this affects all CI Lake jobs, not just one.

🤖 Prepared with Claude Code