### PR TITLE
feat: introduce `simpa using!` syntax (no-op alias)

### DIFF
--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -764,8 +764,24 @@ This is a "finishing" tactic modification of `simp`. It has two forms.
 * `simpa [rules, ⋯]` will simplify the goal and the type of a
   hypothesis `this` if present in the context, then try to close the goal using
   the `assumption` tactic.
+
+The `using!` clause (`simpa [rules, ⋯] using! e`) is reserved for a future
+transparency split of the final unification. At present it behaves identically
+to `using`; both close the goal at the ambient (default/semireducible)
+transparency.
 -/
 syntax (name := simpa) "simpa" "?"? "!"? simpaArgsRest : tactic
+
+/-- The arguments to `simpa ... using! e` — like `simpaArgsRest`, but with a
+mandatory `using!` clause. At present the only difference between `using` and
+`using!` is forward-compatibility: a follow-up change will make `using` close
+at reducible transparency, leaving `using!` at the current default
+transparency. -/
+syntax simpaUsingBangArgsRest :=
+  optConfig (discharger)? &" only "? (simpArgs)? " using! " term
+
+@[tactic_alt simpa]
+syntax (name := simpaUsingBang) "simpa" "?"? "!"? simpaUsingBangArgsRest : tactic
 
 @[inherit_doc simpa] macro "simpa!" rest:simpaArgsRest : tactic =>
   `(tactic| simpa ! $rest:simpaArgsRest)
@@ -775,6 +791,18 @@ syntax (name := simpa) "simpa" "?"? "!"? simpaArgsRest : tactic
 
 @[inherit_doc simpa] macro "simpa?!" rest:simpaArgsRest : tactic =>
   `(tactic| simpa ?! $rest:simpaArgsRest)
+
+@[inherit_doc simpa, tactic_alt simpa]
+macro "simpa!" rest:simpaUsingBangArgsRest : tactic =>
+  `(tactic| simpa ! $rest:simpaUsingBangArgsRest)
+
+@[inherit_doc simpa, tactic_alt simpa]
+macro "simpa?" rest:simpaUsingBangArgsRest : tactic =>
+  `(tactic| simpa ? $rest:simpaUsingBangArgsRest)
+
+@[inherit_doc simpa, tactic_alt simpa]
+macro "simpa?!" rest:simpaUsingBangArgsRest : tactic =>
+  `(tactic| simpa ?! $rest:simpaUsingBangArgsRest)
 
 /--
 `delta id1 id2 ...` delta-expands the definitions `id1`, `id2`, ....

--- a/src/Lean/Elab/Tactic/Simpa.lean
+++ b/src/Lean/Elab/Tactic/Simpa.lean
@@ -118,4 +118,18 @@ def getLinterUnnecessarySimpa (o : LinterOptions) : Bool :=
     return stats.diag
     | _ => throwUnsupportedSyntax
 
+@[builtin_tactic Lean.Parser.Tactic.simpaUsingBang] def evalSimpaUsingBang : Tactic := fun stx => do
+  -- For now, `simpa ... using! e` is a no-op alias for `simpa ... using e`: both
+  -- close the goal at the ambient (default/semireducible) transparency. The two
+  -- syntaxes will diverge once `using` is restricted to reducible-transparency
+  -- close in a follow-up change; until then this elaborator just rewrites
+  -- `using!` to `using` and dispatches to `evalSimpa`.
+  match stx with
+  | `(tactic| simpa%$tk $[?%$squeeze]? $[!%$unfold]? $cfg:optConfig $(disch)? $[only%$only]?
+        $[[$args,*]]? using! $usingArg) => do
+    let stx' ← `(tactic| simpa%$tk $[?%$squeeze]? $[!%$unfold]? $cfg:optConfig $(disch)? $[only%$only]?
+        $[[$args,*]]? using $usingArg)
+    evalSimpa stx'
+  | _ => throwUnsupportedSyntax
+
 end Lean.Elab.Tactic.Simpa


### PR DESCRIPTION
This PR adds the `simpa ... using! e` syntax as a parallel form of
`simpa ... using e`. At present `using!` behaves identically to `using` — both
close the goal at the ambient (default/semireducible) transparency.

The syntax is introduced ahead of a follow-up change to `simpa using h`'s
final-unification transparency, so that any site that today requires the
permissive close can be opted in by switching `using` → `using!` independently
of the elaborator change.

The new tactic is declared as a parallel syntax (`simpaUsingBang`) tagged
`@[tactic_alt simpa]`, with its own elaborator that rewrites `using!` to
`using` and dispatches to `evalSimpa`. The parallel macros `simpa?`/`simpa!`/
`simpa?!` are extended to also accept a `using!` clause.

This PR is the first of two — the follow-up at #13636 flips `simpa using h`
to reducible-transparency close (and updates the few in-tree call sites that
need `using!`).

🤖 Prepared with Claude Code