### PR TITLE
feat: add `impossible` tactic combinator

### DIFF
--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -1131,21 +1131,16 @@ scope of the tactic.
 syntax (name := classical) "classical" ppDedent(tacticSeq) : tactic
 
 /--
-`impossible by t` closes the current goal with `sorry`, having checked that
-the tactic `t` proves the goal is impossible.
+`impossible by t` uses the tactic `t` to prove that the current goal is impossible
+to prove.
 
-The tactic `t` sees the goal `¬(∀ xs, body)`, where `xs` are the local
-hypotheses (so they can be refuted by exhibiting a counter-witness). Any
-expression metavariables in the original goal are already introduced into
-the local context as named hypotheses, so `t` can `intro`/`cases` over each
-existential witness. This makes `impossible` useful after `refine
-Exists.intro ?_ ?h; case h => …` and similar.
+If the goal is `xs ⊢ P`, the tactic `t` sees the goal `¬(∀ xs, P)`. Any expression metavariables in
+the original goal turn into variables in the context.
 
-Universe parameters of the surrounding declaration are kept fixed (not
-abstracted); universe metavariables in the goal are rejected.
+Universe parameters of the surrounding declaration are kept fixed (not abstracted); universe
+metavariables in the goal are rejected.
 
-The proof is registered as a private auxiliary lemma so the kernel
-re-checks it.
+The original goal is closed as if `sorry` was used.
 -/
 syntax (name := impossible) "impossible" " by " ppDedent(tacticSeq) : tactic
 

--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -1133,8 +1133,7 @@ syntax (name := classical) "classical" ppDedent(tacticSeq) : tactic
 /--
 `impossible e` closes the current goal with `sorry`, where `e` is a proof of the
 negation of the goal after reverting all local hypotheses. Typically `e` is a
-`by` block, e.g. `impossible by decide`. No new axioms are added to the
-environment.
+`by` block, e.g. `impossible by decide`.
 -/
 syntax (name := impossible) "impossible " term : tactic
 

--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -1131,6 +1131,16 @@ scope of the tactic.
 syntax (name := classical) "classical" ppDedent(tacticSeq) : tactic
 
 /--
+Configuration for the `impossible` tactic.
+-/
+structure ImpossibleConfig where
+  /-- If true (default: false), abstract the universe parameters of the surrounding
+  declaration as level metavariables in the goal handed to the inner tactic, so it
+  can constrain them by exhibiting witnesses at specific universes. By default these
+  parameters are kept fixed. -/
+  levels : Bool := false
+
+/--
 `impossible by t` uses the tactic `t` to prove that the current goal is impossible
 to prove.
 
@@ -1138,11 +1148,12 @@ If the goal is `xs ⊢ P`, the tactic `t` sees the goal `¬(∀ xs, P)`. Any exp
 the original goal turn into variables in the context.
 
 Universe parameters of the surrounding declaration are kept fixed (not abstracted); universe
-metavariables in the goal are rejected.
+metavariables in the goal are rejected. The `+levels` option turns the universe parameters
+(and any universe metavariables) into fresh level metavariables instead.
 
 The original goal is closed as if `sorry` was used.
 -/
-syntax (name := impossible) "impossible" " by " ppDedent(tacticSeq) : tactic
+syntax (name := impossible) "impossible" optConfig " by " ppDedent(tacticSeq) : tactic
 
 /--
 The `split` tactic is useful for breaking nested if-then-else and `match` expressions into separate cases.

--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -1136,8 +1136,8 @@ Configuration for the `impossible` tactic.
 structure ImpossibleConfig where
   /-- If true (default: false), abstract the universe parameters of the surrounding
   declaration as level metavariables in the goal handed to the inner tactic, so it
-  can constrain them by exhibiting witnesses at specific universes. By default these
-  parameters are kept fixed. -/
+  can specialize them by exhibiting witnesses at specific universes. By default
+  these parameters are kept fixed. -/
   levels : Bool := false
 
 /--
@@ -1147,9 +1147,9 @@ to prove.
 If the goal is `xs ⊢ P`, the tactic `t` sees the goal `¬(∀ xs, P)`. Any expression metavariables in
 the original goal turn into variables in the context.
 
-Universe parameters of the surrounding declaration are kept fixed (not abstracted); universe
-metavariables in the goal are rejected. The `+levels` option turns the universe parameters
-(and any universe metavariables) into fresh level metavariables instead.
+Universe parameters of the surrounding declaration are kept fixed (not abstracted); the `+levels`
+option turns them into fresh level metavariables instead. Universe metavariables in the goal are
+rejected.
 
 The original goal is closed as if `sorry` was used.
 -/

--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -1133,8 +1133,22 @@ syntax (name := classical) "classical" ppDedent(tacticSeq) : tactic
 /--
 `impossible by t` closes the current goal with `sorry`, having checked that
 the tactic `t` proves the negation of the goal after reverting all local
-hypotheses. Universe parameters of the surrounding declaration are *not*
-abstracted, so they appear in the negated target as the same fixed parameters.
+hypotheses and abstracting any expression metavariables.
+
+Concretely, the obligation handed to `t` has the form `∀ ms, ¬(∀ xs, body)`,
+where `xs` are the local hypotheses (so the user can refute the goal by
+exhibiting a counter-witness for the existing context) and `ms` are the
+abstracted metavariables, already introduced into the local context as named
+hypotheses (so the user can `intro` and `case`-split each existential
+witness). This makes `impossible` usable on under-determined goals such as
+the proof obligation left by `refine Exists.intro ?_ ?h; case h => …`.
+
+Universe parameters of the surrounding declaration are *not* abstracted: they
+appear in the negated target as the same fixed parameters. Universe
+metavariables in the goal type are rejected upfront.
+
+The proof produced by `t` is registered as a private auxiliary lemma so the
+kernel re-typechecks it; kernel errors surface as ordinary diagnostics.
 -/
 syntax (name := impossible) "impossible" " by " ppDedent(tacticSeq) : tactic
 

--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -1132,23 +1132,20 @@ syntax (name := classical) "classical" ppDedent(tacticSeq) : tactic
 
 /--
 `impossible by t` closes the current goal with `sorry`, having checked that
-the tactic `t` proves the negation of the goal after reverting all local
-hypotheses and abstracting any expression metavariables.
+the tactic `t` proves the goal is impossible.
 
-Concretely, the obligation handed to `t` has the form `∀ ms, ¬(∀ xs, body)`,
-where `xs` are the local hypotheses (so the user can refute the goal by
-exhibiting a counter-witness for the existing context) and `ms` are the
-abstracted metavariables, already introduced into the local context as named
-hypotheses (so the user can `intro` and `case`-split each existential
-witness). This makes `impossible` usable on under-determined goals such as
-the proof obligation left by `refine Exists.intro ?_ ?h; case h => …`.
+The tactic `t` sees the goal `¬(∀ xs, body)`, where `xs` are the local
+hypotheses (so they can be refuted by exhibiting a counter-witness). Any
+expression metavariables in the original goal are already introduced into
+the local context as named hypotheses, so `t` can `intro`/`cases` over each
+existential witness. This makes `impossible` useful after `refine
+Exists.intro ?_ ?h; case h => …` and similar.
 
-Universe parameters of the surrounding declaration are *not* abstracted: they
-appear in the negated target as the same fixed parameters. Universe
-metavariables in the goal type are rejected upfront.
+Universe parameters of the surrounding declaration are kept fixed (not
+abstracted); universe metavariables in the goal are rejected.
 
-The proof produced by `t` is registered as a private auxiliary lemma so the
-kernel re-typechecks it; kernel errors surface as ordinary diagnostics.
+The proof is registered as a private auxiliary lemma so the kernel
+re-checks it.
 -/
 syntax (name := impossible) "impossible" " by " ppDedent(tacticSeq) : tactic
 

--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -1131,6 +1131,20 @@ scope of the tactic.
 syntax (name := classical) "classical" ppDedent(tacticSeq) : tactic
 
 /--
+`impossible e` asserts that the current goal is provably impossible and closes it
+with `sorry`. The proof obligation `e` must have type `¬ (∀ xs, G)`, where `xs` are
+the local hypotheses and `G` is the current target — i.e. after reverting all
+hypotheses and negating, the term `e` must inhabit the resulting type.
+
+Typically `e` is a `by` block, e.g. `impossible by decide`.
+
+The original goal is closed with `sorry`, just like the `sorry` tactic, and no new
+axioms are added to the environment. The goal must not contain expression or
+universe metavariables.
+-/
+syntax (name := impossible) "impossible " term : tactic
+
+/--
 The `split` tactic is useful for breaking nested if-then-else and `match` expressions into separate cases.
 For a `match` expression with `n` cases, the `split` tactic generates at most `n` subgoals.
 

--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -1133,7 +1133,8 @@ syntax (name := classical) "classical" ppDedent(tacticSeq) : tactic
 /--
 `impossible by t` closes the current goal with `sorry`, having checked that
 the tactic `t` proves the negation of the goal after reverting all local
-hypotheses.
+hypotheses. Universe parameters of the surrounding declaration are *not*
+abstracted, so they appear in the negated target as the same fixed parameters.
 -/
 syntax (name := impossible) "impossible" " by " ppDedent(tacticSeq) : tactic
 

--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -1131,11 +1131,11 @@ scope of the tactic.
 syntax (name := classical) "classical" ppDedent(tacticSeq) : tactic
 
 /--
-`impossible e` closes the current goal with `sorry`, where `e` is a proof of the
-negation of the goal after reverting all local hypotheses. Typically `e` is a
-`by` block, e.g. `impossible by decide`.
+`impossible by t` closes the current goal with `sorry`, having checked that
+the tactic `t` proves the negation of the goal after reverting all local
+hypotheses.
 -/
-syntax (name := impossible) "impossible " term : tactic
+syntax (name := impossible) "impossible" " by " ppDedent(tacticSeq) : tactic
 
 /--
 The `split` tactic is useful for breaking nested if-then-else and `match` expressions into separate cases.

--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -1131,16 +1131,10 @@ scope of the tactic.
 syntax (name := classical) "classical" ppDedent(tacticSeq) : tactic
 
 /--
-`impossible e` asserts that the current goal is provably impossible and closes it
-with `sorry`. The proof obligation `e` must have type `¬ (∀ xs, G)`, where `xs` are
-the local hypotheses and `G` is the current target — i.e. after reverting all
-hypotheses and negating, the term `e` must inhabit the resulting type.
-
-Typically `e` is a `by` block, e.g. `impossible by decide`.
-
-The original goal is closed with `sorry`, just like the `sorry` tactic, and no new
-axioms are added to the environment. The goal must not contain expression or
-universe metavariables.
+`impossible e` closes the current goal with `sorry`, where `e` is a proof of the
+negation of the goal after reverting all local hypotheses. Typically `e` is a
+`by` block, e.g. `impossible by decide`. No new axioms are added to the
+environment.
 -/
 syntax (name := impossible) "impossible " term : tactic
 

--- a/src/Lean/Elab/Tactic.lean
+++ b/src/Lean/Elab/Tactic.lean
@@ -45,6 +45,7 @@ public import Lean.Elab.Tactic.DiscrTreeKey
 public import Lean.Elab.Tactic.BVDecide
 public import Lean.Elab.Tactic.BoolToPropSimps
 public import Lean.Elab.Tactic.Classical
+public import Lean.Elab.Tactic.Impossible
 public import Lean.Elab.Tactic.Grind
 public import Lean.Elab.Tactic.Monotonicity
 public import Lean.Elab.Tactic.Try

--- a/src/Lean/Elab/Tactic/Impossible.lean
+++ b/src/Lean/Elab/Tactic/Impossible.lean
@@ -20,6 +20,60 @@ public section
 namespace Lean.Elab.Tactic
 open Lean Meta
 
+/--
+Given the main goal of `impossible`, compute the closed *negated reverted
+target* the user will be asked to inhabit, together with the names under which
+the abstracted metavariables should be introduced.
+
+The construction:
+
+* `revert` all local hypotheses, turning the goal into `∀ xs, body`. Cleanup
+  first so that aux decls etc. don't get reverted.
+* Run `Closure.mkValueTypeClosure` on the reverted type to abstract every
+  expression metavariable it mentions. We reuse this builder (rather than
+  `Meta.abstractMVars`) because it walks without the single-`mctx`-depth filter
+  and correctly eta-expands delayed-assignment metavariables — i.e. the same
+  guarantees `grind`'s `mkAuxTheorem` already relies on. The dummy value we
+  hand it is irrelevant; we only consume `.type` and `.exprArgs`.
+* Substitute the freshly-generated universe parameters back to the originals.
+  We don't want the surrounding declaration's universes to be renamed in the
+  error messages or the user-facing goal state.
+* Push the negation *under* the mvar binders but *over* the reverted-fvar
+  binders, yielding `∀ ms, ¬(∀ xs, body)`. The user can then `intro` each
+  mvar witness and reason about the existing local context as a universal.
+
+Returns the negated type together with the user-friendly mvar names
+(`userName.eraseMacroScopes`, with a fallback to `x` for anonymous ones).
+
+Universe metavariables in the *goal type itself* are rejected by the caller
+before this function runs; if they slipped through, `mkValueTypeClosure`
+would happily abstract them too (turning them into fresh universe params),
+but the resulting goal state with `Sort ?u`-style binders is hard to work
+with, hence the upfront check.
+-/
+private def mkImpossibleNegType (mainGoal : MVarId) (goalType : Expr) :
+    MetaM (Expr × Array Name) := mainGoal.withContext do
+  let dummy ← mkFreshExprSyntheticOpaqueMVar goalType
+  let cleaned ← dummy.mvarId!.cleanup
+  let (_, reverted) ← cleaned.revert
+    (clearAuxDeclsInsteadOfRevert := true)
+    (← cleaned.getDecl).lctx.getFVarIds
+  let revertedType ← reverted.getType
+  let r ← Closure.mkValueTypeClosure revertedType (mkConst ``True)
+    (zetaDelta := false)
+  let rType := r.type.instantiateLevelParamsArray r.levelParams r.levelArgs
+  let negType ← forallBoundedTelescope rType (some r.exprArgs.size) fun ms revBody => do
+    let negBody ← if (← Meta.isProp revBody) then
+      pure (mkNot revBody)
+    else
+      mkArrow revBody (mkConst ``False)
+    mkForallFVars ms negBody
+  let mvarNames ← r.exprArgs.mapM fun mvarExpr => do
+    let .mvar mvarId := mvarExpr | return `x
+    let n := (← mvarId.getDecl).userName.eraseMacroScopes
+    return if n.isAnonymous then `x else n
+  return (negType, mvarNames)
+
 @[builtin_tactic Lean.Parser.Tactic.impossible]
 def evalImpossible : Tactic := fun stx => do
   let kw := stx[0]
@@ -30,51 +84,7 @@ def evalImpossible : Tactic := fun stx => do
   if goalType.hasLevelMVar then
     throwErrorAt kw "\
       `impossible`: goal contains universe metavariables{indentExpr goalType}"
-  -- Compute the negated, reverted target. The form we want is
-  --   `∀ ms, ¬(∀ xs, body)`,
-  -- where `ms` are the (universally-quantified) expression metavariables
-  -- abstracted out of the goal and `xs` are the local hypotheses that
-  -- `revert` introduced. The negation sits *between* the two layers:
-  -- under `ms` (so the user can prove impossibility by case-splitting on
-  -- each existential witness) but over `xs` (so they can refute the goal
-  -- by exhibiting a counter-witness for the existing local context).
-  let (negType, mvarNames) ← mainGoal.withContext do
-    let dummy ← mkFreshExprSyntheticOpaqueMVar goalType
-    let cleaned ← dummy.mvarId!.cleanup
-    let (_, reverted) ← cleaned.revert
-      (clearAuxDeclsInsteadOfRevert := true)
-      (← cleaned.getDecl).lctx.getFVarIds
-    let revertedType ← reverted.getType
-    -- Re-use the aux-lemma machinery's closure builder to abstract over every
-    -- expression mvar in the reverted goal type. `mkValueTypeClosure` walks
-    -- the type without filtering by mctx depth (unlike `Meta.abstractMVars`),
-    -- and also correctly eta-expands delayed-assignment mvars — exactly what
-    -- `Closure.mkAuxTheorem` does when grind builds its aux lemma. The
-    -- `value` we pass is a placeholder; we only care about the abstracted
-    -- type and the original mvars (in `exprArgs`).
-    let r ← Closure.mkValueTypeClosure revertedType (mkConst ``True)
-      (zetaDelta := false)
-    -- `mkValueTypeClosure` also re-parameterizes universe parameters into
-    -- fresh names. We don't want to rename surrounding declaration's
-    -- universes (their original names appear in error messages and elsewhere),
-    -- so we substitute the fresh universe parameters back to the originals.
-    let rType := r.type.instantiateLevelParamsArray r.levelParams r.levelArgs
-    -- `rType` is `∀ ms, revertedType[ms]`. Peel exactly those binders so we
-    -- can push the negation under them (yielding `∀ ms, ¬revertedType`).
-    let negType ← forallBoundedTelescope rType (some r.exprArgs.size) fun ms revBody => do
-      let negBody ← if (← Meta.isProp revBody) then
-        pure (mkNot revBody)
-      else
-        mkArrow revBody (mkConst ``False)
-      mkForallFVars ms negBody
-    -- Pull the abstracted mvars' user names from `r.exprArgs` so we can
-    -- later `intro` them under those (sanitized) names rather than under
-    -- the anonymous `_x.N`s the closure builder uses internally.
-    let mvarNames ← r.exprArgs.mapM fun mvarExpr => do
-      let .mvar mvarId := mvarExpr | return `x
-      let n := (← mvarId.getDecl).userName.eraseMacroScopes
-      return if n.isAnonymous then `x else n
-    return (negType, mvarNames)
+  let (negType, mvarNames) ← mkImpossibleNegType mainGoal goalType
   -- Close the original goal with `sorry` (without adding any axioms) *before*
   -- running the user's tactic. That way, if the inner tactic propagates a
   -- failure, no outer goal is left for the surrounding `by`/`runTactic` to

--- a/src/Lean/Elab/Tactic/Impossible.lean
+++ b/src/Lean/Elab/Tactic/Impossible.lean
@@ -7,7 +7,6 @@ module
 
 prelude
 public import Lean.Elab.Tactic.Basic
-public import Lean.Elab.SyntheticMVars
 public import Lean.Meta.Tactic.Cleanup
 public import Lean.Meta.Tactic.Revert
 
@@ -21,7 +20,8 @@ open Lean Meta
 @[builtin_tactic Lean.Parser.Tactic.impossible]
 def evalImpossible : Tactic := fun stx => do
   let kw := stx[0]
-  let term := stx[1]
+  let byTk := stx[1]
+  let tacs := stx[2]
   let mainGoal ← getMainGoal
   let goalType ← mainGoal.withContext do instantiateMVars (← mainGoal.getType)
   if goalType.hasExprMVar then
@@ -31,9 +31,9 @@ def evalImpossible : Tactic := fun stx => do
     throwErrorAt kw "\
       `impossible`: goal contains universe metavariables{indentExpr goalType}"
   -- Compute the reverted, negated target from a discardable copy of the main
-  -- goal, so the original `mainGoal` remains assignable below. We use `Not` on
-  -- propositions and fall back to `_ → False` otherwise so the construction is
-  -- well-typed at any universe.
+  -- goal, so the original `mainGoal` remains assignable below. We use `Not`
+  -- on propositions and fall back to `_ → False` otherwise so the construction
+  -- is well-typed at any universe.
   let negType ← mainGoal.withContext do
     let dummy ← mkFreshExprSyntheticOpaqueMVar goalType
     let cleaned ← dummy.mvarId!.cleanup
@@ -44,16 +44,26 @@ def evalImpossible : Tactic := fun stx => do
       pure (mkNot revertedType)
     else
       mkArrow revertedType (mkConst ``False)
-  -- Elaborate the user-supplied proof of the closed-form negation. Any errors
-  -- in the term (including inside a `by` block) are reported normally by the
-  -- term elaborator. We discard the resulting expression — we are only checking
-  -- that the user can produce a witness of unreachability.
-  discard <| Term.elabTermEnsuringType term negType
-  -- Force any pending `by` tactic to actually run so its goal info is attached
-  -- to the info tree (otherwise hovers inside `by` would show no goals).
-  Term.synthesizeSyntheticMVarsNoPostponing
-  -- Always close the original goal with `sorry`, without adding any axioms.
+  -- Close the original goal with `sorry` (without adding any axioms) *before*
+  -- running the user's tactic. That way, if the inner tactic propagates a
+  -- failure, no outer goal is left for the surrounding `by`/`runTactic` to
+  -- spuriously report as unsolved on top of the inner error.
   admitGoal mainGoal
-  replaceMainGoal []
+  let restGoals ← getUnsolvedGoals
+  -- Run the user-supplied tactic against a fresh mvar for the negation. We
+  -- follow it with `done` so that an unsolved negated goal throws an
+  -- "unsolved goals" error (mirroring how `have h := by …` propagates failure
+  -- via its `case`/`closeUsingOrAdmit` expansion). Both inner elaboration
+  -- errors and unsolved goals therefore propagate naturally to combinators
+  -- like `first`, while direct user-facing uses still observe the inner
+  -- messages and get a `sorry` from the outer `by`.
+  let negMVarId := (← mkFreshExprSyntheticOpaqueMVar negType).mvarId!
+  try
+    setGoals [negMVarId]
+    withTacticInfoContext byTk do
+      evalTactic tacs
+      done
+  finally
+    setGoals restGoals
 
 end Lean.Elab.Tactic

--- a/src/Lean/Elab/Tactic/Impossible.lean
+++ b/src/Lean/Elab/Tactic/Impossible.lean
@@ -9,6 +9,7 @@ prelude
 public import Lean.Elab.Tactic.Basic
 public import Lean.Meta.Tactic.Cleanup
 public import Lean.Meta.Tactic.Revert
+public import Lean.Meta.Tactic.AuxLemma
 
 public section
 
@@ -50,19 +51,30 @@ def evalImpossible : Tactic := fun stx => do
   -- spuriously report as unsolved on top of the inner error.
   admitGoal mainGoal
   let restGoals ← getUnsolvedGoals
-  -- Run the user-supplied tactic against a fresh mvar for the negation. We
-  -- follow it with `done` so that an unsolved negated goal throws an
+  -- Run the user-supplied tactic against a fresh mvar for the negation, using
+  -- an empty local context (the reverted target is closed). We follow the
+  -- tactic with `done` so that an unsolved negated goal throws an
   -- "unsolved goals" error (mirroring how `have h := by …` propagates failure
   -- via its `case`/`closeUsingOrAdmit` expansion). Both inner elaboration
   -- errors and unsolved goals therefore propagate naturally to combinators
   -- like `first`, while direct user-facing uses still observe the inner
   -- messages and get a `sorry` from the outer `by`.
-  let negMVarId := (← mkFreshExprSyntheticOpaqueMVar negType).mvarId!
+  let negMVarId :=
+    (← mkFreshExprMVarAt {} {} negType (kind := .syntheticOpaque)).mvarId!
   try
     setGoals [negMVarId]
     withTacticInfoContext byTk do
       evalTactic tacs
       done
+    -- The user's tactic produced a proof of the negation. Hand it to the
+    -- kernel via a private aux lemma so kernel-level errors (e.g. proof
+    -- irrelevance / typechecking issues) surface here rather than being
+    -- silently absorbed by the `sorry` we put on the outer goal.
+    let proof ← instantiateMVars (mkMVar negMVarId)
+    let lvls := (collectLevelParams {} negType).params
+    let lemmaLvls := (← Term.getLevelNames).reverse.filter lvls.contains
+    discard <| withOptions (Elab.async.set · false) do
+      mkAuxLemma lemmaLvls negType proof
   finally
     setGoals restGoals
 

--- a/src/Lean/Elab/Tactic/Impossible.lean
+++ b/src/Lean/Elab/Tactic/Impossible.lean
@@ -30,17 +30,20 @@ def evalImpossible : Tactic := fun stx => do
   if goalType.hasLevelMVar then
     throwErrorAt kw "\
       `impossible`: goal contains universe metavariables{indentExpr goalType}"
-  unless (← mainGoal.withContext do Meta.isProp goalType) do
-    throwErrorAt kw "\
-      `impossible`: goal is not a proposition{indentExpr goalType}"
   -- Compute the reverted, negated target from a discardable copy of the main
-  -- goal, so the original `mainGoal` remains assignable below.
+  -- goal, so the original `mainGoal` remains assignable below. We use `Not` on
+  -- propositions and fall back to `_ → False` otherwise so the construction is
+  -- well-typed at any universe.
   let negType ← mainGoal.withContext do
     let dummy ← mkFreshExprSyntheticOpaqueMVar goalType
     let cleaned ← dummy.mvarId!.cleanup
     let (_, reverted) ← cleaned.revert (clearAuxDeclsInsteadOfRevert := true)
       (← cleaned.getDecl).lctx.getFVarIds
-    pure (mkNot (← reverted.getType))
+    let revertedType ← reverted.getType
+    if (← Meta.isProp revertedType) then
+      pure (mkNot revertedType)
+    else
+      mkArrow revertedType (mkConst ``False)
   -- Elaborate the user-supplied proof of the closed-form negation. Any errors
   -- in the term (including inside a `by` block) are reported normally by the
   -- term elaborator. We discard the resulting expression — we are only checking

--- a/src/Lean/Elab/Tactic/Impossible.lean
+++ b/src/Lean/Elab/Tactic/Impossible.lean
@@ -68,6 +68,10 @@ private def mkImpossibleNegType (mainGoal : MVarId) (goalType : Expr)
   -- the surrounding declaration's universes show up unchanged); with `+levels`
   -- we replace them with fresh level metavariables instead, so the user's
   -- tactic can constrain them by picking witnesses at specific universes.
+  --
+  -- The original universe-parameter names are *not* preserved in the display:
+  -- the level pretty-printer (`Lean.Level.toResult`) always renders an mvar
+  -- with a decl in the mctx as `?u.<index>`, ignoring the underlying name.
   let rTypeLevels ←
     if cfg.levels then r.levelParams.mapM fun _ => mkFreshLevelMVar
     else pure r.levelArgs

--- a/src/Lean/Elab/Tactic/Impossible.lean
+++ b/src/Lean/Elab/Tactic/Impossible.lean
@@ -20,6 +20,65 @@ public section
 namespace Lean.Elab.Tactic
 open Lean Meta
 
+/--
+Like `Meta.abstractMVars` with `levels := false`, but abstracts every
+expression metavariable found in `e` regardless of its mctx depth. This is
+sound for our use here, where the resulting type is only used as a *type*
+(a universally quantified obligation): treating a lower-depth mvar as
+universally quantified is a strictly stronger statement than treating it
+as a constant, so the impossibility witness still applies whatever value the
+parent context might eventually assign.
+
+Level metavariables are deliberately left alone.
+-/
+private partial def abstractAllMVars (e : Expr) : MetaM AbstractMVarsResult := do
+  let e ← instantiateMVars e
+  let s : AbstractMVars.State :=
+    { mctx           := (← getMCtx)
+      lctx           := (← getLCtx)
+      ngen           := (← getNGen)
+      abstractLevels := false }
+  -- We mirror `AbstractMVars.abstractExprMVars`, but with the depth check
+  -- elided so mvars from any depth are abstracted.
+  let (e, s) := (go e).run s
+  setNGen s.ngen
+  setMCtx s.mctx
+  let lam := s.lctx.mkLambda s.fvars e
+  return { paramNames := s.paramNames, mvars := s.mvars, expr := lam }
+where
+  go (e : Expr) : StateM AbstractMVars.State Expr := do
+    if !e.hasMVar then return e
+    match e with
+    | .lit _ | .bvar _ | .fvar _ | .sort _ | .const _ _ => return e
+    | .proj _ _ b      => return e.updateProj! (← go b)
+    | .app f a         => return e.updateApp! (← go f) (← go a)
+    | .mdata _ b       => return e.updateMData! (← go b)
+    | .lam _ d b _     => return e.updateLambdaE! (← go d) (← go b)
+    | .forallE _ d b _ => return e.updateForallE! (← go d) (← go b)
+    | .letE _ t v b _  => return e.updateLetE! (← go t) (← go v) (← go b)
+    | .mvar mvarId =>
+      let decl := (← get).mctx.getDecl mvarId
+      match (← get).emap[mvarId]? with
+      | some e => return e
+      | none =>
+        let (mctxNew, instType) := Lean.instantiateExprMVarsImp (← get).mctx decl.type
+        modify ({ · with mctx := mctxNew })
+        let type ← go instType
+        let s ← get
+        let fresh := s.ngen.curr
+        let fvarId : FVarId := { name := fresh }
+        let fvar := mkFVar fvarId
+        let userName :=
+          if decl.userName.isAnonymous then (`x).appendIndexAfter s.fvars.size
+          else decl.userName
+        set { s with
+          ngen  := s.ngen.next
+          emap  := s.emap.insert mvarId fvar
+          fvars := s.fvars.push fvar
+          mvars := s.mvars.push e
+          lctx  := s.lctx.mkLocalDecl fvarId userName type }
+        return fvar
+
 @[builtin_tactic Lean.Parser.Tactic.impossible]
 def evalImpossible : Tactic := fun stx => do
   let kw := stx[0]
@@ -45,7 +104,7 @@ def evalImpossible : Tactic := fun stx => do
       (clearAuxDeclsInsteadOfRevert := true)
       (← cleaned.getDecl).lctx.getFVarIds
     let revertedType ← reverted.getType
-    let abs ← abstractMVars revertedType (levels := false)
+    let abs ← abstractAllMVars revertedType
     -- Pull the abstracted mvars' user names so we can later `intro` them
     -- under those (sanitized) names rather than under the hygienic ones the
     -- mvars carried internally.

--- a/src/Lean/Elab/Tactic/Impossible.lean
+++ b/src/Lean/Elab/Tactic/Impossible.lean
@@ -44,8 +44,8 @@ The construction:
   binders, yielding `∀ ms, ¬(∀ xs, body)`. The user can then `intro` each
   mvar witness and reason about the existing local context as a universal.
 
-Returns the negated type together with the user-friendly mvar names
-(`userName.eraseMacroScopes`, with a fallback to `x` for anonymous ones).
+Returns the negated type together with the abstracted mvars' user names
+(verbatim, scopes included).
 
 Universe metavariables in the *goal type itself* are rejected by the caller
 before this function runs; if they slipped through, `mkValueTypeClosure`
@@ -86,7 +86,7 @@ private def mkImpossibleNegType (mainGoal : MVarId) (goalType : Expr)
     mkForallFVars ms negBody
   let mvarNames ← r.exprArgs.mapM fun mvarExpr => do
     let .mvar mvarId := mvarExpr | return `x
-    let n := (← mvarId.getDecl).userName.eraseMacroScopes
+    let n := (← mvarId.getDecl).userName
     return if n.isAnonymous then `x else n
   return (negType, mvarNames)
 
@@ -121,9 +121,9 @@ def evalImpossible : Tactic := fun stx => do
   let negMVarId :=
     (← mkFreshExprMVarAt {} {} negType (kind := .syntheticOpaque)).mvarId!
   -- Intro the abstracted-mvar binders so the user's tactic sees them as
-  -- local hypotheses rather than as a leading `∀`. We pass cleaned-up
-  -- names (with hygiene scopes erased) so the introduced fvars are
-  -- accessible to the user by name.
+  -- local hypotheses rather than as a leading `∀`. The macro-scoped mvar
+  -- names are used as-is; the user can `expose_names` if they need to
+  -- refer to the introduced fvars by surface name.
   let (_, innerMVarId) ← negMVarId.introN mvarNames.size mvarNames.toList
   try
     setGoals [innerMVarId]

--- a/src/Lean/Elab/Tactic/Impossible.lean
+++ b/src/Lean/Elab/Tactic/Impossible.lean
@@ -7,6 +7,7 @@ module
 
 prelude
 public import Lean.Elab.Tactic.Basic
+public import Lean.Elab.ConfigEval
 public import Lean.Meta.Tactic.Cleanup
 public import Lean.Meta.Tactic.Revert
 public import Lean.Meta.Tactic.AuxLemma
@@ -51,7 +52,8 @@ would happily abstract them too (turning them into fresh universe params),
 but the resulting goal state with `Sort ?u`-style binders is hard to work
 with, hence the upfront check.
 -/
-private def mkImpossibleNegType (mainGoal : MVarId) (goalType : Expr) :
+private def mkImpossibleNegType (mainGoal : MVarId) (goalType : Expr)
+    (cfg : Parser.Tactic.ImpossibleConfig) :
     MetaM (Expr × Array Name) := mainGoal.withContext do
   let dummy ← mkFreshExprSyntheticOpaqueMVar goalType
   let cleaned ← dummy.mvarId!.cleanup
@@ -61,7 +63,15 @@ private def mkImpossibleNegType (mainGoal : MVarId) (goalType : Expr) :
   let revertedType ← reverted.getType
   let r ← Closure.mkValueTypeClosure revertedType (mkConst ``True)
     (zetaDelta := false)
-  let rType := r.type.instantiateLevelParamsArray r.levelParams r.levelArgs
+  -- `mkValueTypeClosure` abstracts both expr mvars and universes. By default we
+  -- substitute the freshly-generated universe params back to the originals (so
+  -- the surrounding declaration's universes show up unchanged); with `+levels`
+  -- we replace them with fresh level metavariables instead, so the user's
+  -- tactic can constrain them by picking witnesses at specific universes.
+  let rTypeLevels ←
+    if cfg.levels then r.levelParams.mapM fun _ => mkFreshLevelMVar
+    else pure r.levelArgs
+  let rType := r.type.instantiateLevelParamsArray r.levelParams rTypeLevels
   let negType ← forallBoundedTelescope rType (some r.exprArgs.size) fun ms revBody => do
     let negBody ← if (← Meta.isProp revBody) then
       pure (mkNot revBody)
@@ -74,17 +84,21 @@ private def mkImpossibleNegType (mainGoal : MVarId) (goalType : Expr) :
     return if n.isAnonymous then `x else n
   return (negType, mvarNames)
 
+declare_config_elab elabImpossibleConfig Parser.Tactic.ImpossibleConfig
+
 @[builtin_tactic Lean.Parser.Tactic.impossible]
 def evalImpossible : Tactic := fun stx => do
   let kw := stx[0]
-  let byTk := stx[1]
-  let tacs := stx[2]
+  let cfg ← elabImpossibleConfig stx[1]
+  let byTk := stx[2]
+  let tacs := stx[3]
   let mainGoal ← getMainGoal
   let goalType ← mainGoal.withContext do instantiateMVars (← mainGoal.getType)
-  if goalType.hasLevelMVar then
+  if goalType.hasLevelMVar && !cfg.levels then
     throwErrorAt kw "\
-      `impossible`: goal contains universe metavariables{indentExpr goalType}"
-  let (negType, mvarNames) ← mkImpossibleNegType mainGoal goalType
+      `impossible`: goal contains universe metavariables{indentExpr goalType}\n\
+      Hint: use `impossible +levels by …` to abstract them."
+  let (negType, mvarNames) ← mkImpossibleNegType mainGoal goalType cfg
   -- Close the original goal with `sorry` (without adding any axioms) *before*
   -- running the user's tactic. That way, if the inner tactic propagates a
   -- failure, no outer goal is left for the surrounding `by`/`runTactic` to
@@ -116,6 +130,10 @@ def evalImpossible : Tactic := fun stx => do
     -- irrelevance / typechecking issues) surface here rather than being
     -- silently absorbed by the `sorry` we put on the outer goal.
     let proof ← instantiateMVars (mkMVar negMVarId)
+    -- Instantiate level mvars in `negType` as well — the user's tactic may
+    -- have assigned them when it concretized the universes (e.g. by
+    -- applying the universal to a witness at `Type 0`).
+    let negType ← instantiateMVars negType
     let lvls := (collectLevelParams {} negType).params
     let lemmaLvls := (← Term.getLevelNames).reverse.filter lvls.contains
     discard <| withOptions (Elab.async.set · false) do

--- a/src/Lean/Elab/Tactic/Impossible.lean
+++ b/src/Lean/Elab/Tactic/Impossible.lean
@@ -130,18 +130,19 @@ def evalImpossible : Tactic := fun stx => do
       evalTactic tacs
       done
     -- The user's tactic produced a proof of the negation. Hand it to the
-    -- kernel via a private aux lemma so kernel-level errors (e.g. proof
+    -- kernel via a private aux theorem so kernel-level errors (e.g. proof
     -- irrelevance / typechecking issues) surface here rather than being
     -- silently absorbed by the `sorry` we put on the outer goal.
+    --
+    -- We use `mkAuxTheorem` rather than `mkAuxLemma` so that any level
+    -- metavariables the user's tactic left unassigned (which is fine: an
+    -- impossibility proof that works at any universe gives a parametric
+    -- counter-example) are closed over as fresh universe parameters of the
+    -- auxiliary lemma, rather than causing a "declaration has metavariables"
+    -- kernel rejection.
     let proof ← instantiateMVars (mkMVar negMVarId)
-    -- Instantiate level mvars in `negType` as well — the user's tactic may
-    -- have assigned them when it concretized the universes (e.g. by
-    -- applying the universal to a witness at `Type 0`).
-    let negType ← instantiateMVars negType
-    let lvls := (collectLevelParams {} negType).params
-    let lemmaLvls := (← Term.getLevelNames).reverse.filter lvls.contains
     discard <| withOptions (Elab.async.set · false) do
-      mkAuxLemma lemmaLvls negType proof
+      mkAuxTheorem (← instantiateMVars negType) proof
   finally
     setGoals restGoals
 

--- a/src/Lean/Elab/Tactic/Impossible.lean
+++ b/src/Lean/Elab/Tactic/Impossible.lean
@@ -36,9 +36,10 @@ The construction:
   and correctly eta-expands delayed-assignment metavariables — i.e. the same
   guarantees `grind`'s `mkAuxTheorem` already relies on. The dummy value we
   hand it is irrelevant; we only consume `.type` and `.exprArgs`.
-* Substitute the freshly-generated universe parameters back to the originals.
-  We don't want the surrounding declaration's universes to be renamed in the
-  error messages or the user-facing goal state.
+* Substitute the freshly-generated universe parameters back to the originals
+  (so the surrounding declaration's universes show up unchanged) — unless
+  `+levels` is set, in which case the originals are replaced with fresh
+  level metavariables so the user's tactic can specialize them.
 * Push the negation *under* the mvar binders but *over* the reverted-fvar
   binders, yielding `∀ ms, ¬(∀ xs, body)`. The user can then `intro` each
   mvar witness and reason about the existing local context as a universal.
@@ -63,11 +64,12 @@ private def mkImpossibleNegType (mainGoal : MVarId) (goalType : Expr)
   let revertedType ← reverted.getType
   let r ← Closure.mkValueTypeClosure revertedType (mkConst ``True)
     (zetaDelta := false)
-  -- `mkValueTypeClosure` abstracts both expr mvars and universes. By default we
-  -- substitute the freshly-generated universe params back to the originals (so
-  -- the surrounding declaration's universes show up unchanged); with `+levels`
-  -- we replace them with fresh level metavariables instead, so the user's
-  -- tactic can constrain them by picking witnesses at specific universes.
+  -- `mkValueTypeClosure` abstracts the surrounding declaration's universe
+  -- parameters as fresh universe params of its own. By default we substitute
+  -- them back to the originals (so the surrounding declaration's universes
+  -- show up unchanged in the goal); with `+levels` we replace them with
+  -- fresh level metavariables instead, so the user's tactic can specialize
+  -- them by picking witnesses at specific universes.
   --
   -- The original universe-parameter names are *not* preserved in the display:
   -- the level pretty-printer (`Lean.Level.toResult`) always renders an mvar
@@ -98,10 +100,9 @@ def evalImpossible : Tactic := fun stx => do
   let tacs := stx[3]
   let mainGoal ← getMainGoal
   let goalType ← mainGoal.withContext do instantiateMVars (← mainGoal.getType)
-  if goalType.hasLevelMVar && !cfg.levels then
+  if goalType.hasLevelMVar then
     throwErrorAt kw "\
-      `impossible`: goal contains universe metavariables{indentExpr goalType}\n\
-      Hint: use `impossible +levels by …` to abstract them."
+      `impossible`: goal contains universe metavariables{indentExpr goalType}"
   let (negType, mvarNames) ← mkImpossibleNegType mainGoal goalType cfg
   -- Close the original goal with `sorry` (without adding any axioms) *before*
   -- running the user's tactic. That way, if the inner tactic propagates a

--- a/src/Lean/Elab/Tactic/Impossible.lean
+++ b/src/Lean/Elab/Tactic/Impossible.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joachim Breitner
+-/
+module
+
+prelude
+public import Lean.Elab.Tactic.Basic
+public import Lean.Elab.SyntheticMVars
+public import Lean.Meta.Tactic.Cleanup
+public import Lean.Meta.Tactic.Revert
+
+public section
+
+/-! # `impossible` tactic -/
+
+namespace Lean.Elab.Tactic
+open Lean Meta
+
+@[builtin_tactic Lean.Parser.Tactic.impossible]
+def evalImpossible : Tactic := fun stx => do
+  let kw := stx[0]
+  let term := stx[1]
+  let mainGoal ← getMainGoal
+  let goalType ← mainGoal.withContext do instantiateMVars (← mainGoal.getType)
+  if goalType.hasExprMVar then
+    throwErrorAt kw "\
+      `impossible`: goal contains metavariables{indentExpr goalType}"
+  if goalType.hasLevelMVar then
+    throwErrorAt kw "\
+      `impossible`: goal contains universe metavariables{indentExpr goalType}"
+  unless (← mainGoal.withContext do Meta.isProp goalType) do
+    throwErrorAt kw "\
+      `impossible`: goal is not a proposition{indentExpr goalType}"
+  -- Compute the reverted, negated target from a discardable copy of the main
+  -- goal, so the original `mainGoal` remains assignable below.
+  let negType ← mainGoal.withContext do
+    let dummy ← mkFreshExprSyntheticOpaqueMVar goalType
+    let cleaned ← dummy.mvarId!.cleanup
+    let (_, reverted) ← cleaned.revert (clearAuxDeclsInsteadOfRevert := true)
+      (← cleaned.getDecl).lctx.getFVarIds
+    pure (mkNot (← reverted.getType))
+  -- Elaborate the user-supplied proof of the closed-form negation. Any errors
+  -- in the term (including inside a `by` block) are reported normally by the
+  -- term elaborator. We discard the resulting expression — we are only checking
+  -- that the user can produce a witness of unreachability.
+  discard <| Term.elabTermEnsuringType term negType
+  -- Force any pending `by` tactic to actually run so its goal info is attached
+  -- to the info tree (otherwise hovers inside `by` would show no goals).
+  Term.synthesizeSyntheticMVarsNoPostponing
+  -- Always close the original goal with `sorry`, without adding any axioms.
+  admitGoal mainGoal
+  replaceMainGoal []
+
+end Lean.Elab.Tactic

--- a/src/Lean/Elab/Tactic/Impossible.lean
+++ b/src/Lean/Elab/Tactic/Impossible.lean
@@ -10,6 +10,7 @@ public import Lean.Elab.Tactic.Basic
 public import Lean.Meta.Tactic.Cleanup
 public import Lean.Meta.Tactic.Revert
 public import Lean.Meta.Tactic.AuxLemma
+public import Lean.Meta.Tactic.Intro
 public import Lean.Meta.AbstractMVars
 
 public section
@@ -29,39 +30,35 @@ def evalImpossible : Tactic := fun stx => do
   if goalType.hasLevelMVar then
     throwErrorAt kw "\
       `impossible`: goal contains universe metavariables{indentExpr goalType}"
-  -- Compute the reverted, negated target from a discardable copy of the main
-  -- goal, so the original `mainGoal` remains assignable below. We:
-  --   * revert all local hypotheses, turning the goal into `∀ xs, body`;
-  --   * abstract over remaining expression metavariables, turning the result
-  --     into `∀ ms, ∀ xs, body` (so `impossible` can be applied to
-  --     under-determined goals like `∃ x, …`); level mvars are left alone
-  --     because abstracting them tends to make tactic state hard to read;
-  --   * push the negation *under* the universal binders, yielding
-  --     `∀ ms, ∀ xs, ¬body` (or `∀ ms, ∀ xs, body → False` when `body` isn't
-  --     a proposition). This lets the user prove impossibility by `intro`ing
-  --     witnesses for the binders and then deriving `False`.
-  let negType ← mainGoal.withContext do
+  -- Compute the negated, reverted target. The form we want is
+  --   `∀ ms, ¬(∀ xs, body)`,
+  -- where `ms` are the (universally-quantified) expression metavariables
+  -- abstracted out of the goal and `xs` are the local hypotheses that
+  -- `revert` introduced. The negation sits *between* the two layers:
+  -- under `ms` (so the user can prove impossibility by case-splitting on
+  -- each existential witness) but over `xs` (so they can refute the goal
+  -- by exhibiting a counter-witness for the existing local context).
+  let (negType, mvarNames) ← mainGoal.withContext do
     let dummy ← mkFreshExprSyntheticOpaqueMVar goalType
     let cleaned ← dummy.mvarId!.cleanup
-    let (revertedFVars, reverted) ← cleaned.revert
+    let (_, reverted) ← cleaned.revert
       (clearAuxDeclsInsteadOfRevert := true)
       (← cleaned.getDecl).lctx.getFVarIds
     let revertedType ← reverted.getType
     let abs ← abstractMVars revertedType (levels := false)
-    -- `abs.expr` is `fun ms => ∀ xs, body`. Telescope through both the
-    -- (lambda) mvar binders and exactly the `revertedFVars.size` (forall)
-    -- fvar binders that `revert` added, negate the original `body`, and
-    -- re-bind everything as a forall. We avoid peeling into deeper foralls
-    -- of the original `body` (e.g. an arrow like `¬X = X → False`), since
-    -- pushing the negation past a non-dependent arrow would change the
-    -- statement (`¬(A → B)` vs. `A → ¬B`).
-    lambdaTelescope abs.expr fun ms revBody => do
-      forallBoundedTelescope revBody (some revertedFVars.size) fun xs body => do
-        let negBody ← if (← Meta.isProp body) then
-          pure (mkNot body)
-        else
-          mkArrow body (mkConst ``False)
-        mkForallFVars (ms ++ xs) negBody
+    -- Pull the abstracted mvars' user names so we can later `intro` them
+    -- under those (sanitized) names rather than under the hygienic ones the
+    -- mvars carried internally.
+    let mvarNames ← abs.mvars.mapM fun mvarExpr => do
+      let n := (← mvarExpr.mvarId!.getDecl).userName.eraseMacroScopes
+      return if n.isAnonymous then `x else n
+    let negType ← lambdaTelescope abs.expr fun ms revBody => do
+      let negBody ← if (← Meta.isProp revBody) then
+        pure (mkNot revBody)
+      else
+        mkArrow revBody (mkConst ``False)
+      mkForallFVars ms negBody
+    return (negType, mvarNames)
   -- Close the original goal with `sorry` (without adding any axioms) *before*
   -- running the user's tactic. That way, if the inner tactic propagates a
   -- failure, no outer goal is left for the surrounding `by`/`runTactic` to
@@ -78,8 +75,13 @@ def evalImpossible : Tactic := fun stx => do
   -- messages and get a `sorry` from the outer `by`.
   let negMVarId :=
     (← mkFreshExprMVarAt {} {} negType (kind := .syntheticOpaque)).mvarId!
+  -- Intro the abstracted-mvar binders so the user's tactic sees them as
+  -- local hypotheses rather than as a leading `∀`. We pass cleaned-up
+  -- names (with hygiene scopes erased) so the introduced fvars are
+  -- accessible to the user by name.
+  let (_, innerMVarId) ← negMVarId.introN mvarNames.size mvarNames.toList
   try
-    setGoals [negMVarId]
+    setGoals [innerMVarId]
     withTacticInfoContext byTk do
       evalTactic tacs
       done

--- a/src/Lean/Elab/Tactic/Impossible.lean
+++ b/src/Lean/Elab/Tactic/Impossible.lean
@@ -11,7 +11,7 @@ public import Lean.Meta.Tactic.Cleanup
 public import Lean.Meta.Tactic.Revert
 public import Lean.Meta.Tactic.AuxLemma
 public import Lean.Meta.Tactic.Intro
-public import Lean.Meta.AbstractMVars
+public import Lean.Meta.Closure
 
 public section
 
@@ -19,65 +19,6 @@ public section
 
 namespace Lean.Elab.Tactic
 open Lean Meta
-
-/--
-Like `Meta.abstractMVars` with `levels := false`, but abstracts every
-expression metavariable found in `e` regardless of its mctx depth. This is
-sound for our use here, where the resulting type is only used as a *type*
-(a universally quantified obligation): treating a lower-depth mvar as
-universally quantified is a strictly stronger statement than treating it
-as a constant, so the impossibility witness still applies whatever value the
-parent context might eventually assign.
-
-Level metavariables are deliberately left alone.
--/
-private partial def abstractAllMVars (e : Expr) : MetaM AbstractMVarsResult := do
-  let e ← instantiateMVars e
-  let s : AbstractMVars.State :=
-    { mctx           := (← getMCtx)
-      lctx           := (← getLCtx)
-      ngen           := (← getNGen)
-      abstractLevels := false }
-  -- We mirror `AbstractMVars.abstractExprMVars`, but with the depth check
-  -- elided so mvars from any depth are abstracted.
-  let (e, s) := (go e).run s
-  setNGen s.ngen
-  setMCtx s.mctx
-  let lam := s.lctx.mkLambda s.fvars e
-  return { paramNames := s.paramNames, mvars := s.mvars, expr := lam }
-where
-  go (e : Expr) : StateM AbstractMVars.State Expr := do
-    if !e.hasMVar then return e
-    match e with
-    | .lit _ | .bvar _ | .fvar _ | .sort _ | .const _ _ => return e
-    | .proj _ _ b      => return e.updateProj! (← go b)
-    | .app f a         => return e.updateApp! (← go f) (← go a)
-    | .mdata _ b       => return e.updateMData! (← go b)
-    | .lam _ d b _     => return e.updateLambdaE! (← go d) (← go b)
-    | .forallE _ d b _ => return e.updateForallE! (← go d) (← go b)
-    | .letE _ t v b _  => return e.updateLetE! (← go t) (← go v) (← go b)
-    | .mvar mvarId =>
-      let decl := (← get).mctx.getDecl mvarId
-      match (← get).emap[mvarId]? with
-      | some e => return e
-      | none =>
-        let (mctxNew, instType) := Lean.instantiateExprMVarsImp (← get).mctx decl.type
-        modify ({ · with mctx := mctxNew })
-        let type ← go instType
-        let s ← get
-        let fresh := s.ngen.curr
-        let fvarId : FVarId := { name := fresh }
-        let fvar := mkFVar fvarId
-        let userName :=
-          if decl.userName.isAnonymous then (`x).appendIndexAfter s.fvars.size
-          else decl.userName
-        set { s with
-          ngen  := s.ngen.next
-          emap  := s.emap.insert mvarId fvar
-          fvars := s.fvars.push fvar
-          mvars := s.mvars.push e
-          lctx  := s.lctx.mkLocalDecl fvarId userName type }
-        return fvar
 
 @[builtin_tactic Lean.Parser.Tactic.impossible]
 def evalImpossible : Tactic := fun stx => do
@@ -104,19 +45,35 @@ def evalImpossible : Tactic := fun stx => do
       (clearAuxDeclsInsteadOfRevert := true)
       (← cleaned.getDecl).lctx.getFVarIds
     let revertedType ← reverted.getType
-    let abs ← abstractAllMVars revertedType
-    -- Pull the abstracted mvars' user names so we can later `intro` them
-    -- under those (sanitized) names rather than under the hygienic ones the
-    -- mvars carried internally.
-    let mvarNames ← abs.mvars.mapM fun mvarExpr => do
-      let n := (← mvarExpr.mvarId!.getDecl).userName.eraseMacroScopes
-      return if n.isAnonymous then `x else n
-    let negType ← lambdaTelescope abs.expr fun ms revBody => do
+    -- Re-use the aux-lemma machinery's closure builder to abstract over every
+    -- expression mvar in the reverted goal type. `mkValueTypeClosure` walks
+    -- the type without filtering by mctx depth (unlike `Meta.abstractMVars`),
+    -- and also correctly eta-expands delayed-assignment mvars — exactly what
+    -- `Closure.mkAuxTheorem` does when grind builds its aux lemma. The
+    -- `value` we pass is a placeholder; we only care about the abstracted
+    -- type and the original mvars (in `exprArgs`).
+    let r ← Closure.mkValueTypeClosure revertedType (mkConst ``True)
+      (zetaDelta := false)
+    -- `mkValueTypeClosure` also re-parameterizes universe parameters into
+    -- fresh names. We don't want to rename surrounding declaration's
+    -- universes (their original names appear in error messages and elsewhere),
+    -- so we substitute the fresh universe parameters back to the originals.
+    let rType := r.type.instantiateLevelParamsArray r.levelParams r.levelArgs
+    -- `rType` is `∀ ms, revertedType[ms]`. Peel exactly those binders so we
+    -- can push the negation under them (yielding `∀ ms, ¬revertedType`).
+    let negType ← forallBoundedTelescope rType (some r.exprArgs.size) fun ms revBody => do
       let negBody ← if (← Meta.isProp revBody) then
         pure (mkNot revBody)
       else
         mkArrow revBody (mkConst ``False)
       mkForallFVars ms negBody
+    -- Pull the abstracted mvars' user names from `r.exprArgs` so we can
+    -- later `intro` them under those (sanitized) names rather than under
+    -- the anonymous `_x.N`s the closure builder uses internally.
+    let mvarNames ← r.exprArgs.mapM fun mvarExpr => do
+      let .mvar mvarId := mvarExpr | return `x
+      let n := (← mvarId.getDecl).userName.eraseMacroScopes
+      return if n.isAnonymous then `x else n
     return (negType, mvarNames)
   -- Close the original goal with `sorry` (without adding any axioms) *before*
   -- running the user's tactic. That way, if the inner tactic propagates a

--- a/src/Lean/Elab/Tactic/Impossible.lean
+++ b/src/Lean/Elab/Tactic/Impossible.lean
@@ -10,7 +10,6 @@ public import Lean.Elab.Tactic.Basic
 public import Lean.Elab.ConfigEval
 public import Lean.Meta.Tactic.Cleanup
 public import Lean.Meta.Tactic.Revert
-public import Lean.Meta.Tactic.AuxLemma
 public import Lean.Meta.Tactic.Intro
 public import Lean.Meta.Closure
 
@@ -22,36 +21,12 @@ namespace Lean.Elab.Tactic
 open Lean Meta
 
 /--
-Given the main goal of `impossible`, compute the closed *negated reverted
-target* the user will be asked to inhabit, together with the names under which
-the abstracted metavariables should be introduced.
-
-The construction:
-
-* `revert` all local hypotheses, turning the goal into `∀ xs, body`. Cleanup
-  first so that aux decls etc. don't get reverted.
-* Run `Closure.mkValueTypeClosure` on the reverted type to abstract every
-  expression metavariable it mentions. We reuse this builder (rather than
-  `Meta.abstractMVars`) because it walks without the single-`mctx`-depth filter
-  and correctly eta-expands delayed-assignment metavariables — i.e. the same
-  guarantees `grind`'s `mkAuxTheorem` already relies on. The dummy value we
-  hand it is irrelevant; we only consume `.type` and `.exprArgs`.
-* Substitute the freshly-generated universe parameters back to the originals
-  (so the surrounding declaration's universes show up unchanged) — unless
-  `+levels` is set, in which case the originals are replaced with fresh
-  level metavariables so the user's tactic can specialize them.
-* Push the negation *under* the mvar binders but *over* the reverted-fvar
-  binders, yielding `∀ ms, ¬(∀ xs, body)`. The user can then `intro` each
-  mvar witness and reason about the existing local context as a universal.
-
-Returns the negated type together with the abstracted mvars' user names
-(verbatim, scopes included).
-
-Universe metavariables in the *goal type itself* are rejected by the caller
-before this function runs; if they slipped through, `mkValueTypeClosure`
-would happily abstract them too (turning them into fresh universe params),
-but the resulting goal state with `Sort ?u`-style binders is hard to work
-with, hence the upfront check.
+Builds the negated reverted target the user must inhabit, of the shape
+`∀ ms, ¬(∀ xs, body)` where `ms` are the goal's expression metavariables
+(abstracted via `mkValueTypeClosure`, which handles arbitrary mctx depths)
+and `xs` are the reverted local hypotheses. With `+levels`, the surrounding
+declaration's universe params become fresh level mvars instead of being
+substituted back. Returns the negated type and the mvar user names.
 -/
 private def mkImpossibleNegType (mainGoal : MVarId) (goalType : Expr)
     (cfg : Parser.Tactic.ImpossibleConfig) :
@@ -64,16 +39,6 @@ private def mkImpossibleNegType (mainGoal : MVarId) (goalType : Expr)
   let revertedType ← reverted.getType
   let r ← Closure.mkValueTypeClosure revertedType (mkConst ``True)
     (zetaDelta := false)
-  -- `mkValueTypeClosure` abstracts the surrounding declaration's universe
-  -- parameters as fresh universe params of its own. By default we substitute
-  -- them back to the originals (so the surrounding declaration's universes
-  -- show up unchanged in the goal); with `+levels` we replace them with
-  -- fresh level metavariables instead, so the user's tactic can specialize
-  -- them by picking witnesses at specific universes.
-  --
-  -- The original universe-parameter names are *not* preserved in the display:
-  -- the level pretty-printer (`Lean.Level.toResult`) always renders an mvar
-  -- with a decl in the mctx as `?u.<index>`, ignoring the underlying name.
   let rTypeLevels ←
     if cfg.levels then r.levelParams.mapM fun _ => mkFreshLevelMVar
     else pure r.levelArgs
@@ -104,46 +69,30 @@ def evalImpossible : Tactic := fun stx => do
     throwErrorAt kw "\
       `impossible`: goal contains universe metavariables{indentExpr goalType}"
   let (negType, mvarNames) ← mkImpossibleNegType mainGoal goalType cfg
-  -- Close the original goal with `sorry` (without adding any axioms) *before*
-  -- running the user's tactic. That way, if the inner tactic propagates a
-  -- failure, no outer goal is left for the surrounding `by`/`runTactic` to
-  -- spuriously report as unsolved on top of the inner error.
+  -- Admit before running the inner tactic so failures don't get an extra
+  -- spurious "unsolved goals" from the outer `by`.
   admitGoal mainGoal
   let restGoals ← getUnsolvedGoals
-  -- Run the user-supplied tactic against a fresh mvar for the negation, using
-  -- an empty local context (the reverted target is closed). We follow the
-  -- tactic with `done` so that an unsolved negated goal throws an
-  -- "unsolved goals" error (mirroring how `have h := by …` propagates failure
-  -- via its `case`/`closeUsingOrAdmit` expansion). Both inner elaboration
-  -- errors and unsolved goals therefore propagate naturally to combinators
-  -- like `first`, while direct user-facing uses still observe the inner
-  -- messages and get a `sorry` from the outer `by`.
   let negMVarId :=
     (← mkFreshExprMVarAt {} {} negType (kind := .syntheticOpaque)).mvarId!
-  -- Intro the abstracted-mvar binders so the user's tactic sees them as
-  -- local hypotheses rather than as a leading `∀`. The macro-scoped mvar
-  -- names are used as-is; the user can `expose_names` if they need to
-  -- refer to the introduced fvars by surface name.
   let (_, innerMVarId) ← negMVarId.introN mvarNames.size mvarNames.toList
   try
     setGoals [innerMVarId]
     withTacticInfoContext byTk do
       evalTactic tacs
       done
-    -- The user's tactic produced a proof of the negation. Hand it to the
-    -- kernel via a private aux theorem so kernel-level errors (e.g. proof
-    -- irrelevance / typechecking issues) surface here rather than being
-    -- silently absorbed by the `sorry` we put on the outer goal.
-    --
-    -- We use `mkAuxTheorem` rather than `mkAuxLemma` so that any level
-    -- metavariables the user's tactic left unassigned (which is fine: an
-    -- impossibility proof that works at any universe gives a parametric
-    -- counter-example) are closed over as fresh universe parameters of the
-    -- auxiliary lemma, rather than causing a "declaration has metavariables"
-    -- kernel rejection.
+    -- Hand the proof to the kernel via a private aux decl so kernel errors
+    -- surface here rather than being absorbed by the outer `sorry`. Close
+    -- over remaining (possibly level) mvars so a parametric counter-example
+    -- is accepted.
     let proof ← instantiateMVars (mkMVar negMVarId)
-    discard <| withOptions (Elab.async.set · false) do
-      mkAuxTheorem (← instantiateMVars negType) proof
+    let r ← Closure.mkValueTypeClosure (← instantiateMVars negType) proof
+      (zetaDelta := false)
+    let auxName ← mkAuxDeclName (kind := `_proof)
+    withOptions (Elab.async.set · false) do
+      addDecl <| .thmDecl
+        { name := auxName, levelParams := r.levelParams.toList,
+          type := r.type, value := r.value }
   finally
     setGoals restGoals
 

--- a/src/Lean/Elab/Tactic/Impossible.lean
+++ b/src/Lean/Elab/Tactic/Impossible.lean
@@ -88,7 +88,7 @@ def evalImpossible : Tactic := fun stx => do
     let proof ← instantiateMVars (mkMVar negMVarId)
     let r ← Closure.mkValueTypeClosure (← instantiateMVars negType) proof
       (zetaDelta := false)
-    let auxName ← mkAuxDeclName (kind := `_proof)
+    let auxName ← mkAuxDeclName (kind := `_impossible)
     withOptions (Elab.async.set · false) do
       addDecl <| .thmDecl
         { name := auxName, levelParams := r.levelParams.toList,

--- a/src/Lean/Elab/Tactic/Impossible.lean
+++ b/src/Lean/Elab/Tactic/Impossible.lean
@@ -10,6 +10,7 @@ public import Lean.Elab.Tactic.Basic
 public import Lean.Meta.Tactic.Cleanup
 public import Lean.Meta.Tactic.Revert
 public import Lean.Meta.Tactic.AuxLemma
+public import Lean.Meta.AbstractMVars
 
 public section
 
@@ -25,26 +26,42 @@ def evalImpossible : Tactic := fun stx => do
   let tacs := stx[2]
   let mainGoal ← getMainGoal
   let goalType ← mainGoal.withContext do instantiateMVars (← mainGoal.getType)
-  if goalType.hasExprMVar then
-    throwErrorAt kw "\
-      `impossible`: goal contains metavariables{indentExpr goalType}"
   if goalType.hasLevelMVar then
     throwErrorAt kw "\
       `impossible`: goal contains universe metavariables{indentExpr goalType}"
   -- Compute the reverted, negated target from a discardable copy of the main
-  -- goal, so the original `mainGoal` remains assignable below. We use `Not`
-  -- on propositions and fall back to `_ → False` otherwise so the construction
-  -- is well-typed at any universe.
+  -- goal, so the original `mainGoal` remains assignable below. We:
+  --   * revert all local hypotheses, turning the goal into `∀ xs, body`;
+  --   * abstract over remaining expression metavariables, turning the result
+  --     into `∀ ms, ∀ xs, body` (so `impossible` can be applied to
+  --     under-determined goals like `∃ x, …`); level mvars are left alone
+  --     because abstracting them tends to make tactic state hard to read;
+  --   * push the negation *under* the universal binders, yielding
+  --     `∀ ms, ∀ xs, ¬body` (or `∀ ms, ∀ xs, body → False` when `body` isn't
+  --     a proposition). This lets the user prove impossibility by `intro`ing
+  --     witnesses for the binders and then deriving `False`.
   let negType ← mainGoal.withContext do
     let dummy ← mkFreshExprSyntheticOpaqueMVar goalType
     let cleaned ← dummy.mvarId!.cleanup
-    let (_, reverted) ← cleaned.revert (clearAuxDeclsInsteadOfRevert := true)
+    let (revertedFVars, reverted) ← cleaned.revert
+      (clearAuxDeclsInsteadOfRevert := true)
       (← cleaned.getDecl).lctx.getFVarIds
     let revertedType ← reverted.getType
-    if (← Meta.isProp revertedType) then
-      pure (mkNot revertedType)
-    else
-      mkArrow revertedType (mkConst ``False)
+    let abs ← abstractMVars revertedType (levels := false)
+    -- `abs.expr` is `fun ms => ∀ xs, body`. Telescope through both the
+    -- (lambda) mvar binders and exactly the `revertedFVars.size` (forall)
+    -- fvar binders that `revert` added, negate the original `body`, and
+    -- re-bind everything as a forall. We avoid peeling into deeper foralls
+    -- of the original `body` (e.g. an arrow like `¬X = X → False`), since
+    -- pushing the negation past a non-dependent arrow would change the
+    -- statement (`¬(A → B)` vs. `A → ¬B`).
+    lambdaTelescope abs.expr fun ms revBody => do
+      forallBoundedTelescope revBody (some revertedFVars.size) fun xs body => do
+        let negBody ← if (← Meta.isProp body) then
+          pure (mkNot body)
+        else
+          mkArrow body (mkConst ``False)
+        mkForallFVars (ms ++ xs) negBody
   -- Close the original goal with `sorry` (without adding any axioms) *before*
   -- running the user's tactic. That way, if the inner tactic propagates a
   -- failure, no outer goal is left for the surrounding `by`/`runTactic` to

--- a/src/Lean/Elab/Tactic/Try.lean
+++ b/src/Lean/Elab/Tactic/Try.lean
@@ -1003,6 +1003,14 @@ private unsafe def mkTryEvalSuggestStxUnsafe (goal : MVarId) (info : Try.Info) :
   let grind ← mkGrindStx info
 
   let atomic ← `(tactic| attempt_all_par | $simple:tactic | $simp:tactic | $grind:tactic | simp_all)
+  -- Try to show the goal is unreachable. Only one suggestion is reported, so we
+  -- use `first_par` rather than `attempt_all_par`. This is intentionally not
+  -- folded into `atomic`, because `atomic` is reused inside the
+  -- `induction`/`fun_induction` branches: suggesting `impossible` for an
+  -- individual subgoal of a case split would be incorrect — it would discharge
+  -- a single case with `sorry` rather than proving the overall induction.
+  let impossible ← `(tactic|
+    first_par | impossible by decide | impossible by simp | impossible by grind)
   let atomicSuggestions ← mkAtomicWithSuggestionsStx
   let atomicOrSuggestions ← `(tactic| first | $atomic:tactic | $atomicSuggestions:tactic)
   let funInds ← mkAllFunIndStx info atomicOrSuggestions
@@ -1011,10 +1019,10 @@ private unsafe def mkTryEvalSuggestStxUnsafe (goal : MVarId) (info : Try.Info) :
 
   -- Build final tactic: built-ins first, then user suggestions as fallback
   if userTactics.isEmpty then
-    `(tactic| first | $atomic:tactic | $atomicSuggestions:tactic | $funInds:tactic | $inds:tactic | $extra:tactic)
+    `(tactic| first | $atomic:tactic | $impossible:tactic | $atomicSuggestions:tactic | $funInds:tactic | $inds:tactic | $extra:tactic)
   else
     let userAttemptAll ← `(tactic| attempt_all_par $[| $userTactics:tactic]*)
-    `(tactic| first | $atomic:tactic | $atomicSuggestions:tactic | $funInds:tactic | $inds:tactic | $extra:tactic | $userAttemptAll:tactic)
+    `(tactic| first | $atomic:tactic | $impossible:tactic | $atomicSuggestions:tactic | $funInds:tactic | $inds:tactic | $extra:tactic | $userAttemptAll:tactic)
 
 @[implemented_by mkTryEvalSuggestStxUnsafe]
 private opaque mkTryEvalSuggestStx (goal : MVarId) (info : Try.Info) : MetaM (TSyntax `tactic)

--- a/tests/elab/impossibleTactic.lean
+++ b/tests/elab/impossibleTactic.lean
@@ -182,15 +182,20 @@ end
 -- The `+levels` option abstracts universe parameters of the surrounding
 -- declaration as fresh level metavariables in the negated goal, so the user
 -- can refute a universe-polymorphic claim by exhibiting witnesses at
--- specific universes.
+-- specific universes. Note that the level pretty-printer doesn't preserve
+-- the original universe parameter names — they show as `?u.<N>`/`?u.<M>`
+-- in the goal state.
+set_option pp.mvars false in
 /--
+trace: ⊢ ¬∀ (α : Type _) (β : Type _), ¬ULift α = ULift β
+---
 warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (α : Type u) (β : Type v) : ¬(ULift.{v} α = ULift.{u} β) := by
   impossible +levels by
+    trace_state
     intro h
-    -- `h : ∀ (α : Type ?u) (β : Type ?v), ¬(ULift α = ULift β)`.
     -- Specializing at `Unit : Type 0` unifies both universe mvars.
     exact h Unit Unit rfl
 

--- a/tests/elab/impossibleTactic.lean
+++ b/tests/elab/impossibleTactic.lean
@@ -48,6 +48,19 @@ error: unsolved goals
 example : Nat := by
   impossible by skip
 
+-- Universe parameters of the surrounding declaration are not abstracted: the
+-- negated target inherits them as fixed `Type u` / `Type v` binders rather than
+-- universe mvars.
+/--
+error: unsolved goals
+α : Type u
+β : Type v
+⊢ ¬∀ (α : Type u) (β : Type v), ¬ULift α = ULift β
+-/
+#guard_msgs in
+example (α : Type u) (β : Type v) : ¬(ULift.{v} α = ULift.{u} β) := by
+  impossible by skip
+
 -- The tactic should complain if the goal contains expression metavariables.
 section
 opaque P : Nat → Prop

--- a/tests/elab/impossibleTactic.lean
+++ b/tests/elab/impossibleTactic.lean
@@ -1,8 +1,7 @@
 import Lean
 /-! # Tests for the `impossible` tactic combinator -/
 
--- Closed goal: the user proves the plain negation.
-
+-- Closed goal: the negation has no binders, so the user proves it directly.
 /--
 warning: declaration uses `sorry`
 -/
@@ -20,15 +19,54 @@ error: unsolved goals
 example : 0 = 0 := by
   impossible by skip
 
--- The tactic reverts all hypotheses, producing a closed-form negation.
+-- The tactic reverts all hypotheses and pushes the negation under the
+-- universal binders, so the user can `intro` witnesses and derive `False`.
 /--
 warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (n : Nat) : n = n + 1 := by
   impossible by
-    intro h
-    exact Nat.succ_ne_zero _ ((h 0).symm)
+    intro n h
+    omega
+
+-- Expression metavariables in the goal are abstracted as additional universal
+-- binders. This is what makes `impossible` usable inside an `∃`-introduction
+-- (the user does `refine Exists.intro ?w ?h` and addresses `?h` first while
+-- `?w` is still a metavariable). The body is negated under all binders, so the
+-- user can `intro` each witness and case-split.
+/--
+warning: declaration uses `sorry`
+-/
+#guard_msgs in
+example : ∃ x, x * x = 2 := by
+  refine Exists.intro ?w ?h
+  case h =>
+    impossible by
+      intro x hx
+      cases x <;> grind
+  case w =>
+    exact 0
+
+-- An mvar whose *type* depends on a reverted local hypothesis gets generalized
+-- to a function type (since `revert` + `abstractMVars` together produce the
+-- right Pi). This is less ergonomic than the independent case but logically
+-- sound: the user receives a witness function from the dependency.
+/--
+warning: declaration uses `sorry`
+---
+warning: declaration uses `sorry`
+-/
+#guard_msgs in
+example (n : Nat) : ∃ v : Vector Nat n, v[0]? = some 0 := by
+  refine Exists.intro ?v ?h
+  case h =>
+    impossible by
+      intro vfun n h
+      -- `vfun : (n : Nat) → Vector Nat n` is the abstracted `?v`.
+      sorry
+  case v =>
+    exact Vector.replicate n 0
 
 -- Goal `False`: `¬False` is `False → False`, which is closed by `exact id`.
 /--
@@ -49,14 +87,14 @@ example : Nat := by
   impossible by skip
 
 -- Universe parameters of the surrounding declaration are not abstracted: the
--- negated target inherits them as fixed `Type u` / `Type v` binders rather than
--- universe mvars.
+-- negated target inherits them as fixed `Type u` / `Type v` binders rather
+-- than universe mvars.
 /--
 error: unsolved goals
-⊢ ¬∀ (α : Type u) (β : Type v), ¬ULift α = ULift β
+⊢ ∀ (α : Type u) (β : Type v), ¬ULift α = ULift β
 -/
 #guard_msgs in
-example (α : Type u) (β : Type v) : ¬(ULift.{v} α = ULift.{u} β) := by
+example (α : Type u) (β : Type v) : ULift.{v} α = ULift.{u} β := by
   impossible by skip
 
 -- The proof of the negation is registered as a private aux lemma, which means
@@ -78,21 +116,6 @@ example : ¬True := by
   impossible by
     intro _
     _fake_close
-
--- The tactic should complain if the goal contains expression metavariables.
-section
-opaque P : Nat → Prop
-opaque h : ∀ {n : Nat}, P n → True
-/--
-@ +3:2...12
-error: `impossible`: goal contains metavariables
-  P ?n
--/
-#guard_msgs (positions := true) in
-example : True := by
-  apply h
-  impossible by intro h; exact h
-end
 
 -- The tactic should complain if the goal contains universe metavariables. We
 -- have to inject one manually since user-level `Sort _` is auto-bound.
@@ -120,7 +143,7 @@ error: Unknown identifier `this_identifier_does_not_exist`
 -/
 #guard_msgs in
 example (n : Nat) : n = 0 := by
-  impossible by exact this_identifier_does_not_exist
+  impossible by intro n; exact this_identifier_does_not_exist
 
 -- `impossible` plays well with surrounding tactic combinators.
 /--

--- a/tests/elab/impossibleTactic.lean
+++ b/tests/elab/impossibleTactic.lean
@@ -125,6 +125,39 @@ example : ¬True := by
     intro _
     _fake_close
 
+-- An expression metavariable that lives at a lower `mctx` depth (e.g. from a
+-- surrounding `withNewMCtxDepth`) still gets abstracted: we want every mvar
+-- in the goal to become a universal binder, regardless of its depth, since
+-- the resulting type is only used as a proof obligation. The unrelated
+-- `(kernel) declaration has metavariables` here comes from the synthetic
+-- injection leaving its own outer mvar unassigned and is not part of what
+-- `impossible` is being asserted about.
+section
+open Lean Lean.Elab Lean.Elab.Tactic Lean.Meta in
+elab "_with_lower_depth_mvar_goal" : tactic => do
+  let lowMVar ← mkFreshExprMVar (mkConst ``Nat)
+  let mctx ← Lean.getMCtx
+  Lean.setMCtx { mctx with depth := mctx.depth + 1 }
+  let goalType := mkApp3 (mkConst ``Eq [.succ .zero]) (mkConst ``Nat) lowMVar (mkNatLit 0)
+  let g ← mkFreshExprSyntheticOpaqueMVar goalType
+  setGoals [g.mvarId!]
+/--
+warning: declaration uses `sorry`
+---
+trace: x : Nat
+⊢ ¬x = 0
+---
+error: (kernel) declaration has metavariables '_example'
+-/
+#guard_msgs in
+example : True := by
+  _with_lower_depth_mvar_goal
+  impossible by
+    trace_state
+    intro h
+    exact (by sorry : False)
+end
+
 -- The tactic should complain if the goal contains universe metavariables. We
 -- have to inject one manually since user-level `Sort _` is auto-bound.
 section

--- a/tests/elab/impossibleTactic.lean
+++ b/tests/elab/impossibleTactic.lean
@@ -171,12 +171,28 @@ set_option pp.mvars false in
 /--
 error: `impossible`: goal contains universe metavariables
   Subsingleton (Sort _)
+Hint: use `impossible +levels by …` to abstract them.
 -/
 #guard_msgs in
 example : True := by
   with_level_mvar_goal
   impossible by skip
 end
+
+-- The `+levels` option abstracts universe parameters of the surrounding
+-- declaration as fresh level metavariables in the negated goal, so the user
+-- can refute a universe-polymorphic claim by exhibiting witnesses at
+-- specific universes.
+/--
+warning: declaration uses `sorry`
+-/
+#guard_msgs in
+example (α : Type u) (β : Type v) : ¬(ULift.{v} α = ULift.{u} β) := by
+  impossible +levels by
+    intro h
+    -- `h : ∀ (α : Type ?u) (β : Type ?v), ¬(ULift α = ULift β)`.
+    -- Specializing at `Unit : Type 0` unifies both universe mvars.
+    exact h Unit Unit rfl
 
 -- Errors in the user's term/tactic are surfaced normally.
 /--

--- a/tests/elab/impossibleTactic.lean
+++ b/tests/elab/impossibleTactic.lean
@@ -114,7 +114,7 @@ elab "_fake_close" : tactic => do
   let mvar ← getMainGoal
   mvar.assign (mkNatLit 0)
 /--
-error: (kernel) declaration type mismatch, '_example._proof_1' has type
+error: (kernel) declaration type mismatch, '_example._impossible_1' has type
   ¬True → Nat
 but it is expected to have type
   ¬¬True

--- a/tests/elab/impossibleTactic.lean
+++ b/tests/elab/impossibleTactic.lean
@@ -30,13 +30,13 @@ example (n : Nat) : n = n + 1 := by
     intro h
     exact Nat.succ_ne_zero _ ((h 0).symm)
 
--- The tactic accepts arbitrary terms, not just `by` blocks.
+-- Goal `False`: `¬False` is `False → False`, which is closed by `exact id`.
 /--
 warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : False := by
-  impossible id
+  impossible by exact id
 
 -- The tactic works at any universe, including non-`Prop` goals: it falls back
 -- to `_ → False` instead of `Not _` so the construction is well-typed.

--- a/tests/elab/impossibleTactic.lean
+++ b/tests/elab/impossibleTactic.lean
@@ -200,14 +200,15 @@ example (α : Type u) (β : Type v) : ¬(ULift.{v} α = ULift.{u} β) := by
     exact h Unit Unit rfl
 
 -- If the inner tactic doesn't pin down all the level mvars (e.g. it uses
--- `sorry` without constraining them), the resulting auxiliary lemma carries
--- unresolved level metavariables and the kernel rejects it. This surfaces
--- as a `(kernel) declaration has metavariables` diagnostic, which is the
--- expected behaviour — `impossible` doesn't silently accept the proof.
+-- `sorry` without constraining them), `mkAuxTheorem` closes over the
+-- remaining level mvars as fresh universe parameters of the auxiliary
+-- lemma. Semantically: a counter-example that works at any level is a
+-- *parametric* counter-example, which is fine — we don't need to spuriously
+-- pin a universe just to make the kernel happy.
 /--
 warning: declaration uses `sorry`
 ---
-error: (kernel) declaration has metavariables '_example._proof_1'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (α : Type u) (β : Type v) : ¬(ULift.{v} α = ULift.{u} β) := by

--- a/tests/elab/impossibleTactic.lean
+++ b/tests/elab/impossibleTactic.lean
@@ -171,7 +171,6 @@ set_option pp.mvars false in
 /--
 error: `impossible`: goal contains universe metavariables
   Subsingleton (Sort _)
-Hint: use `impossible +levels by …` to abstract them.
 -/
 #guard_msgs in
 example : True := by

--- a/tests/elab/impossibleTactic.lean
+++ b/tests/elab/impossibleTactic.lean
@@ -19,23 +19,28 @@ error: unsolved goals
 example : 0 = 0 := by
   impossible by skip
 
--- The tactic reverts all hypotheses and pushes the negation under the
--- universal binders, so the user can `intro` witnesses and derive `False`.
+-- The tactic reverts all hypotheses, so the user can refute the original
+-- universal by exhibiting a counter-witness for the local context.
 /--
+trace: ⊢ ¬∀ (n : Nat), n = n + 1
+---
 warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example (n : Nat) : n = n + 1 := by
   impossible by
-    intro n h
-    omega
+    trace_state
+    intro h
+    exact Nat.succ_ne_zero _ ((h 0).symm)
 
--- Expression metavariables in the goal are abstracted as additional universal
--- binders. This is what makes `impossible` usable inside an `∃`-introduction
--- (the user does `refine Exists.intro ?w ?h` and addresses `?h` first while
--- `?w` is still a metavariable). The body is negated under all binders, so the
--- user can `intro` each witness and case-split.
+-- Expression metavariables in the goal are abstracted as additional binders;
+-- those are introduced into the local context *before* the user's tactic runs,
+-- with the negation pushed under the mvar binders but over the reverted ones.
+-- This is what makes `impossible` usable inside an `∃`-introduction.
 /--
+trace: w : Nat
+⊢ ¬w * w = 2
+---
 warning: declaration uses `sorry`
 -/
 #guard_msgs in
@@ -43,17 +48,21 @@ example : ∃ x, x * x = 2 := by
   refine Exists.intro ?w ?h
   case h =>
     impossible by
-      intro x hx
-      cases x <;> grind
+      trace_state
+      intro hx
+      cases w <;> grind
   case w =>
     exact 0
 
 -- An mvar whose *type* depends on a reverted local hypothesis gets generalized
--- to a function type (since `revert` + `abstractMVars` together produce the
--- right Pi). This is less ergonomic than the independent case but logically
--- sound: the user receives a witness function from the dependency.
+-- to a function type (since `revert` produces the right Pi and the original
+-- mvar gets replaced with a fresh anonymous one — hence the fallback name
+-- `x`, rather than `v`).
 /--
 warning: declaration uses `sorry`
+---
+trace: x : (n : Nat) → Vector Nat n
+⊢ ¬∀ (n : Nat), (x n)[0]? = some 0
 ---
 warning: declaration uses `sorry`
 -/
@@ -62,8 +71,7 @@ example (n : Nat) : ∃ v : Vector Nat n, v[0]? = some 0 := by
   refine Exists.intro ?v ?h
   case h =>
     impossible by
-      intro vfun n h
-      -- `vfun : (n : Nat) → Vector Nat n` is the abstracted `?v`.
+      trace_state
       sorry
   case v =>
     exact Vector.replicate n 0
@@ -91,7 +99,7 @@ example : Nat := by
 -- than universe mvars.
 /--
 error: unsolved goals
-⊢ ∀ (α : Type u) (β : Type v), ¬ULift α = ULift β
+⊢ ¬∀ (α : Type u) (β : Type v), ULift α = ULift β
 -/
 #guard_msgs in
 example (α : Type u) (β : Type v) : ULift.{v} α = ULift.{u} β := by
@@ -143,7 +151,7 @@ error: Unknown identifier `this_identifier_does_not_exist`
 -/
 #guard_msgs in
 example (n : Nat) : n = 0 := by
-  impossible by intro n; exact this_identifier_does_not_exist
+  impossible by intro h; exact this_identifier_does_not_exist
 
 -- `impossible` plays well with surrounding tactic combinators.
 /--

--- a/tests/elab/impossibleTactic.lean
+++ b/tests/elab/impossibleTactic.lean
@@ -53,13 +53,31 @@ example : Nat := by
 -- universe mvars.
 /--
 error: unsolved goals
-α : Type u
-β : Type v
 ⊢ ¬∀ (α : Type u) (β : Type v), ¬ULift α = ULift β
 -/
 #guard_msgs in
 example (α : Type u) (β : Type v) : ¬(ULift.{v} α = ULift.{u} β) := by
   impossible by skip
+
+-- The proof of the negation is registered as a private aux lemma, which means
+-- the kernel re-checks it. A tactic that produces a syntactically well-formed
+-- but ill-typed mvar assignment (here, a `Nat` literal where a proof is
+-- expected) is therefore rejected by the kernel rather than silently absorbed.
+open Lean Lean.Elab Lean.Elab.Tactic in
+elab "_fake_close" : tactic => do
+  let mvar ← getMainGoal
+  mvar.assign (mkNatLit 0)
+/--
+error: (kernel) declaration type mismatch, '_example._proof_1' has type
+  ¬True → Nat
+but it is expected to have type
+  ¬¬True
+-/
+#guard_msgs in
+example : ¬True := by
+  impossible by
+    intro _
+    _fake_close
 
 -- The tactic should complain if the goal contains expression metavariables.
 section

--- a/tests/elab/impossibleTactic.lean
+++ b/tests/elab/impossibleTactic.lean
@@ -1,0 +1,121 @@
+import Lean
+/-! # Tests for the `impossible` tactic combinator -/
+
+-- Closed goal: the user proves the plain negation.
+
+/--
+warning: declaration uses `sorry`
+-/
+#guard_msgs in
+example : 0 = 1 := by
+  impossible by decide
+
+-- When the user's tactic fails to close the negation, the normal `unsolved goals`
+-- error is reported (no error suppression).
+/--
+error: unsolved goals
+⊢ ¬0 = 0
+-/
+#guard_msgs in
+example : 0 = 0 := by
+  impossible by skip
+
+-- The tactic reverts all hypotheses, producing a closed-form negation.
+/--
+warning: declaration uses `sorry`
+-/
+#guard_msgs in
+example (n : Nat) : n = n + 1 := by
+  impossible by
+    intro h
+    exact Nat.succ_ne_zero _ ((h 0).symm)
+
+-- The tactic accepts arbitrary terms, not just `by` blocks.
+/--
+warning: declaration uses `sorry`
+-/
+#guard_msgs in
+example : False := by
+  impossible id
+
+-- The tactic should complain (with range = `impossible` keyword) if the goal is
+-- not a proposition.
+/--
+@ +2:2...12
+error: `impossible`: goal is not a proposition
+  Nat
+-/
+#guard_msgs (positions := true) in
+example : Nat := by
+  impossible by skip
+
+-- The tactic should complain if the goal contains expression metavariables.
+section
+opaque P : Nat → Prop
+opaque h : ∀ {n : Nat}, P n → True
+/--
+@ +3:2...12
+error: `impossible`: goal contains metavariables
+  P ?n
+-/
+#guard_msgs (positions := true) in
+example : True := by
+  apply h
+  impossible by intro h; exact h
+end
+
+-- The tactic should complain if the goal contains universe metavariables. We
+-- have to inject one manually since user-level `Sort _` is auto-bound.
+section
+open Lean Lean.Elab.Tactic in
+elab "with_level_mvar_goal" : tactic => do
+  let lvl ← Lean.Meta.mkFreshLevelMVar
+  let ty := mkApp (mkConst ``Subsingleton [lvl]) (mkSort lvl)
+  let g ← Lean.Meta.mkFreshExprSyntheticOpaqueMVar ty
+  setGoals [g.mvarId!]
+set_option pp.mvars false in
+/--
+error: `impossible`: goal contains universe metavariables
+  Subsingleton (Sort _)
+-/
+#guard_msgs in
+example : True := by
+  with_level_mvar_goal
+  impossible by skip
+end
+
+-- Errors in the user's term/tactic are surfaced normally.
+/--
+error: Unknown identifier `this_identifier_does_not_exist`
+-/
+#guard_msgs in
+example (n : Nat) : n = 0 := by
+  impossible by exact this_identifier_does_not_exist
+
+-- `impossible` plays well with surrounding tactic combinators.
+/--
+warning: declaration uses `sorry`
+-/
+#guard_msgs in
+example : 0 = 1 := by
+  first | impossible by decide | exact rfl
+
+-- `impossible` fails when there is no goal.
+/--
+error: No goals to be solved
+-/
+#guard_msgs in
+example : True := by
+  trivial
+  impossible by skip
+
+-- With multiple goals, `impossible` only admits the first; the second is left
+-- for the next tactic.
+/--
+warning: declaration uses `sorry`
+-/
+#guard_msgs in
+example : 0 = 1 ∧ True := by
+  constructor
+  impossible by decide
+  trivial

--- a/tests/elab/impossibleTactic.lean
+++ b/tests/elab/impossibleTactic.lean
@@ -199,6 +199,22 @@ example (α : Type u) (β : Type v) : ¬(ULift.{v} α = ULift.{u} β) := by
     -- Specializing at `Unit : Type 0` unifies both universe mvars.
     exact h Unit Unit rfl
 
+-- If the inner tactic doesn't pin down all the level mvars (e.g. it uses
+-- `sorry` without constraining them), the resulting auxiliary lemma carries
+-- unresolved level metavariables and the kernel rejects it. This surfaces
+-- as a `(kernel) declaration has metavariables` diagnostic, which is the
+-- expected behaviour — `impossible` doesn't silently accept the proof.
+/--
+warning: declaration uses `sorry`
+---
+error: (kernel) declaration has metavariables '_example._proof_1'
+-/
+#guard_msgs in
+example (α : Type u) (β : Type v) : ¬(ULift.{v} α = ULift.{u} β) := by
+  impossible +levels by
+    intro _
+    exact sorry
+
 -- Errors in the user's term/tactic are surfaced normally.
 /--
 error: Unknown identifier `this_identifier_does_not_exist`

--- a/tests/elab/impossibleTactic.lean
+++ b/tests/elab/impossibleTactic.lean
@@ -38,14 +38,13 @@ warning: declaration uses `sorry`
 example : False := by
   impossible id
 
--- The tactic should complain (with range = `impossible` keyword) if the goal is
--- not a proposition.
+-- The tactic works at any universe, including non-`Prop` goals: it falls back
+-- to `_ → False` instead of `Not _` so the construction is well-typed.
 /--
-@ +2:2...12
-error: `impossible`: goal is not a proposition
-  Nat
+error: unsolved goals
+⊢ ∀ (x : Nat), False
 -/
-#guard_msgs (positions := true) in
+#guard_msgs in
 example : Nat := by
   impossible by skip
 

--- a/tests/elab/prelude-injectivity.lean
+++ b/tests/elab/prelude-injectivity.lean
@@ -21,6 +21,7 @@ gen_injective_theorems% Syntax.SepArray
 gen_injective_theorems% Syntax.TSepArray
 gen_injective_theorems% Try.Config
 gen_injective_theorems% Parser.Tactic.DecideConfig
+gen_injective_theorems% Parser.Tactic.ImpossibleConfig
 gen_injective_theorems% Parser.Tactic.LibrarySearchConfig
 -/
 #guard_msgs in

--- a/tests/elab/qed_macro.lean
+++ b/tests/elab/qed_macro.lean
@@ -46,12 +46,14 @@ info: Try these:
 example (a b : Nat) (h : a = b) : b = a :=
   ∎
 
--- Check that error messages are appropriate when try? fails
+-- Check that error messages are appropriate when try? fails. We use an opaque
+-- Prop so the default branches (including `impossible by …`) can't dispatch it.
+opaque QedTestOpaque : Prop
 /--
 error: Tactic `try?` failed: consider using `grind` manually, or `try? +missing` for partial proofs containing `sorry`
 
-⊢ False
+⊢ QedTestOpaque
 -/
 #guard_msgs in
-example : False := by
+example : QedTestOpaque := by
   ∎

--- a/tests/elab/tryOnEmptyBy.lean
+++ b/tests/elab/tryOnEmptyBy.lean
@@ -50,12 +50,15 @@ example : True := by { }
 
 -- Unprovable goal: try? finds no suggestions, so the implicit mode is fully silent
 -- (no "Try this", no error or warning from try? itself — only the unsolved-goals error).
+-- We use an opaque Prop so the default branches (including `impossible by decide |
+-- impossible by simp | impossible by grind`) cannot dispatch it.
+opaque OpaqueProp : Prop
 /--
 error: unsolved goals
-⊢ False
+⊢ OpaqueProp
 -/
 #guard_msgs in
-example : False := by
+example : OpaqueProp := by
 
 -- Nested in a backtracking combinator (`errToSorry = false`): try? must stay silent.
 -- We only assert the absence of the try? info message; the unsolved-goals error is expected

--- a/tests/server_interactive/impossibleTactic.lean
+++ b/tests/server_interactive/impossibleTactic.lean
@@ -1,0 +1,12 @@
+/-!
+Tests that `impossible by ...` provides the same hover / goal info as a regular
+`by` block, via the term elaborator.
+-/
+
+example (n : Nat) : n = n + 1 := by
+  impossible by
+            --^ $/lean/plainGoal
+    intro h
+   --^ textDocument/hover
+    exact Nat.succ_ne_zero _ ((h 0).symm)
+   --^ textDocument/hover

--- a/tests/server_interactive/impossibleTactic.lean
+++ b/tests/server_interactive/impossibleTactic.lean
@@ -6,7 +6,7 @@ Tests that `impossible by ...` provides the same hover / goal info as a regular
 example (n : Nat) : n = n + 1 := by
   impossible by
             --^ $/lean/plainGoal
-    intro n h
+    intro h
    --^ textDocument/hover
-    omega
+    exact Nat.succ_ne_zero _ ((h 0).symm)
    --^ textDocument/hover

--- a/tests/server_interactive/impossibleTactic.lean
+++ b/tests/server_interactive/impossibleTactic.lean
@@ -6,7 +6,7 @@ Tests that `impossible by ...` provides the same hover / goal info as a regular
 example (n : Nat) : n = n + 1 := by
   impossible by
             --^ $/lean/plainGoal
-    intro h
+    intro n h
    --^ textDocument/hover
-    exact Nat.succ_ne_zero _ ((h 0).symm)
+    omega
    --^ textDocument/hover

--- a/tests/server_interactive/impossibleTactic.lean.out.expected
+++ b/tests/server_interactive/impossibleTactic.lean.out.expected
@@ -1,11 +1,11 @@
 {"textDocument": {"uri": "file:///impossibleTactic.lean"},
  "position": {"line": 6, "character": 14}}
-{"rendered": "```lean\n⊢ ¬∀ (n : Nat), n = n + 1\n```",
- "goals": ["⊢ ¬∀ (n : Nat), n = n + 1"]}
+{"rendered": "```lean\n⊢ ∀ (n : Nat), ¬n = n + 1\n```",
+ "goals": ["⊢ ∀ (n : Nat), ¬n = n + 1"]}
 {"textDocument": {"uri": "file:///impossibleTactic.lean"},
  "position": {"line": 8, "character": 5}}
 {"range":
- {"start": {"line": 8, "character": 4}, "end": {"line": 8, "character": 11}},
+ {"start": {"line": 8, "character": 4}, "end": {"line": 8, "character": 13}},
  "contents":
  {"value":
   "Introduces one or more hypotheses, optionally naming and/or pattern-matching them.\nFor each hypothesis to be introduced, the remaining main goal's target type must\nbe a `let` or function type.\n\n* `intro` by itself introduces one anonymous hypothesis, which can be accessed\n  by e.g. `assumption`. It is equivalent to `intro _`.\n* `intro x y` introduces two hypotheses and names them. Individual hypotheses\n  can be anonymized via `_`, given a type ascription, or matched against a pattern:\n  ```lean\n  -- ... ⊢ α × β → ...\n  intro (a, b)\n  -- ..., a : α, b : β ⊢ ...\n  ```\n* `intro rfl` is short for `intro h; subst h`, if `h` is an equality where the left-hand or right-hand side\n  is a variable.\n* Alternatively, `intro` can be combined with pattern matching much like `fun`:\n  ```lean\n  intro\n  | n + 1, 0 => tac\n  | ...\n  ```\n",
@@ -13,8 +13,8 @@
 {"textDocument": {"uri": "file:///impossibleTactic.lean"},
  "position": {"line": 10, "character": 5}}
 {"range":
- {"start": {"line": 10, "character": 4}, "end": {"line": 10, "character": 41}},
+ {"start": {"line": 10, "character": 4}, "end": {"line": 10, "character": 9}},
  "contents":
  {"value":
-  "`exact e` closes the main goal if its target type matches that of `e`.\n",
+  "The `omega` tactic, for resolving integer and natural linear arithmetic problems.\n\nIt is not yet a full decision procedure (no \"dark\" or \"grey\" shadows),\nbut should be effective on many problems.\n\nWe handle hypotheses of the form `x = y`, `x < y`, `x ≤ y`, and `k ∣ x` for `x y` in `Nat` or `Int`\n(and `k` a literal), along with negations of these statements.\n\nWe decompose the sides of the inequalities as linear combinations of atoms.\n\nIf we encounter `x / k` or `x % k` for literal integers `k` we introduce new auxiliary variables\nand the relevant inequalities.\n\nOn the first pass, we do not perform case splits on natural subtraction.\nIf `omega` fails, we recursively perform a case split on\na natural subtraction appearing in a hypothesis, and try again.\n\nThe options\n```\nomega +splitDisjunctions +splitNatSub +splitNatAbs +splitMinMax\n```\ncan be used to:\n* `splitDisjunctions`: split any disjunctions found in the context,\n  if the problem is not otherwise solvable.\n* `splitNatSub`: for each appearance of `((a - b : Nat) : Int)`, split on `a ≤ b` if necessary.\n* `splitNatAbs`: for each appearance of `Int.natAbs a`, split on `0 ≤ a` if necessary.\n* `splitMinMax`: for each occurrence of `min a b`, split on `min a b = a ∨ min a b = b`\nCurrently, all of these are on by default.\n",
   "kind": "markdown"}}

--- a/tests/server_interactive/impossibleTactic.lean.out.expected
+++ b/tests/server_interactive/impossibleTactic.lean.out.expected
@@ -1,0 +1,20 @@
+{"textDocument": {"uri": "file:///impossibleTactic.lean"},
+ "position": {"line": 6, "character": 14}}
+{"rendered": "```lean\nn : Nat\n⊢ ¬∀ (n : Nat), n = n + 1\n```",
+ "goals": ["n : Nat\n⊢ ¬∀ (n : Nat), n = n + 1"]}
+{"textDocument": {"uri": "file:///impossibleTactic.lean"},
+ "position": {"line": 8, "character": 5}}
+{"range":
+ {"start": {"line": 8, "character": 4}, "end": {"line": 8, "character": 11}},
+ "contents":
+ {"value":
+  "Introduces one or more hypotheses, optionally naming and/or pattern-matching them.\nFor each hypothesis to be introduced, the remaining main goal's target type must\nbe a `let` or function type.\n\n* `intro` by itself introduces one anonymous hypothesis, which can be accessed\n  by e.g. `assumption`. It is equivalent to `intro _`.\n* `intro x y` introduces two hypotheses and names them. Individual hypotheses\n  can be anonymized via `_`, given a type ascription, or matched against a pattern:\n  ```lean\n  -- ... ⊢ α × β → ...\n  intro (a, b)\n  -- ..., a : α, b : β ⊢ ...\n  ```\n* `intro rfl` is short for `intro h; subst h`, if `h` is an equality where the left-hand or right-hand side\n  is a variable.\n* Alternatively, `intro` can be combined with pattern matching much like `fun`:\n  ```lean\n  intro\n  | n + 1, 0 => tac\n  | ...\n  ```\n",
+  "kind": "markdown"}}
+{"textDocument": {"uri": "file:///impossibleTactic.lean"},
+ "position": {"line": 10, "character": 5}}
+{"range":
+ {"start": {"line": 10, "character": 4}, "end": {"line": 10, "character": 41}},
+ "contents":
+ {"value":
+  "`exact e` closes the main goal if its target type matches that of `e`.\n",
+  "kind": "markdown"}}

--- a/tests/server_interactive/impossibleTactic.lean.out.expected
+++ b/tests/server_interactive/impossibleTactic.lean.out.expected
@@ -1,7 +1,7 @@
 {"textDocument": {"uri": "file:///impossibleTactic.lean"},
  "position": {"line": 6, "character": 14}}
-{"rendered": "```lean\nn : Nat\n⊢ ¬∀ (n : Nat), n = n + 1\n```",
- "goals": ["n : Nat\n⊢ ¬∀ (n : Nat), n = n + 1"]}
+{"rendered": "```lean\n⊢ ¬∀ (n : Nat), n = n + 1\n```",
+ "goals": ["⊢ ¬∀ (n : Nat), n = n + 1"]}
 {"textDocument": {"uri": "file:///impossibleTactic.lean"},
  "position": {"line": 8, "character": 5}}
 {"range":

--- a/tests/server_interactive/impossibleTactic.lean.out.expected
+++ b/tests/server_interactive/impossibleTactic.lean.out.expected
@@ -1,11 +1,11 @@
 {"textDocument": {"uri": "file:///impossibleTactic.lean"},
  "position": {"line": 6, "character": 14}}
-{"rendered": "```lean\n⊢ ∀ (n : Nat), ¬n = n + 1\n```",
- "goals": ["⊢ ∀ (n : Nat), ¬n = n + 1"]}
+{"rendered": "```lean\n⊢ ¬∀ (n : Nat), n = n + 1\n```",
+ "goals": ["⊢ ¬∀ (n : Nat), n = n + 1"]}
 {"textDocument": {"uri": "file:///impossibleTactic.lean"},
  "position": {"line": 8, "character": 5}}
 {"range":
- {"start": {"line": 8, "character": 4}, "end": {"line": 8, "character": 13}},
+ {"start": {"line": 8, "character": 4}, "end": {"line": 8, "character": 11}},
  "contents":
  {"value":
   "Introduces one or more hypotheses, optionally naming and/or pattern-matching them.\nFor each hypothesis to be introduced, the remaining main goal's target type must\nbe a `let` or function type.\n\n* `intro` by itself introduces one anonymous hypothesis, which can be accessed\n  by e.g. `assumption`. It is equivalent to `intro _`.\n* `intro x y` introduces two hypotheses and names them. Individual hypotheses\n  can be anonymized via `_`, given a type ascription, or matched against a pattern:\n  ```lean\n  -- ... ⊢ α × β → ...\n  intro (a, b)\n  -- ..., a : α, b : β ⊢ ...\n  ```\n* `intro rfl` is short for `intro h; subst h`, if `h` is an equality where the left-hand or right-hand side\n  is a variable.\n* Alternatively, `intro` can be combined with pattern matching much like `fun`:\n  ```lean\n  intro\n  | n + 1, 0 => tac\n  | ...\n  ```\n",
@@ -13,8 +13,8 @@
 {"textDocument": {"uri": "file:///impossibleTactic.lean"},
  "position": {"line": 10, "character": 5}}
 {"range":
- {"start": {"line": 10, "character": 4}, "end": {"line": 10, "character": 9}},
+ {"start": {"line": 10, "character": 4}, "end": {"line": 10, "character": 41}},
  "contents":
  {"value":
-  "The `omega` tactic, for resolving integer and natural linear arithmetic problems.\n\nIt is not yet a full decision procedure (no \"dark\" or \"grey\" shadows),\nbut should be effective on many problems.\n\nWe handle hypotheses of the form `x = y`, `x < y`, `x ≤ y`, and `k ∣ x` for `x y` in `Nat` or `Int`\n(and `k` a literal), along with negations of these statements.\n\nWe decompose the sides of the inequalities as linear combinations of atoms.\n\nIf we encounter `x / k` or `x % k` for literal integers `k` we introduce new auxiliary variables\nand the relevant inequalities.\n\nOn the first pass, we do not perform case splits on natural subtraction.\nIf `omega` fails, we recursively perform a case split on\na natural subtraction appearing in a hypothesis, and try again.\n\nThe options\n```\nomega +splitDisjunctions +splitNatSub +splitNatAbs +splitMinMax\n```\ncan be used to:\n* `splitDisjunctions`: split any disjunctions found in the context,\n  if the problem is not otherwise solvable.\n* `splitNatSub`: for each appearance of `((a - b : Nat) : Int)`, split on `a ≤ b` if necessary.\n* `splitNatAbs`: for each appearance of `Int.natAbs a`, split on `0 ≤ a` if necessary.\n* `splitMinMax`: for each occurrence of `min a b`, split on `min a b = a ∨ min a b = b`\nCurrently, all of these are on by default.\n",
+  "`exact e` closes the main goal if its target type matches that of `e`.\n",
   "kind": "markdown"}}


### PR DESCRIPTION
This PR adds a new `impossible by t` tactic combinator and wires it into the
default suggestion set of `try?`.

`impossible by t` uses the tactic `t` to prove that the current goal is
impossible. If the goal is `xs ⊢ P`, the tactic `t` sees the goal
`¬(∀ xs, P)`. Any expression metavariables in the original goal turn into
named variables in the local context, so `t` can `intro`/`cases` over each
existential witness directly. This makes `impossible` usable on
under-determined goals such as the proof obligation left by
`refine Exists.intro ?_ ?h; case h => …`:

```lean
example : ∃ x, x * x = 2 := by
  refine Exists.intro ?w ?h
  case h => impossible by intro hx; cases w <;> grind
  case w => exact 0
```

The original goal is closed as if `sorry` were used. Failure of `t` is
propagated cleanly, so combinators like `first` see it correctly.

`impossible +levels by t` additionally abstracts the universe parameters of
the surrounding declaration as fresh level metavariables, so `t` can refute
a universe-polymorphic claim by exhibiting witnesses at specific universes
(or leave the universes parametric).

`try?` gains an `impossible` branch — between `atomic` and
`atomicSuggestions` — that runs `impossible by decide`, `impossible by
simp`, and `impossible by grind` in parallel.