### PR TITLE
feat: consolidate mvcgen' syntax

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
@@ -20,23 +20,10 @@ open Std.Do
 namespace Lean.Elab.Tactic.Do.Internal
 
 /-!
-The `VCGenM` monad: its read-only `Context` (spec database + a fixed bundle of
-pre-built `BackwardRule`s + user-customisable simp methods + pre-tactic) and
-its mutable `State` (rule caches, accumulated invariants/VCs, simp cache).
+The `VCGenM` monad: its read-only `Context` (a fixed bundle of pre-built
+`BackwardRule`s + user-customisable simp methods) and its mutable `State`
+(rule caches, accumulated invariants/VCs, simp cache).
 -/
-
-/-- Pre-tactic to try on each emitted VC before returning it to the user. -/
-public inductive VCGen.PreTac where
-  /-- No pre-tactic; VCs are returned as-is. -/
-  | none
-  /-- Use grind with the given hypothesis simplification methods. -/
-  | grind (silent : Bool := false)
-  /-- Use a user-provided tactic syntax. -/
-  | tactic (tac : Syntax)
-
-public def VCGen.PreTac.isGrind : VCGen.PreTac → Bool
-  | .grind .. => true
-  | _ => false
 
 public structure VCGen.Context where
   /-- The backward rule for `SPred.entails_cons_intro`. -/
@@ -78,8 +65,6 @@ public structure VCGen.Context where
   andIntroRule : BackwardRule
   /-- User-customizable simp methods used to pre-simplify hypotheses. -/
   hypSimpMethods : Option Sym.Simp.Methods := none
-  /-- Pre-tactic to try on each emitted VC. -/
-  preTac : PreTac := .none
   /-- The `trivial` config option: when `true` (default), `Driver.emitVC` runs
   `repeatAndRfl` to collapse trivial `And.intro` chains; when `false`, the goal is
   emitted as-is. -/
@@ -99,6 +84,10 @@ public structure VCGen.Context where
   `BackwardRule.apply` calls after `unfoldReducible` and reports an error when the
   retry succeeds, pinpointing missing normalization steps in `mvcgen'`. -/
   debug : Bool := false
+  /-- The `internalize` config option: when `true` (default), `emitVC` and the
+  multi-subgoal fork in `Driver.work` call `Grind.processHypotheses`. The tactic-mode
+  entry point disables this when there is no `with` clause. -/
+  internalize : Bool := true
   /-- Pre-parsed `invariants`/`invariants?` alternatives, indexed by 1-based invariant
   number. Bullet form maps positions to entries (`bullet n+1 → alt`); labelled form maps
   the parsed `inv<n>` numbers (out-of-order labels are supported). Empty when no
@@ -155,8 +144,6 @@ public structure VCGen.State where
   this to know which user-provided alts have already been consumed (so it doesn't
   warn about them). -/
   inlineHandledInvariants : Std.HashSet Nat := {}
-  /-- Set when a pre-tactic failed on some VC; `elabMVCGen'` throws if true. -/
-  preTacFailed : Bool := false
 
 public abbrev VCGenM := ReaderT VCGen.Context (StateRefT VCGen.State Grind.GrindM)
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
@@ -18,39 +18,11 @@ open Std.Do
 namespace Lean.Elab.Tactic.Do.Internal
 
 /-!
-Worklist driver for `mvcgen'`. Wraps `solve` with a queue of pending goals,
-emits VCs (or invariant holes) for those `solve` cannot decompose further,
-and runs the user-configured `preTac` on each emitted VC.
+Worklist driver for `mvcgen'`. Wraps `solve` with a queue of pending goals
+and emits VCs (or invariant holes) for those `solve` cannot decompose further.
 -/
 
 namespace VCGen
-
-/--
-Runs the `preTac` on the VC:
-- `.grind`: tries to solve the VC using the accumulated `Grind.Goal` state via `Grind.Goal.grind`.
-  Reports failure via `Lean.logError` unless `silent` is set.
-- `.tactic`: runs the user-provided tactic on the VC, potentially emitting multiple subgoals.
-- `.none`: returns the VC as-is.
--/
-public def PreTac.run : PreTac → Grind.Goal → VCGenM (List Grind.Goal)
-  | .none, goal => return [goal]
-  | .grind silent, goal => do
-    let savedMCtx ← getMCtx
-    match ← goal.grind with
-    | .closed => return []
-    | .failed .. =>
-      setMCtx savedMCtx
-      unless silent do
-        goal.mvarId.withContext do
-          Lean.logError m!"`grind` failed on goal:{indentD (MessageData.ofGoal goal.mvarId)}"
-        modify fun s => { s with preTacFailed := true }
-      return [goal]
-  | .tactic tac, goal => do
-    let (gs, _) ← Lean.Elab.runTactic goal.mvarId tac {} {}
-    -- Need to wrap `gs` in fresh `Grind.Goal`s, preprocessing the whole goal anew.
-    -- This is important because `tac` might call e.g., `revert` which violates the contract
-    -- of `SymM` (local contexts grow monotonically).
-    gs.mapM fun mv => Grind.mkGoalCore mv
 
 /--
 Try to elaborate the user's invariant alt for invariant number `n` inline,
@@ -90,7 +62,7 @@ public def elabInvariant (invariantAlts : Std.HashMap Nat Syntax) (n : Nat) (mv 
 each in `State.invariants` (1-based stable index) and try to inline-elaborate
 its matching user alt. Returns the remaining non-invariant subgoals for `work`
 to enqueue. Eager handling here ensures dependent VCs see `?inv` assigned by
-the time they reach `emitVC`/`preTac`. -/
+the time they reach `emitVC`. -/
 private def handleInvariantSubgoals (subgoals : List MVarId) : VCGenM (Array MVarId) := do
   let env ← getEnv
   let mut others : Array MVarId := #[]
@@ -112,8 +84,8 @@ Invariant subgoals are handled separately by `handleInvariantSubgoals` directly 
 so they never reach this path.
 -/
 public def emitVC (goal : Grind.Goal) : VCGenM Unit := do
-  let goal ← (← read).preTac.processHypotheses goal
-  let mut vcs : Array Grind.Goal := #[]
+  let goal ← processHypotheses goal
+  if goal.inconsistent then return
   -- `trivial`: when false, skip `repeatAndRfl` (which collapses And-chains via rfl);
   -- emit the goal as-is.
   let mvarId ←
@@ -122,11 +94,8 @@ public def emitVC (goal : Grind.Goal) : VCGenM Unit := do
       pure mvarId
     else
       pure goal.mvarId
-  let goal := { goal with mvarId }
-  for newGoal in (← (← read).preTac.run goal) do
-    newGoal.mvarId.setKind .syntheticOpaque
-    vcs := vcs.push newGoal
-  modify fun s => { s with vcs := s.vcs ++ vcs }
+  mvarId.setKind .syntheticOpaque
+  modify fun s => { s with vcs := s.vcs.push { goal with mvarId } }
 
 private structure WorkItem where
   goal : Grind.Goal
@@ -138,6 +107,7 @@ public def work (scope : Scope) (goal : Grind.Goal) : VCGenM Unit := do
   while let some s := worklist.back? do
     worklist := worklist.pop
     let goal := s.goal
+    if goal.inconsistent then continue
     if ← outOfFuel then
       emitVC goal
       continue
@@ -159,11 +129,9 @@ public def work (scope : Scope) (goal : Grind.Goal) : VCGenM Unit := do
       -- from the worklist later see the invariant MVar already assigned.
       -- Non-invariant subgoals go to the worklist as usual and will eventually go through `emitVC`.
       let subgoals ← handleInvariantSubgoals subgoals
-      -- In grind mode with multiple subgoals, preprocess pending hypotheses
-      -- to share E-graph context before forking.
       let goal ←
         if subgoals.size > 1 then
-          (← read).preTac.processHypotheses goal
+          processHypotheses goal
         else
           pure goal
       worklist := worklist ++ subgoals.reverse.map (fun mv =>
@@ -181,8 +149,6 @@ public structure Result where
   avoid spurious "alt does not match any invariant" warnings for inline-consumed
   alts. -/
   inlineHandledInvariants : Std.HashSet Nat := {}
-  /-- True iff some non-silent pre-tactic failed during VC generation. -/
-  preTacFailed : Bool := false
 
 /--
 Generate verification conditions for a goal of the form `P ⊢ₛ wp⟦e⟧ Q s₁ ... sₙ` by repeatedly
@@ -203,8 +169,7 @@ public partial def run (goal : Grind.Goal) (ctx : Context) (scope : VCGen.Scope)
   return {
     invariants := state.invariants,
     vcs,
-    inlineHandledInvariants := state.inlineHandledInvariants,
-    preTacFailed := state.preTacFailed }
+    inlineHandledInvariants := state.inlineHandledInvariants }
 
 end VCGen
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
@@ -155,14 +155,6 @@ private def warnIgnoredConfig (config : VCGen.Config) : MetaM Unit := do
   if config.leave != default.leave then
     logWarning "mvcgen': the `leave` config option is currently ignored."
 
-/-- Parse grind configuration from the `with grind ...` clause and build `Grind.Params`.
-Overrides the internal simp step limit to accommodate large unrolled goals. -/
-private def elabGrindParams (grindStx : Syntax) (goal : MVarId) : TermElabM Grind.Params := do
-  let `(tactic| grind $config:optConfig $[only%$only]? $[ [$grindParams:grindParam,*] ]? $[=> $_:grindSeq]?) := grindStx
-    | throwUnsupportedSyntax
-  let grindConfig ← runTacticM <| elabGrindConfig config
-  mkGrindParams grindConfig only.isSome (grindParams.getD {}).getElems goal
-
 /--
 Build `Sym.Simp.Methods` from a variant name and extra theorems.
 Supports the anonymous (default) variant. Named variants require a public
@@ -208,23 +200,6 @@ private def elabSimplifyingAssumptions (simpClause : Syntax) : MetaM (Option Sym
   let extraIds? := if simpClause[2].getNumArgs != 0
     then some (simpClause[2][1].getSepArgs.map (⟨·⟩)) else none
   pure (some (← elabSymSimpParts variantId? extraIds?))
-
--- The goal is for `elabGrindParams` which uses it for library suggestions.
-private def elabPreTac (goal : MVarId) (withPreTac : Syntax) : TermElabM (VCGen.PreTac × Grind.Params) := do
-  let mut params ← Grind.mkDefaultParams {}
-  if withPreTac.getNumArgs == 0 then return (.none, params)
-  let preTac := withPreTac[1]
-  -- Look through `try` so `with (try grind)` still uses the `.grind` path.
-  let (silent, preTac) :=
-    if preTac.getKind == ``Lean.Parser.Tactic.tacticTry_ then
-      (true, preTac[1][0][0][0])
-    else
-      (false, preTac)
-  if preTac.getKind == ``Lean.Parser.Tactic.grind then
-    params ← elabGrindParams preTac goal
-    return (.grind silent, params)
-  else
-    return (.tactic preTac, params)
 
 /--
 Pre-parse the optional `invariantAlts` syntax into a map from invariant number
@@ -300,7 +275,6 @@ private structure ParsedArgs where
   config : VCGen.Config
   ctx : VCGen.Context
   scope : VCGen.Scope
-  params : Grind.Params
   invariantAlts? : Option (Std.HashMap Nat Syntax)
 
 /-- Parse `mvcgen'` arguments. -/
@@ -317,59 +291,64 @@ private def parseArgs (stx : Syntax) (goal : MVarId) : TermElabM ParsedArgs := g
   -- distinguish "default true" from "user-set true"); not yet wired.
   let (ctx, scope) ← VCGen.mkContext stx[2] goal
   let hypSimpMethods ← elabSimplifyingAssumptions stx[4]
-  let (preTac, params) ← elabPreTac goal stx[5]
   let invariantAlts? ← parseInvariantMap stx[3]
   let ctx := { ctx with
-    preTac, hypSimpMethods,
+    hypSimpMethods,
     trivial := config.trivial,
     useJP := config.jp,
     errorOnMissingSpec := config.errorOnMissingSpec,
     debug := config.debug,
+    internalize := config.internalize,
     invariantAlts := invariantAlts?.getD {} }
-  return { config, ctx, scope, params, invariantAlts? }
+  return { config, ctx, scope, invariantAlts? }
 
 /-- `mvcgen'` step inside `sym => …` blocks. -/
 @[builtin_grind_tactic Lean.Parser.Tactic.Grind.mvcgen']
 def evalSymMVCGen' : Lean.Elab.Tactic.Grind.GrindTactic := fun stx => do
   let goal ← Lean.Elab.Tactic.Grind.getMainGoal
   let args ← parseArgs stx goal.mvarId
-  if args.invariantAlts?.isNone && !stx[3].isNone then
-    throwError "`mvcgen' invariants?` (suggest mode) is not supported inside `sym => …` blocks"
   let result ← Lean.Elab.Tactic.Grind.liftGrindM do
     let result ← VCGen.run goal args.ctx args.scope args.config.stepLimit
     if let some alts := args.invariantAlts? then
       elabRemainingInvariants alts result.invariants result.inlineHandledInvariants
     return result
+  if args.invariantAlts?.isNone then
+    runTacticM (goals := result.invariants.toList) <|
+      elabInvariants stx[3] result.invariants (suggestInvariant (result.vcs.map (·.mvarId)))
   let invariants ← result.invariants.filterM (not <$> ·.isAssigned)
   let newGoals ← Lean.Elab.Tactic.Grind.liftGrindM do
     let invGoals ← invariants.toList.mapM Grind.mkGoalCore
-    -- Need to internalize all remaining hypotheses in the goal. As of May 26, it is still unclear
-    -- whether it is the job of downstream tactics such as `finish` in `sym => mvcgen'; finish`
-    -- to internalize.
-    let vcGoals ← result.vcs.toList.mapM Grind.processHypotheses
-    return invGoals ++ vcGoals
+    return invGoals ++ result.vcs.toList
   Lean.Elab.Tactic.Grind.replaceMainGoal newGoals
-  if result.preTacFailed then
-    throwError "pre-tactic failed on at least one VC; see errors above"
 
-/-- Tactic-level `mvcgen'`. -/
--- Cannot wrap `evalSymMVCGen'` because routing through `runAtGoal`/`withProtectedMCtx` wraps the
--- proof in an aux theorem, which rejects unsolved leftover VCs.
+/-- Tactic-level `mvcgen'`. Reuses the grind-mode implementation by re-quoting the
+input as `Grind.mvcgen' …` and running it inside a `GrindTacticM` context built
+without `withProtectedMCtx`, so leftover `Grind.Goal`s flow back as the new tactic
+goals. The optional `with $g:grind` clause runs as `<;> $g` and lets the user-supplied
+grind step share an internalised E-graph with `mvcgen'`. -/
 @[builtin_tactic Lean.Parser.Tactic.mvcgen']
 public def elabMVCGen' : Tactic := fun stx => withMainContext do
+  let `(tactic| mvcgen'%$tk $cfg:optConfig $[[$lems,*]]? $(invs)?
+        $[simplifying_assumptions $(sa)? $[[$thms,*]]?]? $[with $g:grind]?) := stx
+    | throwUnsupportedSyntax
+  -- Without `with`, no downstream grind step will read the E-graph, so opt out of
+  -- internalisation; `with` keeps the default `internalize := true`.
+  let cfg ← match g with
+    | some _ => pure cfg
+    | none   => do
+        let off ← `(optConfig| -internalize)
+        pure (Lean.Parser.Tactic.appendConfig off cfg)
+  let core ← `(grind| mvcgen'%$tk $cfg:optConfig $[[$lems,*]]? $(invs)?
+        $[simplifying_assumptions $(sa)? $[[$thms,*]]?]?)
+  let step ← match g with
+    | some g => `(grind| $core <;> $g)
+    | none   => pure core
   let goal ← getMainGoal
-  let args ← parseArgs stx goal
-  let result ← Grind.GrindM.run (params := args.params) do
-    let result ← VCGen.run (← Grind.mkGoalCore goal) args.ctx args.scope args.config.stepLimit
-    if let some alts := args.invariantAlts? then
-      elabRemainingInvariants alts result.invariants result.inlineHandledInvariants
-    return result
-  if args.invariantAlts?.isNone then
-    -- handle `mvcgen invariants?` suggestions. TODO: re-implement
-    elabInvariants stx[3] result.invariants (suggestInvariant (result.vcs.map (·.mvarId)))
-  let invariants ← result.invariants.filterM (not <$> ·.isAssigned)
-  replaceMainGoal (invariants.toList ++ result.vcs.toList.map (·.mvarId))
-  if result.preTacFailed then
-    throwError "pre-tactic failed on at least one VC; see errors above"
+  -- `clean := false` keeps inaccessible binder names (no `exposeNames`), so users can
+  -- still rename them with `case vcN h => …`.
+  let params ← Grind.mkDefaultParams { clean := false }
+  let (_, state) ← Grind.GrindTacticM.runAtGoal goal params (sym := true) <|
+    Grind.evalGrindTactic step
+  replaceMainGoal (state.goals.map (·.mvarId))
 
 end Lean.Elab.Tactic.Do.Internal

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Util.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Util.lean
@@ -72,6 +72,10 @@ namespace VCGen
 open Sym Sym.Internal
 open Lean.Elab.Tactic.Do.Internal
 
+/-- `Grind.processHypotheses` if `Context.internalize` is `true`, otherwise a no-op. -/
+public def processHypotheses (goal : Grind.Goal) : VCGenM Grind.Goal := do
+  if (← read).internalize then Grind.processHypotheses goal else return goal
+
 public def simpTargetTelescope (mvarId : MVarId) : VCGenM (MVarId × Bool) := do
   let some methods := (← read).hypSimpMethods | return (mvarId, false)
   let target ← mvarId.getType
@@ -98,18 +102,6 @@ public def introsSimp (mvarId : MVarId) (errorMsg : MessageData) : VCGenM MVarId
     else
       throwError m!"Failed to intro on {mvarId}\nContext: {errorMsg}."
   | .goal _ mvarId' => return mvarId'
-
-/-- Internalize pending hypotheses into the E-graph for sharing before forking to multiple subgoals.
-If `processHypotheses` discovers a contradiction (`inconsistent = true`), the E-graph state
-contains stale proof data (the contradiction proof targets the parent's mvar, not the children's).
-In that case, restore the pre-internalization state so each child can discover the contradiction
-independently and construct its own proof via `closeGoal`.
--/
-public def PreTac.processHypotheses (preTac : PreTac) (goal : Grind.Goal) : VCGenM Grind.Goal := do
-  if preTac.isGrind then
-    Grind.processHypotheses goal
-  else
-    return goal
 
 /--
 Solves conjunctions whose leaves are `True` or `e₁ = e₂`, and returns a residual goal containing

--- a/src/Std/Tactic/Do/Syntax.lean
+++ b/src/Std/Tactic/Do/Syntax.lean
@@ -60,6 +60,14 @@ structure Config where
   rule and the missing reduction. Off by default; only consulted by `mvcgen'`.
   -/
   debug : Bool := false
+  /--
+  If `true` (the default in grind mode), `mvcgen'` calls `Grind.processHypotheses` on
+  each emitted VC, internalising local hypotheses into the parent's E-graph so that
+  downstream grind steps share context. The tactic-level entry point disables this
+  when there is no `with` clause (no grind step will consume the E-graph anyway).
+  Ignored by `mvcgen`.
+  -/
+  internalize : Bool := true
 end Lean.Elab.Tactic.Do.VCGen
 
 namespace Lean.Parser
@@ -429,20 +437,25 @@ syntax (name := mvcgenHint) "mvcgen?" optConfig
 
 -- Prototypical Sym-based variant of `mvcgen`; see `mvcgen` for documentation.
 -- Same surface syntax modulo `vcAlts`, replaced by `simplifying_assumptions … with …`.
+-- The optional `with $g` form is sugar for `sym => mvcgen' … <;> $g`: it enters grind
+-- mode to share the internalised goal context with the user-supplied grind step (the only
+-- way to do so from tactic mode). `$g` is a single grind-mode step, so passing a
+-- multi-step sequence requires explicit grouping (e.g. `with (s₁; s₂)`).
 @[tactic_alt Lean.Parser.Tactic.mvcgen'Macro]
 syntax (name := mvcgen') "mvcgen'" optConfig
   (" [" withoutPosition((simpStar <|> simpErase <|> simpLemma),*,?) "] ")?
   (invariantAlts)?
   (&" simplifying_assumptions" (ppSpace colGt ident)? (" [" ident,* "]")?)?
-  (&" with " tactic)? : tactic
+  (&" with " grind)? : tactic
 
 namespace Grind
 
-/-- `mvcgen'` step for `sym => …` blocks; same surface as the tactic form. -/
+/-- `mvcgen'` step for `sym => …` blocks. No `with` clause: compose with subsequent grind
+steps using `<;>` instead. -/
 syntax (name := mvcgen') "mvcgen'" optConfig
   (" [" withoutPosition((simpStar <|> simpErase <|> simpLemma),*,?) "] ")?
   (invariantAlts)?
   (&" simplifying_assumptions" (ppSpace colGt ident)? (" [" ident,* "]")?)?
-  (&" with " tactic)? : grind
+  : grind
 
 end Grind

--- a/tests/bench/mvcgen/sym/test_do_logic.lean
+++ b/tests/bench/mvcgen/sym/test_do_logic.lean
@@ -585,7 +585,7 @@ example (p : Nat → Prop) [DecidablePred p] (n : Nat) :
     · Invariant.withEarlyReturnNewDo
         (onReturn := fun ret _ => ⌜ret = false ∧ ¬ ∀ i < n, p i⌝)
         (onContinue := fun xs _ => ⌜∀ i, i ∈ xs.prefix → p i⌝)
-  with (simp_all [-Classical.not_forall]; try grind)
+  all_goals simp_all [-Classical.not_forall]; try grind
 
 -- Labelled form: `| inv1 => …`.
 example (p : Nat → Prop) [DecidablePred p] (n : Nat) :
@@ -596,7 +596,7 @@ example (p : Nat → Prop) [DecidablePred p] (n : Nat) :
     | inv1 => Invariant.withEarlyReturnNewDo
         (onReturn := fun ret _ => ⌜ret = false ∧ ¬ ∀ i < n, p i⌝)
         (onContinue := fun xs _ => ⌜∀ i, i ∈ xs.prefix → p i⌝)
-  with (simp_all [-Classical.not_forall]; try grind)
+  all_goals simp_all [-Classical.not_forall]; try grind
 
 end InvariantSyntaxTests
 
@@ -654,13 +654,13 @@ theorem foo_spec
     (x : Id Nat → Id Nat)
     (x_spec : ∀ (k : Id Nat) (_ : ⦃⌜True⌝⦄ k ⦃⇓r => ⌜r % 2 = 0⌝⦄), ⦃⌜True⌝⦄ x k ⦃⇓r => ⌜r % 2 = 0⌝⦄) :
     ⦃⌜True⌝⦄ foo x ⦃⇓r => ⌜r % 2 = 0⌝⦄ := by
-  mvcgen' [foo, x_spec] with grind
+  mvcgen' [foo, x_spec] with finish
 
 def bar (k : Id Nat) : Id Nat := do
   let r ← k
   if r > 30 then return 12 else return r
 
 example : ⦃⌜True⌝⦄ foo bar ⦃⇓r => ⌜r % 2 = 0⌝⦄ := by
-  mvcgen' [foo_spec, bar] with grind
+  mvcgen' [foo_spec, bar] with finish
 
 end LocalSpec

--- a/tests/bench/mvcgen/sym/test_vcgen.lean
+++ b/tests/bench/mvcgen/sym/test_vcgen.lean
@@ -41,12 +41,12 @@ set_option maxHeartbeats 10000000
     `(tactic| mvcgen') `(tactic| grind) [10]
   runBenchUsingTactic ``GetThrowSet.Goal [``GetThrowSet.loop, ``GetThrowSet.step]
     `(tactic| mvcgen') `(tactic| sorry) [10]
-  -- `mvcgen' with grind`: grind integrated into VCGen loop
+  -- `mvcgen' with finish`: grind integrated into VCGen loop
   runBenchUsingTactic ``GetThrowSet.Goal [``GetThrowSet.loop, ``GetThrowSet.step]
-    `(tactic| mvcgen' with grind) `(tactic| fail) [10]
-  -- `mvcgen' with grind` on AddSubCancel
+    `(tactic| mvcgen' with finish) `(tactic| fail) [10]
+  -- `mvcgen' with finish` on AddSubCancel
   runBenchUsingTactic ``AddSubCancel.Goal [``AddSubCancel.loop, ``AddSubCancel.step]
-    `(tactic| mvcgen' with grind) `(tactic| fail) [10]
+    `(tactic| mvcgen' with finish) `(tactic| fail) [10]
   runBenchUsingTactic ``PurePrecond.Goal [``PurePrecond.loop, ``PurePrecond.step]
     `(tactic| mvcgen') `(tactic| fail) [10]
   runBenchUsingTactic ``ReaderState.Goal [``ReaderState.loop, ``ReaderState.step]

--- a/tests/bench/mvcgen/sym/vcgen_get_throw_set_grind.lean
+++ b/tests/bench/mvcgen/sym/vcgen_get_throw_set_grind.lean
@@ -15,9 +15,9 @@ end GetThrowSetGrind
 set_option maxRecDepth 100000
 set_option maxHeartbeats 100000000
 
--- Benchmark `mvcgen' with grind`: grind integrated into VCGen loop for incremental
+-- Benchmark `mvcgen' with finish`: grind integrated into VCGen loop for incremental
 -- context internalization. This avoids O(n) re-internalization per VC.
 -- `simplifying_assumptions [Nat.add_assoc]` here speeds up grind and kernel checking by a factor
 -- of 2 because long chains `s + 1 + ... + 1` are collapsed into `s + n`.
-#eval runBenchUsingTactic ``GetThrowSetGrind.Goal [``loop, ``step] `(tactic| mvcgen' simplifying_assumptions [Nat.add_assoc] with grind) `(tactic| fail)
+#eval runBenchUsingTactic ``GetThrowSetGrind.Goal [``loop, ``step] `(tactic| mvcgen' simplifying_assumptions [Nat.add_assoc] with finish) `(tactic| fail)
   [50, 100, 150]

--- a/tests/elab/mvcgenSymBlock.lean
+++ b/tests/elab/mvcgenSymBlock.lean
@@ -5,6 +5,7 @@ import Std.Tactic.Do
 open Std.Do
 
 set_option mvcgen.warning false
+set_option warn.sorry false
 
 /-! ## Trivial postcondition: `mvcgen'` closes the goal -/
 
@@ -44,7 +45,7 @@ axiom H2_spec : ⦃fun n => ⌜P n⌝⦄ H2 ⦃⇓ _ n => ⌜True⌝⦄
 
 example : ⦃⌜True⌝⦄ F2 ⦃⇓ _ n => ⌜True⌝⦄ := by
   sym =>
-    mvcgen' [F2] with grind
+    mvcgen' [F2] <;> finish
 
 /-! ## VC leftover; closed by a subsequent grind step -/
 
@@ -95,17 +96,6 @@ example : ⦃⌜True⌝⦄ F4 ⦃⇓ r _ => ⌜Q4 r⌝⦄ := by
     mvcgen' [F4]
     finish [hPQ4]
 
--- `clear hk` drops `hk` from the lctx; `hk2` remains as a proof of `k = 0`. If
--- `PreTac.run`'s `.tactic` branch inherited the parent `Grind.Goal` instead of
--- building fresh ones, the E-graph (populated by `internalize_all`) would keep
--- the now-dead `hk` fvar; `finish` constructs a proof citing it and the kernel
--- rejects with `unknown free variable`.
-example (k : Nat) (hk : k = 0) (hk2 : k = 0) : ⦃⌜True⌝⦄ F4 ⦃⇓ _ _ => ⌜k = 0⌝⦄ := by
-  sym =>
-    internalize_all
-    mvcgen' [F4] with (clear hk)
-    finish
-
 /-! ## Inline invariants (bullet form) inside `sym =>` -/
 
 example :
@@ -119,14 +109,25 @@ example :
   sym =>
     mvcgen' invariants
       · ⇓(xs, r) => ⌜r + xs.suffix.length * 5 ≤ 25⌝
-    with (simp_all; try grind)
+    <;> finish
 
-/-! ## `invariants?` (suggest mode) is rejected inside `sym =>` -/
+/-! ## `invariants?` (suggest mode) works inside `sym =>` -/
+
+def mySum (l : List Nat) : Nat := Id.run do
+  let mut acc := 0
+  for x in l do
+    acc := acc + x
+  return acc
 
 /--
-error: `mvcgen' invariants?` (suggest mode) is not supported inside `sym => …` blocks
+info: Try this:
+  [apply] invariants
+  · ⇓⟨xs, letMuts⟩ => ⌜xs.prefix = [] ∧ letMuts = 0 ∨ xs.suffix = [] ∧ letMuts = l.sum⌝
 -/
-#guard_msgs in
-example : ⦃⌜True⌝⦄ F ⦃⇓ _ n => ⌜n = n⌝⦄ := by
+#guard_msgs (info) in
+theorem mySum_suggest (l : List Nat) : mySum l = l.sum := by
+  generalize h : mySum l = r
+  apply Id.of_wp_run_eq h
   sym =>
-    mvcgen' [F] invariants?
+    mvcgen' [mySum] invariants?
+    all_goals tactic => admit


### PR DESCRIPTION
This PR consolidates `mvcgen'`'s syntax across tactic and grind (`sym =>`) modes. The grind-mode `with` clause is removed (use `<;>` instead), and the tactic-level `with` now takes a single grind step that shares an E-graph with `mvcgen'`. `mvcgen' invariants?` (suggest mode) also works inside `sym => …` blocks.

The tactic-level entry point is now a thin shim around `Grind.GrindTacticM.runAtGoal` that surfaces the remaining `Grind.Goal`s as tactic goals, so leftover VCs flow back unchanged. `emitVC` and `Driver.work`'s multi-subgoal fork call `Grind.processHypotheses` unconditionally; inconsistent goals are discharged in place via grind's `closeGoal`, and the worklist loop short-circuits any item whose E-graph is already inconsistent. A new `internalize` config option (default `true` in grind mode, `false` in tactic mode when no `with` clause is present) gates the hypothesis internalisation step. The legacy `PreTac` machinery and the duplicate tactic-mode elaborator are gone.