### PR TITLE
perf: use `MVarId.assign` instead of `isDefEq` in type class search

### DIFF
--- a/src/Lean/Meta/SynthInstance.lean
+++ b/src/Lean/Meta/SynthInstance.lean
@@ -371,8 +371,8 @@ def tryResolve (mvar : Expr) (inst : Instance) : MetaM (Option (MetavarContext �
       we would start getting terms such as `fun x => (fun x => inst x) x` when using the equational theorem.
       -/
       let instVal ← mkLambdaFVars xs instVal (etaReduce := true)
-      if (← isDefEq mvar instVal) then
-        return some ((← getMCtx), subgoals)
+      mvar.mvarId!.assign instVal
+      return some ((← getMCtx), subgoals)
     return none
 
 /--

--- a/tests/elab/isDefEqCheckAssignmentBug.lean.out.expected
+++ b/tests/elab/isDefEqCheckAssignmentBug.lean.out.expected
@@ -43,9 +43,6 @@
     [Meta.isDefEq] ✅️ Type → Type ?u =?= Type → Type
       [Meta.isDefEq] ✅️ Type =?= Type
       [Meta.isDefEq] ✅️ Type ?u =?= Type
-[Meta.isDefEq] ✅️ ?m =?= instMonadEvalTOfMonadEval MetaM ?m Elab.Command.CommandElabM
-  [Meta.isDefEq] ?m [assignable] =?= instMonadEvalTOfMonadEval MetaM ?m Elab.Command.CommandElabM [nonassignable]
-  [Meta.isDefEq] ✅️ MonadEvalT MetaM Elab.Command.CommandElabM =?= MonadEvalT MetaM Elab.Command.CommandElabM
 [Meta.isDefEq] ✅️ MonadEval ?m Elab.Command.CommandElabM =?= MonadEval Elab.TermElabM Elab.Command.CommandElabM
   [Meta.isDefEq] ✅️ ?m =?= Elab.TermElabM
     [Meta.isDefEq] ?m [assignable] =?= Elab.TermElabM [nonassignable]
@@ -53,12 +50,6 @@
       [Meta.isDefEq] ✅️ Type =?= Type
       [Meta.isDefEq] ✅️ Type ?u =?= Type
   [Meta.isDefEq] ✅️ Elab.Command.CommandElabM =?= Elab.Command.CommandElabM
-[Meta.isDefEq] ✅️ ?m =?= Elab.Command.instMonadEvalTermElabMCommandElabM
-  [Meta.isDefEq] ?m [assignable] =?= Elab.Command.instMonadEvalTermElabMCommandElabM [nonassignable]
-  [Meta.isDefEq] ✅️ MonadEval Elab.TermElabM
-        Elab.Command.CommandElabM =?= MonadEval Elab.TermElabM Elab.Command.CommandElabM
-    [Meta.isDefEq] ✅️ Elab.TermElabM =?= Elab.TermElabM
-    [Meta.isDefEq] ✅️ Elab.Command.CommandElabM =?= Elab.Command.CommandElabM
 [Meta.isDefEq] ✅️ ?m =?= Elab.Command.instMonadEvalTermElabMCommandElabM
   [Meta.isDefEq] ?m [assignable] =?= Elab.Command.instMonadEvalTermElabMCommandElabM [nonassignable]
   [Meta.isDefEq] ✅️ MonadEval ?m Elab.Command.CommandElabM =?= MonadEval Elab.TermElabM Elab.Command.CommandElabM
@@ -96,11 +87,6 @@
     [Meta.isDefEq] ✅️ Type → Type ?u =?= Type → Type
       [Meta.isDefEq] ✅️ Type =?= Type
       [Meta.isDefEq] ✅️ Type ?u =?= Type
-[Meta.isDefEq] ✅️ ?m =?= instMonadEvalTOfMonadEval MetaM ?m Elab.TermElabM
-  [Meta.isDefEq] ?m [assignable] =?= instMonadEvalTOfMonadEval MetaM ?m Elab.TermElabM [nonassignable]
-  [Meta.isDefEq] ✅️ MonadEvalT MetaM Elab.TermElabM =?= MonadEvalT MetaM Elab.TermElabM
-    [Meta.isDefEq] ✅️ MetaM =?= MetaM
-    [Meta.isDefEq] ✅️ Elab.TermElabM =?= Elab.TermElabM
 [Meta.isDefEq] ✅️ MonadEval ?m Elab.TermElabM =?= MonadEval ?m ?m
   [Meta.isDefEq] ✅️ ?m =?= ?m
     [Meta.isDefEq] ?m [assignable] =?= ?m [assignable]
@@ -112,11 +98,6 @@
     [Meta.isDefEq] ✅️ Type → Type ?u =?= Type → Type
       [Meta.isDefEq] ✅️ Type =?= Type
       [Meta.isDefEq] ✅️ Type ?u =?= Type
-[Meta.isDefEq] ✅️ ?m =?= instMonadEvalOfMonadLift
-  [Meta.isDefEq] ?m [assignable] =?= instMonadEvalOfMonadLift [nonassignable]
-  [Meta.isDefEq] ✅️ MonadEval ?m Elab.TermElabM =?= MonadEval ?m Elab.TermElabM
-    [Meta.isDefEq] ✅️ ?m =?= ?m
-    [Meta.isDefEq] ✅️ Elab.TermElabM =?= Elab.TermElabM
 [Meta.isDefEq] ✅️ MonadLift ?m Elab.TermElabM =?= MonadLift ?m (ReaderT ?m ?m)
   [Meta.isDefEq] ✅️ ?m =?= ?m
     [Meta.isDefEq] ?m [assignable] =?= ?m [assignable]
@@ -133,16 +114,6 @@
         [Meta.isDefEq] ✅️ Type → Type ?u =?= Type → Type
           [Meta.isDefEq] ✅️ Type =?= Type
           [Meta.isDefEq] ✅️ Type ?u =?= Type
-[Meta.isDefEq] ✅️ ?m =?= ReaderT.instMonadLift
-  [Meta.isDefEq] ?m [assignable] =?= ReaderT.instMonadLift [nonassignable]
-  [Meta.isDefEq] ✅️ MonadLift (StateRefT' IO.RealWorld Elab.Term.State MetaM)
-        Elab.TermElabM =?= MonadLift (StateRefT' IO.RealWorld Elab.Term.State MetaM)
-        (ReaderT Elab.Term.Context (StateRefT' IO.RealWorld Elab.Term.State MetaM))
-    [Meta.isDefEq] ✅️ StateRefT' IO.RealWorld Elab.Term.State MetaM =?= StateRefT' IO.RealWorld Elab.Term.State MetaM
-    [Meta.isDefEq] ✅️ Elab.TermElabM =?= ReaderT Elab.Term.Context (StateRefT' IO.RealWorld Elab.Term.State MetaM)
-      [Meta.isDefEq] ✅️ ReaderT Elab.Term.Context
-            (StateRefT' IO.RealWorld Elab.Term.State
-              MetaM) =?= ReaderT Elab.Term.Context (StateRefT' IO.RealWorld Elab.Term.State MetaM)
 [Meta.isDefEq] ✅️ ?m =?= ReaderT.instMonadLift
   [Meta.isDefEq] ?m [assignable] =?= ReaderT.instMonadLift [nonassignable]
   [Meta.isDefEq] ✅️ MonadLift ?m
@@ -197,14 +168,6 @@
     [Meta.isDefEq] ✅️ Type → Type ?u =?= Type → Type
       [Meta.isDefEq] ✅️ Type =?= Type
       [Meta.isDefEq] ✅️ Type ?u =?= Type
-[Meta.isDefEq] ✅️ ?m =?= instMonadEvalTOfMonadEval MetaM ?m (StateRefT' IO.RealWorld Elab.Term.State MetaM)
-  [Meta.isDefEq] ?m [assignable] =?= instMonadEvalTOfMonadEval MetaM ?m
-        (StateRefT' IO.RealWorld Elab.Term.State MetaM) [nonassignable]
-  [Meta.isDefEq] ✅️ MonadEvalT MetaM
-        (StateRefT' IO.RealWorld Elab.Term.State
-          MetaM) =?= MonadEvalT MetaM (StateRefT' IO.RealWorld Elab.Term.State MetaM)
-    [Meta.isDefEq] ✅️ MetaM =?= MetaM
-    [Meta.isDefEq] ✅️ StateRefT' IO.RealWorld Elab.Term.State MetaM =?= StateRefT' IO.RealWorld Elab.Term.State MetaM
 [Meta.isDefEq] ✅️ MonadEval ?m (StateRefT' IO.RealWorld Elab.Term.State MetaM) =?= MonadEval ?m ?m
   [Meta.isDefEq] ✅️ ?m =?= ?m
     [Meta.isDefEq] ?m [assignable] =?= ?m [assignable]
@@ -216,13 +179,6 @@
     [Meta.isDefEq] ✅️ Type → Type ?u =?= Type → Type
       [Meta.isDefEq] ✅️ Type =?= Type
       [Meta.isDefEq] ✅️ Type ?u =?= Type
-[Meta.isDefEq] ✅️ ?m =?= instMonadEvalOfMonadLift
-  [Meta.isDefEq] ?m [assignable] =?= instMonadEvalOfMonadLift [nonassignable]
-  [Meta.isDefEq] ✅️ MonadEval ?m
-        (StateRefT' IO.RealWorld Elab.Term.State
-          MetaM) =?= MonadEval ?m (StateRefT' IO.RealWorld Elab.Term.State MetaM)
-    [Meta.isDefEq] ✅️ ?m =?= ?m
-    [Meta.isDefEq] ✅️ StateRefT' IO.RealWorld Elab.Term.State MetaM =?= StateRefT' IO.RealWorld Elab.Term.State MetaM
 [Meta.isDefEq] ✅️ MonadLift ?m
       (StateRefT' IO.RealWorld Elab.Term.State MetaM) =?= MonadLift ?m (StateRefT' ?m ?m ?m)
   [Meta.isDefEq] ✅️ ?m =?= ?m
@@ -240,13 +196,6 @@
     [Meta.isDefEq] ✅️ MetaM =?= ?m
       [Meta.isDefEq] MetaM [nonassignable] =?= ?m [assignable]
       [Meta.isDefEq] ✅️ Type → Type =?= Type → Type
-[Meta.isDefEq] ✅️ ?m =?= StateRefT'.instMonadLift
-  [Meta.isDefEq] ?m [assignable] =?= StateRefT'.instMonadLift [nonassignable]
-  [Meta.isDefEq] ✅️ MonadLift MetaM
-        (StateRefT' IO.RealWorld Elab.Term.State
-          MetaM) =?= MonadLift MetaM (StateRefT' IO.RealWorld Elab.Term.State MetaM)
-    [Meta.isDefEq] ✅️ MetaM =?= MetaM
-    [Meta.isDefEq] ✅️ StateRefT' IO.RealWorld Elab.Term.State MetaM =?= StateRefT' IO.RealWorld Elab.Term.State MetaM
 [Meta.isDefEq] ✅️ ?m =?= StateRefT'.instMonadLift
   [Meta.isDefEq] ?m [assignable] =?= StateRefT'.instMonadLift [nonassignable]
   [Meta.isDefEq] ✅️ MonadLift ?m
@@ -276,11 +225,6 @@
       [Meta.isDefEq] ✅️ Type ?u =?= Type
       [Meta.isDefEq] ✅️ Type ?u =?= Type
   [Meta.isDefEq] ✅️ MetaM =?= MetaM
-[Meta.isDefEq] ✅️ ?m =?= instMonadEvalT MetaM
-  [Meta.isDefEq] ?m [assignable] =?= instMonadEvalT MetaM [nonassignable]
-  [Meta.isDefEq] ✅️ MonadEvalT MetaM MetaM =?= MonadEvalT MetaM MetaM
-    [Meta.isDefEq] ✅️ MetaM =?= MetaM
-    [Meta.isDefEq] ✅️ MetaM =?= MetaM
 [Meta.isDefEq] ✅️ ?m =?= instMonadEvalT MetaM
   [Meta.isDefEq] ?m [assignable] =?= instMonadEvalT MetaM [nonassignable]
   [Meta.isDefEq] ✅️ MonadEvalT MetaM MetaM =?= MonadEvalT MetaM MetaM


### PR DESCRIPTION
This PR removes an `isDefEq` check in type class synthesis that is redundant.

Unfortunately, making this change breaks a few things in Mathlib, due to #9726, in combination with #9727.