### PR TITLE
fix: typo in error message

### DIFF
--- a/src/Lean/Elab/DocString.lean
+++ b/src/Lean/Elab/DocString.lean
@@ -1363,7 +1363,7 @@ def throwUnknownDocElem {α β : Type}
   let resolved? ← try some <$> realizeGlobalConstNoOverload name catch | _ => pure none
   if let some resolved := resolved? then
     let info ← getConstInfo resolved
-    throwErrorAt name m!"`{name} : {info.type}` is not registered as a a {kind}{hint}"
+    throwErrorAt name m!"`{name} : {info.type}` is not registered as a {kind}{hint}"
   else
     throwErrorAt name m!"Unknown {kind} `{name}`{hint}"
 

--- a/tests/elab/versoDocSuggestionNoImport.lean
+++ b/tests/elab/versoDocSuggestionNoImport.lean
@@ -38,7 +38,7 @@ def testQualifiedLit2 := 1
 
 -- {lit} fails when shadowed
 /--
-error: `lit : Type` is not registered as a a role
+error: `lit : Type` is not registered as a role
 
 Hint: `lit` shadows a role. Use the full name of the shadowed role:
   L̲e̲a̲n̲.̲D̲o̲c̲.̲lit

--- a/tests/elab/versoDocs.lean
+++ b/tests/elab/versoDocs.lean
@@ -565,7 +565,7 @@ def testQualifiedLit := 1
 
 -- {lit} fails when shadowed
 /--
-error: `lit : Type` is not registered as a a role
+error: `lit : Type` is not registered as a role
 
 Hint: `lit` shadows a role. Use the full name of the shadowed role:
   L̲e̲a̲n̲.̲D̲o̲c̲.̲lit
@@ -593,7 +593,7 @@ namespace ShadowedNonBuiltin
 def r := 15
 
 /--
-error: `r : Nat` is not registered as a a role
+error: `r : Nat` is not registered as a role
 
 Hint: `r` shadows a role. Use the full name of the shadowed role:
   _̲ro̲o̲t̲_̲.̲r̲
@@ -614,7 +614,7 @@ namespace Inner
 def lit := 5
 
 /--
-error: `lit : Nat` is not registered as a a role
+error: `lit : Nat` is not registered as a role
 
 Hint: `lit` shadows a role. Use the full name of the shadowed role:
   • l̵i̵t̵D̲o̲u̲b̲l̲e̲S̲h̲a̲d̲o̲w̲e̲d̲.̲l̲i̲t̲


### PR DESCRIPTION
This PR fixes a duplicated word in an error message shown for unknown Verso docstring extensions.
