### PR TITLE
feat: add module features to `#where` command

### DIFF
--- a/src/Lean/Elab/BuiltinCommand.lean
+++ b/src/Lean/Elab/BuiltinCommand.lean
@@ -628,9 +628,14 @@ open Lean.Parser.Command.InternalSyntax in
 @[builtin_command_elab Parser.Command.where] def elabWhere : CommandElab := fun _ => do
   let scope ← getScope
   let mut msg : Array MessageData := #[]
-  -- Noncomputable
-  if scope.isNoncomputable then
-    msg := msg.push <| ← `(Parser.Command.section| noncomputable section)
+  let isExpose := scope.attrs.any (· matches `(attrInstance| expose))
+  -- Section header
+  if isExpose || scope.isPublic || scope.isNoncomputable || scope.isMeta then
+    let expTk? := if isExpose then some Syntax.missing else none
+    let publicTk? := if scope.isPublic then some Syntax.missing else none
+    let ncTk? := if scope.isNoncomputable then some Syntax.missing else none
+    let metaTk? := if scope.isMeta then some Syntax.missing else none
+    msg := msg.push <| ← `(Parser.Command.section| $[@[expose%$expTk?]]? $[public%$publicTk?]? $[noncomputable%$ncTk?]? $[meta%$metaTk?]? section)
   -- Namespace
   if !scope.currNamespace.isAnonymous then
     msg := msg.push <| ← `(command| namespace $(mkIdent scope.currNamespace))
@@ -648,6 +653,9 @@ open Lean.Parser.Command.InternalSyntax in
   -- Included variables
   if !scope.includedVars.isEmpty then
     msg := msg.push <| ← `(command| include $(scope.includedVars.toArray.map (mkIdent ·.eraseMacroScopes))*)
+  -- Omitted variables
+  if !scope.omittedVars.isEmpty then
+    msg := msg.push <| ← `(command| omit $(scope.omittedVars.toArray.map (mkIdent ·.eraseMacroScopes))*)
   -- Options
   if let some optionsMsg ← describeOptions scope.opts then
     msg := msg.push optionsMsg

--- a/tests/elab/whereCmdModule.lean
+++ b/tests/elab/whereCmdModule.lean
@@ -1,0 +1,70 @@
+module
+import Lean
+/-!
+# Tests for the `#where` command, `module` features
+-/
+
+-- Restore the options to a pristine state
+set_option internal.cmdlineSnapshots false
+set_option printMessageEndPos false
+set_option Elab.inServer false
+
+/-- info: -- In root namespace with initial scope -/
+#guard_msgs in #where
+
+/-!
+Test `noncomputable section`
+-/
+noncomputable section
+/-- info: noncomputable section -/
+#guard_msgs in #where
+end
+
+/-!
+Test `public section`
+-/
+public section
+/-- info: public section -/
+#guard_msgs in #where
+end
+
+/-!
+Test `@[expose] section`
+-/
+@[expose] section
+/-- info: @[expose] section -/
+#guard_msgs in #where
+end
+
+/-!
+Test `meta section`
+-/
+meta section
+/-- info: meta section -/
+#guard_msgs in #where
+end
+
+/-!
+Test combination
+-/
+@[expose] public noncomputable meta section
+/-- info: @[expose] public noncomputable meta section -/
+#guard_msgs in #where
+end
+
+/-!
+Test combination with interleaved namespace. Since `#where` only prints the current scope,
+all the `section` modifiers are combined.
+-/
+public section
+namespace Foo
+@[expose] section Bar
+/--
+info: @[expose] public section
+
+namespace Foo
+-/
+#guard_msgs in #where
+end Bar
+end Foo
+end


### PR DESCRIPTION
This PR updates the `#where` command to be able to report `module`-related scope state, for example a  `@[expose] public meta section` line in the output.