### PR TITLE
perf: defer `region_reader` dep-region sort to slow path

### DIFF
--- a/src/runtime/compact.cpp
+++ b/src/runtime/compact.cpp
@@ -529,6 +529,13 @@ region_reader::region_reader(size_t sz, void * data, void * base_addr,
     m_dep_regions(std::move(dep_regions)),
     m_lib_relocs(std::move(lib_relocs)),
     m_closure_offsets(std::move(closure_offsets)) {
+    // Sort + overlap validation are deferred to `sort_and_validate_dep_regions()`: needed only
+    // before the fixup walk; the fast path in `read()` skips both. Doing them eagerly here was
+    // an O(N log N) per construction over a `dep_regions` array that grows linearly across
+    // successive `CompactedRegion.read` calls (e.g. `--incr-load` chaining 9000+ dep oleans).
+}
+
+void region_reader::sort_and_validate_dep_regions() {
     // Sort dep regions by `base_addr` for binary search in `fix_object_ptr`
     std::sort(m_dep_regions.begin(), m_dep_regions.end(),
               [](region_view const & a, region_view const & b) { return a.base_addr < b.base_addr; });
@@ -657,8 +664,6 @@ object * region_reader::read() {
     if (m_next == m_end)
         return nullptr; /* all objects have been read */
 
-    object * root = fix_object_ptr(*static_cast<object_offset *>(m_next));
-    move(sizeof(object_offset));
     // Check if any closure fn ptr relocation is actually needed
     bool needs_fn_reloc = false;
     for (std::pair<size_t, ptrdiff_t> const & reloc : m_lib_relocs) {
@@ -684,22 +689,25 @@ object * region_reader::read() {
     }
 
     if (m_begin == m_base_addr) {
-        // Own-region pointers are already correct (this region landed at its saved address).
-        // But if any dep region missed its `base_addr`, cross-region pointers in this region
-        // still hold the dep's saved address and need fixup, so fall through to the walk in
-        // that case.
         bool needs_dep_reloc = false;
         for (region_view const & dep : m_dep_regions) {
             if (dep.begin != dep.base_addr) { needs_dep_reloc = true; break; }
         }
         if (!needs_dep_reloc) {
-            // Closure fn pointers (if any) were already patched via the offset list.
+            // Fast path: own pointers and all dep pointers are already correct, so the saved root
+            // pointer needs no fixup and the structural walk can be skipped entirely. This also
+            // lets us avoid sorting and validating `m_dep_regions` (the dominant cost when chaining
+            // many dep oleans into a single `region_reader`).
+            object * root = *static_cast<object_offset *>(m_next);
             m_end = m_next;
             return root;
         }
-        // Otherwise (needs_dep_reloc): fall through to full ctor walk. `fix_closure`
-        // ignores `m_fun` since it was already patched.
     }
+
+    // Slow path: dep-region fixup needed. Sort and validate dep regions now.
+    sort_and_validate_dep_regions();
+    object * root = fix_object_ptr(*static_cast<object_offset *>(m_next));
+    move(sizeof(object_offset));
 
     while (m_next < m_end) {
         object * curr = reinterpret_cast<object*>(m_next);

--- a/src/runtime/compact.h
+++ b/src/runtime/compact.h
@@ -117,6 +117,7 @@ class LEAN_EXPORT region_reader {
     // Data-relative byte offsets of every closure's `m_fun` field. Used to patch fn
     // pointers on load without scanning the compacted region. Empty if no closures.
     std::vector<size_t> m_closure_offsets;
+    void sort_and_validate_dep_regions();
     void move(size_t d);
     void move(object * o);
     object * fix_object_ptr(object * o);


### PR DESCRIPTION
This PR speeds up snapshot loading (`--incr-load`) by roughly 5× on headers that pull in many oleans (an `import Lean` snapshot goes from ~1.5 s to ~0.3 s wall time), by skipping the dep-region sort whenever the structural fixup walk would itself be skipped.

`region_reader`'s constructor previously sorted `m_dep_regions` by `base_addr` so that `fix_object_ptr` can binary-search across regions. But the walk is skipped entirely on the common fast path (the region landed at its saved `base_addr` and every dep did too), and `--incr-load` chains 9000+ dep oleans through one `region_reader` per `CompactedRegion.read` call against a growing `depRegions` array, so the eager sort accumulated `O(N² log N)` work for no benefit.

The sort and overlap validation now live in `sort_and_validate_dep_regions()` and run only when the slow-path walk starts. `read()` is reordered so the fast-path check fires before any `fix_object_ptr` call, including the root pointer (the saved value already matches the load-time address on the fast path, so no fixup is needed).