### PR TITLE
chore: rewrite some `Fin` theorems to use `NeZero`

### DIFF
--- a/src/Init/Data/Fin/Lemmas.lean
+++ b/src/Init/Data/Fin/Lemmas.lean
@@ -459,7 +459,9 @@ theorem one_lt_succ_succ (a : Fin n) : (1 : Fin (n + 2)) < a.succ.succ := by
 @[simp] theorem lt_add_one_iff {n : Nat} {k : Fin (n + 1)} : k < k + 1 ↔ k < last n := by
   rw [← Decidable.not_iff_not]; simp
 
-@[simp] theorem le_zero_iff {n : Nat} [NeZero n] {k : Fin n} : k ≤ 0 ↔ k = 0 :=
+@[simp] theorem le_zero_iff {n : Nat} {k : Fin n} :
+    haveI : NeZero n := ⟨Nat.ne_zero_of_lt k.isLt⟩
+    k ≤ 0 ↔ k = 0 :=
   ⟨fun h => Fin.eq_of_val_eq <| Nat.eq_zero_of_le_zero h, (· ▸ Nat.le_refl _)⟩
 
 theorem succ_succ_ne_one (a : Fin n) : Fin.succ (Fin.succ a) ≠ 1 :=

--- a/src/Init/Data/Fin/Lemmas.lean
+++ b/src/Init/Data/Fin/Lemmas.lean
@@ -703,7 +703,7 @@ theorem natAdd_cast {n n' : Nat} (m : Nat) (i : Fin n') (h : n' = n) :
     natAdd m (i.cast h) = (natAdd m i).cast (congrArg _ h) := rfl
 
 theorem cast_natAdd_right {n n' m : Nat} (i : Fin n') (h : m + n' = m + n) :
-    (natAdd m i).cast h  = natAdd m (i.cast (Nat.add_left_cancel h)) := rfl
+    (natAdd m i).cast h = natAdd m (i.cast (Nat.add_left_cancel h)) := rfl
 
 @[simp] theorem cast_natAdd_left {n m m' : Nat} (i : Fin n) (h : m' + n = m + n) :
     (natAdd m' i).cast h = natAdd m i :=

--- a/src/Init/Data/Fin/Lemmas.lean
+++ b/src/Init/Data/Fin/Lemmas.lean
@@ -230,7 +230,7 @@ theorem mk_le_of_le_val {b : Fin n} {a : Nat} (h : a ≤ b) :
 
 @[simp] theorem val_zero (n : Nat) [NeZero n] : ((0 : Fin n) : Nat) = 0 := rfl
 
-@[simp] theorem mk_zero : (⟨0, Nat.succ_pos n⟩ : Fin (n + 1)) = 0 := rfl
+@[simp] theorem mk_zero [NeZero n] : (⟨0, Nat.pos_of_neZero n⟩ : Fin n) = 0 := rfl
 
 @[simp] theorem zero_le [NeZero n] (a : Fin n) : 0 ≤ a := Nat.zero_le a.val
 
@@ -418,7 +418,8 @@ grind_pattern val_succ => j.succ
 theorem succ_ne_zero {n} : ∀ k : Fin n, Fin.succ k ≠ 0
   | ⟨k, _⟩, heq => Nat.succ_ne_zero k <| congrArg Fin.val heq
 
-@[simp] theorem succ_zero_eq_one : Fin.succ (0 : Fin (n + 1)) = 1 := rfl
+@[simp] theorem succ_zero_eq_one [NeZero n] : Fin.succ (0 : Fin n) = 1 :=
+  n.casesOn (fun hn => (hn.out rfl).elim) (fun _ _ => rfl) hn
 
 /-- Version of `succ_one_eq_two` to be used by `dsimp` -/
 @[simp] theorem succ_one_eq_two : Fin.succ (1 : Fin (n + 2)) = 2 := rfl
@@ -458,7 +459,7 @@ theorem one_lt_succ_succ (a : Fin n) : (1 : Fin (n + 2)) < a.succ.succ := by
 @[simp] theorem lt_add_one_iff {n : Nat} {k : Fin (n + 1)} : k < k + 1 ↔ k < last n := by
   rw [← Decidable.not_iff_not]; simp
 
-@[simp] theorem le_zero_iff {n : Nat} {k : Fin (n + 1)} : k ≤ 0 ↔ k = 0 :=
+@[simp] theorem le_zero_iff {n : Nat} [NeZero n] {k : Fin n} : k ≤ 0 ↔ k = 0 :=
   ⟨fun h => Fin.eq_of_val_eq <| Nat.eq_zero_of_le_zero h, (· ▸ Nat.le_refl _)⟩
 
 theorem succ_succ_ne_one (a : Fin n) : Fin.succ (Fin.succ a) ≠ 1 :=
@@ -480,7 +481,9 @@ theorem coe_castLE (h : n ≤ m) (i : Fin n) : (castLE h i : Nat) = i := rfl
 @[simp] theorem castLE_mk (i n m : Nat) (hn : i < n) (h : n ≤ m) :
     castLE h ⟨i, hn⟩ = ⟨i, Nat.lt_of_lt_of_le hn h⟩ := rfl
 
-@[simp] theorem castLE_zero {n m : Nat} (h : n.succ ≤ m.succ) : castLE h 0 = 0 := by simp [Fin.ext_iff]
+@[simp] theorem castLE_zero {n m : Nat} [NeZero n] (h : n ≤ m) :
+    haveI : NeZero m := ⟨Nat.ne_zero_of_lt (Nat.lt_of_lt_of_le (Nat.pos_of_neZero n) h)⟩
+    castLE h 0 = 0 := rfl
 
 @[simp] theorem castLE_succ {m n : Nat} (h : m + 1 ≤ n + 1) (i : Fin m) :
     castLE h i.succ = (castLE (Nat.succ_le_succ_iff.mp h) i).succ := by simp [Fin.ext_iff]
@@ -508,7 +511,7 @@ theorem coe_cast (h : n = m) (i : Fin n) : (i.cast h : Nat) = i := rfl
 
 @[simp] theorem cast_zero [NeZero n] [NeZero m] (h : n = m) : Fin.cast h 0 = 0 := rfl
 
-@[simp] theorem cast_last {n' : Nat} {h : n + 1 = n' + 1} : (last n).cast h  = last n' :=
+@[simp] theorem cast_last {n' : Nat} {h : n + 1 = n' + 1} : (last n).cast h = last n' :=
   Fin.ext (by rw [val_cast, val_last, val_last, Nat.succ.inj h])
 
 @[simp] theorem cast_mk (h : n = m) (i : Nat) (hn : i < n) : Fin.cast h ⟨i, hn⟩ = ⟨i, h ▸ hn⟩ := rfl

--- a/src/Init/Data/Fin/Lemmas.lean
+++ b/src/Init/Data/Fin/Lemmas.lean
@@ -1217,9 +1217,9 @@ instance [NeZero n] : Std.LawfulIdentity (α := Fin n) (· * ·) 1 where
   right_id := Fin.mul_one
 
 protected theorem mul_zero [NeZero n] (k : Fin n) : k * 0 = 0 := by
-  simp [Fin.ext_iff, mul_def]
+  simp [mul_def]
 
 protected theorem zero_mul [NeZero n] (k : Fin n) : (0 : Fin n) * k = 0 := by
-  simp [Fin.ext_iff, mul_def]
+  simp [mul_def]
 
 end Fin

--- a/src/Init/Data/Fin/Lemmas.lean
+++ b/src/Init/Data/Fin/Lemmas.lean
@@ -418,7 +418,7 @@ grind_pattern val_succ => j.succ
 theorem succ_ne_zero {n} : ∀ k : Fin n, Fin.succ k ≠ 0
   | ⟨k, _⟩, heq => Nat.succ_ne_zero k <| congrArg Fin.val heq
 
-@[simp] theorem succ_zero_eq_one [NeZero n] : Fin.succ (0 : Fin n) = 1 :=
+@[simp] theorem succ_zero_eq_one [hn : NeZero n] : Fin.succ (0 : Fin n) = 1 :=
   n.casesOn (fun hn => (hn.out rfl).elim) (fun _ _ => rfl) hn
 
 /-- Version of `succ_one_eq_two` to be used by `dsimp` -/


### PR DESCRIPTION
<!--
# Read this section before submitting

* Ensure your PR follows the [External Contribution Guidelines](https://github.com/leanprover/lean4/blob/master/CONTRIBUTING.md).
* Please make sure the PR has excellent documentation and tests. If we label it `missing documentation` or `missing tests` then it needs fixing!
* Include the link to your `RFC` or `bug` issue in the description.
* If the issue does not already have approval from a developer, submit the PR as draft.
* The PR title/description will become the commit message. Keep it up-to-date as the PR evolves.
* For `feat/fix` PRs, the first paragraph starting with "This PR" must be present and will become a
  changelog entry unless the PR is labeled with `no-changelog`. If the PR does not have this label,
  it must instead be categorized with one of the `changelog-*` labels (which will be done by a
  reviewer for external PRs).
* A toolchain of the form `leanprover/lean4-pr-releases:pr-release-NNNN` for Linux and M-series Macs will be generated upon build. To generate binaries for Windows and Intel-based Macs as well, write a comment containing `release-ci` on its own line.
* If you rebase your PR onto `nightly-with-mathlib` then CI will test Mathlib against your PR.
* You can manage the `awaiting-review`, `awaiting-author`, and `WIP` labels yourself, by writing a comment containing one of these labels on its own line.
* Remove this section, up to and including the `---` before submitting.

---
-->
This PR rewrites some theorems so that instead of mentioning `Fin (n + 1)`, they instead are about `Fin n` where `[NeZero n]`, which is syntactically more general.

- The theorem [`Fin.mk_zero`](https://github.com/leanprover/lean4/blob/49bb2031db89ba0405d44f7e8a439f96f459b287/src/Init/Data/Fin/Lemmas.lean#L233) is changed to be the same as mathlib's [`Fin.mk_zero'`](https://github.com/leanprover-community/mathlib4/blob/6923f2f17585e9f2ef76e10ad91efe1b9cb8500d/Mathlib/Data/Fin/Basic.lean#L180-L184).
- The theorem [`Fin.succ_zero_eq_one`](https://github.com/leanprover/lean4/blob/49bb2031db89ba0405d44f7e8a439f96f459b287/src/Init/Data/Fin/Lemmas.lean#L421) is changed to be the same as mathlib's [`Fin.succ_zero_eq_one'`](https://github.com/leanprover-community/mathlib4/blob/6923f2f17585e9f2ef76e10ad91efe1b9cb8500d/Mathlib/Data/Fin/SuccPred.lean#L52-L56).
- The theorem [`Fin.le_zero_iff`](https://github.com/leanprover/lean4/blob/49bb2031db89ba0405d44f7e8a439f96f459b287/src/Init/Data/Fin/Lemmas.lean#L461-L462) is changed to assume `{n : Nat} {k : Fin n}` instead of `{n : Nat} {k : Fin (n + 1)}`, and the `[NeZero n]` required for `(0 : Fin n)` is proved inline from the other hypotheses, see for example leanprover-community/mathlib4#33079.
- The theorem [`Fin.castLE_zero`](https://github.com/leanprover/lean4/blob/49bb2031db89ba0405d44f7e8a439f96f459b287/src/Init/Data/Fin/Lemmas.lean#L483) is changed to assume `{n m : Nat} [NeZero n] (h : n ≤ m)` instead of `{n m : Nat} (h : n.succ ≤ m.succ)`, and the `[NeZero m]` required for `(0 : Fin m)` is proved inline from the other hypotheses.
- Remove a double space in [`Fin.cast_last`](https://github.com/leanprover/lean4/blob/49bb2031db89ba0405d44f7e8a439f96f459b287/src/Init/Data/Fin/Lemmas.lean#L511-L512) and [`Fin.cast_natAdd_right`](https://github.com/leanprover/lean4/blob/49bb2031db89ba0405d44f7e8a439f96f459b287/src/Init/Data/Fin/Lemmas.lean#L700-L701).
