### PR TITLE
fix: make MatchCond proof creation use correct goal

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/MatchCond.lean
+++ b/src/Lean/Meta/Tactic/Grind/MatchCond.lean
@@ -280,7 +280,6 @@ where
     trace_goal[grind.debug.matchCond] "go?: {← inferType h}"
     let some (α?, lhs, rhs) := isEqHEq? (← inferType h)
       | return none
-    let target ← (← get).mvarId.getType
     -- We use `shareCommon` here because we may accessing a new expression
     -- created when we infer the type of the `noConfusion` term below
     let lhs ← shareCommon lhs
@@ -298,7 +297,7 @@ where
       let some ctorLhs ← isConstructorApp? root.self | return none
       let some ctorRhs ← isConstructorApp? rhs | return none
       -- See comment on `shareCommon` above.
-      let h ← mkNoConfusion target h
+      let h ← mkNoConfusion (← getFalseExpr) h
       if ctorLhs.name ≠ ctorRhs.name then
         return some h
       else

--- a/tests/elab/grind_match_cond_proof.lean
+++ b/tests/elab/grind_match_cond_proof.lean
@@ -1,0 +1,7 @@
+-- Better as a `theorem` and not an `example` until #13950 is fixed
+theorem test (a b : Bool) (q : Bool) (hq : q = true) :
+    match a, b with
+    | false, false => q = true
+    | true, true => q = true
+    | _, _ => True := by
+  grind


### PR DESCRIPTION
This PR fixes the creation of MatchCond proofs when using `mkNoConfusion`.

The conclusion of a MatchCond is always `False`, but `mkNoConfusion` was given the `target` which is not always `False`.

This partially addresses #13773. It fixes the surfaced issue reported there but that specific example still does not succeed due to more issues.

