### PR TITLE
fix: lake: skip artifacts already present when staging or unstaging

### DIFF
--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -666,6 +666,9 @@ protected def stage : CliM PUnit := do
   let ok ← descrs.foldlM (init := true) fun ok descr => do
     let cachePath := cache.artifactDir / descr.relPath
     let stagingPath := stagingDir / descr.relPath
+    -- artifacts are content-addressed: an existing file already has the right contents
+    if (← stagingPath.pathExists) then
+      return ok
     match (← copyFile cachePath stagingPath |>.toBaseIO) with
     | .ok _ =>
       return ok
@@ -706,6 +709,11 @@ protected def unstage : CliM PUnit := do
   let ok ← descrs.foldlM (init := true) fun ok descr => do
     let cachePath := artDir/ descr.relPath
     let stagingPath := stagingDir / descr.relPath
+    -- artifacts are content-addressed: an existing file already has the right
+    -- contents (and may be read-only when cached by a build, so overwriting
+    -- it would fail)
+    if (← cachePath.pathExists) then
+      return ok
     match (← copyFile stagingPath cachePath |>.toBaseIO) with
     | .ok _ =>
       return ok

--- a/tests/lake/tests/cache/test.sh
+++ b/tests/lake/tests/cache/test.sh
@@ -228,6 +228,14 @@ test_cmd mkdir -p .lake/staging-empty
 test_cmd cp .lake/outputs.jsonl .lake/staging-empty/outputs.jsonl
 test_err 'artifact not found in staging directory' cache unstage .lake/staging-empty
 
+# Verify staging and unstaging skip artifacts already present at the destination
+# (artifacts cached by builds are read-only, so overwriting them would fail)
+test_run build +Test -o .lake/outputs-skip.jsonl
+test_run cache stage .lake/outputs-skip.jsonl .lake/staging-skip
+test_run cache stage .lake/outputs-skip.jsonl .lake/staging-skip
+test_run cache unstage .lake/staging-skip
+test_run build +Test --no-build
+
 # Verify that `lake cache clean` deletes the cache directory
 test_exp -d "$CACHE_DIR"
 test_cmd cp -r "$CACHE_DIR" .lake/cache-backup


### PR DESCRIPTION
This PR makes lake skip files that already exist for `lake cache unstage`, which currently copies artifacts into the local cache unconditionally. Artifacts cached by builds are read-only, so unstaging over a cache that already holds them failed with a permission error. The contents are identical by content-addressing, so skipping is correct.

Closes #13997 
