### PR TITLE
fix: panic in `simp +ground` congruence for class constructors

### DIFF
--- a/src/Lean/Meta/Tactic/Simp/Types.lean
+++ b/src/Lean/Meta/Tactic/Simp/Types.lean
@@ -824,6 +824,10 @@ def tryAutoCongrTheorem? (e : Expr) : SimpM (Option Result) := do
         -- Do not visit instance implicit arguments when `ground := true`
         -- See comment at `congrArgs`
         argsNew := argsNew.push arg
+        -- If this instance argument has kind `eq` we must still record a reflexivity result so that
+        -- `argResults` stays aligned with the `eq` arguments consumed by the second loop below.
+        if kind matches .eq then
+          argResults := argResults.push { expr := arg }
         i := i + 1
         continue
     match kind with

--- a/tests/elab/12620.lean
+++ b/tests/elab/12620.lean
@@ -1,0 +1,23 @@
+/-!
+Tests `simp +ground` on congruence for class constructors. The parent subobject
+field is an instance argument with congruence kind `eq`, which used to panic with
+`unknown constant _inhabitedExprDummy` (#12620).
+-/
+
+class A (α : Type) where
+  a : α
+
+class B (α : Type) extends A α where
+  b : α
+  hb : b = b
+
+example (x y : Nat) (h : x = y) :
+    (@B.mk Nat ⟨0⟩ x rfl) = (@B.mk Nat ⟨0⟩ y rfl) := by
+  simp +ground [h]
+
+opaque P : B Nat → Prop
+
+example (x y : Nat) (h : x = y) (hyp : P (@B.mk Nat ⟨0⟩ x rfl)) :
+    P (@B.mk Nat ⟨0⟩ y rfl) := by
+  simp +ground [h] at hyp
+  exact hyp


### PR DESCRIPTION
This PR fixes a panic in `simp +ground` that aborted with an "unknown constant `_inhabitedExprDummy`" error.

The crash originated in `Simp.tryAutoCongrTheorem?`, which builds a congruence proof in two passes over a function's arguments. In ground mode the first pass skips instance arguments, but when such an argument also has congruence kind `eq` -- as happens for the parent subobject fields of class constructors -- it did not record a result, so the results array fell out of sync with the `eq` arguments consumed by the second pass. The out-of-bounds read returned the placeholder `Inhabited Expr` value `_inhabitedExprDummy`.

Closes #12620