### PR TITLE
chore: better version parse errors & docs

### DIFF
--- a/src/lake/Lake/DSL/Syntax.lean
+++ b/src/lake/Lake/DSL/Syntax.lean
@@ -164,7 +164,7 @@ public syntax depSpec :=
 Adds a new package dependency to the workspace. The general syntax is:
 
 ```
-require ["<scope>" /] <pkg-name> [@ <version>]
+require ["<scope>" /] <pkg-name> [@ [git]? <version>]
   [from <source>] [with <options>]
 ```
 

--- a/src/lake/Lake/Util/Version.lean
+++ b/src/lake/Lake/Util/Version.lean
@@ -111,7 +111,7 @@ def parseSpecialDescr (s : String) : EStateM String s.Pos String := do
     throw "invalid version: '-' suffix cannot be empty"
   return specialDescr
 
-def runVerParse
+@[inline] def runVerParse
   (s : String) (x : (s : String) → EStateM String s.Pos α)
   (startPos := s.startPos) (endPos := s.endPos)
 : Except String α :=
@@ -153,7 +153,7 @@ def parseM (s : String) : EStateM String s.Pos SemVerCore := do
   catch e =>
     throw s!"invalid version core: {e}"
 
-@[inline] public def parse (s : String) : Except String SemVerCore := do
+public def parse (s : String) : Except String SemVerCore := do
   runVerParse s parseM
 
 public protected def toString (ver : SemVerCore) : String :=
@@ -209,7 +209,7 @@ public def parseM (s : String) : EStateM String s.Pos StdVer := do
   let specialDescr ← parseSpecialDescr s
   return {toSemVerCore := core, specialDescr}
 
-@[inline] public def parse (s : String) : Except String StdVer := do
+public def parse (s : String) : Except String StdVer := do
   runVerParse s parseM
 
 public protected def toString (ver : StdVer) : String :=
@@ -416,7 +416,10 @@ public def wild : VerComparator :=
 public instance : Inhabited VerComparator := ⟨.wild⟩
 
 def parseM (s : String) : EStateM String s.Pos VerComparator := do
+  let iniPos ← get
   let op ← ComparatorOp.parseM s
+  if (← get) = s.endPos then
+    throw s!"invalid comparison: expected version after `{s.sliceFrom iniPos}`"
   let core ← SemVerCore.parseM s
   if let some specialDescr ← parseSpecialDescr? s then
     if  specialDescr.isEmpty then
@@ -426,7 +429,7 @@ def parseM (s : String) : EStateM String s.Pos VerComparator := do
   else
     return {ver := .ofSemVerCore core, op}
 
-@[inline] public def parse (s : String) : Except String VerComparator := do
+public def parse (s : String) : Except String VerComparator := do
   runVerParse s parseM
 
 public def test (self : VerComparator) (ver : StdVer) : Bool :=
@@ -476,7 +479,7 @@ namespace VerRange
 
 public instance : ToString VerRange := ⟨VerRange.toString⟩
 
-public def ofClauses (clauses : Array (Array VerComparator)) : VerRange :=
+@[inline] public def ofClauses (clauses : Array (Array VerComparator)) : VerRange :=
   {toString := fmtOrs clauses, clauses}
 where
   fmtOrs ors :=
@@ -492,7 +495,7 @@ where
       ands.foldl (init := ands[0].toString) (start := 1) fun s v =>
         s!"{s}, {v}"
 
-partial def parseM (s : String) : EStateM String s.Pos VerRange := do
+@[inline] partial def parseM (s : String) : EStateM String s.Pos VerRange := do
   let clauses ← go true #[] #[]
   return {toString := s, clauses}
 where
@@ -510,15 +513,23 @@ where
           go false ors ands p
         | .error e p => .error e p
       else if c == '^' then
-        match parseCaret s ands (p.next h) with
-        | .ok ands p =>
-          go false ors ands p
-        | .error e p => .error e p
+        let p := p.next h
+        if p = s.endPos then
+          .error  "invalid caret range: expected version after `^`" p
+        else
+          match parseCaret s ands p with
+          | .ok ands p =>
+            go false ors ands p
+          | .error e p => .error e p
       else if c == '~' then
-        match parseTilde s ands (p.next h) with
-        | .ok ands p =>
-          go false ors ands p
-        | .error e p => .error e p
+        let p := p.next h
+        if p = s.endPos then
+          .error "invalid tilde range: expected version after `~`" p
+        else
+          match parseTilde s ands p with
+          | .ok ands p =>
+            go false ors ands p
+          | .error e p => .error e p
       else if c.isWhitespace then
         go needsRange ors ands (p.next h)
       else if c == ',' then
@@ -547,15 +558,16 @@ where
     let maxVer := StdVer.ofSemVerCore maxVer
     ands.push {op := .ge, ver := minVer} |>.push {op := .lt, ver := maxVer, includeSuffixes := true}
   parseWild (s : String) ands : EStateM String s.Pos _ := do
-    let cs ← parseVerComponents s
+    let cs ← parseVerComponents s -- `cs.size ≠ 0` due to how `parseWild` is called
+    -- Parsed first so its error is seen on arbitrary alphanumeric versions (e.g., `v1`, `1.o`, `beta`)
+    let major? ← parseVerComponent "major" cs[0]?
+    let minor? ← parseVerComponent "minor" cs[1]?
+    let patch? ← parseVerComponent "patch" cs[2]?
     if (← get).get?.any (· == '-') then
-      throw s!"invalid wildcard range: wildcard versions do not support suffixes"
-    else if cs.size = 0 ∨ cs.size > 3 then
+      throw "invalid wildcard range: wildcard versions do not support suffixes"
+    else if cs.size > 3 then
       throw s!"invalid wildcard range: incorrect number of components: got {cs.size}, expected 1-3"
     else
-      let major? ← parseVerComponent "major" cs[0]?
-      let minor? ← parseVerComponent "minor" cs[1]?
-      let patch? ← parseVerComponent "patch" cs[2]?
       match major?, minor?, patch? with
       | .nat major, .nat minor, .wild =>
         return appendRange ands {major, minor} {major, minor := minor + 1}
@@ -618,7 +630,7 @@ where
     else
       throw s!"invalid tilde range: incorrect number of components: got {cs.size}, expected 1-3"
 
-@[inline] public def parse (s : String) : Except String VerRange := do
+public def parse (s : String) : Except String VerRange := do
   runVerParse s parseM
 
 public def test (self : VerRange) (ver : StdVer) : Bool :=

--- a/tests/lake/tests/api/vers.lean
+++ b/tests/lake/tests/api/vers.lean
@@ -70,6 +70,9 @@ https://doc.rust-lang.org/stable/cargo/reference/specifying-dependencies.html#co
 #eval checkMatch "<1.2.3-"
   #["1.0.0-alpha.9", "1.2.3-alpha.1"] #["1.2.3", "1.2.4-beta.2"]
 
+/-- error: invalid comparison: expected version after `>` -/
+#guard_msgs in #eval runParse ">"
+
 /-- error: invalid version core: incorrect number of components: got 2, expected 3 -/
 #guard_msgs in #eval runParse ">1.2"
 
@@ -150,7 +153,7 @@ https://doc.rust-lang.org/stable/cargo/reference/specifying-dependencies.html#ca
 #eval checkParse "^1.2.3-beta.2"  "≥1.2.3-beta.2, <2.0.0-"
 #eval checkParse "^0.0.0-beta.2"  "≥0.0.0-beta.2, <0.0.1-"
 
-/-- error: invalid major version: expected numeral, got '' -/
+/-- error: invalid caret range: expected version after `^` -/
 #guard_msgs in #eval runParse "^"
 
 /-- error: invalid version: '-' suffix cannot be empty -/
@@ -190,7 +193,7 @@ https://doc.rust-lang.org/stable/cargo/reference/specifying-dependencies.html#ti
   #["1.2.3-beta.2", "1.2.3-beta.7", "1.2.3", "1.2.7"]
   #["1.2.1", "1.2.3-alpha.3", "1.2.3-beta.1"]
 
-/-- error: invalid major version: expected numeral, got '' -/
+/-- error: invalid tilde range: expected version after `~` -/
 #guard_msgs in #eval runParse "~"
 
 /-- error: invalid version: '-' suffix cannot be empty -/
@@ -225,14 +228,14 @@ https://doc.rust-lang.org/stable/cargo/reference/specifying-dependencies.html#wi
 
 /-! ### Errors -/
 
-/-- error: invalid wildcard range: wildcard versions do not support suffixes -/
-#guard_msgs in #eval runParse "1.*.*-*"
+/-- error: invalid major version: expected numeral or wildcard, got 'v4' -/
+#guard_msgs in #eval runParse "v4.31.0-rc1"
 
 /-- error: invalid major version: expected numeral or wildcard, got 'a' -/
-#guard_msgs in #eval runParse "a.*.*"
+#guard_msgs in #eval runParse "a"
 
 /-- error: invalid minor version: expected numeral or wildcard, got 'b' -/
-#guard_msgs in #eval runParse "*.b.*"
+#guard_msgs in #eval runParse "*.b"
 
 /-- error: invalid patch version: expected numeral or wildcard, got 'c' -/
 #guard_msgs in #eval runParse "*.*.c"
@@ -248,3 +251,6 @@ https://doc.rust-lang.org/stable/cargo/reference/specifying-dependencies.html#wi
 
 /-- error: invalid wildcard range: incorrect number of components: got 4, expected 1-3 -/
 #guard_msgs in #eval runParse "1.*.*.*"
+
+/-- error: invalid wildcard range: wildcard versions do not support suffixes -/
+#guard_msgs in #eval runParse "1.*.*-*"


### PR DESCRIPTION
This PR improves the guidance Lake provides on unexpected version syntax. For example, if a user does not know to use `git` when requiring a version tag (e.g., via `@ "v4.31.0-rc1"`), the parser produces a better error, and the docstring of `require` highlights the `git` variant.