### PR TITLE
fix: also check for identifier escapes after digits

### DIFF
--- a/src/Lean/Parser/Basic.lean
+++ b/src/Lean/Parser/Basic.lean
@@ -876,7 +876,7 @@ where
           takeDigitsFn (fun c => c.isDigit) "decimal number" false c (s.setPos i)
         else
           s.mkUnexpectedError "missing exponent digits in scientific literal"
-      else if hasBareDot && isIdFirst curr then
+      else if hasBareDot && (isIdFirst curr || isIdBeginEscape curr) then
           (s.setPos startPos).mkUnexpectedError s!"unexpected identifier after decimal point; consider parenthesizing the number"
       else
         s

--- a/tests/elab_fail/10488.lean
+++ b/tests/elab_fail/10488.lean
@@ -58,3 +58,7 @@ inductive Nope where
 
 example := (match · with
   | succ x y => 4)
+
+-- Escaped identifiers after a bare decimal point should also be flagged
+#check 31.«succ»
+#check 11.«foo bar»

--- a/tests/elab_fail/10488.lean.out.expected
+++ b/tests/elab_fail/10488.lean.out.expected
@@ -52,3 +52,5 @@ bar.x.snd.snd : Nat
 Hint: Using one of these would be valid:
   [apply] `Nat.succ`
   [apply] `Nope.succ`
+10488.lean:63:7: error: unexpected identifier after decimal point; consider parenthesizing the number
+10488.lean:64:7: error: unexpected identifier after decimal point; consider parenthesizing the number


### PR DESCRIPTION
This PR updates the error message improvement from #10488 to also check for identifier escape characters when providing the improved message. Before, it checked only for identifier start characters.

