### PR TITLE
fix: kvmap: declare lean_mk_bool_data_value extern parameter as uint8

### DIFF
--- a/src/util/kvmap.cpp
+++ b/src/util/kvmap.cpp
@@ -7,7 +7,7 @@ Author: Leonardo de Moura
 #include "util/kvmap.h"
 
 namespace lean {
-extern "C" object * lean_mk_bool_data_value(bool b);
+extern "C" object * lean_mk_bool_data_value(uint8 b);
 extern "C" uint8 lean_data_value_bool(object * v);
 extern "C" uint8 lean_data_value_beq(object * a, object * b);
 


### PR DESCRIPTION
This PR declares the `extern "C"` parameter of `lean_mk_bool_data_value` as `uint8` to match its `@[export]`ed Lean definition (where a `Bool` argument lowers to `uint8_t` at the C ABI), fixing a `wasm32`-emscripten/LTO ABI mismatch that trapped during module initialization.

I seemed to need to do this to not get ABI errors with WASM LTO.

AI description:
<details>
This PR fixes the `extern "C"` declaration of `lean_mk_bool_data_value` in `src/util/kvmap.cpp`, which declared the parameter as `bool` while the function is actually defined with a `uint8_t` parameter by `@[export lean_mk_bool_data_value] def mkBoolDataValueEx (b : Bool)` in `Lean/Data/KVMap.lean` (Lean lowers a `Bool` argument to `uint8_t` at the C ABI). The two sibling `extern "C"` declarations immediately below it (`lean_data_value_bool`, `lean_data_value_beq`) already use `uint8` for the same ABI, so this one was the lone outlier.

On native targets the mismatch is harmless, since `bool` and `uint8_t` share the same size and calling convention. When compiling to `wasm32-emscripten` with `-flto`, however, `bool` lowers to LLVM `i1` and `uint8_t` to `i8`; LTO cannot reconcile the call site (passing `i1`) with the definition (taking `i8`) and emits a trapping bitcast, so the first `register_option` for a `Bool`-valued option aborts during module initialization with `RuntimeError: unreachable`. This went unnoticed because the `linux_wasm32` build was dropped from CI after v4.15.0.
</details>
