### PR TITLE
feat: include error message in `instances`-level type-check failure

### DIFF
--- a/src/Lean/Linter/TacticTypeCheck.lean
+++ b/src/Lean/Linter/TacticTypeCheck.lean
@@ -77,7 +77,7 @@ def tacticCheckInstances : Linter where
             try
               Meta.check target .instances
               return none
-            catch _ =>
+            catch e =>
               let counterInst := (← get).diag.unfoldCounter
               let diff := Meta.subCounters counterDefault counterInst
               let env ← getEnv
@@ -95,7 +95,9 @@ def tacticCheckInstances : Linter where
               return some m!"{kind} tactic goal is not type-correct at \
                 `.instances` transparency; {remedy} some of the following as \
                 `@[implicit_reducible]`:\
-                {indentD (.joinSep candidates Format.line)}"
+                {indentD (.joinSep candidates Format.line)}\n\
+                Full error:\
+                {indentD e.toMessageData}"
           -- Always restore the original diagnostics snapshot.
           modify ({ · with diag := origDiag })
           return result

--- a/src/Lean/Meta/Check.lean
+++ b/src/Lean/Meta/Check.lean
@@ -350,11 +350,13 @@ def withInstancesTypeCheckNote [MonadControlT MetaM m] [Monad m] (e : Expr) (x :
     try
       check e .instances
       return .nil
-    catch _ =>
+    catch e =>
       return MessageData.note m!"The target expression is not type-correct \
         under the `instances` transparency level, which may have triggered the failure. \
         This is usually caused by unfolding of semireducible definitions in prior tactic steps. \
-        Use `set_option linter.tacticCheckInstances true` to investigate the source of the issue."
+        Use `set_option linter.tacticCheckInstances true` to investigate the source of the issue.\n\
+        Full error:\
+        {indentD e.toMessageData}"
   Meta.mapError x (· ++ typeCheckNote)
 
 /--

--- a/tests/elab/linterTacticCheckInstances.lean
+++ b/tests/elab/linterTacticCheckInstances.lean
@@ -31,6 +31,18 @@ set_option linter.tacticCheckInstances true
 warning: produced tactic goal is not type-correct at `.instances` transparency; consider using propositional rewriting or marking some of the following as `@[implicit_reducible]`:
   composed
   myF
+Full error:
+  Application type mismatch: The argument
+    h2
+  has type
+    @LT.lt Nat instLTNat idx (composed s a b).s.decls.size
+  but is expected to have type
+    @LT.lt Nat instLTNat idx
+      (have res := myF s { x := a };
+            myF res.s { x := b }).s.decls.size
+  in the application
+    (have res := myF s { x := a };
+          myF res.s { x := b }).s.decls[idx]
 
 Note: This linter can be disabled with `set_option linter.tacticCheckInstances false`
 -/
@@ -46,6 +58,15 @@ example (s : S) (a b idx : Nat) (h1 : idx < s.decls.size)
 warning: initial tactic goal is not type-correct at `.instances` transparency; consider rephrasing the goal or marking some of the following as `@[implicit_reducible]`:
   composed
   myF
+Full error:
+  Application type mismatch: The argument
+    h1
+  has type
+    @LT.lt Nat instLTNat idx s.decls.size
+  but is expected to have type
+    @LT.lt Nat instLTNat idx (composed s a b).s.decls.size
+  in the application
+    (composed s a b).s.decls[idx]
 
 Note: This linter can be disabled with `set_option linter.tacticCheckInstances false`
 -/

--- a/tests/elab/typeCheckNote.lean
+++ b/tests/elab/typeCheckNote.lean
@@ -93,6 +93,18 @@ example (s : S) (a b idx : Nat) (h1 : idx < s.decls.size)
 error: `simp` made no progress
 
 Note: The target expression is not type-correct under the `instances` transparency level, which may have triggered the failure. This is usually caused by unfolding of semireducible definitions in prior tactic steps. Use `set_option linter.tacticCheckInstances true` to investigate the source of the issue.
+Full error:
+  Application type mismatch: The argument
+    h2
+  has type
+    @LT.lt Nat instLTNat idx (composed s a b).s.decls.size
+  but is expected to have type
+    @LT.lt Nat instLTNat idx
+      (have res := myF s { x := a };
+            myF res.s { x := b }).s.decls.size
+  in the application
+    (have res := myF s { x := a };
+          myF res.s { x := b }).s.decls[idx]
 -/
 #guard_msgs in
 example (s : S) (a b idx : Nat) (h1 : idx < s.decls.size)


### PR DESCRIPTION
This PR extends the new tactic hints about type-incorrect goals at `instances` transparency with the type checking error message to assist with cases that are more complex than "inadvisable `unfold`".