### PR TITLE
feat: generalize `Sym.Pattern` construction over binder telescopes

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Attr.lean
+++ b/src/Lean/Elab/Tactic/Do/Attr.lean
@@ -363,62 +363,6 @@ def SpecTheorems.erase (d : SpecTheorems) (thmId : SpecProof) : SpecTheorems :=
 abbrev SpecExtension := SimpleScopedEnvExtension SpecEntry SpecTheorems
 
 /--
-Drops pattern variables that the pattern expression does not depend on.
-
-`Sym.mkPatternFromExprWithKey`/`Sym.mkPatternFromDeclWithKey` turn *every* leading `∀`-binder of the
-source type into a pattern variable, even binders the selected key (e.g. the program of a `Triple`
-conclusion) never mentions. During matching those variables only ever become fresh metavariables
-(see `Sym.mkPreResult`); for instance binders they additionally trigger spurious `trySynthInstance`
-calls. This keeps only the variables that the pattern expression references, together with the
-transitive closure of variables their types depend on, and renumbers the remaining de Bruijn
-indices. `varInfos?` and `checkTypeMask?` are filtered to the surviving telescope; `fnInfos`,
-`levelParams`, and the discrimination-tree key are unchanged because the pattern expression's
-structure is untouched (bound variables are wildcards in the key).
-
-**Important:** only use this when the matched arguments are *not* reused to rebuild a proof term,
-as `Sym.BackwardRule`/`Sym.mkValue` do — dropping variables would drop arguments those need. It is
-meant for databases such as `mvcgen'`'s spec table, where the proof is re-elaborated independently
-of the pattern.
--/
-def eraseUnusedVarsFromPattern (p : Sym.Pattern) : Sym.Pattern := Id.run do
-  let n := p.varTypes.size
-  -- Variable `j` (0 = outermost binder) is bound variable `#(ctx-1-j)` in a context of `ctx`
-  -- binders. `used[j]` becomes `true` once we know variable `j` is reachable from the pattern.
-  let mut used := Array.replicate n false
-  for j in *...n do
-    if p.pattern.hasLooseBVar (n - 1 - j) then
-      used := used.set! j true
-  -- A variable's type may reference earlier variables, so propagate top-down: when a kept variable
-  -- is reached, mark every variable occurring in its type as kept too.
-  for j in *...n do
-    let i := n - 1 - j
-    if used[i]! then
-      for k in *...i do
-        if p.varTypes[i]!.hasLooseBVar (i - 1 - k) then
-          used := used.set! k true
-  if used.all (· == true) then return p
-  let kept := (Array.range n).filter (used[·]!)
-  -- Rebuild the telescope via fvar placeholders to avoid manual de Bruijn arithmetic.
-  let fvars := (Array.range n).map fun i => mkFVar ⟨.num `_sym_prune i⟩
-  let keptFVars := kept.map (fvars[·]!)
-  let newPattern := (p.pattern.instantiateRev fvars).abstract keptFVars
-  let newVarTypes := kept.mapIdx fun k i =>
-    (p.varTypes[i]!.instantiateRev (fvars.extract 0 i)).abstract (keptFVars.extract 0 k)
-  -- `varInfos?`/`checkTypeMask?` are parallel to `varTypes`; their per-variable meaning does not
-  -- depend on the de Bruijn numbering, so we simply keep the surviving entries.
-  let newVarInfos? := p.varInfos?.bind fun infos =>
-    let argsInfo := kept.map (infos.argsInfo[·]!)
-    if argsInfo.any fun a => a.isProof || a.isInstance then some { argsInfo } else none
-  let newCheckTypeMask? := p.checkTypeMask?.bind fun mask =>
-    let newMask := kept.map (mask[·]!)
-    if newMask.all (· == false) then none else some newMask
-  return { p with
-    varTypes := newVarTypes
-    pattern := newPattern
-    varInfos? := newVarInfos?
-    checkTypeMask? := newCheckTypeMask? }
-
-/--
 Selects the program a spec conclusion is keyed on: the program of a `Triple`, or the program inside
 the `wp` on the RHS of a `pre ⊑ wp …` entailment. Returns `none` if `type` is neither shape — e.g. a
 bare `lhs ⊑ rhs` whose RHS is not a `wp` application (an invariant entailment such as
@@ -439,14 +383,19 @@ def selectProg (type : Expr) : MetaM (Option Expr) := do
 Builds a `Sym.Pattern` keyed on the program selected by `selectProg` from a spec conclusion.
 The conclusion is assumed to already be a valid spec shape (checked by the caller via `selectProg`);
 a non-spec shape reaching here is a logic error and throws.
+
+Built with `usedOnly := true`, so only the binders the program key depends on become pattern
+variables; the rest would only ever match as fresh metavariables (and, for instance binders, trigger
+spurious instance synthesis). This is sound here because the spec table re-elaborates the proof
+independently of the matched arguments, unlike `Sym.BackwardRule`/`Sym.mkValue`, which reuse them.
 -/
 def mkSpecPatternFromExpr (expr : Expr)
     (levelParams : List Name := []) : MetaM Sym.Pattern := do
-  let (pattern, _) ← Sym.mkPatternFromExprWithKey expr levelParams fun type => do
-    let some prog ← selectProg type
-      | throwError "unexpected kind of spec theorem; expected `Triple` or `⊑ wp`{indentExpr type}"
-    return (prog, ())
-  return eraseUnusedVarsFromPattern pattern
+  let (levelParams, type) ← Sym.preprocessExprPattern expr levelParams
+  Sym.Pattern.forallTelescope type none fun xs body => do
+    let some prog ← selectProg body
+      | throwError "unexpected kind of spec theorem; expected `Triple` or `⊑ wp`{indentExpr body}"
+    Sym.mkPatternFVars xs prog levelParams (usedOnly := true)
 
 private def mkSpecTheorem (type : Expr) (proof : SpecProof) (prio : Nat) : MetaM (Option SpecTheorem) := do
   let (levelParams, expr) ← proof.getProof

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
@@ -91,7 +91,7 @@ public structure SpecTheoremsNew where
   deriving Inhabited
 
 public def mkTriplePatternFromExpr (expr : Expr) (levelParams : List Name := []) : SymM Pattern := do
-  Prod.fst <$> Sym.mkPatternFromExprWithKey expr levelParams fun type => do
+  Prod.fst <$> Sym.mkPatternFromExprWithKey expr levelParams fun _abstract type => do
     let_expr Triple _m _ps _inst _α prog _P _Q := type | throwError "conclusion is not a Triple {indentExpr type}"
     return (prog, ())
 
@@ -162,9 +162,9 @@ may be between functions rather than values. In that case, the pattern is eta-ex
 so the discrimination tree key includes all arguments.
 -/
 public def mkSpecTheoremNewFromSimpDecl? (declName : Name) (prio : Nat) : MetaM (Option SpecTheoremNew) := do
-  let (pattern, (eqTy, rhs)) ← Sym.mkPatternFromDeclWithKey declName fun body => do
+  let (pattern, (eqTy, rhs)) ← Sym.mkPatternFromDeclWithKey declName fun abstract body => do
     let_expr Eq eqTy lhs rhs := body | throwError "conclusion is not an equality{indentExpr body}"
-    return (lhs, (eqTy, rhs))
+    return (lhs, (abstract eqTy, abstract rhs))
   let (pattern, etaArgs) := etaExpandEqPattern pattern eqTy
   -- Skip no-op equations where LHS and RHS are the same after `unfoldReducible`.
   -- E.g., `getThe.eq_1 : getThe σ = MonadStateOf.get` becomes a no-op because

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
@@ -92,7 +92,7 @@ public structure SpecTheoremsNew where
 
 public def mkTriplePatternFromExpr (expr : Expr) (levelParams : List Name := []) : SymM Pattern := do
   let (levelParams, type) ← Sym.preprocessExprPattern expr levelParams
-  forallTelescope type fun xs body => do
+  Sym.Pattern.forallTelescope type none fun xs body => do
     let_expr Triple _m _ps _inst _α prog _P _Q := body | throwError "conclusion is not a Triple {indentExpr body}"
     Sym.mkPatternFVars xs prog levelParams
 
@@ -164,7 +164,7 @@ so the discrimination tree key includes all arguments.
 -/
 public def mkSpecTheoremNewFromSimpDecl? (declName : Name) (prio : Nat) : MetaM (Option SpecTheoremNew) := do
   let (levelParams, type) ← Sym.preprocessDeclPattern declName
-  let (pattern, eqTy, rhs) ← forallTelescope type fun xs body => do
+  let (pattern, eqTy, rhs) ← Sym.Pattern.forallTelescope type none fun xs body => do
     let_expr Eq eqTy lhs rhs := body | throwError "conclusion is not an equality{indentExpr body}"
     return (← Sym.mkPatternFVars xs lhs levelParams, eqTy.abstract xs, rhs.abstract xs)
   let (pattern, etaArgs) := etaExpandEqPattern pattern eqTy

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
@@ -91,9 +91,10 @@ public structure SpecTheoremsNew where
   deriving Inhabited
 
 public def mkTriplePatternFromExpr (expr : Expr) (levelParams : List Name := []) : SymM Pattern := do
-  Prod.fst <$> Sym.mkPatternFromExprWithKey expr levelParams fun _abstract type => do
-    let_expr Triple _m _ps _inst _α prog _P _Q := type | throwError "conclusion is not a Triple {indentExpr type}"
-    return (prog, ())
+  let (levelParams, type) ← Sym.preprocessExprPattern expr levelParams
+  forallTelescope type fun xs body => do
+    let_expr Triple _m _ps _inst _α prog _P _Q := body | throwError "conclusion is not a Triple {indentExpr body}"
+    Sym.mkPatternFVars xs prog levelParams
 
 public def mkSpecTheoremNew (proof : SpecProof) (prio : Nat) : SymM (Option SpecTheoremNew) := do
   -- cf. mkSimpTheoremCore
@@ -162,9 +163,10 @@ may be between functions rather than values. In that case, the pattern is eta-ex
 so the discrimination tree key includes all arguments.
 -/
 public def mkSpecTheoremNewFromSimpDecl? (declName : Name) (prio : Nat) : MetaM (Option SpecTheoremNew) := do
-  let (pattern, (eqTy, rhs)) ← Sym.mkPatternFromDeclWithKey declName fun abstract body => do
+  let (levelParams, type) ← Sym.preprocessDeclPattern declName
+  let (pattern, eqTy, rhs) ← forallTelescope type fun xs body => do
     let_expr Eq eqTy lhs rhs := body | throwError "conclusion is not an equality{indentExpr body}"
-    return (lhs, (abstract eqTy, abstract rhs))
+    return (← Sym.mkPatternFVars xs lhs levelParams, eqTy.abstract xs, rhs.abstract xs)
   let (pattern, etaArgs) := etaExpandEqPattern pattern eqTy
   -- Skip no-op equations where LHS and RHS are the same after `unfoldReducible`.
   -- E.g., `getThe.eq_1 : getThe σ = MonadStateOf.get` becomes a no-op because

--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -105,8 +105,8 @@ def isUVar? (n : Name) : Option Nat := Id.run do
   unless p == uvarPrefix do return none
   return some idx
 
-/-- Helper function for implementing `mkPatternFromDecl` and `mkEqPatternFromDecl` -/
-def preprocessDeclPattern (declName : Name) : MetaM (List Name × Expr) := do
+/-- Renames the universe parameters of `declName` to `_uvar.*` and normalizes its type for use as a pattern. -/
+public def preprocessDeclPattern (declName : Name) : MetaM (List Name × Expr) := do
   let info ← getConstInfo declName
   let levelParams := info.levelParams.mapIdx fun i _ => Name.num uvarPrefix i
   let us := levelParams.map mkLevelParam
@@ -115,7 +115,8 @@ def preprocessDeclPattern (declName : Name) : MetaM (List Name × Expr) := do
   let type ← normalizeLevels type
   return (levelParams, type)
 
-def preprocessExprPattern (e : Expr) (levelParams₀ : List Name) : MetaM (List Name × Expr) := do
+/-- Renames `levelParams₀` to `_uvar.*` and normalizes the type of `e` for use as a pattern. -/
+public def preprocessExprPattern (e : Expr) (levelParams₀ : List Name) : MetaM (List Name × Expr) := do
   let type ← inferType e
   let levelParams := levelParams₀.mapIdx fun i _ => Name.num uvarPrefix i
   let us := levelParams.map mkLevelParam
@@ -219,11 +220,12 @@ public def mkPatternFVars (xs : Array Expr) (e : Expr) (levelParams : List Name 
   let varInfos? ← mkProofInstArgInfo? xs
   return { levelParams, varTypes, pattern, fnInfos, varInfos?, checkTypeMask? }
 
-def mkPatternFromType (levelParams : List Name) (type : Expr) (num? : Option Nat) : MetaM Pattern := do
-  -- Peel only literal binders: a reducing telescope could unfold a reducible conclusion (e.g. `⊢ₛ`)
-  -- into further binders, changing the pattern.
-  let n := min (num?.getD type.getNumHeadForalls) type.getNumHeadForalls
-  forallBoundedTelescope type (some n) fun xs body => mkPatternFVars xs body levelParams
+def mkPatternFromType (levelParams : List Name) (type : Expr) (num? : Option Nat) : MetaM Pattern :=
+  -- `forallTelescope` is non-reducing, so only literal binders are peeled; a reducing telescope could
+  -- unfold a reducible conclusion (e.g. `⊢ₛ`) into further binders, changing the pattern.
+  match num? with
+  | none   => forallTelescope type fun xs body => mkPatternFVars xs body levelParams
+  | some n => forallBoundedTelescope type (some n) fun xs body => mkPatternFVars xs body levelParams
 
 /--
 Creates a `Pattern` from the type of a theorem.
@@ -246,43 +248,6 @@ public def mkPatternFromExpr (e : Expr) (levelParams : List Name := []) (num? : 
   let (levelParams, type) ← preprocessExprPattern e levelParams
   mkPatternFromType levelParams type num?
 
-@[inline]
-def mkPatternFromTypeWithKey (levelParams : List Name) (type : Expr) (selectKey : (Expr → Expr) → Expr → MetaM (Expr × α)) : MetaM (Pattern × α) :=
-  forallBoundedTelescope type (some type.getNumHeadForalls) fun xs body => do
-    let (key, a) ← selectKey (·.abstract xs) body
-    return (← mkPatternFVars xs key levelParams, a)
-
-/--
-Creates a `Pattern` from a theorem, using the supplied selection function to extract the key from
-the theorem's result type.
-
-This function is used to implement `mkEqPatternFromDecl`.
-Like `mkPatternFromDecl`, this strips all leading universal quantifiers, recording variable
-types and instance status. However, instead of using the entire resulting type as the pattern,
-it uses the selection function to extract the key.
-
-`selectKey` runs under the stripped binders, which are presented as free variables, and receives an
-`abstract` function. The returned key is abstracted automatically; apply `abstract` to any other
-expressions carried out in the result so they refer to the pattern variables instead of the free
-variables.
-
-For a theorem `∀ x₁ ... xₙ, type`, returns a pattern matching the first component of `selectKey type`
-with `n` pattern variables.
--/
-@[inline]
-public def mkPatternFromDeclWithKey (declName : Name) (selectKey : (Expr → Expr) → Expr → MetaM (Expr × α)) : MetaM (Pattern × α) := do
-  let (levelParams, type) ← preprocessDeclPattern declName
-  mkPatternFromTypeWithKey levelParams type selectKey
-
-/--
-Like `mkPatternFromDeclWithKey`, but for a complex proof expression instead of the declaration of a
-theorem.
--/
-@[inline]
-public def mkPatternFromExprWithKey (e : Expr) (levelParams : List Name := []) (selectKey : (Expr → Expr) → Expr → MetaM (Expr × α)) : MetaM (Pattern × α) := do
-  let (levelParams, type) ← preprocessExprPattern e levelParams
-  mkPatternFromTypeWithKey levelParams type selectKey
-
 /--
 Creates a `Pattern` from an equational theorem, using the left-hand side of the equation.
 It also returns the right-hand side of the equation
@@ -295,9 +260,10 @@ For a theorem `∀ x₁ ... xₙ, lhs = rhs`, returns a pattern matching `lhs` w
 Throws an error if the theorem's conclusion is not an equality.
 -/
 public def mkEqPatternFromDecl (declName : Name) : MetaM (Pattern × Expr) := do
-  mkPatternFromDeclWithKey declName fun abstract type => do
-    let_expr Eq _ lhs rhs := type | throwError "conclusion is not a equality{indentExpr type}"
-    return (lhs, abstract rhs)
+  let (levelParams, type) ← preprocessDeclPattern declName
+  forallTelescope type fun xs body => do
+    let_expr Eq _ lhs rhs := body | throwError "conclusion is not a equality{indentExpr body}"
+    return (← mkPatternFVars xs lhs levelParams, rhs.abstract xs)
 
 structure UnifyM.Context where
   pattern   : Pattern

--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -19,6 +19,8 @@ import Lean.Meta.Sym.Offset
 import Lean.Meta.Sym.Eta
 import Lean.Meta.Sym.Util
 import Lean.Meta.HasAssignableMVar
+import Lean.Util.CollectFVars
+import Lean.Util.CollectMVars
 import Init.Data.List.MapIdx
 import Init.Data.Nat.Linear
 import Std.Do.Triple.Basic
@@ -174,23 +176,54 @@ where
       else
         mask
 
-def mkPatternCore (type : Expr) (levelParams : List Name) (varTypes : Array Expr) (pattern : Expr) : MetaM Pattern := do
+/--
+Keeps only the variables in `xs` that `e` depends on, transitively through binder-domain types,
+preserving order. Used to implement the `usedOnly` option of `mkPatternFVars`.
+
+This computes the same set as the `usedOnly` option of `Meta.mkForallFVars`/`MetavarContext.mkBinding`:
+`xs[i]` is kept iff it occurs in `e` or in the type of some kept `xs[j]` with `j > i`. Both free
+variables and metavariables are tracked, so `xs` may freely mix the two.
+-/
+def usedVars (xs : Array Expr) (e : Expr) : MetaM (Array Expr) := do
+  let mut sf := collectFVars {} e
+  let mut sm := e.collectMVars {}
+  let mut keep := #[]
+  for x in xs.reverse do
+    let used := if x.isMVar then sm.result.contains x.mvarId! else sf.fvarSet.contains x.fvarId!
+    if used then
+      keep := keep.push x
+      let t ← inferType x
+      sf := collectFVars sf t
+      sm := t.collectMVars sm
+  return keep.reverse
+
+/--
+Creates a `Pattern` by abstracting the free variables and metavariables `xs` out of `e`.
+
+`xs` are the binders opened by some telescope (`forallTelescope`, `lambdaTelescope`,
+`lambdaLetTelescope`, `forallMetaTelescope`, ...) and `e` is the selected key. Each entry of `xs`
+becomes a pattern variable, in order, and may be either a free variable or a metavariable.
+
+If `usedOnly := true`, only the variables `e` actually depends on become pattern variables; the
+rest are dropped (see `usedVars`).
+-/
+public def mkPatternFVars (xs : Array Expr) (e : Expr) (levelParams : List Name := []) (usedOnly := false) : MetaM Pattern := do
+  let xs ← if usedOnly then usedVars xs e else pure xs
+  let pattern := e.abstract xs
+  let mut varTypes := #[]
+  for h : i in [0:xs.size] do
+    varTypes := varTypes.push ((← inferType xs[i]).abstractRange i xs)
   let fnInfos ← mkProofInstInfoMapFor pattern
-  let checkTypeMask := mkCheckTypeMask pattern varTypes.size
+  let checkTypeMask := mkCheckTypeMask pattern xs.size
   let checkTypeMask? := if checkTypeMask.all (· == false) then none else some checkTypeMask
-  let varInfos? ← forallBoundedTelescope type varTypes.size fun xs _ =>
-    mkProofInstArgInfo? xs
+  let varInfos? ← mkProofInstArgInfo? xs
   return { levelParams, varTypes, pattern, fnInfos, varInfos?, checkTypeMask? }
 
 def mkPatternFromType (levelParams : List Name) (type : Expr) (num? : Option Nat) : MetaM Pattern := do
-  let hugeNumber := 10000000
-  let num := num?.getD hugeNumber
-  let rec go (i : Nat) (pattern : Expr) (varTypes : Array Expr) : MetaM Pattern := do
-    if i < num then
-      if let .forallE _ d b _ := pattern then
-        return (← go (i+1) b (varTypes.push d))
-    mkPatternCore type levelParams varTypes pattern
-  go 0 type #[]
+  -- Peel only literal binders: a reducing telescope could unfold a reducible conclusion (e.g. `⊢ₛ`)
+  -- into further binders, changing the pattern.
+  let n := min (num?.getD type.getNumHeadForalls) type.getNumHeadForalls
+  forallBoundedTelescope type (some n) fun xs body => mkPatternFVars xs body levelParams
 
 /--
 Creates a `Pattern` from the type of a theorem.
@@ -214,15 +247,10 @@ public def mkPatternFromExpr (e : Expr) (levelParams : List Name := []) (num? : 
   mkPatternFromType levelParams type num?
 
 @[inline]
-def mkPatternFromTypeWithKey (levelParams : List Name) (type : Expr) (selectKey : Expr → MetaM (Expr × α)) : MetaM (Pattern × α) := do
-  let rec go (pattern : Expr) (varTypes : Array Expr) : MetaM (Pattern × α) := do
-    if let .forallE _ d b _ := pattern then
-      return (← go b (varTypes.push d))
-    else
-      let (key, a) ← selectKey pattern
-      let pattern ← mkPatternCore type levelParams varTypes key
-      return (pattern, a)
-  go type #[]
+def mkPatternFromTypeWithKey (levelParams : List Name) (type : Expr) (selectKey : (Expr → Expr) → Expr → MetaM (Expr × α)) : MetaM (Pattern × α) :=
+  forallBoundedTelescope type (some type.getNumHeadForalls) fun xs body => do
+    let (key, a) ← selectKey (·.abstract xs) body
+    return (← mkPatternFVars xs key levelParams, a)
 
 /--
 Creates a `Pattern` from a theorem, using the supplied selection function to extract the key from
@@ -233,11 +261,16 @@ Like `mkPatternFromDecl`, this strips all leading universal quantifiers, recordi
 types and instance status. However, instead of using the entire resulting type as the pattern,
 it uses the selection function to extract the key.
 
+`selectKey` runs under the stripped binders, which are presented as free variables, and receives an
+`abstract` function. The returned key is abstracted automatically; apply `abstract` to any other
+expressions carried out in the result so they refer to the pattern variables instead of the free
+variables.
+
 For a theorem `∀ x₁ ... xₙ, type`, returns a pattern matching the first component of `selectKey type`
 with `n` pattern variables.
 -/
 @[inline]
-public def mkPatternFromDeclWithKey (declName : Name) (selectKey : Expr → MetaM (Expr × α)) : MetaM (Pattern × α) := do
+public def mkPatternFromDeclWithKey (declName : Name) (selectKey : (Expr → Expr) → Expr → MetaM (Expr × α)) : MetaM (Pattern × α) := do
   let (levelParams, type) ← preprocessDeclPattern declName
   mkPatternFromTypeWithKey levelParams type selectKey
 
@@ -246,7 +279,7 @@ Like `mkPatternFromDeclWithKey`, but for a complex proof expression instead of t
 theorem.
 -/
 @[inline]
-public def mkPatternFromExprWithKey (e : Expr) (levelParams : List Name := []) (selectKey : Expr → MetaM (Expr × α)) : MetaM (Pattern × α) := do
+public def mkPatternFromExprWithKey (e : Expr) (levelParams : List Name := []) (selectKey : (Expr → Expr) → Expr → MetaM (Expr × α)) : MetaM (Pattern × α) := do
   let (levelParams, type) ← preprocessExprPattern e levelParams
   mkPatternFromTypeWithKey levelParams type selectKey
 
@@ -262,9 +295,9 @@ For a theorem `∀ x₁ ... xₙ, lhs = rhs`, returns a pattern matching `lhs` w
 Throws an error if the theorem's conclusion is not an equality.
 -/
 public def mkEqPatternFromDecl (declName : Name) : MetaM (Pattern × Expr) := do
-  mkPatternFromDeclWithKey declName fun type => do
+  mkPatternFromDeclWithKey declName fun abstract type => do
     let_expr Eq _ lhs rhs := type | throwError "conclusion is not a equality{indentExpr type}"
-    return (lhs, rhs)
+    return (lhs, abstract rhs)
 
 structure UnifyM.Context where
   pattern   : Pattern

--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -221,8 +221,8 @@ public def mkPatternFVars (xs : Array Expr) (e : Expr) (levelParams : List Name 
   return { levelParams, varTypes, pattern, fnInfos, varInfos?, checkTypeMask? }
 
 def mkPatternFromType (levelParams : List Name) (type : Expr) (num? : Option Nat) : MetaM Pattern :=
-  -- `forallTelescope` is non-reducing, so only literal binders are peeled; a reducing telescope could
-  -- unfold a reducible conclusion (e.g. `⊢ₛ`) into further binders, changing the pattern.
+  -- A reducing telescope would unfold a reducible conclusion into extra binders, changing the
+  -- pattern, so the unbounded case peels only literal binders via `forallTelescope`.
   match num? with
   | none   => forallTelescope type fun xs body => mkPatternFVars xs body levelParams
   | some n => forallBoundedTelescope type (some n) fun xs body => mkPatternFVars xs body levelParams

--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -21,6 +21,7 @@ import Lean.Meta.Sym.Util
 import Lean.Meta.HasAssignableMVar
 import Lean.Util.CollectFVars
 import Lean.Util.CollectMVars
+import Std.Data.HashSet.Basic
 import Init.Data.List.MapIdx
 import Init.Data.Nat.Linear
 import Std.Do.Triple.Basic
@@ -187,15 +188,15 @@ variables and metavariables are tracked, so `xs` may freely mix the two.
 -/
 def usedVars (xs : Array Expr) (e : Expr) : MetaM (Array Expr) := do
   let mut sf := collectFVars {} e
-  let mut sm := e.collectMVars {}
+  let mut mvars : Std.HashSet MVarId := .ofArray (e.collectMVars {}).result
   let mut keep := #[]
   for x in xs.reverse do
-    let used := if x.isMVar then sm.result.contains x.mvarId! else sf.fvarSet.contains x.fvarId!
+    let used := if x.isMVar then mvars.contains x.mvarId! else sf.fvarSet.contains x.fvarId!
     if used then
       keep := keep.push x
       let t ← inferType x
       sf := collectFVars sf t
-      sm := t.collectMVars sm
+      mvars := mvars.insertMany (t.collectMVars {}).result
   return keep.reverse
 
 /--
@@ -220,11 +221,28 @@ public def mkPatternFVars (xs : Array Expr) (e : Expr) (levelParams : List Name 
   let varInfos? ← mkProofInstArgInfo? xs
   return { levelParams, varTypes, pattern, fnInfos, varInfos?, checkTypeMask? }
 
+private partial def forallTelescopeAux (num : Nat) (k : Array Expr → Expr → MetaM α)
+    (fvars : Array Expr) (type : Expr) : MetaM α := do
+  if let .forallE n d b bi := type then
+    if fvars.size < num then
+      return ← withLocalDecl n bi (d.instantiateRev fvars) fun fvar =>
+        forallTelescopeAux num k (fvars.push fvar) b
+  k fvars (type.instantiateRev fvars)
+
+/--
+Opens the leading binders of a (preprocessed) pattern `type` as free variables and runs `k` with
+them and the conclusion. If `num? = some n`, at most `n` binders are opened.
+
+Only literal `∀`-binders are peeled; the conclusion is never reduced, so a conclusion that happens to
+unfold to `∀ …` is left intact rather than peeled into extra pattern variables (`preprocessType`
+already exposed the intended binders).
+-/
+public def Pattern.forallTelescope (type : Expr) (num? : Option Nat) (k : Array Expr → Expr → MetaM α) : MetaM α :=
+  let hugeNumber := 10000000
+  forallTelescopeAux (num?.getD hugeNumber) k #[] type
+
 def mkPatternFromType (levelParams : List Name) (type : Expr) (num? : Option Nat) : MetaM Pattern :=
-  -- `forallBoundedTelescope` whnf-reduces the conclusion; at the default transparency it would unfold
-  -- a definition expanding to `∀ …` into extra pattern variables. `withReducible` peels only what
-  -- `preprocessType` already exposed.
-  withReducible <| forallBoundedTelescope type num? fun xs body => mkPatternFVars xs body levelParams
+  Pattern.forallTelescope type num? fun xs body => mkPatternFVars xs body levelParams
 
 /--
 Creates a `Pattern` from the type of a theorem.
@@ -248,6 +266,39 @@ public def mkPatternFromExpr (e : Expr) (levelParams : List Name := []) (num? : 
   mkPatternFromType levelParams type num?
 
 /--
+Creates a `Pattern` from a theorem type, using `selectKey` to pick the key from the conclusion.
+
+The leading binders are opened as free variables and the conclusion is passed to `selectKey`; the
+returned key becomes the pattern, and the remaining components of `selectKey`'s result are returned
+unchanged. Any expressions returned alongside the key must not mention the opened binders, as they
+would otherwise escape their scope; abstract them over the binders inside `selectKey` if needed.
+-/
+@[inline]
+def mkPatternFromTypeWithKey (levelParams : List Name) (type : Expr)
+    (selectKey : Expr → MetaM (Expr × α)) : MetaM (Pattern × α) :=
+  Pattern.forallTelescope type none fun xs body => do
+    let (key, a) ← selectKey body
+    return (← mkPatternFVars xs key levelParams, a)
+
+/--
+Like `mkPatternFromTypeWithKey`, but takes a theorem declaration.
+-/
+@[inline]
+public def mkPatternFromDeclWithKey (declName : Name)
+    (selectKey : Expr → MetaM (Expr × α)) : MetaM (Pattern × α) := do
+  let (levelParams, type) ← preprocessDeclPattern declName
+  mkPatternFromTypeWithKey levelParams type selectKey
+
+/--
+Like `mkPatternFromDeclWithKey`, but for a proof expression instead of a declaration.
+-/
+@[inline]
+public def mkPatternFromExprWithKey (e : Expr) (levelParams : List Name := [])
+    (selectKey : Expr → MetaM (Expr × α)) : MetaM (Pattern × α) := do
+  let (levelParams, type) ← preprocessExprPattern e levelParams
+  mkPatternFromTypeWithKey levelParams type selectKey
+
+/--
 Creates a `Pattern` from an equational theorem, using the left-hand side of the equation.
 It also returns the right-hand side of the equation
 
@@ -260,7 +311,7 @@ Throws an error if the theorem's conclusion is not an equality.
 -/
 public def mkEqPatternFromDecl (declName : Name) : MetaM (Pattern × Expr) := do
   let (levelParams, type) ← preprocessDeclPattern declName
-  forallTelescope type fun xs body => do
+  Pattern.forallTelescope type none fun xs body => do
     let_expr Eq _ lhs rhs := body | throwError "conclusion is not a equality{indentExpr body}"
     return (← mkPatternFVars xs lhs levelParams, rhs.abstract xs)
 

--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -232,12 +232,12 @@ already exposed the intended binders).
 public partial def Pattern.forallTelescope (type : Expr) (num? : Option Nat) (k : Array Expr → Expr → MetaM α) : MetaM α := do
   let hugeNumber := 10000000
   let num := num?.getD hugeNumber
-  let rec go (fvars : Array Expr) (type : Expr) : MetaM α := do
-    if let .forallE n d b bi := type then
-      if fvars.size < num then
-        return ← withLocalDecl n bi (d.instantiateRev fvars) fun fvar => go (fvars.push fvar) b
+  let rec go (i : Nat) (fvars : Array Expr) (type : Expr) : MetaM α := do
+    if i < num then
+      if let .forallE n d b bi := type then
+        return ← withLocalDecl n bi (d.instantiateRev fvars) fun fvar => go (i+1) (fvars.push fvar) b
     k fvars (type.instantiateRev fvars)
-  go #[] type
+  go 0 #[] type
 
 def mkPatternFromType (levelParams : List Name) (type : Expr) (num? : Option Nat) : MetaM Pattern :=
   Pattern.forallTelescope type num? fun xs body => mkPatternFVars xs body levelParams

--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -221,11 +221,10 @@ public def mkPatternFVars (xs : Array Expr) (e : Expr) (levelParams : List Name 
   return { levelParams, varTypes, pattern, fnInfos, varInfos?, checkTypeMask? }
 
 def mkPatternFromType (levelParams : List Name) (type : Expr) (num? : Option Nat) : MetaM Pattern :=
-  -- A reducing telescope would unfold a reducible conclusion into extra binders, changing the
-  -- pattern, so the unbounded case peels only literal binders via `forallTelescope`.
-  match num? with
-  | none   => forallTelescope type fun xs body => mkPatternFVars xs body levelParams
-  | some n => forallBoundedTelescope type (some n) fun xs body => mkPatternFVars xs body levelParams
+  -- `forallBoundedTelescope` whnf-reduces the conclusion; at the default transparency it would unfold
+  -- a definition expanding to `∀ …` into extra pattern variables. `withReducible` peels only what
+  -- `preprocessType` already exposed.
+  withReducible <| forallBoundedTelescope type num? fun xs body => mkPatternFVars xs body levelParams
 
 /--
 Creates a `Pattern` from the type of a theorem.

--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -221,14 +221,6 @@ public def mkPatternFVars (xs : Array Expr) (e : Expr) (levelParams : List Name 
   let varInfos? ← mkProofInstArgInfo? xs
   return { levelParams, varTypes, pattern, fnInfos, varInfos?, checkTypeMask? }
 
-private partial def forallTelescopeAux (num : Nat) (k : Array Expr → Expr → MetaM α)
-    (fvars : Array Expr) (type : Expr) : MetaM α := do
-  if let .forallE n d b bi := type then
-    if fvars.size < num then
-      return ← withLocalDecl n bi (d.instantiateRev fvars) fun fvar =>
-        forallTelescopeAux num k (fvars.push fvar) b
-  k fvars (type.instantiateRev fvars)
-
 /--
 Opens the leading binders of a (preprocessed) pattern `type` as free variables and runs `k` with
 them and the conclusion. If `num? = some n`, at most `n` binders are opened.
@@ -237,9 +229,15 @@ Only literal `∀`-binders are peeled; the conclusion is never reduced, so a con
 unfold to `∀ …` is left intact rather than peeled into extra pattern variables (`preprocessType`
 already exposed the intended binders).
 -/
-public def Pattern.forallTelescope (type : Expr) (num? : Option Nat) (k : Array Expr → Expr → MetaM α) : MetaM α :=
+public partial def Pattern.forallTelescope (type : Expr) (num? : Option Nat) (k : Array Expr → Expr → MetaM α) : MetaM α := do
   let hugeNumber := 10000000
-  forallTelescopeAux (num?.getD hugeNumber) k #[] type
+  let num := num?.getD hugeNumber
+  let rec go (fvars : Array Expr) (type : Expr) : MetaM α := do
+    if let .forallE n d b bi := type then
+      if fvars.size < num then
+        return ← withLocalDecl n bi (d.instantiateRev fvars) fun fvar => go (fvars.push fvar) b
+    k fvars (type.instantiateRev fvars)
+  go #[] type
 
 def mkPatternFromType (levelParams : List Name) (type : Expr) (num? : Option Nat) : MetaM Pattern :=
   Pattern.forallTelescope type num? fun xs body => mkPatternFVars xs body levelParams

--- a/src/Lean/Meta/Sym/Simp/Theorems.lean
+++ b/src/Lean/Meta/Sym/Simp/Theorems.lean
@@ -112,11 +112,11 @@ rewrite rule in `Sym.simp`. Handles:
 - `p ↔ q` — adapted to `p = q`
 - `p` (proposition) — adapted to `p = True`
 -/
-private def selectEqKey (abstract : Expr → Expr) (type : Expr) : MetaM (Expr × Expr × EqAdaptation) := do
+private def selectEqKey (type : Expr) : MetaM (Expr × Expr × EqAdaptation) := do
   match_expr type with
-  | Eq _ lhs rhs => return (lhs, abstract rhs, .eq)
+  | Eq _ lhs rhs => return (lhs, rhs, .eq)
   | Not p => return (p, mkConst ``False, .eqFalse)
-  | Iff lhs rhs => return (lhs, abstract rhs, .iff)
+  | Iff lhs rhs => return (lhs, rhs, .iff)
   | _ =>
     unless (← isProp type) do
       throwError "cannot use as a simp theorem, conclusion is not a proposition{indentExpr type}"
@@ -145,17 +145,25 @@ where
       mkLambdaFVars xs (← wrap h)
 
 def mkTheoremFromDecl (declName : Name) : MetaM Theorem := do
-  let (pattern, (rhs, adaptation)) ← mkPatternFromDeclWithKey declName selectEqKey
-  let expr ← wrapProof pattern.varTypes.size (mkConst declName) adaptation
-  let perm := isPerm pattern.varTypes.size pattern.pattern rhs
-  return { expr, pattern, rhs, perm }
+  let (levelParams, type) ← preprocessDeclPattern declName
+  forallTelescope type fun xs body => do
+    let (key, rhs, adaptation) ← selectEqKey body
+    let pattern ← mkPatternFVars xs key levelParams
+    let rhs := rhs.abstract xs
+    let expr ← wrapProof pattern.varTypes.size (mkConst declName) adaptation
+    let perm := isPerm pattern.varTypes.size pattern.pattern rhs
+    return { expr, pattern, rhs, perm }
 
 /-- Create a `Theorem` from a proof expression. Handles equalities, `¬`, `↔`, and propositions. -/
 def mkTheoremFromExpr (e : Expr) : MetaM Theorem := do
-  let (pattern, (rhs, adaptation)) ← mkPatternFromExprWithKey e [] selectEqKey
-  let expr ← wrapProof pattern.varTypes.size e adaptation
-  let perm := isPerm pattern.varTypes.size pattern.pattern rhs
-  return { expr, pattern, rhs, perm }
+  let (levelParams, type) ← preprocessExprPattern e []
+  forallTelescope type fun xs body => do
+    let (key, rhs, adaptation) ← selectEqKey body
+    let pattern ← mkPatternFVars xs key levelParams
+    let rhs := rhs.abstract xs
+    let expr ← wrapProof pattern.varTypes.size e adaptation
+    let perm := isPerm pattern.varTypes.size pattern.pattern rhs
+    return { expr, pattern, rhs, perm }
 
 /--
 Environment extension storing a set of `Sym.Simp` theorems.

--- a/src/Lean/Meta/Sym/Simp/Theorems.lean
+++ b/src/Lean/Meta/Sym/Simp/Theorems.lean
@@ -144,26 +144,25 @@ where
       let h := mkAppN expr xs
       mkLambdaFVars xs (← wrap h)
 
-def mkTheoremFromDecl (declName : Name) : MetaM Theorem := do
-  let (levelParams, type) ← preprocessDeclPattern declName
-  forallTelescope type fun xs body => do
+/-- Builds a `Theorem` from a preprocessed equational type, keyed on the selected LHS, with `proof`
+as the underlying proof term. -/
+private def mkTheoremCore (levelParams : List Name) (type : Expr) (proof : Expr) : MetaM Theorem :=
+  Pattern.forallTelescope type none fun xs body => do
     let (key, rhs, adaptation) ← selectEqKey body
     let pattern ← mkPatternFVars xs key levelParams
     let rhs := rhs.abstract xs
-    let expr ← wrapProof pattern.varTypes.size (mkConst declName) adaptation
+    let expr ← wrapProof pattern.varTypes.size proof adaptation
     let perm := isPerm pattern.varTypes.size pattern.pattern rhs
     return { expr, pattern, rhs, perm }
+
+def mkTheoremFromDecl (declName : Name) : MetaM Theorem := do
+  let (levelParams, type) ← preprocessDeclPattern declName
+  mkTheoremCore levelParams type (mkConst declName)
 
 /-- Create a `Theorem` from a proof expression. Handles equalities, `¬`, `↔`, and propositions. -/
 def mkTheoremFromExpr (e : Expr) : MetaM Theorem := do
   let (levelParams, type) ← preprocessExprPattern e []
-  forallTelescope type fun xs body => do
-    let (key, rhs, adaptation) ← selectEqKey body
-    let pattern ← mkPatternFVars xs key levelParams
-    let rhs := rhs.abstract xs
-    let expr ← wrapProof pattern.varTypes.size e adaptation
-    let perm := isPerm pattern.varTypes.size pattern.pattern rhs
-    return { expr, pattern, rhs, perm }
+  mkTheoremCore levelParams type e
 
 /--
 Environment extension storing a set of `Sym.Simp` theorems.

--- a/src/Lean/Meta/Sym/Simp/Theorems.lean
+++ b/src/Lean/Meta/Sym/Simp/Theorems.lean
@@ -112,11 +112,11 @@ rewrite rule in `Sym.simp`. Handles:
 - `p ↔ q` — adapted to `p = q`
 - `p` (proposition) — adapted to `p = True`
 -/
-private def selectEqKey (type : Expr) : MetaM (Expr × Expr × EqAdaptation) := do
+private def selectEqKey (abstract : Expr → Expr) (type : Expr) : MetaM (Expr × Expr × EqAdaptation) := do
   match_expr type with
-  | Eq _ lhs rhs => return (lhs, rhs, .eq)
+  | Eq _ lhs rhs => return (lhs, abstract rhs, .eq)
   | Not p => return (p, mkConst ``False, .eqFalse)
-  | Iff lhs rhs => return (lhs, rhs, .iff)
+  | Iff lhs rhs => return (lhs, abstract rhs, .iff)
   | _ =>
     unless (← isProp type) do
       throwError "cannot use as a simp theorem, conclusion is not a proposition{indentExpr type}"

--- a/tests/elab/sym_eta_mwe.lean
+++ b/tests/elab/sym_eta_mwe.lean
@@ -14,7 +14,7 @@ open Lean Meta Sym Std Do
 private def mkProgPattern (declName : Name) : MetaM Pattern := do
   let ci ← getConstInfo declName
   let expr ← mkExpectedTypeHint (← mkConstWithLevelParams declName) ci.type
-  Prod.fst <$> (mkPatternFromExprWithKey expr ci.levelParams fun type => do
+  Prod.fst <$> (mkPatternFromExprWithKey expr ci.levelParams fun _abstract type => do
     let type ← whnfR type
     let_expr Triple _m _ps _inst _α prog _P _Q := type
       | throwError "not a Triple: {indentExpr type}"

--- a/tests/elab/sym_eta_mwe.lean
+++ b/tests/elab/sym_eta_mwe.lean
@@ -14,11 +14,13 @@ open Lean Meta Sym Std Do
 private def mkProgPattern (declName : Name) : MetaM Pattern := do
   let ci ← getConstInfo declName
   let expr ← mkExpectedTypeHint (← mkConstWithLevelParams declName) ci.type
-  Prod.fst <$> (mkPatternFromExprWithKey expr ci.levelParams fun _abstract type => do
-    let type ← whnfR type
-    let_expr Triple _m _ps _inst _α prog _P _Q := type
-      | throwError "not a Triple: {indentExpr type}"
-    return (prog, ())).run' {}
+  (do
+    let (levelParams, type) ← preprocessExprPattern expr ci.levelParams
+    forallTelescope type fun xs body => do
+      let body ← whnfR body
+      let_expr Triple _m _ps _inst _α prog _P _Q := body
+        | throwError "not a Triple: {indentExpr body}"
+      mkPatternFVars xs prog levelParams).run' {}
 
 /-- A `forIn` on a mapped iterator — the expression we want to look up. -/
 noncomputable def lookupTerm : Id Unit :=

--- a/tests/elab/sym_pattern_fvars.lean
+++ b/tests/elab/sym_pattern_fvars.lean
@@ -4,7 +4,8 @@ open Lean Meta Sym
 /-!
 Tests for `mkPatternFVars`, the telescope-agnostic `Sym.Pattern` constructor. Covers abstracting
 over an array that mixes free variables (from `forallTelescope`) and metavariables (from
-`forallMetaTelescope`), the `usedOnly` option, and building patterns from lambda/let telescopes.
+`forallMetaTelescope`), the `usedOnly` option, building patterns from lambda/let telescopes, and
+building a simproc-style pattern from an expression with a metavariable wildcard (#12569).
 -/
 
 opaque a : Nat
@@ -79,3 +80,25 @@ def testLet : SymM Unit := do
 /-- info: a -/
 #guard_msgs in
 #eval SymM.run testLet
+
+/--
+Regression test for #12569: a simproc trigger pattern given as an expression with a metavariable
+wildcard (`Nat.succ ?m`) is built directly with `mkPatternFVars`, abstracting the metavariable.
+The discrimination-tree keys are `[Nat.succ, *]` and it matches `Nat.succ 42`. `mkPatternFVars`
+handles the metavariable directly, so no `abstractMVars`/lambda detour is needed.
+-/
+def testMVarWildcard : MetaM Unit := do
+  let natMVar ← mkFreshExprMVar (mkConst ``Nat)
+  let e := mkApp (mkConst ``Nat.succ) natMVar
+  let pattern ← mkPatternFVars #[natMVar] e
+  let d : DiscrTree Bool := Sym.insertPattern {} pattern true
+  let tgt := mkApp (mkConst ``Nat.succ) (mkNatLit 42)
+  logInfo m!"keys: {pattern.mkDiscrTreeKeys}\nmatch: {Sym.getMatch d tgt}\nover-applied: {Sym.getMatchWithExtra d tgt}"
+
+/--
+info: keys: [Nat.succ, *]
+match: [true]
+over-applied: [(true, 0)]
+-/
+#guard_msgs in
+#eval testMVarWildcard

--- a/tests/elab/sym_pattern_fvars.lean
+++ b/tests/elab/sym_pattern_fvars.lean
@@ -1,0 +1,81 @@
+import Lean.Meta.Sym
+open Lean Meta Sym
+
+/-!
+Tests for `mkPatternFVars`, the telescope-agnostic `Sym.Pattern` constructor. Covers abstracting
+over an array that mixes free variables (from `forallTelescope`) and metavariables (from
+`forallMetaTelescope`), the `usedOnly` option, and building patterns from lambda/let telescopes.
+-/
+
+opaque a : Nat
+opaque q : Nat → Nat → Prop
+axiom qax (x y : Nat) : q x y
+axiom hax (x : Nat) (h : x = x) : q x x
+
+/--
+Open the first binder of `∀ x y, q x y` as a metavariable and the second as a free variable, then
+abstract over the mixed array. The result must equal the all-free-variable pattern from
+`mkPatternFromDecl`, and match a concrete application.
+-/
+def testMixed : SymM Unit := do
+  let type := (← getConstInfo ``qax).type
+  let (mvars, _, body) ← forallMetaBoundedTelescope type 1
+  forallTelescope body fun fvars key => do
+    let pMixed ← mkPatternFVars (mvars ++ fvars) key
+    let pAll ← mkPatternFromDecl ``qax
+    unless pMixed.pattern == pAll.pattern do
+      throwError "pattern mismatch:{indentExpr pMixed.pattern}\n!={indentExpr pAll.pattern}"
+    unless pMixed.varTypes.size == pAll.varTypes.size do
+      throwError "varTypes size mismatch: {pMixed.varTypes.size} != {pAll.varTypes.size}"
+    let tgt ← shareCommon (mkApp2 (mkConst ``q) (mkConst ``a) (mkNatLit 7))
+    let some r ← pMixed.match? tgt | throwError "match failed"
+    logInfo <| mkAppN (mkConst ``q) r.args
+
+/-- info: q a 7 -/
+#guard_msgs in
+#eval SymM.run testMixed
+
+/--
+In `∀ (x : Nat) (h : x = x), q x x` the hypothesis `h` does not occur in the conclusion, so
+`usedOnly := true` drops it. The surviving count matches `mkForallFVars (usedOnly := true)`.
+-/
+def testUsedOnly : SymM Unit := do
+  let type := (← getConstInfo ``hax).type
+  forallTelescope type fun xs body => do
+    let pKeep ← mkPatternFVars xs body
+    let pUsed ← mkPatternFVars xs body (usedOnly := true)
+    let mkForall ← forallTelescope (← mkForallFVars xs body (usedOnly := true)) fun ys _ => pure ys.size
+    logInfo m!"keep={pKeep.varTypes.size} used={pUsed.varTypes.size} mkForallFVars={mkForall}"
+    let tgt ← shareCommon (mkApp2 (mkConst ``q) (mkConst ``a) (mkConst ``a))
+    let some r ← pUsed.match? tgt | throwError "match failed"
+    unless r.args.size == 1 do throwError "expected 1 pattern variable, got {r.args.size}"
+
+/-- info: keep=2 used=1 mkForallFVars=1 -/
+#guard_msgs in
+#eval SymM.run testUsedOnly
+
+/-- Build a pattern from the body of a `fun` via `lambdaTelescope`. -/
+def testLambda : SymM Unit := do
+  let e := Expr.lam `x (mkConst ``Nat) (mkApp2 (mkConst ``q) (.bvar 0) (.bvar 0)) .default
+  lambdaTelescope e fun xs body => do
+    let p ← mkPatternFVars xs body
+    let tgt ← shareCommon (mkApp2 (mkConst ``q) (mkConst ``a) (mkConst ``a))
+    let some r ← p.match? tgt | throwError "match failed"
+    logInfo r.args[0]!
+
+/-- info: a -/
+#guard_msgs in
+#eval SymM.run testLambda
+
+/-- Build a pattern from the body of a `let` via `lambdaLetTelescope`. -/
+def testLet : SymM Unit := do
+  let e := Expr.letE `x (mkConst ``Nat) (mkNatLit 1) (mkApp2 (mkConst ``q) (.bvar 0) (.bvar 0)) false
+  lambdaLetTelescope e fun xs body => do
+    let p ← mkPatternFVars xs body
+    let tgt ← shareCommon (mkApp2 (mkConst ``q) (mkConst ``a) (mkConst ``a))
+    let some r ← p.match? tgt | throwError "match failed"
+    logInfo r.args[0]!
+
+/-- info: a -/
+#guard_msgs in
+#eval SymM.run testLet

--- a/tests/elab/sym_pattern_fvars.lean
+++ b/tests/elab/sym_pattern_fvars.lean
@@ -2,10 +2,10 @@ import Lean.Meta.Sym
 open Lean Meta Sym
 
 /-!
-Tests for `mkPatternFVars`, the telescope-agnostic `Sym.Pattern` constructor. Covers abstracting
-over an array that mixes free variables (from `forallTelescope`) and metavariables (from
-`forallMetaTelescope`), the `usedOnly` option, building patterns from lambda/let telescopes, and
-building a simproc-style pattern from an expression with a metavariable wildcard (#12569).
+Tests for `mkPatternFVars`, exercising how it abstracts the locally nameless variables of the
+ambient context into a `Sym.Pattern`: an array mixing free variables (from `forallTelescope`) and
+metavariables (from `forallMetaTelescope`), the `usedOnly` option, binders opened by lambda and let
+telescopes, and a metavariable wildcard (`Nat.succ ?m`) used as a simproc trigger pattern.
 -/
 
 opaque a : Nat
@@ -82,10 +82,9 @@ def testLet : SymM Unit := do
 #eval SymM.run testLet
 
 /--
-Regression test for #12569: a simproc trigger pattern given as an expression with a metavariable
-wildcard (`Nat.succ ?m`) is built directly with `mkPatternFVars`, abstracting the metavariable.
-The discrimination-tree keys are `[Nat.succ, *]` and it matches `Nat.succ 42`. `mkPatternFVars`
-handles the metavariable directly, so no `abstractMVars`/lambda detour is needed.
+`mkPatternFVars` abstracts a metavariable wildcard (`Nat.succ ?m`) directly into a pattern variable,
+producing the discrimination-tree keys `[Nat.succ, *]` that match `Nat.succ 42`. This is the shape
+of a simproc trigger pattern.
 -/
 def testMVarWildcard : MetaM Unit := do
   let natMVar ← mkFreshExprMVar (mkConst ``Nat)

--- a/tests/elab/sym_pattern_universe_issue.lean
+++ b/tests/elab/sym_pattern_universe_issue.lean
@@ -29,10 +29,11 @@ info: Match SUCCEEDED: 2 levels, 6 args
   let info ← getConstInfo ``Spec.get_StateT
   let levelParams := info.levelParams
   let proof := mkConst ``Spec.get_StateT (levelParams.map mkLevelParam)
-  let (pat, _) ← Sym.mkPatternFromExprWithKey proof levelParams fun _abstract type => do
-    let_expr Triple _m _ps _inst _α prog _P _Q := type
-      | throwError "not a Triple: {type}"
-    return (prog, ())
+  let (levelParams, type) ← Sym.preprocessExprPattern proof levelParams
+  let pat ← forallTelescope type fun xs body => do
+    let_expr Triple _m _ps _inst _α prog _P _Q := body
+      | throwError "not a Triple: {body}"
+    Sym.mkPatternFVars xs prog levelParams
 
   -- 2. Build target: @MonadStateOf.get (Nat × Nat) (StateT (Nat × Nat) m) inst
   let u1 := Level.param `u_1

--- a/tests/elab/sym_pattern_universe_issue.lean
+++ b/tests/elab/sym_pattern_universe_issue.lean
@@ -29,7 +29,7 @@ info: Match SUCCEEDED: 2 levels, 6 args
   let info ← getConstInfo ``Spec.get_StateT
   let levelParams := info.levelParams
   let proof := mkConst ``Spec.get_StateT (levelParams.map mkLevelParam)
-  let (pat, _) ← Sym.mkPatternFromExprWithKey proof levelParams fun type => do
+  let (pat, _) ← Sym.mkPatternFromExprWithKey proof levelParams fun _abstract type => do
     let_expr Triple _m _ps _inst _α prog _P _Q := type
       | throwError "not a Triple: {type}"
     return (prog, ())


### PR DESCRIPTION
This PR reworks `Sym.Pattern` construction around `mkPatternFVars`, which builds a pattern by abstracting an array of free variables and/or metavariables out of an expression. Pattern keys can now be selected from under any binder telescope (forall, lambda, or let) via the new non-reducing `Pattern.forallTelescope`, expressions with metavariable wildcards (e.g. `Nat.succ _`) become patterns directly, and an optional `usedOnly` keeps only the binders the key depends on.

`mkPatternFromType`, `mkEqPatternFromDecl`, the public `mkPatternFromDeclWithKey`/`mkPatternFromExprWithKey` helpers, and the `Sym.simp` and do-notation spec-database constructors all share `Pattern.forallTelescope` and `mkPatternFVars`. The `@[spec]` attribute drops its bespoke pattern-pruning pass in favor of `mkPatternFVars (usedOnly := true)`.