### PR TITLE
chore: CI: fix generation of releases in forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,7 +369,7 @@ jobs:
               },
               {
                 "name": "Linux aarch64",
-                "os": "nscloud-ubuntu-22.04-arm64-4x16",
+                "os": large ? "nscloud-ubuntu-22.04-arm64-4x16" : "ubuntu-24.04-arm",
                 "CMAKE_OPTIONS": "-DLEAN_INSTALL_SUFFIX=-linux_aarch64",
                 "release": true,
                 "enabled": level >= 2,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,6 +490,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update release.lean-lang.org
+        if: github.repository == 'leanprover/lean4'
         run: |
           gh workflow -R leanprover/release-index run update-index.yml
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,6 +477,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v7
         with:

--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -56,10 +56,17 @@ folder to gdb, or use `gdb $(elan which lean)`.
 
 It is also possible to generate releases that others can use,
 simply by pushing a tag to your fork of the Lean 4 github repository
-(and waiting about an hour; check the `Actions` tab for completion).
+(and waiting for some time; check the `Actions` tab for completion).
 If you push `my-tag` to a fork in your github account `my_name`,
 you can then put `my_name/lean4:my-tag` in your `lean-toolchain` file in a project using `lake`.
-(You must use a tag name that does not start with a numeral, or contain `_`).
+(You must use a tag name that does not start with a numeral, or contains `_`).
+
+Some tests that run when generating a release are a bit flaky and workflows
+occasionally have to be re-run. When the `master` branch of the official
+repository is in a state that cannot pass all tests, you can filter for
+`workflow:CI branch:master event:schedule` in the Actions tab of the official
+repository. That lists the scheduled nightly releases. There you can find a
+recent state of `master` that did pass the tests.
 
 ### VS Code
 

--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -59,14 +59,7 @@ simply by pushing a tag to your fork of the Lean 4 github repository
 (and waiting for some time; check the `Actions` tab for completion).
 If you push `my-tag` to a fork in your github account `my_name`,
 you can then put `my_name/lean4:my-tag` in your `lean-toolchain` file in a project using `lake`.
-(You must use a tag name that does not start with a numeral, or contains `_`).
-
-Some tests that run when generating a release are a bit flaky and workflows
-occasionally have to be re-run. When the `master` branch of the official
-repository is in a state that cannot pass all tests, you can filter for
-`workflow:CI branch:master event:schedule` in the Actions tab of the official
-repository. That lists the scheduled nightly releases. There you can find a
-recent state of `master` that did pass the tests.
+(You must use a tag name that does not start with a numeral, or contain `_`).
 
 ### VS Code
 


### PR DESCRIPTION
This PR fixes `ci.yml` so that the generation of releases in forks of the official repository works again:

The Linux aarch64 build unconditionally used the `nscloud-ubuntu-22.04-arm64-4x16` runner that is not GitHub-hosted. Add the GitHub-hosted runner `ubuntu-24.04-arm` as a fallback for when the CI is run in a fork. Unfortunately, there is no `ubuntu-latest-arm` GitHub-hosted runner, see [here](https://docs.github.com/en/actions/reference/runners/github-hosted-runners). So we have to explicitly specify (and maintain) a Ubuntu version here.

The "Update release.lean-lang.org" step of the `release` job was run unconditionally. That fails when run in a fork. Add a condition that only runs this step in the official repository.

`softprops/action-gh-release` requires the `contents: write` permission on the repository. Add the permission to the `release` job, so that the job works in forks without requiring the user to elevate default GitHub Action permissions.

Update the docs for generating releases in forks: Release builds using GitHub-hosted runners nowadays take considerably more than "about an hour" (up to 3 hours). Change that to "some time". Add a note about flaky tests that may require workflows to be rerun. And how to find a reasonably recent state of `master` that passed the tests that are run during a release.