### PR TITLE
chore: CI: update and sha-pin github actions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -17,6 +17,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
     - name: actionlint
-      uses: raven-actions/actionlint@v2
+      uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2
       with:
         pyflakes: false # we do not use python scripts

--- a/.github/workflows/awaiting-manual.yml
+++ b/.github/workflows/awaiting-manual.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check awaiting-manual label
         id: check-awaiting-manual-label
         if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const { labels, number: prNumber } = context.payload.pull_request;
@@ -29,7 +29,7 @@ jobs:
               core.info('PR is marked "awaiting-manual" but neither "breaks-manual" nor "builds-manual" labels are present.');
               core.setOutput('awaiting', 'true');
             }
-      
+
       - name: Wait for manual compatibility
         if: github.event_name == 'pull_request_target' && steps.check-awaiting-manual-label.outputs.awaiting == 'true'
         run: |

--- a/.github/workflows/awaiting-mathlib.yml
+++ b/.github/workflows/awaiting-mathlib.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check awaiting-mathlib label
         id: check-awaiting-mathlib-label
         if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const { labels, number: prNumber } = context.payload.pull_request;
@@ -29,7 +29,7 @@ jobs:
               core.info('PR is marked "awaiting-mathlib" but neither "breaks-mathlib" nor "builds-mathlib" labels are present.');
               core.setOutput('awaiting', 'true');
             }
-      
+
       - name: Wait for mathlib compatibility
         if: github.event_name == 'pull_request_target' && steps.check-awaiting-mathlib-label.outputs.awaiting == 'true'
         run: |

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,6 +21,6 @@ jobs:
         )
       )
     steps:
-      - uses: tibdex/backport@v2
+      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -266,7 +266,7 @@ jobs:
           time ctest --preset ${{ matrix.CMAKE_PRESET || 'release' }} --test-dir build/$TARGET_STAGE -j$NPROC --output-junit test-results.xml ${{ matrix.CTEST_OPTIONS }}
         if: matrix.test
       - name: Test Summary
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
         with:
           paths: build/${{ env.TARGET_STAGE }}/test-results.xml
         # prefix `if` above with `always` so it's run even if tests failed

--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -83,7 +83,7 @@ jobs:
         if: github.event_name == 'pull_request'
       # (needs to be after "Checkout" so files don't get overridden)
       - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v14
+        uses: emscripten-core/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984 # v16
         with:
           version: 3.1.44
           actions-cache-folder: emsdk

--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -250,7 +250,7 @@ jobs:
           else
             ${{ matrix.tar || 'tar' }} cf - $dir | zstd -T0 --no-progress -o pack/$dir.tar.zst
           fi
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: matrix.release
         with:
           name: build-${{ matrix.name }}

--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -52,7 +52,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: 11.0
     steps:
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
         if: runner.os == 'Linux' && !matrix.cmultilib
       - name: Install MSYS2
         uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1

--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -55,7 +55,7 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@main
         if: runner.os == 'Linux' && !matrix.cmultilib
       - name: Install MSYS2
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
         with:
           msystem: clang64
           # `:` means do not prefix with msystem

--- a/.github/workflows/check-stage0.yml
+++ b/.github/workflows/check-stage0.yml
@@ -31,7 +31,7 @@ jobs:
 
     - if: github.event_name == 'pull_request'
       name: Set label
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       with:
         script: |
           const { owner, repo, number: issue_number  } = context.issue;

--- a/.github/workflows/check-stdlib-flags.yml
+++ b/.github/workflows/check-stdlib-flags.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if stdlib_flags.h was modified
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             // Get the list of files changed in this PR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,7 +482,7 @@ jobs:
         with:
           path: artifacts
       - name: Release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: artifacts/*/*
           fail_on_unmatched_files: true
@@ -528,7 +528,7 @@ jobs:
           echo -e "\n*Full commit log*\n" >> diff.md
           git log --oneline "$last_tag"..HEAD | sed 's/^/* /' >> diff.md
       - name: Release Nightly
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           body_path: diff.md
           prerelease: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
 
       - name: Configure build matrix
         id: set-matrix
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const level = ${{ steps.set-level.outputs.check-level }};
@@ -466,7 +466,7 @@ jobs:
           content: |
             A build of `${{ github.ref_name }}`, triggered by event `${{ github.event_name }}`, [failed](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
       - if: contains(needs.*.result, 'failure')
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             core.setFailed('Some jobs failed')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
 
       - name: Check self-hosted runner availability
         id: runner-fallback
-        uses: mikehardy/runner-fallback-action@v1
+        uses: mikehardy/runner-fallback-action@dc7732f9e532c451b2527b288ba8d58fd4b0a4ca # v1.1.0
         with:
           github-token: ${{ secrets.READ_RUNNERS_TOKEN }}
           primary-runner: self-hosted,chonk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,7 +478,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
       - name: Release
@@ -510,7 +510,7 @@ jobs:
           # Doesn't seem to be working when additionally fetching from lean4-nightly
           #filter: tree:0
           token: ${{ secrets.PUSH_NIGHTLY_TOKEN }}
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
       - name: Prepare Nightly Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,7 +455,7 @@ jobs:
     if: ${{ !cancelled() }}
     steps:
       - if: ${{ contains(needs.*.result, 'failure') && github.repository == 'leanprover/lean4' && github.ref_name == 'master' }}
-        uses: zulip/github-actions-zulip/send-message@v1
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa # v2.0.1
         with:
           api-key: ${{ secrets.ZULIP_BOT_KEY }}
           email: "github-actions-bot@lean-fro.zulipchat.com"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,7 +545,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_INDEX_TOKEN }}
       - name: Generate mathlib nightly-testing app token
         id: mathlib-app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.MATHLIB_NIGHTLY_TESTING_APP_ID }}

--- a/.github/workflows/grove.yml
+++ b/.github/workflows/grove.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Deploy to Netlify
         if: ${{ steps.should-run.outputs.should-run == 'true' }}
         id: deploy-draft
-        uses: nwtgck/actions-netlify@v3.0
+        uses: nwtgck/actions-netlify@d22a32a27c918fe470bbc562e984f80ec48c2668 # v4.0.0
         with:
           publish-dir: ${{ steps.build.outputs.out-path }}
           production-deploy: false

--- a/.github/workflows/grove.yml
+++ b/.github/workflows/grove.yml
@@ -147,7 +147,7 @@ jobs:
       # https://github.com/nwtgck/actions-netlify/issues/545
       # We work around by using a comment to post the latest link
       - name: "Comment on PR with preview links"
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         if: ${{ steps.should-run.outputs.should-run == 'true' && steps.workflow-info.outputs.pullRequestNumber != '' }}
         with:
           number: ${{ env.PR_NUMBER }}

--- a/.github/workflows/grove.yml
+++ b/.github/workflows/grove.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Retrieve information about the original workflow
-        uses: potiuk/get-workflow-origin@v1_1 # https://github.com/marketplace/actions/get-workflow-origin
+        uses: potiuk/get-workflow-origin@08219db9dbbbec802d571eaf0e14ece0bc005f72 # v1_6
         # This action is deprecated and archived, but it seems hard to find a
         # better solution for getting the PR number
         # see https://github.com/orgs/community/discussions/25220 for some discussion

--- a/.github/workflows/grove.yml
+++ b/.github/workflows/grove.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Download toolchain for this commit
         if: ${{ steps.should-run.outputs.should-run == 'true' }}
         id: download-toolchain
-        uses: dawidd6/action-download-artifact@v19
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           commit: ${{ steps.workflow-info.outputs.sourceHeadSha }}
           workflow: ci.yml

--- a/.github/workflows/grove.yml
+++ b/.github/workflows/grove.yml
@@ -111,7 +111,7 @@ jobs:
       # material.
       - id: deploy-alias
         if: ${{ steps.should-run.outputs.should-run == 'true' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         name: Compute Alias
         with:
           result-encoding: string

--- a/.github/workflows/labels-from-comments.yml
+++ b/.github/workflows/labels-from-comments.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Add label based on comment
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Check PR body
         if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           # Safety note: this uses pull_request_target, so the workflow has elevated privileges.
           # The PR title and body are only used in regex tests (read-only string matching),

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -169,7 +169,7 @@ jobs:
 
       - name: 'Setup jq'
         if: ${{ steps.workflow-info.outputs.pullRequestNumber != '' }}
-        uses: dcarbone/install-jq-action@v3.2.0
+        uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
 
       # Generate a token for posting comments to Lean PRs about mathlib compatibility.
       # This app is in the leanprover org and installed on leanprover/lean4.

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Download artifact from the previous workflow.
         if: ${{ steps.workflow-info.outputs.pullRequestNumber != '' }}
         id: download-artifact
-        uses: dawidd6/action-download-artifact@v19 # https://github.com/marketplace/actions/download-workflow-artifact
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           run_id: ${{ github.event.workflow_run.id }}
           path: artifacts

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -25,8 +25,9 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.repository == 'leanprover/lean4'
     steps:
       - name: Retrieve information about the original workflow
-        uses: potiuk/get-workflow-origin@v1_1 # https://github.com/marketplace/actions/get-workflow-origin
-        # This action is deprecated and archived, but it seems hard to find a better solution for getting the PR number
+        uses: potiuk/get-workflow-origin@08219db9dbbbec802d571eaf0e14ece0bc005f72 # v1_6
+        # This action is deprecated and archived, but it seems hard to find a
+        # better solution for getting the PR number
         # see https://github.com/orgs/community/discussions/25220 for some discussion
         id: workflow-info
         with:

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Report release status (short format)
         if: ${{ steps.workflow-info.outputs.pullRequestNumber != '' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -132,7 +132,7 @@ jobs:
 
       - name: Report release status (SHA-suffixed format)
         if: ${{ steps.workflow-info.outputs.pullRequestNumber != '' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -146,7 +146,7 @@ jobs:
 
       - name: Add toolchain-available label
         if: ${{ steps.workflow-info.outputs.pullRequestNumber != '' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.addLabels({
@@ -390,7 +390,7 @@ jobs:
 
       - name: Report mathlib base
         if: ${{ steps.workflow-info.outputs.pullRequestNumber != '' && steps.ready.outputs.mathlib_ready == 'true' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const description =
@@ -551,7 +551,7 @@ jobs:
 
       - name: Add mathlib4-nightly-available label
         if: steps.workflow-info.outputs.pullRequestNumber != '' && steps.ready.outputs.mathlib_ready == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.addLabels({

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -175,7 +175,7 @@ jobs:
       - name: Generate GitHub App token for Lean PR comments
         if: ${{ steps.workflow-info.outputs.pullRequestNumber != '' }}
         id: mathlib-comment-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.MATHLIB_LEAN_PR_TESTING_APP_ID }}
           private-key: ${{ secrets.MATHLIB_LEAN_PR_TESTING_PRIVATE_KEY }}
@@ -414,7 +414,7 @@ jobs:
       - name: Generate GitHub App token for leanprover-community repos
         if: steps.workflow-info.outputs.pullRequestNumber != '' && steps.ready.outputs.mathlib_ready == 'true'
         id: mathlib-app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.MATHLIB_NIGHTLY_TESTING_APP_ID }}
           private-key: ${{ secrets.MATHLIB_NIGHTLY_TESTING_PRIVATE_KEY }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const msg = context.payload.pull_request? context.payload.pull_request.title : context.payload.merge_group.head_commit.message;

--- a/.github/workflows/update-stage0.yml
+++ b/.github/workflows/update-stage0.yml
@@ -53,7 +53,7 @@ jobs:
           git config --global user.email "<>"
     - if: env.should_update_stage0 == 'yes'
       name: Install Nix
-      uses: DeterminateSystems/nix-installer-action@main
+      uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
     - name: Open Nix shell once
       if: env.should_update_stage0 == 'yes'
       run: true


### PR DESCRIPTION
This PR updates all github actions to their last release.

For all actions in the `actions/` namespace (and those by @TwoFX), it uses the `vX` tag for the latest major version. All other actions are sha-pinned to their latest release.