### PR TITLE
feat: collect local mvcgen' specs from in-scope hypotheses

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
@@ -9,6 +9,7 @@ prelude
 public import Lean.Elab.Tactic.Do.VCGen.Basic
 public import Lean.Elab.Tactic.Do.Internal.VCGen.SpecDB
 public import Lean.Meta.Sym.Apply
+public import Lean.Meta.Sym.Simp.DiscrTree
 public import Lean.Meta.Sym.Simp.SimpM
 public import Lean.Meta.Tactic.Grind.Types
 
@@ -38,7 +39,6 @@ public def VCGen.PreTac.isGrind : VCGen.PreTac → Bool
   | _ => false
 
 public structure VCGen.Context where
-  specThms : SpecTheoremsNew
   /-- The backward rule for `SPred.entails_cons_intro`. -/
   entailsConsIntroRule : BackwardRule
   /-- The backward rule for `SPred.entails_nil_pure_intro`. Preferred over `entails_nil_intro`
@@ -105,6 +105,15 @@ public structure VCGen.Context where
   `invariants` clause is provided or in `invariants?` (suggest) mode (handled separately). -/
   invariantAlts : Std.HashMap Nat Syntax := {}
 
+public structure VCGen.Scope where
+  /-- Spec database in scope: globals plus locals from in-scope hypotheses. -/
+  specs : SpecTheoremsNew
+  /-- `__do_jp` fvars currently in scope. -/
+  jps : FVarIdMap JumpSiteInfo := {}
+  /-- Index of the next local declaration to consider for local specs. -/
+  nextDeclIdx : Nat := 0
+  deriving Inhabited
+
 public structure VCGen.State where
   /--
   A cache mapping registered SpecThms to their backward rule to apply.
@@ -134,12 +143,6 @@ public structure VCGen.State where
   -/
   simpState : Sym.Simp.State := {}
   /--
-  Map from `__do_jp` fvar id to its `JumpSiteInfo`. Populated when `tryLetIntro`
-  registers a join point (`Context.useJP = true`); consulted by `tryFvarZeta` /
-  `tryJumpSite` to short-circuit zeta-unfolding at call sites.
-  -/
-  jps : FVarIdMap JumpSiteInfo := {}
-  /--
   Remaining VC-generation steps. Initialized from `Context.config.stepLimit` (or
   `.unlimited` when no limit is set). Decremented at each successful program-shape
   step (`tryLetHoist`, `trySplit`, `tryFvarZeta`, `applySpec`). When exhausted,
@@ -159,14 +162,30 @@ public abbrev VCGenM := ReaderT VCGen.Context (StateRefT VCGen.State Grind.Grind
 
 namespace VCGen
 
-/-- Register a join-point `JumpSiteInfo` for the given fvar. Called when a
-`let __do_jp := …` is detected as a shared continuation. -/
-public def registerJP (fv : FVarId) (info : JumpSiteInfo) : VCGenM Unit :=
-  modify fun s => { s with jps := s.jps.insert fv info }
+public def Scope.registerJP (s : Scope) (fv : FVarId) (info : JumpSiteInfo) : Scope :=
+  { s with jps := s.jps.insert fv info }
 
-/-- Look up a previously-registered join point by fvar id. -/
-public def knownJP? (fv : FVarId) : VCGenM (Option JumpSiteInfo) :=
-  return (← get).jps.get? fv
+public def Scope.knownJP? (s : Scope) (fv : FVarId) : Option JumpSiteInfo :=
+  s.jps.get? fv
+
+public def Scope.insertSpec (s : Scope) (thm : SpecTheoremNew) : Scope :=
+  { s with specs := { s.specs with specs := Sym.insertPattern s.specs.specs thm.pattern thm } }
+
+/-- Walk `goal`'s local context from `scope.nextDeclIdx` onward, registering any
+spec-shaped hypotheses as local specs. Advances `nextDeclIdx` to the current
+context size so siblings share work. -/
+public def Scope.collectLocalSpecs (scope : Scope) (goal : MVarId) : VCGenM Scope :=
+  goal.withContext do
+    let lctx ← getLCtx
+    if scope.nextDeclIdx == lctx.decls.size then return scope
+    let scope ← lctx.foldlM (init := scope) (start := scope.nextDeclIdx) fun scope decl => do
+      if decl.isAuxDecl then return scope
+      try
+        if let some thm ← mkSpecTheoremNew (.local decl.fvarId) (eval_prio low) then
+          return scope.insertSpec thm
+      catch _ => pure ()
+      return scope
+    return { scope with nextDeclIdx := lctx.decls.size }
 
 /-- True iff fuel has been exhausted (`Fuel.limited 0`). -/
 public def outOfFuel : VCGenM Bool :=

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
@@ -122,23 +122,26 @@ public def emitVC (goal : Grind.Goal) : VCGenM Unit := do
       pure mvarId
     else
       pure goal.mvarId
-  let goal := { goal with mvarId := mvarId }
+  let goal := { goal with mvarId }
   for newGoal in (← (← read).preTac.run goal) do
     newGoal.mvarId.setKind .syntheticOpaque
     vcs := vcs.push newGoal
   modify fun s => { s with vcs := s.vcs ++ vcs }
 
-public def work (goal : Grind.Goal) : VCGenM Unit := do
+private structure WorkItem where
+  goal : Grind.Goal
+  scope : Scope
+
+public def work (scope : Scope) (goal : Grind.Goal) : VCGenM Unit := do
   let mvarId ← preprocessMVar goal.mvarId
-  let goal := { goal with mvarId }
-  let mut worklist := #[goal] -- worklist is LIFO (popped from the back)
-  while let some goal := worklist.back? do
+  let mut worklist : Array WorkItem := #[{ goal := { goal with mvarId }, scope }]
+  while let some s := worklist.back? do
     worklist := worklist.pop
+    let goal := s.goal
     if ← outOfFuel then
       emitVC goal
       continue
-    let res ← solve goal.mvarId
-    match res with
+    match ← solve s.scope goal.mvarId with
     | .noEntailment .. | .noProgramFoundInTarget .. =>
       emitVC goal
     | .noSpecFoundForProgram prog monad thms =>
@@ -151,7 +154,7 @@ public def work (goal : Grind.Goal) : VCGenM Unit := do
         emitVC goal
     | .noStrategyForProgram prog => goal.mvarId.withContext do
       throwError "Did not know how to decompose weakest precondition for {prog}"
-    | .goals subgoals =>
+    | .goals scope subgoals =>
       -- Handle invariant subgoals eagerly here, so that VC subgoals popped
       -- from the worklist later see the invariant MVar already assigned.
       -- Non-invariant subgoals go to the worklist as usual and will eventually go through `emitVC`.
@@ -163,7 +166,8 @@ public def work (goal : Grind.Goal) : VCGenM Unit := do
           (← read).preTac.processHypotheses goal
         else
           pure goal
-      worklist := worklist ++ subgoals.reverse.map (fun sg => { goal with mvarId := sg })
+      worklist := worklist ++ subgoals.reverse.map (fun mv =>
+        { goal := { goal with mvarId := mv }, scope })
 
 public structure Result where
   /-- All invariant goals emitted during VC generation, in emit order. The MVarId at
@@ -187,10 +191,10 @@ Return the VCs and invariant goals.
 
 `stepLimit?`, when `some n`, seeds the fuel counter to `n`; when `none`, fuel is unlimited.
 -/
-public partial def run (goal : Grind.Goal) (ctx : Context) (stepLimit? : Option Nat := none) :
-    Grind.GrindM Result := do
+public partial def run (goal : Grind.Goal) (ctx : Context) (scope : VCGen.Scope)
+    (stepLimit? : Option Nat := none) : Grind.GrindM Result := do
   let initState : State := { fuel := match stepLimit? with | some n => .limited n | none => .unlimited }
-  let ((), state) ← StateRefT'.run (ReaderT.run (work goal) ctx) initState
+  let ((), state) ← StateRefT'.run (ReaderT.run (work scope goal) ctx) initState
   _ ← state.invariants.mapIdxM fun idx mv => do
     mv.setTag (Name.mkSimple ("inv" ++ toString (idx + 1)))
   _ ← state.vcs.mapIdxM fun idx g => do

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
@@ -40,10 +40,11 @@ namespace VCGen
 /--
 Parse the optional `[...]` argument list for `mvcgen'`, partitioning entries into
 spec theorems and simp lemmas. Follows the same approach as
-`Lean.Elab.Tactic.Do.VCGen.mkSpecContext`: each entry is first tried as a spec theorem,
+`Lean.Elab.Tactic.Do.VCGen.mkContext`: each entry is first tried as a spec theorem,
 and on failure falls back to a simp/unfold lemma processed via `mkSimpContext`.
 -/
-public def mkSpecContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := false) : TermElabM VCGen.Context := do
+public def mkContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := false) :
+    TermElabM (VCGen.Context × VCGen.Scope) := do
   let mut specThms ← getSpecTheorems
   let mut simpStuff := #[]
   let mut starArg := false
@@ -123,8 +124,7 @@ public def mkSpecContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := fal
   let tripleOfEntailsWPRule ← mkBackwardRuleFromDecl ``Triple.of_entails_wp
   let andIntroRule ← mkBackwardRuleFromDecl ``And.intro
   let specThmsNew ← SymM.run <| migrateSpecTheoremsDatabase specThms simpThms
-  return {
-    specThms := specThmsNew,
+  let ctx : VCGen.Context := {
     entailsConsIntroRule,
     entailsNilPureIntroRule,
     entailsNilIntroRule,
@@ -142,6 +142,7 @@ public def mkSpecContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := fal
     tripleOfEntailsWPRule,
     andIntroRule,
   }
+  return (ctx, { specs := specThmsNew })
 
 end VCGen
 
@@ -298,6 +299,7 @@ private def elabRemainingInvariants (alts : Std.HashMap Nat Syntax)
 private structure ParsedArgs where
   config : VCGen.Config
   ctx : VCGen.Context
+  scope : VCGen.Scope
   params : Grind.Params
   invariantAlts? : Option (Std.HashMap Nat Syntax)
 
@@ -313,7 +315,7 @@ private def parseArgs (stx : Syntax) (goal : MVarId) : TermElabM ParsedArgs := g
   -- `case vcN bs* =>` patterns line up. Re-enabling on opt-in would require detecting
   -- explicit `(elimLets := true)` at the syntax level (upstream `Config` can't
   -- distinguish "default true" from "user-set true"); not yet wired.
-  let ctx ← VCGen.mkSpecContext stx[2] goal
+  let (ctx, scope) ← VCGen.mkContext stx[2] goal
   let hypSimpMethods ← elabSimplifyingAssumptions stx[4]
   let (preTac, params) ← elabPreTac goal stx[5]
   let invariantAlts? ← parseInvariantMap stx[3]
@@ -324,7 +326,7 @@ private def parseArgs (stx : Syntax) (goal : MVarId) : TermElabM ParsedArgs := g
     errorOnMissingSpec := config.errorOnMissingSpec,
     debug := config.debug,
     invariantAlts := invariantAlts?.getD {} }
-  return { config, ctx, params, invariantAlts? }
+  return { config, ctx, scope, params, invariantAlts? }
 
 /-- `mvcgen'` step inside `sym => …` blocks. -/
 @[builtin_grind_tactic Lean.Parser.Tactic.Grind.mvcgen']
@@ -334,7 +336,7 @@ def evalSymMVCGen' : Lean.Elab.Tactic.Grind.GrindTactic := fun stx => do
   if args.invariantAlts?.isNone && !stx[3].isNone then
     throwError "`mvcgen' invariants?` (suggest mode) is not supported inside `sym => …` blocks"
   let result ← Lean.Elab.Tactic.Grind.liftGrindM do
-    let result ← VCGen.run goal args.ctx args.config.stepLimit
+    let result ← VCGen.run goal args.ctx args.scope args.config.stepLimit
     if let some alts := args.invariantAlts? then
       elabRemainingInvariants alts result.invariants result.inlineHandledInvariants
     return result
@@ -358,7 +360,7 @@ public def elabMVCGen' : Tactic := fun stx => withMainContext do
   let goal ← getMainGoal
   let args ← parseArgs stx goal
   let result ← Grind.GrindM.run (params := args.params) do
-    let result ← VCGen.run (← Grind.mkGoalCore goal) args.ctx args.config.stepLimit
+    let result ← VCGen.run (← Grind.mkGoalCore goal) args.ctx args.scope args.config.stepLimit
     if let some alts := args.invariantAlts? then
       elabRemainingInvariants alts result.invariants result.inlineHandledInvariants
     return result

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -39,8 +39,8 @@ public inductive SolveResult where
   Candidates were `thms`, but none of them matched the monad.
   -/
   | noSpecFoundForProgram (e : Expr) (monad : Expr) (thms : Array SpecTheoremNew)
-  /-- Successfully decomposed the goal. These are the subgoals. -/
-  | goals (subgoals : List MVarId)
+  /-- Successfully decomposed the goal. These are the subgoals, sharing `scope`. -/
+  | goals (scope : VCGen.Scope) (subgoals : List MVarId)
 
 private def isDuplicable (e : Expr) : Bool := match e with
   | .bvar .. | .mvar .. | .fvar .. | .const .. | .lit .. | .sort .. => true
@@ -49,10 +49,9 @@ private def isDuplicable (e : Expr) : Bool := match e with
   | .app .. => e.isAppOf ``OfNat.ofNat
 
 /-- Strategy 1: introduce binders if the target is a `∀`. -/
-private def tryForallIntro (goal : MVarId) (target : Expr) :
-    VCGenM (Option SolveResult) := do
+private def tryForallIntro (goal : MVarId) (target : Expr) : VCGenM (Option MVarId) := do
   unless target.isForall do return none
-  return some <| .goals [← introsSimp goal m!"foralls in `solve`"]
+  return some (← introsSimp goal m!"foralls in `solve`")
 
 /-- Strategy 7a: zeta-substitute (if the bound value is duplicable) or introduce a
 top-level `let` in the target.
@@ -63,8 +62,7 @@ at the point where the upstream `mvcgen.onJoinPoint` would set up shared-continu
 proof construction. That port (Phase 6 of the plan) is not yet done; we throw an
 explicit error here so that enabling `jp := true` is honest about the gap rather
 than silently ignored. -/
-private def tryLetIntro (goal : MVarId) (target : Expr) :
-    VCGenM (Option SolveResult) := do
+private def tryLetIntro (goal : MVarId) (target : Expr) : VCGenM (Option MVarId) := do
   unless target.isLet do return none
   if (← read).useJP && Lean.Elab.Tactic.Do.isJP target.letName! then
     if target.letValue!.isLambda then
@@ -76,48 +74,42 @@ private def tryLetIntro (goal : MVarId) (target : Expr) :
   if isDuplicable target.letValue! then
     trace[Elab.Tactic.Do.vcgen] "let-zeta-dup: {target.letName!}"
     let target' ← Sym.instantiateRevBetaS target.letBody! #[target.letValue!]
-    return some <| .goals [← goal.replaceTargetDefEq target']
+    return some (← goal.replaceTargetDefEq target')
   else
     trace[Elab.Tactic.Do.vcgen] "let-intro: {target.letName!}"
-    return some <| .goals [← introsSimp goal m!"let-intro: {target.letName!}"]
+    return some (← introsSimp goal m!"let-intro: {target.letName!}")
 
 /-- Strategy 2: unfold a `Triple` target into the underlying `P ⊢ₛ wp⟦x⟧ Q`. -/
-private def tryTripleUnfold (goal : MVarId) (target : Expr) :
-    VCGenM (Option SolveResult) := do
+private def tryTripleUnfold (goal : MVarId) (target : Expr) : VCGenM (Option MVarId) := do
   unless target.getAppFn.isConstOf ``Triple do return none
-  let goal ← tripleOfWP goal
-  return some <| .goals [goal]
+  return some (← tripleOfWP goal)
 
 /-- Strategy 4: eta-expand a lambda RHS via `entails_cons_intro`. -/
-private def tryTargetLambdaIntro (goal : MVarId) (T : Expr) :
-    VCGenM (Option SolveResult) := do
+private def tryTargetLambdaIntro (goal : MVarId) (T : Expr) : VCGenM (Option MVarId) := do
   unless T.isLambda do return none
   let .goals [goal] ← (← read).entailsConsIntroRule.applyChecked goal
     | throwError "Applying {.ofConstName ``SPred.entails_cons_intro} to {← goal.getType} failed. It should not."
-  return some <| .goals [goal]
+  return some goal
 
 /-- Strategy 5: head-reduce `H` and/or `T` and replace the target if either side reduced. -/
-private def tryHeadReduceHT (goal : MVarId) (ent σs H T : Expr) :
-    VCGenM (Option SolveResult) := do
+private def tryHeadReduceHT (goal : MVarId) (ent σs H T : Expr) : VCGenM (Option MVarId) := do
   let H? ← reduceHead? H
   let T? ← reduceHead? T
   unless H?.isSome || T?.isSome do return none
-  let goal ← goal.replaceTargetDefEq (← Sym.Internal.mkAppS₃ ent σs (H?.getD H) (T?.getD T))
-  return some <| .goals [goal]
+  return some (← goal.replaceTargetDefEq (← Sym.Internal.mkAppS₃ ent σs (H?.getD H) (T?.getD T)))
 
 /-- Strategy 6: when the target's RHS isn't `wp⟦e⟧ Q s₁ ... sₙ`, attempt syntactic
-reflexivity, fall back to `solveSPredEntails`, otherwise classify as
-`.noProgramFoundInTarget`. -/
-private def tryRflOrSPred (goal : MVarId) (ent σs H T : Expr) :
-    VCGenM SolveResult := do
+reflexivity, fall back to `solveSPredEntails`. Returns `none` when neither applies. -/
+private def trySolveSPredEntails (goal : MVarId) (ent σs H T : Expr) :
+    VCGenM (Option (List MVarId)) := do
   trace[Elab.Tactic.Do.vcgen] "Trying rfl {goal}"
   if ← withAssignableSyntheticOpaque <| isDefEqS H T then
     trace[Elab.Tactic.Do.vcgen] "Solved by rfl {goal}"
     goal.assign (mkApp2 (mkConst ``SPred.entails.refl ent.constLevels!) σs H)
-    return .goals []
+    return some []
   if let some goal ← solveSPredEntails goal then
-    return .goals [goal]
-  return .noProgramFoundInTarget T
+    return some [goal]
+  return none
 
 /-- Replace the program in `goal`'s target with `e'` (which must be definitionally equal). -/
 private def replaceProgDefEq (goal : MVarId) (head H σs ent : Expr) (args : Array Expr)
@@ -129,7 +121,7 @@ private def replaceProgDefEq (goal : MVarId) (head H σs ent : Expr) (args : Arr
 
 /-- Hoist a `letE` from the program head to the goal target. -/
 private def tryLetHoist (goal : MVarId) (head H σs ent : Expr) (args : Array Expr)
-    (wpConst m ps instWP α e f : Expr) : VCGenM (Option SolveResult) := do
+    (wpConst m ps instWP α e f : Expr) : VCGenM (Option MVarId) := do
   let .letE x ty val body nonDep := f | return none
   trace[Elab.Tactic.Do.vcgen] "let-hoist: {x}"
   let e' ← mkAppRevS body e.getAppRevArgs  -- body still has #0 for the let-bound var
@@ -137,62 +129,62 @@ private def tryLetHoist (goal : MVarId) (head H σs ent : Expr) (args : Array Ex
   let T' ← mkAppNS head (args.set! 2 wp')
   let target' ← mkAppS₃ ent σs H T'
   let hoisted := Expr.letE x ty val target' nonDep
-  return some <| .goals [← goal.replaceTargetDefEq hoisted]
+  return some (← goal.replaceTargetDefEq hoisted)
 
 /-- Split an `ite`/`dite`/match program head, or iota-reduce if the discriminant is
 constructor-shaped. Returns `none` when the program isn't a split. -/
 private def trySplit (goal : MVarId) (head H σs ent : Expr) (args : Array Expr)
-    (wpConst m ps instWP α e : Expr) (excessArgs : Array Expr) : VCGenM (Option SolveResult) := do
+    (wpConst m ps instWP α e : Expr) (excessArgs : Array Expr) : VCGenM (Option (List MVarId)) := do
   let some info ← liftMetaM <| Lean.Elab.Tactic.Do.getSplitInfo? e | return none
   -- Try iota reduction first (reduces matcher/recursor with concrete discriminant)
   if let some e' ← liftMetaM <| withReducible <| reduceRecMatcher? e then
-    return some <| .goals [← replaceProgDefEq goal head H σs ent args wpConst m ps instWP α
-                              (← shareCommonInc e')]
+    return some [← replaceProgDefEq goal head H σs ent args wpConst m ps instWP α
+                    (← shareCommonInc e')]
   let rule ← mkBackwardRuleFromSplitInfoCached info m σs ps instWP excessArgs
   let ApplyResult.goals goals ← rule.applyChecked goal m!"split rule for{indentExpr e}"
     | throwError "Failed to apply split rule for {indentExpr e}"
-  return some <| .goals goals
+  return some goals
 
 /-- Zeta-unfold a local `let`-bound fvar that appears as the program head. -/
 private def tryFvarZeta (goal : MVarId) (head H σs ent : Expr) (args : Array Expr)
-    (wpConst m ps instWP α e f : Expr) : VCGenM (Option SolveResult) := do
+    (wpConst m ps instWP α e f : Expr) : VCGenM (Option MVarId) := do
   let some fvarId := f.fvarId? | return none
   let some val ← fvarId.getValue? | return none
   trace[Elab.Tactic.Do.vcgen] "fvar-zeta: {(← fvarId.getUserName)}"
   let e' ← shareCommonInc (val.betaRev e.getAppRevArgs)
-  return some <| .goals [← replaceProgDefEq goal head H σs ent args wpConst m ps instWP α e']
+  return some (← replaceProgDefEq goal head H σs ent args wpConst m ps instWP α e')
 
 /-- Reduce a kernel `.proj` head in the program `e`. -/
 private def tryHeadReduceProg (goal : MVarId) (head H σs ent : Expr) (args : Array Expr)
-    (wpConst m ps instWP α e f : Expr) : VCGenM (Option SolveResult) := do
+    (wpConst m ps instWP α e f : Expr) : VCGenM (Option MVarId) := do
   unless f matches .proj .. do return none
   let some e' ← reduceHead? e | return none
   -- `reduceHead?` does not unfold reducible definitions; normalize the result here so
   -- abbrevs introduced by the instance body match `@[spec]` rule patterns.
   let e' ← Sym.unfoldReducible e'
   let e' ← Sym.shareCommonInc e'
-  return some <| .goals [← replaceProgDefEq goal head H σs ent args wpConst m ps instWP α e']
+  return some (← replaceProgDefEq goal head H σs ent args wpConst m ps instWP α e')
 
 /-- Look up a registered `@[spec]` theorem for the program head and apply its cached
 backward rule. Falls back to `.noSpecFoundForProgram` / `.noStrategyForProgram` when no
 spec applies. -/
-private def applySpec (goal : MVarId) (e : Expr) (excessArgs : Array Expr)
+private def applySpec (scope : VCGen.Scope) (goal : MVarId) (e : Expr) (excessArgs : Array Expr)
     (m σs ps instWP : Expr) : VCGenM SolveResult := do
   let f := e.getAppFn
   if f.isConst || f.isFVar then
     trace[Elab.Tactic.Do.vcgen] "Applying a spec for {e}. Excess args: {excessArgs}"
-    match ← (← read).specThms.findSpecs e with
+    match ← scope.specs.findSpecs e with
     | .error thms => return .noSpecFoundForProgram e m thms
     | .ok thm =>
     trace[Elab.Tactic.Do.vcgen] "Spec for {e}: {thm.proof}"
     if let some goal ← neededStateIntro thm goal excessArgs then
       trace[Elab.Tactic.Do.vcgen] "Needed state intro. Retrying."
-      return .goals [goal]
+      return .goals scope [goal]
     let rule ← mkBackwardRuleFromSpecCached thm m σs ps instWP excessArgs
     trace[Elab.Tactic.Do.vcgen] "Rule type: {← Meta.inferType rule.expr}"
     let ApplyResult.goals goals ← rule.applyChecked goal m!"spec rule for{indentExpr e}"
       | throwError "Failed to apply rule {rule.expr} for {indentExpr e}"
-    return .goals goals
+    return .goals scope goals
   return .noStrategyForProgram e
 
 /--
@@ -219,26 +211,27 @@ The function performs the following steps in order:
 10. **Spec application**: Look up a registered `@[spec]` theorem (triple or simp) and apply
     its cached backward rule.
 -/
-public def solve (goal : MVarId) : VCGenM SolveResult := goal.withContext do
+public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := goal.withContext do
   let target ← goal.getType
   trace[Elab.Tactic.Do.vcgen] "🎯 Target: {target}"
   -- Phase 1: simplify `target` until it is of the form `H ⊢ₛ T`.
-  if let some r ← tryForallIntro goal target then return r
-  if let some r ← tryLetIntro goal target then return r
-  if let some r ← tryTripleUnfold goal target then return r
-  if let some goals ← solvePostCondEntails goal then return .goals goals
+  if let some g ← tryForallIntro goal target then return .goals scope [g]
+  if let some g ← tryLetIntro goal target then return .goals scope [g]
+  if let some g ← tryTripleUnfold goal target then return .goals scope [g]
+  if let some gs ← solvePostCondEntails goal then return .goals scope gs
 
   let_expr ent@SPred.entails σs H T := target | return .noEntailment target
   -- Phase 2: simplify `H`/`T` so that neither is a head redex and `T` is of the form
   -- `wp⟦e⟧ Q s₁ ... sₙ`.
-  if let some r ← tryTargetLambdaIntro goal T then return r
-  if let some r ← tryHeadReduceHT goal ent σs H T then return r
+  if let some g ← tryTargetLambdaIntro goal T then return .goals scope [g]
+  if let some g ← tryHeadReduceHT goal ent σs H T then return .goals scope [g]
 
   -- Look for program syntax in `T`.
   let (head, args) := T.withApp fun head args => (head, args) -- (head, args) for nicer stack traces
 
   unless head.isConstOf ``PredTrans.apply do
-    return ← tryRflOrSPred goal ent σs H T
+    if let some gs ← trySolveSPredEntails goal ent σs H T then return .goals scope gs
+    return .noProgramFoundInTarget T
 
   let wp := args[2]!
   let_expr wpConst@WP.wp m ps instWP α e := wp | return .noProgramFoundInTarget T
@@ -255,28 +248,33 @@ public def solve (goal : MVarId) : VCGenM SolveResult := goal.withContext do
   -- `VCGen.burnOne` are gathered here rather than scattered inside the helpers.
 
   -- Let-expressions: hoist to top of goal
-  if let some r ← tryLetHoist goal head H σs ent args wpConst m ps instWP α e f then
+  if let some g ← tryLetHoist goal head H σs ent args wpConst m ps instWP α e f then
     VCGen.burnOne
-    return r
+    return .goals scope [g]
+
+  -- Collect new local specs before any strategy that may emit multiple subgoals
+  -- (`trySplit`) or apply a registered spec (`applySpec`). Single-goal strategies
+  -- above this point don't need the updated scope.
+  let scope ← scope.collectLocalSpecs goal
 
   -- Split ite/dite/match (or iota-reduce if discriminant is concrete)
-  if let some r ← trySplit goal head H σs ent args wpConst m ps instWP α e excessArgs then
+  if let some gs ← trySplit goal head H σs ent args wpConst m ps instWP α e excessArgs then
     VCGen.burnOne
-    return r
+    return .goals scope gs
 
   -- Zeta-unfold local let bindings on demand
-  if let some r ← tryFvarZeta goal head H σs ent args wpConst m ps instWP α e f then
+  if let some g ← tryFvarZeta goal head H σs ent args wpConst m ps instWP α e f then
     VCGen.burnOne
-    return r
+    return .goals scope [g]
 
   -- Reduce kernel `.proj` heads in the program (e.g., `instAddNat.1 a b`).
-  if let some r ← tryHeadReduceProg goal head H σs ent args wpConst m ps instWP α e f then
+  if let some g ← tryHeadReduceProg goal head H σs ent args wpConst m ps instWP α e f then
     VCGen.burnOne
-    return r
+    return .goals scope [g]
 
   -- Apply registered specifications, or fall through to `.noStrategyForProgram`.
   VCGen.burnOne
-  applySpec goal e excessArgs m σs ps instWP
+  applySpec scope goal e excessArgs m σs ps instWP
 
 end VCGen
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
@@ -8,8 +8,9 @@ module
 prelude
 public import Lean.Elab.Tactic.Do.Attr
 public import Lean.Meta.Sym.Pattern
-import Lean.Meta.Sym.Simp.DiscrTree
 public import Lean.Meta.DiscrTree.Util
+import Lean.Meta.Sym.Simp.DiscrTree
+import Lean.Meta.Sym.Util
 
 open Lean Meta Elab Tactic Sym
 open Lean.Elab.Tactic.Do.SpecAttr
@@ -94,26 +95,26 @@ public def mkTriplePatternFromExpr (expr : Expr) (levelParams : List Name := [])
     let_expr Triple _m _ps _inst _α prog _P _Q := type | throwError "conclusion is not a Triple {indentExpr type}"
     return (prog, ())
 
-public def mkSpecTheoremNew (proof : SpecProof) (prio : Nat) : SymM SpecTheoremNew := do
+public def mkSpecTheoremNew (proof : SpecProof) (prio : Nat) : SymM (Option SpecTheoremNew) := do
   -- cf. mkSimpTheoremCore
   let (levelParams, expr) ← proof.getProof
   let type ← Meta.inferType expr
   let type ← instantiateMVars type
-  unless (← isProp type) do
-    throwError "invalid 'spec', proposition expected{indentExpr type}"
+  unless type.getForallBody.getAppFn.isConstOf ``Triple do
+    return none
   let pattern ← mkTriplePatternFromExpr expr levelParams
   withNewMCtxDepth do
-  let (xs, _, type) ← withSimpGlobalConfig (forallMetaTelescopeReducing type)
+  let (xs, _, type) ← withSimpGlobalConfig (forallMetaTelescope type)
   let type ← whnfR type
   let_expr c@Triple _m ps _inst _α _prog P _Q := type
-    | throwError "unexpected kind of spec theorem; not a triple{indentExpr type}"
+    | throwError "{type} was not a Triple. Should not happen with the previous tests in place."
   -- beta potential of `P` describes how many times we want to `mintro ∀s`, that is,
   -- *eta*-expand the goal.
   let σs := mkApp (mkConst ``PostShape.args [c.constLevels![0]!]) ps
   let etaPotential ← computeMVarBetaPotentialForSPred xs σs P
   -- logInfo m!"Beta potential {etaPotential} for {P}"
   -- logInfo m!"mkSpecTheorem: {keys}, proof: {proof}"
-  return { pattern, proof, kind := .triple etaPotential, priority := prio }
+  return some { pattern, proof, kind := .triple etaPotential, priority := prio }
 
 /--
 Eta-expand a pattern for a function-level equation.
@@ -179,7 +180,8 @@ public def migrateSpecTheoremsDatabase (database : SpecTheorems) (simpThms : Sim
   let mut specs : DiscrTree SpecTheoremNew := DiscrTree.empty
   for spec in database.specs.values do
     if database.isErased spec.proof then continue
-    let newSpec ← mkSpecTheoremNew spec.proof spec.priority
+    let some newSpec ← mkSpecTheoremNew spec.proof spec.priority
+      | throwError "could not migrate spec theorem {spec.proof}"
     specs := Sym.insertPattern specs newSpec.pattern newSpec
   -- Migrate simp spec theorems (equational lemmas registered via `@[spec]`)
   for simpThm in simpThms.post.values do

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Util.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Util.lean
@@ -97,8 +97,7 @@ public def introsSimp (mvarId : MVarId) (errorMsg : MessageData) : VCGenM MVarId
       return mvarId
     else
       throwError m!"Failed to intro on {mvarId}\nContext: {errorMsg}."
-  | .goal _ mvarId' =>
-    return mvarId'
+  | .goal _ mvarId' => return mvarId'
 
 /-- Internalize pending hypotheses into the E-graph for sharing before forking to multiple subgoals.
 If `processHypotheses` discovers a contradiction (`inconsistent = true`), the E-graph state

--- a/tests/bench/mvcgen/sym/test_do_logic.lean
+++ b/tests/bench/mvcgen/sym/test_do_logic.lean
@@ -642,3 +642,25 @@ example (a : UInt64) :
   mvcgen' (errorOnMissingSpec := false) [MyShl.shl, MyAddU.add]
 
 end RflReducibility
+
+namespace LocalSpec
+
+def foo (x : Id Nat → Id Nat) : Id Nat := do
+  let r₁ ← x (pure 42)
+  let r₂ ← x (pure 26)
+  pure (r₁ + r₂)
+
+theorem foo_spec
+    (x : Id Nat → Id Nat)
+    (x_spec : ∀ (k : Id Nat) (_ : ⦃⌜True⌝⦄ k ⦃⇓r => ⌜r % 2 = 0⌝⦄), ⦃⌜True⌝⦄ x k ⦃⇓r => ⌜r % 2 = 0⌝⦄) :
+    ⦃⌜True⌝⦄ foo x ⦃⇓r => ⌜r % 2 = 0⌝⦄ := by
+  mvcgen' [foo, x_spec] with grind
+
+def bar (k : Id Nat) : Id Nat := do
+  let r ← k
+  if r > 30 then return 12 else return r
+
+example : ⦃⌜True⌝⦄ foo bar ⦃⇓r => ⌜r % 2 = 0⌝⦄ := by
+  mvcgen' [foo_spec, bar] with grind
+
+end LocalSpec


### PR DESCRIPTION
This PR teaches `mvcgen'` to register Triple-shaped local hypotheses as specs as they come into scope during VC generation. This is an existing feature of `mvcgen`.

Internally, the spec database now lives in a per-subgoal `VCGen.Scope` carried alongside each `Grind.Goal` in the worklist (`VCGen.WorkItem`). `Scope.collectLocalSpecs` walks the local context past a `nextDeclIdx` counter (à la `Grind.processHypotheses`) and inserts any Triple-shaped fvars. It runs once per `solve` iteration between `tryLetHoist` and `trySplit`, so it precedes every spec lookup and every multi-subgoal step. Most strategies are scope-agnostic and return `VCGenM (Option MVarId)`; only `applySpec` reads `scope.specs`. The perf regression of the earlier attempt is mitigated by delaying `Sym.unfoldReducible` in `mkSpecTheoremNew` so non-Triple-shaped types are rejected by the cheap structural check before any reducible-unfolding work is done.