### PR TITLE
fix: app elaborator infotrees should have context when there is ambiguity

### DIFF
--- a/src/Lean/Elab/App.lean
+++ b/src/Lean/Elab/App.lean
@@ -2187,30 +2187,29 @@ private def getSuccesses (candidates : Array (TermElabResult Expr)) : TermElabM 
   Throw an error message that describes why each possible interpretation for the overloaded notation and symbols did not work.
   We use a nested error message to aggregate the exceptions produced by each failure.
 -/
-private def mergeFailures (failures : Array (TermElabResult Expr)) (expectedType? : Option Expr) : TermElabM α := do
-  let exs := failures.map fun | .error ex _ => ex | _ => unreachable!
+private def mergeFailures (failures : Array (TermElabResult Expr)) : TermElabM α := do
   -- Retain partial `InfoTree` subtrees in an `.ofChoiceInfo` node in case of multiple failures.
   -- This ensures that the language server still has `Info` to work with when multiple overloaded
   -- elaborators fail.
   withInfoContext (mkInfo := pure <| .ofChoiceInfo { elaborator := .anonymous, stx := (← getRef) }) do
     for failure in failures do
       let .error _ s := failure | unreachable!
-      withoutModifyingStateWithInfoAndMessages do
-        s.restore
-        withSaveInfoContext do
-          pushInfoTree <| .node s.meta.core.infoState.trees
-            (i := .ofPartialTermInfo { elaborator := .anonymous, stx := (← getRef), lctx := (← getLCtx), expectedType? })
+      if let some tree := s.meta.core.infoState.trees[0]? then
+        let ctxTree : InfoTree ← withoutModifyingState do
+          s.restore
+          let ctx ← CommandContextInfo.save
+          return .context (.commandCtx ctx) tree
+        pushInfoTree ctxTree
+  let exs := failures.map fun | .error ex _ => ex | _ => unreachable!
   throwErrorWithNestedErrors "overloaded" exs
 
 private def elabAppAux (f : Syntax) (namedArgs : Array NamedArg) (args : Array Arg) (ellipsis : Bool) (expectedType? : Option Expr) : TermElabM Expr := do
   let candidates ← elabAppFn f [] namedArgs args expectedType? (explicit := false) (ellipsis := ellipsis) (overloaded := false) #[]
   if h : candidates.size = 1 then
-    have : 0 < candidates.size := by rw [h]; decide
     applyResult candidates[0]
   else
     let successes ← getSuccesses candidates
     if h : successes.size = 1 then
-      have : 0 < successes.size := by rw [h]; decide
       applyResult successes[0]
     else if successes.size > 1 then
       -- Retain `InfoTree` subtrees in an `.ofChoiceInfo` node in case of ambiguity.
@@ -2218,16 +2217,24 @@ private def elabAppAux (f : Syntax) (namedArgs : Array NamedArg) (args : Array A
         let mut msgs : Array MessageData := #[]
         for success in successes do
           let .ok e s := success | unreachable!
-          let msg ← withoutModifyingStateWithInfoAndMessages do
+          let (tree?, msg) ← withoutModifyingState do
             s.restore
-            withSaveInfoContext do
-              pushInfoTree <| .node s.meta.core.infoState.trees
-                (i := .ofTermInfo { elaborator := .anonymous, stx := (← getRef), lctx := (← getLCtx), expectedType?, expr := e })
-            addMessageContext m!"{e} : {← inferType e}"
+            let msg ← addMessageContext m!"{e} : {← inferType e}"
+            let tree? : Option InfoTree ←
+              if let some tree := s.meta.core.infoState.trees[0]? then
+                let ctx ← CommandContextInfo.save
+                pure <| some <| .context (.commandCtx ctx) <|
+                  .node (.ofPartialTermInfo { elaborator := .anonymous, stx := (← getRef), lctx := (← getLCtx), expectedType? })
+                    s.meta.core.infoState.trees
+              else
+                pure none
+            return (tree?, msg)
+          if let some tree := tree? then
+            pushInfoTree tree
           msgs := msgs.push msg
         throwErrorAt f "Ambiguous term{indentD f}\nPossible interpretations:{toMessageList msgs}"
     else
-      withRef f <| mergeFailures candidates expectedType?
+      withRef f <| mergeFailures candidates
 
 /--
   We annotate recursive applications with their `Syntax` node to make sure we can produce error messages with

--- a/src/Lean/Elab/App.lean
+++ b/src/Lean/Elab/App.lean
@@ -2187,16 +2187,19 @@ private def getSuccesses (candidates : Array (TermElabResult Expr)) : TermElabM 
   Throw an error message that describes why each possible interpretation for the overloaded notation and symbols did not work.
   We use a nested error message to aggregate the exceptions produced by each failure.
 -/
-private def mergeFailures (failures : Array (TermElabResult Expr)) : TermElabM α := do
+private def mergeFailures (failures : Array (TermElabResult Expr)) (expectedType? : Option Expr) : TermElabM α := do
   let exs := failures.map fun | .error ex _ => ex | _ => unreachable!
-  let trees := failures.map (fun | .error _ s => s.meta.core.infoState.trees | _ => unreachable!)
-    |>.filterMap (·[0]?)
   -- Retain partial `InfoTree` subtrees in an `.ofChoiceInfo` node in case of multiple failures.
   -- This ensures that the language server still has `Info` to work with when multiple overloaded
   -- elaborators fail.
-  withInfoContext (mkInfo := pure <| .ofChoiceInfo { elaborator := .anonymous, stx := ← getRef }) do
-    for tree in trees do
-      pushInfoTree tree
+  withInfoContext (mkInfo := pure <| .ofChoiceInfo { elaborator := .anonymous, stx := (← getRef) }) do
+    for failure in failures do
+      let .error _ s := failure | unreachable!
+      withoutModifyingStateWithInfoAndMessages do
+        s.restore
+        withSaveInfoContext do
+          pushInfoTree <| .node s.meta.core.infoState.trees
+            (i := .ofPartialTermInfo { elaborator := .anonymous, stx := (← getRef), lctx := (← getLCtx), expectedType? })
   throwErrorWithNestedErrors "overloaded" exs
 
 private def elabAppAux (f : Syntax) (namedArgs : Array NamedArg) (args : Array Arg) (ellipsis : Bool) (expectedType? : Option Expr) : TermElabM Expr := do
@@ -2210,13 +2213,21 @@ private def elabAppAux (f : Syntax) (namedArgs : Array NamedArg) (args : Array A
       have : 0 < successes.size := by rw [h]; decide
       applyResult successes[0]
     else if successes.size > 1 then
-      let msgs : Array MessageData ← successes.mapM fun success => do
-        match success with
-        | .ok e s => withMCtx s.meta.meta.mctx <| withEnv s.meta.core.env do addMessageContext m!"{e} : {← inferType e}"
-        | _       => unreachable!
-      throwErrorAt f "Ambiguous term{indentD f}\nPossible interpretations:{toMessageList msgs}"
+      -- Retain `InfoTree` subtrees in an `.ofChoiceInfo` node in case of ambiguity.
+      withInfoContext (mkInfo := pure <| .ofChoiceInfo { elaborator := .anonymous, stx := (← getRef) }) do
+        let mut msgs : Array MessageData := #[]
+        for success in successes do
+          let .ok e s := success | unreachable!
+          let msg ← withoutModifyingStateWithInfoAndMessages do
+            s.restore
+            withSaveInfoContext do
+              pushInfoTree <| .node s.meta.core.infoState.trees
+                (i := .ofTermInfo { elaborator := .anonymous, stx := (← getRef), lctx := (← getLCtx), expectedType?, expr := e })
+            addMessageContext m!"{e} : {← inferType e}"
+          msgs := msgs.push msg
+        throwErrorAt f "Ambiguous term{indentD f}\nPossible interpretations:{toMessageList msgs}"
     else
-      withRef f <| mergeFailures candidates
+      withRef f <| mergeFailures candidates expectedType?
 
 /--
   We annotate recursive applications with their `Syntax` node to make sure we can produce error messages with

--- a/tests/server_interactive/8108.lean
+++ b/tests/server_interactive/8108.lean
@@ -1,0 +1,17 @@
+/-!
+# App elaborator infotrees should have full context when there is ambiguity
+
+This file contains a simplified version of the example in the following issue:
+https://github.com/leanprover/lean4/issues/8108
+
+The term goal used to have an unknown metavariable.
+-/
+
+def mk_cons (I S : Type) : Type := sorry
+
+infixr:50 " >> " => mk_cons
+
+def eq (x y : Nat) : Prop := sorry
+
+def chain := eq >> (eq _)
+                     --^ $/lean/plainTermGoal

--- a/tests/server_interactive/8108.lean
+++ b/tests/server_interactive/8108.lean
@@ -3,10 +3,16 @@
 
 This file contains a simplified version of the example in the following issue:
 https://github.com/leanprover/lean4/issues/8108
-
-The term goal used to have an unknown metavariable.
 -/
 
+--^ collectDiagnostics
+
+set_option warn.sorry false
+set_option pp.mvars false
+
+/-!
+The term goal used to have an unknown metavariable.
+-/
 def mk_cons (I S : Type) : Type := sorry
 
 infixr:50 " >> " => mk_cons
@@ -15,3 +21,13 @@ def eq (x y : Nat) : Prop := sorry
 
 def chain := eq >> (eq _)
                      --^ $/lean/plainTermGoal
+
+/-!
+Incidentally, ambiguous elaboration used to discard all info trees.
+Now we can see that the expected type at `??` is `Nat` despite the ambiguity.
+-/
+notation "??" => 1
+notation "??" => ?_
+
+def test : Nat := ??
+                --^ $/lean/plainTermGoal

--- a/tests/server_interactive/8108.lean.out.expected
+++ b/tests/server_interactive/8108.lean.out.expected
@@ -1,0 +1,5 @@
+{"textDocument": {"uri": "file:///8108.lean"},
+ "position": {"line": 15, "character": 23}}
+{"range":
+ {"start": {"line": 15, "character": 23}, "end": {"line": 15, "character": 24}},
+ "goal": "⊢ Nat"}

--- a/tests/server_interactive/8108.lean.out.expected
+++ b/tests/server_interactive/8108.lean.out.expected
@@ -1,5 +1,34 @@
+{"version": 1,
+ "uri": "file:///8108.lean",
+ "isIncremental": false,
+ "diagnostics":
+ [{"source": "Lean 4",
+   "severity": 1,
+   "range":
+   {"start": {"line": 21, "character": 13},
+    "end": {"line": 21, "character": 25}},
+   "message":
+   "overloaded, errors \n  Application type mismatch: The argument\n    eq\n  has type\n    Nat → Nat → Prop\n  of sort `Type` but is expected to have type\n    Type\n  of sort `Type 1` in the application\n    mk_cons eq\n  \n  failed to synthesize instance of type class\n    HAndThen (Nat → Nat → Prop) (Nat → Prop) ?_\n  \n  Hint: Type class instance resolution failures can be inspected with the `set_option trace.Meta.synthInstance true` command.",
+   "fullRange":
+   {"start": {"line": 21, "character": 13},
+    "end": {"line": 21, "character": 25}}},
+  {"source": "Lean 4",
+   "severity": 1,
+   "range":
+   {"start": {"line": 31, "character": 18},
+    "end": {"line": 31, "character": 20}},
+   "message":
+   "Ambiguous term\n  ??\nPossible interpretations:\n  ?_ : Nat\n  \n  1 : Nat",
+   "fullRange":
+   {"start": {"line": 31, "character": 18},
+    "end": {"line": 31, "character": 20}}}]}
 {"textDocument": {"uri": "file:///8108.lean"},
- "position": {"line": 15, "character": 23}}
+ "position": {"line": 21, "character": 23}}
 {"range":
- {"start": {"line": 15, "character": 23}, "end": {"line": 15, "character": 24}},
+ {"start": {"line": 21, "character": 23}, "end": {"line": 21, "character": 24}},
+ "goal": "⊢ Nat"}
+{"textDocument": {"uri": "file:///8108.lean"},
+ "position": {"line": 31, "character": 18}}
+{"range":
+ {"start": {"line": 31, "character": 18}, "end": {"line": 31, "character": 20}},
  "goal": "⊢ Nat"}


### PR DESCRIPTION
This PR fixes an issue where ambiguous syntax would have missing terminfo or missing context (such as the metavariable context), leading to errors in the infoview. Closes #8108.