### PR TITLE
chore: pass `-ffp-contract=off`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -211,6 +211,10 @@ endif()
 # We want explicit stack probes in huge Lean stack frames for robust stack overflow detection
 string(APPEND LEANC_EXTRA_CC_FLAGS " -fstack-clash-protection")
 
+# Disable contraction of floating-point operations to ensure predictable semantics
+string(APPEND LEANC_EXTRA_CC_FLAGS " -ffp-contract=off")
+string(APPEND LEAN_EXTRA_CXX_FLAGS " -ffp-contract=off")
+
 if(NOT MULTI_THREAD)
   message(STATUS "Disabled multi-thread support, it will not be safe to run multiple threads in parallel")
   set(AUTO_THREAD_FINALIZATION OFF)


### PR DESCRIPTION
This PR passes `-ffp-contract=off` to ensure that the compiler doesn't silently change the meaning of compound floating-point operations to be different from the result of doing each operation individually.

This is just a safety measure. The expectation is that today, passing the option does not make a difference, because C compilers will not actually perform contraction on the kind of code that our C backend emits even with the default contraction setting. We pass the option anyway to future-proof against future changes to our backend and C compilers.

Independently of this, we may in the future provide a `Float.fma` function that compiles to a fused multiply-add compiler intrinsic that guarantees the fused calculation with infinite precision for the intermediate result.