### PR TITLE
refactor: consolidate VCGen backward rules and missing-spec handling

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
@@ -72,8 +72,8 @@ public def prog (info : WPInfo) : Expr := info.args[8]!
 
 end VCGen.WPInfo
 
-/-- Pre-built backward rules for the introduction steps of `solve`. -/
-public structure VCGen.IntroRules where
+/-- Pre-built backward rules used by `solve`. -/
+public structure VCGen.BackwardRules where
   /-- The backward rule for `Triple.intro`. Unfolds `⦃P⦄ x ⦃Q; E⦄` into `P ⊑ wp x Q E`. -/
   tripleIntro : BackwardRule
   /-- The backward rule for `Lean.Order.le_of_forall_le`. Peels one excess state argument
@@ -88,21 +88,35 @@ public structure VCGen.IntroRules where
   /-- The backward rule for `Lean.Order.true_le_of_top_le`. Replaces a `True` precondition
   with `⊤` on the `Prop` lattice. -/
   truePreIntro : BackwardRule
-
-public structure VCGen.Context where
-  /-- Pre-built backward rules for the introduction steps of `solve`. -/
-  introRules : VCGen.IntroRules
   /-- The backward rule for `Lean.Order.top_le_prop`. Strips a `(⊤ : Prop) ⊑ ·` wrapper
   from a VC before it is emitted. -/
-  elimPreRule : BackwardRule
+  elimPre : BackwardRule
   /-- The backward rule for `And.intro`. -/
-  andIntroRule : BackwardRule
+  andIntro : BackwardRule
   /-- The backward rule for `Lean.Order.PartialOrder.rel_refl`. Closes a reflexive
   entailment `pre ⊑ pre`. -/
-  reflRule : BackwardRule
+  refl : BackwardRule
   /-- The backward rule for `meet_top_le_of_le`. Cancels a redundant `⊓ ⊤` on the left of an
   entailment, turning `P ⊓ ⊤ ⊑ Q` into `P ⊑ Q`. -/
-  meetTopRule : BackwardRule
+  meetTop : BackwardRule
+
+/-- Build the backward rules used by `solve` from their underlying lemmas. -/
+public def VCGen.mkBackwardRules : MetaM VCGen.BackwardRules := do
+  return {
+    tripleIntro := ← mkBackwardRuleFromDecl ``Std.Internal.Do.Triple.intro
+    stateArgIntro := ← mkBackwardRuleFromDecl ``Lean.Order.le_of_forall_le
+    propPreIntro := ← mkBackwardRuleFromDecl ``Lean.Order.le_of_imp_top_le
+    ofPropPreIntro := ← mkBackwardRuleFromDecl ``Lean.Order.ofProp_le
+    truePreIntro := ← mkBackwardRuleFromDecl ``Lean.Order.true_le_of_top_le
+    elimPre := ← mkBackwardRuleFromDecl ``Lean.Order.top_le_prop
+    andIntro := ← mkBackwardRuleFromDecl ``And.intro
+    refl := ← mkBackwardRuleFromDecl ``Lean.Order.PartialOrder.rel_refl
+    meetTop := ← mkBackwardRuleFromDecl ``Std.Internal.Do.CompleteLattice.meet_top_le_of_le
+  }
+
+public structure VCGen.Context where
+  /-- Pre-built backward rules used by `solve`. -/
+  backwardRules : VCGen.BackwardRules
   /-- User-customizable simp methods used to pre-simplify hypotheses. -/
   hypSimpMethods : Option Sym.Simp.Methods := none
   /-- The `trivial` config option: when `true` (default), `Driver.emitVC` runs
@@ -114,11 +128,10 @@ public structure VCGen.Context where
   zeta-unfolding. When `false` (default, matching original `mvcgen`), every call
   site of the JP zeta-unfolds, leading to exponential blow-up on nested splits. -/
   useJP : Bool := false
-  /-- The `errorOnMissingSpec` config option: when `true` (default), `Driver.work`
-  raises a hard error when `solve` returns `.noSpecFoundForProgram`. When `false`,
-  the goal is emitted as an unsolved VC for the user to discharge — useful with
-  `mvcgen' [-some_spec]` patterns where the user knows the spec is intentionally
-  removed and wants to handle the residual goal by hand. -/
+  /-- The `errorOnMissingSpec` config option: when `true` (default), a program with no matching
+  spec raises a hard error. When `false`, the goal is emitted as an unsolved VC for the user to
+  discharge — useful with `mvcgen' [-some_spec]` patterns where the user knows the spec is
+  intentionally removed and wants to handle the residual goal by hand. -/
   errorOnMissingSpec : Bool := true
   /-- The `debug` config option: when `true`, `tryApplyRule` retries failed
   `BackwardRule.apply` calls after `unfoldReducible` and reports an error when the

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
@@ -81,11 +81,9 @@ private def handleInvariantSubgoals (subgoals : List MVarId) : VCGenM (Array MVa
 Called when decomposing the goal further did not succeed; in this case we emit a VC for the goal.
 Invariant subgoals are handled separately by `handleInvariantSubgoals` directly inside `work`,
 so they never reach this path.
-If the goal is `(⊤ : Prop) ⊑ φ`, the `⊤ ⊑` wrapper is stripped first.
 -/
 public def emitVC (goal : Grind.Goal) : VCGenM Unit := do
-  let mvarId ← elimTopPre goal.mvarId
-  let mut goal := { goal with mvarId }
+  let mut goal := { goal with mvarId := ← elimTopPre goal.mvarId }
   goal ← processHypotheses goal
   if goal.inconsistent then return
   -- `trivial`: when false, skip `solveTrivialConjuncts` (which collapses And-chains via rfl);
@@ -113,14 +111,6 @@ public def work (scope : Scope) (goal : Grind.Goal) : VCGenM Unit := do
     match ← solve s.scope goal.mvarId with
     | .stop _reason =>
       emitVC goal
-    | .noSpecFoundForProgram prog monad thms => goal.mvarId.withContext do
-      if (← read).errorOnMissingSpec then
-        if thms.isEmpty then
-          throwError "No spec found for program {prog}."
-        else
-          throwError "No spec matching the monad {monad} found for program {prog}. Candidates were {thms.map (·.proof)}."
-      else
-        emitVC goal
     | .goals scope subgoals =>
       -- Handle invariant subgoals eagerly here, so that VC subgoals popped
       -- from the worklist later see the invariant MVar already assigned.

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Entails.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Entails.lean
@@ -30,7 +30,7 @@ namespace VCGen
 
 /-- Unfold `⦃P⦄ x ⦃Q; E⦄` into the underlying entailment `P ⊑ wp x Q E`. -/
 public def unfoldTriple (goal : MVarId) : VCGenM MVarId := do
-  let .goals [goal] ← (← read).introRules.tripleIntro.applyChecked goal
+  let .goals [goal] ← (← read).backwardRules.tripleIntro.applyChecked goal
     | throwError "Failed to unfold the Triple target of {goal}"
   return goal
 
@@ -92,7 +92,7 @@ public def elimTopPre (goal : MVarId) : VCGenM MVarId := do
   let some (.sort .zero, _, pre, _) := (← goal.getType).app4? ``Lean.Order.PartialOrder.rel
     | return goal
   unless pre.isAppOf ``Lean.Order.top do return goal
-  let .goals [goal] ← (← read).elimPreRule.apply goal
+  let .goals [goal] ← (← read).backwardRules.elimPre.apply goal
     | throwError "Failed to strip the `⊤ ⊑` wrapper of {goal}"
   return goal
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
@@ -111,23 +111,9 @@ public def mkContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := false) 
           if let some thm ← mkSpecTheoremFromLocal fvar then
             specThms := specThms.insert thm
         catch _ => continue
-  let tripleIntro ← mkBackwardRuleFromDecl ``Std.Internal.Do.Triple.intro
-  let stateArgIntro ← mkBackwardRuleFromDecl ``Lean.Order.le_of_forall_le
-  let propPreIntro ← mkBackwardRuleFromDecl ``Lean.Order.le_of_imp_top_le
-  let ofPropPreIntro ← mkBackwardRuleFromDecl ``Lean.Order.ofProp_le
-  let truePreIntro ← mkBackwardRuleFromDecl ``Lean.Order.true_le_of_top_le
-  let elimPreRule ← mkBackwardRuleFromDecl ``Lean.Order.top_le_prop
-  let andIntroRule ← mkBackwardRuleFromDecl ``And.intro
-  let reflRule ← mkBackwardRuleFromDecl ``Lean.Order.PartialOrder.rel_refl
-  let meetTopRule ← mkBackwardRuleFromDecl ``Std.Internal.Do.CompleteLattice.meet_top_le_of_le
-  let allSpecThms ← SymM.run <| extendWithSimpSpecs specThms simpThms
-  let ctx : VCGen.Context := {
-    introRules := { tripleIntro, stateArgIntro, propPreIntro, ofPropPreIntro, truePreIntro },
-    elimPreRule,
-    andIntroRule,
-    reflRule,
-    meetTopRule,
-  }
+  let backwardRules ← VCGen.mkBackwardRules
+  let allSpecThms ← extendWithSimpSpecs specThms simpThms
+  let ctx : VCGen.Context := { backwardRules }
   return (ctx, { specs := allSpecThms })
 
 end VCGen

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
@@ -67,7 +67,7 @@ public def mkBackwardRuleForSplitCached (splitInfo : SplitInfo) (info : WPInfo) 
   return rule
 
 /--
-Cached version of `LatticeSplit.mkBackwardRule`.
+Cached version of `LatticeSplit.mkBackwardRuleForLattice`.
 
 Cache key: `(distribution lemma, argument types, excessArgs.size)`.
 -/
@@ -77,7 +77,7 @@ public def mkBackwardRuleForLatticeCached (c : LatticeSplit) (as excessArgs : Ar
   let asTypes ← (as.mapM Sym.inferType : SymM (Array Expr))
   let key := (c.applyLemma, asTypes, excessArgs.size)
   if let some rule := s[key]? then return rule
-  let rule ← c.mkBackwardRule as excessArgs resultType?
+  let rule ← c.mkBackwardRuleForLattice as excessArgs resultType?
   modify fun st => { st with latticeBackwardRuleCache := st.latticeBackwardRuleCache.insert key rule }
   return rule
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
@@ -36,7 +36,7 @@ entailment `pre ⊑ e s₁ … sₙ`.
 -/
 
 /-- A decomposition of a lattice logic connective on the RHS of an entailment. Bundles everything
-`LatticeSplit.mkBackwardRule` needs: how to rebuild the connective, the pointwise `_apply`
+`LatticeSplit.mkBackwardRuleForLattice` needs: how to rebuild the connective, the pointwise `_apply`
 distribution lemma, the `⊑`-form split lemma, and whether the operands depend on the excess (state)
 arguments. -/
 public structure LatticeSplit where
@@ -163,7 +163,7 @@ For `⇨`, produces:
 ```
 Works for any `CompleteLattice`, not just `Prop`.
 -/
-public def LatticeSplit.mkBackwardRule
+public def LatticeSplit.mkBackwardRuleForLattice
     (c : LatticeSplit) (as : Array Expr) (excessArgs : Array Expr)
     (resultType? : Option Expr := none)
     : MetaM BackwardRule := do

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -37,17 +37,15 @@ public inductive SolveResult.StopReason where
   | noEntailment (target : Expr)
   /-- The target was of the form `pre ⊑ rhs`, but we couldn't make further progress. -/
   | noProgress (pre rhs : Expr)
+  /-- No spec was found for the program `e` in `pre ⊑ wp e post epost s₁ ... sₙ`. Candidates
+  were `thms`, but none matched the monad. Reached only when `errorOnMissingSpec` is `false`. -/
+  | noSpecFound (e : Expr) (monad : Expr) (thms : Array SpecTheorem)
 
 /-- The result of one `solve` step of VC generation. -/
 public inductive SolveResult where
   /-- Successfully decomposed the goal. These are the subgoals, sharing `scope`. -/
   | goals (scope : VCGen.Scope) (subgoals : List MVarId)
-  /--
-  Did not find a spec for the `e` in `pre ⊑ wp e post epost s₁ ... sₙ`.
-  Candidates were `thms`, but none of them matched the monad.
-  -/
-  | noSpecFoundForProgram (e : Expr) (monad : Expr) (thms : Array SpecTheorem)
-  /-- No further progress possible on the current goal for the given reason. Emit goal as VC. -/
+  /-- No further progress possible; emit the current goal as a VC. -/
   | stop (reason : SolveResult.StopReason)
 
 private def isDuplicable (e : Expr) : Bool := match e with
@@ -116,26 +114,27 @@ Runs before the precondition lift so a spec handoff `pre ⊑ specPre` closes by 
 than an assumption search. The pattern matcher keeps synthetic-opaque invariant holes rigid, so
 `⊤ ⊑ ?inv args` is left untouched. -/
 private def rfl? (goal : MVarId) : VCGenM (Option (List MVarId)) := do
-  let .goals gs ← (← read).reflRule.apply goal | return none
+  let .goals gs ← (← read).backwardRules.refl.apply goal | return none
   trace[Elab.Tactic.Do.vcgen] "Solved by rfl {goal}"
   return some gs
 
-/-- Strategy 10: close `pre ⊑ φ` on the `Prop` lattice against the most recently lifted pure
-precondition, cached in `Scope.lastLiftedPre?`. Runs after lattice decomposition, so `φ` is an
-opaque proposition rather than a lattice connective. This is one defeq check against one
-hypothesis, not an assumption search.
+/-- The most recently lifted pure precondition (cached in `Scope.lastLiftedPre?`) whose type is
+the same hash-consed expression as `e`, or `none`. Must run in `goal`'s context. -/
+private def liftedPreFor? (scope : VCGen.Scope) (e : Expr) : VCGenM (Option LocalDecl) := do
+  let some fvarId := scope.lastLiftedPre? | return none
+  let some hyp := (← getLCtx).find? fvarId | return none
+  unless isSameExpr e hyp.type do return none
+  trace[Elab.Tactic.Do.vcgen] "Solved by lifted hypothesis {hyp.userName}"
+  return some hyp
 
-Goals whose RHS contains metavariables are skipped: the defeq check could otherwise assign
-a post abstraction from an unrelated hypothesis. -/
+/-- Strategy 10: close `pre ⊑ φ` on the `Prop` lattice against the most recently lifted pure
+precondition. Runs after lattice decomposition, so `φ` is an opaque proposition rather than a
+lattice connective. This is one comparison against one hypothesis, not an assumption search. -/
 private def liftedHyp? (scope : VCGen.Scope) (goal : MVarId) (α pre rhs : Expr) :
     VCGenM (Option (List MVarId)) :=
   goal.withContext do
     unless α.isProp do return none
-    if rhs.hasExprMVar then return none
-    let some fvarId := scope.lastLiftedPre? | return none
-    let some hyp := (← getLCtx).find? fvarId | return none
-    unless ← isDefEqS rhs hyp.type do return none -- TODO: Replace with isSameExpr test?
-    trace[Elab.Tactic.Do.vcgen] "Solved by lifted hypothesis {hyp.userName}"
+    let some hyp ← liftedPreFor? scope rhs | return none
     goal.assign (← mkAppM ``Lean.Order.le_of_right #[pre, rhs, hyp.toExpr])
     return some []
 
@@ -145,11 +144,7 @@ just before it would be classified as a VC. -/
 private def liftedHypBare? (scope : VCGen.Scope) (goal : MVarId) (target : Expr) :
     VCGenM (Option (List MVarId)) :=
   goal.withContext do
-    if target.hasExprMVar then return none
-    let some fvarId := scope.lastLiftedPre? | return none
-    let some hyp := (← getLCtx).find? fvarId | return none
-    unless ← isDefEqS target hyp.type do return none -- TODO: Replace with isSameExpr test?
-    trace[Elab.Tactic.Do.vcgen] "Solved by lifted hypothesis {hyp.userName}"
+    let some hyp ← liftedPreFor? scope target | return none
     goal.assign hyp.toExpr
     return some []
 
@@ -158,7 +153,7 @@ Such a precondition arises when `himp_complete` splits `⊤ ⊑ a ⇨ b` into `a
 private def stripMeetTopPre? (goal : MVarId) (pre : Expr) : VCGenM (Option MVarId) := do
   let_expr Lean.Order.meet _l _inst _P top := pre | return none
   unless top.isAppOf ``Lean.Order.top do return none
-  let .goals [g] ← (← read).meetTopRule.applyChecked goal
+  let .goals [g] ← (← read).backwardRules.meetTop.applyChecked goal
     | throwError "Failed to cancel the `⊓ ⊤` precondition of {goal}"
   return some g
 
@@ -168,7 +163,7 @@ leave `⌜φ⌝` applied to the introduced arguments. Returns the new goal and t
 private def ofPropPreIntro? (goal : MVarId) (pre : Expr) : VCGenM (Option (MVarId × FVarId)) := do
   let_expr CompleteLattice.ofProp _l _inst φ := pre | return none
   if φ.isTrue then return none
-  return some (← introPre (← read).introRules.ofPropPreIntro goal)
+  return some (← introPre (← read).backwardRules.ofPropPreIntro goal)
 
 /-- Strategy 7: move a bare `Prop` precondition `φ ⊑ rhs` into the local context via
 `le_of_imp_top_le`, leaving `⊤ ⊑ rhs`. Runs after `True` and `⊤` preconditions are handled, so
@@ -176,13 +171,13 @@ private def ofPropPreIntro? (goal : MVarId) (pre : Expr) : VCGenM (Option (MVarI
 private def barePreIntro? (goal : MVarId) (α pre : Expr) : VCGenM (Option (MVarId × FVarId)) := do
   unless α.isProp do return none
   if pre.isAppOf ``Lean.Order.top then return none
-  return some (← introPre (← read).introRules.propPreIntro goal)
+  return some (← introPre (← read).backwardRules.propPreIntro goal)
 
 /-- Strategy 7: replace a `True` precondition by `⊤` via `true_le_of_top_le`, so the goal
 follows the `⊤` path instead of lifting `True` into the local context. -/
 private def truePre? (goal : MVarId) (pre target : Expr) : VCGenM (Option (List MVarId)) := do
   unless pre.isTrue do return none
-  let .goals [g] ← (← read).introRules.truePreIntro.applyChecked goal
+  let .goals [g] ← (← read).backwardRules.truePreIntro.applyChecked goal
     | throwError "Failed to apply {.ofConstName ``Lean.Order.true_le_of_top_le} to{indentExpr target}"
   return some [g]
 
@@ -277,13 +272,25 @@ private def wpHeadReduce? (goal : MVarId) (target : Expr) (info : WPInfo) :
   let prog ← betaRevS f' info.prog.getAppRevArgs
   return some (← replaceProgDefEq goal target info prog)
 
+/-- Stop or raise on a program with no matching spec. With `errorOnMissingSpec` (default), raise a
+hard error naming the program and any candidate specs; otherwise stop and emit the goal as a VC. -/
+private def stopOrErrorOnMissingSpec (prog monad : Expr) (thms : Array SpecTheorem) :
+    VCGenM SolveResult := do
+  unless (← read).errorOnMissingSpec do
+    return .stop (.noSpecFound prog monad thms)
+  if thms.isEmpty then
+    throwError "No spec found for program {prog}."
+  else
+    throwError "No spec matching the monad {monad} found for program {prog}. \
+      Candidates were {thms.map (·.proof)}."
+
 /-- Strategy 11e: look up a registered `@[spec]` theorem (triple or simp) for the program head
 and apply its cached backward rule. -/
 private def applySpec (scope : VCGen.Scope) (goal : MVarId) (target : Expr) (info : WPInfo) :
     VCGenM SolveResult := do
   trace[Elab.Tactic.Do.vcgen] "Applying a spec for {info.prog}. Excess args: {info.excessArgs}"
   match ← SpecTheorems.findSpecs scope.specs info.prog with
-  | .error thms => return .noSpecFoundForProgram info.prog info.m thms
+  | .error thms => stopOrErrorOnMissingSpec info.prog info.m thms
   | .ok thm =>
   trace[Elab.Tactic.Do.vcgen] "Spec for {info.prog}: {thm.proof}"
   let some rule ←
@@ -295,7 +302,7 @@ private def applySpec (scope : VCGen.Scope) (goal : MVarId) (target : Expr) (inf
         target:{indentExpr target}\n\
         Pred:{indentExpr info.Pred}\n\
         excessArgs: {info.excessArgs}"
-    | return .noSpecFoundForProgram info.prog info.m #[thm]
+    | stopOrErrorOnMissingSpec info.prog info.m #[thm]
   let .goals goals ← rule.applyChecked goal m!"spec rule for{indentExpr info.prog}"
     | do
       let ruleType ← Meta.inferType rule.expr
@@ -359,10 +366,10 @@ public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := g
   if let some g ← targetLetIntro? goal target then return .goals scope [g]
   if let some g ← tripleUnfold? goal target then return .goals scope [g]
   if let some g ← bareWPToLe? goal target then return .goals scope [g]
+  if let some gs ← liftedHypBare? scope goal target then return .goals scope gs
 
   let_expr PartialOrder.rel α inst pre rhs := target
-    | if let some gs ← liftedHypBare? scope goal target then return .goals scope gs
-      else return .stop (.noEntailment target)
+    | return .stop (.noEntailment target)
 
   -- Phase 2: close reflexive goals, then drive `pre` toward `⊤`, lifting any pure content so a
   -- later spec application sees a `⊤` precondition.

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
@@ -131,7 +131,7 @@ Hoare triple and `⊑ wp` specs are already in `database`: the attribute stores 
 at annotation time.
 -/
 public def extendWithSimpSpecs (database : SpecTheorems) (simpThms : SimpTheorems) :
-    SymM SpecTheorems := do
+    MetaM SpecTheorems := do
   let mut specs := database.specs
   -- Erased entries are still inserted into `specs` below; `findSpecs` filters them out
   -- at lookup time.
@@ -153,7 +153,7 @@ public def extendWithSimpSpecs (database : SpecTheorems) (simpThms : SimpTheorem
       | some eqThms => pure eqThms
       | none =>
         -- No explicit equational theorems stored; generate them via `getEqnsFor?`
-        let some eqThms ← liftMetaM <| Meta.getEqnsFor? declName | continue
+        let some eqThms ← Meta.getEqnsFor? declName | continue
         pure eqThms
     for eqThm in eqThms do
       try

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Util.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Util.lean
@@ -122,7 +122,7 @@ public partial def introsExcessArgs (goal : MVarId) :
   let type ← goal.getType
   let_expr PartialOrder.rel α _inst _pre _rhs := type | return goal
   unless α.isForall do return goal
-  let .goals [goal] ← (← read).introRules.stateArgIntro.applyChecked goal | return goal
+  let .goals [goal] ← (← read).backwardRules.stateArgIntro.applyChecked goal | return goal
   let goal ← introsHygienic goal
   introsExcessArgs goal
 
@@ -140,7 +140,7 @@ public partial def solveTrivialConjuncts (goal : MVarId) : VCGenM (Option MVarId
     goal.assign (mkConst ``True.intro)
     return none
   else if ty.isAppOf ``And then
-    let .goals [g₁, g₂] ← ctx.andIntroRule.applyChecked goal
+    let .goals [g₁, g₂] ← ctx.backwardRules.andIntro.applyChecked goal
       | throwError "solveTrivialConjuncts: failed to apply {.ofConstName ``And.intro} to{indentExpr ty}"
     match ← solveTrivialConjuncts g₁, ← solveTrivialConjuncts g₂ with
     | none,    none    => return none


### PR DESCRIPTION
This PR refactors the internal `mvcgen'` VC generator with no change in behaviour. It collects the backward rules into one `BackwardRules` structure built by `VCGen.mkBackwardRules`, folds the `SolveResult.noSpecFoundForProgram` constructor into a `stopOrErrorOnMissingSpec` helper plus a `StopReason` so `solve` owns the `errorOnMissingSpec` decision, factors the shared lifted-hypothesis lookup into `liftedPreFor?`, renames `LatticeSplit.mkBackwardRule` to `mkBackwardRuleForLattice`, and runs `extendWithSimpSpecs` in `MetaM`.
