### PR TITLE
chore: deprecate `Lean.Data.RBMap` and `Lean.Data.RBTree`

### DIFF
--- a/src/Lean/Data.lean
+++ b/src/Lean/Data.lean
@@ -26,7 +26,7 @@ public import Lean.Data.PrefixTree
 public import Lean.Data.SMap
 public import Lean.Data.Trie
 public import Lean.Data.NameTrie
-public import Lean.Data.RBTree
-public import Lean.Data.RBMap
+public import Lean.Data.RBTree -- deprecated_module: ignore
+public import Lean.Data.RBMap -- deprecated_module: ignore
 public import Lean.Data.RArray
 public import Lean.Data.Iterators

--- a/src/Lean/Data/RBMap.lean
+++ b/src/Lean/Data/RBMap.lean
@@ -11,6 +11,8 @@ public import Init.Data.Nat.Linear
 public import Init.Data.Array.Basic
 import Init.WFTactics
 
+deprecated_module "`Lean.RBMap` is deprecated; use `Std.TreeMap` instead" (since := "2026-06-01")
+
 public section
 
 namespace Lean

--- a/src/Lean/Data/RBTree.lean
+++ b/src/Lean/Data/RBTree.lean
@@ -6,7 +6,9 @@ Authors: Leonardo de Moura
 module
 
 prelude
-public import Lean.Data.RBMap
+public import Lean.Data.RBMap -- deprecated_module: ignore
+
+deprecated_module "`Lean.RBTree` is deprecated; use `Std.TreeSet` instead" (since := "2026-06-01")
 
 public section
 namespace Lean

--- a/tests/compile/rbmap_library.lean
+++ b/tests/compile/rbmap_library.lean
@@ -1,4 +1,4 @@
-import Lean.Data.RBMap
+import Lean.Data.RBMap -- deprecated_module: ignore
 open Lean
 
 def check (b : Bool) : IO Unit := do

--- a/tests/compile_bench/rbmap_library.lean
+++ b/tests/compile_bench/rbmap_library.lean
@@ -1,4 +1,4 @@
-import Lean.Data.RBMap
+import Lean.Data.RBMap -- deprecated_module: ignore
 
 open Lean
 


### PR DESCRIPTION
This PR deprecates the `Lean.RBMap` and `Lean.RBTree` containers in favour of `Std.TreeMap` and `Std.TreeSet`, which offer a more complete and consistent API. Nothing in the Lean repository uses these types any longer, and downstream code should migrate to the `Std` containers.

The modules are marked with `deprecated_module`, so any file that directly imports `Lean.Data.RBMap` or `Lean.Data.RBTree` now receives a deprecation warning pointing at the `Std` replacement. The few internal importers — the `Lean.Data` re-export, `RBTree`'s import of `RBMap`, and the two compile tests that exercise the API on purpose — carry a `-- deprecated_module: ignore` annotation. This mirrors the corresponding deprecation of `Batteries.RBMap` in https://github.com/leanprover-community/batteries/pull/1792 - feat: deprecate `Batteries.RBMap` declarations.

🤖 Prepared with Claude Code