### PR TITLE
feat: accept arbitrary `doElem`s after `←`

### DIFF
--- a/src/Lean/Elab/BuiltinDo/If.lean
+++ b/src/Lean/Elab/BuiltinDo/If.lean
@@ -33,7 +33,7 @@ If the given syntax is a `doIf`, return an equivalent `doIf` that has an `else` 
       e ← if eIsSeq then pure e else `(doSeq|$(⟨e⟩):doElem)
       e ← match cond with
         | `(doIfCond|let $pat := $d) => `(doElem| match $d:term with | $pat:term => $t | _ => $(⟨e⟩))
-        | `(doIfCond|let $pat ← $d)  => `(doElem| match ← $d    with | $pat:term => $t | _ => $(⟨e⟩))
+        | `(doIfCond|let $pat ← $d)  => `(doElem| match ← $d:term with | $pat:term => $t | _ => $(⟨e⟩))
         | `(doIfCond|$cond:doIfProp) => `(doElem| if $cond:doIfProp then $t else $(⟨e⟩))
         | _                          => Macro.throwUnsupported
       eIsSeq := false

--- a/src/Lean/Elab/Do/Basic.lean
+++ b/src/Lean/Elab/Do/Basic.lean
@@ -817,11 +817,17 @@ private partial def expandNestedActionsAux (baseId : Name) (inQuot : Bool) (inBi
     else if k == ``Parser.Term.nestedAction && !inQuot then withFreshMacroScope do
       if inBinder then
         throwErrorAt stx "Cannot lift nested action `{stx}` over a binder.\nThis error usually happens when you are trying to lift a method nested in a `fun`, `let`, or `match`-alternative, and it can often be fixed by adding a missing `do`."
-      let term := args[1]!
-      let term ← expandNestedActionsAux baseId inQuot inBinder term
+      let arg ← expandNestedActionsAux baseId inQuot inBinder args[1]!
+      -- Pre-stage0-update format stored a term in `args[1]`; the new format stores a doElem.
+      -- Wrap raw terms in `doExpr` so the subsequent `let _ ← _` quotation parses correctly.
+      let isDoElem :=
+        (Parser.getParserCategory? (← getEnv) `doElem).any (·.kinds.contains arg.getKind)
+      let act : TSyntax `doElem ←
+        if isDoElem then pure ⟨arg⟩
+        else let t : Term := ⟨arg⟩; `(doElem| $t:term)
       -- keep name deterministic across choice branches
       let id ← mkIdentFromRef (.num baseId (← get).size)
-      let auxDoElem ← `(doElem| let $id:ident ← $(⟨term⟩):term)
+      let auxDoElem ← `(doElem| let $id:ident ← $act)
       modify fun s => s.push auxDoElem
       return id
     else do

--- a/src/Lean/Elab/Do/Legacy.lean
+++ b/src/Lean/Elab/Do/Legacy.lean
@@ -761,7 +761,7 @@ private def expandDoIf? (stx : Syntax) : MacroM (Option Syntax) := match stx wit
       e ← if eIsSeq then pure e else `(doSeq|$e:doElem)
       e ← match cond with
         | `(doIfCond|let $pat := $d) => `(doElem| match $d:term with | $pat:term => $t | _ => $e)
-        | `(doIfCond|let $pat ← $d)  => `(doElem| match ← $d    with | $pat:term => $t | _ => $e)
+        | `(doIfCond|let $pat ← $d)  => `(doElem| match ← $d:term with | $pat:term => $t | _ => $e)
         | `(doIfCond|$cond:doIfProp) => `(doElem| if $cond:doIfProp then $t else $e)
         | _                          => `(doElem| if $(Syntax.missing) then $t else $e)
       eIsSeq := false
@@ -1341,8 +1341,20 @@ private partial def expandNestedActionAux (inQuot : Bool) (inBinder : Bool) : Sy
     else if k == ``Parser.Term.nestedAction && !inQuot then withFreshMacroScope do
       if inBinder then
         throwErrorAt stx "cannot lift `(<- ...)` over a binder, this error usually happens when you are trying to lift a method nested in a `fun`, `let`, or `match`-alternative, and it can often be fixed by adding a missing `do`"
-      let term := args[1]!
-      let term ← expandNestedActionAux inQuot inBinder term
+      let arg := args[1]!
+      -- The parser has been extended to accept arbitrary `doElem`s, but the legacy `do` elaborator
+      -- only supports a term after `←`. Pre-stage0-update format stored a term directly; the new
+      -- format wraps a term in `doExpr`. Anything else is a non-trivial `doElem` we cannot lift.
+      let isDoElem :=
+        (Parser.getParserCategory? (← getEnv) `doElem).any (·.kinds.contains arg.getKind)
+      let termArg ←
+        if arg.getKind == ``Parser.Term.doExpr then
+          pure arg[0]
+        else if isDoElem then
+          throwErrorAt arg "the legacy `do` elaborator only supports a term after `←`; use `set_option backward.do.legacy false` to enable the new elaborator with full `doElem` support"
+        else
+          pure arg
+      let term ← expandNestedActionAux inQuot inBinder termArg
       -- keep name deterministic across choice branches
       let id ← mkIdentFromRef (.num baseId (← get).length)
       let auxDoElem : Syntax ← `(doElem| let $id:ident ← $term:term)

--- a/src/Lean/Elab/Syntax.lean
+++ b/src/Lean/Elab/Syntax.lean
@@ -422,7 +422,7 @@ def elabSyntax (stx : Syntax) : CommandElabM Name := do
       let mut name := base
       let mut i := 1
       -- Avoid name conflicts, for which we have to check both public and private name
-      while (←
+      while (← do
         let fullName := (← getCurrNamespace) ++ name
         hasConst fullName <||>
           (withoutExporting <| hasConst (mkPrivateName (← getEnv) fullName))) do

--- a/src/Lean/Parser/Do.lean
+++ b/src/Lean/Parser/Do.lean
@@ -22,7 +22,7 @@ builtin_initialize registerBuiltinDynamicParserAttribute `doElem_parser `doElem
 namespace Term
 def leftArrow : Parser := unicodeSymbol "← " "<- "
 @[builtin_term_parser] def nestedAction := leading_parser:minPrec
-  leftArrow >> termParser
+  leftArrow >> doElemParser
 
 def doSeqItem      := leading_parser
   ppLine >> doElemParser >> optional "; "

--- a/tests/elab/issue11183.lean
+++ b/tests/elab/issue11183.lean
@@ -219,7 +219,7 @@ def currentlyEnabled [Monad M] (merge_var : extension) : M Bool := do
   | Ext_Zicfilp =>
     (pure ((← (currentlyEnabled Ext_Zicsr))
       && ((hartSupports Ext_Zicfilp)
-      && (← (get_xLPE (← return User))))))
+      && (← (get_xLPE (← pure User))))))
   | Ext_Svnapot => (pure false)
   | Ext_Svpbmt => (pure false)
   | Ext_Svrsw60t59b => (pure ((hartSupports Ext_Svrsw60t59b) && (← (currentlyEnabled Ext_Sv39))))

--- a/tests/elab/nestedActionDoElem.lean
+++ b/tests/elab/nestedActionDoElem.lean
@@ -1,0 +1,101 @@
+/-!
+Tests that the `nestedAction` parser (`← <action>`) accepts a `doElem` after `←`.
+
+The legacy `do` elaborator only supports a `doExpr` (a `doElem` wrapping a term) after `←` and
+rejects more general `doElem`s; the new elaborator (`backward.do.legacy false`) handles
+arbitrary `doElem`s.
+-/
+
+/-! ## Backward compatibility: `← term` (parsed as `doExpr`) still works in both elaborators -/
+
+namespace LegacyTerm
+set_option backward.do.legacy true
+
+/-- info: 5 -/
+#guard_msgs in
+#eval show IO Nat from do
+  let x ← pure (← pure 5)
+  return x
+
+/-- info: 7 -/
+#guard_msgs in
+#eval show IO Nat from do
+  let x ← pure ((← pure 3) + (← pure 4))
+  return x
+
+end LegacyTerm
+
+namespace NewTerm
+set_option backward.do.legacy false
+
+/-- info: 5 -/
+#guard_msgs in
+#eval show IO Nat from do
+  let x ← pure (← pure 5)
+  return x
+
+/-- info: 7 -/
+#guard_msgs in
+#eval show IO Nat from do
+  let x ← pure ((← pure 3) + (← pure 4))
+  return x
+
+end NewTerm
+
+/-! ## Legacy elaborator rejects more general `doElem`s after `←` -/
+
+namespace LegacyRejects
+set_option backward.do.legacy true
+
+/--
+error: the legacy `do` elaborator only supports a term after `←`; use `set_option backward.do.legacy false` to enable the new elaborator with full `doElem` support
+-/
+#guard_msgs in
+example : IO Nat := do
+  let x ← pure (← if true then pure 5 else pure 6)
+  return x
+
+/--
+error: the legacy `do` elaborator only supports a term after `←`; use `set_option backward.do.legacy false` to enable the new elaborator with full `doElem` support
+-/
+#guard_msgs in
+example : IO Nat := do
+  let x ← pure (← return 5)
+  return x
+
+end LegacyRejects
+
+/-! ## New elaborator accepts `← <doElem>` for `doIf`, `doReturn`, and `doIf` with
+`doElem`-only branches. -/
+
+namespace NewAcceptsDoElem
+set_option backward.do.legacy false
+
+/-- info: 5 -/
+#guard_msgs in
+#eval show IO Nat from do
+  let x ← pure (← if true then pure 5 else pure 6)
+  return x
+
+/--
+warning: This `do` element and its control-flow region are dead code. Consider removing it.
+---
+info: true
+-/
+#guard_msgs in
+#eval show IO Bool from do
+  let x ← pure (← return true)
+  return x > 7
+
+/-- info: 4 -/
+#guard_msgs in
+#eval show IO Nat from do
+  let mut y := 1
+  let x ← pure (← if true then
+    y := y + 1
+    pure y
+  else
+    pure 0)
+  return x + y
+
+end NewAcceptsDoElem

--- a/tests/elab/nestedActionInMacrosIssue.lean
+++ b/tests/elab/nestedActionInMacrosIssue.lean
@@ -27,7 +27,7 @@ else
 syntax term "<|||>" term : doElem
 
 macro_rules
-| `(doElem| $a:term <|||> $b) => `(doElem| if (← $a) then pure true else $b:term)
+| `(doElem| $a:term <|||> $b) => `(doElem| if (← $a:term) then pure true else $b:term)
 
 def tst2 : IO Bool := do
 pure true <|||> (← throw $ IO.userError "failed")

--- a/tests/elab/nestedActionLegacyElab.lean
+++ b/tests/elab/nestedActionLegacyElab.lean
@@ -23,7 +23,7 @@ def tst (x : Nat) : IO Bool := do
 #eval tst 2
 
 def tstReturn (x : Nat) : IO Nat := do
-  return (← return 42) + x
+  return (← pure 42) + x
 
 /-- info: 47 -/
 #guard_msgs in


### PR DESCRIPTION
This PR extends the `nestedAction` parser (`←` inside `do` blocks) to accept arbitrary `doElem`s after `←` instead of just terms. The new `do` elaborator handles any `doElem`; the legacy elaborator (`set_option backward.do.legacy true`) keeps the old restriction to terms and rejects more general `doElem`s with an explicit error.

This is a breaking change: `return e` (and `| return none`, etc.) inside `(← do …)`, `(← try … catch …)`, etc. now early-returns from the *enclosing* `do` block, not from the nested action. Migrate by replacing with `pure e` / `| pure none` when value-return from the nested block is intended, or wrapping the `do` block in parentheses (`(← (do …))`) or `id` (`(← id do …)`).

For backward compatibility with pre-stage0-update macros that stored a term in the second child of `nestedAction`, both elaborators detect whether the child is a doElem or a raw term via the parser category and wrap raw terms in `doExpr`.