### PR TITLE
feat: finalize libuv thread

### DIFF
--- a/src/initialize/init.cpp
+++ b/src/initialize/init.cpp
@@ -7,6 +7,7 @@ Author: Leonardo de Moura
 #include "runtime/stackinfo.h"
 #include "runtime/thread.h"
 #include "runtime/init_module.h"
+#include "runtime/libuv.h"
 #include "util/init_module.h"
 #include "util/io.h"
 #include "kernel/init_module.h"
@@ -43,6 +44,9 @@ extern "C" LEAN_EXPORT void lean_initialize() {
 }
 
 void finalize() {
+    // NOTE: must be run before finalizing the task manager
+    finalize_libuv();
+    lean_finalize_task_manager();
     run_thread_finalizers();
     finalize_constructions_module();
     finalize_library_module();

--- a/src/runtime/libuv.cpp
+++ b/src/runtime/libuv.cpp
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Markus Himmel, Sofia Rodrigues
  */
 #include <pthread.h>
+#include <memory>
+#include <vector>
 #include "runtime/libuv.h"
 #include "runtime/object.h"
 
@@ -16,25 +18,122 @@ namespace lean {
 
 #ifndef LEAN_EMSCRIPTEN
 
-extern "C" void initialize_libuv() {
-    initialize_libuv_timer();
-    initialize_libuv_tcp_socket();
-    initialize_libuv_udp_socket();
-    initialize_libuv_signal();
-    initialize_libuv_loop();
+// The thread running the global event loop. Retained so that it can be joined in
+// `finalize_libuv`.
+static std::unique_ptr<lthread> g_loop_thread;
 
-    lthread([]() { event_loop_run_loop(&global_ev); });
+extern "C" void initialize_libuv() {
+    // Initializing while the loop thread of a previous initialization is still running is not
+    // supported; `finalize_libuv` must run in between. Since `finalize_libuv` always sets
+    // `g_libuv_finalized` (and nulls `g_loop_thread`), the flag being set here means this is a
+    // restart rather than the first initialization.
+    lean_always_assert(g_loop_thread == nullptr);
+
+    if (g_libuv_finalized) {
+        // Restart after a `finalize_libuv` (e.g. an embedder cycling the runtime). The external
+        // classes and `global_ev` survive finalization (see `event_loop_cleanup`), so only the
+        // loop is re-armed; the one-time setup below is not repeated -- it is not idempotent
+        // (`lean_register_external_class` would leak and duplicate, `event_loop_init` would
+        // re-init the still-queued async handle and corrupt the loop).
+        //
+        // Lean objects backed by handles of the previous loop incarnation must not survive into
+        // the restart: their handles were already closed and dequeued by the teardown, and their
+        // finalizers free memory directly only while `g_libuv_finalized` is set -- so both using
+        // such an object and dropping its last reference after this point is undefined behavior
+        // (its finalizer would close an already-closed handle).
+        event_loop_restart(&global_ev);
+    } else {
+        initialize_libuv_timer();
+        initialize_libuv_tcp_socket();
+        initialize_libuv_udp_socket();
+        initialize_libuv_signal();
+        initialize_libuv_loop();
+    }
+
+    g_loop_thread.reset(new lthread([]() { event_loop_run_loop(&global_ev); }));
+}
+
+// Atomically takes a reference to `obj`, failing if the reference count already reached zero. In
+// that case the object's finalizer is already running on a worker thread — blocked on the
+// event-loop mutex held by `finalize_libuv` — and the object must not be touched: a dying handle
+// has no loop-held references left to release, and the blocked finalizer frees the handle and
+// object memory once the teardown is done (`lean_inc`/`lean_dec` cannot be used here, as they
+// treat a zero count as a persistent object and would let the walk read fields the finalizer
+// concurrently frees). All handle-backed objects are `lean_mark_mt`ed at creation, so the count
+// is never positive and can be accessed atomically (multi-threaded objects count negatively).
+static bool try_pin(lean_object * obj) {
+    _Atomic(int) * rc = lean_get_rc_mt_addr(obj);
+    int v = rc->load(std::memory_order_acquire);
+    lean_assert(v <= 0);
+
+    while (v < 0) {
+        if (rc->compare_exchange_weak(v, v - 1, std::memory_order_acq_rel, std::memory_order_acquire)) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 extern "C" void finalize_libuv() {
-    // TODO: implement a clean libuv shutdown. The event-loop thread spawned in
-    // `initialize_libuv` is detached and kept alive indefinitely by the persistent
-    // `global_ev.async` handle, so stopping it cleanly requires: a join handle for the
-    // loop thread; a shutdown signal that breaks `event_loop_run_loop`, closes the async
-    // handle, and calls `uv_loop_close`; and resolving any in-flight promises so dedicated
-    // workers blocked on libuv operations are released before the task-manager drain.
-    // See the (also unimplemented) `event_loop_cleanup`. For now this is a no-op, matching
-    // the prior behaviour where libuv was never finalized.
+    if (!g_loop_thread)
+        return;
+
+    event_loop_request_stop(&global_ev);
+    g_loop_thread->join();
+    g_loop_thread.reset();
+
+    std::vector<lean_object *> pinned;
+
+    event_loop_lock(&global_ev);
+
+    uv_walk(global_ev.loop, [](uv_handle_t * handle, void * arg) {
+        auto * pinned = static_cast<std::vector<lean_object *> *>(arg);
+
+        if (uv_is_closing(handle)) {
+            return;
+        }
+
+        uv_handle_type type = uv_handle_get_type(handle);
+
+        if (type != UV_TIMER && type != UV_TCP && type != UV_UDP && type != UV_SIGNAL) {
+            return;
+        }
+
+        auto * obj = (lean_object *)handle->data;
+
+        if (!try_pin(obj)) {
+            return;
+        }
+
+        pinned->push_back(obj);
+
+        switch (type) {
+        case UV_TIMER:
+            lean_uv_timer_shutdown(obj);
+            break;
+        case UV_TCP:
+            lean_uv_tcp_socket_shutdown(obj);
+            break;
+        case UV_UDP:
+            lean_uv_udp_socket_shutdown(obj);
+            break;
+        case UV_SIGNAL:
+            lean_uv_signal_shutdown(obj);
+            break;
+        default:
+            break;
+        }
+    }, &pinned);
+
+    g_libuv_finalized = true;
+
+    event_loop_cleanup(&global_ev);
+    event_loop_unlock(&global_ev);
+
+    for (lean_object * obj : pinned) {
+        lean_dec(obj);
+    }
 }
 
 extern "C" LEAN_EXPORT char ** lean_setup_args(int argc, char ** argv) {

--- a/src/runtime/libuv.cpp
+++ b/src/runtime/libuv.cpp
@@ -26,6 +26,17 @@ extern "C" void initialize_libuv() {
     lthread([]() { event_loop_run_loop(&global_ev); });
 }
 
+extern "C" void finalize_libuv() {
+    // TODO: implement a clean libuv shutdown. The event-loop thread spawned in
+    // `initialize_libuv` is detached and kept alive indefinitely by the persistent
+    // `global_ev.async` handle, so stopping it cleanly requires: a join handle for the
+    // loop thread; a shutdown signal that breaks `event_loop_run_loop`, closes the async
+    // handle, and calls `uv_loop_close`; and resolving any in-flight promises so dedicated
+    // workers blocked on libuv operations are released before the task-manager drain.
+    // See the (also unimplemented) `event_loop_cleanup`. For now this is a no-op, matching
+    // the prior behaviour where libuv was never finalized.
+}
+
 extern "C" LEAN_EXPORT char ** lean_setup_args(int argc, char ** argv) {
     return uv_setup_args(argc, argv);
 }
@@ -38,6 +49,8 @@ extern "C" LEAN_EXPORT lean_obj_res lean_libuv_version(lean_obj_arg o) {
 #else
 
 extern "C" void initialize_libuv() {}
+
+extern "C" void finalize_libuv() {}
 
 extern "C" LEAN_EXPORT lean_obj_res lean_libuv_version(lean_obj_arg o) {
     return lean_box(0);

--- a/src/runtime/libuv.cpp
+++ b/src/runtime/libuv.cpp
@@ -23,24 +23,9 @@ namespace lean {
 static std::unique_ptr<lthread> g_loop_thread;
 
 extern "C" void initialize_libuv() {
-    // Initializing while the loop thread of a previous initialization is still running is not
-    // supported; `finalize_libuv` must run in between. Since `finalize_libuv` always sets
-    // `g_libuv_finalized` (and nulls `g_loop_thread`), the flag being set here means this is a
-    // restart rather than the first initialization.
     lean_always_assert(g_loop_thread == nullptr);
 
     if (g_libuv_finalized) {
-        // Restart after a `finalize_libuv` (e.g. an embedder cycling the runtime). The external
-        // classes and `global_ev` survive finalization (see `event_loop_cleanup`), so only the
-        // loop is re-armed; the one-time setup below is not repeated -- it is not idempotent
-        // (`lean_register_external_class` would leak and duplicate, `event_loop_init` would
-        // re-init the still-queued async handle and corrupt the loop).
-        //
-        // Lean objects backed by handles of the previous loop incarnation must not survive into
-        // the restart: their handles were already closed and dequeued by the teardown, and their
-        // finalizers free memory directly only while `g_libuv_finalized` is set -- so both using
-        // such an object and dropping its last reference after this point is undefined behavior
-        // (its finalizer would close an already-closed handle).
         event_loop_restart(&global_ev);
     } else {
         initialize_libuv_timer();
@@ -51,28 +36,6 @@ extern "C" void initialize_libuv() {
     }
 
     g_loop_thread.reset(new lthread([]() { event_loop_run_loop(&global_ev); }));
-}
-
-// Atomically takes a reference to `obj`, failing if the reference count already reached zero. In
-// that case the object's finalizer is already running on a worker thread — blocked on the
-// event-loop mutex held by `finalize_libuv` — and the object must not be touched: a dying handle
-// has no loop-held references left to release, and the blocked finalizer frees the handle and
-// object memory once the teardown is done (`lean_inc`/`lean_dec` cannot be used here, as they
-// treat a zero count as a persistent object and would let the walk read fields the finalizer
-// concurrently frees). All handle-backed objects are `lean_mark_mt`ed at creation, so the count
-// is never positive and can be accessed atomically (multi-threaded objects count negatively).
-static bool try_pin(lean_object * obj) {
-    _Atomic(int) * rc = lean_get_rc_mt_addr(obj);
-    int v = rc->load(std::memory_order_acquire);
-    lean_assert(v <= 0);
-
-    while (v < 0) {
-        if (rc->compare_exchange_weak(v, v - 1, std::memory_order_acq_rel, std::memory_order_acquire)) {
-            return true;
-        }
-    }
-
-    return false;
 }
 
 extern "C" void finalize_libuv() {
@@ -101,11 +64,6 @@ extern "C" void finalize_libuv() {
         }
 
         auto * obj = (lean_object *)handle->data;
-
-        if (!try_pin(obj)) {
-            return;
-        }
-
         pinned->push_back(obj);
 
         switch (type) {

--- a/src/runtime/libuv.h
+++ b/src/runtime/libuv.h
@@ -23,6 +23,7 @@ Author: Markus Himmel, Sofia Rodrigues
 namespace lean {
 
 extern "C" void initialize_libuv();
+extern "C" void finalize_libuv();
 extern "C" LEAN_EXPORT char ** lean_setup_args(int argc, char ** argv);
 
 // =======================================

--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -1096,22 +1096,6 @@ extern "C" LEAN_EXPORT void lean_finalize_task_manager() {
     }
 }
 
-scoped_task_manager::scoped_task_manager(unsigned num_workers) {
-    lean_assert(g_task_manager == nullptr);
-#if defined(LEAN_MULTI_THREAD)
-    if (num_workers > 0) {
-        g_task_manager = new task_manager(num_workers);
-    }
-#endif
-}
-
-scoped_task_manager::~scoped_task_manager() {
-    if (g_task_manager) {
-        delete g_task_manager;
-        g_task_manager = nullptr;
-    }
-}
-
 void deactivate_task(lean_task_object * t) {
     if (g_task_manager) {
         g_task_manager->deactivate_task(t);

--- a/src/runtime/object.h
+++ b/src/runtime/object.h
@@ -272,12 +272,6 @@ inline obj_res thunk_get_own(b_obj_arg t) { return lean_thunk_get_own(t); }
 // =======================================
 // Tasks
 
-class LEAN_EXPORT scoped_task_manager {
-public:
-    scoped_task_manager(unsigned num_workers);
-    ~scoped_task_manager();
-};
-
 inline obj_res task_spawn(obj_arg c, unsigned prio = 0, bool keep_alive = false) { return lean_task_spawn_core(c, prio, keep_alive); }
 inline obj_res task_pure(obj_arg a) { return lean_task_pure(a); }
 inline obj_res task_bind(obj_arg x, obj_arg f, unsigned prio = 0, bool sync = false, bool keep_alive = false) { return lean_task_bind_core(x, f, prio, sync, keep_alive); }

--- a/src/runtime/uv/dns.cpp
+++ b/src/runtime/uv/dns.cpp
@@ -67,8 +67,19 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_dns_get_info(b_obj_arg name, b_obj_a
         default: hints.ai_family = PF_UNSPEC; break;
     }
 
-    event_loop_lock(&global_ev);
     lean_inc(promise);
+
+    event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+
+        lean_dec(promise);
+        lean_dec(promise);
+        free(resolver);
+
+        return lean_uv_loop_finalized_error();
+    }
 
     int result = uv_getaddrinfo(global_ev.loop, resolver, [](uv_getaddrinfo_t* req, int status, struct addrinfo* res) {
         lean_object* promise = (lean_object*) req->data;
@@ -109,18 +120,16 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_dns_get_info(b_obj_arg name, b_obj_a
         free(req);
     }, name_cstr, service_cstr, &hints);
 
+    event_loop_unlock(&global_ev);
+
     if (result != 0) {
-        lean_dec(promise); // The structure does not own it.
-        lean_dec(promise); // We are not going to return it.
-
+        lean_dec(promise);
+        lean_dec(promise);
         free(resolver);
-
-        event_loop_unlock(&global_ev);
 
         return lean_io_result_mk_error(lean_decode_uv_error(result, nullptr));
     }
 
-    event_loop_unlock(&global_ev);
     return lean_io_result_mk_ok(promise);
 }
 
@@ -138,8 +147,21 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_dns_get_name(b_obj_arg addr) {
     sockaddr_storage addr_ptr;
     lean_socket_address_to_sockaddr_storage(addr, &addr_ptr);
 
-    event_loop_lock(&global_ev);
+    // While the request is in flight the loop owns one promise reference (released by the
+    // callback); the other one is the caller's return value.
     lean_inc(promise);
+
+    event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+
+        lean_dec(promise);
+        lean_dec(promise);
+        free(req);
+
+        return lean_uv_loop_finalized_error();
+    }
 
     int result = uv_getnameinfo(global_ev.loop, req, [](uv_getnameinfo_t* req, int status, const char* hostname, const char* service) {
         lean_object* promise = (lean_object*) req->data;
@@ -161,18 +183,16 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_dns_get_name(b_obj_arg addr) {
         free(req);
     }, (const struct sockaddr*)&addr_ptr, 0);
 
+    event_loop_unlock(&global_ev);
+
     if (result != 0) {
-        lean_dec(promise); // The structure does not own it.
-        lean_dec(promise); // We are not going to return it.
-
+        lean_dec(promise);
+        lean_dec(promise);
         free(req);
-
-        event_loop_unlock(&global_ev);
 
         return lean_io_result_mk_error(lean_decode_uv_error(result, nullptr));
     }
 
-    event_loop_unlock(&global_ev);
     return lean_io_result_mk_ok(promise);
 }
 

--- a/src/runtime/uv/event_loop.cpp
+++ b/src/runtime/uv/event_loop.cpp
@@ -23,6 +23,9 @@ using namespace std;
 
 event_loop_t global_ev;
 
+// It's only accessed under lock.
+bool g_libuv_finalized = false;
+
 // Helpers
 
 void lean_promise_resolve_with_code(int status, obj_arg promise) {
@@ -54,6 +57,14 @@ void event_loop_interrupt(event_loop_t * event_loop) {
     lean_assert(result == 0);
 }
 
+// Requests that the thread running `event_loop_run_loop` exit. The `shutdown` flag is read at the
+// top of every loop iteration, and the async interrupt wakes the loop in case it is currently
+// blocked inside `uv_run`.
+void event_loop_request_stop(event_loop_t * event_loop) {
+    event_loop->shutdown = true;
+    event_loop_interrupt(event_loop);
+}
+
 // Initializes the event loop
 void event_loop_init(event_loop_t * event_loop) {
     event_loop->loop = uv_default_loop();
@@ -61,6 +72,7 @@ void event_loop_init(event_loop_t * event_loop) {
     check_uv(uv_cond_init(&event_loop->cond_var), "Failed to initialize condition variable");
     check_uv(uv_async_init(event_loop->loop, &event_loop->async, NULL), "Failed to initialize async");
     event_loop->n_waiters = 0;
+    event_loop->shutdown = false;
 }
 
 // Locks the event loop for the side of the requesters.
@@ -81,9 +93,34 @@ void event_loop_unlock(event_loop_t * event_loop) {
     uv_mutex_unlock(&event_loop->mutex);
 }
 
+lean_obj_res lean_uv_loop_finalized_error() {
+    return lean_io_result_mk_error(lean_decode_uv_error(UV_ECANCELED, nullptr));
+}
+
+// See event_loop.h.
+void lean_uv_close_and_free(uv_handle_t * handle, void * obj_mem) {
+    event_loop_lock(&global_ev);
+
+    bool finalized = g_libuv_finalized;
+
+    if (!finalized) {
+        uv_close(handle, [](uv_handle_t * h) {
+            free(h);
+        });
+    }
+
+    event_loop_unlock(&global_ev);
+
+    if (finalized) {
+        free(handle);
+    }
+
+    free(obj_mem);
+}
+
 // Runs the loop and stops when it needs to register new requests.
 void event_loop_run_loop(event_loop_t * event_loop) {
-    while (uv_loop_alive(event_loop->loop)) {
+    while (!event_loop->shutdown && uv_loop_alive(event_loop->loop)) {
         uv_mutex_lock(&event_loop->mutex);
 
         while (event_loop->n_waiters != 0) {
@@ -108,15 +145,28 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_event_loop_configure(b_obj_arg optio
 
     event_loop_lock(&global_ev);
 
-    if (accum) {
-        int result = uv_loop_configure(global_ev.loop, UV_METRICS_IDLE_TIME);
-        if (result != 0) return lean_io_result_mk_error(lean_decode_uv_error(result, NULL));
+    // Vacuous success: the function is `BaseIO Unit`, which cannot carry an error, and
+    // configuring a torn-down loop has no observable effect anyway.
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_box(0);
     }
 
-    #if!defined(WIN32) && !defined(_WIN32)
+    if (accum) {
+        int result = uv_loop_configure(global_ev.loop, UV_METRICS_IDLE_TIME);
+        if (result != 0) {
+            event_loop_unlock(&global_ev);
+            return lean_io_result_mk_error(lean_decode_uv_error(result, nullptr));
+        }
+    }
+
+    #if !defined(WIN32) && !defined(_WIN32)
     if (block) {
         int result = uv_loop_configure(global_ev.loop, UV_LOOP_BLOCK_SIGNAL, SIGPROF);
-        if (result != 0) return lean_io_result_mk_error(lean_decode_uv_error(result, NULL));
+        if (result != 0) {
+            event_loop_unlock(&global_ev);
+            return lean_io_result_mk_error(lean_decode_uv_error(result, nullptr));
+        }
     }
     #endif
 
@@ -128,10 +178,65 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_event_loop_configure(b_obj_arg optio
 /* Std.Internal.UV.Loop.alive : BaseIO Bool */
 extern "C" LEAN_EXPORT uint8_t lean_uv_event_loop_alive() {
     event_loop_lock(&global_ev);
-    int is_alive = uv_loop_alive(global_ev.loop);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return 0;
+    }
+
+    uint8_t is_alive = uv_loop_alive(global_ev.loop);
+
     event_loop_unlock(&global_ev);
 
     return is_alive;
+}
+
+// Tears down the event loop. Must only be called by `finalize_libuv`, after the thread running
+// `event_loop_run_loop` has been joined and while holding the requester lock, so the loop can be
+// driven from the calling thread without racing FFI calls from still-live task-manager workers.
+//
+// The loop, the async handle, and the mutex/condition-variable pair are intentionally *not*
+// destroyed: workers keep racing into `event_loop_lock` (and, when contended, into
+// `event_loop_interrupt`'s `uv_async_send`, which happens *before* the mutex is held and therefore
+// cannot be excluded by any locking) until `lean_finalize_task_manager` has joined them. Keeping
+// these primitives alive makes those late calls harmless: the mutex stays lockable, and a stray
+// `uv_async_send` just writes to an eventfd nobody reads anymore. All of them live in static
+// storage (`global_ev` and libuv's static default loop), so nothing is reported as leaked.
+void event_loop_cleanup(event_loop_t * event_loop) {
+    // Unreference the async handle (instead of closing it, see above) so the flush below can
+    // terminate: unreferenced handles do not keep `uv_run` alive.
+    uv_unref((uv_handle_t*)&event_loop->async);
+
+    // Close every remaining handle (timers/sockets/etc. whose backing references were already
+    // released) so that their close callbacks can free the handle memory — except the async
+    // handle, which must stay open for late `event_loop_interrupt` calls (see above).
+    uv_walk(event_loop->loop, [](uv_handle_t * handle, void * async) {
+        if (handle != static_cast<uv_handle_t *>(async) && !uv_is_closing(handle)) {
+            uv_close(handle, nullptr);
+        }
+    }, &event_loop->async);
+
+    // Drive the loop to completion: this runs all pending close callbacks, fires the
+    // `UV_ECANCELED` callbacks of in-flight stream requests, and waits for in-flight
+    // threadpool-backed requests (`uv_getaddrinfo`, `uv_random`, ...) to complete and deliver, so
+    // every promise the loop still owes is resolved before the task manager is drained.
+    uv_run(event_loop->loop, UV_RUN_DEFAULT);
+}
+
+// See event_loop.h. Everything `event_loop_cleanup` intentionally kept alive — the loop, the
+// async handle, and the mutex/condition-variable pair — is reused; restarting only needs to take
+// back a reference to the async handle (undoing the teardown's `uv_unref`, so the loop blocks in
+// `uv_run` again instead of exiting), clear the shutdown request, and lift `g_libuv_finalized` so
+// the FFI entry points stop failing. The lock pairs the flag write with its readers; no loop
+// thread exists at this point, so there is nothing else to synchronize with.
+void event_loop_restart(event_loop_t * event_loop) {
+    event_loop_lock(event_loop);
+
+    uv_ref((uv_handle_t *)&event_loop->async);
+    event_loop->shutdown = false;
+    g_libuv_finalized = false;
+
+    event_loop_unlock(event_loop);
 }
 
 void initialize_libuv_loop() {

--- a/src/runtime/uv/event_loop.h
+++ b/src/runtime/uv/event_loop.h
@@ -22,15 +22,20 @@ using namespace std;
 
 // Event loop structure for managing asynchronous events and synchronization across multiple threads.
 typedef struct {
-    uv_loop_t  * loop;      // The libuv event loop.
-    uv_mutex_t   mutex;     // Mutex for protecting `loop`.
-    uv_cond_t    cond_var;  // Condition variable for signaling that `loop` is free.
-    uv_async_t   async;     // Async handle to interrupt `loop`.
-    _Atomic(int) n_waiters; // Atomic counter for managing waiters for `loop`.
+    uv_loop_t  *  loop;      // The libuv event loop.
+    uv_mutex_t    mutex;     // Mutex for protecting `loop`.
+    uv_cond_t     cond_var;  // Condition variable for signaling that `loop` is free.
+    uv_async_t    async;     // Async handle to interrupt `loop`.
+    _Atomic(int)  n_waiters; // Atomic counter for managing waiters for `loop`.
+    _Atomic(bool) shutdown;  // Set to request the loop thread to exit `event_loop_run_loop`.
 } event_loop_t;
 
 // The multithreaded event loop object for all tasks in the task manager.
 extern event_loop_t global_ev;
+
+// Set once `finalize_libuv` has torn down the event loop, and cleared again only if a later
+// `initialize_libuv` restarts it (see `event_loop_restart`). Guarded by `global_ev.mutex`.
+extern bool g_libuv_finalized;
 
 // =======================================
 // Event loop manipulation functions.
@@ -39,6 +44,10 @@ void event_loop_cleanup(event_loop_t *event_loop);
 void event_loop_lock(event_loop_t *event_loop);
 void event_loop_unlock(event_loop_t *event_loop);
 void event_loop_run_loop(event_loop_t *event_loop);
+void event_loop_request_stop(event_loop_t *event_loop);
+void event_loop_restart(event_loop_t *event_loop);
+lean_obj_res lean_uv_loop_finalized_error();
+void lean_uv_close_and_free(uv_handle_t * handle, void * obj_mem);
 
 #endif
 

--- a/src/runtime/uv/signal.cpp
+++ b/src/runtime/uv/signal.cpp
@@ -18,15 +18,7 @@ void lean_uv_signal_finalizer(void* ptr) {
         lean_dec(signal->m_promise);
     }
 
-    event_loop_lock(&global_ev);
-
-    uv_close((uv_handle_t*)signal->m_uv_signal, [](uv_handle_t* handle) {
-        free(handle);
-    });
-
-    event_loop_unlock(&global_ev);
-
-    free(signal);
+    lean_uv_close_and_free((uv_handle_t*)signal->m_uv_signal, signal);
 }
 
 void initialize_libuv_signal() {
@@ -115,10 +107,18 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_signal_mk(uint32_t signum_obj, uint8
     }
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        free(uv_signal);
+        free(signal);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_signal_init(global_ev.loop, uv_signal);
-    event_loop_unlock(&global_ev);
 
     if (result != 0) {
+        event_loop_unlock(&global_ev);
         free(uv_signal);
         free(signal);
         return lean_io_result_mk_error(lean_decode_uv_error(result, NULL));
@@ -126,16 +126,46 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_signal_mk(uint32_t signum_obj, uint8
 
     signal->m_uv_signal = uv_signal;
 
+    // The handle is visible to the walk in `finalize_libuv` as soon as `uv_signal_init` inserts it
+    // into the loop, so `data` must point to the (mt-marked) object before the lock is released.
     lean_object * obj = lean_uv_signal_new(signal);
     lean_mark_mt(obj);
-    signal->m_uv_signal->data = obj;
+    uv_signal->data = obj;
+
+    event_loop_unlock(&global_ev);
 
     return lean_io_result_mk_ok(obj);
+}
+
+// Releases the references the event loop holds for a running signal handler. Called from
+// `finalize_libuv` while walking the loop's handles, after the loop thread has been joined, so no
+// locking is needed.
+void lean_uv_signal_shutdown(lean_object * obj) {
+    lean_uv_signal_object * signal = lean_to_uv_signal(obj);
+
+    if (signal->m_state == SIGNAL_STATE_RUNNING) {
+        if (signal->m_promise != nullptr) {
+            lean_dec(signal->m_promise);
+            signal->m_promise = nullptr;
+        }
+
+        // While running, the loop keeps the signal alive with an extra reference (see
+        // `setup_signal`); drop it last, as it may run the signal's finalizer.
+        signal->m_state = SIGNAL_STATE_FINISHED;
+        lean_dec(obj);
+    }
 }
 
 /* Std.Internal.UV.Signal.next (signal : @& Signal) : IO (IO.Promise Int) */
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_signal_next(b_obj_arg obj) {
     lean_uv_signal_object * signal = lean_to_uv_signal(obj);
+
+    event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
 
     auto setup_signal = [obj, signal]() {
         lean_assert(signal->m_promise == NULL);
@@ -173,8 +203,6 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_signal_next(b_obj_arg obj) {
         event_loop_unlock(&global_ev);
         return lean_io_result_mk_ok(promise);
     };
-
-    event_loop_lock(&global_ev);
 
     if (signal->m_repeating) {
         switch (signal->m_state) {
@@ -228,37 +256,61 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_signal_next(b_obj_arg obj) {
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_signal_stop(b_obj_arg obj) {
     lean_uv_signal_object * signal = lean_to_uv_signal(obj);
 
-    if (signal->m_state == SIGNAL_STATE_RUNNING) {
-        event_loop_lock(&global_ev);
-        int result = uv_signal_stop(signal->m_uv_signal);
-        event_loop_unlock(&global_ev);
+    int result = 0;
+    bool was_running = false;
 
-        if  (signal->m_promise != NULL) {
+    // Locking before reading the state to avoid a data race with the loop thread and with the
+    // teardown walk in `finalize_libuv`. After finalization this is a vacuous success: the
+    // walk already stopped the signal handler and dropped its promise.
+    event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_io_result_mk_ok(lean_box(0));
+    }
+
+    if (signal->m_state == SIGNAL_STATE_RUNNING) {
+        result = uv_signal_stop(signal->m_uv_signal);
+
+        if (signal->m_promise != nullptr) {
             lean_dec(signal->m_promise);
-            signal->m_promise = NULL;
+            signal->m_promise = nullptr;
         }
 
         signal->m_state = SIGNAL_STATE_FINISHED;
+        was_running = true;
+    }
 
-        // The loop does not need to keep the signal alive anymore.
-        lean_dec(obj);
+    event_loop_unlock(&global_ev);
 
-        if (result != 0) {
-            return lean_io_result_mk_error(lean_decode_uv_error(result, NULL));
-        } else {
-            return lean_io_result_mk_ok(lean_box(0));
-        }
-    } else {
+    if (!was_running) {
         return lean_io_result_mk_ok(lean_box(0));
     }
+
+    // The loop does not need to keep the signal alive anymore. Dropped after releasing the lock,
+    // as it may run the signal's finalizer, which re-acquires it.
+    lean_dec(obj);
+
+    if (result != 0) {
+        return lean_io_result_mk_error(lean_decode_uv_error(result, nullptr));
+    }
+
+    return lean_io_result_mk_ok(lean_box(0));
 }
 
 /* Std.Internal.UV.Signal.cancel (signal : @& Signal) : IO Unit */
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_signal_cancel(b_obj_arg obj) {
     lean_uv_signal_object * signal = lean_to_uv_signal(obj);
 
-    // It's locking here to avoid changing the state during other operations.
+    // It's locking here to avoid changing the state during other operations. After finalization
+    // this is a vacuous success: the teardown walk already stopped the signal handler and dropped
+    // its promise.
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_io_result_mk_ok(lean_box(0));
+    }
 
     if (signal->m_state == SIGNAL_STATE_RUNNING && signal->m_promise != NULL) {
         if (signal->m_repeating) {

--- a/src/runtime/uv/signal.h
+++ b/src/runtime/uv/signal.h
@@ -44,6 +44,9 @@ typedef struct {
 static inline lean_object* lean_uv_signal_new(lean_uv_signal_object * s) { return lean_alloc_external(g_uv_signal_external_class, s); }
 static inline lean_uv_signal_object* lean_to_uv_signal(lean_object * o) { return (lean_uv_signal_object*)(lean_get_external_data(o)); }
 
+// Releases the event-loop-held references of a signal handle during libuv finalization.
+void lean_uv_signal_shutdown(lean_object * obj);
+
 #endif
 
 // =======================================

--- a/src/runtime/uv/system.cpp
+++ b/src/runtime/uv/system.cpp
@@ -437,9 +437,22 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_random(uint64_t size) {
 
     req->req.data = req;
 
+    // While the request is in flight the loop owns one promise reference and the byte array
+    // (released by the callback); the other promise reference is the caller's return value.
     lean_inc(promise);
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+
+        lean_dec(byte_array);
+        lean_dec(promise);
+        lean_dec(promise);
+        free(req);
+
+        return lean_uv_loop_finalized_error();
+    }
 
     int result = uv_random(
         global_ev.loop,
@@ -634,7 +647,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_os_get_passwd() {
 }
 
 // Std.Internal.UV.System.osGetGroup : IO (Option GroupInfo)
-extern "C" LEAN_EXPORT lean_obj_res lean_uv_os_get_group() {
+extern "C" LEAN_EXPORT lean_obj_res lean_uv_os_get_group(uint64_t gid) {
     lean_always_assert(
         false && ("Please build a version of Lean4 with libuv to invoke this.")
     );

--- a/src/runtime/uv/tcp.cpp
+++ b/src/runtime/uv/tcp.cpp
@@ -36,19 +36,7 @@ void lean_uv_tcp_socket_finalizer(void* ptr) {
     lean_always_assert(tcp_socket->m_promise_read == nullptr);
     lean_always_assert(tcp_socket->m_byte_array == nullptr);
 
-    /// It's changing here because the object is being freed in the finalizer, and we need the data
-    /// inside of it.
-    tcp_socket->m_uv_tcp->data = ptr;
-
-    event_loop_lock(&global_ev);
-
-    uv_close((uv_handle_t*)tcp_socket->m_uv_tcp, [](uv_handle_t* handle) {
-        lean_uv_tcp_socket_object* tcp_socket = (lean_uv_tcp_socket_object*)handle->data;
-        free(tcp_socket->m_uv_tcp);
-        free(tcp_socket);
-    });
-
-    event_loop_unlock(&global_ev);
+    lean_uv_close_and_free((uv_handle_t*)tcp_socket->m_uv_tcp, tcp_socket);
 }
 
 void initialize_libuv_tcp_socket() {
@@ -77,6 +65,54 @@ void initialize_libuv_tcp_socket() {
     });
 }
 
+// Releases the references the event loop holds for a socket via callback-less operations. Called
+// from `finalize_libuv` while walking the loop's handles, after the loop thread has been joined, so
+// no locking is needed.
+//
+// Only `recv`/`waitReadable` (`m_promise_read`) and `accept` (`m_promise_accept`) are handled here:
+// these are driven by `uv_read_start`/`uv_listen` whose callbacks do *not* fire once the handle is
+// closed, so their references would leak if not released now. Each holds one reference to the socket
+// (see `recv`, `wait_readable` and `accept`), so the socket reference is dropped once per such
+// pending operation, and last, as it may run the socket's finalizer (which asserts the promise/buffer
+// fields have been cleared).
+//
+// Request-based operations (`connect`/`send`/`shutdown`) are deliberately *not* touched here: their
+// `uv_connect_t`/`uv_write_t`/`uv_shutdown_t` callbacks fire with `UV_ECANCELED` when the handle is
+// closed during `event_loop_cleanup`, and own their own teardown (resolving the promise and dropping
+// the socket and promise references). Releasing them here too would double-drop those references and
+// leave the callback dereferencing a now-null `m_promise_shutdown`.
+void lean_uv_tcp_socket_shutdown(lean_object * obj) {
+    lean_uv_tcp_socket_object * tcp_socket = lean_to_uv_tcp_socket(obj);
+
+    unsigned socket_refs = 0;
+
+    if (tcp_socket->m_promise_read != nullptr) {
+        lean_dec(tcp_socket->m_promise_read);
+        tcp_socket->m_promise_read = nullptr;
+        socket_refs++;
+    }
+
+    if (tcp_socket->m_promise_accept != nullptr) {
+        lean_dec(tcp_socket->m_promise_accept);
+        tcp_socket->m_promise_accept = nullptr;
+        socket_refs++;
+    }
+
+    if (tcp_socket->m_byte_array != nullptr) {
+        lean_dec(tcp_socket->m_byte_array);
+        tcp_socket->m_byte_array = nullptr;
+    }
+
+    if (tcp_socket->m_client != nullptr) {
+        lean_dec(tcp_socket->m_client);
+        tcp_socket->m_client = nullptr;
+    }
+
+    for (unsigned i = 0; i < socket_refs; i++) {
+        lean_dec(obj);
+    }
+}
+
 // =======================================
 // TCP Socket Operations
 
@@ -100,10 +136,18 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_new() {
     }
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        free(uv_tcp);
+        free(tcp_socket);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_tcp_init(global_ev.loop, uv_tcp);
-    event_loop_unlock(&global_ev);
 
     if (result != 0) {
+        event_loop_unlock(&global_ev);
         free(uv_tcp);
         free(tcp_socket);
 
@@ -112,10 +156,13 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_new() {
 
     tcp_socket->m_uv_tcp = uv_tcp;
 
+    // The handle is visible to the walk in `finalize_libuv` as soon as `uv_tcp_init` inserts it
+    // into the loop, so `data` must point to the (mt-marked) object before the lock is released.
     lean_object* obj = lean_uv_tcp_socket_new(tcp_socket);
     lean_mark_mt(obj);
+    uv_tcp->data = obj;
 
-    tcp_socket->m_uv_tcp->data = obj;
+    event_loop_unlock(&global_ev);
 
     return lean_io_result_mk_ok(obj);
 }
@@ -145,11 +192,26 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_connect(b_obj_arg socket, b_obj_
 
     uv_connect->data = connect_data;
 
-    // The event loop owns the socket.
+    // While the request is in flight the loop owns one reference to the socket and one to the
+    // promise (both released by the connect callback); a second promise reference is the caller's
+    // return value.
     lean_inc(socket);
     lean_inc(promise);
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+
+        lean_dec(promise); // The structure does not own it.
+        lean_dec(promise); // We are not going to return it.
+        lean_dec(socket);
+
+        free(connect_data);
+        free(uv_connect);
+
+        return lean_uv_loop_finalized_error();
+    }
 
     int result = uv_tcp_connect(uv_connect, tcp_socket->m_uv_tcp, (sockaddr*)&addr_struct, [](uv_connect_t* req, int status) {
         tcp_connect_data* tup = (tcp_connect_data*) req->data;
@@ -170,7 +232,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_connect(b_obj_arg socket, b_obj_
         lean_dec(promise); // We are not going to return it.
         lean_dec(socket);
 
-        free(uv_connect->data);
+        free(connect_data);
         free(uv_connect);
 
         return lean_io_result_mk_error(lean_decode_uv_error(result, nullptr));
@@ -219,28 +281,45 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_send(b_obj_arg socket, obj_arg d
         free(bufs);
         return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
-    write_uv->data = (tcp_send_data*)malloc(sizeof(tcp_send_data));
-    if (write_uv->data == nullptr) {
+    tcp_send_data* send_data = (tcp_send_data*)malloc(sizeof(tcp_send_data));
+    if (send_data == nullptr) {
         lean_dec(data_array);
         free(bufs);
         free(write_uv);
         return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
+    write_uv->data = send_data;
 
     lean_object* promise = lean_promise_new();
     mark_mt(promise);
 
-    tcp_send_data* send_data = (tcp_send_data*)write_uv->data;
     send_data->promise = promise;
     send_data->data = data_array;
     send_data->socket = socket;
     send_data->bufs = bufs;
 
-    // These objects are going to enter the loop and be owned by it
+    // While the request is in flight the loop owns one reference each to the socket, the promise
+    // and the data array (all released by the write callback); a second promise reference is the
+    // caller's return value.
     lean_inc(promise);
     lean_inc(socket);
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+
+        lean_dec(promise); // The structure does not own it.
+        lean_dec(promise); // We are not going to return it.
+        lean_dec(socket);
+        lean_dec(data_array);
+        free(bufs);
+
+        free(send_data);
+        free(write_uv);
+
+        return lean_uv_loop_finalized_error();
+    }
 
     int result = uv_write(write_uv, (uv_stream_t*)tcp_socket->m_uv_tcp, bufs, array_len, [](uv_write_t* req, int status) {
         tcp_send_data* tup = (tcp_send_data*) req->data;
@@ -265,7 +344,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_send(b_obj_arg socket, obj_arg d
         lean_dec(data_array);
         free(bufs);
 
-        free(write_uv->data);
+        free(send_data);
         free(write_uv);
 
         return lean_io_result_mk_error(lean_decode_uv_error(result, nullptr));
@@ -281,6 +360,11 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_recv(b_obj_arg socket, uint64_t 
     // Locking early prevents potential parallelism issues setting the byte_array.
     event_loop_lock(&global_ev);
 
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     if (tcp_socket->m_promise_read != nullptr) {
         event_loop_unlock(&global_ev);
         return lean_io_result_mk_error(lean_decode_uv_error(UV_EALREADY, nullptr));
@@ -291,10 +375,11 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_recv(b_obj_arg socket, uint64_t 
 
     lean_object* promise = lean_promise_new();
     mark_mt(promise);
-
     tcp_socket->m_promise_read = promise;
 
-    // The event loop owns the socket.
+    // While the read is pending the loop owns one reference to the socket and one to the
+    // promise (both released by the read callback); a second promise reference is the
+    // caller's return value.
     lean_inc(socket);
     lean_inc(promise);
 
@@ -355,6 +440,11 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_wait_readable(b_obj_arg socket) 
 
     event_loop_lock(&global_ev);
 
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     if (tcp_socket->m_promise_read != nullptr) {
         event_loop_unlock(&global_ev);
         return lean_io_result_mk_error(lean_decode_uv_error(UV_EALREADY, nullptr));
@@ -362,10 +452,11 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_wait_readable(b_obj_arg socket) 
 
     lean_object* promise = lean_promise_new();
     mark_mt(promise);
-
     tcp_socket->m_promise_read = promise;
 
-    // The event loop owns the socket.
+    // While the read is pending the loop owns one reference to the socket and one to the
+    // promise (both released by the read callback); a second promise reference is the
+    // caller's return value.
     lean_inc(socket);
     lean_inc(promise);
 
@@ -420,7 +511,14 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_wait_readable(b_obj_arg socket) 
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_cancel_recv(b_obj_arg socket) {
     lean_uv_tcp_socket_object* tcp_socket = lean_to_uv_tcp_socket(socket);
 
+    // After finalization this is a vacuous success: the teardown walk already cancelled any
+    // pending read and dropped its references.
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_io_result_mk_ok(lean_box(0));
+    }
 
     if (tcp_socket->m_promise_read == nullptr) {
         event_loop_unlock(&global_ev);
@@ -429,19 +527,19 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_cancel_recv(b_obj_arg socket) {
 
     uv_read_stop((uv_stream_t*)tcp_socket->m_uv_tcp);
 
-    lean_object* promise = tcp_socket->m_promise_read;
-    lean_dec(promise);
+    lean_dec(tcp_socket->m_promise_read);
     tcp_socket->m_promise_read = nullptr;
 
-    lean_object* byte_array = tcp_socket->m_byte_array;
-    if (byte_array != nullptr) {
-        lean_dec(byte_array);
+    if (tcp_socket->m_byte_array != nullptr) {
+        lean_dec(tcp_socket->m_byte_array);
         tcp_socket->m_byte_array = nullptr;
     }
 
+    // Drop the loop's reference to the socket (held since `recv`/`waitReadable`).
     lean_dec(socket);
 
     event_loop_unlock(&global_ev);
+
     return lean_io_result_mk_ok(lean_box(0));
 }
 
@@ -453,7 +551,14 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_bind(b_obj_arg socket, b_obj_arg
     lean_socket_address_to_sockaddr_storage(addr, &addr_ptr);
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_tcp_bind(tcp_socket->m_uv_tcp, (sockaddr*)&addr_ptr, 0);
+
     event_loop_unlock(&global_ev);
 
     if (result < 0) {
@@ -469,6 +574,11 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_listen(b_obj_arg socket, int32_t
 
     event_loop_lock(&global_ev);
 
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_listen((uv_stream_t*)tcp_socket->m_uv_tcp, backlog, [](uv_stream_t* stream, int status) {
         lean_uv_tcp_socket_object* tcp_socket = lean_to_uv_tcp_socket((lean_object*)stream->data);
 
@@ -482,6 +592,14 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_listen(b_obj_arg socket, int32_t
             lean_promise_resolve_with_code(status, promise);
             lean_dec(promise);
             tcp_socket->m_promise_accept = nullptr;
+
+            if (tcp_socket->m_client != nullptr) {
+                lean_dec(tcp_socket->m_client);
+                tcp_socket->m_client = nullptr;
+            }
+
+            // The accept increases the count and then the listen decreases
+            lean_dec((lean_object*)stream->data);
             return;
         }
 
@@ -497,6 +615,9 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_listen(b_obj_arg socket, int32_t
             lean_dec(client);
             lean_promise_resolve_with_code(result, promise);
             lean_dec(promise);
+
+            // The accept increases the count and then the listen decreases
+            lean_dec((lean_object*)stream->data);
             return;
         }
 
@@ -520,38 +641,51 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_listen(b_obj_arg socket, int32_t
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_accept(b_obj_arg socket) {
     lean_uv_tcp_socket_object* tcp_socket = lean_to_uv_tcp_socket(socket);
 
-    // Locking early prevents potential parallelism issues setting m_promise_accept.
+    lean_object* promise;
+    lean_object* client;
+    int result;
+
+    // Locking early prevents potential parallelism issues setting m_promise_accept. The nested
+    // `lean_uv_tcp_new` below re-locks; this is fine, the mutex is recursive and the finalized
+    // flag cannot flip while this thread holds the lock.
     event_loop_lock(&global_ev);
 
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     if (tcp_socket->m_promise_accept != nullptr) {
+        event_loop_unlock(&global_ev);
         return lean_io_result_mk_error(lean_decode_uv_error(UV_EALREADY, mk_string("parallel accept is not allowed! consider binding multiple sockets to the same address and accepting on them instead")));
     }
 
-    lean_object* promise = lean_promise_new();
+    promise = lean_promise_new();
     mark_mt(promise);
 
-    lean_object* client = lean_io_result_take_value(lean_uv_tcp_new());
-
+    client = lean_io_result_take_value(lean_uv_tcp_new());
     lean_uv_tcp_socket_object* client_socket = lean_to_uv_tcp_socket(client);
 
-    int result = uv_accept((uv_stream_t*)tcp_socket->m_uv_tcp, (uv_stream_t*)client_socket->m_uv_tcp);
+    result = uv_accept((uv_stream_t*)tcp_socket->m_uv_tcp, (uv_stream_t*)client_socket->m_uv_tcp);
 
-    if (result < 0 && result != UV_EAGAIN) {
-        event_loop_unlock(&global_ev);
-        lean_dec(client);
-        lean_promise_resolve_with_code(result, promise);
-    } else if (result >= 0) {
-        event_loop_unlock(&global_ev);
-        lean_promise_resolve(mk_except_ok(client), promise);
-    } else {
-        // The event loop owns the object. It will be released in the listen
+    if (result == UV_EAGAIN) {
+        // No connection is ready yet: park the client and promise for the listen callback,
+        // which owns one reference to the promise and one to the listening socket (and takes
+        // over the client's) until it completes.
         lean_inc(socket);
         lean_inc(promise);
 
         tcp_socket->m_promise_accept = promise;
         tcp_socket->m_client = client;
+    }
 
-        event_loop_unlock(&global_ev);
+    event_loop_unlock(&global_ev);
+
+    if (result < 0 && result != UV_EAGAIN) {
+        lean_dec(client);
+        lean_promise_resolve_with_code(result, promise);
+    } else if (result >= 0) {
+        lean_promise_resolve(mk_except_ok(client), promise);
     }
 
     return lean_io_result_mk_ok(promise);
@@ -561,8 +695,14 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_accept(b_obj_arg socket) {
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_try_accept(b_obj_arg socket) {
     lean_uv_tcp_socket_object* tcp_socket = lean_to_uv_tcp_socket(socket);
 
-    // Locking early prevents potential parallelism issues setting m_promise_accept.
+    // Locking early prevents potential parallelism issues setting m_promise_accept. The nested
+    // `lean_uv_tcp_new` below re-locks; this is fine, the mutex is recursive.
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
 
     if (tcp_socket->m_promise_accept != nullptr) {
         event_loop_unlock(&global_ev);
@@ -574,15 +714,14 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_try_accept(b_obj_arg socket) {
 
     int result = uv_accept((uv_stream_t*)tcp_socket->m_uv_tcp, (uv_stream_t*)client_socket->m_uv_tcp);
 
+    event_loop_unlock(&global_ev);
+
     if (result < 0 && result != UV_EAGAIN) {
-        event_loop_unlock(&global_ev);
         lean_dec(client);
         return lean_io_result_mk_error(lean_decode_uv_error(result, NULL));
     } else if (result >= 0) {
-        event_loop_unlock(&global_ev);
         return lean_io_result_mk_ok(mk_except_ok(lean::mk_option_some(client)));
     } else {
-        event_loop_unlock(&global_ev);
         lean_dec(client);
         return lean_io_result_mk_ok(mk_except_ok(lean::mk_option_none()));
     }
@@ -594,27 +733,33 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_try_accept(b_obj_arg socket) {
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_cancel_accept(b_obj_arg socket) {
     lean_uv_tcp_socket_object* tcp_socket = lean_to_uv_tcp_socket(socket);
 
+    // After finalization this is a vacuous success: the teardown walk already cancelled any
+    // pending accept and dropped its references.
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_io_result_mk_ok(lean_box(0));
+    }
 
     if (tcp_socket->m_promise_accept == nullptr) {
         event_loop_unlock(&global_ev);
         return lean_io_result_mk_ok(lean_box(0));
     }
 
-    lean_object* promise = tcp_socket->m_promise_accept;
-    lean_dec(promise);
+    lean_dec(tcp_socket->m_promise_accept);
     tcp_socket->m_promise_accept = nullptr;
 
-    lean_object* client = tcp_socket->m_client;
-
-    if (client != nullptr) {
-        lean_dec(client);
+    if (tcp_socket->m_client != nullptr) {
+        lean_dec(tcp_socket->m_client);
         tcp_socket->m_client = nullptr;
     }
 
+    // Drop the loop's reference to the socket (held since `accept`).
     lean_dec(socket);
 
     event_loop_unlock(&global_ev);
+
     return lean_io_result_mk_ok(lean_box(0));
 }
 
@@ -624,6 +769,11 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_shutdown(b_obj_arg socket) {
 
     // Locking early prevents potential parallelism issues setting the m_promise_shutdown.
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
 
     if (tcp_socket->m_promise_shutdown != nullptr) {
         event_loop_unlock(&global_ev);
@@ -640,8 +790,11 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_shutdown(b_obj_arg socket) {
     lean_object* promise = lean_promise_new();
     mark_mt(promise);
     tcp_socket->m_promise_shutdown = promise;
-    lean_inc(promise);
 
+    // While the request is in flight the loop owns one reference to the socket and one to the
+    // promise (via `m_promise_shutdown`, both released by the shutdown callback); a second promise
+    // reference is the caller's return value.
+    lean_inc(promise);
     lean_inc(socket);
 
     int result = uv_shutdown(shutdown_req, (uv_stream_t*)tcp_socket->m_uv_tcp, [](uv_shutdown_t* req, int status) {
@@ -661,12 +814,15 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_shutdown(b_obj_arg socket) {
         free(req);
     });
 
-
     if (result < 0) {
         free(shutdown_req);
-        lean_dec(tcp_socket->m_promise_shutdown);
         tcp_socket->m_promise_shutdown = nullptr;
+
         event_loop_unlock(&global_ev);
+
+        lean_dec(promise); // The structure does not own it.
+        lean_dec(promise); // We are not going to return it.
+        lean_dec(socket);
 
         return lean_io_result_mk_error(lean_decode_uv_error(result, nullptr));
     }
@@ -684,7 +840,14 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_getpeername(b_obj_arg socket) {
     int addr_len = sizeof(addr_storage);
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_tcp_getpeername(tcp_socket->m_uv_tcp, (struct sockaddr*)&addr_storage, &addr_len);
+
     event_loop_unlock(&global_ev);
 
     if (result < 0) {
@@ -704,7 +867,14 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_getsockname(b_obj_arg socket) {
     int addr_len = sizeof(addr_storage);
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_tcp_getsockname(tcp_socket->m_uv_tcp, (struct sockaddr*)&addr_storage, &addr_len);
+
     event_loop_unlock(&global_ev);
 
     if (result < 0) {
@@ -720,7 +890,14 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_nodelay(b_obj_arg socket) {
     lean_uv_tcp_socket_object* tcp_socket = lean_to_uv_tcp_socket(socket);
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_tcp_nodelay(tcp_socket->m_uv_tcp, 1);
+
     event_loop_unlock(&global_ev);
 
     if (result < 0) {
@@ -735,7 +912,14 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_keepalive(b_obj_arg socket, int3
     lean_uv_tcp_socket_object* tcp_socket = lean_to_uv_tcp_socket(socket);
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_tcp_keepalive(tcp_socket->m_uv_tcp, enable, delay);
+
     event_loop_unlock(&global_ev);
 
     if (result < 0) {
@@ -802,7 +986,6 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_tcp_shutdown(b_obj_arg socket) {
         false && ("Please build a version of Lean4 with libuv to invoke this.")
     );
 }
-
 
 // =======================================
 // TCP Socket Utility Functions

--- a/src/runtime/uv/tcp.cpp
+++ b/src/runtime/uv/tcp.cpp
@@ -65,22 +65,6 @@ void initialize_libuv_tcp_socket() {
     });
 }
 
-// Releases the references the event loop holds for a socket via callback-less operations. Called
-// from `finalize_libuv` while walking the loop's handles, after the loop thread has been joined, so
-// no locking is needed.
-//
-// Only `recv`/`waitReadable` (`m_promise_read`) and `accept` (`m_promise_accept`) are handled here:
-// these are driven by `uv_read_start`/`uv_listen` whose callbacks do *not* fire once the handle is
-// closed, so their references would leak if not released now. Each holds one reference to the socket
-// (see `recv`, `wait_readable` and `accept`), so the socket reference is dropped once per such
-// pending operation, and last, as it may run the socket's finalizer (which asserts the promise/buffer
-// fields have been cleared).
-//
-// Request-based operations (`connect`/`send`/`shutdown`) are deliberately *not* touched here: their
-// `uv_connect_t`/`uv_write_t`/`uv_shutdown_t` callbacks fire with `UV_ECANCELED` when the handle is
-// closed during `event_loop_cleanup`, and own their own teardown (resolving the promise and dropping
-// the socket and promise references). Releasing them here too would double-drop those references and
-// leave the callback dereferencing a now-null `m_promise_shutdown`.
 void lean_uv_tcp_socket_shutdown(lean_object * obj) {
     lean_uv_tcp_socket_object * tcp_socket = lean_to_uv_tcp_socket(obj);
 

--- a/src/runtime/uv/tcp.h
+++ b/src/runtime/uv/tcp.h
@@ -35,6 +35,9 @@ typedef struct {
 // Tcp socket object manipulation functions.
 static inline lean_object* lean_uv_tcp_socket_new(lean_uv_tcp_socket_object* s) { return lean_alloc_external(g_uv_tcp_socket_external_class, s); }
 static inline lean_uv_tcp_socket_object* lean_to_uv_tcp_socket(lean_object* o) { return (lean_uv_tcp_socket_object*)(lean_get_external_data(o)); }
+
+// Releases the event-loop-held references of a TCP socket handle during libuv finalization.
+void lean_uv_tcp_socket_shutdown(lean_object * obj);
 #endif
 
 // =======================================

--- a/src/runtime/uv/timer.cpp
+++ b/src/runtime/uv/timer.cpp
@@ -15,20 +15,12 @@ using namespace std;
 void lean_uv_timer_finalizer(void* ptr) {
     lean_uv_timer_object * timer = (lean_uv_timer_object*) ptr;
 
-    /// The timer can be null in two states, it has not started and it got cancelled.
+    // The promise can be null in two states: the timer has not started, or it got cancelled.
     if (timer->m_promise != NULL) {
         lean_dec(timer->m_promise);
     }
 
-    event_loop_lock(&global_ev);
-
-    uv_close((uv_handle_t*)timer->m_uv_timer, [](uv_handle_t* handle) {
-        free(handle);
-    });
-
-    event_loop_unlock(&global_ev);
-
-    free(timer);
+    lean_uv_close_and_free((uv_handle_t*)timer->m_uv_timer, timer);
 }
 
 void initialize_libuv_timer() {
@@ -74,6 +66,22 @@ void handle_timer_event(uv_timer_t* handle) {
     }
 }
 
+void lean_uv_timer_shutdown(lean_object * obj) {
+    lean_uv_timer_object * timer = lean_to_uv_timer(obj);
+
+    if (timer->m_promise != NULL) {
+        lean_dec(timer->m_promise);
+        timer->m_promise = NULL;
+    }
+
+    // While running, the loop keeps the timer alive with an extra reference (see `setup_timer`);
+    // drop it last, as it may run the timer's finalizer.
+    if (timer->m_state == TIMER_STATE_RUNNING) {
+        timer->m_state = TIMER_STATE_FINISHED;
+        lean_dec(obj);
+    }
+}
+
 /* Std.Internal.UV.Timer.mk (timeout : UInt64) (repeating : Bool) : IO Timer */
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_timer_mk(uint64_t timeout, uint8_t repeating) {
     lean_uv_timer_object * timer = (lean_uv_timer_object*)malloc(sizeof(lean_uv_timer_object));
@@ -92,10 +100,18 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_timer_mk(uint64_t timeout, uint8_t r
     }
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        free(uv_timer);
+        free(timer);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_timer_init(global_ev.loop, uv_timer);
-    event_loop_unlock(&global_ev);
 
     if (result != 0) {
+        event_loop_unlock(&global_ev);
         free(uv_timer);
         free(timer);
         return lean_io_result_mk_error(lean_decode_uv_error(result, NULL));
@@ -103,9 +119,13 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_timer_mk(uint64_t timeout, uint8_t r
 
     timer->m_uv_timer = uv_timer;
 
+    // The handle is visible to the walk in `finalize_libuv` as soon as `uv_timer_init` inserts it
+    // into the loop, so `data` must point to the (mt-marked) object before the lock is released.
     lean_object * obj = lean_uv_timer_new(timer);
     lean_mark_mt(obj);
-    timer->m_uv_timer->data = obj;
+    uv_timer->data = obj;
+
+    event_loop_unlock(&global_ev);
 
     return lean_io_result_mk_ok(obj);
 }
@@ -114,14 +134,17 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_timer_mk(uint64_t timeout, uint8_t r
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_timer_next(b_obj_arg obj) {
     lean_uv_timer_object * timer = lean_to_uv_timer(obj);
 
-    auto create_promise = []() {
-        return lean_io_promise_new();
-    };
+    event_loop_lock(&global_ev);
 
-    auto setup_timer = [create_promise, obj, timer]() {
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
+    auto setup_timer = [obj, timer]() {
         lean_assert(timer->m_promise == NULL);
 
-        lean_object* promise = create_promise();
+        lean_object* promise = lean_io_promise_new();
         timer->m_promise = promise;
         timer->m_state = TIMER_STATE_RUNNING;
 
@@ -147,8 +170,6 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_timer_next(b_obj_arg obj) {
         return lean_io_result_mk_ok(promise);
     };
 
-    event_loop_lock(&global_ev);
-
     if (timer->m_repeating) {
         switch (timer->m_state) {
             case TIMER_STATE_INITIAL:
@@ -162,7 +183,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_timer_next(b_obj_arg obj) {
                             lean_dec(timer->m_promise);
                         }
 
-                        timer->m_promise = create_promise();
+                        timer->m_promise = lean_io_promise_new();
                     }
 
                     lean_inc(timer->m_promise);
@@ -179,7 +200,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_timer_next(b_obj_arg obj) {
                         return lean_io_result_mk_ok(timer->m_promise);
                     } else {
                         // Creates a resolved promise
-                        lean_object* finished_promise = create_promise();
+                        lean_object* finished_promise = lean_io_promise_new();
                         event_loop_unlock(&global_ev);
                         return lean_io_result_mk_ok(finished_promise);
                     }
@@ -196,7 +217,7 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_timer_next(b_obj_arg obj) {
         } else {
             event_loop_unlock(&global_ev);
             // Creates a resolved promise
-            lean_object* finished_promise = create_promise();
+            lean_object* finished_promise = lean_io_promise_new();
             return lean_io_result_mk_ok(finished_promise);
         }
     }
@@ -209,36 +230,48 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_timer_reset(b_obj_arg obj) {
     // Locking to access the state in order to avoid data-race
     event_loop_lock(&global_ev);
 
-    if (timer->m_state == TIMER_STATE_RUNNING) {
-
-        uv_timer_stop(timer->m_uv_timer);
-
-        int result = uv_timer_start(
-            timer->m_uv_timer,
-            handle_timer_event,
-            timer->m_timeout,
-            timer->m_repeating ? timer->m_timeout : 0
-        );
-
+    if (g_libuv_finalized) {
         event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
 
-        if (result != 0) {
-            return lean_io_result_mk_error(lean_decode_uv_error(result, NULL));
-        } else {
-            return lean_io_result_mk_ok(lean_box(0));
-        }
-    } else {
+    if (timer->m_state != TIMER_STATE_RUNNING) {
         event_loop_unlock(&global_ev);
         return lean_io_result_mk_ok(lean_box(0));
     }
+
+    uv_timer_stop(timer->m_uv_timer);
+
+    int result = uv_timer_start(
+        timer->m_uv_timer,
+        handle_timer_event,
+        timer->m_timeout,
+        timer->m_repeating ? timer->m_timeout : 0
+    );
+
+    event_loop_unlock(&global_ev);
+
+    if (result != 0) {
+        return lean_io_result_mk_error(lean_decode_uv_error(result, NULL));
+    }
+
+    return lean_io_result_mk_ok(lean_box(0));
 }
 
 /* Std.Internal.UV.Timer.stop (timer : @& Timer) : IO Unit */
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_timer_stop(b_obj_arg obj) {
     lean_uv_timer_object * timer = lean_to_uv_timer(obj);
 
-    // Locking to access the state in order to avoid data-race
+    bool was_running = false;
+
+    // Locking to access the state in order to avoid data-race. After finalization this is a
+    // vacuous success: the teardown walk already stopped the timer and dropped its promise.
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_io_result_mk_ok(lean_box(0));
+    }
 
     if (timer->m_promise != NULL) {
         lean_dec(timer->m_promise);
@@ -247,17 +280,18 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_timer_stop(b_obj_arg obj) {
 
     if (timer->m_state == TIMER_STATE_RUNNING) {
         uv_timer_stop(timer->m_uv_timer);
-        event_loop_unlock(&global_ev);
-
         timer->m_state = TIMER_STATE_FINISHED;
-
-        // The loop does not need to keep the timer alive anymore.
-        lean_dec(obj);
-
-        return lean_io_result_mk_ok(lean_box(0));
+        was_running = true;
     }
 
     event_loop_unlock(&global_ev);
+
+    if (was_running) {
+        // The loop does not need to keep the timer alive anymore. Dropped after releasing the
+        // lock, as it may run the timer's finalizer, which re-acquires it.
+        lean_dec(obj);
+    }
+
     return lean_io_result_mk_ok(lean_box(0));
 }
 
@@ -265,8 +299,15 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_timer_stop(b_obj_arg obj) {
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_timer_cancel(b_obj_arg obj) {
     lean_uv_timer_object * timer = lean_to_uv_timer(obj);
 
-    // It's locking here to avoid changing the state during other operations.
+    // It's locking here to avoid changing the state during other operations. After finalization
+    // this is a vacuous success: the teardown walk already stopped the timer and dropped its
+    // promise.
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_io_result_mk_ok(lean_box(0));
+    }
 
     if (timer->m_state == TIMER_STATE_RUNNING && timer->m_promise != NULL) {
         if (timer->m_repeating) {
@@ -290,8 +331,6 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_timer_cancel(b_obj_arg obj) {
 }
 
 #else
-
-void lean_uv_timer_finalizer(void* ptr);
 
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_timer_mk(uint64_t timeout, uint8_t repeating) {
     lean_always_assert(

--- a/src/runtime/uv/timer.h
+++ b/src/runtime/uv/timer.h
@@ -43,6 +43,9 @@ typedef struct {
 static inline lean_object* lean_uv_timer_new(lean_uv_timer_object * s) { return lean_alloc_external(g_uv_timer_external_class, s); }
 static inline lean_uv_timer_object* lean_to_uv_timer(lean_object * o) { return (lean_uv_timer_object*)(lean_get_external_data(o)); }
 
+// Releases the event-loop-held references of a timer handle during libuv finalization.
+void lean_uv_timer_shutdown(lean_object * obj);
+
 #else
 
 // =======================================

--- a/src/runtime/uv/udp.cpp
+++ b/src/runtime/uv/udp.cpp
@@ -25,19 +25,23 @@ void lean_uv_udp_socket_finalizer(void* ptr) {
     lean_always_assert(udp_socket->m_promise_read == nullptr);
     lean_always_assert(udp_socket->m_byte_array == nullptr);
 
-    /// It's changing here because the object is being freed in the finalizer, and we need the data
-    /// inside of it.
-    udp_socket->m_uv_udp->data = ptr;
+    lean_uv_close_and_free((uv_handle_t*)udp_socket->m_uv_udp, udp_socket);
+}
 
-    event_loop_lock(&global_ev);
+void lean_uv_udp_socket_shutdown(lean_object * obj) {
+    lean_uv_udp_socket_object * udp_socket = lean_to_uv_udp_socket(obj);
 
-    uv_close((uv_handle_t*)udp_socket->m_uv_udp, [](uv_handle_t* handle) {
-        lean_uv_udp_socket_object* udp_socket = (lean_uv_udp_socket_object*)handle->data;
-        free(udp_socket->m_uv_udp);
-        free(udp_socket);
-    });
+    if (udp_socket->m_promise_read != nullptr) {
+        lean_dec(udp_socket->m_promise_read);
+        udp_socket->m_promise_read = nullptr;
 
-    event_loop_unlock(&global_ev);
+        if (udp_socket->m_byte_array != nullptr) {
+            lean_dec(udp_socket->m_byte_array);
+            udp_socket->m_byte_array = nullptr;
+        }
+
+        lean_dec(obj);
+    }
 }
 
 void initialize_libuv_udp_socket() {
@@ -76,21 +80,33 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_new() {
     }
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        free(uv_udp);
+        free(udp_socket);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_udp_init(global_ev.loop, uv_udp);
-    event_loop_unlock(&global_ev);
 
     if (result != 0) {
+        event_loop_unlock(&global_ev);
         free(uv_udp);
         free(udp_socket);
 
         return lean_io_result_mk_error(lean_decode_uv_error(result, nullptr));
     }
 
+    udp_socket->m_uv_udp = uv_udp;
+
+    // The handle is visible to the walk in `finalize_libuv` as soon as `uv_udp_init` inserts it
+    // into the loop, so `data` must point to the (mt-marked) object before the lock is released.
     lean_object* obj = lean_uv_udp_socket_new(udp_socket);
     lean_mark_mt(obj);
+    uv_udp->data = obj;
 
-    udp_socket->m_uv_udp = uv_udp;
-    udp_socket->m_uv_udp->data = obj;
+    event_loop_unlock(&global_ev);
 
     return lean_io_result_mk_ok(obj);
 }
@@ -103,7 +119,14 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_bind(b_obj_arg socket, b_obj_arg
     lean_socket_address_to_sockaddr_storage(addr, &addr_ptr);
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_udp_bind(udp_socket->m_uv_udp, (sockaddr*)&addr_ptr, UV_UDP_REUSEADDR);
+
     event_loop_unlock(&global_ev);
 
     if (result < 0) {
@@ -121,7 +144,14 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_connect(b_obj_arg socket, b_obj_
     lean_socket_address_to_sockaddr_storage(addr, &addr_ptr);
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_udp_connect(udp_socket->m_uv_udp, (sockaddr*)&addr_ptr);
+
     event_loop_unlock(&global_ev);
 
     if (result < 0) {
@@ -174,22 +204,24 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_send(b_obj_arg socket, obj_arg d
         free(bufs);
         return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
-    send_uv->data = (udp_send_data*)malloc(sizeof(udp_send_data));
-    if (send_uv->data == nullptr) {
+    udp_send_data* send_data = (udp_send_data*)malloc(sizeof(udp_send_data));
+    if (send_data == nullptr) {
         lean_dec(data_array);
         lean_dec(promise);
         free(bufs);
         free(send_uv);
         return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
     }
+    send_uv->data = send_data;
 
-    udp_send_data* send_data = (udp_send_data*)send_uv->data;
     send_data->promise = promise;
     send_data->data = data_array;
     send_data->socket = socket;
     send_data->bufs = bufs;
 
-    // These objects are going to enter the loop and be owned by it
+    // While the request is in flight the loop owns one reference each to the socket, the promise
+    // and the data array (all released by the send callback); a second promise reference is the
+    // caller's return value.
     lean_inc(promise);
     lean_inc(socket);
 
@@ -199,19 +231,38 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_send(b_obj_arg socket, obj_arg d
         lean_object* addr = lean_ctor_get(opt_addr, 0);
         addr_ptr = (sockaddr_storage*)malloc(sizeof(sockaddr_storage));
         if (addr_ptr == nullptr) {
-            lean_dec(promise);
-            lean_dec(promise);
+            lean_dec(promise); // The structure does not own it.
+            lean_dec(promise); // We are not going to return it.
             lean_dec(socket);
             lean_dec(data_array);
             free(bufs);
-            free(send_uv->data);
+
+            free(send_data);
             free(send_uv);
+
             return lean_io_result_mk_error(decode_io_error(ENOMEM, nullptr));
         }
         lean_socket_address_to_sockaddr_storage(addr, addr_ptr);
     }
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+
+        free(addr_ptr);
+
+        lean_dec(promise); // The structure does not own it.
+        lean_dec(promise); // We are not going to return it.
+        lean_dec(socket);
+        lean_dec(data_array);
+        free(bufs);
+
+        free(send_data);
+        free(send_uv);
+
+        return lean_uv_loop_finalized_error();
+    }
 
     int result = uv_udp_send(send_uv, udp_socket->m_uv_udp, bufs, array_len, (sockaddr*)addr_ptr, [](uv_udp_send_t* req, int status) {
         udp_send_data* tup = (udp_send_data*) req->data;
@@ -235,11 +286,11 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_send(b_obj_arg socket, obj_arg d
     if (result < 0) {
         lean_dec(promise); // The structure does not own it.
         lean_dec(promise); // We are not going to return it.
-        lean_dec(socket); // The loop does not own the object.
-        lean_dec(data_array); // The data is owned.
+        lean_dec(socket);
+        lean_dec(data_array);
         free(bufs);
 
-        free(send_uv->data);
+        free(send_data);
         free(send_uv);
 
         return lean_io_result_mk_error(lean_decode_uv_error(result, nullptr));
@@ -255,6 +306,11 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_recv(b_obj_arg socket, uint64_t 
     // Locking earlier to avoid parallelism issues with m_promise_read.
     event_loop_lock(&global_ev);
 
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     if (udp_socket->m_promise_read != nullptr) {
         event_loop_unlock(&global_ev);
         return lean_io_result_mk_error(lean_decode_uv_error(UV_EALREADY, nullptr));
@@ -267,7 +323,9 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_recv(b_obj_arg socket, uint64_t 
     udp_socket->m_byte_array = byte_array;
     udp_socket->m_promise_read = promise;
 
-    // The event loop owns the socket.
+    // While the read is pending the loop owns one reference to the socket and one to the
+    // promise (both released by the read callback); a second promise reference is the
+    // caller's return value.
     lean_inc(promise);
     lean_inc(socket);
 
@@ -339,6 +397,11 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_wait_readable(b_obj_arg socket) 
     // Locking earlier to avoid parallelism issues with m_promise_read.
     event_loop_lock(&global_ev);
 
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     if (udp_socket->m_promise_read != nullptr) {
         event_loop_unlock(&global_ev);
         return lean_io_result_mk_error(lean_decode_uv_error(UV_EALREADY, nullptr));
@@ -349,7 +412,9 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_wait_readable(b_obj_arg socket) 
 
     udp_socket->m_promise_read = promise;
 
-    // The event loop owns the socket.
+    // While the read is pending the loop owns one reference to the socket and one to the
+    // promise (both released by the read callback); a second promise reference is the
+    // caller's return value.
     lean_inc(promise);
     lean_inc(socket);
 
@@ -402,30 +467,34 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_wait_readable(b_obj_arg socket) 
 extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_cancel_recv(b_obj_arg socket) {
     lean_uv_udp_socket_object* udp_socket = lean_to_uv_udp_socket(socket);
 
-    lean_inc(socket);
+    // After finalization this is a vacuous success: the teardown walk already cancelled any
+    // pending read and dropped its references.
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_io_result_mk_ok(lean_box(0));
+    }
 
     if (udp_socket->m_promise_read == nullptr) {
         event_loop_unlock(&global_ev);
-        lean_dec(socket);
         return lean_io_result_mk_ok(lean_box(0));
     }
 
     uv_udp_recv_stop(udp_socket->m_uv_udp);
 
-    lean_object* promise = udp_socket->m_promise_read;
-    lean_dec(promise);
+    lean_dec(udp_socket->m_promise_read);
     udp_socket->m_promise_read = nullptr;
 
-    lean_object* byte_array = udp_socket->m_byte_array;
-
-    if (byte_array != nullptr) {
-        lean_dec(byte_array);
+    if (udp_socket->m_byte_array != nullptr) {
+        lean_dec(udp_socket->m_byte_array);
         udp_socket->m_byte_array = nullptr;
     }
 
-    event_loop_unlock(&global_ev);
+    // Drop the loop's reference to the socket (held since `recv`/`waitReadable`).
     lean_dec(socket);
+
+    event_loop_unlock(&global_ev);
 
     return lean_io_result_mk_ok(lean_box(0));
 }
@@ -442,7 +511,14 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_getpeername(b_obj_arg socket) {
     int addr_len = sizeof(addr_storage);
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_udp_getpeername(udp_socket->m_uv_udp, (struct sockaddr*)&addr_storage, &addr_len);
+
     event_loop_unlock(&global_ev);
 
     if (result < 0) {
@@ -462,7 +538,14 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_getsockname(b_obj_arg socket) {
     int addr_len = sizeof(addr_storage);
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_udp_getsockname(udp_socket->m_uv_udp, (struct sockaddr*)&addr_storage, &addr_len);
+
     event_loop_unlock(&global_ev);
 
     if (result < 0) {
@@ -478,7 +561,14 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_set_broadcast(b_obj_arg socket, 
     lean_uv_udp_socket_object *udp_socket = lean_to_uv_udp_socket(socket);
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_udp_set_broadcast(udp_socket->m_uv_udp, enable);
+
     event_loop_unlock(&global_ev);
 
     if (result < 0) {
@@ -493,7 +583,14 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_set_multicast_loop(b_obj_arg soc
     lean_uv_udp_socket_object *udp_socket = lean_to_uv_udp_socket(socket);
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_udp_set_multicast_loop(udp_socket->m_uv_udp, enable);
+
     event_loop_unlock(&global_ev);
 
     if (result < 0) {
@@ -508,7 +605,14 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_set_multicast_ttl(b_obj_arg sock
     lean_uv_udp_socket_object *udp_socket = lean_to_uv_udp_socket(socket);
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_udp_set_multicast_ttl(udp_socket->m_uv_udp, ttl);
+
     event_loop_unlock(&global_ev);
 
     if (result < 0) {
@@ -534,7 +638,14 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_set_membership(b_obj_arg socket,
     }
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_udp_set_membership(udp_socket->m_uv_udp, multicast_addr_str, is_interface_null ? nullptr : interface_addr_str, (uv_membership)membership);
+
     event_loop_unlock(&global_ev);
 
     if (result < 0) {
@@ -552,7 +663,14 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_set_multicast_interface(b_obj_ar
     lean_ip_addr_ntop(interface_addr, interface_addr_str, sizeof(interface_addr_str));
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_udp_set_multicast_interface(udp_socket->m_uv_udp, interface_addr_str);
+
     event_loop_unlock(&global_ev);
 
     if (result < 0) {
@@ -567,7 +685,14 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_udp_set_ttl(b_obj_arg socket, uint32
     lean_uv_udp_socket_object *udp_socket = lean_to_uv_udp_socket(socket);
 
     event_loop_lock(&global_ev);
+
+    if (g_libuv_finalized) {
+        event_loop_unlock(&global_ev);
+        return lean_uv_loop_finalized_error();
+    }
+
     int result = uv_udp_set_ttl(udp_socket->m_uv_udp, ttl);
+
     event_loop_unlock(&global_ev);
 
     if (result < 0) {

--- a/src/runtime/uv/udp.h
+++ b/src/runtime/uv/udp.h
@@ -33,6 +33,9 @@ typedef struct {
 static inline lean_object* lean_uv_udp_socket_new(lean_uv_udp_socket_object * s) { return lean_alloc_external(g_uv_udp_socket_external_class, s); }
 static inline lean_uv_udp_socket_object* lean_to_uv_udp_socket(lean_object * o) { return (lean_uv_udp_socket_object*)(lean_get_external_data(o)); }
 
+// Releases the event-loop-held references of a UDP socket handle during libuv finalization.
+void lean_uv_udp_socket_shutdown(lean_object * obj);
+
 #endif
 
 // =======================================

--- a/src/util/shell.cpp
+++ b/src/util/shell.cpp
@@ -344,7 +344,10 @@ extern "C" LEAN_EXPORT int lean_main(int argc, char ** argv) {
         report_profiling_time("initialization", init_time);
     }
 
-    scoped_task_manager scope_task_man(get_shell_num_threads(shell_opts));
+    // The task manager needs the thread count, which is only known after option parsing, so
+    // it is initialized here. It is finalized (together with libuv) in `finalize()` via the
+    // `initializer` destructor below.
+    lean_init_task_manager_using(get_shell_num_threads(shell_opts));
 
     try {
         return run_shell_main(argc - optind, argv + optind, shell_opts);


### PR DESCRIPTION
This PR finalizes all the handles, destroys all objects, and destroys the lthread that runs event_loop before task_manager is null. It also adds safeguards so we can check if the libuv thread died when a Task accesses libuv during the interval in which it is finalizing.

As a future PR, as the code gets more and more complicated, I want to make a PR adding a libuv_loop class and RAII safety guards to lock and unlock libuv.