### PR TITLE
chore: hard-code a specific bit pattern for normalized quiet NaN

### DIFF
--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -1890,20 +1890,20 @@ extern "C" LEAN_EXPORT obj_res lean_float_frexp(double a) {
 extern "C" LEAN_EXPORT double lean_float_of_bits(uint64_t u)
 {
     static_assert(sizeof(double) == sizeof(u), "`double` unexpected size.");
-    double ret;
-    std::memcpy(&ret, &u, sizeof(double));
-    if (isnan(ret))
-        ret = std::numeric_limits<double>::quiet_NaN();
+    double ret = std::bit_cast<double>(u);
+    if (isnan(ret)) return std::numeric_limits<double>::quiet_NaN();
     return ret;
 }
 
+// We use a specific bit pattern instead of `std::numeric_limits<double>::quiet_NaN()` because
+// the returned bit pattern needs to match exactly with what we return in the logical model and
+// the exact value of `quiet_NaN` is implementation-defined.
+constexpr uint64_t quietNaN64 = 0x7ff8000000000000;
+
 extern "C" LEAN_EXPORT uint64_t lean_float_to_bits(double d)
 {
-    uint64_t ret;
-    if (isnan(d))
-        d = std::numeric_limits<double>::quiet_NaN();
-    std::memcpy(&ret, &d, sizeof(double));
-    return ret;
+    if (isnan(d)) return quietNaN64;
+    return std::bit_cast<uint64_t>(d);
 }
 
 // =======================================
@@ -1942,20 +1942,20 @@ extern "C" LEAN_EXPORT obj_res lean_float32_frexp(float a) {
 extern "C" LEAN_EXPORT float lean_float32_of_bits(uint32_t u)
 {
     static_assert(sizeof(float) == sizeof(u), "`float` unexpected size.");
-    float ret;
-    std::memcpy(&ret, &u, sizeof(float));
-    if (isnan(ret))
-        ret = std::numeric_limits<float>::quiet_NaN();
+    float ret = std::bit_cast<float>(u);
+    if (isnan(ret)) ret = std::numeric_limits<float>::quiet_NaN();
     return ret;
 }
 
+// We use a specific bit pattern instead of `std::numeric_limits<float>::quiet_NaN()` because
+// the returned bit pattern needs to match exactly with what we return in the logical model and
+// the exact value of `quiet_NaN` is implementation-defined.
+constexpr uint32_t quietNaN32 = 0x7fc00000;
+
 extern "C" LEAN_EXPORT uint32_t lean_float32_to_bits(float d)
 {
-    uint32_t ret;
-    if (isnan(d))
-        d = std::numeric_limits<float>::quiet_NaN();
-    std::memcpy(&ret, &d, sizeof(float));
-    return ret;
+    if (isnan(d)) return quietNaN32;
+    return std::bit_cast<uint32_t>(d);
 }
 
 // =======================================

--- a/tests/elab/floatBits.lean
+++ b/tests/elab/floatBits.lean
@@ -1,3 +1,8 @@
+/-!
+Tests for `Float.toBits`/`Float.ofBits` and `Float32.toBits`/`Float32.ofBits`,
+including NaN normalization to the quiet NaN bit pattern.
+-/
+
 def d : Float := 1.245
 
 /--
@@ -47,3 +52,53 @@ info: 9221120237041090560
 -- Should also produce quiet_NaN
 #guard_msgs in
 #eval (-(1.0/0.0 - 1.0/0.0)).toBits
+
+def f : Float32 := 1.245
+
+/--
+info: 1067408425
+-/
+#guard_msgs in
+#eval f.toBits
+
+/--
+info: true
+-/
+#guard_msgs in
+#eval Float32.ofBits f.toBits == f
+
+/--
+info: NaN
+-/
+#guard_msgs in
+#eval Float32.ofBits 2143289344
+/--
+info: NaN
+-/
+#guard_msgs in
+#eval Float32.ofBits 4290772992
+
+/--
+info: 2143289344
+-/
+#guard_msgs in
+#eval (Float32.ofBits 2143289344).toBits
+
+/--
+info: 2143289344
+-/
+#guard_msgs in
+#eval (Float32.ofBits 4290772992).toBits
+
+/--
+info: 2143289344
+-/
+#guard_msgs in
+#eval ((1.0 : Float32)/0.0 - 1.0/0.0).toBits
+
+/--
+info: 2143289344
+-/
+-- Should also produce quiet_NaN
+#guard_msgs in
+#eval (-((1.0 : Float32)/0.0 - 1.0/0.0)).toBits


### PR DESCRIPTION
This PR changes the normalization procedure for NaN in `lean_float_to_bits` to return a specific hard-coded bit pattern instead of `std::numeric_limits<double>::quiet_NaN()`.

This is because the value of `quiet_NaN` is implementation-defined, which makes it unsuitable if we want to give a logical model to `Float`.

This actually changes nothing, because we already had a test that effectively asserted that `quiet_NaN` always returns the exact bit pattern that is now hard-coded.