### PR TITLE
fix: omit empty moreLeancArgs when leanc flags are unset

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1064,8 +1064,8 @@ configure_file(${LEAN_SOURCE_DIR}/stdlib.make.in ${CMAKE_BINARY_DIR}/stdlib.make
 
 # hacky
 function(toml_escape IN OUTVAR)
-  if(IN)
-    string(STRIP "${IN}" OUT)
+  string(STRIP "${IN}" OUT)
+  if(OUT)
     string(REPLACE " " "\", \"" OUT "${OUT}")
     set(${OUTVAR} "\"${OUT}\"" PARENT_SCOPE)
   endif()


### PR DESCRIPTION
This PR fixes toml_escape so it does not emit moreLeancArgs = [""] when internal leanc flags are both empty (the combined placeholder was only whitespace). This led GCC to see an extra empty argv entry and fail with a confusing linker error.
