### PR TITLE
feat: enter private scope when elaborating proof fields of structure instances

### DIFF
--- a/src/Lean/Elab/StructInst.lean
+++ b/src/Lean/Elab/StructInst.lean
@@ -9,6 +9,7 @@ prelude
 public import Lean.Meta.Structure
 public import Lean.Elab.App
 public import Lean.Elab.StructInstHint
+public import Lean.Elab.SyntheticMVars
 
 public section
 
@@ -741,7 +742,23 @@ private def addStructField (fieldView : ExpandedField) (e : Expr) : StructInstM 
 private def elabStructField (fieldName : Name) (stx : Term) (fieldType : Expr) : StructInstM Expr := do
   let fieldType ← normalizeExpr fieldType
   withTraceNode `Elab.structInst (fun _ => return m!"elaborating field `{fieldName}` : {fieldType}") do
-    elabTermEnsuringType stx fieldType
+    -- Enter private scope if entering proof, analogous to `Term.runTactic`.
+    let wasExporting := (← getEnv).isExporting
+    let isNoLongerExporting ← pure (wasExporting && !(← backward.proofsInPublic.getM)) <&&> isProp fieldType
+    withExporting (isExporting := wasExporting && !isNoLongerExporting) do
+      let e ← elabTermEnsuringType stx fieldType
+      if isNoLongerExporting then
+        -- Force resolution of nested synthetic mvars (e.g. `by` blocks) so any private references
+        -- inside `e` are concrete before we abstract.
+        synthesizeSyntheticMVarsNoPostponing
+        let e ← instantiateMVars e
+        if e.isFVar then
+          return e
+        else
+          withExporting (isExporting := wasExporting) do
+            mkAuxTheorem (cache := !e.hasSorry) fieldType e (zetaDelta := true)
+      else
+        return e
 
 private def addStructFieldMVar (fieldName : Name) (ty : Expr) (kind : MetavarKind := .natural) : StructInstM Expr := do
   let ty ← normalizeExpr ty

--- a/tests/elab/grind_cat2.lean.out.expected
+++ b/tests/elab/grind_cat2.lean.out.expected
@@ -1,2 +1,2 @@
-grind_cat2.lean:179:4-179:14: warning: declaration uses `sorry`
-grind_cat2.lean:244:4-244:19: warning: declaration uses `sorry`
+grind_cat2.lean:183:15-183:20: warning: declaration uses `sorry`
+grind_cat2.lean:248:15-248:20: warning: declaration uses `sorry`

--- a/tests/pkg/module/Module/Basic.lean
+++ b/tests/pkg/module/Module/Basic.lean
@@ -549,6 +549,30 @@ Eq.refl five
 #guard_msgs in
 #print instA._proof_1
 
+/--
+A proof field of a structure instance should have access to the private scope, and the resulting
+proof should be abstracted into an aux theorem.
+-/
+
+public def seven : Nat := 7
+
+public class Seven where
+  proof : seven = 7
+  data : Nat
+
+theorem sevenEqSeven : seven = 7 := rfl
+
+public instance termInstSeven : Seven where
+  proof := sevenEqSeven
+  data := 0
+
+/--
+info: @[implicit_reducible, expose] def termInstSeven : Seven :=
+{ proof := termInstSeven._proof_1, data := 0 }
+-/
+#guard_msgs in
+#print termInstSeven
+
 /-- Setup for #11715. -/
 
 public structure OpOperand2 where


### PR DESCRIPTION
This PR makes structure instance notation enter the private scope when elaborating a field whose type is a proposition, mirroring the existing behavior of `by` blocks, allowing access to private theorem even without `:= by exact ...`.