### PR TITLE
feat: improve diagnostiscs for `grind` local theorems

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/ForallProp.lean
+++ b/src/Lean/Meta/Tactic/Grind/ForallProp.lean
@@ -54,11 +54,6 @@ where
       -- (a → b) = True → b = False → a = False
       pushEqFalse a <| mkApp4 (mkConst ``Grind.eq_false_of_imp_eq_true) a b (← mkEqTrueProof e) (← mkEqFalseProof b)
 
-private def isEqTrueHyp? (proof : Expr) : Option FVarId := Id.run do
-  let_expr eq_true _ p := proof | return none
-  let .fvar fvarId := p | return none
-  return some fvarId
-
 /-- Similar to `mkEMatchTheoremWithKind?`, but swallow any exceptions. -/
 private def mkEMatchTheoremWithKind'? (origin : Origin) (proof : Expr) (kind : EMatchTheoremKind) (prios : SymbolPriorities) : MetaM (Option EMatchTheorem) := do
   try
@@ -72,6 +67,17 @@ private def mkEMatchTheoremWithKind'? (origin : Origin) (proof : Expr) (kind : E
 private def isNewPat (patternsFoundSoFar : Array (List Expr)) (thm' : EMatchTheorem) : Bool :=
   patternsFoundSoFar.all fun ps => thm'.patterns != ps
 
+private partial def getOrigin (proof : Expr) : GoalM Origin := do
+  match_expr proof with
+  | eq_true _ p => getOrigin p
+  | Eq.mp _ _ _ p => getOrigin p
+  | _ =>
+    if let .fvar fvarId := proof then
+      return .fvar fvarId
+    else
+      let idx ← modifyGet fun s => (s.ematch.nextThmIdx, { s with ematch.nextThmIdx := s.ematch.nextThmIdx + 1 })
+      return .local ((`local).appendIndexAfter idx)
+
 /--
 Given a proof of an `EMatchTheorem`, returns `true`, if there are no
 anchor references restricting the search, or there is an anchor
@@ -84,11 +90,7 @@ def checkAnchorRefsEMatchTheoremProof (proof : Expr) : GrindM Bool := do
 
 private def addLocalEMatchTheorems (e : Expr) : GoalM Unit := do
   let proof ← mkEqTrueProof e
-  let origin ← if let some fvarId := isEqTrueHyp? proof then
-    pure <| .fvar fvarId
-  else
-    let idx ← modifyGet fun s => (s.ematch.nextThmIdx, { s with ematch.nextThmIdx := s.ematch.nextThmIdx + 1 })
-    pure <| .local ((`local).appendIndexAfter idx)
+  let origin ← getOrigin proof
   let proof := mkOfEqTrueCore e proof
   -- **Note**: Do we really need to restrict the instantiation of local theorems?
   -- **Note**: Should we distinguish anchors restricting case-splits and local theorems?

--- a/src/Lean/Meta/Tactic/Grind/Main.lean
+++ b/src/Lean/Meta/Tactic/Grind/Main.lean
@@ -180,7 +180,15 @@ structure Result where
 private def countersToMessageData (header : String) (cls : Name) (data : Array (Name × Nat)) : MetaM MessageData := do
   let data := data.qsort fun (d₁, c₁) (d₂, c₂) => if c₁ == c₂ then Name.lt d₁ d₂ else c₁ > c₂
   let data ← data.mapM fun (declName, counter) =>
-    return .trace { cls } m!"{.ofConst (← mkConstWithLevelParams declName)} ↦ {counter}" #[]
+    return .trace { cls } m!"{.ofConstName declName} ↦ {counter}" #[]
+  return .trace { cls } header data
+
+private def countersWithOriginToMessageData (header : String) (cls : Name) (data : Array (Origin × Name × Nat)) : MetaM MessageData := do
+  let data := data.qsort fun (_, n₁, c₁) (_, n₂, c₂) => if c₁ == c₂ then Name.lt n₁ n₂ else c₁ > c₂
+  let data ← data.mapM fun (origin, name, counter) =>
+    match origin with
+    | .decl _ => return .trace { cls } m!"{.ofConstName name} ↦ {counter}" #[]
+    | _ => return .trace { cls } m!"{name} ↦ {counter}" #[]
   return .trace { cls } header data
 
 private def splitDiagInfoToMessageData (ss : Array SplitDiagInfo) : MetaM MessageData := do
@@ -199,15 +207,19 @@ private def splitDiagInfoToMessageData (ss : Array SplitDiagInfo) : MetaM Messag
 
 -- Diagnostics information for the whole search
 private def mkGlobalDiag (cs : Counters) (simp : Simp.Stats) (ss : PArray SplitDiagInfo) : MetaM (Option MessageData) := do
-  let thms := cs.thm.toList.toArray.filterMap fun (origin, c) =>
-    match origin with
-    | .decl declName => some (declName, c)
-    | _ => none
   -- We do not report `cases` applications on builtin types
   let cases := cs.case.toList.toArray.filter fun (declName, _) => !isBuiltinEagerCases declName
   let mut msgs := #[]
-  unless thms.isEmpty do
-    msgs := msgs.push <| (← countersToMessageData "E-Matching instances" `thm thms)
+  unless cs.thm.isEmpty do
+    let thms := cs.thm.toList.toArray.map fun (origin, c) => Id.run do
+      match origin with
+      | .fvar fvarId =>
+        let some userName := cs.fvarUserNames.find? fvarId | unreachable!
+        return (origin, userName, c)
+      | .decl n => return (origin, n, c)
+      | .local n => return (origin, n, c)
+      | .stx n _ => return (origin, n, c)
+    msgs := msgs.push <| (← countersWithOriginToMessageData "E-Matching instances" `thm thms)
   let ss := ss.toArray.filter fun { numCases, .. } => numCases > 1
   unless ss.isEmpty do
     msgs := msgs.push <| (← splitDiagInfoToMessageData ss)

--- a/src/Lean/Meta/Tactic/Grind/Types.lean
+++ b/src/Lean/Meta/Tactic/Grind/Types.lean
@@ -201,6 +201,11 @@ instance : Hashable CongrTheoremCacheKey where
 structure Counters where
   /-- Number of times E-match theorem has been instantiated. -/
   thm  : PHashMap Origin Nat := {}
+  /--
+  User names for theorem origins that are `.fvar`s. We need to store this information
+  because subgoals are created while we are solving subgoals.
+  -/
+  fvarUserNames : PHashMap FVarId Name := {}
   /-- Number of times a `cases` has been performed on an inductive type/predicate -/
   case : PHashMap Name Nat := {}
   /-- Number of applications per function symbol. This information is only collected if `set_option diagnostics true` -/
@@ -398,6 +403,12 @@ private def incCounter [Hashable α] [BEq α] (s : PHashMap α Nat) (k : α) : P
       s.insert k 1
 
 private def saveEMatchTheorem (thm : EMatchTheorem) : GrindM Unit := do
+  if let .fvar fvarId := thm.origin then
+    unless (← get).counters.fvarUserNames.contains fvarId do
+      let userName ← fvarId.getUserName
+      modify fun s => { s with
+        counters.fvarUserNames := s.counters.fvarUserNames.insert fvarId userName
+      }
   modify fun s => { s with counters.thm := incCounter s.counters.thm thm.origin }
 
 def getEMatchTheoremNumInstances (thm : EMatchTheorem) : GrindM Nat := do


### PR DESCRIPTION
This PR improves the `grind` diagnostics output so that local hypotheses used
as E-matching theorems show up with their user-facing names and instantiation
counters, instead of being silently dropped or reported under an anonymous
`local.<idx>` identifier.

Previously, `mkGlobalDiag` filtered the `E-Matching instances` table down to
origins of the form `.decl declName`, discarding every counter coming from a
local hypothesis (`.fvar`, `.local`, `.stx`). Even when an origin was kept, the
local-theorem path in `addLocalEMatchTheorems` only recognized `eq_true h` for
a bare `h : fvar` and fell back to a synthetic `.local <idx>` origin in all
other cases, including the common one where the proof has been wrapped by an
`Eq.mp` cast.
