### PR TITLE
fix: bug is `match` reduction at `SymM` `dsimp`

### DIFF
--- a/src/Lean/Meta/Sym/DSimp/Reduce.lean
+++ b/src/Lean/Meta/Sym/DSimp/Reduce.lean
@@ -61,9 +61,7 @@ public def dsimpMatch : DSimproc := fun e => do
   -- Iota-reduction may expose kernel `Expr.proj` terms via struct-eta,
   -- which the structural simplifier cannot consume directly.
   let e'' ← Sym.foldProjs e'
-  if isSameExpr e' e'' then
-    return .rfl
-  else
-    return .step (← share e'')
+  let e'' ← share e''
+  return .step e''
 
 end Lean.Meta.Sym.DSimp

--- a/src/Lean/Meta/Sym/Simp/ControlFlow.lean
+++ b/src/Lean/Meta/Sym/Simp/ControlFlow.lean
@@ -124,9 +124,8 @@ def simpMatch (declName : Name) : Simproc := fun e => do
   if let some e' ← reduceRecMatcher? e then
     -- Iota-reduction may expose kernel `Expr.proj` terms via struct-eta,
     -- which the structural simplifier cannot consume directly.
-    let mut e'' ← Sym.foldProjs e'
-    unless isSameExpr e' e'' do
-      e'' ← share e''
+    let e'' ← Sym.foldProjs e'
+    let e'' ← share e''
     return .step e'' (← mkEqRefl e'')
   let some info ← getMatcherInfo? declName
     | return .rfl

--- a/tests/elab/sym_dsimp_match.lean
+++ b/tests/elab/sym_dsimp_match.lean
@@ -1,0 +1,24 @@
+inductive Directive where
+  | label (s : String)
+  | instr (i : Nat)
+  | byteArray (a : ByteArray)
+
+def foo (d : Directive) :=
+  match d with
+  | .label _ => 0
+  | .instr i => i + 1
+  | .byteArray _ => 2
+
+/--
+trace: case grind
+a : Nat
+h : 0 = a
+⊢ 0 = a
+-/
+#guard_msgs in
+theorem ex (h : 0 = a) : foo (.label "start") = a := by
+  unfold foo
+  sym =>
+    dsimp
+    show_goals
+    exact h


### PR DESCRIPTION
This PR fixes a bug when reducing `match`-expressions in the `Sym.dsimp` tactic.
