### PR TITLE
feat: detect and special case XORs when lowering AIG to CNF

### DIFF
--- a/src/Std/Sat/AIG/Basic.lean
+++ b/src/Std/Sat/AIG/Basic.lean
@@ -85,7 +85,7 @@ private theorem invert_eq_testBit (f : Fanin) : f.invert = f.val.testBit 0 := by
   simp [invert, Nat.testBit]
 
 @[simp]
-theorem invert_flip (f : Fanin) : (f.flip v).invert = f.invert ^^ v := by
+theorem invert_flip (f : Fanin) : (f.flip v).invert = (f.invert ^^ v) := by
   cases v <;> simp [flip, invert_eq_testBit, -Nat.mod_two_not_eq_one]
 
 end Fanin

--- a/src/Std/Sat/AIG/CNF.lean
+++ b/src/Std/Sat/AIG/CNF.lean
@@ -8,6 +8,7 @@ module
 prelude
 public import Std.Sat.CNF
 public import Std.Sat.AIG.Lemmas
+import Std.Sat.AIG.DetectGates
 import Init.ByCases
 import Init.Omega
 
@@ -51,6 +52,17 @@ def gateToCNF (output : α) (lhs rhs : α) (linv rinv : Bool) : CNF α :=
     |>.add [(output, .false), (rhs, !rinv)]
     |>.add [(output, true),  (lhs, linv), (rhs, rinv)]
 
+/--
+Produce a Tseitin style CNF for an XOR gate, using `output` as the tree node variable.
+-/
+def xorToCNF (output : α) (lhs rhs : α) (linv rinv : Bool) : CNF α :=
+  -- a ↔ (b xor c) as cnf: (¬a ∨ b ∨ c) ∧ (¬a ∨ ¬b ∨ ¬c) ∧ (a ∨ b ∨ ¬c) ∧ (a ∨ ¬b ∨ c)
+  CNF.empty
+    |>.add [(output, .false), (lhs, linv), (rhs, rinv)]
+    |>.add [(output, .false), (lhs, !linv), (rhs, !rinv)]
+    |>.add [(output, true), (lhs, linv), (rhs, !rinv)]
+    |>.add [(output, true), (lhs, !linv), (rhs, rinv)]
+
 @[simp]
 theorem falseToCNF_eval :
     (falseToCNF output).eval assign
@@ -73,6 +85,20 @@ theorem gateToCNF_eval :
       =
     (assign output == (((assign lhs) ^^ linv) && ((assign rhs) ^^ rinv))) := by
   simp only [gateToCNF, CNF.eval_add, CNF.Clause.eval_cons, beq_true, CNF.Clause.eval_nil,
+    Bool.or_false, beq_false, CNF.eval_empty, Bool.and_true]
+  cases assign output
+    <;> cases assign lhs
+      <;> cases assign rhs
+        <;> cases linv
+          <;> cases rinv
+            <;> decide
+
+@[simp]
+theorem xorToCNF_eval :
+    (xorToCNF output lhs rhs linv rinv).eval assign
+      =
+    (assign output == (((assign lhs) ^^ linv) ^^ ((assign rhs) ^^ rinv))) := by
+  simp only [xorToCNF, CNF.eval_add, CNF.Clause.eval_cons, beq_true, CNF.Clause.eval_nil,
     Bool.or_false, beq_false, CNF.eval_empty, Bool.and_true]
   cases assign output
     <;> cases assign lhs
@@ -349,6 +375,48 @@ def Cache.addGate (cache : Cache aig cnf) {hlb} {hrb} (idx : Nat) (h : idx < aig
   ⟨out, IsExtensionBy_set cache out idx hmarkbound (by simp [out])⟩
 
 /--
+Add an XOR gate to a cache.
+-/
+def Cache.addXor (cache : Cache aig cnf) {lhs rhs : Fanin} {hlb} {hrb} (idx : Nat)
+    (h : idx < aig.decls.size)
+    (hltl : lhs.gate < idx)
+    (hltr : rhs.gate < idx)
+    (hl : cache.marks[lhs.gate]'hlb = true)
+    (hr : cache.marks[rhs.gate]'hrb = true)
+    (hdenote : ∀ assign, ⟦aig, ⟨idx, false, h⟩, assign⟧ =
+      (⟦aig, ⟨lhs.gate, lhs.invert, by omega⟩, assign⟧ ^^ ⟦aig, ⟨rhs.gate, rhs.invert, by omega⟩, assign⟧)) :
+    {
+      out : Cache aig (cnf ++ Decl.xorToCNF idx lhs.gate rhs.gate lhs.invert rhs.invert)
+        //
+      Cache.IsExtensionBy cache out idx h
+    } :=
+  have hmarkbound : idx < cache.marks.size := by have := cache.hmarks; omega
+  let out :=
+    { cache with
+      marks := cache.marks.set idx true
+      hmarks := by simp [cache.hmarks]
+      inv := by
+        intro assign heval idx hbound hmarked
+        rw [Array.getElem_set] at hmarked
+        split at hmarked
+        next heq =>
+          simp only [heq, CNF.eval_append, Decl.xorToCNF_eval, Bool.and_eq_true, beq_iff_eq]
+            at heval
+          have hleval := cache.inv assign heval.left lhs.gate (by omega) hl
+          have hreval := cache.inv assign heval.left rhs.gate (by omega) hr
+          subst heq
+          simp only [hdenote, projectRightAssign_property, heval]
+          generalize lhs.invert = linv
+          generalize rhs.invert = rinv
+          cases linv <;> cases rinv <;> simp [hleval, hreval]
+        next heq =>
+          simp only [CNF.eval_append, Decl.xorToCNF_eval, Bool.and_eq_true, beq_iff_eq] at heval
+          have := cache.inv assign heval.left idx hbound hmarked
+          rw [this]
+    }
+  ⟨out, IsExtensionBy_set cache out idx hmarkbound (by simp [out])⟩
+
+/--
 The key invariant about the `State` itself (without cache): The CNF we produce is always satisfiable
 at `cnfSatAssignment`.
 -/
@@ -403,6 +471,22 @@ theorem State.Inv_gateToCNF {aig : AIG Nat} {h}
   generalize hrinv : rhs.invert = rinv
   rw [CNF.sat_def]
   cases linv <;> cases rinv <;> simp [denote_idx_gate heq, hlinv, hrinv, h, hlhs, hrhs]
+
+/--
+`State.Inv` holds for the CNF that we produce for an XOR.
+-/
+theorem State.Inv_xorToCNF {aig : AIG Nat} {lhs rhs : Fanin}
+    (h : idx < aig.decls.size)
+    (hltl : lhs.gate < idx)
+    (hltr : rhs.gate < idx)
+    (hdenote : ∀ assign, ⟦aig, ⟨idx, false, h⟩, assign⟧ =
+      (⟦aig, ⟨lhs.gate, lhs.invert, by omega⟩, assign⟧ ^^ ⟦aig, ⟨rhs.gate, rhs.invert, by omega⟩, assign⟧)) :
+    State.Inv aig (Decl.xorToCNF idx lhs.gate rhs.gate lhs.invert rhs.invert) := by
+  intro assign1
+  rw [CNF.sat_def, Decl.xorToCNF_eval, satAssignment_inr h, hdenote, satAssignment_inr (by omega), satAssignment_inr (by omega)]
+  generalize hlinv : lhs.invert = linv
+  generalize hrinv : rhs.invert = rinv
+  cases linv <;> cases rinv <;> simp
 
 /--
 The state to accumulate CNF clauses as we run our Tseitin transformation on the AIG.
@@ -497,6 +581,25 @@ def State.addGate (state : State aig) {hlb} {hrb} (idx : Nat) (h : idx < aig.dec
   ⟨⟨cnf ++ newCnf, cache, State.Inv_append inv hinv⟩, by simp [newCnf, hcache]⟩
 
 /--
+Add the CNF for an XOR to the state.
+-/
+def State.addXor (state : State aig) {lhs rhs : Fanin} {hlb} {hrb} (idx : Nat)
+    (h : idx < aig.decls.size)
+    (hltl : lhs.gate < idx)
+    (hltr : rhs.gate < idx)
+    (hl : state.cache.marks[lhs.gate]'hlb = true)
+    (hr : state.cache.marks[rhs.gate]'hrb = true)
+    (hdenote : ∀ assign, ⟦aig, ⟨idx, false, h⟩, assign⟧ =
+      (⟦aig, ⟨lhs.gate, lhs.invert, by omega⟩, assign⟧ ^^ ⟦aig, ⟨rhs.gate, rhs.invert, by omega⟩, assign⟧)) :
+    { out : State aig // State.IsExtensionBy state out idx h } :=
+  -- have := aig.hdag h htip
+  let ⟨cnf, cache, inv⟩ := state
+  let newCnf := Decl.xorToCNF idx lhs.gate rhs.gate lhs.invert rhs.invert
+  have hinv := toCNF.State.Inv_xorToCNF h hltl hltr hdenote
+  let ⟨cache, hcache⟩ := cache.addXor idx h hltl hltr hl hr hdenote
+  ⟨⟨cnf ++ newCnf, cache, State.Inv_append inv hinv⟩, by simp [newCnf, hcache]⟩
+
+/--
 Evaluate the CNF contained within the state.
 -/
 def State.eval (assign : Nat → Bool) (state : State aig) : Bool :=
@@ -543,25 +646,56 @@ where
       | .false => state.addFalse upper h heq
       | .atom _ => state.addAtom upper h heq
       | .gate lhs rhs =>
-        have := aig.hdag h heq
-        let ⟨lstate, hlstate⟩ := go aig lhs.gate (by omega) state
-        let ⟨rstate, hrstate⟩ := go aig rhs.gate (by omega) lstate
+        match hxor : detectXor ⟨aig, ⟨upper, false, h⟩⟩ with
+        | some xor =>
+          let lhs : Fanin := .mk xor.lhs.gate xor.lhs.invert
+          let rhs : Fanin := .mk xor.rhs.gate xor.rhs.invert
 
-        have : toCNF.State.IsExtensionBy state rstate lhs.gate (by omega) := by
-          apply toCNF.State.IsExtensionBy_trans_left
-          · exact hlstate
-          · exact hrstate
+          have hltl : lhs.gate < upper := by simp [detectXor_lhs_lt hxor, lhs]
+          have hltr : rhs.gate < upper := by simp [detectXor_rhs_lt hxor, rhs]
 
-        let ⟨ret, hretstate⟩ := rstate.addGate upper h heq this.trueAt hrstate.trueAt
-        ⟨
-          ret,
-          by
-            apply toCNF.State.IsExtensionBy_trans_right
+          let ⟨lstate, hlstate⟩ := go aig lhs.gate (by omega) state
+          let ⟨rstate, hrstate⟩ := go aig rhs.gate (by omega) lstate
+
+          have : toCNF.State.IsExtensionBy state rstate lhs.gate (by omega) := by
+            apply toCNF.State.IsExtensionBy_trans_left
             · exact hlstate
-            · apply toCNF.State.IsExtensionBy_trans_right
-              · exact hrstate
-              · exact hretstate
-        ⟩
+            · exact hrstate
+
+          let ⟨ret, hretstate⟩ := rstate.addXor upper h hltl hltr this.trueAt hrstate.trueAt
+            (by simp [denote_detectXor hxor, lhs, rhs])
+          ⟨
+            ret,
+            by
+              apply toCNF.State.IsExtensionBy_trans_right
+              · exact hlstate
+              · apply toCNF.State.IsExtensionBy_trans_right
+                · exact hrstate
+                · exact hretstate
+          ⟩
+
+        | none =>
+          have := aig.hdag h heq
+          let ⟨lstate, hlstate⟩ := go aig lhs.gate (by omega) state
+          let ⟨rstate, hrstate⟩ := go aig rhs.gate (by omega) lstate
+
+          have : toCNF.State.IsExtensionBy state rstate lhs.gate (by omega) := by
+            apply toCNF.State.IsExtensionBy_trans_left
+            · exact hlstate
+            · exact hrstate
+
+          let ⟨ret, hretstate⟩ := rstate.addGate upper h heq this.trueAt hrstate.trueAt
+          ⟨
+            ret,
+            by
+              apply toCNF.State.IsExtensionBy_trans_right
+              · exact hlstate
+              · apply toCNF.State.IsExtensionBy_trans_right
+                · exact hrstate
+                · exact hretstate
+          ⟩
+  termination_by upper
+  decreasing_by all_goals omega
 
 /--
 The node that we started CNF conversion at will always be marked as visited in the CNF cache.

--- a/src/Std/Sat/AIG/DetectGates.lean
+++ b/src/Std/Sat/AIG/DetectGates.lean
@@ -37,7 +37,8 @@ def detectXor (entry : Entrypoint α) : Option entry.aig.BinaryInput := do
 
   -- We expect the structure to be a (potentially inverted) conjunction of disjunctions so l/r
   -- must be inverted
-  let true := l.invert && r.invert | none
+  if ¬l.invert ∨ ¬r.invert then
+    none
 
   -- Match l = (l0 ∧ l1)
   let (eq:=hl) .gate l0 l1 := entry.aig.decls[l.gate] | none

--- a/src/Std/Sat/AIG/DetectGates.lean
+++ b/src/Std/Sat/AIG/DetectGates.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: George Rennie
+-/
+module
+
+prelude
+public import Std.Sat.AIG.Lemmas
+import Init.Omega
+
+@[expose] public section
+
+/-!
+This module contains functions to detect compound logic gates represented by sub-graphs of the `AIG`.
+-/
+
+namespace Std
+namespace Sat
+
+namespace AIG
+
+variable {α : Type} [Hashable α] [DecidableEq α]
+
+/--
+Try to detect an XOR/XNOR gate rooted at the given entrypoint, returning a pair of `Refs` with
+the same semantics as `entry` when XORed.
+
+This can detect XOR/XNOR gates represented in the two-level form `¬(a ∧ b) ∧ ¬(¬a ∧ ¬b)` up to
+permutation of inputs and negation of inputs and output.
+-/
+def detectXor (entry : Entrypoint α) : Option entry.aig.BinaryInput := do
+  have := entry.ref.hgate
+  -- Match root = (l ∧ r)
+  let (eq:=hroot) .gate l r := entry.aig.decls[entry.ref.gate] | none
+  have := entry.aig.hdag entry.ref.hgate hroot
+
+  -- We expect the structure to be a (potentially inverted) conjunction of disjunctions so l/r
+  -- must be inverted
+  let true := l.invert && r.invert | none
+
+  -- Match l = (l0 ∧ l1)
+  let (eq:=hl) .gate l0 l1 := entry.aig.decls[l.gate] | none
+  have := entry.aig.hdag (by omega) hl
+
+  -- Match r = (r0 ∧ r1)
+  let (eq:=hr) .gate r0 r1 := entry.aig.decls[r.gate] | none
+  have := entry.aig.hdag (by omega) hr
+
+  -- l and r must have the same inputs with opposite inversions to be an xor. We consider both
+  -- permutations of l/r inputs with one another.
+  if (l0 = r0.flip true ∧ l1 = r1.flip true) ∨ (l1 = r0.flip true ∧ l0 = r1.flip true) then
+    -- If the root is uninverted, the gate represents `l0 xor l1`, otherwise it represents
+    -- `l0 xnor l1` = `l0 xor ¬l1`.
+    let lhs := ⟨l0.gate, l0.invert, by omega⟩
+    let rhs := (⟨l1.gate, l1.invert, by omega⟩ : Ref entry.aig).flip entry.ref.invert
+    some ⟨lhs, rhs⟩
+  else
+    none
+
+variable {assign}
+
+theorem denote_detectXor {entry : Entrypoint α} {fi : entry.aig.BinaryInput} (heq : detectXor entry = some fi) :
+    ⟦entry, assign⟧ = (⟦entry.aig, fi.lhs, assign⟧ ^^ ⟦entry.aig, fi.rhs, assign⟧) := by
+  simp only [detectXor] at heq
+  split at heq; (all_goals try contradiction); next l r hroot =>
+  split at heq; (all_goals try contradiction); next hinvert =>
+  split at heq; (all_goals try contradiction); next l0 l1 hl =>
+  split at heq; (all_goals try contradiction); next r0 r1 hr =>
+  split at heq; (all_goals try contradiction); next hmatch =>
+  · simp at hinvert
+    rw [denote_idx_gate hroot, hinvert.left, hinvert.right, denote_idx_gate hl, denote_idx_gate hr]
+    simp only [Option.some.injEq] at heq
+    rcases hmatch with ⟨hl0, hl1⟩ | ⟨hl0, hl1⟩
+    · have {a b : Bool} : ((a || b) && (!a || !b)) = (a ^^ b) := by cases a <;> cases b <;> decide
+      simp only [hl0, Fanin.gate_flip, Fanin.invert_flip, Bool.bne_true, denote_not_invert, hl1,
+        Bool.not_and, Bool.not_not, this, ← heq]
+      <;> cases r0.invert
+      <;> cases r1.invert
+      <;> cases entry.ref.invert
+      <;> simp
+    · have {a b : Bool} : ((a || b) && (!b || !a)) = (a ^^ b) := by cases a <;> cases b <;> decide
+      simp only [hl0, Fanin.gate_flip, Fanin.invert_flip, Bool.bne_true, denote_not_invert, hl1,
+        Bool.not_and, Bool.not_not, this, ← heq]
+      <;> cases r0.invert
+      <;> cases r1.invert
+      <;> cases entry.ref.invert
+      <;> simp
+
+theorem detectXor_lhs_lt {entry : Entrypoint α} {fi : entry.aig.BinaryInput} (heq : detectXor entry = some fi) :
+    fi.lhs.gate < entry.ref.gate := by
+  simp only [detectXor] at heq
+  split at heq; (all_goals try contradiction); next l r hroot =>
+  split at heq; (all_goals try contradiction); next hinvert =>
+  split at heq; (all_goals try contradiction); next l0 l1 hl =>
+  split at heq; (all_goals try contradiction); next r0 r1 hr =>
+  split at heq; (all_goals try contradiction); next hmatch =>
+  have := entry.ref.hgate
+  have := entry.aig.hdag (by omega) hroot
+  have := entry.aig.hdag (by omega) hl
+  rw [Option.some.injEq] at heq
+  simp only [← heq]
+  omega
+
+theorem detectXor_rhs_lt {entry : Entrypoint α} {fi : entry.aig.BinaryInput} (heq : detectXor entry = some fi) :
+    fi.rhs.gate < entry.ref.gate := by
+  simp only [detectXor] at heq
+  split at heq; (all_goals try contradiction); next l r hroot =>
+  split at heq; (all_goals try contradiction); next hinvert =>
+  split at heq; (all_goals try contradiction); next l0 l1 hl =>
+  split at heq; (all_goals try contradiction); next r0 r1 hr =>
+  split at heq; (all_goals try contradiction); next hmatch =>
+  have := entry.ref.hgate
+  have := entry.aig.hdag (by omega) hroot
+  have := entry.aig.hdag (by omega) hl
+  rw [Option.some.injEq] at heq
+  simp only [← heq, Ref.gate_flip]
+  omega
+
+end AIG
+
+end Sat
+end Std

--- a/src/Std/Sat/AIG/Lemmas.lean
+++ b/src/Std/Sat/AIG/Lemmas.lean
@@ -34,6 +34,10 @@ theorem Ref.cast_eq {aig1 aig2 : AIG α} (ref : Ref aig1)
     (ref.cast h) = ⟨ref.gate, ref.invert, by have := ref.hgate; omega⟩ := rfl
 
 @[simp]
+theorem Ref.gate_flip {aig : AIG α} (ref : Ref aig) (inv : Bool) :
+    (ref.flip inv).gate = ref.gate := rfl
+
+@[simp]
 theorem BinaryInput.lhs_cast {aig1 aig2 : AIG α} (input : BinaryInput aig1)
     (h : aig1.decls.size ≤ aig2.decls.size) :
     (input.cast h).lhs = input.lhs.cast h := rfl

--- a/tests/elab/aig_lowering_optimizations.lean
+++ b/tests/elab/aig_lowering_optimizations.lean
@@ -33,8 +33,8 @@ def mkXor : Entrypoint Nat :=
 -- Check that the CNF lowering uses a 4-clause encoding for XOR
 /--
 info: { clauses := #[[(1, true), (6, false)], [(1, false), (6, true)], [(2, true), (7, false)], [(2, false), (7, true)],
-               [(1, true), (2, true), (5, false)], [(1, true), (2, false), (5, true)],
-               [(1, false), (2, true), (5, true)], [(1, false), (2, false), (5, false)], [(5, true)]] }
+               [(5, false), (1, false), (2, false)], [(5, false), (1, true), (2, true)],
+               [(5, true), (1, false), (2, true)], [(5, true), (1, true), (2, false)], [(5, true)]] }
 -/
 #guard_msgs in
 #eval AIG.toCNF mkXor

--- a/tests/elab/aig_lowering_optimizations.lean
+++ b/tests/elab/aig_lowering_optimizations.lean
@@ -1,0 +1,68 @@
+import Std.Sat.AIG
+
+open Std.Sat AIG
+
+def mkTwoAtoms : (aig : AIG Nat) × BinaryInput aig :=
+  let aig : AIG Nat := .empty
+
+  let res := aig.mkAtom 0
+  let aig := res.aig
+  let lhs := res.ref
+
+  let res := aig.mkAtom 1
+  let aig := res.aig
+  let rhs := res.ref
+  let lhs := lhs.cast <| LawfulOperator.le_size (f := mkAtom) ..
+
+  ⟨aig, ⟨lhs, rhs⟩⟩
+
+def mkXor : Entrypoint Nat :=
+  let ⟨aig, inputs⟩ := mkTwoAtoms
+  aig.mkXorCached inputs
+
+-- Check mkXorCached and its inversion are detected as XORs
+
+/-- info: true -/
+#guard_msgs in
+#eval AIG.detectXor mkXor |>.isSome
+
+/-- info: true -/
+#guard_msgs in
+#eval AIG.detectXor ⟨mkXor.aig, mkXor.ref.flip true⟩ |>.isSome
+
+-- Check that the CNF lowering uses a 4-clause encoding for XOR
+/--
+info: { clauses := #[[(1, true), (6, false)], [(1, false), (6, true)], [(2, true), (7, false)], [(2, false), (7, true)],
+               [(1, true), (2, true), (5, false)], [(1, true), (2, false), (5, true)],
+               [(1, false), (2, true), (5, true)], [(1, false), (2, false), (5, false)], [(5, true)]] }
+-/
+#guard_msgs in
+#eval AIG.toCNF mkXor
+
+def mkXorAnds (inv invl invr : Bool) (perm : Bool) : Entrypoint Nat :=
+  let ⟨aig, ⟨lhs, rhs⟩⟩ := mkTwoAtoms
+  let lhs := lhs.flip invl
+  let rhs := rhs.flip invr
+
+  let res := aig.mkGate ⟨lhs,  rhs⟩
+  let aig := res.aig
+  let l := res.ref
+
+  let lhsinv := lhs.flip true |>.cast <| LawfulOperator.le_size (f := mkGate) ..
+  let rhsinv := rhs.flip true |>.cast <| LawfulOperator.le_size (f := mkGate) ..
+
+  let res := aig.mkGate (if perm then ⟨rhsinv,  lhsinv⟩ else ⟨lhsinv, rhsinv⟩)
+  let aig := res.aig
+  let r := res.ref
+  let l := l.cast <| LawfulOperator.le_size (f := mkGate) ..
+
+  let res := aig.mkGate ⟨l.flip true, r.flip true⟩
+  let aig := res.aig
+  let root := res.ref.flip inv
+
+  ⟨aig, root⟩
+
+-- Check that all NPN variations of the two-level XOR are detected as XORs
+/-- info: true -/
+#guard_msgs in
+#eval ∀ inv invl invr perm, AIG.detectXor (mkXorAnds inv invl invr perm) |>.isSome


### PR DESCRIPTION
This PR adds detection and optimized lowering of XOR/XNOR gates to `bv_decide`'s AIG to CNF lowering. It adds a function `Std.Sat.AIG.detectXOR` that detects XOR gates of the form `¬(a ∧ b) ∧ ¬(¬a ∧ ¬b)` up to permutation of inputs and negation of inputs/output. When the CNF lowering lowers a gate, it first uses `detectXor` to see if it can be lowered as an XOR, and if so uses a 4 clause encoding instead of the 12 used by lowering as AND gates.
