### PR TITLE
perf: less aggressive BitVec e-matching

### DIFF
--- a/src/Init/Data/BitVec/Lemmas.lean
+++ b/src/Init/Data/BitVec/Lemmas.lean
@@ -5429,6 +5429,7 @@ theorem getLsbD_intMin (w : Nat) : (intMin w).getLsbD i = decide (i + 1 = w) := 
   simp only [intMin, getLsbD_twoPow, bool_to_prop]
   omega
 
+@[grind =]
 theorem getMsbD_intMin {w i : Nat} :
     (intMin w).getMsbD i = (decide (0 < w) && decide (i = 0)) := by
   simp only [getMsbD, getLsbD_intMin]

--- a/src/Init/Data/BitVec/Lemmas.lean
+++ b/src/Init/Data/BitVec/Lemmas.lean
@@ -521,7 +521,6 @@ theorem msb_eq_getLsbD_last (x : BitVec w) :
 @[bitvec_to_nat] theorem getLsbD_succ_last (x : BitVec (w + 1)) :
     x.getLsbD w = decide (2 ^ w ≤ x.toNat) := getLsbD_last x
 
-
 @[bitvec_to_nat] theorem msb_eq_decide (x : BitVec w) : BitVec.msb x = decide (2 ^ (w-1) ≤ x.toNat) := by
   simp [msb_eq_getLsbD_last, getLsbD_last]
 

--- a/src/Init/Data/BitVec/Lemmas.lean
+++ b/src/Init/Data/BitVec/Lemmas.lean
@@ -154,8 +154,15 @@ theorem two_pow_le_toNat_of_getElem_eq_true {i : Nat} {x : BitVec w}
   simp only [getMsb?, getLsb?_eq_getElem?]
   split <;> simp [getMsb_eq_getLsb]
 
-@[grind =] theorem getMsbD_eq_getLsbD (x : BitVec w) (i : Nat) : x.getMsbD i = (decide (i < w) && x.getLsbD (w - 1 - i)) := by
+theorem getMsbD_eq_getLsbD (x : BitVec w) (i : Nat) : x.getMsbD i = (decide (i < w) && x.getLsbD (w - 1 - i)) := by
   rw [getMsbD, getLsbD]
+
+grind_pattern getMsbD_eq_getLsbD => x.getMsbD i, x.getLsbD _
+
+@[grind =]
+theorem getMsbD_eq_getElem (x : BitVec w) (i : Nat) (h : i < w) : x.getMsbD i = x[w - 1 - i] := by
+  rw [← getLsbD_eq_getElem]
+  simp [getMsbD_eq_getLsbD, h]
 
 theorem getLsbD_eq_getMsbD (x : BitVec w) (i : Nat) : x.getLsbD i = (decide (i < w) && x.getMsbD (w - 1 - i)) := by
   rw [getMsbD]
@@ -514,8 +521,13 @@ theorem msb_eq_getLsbD_last (x : BitVec w) :
 @[bitvec_to_nat] theorem getLsbD_succ_last (x : BitVec (w + 1)) :
     x.getLsbD w = decide (2 ^ w ≤ x.toNat) := getLsbD_last x
 
+
 @[bitvec_to_nat] theorem msb_eq_decide (x : BitVec w) : BitVec.msb x = decide (2 ^ (w-1) ≤ x.toNat) := by
   simp [msb_eq_getLsbD_last, getLsbD_last]
+
+@[grind =]
+theorem getMsbD_last (x : BitVec w) : x.getMsbD 0 = decide (2 ^ (w-1) ≤ x.toNat) := by
+  rw [← BitVec.msb, msb_eq_decide]
 
 theorem toNat_ge_of_msb_true {x : BitVec n} (p : BitVec.msb x = true) : x.toNat ≥ 2^(n-1) := by
   match n with

--- a/src/Lean/Elab/Tactic/Grind/LintExceptions.lean
+++ b/src/Lean/Elab/Tactic/Grind/LintExceptions.lean
@@ -11,8 +11,6 @@ import Lean.Elab.Tactic.Grind.Lint
 
 -- We allow these as grind lemmas even though they triggers >20 further instantiations.
 -- See tests/lean/run/grind_lint_*.lean for more details.
-#grind_lint skip BitVec.msb_replicate
-#grind_lint skip BitVec.msb_signExtend
 #grind_lint skip List.replicate_sublist_iff
 #grind_lint skip List.Sublist.append
 #grind_lint skip List.Sublist.middle

--- a/src/Lean/Elab/Tactic/Grind/LintExceptions.lean
+++ b/src/Lean/Elab/Tactic/Grind/LintExceptions.lean
@@ -11,6 +11,9 @@ import Lean.Elab.Tactic.Grind.Lint
 
 -- We allow these as grind lemmas even though they triggers >20 further instantiations.
 -- See tests/lean/run/grind_lint_*.lean for more details.
+#grind_lint skip BitVec.msb_extractLsb
+#grind_lint skip BitVec.msb_signExtend
+#grind_lint skip BitVec.toInt_shiftLeftZeroExtend
 #grind_lint skip List.replicate_sublist_iff
 #grind_lint skip List.Sublist.append
 #grind_lint skip List.Sublist.middle

--- a/src/Lean/Elab/Tactic/Grind/LintExceptions.lean
+++ b/src/Lean/Elab/Tactic/Grind/LintExceptions.lean
@@ -17,18 +17,11 @@ import Lean.Elab.Tactic.Grind.Lint
 #grind_lint skip List.Sublist.append
 #grind_lint skip List.Sublist.middle
 #grind_lint skip List.getLast?_pmap
-#grind_lint skip List.getLast_attach
-#grind_lint skip List.getLast_attachWith
-#grind_lint skip List.head_attachWith
 #grind_lint skip List.drop_append_length
 #grind_lint skip List.getLast_scanr
 #grind_lint skip Array.back_singleton
 #grind_lint skip Array.count_singleton
 #grind_lint skip Array.foldl_empty
 #grind_lint skip Array.foldr_empty
-#grind_lint skip Std.ExtHashMap.getElem_filterMap'
-#grind_lint skip Std.ExtTreeMap.getElem_filterMap'
-#grind_lint skip Std.HashMap.getElem_filterMap'
-#grind_lint skip Std.TreeMap.getElem_filterMap'
 
 #grind_lint skip suffix sizeOf_spec

--- a/tests/elab/grind_lint_bitvec.lean
+++ b/tests/elab/grind_lint_bitvec.lean
@@ -6,4 +6,14 @@ import Lean.Elab.Tactic.Grind.LintExceptions
 /-! Check BitVec namespace: -/
 
 #guard_msgs in
-#grind_lint check (min := 20) in BitVec
+#grind_lint inspect (min := 21) BitVec.msb_extractLsb
+
+#guard_msgs in
+#grind_lint inspect (min := 21) BitVec.msb_signExtend
+
+#guard_msgs in
+#grind_lint inspect (min := 21) BitVec.toInt_shiftLeftZeroExtend
+
+#guard_msgs in
+#grind_lint check  (min := 20) in BitVec
+

--- a/tests/elab/grind_lint_bitvec.lean
+++ b/tests/elab/grind_lint_bitvec.lean
@@ -3,15 +3,7 @@ import Lean.Elab.Tactic.Grind.LintExceptions
 
 /-! `BitVec` exceptions -/
 
--- `BitVec.msb_replicate` is reasonable at 25.
-#guard_msgs in
-#grind_lint inspect (min := 30) BitVec.msb_replicate
-
--- `BitVec.msb_signExtend` is reasonable at 26.
-#guard_msgs in
-#grind_lint inspect (min := 26) BitVec.msb_signExtend
-
 /-! Check BitVec namespace: -/
 
 #guard_msgs in
-#grind_lint check (min := 23) in BitVec
+#grind_lint check (min := 20) in BitVec

--- a/tests/elab/grind_lint_list.lean
+++ b/tests/elab/grind_lint_list.lean
@@ -23,18 +23,6 @@ import Lean.Elab.Tactic.Grind.LintExceptions
 #guard_msgs in
 #grind_lint inspect (min := 25) List.Sublist.middle
 
--- `List.getLast_attach` is reasonable at 21.
-#guard_msgs in
-#grind_lint inspect (min := 25) List.getLast_attach
-
--- `List.getLast_attachWith` is reasonable at 22.
-#guard_msgs in
-#grind_lint inspect (min := 25) List.getLast_attachWith
-
--- `List.head_attachWith` is reasonable at 21.
-#guard_msgs in
-#grind_lint inspect (min := 25) List.head_attachWith
-
 -- `List.drop_append_length` is reasonable at 25.
 #guard_msgs in
 #grind_lint inspect (min := 25) List.drop_append_length

--- a/tests/elab/grind_lint_std_hashmap.lean
+++ b/tests/elab/grind_lint_std_hashmap.lean
@@ -3,13 +3,5 @@ import Lean.Elab.Tactic.Grind.LintExceptions
 
 /-! Check Std hash map/set namespaces: -/
 
--- `Std.ExtHashMap.getElem_filterMap'` is reasonable at 30.
-#guard_msgs in
-#grind_lint inspect (min := 35) Std.ExtHashMap.getElem_filterMap'
-
--- `Std.HashMap.getElem_filterMap'` is reasonable at 28.
-#guard_msgs in
-#grind_lint inspect (min := 30) Std.HashMap.getElem_filterMap'
-
 #guard_msgs in
 #grind_lint check (min := 20) in Std.DHashMap Std.HashMap Std.HashSet Std.ExtDHashMap Std.ExtHashMap Std.ExtHashSet

--- a/tests/elab/grind_lint_std_treemap.lean
+++ b/tests/elab/grind_lint_std_treemap.lean
@@ -3,13 +3,5 @@ import Lean.Elab.Tactic.Grind.LintExceptions
 
 /-! Check Std tree map/set namespaces: -/
 
--- `Std.ExtTreeMap.getElem_filterMap'` is reasonable at 30.
-#guard_msgs in
-#grind_lint inspect (min := 35) Std.ExtTreeMap.getElem_filterMap'
-
--- `Std.TreeMap.getElem_filterMap'` is reasonable at 28.
-#guard_msgs in
-#grind_lint inspect (min := 30) Std.TreeMap.getElem_filterMap'
-
 #guard_msgs in
 #grind_lint check (min := 20) in Std.DTreeMap Std.TreeMap Std.TreeSet Std.ExtDTreeMap Std.ExtTreeMap Std.ExtTreeSet


### PR DESCRIPTION
This PR changes the e-matching annotations on `BitVec` to avoid automatically going from `getMsbD` theory to `getLsbD` theory. The key reason being that all lemmas are already duplicated between `getMsbD` and `getLsbD` anyways. Thus, whenever we connect them all lemmas fire in both variants even though usually one is already sufficient. In order to make this possible without reducing proof strength noticeably we introduce two changes:
1. Write or annotate a few additional `BitVec.getMsbD` lemmas to match the reasoning power of `BitVec.getLsbD`. Most notably `getMsbD_eq_getElem` so `getMsbD` can attempt to convert into `getElem` on its own.
2. Introduce `grind_pattern getMsbD_eq_getLsbD => x.getMsbD i, x.getLsbD _` such that whenever we have both `getMsbD` and `getLsbD` on the same value in scope we attempt to match them up. We expect that this annotation should *usually* not fire much as most `get*D` can probably be converted into `getElem` and be worked from there.

Note that this PR does not perfectly solve the problem yet as there are some BitVec lemmas on GetElem that reduce to BitVec.getLsbD.