### PR TITLE
feat: request full `maxSuggestions` from both selectors in `intersperse`

### DIFF
--- a/src/Lean/LibrarySuggestions/Basic.lean
+++ b/src/Lean/LibrarySuggestions/Basic.lean
@@ -245,10 +245,14 @@ def filterGrindAnnotated (selector : Selector) : Selector := fun g c => do
 Combine two premise selectors by interspersing their results (ignoring scores).
 The parameter `ratio` (defaulting to 0.5) controls the ratio of suggestions from each selector
 while results are available from both.
+
+Both selectors are asked for the full `maxSuggestions`, rather than a `ratio`-split share, so that
+if one selector returns fewer than its share the other can compensate. This doubles the retrieval
+work compared to splitting the budget.
 -/
 def intersperse (selector₁ selector₂ : Selector) (ratio : Float := 0.5) : Selector := fun g c => do
-  let suggestions₁ ← selector₁ g { c with maxSuggestions := c.maxSuggestions }
-  let suggestions₂ ← selector₂ g { c with maxSuggestions := c.maxSuggestions }
+  let suggestions₁ ← selector₁ g c
+  let suggestions₂ ← selector₂ g c
 
   let mut result := #[]
   let mut i₁ := 0

--- a/src/Lean/LibrarySuggestions/Basic.lean
+++ b/src/Lean/LibrarySuggestions/Basic.lean
@@ -247,12 +247,8 @@ The parameter `ratio` (defaulting to 0.5) controls the ratio of suggestions from
 while results are available from both.
 -/
 def intersperse (selector₁ selector₂ : Selector) (ratio : Float := 0.5) : Selector := fun g c => do
-  -- Calculate how many suggestions to request from each selector based on the ratio
-  let max₁ := (c.maxSuggestions.toFloat * ratio).toUInt32.toNat
-  let max₂ := (c.maxSuggestions.toFloat * (1 - ratio)).toUInt32.toNat
-
-  let suggestions₁ ← selector₁ g { c with maxSuggestions := max₁ }
-  let suggestions₂ ← selector₂ g { c with maxSuggestions := max₂ }
+  let suggestions₁ ← selector₁ g { c with maxSuggestions := c.maxSuggestions }
+  let suggestions₂ ← selector₂ g { c with maxSuggestions := c.maxSuggestions }
 
   let mut result := #[]
   let mut i₁ := 0


### PR DESCRIPTION
This PR makes the `intersperse` library suggestion combinator request `maxSuggestions` results from each of its two selectors instead of splitting the budget by `ratio`, so that if one selector returns fewer suggestions than its allocation the other can compensate to still fill the request. The interspersing ratio and the final `maxSuggestions` cap on the combined result are unchanged.

This addresses the behavior discussed at https://leanprover.zulipchat.com/#narrow/channel/239415-metaprogramming-.2F-tactics/topic/Intersperse.20Library.20Suggestion.20Behavior/with/598163167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)