### PR TITLE
perf: load `--incr-load` snapshot dep regions in parallel 

### DIFF
--- a/src/Init/System/Platform.lean
+++ b/src/Init/System/Platform.lean
@@ -55,6 +55,12 @@ The LLVM target triple of the current platform. Empty if missing when Lean was c
 -/
 def target : String := getTarget ()
 
+/--
+The platform's native concurrency limit (number of hardware threads), or `0` if indeterminate.
+-/
+@[extern "lean_internal_get_hardware_concurrency"]
+opaque Internal.getHardwareConcurrency : Unit → UInt32
+
 @[simp]
 theorem numBits_pos : 0 < numBits := by
   cases numBits_eq <;> next h => simp [h]

--- a/src/Lean/Elab/Frontend.lean
+++ b/src/Lean/Elab/Frontend.lean
@@ -6,6 +6,7 @@ Authors: Leonardo de Moura, Sebastian Ullrich
 module
 
 prelude
+import Init.System.Platform
 public import Lean.Language.Lean
 public import Lean.Server.References
 public import Lean.Util.Profiler
@@ -178,6 +179,21 @@ private def regionsToModuleArtifacts (regions : Array CompactedRegion) : Array M
       byBase := byBase.insert base (upd (byBase.getD base {}))
     return order.map (byBase[·]!)
 
+/--
+Reads all the regions of one module's `ModuleArtifacts`: the `.olean` variant chain (each variant
+read with only its prior siblings as deps) plus the `.ir` region (no deps, as in regular import).
+-/
+private unsafe def readModuleArtifactRegions (arts : ModuleArtifacts) :
+    IO (Array CompactedRegion) := do
+  let mut chainDeps : Array CompactedRegion := #[]
+  for partPath in arts.oleanParts do
+    let (_, region) ← CompactedRegion.read (α := ModuleData) partPath chainDeps
+    chainDeps := chainDeps.push region
+  if let some irPath := arts.ir? then
+    let (_, region) ← CompactedRegion.read (α := ModuleData) irPath #[]
+    chainDeps := chainDeps.push region
+  return chainDeps
+
 /-- Loads a snapshot saved by `--incr-(header-)save`. -/
 private unsafe def loadIncrSnapshot (fname : System.FilePath) :
     IO IncrSnapshot := do
@@ -186,19 +202,29 @@ private unsafe def loadIncrSnapshot (fname : System.FilePath) :
     match Json.parse (← IO.FS.readFile depsFile) >>= fromJson? with
     | .ok arts => pure arts
     | .error e => throw <| IO.userError s!"failed to parse snapshot deps file {depsFile}: {e}"
+  -- Modules are mutually independent (cross-module references go through the constant map, not
+  -- region pointers), so read them in parallel. Spawn exactly `numWorkers` striped tasks.
+  -- Parallelism overlaps each region's cold root-page fault I/O: for an `import Mathlib` snapshot,
+  -- sequential cold load is ~16 s, dropping to ~6 s at 4 workers. More workers help cold further
+  -- (~3 s at 32) but begin shifting the warm-cache case into a slower mode (`mmap` address-space
+  -- lock contention), so the default caps low to keep warm load time unchanged. Raise
+  -- `LEAN_IMPORT_WORKERS` to trade warm parity for faster cold loads.
+  let defaultNumWorkers := min (System.Platform.Internal.getHardwareConcurrency ()).toNat 4
+  let numWorkers := max 1 <|
+    ((← IO.getEnv "LEAN_IMPORT_WORKERS").bind (·.toNat?)).getD defaultNumWorkers
+  let mut chunkTasks := Array.emptyWithCapacity numWorkers
+  for w in 0...numWorkers do
+    -- worker `w` handles modules w, w+numWorkers, w+2·numWorkers, … (stripe for load balance)
+    chunkTasks := chunkTasks.push (← IO.asTask (do
+      let mut regions : Array CompactedRegion := #[]
+      let mut i := w
+      while i < moduleArts.size do
+        regions := regions ++ (← readModuleArtifactRegions moduleArts[i]!)
+        i := i + numWorkers
+      return regions))
   let mut depRegions : Array CompactedRegion := Array.emptyWithCapacity (moduleArts.size * 4)
-  for arts in moduleArts do
-    -- A module's `.olean` variants only point into the prior variants of the same module, so read
-    -- the chain with just its own siblings as deps.
-    let mut chainDeps : Array CompactedRegion := #[]
-    for partPath in arts.oleanParts do
-      let (_, region) ← CompactedRegion.read (α := ModuleData) partPath chainDeps
-      chainDeps := chainDeps.push region
-    depRegions := depRegions ++ chainDeps
-    -- IR regions carry no cross-region pointers (loaded with no deps in regular import).
-    if let some irPath := arts.ir? then
-      let (_, region) ← CompactedRegion.read (α := ModuleData) irPath #[]
-      depRegions := depRegions.push region
+  for t in chunkTasks do
+    depRegions := depRegions ++ (← IO.ofExcept t.get)
   -- The snapshot region itself references every loaded dep region.
   let (data, _region) ← CompactedRegion.read (α := IncrSnapshot) fname depRegions
   return data

--- a/src/Lean/Shell.lean
+++ b/src/Lean/Shell.lean
@@ -219,14 +219,10 @@ opaque Internal.getBelieverTrustLevel (_ : Unit) : UInt32
 def defaultTrustLevel : UInt32 :=
   Internal.getBelieverTrustLevel () + 1
 
-/-- Returns the platform's native concurrency limit. -/
-@[extern "lean_internal_get_hardware_concurrency"]
-opaque Internal.getHardwareCurrency (_ : Unit) : UInt32
-
 /-- Returns the default number of threads for the shell's task manager. -/
 def defaultNumThreads : UInt32 :=
   if Internal.isMultiThread () then
-    Internal.getHardwareCurrency ()
+    Platform.Internal.getHardwareConcurrency ()
   else 0
 
 structure ShellOptions where


### PR DESCRIPTION
This PR reads a snapshot's dependency `.olean*` regions in parallel across modules. For a cold-cache `import Mathlib` snapshot (the typical case, where the snapshot is loaded by a process that did not just create it), this overlaps the otherwise-serialized root-page fault I/O of mapping ~37k regions, taking load time from ~16 s to ~6 s.

Modules are mutually independent for region loading (a regular `.olean*` only points into the prior variants of the same module; cross-module references go through the constant map), so each module's regions are read by a striped worker task. Only the final read of the snapshot region itself, which references every dependency, runs after the join.

The worker count defaults to `min(hardwareConcurrency, 4)` and is overridable via `LEAN_IMPORT_WORKERS`. Four workers keep warm-cache load time unchanged while still overlapping most of the cold I/O; higher counts speed up cold loads further (~3 s at 32) but push the warm case into a slower mode, perhaps from `mmap` address-space lock contention.