### PR TITLE
feat: constant folding for `USize.decEq`

### DIFF
--- a/src/Lean/Compiler/LCNF/Simp/ConstantFold.lean
+++ b/src/Lean/Compiler/LCNF/Simp/ConstantFold.lean
@@ -409,6 +409,10 @@ def relationFolders : List (Name × Folder) := [
   (``UInt64.decEq, Folder.mkBinaryDecisionProcedure UInt64.decEq),
   (``UInt64.decLt, Folder.mkBinaryDecisionProcedure UInt64.decLt),
   (``UInt64.decLe, Folder.mkBinaryDecisionProcedure UInt64.decLe),
+  -- Equality is perserved across bit widths,
+  -- so it is safe to interpret `USize` literals as `UInt64` values
+  have : Literal UInt64 := mkUIntInstance (fun | .usize x => some x | _ => none) .usize
+  (``USize.decEq, Folder.mkBinaryDecisionProcedure UInt64.decEq),
   (``Bool.decEq, Folder.mkBinaryDecisionProcedure Bool.decEq),
   (``String.decEq, Folder.mkBinaryDecisionProcedure String.decEq)
 ]

--- a/tests/elab/fold_uint.lean
+++ b/tests/elab/fold_uint.lean
@@ -21,3 +21,13 @@ def mwe : Bool :=
     let y64 := 2
     x8 + y8 < 4 && x16 + y16 < 4 && x32 + y32 < 4 && x64 + y64 < 4
 
+/--
+trace: [Compiler.IR] [result]
+    def usizeDecEq : u8 :=
+      let x_1 : u8 := 1;
+      ret x_1
+-/
+#guard_msgs in
+set_option trace.compiler.ir.result true in
+def usizeDecEq : Bool :=
+    (0 : USize) = (0 : USize)


### PR DESCRIPTION
This PR adds constant folding support for `USize.decEq` to the compiler.
