### PR TITLE
feat: add support for `Nat.log2` in `simp` and `cbv`

### DIFF
--- a/src/Init/Data/Nat/Lemmas.lean
+++ b/src/Init/Data/Nat/Lemmas.lean
@@ -1365,6 +1365,12 @@ theorem lt_log2_self : n < 2 ^ (n.log2 + 1) :=
   | 0 => by simp
   | n+1 => (log2_lt n.succ_ne_zero).1 (Nat.le_refl _)
 
+theorem log2.simp_eval {a b : Nat} (hl : ((nat_lit 1).shiftLeft b).ble a = true)
+    (hr : ((nat_lit 1).shiftLeft b.succ).ble a = false) : a.log2 = b := by
+  simp only [Nat.shiftLeft_eq', Nat.one_shiftLeft, Nat.ble_eq, Nat.succ_eq_add_one,
+    ← Bool.not_eq_true, Nat.not_le] at hl hr
+  exact Nat.log2_eq_iff (Nat.ne_of_gt (Nat.lt_of_lt_of_le (Nat.two_pow_pos b) hl)) |>.mpr ⟨hl, hr⟩
+
 /-! ### mod, dvd -/
 
 theorem pow_dvd_pow_iff_pow_le_pow {k l : Nat} :

--- a/src/Init/Data/Nat/Log2.lean
+++ b/src/Init/Data/Nat/Log2.lean
@@ -38,7 +38,7 @@ Examples:
  * `Nat.log2 7 = 2`
  * `Nat.log2 8 = 3`
 -/
-@[expose, extern "lean_nat_log2"]
+@[expose, extern "lean_nat_log2", cbv_opaque]
 def log2 (n : @& Nat) : Nat :=
   -- Lean "assembly"
   n.rec (fun _ => nat_lit 0) (fun _ ih n =>

--- a/src/Lean/Meta/Sym/Simp/EvalGround.lean
+++ b/src/Lean/Meta/Sym/Simp/EvalGround.lean
@@ -321,6 +321,14 @@ def evalShift (left : Bool) (α β : Expr) (a b : Expr) : SimpM Result :=
     return .step e (mkApp2 (mkConst ``Eq.refl [1]) α e) (done := true)
   | _ => return .rfl
 
+def evalNatLog2 (a : Expr) : SimpM Result := do
+  let some va := getNatValue? a | return .rfl
+  if va = 0 then
+    return .step a (mkConst ``Nat.log2_zero)
+  else
+    let e ← share <| toExpr va.log2
+    return .step e (mkApp4 (mkConst ``Nat.log2.simp_eval) a e reflBoolTrue reflBoolFalse)
+
 def evalIntGcd (a b : Expr) : SimpM Result := do
   let some a := getIntValue? a | return .rfl
   let some b := getIntValue? b | return .rfl
@@ -566,6 +574,7 @@ public def evalGround (config : EvalStepConfig := {}) : Simproc := fun e =>
   | Complement.complement α _ a => evalComplement α a
   | Nat.gcd a b => evalBinNat Nat.gcd a b
   | Nat.succ a => evalUnaryNat (· + 1) a
+  | Nat.log2 a => evalNatLog2 a
   | Int.gcd a b => evalIntGcd a b
   | Int.tdiv a b => evalBinInt Int.tdiv a b
   | Int.fdiv a b => evalBinInt Int.fdiv a b

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Nat.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Nat.lean
@@ -363,4 +363,12 @@ builtin_simproc [simp, seval] reduceDvd ((_ : Nat) ∣ _) := fun e => do
   else
     return .done { expr := mkConst ``False, proof? := mkApp3 (mkConst ``Nat.dvd_eq_false_of_mod_ne_zero) a b eagerReflBoolTrue}
 
+builtin_simproc [simp, seval] reduceLog2 (Nat.log2 _) := fun e => do
+  let_expr Nat.log2 n ← e | return .continue
+  let some va ← fromExpr? n | return .continue
+  if va = 0 then
+    return .done { expr := toExpr 0, proof? := mkConst ``Nat.log2_zero }
+  else
+    return .done { expr := toExpr va.log2, proof? := mkApp4 (mkConst ``Nat.log2.simp_eval) n (toExpr va.log2) reflBoolTrue reflBoolFalse }
+
 end Nat

--- a/tests/elab/simprocNat.lean
+++ b/tests/elab/simprocNat.lean
@@ -110,6 +110,13 @@ variable (a b : Nat)
 #check_simp (a + 1000) != (b +  400) ~> a + 600 != b
 #check_simp (a +  400) != (b + 1000) ~> a != b + 600
 
+/- log2 tests -/
+
+#check_simp Nat.log2 0 ~> 0
+#check_simp Nat.log2 1 ~> 0
+#check_simp Nat.log2 16 ~> 4
+#check_simp Nat.log2 (1 <<< 10000 + 1 <<< 9999 + 3) ~> 10000
+
 /-! Alternate instance tests
 
 These check that the simplification rules will matching

--- a/tests/elab/sym_simp_2.lean
+++ b/tests/elab/sym_simp_2.lean
@@ -16,6 +16,7 @@ example : 17 % 5 = 2 := by sym_simp
 example : 2 ^ 10 = 1024 := by sym_simp
 example : Nat.succ 5 = 6 := by sym_simp
 example : Nat.gcd 12 18 = 6 := by sym_simp
+example : Nat.log2 13489 = 13 := by sym_simp
 
 -- Basic arithmetic: Int
 example : (2 : Int) + 3 = 5 := by sym_simp
@@ -171,9 +172,10 @@ example : ∀ n : Nat, (n = n) = True := by intro n; sym_simp
 example : ∀ n : Nat, (n ≠ n) = False := by intro n; sym_simp
 
 -- Edge cases
-example : 0 / 0 = 0 := by sym_simp  -- Nat division by zero
-example : 5 % 0 = 5 := by sym_simp  -- Nat mod by zero
-example : 0 ^ 0 = 1 := by sym_simp  -- 0^0 = 1 in Lean
+example : 0 / 0 = 0 := by sym_simp       -- Nat division by zero
+example : 5 % 0 = 5 := by sym_simp       -- Nat mod by zero
+example : 0 ^ 0 = 1 := by sym_simp       -- 0^0 = 1 in Lean
+example : Nat.log2 0 = 0 := by sym_simp  -- Logarithm of zero
 
 theorem ex₁ : (2 / 3 : Rat) + 2 / 3 = 8 / 6 := by sym_simp
 


### PR DESCRIPTION
This PR adds support for `Nat.log2` in `simp` (through a new simproc `Nat.reduceLog2`) and `cbv`. However, instead of just relying on the kernel to reduce the definition `Nat.log2`, we use a specialized lemma to reduce the problem `Nat.log2 a = b` to a (simpler for the kernel) problem `2^b <= a < 2^(b+1)`. This already produces speedups for small numbers that get more significant the larger the number is. For example:
```lean-4
example : Nat.log2 (1 <<< 100000 + 3) = 100000 := by decide +kernel
```
(i.e. evaluation by reduction) takes roughly 3 seconds while
```lean-4
example : Nat.log2 (1 <<< 100000 + 3) = 100000 := by cbv
```
now solves the same goal in a few milliseconds.