### PR TITLE
perf: improve DiscrTree insertion time

### DIFF
--- a/src/Lean/Meta/DiscrTree/Basic.lean
+++ b/src/Lean/Meta/DiscrTree/Basic.lean
@@ -171,6 +171,7 @@ def insertKeyValue [BEq α] (d : DiscrTree α) (keys : Array Key) (v : α) : Dis
       let c := createNodes keys v 1
       { root := d.root.insert k c }
     | some c =>
+      let d := { d with root := d.root.erase k }
       let c := insertAux keys v 1 c
       { root := d.root.insert k c }
 

--- a/src/Lean/Meta/DiscrTree/Basic.lean
+++ b/src/Lean/Meta/DiscrTree/Basic.lean
@@ -166,11 +166,11 @@ def insertKeyValue [BEq α] (d : DiscrTree α) (keys : Array Key) (v : α) : Dis
   if keys.isEmpty then panic! "invalid key sequence"
   else
     let k := keys[0]!
-    let ⟨root⟩ := d
-    let root := root.alter k fun
-      | none => some <| createNodes keys v 1
-      | some c => insertAux keys v 1 c
-    ⟨root⟩
+    { d with root :=
+        d.root.alter k fun
+          | none => some <| createNodes keys v 1
+          | some c => insertAux keys v 1 c
+    }
 
 @[deprecated insertKeyValue (since := "2026-01-02")]
 def insertCore [BEq α] (d : DiscrTree α) (keys : Array Key) (v : α) : DiscrTree α :=

--- a/src/Lean/Meta/DiscrTree/Basic.lean
+++ b/src/Lean/Meta/DiscrTree/Basic.lean
@@ -166,14 +166,11 @@ def insertKeyValue [BEq α] (d : DiscrTree α) (keys : Array Key) (v : α) : Dis
   if keys.isEmpty then panic! "invalid key sequence"
   else
     let k := keys[0]!
-    match d.root.find? k with
-    | none =>
-      let c := createNodes keys v 1
-      { root := d.root.insert k c }
-    | some c =>
-      let d := { d with root := d.root.erase k }
-      let c := insertAux keys v 1 c
-      { root := d.root.insert k c }
+    let ⟨root⟩ := d
+    let root := root.alter k fun
+      | none => some <| createNodes keys v 1
+      | some c => insertAux keys v 1 c
+    ⟨root⟩
 
 @[deprecated insertKeyValue (since := "2026-01-02")]
 def insertCore [BEq α] (d : DiscrTree α) (keys : Array Key) (v : α) : DiscrTree α :=


### PR DESCRIPTION
This PR fixes a non-linearity in DiscrTree insertion, reducing the time it takes to `import Mathlib` by ~10%