### PR TITLE
chore: localize `unfoldReducible` cost in mvcgen' `.proj` reduction

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Reduce.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Reduce.lean
@@ -21,6 +21,16 @@ SymM-level head-redex reducer used throughout VCGen.
 -/
 
 /--
+Like `Meta.reduceProj?` but also `Sym.unfoldReducible`s the projected field when whnf
+reduced the structure. Transparency is the caller's choice.
+-/
+private def reduceProjAndUnfold? (e : Expr) : MetaM (Option Expr) := do
+  let .proj _ idx s := e | return none
+  let s' ← Lean.Meta.whnf s
+  let some f ← Lean.Meta.projectCore? s' idx | return none
+  if isSameExpr s s' then return some f else return some (← Sym.unfoldReducible f)
+
+/--
 Repeatedly reduces head redexes in `e`, cycling through the following reductions until
 no further progress is made:
 
@@ -31,11 +41,8 @@ no further progress is made:
 4. **Projection delta**: `Struct.field x` → `x.5` (unfolds projection *functions*,
    progress only if followed by proj-reduction)
 
-Returns `none` when no reduction was possible. Maintains maximal sharing via `shareCommonInc`.
-
-Note: `reduceHead?` does **not** unfold reducible definitions exposed by its reductions.
-Callers that need rule patterns to match against the unfolded form should run
-`Sym.unfoldReducible` on the result themselves; see `tryHeadReduceProg` in `Solve.lean`.
+Returns `none` when no reduction was possible. Maintains maximal sharing via `shareCommonInc`
+and the SymM no-exposed-reducibles invariant.
 -/
 public partial def reduceHead? (e : Expr) : SymM (Option Expr) :=
   withReducible <| go none e.getAppFn e.getAppRevArgs
@@ -62,10 +69,7 @@ public partial def reduceHead? (e : Expr) : SymM (Option Expr) :=
         else
           pure lastReduction
       | .proj .. =>
-        -- whnf at `instances` transparency: unfold `instMyAddInt32` (an instance) to
-        -- expose its `MyAdd.mk` constructor so `reduceProj?` can project the field,
-        -- but do not unfold arbitrary user definitions.
-        match ← withReducibleAndInstances (reduceProj? f) with
+        match ← withReducibleAndInstances <| reduceProjAndUnfold? f with
         | some f' =>
           let f' ← Sym.shareCommonInc f'
           let e' := mkAppRev f' rargs

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -159,10 +159,6 @@ private def tryHeadReduceProg (goal : MVarId) (head H σs ent : Expr) (args : Ar
     (wpConst m ps instWP α e f : Expr) : VCGenM (Option MVarId) := do
   unless f matches .proj .. do return none
   let some e' ← reduceHead? e | return none
-  -- `reduceHead?` does not unfold reducible definitions; normalize the result here so
-  -- abbrevs introduced by the instance body match `@[spec]` rule patterns.
-  let e' ← Sym.unfoldReducible e'
-  let e' ← Sym.shareCommonInc e'
   return some (← replaceProgDefEq goal head H σs ent args wpConst m ps instWP α e')
 
 /-- Look up a registered `@[spec]` theorem for the program head and apply its cached


### PR DESCRIPTION
This PR factors the whnf-based projection step used inside `mvcgen'`'s head reducer into a new `reduceProjAndUnfold?` helper that `unfoldReducible`s the projected field only when whnf reduced the structure. The outer `Sym.unfoldReducible` call in `tryHeadReduceProg` is no longer needed, so the per-step cost of normalizing abbrevs is proportional to the small unfolded instance body rather than the whole program expression.

Follow-up to #13881.