### PR TITLE
fix: recover theorem-backed grind? suggestions without regressing stable output

### DIFF
--- a/src/Lean/Elab/Tactic/Grind/Main.lean
+++ b/src/Lean/Elab/Tactic/Grind/Main.lean
@@ -10,6 +10,7 @@ public import Lean.Meta.Tactic.TryThis
 public import Lean.Elab.Tactic.Grind.Config
 public import Lean.LibrarySuggestions.Basic
 import Lean.Meta.Tactic.Grind.SimpUtil
+import Lean.Meta.Tactic.Grind.EMatchAction
 import Lean.Elab.Tactic.Grind.Param
 import Lean.Meta.Tactic.Grind.Finish
 import Lean.Meta.Tactic.Grind.CollectParams
@@ -393,6 +394,8 @@ def evalGrindTraceCore (stx : Syntax) (trace := true) (verbose := true) (useSorr
     | _ => return true
   let mvarId ← getMainGoal
   let params ← mkGrindParams config only paramStxs mvarId
+  let params := if trace then { params with config.markInstances := true } else params
+  let config := params.config
   Grind.withProtectedMCtx config mvarId fun mvarId' => do
     let (tacs, _) ← Grind.GrindTacticM.runAtGoal mvarId' params do
       let finish ← Grind.Action.mkFinish
@@ -411,7 +414,9 @@ def evalGrindTraceCore (stx : Syntax) (trace := true) (verbose := true) (useSorr
         match (← finish.run goal) with
         | .closed seq =>
           let configStx' := filterSuggestionsAndLocalsFromGrindConfig configStx
-          let tacs ← Grind.mkGrindOnlyTactics configStx' seq termParamStxs
+          let proof ← instantiateMVars (mkMVar goal.mvarId)
+          let usedThms := Grind.Action.collect proof (← get).instanceMap
+          let tacs ← Grind.mkGrindOnlyTacticsUsingTheorems configStx' seq usedThms termParamStxs
           let seq := Grind.Action.mkGrindSeq seq
           let tac ← `(tactic| grind $configStx':optConfig => $seq:grindSeq)
           let tacs := tacs.push tac

--- a/src/Lean/Elab/Tactic/Grind/Main.lean
+++ b/src/Lean/Elab/Tactic/Grind/Main.lean
@@ -396,36 +396,61 @@ def evalGrindTraceCore (stx : Syntax) (trace := true) (verbose := true) (useSorr
   let params ← mkGrindParams config only paramStxs mvarId
   let params := if trace then { params with config.markInstances := true } else params
   let config := params.config
+  let saved ← Tactic.saveState
   Grind.withProtectedMCtx config mvarId fun mvarId' => do
-    let (tacs, _) ← Grind.GrindTacticM.runAtGoal mvarId' params do
+    let ((syntaxTacs, theoremTacs, tac), _) ← Grind.GrindTacticM.runAtGoal mvarId' params do
       let finish ← Grind.Action.mkFinish
       let goal :: _ ← Grind.getGoals
         | -- Goal was closed during initialization
           let configStx' := filterSuggestionsAndLocalsFromGrindConfig configStx
           if termParamStxs.isEmpty then
             let tac ← `(tactic| grind $configStx':optConfig only)
-            return #[tac]
+            return (#[tac], #[tac], tac)
           else
             let tac ← `(tactic| grind $configStx':optConfig only [$termParamStxs,*])
-            return #[tac]
+            return (#[tac], #[tac], tac)
       Grind.liftGrindM do
-        -- **Note**: If we get failures when using the first suggestion, we should test is using `saved`
-        -- let saved ← saveState
         match (← finish.run goal) with
         | .closed seq =>
           let configStx' := filterSuggestionsAndLocalsFromGrindConfig configStx
+          let syntaxTacs ← Grind.mkGrindOnlyTactics configStx' seq termParamStxs
           let proof ← instantiateMVars (mkMVar goal.mvarId)
           let usedThms := Grind.Action.collect proof (← get).instanceMap
-          let tacs ← Grind.mkGrindOnlyTacticsUsingTheorems configStx' seq usedThms termParamStxs
+          let theoremTacs ← Grind.mkGrindOnlyTacticsUsingTheorems configStx' seq usedThms termParamStxs
           let seq := Grind.Action.mkGrindSeq seq
           let tac ← `(tactic| grind $configStx':optConfig => $seq:grindSeq)
-          let tacs := tacs.push tac
-          return tacs
+          return (syntaxTacs, theoremTacs, tac)
         | .stuck gs =>
           let goal :: _ := gs | throwError "`grind?` failed, but resulting goal is not available"
           let result ← Grind.mkResult params (some goal)
           throwError "`grind?` failed\n{← result.toMessageData}"
-    return tacs
+    let syntaxTacs ← filterClosingSuggestions saved syntaxTacs
+    let tacs := if syntaxTacs.isEmpty then theoremTacs else syntaxTacs
+    return appendIfNew tacs tac
+
+where
+  appendIfNew (tacs : Array (TSyntax `tactic)) (tac : TSyntax `tactic) :
+      Array (TSyntax `tactic) :=
+    if tacs.contains tac then tacs else tacs.push tac
+
+  filterClosingSuggestions (savedState : Tactic.SavedState)
+      (tacs : Array (TSyntax `tactic)) : TacticM (Array (TSyntax `tactic)) := do
+    let mut valid := #[]
+    for tac in tacs do
+      if ← closesGoal savedState tac then
+        valid := valid.push tac
+    return valid
+
+  closesGoal (savedState : Tactic.SavedState) (tac : TSyntax `tactic) : TacticM Bool := do
+    let currState ← saveState
+    savedState.restore
+    try
+      Term.withoutErrToSorry <| withoutRecover <| evalTactic tac
+      return (← getGoals).isEmpty
+    catch _ =>
+      return false
+    finally
+      currState.restore
 
 @[builtin_tactic Lean.Parser.Tactic.grindTrace] def evalGrindTrace : Tactic := fun stx => do
   let tacs ← evalGrindTraceCore stx

--- a/src/Lean/Elab/Tactic/Grind/Main.lean
+++ b/src/Lean/Elab/Tactic/Grind/Main.lean
@@ -443,6 +443,7 @@ where
 
   closesGoal (savedState : Tactic.SavedState) (tac : TSyntax `tactic) : TacticM Bool := do
     let currState ← saveState
+    let coreState ← getThe Core.State
     savedState.restore
     try
       Term.withoutErrToSorry <| withoutRecover <| evalTactic tac
@@ -451,6 +452,20 @@ where
       return false
     finally
       currState.restore
+      /-
+      `restore` only backtracks the environment/messages portion of `Core.State`.
+      Internal validation must also restore the name generators and tracing/info
+      state, otherwise replaying a suggestion perturbs later private theorem names
+      such as `_proof_1_1`.
+      -/
+      modifyThe Core.State fun s => { s with
+        nextMacroScope := coreState.nextMacroScope
+        ngen := coreState.ngen
+        auxDeclNGen := coreState.auxDeclNGen
+        traceState := coreState.traceState
+        cache := coreState.cache
+        infoState := coreState.infoState
+      }
 
 @[builtin_tactic Lean.Parser.Tactic.grindTrace] def evalGrindTrace : Tactic := fun stx => do
   let tacs ← evalGrindTraceCore stx

--- a/src/Lean/Meta/Tactic/Grind/CollectParams.lean
+++ b/src/Lean/Meta/Tactic/Grind/CollectParams.lean
@@ -6,6 +6,8 @@ Authors: Leonardo de Moura
 module
 prelude
 public import Lean.Meta.Tactic.Grind.Types
+import Lean.Meta.Tactic.Grind.EMatchTheoremParam
+import Lean.Meta.Match.Basic
 namespace Lean.Meta.Grind
 /-!
 Given an auto-generated `grind` tactic script, collect params for
@@ -114,5 +116,76 @@ where
       `(tactic| grind $cfg:optConfig only)
     else
       `(tactic| grind $cfg:optConfig only [$params,*])
+
+
+public def mkGrindOnlyTacticsUsingTheorems (cfg : TSyntax `Lean.Parser.Tactic.optConfig)
+    (seq : List TGrind) (usedThms : Array EMatchTheorem) (extraParams : Array TParam := #[]) : MetaM (Array (TSyntax `tactic)) := do
+  let (hasSorry, syntaxParams, anchors) ← collectParamsCore seq
+  if hasSorry then
+    return #[]
+  let existingDecls ← collectSimpleDeclParams syntaxParams
+  let init : NameSet × Array TParam := ({}, #[])
+  let (_, theoremParams) ← usedThms.foldlM (init := init) fun (foundFns, params) thm => do
+    match thm.origin with
+    | .decl declName =>
+      if declName.isAtomic then
+        if existingDecls.contains declName then
+          return (foundFns, params)
+        let param ← globalDeclToGrindParamSyntax declName thm.kind thm.minIndexable
+        return (foundFns, pushUnique params param)
+      else if Lean.Meta.Match.isCongrEqnReservedNameSuffix declName.getString! then
+        return (foundFns, params)
+      else if let some fnName ← isEqnThm? declName then
+        if foundFns.contains fnName || existingDecls.contains fnName then
+          return (foundFns, params)
+        else
+          let param ← globalDeclToGrindParamSyntax fnName thm.kind thm.minIndexable
+          return (foundFns.insert fnName, pushUnique params param)
+      else
+        if existingDecls.contains declName then
+          return (foundFns, params)
+        let param ← globalDeclToGrindParamSyntax declName thm.kind thm.minIndexable
+        return (foundFns, pushUnique params param)
+    | _ =>
+      return (foundFns, params)
+  let params := syntaxParams.foldl pushUnique theoremParams
+  mkGrindOnlyTacticsFromParams (params ++ anchors ++ extraParams) (params ++ extraParams)
+where
+  mkTac (params : Array TParam) : CoreM (TSyntax `tactic) :=
+    if params.isEmpty then
+      `(tactic| grind $cfg:optConfig only)
+    else
+      `(tactic| grind $cfg:optConfig only [$params,*])
+
+  mkGrindOnlyTacticsFromParams (withAnchors withoutAnchors : Array TParam) : MetaM (Array (TSyntax `tactic)) := do
+    let withAnchorsTac ← mkTac withAnchors
+    let withoutAnchorsTac ← mkTac withoutAnchors
+    if withAnchorsTac.raw == withoutAnchorsTac.raw then
+      return #[withAnchorsTac]
+    else
+      return #[withAnchorsTac, withoutAnchorsTac]
+
+  pushUnique (params : Array TParam) (param : TParam) : Array TParam :=
+    if params.contains param then params else params.push param
+
+  collectSimpleDeclParams (params : Array TParam) : MetaM NameSet := do
+    let mut result := ({ } : NameSet)
+    for p in params do
+      match p with
+      | `(Parser.Tactic.grindParam| $[$_:grindMod]? $id:ident) =>
+        result ← insertDecl result id.getId
+      | `(Parser.Tactic.grindParam| ! $[$_:grindMod]? $id:ident) =>
+        result ← insertDecl result id.getId
+      | _ =>
+        pure ()
+    return result
+
+  insertDecl (result : NameSet) (declName : Name) : MetaM NameSet := do
+    let declName := declName.eraseMacroScopes
+    let result := result.insert declName
+    if let some fnName ← isEqnThm? declName then
+      return result.insert fnName
+    else
+      return result
 
 end Lean.Meta.Grind

--- a/src/Lean/Meta/Tactic/Grind/EMatchAction.lean
+++ b/src/Lean/Meta/Tactic/Grind/EMatchAction.lean
@@ -7,7 +7,7 @@ module
 prelude
 public import Lean.Meta.Tactic.Grind.Intro
 import Lean.Util.ParamMinimizer
-import Lean.Meta.Tactic.Grind.EMatch
+public import Lean.Meta.Tactic.Grind.EMatch
 import Lean.Meta.Tactic.Grind.EMatchTheoremParam
 import Lean.Meta.Tactic.Grind.EMatchTheoremPtr
 import Lean.Meta.Tactic.Grind.MarkNestedSubsingletons
@@ -47,7 +47,7 @@ structure CollectState where
   collectedThms : Std.HashSet (Origin × EMatchTheoremKind) := {}
   thms          : Array EMatchTheorem := #[]
 
-def collect (e : Expr) (map : EMatch.InstanceMap) : Array EMatchTheorem :=
+public def collect (e : Expr) (map : EMatch.InstanceMap) : Array EMatchTheorem :=
   let (_, s) := go e |>.run {}
   s.thms
 where

--- a/tests/elab/grind_13877.lean
+++ b/tests/elab/grind_13877.lean
@@ -1,0 +1,106 @@
+namespace Relation
+
+variable {r : α → α → Prop}
+
+@[grind]
+inductive ReflTransGen (r : α → α → Prop) (a : α) : α → Prop
+  | refl : ReflTransGen r a a
+  | tail {b c : α} : ReflTransGen r a b → r b c → ReflTransGen r a c
+
+@[grind =]
+theorem reflTransGen_iff_eq (h : ∀ b, ¬r a b) : ReflTransGen r a b ↔ b = a where
+  mp h := by induction h with grind
+  mpr := by grind
+
+variable (r) in
+inductive EqvGen : α → α → Prop
+  | rel x y : r x y → EqvGen x y
+  | refl x : EqvGen x x
+  | symm x y : EqvGen x y → EqvGen y x
+  | trans x y z : EqvGen x y → EqvGen y z → EqvGen x z
+
+def Join (r : α → α → Prop) : α → α → Prop := fun a b ↦ ∃ c, r a c ∧ r b c
+
+abbrev ChurchRosser (r : α → α → Prop) := ∀ {x y}, EqvGen r x y → Join (ReflTransGen r) x y
+
+abbrev Reducible (r : α → α → Prop) (x : α) : Prop := ∃ y, r x y
+
+abbrev Normal (r : α → α → Prop) (x : α) : Prop := ¬ Reducible r x
+
+/--
+warning: generated tactic cannot close the goal
+  · instantiate approx
+    instantiate approx
+    instantiate approx
+    instantiate approx
+    cases #14e8
+    · cases #d806
+      cases #f38a
+      · cases #e48b <;> instantiate only [#9242]
+      · cases #e48b8a1c9d724d48 <;> instantiate only [#9242]
+    · instantiate approx
+      cases #d806c9c25a5bb198
+      · cases #f38a <;> cases #5525352b0f5c2899 <;> instantiate only [#3442]
+      · instantiate approx
+        cases #f38ab3f9c8353d60
+        · instantiate approx
+          cases #ae986558d4efb01d
+          · instantiate only [#3442]
+          · cases #e48b8a1c9d724d48 <;> instantiate only [#9242]
+        · instantiate approx
+          instantiate approx
+          instantiate approx
+          cases #ae986558d4efb01d
+          · instantiate only [#3442]
+          · cases #e48b8a1c9d724d48 <;> instantiate only [#9242]
+Initial goal
+case grind
+α : Sort u_1
+r : α → α → Prop
+x y : α
+cr : ChurchRosser r
+nx : Normal r x
+ny : Normal r y
+xy : EqvGen r x y
+w✝ : α
+left✝ : ReflTransGen r x w✝
+right✝ : ReflTransGen r y w✝
+h✝ : ¬x = y
+⊢ False
+---
+info: Try these:
+  [apply] grind only [= reflTransGen_iff_eq, ReflTransGen.tail, EqvGen.trans, ReflTransGen.refl, #14e8, #d806, #f38a,
+    #e48b, #9242, #e48b8a1c9d724d48, #d806c9c25a5bb198, #5525352b0f5c2899, #3442, #f38ab3f9c8353d60, #ae986558d4efb01d]
+  [apply] grind only [= reflTransGen_iff_eq, ReflTransGen.tail, EqvGen.trans, ReflTransGen.refl]
+  [apply] grind =>
+    instantiate approx
+    instantiate approx
+    instantiate approx
+    instantiate approx
+    cases #14e8
+    · cases #d806
+      cases #f38a
+      · cases #e48b <;> instantiate only [#9242]
+      · cases #e48b8a1c9d724d48 <;> instantiate only [#9242]
+    · instantiate approx
+      cases #d806c9c25a5bb198
+      · cases #f38a <;> cases #5525352b0f5c2899 <;> instantiate only [#3442]
+      · instantiate approx
+        cases #f38ab3f9c8353d60
+        · instantiate approx
+          cases #ae986558d4efb01d
+          · instantiate only [#3442]
+          · cases #e48b8a1c9d724d48 <;> instantiate only [#9242]
+        · instantiate approx
+          instantiate approx
+          instantiate approx
+          cases #ae986558d4efb01d
+          · instantiate only [#3442]
+          · cases #e48b8a1c9d724d48 <;> instantiate only [#9242]
+-/
+#guard_msgs (warning, info) in
+example (cr : ChurchRosser r) (nx : Normal r x) (ny : Normal r y) (xy : EqvGen r x y) : x = y := by
+  have ⟨_, _, _⟩ := cr xy
+  grind? [EqvGen]
+
+end Relation


### PR DESCRIPTION
This PR recovers theorem-backed `grind?` suggestions when syntax-only replay loses dependencies introduced by `instantiate approx`.

1. It keeps syntax-only `grind only` suggestions when they already replay on the original goal.
2. It falls back to theorem-backed `grind only` parameters from the proof-used `instanceMap` only when every syntax-only candidate fails.
3. It de-duplicates the final suggestion list so initialization-only cases do not emit the same `grind only` tactic twice.
4. It restores the internal validation state after suggestion replay so the validator does not perturb later private theorem names or snapshot output.

Files in scope:

1. `src/Lean/Elab/Tactic/Grind/Main.lean`
2. `src/Lean/Meta/Tactic/Grind/CollectParams.lean`
3. `src/Lean/Meta/Tactic/Grind/EMatchAction.lean`
4. `tests/elab/grind_13877.lean`

Validation:

1. `make -C build/release -j$(nproc)`
2. `build/release/stage1/bin/lean tests/elab/grind_try_trace.lean`
3. `build/release/stage1/bin/lean tests/elab/grind_trace.lean`
4. `build/release/stage1/bin/lean tests/elab/grind_finish_trace.lean`
5. `build/release/stage1/bin/lean tests/elab/grind_eval_suggest.lean`
6. `build/release/stage1/bin/lean tests/elab/grind_suggestions.lean`
7. `build/release/stage1/bin/lean tests/elab/grind_question_mark_suggestions.lean`
8. `build/release/stage1/bin/lean tests/elab/grind_unused_lemmas.lean`
9. `build/release/stage1/bin/lean tests/elab/grind_12390.lean`
10. `build/release/stage1/bin/lean tests/elab/grind_13877.lean`
11. `build/release/stage1/bin/lean tests/elab/grind_ground_thm.lean`
12. `build/release/stage1/bin/lean tests/elab/grind_option.lean`
13. `build/release/stage1/bin/lean tests/elab/grind_indexmap_trace.lean`
14. `cd build/release/stage1 && ctest -j8 --output-on-failure`
15. `cd build/release/stage1 && ctest -V -R "^elab/grind_list\\.lean$" --output-on-failure`
