### PR TITLE
feat: add `lake build --sandbox` to write-isolate module builds via Landlock

### DIFF
--- a/src/lake/Lake/Build/Actions.lean
+++ b/src/lake/Lake/Build/Actions.lean
@@ -84,6 +84,21 @@ def relocateSandboxOutput (d : SandboxDirs) (real : FilePath) : LogIO Unit := do
   createParentDirs real
   IO.FS.rename sp real
 
+/--
+Relocate each artifact `lean` produced under the sandbox scratch dir `d` into its
+real path. Artifacts that were not produced (e.g. `.c`/`.ir` in postpone-compile
+mode, which `leanir` writes later) are absent from the scratch dir and skipped by
+`relocateSandboxOutput`.
+-/
+def _root_.Lean.ModuleArtifacts.relocateFrom (arts : ModuleArtifacts) (d : SandboxDirs) : LogIO Unit := do
+  if let some f := arts.olean? then relocateSandboxOutput d f
+  if let some f := arts.oleanServer? then relocateSandboxOutput d f
+  if let some f := arts.oleanPrivate? then relocateSandboxOutput d f
+  if let some f := arts.ilean? then relocateSandboxOutput d f
+  if let some f := arts.ir? then relocateSandboxOutput d f
+  if let some f := arts.c? then relocateSandboxOutput d f
+  if let some f := arts.bc? then relocateSandboxOutput d f
+
 public def compileLeanModule
   (leanFile relLeanFile : FilePath)
   (setup : ModuleSetup) (setupFile : FilePath)
@@ -149,9 +164,7 @@ public def compileLeanModule
   -- (In postpone-compile mode `.c`/`.ir` are produced later by `leanir` and are
   -- simply absent from the scratch dir here, so they are skipped.)
   if let some d := sandbox? then
-    for real in #[arts.olean?, arts.oleanServer?, arts.oleanPrivate?,
-        arts.ilean?, arts.ir?, arts.c?, arts.bc?].filterMap id do
-      relocateSandboxOutput d real
+    arts.relocateFrom d
   if postponeCompile then
     if let (some irFile, some cFile) := (arts.ir?, arts.c?) then
       createParentDirs irFile

--- a/src/lake/Lake/Build/Actions.lean
+++ b/src/lake/Lake/Build/Actions.lean
@@ -25,6 +25,65 @@ open Lean hiding SearchPath
 
 namespace Lake
 
+/--
+Per-module sandbox directories: a private `scratch` directory that a sandboxed
+`lean`/`leanir` subprocess is permitted to write to, and a `tmp` subdirectory
+for the subprocess's temporary files.
+-/
+structure SandboxDirs where
+  scratch : FilePath
+  tmp : FilePath
+
+@[inline] def SandboxDirs.ofScratch (scratch : FilePath) : SandboxDirs where
+  scratch := scratch
+  tmp := scratch / "tmp"
+
+/-- Empty the scratch and tmp directories, ready for a fresh sandboxed run. -/
+def SandboxDirs.reset (d : SandboxDirs) : IO Unit := do
+  removeDirAllIfExists d.scratch
+  IO.FS.createDirAll d.scratch
+  IO.FS.createDirAll d.tmp
+
+/-- Where a sandboxed subprocess should write the artifact whose real path is `real`. -/
+@[inline] def SandboxDirs.outPath (d : SandboxDirs) (real : FilePath) : FilePath :=
+  d.scratch / real.fileName.getD real.toString
+
+/--
+Spawn arguments for running `cmd args` with `LEAN_PATH` set to `leanPath`.
+When `sandbox?` is set, the command is wrapped as
+`lean --sandbox-exec --rw <scratch> --rw <tmp> -- cmd args`, which applies a
+Landlock policy permitting filesystem writes only beneath the scratch and tmp
+directories, and `TMPDIR`/`TMP`/`TEMP`/`XDG_CACHE_HOME` are pointed at `tmp`.
+-/
+def mkLeanSpawn (lean cmd : FilePath) (args : Array String)
+    (leanPath : SearchPath) (sandbox? : Option SandboxDirs) : IO.Process.SpawnArgs :=
+  let leanPathEnv : String × Option String := ("LEAN_PATH", leanPath.toString)
+  match sandbox? with
+  | none => { cmd := cmd.toString, args, env := #[leanPathEnv] }
+  | some d =>
+    { cmd := lean.toString
+      args :=
+        #["--sandbox-exec", "--rw", d.scratch.toString, "--rw", d.tmp.toString,
+          "--", cmd.toString] ++ args
+      env := #[leanPathEnv,
+        ("TMPDIR", some d.tmp.toString), ("TMP", some d.tmp.toString),
+        ("TEMP", some d.tmp.toString), ("XDG_CACHE_HOME", some d.tmp.toString)] }
+
+/--
+Move a sandboxed output from the scratch directory to its real path `real`.
+The scratch contents are produced by an untrusted build, so anything that is not
+a plain regular file (a symlink, FIFO, device node, ...) is rejected rather than
+installed into the trusted build tree. Does nothing if the file was not produced.
+-/
+def relocateSandboxOutput (d : SandboxDirs) (real : FilePath) : LogIO Unit := do
+  let sp := d.outPath real
+  unless (← sp.pathExists) do return
+  let md ← sp.symlinkMetadata
+  unless md.type == .file do
+    error s!"sandbox produced a non-regular file for '{real}'; refusing to install it"
+  createParentDirs real
+  IO.FS.rename sp real
+
 public def compileLeanModule
   (leanFile relLeanFile : FilePath)
   (setup : ModuleSetup) (setupFile : FilePath)
@@ -33,35 +92,40 @@ public def compileLeanModule
   (leanPath : SearchPath := [])
   (lean : FilePath := "lean")
   (leanir : FilePath := "leanir")
+  (sandboxDir? : Option FilePath := none)
 : LogIO Unit := do
+  let sandbox? := sandboxDir?.map SandboxDirs.ofScratch
+  if let some d := sandbox? then d.reset
+  -- Effective output path for an artifact: redirected into the scratch dir when
+  -- sandboxing, so the untrusted subprocess never writes the real build tree.
+  let outArt (real : FilePath) : FilePath :=
+    match sandbox? with | some d => d.outPath real | none => real
   let mut args := leanArgs.push leanFile.toString
   if let some oleanFile := arts.olean? then
-    createParentDirs oleanFile
-    args := args ++ #["-o", oleanFile.toString]
+    let o := outArt oleanFile
+    createParentDirs o
+    args := args ++ #["-o", o.toString]
   if let some ileanFile := arts.ilean? then
-    createParentDirs ileanFile
-    args := args ++ #["-i", ileanFile.toString]
+    let i := outArt ileanFile
+    createParentDirs i
+    args := args ++ #["-i", i.toString]
   let opts := setup.options.toOptions
   let postponeCompile := setup.isModule && Compiler.compiler.postponeCompile.get opts
   if !postponeCompile then
     if let some cFile := arts.c? then
-      createParentDirs cFile
-      args := args ++ #["-c", cFile.toString]
+      let c := outArt cFile
+      createParentDirs c
+      args := args ++ #["-c", c.toString]
   if let some bcFile := arts.bc? then
-    createParentDirs bcFile
-    args := args ++ #["-b", bcFile.toString]
+    let b := outArt bcFile
+    createParentDirs b
+    args := args ++ #["-b", b.toString]
   createParentDirs setupFile
   IO.FS.writeFile setupFile (toJson setup).pretty
   args := args ++ #["--setup", setupFile.toString]
   args := args.push "--json"
   withLogErrorPos do
-  let out ← rawProc {
-    args
-    cmd := lean.toString
-    env := #[
-      ("LEAN_PATH", leanPath.toString)
-    ]
-  }
+  let out ← rawProc (mkLeanSpawn lean lean args leanPath sandbox?)
   unless out.stdout.isEmpty do
     let txt ← out.stdout.split '\n' |>.foldM (init := "") fun (txt : String) ln => do
       let ln := ln.copy
@@ -81,18 +145,34 @@ public def compileLeanModule
     logInfo s!"stderr:\n{out.stderr.trimAscii}"
   if out.exitCode ≠ 0 then
     error s!"Lean exited with code {out.exitCode}"
+  -- Relocate the artifacts the sandboxed `lean` produced into the real build tree.
+  -- (In postpone-compile mode `.c`/`.ir` are produced later by `leanir` and are
+  -- simply absent from the scratch dir here, so they are skipped.)
+  if let some d := sandbox? then
+    for real in #[arts.olean?, arts.oleanServer?, arts.oleanPrivate?,
+        arts.ilean?, arts.ir?, arts.c?, arts.bc?].filterMap id do
+      relocateSandboxOutput d real
   if postponeCompile then
     if let (some irFile, some cFile) := (arts.ir?, arts.c?) then
       createParentDirs irFile
       createParentDirs cFile
       try
-        proc {
-          cmd := leanir.toString
-          args := #[setupFile.toString, irFile.toString, cFile.toString]
-          env := #[
-            ("LEAN_PATH", leanPath.toString)
-          ]
-        }
+        match sandbox? with
+        | some d =>
+          d.reset
+          proc <| mkLeanSpawn lean leanir
+            #[setupFile.toString, (d.outPath irFile).toString, (d.outPath cFile).toString]
+            leanPath sandbox?
+          relocateSandboxOutput d irFile
+          relocateSandboxOutput d cFile
+        | none =>
+          proc {
+            cmd := leanir.toString
+            args := #[setupFile.toString, irFile.toString, cFile.toString]
+            env := #[
+              ("LEAN_PATH", leanPath.toString)
+            ]
+          }
       catch e =>
         if let some oleanFile := arts.olean? then
           removeFileIfExists oleanFile

--- a/src/lake/Lake/Build/Context.lean
+++ b/src/lake/Lake/Build/Context.lean
@@ -28,6 +28,14 @@ public structure BuildConfig extends LogConfig where
   /-- File to save input-to-output mappings from the build of the workspace's root -/
   outputsFile? : Option FilePath := none
   /--
+  Sandbox each module compilation so the `lean`/`leanir` subprocess can only
+  write beneath a private per-module scratch directory (Linux Landlock). Trusted
+  Lake relocates the produced artifacts afterwards. Prevents one module's build
+  from poisoning another module's `.olean`. Hard-fails if Landlock is
+  unavailable.
+  -/
+  sandbox : Bool := false
+  /--
   Per-package Lean option overrides, applied to every module whose owning
   package's `baseName` appears as a key. When `recFetchSetup` builds module
   `M`, the `LeanOptions` associated with `M.pkg.baseName` (if any) are appended
@@ -93,6 +101,9 @@ public instance [Pure m] : MonadLift LakeM (BuildT m) where
 
 @[inline] public def getNoBuild [Functor m] [MonadBuild m] : m Bool :=
   (·.noBuild) <$> getBuildConfig
+
+@[inline] public def getSandbox [Functor m] [MonadBuild m] : m Bool :=
+  (·.sandbox) <$> getBuildConfig
 
 @[inline] public def getVerbosity [Functor m] [MonadBuild m] : m Verbosity :=
   (·.verbosity) <$> getBuildConfig

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -890,8 +890,13 @@ def Module.buildLean
   let setup := {setup with importArts := transImpArts}
   let arts := mod.mkArtifacts srcFile setup.isModule
   mod.clearOutputArtifacts
+  -- When sandboxing, the `lean`/`leanir` subprocesses may only write beneath a
+  -- private per-module scratch directory (on the same filesystem as the build
+  -- dir, so artifacts can be relocated by a trusted rename).
+  let sandboxDir? := if (← getSandbox) then
+    some (mod.pkg.buildDir / "sandbox" / mod.name.toString) else none
   compileLeanModule srcFile relSrcFile setup mod.setupFile arts args
-    (← getLeanPath) (← getLean) (← getLeanir)
+    (← getLeanPath) (← getLean) (← getLeanir) sandboxDir?
   mod.clearOutputHashes
   mod.computeArtifacts setup.isModule
 

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -893,8 +893,7 @@ def Module.buildLean
   -- When sandboxing, the `lean`/`leanir` subprocesses may only write beneath a
   -- private per-module scratch directory (on the same filesystem as the build
   -- dir, so artifacts can be relocated by a trusted rename).
-  let sandboxDir? := if (← getSandbox) then
-    some (mod.pkg.buildDir / "sandbox" / mod.name.toString) else none
+  let sandboxDir? := if (← getSandbox) then some mod.sandboxDir else none
   compileLeanModule srcFile relSrcFile setup mod.setupFile arts args
     (← getLeanPath) (← getLean) (← getLeanir) sandboxDir?
   mod.clearOutputHashes

--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -57,6 +57,7 @@ BASIC OPTIONS:
   --keep-toolchain      do not update toolchain on workspace update
   --allow-empty         accept bare builds with no default targets configured
   --no-build            exit immediately if a build target is not up-to-date
+  --sandbox             confine each module build's writes via Landlock (Linux)
   --no-cache            build packages locally; do not download build caches
   --try-cache           attempt to download build caches for supported packages
   --json, -J            output JSON-formatted results (in `lake query`)

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -58,6 +58,7 @@ public structure LakeOptions where
   trustHash : Bool := true
   allowEmpty : Bool := false
   noBuild : Bool := false
+  sandbox : Bool := false
   noCache : Option Bool := none
   failLv : LogLevel := .error
   outLv? : Option LogLevel := .none
@@ -134,6 +135,7 @@ def LakeOptions.mkBuildConfig
   oldMode := opts.oldMode
   trustHash := opts.trustHash
   noBuild := opts.noBuild
+  sandbox := opts.sandbox
   verbosity := opts.verbosity
   failLv := opts.failLv
   outLv := opts.outLv
@@ -250,6 +252,7 @@ def lakeLongOption : (opt : String) → CliM PUnit
 | "--json"        => modifyThe LakeOptions ({· with outFormat := .json})
 | "--allow-empty" => modifyThe LakeOptions ({· with allowEmpty := true})
 | "--no-build"    => modifyThe LakeOptions ({· with noBuild := true})
+| "--sandbox"     => modifyThe LakeOptions ({· with sandbox := true})
 | "--no-cache"    => modifyThe LakeOptions ({· with noCache := true})
 | "--try-cache"   => modifyThe LakeOptions ({· with noCache := false})
 | "--rehash"      => modifyThe LakeOptions ({· with trustHash := false})

--- a/src/lake/Lake/Config/Module.lean
+++ b/src/lake/Lake/Config/Module.lean
@@ -122,6 +122,10 @@ public abbrev pkg (self : Module) : Package :=
 @[inline] public def irDir (self : Module) : FilePath :=
   Lean.modToFilePath self.pkg.irDir self.name.getPrefix ""
 
+/-- The private per-module scratch directory used by `lake build --sandbox`. -/
+@[inline] public def sandboxDir (self : Module) : FilePath :=
+  Lean.modToFilePath (self.pkg.buildDir / "sandbox") self.name ""
+
 @[inline] public def setupFile (self : Module) : FilePath :=
   self.irPath "setup.json"
 

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -21,6 +21,7 @@ set(
   sharecommon.cpp
   stack_overflow.cpp
   process.cpp
+  landlock.cpp
   object_ref.cpp
   mpn.cpp
   mutex.cpp

--- a/src/runtime/landlock.cpp
+++ b/src/runtime/landlock.cpp
@@ -1,0 +1,287 @@
+/*
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Kim Morrison
+*/
+#include "runtime/landlock.h"
+
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+
+/* This file is deliberately freestanding: it runs before any Lean runtime
+   initialization and must not depend on runtime state. It uses only libc and
+   raw syscalls. The Landlock ABI constants and syscall numbers are defined
+   here rather than pulled from `<linux/landlock.h>` / `<sys/syscall.h>`, since
+   build hosts frequently have userspace headers older than the running
+   kernel. */
+
+#if defined(__linux__)
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <dirent.h>
+#include <errno.h>
+#include <stdint.h>
+#include <signal.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <sys/types.h>
+
+#ifndef PR_SET_NO_NEW_PRIVS
+#define PR_SET_NO_NEW_PRIVS 38
+#endif
+
+// Landlock syscall numbers. These share the same values on the architectures
+// Lean targets on Linux (x86-64 and arm64); fall back to them if the toolchain
+// headers predate Landlock.
+#ifndef __NR_landlock_create_ruleset
+#define __NR_landlock_create_ruleset 444
+#endif
+#ifndef __NR_landlock_add_rule
+#define __NR_landlock_add_rule 445
+#endif
+#ifndef __NR_landlock_restrict_self
+#define __NR_landlock_restrict_self 446
+#endif
+#ifndef __NR_close_range
+#define __NR_close_range 436
+#endif
+
+// Landlock ABI constants (see include/uapi/linux/landlock.h).
+#define LL_CREATE_RULESET_VERSION (1U << 0)
+
+#define LL_ACCESS_FS_EXECUTE     (1ULL << 0)
+#define LL_ACCESS_FS_WRITE_FILE  (1ULL << 1)
+#define LL_ACCESS_FS_READ_FILE   (1ULL << 2)
+#define LL_ACCESS_FS_READ_DIR    (1ULL << 3)
+#define LL_ACCESS_FS_REMOVE_DIR  (1ULL << 4)
+#define LL_ACCESS_FS_REMOVE_FILE (1ULL << 5)
+#define LL_ACCESS_FS_MAKE_CHAR   (1ULL << 6)
+#define LL_ACCESS_FS_MAKE_DIR    (1ULL << 7)
+#define LL_ACCESS_FS_MAKE_REG    (1ULL << 8)
+#define LL_ACCESS_FS_MAKE_SOCK   (1ULL << 9)
+#define LL_ACCESS_FS_MAKE_FIFO   (1ULL << 10)
+#define LL_ACCESS_FS_MAKE_BLOCK  (1ULL << 11)
+#define LL_ACCESS_FS_MAKE_SYM    (1ULL << 12)
+#define LL_ACCESS_FS_REFER       (1ULL << 13)  // ABI >= 2
+#define LL_ACCESS_FS_TRUNCATE    (1ULL << 14)  // ABI >= 3
+
+#define LL_RULE_PATH_BENEATH 1
+
+namespace {
+
+struct ll_ruleset_attr {
+    uint64_t handled_access_fs;
+};
+
+struct ll_path_beneath_attr {
+    uint64_t allowed_access;
+    int32_t  parent_fd;
+} __attribute__((packed));
+
+inline long ll_create_ruleset(const ll_ruleset_attr * attr, size_t size, uint32_t flags) {
+    return syscall(__NR_landlock_create_ruleset, attr, size, flags);
+}
+
+inline long ll_add_rule(int ruleset_fd, const ll_path_beneath_attr * attr, uint32_t flags) {
+    return syscall(__NR_landlock_add_rule, ruleset_fd, LL_RULE_PATH_BENEATH, attr, flags);
+}
+
+inline long ll_restrict_self(int ruleset_fd, uint32_t flags) {
+    return syscall(__NR_landlock_restrict_self, ruleset_fd, flags);
+}
+
+void fail(const char * msg) {
+    fprintf(stderr, "lean: --sandbox-exec: %s\n", msg);
+}
+
+void fail_errno(const char * msg) {
+    fprintf(stderr, "lean: --sandbox-exec: %s: %s\n", msg, strerror(errno));
+}
+
+// Close every file descriptor except stdio (0/1/2). This is essential, not
+// hygiene: Landlock does not restrict files that were already open before the
+// policy is applied, so an inherited writable fd into the build tree would
+// defeat the sandbox entirely (man landlock.7).
+void close_inherited_fds() {
+    long r = syscall(__NR_close_range, (unsigned)3, ~0U, 0u);
+    if (r == 0)
+        return;
+    // Fallback for kernels < 5.9 without close_range: walk /proc/self/fd.
+    DIR * d = opendir("/proc/self/fd");
+    if (d == nullptr) {
+        // Last-resort: best-effort close up to a conservative bound.
+        for (int fd = 3; fd < 1024; fd++)
+            close(fd);
+        return;
+    }
+    int dir_fd = dirfd(d);
+    struct dirent * ent;
+    while ((ent = readdir(d)) != nullptr) {
+        if (ent->d_name[0] < '0' || ent->d_name[0] > '9')
+            continue;
+        int fd = atoi(ent->d_name);
+        if (fd >= 3 && fd != dir_fd)
+            close(fd);
+    }
+    closedir(d);
+}
+
+} // namespace
+
+extern "C" int lean_sandbox_exec(int argc, char ** argv) {
+    // Expected layout: argv[0] = this lean binary
+    //                  argv[1] = "--sandbox-exec"
+    //                  ("--rw" <dir>)*  "--"  <prog> <args...>
+    char * rw_dirs[256];
+    int num_rw = 0;
+    int i = 2;
+    for (; i < argc; i++) {
+        if (strcmp(argv[i], "--rw") == 0) {
+            if (i + 1 >= argc) { fail("--rw requires a directory argument"); return 1; }
+            if (num_rw >= 256) { fail("too many --rw directories"); return 1; }
+            rw_dirs[num_rw++] = argv[++i];
+        } else if (strcmp(argv[i], "--") == 0) {
+            i++;
+            break;
+        } else {
+            fail("unexpected argument before '--' (expected --rw <dir> or --)");
+            return 1;
+        }
+    }
+    if (i >= argc) { fail("missing '-- <prog> <args...>'"); return 1; }
+    char ** child_argv = &argv[i];
+
+    // Run the inner program in a fresh process group under a Landlock policy, so
+    // we can later SIGKILL the whole group (defeating any backgrounded writer
+    // that retained an fd to a scratch artifact) before Lake relocates outputs.
+    pid_t pid = fork();
+    if (pid < 0) {
+        fail_errno("fork failed");
+        return 1;
+    }
+    if (pid == 0) {
+        // --- Child: new process group, sandbox, then exec the inner program. ---
+        setpgid(0, 0);
+
+        // 1. Drop inherited file descriptors. Essential, not hygiene: Landlock
+        //    does not restrict files already open before the policy is applied.
+        close_inherited_fds();
+
+        // 2. No new privileges, required for unprivileged Landlock.
+        if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) {
+            fail_errno("prctl(PR_SET_NO_NEW_PRIVS) failed");
+            _exit(1);
+        }
+
+        // 3. Require Landlock ABI >= 3 (TRUNCATE handling). Below that we cannot
+        //    prevent a sibling artifact from being truncated, so the write
+        //    isolation property would not hold.
+        long abi = ll_create_ruleset(nullptr, 0, LL_CREATE_RULESET_VERSION);
+        if (abi < 0) {
+            fail_errno("Landlock is not available (landlock_create_ruleset)");
+            _exit(1);
+        }
+        if (abi < 3) {
+            fprintf(stderr, "lean: --sandbox-exec: Landlock ABI %ld too old; "
+                            "version >= 3 (Linux 6.2) is required\n", abi);
+            _exit(1);
+        }
+
+        // 4. Handle only write-class filesystem access rights. Read, execute,
+        //    and ioctl rights are intentionally NOT handled, so they remain
+        //    unrestricted.
+        uint64_t handled =
+            LL_ACCESS_FS_WRITE_FILE  |
+            LL_ACCESS_FS_REMOVE_DIR  |
+            LL_ACCESS_FS_REMOVE_FILE |
+            LL_ACCESS_FS_MAKE_CHAR   |
+            LL_ACCESS_FS_MAKE_DIR    |
+            LL_ACCESS_FS_MAKE_REG    |
+            LL_ACCESS_FS_MAKE_SOCK   |
+            LL_ACCESS_FS_MAKE_FIFO   |
+            LL_ACCESS_FS_MAKE_BLOCK  |
+            LL_ACCESS_FS_MAKE_SYM    |
+            LL_ACCESS_FS_REFER       |   // ABI >= 2
+            LL_ACCESS_FS_TRUNCATE;       // ABI >= 3
+
+        ll_ruleset_attr attr = { handled };
+        int ruleset_fd = (int)ll_create_ruleset(&attr, sizeof(attr), 0);
+        if (ruleset_fd < 0) {
+            fail_errno("landlock_create_ruleset failed");
+            _exit(1);
+        }
+
+        // 5. Grant the handled write rights beneath each --rw directory only.
+        for (int k = 0; k < num_rw; k++) {
+            const char * dir = rw_dirs[k];
+            int dfd = open(dir, O_PATH | O_CLOEXEC);
+            if (dfd < 0) {
+                fprintf(stderr, "lean: --sandbox-exec: cannot open --rw directory '%s': %s\n",
+                        dir, strerror(errno));
+                _exit(1);
+            }
+            ll_path_beneath_attr pb = { handled, dfd };
+            if (ll_add_rule(ruleset_fd, &pb, 0) != 0) {
+                fprintf(stderr, "lean: --sandbox-exec: landlock_add_rule for '%s' failed: %s\n",
+                        dir, strerror(errno));
+                _exit(1);
+            }
+            close(dfd);
+        }
+
+        // 5b. Always permit writing to /dev/null (and /dev/full): tooling writes
+        //     there routinely and it cannot be used to poison build outputs.
+        static const char * const writable_devs[] = { "/dev/null", "/dev/full" };
+        for (unsigned di = 0; di < sizeof(writable_devs) / sizeof(writable_devs[0]); di++) {
+            int fd = open(writable_devs[di], O_PATH | O_CLOEXEC);
+            if (fd < 0)
+                continue; // best-effort
+            ll_path_beneath_attr pb = { LL_ACCESS_FS_WRITE_FILE | LL_ACCESS_FS_TRUNCATE, fd };
+            ll_add_rule(ruleset_fd, &pb, 0); // ignore failure
+            close(fd);
+        }
+
+        // 6. Enforce, then exec; the domain is inherited across execve.
+        if (ll_restrict_self(ruleset_fd, 0) != 0) {
+            fail_errno("landlock_restrict_self failed");
+            _exit(1);
+        }
+        close(ruleset_fd);
+
+        execvp(child_argv[0], child_argv);
+        fprintf(stderr, "lean: --sandbox-exec: failed to exec '%s': %s\n",
+                child_argv[0], strerror(errno));
+        _exit(127);
+    }
+
+    // --- Parent: supervise. Not under Landlock, in a different process group. ---
+    setpgid(pid, pid); // race-free with the child's own setpgid
+
+    int status = 0;
+    while (waitpid(pid, &status, 0) < 0 && errno == EINTR) { /* retry */ }
+
+    // Kill anything the inner build left running in its process group, so no
+    // surviving process can mutate a scratch artifact after this returns.
+    kill(-pid, SIGKILL);
+    while (waitpid(-pid, nullptr, WNOHANG) > 0) { /* reap */ }
+
+    if (WIFEXITED(status))
+        return WEXITSTATUS(status);
+    if (WIFSIGNALED(status))
+        return 128 + WTERMSIG(status);
+    return 1;
+}
+
+#else // !__linux__
+
+extern "C" int lean_sandbox_exec(int, char **) {
+    fprintf(stderr, "lean: --sandbox-exec: filesystem sandboxing is only "
+                    "supported on Linux (Landlock)\n");
+    return 1;
+}
+
+#endif

--- a/src/runtime/landlock.h
+++ b/src/runtime/landlock.h
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Kim Morrison
+*/
+#pragma once
+
+/* Self-exec sandbox entry point.
+
+   When the `lean` binary is invoked as
+
+       lean --sandbox-exec --rw <dir> [--rw <dir>...] -- <prog> <args...>
+
+   it forks a child that starts a new process group, closes inherited file
+   descriptors, applies a Linux Landlock policy permitting filesystem *writes*
+   only beneath the given `--rw` directories (reads and execution stay
+   unrestricted), and then `execvp`s `<prog> <args...>`. The parent supervises:
+   once the child exits it `SIGKILL`s the whole process group, so no backgrounded
+   process can mutate a sandboxed output after this returns.
+
+   This must be called as the very first thing in `main`, before any thread or
+   runtime state exists, so that the (inherited-across-execve) Landlock domain
+   covers the inner process and all of its future threads.
+
+   Returns the inner program's exit code (or 128+signal), or a nonzero error
+   code if the sandbox could not be set up. */
+extern "C" int lean_sandbox_exec(int argc, char ** argv);

--- a/src/util/shell.cpp
+++ b/src/util/shell.cpp
@@ -9,6 +9,7 @@ Author: Leonardo de Moura
 #include <signal.h>
 #include <cctype>
 #include <cstdlib>
+#include <cstring>
 #include <string>
 #include <utility>
 #include <vector>
@@ -23,6 +24,7 @@ Author: Leonardo de Moura
 #include "runtime/object_ref.h"
 #include "runtime/option_ref.h"
 #include "runtime/utf8.h"
+#include "runtime/landlock.h"
 #include "util/timer.h"
 #include "util/macros.h"
 #include "util/io.h"
@@ -281,6 +283,11 @@ static void report_task_get_blocked_time(std::chrono::nanoseconds d) {
 }
 
 extern "C" LEAN_EXPORT int lean_main(int argc, char ** argv) {
+    // Self-exec sandbox mode: apply a Landlock write-isolation policy and exec
+    // the inner program. This must run before any runtime/thread state exists so
+    // the inherited Landlock domain covers all of the inner process's threads.
+    if (argc >= 2 && strcmp(argv[1], "--sandbox-exec") == 0)
+        return lean_sandbox_exec(argc, argv);
 #ifdef LEAN_EMSCRIPTEN
     // When running in command-line mode under Node.js, we make system directories available in the virtual filesystem.
     // This mode is used to compile 32-bit oleans.

--- a/tests/lake/tests/sandbox/Test/A.lean
+++ b/tests/lake/tests/sandbox/Test/A.lean
@@ -1,0 +1,2 @@
+-- An innocuous module whose `.olean` an attacker would like to poison.
+def Test.A.value : Nat := 1

--- a/tests/lake/tests/sandbox/Test/B.lean
+++ b/tests/lake/tests/sandbox/Test/B.lean
@@ -1,0 +1,13 @@
+-- A module with an innocuous-looking diff. It does NOT import `Test.A`, but its
+-- elaboration tries to overwrite `Test.A`'s `.olean` on disk. Without the
+-- sandbox this succeeds (the cache-poisoning attack); under `--sandbox` the
+-- write is denied by Landlock and is caught here.
+def Test.B.value : Nat := 2
+
+#eval show IO Unit from do
+  let target : System.FilePath := ".lake/build/lib/lean/Test/A.olean"
+  try
+    IO.FS.writeFile target "POISONED-BY-B"
+    IO.eprintln "B: overwrote Test/A.olean"
+  catch e =>
+    IO.eprintln s!"B: write to Test/A.olean was blocked: {e}"

--- a/tests/lake/tests/sandbox/clean.sh
+++ b/tests/lake/tests/sandbox/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out probe.out

--- a/tests/lake/tests/sandbox/lakefile.toml
+++ b/tests/lake/tests/sandbox/lakefile.toml
@@ -1,0 +1,6 @@
+name = "sandbox"
+defaultTargets = ["Test"]
+
+[[lean_lib]]
+name = "Test"
+globs = "Test.+"

--- a/tests/lake/tests/sandbox/test.sh
+++ b/tests/lake/tests/sandbox/test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+# `lake build --sandbox` confines each module compilation so the `lean`
+# subprocess can only write beneath a private per-module scratch directory
+# (Linux Landlock). This prevents one module's build from poisoning another
+# module's `.olean` -- see the "Hardening the cache" discussion.
+
+OLEAN=.lake/build/lib/lean/Test/A.olean
+
+# Probe whether Landlock (and thus `--sandbox`) is available on this host.
+# `--sandbox` hard-fails where Landlock is unavailable, so on such hosts we
+# skip the behavioural assertions rather than report a spurious failure.
+echo "# probe --sandbox availability"
+if ! "$LAKE" build --sandbox Test.A >probe.out 2>&1; then
+  if grep -qi "landlock\|sandbox" probe.out; then
+    echo "SKIP: Landlock unavailable on this host"
+    cat probe.out
+    ./clean.sh
+    exit 0
+  fi
+  cat probe.out
+  echo "FAILURE: --sandbox probe failed for a non-Landlock reason"
+  exit 1
+fi
+./clean.sh
+
+# 1. Threat reproduction: without the sandbox, building `Test.B` overwrites the
+#    already-built `Test.A.olean`.
+echo "# TEST: without --sandbox, a sibling module poisons A.olean"
+test_run build Test.A   # build A first, so its .olean exists to be clobbered
+test_run build Test.B   # B's elaboration overwrites A.olean
+if grep -qa "POISONED-BY-B" "$OLEAN"; then
+  echo "OK: A.olean was poisoned without the sandbox (threat reproduced)"
+else
+  echo "FAILURE: expected A.olean to be poisoned without --sandbox"
+  exit 1
+fi
+
+./clean.sh
+
+# 2. With the sandbox, B's write to A.olean is denied and A.olean stays intact.
+echo "# TEST: with --sandbox, the sibling write is denied"
+test_run build --sandbox Test.A
+test_run build --sandbox Test.B
+if grep -qa "POISONED-BY-B" "$OLEAN"; then
+  echo "FAILURE: A.olean was poisoned despite --sandbox"
+  exit 1
+fi
+echo "OK: A.olean intact under --sandbox"
+
+# Sanity: the sandboxed build still produces a usable A.olean.
+test_run build --sandbox Test.A Test.B
+
+./clean.sh
+rm -f produced.out probe.out


### PR DESCRIPTION
This PR adds an opt-in `lake build --sandbox` flag that confines each module compilation so the `lean`/`leanir` subprocess can only write beneath a private per-module scratch directory (via the Linux Landlock LSM); trusted Lake then relocates the produced artifacts into the build tree. This prevents one module's build from writing another module's `.olean` (or any other build output), closing the cache-poisoning vector in which an innocuous-looking diff ships a poisoned olean under an unrelated module's hash — the concern discussed in [#mathlib-maintainers > Hardening the cache](https://leanprover.zulipchat.com/#narrow/channel/180721-mathlib-maintainers/topic/Hardening.20the.20cache).

The sandbox restricts only filesystem *writes* — reads and execution stay unrestricted, so no read allow-listing is needed. It is applied by a new `lean --sandbox-exec --rw <dir> … -- <prog>` mode handled at the very top of `main` (before any thread exists, so the Landlock domain is inherited by all of the inner process's threads). That mode closes inherited file descriptors (Landlock does not restrict already-open fds), installs a write-only ruleset granted on the scratch and tmp directories (plus `/dev/null`), and runs the inner process in its own process group, `SIGKILL`-ing the group once it exits so a backgrounded writer cannot mutate an output after the build. Lake redirects each module's outputs into the scratch dir, validates the produced files as regular files (rejecting symlinks/FIFOs/device nodes), and relocates them with an atomic rename.

It requires Landlock ABI ≥ 3 (Linux 6.2, for `LANDLOCK_ACCESS_FS_TRUNCATE`) and hard-fails where Landlock is unavailable; it is off by default. `tests/lake/tests/sandbox` reproduces the sibling-poisoning attack and checks that `--sandbox` blocks it (gated to skip on hosts without Landlock).

This is a draft. Known follow-ups: the guarantee is filesystem write-isolation only (network/ptrace/etc. are out of scope; builds already run without network); evil code that lives in a module's *own* reviewable diff is by design not prevented; non-Linux platforms get no protection; and signing CI-produced cache artifacts is a complementary, orthogonal direction not addressed here.

🤖 Prepared with Claude Code