### PR TITLE
fix: do not use anonymous binder name in `mkSimpleThunkType`

### DIFF
--- a/src/Lean/Expr.lean
+++ b/src/Lean/Expr.lean
@@ -683,7 +683,18 @@ def mkForall (x : Name) (bi : BinderInfo) (t : Expr) (b : Expr) : Expr :=
 
 /-- Return `Unit -> type`. Do not confuse with `Thunk type` -/
 def mkSimpleThunkType (type : Expr) : Expr :=
-  mkForall Name.anonymous .default (mkConst `Unit) type
+  /-
+  **Note**: We must not use `Name.anonymous` as the binder name.  If a tactic introduces
+  this binder using its name, the resulting local declaration named `Name.anonymous`
+  matches the terminal step of `resolveLocalName`'s component-stripping, capturing every
+  identifier in scope and breaking name resolution and pretty printing for the entire
+  local context.
+
+  Another possible fix is to modify `resolveLocalName` to ignore local declarations
+  whose user name is `Name.anonymous`, making name resolution robust against any
+  producer of anonymous local declarations.
+  -/
+  mkForall `_ .default (mkConst `Unit) type
 
 /-- Return `fun (_ : Unit), e` -/
 def mkSimpleThunk (type : Expr) : Expr :=

--- a/tests/elab/anonBinderName.lean
+++ b/tests/elab/anonBinderName.lean
@@ -1,0 +1,35 @@
+import Lean
+
+/-!
+A local declaration whose user name is `Name.anonymous` breaks name resolution for the
+entire local context: `resolveLocalName` resolves an identifier by stripping trailing
+components and searching the local context for the remaining prefix, and this stripping
+bottoms out at `Name.anonymous`.  Thus, a local declaration named `Name.anonymous`
+matches *every* identifier, shadowing all global constants.  The delaborator
+(`delabConst`) then cannot find any name that round-trips for any constant, and renders
+all of them as inaccessible (e.g., `True✝`).
+
+`mkSimpleThunkType` used to create its binder with `Name.anonymous`.  The `match`
+compiler uses it to create the minor premises of parameterless alternatives, and
+tactics that introduce these binders using their binder name (e.g., `grind`) ended up
+with a corrupted local context.  See issue #13773.
+-/
+
+open Lean Meta
+
+/-- info: with anonymous binder: True✝ -/
+#guard_msgs in
+run_meta do
+  -- Negative control: a binder named `Name.anonymous` introduced into the local
+  -- context makes even the constant `True` unreferenceable.
+  let bad := Expr.forallE .anonymous (mkConst ``Unit) (mkConst ``True) .default
+  forallTelescope bad fun _ _ => do
+    logInfo m!"with anonymous binder: {mkConst ``True}"
+
+/-- info: with mkSimpleThunkType: True -/
+#guard_msgs in
+run_meta do
+  -- `mkSimpleThunkType` must not use `Name.anonymous` for its binder.
+  let thunk := mkSimpleThunkType (mkConst ``True)
+  forallTelescope thunk fun _ _ => do
+    logInfo m!"with mkSimpleThunkType: {mkConst ``True}"

--- a/tests/elab/grind_match2.lean.out.expected
+++ b/tests/elab/grind_match2.lean.out.expected
@@ -16,9 +16,9 @@
         match as with
         | [] => [a]
         | b :: bs => a :: a :: b :: bs with
-      | [] => Bool.true✝
-      | head :: tail => Bool.false✝) =
-      Bool.false✝
+      | [] => true
+      | head :: tail => false) =
+      false
 [grind] closed `grind.1`
 [grind] working on goal `grind.2`
 [grind.assert] as = b :: bs


### PR DESCRIPTION
This PR fixes `mkSimpleThunkType` to use `_` instead of `Name.anonymous` as its binder name. A local declaration whose user name is `Name.anonymous` matches every identifier in `resolveLocalName`, shadowing all global constants and making the pretty printer render every constant in the local context as inaccessible (e.g., `True✝`). The `match` compiler uses `mkSimpleThunkType` to create the minor premises of parameterless alternatives, and tactics that introduce these binders using their binder name verbatim (e.g., `grind`) ended up with a corrupted local context. Found while investigating #13773.

🤖 Generated with [Claude Code](https://claude.com/claude-code)