### PR TITLE
doc: fix typo in Format.nest example

### DIFF
--- a/src/Init/Data/Format/Basic.lean
+++ b/src/Init/Data/Format/Basic.lean
@@ -90,7 +90,7 @@ inductive Format where
   ```lean example
   open Std Format in
   def fmtList (l : List Format) : Format :=
-    let f := joinSep l  (", " ++ Format.line)
+    let f := joinSep l  ("," ++ Format.line)
     group (nest 1 <| "[" ++ f ++ "]")
   ```
 


### PR DESCRIPTION
This PR fixes the example in the documentation of `Format.nest`. The documentation says that "the formatter will put in linebreaks after the commas", but before this PR it will put line breaks after the space following the commas. This seems like a typo in the example.