### PR TITLE
test: reuse snapshots of most common headers across elab pile 

### DIFF
--- a/src/Lean/Elab/Frontend.lean
+++ b/src/Lean/Elab/Frontend.lean
@@ -240,6 +240,33 @@ private partial def resolveCancelTokensForSave (s : Language.SnapshotTree) : Bas
       tk.set
     resolveCancelTokensForSave child.get
 
+/--
+Updates the post-import `cmdState`'s `Environment.mainModule` so that subsequent commands
+elaborated on top of `snap` produce names under the correct module. Needed when the loader's
+main module name differs from the one baked into the saved snapshot (e.g. the snapshot was
+saved from `--stdin` but is loaded for a real file). For non-truncated snapshots whose
+`mainModule` already matches, this is effectively a no-op.
+-/
+private def setMainModule (snap : Language.Lean.InitialSnapshot) (m : Name) :
+    Language.Lean.InitialSnapshot := Id.run do
+  let some parsed := snap.result? | return snap
+  let processed := parsed.processedSnap.get
+  let some hps := processed.result? | return snap
+  if hps.cmdState.env.header.mainModule == m then
+    return snap
+  let newEnv := hps.cmdState.env.setMainModule m
+  -- `Command.mkState` derives `auxDeclNGen.namePrefix` from `mkPrivateName env .anonymous`, which
+  -- bakes in `env.mainModule`. Re-derive so aux decls land in the new module's private namespace
+  -- (otherwise `delabConst` flags them as inaccessible and pretty-prints them with `✝`).
+  let newCmdState := { hps.cmdState with
+    env := newEnv
+    auxDeclNGen := { hps.cmdState.auxDeclNGen with namePrefix := mkPrivateName newEnv .anonymous } }
+  let newProcessed : Language.Lean.HeaderProcessedSnapshot := { processed with
+    result? := some { hps with cmdState := newCmdState } }
+  { snap with
+    result? := some { parsed with
+      processedSnap := .finished none newProcessed } }
+
 def runFrontend
     (input : String)
     (opts : Options)
@@ -287,7 +314,11 @@ def runFrontend
       }
   let old? ← incrLoadFileName?.mapM fun incrFile => do
     let incr ← unsafe loadIncrSnapshot incrFile
-    if let some res := incr.snap.processedResult.get then
+    -- A loaded snapshot may have been saved from a different file (e.g. via `--incr-header-save`
+    -- on stdin) and so bake in a different `mainModule`. Patch it to match this invocation
+    -- so generated names like `_private.<mainModule>.<hash>...` stay consistent.
+    let snap := setMainModule incr.snap mainModuleName
+    if let some res := snap.processedResult.get then
       withImporting do
         -- The central incr HACK:
         -- Initializers roughly perform one of two functions: initializing their own variable, or
@@ -301,7 +332,7 @@ def runFrontend
       -- `Language.Lean.process` (taken when the loaded header doesn't match the new file's
       -- imports) calls `importModules`, which in turn requires the flag to be set. Restore it.
       unsafe enableInitializersExecution
-    return incr.snap
+    return snap
   let processor := Language.Lean.process
   let snap ← processor setup old? ctx
   let snaps := Language.toSnapshotTree snap

--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -543,6 +543,19 @@ extern "C" LEAN_EXPORT object * lean_compacted_region_read(b_obj_arg ofname, b_o
 #endif
 #endif
 
+        // A `--incr-load` snapshot bakes the whole environment into the region, including mutable
+        // `IO.Ref`s (e.g. each `RealizationContext.realizeMapRef`). Realizing on top of a loaded
+        // snapshot stores freshly heap-allocated objects through such a ref; their only root is the
+        // ref cell, which lives inside this mapping. LSan does not scan the mapping, so it would
+        // report those objects as leaks. Register the mapping as a root region so LSan follows the
+        // in-region refs. (The malloc fallback below is covered by `__lsan_ignore_object` instead.)
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+        if (is_mmap)
+            __lsan_register_root_region(buffer, size);
+#endif
+#endif
+
         if (!buffer) {
             buffer = static_cast<char *>(malloc(size));
             lseek(fd.get(), 0, SEEK_SET);
@@ -618,6 +631,11 @@ extern "C" LEAN_EXPORT obj_res lean_compacted_region_free(obj_arg region, object
     lean_ctor_set(region, 1, lean_box(0));
     lean_dec_ref(region);
     if (is_mmap) {
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+        __lsan_unregister_root_region(buffer, full_sz);
+#endif
+#endif
 #ifdef LEAN_WINDOWS
         lean_always_assert(UnmapViewOfFile(buffer));
 #else

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,12 @@ mangle_windows_path(MANGLED_CURRENT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
 set(LEAN_BIN "${MANGLED_BINARY_DIR}/bin")
 
+# Pre-elaborated header snapshots reused by tests with matching imports. The
+# `_lean` snapshot is for tests whose only import is `Lean`; the `_init`
+# snapshot is for tests with no imports at all (auto-imports `Init`).
+set(LEAN_HEADER_SNAPSHOT "${CMAKE_CURRENT_BINARY_DIR}/lean_header.snap")
+set(LEAN_HEADER_SNAPSHOT_INIT "${CMAKE_CURRENT_BINARY_DIR}/lean_header_init.snap")
+
 set(TEST_VARS "${LEAN_TEST_VARS}")
 
 # Test scripts can use these to find other parts of the repo, e.g. "$TEST_DIR/measure.py"
@@ -37,6 +43,14 @@ string(APPEND TEST_VARS " LEANC_OPTS='${LEANC_OPTS}'")
 
 # LEANC_OPTS in CXX is necessary for macOS c++ to find its headers
 string(APPEND TEST_VARS " CXX='${CMAKE_CXX_COMPILER} ${LEANC_OPTS}'")
+
+# Variables exported only for ctest-driven runs, via each test's `ENVIRONMENT` property, rather than
+# the shared `with_*_test_env.sh` that manual `run_test.sh` invocations also source. The header
+# snapshots live here so the helper only sees them under ctest (where the `lean_header_snapshot`
+# fixture guarantees a fresh snapshot); a manual run sees no snapshot var and takes the normal path.
+set(TEST_VARS_CTEST
+  "LEAN_HEADER_SNAPSHOT_LEAN=${LEAN_HEADER_SNAPSHOT}"
+  "LEAN_HEADER_SNAPSHOT_INIT=${LEAN_HEADER_SNAPSHOT_INIT}")
 
 set(WITH_TEST_ENV "${CMAKE_CURRENT_SOURCE_DIR}/with_stage${STAGE}_test_env.sh")
 set(WITH_BENCH_ENV "${CMAKE_CURRENT_SOURCE_DIR}/with_stage${STAGE}_bench_env.sh")
@@ -137,7 +151,7 @@ endfunction()
 # a single `measurements.jsonl` file in the pile directory, whose path will be
 # added to the list specified by the BENCH argument.
 function(add_test_pile DIR GLOB)
-  cmake_parse_arguments(ARGS "" BENCH EXCEPT ${ARGN})
+  cmake_parse_arguments(ARGS "" "BENCH;FIXTURES_REQUIRED" EXCEPT ${ARGN})
   cmake_path(ABSOLUTE_PATH DIR NORMALIZE)
 
   check_test_bench_scripts("${DIR}")
@@ -164,8 +178,16 @@ function(add_test_pile DIR GLOB)
         # On Windows, we can't call the file directly, hence we always use bash.
         COMMAND bash "${WITH_TEST_ENV}" "${RUN_TEST}" "${FILE_IN_DIR}"
       )
+      # ctest-only environment (e.g. header-snapshot paths); absent in manual `run_test.sh` runs.
+      set_tests_properties("${FILE_IN_SOURCE_DIR}" PROPERTIES ENVIRONMENT "${TEST_VARS_CTEST}")
       if(EXISTS "${FILE}.serial")
         set_tests_properties("${FILE_IN_SOURCE_DIR}" PROPERTIES RUN_SERIAL TRUE)
+      endif()
+      if(ARGS_FIXTURES_REQUIRED)
+        set_tests_properties(
+          "${FILE_IN_SOURCE_DIR}"
+          PROPERTIES FIXTURES_REQUIRED "${ARGS_FIXTURES_REQUIRED}"
+        )
       endif()
     endif()
 
@@ -238,6 +260,40 @@ function(add_dir_of_test_dirs DIR)
   endforeach()
 endfunction()
 
+# Build header-only incremental snapshots for common imports.
+# The options here must match those passed by the elab/elab_fail runners
+# so the saved `cmdState` is consistent with what tests will see.
+# Built lazily as a CTest setup fixture (not in `ALL`) so it runs only after
+# `lean` is built and can self-import, never blocking `make`. Tracked as an
+# output of `lean`, so the fixture rebuilds the snapshots only when `lean`
+# changed and is otherwise a no-op, keeping single-test runs cheap.
+add_custom_command(
+  OUTPUT "${LEAN_HEADER_SNAPSHOT}" "${LEAN_HEADER_SNAPSHOT_INIT}"
+  COMMAND ${CMAKE_COMMAND} -E rm -f "${LEAN_HEADER_SNAPSHOT}" "${LEAN_HEADER_SNAPSHOT_INIT}"
+  COMMAND
+    bash -c
+    "echo 'import Lean' | '${LEAN_BIN}/lean' --stdin --incr-header-save='${LEAN_HEADER_SNAPSHOT}' -DprintMessageEndPos=true -Dlinter.all=false -DElab.inServer=true"
+  COMMAND
+    bash -c
+    "echo -n '' | '${LEAN_BIN}/lean' --stdin --incr-header-save='${LEAN_HEADER_SNAPSHOT_INIT}' -DprintMessageEndPos=true -Dlinter.all=false -DElab.inServer=true"
+  # `lean` (the target) for build ordering; `${LEAN_BIN}/lean` (the file) for the mtime dependency
+  # that makes the snapshots rebuild when the binary changes. The target alone yields no file
+  # prerequisite because `lean` is an `add_custom_target` with no tracked output file.
+  DEPENDS lean "${LEAN_BIN}/lean${CMAKE_EXECUTABLE_SUFFIX}"
+  COMMENT "Saving Lean header snapshots for tests"
+  VERBATIM
+)
+add_custom_target(test_header_snapshots
+  DEPENDS "${LEAN_HEADER_SNAPSHOT}" "${LEAN_HEADER_SNAPSHOT_INIT}")
+add_test(
+  NAME tests/test_header_snapshots
+  COMMAND ${CMAKE_COMMAND} --build "${CMAKE_BINARY_DIR}" --target test_header_snapshots
+)
+set_tests_properties(
+  tests/test_header_snapshots
+  PROPERTIES FIXTURES_SETUP lean_header_snapshot
+)
+
 # Benchmarks are split into two parts which should be roughly equal in total runtime.
 # In radar, each part is run on a different runner.
 set(PART1 "")
@@ -291,9 +347,10 @@ add_test_pile(
   EXCEPT
     async_select_channel.lean # Flaky
     sync_mutex.lean # Flaky
+  FIXTURES_REQUIRED lean_header_snapshot
 )
 add_test_pile(elab_bench *.lean BENCH PART2)
-add_test_pile(elab_fail *.lean)
+add_test_pile(elab_fail *.lean FIXTURES_REQUIRED lean_header_snapshot)
 add_test_pile(misc *.sh)
 add_test_pile(misc_bench *.sh BENCH PART2)
 add_test_pile(server *.lean)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -250,10 +250,10 @@ function(add_dir_of_test_dirs DIR)
   endforeach()
 endfunction()
 
-# Build the header snapshots reused by the `elab`/`elab_fail` piles. Run as a
-# CTest setup fixture (not in `ALL`) so it runs only after `lean` is built,
-# never blocking `make`. The script itself skips the rebuild unless `lean` is
-# newer than the snapshots, keeping single-test runs cheap.
+# Build the header snapshots reused by the elab* piles. Run as a CTest setup
+# fixture (not in `ALL`) so it runs only after `lean` is built, never blocking
+# `make`. The script itself skips the rebuild unless `lean` is newer than the
+# snapshots, keeping single-test runs cheap.
 add_test(
   NAME build_lean_header_snapshots.sh
   COMMAND bash "${WITH_TEST_ENV}" "${CMAKE_CURRENT_SOURCE_DIR}/build_lean_header_snapshots.sh"
@@ -315,7 +315,7 @@ add_test_pile(
     sync_mutex.lean # Flaky
   FIXTURES_REQUIRED lean_header_snapshot
 )
-add_test_pile(elab_bench *.lean BENCH PART2)
+add_test_pile(elab_bench *.lean BENCH PART2 FIXTURES_REQUIRED lean_header_snapshot)
 add_test_pile(elab_fail *.lean FIXTURES_REQUIRED lean_header_snapshot)
 add_test_pile(misc *.sh)
 add_test_pile(misc_bench *.sh BENCH PART2)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,16 +16,11 @@ function(mangle_windows_path OUT PATH)
 endfunction()
 
 mangle_windows_path(MANGLED_BINARY_DIR "${CMAKE_BINARY_DIR}")
+mangle_windows_path(MANGLED_CURRENT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 mangle_windows_path(MANGLED_SOURCE_DIR "${CMAKE_SOURCE_DIR}")
 mangle_windows_path(MANGLED_CURRENT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
 set(LEAN_BIN "${MANGLED_BINARY_DIR}/bin")
-
-# Pre-elaborated header snapshots reused by tests with matching imports. The
-# `_lean` snapshot is for tests whose only import is `Lean`; the `_init`
-# snapshot is for tests with no imports at all (auto-imports `Init`).
-set(LEAN_HEADER_SNAPSHOT "${CMAKE_CURRENT_BINARY_DIR}/lean_header.snap")
-set(LEAN_HEADER_SNAPSHOT_INIT "${CMAKE_CURRENT_BINARY_DIR}/lean_header_init.snap")
 
 set(TEST_VARS "${LEAN_TEST_VARS}")
 
@@ -44,13 +39,13 @@ string(APPEND TEST_VARS " LEANC_OPTS='${LEANC_OPTS}'")
 # LEANC_OPTS in CXX is necessary for macOS c++ to find its headers
 string(APPEND TEST_VARS " CXX='${CMAKE_CXX_COMPILER} ${LEANC_OPTS}'")
 
-# Variables exported only for ctest-driven runs, via each test's `ENVIRONMENT` property, rather than
-# the shared `with_*_test_env.sh` that manual `run_test.sh` invocations also source. The header
-# snapshots live here so the helper only sees them under ctest (where the `lean_header_snapshot`
-# fixture guarantees a fresh snapshot); a manual run sees no snapshot var and takes the normal path.
-set(TEST_VARS_CTEST
-  "LEAN_HEADER_SNAPSHOT_LEAN=${LEAN_HEADER_SNAPSHOT}"
-  "LEAN_HEADER_SNAPSHOT_INIT=${LEAN_HEADER_SNAPSHOT_INIT}")
+# Pre-elaborated header snapshots reused by tests with matching imports. The
+# `_lean` snapshot is for tests whose only import is `Lean`; the `_init`
+# snapshot is for tests with no imports at all (auto-imports `Init`). Built by
+# the `build_lean_header_snapshots.sh` fixture below; absent for manual
+# `run_test.sh` runs, where `maybe_use_lean_header_snapshot` skips them.
+string(APPEND TEST_VARS " LEAN_HEADER_SNAPSHOT_LEAN='${MANGLED_CURRENT_BINARY_DIR}/lean_header_lean.snap'")
+string(APPEND TEST_VARS " LEAN_HEADER_SNAPSHOT_INIT='${MANGLED_CURRENT_BINARY_DIR}/lean_header_init.snap'")
 
 set(WITH_TEST_ENV "${CMAKE_CURRENT_SOURCE_DIR}/with_stage${STAGE}_test_env.sh")
 set(WITH_BENCH_ENV "${CMAKE_CURRENT_SOURCE_DIR}/with_stage${STAGE}_bench_env.sh")
@@ -178,16 +173,11 @@ function(add_test_pile DIR GLOB)
         # On Windows, we can't call the file directly, hence we always use bash.
         COMMAND bash "${WITH_TEST_ENV}" "${RUN_TEST}" "${FILE_IN_DIR}"
       )
-      # ctest-only environment (e.g. header-snapshot paths); absent in manual `run_test.sh` runs.
-      set_tests_properties("${FILE_IN_SOURCE_DIR}" PROPERTIES ENVIRONMENT "${TEST_VARS_CTEST}")
       if(EXISTS "${FILE}.serial")
         set_tests_properties("${FILE_IN_SOURCE_DIR}" PROPERTIES RUN_SERIAL TRUE)
       endif()
       if(ARGS_FIXTURES_REQUIRED)
-        set_tests_properties(
-          "${FILE_IN_SOURCE_DIR}"
-          PROPERTIES FIXTURES_REQUIRED "${ARGS_FIXTURES_REQUIRED}"
-        )
+        set_tests_properties("${FILE_IN_SOURCE_DIR}" PROPERTIES FIXTURES_REQUIRED "${ARGS_FIXTURES_REQUIRED}")
       endif()
     endif()
 
@@ -260,39 +250,15 @@ function(add_dir_of_test_dirs DIR)
   endforeach()
 endfunction()
 
-# Build header-only incremental snapshots for common imports.
-# The options here must match those passed by the elab/elab_fail runners
-# so the saved `cmdState` is consistent with what tests will see.
-# Built lazily as a CTest setup fixture (not in `ALL`) so it runs only after
-# `lean` is built and can self-import, never blocking `make`. Tracked as an
-# output of `lean`, so the fixture rebuilds the snapshots only when `lean`
-# changed and is otherwise a no-op, keeping single-test runs cheap.
-add_custom_command(
-  OUTPUT "${LEAN_HEADER_SNAPSHOT}" "${LEAN_HEADER_SNAPSHOT_INIT}"
-  COMMAND ${CMAKE_COMMAND} -E rm -f "${LEAN_HEADER_SNAPSHOT}" "${LEAN_HEADER_SNAPSHOT_INIT}"
-  COMMAND
-    bash -c
-    "echo 'import Lean' | '${LEAN_BIN}/lean' --stdin --incr-header-save='${LEAN_HEADER_SNAPSHOT}' -DprintMessageEndPos=true -Dlinter.all=false -DElab.inServer=true"
-  COMMAND
-    bash -c
-    "echo -n '' | '${LEAN_BIN}/lean' --stdin --incr-header-save='${LEAN_HEADER_SNAPSHOT_INIT}' -DprintMessageEndPos=true -Dlinter.all=false -DElab.inServer=true"
-  # `lean` (the target) for build ordering; `${LEAN_BIN}/lean` (the file) for the mtime dependency
-  # that makes the snapshots rebuild when the binary changes. The target alone yields no file
-  # prerequisite because `lean` is an `add_custom_target` with no tracked output file.
-  DEPENDS lean "${LEAN_BIN}/lean${CMAKE_EXECUTABLE_SUFFIX}"
-  COMMENT "Saving Lean header snapshots for tests"
-  VERBATIM
-)
-add_custom_target(test_header_snapshots
-  DEPENDS "${LEAN_HEADER_SNAPSHOT}" "${LEAN_HEADER_SNAPSHOT_INIT}")
+# Build the header snapshots reused by the `elab`/`elab_fail` piles. Run as a
+# CTest setup fixture (not in `ALL`) so it runs only after `lean` is built,
+# never blocking `make`. The script itself skips the rebuild unless `lean` is
+# newer than the snapshots, keeping single-test runs cheap.
 add_test(
-  NAME tests/test_header_snapshots
-  COMMAND ${CMAKE_COMMAND} --build "${CMAKE_BINARY_DIR}" --target test_header_snapshots
+  NAME build_lean_header_snapshots.sh
+  COMMAND bash "${WITH_TEST_ENV}" "${CMAKE_CURRENT_SOURCE_DIR}/build_lean_header_snapshots.sh"
 )
-set_tests_properties(
-  tests/test_header_snapshots
-  PROPERTIES FIXTURES_SETUP lean_header_snapshot
-)
+set_tests_properties(build_lean_header_snapshots.sh PROPERTIES FIXTURES_SETUP lean_header_snapshot)
 
 # Benchmarks are split into two parts which should be roughly equal in total runtime.
 # In radar, each part is run on a different runner.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -173,6 +173,7 @@ function(add_test_pile DIR GLOB)
         # On Windows, we can't call the file directly, hence we always use bash.
         COMMAND bash "${WITH_TEST_ENV}" "${RUN_TEST}" "${FILE_IN_DIR}"
       )
+      set_tests_properties("${FILE_IN_SOURCE_DIR}" PROPERTIES ENVIRONMENT "TEST_CTEST=1")
       if(EXISTS "${FILE}.serial")
         set_tests_properties("${FILE_IN_SOURCE_DIR}" PROPERTIES RUN_SERIAL TRUE)
       endif()
@@ -221,6 +222,7 @@ function(add_test_dir DIR)
       # On Windows, we can't call the file directly, hence we always use bash.
       COMMAND bash "${WITH_TEST_ENV}" "${RUN_TEST}"
     )
+    set_tests_properties("${DIR_IN_SOURCE_DIR}" PROPERTIES ENVIRONMENT "TEST_CTEST=1")
   endif()
 
   # Add as benchmark

--- a/tests/README.md
+++ b/tests/README.md
@@ -248,6 +248,13 @@ These bash variables (set via `<file>.init.sh`) are used by the run script:
   A bash variable containing the expected exit code of the program.
   When set to `nonzero` instead of a numerical value, the exit code must not be 0.
 
+For performance reasons,
+elab tests use prebuilt header snapshots when running in ctest.
+To disable use of the snapshots, set `LEAN_DISABLE_HEADER_SNAPSHOT=1`.
+To use the pre-built snapshots when manually running tests,
+run `tests/with_stage1_test_env.sh tests/build_lean_header_snapshots.sh`
+before running the test itself.
+
 ## The `compile*` test pile
 
 These files are available to configure a test:

--- a/tests/README.md
+++ b/tests/README.md
@@ -199,6 +199,7 @@ The most notable environment variables are:
 - `TEST_DIR`: Absolute path to the `tests` directory.
 - `SCRIPT_DIR`: Absolute path to the `script` directory.
 - `TEST_BENCH`: Set to `1` if we're currently executing a benchmark, unset otherwise.
+- `TEST_CTEST`: Set to `1` if the test is run under ctest, unset otherwise.
 
 The definitions come from `util.sh`,
 which provides a few utility functions and also uses `set` to set sensible bash defaults.
@@ -248,12 +249,13 @@ These bash variables (set via `<file>.init.sh`) are used by the run script:
   A bash variable containing the expected exit code of the program.
   When set to `nonzero` instead of a numerical value, the exit code must not be 0.
 
-For performance reasons,
-elab tests use prebuilt header snapshots when running in ctest.
-To disable use of the snapshots, set `LEAN_DISABLE_HEADER_SNAPSHOT=1`.
+For performance reasons, elab tests can use prebuilt header snapshots.
+Use of the snapshots is controlled by `LEAN_HEADER_SNAPSHOTS`:
+set it to `0` to force them off, or to `1` to force them on.
+By default, they are turned on only when running under ctest.
 To use the pre-built snapshots when manually running tests,
 run `tests/with_stage1_test_env.sh tests/build_lean_header_snapshots.sh`
-before running the test itself.
+before running the test itself with `LEAN_HEADER_SNAPSHOTS=1` set.
 
 ## The `compile*` test pile
 

--- a/tests/build_lean_header_snapshots.sh
+++ b/tests/build_lean_header_snapshots.sh
@@ -1,0 +1,17 @@
+set -euo pipefail
+
+lean_bin=$(command -v lean)
+
+# Rebuild only when a snapshot is missing or older than the `lean` binary, to
+# avoid unnecessary recomputation.
+for snap in "$LEAN_HEADER_SNAPSHOT_LEAN" "$LEAN_HEADER_SNAPSHOT_INIT"; do
+  if [[ ! -f "$snap" || "$lean_bin" -nt "$snap" ]]; then
+    needs_rebuild=1
+  fi
+done
+[[ -z "${needs_rebuild:-}" ]] && exit 0
+
+# These options must match those passed by the elab/elab_fail runners so the
+# saved `cmdState` is consistent with what tests will see.
+echo 'import Lean' | lean --stdin --incr-header-save="$LEAN_HEADER_SNAPSHOT_LEAN" -DprintMessageEndPos=true -Dlinter.all=false -DElab.inServer=true
+echo -n '' | lean --stdin --incr-header-save="$LEAN_HEADER_SNAPSHOT_INIT" -DprintMessageEndPos=true -Dlinter.all=false -DElab.inServer=true

--- a/tests/build_lean_header_snapshots.sh
+++ b/tests/build_lean_header_snapshots.sh
@@ -11,7 +11,7 @@ for snap in "$LEAN_HEADER_SNAPSHOT_LEAN" "$LEAN_HEADER_SNAPSHOT_INIT"; do
 done
 [[ -z "${needs_rebuild:-}" ]] && exit 0
 
-# These options must match those passed by the elab/elab_fail runners so the
-# saved `cmdState` is consistent with what tests will see.
+# These options must match those passed by the elab* runners so the saved
+# `cmdState` is consistent with what tests will see.
 echo 'import Lean' | lean --stdin --incr-header-save="$LEAN_HEADER_SNAPSHOT_LEAN" -DprintMessageEndPos=true -Dlinter.all=false -DElab.inServer=true
 echo -n '' | lean --stdin --incr-header-save="$LEAN_HEADER_SNAPSHOT_INIT" -DprintMessageEndPos=true -Dlinter.all=false -DElab.inServer=true

--- a/tests/elab/run_test.sh
+++ b/tests/elab/run_test.sh
@@ -1,5 +1,6 @@
 source_init "$1"
 run_before "$1"
+maybe_use_lean_header_snapshot "$1"
 
 # `--root` to infer same private names as in the server
 # Elab.inServer to allow for arbitrary `#eval`
@@ -8,7 +9,6 @@ capture_only "$1" \
   lean --root=.. -DprintMessageEndPos=true -Dlinter.all=false -DElab.inServer=true -Dcompiler.postponeCompile=false "${TEST_LEAN_ARGS[@]}" "$1"
 normalize_mvar_suffixes
 normalize_reference_urls
-normalize_measurements
 check_out_file
 check_exit_is_success
 

--- a/tests/elab/run_test.sh
+++ b/tests/elab/run_test.sh
@@ -9,6 +9,7 @@ capture_only "$1" \
   lean --root=.. -DprintMessageEndPos=true -Dlinter.all=false -DElab.inServer=true -Dcompiler.postponeCompile=false "${TEST_LEAN_ARGS[@]}" "$1"
 normalize_mvar_suffixes
 normalize_reference_urls
+normalize_measurements
 check_out_file
 check_exit_is_success
 

--- a/tests/elab_bench/run_test.sh
+++ b/tests/elab_bench/run_test.sh
@@ -1,1 +1,12 @@
-../elab/run_test.sh
+source_init "$1"
+run_before "$1"
+
+capture_only "$1" \
+  lean --root=.. -DprintMessageEndPos=true -Dlinter.all=false -DElab.inServer=true -Dcompiler.postponeCompile=false "${TEST_LEAN_ARGS[@]}" "$1"
+normalize_mvar_suffixes
+normalize_reference_urls
+normalize_measurements
+check_out_file
+check_exit_is_success
+
+run_after "$1"

--- a/tests/elab_bench/run_test.sh
+++ b/tests/elab_bench/run_test.sh
@@ -1,16 +1,1 @@
-source_init "$1"
-run_before "$1"
-maybe_use_lean_header_snapshot "$1"
-
-# `--root` to infer same private names as in the server
-# Elab.inServer to allow for arbitrary `#eval`
-# compiler.postponeCompile for immediate trace output
-capture_only "$1" \
-  lean --root=.. -DprintMessageEndPos=true -Dlinter.all=false -DElab.inServer=true -Dcompiler.postponeCompile=false "${TEST_LEAN_ARGS[@]}" "$1"
-normalize_mvar_suffixes
-normalize_reference_urls
-normalize_measurements
-check_out_file
-check_exit_is_success
-
-run_after "$1"
+../elab/run_test.sh

--- a/tests/elab_bench/run_test.sh
+++ b/tests/elab_bench/run_test.sh
@@ -1,6 +1,10 @@
 source_init "$1"
 run_before "$1"
+maybe_use_lean_header_snapshot "$1"
 
+# `--root` to infer same private names as in the server
+# Elab.inServer to allow for arbitrary `#eval`
+# compiler.postponeCompile for immediate trace output
 capture_only "$1" \
   lean --root=.. -DprintMessageEndPos=true -Dlinter.all=false -DElab.inServer=true -Dcompiler.postponeCompile=false "${TEST_LEAN_ARGS[@]}" "$1"
 normalize_mvar_suffixes

--- a/tests/elab_fail/run_test.sh
+++ b/tests/elab_fail/run_test.sh
@@ -1,5 +1,6 @@
 source_init "$1"
 run_before "$1"
+maybe_use_lean_header_snapshot "$1"
 
 # `--root` to infer same private names as in the server
 # Elab.inServer to allow for arbitrary `#eval`
@@ -7,7 +8,6 @@ capture_only "$1" \
   lean --root=.. -DprintMessageEndPos=true -Dlinter.all=false -DElab.inServer=true "${TEST_LEAN_ARGS[@]}" "$1"
 normalize_mvar_suffixes
 normalize_reference_urls
-normalize_measurements
 check_out_file
 check_exit_is_fail
 

--- a/tests/elab_fail/run_test.sh
+++ b/tests/elab_fail/run_test.sh
@@ -8,6 +8,7 @@ capture_only "$1" \
   lean --root=.. -DprintMessageEndPos=true -Dlinter.all=false -DElab.inServer=true "${TEST_LEAN_ARGS[@]}" "$1"
 normalize_mvar_suffixes
 normalize_reference_urls
+normalize_measurements
 check_out_file
 check_exit_is_fail
 

--- a/tests/util.sh
+++ b/tests/util.sh
@@ -129,9 +129,10 @@ function source_init {
 # match byte-for-byte at the header level; if it doesn't, the loader takes
 # the slow path which costs the snapshot env *plus* a fresh import.
 function maybe_use_lean_header_snapshot {
-  [[ -n "${LEAN_DISABLE_HEADER_SNAPSHOT:-}" ]] && return
-  # Files kinds that are not supported yet; we should add `module` snapshots when we have ported a
-  # significant number of tests
+  [[ "${LEAN_HEADER_SNAPSHOTS:-}" == 0 ]] && return
+  [[ -z "${LEAN_HEADER_SNAPSHOTS:-}" && -z "${TEST_CTEST:-}" ]] && return
+  # File kinds that are not supported yet; we should add `module` snapshots when
+  # we have ported a significant number of tests
   grep -qE '^(module|prelude)$' "$1" && return
   local snap=
   if awk 'NR==1 { if ($0 != "import Lean") exit 1; n=1; next }
@@ -141,9 +142,7 @@ function maybe_use_lean_header_snapshot {
   elif ! grep -qE '^import ' "$1"; then
     snap=${LEAN_HEADER_SNAPSHOT_INIT:-}
   fi
-  # We must handle the case where the file does not exist (e.g. when running a
-  # test manually).
-  if [[ -n "$snap" && -f "$snap" ]]; then
+  if [[ -n "$snap" ]]; then
     TEST_LEAN_ARGS+=("--incr-load=$snap")
   fi
 }

--- a/tests/util.sh
+++ b/tests/util.sh
@@ -141,7 +141,9 @@ function maybe_use_lean_header_snapshot {
   elif ! grep -qE '^import ' "$1"; then
     snap=${LEAN_HEADER_SNAPSHOT_INIT:-}
   fi
-  if [[ -n "$snap" ]]; then
+  # We must handle the case where the file does not exist (e.g. when running a
+  # test manually).
+  if [[ -n "$snap" && -f "$snap" ]]; then
     TEST_LEAN_ARGS+=("--incr-load=$snap")
   fi
 }

--- a/tests/util.sh
+++ b/tests/util.sh
@@ -123,6 +123,29 @@ function source_init {
   fi
 }
 
+# Append `--incr-load=...` to TEST_LEAN_ARGS if `$1`'s parsed header matches
+# one of the prebuilt snapshots exactly. The Lean snapshot is built from the
+# bytes `import Lean\n`; the Init snapshot from empty input. The file must
+# match byte-for-byte at the header level; if it doesn't, the loader takes
+# the slow path which costs the snapshot env *plus* a fresh import.
+function maybe_use_lean_header_snapshot {
+  [[ -n "${LEAN_DISABLE_HEADER_SNAPSHOT:-}" ]] && return
+  # Files kinds that are not supported yet; we should add `module` snapshots when we have ported a
+  # significant number of tests
+  grep -qE '^(module|prelude)$' "$1" && return
+  local snap=
+  if awk 'NR==1 { if ($0 != "import Lean") exit 1; n=1; next }
+          /^import / { exit 1 }
+          END { if (n != 1) exit 1 }' "$1"; then
+    snap=${LEAN_HEADER_SNAPSHOT_LEAN:-}
+  elif ! grep -qE '^import ' "$1"; then
+    snap=${LEAN_HEADER_SNAPSHOT_INIT:-}
+  fi
+  if [[ -n "$snap" ]]; then
+    TEST_LEAN_ARGS+=("--incr-load=$snap")
+  fi
+}
+
 function run_before {
   if [[ -f "$1.before.sh" ]]; then
     bash -- "$1.before.sh" || fail "$1.before.sh failed"


### PR DESCRIPTION
Wires the snapshot `--incr-load` machinery into the test suite so the ~389 elab tests that have `import Lean` (and the empty-imports variants) reuse a single pre-built `Environment` snapshot instead of re-importing the prelude per file.

elab pile results:

| Metric | OFF (no reuse) | ON (reuse) | Reduction |
|---|---|---|---|
| Instructions | 7.775 T | 6.588 T | −1.19 T (−15.3%) |
| Task-clock (CPU time) | 2222 s | 1645 s | −577 s (−26.0%) |
| Wall-clock (`-j96`) | 51.5 s | 49.2 s | −2.3 s (−4.5%) |

elab_fail:

| Metric | OFF (no reuse) | ON (reuse) | Reduction |
|---|---|---|---|
| Instructions | 419 B | 287 B | −132 B (−31.4%) |
| Task-clock (CPU time) | 118.9 s | 69.1 s | −49.8 s (−41.9%) |
| Wall-clock (`-j96`) | 9.6 s | 9.0 s | −0.6 s (−6.6%) |

CI test wall-clock speedup is ~10-40% depending on platform.

- `src/Lean/Language/Lean.lean`: add `setMainModule`, which patches a loaded snapshot's `Environment.mainModule` (and the dependent `auxDeclNGen` private prefix) so commands elaborated on top of a shared snapshot land in the loading file's module rather than the one baked in at save time.
- `src/Lean/Elab/Frontend.lean`: apply `setMainModule` to the loaded snapshot in the `--incr-load` path.
- `tests/CMakeLists.txt`: add a `lean_header_snapshot` CMake fixture that builds `lean_header.snap` (for `import Lean`) and `lean_header_init.snap` (for empty imports) once via `lean --stdin --incr-header-save=...`, and mark the `elab`/`elab_fail` test piles `FIXTURES_REQUIRED lean_header_snapshot`.
- `tests/util.sh`: new helper that inspects a test file's import line and appends `--incr-load=$LEAN_HEADER_SNAPSHOT_{LEAN,INIT}` to `TEST_LEAN_ARGS` when it matches.
- `tests/elab/run_test.sh`, `tests/elab_fail/run_test.sh`: invoke the helper before running `lean`.