### PR TITLE
refactor: tidy Std.Internal.Do EPost, wp and order lemma names

### DIFF
--- a/src/Std/Internal/Do/ExceptPost.lean
+++ b/src/Std/Internal/Do/ExceptPost.lean
@@ -25,28 +25,28 @@ monad transformer stack. For example, `ExceptT Nat (ExceptT String (StateM σ))`
 
 ## Overview
 
-- `EPost.nil` is the empty exception postcondition (no exceptions).
-- `EPost.cons eh et` pairs a head postcondition type `eh` with a tail `et`.
-- `EPost⟨e₁, e₂, ...⟩` is notation for nested `EPost.cons`.
+- `EPost.Nil` is the empty exception postcondition (no exceptions).
+- `EPost.Cons eh et` pairs a head postcondition type `eh` with a tail `et`.
+- `EPost⟨e₁, e₂, ...⟩` is notation for nested `EPost.Cons`.
 - `epost⟨v₁, v₂, ...⟩` is notation for constructing exception postcondition values.
 -/
 
 namespace Std.Internal.Do
 
 /-- The empty exception postcondition type, used when a monad has no exception layers. -/
-structure EPost.nil : Type
+structure EPost.Nil : Type
 
 /-- A cons cell pairing a head exception postcondition type `eh` with a tail `et`.
 
 For a monad with exception type `ε` over lattice `l`, the head `eh` is typically `ε → l`
 and the tail `et` tracks remaining exception layers. -/
-structure EPost.cons (eh : Type u) (et : Type v) where
+structure EPost.Cons (eh : Type u) (et : Type v) where
   /-- The head exception postcondition. -/
   head : eh
   /-- The tail exception postconditions. -/
   tail : et
 
-attribute [simp] EPost.cons.head EPost.cons.tail
+attribute [simp] EPost.Cons.head EPost.Cons.tail
 
 /-!
 ## Partial Order and Complete Lattice Instances
@@ -55,19 +55,19 @@ Exception postconditions are ordered componentwise: `p ⊑ q` iff each component
 is below the corresponding component of `q`.
 -/
 
-/-- The trivial partial order on `EPost.nil`: all values are equal. -/
-instance : PartialOrder EPost.nil where
+/-- The trivial partial order on `EPost.Nil`: all values are equal. -/
+instance : PartialOrder EPost.Nil where
   rel _ _ := True
   rel_refl := trivial
   rel_trans _ _ := trivial
   rel_antisymm := fun {p q} _ _ => by cases p; cases q; rfl
 
-/-- The trivial complete lattice on `EPost.nil`. -/
-instance : CompleteLattice EPost.nil where
-  has_sup _ := ⟨EPost.nil.mk, fun _ => ⟨fun _ _ _ => trivial, fun _ => trivial⟩⟩
+/-- The trivial complete lattice on `EPost.Nil`. -/
+instance : CompleteLattice EPost.Nil where
+  has_sup _ := ⟨EPost.Nil.mk, fun _ => ⟨fun _ _ _ => trivial, fun _ => trivial⟩⟩
 
-/-- Componentwise partial order on `EPost.cons`, via `PProd`. -/
-instance [PartialOrder eh] [PartialOrder et] : PartialOrder (EPost.cons eh et) where
+/-- Componentwise partial order on `EPost.Cons`, via `PProd`. -/
+instance [PartialOrder eh] [PartialOrder et] : PartialOrder (EPost.Cons eh et) where
   rel p q := (⟨p.head, p.tail⟩ : eh ×' et) ⊑ ⟨q.head, q.tail⟩
   rel_refl := PartialOrder.rel_refl
   rel_trans h1 h2 := PartialOrder.rel_trans h1 h2
@@ -75,8 +75,8 @@ instance [PartialOrder eh] [PartialOrder et] : PartialOrder (EPost.cons eh et) w
     have := PartialOrder.rel_antisymm (α := eh ×' et) h1 h2
     cases p; cases q; cases this; rfl
 
-/-- Componentwise complete lattice on `EPost.cons`, via `PProd`. -/
-instance [CompleteLattice eh] [CompleteLattice et] : CompleteLattice (EPost.cons eh et) where
+/-- Componentwise complete lattice on `EPost.Cons`, via `PProd`. -/
+instance [CompleteLattice eh] [CompleteLattice et] : CompleteLattice (EPost.Cons eh et) where
   has_sup c :=
     let c' : (eh ×' et) → Prop := fun p => c ⟨p.1, p.2⟩
     let ⟨sup, hsup⟩ := CompleteLattice.has_sup c'
@@ -88,90 +88,89 @@ instance [CompleteLattice eh] [CompleteLattice et] : CompleteLattice (EPost.cons
 ## Ordering Lemmas
 -/
 
-/-- Extract a head ordering from an `EPost.cons` ordering. -/
-@[grind .] theorem EPost.cons.rel_head [PartialOrder eh] [PartialOrder et]
-    {p q : EPost.cons eh et} (h : p ⊑ q) : p.head ⊑ q.head :=
+/-- Extract a head ordering from an `EPost.Cons` ordering. -/
+theorem EPost.Cons.le_head [PartialOrder eh] [PartialOrder et]
+    {p q : EPost.Cons eh et} (h : p ⊑ q) : p.head ⊑ q.head :=
   h.1
 
-/-- Extract a tail ordering from an `EPost.cons` ordering. -/
-@[grind .] theorem EPost.cons.rel_tail [PartialOrder eh] [PartialOrder et]
-    {p q : EPost.cons eh et} (h : p ⊑ q) : p.tail ⊑ q.tail :=
+/-- Extract a tail ordering from an `EPost.Cons` ordering. -/
+theorem EPost.Cons.le_tail [PartialOrder eh] [PartialOrder et]
+    {p q : EPost.Cons eh et} (h : p ⊑ q) : p.tail ⊑ q.tail :=
   h.2
 
-/-- An `EPost.cons` value is below another if both components are below. -/
-@[grind .]
-theorem EPost.cons_rel [PartialOrder e] [PartialOrder e'] (eposth : e) (epostt : e') (epost : EPost.cons e e') :
+/-- An `EPost.Cons` value is below another if both components are below. -/
+theorem EPost.Cons.mk_le [PartialOrder e] [PartialOrder e'] (eposth : e) (epostt : e') (epost : EPost.Cons e e') :
     eposth ⊑ epost.head →
     epostt ⊑ epost.tail →
-    EPost.cons.mk eposth epostt ⊑ epost :=
+    EPost.Cons.mk eposth epostt ⊑ epost :=
   fun hh ht => ⟨hh, ht⟩
 
-/-- An `EPost.cons` value is below another if both components are below. -/
-theorem EPost.cons_rel_tail [PartialOrder e] [PartialOrder e'] (epostt : e') (epost : EPost.cons e e') :
+/-- An `EPost.Cons` value is below another if both components are below. -/
+theorem EPost.Cons.mk_le_tail [PartialOrder e] [PartialOrder e'] (epostt : e') (epost : EPost.Cons e e') :
     epostt ⊑ epost.tail →
-    EPost.cons.mk epost.head epostt ⊑ epost := by
-  apply EPost.cons_rel; rfl
+    EPost.Cons.mk epost.head epostt ⊑ epost := by
+  apply EPost.Cons.mk_le; rfl
 
-/-- The unique `EPost.nil` value is below any `EPost.nil` value. -/
-theorem EPost.nil_rel (epost : EPost.nil) :
-    EPost.nil.mk ⊑ epost := by
+/-- The unique `EPost.Nil` value is below any `EPost.Nil` value. -/
+theorem EPost.Nil.le (epost : EPost.Nil) :
+    EPost.Nil.mk ⊑ epost := by
   simp [PartialOrder.rel]
 
-/-- The head component of the bottom `EPost.cons` is the bottom element. Propositional (not
+/-- The head component of the bottom `EPost.Cons` is the bottom element. Propositional (not
 definitional), because `⊥` of a complete lattice is `csup ∅`, not a constructor application. -/
-theorem EPost.cons.head_bot {eh : Type u} {et : Type v}
+theorem EPost.Cons.head_bot {eh : Type u} {et : Type v}
     [CompleteLattice eh] [CompleteLattice et] :
-    EPost.cons.head (⊥ : EPost.cons eh et) = (⊥ : eh) := by
+    EPost.Cons.head (⊥ : EPost.Cons eh et) = (⊥ : eh) := by
   refine PartialOrder.rel_antisymm ?_ (bot_le _)
-  have h : (⊥ : EPost.cons eh et) ⊑ EPost.cons.mk (⊥ : eh) (⊥ : et) := bot_le _
-  exact EPost.cons.rel_head h
+  have h : (⊥ : EPost.Cons eh et) ⊑ EPost.Cons.mk (⊥ : eh) (⊥ : et) := bot_le _
+  exact EPost.Cons.le_head h
 
 /-!
 ## Notation
 
-- `EPost⟨e₁, e₂, ...⟩` builds an exception postcondition **type** (nested `EPost.cons`).
-- `epost⟨v₁, v₂, ...⟩` builds an exception postcondition **value** (nested `EPost.cons.mk`).
+- `EPost⟨e₁, e₂, ...⟩` builds an exception postcondition **type** (nested `EPost.Cons`).
+- `epost⟨v₁, v₂, ...⟩` builds an exception postcondition **value** (nested `EPost.Cons.mk`).
 -/
 
-/-- Exception postcondition type notation: `EPost⟨ε₁ → l, ε₂ → l⟩` for nested `EPost.cons`. -/
+/-- Exception postcondition type notation: `EPost⟨ε₁ → l, ε₂ → l⟩` for nested `EPost.Cons`. -/
 syntax "EPost⟨" term,* "⟩" : term
-/-- Exception postcondition value notation: `epost⟨h₁, h₂⟩` for nested `EPost.cons.mk`. -/
+/-- Exception postcondition value notation: `epost⟨h₁, h₂⟩` for nested `EPost.Cons.mk`. -/
 syntax "epost⟨" term,* "⟩" : term
 
 macro_rules
-  | `(EPost⟨⟩) => `(EPost.nil)
-  | `(EPost⟨$x⟩) => `(EPost.cons $x EPost.nil)
-  | `(EPost⟨$x, $xs,*⟩) => `(EPost.cons $x EPost⟨$xs,*⟩)
-  | `(epost⟨⟩) => `(EPost.nil.mk)
-  | `(epost⟨$x⟩) => `(EPost.cons.mk $x EPost.nil.mk)
-  | `(epost⟨$x, $xs,*⟩) => `(EPost.cons.mk $x epost⟨$xs,*⟩)
+  | `(EPost⟨⟩) => `(EPost.Nil)
+  | `(EPost⟨$x⟩) => `(EPost.Cons $x EPost.Nil)
+  | `(EPost⟨$x, $xs,*⟩) => `(EPost.Cons $x EPost⟨$xs,*⟩)
+  | `(epost⟨⟩) => `(EPost.Nil.mk)
+  | `(epost⟨$x⟩) => `(EPost.Cons.mk $x EPost.Nil.mk)
+  | `(epost⟨$x, $xs,*⟩) => `(EPost.Cons.mk $x epost⟨$xs,*⟩)
 
-/-- Pretty-print `EPost.nil` as `EPost⟨⟩`. -/
-@[app_unexpander EPost.nil] meta def unexpandEPostNil : Lean.PrettyPrinter.Unexpander
+/-- Pretty-print `EPost.Nil` as `EPost⟨⟩`. -/
+@[app_unexpander EPost.Nil] meta def unexpandEPostNil : Lean.PrettyPrinter.Unexpander
   | `($(_)) => `(EPost⟨⟩)
 
-/-- Pretty-print `EPost.cons` as `EPost⟨e₁, e₂, ...⟩`. -/
-@[app_unexpander EPost.cons] meta def unexpandEPostCons : Lean.PrettyPrinter.Unexpander
+/-- Pretty-print `EPost.Cons` as `EPost⟨e₁, e₂, ...⟩`. -/
+@[app_unexpander EPost.Cons] meta def unexpandEPostCons : Lean.PrettyPrinter.Unexpander
   | `($(_) $x $xs) =>
     match xs with
     | `(EPost⟨⟩) => `(EPost⟨$x⟩)
     | `(EPost⟨$y⟩) => `(EPost⟨$x, $y⟩)
     | `(EPost⟨$y, $ys,*⟩) => `(EPost⟨$x, $y, $ys,*⟩)
-    | _ => `(EPost.cons $x $xs)
+    | _ => `(EPost.Cons $x $xs)
   | _ => throw ()
 
-/-- Pretty-print `EPost.nil.mk` as `epost⟨⟩`. -/
-@[app_unexpander EPost.nil.mk] meta def unexpandEPostNilMk : Lean.PrettyPrinter.Unexpander
+/-- Pretty-print `EPost.Nil.mk` as `epost⟨⟩`. -/
+@[app_unexpander EPost.Nil.mk] meta def unexpandEPostNilMk : Lean.PrettyPrinter.Unexpander
   | `($(_)) => `(epost⟨⟩)
 
-/-- Pretty-print `EPost.cons.mk` as `epost⟨v₁, v₂, ...⟩`. -/
-@[app_unexpander EPost.cons.mk] meta def unexpandEPostConsMk : Lean.PrettyPrinter.Unexpander
+/-- Pretty-print `EPost.Cons.mk` as `epost⟨v₁, v₂, ...⟩`. -/
+@[app_unexpander EPost.Cons.mk] meta def unexpandEPostConsMk : Lean.PrettyPrinter.Unexpander
   | `($(_) $x $xs) =>
     match xs with
     | `(epost⟨⟩) => `(epost⟨$x⟩)
     | `(epost⟨$y⟩) => `(epost⟨$x, $y⟩)
     | `(epost⟨$y, $ys,*⟩) => `(epost⟨$x, $y, $ys,*⟩)
-    | _ => `(EPost.cons.mk $x $xs)
+    | _ => `(EPost.Cons.mk $x $xs)
   | _ => throw ()
 
 end Std.Internal.Do

--- a/src/Std/Internal/Do/Order/Basic.lean
+++ b/src/Std/Internal/Do/Order/Basic.lean
@@ -325,7 +325,6 @@ theorem CompleteLattice.ofProp_true (l : Type v) [CompleteLattice l] : ⌜True�
 theorem CompleteLattice.ofProp_false (l : Type v) [CompleteLattice l] : ⌜False⌝ = (⊥ : l) := by
   simp [CompleteLattice.ofProp]
 
-@[grind .]
 theorem CompleteLattice.ofProp_imp [CompleteLattice l]
   (p₁ p₂ : Prop) : (p₁ → p₂) → ⌜p₁⌝ ⊑ (⌜p₂⌝ : l) := by
   simp only [CompleteLattice.ofProp]

--- a/src/Std/Internal/Do/Order/Lemmas.lean
+++ b/src/Std/Internal/Do/Order/Lemmas.lean
@@ -35,284 +35,286 @@ variable {l : Type u} [CompleteLattice l] {P P' Q Q' R R' T : l} {φ φ₁ φ₂
 
 /-! # Connectives -/
 
-theorem and_intro_l (h : P ⊑ Q) : P ⊑ Q ⊓ P := le_meet _ _ _ h rel_refl
-theorem and_intro_r (h : P ⊑ Q) : P ⊑ P ⊓ Q := le_meet _ _ _ rel_refl h
-theorem and_intro_eq (hand : T = Q ⊓ R) (hQ : P ⊑ Q) (hR : P ⊑ R) : P ⊑ T := by
+theorem le_meet_left (h : P ⊑ Q) : P ⊑ Q ⊓ P := le_meet _ _ _ h rel_refl
+theorem le_meet_right (h : P ⊑ Q) : P ⊑ P ⊓ Q := le_meet _ _ _ rel_refl h
+theorem le_meet_of_eq (hand : T = Q ⊓ R) (hQ : P ⊑ Q) (hR : P ⊑ R) : P ⊑ T := by
   rw [hand]
   exact le_meet _ _ _ hQ hR
-theorem and_elim_l' (h : P ⊑ R) : P ⊓ Q ⊑ R := rel_trans (meet_le_left _ _) h
-theorem and_elim_r' (h : Q ⊑ R) : P ⊓ Q ⊑ R := rel_trans (meet_le_right _ _) h
-theorem or_intro_l' (h : P ⊑ Q) : P ⊑ Q ⊔ R := rel_trans h (left_le_join _ _)
-theorem or_intro_r' (h : P ⊑ R) : P ⊑ Q ⊔ R := rel_trans h (right_le_join _ _)
-theorem and_symm : P ⊓ Q ⊑ Q ⊓ P := le_meet _ _ _ (meet_le_right _ _) (meet_le_left _ _)
-theorem or_symm : P ⊔ Q ⊑ Q ⊔ P := join_le _ _ _ (right_le_join _ _) (left_le_join _ _)
-theorem rel_trans' (h₁ : P ⊑ Q) (h₂ : P ⊓ Q ⊑ R) : P ⊑ R := rel_trans (le_meet _ _ _ rel_refl h₁) h₂
-theorem false_elim : (⊥ : l) ⊑ P := bot_le _
-theorem true_intro : P ⊑ (⊤ : l) := le_top _
-theorem exists_intro' {α} {Ψ : α → l} (a : α) (h : P ⊑ Ψ a) : P ⊑ iSup Ψ :=
+theorem meet_le_of_left_le (h : P ⊑ R) : P ⊓ Q ⊑ R := rel_trans (meet_le_left _ _) h
+theorem meet_le_of_right_le (h : Q ⊑ R) : P ⊓ Q ⊑ R := rel_trans (meet_le_right _ _) h
+theorem le_join_of_le_left (h : P ⊑ Q) : P ⊑ Q ⊔ R := rel_trans h (left_le_join _ _)
+theorem le_join_of_le_right (h : P ⊑ R) : P ⊑ Q ⊔ R := rel_trans h (right_le_join _ _)
+theorem meet_le_comm : P ⊓ Q ⊑ Q ⊓ P := le_meet _ _ _ (meet_le_right _ _) (meet_le_left _ _)
+theorem join_le_comm : P ⊔ Q ⊑ Q ⊔ P := join_le _ _ _ (right_le_join _ _) (left_le_join _ _)
+theorem le_trans_meet (h₁ : P ⊑ Q) (h₂ : P ⊓ Q ⊑ R) : P ⊑ R := rel_trans (le_meet _ _ _ rel_refl h₁) h₂
+theorem le_iSup_of_le {α} {Ψ : α → l} (a : α) (h : P ⊑ Ψ a) : P ⊑ iSup Ψ :=
   rel_trans h (le_iSup _ a)
-theorem exfalso (h : P ⊑ (⊥ : l)) : P ⊑ Q := rel_trans h false_elim
+theorem le_of_le_bot (h : P ⊑ (⊥ : l)) : P ⊑ Q := rel_trans h (bot_le _)
 
 /-! ## Connectives requiring `Frame` -/
 
 section Frame
 variable [Frame l]
 
-theorem imp_intro (h : P ⊓ Q ⊑ R) : P ⊑ Q ⇨ R := himp_complete _ _ _ (rel_trans and_symm h)
-theorem imp_intro' (h : Q ⊓ P ⊑ R) : P ⊑ Q ⇨ R := himp_complete _ _ _ h
-theorem imp_elim (h : P ⊑ Q ⇨ R) : P ⊓ Q ⊑ R := rel_trans
-  (le_meet _ _ _ (meet_le_right _ _) (and_elim_l' h))
+theorem le_himp (h : P ⊓ Q ⊑ R) : P ⊑ Q ⇨ R := himp_complete _ _ _ (rel_trans meet_le_comm h)
+theorem le_himp_of_meet_le_comm (h : Q ⊓ P ⊑ R) : P ⊑ Q ⇨ R := himp_complete _ _ _ h
+theorem meet_le_of_le_himp (h : P ⊑ Q ⇨ R) : P ⊓ Q ⊑ R := rel_trans
+  (le_meet _ _ _ (meet_le_right _ _) (meet_le_of_left_le h))
   (himp_sound _ _)
-theorem imp_elim' (h : Q ⊑ P ⇨ R) : P ⊓ Q ⊑ R := rel_trans and_symm (imp_elim h)
-theorem imp_elim_l : (P ⇨ Q) ⊓ P ⊑ Q := imp_elim rel_refl
-theorem imp_elim_r : P ⊓ (P ⇨ Q) ⊑ Q := imp_elim' rel_refl
-theorem mp (h₁ : P ⊑ Q ⇨ R) (h₂ : P ⊑ Q) : P ⊑ R := rel_trans' h₂ (imp_elim h₁)
+theorem meet_le_of_le_himp_comm (h : Q ⊑ P ⇨ R) : P ⊓ Q ⊑ R :=
+  rel_trans meet_le_comm (meet_le_of_le_himp h)
+theorem himp_meet_le : (P ⇨ Q) ⊓ P ⊑ Q := meet_le_of_le_himp rel_refl
+theorem meet_himp_le : P ⊓ (P ⇨ Q) ⊑ Q := meet_le_of_le_himp_comm rel_refl
+theorem le_himp_mp (h₁ : P ⊑ Q ⇨ R) (h₂ : P ⊑ Q) : P ⊑ R :=
+  le_trans_meet h₂ (meet_le_of_le_himp h₁)
 
-theorem and_or_elim_l (hleft : P ⊓ R ⊑ T) (hright : Q ⊓ R ⊑ T) : (P ⊔ Q) ⊓ R ⊑ T :=
-  imp_elim (join_le _ _ _ (imp_intro hleft) (imp_intro hright))
-theorem and_or_elim_r (hleft : P ⊓ Q ⊑ T) (hright : P ⊓ R ⊑ T) : P ⊓ (Q ⊔ R) ⊑ T :=
-  imp_elim'
+theorem meet_join_le_left (hleft : P ⊓ R ⊑ T) (hright : Q ⊓ R ⊑ T) : (P ⊔ Q) ⊓ R ⊑ T :=
+  meet_le_of_le_himp (join_le _ _ _ (le_himp hleft) (le_himp hright))
+theorem meet_join_le_right (hleft : P ⊓ Q ⊑ T) (hright : P ⊓ R ⊑ T) : P ⊓ (Q ⊔ R) ⊑ T :=
+  meet_le_of_le_himp_comm
     (join_le _ _ _
-      (imp_intro (rel_trans and_symm hleft))
-      (imp_intro (rel_trans and_symm hright)))
+      (le_himp (rel_trans meet_le_comm hleft))
+      (le_himp (rel_trans meet_le_comm hright)))
 
 end Frame
 
 /-! # Monotonicity -/
 
-theorem and_mono (hp : P ⊑ P') (hq : Q ⊑ Q') : P ⊓ Q ⊑ P' ⊓ Q' :=
-  le_meet _ _ _ (and_elim_l' hp) (and_elim_r' hq)
-theorem and_mono_l (h : P ⊑ P') : P ⊓ Q ⊑ P' ⊓ Q := and_mono h rel_refl
-theorem and_mono_r (h : Q ⊑ Q') : P ⊓ Q ⊑ P ⊓ Q' := and_mono rel_refl h
+theorem meet_mono (hp : P ⊑ P') (hq : Q ⊑ Q') : P ⊓ Q ⊑ P' ⊓ Q' :=
+  le_meet _ _ _ (meet_le_of_left_le hp) (meet_le_of_right_le hq)
+theorem meet_mono_left (h : P ⊑ P') : P ⊓ Q ⊑ P' ⊓ Q := meet_mono h rel_refl
+theorem meet_mono_right (h : Q ⊑ Q') : P ⊓ Q ⊑ P ⊓ Q' := meet_mono rel_refl h
 
-theorem or_mono (hp : P ⊑ P') (hq : Q ⊑ Q') : P ⊔ Q ⊑ P' ⊔ Q' :=
-  join_le _ _ _ (or_intro_l' hp) (or_intro_r' hq)
-theorem or_mono_l (h : P ⊑ P') : P ⊔ Q ⊑ P' ⊔ Q := or_mono h rel_refl
-theorem or_mono_r (h : Q ⊑ Q') : P ⊔ Q ⊑ P ⊔ Q' := or_mono rel_refl h
+theorem join_mono (hp : P ⊑ P') (hq : Q ⊑ Q') : P ⊔ Q ⊑ P' ⊔ Q' :=
+  join_le _ _ _ (le_join_of_le_left hp) (le_join_of_le_right hq)
+theorem join_mono_left (h : P ⊑ P') : P ⊔ Q ⊑ P' ⊔ Q := join_mono h rel_refl
+theorem join_mono_right (h : Q ⊑ Q') : P ⊔ Q ⊑ P ⊔ Q' := join_mono rel_refl h
 
-theorem forall_mono {α} {Φ Ψ : α → l} (h : ∀ a, Φ a ⊑ Ψ a) : iInf Φ ⊑ iInf Ψ :=
+theorem iInf_mono {α} {Φ Ψ : α → l} (h : ∀ a, Φ a ⊑ Ψ a) : iInf Φ ⊑ iInf Ψ :=
   le_iInf _ _ fun a => rel_trans (iInf_le _ a) (h a)
-theorem exists_mono {α} {Φ Ψ : α → l} (h : ∀ a, Φ a ⊑ Ψ a) : iSup Φ ⊑ iSup Ψ :=
+theorem iSup_mono {α} {Φ Ψ : α → l} (h : ∀ a, Φ a ⊑ Ψ a) : iSup Φ ⊑ iSup Ψ :=
   iSup_le _ _ fun a => rel_trans (h a) (le_iSup _ a)
 
 section Frame
 variable [Frame l]
 
-theorem imp_mono (h1 : Q ⊑ P) (h2 : P' ⊑ Q') : (P ⇨ P') ⊑ Q ⇨ Q' :=
-  imp_intro <| rel_trans (and_mono_r h1) <| rel_trans imp_elim_l h2
-theorem imp_mono_l (h : P' ⊑ P) : (P ⇨ Q) ⊑ (P' ⇨ Q) := imp_mono h rel_refl
-theorem imp_mono_r (h : Q ⊑ Q') : (P ⇨ Q) ⊑ (P ⇨ Q') := imp_mono rel_refl h
+theorem himp_mono (h1 : Q ⊑ P) (h2 : P' ⊑ Q') : (P ⇨ P') ⊑ Q ⇨ Q' :=
+  le_himp <| rel_trans (meet_mono_right h1) <| rel_trans himp_meet_le h2
+theorem himp_mono_left (h : P' ⊑ P) : (P ⇨ Q) ⊑ (P' ⇨ Q) := himp_mono h rel_refl
+theorem himp_mono_right (h : Q ⊑ Q') : (P ⇨ Q) ⊑ (P ⇨ Q') := himp_mono rel_refl h
 
 end Frame
 
 /-! # Boolean algebra -/
 
-theorem and_self : P ⊓ P = P :=
+theorem meet_self : P ⊓ P = P :=
   rel_antisymm (meet_le_left _ _) (le_meet _ _ _ rel_refl rel_refl)
-theorem or_self : P ⊔ P = P :=
+theorem join_self : P ⊔ P = P :=
   rel_antisymm (join_le _ _ _ rel_refl rel_refl) (left_le_join _ _)
-theorem and_comm : P ⊓ Q = Q ⊓ P := rel_antisymm and_symm and_symm
-theorem or_comm : P ⊔ Q = Q ⊔ P := rel_antisymm or_symm or_symm
-theorem and_assoc : (P ⊓ Q) ⊓ R = P ⊓ (Q ⊓ R) :=
+theorem meet_comm : P ⊓ Q = Q ⊓ P := rel_antisymm meet_le_comm meet_le_comm
+theorem join_comm : P ⊔ Q = Q ⊔ P := rel_antisymm join_le_comm join_le_comm
+theorem meet_assoc : (P ⊓ Q) ⊓ R = P ⊓ (Q ⊓ R) :=
   rel_antisymm
-    (le_meet _ _ _ (and_elim_l' (meet_le_left _ _))
-      (le_meet _ _ _ (and_elim_l' (meet_le_right _ _)) (meet_le_right _ _)))
+    (le_meet _ _ _ (meet_le_of_left_le (meet_le_left _ _))
+      (le_meet _ _ _ (meet_le_of_left_le (meet_le_right _ _)) (meet_le_right _ _)))
     (le_meet _ _ _
-      (le_meet _ _ _ (meet_le_left _ _) (and_elim_r' (meet_le_left _ _)))
-      (and_elim_r' (meet_le_right _ _)))
-theorem or_assoc : (P ⊔ Q) ⊔ R = P ⊔ (Q ⊔ R) :=
+      (le_meet _ _ _ (meet_le_left _ _) (meet_le_of_right_le (meet_le_left _ _)))
+      (meet_le_of_right_le (meet_le_right _ _)))
+theorem join_assoc : (P ⊔ Q) ⊔ R = P ⊔ (Q ⊔ R) :=
   rel_antisymm
     (join_le _ _ _
-      (join_le _ _ _ (left_le_join _ _) (or_intro_r' (left_le_join _ _)))
-      (or_intro_r' (right_le_join _ _)))
-    (join_le _ _ _ (or_intro_l' (left_le_join _ _))
-      (join_le _ _ _ (or_intro_l' (right_le_join _ _)) (right_le_join _ _)))
+      (join_le _ _ _ (left_le_join _ _) (le_join_of_le_right (left_le_join _ _)))
+      (le_join_of_le_right (right_le_join _ _)))
+    (join_le _ _ _ (le_join_of_le_left (left_le_join _ _))
+      (join_le _ _ _ (le_join_of_le_left (right_le_join _ _)) (right_le_join _ _)))
 
-theorem and_eq_right : (P ⊑ Q) ↔ Q ⊓ P = P :=
+theorem le_iff_meet_eq_right : (P ⊑ Q) ↔ Q ⊓ P = P :=
   ⟨fun h => rel_antisymm (meet_le_right _ _) (le_meet _ _ _ h rel_refl),
    fun h => h ▸ meet_le_left _ _⟩
-theorem and_eq_left : (P ⊑ Q) ↔ P ⊓ Q = P :=
+theorem le_iff_meet_eq_left : (P ⊑ Q) ↔ P ⊓ Q = P :=
   ⟨fun h => rel_antisymm (meet_le_left _ _) (le_meet _ _ _ rel_refl h),
    fun h => h ▸ meet_le_right _ _⟩
-theorem or_eq_left : (P ⊑ Q) ↔ Q ⊔ P = Q :=
+theorem le_iff_join_eq_left : (P ⊑ Q) ↔ Q ⊔ P = Q :=
   ⟨fun h => rel_antisymm (join_le _ _ _ rel_refl h) (left_le_join _ _),
    fun h => h ▸ right_le_join _ _⟩
-theorem or_eq_right : (P ⊑ Q) ↔ P ⊔ Q = Q :=
+theorem le_iff_join_eq_right : (P ⊑ Q) ↔ P ⊔ Q = Q :=
   ⟨fun h => rel_antisymm (join_le _ _ _ h rel_refl) (right_le_join _ _),
    fun h => h ▸ left_le_join _ _⟩
 
-theorem true_and : (⊤ : l) ⊓ P = P :=
+theorem top_meet : (⊤ : l) ⊓ P = P :=
   rel_antisymm (meet_le_right _ _) (le_meet _ _ _ (le_top _) rel_refl)
-theorem and_true : P ⊓ (⊤ : l) = P := and_comm.trans true_and
-theorem false_and : (⊥ : l) ⊓ P = ⊥ :=
-  rel_antisymm (and_elim_l' false_elim) false_elim
-theorem and_false : P ⊓ (⊥ : l) = ⊥ := and_comm.trans false_and
-theorem true_or : (⊤ : l) ⊔ P = ⊤ :=
+theorem meet_top : P ⊓ (⊤ : l) = P := meet_comm.trans top_meet
+theorem bot_meet : (⊥ : l) ⊓ P = ⊥ :=
+  rel_antisymm (meet_le_of_left_le (bot_le _)) (bot_le _)
+theorem meet_bot : P ⊓ (⊥ : l) = ⊥ := meet_comm.trans bot_meet
+theorem top_join : (⊤ : l) ⊔ P = ⊤ :=
   rel_antisymm (le_top _) (left_le_join _ _)
-theorem or_true : P ⊔ (⊤ : l) = ⊤ := or_comm.trans true_or
-theorem false_or : (⊥ : l) ⊔ P = P :=
-  rel_antisymm (join_le _ _ _ false_elim rel_refl) (right_le_join _ _)
-theorem or_false : P ⊔ (⊥ : l) = P := or_comm.trans false_or
+theorem join_top : P ⊔ (⊤ : l) = ⊤ := join_comm.trans top_join
+theorem bot_join : (⊥ : l) ⊔ P = P :=
+  rel_antisymm (join_le _ _ _ (bot_le _) rel_refl) (right_le_join _ _)
+theorem join_bot : P ⊔ (⊥ : l) = P := join_comm.trans bot_join
 
 section Frame
 variable [Frame l]
 
-theorem and_or_left : P ⊓ (Q ⊔ R) = (P ⊓ Q) ⊔ (P ⊓ R) :=
+theorem meet_join_left : P ⊓ (Q ⊔ R) = (P ⊓ Q) ⊔ (P ⊓ R) :=
   rel_antisymm
-    (and_or_elim_r (or_intro_l' rel_refl) (or_intro_r' rel_refl))
-    (join_le _ _ _ (and_mono_r (left_le_join _ _)) (and_mono_r (right_le_join _ _)))
-theorem or_and_left : P ⊔ (Q ⊓ R) = (P ⊔ Q) ⊓ (P ⊔ R) :=
+    (meet_join_le_right (le_join_of_le_left rel_refl) (le_join_of_le_right rel_refl))
+    (join_le _ _ _ (meet_mono_right (left_le_join _ _)) (meet_mono_right (right_le_join _ _)))
+theorem join_meet_left : P ⊔ (Q ⊓ R) = (P ⊔ Q) ⊓ (P ⊔ R) :=
   rel_antisymm
     (join_le _ _ _ (le_meet _ _ _ (left_le_join _ _) (left_le_join _ _))
-      (and_mono (right_le_join _ _) (right_le_join _ _)))
-    (and_or_elim_l (or_intro_l' (meet_le_left _ _))
-      (and_or_elim_r (or_intro_l' (meet_le_right _ _)) (or_intro_r' rel_refl)))
-theorem or_and_right : (P ⊔ Q) ⊓ R = (P ⊓ R) ⊔ (Q ⊓ R) :=
-  and_comm.trans (and_or_left.trans (rel_antisymm
-    (or_mono (P := _) (Q := _) (P' := _) (Q' := _)
-      (rel_of_eq and_comm) (rel_of_eq and_comm))
-    (or_mono (rel_of_eq and_comm) (rel_of_eq and_comm))))
-theorem and_or_right : (P ⊓ Q) ⊔ R = (P ⊔ R) ⊓ (Q ⊔ R) :=
-  or_comm.trans (or_and_left.trans (rel_antisymm
-    (and_mono (rel_of_eq or_comm) (rel_of_eq or_comm))
-    (and_mono (rel_of_eq or_comm) (rel_of_eq or_comm))))
+      (meet_mono (right_le_join _ _) (right_le_join _ _)))
+    (meet_join_le_left (le_join_of_le_left (meet_le_left _ _))
+      (meet_join_le_right (le_join_of_le_left (meet_le_right _ _)) (le_join_of_le_right rel_refl)))
+theorem meet_join_right : (P ⊔ Q) ⊓ R = (P ⊓ R) ⊔ (Q ⊓ R) :=
+  meet_comm.trans (meet_join_left.trans (rel_antisymm
+    (join_mono (P := _) (Q := _) (P' := _) (Q' := _)
+      (rel_of_eq meet_comm) (rel_of_eq meet_comm))
+    (join_mono (rel_of_eq meet_comm) (rel_of_eq meet_comm))))
+theorem join_meet_right : (P ⊓ Q) ⊔ R = (P ⊔ R) ⊓ (Q ⊔ R) :=
+  join_comm.trans (join_meet_left.trans (rel_antisymm
+    (meet_mono (rel_of_eq join_comm) (rel_of_eq join_comm))
+    (meet_mono (rel_of_eq join_comm) (rel_of_eq join_comm))))
 
-theorem true_imp : ((⊤ : l) ⇨ P) = P :=
+theorem top_himp : ((⊤ : l) ⇨ P) = P :=
   rel_antisymm
-    (rel_trans (le_meet _ _ _ (le_top _) rel_refl) imp_elim_r)
-    (imp_intro (and_elim_l' rel_refl))
-theorem imp_self : Q ⊑ P ⇨ P := imp_intro (meet_le_right _ _)
-theorem imp_self_simp : (Q ⊑ P ⇨ P) ↔ True := iff_true_intro imp_self
-theorem imp_trans : (P ⇨ Q) ⊓ (Q ⇨ R) ⊑ P ⇨ R :=
-  imp_intro' <|
-    rel_trans (rel_of_eq and_assoc.symm) <|
-      rel_trans (and_mono_l imp_elim_r) imp_elim_r
-theorem false_imp : ((⊥ : l) ⇨ P) = ⊤ :=
-  rel_antisymm (le_top _) (imp_intro (and_elim_r' false_elim))
+    (rel_trans (le_meet _ _ _ (le_top _) rel_refl) meet_himp_le)
+    (le_himp (meet_le_of_left_le rel_refl))
+theorem le_himp_self : Q ⊑ P ⇨ P := le_himp (meet_le_right _ _)
+theorem le_himp_self_iff : (Q ⊑ P ⇨ P) ↔ True := iff_true_intro le_himp_self
+theorem himp_meet_himp_le : (P ⇨ Q) ⊓ (Q ⇨ R) ⊑ P ⇨ R :=
+  le_himp_of_meet_le_comm <|
+    rel_trans (rel_of_eq meet_assoc.symm) <|
+      rel_trans (meet_mono_left meet_himp_le) meet_himp_le
+theorem bot_himp : ((⊥ : l) ⇨ P) = ⊤ :=
+  rel_antisymm (le_top _) (le_himp (meet_le_of_right_le (bot_le _)))
 
-theorem and_imp : P' ⊓ (P' ⇨ Q') ⊑ P' ⊓ Q' :=
-  le_meet _ _ _ (meet_le_left _ _) (rel_trans and_symm imp_elim_l)
-theorem of_and_imp (hp : P ⊑ P') (hq : Q ⊑ (P' ⇨ Q')) : P ⊓ Q ⊑ P' ⊓ Q' :=
-  rel_trans (and_mono hp hq) and_imp
+theorem meet_himp_le_meet : P' ⊓ (P' ⇨ Q') ⊑ P' ⊓ Q' :=
+  le_meet _ _ _ (meet_le_left _ _) (rel_trans meet_le_comm himp_meet_le)
+theorem meet_le_meet_of_le_himp (hp : P ⊑ P') (hq : Q ⊑ (P' ⇨ Q')) : P ⊓ Q ⊑ P' ⊓ Q' :=
+  rel_trans (meet_mono hp hq) meet_himp_le_meet
 
 end Frame
 
-/-! # Pure (`CompleteLattice.ofProp`) -/
+/-! # Propositional embedding (`CompleteLattice.ofProp`) -/
 
-theorem pure_elim {φ : Prop} (h1 : Q ⊑ (⌜φ⌝ : l)) (h2 : φ → Q ⊑ R) : Q ⊑ R := by
+theorem ofProp_elim {φ : Prop} (h1 : Q ⊑ (⌜φ⌝ : l)) (h2 : φ → Q ⊑ R) : Q ⊑ R := by
   by_cases hφ : φ
   · exact h2 hφ
   · simp [CompleteLattice.ofProp, hφ] at h1
-    exact rel_trans h1 false_elim
+    exact rel_trans h1 (bot_le _)
 
-theorem pure_mono {φ₁ φ₂ : Prop} (h : φ₁ → φ₂) : ⌜φ₁⌝ ⊑ (⌜φ₂⌝ : l) :=
+theorem ofProp_mono {φ₁ φ₂ : Prop} (h : φ₁ → φ₂) : ⌜φ₁⌝ ⊑ (⌜φ₂⌝ : l) :=
   CompleteLattice.ofProp_imp _ _ h
-theorem pure_congr {φ₁ φ₂ : Prop} (h : φ₁ ↔ φ₂) : (⌜φ₁⌝ : l) = ⌜φ₂⌝ :=
-  rel_antisymm (pure_mono h.1) (pure_mono h.2)
+theorem ofProp_congr {φ₁ φ₂ : Prop} (h : φ₁ ↔ φ₂) : (⌜φ₁⌝ : l) = ⌜φ₂⌝ :=
+  rel_antisymm (ofProp_mono h.1) (ofProp_mono h.2)
 
-theorem pure_elim_l {φ : Prop} (h : φ → Q ⊑ R) : (⌜φ⌝ : l) ⊓ Q ⊑ R := by
+theorem ofProp_meet_le_left {φ : Prop} (h : φ → Q ⊑ R) : (⌜φ⌝ : l) ⊓ Q ⊑ R := by
   rw [CompleteLattice.ofProp_intro_r]; exact h
-theorem pure_elim_r {φ : Prop} (h : φ → Q ⊑ R) : Q ⊓ (⌜φ⌝ : l) ⊑ R := by
+theorem ofProp_meet_le_right {φ : Prop} (h : φ → Q ⊑ R) : Q ⊓ (⌜φ⌝ : l) ⊑ R := by
   rw [CompleteLattice.ofProp_intro_l]; exact h
-theorem pure_true {φ : Prop} (h : φ) : (⌜φ⌝ : l) = ⌜True⌝ := pure_congr ⟨fun _ => trivial, fun _ => h⟩
+theorem ofProp_eq_top {φ : Prop} (h : φ) : (⌜φ⌝ : l) = ⊤ :=
+  (ofProp_congr ⟨fun _ => trivial, fun _ => h⟩).trans (CompleteLattice.ofProp_true l)
 
-theorem pure_and {φ₁ φ₂ : Prop} : (⌜φ₁⌝ : l) ⊓ ⌜φ₂⌝ = ⌜φ₁ ∧ φ₂⌝ := by
+theorem ofProp_and {φ₁ φ₂ : Prop} : (⌜φ₁⌝ : l) ⊓ ⌜φ₂⌝ = ⌜φ₁ ∧ φ₂⌝ := by
   apply rel_antisymm
-  · apply pure_elim_r
+  · apply ofProp_meet_le_right
     intro h₂
-    apply pure_mono
+    apply ofProp_mono
     exact (⟨·, h₂⟩)
-  · exact le_meet _ _ _ (pure_mono And.left) (pure_mono And.right)
+  · exact le_meet _ _ _ (ofProp_mono And.left) (ofProp_mono And.right)
 
-theorem pure_or {φ₁ φ₂ : Prop} : (⌜φ₁⌝ : l) ⊔ ⌜φ₂⌝ = ⌜φ₁ ∨ φ₂⌝ := by
+theorem ofProp_or {φ₁ φ₂ : Prop} : (⌜φ₁⌝ : l) ⊔ ⌜φ₂⌝ = ⌜φ₁ ∨ φ₂⌝ := by
   apply rel_antisymm
-  · exact join_le _ _ _ (pure_mono Or.inl) (pure_mono Or.inr)
+  · exact join_le _ _ _ (ofProp_mono Or.inl) (ofProp_mono Or.inr)
   · rw [CompleteLattice.ofProp_intro]
     rintro (h₁ | h₂)
-    · rw [pure_true h₁, CompleteLattice.ofProp_true]
+    · rw [ofProp_eq_top h₁]
       exact left_le_join _ _
-    · rw [pure_true h₂, CompleteLattice.ofProp_true]
+    · rw [ofProp_eq_top h₂]
       exact right_le_join _ _
 
-theorem pure_forall_le {α} {Φ : α → Prop} : (⌜∀ x, Φ x⌝ : l) ⊑ iInf (fun x => ⌜Φ x⌝) :=
-  le_iInf _ _ fun _ => pure_mono (· _)
+theorem ofProp_forall_le {α} {Φ : α → Prop} : (⌜∀ x, Φ x⌝ : l) ⊑ iInf (fun x => ⌜Φ x⌝) :=
+  le_iInf _ _ fun _ => ofProp_mono (· _)
 
-theorem pure_exists {α} {Φ : α → Prop} :
+theorem ofProp_exists {α} {Φ : α → Prop} :
     iSup (fun x => (⌜Φ x⌝ : l)) = ⌜∃ x, Φ x⌝ := by
   apply rel_antisymm
-  · exact iSup_le _ _ fun a => pure_mono (⟨a, ·⟩)
+  · exact iSup_le _ _ fun a => ofProp_mono (⟨a, ·⟩)
   · rw [CompleteLattice.ofProp_intro]
     rintro ⟨x, hx⟩
-    have h : (⌜Φ x⌝ : l) = ⊤ := by rw [pure_true hx, CompleteLattice.ofProp_true]
+    have h : (⌜Φ x⌝ : l) = ⊤ := ofProp_eq_top hx
     exact h ▸ le_iSup (fun x => (⌜Φ x⌝ : l)) x
 
-theorem pure_forall {α} {Φ : α → Prop} :
+theorem ofProp_forall {α} {Φ : α → Prop} :
     iInf (fun x => (⌜Φ x⌝ : l)) = ⌜∀ x, Φ x⌝ := by
   apply rel_antisymm
   · by_cases h : ∃ x, ¬Φ x
     · obtain ⟨x, hx⟩ := h
-      exact rel_trans (iInf_le _ x) (pure_mono hx.elim)
+      exact rel_trans (iInf_le _ x) (ofProp_mono hx.elim)
     · have hall : ∀ x, Φ x := fun x => Classical.not_not.1 <| mt (⟨x, ·⟩) h
-      have heq : (⌜∀ x, Φ x⌝ : l) = ⊤ := by rw [pure_true hall, CompleteLattice.ofProp_true]
+      have heq : (⌜∀ x, Φ x⌝ : l) = ⊤ := ofProp_eq_top hall
       exact heq ▸ le_top _
-  · exact pure_forall_le
+  · exact ofProp_forall_le
 
 section Frame
 variable [Frame l]
 
-theorem pure_imp_2 {φ₁ φ₂ : Prop} : (⌜φ₁ → φ₂⌝ : l) ⊑ (⌜φ₁⌝ ⇨ ⌜φ₂⌝) :=
-  imp_intro (rel_trans (rel_of_eq pure_and) (pure_mono (And.elim id)))
+theorem himp_ofProp_le {φ₁ φ₂ : Prop} : (⌜φ₁ → φ₂⌝ : l) ⊑ (⌜φ₁⌝ ⇨ ⌜φ₂⌝) :=
+  le_himp (rel_trans (rel_of_eq ofProp_and) (ofProp_mono (And.elim id)))
 
-theorem pure_imp {φ₁ φ₂ : Prop} : ((⌜φ₁⌝ : l) ⇨ ⌜φ₂⌝) = ⌜φ₁ → φ₂⌝ := by
+theorem himp_ofProp {φ₁ φ₂ : Prop} : ((⌜φ₁⌝ : l) ⇨ ⌜φ₂⌝) = ⌜φ₁ → φ₂⌝ := by
   apply rel_antisymm
   · by_cases h₁ : φ₁
-    · -- φ₁ true: goal `(⌜φ₁⌝ ⇨ ⌜φ₂⌝) ⊑ ⌜φ₁ → φ₂⌝`. Use `imp_elim_l` after weakening LHS to `⌜φ₁⌝ ⇨ ⌜φ₂⌝ ⊓ ⌜φ₁⌝`.
+    · -- φ₁ true: weaken the LHS to `(⌜φ₁⌝ ⇨ ⌜φ₂⌝) ⊓ ⌜φ₁⌝` and apply `himp_meet_le`.
       have h₁' : (⊤ : l) ⊑ ⌜φ₁⌝ := by
-        have : (⌜φ₁⌝ : l) = ⊤ := by rw [pure_true h₁, CompleteLattice.ofProp_true]
+        have : (⌜φ₁⌝ : l) = ⊤ := ofProp_eq_top h₁
         exact this ▸ rel_refl
       exact rel_trans
         (le_meet _ _ _ rel_refl (rel_trans (le_top _) h₁'))
-        (rel_trans imp_elim_l (pure_mono (fun h _ => h)))
-    · -- φ₁ false: ⌜φ₁⌝ = ⊥, ⌜φ₁ → φ₂⌝ = ⊤
-      have : (⌜φ₁ → φ₂⌝ : l) = ⊤ := by rw [pure_true (fun hp => absurd hp h₁), CompleteLattice.ofProp_true]
+        (rel_trans himp_meet_le (ofProp_mono (fun h _ => h)))
+    · -- φ₁ false: `⌜φ₁ → φ₂⌝ = ⊤`
+      have : (⌜φ₁ → φ₂⌝ : l) = ⊤ := ofProp_eq_top (fun hp => absurd hp h₁)
       exact this ▸ le_top _
-  · exact pure_imp_2
+  · exact himp_ofProp_le
 
 end Frame
 
 /-! # Miscellaneous -/
 
-theorem and_left_comm : P ⊓ (Q ⊓ R) = Q ⊓ (P ⊓ R) := by
-  rw [← and_assoc, and_comm (P := P), and_assoc]
-theorem and_right_comm : (P ⊓ Q) ⊓ R = (P ⊓ R) ⊓ Q := by
-  rw [and_assoc, and_comm (P := Q), ← and_assoc]
+theorem meet_left_comm : P ⊓ (Q ⊓ R) = Q ⊓ (P ⊓ R) := by
+  rw [← meet_assoc, meet_comm (P := P), meet_assoc]
+theorem meet_right_comm : (P ⊓ Q) ⊓ R = (P ⊓ R) ⊓ Q := by
+  rw [meet_assoc, meet_comm (P := Q), ← meet_assoc]
 
 /-! # Working with entailment -/
 
-/-- `⊤ ⊑ (P ⇨ Q)` iff `P ⊑ Q`. Analogue of `entails_true_intro` for SPred. -/
+/-- `⊤ ⊑ (P ⇨ Q)` iff `P ⊑ Q`. -/
 @[simp] theorem top_le_himp_iff [Frame l] (P Q : l) :
     ((⊤ : l) ⊑ P ⇨ Q) ↔ (P ⊑ Q) :=
   ⟨fun h => rel_trans
     (le_meet _ _ _ (le_top _) rel_refl)
-    (rel_trans (and_mono_l h) imp_elim_l),
-   fun h => imp_intro (and_elim_r' h)⟩
+    (rel_trans (meet_mono_left h) himp_meet_le),
+   fun h => le_himp (meet_le_of_right_le h)⟩
 
-@[simp] theorem true_intro_simp : (Q ⊑ (⊤ : l)) ↔ True := iff_true_intro true_intro
+@[simp] theorem le_top_iff : (Q ⊑ (⊤ : l)) ↔ True := iff_true_intro (le_top _)
 
 /-! ## Pointwise unfoldings of `⊑` on function lattices
 
-Analogues of `Std.Do.SPred.entails_1`–`entails_5` for nested function-space
-CompleteLattices. Each is definitional via the function-space `PartialOrder` instance. -/
+Fixed-arity instances of `le_iff_forall_le` for nested function lattices, stated separately per
+arity so that `simp` and `grind` can apply them. Each is definitional via the function-space
+`PartialOrder` instance. -/
 
-@[simp] theorem entails_1 {σ : Type v} {P Q : σ → l} :
+@[simp] theorem le_iff_forall_le_1 {σ : Type v} {P Q : σ → l} :
     P ⊑ Q ↔ ∀ s, P s ⊑ Q s := Iff.rfl
-@[simp] theorem entails_2 {σ₁ σ₂ : Type v} {P Q : σ₁ → σ₂ → l} :
+@[simp] theorem le_iff_forall_le_2 {σ₁ σ₂ : Type v} {P Q : σ₁ → σ₂ → l} :
     P ⊑ Q ↔ ∀ s₁ s₂, P s₁ s₂ ⊑ Q s₁ s₂ := Iff.rfl
-@[simp] theorem entails_3 {σ₁ σ₂ σ₃ : Type v} {P Q : σ₁ → σ₂ → σ₃ → l} :
+@[simp] theorem le_iff_forall_le_3 {σ₁ σ₂ σ₃ : Type v} {P Q : σ₁ → σ₂ → σ₃ → l} :
     P ⊑ Q ↔ ∀ s₁ s₂ s₃, P s₁ s₂ s₃ ⊑ Q s₁ s₂ s₃ := Iff.rfl
-@[simp] theorem entails_4 {σ₁ σ₂ σ₃ σ₄ : Type v} {P Q : σ₁ → σ₂ → σ₃ → σ₄ → l} :
+@[simp] theorem le_iff_forall_le_4 {σ₁ σ₂ σ₃ σ₄ : Type v} {P Q : σ₁ → σ₂ → σ₃ → σ₄ → l} :
     P ⊑ Q ↔ ∀ s₁ s₂ s₃ s₄, P s₁ s₂ s₃ s₄ ⊑ Q s₁ s₂ s₃ s₄ := Iff.rfl
-@[simp] theorem entails_5 {σ₁ σ₂ σ₃ σ₄ σ₅ : Type v} {P Q : σ₁ → σ₂ → σ₃ → σ₄ → σ₅ → l} :
+@[simp] theorem le_iff_forall_le_5 {σ₁ σ₂ σ₃ σ₄ σ₅ : Type v} {P Q : σ₁ → σ₂ → σ₃ → σ₄ → σ₅ → l} :
     P ⊑ Q ↔ ∀ s₁ s₂ s₃ s₄ s₅, P s₁ s₂ s₃ s₄ s₅ ⊑ Q s₁ s₂ s₃ s₄ s₅ := Iff.rfl
 
 end Std.Internal.Do.CompleteLattice

--- a/src/Std/Internal/Do/PredTrans.lean
+++ b/src/Std/Internal/Do/PredTrans.lean
@@ -159,8 +159,8 @@ Definitions for pushing and lifting exception layers through predicate transform
 /-- Push an `Except ε α` result into separate normal and exception postconditions:
 `ok a` uses `post a`, and `error e` uses `epost.head e`. -/
 @[simp]
-abbrev EPost.cons.pushExcept {α : Type u} {ε : Type v} {Pred : Type w} {EPred : Type z}
-    (post : α → Pred) (epost : EPost.cons (ε → Pred) EPred) : Except ε α → Pred :=
+abbrev EPost.Cons.pushExcept {α : Type u} {ε : Type v} {Pred : Type w} {EPred : Type z}
+    (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) : Except ε α → Pred :=
   fun
   | .ok a => post a
   | .error e => epost.head e
@@ -171,14 +171,14 @@ Given a transformer over `Except ε α`, produces one over `α` with an addition
 exception postcondition for `ε`. The normal and error postconditions are combined
 via `pushExcept`. -/
 def PredTrans.pushExcept {α : Type u} {ε : Type v} {Pred : Type w} {EPred : Type z}
-    (x : PredTrans Pred EPred (Except ε α)) : PredTrans Pred (EPost.cons (ε → Pred) EPred) α :=
+    (x : PredTrans Pred EPred (Except ε α)) : PredTrans Pred (EPost.Cons (ε → Pred) EPred) α :=
   ⟨fun post epost => x.apply (epost.pushExcept post) epost.tail⟩
 
 /-- Push an `Option α` result into separate normal and none postconditions:
 `some a` uses `post a`, and `none` uses `epost.head`. -/
 @[simp]
-abbrev EPost.cons.pushOption {α : Type u} {Pred : Type u} {EPred : Type v}
-    (post : α → Pred) (epost : EPost.cons Pred EPred) : Option α → Pred :=
+abbrev EPost.Cons.pushOption {α : Type u} {Pred : Type u} {EPred : Type v}
+    (post : α → Pred) (epost : EPost.Cons Pred EPred) : Option α → Pred :=
   fun
   | .some a => post a
   | .none => epost.head
@@ -187,14 +187,14 @@ abbrev EPost.cons.pushOption {α : Type u} {Pred : Type u} {EPred : Type v}
 early termination. Given a transformer over `Option α`, produces one over `α` with an
 additional exception postcondition for the `none` case. -/
 def PredTrans.pushOption {α : Type u} {Pred : Type u} {EPred : Type v}
-    (x : PredTrans Pred EPred (Option α)) : PredTrans Pred (EPost.cons Pred EPred) α :=
+    (x : PredTrans Pred EPred (Option α)) : PredTrans Pred (EPost.Cons Pred EPred) α :=
   ⟨fun post epost => x.apply (epost.pushOption post) epost.tail⟩
 
 /-- Unfolding `pushOption` through `apply`. -/
 @[simp, grind =]
 theorem PredTrans.apply_pushOption {α : Type u} {Pred : Type u} {EPred : Type v}
     (x : PredTrans Pred EPred (Option α)) (post : α → Pred)
-    (epost : EPost.cons Pred EPred) :
+    (epost : EPost.Cons Pred EPred) :
     (PredTrans.pushOption x).apply post epost = x.apply (epost.pushOption post) epost.tail := rfl
 
 /-!
@@ -224,7 +224,7 @@ instance {σ : Type u} {Pred : Type v} {EPred : Type w} :
 
 /-- Lift a predicate transformer to one with an additional exception layer (high priority). -/
 instance (priority := high) {ε : Type u} {Pred : Type u} {EPred : Type u} :
-    MonadLift (PredTrans Pred EPred) (PredTrans Pred (EPost.cons (ε → Pred) EPred)) where
+    MonadLift (PredTrans Pred EPred) (PredTrans Pred (EPost.Cons (ε → Pred) EPred)) where
   monadLift x := ⟨fun post epost => x.apply post epost.tail⟩
 
 /-!
@@ -249,7 +249,7 @@ instance {σ : Type u} {Pred : Type v} {EPred : Type w} :
 /-- `MonadExceptOf` instance for the outermost exception layer:
 `throw` invokes the head exception postcondition, `tryCatch` intercepts it. -/
 instance {ε : Type u} {Pred : Type v} {EPred : Type w} :
-    MonadExceptOf ε (PredTrans Pred (EPost.cons (ε → Pred) EPred)) where
+    MonadExceptOf ε (PredTrans Pred (EPost.Cons (ε → Pred) EPred)) where
   throw e := ⟨fun _post epost => epost.head e⟩
   tryCatch x handle := ⟨fun post epost => x.apply post ⟨(fun e => (handle e).apply post epost), epost.tail⟩⟩
 
@@ -270,7 +270,7 @@ instance {ε : Type u} {Pred : Type v} {EPred : Type w} {σ : Type z}
 delegates to the inner instance, threading the extra exception postcondition. -/
 instance {ε : Type u} {Pred : Type v} {EPred : Type w} {ε' : Type u}
     [MonadExceptOf ε (PredTrans Pred EPred)] :
-    MonadExceptOf ε (PredTrans Pred (EPost.cons (ε' → Pred) EPred)) where
+    MonadExceptOf ε (PredTrans Pred (EPost.Cons (ε' → Pred) EPred)) where
   throw x := ⟨fun post epost => (throw (m := PredTrans Pred EPred) x).apply post epost.tail⟩
   tryCatch x handle := ⟨fun post epost =>
     (tryCatch (m := PredTrans Pred EPred)

--- a/src/Std/Internal/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Internal/Do/Triple/SpecLemmas.lean
@@ -104,12 +104,12 @@ theorem Spec.monadLift_ReaderT (x : m α) (post : α → ρ → Pred) :
   Triple.iff.mpr (by rw [WPMonad.monadLift_ReaderT_wp]; rfl)
 
 
-theorem Spec.monadLift_ExceptT (x : m α) (post : α → Pred) (epost : EPost.cons (ε → Pred) EPred) :
+theorem Spec.monadLift_ExceptT (x : m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (wp x post epost.tail) (MonadLift.monadLift x : ExceptT ε m α) post epost :=
   Triple.iff.mpr (WPMonad.monadLift_ExceptT_wp x post epost)
 
 
-theorem Spec.monadLift_OptionT (x : m α) (post : α → Pred) (epost : EPost.cons Pred EPred) :
+theorem Spec.monadLift_OptionT (x : m α) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (wp x post epost.tail) (MonadLift.monadLift x : OptionT m α) post epost :=
   Triple.iff.mpr (WPMonad.monadLift_OptionT_wp x)
 
@@ -143,14 +143,14 @@ theorem Spec.monadMap_ReaderT
 
 
 theorem Spec.monadMap_ExceptT
-    (f : ∀{β}, m β → m β) {α} (x : ExceptT ε m α) (post : α → Pred) (epost : EPost.cons (ε → Pred) EPred) :
+    (f : ∀{β}, m β → m β) {α} (x : ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (wp (f x.run) (epost.pushExcept post) epost.tail)
       (MonadFunctor.monadMap (m := m) f x : ExceptT ε m α) post epost :=
   Triple.iff.mpr (by rw [WPMonad.monadMap_ExceptT_wp])
 
 
 theorem Spec.monadMap_OptionT
-    (f : ∀{β}, m β → m β) {α} (x : OptionT m α) (post : α → Pred) (epost : EPost.cons Pred EPred) :
+    (f : ∀{β}, m β → m β) {α} (x : OptionT m α) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (wp (f x.run) (epost.pushOption post) epost.tail)
       (MonadFunctor.monadMap (m := m) f x : OptionT m α) post epost :=
   Triple.iff.mpr (by rw [WPMonad.monadMap_OptionT_wp])
@@ -180,14 +180,14 @@ theorem Spec.liftWith_ReaderT
 
 
 theorem Spec.liftWith_ExceptT
-    (f : (∀{β}, ExceptT ε m β → m (Except ε β)) → m α) (post : α → Pred) (epost : EPost.cons (ε → Pred) EPred) :
+    (f : (∀{β}, ExceptT ε m β → m (Except ε β)) → m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (wp (f (fun x => x.run)) post epost.tail)
       (MonadControl.liftWith (m:=m) f : ExceptT ε m α) post epost :=
   Triple.iff.mpr (by simp [WPMonad.liftWith_ExceptT_wp f]; apply WPMonad.wp_map'; ext; rfl)
 
 
 theorem Spec.liftWith_OptionT
-    (f : (∀{β}, OptionT m β → m (Option β)) → m α) (post : α → Pred) (epost : EPost.cons Pred EPred) :
+    (f : (∀{β}, OptionT m β → m (Option β)) → m α) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (wp (f (fun x => x.run)) post epost.tail)
       (MonadControl.liftWith (m:=m) f : OptionT m α) post epost :=
   Triple.iff.mpr (WPMonad.liftWith_OptionT_wp f)
@@ -205,13 +205,13 @@ theorem Spec.restoreM_ReaderT (x : m α) (post : α → ρ → Pred) :
   Triple.iff.mpr (by rw [WPMonad.restoreM_ReaderT_wp]; rfl)
 
 
-theorem Spec.restoreM_ExceptT (x : m (@Except.{u, u} ε α)) (post : α → Pred) (epost : EPost.cons (ε → Pred) EPred) :
+theorem Spec.restoreM_ExceptT (x : m (@Except.{u, u} ε α)) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (wp x (epost.pushExcept post) epost.tail)
       (MonadControl.restoreM (m:=m) x : ExceptT ε m α) post epost :=
   Triple.iff.mpr (by rw [WPMonad.restoreM_ExceptT_wp])
 
 
-theorem Spec.restoreM_OptionT (x : m (Option α)) (post : α → Pred) (epost : EPost.cons Pred EPred) :
+theorem Spec.restoreM_OptionT (x : m (Option α)) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (wp x (epost.pushOption post) epost.tail)
       (MonadControl.restoreM (m:=m) x : OptionT m α) post epost :=
   Triple.iff.mpr (by rw [WPMonad.restoreM_OptionT_wp])
@@ -306,7 +306,7 @@ theorem Spec.UnfoldLift.withReader [MonadFunctor m n] [MonadWithReaderOf ρ m] (
 /-! # `ExceptT` -/
 
 
-theorem Spec.run_ExceptT (x : ExceptT ε m α) (post : α → Pred) (epost : EPost.cons (ε → Pred) EPred) :
+theorem Spec.run_ExceptT (x : ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (wp x post epost)
       (x.run : m (@Except.{u, u} ε α))
       (epost.pushExcept post)
@@ -314,27 +314,27 @@ theorem Spec.run_ExceptT (x : ExceptT ε m α) (post : α → Pred) (epost : EPo
   Triple.iff.mpr (by simp [PartialOrder.rel_refl])
 
 
-theorem Spec.throw_ExceptT (err : ε) (post : α → Pred) (epost : EPost.cons (ε → Pred) EPred) :
+theorem Spec.throw_ExceptT (err : ε) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (epost.head err) (MonadExceptOf.throw err : ExceptT ε m α) post epost :=
-  Triple.iff.mpr (by simpa [EPost.cons.pushExcept] using!
+  Triple.iff.mpr (by simpa [EPost.Cons.pushExcept] using!
     (WPMonad.wp_pure (m := m) (x := Except.error err)
       (post := epost.pushExcept post)
       (epost := epost.tail)))
 
 
-theorem Spec.tryCatch_ExceptT (x : ExceptT ε m α) (h : ε → ExceptT ε m α) (post : α → Pred) (epost : EPost.cons (ε → Pred) EPred) :
+theorem Spec.tryCatch_ExceptT (x : ExceptT ε m α) (h : ε → ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (wp x post ⟨fun e => wp (h e) post epost, epost.tail⟩)
       (MonadExceptOf.tryCatch x h : ExceptT ε m α) post epost :=
   Triple.iff.mpr (WPMonad.tryCatch_ExceptT_wp x h)
 
 
-theorem Spec.orElse_ExceptT (x : ExceptT ε m α) (h : Unit → ExceptT ε m α) (post : α → Pred) (epost : EPost.cons (ε → Pred) EPred) :
+theorem Spec.orElse_ExceptT (x : ExceptT ε m α) (h : Unit → ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (wp x post ⟨fun _ => wp (h ()) post epost, epost.tail⟩)
       (OrElse.orElse x h : ExceptT ε m α) post epost :=
   Triple.iff.mpr (WPMonad.orElse_ExceptT_wp x h)
 
 
-theorem Spec.adapt_ExceptT (f : ε → ε') (x : ExceptT ε m α) (post : α → Pred) (epost : EPost.cons (ε' → Pred) EPred) :
+theorem Spec.adapt_ExceptT (f : ε → ε') (x : ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε' → Pred) EPred) :
     Triple (wp x post ⟨fun e => epost.head (f e), epost.tail⟩)
       (ExceptT.adapt f x : ExceptT ε' m α) post epost :=
   Triple.iff.mpr (WPMonad.adapt_ExceptT_wp f x)
@@ -361,7 +361,7 @@ theorem Spec.orElse_Except (x : Except ε α) (h : Unit → Except ε α) :
 /-! # `OptionT` -/
 
 
-theorem Spec.run_OptionT (x : OptionT m α) (post : α → Pred) (epost : EPost.cons Pred EPred) :
+theorem Spec.run_OptionT (x : OptionT m α) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (wp x post epost)
       (x.run : m (Option α))
       (epost.pushOption post)
@@ -369,18 +369,18 @@ theorem Spec.run_OptionT (x : OptionT m α) (post : α → Pred) (epost : EPost.
   Triple.iff.mpr (by rw [← OptionT.apply_wp])
 
 
-theorem Spec.throw_OptionT (err : PUnit) (post : α → Pred) (epost : EPost.cons Pred EPred) :
+theorem Spec.throw_OptionT (err : PUnit) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple epost.head (MonadExceptOf.throw err : OptionT m α) post epost :=
   Triple.iff.mpr (WPMonad.throw_OptionT_wp err)
 
 
-theorem Spec.tryCatch_OptionT (x : OptionT m α) (h : PUnit → OptionT m α) (post : α → Pred) (epost : EPost.cons Pred EPred) :
+theorem Spec.tryCatch_OptionT (x : OptionT m α) (h : PUnit → OptionT m α) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (wp x post ⟨wp (h ⟨⟩) post epost, epost.tail⟩)
       (MonadExceptOf.tryCatch x h : OptionT m α) post epost :=
   Triple.iff.mpr (WPMonad.tryCatch_OptionT_wp x h)
 
 
-theorem Spec.orElse_OptionT (x : OptionT m α) (h : Unit → OptionT m α) (post : α → Pred) (epost : EPost.cons Pred EPred) :
+theorem Spec.orElse_OptionT (x : OptionT m α) (h : Unit → OptionT m α) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (wp x post ⟨wp (h ()) post epost, epost.tail⟩)
       (OrElse.orElse x h : OptionT m α) post epost :=
   Triple.iff.mpr (WPMonad.orElse_OptionT_wp x h)
@@ -479,14 +479,14 @@ theorem Spec.throw_StateT [MonadExceptOf ε m] (err : ε) (post : α → σ → 
   Triple.iff.mpr (by rw [WPMonad.throw_StateT_lift_wp]; rfl)
 
 
-theorem Spec.throw_ExceptT_lift [MonadExceptOf ε m] (err : ε) (post : α → Pred) (epost : EPost.cons (ε' → Pred) EPred) :
+theorem Spec.throw_ExceptT_lift [MonadExceptOf ε m] (err : ε) (post : α → Pred) (epost : EPost.Cons (ε' → Pred) EPred) :
     Triple (wp (MonadExceptOf.throw (ε:=ε) err : m (@Except.{u, u} ε' α))
         (fun r => match r with | .ok a => post a | .error e => epost.head e) epost.tail)
       (MonadExceptOf.throw (ε:=ε) err : ExceptT ε' m α) post epost :=
   Triple.iff.mpr (by rw [WPMonad.throw_lift_ExceptT_wp]; apply WPMonad.wp_consequence; intro r; cases r <;> rfl)
 
 
-theorem Spec.throw_Option_lift [MonadExceptOf ε m] (err : ε) (post : α → Pred) (epost : EPost.cons Pred EPred) :
+theorem Spec.throw_Option_lift [MonadExceptOf ε m] (err : ε) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (wp (MonadExceptOf.throw (ε:=ε) err : m (Option α))
         (epost.pushOption post) epost.tail)
       (MonadExceptOf.throw (ε:=ε) err : OptionT m α) post epost :=
@@ -510,7 +510,7 @@ theorem Spec.tryCatch_StateT [MonadExceptOf ε m] (x : StateT σ m α) (h : ε �
 
 
 theorem Spec.tryCatch_ExceptT_lift [MonadExceptOf ε m] (x : ExceptT ε' m α) (h : ε → ExceptT ε' m α)
-    (post : α → Pred) (epost : EPost.cons (ε' → Pred) EPred) :
+    (post : α → Pred) (epost : EPost.Cons (ε' → Pred) EPred) :
     Triple (wp (MonadExceptOf.tryCatch (ε:=ε) x h : m (@Except.{u, u} ε' α))
         (fun | .ok a => post a | .error e => epost.head e) epost.tail)
       (MonadExceptOf.tryCatch (ε:=ε) x h : ExceptT ε' m α) post epost :=
@@ -518,7 +518,7 @@ theorem Spec.tryCatch_ExceptT_lift [MonadExceptOf ε m] (x : ExceptT ε' m α) (
 
 
 theorem Spec.tryCatch_OptionT_lift [MonadExceptOf ε m] (x : OptionT m α) (h : ε → OptionT m α)
-    (post : α → Pred) (epost : EPost.cons Pred EPred) :
+    (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (wp (MonadExceptOf.tryCatch (ε:=ε) x h : m (Option α))
         (epost.pushOption post) epost.tail)
       (MonadExceptOf.tryCatch (ε:=ε) x h : OptionT m α) post epost :=

--- a/src/Std/Internal/Do/WP/Basic.lean
+++ b/src/Std/Internal/Do/WP/Basic.lean
@@ -33,9 +33,9 @@ and `Assertion EPred` for exception postconditions.
 
 ## Pre-defined instances
 
-* `WPMonad Id Prop EPost.nil` — pure computations.
+* `WPMonad Id Prop EPost.Nil` — pure computations.
 * `WPMonad (StateT σ m) (σ → Pred) EPred` — stateful computations.
-* `WPMonad (ExceptT ε m) Pred (EPost.cons (ε → Pred) EPred)` — computations with exceptions.
+* `WPMonad (ExceptT ε m) Pred (EPost.Cons (ε → Pred) EPred)` — computations with exceptions.
 * `WPMonad (ReaderT ρ m) (ρ → Pred) EPred` — reader computations.
 * `WPMonad (Except ε) Prop EPost⟨ε → Prop⟩` — concrete exception type.
 * `WPMonad (EStateM ε σ) (σ → Prop) (ε → σ → Prop)` — concrete error-state monad.
@@ -117,19 +117,19 @@ theorem wp_econs_bot (x : m α)
     wp x post ⊥ ⊑ wp x post epost := by
   solve_by_elim [wp_econs, bot_le]
 
-theorem wp_consequence_rel (x : m α)
+theorem wp_consequence_le (x : m α)
   (post post' : α → Pred) (epost : EPred) (h : post ⊑ post') {pre : Pred}
     (h' : pre ⊑ wp x post epost) :
     pre ⊑ wp x post' epost :=
   PartialOrder.rel_trans h' (wp_consequence x post post' epost h)
 
-theorem wp_econs_rel (x : m α)
+theorem wp_econs_le (x : m α)
   (post : α → Pred) (epost epost' : EPred) (h : epost ⊑ epost') {pre : Pred}
     (h' : pre ⊑ wp x post epost) :
     pre ⊑ wp x post epost' :=
   PartialOrder.rel_trans h' (wp_econs x post epost epost' h)
 
-theorem wp_econs_bot_rel (x : m α)
+theorem wp_econs_bot_le (x : m α)
   (post : α → Pred) (epost : EPred) {pre : Pred} (h : pre ⊑ wp x post ⊥) :
     pre ⊑ wp x post epost :=
   PartialOrder.rel_trans h (wp_econs_bot x post epost)
@@ -177,7 +177,7 @@ end WPMonad
 -/
 
 /-- `Id` is a WPMonad with `Prop` assertions and no exceptions. -/
-instance Id.instWPMonad : WPMonad Id.{u} Prop EPost.nil where
+instance Id.instWPMonad : WPMonad Id.{u} Prop EPost.Nil where
   wpTrans x := ⟨fun post _epost => post x⟩
   wp_trans_pure _x := PartialOrder.rel_refl
   wp_trans_bind _x _f := PartialOrder.rel_refl
@@ -186,13 +186,13 @@ instance Id.instWPMonad : WPMonad Id.{u} Prop EPost.nil where
 @[simp, grind =]
 theorem PredTrans.apply_pushExcept {α ε Pred EPred}
     (x : PredTrans Pred EPred (Except ε α)) (post : α → Pred)
-    (epost : EPost.cons (ε → Pred) EPred) :
+    (epost : EPost.Cons (ε → Pred) EPred) :
     (PredTrans.pushExcept x).apply post epost = x.apply (epost.pushExcept post) epost.tail := rfl
 
 /-- `ExceptT` lifts a `WPMonad` instance by adding an exception postcondition layer. -/
 instance ExceptT.instWPMonad {Pred : Type v}
   [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
-    WPMonad (ExceptT ε m) Pred (EPost.cons (ε → Pred) EPred) where
+    WPMonad (ExceptT ε m) Pred (EPost.Cons (ε → Pred) EPred) where
   wpTrans x := PredTrans.pushExcept (WPMonad.wpTrans x.run)
   wp_trans_pure x := fun post epost =>
     WPMonad.wp_pure (m := m) (Except.ok x) (epost.pushExcept post) epost.tail
@@ -221,13 +221,13 @@ instance ExceptT.instWPMonad {Pred : Type v}
 @[simp, grind =]
 theorem ExceptT.apply_wp {α ε Pred EPred}
   [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] (x : ExceptT ε m α)
-  (post : α → Pred) (epost : EPost.cons (ε → Pred) EPred) :
+  (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     wp x post epost = wp x.run (epost.pushExcept post) epost.tail := rfl
 
 /-- `OptionT` lifts a `WPMonad` instance by adding a `PUnit` exception postcondition layer. -/
 instance OptionT.instWPMonad {Pred : Type u}
   [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
-    WPMonad (OptionT m) Pred (EPost.cons Pred EPred) where
+    WPMonad (OptionT m) Pred (EPost.Cons Pred EPred) where
   wpTrans x := PredTrans.pushOption (WPMonad.wpTrans x.run)
   wp_trans_pure x := fun post epost =>
     WPMonad.wp_pure (m := m) (some x) (epost.pushOption post) epost.tail
@@ -252,7 +252,7 @@ instance OptionT.instWPMonad {Pred : Type u}
 @[simp, grind =]
 theorem OptionT.apply_wp {α : Type u} {Pred : Type u} {EPred}
   [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] (x : OptionT m α)
-  (post : α → Pred) (epost : EPost.cons Pred EPred) :
+  (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     wp x post epost = wp x.run (epost.pushOption post) epost.tail := rfl
 
 /-- `StateT` lifts a `WPMonad` instance by adding a state argument. -/
@@ -361,7 +361,7 @@ if `wp prog ...` holds, then a property `P` holds of the program's result.
 /-- Soundness for `Id`: if `wp prog P` holds, then `P` holds of the result. -/
 theorem Id.of_wp_run_eq {α : Type u} {x : α} {prog : Id α}
   (h : Id.run prog = x) (P : α → Prop)
-  (hwp : wp prog P EPost.nil.mk) : P x := by
+  (hwp : wp prog P EPost.Nil.mk) : P x := by
   rw [← h]
   exact hwp
 
@@ -377,21 +377,21 @@ theorem Option.of_wp_eq {α : Type u} {x prog : Option α}
 /-- Soundness for `StateM`: if `wp prog P s` holds, then `P` holds of `(prog.run s)`. -/
 theorem StateM.of_wp_run_eq {x : α × σ} {prog : StateM σ α} {s : σ}
   (h : StateT.run prog s = x) (P : α × σ → Prop)
-  (hwp : wp prog (fun a s' => P (a, s')) EPost.nil.mk s) : P x := by
+  (hwp : wp prog (fun a s' => P (a, s')) EPost.Nil.mk s) : P x := by
   rw [← h]
   exact hwp
 
 /-- Soundness for `StateM` (discarding final state). -/
 theorem StateM.of_wp_run'_eq {α σ : Type} {x : α} {prog : StateM σ α} {s : σ}
   (h : StateT.run' prog s = x) (P : α → Prop)
-  (hwp : wp prog (fun a _ => P a) EPost.nil.mk s) : P x := by
+  (hwp : wp prog (fun a _ => P a) EPost.Nil.mk s) : P x := by
   rw [← h]
   exact hwp
 
 /-- Soundness for `ReaderM`: if `wp prog P r` holds, then `P` holds of `(prog.run r)`. -/
 theorem ReaderM.of_wp_run_eq {α ρ : Type} {x : α} {prog : ReaderM ρ α} {r : ρ}
   (h : ReaderT.run prog r = x) (P : α → Prop)
-  (hwp : wp prog (fun a _ => P a) EPost.nil.mk r) : P x := by
+  (hwp : wp prog (fun a _ => P a) EPost.Nil.mk r) : P x := by
   rw [← h]
   exact hwp
 

--- a/src/Std/Internal/Do/WP/Lemmas.lean
+++ b/src/Std/Internal/Do/WP/Lemmas.lean
@@ -122,7 +122,7 @@ theorem throw_Except_wp (e : ε) :
 
 theorem throw_ExceptT_wp (err : ε) :
     epost.head err ⊑ wp (MonadExceptOf.throw err : ExceptT ε m α) post epost := by
-  simpa [MonadExceptOf.throw, EPost.cons.pushExcept] using
+  simpa [MonadExceptOf.throw, EPost.Cons.pushExcept] using
     (WPMonad.wp_pure (m := m) (x := Except.error err)
       (post := epost.pushExcept post) (epost := epost.tail))
 
@@ -141,7 +141,7 @@ theorem throw_Option_wp (e : PUnit) :
 theorem throw_OptionT_wp (err : PUnit) :
   epost.head ⊑ wp (MonadExceptOf.throw err : OptionT m α) post epost := by
   show epost.head ⊑ wp (pure none : m (Option α)) (epost.pushOption post) epost.tail
-  simpa [MonadExceptOf.throw, EPost.cons.pushOption] using
+  simpa [MonadExceptOf.throw, EPost.Cons.pushOption] using
     (WPMonad.wp_pure (m := m) (x := none)
       (post := epost.pushOption post) (epost := epost.tail))
 
@@ -217,7 +217,7 @@ theorem tryCatch_OptionT_wp (x : OptionT m α)
   apply WPMonad.wp_consequence (m := m); intro o; cases o with
   | some a =>
     apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_pure
-    simp [EPost.cons.pushOption]; exact PartialOrder.rel_refl
+    simp [EPost.Cons.pushOption]; exact PartialOrder.rel_refl
   | none => exact PartialOrder.rel_refl
 
 /-! ## Additional state operation lemmas -/
@@ -290,7 +290,7 @@ theorem monadLift_ReaderT_wp (x : m α) :
   rfl
 
 theorem monadLift_ExceptT_wp (x : m α) (post : α → Pred)
-    (epost : EPost.cons (ε → Pred) EPred) :
+    (epost : EPost.Cons (ε → Pred) EPred) :
     wp x post epost.tail ⊑
       wp (MonadLift.monadLift x : ExceptT ε m α) post epost := by
   simp only [wp, MonadLift.monadLift, ExceptT.lift, ExceptT.mk]
@@ -318,12 +318,12 @@ theorem monadLift_OptionT_wp (x : m α) :
   apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_bind
   apply WPMonad.wp_consequence (m := m); intro a
   apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_pure
-  simp [EPost.cons.pushOption]; exact PartialOrder.rel_refl
+  simp [EPost.Cons.pushOption]; exact PartialOrder.rel_refl
 
 omit [Assertion EPred] [WPMonad m Pred EPred] in
 @[simp]
 theorem lift_OptionT_wp
-    [Assertion (EPost.cons Pred EPred)] [WPMonad (OptionT m) Pred (EPost.cons Pred EPred)] (x : m α) :
+    [Assertion (EPost.Cons Pred EPred)] [WPMonad (OptionT m) Pred (EPost.Cons Pred EPred)] (x : m α) :
     wp (OptionT.lift x : OptionT m α) post epost =
       wp (MonadLift.monadLift x : OptionT m α) post epost := rfl
 
@@ -348,14 +348,14 @@ theorem monadMap_ReaderT_wp
 @[simp]
 theorem monadMap_ExceptT_wp
     (f : ∀{β}, m β → m β) {α} (x : ExceptT ε m α) (post : α → Pred)
-    (epost : EPost.cons (ε → Pred) EPred) :
+    (epost : EPost.Cons (ε → Pred) EPred) :
     wp (MonadFunctor.monadMap (m:=m) f x : ExceptT ε m α) post epost =
       wp (f x.run) (epost.pushExcept post) epost.tail := by
   simp [MonadFunctor.monadMap, ExceptT.run]
 
 @[simp]
 theorem monadMap_OptionT_wp
-  (f : ∀{β}, m β → m β) {α} (x : OptionT m α) (post : α → Pred) (epost : EPost.cons Pred EPred) :
+  (f : ∀{β}, m β → m β) {α} (x : OptionT m α) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
   wp (MonadFunctor.monadMap (m:=m) f x : OptionT m α) post epost =
     wp (f x.run) (epost.pushOption post) epost.tail := by
   simp only [wp, MonadFunctor.monadMap, OptionT.run]; rfl
@@ -679,7 +679,7 @@ theorem orElse_OptionT_wp (x : OptionT m α)
   apply WPMonad.wp_consequence (m := m); intro o; cases o with
   | some a =>
     apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_pure
-    simp [EPost.cons.pushOption]; exact PartialOrder.rel_refl
+    simp [EPost.Cons.pushOption]; exact PartialOrder.rel_refl
   | none => exact PartialOrder.rel_refl
 
 end


### PR DESCRIPTION
This PR renames the `Std.Internal.Do` exception-postcondition types `EPost.nil`/`EPost.cons` to UpperCamelCase `EPost.Nil`/`EPost.Cons`, gives their order lemmas `le`-based names (`Cons.le_head`, `Cons.mk_le`, `Nil.le`, and so on), renames the `wp_*_rel` lemmas to `wp_*_le` for forward compatibility with the standard `LE.le`, and drops the speculative `@[grind .]` ematch annotations on the order and exception-postcondition lemmas. It is a naming and attribute cleanup of the #12965 declarations with no other change.

It also renames the derived `CompleteLattice` laws in `Std.Internal.Do.Order.Lemmas` to the type-derived style of `doc/std/naming.md`: the propositional-logic vocabulary (`and_*`/`or_*`/`imp_*`/`pure_*`) becomes lattice vocabulary (`meet_*`/`join_*`/`himp_*`/`ofProp_*`), intro/elim rules are named after their conclusions (`le_meet_left`, `meet_le_of_le_himp`, and so on), `true_intro`/`false_elim` are removed in favor of `le_top`/`bot_le`, `pure_true` is strengthened to `ofProp_eq_top : ⌜φ⌝ = ⊤`, and the fixed-arity pointwise-entailment simp lemmas become `le_iff_forall_le_1` through `le_iff_forall_le_5`.