### PR TITLE
feat(lake): content-stable module archives in Lake's artifact cache

### DIFF
--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -863,8 +863,8 @@ them. Consumers recover the input hash from the cache mapping used to locate
 the archive (see `Module.stampLtarTrace`).
 
 Since the log is not packed, restoring a module from an archive does not
-replay the producer's build log (e.g., warnings) on later builds, matching
-the behavior of individually cached artifacts (see `BuildMetadata.ofFetch`).
+replay the producer's build log (e.g., warnings) on later builds, like any
+other restore from the cache (see `BuildMetadata.ofFetch`).
 -/
 def Module.mkLtarMetadata (outputs : Json) : BuildMetadata :=
   {depHash := .nil, inputs := #[], outputs? := some outputs, log := {}, synthetic := false}
@@ -1145,9 +1145,7 @@ where
         -- individual output content hashes the bundle expands to. The consumer
         -- fetches the bundle to materialize the outputs and checks them against
         -- the recorded hashes (see `fetchFromCache?`). Only the bundle is an
-        -- upload target; the hashes are descriptive metadata. The entry is
-        -- inserted the same way whether the archive was just packed or already
-        -- existed, including the platform-independence flag.
+        -- upload target; the hashes are descriptive metadata.
         let arts ← id do
           if arts.ltar?.isSome then
             return arts

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -666,7 +666,10 @@ def resolveModuleOutputArtifacts (out : CacheOutput) : JobM ModuleOutputArtifact
 instance : ResolveOutputs ModuleOutputArtifacts := ⟨resolveModuleOutputArtifacts⟩
 
 inductive ModuleOutputs
-| ltar (art : Artifact)
+| /-- An archive bundle. `descrs?` carries the receipt's independently-recorded
+    output content hashes (when the receipt is a full mapping rather than a bare
+    archive reference), used to verify the unpacked bundle (see `fetchFromCache?`). -/
+  ltar (art : Artifact) (descrs? : Option ModuleOutputDescrs := none)
 | arts (arts : ModuleOutputArtifacts)
 
 instance : Coe ModuleOutputArtifacts ModuleOutputs := ⟨.arts⟩
@@ -675,18 +678,27 @@ def resolveModuleOutputs (out : CacheOutput) : JobM ModuleOutputs := do
   if let .str descr := out.data then
     match ArtifactDescr.ofFilePath? descr with
     | .ok descr =>
-      return .ltar (← resolveArtifact descr out.service? out.scope?)
+      -- Receipt references an archive bundle. If it also recorded the output
+      -- hashes, carry them so the unpacked bundle can be verified; an older
+      -- receipt without them resolves the bundle directly.
+      let art ← resolveArtifact descr out.service? out.scope?
+      let descrs? := out.outputs?.bind fun o => (fromJson? o : Except _ ModuleOutputDescrs).toOption
+      return .ltar art descrs?
     | .error e =>
       error s!"ill-formed module archive output:\n{out.data.render.pretty 80 2}\n{e}"
   else
     match fromJson? out.data with
     | .ok (descrs : ModuleOutputDescrs) =>
       if let some descr := descrs.ltar? then
+        -- A full receipt that also references an archive bundle. Prefer the
+        -- individually-cached artifacts when present (no unpack needed); when
+        -- only the bundle is cached, fall back to it, carrying `descrs` so the
+        -- unpacked outputs can be verified against the receipt's record.
         try
           descrs.resolve out.service? out.scope?
         catch e =>
           dropLogFrom e
-          return .ltar (← resolveArtifact descr out.service? out.scope?)
+          return .ltar (← resolveArtifact descr out.service? out.scope?) (some descrs)
       else
         descrs.resolve out.service? out.scope?
     | .error e => error s!"ill-formed module outputs:\n{out.data.render.pretty 80 2}\n{e}"
@@ -820,6 +832,20 @@ where
 
 instance : ToOutputJson ModuleOutputArtifacts := ⟨(toJson ·.descrs)⟩
 
+/--
+Build metadata packed into a module's `.ltar` archive.
+
+The metadata omits any input- or environment-derived data: the input hash
+(`depHash := .nil`), the input tree, and the build log (which records the
+`lean` invocation, including absolute paths). The archive bytes are therefore a
+pure function of the module's *outputs*, so byte-identical outputs always
+produce a byte-identical, content-hash-identical archive, independent of the
+inputs or machine that produced them. Consumers recover the input hash from the
+cache mapping used to locate the archive (see `Module.stampLtarTrace`).
+-/
+def Module.mkLtarMetadata (outputs : Json) : BuildMetadata :=
+  {depHash := .nil, inputs := #[], outputs? := some outputs, log := {}, synthetic := false}
+
 def Module.packLtar (self : Module) (arts : ModuleOutputArtifacts) : JobM Artifact := do
   let arts ← id do
     if (← self.checkArtifactsExist arts.isModule) then
@@ -849,7 +875,20 @@ def Module.packLtar (self : Module) (arts : ModuleOutputArtifacts) : JobM Artifa
         | error "LLVM backend enabled but module outputs lack bitcode"
       args := addArt args "1" art
     return args
-  proc (quiet := true) {cmd := (← getLeantar).toString, args}
+  /-
+  Swap a canonical, input-free trace into the trace file for the duration of
+  the pack so that the archive bytes depend only on the module's outputs
+  (see `Module.mkLtarMetadata`). The on-disk trace (which carries the real
+  input hash for incremental checks) is restored afterwards.
+  -/
+  let savedContents? ← (some <$> IO.FS.readBinFile self.traceFile).catchExceptions fun _ => pure none
+  let metadata := mkLtarMetadata (toJson {arts with ltar? := none}.descrs)
+  try
+    metadata.writeFile self.traceFile
+    proc (quiet := true) {cmd := (← getLeantar).toString, args}
+  finally
+    if let some contents := savedContents? then
+      IO.FS.writeBinFile self.traceFile contents
   if (← self.pkg.isArtifactCacheWritable) then
     cacheArtifact self.ltarFile "ltar" (useLocalFile := ← self.pkg.restoreAllArtifacts)
   else
@@ -862,6 +901,28 @@ def Module.unpackLtar (self : Module) (ltar : FilePath) : JobM Unit := do
     "-x", ltar.toString
   ]
   proc (quiet := true) {cmd := (← getLeantar).toString, args}
+
+/--
+Stamp the input hash into the trace file just unpacked from a module's `.ltar`.
+
+The packed trace is input-free (`depHash := .nil`, see `Module.mkLtarMetadata`),
+so after unpacking, the consumer must stamp it with the input hash for which
+the archive is valid — either the hash used to locate the archive in the cache,
+or, on a local up-to-date replay, the module's current dependency hash. This
+preserves the invariant that the on-disk trace always carries the real input
+hash; an unstamped `.nil` trace would force a needless rebuild on the next run.
+
+Traces packed by older Lake versions carry the producer's input hash and are
+returned unchanged. Returns the resulting `SavedTrace`.
+-/
+def Module.stampLtarTrace (self : Module) (inputHash : Hash) : LogIO SavedTrace := do
+  let savedTrace ← readTraceFile self.traceFile
+  if let .ok data := savedTrace then
+    if data.depHash == .nil then
+      let data := {data with depHash := inputHash, synthetic := true}
+      data.writeFile self.traceFile
+      return .ok data
+  return savedTrace
 
 def Module.recBuildLtar (self : Module) : FetchM (Job FilePath) := do
   withRegisterJob s!"{self.name}:ltar" <| withCurrPackage self.pkg do
@@ -935,13 +996,33 @@ where
     let some ltarOrArts ← getArtifacts? inputHash savedTrace mod.pkg
       | return .inr savedTrace
     match (ltarOrArts : ModuleOutputs) with
-    | .ltar ltar =>
+    | .ltar ltar descrs? =>
       updateAction .unpack
       mod.clearOutputArtifacts
       mod.unpackLtar ltar.path
       -- Note: This branch implies that only the ltar output is (validly) cached.
       -- Thus, we use only the new trace unpacked from the ltar to resolve further artifacts.
-      let savedTrace ← readTraceFile mod.traceFile
+      let savedTrace ← mod.stampLtarTrace inputHash
+      -- Integrity: when the receipt records the output hashes, confirm the
+      -- unpacked bundle declares exactly those outputs, so a receipt whose
+      -- archive reference and recorded outputs disagree (e.g. one wired to
+      -- another module's bundle) is rejected rather than silently trusted.
+      if let some receiptDescrs := descrs? then
+        let bundleDescrs ← id do
+          let .ok data := savedTrace
+            | error s!"cache integrity error: archive for input {inputHash} has no usable trace"
+          let some out := data.outputs?
+            | error s!"cache integrity error: archive for input {inputHash} records no outputs"
+          match fromJson? out with
+          | .ok (d : ModuleOutputDescrs) => pure d
+          | .error e => error s!"cache integrity error: archive for input {inputHash} has ill-formed outputs: {e}"
+        -- Clear the `ltar?` self-reference on both sides: it identifies the
+        -- bundle itself, not one of the outputs being compared.
+        let got := (toJson {bundleDescrs with ltar? := none}).compress
+        let want := (toJson {receiptDescrs with ltar? := none}).compress
+        unless got == want do
+          error s!"cache integrity error: archive for input {inputHash} does not \
+            match the outputs recorded in its cache mapping\n  recorded: {want}\n  unpacked: {got}"
       let arts? ← getArtifactsUsingTrace? inputHash savedTrace mod.pkg
       if let some (arts : ModuleOutputArtifacts) := arts? then
         -- on initial unpack from cache ensure all artifacts uniformly
@@ -978,6 +1059,7 @@ where
         if status.isUpToDate then
           unless (← mod.checkArtifactsExist setup.isModule) do
             mod.unpackLtar mod.ltarFile
+            discard <| mod.stampLtarTrace depTrace.hash
         else
           discard <| mod.buildLean depTrace srcFile setup
         if status.isCacheable then
@@ -990,6 +1072,7 @@ where
       if (← savedTrace.replayIfUpToDate (oldTrace := srcTrace.mtime) mod depTrace) then
         unless (← mod.checkArtifactsExist setup.isModule) do
           mod.unpackLtar mod.ltarFile
+          discard <| mod.stampLtarTrace depTrace.hash
         mod.computeArtifacts setup.isModule
       else
         if (← mod.pkg.isArtifactCacheReadable) then
@@ -1007,17 +1090,24 @@ where
     if mod.pkg.isRoot then
       if let some ref := (← getBuildContext).outputsRef? then
         let inputHash := (← getTrace).hash
-        if let some ltar := arts.ltar? then
-          ref.insert inputHash ltar.descr
-          return arts
-        else
+        -- Record the archive bundle as the output to fetch, alongside the
+        -- individual output content hashes the bundle expands to. The consumer
+        -- fetches the bundle to materialize the outputs and checks them against
+        -- the recorded hashes (see `fetchFromCache?`). Only the bundle is an
+        -- upload target; the hashes are descriptive metadata.
+        let arts ← id do
+          if arts.ltar?.isSome then
+            return arts
           let ltar ← id do
             if (← mod.ltarFile.pathExists) then
               computeArtifact mod.ltarFile "ltar"
             else
               mod.packLtar arts
-          ref.insert inputHash ltar.descr (mod.platformIndependent.getD false)
           return {arts with ltar? := some ltar}
+        if let some ltar := arts.ltar? then
+          ref.insert inputHash ltar.descr (mod.platformIndependent.getD false)
+            (outputs? := some (toJson {arts.descrs with ltar? := none}))
+        return arts
     return arts
   adjustMTime arts : JobM ModuleOutputArtifacts := do
     match (← getMTime mod.traceFile |>.toBaseIO) with

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -688,6 +688,14 @@ def resolveModuleOutputs (out : CacheOutput) : JobM ModuleOutputs := do
         | .error e =>
           logWarning s!"ignoring ill-formed outputs recorded in cache mapping: {e}"
           return none
+      if let some descrs := descrs? then
+        -- Prefer individually cached artifacts (no fetch or unpack needed).
+        -- They are not uploaded alongside the bundle, so consult only the
+        -- local cache; when any is missing, fall back to the bundle.
+        try
+          return .arts (← descrs.resolve none none)
+        catch e =>
+          dropLogFrom e
       let art ← resolveArtifact descr out.service? out.scope?
       return .ltar art descrs?
     | .error e =>

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -1148,7 +1148,10 @@ where
         -- individual output content hashes the bundle expands to. The consumer
         -- fetches the bundle to materialize the outputs and checks them against
         -- the recorded hashes (see `fetchFromCache?`). Only the bundle is an
-        -- upload target; the hashes are descriptive metadata.
+        -- upload target; the hashes are descriptive metadata. The entry is
+        -- inserted the same way whether or not the archive already existed, so
+        -- the platform-independence flag and recorded outputs are never dropped
+        -- (previously the pre-existing-archive path omitted the flag).
         let arts ← id do
           if arts.ltar?.isSome then
             return arts

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -681,8 +681,14 @@ def resolveModuleOutputs (out : CacheOutput) : JobM ModuleOutputs := do
       -- Receipt references an archive bundle. If it also recorded the output
       -- hashes, carry them so the unpacked bundle can be verified; an older
       -- receipt without them resolves the bundle directly.
+      let descrs? ← id do
+        let some o := out.outputs? | return none
+        match (fromJson? o : Except _ ModuleOutputDescrs) with
+        | .ok descrs => return some descrs
+        | .error e =>
+          logWarning s!"ignoring ill-formed outputs recorded in cache mapping: {e}"
+          return none
       let art ← resolveArtifact descr out.service? out.scope?
-      let descrs? := out.outputs?.bind fun o => (fromJson? o : Except _ ModuleOutputDescrs).toOption
       return .ltar art descrs?
     | .error e =>
       error s!"ill-formed module archive output:\n{out.data.render.pretty 80 2}\n{e}"
@@ -842,6 +848,11 @@ pure function of the module's *outputs*, so byte-identical outputs always
 produce a byte-identical, content-hash-identical archive, independent of the
 inputs or machine that produced them. Consumers recover the input hash from the
 cache mapping used to locate the archive (see `Module.stampLtarTrace`).
+
+Because the log is omitted, restoring a module from an archive does not replay
+the producer's build log (e.g., warnings) on later builds. This matches the
+behavior of restoring individually cached artifacts (see `BuildMetadata.ofFetch`)
+and avoids replaying a foreign machine's paths.
 -/
 def Module.mkLtarMetadata (outputs : Json) : BuildMetadata :=
   {depHash := .nil, inputs := #[], outputs? := some outputs, log := {}, synthetic := false}
@@ -881,14 +892,19 @@ def Module.packLtar (self : Module) (arts : ModuleOutputArtifacts) : JobM Artifa
   (see `Module.mkLtarMetadata`). The on-disk trace (which carries the real
   input hash for incremental checks) is restored afterwards.
   -/
-  let savedContents? ← (some <$> IO.FS.readBinFile self.traceFile).catchExceptions fun _ => pure none
+  let savedContents? ← id do
+    match (← IO.FS.readBinFile self.traceFile |>.toBaseIO) with
+    | .ok contents => return some contents
+    | .error (.noFileOrDirectory ..) => return none
+    | .error e => error s!"failed to read trace file: {e}"
   let metadata := mkLtarMetadata (toJson {arts with ltar? := none}.descrs)
   try
     metadata.writeFile self.traceFile
     proc (quiet := true) {cmd := (← getLeantar).toString, args}
   finally
-    if let some contents := savedContents? then
-      IO.FS.writeBinFile self.traceFile contents
+    match savedContents? with
+    | some contents => IO.FS.writeBinFile self.traceFile contents
+    | none => removeFileIfExists self.traceFile
   if (← self.pkg.isArtifactCacheWritable) then
     cacheArtifact self.ltarFile "ltar" (useLocalFile := ← self.pkg.restoreAllArtifacts)
   else
@@ -903,7 +919,8 @@ def Module.unpackLtar (self : Module) (ltar : FilePath) : JobM Unit := do
   proc (quiet := true) {cmd := (← getLeantar).toString, args}
 
 /--
-Stamp the input hash into the trace file just unpacked from a module's `.ltar`.
+Stamp the input hash into the trace file just unpacked from a module's `.ltar`,
+given the trace data (`savedTrace`) already read from it.
 
 The packed trace is input-free (`depHash := .nil`, see `Module.mkLtarMetadata`),
 so after unpacking, the consumer must stamp it with the input hash for which
@@ -915,8 +932,9 @@ hash; an unstamped `.nil` trace would force a needless rebuild on the next run.
 Traces packed by older Lake versions carry the producer's input hash and are
 returned unchanged. Returns the resulting `SavedTrace`.
 -/
-def Module.stampLtarTrace (self : Module) (inputHash : Hash) : LogIO SavedTrace := do
-  let savedTrace ← readTraceFile self.traceFile
+def Module.stampLtarTrace
+  (self : Module) (savedTrace : SavedTrace) (inputHash : Hash)
+: LogIO SavedTrace := do
   if let .ok data := savedTrace then
     if data.depHash == .nil then
       let data := {data with depHash := inputHash, synthetic := true}
@@ -1002,27 +1020,39 @@ where
       mod.unpackLtar ltar.path
       -- Note: This branch implies that only the ltar output is (validly) cached.
       -- Thus, we use only the new trace unpacked from the ltar to resolve further artifacts.
-      let savedTrace ← mod.stampLtarTrace inputHash
+      let savedTrace ← readTraceFile mod.traceFile
       -- Integrity: when the receipt records the output hashes, confirm the
       -- unpacked bundle declares exactly those outputs, so a receipt whose
       -- archive reference and recorded outputs disagree (e.g. one wired to
       -- another module's bundle) is rejected rather than silently trusted.
+      -- This runs *before* the input hash is stamped into the trace so that a
+      -- rejected unpack leaves no trace claiming the input produced these outputs.
       if let some receiptDescrs := descrs? then
-        let bundleDescrs ← id do
+        let err? : Option String := Id.run do
           let .ok data := savedTrace
-            | error s!"cache integrity error: archive for input {inputHash} has no usable trace"
+            | return some "has no usable trace"
           let some out := data.outputs?
-            | error s!"cache integrity error: archive for input {inputHash} records no outputs"
-          match fromJson? out with
-          | .ok (d : ModuleOutputDescrs) => pure d
-          | .error e => error s!"cache integrity error: archive for input {inputHash} has ill-formed outputs: {e}"
-        -- Clear the `ltar?` self-reference on both sides: it identifies the
-        -- bundle itself, not one of the outputs being compared.
-        let got := (toJson {bundleDescrs with ltar? := none}).compress
-        let want := (toJson {receiptDescrs with ltar? := none}).compress
-        unless got == want do
-          error s!"cache integrity error: archive for input {inputHash} does not \
-            match the outputs recorded in its cache mapping\n  recorded: {want}\n  unpacked: {got}"
+            | return some "records no outputs"
+          match (fromJson? out : Except _ ModuleOutputDescrs) with
+          | .error e => return some s!"has ill-formed outputs: {e}"
+          | .ok bundleDescrs =>
+            -- Clear the `ltar?` self-reference on both sides: it identifies the
+            -- bundle itself, not one of the outputs being compared.
+            let got := {bundleDescrs with ltar? := none}
+            let want := {receiptDescrs with ltar? := none}
+            if got == want then
+              return none
+            return some s!"does not match the outputs recorded in its cache mapping\
+              \n  recorded: {(toJson want).compress}\n  unpacked: {(toJson got).compress}"
+        if let some msg := err? then
+          -- A cache problem should not fail a build that can succeed by building,
+          -- so discard the unpacked outputs and treat the input as a cache miss.
+          -- The subsequent rebuild overwrites the offending receipt.
+          logWarning s!"cache integrity error: archive for input {inputHash} {msg}"
+          mod.clearOutputArtifacts
+          removeFileIfExists mod.traceFile
+          return .inr .missing
+      let savedTrace ← mod.stampLtarTrace savedTrace inputHash
       let arts? ← getArtifactsUsingTrace? inputHash savedTrace mod.pkg
       if let some (arts : ModuleOutputArtifacts) := arts? then
         -- on initial unpack from cache ensure all artifacts uniformly
@@ -1044,6 +1074,15 @@ where
         else
           mod.restoreNeededArtifacts arts
       return .inl arts
+  restoreTraceAfterUnpack savedTrace inputHash : JobM Unit := do
+    -- Unpacking clobbers the trace file with the trace packed in the archive
+    -- (input-free for archives packed by this Lake version). Restore the richer
+    -- pre-unpack trace (real input hash, inputs, and log) when available;
+    -- otherwise, stamp the input hash (see `Module.stampLtarTrace`).
+    if let .ok data := savedTrace then
+      data.writeFile mod.traceFile
+    else
+      discard <| mod.stampLtarTrace (← readTraceFile mod.traceFile) inputHash
   fetchCore setup srcFile srcTrace : JobM ModuleOutputArtifacts := do
     let depTrace ← getTrace
     have : GetMTime Module := ⟨Module.getMTime (isModule := setup.isModule)⟩
@@ -1059,7 +1098,7 @@ where
         if status.isUpToDate then
           unless (← mod.checkArtifactsExist setup.isModule) do
             mod.unpackLtar mod.ltarFile
-            discard <| mod.stampLtarTrace depTrace.hash
+            restoreTraceAfterUnpack savedTrace depTrace.hash
         else
           discard <| mod.buildLean depTrace srcFile setup
         if status.isCacheable then
@@ -1072,7 +1111,7 @@ where
       if (← savedTrace.replayIfUpToDate (oldTrace := srcTrace.mtime) mod depTrace) then
         unless (← mod.checkArtifactsExist setup.isModule) do
           mod.unpackLtar mod.ltarFile
-          discard <| mod.stampLtarTrace depTrace.hash
+          restoreTraceAfterUnpack savedTrace depTrace.hash
         mod.computeArtifacts setup.isModule
       else
         if (← mod.pkg.isArtifactCacheReadable) then

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -667,9 +667,9 @@ instance : ResolveOutputs ModuleOutputArtifacts := ⟨resolveModuleOutputArtifac
 
 inductive ModuleOutputs
 | /-- An archive bundle. `descrs?` carries the output content hashes recorded
-    independently in the cache mapping entry (absent for older entries, which
-    are a bare archive reference), used to verify the unpacked bundle (see
-    `fetchFromCache?`). -/
+    independently in the cache mapping entry, used to verify the unpacked
+    bundle (see `fetchFromCache?`). Absent for older entries, which carry only
+    the archive reference. -/
   ltar (art : Artifact) (descrs? : Option ModuleOutputDescrs := none)
 | arts (arts : ModuleOutputArtifacts)
 
@@ -690,14 +690,12 @@ def resolveModuleOutputs (out : CacheOutput) : JobM ModuleOutputs := do
           logWarning s!"ignoring ill-formed outputs recorded in cache mapping: {e}"
           return none
       if let some descrs := descrs? then
-        -- Prefer the entry's individually recorded outputs when all of them are
-        -- already in the local artifact cache: any earlier build or unpack that
-        -- produced the same outputs (under any input hash) cached them, so a
-        -- warm cache satisfies the entry without fetching or unpacking the
-        -- bundle. This trusts the recorded outputs exactly as resolving an
-        -- entry that holds only output descriptions does. Individual outputs
-        -- are never uploaded alongside the bundle, so consult only the local
-        -- cache; when any is missing, fall back to the bundle.
+        -- A warm artifact cache satisfies the entry without fetching or
+        -- unpacking the bundle: earlier builds or unpacks of the same outputs
+        -- cached them individually, whatever their input hash. Individual
+        -- outputs are never uploaded alongside the bundle, so only the local
+        -- cache is consulted; if any output is missing, fall back to the
+        -- bundle.
         try
           return .arts (← descrs.resolve none none)
         catch e =>
@@ -856,18 +854,17 @@ instance : ToOutputJson ModuleOutputArtifacts := ⟨(toJson ·.descrs)⟩
 /--
 Build metadata packed into a module's `.ltar` archive.
 
-The metadata omits any input- or environment-derived data: the input hash
+The metadata omits all input- and environment-derived data: the input hash
 (`depHash := .nil`), the input tree, and the build log (which records the
-`lean` invocation, including absolute paths). The archive bytes are therefore a
-pure function of the module's *outputs*, so byte-identical outputs always
-produce a byte-identical, content-hash-identical archive, independent of the
-inputs or machine that produced them. Consumers recover the input hash from the
-cache mapping used to locate the archive (see `Module.stampLtarTrace`).
+`lean` invocation, including absolute paths). The archive bytes are therefore
+a pure function of the module's outputs: byte-identical outputs produce a
+byte-identical archive, regardless of the inputs or machine that produced
+them. Consumers recover the input hash from the cache mapping used to locate
+the archive (see `Module.stampLtarTrace`).
 
-Because the log is omitted, restoring a module from an archive does not replay
-the producer's build log (e.g., warnings) on later builds. This matches the
-behavior of restoring individually cached artifacts (see `BuildMetadata.ofFetch`)
-and avoids replaying a foreign machine's paths.
+Since the log is not packed, restoring a module from an archive does not
+replay the producer's build log (e.g., warnings) on later builds, matching
+the behavior of individually cached artifacts (see `BuildMetadata.ofFetch`).
 -/
 def Module.mkLtarMetadata (outputs : Json) : BuildMetadata :=
   {depHash := .nil, inputs := #[], outputs? := some outputs, log := {}, synthetic := false}
@@ -1036,12 +1033,12 @@ where
       -- Note: This branch implies that only the ltar output is (validly) cached.
       -- Thus, we use only the new trace unpacked from the ltar to resolve further artifacts.
       let savedTrace ← readTraceFile mod.traceFile
-      -- Integrity: when the mapping entry records the output hashes, confirm
-      -- the unpacked bundle declares exactly those outputs, so an entry whose
-      -- archive reference and recorded outputs disagree (e.g. one wired to
-      -- another module's bundle) is rejected rather than silently trusted.
-      -- This runs *before* the input hash is stamped into the trace so that a
-      -- rejected unpack leaves no trace claiming the input produced these outputs.
+      -- When the mapping entry records the output hashes, check that the
+      -- unpacked bundle declares exactly those outputs, rejecting an entry
+      -- whose archive reference and recorded outputs disagree (e.g. one wired
+      -- to another module's bundle). This happens before the input hash is
+      -- stamped into the trace, so a rejected unpack leaves no trace claiming
+      -- the input produced these outputs.
       if let some recordedDescrs := descrs? then
         let err? : Option String := Id.run do
           let .ok data := savedTrace
@@ -1060,9 +1057,9 @@ where
             return some s!"does not match the outputs recorded in its cache mapping\
               \n  recorded: {(toJson want).compress}\n  unpacked: {(toJson got).compress}"
         if let some msg := err? then
-          -- A cache problem should not fail a build that can succeed by building,
-          -- so discard the unpacked outputs and treat the input as a cache miss.
-          -- The subsequent rebuild overwrites the offending entry.
+          -- A bad cache entry should not fail a build that can succeed by
+          -- rebuilding: discard the unpacked outputs and treat the input as a
+          -- cache miss. The rebuild then overwrites the offending entry.
           logWarning s!"cache integrity error: archive for input {inputHash} {msg}"
           mod.clearOutputArtifacts
           removeFileIfExists mod.traceFile
@@ -1149,9 +1146,8 @@ where
         -- fetches the bundle to materialize the outputs and checks them against
         -- the recorded hashes (see `fetchFromCache?`). Only the bundle is an
         -- upload target; the hashes are descriptive metadata. The entry is
-        -- inserted the same way whether or not the archive already existed, so
-        -- the platform-independence flag and recorded outputs are never dropped
-        -- (previously the pre-existing-archive path omitted the flag).
+        -- inserted the same way whether the archive was just packed or already
+        -- existed, including the platform-independence flag.
         let arts ← id do
           if arts.ltar?.isSome then
             return arts

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -666,9 +666,10 @@ def resolveModuleOutputArtifacts (out : CacheOutput) : JobM ModuleOutputArtifact
 instance : ResolveOutputs ModuleOutputArtifacts := ⟨resolveModuleOutputArtifacts⟩
 
 inductive ModuleOutputs
-| /-- An archive bundle. `descrs?` carries the receipt's independently-recorded
-    output content hashes (when the receipt is a full mapping rather than a bare
-    archive reference), used to verify the unpacked bundle (see `fetchFromCache?`). -/
+| /-- An archive bundle. `descrs?` carries the output content hashes recorded
+    independently in the cache mapping entry (absent for older entries, which
+    are a bare archive reference), used to verify the unpacked bundle (see
+    `fetchFromCache?`). -/
   ltar (art : Artifact) (descrs? : Option ModuleOutputDescrs := none)
 | arts (arts : ModuleOutputArtifacts)
 
@@ -678,9 +679,9 @@ def resolveModuleOutputs (out : CacheOutput) : JobM ModuleOutputs := do
   if let .str descr := out.data then
     match ArtifactDescr.ofFilePath? descr with
     | .ok descr =>
-      -- Receipt references an archive bundle. If it also recorded the output
-      -- hashes, carry them so the unpacked bundle can be verified; an older
-      -- receipt without them resolves the bundle directly.
+      -- The mapping entry references an archive bundle. If it also recorded
+      -- the output hashes, carry them so the unpacked bundle can be verified;
+      -- an older entry without them resolves the bundle directly.
       let descrs? ← id do
         let some o := out.outputs? | return none
         match (fromJson? o : Except _ ModuleOutputDescrs) with
@@ -689,9 +690,14 @@ def resolveModuleOutputs (out : CacheOutput) : JobM ModuleOutputs := do
           logWarning s!"ignoring ill-formed outputs recorded in cache mapping: {e}"
           return none
       if let some descrs := descrs? then
-        -- Prefer individually cached artifacts (no fetch or unpack needed).
-        -- They are not uploaded alongside the bundle, so consult only the
-        -- local cache; when any is missing, fall back to the bundle.
+        -- Prefer the entry's individually recorded outputs when all of them are
+        -- already in the local artifact cache: any earlier build or unpack that
+        -- produced the same outputs (under any input hash) cached them, so a
+        -- warm cache satisfies the entry without fetching or unpacking the
+        -- bundle. This trusts the recorded outputs exactly as resolving an
+        -- entry that holds only output descriptions does. Individual outputs
+        -- are never uploaded alongside the bundle, so consult only the local
+        -- cache; when any is missing, fall back to the bundle.
         try
           return .arts (← descrs.resolve none none)
         catch e =>
@@ -704,10 +710,11 @@ def resolveModuleOutputs (out : CacheOutput) : JobM ModuleOutputs := do
     match fromJson? out.data with
     | .ok (descrs : ModuleOutputDescrs) =>
       if let some descr := descrs.ltar? then
-        -- A full receipt that also references an archive bundle. Prefer the
-        -- individually-cached artifacts when present (no unpack needed); when
-        -- only the bundle is cached, fall back to it, carrying `descrs` so the
-        -- unpacked outputs can be verified against the receipt's record.
+        -- An entry with full output descriptions that also references an
+        -- archive bundle. Prefer the individually-cached artifacts when present
+        -- (no unpack needed); when only the bundle is cached, fall back to it,
+        -- carrying `descrs` so the unpacked outputs can be verified against the
+        -- recorded outputs.
         try
           descrs.resolve out.service? out.scope?
         catch e =>
@@ -1029,13 +1036,13 @@ where
       -- Note: This branch implies that only the ltar output is (validly) cached.
       -- Thus, we use only the new trace unpacked from the ltar to resolve further artifacts.
       let savedTrace ← readTraceFile mod.traceFile
-      -- Integrity: when the receipt records the output hashes, confirm the
-      -- unpacked bundle declares exactly those outputs, so a receipt whose
+      -- Integrity: when the mapping entry records the output hashes, confirm
+      -- the unpacked bundle declares exactly those outputs, so an entry whose
       -- archive reference and recorded outputs disagree (e.g. one wired to
       -- another module's bundle) is rejected rather than silently trusted.
       -- This runs *before* the input hash is stamped into the trace so that a
       -- rejected unpack leaves no trace claiming the input produced these outputs.
-      if let some receiptDescrs := descrs? then
+      if let some recordedDescrs := descrs? then
         let err? : Option String := Id.run do
           let .ok data := savedTrace
             | return some "has no usable trace"
@@ -1047,7 +1054,7 @@ where
             -- Clear the `ltar?` self-reference on both sides: it identifies the
             -- bundle itself, not one of the outputs being compared.
             let got := {bundleDescrs with ltar? := none}
-            let want := {receiptDescrs with ltar? := none}
+            let want := {recordedDescrs with ltar? := none}
             if got == want then
               return none
             return some s!"does not match the outputs recorded in its cache mapping\
@@ -1055,7 +1062,7 @@ where
         if let some msg := err? then
           -- A cache problem should not fail a build that can succeed by building,
           -- so discard the unpacked outputs and treat the input as a cache miss.
-          -- The subsequent rebuild overwrites the offending receipt.
+          -- The subsequent rebuild overwrites the offending entry.
           logWarning s!"cache integrity error: archive for input {inputHash} {msg}"
           mod.clearOutputArtifacts
           removeFileIfExists mod.traceFile

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -696,10 +696,23 @@ def resolveModuleOutputs (out : CacheOutput) : JobM ModuleOutputs := do
         -- outputs are never uploaded alongside the bundle, so only the local
         -- cache is consulted; if any output is missing, fall back to the
         -- bundle.
-        try
-          return .arts (← descrs.resolve none none)
-        catch e =>
-          dropLogFrom e
+        let arts? ← id do
+          try
+            return some (← descrs.resolve none none)
+          catch e =>
+            dropLogFrom e
+            return none
+        if let some arts := arts? then
+          -- Also attach the bundle when it is cached locally, so that
+          -- mapping-producing builds rehash it rather than repack it
+          -- (see `trackOutputsIfEnabled`).
+          let ltar? ← id do
+            try
+              return some (← resolveArtifact descr none none)
+            catch e =>
+              dropLogFrom e
+              return none
+          return .arts {arts with ltar? := ltar?}
       let art ← resolveArtifact descr out.service? out.scope?
       return .ltar art descrs?
     | .error e =>

--- a/src/lake/Lake/Build/ModuleArtifacts.lean
+++ b/src/lake/Lake/Build/ModuleArtifacts.lean
@@ -24,6 +24,7 @@ public structure ModuleOutputDescrs where
   c : ArtifactDescr
   bc? : Option ArtifactDescr := none
   ltar? : Option ArtifactDescr := none
+  deriving BEq
 
 public def ModuleOutputDescrs.oleanParts (self : ModuleOutputDescrs) : Array ArtifactDescr := Id.run do
   let mut descrs := #[self.olean]

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -666,6 +666,9 @@ protected def stage : CliM PUnit := do
   let ok ← descrs.foldlM (init := true) fun ok descr => do
     let cachePath := cache.artifactDir / descr.relPath
     let stagingPath := stagingDir / descr.relPath
+    -- artifacts are content-addressed: an existing file already has the right contents
+    if (← stagingPath.pathExists) then
+      return ok
     match (← copyFile cachePath stagingPath |>.toBaseIO) with
     | .ok _ =>
       return ok
@@ -706,6 +709,11 @@ protected def unstage : CliM PUnit := do
   let ok ← descrs.foldlM (init := true) fun ok descr => do
     let cachePath := artDir/ descr.relPath
     let stagingPath := stagingDir / descr.relPath
+    -- artifacts are content-addressed: an existing file already has the right
+    -- contents (and may be read-only when cached by a build, so overwriting
+    -- it would fail)
+    if (← cachePath.pathExists) then
+      return ok
     match (← copyFile stagingPath cachePath |>.toBaseIO) with
     | .ok _ =>
       return ok

--- a/src/lake/Lake/Config/Artifact.lean
+++ b/src/lake/Lake/Config/Artifact.lean
@@ -22,7 +22,7 @@ public structure ArtifactDescr where
   hash : Hash
   /-- The artifact's file extension. -/
   ext : String := "art"
-  deriving Inhabited, Repr
+  deriving Inhabited, Repr, BEq
 
 /--
 A content-hashed artifact that should have the file extension `ext`.

--- a/src/lake/Lake/Config/Cache.lean
+++ b/src/lake/Lake/Config/Cache.lean
@@ -32,8 +32,8 @@ public structure CacheMap.Entry where
     out : Json
     platformIndependent : Bool
     /-- Optional structured description of the output artifacts (e.g. the
-    individual content hashes a bundle in `out` expands to). Carried as an extra
-    element of the mapping line; older readers ignore it. -/
+    individual content hashes a bundle in `out` expands to). Absent in mappings
+    written by older Lake versions. -/
     outputs? : Option Json := none
 
 /--
@@ -155,6 +155,8 @@ def writeCacheEntries
     -- skip platform-dependent outputs in platform-independent maps
     if platformIndependent && !e.platformIndependent then
       return
+    -- older parsers read only the first two elements, so any addition to the
+    -- line format must remain a trailing, optional element
     let line := match e.outputs? with
       | some outputs => #[toJson k, e.out, outputs]
       | none => #[toJson k, e.out]

--- a/src/lake/Lake/Config/Cache.lean
+++ b/src/lake/Lake/Config/Cache.lean
@@ -31,6 +31,10 @@ public structure CacheMap.Entry where
   private mk ::
     out : Json
     platformIndependent : Bool
+    /-- Optional structured description of the output artifacts (e.g. the
+    individual content hashes a bundle in `out` expands to). Carried as an extra
+    element of the mapping line; older readers ignore it. -/
+    outputs? : Option Json := none
 
 /--
 Maps an input hash to a structure of output artifact content hashes.
@@ -69,7 +73,8 @@ where go : Except String CacheMap := do
   let a : Array Json ← fromJson? json
   let inputHash ← a[0]?.elim (throw "expected array of size > 0") (fromJson? ·)
   let out ← a[1]?.elim (throw "expected array of size > 1") (fromJson? ·)
-  return cache.insert inputHash {out, platformIndependent}
+  let outputs? := match a[2]? with | some Json.null => none | o => o
+  return cache.insert inputHash {out, platformIndependent, outputs?}
 
 /--
 Parse a `Cache` from a JSON Lines string.
@@ -146,14 +151,14 @@ public def load? (file : FilePath) (platformIndependent := false) : LogIO (Optio
 def writeCacheEntries
   (h : IO.FS.Handle) (cache : CacheMap) (platformIndependent : Bool)
 : LogIO Unit :=
-  if platformIndependent then
-    cache.forM fun k ⟨v, platformIndependentMapping⟩ => do
-      -- skip platform-dependent outputs in platform-independent maps
-      if platformIndependentMapping then
-        h.putStrLn (Json.arr #[toJson k, toJson v]).compress
-  else
-    cache.forM fun k ⟨v, _⟩ => do
-      h.putStrLn (Json.arr #[toJson k, toJson v]).compress
+  cache.forM fun k e => do
+    -- skip platform-dependent outputs in platform-independent maps
+    if platformIndependent && !e.platformIndependent then
+      return
+    let line := match e.outputs? with
+      | some outputs => #[toJson k, e.out, outputs]
+      | none => #[toJson k, e.out]
+    h.putStrLn (Json.arr line).compress
 
 /--
 Save a `CacheMap` to a JSON Lines file.
@@ -199,14 +204,14 @@ public nonrec def get? (inputHash : Hash) (cache : CacheMap) : Option Json :=
 /-- Associate output data (as JSON) with the given the input hash. -/
 def insertCore
   (inputHash : Hash) (out : Json) (cache : CacheMap)
-  (platformIndependent : Bool)
-: CacheMap := cache.insert inputHash {out, platformIndependent}
+  (platformIndependent : Bool) (outputs? : Option Json := none)
+: CacheMap := cache.insert inputHash {out, platformIndependent, outputs?}
 
 /-- Associate output data with the given the input hash. -/
 @[inline] public def insert
   [ToJson α] (inputHash : Hash) (val : α) (cache : CacheMap)
-  (platformIndependent := false)
-: CacheMap := cache.insertCore inputHash (toJson val) platformIndependent
+  (platformIndependent := false) (outputs? : Option Json := none)
+: CacheMap := cache.insertCore inputHash (toJson val) platformIndependent outputs?
 
 /-- Extract each output from their structured data into a flat array of artifact descriptions. -/
 public partial def collectOutputDescrs (map : CacheMap) : LogIO (Array ArtifactDescr) := do
@@ -252,8 +257,8 @@ public def get? (inputHash : Hash) (cache : CacheRef) : BaseIO (Option Json) :=
 @[inline, inherit_doc CacheMap.insert]
 public def insert
   [ToJson α] (inputHash : Hash) (val : α) (cache : CacheRef)
-  (platformIndependent := false)
-: BaseIO Unit := cache.modify (·.insert inputHash (toJson val) platformIndependent)
+  (platformIndependent := false) (outputs? : Option Json := none)
+: BaseIO Unit := cache.modify (·.insert inputHash (toJson val) platformIndependent outputs?)
 
 end CacheRef
 
@@ -343,6 +348,10 @@ public structure CacheOutput where
     data : Json
     service? : Option CacheServiceName := none
     scope? : Option CacheServiceScope := none
+    /-- Optional structured description of the output artifacts (e.g. the
+    individual content hashes a bundle in `data` expands to). Absent in outputs
+    written by older Lake versions. -/
+    outputs? : Option Json := none
     deriving Inhabited
 
 namespace CacheOutput
@@ -357,6 +366,8 @@ public protected def toJson (out : CacheOutput) : Json := Id.run do
     |>.insert "service" out.service?
   if let some scope := out.scope? then
     obj := obj.insert (if scope.isRepo then "repo" else "scope") scope.toJson
+  if let some outputs := out.outputs? then
+    obj := obj.insert "outputs" outputs
   return obj.insert "data" out.data
 
 public instance : ToJson CacheOutput := ⟨CacheOutput.toJson⟩
@@ -377,7 +388,8 @@ public protected def fromJson? (json : Json) : Except String CacheOutput := do
           return some (.ofString scope)
         else
           return none
-      return {data, service?, scope?}
+      let outputs? ← obj.get? "outputs"
+      return {data, service?, scope?, outputs?}
   -- old format: just the data
   return .ofData json
 
@@ -434,10 +446,11 @@ public def getArtifact (cache : Cache) (descr : ArtifactDescr) : EIO String Arti
 def writeOutputsCore
   (cache : Cache) (scope : String) (inputHash : Hash) (out : Json)
   (service? : Option CacheServiceName) (remoteScope? : Option CacheServiceScope)
+  (outputs? : Option Json := none)
 : IO Unit := do
   let file := cache.outputsFile scope inputHash
   createParentDirs file
-  let out := {service?, scope? := remoteScope?, data := out : CacheOutput}
+  let out := {service?, scope? := remoteScope?, data := out, outputs? : CacheOutput}
   IO.FS.writeFile file (toJson out).pretty
 
 /-- Cache the outputs corresponding to the given input for the package.  -/
@@ -449,7 +462,7 @@ def writeOutputsCore
 public def writeMap
   (cache : Cache) (scope : String) (map : CacheMap)
   (service? : Option CacheServiceName := none) (remoteScope? : Option CacheServiceScope := none)
-: IO Unit := map.forM fun i e => cache.writeOutputsCore scope i e.out service? remoteScope?
+: IO Unit := map.forM fun i e => cache.writeOutputsCore scope i e.out service? remoteScope? e.outputs?
 
 /-- Retrieve the cached outputs corresponding to the given input for the package (if any). -/
 public def readOutputs? (cache : Cache) (scope : String) (inputHash : Hash) : LogIO (Option CacheOutput) := do

--- a/tests/lake/tests/ltarCache/Test.lean
+++ b/tests/lake/tests/ltarCache/Test.lean
@@ -1,0 +1,3 @@
+module
+public import Test.A
+public import Test.B

--- a/tests/lake/tests/ltarCache/Test/A.lean
+++ b/tests/lake/tests/ltarCache/Test/A.lean
@@ -1,0 +1,2 @@
+module
+public def a : Nat := 1

--- a/tests/lake/tests/ltarCache/Test/B.lean
+++ b/tests/lake/tests/ltarCache/Test/B.lean
@@ -1,0 +1,3 @@
+module
+public import Test.A
+public def b : Nat := a + 1

--- a/tests/lake/tests/ltarCache/clean.sh
+++ b/tests/lake/tests/ltarCache/clean.sh
@@ -1,0 +1,3 @@
+[ -f Test/A.lean.bak ] && mv -f Test/A.lean.bak Test/A.lean
+rm -rf .lake lake-manifest.json produced.* out1.jsonl out2.jsonl \
+  bundles1.txt bundles2.txt staging staging_bad staging_old

--- a/tests/lake/tests/ltarCache/clean.sh
+++ b/tests/lake/tests/ltarCache/clean.sh
@@ -1,3 +1,3 @@
 [ -f Test/A.lean.bak ] && mv -f Test/A.lean.bak Test/A.lean
-rm -rf .lake lake-manifest.json produced.* out1.jsonl out2.jsonl \
-  bundles1.txt bundles2.txt staging staging_bad staging_old
+rm -rf .lake lake-manifest.json produced.* out*.jsonl bundles*.txt \
+  staging staging_bad staging_old staging8

--- a/tests/lake/tests/ltarCache/clean.sh
+++ b/tests/lake/tests/ltarCache/clean.sh
@@ -1,3 +1,2 @@
 [ -f Test/A.lean.bak ] && mv -f Test/A.lean.bak Test/A.lean
-rm -rf .lake lake-manifest.json produced.* out*.jsonl bundles*.txt \
-  staging staging_bad staging_old staging8
+rm -rf .lake lake-manifest.json produced.* out*.jsonl bundles*.txt staging*

--- a/tests/lake/tests/ltarCache/lakefile.toml
+++ b/tests/lake/tests/ltarCache/lakefile.toml
@@ -1,0 +1,7 @@
+name = "test"
+enableArtifactCache = true
+restoreAllArtifacts = true
+defaultTargets = ["Test"]
+
+[[lean_lib]]
+name = "Test"

--- a/tests/lake/tests/ltarCache/test.sh
+++ b/tests/lake/tests/ltarCache/test.sh
@@ -4,7 +4,7 @@ source ../common.sh
 ./clean.sh
 
 # Hermetic, workspace-local artifact cache: an empty `LAKE_CACHE_DIR` disables the
-# system cache, so all artifacts/receipts live under `.lake/cache`. The package
+# system cache, so all artifacts and mappings live under `.lake/cache`. The package
 # enables the artifact cache and `restoreAllArtifacts` (see lakefile.toml).
 export LAKE_CACHE_DIR=
 
@@ -13,7 +13,7 @@ bundles() { grep -oE '[0-9a-f]{16}\.ltar' "$1" | sort -u; }
 
 #-------------------------------------------------------------------------------
 echo "# 1. A build populates the cache and emits a mapping whose entries pair a"
-echo "#    bundle reference with the recorded output hashes (the receipt)."
+echo "#    bundle reference with its recorded output hashes."
 #-------------------------------------------------------------------------------
 test_run build -o out1.jsonl
 test_cmd ls .lake/cache/artifacts/*.ltar
@@ -32,7 +32,7 @@ for ln in open("out1.jsonl"):
     assert len(a) == 3 and isinstance(a[2], dict) and "o" in a[2], a
     seen = True
 assert seen, "no mapping entries found"
-print("receipt shape OK: data=bundle ref + recorded outputs")
+print("mapping entry shape OK: data=bundle ref + recorded outputs")
 '
 
 #-------------------------------------------------------------------------------
@@ -60,7 +60,7 @@ test_cmd_fails ls staging/*.ilean
 test_cmd_fails ls staging/*.c
 
 #-------------------------------------------------------------------------------
-echo "# 4. Distribution consume: a cache holding only bundles + receipts must fetch,"
+echo "# 4. Distribution consume: a cache holding only bundles + mappings must fetch,"
 echo "#    unpack, and verify the bundle against the recorded outputs."
 #-------------------------------------------------------------------------------
 rm -rf .lake/cache .lake/build
@@ -70,9 +70,9 @@ test_out "leantar" build -v                       # bundles are unpacked
 test_run build --no-build --rehash                # outputs verify as up-to-date
 
 #-------------------------------------------------------------------------------
-echo "# 5. Integrity: a receipt whose recorded outputs disagree with the bundle is"
-echo "#    rejected with a warning rather than silently trusted; the build"
-echo "#    self-heals by rebuilding and overwriting the offending receipt."
+echo "# 5. Integrity: a mapping entry whose recorded outputs disagree with the bundle"
+echo "#    is rejected with a warning rather than silently trusted; the build"
+echo "#    self-heals by rebuilding and overwriting the offending entry."
 #-------------------------------------------------------------------------------
 rm -rf .lake/cache .lake/build
 python3 - <<'PY'
@@ -97,8 +97,8 @@ test_out "cache integrity error" build
 test_not_out "cache integrity error" build --no-build --rehash
 
 #-------------------------------------------------------------------------------
-echo "# 6. Backward compatible: an older receipt (bundle reference only, no recorded"
-echo "#    outputs) is consumed without verification and without error."
+echo "# 6. Backward compatible: an older mapping entry (bundle reference only, no"
+echo "#    recorded outputs) is consumed without verification and without error."
 #-------------------------------------------------------------------------------
 rm -rf .lake/cache .lake/build
 python3 - <<'PY'
@@ -121,10 +121,10 @@ test_not_out "cache integrity error" build
 test_run build --no-build --rehash
 
 #-------------------------------------------------------------------------------
-echo "# 7. With recorded outputs and a warm artifact cache, a bundle receipt is"
-echo "#    served from the individually cached artifacts without unpacking."
+echo "# 7. With recorded outputs and a warm artifact cache, a bundle mapping entry"
+echo "#    is served from the individually cached artifacts without unpacking."
 #-------------------------------------------------------------------------------
-# Step 6 left the individual artifacts in the cache; rewrite the receipts back to
+# Step 6 left the individual artifacts in the cache; rewrite the mappings back to
 # bundle-reference form and wipe the build directory. The recorded outputs resolve
 # locally, so no bundle is unpacked.
 rm -rf .lake/build

--- a/tests/lake/tests/ltarCache/test.sh
+++ b/tests/lake/tests/ltarCache/test.sh
@@ -120,5 +120,17 @@ test_run cache unstage staging_old
 test_not_out "cache integrity error" build
 test_run build --no-build --rehash
 
+#-------------------------------------------------------------------------------
+echo "# 7. With recorded outputs and a warm artifact cache, a bundle receipt is"
+echo "#    served from the individually cached artifacts without unpacking."
+#-------------------------------------------------------------------------------
+# Step 6 left the individual artifacts in the cache; rewrite the receipts back to
+# bundle-reference form and wipe the build directory. The recorded outputs resolve
+# locally, so no bundle is unpacked.
+rm -rf .lake/build
+test_run cache unstage staging
+test_not_out "leantar" build -v
+test_run build --no-build --rehash
+
 ./clean.sh
 echo "ltarCache: all checks passed"

--- a/tests/lake/tests/ltarCache/test.sh
+++ b/tests/lake/tests/ltarCache/test.sh
@@ -132,6 +132,11 @@ rm -rf .lake/build
 test_run cache unstage staging
 test_not_out "leantar" build -v
 test_run build --no-build --rehash
+# A mapping-producing build after the no-unpack restore reuses the locally
+# cached bundles instead of repacking them, emitting the same bundle set.
+test_not_out "leantar" build -v -o out7.jsonl
+bundles out7.jsonl > bundles7.txt
+test_cmd diff bundles2.txt bundles7.txt
 
 ./clean.sh
 echo "ltarCache: all checks passed"

--- a/tests/lake/tests/ltarCache/test.sh
+++ b/tests/lake/tests/ltarCache/test.sh
@@ -71,7 +71,8 @@ test_run build --no-build --rehash                # outputs verify as up-to-date
 
 #-------------------------------------------------------------------------------
 echo "# 5. Integrity: a receipt whose recorded outputs disagree with the bundle is"
-echo "#    rejected rather than silently trusted."
+echo "#    rejected with a warning rather than silently trusted; the build"
+echo "#    self-heals by rebuilding and overwriting the offending receipt."
 #-------------------------------------------------------------------------------
 rm -rf .lake/cache .lake/build
 python3 - <<'PY'
@@ -92,7 +93,8 @@ for ln in f.read_text().splitlines():
 f.write_text("\n".join(out) + "\n")
 PY
 test_run cache unstage staging_bad
-test_err "cache integrity error" build
+test_out "cache integrity error" build
+test_not_out "cache integrity error" build --no-build --rehash
 
 #-------------------------------------------------------------------------------
 echo "# 6. Backward compatible: an older receipt (bundle reference only, no recorded"

--- a/tests/lake/tests/ltarCache/test.sh
+++ b/tests/lake/tests/ltarCache/test.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+# Hermetic, workspace-local artifact cache: an empty `LAKE_CACHE_DIR` disables the
+# system cache, so all artifacts/receipts live under `.lake/cache`. The package
+# enables the artifact cache and `restoreAllArtifacts` (see lakefile.toml).
+export LAKE_CACHE_DIR=
+
+# Extract the set of bundle (`.ltar`) content hashes referenced by a mapping file.
+bundles() { grep -oE '[0-9a-f]{16}\.ltar' "$1" | sort -u; }
+
+#-------------------------------------------------------------------------------
+echo "# 1. A build populates the cache and emits a mapping whose entries pair a"
+echo "#    bundle reference with the recorded output hashes (the receipt)."
+#-------------------------------------------------------------------------------
+test_run build -o out1.jsonl
+test_cmd ls .lake/cache/artifacts/*.ltar
+bundles out1.jsonl > bundles1.txt
+test_exp -s bundles1.txt
+# Each mapping entry is [inputHash, "<bundle>.ltar", {outputs}]: `data` is the bare
+# bundle reference (stock-compatible) and the output hashes ride in an added field.
+test_cmd python3 -c '
+import json
+seen = False
+for ln in open("out1.jsonl"):
+    ln = ln.strip()
+    if not ln.startswith("["): continue
+    a = json.loads(ln)
+    assert isinstance(a[1], str) and a[1].endswith(".ltar"), a
+    assert len(a) == 3 and isinstance(a[2], dict) and "o" in a[2], a
+    seen = True
+assert seen, "no mapping entries found"
+print("receipt shape OK: data=bundle ref + recorded outputs")
+'
+
+#-------------------------------------------------------------------------------
+echo "# 2. De-traced bundles are content-stable: a comment-only edit changes the"
+echo "#    input hash but no output, so every bundle hash is unchanged."
+echo "#    (Stock Lake embeds the input hash in the bundle and would churn here.)"
+#-------------------------------------------------------------------------------
+cp Test/A.lean Test/A.lean.bak
+printf '\n-- a cosmetic comment; does not change any output\n' >> Test/A.lean
+test_run build -o out2.jsonl
+bundles out2.jsonl > bundles2.txt
+# The set of bundle content hashes is identical across the edit ...
+test_cmd diff bundles1.txt bundles2.txt
+# ... even though the mapping itself changed (the edited module's input hash moved).
+test_cmd_fails diff out1.jsonl out2.jsonl
+
+#-------------------------------------------------------------------------------
+echo "# 3. Staging from the mapping collects only bundles; the recorded output"
+echo "#    hashes are metadata, not upload targets."
+#-------------------------------------------------------------------------------
+test_run cache stage out2.jsonl staging
+test_cmd ls staging/*.ltar
+test_cmd_fails ls staging/*.olean
+test_cmd_fails ls staging/*.ilean
+test_cmd_fails ls staging/*.c
+
+#-------------------------------------------------------------------------------
+echo "# 4. Distribution consume: a cache holding only bundles + receipts must fetch,"
+echo "#    unpack, and verify the bundle against the recorded outputs."
+#-------------------------------------------------------------------------------
+rm -rf .lake/cache .lake/build
+test_run cache unstage staging
+test_cmd_fails ls .lake/cache/artifacts/*.olean   # no individual artifacts present
+test_out "leantar" build -v                       # bundles are unpacked
+test_run build --no-build --rehash                # outputs verify as up-to-date
+
+#-------------------------------------------------------------------------------
+echo "# 5. Integrity: a receipt whose recorded outputs disagree with the bundle is"
+echo "#    rejected rather than silently trusted."
+#-------------------------------------------------------------------------------
+rm -rf .lake/cache .lake/build
+python3 - <<'PY'
+import json, shutil
+from pathlib import Path
+src, dst = Path("staging"), Path("staging_bad")
+shutil.rmtree(dst, ignore_errors=True); shutil.copytree(src, dst)
+f = dst / "outputs.jsonl"; out = []
+for ln in f.read_text().splitlines():
+    s = ln.strip()
+    if s.startswith("["):
+        a = json.loads(s)
+        if len(a) > 2 and isinstance(a[2], dict) and a[2].get("o"):
+            a[2]["o"][0] = "deadbeefdeadbeef.olean"   # corrupt a recorded output hash
+        out.append(json.dumps(a))
+    else:
+        out.append(ln)
+f.write_text("\n".join(out) + "\n")
+PY
+test_run cache unstage staging_bad
+test_err "cache integrity error" build
+
+#-------------------------------------------------------------------------------
+echo "# 6. Backward compatible: an older receipt (bundle reference only, no recorded"
+echo "#    outputs) is consumed without verification and without error."
+#-------------------------------------------------------------------------------
+rm -rf .lake/cache .lake/build
+python3 - <<'PY'
+import json, shutil
+from pathlib import Path
+src, dst = Path("staging"), Path("staging_old")
+shutil.rmtree(dst, ignore_errors=True); shutil.copytree(src, dst)
+f = dst / "outputs.jsonl"; out = []
+for ln in f.read_text().splitlines():
+    s = ln.strip()
+    if s.startswith("["):
+        a = json.loads(s)[:2]   # drop the recorded-outputs element -> old 2-element form
+        out.append(json.dumps(a))
+    else:
+        out.append(ln)
+f.write_text("\n".join(out) + "\n")
+PY
+test_run cache unstage staging_old
+test_not_out "cache integrity error" build
+test_run build --no-build --rehash
+
+./clean.sh
+echo "ltarCache: all checks passed"

--- a/tests/lake/tests/ltarCache/test.sh
+++ b/tests/lake/tests/ltarCache/test.sh
@@ -19,8 +19,9 @@ test_run build -o out1.jsonl
 test_cmd ls .lake/cache/artifacts/*.ltar
 bundles out1.jsonl > bundles1.txt
 test_exp -s bundles1.txt
-# Each mapping entry is [inputHash, "<bundle>.ltar", {outputs}]: `data` is the bare
-# bundle reference (stock-compatible) and the output hashes ride in an added field.
+# Each mapping entry is [inputHash, "<bundle>.ltar", {outputs}]: the second element
+# is the bare bundle reference (readable by older Lake) and the third carries the
+# recorded output hashes.
 test_cmd python3 -c '
 import json
 seen = False
@@ -36,9 +37,9 @@ print("mapping entry shape OK: data=bundle ref + recorded outputs")
 '
 
 #-------------------------------------------------------------------------------
-echo "# 2. De-traced bundles are content-stable: a comment-only edit changes the"
-echo "#    input hash but no output, so every bundle hash is unchanged."
-echo "#    (Stock Lake embeds the input hash in the bundle and would churn here.)"
+echo "# 2. Bundles are content-stable: a comment-only edit changes the input"
+echo "#    hash but no output, so every bundle hash is unchanged. (Older Lake"
+echo "#    embeds the input hash in the bundle, so every bundle would change.)"
 #-------------------------------------------------------------------------------
 cp Test/A.lean Test/A.lean.bak
 printf '\n-- a cosmetic comment; does not change any output\n' >> Test/A.lean

--- a/tests/lake/tests/ltarCache/test.sh
+++ b/tests/lake/tests/ltarCache/test.sh
@@ -69,6 +69,14 @@ test_run cache unstage staging
 test_cmd_fails ls .lake/cache/artifacts/*.olean   # no individual artifacts present
 test_out "leantar" build -v                       # bundles are unpacked
 test_run build --no-build --rehash                # outputs verify as up-to-date
+# The unpacked trace is stamped with the mapping's input hash and marked synthetic.
+test_cmd python3 -c '
+import json
+hashes = {json.loads(ln)[0] for ln in open("staging/outputs.jsonl") if ln.strip().startswith("[")}
+t = json.load(open(".lake/build/lib/lean/Test/A.trace"))
+assert t["depHash"] in hashes, (t["depHash"], hashes)
+assert t.get("synthetic") is True, t
+print("unpacked trace stamped with input hash, synthetic")'
 
 #-------------------------------------------------------------------------------
 echo "# 5. Integrity: a mapping entry whose recorded outputs disagree with the bundle"
@@ -147,6 +155,34 @@ test_run build -o out8.jsonl            # packs; cached bundles are read-only
 test_run cache stage out8.jsonl staging8
 test_run cache unstage staging8
 test_run build --no-build --rehash
+
+#-------------------------------------------------------------------------------
+echo "# 9. Degraded recorded outputs: an ill-formed third element is reported and"
+echo "#    skipped (bundle still consumed); an explicit null means absent."
+#-------------------------------------------------------------------------------
+rm -rf .lake/cache .lake/build
+python3 - <<'PY'
+import json, shutil
+from pathlib import Path
+src, dst = Path("staging"), Path("staging_degraded")
+shutil.rmtree(dst, ignore_errors=True); shutil.copytree(src, dst)
+f = dst / "outputs.jsonl"; out = []; mutated = 0
+for ln in f.read_text().splitlines():
+    s = ln.strip()
+    if s.startswith("["):
+        a = json.loads(s)
+        if len(a) > 2:
+            mutated += 1
+            a[2] = {"x": 1} if mutated == 1 else None   # ill-formed, then explicit null
+        out.append(json.dumps(a))
+    else:
+        out.append(ln)
+assert mutated >= 2
+f.write_text("\n".join(out) + "\n")
+PY
+test_run cache unstage staging_degraded
+test_out "ignoring ill-formed outputs" build -v
+test_not_out "cache integrity error" build --no-build --rehash
 
 ./clean.sh
 echo "ltarCache: all checks passed"

--- a/tests/lake/tests/ltarCache/test.sh
+++ b/tests/lake/tests/ltarCache/test.sh
@@ -138,5 +138,15 @@ test_not_out "leantar" build -v -o out7.jsonl
 bundles out7.jsonl > bundles7.txt
 test_cmd diff bundles2.txt bundles7.txt
 
+#-------------------------------------------------------------------------------
+echo "# 8. Unstaging over a cache that already holds the artifacts skips them,"
+echo "#    even when builds cached them read-only."
+#-------------------------------------------------------------------------------
+rm -rf .lake out8.jsonl staging8
+test_run build -o out8.jsonl            # packs; cached bundles are read-only
+test_run cache stage out8.jsonl staging8
+test_run cache unstage staging8
+test_run build --no-build --rehash
+
 ./clean.sh
 echo "ltarCache: all checks passed"


### PR DESCRIPTION
This PR makes Lake's module archives (`.ltar`) content-stable and records each module's output content hashes in cache mappings alongside the archive reference. Previously, the trace file packed into an archive carried the build's input hash, input tree, and log (including absolute paths from the `lean` invocation), so the same outputs produced different archive bytes for every input revision and machine. 

Byte-identical module outputs now produce a byte-identical archive independent of the inputs, checkout path, or machine that produced them, so input-only changes (e.g., comment edits in an imported module) upload no new archive bytes and identical outputs deduplicate across revisions on cache services. 

Consumers verify unpacked archives against the hashes recorded in their cache mapping entry, recovering from mismatches by rebuilding, and restore outputs directly from the local artifact cache without fetching or unpacking the archive when they are already present.

The archive now packs a canonical input-free trace (`depHash := .nil`, no inputs, empty log), swapped in only for the duration of the pack; consumers stamp the input hash from the cache mapping into the trace after unpacking (marked `synthetic`), preserving the invariant that the on-disk trace carries the real input hash. 

----
Implementation details

```
PUSH  (lake build -o out.jsonl, artifact cache writable)
  ═══════════════════════════════════════════════════════════════════════

   lean compile ──► outputs: .olean[.server/.private] .ilean .ir .c [.bc]
        │
        ▼
   trace file = real metadata {depHash=H(inputs), inputs, log, outputs}
        │
        ▼  packLtar
   ┌───────────────────────────────────────────────┐
   │ 1. swap in canonical trace                    │
   │    {depHash=nil, inputs=[], log={}, outputs}  │   archive bytes =
   │ 2. leantar pack ───► M.ltar                   │   f(outputs only)
   │ 3. restore real trace on disk                 │
   └───────────────────────────────────────────────┘
        │
        ▼
   local CAS:  artifacts/<C>.ltar            C = content hash of bundle
        │
        ▼  trackOutputsIfEnabled
   mapping entry   [ H ,  "<C>.ltar" ,  {o,i,c,r,…} ]
                     │        │              │
                inputHash   data        recorded output hashes
                          (upload       (metadata only —
                           target)       never uploaded)
        │
        ▼  lake cache stage / put
   1. upload bundles   (collected from the data field only)
   2. upload mapping   (after artifacts: mapping present ⇒ blobs present)
```

```


  LOOKUP  (fetchFromCache?, consumer)
  ═══════════════════════════════════════════════════════════════════════

   inputHash H ──► mapping entry for H?
        │
        ├─ none ───────────────────────────► local trace up-to-date?
        │                                      yes: replay · no: BUILD
        ├─ full descrs (local entry)
        │      └─► resolve each from CAS ──► hit: DONE · miss: BUILD
        │
        └─ bundle ref "<C>.ltar" + recorded outputs
               │
               ▼  (A)  all recorded outputs in LOCAL CAS?
               ├─ yes ──► serve from CAS        (no fetch, no unpack)
               │
               └─ no
                    ▼  resolve bundle: local CAS, else download <C>.ltar
                    │                  (bytes hash-verified against C)
                    ▼  unpack into build dir
                    ▼  read unpacked trace
                    verify  trace outputs == recorded outputs ?
                    ├─ no ──► warn "cache integrity error"
                    │         discard outputs + trace ──► BUILD
                    │         (rebuild overwrites the entry: self-heals)
                    └─ yes ─► stamp H into trace (synthetic)
                              cache unpacked outputs individually
                              (next lookup takes the (A) fast path)

   Old entries (no recorded outputs): same bundle path, verification skipped.
   Old bundles (real depHash inside): stamp is a no-op pass-through.
```


Cache mapping lines gain an optional third element carrying the module's output descriptions (`[inputHash, "<hash>.ltar", {outputs}]`), and locally cached output entries gain a corresponding `outputs` field. Only the bundle remains an upload target; the recorded hashes are descriptive metadata. The recorded outputs serve two purposes on the consumer side:

* Integrity: after unpacking a bundle, the outputs declared by its embedded trace are checked against the mapping entry's record, so a mapping entry whose archive reference and recorded outputs disagree (e.g., wired to another module's bundle, or corrupted) is rejected rather than silently trusted. Verification runs before the input hash is stamped, a rejected unpack is discarded and treated as a cache miss with a warning, and the subsequent rebuild overwrites the offending mapping entry, so a corrupt cache entry self-heals instead of failing the build; `--wfail` restores strict failure for CI.
* Reuse: when the mapping entry records the output hashes and all of them are already present in the local artifact cache, the outputs are restored directly from it (local-only lookup, since individual outputs are not uploaded alongside bundles) and the bundle is neither downloaded nor unpacked; the bundle remains the fallback whenever any output is missing.

---
#### Compatibility

The change is compatible in both directions: older Lake versions ignore the extra mapping element and the `outputs` field, mappings and archives produced by older Lake versions are consumed as before (archives with an embedded input hash pass through unchanged, mapping entries without recorded outputs skip verification), and mixed-version cache sharing is unaffected since module input hashes already incorporate the toolchain.


#### Validation

A/B results on Batteries (187 modules, 306 MB of artifacts), feature branch vs. a stage1 built from the merge-base — same compiler, only Lake differs:

``` ┌────────────────────────────────────────────────┬──────────────┬───────────────┬────────────────────────────────┐
  │                    Scenario                    │   Feature    │   Baseline    │            Verdict             │
  ├────────────────────────────────────────────────┼──────────────┼───────────────┼────────────────────────────────┤
  │ Pack-only lake build -o (187 packs)            │ 2.22 s       │ 2.22 s        │ trace swap ×187: free          │
  ├────────────────────────────────────────────────┼──────────────┼───────────────┼────────────────────────────────┤
  │ Cold consume (every added check runs:          │ 0.55 s / 187 │ 0.54 s / 187  │ added cost ≈ 50 µs/module,     │
  │ probe-miss, verify, stamp)                     │  spawns      │ spawns        │ below noise                    │
  ├────────────────────────────────────────────────┼──────────────┼───────────────┼────────────────────────────────┤
  │ Adversarial worst case (cache warm except .c,  │ 0.66 s       │ —             │ identical to plain cold        │
  │ probe pays max stats then full fallback)       │              │               │ consume in the same session    │
  ├────────────────────────────────────────────────┼──────────────┼───────────────┼────────────────────────────────┤
  │ Warm consume                                   │ 0.13 s / 0   │ 0.44 s / 187  │ restore now equals no-op time  │
  │                                                │ spawns       │ spawns        │                                │
  ├────────────────────────────────────────────────┼──────────────┼───────────────┼────────────────────────────────┤
  │ No-op build                                    │ 0.131 s      │ 0.132 s       │ zero steady-state cost         │
  └────────────────────────────────────────────────┴──────────────┴───────────────┴────────────────────────────────┘
```

Covered by the new `tests/lake/tests/ltarCache` test: mapping entry shape, archive byte-stability across an input-only edit, bundle-only staging, fresh consume with verification, rejection of and self-healing from a corrupted mapping entry, backward compatibility with two-element mappings, and the no-unpack restore from a warm artifact cache.

Closes #13996
Closes #13997
