### PR TITLE
feat: add `cbv` as the `sym =>` mode tactic

### DIFF
--- a/src/Init/Grind/Interactive.lean
+++ b/src/Init/Grind/Interactive.lean
@@ -332,5 +332,31 @@ syntax (name := symDSimp) "dsimp" (ppSpace colGt ident)? (" [" ("*" <|> ident),*
 /-- `exact e` closes the main goal if its target type matches that of `e`. -/
 macro "exact " e:term : grind => `(grind| tactic => exact $e:term)
 
+
+/--
+`cbv` performs simplification that closely mimics call-by-value evaluation.
+It reduces terms by unfolding definitions using their defining equations and
+applying matcher equations. The unfolding is propositional, so `cbv` also works
+with functions defined via well-founded recursion or partial fixpoints.
+
+`cbv` reduces the goal type (and optionally hypothesis types) using call-by-value
+evaluation. For equation goals (`lhs = rhs`), `cbv` automatically attempts `refl`
+after reduction to close the goal.
+
+`cbv` supports the standard `at` location syntax:
+- `cbv` — reduce the goal target
+- `cbv at h` — reduce hypothesis `h`
+- `cbv at h |-` — reduce hypothesis `h` and the goal target
+- `cbv at *` — reduce all non-dependent propositional hypotheses and the goal target
+
+`cbv` is not a finishing tactic in general: it may leave a new (simpler) goal.
+
+The proofs produced by `cbv` only use the three standard axioms.
+In particular, they do not require trust in the correctness of the code
+generator.
+
+This is a variant of `cbv` that only works in `sym =>` mode.
+-/
+syntax (name := symCbv) "cbv" (location)? : grind
 end Grind
 end Lean.Parser.Tactic

--- a/src/Lean/Elab/Tactic/Grind/Sym.lean
+++ b/src/Lean/Elab/Tactic/Grind/Sym.lean
@@ -20,6 +20,8 @@ import Lean.Meta.Sym.DSimp.Variant
 import Lean.Meta.Sym.DSimp.Reduce
 import Lean.Meta.Sym.DSimp.DSimproc
 import Lean.Meta.Tactic.Apply
+import Lean.Meta.Tactic.Cbv.Main
+import Lean.Elab.Tactic.Location
 import Lean.Elab.SyntheticMVars
 namespace Lean.Elab.Tactic.Grind
 open Meta Grind
@@ -292,6 +294,25 @@ def elabDSimpVariant (variantName : Name) (args : DSimpArgs) : GrindTacticM (Sym
       let mvarNew ← mkFreshExprSyntheticOpaqueMVar target' decl.userName
       goal.mvarId.assign mvarNew
       replaceMainGoal [{ goal with mvarId := mvarNew.mvarId! }]
+
+/-- Resolve the hypothesis identifiers of a `cbv at` location to `FVarId`s. -/
+private def resolveLocFVarIds (hyps : Array Syntax) : GrindTacticM (Array FVarId) := do
+  let lctx ← getLCtx
+  hyps.mapM fun hyp => do
+    let some decl := lctx.findFromUserName? hyp.getId
+      | throwError "unknown hypothesis `{hyp}`"
+    return decl.fvarId
+
+@[builtin_grind_tactic Parser.Tactic.Grind.symCbv] def evalSymCbv : GrindTactic := fun stx => withMainContext do
+  ensureSym
+  let goal ← getMainGoal
+  let (fvarIds, simplifyTarget) ← match expandOptLocation stx[1] with
+    | .targets hyps simplifyTarget => pure (← resolveLocFVarIds hyps, simplifyTarget)
+    | .wildcard => pure (← goal.mvarId.getNondepPropHyps, true)
+  match (← Lean.Meta.Tactic.Cbv.cbvGoal goal.mvarId (simplifyTarget := simplifyTarget)
+      (fvarIdsToSimp := fvarIds)) with
+  | none => replaceMainGoal []
+  | some mvarId => replaceMainGoal [{ goal with mvarId }]
 
 end
 

--- a/src/Lean/Elab/Tactic/Grind/Sym.lean
+++ b/src/Lean/Elab/Tactic/Grind/Sym.lean
@@ -309,8 +309,9 @@ private def resolveLocFVarIds (hyps : Array Syntax) : GrindTacticM (Array FVarId
   let (fvarIds, simplifyTarget) ← match expandOptLocation stx[1] with
     | .targets hyps simplifyTarget => pure (← resolveLocFVarIds hyps, simplifyTarget)
     | .wildcard => pure (← goal.mvarId.getNondepPropHyps, true)
-  match (← Lean.Meta.Tactic.Cbv.cbvGoal goal.mvarId (simplifyTarget := simplifyTarget)
-      (fvarIdsToSimp := fvarIds)) with
+  let result ← liftGrindM <|
+    Lean.Meta.Tactic.Cbv.cbvGoalCore goal.mvarId simplifyTarget fvarIds
+  match result with
   | none => replaceMainGoal []
   | some mvarId => replaceMainGoal [{ goal with mvarId }]
 

--- a/src/Lean/Meta/Tactic/Cbv/Main.lean
+++ b/src/Lean/Meta/Tactic/Cbv/Main.lean
@@ -332,70 +332,67 @@ public def cbvEntry (e : Expr) : MetaM Result := do
     let e ← Sym.shareCommon e
     SimpM.run' (simp e) (methods := methods) (config := config)
 
-/-- Reduce goal target and/or hypothesis types using call-by-value evaluation.
-
-Preprocesses the goal via `Sym.preprocessMVar` (instantiates metavariables, unfolds
-reducibles, shares common subterms), then runs `cbvCore` on each selected hypothesis
-and the target within a single `SymM` context.
-
-For each hypothesis in `fvarIdsToSimp`, reduces its type via `cbvCore`. If the
-reduced type is `False`, the goal is closed immediately. Otherwise, the hypothesis
-is replaced with the reduced type.
-
-If `simplifyTarget` is true, reduces the goal type via `cbvCore`. If the reduced
-type is `True`, the goal is closed. Otherwise, the target is replaced.
-
-After all reductions, attempts `refl` to close equation goals of the form `v = v`. -/
-public def cbvGoal (mvarId : MVarId) (simplifyTarget : Bool := true) (fvarIdsToSimp : Array FVarId := #[]) : MetaM (Option MVarId) := do
+/--
+Core of `cbvGoal`: reduces the selected hypotheses and/or target of an already
+preprocessed `mvarId` using call-by-value evaluation, within the caller's `SymM` context.
+-/
+public def cbvGoalCore (mvarId : MVarId) (simplifyTarget : Bool := true)
+    (fvarIdsToSimp : Array FVarId := #[]) : Sym.SymM (Option MVarId) := do
   let config : Sym.Simp.Config := { maxSteps := cbv.maxSteps.get (← getOptions) }
+  mvarId.withContext do
+    let mut mvarIdNew := mvarId
+    let mut toAssert : Array Hypothesis := #[]
+    -- Process hypotheses
+    for fvarId in fvarIdsToSimp do
+      let localDecl ← fvarId.getDecl
+      let type := localDecl.type
+      let result ← withTraceNode `Meta.Tactic.cbv (fun
+          | .ok (Result.step type' ..) => return m!"hypothesis `{localDecl.userName}`:{indentExpr type}\n==>{indentExpr type'}"
+          | .ok (Result.rfl ..)        => return m!"hypothesis `{localDecl.userName}`: no change"
+          | .error err                 => return m!"hypothesis `{localDecl.userName}`: {err.toMessageData}") do
+        cbvCore type config
+      match result with
+      | .rfl _ _ => pure ()
+      | .step type' proof _ _ =>
+        if type'.isFalse then
+          let u ← Sym.getLevel type
+          mvarIdNew.assign (← mkFalseElim (← mvarIdNew.getType) (mkApp4 (mkConst ``Eq.mp [u]) type type' proof (mkFVar fvarId)))
+          return none
+        else
+          let u ← Sym.getLevel type
+          toAssert := toAssert.push { userName := localDecl.userName, type := type', value := mkApp4 (mkConst ``Eq.mp [u]) type type' proof (mkFVar fvarId) }
+    -- Process target
+    if simplifyTarget then
+      let target ← mvarIdNew.getType
+      let result ← withTraceNode `Meta.Tactic.cbv (fun
+          | .ok (Result.step target' ..) => return m!"target:{indentExpr target}\n==>{indentExpr target'}"
+          | .ok (Result.rfl ..)          => return m!"target: no change"
+          | .error err                   => return m!"target: {err.toMessageData}") do
+        cbvCore target config
+      match result with
+      | .rfl _ _ => pure ()
+      | .step target' proof _ _ =>
+        if target'.isTrue then
+          mvarIdNew.assign (← mkOfEqTrue proof)
+          return none
+        else
+          mvarIdNew ← mvarIdNew.replaceTargetEq target' proof
+    -- Assert new hypotheses and clear old ones
+    let (_, mvarIdNew') ← mvarIdNew.assertHypotheses toAssert
+    mvarIdNew := mvarIdNew'
+    mvarIdNew ← mvarIdNew.tryClearMany fvarIdsToSimp
+    -- Try refl to close equation goals
+    let s ← Meta.saveState
+    try mvarIdNew.refl; return none
+    catch _ => s.restore; return some mvarIdNew
+
+/--
+Reduce goal target and/or hypothesis types using call-by-value evaluation.
+Performs the preprocessing and sharing steps
+-/
+public def cbvGoal (mvarId : MVarId) (simplifyTarget : Bool := true) (fvarIdsToSimp : Array FVarId := #[]) : MetaM (Option MVarId) :=
   Sym.SymM.run do
-    let mvarId ← Sym.preprocessMVar mvarId
-    mvarId.withContext do
-      let mut mvarIdNew := mvarId
-      let mut toAssert : Array Hypothesis := #[]
-      -- Process hypotheses
-      for fvarId in fvarIdsToSimp do
-        let localDecl ← fvarId.getDecl
-        let type := localDecl.type
-        let result ← withTraceNode `Meta.Tactic.cbv (fun
-            | .ok (Result.step type' ..) => return m!"hypothesis `{localDecl.userName}`:{indentExpr type}\n==>{indentExpr type'}"
-            | .ok (Result.rfl ..)        => return m!"hypothesis `{localDecl.userName}`: no change"
-            | .error err                 => return m!"hypothesis `{localDecl.userName}`: {err.toMessageData}") do
-          cbvCore type config
-        match result with
-        | .rfl _ _ => pure ()
-        | .step type' proof _ _ =>
-          if type'.isFalse then
-            let u ← Sym.getLevel type
-            mvarIdNew.assign (← mkFalseElim (← mvarIdNew.getType) (mkApp4 (mkConst ``Eq.mp [u]) type type' proof (mkFVar fvarId)))
-            return none
-          else
-            let u ← Sym.getLevel type
-            toAssert := toAssert.push { userName := localDecl.userName, type := type', value := mkApp4 (mkConst ``Eq.mp [u]) type type' proof (mkFVar fvarId) }
-      -- Process target
-      if simplifyTarget then
-        let target ← mvarIdNew.getType
-        let result ← withTraceNode `Meta.Tactic.cbv (fun
-            | .ok (Result.step target' ..) => return m!"target:{indentExpr target}\n==>{indentExpr target'}"
-            | .ok (Result.rfl ..)          => return m!"target: no change"
-            | .error err                   => return m!"target: {err.toMessageData}") do
-          cbvCore target config
-        match result with
-        | .rfl _ _ => pure ()
-        | .step target' proof _ _ =>
-          if target'.isTrue then
-            mvarIdNew.assign (← mkOfEqTrue proof)
-            return none
-          else
-            mvarIdNew ← mvarIdNew.replaceTargetEq target' proof
-      -- Assert new hypotheses and clear old ones
-      let (_, mvarIdNew') ← mvarIdNew.assertHypotheses toAssert
-      mvarIdNew := mvarIdNew'
-      mvarIdNew ← mvarIdNew.tryClearMany fvarIdsToSimp
-      -- Try refl to close equation goals
-      let s ← Meta.saveState
-      try mvarIdNew.refl; return none
-      catch _ => s.restore; return some mvarIdNew
+    cbvGoalCore (← Sym.preprocessMVar mvarId) simplifyTarget fvarIdsToSimp
 
 /--
 Attempt to close a goal of the form `decide P = true` by reducing only the LHS using `cbv`.

--- a/src/Lean/Meta/Tactic/Cbv/Main.lean
+++ b/src/Lean/Meta/Tactic/Cbv/Main.lean
@@ -388,7 +388,19 @@ public def cbvGoalCore (mvarId : MVarId) (simplifyTarget : Bool := true)
 
 /--
 Reduce goal target and/or hypothesis types using call-by-value evaluation.
-Performs the preprocessing and sharing steps
+
+Preprocesses the goal via `Sym.preprocessMVar` (instantiates metavariables, unfolds
+reducibles, shares common subterms), then runs `cbvCore` on each selected hypothesis
+and the target within a single `SymM` context.
+
+For each hypothesis in `fvarIdsToSimp`, reduces its type via `cbvCore`. If the
+reduced type is `False`, the goal is closed immediately. Otherwise, the hypothesis
+is replaced with the reduced type.
+
+If `simplifyTarget` is true, reduces the goal type via `cbvCore`. If the reduced
+type is `True`, the goal is closed. Otherwise, the target is replaced.
+
+After all reductions, attempts `refl` to close equation goals of the form `v = v`.
 -/
 public def cbvGoal (mvarId : MVarId) (simplifyTarget : Bool := true) (fvarIdsToSimp : Array FVarId := #[]) : MetaM (Option MVarId) :=
   Sym.SymM.run do

--- a/tests/elab/sym_cbv.lean
+++ b/tests/elab/sym_cbv.lean
@@ -1,0 +1,25 @@
+/-! Tests for the `cbv` tactic in `grind`'s `sym =>` interactive mode. -/
+
+example : Nat.succ 7 = 8 := by
+  sym =>
+    cbv
+
+example (h : a = 8) : Nat.succ 7 = a := by
+  sym =>
+    cbv
+    exact h.symm
+
+example (h : Nat.succ 7 = a) : 8 = a := by
+  sym =>
+    cbv at h
+    exact h
+
+example (h : Nat.succ 7 = a) : Nat.succ 7 = a := by
+  sym =>
+    cbv at h ⊢
+    exact h
+
+example (h : Nat.succ 7 = a) : Nat.succ 7 = a := by
+  sym =>
+    cbv at *
+    exact h


### PR DESCRIPTION
This PR makes the `cbv` tactic available inside `grind`'s interactive `sym =>` mode. It reduces the goal target using call-by-value evaluation and supports the standard `at` location syntax (`cbv at h`, `cbv at h ⊢`, `cbv at *`) to reduce selected hypotheses, automatically closing equation goals via `refl` when reduction finishes the proof.