### PR TITLE
perf: inline assorted declarations used in match_expr

### DIFF
--- a/src/Lean/Elab/MatchExpr.lean
+++ b/src/Lean/Elab/MatchExpr.lean
@@ -176,9 +176,9 @@ partial def generate (discr : Term) (alts : List Alt) (elseAlt : ElseAlt) : Macr
       let discr' ← `(__discr)
       let body ← loop discr' altsNext
       if saveActual then
-        `(if h : ($discr).isApp then let a := Expr.appArg $discr h; let __discr := Expr.appFnCleanup $discr h; $body else $kElse ())
+        `(if h : (($discr).isAppInline) then let a := Expr.appArgInline $discr h; let __discr := Expr.appFnCleanupInline $discr h; $body else $kElse ())
       else
-        `(if h : ($discr).isApp then let __discr := Expr.appFnCleanup $discr h; $body else $kElse ())
+        `(if h : (($discr).isAppInline) then let __discr := Expr.appFnCleanupInline $discr h; $body else $kElse ())
     let mut result := body
     for funName in funNamesToMatch do
       if let some alt := getAltFor? alts funName then

--- a/src/Lean/Expr.lean
+++ b/src/Lean/Expr.lean
@@ -1706,9 +1706,11 @@ def getAutoParamTactic? (e : Expr) : Option Expr :=
     none
 
 /-- Return `true` if `e` is of the form `outParam _` -/
-@[export lean_is_out_param]
 def isOutParam (e : Expr) : Bool :=
   e.isAppOfArity ``outParam 1
+
+@[export lean_is_out_param]
+def isOutParamEx := isOutParam
 
 /-- Return `true` if `e` is of the form `semiOutParam _` -/
 def isSemiOutParam (e : Expr) : Bool :=
@@ -1736,14 +1738,30 @@ Examples:
 - Given `e` of the form `outParam (optParam Nat b)`, `consumeTypeAnnotations e = b`.
 - Given `e` of the form `Nat → outParam (optParam Nat b)`, `consumeTypeAnnotations e = e`.
 -/
-@[export lean_expr_consume_type_annotations]
-partial def consumeTypeAnnotations (e : Expr) : Expr :=
+partial def consumeTypeAnnotations (e : Expr) : Expr := Id.run do
   if e.isOptParam || e.isAutoParam then
-    consumeTypeAnnotations e.appFn!.appArg!
+    let (.app (.app _ e) _) := e | unreachable!
+    consumeTypeAnnotations e
   else if e.isOutParam || e.isSemiOutParam then
-    consumeTypeAnnotations e.appArg!
+    let (.app _ e) := e | unreachable!
+    consumeTypeAnnotations e
   else
     e
+
+@[export lean_expr_consume_type_annotations]
+def consumeTypeAnnotationsEx := consumeTypeAnnotations
+
+-- CPS to enable borrowed value for e, might not be necessary with pseudo projections
+@[specialize]
+partial def consumeTypeAnnotations' (e : Expr) (k : Expr → Expr) : Expr := Id.run do
+  if e.isOptParam || e.isAutoParam then
+    let (.app (.app _ e) _) := e | unreachable!
+    consumeTypeAnnotations e
+  else if e.isOutParam || e.isSemiOutParam then
+    let (.app _ e) := e | unreachable!
+    consumeTypeAnnotations e
+  else
+    k e
 
 /--
 Remove metadata annotations and `outParam`, `optParam`, and `autoParam` applications/annotations from `e`.
@@ -1753,8 +1771,8 @@ Examples:
 - Given `e` of the form `Nat → outParam (optParam Nat b)`, `cleanupAnnotations e = e`.
 -/
 partial def cleanupAnnotations (e : Expr) : Expr :=
-  let e' := e.consumeMData.consumeTypeAnnotations
-  if e' == e then e else cleanupAnnotations e'
+  e.consumeMData.consumeTypeAnnotations' fun e' =>
+    if e' == e then e else cleanupAnnotations e'
 
 /--
 Similar to `appFn`, but also applies `cleanupAnnotations` to resulting function.

--- a/src/Lean/Expr.lean
+++ b/src/Lean/Expr.lean
@@ -848,6 +848,11 @@ def isApp : Expr → Bool
   | app .. => true
   | _      => false
 
+@[inline, inherit_doc isApp]
+def isAppInline : Expr → Bool
+  | app .. => true
+  | _      => false
+
 /-- Return `true` if the given expression is a projection `.proj ..` -/
 def isProj : Expr → Bool
   | proj ..  => true
@@ -936,6 +941,11 @@ def appArg!' : Expr → Expr
   | _         => panic! "application expected"
 
 def appArg (e : Expr) (h : e.isApp) : Expr :=
+  match e, h with
+  | .app _ a, _ => a
+
+@[inline]
+def appArgInline (e : Expr) (h : e.isAppInline) : Expr :=
   match e, h with
   | .app _ a, _ => a
 
@@ -1751,6 +1761,11 @@ Similar to `appFn`, but also applies `cleanupAnnotations` to resulting function.
 This function is used compile the `match_expr` term.
 -/
 def appFnCleanup (e : Expr) (h : e.isApp) : Expr :=
+  match e, h with
+  | .app f _, _ => f.cleanupAnnotations
+
+@[inline]
+def appFnCleanupInline (e : Expr) (h : e.isAppInline) : Expr :=
   match e, h with
   | .app f _, _ => f.cleanupAnnotations
 

--- a/tests/bench/build/run_bench.sh
+++ b/tests/bench/build/run_bench.sh
@@ -30,3 +30,19 @@ WRAPPER_PREFIX="$(realpath fake_root)" WRAPPER_OUT="$OUT" \
   lakeprof record -- \
   "$TEST_DIR/measure.py" -t build -d -a -- \
   make -C "$BUILD_NEXT" -j"$(nproc)" make_stdlib LAKE_EXTRA_ARGS="+Init:olean +Std:olean +Lean:olean +Lake:olean +LakeMain:olean +LeanIR:olean +Leanc:olean +LeanChecker:olean"
+
+
+
+echo
+echo ">"
+echo "> Analyzing lakeprof data..."
+echo ">"
+
+# Lakeprof must be executed in the src dir because it obtains some metadata by
+# calling lake in its current working directory.
+mv lakeprof.log "$SRC_DIR"
+pushd "$SRC_DIR"
+lakeprof report -prc > lakeprof_report.txt
+lakeprof report -pj | jq '{metric: "build/lakeprof/longest build path//wall-clock", value: .[-1][2], unit: "s"}' -c >> "$OUT"
+lakeprof report -rj | jq '{metric: "build/lakeprof/longest rebuild path//wall-clock", value: .[-1][2], unit: "s"}' -c >> "$OUT"
+popd

--- a/tests/bench/build/run_bench.sh
+++ b/tests/bench/build/run_bench.sh
@@ -30,19 +30,3 @@ WRAPPER_PREFIX="$(realpath fake_root)" WRAPPER_OUT="$OUT" \
   lakeprof record -- \
   "$TEST_DIR/measure.py" -t build -d -a -- \
   make -C "$BUILD_NEXT" -j"$(nproc)" make_stdlib LAKE_EXTRA_ARGS="+Init:olean +Std:olean +Lean:olean +Lake:olean +LakeMain:olean +LeanIR:olean +Leanc:olean +LeanChecker:olean"
-
-
-
-echo
-echo ">"
-echo "> Analyzing lakeprof data..."
-echo ">"
-
-# Lakeprof must be executed in the src dir because it obtains some metadata by
-# calling lake in its current working directory.
-mv lakeprof.log "$SRC_DIR"
-pushd "$SRC_DIR"
-lakeprof report -prc > lakeprof_report.txt
-lakeprof report -pj | jq '{metric: "build/lakeprof/longest build path//wall-clock", value: .[-1][2], unit: "s"}' -c >> "$OUT"
-lakeprof report -rj | jq '{metric: "build/lakeprof/longest rebuild path//wall-clock", value: .[-1][2], unit: "s"}' -c >> "$OUT"
-popd

--- a/tests/lean/foo.lean
+++ b/tests/lean/foo.lean
@@ -1,0 +1,18 @@
+import Lean
+
+open Lean Meta
+
+/-
+This code currently compiles to a chain of a lot of inc/dec. If we could infer
+Lean.Expr.cleanupAnnotations to be a pseudo projection it should be possible to just do this
+-/
+
+set_option trace.Compiler.saveImpure true in
+def test (type : Expr) : MetaM Unit := do
+    let_expr Eq _ _ rhs := type | return ()
+    let_expr HAdd.hAdd _ _ _ _ _ rhs := rhs | return ()
+    let_expr OfNat.ofNat _ rhs _ := rhs | return ()
+    let some 1 := getRawNatValue? rhs | return ()
+
+    logInfo "ah"
+


### PR DESCRIPTION
blocked on https://github.com/leanprover/lean4/pull/9929/ 