### PR TITLE
test: tidy mvcgen' sym benchmark cases

### DIFF
--- a/tests/bench/mvcgen/sym/cases/Cases/AddSubCancel.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/AddSubCancel.lean
@@ -1,17 +1,20 @@
 import Lean
 import Std.Tactic.Do
-/-!
-Port of `Sym/Cases/AddSubCancel` to the new meta theory.
 
+/-!
 Basic add/sub loop in `StateM`: each `step` adds then subtracts the same value, so the
 loop preserves the state. Exercises the `get`/`set` `StateT` specs in the simplest setting.
 -/
 
 open Lean Meta Order Std.Internal.Do
 
+namespace AddSubCancel
+
 set_option mvcgen.warning false
 
-namespace AddSubCancel
+-- The following specs partially evaluate the specs for `get` and `set` that otherwise would need
+-- multiple small substeps in the modular lifting framework. This is good practice for performance
+-- sensitive use cases.
 
 @[spec high] theorem spec_get_StateT {m : Type u → Type v} {Pred EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]

--- a/tests/bench/mvcgen/sym/cases/Cases/AddSubCancelDeep.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/AddSubCancelDeep.lean
@@ -1,25 +1,15 @@
 import Lean
 import Std.Tactic.Do
+
 /-!
-Port of `Sym/Cases/AddSubCancelDeep` to the new meta theory.
-
 Same loop as `AddSubCancel` but threaded through a deep monad transformer stack.
-
-Known issue: the partially-evaluated `getThe`/`set` specs for this deep stack are not yet
-provable by `mvcgen'` (see the divergence notes below),
-so they are currently axiomatized with `sorry`. The benchmark still exercises VC generation
-through the deep stack using these specs.
 -/
 
 open Lean Parser Meta Elab Tactic Sym Lean.Order Std.Internal.Do
 
-set_option mvcgen.warning false
-
 namespace AddSubCancelDeep
 
-/-!
-Same case as `AddSubCancel` but using a deep transformer stack.
--/
+set_option mvcgen.warning false
 
 abbrev M := ExceptT String <| ReaderT String <| ExceptT Nat <| StateT Nat <| ExceptT Unit <| StateM Unit
 

--- a/tests/bench/mvcgen/sym/cases/Cases/AddSubCancelSimp.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/AddSubCancelSimp.lean
@@ -1,17 +1,16 @@
 import Lean
 import Std.Tactic.Do
-/-!
-Port of `Sym/Cases/AddSubCancelSimp` to the new meta theory.
 
+/-!
 Same benchmark as `AddSubCancel` but using equality (`simp`) specs for `get` and `set`
 instead of triple specs. Exercises the simp/equality spec rule-construction path.
 -/
 
 open Lean Meta Order Std.Internal.Do
 
-set_option mvcgen.warning false
-
 namespace AddSubCancelSimp
+
+set_option mvcgen.warning false
 
 /- TODO: Those lemmas actually not used because priorites are not respected for simp lemmas.
   Moreover, if `mvcgen'` actually used them, it wpould have lead to a bug:

--- a/tests/bench/mvcgen/sym/cases/Cases/DiteSplit.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/DiteSplit.lean
@@ -1,17 +1,16 @@
 import Lean
 import Std.Tactic.Do
-/-!
-Port of `Sym/Cases/DiteSplit` to the new meta theory.
 
+/-!
 Dependent if-then-else (`if h : cond then ...`) inside an `ExceptT String <| StateM Nat`
 program. The add/sub around the guarded `throw` keeps the state unchanged on the success path.
 -/
 
 open Lean Meta Order Std.Internal.Do
 
-set_option mvcgen.warning false
-
 namespace DiteSplit
+
+set_option mvcgen.warning false
 
 abbrev M := ExceptT String <| StateM Nat
 
@@ -38,6 +37,5 @@ def loop (n : Nat) : M Unit := do
   | n+1 => step n; loop n
 
 def Goal (n : Nat) : Prop := ⦃fun s => s = 0⦄ loop n ⦃fun _ s => s = 0⦄
-
 
 end DiteSplit

--- a/tests/bench/mvcgen/sym/cases/Cases/GetThrowSet.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/GetThrowSet.lean
@@ -1,8 +1,7 @@
 import Lean
 import Std.Tactic.Do
-/-!
-Port of `Sym/Cases/GetThrowSet` to the new meta theory.
 
+/-!
 Exception handling with `ExceptT String <| StateM Nat`: each `step` conditionally throws and
 otherwise increments the state by one. With the loop driving the state up from `0` the guard
 never fires, so the program never throws and ends at state `n`.
@@ -10,14 +9,16 @@ never fires, so the program never throws and ends at state `n`.
 
 open Lean Meta Order Std.Internal.Do
 
-set_option mvcgen.warning false
-
 namespace GetThrowSet
+
+set_option mvcgen.warning false
 
 abbrev M := ExceptT String <| StateM Nat
 
-@[spec high] theorem spec_throw (e : String) {post : α → Nat → Prop} {epost : EPost⟨String → Nat → Prop⟩} :
-    Triple (epost.head e) (throw (m := M) e) post epost := ⟨PartialOrder.rel_refl⟩
+-- Partially evaluated specs for best performance.
+
+@[spec high] theorem spec_throw (e : String) {post : α → Nat → Prop} :
+    ⦃epost e⦄ (throw (m := M) e) ⦃post; epost⦄ := ⟨PartialOrder.rel_refl⟩
 
 @[spec high] theorem spec_set (x : Nat) :
     ⦃fun _ => post ⟨⟩ x⦄ (set (m := M) x) ⦃post⦄ := by

--- a/tests/bench/mvcgen/sym/cases/Cases/LetBinding.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/LetBinding.lean
@@ -1,17 +1,18 @@
 import Lean
 import Std.Tactic.Do
-/-!
-Port of `Sym/Cases/LetBinding` to the new meta theory.
 
+/-!
 Same add/sub loop as `AddSubCancel` but with a pure `let offset := ...` binding inside `step`.
 Exercises the handling of pure `letE` nodes in the elaborated program (let-hoist / let-intro).
 -/
 
 open Lean Meta Order Std.Internal.Do
 
+namespace LetBinding
+
 set_option mvcgen.warning false
 
-namespace LetBinding
+-- Partially evaluated specs for best performance.
 
 @[spec high] theorem spec_get_StateT {m : Type u → Type v} {Pred EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
@@ -27,7 +28,7 @@ namespace LetBinding
 
 def step (v : Nat) : StateM Nat Unit := do
   let s ← get
-  -- Pure let binding: `let offset := ...` produces a `letE` node in the elaborated term.
+  -- Pure let binding: `let offset := ...` produces a letE node in the elaborated term
   let offset := v + 1
   set (s + offset)
   let s ← get
@@ -39,6 +40,5 @@ def loop (n : Nat) : StateM Nat Unit := do
   | n+1 => step n; loop n
 
 def Goal (n : Nat) : Prop := ∀ post, ⦃post⦄ loop n ⦃fun _ => post⦄
-
 
 end LetBinding

--- a/tests/bench/mvcgen/sym/cases/Cases/MatchIota.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/MatchIota.lean
@@ -1,30 +1,29 @@
 import Lean
 import Std.Tactic.Do
-/-!
-Port of `Sym/Cases/MatchIota` to the new meta theory.
 
+/-!
 Pattern matching with a concrete discriminant (the literal argument `v` of `step`). Each
 `match v with | 0 => ... | n+1 => ...` iota-reduces during VC generation (no symbolic split).
 Because `loop` eventually calls `step 0`, the program throws, so the exceptional postcondition
-is left unconstrained (`⊤`).
+is left unconstrained.
 -/
 
 open Lean Meta Order Std.Internal.Do
 
-set_option mvcgen.warning false
-
 namespace MatchIota
+
+set_option mvcgen.warning false
 
 abbrev M := ExceptT String <| StateM Nat
 
-@[spec high] theorem spec_throw (e : String) {post : α → Nat → Prop} {epost : EPost⟨String → Nat → Prop⟩} :
-    Triple (epost.head e) (throw (m := M) e) post epost := ⟨PartialOrder.rel_refl⟩
+@[spec high] theorem spec_throw (e : String) {post : α → Nat → Prop} :
+    ⦃epost e⦄ (throw (m := M) e) ⦃post; epost⦄ := ⟨PartialOrder.rel_refl⟩
 
-@[spec high] theorem spec_set (x : Nat) {post : PUnit → Nat → Prop} {epost : EPost⟨String → Nat → Prop⟩} :
-    Triple (fun _ => post ⟨⟩ x) (set (m := M) x) post epost := ⟨PartialOrder.rel_refl⟩
+@[spec high] theorem spec_set (x : Nat) {post : PUnit → Nat → Prop} :
+    ⦃fun _ => post ⟨⟩ x⦄ (set (m := M) x) ⦃post⦄ := ⟨PartialOrder.rel_refl⟩
 
-@[spec high] theorem spec_get (post : Nat → Nat → Prop) {epost : EPost⟨String → Nat → Prop⟩} :
-    Triple (fun s => post s s) (get (m := M)) post epost := ⟨PartialOrder.rel_refl⟩
+@[spec high] theorem spec_get (post : Nat → Nat → Prop) :
+    ⦃fun s => post s s⦄ (get (m := M)) ⦃post⦄ := ⟨PartialOrder.rel_refl⟩
 
 def step (v : Nat) : M Unit := do
   let s ← get

--- a/tests/bench/mvcgen/sym/cases/Cases/MatchSplit.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/MatchSplit.lean
@@ -1,8 +1,7 @@
 import Lean
 import Std.Tactic.Do
-/-!
-Port of `Sym/Cases/MatchSplit` to the new meta theory.
 
+/-!
 Pattern matching where the discriminant *is* the symbolic state (`match s with ...` after
 `let s ← get`). Unlike `MatchIota`, the discriminant is not a literal, so VC generation must
 perform a genuine match split. The initial state is kept symbolic (via `s = n`) so the split
@@ -12,20 +11,20 @@ at `0` after exactly `n` steps without ever throwing.
 
 open Lean Meta Order Std.Internal.Do
 
-set_option mvcgen.warning false
-
 namespace MatchSplit
+
+set_option mvcgen.warning false
 
 abbrev M := ExceptT String <| StateM Nat
 
-@[spec high] theorem spec_throw (e : String) {post : α → Nat → Prop} {epost : EPost⟨String → Nat → Prop⟩} :
-    Triple (epost.head e) (throw (m := M) e) post epost := ⟨PartialOrder.rel_refl⟩
+@[spec high] theorem spec_throw (e : String) {post : α → Nat → Prop} :
+    ⦃epost e⦄ (throw (m := M) e) ⦃post; epost⦄ := ⟨PartialOrder.rel_refl⟩
 
-@[spec high] theorem spec_set (x : Nat) {post : PUnit → Nat → Prop} {epost : EPost⟨String → Nat → Prop⟩} :
-    Triple (fun _ => post ⟨⟩ x) (set (m := M) x) post epost := ⟨PartialOrder.rel_refl⟩
+@[spec high] theorem spec_set (x : Nat) {post : PUnit → Nat → Prop} :
+    ⦃fun _ => post ⟨⟩ x⦄ (set (m := M) x) ⦃post⦄ := ⟨PartialOrder.rel_refl⟩
 
-@[spec high] theorem spec_get (post : Nat → Nat → Prop) {epost : EPost⟨String → Nat → Prop⟩} :
-    Triple (fun s => post s s) (get (m := M)) post epost := ⟨PartialOrder.rel_refl⟩
+@[spec high] theorem spec_get (post : Nat → Nat → Prop) :
+    ⦃fun s => post s s⦄ (get (m := M)) ⦃post⦄ := ⟨PartialOrder.rel_refl⟩
 
 /-- Matches on state `s` — the discriminant IS the excess state arg. -/
 def step : M Unit := do

--- a/tests/bench/mvcgen/sym/cases/Cases/PurePrecond.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/PurePrecond.lean
@@ -1,8 +1,7 @@
 import Lean
 import Std.Tactic.Do
-/-!
-Port of `Sym/Cases/PurePrecond` to the new meta theory.
 
+/-!
 Exercises pure propositional hypotheses in preconditions. `flipp` flips a `Bool` state, but
 its specs only apply under a pure precondition fixing the current value (`b = true` / `b = false`),
 so VC generation must introduce and discharge these pure preconditions. `step` flips twice,
@@ -11,21 +10,21 @@ preserving `b = true`.
 
 open Lean Meta Order Std.Internal.Do
 
-set_option mvcgen.warning false
-
 namespace PurePrecond
+
+set_option mvcgen.warning false
 
 def flipp (_ : Bool) : StateM Bool Unit := modify not
 
 @[spec]
 theorem Spec.flipp_true :
-    Triple (fun b => b = true) (flipp true) (fun _ b => b = false) (⟨⟩ : EPost.Nil) := by
+    ⦃fun b => b = true⦄ (flipp true) ⦃fun _ b => b = false⦄ := by
   simp only [flipp, modify]
   mvcgen' with finish
 
 @[spec]
 theorem Spec.flipp_false :
-    Triple (fun b => b = false) (flipp false) (fun _ b => b = true) (⟨⟩ : EPost.Nil) := by
+    ⦃fun b => b = false⦄ (flipp false) ⦃fun _ b => b = true⦄ := by
   simp only [flipp, modify]
   mvcgen' with finish
 
@@ -38,7 +37,6 @@ def loop (n : Nat) : StateM Bool Unit := do
   | 0 => pure ()
   | n+1 => step; loop n
 
-def Goal (n : Nat) : Prop :=
-  ⦃fun b => b = true⦄ loop n ⦃fun _ b => b = true⦄
+def Goal (n : Nat) : Prop := ⦃fun b => b = true⦄ loop n ⦃fun _ b => b = true⦄
 
 end PurePrecond

--- a/tests/bench/mvcgen/sym/cases/Cases/ReaderState.lean
+++ b/tests/bench/mvcgen/sym/cases/Cases/ReaderState.lean
@@ -1,8 +1,7 @@
 import Lean
 import Std.Tactic.Do
-/-!
-Port of `Sym/Cases/ReaderState` to the new meta theory.
 
+/-!
 A `ReaderT Nat <| StateM Nat` combination. Each `step` reads the reader `r`, adds it to the
 state and then subtracts it again, so the loop preserves both the reader and the state.
 Exercises partially-evaluated `read`/`get`/`set` specs for the reader+state stack.
@@ -10,20 +9,22 @@ Exercises partially-evaluated `read`/`get`/`set` specs for the reader+state stac
 
 open Lean Meta Order Std.Internal.Do
 
-set_option mvcgen.warning false
-
 namespace ReaderState
+
+set_option mvcgen.warning false
 
 abbrev M := ReaderT Nat <| StateM Nat
 
-@[spec high] theorem spec_read (post : Nat → Nat → Nat → Prop) (epost : EPost.Nil) :
-    Triple (fun r s => post r r s) (read (m := M)) post epost := ⟨PartialOrder.rel_refl⟩
+-- Partially evaluated specs for best performance.
 
-@[spec high] theorem spec_get (post : Nat → Nat → Nat → Prop) (epost : EPost.Nil) :
-    Triple (fun r s => post s r s) (get (m := M)) post epost := ⟨PartialOrder.rel_refl⟩
+@[spec high] theorem spec_read (post : Nat → Nat → Nat → Prop) :
+    ⦃fun r s => post r r s⦄ (read (m := M)) ⦃post⦄ := ⟨PartialOrder.rel_refl⟩
 
-@[spec high] theorem spec_set (n : Nat) (post : PUnit → Nat → Nat → Prop) (epost : EPost.Nil) :
-    Triple (fun r _ => post ⟨⟩ r n) (set (m := M) n) post epost := ⟨PartialOrder.rel_refl⟩
+@[spec high] theorem spec_get (post : Nat → Nat → Nat → Prop) :
+    ⦃fun r s => post s r s⦄ (get (m := M)) ⦃post⦄ := ⟨PartialOrder.rel_refl⟩
+
+@[spec high] theorem spec_set (n : Nat) (post : PUnit → Nat → Nat → Prop) :
+    ⦃fun r _ => post ⟨⟩ r n⦄ (set (m := M) n) ⦃post⦄ := ⟨PartialOrder.rel_refl⟩
 
 def step : M Unit := do
   let r ← read

--- a/tests/bench/mvcgen/sym/test_do_logic.lean
+++ b/tests/bench/mvcgen/sym/test_do_logic.lean
@@ -22,7 +22,7 @@ Tests whose proofs do not mention `mvcgen`/`mvcgen'` (manual `mspec`/`mintro` pr
 are intentionally not ported.
 -/
 
-open Lean Order Meta Elab Tactic Sym Std Internal.Do Do.Internal.SpecAttr
+open Lean Order Meta Elab Tactic Sym Std Internal.Do
 
 set_option grind.warning false
 set_option warn.sorry false

--- a/tests/bench/mvcgen/sym/test_vcgen.lean
+++ b/tests/bench/mvcgen/sym/test_vcgen.lean
@@ -25,7 +25,7 @@ Each case exercises a different aspect of the VC generation:
 - `MatchSplit`: Pattern matching with symbolic discriminant (state), exercising match split
 -/
 
-open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do Do.Internal.SpecAttr
+open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do
 
 set_option maxRecDepth 10000
 set_option maxHeartbeats 10000000

--- a/tests/bench/mvcgen/sym/vcgen_add_sub_cancel.lean
+++ b/tests/bench/mvcgen/sym/vcgen_add_sub_cancel.lean
@@ -8,7 +8,7 @@ import Driver
 
 set_option mvcgen.warning false
 
-open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do Do.Internal.SpecAttr
+open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do
 open AddSubCancel
 
 set_option maxRecDepth 10000

--- a/tests/bench/mvcgen/sym/vcgen_add_sub_cancel_deep.lean
+++ b/tests/bench/mvcgen/sym/vcgen_add_sub_cancel_deep.lean
@@ -8,7 +8,7 @@ import Driver
 
 set_option mvcgen.warning false
 
-open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do Do.Internal.SpecAttr
+open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do
 open AddSubCancelDeep
 
 set_option maxRecDepth 10000

--- a/tests/bench/mvcgen/sym/vcgen_add_sub_cancel_simp.lean
+++ b/tests/bench/mvcgen/sym/vcgen_add_sub_cancel_simp.lean
@@ -8,7 +8,7 @@ import Driver
 
 set_option mvcgen.warning false
 
-open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do Do.Internal.SpecAttr
+open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do
 open AddSubCancelSimp
 
 set_option maxRecDepth 10000

--- a/tests/bench/mvcgen/sym/vcgen_get_throw_set.lean
+++ b/tests/bench/mvcgen/sym/vcgen_get_throw_set.lean
@@ -8,7 +8,7 @@ import Driver
 
 set_option mvcgen.warning false
 
-open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do Do.Internal.SpecAttr
+open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do
 open GetThrowSet
 
 set_option maxRecDepth 10000

--- a/tests/bench/mvcgen/sym/vcgen_get_throw_set_grind.lean
+++ b/tests/bench/mvcgen/sym/vcgen_get_throw_set_grind.lean
@@ -3,7 +3,7 @@ import Driver
 
 set_option mvcgen.warning false
 
-open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do Do.Internal.SpecAttr
+open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do
 open GetThrowSet
 
 -- Copy Goal into a separate namespace so the benchmark label reads `GetThrowSetGrind(n)`

--- a/tests/bench/mvcgen/sym/vcgen_match_split.lean
+++ b/tests/bench/mvcgen/sym/vcgen_match_split.lean
@@ -8,7 +8,7 @@ import Driver
 
 set_option mvcgen.warning false
 
-open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do Do.Internal.SpecAttr
+open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do
 open MatchIota
 
 set_option maxRecDepth 10000

--- a/tests/bench/mvcgen/sym/vcgen_pure_precond.lean
+++ b/tests/bench/mvcgen/sym/vcgen_pure_precond.lean
@@ -8,7 +8,7 @@ import Driver
 
 set_option mvcgen.warning false
 
-open Lean Parser Meta Elab Tactic Sym Std Do SpecAttr
+open Lean Parser Meta Elab Tactic Sym Std Do
 open PurePrecond
 
 set_option maxRecDepth 10000

--- a/tests/bench/mvcgen/sym/vcgen_reader_state.lean
+++ b/tests/bench/mvcgen/sym/vcgen_reader_state.lean
@@ -8,7 +8,7 @@ import Driver
 
 set_option mvcgen.warning false
 
-open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do Do.Internal.SpecAttr
+open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do
 open ReaderState
 
 set_option maxRecDepth 10000


### PR DESCRIPTION
This PR tidies the `mvcgen'` sym benchmark cases, leaving the test behaviour unchanged. It drops the "port to the new meta theory" framing from the module docstrings, prefers the `⦃ ⦄ ⦃ ⦄` triple notation over raw `Triple` applications where the exceptional postcondition is fixed, and removes the now-redundant `SpecAttr` opens since `@[spec]` is a builtin attribute.
