### PR TITLE
chore: turn on `defProp` and `checkUnivs` linters

### DIFF
--- a/src/Init/Control/Except.lean
+++ b/src/Init/Control/Except.lean
@@ -330,6 +330,7 @@ instance ExceptT.finally {m : Type u → Type v} {ε : Type u} [MonadFinally m] 
     | (_,        .error e) => pure (.error e)  -- second error has precedence
     | (.error e, _)        => pure (.error e)
 
+set_option linter.checkUnivs false in
 instance [Monad m] [MonadAttach m] : MonadAttach (ExceptT ε m) where
   CanReturn x a := MonadAttach.CanReturn (m := m) x (.ok a)
   attach x := show m (Except ε _) from

--- a/src/Init/Control/Lawful/Instances.lean
+++ b/src/Init/Control/Lawful/Instances.lean
@@ -32,6 +32,7 @@ namespace ExceptT
 
 @[simp] theorem stM_eq [Monad m] : stM m (ExceptT ε m) α = Except ε α := rfl
 
+set_option linter.checkUnivs false in
 @[simp, grind =] theorem run_mk (x : m (Except ε α)) : run (mk x : ExceptT ε m α) = x := rfl
 
 @[simp, grind =] theorem run_pure [Monad m] (x : α) : run (pure x : ExceptT ε m α) = pure (Except.ok x) := rfl

--- a/src/Init/Data/Array/Lemmas.lean
+++ b/src/Init/Data/Array/Lemmas.lean
@@ -4348,6 +4348,7 @@ theorem sum_toList [Add α] [Zero α] {as : Array α} : as.toList.sum = as.sum :
   cases as
   simp [Array.sum, List.sum]
 
+set_option linter.defProp false in
 @[deprecated sum_toList (since := "2026-01-14")]
 def sum_eq_sum_toList := @sum_toList
 

--- a/src/Init/Data/Array/Subarray.lean
+++ b/src/Init/Data/Array/Subarray.lean
@@ -66,10 +66,12 @@ def Subarray.start (xs : Subarray α) : Nat :=
 def Subarray.stop (xs : Subarray α) : Nat :=
   xs.internalRepresentation.stop
 
+set_option linter.defProp false in
 @[always_inline, inline, expose, inherit_doc Internal.SubarrayData.start_le_stop]
 def Subarray.start_le_stop (xs : Subarray α) : xs.start ≤ xs.stop :=
   xs.internalRepresentation.start_le_stop
 
+set_option linter.defProp false in
 @[always_inline, inline, expose, inherit_doc Internal.SubarrayData.stop_le_array_size]
 def Subarray.stop_le_array_size (xs : Subarray α) : xs.stop ≤ xs.array.size :=
   xs.internalRepresentation.stop_le_array_size

--- a/src/Init/Data/BitVec/Bitblast.lean
+++ b/src/Init/Data/BitVec/Bitblast.lean
@@ -872,9 +872,8 @@ structure DivModState.Lawful {w : Nat} (args : DivModArgs w) (qr : DivModState w
   /-- The low `(w - wn)` bits of `n` obey the invariant for division. -/
   hdiv : args.n.toNat >>> qr.wn = args.d.toNat * qr.q.toNat + qr.r.toNat
 
-set_option linter.defProp false in
 /-- A lawful DivModState implies `w > 0`. -/
-def DivModState.Lawful.hw {args : DivModArgs w} {qr : DivModState w}
+theorem DivModState.Lawful.hw {args : DivModArgs w} {qr : DivModState w}
     {h : DivModState.Lawful args qr} : 0 < w := by
   have hd := h.hdPos
   rcases w with rfl | w
@@ -891,9 +890,8 @@ def DivModState.init (w : Nat) : DivModState w := {
   r := 0#w
 }
 
-set_option linter.defProp false in
 /-- The initial state is lawful. -/
-def DivModState.lawful_init {w : Nat} (args : DivModArgs w) (hd : 0#w < args.d) :
+theorem DivModState.lawful_init {w : Nat} (args : DivModArgs w) (hd : 0#w < args.d) :
     DivModState.Lawful args (DivModState.init w) := by
   simp only [BitVec.DivModState.init]
   exact {
@@ -949,12 +947,11 @@ structure DivModState.Poised {w : Nat} (args : DivModArgs w) (qr : DivModState w
   /-- Only perform a round of shift-subtract if we have dividend bits. -/
   hwn_lt : 0 < qr.wn
 
-set_option linter.defProp false in
 /--
 In the shift subtract input, the dividend is at least one bit long (`wn > 0`), so
 the remainder has bits to be computed (`wr < w`).
 -/
-def DivModState.wr_lt_w {qr : DivModState w} (h : qr.Poised args) : qr.wr < w := by
+theorem DivModState.wr_lt_w {qr : DivModState w} (h : qr.Poised args) : qr.wr < w := by
   have hwrn := h.hwrn
   have hwn_lt := h.hwn_lt
   omega

--- a/src/Init/Data/BitVec/Bitblast.lean
+++ b/src/Init/Data/BitVec/Bitblast.lean
@@ -872,6 +872,7 @@ structure DivModState.Lawful {w : Nat} (args : DivModArgs w) (qr : DivModState w
   /-- The low `(w - wn)` bits of `n` obey the invariant for division. -/
   hdiv : args.n.toNat >>> qr.wn = args.d.toNat * qr.q.toNat + qr.r.toNat
 
+set_option linter.defProp false in
 /-- A lawful DivModState implies `w > 0`. -/
 def DivModState.Lawful.hw {args : DivModArgs w} {qr : DivModState w}
     {h : DivModState.Lawful args qr} : 0 < w := by
@@ -890,6 +891,7 @@ def DivModState.init (w : Nat) : DivModState w := {
   r := 0#w
 }
 
+set_option linter.defProp false in
 /-- The initial state is lawful. -/
 def DivModState.lawful_init {w : Nat} (args : DivModArgs w) (hd : 0#w < args.d) :
     DivModState.Lawful args (DivModState.init w) := by
@@ -947,6 +949,7 @@ structure DivModState.Poised {w : Nat} (args : DivModArgs w) (qr : DivModState w
   /-- Only perform a round of shift-subtract if we have dividend bits. -/
   hwn_lt : 0 < qr.wn
 
+set_option linter.defProp false in
 /--
 In the shift subtract input, the dividend is at least one bit long (`wn > 0`), so
 the remainder has bits to be computed (`wr < w`).

--- a/src/Init/Data/Fin/Lemmas.lean
+++ b/src/Init/Data/Fin/Lemmas.lean
@@ -520,9 +520,6 @@ theorem coe_cast (h : n = m) (i : Fin n) : (i.cast h : Nat) = i := rfl
 @[simp, grind =] theorem cast_cast {k : Nat} (h : n = m) (h' : m = k) {i : Fin n} :
     (i.cast h).cast h' = i.cast (Eq.trans h h') := rfl
 
-set_option linter.defProp false in
-@[deprecated cast_cast (since := "2025-09-03")] abbrev cast_trans := @cast_cast
-
 theorem castLE_of_eq {m n : Nat} (h : m = n) {h' : m ≤ n} : castLE h' = Fin.cast h := rfl
 
 @[simp, grind =] theorem val_castAdd (m : Nat) (i : Fin n) : (castAdd m i : Nat) = i := rfl

--- a/src/Init/Data/Fin/Lemmas.lean
+++ b/src/Init/Data/Fin/Lemmas.lean
@@ -520,6 +520,7 @@ theorem coe_cast (h : n = m) (i : Fin n) : (i.cast h : Nat) = i := rfl
 @[simp, grind =] theorem cast_cast {k : Nat} (h : n = m) (h' : m = k) {i : Fin n} :
     (i.cast h).cast h' = i.cast (Eq.trans h h') := rfl
 
+set_option linter.defProp false in
 @[deprecated cast_cast (since := "2025-09-03")] abbrev cast_trans := @cast_cast
 
 theorem castLE_of_eq {m n : Nat} (h : m = n) {h' : m ≤ n} : castLE h' = Fin.cast h := rfl

--- a/src/Init/Data/Int/DivMod/Bootstrap.lean
+++ b/src/Init/Data/Int/DivMod/Bootstrap.lean
@@ -111,24 +111,28 @@ where
       ← Int.neg_neg (_-_), Int.neg_sub, Int.sub_sub_self, Int.add_right_comm]
     exact congrArg (fun x => -(ofNat x + 1)) (Nat.mod_add_div ..)
 
+set_option linter.defProp false in
 @[deprecated emod_add_mul_ediv (since := "2025-09-01")]
 def emod_add_ediv := @emod_add_mul_ediv
 
 theorem emod_add_ediv_mul (a b : Int) : a % b + a / b * b = a := by
   rw [Int.mul_comm]; exact emod_add_mul_ediv ..
 
+set_option linter.defProp false in
 @[deprecated emod_add_ediv_mul (since := "2025-09-01")]
 def emod_add_ediv' := @emod_add_ediv_mul
 
 theorem mul_ediv_add_emod (a b : Int) : b * (a / b) + a % b = a := by
   rw [Int.add_comm]; exact emod_add_mul_ediv ..
 
+set_option linter.defProp false in
 @[deprecated mul_ediv_add_emod (since := "2025-09-01")]
 def ediv_add_emod := @mul_ediv_add_emod
 
 theorem ediv_mul_add_emod (a b : Int) : a / b * b + a % b = a := by
   rw [Int.mul_comm]; exact mul_ediv_add_emod ..
 
+set_option linter.defProp false in
 @[deprecated ediv_mul_add_emod (since := "2025-09-01")]
 def ediv_add_emod' := @ediv_mul_add_emod
 

--- a/src/Init/Data/Int/DivMod/Bootstrap.lean
+++ b/src/Init/Data/Int/DivMod/Bootstrap.lean
@@ -111,30 +111,14 @@ where
       ← Int.neg_neg (_-_), Int.neg_sub, Int.sub_sub_self, Int.add_right_comm]
     exact congrArg (fun x => -(ofNat x + 1)) (Nat.mod_add_div ..)
 
-set_option linter.defProp false in
-@[deprecated emod_add_mul_ediv (since := "2025-09-01")]
-def emod_add_ediv := @emod_add_mul_ediv
-
 theorem emod_add_ediv_mul (a b : Int) : a % b + a / b * b = a := by
   rw [Int.mul_comm]; exact emod_add_mul_ediv ..
-
-set_option linter.defProp false in
-@[deprecated emod_add_ediv_mul (since := "2025-09-01")]
-def emod_add_ediv' := @emod_add_ediv_mul
 
 theorem mul_ediv_add_emod (a b : Int) : b * (a / b) + a % b = a := by
   rw [Int.add_comm]; exact emod_add_mul_ediv ..
 
-set_option linter.defProp false in
-@[deprecated mul_ediv_add_emod (since := "2025-09-01")]
-def ediv_add_emod := @mul_ediv_add_emod
-
 theorem ediv_mul_add_emod (a b : Int) : a / b * b + a % b = a := by
   rw [Int.mul_comm]; exact mul_ediv_add_emod ..
-
-set_option linter.defProp false in
-@[deprecated ediv_mul_add_emod (since := "2025-09-01")]
-def ediv_add_emod' := @ediv_mul_add_emod
 
 theorem emod_def (a b : Int) : a % b = a - b * (a / b) := by
   rw [← Int.add_sub_cancel (a % b), emod_add_mul_ediv]

--- a/src/Init/Data/Int/DivMod/Lemmas.lean
+++ b/src/Init/Data/Int/DivMod/Lemmas.lean
@@ -360,30 +360,14 @@ theorem tmod_add_mul_tdiv : ∀ a b : Int, tmod a b + b * (a.tdiv b) = a
     rw [Int.neg_mul, ← Int.neg_add]
     exact congrArg (-ofNat ·) (Nat.mod_add_div ..)
 
-set_option linter.defProp false in
-@[deprecated tmod_add_mul_tdiv (since := "2025-09-01")]
-def tmod_add_tdiv := @tmod_add_mul_tdiv
-
 theorem mul_tdiv_add_tmod (a b : Int) : b * a.tdiv b + tmod a b = a := by
   rw [Int.add_comm]; apply tmod_add_mul_tdiv ..
-
-set_option linter.defProp false in
-@[deprecated mul_tdiv_add_tmod (since := "2025-09-01")]
-def tdiv_add_tmod := @mul_tdiv_add_tmod
 
 theorem tmod_add_tdiv_mul (m k : Int) : tmod m k + m.tdiv k * k = m := by
   rw [Int.mul_comm]; apply tmod_add_mul_tdiv
 
-set_option linter.defProp false in
-@[deprecated tmod_add_tdiv_mul (since := "2025-09-01")]
-def tmod_add_tdiv' := @tmod_add_mul_tdiv
-
 theorem tdiv_mul_add_tmod (m k : Int) : m.tdiv k * k + tmod m k = m := by
   rw [Int.mul_comm]; apply mul_tdiv_add_tmod
-
-set_option linter.defProp false in
-@[deprecated tdiv_mul_add_tmod (since := "2025-09-01")]
-def tdiv_add_tmod' := @tdiv_mul_add_tmod
 
 theorem tmod_def (a b : Int) : tmod a b = a - b * a.tdiv b := by
   rw [← Int.add_sub_cancel (tmod a b), tmod_add_mul_tdiv]
@@ -411,30 +395,14 @@ theorem fmod_add_mul_fdiv : ∀ a b : Int, a.fmod b + b * a.fdiv b = a
     change -(↑(succ m % succ n) : Int) + -↑(succ n * (succ m / succ n)) = -↑(succ m)
     rw [← Int.neg_add]; exact congrArg (-ofNat ·) <| Nat.mod_add_div ..
 
-set_option linter.defProp false in
-@[deprecated fmod_add_mul_fdiv (since := "2025-09-01")]
-def fmod_add_fdiv := @fmod_add_mul_fdiv
-
 theorem fmod_add_fdiv_mul (a b : Int) : a.fmod b + (a.fdiv b) * b = a := by
   rw [Int.mul_comm]; exact fmod_add_mul_fdiv ..
-
-set_option linter.defProp false in
-@[deprecated fmod_add_fdiv_mul (since := "2025-09-01")]
-def fmod_add_fdiv' := @fmod_add_fdiv_mul
 
 theorem mul_fdiv_add_fmod (a b : Int) : b * a.fdiv b + a.fmod b = a := by
   rw [Int.add_comm]; exact fmod_add_mul_fdiv ..
 
-set_option linter.defProp false in
-@[deprecated mul_fdiv_add_fmod (since := "2025-09-01")]
-def fdiv_add_fmod := @mul_fdiv_add_fmod
-
 theorem fdiv_mul_add_fmod (a b : Int) : (a.fdiv b) * b + a.fmod b = a := by
   rw [Int.mul_comm]; exact mul_fdiv_add_fmod ..
-
-set_option linter.defProp false in
-@[deprecated mul_fdiv_add_fmod (since := "2025-09-01")]
-def fdiv_add_fmod' := @mul_fdiv_add_fmod
 
 theorem fmod_def (a b : Int) : a.fmod b = a - b * a.fdiv b := by
   rw [← Int.add_sub_cancel (a.fmod b), fmod_add_mul_fdiv]

--- a/src/Init/Data/Int/DivMod/Lemmas.lean
+++ b/src/Init/Data/Int/DivMod/Lemmas.lean
@@ -360,24 +360,28 @@ theorem tmod_add_mul_tdiv : ∀ a b : Int, tmod a b + b * (a.tdiv b) = a
     rw [Int.neg_mul, ← Int.neg_add]
     exact congrArg (-ofNat ·) (Nat.mod_add_div ..)
 
+set_option linter.defProp false in
 @[deprecated tmod_add_mul_tdiv (since := "2025-09-01")]
 def tmod_add_tdiv := @tmod_add_mul_tdiv
 
 theorem mul_tdiv_add_tmod (a b : Int) : b * a.tdiv b + tmod a b = a := by
   rw [Int.add_comm]; apply tmod_add_mul_tdiv ..
 
+set_option linter.defProp false in
 @[deprecated mul_tdiv_add_tmod (since := "2025-09-01")]
 def tdiv_add_tmod := @mul_tdiv_add_tmod
 
 theorem tmod_add_tdiv_mul (m k : Int) : tmod m k + m.tdiv k * k = m := by
   rw [Int.mul_comm]; apply tmod_add_mul_tdiv
 
+set_option linter.defProp false in
 @[deprecated tmod_add_tdiv_mul (since := "2025-09-01")]
 def tmod_add_tdiv' := @tmod_add_mul_tdiv
 
 theorem tdiv_mul_add_tmod (m k : Int) : m.tdiv k * k + tmod m k = m := by
   rw [Int.mul_comm]; apply mul_tdiv_add_tmod
 
+set_option linter.defProp false in
 @[deprecated tdiv_mul_add_tmod (since := "2025-09-01")]
 def tdiv_add_tmod' := @tdiv_mul_add_tmod
 
@@ -407,24 +411,28 @@ theorem fmod_add_mul_fdiv : ∀ a b : Int, a.fmod b + b * a.fdiv b = a
     change -(↑(succ m % succ n) : Int) + -↑(succ n * (succ m / succ n)) = -↑(succ m)
     rw [← Int.neg_add]; exact congrArg (-ofNat ·) <| Nat.mod_add_div ..
 
+set_option linter.defProp false in
 @[deprecated fmod_add_mul_fdiv (since := "2025-09-01")]
 def fmod_add_fdiv := @fmod_add_mul_fdiv
 
 theorem fmod_add_fdiv_mul (a b : Int) : a.fmod b + (a.fdiv b) * b = a := by
   rw [Int.mul_comm]; exact fmod_add_mul_fdiv ..
 
+set_option linter.defProp false in
 @[deprecated fmod_add_fdiv_mul (since := "2025-09-01")]
 def fmod_add_fdiv' := @fmod_add_fdiv_mul
 
 theorem mul_fdiv_add_fmod (a b : Int) : b * a.fdiv b + a.fmod b = a := by
   rw [Int.add_comm]; exact fmod_add_mul_fdiv ..
 
+set_option linter.defProp false in
 @[deprecated mul_fdiv_add_fmod (since := "2025-09-01")]
 def fdiv_add_fmod := @mul_fdiv_add_fmod
 
 theorem fdiv_mul_add_fmod (a b : Int) : (a.fdiv b) * b + a.fmod b = a := by
   rw [Int.mul_comm]; exact mul_fdiv_add_fmod ..
 
+set_option linter.defProp false in
 @[deprecated mul_fdiv_add_fmod (since := "2025-09-01")]
 def fdiv_add_fmod' := @mul_fdiv_add_fmod
 

--- a/src/Init/Data/Int/Linear.lean
+++ b/src/Init/Data/Int/Linear.lean
@@ -262,6 +262,7 @@ theorem cmod_eq_zero_iff_emod_eq_zero (a b : Int) : cmod a b = 0 ↔ a%b = 0 := 
   simp only [emod_self, sub_emod_left] at this
   rw [Int.neg_eq_zero, ← this, Eq.comm]
 
+set_option linter.defProp false in
 private abbrev div_mul_cancel_of_mod_zero :=
   @Int.ediv_mul_cancel_of_emod_eq_zero
 

--- a/src/Init/Data/Int/Order.lean
+++ b/src/Init/Data/Int/Order.lean
@@ -155,6 +155,7 @@ protected theorem lt_iff_le_and_not_ge {a b : Int} : a < b ↔ a ≤ b ∧ ¬b �
   · exact Int.le_antisymm h h'
   · subst h'; apply Int.le_refl
 
+set_option linter.defProp false in
 @[deprecated Int.lt_iff_le_and_not_ge (since := "2026-02-11")]
 protected def lt_iff_le_not_le := @Int.lt_iff_le_and_not_ge
 

--- a/src/Init/Data/Iterators/Basic.lean
+++ b/src/Init/Data/Iterators/Basic.lean
@@ -394,20 +394,10 @@ theorem IterM.mk_internalState {α m β} (it : IterM (α := α) m β) :
     ⟨it.internalState⟩ = it := by
   simp
 
-set_option linter.defProp false in
-set_option linter.missingDocs false in
-@[deprecated IterM.mk_internalState (since := "2025-12-01")]
-def Iterators.toIterM_internalState := @IterM.mk_internalState
-
 @[simp]
 theorem IterM.internalState_mk {α m β} (it : α) :
     (⟨it⟩ : IterM m β).internalState = it :=
   rfl
-
-set_option linter.defProp false in
-set_option linter.missingDocs false in
-@[expose, deprecated IterM.internalState_mk (since := "2025-01-29")]
-def internalState_toIterM := @IterM.internalState_mk
 
 @[simp]
 theorem Iter.internalState_toIterM {α β} (it : Std.Iter (α := α) β) :

--- a/src/Init/Data/Iterators/Basic.lean
+++ b/src/Init/Data/Iterators/Basic.lean
@@ -394,6 +394,7 @@ theorem IterM.mk_internalState {α m β} (it : IterM (α := α) m β) :
     ⟨it.internalState⟩ = it := by
   simp
 
+set_option linter.defProp false in
 set_option linter.missingDocs false in
 @[deprecated IterM.mk_internalState (since := "2025-12-01")]
 def Iterators.toIterM_internalState := @IterM.mk_internalState
@@ -403,6 +404,7 @@ theorem IterM.internalState_mk {α m β} (it : α) :
     (⟨it⟩ : IterM m β).internalState = it :=
   rfl
 
+set_option linter.defProp false in
 set_option linter.missingDocs false in
 @[expose, deprecated IterM.internalState_mk (since := "2025-01-29")]
 def internalState_toIterM := @IterM.internalState_mk

--- a/src/Init/Data/Iterators/Lemmas/Combinators/Attach.lean
+++ b/src/Init/Data/Iterators/Lemmas/Combinators/Attach.lean
@@ -88,6 +88,7 @@ theorem Iter.length_attachWith [Iterator α Id β]
   rw [← Iter.length_toList_eq_length, toList_attachWith]
   simp
 
+set_option linter.defProp false in
 @[deprecated Iter.length_attachWith (since := "2026-01-28")]
 def Iter.count_attachWith := @Iter.length_attachWith
 

--- a/src/Init/Data/Iterators/Lemmas/Combinators/FilterMap.lean
+++ b/src/Init/Data/Iterators/Lemmas/Combinators/FilterMap.lean
@@ -259,6 +259,7 @@ theorem Iter.step_map {f : β → γ} :
   generalize it.toIterM.step.run = step
   cases step.inflate using PlausibleIterStep.casesOn <;> simp
 
+set_option linter.defProp false in
 def Iter.step_filter {f : β → Bool} :
     (it.filter f).step = match it.step with
       | .yield it' out h =>
@@ -278,6 +279,7 @@ def Iter.step_filter {f : β → Bool} :
   · simp
   · simp
 
+set_option linter.defProp false in
 def Iter.val_step_filter {f : β → Bool} :
     (it.filter f).step.val = match it.step.val with
       | .yield it' out =>
@@ -738,6 +740,7 @@ theorem Iter.length_map {α β β' : Type w} [Iterator α Id β]
     (it.map f).length = it.length := by
   simp [map_eq_toIter_map_toIterM, length_eq_length_toIterM]
 
+set_option linter.defProp false in
 @[deprecated Iter.length_map (since := "2026-01-28")]
 def Iter.count_map := @Iter.length_map
 

--- a/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/Attach.lean
+++ b/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/Attach.lean
@@ -72,6 +72,7 @@ theorem IterM.length_attachWith [Iterator α m β] [Monad m] [Monad n]
     ← map_unattach_toList_attachWith (it := it) (P := P) (hP := hP)]
   simp only [Functor.map_map, List.length_unattach]
 
+set_option linter.defProp false in
 @[deprecated IterM.length_attachWith (since := "2026-01-28")]
 def IterM.count_attachWith := @IterM.length_attachWith
 

--- a/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/FilterMap.lean
+++ b/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/FilterMap.lean
@@ -1638,6 +1638,7 @@ theorem IterM.length_map {α β β' : Type w} {m : Type w → Type w'} [Iterator
   · simp [ihs ‹_›]
   · simp
 
+set_option linter.defProp false in
 @[deprecated IterM.length_map (since := "2026-01-28")]
 def IterM.count_map := @IterM.length_map
 

--- a/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/ULift.lean
+++ b/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/ULift.lean
@@ -83,6 +83,7 @@ theorem IterM.length_uLift [Iterator α m β] [Monad m] [Monad n] {it : IterM (�
   · simp [ihs ‹_›]
   · simp
 
+set_option linter.defProp false in
 @[deprecated IterM.length_uLift (since := "2026-01-28")]
 def IterM.count_uLift := @IterM.length_uLift
 

--- a/src/Init/Data/Iterators/Lemmas/Combinators/ULift.lean
+++ b/src/Init/Data/Iterators/Lemmas/Combinators/ULift.lean
@@ -67,6 +67,7 @@ theorem Iter.length_uLift [Iterator α Id β] {it : Iter (α := α) β}
   rw [IterM.length_uLift]
   simp [monadLift]
 
+set_option linter.defProp false in
 @[deprecated Iter.length_uLift (since := "2026-01-28")]
 def Iter.count_uLift := @Iter.length_uLift
 

--- a/src/Init/Data/Iterators/Lemmas/Consumers/Loop.lean
+++ b/src/Init/Data/Iterators/Lemmas/Consumers/Loop.lean
@@ -521,10 +521,6 @@ theorem Iter.size_toArray_eq_length {α β : Type w} [Iterator α Id β] [Finite
     ← IterM.up_size_toArray_eq_length]
 
 set_option linter.defProp false in
-@[deprecated Iter.size_toArray_eq_length (since := "2025-10-29")]
-def Iter.size_toArray_eq_size := @size_toArray_eq_length
-
-set_option linter.defProp false in
 @[deprecated Iter.size_toArray_eq_length (since := "2026-01-28")]
 def Iter.size_toArray_eq_count := @size_toArray_eq_length
 
@@ -536,10 +532,6 @@ theorem Iter.length_toList_eq_length {α β : Type w} [Iterator α Id β] [Finit
   rw [← toList_toArray, Array.length_toList, size_toArray_eq_length]
 
 set_option linter.defProp false in
-@[deprecated Iter.length_toList_eq_length (since := "2025-10-29")]
-def Iter.length_toList_eq_size := @length_toList_eq_length
-
-set_option linter.defProp false in
 @[deprecated Iter.length_toList_eq_length (since := "2026-01-28")]
 def Iter.length_toList_eq_count := @length_toList_eq_length
 
@@ -549,10 +541,6 @@ theorem Iter.length_toListRev_eq_length {α β : Type w} [Iterator α Id β] [Fi
     {it : Iter (α := α) β} :
     it.toListRev.length = it.length := by
   rw [toListRev_eq, List.length_reverse, length_toList_eq_length]
-
-set_option linter.defProp false in
-@[deprecated Iter.length_toListRev_eq_length (since := "2025-10-29")]
-def Iter.length_toListRev_eq_size := @length_toListRev_eq_length
 
 set_option linter.defProp false in
 @[deprecated Iter.length_toListRev_eq_length (since := "2026-01-28")]

--- a/src/Init/Data/Iterators/Lemmas/Consumers/Loop.lean
+++ b/src/Init/Data/Iterators/Lemmas/Consumers/Loop.lean
@@ -468,6 +468,7 @@ theorem Iter.length_eq_length_toIterM {α β : Type w} [Iterator α Id β]
     it.length = it.toIterM.length.run.down :=
   (rfl)
 
+set_option linter.defProp false in
 @[deprecated Iter.length_eq_length_toIterM (since := "2026-01-28")]
 def Iter.count_eq_count_toIterM := @Iter.length_eq_length_toIterM
 
@@ -480,6 +481,7 @@ theorem Iter.length_eq_fold {α β : Type w} [Iterator α Id β]
   rw [← fold_hom (f := ULift.down)]
   simp
 
+set_option linter.defProp false in
 @[deprecated Iter.length_eq_fold (since := "2026-01-28")]
 def Iter.count_eq_fold := @Iter.length_eq_fold
 
@@ -490,6 +492,7 @@ theorem Iter.length_eq_forIn {α β : Type w} [Iterator α Id β]
     it.length = (ForIn.forIn (m := Id) it 0 (fun _ acc => return .yield (acc + 1))).run := by
   rw [length_eq_fold, forIn_pure_yield_eq_fold, Id.run_pure]
 
+set_option linter.defProp false in
 @[deprecated Iter.length_eq_forIn (since := "2026-01-28")]
 def Iter.count_eq_forIn := @Iter.length_eq_forIn
 
@@ -505,6 +508,7 @@ theorem Iter.length_eq_match_step {α β : Type w} [Iterator α Id β]
   simp only [bind_pure_comp, id_map', Id.run_bind, Iter.step]
   cases it.toIterM.step.run.inflate using PlausibleIterStep.casesOn <;> simp
 
+set_option linter.defProp false in
 @[deprecated Iter.length_eq_match_step (since := "2026-01-28")]
 def Iter.count_eq_match_step := @Iter.length_eq_match_step
 
@@ -516,9 +520,11 @@ theorem Iter.size_toArray_eq_length {α β : Type w} [Iterator α Id β] [Finite
   simp only [toArray_eq_toArray_toIterM, length_eq_length_toIterM, Id.run_map,
     ← IterM.up_size_toArray_eq_length]
 
+set_option linter.defProp false in
 @[deprecated Iter.size_toArray_eq_length (since := "2025-10-29")]
 def Iter.size_toArray_eq_size := @size_toArray_eq_length
 
+set_option linter.defProp false in
 @[deprecated Iter.size_toArray_eq_length (since := "2026-01-28")]
 def Iter.size_toArray_eq_count := @size_toArray_eq_length
 
@@ -529,9 +535,11 @@ theorem Iter.length_toList_eq_length {α β : Type w} [Iterator α Id β] [Finit
     it.toList.length = it.length := by
   rw [← toList_toArray, Array.length_toList, size_toArray_eq_length]
 
+set_option linter.defProp false in
 @[deprecated Iter.length_toList_eq_length (since := "2025-10-29")]
 def Iter.length_toList_eq_size := @length_toList_eq_length
 
+set_option linter.defProp false in
 @[deprecated Iter.length_toList_eq_length (since := "2026-01-28")]
 def Iter.length_toList_eq_count := @length_toList_eq_length
 
@@ -542,9 +550,11 @@ theorem Iter.length_toListRev_eq_length {α β : Type w} [Iterator α Id β] [Fi
     it.toListRev.length = it.length := by
   rw [toListRev_eq, List.length_reverse, length_toList_eq_length]
 
+set_option linter.defProp false in
 @[deprecated Iter.length_toListRev_eq_length (since := "2025-10-29")]
 def Iter.length_toListRev_eq_size := @length_toListRev_eq_length
 
+set_option linter.defProp false in
 @[deprecated Iter.length_toListRev_eq_length (since := "2026-01-28")]
 def Iter.length_toListRev_eq_count := @length_toListRev_eq_length
 

--- a/src/Init/Data/Iterators/Lemmas/Consumers/Monadic/Loop.lean
+++ b/src/Init/Data/Iterators/Lemmas/Consumers/Monadic/Loop.lean
@@ -489,6 +489,7 @@ theorem IterM.length_eq_fold {α β : Type w} {m : Type w → Type w'} [Iterator
     it.length = it.fold (init := .up 0) (fun acc _ => .up <| acc.down + 1) :=
   (rfl)
 
+set_option linter.defProp false in
 @[deprecated IterM.length_eq_fold (since := "2026-01-28")]
 def IterM.count_eq_fold := @IterM.length_eq_fold
 
@@ -498,6 +499,7 @@ theorem IterM.length_eq_forIn {α β : Type w} {m : Type w → Type w'} [Iterato
     it.length = ForIn.forIn it (.up 0) (fun _ acc => return .yield (.up (acc.down + 1))) :=
   (rfl)
 
+set_option linter.defProp false in
 @[deprecated IterM.length_eq_forIn (since := "2026-01-28")]
 def IterM.count_eq_forIn := @IterM.length_eq_forIn
 
@@ -525,6 +527,7 @@ theorem IterM.length_eq_match_step {α β : Type w} {m : Type w → Type w'} [It
   · simp
   · simp
 
+set_option linter.defProp false in
 @[deprecated IterM.length_eq_match_step (since := "2026-01-28")]
 def IterM.count_eq_match_step := @IterM.length_eq_match_step
 
@@ -538,6 +541,7 @@ theorem IterM.up_size_toArray_eq_length {α β : Type w} [Iterator α m β] [Fin
   · simp only [List.size_toArray, List.length_nil]; rfl
   · simp
 
+set_option linter.defProp false in
 @[deprecated IterM.up_size_toArray_eq_length (since := "2026-01-28")]
 def IterM.up_size_toArray_eq_count := @IterM.up_size_toArray_eq_length
 
@@ -551,6 +555,7 @@ theorem IterM.up_length_toList_eq_length {α β : Type w} [Iterator α m β] [Fi
   · simp only [List.length_nil]; rfl
   · simp
 
+set_option linter.defProp false in
 @[deprecated IterM.up_length_toList_eq_length (since := "2026-01-28")]
 def IterM.up_length_toList_eq_count := @IterM.up_length_toList_eq_length
 
@@ -562,6 +567,7 @@ theorem IterM.up_length_toListRev_eq_length {α β : Type w} [Iterator α m β] 
     (.up <| ·.length) <$> it.toListRev = it.length := by
   simp only [toListRev_eq, Functor.map_map, List.length_reverse, up_length_toList_eq_length]
 
+set_option linter.defProp false in
 @[deprecated IterM.up_length_toListRev_eq_length (since := "2026-01-28")]
 def IterM.up_length_toListRev_eq_count := @IterM.up_length_toListRev_eq_length
 

--- a/src/Init/Data/List/Basic.lean
+++ b/src/Init/Data/List/Basic.lean
@@ -966,6 +966,7 @@ abbrev extract (l : List α) (start : Nat := 0) (stop : Nat := l.length) : List 
 @[simp] theorem extract_eq_take_drop {l : List α} {start stop : Nat} :
     l.extract start stop = (l.drop start).take (stop - start) := rfl
 
+set_option linter.defProp false in
 set_option linter.missingDocs false in
 @[deprecated extract_eq_take_drop (since := "2026-02-06")]
 def extract_eq_drop_take := @extract_eq_take_drop
@@ -1099,6 +1100,7 @@ inductive Sublist {α} : List α → List α → Prop
   /-- If `l₁` is a subsequence of `l₂`, then `a :: l₁` is a subsequence of `a :: l₂`. -/
   | cons_cons a : Sublist l₁ l₂ → Sublist (a :: l₁) (a :: l₂)
 
+set_option linter.defProp false in
 set_option linter.missingDocs false in
 @[deprecated Sublist.cons_cons (since := "2026-02-26"), match_pattern]
 abbrev Sublist.cons₂ := @Sublist.cons_cons

--- a/src/Init/Data/List/Nat/Sum.lean
+++ b/src/Init/Data/List/Nat/Sum.lean
@@ -29,18 +29,10 @@ protected theorem sum_pos_iff_exists_pos_nat {l : List Nat} : 0 < l.sum ↔ ∃ 
     simp [← ih]
     omega
 
-set_option linter.defProp false in
-@[deprecated List.sum_pos_iff_exists_pos_nat (since := "2025-01-15")]
-protected def _root_.Nat.sum_pos_iff_exists_pos := @List.sum_pos_iff_exists_pos_nat
-
 protected theorem sum_eq_zero_iff_forall_eq_nat {xs : List Nat} :
     xs.sum = 0 ↔ ∀ x ∈ xs, x = 0 := by
   rw [← Decidable.not_iff_not]
   simp [← Nat.pos_iff_ne_zero, List.sum_pos_iff_exists_pos_nat]
-
-set_option linter.defProp false in
-@[deprecated List.sum_pos_iff_exists_pos_nat (since := "2025-01-15")]
-protected def _root_.Nat.sum_eq_zero_iff_forall_eq := @List.sum_eq_zero_iff_forall_eq_nat
 
 @[simp]
 theorem sum_replicate_nat {n : Nat} {a : Nat} : (replicate n a).sum = n * a := by

--- a/src/Init/Data/List/Nat/Sum.lean
+++ b/src/Init/Data/List/Nat/Sum.lean
@@ -29,6 +29,7 @@ protected theorem sum_pos_iff_exists_pos_nat {l : List Nat} : 0 < l.sum ↔ ∃ 
     simp [← ih]
     omega
 
+set_option linter.defProp false in
 @[deprecated List.sum_pos_iff_exists_pos_nat (since := "2025-01-15")]
 protected def _root_.Nat.sum_pos_iff_exists_pos := @List.sum_pos_iff_exists_pos_nat
 
@@ -37,6 +38,7 @@ protected theorem sum_eq_zero_iff_forall_eq_nat {xs : List Nat} :
   rw [← Decidable.not_iff_not]
   simp [← Nat.pos_iff_ne_zero, List.sum_pos_iff_exists_pos_nat]
 
+set_option linter.defProp false in
 @[deprecated List.sum_pos_iff_exists_pos_nat (since := "2025-01-15")]
 protected def _root_.Nat.sum_eq_zero_iff_forall_eq := @List.sum_eq_zero_iff_forall_eq_nat
 

--- a/src/Init/Data/List/Perm.lean
+++ b/src/Init/Data/List/Perm.lean
@@ -521,6 +521,7 @@ theorem Perm.eq_of_pairwise : ∀ {l₁ l₂ : List α}
       h₁.tail h₂.tail h
     simp_all
 
+set_option linter.defProp false in
 @[deprecated Perm.eq_of_pairwise (since := "2025-10-23")]
 abbrev Perm.eq_of_sorted := @Perm.eq_of_pairwise
 

--- a/src/Init/Data/List/Perm.lean
+++ b/src/Init/Data/List/Perm.lean
@@ -521,10 +521,6 @@ theorem Perm.eq_of_pairwise : ∀ {l₁ l₂ : List α}
       h₁.tail h₂.tail h
     simp_all
 
-set_option linter.defProp false in
-@[deprecated Perm.eq_of_pairwise (since := "2025-10-23")]
-abbrev Perm.eq_of_sorted := @Perm.eq_of_pairwise
-
 theorem Nodup.perm {l l' : List α} (hR : l.Nodup) (hl : l ~ l') : l'.Nodup :=
   Pairwise.perm hR hl (by intro x y h h'; simp_all)
 

--- a/src/Init/Data/List/Sort/Lemmas.lean
+++ b/src/Init/Data/List/Sort/Lemmas.lean
@@ -88,6 +88,7 @@ theorem splitInTwo_fst_pairwise (l : { l : List α // l.length = n }) (h : Pairw
   rw [splitInTwo_fst]
   exact h.take
 
+set_option linter.defProp false in
 @[deprecated splitInTwo_fst_pairwise (since := "2025-10-23")]
 abbrev splitInTwo_fst_sorted := @splitInTwo_fst_pairwise
 
@@ -95,6 +96,7 @@ theorem splitInTwo_snd_pairwise (l : { l : List α // l.length = n }) (h : Pairw
   rw [splitInTwo_snd]
   exact h.drop
 
+set_option linter.defProp false in
 @[deprecated splitInTwo_snd_pairwise (since := "2025-10-23")]
 abbrev splitInTwo_snd_sorted := @splitInTwo_fst_pairwise
 
@@ -251,6 +253,7 @@ theorem pairwise_merge
           · exact rel_of_pairwise_cons h₂ m
         · exact ih₂ h₂.tail
 
+set_option linter.defProp false in
 @[deprecated pairwise_merge (since := "2025-10-23")]
 abbrev sorted_merge := @pairwise_merge
 
@@ -324,6 +327,7 @@ theorem pairwise_mergeSort
     apply pairwise_mergeSort trans total
 termination_by l => l.length
 
+set_option linter.defProp false in
 @[deprecated pairwise_mergeSort (since := "2025-10-23")]
 abbrev sorted_mergeSort := @pairwise_mergeSort
 
@@ -343,6 +347,7 @@ theorem mergeSort_of_pairwise : ∀ {l : List α} (_ : Pairwise le l), mergeSort
     rw [splitInTwo_fst_append_splitInTwo_snd]
 termination_by l => l.length
 
+set_option linter.defProp false in
 @[deprecated mergeSort_of_pairwise (since := "2025-10-23")]
 abbrev mergeSort_of_sorted := @mergeSort_of_pairwise
 

--- a/src/Init/Data/List/Sort/Lemmas.lean
+++ b/src/Init/Data/List/Sort/Lemmas.lean
@@ -88,17 +88,9 @@ theorem splitInTwo_fst_pairwise (l : { l : List α // l.length = n }) (h : Pairw
   rw [splitInTwo_fst]
   exact h.take
 
-set_option linter.defProp false in
-@[deprecated splitInTwo_fst_pairwise (since := "2025-10-23")]
-abbrev splitInTwo_fst_sorted := @splitInTwo_fst_pairwise
-
 theorem splitInTwo_snd_pairwise (l : { l : List α // l.length = n }) (h : Pairwise le l.1) : Pairwise le (splitInTwo l).2.1 := by
   rw [splitInTwo_snd]
   exact h.drop
-
-set_option linter.defProp false in
-@[deprecated splitInTwo_snd_pairwise (since := "2025-10-23")]
-abbrev splitInTwo_snd_sorted := @splitInTwo_fst_pairwise
 
 theorem splitInTwo_fst_le_splitInTwo_snd {l : { l : List α // l.length = n }} (h : Pairwise le l.1) :
     ∀ a b, a ∈ (splitInTwo l).1.1 → b ∈ (splitInTwo l).2.1 → le a b := by
@@ -253,10 +245,6 @@ theorem pairwise_merge
           · exact rel_of_pairwise_cons h₂ m
         · exact ih₂ h₂.tail
 
-set_option linter.defProp false in
-@[deprecated pairwise_merge (since := "2025-10-23")]
-abbrev sorted_merge := @pairwise_merge
-
 theorem merge_of_le : ∀ {xs ys : List α} (_ : ∀ a b, a ∈ xs → b ∈ ys → le a b),
     merge xs ys le = xs ++ ys
   | [], ys, _
@@ -327,10 +315,6 @@ theorem pairwise_mergeSort
     apply pairwise_mergeSort trans total
 termination_by l => l.length
 
-set_option linter.defProp false in
-@[deprecated pairwise_mergeSort (since := "2025-10-23")]
-abbrev sorted_mergeSort := @pairwise_mergeSort
-
 /--
 If the input list is already sorted, then `mergeSort` does not change the list.
 -/
@@ -346,10 +330,6 @@ theorem mergeSort_of_pairwise : ∀ {l : List α} (_ : Pairwise le l), mergeSort
     rw [merge_of_le (splitInTwo_fst_le_splitInTwo_snd h)]
     rw [splitInTwo_fst_append_splitInTwo_snd]
 termination_by l => l.length
-
-set_option linter.defProp false in
-@[deprecated mergeSort_of_pairwise (since := "2025-10-23")]
-abbrev mergeSort_of_sorted := @mergeSort_of_pairwise
 
 /--
 This merge sort algorithm is stable,

--- a/src/Init/Data/Nat/Basic.lean
+++ b/src/Init/Data/Nat/Basic.lean
@@ -542,9 +542,9 @@ example : (default : Nat) = 0 := rfl
 
 protected theorem lt_asymm {a b : Nat} (h : a < b) : ¬ b < a := Nat.not_lt.2 (Nat.le_of_lt h)
 /-- Alias for `Nat.lt_asymm`. -/
-protected theorem not_lt_of_gt {a b : Nat} (h : a < b) : ¬b < a := Nat.lt_asymm h
+protected abbrev not_lt_of_gt := @Nat.lt_asymm
 /-- Alias for `Nat.lt_asymm`. -/
-protected theorem not_lt_of_lt {a b : Nat} (h : a < b) : ¬b < a := Nat.lt_asymm h
+protected abbrev not_lt_of_lt := @Nat.lt_asymm
 
 protected theorem lt_iff_le_and_not_ge {m n : Nat} : m < n ↔ m ≤ n ∧ ¬ n ≤ m :=
   ⟨fun h => ⟨Nat.le_of_lt h, Nat.not_le_of_gt h⟩, fun ⟨_, h⟩ => Nat.lt_of_not_ge h⟩
@@ -561,13 +561,13 @@ protected theorem ne_iff_lt_or_gt {a b : Nat} : a ≠ b ↔ a < b ∨ b < a :=
   ⟨Nat.lt_or_gt_of_ne, fun | .inl h => Nat.ne_of_lt h | .inr h => Nat.ne_of_gt h⟩
 
 /-- Alias for `Nat.ne_iff_lt_or_gt`. -/
-protected theorem lt_or_gt {a b : Nat} : a ≠ b ↔ a < b ∨ b < a := Nat.ne_iff_lt_or_gt
+protected abbrev lt_or_gt := @Nat.ne_iff_lt_or_gt
 
 /-- Alias for `Nat.le_total`. -/
-protected theorem le_or_ge (m n : Nat) : m ≤ n ∨ n ≤ m := Nat.le_total m n
+protected abbrev le_or_ge := @Nat.le_total
 
 /-- Alias for `Nat.le_total`. -/
-protected theorem le_or_le (m n : Nat) : m ≤ n ∨ n ≤ m := Nat.le_total m n
+protected abbrev le_or_le := @Nat.le_total
 
 protected theorem eq_or_lt_of_not_lt {a b : Nat} (hnlt : ¬ a < b) : a = b ∨ b < a :=
   (Nat.lt_trichotomy ..).resolve_left hnlt
@@ -600,7 +600,7 @@ protected theorem eq_of_le_of_lt_succ (h₁ : n ≤ m) (h₂ : m < n + 1) : m = 
 theorem le_zero : i ≤ 0 ↔ i = 0 := ⟨Nat.eq_zero_of_le_zero, fun | rfl => Nat.le_refl _⟩
 
 /-- Alias for `Nat.zero_lt_one`. -/
-protected theorem one_pos : 0 < 1:= @Nat.zero_lt_one
+protected abbrev one_pos := @Nat.zero_lt_one
 
 protected theorem two_pos : 0 < 2 := Nat.zero_lt_succ _
 

--- a/src/Init/Data/Nat/Basic.lean
+++ b/src/Init/Data/Nat/Basic.lean
@@ -541,12 +541,10 @@ attribute [simp] not_lt_zero
 example : (default : Nat) = 0 := rfl
 
 protected theorem lt_asymm {a b : Nat} (h : a < b) : ¬ b < a := Nat.not_lt.2 (Nat.le_of_lt h)
-set_option linter.defProp false in
 /-- Alias for `Nat.lt_asymm`. -/
-protected abbrev not_lt_of_gt := @Nat.lt_asymm
-set_option linter.defProp false in
+protected theorem not_lt_of_gt {a b : Nat} (h : a < b) : ¬b < a := Nat.lt_asymm h
 /-- Alias for `Nat.lt_asymm`. -/
-protected abbrev not_lt_of_lt := @Nat.lt_asymm
+protected theorem not_lt_of_lt {a b : Nat} (h : a < b) : ¬b < a := Nat.lt_asymm h
 
 protected theorem lt_iff_le_and_not_ge {m n : Nat} : m < n ↔ m ≤ n ∧ ¬ n ≤ m :=
   ⟨fun h => ⟨Nat.le_of_lt h, Nat.not_le_of_gt h⟩, fun ⟨_, h⟩ => Nat.lt_of_not_ge h⟩
@@ -561,16 +559,15 @@ protected theorem lt_iff_le_and_ne {m n : Nat} : m < n ↔ m ≤ n ∧ m ≠ n :
 
 protected theorem ne_iff_lt_or_gt {a b : Nat} : a ≠ b ↔ a < b ∨ b < a :=
   ⟨Nat.lt_or_gt_of_ne, fun | .inl h => Nat.ne_of_lt h | .inr h => Nat.ne_of_gt h⟩
-set_option linter.defProp false in
-/-- Alias for `Nat.ne_iff_lt_or_gt`. -/
-protected abbrev lt_or_gt := @Nat.ne_iff_lt_or_gt
 
-set_option linter.defProp false in
+/-- Alias for `Nat.ne_iff_lt_or_gt`. -/
+protected theorem lt_or_gt {a b : Nat} : a ≠ b ↔ a < b ∨ b < a := Nat.ne_iff_lt_or_gt
+
 /-- Alias for `Nat.le_total`. -/
-protected abbrev le_or_ge := @Nat.le_total
-set_option linter.defProp false in
+protected theorem le_or_ge (m n : Nat) : m ≤ n ∨ n ≤ m := Nat.le_total m n
+
 /-- Alias for `Nat.le_total`. -/
-protected abbrev le_or_le := @Nat.le_total
+protected theorem le_or_le (m n : Nat) : m ≤ n ∨ n ≤ m := Nat.le_total m n
 
 protected theorem eq_or_lt_of_not_lt {a b : Nat} (hnlt : ¬ a < b) : a = b ∨ b < a :=
   (Nat.lt_trichotomy ..).resolve_left hnlt
@@ -602,9 +599,8 @@ protected theorem eq_of_le_of_lt_succ (h₁ : n ≤ m) (h₂ : m < n + 1) : m = 
 
 theorem le_zero : i ≤ 0 ↔ i = 0 := ⟨Nat.eq_zero_of_le_zero, fun | rfl => Nat.le_refl _⟩
 
-set_option linter.defProp false in
 /-- Alias for `Nat.zero_lt_one`. -/
-protected abbrev one_pos := @Nat.zero_lt_one
+protected theorem one_pos : 0 < 1:= @Nat.zero_lt_one
 
 protected theorem two_pos : 0 < 2 := Nat.zero_lt_succ _
 

--- a/src/Init/Data/Nat/Basic.lean
+++ b/src/Init/Data/Nat/Basic.lean
@@ -541,14 +541,17 @@ attribute [simp] not_lt_zero
 example : (default : Nat) = 0 := rfl
 
 protected theorem lt_asymm {a b : Nat} (h : a < b) : ¬ b < a := Nat.not_lt.2 (Nat.le_of_lt h)
+set_option linter.defProp false in
 /-- Alias for `Nat.lt_asymm`. -/
 protected abbrev not_lt_of_gt := @Nat.lt_asymm
+set_option linter.defProp false in
 /-- Alias for `Nat.lt_asymm`. -/
 protected abbrev not_lt_of_lt := @Nat.lt_asymm
 
 protected theorem lt_iff_le_and_not_ge {m n : Nat} : m < n ↔ m ≤ n ∧ ¬ n ≤ m :=
   ⟨fun h => ⟨Nat.le_of_lt h, Nat.not_le_of_gt h⟩, fun ⟨_, h⟩ => Nat.lt_of_not_ge h⟩
 
+set_option linter.defProp false in
 /-- Deprecated alias for `Nat.lt_iff_le_and_not_ge`. -/
 @[deprecated Nat.lt_iff_le_and_not_ge (since := "2026-02-11")]
 protected abbrev lt_iff_le_not_le := @Nat.lt_iff_le_and_not_ge
@@ -558,11 +561,14 @@ protected theorem lt_iff_le_and_ne {m n : Nat} : m < n ↔ m ≤ n ∧ m ≠ n :
 
 protected theorem ne_iff_lt_or_gt {a b : Nat} : a ≠ b ↔ a < b ∨ b < a :=
   ⟨Nat.lt_or_gt_of_ne, fun | .inl h => Nat.ne_of_lt h | .inr h => Nat.ne_of_gt h⟩
+set_option linter.defProp false in
 /-- Alias for `Nat.ne_iff_lt_or_gt`. -/
 protected abbrev lt_or_gt := @Nat.ne_iff_lt_or_gt
 
+set_option linter.defProp false in
 /-- Alias for `Nat.le_total`. -/
 protected abbrev le_or_ge := @Nat.le_total
+set_option linter.defProp false in
 /-- Alias for `Nat.le_total`. -/
 protected abbrev le_or_le := @Nat.le_total
 
@@ -596,6 +602,7 @@ protected theorem eq_of_le_of_lt_succ (h₁ : n ≤ m) (h₂ : m < n + 1) : m = 
 
 theorem le_zero : i ≤ 0 ↔ i = 0 := ⟨Nat.eq_zero_of_le_zero, fun | rfl => Nat.le_refl _⟩
 
+set_option linter.defProp false in
 /-- Alias for `Nat.zero_lt_one`. -/
 protected abbrev one_pos := @Nat.zero_lt_one
 

--- a/src/Init/Data/Nat/Bitwise/Lemmas.lean
+++ b/src/Init/Data/Nat/Bitwise/Lemmas.lean
@@ -592,6 +592,7 @@ theorem and_or_distrib_right (x y z : Nat) : (x ||| y) &&& z = (x &&& z) ||| (y 
    apply Nat.eq_of_testBit_eq
    simp [Bool.and_or_distrib_right]
 
+set_option linter.defProp false in
 @[deprecated and_or_distrib_right (since := "2025-10-02")]
 abbrev and_distrib_right := and_or_distrib_right
 

--- a/src/Init/Data/Nat/Bitwise/Lemmas.lean
+++ b/src/Init/Data/Nat/Bitwise/Lemmas.lean
@@ -592,10 +592,6 @@ theorem and_or_distrib_right (x y z : Nat) : (x ||| y) &&& z = (x &&& z) ||| (y 
    apply Nat.eq_of_testBit_eq
    simp [Bool.and_or_distrib_right]
 
-set_option linter.defProp false in
-@[deprecated and_or_distrib_right (since := "2025-10-02")]
-abbrev and_distrib_right := and_or_distrib_right
-
 theorem or_and_distrib_left (x y z : Nat) : x ||| (y &&& z) = (x ||| y) &&& (x ||| z) := by
    apply Nat.eq_of_testBit_eq
    simp [Bool.or_and_distrib_left]

--- a/src/Init/Data/Nat/Lemmas.lean
+++ b/src/Init/Data/Nat/Lemmas.lean
@@ -355,6 +355,7 @@ protected theorem sub_le_sub_iff_left {n m k : Nat} (h : n ≤ k) : k - m ≤ k 
 
 protected theorem sub_lt_of_pos_le (h₀ : 0 < a) (h₁ : a ≤ b) : b - a < b :=
   Nat.sub_lt (Nat.lt_of_lt_of_le h₀ h₁) h₀
+set_option linter.defProp false in
 protected abbrev sub_lt_self := @Nat.sub_lt_of_pos_le
 
 theorem add_lt_of_lt_sub' {a b c : Nat} : b < c - a → a + b < c := by

--- a/src/Init/Data/Nat/Lemmas.lean
+++ b/src/Init/Data/Nat/Lemmas.lean
@@ -355,8 +355,8 @@ protected theorem sub_le_sub_iff_left {n m k : Nat} (h : n ≤ k) : k - m ≤ k 
 
 protected theorem sub_lt_of_pos_le (h₀ : 0 < a) (h₁ : a ≤ b) : b - a < b :=
   Nat.sub_lt (Nat.lt_of_lt_of_le h₀ h₁) h₀
-set_option linter.defProp false in
-protected abbrev sub_lt_self := @Nat.sub_lt_of_pos_le
+
+protected theorem sub_lt_self {a b : Nat} (h₁ : 0 < a) (h₂ : a ≤ b) : b - a < b := Nat.sub_lt_of_pos_le h₁ h₂
 
 theorem add_lt_of_lt_sub' {a b c : Nat} : b < c - a → a + b < c := by
   rw [Nat.add_comm]; exact Nat.add_lt_of_lt_sub

--- a/src/Init/Data/Nat/Lemmas.lean
+++ b/src/Init/Data/Nat/Lemmas.lean
@@ -356,7 +356,7 @@ protected theorem sub_le_sub_iff_left {n m k : Nat} (h : n ≤ k) : k - m ≤ k 
 protected theorem sub_lt_of_pos_le (h₀ : 0 < a) (h₁ : a ≤ b) : b - a < b :=
   Nat.sub_lt (Nat.lt_of_lt_of_le h₀ h₁) h₀
 
-protected theorem sub_lt_self {a b : Nat} (h₁ : 0 < a) (h₂ : a ≤ b) : b - a < b := Nat.sub_lt_of_pos_le h₁ h₂
+protected abbrev sub_lt_self := @Nat.sub_lt_of_pos_le
 
 theorem add_lt_of_lt_sub' {a b c : Nat} : b < c - a → a + b < c := by
   rw [Nat.add_comm]; exact Nat.add_lt_of_lt_sub

--- a/src/Init/Data/Order/Classes.lean
+++ b/src/Init/Data/Order/Classes.lean
@@ -111,12 +111,11 @@ This typeclass states that `Min.min a b` returns one of its arguments, either `a
 public class MinEqOr (α : Type u) [Min α] where
   min_eq_or : ∀ a b : α, min a b = a ∨ min a b = b
 
-set_option linter.defProp false in
 /--
 If both `a` and `b` satisfy some property `P`, then so does `min a b`, because it is equal to
 either `a` or `b`.
 -/
-public def MinEqOr.elim {α : Type u} [Min α] [MinEqOr α] {P : α → Prop} {a b : α} (ha : P a) (hb : P b) :
+public theorem MinEqOr.elim {α : Type u} [Min α] [MinEqOr α] {P : α → Prop} {a b : α} (ha : P a) (hb : P b) :
     P (min a b) := by
   cases MinEqOr.min_eq_or a b <;> rename_i h
   case inl => exact h.symm ▸ ha
@@ -156,12 +155,11 @@ This typeclass states that `Max.max a b` returns one of its arguments, either `a
 public class MaxEqOr (α : Type u) [Max α] where
   max_eq_or : ∀ a b : α, max a b = a ∨ max a b = b
 
-set_option linter.defProp false in
 /--
 If both `a` and `b` satisfy some property `P`, then so does `max a b`, because it is equal to
 either `a` or `b`.
 -/
-public def MaxEqOr.elim {α : Type u} [Max α] [MaxEqOr α] {P : α → Prop} {a b : α} (ha : P a) (hb : P b) :
+public theorem MaxEqOr.elim {α : Type u} [Max α] [MaxEqOr α] {P : α → Prop} {a b : α} (ha : P a) (hb : P b) :
     P (max a b) := by
   cases MaxEqOr.max_eq_or a b <;> rename_i h
   case inl => exact h.symm ▸ ha

--- a/src/Init/Data/Order/Classes.lean
+++ b/src/Init/Data/Order/Classes.lean
@@ -111,6 +111,7 @@ This typeclass states that `Min.min a b` returns one of its arguments, either `a
 public class MinEqOr (α : Type u) [Min α] where
   min_eq_or : ∀ a b : α, min a b = a ∨ min a b = b
 
+set_option linter.defProp false in
 /--
 If both `a` and `b` satisfy some property `P`, then so does `min a b`, because it is equal to
 either `a` or `b`.
@@ -155,6 +156,7 @@ This typeclass states that `Max.max a b` returns one of its arguments, either `a
 public class MaxEqOr (α : Type u) [Max α] where
   max_eq_or : ∀ a b : α, max a b = a ∨ max a b = b
 
+set_option linter.defProp false in
 /--
 If both `a` and `b` satisfy some property `P`, then so does `max a b`, because it is equal to
 either `a` or `b`.

--- a/src/Init/Data/Range/Polymorphic/Lemmas.lean
+++ b/src/Init/Data/Range/Polymorphic/Lemmas.lean
@@ -632,10 +632,6 @@ theorem toList_eq_toList_rco [LE α] [DecidableLE α] [LT α] [DecidableLT α]
   simp [Internal.toList_eq_toList_iter, Rco.Internal.toList_eq_toList_iter,
     Internal.iter, Rco.Internal.iter, Rxc.Iterator.toList_eq_toList_rxoIterator]
 
-set_option linter.defProp false in
-@[deprecated toList_eq_if_roc (since := "2025-10-29")]
-def toList_eq_match := @toList_eq_if_roc
-
 theorem toArray_eq_if_roc [LE α] [DecidableLE α] [UpwardEnumerable α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [Rxc.IsAlwaysFinite α] :
     r.toArray = if r.lower ≤ r.upper then
@@ -643,10 +639,6 @@ theorem toArray_eq_if_roc [LE α] [DecidableLE α] [UpwardEnumerable α]
       else
         #[] := by
   rw [Internal.toArray_eq_toArray_iter, Rxc.Iterator.toArray_eq_match]; rfl
-
-set_option linter.defProp false in
-@[deprecated toArray_eq_if_roc (since := "2025-10-29")]
-def toArray_eq_match := @toArray_eq_if_roc
 
 @[simp]
 theorem toArray_toList [LE α] [DecidableLE α] [UpwardEnumerable α]
@@ -809,10 +801,6 @@ theorem mem_of_mem_roc [LE α] [LT α] [UpwardEnumerable α]
   simp only [Membership.mem, LawfulUpwardEnumerableLE.le_iff, LawfulUpwardEnumerableLT.lt_iff] at hmem ⊢
   exact UpwardEnumerable.le_of_lt hmem.1
 
-set_option linter.defProp false in
-@[deprecated mem_of_mem_roc (since := "2025-10-29")]
-def mem_of_mem_Roc := @mem_of_mem_roc
-
 theorem forIn'_eq_if [LE α] [DecidableLE α] [LT α]
     [UpwardEnumerable α] [LawfulUpwardEnumerableLT α] [LawfulUpwardEnumerableLE α]
     [Rxc.IsAlwaysFinite α] [LawfulUpwardEnumerable α]
@@ -864,10 +852,6 @@ theorem toList_eq_if_roo [UpwardEnumerable α] [LT α] [DecidableLT α]
         [] := by
   rw [Internal.toList_eq_toList_iter, Rxo.Iterator.toList_eq_match]; rfl
 
-set_option linter.defProp false in
-@[deprecated toList_eq_if_roo (since := "2025-10-29")]
-def toList_eq_if := @toList_eq_if_roo
-
 theorem toArray_eq_if_roo [UpwardEnumerable α] [LT α] [DecidableLT α]
     [LawfulUpwardEnumerable α] [Rxo.IsAlwaysFinite α] [LawfulUpwardEnumerableLT α] :
     r.toArray = if r.lower < r.upper then
@@ -909,10 +893,6 @@ theorem toArray_eq_if_rco [UpwardEnumerable α] [LT α] [DecidableLT α]
     · simp only [*]
       rfl
   · rfl
-
-set_option linter.defProp false in
-@[deprecated toArray_eq_if_roo (since := "2025-10-29")]
-def toArray_eq_if := @toArray_eq_if_roo
 
 @[simp]
 theorem toArray_toList [LT α] [DecidableLT α] [UpwardEnumerable α]
@@ -1073,10 +1053,6 @@ theorem mem_of_mem_roo [LE α] [LT α] [UpwardEnumerable α]
   simp only [Membership.mem, LawfulUpwardEnumerableLE.le_iff, LawfulUpwardEnumerableLT.lt_iff] at hmem ⊢
   exact UpwardEnumerable.le_of_lt hmem.1
 
-set_option linter.defProp false in
-@[deprecated mem_of_mem_roo (since := "2025-10-29")]
-def mem_of_mem_Roo := @mem_of_mem_roo
-
 theorem forIn'_eq_if [LE α] [DecidableLE α] [LT α] [DecidableLT α]
     [UpwardEnumerable α] [LawfulUpwardEnumerableLT α] [LawfulUpwardEnumerableLE α]
     [Rxo.IsAlwaysFinite α] [LawfulUpwardEnumerable α]
@@ -1125,18 +1101,10 @@ theorem toList_eq_toList_roi [UpwardEnumerable α]
     r.toList = r.lower :: (r.lower<...*).toList := by
   rw [Internal.toList_eq_toList_iter, Rxi.Iterator.toList_eq_match]; rfl
 
-set_option linter.defProp false in
-@[deprecated toList_eq_toList_roi (since := "2025-10-29")]
-def toList_eq_toList_Roi := @toList_eq_toList_roi
-
 theorem toArray_eq_toArray_roi [UpwardEnumerable α]
     [LawfulUpwardEnumerable α] [Rxi.IsAlwaysFinite α] :
     r.toArray = #[r.lower] ++ (r.lower<...*).toArray := by
   rw [Internal.toArray_eq_toArray_iter, Rxi.Iterator.toArray_eq_match]; rfl
-
-set_option linter.defProp false in
-@[deprecated toArray_eq_toArray_roi (since := "2025-10-29")]
-def toArray_eq_toArray_Roi := @toArray_eq_toArray_roi
 
 @[simp]
 theorem toArray_toList [UpwardEnumerable α] [LawfulUpwardEnumerable α]
@@ -1289,10 +1257,6 @@ theorem mem_of_mem_roi [LE α] [LT α] [UpwardEnumerable α]
   refine le_trans hrb ?_
   simp only [Membership.mem, LawfulUpwardEnumerableLE.le_iff, LawfulUpwardEnumerableLT.lt_iff] at hmem ⊢
   exact UpwardEnumerable.le_of_lt hmem
-
-set_option linter.defProp false in
-@[deprecated mem_of_mem_roi (since := "2025-10-29")]
-def mem_of_mem_Roi := @mem_of_mem_roi
 
 theorem forIn'_eq_match [LE α] [DecidableLE α] [LT α] [DecidableLT α]
     [UpwardEnumerable α] [LawfulUpwardEnumerableLT α] [LawfulUpwardEnumerableLE α]
@@ -2082,19 +2046,11 @@ theorem toList_eq_toList_rcc [LE α] [DecidableLE α] [Least? α] [UpwardEnumera
     r.toList = ((UpwardEnumerable.least (hn := ⟨r.upper⟩))...=r.upper).toList := by
   simp [toList_eq_match_rcc, UpwardEnumerable.least?_eq_some (hn := ⟨r.upper⟩)]
 
-set_option linter.defProp false in
-@[deprecated toList_eq_toList_rcc (since := "2025-10-29")]
-def toList_eq_toList_Rcc := @toList_eq_toList_rcc
-
 theorem toArray_eq_toArray_rcc [LE α] [DecidableLE α] [Least? α] [UpwardEnumerable α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLeast? α]
     [Rxc.IsAlwaysFinite α] :
     r.toArray = ((UpwardEnumerable.least (hn := ⟨r.upper⟩))...=r.upper).toArray := by
   simp [← toArray_toList, toList_eq_toList_rcc]
-
-set_option linter.defProp false in
-@[deprecated toArray_eq_toArray_rcc (since := "2025-10-29")]
-def toArray_eq_toArray_Rcc := @toArray_eq_toArray_rcc
 
 theorem toList_eq_if_roc [LE α] [DecidableLE α] [Least? α] [UpwardEnumerable α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLeast? α]
@@ -2106,10 +2062,6 @@ theorem toList_eq_if_roc [LE α] [DecidableLE α] [Least? α] [UpwardEnumerable 
         [] := by
   simp [toList_eq_toList_rcc, Rcc.toList_eq_if_roc]
 
-set_option linter.defProp false in
-@[deprecated toList_eq_if_roc (since := "2025-10-29")]
-def toList_eq_if := @toList_eq_if_roc
-
 theorem toArray_eq_if_roc [LE α] [DecidableLE α] [Least? α] [UpwardEnumerable α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLeast? α]
     [Rxc.IsAlwaysFinite α] :
@@ -2119,10 +2071,6 @@ theorem toArray_eq_if_roc [LE α] [DecidableLE α] [Least? α] [UpwardEnumerable
       else
         #[] := by
   simp [toArray_eq_toArray_rcc, Rcc.toArray_eq_if_roc]
-
-set_option linter.defProp false in
-@[deprecated toArray_eq_if_roc (since := "2025-10-29")]
-def toArray_eq_if := @toArray_eq_if_roc
 
 theorem toList_ne_nil [LE α] [DecidableLE α] [Least? α] [UpwardEnumerable α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
@@ -2143,10 +2091,6 @@ theorem mem_iff_mem_rcc [LE α] [Least? α] [UpwardEnumerable α]
     [Rxc.IsAlwaysFinite α] {a : α} :
     a ∈ r ↔ a ∈ ((UpwardEnumerable.least (hn := ⟨r.upper⟩))...=r.upper) := by
   simp [Membership.mem, UpwardEnumerable.le_iff, UpwardEnumerable.least_le]
-
-set_option linter.defProp false in
-@[deprecated mem_iff_mem_rcc (since := "2025-10-29")]
-def mem_iff_mem_Rcc := @mem_iff_mem_rcc
 
 theorem mem_toList_iff_mem [LE α] [DecidableLE α] [Least? α] [UpwardEnumerable α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLeast? α]
@@ -2301,17 +2245,9 @@ theorem mem_of_mem_rcc [LE α] {lo hi a : α} (hmem : a ∈ lo...=hi) :
     a ∈ *...=hi := by
   exact hmem.2
 
-set_option linter.defProp false in
-@[deprecated mem_of_mem_rcc (since := "2025-10-29")]
-def mem_of_mem_Rcc := @mem_of_mem_rcc
-
 theorem mem_of_mem_roc [LE α] [LT α] {lo hi a : α} (hmem : a ∈ lo<...=hi) :
     a ∈ *...=hi := by
   exact hmem.2
-
-set_option linter.defProp false in
-@[deprecated mem_of_mem_roc (since := "2025-10-29")]
-def mem_of_mem_Roc := @mem_of_mem_roc
 
 theorem forIn'_eq_forIn'_rcc [LE α] [DecidableLE α] [Least? α]
     [UpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLeast? α]
@@ -2324,10 +2260,6 @@ theorem forIn'_eq_forIn'_rcc [LE α] [DecidableLE α] [Least? α]
   haveI : Nonempty α := ⟨r.upper⟩
   simp only [Internal.forIn'_eq_forIn'_iter, Rcc.Internal.forIn'_eq_forIn'_iter,
     Internal.iter, Rcc.Internal.iter, UpwardEnumerable.least?_eq_some]
-
-set_option linter.defProp false in
-@[deprecated forIn'_eq_forIn'_rcc (since := "2025-10-29")]
-def forIn'_eq_forIn'_Rcc := @forIn'_eq_forIn'_rcc
 
 theorem forIn'_eq_if_roc [LE α] [DecidableLE α] [LT α] [Least? α]
     [UpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLT α]
@@ -2346,10 +2278,6 @@ theorem forIn'_eq_if_roc [LE α] [DecidableLE α] [LT α] [Least? α]
         return init := by
   simp [forIn'_eq_forIn'_rcc, Rcc.forIn'_eq_if,
     UpwardEnumerable.le_iff.mpr UpwardEnumerable.least_le]
-
-set_option linter.defProp false in
-@[deprecated forIn'_eq_if_roc (since := "2025-10-29")]
-def forIn'_eq_if := @forIn'_eq_if_roc
 
 theorem isEmpty_iff_forall_not_mem [LE α] [UpwardEnumerable α]
     [Rxc.HasSize α] [Rxc.LawfulHasSize α] [LawfulUpwardEnumerableLE α]
@@ -2405,19 +2333,11 @@ theorem toList_eq_toList_rco [LT α] [DecidableLT α] [Least? α] [UpwardEnumera
     r.toList = ((UpwardEnumerable.least (hn := ⟨r.upper⟩))...r.upper).toList := by
   simp [toList_eq_match_rco, UpwardEnumerable.least?_eq_some (hn := ⟨r.upper⟩)]
 
-set_option linter.defProp false in
-@[deprecated toList_eq_toList_rco (since := "2025-10-29")]
-def toList_eq_toList_Rco := @toList_eq_toList_rco
-
 theorem toArray_eq_toArray_rco [LT α] [DecidableLT α] [Least? α] [UpwardEnumerable α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α] [LawfulUpwardEnumerableLeast? α]
     [Rxo.IsAlwaysFinite α] :
     r.toArray = ((UpwardEnumerable.least (hn := ⟨r.upper⟩))...r.upper).toArray := by
   simp [← toArray_toList, toList_eq_toList_rco]
-
-set_option linter.defProp false in
-@[deprecated toArray_eq_toArray_rco (since := "2025-10-29")]
-def toArray_eq_toArray_Rco := @toArray_eq_toArray_rco
 
 theorem toList_eq_if_roo [LT α] [DecidableLT α] [Least? α] [UpwardEnumerable α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α] [LawfulUpwardEnumerableLeast? α]
@@ -2430,10 +2350,6 @@ theorem toList_eq_if_roo [LT α] [DecidableLT α] [Least? α] [UpwardEnumerable 
   haveI : LE α := ⟨UpwardEnumerable.LT⟩
   simp [toList_eq_toList_rco, Rco.toList_eq_if_roo]
 
-set_option linter.defProp false in
-@[deprecated toList_eq_if_roo (since := "2025-10-29")]
-def toList_eq_if := @toList_eq_if_roo
-
 theorem toArray_eq_if_roo [LT α] [DecidableLT α] [Least? α] [UpwardEnumerable α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α] [LawfulUpwardEnumerableLeast? α]
     [Rxo.IsAlwaysFinite α] :
@@ -2444,10 +2360,6 @@ theorem toArray_eq_if_roo [LT α] [DecidableLT α] [Least? α] [UpwardEnumerable
         #[] := by
   haveI : LE α := ⟨UpwardEnumerable.LT⟩
   simp [toArray_eq_toArray_rco, Rco.toArray_eq_if_roo]
-
-set_option linter.defProp false in
-@[deprecated toArray_eq_if_roo (since := "2025-10-29")]
-def toArray_eq_if := @toArray_eq_if_roo
 
 theorem toList_eq_nil_iff [LT α] [DecidableLT α] [Least? α] [UpwardEnumerable α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
@@ -2466,10 +2378,6 @@ theorem mem_iff_mem_rco [LE α] [LT α] [Least? α] [UpwardEnumerable α]
     [Rxo.IsAlwaysFinite α] {a : α} :
     a ∈ r ↔ a ∈ ((UpwardEnumerable.least (hn := ⟨r.upper⟩))...r.upper) := by
   simp [Membership.mem, UpwardEnumerable.le_iff, UpwardEnumerable.least_le]
-
-set_option linter.defProp false in
-@[deprecated mem_iff_mem_rco (since := "2025-10-29")]
-def mem_iff_mem_Rco := @mem_iff_mem_rco
 
 theorem mem_toList_iff_mem [LT α] [DecidableLT α] [Least? α] [UpwardEnumerable α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α] [LawfulUpwardEnumerableLeast? α]
@@ -2631,17 +2539,9 @@ theorem mem_of_mem_rco [LE α] [LT α] {lo hi a : α} (hmem : a ∈ lo...<hi) :
     a ∈ *...hi := by
   exact hmem.2
 
-set_option linter.defProp false in
-@[deprecated mem_of_mem_rco (since := "2025-10-29")]
-def mem_of_mem_Rco := @mem_of_mem_rco
-
 theorem mem_of_mem_roo [LT α] {lo hi a : α} (hmem : a ∈ lo<...hi) :
     a ∈ *...hi := by
   exact hmem.2
-
-set_option linter.defProp false in
-@[deprecated mem_of_mem_roo (since := "2025-10-29")]
-def mem_of_mem_Roo := @mem_of_mem_roo
 
 theorem forIn'_eq_if_roo [LT α] [DecidableLT α] [Least? α] [UpwardEnumerable α]
     [LawfulUpwardEnumerableLT α] [LawfulUpwardEnumerableLeast? α]
@@ -2665,10 +2565,6 @@ theorem forIn'_eq_if_roo [LT α] [DecidableLT α] [Least? α] [UpwardEnumerable 
     split <;> simp
   · simp
 
-set_option linter.defProp false in
-@[deprecated forIn'_eq_if_roo (since := "2025-10-29")]
-def forIn'_eq_if := @forIn'_eq_if_roo
-
 theorem forIn'_eq_forIn'_rco [LE α] [LT α] [DecidableLT α] [Least? α] [UpwardEnumerable α]
     [LawfulUpwardEnumerableLT α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLeast? α]
     [Rxo.IsAlwaysFinite α] [LawfulUpwardEnumerable α] {m : Type u → Type w} [Monad m]
@@ -2677,10 +2573,6 @@ theorem forIn'_eq_forIn'_rco [LE α] [LT α] [DecidableLT α] [Least? α] [Upwar
     ForIn'.forIn' r init f = ForIn'.forIn' (UpwardEnumerable.least...r.upper) init
         (fun a ha acc => f a (mem_of_mem_rco ha) acc) := by
   simp [forIn'_eq_forIn'_toList, toList_eq_toList_rco, Rco.forIn'_toList_eq_forIn']
-
-set_option linter.defProp false in
-@[deprecated forIn'_eq_forIn'_rco (since := "2025-10-29")]
-def forIn'_eq_forIn'_Rco := @forIn'_eq_forIn'_rco
 
 theorem isEmpty_iff_forall_not_mem [LT α] [DecidableLT α] [Least? α] [UpwardEnumerable α]
     [LawfulUpwardEnumerableLT α] [LawfulUpwardEnumerableLeast? α] [LawfulUpwardEnumerable α] :
@@ -2722,10 +2614,6 @@ theorem toList_eq_match_rci [Least? α] [UpwardEnumerable α]
     Rxi.Iterator.toList_eq_match (it := Rci.Internal.iter _)]
   simp [Internal.iter, Rci.Internal.iter]
 
-set_option linter.defProp false in
-@[deprecated toList_eq_match_rci (since := "2025-10-29")]
-def toList_eq_match_toList_Rci := @toList_eq_match_rci
-
 theorem toArray_eq_match_rci [Least? α] [UpwardEnumerable α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α]
     [Rxi.IsAlwaysFinite α] :
@@ -2735,10 +2623,6 @@ theorem toArray_eq_match_rci [Least? α] [UpwardEnumerable α]
   cases h : least? (α := α)
   all_goals simp [← toArray_toList, toList_eq_match_rci, h]
 
-set_option linter.defProp false in
-@[deprecated toArray_eq_match_rci (since := "2025-10-29")]
-def toArray_eq_match_toArray_Rci := @toArray_eq_match_rci
-
 theorem toList_eq_match_roi [Least? α] [UpwardEnumerable α]
     [LawfulUpwardEnumerable α] [Rxi.IsAlwaysFinite α] :
     r.toList = match Least?.least? (α := α) with
@@ -2746,10 +2630,6 @@ theorem toList_eq_match_roi [Least? α] [UpwardEnumerable α]
       | some init => init :: (init<...*).toList := by
   haveI : LE α := ⟨UpwardEnumerable.LE⟩
   simp [toList_eq_match_rci, Rci.toList_eq_toList_roi]
-
-set_option linter.defProp false in
-@[deprecated toList_eq_match_roi (since := "2025-10-29")]
-def toList_eq_match_toList_Roi := @toList_eq_match_roi
 
 theorem toArray_eq_match_roi [Least? α] [UpwardEnumerable α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α]
@@ -2759,10 +2639,6 @@ theorem toArray_eq_match_roi [Least? α] [UpwardEnumerable α]
       | some init => #[init] ++ (init<...*).toArray := by
   haveI : LE α := ⟨UpwardEnumerable.LE⟩
   simp [toArray_eq_match_rci, Rci.toArray_eq_toArray_roi]
-
-set_option linter.defProp false in
-@[deprecated toArray_eq_match_roi (since := "2025-10-29")]
-def toArray_eq_match_Roi := @toArray_eq_match_roi
 
 theorem toList_eq_nil_iff [LT α] [DecidableLT α] [Least? α] [UpwardEnumerable α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
@@ -2785,10 +2661,6 @@ theorem mem_iff_mem_rci [LE α] [Least? α] [UpwardEnumerable α]
     [Rxi.IsAlwaysFinite α] {a : α} :
     a ∈ r ↔ a ∈ ((UpwardEnumerable.least (hn := ⟨a⟩))...*) := by
   simp [Membership.mem, UpwardEnumerable.le_iff, UpwardEnumerable.least_le]
-
-set_option linter.defProp false in
-@[deprecated mem_iff_mem_rci (since := "2025-10-29")]
-def mem_iff_mem_Rci := @mem_iff_mem_rci
 
 theorem mem_toList [Least? α] [UpwardEnumerable α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α]
@@ -2882,10 +2754,6 @@ theorem forIn'_eq_match_rci [LE α] [Least? α] [UpwardEnumerable α]
   simp only [forIn'_eq_forIn'_toList, toList_eq_match_rci, Rci.forIn'_eq_forIn'_toList]
   split <;> simp
 
-set_option linter.defProp false in
-@[deprecated forIn'_eq_match_rci (since := "2025-10-29")]
-def forIn'_eq_match_forIn'_Rci := @forIn'_eq_match_rci
-
 theorem forIn'_eq_match_roi [LT α] [Least? α] [UpwardEnumerable α]
     [LawfulUpwardEnumerableLT α] [LawfulUpwardEnumerableLeast? α]
     [Rxi.IsAlwaysFinite α] [LawfulUpwardEnumerable α] {m : Type u → Type w} [Monad m]
@@ -2904,10 +2772,6 @@ theorem forIn'_eq_match_roi [LT α] [Least? α] [UpwardEnumerable α]
   · simp only [List.forIn'_cons]
     apply bind_congr; intro step
     split <;> simp
-
-set_option linter.defProp false in
-@[deprecated forIn'_eq_match_roi (since := "2025-10-29")]
-def forIn'_eq_match_forIn'_Roi := @forIn'_eq_match_roi
 
 theorem isEmpty_iff [Least? α] [UpwardEnumerable α] [LawfulUpwardEnumerableLeast? α] :
     r.isEmpty ↔ ¬ Nonempty α := by
@@ -2938,10 +2802,6 @@ theorem toList_roc_eq_toList_rcc_of_isSome_succ? [LE α] [DecidableLE α] [Upwar
   simp [Rcc.Internal.toList_eq_toList_iter, Roc.Internal.toList_eq_toList_iter,
     Internal.iter_roc_eq_iter_rcc_of_isSome_succ?, h]
 
-set_option linter.defProp false in
-@[deprecated toList_roc_eq_toList_rcc_of_isSome_succ? (since := "2025-10-29")]
-def toList_Roc_eq_toList_Rcc_of_isSome_succ? := @toList_roc_eq_toList_rcc_of_isSome_succ?
-
 private theorem Internal.iter_roo_eq_iter_rco_of_isSome_succ?
     [LT α] [UpwardEnumerable α] [LawfulUpwardEnumerable α] {lo hi : α}
     (h : (UpwardEnumerable.succ? lo).isSome) :
@@ -2959,10 +2819,6 @@ theorem toList_roo_eq_toList_rco_of_isSome_succ?
   simp [Rco.Internal.toList_eq_toList_iter, Roo.Internal.toList_eq_toList_iter,
     Internal.iter_roo_eq_iter_rco_of_isSome_succ?, h]
 
-set_option linter.defProp false in
-@[deprecated toList_roo_eq_toList_rco_of_isSome_succ? (since := "2025-10-29")]
-def toList_Roo_eq_toList_Rco_of_isSome_succ? := @toList_roo_eq_toList_rco_of_isSome_succ?
-
 private theorem Internal.iter_roi_eq_iter_rci_of_isSome_succ?
     [UpwardEnumerable α] [LawfulUpwardEnumerable α] {lo : α}
     (h : (UpwardEnumerable.succ? lo).isSome) :
@@ -2978,10 +2834,6 @@ theorem toList_roi_eq_toList_rci_of_isSome_succ?
     (lo<...*).toList = ((UpwardEnumerable.succ? lo |>.get h)...*).toList := by
   simp [Rci.Internal.toList_eq_toList_iter, Roi.Internal.toList_eq_toList_iter,
     Internal.iter_roi_eq_iter_rci_of_isSome_succ?, h]
-
-set_option linter.defProp false in
-@[deprecated toList_roc_eq_toList_rcc_of_isSome_succ? (since := "2025-10-29")]
-def toList_Roi_eq_toList_Rci_of_isSome_succ? := @toList_roi_eq_toList_rci_of_isSome_succ?
 
 namespace Rcc
 
@@ -3007,10 +2859,6 @@ theorem size_eq_if_roc [LE α] [DecidableLE α] [UpwardEnumerable α]
         rw [Roc.size, ih _ h, Nat.add_right_cancel_iff]
         simp only [hl', h, ih l' h]
     · simp [← Rxc.size_pos_iff_le, h] at hle
-
-set_option linter.defProp false in
-@[deprecated size_eq_if_roc (since := "2025-10-29")]
-def size_eq_if := @size_eq_if_roc
 
 theorem size_eq_if_rcc [LE α] [DecidableLE α] [UpwardEnumerable α]
     [Rxc.HasSize α] [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
@@ -3391,10 +3239,6 @@ theorem size_eq_if_roo [LT α] [DecidableLT α] [UpwardEnumerable α]
         rw [Roo.size, ih _ h, Nat.add_right_cancel_iff]
         simp only [hl', h, ih l' h]
     · simp [← Rxo.size_pos_iff_lt, h] at hle
-
-set_option linter.defProp false in
-@[deprecated size_eq_if_roo (since := "2025-10-29")]
-def size_eq_if := @size_eq_if_roo
 
 theorem size_eq_if_rcc [LT α] [DecidableLT α] [UpwardEnumerable α]
     [Rxo.HasSize α] [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]

--- a/src/Init/Data/Range/Polymorphic/Lemmas.lean
+++ b/src/Init/Data/Range/Polymorphic/Lemmas.lean
@@ -632,6 +632,7 @@ theorem toList_eq_toList_rco [LE α] [DecidableLE α] [LT α] [DecidableLT α]
   simp [Internal.toList_eq_toList_iter, Rco.Internal.toList_eq_toList_iter,
     Internal.iter, Rco.Internal.iter, Rxc.Iterator.toList_eq_toList_rxoIterator]
 
+set_option linter.defProp false in
 @[deprecated toList_eq_if_roc (since := "2025-10-29")]
 def toList_eq_match := @toList_eq_if_roc
 
@@ -643,6 +644,7 @@ theorem toArray_eq_if_roc [LE α] [DecidableLE α] [UpwardEnumerable α]
         #[] := by
   rw [Internal.toArray_eq_toArray_iter, Rxc.Iterator.toArray_eq_match]; rfl
 
+set_option linter.defProp false in
 @[deprecated toArray_eq_if_roc (since := "2025-10-29")]
 def toArray_eq_match := @toArray_eq_if_roc
 
@@ -807,6 +809,7 @@ theorem mem_of_mem_roc [LE α] [LT α] [UpwardEnumerable α]
   simp only [Membership.mem, LawfulUpwardEnumerableLE.le_iff, LawfulUpwardEnumerableLT.lt_iff] at hmem ⊢
   exact UpwardEnumerable.le_of_lt hmem.1
 
+set_option linter.defProp false in
 @[deprecated mem_of_mem_roc (since := "2025-10-29")]
 def mem_of_mem_Roc := @mem_of_mem_roc
 
@@ -861,6 +864,7 @@ theorem toList_eq_if_roo [UpwardEnumerable α] [LT α] [DecidableLT α]
         [] := by
   rw [Internal.toList_eq_toList_iter, Rxo.Iterator.toList_eq_match]; rfl
 
+set_option linter.defProp false in
 @[deprecated toList_eq_if_roo (since := "2025-10-29")]
 def toList_eq_if := @toList_eq_if_roo
 
@@ -906,6 +910,7 @@ theorem toArray_eq_if_rco [UpwardEnumerable α] [LT α] [DecidableLT α]
       rfl
   · rfl
 
+set_option linter.defProp false in
 @[deprecated toArray_eq_if_roo (since := "2025-10-29")]
 def toArray_eq_if := @toArray_eq_if_roo
 
@@ -1068,6 +1073,7 @@ theorem mem_of_mem_roo [LE α] [LT α] [UpwardEnumerable α]
   simp only [Membership.mem, LawfulUpwardEnumerableLE.le_iff, LawfulUpwardEnumerableLT.lt_iff] at hmem ⊢
   exact UpwardEnumerable.le_of_lt hmem.1
 
+set_option linter.defProp false in
 @[deprecated mem_of_mem_roo (since := "2025-10-29")]
 def mem_of_mem_Roo := @mem_of_mem_roo
 
@@ -1119,6 +1125,7 @@ theorem toList_eq_toList_roi [UpwardEnumerable α]
     r.toList = r.lower :: (r.lower<...*).toList := by
   rw [Internal.toList_eq_toList_iter, Rxi.Iterator.toList_eq_match]; rfl
 
+set_option linter.defProp false in
 @[deprecated toList_eq_toList_roi (since := "2025-10-29")]
 def toList_eq_toList_Roi := @toList_eq_toList_roi
 
@@ -1127,6 +1134,7 @@ theorem toArray_eq_toArray_roi [UpwardEnumerable α]
     r.toArray = #[r.lower] ++ (r.lower<...*).toArray := by
   rw [Internal.toArray_eq_toArray_iter, Rxi.Iterator.toArray_eq_match]; rfl
 
+set_option linter.defProp false in
 @[deprecated toArray_eq_toArray_roi (since := "2025-10-29")]
 def toArray_eq_toArray_Roi := @toArray_eq_toArray_roi
 
@@ -1282,6 +1290,7 @@ theorem mem_of_mem_roi [LE α] [LT α] [UpwardEnumerable α]
   simp only [Membership.mem, LawfulUpwardEnumerableLE.le_iff, LawfulUpwardEnumerableLT.lt_iff] at hmem ⊢
   exact UpwardEnumerable.le_of_lt hmem
 
+set_option linter.defProp false in
 @[deprecated mem_of_mem_roi (since := "2025-10-29")]
 def mem_of_mem_Roi := @mem_of_mem_roi
 
@@ -2073,6 +2082,7 @@ theorem toList_eq_toList_rcc [LE α] [DecidableLE α] [Least? α] [UpwardEnumera
     r.toList = ((UpwardEnumerable.least (hn := ⟨r.upper⟩))...=r.upper).toList := by
   simp [toList_eq_match_rcc, UpwardEnumerable.least?_eq_some (hn := ⟨r.upper⟩)]
 
+set_option linter.defProp false in
 @[deprecated toList_eq_toList_rcc (since := "2025-10-29")]
 def toList_eq_toList_Rcc := @toList_eq_toList_rcc
 
@@ -2082,6 +2092,7 @@ theorem toArray_eq_toArray_rcc [LE α] [DecidableLE α] [Least? α] [UpwardEnume
     r.toArray = ((UpwardEnumerable.least (hn := ⟨r.upper⟩))...=r.upper).toArray := by
   simp [← toArray_toList, toList_eq_toList_rcc]
 
+set_option linter.defProp false in
 @[deprecated toArray_eq_toArray_rcc (since := "2025-10-29")]
 def toArray_eq_toArray_Rcc := @toArray_eq_toArray_rcc
 
@@ -2095,6 +2106,7 @@ theorem toList_eq_if_roc [LE α] [DecidableLE α] [Least? α] [UpwardEnumerable 
         [] := by
   simp [toList_eq_toList_rcc, Rcc.toList_eq_if_roc]
 
+set_option linter.defProp false in
 @[deprecated toList_eq_if_roc (since := "2025-10-29")]
 def toList_eq_if := @toList_eq_if_roc
 
@@ -2108,6 +2120,7 @@ theorem toArray_eq_if_roc [LE α] [DecidableLE α] [Least? α] [UpwardEnumerable
         #[] := by
   simp [toArray_eq_toArray_rcc, Rcc.toArray_eq_if_roc]
 
+set_option linter.defProp false in
 @[deprecated toArray_eq_if_roc (since := "2025-10-29")]
 def toArray_eq_if := @toArray_eq_if_roc
 
@@ -2131,6 +2144,7 @@ theorem mem_iff_mem_rcc [LE α] [Least? α] [UpwardEnumerable α]
     a ∈ r ↔ a ∈ ((UpwardEnumerable.least (hn := ⟨r.upper⟩))...=r.upper) := by
   simp [Membership.mem, UpwardEnumerable.le_iff, UpwardEnumerable.least_le]
 
+set_option linter.defProp false in
 @[deprecated mem_iff_mem_rcc (since := "2025-10-29")]
 def mem_iff_mem_Rcc := @mem_iff_mem_rcc
 
@@ -2287,6 +2301,7 @@ theorem mem_of_mem_rcc [LE α] {lo hi a : α} (hmem : a ∈ lo...=hi) :
     a ∈ *...=hi := by
   exact hmem.2
 
+set_option linter.defProp false in
 @[deprecated mem_of_mem_rcc (since := "2025-10-29")]
 def mem_of_mem_Rcc := @mem_of_mem_rcc
 
@@ -2294,6 +2309,7 @@ theorem mem_of_mem_roc [LE α] [LT α] {lo hi a : α} (hmem : a ∈ lo<...=hi) :
     a ∈ *...=hi := by
   exact hmem.2
 
+set_option linter.defProp false in
 @[deprecated mem_of_mem_roc (since := "2025-10-29")]
 def mem_of_mem_Roc := @mem_of_mem_roc
 
@@ -2309,6 +2325,7 @@ theorem forIn'_eq_forIn'_rcc [LE α] [DecidableLE α] [Least? α]
   simp only [Internal.forIn'_eq_forIn'_iter, Rcc.Internal.forIn'_eq_forIn'_iter,
     Internal.iter, Rcc.Internal.iter, UpwardEnumerable.least?_eq_some]
 
+set_option linter.defProp false in
 @[deprecated forIn'_eq_forIn'_rcc (since := "2025-10-29")]
 def forIn'_eq_forIn'_Rcc := @forIn'_eq_forIn'_rcc
 
@@ -2330,6 +2347,7 @@ theorem forIn'_eq_if_roc [LE α] [DecidableLE α] [LT α] [Least? α]
   simp [forIn'_eq_forIn'_rcc, Rcc.forIn'_eq_if,
     UpwardEnumerable.le_iff.mpr UpwardEnumerable.least_le]
 
+set_option linter.defProp false in
 @[deprecated forIn'_eq_if_roc (since := "2025-10-29")]
 def forIn'_eq_if := @forIn'_eq_if_roc
 
@@ -2387,6 +2405,7 @@ theorem toList_eq_toList_rco [LT α] [DecidableLT α] [Least? α] [UpwardEnumera
     r.toList = ((UpwardEnumerable.least (hn := ⟨r.upper⟩))...r.upper).toList := by
   simp [toList_eq_match_rco, UpwardEnumerable.least?_eq_some (hn := ⟨r.upper⟩)]
 
+set_option linter.defProp false in
 @[deprecated toList_eq_toList_rco (since := "2025-10-29")]
 def toList_eq_toList_Rco := @toList_eq_toList_rco
 
@@ -2396,6 +2415,7 @@ theorem toArray_eq_toArray_rco [LT α] [DecidableLT α] [Least? α] [UpwardEnume
     r.toArray = ((UpwardEnumerable.least (hn := ⟨r.upper⟩))...r.upper).toArray := by
   simp [← toArray_toList, toList_eq_toList_rco]
 
+set_option linter.defProp false in
 @[deprecated toArray_eq_toArray_rco (since := "2025-10-29")]
 def toArray_eq_toArray_Rco := @toArray_eq_toArray_rco
 
@@ -2410,6 +2430,7 @@ theorem toList_eq_if_roo [LT α] [DecidableLT α] [Least? α] [UpwardEnumerable 
   haveI : LE α := ⟨UpwardEnumerable.LT⟩
   simp [toList_eq_toList_rco, Rco.toList_eq_if_roo]
 
+set_option linter.defProp false in
 @[deprecated toList_eq_if_roo (since := "2025-10-29")]
 def toList_eq_if := @toList_eq_if_roo
 
@@ -2424,6 +2445,7 @@ theorem toArray_eq_if_roo [LT α] [DecidableLT α] [Least? α] [UpwardEnumerable
   haveI : LE α := ⟨UpwardEnumerable.LT⟩
   simp [toArray_eq_toArray_rco, Rco.toArray_eq_if_roo]
 
+set_option linter.defProp false in
 @[deprecated toArray_eq_if_roo (since := "2025-10-29")]
 def toArray_eq_if := @toArray_eq_if_roo
 
@@ -2445,6 +2467,7 @@ theorem mem_iff_mem_rco [LE α] [LT α] [Least? α] [UpwardEnumerable α]
     a ∈ r ↔ a ∈ ((UpwardEnumerable.least (hn := ⟨r.upper⟩))...r.upper) := by
   simp [Membership.mem, UpwardEnumerable.le_iff, UpwardEnumerable.least_le]
 
+set_option linter.defProp false in
 @[deprecated mem_iff_mem_rco (since := "2025-10-29")]
 def mem_iff_mem_Rco := @mem_iff_mem_rco
 
@@ -2608,6 +2631,7 @@ theorem mem_of_mem_rco [LE α] [LT α] {lo hi a : α} (hmem : a ∈ lo...<hi) :
     a ∈ *...hi := by
   exact hmem.2
 
+set_option linter.defProp false in
 @[deprecated mem_of_mem_rco (since := "2025-10-29")]
 def mem_of_mem_Rco := @mem_of_mem_rco
 
@@ -2615,6 +2639,7 @@ theorem mem_of_mem_roo [LT α] {lo hi a : α} (hmem : a ∈ lo<...hi) :
     a ∈ *...hi := by
   exact hmem.2
 
+set_option linter.defProp false in
 @[deprecated mem_of_mem_roo (since := "2025-10-29")]
 def mem_of_mem_Roo := @mem_of_mem_roo
 
@@ -2640,6 +2665,7 @@ theorem forIn'_eq_if_roo [LT α] [DecidableLT α] [Least? α] [UpwardEnumerable 
     split <;> simp
   · simp
 
+set_option linter.defProp false in
 @[deprecated forIn'_eq_if_roo (since := "2025-10-29")]
 def forIn'_eq_if := @forIn'_eq_if_roo
 
@@ -2652,6 +2678,7 @@ theorem forIn'_eq_forIn'_rco [LE α] [LT α] [DecidableLT α] [Least? α] [Upwar
         (fun a ha acc => f a (mem_of_mem_rco ha) acc) := by
   simp [forIn'_eq_forIn'_toList, toList_eq_toList_rco, Rco.forIn'_toList_eq_forIn']
 
+set_option linter.defProp false in
 @[deprecated forIn'_eq_forIn'_rco (since := "2025-10-29")]
 def forIn'_eq_forIn'_Rco := @forIn'_eq_forIn'_rco
 
@@ -2695,6 +2722,7 @@ theorem toList_eq_match_rci [Least? α] [UpwardEnumerable α]
     Rxi.Iterator.toList_eq_match (it := Rci.Internal.iter _)]
   simp [Internal.iter, Rci.Internal.iter]
 
+set_option linter.defProp false in
 @[deprecated toList_eq_match_rci (since := "2025-10-29")]
 def toList_eq_match_toList_Rci := @toList_eq_match_rci
 
@@ -2707,6 +2735,7 @@ theorem toArray_eq_match_rci [Least? α] [UpwardEnumerable α]
   cases h : least? (α := α)
   all_goals simp [← toArray_toList, toList_eq_match_rci, h]
 
+set_option linter.defProp false in
 @[deprecated toArray_eq_match_rci (since := "2025-10-29")]
 def toArray_eq_match_toArray_Rci := @toArray_eq_match_rci
 
@@ -2718,6 +2747,7 @@ theorem toList_eq_match_roi [Least? α] [UpwardEnumerable α]
   haveI : LE α := ⟨UpwardEnumerable.LE⟩
   simp [toList_eq_match_rci, Rci.toList_eq_toList_roi]
 
+set_option linter.defProp false in
 @[deprecated toList_eq_match_roi (since := "2025-10-29")]
 def toList_eq_match_toList_Roi := @toList_eq_match_roi
 
@@ -2730,6 +2760,7 @@ theorem toArray_eq_match_roi [Least? α] [UpwardEnumerable α]
   haveI : LE α := ⟨UpwardEnumerable.LE⟩
   simp [toArray_eq_match_rci, Rci.toArray_eq_toArray_roi]
 
+set_option linter.defProp false in
 @[deprecated toArray_eq_match_roi (since := "2025-10-29")]
 def toArray_eq_match_Roi := @toArray_eq_match_roi
 
@@ -2755,6 +2786,7 @@ theorem mem_iff_mem_rci [LE α] [Least? α] [UpwardEnumerable α]
     a ∈ r ↔ a ∈ ((UpwardEnumerable.least (hn := ⟨a⟩))...*) := by
   simp [Membership.mem, UpwardEnumerable.le_iff, UpwardEnumerable.least_le]
 
+set_option linter.defProp false in
 @[deprecated mem_iff_mem_rci (since := "2025-10-29")]
 def mem_iff_mem_Rci := @mem_iff_mem_rci
 
@@ -2850,6 +2882,7 @@ theorem forIn'_eq_match_rci [LE α] [Least? α] [UpwardEnumerable α]
   simp only [forIn'_eq_forIn'_toList, toList_eq_match_rci, Rci.forIn'_eq_forIn'_toList]
   split <;> simp
 
+set_option linter.defProp false in
 @[deprecated forIn'_eq_match_rci (since := "2025-10-29")]
 def forIn'_eq_match_forIn'_Rci := @forIn'_eq_match_rci
 
@@ -2872,6 +2905,7 @@ theorem forIn'_eq_match_roi [LT α] [Least? α] [UpwardEnumerable α]
     apply bind_congr; intro step
     split <;> simp
 
+set_option linter.defProp false in
 @[deprecated forIn'_eq_match_roi (since := "2025-10-29")]
 def forIn'_eq_match_forIn'_Roi := @forIn'_eq_match_roi
 
@@ -2904,6 +2938,7 @@ theorem toList_roc_eq_toList_rcc_of_isSome_succ? [LE α] [DecidableLE α] [Upwar
   simp [Rcc.Internal.toList_eq_toList_iter, Roc.Internal.toList_eq_toList_iter,
     Internal.iter_roc_eq_iter_rcc_of_isSome_succ?, h]
 
+set_option linter.defProp false in
 @[deprecated toList_roc_eq_toList_rcc_of_isSome_succ? (since := "2025-10-29")]
 def toList_Roc_eq_toList_Rcc_of_isSome_succ? := @toList_roc_eq_toList_rcc_of_isSome_succ?
 
@@ -2924,6 +2959,7 @@ theorem toList_roo_eq_toList_rco_of_isSome_succ?
   simp [Rco.Internal.toList_eq_toList_iter, Roo.Internal.toList_eq_toList_iter,
     Internal.iter_roo_eq_iter_rco_of_isSome_succ?, h]
 
+set_option linter.defProp false in
 @[deprecated toList_roo_eq_toList_rco_of_isSome_succ? (since := "2025-10-29")]
 def toList_Roo_eq_toList_Rco_of_isSome_succ? := @toList_roo_eq_toList_rco_of_isSome_succ?
 
@@ -2943,6 +2979,7 @@ theorem toList_roi_eq_toList_rci_of_isSome_succ?
   simp [Rci.Internal.toList_eq_toList_iter, Roi.Internal.toList_eq_toList_iter,
     Internal.iter_roi_eq_iter_rci_of_isSome_succ?, h]
 
+set_option linter.defProp false in
 @[deprecated toList_roc_eq_toList_rcc_of_isSome_succ? (since := "2025-10-29")]
 def toList_Roi_eq_toList_Rci_of_isSome_succ? := @toList_roi_eq_toList_rci_of_isSome_succ?
 
@@ -2971,6 +3008,7 @@ theorem size_eq_if_roc [LE α] [DecidableLE α] [UpwardEnumerable α]
         simp only [hl', h, ih l' h]
     · simp [← Rxc.size_pos_iff_le, h] at hle
 
+set_option linter.defProp false in
 @[deprecated size_eq_if_roc (since := "2025-10-29")]
 def size_eq_if := @size_eq_if_roc
 
@@ -3354,6 +3392,7 @@ theorem size_eq_if_roo [LT α] [DecidableLT α] [UpwardEnumerable α]
         simp only [hl', h, ih l' h]
     · simp [← Rxo.size_pos_iff_lt, h] at hle
 
+set_option linter.defProp false in
 @[deprecated size_eq_if_roo (since := "2025-10-29")]
 def size_eq_if := @size_eq_if_roo
 

--- a/src/Init/Data/Range/Polymorphic/NatLemmas.lean
+++ b/src/Init/Data/Range/Polymorphic/NatLemmas.lean
@@ -53,9 +53,11 @@ theorem size_rcc {a b : Nat} :
     (a...=b).size = b + 1 - a := by
   simp [Rcc.size, Rxc.HasSize.size]
 
+set_option linter.defProp false in
 @[deprecated size_rcc (since := "2025-10-30")]
 def _root_.Std.PRange.Nat.size_Rcc := @_root_.Nat.size_rcc
 
+set_option linter.defProp false in
 @[deprecated size_rcc (since := "2025-12-01")]
 def _root_.Std.PRange.Nat.size_rcc := @_root_.Nat.size_rcc
 
@@ -75,9 +77,11 @@ theorem size_rco {a b : Nat} :
   simp only [Rco.size, Rxo.HasSize.size, Rxc.HasSize.size]
   omega
 
+set_option linter.defProp false in
 @[deprecated size_rco (since := "2025-10-30")]
 def _root_.Std.PRange.Nat.size_Rco := @_root_.Nat.size_rco
 
+set_option linter.defProp false in
 @[deprecated size_rco (since := "2025-12-01")]
 def _root_.Std.PRange.Nat.size_rco := @_root_.Nat.size_rco
 
@@ -96,9 +100,11 @@ theorem size_roc {a b : Nat} :
     (a<...=b).size = b - a := by
   simp [Roc.size, Rxc.HasSize.size]
 
+set_option linter.defProp false in
 @[deprecated size_roc (since := "2025-10-30")]
 def _root_.Std.PRange.Nat.size_Roc := @_root_.Nat.size_roc
 
+set_option linter.defProp false in
 @[deprecated size_roc (since := "2025-12-01")]
 def _root_.Std.PRange.Nat.size_roc := @_root_.Nat.size_roc
 
@@ -117,9 +123,11 @@ theorem size_roo {a b : Nat} :
     (a<...b).size = b - a - 1 := by
   simp [Roo.size, Rxo.HasSize.size, Rxc.HasSize.size]
 
+set_option linter.defProp false in
 @[deprecated size_roo (since := "2025-10-30")]
 def _root_.Std.PRange.Nat.size_Roo := @_root_.Nat.size_roo
 
+set_option linter.defProp false in
 @[deprecated size_roo (since := "2025-12-01")]
 def _root_.Std.PRange.Nat.size_roo := @_root_.Nat.size_roo
 
@@ -138,9 +146,11 @@ theorem size_ric {b : Nat} :
     (*...=b).size = b + 1 := by
   simp [Ric.size, Rxc.HasSize.size, Least?.least?]
 
+set_option linter.defProp false in
 @[deprecated size_ric (since := "2025-10-30")]
 def _root_.Std.PRange.Nat.size_Ric := @_root_.Nat.size_ric
 
+set_option linter.defProp false in
 @[deprecated size_ric (since := "2025-12-01")]
 def _root_.Std.PRange.Nat.size_ric := @_root_.Nat.size_ric
 
@@ -159,9 +169,11 @@ theorem size_rio {b : Nat} :
     (*...b).size = b := by
   simp [Rio.size, Rxo.HasSize.size, Rxc.HasSize.size, Least?.least?]
 
+set_option linter.defProp false in
 @[deprecated size_rio (since := "2025-10-30")]
 def _root_.Std.PRange.Nat.size_Rio := @_root_.Nat.size_rio
 
+set_option linter.defProp false in
 @[deprecated size_rio (since := "2025-12-01")]
 def _root_.Std.PRange.Nat.size_rio := @_root_.Nat.size_rio
 
@@ -194,9 +206,11 @@ theorem toList_rco_succ_succ {m n : Nat} :
     ((m+1)...(n+1)).toList = (m...n).toList.map (· + 1) := by
   simp [← succ_eq, Rco.toList_succ_succ_eq_map]
 
+set_option linter.defProp false in
 @[deprecated _root_.Nat.toList_rco_succ_succ (since := "2025-10-30")]
 def _root_.Std.PRange.Nat.toList_Rco_succ_succ := @_root_.Nat.toList_rco_succ_succ
 
+set_option linter.defProp false in
 @[deprecated _root_.Nat.toList_rco_succ_succ (since := "2025-12-01")]
 def _root_.Std.PRange.Nat.toList_rco_succ_succ := @_root_.Nat.toList_rco_succ_succ
 

--- a/src/Init/Data/Range/Polymorphic/NatLemmas.lean
+++ b/src/Init/Data/Range/Polymorphic/NatLemmas.lean
@@ -53,14 +53,6 @@ theorem size_rcc {a b : Nat} :
     (a...=b).size = b + 1 - a := by
   simp [Rcc.size, Rxc.HasSize.size]
 
-set_option linter.defProp false in
-@[deprecated size_rcc (since := "2025-10-30")]
-def _root_.Std.PRange.Nat.size_Rcc := @_root_.Nat.size_rcc
-
-set_option linter.defProp false in
-@[deprecated size_rcc (since := "2025-12-01")]
-def _root_.Std.PRange.Nat.size_rcc := @_root_.Nat.size_rcc
-
 @[simp]
 theorem length_toList_rcc {a b : Nat} :
     (a...=b).toList.length = b + 1 - a := by
@@ -77,14 +69,6 @@ theorem size_rco {a b : Nat} :
   simp only [Rco.size, Rxo.HasSize.size, Rxc.HasSize.size]
   omega
 
-set_option linter.defProp false in
-@[deprecated size_rco (since := "2025-10-30")]
-def _root_.Std.PRange.Nat.size_Rco := @_root_.Nat.size_rco
-
-set_option linter.defProp false in
-@[deprecated size_rco (since := "2025-12-01")]
-def _root_.Std.PRange.Nat.size_rco := @_root_.Nat.size_rco
-
 @[simp]
 theorem length_toList_rco {a b : Nat} :
     (a...b).toList.length = b - a := by
@@ -99,14 +83,6 @@ theorem size_toArray_rco {a b : Nat} :
 theorem size_roc {a b : Nat} :
     (a<...=b).size = b - a := by
   simp [Roc.size, Rxc.HasSize.size]
-
-set_option linter.defProp false in
-@[deprecated size_roc (since := "2025-10-30")]
-def _root_.Std.PRange.Nat.size_Roc := @_root_.Nat.size_roc
-
-set_option linter.defProp false in
-@[deprecated size_roc (since := "2025-12-01")]
-def _root_.Std.PRange.Nat.size_roc := @_root_.Nat.size_roc
 
 @[simp]
 theorem length_toList_roc {a b : Nat} :
@@ -123,14 +99,6 @@ theorem size_roo {a b : Nat} :
     (a<...b).size = b - a - 1 := by
   simp [Roo.size, Rxo.HasSize.size, Rxc.HasSize.size]
 
-set_option linter.defProp false in
-@[deprecated size_roo (since := "2025-10-30")]
-def _root_.Std.PRange.Nat.size_Roo := @_root_.Nat.size_roo
-
-set_option linter.defProp false in
-@[deprecated size_roo (since := "2025-12-01")]
-def _root_.Std.PRange.Nat.size_roo := @_root_.Nat.size_roo
-
 @[simp]
 theorem length_toList_roo {a b : Nat} :
     (a<...b).toList.length = b - a - 1 := by
@@ -146,14 +114,6 @@ theorem size_ric {b : Nat} :
     (*...=b).size = b + 1 := by
   simp [Ric.size, Rxc.HasSize.size, Least?.least?]
 
-set_option linter.defProp false in
-@[deprecated size_ric (since := "2025-10-30")]
-def _root_.Std.PRange.Nat.size_Ric := @_root_.Nat.size_ric
-
-set_option linter.defProp false in
-@[deprecated size_ric (since := "2025-12-01")]
-def _root_.Std.PRange.Nat.size_ric := @_root_.Nat.size_ric
-
 @[simp]
 theorem length_toList_ric {b : Nat} :
     (*...=b).toList.length = b + 1 := by
@@ -168,14 +128,6 @@ theorem size_toArray_ric {b : Nat} :
 theorem size_rio {b : Nat} :
     (*...b).size = b := by
   simp [Rio.size, Rxo.HasSize.size, Rxc.HasSize.size, Least?.least?]
-
-set_option linter.defProp false in
-@[deprecated size_rio (since := "2025-10-30")]
-def _root_.Std.PRange.Nat.size_Rio := @_root_.Nat.size_rio
-
-set_option linter.defProp false in
-@[deprecated size_rio (since := "2025-12-01")]
-def _root_.Std.PRange.Nat.size_rio := @_root_.Nat.size_rio
 
 @[simp]
 theorem length_toList_rio {b : Nat} :

--- a/src/Init/Data/Range/Polymorphic/RangeIterator.lean
+++ b/src/Init/Data/Range/Polymorphic/RangeIterator.lean
@@ -210,15 +210,14 @@ theorem Iterator.isSome_next_of_isPlausibleIndirectOutput
     obtain ⟨a, ha, _⟩ := h
     simp [ha]
 
-set_option linter.defProp false in
-private def List.Sublist.filter_mono {l : List α} {P Q : α → Bool} (h : ∀ a, P a → Q a) :
+
+private theorem List.Sublist.filter_mono {l : List α} {P Q : α → Bool} (h : ∀ a, P a → Q a) :
     List.Sublist (l.filter P) (l.filter Q) := by
   apply List.Sublist.trans (l₂ := (l.filter Q).filter P)
   · simp [Bool.and_eq_left_iff_imp.mpr (h _)]
   · apply List.filter_sublist
 
-set_option linter.defProp false in
-private def List.length_filter_strict_mono {l : List α} {P Q : α → Bool} {a : α}
+private theorem List.length_filter_strict_mono {l : List α} {P Q : α → Bool} {a : α}
     (h : ∀ a, P a → Q a) (ha : a ∈ l) (hPa : ¬ P a) (hQa : Q a) :
     (l.filter P).length < (l.filter Q).length := by
   have hsl : List.Sublist (l.filter P) (l.filter Q) := by
@@ -792,15 +791,13 @@ theorem Iterator.isSome_next_of_isPlausibleIndirectOutput
     obtain ⟨a, ha, _⟩ := h
     simp [ha]
 
-set_option linter.defProp false in
-private def List.Sublist.filter_mono {l : List α} {P Q : α → Bool} (h : ∀ a, P a → Q a) :
+private theorem List.Sublist.filter_mono {l : List α} {P Q : α → Bool} (h : ∀ a, P a → Q a) :
     List.Sublist (l.filter P) (l.filter Q) := by
   apply List.Sublist.trans (l₂ := (l.filter Q).filter P)
   · simp [Bool.and_eq_left_iff_imp.mpr (h _)]
   · apply List.filter_sublist
 
-set_option linter.defProp false in
-private def List.length_filter_strict_mono {l : List α} {P Q : α → Bool} {a : α}
+private theorem List.length_filter_strict_mono {l : List α} {P Q : α → Bool} {a : α}
     (h : ∀ a, P a → Q a) (ha : a ∈ l) (hPa : ¬ P a) (hQa : Q a) :
     (l.filter P).length < (l.filter Q).length := by
   have hsl : List.Sublist (l.filter P) (l.filter Q) := by

--- a/src/Init/Data/Range/Polymorphic/RangeIterator.lean
+++ b/src/Init/Data/Range/Polymorphic/RangeIterator.lean
@@ -210,12 +210,14 @@ theorem Iterator.isSome_next_of_isPlausibleIndirectOutput
     obtain ⟨a, ha, _⟩ := h
     simp [ha]
 
+set_option linter.defProp false in
 private def List.Sublist.filter_mono {l : List α} {P Q : α → Bool} (h : ∀ a, P a → Q a) :
     List.Sublist (l.filter P) (l.filter Q) := by
   apply List.Sublist.trans (l₂ := (l.filter Q).filter P)
   · simp [Bool.and_eq_left_iff_imp.mpr (h _)]
   · apply List.filter_sublist
 
+set_option linter.defProp false in
 private def List.length_filter_strict_mono {l : List α} {P Q : α → Bool} {a : α}
     (h : ∀ a, P a → Q a) (ha : a ∈ l) (hPa : ¬ P a) (hQa : Q a) :
     (l.filter P).length < (l.filter Q).length := by
@@ -790,12 +792,14 @@ theorem Iterator.isSome_next_of_isPlausibleIndirectOutput
     obtain ⟨a, ha, _⟩ := h
     simp [ha]
 
+set_option linter.defProp false in
 private def List.Sublist.filter_mono {l : List α} {P Q : α → Bool} (h : ∀ a, P a → Q a) :
     List.Sublist (l.filter P) (l.filter Q) := by
   apply List.Sublist.trans (l₂ := (l.filter Q).filter P)
   · simp [Bool.and_eq_left_iff_imp.mpr (h _)]
   · apply List.filter_sublist
 
+set_option linter.defProp false in
 private def List.length_filter_strict_mono {l : List α} {P Q : α → Bool} {a : α}
     (h : ∀ a, P a → Q a) (ha : a ∈ l) (hPa : ¬ P a) (hQa : Q a) :
     (l.filter P).length < (l.filter Q).length := by

--- a/src/Init/Data/Rat/Lemmas.lean
+++ b/src/Init/Data/Rat/Lemmas.lean
@@ -176,6 +176,7 @@ theorem num_divInt_den (a : Rat) : a.num /. a.den = a := by rw [divInt_ofNat, mk
 @[deprecated mk_eq_divInt (since := "2025-10-29")]
 theorem mk'_eq_divInt {n d h c} : (⟨n, d, h, c⟩ : Rat) = n /. d := (num_divInt_den _).symm
 
+set_option linter.defProp false in
 @[deprecated num_divInt_den (since := "2025-08-22")]
 abbrev divInt_self := @num_divInt_den
 
@@ -202,6 +203,7 @@ theorem divInt_eq_divInt_iff (z₁ : d₁ ≠ 0) (z₂ : d₂ ≠ 0) :
   simp_all [divInt_neg', Int.neg_eq_zero,
     mkRat_eq_iff, Int.neg_mul, Int.mul_neg, Int.eq_neg_comm, eq_comm]
 
+set_option linter.defProp false in
 @[deprecated divInt_eq_divInt_iff (since := "2025-08-22")]
 abbrev divInt_eq_iff := @divInt_eq_divInt_iff
 
@@ -280,8 +282,10 @@ def numDenCasesOn''.{u} {C : Rat → Sort u} (a : Rat)
 @[simp] theorem num_natCast (n : Nat) : (n : Rat).num = n := rfl
 @[simp] theorem den_natCast (n : Nat) : (n : Rat).den = 1 := rfl
 
+set_option linter.defProp false in
 @[deprecated num_ofNat (since := "2025-08-22")]
 abbrev ofNat_num := @num_ofNat
+set_option linter.defProp false in
 @[deprecated den_ofNat (since := "2025-08-22")]
 abbrev ofNat_den := @den_ofNat
 
@@ -996,8 +1000,10 @@ protected theorem lt_div_iff' {a b c : Rat} (hc : 0 < c) : a < b / c ↔ c * a <
 
 @[simp] theorem num_intCast (a : Int) : (a : Rat).num = a := rfl
 
+set_option linter.defProp false in
 @[deprecated den_intCast (since := "2025-08-22")]
 abbrev intCast_den := @den_intCast
+set_option linter.defProp false in
 @[deprecated num_intCast (since := "2025-08-22")]
 abbrev intCast_num := @num_intCast
 

--- a/src/Init/Data/Rat/Lemmas.lean
+++ b/src/Init/Data/Rat/Lemmas.lean
@@ -172,14 +172,6 @@ theorem mk_eq_divInt {num den nz c} : ⟨num, den, nz, c⟩ = num /. (den : Nat)
   simp [mk_eq_mkRat]
 
 theorem num_divInt_den (a : Rat) : a.num /. a.den = a := by rw [divInt_ofNat, mkRat_self]
-
-@[deprecated mk_eq_divInt (since := "2025-10-29")]
-theorem mk'_eq_divInt {n d h c} : (⟨n, d, h, c⟩ : Rat) = n /. d := (num_divInt_den _).symm
-
-set_option linter.defProp false in
-@[deprecated num_divInt_den (since := "2025-08-22")]
-abbrev divInt_self := @num_divInt_den
-
 @[simp] theorem zero_divInt (n) : 0 /. n = 0 := by cases n <;> simp [divInt]
 
 @[simp] theorem divInt_zero (n) : n /. 0 = 0 := mkRat_zero n
@@ -202,10 +194,6 @@ theorem divInt_eq_divInt_iff (z₁ : d₁ ≠ 0) (z₂ : d₂ ≠ 0) :
   rcases Int.eq_nat_or_neg d₂ with ⟨_, rfl | rfl⟩ <;>
   simp_all [divInt_neg', Int.neg_eq_zero,
     mkRat_eq_iff, Int.neg_mul, Int.mul_neg, Int.eq_neg_comm, eq_comm]
-
-set_option linter.defProp false in
-@[deprecated divInt_eq_divInt_iff (since := "2025-08-22")]
-abbrev divInt_eq_iff := @divInt_eq_divInt_iff
 
 theorem divInt_mul_left {a : Int} (a0 : a ≠ 0) : (a * n) /. (a * d) = n /. d := by
   if d0 : d = 0 then simp [d0] else
@@ -281,13 +269,6 @@ def numDenCasesOn''.{u} {C : Rat → Sort u} (a : Rat)
 
 @[simp] theorem num_natCast (n : Nat) : (n : Rat).num = n := rfl
 @[simp] theorem den_natCast (n : Nat) : (n : Rat).den = 1 := rfl
-
-set_option linter.defProp false in
-@[deprecated num_ofNat (since := "2025-08-22")]
-abbrev ofNat_num := @num_ofNat
-set_option linter.defProp false in
-@[deprecated den_ofNat (since := "2025-08-22")]
-abbrev ofNat_den := @den_ofNat
 
 theorem add_def (a b : Rat) :
     a + b = normalize (a.num * b.den + b.num * a.den) (a.den * b.den)
@@ -999,13 +980,6 @@ protected theorem lt_div_iff' {a b c : Rat} (hc : 0 < c) : a < b / c ↔ c * a <
 @[simp] theorem den_intCast (a : Int) : (a : Rat).den = 1 := rfl
 
 @[simp] theorem num_intCast (a : Int) : (a : Rat).num = a := rfl
-
-set_option linter.defProp false in
-@[deprecated den_intCast (since := "2025-08-22")]
-abbrev intCast_den := @den_intCast
-set_option linter.defProp false in
-@[deprecated num_intCast (since := "2025-08-22")]
-abbrev intCast_num := @num_intCast
 
 /-!
 The following lemmas are later subsumed by e.g. `Int.cast_add` and `Int.cast_mul` in Mathlib

--- a/src/Init/Data/Slice/Array/Lemmas.lean
+++ b/src/Init/Data/Slice/Array/Lemmas.lean
@@ -93,6 +93,7 @@ theorem length_eq {α : Type u} {it : Iter (α := SubarrayIterator α) α} :
     it.length = it.internalState.xs.stop - it.internalState.xs.start := by
   simp [← Iter.length_toList_eq_length, toList_eq, it.internalState.xs.stop_le_array_size]
 
+set_option linter.defProp false in
 @[deprecated length_eq (since := "2026-01-28")]
 def count_eq := @length_eq
 

--- a/src/Init/Ext.lean
+++ b/src/Init/Ext.lean
@@ -82,10 +82,6 @@ end Lean
 attribute [ext] Prod PProd Sigma PSigma
 attribute [ext] funext propext Subtype.ext Array.ext Char.ext
 
-set_option linter.defProp false in
-@[deprecated Subtype.ext_iff (since := "2025-10-26")]
-protected def Subtype.eq_iff := @Subtype.ext_iff
-
 attribute [grind ext] funext Array.ext
 
 attribute [ext] PUnit.ext

--- a/src/Init/Ext.lean
+++ b/src/Init/Ext.lean
@@ -82,6 +82,7 @@ end Lean
 attribute [ext] Prod PProd Sigma PSigma
 attribute [ext] funext propext Subtype.ext Array.ext Char.ext
 
+set_option linter.defProp false in
 @[deprecated Subtype.ext_iff (since := "2025-10-26")]
 protected def Subtype.eq_iff := @Subtype.ext_iff
 

--- a/src/Init/Grind/Module/Basic.lean
+++ b/src/Init/Grind/Module/Basic.lean
@@ -265,6 +265,7 @@ export NoNatZeroDivisors (no_nat_zero_divisors)
 
 namespace NoNatZeroDivisors
 
+set_option linter.defProp false in
 /-- Alternative constructor for `NoNatZeroDivisors` when we have an `IntModule`. -/
 @[implicit_reducible]
 def mk' {α} [IntModule α]

--- a/src/Init/Grind/Module/Envelope.lean
+++ b/src/Init/Grind/Module/Envelope.lean
@@ -68,8 +68,7 @@ def Q.liftOn₂ (q₁ q₂ : Q α)
 
 attribute [local simp] Q.mk Q.liftOn₂ AddCommMonoid.add_zero
 
-set_option linter.defProp false in
-def Q.ind {β : Q α → Prop} (mk : ∀ (a : α × α), β (Q.mk a)) (q : Q α) : β q :=
+theorem Q.ind {β : Q α → Prop} (mk : ∀ (a : α × α), β (Q.mk a)) (q : Q α) : β q :=
   Quot.ind mk q
 
 @[local simp] def nsmul (n : Nat) (q : Q α) : (Q α) :=

--- a/src/Init/Grind/Module/Envelope.lean
+++ b/src/Init/Grind/Module/Envelope.lean
@@ -68,6 +68,7 @@ def Q.liftOn₂ (q₁ q₂ : Q α)
 
 attribute [local simp] Q.mk Q.liftOn₂ AddCommMonoid.add_zero
 
+set_option linter.defProp false in
 def Q.ind {β : Q α → Prop} (mk : ∀ (a : α × α), β (Q.mk a)) (q : Q α) : β q :=
   Quot.ind mk q
 

--- a/src/Init/Grind/Module/NatModuleNorm.lean
+++ b/src/Init/Grind/Module/NatModuleNorm.lean
@@ -34,11 +34,9 @@ def Poly.denoteN {α} [NatModule α] (ctx : Context α) (p : Poly) : α :=
     else
       k.natAbs • v.denote ctx + denoteN ctx p
 
-set_option linter.defProp false in
-def Poly.denoteN_nil {α} [NatModule α] (ctx : Context α) : Poly.denoteN ctx .nil = 0 := rfl
+theorem Poly.denoteN_nil {α} [NatModule α] (ctx : Context α) : Poly.denoteN ctx .nil = 0 := rfl
 
-set_option linter.defProp false in
-def Poly.denoteN_add {α} [NatModule α] (ctx : Context α) (k : Int) (x : Var) (p : Poly)
+theorem Poly.denoteN_add {α} [NatModule α] (ctx : Context α) (k : Int) (x : Var) (p : Poly)
     : k ≥ 0 → Poly.denoteN ctx (.add k x p) = k.toNat • x.denote ctx + p.denoteN ctx := by
   intro h; simp [denoteN, cond_eq_ite]; split
   next => omega

--- a/src/Init/Grind/Module/NatModuleNorm.lean
+++ b/src/Init/Grind/Module/NatModuleNorm.lean
@@ -34,8 +34,10 @@ def Poly.denoteN {α} [NatModule α] (ctx : Context α) (p : Poly) : α :=
     else
       k.natAbs • v.denote ctx + denoteN ctx p
 
+set_option linter.defProp false in
 def Poly.denoteN_nil {α} [NatModule α] (ctx : Context α) : Poly.denoteN ctx .nil = 0 := rfl
 
+set_option linter.defProp false in
 def Poly.denoteN_add {α} [NatModule α] (ctx : Context α) (k : Int) (x : Var) (p : Poly)
     : k ≥ 0 → Poly.denoteN ctx (.add k x p) = k.toNat • x.denote ctx + p.denoteN ctx := by
   intro h; simp [denoteN, cond_eq_ite]; split

--- a/src/Init/Grind/Ring/Basic.lean
+++ b/src/Init/Grind/Ring/Basic.lean
@@ -500,6 +500,7 @@ private theorem mk'_aux {x y : Nat} (p : Nat) (h : y ≤ x) :
       simp [Nat.mul_sub, Nat.mul_comm p k₁, Nat.mul_comm p k₂]
       omega
 
+set_option linter.defProp false in
 /-- Alternative constructor when `α` is a `Ring`. -/
 @[implicit_reducible]
 def mk' (p : Nat) (α : Type u) [Ring α]

--- a/src/Init/Grind/Ring/CommSolver.lean
+++ b/src/Init/Grind/Ring/CommSolver.lean
@@ -1593,6 +1593,7 @@ theorem div {α} [CommRing α] (ctx : Context α) [NoNatZeroDivisors α] (p₁ :
 noncomputable def unsat_eq_cert (p : Poly) (k : Int) : Bool :=
   !Int.beq' k 0 |>.and' (p.beq' (.num k))
 
+set_option linter.defProp false in
 def unsat_eq {α} [CommRing α] (ctx : Context α) [IsCharP α 0] (p : Poly) (k : Int)
     : unsat_eq_cert p k → p.denote ctx = 0 → False := by
   simp [unsat_eq_cert]; intro h _; subst p; simp [Poly.denote]
@@ -1658,6 +1659,7 @@ theorem superposeC {α c} [CommRing α] [IsCharP α c] (ctx : Context α) (k₁ 
 noncomputable def mul_certC (p₁ : Poly) (k : Int) (p : Poly) (c : Nat) : Bool :=
   p₁.mulConstC k c |>.beq' p
 
+set_option linter.defProp false in
 def mulC {α c} [CommRing α] [IsCharP α c] (ctx : Context α) (p₁ : Poly) (k : Int) (p : Poly)
     : mul_certC p₁ k p c → p₁.denote ctx = 0 → p.denote ctx = 0 := by
   simp [mul_certC]; intro _ h; subst p
@@ -1666,6 +1668,7 @@ def mulC {α c} [CommRing α] [IsCharP α c] (ctx : Context α) (p₁ : Poly) (k
 noncomputable def div_certC (p₁ : Poly) (k : Int) (p : Poly) (c : Nat) : Bool :=
   !Int.beq' k 0 |>.and' ((p.mulConstC k c).beq' p₁)
 
+set_option linter.defProp false in
 def divC {α c} [CommRing α] [IsCharP α c] (ctx : Context α) [NoNatZeroDivisors α] (p₁ : Poly) (k : Int) (p : Poly)
     : div_certC p₁ k p c → p₁.denote ctx = 0 → p.denote ctx = 0 := by
   simp [div_certC]; intro hnz _ h; subst p₁
@@ -1683,6 +1686,7 @@ theorem simpC {α c} [CommRing α] [IsCharP α c] (ctx : Context α) (k₁ : Int
 noncomputable def unsat_eq_certC (p : Poly) (k : Int) (c : Nat) : Bool :=
   !Int.beq' (k % c) 0 |>.and' (p.beq' (.num k))
 
+set_option linter.defProp false in
 def unsat_eqC {α c} [CommRing α] [IsCharP α c] (ctx : Context α) (p : Poly) (k : Int)
     : unsat_eq_certC p k c → p.denote ctx = 0 → False := by
   simp [unsat_eq_certC]; intro h _; subst p; simp [Poly.denote]

--- a/src/Init/Grind/Ring/CommSolver.lean
+++ b/src/Init/Grind/Ring/CommSolver.lean
@@ -1593,8 +1593,7 @@ theorem div {α} [CommRing α] (ctx : Context α) [NoNatZeroDivisors α] (p₁ :
 noncomputable def unsat_eq_cert (p : Poly) (k : Int) : Bool :=
   !Int.beq' k 0 |>.and' (p.beq' (.num k))
 
-set_option linter.defProp false in
-def unsat_eq {α} [CommRing α] (ctx : Context α) [IsCharP α 0] (p : Poly) (k : Int)
+theorem unsat_eq {α} [CommRing α] (ctx : Context α) [IsCharP α 0] (p : Poly) (k : Int)
     : unsat_eq_cert p k → p.denote ctx = 0 → False := by
   simp [unsat_eq_cert]; intro h _; subst p; simp [Poly.denote]
   have := IsCharP.intCast_eq_zero_iff (α := α) 0 k
@@ -1659,8 +1658,7 @@ theorem superposeC {α c} [CommRing α] [IsCharP α c] (ctx : Context α) (k₁ 
 noncomputable def mul_certC (p₁ : Poly) (k : Int) (p : Poly) (c : Nat) : Bool :=
   p₁.mulConstC k c |>.beq' p
 
-set_option linter.defProp false in
-def mulC {α c} [CommRing α] [IsCharP α c] (ctx : Context α) (p₁ : Poly) (k : Int) (p : Poly)
+theorem mulC {α c} [CommRing α] [IsCharP α c] (ctx : Context α) (p₁ : Poly) (k : Int) (p : Poly)
     : mul_certC p₁ k p c → p₁.denote ctx = 0 → p.denote ctx = 0 := by
   simp [mul_certC]; intro _ h; subst p
   simp [Poly.denote_mulConstC, *, mul_zero]
@@ -1668,8 +1666,7 @@ def mulC {α c} [CommRing α] [IsCharP α c] (ctx : Context α) (p₁ : Poly) (k
 noncomputable def div_certC (p₁ : Poly) (k : Int) (p : Poly) (c : Nat) : Bool :=
   !Int.beq' k 0 |>.and' ((p.mulConstC k c).beq' p₁)
 
-set_option linter.defProp false in
-def divC {α c} [CommRing α] [IsCharP α c] (ctx : Context α) [NoNatZeroDivisors α] (p₁ : Poly) (k : Int) (p : Poly)
+theorem divC {α c} [CommRing α] [IsCharP α c] (ctx : Context α) [NoNatZeroDivisors α] (p₁ : Poly) (k : Int) (p : Poly)
     : div_certC p₁ k p c → p₁.denote ctx = 0 → p.denote ctx = 0 := by
   simp [div_certC]; intro hnz _ h; subst p₁
   simp [Poly.denote_mulConstC, ← zsmul_eq_intCast_mul] at h
@@ -1686,8 +1683,7 @@ theorem simpC {α c} [CommRing α] [IsCharP α c] (ctx : Context α) (k₁ : Int
 noncomputable def unsat_eq_certC (p : Poly) (k : Int) (c : Nat) : Bool :=
   !Int.beq' (k % c) 0 |>.and' (p.beq' (.num k))
 
-set_option linter.defProp false in
-def unsat_eqC {α c} [CommRing α] [IsCharP α c] (ctx : Context α) (p : Poly) (k : Int)
+theorem unsat_eqC {α c} [CommRing α] [IsCharP α c] (ctx : Context α) (p : Poly) (k : Int)
     : unsat_eq_certC p k c → p.denote ctx = 0 → False := by
   simp [unsat_eq_certC]; intro h _; subst p; simp [Poly.denote]
   have := IsCharP.intCast_eq_zero_iff (α := α) c k

--- a/src/Init/Grind/Ring/Envelope.lean
+++ b/src/Init/Grind/Ring/Envelope.lean
@@ -103,6 +103,7 @@ def Q.liftOn₂ (q₁ q₂ : Q α)
 
 attribute [local simp] Q.mk Q.liftOn₂
 
+set_option linter.defProp false in
 def Q.ind {β : Q α → Prop} (mk : ∀ (a : α × α), β (Q.mk a)) (q : Q α) : β q :=
   Quot.ind mk q
 

--- a/src/Init/Grind/Ring/Envelope.lean
+++ b/src/Init/Grind/Ring/Envelope.lean
@@ -103,8 +103,7 @@ def Q.liftOn₂ (q₁ q₂ : Q α)
 
 attribute [local simp] Q.mk Q.liftOn₂
 
-set_option linter.defProp false in
-def Q.ind {β : Q α → Prop} (mk : ∀ (a : α × α), β (Q.mk a)) (q : Q α) : β q :=
+theorem Q.ind {β : Q α → Prop} (mk : ∀ (a : α × α), β (Q.mk a)) (q : Q α) : β q :=
   Quot.ind mk q
 
 @[local simp] def natCast (n : Nat) : Q α :=

--- a/src/Init/Grind/Ring/Field.lean
+++ b/src/Init/Grind/Ring/Field.lean
@@ -224,6 +224,7 @@ theorem natCast_div_of_dvd {x y : Nat} (h : y ∣ x) (w : (y : α) ≠ 0) :
       mul_inv_cancel w, Semiring.mul_one]
 
 -- This is expensive as an instance. Let's see what breaks without it.
+set_option linter.defProp false in
 @[implicit_reducible]
 def noNatZeroDivisors.ofIsCharPZero [IsCharP α 0] : NoNatZeroDivisors α := NoNatZeroDivisors.mk' <| by
   intro a b h w

--- a/src/Init/Grind/Ring/ToInt.lean
+++ b/src/Init/Grind/Ring/ToInt.lean
@@ -14,6 +14,7 @@ public section
 
 namespace Lean.Grind
 
+set_option linter.defProp false in
 /-- A `ToInt` instance on a semiring preserves powers if it preserves numerals and multiplication. -/
 @[implicit_reducible]
 def ToInt.pow_of_semiring [Semiring α] [ToInt α I] [ToInt.OfNat α I] [ToInt.Mul α I]

--- a/src/Init/Grind/ToInt.lean
+++ b/src/Init/Grind/ToInt.lean
@@ -348,6 +348,7 @@ theorem wrap_toInt (I : IntInterval) [ToInt α I] (x : α) :
   rw [I.wrap_eq_self_iff (I.nonEmpty_of_mem (toInt_mem x))]
   exact ToInt.toInt_mem x
 
+set_option linter.defProp false in
 /-- Construct a `ToInt.Sub` instance from a `ToInt.Add` and `ToInt.Neg` instance and
 a `sub_eq_add_neg` assumption. -/
 @[implicit_reducible]

--- a/src/Init/Grind/Util.lean
+++ b/src/Init/Grind/Util.lean
@@ -12,9 +12,8 @@ import Init.Classical
 public section
 namespace Lean.Grind
 
-set_option linter.defProp false in
 /-- A helper gadget for annotating nested proofs in goals. -/
-def nestedProof (p : Prop) {h : p} : p := h
+theorem nestedProof (p : Prop) {h : p} : p := h
 
 /-- A helper gadget for annotating nested decidable instances in goals. -/
 -- Remark: we currently have special gadgets for the two most common subsingletons in Lean, and are the only

--- a/src/Init/Grind/Util.lean
+++ b/src/Init/Grind/Util.lean
@@ -12,6 +12,7 @@ import Init.Classical
 public section
 namespace Lean.Grind
 
+set_option linter.defProp false in
 /-- A helper gadget for annotating nested proofs in goals. -/
 def nestedProof (p : Prop) {h : p} : p := h
 

--- a/src/Init/Internal/Order/Basic.lean
+++ b/src/Init/Internal/Order/Basic.lean
@@ -114,8 +114,7 @@ theorem le_csup {c : α → Prop} (hc : chain c) {y : α} (hy : c y) : y ⊑ csu
 
 def empty_chain (α) : α → Prop := fun _ => False
 
-set_option linter.defProp false in
-def chain_empty (α : Sort u) [PartialOrder α] : chain (empty_chain α) := by
+theorem chain_empty (α : Sort u) [PartialOrder α] : chain (empty_chain α) := by
   intro x y hx hy; contradiction
 
 /--
@@ -291,8 +290,7 @@ theorem admissible_or (P Q : α → Prop)
     intro x ⟨hcx, hQx⟩
     exact hQx
 
-set_option linter.defProp false in
-def admissible_pi (P : α → β → Prop)
+theorem admissible_pi (P : α → β → Prop)
   (hadm₁ : ∀ y, admissible (fun x => P x y)) : admissible (fun x => ∀ y, P x y) :=
     fun c hchain h y => hadm₁ y c hchain fun x hx => h x hx y
 
@@ -570,8 +568,7 @@ theorem fun_sup_eq [∀ x, CompleteLattice (β x)] (c : (∀ x, β x) → Prop) 
   · apply fun_sup_is_sup
   · apply CompleteLattice.sup_spec
 
-set_option linter.defProp false in
-def admissible_apply [∀ x, CCPO (β x)] (P : ∀ x, β x → Prop) (x : α)
+theorem admissible_apply [∀ x, CCPO (β x)] (P : ∀ x, β x → Prop) (x : α)
   (hadm : admissible (P x)) : admissible (fun (f : ∀ x, β x) => P x (f x)) := by
   intro c hchain h
   rw [← fun_csup_eq]
@@ -579,8 +576,7 @@ def admissible_apply [∀ x, CCPO (β x)] (P : ∀ x, β x → Prop) (x : α)
   rintro _ ⟨f, hcf, rfl⟩
   apply h _ hcf
 
-set_option linter.defProp false in
-def admissible_pi_apply [∀ x, CCPO (β x)] (P : ∀ x, β x → Prop) (hadm : ∀ x, admissible (P x)) :
+theorem admissible_pi_apply [∀ x, CCPO (β x)] (P : ∀ x, β x → Prop) (hadm : ∀ x, admissible (P x)) :
     admissible (fun (f : ∀ x, β x) => ∀ x, P x (f x)) := by
   apply admissible_pi
   intro

--- a/src/Init/Internal/Order/Basic.lean
+++ b/src/Init/Internal/Order/Basic.lean
@@ -114,6 +114,7 @@ theorem le_csup {c : α → Prop} (hc : chain c) {y : α} (hy : c y) : y ⊑ csu
 
 def empty_chain (α) : α → Prop := fun _ => False
 
+set_option linter.defProp false in
 def chain_empty (α : Sort u) [PartialOrder α] : chain (empty_chain α) := by
   intro x y hx hy; contradiction
 
@@ -290,6 +291,7 @@ theorem admissible_or (P Q : α → Prop)
     intro x ⟨hcx, hQx⟩
     exact hQx
 
+set_option linter.defProp false in
 def admissible_pi (P : α → β → Prop)
   (hadm₁ : ∀ y, admissible (fun x => P x y)) : admissible (fun x => ∀ y, P x y) :=
     fun c hchain h y => hadm₁ y c hchain fun x hx => h x hx y
@@ -568,6 +570,7 @@ theorem fun_sup_eq [∀ x, CompleteLattice (β x)] (c : (∀ x, β x) → Prop) 
   · apply fun_sup_is_sup
   · apply CompleteLattice.sup_spec
 
+set_option linter.defProp false in
 def admissible_apply [∀ x, CCPO (β x)] (P : ∀ x, β x → Prop) (x : α)
   (hadm : admissible (P x)) : admissible (fun (f : ∀ x, β x) => P x (f x)) := by
   intro c hchain h
@@ -576,6 +579,7 @@ def admissible_apply [∀ x, CCPO (β x)] (P : ∀ x, β x → Prop) (x : α)
   rintro _ ⟨f, hcf, rfl⟩
   apply h _ hcf
 
+set_option linter.defProp false in
 def admissible_pi_apply [∀ x, CCPO (β x)] (P : ∀ x, β x → Prop) (hadm : ∀ x, admissible (P x)) :
     admissible (fun (f : ∀ x, β x) => ∀ x, P x (f x)) := by
   apply admissible_pi

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -1971,10 +1971,9 @@ theorem Nat.le_of_succ_le_succ {n m : Nat} : LE.le (succ n) (succ m) → LE.le n
 theorem Nat.le_of_lt_succ {m n : Nat} : LT.lt m (succ n) → LE.le m n :=
   le_of_succ_le_succ
 
-set_option linter.defProp false in
 set_option linter.missingDocs false in
 -- single generic "theorem" used in `WellFounded` reduction in core
-protected def Nat.eq_or_lt_of_le : {n m: Nat} → LE.le n m → Or (Eq n m) (LT.lt n m)
+protected theorem Nat.eq_or_lt_of_le : {n m: Nat} → LE.le n m → Or (Eq n m) (LT.lt n m)
   | zero,   zero,   _ => Or.inl rfl
   | zero,   succ _, _ => Or.inr (Nat.succ_le_succ (Nat.zero_le _))
   | succ _, zero,   h => absurd h (not_succ_le_zero _)

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -339,6 +339,7 @@ For more information: [Propositional Logic](https://lean-lang.org/theorem_provin
 @[macro_inline] def absurd {a : Prop} {b : Sort v} (h₁ : a) (h₂ : Not a) : b :=
   (h₂ h₁).rec
 
+set_option linter.defProp false in
 /--
 `rfl : a = a` is the unique constructor of the equality type. This is the
 same as `Eq.refl` except that it takes `a` implicitly instead of explicitly.
@@ -535,7 +536,7 @@ Unsafe auxiliary constant used by the compiler to erase `Quot.lift`.
 -/
 unsafe axiom Quot.lcInv {α : Sort u} {r : α → α → Prop} (q : Quot r) : α
 
-
+set_option linter.defProp false in
 /-- A version of `HEq.refl` with an implicit argument. -/
 @[match_pattern] protected def HEq.rfl {α : Sort u} {a : α} : HEq a a :=
   HEq.refl a
@@ -1970,6 +1971,7 @@ theorem Nat.le_of_succ_le_succ {n m : Nat} : LE.le (succ n) (succ m) → LE.le n
 theorem Nat.le_of_lt_succ {m n : Nat} : LT.lt m (succ n) → LE.le m n :=
   le_of_succ_le_succ
 
+set_option linter.defProp false in
 set_option linter.missingDocs false in
 -- single generic "theorem" used in `WellFounded` reduction in core
 protected def Nat.eq_or_lt_of_le : {n m: Nat} → LE.le n m → Or (Eq n m) (LT.lt n m)

--- a/src/Init/PropLemmas.lean
+++ b/src/Init/PropLemmas.lean
@@ -476,6 +476,7 @@ end Mem
 
 @[simp] theorem Decidable.not_not [Decidable p] : ¬¬p ↔ p := ⟨of_not_not, not_not_intro⟩
 
+set_option linter.defProp false in
 /-- Excluded middle.  Added as alias for Decidable.em -/
 abbrev Decidable.or_not_self := em
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
@@ -23,6 +23,7 @@ open Std.Do
 
 namespace Lean.Elab.Tactic.Do.Internal
 
+set_option linter.checkUnivs false in
 @[inline]
 def Std.HashMap.getDM [Monad m] [BEq α] [Hashable α]
     (cache : Std.HashMap α β) (key : α) (fallback : m β) : m (β × Std.HashMap α β) := do

--- a/src/Lean/Linter/CheckUnivs.lean
+++ b/src/Lean/Linter/CheckUnivs.lean
@@ -27,7 +27,7 @@ This usually means that the type contains a `max u v` where neither `u` nor `v` 
 themselves; the fix is to provide the universe level explicitly.
 -/
 register_builtin_option linter.checkUnivs : Bool := {
-  defValue := false
+  defValue := true
   descr := "enable the `checkUnivs` linter, which warns when a declaration has a universe \
     parameter that only ever occurs in a `max u v` together with another parameter, never \
     on its own."

--- a/src/Lean/Linter/DefProp.lean
+++ b/src/Lean/Linter/DefProp.lean
@@ -24,7 +24,7 @@ declaration whose type is a `Prop`. Such a declaration should be written using
 `theorem` instead.
 -/
 register_builtin_option linter.defProp : Bool := {
-  defValue := false
+  defValue := true
   descr := "enable the `defProp` linter, which warns when a `def` is used to introduce \
     a declaration whose type is a `Prop`; such a declaration should be written using \
     `theorem` instead."

--- a/src/Lean/Linter/DefProp.lean
+++ b/src/Lean/Linter/DefProp.lean
@@ -43,6 +43,7 @@ def defPropLinter : Linter where run := withSetOptionIn fun _ => do
     for declName in getDeclsByBody t do
       let some info := env.find? declName | continue
       unless info.isDefinition do continue
+      if info.hints.isAbbrev then continue
       let isPropType ← liftTermElabM <| isProp info.type
       if isPropType then
         logLintIf linter.defProp (← getRef) m!"\

--- a/src/Std/Data/DHashMap/Raw.lean
+++ b/src/Std/Data/DHashMap/Raw.lean
@@ -719,6 +719,7 @@ inductive WF : {α : Type u} → {β : α → Type v} → [BEq α] → [Hashable
 
 -- TODO: this needs to be deprecated, but there is a bootstrapping issue.
 -- @[deprecated WF.emptyWithCapacity₀ (since := "2025-03-12")]
+set_option linter.defProp false in
 @[inherit_doc Raw.WF.emptyWithCapacity₀]
 abbrev WF.empty₀ := @WF.emptyWithCapacity₀
 

--- a/src/Std/Data/Iterators/Lemmas/Combinators/Zip.lean
+++ b/src/Std/Data/Iterators/Lemmas/Combinators/Zip.lean
@@ -41,8 +41,7 @@ noncomputable def Iter.Intermediate.zip [Iterator α₁ Id β₁]
     ((fun x => ⟨x.1, x.2.choose.toIterM, x.2.choose_spec⟩) <$> memo)
     it₂.toIterM).toIter
 
-set_option linter.defProp false in
-def Iter.Intermediate.zip_inj [Iterator α₁ Id β₁] :
+theorem Iter.Intermediate.zip_inj [Iterator α₁ Id β₁] :
     ∀ {it₁ it₁' : Iter (α := α₁) β₁} {memo memo'} {it₂ it₂' : Iter (α := α₂) β₂},
       zip it₁ memo it₂ = zip it₁' memo' it₂' ↔ it₁ = it₁' ∧ memo = memo' ∧ it₂ = it₂' := by
   intro it₁ it₁' memo memo' it₂ it₂'
@@ -54,8 +53,7 @@ def Iter.Intermediate.zip_inj [Iterator α₁ Id β₁] :
   · rintro ⟨rfl, rfl, rfl⟩
     rfl
 
-set_option linter.defProp false in
-def Iter.Intermediate.zip_surj [Iterator α₁ Id β₁] :
+theorem Iter.Intermediate.zip_surj [Iterator α₁ Id β₁] :
     ∀ it : Iter (α := Zip α₁ Id α₂ β₂) (β₁ × β₂), ∃ it₁ memo it₂, it = Intermediate.zip it₁ memo it₂ := by
   refine fun it => ⟨it.internalState.left.toIter,
       (fun x => ⟨x.1, x.2.choose.toIter, x.2.choose_spec⟩) <$> it.internalState.memoizedLeft,

--- a/src/Std/Data/Iterators/Lemmas/Combinators/Zip.lean
+++ b/src/Std/Data/Iterators/Lemmas/Combinators/Zip.lean
@@ -41,6 +41,7 @@ noncomputable def Iter.Intermediate.zip [Iterator α₁ Id β₁]
     ((fun x => ⟨x.1, x.2.choose.toIterM, x.2.choose_spec⟩) <$> memo)
     it₂.toIterM).toIter
 
+set_option linter.defProp false in
 def Iter.Intermediate.zip_inj [Iterator α₁ Id β₁] :
     ∀ {it₁ it₁' : Iter (α := α₁) β₁} {memo memo'} {it₂ it₂' : Iter (α := α₂) β₂},
       zip it₁ memo it₂ = zip it₁' memo' it₂' ↔ it₁ = it₁' ∧ memo = memo' ∧ it₂ = it₂' := by
@@ -53,6 +54,7 @@ def Iter.Intermediate.zip_inj [Iterator α₁ Id β₁] :
   · rintro ⟨rfl, rfl, rfl⟩
     rfl
 
+set_option linter.defProp false in
 def Iter.Intermediate.zip_surj [Iterator α₁ Id β₁] :
     ∀ it : Iter (α := Zip α₁ Id α₂ β₂) (β₁ × β₂), ∃ it₁ memo it₂, it = Intermediate.zip it₁ memo it₂ := by
   refine fun it => ⟨it.internalState.left.toIter,

--- a/src/Std/Data/Iterators/Lemmas/Producers/Range.lean
+++ b/src/Std/Data/Iterators/Lemmas/Producers/Range.lean
@@ -47,9 +47,11 @@ theorem Rcc.length_iter [LE α] [DecidableLE α] [UpwardEnumerable α]
     r.iter.length = r.size := by
   rw [← size_toArray, ← toArray_iter, Iter.size_toArray_eq_length]
 
+set_option linter.defProp false in
 @[deprecated Rcc.length_iter (since := "2026-01-28")]
 def Rcc.count_iter := @Rcc.length_iter
 
+set_option linter.defProp false in
 @[deprecated Rcc.length_iter (since := "2025-11-13")]
 def Rcc.count_iter_eq_size := @Rcc.length_iter
 
@@ -85,9 +87,11 @@ theorem Rco.length_iter [LT α] [DecidableLT α] [UpwardEnumerable α]
     r.iter.length = r.size := by
   rw [← size_toArray, ← toArray_iter, Iter.size_toArray_eq_length]
 
+set_option linter.defProp false in
 @[deprecated Rco.length_iter (since := "2026-01-28")]
 def Rco.count_iter := @Rco.length_iter
 
+set_option linter.defProp false in
 @[deprecated Rco.length_iter (since := "2025-11-13")]
 def Rco.count_iter_eq_size := @Rco.length_iter
 
@@ -123,9 +127,11 @@ theorem Rci.length_iter [UpwardEnumerable α]
     r.iter.length = r.size := by
   rw [← size_toArray, ← toArray_iter_eq_toArray, Iter.size_toArray_eq_length]
 
+set_option linter.defProp false in
 @[deprecated Rci.length_iter (since := "2026-01-28")]
 def Rci.count_iter := @Rci.length_iter
 
+set_option linter.defProp false in
 @[deprecated Rci.length_iter (since := "2025-11-13")]
 def Rci.count_iter_eq_size := @Rci.length_iter
 
@@ -161,9 +167,11 @@ theorem Roc.length_iter [LE α] [DecidableLE α] [UpwardEnumerable α]
     r.iter.length = r.size := by
   rw [← size_toArray, ← toArray_iter_eq_toArray, Iter.size_toArray_eq_length]
 
+set_option linter.defProp false in
 @[deprecated Roc.length_iter (since := "2026-01-28")]
 def Roc.count_iter := @Roc.length_iter
 
+set_option linter.defProp false in
 @[deprecated Roc.length_iter (since := "2025-11-13")]
 def Roc.count_iter_eq_size := @Roc.length_iter
 
@@ -199,9 +207,11 @@ theorem Roo.length_iter [LT α] [DecidableLT α] [UpwardEnumerable α]
     r.iter.length = r.size := by
   rw [← size_toArray, ← toArray_iter_eq_toArray, Iter.size_toArray_eq_length]
 
+set_option linter.defProp false in
 @[deprecated Roo.length_iter (since := "2026-01-28")]
 def Roo.count_iter := @Roo.length_iter
 
+set_option linter.defProp false in
 @[deprecated Roo.length_iter (since := "2025-11-13")]
 def Roo.count_iter_eq_size := @Roo.length_iter
 
@@ -237,9 +247,11 @@ theorem Roi.length_iter [UpwardEnumerable α]
     r.iter.length = r.size := by
   rw [← size_toArray, ← toArray_iter, Iter.size_toArray_eq_length]
 
+set_option linter.defProp false in
 @[deprecated Roi.length_iter (since := "2026-01-28")]
 def Roi.count_iter := @Roi.length_iter
 
+set_option linter.defProp false in
 @[deprecated Roi.length_iter (since := "2025-11-13")]
 def Roi.count_iter_eq_size := @Roi.length_iter
 
@@ -275,9 +287,11 @@ theorem Ric.length_iter [Least? α] [LE α] [DecidableLE α] [UpwardEnumerable �
     r.iter.length = r.size := by
   rw [← size_toArray, ← toArray_iter, Iter.size_toArray_eq_length]
 
+set_option linter.defProp false in
 @[deprecated Ric.length_iter (since := "2026-01-28")]
 def Ric.count_iter := @Ric.length_iter
 
+set_option linter.defProp false in
 @[deprecated Ric.length_iter (since := "2025-11-13")]
 def Ric.count_iter_eq_size := @Ric.length_iter
 
@@ -313,9 +327,11 @@ theorem Rio.length_iter [Least? α] [LT α] [DecidableLT α] [UpwardEnumerable �
     r.iter.length = r.size := by
   rw [← size_toArray, ← toArray_iter, Iter.size_toArray_eq_length]
 
+set_option linter.defProp false in
 @[deprecated Rio.length_iter (since := "2026-01-28")]
 def Rio.count_iter := @Rio.length_iter
 
+set_option linter.defProp false in
 @[deprecated Rio.length_iter (since := "2025-11-13")]
 def Rio.count_iter_eq_size := @Rio.length_iter
 
@@ -351,9 +367,11 @@ theorem Rii.length_iter [Least? α] [UpwardEnumerable α]
     r.iter.length = r.size := by
   rw [← size_toArray, ← toArray_iter, Iter.size_toArray_eq_length]
 
+set_option linter.defProp false in
 @[deprecated Rii.length_iter (since := "2026-01-28")]
 def Rii.count_iter := @Rii.length_iter
 
+set_option linter.defProp false in
 @[deprecated Rii.length_iter (since := "2025-11-13")]
 def Rii.count_iter_eq_size := @Rii.length_iter
 

--- a/src/Std/Data/Iterators/Lemmas/Producers/Range.lean
+++ b/src/Std/Data/Iterators/Lemmas/Producers/Range.lean
@@ -51,9 +51,6 @@ set_option linter.defProp false in
 @[deprecated Rcc.length_iter (since := "2026-01-28")]
 def Rcc.count_iter := @Rcc.length_iter
 
-set_option linter.defProp false in
-@[deprecated Rcc.length_iter (since := "2025-11-13")]
-def Rcc.count_iter_eq_size := @Rcc.length_iter
 
 @[simp]
 theorem Rco.toList_iter [LT α] [DecidableLT α] [UpwardEnumerable α]
@@ -91,10 +88,6 @@ set_option linter.defProp false in
 @[deprecated Rco.length_iter (since := "2026-01-28")]
 def Rco.count_iter := @Rco.length_iter
 
-set_option linter.defProp false in
-@[deprecated Rco.length_iter (since := "2025-11-13")]
-def Rco.count_iter_eq_size := @Rco.length_iter
-
 @[simp]
 theorem Rci.toList_iter [UpwardEnumerable α]
     [Rxi.IsAlwaysFinite α] [LawfulUpwardEnumerable α] {r : Rci α} :
@@ -130,10 +123,6 @@ theorem Rci.length_iter [UpwardEnumerable α]
 set_option linter.defProp false in
 @[deprecated Rci.length_iter (since := "2026-01-28")]
 def Rci.count_iter := @Rci.length_iter
-
-set_option linter.defProp false in
-@[deprecated Rci.length_iter (since := "2025-11-13")]
-def Rci.count_iter_eq_size := @Rci.length_iter
 
 @[simp]
 theorem Roc.toList_iter [LE α] [DecidableLE α] [UpwardEnumerable α]
@@ -171,10 +160,6 @@ set_option linter.defProp false in
 @[deprecated Roc.length_iter (since := "2026-01-28")]
 def Roc.count_iter := @Roc.length_iter
 
-set_option linter.defProp false in
-@[deprecated Roc.length_iter (since := "2025-11-13")]
-def Roc.count_iter_eq_size := @Roc.length_iter
-
 @[simp]
 theorem Roo.toList_iter [LT α] [DecidableLT α] [UpwardEnumerable α]
     [LawfulUpwardEnumerableLT α] [Rxo.IsAlwaysFinite α] [LawfulUpwardEnumerable α] {r : Roo α} :
@@ -210,10 +195,6 @@ theorem Roo.length_iter [LT α] [DecidableLT α] [UpwardEnumerable α]
 set_option linter.defProp false in
 @[deprecated Roo.length_iter (since := "2026-01-28")]
 def Roo.count_iter := @Roo.length_iter
-
-set_option linter.defProp false in
-@[deprecated Roo.length_iter (since := "2025-11-13")]
-def Roo.count_iter_eq_size := @Roo.length_iter
 
 @[simp]
 theorem Roi.toList_iter [UpwardEnumerable α]
@@ -251,10 +232,6 @@ set_option linter.defProp false in
 @[deprecated Roi.length_iter (since := "2026-01-28")]
 def Roi.count_iter := @Roi.length_iter
 
-set_option linter.defProp false in
-@[deprecated Roi.length_iter (since := "2025-11-13")]
-def Roi.count_iter_eq_size := @Roi.length_iter
-
 @[simp]
 theorem Ric.toList_iter [Least? α] [LE α] [DecidableLE α] [UpwardEnumerable α]
     [LawfulUpwardEnumerableLE α] [Rxc.IsAlwaysFinite α] [LawfulUpwardEnumerable α] {r : Ric α} :
@@ -290,10 +267,6 @@ theorem Ric.length_iter [Least? α] [LE α] [DecidableLE α] [UpwardEnumerable �
 set_option linter.defProp false in
 @[deprecated Ric.length_iter (since := "2026-01-28")]
 def Ric.count_iter := @Ric.length_iter
-
-set_option linter.defProp false in
-@[deprecated Ric.length_iter (since := "2025-11-13")]
-def Ric.count_iter_eq_size := @Ric.length_iter
 
 @[simp]
 theorem Rio.toList_iter [Least? α] [LT α] [DecidableLT α] [UpwardEnumerable α]
@@ -331,10 +304,6 @@ set_option linter.defProp false in
 @[deprecated Rio.length_iter (since := "2026-01-28")]
 def Rio.count_iter := @Rio.length_iter
 
-set_option linter.defProp false in
-@[deprecated Rio.length_iter (since := "2025-11-13")]
-def Rio.count_iter_eq_size := @Rio.length_iter
-
 @[simp]
 theorem Rii.toList_iter [Least? α] [UpwardEnumerable α]
     [Rxi.IsAlwaysFinite α] [LawfulUpwardEnumerable α] {r : Rii α} :
@@ -370,9 +339,5 @@ theorem Rii.length_iter [Least? α] [UpwardEnumerable α]
 set_option linter.defProp false in
 @[deprecated Rii.length_iter (since := "2026-01-28")]
 def Rii.count_iter := @Rii.length_iter
-
-set_option linter.defProp false in
-@[deprecated Rii.length_iter (since := "2025-11-13")]
-def Rii.count_iter_eq_size := @Rii.length_iter
 
 end Std

--- a/src/Std/Data/Iterators/Lemmas/Producers/Slice.lean
+++ b/src/Std/Data/Iterators/Lemmas/Producers/Slice.lean
@@ -56,6 +56,7 @@ theorem size_eq_length_iter [ToIterator (Slice γ) Id α β]
     s.size = s.iter.length := by
   simp [Internal.iter_eq_iter, Internal.size_eq_length_iter]
 
+set_option linter.defProp false in
 @[deprecated size_eq_length_iter (since := "2026-01-28")]
 def size_eq_count_iter := @size_eq_length_iter
 
@@ -67,6 +68,7 @@ theorem length_iter_eq_size [ToIterator (Slice γ) Id α β]
     s.iter.length = s.size :=
   size_eq_length_iter.symm
 
+set_option linter.defProp false in
 @[deprecated length_iter_eq_size (since := "2026-01-28")]
 def count_iter_eq_size := @length_iter_eq_size
 

--- a/src/Std/Do/PredTrans.lean
+++ b/src/Std/Do/PredTrans.lean
@@ -48,6 +48,7 @@ postconditions.
 def PredTrans.Conjunctive (t : PostCond α ps → Assertion ps) : Prop :=
   ∀ Q₁ Q₂, t (Q₁ ∧ₚ Q₂) ⊣⊢ₛ t Q₁ ∧ t Q₂
 
+set_option linter.defProp false in
 /-- Any predicate transformer that is conjunctive is also monotonic. -/
 def PredTrans.Conjunctive.mono (t : PostCond α ps → Assertion ps) (h : PredTrans.Conjunctive t) : PredTrans.Monotonic t := by
   intro Q₁ Q₂ hq

--- a/src/Std/Do/PredTrans.lean
+++ b/src/Std/Do/PredTrans.lean
@@ -48,9 +48,8 @@ postconditions.
 def PredTrans.Conjunctive (t : PostCond α ps → Assertion ps) : Prop :=
   ∀ Q₁ Q₂, t (Q₁ ∧ₚ Q₂) ⊣⊢ₛ t Q₁ ∧ t Q₂
 
-set_option linter.defProp false in
 /-- Any predicate transformer that is conjunctive is also monotonic. -/
-def PredTrans.Conjunctive.mono (t : PostCond α ps → Assertion ps) (h : PredTrans.Conjunctive t) : PredTrans.Monotonic t := by
+theorem PredTrans.Conjunctive.mono (t : PostCond α ps → Assertion ps) (h : PredTrans.Conjunctive t) : PredTrans.Monotonic t := by
   intro Q₁ Q₂ hq
   replace hq : Q₁ = (Q₁ ∧ₚ Q₂) := PostCond.and_left_of_entails hq
   rw [hq, (h Q₁ Q₂).to_eq]

--- a/src/Std/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Do/Triple/SpecLemmas.lean
@@ -704,6 +704,7 @@ After running the loop body, the invariant then holds after shifting `x` to the 
 def Invariant {α : Type u₁} (xs : List α) (β : Type u₂) (ps : PostShape.{max u₁ u₂}) :=
   PostCond (List.Cursor xs × β) ps
 
+set_option linter.checkUnivs false in
 /--
 Helper definition for specifying loop invariants for loops with early return.
 
@@ -732,6 +733,7 @@ abbrev Invariant.withEarlyReturn {α} {xs : List α} {γ : Type (max u₁ u₂)}
       ∨ (∃ r, ⌜x = some r⌝ ∧ ⌜xs.suffix = []⌝ ∧ onReturn r b)),
    onExcept⟩
 
+set_option linter.checkUnivs false in
 /-- Like `Invariant.withEarlyReturn`, but for the new `do` elaborator which uses `Prod`
 instead of `MProd` for the state tuple. -/
 abbrev Invariant.withEarlyReturnNewDo {α} {xs : List α} {γ : Type (max u₁ u₂)}
@@ -2034,6 +2036,7 @@ A loop invariant is a `PostCond` that takes as parameters
 def StringInvariant (s : String) (β : Type u) (ps : PostShape.{u}) :=
   PostCond (s.Pos × β) ps
 
+set_option linter.checkUnivs false in
 /--
 Helper definition for specifying loop invariants for loops with early return.
 
@@ -2063,6 +2066,7 @@ abbrev StringInvariant.withEarlyReturn {s : String}
       ∨ (∃ r, ⌜x = some r⌝ ∧ ⌜pos = s.endPos⌝ ∧ onReturn r b)),
    onExcept⟩
 
+set_option linter.checkUnivs false in
 /-- Like `StringInvariant.withEarlyReturn`, but for the new `do` elaborator which uses `Prod`
 instead of `MProd` for the state tuple. -/
 abbrev StringInvariant.withEarlyReturnNewDo {s : String}
@@ -2119,6 +2123,7 @@ A loop invariant is a `PostCond` that takes as parameters
 def StringSliceInvariant (s : String.Slice) (β : Type u) (ps : PostShape.{u}) :=
   PostCond (s.Pos × β) ps
 
+set_option linter.checkUnivs false in
 /--
 Helper definition for specifying loop invariants for loops with early return.
 
@@ -2148,6 +2153,7 @@ abbrev StringSliceInvariant.withEarlyReturn {s : String.Slice}
       ∨ (∃ r, ⌜x = some r⌝ ∧ ⌜pos = s.endPos⌝ ∧ onReturn r b)),
    onExcept⟩
 
+set_option linter.checkUnivs false in
 /-- Like `StringSliceInvariant.withEarlyReturn`, but for the new `do` elaborator which uses `Prod`
 instead of `MProd` for the state tuple. -/
 abbrev StringSliceInvariant.withEarlyReturnNewDo {s : String.Slice}

--- a/src/lake/Lake/Util/EquipT.lean
+++ b/src/lake/Lake/Util/EquipT.lean
@@ -97,9 +97,11 @@ public instance (ε) [MonadExceptOf ε m] : MonadExceptOf ε (EquipT ρ m) where
   throw    := EquipT.throw
   tryCatch := EquipT.tryCatch
 
+set_option linter.checkUnivs false in
 @[always_inline, inline]
 public protected def tryFinally' [MonadFinally m] [Monad m]
   (x : EquipT ρ m α) (f : Option α → EquipT ρ m β)
 : EquipT ρ m (α × β) := fun ctx => tryFinally' (x.run ctx) (fun a? => f a? |>.run ctx)
 
+set_option linter.checkUnivs false in
 public instance [MonadFinally m] [Monad m] : MonadFinally (EquipT ρ m) := ⟨EquipT.tryFinally'⟩

--- a/tests/server_interactive/incrementalCombinator.lean
+++ b/tests/server_interactive/incrementalCombinator.lean
@@ -16,7 +16,7 @@ def case (h : a ∨ b ∨ c) : True := by
 -/
 
 -- RESET
-def case2 (h : a ∨ b ∨ c) : True := by
+theorem case2 (h : a ∨ b ∨ c) : True := by
   cases h
   case inl | inr =>
     skip

--- a/tests/server_interactive/incrementalCombinator.lean.out.expected
+++ b/tests/server_interactive/incrementalCombinator.lean.out.expected
@@ -9,10 +9,11 @@ c 2.5
  [{"source": "Lean 4",
    "severity": 2,
    "range":
-   {"start": {"line": 1, "character": 4}, "end": {"line": 1, "character": 9}},
+   {"start": {"line": 1, "character": 8}, "end": {"line": 1, "character": 13}},
    "message": "declaration uses `sorry`",
    "fullRange":
-   {"start": {"line": 1, "character": 4}, "end": {"line": 1, "character": 9}}}]}
+   {"start": {"line": 1, "character": 8},
+    "end": {"line": 1, "character": 13}}}]}
 d 0
 d 1
 d 2


### PR DESCRIPTION
This PR sets the default values of options controlling `defProp` and `checkUnivs` linters to true and does the appropriate adaptations to make that work.