### PR TITLE
feat: add `Spec.monadLift_Id` lift spec for `Id`

### DIFF
--- a/src/Std/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Do/Triple/SpecLemmas.lean
@@ -261,6 +261,11 @@ theorem Spec.monadLift_OptionT [Monad m] [WPMonad m ps] (x : m α) (Q : PostCond
     (wp⟦x⟧ (fun a => Q.1 a, Q.2.2))
     Q := by simp [Triple.iff, SPred.entails.refl]
 
+@[spec]
+theorem Spec.monadLift_Id [Monad m] [WPMonad m ps] {α} (x : Id α) (Q : PostCond α ps) :
+    Triple (@MonadLiftT.monadLift Id m Id.instMonadLiftTOfPure α x) (spred(Q.1 x.run)) Q :=
+  Spec.pure' .rfl
+
 /-! # `MonadLiftT` -/
 
 @[spec]

--- a/src/Std/Internal/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Internal/Do/Triple/SpecLemmas.lean
@@ -98,6 +98,11 @@ theorem Spec.monadLift_OptionT (x : m α) (post : α → Pred) (epost : EPost.Co
     Triple (wp x post epost.tail) (MonadLift.monadLift x : OptionT m α) post epost :=
   Triple.iff.mpr (WPMonad.le_wp_monadLift_OptionT_apply x)
 
+@[spec]
+theorem Spec.monadLift_Id (x : Id α) :
+    Triple (post x.run) (@MonadLiftT.monadLift Id m Id.instMonadLiftTOfPure α x) post epost :=
+  Triple.pure x.run PartialOrder.rel_refl
+
 /-! # `MonadLiftT` -/
 
 omit [Monad m] in

--- a/tests/bench/mvcgen/sym/test_do_logic.lean
+++ b/tests/bench/mvcgen/sym/test_do_logic.lean
@@ -660,24 +660,12 @@ end LocalSpec
 
 namespace RawMonadLiftRegression
 
-/-! A raw `monadLift`/`liftM` of an inner-monad value used to loop, because `liftM.eq_1`
-(`@liftM = @monadLift`, a reducible no-op) was registered as a productive simp spec. It now
-terminates. It is still not dischargeable: `monadLift_trans` is selected but cannot determine the
-existential intermediate monad, so a missing spec is reported. Turn this into a successful proof
-once raw lifts are supported. -/
+/-! A raw `monadLift` of an `Id` value into an outer monad, discharged by `Spec.monadLift_Id`. -/
 
 def liftProg : StateT Nat Id Nat := do
   let x ← (pure 5 : Id Nat)
   return x
 
-/--
-error: No spec matching the monad StateT Nat
-  Id found for program monadLift
-  (pure
-    5). Candidates were [SpecProof.global Std.Do.Spec.UnfoldLift.monadLift_trans,
- SpecProof.global Std.Do.Spec.UnfoldLift.monadLift_refl].
--/
-#guard_msgs in
-example : ⦃ ⊤ ⦄ liftProg ⦃ fun r _ => r = 5 ⦄ := by mvcgen' [liftProg]
+example : ⦃ fun _ => ⌜True⌝ ⦄ liftProg ⦃ fun r _ => ⌜r = 5⌝ ⦄ := by mvcgen' [liftProg] <;> grind
 
 end RawMonadLiftRegression


### PR DESCRIPTION
This PR adds the weakest-precondition spec lemma `Spec.monadLift_Id` so that `mvcgen`/`mvcgen'` can discharge a do-bind that lifts an `Id` value into a `Pure`/`WPMonad` transformer stack (for example `let x ← (pure 5 : Id Nat)` inside `StateT Nat Id`).

The lemma is added in both the `Std.Do` and `Std.Internal.Do` spec families, alongside the existing `Spec.monadLift_StateT`/`ReaderT`/`ExceptT`/`OptionT` lemmas, covering the direct `Id`-into-`Pure` lift via `Id.instMonadLiftTOfPure`.