### PR TITLE
feat: add builtin linter sets and make `linter.extra` a builtin linter set

### DIFF
--- a/src/Lean/Linter/Extra.lean
+++ b/src/Lean/Linter/Extra.lean
@@ -10,3 +10,18 @@ public import Lean.Linter.Extra.DupNamespace
 public import Lean.Linter.Extra.UnnecessarySeqFocus
 public import Lean.Linter.Extra.UnreachableTactic
 public import Lean.Linter.Extra.UnusedDecidableInType
+
+namespace Lean.Linter
+
+/-- Record the four extra linters as members of the `linter.extra` set, so that they pick up the
+set-membership fallback in `getLinterValue`. The `linter.extra` option itself is registered as a
+builtin option in `Lean.Linter.Init`. -/
+builtin_initialize
+  addBuiltinLinterSet `linter.extra <|
+    NameSet.empty
+      |>.insert `linter.extra.dupNamespace
+      |>.insert `linter.extra.unnecessarySeqFocus
+      |>.insert `linter.extra.unreachableTactic
+      |>.insert `linter.extra.unusedDecidableInType
+
+end Lean.Linter

--- a/src/Lean/Linter/Extra/DupNamespace.lean
+++ b/src/Lean/Linter/Extra/DupNamespace.lean
@@ -70,7 +70,7 @@ def getAliasSyntax {m} [Monad m] [MonadResolveName m] (stx : Syntax) : m (Array 
 
 @[inherit_doc linter.extra.dupNamespace]
 def dupNamespace : Linter where run := withSetOptionIn fun stx ↦ do
-  if getLinterValueExtra linter.extra.dupNamespace (← getLinterOptions) then
+  if getLinterValue linter.extra.dupNamespace (← getLinterOptions) then
     let mut aliases := #[]
     if let some exp := stx.find? (·.isOfKind `Lean.Parser.Command.export) then
       aliases ← getAliasSyntax exp
@@ -80,7 +80,7 @@ def dupNamespace : Linter where run := withSetOptionIn fun stx ↦ do
       let nm := declName.components
       let some (dup, _) := nm.zip (nm.tailD []) |>.find? fun (x, y) ↦ x == y
         | continue
-      Linter.logLintIfExtra linter.extra.dupNamespace id
+      Linter.logLintIf linter.extra.dupNamespace id
         m!"The namespace '{dup}' is duplicated in the declaration '{declName}'"
 
 end DupNamespaceLinter

--- a/src/Lean/Linter/Extra/UnnecessarySeqFocus.lean
+++ b/src/Lean/Linter/Extra/UnnecessarySeqFocus.lean
@@ -165,7 +165,7 @@ end
 
 @[inherit_doc Lean.Linter.Extra.linter.extra.unnecessarySeqFocus]
 def unnecessarySeqFocusLinter : Linter where run := withSetOptionIn fun stx => do
-  unless getLinterValueExtra linter.extra.unnecessarySeqFocus (← getLinterOptions)
+  unless getLinterValue linter.extra.unnecessarySeqFocus (← getLinterOptions)
       && (← getInfoState).enabled do
     return
   if (← get).messages.hasErrors then
@@ -182,7 +182,7 @@ def unnecessarySeqFocusLinter : Linter where run := withSetOptionIn fun stx => d
   let mut last : Lean.Syntax.Range := ⟨0, 0⟩
   for (r, stx) in let _ := @lexOrd; let _ := @ltOfOrd.{0}; unused.qsort (key ·.1 < key ·.1) do
     if last.start ≤ r.start && r.stop ≤ last.stop then continue
-    logLintIfExtra linter.extra.unnecessarySeqFocus stx
+    logLintIf linter.extra.unnecessarySeqFocus stx
       "Used `tac1 <;> tac2` where `(tac1; tac2)` would suffice"
     last := r
 

--- a/src/Lean/Linter/Extra/UnreachableTactic.lean
+++ b/src/Lean/Linter/Extra/UnreachableTactic.lean
@@ -96,7 +96,7 @@ end
 
 @[inherit_doc linter.extra.unreachableTactic]
 def unreachableTacticLinter : Linter where run := withSetOptionIn fun stx => do
-  unless getLinterValueExtra linter.extra.unreachableTactic (← getLinterOptions)
+  unless getLinterValue linter.extra.unreachableTactic (← getLinterOptions)
     && (← getInfoState).enabled do
     return
   if (← get).messages.hasErrors then
@@ -117,7 +117,7 @@ def unreachableTacticLinter : Linter where run := withSetOptionIn fun stx => do
   let mut last : Lean.Syntax.Range := ⟨0, 0⟩
   for (r, stx) in let _ := @lexOrd; let _ := @ltOfOrd.{0}; unreachable.qsort (key ·.1 < key ·.1) do
     if last.start ≤ r.start && r.stop ≤ last.stop then continue
-    logLintIfExtra linter.extra.unreachableTactic stx "this tactic is never executed"
+    logLintIf linter.extra.unreachableTactic stx "this tactic is never executed"
     last := r
 
 builtin_initialize addLinter unreachableTacticLinter

--- a/src/Lean/Linter/Extra/UnusedDecidableInType.lean
+++ b/src/Lean/Linter/Extra/UnusedDecidableInType.lean
@@ -275,7 +275,7 @@ private def isDecidableVariant (type : Expr) : Bool :=
 
 @[inherit_doc linter.extra.unusedDecidableInType]
 def unusedDecidableInTypeLinter : Linter where run := withSetOptionIn fun _ => do
-  unless getLinterValueExtra linter.extra.unusedDecidableInType (← getLinterOptions)
+  unless getLinterValue linter.extra.unusedDecidableInType (← getLinterOptions)
       && (← getInfoState).enabled do
     return
   if (← get).messages.hasErrors then
@@ -289,7 +289,7 @@ def unusedDecidableInTypeLinter : Linter where run := withSetOptionIn fun _ => d
         && thm.type.hasInstanceBinderOf isDecidableVariant
     unless thms.isEmpty do liftTermElabM do for thm in thms do
       onUnusedInstancesWhere thm isDecidableVariant fun unusedParams => do
-        logLintIfExtra linter.extra.unusedDecidableInType (← getRef) m!"\
+        logLintIf linter.extra.unusedDecidableInType (← getRef) m!"\
           {unusedInstancesMsg thm.name unusedParams}\n\n\
           Consider removing \
           {if unusedParams.size = 1 then "this hypothesis" else "these hypotheses"} \

--- a/src/Lean/Linter/Init.lean
+++ b/src/Lean/Linter/Init.lean
@@ -28,11 +28,48 @@ def insertLinterSetEntry (map : LinterSets) (setName : Name) (options : NameSet)
   options.foldl (init := map) fun map linterName =>
     map.insert linterName ((map.getD linterName #[]).push setName)
 
-builtin_initialize linterSetsExt : SimplePersistentEnvExtension (Name × NameSet) LinterSets ← Lean.registerSimplePersistentEnvExtension {
-  addImportedFn := mkStateFromImportedEntries (Function.uncurry <| insertLinterSetEntry ·) {}
-  addEntryFn := (Function.uncurry <| insertLinterSetEntry ·)
-  toArrayFn es := es.toArray
-}
+/-- State of `linterSetsExt`.
+
+`merged` is the queryable union of all sources (builtins folded in at env creation,
+imported entries from oleans, and locally added entries). `localEntries` tracks entries
+added in the current module so they can be exported into the olean.
+-/
+structure LinterSetsState where
+  merged : LinterSets := {}
+  localEntries : Array (Name × NameSet) := #[]
+  deriving Inhabited
+
+/-- Builtin linter sets registered from `builtin_initialize` blocks in core code.
+
+Entries here are folded into every `LinterSetsState` produced by `linterSetsExt`, so they
+participate in `getLinterValue` like any user-declared set.
+-/
+builtin_initialize builtinLinterSetsRef : IO.Ref (Array (Name × NameSet)) ← IO.mkRef #[]
+
+/-- Register a builtin linter set entry. Only valid during initialization;
+use `register_builtin_linter_set` rather than calling this directly. -/
+def addBuiltinLinterSet (setName : Name) (linterNames : NameSet) : IO Unit := do
+  builtinLinterSetsRef.modify (·.push (setName, linterNames))
+
+private def foldBuiltinsInto (init : LinterSets) : IO LinterSets := do
+  let mut s := init
+  for (n, ms) in (← builtinLinterSetsRef.get) do
+    s := insertLinterSetEntry s n ms
+  return s
+
+builtin_initialize linterSetsExt :
+    PersistentEnvExtension (Name × NameSet) (Name × NameSet) LinterSetsState ←
+  registerPersistentEnvExtension {
+    mkInitial := return { merged := (← foldBuiltinsInto {}), localEntries := #[] }
+    addImportedFn := fun ess => do
+      let mut s ← foldBuiltinsInto {}
+      for es in ess do for (n, ms) in es do
+        s := insertLinterSetEntry s n ms
+      return { merged := s, localEntries := #[] }
+    addEntryFn := fun st (n, ms) =>
+      { merged := insertLinterSetEntry st.merged n ms, localEntries := st.localEntries.push (n, ms) }
+    exportEntriesFn := fun st => st.localEntries
+  }
 
 /-- The `LinterOptions` structure is used to determine whether given linters are enabled.
 
@@ -50,7 +87,7 @@ def LinterOptions.get [KVMap.Value α] (o : LinterOptions) := o.toOptions.get (�
 def LinterOptions.get? [KVMap.Value α] (o : LinterOptions) := o.toOptions.get? (α := α)
 
 def _root_.Lean.Options.toLinterOptions [Monad m] [MonadEnv m] (o : Options) : m LinterOptions := do
-  let linterSets := linterSetsExt.getState (← getEnv)
+  let linterSets := (linterSetsExt.getState (← getEnv)).merged
   return { toOptions := o, linterSets }
 
 /-- Return the set of linter sets that this option is contained in. -/

--- a/src/Lean/Linter/Init.lean
+++ b/src/Lean/Linter/Init.lean
@@ -109,17 +109,8 @@ register_builtin_option linter.extra : Bool := {
 def getLinterAll (o : LinterOptions) (defValue := linter.all.defValue) : Bool :=
     o.get linter.all.name defValue
 
-def getLinterExtra (o : LinterOptions) (defValue := linter.extra.defValue) : Bool :=
-  o.get linter.extra.name defValue
-
 def getLinterValue (opt : Lean.Option Bool) (o : LinterOptions) : Bool :=
   o.get opt.name (getLinterAll o <| (o.getSet opt).any (o.get? · == some true) || opt.defValue)
-
-/--
-Like `getLinterValue`, but the cross-linter fallback is `linter.extra` instead of `linter.all`.
--/
-def getLinterValueExtra (opt : Lean.Option Bool) (o : LinterOptions) : Bool :=
-  o.get opt.name (getLinterExtra o opt.defValue)
 
 /--
 Tag attached by `logLint` to every linter warning so consumers
@@ -153,12 +144,3 @@ Whether a linter option is enabled or not is determined by the following sequenc
 def logLintIf [Monad m] [MonadLog m] [AddMessageContext m] [MonadOptions m] [MonadEnv m]
     (linterOption : Lean.Option Bool) (stx : Syntax) (msg : MessageData) : m Unit := do
   if getLinterValue linterOption (← getLinterOptions) then logLint linterOption stx msg
-
-/--
-Like `logLintIf`, but uses `getLinterValueExtra` to gate emission on the extra fallback.
-Use for extra linters: emits the warning iff `linterOption` is on under the extra
-selection rules described on `getLinterValueExtra`.
--/
-def logLintIfExtra [Monad m] [MonadLog m] [AddMessageContext m] [MonadOptions m] [MonadEnv m]
-    (linterOption : Lean.Option Bool) (stx : Syntax) (msg : MessageData) : m Unit := do
-  if getLinterValueExtra linterOption (← getLinterOptions) then logLint linterOption stx msg

--- a/src/Lean/Linter/Init.lean
+++ b/src/Lean/Linter/Init.lean
@@ -51,21 +51,19 @@ use `register_builtin_linter_set` rather than calling this directly. -/
 def addBuiltinLinterSet (setName : Name) (linterNames : NameSet) : IO Unit := do
   builtinLinterSetsRef.modify (·.push (setName, linterNames))
 
-private def foldBuiltinsInto (init : LinterSets) : IO LinterSets := do
-  let mut s := init
-  for (n, ms) in (← builtinLinterSetsRef.get) do
-    s := insertLinterSetEntry s n ms
-  return s
-
 builtin_initialize linterSetsExt :
     PersistentEnvExtension (Name × NameSet) (Name × NameSet) LinterSetsState ←
   registerPersistentEnvExtension {
-    mkInitial := return { merged := (← foldBuiltinsInto {}), localEntries := #[] }
+    mkInitial := do
+      let merged := (← builtinLinterSetsRef.get).foldl (init := {}) fun s (n, ms) =>
+        insertLinterSetEntry s n ms
+      return { merged, localEntries := #[] }
     addImportedFn := fun ess => do
-      let mut s ← foldBuiltinsInto {}
-      for es in ess do for (n, ms) in es do
-        s := insertLinterSetEntry s n ms
-      return { merged := s, localEntries := #[] }
+      let s := (← builtinLinterSetsRef.get).foldl (init := {}) fun s (n, ms) =>
+        insertLinterSetEntry s n ms
+      let merged := ess.foldl (init := s) fun s es =>
+        es.foldl (init := s) fun s (n, ms) => insertLinterSetEntry s n ms
+      return { merged, localEntries := #[] }
     addEntryFn := fun st (n, ms) =>
       { merged := insertLinterSetEntry st.merged n ms, localEntries := st.localEntries.push (n, ms) }
     exportEntriesFn := fun st => st.localEntries

--- a/src/Lean/Linter/Sets.lean
+++ b/src/Lean/Linter/Sets.lean
@@ -36,5 +36,4 @@ elab doc?:(docComment)? "register_linter_set" name:ident " := " decl:ident* : co
   let initializer ← `($[$doc?]? meta initialize $name : Lean.Option Bool ← Lean.Linter.registerSet $(quote name.getId))
   withMacroExpansion (← getRef) initializer <| elabCommand initializer
 
-
 end Lean.Linter

--- a/src/Lean/Linter/UnusedVariables.lean
+++ b/src/Lean/Linter/UnusedVariables.lean
@@ -494,7 +494,7 @@ def unusedVariables : Linter where
 
     let infoTrees := (← get).infoState.trees.toArray
 
-    let linterSets := linterSetsExt.getState (← getEnv)
+    let linterSets := (linterSetsExt.getState (← getEnv)).merged
 
     -- Run the main collection pass, resulting in `s : References`.
     let (_, s) ← (collectReferences infoTrees cmdStxRange linterSets).run {}

--- a/src/Std/Data/DTreeMap/Internal/Model.lean
+++ b/src/Std/Data/DTreeMap/Internal/Model.lean
@@ -45,7 +45,7 @@ def contains' [Ord α] (k : α → Ordering) (l : Impl α β) : Bool :=
 
 theorem contains'_compare [Ord α] {k : α} {l : Impl α β} :
     l.contains' (compare k) = l.contains k := by
-  induction l <;> simp_all only [contains', contains] <;> rfl
+  induction l <;> simp_all only [contains', contains] ; rfl
 
 /-- General tree-traversal function. Internal implementation detail of the tree map -/
 def applyPartition [Ord α] (k : α → Ordering) (l : Impl α β)
@@ -635,14 +635,14 @@ theorem minEntryD_eq_getD_minEntry? {l : Impl α β} {fallback : (a : α) × β 
 
 theorem some_minEntry_eq_minEntry? {l : Impl α β} {he} :
     some (l.minEntry he) = l.minEntry? := by
-  induction l, he using minEntry.induct_unfolding <;> simp only [minEntry?] <;> assumption
+  induction l, he using minEntry.induct_unfolding <;> simp only [minEntry?] ; assumption
 
 theorem minEntry_eq_get_minEntry? {l : Impl α β} {he} :
     l.minEntry he = l.minEntry?.get (by simp [← some_minEntry_eq_minEntry? (he := he)]) := by
   simp [← some_minEntry_eq_minEntry? (he := he)]
 
 theorem maxEntry?_eq_minEntry?_reverse {l : Impl α β} : l.maxEntry? = l.reverse.minEntry? := by
-  induction l using maxEntry?.induct_unfolding <;> simp only [minEntry?, reverse] <;> assumption
+  induction l using maxEntry?.induct_unfolding <;> simp only [minEntry?, reverse] ; assumption
 
 theorem maxEntry!_eq_get!_maxEntry? [Inhabited ((a : α) × β a)] {l : Impl α β} :
     l.maxEntry! = l.maxEntry?.get! := by
@@ -653,13 +653,13 @@ theorem maxEntryD_eq_getD_maxEntry? {l : Impl α β} {fallback : (a : α) × β 
   induction l using maxEntry?.induct_unfolding <;> simp only [maxEntryD] <;> trivial
 
 theorem some_maxEntry_eq_maxEntry? {l : Impl α β} {he} : some (l.maxEntry he) = l.maxEntry? := by
-  induction l, he using maxEntry.induct_unfolding <;> simp only [maxEntry?] <;> assumption
+  induction l, he using maxEntry.induct_unfolding <;> simp only [maxEntry?] ; assumption
 
 theorem minKey?_eq_minEntry?_map_fst {l : Impl α β} : l.minKey? = l.minEntry?.map Sigma.fst := by
   induction l using minKey?.induct_unfolding <;> simp only [minEntry?] <;> trivial
 
 theorem minKey_eq_minEntry_fst {l : Impl α β} {he} : l.minKey he = (l.minEntry he).fst := by
-  induction l, he using minKey.induct_unfolding <;> simp only [minEntry] <;> trivial
+  induction l, he using minKey.induct_unfolding <;> simp only [minEntry] ; trivial
 
 theorem minKey!_eq_getElem!_minKey? [Inhabited α] {l : Impl α β} :
     l.minKey! = l.minKey?.get! := by
@@ -670,10 +670,10 @@ theorem minKeyD_eq_getD_minKey? {l : Impl α β} {fallback} :
   induction l, fallback using minKeyD.induct_unfolding <;> simp only [minKey?] <;> trivial
 
 theorem maxKey?_eq_minKey?_reverse {l : Impl α β} : l.maxKey? = l.reverse.minKey? := by
-  induction l using maxKey?.induct_unfolding <;> simp only [minKey?, reverse] <;> assumption
+  induction l using maxKey?.induct_unfolding <;> simp only [minKey?, reverse] ; assumption
 
 theorem some_maxKey_eq_maxKey? {l : Impl α β} {he} : some (l.maxKey he) = l.maxKey? := by
-  induction l, he using maxKey.induct_unfolding <;> simp only [maxKey?] <;> assumption
+  induction l, he using maxKey.induct_unfolding <;> simp only [maxKey?] ; assumption
 
 theorem maxKey_eq_get_maxKey? {l : Impl α β} {he} :
     l.maxKey he = l.maxKey?.get (by simp [← some_maxKey_eq_maxKey? (he := he)]) := by
@@ -705,7 +705,7 @@ theorem minEntryD_eq_getD_minEntry? [Ord α] {l : Impl α fun _ => β} {fallback
 
 theorem some_minEntry_eq_minEntry? [Ord α] {l : Impl α fun _ => β} {he} :
     some (minEntry l he) = minEntry? l := by
-  induction l, he using minEntry.induct_unfolding <;> simp only [minEntry?] <;> trivial
+  induction l, he using minEntry.induct_unfolding <;> simp only [minEntry?] ; trivial
 
 theorem maxEntry?_eq_maxEntry? [Ord α] {l : Impl α fun _ => β} :
     maxEntry? l = l.maxEntry?.map (fun x => (x.1, x.2)) := by
@@ -721,7 +721,7 @@ theorem maxEntryD_eq_getD_maxEntry? [Ord α] {l : Impl α fun _ => β} {fallback
 
 theorem some_maxEntry_eq_maxEntry? [Ord α] {l : Impl α fun _ => β} {he} :
     some (maxEntry l he) = maxEntry? l := by
-  induction l, he using maxEntry.induct_unfolding <;> simp only [maxEntry?] <;> trivial
+  induction l, he using maxEntry.induct_unfolding <;> simp only [maxEntry?] ; trivial
 
 end Const
 
@@ -920,7 +920,7 @@ theorem get?_eq_get?ₘ [Ord α] (k : α) (l : Impl α (fun _ => β)) :
 
 theorem get_eq_get? [Ord α] (k : α) (l : Impl α (fun _ => β)) {h} :
     some (get l k h) = get? l k := by
-  induction l using tree_split_ind_no_gen (compare k) <;> simp only [*, get, get?] <;> contradiction
+  induction l using tree_split_ind_no_gen (compare k) <;> simp only [*, get, get?] ; contradiction
 
 theorem get_eq_getₘ [Ord α] (k : α) (l : Impl α (fun _ => β)) {h} (h') :
     get l k h = getₘ l k h' := by
@@ -1082,28 +1082,28 @@ theorem some_getEntryGE_eq_getEntryGE? [Ord α] [TransOrd α] (k : α) (t : Impl
   rw [getEntryGE?]; apply of_eq_true
   induction t, none using tree_split_ind (compare k) <;>
     simp only [*, getEntryGE?.go, getEntryGE, getEntryGED, ← Option.or_some,
-      getEntryGE?.eq_go] <;> contradiction
+      getEntryGE?.eq_go] ; contradiction
 
 theorem some_getEntryGT_eq_getEntryGT? [Ord α] [TransOrd α] (k : α) (t : Impl α β) {ho he} :
     some (getEntryGT k t ho he) = getEntryGT? k t := by
   rw [getEntryGT?]; apply of_eq_true
   induction t, none using tree_split_ind (compare k) <;>
     simp only [*, getEntryGT?.go, getEntryGT, getEntryGTD, ← Option.or_some,
-      getEntryGT?.eq_go, ↓reduceDIte, reduceCtorEq] <;> contradiction
+      getEntryGT?.eq_go, ↓reduceDIte, reduceCtorEq] ; contradiction
 
 theorem some_getEntryLE_eq_getEntryLE? [Ord α] [TransOrd α] (k : α) (t : Impl α β) {ho he} :
     some (getEntryLE k t ho he) = getEntryLE? k t := by
   rw [getEntryLE?]; apply of_eq_true
   induction t, none using tree_split_ind (compare k) <;>
     simp only [*, getEntryLE?.go, getEntryLE, getEntryLED, ← Option.or_some,
-      getEntryLE?.eq_go] <;> contradiction
+      getEntryLE?.eq_go] ; contradiction
 
 theorem some_getEntryLT_eq_getEntryLT? [Ord α] [TransOrd α] (k : α) (t : Impl α β) {ho he} :
     some (getEntryLT k t ho he) = getEntryLT? k t := by
   rw [getEntryLT?]; apply of_eq_true
   induction t, none using tree_split_ind (compare k) <;>
     simp only [*, getEntryLT?.go, getEntryLT, getEntryLTD, ← Option.or_some,
-      getEntryLT?.eq_go, ↓reduceDIte, reduceCtorEq] <;> contradiction
+      getEntryLT?.eq_go, ↓reduceDIte, reduceCtorEq] ; contradiction
 
 theorem getKeyGE?_eq_getEntryGE? [Ord α] {t : Impl α β} {k : α} :
     getKeyGE? k t = (getEntryGE? k t).map (·.1) := by

--- a/src/Std/Http/Data/Headers/Name.lean
+++ b/src/Std/Http/Data/Headers/Name.lean
@@ -69,12 +69,17 @@ instance : BEq Name where
 instance : Hashable Name where
   hash x := Hashable.hash x.value
 
-theorem Name.beq_eq {x y : Name} : (x == y) = (x.value == y.value) :=
+theorem beq_eq {x y : Name} : (x == y) = (x.value == y.value) :=
   rfl
 
+set_option linter.extra.dupNamespace false in
+@[deprecated beq_eq (since := "2026-06-04")]
+theorem Name.beq_eq {x y : Name} : (x == y) = (x.value == y.value) :=
+  Header.Name.beq_eq
+
 instance : LawfulBEq Name where
-  rfl {x} := by simp [Name.beq_eq]
-  eq_of_beq {x y} := by grind [Name.beq_eq, Name.ext]
+  rfl {x} := by simp [beq_eq]
+  eq_of_beq {x y} := by grind [beq_eq, Name.ext]
 
 instance : LawfulHashable Name := inferInstance
 

--- a/src/Std/Time/Duration.lean
+++ b/src/Std/Time/Duration.lean
@@ -59,7 +59,7 @@ instance : Inhabited Duration where
 instance : OfNat Duration n where
   ofNat := by
     refine ⟨.ofInt n, ⟨0, by decide⟩, ?_⟩
-    simp <;> exact Int.le_total n 0 |>.symm
+    simp ; exact Int.le_total n 0 |>.symm
 
 instance : Ord Duration where
   compare := compareLex (compareOn (·.second)) (compareOn (·.nano))
@@ -94,7 +94,7 @@ Creates a new `Duration` out of `Second.Offset`.
 @[inline]
 def ofSeconds (s : Second.Offset) : Duration := by
   refine ⟨s, ⟨0, by decide⟩, ?_⟩
-  simp <;> exact Int.le_total s.val 0 |>.symm
+  simp ; exact Int.le_total s.val 0 |>.symm
 
 /--
 Creates a new `Duration` out of `Nanosecond.Offset`.

--- a/src/Std/Time/Zoned/Database/TzIf.lean
+++ b/src/Std/Time/Zoned/Database/TzIf.lean
@@ -161,6 +161,7 @@ structure TZifV2 extends TZifV1 where
   footer : Option String
   deriving Repr, Inhabited
 
+set_option linter.extra.dupNamespace false in
 /--
 Represents a TZif file, which can be either version 1 or version 2.
 -/

--- a/tests/lake/tests/builtin-lint/Linters.lean
+++ b/tests/lake/tests/builtin-lint/Linters.lean
@@ -16,7 +16,7 @@ open Lean Meta Lean.Linter Lean.Elab.Command
 -- `logLint`, which is how `lake lint --extra` identifies extra-scope entries.
 def dummyExtraTextLinter : Linter where
   run cmdStx := do
-    unless getLinterExtra (← getLinterOptions) do return
+    unless getLinterValue linter.extra (← getLinterOptions) do return
     unless cmdStx.getKind == ``Lean.Parser.Command.declaration do return
     logLint linter.extra cmdStx m!"extra text linter saw a declaration"
 


### PR DESCRIPTION
This PR adds builtin linter sets — linter sets registered from core Lean code during initialization, complementing the user-facing `register_linter_set` command — and makes `linter.extra` one of them. Enabling `linter.extra` (e.g. via `set_option linter.extra true` or `lake lint --extra`) now activates the extra linters through the same set-membership mechanism as any other linter set.

The extra linters (`dupNamespace`, `unnecessarySeqFocus`, `unreachableTactic`, `unusedDecidableInType`) previously relied on dedicated `getLinterValueExtra` and `logLintIfExtra` helpers with a special `linter.extra` fallback; these are removed in favor of the standard `getLinterValue`/`logLintIf`. Registering sets from `builtin_initialize` (before the `register_linter_set` command elaborator is available) is supported by giving `linterSetsExt` a `LinterSetsState` that folds a global `builtinLinterSetsRef` of builtin sets into every environment, alongside imported and locally-declared entries.