### PR TITLE
fix: use consistent, robust instance-like check in compiler

### DIFF
--- a/src/Lean/Compiler/LCNF/Basic.lean
+++ b/src/Lean/Compiler/LCNF/Basic.lean
@@ -1091,13 +1091,27 @@ def hasLocalInst (type : Expr) : CoreM Bool := do
   | _ => return false
 
 /--
+Returns `true` if `name` should be considered an instance by the compiler.
+
+We use `Meta.getInstanceAttrKind?` to also detect defs that *used* to be instances, e.g. under
+separate compilation. Note that this does not detect private markers hidden by the module system or
+defs that *will* be instances, but we claim this is acceptable here as in the worst case this means
+some missed optimizations.
+
+We don't want to use `@[instance_reducible]` because we use it on many decls that are never
+instances.
+-/
+def isInstanceLike (name : Name) : CoreM Bool := do
+  return (← Meta.getInstanceAttrKind? name).isSome
+
+/--
 Return `true` if `decl` is supposed to be inlined/specialized.
 -/
 def Decl.isTemplateLike (decl : Decl pu) : CoreM Bool := do
   let env ← getEnv
   if !hasNospecializeAttribute env decl.name && (← hasLocalInst decl.type) then
     return true -- `decl` applications will be specialized
-  else if (← isImplicitReducible decl.name) then
+  else if (← isInstanceLike decl.name) then
     return true -- `decl` is "fuel" for code specialization
   else if decl.inlineable || hasSpecializeAttribute env decl.name then
     return true -- `decl` is going to be inlined or specialized

--- a/src/Lean/Compiler/LCNF/LambdaLifting.lean
+++ b/src/Lean/Compiler/LCNF/LambdaLifting.lean
@@ -216,7 +216,7 @@ def eagerLambdaLifting : Pass where
   name       := `eagerLambdaLifting
   run        := fun decls => do
     decls.foldlM (init := #[]) fun decls decl => do
-      if decl.inlineable || (← isImplicitReducible decl.name) then
+      if decl.inlineable || (← isInstanceLike decl.name) then
         return decls.push decl
       else
         return decls ++ (← decl.lambdaLifting (liftInstParamOnly := true) (allowEtaContraction := false) (suffix := `_elam))

--- a/src/Lean/Compiler/LCNF/Simp/InlineCandidate.lean
+++ b/src/Lean/Compiler/LCNF/Simp/InlineCandidate.lean
@@ -69,17 +69,7 @@ def inlineCandidate? (e : LetValue .pure) : SimpM (Option InlineCandidateInfo) :
       By inlining their definitions we would be just generating extra work for the lambda lifter.
       -/
       if (← inBasePhase) then
-        /-
-        We claim it is correct to use `Meta.isInstance` because
-        1. `shouldInline` is called during LCNF compilation, which runs at `addDecl` time
-        2. Any instance referenced in the code was found by type class resolution during elaboration
-        3. For TC resolution to find it, the scope was active during elaboration
-        4. LCNF compilation happens before the scope changes
-
-        We don't want to use `isImplicitReducible` because some `instanceReducible` declarations are
-        **not** instances.
-        -/
-        if (← Meta.isInstance decl.name) then
+        if (← isInstanceLike decl.name) then
           unless decl.name == ``instDecidableEqBool do
             /-
             TODO: remove this hack after we refactor `Decidable` as suggested by Gabriel.

--- a/src/Lean/Compiler/LCNF/Simp/Main.lean
+++ b/src/Lean/Compiler/LCNF/Simp/Main.lean
@@ -76,7 +76,7 @@ def etaPolyApp? (letDecl : LetDecl .pure) : OptionT SimpM (FunDecl .pure) := do
   let .const declName us args := letDecl.value | failure
   let some info := (← getEnv).find? declName | failure
   guard <| (← hasLocalInst info.type)
-  guard <| !(← isImplicitReducible declName)
+  guard <| !(← isInstanceLike declName)
   let some ⟨.pure, decl⟩ ← getDecl? declName | failure
   guard <| decl.getArity > args.size
   let params ← mkNewParams letDecl.type

--- a/src/Lean/Compiler/LCNF/Specialize.lean
+++ b/src/Lean/Compiler/LCNF/Specialize.lean
@@ -398,7 +398,7 @@ mutual
   partial def specializeApp? (e : LetValue .pure) : SpecializeM (Option (LetValue .pure)) := do
     let .const declName us args := e | return none
     if args.isEmpty then return none
-    if (← isImplicitReducible declName) then return none
+    if (← isInstanceLike declName) then return none
     let some specEntry ← getSpecEntry? declName | return none
     unless (← shouldSpecialize specEntry args) do return none
     let some ⟨.pure, decl⟩ ← getDecl? declName | return none


### PR DESCRIPTION
Previously we used both `isInstance` and `isImplicitReducible` in parts but the former is too narrow (scope-dependent) and the latter too broad, so look at `@[instance]` in any scope instead.