### PR TITLE
doc: fix wrong example for String.split

### DIFF
--- a/src/Init/Data/String/Search.lean
+++ b/src/Init/Data/String/Search.lean
@@ -251,7 +251,7 @@ Examples:
  * {lean}`("coffee tea water".split Char.isWhitespace).toList == ["coffee".toSlice, "tea".toSlice, "water".toSlice]`
  * {lean}`("coffee tea water".split ' ').toList == ["coffee".toSlice, "tea".toSlice, "water".toSlice]`
  * {lean}`("coffee tea water".split " tea ").toList == ["coffee".toSlice, "water".toSlice]`
- * {lean}`("ababababa".split "aba").toList == ["coffee".toSlice, "water".toSlice]`
+ * {lean}`("ababababa".split "aba").toList == ["".toSlice, "b".toSlice, "ba".toSlice]`
  * {lean}`("baaab".split "aa").toList == ["b".toSlice, "ab".toSlice]`
 -/
 @[inline]


### PR DESCRIPTION
This PR fixes a small docsting error for `String.split`.