### PR TITLE
chore: make async tests less flaky

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -164,6 +164,9 @@ function(add_test_pile DIR GLOB)
         # On Windows, we can't call the file directly, hence we always use bash.
         COMMAND bash "${WITH_TEST_ENV}" "${RUN_TEST}" "${FILE_IN_DIR}"
       )
+      if(EXISTS "${FILE}.serial")
+        set_tests_properties("${FILE_IN_SOURCE_DIR}" PROPERTIES RUN_SERIAL TRUE)
+      endif()
     endif()
 
     if(RUN_BENCH_EXISTS AND NOT EXISTS "${FILE}.no_bench")

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,6 +13,13 @@ Here however, each file of a directory-specific extension (usually `.lean`) repr
 The run scripts are executed once for each test file with their working directory set to the pile directory.
 Often, additional supplementary files are placed next to the test files and interpreted by the run scripts.
 
+In a test pile, individual files can be excluded from testing or benchmarking
+by creating a `<file>.no_test` or `<file>.no_bench` file next to the test file.
+If a test must run serially (i.e. not in parallel with any other tests),
+create a `<file>.serial` file next to the test file.
+These auxiliary files should be avoided if possible.
+When used, they should contain a short comment describing why.
+
 ## Directory structure
 
 Benchmarks belonging to the old framework are not included in this description.

--- a/tests/elab/async_cancellation.lean.serial
+++ b/tests/elab/async_cancellation.lean.serial
@@ -1,0 +1,2 @@
+This test counts completed work units in a specific window of time. The count
+must neither be too high nor too low. Under high load, the test may fail.

--- a/tests/elab/async_dns.lean.serial
+++ b/tests/elab/async_dns.lean.serial
@@ -1,0 +1,2 @@
+This test uses a timeout while doing a DNS lookup. Under high load, the test may
+fail.

--- a/tests/elab/async_http_fuzz.lean.serial
+++ b/tests/elab/async_http_fuzz.lean.serial
@@ -1,0 +1,1 @@
+This test uses timeouts and thus may fail under heavy load.

--- a/tests/elab/async_http_fuzz_limits.lean.serial
+++ b/tests/elab/async_http_fuzz_limits.lean.serial
@@ -1,0 +1,1 @@
+This test uses timeouts and thus may fail under heavy load.

--- a/tests/elab/async_http_fuzz_random.lean.serial
+++ b/tests/elab/async_http_fuzz_random.lean.serial
@@ -1,0 +1,1 @@
+This test uses timeouts and thus may fail under heavy load.

--- a/tests/elab/async_http_hang_regressions.lean.serial
+++ b/tests/elab/async_http_hang_regressions.lean.serial
@@ -1,0 +1,1 @@
+This test uses timeouts and thus may fail under heavy load.

--- a/tests/elab/async_select_socket.lean
+++ b/tests/elab/async_select_socket.lean
@@ -2,8 +2,6 @@ import Std.Async.Timer
 import Std.Async.TCP
 import Std.Async.UDP
 
-#exit -- TODO: remove `#exit` after nondet issue is resolved.
-
 open Std Async
 
 namespace TCP

--- a/tests/elab/async_select_socket.lean.out.expected
+++ b/tests/elab/async_select_socket.lean.out.expected
@@ -1,1 +1,2 @@
-async_select_socket.lean:5:0-5:5: warning: using 'exit' to interrupt Lean
+sending client
+sending client

--- a/tests/elab/async_select_socket.lean.serial
+++ b/tests/elab/async_select_socket.lean.serial
@@ -1,0 +1,1 @@
+This test uses timeouts and thus may fail under heavy load.

--- a/tests/elab/async_select_timer.lean.serial
+++ b/tests/elab/async_select_timer.lean.serial
@@ -1,0 +1,1 @@
+This test relies on sleep timing and thus may fail under heavy load.

--- a/tests/env.sh.in
+++ b/tests/env.sh.in
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-export ${TEST_VARS}
-source "$TEST_DIR/util.sh"


### PR DESCRIPTION
The async tests seem to miss even generous timeouts under high load. This PR runs those tests that include timeouts in serial instead of in parallel with all the other tests. The reduced load should make the tests less flaky.