### PR TITLE
[Backport releases/v4.31.0] chore: fix wrong assertions

### DIFF
--- a/src/include/lean/lean.h
+++ b/src/include/lean/lean.h
@@ -680,7 +680,7 @@ static inline b_lean_obj_res lean_ctor_get(b_lean_obj_arg o, unsigned i) {
 }
 
 static inline void lean_dec_ref_known(lean_object * o, unsigned objs) {
-    assert(lean_is_ref(o));
+    assert(!lean_is_scalar(o));
     if (lean_is_exclusive(o)) {
         for(unsigned i = 0; i < objs; i++) {
             lean_dec(lean_ctor_get(o, i));


### PR DESCRIPTION
Backport 714d4599e4a34e85646131f00d96e62e41b78a35 from #13975
