### PR TITLE
refactor: clean up the Std.Internal.Do weakest-precondition library

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Attr.lean
+++ b/src/Lean/Elab/Tactic/Do/Attr.lean
@@ -294,7 +294,7 @@ Normalises a specification proof so its conclusion is in `pre ⊑ wp …` form.
 def tripleToWpProof? (proof type : Expr) : MetaM (Option (Expr × Expr)) := do
   let type ← whnfR type
   if type.isAppOfArity ``Triple 12 then
-    -- Build the `Triple.rel_wp` projection application explicitly from the `Triple` type's own
+    -- Build the `Triple.le_wp` projection application explicitly from the `Triple` type's own
     -- arguments rather than via `mkAppM`. `mkAppM` would re-synthesise the instance arguments
     -- (`Monad m`, `WPMonad m …`), which fails for transformer specs whose monad is a partially
     -- applied transformer with still-unassigned parameters (e.g. `ExceptT ?ε ?m` in
@@ -302,7 +302,7 @@ def tripleToWpProof? (proof type : Expr) : MetaM (Option (Expr × Expr)) := do
     -- caller has unified the spec's program against the goal. Reusing the type's arguments keeps
     -- those instance metavariables shared with the proof, so no premature synthesis happens.
     let lvls := type.getAppFn.constLevels!
-    let proof := mkAppN (.const ``Triple.rel_wp lvls) (type.getAppArgs.push proof)
+    let proof := mkAppN (.const ``Triple.le_wp lvls) (type.getAppArgs.push proof)
     let type ← instantiateMVars (← inferType proof)
     return some (proof, type)
   else if type.isAppOfArity ``PartialOrder.rel 4 then

--- a/src/Std/Internal/Do/Order/Basic.lean
+++ b/src/Std/Internal/Do/Order/Basic.lean
@@ -244,7 +244,7 @@ instance : PartialOrder Prop where
   rel_trans := fun h1 h2 x => h2 (h1 x)
   rel_antisymm := fun h1 h2 => propext ⟨h1, h2⟩
 
-@[simp] theorem entails_prop_eq_imp (p q : Prop) : (p ⊑ q) = (p → q) := rfl
+@[grind =, simp] theorem le_prop_eq_imp (p q : Prop) : (p ⊑ q) = (p → q) := rfl
 
 /-- Supremum for Prop: true iff some element of the set is true -/
 def propSup (c : Prop → Prop) : Prop := ∃ p, c p ∧ p
@@ -261,11 +261,20 @@ theorem propSup_is_sup (c : Prop → Prop) : is_sup c (propSup c) := by
 instance : CompleteLattice Prop where
   has_sup c := ⟨propSup c, propSup_is_sup c⟩
 
-theorem prop_pre_intro (x y : Prop) : (x → (⊤ : Prop) ⊑ y) → x ⊑ y :=
+theorem le_of_imp_top_le (x y : Prop) : (x → (⊤ : Prop) ⊑ y) → x ⊑ y :=
   fun h hx => h hx (le_top True trivial)
 
-theorem prop_pre_elim (x : Prop) : x → (⊤ : Prop) ⊑ x :=
+theorem top_le_prop (x : Prop) : x → (⊤ : Prop) ⊑ x :=
   fun hx _ => hx
+
+theorem le_of_right (x y : Prop) : y → x ⊑ y :=
+  fun hy _ => hy
+
+theorem of_top_le_prop {x : Prop} : (⊤ : Prop) ⊑ x → x :=
+  fun h => h (le_top True trivial)
+
+theorem true_le_of_top_le (x : Prop) : ((⊤ : Prop) ⊑ x) → (True : Prop) ⊑ x :=
+  fun h => le_of_right True x (of_top_le_prop h)
 
 @[simp] theorem iInf_prop_eq_forall {ι : Type u} (f : ι → Prop) :
     (iInf f : Prop) = (∀ i, f i) := by
@@ -325,6 +334,7 @@ theorem CompleteLattice.ofProp_true (l : Type v) [CompleteLattice l] : ⌜True�
 theorem CompleteLattice.ofProp_false (l : Type v) [CompleteLattice l] : ⌜False⌝ = (⊥ : l) := by
   simp [CompleteLattice.ofProp]
 
+@[grind .]
 theorem CompleteLattice.ofProp_imp [CompleteLattice l]
   (p₁ p₂ : Prop) : (p₁ → p₂) → ⌜p₁⌝ ⊑ (⌜p₂⌝ : l) := by
   simp only [CompleteLattice.ofProp]
@@ -388,6 +398,7 @@ theorem CompleteLattice.ofProp_intro_r [CompleteLattice l] (p : Prop) (x y : l) 
   simp only [CompleteLattice.ofProp]
   rcases Classical.em p with h | h <;> simp [h]
 
+@[grind .]
 theorem top_le_ofProp [CompleteLattice l] (p : Prop) : p → (⊤ : l) ⊑ ⌜p⌝ := by
   simp only [CompleteLattice.ofProp]
   rcases Classical.em p with h | h <;> simp [h]
@@ -405,6 +416,17 @@ theorem ofProp_le [CompleteLattice l] (p : Prop) (rhs : l) :
 /-- Entailment between functions is pointwise. -/
 theorem le_iff_forall_le {σ α : Type u} [PartialOrder α] {f g : σ → α} :
     (f ⊑ g) ↔ (∀ s, f s ⊑ g s) := Iff.rfl
+
+/-- Entailment between functions follows from pointwise entailment. -/
+theorem le_of_forall_le {σ α : Type u} [PartialOrder α] {f g : σ → α} :
+    (∀ s, f s ⊑ g s) → f ⊑ g := le_iff_forall_le.mpr
+
+/-- `⊤ ⊑ g` for a function `g` follows from pointwise `⊤ ⊑ g s`. -/
+theorem top_le_of_forall_top_le {σ α : Type u} [CompleteLattice α] {g : σ → α} :
+    (∀ s, (⊤ : α) ⊑ g s) → (⊤ : σ → α) ⊑ g := by
+  intro h s
+  rw [top_apply]
+  exact h s
 
 /-- The top element of the `Prop` lattice is `True`. Not a global `@[simp]` lemma: collapsing the
 lattice `⊤`/`⊥`/`⌜·⌝` to `True`/`False`/`p` would change how `mvcgen` discharge lattice

--- a/src/Std/Internal/Do/Triple/Basic.lean
+++ b/src/Std/Internal/Do/Triple/Basic.lean
@@ -37,7 +37,7 @@ structure Triple [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EP
   /-- Construct a triple from a weakest precondition entailment. -/
   intro ::
   /-- The weakest precondition entailment witnessing the triple. -/
-  rel_wp : pre ⊑ wp x post epost
+  le_wp : pre ⊑ wp x post epost
 
 /-- Hoare triple notation without exception postcondition (defaults to `⊥`). -/
 scoped notation:60 "⦃ " pre " ⦄ " x " ⦃ " post " ⦄" => Triple pre x post Lean.Order.bot
@@ -103,6 +103,16 @@ theorem bind (x : m α) (f : α → m β)
   apply PartialOrder.rel_trans (WPMonad.wp_consequence x mid (fun a => wp (f a) post epost) epost
     (fun a => iff.mp (hf a)))
   exact WPMonad.wp_bind x f post epost
+
+theorem map (f : α → β) (x : m α)
+    (h : Triple pre x (fun a => post (f a)) epost) :
+    Triple pre (f <$> x) post epost :=
+  iff.mpr (PartialOrder.rel_trans (iff.mp h) (WPMonad.wp_map f x post epost))
+
+theorem seq (x : m (α → β)) (y : m α)
+    (h : Triple pre x (fun f => wp y (fun a => post (f a)) epost) epost) :
+    Triple pre (x <*> y) post epost :=
+  iff.mpr (PartialOrder.rel_trans (iff.mp h) (WPMonad.wp_seq x y post epost))
 
 end Triple
 

--- a/src/Std/Internal/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Internal/Do/Triple/SpecLemmas.lean
@@ -51,67 +51,52 @@ variable {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
 
 variable [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
 
-theorem Spec.pure' (a : α) (h : pre ⊑ post a) :
-    Triple pre (Pure.pure (f := m) a) post epost :=
-  Triple.pure a h
-
-
+@[spec]
 theorem Spec.pure (a : α) :
     Triple (post a) (Pure.pure (f := m) a) post epost :=
-  Spec.pure' a PartialOrder.rel_refl
+  Triple.pure a PartialOrder.rel_refl
 
-theorem Spec.bind' (x : m α) (f : α → m β)
-    (h : Triple pre x (fun a => wp (f a) post epost) epost) :
-    Triple pre (x >>= f) post epost :=
-  Triple.bind x f (fun a => wp (f a) post epost) h (fun _ => Triple.iff.mpr PartialOrder.rel_refl)
-
-
+@[spec]
 theorem Spec.bind (x : m α) (f : α → m β) :
     Triple (wp x (fun a => wp (f a) post epost) epost) (x >>= f) post epost :=
-  Spec.bind' x f (Triple.iff.mpr PartialOrder.rel_refl)
+  Triple.bind x f (fun a => wp (f a) post epost)
+    (Triple.iff.mpr PartialOrder.rel_refl) (fun _ => Triple.iff.mpr PartialOrder.rel_refl)
 
-
-theorem Spec.map' (f : α → β) (x : m α)
-    (h : Triple pre x (fun a => post (f a)) epost) :
-    Triple pre (f <$> x) post epost :=
-  Triple.iff.mpr (PartialOrder.rel_trans (Triple.iff.mp h) (WPMonad.wp_map f x post epost))
-
-
+@[spec]
 theorem Spec.map (f : α → β) (x : m α) :
     Triple (wp x (fun a => post (f a)) epost) (f <$> x) post epost :=
-  Spec.map' f x (Triple.iff.mpr PartialOrder.rel_refl)
+  Triple.map f x (Triple.iff.mpr PartialOrder.rel_refl)
 
-theorem Spec.seq' (x : m (α → β)) (y : m α)
-    (h : Triple pre x (fun f => wp y (fun a => post (f a)) epost) epost) :
-    Triple pre (x <*> y) post epost :=
-  Triple.iff.mpr (PartialOrder.rel_trans (Triple.iff.mp h) (WPMonad.wp_seq x y post epost))
-
-
+@[spec]
 theorem Spec.seq (x : m (α → β)) (y : m α) :
     Triple (wp x (fun f => wp y (fun a => post (f a)) epost) epost) (x <*> y) post epost :=
-  Spec.seq' x y (Triple.iff.mpr PartialOrder.rel_refl)
+  Triple.seq x y (Triple.iff.mpr PartialOrder.rel_refl)
 
 /-! # `MonadLift` -/
 
 
+@[spec]
 theorem Spec.monadLift_StateT (x : m α) (post : α → σ → Pred) :
     Triple (fun s => wp x (fun a => post a s) epost) (MonadLift.monadLift x : StateT σ m α) post epost :=
-  Triple.iff.mpr (WPMonad.monadLift_StateT_wp x post)
+  Triple.iff.mpr (WPMonad.le_wp_monadLift_StateT_apply x post)
 
 
+@[spec]
 theorem Spec.monadLift_ReaderT (x : m α) (post : α → ρ → Pred) :
     Triple (fun r => wp x (fun a => post a r) epost) (MonadLift.monadLift x : ReaderT ρ m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.monadLift_ReaderT_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_monadLift_ReaderT_apply_eq]; rfl)
 
 
+@[spec]
 theorem Spec.monadLift_ExceptT (x : m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (wp x post epost.tail) (MonadLift.monadLift x : ExceptT ε m α) post epost :=
-  Triple.iff.mpr (WPMonad.monadLift_ExceptT_wp x post epost)
+  Triple.iff.mpr (WPMonad.le_wp_monadLift_ExceptT_apply x post epost)
 
 
+@[spec]
 theorem Spec.monadLift_OptionT (x : m α) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (wp x post epost.tail) (MonadLift.monadLift x : OptionT m α) post epost :=
-  Triple.iff.mpr (WPMonad.monadLift_OptionT_wp x)
+  Triple.iff.mpr (WPMonad.le_wp_monadLift_OptionT_apply x)
 
 /-! # `MonadLiftT` -/
 
@@ -128,93 +113,106 @@ theorem Spec.UnfoldLift.monadLift_refl (x : m α) :
 attribute [refl] PartialOrder.rel_refl
 
 
+@[spec]
 theorem Spec.monadMap_StateT
     (f : ∀{β}, m β → m β) {α} (x : StateT σ m α) (post : α → σ → Pred) :
     Triple (fun s => wp (f (x.run s)) (fun (a, s') => post a s') epost)
       (MonadFunctor.monadMap (m := m) f x : StateT σ m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.monadMap_StateT_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_monadMap_StateT_apply_eq]; rfl)
 
 
+@[spec]
 theorem Spec.monadMap_ReaderT
     (f : ∀{β}, m β → m β) {α} (x : ReaderT ρ m α) (post : α → ρ → Pred) :
     Triple (fun r => wp (f (x.run r)) (fun a => post a r) epost)
       (MonadFunctor.monadMap (m := m) f x : ReaderT ρ m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.monadMap_ReaderT_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_monadMap_ReaderT_apply_eq]; rfl)
 
 
+@[spec]
 theorem Spec.monadMap_ExceptT
     (f : ∀{β}, m β → m β) {α} (x : ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (wp (f x.run) (epost.pushExcept post) epost.tail)
       (MonadFunctor.monadMap (m := m) f x : ExceptT ε m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.monadMap_ExceptT_wp])
+  Triple.iff.mpr (by rw [WPMonad.wp_monadMap_ExceptT_apply_eq])
 
 
+@[spec]
 theorem Spec.monadMap_OptionT
     (f : ∀{β}, m β → m β) {α} (x : OptionT m α) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (wp (f x.run) (epost.pushOption post) epost.tail)
       (MonadFunctor.monadMap (m := m) f x : OptionT m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.monadMap_OptionT_wp])
+  Triple.iff.mpr (by rw [WPMonad.wp_monadMap_OptionT_apply_eq])
 
 
 
+@[spec]
 theorem Spec.monadMap_refl (x : m α) :
     Triple (wp (f x : m α) post epost)
       (MonadFunctorT.monadMap f x : m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.monadMap_refl_wp])
+  Triple.iff.mpr (by rw [WPMonad.wp_monadMap_refl_apply_eq])
 
 /-! # `MonadControl` -/
 
 
+@[spec]
 theorem Spec.liftWith_StateT
     (f : (∀{β}, StateT σ m β → m (β × σ)) → m α) (post : α → σ → Pred) :
     Triple (fun s => wp (f (fun x => x.run s)) (fun a => post a s) epost)
       (MonadControl.liftWith (m:=m) f : StateT σ m α) post epost :=
-  Triple.iff.mpr (by intro s; simp [WPMonad.liftWith_StateT_wp f]; apply WPMonad.wp_map'; ext; rfl)
+  Triple.iff.mpr (by intro s; simp [WPMonad.wp_liftWith_StateT_apply_eq f]; apply WPMonad.wp_map'; ext; rfl)
 
 
+@[spec]
 theorem Spec.liftWith_ReaderT
     (f : (∀{β}, ReaderT ρ m β → m β) → m α) (post : α → ρ → Pred) :
     Triple (fun r => wp (f (fun x => x.run r)) (fun a => post a r) epost)
       (MonadControl.liftWith (m:=m) f : ReaderT ρ m α) post epost :=
-  Triple.iff.mpr (by intro r; simp [WPMonad.liftWith_ReaderT_wp f]; rfl)
+  Triple.iff.mpr (by intro r; simp [WPMonad.wp_liftWith_ReaderT_apply_eq f]; rfl)
 
 
+@[spec]
 theorem Spec.liftWith_ExceptT
     (f : (∀{β}, ExceptT ε m β → m (Except ε β)) → m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (wp (f (fun x => x.run)) post epost.tail)
       (MonadControl.liftWith (m:=m) f : ExceptT ε m α) post epost :=
-  Triple.iff.mpr (by simp [WPMonad.liftWith_ExceptT_wp f]; apply WPMonad.wp_map'; ext; rfl)
+  Triple.iff.mpr (by simp [WPMonad.wp_liftWith_ExceptT_apply_eq f]; apply WPMonad.wp_map'; ext; rfl)
 
 
+@[spec]
 theorem Spec.liftWith_OptionT
     (f : (∀{β}, OptionT m β → m (Option β)) → m α) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (wp (f (fun x => x.run)) post epost.tail)
       (MonadControl.liftWith (m:=m) f : OptionT m α) post epost :=
-  Triple.iff.mpr (WPMonad.liftWith_OptionT_wp f)
+  Triple.iff.mpr (WPMonad.le_wp_liftWith_OptionT_apply f)
 
 
+@[spec]
 theorem Spec.restoreM_StateT (x : m (α × σ)) (post : α → σ → Pred) :
     Triple (fun _ => wp x (fun (a, s) => post a s) epost)
       (MonadControl.restoreM (m:=m) x : StateT σ m α) post epost :=
-  Triple.iff.mpr (WPMonad.restoreM_StateT_wp x)
+  Triple.iff.mpr (WPMonad.le_wp_restoreM_StateT_apply x)
 
 
+@[spec]
 theorem Spec.restoreM_ReaderT (x : m α) (post : α → ρ → Pred) :
     Triple (fun r => wp x (fun a => post a r) epost)
       (MonadControl.restoreM (m:=m) x : ReaderT ρ m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.restoreM_ReaderT_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_restoreM_ReaderT_apply_eq]; rfl)
 
 
+@[spec]
 theorem Spec.restoreM_ExceptT (x : m (@Except.{u, u} ε α)) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (wp x (epost.pushExcept post) epost.tail)
       (MonadControl.restoreM (m:=m) x : ExceptT ε m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.restoreM_ExceptT_wp])
+  Triple.iff.mpr (by rw [WPMonad.wp_restoreM_ExceptT_apply_eq])
 
 
+@[spec]
 theorem Spec.restoreM_OptionT (x : m (Option α)) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (wp x (epost.pushOption post) epost.tail)
       (MonadControl.restoreM (m:=m) x : OptionT m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.restoreM_OptionT_wp])
+  Triple.iff.mpr (by rw [WPMonad.wp_restoreM_OptionT_apply_eq])
 
 /-! # `MonadControlT` -/
 
@@ -224,18 +222,19 @@ theorem Spec.liftWith_refl
     (f : (∀{β}, m β → m β) → m α) :
     Triple (wp (f (fun x => x) : m α) post epost)
       (MonadControlT.liftWith (m:=m) f : m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.liftWith_refl_wp])
+  Triple.iff.mpr (by rw [WPMonad.wp_liftWith_refl_apply_eq])
 
 
 
 theorem Spec.restoreM_refl (x : stM m m α) :
     Triple (wp (Pure.pure x : m α) post epost)
       (MonadControlT.restoreM (m:=m) x : m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.restoreM_refl_wp])
+  Triple.iff.mpr (by rw [WPMonad.wp_restoreM_refl_apply_eq])
 
 /-! # `ReaderT` -/
 
 
+@[spec]
 theorem Spec.read_ReaderT (post : ρ → ρ → Pred) :
     Triple (fun r => post r r)
       (MonadReaderOf.read : ReaderT ρ m ρ) post epost :=
@@ -245,17 +244,18 @@ theorem Spec.read_ReaderT (post : ρ → ρ → Pred) :
 theorem Spec.withReader_ReaderT (f : ρ → ρ) (x : ReaderT ρ m α) (post : α → ρ → Pred) :
     Triple (fun r => wp x (fun a _ => post a r) epost (f r))
       (MonadWithReaderOf.withReader f x : ReaderT ρ m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.withReader_ReaderT_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_withReader_ReaderT_apply_eq]; rfl)
 
 
 theorem Spec.adapt_ReaderT (f : ρ → ρ') (x : ReaderT ρ' m α) (post : α → ρ → Pred) :
     Triple (fun r => wp x (fun a _ => post a r) epost (f r))
       (ReaderT.adapt f x : ReaderT ρ m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.adapt_ReaderT_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_adapt_ReaderT_apply_eq]; rfl)
 
 /-! # `StateT` -/
 
 
+@[spec]
 theorem Spec.get_StateT (post : σ → σ → Pred) :
     Triple (fun s => post s s)
       (MonadStateOf.get : StateT σ m σ) post epost :=
@@ -264,6 +264,7 @@ theorem Spec.get_StateT (post : σ → σ → Pred) :
       (post := fun x => post x.fst x.snd) (epost := epost)))
 
 
+@[spec]
 theorem Spec.set_StateT (s : σ) (post : PUnit → σ → Pred) :
     Triple (fun _ => post ⟨⟩ s)
       (set s : StateT σ m PUnit) post epost :=
@@ -272,6 +273,7 @@ theorem Spec.set_StateT (s : σ) (post : PUnit → σ → Pred) :
       (post := fun x => post x.fst x.snd) (epost := epost)))
 
 
+@[spec]
 theorem Spec.modifyGet_StateT (f : σ → α × σ) (post : α → σ → Pred) :
     Triple (fun s => post (f s).1 (f s).2)
       (MonadStateOf.modifyGet f : StateT σ m α) post epost :=
@@ -306,6 +308,7 @@ theorem Spec.UnfoldLift.withReader [MonadFunctor m n] [MonadWithReaderOf ρ m] (
 /-! # `ExceptT` -/
 
 
+@[spec]
 theorem Spec.run_ExceptT (x : ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (wp x post epost)
       (x.run : m (@Except.{u, u} ε α))
@@ -314,6 +317,7 @@ theorem Spec.run_ExceptT (x : ExceptT ε m α) (post : α → Pred) (epost : EPo
   Triple.iff.mpr (by simp [PartialOrder.rel_refl])
 
 
+@[spec]
 theorem Spec.throw_ExceptT (err : ε) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (epost.head err) (MonadExceptOf.throw err : ExceptT ε m α) post epost :=
   Triple.iff.mpr (by simpa [EPost.Cons.pushExcept] using!
@@ -322,37 +326,43 @@ theorem Spec.throw_ExceptT (err : ε) (post : α → Pred) (epost : EPost.Cons (
       (epost := epost.tail)))
 
 
+@[spec]
 theorem Spec.tryCatch_ExceptT (x : ExceptT ε m α) (h : ε → ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (wp x post ⟨fun e => wp (h e) post epost, epost.tail⟩)
       (MonadExceptOf.tryCatch x h : ExceptT ε m α) post epost :=
-  Triple.iff.mpr (WPMonad.tryCatch_ExceptT_wp x h)
+  Triple.iff.mpr (WPMonad.le_wp_tryCatch_ExceptT_apply x h)
 
 
+@[spec]
 theorem Spec.orElse_ExceptT (x : ExceptT ε m α) (h : Unit → ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (wp x post ⟨fun _ => wp (h ()) post epost, epost.tail⟩)
       (OrElse.orElse x h : ExceptT ε m α) post epost :=
-  Triple.iff.mpr (WPMonad.orElse_ExceptT_wp x h)
+  Triple.iff.mpr (WPMonad.le_wp_orElse_ExceptT_apply x h)
 
 
+@[spec]
 theorem Spec.adapt_ExceptT (f : ε → ε') (x : ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε' → Pred) EPred) :
     Triple (wp x post ⟨fun e => epost.head (f e), epost.tail⟩)
       (ExceptT.adapt f x : ExceptT ε' m α) post epost :=
-  Triple.iff.mpr (WPMonad.adapt_ExceptT_wp f x)
+  Triple.iff.mpr (WPMonad.le_wp_adapt_ExceptT_apply f x)
 
 /-! # `Except` -/
 
 
+@[spec]
 theorem Spec.throw_Except (err : ε) :
     Triple (epost.head err) (MonadExceptOf.throw err : Except ε α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.throw_Except_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_throw_Except_apply_eq]; rfl)
 
 
+@[spec]
 theorem Spec.tryCatch_Except (x : Except ε α) (h : ε → Except ε α) :
     Triple (wp x post epost⟨fun e => wp (h e) post epost⟩)
       (MonadExceptOf.tryCatch x h : Except ε α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.tryCatch_Except_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_tryCatch_Except_apply_eq]; rfl)
 
 
+@[spec]
 theorem Spec.orElse_Except (x : Except ε α) (h : Unit → Except ε α) :
     Triple (wp x post epost⟨fun (_ : ε) => wp (h ()) post epost⟩)
       (OrElse.orElse x h : Except ε α) post epost :=
@@ -361,99 +371,112 @@ theorem Spec.orElse_Except (x : Except ε α) (h : Unit → Except ε α) :
 /-! # `OptionT` -/
 
 
+@[spec]
 theorem Spec.run_OptionT (x : OptionT m α) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (wp x post epost)
       (x.run : m (Option α))
       (epost.pushOption post)
       epost.tail :=
-  Triple.iff.mpr (by rw [← OptionT.apply_wp])
+  Triple.iff.mpr (by rw [← OptionT.wp_apply_eq])
 
 
+@[spec]
 theorem Spec.throw_OptionT (err : PUnit) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple epost.head (MonadExceptOf.throw err : OptionT m α) post epost :=
-  Triple.iff.mpr (WPMonad.throw_OptionT_wp err)
+  Triple.iff.mpr (WPMonad.le_wp_throw_OptionT_apply err)
 
 
+@[spec]
 theorem Spec.tryCatch_OptionT (x : OptionT m α) (h : PUnit → OptionT m α) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (wp x post ⟨wp (h ⟨⟩) post epost, epost.tail⟩)
       (MonadExceptOf.tryCatch x h : OptionT m α) post epost :=
-  Triple.iff.mpr (WPMonad.tryCatch_OptionT_wp x h)
+  Triple.iff.mpr (WPMonad.le_wp_tryCatch_OptionT_apply x h)
 
 
+@[spec]
 theorem Spec.orElse_OptionT (x : OptionT m α) (h : Unit → OptionT m α) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (wp x post ⟨wp (h ()) post epost, epost.tail⟩)
       (OrElse.orElse x h : OptionT m α) post epost :=
-  Triple.iff.mpr (WPMonad.orElse_OptionT_wp x h)
+  Triple.iff.mpr (WPMonad.le_wp_orElse_OptionT_apply x h)
 
 /-! # `Option` -/
 
 
+@[spec]
 theorem Spec.throw_Option (err : PUnit) :
     Triple epost (MonadExceptOf.throw err : Option α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.throw_Option_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_throw_Option_apply_eq]; rfl)
 
 
+@[spec]
 theorem Spec.tryCatch_Option (x : Option α) (h : PUnit → Option α) :
     Triple (wp x post (wp (h ⟨⟩) post epost))
       (MonadExceptOf.tryCatch x h : Option α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.tryCatch_Option_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_tryCatch_Option_apply_eq]; rfl)
 
 
+@[spec]
 theorem Spec.orElse_Option (x : Option α) (h : Unit → Option α) (post : α → Prop) (epost : Prop) :
     Triple (wp x post (wp (h ()) post epost))
       (OrElse.orElse x h : Option α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.orElse_Option_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_orElse_Option_apply_eq]; rfl)
 
 /-! # `EStateM` -/
 
 
+@[spec]
 theorem Spec.get_EStateM (post : σ → σ → Prop) (epost : ε → σ → Prop) :
     Triple (fun s => post s s)
       (MonadStateOf.get : EStateM ε σ σ) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.get_EStateM_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_get_EStateM_apply_eq]; rfl)
 
 
+@[spec]
 theorem Spec.set_EStateM (s : σ) (post : PUnit → σ → Prop) (epost : ε → σ → Prop) :
     Triple (fun _ => post ⟨⟩ s)
       (MonadStateOf.set s : EStateM ε σ PUnit) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.set_EStateM_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_set_EStateM_apply_eq]; rfl)
 
 
+@[spec]
 theorem Spec.modifyGet_EStateM (f : σ → α × σ) (post : α → σ → Prop) (epost : ε → σ → Prop) :
     Triple (fun s => post (f s).1 (f s).2)
       (MonadStateOf.modifyGet f : EStateM ε σ α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.modifyGet_EStateM_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_modifyGet_EStateM_apply_eq]; rfl)
 
 
+@[spec]
 theorem Spec.throw_EStateM (err : ε) (post : α → σ → Prop) (epost : ε → σ → Prop) :
     Triple (epost err) (MonadExceptOf.throw err : EStateM ε σ α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.throw_EStateM_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_throw_EStateM_apply_eq]; rfl)
 
 
+@[spec]
 theorem Spec.tryCatch_EStateM (x : EStateM ε σ α) (h : ε → EStateM ε σ α)
     (post : α → σ → Prop) (epost : ε → σ → Prop) :
     Triple (fun s => wp x post (fun e s' => wp (h e) post epost s') s)
       (MonadExceptOf.tryCatch x h : EStateM ε σ α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.tryCatch_EStateM_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_tryCatch_EStateM_apply_eq]; rfl)
 
 
 theorem Spec.orElse_EStateM (x : EStateM ε σ α) (h : Unit → EStateM ε σ α)
     (post : α → σ → Prop) (epost : ε → σ → Prop) :
     Triple (fun s => wp x post (fun _ s' => wp (h ()) post epost s') s)
       (OrElse.orElse x h : EStateM ε σ α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.orElse_EStateM_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_orElse_EStateM_apply_eq]; rfl)
 
 
 theorem Spec.adaptExcept_EStateM (f : ε → ε') (x : EStateM ε σ α)
     (post : α → σ → Prop) (epost : ε' → σ → Prop) :
     Triple (wp x post (fun e => epost (f e)))
       (EStateM.adaptExcept f x : EStateM ε' σ α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.adaptExcept_EStateM_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_adaptExcept_EStateM_apply_eq]; rfl)
 
 /-! # Lifting `MonadExceptOf` -/
 
 
 
+@[spec]
 theorem Spec.throw_MonadExcept [MonadExceptOf ε m] (err : ε) :
     Triple (wp (MonadExceptOf.throw err : m α) post epost)
       (throw err : m α) post epost :=
@@ -464,70 +487,79 @@ theorem Spec.throw_MonadExcept [MonadExceptOf ε m] (err : ε) :
 theorem Spec.tryCatch_MonadExcept [MonadExceptOf ε m] (x : m α) (h : ε → m α) :
     Triple (wp (MonadExceptOf.tryCatch x h : m α) post epost)
       (tryCatch x h : m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.tryCatch_MonadExcept_wp])
+  Triple.iff.mpr (by rw [WPMonad.wp_tryCatch_MonadExcept_apply_eq])
 
 
+@[spec]
 theorem Spec.throw_ReaderT [MonadExceptOf ε m] (err : ε) (post : α → ρ → Pred) :
     Triple (wp (MonadLift.monadLift (MonadExceptOf.throw (ε:=ε) err : m α) : ReaderT ρ m α) post epost)
       (MonadExceptOf.throw (ε:=ε) err : ReaderT ρ m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.throw_ReaderT_lift_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_throw_ReaderT_lift_apply_eq]; rfl)
 
 
+@[spec]
 theorem Spec.throw_StateT [MonadExceptOf ε m] (err : ε) (post : α → σ → Pred) :
     Triple (wp (MonadLift.monadLift (MonadExceptOf.throw (ε:=ε) err : m α) : StateT σ m α) post epost)
       (MonadExceptOf.throw (ε:=ε) err : StateT σ m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.throw_StateT_lift_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_throw_StateT_lift_apply_eq]; rfl)
 
 
+@[spec]
 theorem Spec.throw_ExceptT_lift [MonadExceptOf ε m] (err : ε) (post : α → Pred) (epost : EPost.Cons (ε' → Pred) EPred) :
     Triple (wp (MonadExceptOf.throw (ε:=ε) err : m (@Except.{u, u} ε' α))
         (fun r => match r with | .ok a => post a | .error e => epost.head e) epost.tail)
       (MonadExceptOf.throw (ε:=ε) err : ExceptT ε' m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.throw_lift_ExceptT_wp]; apply WPMonad.wp_consequence; intro r; cases r <;> rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_throw_lift_ExceptT_apply_eq]; apply WPMonad.wp_consequence; intro r; cases r <;> rfl)
 
 
+@[spec]
 theorem Spec.throw_Option_lift [MonadExceptOf ε m] (err : ε) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (wp (MonadExceptOf.throw (ε:=ε) err : m (Option α))
         (epost.pushOption post) epost.tail)
       (MonadExceptOf.throw (ε:=ε) err : OptionT m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.throw_lift_OptionT_wp])
+  Triple.iff.mpr (by rw [WPMonad.wp_throw_lift_OptionT_apply_eq])
 
 
+@[spec]
 theorem Spec.tryCatch_ReaderT [MonadExceptOf ε m] (x : ReaderT ρ m α) (h : ε → ReaderT ρ m α)
     (post : α → ρ → Pred) :
     Triple (fun r => wp (MonadExceptOf.tryCatch (ε:=ε) (x.run r) (fun e => (h e).run r) : m α)
         (fun a => post a r) epost)
       (MonadExceptOf.tryCatch (ε:=ε) x h : ReaderT ρ m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.tryCatch_ReaderT_lift_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_tryCatch_ReaderT_lift_apply_eq]; rfl)
 
 
+@[spec]
 theorem Spec.tryCatch_StateT [MonadExceptOf ε m] (x : StateT σ m α) (h : ε → StateT σ m α)
     (post : α → σ → Pred) :
     Triple (fun s => wp (MonadExceptOf.tryCatch (ε:=ε) (x.run s) (fun e => (h e).run s) : m (α × σ))
         (fun (a, s') => post a s') epost)
       (MonadExceptOf.tryCatch (ε:=ε) x h : StateT σ m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.tryCatch_StateT_lift_wp]; rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_tryCatch_StateT_lift_apply_eq]; rfl)
 
 
+@[spec]
 theorem Spec.tryCatch_ExceptT_lift [MonadExceptOf ε m] (x : ExceptT ε' m α) (h : ε → ExceptT ε' m α)
     (post : α → Pred) (epost : EPost.Cons (ε' → Pred) EPred) :
     Triple (wp (MonadExceptOf.tryCatch (ε:=ε) x h : m (@Except.{u, u} ε' α))
         (fun | .ok a => post a | .error e => epost.head e) epost.tail)
       (MonadExceptOf.tryCatch (ε:=ε) x h : ExceptT ε' m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.tryCatch_lift_ExceptT_wp]; apply WPMonad.wp_consequence; intro r; cases r <;> rfl)
+  Triple.iff.mpr (by rw [WPMonad.wp_tryCatch_lift_ExceptT_apply_eq]; apply WPMonad.wp_consequence; intro r; cases r <;> rfl)
 
 
+@[spec]
 theorem Spec.tryCatch_OptionT_lift [MonadExceptOf ε m] (x : OptionT m α) (h : ε → OptionT m α)
     (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (wp (MonadExceptOf.tryCatch (ε:=ε) x h : m (Option α))
         (epost.pushOption post) epost.tail)
       (MonadExceptOf.tryCatch (ε:=ε) x h : OptionT m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.tryCatch_lift_OptionT_wp])
+  Triple.iff.mpr (by rw [WPMonad.wp_tryCatch_lift_OptionT_apply_eq])
 
 -- /-! # `MonadFunctorT` / `MonadControlT` transitivity -/
 
 
 
+@[spec]
 theorem Spec.monadMap_trans
     {n₁ : Type u → Type v} {n₂ : Type u → Type v}
     [MonadFunctor n₁ m] [MonadFunctorT n₂ n₁]
@@ -535,32 +567,36 @@ theorem Spec.monadMap_trans
     (x : m α) :
     Triple (wp (MonadFunctor.monadMap (m:=n₁) (MonadFunctorT.monadMap (m:=n₂) f) x : m α) post epost)
       (MonadFunctorT.monadMap (m:=n₂) f x : m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.monadMap_trans_wp])
+  Triple.iff.mpr (by rw [WPMonad.wp_monadMap_trans_apply_eq])
 
 
 
+@[spec]
 theorem Spec.liftWith_trans
     {n₁ : Type u → Type v} {n₂ : Type u → Type v}
     [MonadControl n₁ m] [MonadControlT n₂ n₁]
     (f : (∀{β}, m β → n₂ (stM n₂ m β)) → n₂ α) :
     Triple (wp (MonadControl.liftWith (m:=n₁) fun x₂ => MonadControlT.liftWith fun x₁ => f (x₁ ∘ x₂) : m α) post epost)
       (MonadControlT.liftWith (m:=n₂) f : m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.liftWith_trans_wp])
+  Triple.iff.mpr (by rw [WPMonad.wp_liftWith_trans_apply_eq])
 
 
+@[spec]
 theorem Spec.restoreM_trans
     {n₁ : Type u → Type v} {n₂ : Type u → Type v}
     [MonadControl n₁ m] [MonadControlT n₂ n₁]
     (x : stM n₂ m α) :
     Triple (wp (MonadControl.restoreM (m:=n₁) (MonadControlT.restoreM (m:=n₂) x) : m α) post epost)
       (MonadControlT.restoreM (m:=n₂) x : m α) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.restoreM_trans_wp])
+  Triple.iff.mpr (by rw [WPMonad.wp_restoreM_trans_apply_eq])
 
 end Std.Internal.Do
 
 -- /-! # `ForIn` -/
 
 namespace Std.Internal.Do
+
+open Lean.Order
 
 universe u₁ u₂ v
 
@@ -572,30 +608,43 @@ A loop invariant maps the iteration cursor and accumulator state to an assertion
 The exception postcondition is specified separately as the spec's `epost` parameter. -/
 @[spec_invariant_type, simp, grind =]
 def Invariant {α : Type u₁} (xs : List α) (β : Type u₂) (Pred : Type (max u₁ u₂)) :=
-  (List.Cursor xs × β → Pred)
+  List.Cursor xs → β → Pred
 
+/-- An invariant combinator for loops with early return, for the new `do` elaborator which
+uses `Prod` for the state tuple: `onContinue` is the invariant while iterating, `onReturn`
+holds once the loop returned early with a value. -/
+noncomputable abbrev Invariant.withEarlyReturnNewDo {α : Type u₁} {xs : List α} {β : Type u₂}
+    {γ : Type u₂} (Pred) [Assertion Pred]
+    (onContinue : List.Cursor xs → β → Pred)
+    (onReturn : γ → β → Pred) :
+    Invariant xs (Option γ × β) Pred :=
+  fun xs ⟨x, b⟩ =>
+        (⌜x = none⌝ ⊓ onContinue xs b)
+      ⊔ (iSup fun r => ⌜x = some r ∧ xs.suffix = []⌝ ⊓ onReturn r b)
+
+@[spec]
 theorem Spec.forIn'_list
     {xs : List α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
     (inv : Invariant xs β Pred)
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur (by simp [h]) b)
         (fun r => match r with
-                 | .yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-                 | .done b' => inv (⟨xs, [], by simp⟩, b'))
+                 | .yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+                 | .done b' => inv ⟨xs, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs, rfl⟩, init))
+      (inv ⟨[], xs, rfl⟩ init)
       (forIn' xs init f)
-      (fun b => inv (⟨xs, [], by simp⟩, b))
+      (fun b => inv ⟨xs, [], by simp⟩ b)
       epost := by
   suffices h : ∀ c,
       Triple
-        (inv (c, init))
+        (inv c init)
         (forIn' (m:=m) c.suffix init (fun a ha => f a (by simp [←c.property, ha])))
-        (fun b => inv (⟨xs, [], by simp⟩, b))
+        (fun b => inv ⟨xs, [], by simp⟩ b)
         epost
     from h ⟨[], xs, rfl⟩
   rintro ⟨pref, suff, h⟩
@@ -628,27 +677,28 @@ theorem Spec.forIn'_list_const_inv
         (fun r => match r with | .yield b' => inv b' | .done b' => inv b')
         epost) :
     Triple (inv init) (forIn' xs init f) inv epost :=
-  Spec.forIn'_list (fun p => inv p.2)
+  Spec.forIn'_list (fun _ b => inv b)
     (fun _p c _s h b => step c (by rw [h]; exact List.mem_append_right _ (List.Mem.head _)) b)
 
 
 
+@[spec]
 theorem Spec.forIn_list
     {xs : List α} {init : β} {f : α → β → m (ForInStep β)}
     (inv : Invariant xs β Pred)
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur b)
         (fun r => match r with
-          | .yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | .done b' => inv (⟨xs, [], by simp⟩, b'))
+          | .yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | .done b' => inv ⟨xs, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs, rfl⟩, init))
+      (inv ⟨[], xs, rfl⟩ init)
       (forIn xs init f)
-      (fun b => inv (⟨xs, [], by simp⟩, b))
+      (fun b => inv ⟨xs, [], by simp⟩ b)
       epost := by
   simp only [← forIn'_eq_forIn]
   exact Spec.forIn'_list inv step
@@ -666,30 +716,31 @@ theorem Spec.forIn_list_const_inv
         (fun r => match r with | .yield b' => inv b' | .done b' => inv b')
         epost) :
     Triple (inv init) (forIn xs init f) inv epost :=
-  Spec.forIn_list (fun p => inv p.2) (fun _p c _s _h b => step c b)
+  Spec.forIn_list (fun _ b => inv b) (fun _p c _s _h b => step c b)
 
 
+@[spec]
 theorem Spec.foldlM_list [LawfulMonad m]
     {xs : List α} {init : β} {f : β → α → m β}
     (inv : Invariant xs β Pred)
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f b cur)
-        (fun b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b'))
+        (fun b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs, rfl⟩, init))
+      (inv ⟨[], xs, rfl⟩ init)
       (List.foldlM f init xs)
-      (fun b => inv (⟨xs, [], by simp⟩, b))
+      (fun b => inv ⟨xs, [], by simp⟩ b)
       epost := by
   have : xs.foldlM f init = forIn xs init (fun a b => ForInStep.yield <$> f b a) := by
     simp [List.forIn_yield_eq_foldlM, id_map']
   rw [this]
   apply Spec.forIn_list inv
   intros
-  apply Spec.map'
+  apply Triple.map
   apply step <;> assumption
 
 
@@ -704,9 +755,10 @@ theorem Spec.foldlM_list_const_inv [LawfulMonad m]
         (fun b' => inv b')
         epost) :
     Triple (inv init) (List.foldlM f init xs) inv epost :=
-    Spec.foldlM_list (fun p => inv p.2) (fun _p c _s _h b => step c b)
+    Spec.foldlM_list (fun _ b => inv b) (fun _p c _s _h b => step c b)
 
 
+@[spec]
 theorem Spec.forIn'_range {β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {xs : Std.Legacy.Range} {init : β} {f : (a : Nat) → a ∈ xs → β → m (ForInStep β)}
@@ -714,21 +766,22 @@ theorem Spec.forIn'_range {β : Type u} {m : Type u → Type v} {Pred : Type u} 
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur (by simp [Std.Legacy.Range.mem_of_mem_range', h]) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn' xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [Std.Legacy.Range.forIn'_eq_forIn'_range', Std.Legacy.Range.size, Std.Legacy.Range.size.eq_1]
   exact Spec.forIn'_list inv (fun c hcur b => step c hcur b)
 
 
+@[spec]
 theorem Spec.forIn_range {β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {xs : Std.Legacy.Range} {init : β} {f : Nat → β → m (ForInStep β)}
@@ -736,22 +789,23 @@ theorem Spec.forIn_range {β : Type u} {m : Type u → Type v} {Pred : Type u} {
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [Std.Legacy.Range.forIn_eq_forIn_range', Std.Legacy.Range.size]
   exact Spec.forIn_list inv step
 
 open Std Std.PRange in
 
+@[spec]
 theorem Spec.forIn'_rcc {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
@@ -761,22 +815,23 @@ theorem Spec.forIn'_rcc {α β : Type u} {m : Type u → Type v} {Pred : Type u}
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur (by simp [← Rcc.mem_toList_iff_mem, h]) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn' xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [Rcc.forIn'_eq_forIn'_toList]
   exact Spec.forIn'_list inv step
 
 open Std Std.PRange in
 
+@[spec]
 theorem Spec.forIn_rcc {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
@@ -786,22 +841,23 @@ theorem Spec.forIn_rcc {α β : Type u} {m : Type u → Type v} {Pred : Type u} 
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [forIn]
   exact Spec.forIn'_rcc inv step
 
 open Std Std.PRange in
 
+@[spec]
 theorem Spec.forIn'_rco {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [LE α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
@@ -811,22 +867,23 @@ theorem Spec.forIn'_rco {α β : Type u} {m : Type u → Type v} {Pred : Type u}
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur (by simp [← Rco.mem_toList_iff_mem, h]) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn' xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [Rco.forIn'_eq_forIn'_toList]
   exact Spec.forIn'_list inv step
 
 open Std Std.PRange in
 
+@[spec]
 theorem Spec.forIn_rco {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [LE α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
@@ -836,22 +893,23 @@ theorem Spec.forIn_rco {α β : Type u} {m : Type u → Type v} {Pred : Type u} 
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [forIn]
   exact Spec.forIn'_rco inv step
 
 open Std Std.PRange in
 
+@[spec]
 theorem Spec.forIn'_rci {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [LE α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
@@ -861,22 +919,23 @@ theorem Spec.forIn'_rci {α β : Type u} {m : Type u → Type v} {Pred : Type u}
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur (by simp [← Rci.mem_toList_iff_mem, h]) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn' xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [Rci.forIn'_eq_forIn'_toList]
   exact Spec.forIn'_list inv step
 
 open Std Std.PRange in
 
+@[spec]
 theorem Spec.forIn_rci {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [LE α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
@@ -886,22 +945,23 @@ theorem Spec.forIn_rci {α β : Type u} {m : Type u → Type v} {Pred : Type u} 
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [forIn]
   exact Spec.forIn'_rci inv step
 
 open Std Std.PRange in
 
+@[spec]
 theorem Spec.forIn'_roc {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [LE α] [DecidableLE α] [LT α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
@@ -911,16 +971,16 @@ theorem Spec.forIn'_roc {α β : Type u} {m : Type u → Type v} {Pred : Type u}
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur (by simp [← Roc.mem_toList_iff_mem, h]) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn' xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [Roc.forIn'_eq_forIn'_toList]
   exact Spec.forIn'_list inv step
@@ -936,22 +996,23 @@ theorem Spec.forIn_roc {α β : Type u} {m : Type u → Type v} {Pred : Type u} 
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [forIn]
   exact Spec.forIn'_roc inv step
 
 open Std Std.PRange in
 
+@[spec]
 theorem Spec.forIn'_roo {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
@@ -961,22 +1022,23 @@ theorem Spec.forIn'_roo {α β : Type u} {m : Type u → Type v} {Pred : Type u}
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur (by simp [← Roo.mem_toList_iff_mem, h]) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn' xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [Roo.forIn'_eq_forIn'_toList]
   exact Spec.forIn'_list inv step
 
 open Std Std.PRange in
 
+@[spec]
 theorem Spec.forIn_roo {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
@@ -986,22 +1048,23 @@ theorem Spec.forIn_roo {α β : Type u} {m : Type u → Type v} {Pred : Type u} 
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [forIn]
   exact Spec.forIn'_roo inv step
 
 open Std Std.PRange in
 
+@[spec]
 theorem Spec.forIn'_roi {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
@@ -1011,22 +1074,23 @@ theorem Spec.forIn'_roi {α β : Type u} {m : Type u → Type v} {Pred : Type u}
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur (by simp [← Roi.mem_toList_iff_mem, h]) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn' xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [Roi.forIn'_eq_forIn'_toList]
   exact Spec.forIn'_list inv step
 
 open Std Std.PRange in
 
+@[spec]
 theorem Spec.forIn_roi {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
@@ -1036,22 +1100,23 @@ theorem Spec.forIn_roi {α β : Type u} {m : Type u → Type v} {Pred : Type u} 
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [forIn]
   exact Spec.forIn'_roi inv step
 
 open Std Std.PRange in
 
+@[spec]
 theorem Spec.forIn'_ric {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [Least? α] [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
@@ -1061,22 +1126,23 @@ theorem Spec.forIn'_ric {α β : Type u} {m : Type u → Type v} {Pred : Type u}
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur (by simp [← Ric.mem_toList_iff_mem, h]) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn' xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [Ric.forIn'_eq_forIn'_toList]
   exact Spec.forIn'_list inv step
 
 open Std Std.PRange in
 
+@[spec]
 theorem Spec.forIn_ric {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [Least? α] [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
@@ -1086,22 +1152,23 @@ theorem Spec.forIn_ric {α β : Type u} {m : Type u → Type v} {Pred : Type u} 
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [forIn]
   exact Spec.forIn'_ric inv step
 
 open Std Std.PRange in
 
+@[spec]
 theorem Spec.forIn'_rio {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [Least? α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
@@ -1111,22 +1178,23 @@ theorem Spec.forIn'_rio {α β : Type u} {m : Type u → Type v} {Pred : Type u}
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur (by simp [← Rio.mem_toList_iff_mem, h]) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn' xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [Rio.forIn'_eq_forIn'_toList]
   exact Spec.forIn'_list inv step
 
 open Std Std.PRange in
 
+@[spec]
 theorem Spec.forIn_rio {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [Least? α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
@@ -1136,22 +1204,23 @@ theorem Spec.forIn_rio {α β : Type u} {m : Type u → Type v} {Pred : Type u} 
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [forIn]
   exact Spec.forIn'_rio inv step
 
 open Std Std.PRange in
 
+@[spec]
 theorem Spec.forIn'_rii {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [Least? α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
@@ -1161,22 +1230,23 @@ theorem Spec.forIn'_rii {α β : Type u} {m : Type u → Type v} {Pred : Type u}
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur (by simp [Rii.mem]) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn' xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [Rii.forIn'_eq_forIn'_toList]
   exact Spec.forIn'_list inv step
 
 open Std Std.PRange in
 
+@[spec]
 theorem Spec.forIn_rii {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [Least? α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
@@ -1186,22 +1256,23 @@ theorem Spec.forIn_rii {α β : Type u} {m : Type u → Type v} {Pred : Type u} 
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur b)
         (fun r => match r with
-          | ForInStep.yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | ForInStep.done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   simp only [forIn]
   exact Spec.forIn'_rii inv step
 
 open Std Std.Iterators in
 
+@[spec]
 theorem Spec.forIn_slice {δ : Type u} {m : Type u → Type w} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     {γ : Type u'} {α β : Type u}
@@ -1216,14 +1287,14 @@ theorem Spec.forIn_slice {δ : Type u} {m : Type u → Type w} {Pred : Type u} {
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur b)
         (fun r => match r with
-          | .yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | .done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | .yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | .done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
-    Triple (inv (⟨[], xs.toList, rfl⟩, init)) (forIn xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b)) epost := by
+    Triple (inv ⟨[], xs.toList, rfl⟩ init) (forIn xs init f)
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b) epost := by
   simp only [← Slice.forIn_toList]
   exact Spec.forIn_list inv step
 
@@ -1231,6 +1302,7 @@ section Iterators
 open Std Std.Iterators
 
 
+@[spec low]
 theorem Spec.forIn_iter {α β γ : Type u} {m : Type u → Type w} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [Iterator α Id β] [Finite α Id] [IteratorLoop α Id m] [LawfulIteratorLoop α Id m]
@@ -1240,18 +1312,19 @@ theorem Spec.forIn_iter {α β γ : Type u} {m : Type u → Type w} {Pred : Type
     {epost : EPred}
     (step : ∀ pref cur suff (h : it.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur b)
         (fun r => match r with
-          | .yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | .done b' => inv (⟨it.toList, [], by simp⟩, b'))
+          | .yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | .done b' => inv ⟨it.toList, [], by simp⟩ b')
         epost) :
-    Triple (inv (⟨[], it.toList, rfl⟩, init)) (forIn it init f)
-      (fun b => inv (⟨it.toList, [], by simp⟩, b)) epost := by
+    Triple (inv ⟨[], it.toList, rfl⟩ init) (forIn it init f)
+      (fun b => inv ⟨it.toList, [], by simp⟩ b) epost := by
   simp only [← Iter.forIn_toList]
   exact Spec.forIn_list inv step
 
 
+@[spec low]
 theorem Spec.forIn_iterM_id {α β γ : Type u} {m : Type u → Type w} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [Iterator α Id β] [Finite α Id] [IteratorLoop α Id m] [LawfulIteratorLoop α Id m]
@@ -1261,20 +1334,21 @@ theorem Spec.forIn_iterM_id {α β γ : Type u} {m : Type u → Type w} {Pred : 
     {epost : EPred}
     (step : ∀ pref cur suff (h : it.toList.run = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur b)
         (fun r => match r with
-          | .yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | .done b' => inv (⟨it.toList.run, [], by simp⟩, b'))
+          | .yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | .done b' => inv ⟨it.toList.run, [], by simp⟩ b')
         epost) :
-    Triple (inv (⟨[], it.toList.run, rfl⟩, init)) (forIn it init f)
-      (fun b => inv (⟨it.toList.run, [], by simp⟩, b)) epost := by
+    Triple (inv ⟨[], it.toList.run, rfl⟩ init) (forIn it init f)
+      (fun b => inv ⟨it.toList.run, [], by simp⟩ b) epost := by
   conv in forIn it init f =>
     rw [← Iter.toIterM_toIter (it := it), ← Iter.forIn_eq_forIn_toIterM, ← Iter.forIn_toList,
       IterM.toList_toIter]
   exact Spec.forIn_list inv step
 
 
+@[spec low]
 theorem Spec.foldM_iter {α β γ : Type u} {m : Type u → Type w} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [Iterator α Id β] [Finite α Id] [IteratorLoop α Id m] [LawfulIteratorLoop α Id m]
@@ -1284,16 +1358,17 @@ theorem Spec.foldM_iter {α β γ : Type u} {m : Type u → Type w} {Pred : Type
     {epost : EPred}
     (step : ∀ pref cur suff (h : it.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f b cur)
-        (fun b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b'))
+        (fun b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b')
         epost) :
-    Triple (inv (⟨[], it.toList, rfl⟩, init)) (it.foldM f init)
-      (fun b => inv (⟨it.toList, [], by simp⟩, b)) epost := by
+    Triple (inv ⟨[], it.toList, rfl⟩ init) (it.foldM f init)
+      (fun b => inv ⟨it.toList, [], by simp⟩ b) epost := by
   rw [← Iter.foldlM_toList]
   exact Spec.foldlM_list inv step
 
 
+@[spec low]
 theorem Spec.foldM_iterM_id {α β γ : Type u} {m : Type u → Type w} {Pred : Type u} {EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
     [Iterator α Id β] [Finite α Id] [IteratorLoop α Id m] [LawfulIteratorLoop α Id m]
@@ -1303,16 +1378,17 @@ theorem Spec.foldM_iterM_id {α β γ : Type u} {m : Type u → Type w} {Pred : 
     {epost : EPred}
     (step : ∀ pref cur suff (h : it.toList.run = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f b cur)
-        (fun b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b'))
+        (fun b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b')
         epost) :
-    Triple (inv (⟨[], it.toList.run, rfl⟩, init)) (it.foldM f init)
-      (fun b => inv (⟨it.toList.run, [], by simp⟩, b)) epost := by
+    Triple (inv ⟨[], it.toList.run, rfl⟩ init) (it.foldM f init)
+      (fun b => inv ⟨it.toList.run, [], by simp⟩ b) epost := by
   rw [← IterM.foldlM_toList]
   exact Spec.foldlM_list inv step
 
 
+@[spec]
 theorem Spec.IterM.forIn_filterMapWithPostcondition {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
@@ -1332,6 +1408,7 @@ theorem Spec.IterM.forIn_filterMapWithPostcondition {α β β₂ γ : Type w}
   rwa [Std.IterM.forIn_filterMapWithPostcondition]
 
 
+@[spec]
 theorem Spec.IterM.forIn_filterMapM {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
@@ -1352,6 +1429,7 @@ theorem Spec.IterM.forIn_filterMapM {α β β₂ γ : Type w}
   rwa [Std.IterM.forIn_filterMapM]
 
 
+@[spec]
 theorem Spec.IterM.forIn_filterMap {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1369,6 +1447,7 @@ theorem Spec.IterM.forIn_filterMap {α β β₂ γ : Type w}
   rwa [Std.IterM.forIn_filterMap]
 
 
+@[spec]
 theorem Spec.IterM.forIn_mapWithPostcondition {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
@@ -1385,6 +1464,7 @@ theorem Spec.IterM.forIn_mapWithPostcondition {α β β₂ γ : Type w}
   rwa [Std.IterM.forIn_mapWithPostcondition]
 
 
+@[spec]
 theorem Spec.IterM.forIn_mapM {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
@@ -1402,6 +1482,7 @@ theorem Spec.IterM.forIn_mapM {α β β₂ γ : Type w}
   rwa [Std.IterM.forIn_mapM]
 
 
+@[spec]
 theorem Spec.IterM.forIn_map {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1415,6 +1496,7 @@ theorem Spec.IterM.forIn_map {α β β₂ γ : Type w}
   rwa [Std.IterM.forIn_map]
 
 
+@[spec]
 theorem Spec.IterM.forIn_filterWithPostcondition {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
@@ -1431,6 +1513,7 @@ theorem Spec.IterM.forIn_filterWithPostcondition {α β γ : Type w}
   rwa [Std.IterM.forIn_filterWithPostcondition]
 
 
+@[spec]
 theorem Spec.IterM.forIn_filterM {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
@@ -1448,6 +1531,7 @@ theorem Spec.IterM.forIn_filterM {α β γ : Type w}
   rwa [Std.IterM.forIn_filterM]
 
 
+@[spec]
 theorem Spec.IterM.forIn_filter {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1461,6 +1545,7 @@ theorem Spec.IterM.forIn_filter {α β γ : Type w}
   rwa [Std.IterM.forIn_filter]
 
 
+@[spec]
 theorem Spec.IterM.foldM_filterMapWithPostcondition {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
@@ -1480,6 +1565,7 @@ theorem Spec.IterM.foldM_filterMapWithPostcondition {α β γ δ : Type w}
   rwa [Std.IterM.foldM_filterMapWithPostcondition]
 
 
+@[spec]
 theorem Spec.IterM.foldM_filterMapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
@@ -1501,6 +1587,7 @@ theorem Spec.IterM.foldM_filterMapM {α β γ δ : Type w}
   rwa [Std.IterM.foldM_filterMapM]
 
 
+@[spec]
 theorem Spec.IterM.foldM_mapWithPostcondition {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
@@ -1518,6 +1605,7 @@ theorem Spec.IterM.foldM_mapWithPostcondition {α β γ δ : Type w}
   rwa [Std.IterM.foldM_mapWithPostcondition]
 
 
+@[spec]
 theorem Spec.IterM.foldM_mapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
@@ -1537,6 +1625,7 @@ theorem Spec.IterM.foldM_mapM {α β γ δ : Type w}
   rwa [Std.IterM.foldM_mapM]
 
 
+@[spec]
 theorem Spec.IterM.foldM_filterWithPostcondition {α β δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
@@ -1554,6 +1643,7 @@ theorem Spec.IterM.foldM_filterWithPostcondition {α β δ : Type w}
   rwa [Std.IterM.foldM_filterWithPostcondition]
 
 
+@[spec]
 theorem Spec.IterM.foldM_filterM {α β δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
@@ -1573,6 +1663,7 @@ theorem Spec.IterM.foldM_filterM {α β δ : Type w}
   rwa [Std.IterM.foldM_filterM]
 
 
+@[spec]
 theorem Spec.IterM.foldM_filterMap {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1589,6 +1680,7 @@ theorem Spec.IterM.foldM_filterMap {α β γ δ : Type w}
   rwa [Std.IterM.foldM_filterMap]
 
 
+@[spec]
 theorem Spec.IterM.foldM_map {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1602,6 +1694,7 @@ theorem Spec.IterM.foldM_map {α β γ δ : Type w}
   rwa [Std.IterM.foldM_map]
 
 
+@[spec]
 theorem Spec.IterM.foldM_filter {α β δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1616,6 +1709,7 @@ theorem Spec.IterM.foldM_filter {α β δ : Type w}
   rwa [Std.IterM.foldM_filter]
 
 
+@[spec]
 theorem Spec.IterM.fold_filterMapWithPostcondition {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1633,6 +1727,7 @@ theorem Spec.IterM.fold_filterMapWithPostcondition {α β γ δ : Type w}
   rwa [Std.IterM.fold_filterMapWithPostcondition]
 
 
+@[spec]
 theorem Spec.IterM.fold_filterMapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1650,6 +1745,7 @@ theorem Spec.IterM.fold_filterMapM {α β γ δ : Type w}
   rwa [Std.IterM.fold_filterMapM]
 
 
+@[spec]
 theorem Spec.IterM.fold_mapWithPostcondition {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1665,6 +1761,7 @@ theorem Spec.IterM.fold_mapWithPostcondition {α β γ δ : Type w}
   rwa [Std.IterM.fold_mapWithPostcondition]
 
 
+@[spec]
 theorem Spec.IterM.fold_mapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1680,6 +1777,7 @@ theorem Spec.IterM.fold_mapM {α β γ δ : Type w}
   rwa [Std.IterM.fold_mapM]
 
 
+@[spec]
 theorem Spec.IterM.fold_filterWithPostcondition {α β δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1695,6 +1793,7 @@ theorem Spec.IterM.fold_filterWithPostcondition {α β δ : Type w}
   rwa [Std.IterM.fold_filterWithPostcondition]
 
 
+@[spec]
 theorem Spec.IterM.fold_filterM {α β δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1710,6 +1809,7 @@ theorem Spec.IterM.fold_filterM {α β δ : Type w}
   rwa [Std.IterM.fold_filterM]
 
 
+@[spec]
 theorem Spec.IterM.fold_filterMap {α β γ δ : Type w}
     {m : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
@@ -1725,6 +1825,7 @@ theorem Spec.IterM.fold_filterMap {α β γ δ : Type w}
   rwa [Std.IterM.fold_filterMap]
 
 
+@[spec]
 theorem Spec.IterM.fold_map {α β γ δ : Type w}
     {m : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
@@ -1737,6 +1838,7 @@ theorem Spec.IterM.fold_map {α β γ δ : Type w}
   rwa [Std.IterM.fold_map]
 
 
+@[spec]
 theorem Spec.IterM.fold_filter {α β δ : Type w}
     {m : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
@@ -1749,6 +1851,7 @@ theorem Spec.IterM.fold_filter {α β δ : Type w}
   rwa [Std.IterM.fold_filter]
 
 
+@[spec]
 theorem Spec.Iter.forIn_filterMapWithPostcondition {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1766,6 +1869,7 @@ theorem Spec.Iter.forIn_filterMapWithPostcondition {α β β₂ γ : Type w}
   rwa [Std.Iter.forIn_filterMapWithPostcondition]
 
 
+@[spec]
 theorem Spec.Iter.forIn_filterMapM {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1784,6 +1888,7 @@ theorem Spec.Iter.forIn_filterMapM {α β β₂ γ : Type w}
   rwa [Std.Iter.forIn_filterMapM]
 
 
+@[spec]
 theorem Spec.Iter.forIn_filterMap {α β β₂ γ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
@@ -1800,6 +1905,7 @@ theorem Spec.Iter.forIn_filterMap {α β β₂ γ : Type w}
   rwa [Std.Iter.forIn_filterMap]
 
 
+@[spec]
 theorem Spec.Iter.forIn_mapWithPostcondition {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1814,6 +1920,7 @@ theorem Spec.Iter.forIn_mapWithPostcondition {α β β₂ γ : Type w}
   rwa [Std.Iter.forIn_mapWithPostcondition]
 
 
+@[spec]
 theorem Spec.Iter.forIn_mapM {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1830,6 +1937,7 @@ theorem Spec.Iter.forIn_mapM {α β β₂ γ : Type w}
   rwa [Std.Iter.forIn_mapM]
 
 
+@[spec]
 theorem Spec.Iter.forIn_map {α β β₂ γ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
@@ -1843,6 +1951,7 @@ theorem Spec.Iter.forIn_map {α β β₂ γ : Type w}
   rwa [Std.Iter.forIn_map]
 
 
+@[spec]
 theorem Spec.Iter.forIn_filterWithPostcondition {α β γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1857,6 +1966,7 @@ theorem Spec.Iter.forIn_filterWithPostcondition {α β γ : Type w}
   rwa [Std.Iter.forIn_filterWithPostcondition]
 
 
+@[spec]
 theorem Spec.Iter.forIn_filterM {α β γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1872,6 +1982,7 @@ theorem Spec.Iter.forIn_filterM {α β γ : Type w}
   rwa [Std.Iter.forIn_filterM]
 
 
+@[spec]
 theorem Spec.Iter.forIn_filter {α β γ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
@@ -1885,6 +1996,7 @@ theorem Spec.Iter.forIn_filter {α β γ : Type w}
   rwa [Std.Iter.forIn_filter]
 
 
+@[spec]
 theorem Spec.Iter.foldM_filterMapWithPostcondition {α β γ δ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1902,6 +2014,7 @@ theorem Spec.Iter.foldM_filterMapWithPostcondition {α β γ δ : Type w}
   rwa [Std.Iter.foldM_filterMapWithPostcondition]
 
 
+@[spec]
 theorem Spec.Iter.foldM_filterMapM {α β γ δ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1920,6 +2033,7 @@ theorem Spec.Iter.foldM_filterMapM {α β γ δ : Type w}
   rwa [Std.Iter.foldM_filterMapM]
 
 
+@[spec]
 theorem Spec.Iter.foldM_mapWithPostcondition {α β γ δ : Type w}
     {m : Type w → Type w'''} {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1935,6 +2049,7 @@ theorem Spec.Iter.foldM_mapWithPostcondition {α β γ δ : Type w}
   rwa [Std.Iter.foldM_mapWithPostcondition (m := m)]
 
 
+@[spec]
 theorem Spec.Iter.foldM_mapM {α β γ δ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1951,6 +2066,7 @@ theorem Spec.Iter.foldM_mapM {α β γ δ : Type w}
   rwa [Std.Iter.foldM_mapM]
 
 
+@[spec]
 theorem Spec.Iter.foldM_filterWithPostcondition {α β δ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1966,6 +2082,7 @@ theorem Spec.Iter.foldM_filterWithPostcondition {α β δ : Type w}
   rwa [Std.Iter.foldM_filterWithPostcondition]
 
 
+@[spec]
 theorem Spec.Iter.foldM_filterM {α β δ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
@@ -1982,6 +2099,7 @@ theorem Spec.Iter.foldM_filterM {α β δ : Type w}
   rwa [Std.Iter.foldM_filterM]
 
 
+@[spec]
 theorem Spec.Iter.foldM_filterMap {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
@@ -1997,6 +2115,7 @@ theorem Spec.Iter.foldM_filterMap {α β γ δ : Type w}
   rwa [Std.Iter.foldM_filterMap]
 
 
+@[spec]
 theorem Spec.Iter.foldM_map {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
@@ -2009,6 +2128,7 @@ theorem Spec.Iter.foldM_map {α β γ δ : Type w}
   rwa [Std.Iter.foldM_map]
 
 
+@[spec]
 theorem Spec.Iter.foldM_filter {α β δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
@@ -2021,6 +2141,7 @@ theorem Spec.Iter.foldM_filter {α β δ : Type w}
   rwa [Std.Iter.foldM_filter]
 
 
+@[spec]
 theorem Spec.Iter.fold_filterMapWithPostcondition {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
@@ -2036,6 +2157,7 @@ theorem Spec.Iter.fold_filterMapWithPostcondition {α β γ δ : Type w}
   rwa [Std.Iter.fold_filterMapWithPostcondition]
 
 
+@[spec]
 theorem Spec.Iter.fold_filterMapM {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
@@ -2051,6 +2173,7 @@ theorem Spec.Iter.fold_filterMapM {α β γ δ : Type w}
   rwa [Std.Iter.fold_filterMapM]
 
 
+@[spec]
 theorem Spec.Iter.fold_mapWithPostcondition {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
@@ -2064,6 +2187,7 @@ theorem Spec.Iter.fold_mapWithPostcondition {α β γ δ : Type w}
   rwa [Std.Iter.fold_mapWithPostcondition]
 
 
+@[spec]
 theorem Spec.Iter.fold_mapM {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
@@ -2077,6 +2201,7 @@ theorem Spec.Iter.fold_mapM {α β γ δ : Type w}
   rwa [Std.Iter.fold_mapM]
 
 
+@[spec]
 theorem Spec.Iter.fold_filterWithPostcondition {α β δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
@@ -2090,6 +2215,7 @@ theorem Spec.Iter.fold_filterWithPostcondition {α β δ : Type w}
   rwa [Std.Iter.fold_filterWithPostcondition]
 
 
+@[spec]
 theorem Spec.Iter.fold_filterM {α β δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
@@ -2106,58 +2232,61 @@ end Iterators
 
 
 
+@[spec]
 theorem Spec.forIn'_array {xs : Array α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
     (inv : Invariant xs.toList β Pred)
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur (by simp [←Array.mem_toList_iff, h]) b)
         (fun r => match r with
-          | .yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | .done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | .yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | .done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn' xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   cases xs; simp; apply Spec.forIn'_list inv step
 
 
+@[spec]
 theorem Spec.forIn_array {xs : Array α} {init : β} {f : α → β → m (ForInStep β)}
     (inv : Invariant xs.toList β Pred)
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f cur b)
         (fun r => match r with
-          | .yield b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b')
-          | .done b' => inv (⟨xs.toList, [], by simp⟩, b'))
+          | .yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
+          | .done b' => inv ⟨xs.toList, [], by simp⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (forIn xs init f)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   cases xs; simp; apply Spec.forIn_list inv step
 
 
+@[spec]
 theorem Spec.foldlM_array [LawfulMonad m]
     {xs : Array α} {init : β} {f : β → α → m β}
     (inv : Invariant xs.toList β Pred)
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
-        (inv (⟨pref, cur::suff, h.symm⟩, b))
+        (inv ⟨pref, cur::suff, h.symm⟩ b)
         (f b cur)
-        (fun b' => inv (⟨pref ++ [cur], suff, by simp [h]⟩, b'))
+        (fun b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b')
         epost) :
     Triple
-      (inv (⟨[], xs.toList, rfl⟩, init))
+      (inv ⟨[], xs.toList, rfl⟩ init)
       (Array.foldlM f init xs)
-      (fun b => inv (⟨xs.toList, [], by simp⟩, b))
+      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
       epost := by
   cases xs; simp; apply Spec.foldlM_list inv step
 
@@ -2165,25 +2294,38 @@ theorem Spec.foldlM_array [LawfulMonad m]
 The type of loop invariants used by the specifications of `for ... in ...` loops over strings.
 A loop invariant is a function mapping the current position and state to a lattice element.
 -/
-abbrev StringInvariant (s : String) (β : Type u)
-    (Pred : Type u) :=
-  (s.Pos × β → Pred)
+@[spec_invariant_type, simp, grind =]
+def StringInvariant (s : String) (β : Type u) (Pred : Type u) :=
+  s.Pos → β → Pred
 
+/-- An invariant combinator for `String` loops with early return, for the new `do` elaborator
+which uses `Prod` for the state tuple: `onContinue` is the invariant while iterating, `onReturn`
+holds once the loop returned early with a value. -/
+noncomputable abbrev StringInvariant.withEarlyReturnNewDo {s : String} {β : Type u} {γ : Type u}
+    (Pred : Type u) [Assertion Pred]
+    (onContinue : s.Pos → β → Pred)
+    (onReturn : γ → β → Pred) :
+    StringInvariant s (Option γ × β) Pred :=
+  fun pos ⟨x, b⟩ =>
+        (⌜x = none⌝ ⊓ onContinue pos b)
+      ⊔ (iSup fun r => ⌜x = some r ∧ pos = s.endPos⌝ ⊓ onReturn r b)
+
+@[spec]
 theorem Spec.forIn_string
     {s : String} {init : β} {f : Char → β → m (ForInStep β)}
     (inv : StringInvariant s β Pred)
     {epost : EPred}
     (step : ∀ pos b (h : pos ≠ s.endPos),
       Triple
-        (inv (pos, b))
+        (inv pos b)
         (f (pos.get h) b)
         (fun r => match r with
-          | .yield b' => inv (pos.next h, b')
-          | .done b' => inv (s.endPos, b'))
+          | .yield b' => inv (pos.next h) b'
+          | .done b' => inv s.endPos b')
         epost) :
-    Triple (inv (s.startPos, init)) (forIn s init f) (fun b => inv (s.endPos, b)) epost := by
+    Triple (inv s.startPos init) (forIn s init f) (fun b => inv s.endPos b) epost := by
   suffices h : ∀ (p : s.Pos) (t₁ t₂ : String) (h : p.Splits t₁ t₂),
-      Triple (inv (p, init)) (forIn t₂.toList init f) (fun b => inv (s.endPos, b)) epost by
+      Triple (inv p init) (forIn t₂.toList init f) (fun b => inv s.endPos b) epost by
     simpa using h s.startPos _ _ s.splits_startPos
   intro p
   induction p using String.Pos.next_induction generalizing init with
@@ -2209,25 +2351,38 @@ theorem Spec.forIn_string
 The type of loop invariants used by the specifications of `for ... in ...` loops over string slices.
 A loop invariant is a function mapping the current position and state to a lattice element.
 -/
-abbrev StringSliceInvariant (s : String.Slice) (β : Type u)
-    (Pred : Type u) :=
-  (s.Pos × β → Pred)
+@[spec_invariant_type, simp, grind =]
+def StringSliceInvariant (s : String.Slice) (β : Type u) (Pred : Type u) :=
+  s.Pos → β → Pred
 
+/-- An invariant combinator for `String.Slice` loops with early return, for the new `do`
+elaborator which uses `Prod` for the state tuple: `onContinue` is the invariant while iterating,
+`onReturn` holds once the loop returned early with a value. -/
+noncomputable abbrev StringSliceInvariant.withEarlyReturnNewDo {s : String.Slice} {β : Type u}
+    {γ : Type u} (Pred : Type u) [Assertion Pred]
+    (onContinue : s.Pos → β → Pred)
+    (onReturn : γ → β → Pred) :
+    StringSliceInvariant s (Option γ × β) Pred :=
+  fun pos ⟨x, b⟩ =>
+        (⌜x = none⌝ ⊓ onContinue pos b)
+      ⊔ (iSup fun r => ⌜x = some r ∧ pos = s.endPos⌝ ⊓ onReturn r b)
+
+@[spec]
 theorem Spec.forIn_stringSlice
     {s : String.Slice} {init : β} {f : Char → β → m (ForInStep β)}
     (inv : StringSliceInvariant s β Pred)
     {epost : EPred}
     (step : ∀ pos b (h : pos ≠ s.endPos),
       Triple
-        (inv (pos, b))
+        (inv pos b)
         (f (pos.get h) b)
         (fun r => match r with
-          | .yield b' => inv (pos.next h, b')
-          | .done b' => inv (s.endPos, b'))
+          | .yield b' => inv (pos.next h) b'
+          | .done b' => inv s.endPos b')
         epost) :
-    Triple (inv (s.startPos, init)) (forIn s init f) (fun b => inv (s.endPos, b)) epost := by
+    Triple (inv s.startPos init) (forIn s init f) (fun b => inv s.endPos b) epost := by
   suffices h : ∀ (p : s.Pos) (t₁ t₂ : String) (h : p.Splits t₁ t₂),
-      Triple (inv (p, init)) (forIn t₂.toList init f) (fun b => inv (s.endPos, b)) epost by
+      Triple (inv p init) (forIn t₂.toList init f) (fun b => inv s.endPos b) epost by
     simpa using h s.startPos _ _ s.splits_startPos
   intro p
   induction p using String.Slice.Pos.next_induction generalizing init with
@@ -2248,5 +2403,114 @@ theorem Spec.forIn_stringSlice
     obtain ⟨-, rfl⟩ := String.Slice.splits_endPos_iff.mp hsp
     simp only [String.toList_empty, List.forIn_nil]
     exact Triple.pure init Lean.Order.PartialOrder.rel_refl
+
+section While
+
+universe u
+
+variable {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+variable [Monad m] [Lean.Order.MonadTail m] [Assertion Pred] [Assertion EPred]
+  [WPMonad m Pred EPred]
+
+/--
+An invariant for a `whileM` loop, given as a predicate over the `α ⊕ β` cursor:
+`.inl a` is the `continue` case at `a`; `.inr b` is the `break` case with result `b`.
+-/
+@[spec_invariant_type, simp, grind =]
+def WhileInvariant (α β : Type u) (Pred : Type u) :=
+  α ⊕ β → Pred
+
+/-- A termination measure for a `whileM` loop. -/
+@[spec_invariant_type]
+def WhileVariant (α : Type u) :=
+  α → Nat
+
+/--
+Specification for `whileM`. The user supplies a termination `measure`, an invariant, and a step
+`Triple` whose post either continues with a strictly smaller measure or finishes with the `.inr`
+invariant.
+-/
+@[spec]
+theorem Spec.whileM
+    {init : α} {f : α → m (α ⊕ β)} [Nonempty β]
+    (measure : WhileVariant α)
+    (inv : WhileInvariant α β Pred)
+    (einv : EPred)
+    (step : ∀ a,
+      Triple
+        (inv (.inl a))
+        (f a)
+        (fun r => match r with
+          | .inl a' => ⌜measure a' < measure a⌝ ⊓ inv (.inl a')
+          | .inr b => inv (.inr b))
+        einv) :
+    Triple
+      (inv (.inl init))
+      (whileM f init)
+      (fun b => inv (.inr b))
+      einv := by
+  suffices key : ∀ (n : Nat) (a : α), measure a ≤ n →
+      Triple
+        (inv (.inl a))
+        (_root_.whileM f a)
+        (fun b => inv (.inr b))
+        einv
+    from key (measure init) init (Nat.le_refl _)
+  intro n
+  induction n using Nat.strongRecOn with
+  | _ n ih =>
+    intro a hle
+    rw [whileM_eq_of_monadTail (f := f) a]
+    refine Triple.bind (f := fun x => match x with
+      | .inl a' => _root_.whileM f a'
+      | .inr b => Pure.pure b)
+      (f a) (fun r => match r with
+        | .inl a' => ⌜measure a' < measure a⌝ ⊓ inv (.inl a')
+        | .inr b => inv (.inr b))
+      (step a) ?_
+    rintro (a' | b)
+    · refine Triple.iff.mpr ?_
+      refine CompleteLattice.ofProp_meet_le_left ?_
+      intro hlt
+      exact Triple.iff.mp (ih (measure a') (Nat.lt_of_lt_of_le hlt hle) a' (Nat.le_refl _))
+    · exact Triple.pure b Lean.Order.PartialOrder.rel_refl
+
+/--
+Specification for `forIn` over a `Lean.Loop`. The cursor is `β ⊕ β`: `.inl b` means
+"still iterating with `b`", `.inr b` means "finished with result `b`".
+-/
+@[spec]
+theorem Spec.forIn_loop
+    {l : Lean.Loop} {init : β} {f : Unit → β → m (ForInStep β)}
+    (measure : WhileVariant β)
+    (inv : WhileInvariant β β Pred)
+    (einv : EPred)
+    (step : ∀ b,
+      Triple
+        (inv (.inl b))
+        (f () b)
+        (fun r => match r with
+          | .yield b' => ⌜measure b' < measure b⌝ ⊓ inv (.inl b')
+          | .done b' => inv (.inr b'))
+        einv) :
+    Triple
+      (inv (.inl init))
+      (forIn l init f)
+      (fun b => inv (.inr b))
+      einv := by
+  haveI : Nonempty β := ⟨init⟩
+  change Triple (pre := inv (.inl init)) (_root_.Lean.Loop.forIn l init f)
+    (fun b => inv (.inr b)) einv
+  simp only [_root_.Lean.Loop.forIn]
+  apply Spec.whileM (measure := measure) (inv := inv) (einv := einv)
+  intro b
+  apply Triple.bind
+  · exact step b
+  · intro r
+    cases r with
+    | yield b' => exact Triple.pure (Sum.inl b') Lean.Order.PartialOrder.rel_refl
+    | done b' => exact Triple.pure (Sum.inr b') Lean.Order.PartialOrder.rel_refl
+
+end While
 
 end Std.Internal.Do

--- a/src/Std/Internal/Do/WP/Basic.lean
+++ b/src/Std/Internal/Do/WP/Basic.lean
@@ -75,7 +75,7 @@ exception postcondition `epost`. -/
 def wp [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] {α} (x : m α) (post : α → Pred) (epost : EPred) : Pred :=
   (WPMonad.wpTrans x).apply post epost
 
-@[simp, grind =] theorem WPMonad.wp_impl_eq_wp [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] {α} (x : m α) :
+@[simp, grind =] theorem WPMonad.wpTrans_apply_eq [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] {α} (x : m α) :
   (WPMonad.wpTrans x).apply = wp x := rfl
 
 /-!
@@ -219,7 +219,7 @@ instance ExceptT.instWPMonad {Pred : Type v}
     · exact htail
 
 @[simp, grind =]
-theorem ExceptT.apply_wp {α ε Pred EPred}
+theorem ExceptT.wp_apply_eq {α ε Pred EPred}
   [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] (x : ExceptT ε m α)
   (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     wp x post epost = wp x.run (epost.pushExcept post) epost.tail := rfl
@@ -250,7 +250,7 @@ instance OptionT.instWPMonad {Pred : Type u}
     · exact hepost'.2
 
 @[simp, grind =]
-theorem OptionT.apply_wp {α : Type u} {Pred : Type u} {EPred}
+theorem OptionT.wp_apply_eq {α : Type u} {Pred : Type u} {EPred}
   [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] (x : OptionT m α)
   (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     wp x post epost = wp x.run (epost.pushOption post) epost.tail := rfl
@@ -272,7 +272,7 @@ instance (priority := low) StateT.instWPMonad {EPred : Type v} {σ : Type u} {Pr
     · exact hepost
 
 @[simp, grind =]
-theorem StateT.apply_wp {σ : Type u}
+theorem StateT.wp_apply_eq {σ : Type u}
   [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] (x : StateT σ m α)
   (post : α → σ → Pred) (epost : EPred) (s : σ) :
     wp x post epost s = wp (x.run s) (fun (a, s) => post a s) epost := rfl
@@ -297,7 +297,7 @@ instance ReaderT.instWPMonad {Pred : Type v}
     · exact hepost
 
 @[simp, grind =]
-theorem ReaderT.apply_wp {ρ : Type u}
+theorem ReaderT.wp_apply_eq {ρ : Type u}
   [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] (x : ReaderT ρ m α)
   (post : α → ρ → Pred) (epost : EPred) (r : ρ) :
     wp x post epost r = wp (x.run r) (fun a => post a r) epost := rfl

--- a/src/Std/Internal/Do/WP/Lemmas.lean
+++ b/src/Std/Internal/Do/WP/Lemmas.lean
@@ -32,7 +32,7 @@ variable {m : Type u → Type v} [Monad m] [Assertion Pred] [Assertion EPred] [W
 
 /-! ## MonadReaderOf simp lemmas -/
 
-theorem read_ReaderT_wp
+theorem le_wp_read_ReaderT_apply
     (post : ρ → ρ → Pred) (epost : EPred) :
     (fun r => post r r) ⊑ wp (MonadReaderOf.read : ReaderT ρ m ρ) post epost := by
   intro r
@@ -40,13 +40,13 @@ theorem read_ReaderT_wp
     (WPMonad.wp_pure (m := m) (x := r) (post := fun a => post a r) (epost := epost))
 
 @[simp]
-theorem adapt_ReaderT_wp (f : ρ → ρ') (x : ReaderT ρ' m α) :
+theorem wp_adapt_ReaderT_apply_eq (f : ρ → ρ') (x : ReaderT ρ' m α) :
     wp (ReaderT.adapt f x : ReaderT ρ m α) post epost =
       fun r => wp x (fun a _ => post a r) epost (f r) := rfl
 
 /-! ## MonadStateOf simp lemmas -/
 
-theorem get_StateT_wp
+theorem le_wp_get_StateT_apply
     (post : σ → σ → Pred) (epost : EPred) :
     (fun s => post s s) ⊑ wp (MonadStateOf.get : StateT σ m σ) post epost := by
   intro s
@@ -54,7 +54,7 @@ theorem get_StateT_wp
     (WPMonad.wp_pure (m := m) (x := (s, s))
       (post := fun x => post x.fst x.snd) (epost := epost))
 
-theorem set_StateT_wp (x : σ)
+theorem le_wp_set_StateT_apply (x : σ)
     (post : PUnit → σ → Pred) (epost : EPred) :
     (fun _ => post ⟨⟩ x) ⊑ wp (MonadStateOf.set x : StateT σ m PUnit) post epost := by
   intro s
@@ -62,7 +62,7 @@ theorem set_StateT_wp (x : σ)
     (WPMonad.wp_pure (m := m) (x := (PUnit.unit, x))
       (post := fun x => post x.fst x.snd) (epost := epost))
 
-theorem modifyGet_StateT_wp (f : σ → α × σ)
+theorem le_wp_modifyGet_StateT_apply (f : σ → α × σ)
     (post : α → σ → Pred) (epost : EPred) :
     (fun s => post (f s).1 (f s).2) ⊑ wp (MonadStateOf.modifyGet f : StateT σ m α) post epost := by
   intro s
@@ -70,39 +70,39 @@ theorem modifyGet_StateT_wp (f : σ → α × σ)
     (WPMonad.wp_pure (m := m) (x := f s)
       (post := fun x => post x.fst x.snd) (epost := epost))
 
-theorem get_EStateM_wp :
+theorem wp_get_EStateM_apply_eq :
     wp (MonadStateOf.get : EStateM ε σ σ) post epost = fun s => post s s := by
   funext s
   simp only [wp, WPMonad.wpTrans, MonadStateOf.get, EStateM.get]
 
-theorem set_EStateM_wp (x : σ) :
+theorem wp_set_EStateM_apply_eq (x : σ) :
     wp (MonadStateOf.set x : EStateM ε σ PUnit) post epost = fun _ => post ⟨⟩ x := by
   funext s
   simp only [wp, WPMonad.wpTrans, MonadStateOf.set, EStateM.set]
 
-theorem modifyGet_EStateM_wp (f : σ → α × σ) :
+theorem wp_modifyGet_EStateM_apply_eq (f : σ → α × σ) :
     wp (MonadStateOf.modifyGet f : EStateM ε σ α) post epost = fun s => post (f s).1 (f s).2 := by
   funext s
   simp only [wp, WPMonad.wpTrans, MonadStateOf.modifyGet, EStateM.modifyGet]
 
 @[simp]
-theorem modify_StateT_wp (f : σ → σ) :
+theorem wp_modify_StateT_apply_eq (f : σ → σ) :
     wp (modify f : StateT σ m PUnit) post epost =
       wp (MonadStateOf.modifyGet fun s => (⟨⟩, f s) : StateT σ m PUnit) post epost := by
   rfl
 
 @[simp]
-theorem getModify_StateT_wp (f : σ → σ) :
+theorem wp_getModify_StateT_apply_eq (f : σ → σ) :
     wp (getModify f : StateT σ m σ) post epost =
       wp (MonadStateOf.modifyGet fun s => (s, f s) : StateT σ m σ) post epost := by
   rfl
 
-theorem modify_EStateM_wp (f : σ → σ) :
+theorem wp_modify_EStateM_apply_eq (f : σ → σ) :
     wp (modify f : EStateM ε σ PUnit) post epost =
       wp (MonadStateOf.modifyGet fun s => (⟨⟩, f s) : EStateM ε σ PUnit) post epost := by
   rfl
 
-theorem getModify_EStateM_wp (f : σ → σ) :
+theorem wp_getModify_EStateM_apply_eq (f : σ → σ) :
     wp (getModify f : EStateM ε σ σ) post epost =
       wp (MonadStateOf.modifyGet fun s => (s, f s) : EStateM ε σ σ) post epost := by
   rfl
@@ -110,35 +110,35 @@ theorem getModify_EStateM_wp (f : σ → σ) :
 /-! ## MonadExceptOf simp lemmas -/
 
 @[simp]
-theorem throwThe_wp [MonadExceptOf ε m] (err : ε) :
+theorem wp_throwThe_apply_eq [MonadExceptOf ε m] (err : ε) :
     wp (throwThe ε err : m α) post epost =
       wp (MonadExceptOf.throw err : m α) post epost := by
   rfl
 
 @[simp]
-theorem throw_Except_wp (e : ε) :
+theorem wp_throw_Except_apply_eq (e : ε) :
     wp (MonadExceptOf.throw e : Except ε α) post epost = epost.head e := by
   simp [wp, WPMonad.wpTrans, MonadExceptOf.throw]
 
-theorem throw_ExceptT_wp (err : ε) :
+theorem le_wp_throw_ExceptT_apply (err : ε) :
     epost.head err ⊑ wp (MonadExceptOf.throw err : ExceptT ε m α) post epost := by
   simpa [MonadExceptOf.throw, EPost.Cons.pushExcept] using
     (WPMonad.wp_pure (m := m) (x := Except.error err)
       (post := epost.pushExcept post) (epost := epost.tail))
 
 @[simp]
-theorem throw_EStateM_wp (e : ε) :
+theorem wp_throw_EStateM_apply_eq (e : ε) :
     wp (MonadExceptOf.throw e : EStateM ε σ α) post epost = epost e := by
   funext s
   simp only [wp, WPMonad.wpTrans, MonadExceptOf.throw, EStateM.throw]
 
 @[simp]
-theorem throw_Option_wp (e : PUnit) :
+theorem wp_throw_Option_apply_eq (e : PUnit) :
     wp (MonadExceptOf.throw e : Option α) post epost = epost := by
   simp only [wp, MonadExceptOf.throw]
   rfl
 
-theorem throw_OptionT_wp (err : PUnit) :
+theorem le_wp_throw_OptionT_apply (err : PUnit) :
   epost.head ⊑ wp (MonadExceptOf.throw err : OptionT m α) post epost := by
   show epost.head ⊑ wp (pure none : m (Option α)) (epost.pushOption post) epost.tail
   simpa [MonadExceptOf.throw, EPost.Cons.pushOption] using
@@ -146,20 +146,20 @@ theorem throw_OptionT_wp (err : PUnit) :
       (post := epost.pushOption post) (epost := epost.tail))
 
 @[simp]
-theorem tryCatch_MonadExcept_wp [MonadExceptOf ε m] (x : m α)
+theorem wp_tryCatch_MonadExcept_apply_eq [MonadExceptOf ε m] (x : m α)
     (h : ε → m α) :
     wp (tryCatch x h : m α) post epost =
       wp (MonadExceptOf.tryCatch x h : m α) post epost := by
   rfl
 
 @[simp]
-theorem tryCatchThe_wp [MonadExceptOf ε m] (x : m α) (h : ε → m α) :
+theorem wp_tryCatchThe_apply_eq [MonadExceptOf ε m] (x : m α) (h : ε → m α) :
     wp (tryCatchThe ε x h : m α) post epost =
       wp (MonadExceptOf.tryCatch x h : m α) post epost := by
   rfl
 
 @[simp]
-theorem tryCatch_Except_wp (x : Except ε α) (h : ε → Except ε α) :
+theorem wp_tryCatch_Except_apply_eq (x : Except ε α) (h : ε → Except ε α) :
     wp (MonadExceptOf.tryCatch x h : Except ε α) post epost =
       wp x post epost⟨fun e => wp (h e) post epost⟩ := by
   simp only [wp, WPMonad.wpTrans, MonadExceptOf.tryCatch, Except.tryCatch]
@@ -178,12 +178,12 @@ omit [Monad m] in
   simp only [tryCatch, tryCatchThe, MonadExceptOf.tryCatch, ExceptT.tryCatch, ExceptT.run_mk]
   rfl
 
-theorem tryCatch_ExceptT_wp (x : ExceptT ε m α)
+theorem le_wp_tryCatch_ExceptT_apply (x : ExceptT ε m α)
     (h : ε → ExceptT ε m α) :
     wp x post ⟨fun e => wp (h e) post epost, epost.tail⟩ ⊑
       wp (MonadExceptOf.tryCatch x h : ExceptT ε m α) post epost := by
   change _ ⊑ wp (tryCatch x h : ExceptT ε m α) _ _
-  simp only [ExceptT.apply_wp, ExceptT.run_tryCatch]
+  simp only [ExceptT.wp_apply_eq, ExceptT.run_tryCatch]
   apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_bind
   apply WPMonad.wp_consequence; intro r; cases r with
   | ok a =>
@@ -192,14 +192,14 @@ theorem tryCatch_ExceptT_wp (x : ExceptT ε m α)
   | error _ => exact PartialOrder.rel_refl
 
 @[simp]
-theorem tryCatch_Option_wp (x : Option α) (h : PUnit → Option α) :
+theorem wp_tryCatch_Option_apply_eq (x : Option α) (h : PUnit → Option α) :
   wp (MonadExceptOf.tryCatch x h : Option α) post epost =
     wp x post (wp (h ⟨⟩) post epost) := by
   simp only [wp, WPMonad.wpTrans, MonadExceptOf.tryCatch, Option.tryCatch]
   cases x <;> rfl
 
 
-theorem tryCatch_EStateM_wp (x : EStateM ε σ α) (h : ε → EStateM ε σ α) :
+theorem wp_tryCatch_EStateM_apply_eq (x : EStateM ε σ α) (h : ε → EStateM ε σ α) :
     wp (MonadExceptOf.tryCatch x h : EStateM ε σ α) post epost =
       fun s => wp x post (fun e s' => wp (h e) post epost s') s := by
   funext s
@@ -208,7 +208,7 @@ theorem tryCatch_EStateM_wp (x : EStateM ε σ α) (h : ε → EStateM ε σ α)
   rfl
 
 @[simp]
-theorem tryCatch_OptionT_wp (x : OptionT m α)
+theorem le_wp_tryCatch_OptionT_apply (x : OptionT m α)
     (h : PUnit → OptionT m α) :
   wp x post ⟨wp (h ⟨⟩) post epost, epost.tail⟩ ⊑
     wp (MonadExceptOf.tryCatch x h : OptionT m α) post epost := by
@@ -223,56 +223,56 @@ theorem tryCatch_OptionT_wp (x : OptionT m α)
 /-! ## Additional state operation lemmas -/
 
 @[simp]
-theorem getThe_StateT_wp :
+theorem wp_getThe_StateT_apply_eq :
     wp (getThe σ : StateT σ m σ) post epost =
       wp (MonadStateOf.get : StateT σ m σ) post epost := by
   rfl
 
 @[simp]
-theorem modifyThe_StateT_wp (f : σ → σ) :
+theorem wp_modifyThe_StateT_apply_eq (f : σ → σ) :
     wp (modifyThe σ f : StateT σ m PUnit) post epost =
       wp (MonadStateOf.modifyGet fun s => (⟨⟩, f s) : StateT σ m PUnit) post epost := by
   rfl
 
 @[simp]
-theorem modifyGetThe_StateT_wp (f : σ → α × σ) :
+theorem wp_modifyGetThe_StateT_apply_eq (f : σ → α × σ) :
     wp (modifyGetThe σ f : StateT σ m α) post epost =
       wp (MonadStateOf.modifyGet f : StateT σ m α) post epost := by
   rfl
 
 @[simp]
-theorem get_MonadState_wp [MonadStateOf σ m] :
+theorem wp_get_MonadState_apply_eq [MonadStateOf σ m] :
     wp (MonadState.get : m σ) post epost =
       wp (MonadStateOf.get : m σ) post epost := by
   rfl
 
 @[simp]
-theorem set_MonadState_wp [MonadStateOf σ m] (x : σ) :
+theorem wp_set_MonadState_apply_eq [MonadStateOf σ m] (x : σ) :
     wp (MonadState.set x : m PUnit) post epost =
       wp (MonadStateOf.set x : m PUnit) post epost := by
   rfl
 
 @[simp]
-theorem modifyGet_MonadState_wp [MonadStateOf σ m] (f : σ → α × σ) :
+theorem wp_modifyGet_MonadState_apply_eq [MonadStateOf σ m] (f : σ → α × σ) :
     wp (MonadState.modifyGet f : m α) post epost =
       wp (MonadStateOf.modifyGet f : m α) post epost := by
   rfl
 
 @[simp]
-theorem read_MonadReader_wp [MonadReaderOf ρ m] :
+theorem wp_read_MonadReader_apply_eq [MonadReaderOf ρ m] :
     wp (MonadReader.read : m ρ) post epost =
       wp (MonadReaderOf.read : m ρ) post epost := by
   rfl
 
 @[simp]
-theorem readThe_ReaderT_wp :
+theorem wp_readThe_ReaderT_apply_eq :
     wp (readThe ρ : ReaderT ρ m ρ) post epost =
       wp (MonadReaderOf.read : ReaderT ρ m ρ) post epost := by
   rfl
 
 /-! ## MonadLift simp lemmas -/
 
-theorem monadLift_StateT_wp (x : m α) (post : α → σ → Pred) :
+theorem le_wp_monadLift_StateT_apply (x : m α) (post : α → σ → Pred) :
     (fun s => wp x (fun a => post a s) epost) ⊑
       wp (MonadLift.monadLift x : StateT σ m α) post epost := by
   intro s
@@ -284,12 +284,12 @@ theorem monadLift_StateT_wp (x : m α) (post : α → σ → Pred) :
       (post := fun x => post x.fst x.snd) (epost := epost))
 
 @[simp]
-theorem monadLift_ReaderT_wp (x : m α) :
+theorem wp_monadLift_ReaderT_apply_eq (x : m α) :
     wp (MonadLift.monadLift x : ReaderT ρ m α) post epost =
       fun r => wp x (fun a => post a r) epost := by
   rfl
 
-theorem monadLift_ExceptT_wp (x : m α) (post : α → Pred)
+theorem le_wp_monadLift_ExceptT_apply (x : m α) (post : α → Pred)
     (epost : EPost.Cons (ε → Pred) EPred) :
     wp x post epost.tail ⊑
       wp (MonadLift.monadLift x : ExceptT ε m α) post epost := by
@@ -299,19 +299,19 @@ theorem monadLift_ExceptT_wp (x : m α) (post : α → Pred)
   · exact PartialOrder.rel_refl
 
 @[simp]
-theorem lift_StateT_wp (x : m α) :
+theorem wp_lift_StateT_apply_eq (x : m α) :
     wp (StateT.lift x : StateT σ m α) post epost =
       wp (MonadLift.monadLift x : StateT σ m α) post epost := by
   rfl
 
 @[simp]
-theorem lift_ExceptT_wp (x : m α) :
+theorem wp_lift_ExceptT_apply_eq (x : m α) :
     wp (ExceptT.lift x : ExceptT ε m α) post epost =
       wp (MonadLift.monadLift x : ExceptT ε m α) post epost := by
   rfl
 
 @[simp]
-theorem monadLift_OptionT_wp (x : m α) :
+theorem le_wp_monadLift_OptionT_apply (x : m α) :
   wp x post epost.tail ⊑
     wp (MonadLift.monadLift x : OptionT m α) post epost := by
   simp only [wp, MonadLift.monadLift, OptionT.mk, OptionT.lift]
@@ -322,7 +322,7 @@ theorem monadLift_OptionT_wp (x : m α) :
 
 omit [Assertion EPred] [WPMonad m Pred EPred] in
 @[simp]
-theorem lift_OptionT_wp
+theorem wp_lift_OptionT_apply_eq
     [Assertion (EPost.Cons Pred EPred)] [WPMonad (OptionT m) Pred (EPost.Cons Pred EPred)] (x : m α) :
     wp (OptionT.lift x : OptionT m α) post epost =
       wp (MonadLift.monadLift x : OptionT m α) post epost := rfl
@@ -330,7 +330,7 @@ theorem lift_OptionT_wp
 /-! ## MonadFunctor simp lemmas -/
 
 @[simp]
-theorem monadMap_StateT_wp
+theorem wp_monadMap_StateT_apply_eq
     (f : ∀{β}, m β → m β) {α} (x : StateT σ m α) (post : α → σ → Pred) (epost : EPred) :
     wp (MonadFunctor.monadMap (m:=m) f x : StateT σ m α) post epost =
       fun s => wp (f (x.run s)) (fun (a, s') => post a s') epost := by
@@ -338,7 +338,7 @@ theorem monadMap_StateT_wp
   simp [MonadFunctor.monadMap, StateT.run]
 
 @[simp]
-theorem monadMap_ReaderT_wp
+theorem wp_monadMap_ReaderT_apply_eq
     (f : ∀{β}, m β → m β) {α} (x : ReaderT ρ m α) (post : α → ρ → Pred) (epost : EPred) :
     wp (MonadFunctor.monadMap (m:=m) f x : ReaderT ρ m α) post epost =
       fun r => wp (f (x.run r)) (fun a => post a r) epost := by
@@ -346,7 +346,7 @@ theorem monadMap_ReaderT_wp
   simp [MonadFunctor.monadMap, ReaderT.run]
 
 @[simp]
-theorem monadMap_ExceptT_wp
+theorem wp_monadMap_ExceptT_apply_eq
     (f : ∀{β}, m β → m β) {α} (x : ExceptT ε m α) (post : α → Pred)
     (epost : EPost.Cons (ε → Pred) EPred) :
     wp (MonadFunctor.monadMap (m:=m) f x : ExceptT ε m α) post epost =
@@ -354,31 +354,31 @@ theorem monadMap_ExceptT_wp
   simp [MonadFunctor.monadMap, ExceptT.run]
 
 @[simp]
-theorem monadMap_OptionT_wp
+theorem wp_monadMap_OptionT_apply_eq
   (f : ∀{β}, m β → m β) {α} (x : OptionT m α) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
   wp (MonadFunctor.monadMap (m:=m) f x : OptionT m α) post epost =
     wp (f x.run) (epost.pushOption post) epost.tail := by
   simp only [wp, MonadFunctor.monadMap, OptionT.run]; rfl
 
 @[simp]
-theorem withReader_ReaderT_wp (f : ρ → ρ) (x : ReaderT ρ m α) :
+theorem wp_withReader_ReaderT_apply_eq (f : ρ → ρ) (x : ReaderT ρ m α) :
     wp (MonadWithReaderOf.withReader f x : ReaderT ρ m α) post epost =
       fun r => wp x (fun a _ => post a r) epost (f r) := rfl
 
 @[simp]
-theorem withReader_MonadWithReader_wp [MonadWithReaderOf ρ m]
+theorem wp_withReader_MonadWithReader_apply_eq [MonadWithReaderOf ρ m]
     (f : ρ → ρ) (x : m α) :
     wp (MonadWithReader.withReader f x : m α) post epost =
       wp (MonadWithReaderOf.withReader f x : m α) post epost := rfl
 
 @[simp]
-theorem withTheReader_ReaderT_wp (f : ρ → ρ) (x : ReaderT ρ m α) :
+theorem wp_withTheReader_ReaderT_apply_eq (f : ρ → ρ) (x : ReaderT ρ m α) :
     wp (withTheReader ρ f x : ReaderT ρ m α) post epost =
       wp (MonadWithReaderOf.withReader f x : ReaderT ρ m α) post epost := rfl
 
 /-! ## Transformer adapt lemmas -/
 
-theorem adapt_ExceptT_wp (f : ε → ε') (x : ExceptT ε m α) :
+theorem le_wp_adapt_ExceptT_apply (f : ε → ε') (x : ExceptT ε m α) :
     wp x post ⟨fun e => epost.head (f e), epost.tail⟩ ⊑
       wp (ExceptT.adapt f x : ExceptT ε' m α) post epost := by
   simp only [wp, ExceptT.adapt, ExceptT.mk]
@@ -387,7 +387,7 @@ theorem adapt_ExceptT_wp (f : ε → ε') (x : ExceptT ε m α) :
   · apply WPMonad.wp_consequence (m := m); intro r; cases r <;> exact PartialOrder.rel_refl
 
 @[simp]
-theorem adaptExcept_EStateM_wp (f : ε → ε') (x : EStateM ε σ α) :
+theorem wp_adaptExcept_EStateM_apply_eq (f : ε → ε') (x : EStateM ε σ α) :
     wp (EStateM.adaptExcept f x : EStateM ε' σ α) post epost =
       wp x post (fun e => epost (f e)) := by
   funext s
@@ -397,14 +397,14 @@ theorem adaptExcept_EStateM_wp (f : ε → ε') (x : EStateM ε σ α) :
 /-! ## MonadControl simp lemmas -/
 
 @[simp]
-theorem liftWith_StateT_wp
+theorem wp_liftWith_StateT_apply_eq
     (f : (∀{β}, StateT σ m β → m (β × σ)) → m α) :
     wp (MonadControl.liftWith (m:=m) f : StateT σ m α) post epost s =
       wp ((fun a => (a, s)) <$> f (fun x => x.run s)) (fun ⟨a, s⟩ => post a s) epost := by
   simp [MonadControl.liftWith]
 
 @[simp]
-theorem liftWith_ReaderT_wp
+theorem wp_liftWith_ReaderT_apply_eq
     (f : (∀{β}, ReaderT ρ m β → m β) → m α) :
     wp (MonadControl.liftWith (m:=m) f : ReaderT ρ m α) post epost r =
       wp (f (fun x => x.run r)) (fun a => post a r) epost := by
@@ -416,7 +416,7 @@ omit [Monad m] in
     (liftM x : ExceptT ε m α).run = (Except.ok <$> x : m (Except ε α)) := rfl
 
 @[simp]
-theorem liftWith_ExceptT_wp
+theorem wp_liftWith_ExceptT_apply_eq
     (f : (∀{β}, ExceptT ε m β → m (Except ε β)) → m α) :
     wp (MonadControl.liftWith (m:=m) f : ExceptT ε m α) post epost =
       wp (Except.ok <$> f (fun x => x.run)) (epost.pushExcept post) epost.tail := by
@@ -425,19 +425,19 @@ theorem liftWith_ExceptT_wp
   simp
 
 @[simp]
-theorem liftWith_OptionT_wp
+theorem le_wp_liftWith_OptionT_apply
   (f : (∀{β}, OptionT m β → m (Option β)) → m α) :
   wp (f (fun x => x.run)) post epost.tail ⊑
     wp (MonadControl.liftWith (m:=m) f : OptionT m α) post epost := by
-  simp only [MonadControl.liftWith, liftM, monadLift, OptionT.apply_wp]
-  exact monadLift_OptionT_wp (f (fun x => x.run))
+  simp only [MonadControl.liftWith, liftM, monadLift, OptionT.wp_apply_eq]
+  exact le_wp_monadLift_OptionT_apply (f (fun x => x.run))
 
-theorem restoreM_StateT_wp (x : m (α × σ)) :
+theorem le_wp_restoreM_StateT_apply (x : m (α × σ)) :
     (fun _ => wp x (fun (a, s) => post a s) epost) ⊑
       wp (MonadControl.restoreM (m:=m) x : StateT σ m α) post epost := by
   simp only [MonadControl.restoreM]
   apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_bind; simp only [liftM, monadLift]
-  apply PartialOrder.rel_trans; rotate_left; apply monadLift_StateT_wp
+  apply PartialOrder.rel_trans; rotate_left; apply le_wp_monadLift_StateT_apply
   intro s; apply WPMonad.wp_consequence; intro s'; simp only
   apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_bind
   simp [set, StateT.set, pure, StateT.pure]
@@ -451,20 +451,20 @@ theorem restoreM_StateT_wp (x : m (α × σ)) :
         (epost := epost))
 
 @[simp]
-theorem restoreM_ReaderT_wp (x : m α) :
+theorem wp_restoreM_ReaderT_apply_eq (x : m α) :
     wp (MonadControl.restoreM (m:=m) x : ReaderT ρ m α) post epost =
       fun r => wp x (fun a => post a r) epost := by
   funext r
   simp [MonadControl.restoreM, ReaderT.run]
 
 @[simp]
-theorem restoreM_ExceptT_wp (x : m (Except ε α)) :
+theorem wp_restoreM_ExceptT_apply_eq (x : m (Except ε α)) :
     wp (MonadControl.restoreM (m:=m) x : ExceptT ε m α) post epost =
       wp x (epost.pushExcept post) epost.tail := by
   simp [MonadControl.restoreM, ExceptT.run]
 
 @[simp]
-theorem restoreM_OptionT_wp (x : m (Option α)) :
+theorem wp_restoreM_OptionT_apply_eq (x : m (Option α)) :
   wp (MonadControl.restoreM (m:=m) x : OptionT m α) post epost =
     wp x (epost.pushOption post) epost.tail := by
   simp only [wp, MonadControl.restoreM]; rfl
@@ -472,14 +472,14 @@ theorem restoreM_OptionT_wp (x : m (Option α)) :
 end
 
 @[simp]
-theorem controlAt_wp [Bind n] [Monad m] [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred] [MonadControlT m n]
+theorem wp_controlAt_apply_eq [Bind n] [Monad m] [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred] [MonadControlT m n]
     (f : (∀{β}, n β → m (stM m n β)) → m (stM m n α)) :
     wp (controlAt m f : n α) post epost =
       wp (liftWith f >>= restoreM : n α) post epost := by
   rfl
 
 @[simp]
-theorem control_wp [Bind n] [Monad m] [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred] [MonadControlT m n]
+theorem wp_control_apply_eq [Bind n] [Monad m] [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred] [MonadControlT m n]
     (f : (∀{β}, n β → m (stM m n β)) → m (stM m n α)) :
     wp (control f : n α) post epost =
       wp (liftWith f >>= restoreM : n α) post epost := by
@@ -489,24 +489,24 @@ section
 variable {m : Type u → Type v} [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
 
 @[simp]
-theorem monadLift_refl_wp [Pure m] (x : m α) :
+theorem wp_monadLift_refl_apply_eq [Pure m] (x : m α) :
     wp (MonadLiftT.monadLift x : m α) post epost =
       wp (x : m α) post epost := rfl
 
 @[simp]
-theorem monadMap_refl_wp [Pure m] (x : m α) :
+theorem wp_monadMap_refl_apply_eq [Pure m] (x : m α) :
     wp (MonadFunctorT.monadMap f x : m α) post epost =
       wp (f x : m α) post epost := by rfl
 
 @[simp]
-theorem liftWith_refl_wp [Pure m]
+theorem wp_liftWith_refl_apply_eq [Pure m]
     (f : (∀{β}, m β → m β) → m α) :
     wp (MonadControlT.liftWith (m:=m) f : m α) post epost =
       wp (f (fun x => x) : m α) post epost := by
   rfl
 
 @[simp]
-theorem restoreM_refl_wp [Pure m] (x : stM m m α) :
+theorem wp_restoreM_refl_apply_eq [Pure m] (x : stM m m α) :
     wp (MonadControlT.restoreM x : m α) post epost =
       wp (Pure.pure x : m α) post epost := by
   rfl
@@ -519,19 +519,19 @@ section
 variable {m n : Type u → Type v} {o : Type u → Type v} [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
 
 @[simp]
-theorem monadLift_trans_wp [MonadLift n o] [MonadLiftT m n] (x : m α) :
+theorem wp_monadLift_trans_apply_eq [MonadLift n o] [MonadLiftT m n] (x : m α) :
     wp (MonadLiftT.monadLift x : o α) post epost =
       wp (MonadLift.monadLift (m:=n) (MonadLiftT.monadLift (m:=m) x) : o α) post epost := rfl
 
 @[simp]
-theorem monadMap_trans_wp [MonadFunctor n o] [MonadFunctorT m n]
+theorem wp_monadMap_trans_apply_eq [MonadFunctor n o] [MonadFunctorT m n]
     (x : o α) :
     wp (MonadFunctorT.monadMap f x : o α) post epost =
       wp (MonadFunctor.monadMap (m:=n) (MonadFunctorT.monadMap (m:=m) f) x : o α) post epost := by
   rfl
 
 @[simp]
-theorem liftWith_trans_wp [MonadControl n o] [MonadControlT m n]
+theorem wp_liftWith_trans_apply_eq [MonadControl n o] [MonadControlT m n]
     (f : (∀{β}, o β → m (stM m o β)) → m α) :
     wp (MonadControlT.liftWith f : o α) post epost =
       wp (MonadControl.liftWith (m:=n) fun x₂ =>
@@ -539,7 +539,7 @@ theorem liftWith_trans_wp [MonadControl n o] [MonadControlT m n]
   rfl
 
 @[simp]
-theorem restoreM_trans_wp [MonadControl n o] [MonadControlT m n]
+theorem wp_restoreM_trans_apply_eq [MonadControl n o] [MonadControlT m n]
     (x : stM m o α) :
     wp (MonadControlT.restoreM x : o α) post epost =
       wp (MonadControl.restoreM (m:=n) (MonadControlT.restoreM (m:=m) x) : o α)
@@ -554,25 +554,25 @@ section
 variable {m n : Type u → Type v} [Monad n] [MonadLift m n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
 
 @[simp]
-theorem get_MonadStateOf_lift_wp [MonadStateOf σ m] :
+theorem wp_get_MonadStateOf_lift_apply_eq [MonadStateOf σ m] :
     wp (MonadStateOf.get : n σ) post epost =
       wp (MonadLift.monadLift (MonadStateOf.get : m σ) : n σ) post epost := by
   rfl
 
 @[simp]
-theorem set_MonadStateOf_lift_wp [MonadStateOf σ m] (x : σ) :
+theorem wp_set_MonadStateOf_lift_apply_eq [MonadStateOf σ m] (x : σ) :
     wp (MonadStateOf.set x : n PUnit) post epost =
       wp (MonadLift.monadLift (MonadStateOf.set (σ:=σ) x : m PUnit) : n PUnit) post epost := by
   rfl
 
 @[simp]
-theorem modifyGet_MonadStateOf_lift_wp [MonadStateOf σ m] (f : σ → α × σ) :
+theorem wp_modifyGet_MonadStateOf_lift_apply_eq [MonadStateOf σ m] (f : σ → α × σ) :
     wp (MonadStateOf.modifyGet f : n α) post epost =
       wp (MonadLift.monadLift (MonadState.modifyGet f : m α) : n α) post epost := by
   rfl
 
 @[simp]
-theorem read_MonadReaderOf_lift_wp [MonadReaderOf ρ m] :
+theorem wp_read_MonadReaderOf_lift_apply_eq [MonadReaderOf ρ m] :
     wp (MonadReaderOf.read : n ρ) post epost =
       wp (MonadLift.monadLift (MonadReader.read : m ρ) : n ρ) post epost := by
   rfl
@@ -585,54 +585,54 @@ section
 variable {m : Type u → Type v} [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [MonadExceptOf ε m]
 
 @[simp]
-theorem throw_lift_ExceptT_wp (err : ε) :
+theorem wp_throw_lift_ExceptT_apply_eq (err : ε) :
     wp (MonadExceptOf.throw (ε:=ε) err : ExceptT ε' m α) post epost =
       wp (MonadExceptOf.throw (ε:=ε) err : m (Except ε' α)) (epost.pushExcept post) epost.tail := by
   rfl
 
 @[simp]
-theorem throw_lift_OptionT_wp (err : ε) :
+theorem wp_throw_lift_OptionT_apply_eq (err : ε) :
   wp (MonadExceptOf.throw (ε:=ε) err : OptionT m α) post epost =
     wp (MonadExceptOf.throw (ε:=ε) err : m (Option α)) (epost.pushOption post) epost.tail := by
   rfl
 
 @[simp]
-theorem tryCatch_lift_ExceptT_wp (x : ExceptT ε' m α) (h : ε → ExceptT ε' m α) :
+theorem wp_tryCatch_lift_ExceptT_apply_eq (x : ExceptT ε' m α) (h : ε → ExceptT ε' m α) :
     wp (MonadExceptOf.tryCatch (ε:=ε) x h : ExceptT ε' m α) post epost =
       wp (MonadExceptOf.tryCatch (ε:=ε) x h : m (Except ε' α))
         (epost.pushExcept post) epost.tail := by
   rfl
 
 @[simp]
-theorem tryCatch_lift_OptionT_wp (x : OptionT m α) (h : ε → OptionT m α) :
+theorem wp_tryCatch_lift_OptionT_apply_eq (x : OptionT m α) (h : ε → OptionT m α) :
   wp (MonadExceptOf.tryCatch (ε:=ε) x h : OptionT m α) post epost =
     wp (MonadExceptOf.tryCatch (ε:=ε) x h : m (Option α))
       (epost.pushOption post) epost.tail := by
   rfl
 
 @[simp]
-theorem throw_ReaderT_lift_wp (err : ε) :
+theorem wp_throw_ReaderT_lift_apply_eq (err : ε) :
     wp (MonadExceptOf.throw (ε:=ε) err : ReaderT ρ m α) post epost =
       wp (MonadLift.monadLift (MonadExceptOf.throw (ε:=ε) err : m α) :
         ReaderT ρ m α) post epost := by
   rfl
 
 @[simp]
-theorem throw_StateT_lift_wp (err : ε) :
+theorem wp_throw_StateT_lift_apply_eq (err : ε) :
     wp (MonadExceptOf.throw (ε:=ε) err : StateT σ m α) post epost =
       wp (MonadLift.monadLift (MonadExceptOf.throw (ε:=ε) err : m α) :
         StateT σ m α) post epost := by
   rfl
 
 @[simp]
-theorem tryCatch_ReaderT_lift_wp (x : ReaderT ρ m α) (h : ε → ReaderT ρ m α) :
+theorem wp_tryCatch_ReaderT_lift_apply_eq (x : ReaderT ρ m α) (h : ε → ReaderT ρ m α) :
     wp (MonadExceptOf.tryCatch (ε:=ε) x h : ReaderT ρ m α) post epost =
       fun r => wp (MonadExceptOf.tryCatch (ε:=ε) (x.run r) (fun e => (h e).run r) : m α)
         (fun a => post a r) epost := by
   rfl
 
 @[simp]
-theorem tryCatch_StateT_lift_wp (x : StateT σ m α) (h : ε → StateT σ m α) :
+theorem wp_tryCatch_StateT_lift_apply_eq (x : StateT σ m α) (h : ε → StateT σ m α) :
     wp (MonadExceptOf.tryCatch (ε:=ε) x h : StateT σ m α) post epost =
       fun s => wp (MonadExceptOf.tryCatch (ε:=ε) (x.run s) (fun e => (h e).run s) : m (α × σ))
         (fun (a, s') => post a s') epost := by
@@ -643,7 +643,7 @@ end
 /-! ## OrElse simp lemmas -/
 
 @[simp]
-theorem orElse_Except_wp (x : Except ε α) (h : Unit → Except ε α) :
+theorem wp_orElse_Except_apply_eq (x : Except ε α) (h : Unit → Except ε α) :
     wp (OrElse.orElse x h : Except ε α) post epost =
       wp x post epost⟨fun _ => wp (h ()) post epost⟩ := by
   simp only [wp, OrElse.orElse, MonadExcept.orElse]
@@ -663,14 +663,14 @@ variable {m : Type u → Type v} in
 section
 variable {m : Type u → Type v} [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
 
-theorem orElse_ExceptT_wp (x : ExceptT ε m α)
+theorem le_wp_orElse_ExceptT_apply (x : ExceptT ε m α)
     (h : Unit → ExceptT ε m α) :
     wp x post ⟨fun _ => wp (h ()) post epost, epost.tail⟩ ⊑
       wp (OrElse.orElse x h : ExceptT ε m α) post epost := by
-  apply tryCatch_ExceptT_wp
+  apply le_wp_tryCatch_ExceptT_apply
 
 @[simp]
-theorem orElse_OptionT_wp (x : OptionT m α)
+theorem le_wp_orElse_OptionT_apply (x : OptionT m α)
     (h : Unit → OptionT m α) :
   wp x post ⟨wp (h ()) post epost, epost.tail⟩ ⊑
     wp (OrElse.orElse x h : OptionT m α) post epost := by
@@ -685,7 +685,7 @@ theorem orElse_OptionT_wp (x : OptionT m α)
 end
 
 @[simp]
-theorem orElse_Option_wp (x : Option α) (h : Unit → Option α) :
+theorem wp_orElse_Option_apply_eq (x : Option α) (h : Unit → Option α) :
   ∀ post (epost : Prop),
   wp (OrElse.orElse x h : Option α) post epost =
     wp x post (wp (h ()) post epost) := by
@@ -693,7 +693,7 @@ theorem orElse_Option_wp (x : Option α) (h : Unit → Option α) :
   cases x <;> intro _ _ <;> rfl
 
 @[simp]
-theorem orElse_EStateM_wp (x : EStateM ε σ α) (h : Unit → EStateM ε σ α) :
+theorem wp_orElse_EStateM_apply_eq (x : EStateM ε σ α) (h : Unit → EStateM ε σ α) :
     wp (OrElse.orElse x h : EStateM ε σ α) post epost =
       fun s => wp x post (fun _ s' => wp (h ()) post epost s') s := by
   funext s


### PR DESCRIPTION
This PR cleans up the internal `Std.Internal.Do` weakest-precondition library: the wp application lemmas and the `Triple` entailment field are renamed to follow the naming convention, the loop-invariant types are curried, and the monad spec lemmas reuse the `Triple` rules.
