### PR TITLE
feat: rework WP soundness as `WPSound`, add generic per-monad lemmas

### DIFF
--- a/src/Init/Control/Lawful/MonadAttach/Instances.lean
+++ b/src/Init/Control/Lawful/MonadAttach/Instances.lean
@@ -10,6 +10,7 @@ import Init.Control.Lawful.MonadAttach.Lemmas
 public import Init.Control.Lawful.Basic
 public import Init.Control.State
 public import Init.Control.StateRef
+public import Init.Control.EState
 public import Init.Ext
 
 public instance [Monad m] [LawfulMonad m] [MonadAttach m] [WeaklyLawfulMonadAttach m] :
@@ -77,6 +78,31 @@ public instance [Monad m] [MonadAttach m] [LawfulMonad m] [WeaklyLawfulMonadAtta
 public instance [Monad m] [MonadAttach m] [LawfulMonad m] [LawfulMonadAttach m] :
     LawfulMonadAttach (StateRefT' ω σ m) :=
   inferInstanceAs (LawfulMonadAttach (ReaderT (ST.Ref ω σ) m))
+
+public instance {ε σ : Type u} : WeaklyLawfulMonadAttach (EStateM ε σ) where
+  map_attach {α} {x} := by
+    funext s
+    show EStateM.map Subtype.val (MonadAttach.attach x) s = x s
+    simp only [EStateM.map, MonadAttach.attach]
+    split
+    · next a s' h =>
+      split at h
+      · next a₀ s₀ h_eq =>
+        injection h with ha hs_eq; subst hs_eq; cases ha; exact h_eq.symm
+      · cases h
+    · next e s' h =>
+      split at h
+      · cases h
+      · next e₀ s₀ h_eq =>
+        injection h with he hs_eq; subst he; subst hs_eq; exact h_eq.symm
+
+public instance {ε σ : Type u} : LawfulMonadAttach (EStateM ε σ) where
+  canReturn_map_imp {α P x a} h := by
+    simp only [MonadAttach.CanReturn, Functor.map, EStateM.map, EStateM.run] at h
+    obtain ⟨s, s', heq⟩ := h
+    split at heq
+    · next a₀ _ _ => injection heq with ha _; cases ha; exact a₀.property
+    · cases heq
 
 section
 

--- a/src/Std/Do/WP.lean
+++ b/src/Std/Do/WP.lean
@@ -9,6 +9,6 @@ prelude
 public import Std.Do.WP.Basic
 public import Std.Do.WP.Monad
 public import Std.Do.WP.SimpLemmas
-public import Std.Do.WP.Adequate
+public import Std.Do.WP.Sound
 
 set_option linter.missingDocs true

--- a/src/Std/Do/WP/Basic.lean
+++ b/src/Std/Do/WP/Basic.lean
@@ -112,15 +112,7 @@ instance Option.instWP : WP Option (.except PUnit .pure) :=
   inferInstanceAs (WP (OptionT Id) (.except PUnit .pure))
 
 /--
-Adequacy lemma for `Id.run`.
-Useful if you want to prove a property about an expression `x` defined as `Id.run prog` and you
-want to use `mvcgen` to reason about `prog`.
--/
-theorem Id.of_wp_run_eq {α : Type u} {x : α} {prog : Id α} (h : Id.run prog = x) (P : α → Prop) :
-  (⊢ₛ wp⟦prog⟧ (⇓ a => ⟨P a⟩)) → P x := h ▸ (· True.intro)
-
-/--
-Adequacy lemma for `StateM.run`.
+Soundness lemma for `StateM.run`.
 Useful if you want to prove a property about an expression `x` defined as `StateM.run prog s` and
 you want to use `mvcgen` to reason about `prog`.
 -/
@@ -128,7 +120,7 @@ theorem StateM.of_wp_run_eq {α} {x : α × σ} {prog : StateM σ α} (h : State
   (⊢ₛ wp⟦prog⟧ (⇓ a s' => ⌜P (a, s')⌝) s) → P x := h ▸ (· True.intro)
 
 /--
-Adequacy lemma for `StateM.run'`.
+Soundness lemma for `StateM.run'`.
 Useful if you want to prove a property about an expression `x` defined as `StateM.run' prog s` and
 you want to use `mvcgen` to reason about `prog`.
 -/
@@ -136,7 +128,7 @@ theorem StateM.of_wp_run'_eq {α} {x : α} {prog : StateM σ α} (h : StateT.run
   (⊢ₛ wp⟦prog⟧ (⇓ a => ⌜P a⌝) s) → P x := h ▸ (· True.intro)
 
 /--
-Adequacy lemma for `ReaderM.run`.
+Soundness lemma for `ReaderM.run`.
 Useful if you want to prove a property about an expression `x` defined as `ReaderM.run prog r` and
 you want to use `mvcgen` to reason about `prog`.
 -/
@@ -144,7 +136,7 @@ theorem ReaderM.of_wp_run_eq {α} {x : α} {prog : ReaderM ρ α} (h : ReaderT.r
   (⊢ₛ wp⟦prog⟧ (⇓ a _ => ⌜P a⌝) r) → P x := h ▸ (· True.intro)
 
 /--
-Adequacy lemma for `Except`.
+Soundness lemma for `Except`.
 Useful if you want to prove a property about a complex expression `prog : Except ε α` that you have
 generalized to a variable `x` and you want to use `mvcgen` to reason about `prog`.
 -/
@@ -156,7 +148,7 @@ theorem Except.of_wp_eq {ε α : Type u} {x prog : Except ε α} (h : prog = x) 
   split at hspec <;> exact hspec True.intro
 
 /--
-Adequacy lemma for `Except`.
+Soundness lemma for `Except`.
 Useful if you want to prove a property about an expression `prog : Except ε α` and you want to use
 `mvcgen` to reason about `prog`.
 -/
@@ -168,7 +160,7 @@ theorem Except.of_wp {ε α : Type u} {prog : Except ε α} (P : Except ε α �
   split at hspec <;> exact hspec True.intro
 
 /--
-Adequacy lemma for `Option`.
+Soundness lemma for `Option`.
 Useful if you want to prove a property about a complex expression `prog : Option α` that you have
 generalized to a variable `x` and you want to use `mvcgen` to reason about `prog`.
 -/
@@ -180,7 +172,7 @@ theorem Option.of_wp_eq {α : Type u} {x prog : Option α} (h : prog = x) (P : O
   split at hspec <;> exact hspec True.intro
 
 /--
-Adequacy lemma for `EStateM.run`.
+Soundness lemma for `EStateM.run`.
 Useful if you want to prove a property about an expression `x` defined as `EStateM.run prog s` and
 you want to use `mvcgen` to reason about `prog`.
 -/

--- a/src/Std/Do/WP/Basic.lean
+++ b/src/Std/Do/WP/Basic.lean
@@ -112,66 +112,6 @@ instance Option.instWP : WP Option (.except PUnit .pure) :=
   inferInstanceAs (WP (OptionT Id) (.except PUnit .pure))
 
 /--
-Soundness lemma for `StateM.run`.
-Useful if you want to prove a property about an expression `x` defined as `StateM.run prog s` and
-you want to use `mvcgen` to reason about `prog`.
--/
-theorem StateM.of_wp_run_eq {α} {x : α × σ} {prog : StateM σ α} (h : StateT.run prog s = x) (P : α × σ → Prop) :
-  (⊢ₛ wp⟦prog⟧ (⇓ a s' => ⌜P (a, s')⌝) s) → P x := h ▸ (· True.intro)
-
-/--
-Soundness lemma for `StateM.run'`.
-Useful if you want to prove a property about an expression `x` defined as `StateM.run' prog s` and
-you want to use `mvcgen` to reason about `prog`.
--/
-theorem StateM.of_wp_run'_eq {α} {x : α} {prog : StateM σ α} (h : StateT.run' prog s = x) (P : α → Prop) :
-  (⊢ₛ wp⟦prog⟧ (⇓ a => ⌜P a⌝) s) → P x := h ▸ (· True.intro)
-
-/--
-Soundness lemma for `ReaderM.run`.
-Useful if you want to prove a property about an expression `x` defined as `ReaderM.run prog r` and
-you want to use `mvcgen` to reason about `prog`.
--/
-theorem ReaderM.of_wp_run_eq {α} {x : α} {prog : ReaderM ρ α} (h : ReaderT.run prog r = x) (P : α → Prop) :
-  (⊢ₛ wp⟦prog⟧ (⇓ a _ => ⌜P a⌝) r) → P x := h ▸ (· True.intro)
-
-/--
-Soundness lemma for `Except`.
-Useful if you want to prove a property about a complex expression `prog : Except ε α` that you have
-generalized to a variable `x` and you want to use `mvcgen` to reason about `prog`.
--/
-theorem Except.of_wp_eq {ε α : Type u} {x prog : Except ε α} (h : prog = x) (P : Except ε α → Prop) :
-    (⊢ₛ wp⟦prog⟧ post⟨fun a => ⌜P (.ok a)⌝, fun e => ⌜P (.error e)⌝⟩) → P x := by
-  subst h
-  intro hspec
-  simp only [wp, ExceptT.run, Id.run, PredTrans.apply_pushExcept, PredTrans.apply_Pure_pure, instWP._aux_1] at hspec
-  split at hspec <;> exact hspec True.intro
-
-/--
-Soundness lemma for `Except`.
-Useful if you want to prove a property about an expression `prog : Except ε α` and you want to use
-`mvcgen` to reason about `prog`.
--/
-@[deprecated Except.of_wp_eq (since := "2026-01-26")]
-theorem Except.of_wp {ε α : Type u} {prog : Except ε α} (P : Except ε α → Prop) :
-    (⊢ₛ wp⟦prog⟧ post⟨fun a => ⌜P (.ok a)⌝, fun e => ⌜P (.error e)⌝⟩) → P prog := by
-  intro hspec
-  simp only [wp, ExceptT.run, Id.run, PredTrans.apply_pushExcept, PredTrans.apply_Pure_pure, instWP._aux_1] at hspec
-  split at hspec <;> exact hspec True.intro
-
-/--
-Soundness lemma for `Option`.
-Useful if you want to prove a property about a complex expression `prog : Option α` that you have
-generalized to a variable `x` and you want to use `mvcgen` to reason about `prog`.
--/
-theorem Option.of_wp_eq {α : Type u} {x prog : Option α} (h : prog = x) (P : Option α → Prop) :
-    (⊢ₛ wp⟦prog⟧ post⟨fun a => ⌜P (some a)⌝, fun _ => ⌜P none⌝⟩) → P x := by
-  subst h
-  intro hspec
-  simp only [wp, OptionT.run, Id.run, PredTrans.apply_pushOption, PredTrans.apply_Pure_pure, instWP._aux_1] at hspec
-  split at hspec <;> exact hspec True.intro
-
-/--
 Soundness lemma for `EStateM.run`.
 Useful if you want to prove a property about an expression `x` defined as `EStateM.run prog s` and
 you want to use `mvcgen` to reason about `prog`.

--- a/src/Std/Do/WP/Sound.lean
+++ b/src/Std/Do/WP/Sound.lean
@@ -7,41 +7,62 @@ module
 
 prelude
 public import Std.Do.WP.Monad
-public import Std.Do.Internal.Ensures.Def
+public import Std.Do.Internal.Ensures
 
 set_option linter.missingDocs true
 
 /-!
-# WP Adequacy
+# WP Soundness
 
-`WPAdequate m ps` provides a soundness bridge: if `wp x` proves a postcondition `P`,
-then `x` is `Internal.Ensures`-witnessed at `P`. Combined with `Internal.MayReturn x a`,
-this yields `P a` for any value `a` that `x` may classically return.
+`WPSound m ps` is the soundness bridge from `wp`-style reasoning to the operational
+`Internal.Ensures` predicate: if `wp x` proves a postcondition `P`, then `x` is
+`Internal.Ensures`-witnessed at `P`. Combined with `Internal.MayReturn x a`, this
+yields `P a` for any value `a` that `x` may classically return.
 -/
 
 namespace Std.Do
 
-/-- A small adequacy principle: a `wp`-provable postcondition is `Internal.Ensures`-witnessed. -/
-public class WPAdequate (m : Type u → Type v) (ps : outParam PostShape.{u}) [Monad m] [WP m ps] where
+/-- Soundness of `wp`: a `wp`-provable postcondition is `Internal.Ensures`-witnessed. -/
+public class WPSound (m : Type u → Type v) (ps : outParam PostShape.{u}) [Monad m] [WP m ps] where
   /-- A `wp`-provable postcondition refines `x` via `Internal.Ensures`. -/
   ensures_of_wp {α : Type u} {x : m α} {P : α → Prop} :
      (⊢ₛ wp⟦x⟧ (⇓? a => ⌜P a⌝)) → Internal.Ensures P x
 
-public instance : WPAdequate Id .pure where
+/--
+From a `wp`-provable postcondition and an `Internal.MayReturn` witness, conclude `P`
+at that value.
+-/
+public theorem WPSound.of_wp [Monad m] [WP m ps] [WPSound m ps]
+    {α : Type u} {x : m α} {a : α} {P : α → Prop}
+    (hmay : Internal.MayReturn x a) (hwp : ⊢ₛ wp⟦x⟧ (⇓? a => ⌜P a⌝)) : P a :=
+  hmay.imp (WPSound.ensures_of_wp hwp)
+
+/--
+From a `wp`-provable postcondition and a `MonadAttach.CanReturn` witness, conclude `P`
+at that value. Convenient when the monad has a `LawfulMonadAttach` instance, since
+`CanReturn` is typically definitional.
+-/
+public theorem WPSound.of_wp_canReturn [Monad m] [LawfulMonad m] [WP m ps] [WPSound m ps]
+    [MonadAttach m] [LawfulMonadAttach m]
+    {α : Type u} {x : m α} {a : α} {P : α → Prop}
+    (hcan : MonadAttach.CanReturn x a) (hwp : ⊢ₛ wp⟦x⟧ (⇓? a => ⌜P a⌝)) : P a :=
+  WPSound.of_wp (Internal.MayReturn.of_canReturn hcan) hwp
+
+public instance : WPSound Id .pure where
   ensures_of_wp hwp := ⟨⟨pure ⟨_, by simpa [WP.wp] using! hwp⟩, ⟨fun {_} _ => rfl⟩⟩⟩
 
-public instance [Monad m] [WP m ps] [WPAdequate m ps] :
-    WPAdequate (ReaderT ρ m) (.arg ρ ps) where
+public instance [Monad m] [WP m ps] [WPSound m ps] :
+    WPSound (ReaderT ρ m) (.arg ρ ps) where
   ensures_of_wp hwp := by
     obtain ⟨X, hX⟩ := Classical.skolem.mp fun r =>
-      (WPAdequate.ensures_of_wp (m := m) (ps := ps) (hwp r)).exists_refinement
+      (WPSound.ensures_of_wp (m := m) (ps := ps) (hwp r)).exists_refinement
     exact ⟨X, ⟨fun {β} k =>funext fun r => (hX r).bind_eq (fun a => (k a).run r)⟩⟩
 
-public instance [Monad m] [LawfulMonad m] [WP m ps] [WPAdequate m ps] :
-    WPAdequate (StateT σ m) (.arg σ ps) where
+public instance [Monad m] [LawfulMonad m] [WP m ps] [WPSound m ps] :
+    WPSound (StateT σ m) (.arg σ ps) where
   ensures_of_wp {α} {x} {P} hwp := by
     obtain ⟨X, hX⟩ := Classical.skolem.mp fun s =>
-      (WPAdequate.ensures_of_wp (m := m) (ps := ps) (hwp s)).exists_refinement
+      (WPSound.ensures_of_wp (m := m) (ps := ps) (hwp s)).exists_refinement
     refine ⟨⟨fun s => X s >>= fun r => pure (⟨r.val.1, r.property⟩, r.val.2), ⟨fun {β} k =>funext fun s => ?_⟩⟩⟩
     show (X s >>= fun r : {p : α × σ // P p.1} => pure (⟨r.val.1, r.property⟩, r.val.2)) >>=
          (fun (b : {a // P a} × σ) => (k b.1.val).run b.2) =
@@ -49,15 +70,15 @@ public instance [Monad m] [LawfulMonad m] [WP m ps] [WPAdequate m ps] :
     rw [bind_assoc]; simp only [pure_bind]
     exact (hX s).bind_eq (fun r : α × σ => (k r.1).run r.2)
 
-public instance [Monad m] [LawfulMonad m] [WP m .pure] [WPAdequate m .pure] :
-    WPAdequate (ExceptT ε m) (.except ε .pure) where
+public instance [Monad m] [LawfulMonad m] [WP m .pure] [WPSound m .pure] :
+    WPSound (ExceptT ε m) (.except ε .pure) where
   ensures_of_wp {α} {x} {P} hwp := by
     have hwp_inner : ⊢ₛ wp⟦x.run⟧
         (⇓? r => ⌜match r with | .ok a => P a | .error _ => True⌝) := by
       simp only [WP.wp, PredTrans.apply_pushExcept, ExceptConds.fst_true, ExceptConds.snd_true] at hwp
       apply SPred.entails.trans hwp; apply (wp x.run).mono
       simp [PostCond.entails]; intro r <;> cases r <;> simp
-    obtain ⟨X, hX⟩ := (WPAdequate.ensures_of_wp (m := m) (ps := .pure) hwp_inner).exists_refinement
+    obtain ⟨X, hX⟩ := (WPSound.ensures_of_wp (m := m) (ps := .pure) hwp_inner).exists_refinement
     refine ⟨⟨ExceptT.mk (X >>= fun ⟨r, h⟩ => match r, h with
       | .ok a, hp => pure (.ok ⟨a, hp⟩)
       | .error e, _ => pure (.error e)), ⟨fun {β} k =>?_⟩⟩⟩
@@ -66,15 +87,15 @@ public instance [Monad m] [LawfulMonad m] [WP m .pure] [WPAdequate m .pure] :
     refine Eq.trans ?_ (hX.bind_eq (β := Except ε β) (ExceptT.bindCont k))
     exact bind_congr fun ⟨r, _⟩ => by cases r <;> simp [pure_bind, ExceptT.bindCont]
 
-public instance [Monad m] [LawfulMonad m] [WP m .pure] [WPAdequate m .pure] :
-    WPAdequate (OptionT m) (.except PUnit .pure) where
+public instance [Monad m] [LawfulMonad m] [WP m .pure] [WPSound m .pure] :
+    WPSound (OptionT m) (.except PUnit .pure) where
   ensures_of_wp {α} {x} {P} hwp := by
     have hwp_inner : ⊢ₛ wp⟦x.run⟧
         (⇓? r => ⌜match r with | some a => P a | none => True⌝) := by
       simp only [WP.wp, PredTrans.apply_pushOption, ExceptConds.fst_true, ExceptConds.snd_true] at hwp
       apply SPred.entails.trans hwp; apply (wp x.run).mono
       simp [PostCond.entails]; intro r <;> cases r <;> simp
-    obtain ⟨X, hX⟩ := (WPAdequate.ensures_of_wp (m := m) (ps := .pure) hwp_inner).exists_refinement
+    obtain ⟨X, hX⟩ := (WPSound.ensures_of_wp (m := m) (ps := .pure) hwp_inner).exists_refinement
     refine ⟨⟨OptionT.mk (X >>= fun ⟨r, h⟩ => match r, h with
       | some a, hp => pure (some ⟨a, hp⟩)
       | none, _ => pure none), ⟨fun {β} k =>?_⟩⟩⟩
@@ -83,5 +104,14 @@ public instance [Monad m] [LawfulMonad m] [WP m .pure] [WPAdequate m .pure] :
     refine Eq.trans ?_
       (hX.bind_eq (β := Option β) (fun r => match r with | some a => (k a).run | none => pure none))
     exact bind_congr fun ⟨r, _⟩ => by cases r <;> simp [pure_bind, OptionT.run]
+
+/--
+Soundness lemma for `Id.run`. Derived from `WPSound.of_wp_canReturn`: `Id.run prog = x`
+is the `MonadAttach.CanReturn prog x` witness.
+-/
+public theorem Id.of_wp_run_eq {α : Type u} {x : α} {prog : _root_.Id α}
+    (h : _root_.Id.run prog = x) (P : α → Prop) :
+    (⊢ₛ wp⟦prog⟧ (⇓ a => ⟨P a⟩)) → P x := fun hwp =>
+  WPSound.of_wp_canReturn (m := _root_.Id) (P := P) (x := prog) (a := x) h hwp
 
 end Std.Do

--- a/src/Std/Do/WP/Sound.lean
+++ b/src/Std/Do/WP/Sound.lean
@@ -114,4 +114,105 @@ public theorem Id.of_wp_run_eq {α : Type u} {x : α} {prog : _root_.Id α}
     (⊢ₛ wp⟦prog⟧ (⇓ a => ⟨P a⟩)) → P x := fun hwp =>
   WPSound.of_wp_canReturn (m := _root_.Id) (P := P) (x := prog) (a := x) h hwp
 
+/--
+Soundness lemma for `ReaderT.run`: at any read parameter `r`, a `wp`-provable
+postcondition refines the post-run computation `prog.run r : m α` via `Internal.Ensures`.
+-/
+public theorem ReaderT.of_wp_run_eq [Monad m] [WP m ps] [WPSound m ps]
+    {α : Type u} {ρ : Type u} {prog : ReaderT ρ m α} (r : ρ) (P : α → Prop)
+    (hwp : ⊢ₛ wp⟦prog⟧ (⇓? a => ⌜P a⌝) r) :
+    Internal.Ensures P (prog.run r) := by
+  apply WPSound.ensures_of_wp
+  simp only [WP.wp, PredTrans.apply_pushArg] at hwp
+  exact hwp
+
+/-- Soundness lemma for `ReaderM.run`: `Id`-specialization of `ReaderT.of_wp_run_eq`. -/
+public theorem ReaderM.of_wp_run_eq {α ρ : Type u} {x : α} {r : ρ} {prog : ReaderM ρ α}
+    (h : ReaderT.run prog r = x) (P : α → Prop) :
+    (⊢ₛ wp⟦prog⟧ (⇓ a _ => ⌜P a⌝) r) → P x := fun hwp =>
+  (Internal.MayReturn.of_canReturn (m := _root_.Id) (x := prog.run r) (a := x) h).imp
+    (ReaderT.of_wp_run_eq r P hwp)
+
+/--
+Soundness lemma for `StateT.run`: at any initial state `s`, a `wp`-provable
+postcondition refines the post-run computation `prog.run s : m (α × σ)` via
+`Internal.Ensures`.
+-/
+public theorem StateT.of_wp_run_eq [Monad m] [WP m ps] [WPSound m ps]
+    {α σ : Type u} {prog : StateT σ m α} (s : σ) (P : α × σ → Prop)
+    (hwp : ⊢ₛ wp⟦prog⟧ (⇓ a s' => ⌜P (a, s')⌝) s) :
+    Internal.Ensures P (prog.run s) := by
+  apply WPSound.ensures_of_wp
+  simp only [WP.wp, PredTrans.apply_pushArg] at hwp
+  apply SPred.entails.trans hwp
+  apply (wp (prog.run s)).mono
+  refine ⟨fun _ => SPred.entails.refl _, by simp⟩
+
+/-- Soundness lemma for `StateM.run`: `Id`-specialization of `StateT.of_wp_run_eq`. -/
+public theorem StateM.of_wp_run_eq {α σ : Type} {x : α × σ} {s : σ} {prog : StateM σ α}
+    (h : StateT.run prog s = x) (P : α × σ → Prop) :
+    (⊢ₛ wp⟦prog⟧ (⇓ a s' => ⌜P (a, s')⌝) s) → P x := fun hwp =>
+  (Internal.MayReturn.of_canReturn (m := _root_.Id) (x := prog.run s) (a := x) h).imp
+    (StateT.of_wp_run_eq s P hwp)
+
+/-- Soundness lemma for `StateM.run'`: `Id`-specialization of `StateT.of_wp_run_eq`. -/
+public theorem StateM.of_wp_run'_eq {α σ : Type} {x : α} {s : σ} {prog : StateM σ α}
+    (h : StateT.run' prog s = x) (P : α → Prop) :
+    (⊢ₛ wp⟦prog⟧ (⇓ a => ⌜P a⌝) s) → P x := fun hwp =>
+  let hens := StateT.of_wp_run_eq s (fun p => P p.1) hwp
+  let hcan : MonadAttach.CanReturn (m := _root_.Id) (prog.run s) (StateT.run prog s) := rfl
+  h ▸ (Internal.MayReturn.of_canReturn hcan).imp hens
+
+/--
+Soundness lemma for `ExceptT.run`: a `wp`-provable postcondition with split
+`.ok`/`.error` postconditions refines the post-run computation
+`prog.run : m (Except ε α)` via `Internal.Ensures`.
+-/
+public theorem ExceptT.of_wp_run_eq [Monad m] [LawfulMonad m] [WP m .pure] [WPSound m .pure]
+    {ε α : Type u} {prog : ExceptT ε m α} (P : Except ε α → Prop)
+    (hwp : ⊢ₛ wp⟦prog⟧ post⟨fun a => ⌜P (.ok a)⌝, fun e => ⌜P (.error e)⌝⟩) :
+    Internal.Ensures P prog.run := by
+  apply WPSound.ensures_of_wp (m := m) (ps := .pure)
+  simp only [WP.wp, PredTrans.apply_pushExcept] at hwp
+  apply SPred.entails.trans hwp
+  apply (wp prog.run).mono
+  refine ⟨fun a => ?_, by simp⟩
+  cases a <;> simp
+
+/-- Soundness lemma for `Except`: `Id`-specialization of `ExceptT.of_wp_run_eq`. -/
+public theorem Except.of_wp_eq {ε α : Type} {x prog : Except ε α}
+    (h : prog = x) (P : Except ε α → Prop) :
+    (⊢ₛ wp⟦prog⟧ post⟨fun a => ⌜P (.ok a)⌝, fun e => ⌜P (.error e)⌝⟩) → P x := fun hwp =>
+  (Internal.MayReturn.of_canReturn (m := _root_.Id) (x := (prog : Id (Except ε α))) (a := x) h).imp
+    (ExceptT.of_wp_run_eq (m := _root_.Id) (prog := prog) P hwp)
+
+/-- Soundness lemma for `Except` without the equality hypothesis (deprecated). -/
+@[deprecated Except.of_wp_eq (since := "2026-01-26")]
+public theorem Except.of_wp {ε α : Type} {prog : Except ε α} (P : Except ε α → Prop) :
+    (⊢ₛ wp⟦prog⟧ post⟨fun a => ⌜P (.ok a)⌝, fun e => ⌜P (.error e)⌝⟩) → P prog :=
+  Except.of_wp_eq rfl P
+
+/--
+Soundness lemma for `OptionT.run`: a `wp`-provable postcondition with split
+`some`/`none` postconditions refines the post-run computation
+`prog.run : m (Option α)` via `Internal.Ensures`.
+-/
+public theorem OptionT.of_wp_run_eq [Monad m] [LawfulMonad m] [WP m .pure] [WPSound m .pure]
+    {α : Type u} {prog : OptionT m α} (P : Option α → Prop)
+    (hwp : ⊢ₛ wp⟦prog⟧ post⟨fun a => ⌜P (some a)⌝, fun _ => ⌜P none⌝⟩) :
+    Internal.Ensures P prog.run := by
+  apply WPSound.ensures_of_wp (m := m) (ps := .pure)
+  simp only [WP.wp, PredTrans.apply_pushOption] at hwp
+  apply SPred.entails.trans hwp
+  apply (wp prog.run).mono
+  refine ⟨fun a => ?_, by simp⟩
+  cases a <;> simp
+
+/-- Soundness lemma for `Option`: `Id`-specialization of `OptionT.of_wp_run_eq`. -/
+public theorem Option.of_wp_eq {α : Type} {x prog : Option α}
+    (h : prog = x) (P : Option α → Prop) :
+    (⊢ₛ wp⟦prog⟧ post⟨fun a => ⌜P (some a)⌝, fun _ => ⌜P none⌝⟩) → P x := fun hwp =>
+  (Internal.MayReturn.of_canReturn (m := _root_.Id) (x := (prog : Id (Option α))) (a := x) h).imp
+    (OptionT.of_wp_run_eq (m := _root_.Id) (prog := prog) P hwp)
+
 end Std.Do

--- a/src/Std/Do/WP/Sound.lean
+++ b/src/Std/Do/WP/Sound.lean
@@ -8,6 +8,7 @@ module
 prelude
 public import Std.Do.WP.Monad
 public import Std.Do.Internal.Ensures
+public import Init.Control.Lawful.MonadAttach.Instances
 
 set_option linter.missingDocs true
 
@@ -104,6 +105,15 @@ public instance [Monad m] [LawfulMonad m] [WP m .pure] [WPSound m .pure] :
     refine Eq.trans ?_
       (hX.bind_eq (β := Option β) (fun r => match r with | some a => (k a).run | none => pure none))
     exact bind_congr fun ⟨r, _⟩ => by cases r <;> simp [pure_bind, OptionT.run]
+
+public instance : WPSound (EStateM ε σ) (.except ε (.arg σ .pure)) where
+  ensures_of_wp {α} {x} {P} hwp :=
+    Internal.Ensures.canReturn.weaken fun a (hcan : MonadAttach.CanReturn x a) => by
+      obtain ⟨s, s', heq⟩ := hcan
+      have hs := hwp s True.intro
+      simp only [WP.wp, PredTrans.apply] at hs
+      rw [heq] at hs
+      exact hs
 
 /--
 Soundness lemma for `Id.run`. Derived from `WPSound.of_wp_canReturn`: `Id.run prog = x`

--- a/src/Std/Do/WP/Sound.lean
+++ b/src/Std/Do/WP/Sound.lean
@@ -114,11 +114,20 @@ public theorem Id.of_wp_run_eq {α : Type u} {x : α} {prog : _root_.Id α}
     (⊢ₛ wp⟦prog⟧ (⇓ a => ⟨P a⟩)) → P x := fun hwp =>
   WPSound.of_wp_canReturn (m := _root_.Id) (P := P) (x := prog) (a := x) h hwp
 
-/--
-Soundness lemma for `ReaderT.run`: at any read parameter `r`, a `wp`-provable
-postcondition refines the post-run computation `prog.run r : m α` via `Internal.Ensures`.
+/-! ### Per-transformer soundness lemmas
+
+For each transformer `T`, `T.ensures_of_wp_run` produces an `Internal.Ensures` over the post-run
+computation `prog.run «args» : m _`. `T.of_wp_run` further collapses this to a pure proposition
+`P a` when the base monad `m` has `LawfulMonadAttach` and the caller can supply a
+`MonadAttach.CanReturn` witness — the natural generalization of the `Id`-specialized
+`*.of_wp_run_eq` family below.
 -/
-public theorem ReaderT.of_wp_run_eq [Monad m] [WP m ps] [WPSound m ps]
+
+/--
+A `wp`-provable postcondition refines the post-run computation `prog.run r : m α`
+via `Internal.Ensures`.
+-/
+public theorem ReaderT.ensures_of_wp_run [Monad m] [WP m ps] [WPSound m ps]
     {α : Type u} {ρ : Type u} {prog : ReaderT ρ m α} (r : ρ) (P : α → Prop)
     (hwp : ⊢ₛ wp⟦prog⟧ (⇓? a => ⌜P a⌝) r) :
     Internal.Ensures P (prog.run r) := by
@@ -126,19 +135,28 @@ public theorem ReaderT.of_wp_run_eq [Monad m] [WP m ps] [WPSound m ps]
   simp only [WP.wp, PredTrans.apply_pushArg] at hwp
   exact hwp
 
-/-- Soundness lemma for `ReaderM.run`: `Id`-specialization of `ReaderT.of_wp_run_eq`. -/
+/--
+Pure-proposition soundness: from a `MonadAttach.CanReturn` witness for `prog.run r` and a
+`wp`-provable postcondition, conclude `P a`.
+-/
+public theorem ReaderT.of_wp_run [Monad m] [LawfulMonad m] [WP m ps] [WPSound m ps]
+    [MonadAttach m] [LawfulMonadAttach m]
+    {α : Type u} {ρ : Type u} {prog : ReaderT ρ m α} {r : ρ} {a : α} (P : α → Prop)
+    (hcan : MonadAttach.CanReturn (prog.run r) a)
+    (hwp : ⊢ₛ wp⟦prog⟧ (⇓? a => ⌜P a⌝) r) : P a :=
+  (Internal.MayReturn.of_canReturn hcan).imp (ReaderT.ensures_of_wp_run r P hwp)
+
+/-- Soundness lemma for `ReaderM.run`: `Id`-specialization of `ReaderT.of_wp_run`. -/
 public theorem ReaderM.of_wp_run_eq {α ρ : Type u} {x : α} {r : ρ} {prog : ReaderM ρ α}
     (h : ReaderT.run prog r = x) (P : α → Prop) :
     (⊢ₛ wp⟦prog⟧ (⇓ a _ => ⌜P a⌝) r) → P x := fun hwp =>
-  (Internal.MayReturn.of_canReturn (m := _root_.Id) (x := prog.run r) (a := x) h).imp
-    (ReaderT.of_wp_run_eq r P hwp)
+  ReaderT.of_wp_run (m := _root_.Id) (a := x) P h hwp
 
 /--
-Soundness lemma for `StateT.run`: at any initial state `s`, a `wp`-provable
-postcondition refines the post-run computation `prog.run s : m (α × σ)` via
-`Internal.Ensures`.
+A `wp`-provable postcondition refines the post-run computation `prog.run s : m (α × σ)`
+via `Internal.Ensures`.
 -/
-public theorem StateT.of_wp_run_eq [Monad m] [WP m ps] [WPSound m ps]
+public theorem StateT.ensures_of_wp_run [Monad m] [WP m ps] [WPSound m ps]
     {α σ : Type u} {prog : StateT σ m α} (s : σ) (P : α × σ → Prop)
     (hwp : ⊢ₛ wp⟦prog⟧ (⇓ a s' => ⌜P (a, s')⌝) s) :
     Internal.Ensures P (prog.run s) := by
@@ -148,27 +166,35 @@ public theorem StateT.of_wp_run_eq [Monad m] [WP m ps] [WPSound m ps]
   apply (wp (prog.run s)).mono
   refine ⟨fun _ => SPred.entails.refl _, by simp⟩
 
-/-- Soundness lemma for `StateM.run`: `Id`-specialization of `StateT.of_wp_run_eq`. -/
+/-- Pure-proposition soundness for `StateT.run`, generalizing `StateM.of_wp_run_eq`. -/
+public theorem StateT.of_wp_run [Monad m] [LawfulMonad m] [WP m ps] [WPSound m ps]
+    [MonadAttach m] [LawfulMonadAttach m]
+    {α σ : Type u} {prog : StateT σ m α} {s : σ} {p : α × σ} (P : α × σ → Prop)
+    (hcan : MonadAttach.CanReturn (prog.run s) p)
+    (hwp : ⊢ₛ wp⟦prog⟧ (⇓ a s' => ⌜P (a, s')⌝) s) : P p :=
+  (Internal.MayReturn.of_canReturn hcan).imp (StateT.ensures_of_wp_run s P hwp)
+
+/-- Soundness lemma for `StateM.run`: `Id`-specialization of `StateT.of_wp_run`. -/
 public theorem StateM.of_wp_run_eq {α σ : Type} {x : α × σ} {s : σ} {prog : StateM σ α}
     (h : StateT.run prog s = x) (P : α × σ → Prop) :
     (⊢ₛ wp⟦prog⟧ (⇓ a s' => ⌜P (a, s')⌝) s) → P x := fun hwp =>
-  (Internal.MayReturn.of_canReturn (m := _root_.Id) (x := prog.run s) (a := x) h).imp
-    (StateT.of_wp_run_eq s P hwp)
+  StateT.of_wp_run (m := _root_.Id) (p := x) P h hwp
 
-/-- Soundness lemma for `StateM.run'`: `Id`-specialization of `StateT.of_wp_run_eq`. -/
+/-- Soundness lemma for `StateM.run'`: `Id`-specialization of `StateT.of_wp_run`. -/
 public theorem StateM.of_wp_run'_eq {α σ : Type} {x : α} {s : σ} {prog : StateM σ α}
     (h : StateT.run' prog s = x) (P : α → Prop) :
-    (⊢ₛ wp⟦prog⟧ (⇓ a => ⌜P a⌝) s) → P x := fun hwp =>
-  let hens := StateT.of_wp_run_eq s (fun p => P p.1) hwp
-  let hcan : MonadAttach.CanReturn (m := _root_.Id) (prog.run s) (StateT.run prog s) := rfl
-  h ▸ (Internal.MayReturn.of_canReturn hcan).imp hens
+    (⊢ₛ wp⟦prog⟧ (⇓ a => ⌜P a⌝) s) → P x := fun hwp => by
+  have hwp' : ⊢ₛ wp⟦prog⟧ (⇓ a s' => ⌜(fun p : α × σ => P p.1) (a, s')⌝) s := hwp
+  have := StateT.of_wp_run (m := _root_.Id) (prog := prog) (s := s) (p := StateT.run prog s)
+    (fun p => P p.1) rfl hwp'
+  exact h ▸ this
 
 /--
-Soundness lemma for `ExceptT.run`: a `wp`-provable postcondition with split
-`.ok`/`.error` postconditions refines the post-run computation
+A `wp`-provable postcondition with split `.ok`/`.error` cases refines the post-run computation
 `prog.run : m (Except ε α)` via `Internal.Ensures`.
 -/
-public theorem ExceptT.of_wp_run_eq [Monad m] [LawfulMonad m] [WP m .pure] [WPSound m .pure]
+public theorem ExceptT.ensures_of_wp_run
+    [Monad m] [LawfulMonad m] [WP m .pure] [WPSound m .pure]
     {ε α : Type u} {prog : ExceptT ε m α} (P : Except ε α → Prop)
     (hwp : ⊢ₛ wp⟦prog⟧ post⟨fun a => ⌜P (.ok a)⌝, fun e => ⌜P (.error e)⌝⟩) :
     Internal.Ensures P prog.run := by
@@ -179,12 +205,20 @@ public theorem ExceptT.of_wp_run_eq [Monad m] [LawfulMonad m] [WP m .pure] [WPSo
   refine ⟨fun a => ?_, by simp⟩
   cases a <;> simp
 
-/-- Soundness lemma for `Except`: `Id`-specialization of `ExceptT.of_wp_run_eq`. -/
+/-- Pure-proposition soundness for `ExceptT.run`, generalizing `Except.of_wp_eq`. -/
+public theorem ExceptT.of_wp_run
+    [Monad m] [LawfulMonad m] [WP m .pure] [WPSound m .pure]
+    [MonadAttach m] [LawfulMonadAttach m]
+    {ε α : Type u} {prog : ExceptT ε m α} {x : Except ε α} (P : Except ε α → Prop)
+    (hcan : MonadAttach.CanReturn prog.run x)
+    (hwp : ⊢ₛ wp⟦prog⟧ post⟨fun a => ⌜P (.ok a)⌝, fun e => ⌜P (.error e)⌝⟩) : P x :=
+  (Internal.MayReturn.of_canReturn hcan).imp (ExceptT.ensures_of_wp_run P hwp)
+
+/-- Soundness lemma for `Except`: `Id`-specialization of `ExceptT.of_wp_run`. -/
 public theorem Except.of_wp_eq {ε α : Type} {x prog : Except ε α}
     (h : prog = x) (P : Except ε α → Prop) :
     (⊢ₛ wp⟦prog⟧ post⟨fun a => ⌜P (.ok a)⌝, fun e => ⌜P (.error e)⌝⟩) → P x := fun hwp =>
-  (Internal.MayReturn.of_canReturn (m := _root_.Id) (x := (prog : Id (Except ε α))) (a := x) h).imp
-    (ExceptT.of_wp_run_eq (m := _root_.Id) (prog := prog) P hwp)
+  ExceptT.of_wp_run (m := _root_.Id) (prog := prog) (x := x) P h hwp
 
 /-- Soundness lemma for `Except` without the equality hypothesis (deprecated). -/
 @[deprecated Except.of_wp_eq (since := "2026-01-26")]
@@ -193,11 +227,11 @@ public theorem Except.of_wp {ε α : Type} {prog : Except ε α} (P : Except ε 
   Except.of_wp_eq rfl P
 
 /--
-Soundness lemma for `OptionT.run`: a `wp`-provable postcondition with split
-`some`/`none` postconditions refines the post-run computation
+A `wp`-provable postcondition with split `some`/`none` cases refines the post-run computation
 `prog.run : m (Option α)` via `Internal.Ensures`.
 -/
-public theorem OptionT.of_wp_run_eq [Monad m] [LawfulMonad m] [WP m .pure] [WPSound m .pure]
+public theorem OptionT.ensures_of_wp_run
+    [Monad m] [LawfulMonad m] [WP m .pure] [WPSound m .pure]
     {α : Type u} {prog : OptionT m α} (P : Option α → Prop)
     (hwp : ⊢ₛ wp⟦prog⟧ post⟨fun a => ⌜P (some a)⌝, fun _ => ⌜P none⌝⟩) :
     Internal.Ensures P prog.run := by
@@ -208,11 +242,19 @@ public theorem OptionT.of_wp_run_eq [Monad m] [LawfulMonad m] [WP m .pure] [WPSo
   refine ⟨fun a => ?_, by simp⟩
   cases a <;> simp
 
-/-- Soundness lemma for `Option`: `Id`-specialization of `OptionT.of_wp_run_eq`. -/
+/-- Pure-proposition soundness for `OptionT.run`, generalizing `Option.of_wp_eq`. -/
+public theorem OptionT.of_wp_run
+    [Monad m] [LawfulMonad m] [WP m .pure] [WPSound m .pure]
+    [MonadAttach m] [LawfulMonadAttach m]
+    {α : Type u} {prog : OptionT m α} {x : Option α} (P : Option α → Prop)
+    (hcan : MonadAttach.CanReturn prog.run x)
+    (hwp : ⊢ₛ wp⟦prog⟧ post⟨fun a => ⌜P (some a)⌝, fun _ => ⌜P none⌝⟩) : P x :=
+  (Internal.MayReturn.of_canReturn hcan).imp (OptionT.ensures_of_wp_run P hwp)
+
+/-- Soundness lemma for `Option`: `Id`-specialization of `OptionT.of_wp_run`. -/
 public theorem Option.of_wp_eq {α : Type} {x prog : Option α}
     (h : prog = x) (P : Option α → Prop) :
     (⊢ₛ wp⟦prog⟧ post⟨fun a => ⌜P (some a)⌝, fun _ => ⌜P none⌝⟩) → P x := fun hwp =>
-  (Internal.MayReturn.of_canReturn (m := _root_.Id) (x := (prog : Id (Option α))) (a := x) h).imp
-    (OptionT.of_wp_run_eq (m := _root_.Id) (prog := prog) P hwp)
+  OptionT.of_wp_run (m := _root_.Id) (prog := prog) (x := x) P h hwp
 
 end Std.Do

--- a/src/Std/Internal/Do/WP/Basic.lean
+++ b/src/Std/Internal/Do/WP/Basic.lean
@@ -352,20 +352,20 @@ instance EStateM.instWPMonad : WPMonad (EStateM ε σ) (σ → Prop) (ε → σ 
       simpa [hxs] using hepost el s'
 
 /-!
-## Adequacy Lemmas
+## Soundness Lemmas
 
 These lemmas bridge `wp` reasoning to concrete program properties. Each one says:
 if `wp prog ...` holds, then a property `P` holds of the program's result.
 -/
 
-/-- Adequacy for `Id`: if `wp prog P` holds, then `P` holds of the result. -/
+/-- Soundness for `Id`: if `wp prog P` holds, then `P` holds of the result. -/
 theorem Id.of_wp_run_eq {α : Type u} {x : α} {prog : Id α}
   (h : Id.run prog = x) (P : α → Prop)
   (hwp : wp prog P EPost.nil.mk) : P x := by
   rw [← h]
   exact hwp
 
-/-- Adequacy for `Option`: if `wp prog P` holds, then `P` holds of the result. -/
+/-- Soundness for `Option`: if `wp prog P` holds, then `P` holds of the result. -/
 theorem Option.of_wp_eq {α : Type u} {x prog : Option α}
   (h : prog = x) (P : Option α → Prop)
   (hwp : wp prog (fun a => P (some a)) (P none)) : P x := by
@@ -374,28 +374,28 @@ theorem Option.of_wp_eq {α : Type u} {x prog : Option α}
   | none => exact hwp
   | some a => exact hwp
 
-/-- Adequacy for `StateM`: if `wp prog P s` holds, then `P` holds of `(prog.run s)`. -/
+/-- Soundness for `StateM`: if `wp prog P s` holds, then `P` holds of `(prog.run s)`. -/
 theorem StateM.of_wp_run_eq {x : α × σ} {prog : StateM σ α} {s : σ}
   (h : StateT.run prog s = x) (P : α × σ → Prop)
   (hwp : wp prog (fun a s' => P (a, s')) EPost.nil.mk s) : P x := by
   rw [← h]
   exact hwp
 
-/-- Adequacy for `StateM` (discarding final state). -/
+/-- Soundness for `StateM` (discarding final state). -/
 theorem StateM.of_wp_run'_eq {α σ : Type} {x : α} {prog : StateM σ α} {s : σ}
   (h : StateT.run' prog s = x) (P : α → Prop)
   (hwp : wp prog (fun a _ => P a) EPost.nil.mk s) : P x := by
   rw [← h]
   exact hwp
 
-/-- Adequacy for `ReaderM`: if `wp prog P r` holds, then `P` holds of `(prog.run r)`. -/
+/-- Soundness for `ReaderM`: if `wp prog P r` holds, then `P` holds of `(prog.run r)`. -/
 theorem ReaderM.of_wp_run_eq {α ρ : Type} {x : α} {prog : ReaderM ρ α} {r : ρ}
   (h : ReaderT.run prog r = x) (P : α → Prop)
   (hwp : wp prog (fun a _ => P a) EPost.nil.mk r) : P x := by
   rw [← h]
   exact hwp
 
-/-- Adequacy for `Except`: if `wp prog P` holds, then `P` holds of the result. -/
+/-- Soundness for `Except`: if `wp prog P` holds, then `P` holds of the result. -/
 theorem Except.of_wp_eq {ε α : Type} {x prog : Except ε α}
   (h : prog = x) (P : Except ε α → Prop)
   (hwp : wp prog (fun a => P (.ok a)) epost⟨fun e => P (.error e)⟩) : P x := by
@@ -404,7 +404,7 @@ theorem Except.of_wp_eq {ε α : Type} {x prog : Except ε α}
   | ok a => simpa only [wp] using! hwp
   | error e => simpa only [wp] using! hwp
 
-/-- Adequacy for `EStateM`: if `wp prog P s` holds, then `P` holds of `(prog.run s)`. -/
+/-- Soundness for `EStateM`: if `wp prog P s` holds, then `P` holds of `(prog.run s)`. -/
 theorem EStateM.of_wp_run_eq {ε σ α : Type} {x : EStateM.Result ε σ α}
   {prog : EStateM ε σ α} {s : σ}
   (h : EStateM.run prog s = x) (P : EStateM.Result ε σ α → Prop)


### PR DESCRIPTION
This PR renames the `WPAdequate` typeclass to `WPSound` to reflect that it encodes the directional soundness arrow `wp x P → Internal.Ensures P x` (not a bidirectional adequacy correspondence), and replaces the `Id`-only `*.of_wp_run_eq` family with a uniform per-transformer soundness framework that works over any base monad with `WPSound`.

`WPSound m ps` exposes the soundness bridge `wp⟦x⟧ Q → Internal.Ensures P x`, with convenience corollaries `WPSound.of_wp` (taking an `Internal.MayReturn` witness) and `WPSound.of_wp_canReturn` (taking a `MonadAttach.CanReturn` witness). New per-transformer lemmas `ReaderT.ensures_of_wp_run`, `StateT.ensures_of_wp_run`, `ExceptT.ensures_of_wp_run`, `OptionT.ensures_of_wp_run` lift wp proofs to `Internal.Ensures` over the post-run computation `prog.run «args»` at any base monad with a `WPSound` instance. Pure-prop variants `T.of_wp_run` close `P a` directly from a `CanReturn` witness, generalizing the existing `Id`-specialized lemmas to any sound base monad with `LawfulMonadAttach`. The `Id`-specialized `StateM.of_wp_run_eq`, `StateM.of_wp_run'_eq`, `ReaderM.of_wp_run_eq`, `Except.of_wp_eq`, `Option.of_wp_eq` lemmas are re-derived as `m = Id` corollaries of the generic versions; their statements and namespaces are preserved so existing callers are unaffected.

`WeaklyLawfulMonadAttach (EStateM ε σ)`, `LawfulMonadAttach (EStateM ε σ)`, and `WPSound (EStateM ε σ)` instances are added in `Init/Control/Lawful/MonadAttach/Instances.lean` and `Std/Do/WP/Sound.lean`, so `EStateM` plugs into the same framework as the transformer monads via `Internal.Ensures.canReturn.weaken`. The custom `EStateM.of_wp_run_eq` (Result-shaped postcondition) remains in `Std/Do/WP/Basic.lean` since deriving it via `WPSound` requires bridging the α-level `Internal.Ensures` to a `Result`-level form, which is a follow-up.
