### PR TITLE
feat: add document formatting fields to LSP ServerCapabilities

### DIFF
--- a/src/Lean/Data/Lsp/Capabilities.lean
+++ b/src/Lean/Data/Lsp/Capabilities.lean
@@ -136,6 +136,9 @@ structure ServerCapabilities where
   inlayHintProvider?        : Option InlayHintOptions        := none
   signatureHelpProvider?    : Option SignatureHelpOptions    := none
   colorProvider?            : Option DocumentColorOptions    := none
+  documentFormattingProvider?       : Option DocumentFormattingOptions       := none
+  documentRangeFormattingProvider?  : Option DocumentRangeFormattingOptions  := none
+  documentOnTypeFormattingProvider? : Option DocumentOnTypeFormattingOptions := none
   experimental?             : Option LeanServerCapabilities  := none
   deriving ToJson, FromJson
 

--- a/src/Lean/Data/Lsp/LanguageFeatures.lean
+++ b/src/Lean/Data/Lsp/LanguageFeatures.lean
@@ -725,5 +725,121 @@ structure ColorInformation where
 structure DocumentColorOptions extends WorkDoneProgressOptions where
   deriving FromJson, ToJson
 
+/--
+The format options used in the `textDocument/formatting`,
+`textDocument/rangeFormatting`, `textDocument/rangesFormatting`, and
+`textDocument/onTypeFormatting` requests.
+
+In addition to the well-known fields below, the LSP spec permits arbitrary
+server-specific properties (`[key: string]: boolean | integer | string`). Those
+extra keys are preserved verbatim in `additionalProperties` rather than being
+dropped, so this type round-trips faithfully.
+-/
+structure FormattingOptions where
+  /-- Size of a tab in spaces. -/
+  tabSize : Nat
+  /-- Prefer spaces over tabs. -/
+  insertSpaces : Bool
+  /-- Trim trailing whitespace on a line. -/
+  trimTrailingWhitespace? : Option Bool := none
+  /-- Insert a newline character at the end of the file if one does not exist. -/
+  insertFinalNewline? : Option Bool := none
+  /-- Trim all newlines after the final newline at the end of the file. -/
+  trimFinalNewlines? : Option Bool := none
+  /--
+  Additional, server-specific properties allowed by the spec's open
+  `[key: string]: boolean | integer | string` clause. This holds only the keys
+  that are not among the well-known fields above, as a JSON object (empty when
+  there are none).
+  -/
+  additionalProperties : Json := Json.mkObj []
+
+instance : ToJson FormattingOptions where
+  toJson o :=
+    let core := Json.mkObj <|
+      [("tabSize", toJson o.tabSize), ("insertSpaces", toJson o.insertSpaces)]
+      ++ Json.opt "trimTrailingWhitespace" o.trimTrailingWhitespace?
+      ++ Json.opt "insertFinalNewline" o.insertFinalNewline?
+      ++ Json.opt "trimFinalNewlines" o.trimFinalNewlines?
+    -- Merge the extras in first so the well-known fields always take precedence.
+    o.additionalProperties.mergeObj core
+
+instance : FromJson FormattingOptions where
+  fromJson? j := do
+    let obj ← j.getObj?
+    let tabSize ← j.getObjValAs? Nat "tabSize"
+    let insertSpaces ← j.getObjValAs? Bool "insertSpaces"
+    let trimTrailingWhitespace? ← j.getObjValAs? (Option Bool) "trimTrailingWhitespace"
+    let insertFinalNewline? ← j.getObjValAs? (Option Bool) "insertFinalNewline"
+    let trimFinalNewlines? ← j.getObjValAs? (Option Bool) "trimFinalNewlines"
+    -- Keys that are not well-known fields are preserved as additional properties.
+    let wellKnownFields := #["tabSize", "insertSpaces", "trimTrailingWhitespace",
+      "insertFinalNewline", "trimFinalNewlines"]
+    let additionalProperties := obj.foldl (init := Json.mkObj []) fun acc k v =>
+      if wellKnownFields.contains k then acc else acc.setObjVal! k v
+    return {
+      tabSize, insertSpaces, trimTrailingWhitespace?, insertFinalNewline?,
+      trimFinalNewlines?, additionalProperties
+    }
+
+/-- Params for the `textDocument/formatting` request. -/
+structure DocumentFormattingParams extends WorkDoneProgressParams where
+  textDocument : TextDocumentIdentifier
+  options : FormattingOptions
+  deriving FromJson, ToJson
+
+/-- Params for the `textDocument/rangeFormatting` request. -/
+structure DocumentRangeFormattingParams extends WorkDoneProgressParams where
+  textDocument : TextDocumentIdentifier
+  range : Range
+  options : FormattingOptions
+  deriving FromJson, ToJson
+
+/--
+Params for the `textDocument/rangesFormatting` request.
+
+The LSP 3.18 successor to `textDocument/rangeFormatting` that formats multiple
+ranges at once.
+-/
+structure DocumentRangesFormattingParams extends WorkDoneProgressParams where
+  textDocument : TextDocumentIdentifier
+  ranges : Array Range
+  options : FormattingOptions
+  deriving FromJson, ToJson
+
+/--
+Params for the `textDocument/onTypeFormatting` request.
+
+Unlike the other formatting params, this one does not carry a
+`WorkDoneProgressParams` mixin; extending `TextDocumentPositionParams` supplies
+the spec's `textDocument` and `position` fields.
+-/
+structure DocumentOnTypeFormattingParams extends TextDocumentPositionParams where
+  /-- The character that has been typed that triggered the on-type formatting request. -/
+  ch : String
+  options : FormattingOptions
+  deriving FromJson, ToJson
+
+/-- Server capability options for the `textDocument/formatting` request. -/
+structure DocumentFormattingOptions extends WorkDoneProgressOptions where
+  deriving FromJson, ToJson
+
+/-- Server capability options for the `textDocument/rangeFormatting` request. -/
+structure DocumentRangeFormattingOptions extends WorkDoneProgressOptions where
+  /--
+  Whether the server supports formatting multiple ranges at once via
+  `textDocument/rangesFormatting`. Added in LSP 3.18.
+  -/
+  rangesSupport? : Option Bool := none
+  deriving FromJson, ToJson
+
+/-- Server capability options for the `textDocument/onTypeFormatting` request. -/
+structure DocumentOnTypeFormattingOptions where
+  /-- A character on which formatting should be triggered, like `{`. -/
+  firstTriggerCharacter : String
+  /-- More trigger characters. -/
+  moreTriggerCharacter? : Option (Array String) := none
+  deriving FromJson, ToJson
+
 end Lsp
 end Lean

--- a/tests/elab/lspFormattingTypes.lean
+++ b/tests/elab/lspFormattingTypes.lean
@@ -1,0 +1,137 @@
+import Lean
+
+/-!
+Tests for the LSP `textDocument/formatting` protocol types in `Lean.Lsp`:
+`FormattingOptions`, the `*FormattingParams` request types, the
+`*FormattingOptions` server-capability types, and the formatting `*Provider?`
+fields wired into `ServerCapabilities`.
+
+These check both the exact wire shape against the LSP 3.17/3.18 specification and
+that the derived `FromJson`/`ToJson` instances round-trip.
+-/
+
+open Lean Lsp
+
+/-- `toJson` then `fromJson?` then `toJson` again yields the same `Json`. -/
+private def roundTrips {α} [FromJson α] [ToJson α] (a : α) : Bool :=
+  match (fromJson? (toJson a) : Except String α) with
+  | .ok b => toJson a == toJson b
+  | .error _ => false
+
+/-! ## `FormattingOptions` -/
+
+-- Minimal: the two required fields; optionals are omitted from the wire form.
+#guard
+  let o : FormattingOptions := { tabSize := 2, insertSpaces := true }
+  toJson o == json% { "tabSize": 2, "insertSpaces": true }
+
+-- Full: the optional `@since 3.15.0` fields are emitted when present.
+#guard
+  let o : FormattingOptions := {
+    tabSize := 4, insertSpaces := false,
+    trimTrailingWhitespace? := some true, insertFinalNewline? := some true,
+    trimFinalNewlines? := some false }
+  toJson o == json% { "tabSize": 4, "insertSpaces": false,
+    "trimTrailingWhitespace": true, "insertFinalNewline": true,
+    "trimFinalNewlines": false }
+
+-- Parsing leaves absent optionals as `none`.
+#guard
+  match (fromJson? (json% { "tabSize": 2, "insertSpaces": true }) : Except String FormattingOptions) with
+  | .ok o => o.tabSize == 2 && o.insertSpaces == true
+      && o.trimTrailingWhitespace? == none && o.insertFinalNewline? == none
+      && o.trimFinalNewlines? == none
+  | .error _ => false
+
+#guard roundTrips (α := FormattingOptions)
+  { tabSize := 4, insertSpaces := false, trimTrailingWhitespace? := some true }
+
+-- The spec's open `[key: string]` clause: server-specific keys are preserved
+-- (not dropped) and kept out of the well-known fields.
+#guard
+  let j := json% { "tabSize": 2, "insertSpaces": true,
+    "myServer.cleverness": 11, "myServer.style": "compact" }
+  match (fromJson? j : Except String FormattingOptions) with
+  | .ok o => o.tabSize == 2
+      && o.additionalProperties == json% { "myServer.cleverness": 11, "myServer.style": "compact" }
+  | .error _ => false
+
+-- Extras are emitted alongside the well-known fields.
+#guard
+  let o : FormattingOptions := {
+    tabSize := 2, insertSpaces := true
+    additionalProperties := json% { "myServer.cleverness": 11 } }
+  toJson o == json% { "tabSize": 2, "insertSpaces": true, "myServer.cleverness": 11 }
+
+#guard roundTrips (α := FormattingOptions)
+  { tabSize := 2, insertSpaces := true, additionalProperties := json% { "a": "b", "c": 3 } }
+
+/-! ## Request params -/
+
+#guard
+  let p : DocumentFormattingParams := {
+    textDocument := ⟨"file:///a.lean"⟩
+    options := { tabSize := 2, insertSpaces := true } }
+  toJson p == json% { "textDocument": { "uri": "file:///a.lean" },
+    "options": { "tabSize": 2, "insertSpaces": true } }
+
+#guard
+  let p : DocumentRangeFormattingParams := {
+    textDocument := ⟨"file:///a.lean"⟩
+    range := ⟨⟨0, 0⟩, ⟨1, 0⟩⟩
+    options := { tabSize := 2, insertSpaces := true } }
+  toJson p == json% { "textDocument": { "uri": "file:///a.lean" },
+    "range": { "start": { "line": 0, "character": 0 },
+      "end": { "line": 1, "character": 0 } },
+    "options": { "tabSize": 2, "insertSpaces": true } }
+
+#guard
+  let p : DocumentRangesFormattingParams := {
+    textDocument := ⟨"file:///a.lean"⟩
+    ranges := #[⟨⟨0, 0⟩, ⟨1, 0⟩⟩]
+    options := { tabSize := 2, insertSpaces := true } }
+  toJson p == json% { "textDocument": { "uri": "file:///a.lean" },
+    "ranges": [ { "start": { "line": 0, "character": 0 },
+      "end": { "line": 1, "character": 0 } } ],
+    "options": { "tabSize": 2, "insertSpaces": true } }
+
+-- `DocumentOnTypeFormattingParams` carries `position` and `ch`, and (unlike the
+-- others) no `workDoneToken` mixin.
+#guard
+  let p : DocumentOnTypeFormattingParams := {
+    textDocument := ⟨"file:///a.lean"⟩
+    position := ⟨3, 5⟩
+    ch := "}"
+    options := { tabSize := 2, insertSpaces := true } }
+  toJson p == json% { "textDocument": { "uri": "file:///a.lean" },
+    "position": { "line": 3, "character": 5 },
+    "ch": "}", "options": { "tabSize": 2, "insertSpaces": true } }
+
+#guard roundTrips (α := DocumentFormattingParams)
+  { textDocument := ⟨"file:///a.lean"⟩, options := { tabSize := 2, insertSpaces := true } }
+
+/-! ## Server-capability options -/
+
+#guard
+  let o : DocumentOnTypeFormattingOptions :=
+    { firstTriggerCharacter := "}", moreTriggerCharacter? := some #[";"] }
+  toJson o == json% { "firstTriggerCharacter": "}", "moreTriggerCharacter": [ ";" ] }
+
+#guard roundTrips (α := DocumentOnTypeFormattingOptions) { firstTriggerCharacter := "{" }
+#guard roundTrips (α := DocumentRangeFormattingOptions) { rangesSupport? := some true }
+#guard roundTrips (α := DocumentFormattingOptions) {}
+
+/-! ## `ServerCapabilities` exposes the three formatting providers -/
+
+#guard
+  let caps : ServerCapabilities := {
+    documentFormattingProvider? := some {}
+    documentRangeFormattingProvider? := some {}
+    documentOnTypeFormattingProvider? := some { firstTriggerCharacter := "}" }
+  }
+  match (fromJson? (toJson caps) : Except String ServerCapabilities) with
+  | .ok c =>
+    c.documentFormattingProvider?.isSome
+      && c.documentRangeFormattingProvider?.isSome
+      && c.documentOnTypeFormattingProvider?.map (·.firstTriggerCharacter) == some "}"
+  | .error _ => false


### PR DESCRIPTION
This PR adds fields `documentFormattingProvider`, `documentRangeFormattingProvider`, and `documentOnTypeFormattingProvider` to `ServerCapabilities` in `Lean.Data.Lsp.Capabilities`. They're part of the standard Language Server Protocol specification.

Link to `documentFormattingProvider` is [here](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_formatting); the remaining two fields are directly after it.

The Lean LSP itself doesn't really need this given that formatting Lean code is still a hard question, but for us Lean users implementing our own programming language and LSP in Lean, these fields are super helpful because users often expect a language to come with a formatter.

<!--
# Read this section before submitting

* Ensure your PR follows the [External Contribution Guidelines](https://github.com/leanprover/lean4/blob/master/CONTRIBUTING.md).
* Please make sure the PR has excellent documentation and tests. If we label it `missing documentation` or `missing tests` then it needs fixing!
* Include the link to your `RFC` or `bug` issue in the description.
* If the issue does not already have approval from a developer, submit the PR as draft.
* The PR title/description will become the commit message. Keep it up-to-date as the PR evolves.
* For `feat/fix` PRs, the first paragraph starting with "This PR" must be present and will become a
  changelog entry unless the PR is labeled with `no-changelog`. If the PR does not have this label,
  it must instead be categorized with one of the `changelog-*` labels (which will be done by a
  reviewer for external PRs).
* A toolchain of the form `leanprover/lean4-pr-releases:pr-release-NNNN` for Linux and M-series Macs will be generated upon build. To generate binaries for Windows and Intel-based Macs as well, write a comment containing `release-ci` on its own line.
* If you rebase your PR onto `nightly-with-mathlib` then CI will test Mathlib against your PR.
* You can manage the `awaiting-review`, `awaiting-author`, and `WIP` labels yourself, by writing a comment containing one of these labels on its own line.
* Remove this section, up to and including the `---` before submitting.
-->