### PR TITLE
chore: adjust `dev-release` preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,13 +13,13 @@
       "binaryDir": "${sourceDir}/build/release"
     },
     {
-      "name": "dev",
+      "name": "dev-release",
       "displayName": "Default development optimized build config",
       "cacheVariables": {
         "STRIP_BINARIES": "OFF"
       },
       "generator": "Unix Makefiles",
-      "binaryDir": "${sourceDir}/build/dev"
+      "binaryDir": "${sourceDir}/build/release"
     },
     {
       "name": "debug",
@@ -71,8 +71,8 @@
       "configurePreset": "release"
     },
     {
-      "name": "dev",
-      "configurePreset": "dev"
+      "name": "dev-release",
+      "configurePreset": "dev-release"
     },
     {
       "name": "debug",
@@ -98,8 +98,8 @@
       "output": {"outputOnFailure": true, "shortProgress": true}
     },
     {
-      "name": "dev",
-      "configurePreset": "dev",
+      "name": "dev-release",
+      "configurePreset": "dev-release",
       "output": {"outputOnFailure": true, "shortProgress": true}
     },
     {

--- a/doc/make/index.md
+++ b/doc/make/index.md
@@ -31,7 +31,7 @@ cmake --preset release
 make -C build/release -j$(nproc || sysctl -n hw.logicalcpu)
 ```
 
-For development, `cmake --preset dev` is recommended instead.
+For development, `cmake --preset dev-release` (reusing the same `build/release` output directory) is recommended instead.
 
 You can replace `$(nproc || sysctl -n hw.logicalcpu)` with the desired parallelism amount.
 


### PR DESCRIPTION
Use same output directory as `release` to avoid lean-toolchain/CLAUDE.md/... issues, rename preset accordingly