### PR TITLE
perf: optimize String.compare

### DIFF
--- a/src/Init/Data/Ord/String.lean
+++ b/src/Init/Data/Ord/String.lean
@@ -28,6 +28,7 @@ namespace String
 /--
 Lexicographic comparison of strings
 -/
+@[extern "lean_string_compare"]
 def compare (s₁ s₂ : @& String) : Ordering :=
   compareOfLessAndEq s₁ s₂
 


### PR DESCRIPTION
This PR optimizes `String.compare` to turn it into 1 instead of 2 `memcmp` calls.