### PR TITLE
chore: CI: fix stage2 release build

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -145,9 +145,8 @@ jobs:
           if [[ -n '${{ matrix.prepare-llvm }}' ]]; then
             wget -q ${{ matrix.llvm-url }}
             PREPARE="$(${{ matrix.prepare-llvm }})"
-            if [ "$TARGET_STAGE" == "stage2" ]; then
-              cp -r stage1 stage2
-            fi
+            cp -r stage1 stage2
+            cp -r stage1 stage3
             eval "OPTIONS+=($PREPARE)"
           fi
           if [[ -n '${{ matrix.release }}' && -n '${{ inputs.nightly }}' ]]; then


### PR DESCRIPTION
If we're using the downloaded LLVM release and building stage2/stage3, we need to also copy stage1 to stage2/stage3 respectively before continuing the build. Previously, the CI did not do this in every case. Now we do it unconditionally because the overhead is small enough.