### PR TITLE
fix: generalize `eqRec_heq_iff` and `heq_eqRec_iff`

### DIFF
--- a/src/Init/Core.lean
+++ b/src/Init/Core.lean
@@ -991,7 +991,7 @@ equality on the original term.
 theorem eqRec_heq_iff {α : Sort u} {β : Sort v} {a : α} {motive : (b : α) → a = b → Sort v}
     {b : α} {refl : motive a (Eq.refl a)} {h : a = b} {c : β}
     : @Eq.rec α a motive refl b h ≍ c ↔ refl ≍ c :=
-  h.rec Iff.rfl
+  h.rec ⟨id, id⟩
 
 /--
 Heterogeneous equality with an `Eq.rec` application on the right is equivalent to a heterogeneous
@@ -1000,7 +1000,7 @@ equality on the original term.
 theorem heq_eqRec_iff {α : Sort u} {β : Sort v} {a : α} {motive : (b : α) → a = b → Sort v}
     {b : α} {refl : motive a (Eq.refl a)} {h : a = b} {c : β} :
     c ≍ @Eq.rec α a motive refl b h ↔ c ≍ refl :=
-  h.rec Iff.rfl
+  h.rec ⟨id, id⟩
 
 /--
 Moves an cast using `Eq.rec` from the function to the argument.

--- a/src/Init/Core.lean
+++ b/src/Init/Core.lean
@@ -988,19 +988,19 @@ theorem eqRec_heq {α : Sort u} {φ : α → Sort v} {a a' : α} : (h : a = a') 
 Heterogeneous equality with an `Eq.rec` application on the left is equivalent to a heterogeneous
 equality on the original term.
 -/
-theorem eqRec_heq_iff {α : Sort u} {a : α} {motive : (b : α) → a = b → Sort v}
-    {b : α} {refl : motive a (Eq.refl a)} {h : a = b} {c : motive b h}
+theorem eqRec_heq_iff {α : Sort u} {β : Sort v} {a : α} {motive : (b : α) → a = b → Sort v}
+    {b : α} {refl : motive a (Eq.refl a)} {h : a = b} {c : β}
     : @Eq.rec α a motive refl b h ≍ c ↔ refl ≍ c :=
-  h.rec (fun _ => ⟨id, id⟩) c
+  h.rec Iff.rfl
 
 /--
 Heterogeneous equality with an `Eq.rec` application on the right is equivalent to a heterogeneous
 equality on the original term.
 -/
-theorem heq_eqRec_iff {α : Sort u} {a : α} {motive : (b : α) → a = b → Sort v}
-    {b : α} {refl : motive a (Eq.refl a)} {h : a = b} {c : motive b h} :
+theorem heq_eqRec_iff {α : Sort u} {β : Sort v} {a : α} {motive : (b : α) → a = b → Sort v}
+    {b : α} {refl : motive a (Eq.refl a)} {h : a = b} {c : β} :
     c ≍ @Eq.rec α a motive refl b h ↔ c ≍ refl :=
-  h.rec (fun _ => ⟨id, id⟩) c
+  h.rec Iff.rfl
 
 /--
 Moves an cast using `Eq.rec` from the function to the argument.


### PR DESCRIPTION
<!--
# Read this section before submitting

* Ensure your PR follows the [External Contribution Guidelines](https://github.com/leanprover/lean4/blob/master/CONTRIBUTING.md).
* Please make sure the PR has excellent documentation and tests. If we label it `missing documentation` or `missing tests` then it needs fixing!
* Include the link to your `RFC` or `bug` issue in the description.
* If the issue does not already have approval from a developer, submit the PR as draft.
* The PR title/description will become the commit message. Keep it up-to-date as the PR evolves.
* For `feat/fix` PRs, the first paragraph starting with "This PR" must be present and will become a
  changelog entry unless the PR is labeled with `no-changelog`. If the PR does not have this label,
  it must instead be categorized with one of the `changelog-*` labels (which will be done by a
  reviewer for external PRs).
* A toolchain of the form `leanprover/lean4-pr-releases:pr-release-NNNN` for Linux and M-series Macs will be generated upon build. To generate binaries for Windows and Intel-based Macs as well, write a comment containing `release-ci` on its own line.
* If you rebase your PR onto `nightly-with-mathlib` then CI will test Mathlib against your PR.
* You can manage the `awaiting-review`, `awaiting-author`, and `WIP` labels yourself, by writing a comment containing one of these labels on its own line.
* Remove this section, up to and including the `---` before submitting.

---
-->

This PR generalizes the theorems [`eqRec_heq_iff`](https://github.com/leanprover/lean4/blob/9f1e8022b71e919870342562a89a6cb71e3e38c7/src/Init/Core.lean#L987-L994) and [`heq_eqRec_iff`](https://github.com/leanprover/lean4/blob/9f1e8022b71e919870342562a89a6cb71e3e38c7/src/Init/Core.lean#L996-L1003), so that they can be applied to heterogeneous equalities. Before this change, the statements of these lemmas require `h ▸ refl` and `c` to have the same type, meaning the equality on the left hand side of the iff is always a homogeneous equality. The new versions are the same as [`eqRec_heq_iff_heq`](https://github.com/leanprover-community/batteries/blob/c43d7789ff29244c1f6f7c8480342a2d2d6c0d30/Batteries/Logic.lean#L88-L92) and [`heq_eqRec_iff_heq`](https://github.com/leanprover-community/batteries/blob/c43d7789ff29244c1f6f7c8480342a2d2d6c0d30/Batteries/Logic.lean#L94-L98) in Batteries.
