### PR TITLE
fix: preserve cases params in grind? suggestions

### DIFF
--- a/src/Lean/Elab/Tactic/Grind/Main.lean
+++ b/src/Lean/Elab/Tactic/Grind/Main.lean
@@ -367,24 +367,37 @@ def evalGrindTraceCore (stx : Syntax) (trace := true) (verbose := true) (useSorr
   let config := { config with clean := false, trace, verbose, useSorry }
   let only := only.isSome
   let paramStxs := if let some params := params? then params.getElems else #[]
+  let isCasesModifier (mod? : Option (TSyntax ``Parser.Attr.grindMod)) : TacticM Bool := do
+    match mod? with
+    | none => return false
+    | some mod =>
+      match ← Grind.getAttrKindCore mod with
+      | .cases _ => return true
+      | _ => return false
   -- Extract term parameters (non-ident params) to include in the suggestion.
   -- These are not tracked via E-matching, so we conservatively include them all.
   -- Plain ident params that resolve to global declarations are tracked via E-matching.
+  -- `cases` parameters are tracked through the case-split configuration rather
+  -- than E-matching, so we preserve them too.
   -- But idents with local variable dot notation (e.g., `cs.getD_rightInvSeq` where `cs`
   -- is a local variable) must be preserved because they produce anchors that need
   -- the original term to be loaded during replay.
   -- Non-ident terms (like `show P by tac`) need to be preserved explicitly.
   let termParamStxs : Array Grind.TParam ← paramStxs.filterM fun p => do
     match p with
-    | `(Parser.Tactic.grindParam| $[$_:grindMod]? $id:ident) =>
+    | `(Parser.Tactic.grindParam| $[$mod?:grindMod]? $id:ident) =>
+      if ← isCasesModifier mod? then
+        return true
       -- Check if this ident resolves to local variable dot notation
       -- If so, keep it because it's not a simple global declaration
-      if let some (_, _ :: _) := (← resolveLocalName id.getId) then
+      else if let some (_, _ :: _) := (← resolveLocalName id.getId) then
         return true
       else
         return false
-    | `(Parser.Tactic.grindParam| ! $[$_:grindMod]? $id:ident) =>
-      if let some (_, _ :: _) := (← resolveLocalName id.getId) then
+    | `(Parser.Tactic.grindParam| ! $[$mod?:grindMod]? $id:ident) =>
+      if ← isCasesModifier mod? then
+        return true
+      else if let some (_, _ :: _) := (← resolveLocalName id.getId) then
         return true
       else
         return false

--- a/tests/elab/grind_question_mark_suggestions.lean
+++ b/tests/elab/grind_question_mark_suggestions.lean
@@ -21,3 +21,20 @@ info: Try these:
 #guard_msgs in
 example {x y : Nat} (h : x = y) : x = f y := by
   grind? +suggestions [f]
+
+-- `cases` parameters affect the case-split configuration rather than the
+-- E-matching theorem set, so `grind?` must preserve them in `grind only`
+-- suggestions.
+/--
+grind only [cases Option]
+-/
+#guard_msgs (substring := true) in
+example (x : Option Nat) : x = none \/ Exists fun n => x = some n := by
+  grind? [cases Option]
+
+/--
+grind only [cases Bool]
+-/
+#guard_msgs (substring := true) in
+example (f : Bool -> Bool) (x : Bool) : f (f (f x)) = f x := by
+  cases h1 : f true <;> cases h2 : f false <;> grind? only [cases Bool]


### PR DESCRIPTION
This PR preserves explicit `cases` parameters in `grind?` suggestions.

`grind?` already preserves non-ident term parameters when reconstructing `grind only` suggestions because they are not tracked through E-matching. Explicit `cases` parameters are another non-E-matching input: they update the case-split configuration.

The added regression tests check that `grind?` suggestions contain the required `cases Bool` and `cases Option` parameters.

Fixes #13828.

Tests: `git diff --check` locally. I did not run the Lean test suite locally because this workspace is a shallow sparse checkout without a local Lean toolchain.