### PR TITLE
fix: let try? continue after maxRecDepth

### DIFF
--- a/src/Lean/Elab/Tactic/Try.lean
+++ b/src/Lean/Elab/Tactic/Try.lean
@@ -417,6 +417,8 @@ def withOriginalHeartbeats (x : TryTacticM α) : TryTacticM α := do
     (fun ex => do
       if Exception.isMaxHeartbeat ex then
         throwError "tactic exceeded heartbeat limit"
+      else if ex.isMaxRecDepth then
+        throwError "tactic exceeded recursion depth limit"
       else
         throw ex)
 

--- a/tests/elab/try_eval_suggest.lean
+++ b/tests/elab/try_eval_suggest.lean
@@ -49,3 +49,12 @@ example (h : 1 = 1) : 1 = 1 := by
 #guard_msgs (info) in
 example : 1 = 1 := by
   try? (max := 1) => attempt_all | rfl | simp_all
+
+-- A resource-limit error in one branch should not prevent other branches from producing suggestions.
+/--
+info: Try this:
+  [apply] grind
+-/
+#guard_msgs (substring := true) in
+example (f : Nat → Nat) (x : Nat) (h : x = f x) : x = f (f x) := by
+  try?


### PR DESCRIPTION
This PR lets `try?` continue evaluating other candidate branches when one branch hits Lean's recursion-depth resource limit.

`try?` already converts heartbeat exhaustion into an ordinary branch failure. This applies the same treatment to `maxRecDepth`, so an expensive `simp`/`simp_all` candidate does not suppress a useful `grind` suggestion.

Closes #13216.

<!-- retrigger changelog check -->