### PR TITLE
chore: prepare mvcgen spec attribute for stage0 update

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Attr.lean
+++ b/src/Lean/Elab/Tactic/Do/Attr.lean
@@ -240,6 +240,26 @@ namespace Lean.Elab.Tactic.Do.Internal.SpecAttr
 
 open Lean Meta Std.Internal.Do Lean.Order
 
+/--
+The kind of a spec theorem.
+-/
+public inductive SpecTheoremKind where
+  /--
+  A Hoare triple spec: `⦃P⦄ prog ⦃Q⦄`.
+  If `etaPotential` is non-zero, then the precondition contains meta variables that can be
+  instantiated after applying `mintro ∀s` `etaPotential` many times.
+  -/
+  | triple
+  /--
+  A simp/equational spec: `lhs = rhs`.
+  The pattern is the LHS.
+  When matched, the VCGen rewrites the program from `lhs` to `rhs` and continues.
+  `etaArgs` is the number of extra arguments introduced by eta-expanding function-level equations
+  (e.g., class projection unfold lemmas). These args need `congrFun` at instantiation time.
+  -/
+  | simp (etaArgs : Nat := 0)
+  deriving Inhabited
+
 inductive SpecProof where
   | global (declName : Name)
   | local (fvarId : FVarId)
@@ -278,7 +298,15 @@ Normalises a specification proof so its conclusion is in `pre ⊑ wp …` form.
 private def tripleToWpProof? (proof type : Expr) : MetaM (Option (Expr × Expr)) := do
   let type ← whnfR type
   if type.isAppOfArity ``Triple 12 then
-    let proof ← mkAppM ``Triple.hwp #[proof]
+    -- Build the `Triple.hwp` projection application explicitly from the `Triple` type's own
+    -- arguments rather than via `mkAppM`. `mkAppM` would re-synthesise the instance arguments
+    -- (`Monad m`, `WPMonad m …`), which fails for transformer specs whose monad is a partially
+    -- applied transformer with still-unassigned parameters (e.g. `ExceptT ?ε ?m` in
+    -- `Spec.monadLift_ExceptT`): synthesis of `Monad (ExceptT ?ε ?m)` is attempted before the
+    -- caller has unified the spec's program against the goal. Reusing the type's arguments keeps
+    -- those instance metavariables shared with the proof, so no premature synthesis happens.
+    let lvls := type.getAppFn.constLevels!
+    let proof := mkAppN (.const ``Triple.hwp lvls) (type.getAppArgs.push proof)
     let type ← instantiateMVars (← inferType proof)
     return some (proof, type)
   else if type.isAppOfArity ``PartialOrder.rel 4 then
@@ -286,14 +314,17 @@ private def tripleToWpProof? (proof type : Expr) : MetaM (Option (Expr × Expr))
   else
     return none
 
-def SpecProof.instantiate (proof : SpecProof) : MetaM (Array Expr × Array BinderInfo × Expr × Expr) := do
+def SpecProof.instantiateRaw (proof : SpecProof) : MetaM (Array Expr × Array BinderInfo × Expr × Expr) := do
   let prf ← match proof with
     | .global declName => mkConstWithFreshMVarLevels declName
     | .local fvarId => pure <| mkFVar fvarId
     | .stx _ _ proof => pure proof
   let type ← instantiateMVars (← inferType prf)
   let (xs, bs, type) ← forallMetaTelescope type
-  let prf := prf.beta xs
+  return (xs, bs, prf.beta xs, type)
+
+def SpecProof.instantiate (proof : SpecProof) : MetaM (Array Expr × Array BinderInfo × Expr × Expr) := do
+  let (xs, bs, prf, type) ← proof.instantiateRaw
   let some (prf, type) ← tripleToWpProof? prf type
     | throwError "expected `Triple` or `⊑ wp` specification, got{indentExpr type}"
   return (xs, bs, prf, type)
@@ -314,6 +345,8 @@ structure SpecTheorem where
   pattern : Sym.Pattern
   /-- The proof for the theorem. -/
   proof : SpecProof
+  /-- The kind of spec theorem: triple or simp. -/
+  kind : SpecTheoremKind := .triple
   priority : Nat := eval_prio default
   deriving Inhabited
 
@@ -395,44 +428,63 @@ def eraseUnusedVarsFromPattern (p : Sym.Pattern) : Sym.Pattern := Id.run do
     checkTypeMask? := newCheckTypeMask? }
 
 /--
-Builds a `Sym.Pattern` keyed on the program inside a spec conclusion.
-Accepts both `Triple` and `pre ⊑ wp prog post epost` shapes.
+Selects the program a spec conclusion is keyed on: the program of a `Triple`, or the program inside
+the `wp` on the RHS of a `pre ⊑ wp …` entailment. Returns `none` if `type` is neither shape — e.g. a
+bare `lhs ⊑ rhs` whose RHS is not a `wp` application (an invariant entailment such as
+`(I n h).inv … ⊑ Q n r.2`, which can appear as an ordinary hypothesis but is not a spec). Callers use
+`none` to skip such non-spec hypotheses instead of failing.
 -/
-def mkSpecPatternFromExpr (expr : Expr) (levelParams : List Name := []) : MetaM Sym.Pattern := do
+def selectProg (type : Expr) : MetaM (Option Expr) := do
+  match_expr type with
+  | Triple _m _Pred _EPred _α _monad _instAL _instEAL _wpInst _pre prog _post _epost =>
+    return prog
+  | PartialOrder.rel _α _inst _pre rhs =>
+    let_expr wp _m _Pred _EPred _monad _instAL _instEAL _wpInst _α prog _post _epost := rhs
+      | return none
+    return prog
+  | _ => return none
+
+/--
+Builds a `Sym.Pattern` keyed on the program selected by `selectProg` from a spec conclusion.
+The conclusion is assumed to already be a valid spec shape (checked by the caller via `selectProg`);
+a non-spec shape reaching here is a logic error and throws.
+-/
+def mkSpecPatternFromExpr (expr : Expr)
+    (levelParams : List Name := []) : MetaM Sym.Pattern := do
   let (pattern, _) ← Sym.mkPatternFromExprWithKey expr levelParams fun type => do
-    let type ← whnfR type
-    if type.isAppOfArity ``Triple 12 then
-      return (type.getArg! 9, ())
-    else if type.isAppOfArity ``PartialOrder.rel 4 then
-      let rhs := type.getArg! 3
-      let_expr wp _m _Pred _EPred _monad _instAL _instEAL _wpInst _α prog _post _epost := rhs
-        | throwError "RHS of ⊑ is not a `wp` application{indentExpr rhs}"
-      return (prog, ())
-    else
-      throwError "unexpected kind of spec theorem; expected `Triple` or `⊑ wp`{indentExpr type}"
+    let some prog ← selectProg type
+      | throwError "unexpected kind of spec theorem; expected `Triple` or `⊑ wp`{indentExpr type}"
+    return (prog, ())
   return eraseUnusedVarsFromPattern pattern
 
-private def mkSpecTheorem (proof : SpecProof) (prio : Nat) : MetaM SpecTheorem := do
+private def mkSpecTheorem (type : Expr) (proof : SpecProof) (prio : Nat) : MetaM (Option SpecTheorem) := do
   let (levelParams, expr) ← proof.getProof
+  let type ← instantiateMVars type
+  let (_, _, type) ← forallMetaTelescope type
+  let some _ ← selectProg type | return none
   let pattern ← mkSpecPatternFromExpr expr levelParams
-  return { pattern, proof, priority := prio }
+  return some { pattern, proof, priority := prio }
 
-def mkSpecTheoremFromConst (declName : Name) (prio : Nat := eval_prio default) : MetaM SpecTheorem :=
-  mkSpecTheorem (.global declName) prio
+def mkSpecTheoremFromConst (declName : Name) (prio : Nat := eval_prio default) : MetaM (Option SpecTheorem) := do
+  let info ← getConstInfo declName
+  mkSpecTheorem info.type (.global declName) prio
 
-def mkSpecTheoremFromLocal (fvar : FVarId) (prio : Nat := eval_prio default) : MetaM SpecTheorem := do
-  let some _ ← fvar.findDecl? | throwError "invalid 'spec', local declaration {fvar.name} not found"
-  mkSpecTheorem (.local fvar) prio
+def mkSpecTheoremFromLocal (fvar : FVarId) (prio : Nat := eval_prio default) : MetaM (Option SpecTheorem) := do
+  let some decl ← fvar.findDecl? | throwError "invalid 'spec', local declaration {fvar.name} not found"
+  mkSpecTheorem decl.type (.local fvar) prio
 
-def mkSpecTheoremFromStx (ref : Syntax) (proof : Expr) (prio : Nat := eval_prio default) : MetaM SpecTheorem := do
-  mkSpecTheorem (.stx (← mkFreshId) ref proof) prio
+def mkSpecTheoremFromStx (ref : Syntax) (proof : Expr) (prio : Nat := eval_prio default) : MetaM (Option SpecTheorem) := do
+  let type ← inferType proof
+  mkSpecTheorem type (.stx (← mkFreshId) ref proof) prio
 
 def SpecExtension.addSpecTheoremFromConst (ext : SpecExtension) (declName : Name) (prio : Nat) (attrKind : AttributeKind) : MetaM Unit := do
-  let thm ← mkSpecTheoremFromConst declName prio
+  let some thm ← mkSpecTheoremFromConst declName prio |
+    throwError "invalid 'spec', expected `Triple` or `⊑ wp`"
   ext.add thm attrKind
 
 def SpecExtension.addSpecTheoremFromLocal (ext : SpecExtension) (fvar : FVarId) (prio : Nat := eval_prio default) : MetaM Unit := do
-  let thm ← mkSpecTheoremFromLocal fvar prio
+  let some thm ← mkSpecTheoremFromLocal fvar prio |
+    throwError "invalid 'spec', expected `Triple` or `⊑ wp`"
   ext.add thm .local
 
 def mkSpecExt : SimpleScopedEnvExtension.Descr SpecEntry SpecTheorems where

--- a/src/Lean/Elab/Tactic/Do/Attr.lean
+++ b/src/Lean/Elab/Tactic/Do/Attr.lean
@@ -244,11 +244,7 @@ open Lean Meta Std.Internal.Do Lean.Order
 The kind of a spec theorem.
 -/
 public inductive SpecTheoremKind where
-  /--
-  A Hoare triple spec: `⦃P⦄ prog ⦃Q⦄`.
-  If `etaPotential` is non-zero, then the precondition contains meta variables that can be
-  instantiated after applying `mintro ∀s` `etaPotential` many times.
-  -/
+  /-- A Hoare triple spec: `⦃P⦄ prog ⦃Q⦄`. -/
   | triple
   /--
   A simp/equational spec: `lhs = rhs`.
@@ -295,10 +291,10 @@ Normalises a specification proof so its conclusion is in `pre ⊑ wp …` form.
   `pre ⊑ wp …` form (passed through unchanged).
 - Returns `none` if `type` is neither shape; callers should `throwError`.
 -/
-private def tripleToWpProof? (proof type : Expr) : MetaM (Option (Expr × Expr)) := do
+def tripleToWpProof? (proof type : Expr) : MetaM (Option (Expr × Expr)) := do
   let type ← whnfR type
   if type.isAppOfArity ``Triple 12 then
-    -- Build the `Triple.hwp` projection application explicitly from the `Triple` type's own
+    -- Build the `Triple.rel_wp` projection application explicitly from the `Triple` type's own
     -- arguments rather than via `mkAppM`. `mkAppM` would re-synthesise the instance arguments
     -- (`Monad m`, `WPMonad m …`), which fails for transformer specs whose monad is a partially
     -- applied transformer with still-unassigned parameters (e.g. `ExceptT ?ε ?m` in
@@ -306,7 +302,7 @@ private def tripleToWpProof? (proof type : Expr) : MetaM (Option (Expr × Expr))
     -- caller has unified the spec's program against the goal. Reusing the type's arguments keeps
     -- those instance metavariables shared with the proof, so no premature synthesis happens.
     let lvls := type.getAppFn.constLevels!
-    let proof := mkAppN (.const ``Triple.hwp lvls) (type.getAppArgs.push proof)
+    let proof := mkAppN (.const ``Triple.rel_wp lvls) (type.getAppArgs.push proof)
     let type ← instantiateMVars (← inferType proof)
     return some (proof, type)
   else if type.isAppOfArity ``PartialOrder.rel 4 then
@@ -314,7 +310,7 @@ private def tripleToWpProof? (proof type : Expr) : MetaM (Option (Expr × Expr))
   else
     return none
 
-def SpecProof.instantiateRaw (proof : SpecProof) : MetaM (Array Expr × Array BinderInfo × Expr × Expr) := do
+def SpecProof.instantiate (proof : SpecProof) : MetaM (Array Expr × Array BinderInfo × Expr × Expr) := do
   let prf ← match proof with
     | .global declName => mkConstWithFreshMVarLevels declName
     | .local fvarId => pure <| mkFVar fvarId
@@ -322,12 +318,6 @@ def SpecProof.instantiateRaw (proof : SpecProof) : MetaM (Array Expr × Array Bi
   let type ← instantiateMVars (← inferType prf)
   let (xs, bs, type) ← forallMetaTelescope type
   return (xs, bs, prf.beta xs, type)
-
-def SpecProof.instantiate (proof : SpecProof) : MetaM (Array Expr × Array BinderInfo × Expr × Expr) := do
-  let (xs, bs, prf, type) ← proof.instantiateRaw
-  let some (prf, type) ← tripleToWpProof? prf type
-    | throwError "expected `Triple` or `⊑ wp` specification, got{indentExpr type}"
-  return (xs, bs, prf, type)
 
 instance : ToMessageData SpecProof where
   toMessageData := fun
@@ -339,7 +329,8 @@ structure SpecTheorem where
   /--
   Pattern for the program expression.
   This is the key used in the discrimination tree.
-  If the proof has type `∀ a b c, ⦃P⦄ prog ⦃Q⦄`, then the pattern is `prog[a:=#2, b:=#1, c:=#0]`.
+  If the proof has type `∀ a b c d e, ⦃P⦄ prog ⦃Q⦄` and only `a`, `c` and `e` occur in `prog`,
+  then the pattern is `prog[a:=#2, c:=#1, e:=#0]`.
   For specs stated as `pre ⊑ wp prog post epost`, the pattern is keyed on `prog`.
   -/
   pattern : Sym.Pattern
@@ -507,6 +498,9 @@ namespace Lean.Elab.Tactic.Do.SpecAttr
 def mkSpecAttr : AttributeImpl where
   name  := `spec
   descr := "Marks Hoare triple specifications and simp theorems for use with `mvcgen` tactics"
+  -- .afterCompilation seems unnecessarily conservative, but the simp attribute impl needs it.
+  -- The reason is that we cannot annotate definitions with `@[spec]` otherwise; the error is
+  -- > trying to realize id.eq_1 but `enableRealizationsForConst` must be called for 'id' first
   applicationTime := AttributeApplicationTime.afterCompilation
   add := fun declName stx attrKind => do
     let go : MetaM Unit := do

--- a/src/Lean/Elab/Tactic/Do/Attr.lean
+++ b/src/Lean/Elab/Tactic/Do/Attr.lean
@@ -339,11 +339,67 @@ def SpecTheorems.erase (d : SpecTheorems) (thmId : SpecProof) : SpecTheorems :=
 abbrev SpecExtension := SimpleScopedEnvExtension SpecEntry SpecTheorems
 
 /--
+Drops pattern variables that the pattern expression does not depend on.
+
+`Sym.mkPatternFromExprWithKey`/`Sym.mkPatternFromDeclWithKey` turn *every* leading `∀`-binder of the
+source type into a pattern variable, even binders the selected key (e.g. the program of a `Triple`
+conclusion) never mentions. During matching those variables only ever become fresh metavariables
+(see `Sym.mkPreResult`); for instance binders they additionally trigger spurious `trySynthInstance`
+calls. This keeps only the variables that the pattern expression references, together with the
+transitive closure of variables their types depend on, and renumbers the remaining de Bruijn
+indices. `varInfos?` and `checkTypeMask?` are filtered to the surviving telescope; `fnInfos`,
+`levelParams`, and the discrimination-tree key are unchanged because the pattern expression's
+structure is untouched (bound variables are wildcards in the key).
+
+**Important:** only use this when the matched arguments are *not* reused to rebuild a proof term,
+as `Sym.BackwardRule`/`Sym.mkValue` do — dropping variables would drop arguments those need. It is
+meant for databases such as `mvcgen'`'s spec table, where the proof is re-elaborated independently
+of the pattern.
+-/
+def eraseUnusedVarsFromPattern (p : Sym.Pattern) : Sym.Pattern := Id.run do
+  let n := p.varTypes.size
+  -- Variable `j` (0 = outermost binder) is bound variable `#(ctx-1-j)` in a context of `ctx`
+  -- binders. `used[j]` becomes `true` once we know variable `j` is reachable from the pattern.
+  let mut used := Array.replicate n false
+  for j in *...n do
+    if p.pattern.hasLooseBVar (n - 1 - j) then
+      used := used.set! j true
+  -- A variable's type may reference earlier variables, so propagate top-down: when a kept variable
+  -- is reached, mark every variable occurring in its type as kept too.
+  for j in *...n do
+    let i := n - 1 - j
+    if used[i]! then
+      for k in *...i do
+        if p.varTypes[i]!.hasLooseBVar (i - 1 - k) then
+          used := used.set! k true
+  if used.all (· == true) then return p
+  let kept := (Array.range n).filter (used[·]!)
+  -- Rebuild the telescope via fvar placeholders to avoid manual de Bruijn arithmetic.
+  let fvars := (Array.range n).map fun i => mkFVar ⟨.num `_sym_prune i⟩
+  let keptFVars := kept.map (fvars[·]!)
+  let newPattern := (p.pattern.instantiateRev fvars).abstract keptFVars
+  let newVarTypes := kept.mapIdx fun k i =>
+    (p.varTypes[i]!.instantiateRev (fvars.extract 0 i)).abstract (keptFVars.extract 0 k)
+  -- `varInfos?`/`checkTypeMask?` are parallel to `varTypes`; their per-variable meaning does not
+  -- depend on the de Bruijn numbering, so we simply keep the surviving entries.
+  let newVarInfos? := p.varInfos?.bind fun infos =>
+    let argsInfo := kept.map (infos.argsInfo[·]!)
+    if argsInfo.any fun a => a.isProof || a.isInstance then some { argsInfo } else none
+  let newCheckTypeMask? := p.checkTypeMask?.bind fun mask =>
+    let newMask := kept.map (mask[·]!)
+    if newMask.all (· == false) then none else some newMask
+  return { p with
+    varTypes := newVarTypes
+    pattern := newPattern
+    varInfos? := newVarInfos?
+    checkTypeMask? := newCheckTypeMask? }
+
+/--
 Builds a `Sym.Pattern` keyed on the program inside a spec conclusion.
 Accepts both `Triple` and `pre ⊑ wp prog post epost` shapes.
 -/
-def mkSpecPatternFromExpr (expr : Expr) (levelParams : List Name := []) : MetaM Sym.Pattern :=
-  Prod.fst <$> Sym.mkPatternFromExprWithKey expr levelParams fun type => do
+def mkSpecPatternFromExpr (expr : Expr) (levelParams : List Name := []) : MetaM Sym.Pattern := do
+  let (pattern, _) ← Sym.mkPatternFromExprWithKey expr levelParams fun type => do
     let type ← whnfR type
     if type.isAppOfArity ``Triple 12 then
       return (type.getArg! 9, ())
@@ -354,6 +410,7 @@ def mkSpecPatternFromExpr (expr : Expr) (levelParams : List Name := []) : MetaM 
       return (prog, ())
     else
       throwError "unexpected kind of spec theorem; expected `Triple` or `⊑ wp`{indentExpr type}"
+  return eraseUnusedVarsFromPattern pattern
 
 private def mkSpecTheorem (proof : SpecProof) (prio : Nat) : MetaM SpecTheorem := do
   let (levelParams, expr) ← proof.getProof

--- a/src/Lean/Elab/Tactic/Do/Attr.lean
+++ b/src/Lean/Elab/Tactic/Do/Attr.lean
@@ -8,6 +8,7 @@ module
 prelude
 public import Lean.Meta.Tactic.Simp
 public import Std.Tactic.Do.Syntax
+public import Std.Internal.Do.Triple.Basic
 import Init.While
 import Init.Syntax
 
@@ -249,13 +250,219 @@ def mkSpecAttr (ext : SpecExtension) : AttributeImpl where
       throwError "Invalid 'spec': target was neither a Hoare triple specification nor a 'simp' lemma"
     discard <| go.run {} {}
 
-builtin_initialize registerBuiltinAttribute (mkSpecAttr specAttr)
+def SpecExtension.getTheorems (ext : SpecExtension) : CoreM SpecTheorems :=
+  return ext.getState (← getEnv)
+
+def getSpecTheorems : CoreM SpecTheorems :=
+  specAttr.getTheorems
+
+end Lean.Elab.Tactic.Do.SpecAttr
+
+namespace Lean.Elab.Tactic.Do.Internal.SpecAttr
+
+open Lean Meta Std.Internal.Do Lean.Order
+
+inductive SpecProof where
+  | global (declName : Name)
+  | local (fvarId : FVarId)
+  | stx (id : Name) (ref : Syntax) (proof : Expr)
+  deriving Inhabited, BEq
+
+/-- A unique identifier corresponding to the origin. -/
+def SpecProof.key : SpecProof → Name
+  | .global declName => declName
+  | .local fvarId => fvarId.name
+  | .stx id _ _ => id
+
+/-- Convert a simp `Origin` to a `SpecProof`. -/
+def SpecProof.ofOrigin : Origin → Option SpecProof
+  | .decl declName .. => some (.global declName)
+  | .fvar fvarId => some (.local fvarId)
+  | _ => none
+
+def SpecProof.getProof : SpecProof → MetaM (List Name × Expr)
+  | .stx _ _ proof => pure ([], proof)
+  | .local fvarId => pure ([], mkFVar fvarId)
+  | .global declName => do
+    let info ← getConstInfo declName
+    pure (info.levelParams, mkConst declName (info.levelParams.map mkLevelParam))
+
+instance : Hashable SpecProof where
+  hash sp := hash sp.key
+
+private def tripleToWpProof? (proof type : Expr) : MetaM (Expr × Expr) := do
+  let type ← whnfR type
+  if type.isAppOfArity ``Triple 12 then
+    let .const _ lvls := type.getAppFn
+      | return (proof, type)
+    let args := type.getAppArgs
+    -- Triple inductive param order:  m Pred EPred α Monad AL EAL WP pre x post epost
+    -- Triple.iff theorem param order: m Pred EPred Monad AL EAL WP α x pre post epost
+    let tripleIff := mkAppN (mkConst ``Triple.iff lvls)
+      #[args[0]!, args[1]!, args[2]!, args[4]!, args[5]!, args[6]!, args[7]!, args[3]!, args[9]!, args[8]!, args[10]!, args[11]!]
+    let proof ← mkAppM ``Iff.mp #[tripleIff, proof]
+    let type ← instantiateMVars (← inferType proof)
+    return (proof, type)
+  else
+    return (proof, type)
+
+def SpecProof.instantiate (proof : SpecProof) : MetaM (Array Expr × Array BinderInfo × Expr × Expr) := do
+  let prf ← match proof with
+    | .global declName => mkConstWithFreshMVarLevels declName
+    | .local fvarId => pure <| mkFVar fvarId
+    | .stx _ _ proof => pure proof
+  let type ← instantiateMVars (← inferType prf)
+  let (xs, bs, type) ← forallMetaTelescope type
+  let prf := prf.beta xs
+  let (prf, type) ← tripleToWpProof? prf type
+  return (xs, bs, prf, type)
+
+instance : ToMessageData SpecProof where
+  toMessageData := fun
+    | .global declName => m!"SpecProof.global {declName}"
+    | .local fvarId => m!"SpecProof.local {mkFVar fvarId}"
+    | .stx _ ref proof => m!"SpecProof.stx _ {ref} {proof}"
+
+structure SpecTheorem where
+  keys : Array DiscrTree.Key
+  /--
+  Expr key tested for matching, in ∀-quantified form.
+  `keys = (← mkPath (← forallMetaTelescope prog).2.2)`.
+  -/
+  prog : Expr
+  /-- The proof for the theorem. -/
+  proof : SpecProof
+  priority : Nat := eval_prio default
+  deriving Inhabited
+
+instance : BEq SpecTheorem where
+  beq a b := a.keys == b.keys && a.prog == b.prog && a.proof == b.proof && a.priority == b.priority
+
+abbrev SpecEntry := SpecTheorem
+
+structure SpecTheorems where
+  specs : DiscrTree SpecTheorem := DiscrTree.empty
+  erased : PHashSet SpecProof := {}
+  deriving Inhabited
+
+def SpecTheorems.insert (d : SpecTheorems) (e : SpecTheorem) : SpecTheorems :=
+  { d with specs := d.specs.insertKeyValue e.keys e }
+
+def SpecTheorems.isErased (d : SpecTheorems) (thmId : SpecProof) : Bool :=
+  d.erased.contains thmId
+
+def SpecTheorems.erase (d : SpecTheorems) (thmId : SpecProof) : SpecTheorems :=
+  { d with erased := d.erased.insert thmId }
+
+abbrev SpecExtension := SimpleScopedEnvExtension SpecEntry SpecTheorems
+
+/-- Extract the program expression from a spec conclusion (`Triple` or `⊑ wp` form). -/
+private def selectProg (type : Expr) : MetaM Expr := do
+  let type ← whnfR type
+  if type.isAppOfArity ``Triple 12 then
+    return type.getArg! 9
+  else if type.isAppOfArity ``PartialOrder.rel 4 then
+    let rhs := type.getArg! 3
+    let_expr wp _m _Pred _EPred _monad _instAL _instEAL _wpInst _α prog _post _epost := rhs
+      | throwError "RHS of ⊑ is not a wp application{indentExpr rhs}"
+    return prog
+  else
+    throwError "unexpected kind of spec theorem; expected Triple or ⊑ wp{indentExpr type}"
+
+private def mkSpecTheorem (type : Expr) (proof : SpecProof) (prio : Nat) : MetaM SpecTheorem := do
+  let type ← instantiateMVars type
+  unless (← isProp type) do
+    throwError "invalid 'spec', proposition expected{indentExpr type}"
+  withNewMCtxDepth do
+  let (xs, _, type) ← withSimpGlobalConfig (forallMetaTelescopeReducing type)
+  let type ← whnfR type
+  let prog ← selectProg type
+  let keys ← DiscrTree.mkPath prog (noIndexAtArgs := false)
+  return { keys, prog := (← mkForallFVars xs prog), proof, priority := prio }
+
+def mkSpecTheoremFromConst (declName : Name) (prio : Nat := eval_prio default) : MetaM SpecTheorem := do
+  let cinfo ← getConstInfo declName
+  let us := cinfo.levelParams.map mkLevelParam
+  let val := mkConst declName us
+  let type ← inferType val
+  mkSpecTheorem type (.global declName) prio
+
+def mkSpecTheoremFromLocal (fvar : FVarId) (prio : Nat := eval_prio default) : MetaM SpecTheorem := do
+  let some decl ← fvar.findDecl? | throwError "invalid 'spec', local declaration {fvar.name} not found"
+  mkSpecTheorem decl.type (.local fvar) prio
+
+def mkSpecTheoremFromStx (ref : Syntax) (proof : Expr) (prio : Nat := eval_prio default) : MetaM SpecTheorem := do
+  let type ← inferType proof
+  mkSpecTheorem type (.stx (← mkFreshId) ref proof) prio
+
+def SpecExtension.addSpecTheoremFromConst (ext : SpecExtension) (declName : Name) (prio : Nat) (attrKind : AttributeKind) : MetaM Unit := do
+  let thm ← mkSpecTheoremFromConst declName prio
+  ext.add thm attrKind
+
+def SpecExtension.addSpecTheoremFromLocal (ext : SpecExtension) (fvar : FVarId) (prio : Nat := eval_prio default) : MetaM Unit := do
+  let thm ← mkSpecTheoremFromLocal fvar prio
+  ext.add thm .local
+
+def mkSpecExt : SimpleScopedEnvExtension.Descr SpecEntry SpecTheorems where
+  name     := `internalSpecMap
+  initial  := {}
+  addEntry := fun d e => d.insert e
+
+builtin_initialize specAttr : SpecExtension ← registerSimpleScopedEnvExtension mkSpecExt
+
+def mkSpecAttr (ext : SpecExtension) : AttributeImpl where
+  name  := `spec
+  descr := "Marks CompleteLattice-based Hoare specifications and simp theorems for use with the new `mvcgen` tactic"
+  applicationTime := AttributeApplicationTime.afterCompilation
+  add   := fun declName stx attrKind => do
+    let go : MetaM Unit := do
+      let _info ← getConstInfo declName
+      let prio ← getAttrParamOptPrio stx[1]
+      try
+        ext.addSpecTheoremFromConst declName prio attrKind
+      catch _ =>
+      let impl ← getBuiltinAttributeImpl `mvcgen_simp
+      try
+        let newStx ← `(attr| mvcgen_simp)
+        let newStx := newStx.raw.setArg 3 stx[1]
+        impl.add declName newStx attrKind
+      catch e =>
+      trace[Elab.Tactic.Do.specAttr] "Reason for failure to apply spec attribute: {e.toMessageData}"
+      throwError "Invalid 'spec': target was neither a Hoare triple specification nor a 'simp' lemma"
+    discard <| go.run {} {}
 
 def SpecExtension.getTheorems (ext : SpecExtension) : CoreM SpecTheorems :=
   return ext.getState (← getEnv)
 
 def getSpecTheorems : CoreM SpecTheorems :=
   specAttr.getTheorems
+
+end Lean.Elab.Tactic.Do.Internal.SpecAttr
+
+namespace Lean.Elab.Tactic.Do.SpecAttr
+
+def mkSpecAttrOpt : AttributeImpl where
+  name  := `spec
+  descr := "Marks Hoare triple specifications and simp theorems for use with `mvcgen` tactics"
+  applicationTime := AttributeApplicationTime.afterCompilation
+  add := fun declName stx attrKind => do
+    -- Classify by the statement's type (no dependency on `new_wp_monad`): first try the legacy
+    -- `Std.Do.Triple` path directly — `mkSpecTheorem` throws if the statement is not an old `Triple`
+    -- (and we deliberately do NOT use the full `mkSpecAttr`, whose `mvcgen_simp` fallback would
+    -- swallow a new-metatheory triple as a `P ↔ True` simp lemma). On failure, hand off to the
+    -- new-metatheory attribute, which routes `⊑ wp`/`Triple` into `internalSpecMap` and otherwise
+    -- falls back to the shared `mvcgen_simp` simp set.
+    try
+      let go : MetaM Unit := do
+        let _ ← getAsyncConstInfo declName
+        let prio ← getAttrParamOptPrio stx[1]
+        specAttr.addSpecTheoremFromConst declName prio attrKind
+      discard <| go.run {} {}
+    catch _ =>
+      (Lean.Elab.Tactic.Do.Internal.SpecAttr.mkSpecAttr
+        Lean.Elab.Tactic.Do.Internal.SpecAttr.specAttr).add declName stx attrKind
+
+builtin_initialize registerBuiltinAttribute mkSpecAttrOpt
 
 /--
 Marks a type as an invariant type for the `mvcgen` tactic.
@@ -274,3 +481,5 @@ def isSpecInvariantType (env : Environment) (ty : Expr) : Bool :=
     specInvariantAttr.hasTag env name
   else
     false
+
+end Lean.Elab.Tactic.Do.SpecAttr

--- a/src/Lean/Elab/Tactic/Do/Attr.lean
+++ b/src/Lean/Elab/Tactic/Do/Attr.lean
@@ -7,10 +7,12 @@ module
 
 prelude
 public import Lean.Meta.Tactic.Simp
+public import Lean.Meta.Sym.Pattern
 public import Std.Tactic.Do.Syntax
 public import Std.Internal.Do.Triple.Basic
 import Init.While
 import Init.Syntax
+import Lean.Meta.Sym.Simp.DiscrTree
 
 public section
 
@@ -226,30 +228,6 @@ def mkSpecExt : SimpleScopedEnvExtension.Descr SpecEntry SpecTheorems where
 
 builtin_initialize specAttr : SpecExtension ← registerSimpleScopedEnvExtension mkSpecExt
 
-def mkSpecAttr (ext : SpecExtension) : AttributeImpl where
-  name  := `spec
-  descr := "Marks Hoare triple specifications and simp theorems to use with the `mspec` and `mvcgen` tactics"
-  -- .afterCompilation seems unnecessarily conservative, but the simp attribute impl needs it.
-  -- The reason is that we cannot annotate definitions with `@[spec]` otherwise; the error is
-  -- > trying to realize id.eq_1 but `enableRealizationsForConst` must be called for 'id' first
-  applicationTime := AttributeApplicationTime.afterCompilation
-  add   := fun declName stx attrKind => do
-    let go : MetaM Unit := do
-      let info ← getAsyncConstInfo declName
-      let prio ← getAttrParamOptPrio stx[1]
-      try
-        ext.addSpecTheoremFromConst declName prio attrKind
-      catch _ =>
-      let impl ← getBuiltinAttributeImpl `mvcgen_simp
-      try
-        let newStx ← `(attr| mvcgen_simp)
-        let newStx := newStx.raw.setArg 3 stx[1]
-        impl.add declName newStx attrKind
-      catch e =>
-      trace[Elab.Tactic.Do.specAttr] "Reason for failure to apply spec attribute: {e.toMessageData}"
-      throwError "Invalid 'spec': target was neither a Hoare triple specification nor a 'simp' lemma"
-    discard <| go.run {} {}
-
 def SpecExtension.getTheorems (ext : SpecExtension) : CoreM SpecTheorems :=
   return ext.getState (← getEnv)
 
@@ -290,21 +268,23 @@ def SpecProof.getProof : SpecProof → MetaM (List Name × Expr)
 instance : Hashable SpecProof where
   hash sp := hash sp.key
 
-private def tripleToWpProof? (proof type : Expr) : MetaM (Expr × Expr) := do
+/--
+Normalises a specification proof so its conclusion is in `pre ⊑ wp …` form.
+
+- Returns `some` for `Triple` proofs (rewriting via `Triple.hwp`) and proofs already in
+  `pre ⊑ wp …` form (passed through unchanged).
+- Returns `none` if `type` is neither shape; callers should `throwError`.
+-/
+private def tripleToWpProof? (proof type : Expr) : MetaM (Option (Expr × Expr)) := do
   let type ← whnfR type
   if type.isAppOfArity ``Triple 12 then
-    let .const _ lvls := type.getAppFn
-      | return (proof, type)
-    let args := type.getAppArgs
-    -- Triple inductive param order:  m Pred EPred α Monad AL EAL WP pre x post epost
-    -- Triple.iff theorem param order: m Pred EPred Monad AL EAL WP α x pre post epost
-    let tripleIff := mkAppN (mkConst ``Triple.iff lvls)
-      #[args[0]!, args[1]!, args[2]!, args[4]!, args[5]!, args[6]!, args[7]!, args[3]!, args[9]!, args[8]!, args[10]!, args[11]!]
-    let proof ← mkAppM ``Iff.mp #[tripleIff, proof]
+    let proof ← mkAppM ``Triple.hwp #[proof]
     let type ← instantiateMVars (← inferType proof)
-    return (proof, type)
+    return some (proof, type)
+  else if type.isAppOfArity ``PartialOrder.rel 4 then
+    return some (proof, type)
   else
-    return (proof, type)
+    return none
 
 def SpecProof.instantiate (proof : SpecProof) : MetaM (Array Expr × Array BinderInfo × Expr × Expr) := do
   let prf ← match proof with
@@ -314,7 +294,8 @@ def SpecProof.instantiate (proof : SpecProof) : MetaM (Array Expr × Array Binde
   let type ← instantiateMVars (← inferType prf)
   let (xs, bs, type) ← forallMetaTelescope type
   let prf := prf.beta xs
-  let (prf, type) ← tripleToWpProof? prf type
+  let some (prf, type) ← tripleToWpProof? prf type
+    | throwError "expected `Triple` or `⊑ wp` specification, got{indentExpr type}"
   return (xs, bs, prf, type)
 
 instance : ToMessageData SpecProof where
@@ -324,19 +305,20 @@ instance : ToMessageData SpecProof where
     | .stx _ ref proof => m!"SpecProof.stx _ {ref} {proof}"
 
 structure SpecTheorem where
-  keys : Array DiscrTree.Key
   /--
-  Expr key tested for matching, in ∀-quantified form.
-  `keys = (← mkPath (← forallMetaTelescope prog).2.2)`.
+  Pattern for the program expression.
+  This is the key used in the discrimination tree.
+  If the proof has type `∀ a b c, ⦃P⦄ prog ⦃Q⦄`, then the pattern is `prog[a:=#2, b:=#1, c:=#0]`.
+  For specs stated as `pre ⊑ wp prog post epost`, the pattern is keyed on `prog`.
   -/
-  prog : Expr
+  pattern : Sym.Pattern
   /-- The proof for the theorem. -/
   proof : SpecProof
   priority : Nat := eval_prio default
   deriving Inhabited
 
 instance : BEq SpecTheorem where
-  beq a b := a.keys == b.keys && a.prog == b.prog && a.proof == b.proof && a.priority == b.priority
+  beq a b := a.proof == b.proof
 
 abbrev SpecEntry := SpecTheorem
 
@@ -346,7 +328,7 @@ structure SpecTheorems where
   deriving Inhabited
 
 def SpecTheorems.insert (d : SpecTheorems) (e : SpecTheorem) : SpecTheorems :=
-  { d with specs := d.specs.insertKeyValue e.keys e }
+  { d with specs := Sym.insertPattern d.specs e.pattern e }
 
 def SpecTheorems.isErased (d : SpecTheorems) (thmId : SpecProof) : Bool :=
   d.erased.contains thmId
@@ -356,44 +338,37 @@ def SpecTheorems.erase (d : SpecTheorems) (thmId : SpecProof) : SpecTheorems :=
 
 abbrev SpecExtension := SimpleScopedEnvExtension SpecEntry SpecTheorems
 
-/-- Extract the program expression from a spec conclusion (`Triple` or `⊑ wp` form). -/
-private def selectProg (type : Expr) : MetaM Expr := do
-  let type ← whnfR type
-  if type.isAppOfArity ``Triple 12 then
-    return type.getArg! 9
-  else if type.isAppOfArity ``PartialOrder.rel 4 then
-    let rhs := type.getArg! 3
-    let_expr wp _m _Pred _EPred _monad _instAL _instEAL _wpInst _α prog _post _epost := rhs
-      | throwError "RHS of ⊑ is not a wp application{indentExpr rhs}"
-    return prog
-  else
-    throwError "unexpected kind of spec theorem; expected Triple or ⊑ wp{indentExpr type}"
+/--
+Builds a `Sym.Pattern` keyed on the program inside a spec conclusion.
+Accepts both `Triple` and `pre ⊑ wp prog post epost` shapes.
+-/
+def mkSpecPatternFromExpr (expr : Expr) (levelParams : List Name := []) : MetaM Sym.Pattern :=
+  Prod.fst <$> Sym.mkPatternFromExprWithKey expr levelParams fun type => do
+    let type ← whnfR type
+    if type.isAppOfArity ``Triple 12 then
+      return (type.getArg! 9, ())
+    else if type.isAppOfArity ``PartialOrder.rel 4 then
+      let rhs := type.getArg! 3
+      let_expr wp _m _Pred _EPred _monad _instAL _instEAL _wpInst _α prog _post _epost := rhs
+        | throwError "RHS of ⊑ is not a `wp` application{indentExpr rhs}"
+      return (prog, ())
+    else
+      throwError "unexpected kind of spec theorem; expected `Triple` or `⊑ wp`{indentExpr type}"
 
-private def mkSpecTheorem (type : Expr) (proof : SpecProof) (prio : Nat) : MetaM SpecTheorem := do
-  let type ← instantiateMVars type
-  unless (← isProp type) do
-    throwError "invalid 'spec', proposition expected{indentExpr type}"
-  withNewMCtxDepth do
-  let (xs, _, type) ← withSimpGlobalConfig (forallMetaTelescopeReducing type)
-  let type ← whnfR type
-  let prog ← selectProg type
-  let keys ← DiscrTree.mkPath prog (noIndexAtArgs := false)
-  return { keys, prog := (← mkForallFVars xs prog), proof, priority := prio }
+private def mkSpecTheorem (proof : SpecProof) (prio : Nat) : MetaM SpecTheorem := do
+  let (levelParams, expr) ← proof.getProof
+  let pattern ← mkSpecPatternFromExpr expr levelParams
+  return { pattern, proof, priority := prio }
 
-def mkSpecTheoremFromConst (declName : Name) (prio : Nat := eval_prio default) : MetaM SpecTheorem := do
-  let cinfo ← getConstInfo declName
-  let us := cinfo.levelParams.map mkLevelParam
-  let val := mkConst declName us
-  let type ← inferType val
-  mkSpecTheorem type (.global declName) prio
+def mkSpecTheoremFromConst (declName : Name) (prio : Nat := eval_prio default) : MetaM SpecTheorem :=
+  mkSpecTheorem (.global declName) prio
 
 def mkSpecTheoremFromLocal (fvar : FVarId) (prio : Nat := eval_prio default) : MetaM SpecTheorem := do
-  let some decl ← fvar.findDecl? | throwError "invalid 'spec', local declaration {fvar.name} not found"
-  mkSpecTheorem decl.type (.local fvar) prio
+  let some _ ← fvar.findDecl? | throwError "invalid 'spec', local declaration {fvar.name} not found"
+  mkSpecTheorem (.local fvar) prio
 
 def mkSpecTheoremFromStx (ref : Syntax) (proof : Expr) (prio : Nat := eval_prio default) : MetaM SpecTheorem := do
-  let type ← inferType proof
-  mkSpecTheorem type (.stx (← mkFreshId) ref proof) prio
+  mkSpecTheorem (.stx (← mkFreshId) ref proof) prio
 
 def SpecExtension.addSpecTheoremFromConst (ext : SpecExtension) (declName : Name) (prio : Nat) (attrKind : AttributeKind) : MetaM Unit := do
   let thm ← mkSpecTheoremFromConst declName prio
@@ -410,16 +385,31 @@ def mkSpecExt : SimpleScopedEnvExtension.Descr SpecEntry SpecTheorems where
 
 builtin_initialize specAttr : SpecExtension ← registerSimpleScopedEnvExtension mkSpecExt
 
-def mkSpecAttr (ext : SpecExtension) : AttributeImpl where
+def SpecExtension.getTheorems (ext : SpecExtension) : CoreM SpecTheorems :=
+  return ext.getState (← getEnv)
+
+def getSpecTheorems : CoreM SpecTheorems :=
+  specAttr.getTheorems
+
+end Lean.Elab.Tactic.Do.Internal.SpecAttr
+
+namespace Lean.Elab.Tactic.Do.SpecAttr
+
+def mkSpecAttr : AttributeImpl where
   name  := `spec
-  descr := "Marks CompleteLattice-based Hoare specifications and simp theorems for use with the new `mvcgen` tactic"
+  descr := "Marks Hoare triple specifications and simp theorems for use with `mvcgen` tactics"
   applicationTime := AttributeApplicationTime.afterCompilation
-  add   := fun declName stx attrKind => do
+  add := fun declName stx attrKind => do
     let go : MetaM Unit := do
-      let _info ← getConstInfo declName
+      let _ ← getAsyncConstInfo declName
       let prio ← getAttrParamOptPrio stx[1]
       try
-        ext.addSpecTheoremFromConst declName prio attrKind
+        -- Legacy `Std.Do.Triple` specs.
+        specAttr.addSpecTheoremFromConst declName prio attrKind
+      catch _ =>
+      try
+        -- New metatheory `Std.Internal.Do.Triple` / `⊑ wp` specs.
+        Internal.SpecAttr.specAttr.addSpecTheoremFromConst declName prio attrKind
       catch _ =>
       let impl ← getBuiltinAttributeImpl `mvcgen_simp
       try
@@ -431,38 +421,7 @@ def mkSpecAttr (ext : SpecExtension) : AttributeImpl where
       throwError "Invalid 'spec': target was neither a Hoare triple specification nor a 'simp' lemma"
     discard <| go.run {} {}
 
-def SpecExtension.getTheorems (ext : SpecExtension) : CoreM SpecTheorems :=
-  return ext.getState (← getEnv)
-
-def getSpecTheorems : CoreM SpecTheorems :=
-  specAttr.getTheorems
-
-end Lean.Elab.Tactic.Do.Internal.SpecAttr
-
-namespace Lean.Elab.Tactic.Do.SpecAttr
-
-def mkSpecAttrOpt : AttributeImpl where
-  name  := `spec
-  descr := "Marks Hoare triple specifications and simp theorems for use with `mvcgen` tactics"
-  applicationTime := AttributeApplicationTime.afterCompilation
-  add := fun declName stx attrKind => do
-    -- Classify by the statement's type (no dependency on `new_wp_monad`): first try the legacy
-    -- `Std.Do.Triple` path directly — `mkSpecTheorem` throws if the statement is not an old `Triple`
-    -- (and we deliberately do NOT use the full `mkSpecAttr`, whose `mvcgen_simp` fallback would
-    -- swallow a new-metatheory triple as a `P ↔ True` simp lemma). On failure, hand off to the
-    -- new-metatheory attribute, which routes `⊑ wp`/`Triple` into `internalSpecMap` and otherwise
-    -- falls back to the shared `mvcgen_simp` simp set.
-    try
-      let go : MetaM Unit := do
-        let _ ← getAsyncConstInfo declName
-        let prio ← getAttrParamOptPrio stx[1]
-        specAttr.addSpecTheoremFromConst declName prio attrKind
-      discard <| go.run {} {}
-    catch _ =>
-      (Lean.Elab.Tactic.Do.Internal.SpecAttr.mkSpecAttr
-        Lean.Elab.Tactic.Do.Internal.SpecAttr.specAttr).add declName stx attrKind
-
-builtin_initialize registerBuiltinAttribute mkSpecAttrOpt
+builtin_initialize registerBuiltinAttribute mkSpecAttr
 
 /--
 Marks a type as an invariant type for the `mvcgen` tactic.

--- a/src/Std/Internal/Do/Triple/Basic.lean
+++ b/src/Std/Internal/Do/Triple/Basic.lean
@@ -36,7 +36,7 @@ structure Triple [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EP
   /-- Construct a triple from a weakest precondition entailment. -/
   intro ::
   /-- The weakest precondition entailment witnessing the triple. -/
-  (hwp : pre ⊑ wp x post epost)
+  rel_wp : pre ⊑ wp x post epost
 
 /-- Hoare triple notation without exception postcondition (defaults to `⊥`). -/
 scoped notation:60 "⦃ " pre " ⦄ " x " ⦃ " post " ⦄" => Triple pre x post ⊥

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -5,6 +5,7 @@ options get_default_options() {
     options opts;
     // see https://github.com/leanprover/lean4/blob/master/doc/dev/bootstrap.md#further-bootstrapping-complications
 #if LEAN_IS_STAGE0 == 1
+    // Request stage0 update for Lean.Elab.Tactic.Do.Attr builtin attribute changes.
     // set to true to generally avoid bootstrapping issues limited to proofs
     opts = opts.update({"debug", "proofAsSorry"}, false);
     // set to true to generally avoid bootstrapping issues in `omega` and `grind`


### PR DESCRIPTION
This PR prepares the `@[spec]` attribute used by `mvcgen` to support both specifications theorems for both new and old `mvcgen'` meta theories.

The change keeps the legacy spec database in place, adds a separate internal spec database for WP-based specs, and registers one dispatcher implementation for `@[spec]`. The dispatcher first tries to register a declaration as a legacy `Std.Do.Triple` spec, then tries the new internal WP-based spec path, and finally falls back to `mvcgen_simp` for simp lemmas. This ordering preserves existing `@[spec]` behavior while allowing declarations written in the new internal spec format to be collected by `mvcgen`.