### PR TITLE
feat: tag linter warnings for `recordLints`

### DIFF
--- a/src/Lean/Linter/Init.lean
+++ b/src/Lean/Linter/Init.lean
@@ -86,10 +86,23 @@ Like `getLinterValue`, but the cross-linter fallback is `linter.extra` instead o
 def getLinterValueExtra (opt : Lean.Option Bool) (o : LinterOptions) : Bool :=
   o.get opt.name (getLinterExtra o opt.defValue)
 
+/--
+Tag attached by `logLint` to every linter warning so consumers
+(e.g. `Lean.Linter.recordLints`) can distinguish linter-produced messages
+from other tagged messages such as named errors or unknown-identifier messages.
+-/
+def linterMessageTag : Name := `Lean.Linter._linter
+
 def logLint [Monad m] [MonadLog m] [AddMessageContext m] [MonadOptions m]
     (linterOption : Lean.Option Bool) (stx : Syntax) (msg : MessageData) : m Unit :=
   let disable := .note m!"This linter can be disabled with `set_option {linterOption.name} false`"
-  logWarningAt stx (.tagged linterOption.name m!"{msg}{disable}")
+  logWarningAt stx <|
+    .tagged linterOption.name <|
+    .tagged linterMessageTag m!"{msg}{disable}"
+
+/-- Returns true if `msg` was produced by `Lean.Linter.logLint` (and therefore by a linter). -/
+def _root_.Lean.MessageData.isLinterMessage (msg : MessageData) : Bool :=
+  msg.hasTag (· == linterMessageTag)
 
 /--
 If `linterOption` is enabled, print a linter warning message at the position determined by `stx`.

--- a/src/Lean/Linter/PersistentLintLog.lean
+++ b/src/Lean/Linter/PersistentLintLog.lean
@@ -8,6 +8,7 @@ module
 prelude
 public import Lean.Environment
 public import Lean.Message
+public import Lean.Linter.Init
 
 public section
 
@@ -32,6 +33,8 @@ def getAllLints (env : Environment) : Array (Name × Array LintEntry) :=
 
 def recordLints (env : Environment) (messages : MessageLog) : BaseIO Environment := do
   messages.reportedPlusUnreported.foldlM (init := env) fun env m => do
+    unless m.data.isLinterMessage do
+      return env
     let kind := m.data.kind
     if kind.isAnonymous then
       return env

--- a/tests/elab/persistent_lint_log.lean
+++ b/tests/elab/persistent_lint_log.lean
@@ -4,18 +4,22 @@ open Lean
 
 /-! ## Tests for the persistent lint log extension -/
 
+/-- Build a linter-shaped `MessageData`: the outer tag is the linter option name and
+the inner tag is `Linter.linterMessageTag`, matching what `Linter.logLint` produces. -/
+def mkLinterMsg (kind : Name) (body : MessageData) : MessageData :=
+  .tagged kind (.tagged Linter.linterMessageTag body)
+
 /--
-Builds a `MessageLog` containing a single tagged warning whose `MessageData.kind` is
+Builds a `MessageLog` containing a single linter-shaped warning whose `MessageData.kind` is
 `linter.dummy`, runs `Linter.recordLints`, and returns the resulting extension state.
 -/
 def testRecordLints : CoreM (Array (Name × String)) := do
   let env ← getEnv
-  let tagged : MessageData := .tagged `linter.dummy (m!"unused variable 'x'")
   let msg : Message := {
     fileName := "Test.lean"
     pos := ⟨3, 5⟩
     severity := .warning
-    data := tagged
+    data := mkLinterMsg `linter.dummy m!"unused variable 'x'"
   }
   let log : MessageLog := MessageLog.empty.add msg
   let env ← Linter.recordLints env log
@@ -43,14 +47,32 @@ def testRecordLintsIgnoresUntagged : CoreM Nat := do
 #guard_msgs in
 #eval testRecordLintsIgnoresUntagged
 
-/-- Multiple tagged messages are all recorded, in log order. -/
+/-- Tagged messages that were not produced by a linter (e.g. named errors,
+unknown-identifier messages) must not be recorded. -/
+def testRecordLintsIgnoresNonLinterTags : CoreM Nat := do
+  let env ← getEnv
+  let msg : Message := {
+    fileName := "Test.lean"
+    pos := ⟨1, 1⟩
+    severity := .error
+    data := .tagged `lean.unknownIdentifier m!"unknown identifier 'foo'"
+  }
+  let log : MessageLog := MessageLog.empty.add msg
+  let env ← Linter.recordLints env log
+  return (Linter.lintLogExt.getState env).size
+
+/-- info: 0 -/
+#guard_msgs in
+#eval testRecordLintsIgnoresNonLinterTags
+
+/-- Multiple linter-shaped messages are all recorded, in log order. -/
 def testRecordLintsMultiple : CoreM (Array Name) := do
   let env ← getEnv
   let mk (kind : Name) (txt : String) : Message := {
     fileName := "Test.lean"
     pos := ⟨1, 1⟩
     severity := .warning
-    data := .tagged kind (m!"{txt}")
+    data := mkLinterMsg kind m!"{txt}"
   }
   let log : MessageLog :=
     MessageLog.empty


### PR DESCRIPTION
This PR makes `Lean.Linter.logLint` attach an internal tag to every
linter warning so that `Lean.Linter.recordLints` can reliably distinguish
linter-produced messages from other tagged messages (named errors,
unknown-identifier messages, `hasSorry` markers, etc.). Previously,
`recordLints` captured every message whose top-level kind was non-anonymous,
which over-recorded non-linter diagnostics into the persistent lint log.

The change preserves the existing `MessageData.kind` of linter warnings (it
still returns the linter option name) by nesting the sentinel tag inside the
kind tag. A new helper `MessageData.isLinterMessage` is exposed alongside the
existing `isDeprecationWarning` / `isUnusedVariableWarning` predicates.