### PR TITLE
feat: break MePo score ties by overlap

### DIFF
--- a/src/Lean/LibrarySuggestions/MePo.lean
+++ b/src/Lean/LibrarySuggestions/MePo.lean
@@ -53,18 +53,20 @@ def mepo (initialRelevant : NameSet) (score : NameSet → NameSet → Float) (ac
     trace[mepo] m!"Considering candidates with threshold {p}."
     trace[mepo] m!"Current relevant set: {relevant.toList}."
     let (newAccepted, candidates') := candidates.map
-      (fun (n, c) => (n, c, score relevant c))
-      |>.partition fun (_, _, s) => p ≤ s
+      (fun (n, c) => (n, c, score relevant c, (relevant ∩ c).size))
+      |>.partition fun (_, _, s, _) => p ≤ s
     if newAccepted.isEmpty then return accepted
-    trace[mepo] m!"Accepted {newAccepted.map fun (n, _, s) => (n, s)}."
+    trace[mepo] m!"Accepted {newAccepted.map fun (n, _, s, overlap) => (n, s, overlap)}."
     -- Scores from different iterations are not comparable: each iteration accepts
     -- against a strictly larger `relevant` set and a higher threshold. We order the
     -- output by `(iteration, score)`: earlier iterations always rank first, and
-    -- within an iteration we sort by descending score.
-    let newAccepted := newAccepted.qsort (fun (_, _, s₁) (_, _, s₂) => s₁ > s₂)
-    accepted := newAccepted.foldl (fun acc (n, _, s) => acc.push { name := n, score := s }) accepted
-    candidates := candidates'.map fun (n, c, _) => (n, c)
-    relevant := newAccepted.foldl (fun acc (_, ns, _) => acc ++ ns) relevant
+    -- within an iteration we sort by descending score, breaking equal-score ties
+    -- by the number of constants shared with the current relevant set.
+    let newAccepted := newAccepted.qsort fun (_, _, s₁, o₁) (_, _, s₂, o₂) =>
+      s₁ > s₂ || (s₁ == s₂ && o₁ > o₂)
+    accepted := newAccepted.foldl (fun acc (n, _, s, _) => acc.push { name := n, score := s }) accepted
+    candidates := candidates'.map fun (n, c, _, _) => (n, c)
+    relevant := newAccepted.foldl (fun acc (_, ns, _, _) => acc ++ ns) relevant
     p := p + (1 - p) / c
   return accepted
 

--- a/tests/elab/library_suggestions_mepo_order.lean
+++ b/tests/elab/library_suggestions_mepo_order.lean
@@ -5,9 +5,10 @@ Regression test: the MePo premise selector filters candidates to theorems
 (matching the convention already used by `SineQuaNon` and `SymbolFrequency`)
 and finds the obvious lemma for an arithmetic equality goal.
 
-Output is ordered by `(iteration, score)` rather than by score alone, so the
-score sequence is not globally monotonic — a score jump signals an iteration
-boundary.
+Output is ordered by `(iteration, score, overlap)` rather than by score alone,
+so the score sequence is not globally monotonic — a score jump signals an
+iteration boundary. The overlap tie-breaker keeps generic one-symbol theorems
+from outranking more specific lemmas with the same MePo score.
 -/
 
 open Lean Lean.Elab.Tactic Lean.LibrarySuggestions
@@ -25,4 +26,13 @@ example (a b : Int) : a + b = b + a := by
         accept filter"
     unless names.contains ``Int.add_comm do
       throwError "Int.add_comm should appear in the MePo suggestions for `a + b = b + a`"
+    match names.findIdx? (· == ``Int.add_comm), names.findIdx? (· == ``Eq.symm) with
+    | some i, some j =>
+      unless i < j do
+        throwError "Int.add_comm should rank before generic Eq.symm when both \
+          have the same MePo score"
+    | none, _ =>
+      throwError "Int.add_comm should appear in the MePo suggestions for `a + b = b + a`"
+    | _, none =>
+      throwError "Eq.symm should appear in the MePo suggestions for this regression test"
   sorry


### PR DESCRIPTION
This PR makes MePo premise suggestions less likely to rank tiny generic theorems ahead of equally-scored domain-specific lemmas.

MePo now breaks score ties within a single iteration by preferring candidates that share more constants with the current relevant set. This does not change which candidates pass the threshold.

A regression check verifies that `Int.add_comm` ranks before generic `Eq.symm` for an integer commutativity goal.

Fixes #13749.

Tests: `git diff --check` locally. I did not run the Lean test suite locally because this workspace is a shallow sparse checkout without a local Lean toolchain.