### PR TITLE
feat: `dsimp` variants and syntax for `SymM`

### DIFF
--- a/src/Init/Grind/Interactive.lean
+++ b/src/Init/Grind/Interactive.lean
@@ -318,6 +318,17 @@ Only available in `sym =>` mode.
 -/
 syntax (name := symSimp) "simp" (ppSpace colGt ident)? (" [" ident,* "]")? : grind
 
+/--
+`dsimp` applies the definitional simplifier to the goal target.
+Only available in `sym =>` mode.
+
+- `dsimp` — uses the default (identity) variant
+- `dsimp myVariant` — uses a named variant registered via `register_sym_dsimp`
+- `dsimp [id₁, id₂, ...]` — default variant with extra declarations to unfold
+- `dsimp myVariant [id₁, id₂, ...]` — named variant with extra declarations
+-/
+syntax (name := symDSimp) "dsimp" (ppSpace colGt ident)? (" [" ("*" <|> ident),* "]")? : grind
+
 /-- `exact e` closes the main goal if its target type matches that of `e`. -/
 macro "exact " e:term : grind => `(grind| tactic => exact $e:term)
 

--- a/src/Init/Sym.lean
+++ b/src/Init/Sym.lean
@@ -7,3 +7,4 @@ module
 prelude
 public import Init.Sym.Lemmas
 public import Init.Sym.Simp.SimprocDSL
+public import Init.Sym.DSimp.DSimprocDSL

--- a/src/Init/Sym/DSimp/DSimprocDSL.lean
+++ b/src/Init/Sym/DSimp/DSimprocDSL.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+module
+prelude
+public import Init.Tactics
+public section
+namespace Lean.Parser.Sym.DSimp
+
+/-!
+# DSimproc DSL for `Sym.dsimp`
+
+A syntax category for specifying `pre` and `post` dsimproc chains in `Sym.dsimp` variants.
+
+## Primitives
+- `ground` — evaluates ground (fully concrete) terms
+- `beta` — beta reduction
+- `zeta` - zeta reduction
+- `zeta_delta [ids]` - zeta delta reduction
+- `proj` - reduce projections
+- `match` - reduce match-expressions
+
+## Combinators
+- `a >> b` — apply `a`, then apply `b` to the result (andThen)
+- `a <|> b` — try `a`, if no progress try `b` (orElse)
+-/
+
+declare_syntax_cat sym_dsimproc (behavior := both)
+
+-- Simproc primitives
+
+/-- Evaluate ground (fully concrete) terms. -/
+syntax (name := ground) "ground" : sym_dsimproc
+
+/-- Beta reduction -/
+syntax (name := beta) "beta" : sym_dsimproc
+
+/-- zeta reduction. That is, expands let-expressions. -/
+syntax (name := zeta) "zeta" : sym_dsimproc
+
+/-- zeta delta reduction. That is, expands all let-declarations. -/
+syntax (name := zetaDelta) "zeta_delta" : sym_dsimproc
+
+/-- Projection reduction. -/
+syntax (name := proj) "proj" : sym_dsimproc
+
+/-- `match`-expression reduction. -/
+syntax (name := reduceMatch) "match" : sym_dsimproc
+
+-- DSimproc combinators
+
+/-- Apply `a`, then apply `b` to the result. -/
+syntax:60 (name := andThen) sym_dsimproc:61 " >> " sym_dsimproc:60 : sym_dsimproc
+
+/-- Try `a`, if no progress try `b`. -/
+syntax:20 (name := orElse) sym_dsimproc:21 " <|> " sym_dsimproc:20 : sym_dsimproc
+
+/-- Parenthesized dsimproc expression. -/
+syntax (name := dsimprocParen) "(" sym_dsimproc ")" : sym_dsimproc
+
+end Lean.Parser.Sym.DSimp
+
+/-!
+## `register_sym_dsimp` command
+
+Declares a named `Sym.dsimp` variant with `pre`/`post` simproc chains and optional config overrides.
+
+```
+register_sym_dsimp myVariant where
+  pre  := match
+  post := ground >> zeta_delta
+```
+-/
+
+namespace Lean.Parser.Command
+
+declare_syntax_cat sym_dsimp_field (behavior := both)
+
+/-- Pre-processing simproc chain. -/
+syntax (name := symDSimpFieldPre) "pre" " := " sym_dsimproc : sym_dsimp_field
+
+/-- Post-processing simproc chain. -/
+syntax (name := symDSimpFieldPost) "post" " := " sym_dsimproc : sym_dsimp_field
+
+/-- Maximum number of simplification steps. -/
+syntax (name := symDSimpFieldMaxSteps) "maxSteps" " := " num : sym_dsimp_field
+
+/--
+Register a named `Sym.dsimp` variant.
+
+```
+register_sym_dsimp myVariant where
+  pre  := match
+  post := ground >> zeta_delta
+  maxSteps := 50000
+```
+-/
+syntax (name := registerSymDSimp) "register_sym_dsimp" ident "where"
+  (colGt sym_dsimp_field)* : command
+
+end Lean.Parser.Command

--- a/src/Lean/Elab/Tactic/Grind.lean
+++ b/src/Lean/Elab/Tactic/Grind.lean
@@ -19,3 +19,5 @@ public import Lean.Elab.Tactic.Grind.Sym
 public import Lean.Elab.Tactic.Grind.SimprocDSL
 public import Lean.Elab.Tactic.Grind.SimprocDSLBuiltin
 public import Lean.Elab.Tactic.Grind.RegisterSymSimp
+public import Lean.Elab.Tactic.Grind.DSimprocDSL
+public import Lean.Elab.Tactic.Grind.RegisterSymDSimp

--- a/src/Lean/Elab/Tactic/Grind/DSimprocDSL.lean
+++ b/src/Lean/Elab/Tactic/Grind/DSimprocDSL.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+module
+prelude
+public import Lean.Elab.Tactic.Grind.Basic
+public import Lean.Meta.Sym.DSimp
+import Init.Sym.DSimp.DSimprocDSL
+public section
+namespace Lean.Elab.Tactic.Grind
+open Meta Sym.DSimp
+
+/-- Elaboration function for `sym_dsimproc` syntax. -/
+abbrev SymDSimprocElab := Syntax → GrindTacticM DSimproc
+
+unsafe builtin_initialize symDSimprocElabAttribute : KeyedDeclsAttribute SymDSimprocElab ←
+  mkElabAttribute SymDSimprocElab `builtin_sym_dsimproc `sym_dsimproc
+    `Lean.Parser.Sym.DSimp `Lean.Elab.Tactic.Grind.SymDSimprocElab "sym_dsimproc"
+
+/-- Elaborate a `sym_dsimproc` syntax node into a `DSimproc`. -/
+partial def elabSymDSimproc (stx : Syntax) : GrindTacticM DSimproc := do
+  let elabFns := symDSimprocElabAttribute.getEntries (← getEnv) stx.getKind
+  for elabFn in elabFns do
+    try
+      return (← elabFn.value stx)
+    catch ex =>
+      match ex with
+      | .internal id _ =>
+        if id == unsupportedSyntaxExceptionId then continue
+        else throw ex
+      | _ => throw ex
+  throwErrorAt stx "unsupported sym_dsimproc syntax `{stx.getKind}`"
+
+end Lean.Elab.Tactic.Grind

--- a/src/Lean/Elab/Tactic/Grind/RegisterSymDSimp.lean
+++ b/src/Lean/Elab/Tactic/Grind/RegisterSymDSimp.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+module
+prelude
+import Init.Sym.DSimp.DSimprocDSL
+import Lean.Meta.Sym.DSimp.Variant
+import Lean.Elab.Tactic.Grind.DSimprocDSL
+import Lean.Elab.Tactic.Grind.WithGrindTacticM
+namespace Lean.Elab.Command
+open Meta Sym.DSimp
+
+def validateOptionDSimprocSyntax (proc? : Option Syntax) : CommandElabM Unit := do
+  let some proc := proc? | return ()
+  discard <| withGrindTacticM <| Tactic.Grind.elabSymDSimproc proc
+
+@[builtin_command_elab Lean.Parser.Command.registerSymDSimp]
+def elabRegisterSymDSimp : CommandElab := fun stx => do
+  let id := stx[1]
+  let name := id.getId
+  -- Check for duplicate variant
+  if (getSymDSimpVariant? (← getEnv) name).isSome then
+    throwErrorAt id "Sym.dsimp variant `{name}` is already registered"
+  let fields := stx[3].getArgs
+  let mut pre? : Option Syntax := none
+  let mut post? : Option Syntax := none
+  let mut maxSteps? : Option Nat := none
+  for field in fields do
+    match field with
+    | `(sym_dsimp_field| maxSteps := $val:num) =>
+      unless maxSteps?.isNone do throwErrorAt field "duplicate `maxSteps` field"
+      maxSteps? := some val.getNat
+    | `(sym_dsimp_field| pre := $proc) =>
+      unless pre?.isNone do throwErrorAt field "duplicate `pre` field"
+      pre? := some proc
+    | `(sym_dsimp_field| post := $proc) =>
+      unless post?.isNone do throwErrorAt field "duplicate `post` field"
+      post? := some proc
+    | _ => throwErrorAt field "unexpected field"
+  -- Validate pre/post by elaborating them
+  validateOptionDSimprocSyntax pre?
+  validateOptionDSimprocSyntax post?
+  let config := { maxSteps := maxSteps?.getD 100_000 }
+  let variant : SymDSimpVariant := { pre?, post?, config }
+  modifyEnv fun env => symDSimpVariantExtension.addEntry env { name, variant }
+
+end Lean.Elab.Command

--- a/src/Lean/Elab/Tactic/Grind/RegisterSymSimp.lean
+++ b/src/Lean/Elab/Tactic/Grind/RegisterSymSimp.lean
@@ -8,29 +8,9 @@ prelude
 import Init.Sym.Simp.SimprocDSL
 import Lean.Meta.Sym.Simp.Variant
 import Lean.Elab.Tactic.Grind.SimprocDSL
-import Lean.Elab.Command
+import Lean.Elab.Tactic.Grind.WithGrindTacticM
 namespace Lean.Elab.Command
 open Meta Sym.Simp
-
-/--
-Runs a `GrindTacticM` computation in a minimal context for validation.
--/
-def withGrindTacticM (k : Tactic.Grind.GrindTacticM α) : CommandElabM α := do
-  liftTermElabM do
-  let params ← Grind.mkDefaultParams {}
-  let (ctx, state) ← Grind.GrindM.run (params := params) do
-    let methods ← Grind.getMethods
-    let grindCtx ← readThe Meta.Grind.Context
-    let symCtx ← readThe Sym.Context
-    let grindState ← get
-    let symState ← getThe Sym.State
-    let ctx := {
-      elaborator := `registerSymSimp,
-      ctx := grindCtx, sctx := symCtx, methods, params
-    }
-    return (ctx, { grindState, symState, goals := [] })
-  let (a, _) ← Tactic.Grind.GrindTacticM.run k ctx state
-  return a
 
 def validateOptionSimprocSyntax (proc? : Option Syntax) : CommandElabM Unit := do
   let some proc := proc? | return ()

--- a/src/Lean/Elab/Tactic/Grind/WithGrindTacticM.lean
+++ b/src/Lean/Elab/Tactic/Grind/WithGrindTacticM.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+module
+prelude
+public import Lean.Elab.Tactic.Grind.Basic
+public import Lean.Elab.Command
+namespace Lean.Elab.Command
+open Meta
+
+/--
+Runs a `GrindTacticM` computation in a minimal context for validation.
+-/
+public def withGrindTacticM (k : Tactic.Grind.GrindTacticM α) : CommandElabM α := do
+  liftTermElabM do
+  let params ← Grind.mkDefaultParams {}
+  let (ctx, state) ← Grind.GrindM.run (params := params) do
+    let methods ← Grind.getMethods
+    let grindCtx ← readThe Meta.Grind.Context
+    let symCtx ← readThe Sym.Context
+    let grindState ← get
+    let symState ← getThe Sym.State
+    let ctx := {
+      elaborator := `registerSymSimp,
+      ctx := grindCtx, sctx := symCtx, methods, params
+    }
+    return (ctx, { grindState, symState, goals := [] })
+  let (a, _) ← Tactic.Grind.GrindTacticM.run k ctx state
+  return a
+
+end Lean.Elab.Command

--- a/src/Lean/Meta/Sym/DSimp.lean
+++ b/src/Lean/Meta/Sym/DSimp.lean
@@ -14,3 +14,4 @@ public import Lean.Meta.Sym.DSimp.Forall
 public import Lean.Meta.Sym.DSimp.Let
 public import Lean.Meta.Sym.DSimp.Main
 public import Lean.Meta.Sym.DSimp.Reduce
+public import Lean.Meta.Sym.DSimp.Variant

--- a/src/Lean/Meta/Sym/DSimp/Variant.lean
+++ b/src/Lean/Meta/Sym/DSimp/Variant.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+module
+prelude
+public import Lean.Meta.Sym.DSimp.DSimpM
+import Lean.ScopedEnvExtension
+public section
+namespace Lean.Meta.Sym.DSimp
+
+/--
+A named `Sym.dsimp` variant. Stores `pre`/`post` dsimproc chains as syntax
+(elaborated at use time in `GrindTacticM`) and configuration overrides.
+-/
+structure SymDSimpVariant where
+  /-- Pre-processing dsimproc chain (elaborated at use time). -/
+  pre?   : Option Syntax := none
+  /-- Post-processing dsimproc chain (elaborated at use time). -/
+  post?  : Option Syntax := none
+  /-- Configuration overrides. -/
+  config : Config := {}
+  deriving Inhabited
+
+/-- Entry for the scoped environment extension. -/
+structure SymDSimpVariantEntry where
+  name    : Name
+  variant : SymDSimpVariant
+  deriving Inhabited
+
+/-- Persistent environment extension mapping variant names to their definitions. -/
+builtin_initialize symDSimpVariantExtension :
+    SimpleScopedEnvExtension SymDSimpVariantEntry (Std.HashMap Name SymDSimpVariant) ←
+  registerSimpleScopedEnvExtension {
+    name     := `symDSimpVariantExtension
+    initial  := {}
+    addEntry := fun map entry => map.insert entry.name entry.variant
+  }
+
+/-- Look up a named `Sym.dsimp` variant. -/
+def getSymDSimpVariant? (env : Environment) (name : Name) : Option SymDSimpVariant :=
+  (symDSimpVariantExtension.getState env)[name]?
+
+end Lean.Meta.Sym.DSimp

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,3 +1,4 @@
+// update me!
 #include "util/options.h"
 
 namespace lean {


### PR DESCRIPTION
This PR implements the syntax for declaring `dsimp` variants for `SymM`.