### PR TITLE
fix: dbgTraceIfShared in all non-linear situations

### DIFF
--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -2786,7 +2786,7 @@ extern "C" LEAN_EXPORT object * lean_dbg_sleep(uint32 ms, obj_arg fn) {
 }
 
 extern "C" LEAN_EXPORT object * lean_dbg_trace_if_shared(obj_arg s, obj_arg a) {
-    if (!lean_is_scalar(a) && lean_is_shared(a)) {
+    if (!lean_is_scalar(a) && !lean_is_exclusive(a)) {
         io_eprintln(mk_string(std::string("shared RC ") + lean_string_cstr(s)));
     }
     return a;


### PR DESCRIPTION
This PR makes `dbgTraceIfShared` print the shared message in all non-linear situations. Previously
it would only trigger if `RC > 1`. However, `RC = 0` and `RC < 0` are also non-linearity triggers.
