### PR TITLE
feat: reduction `DSimproc`s and bug fixes for `Sym.dsimp`

### DIFF
--- a/src/Lean/Meta/Sym/DSimp.lean
+++ b/src/Lean/Meta/Sym/DSimp.lean
@@ -13,3 +13,4 @@ public import Lean.Meta.Sym.DSimp.Lambda
 public import Lean.Meta.Sym.DSimp.Forall
 public import Lean.Meta.Sym.DSimp.Let
 public import Lean.Meta.Sym.DSimp.Main
+public import Lean.Meta.Sym.DSimp.Reduce

--- a/src/Lean/Meta/Sym/DSimp/DSimproc.lean
+++ b/src/Lean/Meta/Sym/DSimp/DSimproc.lean
@@ -13,7 +13,10 @@ public abbrev DSimproc.andThen (f g : DSimproc) : DSimproc := fun e₁ => do
   match r with
   | .rfl  true | .step _ true  => return r
   | .rfl  false    => g e₁
-  | .step e' false => g e'
+  | .step e₂ false =>
+    match (← g e₂) with
+    | .rfl done     => return .step e₂ done
+    | .step e₃ done => return .step e₃ done
 
 public instance : AndThen DSimproc where
   andThen f g := DSimproc.andThen f (g ())

--- a/src/Lean/Meta/Sym/DSimp/Let.lean
+++ b/src/Lean/Meta/Sym/DSimp/Let.lean
@@ -33,10 +33,10 @@ where
       match r with
       | .rfl _ =>
         if modified then
-          return .step (← mkLambdaFVarsS fvars e)
+          return .step (← mkLetFVars (generalizeNondepLet := false) (usedLetOnly := false) fvars e)
         else
           return .rfl
       | .step e' _ =>
-        return .step (← mkLambdaFVarsS fvars e')
+        return .step (← mkLetFVars (generalizeNondepLet := false) (usedLetOnly := false) fvars e')
 
 end Lean.Meta.Sym.DSimp

--- a/src/Lean/Meta/Sym/DSimp/Main.lean
+++ b/src/Lean/Meta/Sym/DSimp/Main.lean
@@ -49,12 +49,18 @@ def dsimpImpl (e₁ : Expr) : DSimpM Result := withIncRecDepth do
   let r ← pre e₁
   let r ← match r with
     | .rfl true | .step _ true  => pure r
-    | .step e₂ false  => dsimp e₂
+    | .step e₂ false  =>
+      match (← dsimp e₂) with
+      | .rfl done     => pure (.step e₂ done)
+      | .step e₃ done => pure (.step e₃ done)
     | .rfl false =>
       let r ← (dsimpStep >> post) e₁
       match r with
       | .rfl _ | .step _ true => pure r
-      | .step e₂ false => dsimp e₂
+      | .step e₂ false =>
+        match (← dsimp e₂) with
+        | .rfl done     => pure (.step e₂ done)
+        | .step e₃ done => pure (.step e₃ done)
   cacheResult e₁ r
 
 end Lean.Meta.Sym.DSimp

--- a/src/Lean/Meta/Sym/DSimp/Reduce.lean
+++ b/src/Lean/Meta/Sym/DSimp/Reduce.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+module
+prelude
+public import Lean.Meta.Sym.DSimp.DSimpM
+import Lean.Meta.Sym.InstantiateS
+import Lean.Meta.Sym.Util
+import Lean.Meta.WHNF
+import Lean.ProjFns
+namespace Lean.Meta.Sym.DSimp
+
+def beta : DSimproc := fun e => do
+  let f := e.getAppFn
+  if f.isHeadBetaTargetFn false then
+    return .step (← betaRevS f e.getAppRevArgs)
+  else
+    return .rfl
+
+def zeta (s : FVarIdSet) : DSimproc := fun e => do
+  let .fvar fvarId := e | return .rfl
+  unless s.contains fvarId do return .rfl
+  let decl ← fvarId.getDecl
+  let some value := decl.value? | return .rfl
+  return .step value
+
+def dsimpProj : DSimproc := fun e => do
+  let f := e.getAppFn
+  let .const declName _ := f | return .rfl
+  let some _projInfo ← getProjectionFnInfo? declName | return .rfl
+  let reduceProjCont? (e? : Option Expr) : DSimpM Result := do
+    match e? with
+    | none   => return .rfl
+    | some e =>
+      match (← reduceProj? e.getAppFn) with
+      | some f => return .step (← shareCommon (mkAppN f e.getAppArgs))
+      | none   => return .rfl
+  -- TODO: special support for instances?
+  reduceProjCont? (← unfoldDefinition? e)
+
+def dsimpMatch : DSimproc := fun e => do
+  let some e' ← reduceRecMatcher? e | return .rfl
+  -- Iota-reduction may expose kernel `Expr.proj` terms via struct-eta,
+  -- which the structural simplifier cannot consume directly.
+  let e'' ← Sym.foldProjs e'
+  if isSameExpr e' e'' then
+    return .rfl
+  else
+    return .step (← share e'')
+
+end Lean.Meta.Sym.DSimp

--- a/src/Lean/Meta/Sym/DSimp/Reduce.lean
+++ b/src/Lean/Meta/Sym/DSimp/Reduce.lean
@@ -12,21 +12,22 @@ import Lean.Meta.WHNF
 import Lean.ProjFns
 namespace Lean.Meta.Sym.DSimp
 
-def beta : DSimproc := fun e => do
+public def beta : DSimproc := fun e => do
+  unless e.isApp do return .rfl
   let f := e.getAppFn
   if f.isHeadBetaTargetFn false then
     return .step (← betaRevS f e.getAppRevArgs)
   else
     return .rfl
 
-def zeta (s : FVarIdSet) : DSimproc := fun e => do
+public def zeta (s : FVarIdSet) : DSimproc := fun e => do
   let .fvar fvarId := e | return .rfl
   unless s.contains fvarId do return .rfl
   let decl ← fvarId.getDecl
   let some value := decl.value? | return .rfl
   return .step value
 
-def dsimpProj : DSimproc := fun e => do
+public def dsimpProj : DSimproc := fun e => do
   let f := e.getAppFn
   let .const declName _ := f | return .rfl
   let some _projInfo ← getProjectionFnInfo? declName | return .rfl
@@ -40,7 +41,7 @@ def dsimpProj : DSimproc := fun e => do
   -- TODO: special support for instances?
   reduceProjCont? (← unfoldDefinition? e)
 
-def dsimpMatch : DSimproc := fun e => do
+public def dsimpMatch : DSimproc := fun e => do
   let some e' ← reduceRecMatcher? e | return .rfl
   -- Iota-reduction may expose kernel `Expr.proj` terms via struct-eta,
   -- which the structural simplifier cannot consume directly.

--- a/src/Lean/Meta/Sym/DSimp/Reduce.lean
+++ b/src/Lean/Meta/Sym/DSimp/Reduce.lean
@@ -27,6 +27,12 @@ public def zeta (s : FVarIdSet) : DSimproc := fun e => do
   let some value := decl.value? | return .rfl
   return .step value
 
+public def zetaAll : DSimproc := fun e => do
+  let .fvar fvarId := e | return .rfl
+  let decl ← fvarId.getDecl
+  let some value := decl.value? | return .rfl
+  return .step value
+
 public def dsimpProj : DSimproc := fun e => do
   let f := e.getAppFn
   let .const declName _ := f | return .rfl

--- a/tests/elab/sym_dsimp_1.lean
+++ b/tests/elab/sym_dsimp_1.lean
@@ -1,0 +1,140 @@
+import Lean
+
+/-! # Tests for `Sym.dsimp` (programmatic API)
+
+`Sym.dsimp` has no surface syntax yet — these tests exercise it directly via
+`SymM`. Each test declares an input `def t_xxx := <term>` and uses
+`#guard_msgs in #eval check ...` to verify the simplified form. -/
+
+open Lean Meta Sym Sym.DSimp
+
+/-- Retrieve the body of a `def`. -/
+private def getBody (declName : Name) : MetaM Expr := do
+  let some e := (← getConstInfo declName).value? | throwError "not a definition"
+  return e
+
+/-- Run `Sym.dsimp` on the body of `declName` and log the result. -/
+private def check (declName : Name) (methods : Methods := {}) : MetaM Unit := do
+  let e ← getBody declName
+  let r ← SymM.run do
+    Sym.dsimp (← Sym.shareCommon e) (methods := methods)
+  logInfo m!"{r}"
+  assert! (← isDefEq e r)
+
+/-- A `DSimproc` rewriting `0 + n` to `n` on `Nat` If `n` is a numeral. -/
+private def zeroAddRw : DSimproc := fun e => do
+  let_expr HAdd.hAdd _ _ _ _ a b := e | return .rfl
+  unless a == mkNatLit 0 do return .rfl
+  let .some _ ← getNatValue? b | return .rfl
+  return .step b
+
+/-- A `DSimproc` rewriting `n + 0` to `n` on `Nat`. -/
+private def addZeroRw : DSimproc := fun e => do
+  let_expr HAdd.hAdd _ _ _ _ a b := e | return .rfl
+  unless b == mkNatLit 0 do return .rfl
+  return .step a
+
+/-! ## 1. Identity: with no `pre`/`post`, `dsimp` returns the input unchanged -/
+
+def t_id : Nat := 0 + 1
+
+/-- info: 0 + 1 -/
+#guard_msgs in #eval check ``t_id
+
+/-! ## 2. `beta` reduction supplied via `pre` -/
+
+def t_beta : Nat := (fun x : Nat => x + 1) 5
+
+/-- info: 5 + 1 -/
+#guard_msgs in #eval check ``t_beta (methods := { pre := beta })
+
+/-! ## 3. `beta` fires inside a lambda body -/
+
+def t_beta_lambda : Nat → Nat := fun y => (fun x : Nat => x) y
+
+-- Output uses `x` rather than `y`: `Sym.shareCommon` is alpha-aware, so the
+-- post-beta `fun y => y` is unified with the input's `fun x => x`.
+/-- info: fun x => x -/
+#guard_msgs in #eval check ``t_beta_lambda (methods := { pre := beta })
+
+/-! ## 4. Custom `post` simproc rewrites at the root -/
+
+def t_zero_add : Nat := 0 + 5
+
+/-- info: 5 -/
+#guard_msgs in #eval check ``t_zero_add (methods := { post := zeroAddRw })
+
+/-! ## 5. Application descent: `dsimp` rewrites a non-head argument -/
+
+def t_succ : Nat := Nat.succ (0 + 5)
+
+/-- info: Nat.succ 5 -/
+#guard_msgs in #eval check ``t_succ (methods := { post := zeroAddRw })
+
+/-! ## 6. Repeated rewrites: `0 + (0 + 5)` reduces to `5` -/
+
+def t_nested : Nat := 0 + (0 + 5)
+
+/-- info: 5 -/
+#guard_msgs in #eval check ``t_nested (methods := { post := zeroAddRw })
+
+/-! ## 7. Lambda descent: `fun y => 0 + y` becomes `fun y => y` -/
+
+def t_lam : Nat → Nat := fun _ => 0 + 5
+
+/-- info: fun x => 5 -/
+#guard_msgs in #eval check ``t_lam (methods := { post := zeroAddRw })
+
+/-! ## 8. Forall descent: simplification reaches under `∀` -/
+
+def t_forall : Prop := ∀ y : Nat, 0 + 5 = y
+
+/-- info: ∀ (y : Nat), 5 = y -/
+#guard_msgs in #eval check ``t_forall (methods := { post := zeroAddRw })
+
+/-! ## 9. Let descent: both the value and the body are simplified -/
+
+def t_let : Nat := let z : Nat := 0 + 7; z + 0
+
+-- The elaborator marks `z` as `nondep` (since the body doesn't depend on its
+-- value at the type level), so the pretty printer shows `have` rather than `let`.
+/--
+info: have z := 7;
+z
+-/
+#guard_msgs in #eval check ``t_let (methods := { post := zeroAddRw >> addZeroRw })
+
+/-! ## 10. `>>` combinator: chained simprocs fire on the same subterm -/
+
+def t_chain : Nat → Nat := fun x => (x + 0) + 0
+
+/-- info: fun x => x -/
+#guard_msgs in #eval check ``t_chain (methods := { post := addZeroRw })
+
+/-! ## 11. `<|>` combinator: second simproc fires when the first does not -/
+
+def t_orelse : Nat → Nat := fun x => x + 0
+
+/-- info: fun x => x -/
+#guard_msgs in #eval check ``t_orelse (methods := { post := zeroAddRw <|> addZeroRw })
+
+/-! ## 12. `done = true` on `.rfl`: `pre` stops descent without rewriting -/
+
+def t_done_rfl : Nat := 0 + (0 + 5)
+
+private def stopHere : DSimproc := fun _ => return .rfl true
+
+/-- info: 0 + (0 + 5) -/
+#guard_msgs in
+#eval check ``t_done_rfl (methods := { pre := stopHere, post := zeroAddRw })
+
+/-! ## 13. `done = true` on `.step`: simplified result is not re-processed -/
+
+def t_done_step : Nat := 0 + 0
+
+/-- Custom `pre` that returns `0` with `done = true`; `post` must not re-fire. -/
+private def replaceWithZero : DSimproc := fun _ => return .step (mkNatLit 0) true
+
+/-- info: 0 -/
+#guard_msgs in
+#eval check ``t_done_step (methods := { pre := replaceWithZero, post := zeroAddRw })


### PR DESCRIPTION
This PR implements a collection of reusable reduction `DSimproc`s (`beta`, `zeta`, `zetaAll`, `dsimpProj`, `dsimpMatch`), exposing them as public so callers can compose them into their own `Methods`, and fixing a few bugs. 