### PR TITLE
perf: less aggressive getElem? e-matching

### DIFF
--- a/src/Init/GetElem.lean
+++ b/src/Init/GetElem.lean
@@ -173,9 +173,6 @@ instance (priority := low) [GetElem coll idx elem valid] [∀ xs i, Decidable (v
   rw [getElem?_def]
   exact dif_pos h
 
-grind_pattern getElem?_pos => c[i], c[i]? where
-  guard dom c i
-
 @[simp, grind =] theorem getElem?_neg [GetElem? cont idx elem dom] [LawfulGetElem cont idx elem dom]
     (c : cont) (i : idx) (h : ¬dom c i) : c[i]? = none := by
   have : Decidable (dom c i) := .isFalse h

--- a/src/Init/GetElem.lean
+++ b/src/Init/GetElem.lean
@@ -173,7 +173,7 @@ instance (priority := low) [GetElem coll idx elem valid] [∀ xs i, Decidable (v
   rw [getElem?_def]
   exact dif_pos h
 
-grind_pattern getElem?_pos => c[i] where
+grind_pattern getElem?_pos => c[i], c[i]? where
   guard dom c i
 
 @[simp, grind =] theorem getElem?_neg [GetElem? cont idx elem dom] [LawfulGetElem cont idx elem dom]

--- a/src/Lean/Elab/Tactic/Grind/LintExceptions.lean
+++ b/src/Lean/Elab/Tactic/Grind/LintExceptions.lean
@@ -26,8 +26,6 @@ import Lean.Elab.Tactic.Grind.Lint
 #grind_lint skip Array.count_singleton
 #grind_lint skip Array.foldl_empty
 #grind_lint skip Array.foldr_empty
-#grind_lint skip Array.getElem_zero_filter
-#grind_lint skip Array.getElem_zero_filterMap
 #grind_lint skip Std.ExtHashMap.getElem_filterMap'
 #grind_lint skip Std.ExtTreeMap.getElem_filterMap'
 #grind_lint skip Std.HashMap.getElem_filterMap'

--- a/tests/elab/grind_indexmap.lean
+++ b/tests/elab/grind_indexmap.lean
@@ -80,8 +80,8 @@ variable [LawfulBEq α] [LawfulHashable α]
 
 local grind_pattern IndexMap.WF1 => self.keys[i]
 local grind_pattern IndexMap.WF2 => self.indices[a]
-attribute [grind ←] IndexMap.WF3
-attribute [grind ←] IndexMap.WF4
+attribute [local grind ←] IndexMap.WF3
+attribute [local grind ←] IndexMap.WF4
 
 instance : GetElem? (IndexMap α β) α β (fun m a => a ∈ m) where
   getElem m a h := m.values[m.indices[a]'h]'(by grind)

--- a/tests/elab/grind_indexmap.lean
+++ b/tests/elab/grind_indexmap.lean
@@ -23,7 +23,11 @@ structure IndexMap (α : Type u) (β : Type v) [BEq α] [Hashable α] where
   private keys : Array α
   private values : Array β
   private size_keys' : keys.size = values.size := by grind
-  private WF : ∀ (i : Nat) (a : α), keys[i]? = some a ↔ indices[a]? = some i := by grind
+  private WF1 : ∀ (i : Nat) (h1 : i < keys.size) (h2 : keys[i] ∈ indices), indices[keys[i]] = i := by grind
+  private WF2 : ∀ (a : α) (h1 : a ∈ indices) (h2 : indices[a] < keys.size), keys[indices[a]] = a := by grind
+  private WF3 : ∀ (a : α) (h1 : a ∈ indices), indices[a] < keys.size := by grind
+  private WF4 : ∀ (i : Nat) (h1 : i < keys.size), keys[i] ∈ indices := by grind
+
 
 namespace IndexMap
 
@@ -74,10 +78,13 @@ private theorem mem_indices {m : IndexMap α β} {a : α} :
 
 variable [LawfulBEq α] [LawfulHashable α]
 
-attribute [local grind _=_] IndexMap.WF
+local grind_pattern IndexMap.WF1 => self.keys[i]
+local grind_pattern IndexMap.WF2 => self.indices[a]
+attribute [grind ←] IndexMap.WF3
+attribute [grind ←] IndexMap.WF4
 
 instance : GetElem? (IndexMap α β) α β (fun m a => a ∈ m) where
-  getElem m a h := m.values[m.indices[a]'h]
+  getElem m a h := m.values[m.indices[a]'h]'(by grind)
   getElem? m a  := m.indices[a]?.bind (fun i => (m.values[i]?))
   getElem! m a  := m.indices[a]?.bind (fun i => (m.values[i]?)) |>.getD default
 

--- a/tests/elab/grind_indexmap_trace.lean
+++ b/tests/elab/grind_indexmap_trace.lean
@@ -9,7 +9,10 @@ structure IndexMap (α : Type u) (β : Type v) [BEq α] [Hashable α] where
   private keys : Array α
   private values : Array β
   private size_keys' : keys.size = values.size := by grind
-  private WF : ∀ (i : Nat) (a : α), keys[i]? = some a ↔ indices[a]? = some i := by grind
+  private WF1 : ∀ (i : Nat) (h1 : i < keys.size) (h2 : keys[i] ∈ indices), indices[keys[i]] = i := by grind
+  private WF2 : ∀ (a : α) (h1 : a ∈ indices) (h2 : indices[a] < keys.size), keys[indices[a]] = a := by grind
+  private WF3 : ∀ (a : α) (h1 : a ∈ indices), indices[a] < keys.size := by grind
+  private WF4 : ∀ (i : Nat) (h1 : i < keys.size), keys[i] ∈ indices := by grind
 
 namespace IndexMap
 
@@ -56,7 +59,10 @@ instance {m : IndexMap α β} {a : α} : Decidable (a ∈ m) :=
 
 variable [LawfulBEq α] [LawfulHashable α]
 
-attribute [local grind _=_] IndexMap.WF
+local grind_pattern IndexMap.WF1 => self.keys[i]
+local grind_pattern IndexMap.WF2 => self.indices[a]
+attribute [local grind ←] IndexMap.WF3
+attribute [local grind ←] IndexMap.WF4
 
 private theorem getElem_indices_lt {h : a ∈ m} : m.indices[a] < m.size := by
   have : m.indices[a]? = some m.indices[a] := by grind
@@ -104,7 +110,6 @@ instance [LawfulBEq α] : LawfulSingleton (α × β) (IndexMap α β) :=
 
 @[local grind .] private theorem WF' (i : Nat) (a : α) (h₁ : i < m.keys.size) (h₂ : a ∈ m) :
     m.keys[i] = a ↔ m.indices[a] = i := by
-  have := m.WF i a
   grind
 
 /--
@@ -150,7 +155,7 @@ info: Try these:
     instantiate only [= mem_indices_of_mem, insert]
     instantiate only [=_ HashMap.contains_iff_mem, = getElem?_neg, = getElem?_pos]
     cases #bd4f
-    · cases #54dd
+    · cases #f969
       · instantiate only
       · instantiate only
         instantiate only [= HashMap.contains_insert]
@@ -159,12 +164,12 @@ info: Try these:
         · instantiate only
         · instantiate only
           instantiate only [= HashMap.contains_insert]
-      · cases #54dd
+      · cases #f969
         · instantiate only
         · instantiate only
           instantiate only [= HashMap.contains_insert]
   [apply] finish only [= mem_indices_of_mem, insert, =_ HashMap.contains_iff_mem, = getElem?_neg, = getElem?_pos,
-    = HashMap.contains_insert, #bd4f, #54dd, #2eb4, #cc2e]
+    = HashMap.contains_insert, #bd4f, #f969, #2eb4, #cc2e]
 -/
 #guard_msgs in
 example (m : IndexMap α β) (a a' : α) (b : β) :
@@ -177,7 +182,7 @@ info: Try these:
     instantiate only [= mem_indices_of_mem, insert]
     instantiate only [=_ HashMap.contains_iff_mem, = getElem?_neg, = getElem?_pos]
     cases #bd4f
-    · cases #54dd
+    · cases #f969
       · instantiate only
       · instantiate only
         instantiate only [= HashMap.contains_insert]
@@ -186,12 +191,12 @@ info: Try these:
         · instantiate only
         · instantiate only
           instantiate only [= HashMap.contains_insert]
-      · cases #54dd
+      · cases #f969
         · instantiate only
         · instantiate only
           instantiate only [= HashMap.contains_insert]
   [apply] finish only [= mem_indices_of_mem, insert, =_ HashMap.contains_iff_mem, = getElem?_neg, = getElem?_pos,
-    = HashMap.contains_insert, #bd4f, #54dd, #2eb4, #cc2e]
+    = HashMap.contains_insert, #bd4f, #f969, #2eb4, #cc2e]
 -/
 #guard_msgs in
 example (m : IndexMap α β) (a a' : α) (b : β) :
@@ -204,7 +209,7 @@ example (m : IndexMap α β) (a a' : α) (b : β) :
     instantiate only [= mem_indices_of_mem, insert]
     instantiate only [=_ HashMap.contains_iff_mem, = getElem?_neg, = getElem?_pos]
     cases #bd4f
-    · cases #54dd
+    · cases #f969
       · instantiate only
       · instantiate only
         instantiate only [= HashMap.contains_insert]
@@ -213,7 +218,7 @@ example (m : IndexMap α β) (a a' : α) (b : β) :
         · instantiate only
         · instantiate only
           instantiate only [= HashMap.contains_insert]
-      · cases #54dd
+      · cases #f969
         · instantiate only
         · instantiate only
           instantiate only [= HashMap.contains_insert]
@@ -224,7 +229,7 @@ example (m : IndexMap α β) (a a' : α) (b : β) :
     instantiate only [= mem_indices_of_mem, insert]
     instantiate only [=_ HashMap.contains_iff_mem, = getElem?_neg, = getElem?_pos]
     cases #bd4f
-    · cases #54dd
+    · cases #f969
       · instantiate only
       · instantiate only
         instantiate only [= HashMap.contains_insert]
@@ -233,7 +238,7 @@ example (m : IndexMap α β) (a a' : α) (b : β) :
         · instantiate only
         · instantiate only
           instantiate only [= HashMap.contains_insert]
-      · cases #54dd
+      · cases #f969
         · instantiate only
         · instantiate only
           instantiate only [= HashMap.contains_insert]
@@ -241,87 +246,77 @@ example (m : IndexMap α β) (a a' : α) (b : β) :
 /--
 info: Try these:
   [apply] ⏎
-    instantiate only [= mem_indices_of_mem, insert, = getElem_def]
-    instantiate only [usr getElem?_pos, = getElem?_neg, = getElem?_pos]
-    instantiate only [=_ WF]
-    instantiate only [= getElem?_neg, = getElem?_pos, = WF]
-    instantiate only [= getElem?_neg, = getElem?_pos, = size_keys]
-    cases #dbaf
-    · instantiate only [size]
-      cases #54dd
-      · instantiate only
-        instantiate only [= Array.getElem_set]
-      · instantiate only
-        instantiate only [= HashMap.getElem?_insert, = Array.getElem_push]
-    · instantiate only [= mem_indices_of_mem, = getElem_def, size]
-      instantiate only [usr getElem_indices_lt, =_ WF]
-      instantiate only [= getElem?_pos]
-      cases #54dd
-      · instantiate only [WF']
-        instantiate only [= Array.getElem_set]
-      · instantiate only
-        instantiate only [= HashMap.getElem?_insert, = Array.getElem_push]
-  [apply] finish only [= mem_indices_of_mem, insert, = getElem_def, usr getElem?_pos, = getElem?_neg, = getElem?_pos,
-    =_ WF, = WF, = size_keys, size, = Array.getElem_set, = HashMap.getElem?_insert, = Array.getElem_push,
-    usr getElem_indices_lt, WF', #dbaf, #54dd]
--/
-#guard_msgs in
-example (m : IndexMap α β) (a a' : α) (b : β) (h : a' ∈ m.insert a b) :
-    (m.insert a b)[a'] = if h' : a' == a then b else m[a'] := by
-  grind => finish?
-
-example (m : IndexMap α β) (a a' : α) (b : β) (h : a' ∈ m.insert a b) :
-    (m.insert a b)[a'] = if h' : a' == a then b else m[a'] := by
-  grind =>
     instantiate only [= mem_indices_of_mem, insert, = getElem_def]
     instantiate only [= getElem?_neg, = getElem?_pos]
     cases #dbaf
-    · cases #54dd
+    · cases #f969
+      · instantiate only
+        instantiate only [= Array.getElem_set]
+      · instantiate only
+        instantiate only [size, = HashMap.mem_insert, = HashMap.getElem_insert, = Array.getElem_push]
+    · instantiate only [= mem_indices_of_mem, = getElem_def]
+      instantiate only [usr getElem_indices_lt, usr WF2]
+      instantiate only [size, ← WF3]
+      cases #f969
+      · instantiate only [WF']
+        instantiate only [= Array.getElem_set]
+      · instantiate only
+        instantiate only [= HashMap.mem_insert, = HashMap.getElem_insert, = Array.getElem_push]
+  [apply] finish only [= mem_indices_of_mem, insert, = getElem_def, = getElem?_neg, = getElem?_pos, = Array.getElem_set,
+    size, = HashMap.mem_insert, = HashMap.getElem_insert, = Array.getElem_push, usr getElem_indices_lt, usr WF2, ← WF3,
+    WF', #dbaf, #f969]
+-/
+#guard_msgs in
+example (m : IndexMap α β) (a a' : α) (b : β) (h : a' ∈ m.insert a b) :
+    (m.insert a b)[a'] = if h' : a' == a then b else m[a'] := by
+  grind => finish?
+
+example (m : IndexMap α β) (a a' : α) (b : β) (h : a' ∈ m.insert a b) :
+    (m.insert a b)[a'] = if h' : a' == a then b else m[a'] := by
+  grind => 
+    instantiate only [= mem_indices_of_mem, insert, = getElem_def]
+    instantiate only [= getElem?_neg, = getElem?_pos]
+    cases #dbaf
+    · cases #f969
       · instantiate only
         instantiate only [= Array.getElem_set]
       · instantiate only
         instantiate only [size, = HashMap.mem_insert, = HashMap.getElem_insert,
           = Array.getElem_push]
     · instantiate only [= mem_indices_of_mem, = getElem_def]
-      instantiate only [usr getElem_indices_lt]
-      instantiate only [size]
-      cases #54dd
-      · instantiate only [usr getElem_indices_lt, =_ WF]
-        instantiate only [= mem_indices_of_mem, = getElem?_pos, = Array.size_set,
-          = Array.getElem_set]
-        instantiate only [WF']
+      instantiate only [usr getElem_indices_lt, usr WF2]
+      instantiate only [size, ← WF3]
+      cases #f969
+      · instantiate only [WF']
+        instantiate only [= Array.getElem_set]
       · instantiate only
         instantiate only [= HashMap.mem_insert, = HashMap.getElem_insert, = Array.getElem_push]
 
 /--
 info: Try these:
-  [apply] grind only [= mem_indices_of_mem, insert, = getElem_def, usr getElem?_pos, = getElem?_neg, = getElem?_pos,
-    =_ WF, = WF, = size_keys, size, = Array.getElem_set, = HashMap.getElem?_insert, = Array.getElem_push,
-    usr getElem_indices_lt, WF', #dbaf, #54dd]
-  [apply] grind only [= mem_indices_of_mem, insert, = getElem_def, usr getElem?_pos, = getElem?_neg, = getElem?_pos,
-    =_ WF, = WF, = size_keys, size, = Array.getElem_set, = HashMap.getElem?_insert, = Array.getElem_push,
-    usr getElem_indices_lt, WF']
+  [apply] grind only [= mem_indices_of_mem, insert, = getElem_def, = getElem?_neg, = getElem?_pos, = Array.getElem_set,
+    size, = HashMap.mem_insert, = HashMap.getElem_insert, = Array.getElem_push, usr getElem_indices_lt, usr WF2, ← WF3,
+    WF', #dbaf, #f969]
+  [apply] grind only [= mem_indices_of_mem, insert, = getElem_def, = getElem?_neg, = getElem?_pos, = Array.getElem_set,
+    size, = HashMap.mem_insert, = HashMap.getElem_insert, = Array.getElem_push, usr getElem_indices_lt, usr WF2, ← WF3,
+    WF']
   [apply] grind =>
     instantiate only [= mem_indices_of_mem, insert, = getElem_def]
-    instantiate only [usr getElem?_pos, = getElem?_neg, = getElem?_pos]
-    instantiate only [=_ WF]
-    instantiate only [= getElem?_neg, = getElem?_pos, = WF]
-    instantiate only [= getElem?_neg, = getElem?_pos, = size_keys]
+    instantiate only [= getElem?_neg, = getElem?_pos]
     cases #dbaf
-    · instantiate only [size]
-      cases #54dd
+    · cases #f969
       · instantiate only
         instantiate only [= Array.getElem_set]
       · instantiate only
-        instantiate only [= HashMap.getElem?_insert, = Array.getElem_push]
-    · instantiate only [= mem_indices_of_mem, = getElem_def, size]
-      instantiate only [usr getElem_indices_lt, =_ WF]
-      instantiate only [= getElem?_pos]
-      cases #54dd
+        instantiate only [size, = HashMap.mem_insert, = HashMap.getElem_insert, = Array.getElem_push]
+    · instantiate only [= mem_indices_of_mem, = getElem_def]
+      instantiate only [usr getElem_indices_lt, usr WF2]
+      instantiate only [size, ← WF3]
+      cases #f969
       · instantiate only [WF']
         instantiate only [= Array.getElem_set]
       · instantiate only
-        instantiate only [= HashMap.getElem?_insert, = Array.getElem_push]
+        instantiate only [= HashMap.mem_insert, = HashMap.getElem_insert, = Array.getElem_push]
 -/
 #guard_msgs in
 example (m : IndexMap α β) (a a' : α) (b : β) (h : a' ∈ m.insert a b) :
@@ -334,20 +329,18 @@ example (m : IndexMap α β) (a a' : α) (b : β) (h : a' ∈ m.insert a b) :
     instantiate only [= mem_indices_of_mem, insert, = getElem_def]
     instantiate only [= getElem?_neg, = getElem?_pos]
     cases #dbaf
-    · cases #54dd
+    · cases #f969
       · instantiate only
         instantiate only [= Array.getElem_set]
       · instantiate only
         instantiate only [size, = HashMap.mem_insert, = HashMap.getElem_insert,
           = Array.getElem_push]
     · instantiate only [= mem_indices_of_mem, = getElem_def]
-      instantiate only [usr getElem_indices_lt]
-      instantiate only [size]
-      cases #54dd
-      · instantiate only [usr getElem_indices_lt, =_ WF]
-        instantiate only [= mem_indices_of_mem, = getElem?_pos, = Array.size_set,
-          = Array.getElem_set]
-        instantiate only [WF']
+      instantiate only [usr getElem_indices_lt, usr WF2]
+      instantiate only [size, ← WF3]
+      cases #f969
+      · instantiate only [WF']
+        instantiate only [= Array.getElem_set]
       · instantiate only
         instantiate only [= HashMap.mem_insert, = HashMap.getElem_insert, = Array.getElem_push]
 
@@ -355,23 +348,19 @@ example (m : IndexMap α β) (a a' : α) (b : β) (h : a' ∈ m.insert a b) :
     (m.insert a b)[a'] = if h' : a' == a then b else m[a'] := by
   grind only [= mem_indices_of_mem, insert, = getElem_def, = getElem?_neg, = getElem?_pos,
     = Array.getElem_set, size, = HashMap.mem_insert, = HashMap.getElem_insert, = Array.getElem_push,
-    usr getElem_indices_lt, usr Array.eq_empty_of_size_eq_zero, =_ WF, = Array.size_set, WF', #dbaf,
-    #54dd]
+    usr getElem_indices_lt, usr WF2, ← WF3, WF', #dbaf, #f969]
 
 /--
 info: Try these:
   [apply] ⏎
     instantiate only [findIdx, insert, = mem_indices_of_mem]
-    instantiate only [usr getElem?_pos, = getElem?_neg, = getElem?_pos]
-    instantiate only [=_ WF]
-    instantiate only [= getElem?_neg]
-    instantiate only [= size_keys]
+    instantiate only [= getElem?_neg, = getElem?_pos]
     cases #ffde
     · instantiate only [findIdx]
     · instantiate only
-      instantiate only [= HashMap.getElem?_insert]
-  [apply] finish only [findIdx, insert, = mem_indices_of_mem, usr getElem?_pos, = getElem?_neg, = getElem?_pos, =_ WF,
-    = size_keys, = HashMap.getElem?_insert, #ffde]
+      instantiate only [= HashMap.mem_insert, = HashMap.getElem_insert]
+  [apply] finish only [findIdx, insert, = mem_indices_of_mem, = getElem?_neg, = getElem?_pos, = HashMap.mem_insert,
+    = HashMap.getElem_insert, #ffde]
 -/
 #guard_msgs in
 example (m : IndexMap α β) (a : α) (b : β) :
@@ -381,20 +370,17 @@ example (m : IndexMap α β) (a : α) (b : β) :
 /--
 info: Try these:
   [apply] grind
-  [apply] grind only [findIdx, insert, = mem_indices_of_mem, usr getElem?_pos, = getElem?_neg, = getElem?_pos, =_ WF,
-    = size_keys, = HashMap.getElem?_insert, #ffde]
-  [apply] grind only [findIdx, insert, = mem_indices_of_mem, usr getElem?_pos, = getElem?_neg, = getElem?_pos, =_ WF,
-    = size_keys, = HashMap.getElem?_insert]
+  [apply] grind only [findIdx, insert, = mem_indices_of_mem, = getElem?_neg, = getElem?_pos, = HashMap.mem_insert,
+    = HashMap.getElem_insert, #ffde]
+  [apply] grind only [findIdx, insert, = mem_indices_of_mem, = getElem?_neg, = getElem?_pos, = HashMap.mem_insert,
+    = HashMap.getElem_insert]
   [apply] grind =>
     instantiate only [findIdx, insert, = mem_indices_of_mem]
-    instantiate only [usr getElem?_pos, = getElem?_neg, = getElem?_pos]
-    instantiate only [=_ WF]
-    instantiate only [= getElem?_neg]
-    instantiate only [= size_keys]
+    instantiate only [= getElem?_neg, = getElem?_pos]
     cases #ffde
     · instantiate only [findIdx]
     · instantiate only
-      instantiate only [= HashMap.getElem?_insert]
+      instantiate only [= HashMap.mem_insert, = HashMap.getElem_insert]
 -/
 #guard_msgs in
 example (m : IndexMap α β) (a : α) (b : β) :

--- a/tests/elab/grind_indexmap_trace.lean.out.expected
+++ b/tests/elab/grind_indexmap_trace.lean.out.expected
@@ -1,13 +1,10 @@
 Try these:
   [apply] 
     instantiate only [findIdx, insert, = mem_indices_of_mem]
-    instantiate only [usr getElem?_pos, = getElem?_neg, = getElem?_pos]
-    instantiate only [=_ WF]
-    instantiate only [= getElem?_neg]
-    instantiate only [= size_keys]
+    instantiate only [= getElem?_neg, = getElem?_pos]
     cases #ffde
     · instantiate only [findIdx]
     · instantiate only
-      instantiate only [= HashMap.getElem?_insert]
-  [apply] finish only [findIdx, insert, = mem_indices_of_mem, usr getElem?_pos, = getElem?_neg, = getElem?_pos, =_ WF,
-    = size_keys, = HashMap.getElem?_insert, #ffde]
+      instantiate only [= HashMap.mem_insert, = HashMap.getElem_insert]
+  [apply] finish only [findIdx, insert, = mem_indices_of_mem, = getElem?_neg, = getElem?_pos, = HashMap.mem_insert,
+    = HashMap.getElem_insert, #ffde]

--- a/tests/elab/grind_interactive.lean
+++ b/tests/elab/grind_interactive.lean
@@ -53,26 +53,18 @@ example [CommRing α] (a b c : α)
 trace: [facts] Asserted facts
   [_] (bs.set i₂ v₂ ⋯).size = bs.size
   [_] (as.set i₁ v₁ ⋯).size = as.size
-  [_] ∀ (h : j + 1 ≤ as.size), as[j]? = some as[j]
-  [_] ∀ (h : j + 1 ≤ cs.size), cs[j]? = some cs[j]
   [_] (bs.set i₂ v₂ ⋯)[j] = if i₂ = j then v₂ else bs[j]
 ---
 trace: [props] True propositions
   [_] j < (bs.set i₂ v₂ ⋯).size
   [_] j < bs.size
-  [_] cs[j]? = some cs[j]
-  [_] ∀ (h : j + 1 ≤ cs.size), cs[j]? = some cs[j]
-  [_] as[j]? = some as[j]
-  [_] ∀ (h : j + 1 ≤ as.size), as[j]? = some as[j]
 ---
 trace: [eqc] Equivalence classes
   [eqc] {bs, as.set i₁ v₁ ⋯}
   [eqc] {cs, bs.set i₂ v₂ ⋯}
   [eqc] {as.size, bs.size, cs.size, (as.set i₁ v₁ ⋯).size, (bs.set i₂ v₂ ⋯).size}
-  [eqc] {as[j], as[j]}
-  [eqc] {cs[j], bs[j], cs[j], (bs.set i₂ v₂ ⋯)[j]}
+  [eqc] {cs[j], bs[j], (bs.set i₂ v₂ ⋯)[j]}
     [eqc] {if i₂ = j then v₂ else bs[j]}
-  [eqc] {some as[j], as[j]?}
   [eqc] {as.size = 0, bs.size = 0, cs.size = 0}
   [eqc] others
     [eqc] {↑as.size, ↑bs.size, ↑cs.size, ↑(bs.set i₂ v₂ ⋯).size}
@@ -150,23 +142,14 @@ trace: [grind] Grind state
   [facts] Asserted facts
     [_] (bs.set i₂ v₂ ⋯).size = bs.size
     [_] (as.set i₁ v₁ ⋯).size = as.size
-    [_] ∀ (h : j + 1 ≤ as.size), as[j]? = some as[j]
-    [_] ∀ (h : j + 1 ≤ cs.size), cs[j]? = some cs[j]
     [_] (bs.set i₂ v₂ ⋯)[j] = if i₂ = j then v₂ else bs[j]
   [props] True propositions
     [_] j < (bs.set i₂ v₂ ⋯).size
     [_] j < bs.size
-    [_] cs[j]? = some cs[j]
-    [_] ∀ (h : j + 1 ≤ cs.size), cs[j]? = some cs[j]
-    [_] as[j]? = some as[j]
-    [_] ∀ (h : j + 1 ≤ as.size), as[j]? = some as[j]
   [eqc] Equivalence classes
     [eqc] {as.size, bs.size, cs.size, (as.set i₁ v₁ ⋯).size, (bs.set i₂ v₂ ⋯).size}
-    [eqc] {as[j], as[j]}
-    [eqc] {cs[j], bs[j], cs[j], (bs.set i₂ v₂ ⋯)[j]}
+    [eqc] {cs[j], bs[j], (bs.set i₂ v₂ ⋯)[j]}
       [eqc] {if i₂ = j then v₂ else bs[j]}
-    [eqc] {some as[j], as[j]?}
-    [eqc] {some cs[j], cs[j]?}
     [eqc] {as.size = 0, bs.size = 0, cs.size = 0}
     [eqc] others
       [eqc] {↑as.size, ↑bs.size, ↑cs.size, ↑(bs.set i₂ v₂ ⋯).size}
@@ -452,12 +435,6 @@ example (as bs cs : Array α) (v₁ v₂ : α)
 
 /--
 trace: [grind.ematch.instance] Array.getElem_set: (as.set i₁ v₁ ⋯)[j] = if i₁ = j then v₁ else as[j]
-[grind.ematch.instance] Array.getElem?_set: (bs.set i₂ v₂ ⋯)[j]? = if i₂ = j then some v₂ else bs[j]?
-[grind.ematch.instance] getElem?_neg: ¬j < cs.size → cs[j]? = none
-[grind.ematch.instance] getElem?_neg: ¬j < as.size → as[j]? = none
-[grind.ematch.instance] getElem?_pos: ∀ (h : j < cs.size), cs[j]? = some cs[j]
-[grind.ematch.instance] getElem?_pos: ∀ (h : j < as.size), as[j]? = some as[j]
-[grind.ematch.instance] getElem?_pos: ∀ (h : j < bs.size), bs[j]? = some bs[j]
 -/
 #guard_msgs in
 example (as bs cs : Array α) (v₁ v₂ : α)

--- a/tests/elab/grind_lint_1.lean
+++ b/tests/elab/grind_lint_1.lean
@@ -107,18 +107,12 @@ info: instantiating `Array.findIdx_empty` triggers 20 additional `grind` theorem
 ---
 info: instantiating `Array.findIdx_singleton` triggers 16 additional `grind` theorem instantiations
 ---
-info: instantiating `Array.getElem_attachWith` triggers 16 additional `grind` theorem instantiations
----
-info: instantiating `Array.getElem_eraseIdx` triggers 17 additional `grind` theorem instantiations
----
 info: Try this:
   [apply] #grind_lint check  (min := 15) in Array
   #grind_lint inspect Array.back?_empty
   #grind_lint inspect Array.count_empty
   #grind_lint inspect Array.findIdx_empty
   #grind_lint inspect Array.findIdx_singleton
-  #grind_lint inspect Array.getElem_attachWith
-  #grind_lint inspect Array.getElem_eraseIdx
 -/
 #guard_msgs in
 #grind_lint check (min := 15) in Array

--- a/tests/elab/grind_lint_array.lean
+++ b/tests/elab/grind_lint_array.lean
@@ -3,7 +3,6 @@ import Lean.Elab.Tactic.Grind.LintExceptions
 
 /-! Check Array namespace: -/
 
--- TODO: think about more of these
 -- These go slightly over 20, but seem reasonable.
 #guard_msgs in
 #grind_lint inspect (min := 22) Array.count_singleton

--- a/tests/elab/grind_lint_array.lean
+++ b/tests/elab/grind_lint_array.lean
@@ -3,6 +3,7 @@ import Lean.Elab.Tactic.Grind.LintExceptions
 
 /-! Check Array namespace: -/
 
+-- TODO: think about more of these
 -- These go slightly over 20, but seem reasonable.
 #guard_msgs in
 #grind_lint inspect (min := 22) Array.count_singleton
@@ -13,15 +14,7 @@ import Lean.Elab.Tactic.Grind.LintExceptions
 
 -- `Array.back_singleton` is reasonable at 23.
 #guard_msgs in
-#grind_lint inspect (min := 25) Array.back_singleton
-
--- `Array.getElem_zero_filter` is reasonable at 20.
-#guard_msgs in
-#grind_lint inspect (min := 22) Array.getElem_zero_filter
-
--- `Array.getElem_zero_filterMap` is reasonable at 20.
-#guard_msgs in
-#grind_lint inspect (min := 22) Array.getElem_zero_filterMap
+#grind_lint inspect (min := 20) Array.back_singleton
 
 #guard_msgs in
 #grind_lint check (min := 20) in Array


### PR DESCRIPTION
This PR removes the grind annotation that makes `getElem?_pos` trigger whenever `c[i]` is in the e-graph. We do this to avoid reasoning about `c[i]?` just because `c[i]` is available. The trigger for instantiating `getElem?_pos` whenever `c[i]?` is in scope remains in order to nudge grind towards proving or disproving the bounds check.