### PR TITLE
perf: tail-recursive runtime replacements for bounded-quantifier Decidable instances

### DIFF
--- a/src/Init/Data/Nat/Lemmas.lean
+++ b/src/Init/Data/Nat/Lemmas.lean
@@ -1751,7 +1751,9 @@ grind_pattern shiftLeft_add => (m <<< n) <<< k where
 
 /-! ### Decidability of predicates -/
 
-instance decidableBallLT :
+-- `noncomputable` so the non-tail-recursive code is never compiled; the tail-recursive
+-- `@[csimp]` replacement `decidableBallLTTR` below is the only version used at runtime.
+noncomputable instance decidableBallLT :
   ∀ (n : Nat) (P : ∀ k, k < n → Prop) [∀ n h, Decidable (P n h)], Decidable (∀ n h, P n h)
 | 0, _, _ => isTrue fun _ => (by cases ·)
 | n + 1, P, H =>
@@ -1762,6 +1764,110 @@ instance decidableBallLT :
     | isFalse p => isFalse (p <| · _ _)
     | isTrue p => isTrue fun _ h' => (Nat.lt_succ_iff_lt_or_eq.1 h').elim (h _) fun hn => hn ▸ p
 
+/-! ### Tail-recursive runtime replacements for the bounded-quantifier decision procedures
+
+`decidableBallLT`, `decidableExistsLT`, and `decidableExistsLT'` recurse to depth `n` in non-tail
+position, so *running* the compiled instance is either quadratic (`decidableBallLT` rebuilds the
+predicate at every level) or overflows the stack for large `n`. Each is replaced at runtime by a
+proven-equivalent tail-recursive version via `@[csimp]`; kernel reduction (`by decide`) is
+unaffected, as it uses the original structural definitions.
+
+The roots are marked `noncomputable` so the non-tail-recursive code is never compiled at all, and
+each `@[csimp]` replacement is registered immediately after its root and *before* the `Fin`/`≤`
+wrappers (`decidableForallFin`, `decidableExistsFin`, `decidableBall/ExistsLE`, …). The wrappers
+reduce to these roots through `@[inline] decidable_of_iff`, so they pick up the tail-recursive
+versions; and because the roots are `noncomputable`, a wrapper placed before its replacement fails
+to compile rather than silently regressing. -/
+
+/-- Tail-recursive `Bool` loop: `true` iff `f i h` holds for every `i < n`
+(short-circuits on the first `false`). Used at runtime by `decidableBallLT` via `@[csimp]`. -/
+@[inline] def allLTTR (n : Nat) (f : (i : Nat) → i < n → Bool) : Bool :=
+  let rec @[specialize] loop : (i : Nat) → i ≤ n → Bool
+    | 0,      _ => true
+    | i + 1, h => f (n - (i + 1)) (by omega) && loop i (by omega)
+  loop n (Nat.le_refl n)
+
+private theorem allLTTR_loop_eq_true {n : Nat} {f : (i : Nat) → i < n → Bool} :
+    ∀ j (hj : j ≤ n),
+      (allLTTR.loop n f j hj = true) ↔ ∀ i (_ : n - j ≤ i) (h : i < n), f i h = true := by
+  intro j
+  induction j with
+  | zero =>
+    intro hj
+    constructor
+    · intro _ i hi h; omega
+    · intro _; rfl
+  | succ m ih =>
+    intro hj
+    simp only [allLTTR.loop, Bool.and_eq_true]
+    rw [ih (by omega)]
+    constructor
+    · rintro ⟨hhead, htail⟩ i hi h
+      rcases Nat.eq_or_lt_of_le hi with heq | hlt
+      · have : i = n - (m + 1) := by omega
+        subst this; exact hhead
+      · exact htail i (by omega) h
+    · intro w
+      exact ⟨w (n - (m + 1)) (by omega) (by omega), fun i _ h => w i (by omega) h⟩
+
+theorem allLTTR_eq_true {n : Nat} {f : (i : Nat) → i < n → Bool} :
+    allLTTR n f = true ↔ ∀ i (h : i < n), f i h = true := by
+  rw [allLTTR, allLTTR_loop_eq_true n (Nat.le_refl n)]
+  exact ⟨fun w i h => w i (by omega) h, fun w i _ h => w i h⟩
+
+/-- Tail-recursive `Bool` loop: `true` iff `f i h` holds for some `i < n`
+(short-circuits on the first `true`). Used at runtime by `decidableExistsLT`/`'` via `@[csimp]`. -/
+@[inline] def anyLTTR (n : Nat) (f : (i : Nat) → i < n → Bool) : Bool :=
+  let rec @[specialize] loop : (i : Nat) → i ≤ n → Bool
+    | 0,      _ => false
+    | i + 1, h => f (n - (i + 1)) (by omega) || loop i (by omega)
+  loop n (Nat.le_refl n)
+
+private theorem anyLTTR_loop_eq_true {n : Nat} {f : (i : Nat) → i < n → Bool} :
+    ∀ j (hj : j ≤ n),
+      (anyLTTR.loop n f j hj = true) ↔ ∃ i, ∃ h : i < n, n - j ≤ i ∧ f i h = true := by
+  intro j
+  induction j with
+  | zero =>
+    intro hj
+    simp only [anyLTTR.loop]
+    constructor
+    · intro h; exact Bool.noConfusion h
+    · rintro ⟨i, hlt, hi, _⟩; omega
+  | succ m ih =>
+    intro hj
+    simp only [anyLTTR.loop, Bool.or_eq_true]
+    rw [ih (by omega)]
+    constructor
+    · rintro (hhead | ⟨i, h, hi, hf⟩)
+      · exact ⟨n - (m + 1), by omega, by omega, hhead⟩
+      · exact ⟨i, h, by omega, hf⟩
+    · rintro ⟨i, h, hi, hf⟩
+      rcases Nat.eq_or_lt_of_le hi with heq | hlt
+      · left; have : i = n - (m + 1) := by omega
+        subst this; exact hf
+      · right; exact ⟨i, h, by omega, hf⟩
+
+theorem anyLTTR_eq_true {n : Nat} {f : (i : Nat) → i < n → Bool} :
+    anyLTTR n f = true ↔ ∃ i, ∃ h : i < n, f i h = true := by
+  rw [anyLTTR, anyLTTR_loop_eq_true n (Nat.le_refl n)]
+  exact ⟨fun ⟨i, h, _, hf⟩ => ⟨i, h, hf⟩, fun ⟨i, h, hf⟩ => ⟨i, h, by omega, hf⟩⟩
+
+/-- Tail-recursive runtime replacement for `decidableBallLT`. -/
+def decidableBallLTTR (n : Nat) (P : ∀ k, k < n → Prop) [∀ n h, Decidable (P n h)] :
+    Decidable (∀ n h, P n h) :=
+  decidable_of_iff (allLTTR n (fun i h => decide (P i h)) = true) <| by
+    rw [allLTTR_eq_true]
+    exact ⟨fun w i h => of_decide_eq_true (w i h), fun w i h => decide_eq_true (w i h)⟩
+
+-- Keep this `@[csimp]` *before* the `Fin`/`≤` wrappers below: they reduce to `decidableBallLT`,
+-- which is `noncomputable`, so they only compile once this tail-recursive replacement is
+-- registered. Moving it later turns a wrapper into a "compiler IR check failed" / noncomputable
+-- error rather than a silent regression.
+@[csimp] theorem decidableBallLT_eq_decidableBallLTTR :
+    @decidableBallLT = @decidableBallLTTR := by
+  funext n P H; exact Subsingleton.elim _ _
+
 instance decidableForallFin (P : Fin n → Prop) [DecidablePred P] : Decidable (∀ i, P i) :=
   decidable_of_iff (∀ k h, P ⟨k, h⟩) ⟨fun m ⟨k, h⟩ => m k h, fun m k h => m ⟨k, h⟩⟩
 
@@ -1770,18 +1876,35 @@ instance decidableBallLE (n : Nat) (P : ∀ k, k ≤ n → Prop) [∀ n h, Decid
   decidable_of_iff (∀ (k) (h : k < succ n), P k (le_of_lt_succ h))
     ⟨fun m k h => m k (lt_succ_of_le h), fun m k _ => m k _⟩
 
-instance decidableExistsLT [h : DecidablePred p] : DecidablePred fun n => ∃ m : Nat, m < n ∧ p m
+-- `noncomputable`: replaced at runtime by the tail-recursive `decidableExistsLTTR` below.
+noncomputable instance decidableExistsLT [h : DecidablePred p] :
+    DecidablePred fun n => ∃ m : Nat, m < n ∧ p m
   | 0 => isFalse (by simp only [not_lt_zero, false_and, exists_const, not_false_eq_true])
   | n + 1 =>
     @decidable_of_decidable_of_iff _ _ (@instDecidableOr _ _ (decidableExistsLT (p := p) n) (h n))
       (by simp only [Nat.lt_succ_iff_lt_or_eq, or_and_right, exists_or, exists_eq_left])
+
+/-- Tail-recursive runtime replacement for `decidableExistsLT`. -/
+def decidableExistsLTTR {p : Nat → Prop} [DecidablePred p] (n : Nat) :
+    Decidable (∃ m : Nat, m < n ∧ p m) :=
+  decidable_of_iff (anyLTTR n (fun i _ => decide (p i)) = true) <| by
+    rw [anyLTTR_eq_true]
+    exact ⟨fun ⟨i, h, hf⟩ => ⟨i, h, of_decide_eq_true hf⟩,
+           fun ⟨i, h, hp⟩ => ⟨i, h, decide_eq_true hp⟩⟩
+
+-- Keep this `@[csimp]` *before* the wrappers below (`decidableExistsLE`, `decidableExistsFin`):
+-- they reduce to the `noncomputable` `decidableExistsLT` and only compile once this is registered.
+@[csimp] theorem decidableExistsLT_eq_decidableExistsLTTR :
+    @decidableExistsLT = @decidableExistsLTTR := by
+  funext p inst n; exact Subsingleton.elim _ _
 
 instance decidableExistsLE [DecidablePred p] : DecidablePred fun n => ∃ m : Nat, m ≤ n ∧ p m :=
   fun n => decidable_of_iff (∃ m, m < n + 1 ∧ p m)
     (exists_congr fun _ => and_congr_left' Nat.lt_succ_iff)
 
 /-- Dependent version of `decidableExistsLT`. -/
-instance decidableExistsLT' {p : (m : Nat) → m < k → Prop} [I : ∀ m h, Decidable (p m h)] :
+-- `noncomputable`: replaced at runtime by the tail-recursive `decidableExistsLT'TR` below.
+noncomputable instance decidableExistsLT' {p : (m : Nat) → m < k → Prop} [I : ∀ m h, Decidable (p m h)] :
     Decidable (∃ m : Nat, ∃ h : m < k, p m h) :=
   match k, p, I with
   | 0, _, _ => isFalse (by simp)
@@ -1792,6 +1915,20 @@ instance decidableExistsLT' {p : (m : Nat) → m < k → Prop} [I : ∀ m h, Dec
       (@instDecidableOr _ _
         (decidableExistsLT' (p := fun m h => p m (by omega)) (I := fun m h => I m (by omega)))
         inferInstance)
+
+/-- Tail-recursive runtime replacement for `decidableExistsLT'`. -/
+def decidableExistsLT'TR {p : (m : Nat) → m < k → Prop} [∀ m h, Decidable (p m h)] :
+    Decidable (∃ m : Nat, ∃ h : m < k, p m h) :=
+  decidable_of_iff (anyLTTR k (fun i h => decide (p i h)) = true) <| by
+    rw [anyLTTR_eq_true]
+    exact ⟨fun ⟨i, h, hf⟩ => ⟨i, h, of_decide_eq_true hf⟩,
+           fun ⟨i, h, hp⟩ => ⟨i, h, decide_eq_true hp⟩⟩
+
+-- Keep this `@[csimp]` *before* the wrapper below (`decidableExistsLE'`): it reduces to the
+-- `noncomputable` `decidableExistsLT'` and only compiles once this is registered.
+@[csimp] theorem decidableExistsLT'_eq_decidableExistsLT'TR :
+    @decidableExistsLT' = @decidableExistsLT'TR := by
+  funext k p inst; exact Subsingleton.elim _ _
 
 /-- Dependent version of `decidableExistsLE`. -/
 instance decidableExistsLE' {p : (m : Nat) → m ≤ k → Prop} [I : ∀ m h, Decidable (p m h)] :

--- a/tests/elab/decidableBallLT_tailRecursive.lean
+++ b/tests/elab/decidableBallLT_tailRecursive.lean
@@ -1,0 +1,34 @@
+/-!
+Regression test for the tail-recursive runtime replacements of `Nat.decidableBallLT`,
+`Nat.decidableExistsLT`, and `Nat.decidableExistsLT'` (leanprover/lean4#PRNUM).
+
+Before that change these instances recursed to depth `n` in non-tail position. The `def`s below
+force the decision procedure to be compiled and run: previously `decidableBallLT` rebuilt the
+predicate at every level, so `#eval checkBallLT` took *quadratic* time and did not finish here;
+it now returns immediately. (`decidableExists{LT,LT'}` additionally overflowed the stack, but only
+for much larger `n` than is fast to evaluate, so those are exercised for correctness only below.)
+-/
+
+-- `decidableBallLT` (bounded `∀` over `Nat`): quadratic before, linear now.
+def checkBallLT : Bool := decide (∀ k, k < 2000000 → 0 ≤ k)
+/-- info: true -/
+#guard_msgs in #eval checkBallLT
+
+-- `decidableForallFin → decidableBallLT` (`∀` over `Fin`): quadratic before, linear now.
+def checkForallFin : Bool := decide (∀ i : Fin 2000000, 0 ≤ i.val)
+/-- info: true -/
+#guard_msgs in #eval checkForallFin
+
+-- Correctness of the `∃` replacements (`decidableExistsLT`, `decidableExistsFin`,
+-- `decidableExistsLT'`); small `n` keeps this fast.
+/-- info: true -/
+#guard_msgs in #eval decide (∃ k, k < 1000 ∧ k + 1 = 1000)
+/-- info: false -/
+#guard_msgs in #eval decide (∃ i : Fin 1000, i.val + 1 = 0)
+/-- info: true -/
+#guard_msgs in #eval decide (∃ k, ∃ _ : k < 1000, k + 1 = 1000)
+
+-- Kernel `by decide` (small) is unaffected: it still uses the original structural instances.
+example : ∀ i : Fin 3, i.val < 3 := by decide
+example : ∃ i : Fin 3, i.val = 2 := by decide
+example : ¬ ∃ k, k < 4 ∧ k + 1 = 0 := by decide


### PR DESCRIPTION
This PR adds tail-recursive `@[csimp]` runtime replacements for the bounded-quantifier `Decidable` instances `Nat.decidableBallLT`, `Nat.decidableExistsLT`, and `Nat.decidableExistsLT'`, so that *running* them no longer takes quadratic time or overflows the stack for large `n`.

These instances recurse to depth `n` in non-tail position. As a result the compiled instance is quadratic (`decidableBallLT` rebuilds the predicate at every level) or overflows the stack, which also affects the `Fin`/`≤` wrappers (`decidableForallFin`, `decidableExistsFin`, `decidableBallLE`, …) that reduce to these roots. For example, before this PR `#eval decide (∀ k, k < 2000000 → 0 ≤ k)` does not finish and `#eval decide (∃ k, k < 50000000 ∧ k + 1 = 0)` overflows the stack; both are now immediate.

Each replacement is registered immediately after its root and *before* the wrappers, so the wrappers — which reduce to these roots through `@[inline] decidable_of_iff` — are compiled against the tail-recursive versions too. Kernel reduction (`by decide`) is unaffected: it still uses the original structural definitions.

🤖 Prepared with Claude Code