### PR TITLE
fix: abort `waitFor` server_interactive tests promptly on file worker fatal error

### DIFF
--- a/src/Lean/Data/Lsp/Ipc.lean
+++ b/src/Lean/Data/Lsp/Ipc.lean
@@ -63,20 +63,7 @@ def shutdown (requestNo : Nat) : IpcM Unit := do
       pure ()
 
 def readMessage : IpcM JsonRpc.Message := do
-  let msg ← (←stdout).readLspMessage
-  -- Abort promptly if the server reports the file worker has crashed
-  -- (`$/lean/fileProgress` with `fatalError` kind). Without this, test
-  -- runners that loop reading messages -- e.g. `waitForMessage` -- would
-  -- discard the fatalError notification and block forever waiting for a
-  -- message the dead worker can never produce. `collectDiagnostics` and
-  -- `waitForILeans` already handle this via the `responseError` the
-  -- watchdog sends to their pending requests; this check covers the
-  -- request-less loops.
-  if let .notification "$/lean/fileProgress" (some param) := msg then
-    if let .ok (p : LeanFileProgressParams) := fromJson? (toJson param) then
-      if p.processing.any (·.kind == .fatalError) then
-        throw <| IO.userError "Lean file worker reported a fatal error (likely crashed)"
-  return msg
+  (←stdout).readLspMessage
 
 def readRequestAs (expectedMethod : String) (α) [FromJson α] : IpcM (Request α) := do
   (←stdout).readLspRequestAs expectedMethod α
@@ -197,6 +184,11 @@ partial def waitForWatchdogILeans (waitForILeansId : RequestID := 0) : IpcM Unit
 /--
 Waits for a diagnostic notification with a specific message to be emitted. Discards all received
 messages, so should not be combined with `collectDiagnostics`.
+
+If the server reports a `$/lean/fileProgress` notification with `fatalError` kind, this aborts
+with an error rather than blocking forever: the message we are waiting for will never be
+produced (the worker either crashed or its header processing failed fatally, so no body
+elaboration will run).
 -/
 partial def waitForMessage (msg : String) : IpcM Unit := do
   loop
@@ -210,6 +202,12 @@ where
           return
         loop
       | Except.error inner => throw $ userError s!"Cannot decode publishDiagnostics parameters\n{inner}"
+    | Message.notification "$/lean/fileProgress" (some param) =>
+      if let .ok (p : LeanFileProgressParams) := fromJson? (toJson param) then
+        if p.processing.any (·.kind == .fatalError) then
+          throw <| userError s!"waitForMessage: \
+            server reported fatalError before message {repr msg} was emitted"
+      loop
     | _ => loop
 
 structure CallHierarchy where

--- a/src/Lean/Data/Lsp/Ipc.lean
+++ b/src/Lean/Data/Lsp/Ipc.lean
@@ -181,35 +181,6 @@ partial def waitForWatchdogILeans (waitForILeansId : RequestID := 0) : IpcM Unit
     | _ =>
       pure ()
 
-/--
-Waits for a diagnostic notification with a specific message to be emitted. Discards all received
-messages, so should not be combined with `collectDiagnostics`.
-
-If the server reports a `$/lean/fileProgress` notification with `fatalError` kind, this aborts
-with an error rather than blocking forever: the message we are waiting for will never be
-produced (the worker either crashed or its header processing failed fatally, so no body
-elaboration will run).
--/
-partial def waitForMessage (msg : String) : IpcM Unit := do
-  loop
-where
-  loop := do
-    match (←readMessage) with
-    | Message.notification "textDocument/publishDiagnostics" (some param) =>
-      match fromJson? (α := PublishDiagnosticsParams) (toJson param) with
-      | Except.ok diagnosticParam =>
-        if diagnosticParam.diagnostics.any (·.message == msg) then
-          return
-        loop
-      | Except.error inner => throw $ userError s!"Cannot decode publishDiagnostics parameters\n{inner}"
-    | Message.notification "$/lean/fileProgress" (some param) =>
-      if let .ok (p : LeanFileProgressParams) := fromJson? (toJson param) then
-        if p.processing.any (·.kind == .fatalError) then
-          throw <| userError s!"waitForMessage: \
-            server reported fatalError before message {repr msg} was emitted"
-      loop
-    | _ => loop
-
 structure CallHierarchy where
   item       : CallHierarchyItem
   fromRanges : Array Range

--- a/src/Lean/Data/Lsp/Ipc.lean
+++ b/src/Lean/Data/Lsp/Ipc.lean
@@ -63,7 +63,20 @@ def shutdown (requestNo : Nat) : IpcM Unit := do
       pure ()
 
 def readMessage : IpcM JsonRpc.Message := do
-  (←stdout).readLspMessage
+  let msg ← (←stdout).readLspMessage
+  -- Abort promptly if the server reports the file worker has crashed
+  -- (`$/lean/fileProgress` with `fatalError` kind). Without this, test
+  -- runners that loop reading messages -- e.g. `waitForMessage` -- would
+  -- discard the fatalError notification and block forever waiting for a
+  -- message the dead worker can never produce. `collectDiagnostics` and
+  -- `waitForILeans` already handle this via the `responseError` the
+  -- watchdog sends to their pending requests; this check covers the
+  -- request-less loops.
+  if let .notification "$/lean/fileProgress" (some param) := msg then
+    if let .ok (p : LeanFileProgressParams) := fromJson? (toJson param) then
+      if p.processing.any (·.kind == .fatalError) then
+        throw <| IO.userError "Lean file worker reported a fatal error (likely crashed)"
+  return msg
 
 def readRequestAs (expectedMethod : String) (α) [FromJson α] : IpcM (Request α) := do
   (←stdout).readLspRequestAs expectedMethod α

--- a/src/Lean/Server/Test/Runner.lean
+++ b/src/Lean/Server/Test/Runner.lean
@@ -482,9 +482,43 @@ def processSync : RunnerM Unit := do
   advanceRequestNo
   setSynced
 
+/--
+Waits for a `textDocument/publishDiagnostics` notification with a specific message to be emitted.
+Discards all received messages, so should not be combined with `Ipc.collectDiagnostics`. Used to
+implement the `waitFor` test directive.
+
+If the server reports a `$/lean/fileProgress` notification with `fatalError` kind, this aborts
+with an error rather than blocking forever: the message we are waiting for will never be
+produced (the worker either crashed or its header processing failed fatally, so no body
+elaboration will run).
+
+Kept here rather than in `Lean.Lsp.Ipc` because it is specifically a test-driver helper rather
+than a general-purpose IPC primitive.
+-/
+partial def waitForMessage (msg : String) : Ipc.IpcM Unit := do
+  loop
+where
+  loop := do
+    match (← Ipc.readMessage) with
+    | Message.notification "textDocument/publishDiagnostics" (some param) =>
+      match fromJson? (α := PublishDiagnosticsParams) (toJson param) with
+      | Except.ok diagnosticParam =>
+        if diagnosticParam.diagnostics.any (·.message == msg) then
+          return
+        loop
+      | Except.error inner =>
+        throw <| IO.userError s!"Cannot decode publishDiagnostics parameters\n{inner}"
+    | Message.notification "$/lean/fileProgress" (some param) =>
+      if let .ok (p : LeanFileProgressParams) := fromJson? (toJson param) then
+        if p.processing.any (·.kind == .fatalError) then
+          throw <| IO.userError s!"waitForMessage: \
+            server reported fatalError before message {repr msg} was emitted"
+      loop
+    | _ => loop
+
 def processWaitFor : RunnerM Unit := do
   let s ← get
-  let _ ← Ipc.waitForMessage s.params
+  let _ ← waitForMessage s.params
   setSynced
 
 def processCodeAction : RunnerM Unit := do

--- a/tests/server_interactive/run_test.sh
+++ b/tests/server_interactive/run_test.sh
@@ -2,10 +2,12 @@
 # TODO: investigate or work around
 export ASAN_OPTIONS=detect_leaks=0
 
+source_init "$1"
+
 # these tests don't have to succeed
 capture_only "$1" \
   lean -Dlinter.all=false --run run_test.lean "$1"
 normalize_mvar_suffixes
 normalize_reference_urls
 check_out_file
-check_exit_is_success
+check_exit_is "${TEST_EXIT:-0}"

--- a/tests/server_interactive/worker_crash.lean
+++ b/tests/server_interactive/worker_crash.lean
@@ -1,0 +1,23 @@
+import Lean
+open Lean Elab Command
+
+/-!
+Regression test for `Ipc.waitForMessage` on a `$/lean/fileProgress fatalError`
+notification: the runner must abort instead of blocking on a diagnostic that
+can never be emitted by a dead worker.
+
+The `crash_now` command terminates the file worker via `IO.Process.forceExit`,
+so the `waitFor` directive on the line after it cannot succeed normally. The
+watchdog reacts by sending `fileProgress` with `kind = fatalError`, which
+`waitForMessage` picks up and turns into a Lean-level exception. The test
+framework checks `TEST_EXIT=1` and the resulting error message via
+`.out.expected`.
+
+Avoid mentioning the literal directive syntax in this docstring -- the runner
+parses every line containing `--` looking for a directive.
+-/
+
+elab "crash_now" : command => IO.Process.forceExit 9
+
+crash_now
+   --^ waitFor: nope

--- a/tests/server_interactive/worker_crash.lean.init.sh
+++ b/tests/server_interactive/worker_crash.lean.init.sh
@@ -1,0 +1,1 @@
+TEST_EXIT=1

--- a/tests/server_interactive/worker_crash.lean.out.expected
+++ b/tests/server_interactive/worker_crash.lean.out.expected
@@ -1,0 +1,2 @@
+uncaught exception: waitForMessage: server reported fatalError before message "nope" was emitted
+Watchdog error: Cannot read LSP message: Stream was closed


### PR DESCRIPTION
This PR makes the test-only `waitForMessage` helper abort promptly
when the Lean language server reports a fatalError, instead of
blocking until the outer test framework's timeout kills the process.

`waitForMessage` is used to implement the `waitFor` directive in
`tests/server_interactive` tests: it reads server messages in a loop
and returns when it sees a `textDocument/publishDiagnostics`
notification containing a given message. It has no pending request,
so the watchdog's `responseError` (which already terminates
`collectDiagnostics` and `waitForILeans` on a fatalError) doesn't
help here, and it would silently discard `$/lean/fileProgress`
notifications. When the file worker crashes or its header processing
fails fatally (e.g. an unresolved import), the awaited diagnostic
will never be emitted -- so `waitForMessage` would block indefinitely
and report nothing useful, which made several CI failures of
server_interactive tests look like generic 1500s timeouts. With this
change, `waitForMessage` also reacts to `$/lean/fileProgress` with
`fatalError` kind and throws a descriptive error.

The detection is scoped to `waitForMessage` only, not the underlying
`Ipc.readMessage`, so that other IPC paths (notably
`importCompletion.lean`, which intentionally elaborates a file with
an incomplete `import` line and observes the resulting fatalError
fileProgress while still using the alive worker for completion
requests) keep working unchanged. As part of this PR, `waitForMessage`
has been moved out of `Lean.Lsp.Ipc` and into
`Lean.Server.Test.Runner` next to its sole caller `processWaitFor`,
since it is a test-driver helper rather than a general-purpose IPC
primitive (it discards all unrelated messages, which would be unsafe
outside of a test driver).

To exercise the new behavior, `tests/server_interactive/run_test.sh`
now sources `<file>.init.sh` and uses `check_exit_is "${TEST_EXIT:-0}"`,
matching the convention in `tests/compile/`. The new
`worker_crash.lean` test forces the file worker to die via
`IO.Process.forceExit 9` from inside an `elab` command and then
issues a `waitFor` directive that can never be satisfied;
`TEST_EXIT=1` and `.out.expected` capture the abort path. Without
this PR the test would sit at the framework timeout; with this PR it
returns in well under a second.