### PR TITLE
doc: guide Claude to write concise inline comments

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -52,6 +52,16 @@ When asked to implement new features:
 * write comprehensive tests first (expecting that these will initially fail)
 * and then iterate on the implementation until the tests pass.
 
+## Comments
+
+Inline comments should be concise. Use them for important, non-obvious facts about the code at hand. Avoid comments that:
+
+- restate the code, repeat a type signature, or describe a general API contract;
+- document old behavior, rejected alternatives, or the history of the change (that belongs in the PR body or commit message);
+- explain API usage that belongs with the API definition instead of this call site.
+
+Rewrite a stale comment instead of adding a new one beside it. If a fact applies generally, document it at the definition.
+
 ## Success Criteria
 
 *Never* report success on a task unless you have verified both a clean build without errors, and that the relevant tests pass.


### PR DESCRIPTION
This PR adds a `## Comments` section to the project `.claude/CLAUDE.md`, directing Claude Code to keep inline comments concise and reserve them for important, non-obvious facts about the code at hand. It discourages comments that restate the code or a general API contract, narrate prior or rejected behavior, or document API usage that belongs at the definition.

Prompted by discussion on the lean-fro Zulip about Claude attaching long, path-dependent comments at unremarkable call sites.

🤖 Prepared with Claude Code