### PR TITLE
perf: bail out early in `LocalContext.foldlM` when `start ≥ size`

### DIFF
--- a/src/Lean/Data/PersistentArray.lean
+++ b/src/Lean/Data/PersistentArray.lean
@@ -208,6 +208,7 @@ variable {β : Type v}
   | leaf vs, i, _, b => vs.foldlM (init := b) (start := i.toNat) f
 
 @[specialize] def foldlM (t : PersistentArray α) (f : β → α → m β) (init : β) (start : Nat := 0) : m β := do
+  if start ≥ t.size then return init
   if start == 0 then
     let b ← foldlMAux f t.root init
     t.tail.foldlM f b


### PR DESCRIPTION
This PR avoids redundant work in `LocalContext.foldlM` when the starting index is past the end of the local context, which is a hot path for tactics that fold over the suffix of a freshly extended local context.