### PR TITLE
feat: detect and special case ITE/XORs when lowering AIG to CNF

### DIFF
--- a/src/Std/Sat/AIG/Basic.lean
+++ b/src/Std/Sat/AIG/Basic.lean
@@ -85,7 +85,7 @@ private theorem invert_eq_testBit (f : Fanin) : f.invert = f.val.testBit 0 := by
   simp [invert, Nat.testBit]
 
 @[simp]
-theorem invert_flip (f : Fanin) : (f.flip v).invert = f.invert ^^ v := by
+theorem invert_flip (f : Fanin) : (f.flip v).invert = (f.invert ^^ v) := by
   cases v <;> simp [flip, invert_eq_testBit, -Nat.mod_two_not_eq_one]
 
 end Fanin

--- a/src/Std/Sat/AIG/CNF.lean
+++ b/src/Std/Sat/AIG/CNF.lean
@@ -643,7 +643,6 @@ def detectIte {aig : AIG Nat} (root : Nat) (h : root < aig.decls.size) : Option 
     -- We expect the structure to be a conjunction of disjunctions
     if !l.invert || !r.invert then
       none
-
     else
       -- Match l = (l0 ∧ l1) and r = (r0 ∧ r1)
       have := aig.hdag h hroot
@@ -651,25 +650,20 @@ def detectIte {aig : AIG Nat} (root : Nat) (h : root < aig.decls.size) : Option 
       | .gate l0 l1, .gate r0 r1 => go l r l0 l1 r0 r1
       | _, _ => none
   | _ => none
-
 where
   go (l r l0 l1 r0 r1 : Fanin) : Option (Fanin × Fanin × Fanin) :=
     -- ¬(l0 ∧ l1) ∧ ¬(¬l0 ∧ r1) = (l0 → ¬l1) ∧ (¬l0 → ¬r1)
     if l0 = r0.flip true then
       some (l0, l1.flip true, r1.flip true)
-
     -- ¬(l0 ∧ l1) ∧ ¬(r0 ∧ ¬l0) = (l0 → ¬l1) ∧ (¬l0 → ¬r0)
     else if l0 = r1.flip true then
       some (l0, l1.flip true, r0.flip true)
-
     -- ¬(l0 ∧ l1) ∧ ¬(¬l1 ∧ r1) = (l1 → ¬l0) ∧ (¬l0 → ¬r1)
     else if l1 = r0.flip true then
       some (l1, l0.flip true, r1.flip true)
-
     -- ¬(l0 ∧ l1) ∧ ¬(r0 ∧ ¬l1) = (l1 → ¬l0) ∧ (¬l1 → ¬r0)
     else if l1 = r1.flip true then
       some (l1, l0.flip true, r0.flip true)
-
     else
       none
 
@@ -677,24 +671,21 @@ theorem detectIte.gate_cond_go {l r l0 l1 r0 r1 c t f}
     (heq : go l r l0 l1 r0 r1 = some ⟨c, t, f⟩) :
     c.gate = l0.gate ∨ c.gate = l1.gate := by
   revert heq
-  fun_cases go
-  <;> simp +contextual
+  fun_cases go <;> simp +contextual
 
 theorem detectIte.gate_ifTrue_go {l r l0 l1 r0 r1 c t f}
     (heq : go l r l0 l1 r0 r1 = some ⟨c, t, f⟩) :
     t.gate = l0.gate ∨ t.gate = l1.gate := by
   replace heq := heq.symm
   revert heq
-  fun_cases go
-  <;> simp +contextual
+  fun_cases go <;> simp +contextual
 
 theorem detectIte.gate_ifFalse_go {l r l0 l1 r0 r1 c t f}
     (heq : go l r l0 l1 r0 r1 = some ⟨c, t, f⟩) :
     f.gate = r0.gate ∨ f.gate = r1.gate := by
   replace heq := heq.symm
   revert heq
-  fun_cases go
-  <;> simp +contextual
+  fun_cases go <;> simp +contextual
 
 theorem detectIte_cond_lt {aig : AIG Nat} {root c t f} {h : root < aig.decls.size}
     (heq : detectIte root h = some ⟨c, t, f⟩) :
@@ -732,26 +723,8 @@ theorem detectIte_ifFalse_lt {aig : AIG Nat} {root c t f} {h : root < aig.decls.
     omega
   all_goals simp
 
-theorem detectIte.denote_go' (denote : Fanin → Bool) {l r l0 l1 r0 r1 c t f : Fanin}
-    (heq : go l r l0 l1 r0 r1 = some ⟨c, t, f⟩)
-    (hl : denote l = !(denote l0 && denote l1)) (hr : denote r = !(denote r0 && denote r1))
-    (hflip : ∀ (fi : Fanin), denote (fi.flip true) = !denote fi) :
-    (denote l && denote r) =
-      if denote c then denote t else denote f := by
-  replace heq := heq.symm
-  revert heq
-  fun_cases go
-  <;> rename_i h
-  <;> simp +contextual only [h, hflip, hl, hr, Option.some.injEq, Prod.mk.injEq,
-        reduceCtorEq, false_implies]
-  <;> intros
-  <;> generalize denote l0 = dl0
-  <;> generalize denote l1 = dl1
-  <;> generalize denote r0 = dr0
-  <;> generalize denote r1 = dr1
-  <;> decide +revert
-
-theorem detectIte.denote_go {aig : AIG Nat} {root : Nat} {l r l0 l1 r0 r1 c t f : Fanin} {hroot hl hr}
+theorem detectIte.denote_go {aig : AIG Nat} {root : Nat} {l r l0 l1 r0 r1 c t f : Fanin}
+    {hroot hl hr}
     (heq : go l r l0 l1 r0 r1 = some ⟨c, t, f⟩) (heqroot : aig.decls[root]'hroot = .gate l r)
     (heql : aig.decls[l.gate]'hl = .gate l0 l1) (heqr : aig.decls[r.gate]'hr = .gate r0 r1)
     (hinvl : l.invert) (hinvr : r.invert) :
@@ -764,29 +737,20 @@ theorem detectIte.denote_go {aig : AIG Nat} {root : Nat} {l r l0 l1 r0 r1 c t f 
         ⟦aig, ⟨f.gate, f.invert, by have := gate_ifFalse_go heq; omega⟩, assign⟧ := by
   simp only [denote_idx_gate heqroot, Bool.bne_false]
 
-  let denote (fi : Fanin) : Bool :=
-    if hgate : fi.gate < aig.decls.size then
-      ⟦aig, ⟨fi.gate, fi.invert, hgate⟩, assign⟧
-    else
-      fi.invert
-  have {fi : Fanin} h : ⟦aig, ⟨fi.gate, fi.invert, h⟩, assign⟧ = denote fi := by simp [denote, h]
-  simp only [this]
-
-  have := aig.hdag (by omega) heql
-  have := aig.hdag (by omega) heqr
-  have hl0 : l0.gate < aig.decls.size := by omega
-  have hl1 : l1.gate < aig.decls.size := by omega
-  have hr0 : r0.gate < aig.decls.size := by omega
-  have hr1 : r1.gate < aig.decls.size := by omega
-
-  apply denote_go' denote heq
-  · simp [denote, hl, hl0, hl1, denote_idx_gate heql, hinvl]
-  · simp [denote, hr, hr0, hr1, denote_idx_gate heqr, hinvr]
-  · simp only [Fanin.gate_flip, denote]
-    intro fi
-    split
-    · simp
-    · simp
+  replace heq := heq.symm
+  revert heq
+  fun_cases go
+  case case5 => simp
+  all_goals
+    simp_all only [Fanin.gate_flip, Option.some.injEq, Prod.mk.injEq,
+      denote_idx_gate heql, Fanin.invert_flip, Bool.bne_true, denote_not_invert, Bool.not_and,
+      Bool.not_not, denote_idx_gate heqr, Bool.not_eq_eq_eq_not, Bool.not_true]
+    intro h
+    generalize ⟦aig, ⟨l0.gate, l0.invert, _⟩, assign⟧ = v1
+    generalize ⟦aig, ⟨l1.gate, l1.invert, _⟩, assign⟧ = v2
+    generalize ⟦aig, ⟨r0.gate, r0.invert, _⟩, assign⟧ = v3
+    generalize ⟦aig, ⟨r1.gate, r1.invert, _⟩, assign⟧ = v4
+    decide +revert
 
 theorem denote_detectIte {root h c t f} (heq : detectIte root h = some ⟨c, t, f⟩) :
     ⟦aig, ⟨root, false, h⟩, assign⟧ =
@@ -799,11 +763,12 @@ theorem denote_detectIte {root h c t f} (heq : detectIte root h = some ⟨c, t, 
   next hroot =>
     split at heq
     · simp at heq
-    next hinvert =>
+    · next hinvert =>
       simp only at heq
-      simp at hinvert
       split at heq
-      next hl hr =>
+      · next hl hr =>
+        simp only [Bool.or_eq_true, Bool.not_eq_eq_eq_not, Bool.not_true, not_or,
+          Bool.not_eq_false] at hinvert
         apply detectIte.denote_go heq hroot hl hr hinvert.left hinvert.right
       · simp at heq
   · simp at heq

--- a/src/Std/Sat/AIG/CNF.lean
+++ b/src/Std/Sat/AIG/CNF.lean
@@ -636,86 +636,157 @@ theorem State.unsat_iff : State.Unsat state ↔ state.cnf.Unsat := by rfl
 /--
 Detect if-then-else and XOR/XNOR gates of the form `(c → t) ∧ (¬c → f) = ¬(c ∧ ¬t) ∧ ¬(¬c ∧ ¬f)`.
 -/
-def detectIte {aig : AIG Nat} (root : Nat) (h : root < aig.decls.size) : Option (Fanin × Fanin × Fanin) := do
+def detectIte {aig : AIG Nat} (root : Nat) (h : root < aig.decls.size) : Option (Fanin × Fanin × Fanin) :=
   -- Match root = (l ∧ r)
-  let (eq := hroot) .gate l r := aig.decls[root]'h | none
-  have := aig.hdag h hroot
+  match hroot : aig.decls[root]'h with
+  | .gate l r =>
+    -- We expect the structure to be a conjunction of disjunctions
+    if !l.invert || !r.invert then
+      none
 
-  -- We expect the structure to be a conjunction of disjunctions
-  if !l.invert || !r.invert then
-    none
+    else
+      -- Match l = (l0 ∧ l1) and r = (r0 ∧ r1)
+      have := aig.hdag h hroot
+      match hl : aig.decls[l.gate], hr : aig.decls[r.gate] with
+      | .gate l0 l1, .gate r0 r1 => go l r l0 l1 r0 r1
+      | _, _ => none
+  | _ => none
 
-  -- Match l = (l0 ∧ l1)
-  let (eq := hl) .gate l0 l1 := aig.decls[l.gate] | none
-  have := aig.hdag (by omega) hl
+where
+  go (l r l0 l1 r0 r1 : Fanin) : Option (Fanin × Fanin × Fanin) :=
+    -- ¬(l0 ∧ l1) ∧ ¬(¬l0 ∧ r1) = (l0 → ¬l1) ∧ (¬l0 → ¬r1)
+    if l0 = r0.flip true then
+      some (l0, l1.flip true, r1.flip true)
 
-  -- Match r = (r0 ∧ r1)
-  let (eq := hr) .gate r0 r1 := aig.decls[r.gate] | none
-  have := aig.hdag (by omega) hr
+    -- ¬(l0 ∧ l1) ∧ ¬(r0 ∧ ¬l0) = (l0 → ¬l1) ∧ (¬l0 → ¬r0)
+    else if l0 = r1.flip true then
+      some (l0, l1.flip true, r0.flip true)
 
-  -- ¬(l0 ∧ l1) ∧ ¬(¬l0 ∧ r1) = (l0 → ¬l1) ∧ (¬l0 → ¬r1)
-  if l0 = r0.flip true then
-    some (l0, l1.flip true, r1.flip true)
+    -- ¬(l0 ∧ l1) ∧ ¬(¬l1 ∧ r1) = (l1 → ¬l0) ∧ (¬l0 → ¬r1)
+    else if l1 = r0.flip true then
+      some (l1, l0.flip true, r1.flip true)
 
-  -- ¬(l0 ∧ l1) ∧ ¬(r0 ∧ ¬l0) = (l0 → ¬l1) ∧ (¬l0 → ¬r0)
-  else if l0 = r1.flip true then
-    some (l0, l1.flip true, r0.flip true)
+    -- ¬(l0 ∧ l1) ∧ ¬(r0 ∧ ¬l1) = (l1 → ¬l0) ∧ (¬l1 → ¬r0)
+    else if l1 = r1.flip true then
+      some (l1, l0.flip true, r0.flip true)
 
-  -- ¬(l0 ∧ l1) ∧ ¬(¬l1 ∧ r1) = (l1 → ¬l0) ∧ (¬l0 → ¬r1)
-  else if l1 = r0.flip true then
-    some (l1, l0.flip true, r1.flip true)
+    else
+      none
 
-  -- ¬(l0 ∧ l1) ∧ ¬(r0 ∧ ¬l1) = (l1 → ¬l0) ∧ (¬l1 → ¬r0)
-  else if l1 = r1.flip true then
-    some (l1, l0.flip true, r0.flip true)
+theorem detectIte.gate_cond_go {l r l0 l1 r0 r1 c t f}
+    (heq : go l r l0 l1 r0 r1 = some ⟨c, t, f⟩) :
+    c.gate = l0.gate ∨ c.gate = l1.gate := by
+  revert heq
+  fun_cases go
+  <;> simp +contextual
 
-  else
-    none
+theorem detectIte.gate_ifTrue_go {l r l0 l1 r0 r1 c t f}
+    (heq : go l r l0 l1 r0 r1 = some ⟨c, t, f⟩) :
+    t.gate = l0.gate ∨ t.gate = l1.gate := by
+  replace heq := heq.symm
+  revert heq
+  fun_cases go
+  <;> simp +contextual
+
+theorem detectIte.gate_ifFalse_go {l r l0 l1 r0 r1 c t f}
+    (heq : go l r l0 l1 r0 r1 = some ⟨c, t, f⟩) :
+    f.gate = r0.gate ∨ f.gate = r1.gate := by
+  replace heq := heq.symm
+  revert heq
+  fun_cases go
+  <;> simp +contextual
 
 theorem detectIte_cond_lt {aig : AIG Nat} {root c t f} {h : root < aig.decls.size}
     (heq : detectIte root h = some ⟨c, t, f⟩) :
     c.gate < root := by
-  simp only [detectIte] at heq
-  split at heq; (all_goals try contradiction); next l r hroot =>
-  split at heq; (all_goals try contradiction); next hinvert =>
-  split at heq; (all_goals try contradiction); next l0 l1 hl =>
-  split at heq; (all_goals try contradiction); next r0 r1 hr =>
-  have := aig.hdag (by omega) hroot
-  have := aig.hdag (by omega) hl
-  (repeat' (split at heq))
-  <;> simp only [Option.some.injEq, Prod.mk.injEq, reduceCtorEq] at heq
-  <;> rw [←heq.left]
-  <;> omega
+  revert heq
+  fun_cases detectIte
+  case case2 hl hr =>
+    intro heq
+    have := aig.hdag (by omega) hl
+    have := detectIte.gate_cond_go heq
+    omega
+  all_goals simp
 
 theorem detectIte_ifTrue_lt {aig : AIG Nat} {root c t f} {h : root < aig.decls.size}
     (heq : detectIte root h = some ⟨c, t, f⟩) :
     t.gate < root := by
-  simp only [detectIte] at heq
-  split at heq; (all_goals try contradiction); next l r hroot =>
-  split at heq; (all_goals try contradiction); next hinvert =>
-  split at heq; (all_goals try contradiction); next l0 l1 hl =>
-  split at heq; (all_goals try contradiction); next r0 r1 hr =>
-  have := aig.hdag (by omega) hroot
-  have := aig.hdag (by omega) hl
-  (repeat' (split at heq))
-  <;> simp only [Option.some.injEq, Prod.mk.injEq, reduceCtorEq] at heq
-  <;> rw [←heq.right.left, Fanin.gate_flip]
-  <;> omega
+  revert heq
+  fun_cases detectIte
+  case case2 hl hr =>
+    intro heq
+    have := aig.hdag (by omega) hl
+    have := detectIte.gate_ifTrue_go heq
+    omega
+  all_goals simp
 
 theorem detectIte_ifFalse_lt {aig : AIG Nat} {root c t f} {h : root < aig.decls.size}
     (heq : detectIte root h = some ⟨c, t, f⟩) :
     f.gate < root := by
-  simp only [detectIte] at heq
-  split at heq; (all_goals try contradiction); next l r hroot =>
-  split at heq; (all_goals try contradiction); next hinvert =>
-  split at heq; (all_goals try contradiction); next l0 l1 hl =>
-  split at heq; (all_goals try contradiction); next r0 r1 hr =>
-  have := aig.hdag (by omega) hroot
-  have := aig.hdag (by omega) hr
-  (repeat' (split at heq))
-  <;> simp only [Option.some.injEq, Prod.mk.injEq, reduceCtorEq] at heq
-  <;> rw [←heq.right.right, Fanin.gate_flip]
-  <;> omega
+  revert heq
+  fun_cases detectIte
+  case case2 hl hr =>
+    intro heq
+    have := aig.hdag (by omega) hr
+    have := detectIte.gate_ifFalse_go heq
+    omega
+  all_goals simp
+
+theorem detectIte.denote_go' (denote : Fanin → Bool) {l r l0 l1 r0 r1 c t f : Fanin}
+    (heq : go l r l0 l1 r0 r1 = some ⟨c, t, f⟩)
+    (hl : denote l = !(denote l0 && denote l1)) (hr : denote r = !(denote r0 && denote r1))
+    (hflip : ∀ (fi : Fanin), denote (fi.flip true) = !denote fi) :
+    (denote l && denote r) =
+      if denote c then denote t else denote f := by
+  replace heq := heq.symm
+  revert heq
+  fun_cases go
+  <;> rename_i h
+  <;> simp +contextual only [h, hflip, hl, hr, Option.some.injEq, Prod.mk.injEq,
+        reduceCtorEq, false_implies]
+  <;> intros
+  <;> generalize denote l0 = dl0
+  <;> generalize denote l1 = dl1
+  <;> generalize denote r0 = dr0
+  <;> generalize denote r1 = dr1
+  <;> decide +revert
+
+theorem detectIte.denote_go {aig : AIG Nat} {root : Nat} {l r l0 l1 r0 r1 c t f : Fanin} {hroot hl hr}
+    (heq : go l r l0 l1 r0 r1 = some ⟨c, t, f⟩) (heqroot : aig.decls[root]'hroot = .gate l r)
+    (heql : aig.decls[l.gate]'hl = .gate l0 l1) (heqr : aig.decls[r.gate]'hr = .gate r0 r1)
+    (hinvl : l.invert) (hinvr : r.invert) :
+    ⟦aig, ⟨root, false, hroot⟩, assign⟧ =
+      have := aig.hdag (by omega) heql
+      have := aig.hdag (by omega) heqr
+      ite
+        ⟦aig, ⟨c.gate, c.invert, by have := gate_cond_go heq; omega⟩, assign⟧
+        ⟦aig, ⟨t.gate, t.invert, by have := gate_ifTrue_go heq; omega⟩, assign⟧
+        ⟦aig, ⟨f.gate, f.invert, by have := gate_ifFalse_go heq; omega⟩, assign⟧ := by
+  simp only [denote_idx_gate heqroot, Bool.bne_false]
+
+  let denote (fi : Fanin) : Bool :=
+    if hgate : fi.gate < aig.decls.size then
+      ⟦aig, ⟨fi.gate, fi.invert, hgate⟩, assign⟧
+    else
+      fi.invert
+  have {fi : Fanin} h : ⟦aig, ⟨fi.gate, fi.invert, h⟩, assign⟧ = denote fi := by simp [denote, h]
+  simp only [this]
+
+  have := aig.hdag (by omega) heql
+  have := aig.hdag (by omega) heqr
+  have hl0 : l0.gate < aig.decls.size := by omega
+  have hl1 : l1.gate < aig.decls.size := by omega
+  have hr0 : r0.gate < aig.decls.size := by omega
+  have hr1 : r1.gate < aig.decls.size := by omega
+
+  apply denote_go' denote heq
+  · simp [denote, hl, hl0, hl1, denote_idx_gate heql, hinvl]
+  · simp [denote, hr, hr0, hr1, denote_idx_gate heqr, hinvr]
+  · simp only [Fanin.gate_flip, denote]
+    intro fi
+    split
+    · simp
+    · simp
 
 theorem denote_detectIte {root h c t f} (heq : detectIte root h = some ⟨c, t, f⟩) :
     ⟦aig, ⟨root, false, h⟩, assign⟧ =
@@ -723,26 +794,19 @@ theorem denote_detectIte {root h c t f} (heq : detectIte root h = some ⟨c, t, 
         ⟦aig, ⟨c.gate, c.invert, by have := detectIte_cond_lt heq; omega⟩, assign⟧
         ⟦aig, ⟨t.gate, t.invert, by have := detectIte_ifTrue_lt heq; omega⟩, assign⟧
         ⟦aig, ⟨f.gate, f.invert, by have := detectIte_ifFalse_lt heq; omega⟩, assign⟧ := by
-  simp only [detectIte] at heq
-  split at heq; (all_goals try contradiction); next l r hroot =>
-  split at heq; (all_goals try contradiction); next hinvert =>
-  split at heq; (all_goals try contradiction); next l0 l1 hl =>
-  split at heq; (all_goals try contradiction); next r0 r1 hr =>
-  have := aig.hdag (by omega) hroot
-  have := aig.hdag (by omega) hl
-  have := aig.hdag (by omega) hr
-  simp only [Bool.not_eq_true, not_or, Bool.not_eq_false] at hinvert
-  rw [denote_idx_gate hroot, hinvert.left, hinvert.right, denote_idx_gate hl, denote_idx_gate hr]
-  (repeat' (split at heq))
-  <;> simp only [Option.some.injEq, Prod.mk.injEq, reduceCtorEq] at heq
-  <;> rename_i h
-  <;> simp only [h, Fanin.gate_flip, Fanin.invert_flip, Bool.bne_true, denote_not_invert,
-    ← heq.left, ← heq.right.left, ← heq.right.right]
-  <;> generalize ⟦aig, ⟨l0.gate, l0.invert, by omega⟩, assign⟧ = l0
-  <;> generalize ⟦aig, ⟨l1.gate, l1.invert, by omega⟩, assign⟧ = l1
-  <;> generalize ⟦aig, ⟨r0.gate, r0.invert, by omega⟩, assign⟧ = r0
-  <;> generalize ⟦aig, ⟨r1.gate, r1.invert, by omega⟩, assign⟧ = r1
-  <;> decide +revert
+  unfold detectIte at heq
+  split at heq
+  next hroot =>
+    split at heq
+    · simp at heq
+    next hinvert =>
+      simp only at heq
+      simp at hinvert
+      split at heq
+      next hl hr =>
+        apply detectIte.denote_go heq hroot hl hr hinvert.left hinvert.right
+      · simp at heq
+  · simp at heq
 
 end toCNF
 

--- a/src/Std/Sat/AIG/CNF.lean
+++ b/src/Std/Sat/AIG/CNF.lean
@@ -51,6 +51,18 @@ def gateToCNF (output : α) (lhs rhs : α) (linv rinv : Bool) : CNF α :=
     |>.add [(output, .false), (rhs, !rinv)]
     |>.add [(output, true),  (lhs, linv), (rhs, rinv)]
 
+/--
+Produce a Tseitin style CNF for an if-then-else gate, using `output` as the tree node variable.
+-/
+def iteToCNF (output : α) (cond ifTrue ifFalse : α) (cinv tinv finv : Bool) : CNF α :=
+  -- o ↔ (c ? t : f) as implications: (c ∧ t → o) ∧ (c ∧ ¬t → ¬o) ∧ (¬c ∧ f → o) ∧ (¬c ∧ ¬f → ¬o)
+  -- o ↔ (c ? t : f) as CNF: (¬c ∨ ¬t ∨ o) ∧ (¬c ∨ t ∨ ¬o) ∧ (c ∨ ¬f ∨ o) ∧ (c ∨ f ∨ ¬o)
+  CNF.empty
+    |>.add [(cond, cinv), (ifTrue, tinv), (output, true)]
+    |>.add [(cond, cinv), (ifTrue, !tinv), (output, .false)]
+    |>.add [(cond, !cinv), (ifFalse, finv), (output, true)]
+    |>.add [(cond, !cinv), (ifFalse, !finv), (output, .false)]
+
 @[simp]
 theorem falseToCNF_eval :
     (falseToCNF output).eval assign
@@ -80,6 +92,18 @@ theorem gateToCNF_eval :
         <;> cases linv
           <;> cases rinv
             <;> decide
+
+@[simp]
+theorem iteToCNF_eval {cond ifTrue ifFalse cinv tinv finv assign} :
+    (iteToCNF output cond ifTrue ifFalse cinv tinv finv).eval assign
+      =
+    (assign output == ite ((assign cond) ^^ cinv) ((assign ifTrue) ^^ tinv) ((assign ifFalse) ^^ finv)) := by
+  simp only [iteToCNF, CNF.eval_add, CNF.Clause.eval_cons, CNF.Clause.eval_nil, CNF.eval_empty]
+  generalize assign output = o
+  generalize assign cond = c
+  generalize assign ifTrue = t
+  generalize assign ifFalse = f
+  decide +revert
 
 end Decl
 
@@ -349,6 +373,50 @@ def Cache.addGate (cache : Cache aig cnf) {hlb} {hrb} (idx : Nat) (h : idx < aig
   ⟨out, IsExtensionBy_set cache out idx hmarkbound (by simp [out])⟩
 
 /--
+Add an if-then-else gate to a cache.
+-/
+def Cache.addIte (cache : Cache aig cnf) {cond ifTrue ifFalse : Fanin} (idx : Nat) {hcb htb hfb}
+    (h : idx < aig.decls.size)
+    (hltc : cond.gate < idx) (hltt : ifTrue.gate < idx) (hltf : ifFalse.gate < idx)
+    (hc : cache.marks[cond.gate]'hcb = true)
+    (ht : cache.marks[ifTrue.gate]'htb = true)
+    (hf : cache.marks[ifFalse.gate]'hfb = true)
+    (hdenote : ∀ assign, ⟦aig, ⟨idx, false, h⟩, assign⟧ =
+      ite
+        ⟦aig, ⟨cond.gate, cond.invert, by omega⟩, assign⟧
+        ⟦aig, ⟨ifTrue.gate, ifTrue.invert, by omega⟩, assign⟧
+        ⟦aig, ⟨ifFalse.gate, ifFalse.invert, by omega⟩, assign⟧) :
+    {
+      out : Cache aig (cnf ++ Decl.iteToCNF idx cond.gate ifTrue.gate ifFalse.gate cond.invert ifTrue.invert ifFalse.invert)
+        //
+      Cache.IsExtensionBy cache out idx h
+    } :=
+  have hmarkbound : idx < cache.marks.size := by have := cache.hmarks; omega
+  let out :=
+    { cache with
+      marks := cache.marks.set idx true
+      hmarks := by simp [cache.hmarks]
+      inv := by
+        intro assign heval idx hbound hmarked
+        rw [Array.getElem_set] at hmarked
+        split at hmarked
+        next heq =>
+          simp only [heq, CNF.eval_append, Decl.iteToCNF_eval, Bool.and_eq_true, beq_iff_eq] at heval
+          subst heq
+          have hceval := cache.inv assign heval.left cond.gate (by omega) hc
+          have hteval := cache.inv assign heval.left ifTrue.gate (by omega) ht
+          have hfeval := cache.inv assign heval.left ifFalse.gate (by omega) hf
+          have {fi : Fanin} {aig h} {assign : Nat → Bool} :
+            ⟦aig, ⟨fi.gate, fi.invert, h⟩, assign⟧ = (⟦aig, ⟨fi.gate, false, h⟩, assign⟧ ^^ fi.invert) := by
+              cases fi.invert <;> simp
+          simp [hdenote, heval, this, hceval, hteval, hfeval]
+        next heq =>
+          simp only [CNF.eval_append, Decl.iteToCNF_eval, Bool.and_eq_true, beq_iff_eq] at heval
+          rw [cache.inv assign heval.left idx hbound hmarked]
+    }
+  ⟨out, IsExtensionBy_set cache out idx hmarkbound (by simp [out])⟩
+
+/--
 The key invariant about the `State` itself (without cache): The CNF we produce is always satisfiable
 at `cnfSatAssignment`.
 -/
@@ -403,6 +471,26 @@ theorem State.Inv_gateToCNF {aig : AIG Nat} {h}
   generalize hrinv : rhs.invert = rinv
   rw [CNF.sat_def]
   cases linv <;> cases rinv <;> simp [denote_idx_gate heq, hlinv, hrinv, h, hlhs, hrhs]
+
+/--
+`State.Inv` holds for the CNF that we produce for an ITE.
+-/
+theorem State.Inv_iteToCNF {aig : AIG Nat} {cond ifTrue ifFalse : Fanin} {idx : Nat}
+    (h : idx < aig.decls.size)
+    (hltc : cond.gate < idx) (hltt : ifTrue.gate < idx) (hltf : ifFalse.gate < idx)
+    (hdenote : ∀ assign, ⟦aig, ⟨idx, false, h⟩, assign⟧ =
+      ite
+        ⟦aig, ⟨cond.gate, cond.invert, by omega⟩, assign⟧
+        ⟦aig, ⟨ifTrue.gate, ifTrue.invert, by omega⟩, assign⟧
+        ⟦aig, ⟨ifFalse.gate, ifFalse.invert, by omega⟩, assign⟧) :
+    State.Inv aig (Decl.iteToCNF idx cond.gate ifTrue.gate ifFalse.gate cond.invert ifTrue.invert ifFalse.invert) := by
+  intro assign1
+  rw [CNF.sat_def, Decl.iteToCNF_eval, satAssignment_inr h, hdenote, satAssignment_inr (by omega),
+    satAssignment_inr (by omega), satAssignment_inr (by omega)]
+  have {fi : Fanin} {aig h} {assign : Nat → Bool} :
+    ⟦aig, ⟨fi.gate, fi.invert, h⟩, assign⟧ = (⟦aig, ⟨fi.gate, false, h⟩, assign⟧ ^^ fi.invert) := by
+      cases fi.invert <;> simp
+  simp [this]
 
 /--
 The state to accumulate CNF clauses as we run our Tseitin transformation on the AIG.
@@ -497,6 +585,27 @@ def State.addGate (state : State aig) {hlb} {hrb} (idx : Nat) (h : idx < aig.dec
   ⟨⟨cnf ++ newCnf, cache, State.Inv_append inv hinv⟩, by simp [newCnf, hcache]⟩
 
 /--
+Add the CNF for an if-then-else to the state.
+-/
+def State.addIte (state : State aig) {cond ifTrue ifFalse : Fanin} (idx : Nat) {hcb htb hfb}
+    (h : idx < aig.decls.size)
+    (hltc : cond.gate < idx) (hltt : ifTrue.gate < idx) (hltf : ifFalse.gate < idx)
+    (hc : state.cache.marks[cond.gate]'hcb = true)
+    (ht : state.cache.marks[ifTrue.gate]'htb = true)
+    (hf : state.cache.marks[ifFalse.gate]'hfb = true)
+    (hdenote : ∀ assign, ⟦aig, ⟨idx, false, h⟩, assign⟧ =
+      ite
+        ⟦aig, ⟨cond.gate, cond.invert, by omega⟩, assign⟧
+        ⟦aig, ⟨ifTrue.gate, ifTrue.invert, by omega⟩, assign⟧
+        ⟦aig, ⟨ifFalse.gate, ifFalse.invert, by omega⟩, assign⟧) :
+    { out : State aig // State.IsExtensionBy state out idx h } :=
+  let ⟨cnf, cache, inv⟩ := state
+  let newCnf := Decl.iteToCNF idx cond.gate ifTrue.gate ifFalse.gate cond.invert ifTrue.invert ifFalse.invert
+  have hinv := toCNF.State.Inv_iteToCNF h hltc hltt hltf hdenote
+  let ⟨cache, hcache⟩ := cache.addIte idx h hltc hltt hltf hc ht hf hdenote
+  ⟨⟨cnf ++ newCnf, cache, State.Inv_append inv hinv⟩, by simp [newCnf, hcache]⟩
+
+/--
 Evaluate the CNF contained within the state.
 -/
 def State.eval (assign : Nat → Bool) (state : State aig) : Bool :=
@@ -524,6 +633,117 @@ theorem State.sat_iff : State.Sat assign state ↔ state.cnf.Sat assign := by rf
 @[simp]
 theorem State.unsat_iff : State.Unsat state ↔ state.cnf.Unsat := by rfl
 
+/--
+Detect if-then-else and XOR/XNOR gates of the form `(c → t) ∧ (¬c → f) = ¬(c ∧ ¬t) ∧ ¬(¬c ∧ ¬f)`.
+-/
+def detectIte {aig : AIG Nat} (root : Nat) (h : root < aig.decls.size) : Option (Fanin × Fanin × Fanin) := do
+  -- Match root = (l ∧ r)
+  let (eq:=hroot) .gate l r := aig.decls[root]'h | none
+  have := aig.hdag h hroot
+
+  -- We expect the structure to be a conjunction of disjunctions
+  if ¬l.invert ∨ ¬r.invert then
+    none
+
+  -- Match l = (l0 ∧ l1)
+  let (eq:=hl) .gate l0 l1 := aig.decls[l.gate] | none
+  have := aig.hdag (by omega) hl
+
+  -- Match r = (r0 ∧ r1)
+  let (eq:=hr) .gate r0 r1 := aig.decls[r.gate] | none
+  have := aig.hdag (by omega) hr
+
+  -- ¬(l0 ∧ l1) ∧ ¬(¬l0 ∧ r1) = (l0 → ¬l1) ∧ (¬l0 → ¬r1)
+  if l0 = r0.flip true then
+    some (l0, l1.flip true, r1.flip true)
+
+  -- ¬(l0 ∧ l1) ∧ ¬(r0 ∧ ¬l0) = (l0 → ¬l1) ∧ (¬l0 → ¬r0)
+  else if l0 = r1.flip true then
+    some (l0, l1.flip true, r0.flip true)
+
+  -- ¬(l0 ∧ l1) ∧ ¬(¬l1 ∧ r1) = (l1 → ¬l0) ∧ (¬l0 → ¬r1)
+  else if l1 = r0.flip true then
+    some (l1, l0.flip true, r1.flip true)
+
+  -- ¬(l0 ∧ l1) ∧ ¬(r0 ∧ ¬l1) = (l1 → ¬l0) ∧ (¬l1 → ¬r0)
+  else if l1 = r1.flip true then
+    some (l1, l0.flip true, r0.flip true)
+
+  else
+    none
+
+theorem detectIte_cond_lt {aig : AIG Nat} {root c t f} {h : root < aig.decls.size}
+    (heq : detectIte root h = some ⟨c, t, f⟩) :
+    c.gate < root := by
+  simp only [detectIte] at heq
+  split at heq; (all_goals try contradiction); next l r hroot =>
+  split at heq; (all_goals try contradiction); next hinvert =>
+  split at heq; (all_goals try contradiction); next l0 l1 hl =>
+  split at heq; (all_goals try contradiction); next r0 r1 hr =>
+  have := aig.hdag (by omega) hroot
+  have := aig.hdag (by omega) hl
+  (repeat' (split at heq))
+  <;> simp only [Option.some.injEq, Prod.mk.injEq, reduceCtorEq] at heq
+  <;> rw [←heq.left]
+  <;> omega
+
+theorem detectIte_ifTrue_lt {aig : AIG Nat} {root c t f} {h : root < aig.decls.size}
+    (heq : detectIte root h = some ⟨c, t, f⟩) :
+    t.gate < root := by
+  simp only [detectIte] at heq
+  split at heq; (all_goals try contradiction); next l r hroot =>
+  split at heq; (all_goals try contradiction); next hinvert =>
+  split at heq; (all_goals try contradiction); next l0 l1 hl =>
+  split at heq; (all_goals try contradiction); next r0 r1 hr =>
+  have := aig.hdag (by omega) hroot
+  have := aig.hdag (by omega) hl
+  (repeat' (split at heq))
+  <;> simp only [Option.some.injEq, Prod.mk.injEq, reduceCtorEq] at heq
+  <;> rw [←heq.right.left, Fanin.gate_flip]
+  <;> omega
+
+theorem detectIte_ifFalse_lt {aig : AIG Nat} {root c t f} {h : root < aig.decls.size}
+    (heq : detectIte root h = some ⟨c, t, f⟩) :
+    f.gate < root := by
+  simp only [detectIte] at heq
+  split at heq; (all_goals try contradiction); next l r hroot =>
+  split at heq; (all_goals try contradiction); next hinvert =>
+  split at heq; (all_goals try contradiction); next l0 l1 hl =>
+  split at heq; (all_goals try contradiction); next r0 r1 hr =>
+  have := aig.hdag (by omega) hroot
+  have := aig.hdag (by omega) hr
+  (repeat' (split at heq))
+  <;> simp only [Option.some.injEq, Prod.mk.injEq, reduceCtorEq] at heq
+  <;> rw [←heq.right.right, Fanin.gate_flip]
+  <;> omega
+
+theorem denote_detectIte {root h c t f} (heq : detectIte root h = some ⟨c, t, f⟩) :
+    ⟦aig, ⟨root, false, h⟩, assign⟧ =
+      ite
+        ⟦aig, ⟨c.gate, c.invert, by have := detectIte_cond_lt heq; omega⟩, assign⟧
+        ⟦aig, ⟨t.gate, t.invert, by have := detectIte_ifTrue_lt heq; omega⟩, assign⟧
+        ⟦aig, ⟨f.gate, f.invert, by have := detectIte_ifFalse_lt heq; omega⟩, assign⟧ := by
+  simp only [detectIte] at heq
+  split at heq; (all_goals try contradiction); next l r hroot =>
+  split at heq; (all_goals try contradiction); next hinvert =>
+  split at heq; (all_goals try contradiction); next l0 l1 hl =>
+  split at heq; (all_goals try contradiction); next r0 r1 hr =>
+  have := aig.hdag (by omega) hroot
+  have := aig.hdag (by omega) hl
+  have := aig.hdag (by omega) hr
+  simp only [Bool.not_eq_true, not_or, Bool.not_eq_false] at hinvert
+  rw [denote_idx_gate hroot, hinvert.left, hinvert.right, denote_idx_gate hl, denote_idx_gate hr]
+  (repeat' (split at heq))
+  <;> simp only [Option.some.injEq, Prod.mk.injEq, reduceCtorEq] at heq
+  <;> rename_i h
+  <;> simp only [h, Fanin.gate_flip, Fanin.invert_flip, Bool.bne_true, denote_not_invert,
+    ← heq.left, ← heq.right.left, ← heq.right.right]
+  <;> generalize ⟦aig, ⟨l0.gate, l0.invert, by omega⟩, assign⟧ = l0
+  <;> generalize ⟦aig, ⟨l1.gate, l1.invert, by omega⟩, assign⟧ = l1
+  <;> generalize ⟦aig, ⟨r0.gate, r0.invert, by omega⟩, assign⟧ = r0
+  <;> generalize ⟦aig, ⟨r1.gate, r1.invert, by omega⟩, assign⟧ = r1
+  <;> decide +revert
+
 end toCNF
 
 /--
@@ -543,25 +763,50 @@ where
       | .false => state.addFalse upper h heq
       | .atom _ => state.addAtom upper h heq
       | .gate lhs rhs =>
-        have := aig.hdag h heq
-        let ⟨lstate, hlstate⟩ := go aig lhs.gate (by omega) state
-        let ⟨rstate, hrstate⟩ := go aig rhs.gate (by omega) lstate
+        match hite : toCNF.detectIte upper h with
+        | some ⟨cond, ifTrue, ifFalse⟩ =>
+          have hltc := toCNF.detectIte_cond_lt hite
+          have hltt := toCNF.detectIte_ifTrue_lt hite
+          have hltf := toCNF.detectIte_ifFalse_lt hite
 
-        have : toCNF.State.IsExtensionBy state rstate lhs.gate (by omega) := by
-          apply toCNF.State.IsExtensionBy_trans_left
-          · exact hlstate
-          · exact hrstate
+          let ⟨cstate, hcstate⟩ := go aig cond.gate (by omega) state
+          let ⟨tstate, htstate⟩ := go aig ifTrue.gate (by omega) cstate
+          let ⟨fstate, hfstate⟩ := go aig ifFalse.gate (by omega) tstate
 
-        let ⟨ret, hretstate⟩ := rstate.addGate upper h heq this.trueAt hrstate.trueAt
-        ⟨
-          ret,
-          by
-            apply toCNF.State.IsExtensionBy_trans_right
+          have hcstate' : toCNF.State.IsExtensionBy state fstate cond.gate (by omega) := by
+            apply toCNF.State.IsExtensionBy_trans_left (h23 := hfstate)
+            apply toCNF.State.IsExtensionBy_trans_left (h23 := htstate)
+            · exact hcstate
+
+          have htstate' : toCNF.State.IsExtensionBy cstate fstate ifTrue.gate (by omega) := by
+            apply toCNF.State.IsExtensionBy_trans_left (h23 := hfstate)
+            · exact htstate
+
+          let ⟨ret, hretstate⟩ := fstate.addIte upper h hltc hltt hltf hcstate'.trueAt htstate'.trueAt hfstate.trueAt
+            (by simp [toCNF.denote_detectIte hite])
+          ⟨ret, toCNF.State.IsExtensionBy_trans_right (h12 := hcstate') (h23 := hretstate)⟩
+        | none =>
+          have := aig.hdag h heq
+          let ⟨lstate, hlstate⟩ := go aig lhs.gate (by omega) state
+          let ⟨rstate, hrstate⟩ := go aig rhs.gate (by omega) lstate
+
+          have : toCNF.State.IsExtensionBy state rstate lhs.gate (by omega) := by
+            apply toCNF.State.IsExtensionBy_trans_left
             · exact hlstate
-            · apply toCNF.State.IsExtensionBy_trans_right
-              · exact hrstate
-              · exact hretstate
-        ⟩
+            · exact hrstate
+
+          let ⟨ret, hretstate⟩ := rstate.addGate upper h heq this.trueAt hrstate.trueAt
+          ⟨
+            ret,
+            by
+              apply toCNF.State.IsExtensionBy_trans_right
+              · exact hlstate
+              · apply toCNF.State.IsExtensionBy_trans_right
+                · exact hrstate
+                · exact hretstate
+          ⟩
+  termination_by upper
+  decreasing_by all_goals omega
 
 /--
 The node that we started CNF conversion at will always be marked as visited in the CNF cache.

--- a/src/Std/Sat/AIG/CNF.lean
+++ b/src/Std/Sat/AIG/CNF.lean
@@ -638,19 +638,19 @@ Detect if-then-else and XOR/XNOR gates of the form `(c → t) ∧ (¬c → f) = 
 -/
 def detectIte {aig : AIG Nat} (root : Nat) (h : root < aig.decls.size) : Option (Fanin × Fanin × Fanin) := do
   -- Match root = (l ∧ r)
-  let (eq:=hroot) .gate l r := aig.decls[root]'h | none
+  let (eq := hroot) .gate l r := aig.decls[root]'h | none
   have := aig.hdag h hroot
 
   -- We expect the structure to be a conjunction of disjunctions
-  if ¬l.invert ∨ ¬r.invert then
+  if !l.invert || !r.invert then
     none
 
   -- Match l = (l0 ∧ l1)
-  let (eq:=hl) .gate l0 l1 := aig.decls[l.gate] | none
+  let (eq := hl) .gate l0 l1 := aig.decls[l.gate] | none
   have := aig.hdag (by omega) hl
 
   -- Match r = (r0 ∧ r1)
-  let (eq:=hr) .gate r0 r1 := aig.decls[r.gate] | none
+  let (eq := hr) .gate r0 r1 := aig.decls[r.gate] | none
   have := aig.hdag (by omega) hr
 
   -- ¬(l0 ∧ l1) ∧ ¬(¬l0 ∧ r1) = (l0 → ¬l1) ∧ (¬l0 → ¬r1)
@@ -776,11 +776,11 @@ where
           have hcstate' : toCNF.State.IsExtensionBy state fstate cond.gate (by omega) := by
             apply toCNF.State.IsExtensionBy_trans_left (h23 := hfstate)
             apply toCNF.State.IsExtensionBy_trans_left (h23 := htstate)
-            · exact hcstate
+            exact hcstate
 
           have htstate' : toCNF.State.IsExtensionBy cstate fstate ifTrue.gate (by omega) := by
             apply toCNF.State.IsExtensionBy_trans_left (h23 := hfstate)
-            · exact htstate
+            exact htstate
 
           let ⟨ret, hretstate⟩ := fstate.addIte upper h hltc hltt hltf hcstate'.trueAt htstate'.trueAt hfstate.trueAt
             (by simp [toCNF.denote_detectIte hite])


### PR DESCRIPTION
This PR adds detection and optimized lowering of if-then-else/XOR/XNOR gates to `bv_decide`'s AIG to CNF lowering. This detects `c ? t : f` gates of the form `(c → t) ∧ (¬c → f)` in the AIG, up to permutation/negation of inputs. This pattern also covers XOR/XNOR which are expressed as `a ? ¬b : b`/`a ? b : ¬b`. When a gate is lowered, if it matches these patterns it is lowered to a 4-clause encoding instead of the 12 clauses used by lowering as AND gates.