### PR TITLE
test: always clean full `.lake`

### DIFF
--- a/tests/pkg/builtin_attr/run_test.sh
+++ b/tests/pkg/builtin_attr/run_test.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build

--- a/tests/pkg/cbv_attr/run_test.sh
+++ b/tests/pkg/cbv_attr/run_test.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build

--- a/tests/pkg/collectAxioms/run_test.sh
+++ b/tests/pkg/collectAxioms/run_test.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build

--- a/tests/pkg/debug/run_test.sh
+++ b/tests/pkg/debug/run_test.sh
@@ -1,4 +1,4 @@
-rm -rf .lake/build
+rm -rf .lake
 
 run lake exe release
 run_fail lake exe debug

--- a/tests/pkg/def_clash/clean.sh
+++ b/tests/pkg/def_clash/clean.sh
@@ -1,2 +1,2 @@
-rm -rf lake-manifest.json .lake/build
-rm -rf deps/fooA/.lake/build deps/fooB/.lake/build deps/useA/.lake/build deps/useB/.lake/build
+rm -rf lake-manifest.json .lake
+rm -rf deps/fooA/.lake deps/fooB/.lake deps/useA/.lake deps/useB/.lake

--- a/tests/pkg/deprecated_arg/run_test.sh
+++ b/tests/pkg/deprecated_arg/run_test.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build

--- a/tests/pkg/deprecated_module/run_test.sh
+++ b/tests/pkg/deprecated_module/run_test.sh
@@ -1,4 +1,4 @@
-rm -rf .lake/build
+rm -rf .lake
 
 # Build Main library — includes all test modules
 capture lake build Main

--- a/tests/pkg/deprecated_option/run_test.sh
+++ b/tests/pkg/deprecated_option/run_test.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build

--- a/tests/pkg/deriving/run_test.sh
+++ b/tests/pkg/deriving/run_test.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build

--- a/tests/pkg/frontend/run_test.sh
+++ b/tests/pkg/frontend/run_test.sh
@@ -1,4 +1,4 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build
 
 # Check that we can compile a file which shares with the executable

--- a/tests/pkg/homo/run_test.sh
+++ b/tests/pkg/homo/run_test.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build

--- a/tests/pkg/initialize/run_test.sh
+++ b/tests/pkg/initialize/run_test.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build

--- a/tests/pkg/issue12825/run_test.sh
+++ b/tests/pkg/issue12825/run_test.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build

--- a/tests/pkg/leanchecker/run_test.sh
+++ b/tests/pkg/leanchecker/run_test.sh
@@ -1,4 +1,4 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build
 
 for f in LeanCheckerTests/*.lean; do

--- a/tests/pkg/linter_set/run_test.sh
+++ b/tests/pkg/linter_set/run_test.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build

--- a/tests/pkg/misc/run_test.sh
+++ b/tests/pkg/misc/run_test.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build

--- a/tests/pkg/module/run_test.sh
+++ b/tests/pkg/module/run_test.sh
@@ -1,4 +1,4 @@
-rm -rf .lake/build
+rm -rf .lake
 LEAN_ABORT_ON_PANIC=1 lake build
 
 capture_fail lake lean Module/ConflictingImported.lean

--- a/tests/pkg/path with spaces/run_test.sh
+++ b/tests/pkg/path with spaces/run_test.sh
@@ -1,4 +1,4 @@
-rm -rf .lake/build
+rm -rf .lake
 lake exe "path with spaces"
 # presence of this file should not break process spawn
 touch .lake/build/bin/path

--- a/tests/pkg/prv/run_test.sh
+++ b/tests/pkg/prv/run_test.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build

--- a/tests/pkg/rebuild/run_test.sh
+++ b/tests/pkg/rebuild/run_test.sh
@@ -1,4 +1,4 @@
-rm -rf .lake/build
+rm -rf .lake
 
 mkdir -p Rebuild
 cat <<EOF > Rebuild/Basic.lean

--- a/tests/pkg/signal/run_test.sh
+++ b/tests/pkg/signal/run_test.sh
@@ -1,4 +1,4 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build release
 
 # Create a named pipe for communication

--- a/tests/pkg/structure_docstrings/run_test.sh
+++ b/tests/pkg/structure_docstrings/run_test.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 LEAN_ABORT_ON_PANIC=1 lake build

--- a/tests/pkg/sym_ext/run_test.sh
+++ b/tests/pkg/sym_ext/run_test.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build

--- a/tests/pkg/sym_simp_attr/run_test.sh
+++ b/tests/pkg/sym_simp_attr/run_test.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build

--- a/tests/pkg/test_extern/run_test.sh
+++ b/tests/pkg/test_extern/run_test.sh
@@ -6,7 +6,7 @@
 # Ideally there would be a more principled testing framework
 # that took care of all this!
 
-rm -rf .lake/build
+rm -rf .lake
 
 # TODO Use and/or emulate the helper functions from util.sh?
 

--- a/tests/pkg/user_attr/run_test.sh
+++ b/tests/pkg/user_attr/run_test.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build

--- a/tests/pkg/user_attr_app/run_test.sh
+++ b/tests/pkg/user_attr_app/run_test.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 lake exe user_attr

--- a/tests/pkg/user_ext/run_test.sh
+++ b/tests/pkg/user_ext/run_test.sh
@@ -1,4 +1,4 @@
-rm -rf .lake/build
+rm -rf .lake
 
 capture lake build -v
 check_out_contains 'hello, test, world'

--- a/tests/pkg/user_opt/run_test.sh
+++ b/tests/pkg/user_opt/run_test.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build

--- a/tests/pkg/user_plugin/clean.sh
+++ b/tests/pkg/user_plugin/clean.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 rm -f lake-manifest.json


### PR DESCRIPTION
Ensures we don't reuse outdated config oleans