### PR TITLE
fix: deprecated warnings inside of `grind` proofs

### DIFF
--- a/src/Lean/Elab/Tactic/Grind/Param.lean
+++ b/src/Lean/Elab/Tactic/Grind/Param.lean
@@ -212,7 +212,7 @@ def processParam (params : Grind.Params)
       return (← processTermParam params p mod? id minIndexable)
     else
       throw err
-  Linter.checkDeprecated declName
+  Term.checkDeprecatedCore declName
   let kind ← if let some mod := mod? then Grind.getAttrKindCore mod else pure .infer
   match kind with
   | .ematch .user =>
@@ -281,7 +281,7 @@ public def elabGrindParams (params : Grind.Params) (ps : TSyntaxArray ``Parser.T
         if incremental then
           throwErrorAt p "invalid `-` occurrence, it can only used at the `grind` tactic entry point"
         let declName ← realizeGlobalConstNoOverloadWithInfo id
-        Linter.checkDeprecated declName
+        Term.checkDeprecatedCore declName
         if let some declName ← Grind.isCasesAttrCandidate? declName false then
           Grind.ensureNotBuiltinCases declName
           params ← params.eraseCasesTypes declName

--- a/src/Lean/Elab/Term/TermElabM.lean
+++ b/src/Lean/Elab/Term/TermElabM.lean
@@ -2092,7 +2092,7 @@ def isLetRecAuxMVar (mvarId : MVarId) : TermElabM Bool := do
   trace[Elab.letrec] "mvarId root: {mkMVar mvarId}"
   return (← get).letRecsToLift.any (·.mvarId == mvarId)
 
-private def checkDeprecatedCore (constName : Name) : TermElabM Unit := do
+public def checkDeprecatedCore (constName : Name) : TermElabM Unit := do
   if (← read).checkDeprecated then
     Linter.checkDeprecated constName
 

--- a/tests/elab/deprecated_warning.lean
+++ b/tests/elab/deprecated_warning.lean
@@ -1,0 +1,13 @@
+/-- warning: declaration uses `sorry` -/
+#guard_msgs in
+@[deprecated " " (since := "2020-01-01")]
+theorem test : 3 = 5 := sorry
+
+@[deprecated " " (since := "2020-01-01")]
+theorem test2 : 3 = 5 := by
+  grind [test]
+
+@[deprecated " " (since := "2020-01-01")]
+theorem test3 : 3 = 5 := by
+  as_aux_lemma =>
+    exact test


### PR DESCRIPTION
This PR fixes the silencing of `deprecated` warnings inside of definitions that are themselves deprecated and use `grind` with a `deprecated` theorem.

