### PR TITLE
feat: extract `WP` superclass from `WPMonad` to support deep embeddings

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Attr.lean
+++ b/src/Lean/Elab/Tactic/Do/Attr.lean
@@ -293,7 +293,7 @@ Normalises a specification proof so its conclusion is in `pre ⊑ wp …` form.
 -/
 def tripleToWpProof? (proof type : Expr) : MetaM (Option (Expr × Expr)) := do
   let type ← whnfR type
-  if type.isAppOfArity ``Triple 12 then
+  if type.isAppOfArity ``Triple 11 then
     -- Build the `Triple.le_wp` projection application explicitly from the `Triple` type's own
     -- arguments rather than via `mkAppM`. `mkAppM` would re-synthesise the instance arguments
     -- (`Monad m`, `WPMonad m …`), which fails for transformer specs whose monad is a partially

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
@@ -46,29 +46,35 @@ public def UntilPatternThunk.force (ref : IO.Ref UntilPatternThunk) (m : Expr) :
 
 /--
 Common metadata for a goal whose right-hand side is a weakest-precondition application
-`pre ⊑ wp m Pred EPred monadInst instAL instEAL instWP α prog post epost s₁ ... sₙ`.
+`pre ⊑ wp Prog Value Pred EPred instAL instEAL instWP prog post epost s₁ ... sₙ`.
 -/
 public structure VCGen.WPInfo where
   /-- The `wp` function head, separated from its explicit core arguments. -/
   head : Expr
   /-- The ordered core arguments of the `wp` application:
-  `#[m, Pred, EPred, monadInst, instAL, instEAL, instWP, α, prog, post, epost]`. -/
+  `#[Prog, Value, Pred, EPred, instAL, instEAL, instWP, prog, post, epost]`. -/
   args : Array Expr
   /-- Extra arguments applied after `wp … prog post epost`, usually concrete state arguments. -/
   excessArgs : Array Expr
 
 namespace VCGen.WPInfo
 
-/-- Monad type constructor argument of `wp`. -/
-public def m (info : WPInfo) : Expr := info.args[0]!
+/-- Program type argument of `wp` (e.g. `m α` or a non-monadic program type). -/
+public def progTy (info : WPInfo) : Expr := info.args[0]!
+/-- The monad of an `m α`-shaped program type, obtained by dropping the value type `α`. For a
+non-monadic program type the type itself is returned. -/
+public def m (info : WPInfo) : Expr :=
+  if info.args[0]!.isApp then info.args[0]!.appFn! else info.args[0]!
+/-- Result/value type argument of `wp`. -/
+public def Value (info : WPInfo) : Expr := info.args[1]!
 /-- Predicate/lattice type argument of `wp`. -/
-public def Pred (info : WPInfo) : Expr := info.args[1]!
+public def Pred (info : WPInfo) : Expr := info.args[2]!
 /-- Exception postcondition type argument of `wp`. -/
-public def EPred (info : WPInfo) : Expr := info.args[2]!
-/-- `WPMonad` instance argument of `wp`. -/
+public def EPred (info : WPInfo) : Expr := info.args[3]!
+/-- `WP` instance argument of `wp`. -/
 public def instWP (info : WPInfo) : Expr := info.args[6]!
 /-- Program expression classified by VCGen. -/
-public def prog (info : WPInfo) : Expr := info.args[8]!
+public def prog (info : WPInfo) : Expr := info.args[7]!
 
 end VCGen.WPInfo
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
@@ -173,20 +173,29 @@ public structure VCGen.State where
   A cache mapping registered SpecThms to their backward rule to apply.
   The particular rule depends on the theorem name, the `WPMonad` instance and the number of
   excess state arguments that the weakest precondition target is applied to.
+
+  The instance is keyed by `ExprPtr`, so lookups compare it by pointer rather than structurally.
+  This is sound because the instance is a subterm of the hash-consed goal target.
   -/
-  specBackwardRuleCache : Std.HashMap (Name × Expr × Nat) BackwardRule := {}
+  specBackwardRuleCache : Std.HashMap (Name × ExprPtr × Nat) BackwardRule := {}
   /--
   A cache mapping matchers to their splitting backward rule to apply.
   The particular rule depends on the matcher name, the monad and the number of excess state
   arguments that the weakest precondition target is applied to.
+
+  The instance is keyed by `ExprPtr`, so lookups compare it by pointer rather than structurally.
+  This is sound because the instance is a subterm of the hash-consed goal target.
   -/
-  splitBackwardRuleCache : Std.HashMap (Name × Expr × Nat) BackwardRule := {}
+  splitBackwardRuleCache : Std.HashMap (Name × ExprPtr × Nat) BackwardRule := {}
   /--
   A cache mapping lattice connectives to their backward rule to apply.
   The particular rule depends on the rule name, the monad, and the number of excess state
   arguments that the weakest precondition target is applied to.
+
+  The argument types are keyed by `ExprPtr`, so lookups compare them by pointer rather than
+  structurally. This is sound because they are subterms of the hash-consed goal target.
   -/
-  latticeBackwardRuleCache : Std.HashMap (Name × Array Expr × Nat) BackwardRule := {}
+  latticeBackwardRuleCache : Std.HashMap (Name × Array ExprPtr × Nat) BackwardRule := {}
   /--
   Holes of type `Invariant` that have been generated so far.
   -/

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
@@ -35,7 +35,7 @@ Cache key: `(proof key, instWP, excessArgs.size)`.
 -/
 public def mkBackwardRuleFromSpecCached (specThm : SpecTheorem) (info : WPInfo) :
     OptionT VCGenM BackwardRule := do
-  let key := (specThm.proof.key, info.instWP, info.excessArgs.size)
+  let key := (specThm.proof.key, ExprPtr.mk info.instWP, info.excessArgs.size)
   let s := (← get).specBackwardRuleCache
   if let some rule := s[key]? then return rule
   let some rule ← withNewMCtxDepth <| tryMkBackwardRuleFromSpec specThm info |>.run
@@ -55,7 +55,7 @@ public def mkBackwardRuleForSplitCached (splitInfo : SplitInfo) (info : WPInfo) 
     | .ite .. => ``ite
     | .dite .. => ``dite
     | .matcher matcherApp => matcherApp.matcherName
-  let key := (cacheKey, info.instWP, info.excessArgs.size)
+  let key := (cacheKey, ExprPtr.mk info.instWP, info.excessArgs.size)
   let s := (← get).splitBackwardRuleCache
   if let some rule := s[key]? then return rule
   let rule ← mkBackwardRuleForSplit splitInfo info
@@ -72,7 +72,7 @@ public def mkBackwardRuleForLatticeCached (c : LatticeSplit) (as excessArgs : Ar
     (resultType? : Option Expr := none) : VCGenM BackwardRule := do
   let s := (← get).latticeBackwardRuleCache
   let asTypes ← (as.mapM Sym.inferType : SymM (Array Expr))
-  let key := (c.applyLemma, asTypes, excessArgs.size)
+  let key := (c.applyLemma, asTypes.map ExprPtr.mk, excessArgs.size)
   if let some rule := s[key]? then return rule
   let rule ← c.mkBackwardRuleForLattice as excessArgs resultType?
   modify fun st => { st with latticeBackwardRuleCache := st.latticeBackwardRuleCache.insert key rule }

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
@@ -298,7 +298,7 @@ prf : ∀ (n : Nat) (pre : Prop) (hpre : pre ⊑ True)
   pre ⊑ wp (myPure n) post epost
 ```
 The postcondition VC is pointwise over the return value and over any excess state arguments. The
-proof is generalized with `WPMonad.wp_consequence_le`.
+proof is generalized with `WP.wp_consequence_le`.
 
 #### Exception postcondition VCs
 
@@ -308,8 +308,8 @@ value, the relation `epostSpec ⊑ epost` is decomposed component by component:
 ∀ e s₁ ... sₙ, epostSpec.head e s₁ ... sₙ ⊑ epost.head e s₁ ... sₙ
 ```
 and recursively for the tail. `decomposeEPostRel` assembles these component VCs using
-`EPost.Cons.mk_le` and `EPost.Nil.le`; the proof is then generalized with `WPMonad.wp_econs_le`.
-When the spec exception postcondition is `⊥`, no VC is needed and `WPMonad.wp_econs_bot_le` is
+`EPost.Cons.mk_le` and `EPost.Nil.le`; the proof is then generalized with `WP.wp_econs_le`.
+When the spec exception postcondition is `⊥`, no VC is needed and `WP.wp_econs_bot_le` is
 used instead.
 
 #### Excess state arguments
@@ -383,7 +383,7 @@ private def mkSpecBackwardProof
     let hpostRel ← mkExpectedTypeHint hpost relTy
     /- get the proof of `pre ⊑ wp prog postAbstract epostSpec`, where `post` is abstracted.
        Uses wp_consequence_le: post ⊑ post' → pre ⊑ wp x post epost → pre ⊑ wp x post' epost -/
-    specApplied ← mkAppM ``WPMonad.wp_consequence_le #[prog, postSpec, postAbstract, epostSpec, hpostRel, specApplied]
+    specApplied ← mkAppM ``WP.wp_consequence_le #[prog, postSpec, postAbstract, epostSpec, hpostRel, specApplied]
 
   /- abstract concrete `epost` if it is not already abstract -/
   unless epostAbstract.isMVar do
@@ -392,7 +392,7 @@ private def mkSpecBackwardProof
     /- mvar `epostAbstract` for new abstract `epost` -/
     epostAbstract ← mkFreshExprMVar (userName := `EPost) epostTy
     /- if `epost` is `⊥`, then `epost ⊑ epostAbstract` holds trivially and
-      abstracting `epost` can be simply done by `WPMonad.wp_econs_bot_le` without
+      abstracting `epost` can be simply done by `WP.wp_econs_bot_le` without
       introducing a new premise. This case is quite common, that's why we handle
       it specially. -/
     let isBot ← try
@@ -402,12 +402,12 @@ private def mkSpecBackwardProof
     if isBot then
       /- get the proof of `pre ⊑ wp prog postAbstract epostAbstract`, where `epost (= ⊥)` is abstracted.
         This proof DOES NOT have a `?epostImpl` premise -/
-      specApplied ← mkAppM ``WPMonad.wp_econs_bot_le #[prog, postAbstract, epostAbstract, specApplied]
+      specApplied ← mkAppM ``WP.wp_econs_bot_le #[prog, postAbstract, epostAbstract, specApplied]
     else
       /- Decompose `epostSpec ⊑ epostAbstract` into per-component proofs
         using `EPost.Cons.mk_le` and `EPost.Nil.le` -/
       let hepost ← decomposeEPostRel EPred epostSpec epostAbstract stateArgNames
-      specApplied ← mkAppM ``WPMonad.wp_econs_le #[prog, postAbstract, epostSpec, epostAbstract, hepost, specApplied]
+      specApplied ← mkAppM ``WP.wp_econs_le #[prog, postAbstract, epostSpec, epostAbstract, hepost, specApplied]
 
   /- By default we always abstract `pre`, since in most of the specifications
     `pre` is not schematic. In exceptional cases, where `pre` is schematic, it

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
@@ -270,9 +270,9 @@ verification conditions for the generalization.
 
 ### General idea
 
-Consider the spec theorem `WPMonad.wp_bind`:
+Consider the spec theorem `WPMonad.bind_le_wp_bind`:
 ```
-WPMonad.wp_bind :
+WPMonad.bind_le_wp_bind :
   wp x (fun a => wp (f a) post epost) epost ⊑ wp (x >>= f) post epost
 ```
 This theorem is already in WP-form, so `post` and `epost` are schematic. However, its precondition
@@ -282,7 +282,7 @@ prf : ∀ {α β} (x : m α) (f : α → m β) (post : β → Pred) (epost : EPr
   (pre : Pred) (hpre : pre ⊑ wp x (fun a => wp (f a) post epost) epost),
   pre ⊑ wp (x >>= f) post epost
 ```
-The proof term is constructed with `PartialOrder.rel_trans hpre WPMonad.wp_bind`.
+The proof term is constructed with `PartialOrder.rel_trans hpre WPMonad.bind_le_wp_bind`.
 
 #### Postcondition VCs
 
@@ -343,7 +343,7 @@ it for the particular predicate type, exception postcondition type and `WPMonad`
 `tryMkBackwardRuleFromSpec` does that by instantiating the spec theorem and checking that its
 `Pred` and `WPMonad` arguments match the ones from the use site.
 
-For `StateM Nat` and one excess state arg `s`, the type produced for `WPMonad.wp_bind` becomes
+For `StateM Nat` and one excess state arg `s`, the type produced for `WPMonad.bind_le_wp_bind` becomes
 ```
 prf : ∀ (pre : Prop) (α : Type) (x : StateT Nat Id α) (β : Type)
   (f : α → StateT Nat Id β) (post : β → Nat → Prop) (epost : EPost⟨⟩) (s : Nat),

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
@@ -454,8 +454,11 @@ private def eqSpecToWp? (info : WPInfo) (xs : Array Expr) (eqPrf eqType : Expr) 
   -- monad's domain sort so the equation's element type stays well-formed.
   let α ← mkFreshExprMVar (← inferType info.m).bindingDomain!
   guard <| ← isDefEqGuarded eqα (mkApp info.m α)
-  -- Synthesize leftover dictionary metavariables (e.g. for an abstract-monad lift equation) so the
-  -- projections in `rhs` reduce against concrete instances.
+  -- Pin the schematic instance and state metavariables by unifying the equation's LHS with the goal's
+  -- concrete program, so dictionary projections in `rhs` reduce against the real instance.
+  let _ ← show MetaM Bool from commitWhen <| isDefEqGuarded lhs info.prog
+  -- Synthesize leftover dictionary metavariables (e.g. for an abstract-monad lift equation, whose LHS
+  -- does not unify with a concrete program) so the projections in `rhs` reduce against instances.
   for x in xs do
     if x.isMVar && !(← x.mvarId!.isAssigned) then
       try x.mvarId!.assign (← Meta.synthInstance (← Meta.inferType x))
@@ -475,7 +478,7 @@ private def eqSpecToWp? (info : WPInfo) (xs : Array Expr) (eqPrf eqType : Expr) 
   -- so non-monadic equations like `Option.getD.eq_1` would fail to unify. With `m` fixed, the value
   -- type is inferred from the equation proof.
   let specProof ← mkAppOptM ``Std.Internal.Do.wp_le_wp_of_eq <|
-    (info.args.extract 0 7).map some ++ #[none, none, none, some eqPrf, some post, some epost]
+    (info.args.extract 0 7).map some ++ #[none, none, some eqPrf, some post, some epost]
   return (specProof, ← instantiateMVars (← Meta.inferType specProof))
 
 /--
@@ -503,7 +506,7 @@ public def tryMkBackwardRuleFromSpec (specThm : SpecTheorem) (info : WPInfo)
   let_expr PartialOrder.rel Pred' _cl' pre rhs := specType
     | throwError "target not a partial order ⊑ application {specType}"
   guard <| ← isDefEqGuarded info.Pred Pred'
-  let_expr Std.Internal.Do.wp _m' _Pred' _EPred' _monadInst' _instAL' _instEAL' instWP' _α prog postSpec epostSpec := rhs
+  let_expr Std.Internal.Do.wp _Prog' _Value' _Pred' _EPred' _instAL' _instEAL' instWP' prog postSpec epostSpec := rhs
     | throwError "target not a wp application {rhs}"
   guard <| ← isDefEqGuarded info.instWP instWP'
   -- Use local excess-state binders so explicit post premises can be re-lifted to `⊑`.
@@ -527,13 +530,10 @@ then `SplitInfo.splitWith` to build the splitting proof. Hypothesis types are
 discovered via `rwIfOrMatcher` inside the splitter telescope. -/
 public def mkBackwardRuleForSplit
     (splitInfo : SplitInfo) (info : WPInfo) : MetaM BackwardRule := do
-  let m := info.m
-  let mTy ← Meta.inferType m
-  let some aTy := if mTy.isForall then some mTy.bindingDomain! else none
-    | throwError "Expected monad type constructor at {indentExpr m}"
+  -- The split value type is the goal's, so reuse the goal's program type and `WP` instance directly.
+  let a := info.Value
+  let ma := info.progTy
   let prf ←
-    withLocalDeclD `a aTy fun a => do
-    let ma := mkApp m a
     splitInfo.withAbstract ma fun abstractInfo splitFVars => do
     -- Eta-reduce matcher alts for the backward rule pattern to avoid expensive
     -- higher-order unification. The alts are eta-expanded by `withAbstract` so that
@@ -548,7 +548,7 @@ public def mkBackwardRuleForSplit
     withLocalDeclD `Post (← mkArrow a info.Pred) fun post => do
     withLocalDeclD `EPost info.EPred fun epost => do
     let mkWP (prog : Expr) : Expr :=
-      let args := info.args.take 7 ++ #[a, prog, post, epost]
+      let args := info.args.take 7 ++ #[prog, post, epost]
       mkAppN (mkAppN info.head args) ss
     let Pred' ← Meta.inferType (mkWP abstractProg)
     withLocalDeclD `Pre Pred' fun pre => do
@@ -572,7 +572,7 @@ public def mkBackwardRuleForSplit
           -- pattern (e.g., `Nat.zero` instead of `discr`), which is required for
           -- `rwMatcher` to discharge the equality hypotheses of congr equation theorems.
           -- For ite/dite, `bodyType` equals `mkGoal abstractProg` so this is equivalent.
-          let prog := bodyType.getArg! 3 |>.getArg! 8
+          let prog := bodyType.getArg! 3 |>.getArg! 7
           let res ← rwIfOrMatcher idx prog
           if res.proof?.isNone then
             throwError "mkBackwardRuleForSplit: rwIfOrMatcher failed for alt {idx}"
@@ -583,7 +583,7 @@ public def mkBackwardRuleForSplit
           let eqProof ← mkAppM ``congrArg #[context, res.proof?.get!]
           mkEqMPR eqProof (mkAppN subgoalHyps[idx]! altParams))
     let prf ← instantiateMVars prf
-    mkLambdaFVars (#[a] ++ splitFVars ++ ss ++ #[post, epost, pre] ++ subgoalHyps) prf
+    mkLambdaFVars (splitFVars ++ ss ++ #[post, epost, pre] ++ subgoalHyps) prf
   let prf ← instantiateMVars prf
   let res ← abstractMVars prf
   mkBackwardRuleFromExpr res.expr res.paramNames.toList

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -94,8 +94,8 @@ private def tripleUnfold? (goal : MVarId) (target : Expr) : VCGenM (Option MVarI
 /-- Extract the weakest-precondition metadata from the RHS of a lattice entailment. -/
 private def getWPInfo? (rhs : Expr) : Option WPInfo :=
   rhs.withApp fun head args =>
-    if head.isConstOf ``Std.Internal.Do.wp && args.size ≥ 11 then
-      some { head, args := args.take 11, excessArgs := args.drop 11 }
+    if head.isConstOf ``Std.Internal.Do.wp && args.size ≥ 10 then
+      some { head, args := args.take 10, excessArgs := args.drop 10 }
     else
       none
 
@@ -209,7 +209,7 @@ private def normalizePre? (scope : VCGen.Scope) (goal : MVarId) (α pre target :
 /-- Replace the program in `goal`'s target with `prog` (which must be definitionally equal). -/
 private def replaceProgDefEq (goal : MVarId) (target : Expr) (info : WPInfo) (prog : Expr) :
     VCGenM MVarId := do
-  let wp ← mkAppNS info.head <| info.args.set! 8 prog
+  let wp ← mkAppNS info.head <| info.args.set! 7 prog
   let rhs ← mkAppNS wp info.excessArgs
   let relArgs := target.getAppArgs
   let newTarget ← mkAppNS target.getAppFn (relArgs.set! (relArgs.size - 1) rhs)
@@ -228,7 +228,7 @@ private def wpLet? (goal : MVarId) (target : Expr) (info : WPInfo) : VCGenM (Opt
   else
     trace[Elab.Tactic.Do.vcgen] "let-hoist: {name}"
     let prog ← mkAppRevS body appArgs
-    let wp ← mkAppNS info.head <| info.args.set! 8 prog
+    let wp ← mkAppNS info.head <| info.args.set! 7 prog
     let rhs ← mkAppNS wp info.excessArgs
     let relArgs := target.getAppArgs
     let target ← mkAppNS target.getAppFn (relArgs.set! (relArgs.size - 1) rhs)

--- a/src/Std/Internal/Do/Triple/Basic.lean
+++ b/src/Std/Internal/Do/Triple/Basic.lean
@@ -40,43 +40,50 @@ structure Triple {Prog : Type v} {Value : Type u} [Assertion Pred] [Assertion EP
   le_wp : pre ⊑ wp x post epost
 
 open Lean in
-/-- A program whose `match`/`if` elaboration postpones on a metavariable expected type and so needs
-the monadic-application hint `(_ : _ → _) _` to recover its monad by first-order unification. -/
+/-- A program whose `match`/`if`/`do` elaboration postpones on a metavariable expected type and so
+needs the monadic-application hint `(_ : _ → _) _` to recover its monad by first-order unification. -/
 private meta partial def isSplitProgram (c : Syntax) : Bool :=
   if c.isOfKind `Lean.Parser.Term.paren then
     isSplitProgram c[1]
   else
     c.isOfKind `Lean.Parser.Term.match ||
     c.isOfKind `termIfThenElse ||
-    c.isOfKind `termDepIfThenElse
+    c.isOfKind `termDepIfThenElse ||
+    c.isOfKind `Lean.Parser.Term.do
 
 open Lean in
-/-- Ascribe `match`/`if` programs to the monadic-application shape `?m ?α`, so their match
-elaboration recovers the program's monad via first-order unification. Other programs are untouched. -/
-private meta def hintProgram (c : Term) : MacroM Term :=
-  if isSplitProgram c.raw then `(($c : (_ : _ → _) _)) else pure c
+/-- Ascribe the program so its monad can be recovered during elaboration. An explicit `(m := …)`
+ascribes the program to `… _`, supplying the monad head directly. Otherwise a `match`/`if`/`do`
+program gets the monadic-application hint `(_ : _ → _) _`, recovering its monad by first-order
+unification. Other programs are untouched. -/
+private meta def hintProgram (c : Term) (m? : Option Term) : MacroM Term :=
+  match m? with
+  | some m => `(($c : $m _))
+  | none => if isSplitProgram c.raw then `(($c : (_ : _ → _) _)) else pure c
 
-/-- Hoare triple notation without exception postcondition (defaults to `⊥`). -/
-scoped notation:60 "⦃ " pre " ⦄ " x " ⦃ " post " ⦄" => Triple x pre post Lean.Order.bot
+/-- Hoare triple notation without exception postcondition (defaults to `⊥`). An optional `(m := …)`
+after the precondition ascribes the program to monad `…`. -/
+scoped syntax:60 (name := tripleNotation)
+  "⦃ " term " ⦄ " (atomic("(" ident " := ") term ")")? term " ⦃ " term " ⦄" : term
 /-- Hoare triple notation with a binder for the return value. -/
-scoped notation:60 "⦃ " pre " ⦄ " x " ⦃ " v ", " post " ⦄" => Triple x pre (fun v => post) Lean.Order.bot
+scoped syntax:60 (name := tripleBinderNotation)
+  "⦃ " term " ⦄ " (atomic("(" ident " := ") term ")")? term " ⦃ " ident ", " term " ⦄" : term
 /-- Hoare triple notation with explicit exception postconditions:
 `⦃ P ⦄ x ⦃ Q; E₁; … ⦄ := Triple x P Q epost⟨E₁, …⟩`. -/
 scoped syntax:60 (name := tripleEPost)
-  "⦃ " term " ⦄ " term " ⦃ " term "; " sepBy1(term, "; ") " ⦄" : term
-macro_rules (kind := tripleEPost)
-  | `(⦃ $P ⦄ $c ⦃ $Q; $Es;* ⦄) => `(Triple $c $P $Q epost⟨$Es,*⟩)
+  "⦃ " term " ⦄ " (atomic("(" ident " := ") term ")")? term " ⦃ " term "; " sepBy1(term, "; ") " ⦄" : term
 
 macro_rules (kind := tripleNotation)
-  | `(⦃ $P ⦄ $c ⦃ $Q ⦄) => do `(Triple $(← hintProgram c) $P $Q Lean.Order.bot)
+  | `(⦃ $P ⦄ $[(m := $m)]? $c ⦃ $Q ⦄) => do `(Triple $(← hintProgram c m) $P $Q Lean.Order.bot)
 macro_rules (kind := tripleBinderNotation)
-  | `(⦃ $P ⦄ $c ⦃ $v, $Q ⦄) => do `(Triple $(← hintProgram c) $P (fun $v => $Q) Lean.Order.bot)
+  | `(⦃ $P ⦄ $[(m := $m)]? $c ⦃ $v, $Q ⦄) => do
+      `(Triple $(← hintProgram c m) $P (fun $v => $Q) Lean.Order.bot)
 macro_rules (kind := tripleEPost)
-  | `(⦃ $P ⦄ $c ⦃ $Q; $Es;* ⦄) => do `(Triple $(← hintProgram c) $P $Q epost⟨$Es,*⟩)
+  | `(⦃ $P ⦄ $[(m := $m)]? $c ⦃ $Q; $Es;* ⦄) => do `(Triple $(← hintProgram c m) $P $Q epost⟨$Es,*⟩)
 
 /-- Pretty-print `Triple` applications back as `⦃ … ⦄` notation. -/
 @[app_unexpander Triple]
-meta def unexpandTripleEPost : Lean.PrettyPrinter.Unexpander
+meta def unexpandTriple : Lean.PrettyPrinter.Unexpander
   | `($(_) $c $P $Q epost⟨$Es,*⟩) =>
     if Es.getElems.isEmpty then throw () else `(⦃ $P ⦄ $c ⦃ $Q; $Es;* ⦄)
   | `($(_) $c $P $Q ⊥) => `(⦃ $P ⦄ $c ⦃ $Q ⦄)

--- a/src/Std/Internal/Do/Triple/Basic.lean
+++ b/src/Std/Internal/Do/Triple/Basic.lean
@@ -128,7 +128,7 @@ variable [Monad m] [WPMonad m Pred EPred]
 
 theorem pure (a : α) (h : pre ⊑ post a) :
     Triple (pure (f := m) a) pre post epost :=
-  ⟨PartialOrder.rel_trans h (WPMonad.wp_pure a post epost)⟩
+  ⟨PartialOrder.rel_trans h (WPMonad.pure_le_wp_pure a post epost)⟩
 
 theorem bind (x : m α) (f : α → m β)
     (mid : α → Pred)
@@ -138,17 +138,17 @@ theorem bind (x : m α) (f : α → m β)
   ⟨PartialOrder.rel_trans hx.le_wp
     (PartialOrder.rel_trans
       (WP.wp_consequence x mid (fun a => wp (f a) post epost) epost (fun a => (hf a).le_wp))
-      (WPMonad.wp_bind x f post epost))⟩
+      (WPMonad.bind_le_wp_bind x f post epost))⟩
 
 theorem map [LawfulMonad m] (f : α → β) (x : m α)
     (h : Triple x pre (fun a => post (f a)) epost) :
     Triple (f <$> x) pre post epost :=
-  ⟨PartialOrder.rel_trans h.le_wp (WPMonad.wp_map f x post epost)⟩
+  ⟨PartialOrder.rel_trans h.le_wp (WPMonad.map_le_wp_map f x post epost)⟩
 
 theorem seq [LawfulMonad m] (x : m (α → β)) (y : m α)
     (h : Triple x pre (fun f => wp y (fun a => post (f a)) epost) epost) :
     Triple (x <*> y) pre post epost :=
-  ⟨PartialOrder.rel_trans h.le_wp (WPMonad.wp_seq x y post epost)⟩
+  ⟨PartialOrder.rel_trans h.le_wp (WPMonad.seq_le_wp_seq x y post epost)⟩
 
 end Monad
 

--- a/src/Std/Internal/Do/Triple/Basic.lean
+++ b/src/Std/Internal/Do/Triple/Basic.lean
@@ -30,10 +30,10 @@ namespace Std.Internal.Do
 universe u v
 variable {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
 
-/-- A Hoare triple for reasoning about monadic programs. A Hoare triple `Triple x pre post epost`
+/-- A Hoare triple for reasoning about programs. A Hoare triple `Triple x pre post epost`
 is a *specification* for `x`: if assertion `pre` holds before `x`, then postcondition `post` holds
 after running `x` (and `epost` handles any errors). -/
-structure Triple [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] (x : m α) (pre : Pred) (post : α → Pred) (epost : EPred) : Prop where
+structure Triple {Prog : Type v} {Value : Type u} [Assertion Pred] [Assertion EPred] (x : Prog) [WP Prog Value Pred EPred] (pre : Pred) (post : Value → Pred) (epost : EPred) : Prop where
   /-- Construct a triple from a weakest precondition entailment. -/
   intro ::
   /-- The weakest precondition entailment witnessing the triple. -/
@@ -57,13 +57,15 @@ private meta def hintProgram (c : Term) : MacroM Term :=
   if isSplitProgram c.raw then `(($c : (_ : _ → _) _)) else pure c
 
 /-- Hoare triple notation without exception postcondition (defaults to `⊥`). -/
-scoped syntax:60 (name := tripleNotation) "⦃ " term " ⦄ " term " ⦃ " term " ⦄" : term
+scoped notation:60 "⦃ " pre " ⦄ " x " ⦃ " post " ⦄" => Triple x pre post Lean.Order.bot
 /-- Hoare triple notation with a binder for the return value. -/
-scoped syntax:60 (name := tripleBinderNotation) "⦃ " term " ⦄ " term " ⦃ " ident ", " term " ⦄" : term
+scoped notation:60 "⦃ " pre " ⦄ " x " ⦃ " v ", " post " ⦄" => Triple x pre (fun v => post) Lean.Order.bot
 /-- Hoare triple notation with explicit exception postconditions:
 `⦃ P ⦄ x ⦃ Q; E₁; … ⦄ := Triple x P Q epost⟨E₁, …⟩`. -/
 scoped syntax:60 (name := tripleEPost)
   "⦃ " term " ⦄ " term " ⦃ " term "; " sepBy1(term, "; ") " ⦄" : term
+macro_rules (kind := tripleEPost)
+  | `(⦃ $P ⦄ $c ⦃ $Q; $Es;* ⦄) => `(Triple $c $P $Q epost⟨$Es,*⟩)
 
 macro_rules (kind := tripleNotation)
   | `(⦃ $P ⦄ $c ⦃ $Q ⦄) => do `(Triple $(← hintProgram c) $P $Q Lean.Order.bot)
@@ -74,7 +76,7 @@ macro_rules (kind := tripleEPost)
 
 /-- Pretty-print `Triple` applications back as `⦃ … ⦄` notation. -/
 @[app_unexpander Triple]
-meta def unexpandTriple : Lean.PrettyPrinter.Unexpander
+meta def unexpandTripleEPost : Lean.PrettyPrinter.Unexpander
   | `($(_) $c $P $Q epost⟨$Es,*⟩) =>
     if Es.getElems.isEmpty then throw () else `(⦃ $P ⦄ $c ⦃ $Q; $Es;* ⦄)
   | `($(_) $c $P $Q ⊥) => `(⦃ $P ⦄ $c ⦃ $Q ⦄)
@@ -83,60 +85,65 @@ meta def unexpandTriple : Lean.PrettyPrinter.Unexpander
 
 namespace Triple
 
-variable [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+variable {Prog : Type v} {Value : Type u} [Assertion Pred] [Assertion EPred]
+  [WP Prog Value Pred EPred]
 
-theorem iff {x : m α} {pre : Pred} {post : α → Pred} {epost : EPred} :
+theorem iff {x : Prog} {pre : Pred} {post : Value → Pred} {epost : EPred} :
     Triple x pre post epost ↔ (pre ⊑ wp x post epost) :=
   ⟨fun ⟨h⟩ => h, fun h => ⟨h⟩⟩
 
-theorem iff_conseq {x : m α} {pre : Pred} {post : α → Pred} {epost : EPred} :
+theorem iff_conseq {x : Prog} {pre : Pred} {post : Value → Pred} {epost : EPred} :
     Triple x pre post epost ↔
     (∀ pre' post', (pre' ⊑ pre) → (post ⊑ post') → pre' ⊑ wp x post' epost) := by
   constructor
   · intro ⟨h⟩ pre' post' hpre hpost
-    exact PartialOrder.rel_trans hpre (PartialOrder.rel_trans h (WPMonad.wp_consequence x _ _ epost hpost))
+    exact PartialOrder.rel_trans hpre (PartialOrder.rel_trans h (WP.wp_consequence x _ _ epost hpost))
   · intro h
     exact ⟨h _ _ PartialOrder.rel_refl (fun _ => PartialOrder.rel_refl)⟩
 
-theorem entails_wp_of_pre_post {x : m α} {pre pre' : Pred} {post post' : α → Pred} {epost : EPred}
+theorem entails_wp_of_pre_post {x : Prog} {pre pre' : Pred} {post post' : Value → Pred} {epost : EPred}
     (h : Triple x pre' post' epost) (hpre : pre ⊑ pre') (hpost : post' ⊑ post) :
     pre ⊑ wp x post epost :=
   iff_conseq.mp h _ _ hpre hpost
 
-theorem entails_wp_of_pre {x : m α} {pre pre' : Pred} {post : α → Pred} {epost : EPred}
+theorem entails_wp_of_pre {x : Prog} {pre pre' : Pred} {post : Value → Pred} {epost : EPred}
     (h : Triple x pre' post epost) (hpre : pre ⊑ pre') :
     pre ⊑ wp x post epost :=
   iff_conseq.mp h _ _ hpre (fun _ => PartialOrder.rel_refl)
 
-theorem entails_wp_of_post {x : m α} {pre : Pred} {post post' : α → Pred} {epost : EPred}
+theorem entails_wp_of_post {x : Prog} {pre : Pred} {post post' : Value → Pred} {epost : EPred}
     (h : Triple x pre post' epost) (hpost : post' ⊑ post) :
     pre ⊑ wp x post epost :=
   iff_conseq.mp h _ _ PartialOrder.rel_refl hpost
 
+section Monad
+variable [Monad m] [WPMonad m Pred EPred]
+
 theorem pure (a : α) (h : pre ⊑ post a) :
     Triple (pure (f := m) a) pre post epost :=
-  iff.mpr (PartialOrder.rel_trans h (WPMonad.wp_pure a post epost))
+  ⟨PartialOrder.rel_trans h (WPMonad.wp_pure a post epost)⟩
 
 theorem bind (x : m α) (f : α → m β)
     (mid : α → Pred)
     (hx : Triple x pre mid epost)
     (hf : ∀ a, Triple (f a) (mid a) post epost) :
-    Triple (x >>= f) pre post epost := by
-  apply iff.mpr
-  apply PartialOrder.rel_trans (iff.mp hx)
-  apply PartialOrder.rel_trans (WPMonad.wp_consequence x mid (fun a => wp (f a) post epost) epost
-    (fun a => iff.mp (hf a)))
-  exact WPMonad.wp_bind x f post epost
+    Triple (x >>= f) pre post epost :=
+  ⟨PartialOrder.rel_trans hx.le_wp
+    (PartialOrder.rel_trans
+      (WP.wp_consequence x mid (fun a => wp (f a) post epost) epost (fun a => (hf a).le_wp))
+      (WPMonad.wp_bind x f post epost))⟩
 
-theorem map (f : α → β) (x : m α)
+theorem map [LawfulMonad m] (f : α → β) (x : m α)
     (h : Triple x pre (fun a => post (f a)) epost) :
     Triple (f <$> x) pre post epost :=
-  iff.mpr (PartialOrder.rel_trans (iff.mp h) (WPMonad.wp_map f x post epost))
+  ⟨PartialOrder.rel_trans h.le_wp (WPMonad.wp_map f x post epost)⟩
 
-theorem seq (x : m (α → β)) (y : m α)
+theorem seq [LawfulMonad m] (x : m (α → β)) (y : m α)
     (h : Triple x pre (fun f => wp y (fun a => post (f a)) epost) epost) :
     Triple (x <*> y) pre post epost :=
-  iff.mpr (PartialOrder.rel_trans (iff.mp h) (WPMonad.wp_seq x y post epost))
+  ⟨PartialOrder.rel_trans h.le_wp (WPMonad.wp_seq x y post epost)⟩
+
+end Monad
 
 end Triple
 

--- a/src/Std/Internal/Do/Triple/Gadget.lean
+++ b/src/Std/Internal/Do/Triple/Gadget.lean
@@ -32,7 +32,7 @@ def assertGadget [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EP
 the Heyting implication `as ⇨ post ⟨⟩`, ensuring the assertion holds and the postcondition
 follows from it. -/
 theorem Spec.assertGadget (name : Name) (as : Pred) [Frame Pred] :
-  Triple (m := m) (Std.Internal.Do.assertGadget name as) (as ⊓ (as ⇨ post ⟨⟩)) post epost := by
+  Triple (Std.Internal.Do.assertGadget (m := m) name as) (as ⊓ (as ⇨ post ⟨⟩)) post epost := by
   simpa [Std.Internal.Do.assertGadget] using
     (Triple.pure (m := m) (pre := as ⊓ himp as (post ⟨⟩)) (post := post) (epost := epost)
       (a := ⟨⟩) (h := himp_sound (a := as) (b := post ⟨⟩)))

--- a/src/Std/Internal/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Internal/Do/Triple/SpecLemmas.lean
@@ -66,12 +66,12 @@ theorem Spec.bind (x : m α) (f : α → m β) :
     (Triple.intro PartialOrder.rel_refl) (fun _ => Triple.intro PartialOrder.rel_refl)
 
 @[spec]
-theorem Spec.map [LawfulMonad m] (f : α → β) (x : m α) :
+theorem Spec.map (f : α → β) (x : m α) :
     Triple (f <$> x) (wp x (fun a => post (f a)) epost) post epost :=
   Triple.map f x (Triple.intro PartialOrder.rel_refl)
 
 @[spec]
-theorem Spec.seq [LawfulMonad m] (x : m (α → β)) (y : m α) :
+theorem Spec.seq (x : m (α → β)) (y : m α) :
     Triple (x <*> y) (wp x (fun f => wp y (fun a => post (f a)) epost) epost) post epost :=
   Triple.seq x y (Triple.intro PartialOrder.rel_refl)
 
@@ -91,7 +91,7 @@ theorem Spec.monadLift_ReaderT (x : m α) (post : α → ρ → Pred) :
 
 
 @[spec]
-theorem Spec.monadLift_ExceptT [LawfulMonad m] (x : m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
+theorem Spec.monadLift_ExceptT (x : m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (MonadLift.monadLift x : ExceptT ε m α) (wp x post epost.tail) post epost :=
   Triple.intro (WPMonad.le_wp_monadLift_ExceptT_apply x post epost)
 
@@ -164,7 +164,7 @@ theorem Spec.monadMap_refl (x : m α) :
 
 
 @[spec]
-theorem Spec.liftWith_StateT [LawfulMonad m]
+theorem Spec.liftWith_StateT
     (f : (∀{β}, StateT σ m β → m (β × σ)) → m α) (post : α → σ → Pred) :
     Triple (MonadControl.liftWith (m:=m) f : StateT σ m α)
       (fun s => wp (f (fun x => x.run s)) (fun a => post a s) epost) post epost :=
@@ -180,7 +180,7 @@ theorem Spec.liftWith_ReaderT
 
 
 @[spec]
-theorem Spec.liftWith_ExceptT [LawfulMonad m]
+theorem Spec.liftWith_ExceptT
     (f : (∀{β}, ExceptT ε m β → m (Except ε β)) → m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (MonadControl.liftWith (m:=m) f : ExceptT ε m α)
       (wp (f (fun x => x.run)) post epost.tail) post epost :=
@@ -335,21 +335,21 @@ theorem Spec.throw_ExceptT (err : ε) (post : α → Pred) (epost : EPost.Cons (
 
 
 @[spec]
-theorem Spec.tryCatch_ExceptT [LawfulMonad m] (x : ExceptT ε m α) (h : ε → ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
+theorem Spec.tryCatch_ExceptT (x : ExceptT ε m α) (h : ε → ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (MonadExceptOf.tryCatch x h : ExceptT ε m α)
       (wp x post ⟨fun e => wp (h e) post epost, epost.tail⟩) post epost :=
   Triple.intro (WPMonad.le_wp_tryCatch_ExceptT_apply x h)
 
 
 @[spec]
-theorem Spec.orElse_ExceptT [LawfulMonad m] (x : ExceptT ε m α) (h : Unit → ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
+theorem Spec.orElse_ExceptT (x : ExceptT ε m α) (h : Unit → ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (OrElse.orElse x h : ExceptT ε m α)
       (wp x post ⟨fun _ => wp (h ()) post epost, epost.tail⟩) post epost :=
   Triple.intro (WPMonad.le_wp_orElse_ExceptT_apply x h)
 
 
 @[spec]
-theorem Spec.adapt_ExceptT [LawfulMonad m] (f : ε → ε') (x : ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε' → Pred) EPred) :
+theorem Spec.adapt_ExceptT (f : ε → ε') (x : ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε' → Pred) EPred) :
     Triple (ExceptT.adapt f x : ExceptT ε' m α)
       (wp x post ⟨fun e => epost.head (f e), epost.tail⟩) post epost :=
   Triple.intro (WPMonad.le_wp_adapt_ExceptT_apply f x)
@@ -728,7 +728,7 @@ theorem Spec.forIn_list_const_inv
 
 
 @[spec]
-theorem Spec.foldlM_list [LawfulMonad m]
+theorem Spec.foldlM_list
     {xs : List α} {init : β} {f : β → α → m β}
     (inv : Invariant xs β Pred)
     {epost : EPred}
@@ -752,7 +752,7 @@ theorem Spec.foldlM_list [LawfulMonad m]
   apply step <;> assumption
 
 
-theorem Spec.foldlM_list_const_inv [LawfulMonad m]
+theorem Spec.foldlM_list_const_inv
     {xs : List α} {init : β} {f : β → α → m β}
     {inv : (β → Pred)}
     {epost : EPred}
@@ -815,7 +815,7 @@ open Std Std.PRange in
 
 @[spec]
 theorem Spec.forIn'_rcc {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
     {xs : Rcc α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
@@ -841,7 +841,7 @@ open Std Std.PRange in
 
 @[spec]
 theorem Spec.forIn_rcc {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
     {xs : Rcc α} {init : β} {f : α → β → m (ForInStep β)}
@@ -867,7 +867,7 @@ open Std Std.PRange in
 
 @[spec]
 theorem Spec.forIn'_rco {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LE α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLT α]
     {xs : Rco α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
@@ -893,7 +893,7 @@ open Std Std.PRange in
 
 @[spec]
 theorem Spec.forIn_rco {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LE α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLT α]
     {xs : Rco α} {init : β} {f : α → β → m (ForInStep β)}
@@ -919,7 +919,7 @@ open Std Std.PRange in
 
 @[spec]
 theorem Spec.forIn'_rci {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LE α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
     {xs : Rci α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
@@ -945,7 +945,7 @@ open Std Std.PRange in
 
 @[spec]
 theorem Spec.forIn_rci {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LE α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
     {xs : Rci α} {init : β} {f : α → β → m (ForInStep β)}
@@ -971,7 +971,7 @@ open Std Std.PRange in
 
 @[spec]
 theorem Spec.forIn'_roc {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LE α] [DecidableLE α] [LT α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLT α]
     {xs : Roc α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
@@ -996,7 +996,7 @@ theorem Spec.forIn'_roc {α β : Type u} {m : Type u → Type v} {Pred : Type u}
 open Std Std.PRange in
 
 theorem Spec.forIn_roc {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LE α] [DecidableLE α] [LT α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLT α]
     {xs : Roc α} {init : β} {f : α → β → m (ForInStep β)}
@@ -1022,7 +1022,7 @@ open Std Std.PRange in
 
 @[spec]
 theorem Spec.forIn'_roo {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
     {xs : Roo α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
@@ -1048,7 +1048,7 @@ open Std Std.PRange in
 
 @[spec]
 theorem Spec.forIn_roo {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
     {xs : Roo α} {init : β} {f : α → β → m (ForInStep β)}
@@ -1074,7 +1074,7 @@ open Std Std.PRange in
 
 @[spec]
 theorem Spec.forIn'_roi {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
     {xs : Roi α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
@@ -1100,7 +1100,7 @@ open Std Std.PRange in
 
 @[spec]
 theorem Spec.forIn_roi {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
     {xs : Roi α} {init : β} {f : α → β → m (ForInStep β)}
@@ -1126,7 +1126,7 @@ open Std Std.PRange in
 
 @[spec]
 theorem Spec.forIn'_ric {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Least? α] [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α] [LawfulUpwardEnumerableLE α]
     {xs : Ric α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
@@ -1152,7 +1152,7 @@ open Std Std.PRange in
 
 @[spec]
 theorem Spec.forIn_ric {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Least? α] [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α] [LawfulUpwardEnumerableLE α]
     {xs : Ric α} {init : β} {f : α → β → m (ForInStep β)}
@@ -1178,7 +1178,7 @@ open Std Std.PRange in
 
 @[spec]
 theorem Spec.forIn'_rio {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Least? α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α] [LawfulUpwardEnumerableLT α]
     {xs : Rio α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
@@ -1204,7 +1204,7 @@ open Std Std.PRange in
 
 @[spec]
 theorem Spec.forIn_rio {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Least? α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α] [LawfulUpwardEnumerableLT α]
     {xs : Rio α} {init : β} {f : α → β → m (ForInStep β)}
@@ -1230,7 +1230,7 @@ open Std Std.PRange in
 
 @[spec]
 theorem Spec.forIn'_rii {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Least? α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α]
     {xs : Rii α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
@@ -1256,7 +1256,7 @@ open Std Std.PRange in
 
 @[spec]
 theorem Spec.forIn_rii {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Least? α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α]
     {xs : Rii α} {init : β} {f : α → β → m (ForInStep β)}
@@ -1282,7 +1282,7 @@ open Std Std.Iterators in
 
 @[spec]
 theorem Spec.forIn_slice {δ : Type u} {m : Type u → Type w} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {γ : Type u'} {α β : Type u}
     [ToIterator (Slice γ) Id α β]
     [Iterator α Id β]
@@ -1312,7 +1312,7 @@ open Std Std.Iterators
 
 @[spec low]
 theorem Spec.forIn_iter {α β γ : Type u} {m : Type u → Type w} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Iterator α Id β] [Finite α Id] [IteratorLoop α Id m] [LawfulIteratorLoop α Id m]
     {init : γ} {f : β → γ → m (ForInStep γ)}
     {it : Iter (α := α) β}
@@ -1334,7 +1334,7 @@ theorem Spec.forIn_iter {α β γ : Type u} {m : Type u → Type w} {Pred : Type
 
 @[spec low]
 theorem Spec.forIn_iterM_id {α β γ : Type u} {m : Type u → Type w} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Iterator α Id β] [Finite α Id] [IteratorLoop α Id m] [LawfulIteratorLoop α Id m]
     {init : γ} {f : β → γ → m (ForInStep γ)}
     {it : IterM (α := α) Id β}
@@ -1358,7 +1358,7 @@ theorem Spec.forIn_iterM_id {α β γ : Type u} {m : Type u → Type w} {Pred : 
 
 @[spec low]
 theorem Spec.foldM_iter {α β γ : Type u} {m : Type u → Type w} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Iterator α Id β] [Finite α Id] [IteratorLoop α Id m] [LawfulIteratorLoop α Id m]
     {it : Iter (α := α) β}
     {init : γ} {f : γ → β → m γ}
@@ -1378,7 +1378,7 @@ theorem Spec.foldM_iter {α β γ : Type u} {m : Type u → Type w} {Pred : Type
 
 @[spec low]
 theorem Spec.foldM_iterM_id {α β γ : Type u} {m : Type u → Type w} {Pred : Type u} {EPred : Type u}
-    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] [LawfulMonad m]
+    [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Iterator α Id β] [Finite α Id] [IteratorLoop α Id m] [LawfulIteratorLoop α Id m]
     {it : IterM (α := α) Id β}
     {init : γ} {f : γ → β → m γ}
@@ -1400,7 +1400,7 @@ theorem Spec.foldM_iterM_id {α β γ : Type u} {m : Type u → Type w} {Pred : 
 theorem Spec.IterM.forIn_filterMapWithPostcondition {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
     [IteratorLoop α m o] [LawfulIteratorLoop α m o]
@@ -1420,7 +1420,7 @@ theorem Spec.IterM.forIn_filterMapWithPostcondition {α β β₂ γ : Type w}
 theorem Spec.IterM.forIn_filterMapM {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
@@ -1441,7 +1441,7 @@ theorem Spec.IterM.forIn_filterMapM {α β β₂ γ : Type w}
 theorem Spec.IterM.forIn_filterMap {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
@@ -1459,7 +1459,7 @@ theorem Spec.IterM.forIn_filterMap {α β β₂ γ : Type w}
 theorem Spec.IterM.forIn_mapWithPostcondition {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
     [IteratorLoop α m o] [LawfulIteratorLoop α m o]
@@ -1476,7 +1476,7 @@ theorem Spec.IterM.forIn_mapWithPostcondition {α β β₂ γ : Type w}
 theorem Spec.IterM.forIn_mapM {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
@@ -1494,7 +1494,7 @@ theorem Spec.IterM.forIn_mapM {α β β₂ γ : Type w}
 theorem Spec.IterM.forIn_map {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     {it : IterM (α := α) m β} {f : β → β₂} {init : γ} {g : β₂ → γ → n (ForInStep γ)}
@@ -1508,7 +1508,7 @@ theorem Spec.IterM.forIn_map {α β β₂ γ : Type w}
 theorem Spec.IterM.forIn_filterWithPostcondition {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
     [IteratorLoop α m o] [LawfulIteratorLoop α m o]
@@ -1525,7 +1525,7 @@ theorem Spec.IterM.forIn_filterWithPostcondition {α β γ : Type w}
 theorem Spec.IterM.forIn_filterM {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
@@ -1543,7 +1543,7 @@ theorem Spec.IterM.forIn_filterM {α β γ : Type w}
 theorem Spec.IterM.forIn_filter {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     {it : IterM (α := α) m β} {f : β → Bool} {init : γ} {g : β → γ → n (ForInStep γ)}
@@ -1558,7 +1558,7 @@ theorem Spec.IterM.foldM_filterMapWithPostcondition {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
-    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -1580,7 +1580,7 @@ theorem Spec.IterM.foldM_filterMapM {α β γ δ : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
-    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -1600,7 +1600,7 @@ theorem Spec.IterM.foldM_mapWithPostcondition {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
-    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -1620,7 +1620,7 @@ theorem Spec.IterM.foldM_mapM {α β γ δ : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
-    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -1638,7 +1638,7 @@ theorem Spec.IterM.foldM_filterWithPostcondition {α β δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
-    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -1658,7 +1658,7 @@ theorem Spec.IterM.foldM_filterM {α β δ : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
-    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -1675,7 +1675,7 @@ theorem Spec.IterM.foldM_filterM {α β δ : Type w}
 theorem Spec.IterM.foldM_filterMap {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n]
     [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
@@ -1692,7 +1692,7 @@ theorem Spec.IterM.foldM_filterMap {α β γ δ : Type w}
 theorem Spec.IterM.foldM_map {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → γ} {g : δ → γ → n δ} {init : δ} {it : IterM (α := α) m β}
@@ -1706,7 +1706,7 @@ theorem Spec.IterM.foldM_map {α β γ δ : Type w}
 theorem Spec.IterM.foldM_filter {α β δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n]
     [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
@@ -1723,7 +1723,7 @@ theorem Spec.IterM.fold_filterMapWithPostcondition {α β γ δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → PostconditionT n (Option γ)} {g : δ → γ → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1741,7 +1741,7 @@ theorem Spec.IterM.fold_filterMapM {α β γ δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
-    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [MonadAttach n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → n (Option γ)} {g : δ → γ → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1759,7 +1759,7 @@ theorem Spec.IterM.fold_mapWithPostcondition {α β γ δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → PostconditionT n γ} {g : δ → γ → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1775,7 +1775,7 @@ theorem Spec.IterM.fold_mapM {α β γ δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
-    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [MonadAttach n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → n γ} {g : δ → γ → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1791,7 +1791,7 @@ theorem Spec.IterM.fold_filterWithPostcondition {α β δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → PostconditionT n (ULift Bool)} {g : δ → β → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1807,7 +1807,7 @@ theorem Spec.IterM.fold_filterM {α β δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
-    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [MonadAttach n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → n (ULift Bool)} {g : δ → β → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1821,7 +1821,7 @@ theorem Spec.IterM.fold_filterM {α β δ : Type w}
 theorem Spec.IterM.fold_filterMap {α β γ δ : Type w}
     {m : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α m β] [Finite α m] [Monad m] [LawfulMonad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+    [Iterator α m β] [Finite α m] [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [IteratorLoop α m m] [LawfulIteratorLoop α m m]
     {f : β → Option γ} {g : δ → γ → δ} {init : δ} {it : IterM (α := α) m β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -1837,7 +1837,7 @@ theorem Spec.IterM.fold_filterMap {α β γ δ : Type w}
 theorem Spec.IterM.fold_map {α β γ δ : Type w}
     {m : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α m β] [Finite α m] [Monad m] [LawfulMonad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+    [Iterator α m β] [Finite α m] [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [IteratorLoop α m m] [LawfulIteratorLoop α m m]
     {f : β → γ} {g : δ → γ → δ} {init : δ} {it : IterM (α := α) m β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -1850,7 +1850,7 @@ theorem Spec.IterM.fold_map {α β γ δ : Type w}
 theorem Spec.IterM.fold_filter {α β δ : Type w}
     {m : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α m β] [Finite α m] [Monad m] [LawfulMonad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+    [Iterator α m β] [Finite α m] [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [IteratorLoop α m m] [LawfulIteratorLoop α m m]
     {f : β → Bool} {g : δ → β → δ} {init : δ} {it : IterM (α := α) m β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -1864,7 +1864,7 @@ theorem Spec.Iter.forIn_filterMapWithPostcondition {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadLiftT n o] [LawfulMonadLiftT n o] [Finite α Id]
     [IteratorLoop α Id o] [LawfulIteratorLoop α Id o]
     {it : Iter (α := α) β} {f : β → PostconditionT n (Option β₂)} {init : γ}
@@ -1882,7 +1882,7 @@ theorem Spec.Iter.forIn_filterMapM {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Finite α Id] [IteratorLoop α Id o] [LawfulIteratorLoop α Id o]
@@ -1901,7 +1901,7 @@ theorem Spec.Iter.forIn_filterMap {α β β₂ γ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred] [Finite α Id]
+    [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred] [Finite α Id]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {it : Iter (α := α) β} {f : β → Option β₂} {init : γ} {g : β₂ → γ → n (ForInStep γ)}
     {P : Pred} {Q : γ → Pred} {eQ : EPred}
@@ -1918,7 +1918,7 @@ theorem Spec.Iter.forIn_mapWithPostcondition {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadLiftT n o] [LawfulMonadLiftT n o] [Finite α Id]
     [IteratorLoop α Id o] [LawfulIteratorLoop α Id o]
     {it : Iter (α := α) β} {f : β → PostconditionT n β₂} {init : γ}
@@ -1933,7 +1933,7 @@ theorem Spec.Iter.forIn_mapM {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Finite α Id]
@@ -1950,7 +1950,7 @@ theorem Spec.Iter.forIn_map {α β β₂ γ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [Finite α Id] [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {it : Iter (α := α) β} {f : β → β₂} {init : γ} {g : β₂ → γ → n (ForInStep γ)}
     {P : Pred} {Q : γ → Pred} {eQ : EPred}
@@ -1964,7 +1964,7 @@ theorem Spec.Iter.forIn_filterWithPostcondition {α β γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Finite α Id] [IteratorLoop α Id o] [LawfulIteratorLoop α Id o]
     {it : Iter (α := α) β} {f : β → PostconditionT n (ULift Bool)} {init : γ}
@@ -1979,7 +1979,7 @@ theorem Spec.Iter.forIn_filterM {α β γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT n o] [LawfulMonadLiftT n o] [Finite α Id]
     [IteratorLoop α Id o] [LawfulIteratorLoop α Id o]
@@ -1995,7 +1995,7 @@ theorem Spec.Iter.forIn_filter {α β γ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [Finite α Id] [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {it : Iter (α := α) β} {f : β → Bool} {init : γ} {g : β → γ → n (ForInStep γ)}
     {P : Pred} {Q : γ → Pred} {eQ : EPred}
@@ -2009,7 +2009,7 @@ theorem Spec.Iter.foldM_filterMapWithPostcondition {α β γ δ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [Monad o] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad n] [Monad o] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
     [LawfulIteratorLoop α Id n] [LawfulIteratorLoop α Id o]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -2028,7 +2028,7 @@ theorem Spec.Iter.foldM_filterMapM {α β γ δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
-    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
     [LawfulIteratorLoop α Id n] [LawfulIteratorLoop α Id o]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -2046,7 +2046,7 @@ theorem Spec.Iter.foldM_mapWithPostcondition {α β γ δ : Type w}
     {m : Type w → Type w'''} {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
     [LawfulIteratorLoop α Id n] [LawfulIteratorLoop α Id o]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -2063,7 +2063,7 @@ theorem Spec.Iter.foldM_mapM {α β γ δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
-    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
     [LawfulIteratorLoop α Id n] [LawfulIteratorLoop α Id o]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -2079,7 +2079,7 @@ theorem Spec.Iter.foldM_filterWithPostcondition {α β δ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [Monad o] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad n] [Monad o] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
     [LawfulIteratorLoop α Id n] [LawfulIteratorLoop α Id o]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -2096,7 +2096,7 @@ theorem Spec.Iter.foldM_filterM {α β δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
-    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
     [LawfulIteratorLoop α Id n] [LawfulIteratorLoop α Id o]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -2111,7 +2111,7 @@ theorem Spec.Iter.foldM_filterM {α β δ : Type w}
 theorem Spec.Iter.foldM_filterMap {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α Id β] [Finite α Id] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Iterator α Id β] [Finite α Id] [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n]
     [LawfulIteratorLoop α Id n]
     {f : β → Option γ} {g : δ → γ → n δ} {init : δ} {it : Iter (α := α) β}
@@ -2127,7 +2127,7 @@ theorem Spec.Iter.foldM_filterMap {α β γ δ : Type w}
 theorem Spec.Iter.foldM_map {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α Id β] [Finite α Id] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Iterator α Id β] [Finite α Id] [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → γ} {g : δ → γ → n δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2140,7 +2140,7 @@ theorem Spec.Iter.foldM_map {α β γ δ : Type w}
 theorem Spec.Iter.foldM_filter {α β δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α Id β] [Finite α Id] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Iterator α Id β] [Finite α Id] [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → Bool} {g : δ → β → n δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2154,7 +2154,7 @@ theorem Spec.Iter.fold_filterMapWithPostcondition {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → PostconditionT n (Option γ)} {g : δ → γ → δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2170,7 +2170,7 @@ theorem Spec.Iter.fold_filterMapM {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [MonadAttach n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → n (Option γ)} {g : δ → γ → δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2186,7 +2186,7 @@ theorem Spec.Iter.fold_mapWithPostcondition {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → PostconditionT n γ} {g : δ → γ → δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2200,7 +2200,7 @@ theorem Spec.Iter.fold_mapM {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [MonadAttach n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → n γ} {g : δ → γ → δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2214,7 +2214,7 @@ theorem Spec.Iter.fold_filterWithPostcondition {α β δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → PostconditionT n (ULift Bool)} {g : δ → β → δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2228,7 +2228,7 @@ theorem Spec.Iter.fold_filterM {α β δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [MonadAttach n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → n (ULift Bool)} {g : δ → β → δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2281,7 +2281,7 @@ theorem Spec.forIn_array {xs : Array α} {init : β} {f : α → β → m (ForIn
 
 
 @[spec]
-theorem Spec.foldlM_array [LawfulMonad m]
+theorem Spec.foldlM_array
     {xs : Array α} {init : β} {f : β → α → m β}
     (inv : Invariant xs.toList β Pred)
     {epost : EPred}
@@ -2319,7 +2319,7 @@ noncomputable abbrev StringInvariant.withEarlyReturnNewDo {s : String} {β : Typ
       ⊔ (iSup fun r => ⌜x = some r ∧ pos = s.endPos⌝ ⊓ onReturn r b)
 
 @[spec]
-theorem Spec.forIn_string [LawfulMonad m]
+theorem Spec.forIn_string
     {s : String} {init : β} {f : Char → β → m (ForInStep β)}
     (inv : StringInvariant s β Pred)
     {epost : EPred}
@@ -2376,7 +2376,7 @@ noncomputable abbrev StringSliceInvariant.withEarlyReturnNewDo {s : String.Slice
       ⊔ (iSup fun r => ⌜x = some r ∧ pos = s.endPos⌝ ⊓ onReturn r b)
 
 @[spec]
-theorem Spec.forIn_stringSlice [LawfulMonad m]
+theorem Spec.forIn_stringSlice
     {s : String.Slice} {init : β} {f : Char → β → m (ForInStep β)}
     (inv : StringSliceInvariant s β Pred)
     {epost : EPred}

--- a/src/Std/Internal/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Internal/Do/Triple/SpecLemmas.lean
@@ -31,6 +31,8 @@ import Init.Data.String.Termination
 import Init.Data.String.Lemmas.Iterate
 
 set_option linter.missingDocs true
+-- The `WP`/`WPMonad` split means each lemma uses only the subset of the section variables it needs.
+set_option linter.unusedSectionVars false
 
 @[expose] public section
 
@@ -38,6 +40,7 @@ set_option linter.missingDocs true
 # Hoare triple specifications for select functions
 
 This module contains Hoare triple specifications for some functions in Core.
+The specifications follow the `Triple x pre post epost` argument order, program first.
 -/
 
 namespace Std.Internal.Do
@@ -60,17 +63,17 @@ theorem Spec.pure (a : α) :
 theorem Spec.bind (x : m α) (f : α → m β) :
     Triple (x >>= f) (wp x (fun a => wp (f a) post epost) epost) post epost :=
   Triple.bind x f (fun a => wp (f a) post epost)
-    (Triple.iff.mpr PartialOrder.rel_refl) (fun _ => Triple.iff.mpr PartialOrder.rel_refl)
+    (Triple.intro PartialOrder.rel_refl) (fun _ => Triple.intro PartialOrder.rel_refl)
 
 @[spec]
-theorem Spec.map (f : α → β) (x : m α) :
+theorem Spec.map [LawfulMonad m] (f : α → β) (x : m α) :
     Triple (f <$> x) (wp x (fun a => post (f a)) epost) post epost :=
-  Triple.map f x (Triple.iff.mpr PartialOrder.rel_refl)
+  Triple.map f x (Triple.intro PartialOrder.rel_refl)
 
 @[spec]
-theorem Spec.seq (x : m (α → β)) (y : m α) :
+theorem Spec.seq [LawfulMonad m] (x : m (α → β)) (y : m α) :
     Triple (x <*> y) (wp x (fun f => wp y (fun a => post (f a)) epost) epost) post epost :=
-  Triple.seq x y (Triple.iff.mpr PartialOrder.rel_refl)
+  Triple.seq x y (Triple.intro PartialOrder.rel_refl)
 
 /-! # `MonadLift` -/
 
@@ -78,25 +81,25 @@ theorem Spec.seq (x : m (α → β)) (y : m α) :
 @[spec]
 theorem Spec.monadLift_StateT (x : m α) (post : α → σ → Pred) :
     Triple (MonadLift.monadLift x : StateT σ m α) (fun s => wp x (fun a => post a s) epost) post epost :=
-  Triple.iff.mpr (WPMonad.le_wp_monadLift_StateT_apply x post)
+  Triple.intro (WPMonad.le_wp_monadLift_StateT_apply x post)
 
 
 @[spec]
 theorem Spec.monadLift_ReaderT (x : m α) (post : α → ρ → Pred) :
     Triple (MonadLift.monadLift x : ReaderT ρ m α) (fun r => wp x (fun a => post a r) epost) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_monadLift_ReaderT_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_monadLift_ReaderT_apply_eq]; rfl)
 
 
 @[spec]
-theorem Spec.monadLift_ExceptT (x : m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
+theorem Spec.monadLift_ExceptT [LawfulMonad m] (x : m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (MonadLift.monadLift x : ExceptT ε m α) (wp x post epost.tail) post epost :=
-  Triple.iff.mpr (WPMonad.le_wp_monadLift_ExceptT_apply x post epost)
+  Triple.intro (WPMonad.le_wp_monadLift_ExceptT_apply x post epost)
 
 
 @[spec]
 theorem Spec.monadLift_OptionT (x : m α) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (MonadLift.monadLift x : OptionT m α) (wp x post epost.tail) post epost :=
-  Triple.iff.mpr (WPMonad.le_wp_monadLift_OptionT_apply x)
+  Triple.intro (WPMonad.le_wp_monadLift_OptionT_apply x)
 
 @[spec]
 theorem Spec.monadLift_Id (x : Id α) :
@@ -123,7 +126,7 @@ theorem Spec.monadMap_StateT
     (f : ∀{β}, m β → m β) {α} (x : StateT σ m α) (post : α → σ → Pred) :
     Triple (MonadFunctor.monadMap (m := m) f x : StateT σ m α)
       (fun s => wp (f (x.run s)) (fun (a, s') => post a s') epost) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_monadMap_StateT_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_monadMap_StateT_apply_eq]; rfl)
 
 
 @[spec]
@@ -131,7 +134,7 @@ theorem Spec.monadMap_ReaderT
     (f : ∀{β}, m β → m β) {α} (x : ReaderT ρ m α) (post : α → ρ → Pred) :
     Triple (MonadFunctor.monadMap (m := m) f x : ReaderT ρ m α)
       (fun r => wp (f (x.run r)) (fun a => post a r) epost) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_monadMap_ReaderT_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_monadMap_ReaderT_apply_eq]; rfl)
 
 
 @[spec]
@@ -139,7 +142,7 @@ theorem Spec.monadMap_ExceptT
     (f : ∀{β}, m β → m β) {α} (x : ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (MonadFunctor.monadMap (m := m) f x : ExceptT ε m α)
       (wp (f x.run) (epost.pushExcept post) epost.tail) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_monadMap_ExceptT_apply_eq])
+  Triple.intro (by rw [WPMonad.wp_monadMap_ExceptT_apply_eq])
 
 
 @[spec]
@@ -147,7 +150,7 @@ theorem Spec.monadMap_OptionT
     (f : ∀{β}, m β → m β) {α} (x : OptionT m α) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (MonadFunctor.monadMap (m := m) f x : OptionT m α)
       (wp (f x.run) (epost.pushOption post) epost.tail) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_monadMap_OptionT_apply_eq])
+  Triple.intro (by rw [WPMonad.wp_monadMap_OptionT_apply_eq])
 
 
 
@@ -155,17 +158,17 @@ theorem Spec.monadMap_OptionT
 theorem Spec.monadMap_refl (x : m α) :
     Triple (MonadFunctorT.monadMap f x : m α)
       (wp (f x : m α) post epost) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_monadMap_refl_apply_eq])
+  Triple.intro (by rw [WPMonad.wp_monadMap_refl_apply_eq])
 
 /-! # `MonadControl` -/
 
 
 @[spec]
-theorem Spec.liftWith_StateT
+theorem Spec.liftWith_StateT [LawfulMonad m]
     (f : (∀{β}, StateT σ m β → m (β × σ)) → m α) (post : α → σ → Pred) :
     Triple (MonadControl.liftWith (m:=m) f : StateT σ m α)
       (fun s => wp (f (fun x => x.run s)) (fun a => post a s) epost) post epost :=
-  Triple.iff.mpr (by intro s; simp [WPMonad.wp_liftWith_StateT_apply_eq f]; apply WPMonad.wp_map'; ext; rfl)
+  Triple.intro (by intro s; simp [WPMonad.wp_liftWith_StateT_apply_eq f]; apply WPMonad.wp_map'; ext; rfl)
 
 
 @[spec]
@@ -173,15 +176,15 @@ theorem Spec.liftWith_ReaderT
     (f : (∀{β}, ReaderT ρ m β → m β) → m α) (post : α → ρ → Pred) :
     Triple (MonadControl.liftWith (m:=m) f : ReaderT ρ m α)
       (fun r => wp (f (fun x => x.run r)) (fun a => post a r) epost) post epost :=
-  Triple.iff.mpr (by intro r; simp [WPMonad.wp_liftWith_ReaderT_apply_eq f]; rfl)
+  Triple.intro (by intro r; simp [WPMonad.wp_liftWith_ReaderT_apply_eq f]; rfl)
 
 
 @[spec]
-theorem Spec.liftWith_ExceptT
+theorem Spec.liftWith_ExceptT [LawfulMonad m]
     (f : (∀{β}, ExceptT ε m β → m (Except ε β)) → m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (MonadControl.liftWith (m:=m) f : ExceptT ε m α)
       (wp (f (fun x => x.run)) post epost.tail) post epost :=
-  Triple.iff.mpr (by simp [WPMonad.wp_liftWith_ExceptT_apply_eq f]; apply WPMonad.wp_map'; ext; rfl)
+  Triple.intro (by simp [WPMonad.wp_liftWith_ExceptT_apply_eq f]; apply WPMonad.wp_map'; ext; rfl)
 
 
 @[spec]
@@ -189,35 +192,35 @@ theorem Spec.liftWith_OptionT
     (f : (∀{β}, OptionT m β → m (Option β)) → m α) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (MonadControl.liftWith (m:=m) f : OptionT m α)
       (wp (f (fun x => x.run)) post epost.tail) post epost :=
-  Triple.iff.mpr (WPMonad.le_wp_liftWith_OptionT_apply f)
+  Triple.intro (WPMonad.le_wp_liftWith_OptionT_apply f)
 
 
 @[spec]
 theorem Spec.restoreM_StateT (x : m (α × σ)) (post : α → σ → Pred) :
     Triple (MonadControl.restoreM (m:=m) x : StateT σ m α)
       (fun _ => wp x (fun (a, s) => post a s) epost) post epost :=
-  Triple.iff.mpr (WPMonad.le_wp_restoreM_StateT_apply x)
+  Triple.intro (WPMonad.le_wp_restoreM_StateT_apply x)
 
 
 @[spec]
 theorem Spec.restoreM_ReaderT (x : m α) (post : α → ρ → Pred) :
     Triple (MonadControl.restoreM (m:=m) x : ReaderT ρ m α)
       (fun r => wp x (fun a => post a r) epost) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_restoreM_ReaderT_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_restoreM_ReaderT_apply_eq]; rfl)
 
 
 @[spec]
 theorem Spec.restoreM_ExceptT (x : m (@Except.{u, u} ε α)) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (MonadControl.restoreM (m:=m) x : ExceptT ε m α)
       (wp x (epost.pushExcept post) epost.tail) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_restoreM_ExceptT_apply_eq])
+  Triple.intro (by rw [WPMonad.wp_restoreM_ExceptT_apply_eq])
 
 
 @[spec]
 theorem Spec.restoreM_OptionT (x : m (Option α)) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (MonadControl.restoreM (m:=m) x : OptionT m α)
       (wp x (epost.pushOption post) epost.tail) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_restoreM_OptionT_apply_eq])
+  Triple.intro (by rw [WPMonad.wp_restoreM_OptionT_apply_eq])
 
 /-! # `MonadControlT` -/
 
@@ -227,14 +230,14 @@ theorem Spec.liftWith_refl
     (f : (∀{β}, m β → m β) → m α) :
     Triple (MonadControlT.liftWith (m:=m) f : m α)
       (wp (f (fun x => x) : m α) post epost) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_liftWith_refl_apply_eq])
+  Triple.intro (by rw [WPMonad.wp_liftWith_refl_apply_eq])
 
 
 
 theorem Spec.restoreM_refl (x : stM m m α) :
     Triple (MonadControlT.restoreM (m:=m) x : m α)
       (wp (Pure.pure x : m α) post epost) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_restoreM_refl_apply_eq])
+  Triple.intro (by rw [WPMonad.wp_restoreM_refl_apply_eq])
 
 /-! # `ReaderT` -/
 
@@ -243,19 +246,19 @@ theorem Spec.restoreM_refl (x : stM m m α) :
 theorem Spec.read_ReaderT (post : ρ → ρ → Pred) :
     Triple (MonadReaderOf.read : ReaderT ρ m ρ)
       (fun r => post r r) post epost :=
-  Triple.iff.mpr (by intro r; simpa [MonadReaderOf.read] using
+  Triple.intro (by intro r; simpa [MonadReaderOf.read] using
     (WPMonad.wp_pure (m := m) (x := r) (post := fun a => post a r) (epost := epost)))
 
 theorem Spec.withReader_ReaderT (f : ρ → ρ) (x : ReaderT ρ m α) (post : α → ρ → Pred) :
     Triple (MonadWithReaderOf.withReader f x : ReaderT ρ m α)
       (fun r => wp x (fun a _ => post a r) epost (f r)) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_withReader_ReaderT_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_withReader_ReaderT_apply_eq]; rfl)
 
 
 theorem Spec.adapt_ReaderT (f : ρ → ρ') (x : ReaderT ρ' m α) (post : α → ρ → Pred) :
     Triple (ReaderT.adapt f x : ReaderT ρ m α)
       (fun r => wp x (fun a _ => post a r) epost (f r)) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_adapt_ReaderT_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_adapt_ReaderT_apply_eq]; rfl)
 
 /-! # `StateT` -/
 
@@ -264,7 +267,7 @@ theorem Spec.adapt_ReaderT (f : ρ → ρ') (x : ReaderT ρ' m α) (post : α �
 theorem Spec.get_StateT (post : σ → σ → Pred) :
     Triple (MonadStateOf.get : StateT σ m σ)
       (fun s => post s s) post epost :=
-  Triple.iff.mpr (by intro s; simpa [get_StateT] using!
+  Triple.intro (by intro s; simpa [get_StateT] using!
     (WPMonad.wp_pure (m := m) (x := (s, s))
       (post := fun x => post x.fst x.snd) (epost := epost)))
 
@@ -273,7 +276,7 @@ theorem Spec.get_StateT (post : σ → σ → Pred) :
 theorem Spec.set_StateT (s : σ) (post : PUnit → σ → Pred) :
     Triple (set s : StateT σ m PUnit)
       (fun _ => post ⟨⟩ s) post epost :=
-  Triple.iff.mpr (by intro _; simpa [MonadStateOf.set] using!
+  Triple.intro (by intro _; simpa [MonadStateOf.set] using!
     (WPMonad.wp_pure (m := m) (x := (PUnit.unit, s))
       (post := fun x => post x.fst x.snd) (epost := epost)))
 
@@ -282,7 +285,7 @@ theorem Spec.set_StateT (s : σ) (post : PUnit → σ → Pred) :
 theorem Spec.modifyGet_StateT (f : σ → α × σ) (post : α → σ → Pred) :
     Triple (MonadStateOf.modifyGet f : StateT σ m α)
       (fun s => post (f s).1 (f s).2) post epost :=
-  Triple.iff.mpr (by intro s; simpa [MonadStateOf.modifyGet] using!
+  Triple.intro (by intro s; simpa [MonadStateOf.modifyGet] using!
     (WPMonad.wp_pure (m := m) (x := f s)
       (post := fun x => post x.fst x.snd) (epost := epost)))
 
@@ -319,37 +322,37 @@ theorem Spec.run_ExceptT (x : ExceptT ε m α) (post : α → Pred) (epost : EPo
       (wp x post epost)
       (epost.pushExcept post)
       epost.tail :=
-  Triple.iff.mpr (by simp [PartialOrder.rel_refl])
+  Triple.intro (by simp [PartialOrder.rel_refl])
 
 
 @[spec]
 theorem Spec.throw_ExceptT (err : ε) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (MonadExceptOf.throw err : ExceptT ε m α) (epost.head err) post epost :=
-  Triple.iff.mpr (by simpa [EPost.Cons.pushExcept] using!
+  Triple.intro (by simpa [EPost.Cons.pushExcept] using!
     (WPMonad.wp_pure (m := m) (x := Except.error err)
       (post := epost.pushExcept post)
       (epost := epost.tail)))
 
 
 @[spec]
-theorem Spec.tryCatch_ExceptT (x : ExceptT ε m α) (h : ε → ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
+theorem Spec.tryCatch_ExceptT [LawfulMonad m] (x : ExceptT ε m α) (h : ε → ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (MonadExceptOf.tryCatch x h : ExceptT ε m α)
       (wp x post ⟨fun e => wp (h e) post epost, epost.tail⟩) post epost :=
-  Triple.iff.mpr (WPMonad.le_wp_tryCatch_ExceptT_apply x h)
+  Triple.intro (WPMonad.le_wp_tryCatch_ExceptT_apply x h)
 
 
 @[spec]
-theorem Spec.orElse_ExceptT (x : ExceptT ε m α) (h : Unit → ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
+theorem Spec.orElse_ExceptT [LawfulMonad m] (x : ExceptT ε m α) (h : Unit → ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (OrElse.orElse x h : ExceptT ε m α)
       (wp x post ⟨fun _ => wp (h ()) post epost, epost.tail⟩) post epost :=
-  Triple.iff.mpr (WPMonad.le_wp_orElse_ExceptT_apply x h)
+  Triple.intro (WPMonad.le_wp_orElse_ExceptT_apply x h)
 
 
 @[spec]
-theorem Spec.adapt_ExceptT (f : ε → ε') (x : ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε' → Pred) EPred) :
+theorem Spec.adapt_ExceptT [LawfulMonad m] (f : ε → ε') (x : ExceptT ε m α) (post : α → Pred) (epost : EPost.Cons (ε' → Pred) EPred) :
     Triple (ExceptT.adapt f x : ExceptT ε' m α)
       (wp x post ⟨fun e => epost.head (f e), epost.tail⟩) post epost :=
-  Triple.iff.mpr (WPMonad.le_wp_adapt_ExceptT_apply f x)
+  Triple.intro (WPMonad.le_wp_adapt_ExceptT_apply f x)
 
 /-! # `Except` -/
 
@@ -357,21 +360,21 @@ theorem Spec.adapt_ExceptT (f : ε → ε') (x : ExceptT ε m α) (post : α →
 @[spec]
 theorem Spec.throw_Except (err : ε) :
     Triple (MonadExceptOf.throw err : Except ε α) (epost.head err) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_throw_Except_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_throw_Except_apply_eq]; rfl)
 
 
 @[spec]
 theorem Spec.tryCatch_Except (x : Except ε α) (h : ε → Except ε α) :
     Triple (MonadExceptOf.tryCatch x h : Except ε α)
       (wp x post epost⟨fun e => wp (h e) post epost⟩) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_tryCatch_Except_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_tryCatch_Except_apply_eq]; rfl)
 
 
 @[spec]
 theorem Spec.orElse_Except (x : Except ε α) (h : Unit → Except ε α) :
     Triple (OrElse.orElse x h : Except ε α)
       (wp x post epost⟨fun (_ : ε) => wp (h ()) post epost⟩) post epost :=
-  Triple.iff.mpr (by simp only [wp, WPMonad.wpTrans, OrElse.orElse, MonadExcept.orElse]; cases x <;> rfl)
+  Triple.intro (by simp only [wp, WP.wpTrans, OrElse.orElse, MonadExcept.orElse]; cases x <;> rfl)
 
 /-! # `OptionT` -/
 
@@ -382,27 +385,27 @@ theorem Spec.run_OptionT (x : OptionT m α) (post : α → Pred) (epost : EPost.
       (wp x post epost)
       (epost.pushOption post)
       epost.tail :=
-  Triple.iff.mpr (by rw [← OptionT.wp_apply_eq])
+  Triple.intro (by rw [← OptionT.wp_apply_eq])
 
 
 @[spec]
 theorem Spec.throw_OptionT (err : PUnit) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (MonadExceptOf.throw err : OptionT m α) epost.head post epost :=
-  Triple.iff.mpr (WPMonad.le_wp_throw_OptionT_apply err)
+  Triple.intro (WPMonad.le_wp_throw_OptionT_apply err)
 
 
 @[spec]
 theorem Spec.tryCatch_OptionT (x : OptionT m α) (h : PUnit → OptionT m α) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (MonadExceptOf.tryCatch x h : OptionT m α)
       (wp x post ⟨wp (h ⟨⟩) post epost, epost.tail⟩) post epost :=
-  Triple.iff.mpr (WPMonad.le_wp_tryCatch_OptionT_apply x h)
+  Triple.intro (WPMonad.le_wp_tryCatch_OptionT_apply x h)
 
 
 @[spec]
 theorem Spec.orElse_OptionT (x : OptionT m α) (h : Unit → OptionT m α) (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     Triple (OrElse.orElse x h : OptionT m α)
       (wp x post ⟨wp (h ()) post epost, epost.tail⟩) post epost :=
-  Triple.iff.mpr (WPMonad.le_wp_orElse_OptionT_apply x h)
+  Triple.intro (WPMonad.le_wp_orElse_OptionT_apply x h)
 
 /-! # `Option` -/
 
@@ -410,21 +413,21 @@ theorem Spec.orElse_OptionT (x : OptionT m α) (h : Unit → OptionT m α) (post
 @[spec]
 theorem Spec.throw_Option (err : PUnit) :
     Triple (MonadExceptOf.throw err : Option α) epost post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_throw_Option_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_throw_Option_apply_eq]; rfl)
 
 
 @[spec]
 theorem Spec.tryCatch_Option (x : Option α) (h : PUnit → Option α) :
     Triple (MonadExceptOf.tryCatch x h : Option α)
       (wp x post (wp (h ⟨⟩) post epost)) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_tryCatch_Option_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_tryCatch_Option_apply_eq]; rfl)
 
 
 @[spec]
 theorem Spec.orElse_Option (x : Option α) (h : Unit → Option α) (post : α → Prop) (epost : Prop) :
     Triple (OrElse.orElse x h : Option α)
       (wp x post (wp (h ()) post epost)) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_orElse_Option_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_orElse_Option_apply_eq]; rfl)
 
 /-! # `EStateM` -/
 
@@ -433,27 +436,27 @@ theorem Spec.orElse_Option (x : Option α) (h : Unit → Option α) (post : α �
 theorem Spec.get_EStateM (post : σ → σ → Prop) (epost : ε → σ → Prop) :
     Triple (MonadStateOf.get : EStateM ε σ σ)
       (fun s => post s s) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_get_EStateM_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_get_EStateM_apply_eq]; rfl)
 
 
 @[spec]
 theorem Spec.set_EStateM (s : σ) (post : PUnit → σ → Prop) (epost : ε → σ → Prop) :
     Triple (MonadStateOf.set s : EStateM ε σ PUnit)
       (fun _ => post ⟨⟩ s) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_set_EStateM_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_set_EStateM_apply_eq]; rfl)
 
 
 @[spec]
 theorem Spec.modifyGet_EStateM (f : σ → α × σ) (post : α → σ → Prop) (epost : ε → σ → Prop) :
     Triple (MonadStateOf.modifyGet f : EStateM ε σ α)
       (fun s => post (f s).1 (f s).2) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_modifyGet_EStateM_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_modifyGet_EStateM_apply_eq]; rfl)
 
 
 @[spec]
 theorem Spec.throw_EStateM (err : ε) (post : α → σ → Prop) (epost : ε → σ → Prop) :
     Triple (MonadExceptOf.throw err : EStateM ε σ α) (epost err) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_throw_EStateM_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_throw_EStateM_apply_eq]; rfl)
 
 
 @[spec]
@@ -461,21 +464,21 @@ theorem Spec.tryCatch_EStateM (x : EStateM ε σ α) (h : ε → EStateM ε σ �
     (post : α → σ → Prop) (epost : ε → σ → Prop) :
     Triple (MonadExceptOf.tryCatch x h : EStateM ε σ α)
       (fun s => wp x post (fun e s' => wp (h e) post epost s') s) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_tryCatch_EStateM_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_tryCatch_EStateM_apply_eq]; rfl)
 
 
 theorem Spec.orElse_EStateM (x : EStateM ε σ α) (h : Unit → EStateM ε σ α)
     (post : α → σ → Prop) (epost : ε → σ → Prop) :
     Triple (OrElse.orElse x h : EStateM ε σ α)
       (fun s => wp x post (fun _ s' => wp (h ()) post epost s') s) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_orElse_EStateM_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_orElse_EStateM_apply_eq]; rfl)
 
 
 theorem Spec.adaptExcept_EStateM (f : ε → ε') (x : EStateM ε σ α)
     (post : α → σ → Prop) (epost : ε' → σ → Prop) :
     Triple (EStateM.adaptExcept f x : EStateM ε' σ α)
       (wp x post (fun e => epost (f e))) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_adaptExcept_EStateM_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_adaptExcept_EStateM_apply_eq]; rfl)
 
 /-! # Lifting `MonadExceptOf` -/
 
@@ -485,28 +488,28 @@ theorem Spec.adaptExcept_EStateM (f : ε → ε') (x : EStateM ε σ α)
 theorem Spec.throw_MonadExcept [MonadExceptOf ε m] (err : ε) :
     Triple (throw err : m α)
       (wp (MonadExceptOf.throw err : m α) post epost) post epost :=
-  Triple.iff.mpr (by simp [throw, PartialOrder.rel_refl])
+  Triple.intro (by simp [throw, PartialOrder.rel_refl])
 
 
 
 theorem Spec.tryCatch_MonadExcept [MonadExceptOf ε m] (x : m α) (h : ε → m α) :
     Triple (tryCatch x h : m α)
       (wp (MonadExceptOf.tryCatch x h : m α) post epost) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_tryCatch_MonadExcept_apply_eq])
+  Triple.intro (by rw [WPMonad.wp_tryCatch_MonadExcept_apply_eq])
 
 
 @[spec]
 theorem Spec.throw_ReaderT [MonadExceptOf ε m] (err : ε) (post : α → ρ → Pred) :
     Triple (MonadExceptOf.throw (ε:=ε) err : ReaderT ρ m α)
       (wp (MonadLift.monadLift (MonadExceptOf.throw (ε:=ε) err : m α) : ReaderT ρ m α) post epost) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_throw_ReaderT_lift_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_throw_ReaderT_lift_apply_eq]; rfl)
 
 
 @[spec]
 theorem Spec.throw_StateT [MonadExceptOf ε m] (err : ε) (post : α → σ → Pred) :
     Triple (MonadExceptOf.throw (ε:=ε) err : StateT σ m α)
       (wp (MonadLift.monadLift (MonadExceptOf.throw (ε:=ε) err : m α) : StateT σ m α) post epost) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_throw_StateT_lift_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_throw_StateT_lift_apply_eq]; rfl)
 
 
 @[spec]
@@ -514,7 +517,7 @@ theorem Spec.throw_ExceptT_lift [MonadExceptOf ε m] (err : ε) (post : α → P
     Triple (MonadExceptOf.throw (ε:=ε) err : ExceptT ε' m α)
       (wp (MonadExceptOf.throw (ε:=ε) err : m (@Except.{u, u} ε' α))
         (fun r => match r with | .ok a => post a | .error e => epost.head e) epost.tail) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_throw_lift_ExceptT_apply_eq]; apply WPMonad.wp_consequence; intro r; cases r <;> rfl)
+  Triple.intro (by rw [WPMonad.wp_throw_lift_ExceptT_apply_eq]; apply WP.wp_consequence; intro r; cases r <;> rfl)
 
 
 @[spec]
@@ -522,7 +525,7 @@ theorem Spec.throw_Option_lift [MonadExceptOf ε m] (err : ε) (post : α → Pr
     Triple (MonadExceptOf.throw (ε:=ε) err : OptionT m α)
       (wp (MonadExceptOf.throw (ε:=ε) err : m (Option α))
         (epost.pushOption post) epost.tail) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_throw_lift_OptionT_apply_eq])
+  Triple.intro (by rw [WPMonad.wp_throw_lift_OptionT_apply_eq])
 
 
 @[spec]
@@ -531,7 +534,7 @@ theorem Spec.tryCatch_ReaderT [MonadExceptOf ε m] (x : ReaderT ρ m α) (h : ε
     Triple (MonadExceptOf.tryCatch (ε:=ε) x h : ReaderT ρ m α)
       (fun r => wp (MonadExceptOf.tryCatch (ε:=ε) (x.run r) (fun e => (h e).run r) : m α)
         (fun a => post a r) epost) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_tryCatch_ReaderT_lift_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_tryCatch_ReaderT_lift_apply_eq]; rfl)
 
 
 @[spec]
@@ -540,7 +543,7 @@ theorem Spec.tryCatch_StateT [MonadExceptOf ε m] (x : StateT σ m α) (h : ε �
     Triple (MonadExceptOf.tryCatch (ε:=ε) x h : StateT σ m α)
       (fun s => wp (MonadExceptOf.tryCatch (ε:=ε) (x.run s) (fun e => (h e).run s) : m (α × σ))
         (fun (a, s') => post a s') epost) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_tryCatch_StateT_lift_apply_eq]; rfl)
+  Triple.intro (by rw [WPMonad.wp_tryCatch_StateT_lift_apply_eq]; rfl)
 
 
 @[spec]
@@ -549,7 +552,7 @@ theorem Spec.tryCatch_ExceptT_lift [MonadExceptOf ε m] (x : ExceptT ε' m α) (
     Triple (MonadExceptOf.tryCatch (ε:=ε) x h : ExceptT ε' m α)
       (wp (MonadExceptOf.tryCatch (ε:=ε) x h : m (@Except.{u, u} ε' α))
         (fun | .ok a => post a | .error e => epost.head e) epost.tail) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_tryCatch_lift_ExceptT_apply_eq]; apply WPMonad.wp_consequence; intro r; cases r <;> rfl)
+  Triple.intro (by rw [WPMonad.wp_tryCatch_lift_ExceptT_apply_eq]; apply WP.wp_consequence; intro r; cases r <;> rfl)
 
 
 @[spec]
@@ -558,7 +561,7 @@ theorem Spec.tryCatch_OptionT_lift [MonadExceptOf ε m] (x : OptionT m α) (h : 
     Triple (MonadExceptOf.tryCatch (ε:=ε) x h : OptionT m α)
       (wp (MonadExceptOf.tryCatch (ε:=ε) x h : m (Option α))
         (epost.pushOption post) epost.tail) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_tryCatch_lift_OptionT_apply_eq])
+  Triple.intro (by rw [WPMonad.wp_tryCatch_lift_OptionT_apply_eq])
 
 -- /-! # `MonadFunctorT` / `MonadControlT` transitivity -/
 
@@ -572,7 +575,7 @@ theorem Spec.monadMap_trans
     (x : m α) :
     Triple (MonadFunctorT.monadMap (m:=n₂) f x : m α)
       (wp (MonadFunctor.monadMap (m:=n₁) (MonadFunctorT.monadMap (m:=n₂) f) x : m α) post epost) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_monadMap_trans_apply_eq])
+  Triple.intro (by rw [WPMonad.wp_monadMap_trans_apply_eq])
 
 
 
@@ -583,7 +586,7 @@ theorem Spec.liftWith_trans
     (f : (∀{β}, m β → n₂ (stM n₂ m β)) → n₂ α) :
     Triple (MonadControlT.liftWith (m:=n₂) f : m α)
       (wp (MonadControl.liftWith (m:=n₁) fun x₂ => MonadControlT.liftWith fun x₁ => f (x₁ ∘ x₂) : m α) post epost) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_liftWith_trans_apply_eq])
+  Triple.intro (by rw [WPMonad.wp_liftWith_trans_apply_eq])
 
 
 @[spec]
@@ -593,7 +596,7 @@ theorem Spec.restoreM_trans
     (x : stM n₂ m α) :
     Triple (MonadControlT.restoreM (m:=n₂) x : m α)
       (wp (MonadControl.restoreM (m:=n₁) (MonadControlT.restoreM (m:=n₂) x) : m α) post epost) post epost :=
-  Triple.iff.mpr (by rw [WPMonad.wp_restoreM_trans_apply_eq])
+  Triple.intro (by rw [WPMonad.wp_restoreM_trans_apply_eq])
 
 end Std.Internal.Do
 
@@ -1397,7 +1400,7 @@ theorem Spec.foldM_iterM_id {α β γ : Type u} {m : Type u → Type w} {Pred : 
 theorem Spec.IterM.forIn_filterMapWithPostcondition {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
     [IteratorLoop α m o] [LawfulIteratorLoop α m o]
@@ -1417,7 +1420,7 @@ theorem Spec.IterM.forIn_filterMapWithPostcondition {α β β₂ γ : Type w}
 theorem Spec.IterM.forIn_filterMapM {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
@@ -1438,7 +1441,7 @@ theorem Spec.IterM.forIn_filterMapM {α β β₂ γ : Type w}
 theorem Spec.IterM.forIn_filterMap {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
@@ -1456,7 +1459,7 @@ theorem Spec.IterM.forIn_filterMap {α β β₂ γ : Type w}
 theorem Spec.IterM.forIn_mapWithPostcondition {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
     [IteratorLoop α m o] [LawfulIteratorLoop α m o]
@@ -1473,7 +1476,7 @@ theorem Spec.IterM.forIn_mapWithPostcondition {α β β₂ γ : Type w}
 theorem Spec.IterM.forIn_mapM {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
@@ -1491,7 +1494,7 @@ theorem Spec.IterM.forIn_mapM {α β β₂ γ : Type w}
 theorem Spec.IterM.forIn_map {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     {it : IterM (α := α) m β} {f : β → β₂} {init : γ} {g : β₂ → γ → n (ForInStep γ)}
@@ -1505,7 +1508,7 @@ theorem Spec.IterM.forIn_map {α β β₂ γ : Type w}
 theorem Spec.IterM.forIn_filterWithPostcondition {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
     [IteratorLoop α m o] [LawfulIteratorLoop α m o]
@@ -1522,7 +1525,7 @@ theorem Spec.IterM.forIn_filterWithPostcondition {α β γ : Type w}
 theorem Spec.IterM.forIn_filterM {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
@@ -1540,7 +1543,7 @@ theorem Spec.IterM.forIn_filterM {α β γ : Type w}
 theorem Spec.IterM.forIn_filter {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     {it : IterM (α := α) m β} {f : β → Bool} {init : γ} {g : β → γ → n (ForInStep γ)}
@@ -1555,7 +1558,7 @@ theorem Spec.IterM.foldM_filterMapWithPostcondition {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
-    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -1577,7 +1580,7 @@ theorem Spec.IterM.foldM_filterMapM {α β γ δ : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
-    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -1597,7 +1600,7 @@ theorem Spec.IterM.foldM_mapWithPostcondition {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
-    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -1617,7 +1620,7 @@ theorem Spec.IterM.foldM_mapM {α β γ δ : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
-    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -1635,7 +1638,7 @@ theorem Spec.IterM.foldM_filterWithPostcondition {α β δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
-    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -1655,7 +1658,7 @@ theorem Spec.IterM.foldM_filterM {α β δ : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
-    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -1672,7 +1675,7 @@ theorem Spec.IterM.foldM_filterM {α β δ : Type w}
 theorem Spec.IterM.foldM_filterMap {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n]
     [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
@@ -1689,7 +1692,7 @@ theorem Spec.IterM.foldM_filterMap {α β γ δ : Type w}
 theorem Spec.IterM.foldM_map {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → γ} {g : δ → γ → n δ} {init : δ} {it : IterM (α := α) m β}
@@ -1703,7 +1706,7 @@ theorem Spec.IterM.foldM_map {α β γ δ : Type w}
 theorem Spec.IterM.foldM_filter {α β δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n]
     [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
@@ -1720,7 +1723,7 @@ theorem Spec.IterM.fold_filterMapWithPostcondition {α β γ δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → PostconditionT n (Option γ)} {g : δ → γ → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1738,7 +1741,7 @@ theorem Spec.IterM.fold_filterMapM {α β γ δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
-    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → n (Option γ)} {g : δ → γ → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1756,7 +1759,7 @@ theorem Spec.IterM.fold_mapWithPostcondition {α β γ δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → PostconditionT n γ} {g : δ → γ → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1772,7 +1775,7 @@ theorem Spec.IterM.fold_mapM {α β γ δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
-    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → n γ} {g : δ → γ → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1788,7 +1791,7 @@ theorem Spec.IterM.fold_filterWithPostcondition {α β δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → PostconditionT n (ULift Bool)} {g : δ → β → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1804,7 +1807,7 @@ theorem Spec.IterM.fold_filterM {α β δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
-    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → n (ULift Bool)} {g : δ → β → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1861,7 +1864,7 @@ theorem Spec.Iter.forIn_filterMapWithPostcondition {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [MonadLiftT n o] [LawfulMonadLiftT n o] [Finite α Id]
     [IteratorLoop α Id o] [LawfulIteratorLoop α Id o]
     {it : Iter (α := α) β} {f : β → PostconditionT n (Option β₂)} {init : γ}
@@ -1879,7 +1882,7 @@ theorem Spec.Iter.forIn_filterMapM {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Finite α Id] [IteratorLoop α Id o] [LawfulIteratorLoop α Id o]
@@ -1898,7 +1901,7 @@ theorem Spec.Iter.forIn_filterMap {α β β₂ γ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred] [Finite α Id]
+    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred] [Finite α Id]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {it : Iter (α := α) β} {f : β → Option β₂} {init : γ} {g : β₂ → γ → n (ForInStep γ)}
     {P : Pred} {Q : γ → Pred} {eQ : EPred}
@@ -1915,7 +1918,7 @@ theorem Spec.Iter.forIn_mapWithPostcondition {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [MonadLiftT n o] [LawfulMonadLiftT n o] [Finite α Id]
     [IteratorLoop α Id o] [LawfulIteratorLoop α Id o]
     {it : Iter (α := α) β} {f : β → PostconditionT n β₂} {init : γ}
@@ -1930,7 +1933,7 @@ theorem Spec.Iter.forIn_mapM {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Finite α Id]
@@ -1947,7 +1950,7 @@ theorem Spec.Iter.forIn_map {α β β₂ γ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [Finite α Id] [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {it : Iter (α := α) β} {f : β → β₂} {init : γ} {g : β₂ → γ → n (ForInStep γ)}
     {P : Pred} {Q : γ → Pred} {eQ : EPred}
@@ -1961,7 +1964,7 @@ theorem Spec.Iter.forIn_filterWithPostcondition {α β γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Finite α Id] [IteratorLoop α Id o] [LawfulIteratorLoop α Id o]
     {it : Iter (α := α) β} {f : β → PostconditionT n (ULift Bool)} {init : γ}
@@ -1976,7 +1979,7 @@ theorem Spec.Iter.forIn_filterM {α β γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT n o] [LawfulMonadLiftT n o] [Finite α Id]
     [IteratorLoop α Id o] [LawfulIteratorLoop α Id o]
@@ -1992,7 +1995,7 @@ theorem Spec.Iter.forIn_filter {α β γ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [Finite α Id] [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {it : Iter (α := α) β} {f : β → Bool} {init : γ} {g : β → γ → n (ForInStep γ)}
     {P : Pred} {Q : γ → Pred} {eQ : EPred}
@@ -2006,7 +2009,7 @@ theorem Spec.Iter.foldM_filterMapWithPostcondition {α β γ δ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [Monad o] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad n] [Monad o] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
     [LawfulIteratorLoop α Id n] [LawfulIteratorLoop α Id o]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -2025,7 +2028,7 @@ theorem Spec.Iter.foldM_filterMapM {α β γ δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
-    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
     [LawfulIteratorLoop α Id n] [LawfulIteratorLoop α Id o]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -2043,7 +2046,7 @@ theorem Spec.Iter.foldM_mapWithPostcondition {α β γ δ : Type w}
     {m : Type w → Type w'''} {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
     [LawfulIteratorLoop α Id n] [LawfulIteratorLoop α Id o]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -2060,7 +2063,7 @@ theorem Spec.Iter.foldM_mapM {α β γ δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
-    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
     [LawfulIteratorLoop α Id n] [LawfulIteratorLoop α Id o]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -2076,7 +2079,7 @@ theorem Spec.Iter.foldM_filterWithPostcondition {α β δ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [Monad o] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad n] [Monad o] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
     [LawfulIteratorLoop α Id n] [LawfulIteratorLoop α Id o]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -2093,7 +2096,7 @@ theorem Spec.Iter.foldM_filterM {α β δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
-    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
     [LawfulIteratorLoop α Id n] [LawfulIteratorLoop α Id o]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -2108,7 +2111,7 @@ theorem Spec.Iter.foldM_filterM {α β δ : Type w}
 theorem Spec.Iter.foldM_filterMap {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α Id β] [Finite α Id] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Iterator α Id β] [Finite α Id] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n]
     [LawfulIteratorLoop α Id n]
     {f : β → Option γ} {g : δ → γ → n δ} {init : δ} {it : Iter (α := α) β}
@@ -2124,7 +2127,7 @@ theorem Spec.Iter.foldM_filterMap {α β γ δ : Type w}
 theorem Spec.Iter.foldM_map {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α Id β] [Finite α Id] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Iterator α Id β] [Finite α Id] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → γ} {g : δ → γ → n δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2137,7 +2140,7 @@ theorem Spec.Iter.foldM_map {α β γ δ : Type w}
 theorem Spec.Iter.foldM_filter {α β δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α Id β] [Finite α Id] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Iterator α Id β] [Finite α Id] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → Bool} {g : δ → β → n δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2151,7 +2154,7 @@ theorem Spec.Iter.fold_filterMapWithPostcondition {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → PostconditionT n (Option γ)} {g : δ → γ → δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2167,7 +2170,7 @@ theorem Spec.Iter.fold_filterMapM {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → n (Option γ)} {g : δ → γ → δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2183,7 +2186,7 @@ theorem Spec.Iter.fold_mapWithPostcondition {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → PostconditionT n γ} {g : δ → γ → δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2197,7 +2200,7 @@ theorem Spec.Iter.fold_mapM {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → n γ} {g : δ → γ → δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2211,7 +2214,7 @@ theorem Spec.Iter.fold_filterWithPostcondition {α β δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → PostconditionT n (ULift Bool)} {g : δ → β → δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2225,7 +2228,7 @@ theorem Spec.Iter.fold_filterM {α β δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → n (ULift Bool)} {g : δ → β → δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2316,7 +2319,7 @@ noncomputable abbrev StringInvariant.withEarlyReturnNewDo {s : String} {β : Typ
       ⊔ (iSup fun r => ⌜x = some r ∧ pos = s.endPos⌝ ⊓ onReturn r b)
 
 @[spec]
-theorem Spec.forIn_string
+theorem Spec.forIn_string [LawfulMonad m]
     {s : String} {init : β} {f : Char → β → m (ForInStep β)}
     (inv : StringInvariant s β Pred)
     {epost : EPred}
@@ -2373,7 +2376,7 @@ noncomputable abbrev StringSliceInvariant.withEarlyReturnNewDo {s : String.Slice
       ⊔ (iSup fun r => ⌜x = some r ∧ pos = s.endPos⌝ ⊓ onReturn r b)
 
 @[spec]
-theorem Spec.forIn_stringSlice
+theorem Spec.forIn_stringSlice [LawfulMonad m]
     {s : String.Slice} {init : β} {f : Char → β → m (ForInStep β)}
     (inv : StringSliceInvariant s β Pred)
     {epost : EPred}
@@ -2474,10 +2477,10 @@ theorem Spec.repeatM
         | .inr b => inv (.inr b))
       (step a) ?_
     rintro (a' | b)
-    · refine Triple.iff.mpr ?_
+    · refine Triple.intro ?_
       refine CompleteLattice.ofProp_meet_le_left ?_
       intro hlt
-      exact Triple.iff.mp (ih (measure a') (Nat.lt_of_lt_of_le hlt hle) a' (Nat.le_refl _))
+      exact (ih (measure a') (Nat.lt_of_lt_of_le hlt hle) a' (Nat.le_refl _)).le_wp
     · exact Triple.pure b Lean.Order.PartialOrder.rel_refl
 
 /--

--- a/src/Std/Internal/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Internal/Do/Triple/SpecLemmas.lean
@@ -1400,7 +1400,7 @@ theorem Spec.foldM_iterM_id {α β γ : Type u} {m : Type u → Type w} {Pred : 
 theorem Spec.IterM.forIn_filterMapWithPostcondition {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
     [IteratorLoop α m o] [LawfulIteratorLoop α m o]
@@ -1420,7 +1420,7 @@ theorem Spec.IterM.forIn_filterMapWithPostcondition {α β β₂ γ : Type w}
 theorem Spec.IterM.forIn_filterMapM {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
@@ -1441,7 +1441,7 @@ theorem Spec.IterM.forIn_filterMapM {α β β₂ γ : Type w}
 theorem Spec.IterM.forIn_filterMap {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
@@ -1459,7 +1459,7 @@ theorem Spec.IterM.forIn_filterMap {α β β₂ γ : Type w}
 theorem Spec.IterM.forIn_mapWithPostcondition {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
     [IteratorLoop α m o] [LawfulIteratorLoop α m o]
@@ -1476,7 +1476,7 @@ theorem Spec.IterM.forIn_mapWithPostcondition {α β β₂ γ : Type w}
 theorem Spec.IterM.forIn_mapM {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
@@ -1494,7 +1494,7 @@ theorem Spec.IterM.forIn_mapM {α β β₂ γ : Type w}
 theorem Spec.IterM.forIn_map {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     {it : IterM (α := α) m β} {f : β → β₂} {init : γ} {g : β₂ → γ → n (ForInStep γ)}
@@ -1508,7 +1508,7 @@ theorem Spec.IterM.forIn_map {α β β₂ γ : Type w}
 theorem Spec.IterM.forIn_filterWithPostcondition {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
     [IteratorLoop α m o] [LawfulIteratorLoop α m o]
@@ -1525,7 +1525,7 @@ theorem Spec.IterM.forIn_filterWithPostcondition {α β γ : Type w}
 theorem Spec.IterM.forIn_filterM {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
@@ -1543,7 +1543,7 @@ theorem Spec.IterM.forIn_filterM {α β γ : Type w}
 theorem Spec.IterM.forIn_filter {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
-    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     {it : IterM (α := α) m β} {f : β → Bool} {init : γ} {g : β → γ → n (ForInStep γ)}
@@ -1558,7 +1558,7 @@ theorem Spec.IterM.foldM_filterMapWithPostcondition {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
-    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -1580,7 +1580,7 @@ theorem Spec.IterM.foldM_filterMapM {α β γ δ : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
-    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -1600,7 +1600,7 @@ theorem Spec.IterM.foldM_mapWithPostcondition {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
-    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -1620,7 +1620,7 @@ theorem Spec.IterM.foldM_mapM {α β γ δ : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
-    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -1638,7 +1638,7 @@ theorem Spec.IterM.foldM_filterWithPostcondition {α β δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
-    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -1658,7 +1658,7 @@ theorem Spec.IterM.foldM_filterM {α β δ : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
-    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
     [LawfulIteratorLoop α m n] [LawfulIteratorLoop α m o]
     [MonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT m n] [LawfulMonadLiftT n o]
@@ -1675,7 +1675,7 @@ theorem Spec.IterM.foldM_filterM {α β δ : Type w}
 theorem Spec.IterM.foldM_filterMap {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n]
     [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
@@ -1692,7 +1692,7 @@ theorem Spec.IterM.foldM_filterMap {α β γ δ : Type w}
 theorem Spec.IterM.foldM_map {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → γ} {g : δ → γ → n δ} {init : δ} {it : IterM (α := α) m β}
@@ -1706,7 +1706,7 @@ theorem Spec.IterM.foldM_map {α β γ δ : Type w}
 theorem Spec.IterM.foldM_filter {α β δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n]
     [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
@@ -1723,7 +1723,7 @@ theorem Spec.IterM.fold_filterMapWithPostcondition {α β γ δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → PostconditionT n (Option γ)} {g : δ → γ → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1741,7 +1741,7 @@ theorem Spec.IterM.fold_filterMapM {α β γ δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
-    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → n (Option γ)} {g : δ → γ → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1759,7 +1759,7 @@ theorem Spec.IterM.fold_mapWithPostcondition {α β γ δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → PostconditionT n γ} {g : δ → γ → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1775,7 +1775,7 @@ theorem Spec.IterM.fold_mapM {α β γ δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
-    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → n γ} {g : δ → γ → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1791,7 +1791,7 @@ theorem Spec.IterM.fold_filterWithPostcondition {α β δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → PostconditionT n (ULift Bool)} {g : δ → β → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1807,7 +1807,7 @@ theorem Spec.IterM.fold_filterM {α β δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
-    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     {f : β → n (ULift Bool)} {g : δ → β → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1864,7 +1864,7 @@ theorem Spec.Iter.forIn_filterMapWithPostcondition {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadLiftT n o] [LawfulMonadLiftT n o] [Finite α Id]
     [IteratorLoop α Id o] [LawfulIteratorLoop α Id o]
     {it : Iter (α := α) β} {f : β → PostconditionT n (Option β₂)} {init : γ}
@@ -1882,7 +1882,7 @@ theorem Spec.Iter.forIn_filterMapM {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Finite α Id] [IteratorLoop α Id o] [LawfulIteratorLoop α Id o]
@@ -1901,7 +1901,7 @@ theorem Spec.Iter.forIn_filterMap {α β β₂ γ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred] [Finite α Id]
+    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred] [Finite α Id]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {it : Iter (α := α) β} {f : β → Option β₂} {init : γ} {g : β₂ → γ → n (ForInStep γ)}
     {P : Pred} {Q : γ → Pred} {eQ : EPred}
@@ -1918,7 +1918,7 @@ theorem Spec.Iter.forIn_mapWithPostcondition {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadLiftT n o] [LawfulMonadLiftT n o] [Finite α Id]
     [IteratorLoop α Id o] [LawfulIteratorLoop α Id o]
     {it : Iter (α := α) β} {f : β → PostconditionT n β₂} {init : γ}
@@ -1933,7 +1933,7 @@ theorem Spec.Iter.forIn_mapM {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Finite α Id]
@@ -1950,7 +1950,7 @@ theorem Spec.Iter.forIn_map {α β β₂ γ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [Finite α Id] [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {it : Iter (α := α) β} {f : β → β₂} {init : γ} {g : β₂ → γ → n (ForInStep γ)}
     {P : Pred} {Q : γ → Pred} {eQ : EPred}
@@ -1964,7 +1964,7 @@ theorem Spec.Iter.forIn_filterWithPostcondition {α β γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Finite α Id] [IteratorLoop α Id o] [LawfulIteratorLoop α Id o]
     {it : Iter (α := α) β} {f : β → PostconditionT n (ULift Bool)} {init : γ}
@@ -1979,7 +1979,7 @@ theorem Spec.Iter.forIn_filterM {α β γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad n] [LawfulMonad n] [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT n o] [LawfulMonadLiftT n o] [Finite α Id]
     [IteratorLoop α Id o] [LawfulIteratorLoop α Id o]
@@ -1995,7 +1995,7 @@ theorem Spec.Iter.forIn_filter {α β γ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [Finite α Id] [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {it : Iter (α := α) β} {f : β → Bool} {init : γ} {g : β → γ → n (ForInStep γ)}
     {P : Pred} {Q : γ → Pred} {eQ : EPred}
@@ -2009,7 +2009,7 @@ theorem Spec.Iter.foldM_filterMapWithPostcondition {α β γ δ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [Monad o] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad n] [Monad o] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
     [LawfulIteratorLoop α Id n] [LawfulIteratorLoop α Id o]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -2028,7 +2028,7 @@ theorem Spec.Iter.foldM_filterMapM {α β γ δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
-    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
     [LawfulIteratorLoop α Id n] [LawfulIteratorLoop α Id o]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -2046,7 +2046,7 @@ theorem Spec.Iter.foldM_mapWithPostcondition {α β γ δ : Type w}
     {m : Type w → Type w'''} {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
     [LawfulIteratorLoop α Id n] [LawfulIteratorLoop α Id o]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -2063,7 +2063,7 @@ theorem Spec.Iter.foldM_mapM {α β γ δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
-    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
     [LawfulIteratorLoop α Id n] [LawfulIteratorLoop α Id o]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -2079,7 +2079,7 @@ theorem Spec.Iter.foldM_filterWithPostcondition {α β δ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [Monad o] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad n] [Monad o] [LawfulMonad n] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
     [LawfulIteratorLoop α Id n] [LawfulIteratorLoop α Id o]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -2096,7 +2096,7 @@ theorem Spec.Iter.foldM_filterM {α β δ : Type w}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
-    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred] [WPMonad o Pred EPred]
+    [Monad o] [LawfulMonad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
     [LawfulIteratorLoop α Id n] [LawfulIteratorLoop α Id o]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -2111,7 +2111,7 @@ theorem Spec.Iter.foldM_filterM {α β δ : Type w}
 theorem Spec.Iter.foldM_filterMap {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α Id β] [Finite α Id] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Iterator α Id β] [Finite α Id] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n]
     [LawfulIteratorLoop α Id n]
     {f : β → Option γ} {g : δ → γ → n δ} {init : δ} {it : Iter (α := α) β}
@@ -2127,7 +2127,7 @@ theorem Spec.Iter.foldM_filterMap {α β γ δ : Type w}
 theorem Spec.Iter.foldM_map {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α Id β] [Finite α Id] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Iterator α Id β] [Finite α Id] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → γ} {g : δ → γ → n δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2140,7 +2140,7 @@ theorem Spec.Iter.foldM_map {α β γ δ : Type w}
 theorem Spec.Iter.foldM_filter {α β δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
-    [Iterator α Id β] [Finite α Id] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Iterator α Id β] [Finite α Id] [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → Bool} {g : δ → β → n δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2154,7 +2154,7 @@ theorem Spec.Iter.fold_filterMapWithPostcondition {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → PostconditionT n (Option γ)} {g : δ → γ → δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2170,7 +2170,7 @@ theorem Spec.Iter.fold_filterMapM {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → n (Option γ)} {g : δ → γ → δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2186,7 +2186,7 @@ theorem Spec.Iter.fold_mapWithPostcondition {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → PostconditionT n γ} {g : δ → γ → δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2200,7 +2200,7 @@ theorem Spec.Iter.fold_mapM {α β γ δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → n γ} {g : δ → γ → δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2214,7 +2214,7 @@ theorem Spec.Iter.fold_filterWithPostcondition {α β δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Monad n] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → PostconditionT n (ULift Bool)} {g : δ → β → δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}
@@ -2228,7 +2228,7 @@ theorem Spec.Iter.fold_filterM {α β δ : Type w}
     {n : Type w → Type w'}
     {Pred : Type w} {EPred : Type w}
     [Iterator α Id β] [Finite α Id]
-    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [WPMonad n Pred EPred]
+    [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → n (ULift Bool)} {g : δ → β → δ} {init : δ} {it : Iter (α := α) β}
     {P : Pred} {Q : δ → Pred} {eQ : EPred}

--- a/src/Std/Internal/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Internal/Do/Triple/SpecLemmas.lean
@@ -31,8 +31,6 @@ import Init.Data.String.Termination
 import Init.Data.String.Lemmas.Iterate
 
 set_option linter.missingDocs true
--- The `WP`/`WPMonad` split means each lemma uses only the subset of the section variables it needs.
-set_option linter.unusedSectionVars false
 
 @[expose] public section
 

--- a/src/Std/Internal/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Internal/Do/Triple/SpecLemmas.lean
@@ -166,7 +166,7 @@ theorem Spec.liftWith_StateT
     (f : (∀{β}, StateT σ m β → m (β × σ)) → m α) (post : α → σ → Pred) :
     Triple (MonadControl.liftWith (m:=m) f : StateT σ m α)
       (fun s => wp (f (fun x => x.run s)) (fun a => post a s) epost) post epost :=
-  Triple.intro (by intro s; simp [WPMonad.wp_liftWith_StateT_apply_eq f]; apply WPMonad.wp_map'; ext; rfl)
+  Triple.intro (by intro s; simp [WPMonad.wp_liftWith_StateT_apply_eq f]; apply WPMonad.map_le_wp_map'; ext; rfl)
 
 
 @[spec]
@@ -182,7 +182,7 @@ theorem Spec.liftWith_ExceptT
     (f : (∀{β}, ExceptT ε m β → m (Except ε β)) → m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (MonadControl.liftWith (m:=m) f : ExceptT ε m α)
       (wp (f (fun x => x.run)) post epost.tail) post epost :=
-  Triple.intro (by simp [WPMonad.wp_liftWith_ExceptT_apply_eq f]; apply WPMonad.wp_map'; ext; rfl)
+  Triple.intro (by simp [WPMonad.wp_liftWith_ExceptT_apply_eq f]; apply WPMonad.map_le_wp_map'; ext; rfl)
 
 
 @[spec]
@@ -245,7 +245,7 @@ theorem Spec.read_ReaderT (post : ρ → ρ → Pred) :
     Triple (MonadReaderOf.read : ReaderT ρ m ρ)
       (fun r => post r r) post epost :=
   Triple.intro (by intro r; simpa [MonadReaderOf.read] using
-    (WPMonad.wp_pure (m := m) (x := r) (post := fun a => post a r) (epost := epost)))
+    (WPMonad.pure_le_wp_pure (m := m) (x := r) (post := fun a => post a r) (epost := epost)))
 
 theorem Spec.withReader_ReaderT (f : ρ → ρ) (x : ReaderT ρ m α) (post : α → ρ → Pred) :
     Triple (MonadWithReaderOf.withReader f x : ReaderT ρ m α)
@@ -266,7 +266,7 @@ theorem Spec.get_StateT (post : σ → σ → Pred) :
     Triple (MonadStateOf.get : StateT σ m σ)
       (fun s => post s s) post epost :=
   Triple.intro (by intro s; simpa [get_StateT] using!
-    (WPMonad.wp_pure (m := m) (x := (s, s))
+    (WPMonad.pure_le_wp_pure (m := m) (x := (s, s))
       (post := fun x => post x.fst x.snd) (epost := epost)))
 
 
@@ -275,7 +275,7 @@ theorem Spec.set_StateT (s : σ) (post : PUnit → σ → Pred) :
     Triple (set s : StateT σ m PUnit)
       (fun _ => post ⟨⟩ s) post epost :=
   Triple.intro (by intro _; simpa [MonadStateOf.set] using!
-    (WPMonad.wp_pure (m := m) (x := (PUnit.unit, s))
+    (WPMonad.pure_le_wp_pure (m := m) (x := (PUnit.unit, s))
       (post := fun x => post x.fst x.snd) (epost := epost)))
 
 
@@ -284,7 +284,7 @@ theorem Spec.modifyGet_StateT (f : σ → α × σ) (post : α → σ → Pred) 
     Triple (MonadStateOf.modifyGet f : StateT σ m α)
       (fun s => post (f s).1 (f s).2) post epost :=
   Triple.intro (by intro s; simpa [MonadStateOf.modifyGet] using!
-    (WPMonad.wp_pure (m := m) (x := f s)
+    (WPMonad.pure_le_wp_pure (m := m) (x := f s)
       (post := fun x => post x.fst x.snd) (epost := epost)))
 
 /-! # Lifting `MonadStateOf` -/
@@ -327,7 +327,7 @@ theorem Spec.run_ExceptT (x : ExceptT ε m α) (post : α → Pred) (epost : EPo
 theorem Spec.throw_ExceptT (err : ε) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (MonadExceptOf.throw err : ExceptT ε m α) (epost.head err) post epost :=
   Triple.intro (by simpa [EPost.Cons.pushExcept] using!
-    (WPMonad.wp_pure (m := m) (x := Except.error err)
+    (WPMonad.pure_le_wp_pure (m := m) (x := Except.error err)
       (post := epost.pushExcept post)
       (epost := epost.tail)))
 

--- a/src/Std/Internal/Do/WP/Basic.lean
+++ b/src/Std/Internal/Do/WP/Basic.lean
@@ -173,16 +173,8 @@ namespace WPMonad
 
 variable [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
 
-theorem wp_pure (x : α) (post : α → Pred) (epost : EPred) :
-    post x ⊑ wp (pure (f := m) x) post epost := pure_le_wp_pure x post epost
-
-theorem wp_bind (x : m α) (f : α → m β)
-  (post : β → Pred) (epost : EPred) :
-    wp x (fun x => wp (f x) post epost) epost ⊑ wp (x >>= f) post epost :=
-  bind_le_wp_bind x f post epost
-
 /-- Soundness of `Functor.map`: mapping `f` over `x` preserves the WP. -/
-theorem wp_map (f : α → β) (x : m α) :
+theorem map_le_wp_map (f : α → β) (x : m α) :
   ∀ post epost, wp x (fun a => post (f a)) epost ⊑ wp (f <$> x) post epost := by
   intro post epost
   rw [← bind_pure_comp]
@@ -191,23 +183,23 @@ theorem wp_map (f : α → β) (x : m α) :
   apply WP.wp_consequence
   intro a; exact pure_le_wp_pure (f a) post epost
 
-/-- Variant of `wp_map` with an explicit postcondition equality hypothesis. -/
-theorem wp_map' (f : α → β) (x : m α) :
+/-- Variant of `map_le_wp_map` with an explicit postcondition equality hypothesis. -/
+theorem map_le_wp_map' (f : α → β) (x : m α) :
   ∀ post post' epost (_ : post = fun a => post' (f a)),
     wp x post epost ⊑ wp (f <$> x) post' epost := by
   intro post post' epost h
   subst h
-  apply wp_map
+  apply map_le_wp_map
 
 /-- Soundness of `Seq.seq`: sequencing `f <*> x` preserves the WP. -/
-theorem wp_seq (f : m (α → β)) (x : m α) :
+theorem seq_le_wp_seq (f : m (α → β)) (x : m α) :
   ∀ post epost,
     wp f (fun g => wp x (fun a => post (g a)) epost) epost ⊑
       wp (f <*> x) post epost := by
   intro post epost
   rw [← bind_map]
-  apply PartialOrder.rel_trans _ (wp_bind f (fun g => g <$> x) post epost)
-  apply WP.wp_consequence; intro g; exact wp_map g x post epost
+  apply PartialOrder.rel_trans _ (bind_le_wp_bind f (fun g => g <$> x) post epost)
+  apply WP.wp_consequence; intro g; exact map_le_wp_map g x post epost
 
 end WPMonad
 
@@ -258,15 +250,15 @@ instance ExceptT.instWPMonad {Pred : Type v}
     WPMonad (ExceptT ε m) Pred (EPost.Cons (ε → Pred) EPred) where
   toWP _ := ExceptT.wpInst
   pure_le_wp_pure x := fun post epost =>
-    WPMonad.wp_pure (m := m) (Except.ok x) (epost.pushExcept post) epost.tail
+    WPMonad.pure_le_wp_pure (m := m) (Except.ok x) (epost.pushExcept post) epost.tail
   bind_le_wp_bind x f := fun post epost => by
     show wp x.run _ epost.tail ⊑ wp (x >>= f).run (epost.pushExcept post) epost.tail
-    apply PartialOrder.rel_trans _ (WPMonad.wp_bind (m := m) x.run _ (epost.pushExcept post) epost.tail)
+    apply PartialOrder.rel_trans _ (WPMonad.bind_le_wp_bind (m := m) x.run _ (epost.pushExcept post) epost.tail)
     apply WP.wp_consequence
     intro r; cases r with
     | ok a => exact PartialOrder.rel_refl
     | error el =>
-      exact WPMonad.wp_pure (m := m) (Except.error el) (epost.pushExcept post) epost.tail
+      exact WPMonad.pure_le_wp_pure (m := m) (Except.error el) (epost.pushExcept post) epost.tail
 
 @[simp, grind =]
 theorem ExceptT.wp_apply_eq {α ε Pred EPred}
@@ -296,15 +288,15 @@ instance OptionT.instWPMonad {Pred : Type u}
     WPMonad (OptionT m) Pred (EPost.Cons Pred EPred) where
   toWP _ := OptionT.wpInst
   pure_le_wp_pure x := fun post epost =>
-    WPMonad.wp_pure (m := m) (some x) (epost.pushOption post) epost.tail
+    WPMonad.pure_le_wp_pure (m := m) (some x) (epost.pushOption post) epost.tail
   bind_le_wp_bind x f := fun post epost => by
     show wp x.run _ epost.tail ⊑ wp (x >>= f).run (epost.pushOption post) epost.tail
-    apply PartialOrder.rel_trans _ (WPMonad.wp_bind (m := m) x.run _ (epost.pushOption post) epost.tail)
+    apply PartialOrder.rel_trans _ (WPMonad.bind_le_wp_bind (m := m) x.run _ (epost.pushOption post) epost.tail)
     apply WP.wp_consequence
     intro r; cases r with
     | some a => exact PartialOrder.rel_refl
     | none =>
-      exact WPMonad.wp_pure (m := m) none (epost.pushOption post) epost.tail
+      exact WPMonad.pure_le_wp_pure (m := m) none (epost.pushOption post) epost.tail
 
 @[simp, grind =]
 theorem OptionT.wp_apply_eq {α : Type u} {Pred : Type u} {EPred}
@@ -329,9 +321,9 @@ instance (priority := low) StateT.instWPMonad {EPred : Type v} {σ : Type u} {Pr
     WPMonad (StateT σ m) (σ → Pred) EPred where
   toWP _ := StateT.wpInst
   pure_le_wp_pure x := fun post epost s =>
-    WPMonad.wp_pure (m := m) (x, s) (fun p => post p.1 p.2) epost
+    WPMonad.pure_le_wp_pure (m := m) (x, s) (fun p => post p.1 p.2) epost
   bind_le_wp_bind x f := fun post epost s => by
-    apply WPMonad.wp_bind
+    apply WPMonad.bind_le_wp_bind
 
 @[simp, grind =]
 theorem StateT.wp_apply_eq {σ : Type u}
@@ -356,12 +348,12 @@ instance ReaderT.instWPMonad {Pred : Type v}
     WPMonad (ReaderT ρ m) (ρ → Pred) EPred where
   toWP _ := ReaderT.wpInst
   pure_le_wp_pure x := fun post epost r =>
-    WPMonad.wp_pure (m := m) x (fun a => post a r) epost
+    WPMonad.pure_le_wp_pure (m := m) x (fun a => post a r) epost
   bind_le_wp_bind x f := fun post epost r => by
     apply PartialOrder.rel_trans
     · apply WP.wp_consequence
       intro a; exact PartialOrder.rel_refl
-    · apply WPMonad.wp_bind
+    · apply WPMonad.bind_le_wp_bind
 
 @[simp, grind =]
 theorem ReaderT.wp_apply_eq {ρ : Type u}

--- a/src/Std/Internal/Do/WP/Basic.lean
+++ b/src/Std/Internal/Do/WP/Basic.lean
@@ -158,8 +158,9 @@ end WP
 
 /-- Rewriting the program of a weakest precondition along an equation `x = y` weakens it:
 the precondition of `y` entails the precondition of `x`. -/
-theorem wp_le_wp_of_eq [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] {α}
-    {x y : m α} (h : x = y) (post : α → Pred) (epost : EPred) :
+theorem wp_le_wp_of_eq {Prog : Type u} {Value : Type v} {Pred : Type w} {EPred : Type z}
+    [Assertion Pred] [Assertion EPred] [WP Prog Value Pred EPred]
+    {x y : Prog} (h : x = y) (post : Value → Pred) (epost : EPred) :
     wp y post epost ⊑ wp x post epost := by
   subst h; exact PartialOrder.rel_refl
 

--- a/src/Std/Internal/Do/WP/Basic.lean
+++ b/src/Std/Internal/Do/WP/Basic.lean
@@ -74,8 +74,8 @@ def WP.wp {Prog : Type u} {Value : Type v} {Pred : Type w} {EPred : Type w'}
   (self.wpTrans x).apply post epost
 
 /-- Weakest precondition monad: a monad `m` whose weakest precondition interpretation is sound for
-`pure` and `bind`. The interpretation for every result type is carried as the `toWP` field; the
-`instWPofWPMonad` instance exposes it as a `WP (m α) …` interpretation. -/
+`pure` and `bind`. The interpretation for every result type is carried as the `toWP` field; an
+instance exposes it as a `WP (m α) …` interpretation. -/
 class WPMonad (m : Type u → Type v) (Pred : outParam (Type w)) (EPred : outParam (Type w'))
     [Monad m] [Assertion Pred] [Assertion EPred] extends LawfulMonad m where
   /-- The weakest precondition interpretation of `m` at every result type. -/
@@ -91,8 +91,7 @@ class WPMonad (m : Type u → Type v) (Pred : outParam (Type w)) (EPred : outPar
 
 /-- A monadic `WP` interpretation is sourced from the monad's `WPMonad` instance. Low priority so a
 program type with a bespoke `WP` instance (e.g. a non-monadic one) is preferred. -/
-@[instance_reducible]
-instance (priority := low) instWPofWPMonad
+instance (priority := low)
     {m : Type u → Type v} {Pred : Type w} {EPred : Type w'} {α : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [inst : WPMonad m Pred EPred] :
     WP (m α) α Pred EPred :=

--- a/src/Std/Internal/Do/WP/Basic.lean
+++ b/src/Std/Internal/Do/WP/Basic.lean
@@ -77,7 +77,7 @@ def WP.wp {Prog : Type u} {Value : Type v} {Pred : Type w} {EPred : Type w'}
 `pure` and `bind`. The interpretation for every result type is carried as the `toWP` field; the
 `instWPofWPMonad` instance exposes it as a `WP (m α) …` interpretation. -/
 class WPMonad (m : Type u → Type v) (Pred : outParam (Type w)) (EPred : outParam (Type w'))
-    [Monad m] [Assertion Pred] [Assertion EPred] where
+    [Monad m] [Assertion Pred] [Assertion EPred] extends LawfulMonad m where
   /-- The weakest precondition interpretation of `m` at every result type. -/
   toWP : ∀ α, WP (m α) α Pred EPred
   /-- Soundness of `pure`: the postcondition applied to `x` implies the weakest precondition of
@@ -183,7 +183,7 @@ theorem wp_bind (x : m α) (f : α → m β)
   bind_le_wp_bind x f post epost
 
 /-- Soundness of `Functor.map`: mapping `f` over `x` preserves the WP. -/
-theorem wp_map [LawfulMonad m] (f : α → β) (x : m α) :
+theorem wp_map (f : α → β) (x : m α) :
   ∀ post epost, wp x (fun a => post (f a)) epost ⊑ wp (f <$> x) post epost := by
   intro post epost
   rw [← bind_pure_comp]
@@ -193,7 +193,7 @@ theorem wp_map [LawfulMonad m] (f : α → β) (x : m α) :
   intro a; exact pure_le_wp_pure (f a) post epost
 
 /-- Variant of `wp_map` with an explicit postcondition equality hypothesis. -/
-theorem wp_map' [LawfulMonad m] (f : α → β) (x : m α) :
+theorem wp_map' (f : α → β) (x : m α) :
   ∀ post post' epost (_ : post = fun a => post' (f a)),
     wp x post epost ⊑ wp (f <$> x) post' epost := by
   intro post post' epost h
@@ -201,7 +201,7 @@ theorem wp_map' [LawfulMonad m] (f : α → β) (x : m α) :
   apply wp_map
 
 /-- Soundness of `Seq.seq`: sequencing `f <*> x` preserves the WP. -/
-theorem wp_seq [LawfulMonad m] (f : m (α → β)) (x : m α) :
+theorem wp_seq (f : m (α → β)) (x : m α) :
   ∀ post epost,
     wp f (fun g => wp x (fun a => post (g a)) epost) epost ⊑
       wp (f <*> x) post epost := by

--- a/src/Std/Internal/Do/WP/Basic.lean
+++ b/src/Std/Internal/Do/WP/Basic.lean
@@ -46,37 +46,115 @@ namespace Std.Internal.Do
 variable {m : Type u → Type z}
 
 /-!
-## WPMonad Typeclass
+## WP and WPMonad Typeclasses
 
-The `WPMonad` typeclass defines weakest precondition semantics for monads.
-A `WPMonad m Pred EPred` instance provides a monad morphism `wpTrans : m α → PredTrans Pred EPred α`
-satisfying:
-- `wp_trans_pure`: `pure x` is at least as strong as its predicate transformer.
-- `wp_trans_bind`: sequential composition is sound.
-- `wp_trans_monotone`: the transformer is monotone in both postconditions.
+The `WP` typeclass interprets a program type `Prog` whose results have type `Value` as a monotone
+predicate transformer `wpTrans : Prog → PredTrans Pred EPred Value`.
+
+The `WPMonad` typeclass adds soundness of the weakest precondition interpretation for the monadic
+`pure` and `bind` of a monad `m`, on top of a `WP (m α) α Pred EPred` interpretation for every
+result type `α`.
 -/
 
-/-- Weakest precondition monad: a monad `m` with a sound interpretation as predicate
-transformers over assertion language `Pred` with exception postconditions `EPred`. -/
-class WPMonad (m : Type u → Type v) (Pred : outParam (Type w)) (EPred : outParam (Type w'))
-    [Monad m] [Assertion Pred] [Assertion EPred] extends LawfulMonad m where
-  /-- The weakest precondition transformer for a monadic program. -/
-  wpTrans : m α → PredTrans Pred EPred α
-  /-- Soundness of `pure`: the postcondition applied to `x` implies the WPMonad of `pure x`. -/
-  wp_trans_pure (x : α) : pure x ⊑ wpTrans (pure (f := m) x)
-  /-- Soundness of `bind`: composing WPs is at least as strong as the WPMonad of `>>=`. -/
-  wp_trans_bind (x : m α) (f : α → m β) :
-    wpTrans x >>= (wpTrans <| f ·) ⊑ wpTrans (x >>= f)
+/-- Weakest precondition interpretation of a program type `Prog` whose results have type `Value`,
+as a monotone predicate transformer over assertion language `Pred` with exception postconditions
+`EPred`. -/
+class WP (Prog : Type u) (Value : outParam (Type v)) (Pred : outParam (Type w))
+    (EPred : outParam (Type w')) [Assertion Pred] [Assertion EPred] where
+  /-- The weakest precondition transformer for a program. -/
+  wpTrans : Prog → PredTrans Pred EPred Value
   /-- Monotonicity: weaker postconditions yield weaker preconditions. -/
-  wp_trans_monotone (x : m α) : wpTrans x |>.monotone
+  wp_trans_monotone (x : Prog) : wpTrans x |>.monotone
 
-/-- Compute the weakest precondition of `x` for normal postcondition `post` and
-exception postcondition `epost`. -/
-def wp [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] {α} (x : m α) (post : α → Pred) (epost : EPred) : Pred :=
-  (WPMonad.wpTrans x).apply post epost
+/-- Weakest precondition of `x` for normal postcondition `post` and exception postcondition `epost`.
+The `WP` interpretation can be supplied explicitly via dot notation (`inst.wp x post epost`). -/
+def WP.wp {Prog : Type u} {Value : Type v} {Pred : Type w} {EPred : Type w'}
+    [Assertion Pred] [Assertion EPred] [self : WP Prog Value Pred EPred]
+    (x : Prog) (post : Value → Pred) (epost : EPred) : Pred :=
+  (self.wpTrans x).apply post epost
 
-@[simp, grind =] theorem WPMonad.wpTrans_apply_eq [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] {α} (x : m α) :
-  (WPMonad.wpTrans x).apply = wp x := rfl
+/-- Weakest precondition monad: a monad `m` whose weakest precondition interpretation is sound for
+`pure` and `bind`. The interpretation for every result type is carried as the `toWP` field; the
+`instWPofWPMonad` instance exposes it as a `WP (m α) …` interpretation. -/
+class WPMonad (m : Type u → Type v) (Pred : outParam (Type w)) (EPred : outParam (Type w'))
+    [Monad m] [Assertion Pred] [Assertion EPred] where
+  /-- The weakest precondition interpretation of `m` at every result type. -/
+  toWP : ∀ α, WP (m α) α Pred EPred
+  /-- Soundness of `pure`: the postcondition applied to `x` implies the weakest precondition of
+  `pure x`. -/
+  pure_le_wp_pure (x : α) (post : α → Pred) (epost : EPred) :
+    post x ⊑ (toWP α).wp (pure (f := m) x) post epost
+  /-- Soundness of `bind`: composing weakest preconditions is at least as strong as the weakest
+  precondition of `>>=`. -/
+  bind_le_wp_bind (x : m α) (f : α → m β) (post : β → Pred) (epost : EPred) :
+    (toWP α).wp x (fun a => (toWP β).wp (f a) post epost) epost ⊑ (toWP β).wp (x >>= f) post epost
+
+/-- A monadic `WP` interpretation is sourced from the monad's `WPMonad` instance. Low priority so a
+program type with a bespoke `WP` instance (e.g. a non-monadic one) is preferred. -/
+@[instance_reducible]
+instance (priority := low) instWPofWPMonad
+    {m : Type u → Type v} {Pred : Type w} {EPred : Type w'} {α : Type u}
+    [Monad m] [Assertion Pred] [Assertion EPred] [inst : WPMonad m Pred EPred] :
+    WP (m α) α Pred EPred :=
+  inst.toWP α
+
+-- `wp x post epost` computes the weakest precondition; it is `WP.wp` with the interpretation
+-- synthesised as an instance.
+export Std.Internal.Do.WP (wp)
+
+@[simp, grind =] theorem WP.wpTrans_apply_eq {Prog : Type u} {Value : Type v}
+    [Assertion Pred] [Assertion EPred] [WP Prog Value Pred EPred] (x : Prog) :
+  (WP.wpTrans x).apply = wp x := rfl
+
+/-!
+## Derived WP Lemmas
+
+Monotonicity and weakening consequences of the `WP` monotonicity axiom.
+-/
+
+namespace WP
+
+variable {Prog : Type u} {Value : Type v} [Assertion Pred] [Assertion EPred]
+  [WP Prog Value Pred EPred]
+
+theorem wp_consequence (x : Prog)
+  (post post' : Value → Pred) (epost : EPred) (h : post ⊑ post') :
+    wp x post epost ⊑ wp x post' epost :=
+  wp_trans_monotone x post post' epost epost PartialOrder.rel_refl h
+
+theorem wp_consequence_econs (x : Prog)
+  (post post' : Value → Pred) (epost epost' : EPred) (h : post ⊑ post') (h' : epost ⊑ epost') :
+    wp x post epost ⊑ wp x post' epost' :=
+  wp_trans_monotone x post post' epost epost' h' h
+
+theorem wp_econs (x : Prog)
+  (post : Value → Pred) (epost epost' : EPred) (h' : epost ⊑ epost') :
+    wp x post epost ⊑ wp x post epost' :=
+  wp_trans_monotone x post post epost epost' h' PartialOrder.rel_refl
+
+theorem wp_econs_bot (x : Prog)
+  (post : Value → Pred) (epost : EPred) :
+    wp x post ⊥ ⊑ wp x post epost := by
+  solve_by_elim [wp_econs, bot_le]
+
+theorem wp_consequence_le (x : Prog)
+  (post post' : Value → Pred) (epost : EPred) (h : post ⊑ post') {pre : Pred}
+    (h' : pre ⊑ wp x post epost) :
+    pre ⊑ wp x post' epost :=
+  PartialOrder.rel_trans h' (wp_consequence x post post' epost h)
+
+theorem wp_econs_le (x : Prog)
+  (post : Value → Pred) (epost epost' : EPred) (h : epost ⊑ epost') {pre : Pred}
+    (h' : pre ⊑ wp x post epost) :
+    pre ⊑ wp x post epost' :=
+  PartialOrder.rel_trans h' (wp_econs x post epost epost' h)
+
+theorem wp_econs_bot_le (x : Prog)
+  (post : Value → Pred) (epost : EPred) {pre : Pred} (h : pre ⊑ wp x post ⊥) :
+    pre ⊑ wp x post epost :=
+  PartialOrder.rel_trans h (wp_econs_bot x post epost)
+
+end WP
 
 /-- Rewriting the program of a weakest precondition along an equation `x = y` weakens it:
 the precondition of `y` entails the precondition of `x`. -/
@@ -88,8 +166,7 @@ theorem wp_le_wp_of_eq [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m P
 /-!
 ## Derived WPMonad Lemmas
 
-One-directional consequences of the `WPMonad` axioms for `pure`, `bind`, monotonicity,
-and weakening.
+One-directional consequences of the `WPMonad` axioms for `pure`, `bind`, `map`, and `seq`.
 -/
 
 namespace WPMonad
@@ -97,70 +174,25 @@ namespace WPMonad
 variable [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
 
 theorem wp_pure (x : α) (post : α → Pred) (epost : EPred) :
-    post x ⊑ wp (pure (f := m) x) post epost := wp_trans_pure x post epost
+    post x ⊑ wp (pure (f := m) x) post epost := pure_le_wp_pure x post epost
 
 theorem wp_bind (x : m α) (f : α → m β)
   (post : β → Pred) (epost : EPred) :
     wp x (fun x => wp (f x) post epost) epost ⊑ wp (x >>= f) post epost :=
-  wp_trans_bind x f post epost
-
-theorem wp_consequence (x : m α)
-  (post post' : α → Pred) (epost : EPred) (h : post ⊑ post') :
-    wp x post epost ⊑ wp x post' epost :=
-  wp_trans_monotone x post post' epost epost PartialOrder.rel_refl h
-
-theorem wp_consequence_econs (x : m α)
-  (post post' : α → Pred) (epost epost' : EPred) (h : post ⊑ post') (h' : epost ⊑ epost') :
-    wp x post epost ⊑ wp x post' epost' :=
-  wp_trans_monotone x post post' epost epost' h' h
-
-theorem wp_econs (x : m α)
-  (post : α → Pred) (epost epost' : EPred) (h' : epost ⊑ epost') :
-    wp x post epost ⊑ wp x post epost' :=
-  wp_trans_monotone x post post epost epost' h' PartialOrder.rel_refl
-
-theorem wp_econs_bot (x : m α)
-  (post : α → Pred) (epost : EPred) :
-    wp x post ⊥ ⊑ wp x post epost := by
-  solve_by_elim [wp_econs, bot_le]
-
-theorem wp_consequence_le (x : m α)
-  (post post' : α → Pred) (epost : EPred) (h : post ⊑ post') {pre : Pred}
-    (h' : pre ⊑ wp x post epost) :
-    pre ⊑ wp x post' epost :=
-  PartialOrder.rel_trans h' (wp_consequence x post post' epost h)
-
-theorem wp_econs_le (x : m α)
-  (post : α → Pred) (epost epost' : EPred) (h : epost ⊑ epost') {pre : Pred}
-    (h' : pre ⊑ wp x post epost) :
-    pre ⊑ wp x post epost' :=
-  PartialOrder.rel_trans h' (wp_econs x post epost epost' h)
-
-theorem wp_econs_bot_le (x : m α)
-  (post : α → Pred) (epost : EPred) {pre : Pred} (h : pre ⊑ wp x post ⊥) :
-    pre ⊑ wp x post epost :=
-  PartialOrder.rel_trans h (wp_econs_bot x post epost)
-
-/-!
-## Derived Theorems for `map` and `seq`
-
-One direction of the derived theorems `wp_map` and `wp_seq`. The full bidirectional
-equality from `Std.Do` cannot be proven with our current axioms since `wp_bind` only
-gives one direction (`⊑`).
--/
+  bind_le_wp_bind x f post epost
 
 /-- Soundness of `Functor.map`: mapping `f` over `x` preserves the WP. -/
-theorem wp_map (f : α → β) (x : m α) :
+theorem wp_map [LawfulMonad m] (f : α → β) (x : m α) :
   ∀ post epost, wp x (fun a => post (f a)) epost ⊑ wp (f <$> x) post epost := by
   intro post epost
   rw [← bind_pure_comp]
   apply PartialOrder.rel_trans; rotate_left
-  exact wp_trans_bind x (pure <| f ·) post epost
-  apply wp_consequence
-  intro a; exact wp_trans_pure (f a) post epost
+  exact bind_le_wp_bind x (pure <| f ·) post epost
+  apply WP.wp_consequence
+  intro a; exact pure_le_wp_pure (f a) post epost
 
 /-- Variant of `wp_map` with an explicit postcondition equality hypothesis. -/
-theorem wp_map' (f : α → β) (x : m α) :
+theorem wp_map' [LawfulMonad m] (f : α → β) (x : m α) :
   ∀ post post' epost (_ : post = fun a => post' (f a)),
     wp x post epost ⊑ wp (f <$> x) post' epost := by
   intro post post' epost h
@@ -168,14 +200,14 @@ theorem wp_map' (f : α → β) (x : m α) :
   apply wp_map
 
 /-- Soundness of `Seq.seq`: sequencing `f <*> x` preserves the WP. -/
-theorem wp_seq (f : m (α → β)) (x : m α) :
+theorem wp_seq [LawfulMonad m] (f : m (α → β)) (x : m α) :
   ∀ post epost,
     wp f (fun g => wp x (fun a => post (g a)) epost) epost ⊑
       wp (f <*> x) post epost := by
   intro post epost
   rw [← bind_map]
   apply PartialOrder.rel_trans _ (wp_bind f (fun g => g <$> x) post epost)
-  apply wp_consequence; intro g; exact wp_map g x post epost
+  apply WP.wp_consequence; intro g; exact wp_map g x post epost
 
 end WPMonad
 
@@ -183,12 +215,16 @@ end WPMonad
 ## WPMonad Instances
 -/
 
+/-- `Id`'s `WP` interpretation: `Prop` assertions and no exceptions. -/
+@[instance_reducible] def Id.wpInst {α : Type u} : WP (Id α) α Prop EPost.Nil where
+  wpTrans x := ⟨fun post _epost => post x⟩
+  wp_trans_monotone x := fun _ _ _ _ _ hpost => hpost x
+
 /-- `Id` is a WPMonad with `Prop` assertions and no exceptions. -/
 instance Id.instWPMonad : WPMonad Id.{u} Prop EPost.Nil where
-  wpTrans x := ⟨fun post _epost => post x⟩
-  wp_trans_pure _x := PartialOrder.rel_refl
-  wp_trans_bind _x _f := PartialOrder.rel_refl
-  wp_trans_monotone x := fun _ _ _ _ _ hpost => hpost x
+  toWP _ := Id.wpInst
+  pure_le_wp_pure _ _ _ := PartialOrder.rel_refl
+  bind_le_wp_bind _ _ _ _ := PartialOrder.rel_refl
 
 @[simp, grind =]
 theorem PredTrans.apply_pushExcept {α ε Pred EPred}
@@ -196,21 +232,12 @@ theorem PredTrans.apply_pushExcept {α ε Pred EPred}
     (epost : EPost.Cons (ε → Pred) EPred) :
     (PredTrans.pushExcept x).apply post epost = x.apply (epost.pushExcept post) epost.tail := rfl
 
-/-- `ExceptT` lifts a `WPMonad` instance by adding an exception postcondition layer. -/
-instance ExceptT.instWPMonad {Pred : Type v}
-  [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
-    WPMonad (ExceptT ε m) Pred (EPost.Cons (ε → Pred) EPred) where
-  wpTrans x := PredTrans.pushExcept (WPMonad.wpTrans x.run)
-  wp_trans_pure x := fun post epost =>
-    WPMonad.wp_pure (m := m) (Except.ok x) (epost.pushExcept post) epost.tail
-  wp_trans_bind x f := fun post epost => by
-    simp only [PredTrans.apply_pushExcept, ExceptT.run_bind]
-    apply PartialOrder.rel_trans _ (WPMonad.wp_bind (m := m) x ..)
-    apply WPMonad.wp_consequence (m := m)
-    · intro r; cases r with
-      | ok a => exact PartialOrder.rel_refl
-      | error el =>
-        exact WPMonad.wp_pure (m := m) (Except.error el) (epost.pushExcept post) epost.tail
+/-- `ExceptT`'s `WP` interpretation: lift the base interpretation by adding an exception
+postcondition layer. -/
+@[instance_reducible] def ExceptT.wpInst {Pred : Type v}
+  [Assertion Pred] [Assertion EPred] [WP (m (Except ε α)) (Except ε α) Pred EPred] :
+    WP (ExceptT ε m α) α Pred (EPost.Cons (ε → Pred) EPred) where
+  wpTrans x := PredTrans.pushExcept (WP.wpTrans x.run)
   wp_trans_monotone x := fun post post' epost epost' hepost hpost => by
     change wp x.run (epost.pushExcept post) epost.tail ⊑
            wp x.run (epost'.pushExcept post') epost'.tail
@@ -218,12 +245,28 @@ instance ExceptT.instWPMonad {Pred : Type v}
       simpa [PartialOrder.rel, meet_prop_eq_and] using hepost
     let hhead := hepost'.1
     let htail := hepost'.2
-    apply WPMonad.wp_consequence_econs (m := m) (x := x.run)
+    apply WP.wp_consequence_econs (x := x.run)
     · intro r
       cases r with
       | ok a => exact hpost a
       | error el => exact hhead el
     · exact htail
+
+/-- `ExceptT` lifts a `WPMonad` instance by adding an exception postcondition layer. -/
+instance ExceptT.instWPMonad {Pred : Type v}
+  [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+    WPMonad (ExceptT ε m) Pred (EPost.Cons (ε → Pred) EPred) where
+  toWP _ := ExceptT.wpInst
+  pure_le_wp_pure x := fun post epost =>
+    WPMonad.wp_pure (m := m) (Except.ok x) (epost.pushExcept post) epost.tail
+  bind_le_wp_bind x f := fun post epost => by
+    show wp x.run _ epost.tail ⊑ wp (x >>= f).run (epost.pushExcept post) epost.tail
+    apply PartialOrder.rel_trans _ (WPMonad.wp_bind (m := m) x.run _ (epost.pushExcept post) epost.tail)
+    apply WP.wp_consequence
+    intro r; cases r with
+    | ok a => exact PartialOrder.rel_refl
+    | error el =>
+      exact WPMonad.wp_pure (m := m) (Except.error el) (epost.pushExcept post) epost.tail
 
 @[simp, grind =]
 theorem ExceptT.wp_apply_eq {α ε Pred EPred}
@@ -231,30 +274,37 @@ theorem ExceptT.wp_apply_eq {α ε Pred EPred}
   (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     wp x post epost = wp x.run (epost.pushExcept post) epost.tail := rfl
 
-/-- `OptionT` lifts a `WPMonad` instance by adding a `PUnit` exception postcondition layer. -/
-instance OptionT.instWPMonad {Pred : Type u}
-  [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
-    WPMonad (OptionT m) Pred (EPost.Cons Pred EPred) where
-  wpTrans x := PredTrans.pushOption (WPMonad.wpTrans x.run)
-  wp_trans_pure x := fun post epost =>
-    WPMonad.wp_pure (m := m) (some x) (epost.pushOption post) epost.tail
-  wp_trans_bind x f := fun post epost => by
-    simp only [PredTrans.apply_pushOption, OptionT.run_bind]
-    apply PartialOrder.rel_trans _ (WPMonad.wp_bind (m := m) x ..)
-    apply WPMonad.wp_consequence (m := m)
-    · intro r; cases r with
-      | some a => exact PartialOrder.rel_refl
-      | none =>
-        exact WPMonad.wp_pure (m := m) none (epost.pushOption post) epost.tail
+/-- `OptionT`'s `WP` interpretation: lift the base interpretation by adding a `PUnit` exception
+postcondition layer. -/
+@[instance_reducible] def OptionT.wpInst {Pred : Type u}
+  [Assertion Pred] [Assertion EPred] [WP (m (Option α)) (Option α) Pred EPred] :
+    WP (OptionT m α) α Pred (EPost.Cons Pred EPred) where
+  wpTrans x := PredTrans.pushOption (WP.wpTrans x.run)
   wp_trans_monotone x := fun post post' epost epost' hepost hpost => by
     change wp x.run (epost.pushOption post) epost.tail ⊑
            wp x.run (epost'.pushOption post') epost'.tail
     have hepost' : epost.head ⊑ epost'.head ∧ epost.tail ⊑ epost'.tail := hepost
-    apply WPMonad.wp_consequence_econs (m := m) (x := x.run)
+    apply WP.wp_consequence_econs (x := x.run)
     · intro r; cases r with
       | some a => exact hpost a
       | none => exact hepost'.1
     · exact hepost'.2
+
+/-- `OptionT` lifts a `WPMonad` instance by adding a `PUnit` exception postcondition layer. -/
+instance OptionT.instWPMonad {Pred : Type u}
+  [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+    WPMonad (OptionT m) Pred (EPost.Cons Pred EPred) where
+  toWP _ := OptionT.wpInst
+  pure_le_wp_pure x := fun post epost =>
+    WPMonad.wp_pure (m := m) (some x) (epost.pushOption post) epost.tail
+  bind_le_wp_bind x f := fun post epost => by
+    show wp x.run _ epost.tail ⊑ wp (x >>= f).run (epost.pushOption post) epost.tail
+    apply PartialOrder.rel_trans _ (WPMonad.wp_bind (m := m) x.run _ (epost.pushOption post) epost.tail)
+    apply WP.wp_consequence
+    intro r; cases r with
+    | some a => exact PartialOrder.rel_refl
+    | none =>
+      exact WPMonad.wp_pure (m := m) none (epost.pushOption post) epost.tail
 
 @[simp, grind =]
 theorem OptionT.wp_apply_eq {α : Type u} {Pred : Type u} {EPred}
@@ -262,21 +312,26 @@ theorem OptionT.wp_apply_eq {α : Type u} {Pred : Type u} {EPred}
   (post : α → Pred) (epost : EPost.Cons Pred EPred) :
     wp x post epost = wp x.run (epost.pushOption post) epost.tail := rfl
 
+/-- `StateT`'s `WP` interpretation: lift the base interpretation by adding a state argument. -/
+@[instance_reducible] def StateT.wpInst {EPred : Type v} {σ : Type u} {Pred : Type w}
+  [Assertion Pred] [Assertion EPred] [WP (m (α × σ)) (α × σ) Pred EPred] :
+    WP (StateT σ m α) α (σ → Pred) EPred where
+  wpTrans x := pushArg (WP.wpTrans <| x.run ·)
+  wp_trans_monotone x := fun post post' epost epost' hepost hpost s => by
+    apply WP.wp_consequence_econs (x := x.run s)
+    · intro ⟨a, s'⟩
+      exact hpost a s'
+    · exact hepost
+
 /-- `StateT` lifts a `WPMonad` instance by adding a state argument. -/
 instance (priority := low) StateT.instWPMonad {EPred : Type v} {σ : Type u} {Pred : Type w}
   [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
     WPMonad (StateT σ m) (σ → Pred) EPred where
-  wpTrans x := pushArg (WPMonad.wpTrans <| x.run ·)
-  wp_trans_pure x := fun post epost s =>
+  toWP _ := StateT.wpInst
+  pure_le_wp_pure x := fun post epost s =>
     WPMonad.wp_pure (m := m) (x, s) (fun p => post p.1 p.2) epost
-  wp_trans_bind x f := fun post epost s => by
-    simp only [PredTrans.apply_pushArg, StateT.run_bind]
+  bind_le_wp_bind x f := fun post epost s => by
     apply WPMonad.wp_bind
-  wp_trans_monotone x := fun post post' epost epost' hepost hpost s => by
-    apply WPMonad.wp_consequence_econs (m := m) (x := x.run s)
-    · intro ⟨a, s'⟩
-      exact hpost a s'
-    · exact hepost
 
 @[simp, grind =]
 theorem StateT.wp_apply_eq {σ : Type u}
@@ -284,24 +339,29 @@ theorem StateT.wp_apply_eq {σ : Type u}
   (post : α → σ → Pred) (epost : EPred) (s : σ) :
     wp x post epost s = wp (x.run s) (fun (a, s) => post a s) epost := rfl
 
+/-- `ReaderT`'s `WP` interpretation: lift the base interpretation by adding a reader argument. -/
+@[instance_reducible] def ReaderT.wpInst {Pred : Type v}
+  [Assertion Pred] [Assertion EPred] [WP (m α) α Pred EPred] :
+    WP (ReaderT ρ m α) α (ρ → Pred) EPred where
+  wpTrans x := ⟨fun post epost r => wp (x.run r) (fun a => post a r) epost⟩
+  wp_trans_monotone x := fun post post' epost epost' hepost hpost r => by
+    apply WP.wp_consequence_econs (x := x.run r)
+    · intro a
+      exact hpost a r
+    · exact hepost
+
 /-- `ReaderT` lifts a `WPMonad` instance by adding a reader argument. -/
 instance ReaderT.instWPMonad {Pred : Type v}
   [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
     WPMonad (ReaderT ρ m) (ρ → Pred) EPred where
-  wpTrans x := ⟨fun post epost r => wp (x.run r) (fun a => post a r) epost⟩
-  wp_trans_pure x := fun post epost r =>
+  toWP _ := ReaderT.wpInst
+  pure_le_wp_pure x := fun post epost r =>
     WPMonad.wp_pure (m := m) x (fun a => post a r) epost
-  wp_trans_bind x f := fun post epost r => by
-    simp only [ReaderT.run_bind]
+  bind_le_wp_bind x f := fun post epost r => by
     apply PartialOrder.rel_trans
-    · apply WPMonad.wp_consequence (m := m)
+    · apply WP.wp_consequence
       intro a; exact PartialOrder.rel_refl
     · apply WPMonad.wp_bind
-  wp_trans_monotone x := fun post post' epost epost' hepost hpost r => by
-    apply WPMonad.wp_consequence_econs (m := m) (x := x.run r)
-    · intro a
-      exact hpost a r
-    · exact hepost
 
 @[simp, grind =]
 theorem ReaderT.wp_apply_eq {ρ : Type u}
@@ -315,23 +375,25 @@ theorem ReaderT.wp_apply_eq {ρ : Type u}
 `WPMonad` instances for concrete monads that are type aliases for transformer stacks.
 -/
 
-/-- `Option` is a WPMonad with `Prop` assertions and a single `Prop` exception postcondition. -/
-instance Option.instWPMonad : WPMonad Option.{u} Prop Prop where
+/-- `Option`'s `WP` interpretation: `Prop` assertions and a single `Prop` exception postcondition. -/
+@[instance_reducible] def Option.wpInst {α : Type u} : WP (Option α) α Prop Prop where
   wpTrans x := ⟨fun post epost => x.elim epost post⟩
-  wp_trans_pure x := PartialOrder.rel_refl
-  wp_trans_bind x f := fun post epost => by cases x <;> exact id
   wp_trans_monotone x := fun post post' epost epost' hepost hpost => by
     cases x with
     | none => exact hepost
     | some a => exact hpost a
 
-/-- `Except ε` is a WPMonad with `Prop` assertions and a single exception postcondition. -/
-instance Except.instWPMonad : WPMonad (Except ε) Prop EPost⟨ε → Prop⟩ where
+/-- `Option` is a WPMonad with `Prop` assertions and a single `Prop` exception postcondition. -/
+instance Option.instWPMonad : WPMonad Option.{u} Prop Prop where
+  toWP _ := Option.wpInst
+  pure_le_wp_pure _ _ _ := PartialOrder.rel_refl
+  bind_le_wp_bind x f := fun post epost => by cases x <;> exact id
+
+/-- `Except ε`'s `WP` interpretation: `Prop` assertions and a single exception postcondition. -/
+@[instance_reducible] def Except.wpInst {α : Type u} : WP (Except ε α) α Prop EPost⟨ε → Prop⟩ where
   wpTrans x := ⟨fun post epost => match x with
     | .ok a => post a
     | .error el => epost.head el⟩
-  wp_trans_pure x := PartialOrder.rel_refl
-  wp_trans_bind x f := fun post epost => by cases x <;> exact id
   wp_trans_monotone x := fun post post' epost epost' hepost hpost => by
     cases x with
     | ok a => exact hpost a
@@ -342,21 +404,31 @@ instance Except.instWPMonad : WPMonad (Except ε) Prop EPost⟨ε → Prop⟩ wh
         exact hepost'.1
       exact hhead el
 
-/-- `EStateM ε σ` is a WPMonad combining state and exceptions. -/
-instance EStateM.instWPMonad : WPMonad (EStateM ε σ) (σ → Prop) (ε → σ → Prop) where
+/-- `Except ε` is a WPMonad with `Prop` assertions and a single exception postcondition. -/
+instance Except.instWPMonad : WPMonad (Except ε) Prop EPost⟨ε → Prop⟩ where
+  toWP _ := Except.wpInst
+  pure_le_wp_pure _ _ _ := PartialOrder.rel_refl
+  bind_le_wp_bind x f := fun post epost => by cases x <;> exact id
+
+/-- `EStateM ε σ`'s `WP` interpretation combining state and exceptions. -/
+@[instance_reducible] def EStateM.wpInst {α : Type} : WP (EStateM ε σ α) α (σ → Prop) (ε → σ → Prop) where
   wpTrans x := ⟨fun post epost s => match x s with
     | .ok a s' => post a s'
     | .error el s' => epost el s'⟩
-  wp_trans_pure x := fun post epost s => PartialOrder.rel_refl
-  wp_trans_bind x f := fun post epost s => by
-    simp only [bind, EStateM.bind]
-    cases (x s) <;> exact PartialOrder.rel_refl
   wp_trans_monotone x := fun post post' epost epost' hepost hpost s => by
     cases hxs : x s with
     | ok a s' =>
       simpa [hxs] using hpost a s'
     | error el s' =>
       simpa [hxs] using hepost el s'
+
+/-- `EStateM ε σ` is a WPMonad combining state and exceptions. -/
+instance EStateM.instWPMonad : WPMonad (EStateM ε σ) (σ → Prop) (ε → σ → Prop) where
+  toWP _ := EStateM.wpInst
+  pure_le_wp_pure x := fun post epost s => PartialOrder.rel_refl
+  bind_le_wp_bind x f := fun post epost s => by
+    simp only [WP.wp, WP.wpTrans, bind, EStateM.bind]
+    cases (x s) <;> exact PartialOrder.rel_refl
 
 /-!
 ## Soundness Lemmas
@@ -421,8 +493,8 @@ theorem EStateM.of_wp_run_eq {ε σ α : Type} {x : EStateM.Result ε σ α}
   change P (prog s)
   cases heq : prog s with
   | ok a s' =>
-    simpa [wp, WPMonad.wpTrans, heq] using hwp
+    simpa [wp, WP.wpTrans, heq] using hwp
   | error e s' =>
-    simpa [wp, WPMonad.wpTrans, heq] using hwp
+    simpa [wp, WP.wpTrans, heq] using hwp
 
 end Std.Internal.Do

--- a/src/Std/Internal/Do/WP/Lemmas.lean
+++ b/src/Std/Internal/Do/WP/Lemmas.lean
@@ -10,6 +10,8 @@ public import Std.Internal.Do.WP.Basic
 @[expose] public section
 
 set_option linter.missingDocs true
+-- The `WP`/`WPMonad` split means each lemma uses only the subset of the section variables it needs.
+set_option linter.unusedSectionVars false
 
 /-!
 # Simp lemmas for weakest preconditions
@@ -73,17 +75,17 @@ theorem le_wp_modifyGet_StateT_apply (f : σ → α × σ)
 theorem wp_get_EStateM_apply_eq :
     wp (MonadStateOf.get : EStateM ε σ σ) post epost = fun s => post s s := by
   funext s
-  simp only [wp, WPMonad.wpTrans, MonadStateOf.get, EStateM.get]
+  simp only [wp, WP.wpTrans, MonadStateOf.get, EStateM.get]
 
 theorem wp_set_EStateM_apply_eq (x : σ) :
     wp (MonadStateOf.set x : EStateM ε σ PUnit) post epost = fun _ => post ⟨⟩ x := by
   funext s
-  simp only [wp, WPMonad.wpTrans, MonadStateOf.set, EStateM.set]
+  simp only [wp, WP.wpTrans, MonadStateOf.set, EStateM.set]
 
 theorem wp_modifyGet_EStateM_apply_eq (f : σ → α × σ) :
     wp (MonadStateOf.modifyGet f : EStateM ε σ α) post epost = fun s => post (f s).1 (f s).2 := by
   funext s
-  simp only [wp, WPMonad.wpTrans, MonadStateOf.modifyGet, EStateM.modifyGet]
+  simp only [wp, WP.wpTrans, MonadStateOf.modifyGet, EStateM.modifyGet]
 
 @[simp]
 theorem wp_modify_StateT_apply_eq (f : σ → σ) :
@@ -118,7 +120,7 @@ theorem wp_throwThe_apply_eq [MonadExceptOf ε m] (err : ε) :
 @[simp]
 theorem wp_throw_Except_apply_eq (e : ε) :
     wp (MonadExceptOf.throw e : Except ε α) post epost = epost.head e := by
-  simp [wp, WPMonad.wpTrans, MonadExceptOf.throw]
+  simp [wp, WP.wpTrans, MonadExceptOf.throw]
 
 theorem le_wp_throw_ExceptT_apply (err : ε) :
     epost.head err ⊑ wp (MonadExceptOf.throw err : ExceptT ε m α) post epost := by
@@ -130,7 +132,7 @@ theorem le_wp_throw_ExceptT_apply (err : ε) :
 theorem wp_throw_EStateM_apply_eq (e : ε) :
     wp (MonadExceptOf.throw e : EStateM ε σ α) post epost = epost e := by
   funext s
-  simp only [wp, WPMonad.wpTrans, MonadExceptOf.throw, EStateM.throw]
+  simp only [wp, WP.wpTrans, MonadExceptOf.throw, EStateM.throw]
 
 @[simp]
 theorem wp_throw_Option_apply_eq (e : PUnit) :
@@ -162,7 +164,7 @@ theorem wp_tryCatchThe_apply_eq [MonadExceptOf ε m] (x : m α) (h : ε → m α
 theorem wp_tryCatch_Except_apply_eq (x : Except ε α) (h : ε → Except ε α) :
     wp (MonadExceptOf.tryCatch x h : Except ε α) post epost =
       wp x post epost⟨fun e => wp (h e) post epost⟩ := by
-  simp only [wp, WPMonad.wpTrans, MonadExceptOf.tryCatch, Except.tryCatch]
+  simp only [wp, WP.wpTrans, MonadExceptOf.tryCatch, Except.tryCatch]
   cases x <;> simp
 
 -- TODO: Upstream
@@ -178,14 +180,14 @@ omit [Monad m] in
   simp only [tryCatch, tryCatchThe, MonadExceptOf.tryCatch, ExceptT.tryCatch, ExceptT.run_mk]
   rfl
 
-theorem le_wp_tryCatch_ExceptT_apply (x : ExceptT ε m α)
+theorem le_wp_tryCatch_ExceptT_apply [LawfulMonad m] (x : ExceptT ε m α)
     (h : ε → ExceptT ε m α) :
     wp x post ⟨fun e => wp (h e) post epost, epost.tail⟩ ⊑
       wp (MonadExceptOf.tryCatch x h : ExceptT ε m α) post epost := by
   change _ ⊑ wp (tryCatch x h : ExceptT ε m α) _ _
   simp only [ExceptT.wp_apply_eq, ExceptT.run_tryCatch]
   apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_bind
-  apply WPMonad.wp_consequence; intro r; cases r with
+  apply WP.wp_consequence; intro r; cases r with
   | ok a =>
     simp; apply PartialOrder.rel_trans; rotate_left;
     apply WPMonad.wp_pure; simp; rfl
@@ -195,7 +197,7 @@ theorem le_wp_tryCatch_ExceptT_apply (x : ExceptT ε m α)
 theorem wp_tryCatch_Option_apply_eq (x : Option α) (h : PUnit → Option α) :
   wp (MonadExceptOf.tryCatch x h : Option α) post epost =
     wp x post (wp (h ⟨⟩) post epost) := by
-  simp only [wp, WPMonad.wpTrans, MonadExceptOf.tryCatch, Option.tryCatch]
+  simp only [wp, WP.wpTrans, MonadExceptOf.tryCatch, Option.tryCatch]
   cases x <;> rfl
 
 
@@ -203,7 +205,7 @@ theorem wp_tryCatch_EStateM_apply_eq (x : EStateM ε σ α) (h : ε → EStateM 
     wp (MonadExceptOf.tryCatch x h : EStateM ε σ α) post epost =
       fun s => wp x post (fun e s' => wp (h e) post epost s') s := by
   funext s
-  simp only [wp, WPMonad.wpTrans, MonadExceptOf.tryCatch, EStateM.tryCatch]
+  simp only [wp, WP.wpTrans, MonadExceptOf.tryCatch, EStateM.tryCatch]
   cases (x s) <;> simp
   rfl
 
@@ -214,7 +216,7 @@ theorem le_wp_tryCatch_OptionT_apply (x : OptionT m α)
     wp (MonadExceptOf.tryCatch x h : OptionT m α) post epost := by
   simp only [wp, MonadExceptOf.tryCatch, OptionT.tryCatch, OptionT.mk]
   apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_bind
-  apply WPMonad.wp_consequence (m := m); intro o; cases o with
+  apply WP.wp_consequence (x := x.run); intro o; cases o with
   | some a =>
     apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_pure
     simp [EPost.Cons.pushOption]; exact PartialOrder.rel_refl
@@ -278,7 +280,7 @@ theorem le_wp_monadLift_StateT_apply (x : m α) (post : α → σ → Pred) :
   intro s
   simp only [wp, MonadLift.monadLift]
   apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_bind
-  apply WPMonad.wp_consequence (m := m); intro a
+  apply WP.wp_consequence; intro a
   simpa using
     (WPMonad.wp_pure (m := m) (x := (a, s))
       (post := fun x => post x.fst x.snd) (epost := epost))
@@ -289,7 +291,7 @@ theorem wp_monadLift_ReaderT_apply_eq (x : m α) :
       fun r => wp x (fun a => post a r) epost := by
   rfl
 
-theorem le_wp_monadLift_ExceptT_apply (x : m α) (post : α → Pred)
+theorem le_wp_monadLift_ExceptT_apply [LawfulMonad m] (x : m α) (post : α → Pred)
     (epost : EPost.Cons (ε → Pred) EPred) :
     wp x post epost.tail ⊑
       wp (MonadLift.monadLift x : ExceptT ε m α) post epost := by
@@ -316,14 +318,12 @@ theorem le_wp_monadLift_OptionT_apply (x : m α) :
     wp (MonadLift.monadLift x : OptionT m α) post epost := by
   simp only [wp, MonadLift.monadLift, OptionT.mk, OptionT.lift]
   apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_bind
-  apply WPMonad.wp_consequence (m := m); intro a
+  apply WP.wp_consequence; intro a
   apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_pure
   simp [EPost.Cons.pushOption]; exact PartialOrder.rel_refl
 
-omit [Assertion EPred] [WPMonad m Pred EPred] in
 @[simp]
-theorem wp_lift_OptionT_apply_eq
-    [Assertion (EPost.Cons Pred EPred)] [WPMonad (OptionT m) Pred (EPost.Cons Pred EPred)] (x : m α) :
+theorem wp_lift_OptionT_apply_eq (x : m α) :
     wp (OptionT.lift x : OptionT m α) post epost =
       wp (MonadLift.monadLift x : OptionT m α) post epost := rfl
 
@@ -378,26 +378,26 @@ theorem wp_withTheReader_ReaderT_apply_eq (f : ρ → ρ) (x : ReaderT ρ m α) 
 
 /-! ## Transformer adapt lemmas -/
 
-theorem le_wp_adapt_ExceptT_apply (f : ε → ε') (x : ExceptT ε m α) :
+theorem le_wp_adapt_ExceptT_apply [LawfulMonad m] (f : ε → ε') (x : ExceptT ε m α) :
     wp x post ⟨fun e => epost.head (f e), epost.tail⟩ ⊑
       wp (ExceptT.adapt f x : ExceptT ε' m α) post epost := by
   simp only [wp, ExceptT.adapt, ExceptT.mk]
   apply PartialOrder.rel_trans; rotate_left
   · exact WPMonad.wp_map (m := m) (Except.mapError f) x _ _
-  · apply WPMonad.wp_consequence (m := m); intro r; cases r <;> exact PartialOrder.rel_refl
+  · apply WP.wp_consequence (x := x.run); intro r; cases r <;> exact PartialOrder.rel_refl
 
 @[simp]
 theorem wp_adaptExcept_EStateM_apply_eq (f : ε → ε') (x : EStateM ε σ α) :
     wp (EStateM.adaptExcept f x : EStateM ε' σ α) post epost =
       wp x post (fun e => epost (f e)) := by
   funext s
-  simp only [wp, WPMonad.wpTrans, EStateM.adaptExcept]
+  simp only [wp, WP.wpTrans, EStateM.adaptExcept]
   cases (x s) <;> simp
 
 /-! ## MonadControl simp lemmas -/
 
 @[simp]
-theorem wp_liftWith_StateT_apply_eq
+theorem wp_liftWith_StateT_apply_eq [LawfulMonad m]
     (f : (∀{β}, StateT σ m β → m (β × σ)) → m α) :
     wp (MonadControl.liftWith (m:=m) f : StateT σ m α) post epost s =
       wp ((fun a => (a, s)) <$> f (fun x => x.run s)) (fun ⟨a, s⟩ => post a s) epost := by
@@ -438,7 +438,7 @@ theorem le_wp_restoreM_StateT_apply (x : m (α × σ)) :
   simp only [MonadControl.restoreM]
   apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_bind; simp only [liftM, monadLift]
   apply PartialOrder.rel_trans; rotate_left; apply le_wp_monadLift_StateT_apply
-  intro s; apply WPMonad.wp_consequence; intro s'; simp only
+  intro s; apply WP.wp_consequence (x := x); intro s'; simp only
   apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_bind
   simp [set, StateT.set, pure, StateT.pure]
   apply PartialOrder.rel_trans
@@ -447,7 +447,7 @@ theorem le_wp_restoreM_StateT_apply (x : m (α × σ)) :
         (post := fun x => post x.fst x.snd) (epost := epost))
   · simpa using
       (WPMonad.wp_pure (m := m) (x := (PUnit.unit, s'.snd))
-        (post := fun x => wp (pure (s'.fst, x.snd)) (fun x => post x.fst x.snd) epost)
+        (post := fun (x : PUnit × σ) => wp (pure (s'.fst, x.snd)) (fun (x : α × σ) => post x.fst x.snd) epost)
         (epost := epost))
 
 @[simp]
@@ -472,14 +472,14 @@ theorem wp_restoreM_OptionT_apply_eq (x : m (Option α)) :
 end
 
 @[simp]
-theorem wp_controlAt_apply_eq [Bind n] [Monad m] [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred] [MonadControlT m n]
+theorem wp_controlAt_apply_eq [Bind n] [Monad m] [Monad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [MonadControlT m n]
     (f : (∀{β}, n β → m (stM m n β)) → m (stM m n α)) :
     wp (controlAt m f : n α) post epost =
       wp (liftWith f >>= restoreM : n α) post epost := by
   rfl
 
 @[simp]
-theorem wp_control_apply_eq [Bind n] [Monad m] [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred] [MonadControlT m n]
+theorem wp_control_apply_eq [Bind n] [Monad m] [Monad n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred] [MonadControlT m n]
     (f : (∀{β}, n β → m (stM m n β)) → m (stM m n α)) :
     wp (control f : n α) post epost =
       wp (liftWith f >>= restoreM : n α) post epost := by
@@ -516,7 +516,7 @@ end
 /-! ## Transitive lift/map/control simp lemmas -/
 
 section
-variable {m n : Type u → Type v} {o : Type u → Type v} [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
+variable {m n : Type u → Type v} {o : Type u → Type v} [Monad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred]
 
 @[simp]
 theorem wp_monadLift_trans_apply_eq [MonadLift n o] [MonadLiftT m n] (x : m α) :
@@ -551,7 +551,7 @@ end
 /-! ## Lifted state/reader operations -/
 
 section
-variable {m n : Type u → Type v} [Monad n] [MonadLift m n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
+variable {m n : Type u → Type v} [Monad n] [MonadLift m n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred]
 
 @[simp]
 theorem wp_get_MonadStateOf_lift_apply_eq [MonadStateOf σ m] :
@@ -663,7 +663,7 @@ variable {m : Type u → Type v} in
 section
 variable {m : Type u → Type v} [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
 
-theorem le_wp_orElse_ExceptT_apply (x : ExceptT ε m α)
+theorem le_wp_orElse_ExceptT_apply [LawfulMonad m] (x : ExceptT ε m α)
     (h : Unit → ExceptT ε m α) :
     wp x post ⟨fun _ => wp (h ()) post epost, epost.tail⟩ ⊑
       wp (OrElse.orElse x h : ExceptT ε m α) post epost := by
@@ -676,7 +676,7 @@ theorem le_wp_orElse_OptionT_apply (x : OptionT m α)
     wp (OrElse.orElse x h : OptionT m α) post epost := by
   simp only [wp, OrElse.orElse]
   apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_bind
-  apply WPMonad.wp_consequence (m := m); intro o; cases o with
+  apply WP.wp_consequence (x := x.run); intro o; cases o with
   | some a =>
     apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_pure
     simp [EPost.Cons.pushOption]; exact PartialOrder.rel_refl
@@ -689,7 +689,7 @@ theorem wp_orElse_Option_apply_eq (x : Option α) (h : Unit → Option α) :
   ∀ post (epost : Prop),
   wp (OrElse.orElse x h : Option α) post epost =
     wp x post (wp (h ()) post epost) := by
-  simp only [wp, WPMonad.wpTrans, OrElse.orElse, Option.orElse]
+  simp only [wp, WP.wpTrans, OrElse.orElse, Option.orElse]
   cases x <;> intro _ _ <;> rfl
 
 @[simp]
@@ -697,7 +697,7 @@ theorem wp_orElse_EStateM_apply_eq (x : EStateM ε σ α) (h : Unit → EStateM 
     wp (OrElse.orElse x h : EStateM ε σ α) post epost =
       fun s => wp x post (fun _ s' => wp (h ()) post epost s') s := by
   funext s
-  simp only [wp, WPMonad.wpTrans, OrElse.orElse, EStateM.orElse]
+  simp only [wp, WP.wpTrans, OrElse.orElse, EStateM.orElse]
   cases x s <;> simp; rfl
 
 end Std.Internal.Do.WPMonad

--- a/src/Std/Internal/Do/WP/Lemmas.lean
+++ b/src/Std/Internal/Do/WP/Lemmas.lean
@@ -180,7 +180,7 @@ omit [Monad m] in
   simp only [tryCatch, tryCatchThe, MonadExceptOf.tryCatch, ExceptT.tryCatch, ExceptT.run_mk]
   rfl
 
-theorem le_wp_tryCatch_ExceptT_apply [LawfulMonad m] (x : ExceptT ε m α)
+theorem le_wp_tryCatch_ExceptT_apply (x : ExceptT ε m α)
     (h : ε → ExceptT ε m α) :
     wp x post ⟨fun e => wp (h e) post epost, epost.tail⟩ ⊑
       wp (MonadExceptOf.tryCatch x h : ExceptT ε m α) post epost := by
@@ -291,7 +291,7 @@ theorem wp_monadLift_ReaderT_apply_eq (x : m α) :
       fun r => wp x (fun a => post a r) epost := by
   rfl
 
-theorem le_wp_monadLift_ExceptT_apply [LawfulMonad m] (x : m α) (post : α → Pred)
+theorem le_wp_monadLift_ExceptT_apply (x : m α) (post : α → Pred)
     (epost : EPost.Cons (ε → Pred) EPred) :
     wp x post epost.tail ⊑
       wp (MonadLift.monadLift x : ExceptT ε m α) post epost := by
@@ -378,7 +378,7 @@ theorem wp_withTheReader_ReaderT_apply_eq (f : ρ → ρ) (x : ReaderT ρ m α) 
 
 /-! ## Transformer adapt lemmas -/
 
-theorem le_wp_adapt_ExceptT_apply [LawfulMonad m] (f : ε → ε') (x : ExceptT ε m α) :
+theorem le_wp_adapt_ExceptT_apply (f : ε → ε') (x : ExceptT ε m α) :
     wp x post ⟨fun e => epost.head (f e), epost.tail⟩ ⊑
       wp (ExceptT.adapt f x : ExceptT ε' m α) post epost := by
   simp only [wp, ExceptT.adapt, ExceptT.mk]
@@ -397,7 +397,7 @@ theorem wp_adaptExcept_EStateM_apply_eq (f : ε → ε') (x : EStateM ε σ α) 
 /-! ## MonadControl simp lemmas -/
 
 @[simp]
-theorem wp_liftWith_StateT_apply_eq [LawfulMonad m]
+theorem wp_liftWith_StateT_apply_eq
     (f : (∀{β}, StateT σ m β → m (β × σ)) → m α) :
     wp (MonadControl.liftWith (m:=m) f : StateT σ m α) post epost s =
       wp ((fun a => (a, s)) <$> f (fun x => x.run s)) (fun ⟨a, s⟩ => post a s) epost := by
@@ -663,7 +663,7 @@ variable {m : Type u → Type v} in
 section
 variable {m : Type u → Type v} [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
 
-theorem le_wp_orElse_ExceptT_apply [LawfulMonad m] (x : ExceptT ε m α)
+theorem le_wp_orElse_ExceptT_apply (x : ExceptT ε m α)
     (h : Unit → ExceptT ε m α) :
     wp x post ⟨fun _ => wp (h ()) post epost, epost.tail⟩ ⊑
       wp (OrElse.orElse x h : ExceptT ε m α) post epost := by

--- a/src/Std/Internal/Do/WP/Lemmas.lean
+++ b/src/Std/Internal/Do/WP/Lemmas.lean
@@ -10,8 +10,6 @@ public import Std.Internal.Do.WP.Basic
 @[expose] public section
 
 set_option linter.missingDocs true
--- The `WP`/`WPMonad` split means each lemma uses only the subset of the section variables it needs.
-set_option linter.unusedSectionVars false
 
 /-!
 # Simp lemmas for weakest preconditions
@@ -516,7 +514,7 @@ end
 /-! ## Transitive lift/map/control simp lemmas -/
 
 section
-variable {m n : Type u → Type v} {o : Type u → Type v} [Monad o] [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred]
+variable {m n : Type u → Type v} {o : Type u → Type v} [Assertion Pred] [Assertion EPred] [∀ α, WP (o α) α Pred EPred]
 
 @[simp]
 theorem wp_monadLift_trans_apply_eq [MonadLift n o] [MonadLiftT m n] (x : m α) :
@@ -551,7 +549,7 @@ end
 /-! ## Lifted state/reader operations -/
 
 section
-variable {m n : Type u → Type v} [Monad n] [MonadLift m n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred]
+variable {m n : Type u → Type v} [MonadLift m n] [Assertion Pred] [Assertion EPred] [∀ α, WP (n α) α Pred EPred]
 
 @[simp]
 theorem wp_get_MonadStateOf_lift_apply_eq [MonadStateOf σ m] :

--- a/src/Std/Internal/Do/WP/Lemmas.lean
+++ b/src/Std/Internal/Do/WP/Lemmas.lean
@@ -17,7 +17,7 @@ set_option linter.missingDocs true
 This module provides simp lemmas for simplifying weakest precondition expressions.
 Unlike `Std.Do`, we use direct function application `wp x post epost` without notation.
 
-Some lemmas prove only one direction (`⊑`) instead of equality because our `wp_bind` axiom
+Some lemmas prove only one direction (`⊑`) instead of equality because our `bind_le_wp_bind` axiom
 only provides one direction.
 -/
 
@@ -37,7 +37,7 @@ theorem le_wp_read_ReaderT_apply
     (fun r => post r r) ⊑ wp (MonadReaderOf.read : ReaderT ρ m ρ) post epost := by
   intro r
   simpa [MonadReaderOf.read] using
-    (WPMonad.wp_pure (m := m) (x := r) (post := fun a => post a r) (epost := epost))
+    (WPMonad.pure_le_wp_pure (m := m) (x := r) (post := fun a => post a r) (epost := epost))
 
 @[simp]
 theorem wp_adapt_ReaderT_apply_eq (f : ρ → ρ') (x : ReaderT ρ' m α) :
@@ -51,7 +51,7 @@ theorem le_wp_get_StateT_apply
     (fun s => post s s) ⊑ wp (MonadStateOf.get : StateT σ m σ) post epost := by
   intro s
   simpa [MonadStateOf.get] using!
-    (WPMonad.wp_pure (m := m) (x := (s, s))
+    (WPMonad.pure_le_wp_pure (m := m) (x := (s, s))
       (post := fun x => post x.fst x.snd) (epost := epost))
 
 theorem le_wp_set_StateT_apply (x : σ)
@@ -59,7 +59,7 @@ theorem le_wp_set_StateT_apply (x : σ)
     (fun _ => post ⟨⟩ x) ⊑ wp (MonadStateOf.set x : StateT σ m PUnit) post epost := by
   intro s
   simpa [MonadStateOf.set] using!
-    (WPMonad.wp_pure (m := m) (x := (PUnit.unit, x))
+    (WPMonad.pure_le_wp_pure (m := m) (x := (PUnit.unit, x))
       (post := fun x => post x.fst x.snd) (epost := epost))
 
 theorem le_wp_modifyGet_StateT_apply (f : σ → α × σ)
@@ -67,7 +67,7 @@ theorem le_wp_modifyGet_StateT_apply (f : σ → α × σ)
     (fun s => post (f s).1 (f s).2) ⊑ wp (MonadStateOf.modifyGet f : StateT σ m α) post epost := by
   intro s
   simpa [MonadStateOf.modifyGet] using!
-    (WPMonad.wp_pure (m := m) (x := f s)
+    (WPMonad.pure_le_wp_pure (m := m) (x := f s)
       (post := fun x => post x.fst x.snd) (epost := epost))
 
 theorem wp_get_EStateM_apply_eq :
@@ -123,7 +123,7 @@ theorem wp_throw_Except_apply_eq (e : ε) :
 theorem le_wp_throw_ExceptT_apply (err : ε) :
     epost.head err ⊑ wp (MonadExceptOf.throw err : ExceptT ε m α) post epost := by
   simpa [MonadExceptOf.throw, EPost.Cons.pushExcept] using
-    (WPMonad.wp_pure (m := m) (x := Except.error err)
+    (WPMonad.pure_le_wp_pure (m := m) (x := Except.error err)
       (post := epost.pushExcept post) (epost := epost.tail))
 
 @[simp]
@@ -142,7 +142,7 @@ theorem le_wp_throw_OptionT_apply (err : PUnit) :
   epost.head ⊑ wp (MonadExceptOf.throw err : OptionT m α) post epost := by
   show epost.head ⊑ wp (pure none : m (Option α)) (epost.pushOption post) epost.tail
   simpa [MonadExceptOf.throw, EPost.Cons.pushOption] using
-    (WPMonad.wp_pure (m := m) (x := none)
+    (WPMonad.pure_le_wp_pure (m := m) (x := none)
       (post := epost.pushOption post) (epost := epost.tail))
 
 @[simp]
@@ -184,11 +184,11 @@ theorem le_wp_tryCatch_ExceptT_apply (x : ExceptT ε m α)
       wp (MonadExceptOf.tryCatch x h : ExceptT ε m α) post epost := by
   change _ ⊑ wp (tryCatch x h : ExceptT ε m α) _ _
   simp only [ExceptT.wp_apply_eq, ExceptT.run_tryCatch]
-  apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_bind
+  apply PartialOrder.rel_trans; rotate_left; apply WPMonad.bind_le_wp_bind
   apply WP.wp_consequence; intro r; cases r with
   | ok a =>
     simp; apply PartialOrder.rel_trans; rotate_left;
-    apply WPMonad.wp_pure; simp; rfl
+    apply WPMonad.pure_le_wp_pure; simp; rfl
   | error _ => exact PartialOrder.rel_refl
 
 @[simp]
@@ -213,10 +213,10 @@ theorem le_wp_tryCatch_OptionT_apply (x : OptionT m α)
   wp x post ⟨wp (h ⟨⟩) post epost, epost.tail⟩ ⊑
     wp (MonadExceptOf.tryCatch x h : OptionT m α) post epost := by
   simp only [wp, MonadExceptOf.tryCatch, OptionT.tryCatch, OptionT.mk]
-  apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_bind
+  apply PartialOrder.rel_trans; rotate_left; apply WPMonad.bind_le_wp_bind
   apply WP.wp_consequence (x := x.run); intro o; cases o with
   | some a =>
-    apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_pure
+    apply PartialOrder.rel_trans; rotate_left; apply WPMonad.pure_le_wp_pure
     simp [EPost.Cons.pushOption]; exact PartialOrder.rel_refl
   | none => exact PartialOrder.rel_refl
 
@@ -277,10 +277,10 @@ theorem le_wp_monadLift_StateT_apply (x : m α) (post : α → σ → Pred) :
       wp (MonadLift.monadLift x : StateT σ m α) post epost := by
   intro s
   simp only [wp, MonadLift.monadLift]
-  apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_bind
+  apply PartialOrder.rel_trans; rotate_left; apply WPMonad.bind_le_wp_bind
   apply WP.wp_consequence; intro a
   simpa using
-    (WPMonad.wp_pure (m := m) (x := (a, s))
+    (WPMonad.pure_le_wp_pure (m := m) (x := (a, s))
       (post := fun x => post x.fst x.snd) (epost := epost))
 
 @[simp]
@@ -295,7 +295,7 @@ theorem le_wp_monadLift_ExceptT_apply (x : m α) (post : α → Pred)
       wp (MonadLift.monadLift x : ExceptT ε m α) post epost := by
   simp only [wp, MonadLift.monadLift, ExceptT.lift, ExceptT.mk]
   apply PartialOrder.rel_trans; rotate_left
-  · exact WPMonad.wp_map (m := m) Except.ok x _ _
+  · exact WPMonad.map_le_wp_map (m := m) Except.ok x _ _
   · exact PartialOrder.rel_refl
 
 @[simp]
@@ -315,9 +315,9 @@ theorem le_wp_monadLift_OptionT_apply (x : m α) :
   wp x post epost.tail ⊑
     wp (MonadLift.monadLift x : OptionT m α) post epost := by
   simp only [wp, MonadLift.monadLift, OptionT.mk, OptionT.lift]
-  apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_bind
+  apply PartialOrder.rel_trans; rotate_left; apply WPMonad.bind_le_wp_bind
   apply WP.wp_consequence; intro a
-  apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_pure
+  apply PartialOrder.rel_trans; rotate_left; apply WPMonad.pure_le_wp_pure
   simp [EPost.Cons.pushOption]; exact PartialOrder.rel_refl
 
 @[simp]
@@ -381,7 +381,7 @@ theorem le_wp_adapt_ExceptT_apply (f : ε → ε') (x : ExceptT ε m α) :
       wp (ExceptT.adapt f x : ExceptT ε' m α) post epost := by
   simp only [wp, ExceptT.adapt, ExceptT.mk]
   apply PartialOrder.rel_trans; rotate_left
-  · exact WPMonad.wp_map (m := m) (Except.mapError f) x _ _
+  · exact WPMonad.map_le_wp_map (m := m) (Except.mapError f) x _ _
   · apply WP.wp_consequence (x := x.run); intro r; cases r <;> exact PartialOrder.rel_refl
 
 @[simp]
@@ -434,17 +434,17 @@ theorem le_wp_restoreM_StateT_apply (x : m (α × σ)) :
     (fun _ => wp x (fun (a, s) => post a s) epost) ⊑
       wp (MonadControl.restoreM (m:=m) x : StateT σ m α) post epost := by
   simp only [MonadControl.restoreM]
-  apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_bind; simp only [liftM, monadLift]
+  apply PartialOrder.rel_trans; rotate_left; apply WPMonad.bind_le_wp_bind; simp only [liftM, monadLift]
   apply PartialOrder.rel_trans; rotate_left; apply le_wp_monadLift_StateT_apply
   intro s; apply WP.wp_consequence (x := x); intro s'; simp only
-  apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_bind
+  apply PartialOrder.rel_trans; rotate_left; apply WPMonad.bind_le_wp_bind
   simp [set, StateT.set, pure, StateT.pure]
   apply PartialOrder.rel_trans
   · simpa using
-      (WPMonad.wp_pure (m := m) (x := (s'.fst, s'.snd))
+      (WPMonad.pure_le_wp_pure (m := m) (x := (s'.fst, s'.snd))
         (post := fun x => post x.fst x.snd) (epost := epost))
   · simpa using
-      (WPMonad.wp_pure (m := m) (x := (PUnit.unit, s'.snd))
+      (WPMonad.pure_le_wp_pure (m := m) (x := (PUnit.unit, s'.snd))
         (post := fun (x : PUnit × σ) => wp (pure (s'.fst, x.snd)) (fun (x : α × σ) => post x.fst x.snd) epost)
         (epost := epost))
 
@@ -673,10 +673,10 @@ theorem le_wp_orElse_OptionT_apply (x : OptionT m α)
   wp x post ⟨wp (h ()) post epost, epost.tail⟩ ⊑
     wp (OrElse.orElse x h : OptionT m α) post epost := by
   simp only [wp, OrElse.orElse]
-  apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_bind
+  apply PartialOrder.rel_trans; rotate_left; apply WPMonad.bind_le_wp_bind
   apply WP.wp_consequence (x := x.run); intro o; cases o with
   | some a =>
-    apply PartialOrder.rel_trans; rotate_left; apply WPMonad.wp_pure
+    apply PartialOrder.rel_trans; rotate_left; apply WPMonad.pure_le_wp_pure
     simp [EPost.Cons.pushOption]; exact PartialOrder.rel_refl
   | none => exact PartialOrder.rel_refl
 

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -23,6 +23,8 @@ options get_default_options() {
 
     opts = opts.update({"pp", "rawOnError"}, true);
 
+    // trigger stage0 update: `@[spec]` registers under the new `Triple`/`wp` arity
+
 #endif
     return opts;
 }

--- a/tests/bench/mvcgen/sym/test_do_logic.lean
+++ b/tests/bench/mvcgen/sym/test_do_logic.lean
@@ -202,9 +202,9 @@ theorem unfold_to_expose_match_spec :
 
 theorem test_match_splitting {mo : Option Nat} (h : mo = some 4) :
     ⦃ fun _ => True ⦄
-    ((match mo with
-      | some n => (set n : StateM Nat PUnit)
-      | none => set 0) : StateM Nat PUnit)
+    (match mo with
+     | some n => (set n : StateM Nat PUnit)
+     | none => set 0)
     ⦃ fun _ s => s = 4 ⦄ := by
   mvcgen' <;> simp_all
 
@@ -459,22 +459,22 @@ theorem forIn_eq_sum (xs : Array Nat) {m} [Monad m] [Assertion Pred] [Assertion 
 
 theorem forIn_map_eq_sum_add_size' (xs : Array Nat) {m} [Monad m] [Assertion Pred] [Assertion EPred]
     [WPMonad m Pred EPred] :
-    Triple (Prog := m _) (do
+    ⦃ ⊤ ⦄ (m := m) (do
       let mut sum : Nat := 0
       for n in (xs.iterM Id).map (· + 1) do
         sum := sum + n
-      return sum) ⊤ (fun r => ⌜r = xs.sum + xs.size⌝) ⊥ := by
+      return sum) ⦃ fun r => ⌜r = xs.sum + xs.size⌝ ⦄ := by
   mvcgen'
   case inv1 => exact fun cur n => ⌜n = cur.prefix.sum + cur.prefix.length⌝
   all_goals grind
 
 theorem forIn_map_eq_sum_add_size (xs : Array Nat) {m} [Monad m] [Assertion Pred] [Assertion EPred]
     [WPMonad m Pred EPred] :
-    Triple (Prog := m _) (do
+    ⦃ ⊤ ⦄ (m := m) (do
       let mut sum : Nat := 0
       for n in (xs.iterM Id).map (· + 1) do
         sum := sum + n
-      return sum) ⊤ (fun r => ⌜r = xs.sum + xs.size⌝) ⊥ := by
+      return sum) ⦃ fun r => ⌜r = xs.sum + xs.size⌝ ⦄ := by
   mvcgen'
   case inv1 => exact fun cur n => ⌜n = cur.prefix.sum + cur.prefix.length⌝
   all_goals grind
@@ -482,31 +482,29 @@ theorem forIn_map_eq_sum_add_size (xs : Array Nat) {m} [Monad m] [Assertion Pred
 
 theorem forIn_mapM_eq_sum_add_size (xs : Array Nat) {m} [Monad m] [MonadAttach m]
     [LawfulMonad m] [WeaklyLawfulMonadAttach m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
-    Triple (Prog := m _) (do
+    ⦃ ⊤ ⦄ (m := m) (do
       let mut sum : Nat := 0
       for n in (xs.iterM Id).mapM (pure (f := m) <| · + 1) do
         sum := sum + n
-      return sum) ⊤ (fun r => ⌜r = xs.sum + xs.size⌝) ⊥ := by
+      return sum) ⦃ fun r => ⌜r = xs.sum + xs.size⌝ ⦄ := by
   mvcgen'
   case inv1 => exact fun cur n => ⌜n = cur.prefix.sum + cur.prefix.length⌝
   all_goals grind
 
 theorem forIn_filterMapM_eq_sum_add_size (xs : Array Nat) {m}
     [Monad m] [LawfulMonad m] [MonadAttach m] [WeaklyLawfulMonadAttach m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
-    Triple (Prog := m _) (do
+    ⦃ ⊤ ⦄ (m := m) (do
       let mut sum : Nat := 0
       for n in (xs.iterM Id).filterMapM (pure (f := m) <| some <| · + 1) do
         sum := sum + n
-      return sum) ⊤ (fun r => ⌜r = xs.sum + xs.size⌝) ⊥ := by
+      return sum) ⦃ fun r => ⌜r = xs.sum + xs.size⌝ ⦄ := by
   mvcgen'
   case inv1 => exact fun cur n => ⌜n = cur.prefix.sum + cur.prefix.length⌝
   all_goals grind
 
 theorem foldM_eq_sum (xs : Array Nat) {m} [Monad m] [LawfulMonad m]
     [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
-    Triple (Prog := m _)
-      (xs.iter.foldM (m := m) (init := 0) (pure <| · + ·))
-      ⊤ (fun r => ⌜r = xs.sum⌝) ⊥ := by
+    ⦃ ⊤ ⦄ (xs.iter.foldM (m := m) (init := 0) (pure <| · + ·)) ⦃ fun r => ⌜r = xs.sum⌝ ⦄ := by
   mvcgen'
   case inv1 => exact fun cur n => ⌜n = cur.prefix.sum⌝
   all_goals grind
@@ -623,10 +621,10 @@ h✝ : (UInt64.toBitVec 0).uaddOverflow (a <<< UInt64.ofNat (Int32.toInt 32).toN
 #guard_msgs in
 example (a : UInt64) :
     ⦃True⦄
-      (do
+      do
         let a ← MyShl.shl a (32: Int32)
         let a ← MyAddU.add (0 : UInt64) a
-        pure a : RustM UInt64)
+        pure a
     ⦃fun _ => True⦄ := by
   mvcgen' (errorOnMissingSpec := false) [MyShl.shl, MyAddU.add]
 

--- a/tests/bench/mvcgen/sym/test_do_logic.lean
+++ b/tests/bench/mvcgen/sym/test_do_logic.lean
@@ -142,13 +142,13 @@ theorem fib_impl_vcs
   case vc4 => apply_rules [loop_post]
 
 @[spec]
-theorem mkFreshNat_spec [Monad m] [LawfulMonad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+theorem mkFreshNat_spec [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
     ⦃ fun s => ⌜s.1 = n ∧ s.2 = o⌝ ⦄
     (mkFreshNat : StateT AppState m Nat)
     ⦃ fun r s => ⌜r = n ∧ s.1 = n + 1 ∧ s.2 = o⌝ ⦄ := by
   mvcgen' [mkFreshNat] <;> simp_all
 
-theorem erase_unfold [Monad m] [LawfulMonad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+theorem erase_unfold [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
   ⦃fun s => ⌜s.1 = n ∧ s.2 = o⌝ ⦄
   (mkFreshNat : StateT AppState m Nat)
   ⦃fun r s => ⌜r = n ∧ s.1 = n + 1 ∧ s.2 = o⌝ ⦄ := by
@@ -158,7 +158,7 @@ theorem erase_unfold [Monad m] [LawfulMonad m] [Assertion Pred] [Assertion EPred
   fail_if_success done
   admit
 
-theorem add_unfold [Monad m] [LawfulMonad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+theorem add_unfold [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
     ⦃ fun s => ⌜s.1 = n ∧ s.2 = o⌝ ⦄
     (mkFreshNat : StateT AppState m Nat)
     ⦃ fun r s => ⌜r = n ∧ s.1 = n + 1 ∧ s.2 = o⌝ ⦄ := by
@@ -255,7 +255,7 @@ namespace HimpSplit
 -- A `⇨` (Heyting implication) in the postcondition exercises the `himp_complete` split, whose
 -- subgoal carries a `⊓ ⊤` precondition that `meet_top_le_of_le` cancels. The abstract `Pred` keeps
 -- `⇨` from collapsing to `→`.
-theorem himp_post {m} [Monad m] [LawfulMonad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+theorem himp_post {m} [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
     ⦃ ⊤ ⦄ (pure 4 : m Nat) ⦃ fun r => ⌜r = 4⌝ ⇨ ⌜r > 0⌝ ⦄ := by
   mvcgen'
   all_goals grind
@@ -445,7 +445,7 @@ variable {m} [Monad m]
 open Std Std.Iterators
 
 theorem forIn_eq_sum (xs : Array Nat) {m} [Monad m] [Assertion Pred] [Assertion EPred]
-    [LawfulMonad m] [WPMonad m Pred EPred] :
+    [WPMonad m Pred EPred] :
     ⦃ ⊤ ⦄
     (do
       let mut sum : Nat := 0
@@ -458,7 +458,7 @@ theorem forIn_eq_sum (xs : Array Nat) {m} [Monad m] [Assertion Pred] [Assertion 
   all_goals grind
 
 theorem forIn_map_eq_sum_add_size' (xs : Array Nat) {m} [Monad m] [Assertion Pred] [Assertion EPred]
-    [LawfulMonad m] [WPMonad m Pred EPred] :
+    [WPMonad m Pred EPred] :
     Triple (Prog := m _) (do
       let mut sum : Nat := 0
       for n in (xs.iterM Id).map (· + 1) do
@@ -469,7 +469,7 @@ theorem forIn_map_eq_sum_add_size' (xs : Array Nat) {m} [Monad m] [Assertion Pre
   all_goals grind
 
 theorem forIn_map_eq_sum_add_size (xs : Array Nat) {m} [Monad m] [Assertion Pred] [Assertion EPred]
-    [LawfulMonad m] [WPMonad m Pred EPred] :
+    [WPMonad m Pred EPred] :
     Triple (Prog := m _) (do
       let mut sum : Nat := 0
       for n in (xs.iterM Id).map (· + 1) do

--- a/tests/bench/mvcgen/sym/test_do_logic.lean
+++ b/tests/bench/mvcgen/sym/test_do_logic.lean
@@ -142,13 +142,13 @@ theorem fib_impl_vcs
   case vc4 => apply_rules [loop_post]
 
 @[spec]
-theorem mkFreshNat_spec [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+theorem mkFreshNat_spec [Monad m] [LawfulMonad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
     ⦃ fun s => ⌜s.1 = n ∧ s.2 = o⌝ ⦄
     (mkFreshNat : StateT AppState m Nat)
     ⦃ fun r s => ⌜r = n ∧ s.1 = n + 1 ∧ s.2 = o⌝ ⦄ := by
   mvcgen' [mkFreshNat] <;> simp_all
 
-theorem erase_unfold [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+theorem erase_unfold [Monad m] [LawfulMonad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
   ⦃fun s => ⌜s.1 = n ∧ s.2 = o⌝ ⦄
   (mkFreshNat : StateT AppState m Nat)
   ⦃fun r s => ⌜r = n ∧ s.1 = n + 1 ∧ s.2 = o⌝ ⦄ := by
@@ -158,7 +158,7 @@ theorem erase_unfold [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pre
   fail_if_success done
   admit
 
-theorem add_unfold [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+theorem add_unfold [Monad m] [LawfulMonad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
     ⦃ fun s => ⌜s.1 = n ∧ s.2 = o⌝ ⦄
     (mkFreshNat : StateT AppState m Nat)
     ⦃ fun r s => ⌜r = n ∧ s.1 = n + 1 ∧ s.2 = o⌝ ⦄ := by
@@ -202,9 +202,9 @@ theorem unfold_to_expose_match_spec :
 
 theorem test_match_splitting {mo : Option Nat} (h : mo = some 4) :
     ⦃ fun _ => True ⦄
-    (match mo with
-     | some n => (set n : StateM Nat PUnit)
-     | none => set 0)
+    ((match mo with
+      | some n => (set n : StateM Nat PUnit)
+      | none => set 0) : StateM Nat PUnit)
     ⦃ fun _ s => s = 4 ⦄ := by
   mvcgen' <;> simp_all
 
@@ -255,7 +255,7 @@ namespace HimpSplit
 -- A `⇨` (Heyting implication) in the postcondition exercises the `himp_complete` split, whose
 -- subgoal carries a `⊓ ⊤` precondition that `meet_top_le_of_le` cancels. The abstract `Pred` keeps
 -- `⇨` from collapsing to `→`.
-theorem himp_post {m} [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+theorem himp_post {m} [Monad m] [LawfulMonad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
     ⦃ ⊤ ⦄ (pure 4 : m Nat) ⦃ fun r => ⌜r = 4⌝ ⇨ ⌜r > 0⌝ ⦄ := by
   mvcgen'
   all_goals grind
@@ -445,7 +445,7 @@ variable {m} [Monad m]
 open Std Std.Iterators
 
 theorem forIn_eq_sum (xs : Array Nat) {m} [Monad m] [Assertion Pred] [Assertion EPred]
-    [WPMonad m Pred EPred] :
+    [LawfulMonad m] [WPMonad m Pred EPred] :
     ⦃ ⊤ ⦄
     (do
       let mut sum : Nat := 0
@@ -458,23 +458,23 @@ theorem forIn_eq_sum (xs : Array Nat) {m} [Monad m] [Assertion Pred] [Assertion 
   all_goals grind
 
 theorem forIn_map_eq_sum_add_size' (xs : Array Nat) {m} [Monad m] [Assertion Pred] [Assertion EPred]
-    [WPMonad m Pred EPred] :
-    ⦃ ⊤ ⦄ ((do
+    [LawfulMonad m] [WPMonad m Pred EPred] :
+    Triple (Prog := m _) (do
       let mut sum : Nat := 0
       for n in (xs.iterM Id).map (· + 1) do
         sum := sum + n
-      return sum) : m _) ⦃ fun r => ⌜r = xs.sum + xs.size⌝ ⦄ := by
+      return sum) ⊤ (fun r => ⌜r = xs.sum + xs.size⌝) ⊥ := by
   mvcgen'
   case inv1 => exact fun cur n => ⌜n = cur.prefix.sum + cur.prefix.length⌝
   all_goals grind
 
 theorem forIn_map_eq_sum_add_size (xs : Array Nat) {m} [Monad m] [Assertion Pred] [Assertion EPred]
-    [WPMonad m Pred EPred] :
-    ⦃ ⊤ ⦄ ((do
+    [LawfulMonad m] [WPMonad m Pred EPred] :
+    Triple (Prog := m _) (do
       let mut sum : Nat := 0
       for n in (xs.iterM Id).map (· + 1) do
         sum := sum + n
-      return sum) : m _) ⦃ fun r => ⌜r = xs.sum + xs.size⌝ ⦄ := by
+      return sum) ⊤ (fun r => ⌜r = xs.sum + xs.size⌝) ⊥ := by
   mvcgen'
   case inv1 => exact fun cur n => ⌜n = cur.prefix.sum + cur.prefix.length⌝
   all_goals grind
@@ -482,31 +482,31 @@ theorem forIn_map_eq_sum_add_size (xs : Array Nat) {m} [Monad m] [Assertion Pred
 
 theorem forIn_mapM_eq_sum_add_size (xs : Array Nat) {m} [Monad m] [MonadAttach m]
     [LawfulMonad m] [WeaklyLawfulMonadAttach m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
-    ⦃ ⊤ ⦄ ((do
+    Triple (Prog := m _) (do
       let mut sum : Nat := 0
       for n in (xs.iterM Id).mapM (pure (f := m) <| · + 1) do
         sum := sum + n
-      return sum) : m _) ⦃ fun r => ⌜r = xs.sum + xs.size⌝ ⦄ := by
+      return sum) ⊤ (fun r => ⌜r = xs.sum + xs.size⌝) ⊥ := by
   mvcgen'
   case inv1 => exact fun cur n => ⌜n = cur.prefix.sum + cur.prefix.length⌝
   all_goals grind
 
 theorem forIn_filterMapM_eq_sum_add_size (xs : Array Nat) {m}
     [Monad m] [LawfulMonad m] [MonadAttach m] [WeaklyLawfulMonadAttach m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
-    ⦃ ⊤ ⦄ ((do
+    Triple (Prog := m _) (do
       let mut sum : Nat := 0
       for n in (xs.iterM Id).filterMapM (pure (f := m) <| some <| · + 1) do
         sum := sum + n
-      return sum) : m _) ⦃ fun r => ⌜r = xs.sum + xs.size⌝ ⦄ := by
+      return sum) ⊤ (fun r => ⌜r = xs.sum + xs.size⌝) ⊥ := by
   mvcgen'
   case inv1 => exact fun cur n => ⌜n = cur.prefix.sum + cur.prefix.length⌝
   all_goals grind
 
 theorem foldM_eq_sum (xs : Array Nat) {m} [Monad m] [LawfulMonad m]
     [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
-    ⦃ ⊤ ⦄
+    Triple (Prog := m _)
       (xs.iter.foldM (m := m) (init := 0) (pure <| · + ·))
-      ⦃ fun r => ⌜r = xs.sum⌝ ⦄ := by
+      ⊤ (fun r => ⌜r = xs.sum⌝) ⊥ := by
   mvcgen'
   case inv1 => exact fun cur n => ⌜n = cur.prefix.sum⌝
   all_goals grind
@@ -623,10 +623,10 @@ h✝ : (UInt64.toBitVec 0).uaddOverflow (a <<< UInt64.ofNat (Int32.toInt 32).toN
 #guard_msgs in
 example (a : UInt64) :
     ⦃True⦄
-      do
+      (do
         let a ← MyShl.shl a (32: Int32)
         let a ← MyAddU.add (0 : UInt64) a
-        pure a
+        pure a : RustM UInt64)
     ⦃fun _ => True⦄ := by
   mvcgen' (errorOnMissingSpec := false) [MyShl.shl, MyAddU.add]
 

--- a/tests/bench/mvcgen/sym/vcgen_imp.lean
+++ b/tests/bench/mvcgen/sym/vcgen_imp.lean
@@ -1,0 +1,416 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Graf
+-/
+import Std.Tactic.Do
+import Std.Internal.Do
+import Std.Internal.Do.Triple.SpecLemmas
+
+/-!
+# `mvcgen'` on a non-monadic program type
+
+This test exercises the `WP`/`WPMonad` split: it defines a small IMP language with (non-reentrant)
+function calls whose weakest precondition is an *operational* semantics, gives it a `WP` instance
+(without any `WPMonad` instance, since `Cmd` is not a monad), and uses `mvcgen'` to generate
+verification conditions. The environment lives in the assertion (`Env → State → Prop`) so the
+program stays a bare `Cmd` and `mvcgen'` discriminates on its constructors.
+
+Functions are identified by name. A single unfolding lemma models "unfolding" of a call; each
+concrete function gets a registered contract, proven once from its body and used by callers.
+-/
+
+open Std.Internal.Do
+open Lean.Order
+
+set_option mvcgen.warning false
+
+/-! ## IMP syntax and state -/
+
+abbrev Var := String
+abbrev State := Var → Nat
+
+@[grind] def State.update (s : State) (x : Var) (v : Nat) : State :=
+  fun y => if y = x then v else s y
+
+inductive Expr where
+  | lit (n : Nat)
+  | var (x : Var)
+  | add (e₁ e₂ : Expr)
+  | sub (e₁ e₂ : Expr)
+  | mul (e₁ e₂ : Expr)
+  | mod (e₁ e₂ : Expr)
+  | le (e₁ e₂ : Expr)
+
+@[simp, grind] def Expr.eval (s : State) : Expr → Nat
+  | .lit n => n
+  | .var x => s x
+  | .add e₁ e₂ => e₁.eval s + e₂.eval s
+  | .sub e₁ e₂ => e₁.eval s - e₂.eval s
+  | .mul e₁ e₂ => e₁.eval s * e₂.eval s
+  | .mod e₁ e₂ => e₁.eval s % e₂.eval s
+  | .le e₁ e₂ => if e₁.eval s ≤ e₂.eval s then 1 else 0
+
+abbrev FName := String
+
+inductive Cmd where
+  | skip
+  | assign (x : Var) (e : Expr)
+  | seq (c₁ c₂ : Cmd)
+  | ite (cond : Expr) (c₁ c₂ : Cmd)
+  | while (cond : Expr) (body : Cmd)
+  | call (f : FName)
+
+/-! ## Non-reentrant function environment
+
+Functions are looked up by name; `lookup` returns the body together with the *prefix*
+environment in which it was defined, so a function can call only earlier-defined ones. -/
+
+inductive Env where
+  | nil
+  | snoc (Φ : Env) (name : FName) (body : Cmd)
+
+@[grind] def Env.lookup : Env → FName → Option (Env × Cmd)
+  | .nil, _ => none
+  | .snoc Φ name body, f => if f = name then some (Φ, body) else Φ.lookup f
+
+theorem Env.lookup_sizeOf_lt {Φ Φ' : Env} {body : Cmd} {f : FName}
+    (h : Φ.lookup f = some (Φ', body)) : sizeOf Φ' < sizeOf Φ := by
+  induction Φ with
+  | nil => simp [Env.lookup] at h
+  | snoc Ψ name b ih =>
+    simp only [Env.lookup] at h
+    split at h
+    · simp only [Option.some.injEq, Prod.mk.injEq] at h
+      obtain ⟨rfl, _⟩ := h
+      simp only [Env.snoc.sizeOf_spec]; omega
+    · have := ih h
+      simp only [Env.snoc.sizeOf_spec]; omega
+
+/-! ## Omni-style weakest precondition -/
+
+def wpCmd (Φ : Env) : Cmd → (State → Prop) → State → Prop
+  | .skip, Q, s => Q s
+  | .assign x e, Q, s => Q (s.update x (e.eval s))
+  | .seq c₁ c₂, Q, s => wpCmd Φ c₁ (fun s' => wpCmd Φ c₂ Q s') s
+  | .ite cond c₁ c₂, Q, s =>
+    if cond.eval s ≠ 0 then wpCmd Φ c₁ Q s else wpCmd Φ c₂ Q s
+  | .while cond body, Q, s =>
+    ∃ I : State → Prop,
+      I s ∧
+      (∀ s', I s' → cond.eval s' ≠ 0 → wpCmd Φ body I s') ∧
+      (∀ s', I s' → cond.eval s' = 0 → Q s')
+  | .call f, Q, s =>
+    match _h : Φ.lookup f with
+    | some (Φ', body) => wpCmd Φ' body Q s
+    | none => False
+  termination_by c => (sizeOf Φ, sizeOf c)
+  decreasing_by
+    all_goals first
+      | exact Prod.Lex.left _ _ (Env.lookup_sizeOf_lt _h)
+      | (apply Prod.Lex.right
+         simp only [Cmd.seq.sizeOf_spec, Cmd.ite.sizeOf_spec, Cmd.while.sizeOf_spec]; omega)
+
+theorem wpCmd_mono {Φ : Env} {c : Cmd} {Q Q' : State → Prop} (hQ : ∀ s, Q s → Q' s) :
+    ∀ s, wpCmd Φ c Q s → wpCmd Φ c Q' s := by
+  match Φ, c with
+  | Φ, .skip => intro s h; simp only [wpCmd] at h ⊢; exact hQ s h
+  | Φ, .assign x e => intro s h; simp only [wpCmd] at h ⊢; exact hQ _ h
+  | Φ, .seq c₁ c₂ =>
+    intro s h
+    simp only [wpCmd] at h ⊢
+    exact wpCmd_mono (fun s' h' => wpCmd_mono hQ s' h') s h
+  | Φ, .ite cond c₁ c₂ =>
+    intro s h
+    simp only [wpCmd] at h ⊢
+    split
+    · exact wpCmd_mono hQ s (by rwa [if_pos (by assumption)] at h)
+    · exact wpCmd_mono hQ s (by rwa [if_neg (by assumption)] at h)
+  | Φ, .while cond body =>
+    intro s h
+    simp only [wpCmd] at h ⊢
+    obtain ⟨I, hI, hstep, hexit⟩ := h
+    exact ⟨I, hI, hstep, fun s' hI' hc => hQ s' (hexit s' hI' hc)⟩
+  | Φ, .call f =>
+    intro s h
+    simp only [wpCmd] at h ⊢
+    split
+    · next Φ' body heq => rw [heq] at h; exact wpCmd_mono hQ s h
+    · next heq => rw [heq] at h; exact h.elim
+  termination_by (sizeOf Φ, sizeOf c)
+  decreasing_by
+    all_goals first
+      | exact Prod.Lex.left _ _ (Env.lookup_sizeOf_lt (by assumption))
+      | (apply Prod.Lex.right
+         simp only [Cmd.seq.sizeOf_spec, Cmd.ite.sizeOf_spec]; omega)
+
+/-! ## `WP` instance: the env lives in the assertion -/
+
+abbrev Assn := Env → State → Prop
+
+instance : WP Cmd Unit Assn EPost.Nil where
+  wpTrans c := ⟨fun Q _epost Φ s => wpCmd Φ c (Q () Φ) s⟩
+  wp_trans_monotone c := by
+    intro Q Q' e e' _he hQ Φ s h
+    exact wpCmd_mono (fun s' h' => hQ () Φ s' h') s h
+
+variable {Q : Unit → Assn} {epost : EPost.Nil}
+
+/-! ## `wp` equations, one per constructor
+
+`wpCmd`'s defining equations transported to `wp` itself: each fires only on a concrete `Cmd`
+constructor applied to a postcondition `Q`, and the recursive cases stay at the `wp` level (no
+`wpCmd` leaks into goals). The `while` equation is intentionally not a `simp` lemma so loops stay
+opaque for the `Spec.while`/`inv1` mechanism. -/
+
+/-- `wp` of a `Cmd` is `wpCmd` at the assertion's environment. Not a `simp` lemma; it is the rfl
+bridge behind the per-constructor equations below. -/
+private theorem wp_apply (c : Cmd) :
+    Std.Internal.Do.wp c Q epost = fun Φ s => wpCmd Φ c (Q () Φ) s := rfl
+
+@[simp] theorem wp_skip_eq (Φ : Env) (s : State) :
+    Std.Internal.Do.wp Cmd.skip Q epost Φ s = Q () Φ s := by
+  simp only [wp_apply, wpCmd]
+
+@[simp] theorem wp_assign_eq (x : Var) (e : Expr) (Φ : Env) (s : State) :
+    Std.Internal.Do.wp (Cmd.assign x e) Q epost Φ s = Q () Φ (s.update x (e.eval s)) := by
+  simp only [wp_apply, wpCmd]
+
+@[simp] theorem wp_seq_eq (c₁ c₂ : Cmd) (Φ : Env) (s : State) :
+    Std.Internal.Do.wp (Cmd.seq c₁ c₂) Q epost Φ s =
+      Std.Internal.Do.wp c₁ (fun _ => Std.Internal.Do.wp c₂ Q epost) epost Φ s := by
+  simp only [wp_apply, wpCmd]
+
+@[simp] theorem wp_ite_eq (cond : Expr) (c₁ c₂ : Cmd) (Φ : Env) (s : State) :
+    Std.Internal.Do.wp (Cmd.ite cond c₁ c₂) Q epost Φ s =
+      if cond.eval s ≠ 0 then Std.Internal.Do.wp c₁ Q epost Φ s
+      else Std.Internal.Do.wp c₂ Q epost Φ s := by
+  simp only [wp_apply, wpCmd]
+
+@[simp] theorem wp_call_eq (f : FName) (Φ : Env) (s : State) :
+    Std.Internal.Do.wp (Cmd.call f) Q epost Φ s =
+      (Φ.lookup f).elim False (fun p => Std.Internal.Do.wp p.2 (fun u _ => Q u Φ) epost p.1 s) := by
+  show wpCmd Φ (Cmd.call f) (Q () Φ) s = _
+  rw [wpCmd]; cases Φ.lookup f <;> rfl
+
+theorem wp_while_eq (cond : Expr) (body : Cmd) (Φ : Env) (s : State) :
+    Std.Internal.Do.wp (Cmd.while cond body) Q epost Φ s =
+      ∃ I : State → Prop, I s ∧
+        (∀ s', I s' → cond.eval s' ≠ 0 → Std.Internal.Do.wp body (fun _ _ => I) epost Φ s') ∧
+        (∀ s', I s' → cond.eval s' = 0 → Q () Φ s') := by
+  simp only [wp_apply, wpCmd]
+
+/-- Build a triple from the pointwise `wp` equation of the program. -/
+private theorem triple_of_wp {c : Cmd} {pre : Assn}
+    (h : ∀ Φ s, Std.Internal.Do.wp c Q epost Φ s = pre Φ s) : Triple c pre Q epost :=
+  Triple.iff.mpr (by rw [funext fun Φ => funext fun s => h Φ s]; exact PartialOrder.rel_refl)
+
+/-! ## Specification lemmas, one per constructor -/
+
+@[spec] theorem Spec.skip :
+    Triple Cmd.skip (Q ()) Q epost := triple_of_wp wp_skip_eq
+
+@[spec] theorem Spec.assign (x : Var) (e : Expr) :
+    Triple (Cmd.assign x e) (fun Φ s => Q () Φ (s.update x (e.eval s))) Q epost :=
+  triple_of_wp (wp_assign_eq x e)
+
+@[spec] theorem Spec.seq (c₁ c₂ : Cmd) :
+    Triple (Cmd.seq c₁ c₂)
+      (Std.Internal.Do.wp c₁ (fun _ => Std.Internal.Do.wp c₂ Q epost) epost) Q epost :=
+  triple_of_wp (wp_seq_eq c₁ c₂)
+
+@[spec] theorem Spec.ite (cond : Expr) (c₁ c₂ : Cmd) :
+    Triple (Cmd.ite cond c₁ c₂)
+      (fun Φ s => if cond.eval s ≠ 0
+        then Std.Internal.Do.wp c₁ Q epost Φ s else Std.Internal.Do.wp c₂ Q epost Φ s) Q epost :=
+  triple_of_wp (wp_ite_eq cond c₁ c₂)
+
+/-- Lift a body's contract through a call: if `f` resolves to `body` in prefix environment `Φ'`, a
+triple for `body` (proven with `Φ` pinned to `Φ'`, so its own inner calls resolve) yields a triple
+for `call f`. The call analogue of `Spec.while`: each concrete function's contract is one application
+of this lemma over its body. -/
+theorem Spec.call_of_body (f : FName) (Φ' : Env) (body : Cmd) {P' Q' : State → Prop}
+    (hbody : Triple body (fun Φ s => Φ = Φ' ∧ P' s) (fun _ _ s => Q' s) epost) :
+    Triple (Cmd.call f) (fun Φ s => Φ.lookup f = some (Φ', body) ∧ P' s) (fun _ _ s => Q' s) epost :=
+  Triple.iff.mpr (by
+    rintro Φ s ⟨hlk, hp⟩
+    simp only [wp_call_eq, hlk, Option.elim]
+    exact Triple.le_wp hbody Φ' s ⟨rfl, hp⟩)
+
+/-- A `while` loop invariant: an IMP assertion `Env → State → Prop`. Marked `@[spec_invariant_type]`
+so `mvcgen'` classifies it as an `inv1` case rather than an ordinary verification condition. -/
+@[spec_invariant_type]
+def WhileInvariant := Assn
+
+/-- An invariant `I` proves a `while` triple: it holds on entry, is preserved by running the body
+whenever the guard is nonzero, and implies the postcondition when the guard is zero. `mvcgen'`
+instantiates `I` from the `inv1` case, recurses into `body` for the preservation `step`, and leaves
+the exit condition as a VC. `I` is applied pointwise so the triple's assertion type stays `Assn`
+rather than `WhileInvariant`. -/
+@[spec] theorem Spec.while (cond : Expr) (body : Cmd) (I : WhileInvariant)
+    (step : Triple body (fun Φ s => I Φ s ∧ cond.eval s ≠ 0) (fun _ Φ s => I Φ s) epost)
+    (hexit : ∀ Φ s, I Φ s → cond.eval s = 0 → Q () Φ s) :
+    Triple (Cmd.while cond body) (fun Φ s => I Φ s) Q epost :=
+  Triple.iff.mpr (by
+    intro Φ s hs
+    simp only [wp_while_eq]
+    exact ⟨I Φ, hs, fun s' h' hc => Triple.le_wp step Φ s' ⟨h', hc⟩,
+      fun s' h' hc => hexit Φ s' h' hc⟩)
+
+/-! ## Surface notation
+
+A small concrete syntax elaborating to the `Expr`/`Cmd` AST, so example programs read like
+imperative code rather than nested constructors. -/
+
+declare_syntax_cat imp_expr
+syntax num : imp_expr
+syntax ident : imp_expr
+syntax:50 imp_expr:50 " <= " imp_expr:51 : imp_expr
+syntax:65 imp_expr:65 " + " imp_expr:66 : imp_expr
+syntax:65 imp_expr:65 " - " imp_expr:66 : imp_expr
+syntax:70 imp_expr:70 " * " imp_expr:71 : imp_expr
+syntax:70 imp_expr:70 " % " imp_expr:71 : imp_expr
+syntax "(" imp_expr ")" : imp_expr
+
+declare_syntax_cat imp_cmd
+syntax "skip" : imp_cmd
+syntax ident " := " imp_expr : imp_cmd
+syntax:2 imp_cmd:3 "; " imp_cmd:2 : imp_cmd
+syntax "if " imp_expr " then " imp_cmd " else " imp_cmd " fi" : imp_cmd
+syntax "while " imp_expr " do " imp_cmd " od" : imp_cmd
+syntax "call " ident : imp_cmd
+syntax "(" imp_cmd ")" : imp_cmd
+
+/-- `⟪ e ⟫` elaborates an IMP expression to `Expr`. -/
+syntax "⟪" imp_expr "⟫" : term
+/-- `⟦ c ⟧` elaborates an IMP command to `Cmd`. -/
+syntax "⟦" imp_cmd "⟧" : term
+
+open Lean in
+macro_rules
+  | `(⟪ $n:num ⟫) => `(Expr.lit $n)
+  | `(⟪ $x:ident ⟫) => `(Expr.var $(quote x.getId.toString))
+  | `(⟪ $a <= $b ⟫) => `(Expr.le ⟪$a⟫ ⟪$b⟫)
+  | `(⟪ $a + $b ⟫) => `(Expr.add ⟪$a⟫ ⟪$b⟫)
+  | `(⟪ $a - $b ⟫) => `(Expr.sub ⟪$a⟫ ⟪$b⟫)
+  | `(⟪ $a * $b ⟫) => `(Expr.mul ⟪$a⟫ ⟪$b⟫)
+  | `(⟪ $a % $b ⟫) => `(Expr.mod ⟪$a⟫ ⟪$b⟫)
+  | `(⟪ ($a) ⟫) => `(⟪$a⟫)
+
+open Lean in
+macro_rules
+  | `(⟦ skip ⟧) => `(Cmd.skip)
+  | `(⟦ $x:ident := $e ⟧) => `(Cmd.assign $(quote x.getId.toString) ⟪$e⟫)
+  | `(⟦ $c₁ ; $c₂ ⟧) => `(Cmd.seq ⟦$c₁⟧ ⟦$c₂⟧)
+  | `(⟦ if $b then $c₁ else $c₂ fi ⟧) => `(Cmd.ite ⟪$b⟫ ⟦$c₁⟧ ⟦$c₂⟧)
+  | `(⟦ while $b do $c od ⟧) => `(Cmd.while ⟪$b⟫ ⟦$c⟧)
+  | `(⟦ call $f:ident ⟧) => `(Cmd.call $(quote f.getId.toString))
+  | `(⟦ ($c) ⟧) => `(⟦$c⟧)
+
+/-! ## Straight-line, conditional, and loop -/
+
+/-- Straight-line code: `mvcgen'` chains the `seq`/`assign` specs into one substitution. -/
+example : ⦃ fun _ _ => True ⦄ ⟦ x := 5; y := x + x ⟧ ⦃ fun _ _ s => s "y" = 10 ⦄ := by
+  mvcgen'
+  simp [State.update]
+
+/-- A conditional: `mvcgen'` applies `Spec.ite`, leaving the guarded weakest precondition as a VC. -/
+example : ⦃ fun _ _ => True ⦄ ⟦ if x then y := 1 else y := 0 fi ⟧
+    ⦃ fun _ _ s => s "y" = if s "x" ≠ 0 then 1 else 0 ⦄ := by
+  mvcgen'
+  simp only [wp_assign_eq, State.update, Expr.eval]; grind
+
+/-- A loop preserved vacuously: the guard fails immediately. -/
+example : ⦃ fun _ s => s "x" = 0 ⦄ ⟦ while x do x := x + 1 od ⟧ ⦃ fun _ _ s => s "x" = 0 ⦄ := by
+  mvcgen'
+  case inv1 => exact fun _ s => s "x" = 0
+  all_goals simp_all [State.update]
+
+/-! ## Euclid's gcd as a `while` loop -/
+
+@[grind =] theorem gcd_step (a b : Nat) : Nat.gcd b (a % b) = Nat.gcd a b := by
+  rw [Nat.gcd_comm b (a % b), ← Nat.gcd_rec, Nat.gcd_comm]
+
+def gcd : Cmd := ⟦
+  while b do
+    t := b;
+    b := a % b;
+    a := t
+  od
+⟧
+
+/-- `gcd` leaves `Nat.gcd A B` in `a`. With `State.update`/`Expr.eval`/`gcd_step` available to `grind`,
+`mvcgen' with finish` discharges the entry/preservation/exit verification conditions. -/
+theorem gcd_correct (A B : Nat) :
+    ⦃ fun _ s => s "a" = A ∧ s "b" = B ⦄ gcd ⦃ fun _ _ s => s "a" = Nat.gcd A B ⦄ := by
+  unfold gcd
+  mvcgen' invariants
+  | inv1 => fun _ s => Nat.gcd (s "a") (s "b") = Nat.gcd A B
+  with finish
+
+/-! ## Integer square root as a `while` loop -/
+
+def isqrt : Cmd := ⟦
+  r := 0;
+  while (r + 1) * (r + 1) <= n do
+    r := r + 1
+  od
+⟧
+
+/-- `isqrt` leaves `⌊√n⌋` in `r`: the invariant `r² ≤ n` is preserved while the guard holds, and the
+negated guard at exit gives `n < (r+1)²`. -/
+theorem isqrt_correct (N : Nat) :
+    ⦃ fun _ s => s "n" = N ⦄ isqrt
+      ⦃ fun _ _ s => s "r" * s "r" ≤ N ∧ N < (s "r" + 1) * (s "r" + 1) ⦄ := by
+  unfold isqrt
+  mvcgen' invariants
+  | inv1 => fun _ s => s "r" * s "r" ≤ N ∧ s "n" = N
+  with finish
+
+/-! ## Compositional reasoning: `gcd` and `isqrt` as functions
+
+`Δ` defines `gcd` and `isqrt` as named functions and a `main` routine. Each call contract is
+`Spec.call_of_body` over the function's body theorem; callers are verified against the *contracts*,
+not the bodies, with `with finish` discharging the `Δ` lookups. -/
+
+def mainBody : Cmd := ⟦ call gcd ⟧
+
+@[grind] def Δ : Env :=
+  .snoc (.snoc (.snoc .nil "gcd" gcd) "isqrt" isqrt) "main" mainBody
+
+/-- Contract for `call "gcd"`: `mvcgen'` applies the generic `Spec.call_of_body`, discharges the
+body obligation with `gcd_correct`, and `with finish` settles the lookup. -/
+@[spec] theorem Spec.gcd {A B : Nat} :
+    ⦃ fun Φ s => Φ.lookup "gcd" = some (.nil, _root_.gcd) ∧ s "a" = A ∧ s "b" = B ⦄
+      Cmd.call "gcd" ⦃ fun _ _ s => s "a" = Nat.gcd A B ⦄ :=
+  Spec.call_of_body "gcd" .nil _root_.gcd <| Triple.iff.mpr (by
+    rintro Φ s ⟨-, ha, hb⟩; exact Triple.le_wp (gcd_correct A B) Φ s ⟨ha, hb⟩)
+
+/-- Contract for `call "isqrt"`, proven the same way from `isqrt_correct`. -/
+@[spec] theorem Spec.isqrt {N : Nat} :
+    ⦃ fun Φ s => Φ.lookup "isqrt" = some (.snoc .nil "gcd" _root_.gcd, _root_.isqrt) ∧ s "n" = N ⦄
+      Cmd.call "isqrt"
+      ⦃ fun _ _ s => s "r" * s "r" ≤ N ∧ N < (s "r" + 1) * (s "r" + 1) ⦄ :=
+  Spec.call_of_body "isqrt" (.snoc .nil "gcd" _root_.gcd) _root_.isqrt <| Triple.iff.mpr (by
+    rintro Φ s ⟨-, hn⟩; exact Triple.le_wp (isqrt_correct N) Φ s hn)
+
+/-- Contract for `call "main"`: `main`'s body (`call gcd`) is verified against `Spec.gcd`, not the
+gcd body. -/
+@[spec] theorem Spec.main {A B : Nat} :
+    ⦃ fun Φ s => Φ.lookup "main" = some (.snoc (.snoc .nil "gcd" _root_.gcd) "isqrt" _root_.isqrt,
+        _root_.mainBody) ∧ s "a" = A ∧ s "b" = B ⦄
+      Cmd.call "main" ⦃ fun _ _ s => s "a" = Nat.gcd A B ⦄ :=
+  Spec.call_of_body "main" (.snoc (.snoc .nil "gcd" _root_.gcd) "isqrt" _root_.isqrt) _root_.mainBody <| by
+    unfold mainBody; mvcgen' with finish
+
+/-- The top-level property of `main` run in `Δ`, verified modularly through the contracts. -/
+theorem main_correct (A B : Nat) :
+    ⦃ fun Φ s => Φ = Δ ∧ s "a" = A ∧ s "b" = B ⦄ ⟦ call main ⟧
+      ⦃ fun _ _ s => s "a" = Nat.gcd A B ⦄ := by
+  mvcgen' with finish
+
+/-- `isqrt` called directly in `Δ`, verified through `Spec.isqrt`. -/
+theorem isqrt_call_correct (N : Nat) :
+    ⦃ fun Φ s => Φ = Δ ∧ s "n" = N ⦄ ⟦ call isqrt ⟧
+      ⦃ fun _ _ s => s "r" * s "r" ≤ N ∧ N < (s "r" + 1) * (s "r" + 1) ⦄ := by
+  mvcgen' with finish

--- a/tests/elab/mvcgenDepAssertionLattice.lean
+++ b/tests/elab/mvcgenDepAssertionLattice.lean
@@ -38,7 +38,7 @@ An `abbrev`, so the carrier unfolds to the dependent Pi and `Assertion`/`Partial
 pointwise function-lattice instances. -/
 abbrev StateProp := (st : State) → st.Invariant → Prop
 
-instance : WPMonad Stateful StateProp EPost⟨⟩ where
+instance Stateful.instWP {α : Type} : WP (Stateful α) α StateProp EPost⟨⟩ where
   wpTrans f := ⟨fun post _epost =>
     fun st _ =>
       let (optRes, stOut) := f.run st
@@ -46,10 +46,25 @@ instance : WPMonad Stateful StateProp EPost⟨⟩ where
       match optRes with
       | none => True
       | some res => post res stOut h⟩
-  wp_trans_pure x := by simp only [Lean.Order.PartialOrder.rel, pure, Stateful.run]; grind
-  wp_trans_bind x f := by simp only [Lean.Order.PartialOrder.rel, bind, Stateful.run]; grind
   wp_trans_monotone x := by
     simp only [PredTrans.monotone, Lean.Order.PartialOrder.rel, Stateful.run]; grind
+
+theorem Stateful.wpTrans_apply_eq {α : Type} (x : Stateful α)
+    (post : α → StateProp) (epost : EPost⟨⟩) (st : State) (h : st.Invariant) :
+    wp x post epost st h
+      = ∃ h' : (x st).2.Invariant,
+          match (x st).1 with
+          | none => True
+          | some r => post r (x st).2 h' := rfl
+
+instance : WPMonad Stateful StateProp EPost⟨⟩ where
+  toWP _ := Stateful.instWP
+  pure_le_wp_pure x post epost := by
+    intro st h hp; exact ⟨h, hp⟩
+  bind_le_wp_bind x f post epost := by
+    intro st h hp
+    simp only [Stateful.wpTrans_apply_eq, bind] at hp ⊢
+    grind
 
 /--
 error: failed to apply Lean.Order.le_of_forall_le to goal


### PR DESCRIPTION
This PR extracts a `WP` type class from `WPMonad` so that weakest-precondition reasoning and `mvcgen'` apply to any program type, not only monads. This enables verifying deeply embedded languages: a program type with a `WP` instance but no `WPMonad` instance, for example an inductive command syntax with its own operational semantics, can now be specified with `Triple` and decomposed by `mvcgen'`.

`WP Prog Value Pred EPred` provides the monotone predicate transformer `wpTrans`, indexed by the program type. `WPMonad m Pred EPred` now carries a `WP (m α) α Pred EPred` instance for every result type and extends `LawfulMonad m`. Each predefined instance is split into a `WP` half and a `WPMonad` half. On the tactic side, `mvcgen'`'s `WPInfo` and rule construction follow the new `wp` argument layout.

The `Triple` notation gains an optional `(m := m)` clause that pins the program's monad, and bare `match`/`if`/`do` programs now elaborate directly (their monad is recovered by first-order unification), so specifications need fewer type ascriptions.

A new test, `tests/bench/mvcgen/sym/vcgen_imp.lean`, exercises `mvcgen'` on a deeply embedded IMP language whose `WP` instance has no accompanying `WPMonad`: weakest precondition by operational semantics, the environment threaded through the assertion (`Env → State → Prop`) so programs stay bare `Cmd`, string-named functions verified by per-function contracts, and `while`-loop algorithms (Euclid's gcd, integer square root).
