### PR TITLE
doc: fix a typo in List.foldr

### DIFF
--- a/src/Init/Data/List/Basic.lean
+++ b/src/Init/Data/List/Basic.lean
@@ -532,7 +532,7 @@ noncomputable def filterMap (f : α → Option β) : List α → List β
 
 /--
 Folds a function over a list from the right, accumulating a value starting with `init`. The
-accumulated value is combined with the each element of the list in reverse order, using `f`.
+accumulated value is combined with each element of the list in reverse order, using `f`.
 
 `O(|l|)`. Replaced at runtime with `List.foldrTR`.
 


### PR DESCRIPTION
This PR fixes a simple typo in the List.foldr docstring.