### PR TITLE
fix: isolate `postponed` in `withSynthesize`

### DIFF
--- a/src/Lean/Elab/SyntheticMVars.lean
+++ b/src/Lean/Elab/SyntheticMVars.lean
@@ -661,9 +661,8 @@ def synthesizeSyntheticMVarsUsingDefault : TermElabM Unit := do
 
 private partial def withSynthesizeImp (k : TermElabM α) (postpone : PostponeBehavior) : TermElabM α := do
   let pendingMVarsSaved := (← get).pendingMVars
-  let postponedLevelUnifs ← getPostponed
+  let postponedLevelUnifs ← getResetPostponed
   modify fun s => { s with pendingMVars := [] }
-  setPostponed {}
   try
     let a ← k
     synthesizeSyntheticMVars (postpone := postpone)

--- a/src/Lean/Elab/SyntheticMVars.lean
+++ b/src/Lean/Elab/SyntheticMVars.lean
@@ -671,7 +671,7 @@ private partial def withSynthesizeImp (k : TermElabM α) (postpone : PostponeBeh
     return a
   finally
     modify fun s => { s with pendingMVars := s.pendingMVars ++ pendingMVarsSaved }
-    setPostponed postponedLevelUnifs
+    modifyPostponed fun newPostponed => postponedLevelUnifs ++ newPostponed
 
 /--
   Execute `k`, and synthesize pending synthetic metavariables created while executing `k` are solved.

--- a/src/Lean/Elab/SyntheticMVars.lean
+++ b/src/Lean/Elab/SyntheticMVars.lean
@@ -660,16 +660,19 @@ def synthesizeSyntheticMVarsUsingDefault : TermElabM Unit := do
   synthesizeUsingDefaultLoop
 
 private partial def withSynthesizeImp (k : TermElabM α) (postpone : PostponeBehavior) : TermElabM α := do
-   let pendingMVarsSaved := (← get).pendingMVars
-   modify fun s => { s with pendingMVars := [] }
-   try
-     let a ← k
-     synthesizeSyntheticMVars (postpone := postpone)
-     if postpone == .yes then
-       synthesizeUsingDefaultLoop
-     return a
-   finally
-     modify fun s => { s with pendingMVars := s.pendingMVars ++ pendingMVarsSaved }
+  let pendingMVarsSaved := (← get).pendingMVars
+  let postponedLevelUnifs ← getPostponed
+  modify fun s => { s with pendingMVars := [] }
+  setPostponed {}
+  try
+    let a ← k
+    synthesizeSyntheticMVars (postpone := postpone)
+    if postpone == .yes then
+      synthesizeUsingDefaultLoop
+    return a
+  finally
+    modify fun s => { s with pendingMVars := s.pendingMVars ++ pendingMVarsSaved }
+    setPostponed postponedLevelUnifs
 
 /--
   Execute `k`, and synthesize pending synthetic metavariables created while executing `k` are solved.

--- a/tests/elab/13875.lean
+++ b/tests/elab/13875.lean
@@ -1,0 +1,8 @@
+/-!
+Regression test for https://github.com/leanprover/lean4/issues/13785.
+-/
+
+example (s : String) (x : Nat) : String :=
+  let := s.all (·.isAlphanum)
+  match x with
+  | _ => s


### PR DESCRIPTION
This PR fixes `withSynthesize` to reset the list of postponed universe constraints before running the action `k` and `synthesizeSyntheticMVars`. Previously, `withSynthesize` just ran `synthesizeSyntheticMVars` with all existing universe constraints, causing failures even when using `withSynthesize` with a no-op.

Closes #13875.
