### PR TITLE
fix: remove `OPENSSL_init_ssl`

### DIFF
--- a/src/runtime/openssl.cpp
+++ b/src/runtime/openssl.cpp
@@ -13,9 +13,6 @@ Author: Sofia Rodrigues
 namespace lean {
 
 void initialize_openssl() {
-    if (OPENSSL_init_ssl(0, nullptr) != 1) {
-        lean_internal_panic("failed to initialize OpenSSL");
-    }
 }
 
 void finalize_openssl() {}


### PR DESCRIPTION
This PR removes `OPENSSL_init_ssl` from `initialize_openssl` so it helps with loading OpenSSL lazily.