### PR TITLE
feat: apply `suppressInsideQuot` to `meta` declarations

### DIFF
--- a/src/Lean/Elab/Tactic/Config.lean
+++ b/src/Lean/Elab/Tactic/Config.lean
@@ -136,13 +136,6 @@ def elabConfig (recover : Bool) (structName : Name) (items : Array ConfigItemVie
     let e ← Term.withSynthesize <| Term.elabTermEnsuringType stx (mkConst structName)
     instantiateMVars e
 
-section
--- We automatically disable the following option for `macro`s but the subsequent `def` both contains
--- a quotation and is called only by `macro`s, so we disable the option for it manually. Note that
--- we can't use `in` as it is parsed as a single command and so the option would not influence the
--- parser.
-set_option internal.parseQuotWithCurrentStage false
-
 private meta def mkConfigElaborator
     (doc? : Option (TSyntax ``Parser.Command.docComment)) (elabName type monadName : Ident)
     (adapt recover : Term) : MacroM (TSyntax `command) := do
@@ -177,8 +170,6 @@ private meta def mkConfigElaborator
           else
             throwError msg
       go)
-
-end
 
 /--
 `declare_config_elab_legacy elabName TypeName` declares a function `elabName : Syntax → TacticM TypeName`

--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -279,10 +279,24 @@ def «structure»          := leading_parser
     ppIndent (optDeclSig >> optional «extends») >>
     optional ((symbol " := " <|> " where ") >> optional structCtor >> structFields) >>
     optDeriving
+/--
+If the just-parsed `declModifiers` node on the stack contains a `meta` modifier and we are not
+already inside a quotation, wrap `p` with `suppressInsideQuot`. This matches the behavior that
+`macro_rules`/`macro`/`elab_rules`/`elab` get unconditionally: their quotations are evaluated in
+the current stage and should be ignored when preparing the next stage for a builtin syntax change.
+-/
+private def suppressInsideQuotIfMeta : Parser → Parser := withFn fun f c s =>
+  let mods := s.stxStack.back
+  let isMeta := mods[4][0].getKind == ``Lean.Parser.Command.«meta»
+  adaptCacheableContextFn
+    (fun c => if isMeta && c.quotDepth == 0 then { c with suppressInsideQuot := true } else c)
+    f c s
+
 @[builtin_command_parser] def declaration := leading_parser
   declModifiers false >>
-  («abbrev» <|> definition <|> «theorem» <|> «opaque» <|> «instance» <|> «axiom» <|> «example» <|>
-   «inductive» <|> «coinductive» <|> classInductive <|> «structure»)
+  suppressInsideQuotIfMeta
+    («abbrev» <|> definition <|> «theorem» <|> «opaque» <|> «instance» <|> «axiom» <|> «example» <|>
+     «inductive» <|> «coinductive» <|> classInductive <|> «structure»)
 @[builtin_command_parser] def «deriving»     := leading_parser
   "deriving " >> optional "noncomputable " >> "instance " >> derivingClasses >> " for " >> sepBy1 (recover termParser skip) ", "
 def sectionHeader := leading_parser

--- a/src/Lean/Parser/Extension.lean
+++ b/src/Lean/Parser/Extension.lean
@@ -367,20 +367,17 @@ def leadingIdentBehavior (env : Environment) (catName : Name) : LeadingIdentBeha
   | none     => LeadingIdentBehavior.default
   | some cat => cat.behavior
 
-unsafe def evalParserConstUnsafe (declName : Name) (evalFallback? : Option ParserFn := none) : ParserFn := fun ctx s => unsafeBaseIO do
+unsafe def evalParserConstUnsafe (declName : Name) : ParserFn := fun ctx s => unsafeBaseIO do
   let categories := (parserExtension.getState ctx.env).categories
   match (← (mkParserOfConstant categories declName { env := ctx.env, opts := ctx.options }).toBaseIO) with
   | .ok (_, p) =>
     -- We should manually register `p`'s tokens before invoking it as it might not be part of any syntax category (yet)
     return adaptUncacheableContextFn (fun ctx => { ctx with tokens := p.info.collectTokens [] |>.foldl (fun tks tk => tks.insert tk tk) ctx.tokens }) p.fn ctx s
   | .error e   =>
-    if let some evalFallback := evalFallback? then
-      return evalFallback ctx s
-    else
-      return s.mkUnexpectedError e.toString
+    return s.mkUnexpectedError e.toString
 
 @[implemented_by evalParserConstUnsafe]
-opaque evalParserConst (declName : Name) (evalFallback? : Option ParserFn := none) : ParserFn
+opaque evalParserConst (declName : Name) : ParserFn
 
 register_builtin_option internal.parseQuotWithCurrentStage : Bool := {
   defValue := false
@@ -389,14 +386,10 @@ register_builtin_option internal.parseQuotWithCurrentStage : Bool := {
 
 /-- Interpret `declName` if possible and inside a quotation, or else run `p`. The `ParserInfo` will always be taken from `p`. -/
 def evalInsideQuot (declName : Name) : Parser → Parser := withFn fun f c s =>
-  if c.quotDepth > 0 && !c.suppressInsideQuot && internal.parseQuotWithCurrentStage.get c.options && c.env.contains declName then
+  if c.quotDepth > 0 && !c.suppressInsideQuot && internal.parseQuotWithCurrentStage.get c.options then
     adaptUncacheableContextFn (fun ctx =>
       { ctx with options := ctx.options.set `interpreter.prefer_native false })
-      -- HACK: silently fall back to running compiled `f` on eval error, otherwise parser imported
-      -- but not meta imported can lead to silent backtracking and confusing errors such as
-      -- "unexpected token `by`". Note that the above `contains` already sets a silent fallback for
-      -- "not imported at all".
-      (evalParserConst (evalFallback? := some f) declName) c s
+      (evalParserConst declName) c s
   else
     f c s
 

--- a/src/lake/Lake/Config/Meta.lean
+++ b/src/lake/Lake/Config/Meta.lean
@@ -52,10 +52,6 @@ structure FieldMetadata where
   cmds : Array Command := #[]
   fields : Term := Unhygienic.run `(Array.empty)
 
--- We automatically disable the following option for `macro`s but the subsequent `def`s both contain
--- quotations and are called only by `macro`s, so we disable the option for them manually.
-set_option internal.parseQuotWithCurrentStage false
-
 meta def mkConfigAuxDecls
   (vis? : Option (TSyntax ``visibility))
   (structId : Ident) (structArity : Nat) (structTy : Term) (views : Array FieldView)

--- a/src/lake/Lake/Load/Toml.lean
+++ b/src/lake/Lake/Load/Toml.lean
@@ -367,12 +367,6 @@ def decodeTomlConfig
 @[inline] public def decodeTableValue (decode : Table → DecodeM α) (v : Value) : EDecodeM α := do
   ensureDecode <| decode (← v.decodeTable)
 
-section
--- We automatically disable the following option for `macro`s but the subsequent `def` both contains
--- a quotation and is called only by `macro`s, so we disable the option for it manually. Note that
--- we can't use `in` as it is parsed as a single command and so the option would not influence the
--- parser.
-set_option internal.parseQuotWithCurrentStage false
 meta def genDecodeToml
   (cmds : Array Command)
   (tyName : Name) [info : ConfigInfo tyName]
@@ -394,7 +388,6 @@ meta def genDecodeToml
   let instId ← mkIdentFromRef <| `_root_ ++ tyName.str "instDecodeToml"
   let cmds ← cmds.push <$> `(public instance $instId:ident : DecodeToml $ty := ⟨decodeTableValue $decId⟩)
   return cmds
-end
 
 local macro "gen_toml_decoders%" : command => do
   let cmds := #[]

--- a/tests/elab_fail/metaDefSuppressInsideQuot.lean
+++ b/tests/elab_fail/metaDefSuppressInsideQuot.lean
@@ -1,0 +1,39 @@
+import Lean
+
+/-!
+Tests that the `meta` declaration modifier applies the parser context flag
+`suppressInsideQuot` to the declaration body, matching the unconditional behavior of
+`macro`/`macro_rules`/`elab`/`elab_rules`.
+
+We define a custom term parser that emits a parser error whenever it is invoked inside
+a quotation with `suppressInsideQuot = false`. The parser succeeds inside `meta def` and
+`macro` bodies and fails inside a regular `def` body.
+-/
+
+open Lean Parser PrettyPrinter
+
+private def suppressGuardFn : ParserFn := fun c s =>
+  if c.quotDepth > 0 && !c.suppressInsideQuot then
+    s.mkUnexpectedError "suppressInsideQuot is not set"
+  else
+    s
+
+private def suppressGuard : Parser :=
+  { fn := suppressGuardFn, info := epsilonInfo }
+
+@[combinator_formatter suppressGuard] def suppressGuard.formatter : Formatter := pure ()
+@[combinator_parenthesizer suppressGuard] def suppressGuard.parenthesizer : Parenthesizer := pure ()
+
+@[term_parser]
+private def suppressMarker : Parser :=
+  leading_parser "%%check_suppress%%" >> suppressGuard
+
+-- `meta def` body: our parser combinator sets `suppressInsideQuot`, so the guard passes.
+private meta def metaTest : MacroM Syntax := `(%%check_suppress%%)
+
+-- `macro` body: built-in `suppressInsideQuot`, the guard passes.
+local macro "macroTest" : term => `(%%check_suppress%%)
+
+-- A regular `def` body: `suppressInsideQuot` stays false in the quotation, so the guard fails
+-- with the parser error captured in the expected output.
+private def defTest : MacroM Syntax := `(%%check_suppress%%)

--- a/tests/elab_fail/metaDefSuppressInsideQuot.lean.out.expected
+++ b/tests/elab_fail/metaDefSuppressInsideQuot.lean.out.expected
@@ -1,0 +1,1 @@
+metaDefSuppressInsideQuot.lean:39:59: error: suppressInsideQuot is not set


### PR DESCRIPTION
This PR makes `meta def` behave like `macro`/`macro_rules`/`elab`/`elab_rules` with respect to quotations: when a declaration is marked `meta`, the parser sets `suppressInsideQuot` for the body, so quotations inside it are evaluated using the current stage's parsers and ignored when preparing the next stage for a builtin syntax change. Previously, individual `meta def`s that needed this behavior had to manually disable `internal.parseQuotWithCurrentStage`.

Implementation: a new `suppressInsideQuotIfMeta` parser combinator in `Lean.Parser.Command` peeks at the just-parsed `declModifiers` node on the stack and conditionally wraps the body alternation with the `suppressInsideQuot` context adjustment when the `meta` modifier is present. This follows the same pattern as e.g. `withPositionAfterLinebreak`. The manual `set_option internal.parseQuotWithCurrentStage false` workarounds in `Lean.Elab.Tactic.Config`, `Lake.Config.Meta`, and `Lake.Load.Toml` are no longer needed and have been removed.