### PR TITLE
feat(lake): wrapped exec

### DIFF
--- a/src/lake/Lake/Build.lean
+++ b/src/lake/Lake/Build.lean
@@ -25,6 +25,7 @@ public import Lake.Build.Library
 public import Lake.Build.Module
 public import Lake.Build.ModuleArtifacts
 public import Lake.Build.Package
+public import Lake.Build.WrappedExec
 public import Lake.Build.Run
 public import Lake.Build.Store
 public import Lake.Build.Target

--- a/src/lake/Lake/Build/Actions.lean
+++ b/src/lake/Lake/Build/Actions.lean
@@ -104,7 +104,12 @@ public def compileLeanModule
   IO.FS.writeFile setupFile (toJson setup).pretty
   withLogErrorPos do
   let outputs := collectLeanModuleOutputPaths arts postponeCompile
+  -- `lean` also opens any dynlibs / plugins declared in the setup at runtime
+  -- (e.g. `precompileModules` projects). A sandbox wrapper that allow-lists
+  -- from `inputs` would block those without them; include them so the inputs
+  -- list is a complete read-set for the spawned `lean`.
   let inputs := #[leanFile, setupFile] ++ extraInputs
+                ++ setup.dynlibs ++ setup.plugins.map (·.path)
   let out ← Lake.WrappedExec.runRawProcOrWrapped
     { args, cmd := lean.toString,
       env := #[("LEAN_PATH", leanPath.toString)] }

--- a/src/lake/Lake/Build/Actions.lean
+++ b/src/lake/Lake/Build/Actions.lean
@@ -7,6 +7,7 @@ module
 
 prelude
 public import Lake.Util.Log
+public import Lake.Build.WrappedExec
 import Lake.Util.Proc
 import Lake.Util.FilePath
 import Lake.Util.IO
@@ -54,6 +55,32 @@ public def mkLeanModuleArgs
   args := args.push "--json"
   return (args, postponeCompile)
 
+/-- Collect the absolute output paths Lake expects lean to produce for `arts`.
+Used to populate the wrapped-exec manifest's `outputs` list so workers know
+which files to ship back. `setupFile` is intentionally NOT listed here — it's
+an input (written by Lake before the proc invocation, read by lean), and
+shipping a worker-translated copy back would clobber the head's original. -/
+public def collectLeanModuleOutputPaths
+  (arts : ModuleArtifacts) (postponeCompile : Bool)
+: Array FilePath := Id.run do
+  let mut xs : Array FilePath := #[]
+  if let some f := arts.olean? then xs := xs.push f
+  if let some f := arts.ilean? then xs := xs.push f
+  if !postponeCompile then
+    if let some f := arts.c? then xs := xs.push f
+  if let some f := arts.oleanServer? then xs := xs.push f
+  if let some f := arts.oleanPrivate? then xs := xs.push f
+  if let some f := arts.ir? then xs := xs.push f
+  if let some f := arts.bc? then xs := xs.push f
+  return xs
+
+/-- Remote-exec parameters (after `leanir`):
+* `extraInputs` — transitive olean closure that must be on the worker before
+  `lean` runs (see `Lake.collectLeanInputClosure`).
+* `lakeRoots` — `(workspace, lakeHome, toolchain, toolchainRoot)`; when
+  `some _` AND `$LAKE_WRAPPED_EXEC` is set, the invocation is routed through
+  the wrapper. Otherwise this falls through to local `rawProc`.
+* `jobId` — free-form label for logging. -/
 public def compileLeanModule
   (leanFile relLeanFile : FilePath)
   (setup : ModuleSetup) (setupFile : FilePath)
@@ -62,6 +89,9 @@ public def compileLeanModule
   (leanPath : SearchPath := [])
   (lean : FilePath := "lean")
   (leanir : FilePath := "leanir")
+  (extraInputs : Array FilePath := #[])
+  (lakeRoots : Option (FilePath × FilePath × FilePath × FilePath) := none)
+  (jobId : String := "")
 : LogIO Unit := do
   if let some oleanFile := arts.olean? then createParentDirs oleanFile
   if let some ileanFile := arts.ilean? then createParentDirs ileanFile
@@ -72,13 +102,12 @@ public def compileLeanModule
   createParentDirs setupFile
   IO.FS.writeFile setupFile (toJson setup).pretty
   withLogErrorPos do
-  let out ← rawProc {
-    args
-    cmd := lean.toString
-    env := #[
-      ("LEAN_PATH", leanPath.toString)
-    ]
-  }
+  let outputs := collectLeanModuleOutputPaths arts postponeCompile
+  let inputs := #[leanFile, setupFile] ++ extraInputs
+  let out ← Lake.WrappedExec.runRawProcOrWrapped
+    { args, cmd := lean.toString,
+      env := #[("LEAN_PATH", leanPath.toString)] }
+    inputs outputs lakeRoots jobId
   unless out.stdout.isEmpty do
     let txt ← out.stdout.split '\n' |>.foldM (init := "") fun (txt : String) ln => do
       let ln := ln.copy

--- a/src/lake/Lake/Build/Actions.lean
+++ b/src/lake/Lake/Build/Actions.lean
@@ -25,6 +25,35 @@ open Lean hiding SearchPath
 
 namespace Lake
 
+/--
+Compute the argv for invoking `lean` on a module given its resolved `ModuleSetup`, output
+artifacts, and any extra `leanArgs`. Pure: performs no IO and does not create the setup file.
+Returns `(args, postponeCompile)`; when `postponeCompile` is `true`, `-c` is omitted from `args`
+(the C output is produced by a follow-up `leanir` call instead — see `compileLeanModule`).
+
+Exposed for tooling that needs to reproduce Lake's exact `lean` invocation without running it
+(e.g. static build-graph extraction).
+-/
+public def mkLeanModuleArgs
+  (leanFile : FilePath) (setup : ModuleSetup) (setupFile : FilePath)
+  (arts : ModuleArtifacts) (leanArgs : Array String := #[])
+: Array String × Bool := Id.run do
+  let mut args := leanArgs.push leanFile.toString
+  if let some oleanFile := arts.olean? then
+    args := args ++ #["-o", oleanFile.toString]
+  if let some ileanFile := arts.ilean? then
+    args := args ++ #["-i", ileanFile.toString]
+  let opts := setup.options.toOptions
+  let postponeCompile := setup.isModule && Compiler.compiler.postponeCompile.get opts
+  if !postponeCompile then
+    if let some cFile := arts.c? then
+      args := args ++ #["-c", cFile.toString]
+  if let some bcFile := arts.bc? then
+    args := args ++ #["-b", bcFile.toString]
+  args := args ++ #["--setup", setupFile.toString]
+  args := args.push "--json"
+  return (args, postponeCompile)
+
 public def compileLeanModule
   (leanFile relLeanFile : FilePath)
   (setup : ModuleSetup) (setupFile : FilePath)
@@ -34,26 +63,14 @@ public def compileLeanModule
   (lean : FilePath := "lean")
   (leanir : FilePath := "leanir")
 : LogIO Unit := do
-  let mut args := leanArgs.push leanFile.toString
-  if let some oleanFile := arts.olean? then
-    createParentDirs oleanFile
-    args := args ++ #["-o", oleanFile.toString]
-  if let some ileanFile := arts.ilean? then
-    createParentDirs ileanFile
-    args := args ++ #["-i", ileanFile.toString]
-  let opts := setup.options.toOptions
-  let postponeCompile := setup.isModule && Compiler.compiler.postponeCompile.get opts
+  if let some oleanFile := arts.olean? then createParentDirs oleanFile
+  if let some ileanFile := arts.ilean? then createParentDirs ileanFile
+  let (args, postponeCompile) := mkLeanModuleArgs leanFile setup setupFile arts leanArgs
   if !postponeCompile then
-    if let some cFile := arts.c? then
-      createParentDirs cFile
-      args := args ++ #["-c", cFile.toString]
-  if let some bcFile := arts.bc? then
-    createParentDirs bcFile
-    args := args ++ #["-b", bcFile.toString]
+    if let some cFile := arts.c? then createParentDirs cFile
+  if let some bcFile := arts.bc? then createParentDirs bcFile
   createParentDirs setupFile
   IO.FS.writeFile setupFile (toJson setup).pretty
-  args := args ++ #["--setup", setupFile.toString]
-  args := args.push "--json"
   withLogErrorPos do
   let out ← rawProc {
     args
@@ -98,6 +115,15 @@ public def compileLeanModule
           removeFileIfExists oleanFile
         throw e
 
+/--
+Compute the argv for invoking the C compiler in object-compilation mode. Pure helper exposed for
+tooling that needs to reproduce the invocation without running it.
+-/
+public def mkCcCompileArgs
+  (oFile srcFile : FilePath) (moreArgs : Array String := #[])
+: Array String :=
+  #["-c", "-o", oFile.toString, srcFile.toString] ++ moreArgs
+
 public def compileO
   (oFile srcFile : FilePath)
   (moreArgs : Array String := #[]) (compiler : FilePath := "cc")
@@ -105,8 +131,26 @@ public def compileO
   createParentDirs oFile
   proc {
     cmd := compiler.toString
-    args := #["-c", "-o", oFile.toString, srcFile.toString] ++ moreArgs
+    args := mkCcCompileArgs oFile srcFile moreArgs
   }
+
+private def escapeRspArg (arg : String) : String :=
+  arg.foldl (init := "") fun s c =>
+    if c == '\\' || c == '"' then
+      s.push '\\' |>.push c
+    else
+      s.push c
+
+/--
+Render the contents of a response file in the format `mkArgs` writes: one quoted line per arg,
+with `\\` and `"` escaped. Pure helper exposed for tooling that needs the rsp content without
+materializing it on disk.
+-/
+public def renderRspContents (args : Array String) : String := Id.run do
+  let mut out := ""
+  for arg in args do
+    out := out ++ s!"\"{escapeRspArg arg}\"\n"
+  return out
 
 public def mkArgs (basePath : FilePath) (args : Array String) : LogIO (Array String) := do
   -- Use response file to avoid potentially exceeding CLI length limits.
@@ -114,14 +158,7 @@ public def mkArgs (basePath : FilePath) (args : Array String) : LogIO (Array Str
   -- projects like Mathlib where the number of object files exceeds ARG_MAX.
   let rspFile := basePath.addExtension "rsp"
   let h ← IO.FS.Handle.mk rspFile .write
-  args.forM fun arg =>
-    -- Escape special characters
-    let arg := arg.foldl (init := "") fun s c =>
-      if c == '\\' || c == '"' then
-        s.push '\\' |>.push c
-      else
-        s.push c
-    h.putStr s!"\"{arg}\"\n"
+  args.forM fun arg => h.putStr s!"\"{escapeRspArg arg}\"\n"
   return #[s!"@{rspFile}"]
 
 public def compileStaticLib

--- a/src/lake/Lake/Build/Actions.lean
+++ b/src/lake/Lake/Build/Actions.lean
@@ -80,7 +80,7 @@ public def collectLeanModuleOutputPaths
   (see `Lake.collectLeanInputClosure`).
 * `lakeRoots` — `(workspace, lakeHome, toolchain, toolchainRoot)`; when
   `some _` AND `$LAKE_WRAPPED_EXEC` is set, the invocation is routed
-  through the wrapper. Otherwise this falls through to local `rawProc`.
+  through the wrapper. Otherwise this falls through to direct `rawProc`.
 * `jobId` — free-form label for logging. -/
 public def compileLeanModule
   (leanFile relLeanFile : FilePath)

--- a/src/lake/Lake/Build/Actions.lean
+++ b/src/lake/Lake/Build/Actions.lean
@@ -74,12 +74,13 @@ public def collectLeanModuleOutputPaths
   if let some f := arts.bc? then xs := xs.push f
   return xs
 
-/-- Remote-exec parameters (after `leanir`):
-* `extraInputs` — transitive olean closure that must be on the worker before
-  `lean` runs (see `Lake.collectLeanInputClosure`).
+/-- Wrapped-exec parameters (consulted only when both are populated):
+* `extraInputs` — transitive olean closure declared in the manifest's
+  `inputs` list, so a wrapper can know what to materialize ahead of `lean`
+  (see `Lake.collectLeanInputClosure`).
 * `lakeRoots` — `(workspace, lakeHome, toolchain, toolchainRoot)`; when
-  `some _` AND `$LAKE_WRAPPED_EXEC` is set, the invocation is routed through
-  the wrapper. Otherwise this falls through to local `rawProc`.
+  `some _` AND `$LAKE_WRAPPED_EXEC` is set, the invocation is routed
+  through the wrapper. Otherwise this falls through to local `rawProc`.
 * `jobId` — free-form label for logging. -/
 public def compileLeanModule
   (leanFile relLeanFile : FilePath)

--- a/src/lake/Lake/Build/Actions.lean
+++ b/src/lake/Lake/Build/Actions.lean
@@ -176,12 +176,9 @@ private def escapeRspArg (arg : String) : String :=
     else
       s.push c
 
-/--
-Render the contents of a response file in the format `mkArgs` writes: one quoted line per arg,
-with `\\` and `"` escaped. Pure helper exposed for tooling that needs the rsp content without
-materializing it on disk.
--/
-public def renderRspContents (args : Array String) : String := Id.run do
+/-- Render the response-file body `mkArgs` writes: one quoted line per arg,
+with `\\` and `"` escaped. -/
+private def renderRspContents (args : Array String) : String := Id.run do
   let mut out := ""
   for arg in args do
     out := out ++ s!"\"{escapeRspArg arg}\"\n"
@@ -192,8 +189,7 @@ public def mkArgs (basePath : FilePath) (args : Array String) : LogIO (Array Str
   -- On Windows this is always needed; on macOS/Linux this is needed for large
   -- projects like Mathlib where the number of object files exceeds ARG_MAX.
   let rspFile := basePath.addExtension "rsp"
-  let h ← IO.FS.Handle.mk rspFile .write
-  args.forM fun arg => h.putStr s!"\"{escapeRspArg arg}\"\n"
+  IO.FS.writeFile rspFile (renderRspContents args)
   return #[s!"@{rspFile}"]
 
 public def compileStaticLib

--- a/src/lake/Lake/Build/Actions.lean
+++ b/src/lake/Lake/Build/Actions.lean
@@ -27,10 +27,25 @@ open Lean hiding SearchPath
 namespace Lake
 
 /--
+The `lean` invocation for a module, as computed by `mkLeanModuleArgs`.
+
+`outputs` lists the output files `args` names, with path strings
+byte-identical to the corresponding argv tokens. Wrappers rely on this
+congruence (e.g. a sandbox wrapper computes its redirect table as
+`outputs ∩ args`).
+-/
+public structure LeanModuleInvocation where
+  args : Array String
+  /-- Output files embedded in `args` (see above). -/
+  outputs : Array FilePath
+  /-- When `true`, `-c` is omitted from `args`; the C output is produced by
+  a follow-up `leanir` call instead (see `compileLeanModule`). -/
+  postponeCompile : Bool
+
+/--
 Compute the argv for invoking `lean` on a module given its resolved `ModuleSetup`, output
-artifacts, and any extra `leanArgs`. Pure: performs no IO and does not create the setup file.
-Returns `(args, postponeCompile)`; when `postponeCompile` is `true`, `-c` is omitted from `args`
-(the C output is produced by a follow-up `leanir` call instead — see `compileLeanModule`).
+artifacts, and any extra `leanArgs`, together with the output files the argv names. Pure:
+performs no IO and does not create the setup file.
 
 Exposed for tooling that needs to reproduce Lake's exact `lean` invocation without running it
 (e.g. static build-graph extraction).
@@ -38,50 +53,36 @@ Exposed for tooling that needs to reproduce Lake's exact `lean` invocation witho
 public def mkLeanModuleArgs
   (leanFile : FilePath) (setup : ModuleSetup) (setupFile : FilePath)
   (arts : ModuleArtifacts) (leanArgs : Array String := #[])
-: Array String × Bool := Id.run do
+: LeanModuleInvocation := Id.run do
   let mut args := leanArgs.push leanFile.toString
+  let mut outputs := #[]
   if let some oleanFile := arts.olean? then
     args := args ++ #["-o", oleanFile.toString]
+    outputs := outputs.push oleanFile
   if let some ileanFile := arts.ilean? then
     args := args ++ #["-i", ileanFile.toString]
+    outputs := outputs.push ileanFile
   let opts := setup.options.toOptions
   let postponeCompile := setup.isModule && Compiler.compiler.postponeCompile.get opts
   if !postponeCompile then
     if let some cFile := arts.c? then
       args := args ++ #["-c", cFile.toString]
+      outputs := outputs.push cFile
   if let some bcFile := arts.bc? then
     args := args ++ #["-b", bcFile.toString]
+    outputs := outputs.push bcFile
   args := args ++ #["--setup", setupFile.toString]
   args := args.push "--json"
-  return (args, postponeCompile)
+  return {args, outputs, postponeCompile}
 
-/-- Collect the absolute output paths Lake expects lean to produce for `arts`.
-Used to populate the wrapped-exec manifest's `outputs` list so workers know
-which files to ship back. `setupFile` is intentionally NOT listed here — it's
-an input (written by Lake before the proc invocation, read by lean), and
-shipping a worker-translated copy back would clobber the head's original. -/
-public def collectLeanModuleOutputPaths
-  (arts : ModuleArtifacts) (postponeCompile : Bool)
-: Array FilePath := Id.run do
-  let mut xs : Array FilePath := #[]
-  if let some f := arts.olean? then xs := xs.push f
-  if let some f := arts.ilean? then xs := xs.push f
-  if !postponeCompile then
-    if let some f := arts.c? then xs := xs.push f
-  if let some f := arts.oleanServer? then xs := xs.push f
-  if let some f := arts.oleanPrivate? then xs := xs.push f
-  if let some f := arts.ir? then xs := xs.push f
-  if let some f := arts.bc? then xs := xs.push f
-  return xs
-
-/-- Wrapped-exec parameters (consulted only when both are populated):
-* `extraInputs` — transitive olean closure declared in the manifest's
-  `inputs` list, so a wrapper can know what to materialize ahead of `lean`
-  (see `Lake.collectLeanInputClosure`).
-* `lakeRoots` — `(workspace, lakeHome, toolchain, toolchainRoot)`; when
-  `some _` AND `$LAKE_WRAPPED_EXEC` is set, the invocation is routed
-  through the wrapper. Otherwise this falls through to direct `rawProc`.
-* `jobId` — free-form label for logging. -/
+/-- Wrapped-exec parameter: when `wrap? := some _` AND `$LAKE_WRAPPED_EXEC`
+is set, the `lean` invocation — and the follow-up `leanir` invocation in
+`postponeCompile` mode — are routed through the wrapper, each with its own
+manifest. The caller provides the job label and the transitive
+import-artifact closure in `wrap?.inputs` (see `Module.buildLean`); this
+function extends it with the files it knows about itself (source, setup
+file, dynlibs, plugins) and fills `outputs` from the invocations it
+constructs. Otherwise both run via direct `rawProc`/`proc`. -/
 public def compileLeanModule
   (leanFile relLeanFile : FilePath)
   (setup : ModuleSetup) (setupFile : FilePath)
@@ -90,30 +91,37 @@ public def compileLeanModule
   (leanPath : SearchPath := [])
   (lean : FilePath := "lean")
   (leanir : FilePath := "leanir")
-  (extraInputs : Array FilePath := #[])
-  (lakeRoots : Option (FilePath × FilePath × FilePath × FilePath) := none)
-  (jobId : String := "")
+  (wrap? : Option WrappedExec.JobIO := none)
 : LogIO Unit := do
   if let some oleanFile := arts.olean? then createParentDirs oleanFile
   if let some ileanFile := arts.ilean? then createParentDirs ileanFile
-  let (args, postponeCompile) := mkLeanModuleArgs leanFile setup setupFile arts leanArgs
+  let {args, outputs, postponeCompile} := mkLeanModuleArgs leanFile setup setupFile arts leanArgs
   if !postponeCompile then
     if let some cFile := arts.c? then createParentDirs cFile
   if let some bcFile := arts.bc? then createParentDirs bcFile
   createParentDirs setupFile
   IO.FS.writeFile setupFile (toJson setup).pretty
   withLogErrorPos do
-  let outputs := collectLeanModuleOutputPaths arts postponeCompile
-  -- `lean` also opens any dynlibs / plugins declared in the setup at runtime
-  -- (e.g. `precompileModules` projects). A sandbox wrapper that allow-lists
-  -- from `inputs` would block those without them; include them so the inputs
-  -- list is a complete read-set for the spawned `lean`.
-  let inputs := #[leanFile, setupFile] ++ extraInputs
-                ++ setup.dynlibs ++ setup.plugins.map (·.path)
+  let job? := wrap?.map fun job => { job with
+    -- `inputs` must be the complete read-set of the spawned `lean`:
+    -- besides the source and import artifacts, `lean` opens the setup
+    -- file and any dynlibs / plugins it declares (e.g.
+    -- `precompileModules` projects). The setup file is an input, not an
+    -- output: Lake writes it before the invocation, and a wrapper must
+    -- not ship a copy back over it.
+    inputs := #[leanFile, setupFile] ++ job.inputs
+              ++ setup.dynlibs ++ setup.plugins.map (·.path)
+    -- In module mode `lean` derives companion outputs (`.olean.server`,
+    -- `.olean.private`, `.ir`) from the `-o` path; they never appear in
+    -- argv, so declare them from `arts`. With `postponeCompile` the `.ir`
+    -- (like the `.c`) is produced by the follow-up `leanir` job instead.
+    outputs := outputs ++ #[arts.oleanServer?, arts.oleanPrivate?].filterMap id
+      ++ (if postponeCompile then #[] else #[arts.ir?].filterMap id)
+  }
   let out ← Lake.WrappedExec.runRawProcOrWrapped
     { args, cmd := lean.toString,
       env := #[("LEAN_PATH", leanPath.toString)] }
-    inputs outputs lakeRoots jobId
+    job?
   unless out.stdout.isEmpty do
     let txt ← out.stdout.split '\n' |>.foldM (init := "") fun (txt : String) ln => do
       let ln := ln.copy
@@ -137,14 +145,23 @@ public def compileLeanModule
     if let (some irFile, some cFile) := (arts.ir?, arts.c?) then
       createParentDirs irFile
       createParentDirs cFile
+      -- `leanir` self-imports the module (`import all` + `meta`), reading
+      -- the artifacts the `lean` step just produced plus the same import
+      -- closure via `LEAN_PATH`, and writes the deferred `.ir` and `.c`.
+      let irJob? := job?.map fun job => { job with
+        jobId := s!"{job.jobId}:leanir"
+        inputs := job.inputs
+          ++ #[arts.olean?, arts.oleanServer?, arts.oleanPrivate?].filterMap id
+        outputs := #[irFile, cFile]
+      }
       try
-        proc {
+        WrappedExec.procOrWrapped {
           cmd := leanir.toString
           args := #[setupFile.toString, irFile.toString, cFile.toString]
           env := #[
             ("LEAN_PATH", leanPath.toString)
           ]
-        }
+        } irJob?
       catch e =>
         if let some oleanFile := arts.olean? then
           removeFileIfExists oleanFile

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -226,14 +226,32 @@ structure TransImportEntry where
   /-- Whether this module has been transitively imported by a `meta import`. -/
   needsMeta : Bool
 
+/--
+Fetch the transitive import artifacts reachable from `directImports`.
+
+By default the direct imports' own artifacts are expected in `directArts`
+(as computed by the import-info fold) and only their transitive children
+are walked. With `includeDirect := true` the direct imports themselves are
+walked as well, so the result is self-contained — used by the wrapped-exec
+hook to compute a module's full input closure (`nonModule := true` forces
+`importAll` on every edge, yielding `allArts` for every reachable module).
+-/
 partial def fetchTransImportArts
   (directImports : Array ModuleImport) (directArts : NameMap ImportArtifacts) (nonModule : Bool)
+  (includeDirect := false)
 : FetchM (NameMap ImportArtifacts) := do
-  let q ← directImports.foldrM (init := #[]) fun imp q => do
-    let some mod := imp.module? | return q
-    let input ← (← mod.input.fetch).await
-    let importAll := strictOr nonModule imp.importAll
-    return enqueue importAll imp.isMeta input q
+  let q ←
+    if includeDirect then
+      pure <| directImports.foldr (init := #[]) fun imp q =>
+        match imp.module? with
+        | some mod => q.push {mod, importAll := strictOr nonModule imp.importAll, needsMeta := imp.isMeta}
+        | none => q
+    else
+      directImports.foldrM (init := #[]) fun imp q => do
+        let some mod := imp.module? | return q
+        let input ← (← mod.input.fetch).await
+        let importAll := strictOr nonModule imp.importAll
+        return enqueue importAll imp.isMeta input q
   walk directArts {} q
 where
   walk s (metaVisited : NameSet) (q : Array TransImportEntry) := do
@@ -276,49 +294,6 @@ where
           q.push {mod, importAll, needsMeta}
         else q
       else q
-
-/-! ## Wrapped-exec input closure
-
-Walks the *unfiltered* direct-imports graph of `root` and returns every
-workspace olean file that needs to be on disk before invoking lean for `root`.
-Module-style modules contribute `.olean`, `.ir`, `.olean.server`, and
-`.olean.private`; non-module imports contribute just `.olean`.
-
-This is a strict superset of `setup.importArts` (which only follows exported
-imports). The bigger set is needed because lean's olean loader follows
-non-exported references at runtime via LEAN_PATH lookup — Lake's normal
-build dir is fully populated so this is invisible during a regular
-`lake build`, but in wrapped-exec mode where the worker only sees what's
-shipped, the difference matters.
-
-Only `mod.input.fetch` is consulted (the pure `:input` facet — reads source
-headers without compiling). Self is excluded from the result.
--/
-
-private partial def collectInputClosureRec
-  (root : Module) (mod : Module) (visited : NameSet) (files : Array FilePath)
-: FetchM (NameSet × Array FilePath) := do
-  if visited.contains mod.name then return (visited, files)
-  let visited := visited.insert mod.name
-  let inp ← (← mod.input.fetch).await
-  let files :=
-    if mod.name == root.name then files
-    else
-      let files := files.push mod.oleanFile
-      if inp.header.isModule then
-        files.push mod.irFile
-          |>.push mod.oleanServerFile
-          |>.push mod.oleanPrivateFile
-      else files
-  inp.imports.foldlM (init := (visited, files)) fun (visited, files) imp => do
-    match imp.module? with
-    | none => pure (visited, files)
-    | some depMod => collectInputClosureRec root depMod visited files
-
-/-- See the `Wrapped-exec input closure` doc above. -/
-public def collectLeanInputClosure (root : Module) : FetchM (Array FilePath) := do
-  let (_, files) ← collectInputClosureRec root root {} #[]
-  return files
 
 def ModuleImportInfo.nil (modName : Name) : ModuleImportInfo where
   directArts := {}
@@ -934,19 +909,24 @@ def Module.buildLean
   let arts := mod.mkArtifacts srcFile setup.isModule
   mod.clearOutputArtifacts
   -- Compute wrapped-exec metadata only when the hook is configured:
-  -- a no-op rebuild without the env var should be free of the closure walk.
-  let (extraInputs, lakeRoots, jobId) ← if (← IO.getEnv "LAKE_WRAPPED_EXEC").isSome then
-    let ws ← getWorkspace
-    let lakeEnv := ws.lakeEnv
-    let extraInputs ← collectLeanInputClosure mod
-    pure (extraInputs,
-      some (ws.root.dir, ws.root.lakeDir, lakeEnv.lean.binDir, lakeEnv.lean.sysroot),
-      s!"{mod.pkg.baseName}_{mod.name}")
+  -- a build without the env var should be free of the closure walk.
+  let wrap? : Option WrappedExec.JobIO ← if (← IO.getEnv "LAKE_WRAPPED_EXEC").isSome then
+    /-
+    The manifest's `inputs` must list every import artifact `lean` may
+    load: the olean loader follows non-exported references at runtime, so
+    the unfiltered all-artifacts closure is needed, not the exported view
+    in `setup.importArts`. `fetchTransImportArts` computes exactly that
+    closure for a non-module importer (`nonModule := true` forces
+    `importAll` on every edge), with each module's artifact list coming
+    from its `exportInfo` facet.
+    -/
+    let transArts ← fetchTransImportArts directImports {} (nonModule := true) (includeDirect := true)
+    let inputs := transArts.foldl (init := #[]) fun fs _ arts => fs ++ arts.toArray
+    pure <| some {jobId := s!"{mod.pkg.baseName}_{mod.name}", inputs}
   else
-    pure (#[], none, "")
+    pure none
   compileLeanModule srcFile relSrcFile setup mod.setupFile arts args
-    (← getLeanPath) (← getLean) (← getLeanir)
-    (extraInputs := extraInputs) (lakeRoots := lakeRoots) (jobId := jobId)
+    (← getLeanPath) (← getLean) (← getLeanir) (wrap? := wrap?)
   mod.clearOutputHashes
   mod.computeArtifacts setup.isModule
 

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -933,13 +933,17 @@ def Module.buildLean
   let setup := {setup with importArts := transImpArts}
   let arts := mod.mkArtifacts srcFile setup.isModule
   mod.clearOutputArtifacts
-  -- Compute wrapped-exec metadata. The closure is only consulted when
-  -- `$LAKE_WRAPPED_EXEC` is set; otherwise it's effectively unused.
-  let ws ← getWorkspace
-  let lakeEnv := ws.lakeEnv
-  let extraInputs ← collectLeanInputClosure mod
-  let lakeRoots := some (ws.root.dir, ws.root.lakeDir, lakeEnv.lean.binDir, lakeEnv.lean.sysroot)
-  let jobId := s!"{mod.pkg.baseName}_{mod.name}"
+  -- Compute wrapped-exec metadata only when the hook is configured:
+  -- a no-op rebuild without the env var should be free of the closure walk.
+  let (extraInputs, lakeRoots, jobId) ← if (← IO.getEnv "LAKE_WRAPPED_EXEC").isSome then
+    let ws ← getWorkspace
+    let lakeEnv := ws.lakeEnv
+    let extraInputs ← collectLeanInputClosure mod
+    pure (extraInputs,
+      some (ws.root.dir, ws.root.lakeDir, lakeEnv.lean.binDir, lakeEnv.lean.sysroot),
+      s!"{mod.pkg.baseName}_{mod.name}")
+  else
+    pure (#[], none, "")
   compileLeanModule srcFile relSrcFile setup mod.setupFile arts args
     (← getLeanPath) (← getLean) (← getLeanir)
     (extraInputs := extraInputs) (lakeRoots := lakeRoots) (jobId := jobId)

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -277,6 +277,49 @@ where
         else q
       else q
 
+/-! ## Wrapped-exec input closure
+
+Walks the *unfiltered* direct-imports graph of `root` and returns every
+workspace olean file that needs to be on disk before invoking lean for `root`.
+Module-style modules contribute `.olean`, `.ir`, `.olean.server`, and
+`.olean.private`; non-module imports contribute just `.olean`.
+
+This is a strict superset of `setup.importArts` (which only follows exported
+imports). The bigger set is needed because lean's olean loader follows
+non-exported references at runtime via LEAN_PATH lookup — Lake's normal
+build dir is fully populated so this is invisible during a regular
+`lake build`, but in wrapped-exec mode where the worker only sees what's
+shipped, the difference matters.
+
+Only `mod.input.fetch` is consulted (the pure `:input` facet — reads source
+headers without compiling). Self is excluded from the result.
+-/
+
+private partial def collectInputClosureRec
+  (root : Module) (mod : Module) (visited : NameSet) (files : Array FilePath)
+: FetchM (NameSet × Array FilePath) := do
+  if visited.contains mod.name then return (visited, files)
+  let visited := visited.insert mod.name
+  let inp ← (← mod.input.fetch).await
+  let files :=
+    if mod.name == root.name then files
+    else
+      let files := files.push mod.oleanFile
+      if inp.header.isModule then
+        files.push mod.irFile
+          |>.push mod.oleanServerFile
+          |>.push mod.oleanPrivateFile
+      else files
+  inp.imports.foldlM (init := (visited, files)) fun (visited, files) imp => do
+    match imp.module? with
+    | none => pure (visited, files)
+    | some depMod => collectInputClosureRec root depMod visited files
+
+/-- See the `Wrapped-exec input closure` doc above. -/
+public def collectLeanInputClosure (root : Module) : FetchM (Array FilePath) := do
+  let (_, files) ← collectInputClosureRec root root {} #[]
+  return files
+
 def ModuleImportInfo.nil (modName : Name) : ModuleImportInfo where
   directArts := {}
   trace := .nil s!"imports"
@@ -890,8 +933,16 @@ def Module.buildLean
   let setup := {setup with importArts := transImpArts}
   let arts := mod.mkArtifacts srcFile setup.isModule
   mod.clearOutputArtifacts
+  -- Compute wrapped-exec metadata. The closure is only consulted when
+  -- `$LAKE_WRAPPED_EXEC` is set; otherwise it's effectively unused.
+  let ws ← getWorkspace
+  let lakeEnv := ws.lakeEnv
+  let extraInputs ← collectLeanInputClosure mod
+  let lakeRoots := some (ws.root.dir, ws.root.lakeDir, lakeEnv.lean.binDir, lakeEnv.lean.sysroot)
+  let jobId := s!"{mod.pkg.baseName}_{mod.name}"
   compileLeanModule srcFile relSrcFile setup mod.setupFile arts args
     (← getLeanPath) (← getLean) (← getLeanir)
+    (extraInputs := extraInputs) (lakeRoots := lakeRoots) (jobId := jobId)
   mod.clearOutputHashes
   mod.computeArtifacts setup.isModule
 

--- a/src/lake/Lake/Build/WrappedExec.lean
+++ b/src/lake/Lake/Build/WrappedExec.lean
@@ -26,20 +26,22 @@ in any environment it likes, look up a cached result, hand off to a worker
 pool, etc. From Lake's perspective the wrapper is indistinguishable from
 the original binary: same stdout/stderr/exit-code shape.
 
-Concrete consumers include sandbox executors (use the input/output lists
-to constrain the spawned process to its declared dependencies), tracing
-wrappers (record argv/env/inputs for reproducibility analysis),
-content-addressable cache lookups, and distributed-build orchestrators
-(ship work to a worker pool). Lake is silent about which is downstream.
+The manifest carries only what the build system uniquely knows and a
+wrapper cannot deduce: the spawn recipe (`cmd`/`args`/`env`/`cwd`) and the
+declared input/output file sets. Everything a wrapper can derive itself
+(toolchain location from `cmd`, workspace layout from its own deployment
+configuration) is deliberately left out.
 
 Design constraints:
 
 * No orchestration logic in Lake. The wrapper is opaque; Lake doesn't know
   whether it sandboxes, caches, dispatches, traces, or just exec's the
   command in-process.
-* Inputs are enumerated explicitly, not discovered. Callers (e.g. the lean
-  module compile path) compute the full input closure they need ahead of
-  time.
+* Call sites derive `inputs` and `outputs` from the structures Lake
+  already maintains for incremental builds and the artifact cache
+  (`fetchTransImportArts` for the lean module input closure, the argv
+  construction itself for outputs), keeping the manifest consistent with
+  what the build actually reads and writes.
 * Lake stays the executor: cache, hashes, trace sidecars, incremental
   rebuilds all continue to work because Lake invokes the wrapper the same
   way it would invoke the original binary, and outputs must reappear at
@@ -51,34 +53,45 @@ open Lean (Json toJson)
 
 namespace Lake.WrappedExec
 
-public structure Manifest where
-  cmd       : String
-  args      : Array String
-  env       : Array (String × String)
-  cwd       : Option FilePath := none
-  inputs    : Array FilePath
-  outputs   : Array FilePath
-  workspace : FilePath
-  lakeHome  : FilePath
-  toolchain : FilePath
-  toolchainRoot : FilePath
-  jobId     : String
+/-- Version of the manifest JSON format (the `schema_version` field). -/
+public def schemaVersion : Nat := 1
+
+/--
+The per-job metadata a wrappable call site declares alongside the spawn
+arguments: a free-form job label plus the declared input/output file sets.
+Call sites construct this incrementally (e.g. the module build fetches the
+import closure, then `compileLeanModule` extends `inputs` with the files it
+itself writes/reads and fills `outputs`).
+-/
+public structure JobIO where
+  /-- Free-form label identifying the job (used in logs and the manifest). -/
+  jobId   : String
+  /-- Files that must exist on disk before the command runs. -/
+  inputs  : Array FilePath := #[]
+  /-- Files Lake expects on disk after the command exits successfully.
+  Paths embedded in the command's argv appear here byte-identically
+  (sandbox wrappers compute their redirect table as `outputs ∩ args`). -/
+  outputs : Array FilePath := #[]
+  deriving Inhabited
+
+public structure Manifest extends JobIO where
+  cmd  : String
+  args : Array String
+  env  : Array (String × String)
+  cwd  : Option FilePath := none
   deriving Inhabited
 
 public def manifestToJson (m : Manifest) : Json :=
   let envObj : Json := Json.mkObj (m.env.toList.map fun (k, v) => (k, toJson v))
   Json.mkObj [
+    ("schema_version", toJson schemaVersion),
     ("job_id",         toJson m.jobId),
     ("cmd",            toJson m.cmd),
     ("args",           toJson m.args),
     ("env",            envObj),
     ("cwd",            toJson (m.cwd.map FilePath.toString)),
     ("inputs",         toJson (m.inputs.map FilePath.toString)),
-    ("outputs",        toJson (m.outputs.map FilePath.toString)),
-    ("workspace",      toJson m.workspace.toString),
-    ("lake_home",      toJson m.lakeHome.toString),
-    ("toolchain",      toJson m.toolchain.toString),
-    ("toolchain_root", toJson m.toolchainRoot.toString)
+    ("outputs",        toJson (m.outputs.map FilePath.toString))
   ]
 
 private def writeManifestTemp (m : Manifest) : IO FilePath := do
@@ -115,39 +128,47 @@ public def runViaWrapper (wrapperPath : String) (m : Manifest) (quiet := false) 
 
 /--
 Dispatch a `rawProc` invocation either directly or via `$LAKE_WRAPPED_EXEC`.
-When the env var is set AND `lakeRoots := some _`, the wrapper receives a
-manifest with `inputs`/`outputs`/`workspace` metadata. Otherwise this falls
-through to plain `rawProc`.
+The invocation is routed through the wrapper when the env var is set AND the
+call site declares its I/O via `job? := some _`.
 
-`lakeRoots := none` means "this call site doesn't have enough metadata to
-be wrapped"; we run the command directly even if `$LAKE_WRAPPED_EXEC` is
-set. This lets us extend the wrapped-exec path to new call sites one at a
-time without breaking others.
+`job? := none` means "this call site doesn't have enough metadata to be
+wrapped"; we run the command directly even if `$LAKE_WRAPPED_EXEC` is set.
+This lets the wrapped-exec path be extended to new call sites one at a time
+without breaking others.
 -/
 public def runRawProcOrWrapped
-  (args : IO.Process.SpawnArgs)
-  (inputs outputs : Array FilePath)
-  (lakeRoots : Option (FilePath × FilePath × FilePath × FilePath))
-  (jobId : String) (quiet := false)
+  (args : IO.Process.SpawnArgs) (job? : Option JobIO) (quiet := false)
 : LogIO IO.Process.Output := do
-  match (← IO.getEnv "LAKE_WRAPPED_EXEC"), lakeRoots with
-  | some wrapperPath, some (workspace, lakeHome, toolchain, toolchainRoot) =>
-    -- Note: `args.env` is `Array (String × Option String)`; collapsing to
-    -- `Array (String × String)` drops `none` entries (variables the spawn
-    -- explicitly unsets) and may reorder duplicate keys. The current
-    -- compileLeanModule call passes a single LEAN_PATH so this is benign;
-    -- future hooked call sites with richer env vectors will want to switch
-    -- the manifest schema to an ordered array-of-pairs.
+  match (← IO.getEnv "LAKE_WRAPPED_EXEC"), job? with
+  | some wrapperPath, some job =>
+    -- `args.env` is `Array (String × Option String)`; collapsing it into
+    -- the manifest's string-to-string `env` object drops `none` entries
+    -- (explicit unsets) and cannot express duplicate keys. Hooked call
+    -- sites must therefore pass only plain key-value env entries; a call
+    -- site that needs unsets requires an ordered array-of-pairs encoding
+    -- and a `schema_version` bump.
     let envPairs : Array (String × String) := args.env.filterMap fun (k, v?) =>
       v?.map (k, ·)
     let m : Manifest := {
+      toJobIO := job
       cmd := args.cmd, args := args.args, env := envPairs, cwd := args.cwd
-      inputs, outputs
-      workspace, lakeHome, toolchain, toolchainRoot
-      jobId
     }
     runViaWrapper wrapperPath m (quiet := quiet)
   | _, _ =>
     rawProc args (quiet := quiet)
+
+/-- `Lake.proc`, dispatched through `runRawProcOrWrapped`: identical logging
+and failure behavior, with the invocation routed through
+`$LAKE_WRAPPED_EXEC` when configured and `job? := some _`. -/
+public def procOrWrapped
+  (args : IO.Process.SpawnArgs) (job? : Option JobIO) (quiet := false)
+: LogIO Unit := do
+  withLogErrorPos do
+  let out ← runRawProcOrWrapped args job?
+  if out.exitCode = 0 then
+    logOutput out (if quiet then logVerbose else logInfo)
+  else
+    logOutput out logInfo
+    error s!"external command '{args.cmd}' exited with code {out.exitCode}"
 
 end Lake.WrappedExec

--- a/src/lake/Lake/Build/WrappedExec.lean
+++ b/src/lake/Lake/Build/WrappedExec.lean
@@ -96,17 +96,20 @@ private def writeManifestTemp (m : Manifest) : IO FilePath := do
 /-- Invoke the wrapper binary with `manifest`. Returns the wrapper's
 `IO.Process.Output` (stdout/stderr/exitCode), shaped identically to what
 `rawProc` would return for a direct invocation. -/
-public def runViaWrapper (wrapperPath : String) (m : Manifest) : LogIO IO.Process.Output := do
+public def runViaWrapper (wrapperPath : String) (m : Manifest) (quiet := false) : LogIO IO.Process.Output := do
   let manifestPath ← writeManifestTemp m
-  logVerbose s!"wrapped-exec: wrapper={wrapperPath} manifest={manifestPath} job={m.jobId}"
+  unless quiet do
+    logVerbose s!"wrapped-exec: wrapper={wrapperPath} manifest={manifestPath} job={m.jobId}"
   withLogErrorPos do
-  match (← IO.Process.output {
+  let outcome ← (IO.Process.output {
     cmd := wrapperPath,
     args := #[manifestPath.toString]
-  } |>.toBaseIO) with
-  | .ok out =>
-    try IO.FS.removeFile manifestPath catch _ => pure ()
-    return out
+  } |>.toBaseIO)
+  -- Clean up the manifest on both success and failure to avoid leaking
+  -- a temp file when the wrapper itself can't be spawned.
+  try IO.FS.removeFile manifestPath catch _ => pure ()
+  match outcome with
+  | .ok out => return out
   | .error err =>
     error s!"failed to execute wrapper '{wrapperPath}': {err}"
 
@@ -129,6 +132,12 @@ public def runRawProcOrWrapped
 : LogIO IO.Process.Output := do
   match (← IO.getEnv "LAKE_WRAPPED_EXEC"), lakeRoots with
   | some wrapperPath, some (workspace, lakeHome, toolchain, toolchainRoot) =>
+    -- Note: `args.env` is `Array (String × Option String)`; collapsing to
+    -- `Array (String × String)` drops `none` entries (variables the spawn
+    -- explicitly unsets) and may reorder duplicate keys. The current
+    -- compileLeanModule call passes a single LEAN_PATH so this is benign;
+    -- future hooked call sites with richer env vectors will want to switch
+    -- the manifest schema to an ordered array-of-pairs.
     let envPairs : Array (String × String) := args.env.filterMap fun (k, v?) =>
       v?.map (k, ·)
     let m : Manifest := {
@@ -137,7 +146,7 @@ public def runRawProcOrWrapped
       workspace, lakeHome, toolchain, toolchainRoot
       jobId
     }
-    runViaWrapper wrapperPath m
+    runViaWrapper wrapperPath m (quiet := quiet)
   | _, _ =>
     rawProc args (quiet := quiet)
 

--- a/src/lake/Lake/Build/WrappedExec.lean
+++ b/src/lake/Lake/Build/WrappedExec.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Marcelo Lynch
+-/
+module
+
+prelude
+public import Lake.Util.Log
+public import Lake.Util.Proc
+import Init.Data.String.Search
+import Init.System.IO
+import Lean.Data.Json
+
+/-! # Wrapped-execution hook for Lake's `proc` invocations
+
+When `$LAKE_WRAPPED_EXEC` is set to a path, Lake routes selected subprocess
+invocations through that path (the "wrapper") instead of running them locally.
+
+Lake writes a JSON manifest carrying the exact `argv`, `env`, `cwd`, the set of
+input files that must be available before the invocation runs, and the set of
+output files Lake expects to find on disk after it completes. The wrapper is
+responsible for arranging for the command to be executed somewhere it can
+satisfy those input/output declarations. From Lake's perspective the wrapper
+is indistinguishable from the original binary — same stdout/stderr/exit-code
+shape.
+
+Concrete consumers include sandbox executors (use the input/output lists to
+construct an isolated filesystem view), distributed-build orchestrators (ship
+work to a worker pool), and content-addressable build farms. Lake is silent
+about which is downstream.
+
+Design constraints:
+
+* No orchestration logic in Lake. The wrapper is opaque; Lake doesn't know
+  whether it runs the command locally under a sandbox, dispatches to a
+  worker pool, looks up a pre-built result in a cache, or anything else.
+* Inputs are enumerated explicitly, not discovered. Callers (e.g. the lean
+  module compile path) compute the full input closure they need ahead of
+  time.
+* Lake stays the executor: cache, hashes, trace sidecars, incremental
+  rebuilds all continue to work because Lake invokes the wrapper the same
+  way it would invoke the original binary, and the wrapper re-materializes
+  outputs at the head-node paths Lake expects to read from later.
+-/
+
+open System
+open Lean (Json toJson)
+
+namespace Lake.WrappedExec
+
+public structure Manifest where
+  cmd       : String
+  args      : Array String
+  env       : Array (String × String)
+  cwd       : Option FilePath := none
+  inputs    : Array FilePath
+  outputs   : Array FilePath
+  workspace : FilePath
+  lakeHome  : FilePath
+  toolchain : FilePath
+  toolchainRoot : FilePath
+  jobId     : String
+  deriving Inhabited
+
+public def manifestToJson (m : Manifest) : Json :=
+  let envObj : Json := Json.mkObj (m.env.toList.map fun (k, v) => (k, toJson v))
+  Json.mkObj [
+    ("job_id",         toJson m.jobId),
+    ("cmd",            toJson m.cmd),
+    ("args",           toJson m.args),
+    ("env",            envObj),
+    ("cwd",            toJson (m.cwd.map FilePath.toString)),
+    ("inputs",         toJson (m.inputs.map FilePath.toString)),
+    ("outputs",        toJson (m.outputs.map FilePath.toString)),
+    ("workspace",      toJson m.workspace.toString),
+    ("lake_home",      toJson m.lakeHome.toString),
+    ("toolchain",      toJson m.toolchain.toString),
+    ("toolchain_root", toJson m.toolchainRoot.toString)
+  ]
+
+private def writeManifestTemp (m : Manifest) : IO FilePath := do
+  let tmpDir ← (← IO.getEnv "TMPDIR").getDM (pure "/tmp")
+  let dir := FilePath.mk tmpDir
+  IO.FS.createDirAll dir
+  let pid ← IO.Process.getPID
+  let now ← IO.monoNanosNow
+  let safe := m.jobId.foldl (init := "") fun acc c =>
+    if c.isAlphanum then acc.push c else acc.push '_'
+  let path := dir / s!"lake-wrapped-{pid}-{now}-{safe}.json"
+  IO.FS.writeFile path (manifestToJson m).pretty
+  return path
+
+/-- Invoke the wrapper binary with `manifest`. Returns the wrapper's
+`IO.Process.Output` (stdout/stderr/exitCode), shaped identically to what
+`rawProc` would return for a local invocation. -/
+public def runViaWrapper (wrapperPath : String) (m : Manifest) : LogIO IO.Process.Output := do
+  let manifestPath ← writeManifestTemp m
+  logVerbose s!"wrapped-exec: wrapper={wrapperPath} manifest={manifestPath} job={m.jobId}"
+  withLogErrorPos do
+  match (← IO.Process.output {
+    cmd := wrapperPath,
+    args := #[manifestPath.toString]
+  } |>.toBaseIO) with
+  | .ok out =>
+    try IO.FS.removeFile manifestPath catch _ => pure ()
+    return out
+  | .error err =>
+    error s!"failed to execute wrapper '{wrapperPath}': {err}"
+
+/--
+Dispatch a `rawProc` invocation either locally or via `$LAKE_WRAPPED_EXEC`.
+When the env var is set AND `lakeRoots := some _`, the wrapper receives a
+manifest with `inputs`/`outputs`/`workspace` metadata. Otherwise this falls
+through to plain `rawProc`.
+
+`lakeRoots := none` means "this call site doesn't have enough metadata to be
+wrapped"; we fall through to local even if `$LAKE_WRAPPED_EXEC` is set. This
+lets us extend the wrapped-exec path to new call sites one at a time without
+breaking others.
+-/
+public def runRawProcOrWrapped
+  (args : IO.Process.SpawnArgs)
+  (inputs outputs : Array FilePath)
+  (lakeRoots : Option (FilePath × FilePath × FilePath × FilePath))
+  (jobId : String) (quiet := false)
+: LogIO IO.Process.Output := do
+  match (← IO.getEnv "LAKE_WRAPPED_EXEC"), lakeRoots with
+  | some wrapperPath, some (workspace, lakeHome, toolchain, toolchainRoot) =>
+    let envPairs : Array (String × String) := args.env.filterMap fun (k, v?) =>
+      v?.map (k, ·)
+    let m : Manifest := {
+      cmd := args.cmd, args := args.args, env := envPairs, cwd := args.cwd
+      inputs, outputs
+      workspace, lakeHome, toolchain, toolchainRoot
+      jobId
+    }
+    runViaWrapper wrapperPath m
+  | _, _ =>
+    rawProc args (quiet := quiet)
+
+end Lake.WrappedExec

--- a/src/lake/Lake/Build/WrappedExec.lean
+++ b/src/lake/Lake/Build/WrappedExec.lean
@@ -15,33 +15,35 @@ import Lean.Data.Json
 /-! # Wrapped-execution hook for Lake's `proc` invocations
 
 When `$LAKE_WRAPPED_EXEC` is set to a path, Lake routes selected subprocess
-invocations through that path (the "wrapper") instead of running them locally.
+invocations through that path (the "wrapper") instead of invoking them
+directly via `rawProc`.
 
-Lake writes a JSON manifest carrying the exact `argv`, `env`, `cwd`, the set of
-input files that must be available before the invocation runs, and the set of
-output files Lake expects to find on disk after it completes. The wrapper is
-responsible for arranging for the command to be executed somewhere it can
-satisfy those input/output declarations. From Lake's perspective the wrapper
-is indistinguishable from the original binary — same stdout/stderr/exit-code
-shape.
+Lake writes a JSON manifest carrying the exact `argv`, `env`, `cwd`, the set
+of input files that must be available before the invocation runs, and the
+set of output files Lake expects to find on disk after it completes. The
+wrapper decides what to do with that — it can exec the named command itself
+in any environment it likes, look up a cached result, hand off to a worker
+pool, etc. From Lake's perspective the wrapper is indistinguishable from
+the original binary: same stdout/stderr/exit-code shape.
 
-Concrete consumers include sandbox executors (use the input/output lists to
-construct an isolated filesystem view), distributed-build orchestrators (ship
-work to a worker pool), and content-addressable build farms. Lake is silent
-about which is downstream.
+Concrete consumers include sandbox executors (use the input/output lists
+to constrain the spawned process to its declared dependencies), tracing
+wrappers (record argv/env/inputs for reproducibility analysis),
+content-addressable cache lookups, and distributed-build orchestrators
+(ship work to a worker pool). Lake is silent about which is downstream.
 
 Design constraints:
 
 * No orchestration logic in Lake. The wrapper is opaque; Lake doesn't know
-  whether it runs the command locally under a sandbox, dispatches to a
-  worker pool, looks up a pre-built result in a cache, or anything else.
+  whether it sandboxes, caches, dispatches, traces, or just exec's the
+  command in-process.
 * Inputs are enumerated explicitly, not discovered. Callers (e.g. the lean
   module compile path) compute the full input closure they need ahead of
   time.
 * Lake stays the executor: cache, hashes, trace sidecars, incremental
   rebuilds all continue to work because Lake invokes the wrapper the same
-  way it would invoke the original binary, and the wrapper re-materializes
-  outputs at the head-node paths Lake expects to read from later.
+  way it would invoke the original binary, and outputs must reappear at
+  the paths the manifest names by the time the wrapper returns.
 -/
 
 open System
@@ -93,7 +95,7 @@ private def writeManifestTemp (m : Manifest) : IO FilePath := do
 
 /-- Invoke the wrapper binary with `manifest`. Returns the wrapper's
 `IO.Process.Output` (stdout/stderr/exitCode), shaped identically to what
-`rawProc` would return for a local invocation. -/
+`rawProc` would return for a direct invocation. -/
 public def runViaWrapper (wrapperPath : String) (m : Manifest) : LogIO IO.Process.Output := do
   let manifestPath ← writeManifestTemp m
   logVerbose s!"wrapped-exec: wrapper={wrapperPath} manifest={manifestPath} job={m.jobId}"
@@ -109,15 +111,15 @@ public def runViaWrapper (wrapperPath : String) (m : Manifest) : LogIO IO.Proces
     error s!"failed to execute wrapper '{wrapperPath}': {err}"
 
 /--
-Dispatch a `rawProc` invocation either locally or via `$LAKE_WRAPPED_EXEC`.
+Dispatch a `rawProc` invocation either directly or via `$LAKE_WRAPPED_EXEC`.
 When the env var is set AND `lakeRoots := some _`, the wrapper receives a
 manifest with `inputs`/`outputs`/`workspace` metadata. Otherwise this falls
 through to plain `rawProc`.
 
-`lakeRoots := none` means "this call site doesn't have enough metadata to be
-wrapped"; we fall through to local even if `$LAKE_WRAPPED_EXEC` is set. This
-lets us extend the wrapped-exec path to new call sites one at a time without
-breaking others.
+`lakeRoots := none` means "this call site doesn't have enough metadata to
+be wrapped"; we run the command directly even if `$LAKE_WRAPPED_EXEC` is
+set. This lets us extend the wrapped-exec path to new call sites one at a
+time without breaking others.
 -/
 public def runRawProcOrWrapped
   (args : IO.Process.SpawnArgs)

--- a/src/lake/WRAPPED_EXEC.md
+++ b/src/lake/WRAPPED_EXEC.md
@@ -21,9 +21,9 @@ The patch is two commits:
 2. **`feat(lake): add LAKE_WRAPPED_EXEC hook for wrapping lean execution`**
    — the actual hook. Introduces `Lake/Build/WrappedExec.lean` (manifest
    type + dispatch helper), wires it into the lean-module build path,
-   adds a transitive olean closure walker used to populate the
-   manifest's `inputs` list, and re-exports the new module from
-   `Lake/Build.lean`.
+   derives the manifest's `inputs` from `fetchTransImportArts` (the
+   same machinery that populates the `--setup` file's `importArts`),
+   and re-exports the new module from `Lake/Build.lean`.
 
 When `$LAKE_WRAPPED_EXEC` is unset, the patched Lake is
 byte-for-byte identical in behaviour to upstream — the hook is purely
@@ -71,17 +71,14 @@ the wrapper with the manifest path as `argv[1]`:
 
 ```json
 {
+  "schema_version":  1,
   "job_id":          "mathlib_Mathlib.Data.Finset.Basic",
   "cmd":             "/path/to/lean",
   "args":            ["Mathlib/Data/Finset/Basic.lean", "-o", "...", ...],
   "env":             { "LEAN_PATH": "...", ... },
   "cwd":             "/workspace",
   "inputs":          ["Mathlib/.../Basic.lean", ".../Setup.json", ".../Dep.olean", ...],
-  "outputs":         [".../Basic.olean", ".../Basic.ilean", ".../Basic.c", ...],
-  "workspace":       "/workspace",
-  "lake_home":       "/workspace/.lake",
-  "toolchain":       "/root/.elan/.../bin",
-  "toolchain_root":  "/root/.elan/..."
+  "outputs":         [".../Basic.olean", ".../Basic.ilean", ".../Basic.c", ...]
 }
 ```
 
@@ -89,18 +86,35 @@ Field semantics:
 
 | field             | what it carries                                                                |
 |-------------------|--------------------------------------------------------------------------------|
+| `schema_version`  | version of this manifest format (currently `1`)                                |
+| `job_id`          | free-form job label (`{pkg.baseName}_{mod.name}` for lean modules)             |
 | `cmd / args / env / cwd` | exactly what Lake would have passed to its internal `rawProc`           |
 | `inputs`          | every file that must exist on disk before `cmd` runs (source, setup, oleans)   |
 | `outputs`         | every file Lake expects to find on disk after `cmd` returns successfully       |
-| `workspace`       | the workspace root Lake sees (`Workspace.root.dir`)                            |
-| `lake_home`       | the `.lake` directory Lake sees                                                |
-| `toolchain`       | path to the `lean` binary's parent dir                                         |
-| `toolchain_root`  | toolchain `sysroot` (parent of `toolchain`)                                    |
 
-`workspace / lake_home / toolchain / toolchain_root` are exposed so a
-wrapper that runs the command somewhere with a different filesystem
-layout (a sandbox root, a worker container, etc.) can rewrite the
-manifest's paths into its own view.
+The manifest deliberately carries **only what the build system uniquely
+knows** and a wrapper cannot deduce: the spawn recipe and the declared
+I/O sets. Deployment-layout facts (workspace root, `.lake` dir,
+toolchain paths) are not in the schema — a wrapper that relocates work
+across filesystem views knows its own deployment (and can take
+`dirname(cmd)` for the toolchain), so those mappings are wrapper
+configuration, not per-job manifest data.
+
+Two invariants wrappers may rely on:
+
+- **argv congruence.** Every output path named in `args` (after
+  `-o`/`-i`/`-c`/`-b`) appears in `outputs` as a byte-identical string,
+  so `outputs ∩ args` is a valid redirect table for sandbox-style path
+  translation. `outputs` may list more than argv names: in module mode
+  `lean` derives companion files (`.olean.server`, `.olean.private`,
+  `.ir`) from the `-o` path, and those are declared too.
+- **inputs are the true read-set.** Input paths are byte-identical to
+  what `lean` is told to load via `--setup` (`importArts`). In
+  particular, when Lake's artifact cache is enabled, import artifacts
+  may live under the cache directory (e.g.
+  `~/.cache/lake/artifacts/<hash>.olean`) rather than the workspace
+  build tree — a path-translating wrapper needs a mapping for that
+  root too, or the build can run with `LAKE_ARTIFACT_CACHE=false`.
 
 ### The wrapper return shape
 
@@ -121,11 +135,18 @@ indistinguishable from a direct `lean` invocation from Lake's perspective.
   attempts `IO.FS.removeFile manifestPath catch _ => pure ()`. The
   wrapper MUST NOT delete the manifest itself.
 - **Local fallback**. If `$LAKE_WRAPPED_EXEC` is unset OR the call site
-  passes `lakeRoots = none`, the dispatcher falls through to plain
+  passes `job? = none`, the dispatcher falls through to plain
   `rawProc`. Lets call sites be hooked one at a time.
-- **Input closure computed ahead of time**. `collectLeanInputClosure`
-  walks Lake's dependency graph once per job; the wrapper doesn't need
-  to do any graph walking on its own.
+- **I/O sets derived from Lake's own build machinery**. `inputs` comes
+  from `fetchTransImportArts` — the same walk, over the same per-module
+  `exportInfo` artifact lists, that populates the `--setup` file's
+  `importArts` (invoked in unfiltered `importAll` mode, because `lean`'s
+  loader may follow non-exported references). `outputs` is emitted by
+  `mkLeanModuleArgs` together with the argv it constructs, plus the
+  module-mode companions from the `ModuleArtifacts` record the
+  post-build artifact check uses. A change to Lean's artifact shapes
+  that breaks the manifest would also break Lake's own incremental
+  builds or artifact cache, so the contract cannot silently drift.
 - **Setup file is an input, not an output**. Lake writes the per-module
   `setup.json` to disk before invoking the wrapper; it's listed in
   `inputs` but explicitly excluded from `outputs`. The wrapper must respect
@@ -136,13 +157,20 @@ indistinguishable from a direct `lean` invocation from Lake's perspective.
 
 ## What's currently hooked
 
-Today the hook is wired only at `compileLeanModule` (the per-module
-`lean` invocation). The dispatcher (`Lake.WrappedExec.runRawProcOrWrapped`)
+Today the hook is wired at `compileLeanModule`: the per-module `lean`
+invocation, and the follow-up `leanir` invocation when
+`compiler.postponeCompile` is set (each gets its own manifest; the
+`leanir` job declares the deferred `.ir`/`.c` as its outputs and the
+artifacts the `lean` step produced among its inputs). The dispatcher
+(`Lake.WrappedExec.runRawProcOrWrapped`)
 itself is generic and could be threaded through any other subprocess
 call site — `compileO`, `compileSharedLib`, `compileExe`, etc. — by
-computing inputs/outputs for that proc kind and passing
-`lakeRoots := some ...`. Each is an additive change that doesn't
-disturb call sites left as `lakeRoots := none`.
+declaring inputs/outputs for that proc kind via `job? := some ...`.
+Each is an additive change that doesn't disturb call sites left as
+`job? := none`. The criterion for hooking a call site is that its
+job already enumerates its file I/O somewhere in Lake's build
+machinery (e.g. link jobs know their object-file lists) — the manifest
+should be derived from that, never recomputed in parallel.
 
 ## What stays Lake's responsibility
 
@@ -210,7 +238,7 @@ mapfile -t args < <(jq -r '.args[]' "$m")
 mapfile -t env_kvs < <(jq -r '.env | to_entries[] | "\(.key)=\(.value)"' "$m")
 mapfile -t read_paths < <(jq -r '.inputs[]' "$m")
 mapfile -t write_paths < <(jq -r '.outputs[]' "$m")
-toolchain=$(jq -r '.toolchain_root' "$m")
+toolchain=$(dirname "$(dirname "$cmd")")   # sysroot: parent of lean's bin dir
 
 # Hand the read/write sets to your isolation tool of choice
 # (landlock-sandboxer, bwrap, firejail, sandbox-exec on macOS, …).
@@ -281,21 +309,17 @@ requires any further changes to Lake.
   linking (`compileSharedLib`, `compileExe`), archive (`compileStaticLib`)
   are not hooked yet — they continue to run via `rawProc`. (They
   could be hooked the same way; not in this patch.)
-- The transitive olean closure used to populate `inputs` is a strict
-  superset of `setup.importArts` (the exported-imports view). Lean's
-  olean loader follows non-exported references at LEAN_PATH lookup
-  time; in an unwrapped build Lake's build dir is fully populated so
-  the difference is invisible, but for wrapped-exec we must declare
-  the broader set in `inputs`. The walker is straightforward but not
-  minimal — it lists everything `lean`'s loader might reach, not only
-  what it actually opens during a specific compile.
-- For each module-style import the walker contributes `.olean`, `.ir`,
-  `.olean.server`, and `.olean.private`. Per `Lean/Setup.lean`'s
-  `ImportArtifacts.oleanParts`, batch compilation skips `.olean.server`
-  unless `.olean.private` is also present, and `.olean.private` is
-  populated only for `importAll` imports. A future tightening could
-  drop the server/private contributions for non-`importAll` imports
-  in batch builds (rough estimate: ~30–40% fewer files in the
-  manifest), at the cost of teaching the walker about `lean`'s
-  batch-vs-server modes — which is the kind of coupling we've
-  deliberately kept out of the contract so far.
+- The input closure declared in `inputs` is the *unfiltered*
+  `importAll` view (every reachable module contributes its full
+  artifact set), a strict superset of the exported-imports view in
+  `setup.importArts`, because `lean`'s olean loader may follow
+  non-exported references. It lists everything the loader might
+  reach, not only what a specific compile actually opens — an
+  over-approximation by design. A future tightening could teach the
+  closure about `lean`'s batch-vs-server loading modes
+  (`ImportArtifacts.oleanParts`), at the cost of coupling the
+  contract to loader internals — deliberately avoided so far.
+- The `env` object cannot express "unset this variable" (entries the
+  spawn sets to `none` are dropped). The single-`LEAN_PATH` env of the
+  current call site doesn't need it; a future call site that does will
+  bump `schema_version` and switch to an ordered array-of-pairs.

--- a/src/lake/WRAPPED_EXEC.md
+++ b/src/lake/WRAPPED_EXEC.md
@@ -1,0 +1,285 @@
+# `LAKE_REMOTE_EXEC` — remote execution hook for Lake
+
+This branch adds an optional hook that lets Lake route per-`lean`
+subprocess invocations through an external executable ("the stub")
+instead of running them locally. The stub is opaque to Lake: it can do
+nothing (running `lean` itself), dispatch to a worker pool over the
+network, hand off to a sandbox runner, ship the work to a CAS-backed
+build farm, or anything else.
+
+The patch is two commits:
+
+1. **`refactor: extract pure argv helpers in Build/Actions`** — splits
+   `Lake/Build/Actions.lean`'s subprocess-driving functions into pure
+   argv-construction helpers (`mkLeanModuleArgs`, `mkCcCompileArgs`,
+   `renderRspContents`) and the surrounding IO. No behaviour change to
+   `compileLeanModule` / `compileO` / `mkArgs`; the new helpers are
+   simply available for tooling that wants to reproduce Lake's exact
+   invocations without running them.
+
+2. **`feat(lake): add LAKE_REMOTE_EXEC hook for distributed lean execution`**
+   — the actual hook. Introduces `Lake/Build/RemoteExec.lean` (manifest
+   type + dispatch helper), wires it into the lean-module build path,
+   adds a transitive olean closure walker used to populate the
+   manifest's `inputs` list, and re-exports the new module from
+   `Lake/Build.lean`.
+
+When `$LAKE_REMOTE_EXEC` is unset, the patched Lake is
+byte-for-byte identical in behaviour to upstream — the hook is purely
+additive on the existing local-build path.
+
+## Motivation
+
+Lake's build scheduler is excellent at parallelism within a single
+host. Several distributed-build use-cases want to lift that parallelism
+across hosts:
+
+- **Distributed compilation** for large libraries (Mathlib is
+  ~8k modules and 90+ minutes single-machine compute on Apple Silicon).
+- **Sandboxed execution**, e.g. routing every `lean` through a
+  process-isolating wrapper for reproducibility checks.
+- **Cache farm integration** (Bazel-RBE-shaped backends, content-
+  addressable storage queues, etc.).
+
+All of these want the same thing from Lake: "let me intercept the
+per-module `lean` invocation, given enough information to materialize
+it on a remote node." This patch provides exactly that interception
+point, with no opinions about what's on the other side of it.
+
+## Contract
+
+### The env var
+
+```
+LAKE_REMOTE_EXEC=<path-to-executable>
+```
+
+When set, Lake routes selected subprocess invocations through the
+named binary. When unset, Lake spawns `lean` itself, exactly as
+upstream. **This is the only externally visible switch.**
+
+### The manifest
+
+For each routed invocation, Lake writes a JSON manifest to
+`$TMPDIR/lake-remote-<pid>-<monoNano>-<safe-jobid>.json` and execs
+the stub with the manifest path as `argv[1]`:
+
+```json
+{
+  "job_id":          "mathlib_Mathlib.Data.Finset.Basic",
+  "cmd":             "/path/to/lean",
+  "args":            ["Mathlib/Data/Finset/Basic.lean", "-o", "...", ...],
+  "env":             { "LEAN_PATH": "...", ... },
+  "cwd":             "/workspace",
+  "inputs":          ["Mathlib/.../Basic.lean", ".../Setup.json", ".../Dep.olean", ...],
+  "outputs":         [".../Basic.olean", ".../Basic.ilean", ".../Basic.c", ...],
+  "workspace":       "/workspace",
+  "lake_home":       "/workspace/.lake",
+  "toolchain":       "/root/.elan/.../bin",
+  "toolchain_root":  "/root/.elan/..."
+}
+```
+
+Field semantics:
+
+| field             | what it carries                                                                |
+|-------------------|--------------------------------------------------------------------------------|
+| `cmd / args / env / cwd` | exactly what Lake would have passed to its internal `rawProc`           |
+| `inputs`          | every file that must exist on disk before `cmd` runs (source, setup, oleans)   |
+| `outputs`         | every file Lake expects to find on disk after `cmd` returns successfully       |
+| `workspace`       | head-side workspace root (`Workspace.root.dir`)                                |
+| `lake_home`       | head-side `.lake` directory                                                    |
+| `toolchain`       | path to the `lean` binary's parent dir                                         |
+| `toolchain_root`  | toolchain `sysroot` (parent of `toolchain`)                                    |
+
+`workspace / lake_home / toolchain / toolchain_root` are exposed so the
+stub can rewrite head-side paths to wherever it materializes them on
+the remote node.
+
+### The stub return shape
+
+The stub MUST return:
+
+- **exit code**: 0 on successful `lean` run, non-zero on `lean` failure.
+- **stdout**: `lean`'s stdout, byte-for-byte (Lake parses JSON-encoded
+  diagnostics out of this stream).
+- **stderr**: `lean`'s stderr, byte-for-byte (Lake surfaces this
+  verbatim).
+
+Whatever stub implementation produces those three things is
+indistinguishable from local `lean` from Lake's perspective.
+
+### What Lake guarantees in return
+
+- **Manifest cleanup**. After the stub exits (any exit code), Lake
+  attempts `IO.FS.removeFile manifestPath catch _ => pure ()`. The
+  stub MUST NOT delete the manifest itself.
+- **Local fallback**. If `$LAKE_REMOTE_EXEC` is unset OR the call site
+  passes `lakeRoots = none`, the dispatcher falls through to plain
+  `rawProc`. Lets call sites be hooked one at a time.
+- **Input closure computed ahead of time**. `collectLeanInputClosure`
+  walks Lake's dependency graph once per job; the stub doesn't need
+  to do any graph walking on its own.
+- **Setup file is an input, not an output**. Lake writes the per-module
+  `setup.json` to disk before invoking the stub; it's listed in
+  `inputs` but explicitly excluded from `outputs`. The stub must respect
+  this — translating it per-worker if needed, but never shipping it
+  back as a build artifact.
+- **Stable manifest filename pattern**: `lake-remote-<pid>-<monoNano>-<safe-jobid>.json`
+  in `$TMPDIR`. Unique across concurrent Lake processes.
+
+## What's currently hooked
+
+Today the hook is wired only at `compileLeanModule` (the per-module
+`lean` invocation). The dispatcher (`Lake.RemoteExec.runRawProcOrStub`)
+itself is generic and could be threaded through any other subprocess
+call site — `compileO`, `compileSharedLib`, `compileExe`, etc. — by
+computing inputs/outputs for that proc kind and passing
+`lakeRoots := some ...`. Each is an additive change that doesn't
+disturb call sites left as `lakeRoots := none`.
+
+## What stays Lake's responsibility
+
+- **Build scheduling**. Lake decides which jobs run when. The stub
+  sees jobs one at a time, in whatever order Lake's scheduler dispatches
+  them.
+- **Cache hits, hash sidecars, incremental rebuilds**. Because the hook
+  intercepts below Lake's job layer, all of Lake's normal caching
+  semantics apply unchanged. A no-op rebuild dispatches zero stub
+  calls; the first build dispatches one per missed lean job.
+- **Diagnostic parsing**. Lake reads JSON-encoded diagnostics from the
+  stub's stdout the same way it reads them from `lean`'s.
+- **Manifest lifecycle** (see above).
+
+## What's deliberately *not* part of this patch
+
+- **No coordinator or worker logic in Lake.** The stub binary is opaque.
+- **No orchestration of multiple stubs.** Lake invokes the stub once per
+  lean job; whatever queueing / scheduling / load-balancing happens
+  beyond that is the stub's concern.
+- **No protocol assumptions.** The manifest is JSON-on-disk; the stub
+  is an exec'd binary. The hook is silent about HTTP, gRPC, RDMA,
+  shared memory, or any other transport.
+
+## Example consumers
+
+Anything that accepts `<stub> <manifest.json>` and returns
+`exit + stdout + stderr` qualifies.
+
+### Trivial passthrough
+
+```sh
+#!/usr/bin/env bash
+# stub-passthrough: read manifest, exec exactly what Lake would have run.
+set -e
+m="$1"
+cmd=$(jq -r '.cmd' "$m")
+mapfile -t args < <(jq -r '.args[]' "$m")
+mapfile -t env_kvs < <(jq -r '.env | to_entries[] | "\(.key)=\(.value)"' "$m")
+cwd=$(jq -r '.cwd // ""' "$m")
+[[ -n "$cwd" ]] && cd "$cwd"
+exec env "${env_kvs[@]}" "$cmd" "${args[@]}"
+```
+
+Useful sanity check: builds with `LAKE_REMOTE_EXEC=./stub-passthrough`
+should be byte-for-byte identical to plain `lake build`. Verifies that
+the hook itself introduces no behavioural changes.
+
+### Sandboxing — local execution under an isolation primitive
+
+The manifest lists every file `lean` should be allowed to read
+(`inputs`) and write (`outputs`). Combined with `cmd`/`args`/`env`/`cwd`,
+that's exactly enough to construct a sandbox view. A landlock-style
+sandbox stub looks like:
+
+```sh
+#!/usr/bin/env bash
+# stub-sandbox: run lean under landlock, allowing only the manifest's
+# declared input/output paths plus the toolchain dir.
+set -e
+m="$1"
+cmd=$(jq -r '.cmd' "$m")
+mapfile -t args < <(jq -r '.args[]' "$m")
+mapfile -t env_kvs < <(jq -r '.env | to_entries[] | "\(.key)=\(.value)"' "$m")
+mapfile -t read_paths < <(jq -r '.inputs[]' "$m")
+mapfile -t write_paths < <(jq -r '.outputs[]' "$m")
+toolchain=$(jq -r '.toolchain_root' "$m")
+
+# Hand the read/write sets to your isolation tool of choice
+# (landlock-sandboxer, bwrap, firejail, sandbox-exec on macOS, …).
+# Conceptually:
+exec landlock-sandboxer \
+    --ro $(printf -- "--ro %q " "${read_paths[@]}" "$toolchain") \
+    --rw $(printf -- "--rw %q " "${write_paths[@]}") \
+    -- env "${env_kvs[@]}" "$cmd" "${args[@]}"
+```
+
+A sandbox stub like this lets `lake build` run in a per-job isolated
+view of the filesystem without changing anything in Lake itself. The
+hook is exactly the surface needed: Lake declares its dependencies,
+the stub enforces them at OS level.
+
+### Distributed orchestration
+
+The reference distributed user of this hook is a Go orchestrator
+(coordinator + worker pool + per-job stub) that ships inputs to workers
+over gRPC + HTTP/2 cleartext, runs `lean` on the assigned worker, and
+reflects outputs back to the head's filesystem. See the
+`lake-distbuild` project for the implementation. The same `inputs` /
+`outputs` lists that make sandboxing possible also drive what the
+orchestrator transfers across nodes — same data, different consumer.
+
+### Composing — sandbox + remote together
+
+Stubs compose by chaining: the stub Lake invokes can do its own work
+and then delegate to a downstream stub, since the downstream's
+interface is the same `<binary> <manifest.json>` shape. Two natural
+composition patterns:
+
+**Sandbox-then-remote (head-side wrapping):** the head sandbox stub
+wraps each remote dispatch, e.g. to enforce that the orchestrator can
+only read declared inputs from the head's filesystem when materializing
+a job:
+
+```sh
+#!/usr/bin/env bash
+# stub-sandbox-then-remote: enforce sandbox on the head while the
+# orchestrator does the actual dispatch downstream.
+set -e
+m="$1"
+mapfile -t read_paths  < <(jq -r '.inputs[]'  "$m")
+mapfile -t write_paths < <(jq -r '.outputs[]' "$m")
+exec landlock-sandboxer \
+    --ro $(printf -- "--ro %q " "${read_paths[@]}") \
+    --rw $(printf -- "--rw %q " "${write_paths[@]}") \
+    -- /path/to/stub-remote "$m"
+```
+
+**Sandbox at the worker (downstream wrapping):** the remote
+orchestrator ships the manifest to a worker, and on the worker the
+job is wrapped in a sandbox before invoking `lean`. The worker's own
+job runner, written by the orchestrator's author, applies the same
+`inputs`/`outputs`-based isolation as the standalone sandbox stub
+above — it just runs after the work has been materialized on the
+worker filesystem.
+
+Either is a small, local change relative to a non-composed
+configuration: the sandbox stub treats the orchestrator stub as the
+"command to run after isolating", or the orchestrator's worker treats
+the sandbox as the "wrapper to apply before `exec lean`". Neither
+requires any further changes to Lake.
+
+## Limitations / non-goals (today)
+
+- Only `compileLeanModule` is hooked. C compilation (`compileO`),
+  linking (`compileSharedLib`, `compileExe`), archive (`compileStaticLib`)
+  are not hooked yet — they continue to run locally. (They could be
+  hooked the same way; not in this patch.)
+- The transitive olean closure used to populate `inputs` is a strict
+  superset of `setup.importArts` (the exported-imports view). Lean's
+  olean loader follows non-exported references at LEAN_PATH lookup
+  time; in a local build Lake's build dir is fully populated so the
+  difference is invisible, but for remote-exec we must ship the
+  broader set. The walker is straightforward but not minimal — it
+  ships everything `lean`'s loader might reach, not only what it
+  actually opens during a specific compile.

--- a/src/lake/WRAPPED_EXEC.md
+++ b/src/lake/WRAPPED_EXEC.md
@@ -289,3 +289,13 @@ requires any further changes to Lake.
   the broader set in `inputs`. The walker is straightforward but not
   minimal — it lists everything `lean`'s loader might reach, not only
   what it actually opens during a specific compile.
+- For each module-style import the walker contributes `.olean`, `.ir`,
+  `.olean.server`, and `.olean.private`. Per `Lean/Setup.lean`'s
+  `ImportArtifacts.oleanParts`, batch compilation skips `.olean.server`
+  unless `.olean.private` is also present, and `.olean.private` is
+  populated only for `importAll` imports. A future tightening could
+  drop the server/private contributions for non-`importAll` imports
+  in batch builds (rough estimate: ~30–40% fewer files in the
+  manifest), at the cost of teaching the walker about `lean`'s
+  batch-vs-server modes — which is the kind of coupling we've
+  deliberately kept out of the contract so far.

--- a/src/lake/WRAPPED_EXEC.md
+++ b/src/lake/WRAPPED_EXEC.md
@@ -2,10 +2,11 @@
 
 This branch adds an optional hook that lets Lake route per-`lean`
 subprocess invocations through an external executable ("the wrapper")
-instead of running them locally. The wrapper is opaque to Lake: it can do
-nothing (running `lean` itself), dispatch to a worker pool over the
-network, hand off to a sandbox runner, ship the work to a CAS-backed
-build farm, or anything else.
+instead of invoking them directly via `rawProc`. The wrapper is opaque
+to Lake: it can sandbox the call, look up a result in a
+content-addressable cache, record an audit trail, dispatch to a worker
+pool over the network, or simply exec the command itself — Lake
+doesn't care which.
 
 The patch is two commits:
 
@@ -26,25 +27,29 @@ The patch is two commits:
 
 When `$LAKE_WRAPPED_EXEC` is unset, the patched Lake is
 byte-for-byte identical in behaviour to upstream — the hook is purely
-additive on the existing local-build path.
+additive on the existing direct-execution path.
 
 ## Motivation
 
-Lake's build scheduler is excellent at parallelism within a single
-host. Several distributed-build use-cases want to lift that parallelism
-across hosts:
+A handful of useful capabilities all want the same shape of hook from
+Lake: a way to substitute or augment the per-module subprocess
+invocation, given enough information to satisfy it externally.
+Examples:
 
+- **Sandboxed execution.** Wrap each `lean` call in a per-job isolated
+  filesystem view (landlock, bwrap, sandbox-exec, etc.) using the
+  manifest's declared inputs/outputs as the allow-list.
+- **Tracing / auditing.** Record argv/env/inputs/outputs per job for
+  reproducibility analysis or build provenance.
+- **Cache farm integration.** Look up a pre-built result in
+  content-addressable storage, only invoking `lean` on a cache miss.
 - **Distributed compilation** for large libraries (Mathlib is
   ~8k modules and 90+ minutes single-machine compute on Apple Silicon).
-- **Sandboxed execution**, e.g. routing every `lean` through a
-  process-isolating wrapper for reproducibility checks.
-- **Cache farm integration** (Bazel-RBE-shaped backends, content-
-  addressable storage queues, etc.).
 
-All of these want the same thing from Lake: "let me intercept the
-per-module `lean` invocation, given enough information to materialize
-it on a remote node." This patch provides exactly that interception
-point, with no opinions about what's on the other side of it.
+All of these want the same primitive: an interception point per
+subprocess invocation where the wrapper sees what Lake was about to
+run and the dependencies it needs to satisfy. This patch provides
+exactly that, with no opinions about what's on the other side of it.
 
 ## Contract
 
@@ -87,14 +92,15 @@ Field semantics:
 | `cmd / args / env / cwd` | exactly what Lake would have passed to its internal `rawProc`           |
 | `inputs`          | every file that must exist on disk before `cmd` runs (source, setup, oleans)   |
 | `outputs`         | every file Lake expects to find on disk after `cmd` returns successfully       |
-| `workspace`       | head-side workspace root (`Workspace.root.dir`)                                |
-| `lake_home`       | head-side `.lake` directory                                                    |
+| `workspace`       | the workspace root Lake sees (`Workspace.root.dir`)                            |
+| `lake_home`       | the `.lake` directory Lake sees                                                |
 | `toolchain`       | path to the `lean` binary's parent dir                                         |
 | `toolchain_root`  | toolchain `sysroot` (parent of `toolchain`)                                    |
 
-`workspace / lake_home / toolchain / toolchain_root` are exposed so the
-stub can rewrite head-side paths to wherever it materializes them on
-the remote node.
+`workspace / lake_home / toolchain / toolchain_root` are exposed so a
+wrapper that runs the command somewhere with a different filesystem
+layout (a sandbox root, a worker container, etc.) can rewrite the
+manifest's paths into its own view.
 
 ### The wrapper return shape
 
@@ -106,14 +112,14 @@ The wrapper MUST return:
 - **stderr**: `lean`'s stderr, byte-for-byte (Lake surfaces this
   verbatim).
 
-Whatever stub implementation produces those three things is
-indistinguishable from local `lean` from Lake's perspective.
+Whatever wrapper implementation produces those three things is
+indistinguishable from a direct `lean` invocation from Lake's perspective.
 
 ### What Lake guarantees in return
 
 - **Manifest cleanup**. After the wrapper exits (any exit code), Lake
   attempts `IO.FS.removeFile manifestPath catch _ => pure ()`. The
-  stub MUST NOT delete the manifest itself.
+  wrapper MUST NOT delete the manifest itself.
 - **Local fallback**. If `$LAKE_WRAPPED_EXEC` is unset OR the call site
   passes `lakeRoots = none`, the dispatcher falls through to plain
   `rawProc`. Lets call sites be hooked one at a time.
@@ -145,25 +151,26 @@ disturb call sites left as `lakeRoots := none`.
   them.
 - **Cache hits, hash sidecars, incremental rebuilds**. Because the hook
   intercepts below Lake's job layer, all of Lake's normal caching
-  semantics apply unchanged. A no-op rebuild dispatches zero stub
+  semantics apply unchanged. A no-op rebuild dispatches zero wrapper
   calls; the first build dispatches one per missed lean job.
 - **Diagnostic parsing**. Lake reads JSON-encoded diagnostics from the
-  stub's stdout the same way it reads them from `lean`'s.
+  wrapper's stdout the same way it reads them from `lean`'s.
 - **Manifest lifecycle** (see above).
 
 ## What's deliberately *not* part of this patch
 
-- **No coordinator or worker logic in Lake.** The wrapper binary is opaque.
-- **No orchestration of multiple stubs.** Lake invokes the wrapper once per
-  lean job; whatever queueing / scheduling / load-balancing happens
-  beyond that is the wrapper's concern.
-- **No protocol assumptions.** The manifest is JSON-on-disk; the wrapper
-  is an exec'd binary. The hook is silent about HTTP, gRPC, RDMA,
-  shared memory, or any other transport.
+- **No orchestration or wrapping logic in Lake.** The wrapper binary
+  is opaque; what it does between receiving the manifest and exiting
+  is its concern.
+- **No assumptions about what the wrapper does.** Sandbox, cache
+  lookup, dispatch, plain exec — Lake makes no distinction.
+- **No protocol assumptions.** The manifest is JSON-on-disk; the
+  wrapper is an exec'd binary. The hook is silent about HTTP, gRPC,
+  RDMA, shared memory, or any other transport.
 
 ## Example consumers
 
-Anything that accepts `<stub> <manifest.json>` and returns
+Anything that accepts `<wrapper> <manifest.json>` and returns
 `exit + stdout + stderr` qualifies.
 
 ### Trivial passthrough
@@ -185,12 +192,12 @@ Useful sanity check: builds with `LAKE_WRAPPED_EXEC=./wrapper-passthrough`
 should be byte-for-byte identical to plain `lake build`. Verifies that
 the hook itself introduces no behavioural changes.
 
-### Sandboxing — local execution under an isolation primitive
+### Sandboxing — execution under an isolation primitive
 
 The manifest lists every file `lean` should be allowed to read
 (`inputs`) and write (`outputs`). Combined with `cmd`/`args`/`env`/`cwd`,
 that's exactly enough to construct a sandbox view. A landlock-style
-sandbox stub looks like:
+sandbox wrapper looks like:
 
 ```sh
 #!/usr/bin/env bash
@@ -214,37 +221,36 @@ exec landlock-sandboxer \
     -- env "${env_kvs[@]}" "$cmd" "${args[@]}"
 ```
 
-A sandbox stub like this lets `lake build` run in a per-job isolated
+A sandbox wrapper like this lets `lake build` run in a per-job isolated
 view of the filesystem without changing anything in Lake itself. The
 hook is exactly the surface needed: Lake declares its dependencies,
 the wrapper enforces them at OS level.
 
 ### Distributed orchestration
 
-The reference distributed user of this hook is a Go orchestrator
-(coordinator + worker pool + per-job stub) that ships inputs to workers
-over gRPC + HTTP/2 cleartext, runs `lean` on the assigned worker, and
-reflects outputs back to the head's filesystem. See the
-`lake-distbuild` project for the implementation. The same `inputs` /
+A reference distributed consumer is a Go orchestrator (coordinator +
+worker pool + per-job wrapper) that ships inputs to workers over
+gRPC + HTTP/2 cleartext, runs `lean` on the assigned worker, and
+reflects outputs back to Lake's filesystem. The same `inputs` /
 `outputs` lists that make sandboxing possible also drive what the
-orchestrator transfers across nodes — same data, different consumer.
+orchestrator transfers — same data, different consumer.
 
-### Composing — sandbox + remote together
+### Composing wrappers
 
-Stubs compose by chaining: the wrapper Lake invokes can do its own work
-and then delegate to a downstream stub, since the downstream's
+Wrappers compose by chaining: the wrapper Lake invokes can do its own
+work and then exec a downstream wrapper, since the downstream's
 interface is the same `<binary> <manifest.json>` shape. Two natural
 composition patterns:
 
-**Sandbox-then-remote (head-side wrapping):** the head sandbox stub
-wraps each remote dispatch, e.g. to enforce that the orchestrator can
-only read declared inputs from the head's filesystem when materializing
-a job:
+**Outer-sandbox + inner-dispatch.** An outer wrapper applies a
+sandbox using the manifest's declared inputs/outputs, then exec's
+the inner wrapper which does the actual dispatch (to a worker pool,
+a cache lookup, whatever). Useful when the outer policy should
+hold regardless of where the work eventually runs:
 
 ```sh
 #!/usr/bin/env bash
-# wrapper-sandbox-then-remote: enforce sandbox on the head while the
-# orchestrator does the actual dispatch downstream.
+# wrapper-sandbox-then-dispatch: enforce sandbox before delegating.
 set -e
 m="$1"
 mapfile -t read_paths  < <(jq -r '.inputs[]'  "$m")
@@ -252,34 +258,34 @@ mapfile -t write_paths < <(jq -r '.outputs[]' "$m")
 exec landlock-sandboxer \
     --ro $(printf -- "--ro %q " "${read_paths[@]}") \
     --rw $(printf -- "--rw %q " "${write_paths[@]}") \
-    -- /path/to/wrapper-remote "$m"
+    -- /path/to/wrapper-dispatch "$m"
 ```
 
-**Sandbox at the worker (downstream wrapping):** the remote
-orchestrator ships the manifest to a worker, and on the worker the
-job is wrapped in a sandbox before invoking `lean`. The worker's own
-job runner, written by the orchestrator's author, applies the same
-`inputs`/`outputs`-based isolation as the standalone sandbox stub
-above — it just runs after the work has been materialized on the
-worker filesystem.
+**Outer-dispatch + inner-sandbox at the consumer.** A dispatching
+wrapper ships the manifest somewhere (different process, different
+container, different host); on the receiving side, the actual `lean`
+invocation is itself wrapped in a sandbox, using the same
+`inputs`/`outputs`-based isolation as the standalone sandbox wrapper
+above — it just runs after the work has been materialized in
+whichever environment received the dispatch.
 
-Either is a small, local change relative to a non-composed
-configuration: the sandbox stub treats the orchestrator stub as the
-"command to run after isolating", or the orchestrator's worker treats
-the sandbox as the "wrapper to apply before `exec lean`". Neither
+Either is a small change relative to the non-composed configurations:
+the sandbox wrapper treats the dispatching wrapper as "the command
+to run after isolating", or the dispatched-to environment treats the
+sandbox as "the wrapper to apply before `exec lean`". Neither
 requires any further changes to Lake.
 
 ## Limitations / non-goals (today)
 
 - Only `compileLeanModule` is hooked. C compilation (`compileO`),
   linking (`compileSharedLib`, `compileExe`), archive (`compileStaticLib`)
-  are not hooked yet — they continue to run locally. (They could be
-  hooked the same way; not in this patch.)
+  are not hooked yet — they continue to run via `rawProc`. (They
+  could be hooked the same way; not in this patch.)
 - The transitive olean closure used to populate `inputs` is a strict
   superset of `setup.importArts` (the exported-imports view). Lean's
   olean loader follows non-exported references at LEAN_PATH lookup
-  time; in a local build Lake's build dir is fully populated so the
-  difference is invisible, but for wrapped-exec we must ship the
-  broader set. The walker is straightforward but not minimal — it
-  ships everything `lean`'s loader might reach, not only what it
-  actually opens during a specific compile.
+  time; in an unwrapped build Lake's build dir is fully populated so
+  the difference is invisible, but for wrapped-exec we must declare
+  the broader set in `inputs`. The walker is straightforward but not
+  minimal — it lists everything `lean`'s loader might reach, not only
+  what it actually opens during a specific compile.

--- a/src/lake/WRAPPED_EXEC.md
+++ b/src/lake/WRAPPED_EXEC.md
@@ -1,8 +1,8 @@
-# `LAKE_REMOTE_EXEC` — remote execution hook for Lake
+# `LAKE_WRAPPED_EXEC` — wrapped execution hook for Lake
 
 This branch adds an optional hook that lets Lake route per-`lean`
-subprocess invocations through an external executable ("the stub")
-instead of running them locally. The stub is opaque to Lake: it can do
+subprocess invocations through an external executable ("the wrapper")
+instead of running them locally. The wrapper is opaque to Lake: it can do
 nothing (running `lean` itself), dispatch to a worker pool over the
 network, hand off to a sandbox runner, ship the work to a CAS-backed
 build farm, or anything else.
@@ -17,14 +17,14 @@ The patch is two commits:
    simply available for tooling that wants to reproduce Lake's exact
    invocations without running them.
 
-2. **`feat(lake): add LAKE_REMOTE_EXEC hook for distributed lean execution`**
-   — the actual hook. Introduces `Lake/Build/RemoteExec.lean` (manifest
+2. **`feat(lake): add LAKE_WRAPPED_EXEC hook for wrapping lean execution`**
+   — the actual hook. Introduces `Lake/Build/WrappedExec.lean` (manifest
    type + dispatch helper), wires it into the lean-module build path,
    adds a transitive olean closure walker used to populate the
    manifest's `inputs` list, and re-exports the new module from
    `Lake/Build.lean`.
 
-When `$LAKE_REMOTE_EXEC` is unset, the patched Lake is
+When `$LAKE_WRAPPED_EXEC` is unset, the patched Lake is
 byte-for-byte identical in behaviour to upstream — the hook is purely
 additive on the existing local-build path.
 
@@ -51,7 +51,7 @@ point, with no opinions about what's on the other side of it.
 ### The env var
 
 ```
-LAKE_REMOTE_EXEC=<path-to-executable>
+LAKE_WRAPPED_EXEC=<path-to-executable>
 ```
 
 When set, Lake routes selected subprocess invocations through the
@@ -61,8 +61,8 @@ upstream. **This is the only externally visible switch.**
 ### The manifest
 
 For each routed invocation, Lake writes a JSON manifest to
-`$TMPDIR/lake-remote-<pid>-<monoNano>-<safe-jobid>.json` and execs
-the stub with the manifest path as `argv[1]`:
+`$TMPDIR/lake-wrapped-<pid>-<monoNano>-<safe-jobid>.json` and execs
+the wrapper with the manifest path as `argv[1]`:
 
 ```json
 {
@@ -96,9 +96,9 @@ Field semantics:
 stub can rewrite head-side paths to wherever it materializes them on
 the remote node.
 
-### The stub return shape
+### The wrapper return shape
 
-The stub MUST return:
+The wrapper MUST return:
 
 - **exit code**: 0 on successful `lean` run, non-zero on `lean` failure.
 - **stdout**: `lean`'s stdout, byte-for-byte (Lake parses JSON-encoded
@@ -111,27 +111,27 @@ indistinguishable from local `lean` from Lake's perspective.
 
 ### What Lake guarantees in return
 
-- **Manifest cleanup**. After the stub exits (any exit code), Lake
+- **Manifest cleanup**. After the wrapper exits (any exit code), Lake
   attempts `IO.FS.removeFile manifestPath catch _ => pure ()`. The
   stub MUST NOT delete the manifest itself.
-- **Local fallback**. If `$LAKE_REMOTE_EXEC` is unset OR the call site
+- **Local fallback**. If `$LAKE_WRAPPED_EXEC` is unset OR the call site
   passes `lakeRoots = none`, the dispatcher falls through to plain
   `rawProc`. Lets call sites be hooked one at a time.
 - **Input closure computed ahead of time**. `collectLeanInputClosure`
-  walks Lake's dependency graph once per job; the stub doesn't need
+  walks Lake's dependency graph once per job; the wrapper doesn't need
   to do any graph walking on its own.
 - **Setup file is an input, not an output**. Lake writes the per-module
-  `setup.json` to disk before invoking the stub; it's listed in
-  `inputs` but explicitly excluded from `outputs`. The stub must respect
+  `setup.json` to disk before invoking the wrapper; it's listed in
+  `inputs` but explicitly excluded from `outputs`. The wrapper must respect
   this — translating it per-worker if needed, but never shipping it
   back as a build artifact.
-- **Stable manifest filename pattern**: `lake-remote-<pid>-<monoNano>-<safe-jobid>.json`
+- **Stable manifest filename pattern**: `lake-wrapped-<pid>-<monoNano>-<safe-jobid>.json`
   in `$TMPDIR`. Unique across concurrent Lake processes.
 
 ## What's currently hooked
 
 Today the hook is wired only at `compileLeanModule` (the per-module
-`lean` invocation). The dispatcher (`Lake.RemoteExec.runRawProcOrStub`)
+`lean` invocation). The dispatcher (`Lake.WrappedExec.runRawProcOrWrapped`)
 itself is generic and could be threaded through any other subprocess
 call site — `compileO`, `compileSharedLib`, `compileExe`, etc. — by
 computing inputs/outputs for that proc kind and passing
@@ -140,7 +140,7 @@ disturb call sites left as `lakeRoots := none`.
 
 ## What stays Lake's responsibility
 
-- **Build scheduling**. Lake decides which jobs run when. The stub
+- **Build scheduling**. Lake decides which jobs run when. The wrapper
   sees jobs one at a time, in whatever order Lake's scheduler dispatches
   them.
 - **Cache hits, hash sidecars, incremental rebuilds**. Because the hook
@@ -153,11 +153,11 @@ disturb call sites left as `lakeRoots := none`.
 
 ## What's deliberately *not* part of this patch
 
-- **No coordinator or worker logic in Lake.** The stub binary is opaque.
-- **No orchestration of multiple stubs.** Lake invokes the stub once per
+- **No coordinator or worker logic in Lake.** The wrapper binary is opaque.
+- **No orchestration of multiple stubs.** Lake invokes the wrapper once per
   lean job; whatever queueing / scheduling / load-balancing happens
-  beyond that is the stub's concern.
-- **No protocol assumptions.** The manifest is JSON-on-disk; the stub
+  beyond that is the wrapper's concern.
+- **No protocol assumptions.** The manifest is JSON-on-disk; the wrapper
   is an exec'd binary. The hook is silent about HTTP, gRPC, RDMA,
   shared memory, or any other transport.
 
@@ -170,7 +170,7 @@ Anything that accepts `<stub> <manifest.json>` and returns
 
 ```sh
 #!/usr/bin/env bash
-# stub-passthrough: read manifest, exec exactly what Lake would have run.
+# wrapper-passthrough: read manifest, exec exactly what Lake would have run.
 set -e
 m="$1"
 cmd=$(jq -r '.cmd' "$m")
@@ -181,7 +181,7 @@ cwd=$(jq -r '.cwd // ""' "$m")
 exec env "${env_kvs[@]}" "$cmd" "${args[@]}"
 ```
 
-Useful sanity check: builds with `LAKE_REMOTE_EXEC=./stub-passthrough`
+Useful sanity check: builds with `LAKE_WRAPPED_EXEC=./wrapper-passthrough`
 should be byte-for-byte identical to plain `lake build`. Verifies that
 the hook itself introduces no behavioural changes.
 
@@ -194,7 +194,7 @@ sandbox stub looks like:
 
 ```sh
 #!/usr/bin/env bash
-# stub-sandbox: run lean under landlock, allowing only the manifest's
+# wrapper-sandbox: run lean under landlock, allowing only the manifest's
 # declared input/output paths plus the toolchain dir.
 set -e
 m="$1"
@@ -217,7 +217,7 @@ exec landlock-sandboxer \
 A sandbox stub like this lets `lake build` run in a per-job isolated
 view of the filesystem without changing anything in Lake itself. The
 hook is exactly the surface needed: Lake declares its dependencies,
-the stub enforces them at OS level.
+the wrapper enforces them at OS level.
 
 ### Distributed orchestration
 
@@ -231,7 +231,7 @@ orchestrator transfers across nodes — same data, different consumer.
 
 ### Composing — sandbox + remote together
 
-Stubs compose by chaining: the stub Lake invokes can do its own work
+Stubs compose by chaining: the wrapper Lake invokes can do its own work
 and then delegate to a downstream stub, since the downstream's
 interface is the same `<binary> <manifest.json>` shape. Two natural
 composition patterns:
@@ -243,7 +243,7 @@ a job:
 
 ```sh
 #!/usr/bin/env bash
-# stub-sandbox-then-remote: enforce sandbox on the head while the
+# wrapper-sandbox-then-remote: enforce sandbox on the head while the
 # orchestrator does the actual dispatch downstream.
 set -e
 m="$1"
@@ -252,7 +252,7 @@ mapfile -t write_paths < <(jq -r '.outputs[]' "$m")
 exec landlock-sandboxer \
     --ro $(printf -- "--ro %q " "${read_paths[@]}") \
     --rw $(printf -- "--rw %q " "${write_paths[@]}") \
-    -- /path/to/stub-remote "$m"
+    -- /path/to/wrapper-remote "$m"
 ```
 
 **Sandbox at the worker (downstream wrapping):** the remote
@@ -279,7 +279,7 @@ requires any further changes to Lake.
   superset of `setup.importArts` (the exported-imports view). Lean's
   olean loader follows non-exported references at LEAN_PATH lookup
   time; in a local build Lake's build dir is fully populated so the
-  difference is invisible, but for remote-exec we must ship the
+  difference is invisible, but for wrapped-exec we must ship the
   broader set. The walker is straightforward but not minimal — it
   ships everything `lean`'s loader might reach, not only what it
   actually opens during a specific compile.

--- a/tests/lake/tests/wrapped-exec-failure/Onlymod.lean
+++ b/tests/lake/tests/wrapped-exec-failure/Onlymod.lean
@@ -1,0 +1,1 @@
+def Onlymod.value : Nat := 0

--- a/tests/lake/tests/wrapped-exec-failure/clean.sh
+++ b/tests/lake/tests/wrapped-exec-failure/clean.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+rm -rf .lake lake-manifest.json produced.out tmp

--- a/tests/lake/tests/wrapped-exec-failure/lakefile.lean
+++ b/tests/lake/tests/wrapped-exec-failure/lakefile.lean
@@ -1,0 +1,7 @@
+import Lake
+open Lake DSL
+
+package wrappedExecFailure
+
+@[default_target]
+lean_lib Onlymod

--- a/tests/lake/tests/wrapped-exec-failure/test.sh
+++ b/tests/lake/tests/wrapped-exec-failure/test.sh
@@ -15,6 +15,11 @@
 # concurrent processes.
 source ../common.sh
 
+# These tests need the wrapper to actually be invoked: with a warm Lake
+# artifact cache the modules are restored without any lean job running
+# and no wrapper dispatch happens. Pin the cache off for hermeticity.
+export LAKE_ARTIFACT_CACHE=false
+
 chmod +x ./wrapper-fail.sh ./clean.sh
 
 # Helpers: each assertion reads as its actual claim, not its mechanism.

--- a/tests/lake/tests/wrapped-exec-failure/test.sh
+++ b/tests/lake/tests/wrapped-exec-failure/test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Non-happy-path coverage for the wrapped-exec hook.
+#
+#   (1) Wrapper compile-failure propagation. Lake invokes a wrapper
+#       that simulates a lean compile error (non-zero exit + recognisable
+#       stderr line). Lake must exit non-zero and surface the stderr
+#       verbatim, exactly as it would for a real lean failure.
+#
+#   (2) Wrapper binary not found, no temp-manifest leak. Lake invokes
+#       a path that doesn't exist. Lake must (a) fail with a useful
+#       error message, (b) not leak the per-job temp manifest — exercises
+#       the cleanup-on-spawn-failure branch of runViaWrapper.
+#
+# Both subcases use a private TMPDIR so file counts aren't polluted by
+# concurrent processes.
+source ../common.sh
+
+chmod +x ./wrapper-fail.sh ./clean.sh
+./clean.sh
+
+mkdir -p tmp
+export TMPDIR="$PWD/tmp"
+
+# ----------------------------------------------------------------------
+# (1) Compile-failure propagation
+# ----------------------------------------------------------------------
+echo "--- (1) wrapper compile-failure propagation ---"
+out=$(LAKE_WRAPPED_EXEC="$PWD/wrapper-fail.sh" "$LAKE" build 2>&1 || true)
+
+if echo "$out" | grep -q '^Build completed successfully'; then
+  echo "FAILURE: lake reported success on a wrapper that exited 1"
+  echo "$out"
+  exit 1
+fi
+if ! echo "$out" | grep -q "simulated compile failure from wrapper"; then
+  echo "FAILURE: wrapper's stderr did not surface in lake output"
+  echo "$out"
+  exit 1
+fi
+if ! echo "$out" | grep -q "Lean exited with code 1"; then
+  echo "FAILURE: lake did not report lean's non-zero exit"
+  echo "$out"
+  exit 1
+fi
+echo "(1) PASS: wrapper exit + stderr propagated correctly."
+
+# Reset for subcase 2.
+./clean.sh
+mkdir -p tmp
+
+# ----------------------------------------------------------------------
+# (2) Wrapper not found, no manifest leak
+# ----------------------------------------------------------------------
+echo "--- (2) wrapper-not-found, manifest cleanup ---"
+before=$(find "$TMPDIR" -maxdepth 1 -name 'lake-wrapped-*' 2>/dev/null | wc -l | tr -d ' ')
+
+out=$(LAKE_WRAPPED_EXEC="/nonexistent/wrapper-path" "$LAKE" build 2>&1 || true)
+
+if echo "$out" | grep -q '^Build completed successfully'; then
+  echo "FAILURE: lake reported success when wrapper binary doesn't exist"
+  echo "$out"
+  exit 1
+fi
+# IO.Process.output returns .ok (with non-zero exit + syscall stderr) when
+# the binary is missing — our runViaWrapper .error branch is unreachable on
+# Unix in practice. What surfaces is lean's exit-code-after-spawn-failure
+# stderr from IO.Process.output's underlying call.
+if ! echo "$out" | grep -qE "could not execute external process|No such file|Lean exited with code"; then
+  echo "FAILURE: expected a useful error mentioning the missing wrapper or non-zero exit"
+  echo "$out"
+  exit 1
+fi
+
+after=$(find "$TMPDIR" -maxdepth 1 -name 'lake-wrapped-*' 2>/dev/null | wc -l | tr -d ' ')
+if [[ "$before" != "$after" ]]; then
+  echo "FAILURE: temp manifest leak after failed spawn: $before -> $after files in $TMPDIR"
+  find "$TMPDIR" -maxdepth 1 -name 'lake-wrapped-*' 2>/dev/null
+  exit 1
+fi
+echo "(2) PASS: useful error reported, no manifest leak ($before manifests in $TMPDIR before+after)."
+
+./clean.sh

--- a/tests/lake/tests/wrapped-exec-failure/test.sh
+++ b/tests/lake/tests/wrapped-exec-failure/test.sh
@@ -16,9 +16,26 @@
 source ../common.sh
 
 chmod +x ./wrapper-fail.sh ./clean.sh
-./clean.sh
 
-mkdir -p tmp
+# Helpers: each assertion reads as its actual claim, not its mechanism.
+assert_contains() {
+  local needle="$1" haystack="$2"
+  echo "$haystack" | grep -q -- "$needle" \
+    || { echo "FAILURE: expected output to contain '$needle'"; echo "$haystack"; exit 1; }
+}
+
+assert_not_contains() {
+  local needle="$1" haystack="$2"
+  ! echo "$haystack" | grep -q -- "$needle" \
+    || { echo "FAILURE: output unexpectedly contained '$needle'"; echo "$haystack"; exit 1; }
+}
+
+reset_state() {
+  ./clean.sh
+  mkdir -p tmp
+}
+
+reset_state
 export TMPDIR="$PWD/tmp"
 
 # ----------------------------------------------------------------------
@@ -27,56 +44,33 @@ export TMPDIR="$PWD/tmp"
 echo "--- (1) wrapper compile-failure propagation ---"
 out=$(LAKE_WRAPPED_EXEC="$PWD/wrapper-fail.sh" "$LAKE" build 2>&1 || true)
 
-if echo "$out" | grep -q '^Build completed successfully'; then
-  echo "FAILURE: lake reported success on a wrapper that exited 1"
-  echo "$out"
-  exit 1
-fi
-if ! echo "$out" | grep -q "simulated compile failure from wrapper"; then
-  echo "FAILURE: wrapper's stderr did not surface in lake output"
-  echo "$out"
-  exit 1
-fi
-if ! echo "$out" | grep -q "Lean exited with code 1"; then
-  echo "FAILURE: lake did not report lean's non-zero exit"
-  echo "$out"
-  exit 1
-fi
+assert_not_contains '^Build completed successfully' "$out"
+assert_contains 'simulated compile failure from wrapper' "$out"
+assert_contains 'Lean exited with code 1'              "$out"
 echo "(1) PASS: wrapper exit + stderr propagated correctly."
-
-# Reset for subcase 2.
-./clean.sh
-mkdir -p tmp
 
 # ----------------------------------------------------------------------
 # (2) Wrapper not found, no manifest leak
 # ----------------------------------------------------------------------
+reset_state
 echo "--- (2) wrapper-not-found, manifest cleanup ---"
-before=$(find "$TMPDIR" -maxdepth 1 -name 'lake-wrapped-*' 2>/dev/null | wc -l | tr -d ' ')
+
+count_temp_manifests() {
+  find "$TMPDIR" -maxdepth 1 -name 'lake-wrapped-*' 2>/dev/null | wc -l | tr -d ' '
+}
+before=$(count_temp_manifests)
 
 out=$(LAKE_WRAPPED_EXEC="/nonexistent/wrapper-path" "$LAKE" build 2>&1 || true)
 
-if echo "$out" | grep -q '^Build completed successfully'; then
-  echo "FAILURE: lake reported success when wrapper binary doesn't exist"
-  echo "$out"
-  exit 1
-fi
-# IO.Process.output returns .ok (with non-zero exit + syscall stderr) when
-# the binary is missing — our runViaWrapper .error branch is unreachable on
-# Unix in practice. What surfaces is lean's exit-code-after-spawn-failure
-# stderr from IO.Process.output's underlying call.
-if ! echo "$out" | grep -qE "could not execute external process|No such file|Lean exited with code"; then
-  echo "FAILURE: expected a useful error mentioning the missing wrapper or non-zero exit"
-  echo "$out"
-  exit 1
-fi
+assert_not_contains '^Build completed successfully' "$out"
+# The exact spawn-failure error surface is platform-dependent; accept
+# any of the typical wordings.
+echo "$out" | grep -qE "could not execute external process|No such file|Lean exited with code" \
+  || { echo "FAILURE: expected a useful error about the missing wrapper"; echo "$out"; exit 1; }
 
-after=$(find "$TMPDIR" -maxdepth 1 -name 'lake-wrapped-*' 2>/dev/null | wc -l | tr -d ' ')
-if [[ "$before" != "$after" ]]; then
-  echo "FAILURE: temp manifest leak after failed spawn: $before -> $after files in $TMPDIR"
-  find "$TMPDIR" -maxdepth 1 -name 'lake-wrapped-*' 2>/dev/null
-  exit 1
-fi
+after=$(count_temp_manifests)
+[[ "$before" == "$after" ]] \
+  || { echo "FAILURE: temp manifest leak: $before → $after files in $TMPDIR"; find "$TMPDIR" -maxdepth 1 -name 'lake-wrapped-*'; exit 1; }
 echo "(2) PASS: useful error reported, no manifest leak ($before manifests in $TMPDIR before+after)."
 
 ./clean.sh

--- a/tests/lake/tests/wrapped-exec-failure/wrapper-fail.sh
+++ b/tests/lake/tests/wrapped-exec-failure/wrapper-fail.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Simulates a `lean` compile failure: writes a recognisable line to
+# stderr and exits non-zero. Used to verify that wrapper exit code +
+# stderr surface through Lake unchanged.
+echo "error: simulated compile failure from wrapper" >&2
+exit 1

--- a/tests/lake/tests/wrapped-exec-manifest/Dep.lean
+++ b/tests/lake/tests/wrapped-exec-manifest/Dep.lean
@@ -1,0 +1,3 @@
+module
+
+public def Dep.value : Nat := 41

--- a/tests/lake/tests/wrapped-exec-manifest/Onlymod.lean
+++ b/tests/lake/tests/wrapped-exec-manifest/Onlymod.lean
@@ -1,1 +1,3 @@
-def Onlymod.answer : Nat := 42
+import Dep
+
+def Onlymod.answer : Nat := Dep.value + 1

--- a/tests/lake/tests/wrapped-exec-manifest/Onlymod.lean
+++ b/tests/lake/tests/wrapped-exec-manifest/Onlymod.lean
@@ -1,0 +1,1 @@
+def Onlymod.answer : Nat := 42

--- a/tests/lake/tests/wrapped-exec-manifest/Postponed.lean
+++ b/tests/lake/tests/wrapped-exec-manifest/Postponed.lean
@@ -1,0 +1,3 @@
+module
+
+public def Postponed.val : Nat := 5

--- a/tests/lake/tests/wrapped-exec-manifest/clean.sh
+++ b/tests/lake/tests/wrapped-exec-manifest/clean.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-rm -rf .lake lake-manifest.json produced.out manifest.json
+rm -rf .lake lake-manifest.json produced.out manifests

--- a/tests/lake/tests/wrapped-exec-manifest/clean.sh
+++ b/tests/lake/tests/wrapped-exec-manifest/clean.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+rm -rf .lake lake-manifest.json produced.out manifest.json

--- a/tests/lake/tests/wrapped-exec-manifest/lakefile.lean
+++ b/tests/lake/tests/wrapped-exec-manifest/lakefile.lean
@@ -1,0 +1,7 @@
+import Lake
+open Lake DSL
+
+package wrappedExecManifest
+
+@[default_target]
+lean_lib Onlymod

--- a/tests/lake/tests/wrapped-exec-manifest/lakefile.lean
+++ b/tests/lake/tests/wrapped-exec-manifest/lakefile.lean
@@ -3,5 +3,10 @@ open Lake DSL
 
 package wrappedExecManifest
 
+lean_lib Dep
+
+lean_lib Postponed where
+  leanOptions := #[⟨`compiler.postponeCompile, true⟩]
+
 @[default_target]
 lean_lib Onlymod

--- a/tests/lake/tests/wrapped-exec-manifest/test.sh
+++ b/tests/lake/tests/wrapped-exec-manifest/test.sh
@@ -1,109 +1,162 @@
 #!/usr/bin/env bash
 # Verifies that the manifest Lake writes when LAKE_WRAPPED_EXEC is set
 # has the documented shape: required top-level fields, the lean source
-# + setup.json in `inputs`, the expected oleans in `outputs`, etc.
+# + setup.json + the transitive import-artifact closure in `inputs`,
+# the argv-named outputs plus module-system companions in `outputs`.
 #
-# Strategy: point the env var at a wrapper that captures the manifest
-# and exits non-zero. The build fails — that's expected — but we now
-# have the manifest on disk and can inspect it.
+# Strategy: point the env var at a wrapper that captures each manifest
+# (keyed by job_id) and then passes through to the real command, so the
+# build proceeds through `Dep` (a module-system module) to `Onlymod`
+# (a non-module importer of `Dep`) and we can inspect both manifests.
 source ../common.sh
+
+# These tests need the wrapper to actually be invoked: with a warm Lake
+# artifact cache the modules are restored without any lean job running
+# and no wrapper dispatch happens. Pin the cache off for hermeticity.
+export LAKE_ARTIFACT_CACHE=false
 
 chmod +x ./wrapper-capture.sh ./clean.sh
 ./clean.sh
 
-CAPTURED_MANIFEST="$PWD/manifest.json"
-export CAPTURED_MANIFEST
+CAPTURE_DIR="$PWD/manifests"
+mkdir -p "$CAPTURE_DIR"
+export CAPTURE_DIR
 export LAKE_WRAPPED_EXEC="$PWD/wrapper-capture.sh"
 
-# Build will fail (wrapper exits 71); ignore Lake's exit. We only need
-# the captured manifest to exist.
-"$LAKE" build || true
+test_run build
 
-if [[ ! -s manifest.json ]]; then
-  echo "FAILURE: wrapper did not capture a manifest"
-  exit 1
-fi
+DEP_MANIFEST="$CAPTURE_DIR/wrappedExecManifest_Dep.json"
+MOD_MANIFEST="$CAPTURE_DIR/wrappedExecManifest_Onlymod.json"
 
-# Pretty-print the captured manifest if anything below fails. Quiet
-# on the success path so CI logs stay clean.
+for m in "$DEP_MANIFEST" "$MOD_MANIFEST"; do
+  [[ -s "$m" ]] || { echo "FAILURE: wrapper did not capture $m"; ls "$CAPTURE_DIR"; exit 1; }
+done
+
+# Pretty-print the manifest under scrutiny if anything below fails.
+# Quiet on the success path so CI logs stay clean.
 fail() {
   echo "FAILURE: $1"
-  echo "Captured manifest:"
-  jq . manifest.json
+  echo "Manifest ($M):"
+  jq . "$M"
   exit 1
-}
-
-assert_field() {
-  jq -e "has(\"$1\")" manifest.json > /dev/null \
-    || fail "manifest missing top-level field '$1'"
 }
 
 assert_jq_true() {
   local description="$1" expr="$2"
-  jq -e "$expr" manifest.json > /dev/null \
-    || fail "$description"
+  jq -e "$expr" "$M" > /dev/null || fail "$description"
 }
 
 assert_inputs_endswith() {
-  jq -e --arg s "$1" '[.inputs[] | select(endswith($s))] | length > 0' manifest.json > /dev/null \
-    || fail "manifest.inputs has no entry ending with '$1'"
+  assert_jq_true "manifest.inputs has no entry ending with '$1'" \
+    "[.inputs[] | select(endswith(\"$1\"))] | length > 0"
 }
 
 assert_outputs_endswith() {
-  jq -e --arg s "$1" '[.outputs[] | select(endswith($s))] | length > 0' manifest.json > /dev/null \
-    || fail "manifest.outputs has no entry ending with '$1'"
+  assert_jq_true "manifest.outputs has no entry ending with '$1'" \
+    "[.outputs[] | select(endswith(\"$1\"))] | length > 0"
 }
 
-assert_field_eq() {
-  local field="$1" expected="$2"
-  local actual
-  actual=$(jq -r ".$field" manifest.json)
-  [[ "$actual" == "$expected" ]] \
-    || fail "manifest.$field = '$actual', expected '$expected'"
+# --- shape assertions, common to both manifests ---
+
+check_shape() {
+  M="$1"
+  local cmdname="${2:-lean}"
+  # The manifest schema is exactly these fields — the spawn recipe plus
+  # the declared I/O sets. Pin the full key set so any schema change has
+  # to be made consciously (and bump schema_version).
+  assert_jq_true "manifest key set is not the documented v1 schema" '
+    keys == ["args", "cmd", "cwd", "env", "inputs", "job_id", "outputs", "schema_version"]
+  '
+  assert_jq_true "schema_version != 1" '.schema_version == 1'
+  assert_jq_true "manifest.env does not set LEAN_PATH" '.env | has("LEAN_PATH")'
+  local cmd
+  cmd=$(jq -r '.cmd' "$M")
+  [[ "$cmd" == *"/$cmdname" || "$cmd" == "$cmdname" ]] \
+    || fail "cmd = '$cmd' does not look like a $cmdname binary"
+  # Sandbox wrappers compute their redirect table as `outputs ∩ args`:
+  # every output path named in argv must appear in `outputs` as a
+  # byte-identical string.
+  assert_jq_true "an argv-named output is missing from outputs (byte-identity broken)" '
+    .outputs as $outs
+    | [.args as $a | range(0; $a|length)
+       | select($a[.] == "-o" or $a[.] == "-i" or $a[.] == "-c" or $a[.] == "-b")
+       | $a[. + 1]]
+    | all(. as $p | $outs | index($p) != null)
+  '
 }
 
-assert_field_nonempty() {
-  local v
-  v=$(jq -r ".$1" manifest.json)
-  [[ -n "$v" && "$v" != "null" ]] \
-    || fail "manifest.$1 is empty/null"
-}
+check_shape "$DEP_MANIFEST"
+check_shape "$MOD_MANIFEST"
 
-# --- assertions on the manifest shape ---
+# --- Dep (module-system module): companion outputs ---
 
-for f in job_id cmd args env cwd inputs outputs workspace lake_home toolchain toolchain_root; do
-  assert_field "$f"
-done
+M="$DEP_MANIFEST"
+assert_jq_true "job_id != wrappedExecManifest_Dep" '.job_id == "wrappedExecManifest_Dep"'
+assert_inputs_endswith 'Dep.lean'
+assert_inputs_endswith '.setup.json'
+assert_outputs_endswith 'Dep.olean'
+assert_outputs_endswith 'Dep.ilean'
+# Module-system companions lean derives from the `-o` path; they never
+# appear in argv but a wrapper must know to ship/relocate them.
+assert_outputs_endswith 'Dep.olean.server'
+assert_outputs_endswith 'Dep.olean.private'
+assert_outputs_endswith 'Dep.ir'
 
-# job_id derives from `{pkg.baseName}_{mod.name}`.
-assert_field_eq job_id "wrappedExecManifest_Onlymod"
+# --- Onlymod (imports Dep): transitive import closure in inputs ---
 
-# cmd should be a `lean` binary (path ending in /lean or the bare name).
-cmd=$(jq -r '.cmd' manifest.json)
-[[ "$cmd" == *"/lean" || "$cmd" == "lean" ]] \
-  || fail "cmd = '$cmd' does not look like a lean binary"
-
-# inputs: the source file + the per-module setup.json must both appear.
+M="$MOD_MANIFEST"
+assert_jq_true "job_id != wrappedExecManifest_Onlymod" '.job_id == "wrappedExecManifest_Onlymod"'
 assert_inputs_endswith 'Onlymod.lean'
 assert_inputs_endswith '.setup.json'
-
-# outputs: the olean + ilean for this module must both appear.
 assert_outputs_endswith 'Onlymod.olean'
 assert_outputs_endswith 'Onlymod.ilean'
-
+# The full artifact set of the imported module must be declared: lean's
+# loader may follow non-exported references, so the closure contributes
+# `allArts` (olean + ir + olean.server + olean.private) per module-system
+# import, not just the exported view.
+assert_inputs_endswith 'Dep.olean'
+assert_inputs_endswith 'Dep.ir'
+assert_inputs_endswith 'Dep.olean.server'
+assert_inputs_endswith 'Dep.olean.private'
 # args must include the source-file path that appears in inputs (i.e.
 # `lean` is being asked to compile what we declared).
-src=$(jq -r '.inputs[] | select(endswith("Onlymod.lean"))' manifest.json)
+src=$(jq -r '.inputs[] | select(endswith("Onlymod.lean"))' "$M")
 assert_jq_true "manifest.args does not include the source file" \
   ".args | any(. == \"$src\")"
 
-# env should at least set LEAN_PATH.
-assert_jq_true "manifest.env does not set LEAN_PATH" '.env | has("LEAN_PATH")'
+# --- Postponed (compiler.postponeCompile): split lean/leanir jobs ---
 
-# The four Lake roots Lake hands the wrapper must all be populated.
-for k in workspace lake_home toolchain toolchain_root; do
-  assert_field_nonempty "$k"
+test_run build Postponed
+
+PP_MANIFEST="$CAPTURE_DIR/wrappedExecManifest_Postponed.json"
+IR_MANIFEST="$CAPTURE_DIR/wrappedExecManifest_Postponed:leanir.json"
+for m in "$PP_MANIFEST" "$IR_MANIFEST"; do
+  [[ -s "$m" ]] || { echo "FAILURE: wrapper did not capture $m"; ls "$CAPTURE_DIR"; exit 1; }
 done
+
+check_shape "$PP_MANIFEST"
+check_shape "$IR_MANIFEST" leanir
+
+# The lean job defers .ir/.c to leanir; its outputs must say so.
+M="$PP_MANIFEST"
+assert_outputs_endswith 'Postponed.olean'
+assert_outputs_endswith 'Postponed.olean.server'
+assert_outputs_endswith 'Postponed.olean.private'
+assert_jq_true "lean job in postpone mode must not declare the deferred .ir/.c" '
+  [.outputs[] | select(endswith("Postponed.ir") or endswith("Postponed.c"))] | length == 0
+'
+
+# The leanir job produces exactly the deferred outputs, reading the
+# setup file and the artifacts the lean step produced.
+M="$IR_MANIFEST"
+assert_jq_true "job_id != wrappedExecManifest_Postponed:leanir" \
+  '.job_id == "wrappedExecManifest_Postponed:leanir"'
+assert_outputs_endswith 'Postponed.ir'
+assert_outputs_endswith 'Postponed.c'
+assert_jq_true "leanir job must declare exactly the .ir and .c outputs" '.outputs | length == 2'
+assert_inputs_endswith '.setup.json'
+assert_inputs_endswith 'Postponed.olean'
+assert_inputs_endswith 'Postponed.olean.private'
 
 echo "wrapped-exec manifest: shape checks pass."
 ./clean.sh

--- a/tests/lake/tests/wrapped-exec-manifest/test.sh
+++ b/tests/lake/tests/wrapped-exec-manifest/test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Verifies that the manifest Lake writes when LAKE_WRAPPED_EXEC is set
+# has the documented shape: required top-level fields, a Lean source +
+# setup.json in `inputs`, and an .olean in `outputs`.
+#
+# Strategy: point the env var at a wrapper that captures the manifest
+# and exits non-zero. The build fails — that's expected — but we now
+# have the manifest on disk and can inspect it.
+source ../common.sh
+
+chmod +x ./wrapper-capture.sh ./clean.sh
+./clean.sh
+
+CAPTURED_MANIFEST="$PWD/manifest.json"
+export CAPTURED_MANIFEST
+export LAKE_WRAPPED_EXEC="$PWD/wrapper-capture.sh"
+
+# Build will fail (wrapper exits 71); ignore Lake's exit. We only need
+# the captured manifest to exist.
+"$LAKE" build || true
+
+if [[ ! -s manifest.json ]]; then
+  echo "FAILURE: wrapper did not capture a manifest"
+  exit 1
+fi
+echo "Captured manifest:"
+jq . manifest.json
+
+# --- assertions on the manifest shape ---
+
+assert_field() {
+  local key="$1"
+  if ! jq -e "has(\"$key\")" manifest.json > /dev/null; then
+    echo "FAILURE: manifest missing top-level field '$key'"
+    exit 1
+  fi
+}
+
+assert_inputs_endswith() {
+  local suffix="$1"
+  if ! jq -e --arg s "$suffix" '[.inputs[] | select(endswith($s))] | length > 0' manifest.json > /dev/null; then
+    echo "FAILURE: manifest.inputs has no entry ending with '$suffix'"
+    exit 1
+  fi
+}
+
+assert_outputs_endswith() {
+  local suffix="$1"
+  if ! jq -e --arg s "$suffix" '[.outputs[] | select(endswith($s))] | length > 0' manifest.json > /dev/null; then
+    echo "FAILURE: manifest.outputs has no entry ending with '$suffix'"
+    exit 1
+  fi
+}
+
+for f in job_id cmd args env cwd inputs outputs workspace lake_home toolchain toolchain_root; do
+  assert_field "$f"
+done
+
+# job_id derives from `{pkg.baseName}_{mod.name}` — for this fixture, expect "wrappedExecManifest_Onlymod".
+expected_job_id="wrappedExecManifest_Onlymod"
+actual_job_id=$(jq -r '.job_id' manifest.json)
+if [[ "$actual_job_id" != "$expected_job_id" ]]; then
+  echo "FAILURE: job_id = '$actual_job_id', expected '$expected_job_id'"
+  exit 1
+fi
+
+# cmd should end in '/lean'.
+cmd=$(jq -r '.cmd' manifest.json)
+if [[ "$cmd" != *"/lean" && "$cmd" != "lean" ]]; then
+  echo "FAILURE: cmd = '$cmd' does not look like a lean binary"
+  exit 1
+fi
+
+# inputs should contain the source file and the setup.json.
+assert_inputs_endswith 'Onlymod.lean'
+assert_inputs_endswith '.setup.json'
+
+# outputs should contain the .olean + .ilean for Onlymod.
+assert_outputs_endswith 'Onlymod.olean'
+assert_outputs_endswith 'Onlymod.ilean'
+
+# args should include the source file path that appears in inputs.
+src=$(jq -r '.inputs[] | select(endswith("Onlymod.lean"))' manifest.json)
+if ! jq -e --arg s "$src" '.args | any(. == $s)' manifest.json > /dev/null; then
+  echo "FAILURE: manifest.args does not include the source file"
+  exit 1
+fi
+
+# env should at least set LEAN_PATH.
+if ! jq -e '.env | has("LEAN_PATH")' manifest.json > /dev/null; then
+  echo "FAILURE: manifest.env does not set LEAN_PATH"
+  exit 1
+fi
+
+# workspace + lake_home + toolchain + toolchain_root should be non-empty absolute paths.
+for k in workspace lake_home toolchain toolchain_root; do
+  v=$(jq -r ".$k" manifest.json)
+  if [[ -z "$v" || "$v" == "null" ]]; then
+    echo "FAILURE: manifest.$k is empty/null"
+    exit 1
+  fi
+done
+
+echo "wrapped-exec manifest: shape checks pass."
+
+./clean.sh

--- a/tests/lake/tests/wrapped-exec-manifest/test.sh
+++ b/tests/lake/tests/wrapped-exec-manifest/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Verifies that the manifest Lake writes when LAKE_WRAPPED_EXEC is set
-# has the documented shape: required top-level fields, a Lean source +
-# setup.json in `inputs`, and an .olean in `outputs`.
+# has the documented shape: required top-level fields, the lean source
+# + setup.json in `inputs`, the expected oleans in `outputs`, etc.
 #
 # Strategy: point the env var at a wrapper that captures the manifest
 # and exits non-zero. The build fails — that's expected — but we now
@@ -23,84 +23,87 @@ if [[ ! -s manifest.json ]]; then
   echo "FAILURE: wrapper did not capture a manifest"
   exit 1
 fi
-echo "Captured manifest:"
-jq . manifest.json
 
-# --- assertions on the manifest shape ---
+# Pretty-print the captured manifest if anything below fails. Quiet
+# on the success path so CI logs stay clean.
+fail() {
+  echo "FAILURE: $1"
+  echo "Captured manifest:"
+  jq . manifest.json
+  exit 1
+}
 
 assert_field() {
-  local key="$1"
-  if ! jq -e "has(\"$key\")" manifest.json > /dev/null; then
-    echo "FAILURE: manifest missing top-level field '$key'"
-    exit 1
-  fi
+  jq -e "has(\"$1\")" manifest.json > /dev/null \
+    || fail "manifest missing top-level field '$1'"
+}
+
+assert_jq_true() {
+  local description="$1" expr="$2"
+  jq -e "$expr" manifest.json > /dev/null \
+    || fail "$description"
 }
 
 assert_inputs_endswith() {
-  local suffix="$1"
-  if ! jq -e --arg s "$suffix" '[.inputs[] | select(endswith($s))] | length > 0' manifest.json > /dev/null; then
-    echo "FAILURE: manifest.inputs has no entry ending with '$suffix'"
-    exit 1
-  fi
+  jq -e --arg s "$1" '[.inputs[] | select(endswith($s))] | length > 0' manifest.json > /dev/null \
+    || fail "manifest.inputs has no entry ending with '$1'"
 }
 
 assert_outputs_endswith() {
-  local suffix="$1"
-  if ! jq -e --arg s "$suffix" '[.outputs[] | select(endswith($s))] | length > 0' manifest.json > /dev/null; then
-    echo "FAILURE: manifest.outputs has no entry ending with '$suffix'"
-    exit 1
-  fi
+  jq -e --arg s "$1" '[.outputs[] | select(endswith($s))] | length > 0' manifest.json > /dev/null \
+    || fail "manifest.outputs has no entry ending with '$1'"
 }
+
+assert_field_eq() {
+  local field="$1" expected="$2"
+  local actual
+  actual=$(jq -r ".$field" manifest.json)
+  [[ "$actual" == "$expected" ]] \
+    || fail "manifest.$field = '$actual', expected '$expected'"
+}
+
+assert_field_nonempty() {
+  local v
+  v=$(jq -r ".$1" manifest.json)
+  [[ -n "$v" && "$v" != "null" ]] \
+    || fail "manifest.$1 is empty/null"
+}
+
+# --- assertions on the manifest shape ---
 
 for f in job_id cmd args env cwd inputs outputs workspace lake_home toolchain toolchain_root; do
   assert_field "$f"
 done
 
-# job_id derives from `{pkg.baseName}_{mod.name}` — for this fixture, expect "wrappedExecManifest_Onlymod".
-expected_job_id="wrappedExecManifest_Onlymod"
-actual_job_id=$(jq -r '.job_id' manifest.json)
-if [[ "$actual_job_id" != "$expected_job_id" ]]; then
-  echo "FAILURE: job_id = '$actual_job_id', expected '$expected_job_id'"
-  exit 1
-fi
+# job_id derives from `{pkg.baseName}_{mod.name}`.
+assert_field_eq job_id "wrappedExecManifest_Onlymod"
 
-# cmd should end in '/lean'.
+# cmd should be a `lean` binary (path ending in /lean or the bare name).
 cmd=$(jq -r '.cmd' manifest.json)
-if [[ "$cmd" != *"/lean" && "$cmd" != "lean" ]]; then
-  echo "FAILURE: cmd = '$cmd' does not look like a lean binary"
-  exit 1
-fi
+[[ "$cmd" == *"/lean" || "$cmd" == "lean" ]] \
+  || fail "cmd = '$cmd' does not look like a lean binary"
 
-# inputs should contain the source file and the setup.json.
+# inputs: the source file + the per-module setup.json must both appear.
 assert_inputs_endswith 'Onlymod.lean'
 assert_inputs_endswith '.setup.json'
 
-# outputs should contain the .olean + .ilean for Onlymod.
+# outputs: the olean + ilean for this module must both appear.
 assert_outputs_endswith 'Onlymod.olean'
 assert_outputs_endswith 'Onlymod.ilean'
 
-# args should include the source file path that appears in inputs.
+# args must include the source-file path that appears in inputs (i.e.
+# `lean` is being asked to compile what we declared).
 src=$(jq -r '.inputs[] | select(endswith("Onlymod.lean"))' manifest.json)
-if ! jq -e --arg s "$src" '.args | any(. == $s)' manifest.json > /dev/null; then
-  echo "FAILURE: manifest.args does not include the source file"
-  exit 1
-fi
+assert_jq_true "manifest.args does not include the source file" \
+  ".args | any(. == \"$src\")"
 
 # env should at least set LEAN_PATH.
-if ! jq -e '.env | has("LEAN_PATH")' manifest.json > /dev/null; then
-  echo "FAILURE: manifest.env does not set LEAN_PATH"
-  exit 1
-fi
+assert_jq_true "manifest.env does not set LEAN_PATH" '.env | has("LEAN_PATH")'
 
-# workspace + lake_home + toolchain + toolchain_root should be non-empty absolute paths.
+# The four Lake roots Lake hands the wrapper must all be populated.
 for k in workspace lake_home toolchain toolchain_root; do
-  v=$(jq -r ".$k" manifest.json)
-  if [[ -z "$v" || "$v" == "null" ]]; then
-    echo "FAILURE: manifest.$k is empty/null"
-    exit 1
-  fi
+  assert_field_nonempty "$k"
 done
 
 echo "wrapped-exec manifest: shape checks pass."
-
 ./clean.sh

--- a/tests/lake/tests/wrapped-exec-manifest/wrapper-capture.sh
+++ b/tests/lake/tests/wrapped-exec-manifest/wrapper-capture.sh
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
-# Capture the manifest Lake hands us at $1 to a known location, then
-# return non-zero so the test can inspect the JSON without Lake actually
-# building anything downstream. Exit 71 (EX_OSERR) to signal
-# "infrastructure failure, not a lean compile error" — Lake will treat
-# this as a build failure but the test only cares about the captured
-# manifest, not the build outcome.
+# Capture each manifest Lake hands us into $CAPTURE_DIR (keyed by job_id),
+# then act as a passthrough — exec exactly what Lake would have run — so
+# the build proceeds to downstream modules and we capture one manifest
+# per lean job.
 set -euo pipefail
-cp "$1" "$CAPTURED_MANIFEST"
-exit 71
+
+m="$1"
+job_id=$(jq -r '.job_id' "$m")
+cp "$m" "$CAPTURE_DIR/$job_id.json"
+
+cmd=$(jq -r '.cmd' "$m")
+mapfile -t args < <(jq -r '.args[]' "$m")
+mapfile -t env_kvs < <(jq -r '.env | to_entries[] | "\(.key)=\(.value)"' "$m")
+cwd=$(jq -r '.cwd // ""' "$m")
+
+if [[ -n "$cwd" ]]; then
+  cd "$cwd"
+fi
+exec env "${env_kvs[@]}" "$cmd" "${args[@]}"

--- a/tests/lake/tests/wrapped-exec-manifest/wrapper-capture.sh
+++ b/tests/lake/tests/wrapped-exec-manifest/wrapper-capture.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Capture the manifest Lake hands us at $1 to a known location, then
+# return non-zero so the test can inspect the JSON without Lake actually
+# building anything downstream. Exit 71 (EX_OSERR) to signal
+# "infrastructure failure, not a lean compile error" — Lake will treat
+# this as a build failure but the test only cares about the captured
+# manifest, not the build outcome.
+set -euo pipefail
+cp "$1" "$CAPTURED_MANIFEST"
+exit 71

--- a/tests/lake/tests/wrapped-exec/Bar.lean
+++ b/tests/lake/tests/wrapped-exec/Bar.lean
@@ -1,0 +1,3 @@
+import Foo
+
+def Bar.value : Nat := Foo.value + 1

--- a/tests/lake/tests/wrapped-exec/Foo.lean
+++ b/tests/lake/tests/wrapped-exec/Foo.lean
@@ -1,0 +1,1 @@
+def Foo.value : Nat := 41

--- a/tests/lake/tests/wrapped-exec/clean.sh
+++ b/tests/lake/tests/wrapped-exec/clean.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Removes build state only. The test compares sums captured BETWEEN clean
+# invocations, so we deliberately don't touch them here.
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/wrapped-exec/lakefile.lean
+++ b/tests/lake/tests/wrapped-exec/lakefile.lean
@@ -1,0 +1,9 @@
+import Lake
+open Lake DSL
+
+package wrappedExec
+
+lean_lib Foo
+
+@[default_target]
+lean_lib Bar

--- a/tests/lake/tests/wrapped-exec/test.sh
+++ b/tests/lake/tests/wrapped-exec/test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Verifies the LAKE_WRAPPED_EXEC hook is inert under a passthrough wrapper:
+# a build through `wrapper-passthrough.sh` must produce byte-identical
+# artifacts to a build with the env var unset, and a follow-up rebuild
+# (with the env var unset again) must be a no-op — exercising Lake's
+# trace logic against wrapper-produced outputs.
+source ../common.sh
+
+chmod +x ./wrapper-passthrough.sh ./clean.sh
+
+# --- baseline: build with the hook OFF ---
+./clean.sh
+test_run build
+( cd .lake/build/lib/lean && find . -type f \( -name '*.olean' -o -name '*.ilean' -o -name '*.olean.server' -o -name '*.olean.private' \) -print0 | sort -z | xargs -0 shasum -a 256 ) > unwrapped.sums
+
+# --- same target under the passthrough wrapper ---
+./clean.sh
+LAKE_WRAPPED_EXEC="$PWD/wrapper-passthrough.sh" test_run build
+( cd .lake/build/lib/lean && find . -type f \( -name '*.olean' -o -name '*.ilean' -o -name '*.olean.server' -o -name '*.olean.private' \) -print0 | sort -z | xargs -0 shasum -a 256 ) > wrapped.sums
+
+# Both runs MUST produce the same artifacts.
+if ! diff -u unwrapped.sums wrapped.sums; then
+  echo "FAILURE: wrapped-exec passthrough produced different artifacts"
+  exit 1
+fi
+echo "wrapped-exec passthrough: artifacts byte-identical to baseline."
+
+# Follow-up rebuild with the env var unset should be a no-op — confirms
+# the wrapper-produced trace sidecars are recognised as up-to-date by
+# the unwrapped path. If wrapper outputs were stale or incomplete, lake
+# would re-run a "Built X" job here.
+"$LAKE" build > rebuild.out 2>&1
+if grep -E '^✔ \[[0-9]+/[0-9]+\] Built ' rebuild.out > /dev/null; then
+  echo "FAILURE: follow-up rebuild built modules — wrapper outputs not trace-equivalent"
+  cat rebuild.out
+  rm -f rebuild.out
+  exit 1
+fi
+rm -f rebuild.out
+echo "wrapped-exec follow-up rebuild: no-op as expected."
+
+rm -f produced.out unwrapped.sums wrapped.sums

--- a/tests/lake/tests/wrapped-exec/test.sh
+++ b/tests/lake/tests/wrapped-exec/test.sh
@@ -8,15 +8,30 @@ source ../common.sh
 
 chmod +x ./wrapper-passthrough.sh ./clean.sh
 
+# Hash every artifact Lake actually CONSULTS on rebuild — the four file
+# kinds `lean` writes from a `lean_module` build of a Lean-side module
+# (the `.c` and `.ir` are skipped: they go through a separate downstream
+# `leanir` step, and Lake's trace logic keys off the olean/ilean/server/
+# private set).
+capture_sums() {
+  ( cd .lake/build/lib/lean \
+    && find . -type f \
+        \( -name '*.olean' -o -name '*.ilean' \
+        -o -name '*.olean.server' -o -name '*.olean.private' \) \
+        -print0 \
+    | sort -z \
+    | xargs -0 shasum -a 256 )
+}
+
 # --- baseline: build with the hook OFF ---
 ./clean.sh
 test_run build
-( cd .lake/build/lib/lean && find . -type f \( -name '*.olean' -o -name '*.ilean' -o -name '*.olean.server' -o -name '*.olean.private' \) -print0 | sort -z | xargs -0 shasum -a 256 ) > unwrapped.sums
+capture_sums > unwrapped.sums
 
 # --- same target under the passthrough wrapper ---
 ./clean.sh
 LAKE_WRAPPED_EXEC="$PWD/wrapper-passthrough.sh" test_run build
-( cd .lake/build/lib/lean && find . -type f \( -name '*.olean' -o -name '*.ilean' -o -name '*.olean.server' -o -name '*.olean.private' \) -print0 | sort -z | xargs -0 shasum -a 256 ) > wrapped.sums
+capture_sums > wrapped.sums
 
 # Both runs MUST produce the same artifacts.
 if ! diff -u unwrapped.sums wrapped.sums; then
@@ -33,10 +48,9 @@ echo "wrapped-exec passthrough: artifacts byte-identical to baseline."
 if grep -E '^✔ \[[0-9]+/[0-9]+\] Built ' rebuild.out > /dev/null; then
   echo "FAILURE: follow-up rebuild built modules — wrapper outputs not trace-equivalent"
   cat rebuild.out
-  rm -f rebuild.out
+  rm -f rebuild.out unwrapped.sums wrapped.sums produced.out
   exit 1
 fi
-rm -f rebuild.out
 echo "wrapped-exec follow-up rebuild: no-op as expected."
 
-rm -f produced.out unwrapped.sums wrapped.sums
+rm -f rebuild.out unwrapped.sums wrapped.sums produced.out

--- a/tests/lake/tests/wrapped-exec/test.sh
+++ b/tests/lake/tests/wrapped-exec/test.sh
@@ -6,6 +6,11 @@
 # trace logic against wrapper-produced outputs.
 source ../common.sh
 
+# These tests need the wrapper to actually be invoked: with a warm Lake
+# artifact cache the modules are restored without any lean job running
+# and no wrapper dispatch happens. Pin the cache off for hermeticity.
+export LAKE_ARTIFACT_CACHE=false
+
 chmod +x ./wrapper-passthrough.sh ./clean.sh
 
 # Hash every artifact Lake actually CONSULTS on rebuild — the four file

--- a/tests/lake/tests/wrapped-exec/wrapper-passthrough.sh
+++ b/tests/lake/tests/wrapped-exec/wrapper-passthrough.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Trivial passthrough wrapper for `$LAKE_WRAPPED_EXEC`:
+# read the manifest at argv[1], exec exactly what Lake would have run.
+# A build under this wrapper must be byte-for-byte identical to a build
+# without `$LAKE_WRAPPED_EXEC` set at all.
+set -euo pipefail
+
+m="$1"
+cmd=$(jq -r '.cmd' "$m")
+mapfile -t args < <(jq -r '.args[]' "$m")
+mapfile -t env_kvs < <(jq -r '.env | to_entries[] | "\(.key)=\(.value)"' "$m")
+cwd=$(jq -r '.cwd // ""' "$m")
+
+if [[ -n "$cwd" ]]; then
+  cd "$cwd"
+fi
+exec env "${env_kvs[@]}" "$cmd" "${args[@]}"


### PR DESCRIPTION
Adds an optional hook that lets Lake route per-`lean` subprocess invocations through an external binary ("the wrapper") instead of invoking them directly via `rawProc`.

The wrapper is opaque to Lake: it can sandbox the call, look up a cached result, record an audit trail, dispatch to a worker pool, or simply exec the command itself. Lake just observes the wrapper's stdout/stderr/exit code, the same way it'd observe `lean`'s.