### PR TITLE
feat: port the mvcgen' tactic to the new Std.Internal.Do meta theory

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen.lean
@@ -10,6 +10,7 @@ public import Lean.Elab.Tactic.Do.Internal.VCGen.Reduce
 public import Lean.Elab.Tactic.Do.Internal.VCGen.SpecDB
 public import Lean.Elab.Tactic.Do.Internal.VCGen.RuleConstruction
 public import Lean.Elab.Tactic.Do.Internal.VCGen.Context
+public import Lean.Elab.Tactic.Do.Internal.VCGen.EPost
 public import Lean.Elab.Tactic.Do.Internal.VCGen.Util
 public import Lean.Elab.Tactic.Do.Internal.VCGen.RuleCache
 public import Lean.Elab.Tactic.Do.Internal.VCGen.Entails
@@ -21,12 +22,13 @@ public import Lean.Elab.Tactic.Do.Internal.VCGen.Frontend
 The `mvcgen'` tactic, split across the modules above.
 
 - `VCGen.Reduce` — SymM head-redex reducer.
-- `VCGen.SpecDB` — `SpecTheoremNew`/`SpecTheoremsNew` + database operations.
+- `VCGen.SpecDB` — `SpecTheorem` instantiation, simp-side migration, and `findSpecs` lookup.
 - `VCGen.RuleConstruction` — SymM rule constructors from spec/simp/split info.
 - `VCGen.Context` — `VCGenM`, its `Context`/`State`, the bundle of pre-built rules.
-- `VCGen.Util` — generic VCGenM helpers (`introsSimp`, `repeatAndRfl`, app builders).
+- `VCGen.EPost` — exception-postcondition decomposition helpers.
+- `VCGen.Util` — generic VCGenM helpers (`introsHygienic`, `simpGoalTelescope`, `solveTrivialConjuncts`).
 - `VCGen.RuleCache` — VCGenM cache wrappers around the SymM rule constructors.
-- `VCGen.Entails` — entailment-shaped goal decomposition (`solveSPredEntails` etc.).
+- `VCGen.Entails` — entailment-shaped goal decomposition (Triple unfolding, state/precondition intro, EPost and lattice steps).
 - `VCGen.Solve` — the main `solve` step / `SolveResult`.
 - `VCGen.Driver` — the worklist driver (`work`, `emitVC`, `main`, `Result`).
 - `VCGen.Frontend` — the `mvcgen'` syntax + tactic elaborator + `mkSpecContext`.

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
@@ -14,8 +14,7 @@ public import Lean.Meta.Sym.Simp.SimpM
 public import Lean.Meta.Tactic.Grind.Types
 
 open Lean Meta Elab Tactic Sym
-open Lean.Elab.Tactic.Do Lean.Elab.Tactic.Do.SpecAttr
-open Std.Do
+open Lean.Elab.Tactic.Do Lean.Elab.Tactic.Do.Internal.SpecAttr
 
 namespace Lean.Elab.Tactic.Do.Internal
 
@@ -45,48 +44,69 @@ public def UntilPatternThunk.force (ref : IO.Ref UntilPatternThunk) (m : Expr) :
     ref.set (.elaborated pat)
     return pat
 
+/--
+Common metadata for a goal whose right-hand side is a weakest-precondition application
+`pre ⊑ wp m Pred EPred monadInst instAL instEAL instWP α prog post epost s₁ ... sₙ`.
+-/
+public structure VCGen.WPInfo where
+  /-- The `wp` function head, separated from its explicit core arguments. -/
+  head : Expr
+  /-- The ordered core arguments of the `wp` application:
+  `#[m, Pred, EPred, monadInst, instAL, instEAL, instWP, α, prog, post, epost]`. -/
+  args : Array Expr
+  /-- Extra arguments applied after `wp … prog post epost`, usually concrete state arguments. -/
+  excessArgs : Array Expr
+
+namespace VCGen.WPInfo
+
+/-- Monad type constructor argument of `wp`. -/
+public def m (info : WPInfo) : Expr := info.args[0]!
+/-- Predicate/lattice type argument of `wp`. -/
+public def Pred (info : WPInfo) : Expr := info.args[1]!
+/-- Exception postcondition type argument of `wp`. -/
+public def EPred (info : WPInfo) : Expr := info.args[2]!
+/-- `WPMonad` instance argument of `wp`. -/
+public def instWP (info : WPInfo) : Expr := info.args[6]!
+/-- Program expression classified by VCGen. -/
+public def prog (info : WPInfo) : Expr := info.args[8]!
+
+end VCGen.WPInfo
+
+/-- Pre-built backward rules for the introduction steps of `solve`. -/
+public structure VCGen.IntroRules where
+  /-- The backward rule for `Triple.intro`. Unfolds `⦃P⦄ x ⦃Q; E⦄` into `P ⊑ wp x Q E`. -/
+  tripleIntro : BackwardRule
+  /-- The backward rule for `Lean.Order.le_of_forall_le`. Peels one excess state argument
+  from a function-lattice entailment. -/
+  stateArgIntro : BackwardRule
+  /-- The backward rule for `Lean.Order.top_le_of_forall_top_le`. Peels one excess state
+  argument when the precondition is `⊤`. -/
+  topStateArgIntro : BackwardRule
+  /-- The backward rule for `Lean.Order.le_of_imp_top_le`. Introduces a bare pure
+  precondition on the `Prop` lattice. -/
+  propPreIntro : BackwardRule
+  /-- The backward rule for `Lean.Order.ofProp_le`. Introduces an embedded pure
+  precondition `⌜p⌝` on any complete lattice. -/
+  ofPropPreIntro : BackwardRule
+  /-- The backward rule for `Lean.Order.true_le_of_top_le`. Replaces a `True` precondition
+  with `⊤` on the `Prop` lattice. -/
+  truePreIntro : BackwardRule
+
 public structure VCGen.Context where
-  /-- The backward rule for `SPred.entails_cons_intro`. -/
-  entailsConsIntroRule : BackwardRule
-  /-- The backward rule for `SPred.entails_nil_pure_intro`. Preferred over `entails_nil_intro`
-  when the LHS is `⌜φ⌝`, as it unwraps `.down` on the pure assertion. -/
-  entailsNilPureIntroRule : BackwardRule
-  /-- The backward rule for `SPred.entails_nil_intro`. Fallback when LHS is not `⌜φ⌝`. -/
-  entailsNilIntroRule : BackwardRule
-  /-- The backward rule for `SPred.apply_pure_cons_entails_l`. Peels a state arg from
-  `SPred.pure (σ::σs) φ s` on the LHS of an entailment. -/
-  applyPureConsEntailsLRule : BackwardRule
-  /-- The backward rule for `SPred.apply_pure_cons_entails_r`. Peels a state arg from
-  `SPred.pure (σ::σs) φ s` on the RHS of an entailment. -/
-  applyPureConsEntailsRRule : BackwardRule
-  /-- The backward rule for `SPred.down_pure_intro`. Reduces a target of the form
-  `(SPred.pure [] φ).down` to `φ`. -/
-  downPureIntroRule : BackwardRule
-  /-- The backward rule for `SPred.pure_elim'`. -/
-  pureElimRule : BackwardRule
-  /-- The backward rule for `SPred.pure_intro`. -/
-  pureIntroRule : BackwardRule
-  /-- The backward rule for `PostCond.entails.rfl`. Tried first to close by reflexivity. -/
-  postCondEntailsRflRule : BackwardRule
-  /-- The backward rule for `PostCond.entails.mk`. -/
-  postCondEntailsMkRule : BackwardRule
-  /-- The backward rule for `ExceptConds.entails.rfl`. -/
-  exceptCondsEntailsRflRule : BackwardRule
-  /-- The backward rule for `ExceptConds.entails.pure`. Closes the exception side for
-  pure PostShapes, where `ExceptConds.entails` reduces to `True`. -/
-  exceptCondsEntailsPureRule : BackwardRule
-  /-- The backward rule for `ExceptConds.entails_false`. -/
-  exceptCondsEntailsFalseRule : BackwardRule
-  /-- The backward rule for `ExceptConds.entails_true`. -/
-  exceptCondsEntailsTrueRule : BackwardRule
-  /-- The backward rule for `Triple.of_entails_wp`. -/
-  tripleOfEntailsWPRule : BackwardRule
+  /-- Pre-built backward rules for the introduction steps of `solve`. -/
+  introRules : VCGen.IntroRules
+  /-- The backward rule for `Lean.Order.top_le_prop`. Strips a `(⊤ : Prop) ⊑ ·` wrapper
+  from a VC before it is emitted. -/
+  elimPreRule : BackwardRule
   /-- The backward rule for `And.intro`. -/
   andIntroRule : BackwardRule
+  /-- The backward rule for `Lean.Order.PartialOrder.rel_refl`. Closes a reflexive
+  entailment `pre ⊑ pre`. -/
+  reflRule : BackwardRule
   /-- User-customizable simp methods used to pre-simplify hypotheses. -/
   hypSimpMethods : Option Sym.Simp.Methods := none
   /-- The `trivial` config option: when `true` (default), `Driver.emitVC` runs
-  `repeatAndRfl` to collapse trivial `And.intro` chains; when `false`, the goal is
+  `solveTrivialConjuncts` to collapse trivial `And.intro` chains; when `false`, the goal is
   emitted as-is. -/
   trivial : Bool := true
   /-- The `jp` config option: when `true`, `tryLetIntro` recognises `__do_jp` lets
@@ -119,9 +139,12 @@ public structure VCGen.Context where
 
 public structure VCGen.Scope where
   /-- Spec database in scope: globals plus locals from in-scope hypotheses. -/
-  specs : SpecTheoremsNew
+  specs : SpecTheorems
   /-- `__do_jp` fvars currently in scope. -/
   jps : FVarIdMap JumpSiteInfo := {}
+  /-- The most recently lifted pure precondition. `tryLiftedHyp` closes handoff VCs against
+  it without walking the local context. -/
+  lastLiftedPre? : Option FVarId := none
   /-- Index of the next local declaration to consider for local specs. -/
   nextDeclIdx : Nat := 0
   deriving Inhabited
@@ -129,8 +152,8 @@ public structure VCGen.Scope where
 public structure VCGen.State where
   /--
   A cache mapping registered SpecThms to their backward rule to apply.
-  The particular rule depends on the theorem name, the monad and the number of excess state
-  arguments that the weakest precondition target is applied to.
+  The particular rule depends on the theorem name, the `WPMonad` instance and the number of
+  excess state arguments that the weakest precondition target is applied to.
   -/
   specBackwardRuleCache : Std.HashMap (Name × Expr × Nat) BackwardRule := {}
   /--
@@ -139,6 +162,13 @@ public structure VCGen.State where
   arguments that the weakest precondition target is applied to.
   -/
   splitBackwardRuleCache : Std.HashMap (Name × Expr × Nat) BackwardRule := {}
+  /--
+  A cache mapping logic rules to their backward rule to apply.
+  The particular rule depends on the rule name, the monad, the number of excess state
+  arguments that the weakest precondition target is applied to, and whether the precondition
+  is `⊤` (which selects a `⊤`-specialized split lemma).
+  -/
+  logicBackwardRuleCache : Std.HashMap (Name × Array Expr × Nat × Bool) BackwardRule := {}
   /--
   Holes of type `Invariant` that have been generated so far.
   -/
@@ -178,8 +208,8 @@ public def Scope.registerJP (s : Scope) (fv : FVarId) (info : JumpSiteInfo) : Sc
 public def Scope.knownJP? (s : Scope) (fv : FVarId) : Option JumpSiteInfo :=
   s.jps.get? fv
 
-public def Scope.insertSpec (s : Scope) (thm : SpecTheoremNew) : Scope :=
-  { s with specs := { s.specs with specs := Sym.insertPattern s.specs.specs thm.pattern thm } }
+public def Scope.insertSpec (s : Scope) (thm : SpecTheorem) : Scope :=
+  { s with specs := s.specs.insert thm }
 
 /-- Walk `goal`'s local context from `scope.nextDeclIdx` onward, registering any
 spec-shaped hypotheses as local specs. Advances `nextDeclIdx` to the current
@@ -191,7 +221,7 @@ public def Scope.collectLocalSpecs (scope : Scope) (goal : MVarId) : VCGenM Scop
     let scope ← lctx.foldlM (init := scope) (start := scope.nextDeclIdx) fun scope decl => do
       if decl.isAuxDecl then return scope
       try
-        if let some thm ← mkSpecTheoremNew (.local decl.fvarId) (eval_prio low) then
+        if let some thm ← mkSpecTheoremFromLocal decl.fvarId (eval_prio low) then
           return scope.insertSpec thm
       catch _ => pure ()
       return scope

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
@@ -79,9 +79,6 @@ public structure VCGen.IntroRules where
   /-- The backward rule for `Lean.Order.le_of_forall_le`. Peels one excess state argument
   from a function-lattice entailment. -/
   stateArgIntro : BackwardRule
-  /-- The backward rule for `Lean.Order.top_le_of_forall_top_le`. Peels one excess state
-  argument when the precondition is `⊤`. -/
-  topStateArgIntro : BackwardRule
   /-- The backward rule for `Lean.Order.le_of_imp_top_le`. Introduces a bare pure
   precondition on the `Prop` lattice. -/
   propPreIntro : BackwardRule
@@ -103,6 +100,9 @@ public structure VCGen.Context where
   /-- The backward rule for `Lean.Order.PartialOrder.rel_refl`. Closes a reflexive
   entailment `pre ⊑ pre`. -/
   reflRule : BackwardRule
+  /-- The backward rule for `meet_top_le_of_le`. Cancels a redundant `⊓ ⊤` on the left of an
+  entailment, turning `P ⊓ ⊤ ⊑ Q` into `P ⊑ Q`. -/
+  meetTopRule : BackwardRule
   /-- User-customizable simp methods used to pre-simplify hypotheses. -/
   hypSimpMethods : Option Sym.Simp.Methods := none
   /-- The `trivial` config option: when `true` (default), `Driver.emitVC` runs
@@ -163,12 +163,11 @@ public structure VCGen.State where
   -/
   splitBackwardRuleCache : Std.HashMap (Name × Expr × Nat) BackwardRule := {}
   /--
-  A cache mapping logic rules to their backward rule to apply.
-  The particular rule depends on the rule name, the monad, the number of excess state
-  arguments that the weakest precondition target is applied to, and whether the precondition
-  is `⊤` (which selects a `⊤`-specialized split lemma).
+  A cache mapping lattice connectives to their backward rule to apply.
+  The particular rule depends on the rule name, the monad, and the number of excess state
+  arguments that the weakest precondition target is applied to.
   -/
-  logicBackwardRuleCache : Std.HashMap (Name × Array Expr × Nat × Bool) BackwardRule := {}
+  latticeBackwardRuleCache : Std.HashMap (Name × Array Expr × Nat) BackwardRule := {}
   /--
   Holes of type `Invariant` that have been generated so far.
   -/

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Sebastian Graf
+Authors: Sebastian Graf, Vladimir Gladshtein
 -/
 module
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
@@ -111,20 +111,16 @@ public def work (scope : Scope) (goal : Grind.Goal) : VCGenM Unit := do
     let goal := s.goal
     if goal.inconsistent then continue
     match ← solve s.scope goal.mvarId with
-    | .stop =>
+    | .stop _reason =>
       emitVC goal
-    | .noEntailment .. | .noProgramOrLatticeFoundInTarget .. =>
-      emitVC goal
-    | .noSpecFoundForProgram prog monad thms =>
-      if (← read).errorOnMissingSpec then goal.mvarId.withContext do
+    | .noSpecFoundForProgram prog monad thms => goal.mvarId.withContext do
+      if (← read).errorOnMissingSpec then
         if thms.isEmpty then
           throwError "No spec found for program {prog}."
         else
           throwError "No spec matching the monad {monad} found for program {prog}. Candidates were {thms.map (·.proof)}."
       else
         emitVC goal
-    | .noStrategyForProgram prog => goal.mvarId.withContext do
-      throwError "Did not know how to decompose weakest precondition for {prog}"
     | .goals scope subgoals =>
       -- Handle invariant subgoals eagerly here, so that VC subgoals popped
       -- from the worklist later see the invariant MVar already assigned.

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
@@ -13,7 +13,6 @@ public import Lean.Meta.Sym.Grind
 
 open Lean Meta Elab Tactic Sym
 open Lean.Elab.Tactic.Do.SpecAttr
-open Std.Do
 
 namespace Lean.Elab.Tactic.Do.Internal
 
@@ -82,15 +81,18 @@ private def handleInvariantSubgoals (subgoals : List MVarId) : VCGenM (Array MVa
 Called when decomposing the goal further did not succeed; in this case we emit a VC for the goal.
 Invariant subgoals are handled separately by `handleInvariantSubgoals` directly inside `work`,
 so they never reach this path.
+If the goal is `(⊤ : Prop) ⊑ φ`, the `⊤ ⊑` wrapper is stripped first.
 -/
 public def emitVC (goal : Grind.Goal) : VCGenM Unit := do
-  let goal ← processHypotheses goal
+  let mvarId ← elimTopPre goal.mvarId
+  let mut goal := { goal with mvarId }
+  goal ← processHypotheses goal
   if goal.inconsistent then return
-  -- `trivial`: when false, skip `repeatAndRfl` (which collapses And-chains via rfl);
+  -- `trivial`: when false, skip `solveTrivialConjuncts` (which collapses And-chains via rfl);
   -- emit the goal as-is.
   let mvarId ←
     if (← read).trivial then
-      let some mvarId ← repeatAndRfl goal.mvarId | return
+      let some mvarId ← solveTrivialConjuncts goal.mvarId | return
       pure mvarId
     else
       pure goal.mvarId
@@ -111,7 +113,7 @@ public def work (scope : Scope) (goal : Grind.Goal) : VCGenM Unit := do
     match ← solve s.scope goal.mvarId with
     | .stop =>
       emitVC goal
-    | .noEntailment .. | .noProgramFoundInTarget .. =>
+    | .noEntailment .. | .noProgramOrLatticeFoundInTarget .. =>
       emitVC goal
     | .noSpecFoundForProgram prog monad thms =>
       if (← read).errorOnMissingSpec then goal.mvarId.withContext do
@@ -150,7 +152,7 @@ public structure Result where
   inlineHandledInvariants : Std.HashSet Nat := {}
 
 /--
-Generate verification conditions for a goal of the form `P ⊢ₛ wp⟦e⟧ Q s₁ ... sₙ` by repeatedly
+Generate verification conditions for a goal of the form `pre ⊑ wp e post epost s₁ ... sₙ` by repeatedly
 decomposing `e` using registered `@[spec]` theorems.
 Return the VCs and invariant goals.
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/EPost.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/EPost.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vladimir Gladshtein, Sebastian Graf
+-/
+module
+
+prelude
+public import Lean.Meta.Sym
+public import Std.Internal.Do
+public import Lean.Meta.Tactic.Replace
+
+open Lean Meta Sym
+open Std.Internal.Do Lean.Order
+
+namespace Lean.Elab.Tactic.Do.Internal
+
+namespace VCGen
+
+/-!
+Helpers for decomposing exception-postcondition (`EPost`) goals: reducing an `EPost.Cons.head`
+projection in the RHS of an entailment to the underlying component. The concrete case
+(`epost⟨…⟩`) is handled by `mkEPostAtIndex`/`peelEPostTailChain`; the `⊥` case is handled by
+`replaceEPostHeadBot?`, which rewrites `pre ⊑ ⊥.head x₁ … xₙ` to `pre ⊑ ⊥`.
+-/
+
+/-- Get the `index`-th component from an `EPost` target. -/
+public def mkEPostAtIndex (target : Expr) (index : Nat) : SymM (Option Expr) := do
+  let mut curr := target
+  for _ in [:index] do
+    let_expr EPost.Cons.mk _ _ _ tail := curr | return none
+    curr := tail
+  let_expr EPost.Cons.mk _ _ head _ := curr | return none
+  return head
+
+/-- Peel a chain of `.tail` projections, returning the base `EPost` and the number of tails. -/
+public partial def peelEPostTailChain (curr : Expr) (idx : Nat := 0) : Expr × Nat :=
+  curr.consumeMData.withApp fun fn args =>
+    if fn.isConstOf ``EPost.Cons.tail && args.size > 0 then
+      peelEPostTailChain args[args.size - 1]! (idx + 1)
+    else
+      (curr, idx)
+
+/-- Strip one `Level.succ`, mapping the `Sort`-level of `Type w` back to `w`. -/
+private def predLevel : Level → Level
+  | .succ l => l
+  | l => l
+
+/--
+When the exception postcondition is `⊥`, the RHS of a `pre ⊑ EPost.Cons.head ⊥ x₁ … xₙ` goal is
+propositionally—but not definitionally—equal to `⊥`. This rewrites the goal to `pre ⊑ ⊥`,
+constructing the equality proof from `EPost.Cons.head_bot` (for the head projection) and
+`bot_apply` (for each excess argument).
+
+The proof term is built directly with `mkApp`/`mkConst` and instances extracted from the existing
+goal, avoiding `mkAppM`/instance synthesis (which is both expensive and unable to unify `max`-of-
+universe-variable instance levels in the abstract-monad setting).
+
+`head`/`args` come from `rhs.withApp`, where `rhs = EPost.Cons.head eh et ⊥ x₁ … xₙ`, and `target`
+is the full `pre ⊑ rhs` entailment. Returns the rewritten goal, or `none` if `args[2]` is not `⊥`
+or the lattice instances are not in the expected shape (the caller then falls through). -/
+public def replaceEPostHeadBot? (goal : MVarId) (target head : Expr) (args : Array Expr) :
+    SymM (Option MVarId) := do
+  let some eh := args[0]? | return none
+  let some et := args[1]? | return none
+  let some epostArg := args[2]? | return none
+  -- `epostArg = @bot (EPost.Cons eh et) (scopedCCPO (instCompleteLattice eh et chInst ctInst))`
+  let_expr Lean.Order.bot _ botCCPOInst := epostArg | return none
+  unless botCCPOInst.isApp do return none
+  let clArgs := botCCPOInst.appArg!.getAppArgs
+  unless clArgs.size ≥ 2 do return none
+  let chInst := clArgs[clArgs.size - 2]!
+  let ctInst := clArgs[clArgs.size - 1]!
+  let [u, v] := head.constLevels! | return none
+  -- `p0 : EPost.Cons.head ⊥ = (⊥ : eh)`
+  let headBot := mkApp3 head eh et epostArg
+  let p0 := mkApp4 (mkConst ``EPost.Cons.head_bot [u, v]) eh et chInst ctInst
+  let some (_, _, b0) := (← Sym.inferType p0).eq? | return none
+  -- Fold `bot_apply` over the excess arguments: `acc : EPost.Cons.head ⊥ x₁ … xᵢ = ⊥`.
+  let mut acc := p0
+  let mut curHead := headBot
+  let mut curBot := b0
+  let mut curTy := eh
+  let mut curCL := chInst
+  for x in args.extract 3 args.size do
+    let .forallE _ σ τ _ := curTy | return none
+    if τ.hasLooseBVars then return none
+    unless curCL.isAppOf ``Lean.Order.instCompleteLatticePi do return none
+    let .lam _ _ τCL _ := curCL.appArg! | return none
+    let uσ ← Sym.getLevel σ
+    let uτ ← Sym.getLevel τ
+    -- `bfa : (⊥ : σ → τ) x = (⊥ : τ)`
+    let bfa := mkApp4 (mkConst ``Lean.Order.bot_apply [predLevel uσ, predLevel uτ]) σ τ τCL x
+    let some (_, _, newBot) := (← Sym.inferType bfa).eq? | return none
+    -- `Eq.trans (congrFun acc x) bfa : curHead x = ⊥`
+    let cf := mkApp6 (mkConst ``congrFun [uσ, uτ]) σ (.lam `x σ τ .default) curHead curBot acc x
+    acc := mkApp6 (mkConst ``Eq.trans [uτ]) τ (mkApp curHead x) (mkApp curBot x) newBot cf bfa
+    curHead := mkApp curHead x
+    curBot := newBot
+    curTy := τ
+    curCL := τCL
+  -- `acc : rhs = ⊥`; lift through `pre ⊑ ·` and replace the target.
+  let relArgs := target.getAppArgs
+  let some α := relArgs[0]? | return none
+  let some inst := relArgs[1]? | return none
+  let some pre := relArgs[2]? | return none
+  let relPre := mkApp3 target.getAppFn α inst pre
+  let uα ← Sym.getLevel α
+  let eqProof :=
+    mkApp6 (mkConst ``congrArg [uα, .succ .zero]) α (mkSort .zero) (mkAppN head args) curBot relPre acc
+  return some (← goal.replaceTargetEq (mkApp relPre curBot) eqProof)
+
+end VCGen
+
+end Lean.Elab.Tactic.Do.Internal

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/EPost.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/EPost.lean
@@ -41,11 +41,6 @@ public partial def peelEPostTailChain (curr : Expr) (idx : Nat := 0) : Expr × N
     else
       (curr, idx)
 
-/-- Strip one `Level.succ`, mapping the `Sort`-level of `Type w` back to `w`. -/
-private def predLevel : Level → Level
-  | .succ l => l
-  | l => l
-
 /--
 When the exception postcondition is `⊥`, the RHS of a `pre ⊑ EPost.Cons.head ⊥ x₁ … xₙ` goal is
 propositionally—but not definitionally—equal to `⊥`. This rewrites the goal to `pre ⊑ ⊥`,
@@ -90,7 +85,7 @@ public def replaceEPostHeadBot? (goal : MVarId) (target head : Expr) (args : Arr
     let uσ ← Sym.getLevel σ
     let uτ ← Sym.getLevel τ
     -- `bfa : (⊥ : σ → τ) x = (⊥ : τ)`
-    let bfa := mkApp4 (mkConst ``Lean.Order.bot_apply [predLevel uσ, predLevel uτ]) σ τ τCL x
+    let bfa := mkApp4 (mkConst ``Lean.Order.bot_apply [← decLevel uσ, ← decLevel uτ]) σ τ τCL x
     let some (_, _, newBot) := (← Sym.inferType bfa).eq? | return none
     -- `Eq.trans (congrFun acc x) bfa : curHead x = ⊥`
     let cf := mkApp6 (mkConst ``congrFun [uσ, uτ]) σ (.lam `x σ τ .default) curHead curBot acc x

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Entails.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Entails.lean
@@ -66,35 +66,24 @@ public def reduceEPostHead? (goal : MVarId) (target α inst pre rhs : Expr) :
 
 /--
 Decompose a supported lattice connective (`⊓`, `⇨`, `⌜p⌝`, `⊤`) on the RHS of `pre ⊑ rhs` by
-applying the corresponding cached logic rule. Returns `none` if the RHS head is not a supported
-connective.
+applying its cached split rule, looked up from `latticeSplits` by head constant. Returns `none` if
+the head is not a supported connective or its rule does not apply.
 
-An embedded proposition `⌜p⌝` is only decomposed when the precondition is `⊤`: turning
-`pre ⊑ ⌜p⌝` into the subgoal `p` drops `pre`, which can make the goal unprovable otherwise.
+An embedded proposition `⌜p⌝` is decomposed only when the precondition is `⊤`: its `⊤`-fixed split
+rule fails to apply otherwise, since turning `pre ⊑ ⌜p⌝` into the subgoal `p` drops `pre`.
 -/
-public def solveLatticeConnective? (goal : MVarId) (target rhs : Expr) :
+public def splitLatticeOp? (goal : MVarId) (rhs : Expr) :
     VCGenM (Option (List MVarId)) :=
   rhs.withApp fun head args => do
-    let applyLattice (c : LatticeSplit) (as excessArgs : Array Expr)
-        (resultType? : Option Expr := none) : VCGenM (List MVarId) := do
-      let rule ← mkBackwardRuleForLatticeCached c as excessArgs resultType?
-      let .goals goals ← rule.applyChecked goal
-        | throwError "Failed to apply lattice rule at {indentExpr target}"
-      return goals
-    match_expr head with
-    | meet =>
-      return some (← applyLattice .meet (args.extract 2 4) (args.drop 4))
-    | himp =>
-      return some (← applyLattice .himp (args.extract 2 4) (args.drop 4))
-    | CompleteLattice.ofProp =>
-      let preIsTop := match target.app4? ``Lean.Order.PartialOrder.rel with
-        | some (_, _, pre, _) => pre.isAppOf ``Lean.Order.top && pre.getAppNumArgs == 2
-        | none => false
-      unless preIsTop do return none
-      return some (← applyLattice .ofProp (args.extract 2 3) (args.drop 3) args[0]!)
-    | top =>
-      return some (← applyLattice .top #[] (args.drop 2) args[0]!)
-    | _ => return none
+    let some headName := head.constName? | return none
+    let some c := latticeSplits[headName]? | return none
+    let as := args.extract 2 (2 + c.numOperands)
+    let excessArgs := args.drop (2 + c.numOperands)
+    let resultType? := if c.needApplyArgs then none else args[0]?
+    let rule ← mkBackwardRuleForLatticeCached c as excessArgs resultType?
+    match ← rule.applyChecked goal with
+    | .goals goals => return some goals
+    | .failed => return none
 
 /-- Reduce a `Prop`-lattice goal `(⊤ : Prop) ⊑ φ` to the bare proposition `φ` via `top_le_prop`,
 returning any other goal unchanged. The match on `Sort 0` keeps it to the `Prop` base lattice,

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Entails.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Entails.lean
@@ -72,25 +72,28 @@ connective.
 An embedded proposition `⌜p⌝` is only decomposed when the precondition is `⊤`: turning
 `pre ⊑ ⌜p⌝` into the subgoal `p` drops `pre`, which can make the goal unprovable otherwise.
 -/
-public def solveLatticeConnective? (goal : MVarId) (target rhs : Expr) (preIsTop : Bool) :
+public def solveLatticeConnective? (goal : MVarId) (target rhs : Expr) :
     VCGenM (Option (List MVarId)) :=
   rhs.withApp fun head args => do
-    let applyLattice (lop : LogicOp) (as excessArgs : Array Expr)
+    let applyLattice (c : LatticeSplit) (as excessArgs : Array Expr)
         (resultType? : Option Expr := none) : VCGenM (List MVarId) := do
-      let rule ← mkBackwardRuleForLogicCached lop as excessArgs resultType? preIsTop
+      let rule ← mkBackwardRuleForLatticeCached c as excessArgs resultType?
       let .goals goals ← rule.applyChecked goal
-        | throwError "Failed to apply logic rule at {indentExpr target}"
+        | throwError "Failed to apply lattice rule at {indentExpr target}"
       return goals
     match_expr head with
     | meet =>
-      return some (← applyLattice .And (args.extract 2 4) (args.drop 4))
+      return some (← applyLattice .meet (args.extract 2 4) (args.drop 4))
     | himp =>
-      return some (← applyLattice .Imp (args.extract 2 4) (args.drop 4))
+      return some (← applyLattice .himp (args.extract 2 4) (args.drop 4))
     | CompleteLattice.ofProp =>
+      let preIsTop := match target.app4? ``Lean.Order.PartialOrder.rel with
+        | some (_, _, pre, _) => pre.isAppOf ``Lean.Order.top && pre.getAppNumArgs == 2
+        | none => false
       unless preIsTop do return none
-      return some (← applyLattice .Pure (args.extract 2 3) (args.drop 3) args[0]!)
+      return some (← applyLattice .ofProp (args.extract 2 3) (args.drop 3) args[0]!)
     | top =>
-      return some (← applyLattice .Top #[] (args.drop 2) args[0]!)
+      return some (← applyLattice .top #[] (args.drop 2) args[0]!)
     | _ => return none
 
 /-- Reduce a `Prop`-lattice goal `(⊤ : Prop) ⊑ φ` to the bare proposition `φ` via `top_le_prop`,

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Entails.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Entails.lean
@@ -1,192 +1,108 @@
 /-
 Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Sebastian Graf
+Authors: Sebastian Graf, Vladimir Gladshtein
 -/
 module
 
 prelude
 public import Lean.Elab.Tactic.Do.Internal.VCGen.Context
+public import Lean.Elab.Tactic.Do.Internal.VCGen.EPost
+public import Lean.Elab.Tactic.Do.Internal.VCGen.RuleCache
 public import Lean.Elab.Tactic.Do.Internal.VCGen.Util
 public import Lean.Meta.Sym.Util
+import Lean.Meta.Sym.InferType
 
 open Lean Meta Elab Tactic Sym Sym.Internal
-open Lean.Elab.Tactic.Do.SpecAttr
+open Lean.Elab.Tactic.Do.Internal.SpecAttr
 open Lean.Elab.Tactic.Do.Internal
-open Std.Do
+open Std.Internal.Do Lean.Order
 
 /-!
-Entailment-shaped goal decomposition: unfolding `Triple.of_entails_wp`, splitting
-`PostCond.entails`/`ExceptConds.entails`, and the multi-phase `solveSPredEntails`
-that drives `H ⊢ₛ T` to either a closed goal or a residual.
+Entailment-shaped goal decomposition for `pre ⊑ rhs` targets: unfolding `Triple`,
+introducing excess state arguments and pure preconditions, reducing
+exception-postcondition projections, and decomposing lattice connectives.
 -/
 
 namespace Lean.Elab.Tactic.Do.Internal
 
 namespace VCGen
 
-/--
-Unfold `⦃P⦄ x ⦃Q⦄` into `P ⊢ₛ wp⟦x⟧ Q` by applying `Tiple.of_wp`, ensuring that `PostShape.args ps`
-is reduced.
--/
-public def tripleOfWP (goal : MVarId) : VCGenM MVarId := goal.withContext do
-  let .goals [goal] ← (← read).tripleOfEntailsWPRule.applyChecked goal
-    | throwError "Applying {.ofConstName ``Triple.of_entails_wp} to {goal} failed"
-  goal.withContext do
-    let target ← goal.getType
-    let_expr ent@SPred.entails σs P Q := target | throwError "Expected SPred.entails: {target}"
-    let σs ← shareCommonInc (← unfoldReducible σs)
-    goal.replaceTargetDefEq (← Sym.Internal.mkAppS₃ ent σs P Q)
+/-- Unfold `⦃P⦄ x ⦃Q; E⦄` into the underlying entailment `P ⊑ wp x Q E`. -/
+public def unfoldTriple (goal : MVarId) : VCGenM MVarId := do
+  let .goals [goal] ← (← read).introRules.tripleIntro.applyChecked goal
+    | throwError "Failed to unfold the Triple target of {goal}"
+  return goal
 
-open Lean.Elab.Tactic.Do in
-public def solveExceptCondsEntails (goal : MVarId) : VCGenM (Option MVarId) := goal.withContext do
-  let target ← goal.getType
-  let_expr ent@ExceptConds.entails ps P Q := target | return none
-  let P ← reduceHead P
-  let Q ← reduceHead Q
-  let goal ← goal.replaceTargetDefEq (← Sym.Internal.mkAppS₃ ent ps P Q)
-  if let .goals [] ← (← read).exceptCondsEntailsPureRule.applyChecked goal then
-    return none
-  if let .goals [] ← (← read).exceptCondsEntailsFalseRule.applyChecked goal then
-    return none
-  if let .goals [] ← (← read).exceptCondsEntailsTrueRule.applyChecked goal then
-    return none
-  if let .goals [] ← (← read).exceptCondsEntailsRflRule.applyChecked goal then
-    return none
-  return some goal
-
-open Lean.Elab.Tactic.Do in
-public def solvePostCondEntails (goal : MVarId) : VCGenM (Option (List MVarId)) := goal.withContext do
-  let target ← goal.getType
-  let_expr PostCond.entails _α _ps _P _Q := target | return none
-  -- Try closing the whole entailment by reflexivity first.
-  if let .goals [] ← (← read).postCondEntailsRflRule.applyChecked goal then
-    return some []
-  -- Otherwise, decompose with `PostCond.entails.mk` into success + exception subgoals.
-  let .goals [goal₁, goal₂] ← (← read).postCondEntailsMkRule.applyChecked goal
-    | throwError "Applying {.ofConstName ``PostCond.entails} to {target} failed. It should not."
-  -- Try to discharge the exception subgoal by reflexivity. If that fails, leave it
-  -- as a subgoal so it is emitted as a VC by the surrounding worklist loop.
-  let extraGoal₂? ← goal₂.withContext (solveExceptCondsEntails goal₂)
-  -- Normalize the success goal `∀ a, P a ⊢ₛ Q a`
-  let goal₁ ← goal₁.withContext do
-    let target ← goal₁.getType
-    let .forallE x d b bi := target | throwError "Not a forall: {target}"
-    let_expr ent@SPred.entails σs P Q := b | throwError "Not a SPred.entails: {target}"
-    -- σs is of the form `PostShape.args ps` and we want to reduce it
-    let σs ← shareCommonInc (← unfoldReducible σs)
-    let b ← Sym.Internal.mkAppS₃ ent σs P Q
-    let target ← Sym.Internal.MonadShareCommon.share1 <| .forallE x d b bi
-    goal₁.replaceTargetDefEq target
-  return goal₁ :: extraGoal₂?.toList
+/-- Apply precondition-intro rule `rule` to `goal`, then introduce the freed hypothesis,
+leaving `⊤` as the residual precondition. Returns the new goal and the introduced hypothesis. -/
+public def introPre (rule : BackwardRule) (goal : MVarId) : VCGenM (MVarId × FVarId) := do
+  let .goals [goal] ← rule.applyChecked goal
+    | throwError "Failed to apply precondition intro rule to {goal}"
+  let goal ← introsHygienic goal
+  let some decl := (← goal.withContext getLCtx).lastDecl
+    | throwError "Failed to intro the lifted precondition of {goal}"
+  return (goal, decl.fvarId)
 
 /--
-Apply `SPred.entails_cons_intro` to introduce one state variable, then `introsSimp`,
-then peel a leading `SPred.pure (σ::σs) φ s` from each side of `⊢ₛ` via
-`apply_pure_cons_entails_l/r`. Returns `none` if no `entails_cons_intro` was applicable.
-
-Performs the pure-cons cleanup at the exact iteration the state variable is introduced,
-so the goal stays in canonical form throughout the eta-expansion loop.
+Reduce an `EPost.Cons.head` projection on the RHS of `pre ⊑ rhs` to the underlying component:
+concrete `epost⟨…⟩` values project to the selected component, and `⊥.head x₁ … xₙ` rewrites to
+`⊥` via `replaceEPostHeadBot?`. Returns `none` if the RHS is not such a projection.
 -/
-public def consIntroAndSimpStep (goal : MVarId) : VCGenM (Option MVarId) := do
-  let ctx ← read
-  let .goals [g'] ← ctx.entailsConsIntroRule.applyChecked goal | return none
-  let mut goal ← introsSimp g' m!"after applying {.ofConstName ``SPred.entails_cons_intro}"
-  if let .goals [g''] ← ctx.applyPureConsEntailsLRule.applyChecked goal then
-    goal := g''
-  if let .goals [g''] ← ctx.applyPureConsEntailsRRule.applyChecked goal then
-    goal := g''
-  return some goal
-
-public def neededStateIntro (thm : SpecTheoremNew) (goal : MVarId) (excessArgs : Array Expr) : VCGenM (Option MVarId) := do
-  let .triple potential := thm.kind | return none
-  let mut n := potential - excessArgs.size
-  if n = 0 then return none
-  let mut goal := goal
-  while n > 0 do
-    n := n - 1
-    let some g ← consIntroAndSimpStep goal
-      | throwError "Failed to introduce state at {goal} despite {n+1} spec potential"
-    goal := g
-  return some goal
+public def reduceEPostHead? (goal : MVarId) (target α inst pre rhs : Expr) :
+    VCGenM (Option MVarId) :=
+  rhs.withApp fun head args => do
+    unless head.isConstOf ``EPost.Cons.head do return none
+    let some epostArg := args[2]? | return none
+    -- `⊥.head x₁ … xₙ` is propositionally `⊥`; reduce it to a clean `pre ⊑ ⊥` VC.
+    if epostArg.isAppOf ``Lean.Order.bot then
+      return (← replaceEPostHeadBot? goal target head args)
+    let (epostTarget, index) := peelEPostTailChain epostArg
+    let some epost ← mkEPostAtIndex epostTarget index | return none
+    let excessArgs := args.drop 3
+    let rhs ← betaS epost excessArgs
+    let newTarget ← mkAppNS target.getAppFn #[α, inst, pre, rhs]
+    return some (← goal.replaceTargetDefEq newTarget)
 
 /--
-Break down `H ⊢ₛ T` as far as possible, reporting `none` when no progress was made.
-1. If `H` is pure `⌜φ₁⌝`, turn the goal into `h : φ₁ ⊢ ⊢ₛ T`.
-2. If *also* `T` is pure `⌜φ₂⌝`, turn the goal into `h : φ₁ ⊢ φ₂`, then exit.
-3. Otherwise, `H` or `T` was not pure. We continue by introducing all state variables,
-   `H s₁ ... sₙ ⊢ₛ T s₁ ... sₙ`. For a monomorphic monad stack, this will an entailment on
-  `SPred []`. If either `H` or `T` was pure, `⌜·⌝`, state introduction preserves this.
-4. Finally, turn `H ⊢ₛ T` into `h : H.down ⊢ T.down` (at `SPred []`).
-5. If either `T` was pure `⌜φ₂⌝` (and `H` was not), we turn `T.down` into `φ₂`.
-   (NB: If `H` was pure, then we have already lifted `φ₁` to the local context.)
+Decompose a supported lattice connective (`⊓`, `⇨`, `⌜p⌝`, `⊤`) on the RHS of `pre ⊑ rhs` by
+applying the corresponding cached logic rule. Returns `none` if the RHS head is not a supported
+connective.
+
+An embedded proposition `⌜p⌝` is only decomposed when the precondition is `⊤`: turning
+`pre ⊑ ⌜p⌝` into the subgoal `p` drops `pre`, which can make the goal unprovable otherwise.
 -/
-public def solveSPredEntails (goal : MVarId) : VCGenM (Option MVarId) := goal.withContext do
-  let_expr SPred.entails _σs H T := (← goal.getType) | return none
-  let mut progress := false
-  let mut goal := goal
+public def solveLatticeConnective? (goal : MVarId) (target rhs : Expr) (preIsTop : Bool) :
+    VCGenM (Option (List MVarId)) :=
+  rhs.withApp fun head args => do
+    let applyLattice (lop : LogicOp) (as excessArgs : Array Expr)
+        (resultType? : Option Expr := none) : VCGenM (List MVarId) := do
+      let rule ← mkBackwardRuleForLogicCached lop as excessArgs resultType? preIsTop
+      let .goals goals ← rule.applyChecked goal
+        | throwError "Failed to apply logic rule at {indentExpr target}"
+      return goals
+    match_expr head with
+    | meet =>
+      return some (← applyLattice .And (args.extract 2 4) (args.drop 4))
+    | himp =>
+      return some (← applyLattice .Imp (args.extract 2 4) (args.drop 4))
+    | CompleteLattice.ofProp =>
+      unless preIsTop do return none
+      return some (← applyLattice .Pure (args.extract 2 3) (args.drop 3) args[0]!)
+    | top =>
+      return some (← applyLattice .Top #[] (args.drop 2) args[0]!)
+    | _ => return none
 
-  -- First try to turn `⌜φ₁⌝ ⊢ₛ ⌜φ₂⌝` into `φ₁ → φ₂`.
-  -- Do so in two steps:
-  --   1. Move non-`True` `φ₁` to the local context, yielding `⌜True⌝ ⊢ₛ ⌜φ₂⌝` (which is `⊢ₛ ⌜φ₂⌝`).
-  --   2. Eliminate `⊢ₛ ⌜φ₂⌝` to `φ₂`.
-  -- If both succeed, we return `φ₁ → φ₂`. If 1. fails, we fall back to eta-expansion below.
-  -- If 1. succeeds and 2. fails, we still continue with `φ₁` in the local context and eta-expand.
-  let pureH : Option Expr := Prod.snd <$> H.app2? ``SPred.pure
-  let pureT : Option Expr := Prod.snd <$> T.app2? ``SPred.pure
-
-  let pureHNonTrue : Bool ←
-    match pureH with
-    | none => pure false
-    | some h => not <$> isDefEqS h (mkConst ``True)
-      if pureHNonTrue then
-    let .goals [g'] ← (← read).pureElimRule.applyChecked goal
-      | throwError "Failed to apply {.ofConstName ``SPred.pure_elim'} to {← goal.getType}"
-    progress := true
-    goal ← introsSimp g' m!"after applying {.ofConstName ``SPred.pure_elim'}"
-
-  if pureH.isSome && pureT.isSome then
-    let .goals [g'] ← (← read).pureIntroRule.applyChecked goal
-      | throwError "Failed to apply {.ofConstName ``SPred.pure_intro} to {← goal.getType}"
-    progress := true
-    return some g'
-
-  -- Now introduce states. If the monad stack is monomorphic, we will go all the way to `SPred []`
-  -- and hence every entailment becomes pure.
-  repeat do
-    let some g' ← consIntroAndSimpStep goal | break
-    progress := true
-    goal := g'
-
-  -- Now check again whether `H` became `⌜φ₁⌝` (it might have started as `fun s => ⌜φ₁⌝`).
-  -- * If so, and `φ₁` is not `True`, we move `φ₁` to the local context and then
-  --   turn `(h : φ₁)? ⊢ H ⊢ₛ T` into `⊢ T.down`.
-  -- * Otherwise, we turn `⊢ H ⊢ₛ T` into `⊢ H.down → T.down` and
-  --   introduce `H.down` (at `SPred []`).
-  let_expr SPred.entails _σs H _T := (← goal.getType) | throwError "Not a SPred.entails: {← goal.getType}"
-  if let some (_, h) := H.app2? ``SPred.pure then
-    -- If `H` is `⌜True⌝`, we avoid introducing `h : True`.
-    unless h matches .const ``True _ do
-      if let .goals [g'] ← (← read).pureElimRule.applyChecked goal then
-        progress := true
-        goal ← introsSimp g' m!"after applying {.ofConstName ``SPred.pure_elim'}"
-    if let .goals [g'] ← (← read).pureIntroRule.applyChecked goal then
-      progress := true
-      goal := g'
-  else
-    if let .goals [g'] ← (← read).entailsNilIntroRule.applyChecked goal then
-      progress := true
-      goal ← introsSimp g' m!"after applying {.ofConstName ``SPred.entails_nil_intro}"
-
-  -- Finally, if `T` is pure `⌜φ₂⌝`, we turn `T.down` into `φ₂`.
-  if let .goals [g'] ← (← read).downPureIntroRule.applyChecked goal then
-    progress := true
-    goal := g'
-
-  if progress then
-    return some goal
-  else
-    return none
+/-- Reduce a `Prop`-lattice goal `(⊤ : Prop) ⊑ φ` to the bare proposition `φ` via `top_le_prop`,
+returning any other goal unchanged. The match on `Sort 0` keeps it to the `Prop` base lattice,
+where the reduction is sound; entailments at an abstract lattice carrier pass through. -/
+public def elimTopPre (goal : MVarId) : VCGenM MVarId := do
+  let some (.sort .zero, _, pre, _) := (← goal.getType).app4? ``Lean.Order.PartialOrder.rel
+    | return goal
+  unless pre.isAppOf ``Lean.Order.top do return goal
+  let .goals [goal] ← (← read).elimPreRule.apply goal
+    | throwError "Failed to strip the `⊤ ⊑` wrapper of {goal}"
+  return goal
 
 end VCGen
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
@@ -113,20 +113,20 @@ public def mkContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := false) 
         catch _ => continue
   let tripleIntro ← mkBackwardRuleFromDecl ``Std.Internal.Do.Triple.intro
   let stateArgIntro ← mkBackwardRuleFromDecl ``Lean.Order.le_of_forall_le
-  let topStateArgIntro ← mkBackwardRuleFromDecl ``Lean.Order.top_le_of_forall_top_le
   let propPreIntro ← mkBackwardRuleFromDecl ``Lean.Order.le_of_imp_top_le
   let ofPropPreIntro ← mkBackwardRuleFromDecl ``Lean.Order.ofProp_le
   let truePreIntro ← mkBackwardRuleFromDecl ``Lean.Order.true_le_of_top_le
   let elimPreRule ← mkBackwardRuleFromDecl ``Lean.Order.top_le_prop
   let andIntroRule ← mkBackwardRuleFromDecl ``And.intro
   let reflRule ← mkBackwardRuleFromDecl ``Lean.Order.PartialOrder.rel_refl
+  let meetTopRule ← mkBackwardRuleFromDecl ``Std.Internal.Do.CompleteLattice.meet_top_le_of_le
   let specThmsNew ← SymM.run <| migrateSpecTheoremsDatabase specThms simpThms
   let ctx : VCGen.Context := {
-    introRules := { tripleIntro, stateArgIntro, topStateArgIntro, propPreIntro, ofPropPreIntro,
-                    truePreIntro },
+    introRules := { tripleIntro, stateArgIntro, propPreIntro, ofPropPreIntro, truePreIntro },
     elimPreRule,
     andIntroRule,
     reflRule,
+    meetTopRule,
   }
   return (ctx, { specs := specThmsNew })
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Sebastian Graf
+Authors: Sebastian Graf, Vladimir Gladshtein
 -/
 module
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
@@ -21,8 +21,7 @@ public import Lean.Elab.Tactic.Grind.Basic
 import Lean.Meta.Sym.ProofInstInfo
 
 open Lean Parser Meta Elab Tactic Sym
-open Lean.Elab.Tactic.Do Lean.Elab.Tactic.Do.SpecAttr
-open Std.Do
+open Lean.Elab.Tactic.Do Lean.Elab.Tactic.Do.Internal.SpecAttr
 
 namespace Lean.Elab.Tactic.Do.Internal
 
@@ -53,7 +52,7 @@ public def mkContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := false) 
     if arg.getKind == ``simpErase then
       try
         -- Try to interpret as a spec theorem erasure; fall back to simp erasure.
-        let specThm ←
+        let specThm? ←
           if let some fvar ← Term.isLocalIdent? arg[1] then
             mkSpecTheoremFromLocal fvar.fvarId!
           else
@@ -62,6 +61,8 @@ public def mkContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := false) 
               mkSpecTheoremFromConst declName
             else
               withRef id <| throwUnknownConstant id.getId.eraseMacroScopes
+        let some specThm := specThm?
+          | throwError "not a spec theorem"
         specThms := specThms.erase specThm.proof
       catch _ =>
         simpStuff := simpStuff.push ⟨arg⟩ -- simp tracks its own erase stuff
@@ -74,13 +75,15 @@ public def mkContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := false) 
       match ← Term.resolveId? term (withInfo := true) <|> Term.elabCDotFunctionAlias? ⟨term⟩ with
       | some (.const declName _) =>
         try
-          let thm ← mkSpecTheoremFromConst declName
+          let some thm ← mkSpecTheoremFromConst declName
+            | throwError "not a spec theorem"
           specThms := specThms.insert thm
         catch _ =>
           simpStuff := simpStuff.push ⟨arg⟩
       | some (.fvar fvar) =>
         try
-          let thm ← mkSpecTheoremFromLocal fvar
+          let some thm ← mkSpecTheoremFromLocal fvar
+            | throwError "not a spec theorem"
           specThms := specThms.insert thm
         catch _ =>
           simpStuff := simpStuff.push ⟨arg⟩
@@ -96,7 +99,7 @@ public def mkContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := false) 
   let stx ← `(tactic| simp +unfoldPartialApp -zeta [$(Syntax.TSepArray.ofElems simpStuff),*])
   let res ← runTacticM (goals := [goal]) <| mkSimpContext stx.raw
     (eraseLocal := false)
-    (simpTheorems := getSpecSimpTheorems)
+    (simpTheorems := SpecAttr.getSpecSimpTheorems)
     (ignoreStarArg := ignoreStarArg)
   let simpThms := res.ctx.simpTheorems[0]?.getD {}
   -- Add local spec hypotheses when `*` is used.
@@ -105,43 +108,25 @@ public def mkContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := false) 
     for fvar in fvars do
       unless specThms.isErased (.local fvar) do
         try
-          let thm ← mkSpecTheoremFromLocal fvar
-          specThms := specThms.insert thm
+          if let some thm ← mkSpecTheoremFromLocal fvar then
+            specThms := specThms.insert thm
         catch _ => continue
-  let entailsConsIntroRule ← mkBackwardRuleFromDecl ``SPred.entails_cons_intro
-  let entailsNilPureIntroRule ← mkBackwardRuleFromDecl ``SPred.entails_nil_pure_intro
-  let entailsNilIntroRule ← mkBackwardRuleFromDecl ``SPred.entails_nil_intro
-  let applyPureConsEntailsLRule ← mkBackwardRuleFromDecl ``SPred.apply_pure_cons_entails_l
-  let applyPureConsEntailsRRule ← mkBackwardRuleFromDecl ``SPred.apply_pure_cons_entails_r
-  let downPureIntroRule ← mkBackwardRuleFromDecl ``SPred.down_pure_intro
-  let pureElimRule ← mkBackwardRuleFromDecl ``SPred.pure_elim'
-  let pureIntroRule ← mkBackwardRuleFromDecl ``SPred.pure_intro
-  let postCondEntailsRflRule ← mkBackwardRuleFromDecl ``PostCond.entails.rfl
-  let postCondEntailsMkRule ← mkBackwardRuleFromDecl ``PostCond.entails.mk
-  let exceptCondsEntailsRflRule ← mkBackwardRuleFromDecl ``ExceptConds.entails.rfl
-  let exceptCondsEntailsPureRule ← mkBackwardRuleFromDecl ``ExceptConds.entails.pure
-  let exceptCondsEntailsFalseRule ← mkBackwardRuleFromDecl ``ExceptConds.entails_false
-  let exceptCondsEntailsTrueRule ← mkBackwardRuleFromDecl ``ExceptConds.entails_true
-  let tripleOfEntailsWPRule ← mkBackwardRuleFromDecl ``Triple.of_entails_wp
+  let tripleIntro ← mkBackwardRuleFromDecl ``Std.Internal.Do.Triple.intro
+  let stateArgIntro ← mkBackwardRuleFromDecl ``Lean.Order.le_of_forall_le
+  let topStateArgIntro ← mkBackwardRuleFromDecl ``Lean.Order.top_le_of_forall_top_le
+  let propPreIntro ← mkBackwardRuleFromDecl ``Lean.Order.le_of_imp_top_le
+  let ofPropPreIntro ← mkBackwardRuleFromDecl ``Lean.Order.ofProp_le
+  let truePreIntro ← mkBackwardRuleFromDecl ``Lean.Order.true_le_of_top_le
+  let elimPreRule ← mkBackwardRuleFromDecl ``Lean.Order.top_le_prop
   let andIntroRule ← mkBackwardRuleFromDecl ``And.intro
+  let reflRule ← mkBackwardRuleFromDecl ``Lean.Order.PartialOrder.rel_refl
   let specThmsNew ← SymM.run <| migrateSpecTheoremsDatabase specThms simpThms
   let ctx : VCGen.Context := {
-    entailsConsIntroRule,
-    entailsNilPureIntroRule,
-    entailsNilIntroRule,
-    applyPureConsEntailsLRule,
-    applyPureConsEntailsRRule,
-    downPureIntroRule,
-    pureElimRule,
-    pureIntroRule,
-    postCondEntailsRflRule,
-    postCondEntailsMkRule,
-    exceptCondsEntailsRflRule,
-    exceptCondsEntailsPureRule,
-    exceptCondsEntailsFalseRule,
-    exceptCondsEntailsTrueRule,
-    tripleOfEntailsWPRule,
+    introRules := { tripleIntro, stateArgIntro, topStateArgIntro, propPreIntro, ofPropPreIntro,
+                    truePreIntro },
+    elimPreRule,
     andIntroRule,
+    reflRule,
   }
   return (ctx, { specs := specThmsNew })
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
@@ -120,7 +120,7 @@ public def mkContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := false) 
   let andIntroRule ← mkBackwardRuleFromDecl ``And.intro
   let reflRule ← mkBackwardRuleFromDecl ``Lean.Order.PartialOrder.rel_refl
   let meetTopRule ← mkBackwardRuleFromDecl ``Std.Internal.Do.CompleteLattice.meet_top_le_of_le
-  let specThmsNew ← SymM.run <| migrateSpecTheoremsDatabase specThms simpThms
+  let allSpecThms ← SymM.run <| extendWithSimpSpecs specThms simpThms
   let ctx : VCGen.Context := {
     introRules := { tripleIntro, stateArgIntro, propPreIntro, ofPropPreIntro, truePreIntro },
     elimPreRule,
@@ -128,7 +128,7 @@ public def mkContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := false) 
     reflRule,
     meetTopRule,
   }
-  return (ctx, { specs := specThmsNew })
+  return (ctx, { specs := allSpecThms })
 
 end VCGen
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
@@ -10,57 +10,78 @@ public import Lean.Elab.Tactic.Do.VCGen.Split
 public import Lean.Elab.Tactic.Do.Internal.VCGen.Context
 public import Lean.Elab.Tactic.Do.Internal.VCGen.RuleConstruction
 public import Lean.Elab.Tactic.Do.Internal.VCGen.Util
+import Lean.Meta.Sym.InferType
 
 open Lean Meta Elab Tactic Sym
-open Lean.Elab.Tactic.Do.SpecAttr
+open Lean.Elab.Tactic.Do.Internal.SpecAttr
 open Lean.Elab.Tactic.Do.Internal
-open Std.Do
 
 /-!
 `VCGenM`-level cache wrappers around the `SymM` rule constructors in
-`VCGen.RuleConstruction`. The cache key is `(declName, m, excessArgs.size)`.
+`VCGen.RuleConstruction`.
 -/
 
 namespace Lean.Elab.Tactic.Do.Internal
 
-set_option linter.checkUnivs false in
-@[inline]
-def Std.HashMap.getDM [Monad m] [BEq α] [Hashable α]
-    (cache : Std.HashMap α β) (key : α) (fallback : m β) : m (β × Std.HashMap α β) := do
-  if let some b := cache.get? key then
-    return (b, cache)
-  let b ← fallback
-  return (b, cache.insert key b)
-
 namespace VCGen
 
-public def SpecTheoremNew.global? (specThm : SpecTheoremNew) : Option Name :=
-  match specThm.proof with | .global decl => some decl | _ => none
+/--
+Cached version of ordinary and equality spec rule construction.
 
-/-- See the documentation for `mkBackwardRuleFromSpec` and `mkBackwardRuleFromSimpSpec`. -/
-public def mkBackwardRuleFromSpecCached (specThm : SpecTheoremNew) (m σs ps instWP : Expr)
-    (excessArgs : Array Expr) : VCGenM BackwardRule := do
-  let mkRuleSlow := match specThm.kind with
-    | .triple _ => mkBackwardRuleFromSpec     specThm m σs ps instWP excessArgs
-    | .simp _   => mkBackwardRuleFromSimpSpec specThm m σs ps instWP excessArgs
-  let s ← get
-  let some decl := SpecTheoremNew.global? specThm | mkRuleSlow
-  let (res, specBackwardRuleCache) ← s.specBackwardRuleCache.getDM (decl, m, excessArgs.size) mkRuleSlow
-  set { s with specBackwardRuleCache }
-  return res
+Ordinary `Triple`/`⊑ wp` entries are sent to `tryMkBackwardRuleFromSpec`; equality entries are sent
+to `tryMkBackwardRuleFromSimp`. The caller supplies the full `wp` metadata because equality
+specs must check that their equation type is definitionally equal to `m α`.
+
+Cache key: `(proof key, instWP, excessArgs.size)`.
+-/
+public def mkBackwardRuleFromSpecCached (specThm : SpecTheorem) (info : WPInfo) :
+    OptionT VCGenM BackwardRule := do
+  let key := (specThm.proof.key, info.instWP, info.excessArgs.size)
+  let s := (← get).specBackwardRuleCache
+  if let some rule := s[key]? then return rule
+  let some rule ← withNewMCtxDepth <| match specThm.kind with
+      | .triple => tryMkBackwardRuleFromSpec specThm info |>.run
+      | .simp _ => tryMkBackwardRuleFromSimp specThm info |>.run
+    | failure
+  modify fun st => { st with specBackwardRuleCache := st.specBackwardRuleCache.insert key rule }
+  return rule
 
 open Lean.Elab.Tactic.Do in
-/-- Creates and caches a backward rule for splitting `ite`, `dite`, or matchers. -/
-public def mkBackwardRuleFromSplitInfoCached (splitInfo : SplitInfo) (m σs ps instWP : Expr) (excessArgs : Array Expr) : VCGenM BackwardRule := do
+/--
+Cached version of `mkBackwardRuleForSplit`.
+
+Cache key: `(splitter name, instWP, excessArgs.size)`.
+-/
+public def mkBackwardRuleForSplitCached (splitInfo : SplitInfo) (info : WPInfo) :
+    VCGenM BackwardRule := do
   let cacheKey := match splitInfo with
     | .ite .. => ``ite
     | .dite .. => ``dite
     | .matcher matcherApp => matcherApp.matcherName
-  let mkRuleSlow := mkBackwardRuleForSplit splitInfo m σs ps instWP excessArgs
-  let s ← get
-  let (res, splitBackwardRuleCache) ← s.splitBackwardRuleCache.getDM (cacheKey, m, excessArgs.size) mkRuleSlow
-  set { s with splitBackwardRuleCache }
-  return res
+  let key := (cacheKey, info.instWP, info.excessArgs.size)
+  let s := (← get).splitBackwardRuleCache
+  if let some rule := s[key]? then return rule
+  let rule ← mkBackwardRuleForSplit splitInfo info
+  modify fun st =>
+    { st with splitBackwardRuleCache := st.splitBackwardRuleCache.insert key rule }
+  return rule
+
+/--
+Cached version of `LogicOp.mkBackwardRule`.
+
+Cache key: `(logic rule lemma, argument types, excessArgs.size, preIsTop)`. The `preIsTop` flag is
+part of the key because a `⊤` precondition produces a `⊤`-specialized rule whose type differs from
+the general one.
+-/
+public def mkBackwardRuleForLogicCached (lop : LogicOp) (as excessArgs : Array Expr)
+    (resultType? : Option Expr := none) (preIsTop : Bool := false) : VCGenM BackwardRule := do
+  let s := (← get).logicBackwardRuleCache
+  let asTypes ← (as.mapM Sym.inferType : SymM (Array Expr))
+  let key := (lop.toApplyLemma, asTypes, excessArgs.size, preIsTop)
+  if let some rule := s[key]? then return rule
+  let rule ← LogicOp.mkBackwardRule lop as excessArgs resultType? preIsTop
+  modify fun st => { st with logicBackwardRuleCache := st.logicBackwardRuleCache.insert key rule }
+  return rule
 
 end VCGen
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Sebastian Graf
+Authors: Sebastian Graf, Vladimir Gladshtein
 -/
 module
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
@@ -67,20 +67,18 @@ public def mkBackwardRuleForSplitCached (splitInfo : SplitInfo) (info : WPInfo) 
   return rule
 
 /--
-Cached version of `LogicOp.mkBackwardRule`.
+Cached version of `LatticeSplit.mkBackwardRule`.
 
-Cache key: `(logic rule lemma, argument types, excessArgs.size, preIsTop)`. The `preIsTop` flag is
-part of the key because a `⊤` precondition produces a `⊤`-specialized rule whose type differs from
-the general one.
+Cache key: `(distribution lemma, argument types, excessArgs.size)`.
 -/
-public def mkBackwardRuleForLogicCached (lop : LogicOp) (as excessArgs : Array Expr)
-    (resultType? : Option Expr := none) (preIsTop : Bool := false) : VCGenM BackwardRule := do
-  let s := (← get).logicBackwardRuleCache
+public def mkBackwardRuleForLatticeCached (c : LatticeSplit) (as excessArgs : Array Expr)
+    (resultType? : Option Expr := none) : VCGenM BackwardRule := do
+  let s := (← get).latticeBackwardRuleCache
   let asTypes ← (as.mapM Sym.inferType : SymM (Array Expr))
-  let key := (lop.toApplyLemma, asTypes, excessArgs.size, preIsTop)
+  let key := (c.applyLemma, asTypes, excessArgs.size)
   if let some rule := s[key]? then return rule
-  let rule ← LogicOp.mkBackwardRule lop as excessArgs resultType? preIsTop
-  modify fun st => { st with logicBackwardRuleCache := st.logicBackwardRuleCache.insert key rule }
+  let rule ← c.mkBackwardRule as excessArgs resultType?
+  modify fun st => { st with latticeBackwardRuleCache := st.latticeBackwardRuleCache.insert key rule }
   return rule
 
 end VCGen

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
@@ -10,11 +10,8 @@ public import Lean.Elab.Tactic.Do.VCGen.Split
 public import Lean.Elab.Tactic.Do.Internal.VCGen.Context
 public import Lean.Elab.Tactic.Do.Internal.VCGen.Reduce
 public import Lean.Elab.Tactic.Do.Internal.VCGen.SpecDB
-public import Lean.Meta.Sym.AlphaShareBuilder
 public import Lean.Meta.Sym.Apply
-public import Lean.Meta.Sym.InstantiateMVarsS
 public import Lean.Meta.Sym.Util
-import Lean.Meta.Sym.InferType
 import Lean.Meta.WHNF
 
 open Lean Meta Elab Tactic Sym
@@ -26,13 +23,10 @@ namespace VCGen
 
 /-!
 Construction of `BackwardRule`s from `SpecTheorem`s and split info. Pure
-`SymM` — no knowledge of `VCGenM`. The `VCGenM` cache wrappers live in
+`MetaM` — no knowledge of `VCGenM`. The `VCGenM` cache wrappers live in
 `VCGen.RuleCache`.
 -/
 
-section NewMetaTheory
-
-open Sym.Internal
 open Std.Internal.Do Lean.Order
 
 /-! ## Logic rules
@@ -147,9 +141,9 @@ private partial def LatticeSplit.mkApplyEq
     staying at the lattice level. Returns `((a ⊓ b) s₁…sₙ, eq)` where
     `eq : (a ⊓ b) s₁…sₙ = (a s₁…sₙ ⊓ b s₁…sₙ)`. -/
 private def LatticeSplit.mkDistributeEq
-    (c : LatticeSplit) (as ss : Array Expr) (resultType? : Option Expr := none) : SymM (Expr × Expr) := do
+    (c : LatticeSplit) (as ss : Array Expr) (resultType? : Option Expr := none) : MetaM (Expr × Expr) := do
   let lat ← c.mkLattice as resultType?
-  let goal ← mkAppNS lat ss
+  let goal := mkAppN lat ss
   let eqFun ← c.mkApplyEq as ss.toList resultType?
   return (goal, eqFun)
 
@@ -172,11 +166,11 @@ Works for any `CompleteLattice`, not just `Prop`.
 public def LatticeSplit.mkBackwardRule
     (c : LatticeSplit) (as : Array Expr) (excessArgs : Array Expr)
     (resultType? : Option Expr := none)
-    : SymM BackwardRule := do
+    : MetaM BackwardRule := do
   let as ← as.mapM fun arg => do
-    mkFreshExprMVar (userName := `a) (← Sym.inferType arg)
+    mkFreshExprMVar (userName := `a) (← Meta.inferType arg)
   let ss ← excessArgs.mapM fun arg => do
-    mkFreshExprMVar (userName := `s) (← Sym.inferType arg)
+    mkFreshExprMVar (userName := `s) (← Meta.inferType arg)
 
   let (goal, eqGoalDistributed) ← c.mkDistributeEq as ss resultType?
 
@@ -211,7 +205,7 @@ public def LatticeSplit.mkBackwardRule
     State binders are named positionally from `stateArgNames` (else `s`); their names ride
     on the premise and are later introduced with the right user-facing names. -/
 private def mkPostPointwisePremise (postSpec postTarget postTy : Expr) (ssTypes : Array Expr)
-    (stateArgNames : Array Name := #[]) : SymM Expr := do
+    (stateArgNames : Array Name := #[]) : MetaM Expr := do
   let .forallE _ α _ _ := postTy
     | throwError "expected a postcondition function, got {indentExpr postTy}"
   withLocalDeclD `a α fun a => do
@@ -227,7 +221,7 @@ private def mkPostPointwisePremise (postSpec postTarget postTy : Expr) (ssTypes 
     - Otherwise, if `EPred` is `EPost.Cons`, project `epostSpec.head`/`.tail` and decompose those
     - Otherwise → single mvar for `epostSpec ⊑ epostAbstract` -/
 private partial def decomposeEPostRel (EPred epostSpec epostAbstract : Expr)
-    (stateArgNames : Array Name := #[]) : SymM Expr := do
+    (stateArgNames : Array Name := #[]) : MetaM Expr := do
   match_expr epostSpec with
   | EPost.Cons.mk ehTy etTy head tail =>
     let absHead ← mkAppM ``EPost.Cons.head #[epostAbstract]
@@ -244,7 +238,7 @@ private partial def decomposeEPostRel (EPred epostSpec epostAbstract : Expr)
     else
       -- Collect state types: e.g. String → Nat → Prop → skip first (exc type), rest are state types
       let ssTypes ← forallTelescope ehTy fun xs _ => xs.drop 1 |>.mapM (Meta.inferType ·)
-      let headTy ← Sym.inferType head
+      let headTy ← Meta.inferType head
       let hHeadTy ← mkPostPointwisePremise head absHead headTy ssTypes stateArgNames
       let hHead ← mkFreshExprMVar (userName := `epostImpl) hHeadTy
       mkAppM ``EPost.Cons.mk_le #[head, tail, epostAbstract, hHead, hTail]
@@ -256,7 +250,7 @@ private partial def decomposeEPostRel (EPred epostSpec epostAbstract : Expr)
       let specTail ← mkAppM ``EPost.Cons.tail #[epostSpec]
       let absHead ← mkAppM ``EPost.Cons.head #[epostAbstract]
       let absTail ← mkAppM ``EPost.Cons.tail #[epostAbstract]
-      let headTy ← Sym.inferType specHead
+      let headTy ← Meta.inferType specHead
       -- Collect state types: e.g. String → Nat → Prop → skip first (exc type), rest are state types
       let ssTypes ← forallTelescope ehTy fun xs _ => xs.drop 1 |>.mapM (Meta.inferType ·)
       let hHeadTy ← mkPostPointwisePremise specHead absHead headTy ssTypes stateArgNames
@@ -359,7 +353,7 @@ prf : ∀ (pre : Prop) (α : Type) (x : StateT Nat Id α) (β : Type)
 -/
 private def mkSpecBackwardProof
     (pre prog postSpec epostSpec specProof EPred : Expr) (ss ssTypes : Array Expr)
-    (stateArgNames : Array Name := #[]) : SymM AbstractMVarsResult := do
+    (stateArgNames : Array Name := #[]) : MetaM AbstractMVarsResult := do
   /- we start with `pre ⊑ wp prog post epost` where
   1. `pre` represents the Lean expression for `pre`
   2. `prog`, `postSpec`, and `epostSpec` are the selected arguments of the spec's `wp` RHS
@@ -373,7 +367,7 @@ private def mkSpecBackwardProof
   /- abstract concrete `post` if it is not already abstract -/
   unless postAbstract.isMVar do
     /- `α → Pred`: type of `post` -/
-    let postTy ← Sym.inferType postSpec
+    let postTy ← Meta.inferType postSpec
     /- mvar `postAbstract` for new abstract `post` -/
     postAbstract ← mkFreshExprMVar (userName := `Post) postTy
     /- premise type `∀ (a : α) (s₁ : σ₁) ... (sₙ : σₙ), postSpec a s₁ ... sₙ → postAbstract a s₁ ... sₙ` -/
@@ -394,7 +388,7 @@ private def mkSpecBackwardProof
   /- abstract concrete `epost` if it is not already abstract -/
   unless epostAbstract.isMVar do
     /- `EPost⟨t₁, t₂, ..., tₙ⟩`: type of `epost` -/
-    let epostTy ← Sym.inferType epostSpec
+    let epostTy ← Meta.inferType epostSpec
     /- mvar `epostAbstract` for new abstract `epost` -/
     epostAbstract ← mkFreshExprMVar (userName := `EPost) epostTy
     /- if `epost` is `⊥`, then `epost ⊑ epostAbstract` holds trivially and
@@ -452,7 +446,7 @@ Given a spec `pre ⊑ wp prog post epost` where the lattice type is
   `info.Pred = σ1 → ... → σn → Prop`
 -/
 public def tryMkBackwardRuleFromSpec (specThm : SpecTheorem) (info : WPInfo)
-    (stateArgNames : Array Name := #[]) : OptionT SymM BackwardRule := do
+    (stateArgNames : Array Name := #[]) : OptionT MetaM BackwardRule := do
   -- Instantiate the spec theorem, creating metavars for all universally quantified params
   let (_xs, _bs, specProof, specType) ← specThm.instantiate
   let_expr PartialOrder.rel Pred' _cl' pre rhs := specType
@@ -466,7 +460,7 @@ public def tryMkBackwardRuleFromSpec (specThm : SpecTheorem) (info : WPInfo)
   let mut ss := #[]
   let mut ssTypes := #[]
   for h : i in [0:info.excessArgs.size] do
-    let ty ← Sym.inferType info.excessArgs[i]
+    let ty ← Meta.inferType info.excessArgs[i]
     ssTypes := ssTypes.push ty
     ss := ss.push <| ← mkFreshExprMVar (userName := stateArgNames[i]?.getD `s) ty
   let res ← mkSpecBackwardProof pre prog postSpec epostSpec specProof info.EPred ss ssTypes stateArgNames
@@ -498,11 +492,11 @@ The postcondition, exception postcondition and precondition are created as metav
 abstracted by `abstractMVars`, giving a reusable proof term for `mkBackwardRuleFromExpr`.
 -/
 private def mkSimpBackwardProof
-    (info : WPInfo) (α m lhs rhs eqPrf : Expr) (ss : Array Expr) : SymM AbstractMVarsResult := do
+    (info : WPInfo) (α m lhs rhs eqPrf : Expr) (ss : Array Expr) : MetaM AbstractMVarsResult := do
   let postTy ← mkArrow α info.Pred
   let post ← mkFreshExprMVar (userName := `Post) postTy
   let epost ← mkFreshExprMVar (userName := `EPost) info.EPred
-  let mkWpApplyPostEpost (prog : Expr) : SymM Expr := do
+  let mkWpApplyPostEpost (prog : Expr) : MetaM Expr := do
     let wpProg ← mkAppOptM ``Std.Internal.Do.wp #[m, none, none, none, none, none, none, α, prog, post, epost]
     return mkAppN wpProg ss
   let lhsWp ← mkWpApplyPostEpost lhs
@@ -516,8 +510,8 @@ private def mkSimpBackwardProof
     let progWp ← mkWpApplyPostEpost prog
     let body ← mkAppM ``PartialOrder.rel #[pre, progWp]
     mkLambdaFVars #[prog] body
-  let eqProof ← liftMetaM <| Meta.mkCongrArg motive eqPrf
-  let prf ← liftMetaM <| Meta.mkEqMPR eqProof h
+  let eqProof ← Meta.mkCongrArg motive eqPrf
+  let prf ← Meta.mkEqMPR eqProof h
   abstractMVars prf
 
 /--
@@ -543,7 +537,7 @@ pre ⊑ wp lhs post epost s₁ ... sₙ
 ```
 -/
 public def tryMkBackwardRuleFromSimp (specThm : SpecTheorem) (info : WPInfo)
-    : OptionT SymM BackwardRule := do
+    : OptionT MetaM BackwardRule := do
   let wpInstTy ← whnfR (← Meta.inferType info.instWP)
   let_expr Std.Internal.Do.WPMonad m' Pred' _EPred _monadInst _instAL _instEAL := wpInstTy
     | throwError "expected a WPMonad instance, got {wpInstTy}"
@@ -552,7 +546,7 @@ public def tryMkBackwardRuleFromSimp (specThm : SpecTheorem) (info : WPInfo)
   let (xs, _, eqPrf, eqType) ← specThm.instantiate
   let_expr Eq eqα lhs rhs := eqType
     | throwError "simp spec is not an equation: {eqType}"
-  let wpType ← liftMetaM <| Meta.inferType info.instWP
+  let wpType ← Meta.inferType info.instWP
   let α ← mkFreshExprMVar (mkSort wpType.getAppFn.constLevels![0]!.succ)
   guard <| ← isDefEqGuarded eqα (mkApp info.m α)
   for x in xs do
@@ -563,13 +557,13 @@ public def tryMkBackwardRuleFromSimp (specThm : SpecTheorem) (info : WPInfo)
       catch _ =>
         pure ()
   -- Reduce projections, for example dictionary projections exposed after instance synthesis.
-  let rhs ← liftMetaM <| Meta.transform rhs (pre := fun e => do
+  let rhs ← show MetaM Expr from Meta.transform rhs (pre := fun e => do
     if let .proj .. := e then
       if let some r ← withDefault <| Meta.reduceProj? e then return .done r
     return .continue)
   let mut ss := #[]
   for arg in info.excessArgs do
-    let ty ← Sym.inferType arg
+    let ty ← Meta.inferType arg
     ss := ss.push <| ← mkFreshExprMVar (userName := `s) ty
   let res ← mkSimpBackwardProof info α info.m lhs rhs eqPrf ss
   mkBackwardRuleFromExpr res.expr res.paramNames.toList
@@ -583,14 +577,14 @@ Uses `SplitInfo.withAbstract` to introduce abstract fvars for the split componen
 then `SplitInfo.splitWith` to build the splitting proof. Hypothesis types are
 discovered via `rwIfOrMatcher` inside the splitter telescope. -/
 public def mkBackwardRuleForSplit
-    (splitInfo : SplitInfo) (info : WPInfo) : SymM BackwardRule := do
+    (splitInfo : SplitInfo) (info : WPInfo) : MetaM BackwardRule := do
   let m := info.m
-  let mTy ← Sym.inferType m
+  let mTy ← Meta.inferType m
   let some aTy := if mTy.isForall then some mTy.bindingDomain! else none
     | throwError "Expected monad type constructor at {indentExpr m}"
   let prf ←
     withLocalDeclD `a aTy fun a => do
-    let ma ← shareCommon <| mkApp m a
+    let ma := mkApp m a
     splitInfo.withAbstract ma fun abstractInfo splitFVars => do
     -- Eta-reduce matcher alts for the backward rule pattern to avoid expensive
     -- higher-order unification. The alts are eta-expanded by `withAbstract` so that
@@ -600,14 +594,14 @@ public def mkBackwardRuleForSplit
       | .matcher matcherApp =>
         { matcherApp with alts := matcherApp.alts.map Expr.eta }.toExpr
     let excessArgNamesTypes ← info.excessArgs.mapM fun arg =>
-      return (`s, ← Sym.inferType arg)
+      return (`s, ← Meta.inferType arg)
     withLocalDeclsDND excessArgNamesTypes fun ss => do
-    withLocalDeclD `Post (← shareCommon (← mkArrow a info.Pred)) fun post => do
+    withLocalDeclD `Post (← mkArrow a info.Pred) fun post => do
     withLocalDeclD `EPost info.EPred fun epost => do
     let mkWP (prog : Expr) : Expr :=
       let args := info.args.take 7 ++ #[a, prog, post, epost]
       mkAppN (mkAppN info.head args) ss
-    let Pred' ← Sym.inferType (mkWP abstractProg)
+    let Pred' ← Meta.inferType (mkWP abstractProg)
     withLocalDeclD `Pre Pred' fun pre => do
     let sampleGoal ← mkAppM ``PartialOrder.rel #[pre, mkWP abstractProg]
     let relArgs := sampleGoal.getAppArgs
@@ -616,10 +610,10 @@ public def mkBackwardRuleForSplit
     -- Use synthetic opaque mvars so that `rwIfOrMatcher`'s `assumption` cannot
     -- accidentally assign our subgoal metavariables.
     let subgoals ← splitInfo.altInfos.mapM fun _ =>
-      liftMetaM <| mkFreshExprSyntheticOpaqueMVar (mkSort 0)
+      mkFreshExprSyntheticOpaqueMVar (mkSort 0)
     let namedSubgoals := subgoals.mapIdx fun i mv => ((`h).appendIndexAfter (i+1), mv)
     withLocalDeclsDND namedSubgoals fun subgoalHyps => do
-    let prf ← liftMetaM <|
+    let prf ←
       abstractInfo.splitWith
         (useSplitter := true)
         (mkGoal abstractProg)
@@ -639,13 +633,11 @@ public def mkBackwardRuleForSplit
             mkLambdaFVars #[x] (mkGoal x)
           let eqProof ← mkAppM ``congrArg #[context, res.proof?.get!]
           mkEqMPR eqProof (mkAppN subgoalHyps[idx]! altParams))
-    let prf ← liftMetaM <| instantiateMVars prf
+    let prf ← instantiateMVars prf
     mkLambdaFVars (#[a] ++ splitFVars ++ ss ++ #[post, epost, pre] ++ subgoalHyps) prf
   let prf ← instantiateMVars prf
   let res ← abstractMVars prf
   mkBackwardRuleFromExpr res.expr res.paramNames.toList
-
-end NewMetaTheory
 
 end VCGen
 end Lean.Elab.Tactic.Do.Internal

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
@@ -7,329 +7,623 @@ module
 
 prelude
 public import Lean.Elab.Tactic.Do.VCGen.Split
+public import Lean.Elab.Tactic.Do.Internal.VCGen.Context
 public import Lean.Elab.Tactic.Do.Internal.VCGen.Reduce
 public import Lean.Elab.Tactic.Do.Internal.VCGen.SpecDB
 public import Lean.Meta.Sym.AlphaShareBuilder
 public import Lean.Meta.Sym.Apply
 public import Lean.Meta.Sym.InstantiateMVarsS
 public import Lean.Meta.Sym.Util
+import Lean.Meta.Sym.InferType
 import Lean.Meta.WHNF
 
 open Lean Meta Elab Tactic Sym
-open Lean.Elab.Tactic.Do.SpecAttr
-open Std.Do
+open Lean.Elab.Tactic.Do.Internal.SpecAttr
 
 namespace Lean.Elab.Tactic.Do.Internal
 
 namespace VCGen
 
 /-!
-Construction of `BackwardRule`s from `SpecTheoremNew`s and split info. Pure
+Construction of `BackwardRule`s from `SpecTheorem`s and split info. Pure
 `SymM` — no knowledge of `VCGenM`. The `VCGenM` cache wrappers live in
 `VCGen.RuleCache`.
 -/
 
-/-- Build goal: `P ⊢ₛ wp⟦prog⟧ Q ss...`. Meant to be partially applied for convenience. -/
-private def mkGoal (u v : Level) (m σs ps instWP α : Expr) (ss : Array Expr) (P Q : Expr) (prog : Expr) : Expr :=
-  mkApp3 (mkConst ``SPred.entails [u]) σs P
-    (mkAppN (mkApp4 (mkConst ``PredTrans.apply [u]) ps α
-      (mkApp5 (mkConst ``WP.wp [u, v]) m ps instWP α prog) Q) ss)
+section NewMetaTheory
 
-/-- Extract the program from a goal built by `mkGoal`. -/
-private def extractProgFromGoal (goal : Expr) : Expr :=
-  goal.getArg! 2 |>.getArg! 2 |>.getArg! 4
+open Sym.Internal
+open Std.Internal.Do Lean.Order
+
+/-! ## Logic rules
+
+Backward rules for decomposing lattice logic connectives (`⊓`, `⇨`, `⌜·⌝`, `⊤`) on the RHS of an
+entailment `pre ⊑ e s₁ … sₙ`.
+-/
+
+/-- A lattice logic connective decomposed by VCGen. -/
+public inductive LogicOp where
+  /-- The lattice meet `⊓`. -/
+  | And
+  /-- The Heyting implication `⇨`. -/
+  | Imp
+  /-- The pure assertion embedding `⌜·⌝`. -/
+  | Pure
+  /-- The lattice top `⊤`. Has no operands; the split lemma `le_top` has no premise, so this
+      closes the goal (it is the nullary analogue of `Pure`). -/
+  | Top
+
+/-- Map lattice connective declaration names to supported `LogicOp`s. -/
+public def _root_.Lean.Name.toLogicOp? : Name → Option LogicOp
+  | ``meet => some .And
+  | ``himp => some .Imp
+  | ``Lean.Order.CompleteLattice.ofProp => some .Pure
+  | ``Lean.Order.top => some .Top
+  | _ => none
+
+private def LogicOp.mkLatticeExpr (as : Array Expr) (resultType? : Option Expr := none) : LogicOp → MetaM Expr
+  | .And => mkAppM ``meet as
+  | .Imp => mkAppM ``himp as
+  | .Pure => mkAppOptM ``Lean.Order.CompleteLattice.ofProp #[resultType?, none, some as[0]!]
+  | .Top => mkAppOptM ``Lean.Order.top #[resultType?, none]
+
+/-- Map a logic operator to its corresponding pointwise `_apply` lemma. -/
+public def LogicOp.toApplyLemma : LogicOp → Name
+  | .And => ``meet_apply
+  | .Imp => ``himp_apply
+  | .Pure => ``Lean.Order.CompleteLattice.ofProp_apply
+  | .Top => ``Lean.Order.top_apply
+
+/-- Whether the operands of this logic operator are functions of the excess (state)
+    arguments, and so must be applied to each excess argument when descending one
+    lattice level during `mkApplyEq`.
+
+    For `meet`/`himp` the operands are themselves elements of the function lattice
+    (`(a ⊓ b) s = a s ⊓ b s`), so each operand `a` becomes `a s`. For `ofProp`/`top` the
+    operand is reused unchanged (`(⌜p⌝ : σ→β) s = (⌜p⌝ : β)`, `(⊤ : σ→β) s = (⊤ : β)`), so it must
+    *not* be applied to `s`. -/
+private def LogicOp.needApplyArgs : LogicOp → Bool
+  | .And => true
+  | .Imp => true
+  | .Pure => false
+  | .Top => false
+
+/-- Map a logic operator to its `⊑`-form splitting lemma.
+
+    When `preIsTop` is set, the precondition is `⊤`, so `.Imp` uses the `⊤`-specialized lemma
+    `himp_complete_top` (`a ⊑ b → ⊤ ⊑ a ⇨ b`) instead of `himp_complete`, dropping the redundant
+    `⊓ ⊤`. `.And`/`.Pure` already produce `⊓ ⊤`-free subgoals, so they are unaffected. -/
+private def LogicOp.toRelLemma (preIsTop : Bool) : LogicOp → Name
+  | .And => ``le_meet           -- le_meet (x y z) : x ⊑ y → x ⊑ z → x ⊑ y ⊓ z
+  | .Imp => if preIsTop then ``himp_complete_top -- himp_complete_top (a b) : a ⊑ b → ⊤ ⊑ a ⇨ b
+            else ``himp_complete                 -- himp_complete (x a b) : a ⊓ x ⊑ b → x ⊑ a ⇨ b
+  | .Pure => ``Lean.Order.le_ofProp -- le_ofProp (x p) : p → x ⊑ ⌜p⌝
+  | .Top => ``le_top            -- le_top (x) : x ⊑ ⊤  (no premise ⇒ closes the goal)
+
+/-- Lift an equality `lhs = rhs` to `(lhs args...) = (rhs args...)`. -/
+private def liftEqByArgs (eqPrf : Expr) (args : List Expr) : MetaM Expr := do
+  if args.isEmpty then
+    return eqPrf
+  let eqTy ← inferType eqPrf
+  let some (_, lhs, _rhs) := eqTy.eq?
+    | throwError "Expected equality proof, got {indentExpr eqTy}"
+  let lhsTy ← inferType lhs
+  let context ← withLocalDecl `x .default lhsTy fun x => do
+    let app := mkAppN x args.toArray
+    mkLambdaFVars #[x] app
+  mkCongrArg context eqPrf
 
 /--
-Create a backward rule for the `SpecTheoremNew` that was looked up in the database.
-In order for the backward rule to apply, we need to instantiate both `m` and `ps` with the ones
-given by the use site, and perhaps emit verification conditions for spec lemmas that would not
-apply everywhere.
+Apply a pointwise `_apply` lemma repeatedly over all excess arguments, producing an equality at
+the fully applied level.
+
+Example (`lop = .And`, `stepThm = ``meet_apply`, `as = #[a, b]`, `ss = [s₁, s₂]`): the resulting
+proof has type `((a ⊓ b) s₁ s₂) = (a s₁ s₂ ⊓ b s₁ s₂)`.
+-/
+private partial def LogicOp.mkApplyEq
+    (stepThm : Name) (lop : LogicOp)
+    (as : Array Expr) (ss : List Expr) (resultType? : Option Expr := none) : MetaM Expr := do
+  match ss with
+  | [] => mkEqRefl =<< lop.mkLatticeExpr as resultType?
+  | s :: ss' =>
+    let args := as.push s |>.map some
+    let rt := resultType?.map .bindingBody!
+    let step ← mkAppOptM stepThm <| #[none, rt, none] ++ args
+    if ss'.isEmpty then
+      return step
+    let stepLift ← liftEqByArgs step ss'
+    -- Descend one lattice level: only operators whose operands depend on the excess
+    -- arguments (see `LogicOp.needApplyArgs`) get their operands applied to `s`.
+    let as := if lop.needApplyArgs then as.map (mkApp · s) else as
+    let rest ← lop.mkApplyEq stepThm as ss' rt
+    mkEqTrans stepLift rest
+
+/-- Distribute a logic connective through function applications via its `_apply` lemma,
+    staying at the lattice level. Returns `((a ⊓ b) s₁…sₙ, eq)` where
+    `eq : (a ⊓ b) s₁…sₙ = (a s₁…sₙ ⊓ b s₁…sₙ)`. -/
+private def LogicOp.mkDistributeEq
+    (lop : LogicOp) (as ss : Array Expr) (resultType? : Option Expr := none) : SymM (Expr × Expr) := do
+  let applyLemma := lop.toApplyLemma
+  let lat ← lop.mkLatticeExpr as resultType?
+  let goal ← mkAppNS lat ss
+  let eqFun ← lop.mkApplyEq applyLemma as ss.toList resultType?
+  return (goal, eqFun)
+
+/--
+Creates a reusable backward rule for a lattice logic expression in `⊑` form.
+Chains distribution (`_apply`) with the split lemma (`le_meet`/`himp_complete`).
+
+For `And`, produces:
+```
+∀ (a b : l) (s₁ : σ₁) ... (sₙ : σₙ) (pre : l'),
+  pre ⊑ a s₁...sₙ → pre ⊑ b s₁...sₙ → pre ⊑ (a ⊓ b) s₁...sₙ
+```
+For `Imp`, produces:
+```
+∀ (a b : l) (s₁ : σ₁) ... (sₙ : σₙ) (pre : l'),
+  a s₁...sₙ ⊓ pre ⊑ b s₁...sₙ → pre ⊑ (a ⇨ b) s₁...sₙ
+```
+Works for any `CompleteLattice`, not just `Prop`.
+
+When `preIsTop` is set, the precondition `pre` is fixed to `⊤` (rather than abstracted as a
+parameter) and `Imp` uses the `⊤`-specialized split lemma `himp_complete_top`, so the `Imp` rule
+becomes
+```
+∀ (a b : l) (s₁ : σ₁) ... (sₙ : σₙ),
+  a s₁...sₙ ⊑ b s₁...sₙ → ⊤ ⊑ (a ⇨ b) s₁...sₙ
+```
+dropping the redundant `⊓ ⊤`.
+-/
+public def LogicOp.mkBackwardRule
+    (lop : LogicOp) (as : Array Expr) (excessArgs : Array Expr)
+    (resultType? : Option Expr := none) (preIsTop : Bool := false)
+    : SymM BackwardRule := do
+  let as ← as.mapM fun arg => do
+    mkFreshExprMVar (userName := `a) (← Sym.inferType arg)
+  let ss ← excessArgs.mapM fun arg => do
+    mkFreshExprMVar (userName := `s) (← Sym.inferType arg)
+
+  let (goal, eqGoalDistributed) ← lop.mkDistributeEq as ss resultType?
+
+  let goalTy ← Meta.inferType goal
+  -- When the precondition is `⊤`, bake it into the rule (and use a `⊤`-specialized split lemma
+  -- below) so the resulting subgoals avoid the redundant `⊓ ⊤`. Otherwise the precondition is a
+  -- fresh metavariable that becomes a universally quantified parameter of the rule.
+  let pre ← if preIsTop then
+      mkAppOptM ``Lean.Order.top #[goalTy, none]
+    else
+      mkFreshExprMVar (userName := `Pre) goalTy
+
+  -- Lift equality through `pre ⊑ ·`: (pre ⊑ goal) = (pre ⊑ distributed)
+  -- Use partial application (not lambda) to avoid beta redexes
+  let relPreGoal ← mkAppM ``PartialOrder.rel #[pre]
+  let relEq ← mkCongrArg relPreGoal eqGoalDistributed
+  let relEqSymm ← mkEqSymm relEq
+  -- eqMp : (pre ⊑ distributed) → (pre ⊑ goal)
+  let eqMp ← mkAppM ``Eq.mp #[relEqSymm]
+
+  -- Instantiate the split lemma (le_meet / himp_complete / himp_complete_top) via telescope
+  let splitLemma ← mkConstWithFreshMVarLevels (lop.toRelLemma preIsTop)
+  let (xs, _, body) ← forallMetaTelescope (← Meta.inferType splitLemma)
+  -- Unify conclusion with eqMp's domain to assign param mvars
+  unless ← isDefEq body (← Meta.inferType eqMp).bindingDomain! do
+    throwError "Expected {← Meta.inferType eqMp}.bindingDomain! = {← Meta.inferType body}"
+  -- Compose (abstractMVars handles instantiation of assigned mvars)
+  let prf := mkApp eqMp (mkAppN splitLemma xs)
+
+  let res ← abstractMVars prf
+  mkBackwardRuleFromExpr res.expr res.paramNames.toList
+
+/-! ## Spec rules -/
+
+/-- Build the explicit pointwise implication premise used to weaken a concrete `post`.
+    State binders are named positionally from `stateArgNames` (else `s`); their names ride
+    on the premise and are later introduced with the right user-facing names. -/
+private def mkPostPointwisePremise (postSpec postTarget postTy : Expr) (ssTypes : Array Expr)
+    (stateArgNames : Array Name := #[]) : SymM Expr := do
+  let .forallE _ α _ _ := postTy
+    | throwError "expected a postcondition function, got {indentExpr postTy}"
+  withLocalDeclD `a α fun a => do
+    let ssNamesTypes := ssTypes.mapIdx fun i ty => (stateArgNames[i]?.getD `s, ty)
+    withLocalDeclsDND ssNamesTypes fun ss' => do
+      let lhs := postSpec.betaRev <| ss'.reverse.push a
+      let rhs := mkAppN (mkApp postTarget a) ss'
+      mkForallFVars (#[a] ++ ss') (← mkAppM ``PartialOrder.rel #[lhs, rhs])
+
+/-- Recursively decompose `epostSpec ⊑ epostAbstract` into per-component proofs.
+    - `EPost.Cons.mk head tail` → mvar for `head ⊑ epostAbstract.head`, recurse on tail
+    - `EPost.Nil.mk` → trivial via `EPost.Nil.le`
+    - Otherwise, if `EPred` is `EPost.Cons`, project `epostSpec.head`/`.tail` and decompose those
+    - Otherwise → single mvar for `epostSpec ⊑ epostAbstract` -/
+private partial def decomposeEPostRel (EPred epostSpec epostAbstract : Expr)
+    (stateArgNames : Array Name := #[]) : SymM Expr := do
+  match_expr epostSpec with
+  | EPost.Cons.mk ehTy etTy head tail =>
+    let absHead ← mkAppM ``EPost.Cons.head #[epostAbstract]
+    let absTail ← mkAppM ``EPost.Cons.tail #[epostAbstract]
+    let hTail ← decomposeEPostRel etTy tail absTail stateArgNames
+    /- Sometimes, even though `epost` is not schematic itself, its components might be schematic.
+      Think of a triple of a kind `⦃ pre ⦄ x ⦃ post; epost₁, ⊥, epost₃, ⊥, ... ⦄`.
+      In this case we do not want to create new metavariables for `epost₁`, `epost₃`, etc.
+      Instead, we will just assign them to `epostAbstract.tail.head` and
+      `epostAbstract.tail.tail.head`, etc. -/
+    if head.isMVar then
+      head.mvarId!.assign absHead
+      mkAppM ``EPost.Cons.mk_le_tail #[tail, epostAbstract, hTail]
+    else
+      -- Collect state types: e.g. String → Nat → Prop → skip first (exc type), rest are state types
+      let ssTypes ← forallTelescope ehTy fun xs _ => xs.drop 1 |>.mapM (Meta.inferType ·)
+      let headTy ← Sym.inferType head
+      let hHeadTy ← mkPostPointwisePremise head absHead headTy ssTypes stateArgNames
+      let hHead ← mkFreshExprMVar (userName := `epostImpl) hHeadTy
+      mkAppM ``EPost.Cons.mk_le #[head, tail, epostAbstract, hHead, hTail]
+  | EPost.Nil.mk => mkAppM ``EPost.Nil.le #[epostAbstract]
+  | _ =>
+    match_expr EPred.consumeMData with
+    | EPost.Cons ehTy etTy =>
+      let specHead ← mkAppM ``EPost.Cons.head #[epostSpec]
+      let specTail ← mkAppM ``EPost.Cons.tail #[epostSpec]
+      let absHead ← mkAppM ``EPost.Cons.head #[epostAbstract]
+      let absTail ← mkAppM ``EPost.Cons.tail #[epostAbstract]
+      let headTy ← Sym.inferType specHead
+      -- Collect state types: e.g. String → Nat → Prop → skip first (exc type), rest are state types
+      let ssTypes ← forallTelescope ehTy fun xs _ => xs.drop 1 |>.mapM (Meta.inferType ·)
+      let hHeadTy ← mkPostPointwisePremise specHead absHead headTy ssTypes stateArgNames
+      let hHead ← mkFreshExprMVar (userName := `epostImpl) hHeadTy
+      let hTail ← decomposeEPostRel etTy specTail absTail stateArgNames
+      mkAppM ``EPost.Cons.mk_le #[specHead, specTail, epostAbstract, hHead, hTail]
+    | EPost.Nil => mkAppM ``EPost.Nil.le #[epostAbstract]
+    | _ =>
+      let hTy ← mkAppM ``PartialOrder.rel #[epostSpec, epostAbstract]
+      mkFreshExprMVar (userName := `epostImpl) hTy
+
+/--
+Create the proof term for the backward rule built from an instantiated spec theorem.
+In order for the backward rule to apply, the concrete precondition, postcondition and exception
+postcondition appearing in the spec may need to be generalized into rule parameters, emitting
+verification conditions for the generalization.
 
 ### General idea
 
-Consider the spec theorem `Spec.bind`:
+Consider the spec theorem `WPMonad.wp_bind`:
 ```
-Spec.bind : ∀ {m : Type u → Type v} {ps : PostShape} [inst : Monad m] [inst_1 : WPMonad m ps]
-  {α β : Type u} {x : m α} {f : α → m β} {Q : PostCond β ps},
-  ⦃wp⟦x⟧ (fun a => wp⟦f a⟧ Q, Q.snd)⦄ (x >>= f) ⦃Q⦄
+WPMonad.wp_bind :
+  wp x (fun a => wp (f a) post epost) epost ⊑ wp (x >>= f) post epost
 ```
-This theorem is already in "WP-form", so its postcondition `Q` is schematic (i.e., a ∀-bound var).
-However, its precondition `wp⟦x⟧ ...` is not. Hence we must emit a VC for the precondition:
+This theorem is already in WP-form, so `post` and `epost` are schematic. However, its precondition
+`wp x (fun a => wp (f a) post epost) epost` is not. Hence we must emit a VC for the precondition:
 ```
-prf : ∀ {m : Type u → Type v} {ps : PostShape} [inst : Monad m] [inst_1 : WPMonad m ps]
-  {α β : Type u} {x : m α} {f : α → m β} {Q : PostCond β ps}
-  (P : Assertion ps) (hpre : P ⊢ₛ wp⟦x⟧ (fun a => wp⟦f a⟧ Q, Q.snd)),
-  P ⊢ₛ wp⟦x >>= f⟧ Q
+prf : ∀ {α β} (x : m α) (f : α → m β) (post : β → Pred) (epost : EPred)
+  (pre : Pred) (hpre : pre ⊑ wp x (fun a => wp (f a) post epost) epost),
+  pre ⊑ wp (x >>= f) post epost
 ```
-(Note that `P ⊢ₛ wp⟦x >>= f⟧ Q` is the definition of `⦃P⦄ (x >>= f) ⦃Q⦄`.)
-Where `prf` is constructed by doing `SPred.entails.trans hpre spec` under the forall telescope.
-The conclusion of this rule applies to any situation where `bind` is the top-level symbol in the
-program.
+The proof term is constructed with `PartialOrder.rel_trans hpre WPMonad.wp_bind`.
 
 #### Postcondition VCs
 
-Similarly, a VC `hpost` is generated for the postcondition if it isn't schematic.
-The details here are more complicated because we need to make available the pure facts in `P`
-to prove `Q' ⊢ₚ Q`, so the `hpost` obligation becomes `P ⊢ₛ ⌜Q' ⊢ₚ Q⌝`.
-For example, a hypothetical restrictive spec for `pure` in `Id` would be:
+Similarly, a VC is generated for the postcondition if it is not schematic. For example, a
+hypothetical restrictive spec for `pure` could be:
 ```
-myPure.spec (n : Nat) : ⦃fun x => ⌜True⌝⦄ myPure n ⦃⇓ r x => ⌜r = n⌝⦄
+myPure.spec (n : Nat) : (⊤ : Prop) ⊑ wp (myPure n) (fun r => r = n) epost
 ```
-This yields the following backward rule:
+This yields a backward rule of the form:
 ```
-prf : ∀ (n : Nat) (P : Assertion .pure) (hpre : P ⊢ₛ ⌜True⌝)
-  (Q : PostCond Nat .pure) (hpost : P ⊢ₛ ⌜(⇓ r => ⌜r = n⌝) ⊢ₚ Q⌝),
-  P ⊢ₛ wp⟦myPure n⟧ Q
+prf : ∀ (n : Nat) (pre : Prop) (hpre : pre ⊑ True)
+  (post : Nat → Prop) (hpost : ∀ r, r = n ⊑ post r) (epost : EPost⟨⟩),
+  pre ⊑ wp (myPure n) post epost
 ```
+The postcondition VC is pointwise over the return value and over any excess state arguments. The
+proof is generalized with `WPMonad.wp_consequence_le`.
 
-The `prf` term in this (most general) case is
+#### Exception postcondition VCs
+
+A VC is also generated for the exception postcondition if it is not schematic. For an `EPost.Cons`
+value, the relation `epostSpec ⊑ epost` is decomposed component by component:
 ```
-fun n P hpre Q hpost =>
-  SPred.pure_elim hpost fun h =>
-    SPred.entails.trans (SPred.entails.trans hpre (myPure.spec n))
-      (PredTrans.mono (wp (myPure n)) (⇓ r => ⌜r = n⌝) Q h)
+∀ e s₁ ... sₙ, epostSpec.head e s₁ ... sₙ ⊑ epost.head e s₁ ... sₙ
 ```
+and recursively for the tail. `decomposeEPostRel` assembles these component VCs using
+`EPost.Cons.mk_le` and `EPost.Nil.le`; the proof is then generalized with `WPMonad.wp_econs_le`.
+When the spec exception postcondition is `⊥`, no VC is needed and `WPMonad.wp_econs_bot_le` is
+used instead.
 
 #### Excess state arguments
 
-Furthermore, when there are excess state arguments `[s₁, ..., sₙ]` involved, we rather need to
-specialize the backward rule for that:
+Furthermore, when there are excess state arguments `[s₁, ..., sₙ]` involved, the proof is
+specialized to those arguments:
 ```
-... : ∀ {m : Type u → Type v} {ps : PostShape} [inst : Monad m] [inst_1 : WPMonad m ps]
-  {α β : Type u} {x : m α} {f : α → m β} {Q : PostCond β ps}
-  (P : Assertion ...) (hpre : P ⊢ₛ wp⟦x⟧ (fun a => wp⟦f a⟧ Q, Q.snd) s₁ ... sₙ),
-  P ⊢ₛ wp⟦x >>= f⟧ Q s₁ ... sₙ
+... :
+  pre ⊑ wp x (fun a => wp (f a) post epost) epost s₁ ... sₙ →
+  pre ⊑ wp (x >>= f) post epost s₁ ... sₙ
 ```
+The precondition and all generated pointwise postcondition premises are applied to these same state
+arguments.
 
 ### Caching
 
-It turns out we can cache backward rules for the cache key `(specThm, m, excessArgs.size)`.
-This is very important for performance and helps getting rid of the overhead imposed by the
-generality of `Std.Do`. We do that in the `VCGenM` wrapper `mkBackwardRuleFromSpecCached`.
-Furthermore, in order to avoid re-checking the same proof in the kernel, we generate an auxiliary
-lemma for the backward rule.
+It turns out we can cache backward rules for the cache key
+`(specThm.proof.key, instWP, excessArgs.size)`. This is important for performance and helps avoid
+rebuilding the same rule for every goal that uses the same spec theorem, `WPMonad` instance and
+number of excess state arguments. We do that in the `VCGenM` wrapper
+`mkBackwardRuleFromSpecCached`.
 
-### Specialization and unfolding of `Std.Do` abbreviations and defs
+The rule is built from the abstracted proof returned here via `mkBackwardRuleFromExpr`. This keeps
+the proof construction reusable even when the proof still contains free variables from the goal
+context, such as generic monad or WP instance parameters.
+
+### Specialization
 
 It is unnecessary to use the `bind` rule in full generality. It is much more efficient to specialize
-it for the particular monad, postshape and `WP` instance. In doing so we can also unfold many
-`Std.Do` abbreviations, such as `Assertion ps` and `PostCond α ps`.
-We do that by doing `unfoldReducible` on the forall telescope. The type for `StateM Nat` and one
-excess state arg `s` becomes
-```
-prf : ∀ (α : Type) (x : StateT Nat Id α) (β : Type) (f : α → StateT Nat Id β)
-        (Q : (β → Nat → ULift Prop) × ExceptConds (PostShape.arg Nat PostShape.pure)) (s : Nat)
-        (P : ULift Prop) (hpre : P ⊢ₛ wp⟦x⟧ (fun a => wp⟦f a⟧ Q, Q.snd) s),
-        P ⊢ₛ wp⟦x >>= f⟧ Q s
-```
-We are still investigating how to get rid of more kernel unfolding overhead, such as for `wp` and
-`List.rec`.
--/
-public def mkBackwardRuleFromSpec (specThm : SpecTheoremNew) (m σs ps instWP : Expr) (excessArgs : Array Expr) : SymM BackwardRule := do
-  let preprocessExpr : Expr → SymM Expr := shareCommon <=< liftMetaM ∘ unfoldReducible
-  -- Create a backward rule for the spec we look up in the database.
-  -- In order for the backward rule to apply, we need to instantiate both `m` and `ps` with the ones
-  -- given by the use site.
-  let (xs, _bs, spec, specTy) ← specThm.proof.instantiate
-  let_expr f@Triple m' ps' instWP' α prog P Q := specTy
-    | liftMetaM <| throwError "target not a Triple application {specTy}"
-  -- Reject the spec and try the next if the monad doesn't match.
-  -- `withDefault`: spec/goal instance projections (e.g. `WPMonad.toWP`)
-  -- needs default to unfold; the ambient grind transparency is `reducible`.
-  unless ← Meta.withDefault <| isDefEqGuarded m m' do
-    throwError "Post program defeq Monad mismatch: {m} ≠ {m'}"
-  unless ← Meta.withDefault <| isDefEqGuarded ps ps' do
-    throwError "Post program defeq Postshape mismatch: {ps} ≠ {ps'}"
-  unless ← Meta.withDefault <| isDefEqGuarded instWP instWP' do
-    throwError "Post program defeq WP instance mismatch: {instWP} ≠ {instWP'}"
+it for the particular predicate type, exception postcondition type and `WPMonad` instance.
+`tryMkBackwardRuleFromSpec` does that by instantiating the spec theorem and checking that its
+`Pred` and `WPMonad` arguments match the ones from the use site.
 
-  -- We must ensure that P and Q are pattern variables so that the spec matches for every potential
-  -- P and Q. We do so by introducing VCs accordingly.
-  -- The following code could potentially be extracted into a definition at @[spec] attribute
-  -- annotation time. That might help a bit with kernel checking time.
-  let excessArgNamesTypes ← excessArgs.mapM fun arg =>
-    return (← mkFreshUserName `s, ← Meta.inferType arg)
-  let spec ← withLocalDeclsDND excessArgNamesTypes fun ss => do
-    let needPreVC := !excessArgs.isEmpty || !xs.contains P
-    let needPostVC := !xs.contains Q
-    let us := f.constLevels!
-    let u := us[0]!
-    let wp := mkApp5 (mkConst ``WP.wp us) m ps instWP α prog
-    let wpApplyQ := mkApp4 (mkConst ``PredTrans.apply [u]) ps α wp Q  -- wp⟦prog⟧ Q
-    let Pss ← reduceHead <| mkAppN P ss  -- P s₁ ... sₙ
-    let typeP ← preprocessExpr (mkApp (mkConst ``SPred [u]) σs)
-      -- Note that this is the type of `P s₁ ... sₙ`,
-      -- which is `Assertion ps'`, but we don't know `ps'`
-    let typeQ ← preprocessExpr (mkApp2 (mkConst ``PostCond [u]) α ps)
-    let mut declInfos := #[]
-    if needPreVC then
-      let nmP' ← mkFreshUserName `P
-      let nmHPre ← mkFreshUserName `hpre
-      let entailment P' := preprocessExpr <| mkApp3 (mkConst ``SPred.entails [u]) σs P' Pss
-      declInfos := #[(nmP', .default, fun _ => pure typeP),
-                     (nmHPre, .default, fun xs => entailment xs.back!)]
-    if needPostVC then
-      let nmQ' ← mkFreshUserName `Q
-      let nmHPost ← mkFreshUserName `hpost
-      -- Wrap PostCond.entails under the precondition frame: `P ⊢ₛ ⌜Q_spec ⊢ₚ Q'⌝`.
-      -- This preserves pure precondition facts (e.g., `s = 42`) in the postcondition VC,
-      -- which would otherwise be lost in a bare `PostCond.entails`.
-      let framedEntailment (xs : Array Expr) := do
-        let Q' := xs.back!
-        let bare ← preprocessExpr <| mkApp4 (mkConst ``PostCond.entails [u]) α ps Q Q'
-        let pureBare := mkApp2 (mkConst ``SPred.pure [u]) σs bare
-        let frame := if needPreVC then xs[0]! else Pss
-        preprocessExpr <| mkApp3 (mkConst ``SPred.entails [u]) σs frame pureBare
-      declInfos := declInfos ++
-                   #[(nmQ', .default, fun _ => pure typeQ),
-                     (nmHPost, .default, framedEntailment)]
-    withLocalDecls declInfos fun ys => liftMetaM ∘ mkLambdaFVars (ss ++ ys) =<< do
-      if !needPreVC && !needPostVC && excessArgs.isEmpty then
-        -- Still need to unfold the triple in the spec type
-        let entailment ← preprocessExpr <| mkApp3 (mkConst ``SPred.entails [u]) σs P wpApplyQ
-        let prf ← mkExpectedTypeHint spec entailment
-        -- check prf
-        return prf
-      let mut prf := spec
-      let P := Pss  -- P s₁ ... sₙ
-      let wpApplyQ := mkAppN wpApplyQ ss  -- wp⟦prog⟧ Q s₁ ... sₙ
-      prf := prf.beta ss -- Turn `⦃P⦄ prog ⦃Q⦄` into `P s₁ ... sₙ ⊢ₛ wp⟦prog⟧ Q s₁ ... sₙ`
-      let mut newP := P
-      let mut newQ := Q
-      if needPreVC then
-        -- prf := hpre.trans prf
-        let P' := ys[0]!
-        let hpre := ys[1]!
-        prf := mkApp6 (mkConst ``SPred.entails.trans [u]) σs P' P wpApplyQ hpre prf
-        newP := P'
-        -- check prf
-      if needPostVC then
-        -- prf := pure_elim hpost (fun h => prf.trans <| (wp x).mono _ _ h)
-        let wp := mkApp5 (mkConst ``WP.wp f.constLevels!) m ps instWP α prog
-        let Q' := ys[ys.size-2]!
-        let hpost := ys[ys.size-1]!
-        let wpApplyQ' := mkApp4 (mkConst ``PredTrans.apply [u]) ps α wp Q' -- wp⟦prog⟧ Q'
-        let wpApplyQ' := mkAppN wpApplyQ' ss -- wp⟦prog⟧ Q' s₁ ... sₙ
-        -- Build `lambdaProof`: fun (h : Q ⊢ₚ Q') => entails.trans prf (mono wp Q Q' h ss)
-        let phi ← preprocessExpr <| mkApp4 (mkConst ``PostCond.entails [u]) α ps Q Q'
-        let hmono := mkApp6 (mkConst ``PredTrans.mono [u]) ps α wp Q Q' (mkBVar 0)
-        let hmono := mkAppN hmono ss
-        let innerPrf := mkApp6 (mkConst ``SPred.entails.trans [u]) σs newP wpApplyQ wpApplyQ' prf hmono
-        let lambdaProof := mkLambda `h .default phi innerPrf
-        prf := mkApp6 (mkConst ``SPred.pure_elim [u]) σs newP wpApplyQ' phi hpost lambdaProof
-        newQ := Q'
-        -- check prf
-      return prf
-  -- We use `mkBackwardRuleFromExpr` instead of `mkAuxLemma` + `mkBackwardRuleFromDecl` because
-  -- the proof may contain free variables from the goal context (e.g., generic `m`, `ps`),
-  -- which would cause `mkAuxLemma`'s `addDecl` to fail with a kernel error.
-  let spec ← instantiateMVars spec
-  let res ← abstractMVars spec
-  mkBackwardRuleFromExpr res.expr res.paramNames.toList
+For `StateM Nat` and one excess state arg `s`, the type produced for `WPMonad.wp_bind` becomes
+```
+prf : ∀ (pre : Prop) (α : Type) (x : StateT Nat Id α) (β : Type)
+  (f : α → StateT Nat Id β) (post : β → Nat → Prop) (epost : EPost⟨⟩) (s : Nat),
+  pre ⊑ wp x (fun a => wp (f a) post epost) epost s →
+  pre ⊑ wp (x >>= f) post epost s
+```
+-/
+private def mkSpecBackwardProof
+    (pre prog postSpec epostSpec specProof EPred : Expr) (ss ssTypes : Array Expr)
+    (stateArgNames : Array Name := #[]) : SymM AbstractMVarsResult := do
+  /- we start with `pre ⊑ wp prog post epost` where
+  1. `pre` represents the Lean expression for `pre`
+  2. `prog`, `postSpec`, and `epostSpec` are the selected arguments of the spec's `wp` RHS
+  3. `specProof` is the proof of the spec `pre ⊑ wp prog postSpec epostSpec`
+  4. `ss` represents the Lean expressions for the state variables `s1`, `s2`, ..., `sn`
+  5. `ssTypes` represents the Lean types for the state variables `s1`, `s2`, ..., `sn` -/
+  let mut postAbstract := postSpec.consumeMData
+  let mut epostAbstract := epostSpec.consumeMData
+  let mut specApplied := specProof
+
+  /- abstract concrete `post` if it is not already abstract -/
+  unless postAbstract.isMVar do
+    /- `α → Pred`: type of `post` -/
+    let postTy ← Sym.inferType postSpec
+    /- mvar `postAbstract` for new abstract `post` -/
+    postAbstract ← mkFreshExprMVar (userName := `Post) postTy
+    /- premise type `∀ (a : α) (s₁ : σ₁) ... (sₙ : σₙ), postSpec a s₁ ... sₙ → postAbstract a s₁ ... sₙ` -/
+    let hpostTy ← mkPostPointwisePremise postSpec postAbstract postTy ssTypes stateArgNames
+    /- mvar `?postImpl` for the proof of the premise -/
+    let hpost ← mkFreshExprMVar (userName := `postImpl) hpostTy
+    /- `wp_consequence_le` expects its premise at the *function-lattice* order `postSpec ⊑ postAbstract`,
+       whereas `hpost` is stated pointwise (`∀ a s…, postSpec a s… ⊑ postAbstract a s…`). The two are
+       defeq, but unfolding the function-lattice `⊑` instance is blocked when the post's domain is a
+       metavariable (e.g. the accumulator `β` of a `forIn` loop spec). Cast `hpost` to the function
+       order here so the defeq is forced at this depth, keeping the user-facing VC pointwise. -/
+    let relTy ← mkAppM ``PartialOrder.rel #[postSpec, postAbstract]
+    let hpostRel ← mkExpectedTypeHint hpost relTy
+    /- get the proof of `pre ⊑ wp prog postAbstract epostSpec`, where `post` is abstracted.
+       Uses wp_consequence_le: post ⊑ post' → pre ⊑ wp x post epost → pre ⊑ wp x post' epost -/
+    specApplied ← mkAppM ``WPMonad.wp_consequence_le #[prog, postSpec, postAbstract, epostSpec, hpostRel, specApplied]
+
+  /- abstract concrete `epost` if it is not already abstract -/
+  unless epostAbstract.isMVar do
+    /- `EPost⟨t₁, t₂, ..., tₙ⟩`: type of `epost` -/
+    let epostTy ← Sym.inferType epostSpec
+    /- mvar `epostAbstract` for new abstract `epost` -/
+    epostAbstract ← mkFreshExprMVar (userName := `EPost) epostTy
+    /- if `epost` is `⊥`, then `epost ⊑ epostAbstract` holds trivially and
+      abstracting `epost` can be simply done by `WPMonad.wp_econs_bot_le` without
+      introducing a new premise. This case is quite common, that's why we handle
+      it specially. -/
+    let isBot ← try
+        let botEPost ← mkAppOptM ``Lean.Order.bot #[epostTy, none]
+        isDefEqGuarded epostSpec botEPost
+      catch _ => pure false
+    if isBot then
+      /- get the proof of `pre ⊑ wp prog postAbstract epostAbstract`, where `epost (= ⊥)` is abstracted.
+        This proof DOES NOT have a `?epostImpl` premise -/
+      specApplied ← mkAppM ``WPMonad.wp_econs_bot_le #[prog, postAbstract, epostAbstract, specApplied]
+    else
+      /- Decompose `epostSpec ⊑ epostAbstract` into per-component proofs
+        using `EPost.Cons.mk_le` and `EPost.Nil.le` -/
+      let hepost ← decomposeEPostRel EPred epostSpec epostAbstract stateArgNames
+      specApplied ← mkAppM ``WPMonad.wp_econs_le #[prog, postAbstract, epostSpec, epostAbstract, hepost, specApplied]
+
+  /- By default we always abstract `pre`, since in most of the specifications
+    `pre` is not schematic. In exceptional cases, where `pre` is schematic, it
+    is redundant, but we still do that to keep the code simple.
+
+    Here we also apply the excess state arguments to `pre` and `wp prog postAbstract epostAbstract` -/
+  /- use `beta` to create `pre s₁ ... sₙ`  to avoid creating beta redexes when `pre` is a lambda -/
+  let preApplied := pre.beta ss
+  /- proof of the original theorem with abstracted `post` and `epost` specialized to the excess state arguments -/
+  specApplied := mkAppN specApplied ss
+  /- `wp prog postAbstract epostAbstract s₁ ... sₙ` -/
+  let wpTy ← mkAppM ``Std.Internal.Do.wp <| #[prog, postAbstract, epostAbstract] ++ ss
+  let specAppliedTy ← mkAppM ``PartialOrder.rel #[preApplied, wpTy]
+  /- later when the whole proof is type checked, we want to help the kernel by providing the expected type -/
+  specApplied ← mkExpectedTypeHint specApplied specAppliedTy
+  let preAppliedTy ← Meta.inferType preApplied
+  /- create a new mvar for the abstracted `pre` -/
+  let preAbstract ← mkFreshExprMVar (userName := `Pre) preAppliedTy
+  let specAbstractTy ← mkAppM ``PartialOrder.rel #[preAbstract, preApplied]
+  /- create a new mvar for the proof of the abstracted `pre` -/
+  let specAbstract ← mkFreshExprMVar (userName := `vc) specAbstractTy
+  /- use `PartialOrder.rel_trans` to compose the abstracted `pre` and the proof of the original theorem -/
+  specApplied ← mkAppM ``PartialOrder.rel_trans #[specAbstract, specApplied]
+
+  abstractMVars specApplied
 
 /--
-Create a backward rule for a simp/equational spec `∀ xs, lhs = rhs`.
+Try to build a backward rule from a single spec theorem in `⊑` form.
 
-Instantiates the equation, unifies with the monad `m`, synthesizes typeclass instances,
-reduces projections and applies `unfoldReducible` to the RHS. Then builds a backward rule
-of the form:
-```
-∀ Q s₁ ... sₙ P (h : P ⊢ₛ wp⟦rhs_reduced⟧ Q s₁ ... sₙ), P ⊢ₛ wp⟦lhs⟧ Q s₁ ... sₙ
-```
-using `Eq.mpr` with a `congrArg` proof.
+Given a spec `pre ⊑ wp prog post epost` where the lattice type is
+`info.Pred = σ1 → ... → σn → Prop`, produces an auxiliary lemma.
 
-For example, `MonadState.get.eq_1 : get = self.1` with `m = StateT σ m'` yields a rule
-that rewrites `wp⟦get⟧` to `wp⟦MonadStateOf.get⟧` (after instance synthesis + projection
-reduction + unfoldReducible).
+- `info.Pred`: the goal's lattice type (e.g. `Nat → Prop`)
+- `info.instWP`: the `WPMonad` instance for the goal monad
+- `info.excessArgs`: free variables representing state args from
+  `info.Pred = σ1 → ... → σn → Prop`
 -/
-public def mkBackwardRuleFromSimpSpec (specThm : SpecTheoremNew) (m σs ps instWP : Expr)
-    (excessArgs : Array Expr) : SymM BackwardRule := do
-  let preprocessExpr : Expr → SymM Expr := shareCommon <=< liftMetaM ∘ unfoldReducible
-  let wpType ← liftMetaM <| Meta.inferType instWP
-  let us := wpType.getAppFn.constLevels!
-  let u := us[0]!
-  let v := us[1]!
+public def tryMkBackwardRuleFromSpec (specThm : SpecTheorem) (info : WPInfo)
+    (stateArgNames : Array Name := #[]) : OptionT SymM BackwardRule := do
+  -- Instantiate the spec theorem, creating metavars for all universally quantified params
+  let (_xs, _bs, specProof, specType) ← specThm.instantiate
+  let_expr PartialOrder.rel Pred' _cl' pre rhs := specType
+    | throwError "target not a partial order ⊑ application {specType}"
+  guard <| ← isDefEqGuarded info.Pred Pred'
+  let_expr Std.Internal.Do.wp _m' _Pred' _EPred' _monadInst' _instAL' _instEAL' instWP' _α prog postSpec epostSpec := rhs
+    | throwError "target not a wp application {rhs}"
+  guard <| ← isDefEqGuarded info.instWP instWP'
+  -- Use local excess-state binders so explicit post premises can be re-lifted to `⊑`.
+  -- Name them positionally from `stateArgNames` (else `s`) so the rule's binders carry good names.
+  let mut ss := #[]
+  let mut ssTypes := #[]
+  for h : i in [0:info.excessArgs.size] do
+    let ty ← Sym.inferType info.excessArgs[i]
+    ssTypes := ssTypes.push ty
+    ss := ss.push <| ← mkFreshExprMVar (userName := stateArgNames[i]?.getD `s) ty
+  let res ← mkSpecBackwardProof pre prog postSpec epostSpec specProof info.EPred ss ssTypes stateArgNames
+  mkBackwardRuleFromExpr res.expr res.paramNames.toList
+
+/-! ## Equality spec rules
+
+Backward rules for `@[spec]` lemmas registered through the simp/unfold side of the spec database.
+Such lemmas have the shape `lhs = rhs`; the generated rule rewrites a `wp lhs` goal to a `wp rhs`
+premise and lets VCGen continue decomposing `rhs`.
+-/
+
+/--
+Create the proof term for a backward rule built from an equality spec theorem.
+
+Given an instantiated equality spec `lhs = rhs` where both sides have type `m α`, this constructs a
+rule proof of the form
+```
+pre ⊑ wp rhs post epost s₁ ... sₙ →
+pre ⊑ wp lhs post epost s₁ ... sₙ
+```
+The proof rewrites the whole weakest-precondition target using `Eq.mpr` with a `congrArg` proof:
+```
+motive = fun prog => pre ⊑ wp prog post epost s₁ ... sₙ
+Eq.mpr (congrArg motive eqPrf) h
+```
+
+The postcondition, exception postcondition and precondition are created as metavariables and then
+abstracted by `abstractMVars`, giving a reusable proof term for `mkBackwardRuleFromExpr`.
+-/
+private def mkSimpBackwardProof
+    (info : WPInfo) (α m lhs rhs eqPrf : Expr) (ss : Array Expr) : SymM AbstractMVarsResult := do
+  let postTy ← mkArrow α info.Pred
+  let post ← mkFreshExprMVar (userName := `Post) postTy
+  let epost ← mkFreshExprMVar (userName := `EPost) info.EPred
+  let mkWpApplyPostEpost (prog : Expr) : SymM Expr := do
+    let wpProg ← mkAppOptM ``Std.Internal.Do.wp #[m, none, none, none, none, none, none, α, prog, post, epost]
+    return mkAppN wpProg ss
+  let lhsWp ← mkWpApplyPostEpost lhs
+  let rhsWp ← mkWpApplyPostEpost rhs
+  let preTy ← Meta.inferType lhsWp
+  let pre ← mkFreshExprMVar (userName := `Pre) preTy
+  let premiseType ← mkAppM ``PartialOrder.rel #[pre, rhsWp]
+  let h ← mkFreshExprMVar (userName := `h) premiseType
+  let mα := mkApp info.m α
+  let motive ← withLocalDeclD `prog mα fun prog => do
+    let progWp ← mkWpApplyPostEpost prog
+    let body ← mkAppM ``PartialOrder.rel #[pre, progWp]
+    mkLambdaFVars #[prog] body
+  let eqProof ← liftMetaM <| Meta.mkCongrArg motive eqPrf
+  let prf ← liftMetaM <| Meta.mkEqMPR eqProof h
+  abstractMVars prf
+
+/--
+Try to build a backward rule from a single equality spec theorem.
+
+This is the equality-spec counterpart of `tryMkBackwardRuleFromSpec`. It instantiates the theorem,
+checks that the equation type is definitionally equal to `info.m α` for the current monad, and
+checks that `info.Pred` and `info.instWP` match the current goal.
+
+After instantiation it tries to synthesize unresolved typeclass metavariables. This is needed for
+abstract monad equations such as `Spec.UnfoldLift.get`, where matching a concrete monad like
+`ExceptT ε (StateM σ)` leaves dictionary arguments to be filled.
+
+The RHS is normalized by reducing projections. For example, class projection unfold lemmas often
+produce RHS terms containing projections from instance dictionaries; reducing them exposes the
+actual operation that VCGen should continue on.
+
+Finally, `info.excessArgs` are represented by fresh metavariables and `mkSimpBackwardProof` builds
+the proof:
+```
+pre ⊑ wp rhs post epost s₁ ... sₙ →
+pre ⊑ wp lhs post epost s₁ ... sₙ
+```
+-/
+public def tryMkBackwardRuleFromSimp (specThm : SpecTheorem) (info : WPInfo)
+    : OptionT SymM BackwardRule := do
+  let wpInstTy ← whnfR (← Meta.inferType info.instWP)
+  let_expr Std.Internal.Do.WPMonad m' Pred' _EPred _monadInst _instAL _instEAL := wpInstTy
+    | throwError "expected a WPMonad instance, got {wpInstTy}"
+  guard <| ← isDefEqGuarded info.m m'
+  guard <| ← isDefEqGuarded info.Pred Pred'
   let (xs, _, eqPrf, eqType) ← specThm.instantiate
   let_expr Eq eqα lhs rhs := eqType
-    | liftMetaM <| throwError "simp spec is not an equation: {eqType}"
-  let α ← mkFreshExprMVar (mkSort u.succ)
-  unless ← isDefEqGuarded eqα (mkApp m α) do
-    throwError "Simp spec: could not unify equation type {eqα} with {mkApp m α}"
+    | throwError "simp spec is not an equation: {eqType}"
+  let wpType ← liftMetaM <| Meta.inferType info.instWP
+  let α ← mkFreshExprMVar (mkSort wpType.getAppFn.constLevels![0]!.succ)
+  guard <| ← isDefEqGuarded eqα (mkApp info.m α)
   for x in xs do
     if x.isMVar && !(← x.mvarId!.isAssigned) then
       let xType ← Meta.inferType x
-      try liftMetaM <| Meta.synthInstance xType >>= x.mvarId!.assign catch _ => pure ()
-  -- Reduce projections (e.g., `inst.1` → `getThe σ` when inst is a concrete dictionary).
+      try
+        x.mvarId!.assign (← Meta.synthInstance xType)
+      catch _ =>
+        pure ()
+  -- Reduce projections, for example dictionary projections exposed after instance synthesis.
   let rhs ← liftMetaM <| Meta.transform rhs (pre := fun e => do
     if let .proj .. := e then
       if let some r ← withDefault <| Meta.reduceProj? e then return .done r
     return .continue)
-  let rhs ← shareCommon (← liftMetaM <| unfoldReducible rhs)
-  -- Build the backward rule
-  let excessArgNamesTypes ← excessArgs.mapM fun arg =>
-    return (← mkFreshUserName `s, ← Meta.inferType arg)
-  let typeQ ← preprocessExpr (mkApp2 (mkConst ``PostCond [u]) α ps)
-  let spec ←
-    withLocalDeclD `Q typeQ fun Q => do
-    withLocalDeclsDND excessArgNamesTypes fun ss => do
-    let mkWpApplyQss prog := do
-      let wp ← Sym.Internal.mkAppS₅ (mkConst ``WP.wp [u, v]) m ps instWP α prog
-      let mut t ← Sym.Internal.mkAppS₄ (mkConst ``PredTrans.apply [u]) ps α wp Q
-      for s in ss do t ← Sym.Internal.mkAppS t s
-      pure t
-    let lhsWp ← mkWpApplyQss lhs
-    let rhsWp ← mkWpApplyQss rhs
-    let typeP ← preprocessExpr (mkApp (mkConst ``SPred [u]) σs)
-    withLocalDeclD `P typeP fun P => do
-    let conclusionType ← preprocessExpr <| mkApp3 (mkConst ``SPred.entails [u]) σs P lhsWp
-    let premiseType ← preprocessExpr <| mkApp3 (mkConst ``SPred.entails [u]) σs P rhsWp
-    withLocalDeclD `h premiseType fun h => do
-    -- Build: Eq.mpr (congrArg motive eqPrf) h
-    -- motive = fun prog => P ⊢ₛ wp⟦prog⟧ Q s₁ ... sₙ
-    let mα ← preprocessExpr (mkApp m α)
-    let motiveBody := mkApp3 (mkConst ``SPred.entails [u]) σs P
-      (mkAppN (mkApp4 (mkConst ``PredTrans.apply [u]) ps α
-        (mkApp5 (mkConst ``WP.wp [u, v]) m ps instWP α (.bvar 0)) Q) ss)
-    let motive := Expr.lam `prog mα motiveBody .default
-    let eqProof ← liftMetaM <| Meta.mkCongrArg motive eqPrf
-    let prf := mkApp4 (mkConst ``Eq.mpr [0]) conclusionType premiseType eqProof h
-    liftMetaM <| mkLambdaFVars (#[Q] ++ ss ++ #[P, h]) prf
-  let spec ← instantiateMVars spec
-  let res ← abstractMVars spec
+  let mut ss := #[]
+  for arg in info.excessArgs do
+    let ty ← Sym.inferType arg
+    ss := ss.push <| ← mkFreshExprMVar (userName := `s) ty
+  let res ← mkSimpBackwardProof info α info.m lhs rhs eqPrf ss
   mkBackwardRuleFromExpr res.expr res.paramNames.toList
 
-open Lean.Elab.Tactic.Do in
-/--
-Creates a reusable backward rule for splitting `ite`, `dite`, or matchers.
+/-! ## Split rules -/
 
-Uses `SplitInfo.withAbstract` to open fvars for the split, then `SplitInfo.splitWith`
-to build the splitting proof. Hypothesis types are discovered via `rwIfOrMatcher` inside
-the splitter telescope.
--/
-public def mkBackwardRuleForSplit (splitInfo : SplitInfo) (m σs ps instWP : Expr) (excessArgs : Array Expr) : SymM BackwardRule := do
-  let preprocessExpr : Expr → SymM Expr := shareCommon <=< liftMetaM ∘ unfoldReducible
-  let wpType ← liftMetaM <| Meta.inferType instWP
-  let us := wpType.getAppFn.constLevels!
-  let u := us[0]!
-  let v := us[1]!
+open Lean.Elab.Tactic.Do in
+/-- Creates a reusable backward rule for splitting `ite`, `dite`, or matchers.
+
+Uses `SplitInfo.withAbstract` to introduce abstract fvars for the split components,
+then `SplitInfo.splitWith` to build the splitting proof. Hypothesis types are
+discovered via `rwIfOrMatcher` inside the splitter telescope. -/
+public def mkBackwardRuleForSplit
+    (splitInfo : SplitInfo) (info : WPInfo) : SymM BackwardRule := do
+  let m := info.m
+  let mTy ← Sym.inferType m
+  let some aTy := if mTy.isForall then some mTy.bindingDomain! else none
+    | throwError "Expected monad type constructor at {indentExpr m}"
   let prf ←
-    withLocalDeclD `α (mkSort u.succ) fun α => do
-    let mα ← preprocessExpr <| mkApp m α
-    splitInfo.withAbstract mα fun abstractInfo splitFVars => do
-    -- Eta-reduce alts so the backward rule pattern uses clean fvar alts, avoiding expensive
-    -- higher-order unification. The alts are eta-expanded in `withAbstract` so that
-    -- `splitWith`/`matcherApp.transform` can `instantiateLambda` them.
+    withLocalDeclD `a aTy fun a => do
+    let ma ← shareCommon <| mkApp m a
+    splitInfo.withAbstract ma fun abstractInfo splitFVars => do
+    -- Eta-reduce matcher alts for the backward rule pattern to avoid expensive
+    -- higher-order unification. The alts are eta-expanded by `withAbstract` so that
+    -- `splitWith`/`matcherApp.transform` can `instantiateLambda` them directly.
     let abstractProg := match abstractInfo with
       | .ite e | .dite e => e
       | .matcher matcherApp =>
         { matcherApp with alts := matcherApp.alts.map Expr.eta }.toExpr
-    let excessArgNamesTypes ← excessArgs.mapM fun arg => return (`s, ← Meta.inferType arg)
+    let excessArgNamesTypes ← info.excessArgs.mapM fun arg =>
+      return (`s, ← Sym.inferType arg)
     withLocalDeclsDND excessArgNamesTypes fun ss => do
-    withLocalDeclD `P (← preprocessExpr <| mkApp (mkConst ``SPred [u]) σs) fun P => do
-    withLocalDeclD `Q (← preprocessExpr <| mkApp2 (mkConst ``PostCond [u]) α ps) fun Q => do
-    let mkGoal := mkGoal u v m σs ps instWP α ss P Q
-    -- Subgoal types are synthetic opaque metavariables, filled in the `splitWith` callback below.
-    -- Synthetic opaque so that `rwIfOrMatcher`'s `assumption` tactic cannot assign them.
+    withLocalDeclD `Post (← shareCommon (← mkArrow a info.Pred)) fun post => do
+    withLocalDeclD `EPost info.EPred fun epost => do
+    let mkWP (prog : Expr) : Expr :=
+      let args := info.args.take 7 ++ #[a, prog, post, epost]
+      mkAppN (mkAppN info.head args) ss
+    let Pred' ← Sym.inferType (mkWP abstractProg)
+    withLocalDeclD `Pre Pred' fun pre => do
+    let sampleGoal ← mkAppM ``PartialOrder.rel #[pre, mkWP abstractProg]
+    let relArgs := sampleGoal.getAppArgs
+    let relHead := mkAppN sampleGoal.getAppFn (relArgs.extract 0 3)
+    let mkGoal (prog : Expr) : Expr := mkApp relHead (mkWP prog)
+    -- Use synthetic opaque mvars so that `rwIfOrMatcher`'s `assumption` cannot
+    -- accidentally assign our subgoal metavariables.
     let subgoals ← splitInfo.altInfos.mapM fun _ =>
       liftMetaM <| mkFreshExprSyntheticOpaqueMVar (mkSort 0)
     let namedSubgoals := subgoals.mapIdx fun i mv => ((`h).appendIndexAfter (i+1), mv)
@@ -339,19 +633,28 @@ public def mkBackwardRuleForSplit (splitInfo : SplitInfo) (m σs ps instWP : Exp
         (useSplitter := true)
         (mkGoal abstractProg)
         (fun _name bodyType idx altFVars => do
-          let prog := extractProgFromGoal bodyType
+          -- Extract the program from `bodyType` (the substituted alt goal type).
+          -- For matchers, `bodyType` has the discriminant replaced by the constructor
+          -- pattern (e.g., `Nat.zero` instead of `discr`), which is required for
+          -- `rwMatcher` to discharge the equality hypotheses of congr equation theorems.
+          -- For ite/dite, `bodyType` equals `mkGoal abstractProg` so this is equivalent.
+          let prog := bodyType.getArg! 3 |>.getArg! 8
           let res ← rwIfOrMatcher idx prog
           if res.proof?.isNone then
-            throwError "mkBackwardRuleForSplit: rwIfOrMatcher failed for alt {idx}\n{indentExpr prog}"
-          let boundFVars := altFVars.all
-          subgoals[idx]!.mvarId!.assign (← mkForallFVars boundFVars (mkGoal res.expr))
-          let context ← withLocalDecl `e .default mα fun e =>
-            mkLambdaFVars #[e] (mkGoal e)
-          (← Simp.mkCongrArg context res).mkEqMPR (mkAppN subgoalHyps[idx]! boundFVars))
-    mkLambdaFVars (#[α] ++ splitFVars ++ ss ++ #[P, Q] ++ subgoalHyps) prf
+            throwError "mkBackwardRuleForSplit: rwIfOrMatcher failed for alt {idx}"
+          let altParams := altFVars.all
+          subgoals[idx]!.mvarId!.assign (← mkForallFVars altParams (mkGoal res.expr))
+          let context ← withLocalDecl `x .default ma fun x =>
+            mkLambdaFVars #[x] (mkGoal x)
+          let eqProof ← mkAppM ``congrArg #[context, res.proof?.get!]
+          mkEqMPR eqProof (mkAppN subgoalHyps[idx]! altParams))
+    let prf ← liftMetaM <| instantiateMVars prf
+    mkLambdaFVars (#[a] ++ splitFVars ++ ss ++ #[post, epost, pre] ++ subgoalHyps) prf
   let prf ← instantiateMVars prf
   let res ← abstractMVars prf
   mkBackwardRuleFromExpr res.expr res.paramNames.toList
+
+end NewMetaTheory
 
 end VCGen
 end Lean.Elab.Tactic.Do.Internal

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
@@ -41,64 +41,53 @@ Backward rules for decomposing lattice logic connectives (`⊓`, `⇨`, `⌜·�
 entailment `pre ⊑ e s₁ … sₙ`.
 -/
 
-/-- A lattice logic connective decomposed by VCGen. -/
-public inductive LogicOp where
-  /-- The lattice meet `⊓`. -/
-  | And
-  /-- The Heyting implication `⇨`. -/
-  | Imp
-  /-- The pure assertion embedding `⌜·⌝`. -/
-  | Pure
-  /-- The lattice top `⊤`. Has no operands; the split lemma `le_top` has no premise, so this
-      closes the goal (it is the nullary analogue of `Pure`). -/
-  | Top
+/-- A decomposition of a lattice logic connective on the RHS of an entailment. Bundles everything
+`LatticeSplit.mkBackwardRule` needs: how to rebuild the connective, the pointwise `_apply`
+distribution lemma, the `⊑`-form split lemma, and whether the operands depend on the excess (state)
+arguments. -/
+public structure LatticeSplit where
+  /-- Rebuild the connective from its operands `as` and the optional lattice carrier type. -/
+  mkLattice : Array Expr → Option Expr → MetaM Expr
+  /-- The pointwise `_apply` lemma distributing the connective through function application. -/
+  applyLemma : Name
+  /-- The `⊑`-form split lemma decomposing `pre ⊑ connective`. -/
+  relLemma : Name
+  /-- Whether the operands are functions of the excess (state) arguments, and so must be applied to
+  each excess argument when descending one lattice level during `mkApplyEq`.
 
-/-- Map lattice connective declaration names to supported `LogicOp`s. -/
-public def _root_.Lean.Name.toLogicOp? : Name → Option LogicOp
-  | ``meet => some .And
-  | ``himp => some .Imp
-  | ``Lean.Order.CompleteLattice.ofProp => some .Pure
-  | ``Lean.Order.top => some .Top
-  | _ => none
+  For `⊓`/`⇨` the operands are themselves elements of the function lattice (`(a ⊓ b) s = a s ⊓ b s`),
+  so each operand `a` becomes `a s`. For `⌜·⌝`/`⊤` the operand is reused unchanged
+  (`(⌜p⌝ : σ→β) s = (⌜p⌝ : β)`, `(⊤ : σ→β) s = (⊤ : β)`), so it must not be applied to `s`. -/
+  needApplyArgs : Bool
 
-private def LogicOp.mkLatticeExpr (as : Array Expr) (resultType? : Option Expr := none) : LogicOp → MetaM Expr
-  | .And => mkAppM ``meet as
-  | .Imp => mkAppM ``himp as
-  | .Pure => mkAppOptM ``Lean.Order.CompleteLattice.ofProp #[resultType?, none, some as[0]!]
-  | .Top => mkAppOptM ``Lean.Order.top #[resultType?, none]
+/-- The lattice meet `⊓`. -/
+public def LatticeSplit.meet : LatticeSplit where
+  mkLattice as _ := mkAppM ``meet as
+  applyLemma := ``meet_apply
+  relLemma := ``le_meet           -- le_meet (x y z) : x ⊑ y → x ⊑ z → x ⊑ y ⊓ z
+  needApplyArgs := true
 
-/-- Map a logic operator to its corresponding pointwise `_apply` lemma. -/
-public def LogicOp.toApplyLemma : LogicOp → Name
-  | .And => ``meet_apply
-  | .Imp => ``himp_apply
-  | .Pure => ``Lean.Order.CompleteLattice.ofProp_apply
-  | .Top => ``Lean.Order.top_apply
+/-- The Heyting implication `⇨`. -/
+public def LatticeSplit.himp : LatticeSplit where
+  mkLattice as _ := mkAppM ``himp as
+  applyLemma := ``himp_apply
+  relLemma := ``himp_complete     -- himp_complete (x a b) : a ⊓ x ⊑ b → x ⊑ a ⇨ b
+  needApplyArgs := true
 
-/-- Whether the operands of this logic operator are functions of the excess (state)
-    arguments, and so must be applied to each excess argument when descending one
-    lattice level during `mkApplyEq`.
+/-- The pure assertion embedding `⌜·⌝`. Only built when the precondition is `⊤`. -/
+public def LatticeSplit.ofProp : LatticeSplit where
+  mkLattice as resultType? :=
+    mkAppOptM ``Lean.Order.CompleteLattice.ofProp #[resultType?, none, some as[0]!]
+  applyLemma := ``Lean.Order.CompleteLattice.ofProp_apply
+  relLemma := ``Lean.Order.le_ofProp -- le_ofProp (x p) : p → x ⊑ ⌜p⌝
+  needApplyArgs := false
 
-    For `meet`/`himp` the operands are themselves elements of the function lattice
-    (`(a ⊓ b) s = a s ⊓ b s`), so each operand `a` becomes `a s`. For `ofProp`/`top` the
-    operand is reused unchanged (`(⌜p⌝ : σ→β) s = (⌜p⌝ : β)`, `(⊤ : σ→β) s = (⊤ : β)`), so it must
-    *not* be applied to `s`. -/
-private def LogicOp.needApplyArgs : LogicOp → Bool
-  | .And => true
-  | .Imp => true
-  | .Pure => false
-  | .Top => false
-
-/-- Map a logic operator to its `⊑`-form splitting lemma.
-
-    When `preIsTop` is set, the precondition is `⊤`, so `.Imp` uses the `⊤`-specialized lemma
-    `himp_complete_top` (`a ⊑ b → ⊤ ⊑ a ⇨ b`) instead of `himp_complete`, dropping the redundant
-    `⊓ ⊤`. `.And`/`.Pure` already produce `⊓ ⊤`-free subgoals, so they are unaffected. -/
-private def LogicOp.toRelLemma (preIsTop : Bool) : LogicOp → Name
-  | .And => ``le_meet           -- le_meet (x y z) : x ⊑ y → x ⊑ z → x ⊑ y ⊓ z
-  | .Imp => if preIsTop then ``himp_complete_top -- himp_complete_top (a b) : a ⊑ b → ⊤ ⊑ a ⇨ b
-            else ``himp_complete                 -- himp_complete (x a b) : a ⊓ x ⊑ b → x ⊑ a ⇨ b
-  | .Pure => ``Lean.Order.le_ofProp -- le_ofProp (x p) : p → x ⊑ ⌜p⌝
-  | .Top => ``le_top            -- le_top (x) : x ⊑ ⊤  (no premise ⇒ closes the goal)
+/-- The lattice top `⊤`. Has no operands; `le_top` has no premise, so the rule closes the goal. -/
+public def LatticeSplit.top : LatticeSplit where
+  mkLattice _ resultType? := mkAppOptM ``Lean.Order.top #[resultType?, none]
+  applyLemma := ``Lean.Order.top_apply
+  relLemma := ``le_top            -- le_top (x) : x ⊑ ⊤  (no premise ⇒ closes the goal)
+  needApplyArgs := false
 
 /-- Lift an equality `lhs = rhs` to `(lhs args...) = (rhs args...)`. -/
 private def liftEqByArgs (eqPrf : Expr) (args : List Expr) : MetaM Expr := do
@@ -117,82 +106,68 @@ private def liftEqByArgs (eqPrf : Expr) (args : List Expr) : MetaM Expr := do
 Apply a pointwise `_apply` lemma repeatedly over all excess arguments, producing an equality at
 the fully applied level.
 
-Example (`lop = .And`, `stepThm = ``meet_apply`, `as = #[a, b]`, `ss = [s₁, s₂]`): the resulting
+Example (`c = .meet`, `c.applyLemma = ``meet_apply`, `as = #[a, b]`, `ss = [s₁, s₂]`): the resulting
 proof has type `((a ⊓ b) s₁ s₂) = (a s₁ s₂ ⊓ b s₁ s₂)`.
 -/
-private partial def LogicOp.mkApplyEq
-    (stepThm : Name) (lop : LogicOp)
+private partial def LatticeSplit.mkApplyEq
+    (c : LatticeSplit)
     (as : Array Expr) (ss : List Expr) (resultType? : Option Expr := none) : MetaM Expr := do
   match ss with
-  | [] => mkEqRefl =<< lop.mkLatticeExpr as resultType?
+  | [] => mkEqRefl =<< c.mkLattice as resultType?
   | s :: ss' =>
     let args := as.push s |>.map some
     let rt := resultType?.map .bindingBody!
-    let step ← mkAppOptM stepThm <| #[none, rt, none] ++ args
+    let step ← mkAppOptM c.applyLemma <| #[none, rt, none] ++ args
     if ss'.isEmpty then
       return step
     let stepLift ← liftEqByArgs step ss'
-    -- Descend one lattice level: only operators whose operands depend on the excess
-    -- arguments (see `LogicOp.needApplyArgs`) get their operands applied to `s`.
-    let as := if lop.needApplyArgs then as.map (mkApp · s) else as
-    let rest ← lop.mkApplyEq stepThm as ss' rt
+    -- Descend one lattice level: only connectives whose operands depend on the excess
+    -- arguments (see `LatticeSplit.needApplyArgs`) get their operands applied to `s`.
+    let as := if c.needApplyArgs then as.map (mkApp · s) else as
+    let rest ← c.mkApplyEq as ss' rt
     mkEqTrans stepLift rest
 
-/-- Distribute a logic connective through function applications via its `_apply` lemma,
+/-- Distribute a lattice connective through function applications via its `_apply` lemma,
     staying at the lattice level. Returns `((a ⊓ b) s₁…sₙ, eq)` where
     `eq : (a ⊓ b) s₁…sₙ = (a s₁…sₙ ⊓ b s₁…sₙ)`. -/
-private def LogicOp.mkDistributeEq
-    (lop : LogicOp) (as ss : Array Expr) (resultType? : Option Expr := none) : SymM (Expr × Expr) := do
-  let applyLemma := lop.toApplyLemma
-  let lat ← lop.mkLatticeExpr as resultType?
+private def LatticeSplit.mkDistributeEq
+    (c : LatticeSplit) (as ss : Array Expr) (resultType? : Option Expr := none) : SymM (Expr × Expr) := do
+  let lat ← c.mkLattice as resultType?
   let goal ← mkAppNS lat ss
-  let eqFun ← lop.mkApplyEq applyLemma as ss.toList resultType?
+  let eqFun ← c.mkApplyEq as ss.toList resultType?
   return (goal, eqFun)
 
 /--
-Creates a reusable backward rule for a lattice logic expression in `⊑` form.
+Creates a reusable backward rule for a lattice connective in `⊑` form.
 Chains distribution (`_apply`) with the split lemma (`le_meet`/`himp_complete`).
 
-For `And`, produces:
+For `⊓`, produces:
 ```
 ∀ (a b : l) (s₁ : σ₁) ... (sₙ : σₙ) (pre : l'),
   pre ⊑ a s₁...sₙ → pre ⊑ b s₁...sₙ → pre ⊑ (a ⊓ b) s₁...sₙ
 ```
-For `Imp`, produces:
+For `⇨`, produces:
 ```
 ∀ (a b : l) (s₁ : σ₁) ... (sₙ : σₙ) (pre : l'),
   a s₁...sₙ ⊓ pre ⊑ b s₁...sₙ → pre ⊑ (a ⇨ b) s₁...sₙ
 ```
 Works for any `CompleteLattice`, not just `Prop`.
-
-When `preIsTop` is set, the precondition `pre` is fixed to `⊤` (rather than abstracted as a
-parameter) and `Imp` uses the `⊤`-specialized split lemma `himp_complete_top`, so the `Imp` rule
-becomes
-```
-∀ (a b : l) (s₁ : σ₁) ... (sₙ : σₙ),
-  a s₁...sₙ ⊑ b s₁...sₙ → ⊤ ⊑ (a ⇨ b) s₁...sₙ
-```
-dropping the redundant `⊓ ⊤`.
 -/
-public def LogicOp.mkBackwardRule
-    (lop : LogicOp) (as : Array Expr) (excessArgs : Array Expr)
-    (resultType? : Option Expr := none) (preIsTop : Bool := false)
+public def LatticeSplit.mkBackwardRule
+    (c : LatticeSplit) (as : Array Expr) (excessArgs : Array Expr)
+    (resultType? : Option Expr := none)
     : SymM BackwardRule := do
   let as ← as.mapM fun arg => do
     mkFreshExprMVar (userName := `a) (← Sym.inferType arg)
   let ss ← excessArgs.mapM fun arg => do
     mkFreshExprMVar (userName := `s) (← Sym.inferType arg)
 
-  let (goal, eqGoalDistributed) ← lop.mkDistributeEq as ss resultType?
+  let (goal, eqGoalDistributed) ← c.mkDistributeEq as ss resultType?
 
   let goalTy ← Meta.inferType goal
-  -- When the precondition is `⊤`, bake it into the rule (and use a `⊤`-specialized split lemma
-  -- below) so the resulting subgoals avoid the redundant `⊓ ⊤`. Otherwise the precondition is a
-  -- fresh metavariable that becomes a universally quantified parameter of the rule.
-  let pre ← if preIsTop then
-      mkAppOptM ``Lean.Order.top #[goalTy, none]
-    else
-      mkFreshExprMVar (userName := `Pre) goalTy
+  -- The precondition is a fresh metavariable that becomes a universally quantified parameter of
+  -- the rule.
+  let pre ← mkFreshExprMVar (userName := `Pre) goalTy
 
   -- Lift equality through `pre ⊑ ·`: (pre ⊑ goal) = (pre ⊑ distributed)
   -- Use partial application (not lambda) to avoid beta redexes
@@ -202,8 +177,8 @@ public def LogicOp.mkBackwardRule
   -- eqMp : (pre ⊑ distributed) → (pre ⊑ goal)
   let eqMp ← mkAppM ``Eq.mp #[relEqSymm]
 
-  -- Instantiate the split lemma (le_meet / himp_complete / himp_complete_top) via telescope
-  let splitLemma ← mkConstWithFreshMVarLevels (lop.toRelLemma preIsTop)
+  -- Instantiate the split lemma (le_meet / himp_complete / le_ofProp / le_top) via telescope
+  let splitLemma ← mkConstWithFreshMVarLevels c.relLemma
   let (xs, _, body) ← forallMetaTelescope (← Meta.inferType splitLemma)
   -- Unify conclusion with eqMp's domain to assign param mvars
   unless ← isDefEq body (← Meta.inferType eqMp).bindingDomain! do

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Sebastian Graf
+Authors: Sebastian Graf, Vladimir Gladshtein
 -/
 module
 
@@ -59,6 +59,9 @@ public structure LatticeSplit where
   so each operand `a` becomes `a s`. For `⌜·⌝`/`⊤` the operand is reused unchanged
   (`(⌜p⌝ : σ→β) s = (⌜p⌝ : β)`, `(⊤ : σ→β) s = (⊤ : β)`), so it must not be applied to `s`. -/
   needApplyArgs : Bool
+  /-- The number of explicit lattice operands the connective takes after its carrier type and
+  instance: `2` for `⊓`/`⇨`, `1` for `⌜·⌝`, `0` for `⊤`. -/
+  numOperands : Nat
 
 /-- The lattice meet `⊓`. -/
 public def LatticeSplit.meet : LatticeSplit where
@@ -66,6 +69,7 @@ public def LatticeSplit.meet : LatticeSplit where
   applyLemma := ``meet_apply
   relLemma := ``le_meet           -- le_meet (x y z) : x ⊑ y → x ⊑ z → x ⊑ y ⊓ z
   needApplyArgs := true
+  numOperands := 2
 
 /-- The Heyting implication `⇨`. -/
 public def LatticeSplit.himp : LatticeSplit where
@@ -73,14 +77,17 @@ public def LatticeSplit.himp : LatticeSplit where
   applyLemma := ``himp_apply
   relLemma := ``himp_complete     -- himp_complete (x a b) : a ⊓ x ⊑ b → x ⊑ a ⇨ b
   needApplyArgs := true
+  numOperands := 2
 
-/-- The pure assertion embedding `⌜·⌝`. Only built when the precondition is `⊤`. -/
+/-- The pure assertion embedding `⌜·⌝`. The `⊤`-fixed split lemma makes the rule apply only when the
+precondition is `⊤`, where turning `pre ⊑ ⌜p⌝` into the subgoal `p` is sound. -/
 public def LatticeSplit.ofProp : LatticeSplit where
   mkLattice as resultType? :=
     mkAppOptM ``Lean.Order.CompleteLattice.ofProp #[resultType?, none, some as[0]!]
   applyLemma := ``Lean.Order.CompleteLattice.ofProp_apply
-  relLemma := ``Lean.Order.le_ofProp -- le_ofProp (x p) : p → x ⊑ ⌜p⌝
+  relLemma := ``Lean.Order.top_le_ofProp -- top_le_ofProp (p) : p → ⊤ ⊑ ⌜p⌝
   needApplyArgs := false
+  numOperands := 1
 
 /-- The lattice top `⊤`. Has no operands; `le_top` has no premise, so the rule closes the goal. -/
 public def LatticeSplit.top : LatticeSplit where
@@ -88,6 +95,15 @@ public def LatticeSplit.top : LatticeSplit where
   applyLemma := ``Lean.Order.top_apply
   relLemma := ``le_top            -- le_top (x) : x ⊑ ⊤  (no premise ⇒ closes the goal)
   needApplyArgs := false
+  numOperands := 0
+
+/-- The lattice connectives VCGen decomposes on the RHS of an entailment, keyed by head constant. -/
+public def latticeSplits : Std.HashMap Name LatticeSplit :=
+  .ofList [
+    (``meet, .meet),
+    (``himp, .himp),
+    (``Lean.Order.CompleteLattice.ofProp, .ofProp),
+    (``Lean.Order.top, .top)]
 
 /-- Lift an equality `lhs = rhs` to `(lhs args...) = (rhs args...)`. -/
 private def liftEqByArgs (eqPrf : Expr) (args : List Expr) : MetaM Expr := do
@@ -177,7 +193,7 @@ public def LatticeSplit.mkBackwardRule
   -- eqMp : (pre ⊑ distributed) → (pre ⊑ goal)
   let eqMp ← mkAppM ``Eq.mp #[relEqSymm]
 
-  -- Instantiate the split lemma (le_meet / himp_complete / le_ofProp / le_top) via telescope
+  -- Instantiate the split lemma (le_meet / himp_complete / top_le_ofProp / le_top) via telescope
   let splitLemma ← mkConstWithFreshMVarLevels c.relLemma
   let (xs, _, body) ← forallMetaTelescope (← Meta.inferType splitLemma)
   -- Unify conclusion with eqMp's domain to assign param mvars

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -369,13 +369,13 @@ public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := g
   if let some (scope, gs) ← normalizePre? scope goal α pre target then return .goals scope gs
 
   -- Collect new local specs before any strategy that may emit multiple subgoals
-  -- (`wpMatch?`, `solveLatticeConnective?`) or apply a registered spec (`applySpec`).
+  -- (`wpMatch?`, `splitLatticeOp?`) or apply a registered spec (`applySpec`).
   let scope ← scope.collectLocalSpecs goal
 
   -- Phase 3: shape the `rhs` (reduce an EPost projection, decompose a lattice connective), then
   -- discharge a residual entailment against the lifted hypothesis.
   if let some g ← reduceEPostHead? goal target α inst pre rhs then return .goals scope [g]
-  if let some gs ← solveLatticeConnective? goal target rhs then return .goals scope gs
+  if let some gs ← splitLatticeOp? goal rhs then return .goals scope gs
   if let some gs ← liftedHyp? scope goal α pre rhs then return .goals scope gs
 
   -- Phase 4: wp decomposition. The program-shape steps below all consume one unit of fuel

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -51,7 +51,7 @@ private def isDuplicable (e : Expr) : Bool := match e with
   | .app .. => e.isAppOf ``OfNat.ofNat
 
 /-- Strategy 1: simp the target, then introduce binders if the target is a `∀`. -/
-private def tryForallIntro (goal : MVarId) (target : Expr) : VCGenM (Option (List MVarId)) := do
+private def forallIntro? (goal : MVarId) (target : Expr) : VCGenM (Option (List MVarId)) := do
   unless target.isForall do return none
   let (goal, simped) ← match ← simpGoalTelescope goal with
     | .closed => return some []
@@ -72,7 +72,7 @@ private def throwIfUnsupportedJP (name : Name) (val : Expr) : VCGenM Unit := do
 
 /-- Strategy 2: zeta-substitute a duplicable top-level `let` in the target, otherwise
 introduce it into the local context. -/
-private def tryTargetLetIntro (goal : MVarId) (target : Expr) : VCGenM (Option MVarId) := do
+private def targetLetIntro? (goal : MVarId) (target : Expr) : VCGenM (Option MVarId) := do
   let .letE name _ val body _ := target | return none
   throwIfUnsupportedJP name val
   if isDuplicable val then
@@ -83,7 +83,7 @@ private def tryTargetLetIntro (goal : MVarId) (target : Expr) : VCGenM (Option M
     return some (← introsHygienic goal)
 
 /-- Strategy 3: unfold a `Triple` target into the underlying lattice entailment. -/
-private def tryTripleUnfold (goal : MVarId) (target : Expr) : VCGenM (Option MVarId) := do
+private def tripleUnfold? (goal : MVarId) (target : Expr) : VCGenM (Option MVarId) := do
   unless target.isAppOf ``Triple do return none
   return some (← unfoldTriple goal)
 
@@ -97,7 +97,7 @@ private def getWPInfo? (rhs : Expr) : Option WPInfo :=
 
 /-- Strategy 3b: turn a bare `wp` application target (a `Prop`) into `⊤ ⊑ wp …`. Entry-point
 goals produced by the `of_wp_run_eq` lemmas have this shape. -/
-private def tryBareWPToLe (goal : MVarId) (target : Expr) : VCGenM (Option MVarId) := do
+private def bareWPToLe? (goal : MVarId) (target : Expr) : VCGenM (Option MVarId) := do
   let some _ := getWPInfo? target | return none
   let newTarget ← mkAppM ``PartialOrder.rel #[← mkAppOptM ``Lean.Order.top #[mkSort 0, none], target]
   let newTarget ← shareCommon newTarget
@@ -109,7 +109,7 @@ private def tryBareWPToLe (goal : MVarId) (target : Expr) : VCGenM (Option MVarI
 Runs before the precondition lift so a spec handoff `pre ⊑ specPre` closes by unification rather
 than an assumption search. The pattern matcher keeps synthetic-opaque invariant holes rigid, so
 `⊤ ⊑ ?inv args` is left untouched. -/
-private def tryRfl (goal : MVarId) : VCGenM (Option (List MVarId)) := do
+private def rfl? (goal : MVarId) : VCGenM (Option (List MVarId)) := do
   let .goals gs ← (← read).reflRule.apply goal | return none
   trace[Elab.Tactic.Do.vcgen] "Solved by rfl {goal}"
   return some gs
@@ -121,7 +121,7 @@ hypothesis, not an assumption search.
 
 Goals whose RHS contains metavariables are skipped: the defeq check could otherwise assign
 a post abstraction from an unrelated hypothesis. -/
-private def tryLiftedHyp (scope : VCGen.Scope) (goal : MVarId) (α pre rhs : Expr) :
+private def liftedHyp? (scope : VCGen.Scope) (goal : MVarId) (α pre rhs : Expr) :
     VCGenM (Option (List MVarId)) :=
   goal.withContext do
     unless α.isProp do return none
@@ -136,7 +136,7 @@ private def tryLiftedHyp (scope : VCGen.Scope) (goal : MVarId) (α pre rhs : Exp
 /-- Close a bare `Prop` residual, such as the subgoal of the `⌜φ⌝` lattice rule, against the
 most recently lifted pure precondition. Runs when the target is not a lattice entailment,
 just before it would be classified as a VC. -/
-private def tryLiftedHypBare (scope : VCGen.Scope) (goal : MVarId) (target : Expr) :
+private def liftedHypBare? (scope : VCGen.Scope) (goal : MVarId) (target : Expr) :
     VCGenM (Option (List MVarId)) :=
   goal.withContext do
     if target.hasExprMVar then return none
@@ -147,10 +147,19 @@ private def tryLiftedHypBare (scope : VCGen.Scope) (goal : MVarId) (target : Exp
     goal.assign hyp.toExpr
     return some []
 
+/-- Strategy 5: cancel a redundant `P ⊓ ⊤` precondition via `meet_top_le_of_le`, leaving `P ⊑ rhs`.
+Such a precondition arises when `himp_complete` splits `⊤ ⊑ a ⇨ b` into `a ⊓ ⊤ ⊑ b`. -/
+private def stripMeetTopPre? (goal : MVarId) (pre : Expr) : VCGenM (Option MVarId) := do
+  let_expr Lean.Order.meet _l _inst _P top := pre | return none
+  unless top.isAppOf ``Lean.Order.top do return none
+  let .goals [g] ← (← read).meetTopRule.applyChecked goal
+    | throwError "Failed to cancel the `⊓ ⊤` precondition of {goal}"
+  return some g
+
 /-- Strategy 5: lift an embedded pure precondition `⌜φ⌝` into the local context, leaving `⊤`
 as the residual precondition. Runs before state-argument introduction, which would otherwise
 leave `⌜φ⌝` applied to the introduced arguments. Returns the new goal and the hypothesis. -/
-private def tryOfPropPreIntro (goal : MVarId) (pre : Expr) : VCGenM (Option (MVarId × FVarId)) := do
+private def ofPropPreIntro? (goal : MVarId) (pre : Expr) : VCGenM (Option (MVarId × FVarId)) := do
   let_expr CompleteLattice.ofProp _l _inst φ := pre | return none
   if φ.isTrue then return none
   return some (← introPre (← read).introRules.ofPropPreIntro goal)
@@ -158,40 +167,38 @@ private def tryOfPropPreIntro (goal : MVarId) (pre : Expr) : VCGenM (Option (MVa
 /-- Strategy 7: move a bare `Prop` precondition `φ ⊑ rhs` into the local context via
 `le_of_imp_top_le`, leaving `⊤ ⊑ rhs`. Runs after `True` and `⊤` preconditions are handled, so
 `φ` carries information worth keeping. Returns the new goal and the introduced hypothesis. -/
-private def tryBarePreIntro (goal : MVarId) (α pre : Expr) : VCGenM (Option (MVarId × FVarId)) := do
+private def barePreIntro? (goal : MVarId) (α pre : Expr) : VCGenM (Option (MVarId × FVarId)) := do
   unless α.isProp do return none
   if pre.isAppOf ``Lean.Order.top then return none
   return some (← introPre (← read).introRules.propPreIntro goal)
 
 /-- Strategy 7: replace a `True` precondition by `⊤` via `true_le_of_top_le`, so the goal
 follows the `⊤` path instead of lifting `True` into the local context. -/
-private def tryTruePre (goal : MVarId) (pre target : Expr) : VCGenM (Option (List MVarId)) := do
+private def truePre? (goal : MVarId) (pre target : Expr) : VCGenM (Option (List MVarId)) := do
   unless pre.isTrue do return none
   let .goals [g] ← (← read).introRules.truePreIntro.applyChecked goal
     | throwError "Failed to apply {.ofConstName ``Lean.Order.true_le_of_top_le} to{indentExpr target}"
   return some [g]
 
 /-- Phase 2: drive the precondition of `pre ⊑ rhs` toward `⊤`, lifting any pure content into the
-local context so a later spec application sees a `⊤` precondition. In order: lift an embedded
-`⌜φ⌝` (before state-argument introduction, which would otherwise leave `⌜φ⌝` applied to the
-introduced state); introduce excess state arguments; drop a `True` precondition; lift a bare
-`Prop` precondition. Returns the updated scope, recording any lifted hypothesis. -/
-private def tryNormalizePre (scope : VCGen.Scope) (goal : MVarId) (α pre target : Expr) :
+local context so a later spec application sees a `⊤` precondition. In order: cancel a redundant
+`⊓ ⊤`; lift an embedded `⌜φ⌝` (before state-argument introduction, which would otherwise leave
+`⌜φ⌝` applied to the introduced state); introduce excess state arguments; drop a `True`
+precondition; lift a bare `Prop` precondition. Returns the updated scope, recording any lifted
+hypothesis. -/
+private def normalizePre? (scope : VCGen.Scope) (goal : MVarId) (α pre target : Expr) :
     VCGenM (Option (VCGen.Scope × List MVarId)) := do
-  if let some (g, h) ← tryOfPropPreIntro goal pre then
+  if let some g ← stripMeetTopPre? goal pre then
+    return some (scope, [g])
+  if let some (g, h) ← ofPropPreIntro? goal pre then
     return some ({ scope with lastLiftedPre? := some h }, [g])
   if α.isForall then
     return some (scope, [← introsExcessArgs goal])
-  if let some gs ← tryTruePre goal pre target then
+  if let some gs ← truePre? goal pre target then
     return some (scope, gs)
-  if let some (g, h) ← tryBarePreIntro goal α pre then
+  if let some (g, h) ← barePreIntro? goal α pre then
     return some ({ scope with lastLiftedPre? := some h }, [g])
   return none
-
-/-- Strategy 9: decompose a supported lattice connective on the RHS. -/
-private def tryLattice (goal : MVarId) (target rhs : Expr) (preIsTop : Bool) :
-    VCGenM (Option (List MVarId)) := do
-  solveLatticeConnective? goal target rhs preIsTop
 
 /-- Replace the program in `goal`'s target with `prog` (which must be definitionally equal). -/
 private def replaceProgDefEq (goal : MVarId) (target : Expr) (info : WPInfo) (prog : Expr) :
@@ -202,15 +209,16 @@ private def replaceProgDefEq (goal : MVarId) (target : Expr) (info : WPInfo) (pr
   let newTarget ← mkAppNS target.getAppFn (relArgs.set! (relArgs.size - 1) rhs)
   goal.replaceTargetDefEq newTarget
 
-private def substOrHoistLet (goal : MVarId) (target : Expr) (info : WPInfo)
-    (name : Name) (type val body : Expr) (nondep : Bool)
-    (appArgs : Array Expr) : VCGenM MVarId := do
+/-- Strategy 11a: hoist or zeta-substitute a `let` from the program head. -/
+private def wpLet? (goal : MVarId) (target : Expr) (info : WPInfo) : VCGenM (Option MVarId) := do
+  let .letE name type val body nondep := info.prog.getAppFn | return none
+  let appArgs := info.prog.getAppRevArgs
   throwIfUnsupportedJP name val
   if isDuplicable val then
     trace[Elab.Tactic.Do.vcgen] "let-zeta-dup: {name}"
     let body' ← Sym.instantiateRevBetaS body #[val]
     let prog ← mkAppRevS body' appArgs
-    replaceProgDefEq goal target info prog
+    return some (← replaceProgDefEq goal target info prog)
   else
     trace[Elab.Tactic.Do.vcgen] "let-hoist: {name}"
     let prog ← mkAppRevS body appArgs
@@ -222,17 +230,11 @@ private def substOrHoistLet (goal : MVarId) (target : Expr) (info : WPInfo)
     let goal ← goal.replaceTargetDefEq target
     let .goal _ goal ← Sym.intros goal
       | throwError "Failed to intro hoisted let"
-    return goal
-
-/-- Strategy 11a: hoist or zeta-substitute a `let` from the program head. -/
-private def tryWPLet (goal : MVarId) (target : Expr) (info : WPInfo) : VCGenM (Option MVarId) := do
-  let .letE name type val body nondep := info.prog.getAppFn | return none
-  return some (← substOrHoistLet goal target info name type val body nondep
-    info.prog.getAppRevArgs)
+    return some goal
 
 /-- Strategy 11b: split an `ite`/`dite`/match program, or iota-reduce a matcher with a concrete
 discriminant. -/
-private def tryWPMatch (goal : MVarId) (target : Expr) (info : WPInfo) :
+private def wpMatch? (goal : MVarId) (target : Expr) (info : WPInfo) :
     VCGenM (Option (List MVarId)) := do
   let some splitInfo ← liftMetaM <| Lean.Elab.Tactic.Do.getSplitInfo? info.prog | return none
   if splitInfo matches .matcher .. then
@@ -250,7 +252,7 @@ private def tryWPMatch (goal : MVarId) (target : Expr) (info : WPInfo) :
   return some simpGoals.toList
 
 /-- Strategy 11c: zeta-unfold a local let-bound fvar used as the program head. -/
-private def tryWPFVarZeta (goal : MVarId) (target : Expr) (info : WPInfo) :
+private def wpFVarZeta? (goal : MVarId) (target : Expr) (info : WPInfo) :
     VCGenM (Option MVarId) := do
   let f := info.prog.getAppFn
   let some fvarId := f.fvarId? | return none
@@ -260,7 +262,7 @@ private def tryWPFVarZeta (goal : MVarId) (target : Expr) (info : WPInfo) :
   return some (← replaceProgDefEq goal target info prog)
 
 /-- Strategy 11d: reduce a projection head in the program. -/
-private def tryWPHeadReduce (goal : MVarId) (target : Expr) (info : WPInfo) :
+private def wpHeadReduce? (goal : MVarId) (target : Expr) (info : WPInfo) :
     VCGenM (Option MVarId) := do
   let f := info.prog.getAppFn
   unless f matches .proj .. do return none
@@ -352,45 +354,44 @@ public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := g
     goal ← goal.replaceTargetDefEq target
 
   -- Phase 1: simplify `target` until it is of the form `pre ⊑ rhs`.
-  if let some gs ← tryForallIntro goal target then return .goals scope gs
-  if let some g ← tryTargetLetIntro goal target then return .goals scope [g]
-  if let some g ← tryTripleUnfold goal target then return .goals scope [g]
-  if let some g ← tryBareWPToLe goal target then return .goals scope [g]
+  if let some gs ← forallIntro? goal target then return .goals scope gs
+  if let some g ← targetLetIntro? goal target then return .goals scope [g]
+  if let some g ← tripleUnfold? goal target then return .goals scope [g]
+  if let some g ← bareWPToLe? goal target then return .goals scope [g]
 
   let_expr PartialOrder.rel α inst pre rhs := target
-    | if let some gs ← tryLiftedHypBare scope goal target then return .goals scope gs
+    | if let some gs ← liftedHypBare? scope goal target then return .goals scope gs
       else return .noEntailment target
-  let preIsTop := pre.isAppOf ``Lean.Order.top && pre.getAppNumArgs == 2
 
   -- Phase 2: close reflexive goals, then drive `pre` toward `⊤`, lifting any pure content so a
   -- later spec application sees a `⊤` precondition.
-  if let some gs ← tryRfl goal then return .goals scope gs
-  if let some (scope, gs) ← tryNormalizePre scope goal α pre target then return .goals scope gs
+  if let some gs ← rfl? goal then return .goals scope gs
+  if let some (scope, gs) ← normalizePre? scope goal α pre target then return .goals scope gs
 
   -- Collect new local specs before any strategy that may emit multiple subgoals
-  -- (`tryWPMatch`, `tryLattice`) or apply a registered spec (`applySpec`).
+  -- (`wpMatch?`, `solveLatticeConnective?`) or apply a registered spec (`applySpec`).
   let scope ← scope.collectLocalSpecs goal
 
   -- Phase 3: shape the `rhs` (reduce an EPost projection, decompose a lattice connective), then
   -- discharge a residual entailment against the lifted hypothesis.
   if let some g ← reduceEPostHead? goal target α inst pre rhs then return .goals scope [g]
-  if let some gs ← tryLattice goal target rhs preIsTop then return .goals scope gs
-  if let some gs ← tryLiftedHyp scope goal α pre rhs then return .goals scope gs
+  if let some gs ← solveLatticeConnective? goal target rhs then return .goals scope gs
+  if let some gs ← liftedHyp? scope goal α pre rhs then return .goals scope gs
 
   -- Phase 4: wp decomposition. The program-shape steps below all consume one unit of fuel
   -- (the `stepLimit` config option) when they make progress.
   if let some info := getWPInfo? rhs then
     trace[Elab.Tactic.Do.vcgen] "📜 Program: {info.prog}"
-    if let some g ← tryWPLet goal target info then
+    if let some g ← wpLet? goal target info then
       VCGen.burnOne
       return .goals scope [g]
-    if let some gs ← tryWPMatch goal target info then
+    if let some gs ← wpMatch? goal target info then
       VCGen.burnOne
       return .goals scope gs
-    if let some g ← tryWPFVarZeta goal target info then
+    if let some g ← wpFVarZeta? goal target info then
       VCGen.burnOne
       return .goals scope [g]
-    if let some g ← tryWPHeadReduce goal target info then
+    if let some g ← wpHeadReduce? goal target info then
       VCGen.burnOne
       return .goals scope [g]
     -- Stop if the program matches the `until` pattern.

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -27,22 +27,28 @@ progress is possible (`SolveResult`).
 
 namespace VCGen
 
-public inductive SolveResult where
-  /-- `target` was not of the form `pre ⊑ rhs`. -/
+/-- The reason why no further VC generation progress is possible on the current goal. -/
+public inductive SolveResult.StopReason where
+  /-- Out of fuel. -/
+  | outOfFuel
+  /-- `until <pat>` matched. -/
+  | untilPatternMatched (m : Expr)
+  /-- The target was not of the form `pre ⊑ rhs`. -/
   | noEntailment (target : Expr)
-  /-- The RHS in `pre ⊑ rhs` was neither a `wp` application nor a supported lattice connective. -/
-  | noProgramOrLatticeFoundInTarget (rhs : Expr)
-  /-- Don't know how to handle `e` in `pre ⊑ wp e post epost s₁ ... sₙ`. -/
-  | noStrategyForProgram (e : Expr)
+  /-- The target was of the form `pre ⊑ rhs`, but we couldn't make further progress. -/
+  | noProgress (pre rhs : Expr)
+
+/-- The result of one `solve` step of VC generation. -/
+public inductive SolveResult where
+  /-- Successfully decomposed the goal. These are the subgoals, sharing `scope`. -/
+  | goals (scope : VCGen.Scope) (subgoals : List MVarId)
   /--
   Did not find a spec for the `e` in `pre ⊑ wp e post epost s₁ ... sₙ`.
   Candidates were `thms`, but none of them matched the monad.
   -/
   | noSpecFoundForProgram (e : Expr) (monad : Expr) (thms : Array SpecTheorem)
-  /-- Successfully decomposed the goal. These are the subgoals, sharing `scope`. -/
-  | goals (scope : VCGen.Scope) (subgoals : List MVarId)
-  /-- Stop decomposing and emit the current goal as a VC (out of fuel, or `until` matched). -/
-  | stop
+  /-- No further progress possible on the current goal for the given reason. Emit goal as VC. -/
+  | stop (reason : SolveResult.StopReason)
 
 private def isDuplicable (e : Expr) : Bool := match e with
   | .bvar .. | .mvar .. | .fvar .. | .const .. | .lit .. | .sort .. => true
@@ -337,7 +343,7 @@ The function performs the following steps in order:
     reduce projection heads, and finally apply a registered `@[spec]` theorem.
 -/
 public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := goal.withContext do
-  if ← outOfFuel then return .stop
+  if ← outOfFuel then return .stop .outOfFuel
   let mut goal := goal
   let mut target ← goal.getType
   trace[Elab.Tactic.Do.vcgen] "🎯 Target: {target}"
@@ -356,7 +362,7 @@ public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := g
 
   let_expr PartialOrder.rel α inst pre rhs := target
     | if let some gs ← liftedHypBare? scope goal target then return .goals scope gs
-      else return .noEntailment target
+      else return .stop (.noEntailment target)
 
   -- Phase 2: close reflexive goals, then drive `pre` toward `⊤`, lifting any pure content so a
   -- later spec application sees a `⊤` precondition.
@@ -377,6 +383,9 @@ public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := g
   -- (the `stepLimit` config option) when they make progress.
   if let some info := getWPInfo? rhs then
     trace[Elab.Tactic.Do.vcgen] "📜 Program: {info.prog}"
+    -- Stop if the program matches the `until` pattern.
+    if ← matchesUntilPattern info.m info.prog then
+      return .stop (.untilPatternMatched info.m)
     if let some g ← wpLet? goal target info then
       VCGen.burnOne
       return .goals scope [g]
@@ -389,15 +398,13 @@ public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := g
     if let some g ← wpHeadReduce? goal target info then
       VCGen.burnOne
       return .goals scope [g]
-    -- Stop if the program matches the `until` pattern.
-    if ← matchesUntilPattern info.m info.prog then return .stop
     let f := info.prog.getAppFn
     if f.isConst || f.isFVar then
       VCGen.burnOne
       return ← applySpec scope goal target info
-    return .noStrategyForProgram info.prog
+    throwError "Failed to decompose weakest precondition for {info.prog}. This should not happen."
 
-  return .noProgramOrLatticeFoundInTarget rhs
+  return .stop (.noProgress pre rhs)
 
 end VCGen
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -330,16 +330,11 @@ The function performs the following steps in order:
    precondition by `⊤` and lift any other precondition into the local context.
 8. **EPost projection reduction**: reduce an `EPost.Cons.head` RHS to the projected component.
 9. **Lattice decomposition**: decompose `⊓`, `⇨`, `⌜p⌝` and `⊤` RHS connectives.
-10. **Lifted-hypothesis discharge**: close a residual `pre ⊑ φ` entailment against the most
-    recently lifted precondition, cached in `Scope.lastLiftedPre?`.
+10. **Lifted-hypothesis discharge**: close a residual `pre ⊑ ⌜φ⌝` entailment against the most
+    recently lifted precondition `h : φ` in the local context, cached in `Scope.lastLiftedPre?`.
 11. **WP decomposition**: when the RHS is `wp e post epost s₁ ... sₙ`, in order:
     hoist/zeta program-head lets, split `ite`/`dite`/match, zeta-unfold fvar program heads,
     reduce projection heads, and finally apply a registered `@[spec]` theorem.
-
-Pure preconditions are lifted as soon as they arise (steps 5 and 7). The lifted hypothesis is
-cached in `Scope.lastLiftedPre?`. Step 10 closes residual entailments against it with a single
-defeq check, and bare `Prop` targets, such as the subgoal of the `⌜φ⌝` lattice rule, are
-checked against it before being classified as VCs.
 -/
 public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := goal.withContext do
   if ← outOfFuel then return .stop

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Sebastian Graf
+Authors: Sebastian Graf, Vladimir Gladshtein
 -/
 module
 
@@ -10,14 +10,14 @@ public import Lean.Elab.Tactic.Do.Internal.VCGen.Context
 public import Lean.Elab.Tactic.Do.Internal.VCGen.RuleCache
 public import Lean.Elab.Tactic.Do.Internal.VCGen.Entails
 public import Lean.Meta.Sym.InstantiateS
+import Lean.Meta.Sym.InferType
 
 open Lean Meta Elab Tactic Sym Sym.Internal
-open Lean.Elab.Tactic.Do.SpecAttr
+open Lean.Elab.Tactic.Do.Internal.SpecAttr
 open Lean.Elab.Tactic.Do.Internal
-open Std.Do
+open Std.Internal.Do Lean.Order
 
 namespace Lean.Elab.Tactic.Do.Internal
-
 
 /-!
 The main `solve` step. Runs once per worklist iteration and either fully
@@ -28,17 +28,17 @@ progress is possible (`SolveResult`).
 namespace VCGen
 
 public inductive SolveResult where
-  /-- `target` was not of the form `H ⊢ₛ T`. -/
+  /-- `target` was not of the form `pre ⊑ rhs`. -/
   | noEntailment (target : Expr)
-  /-- The `T` in `H ⊢ₛ T` was not of the form `wp⟦e⟧ Q s₁ ... sₙ`. -/
-  | noProgramFoundInTarget (T : Expr)
-  /-- Don't know how to handle `e` in `H ⊢ₛ wp⟦e⟧ Q s₁ ... sₙ`. -/
+  /-- The RHS in `pre ⊑ rhs` was neither a `wp` application nor a supported lattice connective. -/
+  | noProgramOrLatticeFoundInTarget (rhs : Expr)
+  /-- Don't know how to handle `e` in `pre ⊑ wp e post epost s₁ ... sₙ`. -/
   | noStrategyForProgram (e : Expr)
   /--
-  Did not find a spec for the `e` in `H ⊢ₛ wp⟦e⟧ Q s₁ ... sₙ`.
+  Did not find a spec for the `e` in `pre ⊑ wp e post epost s₁ ... sₙ`.
   Candidates were `thms`, but none of them matched the monad.
   -/
-  | noSpecFoundForProgram (e : Expr) (monad : Expr) (thms : Array SpecTheoremNew)
+  | noSpecFoundForProgram (e : Expr) (monad : Expr) (thms : Array SpecTheorem)
   /-- Successfully decomposed the goal. These are the subgoals, sharing `scope`. -/
   | goals (scope : VCGen.Scope) (subgoals : List MVarId)
   /-- Stop decomposing and emit the current goal as a VC (out of fuel, or `until` matched). -/
@@ -50,240 +50,358 @@ private def isDuplicable (e : Expr) : Bool := match e with
   | .lam .. | .forallE .. | .letE .. => false
   | .app .. => e.isAppOf ``OfNat.ofNat
 
-/-- Strategy 1: introduce binders if the target is a `∀`. -/
-private def tryForallIntro (goal : MVarId) (target : Expr) : VCGenM (Option MVarId) := do
+/-- Strategy 1: simp the target, then introduce binders if the target is a `∀`. -/
+private def tryForallIntro (goal : MVarId) (target : Expr) : VCGenM (Option (List MVarId)) := do
   unless target.isForall do return none
-  return some (← introsSimp goal m!"foralls in `solve`")
+  let (goal, simped) ← match ← simpGoalTelescope goal with
+    | .closed => return some []
+    | .goal goal' => pure (goal', true)
+    | .noProgress => pure (goal, false)
+  let goal' ← introsHygienic goal
+  if !simped && goal' == goal then
+    throwError "Failed to intro forall target {goal}"
+  return some [goal']
 
-/-- Strategy 7a: zeta-substitute (if the bound value is duplicable) or introduce a
-top-level `let` in the target.
+private def throwIfUnsupportedJP (name : Name) (val : Expr) : VCGenM Unit := do
+  if (← read).useJP && Lean.Elab.Tactic.Do.isJP name && val.isLambda then
+    throwError "mvcgen': shared-continuation handling for `__do_jp` is not yet \
+      implemented. Detection point reached at {name}; the upstream \
+      `Lean.Elab.Tactic.Do.onJoinPoint` (`src/Lean/Elab/Tactic/Do/VCGen.lean:215`) \
+      needs to be ported to the worklist style. Drop `(jp := true)` to fall back \
+      to the default zeta-unfold behaviour."
 
-When `Context.useJP` is set and the let binds a `__do_jp` (do-elaborator-emitted
-shared continuation) whose value is a function whose body is a splitter, we are
-at the point where the upstream `mvcgen.onJoinPoint` would set up shared-continuation
-proof construction. That port (Phase 6 of the plan) is not yet done; we throw an
-explicit error here so that enabling `jp := true` is honest about the gap rather
-than silently ignored. -/
-private def tryLetIntro (goal : MVarId) (target : Expr) : VCGenM (Option MVarId) := do
-  unless target.isLet do return none
-  if (← read).useJP && Lean.Elab.Tactic.Do.isJP target.letName! then
-    if target.letValue!.isLambda then
-      throwError "mvcgen': shared-continuation handling for `__do_jp` is not yet \
-        implemented. Detection point reached at {target.letName!}; the upstream \
-        `Lean.Elab.Tactic.Do.onJoinPoint` (`src/Lean/Elab/Tactic/Do/VCGen.lean:215`) \
-        needs to be ported to the worklist style. Drop `(jp := true)` to fall back \
-        to the default zeta-unfold behaviour."
-  if isDuplicable target.letValue! then
-    trace[Elab.Tactic.Do.vcgen] "let-zeta-dup: {target.letName!}"
-    let target' ← Sym.instantiateRevBetaS target.letBody! #[target.letValue!]
-    return some (← goal.replaceTargetDefEq target')
+/-- Strategy 2: zeta-substitute a duplicable top-level `let` in the target, otherwise
+introduce it into the local context. -/
+private def tryTargetLetIntro (goal : MVarId) (target : Expr) : VCGenM (Option MVarId) := do
+  let .letE name _ val body _ := target | return none
+  throwIfUnsupportedJP name val
+  if isDuplicable val then
+    trace[Elab.Tactic.Do.vcgen] "let-zeta-dup: {name}"
+    return some (← goal.replaceTargetDefEq (← Sym.instantiateRevBetaS body #[val]))
   else
-    trace[Elab.Tactic.Do.vcgen] "let-intro: {target.letName!}"
-    return some (← introsSimp goal m!"let-intro: {target.letName!}")
+    trace[Elab.Tactic.Do.vcgen] "let-intro: {name}"
+    return some (← introsHygienic goal)
 
-/-- Strategy 2: unfold a `Triple` target into the underlying `P ⊢ₛ wp⟦x⟧ Q`. -/
+/-- Strategy 3: unfold a `Triple` target into the underlying lattice entailment. -/
 private def tryTripleUnfold (goal : MVarId) (target : Expr) : VCGenM (Option MVarId) := do
-  unless target.getAppFn.isConstOf ``Triple do return none
-  return some (← tripleOfWP goal)
+  unless target.isAppOf ``Triple do return none
+  return some (← unfoldTriple goal)
 
-/-- Strategy 4: eta-expand a lambda RHS via `entails_cons_intro`. -/
-private def tryTargetLambdaIntro (goal : MVarId) (T : Expr) : VCGenM (Option MVarId) := do
-  unless T.isLambda do return none
-  let .goals [goal] ← (← read).entailsConsIntroRule.applyChecked goal
-    | throwError "Applying {.ofConstName ``SPred.entails_cons_intro} to {← goal.getType} failed. It should not."
-  return some goal
+/-- Extract the weakest-precondition metadata from the RHS of a lattice entailment. -/
+private def getWPInfo? (rhs : Expr) : Option WPInfo :=
+  rhs.withApp fun head args =>
+    if head.isConstOf ``Std.Internal.Do.wp && args.size ≥ 11 then
+      some { head, args := args.take 11, excessArgs := args.drop 11 }
+    else
+      none
 
-/-- Strategy 5: head-reduce `H` and/or `T` and replace the target if either side reduced. -/
-private def tryHeadReduceHT (goal : MVarId) (ent σs H T : Expr) : VCGenM (Option MVarId) := do
-  let H? ← reduceHead? H
-  let T? ← reduceHead? T
-  unless H?.isSome || T?.isSome do return none
-  return some (← goal.replaceTargetDefEq (← Sym.Internal.mkAppS₃ ent σs (H?.getD H) (T?.getD T)))
+/-- Strategy 3b: turn a bare `wp` application target (a `Prop`) into `⊤ ⊑ wp …`. Entry-point
+goals produced by the `of_wp_run_eq` lemmas have this shape. -/
+private def tryBareWPToLe (goal : MVarId) (target : Expr) : VCGenM (Option MVarId) := do
+  let some _ := getWPInfo? target | return none
+  let newTarget ← mkAppM ``PartialOrder.rel #[← mkAppOptM ``Lean.Order.top #[mkSort 0, none], target]
+  let newTarget ← shareCommon newTarget
+  let g ← liftMetaM <| mkFreshExprSyntheticOpaqueMVar newTarget
+  goal.assign (mkApp2 (mkConst ``Lean.Order.of_top_le_prop) target g)
+  return some g.mvarId!
 
-/-- Strategy 6: when the target's RHS isn't `wp⟦e⟧ Q s₁ ... sₙ`, attempt syntactic
-reflexivity, fall back to `solveSPredEntails`. Returns `none` when neither applies. -/
-private def trySolveSPredEntails (goal : MVarId) (ent σs H T : Expr) :
-    VCGenM (Option (List MVarId)) := do
-  trace[Elab.Tactic.Do.vcgen] "Trying rfl {goal}"
-  if ← withAssignableSyntheticOpaque <| isDefEqS H T then
-    trace[Elab.Tactic.Do.vcgen] "Solved by rfl {goal}"
-    goal.assign (mkApp2 (mkConst ``SPred.entails.refl ent.constLevels!) σs H)
+/-- Strategy 4: close a reflexive entailment `pre ⊑ pre` by applying `PartialOrder.rel_refl`.
+Runs before the precondition lift so a spec handoff `pre ⊑ specPre` closes by unification rather
+than an assumption search. The pattern matcher keeps synthetic-opaque invariant holes rigid, so
+`⊤ ⊑ ?inv args` is left untouched. -/
+private def tryRfl (goal : MVarId) : VCGenM (Option (List MVarId)) := do
+  let .goals gs ← (← read).reflRule.apply goal | return none
+  trace[Elab.Tactic.Do.vcgen] "Solved by rfl {goal}"
+  return some gs
+
+/-- Strategy 10: close `pre ⊑ φ` on the `Prop` lattice against the most recently lifted pure
+precondition, cached in `Scope.lastLiftedPre?`. Runs after lattice decomposition, so `φ` is an
+opaque proposition rather than a lattice connective. This is one defeq check against one
+hypothesis, not an assumption search.
+
+Goals whose RHS contains metavariables are skipped: the defeq check could otherwise assign
+a post abstraction from an unrelated hypothesis. -/
+private def tryLiftedHyp (scope : VCGen.Scope) (goal : MVarId) (α pre rhs : Expr) :
+    VCGenM (Option (List MVarId)) :=
+  goal.withContext do
+    unless α.isProp do return none
+    if rhs.hasExprMVar then return none
+    let some fvarId := scope.lastLiftedPre? | return none
+    let some hyp := (← getLCtx).find? fvarId | return none
+    unless ← isDefEqS rhs hyp.type do return none -- TODO: Replace with isSameExpr test?
+    trace[Elab.Tactic.Do.vcgen] "Solved by lifted hypothesis {hyp.userName}"
+    goal.assign (← mkAppM ``Lean.Order.le_of_right #[pre, rhs, hyp.toExpr])
     return some []
-  if let some goal ← solveSPredEntails goal then
-    return some [goal]
+
+/-- Close a bare `Prop` residual, such as the subgoal of the `⌜φ⌝` lattice rule, against the
+most recently lifted pure precondition. Runs when the target is not a lattice entailment,
+just before it would be classified as a VC. -/
+private def tryLiftedHypBare (scope : VCGen.Scope) (goal : MVarId) (target : Expr) :
+    VCGenM (Option (List MVarId)) :=
+  goal.withContext do
+    if target.hasExprMVar then return none
+    let some fvarId := scope.lastLiftedPre? | return none
+    let some hyp := (← getLCtx).find? fvarId | return none
+    unless ← isDefEqS target hyp.type do return none -- TODO: Replace with isSameExpr test?
+    trace[Elab.Tactic.Do.vcgen] "Solved by lifted hypothesis {hyp.userName}"
+    goal.assign hyp.toExpr
+    return some []
+
+/-- Strategy 5: lift an embedded pure precondition `⌜φ⌝` into the local context, leaving `⊤`
+as the residual precondition. Runs before state-argument introduction, which would otherwise
+leave `⌜φ⌝` applied to the introduced arguments. Returns the new goal and the hypothesis. -/
+private def tryOfPropPreIntro (goal : MVarId) (pre : Expr) : VCGenM (Option (MVarId × FVarId)) := do
+  let_expr CompleteLattice.ofProp _l _inst φ := pre | return none
+  if φ.isTrue then return none
+  return some (← introPre (← read).introRules.ofPropPreIntro goal)
+
+/-- Strategy 7: move a bare `Prop` precondition `φ ⊑ rhs` into the local context via
+`le_of_imp_top_le`, leaving `⊤ ⊑ rhs`. Runs after `True` and `⊤` preconditions are handled, so
+`φ` carries information worth keeping. Returns the new goal and the introduced hypothesis. -/
+private def tryBarePreIntro (goal : MVarId) (α pre : Expr) : VCGenM (Option (MVarId × FVarId)) := do
+  unless α.isProp do return none
+  if pre.isAppOf ``Lean.Order.top then return none
+  return some (← introPre (← read).introRules.propPreIntro goal)
+
+/-- Strategy 7: replace a `True` precondition by `⊤` via `true_le_of_top_le`, so the goal
+follows the `⊤` path instead of lifting `True` into the local context. -/
+private def tryTruePre (goal : MVarId) (pre target : Expr) : VCGenM (Option (List MVarId)) := do
+  unless pre.isTrue do return none
+  let .goals [g] ← (← read).introRules.truePreIntro.applyChecked goal
+    | throwError "Failed to apply {.ofConstName ``Lean.Order.true_le_of_top_le} to{indentExpr target}"
+  return some [g]
+
+/-- Phase 2: drive the precondition of `pre ⊑ rhs` toward `⊤`, lifting any pure content into the
+local context so a later spec application sees a `⊤` precondition. In order: lift an embedded
+`⌜φ⌝` (before state-argument introduction, which would otherwise leave `⌜φ⌝` applied to the
+introduced state); introduce excess state arguments; drop a `True` precondition; lift a bare
+`Prop` precondition. Returns the updated scope, recording any lifted hypothesis. -/
+private def tryNormalizePre (scope : VCGen.Scope) (goal : MVarId) (α pre target : Expr) :
+    VCGenM (Option (VCGen.Scope × List MVarId)) := do
+  if let some (g, h) ← tryOfPropPreIntro goal pre then
+    return some ({ scope with lastLiftedPre? := some h }, [g])
+  if α.isForall then
+    return some (scope, [← introsExcessArgs goal])
+  if let some gs ← tryTruePre goal pre target then
+    return some (scope, gs)
+  if let some (g, h) ← tryBarePreIntro goal α pre then
+    return some ({ scope with lastLiftedPre? := some h }, [g])
   return none
 
-/-- Replace the program in `goal`'s target with `e'` (which must be definitionally equal). -/
-private def replaceProgDefEq (goal : MVarId) (head H σs ent : Expr) (args : Array Expr)
-    (wpConst m ps instWP α e' : Expr) : VCGenM MVarId := do
-  let wp ← Sym.Internal.mkAppS₅ wpConst m ps instWP α e'
-  let T ← mkAppNS head (args.set! 2 wp)
-  let target ← mkAppS₃ ent σs H T
-  goal.replaceTargetDefEq target
+/-- Strategy 9: decompose a supported lattice connective on the RHS. -/
+private def tryLattice (goal : MVarId) (target rhs : Expr) (preIsTop : Bool) :
+    VCGenM (Option (List MVarId)) := do
+  solveLatticeConnective? goal target rhs preIsTop
 
-/-- Hoist a `letE` from the program head to the goal target. -/
-private def tryLetHoist (goal : MVarId) (head H σs ent : Expr) (args : Array Expr)
-    (wpConst m ps instWP α e f : Expr) : VCGenM (Option MVarId) := do
-  let .letE x ty val body nonDep := f | return none
-  trace[Elab.Tactic.Do.vcgen] "let-hoist: {x}"
-  let e' ← mkAppRevS body e.getAppRevArgs  -- body still has #0 for the let-bound var
-  let wp' ← Sym.Internal.mkAppS₅ wpConst m ps instWP α e'
-  let T' ← mkAppNS head (args.set! 2 wp')
-  let target' ← mkAppS₃ ent σs H T'
-  let hoisted := Expr.letE x ty val target' nonDep
-  return some (← goal.replaceTargetDefEq hoisted)
+/-- Replace the program in `goal`'s target with `prog` (which must be definitionally equal). -/
+private def replaceProgDefEq (goal : MVarId) (target : Expr) (info : WPInfo) (prog : Expr) :
+    VCGenM MVarId := do
+  let wp ← mkAppNS info.head <| info.args.set! 8 prog
+  let rhs ← mkAppNS wp info.excessArgs
+  let relArgs := target.getAppArgs
+  let newTarget ← mkAppNS target.getAppFn (relArgs.set! (relArgs.size - 1) rhs)
+  goal.replaceTargetDefEq newTarget
 
-/-- Split an `ite`/`dite`/match program head, or iota-reduce if the discriminant is
-constructor-shaped. Returns `none` when the program isn't a split. -/
-private def trySplit (goal : MVarId) (head H σs ent : Expr) (args : Array Expr)
-    (wpConst m ps instWP α e : Expr) (excessArgs : Array Expr) : VCGenM (Option (List MVarId)) := do
-  let some info ← liftMetaM <| Lean.Elab.Tactic.Do.getSplitInfo? e | return none
-  -- Try iota reduction first (reduces matcher/recursor with concrete discriminant)
-  if let some e' ← liftMetaM <| withReducible <| reduceRecMatcher? e then
-    return some [← replaceProgDefEq goal head H σs ent args wpConst m ps instWP α
-                    (← shareCommonInc e')]
-  let rule ← mkBackwardRuleFromSplitInfoCached info m σs ps instWP excessArgs
-  let ApplyResult.goals goals ← rule.applyChecked goal m!"split rule for{indentExpr e}"
-    | throwError "Failed to apply split rule for {indentExpr e}"
-  return some goals
+private def substOrHoistLet (goal : MVarId) (target : Expr) (info : WPInfo)
+    (name : Name) (type val body : Expr) (nondep : Bool)
+    (appArgs : Array Expr) : VCGenM MVarId := do
+  throwIfUnsupportedJP name val
+  if isDuplicable val then
+    trace[Elab.Tactic.Do.vcgen] "let-zeta-dup: {name}"
+    let body' ← Sym.instantiateRevBetaS body #[val]
+    let prog ← mkAppRevS body' appArgs
+    replaceProgDefEq goal target info prog
+  else
+    trace[Elab.Tactic.Do.vcgen] "let-hoist: {name}"
+    let prog ← mkAppRevS body appArgs
+    let wp ← mkAppNS info.head <| info.args.set! 8 prog
+    let rhs ← mkAppNS wp info.excessArgs
+    let relArgs := target.getAppArgs
+    let target ← mkAppNS target.getAppFn (relArgs.set! (relArgs.size - 1) rhs)
+    let target := Expr.letE name type val target nondep
+    let goal ← goal.replaceTargetDefEq target
+    let .goal _ goal ← Sym.intros goal
+      | throwError "Failed to intro hoisted let"
+    return goal
 
-/-- Zeta-unfold a local `let`-bound fvar that appears as the program head. -/
-private def tryFvarZeta (goal : MVarId) (head H σs ent : Expr) (args : Array Expr)
-    (wpConst m ps instWP α e f : Expr) : VCGenM (Option MVarId) := do
+/-- Strategy 11a: hoist or zeta-substitute a `let` from the program head. -/
+private def tryWPLet (goal : MVarId) (target : Expr) (info : WPInfo) : VCGenM (Option MVarId) := do
+  let .letE name type val body nondep := info.prog.getAppFn | return none
+  return some (← substOrHoistLet goal target info name type val body nondep
+    info.prog.getAppRevArgs)
+
+/-- Strategy 11b: split an `ite`/`dite`/match program, or iota-reduce a matcher with a concrete
+discriminant. -/
+private def tryWPMatch (goal : MVarId) (target : Expr) (info : WPInfo) :
+    VCGenM (Option (List MVarId)) := do
+  let some splitInfo ← liftMetaM <| Lean.Elab.Tactic.Do.getSplitInfo? info.prog | return none
+  if splitInfo matches .matcher .. then
+    if let some prog ← liftMetaM <| withReducible <| reduceRecMatcher? info.prog then
+      return some [← replaceProgDefEq goal target info (← shareCommonInc prog)]
+  let rule ← mkBackwardRuleForSplitCached splitInfo info
+  let .goals goals ← rule.applyChecked goal m!"split rule for{indentExpr info.prog}"
+    | throwError "Failed to apply split rule for {indentExpr info.prog}"
+  let mut simpGoals := #[]
+  for g in goals do
+    match ← simpGoalTelescope g with
+    | .goal g' => simpGoals := simpGoals.push g'
+    | .noProgress => simpGoals := simpGoals.push g
+    | .closed => continue
+  return some simpGoals.toList
+
+/-- Strategy 11c: zeta-unfold a local let-bound fvar used as the program head. -/
+private def tryWPFVarZeta (goal : MVarId) (target : Expr) (info : WPInfo) :
+    VCGenM (Option MVarId) := do
+  let f := info.prog.getAppFn
   let some fvarId := f.fvarId? | return none
   let some val ← fvarId.getValue? | return none
   trace[Elab.Tactic.Do.vcgen] "fvar-zeta: {(← fvarId.getUserName)}"
-  let e' ← shareCommonInc (val.betaRev e.getAppRevArgs)
-  return some (← replaceProgDefEq goal head H σs ent args wpConst m ps instWP α e')
+  let prog ← shareCommonInc (val.betaRev info.prog.getAppRevArgs)
+  return some (← replaceProgDefEq goal target info prog)
 
-/-- Reduce a kernel `.proj` head in the program `e`. -/
-private def tryHeadReduceProg (goal : MVarId) (head H σs ent : Expr) (args : Array Expr)
-    (wpConst m ps instWP α e f : Expr) : VCGenM (Option MVarId) := do
+/-- Strategy 11d: reduce a projection head in the program. -/
+private def tryWPHeadReduce (goal : MVarId) (target : Expr) (info : WPInfo) :
+    VCGenM (Option MVarId) := do
+  let f := info.prog.getAppFn
   unless f matches .proj .. do return none
-  let some e' ← reduceHead? e | return none
-  return some (← replaceProgDefEq goal head H σs ent args wpConst m ps instWP α e')
+  let some f' ← withReducibleAndInstances (reduceProj? f) | return none
+  let f' ← shareCommon (← liftMetaM <| unfoldReducible f')
+  let prog ← betaRevS f' info.prog.getAppRevArgs
+  return some (← replaceProgDefEq goal target info prog)
 
-/-- Look up a registered `@[spec]` theorem for the program head and apply its cached
-backward rule. Falls back to `.noSpecFoundForProgram` / `.noStrategyForProgram` when no
-spec applies. -/
-private def applySpec (scope : VCGen.Scope) (goal : MVarId) (e : Expr) (excessArgs : Array Expr)
-    (m σs ps instWP : Expr) : VCGenM SolveResult := do
-  let f := e.getAppFn
-  if f.isConst || f.isFVar then
-    trace[Elab.Tactic.Do.vcgen] "Applying a spec for {e}. Excess args: {excessArgs}"
-    match ← scope.specs.findSpecs e with
-    | .error thms => return .noSpecFoundForProgram e m thms
-    | .ok thm =>
-    trace[Elab.Tactic.Do.vcgen] "Spec for {e}: {thm.proof}"
-    if let some goal ← neededStateIntro thm goal excessArgs then
-      trace[Elab.Tactic.Do.vcgen] "Needed state intro. Retrying."
-      return .goals scope [goal]
-    let rule ← mkBackwardRuleFromSpecCached thm m σs ps instWP excessArgs
-    trace[Elab.Tactic.Do.vcgen] "Rule type: {← Meta.inferType rule.expr}"
-    let ApplyResult.goals goals ← rule.applyChecked goal m!"spec rule for{indentExpr e}"
-      | throwError "Failed to apply rule {rule.expr} for {indentExpr e}"
-    return .goals scope goals
-  return .noStrategyForProgram e
+/-- Strategy 11e: look up a registered `@[spec]` theorem (triple or simp) for the program head
+and apply its cached backward rule. -/
+private def applySpec (scope : VCGen.Scope) (goal : MVarId) (target : Expr) (info : WPInfo) :
+    VCGenM SolveResult := do
+  trace[Elab.Tactic.Do.vcgen] "Applying a spec for {info.prog}. Excess args: {info.excessArgs}"
+  match ← SpecTheorems.findSpecs scope.specs info.prog with
+  | .error thms => return .noSpecFoundForProgram info.prog info.m thms
+  | .ok thm =>
+  trace[Elab.Tactic.Do.vcgen] "Spec for {info.prog}: {thm.proof}"
+  let some rule ←
+    try
+      mkBackwardRuleFromSpecCached thm info |>.run
+    catch ex =>
+      throwError "Failed to construct rule {thm.proof} for {indentExpr info.prog}\n\
+        error: {ex.toMessageData}\n\
+        target:{indentExpr target}\n\
+        Pred:{indentExpr info.Pred}\n\
+        excessArgs: {info.excessArgs}"
+    | return .noSpecFoundForProgram info.prog info.m #[thm]
+  let .goals goals ← rule.applyChecked goal m!"spec rule for{indentExpr info.prog}"
+    | do
+      let ruleType ← Meta.inferType rule.expr
+      throwError "Failed to apply rule {thm.proof} for {indentExpr info.prog}\n\
+        target:{indentExpr target}\n\
+        Pred:{indentExpr info.Pred}\n\
+        excessArgs: {info.excessArgs}\n\
+        rule type:{indentExpr ruleType}"
+  return .goals scope goals
+
+/-- True iff the program matches the `until` pattern (elaborated lazily against the program
+monad), in which case VC generation stops at this goal. -/
+private def matchesUntilPattern (m prog : Expr) : VCGenM Bool := do
+  let some ref := (← read).untilPat? | return false
+  let pat ← UntilPatternThunk.force ref m
+  if (← pat.match? prog).isSome then
+    trace[Elab.Tactic.Do.vcgen] "`until` pattern matched program {prog}; stopping"
+    return true
+  return false
 
 /--
 The main VC generation step. Operates on a plain `MVarId` with no knowledge of grind.
 Returns `.goals subgoals` when the goal was decomposed, or a classification result
-(`.noEntailment`, `.noProgramFoundInTarget`, etc.) when no further decomposition is possible.
+(`.noEntailment`, `.noProgramOrLatticeFoundInTarget`, etc.) when no further decomposition is
+possible.
 
 The function performs the following steps in order:
 
-1. **Forall introduction**: If the target is a `∀`, introduce binders via `Sym.intros`.
-2. **Triple unfolding**: If the target is `⦃P⦄ x ⦃Q⦄`, unfold into `P ⊢ₛ wp⟦x⟧ Q`.
-3. **PostCond.entails decomposition**: Split `PostCond.entails` into its components.
-4. **Lambda introduction**: If the RHS `T` in `H ⊢ₛ T` is a lambda, introduce an extra state
-   variable via `SPred.entails_cons_intro`.
-5. **Proj/beta reduction**: Reduce `Prod.fst`/`Prod.snd` projections and beta redexes in
-   both `H` and `T` (e.g., `(fun _ => T, Q.snd).fst s` → `T`).
-6. **Syntactic rfl**: If `T` is not a `PredTrans.apply`, try closing by `SPred.entails.refl`.
-7. **Let-hoisting**: Hoist let-expressions from the program head to the goal target.
-7a. **Let-zeta/intro**: If the target starts with `let`, zeta immediately if duplicable, else
-    introduce into the local context via `introsSimp`.
-7b. **Fvar zeta**: Unfold local let-bound fvars on demand when they appear as the program head.
-8. **Iota reduction**: Reduce matchers/recursors with concrete discriminants.
-9. **ite/dite/match splitting**: Apply the appropriate split backward rule.
-10. **Spec application**: Look up a registered `@[spec]` theorem (triple or simp) and apply
-    its cached backward rule.
+1. **Forall introduction**: If the target is a `∀`, simp it and introduce binders.
+2. **Target-let handling**: zeta-substitute duplicable top-level lets, otherwise introduce them.
+3. **Triple unfolding**: If the target is `⦃P⦄ x ⦃Q; E⦄`, unfold into `P ⊑ wp x Q E`.
+4. **Syntactic rfl**: close `pre ⊑ rhs` by `PartialOrder.rel_refl` when both sides unify.
+5. **Embedded pure precondition introduction**: lift a `⌜φ⌝` precondition into the local
+   context, before state-argument introduction would apply it to the introduced arguments.
+6. **State-argument introduction**: If the lattice carrier is a function type
+   `σ₁ → ... → σₙ → Base`, introduce all excess state arguments.
+7. **Bare pure precondition introduction**: on the `Prop` lattice, replace a `True`
+   precondition by `⊤` and lift any other precondition into the local context.
+8. **EPost projection reduction**: reduce an `EPost.Cons.head` RHS to the projected component.
+9. **Lattice decomposition**: decompose `⊓`, `⇨`, `⌜p⌝` and `⊤` RHS connectives.
+10. **Lifted-hypothesis discharge**: close a residual `pre ⊑ φ` entailment against the most
+    recently lifted precondition, cached in `Scope.lastLiftedPre?`.
+11. **WP decomposition**: when the RHS is `wp e post epost s₁ ... sₙ`, in order:
+    hoist/zeta program-head lets, split `ite`/`dite`/match, zeta-unfold fvar program heads,
+    reduce projection heads, and finally apply a registered `@[spec]` theorem.
+
+Pure preconditions are lifted as soon as they arise (steps 5 and 7). The lifted hypothesis is
+cached in `Scope.lastLiftedPre?`. Step 10 closes residual entailments against it with a single
+defeq check, and bare `Prop` targets, such as the subgoal of the `⌜φ⌝` lattice rule, are
+checked against it before being classified as VCs.
 -/
 public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := goal.withContext do
   if ← outOfFuel then return .stop
-  let target ← goal.getType
+  let mut goal := goal
+  let mut target ← goal.getType
   trace[Elab.Tactic.Do.vcgen] "🎯 Target: {target}"
-  -- Phase 1: simplify `target` until it is of the form `H ⊢ₛ T`.
-  if let some g ← tryForallIntro goal target then return .goals scope [g]
-  if let some g ← tryLetIntro goal target then return .goals scope [g]
+
+  if target.hasExprMVar then
+    -- Rule application may have assigned metavariables in the target; re-normalise so the
+    -- syntactic shape tests below see the assigned form.
+    target ← instantiateMVars target
+    goal ← goal.replaceTargetDefEq target
+
+  -- Phase 1: simplify `target` until it is of the form `pre ⊑ rhs`.
+  if let some gs ← tryForallIntro goal target then return .goals scope gs
+  if let some g ← tryTargetLetIntro goal target then return .goals scope [g]
   if let some g ← tryTripleUnfold goal target then return .goals scope [g]
-  if let some gs ← solvePostCondEntails goal then return .goals scope gs
+  if let some g ← tryBareWPToLe goal target then return .goals scope [g]
 
-  let_expr ent@SPred.entails σs H T := target | return .noEntailment target
-  -- Phase 2: simplify `H`/`T` so that neither is a head redex and `T` is of the form
-  -- `wp⟦e⟧ Q s₁ ... sₙ`.
-  if let some g ← tryTargetLambdaIntro goal T then return .goals scope [g]
-  if let some g ← tryHeadReduceHT goal ent σs H T then return .goals scope [g]
+  let_expr PartialOrder.rel α inst pre rhs := target
+    | if let some gs ← tryLiftedHypBare scope goal target then return .goals scope gs
+      else return .noEntailment target
+  let preIsTop := pre.isAppOf ``Lean.Order.top && pre.getAppNumArgs == 2
 
-  -- Look for program syntax in `T`.
-  let (head, args) := T.withApp fun head args => (head, args) -- (head, args) for nicer stack traces
-
-  unless head.isConstOf ``PredTrans.apply do
-    if let some gs ← trySolveSPredEntails goal ent σs H T then return .goals scope gs
-    return .noProgramFoundInTarget T
-
-  let wp := args[2]!
-  let_expr wpConst@WP.wp m ps instWP α e := wp | return .noProgramFoundInTarget T
-  -- `T` is of the form `wp⟦e⟧ Q s₁ ... sₙ`, where `e` is the program.
-  -- We call `s₁ ... sₙ` the excess state args; the backward rules need to account for these.
-  -- Excess state args are introduced by the spec of `get` (see lambda case above).
-  let excessArgs := args.drop 4
-  let f := e.getAppFn
-
-  trace[Elab.Tactic.Do.vcgen] "📜 Program: {e}"
-
-  -- The four "program-shape" steps below all consume one unit of fuel
-  -- (the `stepLimit` config option) when they make progress, so the calls to
-  -- `VCGen.burnOne` are gathered here rather than scattered inside the helpers.
-
-  -- Let-expressions: hoist to top of goal
-  if let some g ← tryLetHoist goal head H σs ent args wpConst m ps instWP α e f then
-    VCGen.burnOne
-    return .goals scope [g]
+  -- Phase 2: close reflexive goals, then drive `pre` toward `⊤`, lifting any pure content so a
+  -- later spec application sees a `⊤` precondition.
+  if let some gs ← tryRfl goal then return .goals scope gs
+  if let some (scope, gs) ← tryNormalizePre scope goal α pre target then return .goals scope gs
 
   -- Collect new local specs before any strategy that may emit multiple subgoals
-  -- (`trySplit`) or apply a registered spec (`applySpec`). Single-goal strategies
-  -- above this point don't need the updated scope.
+  -- (`tryWPMatch`, `tryLattice`) or apply a registered spec (`applySpec`).
   let scope ← scope.collectLocalSpecs goal
 
-  -- Split ite/dite/match (or iota-reduce if discriminant is concrete)
-  if let some gs ← trySplit goal head H σs ent args wpConst m ps instWP α e excessArgs then
-    VCGen.burnOne
-    return .goals scope gs
+  -- Phase 3: shape the `rhs` (reduce an EPost projection, decompose a lattice connective), then
+  -- discharge a residual entailment against the lifted hypothesis.
+  if let some g ← reduceEPostHead? goal target α inst pre rhs then return .goals scope [g]
+  if let some gs ← tryLattice goal target rhs preIsTop then return .goals scope gs
+  if let some gs ← tryLiftedHyp scope goal α pre rhs then return .goals scope gs
 
-  -- Zeta-unfold local let bindings on demand
-  if let some g ← tryFvarZeta goal head H σs ent args wpConst m ps instWP α e f then
-    VCGen.burnOne
-    return .goals scope [g]
+  -- Phase 4: wp decomposition. The program-shape steps below all consume one unit of fuel
+  -- (the `stepLimit` config option) when they make progress.
+  if let some info := getWPInfo? rhs then
+    trace[Elab.Tactic.Do.vcgen] "📜 Program: {info.prog}"
+    if let some g ← tryWPLet goal target info then
+      VCGen.burnOne
+      return .goals scope [g]
+    if let some gs ← tryWPMatch goal target info then
+      VCGen.burnOne
+      return .goals scope gs
+    if let some g ← tryWPFVarZeta goal target info then
+      VCGen.burnOne
+      return .goals scope [g]
+    if let some g ← tryWPHeadReduce goal target info then
+      VCGen.burnOne
+      return .goals scope [g]
+    -- Stop if the program matches the `until` pattern.
+    if ← matchesUntilPattern info.m info.prog then return .stop
+    let f := info.prog.getAppFn
+    if f.isConst || f.isFVar then
+      VCGen.burnOne
+      return ← applySpec scope goal target info
+    return .noStrategyForProgram info.prog
 
-  -- Reduce kernel `.proj` heads in the program (e.g., `instAddNat.1 a b`).
-  if let some g ← tryHeadReduceProg goal head H σs ent args wpConst m ps instWP α e f then
-    VCGen.burnOne
-    return .goals scope [g]
-
-  -- Stop if the program matches the `until` pattern (elaborated lazily against the program monad).
-  let matchesUntilPattern (m : Expr) : VCGenM Bool := do
-    let some ref := (← read).untilPat? | return false
-    let pat ← UntilPatternThunk.force ref m
-    if (← pat.match? e).isSome then
-      trace[Elab.Tactic.Do.vcgen] "`until` pattern matched program {e}; stopping"
-      return true
-    return false
-  if ← matchesUntilPattern m then return .stop
-
-  -- Apply registered specifications, or fall through to `.noStrategyForProgram`.
-  VCGen.burnOne
-  applySpec scope goal e excessArgs m σs ps instWP
+  return .noProgramOrLatticeFoundInTarget rhs
 
 end VCGen
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
@@ -109,14 +109,15 @@ public def mkSpecTheoremFromSimpDecl? (declName : Name) (prio : Nat) : MetaM (Op
   let (pattern, (eqTy, rhs)) ← Sym.mkPatternFromDeclWithKey declName fun body => do
     let_expr Eq eqTy lhs rhs := body | throwError "conclusion is not an equality{indentExpr body}"
     return (lhs, (eqTy, rhs))
+  -- Skip no-op equations whose preprocessed LHS key is syntactically the RHS, so rewriting makes no
+  -- progress: `getThe.eq_1 : getThe σ = MonadStateOf.get` and the function-level
+  -- `liftM.eq_1 : @liftM = @monadLift` (`getThe`/`liftM` are reducible, so `preprocessDeclPattern`
+  -- already unfolded them in `pattern.pattern`). A structural `==` (not `isDefEq`) avoids both the
+  -- loose-bvar `whnf` panic on the lemma's binders and over-skipping productive unfolds whose RHS is
+  -- only definitionally equal (`get`, `monadLift_trans`, ordinary `foo.eq_1`). The key is compared
+  -- pre-eta so function-level equations are covered.
+  if pattern.pattern == rhs then return none
   let (pattern, etaArgs) := etaExpandEqPattern pattern eqTy
-  -- Skip no-op equations where LHS and RHS are the same after `unfoldReducible`.
-  -- E.g., `getThe.eq_1 : getThe σ = MonadStateOf.get` becomes a no-op because
-  -- `preprocessDeclPattern` unfolds `getThe` to `MonadStateOf.get`.
-  -- We use `==` (structural equality) rather than `isSameExpr` (pointer equality)
-  -- because the LHS and RHS are independently constructed.
-  -- Compare the original (non-expanded) pattern with rhs, since both are in the same context.
-  if etaArgs == 0 && pattern.pattern == rhs then return none
   return some { pattern, proof := .global declName, kind := .simp etaArgs, priority := prio }
 
 /--

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
@@ -127,10 +127,10 @@ side of `@[spec]`:
 - unfold entries registered with `attribute [spec] foo`, using stored equation lemmas when
   available and falling back to `Meta.getEqnsFor?`.
 
-Hoare triple and `⊑ wp` specs need no migration: the attribute stores them pattern-keyed
+Hoare triple and `⊑ wp` specs are already in `database`: the attribute stores them pattern-keyed
 at annotation time.
 -/
-public def migrateSpecTheoremsDatabase (database : SpecTheorems) (simpThms : SimpTheorems) :
+public def extendWithSimpSpecs (database : SpecTheorems) (simpThms : SimpTheorems) :
     SymM SpecTheorems := do
   let mut specs := database.specs
   -- Erased entries are still inserted into `specs` below; `findSpecs` filters them out
@@ -139,15 +139,15 @@ public def migrateSpecTheoremsDatabase (database : SpecTheorems) (simpThms : Sim
     match SpecProof.ofOrigin o with
     | some p => acc.insert p
     | none => acc
-  -- Migrate simp spec theorems (equational lemmas registered via `@[spec]`)
+  -- Add simp spec theorems (equational lemmas registered via `@[spec]`)
   for simpThm in simpThms.post.values do
     if let .decl declName .. := simpThm.origin then
       try
         if let some newSpec ← mkSpecTheoremFromSimpDecl? declName simpThm.priority then
           specs := Sym.insertPattern specs newSpec.pattern newSpec
       catch e =>
-        trace[Elab.Tactic.Do.vcgen] "Failed to migrate simp spec {declName}: {e.toMessageData}"
-  -- Migrate definitions to unfold (registered via `attribute [spec] foo`)
+        trace[Elab.Tactic.Do.vcgen] "Failed to add simp spec {declName}: {e.toMessageData}"
+  -- Add definitions to unfold (registered via `attribute [spec] foo`)
   for declName in simpThms.toUnfold.toList do
     let eqThms ← match simpThms.toUnfoldThms.find? declName with
       | some eqThms => pure eqThms
@@ -160,7 +160,7 @@ public def migrateSpecTheoremsDatabase (database : SpecTheorems) (simpThms : Sim
         if let some newSpec ← mkSpecTheoremFromSimpDecl? eqThm (prio := eval_prio default) then
           specs := Sym.insertPattern specs newSpec.pattern newSpec
       catch e =>
-        trace[Elab.Tactic.Do.vcgen] "Failed to migrate unfold spec {declName}/{eqThm}: {e.toMessageData}"
+        trace[Elab.Tactic.Do.vcgen] "Failed to add unfold spec {declName}/{eqThm}: {e.toMessageData}"
   return { specs, erased }
 
 end VCGen

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Sebastian Graf
+Authors: Sebastian Graf, Vladimir Gladshtein
 -/
 module
 
@@ -13,108 +13,52 @@ import Lean.Meta.Sym.Simp.DiscrTree
 import Lean.Meta.Sym.Util
 
 open Lean Meta Elab Tactic Sym
-open Lean.Elab.Tactic.Do.SpecAttr
-open Std.Do
 
 /-!
-Spec-theorem database used by `mvcgen'`. Mirrors the legacy `SpecTheorems` /
-`SpecProof` API from `Lean.Elab.Tactic.Do.Attr` but indexes specs in a
-`Sym.DiscrTree` keyed on the program's syntactic shape, with explicit
-`SpecTheoremKind` (triple vs. simp) and per-spec eta-potential metadata.
+Spec-theorem database used by `mvcgen'`. The `@[spec]` attribute already stores
+`Std.Internal.Do` specs as pattern-keyed `SpecTheorem`s (see `Lean.Elab.Tactic.Do.Attr`);
+this module adds the operations the VC generator needs on top: instantiating a spec to
+`pre ⊑ wp …` form, migrating the equational lemmas registered through the `mvcgen_simp`
+side of `@[spec]` into the same database, and looking up the specs matching a program.
 -/
 
-namespace Lean.Elab.Tactic.Do.SpecAttr
+namespace Lean.Elab.Tactic.Do.Internal
+
+open SpecAttr
 
 /--
-The kind of a spec theorem.
--/
-public inductive SpecTheoremKind where
-  /--
-  A Hoare triple spec: `⦃P⦄ prog ⦃Q⦄`.
-  If `etaPotential` is non-zero, then the precondition contains meta variables that can be
-  instantiated after applying `mintro ∀s` `etaPotential` many times.
-  -/
-  | triple (etaPotential : Nat := 0)
-  /--
-  A simp/equational spec: `lhs = rhs`.
-  The pattern is the LHS.
-  When matched, the VCGen rewrites the program from `lhs` to `rhs` and continues.
-  `etaArgs` is the number of extra arguments introduced by eta-expanding function-level equations
-  (e.g., class projection unfold lemmas). These args need `congrFun` at instantiation time.
-  -/
-  | simp (etaArgs : Nat := 0)
-  deriving Inhabited
+Instantiates a spec theorem's proof.
 
-public structure SpecTheoremNew where
-  /--
-  Pattern for the program expression.
-  This is the key used in the discrimination tree.
-  If the proof has type `∀ a b c, Triple prog P Q`, then the pattern is `prog[a:=#2, b:=#1, c:=#0]`.
-  For simp specs with type `∀ a b c, lhs = rhs`, the pattern is `lhs[a:=#2, b:=#1, c:=#0]`.
-  -/
-  pattern : Sym.Pattern
-  /-- The proof for the theorem. -/
-  proof : SpecProof
-  /-- The kind of spec theorem: triple or simp. -/
-  kind : SpecTheoremKind
-  priority : Nat  := eval_prio default
-  deriving Inhabited
-
-public instance : BEq SpecTheoremNew where
-  beq thm₁ thm₂ := thm₁.proof == thm₂.proof
-
-/--
-Like `SpecProof.instantiate`, but for simp specs also eta-expands function-level equations.
-
-For unfold equations of class projections (e.g., `MonadState.modifyGet.eq_1`), the equation
+Hoare triple and `⊑ wp` specs are normalised to `pre ⊑ wp …` form via `tripleToWpProof?`.
+Simp specs keep the raw `lhs = rhs` equality, but eta-expand function-level equations:
+for unfold equations of class projections (e.g., `MonadState.modifyGet.eq_1`), the equation
 after `forallMetaTelescope` may be between functions rather than values:
   `@modifyGet σ m self = self.3 : {α} → (σ → α × σ) → m α`
 This method applies `congrFun` for each leading forall to reduce the equation to one between
 values of type `m α`, introducing fresh metavariables for the extra arguments.
 The number of extra args is stored in `SpecTheoremKind.simp etaArgs`.
 -/
-public def SpecTheoremNew.instantiate (specThm : SpecTheoremNew) :
+public def SpecAttr.SpecTheorem.instantiate (specThm : SpecTheorem) :
     MetaM (Array Expr × Array BinderInfo × Expr × Expr) := do
-  let (xs, bs, eqPrf, eqType) ← specThm.proof.instantiate
-  let .simp etaArgs := specThm.kind | return (xs, bs, eqPrf, eqType)
-  if etaArgs == 0 then return (xs, bs, eqPrf, eqType)
-  let_expr Eq eqα _lhs _rhs := eqType | return (xs, bs, eqPrf, eqType)
+  let (xs, bs, prf, type) ← specThm.proof.instantiate
+  let .simp etaArgs := specThm.kind
+    | do
+      let some (prf, type) ← tripleToWpProof? prf type
+        | throwError "expected `Triple` or `⊑ wp` specification, got{indentExpr type}"
+      return (xs, bs, prf, type)
+  if etaArgs == 0 then return (xs, bs, prf, type)
+  let_expr Eq eqα _lhs _rhs := type | return (xs, bs, prf, type)
   -- Eta-expand: introduce fresh metavars for leading foralls, then apply congrFun for each.
   let (extraXs, extraBs, _) ← withReducible <| forallMetaBoundedTelescope eqα etaArgs
-  let eqPrf ← extraXs.foldlM (init := eqPrf) Meta.mkCongrFun
-  let eqType ← inferType eqPrf
-  return (xs ++ extraXs, bs ++ extraBs, eqPrf, eqType)
+  let prf ← extraXs.foldlM (init := prf) Meta.mkCongrFun
+  let type ← inferType prf
+  return (xs ++ extraXs, bs ++ extraBs, prf, type)
 
-public structure SpecTheoremsNew where
-  specs : DiscrTree SpecTheoremNew := DiscrTree.empty
-  erased : PHashSet SpecProof := {}
-  deriving Inhabited
+/-- The declaration name of a global spec theorem, `none` for local/syntactic specs. -/
+public def SpecAttr.SpecTheorem.global? (specThm : SpecTheorem) : Option Name :=
+  match specThm.proof with | .global decl => some decl | _ => none
 
-public def mkTriplePatternFromExpr (expr : Expr) (levelParams : List Name := []) : SymM Pattern := do
-  Prod.fst <$> Sym.mkPatternFromExprWithKey expr levelParams fun type => do
-    let_expr Triple _m _ps _inst _α prog _P _Q := type | throwError "conclusion is not a Triple {indentExpr type}"
-    return (prog, ())
-
-public def mkSpecTheoremNew (proof : SpecProof) (prio : Nat) : SymM (Option SpecTheoremNew) := do
-  -- cf. mkSimpTheoremCore
-  let (levelParams, expr) ← proof.getProof
-  let type ← Meta.inferType expr
-  let type ← instantiateMVars type
-  unless type.getForallBody.getAppFn.isConstOf ``Triple do
-    return none
-  let pattern ← mkTriplePatternFromExpr expr levelParams
-  withNewMCtxDepth do
-  let (xs, _, type) ← withSimpGlobalConfig (forallMetaTelescope type)
-  let type ← whnfR type
-  let_expr c@Triple _m ps _inst _α _prog P _Q := type
-    | throwError "{type} was not a Triple. Should not happen with the previous tests in place."
-  -- beta potential of `P` describes how many times we want to `mintro ∀s`, that is,
-  -- *eta*-expand the goal.
-  let σs := mkApp (mkConst ``PostShape.args [c.constLevels![0]!]) ps
-  let etaPotential ← computeMVarBetaPotentialForSPred xs σs P
-  -- logInfo m!"Beta potential {etaPotential} for {P}"
-  -- logInfo m!"mkSpecTheorem: {keys}, proof: {proof}"
-  return some { pattern, proof, kind := .triple etaPotential, priority := prio }
+namespace VCGen
 
 /--
 Eta-expand a pattern for a function-level equation.
@@ -154,14 +98,14 @@ private def etaExpandEqPattern (pattern : Sym.Pattern) (eqTy : Expr) : Sym.Patte
     (newPattern, k)
 
 /--
-Create a `SpecTheoremNew` from a simp/equational declaration `declName : ∀ xs, lhs = rhs`.
+Create a `SpecTheorem` from a simp/equational declaration `declName : ∀ xs, lhs = rhs`.
 The pattern is keyed on `lhs`.
 
 For unfold equations of class projections (e.g., `MonadState.modifyGet.eq_1`), the equation
 may be between functions rather than values. In that case, the pattern is eta-expanded
 so the discrimination tree key includes all arguments.
 -/
-public def mkSpecTheoremNewFromSimpDecl? (declName : Name) (prio : Nat) : MetaM (Option SpecTheoremNew) := do
+public def mkSpecTheoremFromSimpDecl? (declName : Name) (prio : Nat) : MetaM (Option SpecTheorem) := do
   let (pattern, (eqTy, rhs)) ← Sym.mkPatternFromDeclWithKey declName fun body => do
     let_expr Eq eqTy lhs rhs := body | throwError "conclusion is not an equality{indentExpr body}"
     return (lhs, (eqTy, rhs))
@@ -175,24 +119,30 @@ public def mkSpecTheoremNewFromSimpDecl? (declName : Name) (prio : Nat) : MetaM 
   if etaArgs == 0 && pattern.pattern == rhs then return none
   return some { pattern, proof := .global declName, kind := .simp etaArgs, priority := prio }
 
+/--
+Extend the `@[spec]` database with the equational lemmas registered through the `mvcgen_simp`
+side of `@[spec]`:
+- simp theorem declarations registered directly as `@[spec]`,
+- unfold entries registered with `attribute [spec] foo`, using stored equation lemmas when
+  available and falling back to `Meta.getEqnsFor?`.
+
+Hoare triple and `⊑ wp` specs need no migration: the attribute stores them pattern-keyed
+at annotation time.
+-/
 public def migrateSpecTheoremsDatabase (database : SpecTheorems) (simpThms : SimpTheorems) :
-    SymM SpecTheoremsNew := do
-  let mut specs : DiscrTree SpecTheoremNew := DiscrTree.empty
+    SymM SpecTheorems := do
+  let mut specs := database.specs
   -- Erased entries are still inserted into `specs` below; `findSpecs` filters them out
   -- at lookup time.
   let erased : PHashSet SpecProof := simpThms.erased.fold (init := database.erased) fun acc o =>
     match SpecProof.ofOrigin o with
     | some p => acc.insert p
     | none => acc
-  for spec in database.specs.values do
-    let some newSpec ← mkSpecTheoremNew spec.proof spec.priority
-      | throwError "could not migrate spec theorem {spec.proof}"
-    specs := Sym.insertPattern specs newSpec.pattern newSpec
   -- Migrate simp spec theorems (equational lemmas registered via `@[spec]`)
   for simpThm in simpThms.post.values do
     if let .decl declName .. := simpThm.origin then
       try
-        if let some newSpec ← mkSpecTheoremNewFromSimpDecl? declName simpThm.priority then
+        if let some newSpec ← mkSpecTheoremFromSimpDecl? declName simpThm.priority then
           specs := Sym.insertPattern specs newSpec.pattern newSpec
       catch e =>
         trace[Elab.Tactic.Do.vcgen] "Failed to migrate simp spec {declName}: {e.toMessageData}"
@@ -206,18 +156,20 @@ public def migrateSpecTheoremsDatabase (database : SpecTheorems) (simpThms : Sim
         pure eqThms
     for eqThm in eqThms do
       try
-        if let some newSpec ← mkSpecTheoremNewFromSimpDecl? eqThm (prio := eval_prio default) then
+        if let some newSpec ← mkSpecTheoremFromSimpDecl? eqThm (prio := eval_prio default) then
           specs := Sym.insertPattern specs newSpec.pattern newSpec
       catch e =>
         trace[Elab.Tactic.Do.vcgen] "Failed to migrate unfold spec {declName}/{eqThm}: {e.toMessageData}"
   return { specs, erased }
 
+end VCGen
+
 /--
-Look up `SpecTheoremNew`s in the `@[spec]` database.
+Look up `SpecTheorem`s in the `@[spec]` database.
 Takes all specs that match the given program `e` and sorts by descending priority.
 -/
-public def SpecTheoremsNew.findSpecs (database : SpecTheoremsNew) (e : Expr) :
-    SymM (Except (Array SpecTheoremNew) SpecTheoremNew) := do
+public def SpecAttr.SpecTheorems.findSpecs (database : SpecTheorems) (e : Expr) :
+    SymM (Except (Array SpecTheorem) SpecTheorem) := do
   let e ← instantiateMVars e
   let e ← shareCommon e
   let candidates := Sym.getMatch database.specs e
@@ -232,4 +184,4 @@ public def SpecTheoremsNew.findSpecs (database : SpecTheoremsNew) (e : Expr) :
     return .ok spec
   return .error candidates
 
-end Lean.Elab.Tactic.Do.SpecAttr
+end Lean.Elab.Tactic.Do.Internal

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Util.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Util.lean
@@ -11,17 +11,17 @@ public import Lean.Elab.Tactic.Do.Internal.VCGen.Context
 public import Lean.Elab.Tactic.Do.Internal.VCGen.Reduce
 public import Lean.Meta.Sym.AlphaShareBuilder
 public import Lean.Meta.Sym.Intro
+public import Lean.Meta.Sym.Simp.Goal
 public import Lean.Meta.Sym.Simp.Telescope
 public import Lean.Meta.Sym.Util
 
-open Lean Meta Sym
-open Std.Do
+open Lean Meta Sym Lean.Order
 
 /-!
-Generic `VCGenM` helpers: small-cap operations on `MVarId`s, telescope-aware
-`simp` driver, hypothesis-internalization for grind, and a residual-goal
-generalization of `applyRflAndAndIntro`. None of these know anything about
-`SPred` entailment specifically.
+Generic `VCGenM` helpers: checked backward-rule application, telescope-aware `simp` driver,
+hygienic binder introduction, hypothesis-internalization for grind, and the trivial-conjunct
+collapser `solveTrivialConjuncts`. None of these know anything about the entailment shapes `solve`
+decomposes.
 -/
 
 namespace Lean.Elab.Tactic.Do.Internal
@@ -76,32 +76,55 @@ open Lean.Elab.Tactic.Do.Internal
 public def processHypotheses (goal : Grind.Goal) : VCGenM Grind.Goal := do
   if (← read).internalize then Grind.processHypotheses goal else return goal
 
-public def simpTargetTelescope (mvarId : MVarId) : VCGenM (MVarId × Bool) := do
-  let some methods := (← read).hypSimpMethods | return (mvarId, false)
-  let target ← mvarId.getType
-  let simpState := (← get).simpState
-  let methods := { methods with pre := Sym.Simp.simpTelescope }
-  let (result, simpState') ← Sym.Simp.SimpM.run (Sym.Simp.simp target) methods {} simpState
-  modify fun s => { s with simpState := simpState' }
-  match result with
-  | .rfl .. => return (mvarId, false)
-  | .step newTarget proof .. =>
-    let mvarId' ← mvarId.replaceTargetEq newTarget proof
-    return (mvarId', true)
+/--
+Introduce all leading binders of `goal` in one pass, naming the `i`-th binder `overrides[i]` when
+given and the binder's own name otherwise. Accessibility is decided by `tactic.hygienic` via
+`mkFreshBinderNameForTactic`. The introduction itself is a single `Sym.intros` call (which keeps
+the memoized, sharing-correct intro); only the names are chosen here. Returns the goal unchanged
+when there are no leading binders.
+-/
+public def introsHygienic (goal : MVarId) (overrides : Array Name := #[]) : VCGenM MVarId :=
+  goal.withContext do
+    let rec collectBinders (type : Expr) (acc : Array Name) : Array Name :=
+      match type with
+      | .forallE n _ b _ => collectBinders b (acc.push n)
+      | .letE n _ _ b _ => collectBinders b (acc.push n)
+      | _ => acc
+    let binderNames := collectBinders (← goal.getType) #[]
+    if binderNames.isEmpty then return goal
+    let mut names := #[]
+    for h : i in *...binderNames.size do
+      names := names.push (← Meta.mkFreshBinderNameForTactic (overrides[i]?.getD binderNames[i]))
+    let .goal _ goal ← Sym.intros goal names | return goal
+    return goal
 
 /--
-Simplify the forall telescope of the target using `Sym.Simp.simpTelescope`,
-then introduce all binders via `Sym.intros`.
+Simplify the goal's target with the configured hypothesis simp methods (a no-op without
+`Context.hypSimpMethods`), threading the persistent simp cache through `VCGenM`'s state.
+`.noProgress` is forwarded to the caller.
 -/
-public def introsSimp (mvarId : MVarId) (errorMsg : MessageData) : VCGenM MVarId := do
-  let (mvarId, progress) ← simpTargetTelescope mvarId
-  match ← Sym.intros mvarId with
-  | .failed =>
-    if progress then
-      return mvarId
-    else
-      throwError m!"Failed to intro on {mvarId}\nContext: {errorMsg}."
-  | .goal _ mvarId' => return mvarId'
+public def simpGoalTelescope (goal : MVarId) : VCGenM Sym.SimpGoalResult := do
+  let some methods := (← read).hypSimpMethods | return .noProgress
+  let methods := { methods with pre := Sym.Simp.simpTelescope }
+  let target ← goal.getType
+  let (result, simpState') ← Sym.Simp.SimpM.run (Sym.Simp.simp target) methods {} (← get).simpState
+  modify fun s => { s with simpState := simpState' }
+  result.toSimpGoalResult goal
+
+/--
+Introduce the excess state arguments of an entailment goal `pre ⊑ rhs` whose lattice type is a
+function type `σ₁ → … → σₙ → α`: repeatedly apply `stateArgIntroRule` (a backward rule for
+`Std.Internal.Do.le_of_forall_le`) and introduce the new state binder, until the lattice type is
+no longer a function type.
+-/
+public partial def introsExcessArgs (goal : MVarId) :
+    VCGenM MVarId := goal.withContext do
+  let type ← goal.getType
+  let_expr PartialOrder.rel α _inst _pre _rhs := type | return goal
+  unless α.isForall do return goal
+  let .goals [goal] ← (← read).introRules.stateArgIntro.applyChecked goal | return goal
+  let goal ← introsHygienic goal
+  introsExcessArgs goal
 
 /--
 Solves conjunctions whose leaves are `True` or `e₁ = e₂`, and returns a residual goal containing
@@ -109,7 +132,7 @@ exactly the conjuncts that could not be solved.
 This procedure may assign metavariables in `e₁`/`e₂`, for example for `e = ?m` it will assign
 `?m := e`.
 -/
-public partial def repeatAndRfl (goal : MVarId) : VCGenM (Option MVarId) :=
+public partial def solveTrivialConjuncts (goal : MVarId) : VCGenM (Option MVarId) :=
     goal.withContext do
   let ctx ← read
   let ty ← instantiateMVars (← goal.getType)
@@ -118,8 +141,8 @@ public partial def repeatAndRfl (goal : MVarId) : VCGenM (Option MVarId) :=
     return none
   else if ty.isAppOf ``And then
     let .goals [g₁, g₂] ← ctx.andIntroRule.applyChecked goal
-      | throwError "repeatAndRfl: failed to apply {.ofConstName ``And.intro} to{indentExpr ty}"
-    match ← repeatAndRfl g₁, ← repeatAndRfl g₂ with
+      | throwError "solveTrivialConjuncts: failed to apply {.ofConstName ``And.intro} to{indentExpr ty}"
+    match ← solveTrivialConjuncts g₁, ← solveTrivialConjuncts g₂ with
     | none,    none    => return none
     | some g,  none    => return some g
     | none,    some g  => return some g
@@ -135,7 +158,9 @@ public partial def repeatAndRfl (goal : MVarId) : VCGenM (Option MVarId) :=
     let rhs ← reduceHead rhs
     let u ← Meta.getLevel ty
     let goal ← goal.replaceTargetDefEq (mkApp3 (mkConst ``Eq [u]) ty lhs rhs)
-    if ← withAssignableSyntheticOpaque <| isDefEqS lhs rhs then
+    -- Synthetic opaque metavariables (e.g. invariant holes) stay rigid; natural
+    -- metavariables may be assigned (e.g. `?m := e` for `e = ?m` leaves).
+    if ← isDefEqS lhs rhs then
       goal.assign (mkApp2 (mkConst ``Eq.refl [← Meta.getLevel ty]) ty lhs)
       return none
     else

--- a/src/Lean/Elab/Tactic/Do/VCGen.lean
+++ b/src/Lean/Elab/Tactic/Do/VCGen.lean
@@ -404,8 +404,11 @@ def elabInvariants (stx : Syntax) (invariants : Array MVarId) (suggestInvariant 
         let mv := invariants[i]!
         if ← mv.isAssigned then
           continue
-        let invariant ← suggestInvariant mv
-        suggestions := suggestions.push (← `(invariantDotAlt| · $invariant))
+        -- A failing suggestion (e.g. an invariant shape the analysis does not understand)
+        -- degrades to "no suggestion" rather than failing the tactic.
+        let invariant? ← try some <$> suggestInvariant mv catch _ => pure none
+        if let some invariant := invariant? then
+          suggestions := suggestions.push (← `(invariantDotAlt| · $invariant))
       let alts' := alts ++ suggestions
       let stx' ← `(invariantAlts|invariants $alts'*)
       if suggestions.size > 0 then

--- a/src/Std/Internal/Do/Order/Frame.lean
+++ b/src/Std/Internal/Do/Order/Frame.lean
@@ -48,15 +48,6 @@ theorem himp_complete (x a b : α) : a ⊓ x ⊑ b → x ⊑ a ⇨ b := by
   exact le_sup (c := fun y : α => a ⊓ y ⊑ b) h
 
 /--
-`⊤`-specialized completeness direction: if `a ⊑ b`, then `⊤ ⊑ a ⇨ b`.
-
-This avoids the redundant `⊓ ⊤` that `himp_complete` would leave when the precondition is `⊤`.
--/
-theorem himp_complete_top (a b : α) : a ⊑ b → (⊤ : α) ⊑ a ⇨ b := by
-  intro h
-  exact himp_complete ⊤ a b (PartialOrder.rel_trans (meet_le_left a ⊤) h)
-
-/--
 Soundness direction (`a ⊓ (a ⇨ b) ⊑ b`) from the frame distributivity law.
 -/
 theorem himp_sound [Frame α] (a b : α) : a ⊓ (a ⇨ b) ⊑ b := by

--- a/src/Std/Internal/Do/Order/Lemmas.lean
+++ b/src/Std/Internal/Do/Order/Lemmas.lean
@@ -144,6 +144,8 @@ theorem le_iff_join_eq_right : (P ⊑ Q) ↔ P ⊔ Q = Q :=
 theorem top_meet : (⊤ : l) ⊓ P = P :=
   rel_antisymm (meet_le_right _ _) (le_meet _ _ _ (le_top _) rel_refl)
 theorem meet_top : P ⊓ (⊤ : l) = P := meet_comm.trans top_meet
+/-- Cancel a redundant `⊓ ⊤` on the left of an entailment. -/
+theorem meet_top_le_of_le (h : P ⊑ Q) : P ⊓ ⊤ ⊑ Q := by rw [meet_top]; exact h
 theorem bot_meet : (⊥ : l) ⊓ P = ⊥ :=
   rel_antisymm (meet_le_of_left_le (bot_le _)) (bot_le _)
 theorem meet_bot : P ⊓ (⊥ : l) = ⊥ := meet_comm.trans bot_meet

--- a/tests/bench/mvcgen/sym/cases/Cases/AddSubCancel.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/AddSubCancel.lean
@@ -1,24 +1,28 @@
 import Lean
 import Std.Tactic.Do
+/-!
+Port of `Sym/Cases/AddSubCancel` to the new meta theory.
 
-open Lean Meta Elab Tactic Sym Std Do SpecAttr
+Basic add/sub loop in `StateM`: each `step` adds then subtracts the same value, so the
+loop preserves the state. Exercises the `get`/`set` `StateT` specs in the simplest setting.
+-/
 
-namespace AddSubCancel
+open Lean Meta Order Std.Internal.Do
 
 set_option mvcgen.warning false
 
--- The following specs partially evaluate the specs for `get` and `set` that otherwise would need
--- multiple small substeps in the modular lifting framework. This is good practice for performance
--- sensitive use cases.
+namespace AddSubCancel
 
-@[spec high]
-theorem Spec.MonadState_get {m ps} [Monad m] [WPMonad m ps] {σ} {Q : PostCond σ (.arg σ ps)} :
-    ⦃fun s => Q.fst s s⦄ get (m := StateT σ m) ⦃Q⦄ := by
+@[spec high] theorem spec_get_StateT {m : Type u → Type v} {Pred EPred : Type u}
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+    {σ : Type u} (post : σ → σ → Pred) (epost : EPred) :
+    Triple (fun s => post s s) (get : StateT σ m σ) post epost := by
   mvcgen'
 
-@[spec high]
-theorem Spec.MonadStateOf_set {m ps} [Monad m] [WPMonad m ps] {σ} {Q : PostCond PUnit (.arg σ ps)} {s : σ} :
-    ⦃fun _ => Q.fst ⟨⟩ s⦄ set (m := StateT σ m) s ⦃Q⦄ := by
+@[spec high] theorem spec_set_StateT' {m : Type u → Type v} {Pred EPred : Type u}
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+    {σ : Type u} (s : σ) (post : PUnit → σ → Pred) (epost : EPred) :
+    Triple (fun _ => post ⟨⟩ s) (set s : StateT σ m PUnit) post epost := by
   mvcgen'
 
 def step (v : Nat) : StateM Nat Unit := do
@@ -32,6 +36,6 @@ def loop (n : Nat) : StateM Nat Unit := do
   | 0 => pure ()
   | n+1 => step n; loop n
 
-def Goal (n : Nat) : Prop := ∀ post, ⦃post⦄ loop n ⦃⇓_ => post⦄
+def Goal (n : Nat) : Prop := ∀ post, ⦃post⦄ loop n ⦃fun _ => post⦄
 
 end AddSubCancel

--- a/tests/bench/mvcgen/sym/cases/Cases/AddSubCancelDeep.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/AddSubCancelDeep.lean
@@ -1,11 +1,21 @@
 import Lean
 import Std.Tactic.Do
+/-!
+Port of `Sym/Cases/AddSubCancelDeep` to the new meta theory.
 
-open Lean Meta Elab Tactic Sym Std Do SpecAttr
+Same loop as `AddSubCancel` but threaded through a deep monad transformer stack.
 
-namespace AddSubCancelDeep
+Known issue: the partially-evaluated `getThe`/`set` specs for this deep stack are not yet
+provable by `mvcgen'` (see the divergence notes below),
+so they are currently axiomatized with `sorry`. The benchmark still exercises VC generation
+through the deep stack using these specs.
+-/
+
+open Lean Parser Meta Elab Tactic Sym Lean.Order Std.Internal.Do
 
 set_option mvcgen.warning false
+
+namespace AddSubCancelDeep
 
 /-!
 Same case as `AddSubCancel` but using a deep transformer stack.
@@ -19,13 +29,13 @@ abbrev M := ExceptT String <| ReaderT String <| ExceptT Nat <| StateT Nat <| Exc
 
 @[spec high]
 theorem Spec.M_getThe_Nat :
-    ⦃fun s₁ s₂ => Q.fst s₂ s₁ s₂⦄ getThe (m := M) Nat ⦃Q⦄ := by
-  mvcgen
+    ⦃fun s₁ s₂ => post s₂ s₁ s₂⦄ (getThe (m := M) Nat) ⦃post⦄ := by
+  mvcgen'
 
 @[spec high]
 theorem Spec.M_set_Nat (n : Nat) :
-    ⦃fun s₁ _ => Q.fst ⟨⟩ s₁ n⦄ set (m := M) n ⦃Q⦄ := by
-  mvcgen
+    ⦃fun s₁ _ => post ⟨⟩ s₁ n⦄ (set (m := M) n) ⦃post⦄ := by
+  mvcgen'
 
 def step (v : Nat) : M Unit := do
   let s ← getThe Nat
@@ -38,6 +48,6 @@ def loop (n : Nat) : M Unit := do
   | 0 => pure ()
   | n+1 => step n; loop n
 
-def Goal (n : Nat) : Prop := ∀ post, ⦃post⦄ loop n ⦃⇓_ => post⦄
+def Goal (n : Nat) : Prop := ∀ post, ⦃post⦄ loop n ⦃fun _ => post⦄
 
 end AddSubCancelDeep

--- a/tests/bench/mvcgen/sym/cases/Cases/AddSubCancelSimp.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/AddSubCancelSimp.lean
@@ -1,24 +1,34 @@
 import Lean
 import Std.Tactic.Do
+/-!
+Port of `Sym/Cases/AddSubCancelSimp` to the new meta theory.
 
-open Lean Meta Elab Tactic Sym Std Do SpecAttr
+Same benchmark as `AddSubCancel` but using equality (`simp`) specs for `get` and `set`
+instead of triple specs. Exercises the simp/equality spec rule-construction path.
+-/
 
-namespace AddSubCancelSimp
+open Lean Meta Order Std.Internal.Do
 
 set_option mvcgen.warning false
 
--- Same benchmark as `AddSubCancel` but using simp spec equations instead of triple specs
--- for `get` and `set`. This exercises the `reduceSimpSpec` + `replaceTargetEq` code path.
+namespace AddSubCancelSimp
 
-@[spec high]
-theorem Spec.MonadState_get {m} [Monad m] {σ} :
-    get (m := StateT σ m) = fun s => pure (s, s) := by
-  rfl
+/- TODO: Those lemmas actually not used because priorites are not respected for simp lemmas.
+  Moreover, if `mvcgen'` actually used them, it wpould have lead to a bug:
+  ```
+  Did not know how to decompose weakest precondition for fun s => pure (s, s)
+  ```
+  in both implementations!
+-/
+-- @[spec high]
+-- theorem Spec.MonadState_get {m : Type u → Type v} [Monad m] {σ : Type u} :
+--     (get : StateT σ m σ) = fun s => pure (s, s) := by
+--   rfl
 
-@[spec high]
-theorem Spec.MonadStateOf_set {m} [Monad m] {σ} {s : σ} :
-    set (m := StateT σ m) s = fun _ => pure (⟨⟩, s) := by
-  rfl
+-- @[spec high]
+-- theorem Spec.MonadStateOf_set {m : Type u → Type v} [Monad m] {σ : Type u} {s : σ} :
+--     (set s : StateT σ m PUnit) = fun _ => pure (⟨⟩, s) := by
+--   rfl
 
 def step (v : Nat) : StateM Nat Unit := do
   let s ← get
@@ -31,6 +41,6 @@ def loop (n : Nat) : StateM Nat Unit := do
   | 0 => pure ()
   | n+1 => step n; loop n
 
-def Goal (n : Nat) : Prop := ∀ post, ⦃post⦄ loop n ⦃⇓_ => post⦄
+def Goal (n : Nat) : Prop := ∀ post, ⦃post⦄ loop n ⦃fun _ => post⦄
 
 end AddSubCancelSimp

--- a/tests/bench/mvcgen/sym/cases/Cases/DiteSplit.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/DiteSplit.lean
@@ -1,28 +1,28 @@
 import Lean
 import Std.Tactic.Do
+/-!
+Port of `Sym/Cases/DiteSplit` to the new meta theory.
 
-open Lean Meta Elab Tactic Sym Std Do SpecAttr
+Dependent if-then-else (`if h : cond then ...`) inside an `ExceptT String <| StateM Nat`
+program. The add/sub around the guarded `throw` keeps the state unchanged on the success path.
+-/
 
-namespace DiteSplit
+open Lean Meta Order Std.Internal.Do
 
 set_option mvcgen.warning false
 
+namespace DiteSplit
+
 abbrev M := ExceptT String <| StateM Nat
 
-@[spec high]
-theorem Spec.throw_M {e : String} :
-    ⦃Q.2.1 e⦄ throw (m := M) e ⦃Q⦄ := by
-  mvcgen
+@[spec high] theorem spec_throw (e : String) {post : α → Nat → Prop} :
+    ⦃epost e⦄ (throw (m := M) e) ⦃post; epost⦄ := ⟨PartialOrder.rel_refl⟩
 
-@[spec high]
-theorem Spec.set_M {s : Nat} :
-    ⦃fun _ => Q.1 ⟨⟩ s⦄ set (m := M) s ⦃Q⦄ := by
-  mvcgen
+@[spec high] theorem spec_set (x : Nat) {post : PUnit → Nat → Prop} :
+    ⦃fun _ => post ⟨⟩ x⦄ (set (m := M) x) ⦃post⦄ := ⟨PartialOrder.rel_refl⟩
 
-@[spec high]
-theorem Spec.get_M :
-    ⦃fun s => Q.1 s s⦄ get (m := M) ⦃Q⦄ := by
-  mvcgen
+@[spec high] theorem spec_get (post : Nat → Nat → Prop) :
+    ⦃fun s => post s s⦄ (get (m := M)) ⦃post⦄ := ⟨PartialOrder.rel_refl⟩
 
 def step (v : Nat) : M Unit := do
   let s ← get
@@ -37,6 +37,7 @@ def loop (n : Nat) : M Unit := do
   | 0 => pure ()
   | n+1 => step n; loop n
 
-def Goal (n : Nat) : Prop := ⦃fun s => ⌜s = 0⌝⦄ loop n ⦃⇓_ s => ⌜s = 0⌝⦄
+def Goal (n : Nat) : Prop := ⦃fun s => s = 0⦄ loop n ⦃fun _ s => s = 0⦄
+
 
 end DiteSplit

--- a/tests/bench/mvcgen/sym/cases/Cases/GetThrowSet.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/GetThrowSet.lean
@@ -1,31 +1,31 @@
 import Lean
 import Std.Tactic.Do
+/-!
+Port of `Sym/Cases/GetThrowSet` to the new meta theory.
 
-open Lean Meta Elab Tactic Sym Std Do SpecAttr
+Exception handling with `ExceptT String <| StateM Nat`: each `step` conditionally throws and
+otherwise increments the state by one. With the loop driving the state up from `0` the guard
+never fires, so the program never throws and ends at state `n`.
+-/
+
+open Lean Meta Order Std.Internal.Do
+
+set_option mvcgen.warning false
 
 namespace GetThrowSet
 
-set_option mvcgen.warning false
-set_option backward.do.legacy false -- exercises asymmetric bind depth from new do elaborator
-
 abbrev M := ExceptT String <| StateM Nat
 
--- Partially evaluated specs for best performance.
+@[spec high] theorem spec_throw (e : String) {post : α → Nat → Prop} {epost : EPost⟨String → Nat → Prop⟩} :
+    Triple (epost.head e) (throw (m := M) e) post epost := ⟨PartialOrder.rel_refl⟩
 
-@[spec high]
-theorem Spec.throw_M {e : String} :
-    ⦃Q.2.1 e⦄ throw (m := M) e ⦃Q⦄ := by
-  mvcgen
+@[spec high] theorem spec_set (x : Nat) :
+    ⦃fun _ => post ⟨⟩ x⦄ (set (m := M) x) ⦃post⦄ := by
+  mvcgen'
 
-@[spec high]
-theorem Spec.set_M {s : Nat} :
-    ⦃fun _ => Q.1 ⟨⟩ s⦄ set (m := M) s ⦃Q⦄ := by
-  mvcgen
-
-@[spec high]
-theorem Spec.get_M :
-    ⦃fun s => Q.1 s s⦄ get (m := M) ⦃Q⦄ := by
-  mvcgen
+@[spec high] theorem spec_get :
+    ⦃fun s => post s s⦄ (get (m := M)) ⦃post⦄ := by
+  mvcgen'
 
 def step (lim : Nat) : M Unit := do
   let s ← get
@@ -38,6 +38,6 @@ def loop (n : Nat) : M Unit := do
   | 0 => pure ()
   | n+1 => loop n; step n
 
-def Goal (n : Nat) : Prop := ⦃fun s => ⌜s = 0⌝⦄ loop n ⦃⇓_ s => ⌜s = n⌝⦄
+def Goal (n : Nat) : Prop := ⦃fun s => s = 0⦄ loop n ⦃fun _ s => s = n⦄
 
 end GetThrowSet

--- a/tests/bench/mvcgen/sym/cases/Cases/LetBinding.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/LetBinding.lean
@@ -1,27 +1,33 @@
 import Lean
 import Std.Tactic.Do
+/-!
+Port of `Sym/Cases/LetBinding` to the new meta theory.
 
-open Lean Meta Elab Tactic Sym Std Do SpecAttr
+Same add/sub loop as `AddSubCancel` but with a pure `let offset := ...` binding inside `step`.
+Exercises the handling of pure `letE` nodes in the elaborated program (let-hoist / let-intro).
+-/
 
-namespace LetBinding
+open Lean Meta Order Std.Internal.Do
 
 set_option mvcgen.warning false
 
--- Partially evaluated specs for best performance.
+namespace LetBinding
 
-@[spec high]
-theorem Spec.MonadState_get {m ps} [Monad m] [WPMonad m ps] {σ} {Q : PostCond σ (.arg σ ps)} :
-    ⦃fun s => Q.fst s s⦄ get (m := StateT σ m) ⦃Q⦄ := by
+@[spec high] theorem spec_get_StateT {m : Type u → Type v} {Pred EPred : Type u}
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+    {σ : Type u} (post : σ → σ → Pred) (epost : EPred) :
+    Triple (fun s => post s s) (get : StateT σ m σ) post epost := by
   mvcgen'
 
-@[spec high]
-theorem Spec.MonadStateOf_set {m ps} [Monad m] [WPMonad m ps] {σ} {Q : PostCond PUnit (.arg σ ps)} {s : σ} :
-    ⦃fun _ => Q.fst ⟨⟩ s⦄ set (m := StateT σ m) s ⦃Q⦄ := by
+@[spec high] theorem spec_set_StateT' {m : Type u → Type v} {Pred EPred : Type u}
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+    {σ : Type u} (s : σ) (post : PUnit → σ → Pred) (epost : EPred) :
+    Triple (fun _ => post ⟨⟩ s) (set s : StateT σ m PUnit) post epost := by
   mvcgen'
 
 def step (v : Nat) : StateM Nat Unit := do
   let s ← get
-  -- Pure let binding: `let offset := ...` produces a letE node in the elaborated term
+  -- Pure let binding: `let offset := ...` produces a `letE` node in the elaborated term.
   let offset := v + 1
   set (s + offset)
   let s ← get
@@ -32,6 +38,7 @@ def loop (n : Nat) : StateM Nat Unit := do
   | 0 => pure ()
   | n+1 => step n; loop n
 
-def Goal (n : Nat) : Prop := ∀ post, ⦃post⦄ loop n ⦃⇓_ => post⦄
+def Goal (n : Nat) : Prop := ∀ post, ⦃post⦄ loop n ⦃fun _ => post⦄
+
 
 end LetBinding

--- a/tests/bench/mvcgen/sym/cases/Cases/MatchIota.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/MatchIota.lean
@@ -1,28 +1,30 @@
 import Lean
 import Std.Tactic.Do
+/-!
+Port of `Sym/Cases/MatchIota` to the new meta theory.
 
-open Lean Meta Elab Tactic Sym Std Do SpecAttr
+Pattern matching with a concrete discriminant (the literal argument `v` of `step`). Each
+`match v with | 0 => ... | n+1 => ...` iota-reduces during VC generation (no symbolic split).
+Because `loop` eventually calls `step 0`, the program throws, so the exceptional postcondition
+is left unconstrained (`⊤`).
+-/
 
-namespace MatchIota
+open Lean Meta Order Std.Internal.Do
 
 set_option mvcgen.warning false
 
+namespace MatchIota
+
 abbrev M := ExceptT String <| StateM Nat
 
-@[spec high]
-theorem Spec.throw_M {e : String} :
-    ⦃Q.2.1 e⦄ throw (m := M) e ⦃Q⦄ := by
-  mvcgen
+@[spec high] theorem spec_throw (e : String) {post : α → Nat → Prop} {epost : EPost⟨String → Nat → Prop⟩} :
+    Triple (epost.head e) (throw (m := M) e) post epost := ⟨PartialOrder.rel_refl⟩
 
-@[spec high]
-theorem Spec.set_M {s : Nat} :
-    ⦃fun _ => Q.1 ⟨⟩ s⦄ set (m := M) s ⦃Q⦄ := by
-  mvcgen
+@[spec high] theorem spec_set (x : Nat) {post : PUnit → Nat → Prop} {epost : EPost⟨String → Nat → Prop⟩} :
+    Triple (fun _ => post ⟨⟩ x) (set (m := M) x) post epost := ⟨PartialOrder.rel_refl⟩
 
-@[spec high]
-theorem Spec.get_M :
-    ⦃fun s => Q.1 s s⦄ get (m := M) ⦃Q⦄ := by
-  mvcgen
+@[spec high] theorem spec_get (post : Nat → Nat → Prop) {epost : EPost⟨String → Nat → Prop⟩} :
+    Triple (fun s => post s s) (get (m := M)) post epost := ⟨PartialOrder.rel_refl⟩
 
 def step (v : Nat) : M Unit := do
   let s ← get
@@ -35,6 +37,6 @@ def loop (n : Nat) : M Unit := do
   | 0 => pure ()
   | n+1 => step n; loop n
 
-def Goal (n : Nat) : Prop := ⦃fun s => ⌜s = 0⌝⦄ loop n ⦃⇓_ s => ⌜s = n⌝⦄
+def Goal (n : Nat) : Prop := ⦃fun s => s = 0⦄ loop n ⦃fun _ s => s = n⦄
 
 end MatchIota

--- a/tests/bench/mvcgen/sym/cases/Cases/MatchSplit.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/MatchSplit.lean
@@ -1,28 +1,31 @@
 import Lean
 import Std.Tactic.Do
+/-!
+Port of `Sym/Cases/MatchSplit` to the new meta theory.
 
-open Lean Meta Elab Tactic Sym Std Do SpecAttr
+Pattern matching where the discriminant *is* the symbolic state (`match s with ...` after
+`let s ← get`). Unlike `MatchIota`, the discriminant is not a literal, so VC generation must
+perform a genuine match split. The initial state is kept symbolic (via `s = n`) so the split
+is not iota-reduced away. Starting at `s = n`, each `step` decrements the state by one, ending
+at `0` after exactly `n` steps without ever throwing.
+-/
 
-namespace MatchSplit
+open Lean Meta Order Std.Internal.Do
 
 set_option mvcgen.warning false
 
+namespace MatchSplit
+
 abbrev M := ExceptT String <| StateM Nat
 
-@[spec high]
-theorem Spec.throw_M {e : String} :
-    ⦃Q.2.1 e⦄ throw (m := M) e ⦃Q⦄ := by
-  mvcgen
+@[spec high] theorem spec_throw (e : String) {post : α → Nat → Prop} {epost : EPost⟨String → Nat → Prop⟩} :
+    Triple (epost.head e) (throw (m := M) e) post epost := ⟨PartialOrder.rel_refl⟩
 
-@[spec high]
-theorem Spec.set_M {s : Nat} :
-    ⦃fun _ => Q.1 ⟨⟩ s⦄ set (m := M) s ⦃Q⦄ := by
-  mvcgen
+@[spec high] theorem spec_set (x : Nat) {post : PUnit → Nat → Prop} {epost : EPost⟨String → Nat → Prop⟩} :
+    Triple (fun _ => post ⟨⟩ x) (set (m := M) x) post epost := ⟨PartialOrder.rel_refl⟩
 
-@[spec high]
-theorem Spec.get_M :
-    ⦃fun s => Q.1 s s⦄ get (m := M) ⦃Q⦄ := by
-  mvcgen
+@[spec high] theorem spec_get (post : Nat → Nat → Prop) {epost : EPost⟨String → Nat → Prop⟩} :
+    Triple (fun s => post s s) (get (m := M)) post epost := ⟨PartialOrder.rel_refl⟩
 
 /-- Matches on state `s` — the discriminant IS the excess state arg. -/
 def step : M Unit := do
@@ -36,6 +39,6 @@ def loop (n : Nat) : M Unit := do
   | 0 => pure ()
   | n+1 => step; loop n
 
-def Goal (n : Nat) : Prop := ⦃fun s => ⌜s = n⌝⦄ loop n ⦃⇓_ s => ⌜s = 0⌝⦄
+def Goal (n : Nat) : Prop := ⦃fun s => s = n⦄ loop n ⦃fun _ s => s = 0⦄
 
 end MatchSplit

--- a/tests/bench/mvcgen/sym/cases/Cases/PurePrecond.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/PurePrecond.lean
@@ -1,23 +1,33 @@
 import Lean
 import Std.Tactic.Do
+/-!
+Port of `Sym/Cases/PurePrecond` to the new meta theory.
 
-open Lean Meta Elab Tactic Sym Std Do SpecAttr
+Exercises pure propositional hypotheses in preconditions. `flipp` flips a `Bool` state, but
+its specs only apply under a pure precondition fixing the current value (`b = true` / `b = false`),
+so VC generation must introduce and discharge these pure preconditions. `step` flips twice,
+preserving `b = true`.
+-/
 
-namespace PurePrecond
+open Lean Meta Order Std.Internal.Do
 
 set_option mvcgen.warning false
 
+namespace PurePrecond
+
 def flipp (_ : Bool) : StateM Bool Unit := modify not
 
-theorem Spec.flipp_false :
-    ⦃fun b => ⌜b = false⌝⦄ flipp false ⦃⇓ _ b => ⌜b = true⌝⦄ := by
-  mvcgen [flipp] <;> grind
-
+@[spec]
 theorem Spec.flipp_true :
-    ⦃fun b => ⌜b = true⌝⦄ flipp true ⦃⇓ _ b => ⌜b = false⌝⦄ := by
-  mvcgen [flipp] <;> grind
+    Triple (fun b => b = true) (flipp true) (fun _ b => b = false) (⟨⟩ : EPost.Nil) := by
+  simp only [flipp, modify]
+  mvcgen' with finish
 
-attribute [spec] Spec.flipp_true Spec.flipp_false
+@[spec]
+theorem Spec.flipp_false :
+    Triple (fun b => b = false) (flipp false) (fun _ b => b = true) (⟨⟩ : EPost.Nil) := by
+  simp only [flipp, modify]
+  mvcgen' with finish
 
 def step : StateM Bool Unit := do
   flipp true
@@ -28,6 +38,7 @@ def loop (n : Nat) : StateM Bool Unit := do
   | 0 => pure ()
   | n+1 => step; loop n
 
-def Goal (n : Nat) : Prop := ⦃fun b => ⌜b = true⌝⦄ loop n ⦃⇓ _ b => ⌜b = true⌝⦄
+def Goal (n : Nat) : Prop :=
+  ⦃fun b => b = true⦄ loop n ⦃fun _ b => b = true⦄
 
 end PurePrecond

--- a/tests/bench/mvcgen/sym/cases/Cases/ReaderState.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/ReaderState.lean
@@ -1,30 +1,29 @@
 import Lean
 import Std.Tactic.Do
+/-!
+Port of `Sym/Cases/ReaderState` to the new meta theory.
 
-open Lean Meta Elab Tactic Sym Std Do SpecAttr
+A `ReaderT Nat <| StateM Nat` combination. Each `step` reads the reader `r`, adds it to the
+state and then subtracts it again, so the loop preserves both the reader and the state.
+Exercises partially-evaluated `read`/`get`/`set` specs for the reader+state stack.
+-/
 
-namespace ReaderState
+open Lean Meta Order Std.Internal.Do
 
 set_option mvcgen.warning false
 
+namespace ReaderState
+
 abbrev M := ReaderT Nat <| StateM Nat
 
--- Partially evaluated specs for best performance.
+@[spec high] theorem spec_read (post : Nat → Nat → Nat → Prop) (epost : EPost.Nil) :
+    Triple (fun r s => post r r s) (read (m := M)) post epost := ⟨PartialOrder.rel_refl⟩
 
-@[spec high]
-theorem Spec.M_read :
-    ⦃fun r s => Q.fst r r s⦄ read (m := M) ⦃Q⦄ := by
-  mvcgen
+@[spec high] theorem spec_get (post : Nat → Nat → Nat → Prop) (epost : EPost.Nil) :
+    Triple (fun r s => post s r s) (get (m := M)) post epost := ⟨PartialOrder.rel_refl⟩
 
-@[spec high]
-theorem Spec.M_get :
-    ⦃fun r s => Q.fst s r s⦄ get (m := M) ⦃Q⦄ := by
-  mvcgen
-
-@[spec high]
-theorem Spec.M_set (n : Nat) :
-    ⦃fun r _ => Q.fst () r n⦄ set (m := M) n ⦃Q⦄ := by
-  mvcgen
+@[spec high] theorem spec_set (n : Nat) (post : PUnit → Nat → Nat → Prop) (epost : EPost.Nil) :
+    Triple (fun r _ => post ⟨⟩ r n) (set (m := M) n) post epost := ⟨PartialOrder.rel_refl⟩
 
 def step : M Unit := do
   let r ← read
@@ -38,6 +37,6 @@ def loop (n : Nat) : M Unit := do
   | 0 => pure ()
   | n+1 => step; loop n
 
-def Goal (n : Nat) : Prop := ∀ post, ⦃post⦄ loop n ⦃⇓_ => post⦄
+def Goal (n : Nat) : Prop := ∀ post, ⦃post⦄ loop n ⦃fun _ => post⦄
 
 end ReaderState

--- a/tests/bench/mvcgen/sym/lib/Driver.lean
+++ b/tests/bench/mvcgen/sym/lib/Driver.lean
@@ -4,10 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sebastian Graf
 -/
 module
-public import Lean.Meta
-import Lean.Elab
-import Lean.Meta.Sym.Simp.Theorems
-
+public import Lean
+public import Std.Tactic.Do
+public import Std.Internal.Do
+public import Std.Internal.Do.Triple.SpecLemmas
 open Lean Parser Meta Elab Tactic Sym
 
 def timeItMs (k : MetaM α) : MetaM (α × UInt64) := do

--- a/tests/bench/mvcgen/sym/test_do_logic.lean
+++ b/tests/bench/mvcgen/sym/test_do_logic.lean
@@ -250,6 +250,18 @@ example (p : Nat → Prop) [DecidablePred p] (n : Nat) :
 
 end Automated
 
+namespace HimpSplit
+
+-- A `⇨` (Heyting implication) in the postcondition exercises the `himp_complete` split, whose
+-- subgoal carries a `⊓ ⊤` precondition that `meet_top_le_of_le` cancels. The abstract `Pred` keeps
+-- `⇨` from collapsing to `→`.
+theorem himp_post {m} [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+    ⦃ ⊤ ⦄ (pure 4 : m Nat) ⦃ fun r => ⌜r = 4⌝ ⇨ ⌜r > 0⌝ ⦄ := by
+  mvcgen'
+  all_goals grind
+
+end HimpSplit
+
 namespace VSTTE2010
 
 namespace MaxAndSum

--- a/tests/bench/mvcgen/sym/test_do_logic.lean
+++ b/tests/bench/mvcgen/sym/test_do_logic.lean
@@ -657,3 +657,27 @@ example : ⦃ True ⦄ foo bar ⦃ fun r => r % 2 = 0 ⦄ := by
   mvcgen' [foo_spec, bar] with finish
 
 end LocalSpec
+
+namespace RawMonadLiftRegression
+
+/-! A raw `monadLift`/`liftM` of an inner-monad value used to loop, because `liftM.eq_1`
+(`@liftM = @monadLift`, a reducible no-op) was registered as a productive simp spec. It now
+terminates. It is still not dischargeable: `monadLift_trans` is selected but cannot determine the
+existential intermediate monad, so a missing spec is reported. Turn this into a successful proof
+once raw lifts are supported. -/
+
+def liftProg : StateT Nat Id Nat := do
+  let x ← (pure 5 : Id Nat)
+  return x
+
+/--
+error: No spec matching the monad StateT Nat
+  Id found for program monadLift
+  (pure
+    5). Candidates were [SpecProof.global Std.Do.Spec.UnfoldLift.monadLift_trans,
+ SpecProof.global Std.Do.Spec.UnfoldLift.monadLift_refl].
+-/
+#guard_msgs in
+example : ⦃ ⊤ ⦄ liftProg ⦃ fun r _ => r = 5 ⦄ := by mvcgen' [liftProg]
+
+end RawMonadLiftRegression

--- a/tests/bench/mvcgen/sym/test_do_logic.lean
+++ b/tests/bench/mvcgen/sym/test_do_logic.lean
@@ -1,10 +1,10 @@
 /-
 Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Sebastian Graf
+Authors: Vladimir Gladshtein, Sebastian Graf
 -/
 import Lean
-import Std
+import Std.Internal
 import Std.Tactic.Do
 
 set_option mvcgen.warning false
@@ -22,14 +22,12 @@ Tests whose proofs do not mention `mvcgen`/`mvcgen'` (manual `mspec`/`mintro` pr
 are intentionally not ported.
 -/
 
-open Lean Meta Elab Tactic Sym Std Do SpecAttr
+open Lean Order Meta Elab Tactic Sym Std Internal.Do Do.Internal.SpecAttr
 
 set_option grind.warning false
 set_option warn.sorry false
 set_option backward.do.legacy false
 
-set_option maxRecDepth 10000
-set_option maxHeartbeats 10000000
 
 namespace Code
 
@@ -45,9 +43,9 @@ def fib_impl (n : Nat) : Id Nat := do
 
 @[simp, grind =]
 def fib_spec : Nat → Nat
-| 0 => 0
-| 1 => 1
-| n+2 => fib_spec n + fib_spec (n+1)
+  | 0 => 0
+  | 1 => 1
+  | n+2 => fib_spec n + fib_spec (n+1)
 
 abbrev AppState := Nat × Nat
 
@@ -96,40 +94,46 @@ namespace Automated
 
 open Code
 
-theorem fib_triple : ⦃⌜True⌝⦄ fib_impl n ⦃⇓ r => ⌜r = fib_spec n⌝⦄ := by
+theorem fib_triple : ⦃ True ⦄ fib_impl n ⦃ fun r => r = fib_spec n ⦄ := by
   unfold fib_impl
   mvcgen'
-  case inv1 => exact ⇓ (xs, ⟨a, b⟩) =>
-    ⌜a = fib_spec xs.pos ∧ b = fib_spec (xs.pos + 1)⌝
+  case inv1 => exact fun xs ⟨a, b⟩ =>
+    a = fib_spec xs.pos ∧ b = fib_spec (xs.pos + 1)
   all_goals grind
 
-theorem fib_triple_step : ⦃⌜True⌝⦄ fib_impl n ⦃⇓ r => ⌜r = fib_spec n⌝⦄ := by
+theorem fib_triple_finish : ⦃ True ⦄ fib_impl n ⦃ fun r => r = fib_spec n ⦄ := by
+  mvcgen' [fib_impl] invariants
+  | inv1 => fun xs ⟨a, b⟩ => a = fib_spec xs.pos ∧ b = fib_spec (xs.pos + 1)
+  with finish
+
+theorem fib_triple_step : ⦃ True ⦄ fib_impl n ⦃ fun r => r = fib_spec n ⦄ := by
   unfold fib_impl
   mvcgen' (stepLimit := some 14)
-  case inv1 => exact ⇓ ⟨xs, a, b⟩ =>
-    ⌜a = fib_spec xs.pos ∧ b = fib_spec (xs.pos + 1)⌝
-  all_goals simp_all +zetaDelta [Nat.sub_one_add_one]
+  case inv1 => exact fun xs ⟨a, b⟩ =>
+    a = fib_spec xs.pos ∧ b = fib_spec (xs.pos + 1)
+  all_goals grind
 
 attribute [local spec] fib_triple in
-theorem fib_triple_attr : ⦃⌜True⌝⦄ fib_impl n ⦃⇓ r => ⌜r = fib_spec n⌝⦄ := by
+theorem fib_triple_attr : ⦃ True ⦄ fib_impl n ⦃ fun r => r = fib_spec n ⦄ := by
   mvcgen'
 
 attribute [local spec] fib_triple in
-theorem fib_triple_erase : ⦃⌜True⌝⦄ fib_impl n ⦃⇓ r => ⌜r = fib_spec n⌝⦄ := by
+theorem fib_triple_erase : ⦃ True ⦄ fib_impl n ⦃fun r => r = fib_spec n⦄ := by
   mvcgen' (errorOnMissingSpec := false) [-fib_triple]
   fail_if_success done
   admit
 
 theorem fib_impl_vcs
-    (Q : Nat → PostCond Nat PostShape.pure)
+    (Q : Nat → Nat → Prop)
+    (E : EPost.Nil)
     (I : (n : Nat) → (_ : ¬n = 0) →
-      Invariant [1:n].toList (Prod Nat Nat) PostShape.pure)
-    (ret : ⊢ₛ (Q 0).fst 0)
-    (loop_pre : ∀ n (hn : ¬n = 0), ⊢ₛ (I n hn).fst ⟨⟨[], [1:n].toList, rfl⟩, 0, 1⟩)
-    (loop_post : ∀ n (hn : ¬n = 0) r, (I n hn).fst ⟨⟨[1:n].toList, [], by simp⟩, r⟩ ⊢ₛ (Q n).fst r.2)
+      Invariant [1:n].toList (Prod Nat Nat) Prop)
+    (ret : Q 0 0)
+    (loop_pre : ∀ n (hn : ¬n = 0), (I n hn) ⟨[], [1:n].toList, rfl⟩ (0, 1))
+    (loop_post : ∀ n (hn : ¬n = 0) r, (I n hn) ⟨[1:n].toList, [], by simp⟩ r ⊑ Q n r.2)
     (loop_step : ∀ n (hn : ¬n = 0) r pref cur suff (h : [1:n].toList = pref ++ cur :: suff),
-                  (I n hn).fst ⟨⟨pref, cur::suff, by simp[h]⟩, r⟩ ⊢ₛ (I n hn).1 ⟨⟨pref ++ [cur], suff, by simp[h]⟩, r.2, r.1+r.2⟩)
-    : ⊢ₛ wp⟦fib_impl n⟧ (Q n) := by
+                  (I n hn) ⟨pref, cur::suff, by simp[h]⟩ r ⊑ (I n hn) ⟨pref ++ [cur], suff, by simp[h]⟩ (r.2, r.1+r.2))
+    : wp (fib_impl n) (Q n) E := by
   mvcgen' [fib_impl]
   case inv1 h => exact I n h
   case vc1 h => subst h; apply_rules [ret]
@@ -138,106 +142,92 @@ theorem fib_impl_vcs
   case vc4 => apply_rules [loop_post]
 
 @[spec]
-theorem mkFreshNat_spec [Monad m] [WPMonad m sh] :
-  ⦃fun s => ⌜s.1 = n ∧ s.2 = o⌝⦄
-  (mkFreshNat : StateT AppState m Nat)
-  ⦃⇓ r s => ⌜r = n ∧ s.1 = n + 1 ∧ s.2 = o⌝⦄ := by
-  mvcgen' [mkFreshNat]
-  simp_all +zetaDelta
+theorem mkFreshNat_spec [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+    ⦃ fun s => ⌜s.1 = n ∧ s.2 = o⌝ ⦄
+    (mkFreshNat : StateT AppState m Nat)
+    ⦃ fun r s => ⌜r = n ∧ s.1 = n + 1 ∧ s.2 = o⌝ ⦄ := by
+  mvcgen' [mkFreshNat] <;> simp_all
 
-theorem erase_unfold [Monad m] [WPMonad m sh] :
-  ⦃fun s => ⌜s.1 = n ∧ s.2 = o⌝⦄
+theorem erase_unfold [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+  ⦃fun s => ⌜s.1 = n ∧ s.2 = o⌝ ⦄
   (mkFreshNat : StateT AppState m Nat)
-  ⦃⇓ r s => ⌜r = n ∧ s.1 = n + 1 ∧ s.2 = o⌝⦄ := by
+  ⦃fun r s => ⌜r = n ∧ s.1 = n + 1 ∧ s.2 = o⌝ ⦄ := by
   unfold mkFreshNat
   mvcgen' (errorOnMissingSpec := false) [-modify]
-  simp_all [-WP.modify_MonadStateOf]
+  simp_all [-WPMonad.wp_modify_StateT_apply_eq]
   fail_if_success done
   admit
 
-theorem add_unfold [Monad m] [WPMonad m sh] :
-  ⦃fun s => ⌜s.1 = n ∧ s.2 = o⌝⦄
-  (mkFreshNat : StateT AppState m Nat)
-  ⦃⇓ r s => ⌜r = n ∧ s.1 = n + 1 ∧ s.2 = o⌝⦄ := by
-  mvcgen' [mkFreshNat]
-  simp_all +zetaDelta
+theorem add_unfold [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+    ⦃ fun s => ⌜s.1 = n ∧ s.2 = o⌝ ⦄
+    (mkFreshNat : StateT AppState m Nat)
+    ⦃ fun r s => ⌜r = n ∧ s.1 = n + 1 ∧ s.2 = o⌝ ⦄ := by
+  mvcgen' [mkFreshNat] <;> simp_all
 
--- `mkFreshPair_triple` from doLogicTests uses `mvcgen -elimLets +trivial [mkFreshPair]`.
-theorem mkFreshPair_triple : ⦃⌜True⌝⦄ mkFreshPair ⦃⇓ (a, b) => ⌜a ≠ b⌝⦄ := by
-  mvcgen' [mkFreshPair]
-  simp_all
+theorem mkFreshPair_triple :
+    ⦃ fun _ => True ⦄ mkFreshPair ⦃ fun (p : Nat × Nat) => ⌜p.1 ≠ p.2⌝ ⦄ := by
+  mvcgen' [mkFreshPair] <;> simp_all
 
-theorem sum_loop_spec :
-  ⦃⌜True⌝⦄
-  sum_loop
-  ⦃⇓r => ⌜r < 30⌝⦄ := by
-  -- cf. `ByHand.sum_loop_spec`
-  mintro -
+theorem sum_loop_spec : ⦃ True ⦄ sum_loop ⦃ fun r => r < 30 ⦄ := by
   mvcgen' [sum_loop]
-  case inv1 => exact (⇓ (xs, r) => ⌜r + xs.suffix.length * 5 ≤ 25⌝)
-  all_goals simp_all; try grind
+  case inv1 => exact fun c x => x = c.«prefix».sum
+  all_goals grind
 
 theorem throwing_loop_spec :
-  ⦃fun s => ⌜s = 4⌝⦄
+  ⦃fun s => s = 4⦄
   throwing_loop
-  ⦃post⟨fun _ _ => ⌜False⌝,
-        fun e s => ⌜e = 42 ∧ s = 4⌝⟩⦄ := by
+  ⦃fun _ _ => False;
+  fun e s => e = 42 ∧ s = 4⦄ := by
   mvcgen' [throwing_loop]
-  case inv1 => exact post⟨fun (xs, r) s => ⌜r ≤ 4 ∧ s = 4 ∧ r + xs.suffix.sum > 4⌝,
-                         fun e s => ⌜e = 42 ∧ s = 4⌝⟩
-  all_goals mleave; try (subst_vars; grind)
+  case inv1 => exact fun xs r s => r ≤ 4 ∧ s = 4 ∧ r + xs.suffix.sum > 4
+  all_goals (simp_all; try grind)
 
 theorem test_loop_break :
-  ⦃fun s => ⌜s = 42⌝⦄
-  breaking_loop
-  ⦃⇓ r s => ⌜r > 4 ∧ s = 1⌝⦄ := by
+    ⦃ fun s => s = 42 ⦄ breaking_loop ⦃ fun r s => r > 4 ∧ s = 1 ⦄ := by
   mvcgen' [breaking_loop]
-  case inv1 => exact (⇓ (xs, r) s => ⌜(r ≤ 4 ∧ r = xs.prefix.sum ∨ r > 4) ∧ s = 42⌝)
+  case inv1 => exact fun xs r s => (r ≤ 4 ∧ r = xs.prefix.sum ∨ r > 4) ∧ s = 42
   all_goals grind
 
 theorem test_loop_early_return :
-  ⦃fun s => ⌜s = 4⌝⦄
-  returning_loop
-  ⦃⇓ r s => ⌜r = 42 ∧ s = 4⌝⦄ := by
+    ⦃ fun s => s = 4 ⦄ returning_loop ⦃ fun r s => r = 42 ∧ s = 4 ⦄ := by
   mvcgen' [returning_loop]
-  case inv1 => exact (⇓ (xs, r) s => ⌜(r.1 = none ∧ r.2 = xs.prefix.sum ∧ r.2 ≤ 4 ∨ r.1 = some 42 ∧ r.2 > 4) ∧ s = 4⌝)
+  case inv1 => exact fun xs r s => (r.1 = none ∧ r.2 = xs.prefix.sum ∧ r.2 ≤ 4 ∨ r.1 = some 42 ∧ r.2 > 4) ∧ s = 4
   all_goals grind
 
 theorem unfold_to_expose_match_spec :
-  ⦃fun s => ⌜s = 4⌝⦄
+  ⦃ fun s => s = 4 ⦄
   unfold_to_expose_match
-  ⦃⇓ r => ⌜r = 4⌝⦄ := by
+  ⦃ fun r => ⌜r = 4⌝ ⦄ := by
   mvcgen' [unfold_to_expose_match, Option.getD]
-  simplifying_assumptions [SPred.pure_cons]
 
-theorem test_match_splitting {m : Option Nat} (h : m = some 4) :
-  ⦃⌜True⌝⦄
-  (match m with
-  | some n => (set n : StateM Nat PUnit)
-  | none => set 0)
-  ⦃⇓ _ s => ⌜s = 4⌝⦄ := by
+theorem test_match_splitting {mo : Option Nat} (h : mo = some 4) :
+    ⦃ fun _ => True ⦄
+    (match mo with
+     | some n => (set n : StateM Nat PUnit)
+     | none => set 0)
+    ⦃ fun _ s => s = 4 ⦄ := by
   mvcgen' <;> simp_all
 
 theorem test_sum :
-  ⦃⌜True⌝⦄
-  (do
-    let mut x := 0
-    for i in [1:5] do
-      x := x + i
-    pure x : Id _)
-  ⦃⇓r => ⌜r < 30⌝⦄ := by
+    ⦃ True ⦄
+    (do
+      let mut x := 0
+      for i in [1:5] do
+        x := x + i
+      pure x : Id _)
+    ⦃ fun r => r < 30 ⦄ := by
   mvcgen'
-  case inv1 => exact (⇓ (xs, r) => ⌜r + xs.suffix.length * 5 ≤ 25⌝)
-  all_goals simp_all; try grind
+  case inv1 => exact fun c x => x = c.«prefix».sum
+  all_goals grind
 
 theorem mspec_forwards_mvars {n : Nat} :
-  ⦃⌜True⌝⦄
+  ⦃True⦄
   (do
     for i in [2:n] do
       if n < i * i then
         return 1
     return 1 : Id Nat)
-  ⦃⇓ r => ⌜True⌝⦄ := by
+  ⦃fun r => True⦄ := by
   mvcgen'
   all_goals admit
 
@@ -274,17 +264,18 @@ def max_and_sum (xs : Array Nat) : Id (Nat × Nat) := do
   return (max, sum)
 
 theorem max_and_sum_spec (xs : Array Nat) :
-    ⦃⌜∀ i, (h : i < xs.size) → xs[i] ≥ 0⌝⦄ max_and_sum xs ⦃⇓ (m, s) => ⌜s ≤ m * xs.size⌝⦄ := by
+    ⦃ ∀ i, (h : i < xs.size) → xs[i] ≥ 0 ⦄
+    max_and_sum xs ⦃ fun (m, s) => s ≤ m * xs.size ⦄ := by
   mvcgen' [max_and_sum]
-  case inv1 => exact (⇓ ⟨xs, m, s⟩ => ⌜s ≤ m * xs.pos⌝)
+  case inv1 => exact fun c ⟨mx, s⟩ => s ≤ mx * c.pos
   all_goals simp_all +zetaDelta
-  · rename_i h
+  case vc3 =>
+    rename_i hle hlt
     rw [Nat.left_distrib]
-    simp +zetaDelta only [Nat.mul_one, Nat.add_le_add_iff_right]
-    apply Nat.le_trans h
-    apply Nat.mul_le_mul_right
-    grind
-  · rw [Nat.left_distrib]
+    simp only [Nat.mul_one]
+    exact Nat.add_le_add (Nat.le_trans hle (Nat.mul_le_mul_right _ (Nat.le_of_lt hlt))) (Nat.le_refl _)
+  case vc4 =>
+    rw [Nat.left_distrib]
     grind
 
 end MaxAndSum
@@ -293,39 +284,27 @@ end VSTTE2010
 
 namespace RishsConstApproxBug
 
-@[spec]
-theorem Spec.get_StateT' [Monad m] [WPMonad m psm] :
-  ⦃fun s => Q.1 s s⦄ (MonadState.get : StateT σ m σ) ⦃Q⦄ := Spec.get_StateT
-
 @[inline] def test : StateM Unit Unit := do
   let _ ← get
   if True then
     pure ()
 
 theorem need_const_approx' :
-   ⦃fun x => ⌜x = ()⌝⦄
-   test
-   ⦃⇓ _ => ⌜True⌝⦄ := by
+    ⦃ fun x => x = () ⦄ test ⦃ fun _ _ => True ⦄ := by
   mvcgen' [test]
-  -- mvcgen' leaves trivial VCs that mvcgen would auto-discharge
-  all_goals grind
 
 end RishsConstApproxBug
 
 namespace RishsTailContextBug
 
-axiom Specs.get_StateT' [Monad m] [WPMonad m psm] :
-  ⦃fun s => Q.1 s s⦄ (MonadState.get : StateT σ m σ) ⦃Q⦄
-attribute [local spec] Specs.get_StateT'
-
 axiom I : StateM Nat Unit
 axiom F : StateM Nat Unit
 axiom G : StateM Nat Unit
-axiom P : Assertion (PostShape.arg Nat PostShape.pure)
-axiom Q: PostCond Unit (PostShape.arg Nat PostShape.pure)
-axiom hI : ⦃⌜True⌝⦄ I ⦃⇓ _ => P⦄
-axiom hF : ⦃P⦄ F ⦃Q⦄
-axiom hG : ⦃P⦄ G ⦃Q⦄
+axiom P : Nat → Prop
+axiom Q : Unit → Nat → Prop
+axiom hI : ⦃ fun _ => True ⦄ I ⦃ fun _ => P ⦄
+axiom hF : ⦃ P ⦄ F ⦃ Q ⦄
+axiom hG : ⦃ P ⦄ G ⦃ Q ⦄
 attribute [local spec] hI hF hG
 
 @[inline] noncomputable def test_ite : StateM Nat Unit := do
@@ -336,7 +315,7 @@ attribute [local spec] hI hF hG
   else
     G
 
-theorem ex : ⦃⌜True⌝⦄ test_ite ⦃Q⦄ := by
+theorem ex : ⦃ fun _ => True ⦄ test_ite ⦃ Q ⦄ := by
   mvcgen' [test_ite]
 
 end RishsTailContextBug
@@ -347,7 +326,8 @@ open Std
 
 variable {α : Type u} {β : Type v} {cmp : α → α → Ordering} [TransCmp cmp]
 
-def mergeWithAll (m₁ m₂ : ExtTreeMap α β cmp) (f : α → Option β → Option β → Option β) : ExtTreeMap α β cmp :=
+def mergeWithAll (m₁ m₂ : ExtTreeMap α β cmp) (f : α → Option β → Option β → Option β) :
+    ExtTreeMap α β cmp :=
   Id.run do
     let mut r := ∅
     for (a, b₁) in m₁ do
@@ -364,7 +344,8 @@ def mergeWithAll (m₁ m₂ : ExtTreeMap α β cmp) (f : α → Option β → Op
 -- universe-polymorphic `ExtTreeMap`; both fall back to simp, which simplifies
 -- the body but doesn't fully discharge. With `(errorOnMissingSpec := false)`,
 -- `mvcgen'` matches legacy `mvcgen`'s behaviour of leaving an unsolved VC.
-theorem mem_mergeWithAll [LawfulEqCmp cmp] {m₁ m₂ : ExtTreeMap α β cmp} {f : α → Option β → Option β → Option β} {a : α} :
+theorem mem_mergeWithAll [LawfulEqCmp cmp] {m₁ m₂ : ExtTreeMap α β cmp}
+    {f : α → Option β → Option β → Option β} {a : α} :
     a ∈ mergeWithAll m₁ m₂ f ↔ (a ∈ m₁ ∨ a ∈ m₂) ∧ (f a m₁[a]? m₂[a]?).isSome := by
   generalize h : mergeWithAll m₁ m₂ f = x
   apply Id.of_wp_run_eq h
@@ -385,17 +366,19 @@ theorem subarraySum_correct {xs : Subarray Nat} : subarraySum xs = xs.toList.sum
   generalize h : subarraySum xs = r
   apply Id.of_wp_run_eq h
   mvcgen'
-  case inv1 => exact ⇓⟨cursor, prefixSum⟩ => ⌜prefixSum = cursor.prefix.sum⌝
+  case inv1 => exact fun c s => s = c.«prefix».sum
   all_goals simp_all +zetaDelta
 
 end Slices
+
+/-! ## PatricksFastExp -/
 
 namespace PatricksFastExp
 
 def naive_expo (x n : Nat) : Nat := Id.run do
   let mut y := 1
   for _ in [:n] do
-    y := y*x
+    y := y * x
   return y
 
 def fast_expo (x n : Nat) : Nat := Id.run do
@@ -413,40 +396,31 @@ def fast_expo (x n : Nat) : Nat := Id.run do
 
   return y
 
-theorem naive_expo_correct (x n : Nat) : naive_expo x n = x^n := by
+theorem naive_expo_correct (x n : Nat) : naive_expo x n = x ^ n := by
   generalize h : naive_expo x n = r
   apply Id.of_wp_run_eq h
   mvcgen'
-  case inv1 => exact ⇓⟨xs, r⟩ => ⌜r = x^xs.pos⌝
+  case inv1 => exact fun c y => y = x ^ c.pos
   all_goals simp_all +zetaDelta [Nat.pow_add_one]
 
--- NOTE: mvcgen' leaves VCs with un-destructured tuples (`b.fst`, `b.snd.snd`),
--- so the proof manually `obtain`s them. The legacy mvcgen names the components.
-theorem fast_expo_correct (x n : Nat) : fast_expo x n = x^n := by
+theorem fast_expo_correct (x n : Nat) : fast_expo x n = x ^ n := by
   generalize h : fast_expo x n = r
   apply Id.of_wp_run_eq h
   mvcgen'
-  case inv1 => exact ⇓⟨xs, x', y, e⟩ => ⌜x' ^ e * y = x ^ n ∧ e ≤ n - xs.pos⌝
+  case inv1 => exact fun xs ⟨x', y, e⟩ => x' ^ e * y = x ^ n ∧ e ≤ n - xs.pos
   all_goals simp_all +zetaDelta
-  case vc2 b _ _ _ _ _ _ _ _ ih =>
-    obtain ⟨x', y, e⟩ := b
-    simp at *
+  case vc2 ih =>
+    rw [← ih.1, ih.2, Nat.pow_zero, Nat.one_mul]
+  case vc4 =>
     constructor
-    · rw [← Nat.mul_assoc, ← Nat.pow_add_one, ← ih.1]
-      have : e - 1 + 1 = e := by grind
-      rw [this]
+    · rw [← Nat.mul_assoc, ← Nat.pow_add_one]
+      grind
     · grind
-  case vc3 b _ _ _ _ _ _ _ ih _ =>
-    obtain ⟨x', y, e⟩ := b
-    simp at *
+  case vc5 =>
     constructor
     · rw [← Nat.pow_two, ← Nat.pow_mul]
       grind
     · grind
-  case vc5 b _ _ ih =>
-    obtain ⟨x', y, e⟩ := b
-    simp at *
-    rw [← ih.1, ih.2, Nat.pow_zero, Nat.one_mul]
 
 theorem same_func (x n : Nat) : fast_expo x n = naive_expo x n := by
   rw [naive_expo_correct, fast_expo_correct]
@@ -458,69 +432,71 @@ section IteratorTests
 variable {m} [Monad m]
 open Std Std.Iterators
 
-theorem forIn_eq_sum (xs : Array Nat) {m ps} [Monad m] [WPMonad m ps] :
-    Triple (m := m) (do
+theorem forIn_eq_sum (xs : Array Nat) {m} [Monad m] [Assertion Pred] [Assertion EPred]
+    [WPMonad m Pred EPred] :
+    ⦃ ⊤ ⦄
+    (do
       let mut sum : Nat := 0
       for n in xs.iter do
         sum := sum + n
-      return sum) ⌜True⌝ (⇓r => ⌜r = xs.sum⌝) := by
+      return sum : m _)
+    ⦃ fun r => ⌜r = xs.sum⌝ ⦄ := by
   mvcgen'
-  case inv1 => exact ⇓⟨cur, n⟩ => ⌜n = cur.prefix.sum⌝
+  case inv1 => exact fun cur n => ⌜n = cur.prefix.sum⌝
   all_goals grind
 
-theorem forIn_map_eq_sum_add_size (xs : Array Nat) {m ps} [Monad m] [LawfulMonad m]
-    [WPMonad m ps] :
-    Triple (m := m) (do
+theorem forIn_map_eq_sum_add_size' (xs : Array Nat) {m} [Monad m] [Assertion Pred] [Assertion EPred]
+    [WPMonad m Pred EPred] :
+    Triple (m := m) ⊤ (do
       let mut sum : Nat := 0
       for n in (xs.iterM Id).map (· + 1) do
         sum := sum + n
-      return sum) ⌜True⌝ (⇓r => ⌜r = xs.sum + xs.size⌝) := by
+      return sum) (fun r => ⌜r = xs.sum + xs.size⌝) ⊥ := by
   mvcgen'
-  case inv1 => exact ⇓⟨cur, n⟩ => ⌜n = cur.prefix.sum + cur.prefix.length⌝
+  case inv1 => exact fun cur n => ⌜n = cur.prefix.sum + cur.prefix.length⌝
   all_goals grind
 
-
-theorem forIn_map_eq_sum_add_size' (xs : Array Nat) {m ps} [Monad m] [LawfulMonad m]
-    [WPMonad m ps] :
-    Triple (m := m) (do
+theorem forIn_map_eq_sum_add_size (xs : Array Nat) {m} [Monad m] [Assertion Pred] [Assertion EPred]
+    [WPMonad m Pred EPred] :
+    Triple (m := m) ⊤ (do
       let mut sum : Nat := 0
       for n in (xs.iterM Id).map (· + 1) do
         sum := sum + n
-      return sum) ⌜True⌝ (⇓r => ⌜r = xs.sum + xs.size⌝) := by
+      return sum) (fun r => ⌜r = xs.sum + xs.size⌝) ⊥ := by
   mvcgen'
-  case inv1 => exact ⇓⟨cur, n⟩ => ⌜n = cur.prefix.sum + cur.prefix.length⌝
+  case inv1 => exact fun cur n => ⌜n = cur.prefix.sum + cur.prefix.length⌝
   all_goals grind
 
-theorem forIn_mapM_eq_sum_add_size (xs : Array Nat) {m ps} [Monad m] [MonadAttach m]
-    [LawfulMonad m] [WeaklyLawfulMonadAttach m] [WPMonad m ps] :
-    Triple (m := m) (do
+
+theorem forIn_mapM_eq_sum_add_size (xs : Array Nat) {m} [Monad m] [MonadAttach m]
+    [LawfulMonad m] [WeaklyLawfulMonadAttach m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+    Triple (m := m) ⊤ (do
       let mut sum : Nat := 0
       for n in (xs.iterM Id).mapM (pure (f := m) <| · + 1) do
         sum := sum + n
-      return sum) ⌜True⌝ (⇓r => ⌜r = xs.sum + xs.size⌝) := by
+      return sum) (fun r => ⌜r = xs.sum + xs.size⌝) ⊥ := by
   mvcgen'
-  case inv1 => exact ⇓⟨cur, n⟩ => ⌜n = cur.prefix.sum + cur.prefix.length⌝
+  case inv1 => exact fun cur n => ⌜n = cur.prefix.sum + cur.prefix.length⌝
   all_goals grind
 
-theorem forIn_filterMapM_eq_sum_add_size (xs : Array Nat) {m ps}
-    [Monad m] [LawfulMonad m] [MonadAttach m] [WeaklyLawfulMonadAttach m] [WPMonad m ps] :
-    Triple (m := m) (do
+theorem forIn_filterMapM_eq_sum_add_size (xs : Array Nat) {m}
+    [Monad m] [LawfulMonad m] [MonadAttach m] [WeaklyLawfulMonadAttach m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+    Triple (m := m) ⊤ (do
       let mut sum : Nat := 0
       for n in (xs.iterM Id).filterMapM (pure (f := m) <| some <| · + 1) do
         sum := sum + n
-      return sum) ⌜True⌝ (⇓r => ⌜r = xs.sum + xs.size⌝) := by
+      return sum)  (fun r => ⌜r = xs.sum + xs.size⌝) ⊥ := by
   mvcgen'
-  case inv1 => exact ⇓⟨cur, n⟩ => ⌜n = cur.prefix.sum + cur.prefix.length⌝
+  case inv1 => exact fun cur n => ⌜n = cur.prefix.sum + cur.prefix.length⌝
   all_goals grind
 
-theorem foldM_eq_sum (xs : Array Nat) {m ps} [Monad m] [LawfulMonad m]
-    [WPMonad m ps] :
-    Triple (m := m)
+theorem foldM_eq_sum (xs : Array Nat) {m} [Monad m] [LawfulMonad m]
+    [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+    Triple (m := m) ⊤
       (xs.iter.foldM (m := m) (init := 0) (pure <| · + ·))
-      ⌜True⌝
-      (⇓r => ⌜r = xs.sum⌝) := by
+      (fun r => ⌜r = xs.sum⌝) ⊥ := by
   mvcgen'
-  case inv1 => exact ⇓⟨cur, n⟩ => ⌜n = cur.prefix.sum⌝
+  case inv1 => exact fun cur n => ⌜n = cur.prefix.sum⌝
   all_goals grind
 
 end IteratorTests
@@ -534,33 +510,34 @@ currently ignored. -/
 def trivial_test (n : Nat) : Id Nat := pure n
 
 /-- An empty `(config := {})` matches the default `mvcgen'` behavior. -/
-example : ⦃⌜True⌝⦄ trivial_test 0 ⦃⇓r => ⌜r = 0⌝⦄ := by
+example : ⦃ True ⦄ trivial_test 0 ⦃fun r => r = 0⦄ := by
   mvcgen' (config := {}) [trivial_test]
 
 -- `trivial := false` skips `repeatAndRfl`, leaving a residual entailment.
-example : ⦃⌜True⌝⦄ trivial_test 0 ⦃⇓r => ⌜r = 0⌝⦄ := by
+example : ⦃ True ⦄ trivial_test 0 ⦃fun r => r = 0⦄ := by
   mvcgen' (trivial := false) [trivial_test]
   trivial
 
--- `elimLets := false` is silently accepted (no preprocessing).
-example : ⦃⌜True⌝⦄ trivial_test 0 ⦃⇓r => ⌜r = 0⌝⦄ := by
+-- `elimLets := false` skips the let-elimination pre-pass (now honored by `mvcgen'`).
+example : ⦃ True ⦄ trivial_test 0 ⦃fun r => r = 0⦄ := by
   mvcgen' (config := { elimLets := false }) [trivial_test]
 
 -- `stepLimit` is accepted; with a positive limit, simple programs still discharge.
-example : ⦃⌜True⌝⦄ trivial_test 0 ⦃⇓r => ⌜r = 0⌝⦄ := by
+example : ⦃ True ⦄ trivial_test 0 ⦃fun r => r = 0⦄ := by
   mvcgen' (config := { stepLimit := some 100 }) [trivial_test]
 
 /-- warning: mvcgen': the `leave` config option is currently ignored. -/
 #guard_msgs in
-example : ⦃⌜True⌝⦄ trivial_test 0 ⦃⇓r => ⌜r = 0⌝⦄ := by
+example : ⦃ True ⦄ trivial_test 0 ⦃fun r => r = 0⦄ := by
   mvcgen' (config := { leave := false }) [trivial_test]
 
 -- `jp := true` is accepted and wired through `Context.useJP`; the actual
 -- shared-continuation construction (Phase 6 of the plan) is not yet ported,
 -- so enabling it on a program containing `__do_jp` errors at the detection
 -- point. Programs without `__do_jp` (like this trivial example) are unaffected.
-example : ⦃⌜True⌝⦄ trivial_test 0 ⦃⇓r => ⌜r = 0⌝⦄ := by
+example : ⦃ True ⦄ trivial_test 0 ⦃fun r => r = 0⦄ := by
   mvcgen' (config := { jp := true }) [trivial_test]
+
 
 end ConfigSyntaxTests
 
@@ -583,8 +560,8 @@ example (p : Nat → Prop) [DecidablePred p] (n : Nat) :
   apply Id.of_wp_run_eq h
   mvcgen' invariants
     · Invariant.withEarlyReturnNewDo
-        (onReturn := fun ret _ => ⌜ret = false ∧ ¬ ∀ i < n, p i⌝)
-        (onContinue := fun xs _ => ⌜∀ i, i ∈ xs.prefix → p i⌝)
+      (onReturn := fun ret _ => ⌜ret = false ∧ ¬ ∀ i < n, p i⌝)
+      (onContinue := fun xs _ => ⌜∀ i, i ∈ xs.prefix → p i⌝)
   all_goals simp_all [-Classical.not_forall]; try grind
 
 -- Labelled form: `| inv1 => …`.
@@ -594,8 +571,8 @@ example (p : Nat → Prop) [DecidablePred p] (n : Nat) :
   apply Id.of_wp_run_eq h
   mvcgen' invariants
     | inv1 => Invariant.withEarlyReturnNewDo
-        (onReturn := fun ret _ => ⌜ret = false ∧ ¬ ∀ i < n, p i⌝)
-        (onContinue := fun xs _ => ⌜∀ i, i ∈ xs.prefix → p i⌝)
+      (onReturn := fun ret _ => ⌜ret = false ∧ ¬ ∀ i < n, p i⌝)
+      (onContinue := fun xs _ => ⌜∀ i, i ∈ xs.prefix → p i⌝)
   all_goals simp_all [-Classical.not_forall]; try grind
 
 end InvariantSyntaxTests
@@ -629,16 +606,16 @@ error: unsolved goals
 case vc1
 a : UInt64
 h✝ : (UInt64.toBitVec 0).uaddOverflow (a <<< UInt64.ofNat (Int32.toInt 32).toNat).toBitVec = true
-⊢ ⊢ₛ wp⟦Except.error ""⟧ (fun r => ⌜True⌝, ExceptConds.false)
+⊢ wp (Except.error "") (fun x => True) ⊥
 -/
 #guard_msgs in
 example (a : UInt64) :
-    ⦃⌜True⌝⦄
+    ⦃True⦄
       do
         let a ← MyShl.shl a (32: Int32)
         let a ← MyAddU.add (0 : UInt64) a
         pure a
-    ⦃PostCond.noThrow fun r => ⌜True⌝⦄ := by
+    ⦃fun _ => True⦄ := by
   mvcgen' (errorOnMissingSpec := false) [MyShl.shl, MyAddU.add]
 
 end RflReducibility
@@ -652,15 +629,19 @@ def foo (x : Id Nat → Id Nat) : Id Nat := do
 
 theorem foo_spec
     (x : Id Nat → Id Nat)
-    (x_spec : ∀ (k : Id Nat) (_ : ⦃⌜True⌝⦄ k ⦃⇓r => ⌜r % 2 = 0⌝⦄), ⦃⌜True⌝⦄ x k ⦃⇓r => ⌜r % 2 = 0⌝⦄) :
-    ⦃⌜True⌝⦄ foo x ⦃⇓r => ⌜r % 2 = 0⌝⦄ := by
+    (x_spec : ∀ (k : Id Nat), ⦃ True ⦄ k ⦃ fun r => r % 2 = 0 ⦄ →
+      ⦃ True ⦄ x k ⦃ fun r => r % 2 = 0 ⦄) :
+    ⦃ True ⦄ foo x ⦃ fun r => r % 2 = 0 ⦄ := by
   mvcgen' [foo, x_spec] with finish
 
 def bar (k : Id Nat) : Id Nat := do
   let r ← k
-  if r > 30 then return 12 else return r
+  if r > 30 then
+    return 12
+  else
+    return r
 
-example : ⦃⌜True⌝⦄ foo bar ⦃⇓r => ⌜r % 2 = 0⌝⦄ := by
+example : ⦃ True ⦄ foo bar ⦃ fun r => r % 2 = 0 ⦄ := by
   mvcgen' [foo_spec, bar] with finish
 
 end LocalSpec

--- a/tests/bench/mvcgen/sym/test_vcgen.lean
+++ b/tests/bench/mvcgen/sym/test_vcgen.lean
@@ -25,7 +25,7 @@ Each case exercises a different aspect of the VC generation:
 - `MatchSplit`: Pattern matching with symbolic discriminant (state), exercising match split
 -/
 
-open Lean Parser Meta Elab Tactic Sym Std Do SpecAttr
+open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do Do.Internal.SpecAttr
 
 set_option maxRecDepth 10000
 set_option maxHeartbeats 10000000
@@ -61,6 +61,7 @@ set_option maxHeartbeats 10000000
 -- Verify `simplifying_assumptions [Nat.add_assoc]` works end-to-end with `simp only` unfolding.
 /--
 trace: s✝ : Nat
+a✝ : s✝ = 0
 h✝⁹ : ¬0 < s✝
 h✝⁸ : ¬1 < s✝ + 1
 h✝⁷ : ¬2 < s✝ + 2
@@ -71,7 +72,6 @@ h✝³ : ¬6 < s✝ + 6
 h✝² : ¬7 < s✝ + 7
 h✝¹ : ¬8 < s✝ + 8
 h✝ : ¬9 < s✝ + 9
-a✝ : s✝ = 0
 ⊢ s✝ + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 = 10
 -/
 #guard_msgs in
@@ -87,7 +87,7 @@ example : Goal 10 := by
 -- let-hoist, let-intro (non-duplicable value), and fvar-zeta (let-bound program head).
 -- Run with `set_option trace.Elab.Tactic.Do.vcgen true` to see the traces.
 open LetBinding in
-example : ∀ post, ⦃post⦄ step 5 ⦃⇓_ => post⦄ := by
+example : ∀ post, ⦃post⦄ step 5 ⦃fun _ => post⦄ := by
   unfold step
   intro post
   mvcgen'

--- a/tests/bench/mvcgen/sym/vcgen_add_sub_cancel.lean
+++ b/tests/bench/mvcgen/sym/vcgen_add_sub_cancel.lean
@@ -8,7 +8,7 @@ import Driver
 
 set_option mvcgen.warning false
 
-open Lean Parser Meta Elab Tactic Sym Std Do SpecAttr
+open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do Do.Internal.SpecAttr
 open AddSubCancel
 
 set_option maxRecDepth 10000

--- a/tests/bench/mvcgen/sym/vcgen_add_sub_cancel_deep.lean
+++ b/tests/bench/mvcgen/sym/vcgen_add_sub_cancel_deep.lean
@@ -8,7 +8,7 @@ import Driver
 
 set_option mvcgen.warning false
 
-open Lean Parser Meta Elab Tactic Sym Std Do SpecAttr
+open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do Do.Internal.SpecAttr
 open AddSubCancelDeep
 
 set_option maxRecDepth 10000

--- a/tests/bench/mvcgen/sym/vcgen_add_sub_cancel_simp.lean
+++ b/tests/bench/mvcgen/sym/vcgen_add_sub_cancel_simp.lean
@@ -8,7 +8,7 @@ import Driver
 
 set_option mvcgen.warning false
 
-open Lean Parser Meta Elab Tactic Sym Std Do SpecAttr
+open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do Do.Internal.SpecAttr
 open AddSubCancelSimp
 
 set_option maxRecDepth 10000

--- a/tests/bench/mvcgen/sym/vcgen_get_throw_set.lean
+++ b/tests/bench/mvcgen/sym/vcgen_get_throw_set.lean
@@ -8,7 +8,7 @@ import Driver
 
 set_option mvcgen.warning false
 
-open Lean Parser Meta Elab Tactic Sym Std Do SpecAttr
+open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do Do.Internal.SpecAttr
 open GetThrowSet
 
 set_option maxRecDepth 10000

--- a/tests/bench/mvcgen/sym/vcgen_get_throw_set_grind.lean
+++ b/tests/bench/mvcgen/sym/vcgen_get_throw_set_grind.lean
@@ -3,13 +3,13 @@ import Driver
 
 set_option mvcgen.warning false
 
-open Lean Parser Meta Elab Tactic Sym Std Do SpecAttr
+open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do Do.Internal.SpecAttr
 open GetThrowSet
 
 -- Copy Goal into a separate namespace so the benchmark label reads `GetThrowSetGrind(n)`
 -- instead of colliding with the `GetThrowSet(n)` label in vcgen_get_throw_set.
 namespace GetThrowSetGrind
-def Goal (n : Nat) : Prop := ⦃fun s => ⌜s = 0⌝⦄ loop n ⦃⇓_ s => ⌜s = n⌝⦄
+def Goal (n : Nat) : Prop := ⦃fun s => s = 0⦄ loop n ⦃fun _ s => s = n⦄
 end GetThrowSetGrind
 
 set_option maxRecDepth 100000

--- a/tests/bench/mvcgen/sym/vcgen_match_split.lean
+++ b/tests/bench/mvcgen/sym/vcgen_match_split.lean
@@ -8,7 +8,7 @@ import Driver
 
 set_option mvcgen.warning false
 
-open Lean Parser Meta Elab Tactic Sym Std Do SpecAttr
+open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do Do.Internal.SpecAttr
 open MatchIota
 
 set_option maxRecDepth 10000

--- a/tests/bench/mvcgen/sym/vcgen_reader_state.lean
+++ b/tests/bench/mvcgen/sym/vcgen_reader_state.lean
@@ -8,7 +8,7 @@ import Driver
 
 set_option mvcgen.warning false
 
-open Lean Parser Meta Elab Tactic Sym Std Do SpecAttr
+open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do Do.Internal.SpecAttr
 open ReaderState
 
 set_option maxRecDepth 10000

--- a/tests/elab/mvcgenSymBlock.lean
+++ b/tests/elab/mvcgenSymBlock.lean
@@ -1,8 +1,9 @@
+import Std.Internal.Do
 import Std.Tactic.Do
 
 /-! Tests that `mvcgen'` is usable as a step inside `sym => …` blocks. -/
 
-open Std.Do
+open Std.Internal.Do Lean.Order
 
 set_option mvcgen.warning false
 set_option warn.sorry false
@@ -17,12 +18,12 @@ noncomputable def F : StateM Nat Unit := do
   H
 
 @[spec]
-axiom G_spec : ⦃⌜True⌝⦄ G ⦃⇓ _ n => ⌜n = n⌝⦄
+axiom G_spec : ⦃ (fun (_ : Nat) => True) ⦄ G ⦃ fun _ n => n = n ⦄
 
 @[spec]
-axiom H_spec : ⦃⌜True⌝⦄ H ⦃⇓ _ n => ⌜n = n⌝⦄
+axiom H_spec : ⦃ (fun (_ : Nat) => True) ⦄ H ⦃ fun _ n => n = n ⦄
 
-example : ⦃⌜True⌝⦄ F ⦃⇓ _ n => ⌜n = n⌝⦄ := by
+example : ⦃ (fun (_ : Nat) => True) ⦄ F ⦃ fun _ n => n = n ⦄ := by
   sym =>
     mvcgen' [F]
 
@@ -38,12 +39,12 @@ noncomputable def F2 : StateM Nat Unit := do
 axiom P : Nat → Prop
 
 @[spec]
-axiom G2_spec : ⦃⌜True⌝⦄ G2 ⦃⇓ _ n => ⌜P n⌝⦄
+axiom G2_spec : ⦃ (fun (_ : Nat) => True) ⦄ G2 ⦃ fun _ n => P n ⦄
 
 @[spec]
-axiom H2_spec : ⦃fun n => ⌜P n⌝⦄ H2 ⦃⇓ _ n => ⌜True⌝⦄
+axiom H2_spec : ⦃ (fun n => P n) ⦄ H2 ⦃ fun _ _ => True ⦄
 
-example : ⦃⌜True⌝⦄ F2 ⦃⇓ _ n => ⌜True⌝⦄ := by
+example : ⦃ (fun (_ : Nat) => True) ⦄ F2 ⦃ fun _ _ => True ⦄ := by
   sym =>
     mvcgen' [F2] <;> finish
 
@@ -60,18 +61,18 @@ axiom Q : Nat → Prop
 axiom hPQ : ∀ n, P n → Q n
 
 @[spec]
-axiom G3_spec : ⦃⌜True⌝⦄ G3 ⦃⇓ _ n => ⌜P n⌝⦄
+axiom G3_spec : ⦃ (fun (_ : Nat) => True) ⦄ G3 ⦃ fun _ n => P n ⦄
 
 @[spec]
-axiom H3_spec : ⦃fun n => ⌜Q n⌝⦄ H3 ⦃⇓ _ n => ⌜True⌝⦄
+axiom H3_spec : ⦃ (fun n => Q n) ⦄ H3 ⦃ fun _ _ => True ⦄
 
-example : ⦃⌜True⌝⦄ F3 ⦃⇓ _ n => ⌜True⌝⦄ := by
+example : ⦃ (fun (_ : Nat) => True) ⦄ F3 ⦃ fun _ _ => True ⦄ := by
   sym =>
     mvcgen' [F3]
     finish [hPQ]
 
 -- `sym [hPQ]` propagates to the new VC `Grind.Goal`s; no need to re-pass it.
-example : ⦃⌜True⌝⦄ F3 ⦃⇓ _ n => ⌜True⌝⦄ := by
+example : ⦃ (fun (_ : Nat) => True) ⦄ F3 ⦃ fun _ _ => True ⦄ := by
   sym [hPQ] =>
     mvcgen' [F3]
     finish
@@ -83,7 +84,7 @@ axiom Q4 : Nat → Prop
 axiom hPQ4 : ∀ n, P n → Q4 n
 
 @[spec]
-axiom G4_spec : ⦃⌜True⌝⦄ G4 ⦃⇓ x _ => ⌜P x⌝⦄
+axiom G4_spec : ⦃ (fun (_ : Nat) => True) ⦄ G4 ⦃ fun x _ => P x ⦄
 
 noncomputable def F4 : StateM Nat Nat := do
   let x ← G4
@@ -91,7 +92,7 @@ noncomputable def F4 : StateM Nat Nat := do
 
 -- `mvcgen'` introduces `x` and a hypothesis `P x` into the VC's local context.
 -- The subsequent `finish [hPQ4]` must see `P x` in the E-graph to derive `Q4 x`.
-example : ⦃⌜True⌝⦄ F4 ⦃⇓ r _ => ⌜Q4 r⌝⦄ := by
+example : ⦃ (fun (_ : Nat) => True) ⦄ F4 ⦃ fun r _ => Q4 r ⦄ := by
   sym =>
     mvcgen' [F4]
     finish [hPQ4]
@@ -99,19 +100,19 @@ example : ⦃⌜True⌝⦄ F4 ⦃⇓ r _ => ⌜Q4 r⌝⦄ := by
 /-! ## Inline invariants (bullet form) inside `sym =>` -/
 
 example :
-    ⦃⌜True⌝⦄
+    ⦃ (True : Prop) ⦄
     (do
       let mut x := 0
       for i in [1:5] do
         x := x + i
       pure x : Id Nat)
-    ⦃⇓r => ⌜r < 30⌝⦄ := by
+    ⦃ fun r => r < 30 ⦄ := by
   sym =>
     mvcgen' invariants
-      · ⇓(xs, r) => ⌜r + xs.suffix.length * 5 ≤ 25⌝
+      · fun xs r => r + xs.suffix.length * 5 ≤ 25
     <;> finish
 
-/-! ## `invariants?` (suggest mode) works inside `sym =>` -/
+/-! ## `invariants?` (suggest mode) inside `sym =>` -/
 
 def mySum (l : List Nat) : Nat := Id.run do
   let mut acc := 0
@@ -120,14 +121,12 @@ def mySum (l : List Nat) : Nat := Id.run do
   return acc
 
 /--
-info: Try this:
-  [apply] invariants
-  · ⇓⟨xs, letMuts⟩ => ⌜xs.prefix = [] ∧ letMuts = 0 ∨ xs.suffix = [] ∧ letMuts = l.sum⌝
+info: There were no suggestions for missing invariants.
 -/
 #guard_msgs (info) in
 theorem mySum_suggest (l : List Nat) : mySum l = l.sum := by
   generalize h : mySum l = r
-  apply Id.of_wp_run_eq h
+  apply Std.Internal.Do.Id.of_wp_run_eq h
   sym =>
     mvcgen' [mySum] invariants?
     all_goals tactic => admit

--- a/tests/elab/mvcgenUntil.lean
+++ b/tests/elab/mvcgenUntil.lean
@@ -1,3 +1,4 @@
+import Std.Internal.Do
 import Lean
 import Std
 import Std.Tactic.Do
@@ -7,7 +8,7 @@ set_option warn.sorry false
 
 /-! Tests for the `mvcgen' until <pattern>` stop condition. -/
 
-open Std.Do
+open Std.Internal.Do Lean.Order
 
 namespace MVCGenUntil
 
@@ -28,20 +29,20 @@ def getThenTick : StateM Nat Nat := do
   tick
   return x
 
--- `until tick` matches the nullary `tick` call and stops; `unfold tick` hits the leftover `wp⟦tick⟧`.
-theorem useTick_until : ⦃⌜True⌝⦄ useTick ⦃⇓ _ => ⌜True⌝⦄ := by
+-- `until tick` matches the nullary `tick` call and stops; `unfold tick` hits the leftover `wp tick`.
+theorem useTick_until : ⦃ (fun (_ : Nat) => True) ⦄ useTick ⦃ fun _ _ => True ⦄ := by
   mvcgen' [useTick] until tick
   all_goals unfold tick
   all_goals admit
 
 -- An explicit hole matches: `until step _` stops at `step 1`, the `_` matching its argument.
-theorem useStep_until_hole : ⦃⌜True⌝⦄ useStep ⦃⇓ _ => ⌜True⌝⦄ := by
+theorem useStep_until_hole : ⦃ (fun (_ : Nat) => True) ⦄ useStep ⦃ fun _ _ => True ⦄ := by
   mvcgen' [useStep] until step _
   all_goals unfold step
   all_goals admit
 
 -- A concrete argument discriminates: `until step 1` matches the `step 1` call and stops.
-theorem useStep_until_one : ⦃⌜True⌝⦄ useStep ⦃⇓ _ => ⌜True⌝⦄ := by
+theorem useStep_until_one : ⦃ (fun (_ : Nat) => True) ⦄ useStep ⦃ fun _ _ => True ⦄ := by
   mvcgen' [useStep] until step 1
   all_goals unfold step
   all_goals admit
@@ -49,17 +50,17 @@ theorem useStep_until_one : ⦃⌜True⌝⦄ useStep ⦃⇓ _ => ⌜True⌝⦄ :
 -- ...but `until step 2` does not match `step 1`, so VC generation reaches the un-specced call.
 /-- error: No spec found for program step 1. -/
 #guard_msgs in
-example : ⦃⌜True⌝⦄ useStep ⦃⇓ _ => ⌜True⌝⦄ := by
+example : ⦃ (fun (_ : Nat) => True) ⦄ useStep ⦃ fun _ _ => True ⦄ := by
   mvcgen' [useStep] until step 2
 
 -- A non-matching `until` (with a hole) is a no-op: VC generation runs to completion.
-theorem useStep_until_nomatch : ⦃⌜True⌝⦄ useStep ⦃⇓ r => ⌜r = 0⌝⦄ := by
+theorem useStep_until_nomatch : ⦃ (fun (_ : Nat) => True) ⦄ useStep ⦃ fun r _ => r = 0 ⦄ := by
   mvcgen' [useStep, step] until List.length _
   all_goals grind
 
 -- The overloaded `get` is resolved against the program's monad and matches the `get` call, so VC
 -- generation stops before the un-specced `tick`. A wrong resolution would proceed to `tick` and error.
-theorem getThenTick_until_get : ⦃⌜True⌝⦄ getThenTick ⦃⇓ _ => ⌜True⌝⦄ := by
+theorem getThenTick_until_get : ⦃ (fun (_ : Nat) => True) ⦄ getThenTick ⦃ fun _ _ => True ⦄ := by
   mvcgen' [getThenTick] until get
   all_goals admit
 


### PR DESCRIPTION
This PR ports the experimental `mvcgen'` tactic to the new `Std.Internal.Do` meta theory, where verification-condition generation works on lattice entailments `pre ⊑ wp x post epost`. Two changes are visible at the proof surface: `mvcgen'` now eagerly introduces all state components as local hypotheses, so more facts reach `grind`; and loop invariants no longer have to restate the exceptional postcondition.

Previously the invariant for a loop that can throw had to repeat the exception condition alongside the actual invariant:
```lean
theorem throwing_loop_spec :
    ⦃fun s => ⌜s = 4⌝⦄
    throwing_loop
    ⦃post⟨fun _ _ => ⌜False⌝,
          fun e s => ⌜e = 42 ∧ s = 4⌝⟩⦄ := by
  mvcgen' [throwing_loop]
  case inv1 => exact post⟨fun (xs, r) s => ⌜r ≤ 4 ∧ s = 4 ∧ r + xs.suffix.sum > 4⌝,
                         fun e s => ⌜e = 42 ∧ s = 4⌝⟩
```
Now the exceptional postcondition is taken from the surrounding `Triple`, so the invariant case carries only the invariant:
```lean
theorem throwing_loop_spec :
    ⦃fun s => s = 4⦄
    throwing_loop
    ⦃fun _ _ => False;
     fun e s => e = 42 ∧ s = 4⦄ := by
  mvcgen' [throwing_loop]
  case inv1 => exact ⟨fun (xs, r) s => r ≤ 4 ∧ s = 4 ∧ r + xs.suffix.sum > 4⟩
```

The spec lemmas in `Std.Internal.Do.Triple.SpecLemmas` are registered with `@[spec]` and populate the new spec database, which also gains the `whileM`/`Lean.Loop` specifications, `Invariant.withEarlyReturnNewDo`, and pointwise entailment lemmas for state introduction.

The port replays Vladimir Gladshtein's #13978 onto master's file structure.

The solver diverges from the legacy algorithm in three points. Reflexivity runs on every entailment before the pure-precondition lifts, closing the leaf VCs where a spec precondition meets an identical goal precondition (`Q x ⊑ wp (pure x) Q E` ends in `Q x ⊑ Q x`) and instantiating spec parameters that occur only in rule premises. Reflexivity no longer assigns synthetic opaque metavariables, so function-typed invariant holes are not silently solved away. Pure preconditions are lifted into the local context as soon as they arise; the lifted hypothesis is cached in `Scope.lastLiftedPre?`, and a targeted assumption step closes the handoff VCs of subsequent spec applications against it.

This is the second of two steps that land `vova/new-mvcgen` onto master. The first step (#13954) updated the `@[spec]` builtin attribute and regenerated `stage0`, so this PR reuses master's `stage0` and contains no generated C changes. Invariant suggestion (`invariants?`) yields no suggestions on the new surface; porting the suggestion analysis is deferred until `mvcgen'` replaces the legacy `mvcgen`.
