### PR TITLE
fix: preserve revert argument order

### DIFF
--- a/src/Lean/Elab/Tactic/BuiltinTactic.lean
+++ b/src/Lean/Elab/Tactic/BuiltinTactic.lean
@@ -389,7 +389,7 @@ where
 @[builtin_tactic Lean.Parser.Tactic.revert] def evalRevert : Tactic := fun stx =>
   match stx with
   | `(tactic| revert $hs*) => do
-     let (_, mvarId) ← (← getMainGoal).revert (← getFVarIds hs)
+     let (_, mvarId) ← (← getMainGoal).revert (← getFVarIds hs) (preserveOrder := true)
      replaceMainGoal [mvarId]
   | _                     => throwUnsupportedSyntax
 

--- a/tests/elab/revertOrder.lean
+++ b/tests/elab/revertOrder.lean
@@ -1,4 +1,4 @@
-﻿example (a b c : Nat) : a * b * c = a * b * c := by
+example (a b c : Nat) : a * b * c = a * b * c := by
   revert c a b
   guard_target = forall (c a b : Nat), a * b * c = a * b * c
   intro c a b

--- a/tests/elab/revertOrder.lean
+++ b/tests/elab/revertOrder.lean
@@ -1,0 +1,5 @@
+﻿example (a b c : Nat) : a * b * c = a * b * c := by
+  revert c a b
+  guard_target = forall (c a b : Nat), a * b * c = a * b * c
+  intro c a b
+  rfl


### PR DESCRIPTION
This PR preserves the user-specified argument order in the `revert` tactic.

Fixes #3028.

This changes the `revert` tactic to call `MVarId.revert` with `preserveOrder := true`, so the order written by the user is preserved.

I added a regression test for `revert c a b`.

I was not able to run the local Lean test because this checkout does not have local build artifacts under `build/release/stage1/bin`.