### PR TITLE
feat: hover info on `mut` variable names in `do`-elaborator messages

### DIFF
--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -111,7 +111,7 @@ open Lean.Meta
       defs := defs.push returnVar
     for x in loopMutVars do
       let defn ← getLocalDeclFromUserName x.getId
-      Term.addTermInfo' x defn.toExpr
+      Term.addTermInfo' x.ident defn.toExpr
       -- ForIn forces the mut tuple into the universe mi.u: that of the do block result type.
       -- If we don't do this, then we are stuck on solving constraints such as
       --   `max ?u.46 ?u.47 =?= max (max ?u.22 ?u.46) ?u.47`

--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -93,12 +93,12 @@ open Lean.Meta
   let info ← inferControlInfoSeq body
   let oldReturnCont ← getReturnCont
   let returnVarName ← mkFreshUserName `__r
-  let loopMutVars := mutVars.filter fun x => info.reassigns.contains x.getId
+  let loopMutVars := mutVars.filter fun x => info.reassigns.contains x.ident.getId
   let loopMutVarNames :=
     if info.returnsEarly then
-      returnVarName :: (loopMutVars.map (·.getId)).toList
+      returnVarName :: (loopMutVars.map (·.ident.getId)).toList
     else
-      (loopMutVars.map (·.getId)).toList
+      (loopMutVars.map (·.ident.getId)).toList
   let useLoopMutVars (e : Option Expr) : TermElabM (Array Expr) := do
     let mut defs := #[]
     unless e.isNone || info.returnsEarly do
@@ -110,7 +110,7 @@ open Lean.Meta
         | some e => mkSome oldReturnCont.resultType e
       defs := defs.push returnVar
     for x in loopMutVars do
-      let defn ← getLocalDeclFromUserName x.getId
+      let defn ← getLocalDeclFromUserName x.ident.getId
       Term.addTermInfo' x.ident defn.toExpr
       -- ForIn forces the mut tuple into the universe mi.u: that of the do block result type.
       -- If we don't do this, then we are stuck on solving constraints such as

--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -93,12 +93,12 @@ open Lean.Meta
   let info ← inferControlInfoSeq body
   let oldReturnCont ← getReturnCont
   let returnVarName ← mkFreshUserName `__r
-  let loopMutVars := mutVars.filter fun x => info.reassigns.contains x.ident.getId
+  let loopMutVars := mutVars.filter fun x => info.reassigns.contains x.getId
   let loopMutVarNames :=
     if info.returnsEarly then
-      returnVarName :: (loopMutVars.map (·.ident.getId)).toList
+      returnVarName :: (loopMutVars.map (·.getId)).toList
     else
-      (loopMutVars.map (·.ident.getId)).toList
+      (loopMutVars.map (·.getId)).toList
   let useLoopMutVars (e : Option Expr) : TermElabM (Array Expr) := do
     let mut defs := #[]
     unless e.isNone || info.returnsEarly do
@@ -110,7 +110,7 @@ open Lean.Meta
         | some e => mkSome oldReturnCont.resultType e
       defs := defs.push returnVar
     for x in loopMutVars do
-      let defn ← getLocalDeclFromUserName x.ident.getId
+      let defn ← getLocalDeclFromUserName x.getId
       Term.addTermInfo' x.ident defn.toExpr
       -- ForIn forces the mut tuple into the universe mi.u: that of the do block result type.
       -- If we don't do this, then we are stuck on solving constraints such as

--- a/src/Lean/Elab/BuiltinDo/Let.lean
+++ b/src/Lean/Elab/BuiltinDo/Let.lean
@@ -40,7 +40,7 @@ def LetOrReassign.registerReassignAliasInfo (letOrReassign : LetOrReassign) (var
       if let some baseMutVar ← findMutVar? var.getId then
         let id := (← getFVarFromUserName var.getId).fvarId!
         if id != baseMutVar.baseId then
-          pushInfoLeaf <| .ofFVarAliasInfo { userName := var.getId, id, baseId := baseMutVar.baseId }
+          pushInfoLeaf <| .ofFVarAliasInfo (baseMutVar.mkAliasInfo id)
 
 def elabDoLetOrReassignWith (hint : MessageData) (letOrReassign : LetOrReassign) (vars : Array Ident)
     (k : DoElabM Expr) (elabBody : (body : Term) → TermElabM Expr) : DoElabM Expr := do

--- a/src/Lean/Elab/BuiltinDo/Let.lean
+++ b/src/Lean/Elab/BuiltinDo/Let.lean
@@ -36,12 +36,11 @@ def LetOrReassign.checkMutVars (letOrReassign : LetOrReassign) (vars : Array Ide
 
 def LetOrReassign.registerReassignAliasInfo (letOrReassign : LetOrReassign) (vars : Array Ident) : DoElabM Unit := do
   if letOrReassign matches .reassign then
-    let mutVarDefs := (← read).mutVarDefs
     for var in vars do
-      if let some baseMv := mutVarDefs[var.getId]? then
+      if let some baseMutVar ← findMutVar? var.getId then
         let id := (← getFVarFromUserName var.getId).fvarId!
-        if id != baseMv.initFVarId then
-          pushInfoLeaf <| .ofFVarAliasInfo { userName := var.getId, id, baseId := baseMv.initFVarId }
+        if id != baseMutVar.baseId then
+          pushInfoLeaf <| .ofFVarAliasInfo { userName := var.getId, id, baseId := baseMutVar.baseId }
 
 def elabDoLetOrReassignWith (hint : MessageData) (letOrReassign : LetOrReassign) (vars : Array Ident)
     (k : DoElabM Expr) (elabBody : (body : Term) → TermElabM Expr) : DoElabM Expr := do

--- a/src/Lean/Elab/BuiltinDo/Let.lean
+++ b/src/Lean/Elab/BuiltinDo/Let.lean
@@ -38,10 +38,10 @@ def LetOrReassign.registerReassignAliasInfo (letOrReassign : LetOrReassign) (var
   if letOrReassign matches .reassign then
     let mutVarDefs := (← read).mutVarDefs
     for var in vars do
-      if let some baseId := mutVarDefs[var.getId]? then
+      if let some baseMv := mutVarDefs[var.getId]? then
         let id := (← getFVarFromUserName var.getId).fvarId!
-        if id != baseId then
-          pushInfoLeaf <| .ofFVarAliasInfo { userName := var.getId, id, baseId }
+        if id != baseMv.initFVarId then
+          pushInfoLeaf <| .ofFVarAliasInfo { userName := var.getId, id, baseId := baseMv.initFVarId }
 
 def elabDoLetOrReassignWith (hint : MessageData) (letOrReassign : LetOrReassign) (vars : Array Ident)
     (k : DoElabM Expr) (elabBody : (body : Term) → TermElabM Expr) : DoElabM Expr := do

--- a/src/Lean/Elab/Do/Basic.lean
+++ b/src/Lean/Elab/Do/Basic.lean
@@ -81,11 +81,28 @@ def CodeLiveness.lub (a b : CodeLiveness) : CodeLiveness :=
   | _, .deadSyntactically => a
   | _, _ => a
 
+/-- A mutable variable declared by `let mut` in a `do` block. -/
+structure MutVar where
+  /-- The identifier of the `let mut` declaration. -/
+  ident : Ident
+  /-- The `FVarId` of the initial binding produced by `let mut`. -/
+  initFVarId : FVarId
+  deriving Inhabited
+
+/-- The raw `Name` of a `mut` variable, as found in the local context. -/
+@[inline] def MutVar.getId (mv : MutVar) : Name := mv.ident.getId
+
+/-- The pretty-printable name of a `mut` variable, with macro scopes simplified. -/
+@[inline] def MutVar.userName (mv : MutVar) : Name := mv.ident.getId.simpMacroScopes
+
+instance : ToMessageData MutVar where
+  toMessageData mv := .ofName mv.userName
+
 structure Context where
   /-- Inferred and cached information about the monad. -/
   monadInfo : MonadInfo
   /-- The mutable variables in declaration order. -/
-  mutVars : Array Ident := #[]
+  mutVars : Array MutVar := #[]
   /-- Maps mutable variable names to their initial FVarIds. -/
   mutVarDefs : Std.HashMap Name FVarId := {}
   /--
@@ -298,16 +315,18 @@ def DoOps.default : DoOps where
 /-- Register the given name as that of a `mut` variable. -/
 def declareMutVar (x : Ident) (k : DoElabM α) : DoElabM α := do
   let id ← getFVarFromUserName x.getId
+  let mv : MutVar := { ident := x, initFVarId := id.fvarId! }
   withReader (fun ctx => { ctx with
-    mutVars := ctx.mutVars.push x,
+    mutVars := ctx.mutVars.push mv,
     mutVarDefs := ctx.mutVarDefs.insert x.getId id.fvarId!,
   }) k
 
 /-- Register the given names as that of `mut` variables. -/
 def declareMutVars (xs : Array Ident) (k : DoElabM α) : DoElabM α := do
   let baseIds ← xs.mapM (getFVarFromUserName ·.getId)
+  let mvs : Array MutVar := xs.zipWith (fun x id => { ident := x, initFVarId := id.fvarId! }) baseIds
   withReader (fun ctx => { ctx with
-    mutVars := ctx.mutVars ++ xs,
+    mutVars := ctx.mutVars ++ mvs,
     mutVarDefs := ctx.mutVarDefs.insertMany (xs.map (·.getId) |>.zip (baseIds.map (·.fvarId!))),
   }) k
 
@@ -318,6 +337,10 @@ def declareMutVar? (mutTk? : Option Syntax) (x : Ident) (k : DoElabM α) : DoEla
 /-- Register the given names as that of `mut` variables if the syntax token `mut` is present. -/
 def declareMutVars? (mutTk? : Option Syntax) (xs : Array Ident) (k : DoElabM α) : DoElabM α :=
   if mutTk?.isSome then declareMutVars xs k else k
+
+/-- Look up a declared `mut` variable by its raw `Name`. -/
+def findMutVar? (n : Name) : DoElabM (Option MutVar) := do
+  return (← read).mutVars.find? (·.getId == n)
 
 /-- Throw an error if the given name is not a declared `mut` variable. -/
 def throwUnlessMutVarDeclared (x : Ident) : DoElabM Unit := do
@@ -332,8 +355,8 @@ def throwUnlessMutVarsDeclared (xs : Array Ident) : DoElabM Unit := do
 
 /-- Throw an error if a declaration of the given name would shadow a `mut` variable. -/
 def checkMutVarsForShadowingOne (x : Ident) : DoElabM Unit := do
-  if (← read).mutVarDefs.contains x.getId then
-    throwErrorAt x "mutable variable `{x.getId.simpMacroScopes}` cannot be shadowed"
+  if let some mv ← findMutVar? x.getId then
+    throwErrorAt x "mutable variable `{mv}` cannot be shadowed"
 
 /-- Throw an error if a declaration of the given name would shadow a `mut` variable. -/
 def checkMutVarsForShadowing (xs : Array Ident) : DoElabM Unit := do
@@ -636,7 +659,7 @@ def DoElemCont.withDuplicableCont (nondupDec : DoElemCont) (callerInfo : Control
     let mut e := mkApp jp' result
     for x in mutVars do
       let newX ← getFVarFromUserName x.getId
-      Term.addTermInfo' x newX
+      Term.addTermInfo' x.ident newX
       e := mkApp e (← getFVarFromUserName x.getId)
     return e
 
@@ -649,7 +672,7 @@ def DoElemCont.withDuplicableCont (nondupDec : DoElemCont) (callerInfo : Control
   let joinRhs ← joinRhsMVar.mvarId!.withContext do
     withLocalDeclD nondupDec.resultName nondupDec.resultType fun r => do
     withLocalDeclsDND (mutDecls.map fun (d : LocalDecl) => (d.userName, d.type)) fun muts => do
-    for (x, newX) in mutVars.zip muts do Term.addTermInfo' x newX
+    for (x, newX) in mutVars.zip muts do Term.addTermInfo' x.ident newX
     let e ← (nondupDec.withDeadCodeFromInfo callerInfo).k
     mkLambdaFVars (#[r] ++ muts) e
   unless ← joinRhsMVar.mvarId!.checkedAssign joinRhs do

--- a/src/Lean/Elab/Do/Basic.lean
+++ b/src/Lean/Elab/Do/Basic.lean
@@ -96,7 +96,17 @@ structure MutVar where
 @[inline] def MutVar.userName (mv : MutVar) : Name := mv.ident.getId.simpMacroScopes
 
 instance : ToMessageData MutVar where
-  toMessageData mv := .ofName mv.userName
+  toMessageData mv :=
+    let fmt := format mv.userName
+    let expr := mkFVar mv.initFVarId
+    MessageData.ofLazy
+      (fun ctx? => do
+        let msg : MessageData :=
+          match ctx? with
+          | none => .ofFormat fmt
+          | some ctx => .withExprHover fmt expr ctx.lctx
+        return Dynamic.mk msg)
+      (fun _ => false)
 
 structure Context where
   /-- Inferred and cached information about the monad. -/

--- a/src/Lean/Elab/Do/Basic.lean
+++ b/src/Lean/Elab/Do/Basic.lean
@@ -89,15 +89,18 @@ structure MutVar where
   baseId : FVarId
   deriving Inhabited
 
+/-- The raw `Name` of a `mut` variable, as found in the local context. -/
+def MutVar.getId (mutVar : MutVar) : Name := mutVar.ident.getId
+
 /-- The pretty-printable name of a `mut` variable, with macro scopes simplified. -/
-abbrev MutVar.userName (mutVar : MutVar) : Name := mutVar.ident.getId.simpMacroScopes
+def MutVar.userName (mutVar : MutVar) : Name := mutVar.getId.simpMacroScopes
 
 /--
 Build an `FVarAliasInfo` recording that the reassignment binding `id` aliases the original
 `let mut` binding represented by `mutVar`.
 -/
 def MutVar.mkAliasInfo (mutVar : MutVar) (id : FVarId) : FVarAliasInfo :=
-  { userName := mutVar.ident.getId, id, baseId := mutVar.baseId }
+  { userName := mutVar.getId, id, baseId := mutVar.baseId }
 
 instance : ToMessageData MutVar where
   toMessageData mutVar :=
@@ -335,7 +338,7 @@ def declareMutVars (xs : Array Ident) (k : DoElabM α) : DoElabM α := do
   let newMutVars : Array MutVar := xs.zipWith (fun x fvar => { ident := x, baseId := fvar.fvarId! }) fvars
   withReader (fun ctx => { ctx with
     mutVars := ctx.mutVars ++ newMutVars,
-    mutVarDefs := ctx.mutVarDefs.insertMany (newMutVars.map fun mutVar => (mutVar.ident.getId, mutVar)),
+    mutVarDefs := ctx.mutVarDefs.insertMany (newMutVars.map fun mutVar => (mutVar.getId, mutVar)),
   }) k
 
 /-- Register the given name as that of a `mut` variable if the syntax token `mut` is present. -/
@@ -353,12 +356,7 @@ def findMutVar? (n : Name) : DoElabM (Option MutVar) := do
 /-- Throw an error if the given name is not a declared `mut` variable. -/
 def throwUnlessMutVarDeclared (x : Ident) : DoElabM Unit := do
   if (← findMutVar? x.getId).isNone then
-    let xName := x.getId.simpMacroScopes
-    -- If `x` is bound in the local context, attach hover info so "Go to Definition" on the
-    -- name in the error jumps to its `let` binding.
-    let xMsg ← match (← getLCtx).findFromUserName? x.getId with
-      | some decl => MessageData.withExprHoverM (format xName) (.fvar decl.fvarId)
-      | none => pure (.ofName xName)
+    let xMsg ← MessageData.ofUserName x.getId
     throwErrorAt x "Variable `{xMsg}` cannot be mutated. Only variables declared using `let mut` can be mutated.
       If you did not intend to mutate but define `{xMsg}`, consider using `let {xMsg}` instead"
 
@@ -656,8 +654,8 @@ def DoElemCont.withDuplicableCont (nondupDec : DoElemCont) (callerInfo : Control
     return ← caller nondupDec
   let γ := (← read).doBlockResultType
   let mγ ← mkMonadApp γ
-  let mutVars := (← read).mutVars |>.filter (callerInfo.reassigns.contains ·.ident.getId)
-  let mutVarNames := mutVars.map (·.ident.getId)
+  let mutVars := (← read).mutVars |>.filter (callerInfo.reassigns.contains ·.getId)
+  let mutVarNames := mutVars.map (·.getId)
   let joinName ← mkFreshUserName `__do_jp
   -- σ is the tuple type of the mut vars, or mγ if jumpCount = 0. Hence it is either level mi.u or mi.v.
   -- let σ ← mkFreshTypeMVar (userName := `σ)
@@ -671,9 +669,9 @@ def DoElemCont.withDuplicableCont (nondupDec : DoElemCont) (callerInfo : Control
     let result ← getFVarFromUserName nondupDec.resultName
     let mut e := mkApp jp' result
     for x in mutVars do
-      let newX ← getFVarFromUserName x.ident.getId
+      let newX ← getFVarFromUserName x.getId
       Term.addTermInfo' x.ident newX
-      e := mkApp e (← getFVarFromUserName x.ident.getId)
+      e := mkApp e (← getFVarFromUserName x.getId)
     return e
 
   let elabBody :=

--- a/src/Lean/Elab/Do/Basic.lean
+++ b/src/Lean/Elab/Do/Basic.lean
@@ -89,15 +89,9 @@ structure MutVar where
   baseId : FVarId
   deriving Inhabited
 
-/-- The raw `Name` of a `mut` variable, as found in the local context. -/
-abbrev MutVar.getId (mutVar : MutVar) : Name := mutVar.ident.getId
-
-/-- The pretty-printable name of a `mut` variable, with macro scopes simplified. -/
-abbrev MutVar.userName (mutVar : MutVar) : Name := mutVar.ident.getId.simpMacroScopes
-
 instance : ToMessageData MutVar where
   toMessageData mutVar :=
-    .ofLazyM <| MessageData.withExprHoverM (format mutVar.userName) (.fvar mutVar.baseId)
+    .ofLazyM <| MessageData.withExprHoverM (format mutVar.ident.getId.simpMacroScopes) (.fvar mutVar.baseId)
 
 structure Context where
   /-- Inferred and cached information about the monad. -/
@@ -315,8 +309,8 @@ def DoOps.default : DoOps where
 
 /-- Register the given name as that of a `mut` variable. -/
 def declareMutVar (x : Ident) (k : DoElabM α) : DoElabM α := do
-  let id ← getFVarFromUserName x.getId
-  let mutVar : MutVar := { ident := x, baseId := id.fvarId! }
+  let fvar ← getFVarFromUserName x.getId
+  let mutVar : MutVar := { ident := x, baseId := fvar.fvarId! }
   withReader (fun ctx => { ctx with
     mutVars := ctx.mutVars.push mutVar,
     mutVarDefs := ctx.mutVarDefs.insert x.getId mutVar,
@@ -324,11 +318,11 @@ def declareMutVar (x : Ident) (k : DoElabM α) : DoElabM α := do
 
 /-- Register the given names as that of `mut` variables. -/
 def declareMutVars (xs : Array Ident) (k : DoElabM α) : DoElabM α := do
-  let baseIds ← xs.mapM (getFVarFromUserName ·.getId)
-  let newMutVars : Array MutVar := xs.zipWith (fun x id => { ident := x, baseId := id.fvarId! }) baseIds
+  let fvars ← xs.mapM (getFVarFromUserName ·.getId)
+  let newMutVars : Array MutVar := xs.zipWith (fun x fvar => { ident := x, baseId := fvar.fvarId! }) fvars
   withReader (fun ctx => { ctx with
     mutVars := ctx.mutVars ++ newMutVars,
-    mutVarDefs := ctx.mutVarDefs.insertMany (newMutVars.map fun mutVar => (mutVar.getId, mutVar)),
+    mutVarDefs := ctx.mutVarDefs.insertMany (newMutVars.map fun mutVar => (mutVar.ident.getId, mutVar)),
   }) k
 
 /-- Register the given name as that of a `mut` variable if the syntax token `mut` is present. -/
@@ -644,8 +638,8 @@ def DoElemCont.withDuplicableCont (nondupDec : DoElemCont) (callerInfo : Control
     return ← caller nondupDec
   let γ := (← read).doBlockResultType
   let mγ ← mkMonadApp γ
-  let mutVars := (← read).mutVars |>.filter (callerInfo.reassigns.contains ·.getId)
-  let mutVarNames := mutVars.map (·.getId)
+  let mutVars := (← read).mutVars |>.filter (callerInfo.reassigns.contains ·.ident.getId)
+  let mutVarNames := mutVars.map (·.ident.getId)
   let joinName ← mkFreshUserName `__do_jp
   -- σ is the tuple type of the mut vars, or mγ if jumpCount = 0. Hence it is either level mi.u or mi.v.
   -- let σ ← mkFreshTypeMVar (userName := `σ)
@@ -659,9 +653,9 @@ def DoElemCont.withDuplicableCont (nondupDec : DoElemCont) (callerInfo : Control
     let result ← getFVarFromUserName nondupDec.resultName
     let mut e := mkApp jp' result
     for x in mutVars do
-      let newX ← getFVarFromUserName x.getId
+      let newX ← getFVarFromUserName x.ident.getId
       Term.addTermInfo' x.ident newX
-      e := mkApp e (← getFVarFromUserName x.getId)
+      e := mkApp e (← getFVarFromUserName x.ident.getId)
     return e
 
   let elabBody :=

--- a/src/Lean/Elab/Do/Basic.lean
+++ b/src/Lean/Elab/Do/Basic.lean
@@ -86,18 +86,18 @@ structure MutVar where
   /-- The identifier of the `let mut` declaration. -/
   ident : Ident
   /-- The `FVarId` of the initial binding produced by `let mut`. -/
-  initFVarId : FVarId
+  baseId : FVarId
   deriving Inhabited
 
 /-- The raw `Name` of a `mut` variable, as found in the local context. -/
-abbrev MutVar.getId (mv : MutVar) : Name := mv.ident.getId
+abbrev MutVar.getId (mutVar : MutVar) : Name := mutVar.ident.getId
 
 /-- The pretty-printable name of a `mut` variable, with macro scopes simplified. -/
-abbrev MutVar.userName (mv : MutVar) : Name := mv.ident.getId.simpMacroScopes
+abbrev MutVar.userName (mutVar : MutVar) : Name := mutVar.ident.getId.simpMacroScopes
 
 instance : ToMessageData MutVar where
-  toMessageData mv :=
-    .ofLazyM <| MessageData.withExprHoverM (format mv.userName) (.fvar mv.initFVarId)
+  toMessageData mutVar :=
+    .ofLazyM <| MessageData.withExprHoverM (format mutVar.userName) (.fvar mutVar.baseId)
 
 structure Context where
   /-- Inferred and cached information about the monad. -/
@@ -316,19 +316,19 @@ def DoOps.default : DoOps where
 /-- Register the given name as that of a `mut` variable. -/
 def declareMutVar (x : Ident) (k : DoElabM α) : DoElabM α := do
   let id ← getFVarFromUserName x.getId
-  let mv : MutVar := { ident := x, initFVarId := id.fvarId! }
+  let mutVar : MutVar := { ident := x, baseId := id.fvarId! }
   withReader (fun ctx => { ctx with
-    mutVars := ctx.mutVars.push mv,
-    mutVarDefs := ctx.mutVarDefs.insert x.getId mv,
+    mutVars := ctx.mutVars.push mutVar,
+    mutVarDefs := ctx.mutVarDefs.insert x.getId mutVar,
   }) k
 
 /-- Register the given names as that of `mut` variables. -/
 def declareMutVars (xs : Array Ident) (k : DoElabM α) : DoElabM α := do
   let baseIds ← xs.mapM (getFVarFromUserName ·.getId)
-  let mvs : Array MutVar := xs.zipWith (fun x id => { ident := x, initFVarId := id.fvarId! }) baseIds
+  let newMutVars : Array MutVar := xs.zipWith (fun x id => { ident := x, baseId := id.fvarId! }) baseIds
   withReader (fun ctx => { ctx with
-    mutVars := ctx.mutVars ++ mvs,
-    mutVarDefs := ctx.mutVarDefs.insertMany (mvs.map fun mv => (mv.getId, mv)),
+    mutVars := ctx.mutVars ++ newMutVars,
+    mutVarDefs := ctx.mutVarDefs.insertMany (newMutVars.map fun mutVar => (mutVar.getId, mutVar)),
   }) k
 
 /-- Register the given name as that of a `mut` variable if the syntax token `mut` is present. -/
@@ -345,7 +345,7 @@ def findMutVar? (n : Name) : DoElabM (Option MutVar) := do
 
 /-- Throw an error if the given name is not a declared `mut` variable. -/
 def throwUnlessMutVarDeclared (x : Ident) : DoElabM Unit := do
-  unless (← read).mutVarDefs.contains x.getId do
+  if (← findMutVar? x.getId).isNone then
     let xName := x.getId.simpMacroScopes
     throwErrorAt x "Variable `{xName}` cannot be mutated. Only variables declared using `let mut` can be mutated.
       If you did not intend to mutate but define `{xName}`, consider using `let {xName}` instead"
@@ -356,8 +356,8 @@ def throwUnlessMutVarsDeclared (xs : Array Ident) : DoElabM Unit := do
 
 /-- Throw an error if a declaration of the given name would shadow a `mut` variable. -/
 def checkMutVarsForShadowingOne (x : Ident) : DoElabM Unit := do
-  if let some mv ← findMutVar? x.getId then
-    throwErrorAt x "mutable variable `{mv}` cannot be shadowed"
+  if let some mutVar ← findMutVar? x.getId then
+    throwErrorAt x "mutable variable `{mutVar}` cannot be shadowed"
 
 /-- Throw an error if a declaration of the given name would shadow a `mut` variable. -/
 def checkMutVarsForShadowing (xs : Array Ident) : DoElabM Unit := do

--- a/src/Lean/Elab/Do/Basic.lean
+++ b/src/Lean/Elab/Do/Basic.lean
@@ -97,16 +97,7 @@ abbrev MutVar.userName (mv : MutVar) : Name := mv.ident.getId.simpMacroScopes
 
 instance : ToMessageData MutVar where
   toMessageData mv :=
-    let fmt := format mv.userName
-    let expr := mkFVar mv.initFVarId
-    MessageData.ofLazy
-      (fun ctx? => do
-        let msg : MessageData :=
-          match ctx? with
-          | none => .ofFormat fmt
-          | some ctx => .withExprHover fmt expr ctx.lctx
-        return Dynamic.mk msg)
-      (fun _ => false)
+    .ofLazyM <| MessageData.withExprHoverM (format mv.userName) (.fvar mv.initFVarId)
 
 structure Context where
   /-- Inferred and cached information about the monad. -/

--- a/src/Lean/Elab/Do/Basic.lean
+++ b/src/Lean/Elab/Do/Basic.lean
@@ -92,9 +92,6 @@ structure MutVar where
 /-- The raw `Name` of a `mut` variable, as found in the local context. -/
 def MutVar.getId (mutVar : MutVar) : Name := mutVar.ident.getId
 
-/-- The pretty-printable name of a `mut` variable, with macro scopes simplified. -/
-def MutVar.userName (mutVar : MutVar) : Name := mutVar.getId.simpMacroScopes
-
 /--
 Build an `FVarAliasInfo` recording that the reassignment binding `id` aliases the original
 `let mut` binding represented by `mutVar`.
@@ -104,7 +101,7 @@ def MutVar.mkAliasInfo (mutVar : MutVar) (id : FVarId) : FVarAliasInfo :=
 
 instance : ToMessageData MutVar where
   toMessageData mutVar :=
-    .ofLazyM <| MessageData.withExprHoverM (format mutVar.userName) (.fvar mutVar.baseId)
+    .ofLazyM <| MessageData.withExprHoverM (format mutVar.getId.simpMacroScopes) (.fvar mutVar.baseId)
 
 structure Context where
   /-- Inferred and cached information about the monad. -/

--- a/src/Lean/Elab/Do/Basic.lean
+++ b/src/Lean/Elab/Do/Basic.lean
@@ -89,16 +89,29 @@ structure MutVar where
   baseId : FVarId
   deriving Inhabited
 
+/-- The pretty-printable name of a `mut` variable, with macro scopes simplified. -/
+abbrev MutVar.userName (mutVar : MutVar) : Name := mutVar.ident.getId.simpMacroScopes
+
+/--
+Build an `FVarAliasInfo` recording that the reassignment binding `id` aliases the original
+`let mut` binding represented by `mutVar`.
+-/
+def MutVar.mkAliasInfo (mutVar : MutVar) (id : FVarId) : FVarAliasInfo :=
+  { userName := mutVar.ident.getId, id, baseId := mutVar.baseId }
+
 instance : ToMessageData MutVar where
   toMessageData mutVar :=
-    .ofLazyM <| MessageData.withExprHoverM (format mutVar.ident.getId.simpMacroScopes) (.fvar mutVar.baseId)
+    .ofLazyM <| MessageData.withExprHoverM (format mutVar.userName) (.fvar mutVar.baseId)
 
 structure Context where
   /-- Inferred and cached information about the monad. -/
   monadInfo : MonadInfo
-  /-- The mutable variables in declaration order. -/
+  /--
+  The mutable variables in declaration order. Kept in sync with `mutVarDefs`; insertions go
+  through `declareMutVar` / `declareMutVars` only.
+  -/
   mutVars : Array MutVar := #[]
-  /-- Maps mutable variable names to their `MutVar` record. -/
+  /-- Maps mutable variable names to their `MutVar` record. Kept in sync with `mutVars`. -/
   mutVarDefs : Std.HashMap Name MutVar := {}
   /--
   The expected type of the current `do` block.
@@ -341,8 +354,13 @@ def findMutVar? (n : Name) : DoElabM (Option MutVar) := do
 def throwUnlessMutVarDeclared (x : Ident) : DoElabM Unit := do
   if (← findMutVar? x.getId).isNone then
     let xName := x.getId.simpMacroScopes
-    throwErrorAt x "Variable `{xName}` cannot be mutated. Only variables declared using `let mut` can be mutated.
-      If you did not intend to mutate but define `{xName}`, consider using `let {xName}` instead"
+    -- If `x` is bound in the local context, attach hover info so "Go to Definition" on the
+    -- name in the error jumps to its `let` binding.
+    let xMsg ← match (← getLCtx).findFromUserName? x.getId with
+      | some decl => MessageData.withExprHoverM (format xName) (.fvar decl.fvarId)
+      | none => pure (.ofName xName)
+    throwErrorAt x "Variable `{xMsg}` cannot be mutated. Only variables declared using `let mut` can be mutated.
+      If you did not intend to mutate but define `{xMsg}`, consider using `let {xMsg}` instead"
 
 /-- Throw an error if the given names are not declared `mut` variables. -/
 def throwUnlessMutVarsDeclared (xs : Array Ident) : DoElabM Unit := do

--- a/src/Lean/Elab/Do/Basic.lean
+++ b/src/Lean/Elab/Do/Basic.lean
@@ -90,10 +90,10 @@ structure MutVar where
   deriving Inhabited
 
 /-- The raw `Name` of a `mut` variable, as found in the local context. -/
-@[inline] def MutVar.getId (mv : MutVar) : Name := mv.ident.getId
+abbrev MutVar.getId (mv : MutVar) : Name := mv.ident.getId
 
 /-- The pretty-printable name of a `mut` variable, with macro scopes simplified. -/
-@[inline] def MutVar.userName (mv : MutVar) : Name := mv.ident.getId.simpMacroScopes
+abbrev MutVar.userName (mv : MutVar) : Name := mv.ident.getId.simpMacroScopes
 
 instance : ToMessageData MutVar where
   toMessageData mv :=
@@ -113,8 +113,8 @@ structure Context where
   monadInfo : MonadInfo
   /-- The mutable variables in declaration order. -/
   mutVars : Array MutVar := #[]
-  /-- Maps mutable variable names to their initial FVarIds. -/
-  mutVarDefs : Std.HashMap Name FVarId := {}
+  /-- Maps mutable variable names to their `MutVar` record. -/
+  mutVarDefs : Std.HashMap Name MutVar := {}
   /--
   The expected type of the current `do` block.
   This can be different from `earlyReturnType` in `for` loop `do` blocks, for example.
@@ -328,7 +328,7 @@ def declareMutVar (x : Ident) (k : DoElabM α) : DoElabM α := do
   let mv : MutVar := { ident := x, initFVarId := id.fvarId! }
   withReader (fun ctx => { ctx with
     mutVars := ctx.mutVars.push mv,
-    mutVarDefs := ctx.mutVarDefs.insert x.getId id.fvarId!,
+    mutVarDefs := ctx.mutVarDefs.insert x.getId mv,
   }) k
 
 /-- Register the given names as that of `mut` variables. -/
@@ -337,7 +337,7 @@ def declareMutVars (xs : Array Ident) (k : DoElabM α) : DoElabM α := do
   let mvs : Array MutVar := xs.zipWith (fun x id => { ident := x, initFVarId := id.fvarId! }) baseIds
   withReader (fun ctx => { ctx with
     mutVars := ctx.mutVars ++ mvs,
-    mutVarDefs := ctx.mutVarDefs.insertMany (xs.map (·.getId) |>.zip (baseIds.map (·.fvarId!))),
+    mutVarDefs := ctx.mutVarDefs.insertMany (mvs.map fun mv => (mv.getId, mv)),
   }) k
 
 /-- Register the given name as that of a `mut` variable if the syntax token `mut` is present. -/
@@ -350,7 +350,7 @@ def declareMutVars? (mutTk? : Option Syntax) (xs : Array Ident) (k : DoElabM α)
 
 /-- Look up a declared `mut` variable by its raw `Name`. -/
 def findMutVar? (n : Name) : DoElabM (Option MutVar) := do
-  return (← read).mutVars.find? (·.getId == n)
+  return (← read).mutVarDefs[n]?
 
 /-- Throw an error if the given name is not a declared `mut` variable. -/
 def throwUnlessMutVarDeclared (x : Ident) : DoElabM Unit := do
@@ -458,7 +458,7 @@ mut var definition of `y`.
 def withLCtxKeepingMutVarDefs (oldLCtx : LocalContext) (oldCtx : Context) (resultName : Name) (k : DoElabM α) : DoElabM α := do
   let oldMutVars := oldCtx.mutVars
   let oldMutVarDefs := oldCtx.mutVarDefs
-  let tunneledDefs := oldMutVarDefs.insert resultName ⟨`unused⟩  -- tunneledDefs is used as a set, so the FVarId doesn't matter
+  let tunneledDefs := oldMutVarDefs.insert resultName default  -- tunneledDefs is used as a set, so the value doesn't matter
   let newCtx ← addReachingDefsAsNonDep oldLCtx (← getLCtx) tunneledDefs
   withLCtx' newCtx <| withReader (fun ctx => { ctx with
     mutVars := oldMutVars,

--- a/src/Lean/Elab/Do/Control.lean
+++ b/src/Lean/Elab/Do/Control.lean
@@ -37,16 +37,16 @@ def ControlStack.base (mi : MonadInfo) : ControlStack where
   runInBase e := pure e
   restoreCont dec := pure dec
 
-def ControlStack.stateT (baseMonadInfo : MonadInfo) (mutVarIdents : Array Ident) (σ : Expr) (base : ControlStack) : ControlStack where
+def ControlStack.stateT (baseMonadInfo : MonadInfo) (muts : Array MutVar) (σ : Expr) (base : ControlStack) : ControlStack where
   description _ := m!"StateT {σ} over {base.description ()}"
   m := return mkApp2 (mkConst ``StateT [baseMonadInfo.u, baseMonadInfo.v]) (← getσ) (← base.m)
   stM α := stM α >>= base.stM
   runInBase e := do
     -- `e : StateT σ m α`. Fetch the state tuple `s : σ` and apply it to `e`, `e.run s`.
     -- See also `StateT.monadControl.liftWith`.
-    let mutExprs ← mutVarIdents.mapM fun x => do
+    let mutExprs ← muts.mapM fun x => do
       let defn ← getLocalDeclFromUserName x.getId
-      Term.addTermInfo' x defn.toExpr
+      Term.addTermInfo' x.ident defn.toExpr
       pure defn.toExpr
     let (tuple, tupleTy) ← mkProdMkN mutExprs baseMonadInfo.u
     unless ← isDefEq tupleTy σ do -- just for sanity; maybe delete in the future
@@ -63,7 +63,7 @@ def ControlStack.stateT (baseMonadInfo : MonadInfo) (mutVarIdents : Array Ident)
         dec.k
     base.restoreCont { resultName, resultType, k }
 where
-  mutVarNames := mutVarIdents.map (·.getId)
+  mutVarNames := muts.map (·.getId)
   getσ := do mkProdN (← mutVarNames.mapM (LocalDecl.type <$> getLocalDeclFromUserName ·)) baseMonadInfo.u
   stM α := return mkApp2 (mkConst ``Prod [baseMonadInfo.u, baseMonadInfo.u]) α (← getσ) -- NB: muts `σ` might have been refined by dependent pattern matches
 

--- a/src/Lean/Elab/Do/Control.lean
+++ b/src/Lean/Elab/Do/Control.lean
@@ -45,7 +45,7 @@ def ControlStack.stateT (baseMonadInfo : MonadInfo) (muts : Array MutVar) (σ : 
     -- `e : StateT σ m α`. Fetch the state tuple `s : σ` and apply it to `e`, `e.run s`.
     -- See also `StateT.monadControl.liftWith`.
     let mutExprs ← muts.mapM fun x => do
-      let defn ← getLocalDeclFromUserName x.ident.getId
+      let defn ← getLocalDeclFromUserName x.getId
       Term.addTermInfo' x.ident defn.toExpr
       pure defn.toExpr
     let (tuple, tupleTy) ← mkProdMkN mutExprs baseMonadInfo.u
@@ -63,7 +63,7 @@ def ControlStack.stateT (baseMonadInfo : MonadInfo) (muts : Array MutVar) (σ : 
         dec.k
     base.restoreCont { resultName, resultType, k }
 where
-  mutVarNames := muts.map (·.ident.getId)
+  mutVarNames := muts.map (·.getId)
   getσ := do mkProdN (← mutVarNames.mapM (LocalDecl.type <$> getLocalDeclFromUserName ·)) baseMonadInfo.u
   stM α := return mkApp2 (mkConst ``Prod [baseMonadInfo.u, baseMonadInfo.u]) α (← getσ) -- NB: muts `σ` might have been refined by dependent pattern matches
 
@@ -208,8 +208,8 @@ structure EffectForwarder where
 /-- Build the lifter plan for a body whose effects are summarised by `info`. -/
 def EffectForwarder.ofCont (info : ControlInfo) (dec : DoElemCont) : DoElabM EffectForwarder := do
   let mi := (← read).monadInfo
-  let reassignedMutVars := (← read).mutVars |>.filter (info.reassigns.contains ·.ident.getId)
-  let reassignedMutVarNames := reassignedMutVars.map (·.ident.getId)
+  let reassignedMutVars := (← read).mutVars |>.filter (info.reassigns.contains ·.getId)
+  let reassignedMutVarNames := reassignedMutVars.map (·.getId)
   let ρ := (← getReturnCont).resultType
   let σ ← mkProdN (← reassignedMutVarNames.mapM (LocalDecl.type <$> getLocalDeclFromUserName ·)) mi.u
 

--- a/src/Lean/Elab/Do/Control.lean
+++ b/src/Lean/Elab/Do/Control.lean
@@ -45,7 +45,7 @@ def ControlStack.stateT (baseMonadInfo : MonadInfo) (muts : Array MutVar) (σ : 
     -- `e : StateT σ m α`. Fetch the state tuple `s : σ` and apply it to `e`, `e.run s`.
     -- See also `StateT.monadControl.liftWith`.
     let mutExprs ← muts.mapM fun x => do
-      let defn ← getLocalDeclFromUserName x.getId
+      let defn ← getLocalDeclFromUserName x.ident.getId
       Term.addTermInfo' x.ident defn.toExpr
       pure defn.toExpr
     let (tuple, tupleTy) ← mkProdMkN mutExprs baseMonadInfo.u
@@ -63,7 +63,7 @@ def ControlStack.stateT (baseMonadInfo : MonadInfo) (muts : Array MutVar) (σ : 
         dec.k
     base.restoreCont { resultName, resultType, k }
 where
-  mutVarNames := muts.map (·.getId)
+  mutVarNames := muts.map (·.ident.getId)
   getσ := do mkProdN (← mutVarNames.mapM (LocalDecl.type <$> getLocalDeclFromUserName ·)) baseMonadInfo.u
   stM α := return mkApp2 (mkConst ``Prod [baseMonadInfo.u, baseMonadInfo.u]) α (← getσ) -- NB: muts `σ` might have been refined by dependent pattern matches
 
@@ -208,8 +208,8 @@ structure EffectForwarder where
 /-- Build the lifter plan for a body whose effects are summarised by `info`. -/
 def EffectForwarder.ofCont (info : ControlInfo) (dec : DoElemCont) : DoElabM EffectForwarder := do
   let mi := (← read).monadInfo
-  let reassignedMutVars := (← read).mutVars |>.filter (info.reassigns.contains ·.getId)
-  let reassignedMutVarNames := reassignedMutVars.map (·.getId)
+  let reassignedMutVars := (← read).mutVars |>.filter (info.reassigns.contains ·.ident.getId)
+  let reassignedMutVarNames := reassignedMutVars.map (·.ident.getId)
   let ρ := (← getReturnCont).resultType
   let σ ← mkProdN (← reassignedMutVarNames.mapM (LocalDecl.type <$> getLocalDeclFromUserName ·)) mi.u
 

--- a/src/Lean/Message.lean
+++ b/src/Lean/Message.lean
@@ -316,6 +316,18 @@ def withExprHoverM {m} [Monad m] [MonadLCtx m]
   let lctx ← lctx?.getDM getLCtx
   return withExprHover fmt expr lctx location? docString? mkDocString? explicit
 
+/--
+Render `userName` as `MessageData`, attaching hover information for the local declaration with
+that user-facing name if it is bound in the current `LocalContext`. The lookup uses `userName`
+verbatim (so macro scopes are preserved for matching) and the rendered name uses
+`userName.simpMacroScopes`. Falls back to plain text when the variable is not in scope.
+-/
+def ofUserName {m} [Monad m] [MonadLCtx m] (userName : Name) : m MessageData := do
+  let display := userName.simpMacroScopes
+  match (← getLCtx).findFromUserName? userName with
+  | some decl => withExprHoverM (format display) (.fvar decl.fvarId)
+  | none => pure (ofName display)
+
 partial def hasSyntheticSorry (msg : MessageData) : Bool :=
   visit none msg
 where

--- a/tests/elab/doForInvariant.lean
+++ b/tests/elab/doForInvariant.lean
@@ -62,7 +62,7 @@ elab_rules : doElem <= dec
         reassignments := reassignments.push (← `(_))
       | some fvarId =>
         let decl ← fvarId.getDecl
-        let .some mutVar := (← read).mutVars.find? (·.ident.getId = decl.userName) | continue
+        let .some mutVar := (← read).mutVars.find? (·.getId = decl.userName) | continue
         reassignments := reassignments.push mutVar.ident
       unless more do break
     let mutVarBinders ← Term.Quotation.mkTuple reassignments

--- a/tests/elab/doForInvariant.lean
+++ b/tests/elab/doForInvariant.lean
@@ -62,8 +62,8 @@ elab_rules : doElem <= dec
         reassignments := reassignments.push (← `(_))
       | some fvarId =>
         let decl ← fvarId.getDecl
-        let .some id := (← read).mutVars.find? (·.getId = decl.userName) | continue
-        reassignments := reassignments.push id
+        let .some mv := (← read).mutVars.find? (·.getId = decl.userName) | continue
+        reassignments := reassignments.push mv.ident
       unless more do break
     let mutVarBinders ← Term.Quotation.mkTuple reassignments
     let cursorσ := mkApp2 (mkConst ``Prod [v, mi.u]) cursor σ

--- a/tests/elab/doForInvariant.lean
+++ b/tests/elab/doForInvariant.lean
@@ -62,8 +62,8 @@ elab_rules : doElem <= dec
         reassignments := reassignments.push (← `(_))
       | some fvarId =>
         let decl ← fvarId.getDecl
-        let .some mv := (← read).mutVars.find? (·.getId = decl.userName) | continue
-        reassignments := reassignments.push mv.ident
+        let .some mutVar := (← read).mutVars.find? (·.ident.getId = decl.userName) | continue
+        reassignments := reassignments.push mutVar.ident
       unless more do break
     let mutVarBinders ← Term.Quotation.mkTuple reassignments
     let cursorσ := mkApp2 (mkConst ``Prod [v, mi.u]) cursor σ

--- a/tests/server_interactive/hoverMutVarInDiagnostic.lean
+++ b/tests/server_interactive/hoverMutVarInDiagnostic.lean
@@ -1,0 +1,12 @@
+/-!
+Regression test: in an error message that mentions a `mut` variable, the rendered name carries
+hover info (a `subexprPos`/`__rpcref`-tagged subexpression) so that hovering over it in the
+infoview reveals its type and "Go to Definition" jumps to the original `let mut` binding.
+-/
+
+example : Id Nat := do
+  let mut x := 0
+  let x := 1
+  pure x
+--^ collectDiagnostics
+--^ interactiveDiagnostics

--- a/tests/server_interactive/hoverMutVarInDiagnostic.lean
+++ b/tests/server_interactive/hoverMutVarInDiagnostic.lean
@@ -1,13 +1,23 @@
 /-!
-Regression tests for hover/go-to-def info on variable names in `do`-elaborator diagnostics.
+Regression tests for IDE integration of `mut` variables in `do`-elaborator diagnostics.
 
-* A shadowing error involving multiple `mut` variables identifies the right one, both in the
-  rendered message text (`mutable variable \`x\` cannot be shadowed`) and via the hover info
-  attached to the printed name.
-* A "cannot be mutated" error on a regular `let`-bound variable carries hover info pointing
-  at the `let` binding.
-* A "cannot be mutated" error on an *undeclared* variable falls back to plain text — the
-  `none` branch of `MessageData.ofUserName`.
+The `interactiveDiagnostics` examples assert on the *structural shape* of the rendered
+diagnostic JSON: the presence or absence of a `subexprPos`/`__rpcref` tag on each variable
+name. They do not resolve the RPC ref back to its `FVarId`, so a bug that wired the hover
+info to the wrong expression would still pass these checks. What they do catch: forgetting
+to attach hover info at all (the rpcref would disappear), looking up the wrong `MutVar` for
+a shadowing message (the rendered name would change), and breaking the plain-text fallback
+for undeclared names.
+
+  - Multi-mut shadowing: the message text confirms `findMutVar?` picked the `x`, not the `y`.
+  - Regular `let`-bound variable: each occurrence of the name gets an rpcref attached via
+    the `some decl` branch of `MessageData.ofUserName`.
+  - Undeclared variable: each occurrence renders as plain text via the `none` branch.
+
+The trailing `documentHighlight` example closes the loop on the alias-chain side: with two
+`mut` variables in scope and an explicit reassignment, highlighting at the `let mut x`
+source position should pick up only the `x` occurrences, not the `y` ones. This exercises
+the `FVarAliasInfo` records populated by `MutVar.mkAliasInfo`.
 -/
 
 example : Id Nat := do
@@ -26,3 +36,10 @@ example : Id Nat := do
   pure 0
 --^ collectDiagnostics
 --^ interactiveDiagnostics
+
+example : Id Nat := Id.run do
+  let mut x := 0
+        --^ textDocument/documentHighlight
+  let mut y := 0
+  x := 1
+  pure (x + y)

--- a/tests/server_interactive/hoverMutVarInDiagnostic.lean
+++ b/tests/server_interactive/hoverMutVarInDiagnostic.lean
@@ -1,12 +1,19 @@
 /-!
-Regression test: in an error message that mentions a `mut` variable, the rendered name carries
-hover info (a `subexprPos`/`__rpcref`-tagged subexpression) so that hovering over it in the
-infoview reveals its type and "Go to Definition" jumps to the original `let mut` binding.
+Regression test: error messages from the `do` elaborator that mention a variable wrap that name
+with hover info (a `subexprPos`/`__rpcref`-tagged subexpression). The first `example` triggers
+the shadowing error, where the printed `x` should jump to the `let mut x := 0` binding.
+The second `example` triggers the "cannot be mutated" error, where the printed `y` should jump
+to the `let y := 0` binding.
 -/
 
 example : Id Nat := do
   let mut x := 0
   let x := 1
   pure x
+
+example : Id Nat := do
+  let y := 0
+  y := 1
+  pure y
 --^ collectDiagnostics
 --^ interactiveDiagnostics

--- a/tests/server_interactive/hoverMutVarInDiagnostic.lean
+++ b/tests/server_interactive/hoverMutVarInDiagnostic.lean
@@ -1,19 +1,28 @@
 /-!
-Regression test: error messages from the `do` elaborator that mention a variable wrap that name
-with hover info (a `subexprPos`/`__rpcref`-tagged subexpression). The first `example` triggers
-the shadowing error, where the printed `x` should jump to the `let mut x := 0` binding.
-The second `example` triggers the "cannot be mutated" error, where the printed `y` should jump
-to the `let y := 0` binding.
+Regression tests for hover/go-to-def info on variable names in `do`-elaborator diagnostics.
+
+* A shadowing error involving multiple `mut` variables identifies the right one, both in the
+  rendered message text (`mutable variable \`x\` cannot be shadowed`) and via the hover info
+  attached to the printed name.
+* A "cannot be mutated" error on a regular `let`-bound variable carries hover info pointing
+  at the `let` binding.
+* A "cannot be mutated" error on an *undeclared* variable falls back to plain text — the
+  `none` branch of `MessageData.ofUserName`.
 -/
 
 example : Id Nat := do
   let mut x := 0
+  let mut y := 0
   let x := 1
-  pure x
+  pure (x + y)
 
 example : Id Nat := do
   let y := 0
   y := 1
   pure y
+
+example : Id Nat := do
+  q := 1
+  pure 0
 --^ collectDiagnostics
 --^ interactiveDiagnostics

--- a/tests/server_interactive/hoverMutVarInDiagnostic.lean
+++ b/tests/server_interactive/hoverMutVarInDiagnostic.lean
@@ -1,17 +1,8 @@
 /-!
-Regression tests for hover info on variable names in `do`-elaborator diagnostics.
-
-The examples assert on the structural shape of the rendered diagnostic JSON: the presence
-or absence of a `subexprPos`/`__rpcref` tag on each variable name. They do not resolve the
-RPC ref back to its `FVarId`, so a bug that wired the hover info to the wrong expression
-would still pass these checks. What they do catch: forgetting to attach hover info at all
-(the rpcref would disappear), looking up the wrong `MutVar` for a shadowing message (the
-rendered name would change), and breaking the plain-text fallback for undeclared names.
-
-  - Multi-mut shadowing: the message text confirms `findMutVar?` picked the `x`, not the `y`.
-  - Regular `let`-bound variable: each occurrence of the name gets an rpcref attached via
-    the `some decl` branch of `MessageData.ofUserName`.
-  - Undeclared variable: each occurrence renders as plain text via the `none` branch.
+Regression tests for hover info on variable names in `do`-elaborator diagnostics. Each
+example asserts on the rendered JSON: whether the name carries a `subexprPos`/`__rpcref`
+hover tag (multi-mut shadowing and a regular `let`-bound variable: yes; an undeclared
+variable: no) and which name the message shows.
 -/
 
 example : Id Nat := do

--- a/tests/server_interactive/hoverMutVarInDiagnostic.lean
+++ b/tests/server_interactive/hoverMutVarInDiagnostic.lean
@@ -1,23 +1,17 @@
 /-!
-Regression tests for IDE integration of `mut` variables in `do`-elaborator diagnostics.
+Regression tests for hover info on variable names in `do`-elaborator diagnostics.
 
-The `interactiveDiagnostics` examples assert on the *structural shape* of the rendered
-diagnostic JSON: the presence or absence of a `subexprPos`/`__rpcref` tag on each variable
-name. They do not resolve the RPC ref back to its `FVarId`, so a bug that wired the hover
-info to the wrong expression would still pass these checks. What they do catch: forgetting
-to attach hover info at all (the rpcref would disappear), looking up the wrong `MutVar` for
-a shadowing message (the rendered name would change), and breaking the plain-text fallback
-for undeclared names.
+The examples assert on the structural shape of the rendered diagnostic JSON: the presence
+or absence of a `subexprPos`/`__rpcref` tag on each variable name. They do not resolve the
+RPC ref back to its `FVarId`, so a bug that wired the hover info to the wrong expression
+would still pass these checks. What they do catch: forgetting to attach hover info at all
+(the rpcref would disappear), looking up the wrong `MutVar` for a shadowing message (the
+rendered name would change), and breaking the plain-text fallback for undeclared names.
 
   - Multi-mut shadowing: the message text confirms `findMutVar?` picked the `x`, not the `y`.
   - Regular `let`-bound variable: each occurrence of the name gets an rpcref attached via
     the `some decl` branch of `MessageData.ofUserName`.
   - Undeclared variable: each occurrence renders as plain text via the `none` branch.
-
-The trailing `documentHighlight` example closes the loop on the alias-chain side: with two
-`mut` variables in scope and an explicit reassignment, highlighting at the `let mut x`
-source position should pick up only the `x` occurrences, not the `y` ones. This exercises
-the `FVarAliasInfo` records populated by `MutVar.mkAliasInfo`.
 -/
 
 example : Id Nat := do
@@ -36,10 +30,3 @@ example : Id Nat := do
   pure 0
 --^ collectDiagnostics
 --^ interactiveDiagnostics
-
-example : Id Nat := Id.run do
-  let mut x := 0
-        --^ textDocument/documentHighlight
-  let mut y := 0
-  x := 1
-  pure (x + y)

--- a/tests/server_interactive/hoverMutVarInDiagnostic.lean.out.expected
+++ b/tests/server_interactive/hoverMutVarInDiagnostic.lean.out.expected
@@ -1,0 +1,27 @@
+{"version": 1,
+ "uri": "file:///hoverMutVarInDiagnostic.lean",
+ "isIncremental": false,
+ "diagnostics":
+ [{"source": "Lean 4",
+   "severity": 1,
+   "range":
+   {"start": {"line": 8, "character": 6}, "end": {"line": 8, "character": 7}},
+   "message": "mutable variable `x` cannot be shadowed",
+   "fullRange":
+   {"start": {"line": 8, "character": 6}, "end": {"line": 8, "character": 7}}}]}
+{"lineRange": {"start": 0, "end": 10}}
+[{"source": "Lean 4",
+  "severity": 1,
+  "range":
+  {"start": {"line": 8, "character": 6}, "end": {"line": 8, "character": 7}},
+  "message":
+  {"append":
+   [{"tag": [{"expr": {"text": "mutable variable `"}}, {"text": ""}]},
+    {"tag":
+     [{"expr":
+       {"tag":
+        [{"subexprPos": "/", "info": {"__rpcref": "0"}}, {"text": "x"}]}},
+      {"text": ""}]},
+    {"tag": [{"expr": {"text": "` cannot be shadowed"}}, {"text": ""}]}]},
+  "fullRange":
+  {"start": {"line": 8, "character": 6}, "end": {"line": 8, "character": 7}}}]

--- a/tests/server_interactive/hoverMutVarInDiagnostic.lean.out.expected
+++ b/tests/server_interactive/hoverMutVarInDiagnostic.lean.out.expected
@@ -5,34 +5,34 @@
  [{"source": "Lean 4",
    "severity": 1,
    "range":
-   {"start": {"line": 15, "character": 6}, "end": {"line": 15, "character": 7}},
+   {"start": {"line": 25, "character": 6}, "end": {"line": 25, "character": 7}},
    "message": "mutable variable `x` cannot be shadowed",
    "fullRange":
-   {"start": {"line": 15, "character": 6},
-    "end": {"line": 15, "character": 7}}},
+   {"start": {"line": 25, "character": 6},
+    "end": {"line": 25, "character": 7}}},
   {"source": "Lean 4",
    "severity": 1,
    "range":
-   {"start": {"line": 20, "character": 2}, "end": {"line": 20, "character": 3}},
+   {"start": {"line": 30, "character": 2}, "end": {"line": 30, "character": 3}},
    "message":
    "Variable `y` cannot be mutated. Only variables declared using `let mut` can be mutated.\n      If you did not intend to mutate but define `y`, consider using `let y` instead",
    "fullRange":
-   {"start": {"line": 20, "character": 2},
-    "end": {"line": 20, "character": 3}}},
+   {"start": {"line": 30, "character": 2},
+    "end": {"line": 30, "character": 3}}},
   {"source": "Lean 4",
    "severity": 1,
    "range":
-   {"start": {"line": 24, "character": 2}, "end": {"line": 24, "character": 3}},
+   {"start": {"line": 34, "character": 2}, "end": {"line": 34, "character": 3}},
    "message":
    "Variable `q` cannot be mutated. Only variables declared using `let mut` can be mutated.\n      If you did not intend to mutate but define `q`, consider using `let q` instead",
    "fullRange":
-   {"start": {"line": 24, "character": 2},
-    "end": {"line": 24, "character": 3}}}]}
-{"lineRange": {"start": 0, "end": 26}}
+   {"start": {"line": 34, "character": 2},
+    "end": {"line": 34, "character": 3}}}]}
+{"lineRange": {"start": 0, "end": 36}}
 [{"source": "Lean 4",
   "severity": 1,
   "range":
-  {"start": {"line": 15, "character": 6}, "end": {"line": 15, "character": 7}},
+  {"start": {"line": 25, "character": 6}, "end": {"line": 25, "character": 7}},
   "message":
   {"append":
    [{"tag": [{"expr": {"text": "mutable variable `"}}, {"text": ""}]},
@@ -43,11 +43,11 @@
       {"text": ""}]},
     {"tag": [{"expr": {"text": "` cannot be shadowed"}}, {"text": ""}]}]},
   "fullRange":
-  {"start": {"line": 15, "character": 6}, "end": {"line": 15, "character": 7}}},
+  {"start": {"line": 25, "character": 6}, "end": {"line": 25, "character": 7}}},
  {"source": "Lean 4",
   "severity": 1,
   "range":
-  {"start": {"line": 20, "character": 2}, "end": {"line": 20, "character": 3}},
+  {"start": {"line": 30, "character": 2}, "end": {"line": 30, "character": 3}},
   "message":
   {"append":
    [{"tag": [{"expr": {"text": "Variable `"}}, {"text": ""}]},
@@ -78,11 +78,11 @@
       {"text": ""}]},
     {"tag": [{"expr": {"text": "` instead"}}, {"text": ""}]}]},
   "fullRange":
-  {"start": {"line": 20, "character": 2}, "end": {"line": 20, "character": 3}}},
+  {"start": {"line": 30, "character": 2}, "end": {"line": 30, "character": 3}}},
  {"source": "Lean 4",
   "severity": 1,
   "range":
-  {"start": {"line": 24, "character": 2}, "end": {"line": 24, "character": 3}},
+  {"start": {"line": 34, "character": 2}, "end": {"line": 34, "character": 3}},
   "message":
   {"append":
    [{"tag": [{"expr": {"text": "Variable `"}}, {"text": ""}]},
@@ -101,4 +101,16 @@
     {"tag": [{"expr": {"text": "q"}}, {"text": ""}]},
     {"tag": [{"expr": {"text": "` instead"}}, {"text": ""}]}]},
   "fullRange":
-  {"start": {"line": 24, "character": 2}, "end": {"line": 24, "character": 3}}}]
+  {"start": {"line": 34, "character": 2}, "end": {"line": 34, "character": 3}}}]
+{"textDocument": {"uri": "file:///hoverMutVarInDiagnostic.lean"},
+ "position": {"line": 40, "character": 10}}
+[{"range":
+  {"start": {"line": 40, "character": 10},
+   "end": {"line": 40, "character": 11}},
+  "kind": 1},
+ {"range":
+  {"start": {"line": 43, "character": 2}, "end": {"line": 43, "character": 3}},
+  "kind": 1},
+ {"range":
+  {"start": {"line": 44, "character": 8}, "end": {"line": 44, "character": 9}},
+  "kind": 1}]

--- a/tests/server_interactive/hoverMutVarInDiagnostic.lean.out.expected
+++ b/tests/server_interactive/hoverMutVarInDiagnostic.lean.out.expected
@@ -5,34 +5,34 @@
  [{"source": "Lean 4",
    "severity": 1,
    "range":
-   {"start": {"line": 19, "character": 6}, "end": {"line": 19, "character": 7}},
+   {"start": {"line": 10, "character": 6}, "end": {"line": 10, "character": 7}},
    "message": "mutable variable `x` cannot be shadowed",
    "fullRange":
-   {"start": {"line": 19, "character": 6},
-    "end": {"line": 19, "character": 7}}},
+   {"start": {"line": 10, "character": 6},
+    "end": {"line": 10, "character": 7}}},
   {"source": "Lean 4",
    "severity": 1,
    "range":
-   {"start": {"line": 24, "character": 2}, "end": {"line": 24, "character": 3}},
+   {"start": {"line": 15, "character": 2}, "end": {"line": 15, "character": 3}},
    "message":
    "Variable `y` cannot be mutated. Only variables declared using `let mut` can be mutated.\n      If you did not intend to mutate but define `y`, consider using `let y` instead",
    "fullRange":
-   {"start": {"line": 24, "character": 2},
-    "end": {"line": 24, "character": 3}}},
+   {"start": {"line": 15, "character": 2},
+    "end": {"line": 15, "character": 3}}},
   {"source": "Lean 4",
    "severity": 1,
    "range":
-   {"start": {"line": 28, "character": 2}, "end": {"line": 28, "character": 3}},
+   {"start": {"line": 19, "character": 2}, "end": {"line": 19, "character": 3}},
    "message":
    "Variable `q` cannot be mutated. Only variables declared using `let mut` can be mutated.\n      If you did not intend to mutate but define `q`, consider using `let q` instead",
    "fullRange":
-   {"start": {"line": 28, "character": 2},
-    "end": {"line": 28, "character": 3}}}]}
-{"lineRange": {"start": 0, "end": 30}}
+   {"start": {"line": 19, "character": 2},
+    "end": {"line": 19, "character": 3}}}]}
+{"lineRange": {"start": 0, "end": 21}}
 [{"source": "Lean 4",
   "severity": 1,
   "range":
-  {"start": {"line": 19, "character": 6}, "end": {"line": 19, "character": 7}},
+  {"start": {"line": 10, "character": 6}, "end": {"line": 10, "character": 7}},
   "message":
   {"append":
    [{"tag": [{"expr": {"text": "mutable variable `"}}, {"text": ""}]},
@@ -43,11 +43,11 @@
       {"text": ""}]},
     {"tag": [{"expr": {"text": "` cannot be shadowed"}}, {"text": ""}]}]},
   "fullRange":
-  {"start": {"line": 19, "character": 6}, "end": {"line": 19, "character": 7}}},
+  {"start": {"line": 10, "character": 6}, "end": {"line": 10, "character": 7}}},
  {"source": "Lean 4",
   "severity": 1,
   "range":
-  {"start": {"line": 24, "character": 2}, "end": {"line": 24, "character": 3}},
+  {"start": {"line": 15, "character": 2}, "end": {"line": 15, "character": 3}},
   "message":
   {"append":
    [{"tag": [{"expr": {"text": "Variable `"}}, {"text": ""}]},
@@ -78,11 +78,11 @@
       {"text": ""}]},
     {"tag": [{"expr": {"text": "` instead"}}, {"text": ""}]}]},
   "fullRange":
-  {"start": {"line": 24, "character": 2}, "end": {"line": 24, "character": 3}}},
+  {"start": {"line": 15, "character": 2}, "end": {"line": 15, "character": 3}}},
  {"source": "Lean 4",
   "severity": 1,
   "range":
-  {"start": {"line": 28, "character": 2}, "end": {"line": 28, "character": 3}},
+  {"start": {"line": 19, "character": 2}, "end": {"line": 19, "character": 3}},
   "message":
   {"append":
    [{"tag": [{"expr": {"text": "Variable `"}}, {"text": ""}]},
@@ -101,4 +101,4 @@
     {"tag": [{"expr": {"text": "q"}}, {"text": ""}]},
     {"tag": [{"expr": {"text": "` instead"}}, {"text": ""}]}]},
   "fullRange":
-  {"start": {"line": 28, "character": 2}, "end": {"line": 28, "character": 3}}}]
+  {"start": {"line": 19, "character": 2}, "end": {"line": 19, "character": 3}}}]

--- a/tests/server_interactive/hoverMutVarInDiagnostic.lean.out.expected
+++ b/tests/server_interactive/hoverMutVarInDiagnostic.lean.out.expected
@@ -5,34 +5,34 @@
  [{"source": "Lean 4",
    "severity": 1,
    "range":
-   {"start": {"line": 25, "character": 6}, "end": {"line": 25, "character": 7}},
+   {"start": {"line": 19, "character": 6}, "end": {"line": 19, "character": 7}},
    "message": "mutable variable `x` cannot be shadowed",
    "fullRange":
-   {"start": {"line": 25, "character": 6},
-    "end": {"line": 25, "character": 7}}},
+   {"start": {"line": 19, "character": 6},
+    "end": {"line": 19, "character": 7}}},
   {"source": "Lean 4",
    "severity": 1,
    "range":
-   {"start": {"line": 30, "character": 2}, "end": {"line": 30, "character": 3}},
+   {"start": {"line": 24, "character": 2}, "end": {"line": 24, "character": 3}},
    "message":
    "Variable `y` cannot be mutated. Only variables declared using `let mut` can be mutated.\n      If you did not intend to mutate but define `y`, consider using `let y` instead",
    "fullRange":
-   {"start": {"line": 30, "character": 2},
-    "end": {"line": 30, "character": 3}}},
+   {"start": {"line": 24, "character": 2},
+    "end": {"line": 24, "character": 3}}},
   {"source": "Lean 4",
    "severity": 1,
    "range":
-   {"start": {"line": 34, "character": 2}, "end": {"line": 34, "character": 3}},
+   {"start": {"line": 28, "character": 2}, "end": {"line": 28, "character": 3}},
    "message":
    "Variable `q` cannot be mutated. Only variables declared using `let mut` can be mutated.\n      If you did not intend to mutate but define `q`, consider using `let q` instead",
    "fullRange":
-   {"start": {"line": 34, "character": 2},
-    "end": {"line": 34, "character": 3}}}]}
-{"lineRange": {"start": 0, "end": 36}}
+   {"start": {"line": 28, "character": 2},
+    "end": {"line": 28, "character": 3}}}]}
+{"lineRange": {"start": 0, "end": 30}}
 [{"source": "Lean 4",
   "severity": 1,
   "range":
-  {"start": {"line": 25, "character": 6}, "end": {"line": 25, "character": 7}},
+  {"start": {"line": 19, "character": 6}, "end": {"line": 19, "character": 7}},
   "message":
   {"append":
    [{"tag": [{"expr": {"text": "mutable variable `"}}, {"text": ""}]},
@@ -43,11 +43,11 @@
       {"text": ""}]},
     {"tag": [{"expr": {"text": "` cannot be shadowed"}}, {"text": ""}]}]},
   "fullRange":
-  {"start": {"line": 25, "character": 6}, "end": {"line": 25, "character": 7}}},
+  {"start": {"line": 19, "character": 6}, "end": {"line": 19, "character": 7}}},
  {"source": "Lean 4",
   "severity": 1,
   "range":
-  {"start": {"line": 30, "character": 2}, "end": {"line": 30, "character": 3}},
+  {"start": {"line": 24, "character": 2}, "end": {"line": 24, "character": 3}},
   "message":
   {"append":
    [{"tag": [{"expr": {"text": "Variable `"}}, {"text": ""}]},
@@ -78,11 +78,11 @@
       {"text": ""}]},
     {"tag": [{"expr": {"text": "` instead"}}, {"text": ""}]}]},
   "fullRange":
-  {"start": {"line": 30, "character": 2}, "end": {"line": 30, "character": 3}}},
+  {"start": {"line": 24, "character": 2}, "end": {"line": 24, "character": 3}}},
  {"source": "Lean 4",
   "severity": 1,
   "range":
-  {"start": {"line": 34, "character": 2}, "end": {"line": 34, "character": 3}},
+  {"start": {"line": 28, "character": 2}, "end": {"line": 28, "character": 3}},
   "message":
   {"append":
    [{"tag": [{"expr": {"text": "Variable `"}}, {"text": ""}]},
@@ -101,16 +101,4 @@
     {"tag": [{"expr": {"text": "q"}}, {"text": ""}]},
     {"tag": [{"expr": {"text": "` instead"}}, {"text": ""}]}]},
   "fullRange":
-  {"start": {"line": 34, "character": 2}, "end": {"line": 34, "character": 3}}}]
-{"textDocument": {"uri": "file:///hoverMutVarInDiagnostic.lean"},
- "position": {"line": 40, "character": 10}}
-[{"range":
-  {"start": {"line": 40, "character": 10},
-   "end": {"line": 40, "character": 11}},
-  "kind": 1},
- {"range":
-  {"start": {"line": 43, "character": 2}, "end": {"line": 43, "character": 3}},
-  "kind": 1},
- {"range":
-  {"start": {"line": 44, "character": 8}, "end": {"line": 44, "character": 9}},
-  "kind": 1}]
+  {"start": {"line": 28, "character": 2}, "end": {"line": 28, "character": 3}}}]

--- a/tests/server_interactive/hoverMutVarInDiagnostic.lean.out.expected
+++ b/tests/server_interactive/hoverMutVarInDiagnostic.lean.out.expected
@@ -5,25 +5,34 @@
  [{"source": "Lean 4",
    "severity": 1,
    "range":
-   {"start": {"line": 10, "character": 6}, "end": {"line": 10, "character": 7}},
+   {"start": {"line": 15, "character": 6}, "end": {"line": 15, "character": 7}},
    "message": "mutable variable `x` cannot be shadowed",
    "fullRange":
-   {"start": {"line": 10, "character": 6},
-    "end": {"line": 10, "character": 7}}},
+   {"start": {"line": 15, "character": 6},
+    "end": {"line": 15, "character": 7}}},
   {"source": "Lean 4",
    "severity": 1,
    "range":
-   {"start": {"line": 15, "character": 2}, "end": {"line": 15, "character": 3}},
+   {"start": {"line": 20, "character": 2}, "end": {"line": 20, "character": 3}},
    "message":
    "Variable `y` cannot be mutated. Only variables declared using `let mut` can be mutated.\n      If you did not intend to mutate but define `y`, consider using `let y` instead",
    "fullRange":
-   {"start": {"line": 15, "character": 2},
-    "end": {"line": 15, "character": 3}}}]}
-{"lineRange": {"start": 0, "end": 17}}
+   {"start": {"line": 20, "character": 2},
+    "end": {"line": 20, "character": 3}}},
+  {"source": "Lean 4",
+   "severity": 1,
+   "range":
+   {"start": {"line": 24, "character": 2}, "end": {"line": 24, "character": 3}},
+   "message":
+   "Variable `q` cannot be mutated. Only variables declared using `let mut` can be mutated.\n      If you did not intend to mutate but define `q`, consider using `let q` instead",
+   "fullRange":
+   {"start": {"line": 24, "character": 2},
+    "end": {"line": 24, "character": 3}}}]}
+{"lineRange": {"start": 0, "end": 26}}
 [{"source": "Lean 4",
   "severity": 1,
   "range":
-  {"start": {"line": 10, "character": 6}, "end": {"line": 10, "character": 7}},
+  {"start": {"line": 15, "character": 6}, "end": {"line": 15, "character": 7}},
   "message":
   {"append":
    [{"tag": [{"expr": {"text": "mutable variable `"}}, {"text": ""}]},
@@ -34,11 +43,11 @@
       {"text": ""}]},
     {"tag": [{"expr": {"text": "` cannot be shadowed"}}, {"text": ""}]}]},
   "fullRange":
-  {"start": {"line": 10, "character": 6}, "end": {"line": 10, "character": 7}}},
+  {"start": {"line": 15, "character": 6}, "end": {"line": 15, "character": 7}}},
  {"source": "Lean 4",
   "severity": 1,
   "range":
-  {"start": {"line": 15, "character": 2}, "end": {"line": 15, "character": 3}},
+  {"start": {"line": 20, "character": 2}, "end": {"line": 20, "character": 3}},
   "message":
   {"append":
    [{"tag": [{"expr": {"text": "Variable `"}}, {"text": ""}]},
@@ -69,4 +78,27 @@
       {"text": ""}]},
     {"tag": [{"expr": {"text": "` instead"}}, {"text": ""}]}]},
   "fullRange":
-  {"start": {"line": 15, "character": 2}, "end": {"line": 15, "character": 3}}}]
+  {"start": {"line": 20, "character": 2}, "end": {"line": 20, "character": 3}}},
+ {"source": "Lean 4",
+  "severity": 1,
+  "range":
+  {"start": {"line": 24, "character": 2}, "end": {"line": 24, "character": 3}},
+  "message":
+  {"append":
+   [{"tag": [{"expr": {"text": "Variable `"}}, {"text": ""}]},
+    {"tag": [{"expr": {"text": "q"}}, {"text": ""}]},
+    {"tag":
+     [{"expr":
+       {"text":
+        "` cannot be mutated. Only variables declared using `let mut` can be mutated."}},
+      {"text": ""}]},
+    {"tag": [{"expr": {"text": "\n"}}, {"text": ""}]},
+    {"tag":
+     [{"expr": {"text": "      If you did not intend to mutate but define `"}},
+      {"text": ""}]},
+    {"tag": [{"expr": {"text": "q"}}, {"text": ""}]},
+    {"tag": [{"expr": {"text": "`, consider using `let "}}, {"text": ""}]},
+    {"tag": [{"expr": {"text": "q"}}, {"text": ""}]},
+    {"tag": [{"expr": {"text": "` instead"}}, {"text": ""}]}]},
+  "fullRange":
+  {"start": {"line": 24, "character": 2}, "end": {"line": 24, "character": 3}}}]

--- a/tests/server_interactive/hoverMutVarInDiagnostic.lean.out.expected
+++ b/tests/server_interactive/hoverMutVarInDiagnostic.lean.out.expected
@@ -5,15 +5,25 @@
  [{"source": "Lean 4",
    "severity": 1,
    "range":
-   {"start": {"line": 8, "character": 6}, "end": {"line": 8, "character": 7}},
+   {"start": {"line": 10, "character": 6}, "end": {"line": 10, "character": 7}},
    "message": "mutable variable `x` cannot be shadowed",
    "fullRange":
-   {"start": {"line": 8, "character": 6}, "end": {"line": 8, "character": 7}}}]}
-{"lineRange": {"start": 0, "end": 10}}
+   {"start": {"line": 10, "character": 6},
+    "end": {"line": 10, "character": 7}}},
+  {"source": "Lean 4",
+   "severity": 1,
+   "range":
+   {"start": {"line": 15, "character": 2}, "end": {"line": 15, "character": 3}},
+   "message":
+   "Variable `y` cannot be mutated. Only variables declared using `let mut` can be mutated.\n      If you did not intend to mutate but define `y`, consider using `let y` instead",
+   "fullRange":
+   {"start": {"line": 15, "character": 2},
+    "end": {"line": 15, "character": 3}}}]}
+{"lineRange": {"start": 0, "end": 17}}
 [{"source": "Lean 4",
   "severity": 1,
   "range":
-  {"start": {"line": 8, "character": 6}, "end": {"line": 8, "character": 7}},
+  {"start": {"line": 10, "character": 6}, "end": {"line": 10, "character": 7}},
   "message":
   {"append":
    [{"tag": [{"expr": {"text": "mutable variable `"}}, {"text": ""}]},
@@ -24,4 +34,39 @@
       {"text": ""}]},
     {"tag": [{"expr": {"text": "` cannot be shadowed"}}, {"text": ""}]}]},
   "fullRange":
-  {"start": {"line": 8, "character": 6}, "end": {"line": 8, "character": 7}}}]
+  {"start": {"line": 10, "character": 6}, "end": {"line": 10, "character": 7}}},
+ {"source": "Lean 4",
+  "severity": 1,
+  "range":
+  {"start": {"line": 15, "character": 2}, "end": {"line": 15, "character": 3}},
+  "message":
+  {"append":
+   [{"tag": [{"expr": {"text": "Variable `"}}, {"text": ""}]},
+    {"tag":
+     [{"expr":
+       {"tag":
+        [{"subexprPos": "/", "info": {"__rpcref": "0"}}, {"text": "y"}]}},
+      {"text": ""}]},
+    {"tag":
+     [{"expr":
+       {"text":
+        "` cannot be mutated. Only variables declared using `let mut` can be mutated."}},
+      {"text": ""}]},
+    {"tag": [{"expr": {"text": "\n"}}, {"text": ""}]},
+    {"tag":
+     [{"expr": {"text": "      If you did not intend to mutate but define `"}},
+      {"text": ""}]},
+    {"tag":
+     [{"expr":
+       {"tag":
+        [{"subexprPos": "/", "info": {"__rpcref": "1"}}, {"text": "y"}]}},
+      {"text": ""}]},
+    {"tag": [{"expr": {"text": "`, consider using `let "}}, {"text": ""}]},
+    {"tag":
+     [{"expr":
+       {"tag":
+        [{"subexprPos": "/", "info": {"__rpcref": "2"}}, {"text": "y"}]}},
+      {"text": ""}]},
+    {"tag": [{"expr": {"text": "` instead"}}, {"text": ""}]}]},
+  "fullRange":
+  {"start": {"line": 15, "character": 2}, "end": {"line": 15, "character": 3}}}]


### PR DESCRIPTION
This PR makes the printed name of a variable in a `do`-elaborator error message carry hover info so the infoview surfaces its type. The bulk of the change is a small refactor that introduces a `MutVar` structure (declaration identifier + initial `FVarId`) and threads it through the do-elaborator helpers.