### PR TITLE
test: lake: fix macOS test failures by replacing process substitution with a temp file

### DIFF
--- a/tests/lake/tests/noRelease/test.sh
+++ b/tests/lake/tests/noRelease/test.sh
@@ -53,22 +53,27 @@ diff_out() {
   sed "/$1/ s/^[^${1:0:1}]*//" | diff -u --strip-trailing-cr $2 -
 }
 echo "# TEST: Direct fetch"
-($LAKE build dep:release 2>&1 && exit 1 || true) | diff_out "Running" <(cat << 'EOF'
+# `diff_out` runs as the tail of a pipeline, so its expected-output argument
+# must be a real file. Do not inline it via process substitution
+# (e.g. `... | diff_out "Running" <(cat << 'EOF' ... EOF)`): the resulting
+# `/dev/fd` is not reliably inherited by the `diff` inside `diff_out` on macOS,
+# which then fails with `Bad file descriptor`.
+cat << 'EOF' > produced.expected
 Running dep:release
 error: failed to fetch GitHub release (run with '-v' for details)
 Some required targets logged failures:
 - dep:release
 error: build failed
 EOF
-)
+($LAKE build dep:release 2>&1 && exit 1 || true) | diff_out "Running" produced.expected
 
 # Test that an indirect fetch on the release does not cause the build to fail
 echo "# TEST: Indirect fetch"
-$LAKE build Test -q 2>&1 | diff_out "Ran" <(cat << EOF
+cat << EOF > produced.expected
 Ran dep:extraDep
 warning: building from source; failed to fetch GitHub release (run with '-v' for details)
 EOF
-)
+$LAKE build Test -q 2>&1 | diff_out "Ran" produced.expected
 
 # Test download failure
 echo "# TEST: Download failure"

--- a/tests/lake/tests/targets/clean.sh
+++ b/tests/lake/tests/targets/clean.sh
@@ -1,1 +1,1 @@
-rm -rf .lake lake-manifest.json produced.out
+rm -rf .lake lake-manifest.json produced.out produced.expected

--- a/tests/lake/tests/targets/test.sh
+++ b/tests/lake/tests/targets/test.sh
@@ -15,32 +15,37 @@ test_err 'unknown module facet `bogus`'  build +Foo:bogus
 test_err 'unknown lean_exe facet `bogus`' build a:bogus
 
 # Test custom targets and package, library, and module facets
+# `diff_out` runs as the tail of a pipeline, so its expected-output argument
+# must be a real file. Do not inline it via process substitution
+# (e.g. `$LAKE build bark | diff_out '/Bark!/' <(cat << 'EOF' ... EOF)`): the
+# resulting `/dev/fd` is not reliably inherited by the `diff` inside `diff_out`
+# on macOS, which then fails with `Bad file descriptor`.
 diff_out() {
   awk "/Ran/,$1" | sed '/Ran/ s/^[^R]*//' | diff -u --strip-trailing-cr $2 -
 }
-$LAKE build bark | diff_out '/Bark!/' <(cat << 'EOF'
+cat << 'EOF' > produced.expected
 Ran targets/bark
 info: Bark!
 EOF
-)
-$LAKE build targets/bark_bark | diff_out '0' <(cat << 'EOF'
+$LAKE build bark | diff_out '/Bark!/' produced.expected
+cat << 'EOF' > produced.expected
 Ran targets/bark
 info: Bark!
 Build completed successfully (2 jobs).
 EOF
-)
-$LAKE build targets:print_name | diff_out '/^targets/' <(cat << 'EOF'
+$LAKE build targets/bark_bark | diff_out '0' produced.expected
+cat << 'EOF' > produced.expected
 Ran targets:print_name
 info: stdout/stderr:
 targets
 EOF
-)
-$LAKE build Foo:print_name | diff_out '/^Foo/' <(cat << 'EOF'
+$LAKE build targets:print_name | diff_out '/^targets/' produced.expected
+cat << 'EOF' > produced.expected
 Ran targets/Foo:print_name
 info: stdout/stderr:
 Foo
 EOF
-)
+$LAKE build Foo:print_name | diff_out '/^Foo/' produced.expected
 $LAKE build Foo.Bar:print_src | grep --color Bar.lean
 
 # Test the module `deps` facet
@@ -118,4 +123,4 @@ test -f .lake/build/lib/lean/a.olean
 test ! -f .lake/build/bin/a
 
 # Cleanup
-rm -f produced.out
+rm -f produced.out produced.expected


### PR DESCRIPTION
This PR fixes the `noRelease` and `targets` Lake tests, which could be flaky on macOS with a spurious error: `diff: /dev/fd/63: Bad file descriptor`. See [this job run](https://github.com/whxvd/lean4/actions/runs/26748535546/job/78830277373) for an example.

These tests fed expected output to a local `diff_out` helper via a `<(...)` process substitution while the helper itself ran as the tail of a pipeline. The `<(...)` opens its `/dev/fd` descriptor in the top-level shell, but `diff` ends up running two subshell levels down (`diff_out` is a pipeline tail, and `diff` is the tail of its own inner pipeline), and on macOS that descriptor is not reliably still open there, so the open intermittently fails with `EBADF`.

The expected output is now written to a file first and passed by path, removing the fragile descriptor entirely while preserving the existing trimming logic.

Note: the failure will happen on stock `macos-*` runners, where `bash` resolves to Apple's `/bin/bash` 3.2.57: modern bash, used on other runners such as the ones `lean4` uses for CI, won't hit this.