### PR TITLE
fix: invalid proofs for `match`-expression conditions in `grind`

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/EMatch.lean
+++ b/src/Lean/Meta/Tactic/Grind/EMatch.lean
@@ -8,6 +8,7 @@ prelude
 public import Lean.Meta.Tactic.Grind.Types
 import Lean.Util.CollectLevelMVars
 import Lean.Meta.Tactic.Grind.Util
+import Lean.Meta.Tactic.Grind.CasesMatch
 import Lean.Meta.Tactic.Grind.MatchDiscrOnly
 import Lean.Meta.Tactic.Grind.ProveEq
 import Lean.Meta.Tactic.Grind.SynthInstance
@@ -365,10 +366,15 @@ private def processContinue (c : Choice) (p : Expr) : M Unit := do
 /--
 Given a proposition `prop` corresponding to an equational theorem.
 Annotate the conditions using `Grind.MatchCond`. See `MatchCond.lean`.
+
+Only hypotheses that have the `match`-condition shape `∀ …, _ = _ → … → False` are
+annotated (see `isMatchCondCandidate`). Equational theorems may have other propositional
+hypotheses (e.g., the discriminant equalities of a `match` with proof discriminants),
+and the `MatchCond` propagators assume the annotated conditions have this shape.
 -/
 private partial def annotateEqnTypeConds (prop : Expr) (k : Expr → M Expr := pure) : M Expr := do
   if let .forallE n d b bi := prop then
-    let d := if (← isProp d) then
+    let d := if isMatchCondCandidate d then
       markAsPreMatchCond d
     else
       d

--- a/src/Lean/Meta/Tactic/Grind/MatchCond.lean
+++ b/src/Lean/Meta/Tactic/Grind/MatchCond.lean
@@ -280,7 +280,6 @@ where
     trace_goal[grind.debug.matchCond] "go?: {← inferType h}"
     let some (α?, lhs, rhs) := isEqHEq? (← inferType h)
       | return none
-    let target ← (← get).mvarId.getType
     -- We use `shareCommon` here because we may accessing a new expression
     -- created when we infer the type of the `noConfusion` term below
     let lhs ← shareCommon lhs
@@ -298,7 +297,8 @@ where
       let some ctorLhs ← isConstructorApp? root.self | return none
       let some ctorRhs ← isConstructorApp? rhs | return none
       -- See comment on `shareCommon` above.
-      let h ← mkNoConfusion target h
+      -- Recall that `match`-expression conditions always have `False` as their conclusion.
+      let h ← mkNoConfusion (← getFalseExpr) h
       if ctorLhs.name ≠ ctorRhs.name then
         return some h
       else

--- a/tests/elab/grind_13773.lean
+++ b/tests/elab/grind_13773.lean
@@ -1,0 +1,17 @@
+/-! https://github.com/leanprover/lean4/issues/13773
+
+`grind` was building proofs of `Grind.MatchCond` using the grind goal as the
+`mkNoConfusion` target, which produced terms whose type appended the goal's
+binders after the `MatchCond` body and was rejected by the kernel. -/
+
+theorem ex
+    (a b : Bool)
+    (h : match a, b with
+      | false, false => True
+      | true, true => True
+      | _, _ => False) :
+    match a, b with
+    | false, false => True
+    | true, true => True
+    | _, _ => False := by
+  grind


### PR DESCRIPTION
This PR fixes two bugs that made `grind` construct proofs that are rejected by the kernel for goals involving `match`-expressions with overlapping patterns and proof discriminants (#13773).

- `mkMatchCondProof?` used the current goal's type as the `noConfusion` target when constructing proofs for satisfied `match`-expression conditions. The target must be `False`, the conclusion of every `match`-expression condition; using the goal's type produces a type-incorrect proof whenever the propagator fires while the goal is not `False`.

- `annotateEqnTypeConds` annotated every propositional hypothesis of an instantiated `match`-equation with `Grind.PreMatchCond`, including the discriminant equalities of `match`-expressions with proof discriminants. The `MatchCond` propagators assume the annotated conditions have the shape `∀ …, _ = _ → … → False`, and constructed invalid `False` proofs from hypotheses that do not have this shape. We now use `isMatchCondCandidate`, like the other annotation sites (`casesMatch` and `preprocessHypothesis`).

The example in #13773 still fails (with a `grind` error instead of a kernel error) due to a separate metavariable issue in the E-matching instantiation procedure. It will be addressed in a follow-up PR.
