### PR TITLE
refactor: remove unnecessary library-search import cache environment extensions

### DIFF
--- a/src/Lean/Meta/LazyDiscrTree.lean
+++ b/src/Lean/Meta/LazyDiscrTree.lean
@@ -1043,7 +1043,7 @@ def createTreeCtx (ctx : Core.Context) : Core.Context := {
   }
 
 def findImportMatches
-      (ext : EnvExtension (IO.Ref (Option (LazyDiscrTree α))))
+      (ref : IO.Ref (Option (LazyDiscrTree α)))
       (addEntry : Name → ConstantInfo → MetaM (Array (InitEntry α)))
       (droppedKeys : List (List LazyDiscrTree.Key) := [])
       (constantsPerTask : Nat := 1000)
@@ -1053,8 +1053,6 @@ def findImportMatches
   let ngen ← getNGen
   let (cNGen, ngen) := ngen.mkChild
   setNGen ngen
-  let _ : Inhabited (IO.Ref (Option (LazyDiscrTree α))) := ⟨← IO.mkRef none⟩
-  let ref := ext.getState (←getEnv)
   let importTree ← (←ref.get).getDM $ do
     profileitM Exception  "lazy discriminator import initialization" (←getOptions) $ do
       let t ← createImportedDiscrTree (createTreeCtx cctx) cNGen (←getEnv) addEntry
@@ -1136,8 +1134,7 @@ based on priority and cache module declarations
 
 * `modulesTreeRef` points to the discriminator tree for local environment.
   Used for caching and created by `createLocalTree`.
-* `ext` should be an environment extension with an IO.Ref for caching the import lazy
-   discriminator tree.
+* `ref` is a process-global `IO.Ref` for caching the import lazy discriminator tree.
 * `addEntry` is the function for creating discriminator tree entries from constants.
 * `droppedKeys` contains keys we do not want to consider when searching for matches.
   It is used for dropping very general keys.
@@ -1148,7 +1145,7 @@ based on priority and cache module declarations
 -/
 def findMatchesExt
     (moduleTreeRef : ModuleDiscrTreeRef α)
-    (ext : EnvExtension (IO.Ref (Option (LazyDiscrTree α))))
+    (ref : IO.Ref (Option (LazyDiscrTree α)))
     (addEntry : Name → ConstantInfo → MetaM (Array (InitEntry α)))
     (droppedKeys : List (List LazyDiscrTree.Key) := [])
     (constantsPerTask : Nat := 1000)
@@ -1156,7 +1153,7 @@ def findMatchesExt
     (adjustResult : Nat → α → β)
     (ty : Expr) : MetaM (Array β) := do
   let moduleMatches ← findModuleMatches moduleTreeRef ty
-  let importMatches ← findImportMatches ext addEntry droppedKeys constantsPerTask droppedEntriesRef ty
+  let importMatches ← findImportMatches ref addEntry droppedKeys constantsPerTask droppedEntriesRef ty
   return Array.mkEmpty (moduleMatches.size + importMatches.size)
           |> moduleMatches.appendResultsAux (f := adjustResult)
           |> importMatches.appendResultsAux (f := adjustResult)
@@ -1164,14 +1161,13 @@ def findMatchesExt
 /--
 `findMatches` searches for entries in a lazily initialized discriminator tree.
 
-* `ext` should be an environment extension with an IO.Ref for caching the import lazy
-   discriminator tree.
+* `ref` is a process-global `IO.Ref` for caching the import lazy discriminator tree.
 * `addEntry` is the function for creating discriminator tree entries from constants.
 * `droppedKeys` contains keys we do not want to consider when searching for matches.
   It is used for dropping very general keys.
 * `droppedEntriesRef` optionally stores entries dropped from the tree for later use.
 -/
-def findMatches (ext : EnvExtension (IO.Ref (Option (LazyDiscrTree α))))
+def findMatches (ref : IO.Ref (Option (LazyDiscrTree α)))
     (addEntry : Name → ConstantInfo → MetaM (Array (InitEntry α)))
     (droppedKeys : List (List LazyDiscrTree.Key) := [])
     (constantsPerTask : Nat := 1000)
@@ -1180,4 +1176,4 @@ def findMatches (ext : EnvExtension (IO.Ref (Option (LazyDiscrTree α))))
   -- Pass droppedEntriesRef to also capture star-indexed lemmas from the current module
   let moduleTreeRef ← createModuleTreeRef addEntry droppedKeys droppedEntriesRef
   let incPrio _ v := v
-  findMatchesExt moduleTreeRef ext addEntry droppedKeys constantsPerTask droppedEntriesRef incPrio ty
+  findMatchesExt moduleTreeRef ref addEntry droppedKeys constantsPerTask droppedEntriesRef incPrio ty

--- a/src/Lean/Meta/Tactic/LibrarySearch.lean
+++ b/src/Lean/Meta/Tactic/LibrarySearch.lean
@@ -153,17 +153,12 @@ private def addImport (name : Name) (constInfo : ConstantInfo) :
     else
       pure a
 
-/-- Stores import discrimination tree. -/
-private def LibSearchState := IO.Ref (Option (LazyDiscrTree (Name × DeclMod)))
-
-private builtin_initialize defaultLibSearchState : IO.Ref (Option (LazyDiscrTree (Name × DeclMod))) ← do
+/-- Process-global cache for the imported-declarations discrimination tree. This must *not* live in
+an environment extension: the snapshot used by `--incr-load` compacts the whole environment object
+(including non-persistent extension state), and a mutable `IO.Ref` baked into the read-only mapped
+region is unsound to read or write. A process-global ref is rebuilt per process instead. -/
+private builtin_initialize ext : IO.Ref (Option (LazyDiscrTree (Name × DeclMod))) ←
   IO.mkRef .none
-
-private instance : Inhabited LibSearchState where
-  default := defaultLibSearchState
-
-private builtin_initialize ext : EnvExtension LibSearchState ←
-  registerEnvExtension (IO.mkRef .none)
 
 /--
 We drop `.star` and `Eq * * *` from the discriminator trees because
@@ -181,16 +176,15 @@ initialization performance.
 -/
 private def constantsPerImportTask : Nat := 6500
 
-/-- Environment extension for caching star-indexed lemmas.
-    Used for fallback when primary search finds nothing for fvar-headed goals. -/
-private builtin_initialize starLemmasExt : EnvExtension (IO.Ref (Option (Array (Name × DeclMod)))) ←
-  registerEnvExtension (IO.mkRef .none)
+/-- Process-global cache for star-indexed lemmas (see `ext`); used as a fallback when primary search
+    finds nothing for fvar-headed goals. -/
+private builtin_initialize starLemmasExt : IO.Ref (Option (Array (Name × DeclMod))) ←
+  IO.mkRef .none
 
 /-- Create function for finding relevant declarations.
     Also captures dropped entries in starLemmasExt for fallback search. -/
 def libSearchFindDecls (ty : Expr) : MetaM (Array (Name × DeclMod)) := do
-  let _ : Inhabited (IO.Ref (Option (Array (Name × DeclMod)))) := ⟨← IO.mkRef none⟩
-  let droppedRef := starLemmasExt.getState (←getEnv)
+  let droppedRef := starLemmasExt
   findMatches ext addImport
       (droppedKeys := droppedKeys)
       (constantsPerTask := constantsPerImportTask)
@@ -199,8 +193,7 @@ def libSearchFindDecls (ty : Expr) : MetaM (Array (Name × DeclMod)) := do
 
 /-- Get star-indexed lemmas (lazily computed during tree initialization). -/
 def getStarLemmas : MetaM (Array (Name × DeclMod)) := do
-  let _ : Inhabited (IO.Ref (Option (Array (Name × DeclMod)))) := ⟨← IO.mkRef none⟩
-  let ref := starLemmasExt.getState (←getEnv)
+  let ref := starLemmasExt
   match ←ref.get with
   | some lemmas => return lemmas
   | none =>

--- a/src/Lean/Meta/Tactic/Rewrites.lean
+++ b/src/Lean/Meta/Tactic/Rewrites.lean
@@ -90,16 +90,12 @@ def droppedKeys : List (List LazyDiscrTree.Key) := [[.star], [.const `Eq 3, .sta
 def createModuleTreeRef : MetaM (LazyDiscrTree.ModuleDiscrTreeRef (Name × RwDirection)) :=
   LazyDiscrTree.createModuleTreeRef addImport droppedKeys
 
-private def ExtState := IO.Ref (Option (LazyDiscrTree (Name × RwDirection)))
-
-private builtin_initialize ExtState.default : IO.Ref (Option (LazyDiscrTree (Name × RwDirection))) ← do
+/-- Process-global cache for the imported-declarations discrimination tree. This must *not* live in
+an environment extension: the snapshot used by `--incr-load` compacts the whole environment object
+(including non-persistent extension state), and a mutable `IO.Ref` baked into the read-only mapped
+region is unsound to read or write. A process-global ref is rebuilt per process instead. -/
+private builtin_initialize ext : IO.Ref (Option (LazyDiscrTree (Name × RwDirection))) ←
   IO.mkRef .none
-
-private instance : Inhabited ExtState where
-  default := ExtState.default
-
-private builtin_initialize ext : EnvExtension ExtState ←
-  registerEnvExtension (IO.mkRef .none)
 
 /--
 The maximum number of constants an individual task may perform.


### PR DESCRIPTION
This PR removes a number of environment extensions that were used merely to hold a global IO.Ref, making them unnecessary and preventing compatibility with disk snapshots.