### PR TITLE
feat: `dsimp` tactic for `sym =>`

### DIFF
--- a/src/Init/Sym/DSimp/DSimprocDSL.lean
+++ b/src/Init/Sym/DSimp/DSimprocDSL.lean
@@ -31,6 +31,9 @@ declare_syntax_cat sym_dsimproc (behavior := both)
 
 -- Simproc primitives
 
+/-- Do nothing -/
+syntax (name := none) "none" : sym_dsimproc
+
 /-- Evaluate ground (fully concrete) terms. -/
 syntax (name := ground) "ground" : sym_dsimproc
 

--- a/src/Lean/Elab/Tactic/Grind.lean
+++ b/src/Lean/Elab/Tactic/Grind.lean
@@ -20,4 +20,5 @@ public import Lean.Elab.Tactic.Grind.SimprocDSL
 public import Lean.Elab.Tactic.Grind.SimprocDSLBuiltin
 public import Lean.Elab.Tactic.Grind.RegisterSymSimp
 public import Lean.Elab.Tactic.Grind.DSimprocDSL
+public import Lean.Elab.Tactic.Grind.DSimprocDSLBuiltin
 public import Lean.Elab.Tactic.Grind.RegisterSymDSimp

--- a/src/Lean/Elab/Tactic/Grind/Basic.lean
+++ b/src/Lean/Elab/Tactic/Grind/Basic.lean
@@ -11,6 +11,7 @@ import Lean.Meta.Tactic.Grind.Intro
 public import Lean.Meta.Sym.Apply
 public import Lean.Meta.Sym.Util
 public import Lean.Meta.Sym.Simp.SimpM
+public import Lean.Meta.Sym.DSimp.DSimpM
 import Init.Omega
 public section
 namespace Lean.Elab.Tactic.Grind
@@ -37,6 +38,18 @@ structure SimpCacheKey where
   extras  : Array ExtraTheorem
   deriving BEq, Hashable
 
+structure DSimpArgs where
+  fvarIds : Array FVarId := #[]
+  zetaDeltaAll : Bool := false
+  -- TODO: rfl-theorems and declarations to unfold
+  deriving BEq, Hashable
+
+/-- Cache key for `Sym.dsimp` variant invocations. -/
+structure DSimpCacheKey where
+  variant : Name
+  args    : DSimpArgs
+  deriving BEq, Hashable
+
 structure Cache where
   /-- Cache for `BackwardRule`s created from declaration names (sym mode only). -/
   backwardRuleName : PHashMap Name Sym.BackwardRule := {}
@@ -44,6 +57,8 @@ structure Cache where
   backwardRuleSyntax : PHashMap (Nat × Nat) Sym.BackwardRule := {}
   /-- Per-variant persistent `Sym.simp` cache. Keyed by variant name + extra theorem names. -/
   simpState : Std.HashMap SimpCacheKey Sym.Simp.State := {}
+  /-- Per-variant persistent `Sym.dsimp` cache. Keyed by variant name + args. -/
+  dsimpState : Std.HashMap DSimpCacheKey Sym.DSimp.State := {}
 
 structure State where
   symState   : Meta.Sym.State

--- a/src/Lean/Elab/Tactic/Grind/DSimprocDSLBuiltin.lean
+++ b/src/Lean/Elab/Tactic/Grind/DSimprocDSLBuiltin.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+module
+prelude
+import Lean.Elab.Tactic.Grind.DSimprocDSL
+import Init.Sym.DSimp.DSimprocDSL
+import Lean.Meta.Sym.DSimp.Reduce
+import Lean.Meta.Sym.DSimp.DSimproc
+namespace Lean.Elab.Tactic.Grind
+open Meta Sym.DSimp
+
+-- DSimproc elaborators
+
+@[builtin_sym_dsimproc Lean.Parser.Sym.DSimp.zetaDelta]
+def elabZetaDeltaAll : SymDSimprocElab := fun _ =>
+  return zetaDeltaAll
+
+@[builtin_sym_dsimproc Lean.Parser.Sym.DSimp.zeta]
+def elabZeta : SymDSimprocElab := fun _ =>
+  return zeta
+
+@[builtin_sym_dsimproc Lean.Parser.Sym.DSimp.beta]
+def elabBeta : SymDSimprocElab := fun _ =>
+  return beta
+
+@[builtin_sym_dsimproc Lean.Parser.Sym.DSimp.reduceMatch]
+def elabReduceMatch : SymDSimprocElab := fun _ =>
+  return dsimpMatch
+
+@[builtin_sym_dsimproc Lean.Parser.Sym.DSimp.proj]
+def elabProj : SymDSimprocElab := fun _ =>
+  return dsimpProj
+
+@[builtin_sym_dsimproc Lean.Parser.Sym.DSimp.none]
+def elabNone : SymDSimprocElab := fun _ =>
+  return fun _ => return .rfl
+
+@[builtin_sym_dsimproc andThen]
+def elabDSimprocAndThen : SymDSimprocElab := fun stx => do
+  let `(sym_dsimproc| $left >> $right) := stx | throwUnsupportedSyntax
+  let left ← elabSymDSimproc left
+  let right ← elabSymDSimproc right
+  return left >> right
+
+@[builtin_sym_dsimproc Lean.Parser.Sym.DSimp.orElse]
+def elabDSimprocOrElse : SymDSimprocElab := fun stx => do
+  let `(sym_dsimproc| $left <|> $right) := stx | throwUnsupportedSyntax
+  let left ← elabSymDSimproc left
+  let right ← elabSymDSimproc right
+  return left <|> right
+
+@[builtin_sym_dsimproc dsimprocParen]
+def elabDSimprocParen : SymDSimprocElab := fun stx => do
+  let `(sym_dsimproc| ( $proc) ) := stx | throwUnsupportedSyntax
+  elabSymDSimproc proc
+
+end Lean.Elab.Tactic.Grind

--- a/src/Lean/Elab/Tactic/Grind/Sym.lean
+++ b/src/Lean/Elab/Tactic/Grind/Sym.lean
@@ -7,6 +7,7 @@ module
 prelude
 import Lean.Elab.Tactic.Grind.Basic
 import Lean.Elab.Tactic.Grind.SimprocDSL
+import Lean.Elab.Tactic.Grind.DSimprocDSL
 import Lean.Meta.Sym.Grind
 import Lean.Meta.Sym.Simp.Variant
 import Lean.Meta.Sym.Simp.Rewrite
@@ -15,6 +16,9 @@ import Lean.Meta.Sym.Simp.Goal
 import Lean.Meta.Sym.Simp.Attr
 import Lean.Meta.Sym.Simp.ControlFlow
 import Lean.Meta.Sym.Simp.Forall
+import Lean.Meta.Sym.DSimp.Variant
+import Lean.Meta.Sym.DSimp.Reduce
+import Lean.Meta.Sym.DSimp.DSimproc
 import Lean.Meta.Tactic.Apply
 import Lean.Elab.SyntheticMVars
 namespace Lean.Elab.Tactic.Grind
@@ -175,15 +179,15 @@ def addExtraTheorems (post : Simproc) (extraThms : Array Theorem) : GrindTacticM
     thms := thms.insert thm
   return post >> thms.rewrite
 
-def mkDefaultMethods (extraThms : Array Theorem) : GrindTacticM Sym.Simp.Methods := do
+def mkSimpDefaultMethods (extraThms : Array Theorem) : GrindTacticM Sym.Simp.Methods := do
   let thms ← getSymSimpTheorems
   let pre := simpControl >> simpArrowTelescope
   let post ← addExtraTheorems (evalGround >> thms.rewrite) extraThms
   return { pre, post }
 
-def elabVariant (variantName : Name) (extraThms : Array Theorem) : GrindTacticM (Sym.Simp.Methods × Sym.Simp.Config) := do
+def elabSimpVariant (variantName : Name) (extraThms : Array Theorem) : GrindTacticM (Sym.Simp.Methods × Sym.Simp.Config) := do
   if variantName.isAnonymous then
-    return (← mkDefaultMethods extraThms, {})
+    return (← mkSimpDefaultMethods extraThms, {})
   let some v := getSymSimpVariant? (← getEnv) variantName
     | throwError "unknown Sym.simp variant `{variantName}`"
   let pre ← elabOptSimproc v.pre?
@@ -200,7 +204,7 @@ def elabVariant (variantName : Name) (extraThms : Array Theorem) : GrindTacticM 
   -- Cache lookup/creation
   let cacheKey : SimpCacheKey := { variant := variantName, extras }
   let simpState := (← get).cache.simpState[cacheKey]?.getD {}
-  let (methods, config) ← elabVariant variantName thms
+  let (methods, config) ← elabSimpVariant variantName thms
   let goal ← getMainGoal
   let (simpResult, simpState) ← liftGrindM <| goal.withContext do
     Sym.Simp.SimpM.run (Sym.Simp.simp (← goal.mvarId.getType)) methods config simpState
@@ -211,6 +215,82 @@ def elabVariant (variantName : Name) (extraThms : Array Theorem) : GrindTacticM 
   | .closed => replaceMainGoal []
   | .goal mvarId => replaceMainGoal [{ goal with mvarId }]
   | .noProgress => throwError "`Sym.simp` made no progress"
+
+end
+
+section
+open Sym.DSimp
+
+def elabDSimpArgs (args? : Option (Array (TSyntax [`token.«*», `ident]))) : GrindTacticM DSimpArgs := do
+  let some args := args? | return {}
+  let mut fvarIds := #[]
+  let mut zetaDeltaAll := false
+  let lctx ← getLCtx
+  for arg in args do
+    if arg.raw.getKind == `ident then
+      if let some decl := lctx.findFromUserName? arg.raw.getId then
+        fvarIds := fvarIds.push decl.fvarId
+      else
+        -- TODO: add support for rfl-theorems and unfolding definitions
+        throwError "unknown identifier `{arg.raw.getId}`"
+    else
+      zetaDeltaAll := true
+  if !fvarIds.isEmpty && zetaDeltaAll then
+    throwError "invalid `dsimp` arguments, local declarations and `*` have been provided"
+  return { fvarIds, zetaDeltaAll }
+
+def addDSimpArgs (pre : DSimproc) (args : DSimpArgs) : DSimproc := Id.run do
+  let mut pre := pre
+  if args.zetaDeltaAll then
+    pre := pre >> zetaDeltaAll
+  unless args.fvarIds.isEmpty do
+    pre := pre >> zetaDelta (FVarIdSet.ofArray args.fvarIds)
+  return pre
+
+def mkDSimpDefaultMethods (args : DSimpArgs) : GrindTacticM Sym.DSimp.Methods := do
+  let pre := beta >> dsimpProj >> dsimpMatch
+  let pre := addDSimpArgs pre args
+  return { pre }
+
+def trivialDSimproc : DSimproc := fun _ =>
+  return .rfl
+
+def elabOptDSimproc (stx? : Option Syntax) : GrindTacticM DSimproc := do
+  let some stx := stx? | return trivialDSimproc
+  elabSymDSimproc stx
+
+def elabDSimpVariant (variantName : Name) (args : DSimpArgs) : GrindTacticM (Sym.DSimp.Methods × Sym.DSimp.Config) := do
+  if variantName.isAnonymous then
+    return (← mkDSimpDefaultMethods args, {})
+  let some v := Sym.DSimp.getSymDSimpVariant? (← getEnv) variantName
+    | throwError "unknown Sym.dsimp variant `{variantName}`"
+  let pre := addDSimpArgs (← elabOptDSimproc v.pre?) args
+  let post ← elabOptDSimproc v.post?
+  return ({ pre, post}, v.config)
+
+@[builtin_grind_tactic Parser.Tactic.Grind.symDSimp] def evalSymDSimp : GrindTactic := fun stx => withMainContext do
+  ensureSym
+  let `(grind| dsimp $[$variantId?]? $[[ $[$args],* ]]?) := stx | throwUnsupportedSyntax
+  let variantName := variantId?.map (·.getId) |>.getD .anonymous
+  let args ← elabDSimpArgs args
+  let cacheKey : DSimpCacheKey := { variant := variantName, args }
+  let dsimpState := (← get).cache.dsimpState[cacheKey]?.getD {}
+  let (methods, config) ← elabDSimpVariant variantName args
+  let goal ← getMainGoal
+  let (result, dsimpState) ← liftGrindM <| goal.withContext do
+    Sym.DSimp.DSimpM.run (Sym.DSimp.dsimp (← goal.mvarId.getType)) methods config dsimpState
+  modify fun s => { s with cache.dsimpState := s.cache.dsimpState.insert cacheKey dsimpState }
+  match result with
+  | .rfl _  => throwError "`Sym.dsimp` made no progress"
+  | .step target' _ =>
+    if target'.isTrue then
+      goal.mvarId.assign (mkConst ``True.intro)
+      replaceMainGoal []
+    else
+      let decl ← goal.mvarId.getDecl
+      let mvarNew ← mkFreshExprSyntheticOpaqueMVar target' decl.userName
+      goal.mvarId.assign mvarNew
+      replaceMainGoal [{ goal with mvarId := mvarNew.mvarId! }]
 
 end
 

--- a/src/Lean/Meta/Sym/DSimp/Reduce.lean
+++ b/src/Lean/Meta/Sym/DSimp/Reduce.lean
@@ -20,18 +20,27 @@ public def beta : DSimproc := fun e => do
   else
     return .rfl
 
-public def zeta (s : FVarIdSet) : DSimproc := fun e => do
+public def zetaDelta (s : FVarIdSet) : DSimproc := fun e => do
   let .fvar fvarId := e | return .rfl
   unless s.contains fvarId do return .rfl
   let decl ← fvarId.getDecl
   let some value := decl.value? | return .rfl
   return .step value
 
-public def zetaAll : DSimproc := fun e => do
+public def zetaDeltaAll : DSimproc := fun e => do
   let .fvar fvarId := e | return .rfl
   let decl ← fvarId.getDecl
   let some value := decl.value? | return .rfl
   return .step value
+
+public def zeta : DSimproc := fun e => do
+  let .letE .. := e | return .rfl
+  go e #[]
+where
+  go (e : Expr) (subst : Array Expr) : DSimpM Result := do
+    match e with
+    | .letE _ _ v b _ => go b (subst.push (← instantiateRevS v subst))
+    | _ => return .step (← instantiateRevS e subst)
 
 public def dsimpProj : DSimproc := fun e => do
   let f := e.getAppFn

--- a/tests/elab/sym_dsimp.lean
+++ b/tests/elab/sym_dsimp.lean
@@ -26,3 +26,36 @@ example (h : 10 + a = b) : let x := 10; let y := a; x + y = b := by
     dsimp [*]
     show_goals
     exact h
+
+register_sym_dsimp myDSimp where
+  pre  := beta >> match >> zeta >> zeta_delta
+  post := none
+
+/--
+trace: case grind
+a b : Nat
+h : 10 + a = b
+⊢ 10 + a = b
+-/
+#guard_msgs in
+example (h : 10 + a = b) : let x := 10; let y := a; x + y = b := by
+  sym =>
+    fail_if_success dsimp
+    dsimp myDSimp
+    show_goals
+    exact h
+
+/--
+trace: case grind
+a b : Nat
+β✝ : Type u_1
+c : β✝
+h : 10 + a = b
+⊢ 10 + a = (b, c).fst
+-/
+#guard_msgs in
+example (h : 10 + a = b) : let x := 10; let y := a; x + y = (b, c).1 := by
+  sym =>
+    dsimp myDSimp -- projections are not reduced
+    show_goals
+    exact h

--- a/tests/elab/sym_dsimp.lean
+++ b/tests/elab/sym_dsimp.lean
@@ -1,0 +1,28 @@
+
+
+example (h : a = c) : ((fun x => x) a, b).1 = c := by
+  sym =>
+    dsimp
+    exact h
+
+example (h : 10 + a = b) : let x := 10; x + a = b := by
+  sym =>
+    intro x
+    dsimp [x]
+    exact h
+
+/--
+trace: case grind
+a b : Nat
+h : 10 + a = b
+x : Nat := 10
+y : Nat := a
+⊢ 10 + a = b
+-/
+#guard_msgs in
+example (h : 10 + a = b) : let x := 10; let y := a; x + y = b := by
+  sym =>
+    intro x y
+    dsimp [*]
+    show_goals
+    exact h


### PR DESCRIPTION
This PR implements the `dsimp` tactic for interactive `sym =>` mode. It also adds DSL for declaring `dsimp` variants.