### PR TITLE
feat: implement `textDocument/selectionRange` LSP request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,3 @@ wdErr.txt
 wdIn.txt
 wdOut.txt
 .claude/worktrees/
-
-/vscode-test/

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ wdErr.txt
 wdIn.txt
 wdOut.txt
 .claude/worktrees/
+
+/vscode-test/

--- a/src/Lean/Data/Lsp/Capabilities.lean
+++ b/src/Lean/Data/Lsp/Capabilities.lean
@@ -131,6 +131,7 @@ structure ServerCapabilities where
   renameProvider?           : Option RenameOptions           := none
   workspaceSymbolProvider   : Bool                           := false
   foldingRangeProvider      : Bool                           := false
+  selectionRangeProvider    : Bool                           := false
   semanticTokensProvider?   : Option SemanticTokensOptions   := none
   codeActionProvider?       : Option CodeActionOptions       := none
   inlayHintProvider?        : Option InlayHintOptions        := none

--- a/src/Lean/Data/Lsp/LanguageFeatures.lean
+++ b/src/Lean/Data/Lsp/LanguageFeatures.lean
@@ -550,6 +550,43 @@ structure FoldingRange where
   kind?     : Option FoldingRangeKind := none
   deriving ToJson
 
+structure SelectionRangeAux (Self : Type) where
+  range   : Range
+  parent? : Option Self := none
+  deriving FromJson, ToJson
+
+/-- Selection range result for `textDocument/selectionRange`. Each `SelectionRange` is a linked
+list from innermost to outermost via `parent?`. -/
+inductive SelectionRange where
+  | mk (sr : SelectionRangeAux SelectionRange)
+
+partial instance : ToJson SelectionRange where
+  toJson :=
+    let rec go
+      | SelectionRange.mk sr =>
+        have : ToJson SelectionRange := ⟨go⟩
+        toJson sr
+    go
+
+/-- Required for `Array.getD` and similar operations on `SelectionRange`. -/
+instance : Inhabited SelectionRange where
+  default := .mk { range := default }
+
+/-- Mirrors the `ToJson` instance: uses a `let rec` to provide the recursive instance locally,
+avoiding an attempt to synthesize `FromJson SelectionRange` globally before it is defined. -/
+partial instance : FromJson SelectionRange where
+  fromJson? :=
+    let rec go j : Except String SelectionRange := do
+      have : FromJson SelectionRange := ⟨go⟩
+      let sr : SelectionRangeAux SelectionRange ← fromJson? j
+      return .mk sr
+    go
+
+structure SelectionRangeParams where
+  textDocument : TextDocumentIdentifier
+  positions    : Array Position
+  deriving FromJson, ToJson
+
 structure RenameOptions where
   prepareProvider : Bool := false
   deriving FromJson, ToJson

--- a/src/Lean/Server/FileSource.lean
+++ b/src/Lean/Server/FileSource.lean
@@ -83,6 +83,9 @@ instance : FileSource SemanticTokensRangeParams :=
 instance : FileSource FoldingRangeParams :=
   ⟨fun p => fileSource p.textDocument⟩
 
+instance : FileSource SelectionRangeParams :=
+  ⟨fun p => fileSource p.textDocument⟩
+
 instance : FileSource PlainGoalParams :=
   ⟨fun p => fileSource p.textDocument⟩
 

--- a/src/Lean/Server/FileWorker/RequestHandling.lean
+++ b/src/Lean/Server/FileWorker/RequestHandling.lean
@@ -491,6 +491,46 @@ def handleDocumentColor (_ : DocumentColorParams) :
   -- VS Code one.
   return .pure #[]
 
+/-- Walk the syntax tree collecting all nodes whose range contains `pos`, from innermost to
+outermost. Unlike `Syntax.findStack?`, this accepts non-leaf nodes when none of their children
+cover `pos` (e.g. when `pos` falls on whitespace between tokens). -/
+private partial def findContainingStack (stx : Syntax) (pos : String.Pos.Raw) : List Syntax :=
+  if stx.getRange?.any (·.contains pos) then
+    -- Recurse into the first child (if any) that also contains pos.
+    let childResult : Option (List Syntax) := (Array.range stx.getNumArgs).findSome? fun i =>
+      let sub := findContainingStack stx[i] pos
+      if sub.isEmpty then none else some sub
+    match childResult with
+    | some sub => sub ++ [stx]  -- child chain found; add current node as parent
+    | none => [stx]             -- no child covers pos; this node is the innermost
+  else []
+
+/-- Handles `textDocument/selectionRange`: for each requested position, walks the syntax tree to
+build a `SelectionRange` chain from the innermost enclosing node outward. Waits for all command
+snapshots so that the full file syntax is available. -/
+def handleSelectionRange (p : SelectionRangeParams)
+    : RequestM (RequestTask (Array SelectionRange)) := do
+  let doc ← readDoc
+  let text := doc.meta.text
+  let t := doc.cmdSnaps.waitAll
+  mapTaskCostly t fun (snaps, _) => do
+    let build (lspPos : Lsp.Position) : SelectionRange :=
+      let pos := text.lspPosToUtf8Pos lspPos
+      let fallback : SelectionRange := .mk { range := ⟨lspPos, lspPos⟩ }
+      match snaps.find? (fun s => s.stx.getRange?.any (·.contains pos)) with
+      | none => fallback
+      | some snap =>
+        let stxList := findContainingStack snap.stx pos
+        if stxList.isEmpty then fallback
+        else
+          -- Collect LSP ranges from innermost (leaf) to outermost, deduplicating adjacent equal ranges.
+          let ranges := (stxList.filterMap (fun stx => stx.getRange?.map (·.toLspRange text))).toArray
+          let ranges := ranges.foldl (fun (acc : Array Lsp.Range) r =>
+            if acc.isEmpty || acc.toList.getLast! != r then acc.push r else acc) #[]
+          -- foldr builds the chain with innermost at head (parent? pointing outward).
+          (ranges.foldr (fun r parent? => some (.mk { range := r, parent? })) none).getD fallback
+    return p.positions.map build
+
 builtin_initialize
   registerLspRequestHandler
     "textDocument/waitForDiagnostics"
@@ -543,6 +583,11 @@ builtin_initialize
     FoldingRangeParams
     (Array FoldingRange)
     handleFoldingRange
+  registerLspRequestHandler
+    "textDocument/selectionRange"
+    SelectionRangeParams
+    (Array SelectionRange)
+    handleSelectionRange
   registerLspRequestHandler
     "textDocument/signatureHelp"
     SignatureHelpParams

--- a/src/Lean/Server/ProtocolOverview.lean
+++ b/src/Lean/Server/ProtocolOverview.lean
@@ -236,6 +236,14 @@ def protocolOverview : Array MessageOverview := #[
     description := "Emitted in VS Code when a file is first opened or when it is changed."
   },
   .request {
+    method := "textDocument/selectionRange"
+    direction := .clientToServer
+    kinds := #[.standard]
+    parameterType := SelectionRangeParams
+    responseType := Array SelectionRange
+    description := "Emitted in VS Code when the user expands or shrinks the selection with Shift+Alt+Right or Shift+Alt+Left."
+  },
+  .request {
     method := "textDocument/documentColor"
     direction := .clientToServer
     kinds := #[.standard]

--- a/src/Lean/Server/Test/Runner.lean
+++ b/src/Lean/Server/Test/Runner.lean
@@ -323,6 +323,7 @@ structure RunnerState where
   params : String
   versionNo : Nat
   requestNo : Nat
+  sourceLines : Array String.Slice := #[]
 
 abbrev RunnerM := StateT RunnerState Ipc.IpcM
 
@@ -666,6 +667,50 @@ def processInlayHints : RunnerM Unit := do
   }
   logResponse "textDocument/inlayHint" p
 
+/-- Extracts the source text covered by `r` from `lines`. Uses character counts (Unicode code
+    points), which matches UTF-16 LSP positions for all characters in the BMP. Newlines in
+    multi-line ranges are replaced with `↵`.
+    Source files with characters outside BMP are unsupported. -/
+private def extractRangeText (lines : Array String.Slice) (r : Lsp.Range) : String :=
+  let getLine i := (lines.getD i default).copy
+  if r.start.line == r.end.line then
+    let line := getLine r.start.line
+    ((line.drop r.start.character).take (r.end.character - r.start.character)).copy
+  else
+    let n := r.end.line + 1 - r.start.line
+    let parts := (Array.range n).map fun j =>
+      let i := r.start.line + j
+      let line := getLine i
+      if i == r.start.line then (line.drop r.start.character).copy
+      else if i == r.end.line then (line.take r.end.character).copy
+      else line
+    "↵".intercalate parts.toList
+
+/-- Flattens the `parent?`-linked `SelectionRange` chain into an array, innermost first. -/
+private partial def selectionRangeToChain : SelectionRange → Array Lsp.Range
+  | .mk { range, parent? := none } => #[range]
+  | .mk { range, parent? := some p } => #[range] ++ selectionRangeToChain p
+
+/-- Sends a `textDocument/selectionRange` request for the current cursor position and prints
+    each expansion level as `range line:col-line:col "text"`, one per line.
+    We don't use only the raw JSON to compare with the expected code because it is too hard
+    to verify whether it contains the right ranges. -/
+def processSelectionRange : RunnerM Unit := do
+  let s ← get
+  let p : SelectionRangeParams := {
+    textDocument := { uri := s.uri }
+    positions := #[s.pos]
+  }
+  let results ← request "textDocument/selectionRange" p (Array SelectionRange)
+  for i in [:results.size] do
+    let queryPos := p.positions[i]!
+    IO.eprintln s!"position {queryPos.line}:{queryPos.character}"
+    let chain := selectionRangeToChain results[i]!
+    for r in chain do
+      let text := extractRangeText s.sourceLines r
+      IO.eprintln s!"range {r.start.line}:{r.start.character}-{r.end.line}:{r.end.character} \"{text}\""
+    IO.eprintln ""
+
 def processGenericRequest : RunnerM Unit := do
   let s ← get
   let Except.ok params := Json.parse s.params
@@ -710,6 +755,7 @@ def processDirective (_ws directive : String) (directiveTargetLineNo : Nat)
   | "moduleHierarchyImports" => processModuleHierarchyImports
   | "moduleHierarchyImportedBy" => processModuleHierarchyImportedBy
   | "inlayHints" => processInlayHints
+  | "selectionRange" => processSelectionRange
   | _ => processGenericRequest
 
 def processLine (line : String) : RunnerM Unit := do
@@ -784,6 +830,7 @@ partial def main (args : List String) : IO Unit := do
         Ipc.writeNotification ⟨"textDocument/didOpen", {
           textDocument := { uri := uri, languageId := "lean", version := 1, text := text.copy } : DidOpenTextDocumentParams }⟩
         reset
+        modify fun s => { s with sourceLines := (text.split '\n').toArray }
         for line in text.split '\n' do
           processLine line.copy
         let _ ← Ipc.collectDiagnostics (← get).requestNo uri ((← get).versionNo - 1)

--- a/src/Lean/Server/Watchdog.lean
+++ b/src/Lean/Server/Watchdog.lean
@@ -1579,6 +1579,7 @@ def mkLeanServerCapabilities : ServerCapabilities := {
   documentHighlightProvider := true
   documentSymbolProvider := true
   foldingRangeProvider := true
+  selectionRangeProvider := true
   semanticTokensProvider? := some {
     legend := {
       tokenTypes     := SemanticTokenType.names

--- a/tests/server_interactive/selectionRange.lean
+++ b/tests/server_interactive/selectionRange.lean
@@ -1,0 +1,26 @@
+/-!
+Tests for `textDocument/selectionRange`. Verifies that selection ranges expand from
+the cursor position outward through enclosing syntax nodes, for terms, tactics, and
+type expressions.
+-/
+
+def ex1 : Nat := 1 + 2 * 3
+                       --^ selectionRange
+
+-- Cursor somewhere in the infix notation
+def ex2 : Nat := 1 + 3
+                  --^ selectionRange
+
+def ex3 (x : Nat) : Nat := (x + 1) * 2
+                          --^ selectionRange
+
+def ex4 : Option (List Nat) := none
+                  --^ selectionRange
+
+theorem ex5 : 0 + 1 = 1 := by simp [Nat.zero_add]
+                               --^ selectionRange
+
+def ex6 : Nat :=
+  let x := 10 * 2
+            --^ selectionRange
+  x

--- a/tests/server_interactive/selectionRange.lean.out.expected
+++ b/tests/server_interactive/selectionRange.lean.out.expected
@@ -1,0 +1,43 @@
+position 6:25
+range 6:25-6:26 "3"
+range 6:21-6:26 "2 * 3"
+range 6:17-6:26 "1 + 2 * 3"
+range 6:14-6:26 ":= 1 + 2 * 3"
+range 6:0-6:26 "def ex1 : Nat := 1 + 2 * 3"
+
+position 10:20
+range 10:17-10:22 "1 + 3"
+range 10:14-10:22 ":= 1 + 3"
+range 10:0-10:22 "def ex2 : Nat := 1 + 3"
+
+position 13:28
+range 13:28-13:29 "x"
+range 13:28-13:33 "x + 1"
+range 13:27-13:34 "(x + 1)"
+range 13:27-13:38 "(x + 1) * 2"
+range 13:24-13:38 ":= (x + 1) * 2"
+range 13:0-13:38 "def ex3 (x : Nat) : Nat := (x + 1) * 2"
+
+position 16:20
+range 16:18-16:22 "List"
+range 16:18-16:26 "List Nat"
+range 16:17-16:27 "(List Nat)"
+range 16:10-16:27 "Option (List Nat)"
+range 16:8-16:27 ": Option (List Nat)"
+range 16:0-16:35 "def ex4 : Option (List Nat) := none"
+
+position 19:33
+range 19:30-19:34 "simp"
+range 19:30-19:49 "simp [Nat.zero_add]"
+range 19:27-19:49 "by simp [Nat.zero_add]"
+range 19:24-19:49 ":= by simp [Nat.zero_add]"
+range 19:0-19:49 "theorem ex5 : 0 + 1 = 1 := by simp [Nat.zero_add]"
+
+position 23:14
+range 23:14-23:15 "*"
+range 23:11-23:17 "10 * 2"
+range 23:6-23:17 "x := 10 * 2"
+range 23:2-25:3 "let x := 10 * 2↵            --^ selectionRange↵  x"
+range 22:14-25:3 ":=↵  let x := 10 * 2↵            --^ selectionRange↵  x"
+range 22:0-25:3 "def ex6 : Nat :=↵  let x := 10 * 2↵            --^ selectionRange↵  x"
+


### PR DESCRIPTION
This PR implements the `textDocument/selectionRange` LSP request, enabling editors to expand or shrink the selection through enclosing syntax nodes (Shift+Alt+Right / Shift+Alt+Left in VS Code). The handler walks the syntax tree from the cursor position outward, building a linked chain of ranges from innermost to outermost.