### PR TITLE
fix: honor `ratio` at the endpoints in `intersperse`

### DIFF
--- a/src/Lean/LibrarySuggestions/Basic.lean
+++ b/src/Lean/LibrarySuggestions/Basic.lean
@@ -243,14 +243,16 @@ def filterGrindAnnotated (selector : Selector) : Selector := fun g c => do
 
 /--
 Combine two premise selectors by interspersing their results (ignoring scores).
-The parameter `ratio` (defaulting to 0.5) controls the ratio of suggestions from each selector
-while results are available from both.
+The parameter `ratio` (defaulting to 0.5) controls the fraction of suggestions drawn from
+`selector₁` while results are available from both. It is clamped to `[0, 1]`, and ties are
+resolved in favour of `selector₁`.
 
 Both selectors are asked for the full `maxSuggestions`, rather than a `ratio`-split share, so that
 if one selector returns fewer than its share the other can compensate. This doubles the retrieval
 work compared to splitting the budget.
 -/
 def intersperse (selector₁ selector₂ : Selector) (ratio : Float := 0.5) : Selector := fun g c => do
+  let ratio := min 1.0 (max 0.0 ratio)
   let suggestions₁ ← selector₁ g c
   let suggestions₂ ← selector₂ g c
 
@@ -262,9 +264,15 @@ def intersperse (selector₁ selector₂ : Selector) (ratio : Float := 0.5) : Se
 
   -- Intersperse while both arrays have elements
   while h : i₁ < suggestions₁.size ∧ i₂ < suggestions₂.size ∧ result.size < c.maxSuggestions do
-    -- Decide whether to take from selector₁ or selector₂ based on the ratio
-    let currentRatio := if count₁ + count₂ <= 0.0 then 0.0 else count₁ / (count₁ + count₂)
-    if currentRatio < ratio then
+    -- Take from whichever selector keeps the running fraction of `selector₁`
+    -- contributions closest to `ratio`. Comparing the two candidate next states
+    -- (rather than the achieved fraction) stays accurate at the endpoints, so
+    -- `ratio = 1` draws entirely from `selector₁` and `ratio = 0` entirely from
+    -- `selector₂` while both have results.
+    let total := count₁ + count₂
+    let errIfTake₁ := Float.abs ((count₁ + 1) / (total + 1) - ratio)
+    let errIfTake₂ := Float.abs (count₁ / (total + 1) - ratio)
+    if errIfTake₁ <= errIfTake₂ then
       result := result.push suggestions₁[i₁]
       i₁ := i₁ + 1
       count₁ := count₁ + 1


### PR DESCRIPTION
This PR makes the `intersperse` library suggestion combinator honor `ratio` at the endpoints, so `ratio = 0` draws entirely from `selector₂` and `ratio = 1` entirely from `selector₁` while both selectors still have results. Previously each element was chosen by comparing the achieved fraction of `selector₁` contributions against `ratio` with a strict `<` (seeded to `0` when empty), which left `ratio = 1` drawing one stray element from `selector₂` before settling. The combinator now picks whichever candidate next state keeps the running fraction closest to `ratio`, with ties going to `selector₁`.

This changes the interleaving order on intermediate ratios — including the default `0.5`, which becomes a clean alternation — so under the `maxSuggestions` cap the delivered split can shift by one element at a given cutoff (e.g. at `maxSuggestions = 3`, `ratio = 0.5` the old rule delivered a 1/2 split and the new rule delivers 2/1). The asymptotic ratio is unchanged.

The stray element is only observable once https://github.com/leanprover/lean4/pull/13907 lands: on current `master` the budget split asks `selector₂` for `0` suggestions at `ratio = 1`, masking it for selectors that respect `maxSuggestions`. The two PRs touch different lines of `intersperse` and merge cleanly in either order.

🤖 Prepared with Claude Code