### PR TITLE
fix: unknown metavariable error in `grind` when instantiating `match`-equations with generalized patterns

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/EMatch.lean
+++ b/src/Lean/Meta/Tactic/Grind/EMatch.lean
@@ -548,17 +548,41 @@ private def synthesizeInsts (mvars : Array Expr) (bis : Array BinderInfo) : Opti
         reportEMatchIssue! "failed to synthesize instance when instantiating {thm.origin.pp}{indentExpr type}"
         failure
 
-private def preprocessGeneralizedPatternRHS (lhs : Expr) (rhs : Expr) (origin : Origin) (expectedType : Expr) : OptionT (StateT Choice M) Expr := do
+/--
+Constructs a proof of `lhs = rhs` (`lhs ≍ rhs` if `heq := true`) for a delayed
+generalized-pattern equality. `lhs` is a term from the goal and has already been
+internalized. `rhs` is the value the pattern was instantiated with; it is preprocessed,
+and the equality is established using the e-graph. The instantiation fails if `lhs` and
+`rhs` cannot be proved equal. `expectedType` is used for error messages only.
+
+**Note**: `rhs` is an auxiliary term, and it is internalized inside
+`withoutModifyingState`. The equality proof is also constructed there, before the state
+is restored. `rhs` may contain metavariables corresponding to theorem parameters that
+have not been assigned yet; they are abstracted at the end of `instantiateTheorem`. The
+e-graph must not retain terms containing such metavariables: they become dangling
+references when the `withNewMCtxDepth` at `instantiateTheorem` is exited. See issue
+#13773.
+-/
+private def mkGeneralizedPatternEqProof (lhs : Expr) (rhs : Expr) (origin : Origin) (expectedType : Expr) (heq : Bool)
+    : OptionT (StateT Choice M) Expr := do
   assert! (← alreadyInternalized lhs)
   -- We use `dsimp` here to ensure terms such as `Nat.succ x` are normalized as `x+1`.
   let rhs ← preprocessLight (← dsimpCore rhs)
-  internalize rhs (← getGeneration lhs)
-  processNewFacts
-  if (← isEqv lhs rhs) then
-    return rhs
-  else
+  let some proof ← checkEqvToLhs? rhs |
     reportEMatchIssue! "invalid generalized pattern at `{origin.pp}`\nwhen processing argument with type{indentExpr expectedType}\nfailed to prove{indentExpr lhs}\nis equal to{indentExpr rhs}"
     failure
+  return proof
+where
+  checkEqvToLhs? (rhs : Expr) : GoalM (Option Expr) := withoutModifyingState do
+    internalize rhs (← getGeneration lhs)
+    processNewFacts
+    if (← isEqv lhs rhs) then
+      if heq then
+        return some (← mkHEqProof lhs rhs)
+      else
+        return some (← mkEqProof lhs rhs)
+    else
+      return none
 
 private def assignGeneralizedPatternProof (mvarId : MVarId) (eqProof : Expr) (origin : Origin) : OptionT (StateT Choice M) Unit := do
   unless (← mvarId.checkedAssign eqProof) do
@@ -589,12 +613,12 @@ private def processDelayed (mvars : Array Expr) (i : Nat) (h : i < mvars.size) :
   match_expr mvarIdType with
   | Eq α lhs rhs =>
     let lhs ← findOriginalGeneralizedPatternLhs lhs
-    let rhs ← preprocessGeneralizedPatternRHS lhs rhs thm.origin mvarIdType
-    assignGeneralizedPatternProof mvarId (← mkEqProof lhs rhs) thm.origin
+    let h ← mkGeneralizedPatternEqProof lhs rhs thm.origin mvarIdType (heq := false)
+    assignGeneralizedPatternProof mvarId h thm.origin
   | HEq α lhs β rhs =>
     let lhs ← findOriginalGeneralizedPatternLhs lhs
-    let rhs ← preprocessGeneralizedPatternRHS lhs rhs thm.origin mvarIdType
-    assignGeneralizedPatternProof mvarId (← mkHEqProof lhs rhs) thm.origin
+    let h ← mkGeneralizedPatternEqProof lhs rhs thm.origin mvarIdType (heq := true)
+    assignGeneralizedPatternProof mvarId h thm.origin
   | _ =>
     reportEMatchIssue! "invalid generalized pattern at `{thm.origin.pp}`\nequality type expected{indentExpr mvarIdType}"
     failure

--- a/tests/elab/grind_13773.lean
+++ b/tests/elab/grind_13773.lean
@@ -15,3 +15,16 @@ theorem ex
     | true, true => True
     | _, _ => False := by
   grind
+
+theorem ex2
+    (p : Prop)
+    (a b : Bool)
+    (h : match a, b with
+      | false, false => True
+      | true, true => p
+      | _, _ => False) :
+    match a, b with
+    | false, false => True
+    | true, true => p
+    | _, _ => False := by
+  grind


### PR DESCRIPTION
This PR fixes an `unknown metavariable` error in `grind` that occurred when instantiating `match`-congruence equations whose generalized-pattern equalities mention theorem parameters that cannot be determined by E-matching. 

When processing a delayed generalized-pattern equality, `grind` internalized the instantiated pattern value to discharge the equality using the e-graph. This value is an auxiliary term that may contain metavariables corresponding to theorem parameters that have not been assigned yet; these parameters are abstracted at the end of `instantiateTheorem`, and their declarations are discarded when the `withNewMCtxDepth` at `instantiateTheorem` is exited. The internalization persisted terms and facts mentioning these metavariables in the e-graph (e.g., `p = True` with proof `eq_true p ?h`), and proofs constructed later from these facts contained dangling metavariable references. The auxiliary internalization and the equality-proof construction are now performed inside `withoutModifyingState`, following the same discipline used at `proveEq?`. The function was also renamed from `preprocessGeneralizedPatternRHS` to `mkGeneralizedPatternEqProof`, since it now returns the equality proof.

Closes #13773.
