### PR TITLE
feat: report private inherited declaration in projection notation error

### DIFF
--- a/src/Lean/Elab/App.lean
+++ b/src/Lean/Elab/App.lean
@@ -1432,10 +1432,15 @@ private def resolveLValAux (e : Expr) (eType : Expr) (lval : LVal) : TermElabM L
     -- Then search the environment
     if let some (baseStructName, fullName) ← findMethod? structName (.mkSimple fieldName) then
       return LValResolution.const baseStructName structName fullName levels
-    throwInvalidFieldAt ref fieldName fullName
-      -- Suggest a potential unreachable private name as hint. This does not cover structure
-      -- inheritance, nor `import all`.
-      (declHint := (mkPrivateName env structName).mkStr fieldName)
+    -- In public scope, retry in private scope as error message hint. Does not cover `import all`.
+    let declHint ← (do
+      if env.isExporting then
+        try
+          if let some (_, n) ← withoutExporting <| findMethod? structName (.mkSimple fieldName) then
+            return n
+        catch _ => pure ()
+      return .anonymous)
+    throwInvalidFieldAt ref fieldName fullName (declHint := declHint)
 
   | .forallE .., LVal.fieldName ref fieldName levels suffix? fullRef =>
     let fullName := Name.str `Function fieldName

--- a/tests/pkg/module/Module/Basic.lean
+++ b/tests/pkg/module/Module/Basic.lean
@@ -500,6 +500,21 @@ Note: A private declaration `S.s` (from the current module) exists but would nee
 #guard_msgs in
 @[expose] public def useS (s : S) := s.s
 
+/-! Private dot notation access through structure inheritance should still
+identify the private declaration on the base structure. -/
+
+public structure SDerived extends S
+
+/--
+error: Invalid field `s`: The environment does not contain `SDerived.s`, so it is not possible to project the field `s` from an expression
+  s
+of type `SDerived`
+
+Note: A private declaration `S.s` (from the current module) exists but would need to be public to access here.
+-/
+#guard_msgs in
+@[expose] public def useSDerived (s : SDerived) := s.s
+
 /- `meta` should trump `noncomputable`. -/
 
 noncomputable section


### PR DESCRIPTION
This PR makes projection notation errors always mention a private declaration on a parent structure as the cause when applicable. Previously, for projections that resolved through structure inheritance, the hint was silently omitted, leaving users without the actual cause.

In `resolveLValAux`, when `findMethod?` returns nothing in public scope, retry it under `withoutExporting` so the resolved private name across the structure resolution order can be used as the `declHint` for `mkUnknownIdentifierMessage`. Skip the retry in non-exporting scope, where the hint would be suppressed anyway.