### PR TITLE
feat: add iff theorem for List.toArray equality

### DIFF
--- a/src/Init/Data/List/ToArray.lean
+++ b/src/Init/Data/List/ToArray.lean
@@ -62,6 +62,13 @@ theorem toArray_inj {as bs : List α} (h : as.toArray = bs.toArray) : as = bs :=
     | nil => simp at h
     | cons b bs => simpa using h
 
+@[simp] theorem toArray_eq_toArray_iff {as bs : List α} : as.toArray = bs.toArray ↔ as = bs := by
+  constructor
+  · exact toArray_inj
+  · intro h
+    cases h
+    rfl
+
 theorem toArray_eq_iff {as : List α} {bs : Array α} : as.toArray = bs ↔ as = bs.toList := by
   cases bs
   simp

--- a/tests/elab/list_toarray_inj.lean
+++ b/tests/elab/list_toarray_inj.lean
@@ -1,0 +1,13 @@
+import Init.Data.List.ToArray
+
+example {as bs : List Nat} : as.toArray = bs.toArray ↔ as = bs := by
+  simp
+
+example {as bs : List Nat} (h : as.toArray = bs.toArray) : as = bs :=
+  List.toArray_eq_toArray_iff.mp h
+
+example {as bs : List Nat} (h : as = bs) : as.toArray = bs.toArray :=
+  List.toArray_eq_toArray_iff.mpr h
+
+example {as bs : List Nat} (h : as.toArray = bs.toArray) : as = bs :=
+  List.toArray_inj h


### PR DESCRIPTION
This PR adds `List.toArray_eq_toArray_iff`, the iff-shaped theorem for injectivity of `List.toArray`, while keeping the existing one-way `List.toArray_inj` theorem for compatibility.

The new theorem follows the usual iff naming shape and is marked `[simp]`, so goals comparing two `List.toArray` expressions simplify back to list equality.

Addresses #13095.

<!-- retrigger changelog check -->