### PR TITLE
chore: re-enable Lake tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -250,20 +250,11 @@ set(PART2 "")
 # toolchain: requires elan to download toolchain
 # online: downloads remote repositories
 option(LAKE_CI "Enable full Lake test suite (use `lake-ci` label on PRs)" OFF)
-if(LAKE_CI)
-  file(
-    GLOB_RECURSE LEANLAKETESTS
-    "${LEAN_SOURCE_DIR}/../tests/lake/examples/test.sh"
-    "${LEAN_SOURCE_DIR}/../tests/lake/tests/test.sh"
-  )
-else()
-  file(
-    GLOB_RECURSE LEANLAKETESTS
-    "${LEAN_SOURCE_DIR}/../tests/lake/examples/test.sh"
-    "${LEAN_SOURCE_DIR}/../tests/lake/tests/shake/test.sh"
-    "${LEAN_SOURCE_DIR}/../tests/lake/tests/builtin-lint/test.sh"
-  )
-endif()
+file(
+  GLOB_RECURSE LEANLAKETESTS
+  "${LEAN_SOURCE_DIR}/../tests/lake/examples/test.sh"
+  "${LEAN_SOURCE_DIR}/../tests/lake/tests/test.sh"
+)
 foreach(T ${LEANLAKETESTS})
   if(NOT T MATCHES ".*(lake-packages|bootstrap|toolchain|online).*")
     get_filename_component(T_DIR ${T} DIRECTORY)


### PR DESCRIPTION
This PR re-enables all of the Lake tests by default.  The previous flakiness appears to have been fixed by #13559, as multiple runs of #8580 demonstrate. The `LAKE_CI` CMake setting and the `lake-ci` label is kept to potentially enable expensive Lake tests in the future (e.g., the online tests that are not currently run in CI).
