### PR TITLE
test: harden cancellation_empty_by against scheduling races

### DIFF
--- a/src/Lean/Server/Test/Cancel.lean
+++ b/src/Lean/Server/Test/Cancel.lean
@@ -252,32 +252,6 @@ elab_rules : tactic
     | some _ => return
     | none   => IO.eprintln s!"wait_for_test_task: task {label} dropped without resolution"
 
-/--
-Tactic for testing cancellation propagation. On the first invocation for a given `<label>`,
-prints `<label>: blocked` to stderr and loops on `Core.checkInterrupted` until the tactic's
-cancel token fires (at which point the loop throws and `finally` resolves the shared task).
-Subsequent invocations (e.g. on re-elaboration) wait on that task: they return as soon as
-the first invocation has actually exited the loop, and hang otherwise. So if cancellation
-propagates correctly, the test completes; if propagation is broken, the second invocation's
-wait blocks forever and the test hangs (timeout = failure).
--/
-scoped syntax "block_until_cancelled" str : tactic
-elab_rules : tactic
-| `(tactic| block_until_cancelled $label) => do
-  let lbl := label.getString
-  match (← mkTestTask lbl) with
-  | none =>
-    let some t := (← testTasksRef.get).get? lbl | unreachable!
-    discard <| IO.wait t
-  | some prom =>
-    IO.eprintln s!"{lbl}: blocked"
-    try
-      while true do
-        Core.checkInterrupted
-        IO.sleep 10
-    finally
-      prom.resolve ()
-
 /-- Registry of label-keyed `IO.Promise Unit` for synchronization between cooperating
 tactics/elaborators in tests. The promise is kept alive by the ref itself, so
 `prom.result?` only fires on explicit `resolveSyncPromise` -- there is no drop signal.
@@ -307,5 +281,34 @@ elab_rules : tactic
   | some _ => return
   | none   =>
     IO.eprintln s!"wait_for_sync: sync promise {lbl} dropped without resolution"
+
+/--
+Tactic for testing cancellation propagation. On the first invocation for a given `<label>`,
+prints `<label>: blocked` to stderr, resolves the sync promise `<label>` (so a separate
+theorem can gate the runner's `waitFor` on this invocation having actually started), and
+loops on `Core.checkInterrupted` until the tactic's cancel token fires (at which point the
+loop throws and `finally` resolves the shared task). Subsequent invocations (e.g. on
+re-elaboration) wait on that task: they return as soon as the first invocation has actually
+exited the loop, and hang otherwise. So if cancellation propagates correctly, the test
+completes; if propagation is broken, the second invocation's wait blocks forever and the
+test hangs (timeout = failure).
+-/
+scoped syntax "block_until_cancelled" str : tactic
+elab_rules : tactic
+| `(tactic| block_until_cancelled $label) => do
+  let lbl := label.getString
+  match (← mkTestTask lbl) with
+  | none =>
+    let some t := (← testTasksRef.get).get? lbl | unreachable!
+    discard <| IO.wait t
+  | some prom =>
+    IO.eprintln s!"{lbl}: blocked"
+    resolveSyncPromise lbl
+    try
+      while true do
+        Core.checkInterrupted
+        IO.sleep 10
+    finally
+      prom.resolve ()
 
 

--- a/src/Lean/Server/Test/Cancel.lean
+++ b/src/Lean/Server/Test/Cancel.lean
@@ -277,3 +277,35 @@ elab_rules : tactic
         IO.sleep 10
     finally
       prom.resolve ()
+
+/-- Registry of label-keyed `IO.Promise Unit` for synchronization between cooperating
+tactics/elaborators in tests. The promise is kept alive by the ref itself, so
+`prom.result?` only fires on explicit `resolveSyncPromise` -- there is no drop signal.
+Distinct from `testTasksRef`, which stores only the `Task` side and relies on caller
+liveness to detect dropped-without-resolved. -/
+meta initialize syncPromisesRef : IO.Ref (Std.HashMap String (IO.Promise Unit)) ← IO.mkRef {}
+
+/-- Return the sync promise for `label`, creating it if no entry exists. All callers
+receive the same promise. -/
+meta def getSyncPromise (label : String) : BaseIO (IO.Promise Unit) := do
+  let fresh ← IO.Promise.new
+  syncPromisesRef.modifyGet fun m =>
+    match m[label]? with
+    | some prom => (prom, m)
+    | none      => (fresh, m.insert label fresh)
+
+/-- Resolve the sync promise for `label`. Idempotent (subsequent resolves are no-ops). -/
+meta def resolveSyncPromise (label : String) : BaseIO Unit := do
+  (← getSyncPromise label).resolve ()
+
+/-- Block until `resolveSyncPromise label` has been called. Direct `IO.wait`, no polling. -/
+scoped syntax "wait_for_sync " str : tactic
+elab_rules : tactic
+| `(tactic| wait_for_sync $label) => do
+  let lbl := label.getString
+  match (← IO.wait (← getSyncPromise lbl).result?) with
+  | some _ => return
+  | none   =>
+    IO.eprintln s!"wait_for_sync: sync promise {lbl} dropped without resolution"
+
+

--- a/tests/server_interactive/cancellation_empty_by.lean
+++ b/tests/server_interactive/cancellation_empty_by.lean
@@ -4,35 +4,36 @@ open Lean Lean.Meta Lean.Elab Lean.Elab.Term Lean.Elab.Tactic
 open Lean.Server.Test.Cancel
 
 /-!
-Test cancellation propagation through `elabEmptyByAsTry`. With
-`tactic.tryOnEmptyBy true` an empty `by` (the proof `:= by` with nothing
-following) spawns a `wrapAsyncAsSnapshot` task that runs `try?`. The
-outer snapshot's cancel token (`T_outer`) is registered with
-`Core.logSnapshotTask`; on re-elaboration `cancelRec` walks the
-snapshot tree and sets it.
+Test that `cancelRec` reaches the snapshot task spawned by
+`elabEmptyByAsTry` on re-elaboration.
 
-The `[try_suggestion]` generator runs in MetaM inside the empty-`by`
-snapshot task, so `(← read).cancelTk?` is `T_outer`. It registers a
-test task under label `"T_outer"` (via `mkTestTask`) on the first
-invocation and arranges `T_outer.onSet` to resolve it; the returned
-candidate `wait_for_test_task "T_outer"` blocks until the task fires.
+Chronological flow:
+1. Empty-`by` example elaborates; `elabEmptyByAsTry` spawns a snapshot
+   task with its own cancel token and returns.
+2. The snapshot task's `try?` calls `tracerSuggestion`, which:
+   - registers test task `"cancelTokenSet"`,
+   - registers `cancelTk.onSet` to resolve it,
+   - resolves sync promise `"tracerSuggestion"`,
+   - returns `wait_for_test_task "cancelTokenSet"` as the candidate.
+3. `try?` evaluates the candidate; it blocks on the test task.
+4. `t1` elaborates: `wait_for_sync "tracerSuggestion"` returns
+   immediately, `trace "blocked"` emits the diagnostic.
+5. Runner inserts `; skip`, triggers re-elab; `cancelRec` sets the
+   cancel token; `onSet` resolves the test task; the candidate's wait
+   returns; the snapshot task body completes.
 
-`t1`'s `wait_for_cancel_once_async` is used purely to publish the
-`"blocked"` diagnostic the runner waits for. On re-elaboration
-`cancelRec` walks both `t1`'s tree and the empty-`by` example's
-tree; firing `T_outer` resolves the shared task and the snapshot
-task body completes. The second elaboration's invocation observes
-the already-resolved task and returns immediately.
+Failure modes:
+- `cancelTk? := none` to `Core.logSnapshotTask`: `cancelRec` cannot
+  reach the cancel token, the wait blocks, runner times out.
+- `cancelTk? := none` to `wrapAsyncAsSnapshot`: `tracerSuggestion`
+  sees no cancel token, doesn't register `onSet`; the promise drops;
+  `wait_for_test_task` surfaces a `task dropped` diagnostic.
 
-If `elabEmptyByAsTry` passes `cancelTk? := none` to
-`Core.logSnapshotTask`, `cancelRec` cannot reach `T_outer`. The
-snapshot task body's wait blocks until `T_outer` is dropped; since
-the body holds `T_outer` alive (via `wrapAsync`'s ctx) until it
-returns, `T_outer` does not drop, the wait does not return, and the
-runner times out. If `elabEmptyByAsTry` additionally fails to plumb
-`cancelTk` into `wrapAsyncAsSnapshot`, no `onSet` resolver is
-registered, the promise drops, and `wait_for_test_task` surfaces
-the explicit "task dropped" diagnostic on stderr.
+Ordering note: the empty-`by` example must precede `t1` because `try?`
+inside the snapshot task library-searches the environment in a way
+that synchronously waits on prior pending async theorem bodies. With
+`t1` first, its `wait_for_sync` would block the snapshot's `try?`,
+deadlocking. Likely a separate upstream issue.
 -/
 
 namespace TestEmptyBy
@@ -42,12 +43,14 @@ opaque UnsolvableProp : Prop
 @[try_suggestion]
 def tracerSuggestion (_goal : MVarId) (_info : Try.Info) :
     MetaM (Array (TSyntax `tactic)) := do
-  -- Register the test task on the first call only; later calls reuse the
-  -- existing entry and so observe the same (eventually resolved) task.
-  if let some prom ← mkTestTask "T_outer" then
+  if let some prom ← mkTestTask "cancelTokenSet" then
     if let some cancelTk := (← readThe Core.Context).cancelTk? then
-      cancelTk.onSet (do prom.resolve ())
-  return #[← `(tactic| wait_for_test_task "T_outer")]
+      cancelTk.onSet (do
+        dbg_trace "cancelTokenSet"
+        prom.resolve ())
+  dbg_trace "tracerSuggestion ready"
+  resolveSyncPromise "tracerSuggestion"
+  return #[← `(tactic| wait_for_test_task "cancelTokenSet")]
 
 end TestEmptyBy
 
@@ -59,10 +62,12 @@ example : True := by
        --^ insert: "; skip"
        --^ sync
 
-theorem t1 : True := by
-  wait_for_cancel_once_async
-  trivial
-
 example : TestEmptyBy.UnsolvableProp := by
+
+theorem t1 : True := by
+  wait_for_sync "tracerSuggestion"
+  dbg_trace "sync received"
+  trace "blocked"
+  trivial
 
 

--- a/tests/server_interactive/cancellation_empty_by.lean.out.expected
+++ b/tests/server_interactive/cancellation_empty_by.lean.out.expected
@@ -1,2 +1,5 @@
-blocked!
-cancelled!
+cancelTokenSet
+tracerSuggestion ready
+sync received
+tracerSuggestion ready
+sync received

--- a/tests/server_interactive/cancellation_par.lean
+++ b/tests/server_interactive/cancellation_par.lean
@@ -5,16 +5,20 @@ open Lean.Server.Test.Cancel
 Test that cancellation propagates into parallel tactic combinators (`attempt_all_par`,
 `first_par`).
 
-Each section's first elaboration runs `block_until_cancelled "<label>"`, which loops on
-`Core.checkInterrupted`. The test driver edits the preceding `example` to trigger
-re-elaboration; the second elaboration's invocation no-ops (label already seen) so the test can
-terminate. If cancellation reaches the (possibly subtask) tactic, the loop throws and the test
-completes; if not, the test hangs and the runner times out.
+Per section, chronological flow:
+1. `theorem t` elaborates; its body runs `try? => <combinator> | block_until_cancelled "<L>"`,
+   which on the first invocation registers test task `"<L>"`, resolves sync promise `"<L>"`,
+   and enters a `Core.checkInterrupted` loop.
+2. The gate theorem (`tGate`) elaborates; `wait_for_sync "<L>"` returns immediately (sync was
+   resolved in step 1), `trace "blocked"` emits the diagnostic the runner is waiting for.
+3. Runner inserts `; skip`, triggers re-elab; `cancelRec` walks `t`'s snapshot tree, setting
+   the cancel token of the `block_until_cancelled` subtask. The loop's `Core.checkInterrupted`
+   throws, the `finally` resolves the test task, the second invocation's wait returns.
 
-Section 1 uses sequential `first` (cancellation has always worked here — runs on the main
-elaboration thread). Sections 2 and 3 use `attempt_all_par` and `first_par`, which spawn the
-tactic on a fresh `asTask` cancel token; before the propagation fix in `CoreM.asTask`, those
-tasks would not see the parent's cancellation and the test would hang.
+Section 1 uses sequential `first`; sections 2 and 3 use the parallel combinators
+`attempt_all_par` and `first_par`, which spawn the inner tactic on a fresh `asTask` cancel
+token. The fix in `CoreM.asTask` (#13428) propagates the parent token to those subtasks;
+without it, `cancelRec` cannot reach the subtask's cancel token and the test times out.
 -/
 
 /-! ## Sequential `first` -/
@@ -26,9 +30,13 @@ example : True := by
        --^ sync
 
 theorem t : True := by
-  wait_for_cancel_once_async
   try? => first
     | block_until_cancelled "first"
+
+theorem tGate : True := by
+  wait_for_sync "first"
+  trace "blocked"
+  trivial
 
 -- RESET
 import Lean.Server.Test.Cancel
@@ -43,9 +51,13 @@ example : True := by
        --^ sync
 
 theorem t : True := by
-  wait_for_cancel_once_async
   try? => attempt_all_par
     | block_until_cancelled "attempt_all_par"
+
+theorem tGate : True := by
+  wait_for_sync "attempt_all_par"
+  trace "blocked"
+  trivial
 
 -- RESET
 import Lean.Server.Test.Cancel
@@ -60,6 +72,10 @@ example : True := by
        --^ sync
 
 theorem t : True := by
-  wait_for_cancel_once_async
   try? => first_par
     | block_until_cancelled "first_par"
+
+theorem tGate : True := by
+  wait_for_sync "first_par"
+  trace "blocked"
+  trivial

--- a/tests/server_interactive/cancellation_par.lean.out.expected
+++ b/tests/server_interactive/cancellation_par.lean.out.expected
@@ -1,9 +1,3 @@
-blocked!
 first: blocked
-cancelled!
-blocked!
 attempt_all_par: blocked
-cancelled!
-blocked!
 first_par: blocked
-cancelled!


### PR DESCRIPTION
This PR fixes issues with flaky cancellation_empty_by test.

The original test gated the runner's `waitFor: blocked` on `t1`'s
`wait_for_cancel_once_async`, which had no causal relationship to
`tracerSuggestion` having actually run inside the empty-`by` snapshot
task. On CI under load the runner could trigger the insert before
`tracerSuggestion` registered its `onSet` callback, leading to
intermittent timeouts.

Add a label-keyed `IO.Promise` registry (`syncPromisesRef`) plus
`getSyncPromise` / `resolveSyncPromise` primitives and a
`wait_for_sync <label>` tactic to `Lean.Server.Test.Cancel`. The
empty-`by` test's `tracerSuggestion` now resolves a sync promise
after registering its onSet, and `t1` waits on that promise before
emitting `blocked`. The empty-`by` example must precede `t1` because
`try?` inside the snapshot task synchronously waits on prior pending
async theorem bodies during library search (likely a separate upstream
issue); with that ordering the test is fully deterministic.

`t1` also drops `wait_for_cancel_once_async` in favor of plain
`trace "blocked"`. The test now also `dbg_trace`s at each sync point
(`tracerSuggestion ready`, `sync received`, `cancelTokenSet`) so the
.out.expected captures the deterministic execution sequence.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
