### PR TITLE
refactor: render trace result emoji from TraceData

### DIFF
--- a/src/Lean/Message.lean
+++ b/src/Lean/Message.lean
@@ -84,6 +84,19 @@ inductive TraceResult where
   | error
   deriving Inhabited, BEq, Repr
 
+/-- Emoji used when rendering trace nodes whose actions threw exceptions. -/
+def bombEmoji := "💥️"
+/-- Emoji used when rendering trace nodes whose actions succeeded. -/
+def checkEmoji := "✅️"
+/-- Emoji used when rendering trace nodes whose actions failed without throwing. -/
+def crossEmoji := "❌️"
+
+/-- Convert a `TraceResult` to its emoji representation. -/
+def TraceResult.toEmoji : TraceResult → String
+  | .success => checkEmoji
+  | .failure => crossEmoji
+  | .error   => bombEmoji
+
 structure TraceData where
   /-- Trace class, e.g. `Elab.step`. -/
   cls       : Name
@@ -98,6 +111,12 @@ structure TraceData where
   collapsed : Bool := true
   /-- Optional tag shown in `trace.profiler.output` output after the trace class name. -/
   tag       : String := ""
+
+/-- Add the result-status prefix to a trace header, if the trace has a structured result. -/
+def TraceData.formatHeader (data : TraceData) (header : Format) : Format :=
+  match data.result? with
+  | none => header
+  | some result => f!"{result.toEmoji} {header}"
 
 /-- Structured message data. We use it for reporting errors, trace messages, etc. -/
 inductive MessageData where
@@ -359,7 +378,7 @@ partial def formatAux : NamingContext → Option MessageDataContext → MessageD
     let mut msg := f!"[{data.cls}]"
     if data.startTime != 0 then
       msg := f!"{msg} [{data.stopTime - data.startTime}]"
-    msg := f!"{msg} {(← formatAux nCtx ctx header).nest 2}"
+    msg := f!"{msg} {data.formatHeader ((← formatAux nCtx ctx header).nest 2)}"
     let mut children := children
     if let some maxNum := ctx.map (maxTraceChildren.get ·.opts) then
       if maxNum > 0 && children.size > maxNum then

--- a/src/Lean/Util/Profiler.lean
+++ b/src/Lean/Util/Profiler.lean
@@ -203,7 +203,7 @@ where
       if !data.tag.isEmpty then
         funcName := s!"{funcName}: {data.tag}"
       if pp then
-        funcName := s!"{funcName}: {← msg.format ctx?}"
+        funcName := s!"{funcName}: {data.formatHeader (← msg.format ctx?)}"
       let strIdx ← modifyGet fun thread =>
         if let some idx := thread.stringMap[funcName]? then
           (idx, thread)

--- a/src/Lean/Util/Trace.lean
+++ b/src/Lean/Util/Trace.lean
@@ -271,16 +271,6 @@ instance [always : MonadAlwaysExcept ε m] [STWorld ω m] [BEq α] [Hashable α]
     MonadAlwaysExcept ε (MonadCacheT α β m) where
   except := let _ := always.except; inferInstance
 
-def bombEmoji := "💥️"
-def checkEmoji := "✅️"
-def crossEmoji := "❌️"
-
-/-- Convert a `TraceResult` to its emoji representation. -/
-def TraceResult.toEmoji : TraceResult → String
-  | .success => checkEmoji
-  | .failure => crossEmoji
-  | .error   => bombEmoji
-
 /-- Convert an `Except` result to a `TraceResult`.
 `Except.error` always maps to `.error`.
 For `Bool`, `.ok false` maps to `.failure`. For `Option`, `.ok none` maps to `.failure`. -/
@@ -321,8 +311,8 @@ then `Lean.withTraceNode'` can be used instead.
 If profiling is enabled, this will also log the runtime of `k`.
 
 The class `ExceptToTraceResult` is used to convert the result produced by `k` into a `TraceResult`
-(success/failure/error), which is stored in `TraceData.result?` and also used to select the
-emoji prefix (✅️/❌️/💥️). A typical invocation might be:
+(success/failure/error), which is stored in `TraceData.result?`. Renderers use this field to select
+the emoji prefix (✅️/❌️/💥️). A typical invocation might be:
 ```lean4
 withTraceNode `isPosTrace
     (msg := fun _ => return m!"checking positivity") do
@@ -354,9 +344,8 @@ where
       modifyTraces (oldTraces ++ ·)
       return (← MonadExcept.ofExcept res)
     let ref ← getRef
-    let mut m ← try msg res catch _ => pure m!"<exception thrown while producing trace node message>"
+    let m ← try msg res catch _ => pure m!"<exception thrown while producing trace node message>"
     let result := res.toTraceResult
-    m := m!"{result.toEmoji} {m}"
     let mut data : TraceData := { cls, collapsed, tag, result? := some result }
     if trace.profiler.get opts then
       data := { data with startTime := start, stopTime := stop }
@@ -409,7 +398,7 @@ Similar to `withTraceNode`, but msg is constructed **before** executing `k`.
 This is important when debugging methods such as `isDefEq`, and we want to generate the message
 before `k` updates the metavariable assignment. The class `ExceptToTraceResult` is used to convert
 the result produced by `k` into a `TraceResult` (success/failure/error), which is stored in
-`TraceData.result?` and also used to select the emoji prefix (✅️/❌️/💥️).
+`TraceData.result?`. Renderers use this field to select the emoji prefix (✅️/❌️/💥️).
 
 TODO: find better name for this function.
 -/
@@ -439,7 +428,6 @@ where
       modifyTraces (oldTraces ++ ·)
       return (← MonadExcept.ofExcept res)
     let result := res.toTraceResult
-    let mut msg := m!"{result.toEmoji} {msg}"
     let mut data : TraceData := { cls, collapsed, tag, result? := some result }
     if trace.profiler.get opts then
       data := { data with startTime := start, stopTime := stop }

--- a/src/Lean/Widget/InteractiveDiagnostic.lean
+++ b/src/Lean/Widget/InteractiveDiagnostic.lean
@@ -160,7 +160,7 @@ where
       -- to never put trace nodes on the same line.
       return .join (← children.mapM (go nCtx ctx)).toList
 
-    let mut header := (← go nCtx ctx header).nest 4
+    let mut header := data.formatHeader ((← go nCtx ctx header).nest 4)
     if data.startTime != 0 then
       header := f!"[{data.stopTime - data.startTime}] {header}"
     let nodes ←

--- a/tests/elab/trace_result_header.lean
+++ b/tests/elab/trace_result_header.lean
@@ -1,0 +1,17 @@
+import Lean
+
+open Lean
+
+#eval show IO Unit from do
+  let msg : MessageData := .trace { cls := `trace.test, result? := some .success } "header" #[]
+  let rendered ← (MessageData.toString msg).toIO
+  let expected := s!"[trace.test] {checkEmoji} header"
+  unless rendered == expected do
+    throw <| IO.userError s!"expected {expected}, got {rendered}"
+
+#eval show IO Unit from do
+  let msg : MessageData := .trace { cls := `trace.test } "header" #[]
+  let rendered ← (MessageData.toString msg).toIO
+  let expected := "[trace.test] header"
+  unless rendered == expected do
+    throw <| IO.userError s!"expected {expected}, got {rendered}"


### PR DESCRIPTION
This PR renders trace success/failure/error emoji from `TraceData.result?` instead of baking the emoji into the stored trace header.

Visible trace output remains unchanged, but programmatic consumers can compare trace headers without success-dependent emoji prefixes. The formatter, interactive diagnostics, and profiler renderer all use the structured result field for display.

Closes #13069.