### PR TITLE
refactor: finalize task manager and libuv in `finalize()`

### DIFF
--- a/src/initialize/init.cpp
+++ b/src/initialize/init.cpp
@@ -7,6 +7,7 @@ Author: Leonardo de Moura
 #include "runtime/stackinfo.h"
 #include "runtime/thread.h"
 #include "runtime/init_module.h"
+#include "runtime/libuv.h"
 #include "util/init_module.h"
 #include "util/io.h"
 #include "kernel/init_module.h"
@@ -43,6 +44,9 @@ extern "C" LEAN_EXPORT void lean_initialize() {
 }
 
 void finalize() {
+    // NOTE: must be run before finalizing the task manager
+    finalize_libuv();
+    lean_finalize_task_manager();
     run_thread_finalizers();
     finalize_constructions_module();
     finalize_library_module();

--- a/src/runtime/libuv.cpp
+++ b/src/runtime/libuv.cpp
@@ -26,6 +26,17 @@ extern "C" void initialize_libuv() {
     lthread([]() { event_loop_run_loop(&global_ev); });
 }
 
+extern "C" void finalize_libuv() {
+    // TODO: implement a clean libuv shutdown. The event-loop thread spawned in
+    // `initialize_libuv` is detached and kept alive indefinitely by the persistent
+    // `global_ev.async` handle, so stopping it cleanly requires: a join handle for the
+    // loop thread; a shutdown signal that breaks `event_loop_run_loop`, closes the async
+    // handle, and calls `uv_loop_close`; and resolving any in-flight promises so dedicated
+    // workers blocked on libuv operations are released before the task-manager drain.
+    // See the (also unimplemented) `event_loop_cleanup`. For now this is a no-op, matching
+    // the prior behaviour where libuv was never finalized.
+}
+
 extern "C" LEAN_EXPORT char ** lean_setup_args(int argc, char ** argv) {
     return uv_setup_args(argc, argv);
 }
@@ -38,6 +49,8 @@ extern "C" LEAN_EXPORT lean_obj_res lean_libuv_version(lean_obj_arg o) {
 #else
 
 extern "C" void initialize_libuv() {}
+
+extern "C" void finalize_libuv() {}
 
 extern "C" LEAN_EXPORT lean_obj_res lean_libuv_version(lean_obj_arg o) {
     return lean_box(0);

--- a/src/runtime/libuv.h
+++ b/src/runtime/libuv.h
@@ -23,6 +23,7 @@ Author: Markus Himmel, Sofia Rodrigues
 namespace lean {
 
 extern "C" void initialize_libuv();
+extern "C" void finalize_libuv();
 extern "C" LEAN_EXPORT char ** lean_setup_args(int argc, char ** argv);
 
 // =======================================

--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -1096,22 +1096,6 @@ extern "C" LEAN_EXPORT void lean_finalize_task_manager() {
     }
 }
 
-scoped_task_manager::scoped_task_manager(unsigned num_workers) {
-    lean_assert(g_task_manager == nullptr);
-#if defined(LEAN_MULTI_THREAD)
-    if (num_workers > 0) {
-        g_task_manager = new task_manager(num_workers);
-    }
-#endif
-}
-
-scoped_task_manager::~scoped_task_manager() {
-    if (g_task_manager) {
-        delete g_task_manager;
-        g_task_manager = nullptr;
-    }
-}
-
 void deactivate_task(lean_task_object * t) {
     if (g_task_manager) {
         g_task_manager->deactivate_task(t);

--- a/src/runtime/object.h
+++ b/src/runtime/object.h
@@ -272,12 +272,6 @@ inline obj_res thunk_get_own(b_obj_arg t) { return lean_thunk_get_own(t); }
 // =======================================
 // Tasks
 
-class LEAN_EXPORT scoped_task_manager {
-public:
-    scoped_task_manager(unsigned num_workers);
-    ~scoped_task_manager();
-};
-
 inline obj_res task_spawn(obj_arg c, unsigned prio = 0, bool keep_alive = false) { return lean_task_spawn_core(c, prio, keep_alive); }
 inline obj_res task_pure(obj_arg a) { return lean_task_pure(a); }
 inline obj_res task_bind(obj_arg x, obj_arg f, unsigned prio = 0, bool sync = false, bool keep_alive = false) { return lean_task_bind_core(x, f, prio, sync, keep_alive); }

--- a/src/util/shell.cpp
+++ b/src/util/shell.cpp
@@ -344,7 +344,10 @@ extern "C" LEAN_EXPORT int lean_main(int argc, char ** argv) {
         report_profiling_time("initialization", init_time);
     }
 
-    scoped_task_manager scope_task_man(get_shell_num_threads(shell_opts));
+    // The task manager needs the thread count, which is only known after option parsing, so
+    // it is initialized here. It is finalized (together with libuv) in `finalize()` via the
+    // `initializer` destructor below.
+    lean_init_task_manager_using(get_shell_num_threads(shell_opts));
 
     try {
         return run_shell_main(argc - optind, argv + optind, shell_opts);


### PR DESCRIPTION
This PR moves task-manager teardown out of the shell's RAII `scoped_task_manager` and into the runtime's `finalize()`, where it now runs after a new `finalize_libuv` hook so that libuv is finalized before the task-manager worker pool is drained.

The shell and the compiler-generated `main` already initialize the task manager explicitly (they need the thread count, which is only known after option parsing), so `scoped_task_manager` is removed and the shell relies on the `initializer` destructor for finalization.

TODO: `finalize_libuv` is currently a documented no-op stub matching the prior behaviour where libuv was never finalized; only the ordering is wired up, leaving a real libuv shutdown to be slotted in ahead of the drain. The `-j0` (no task manager) semantics are unchanged.

Fixes #13939