### PR TITLE
perf: JSON fast path for String literal parsing

### DIFF
--- a/src/Lean/Data/Json/Parser.lean
+++ b/src/Lean/Data/Json/Parser.lean
@@ -99,22 +99,24 @@ position at the terminating character (or end of input).
   let stop := skipStrChars it.2
   .success ⟨it.1, stop⟩ (String.extract it.2 stop)
 
-@[inline] partial def str : Parser String := go ""
-where go (acc : String) : Parser String := do
-  -- Scan and copy the next run of unescaped characters in one allocation, only accumulating into
-  -- `acc` across the boundaries that escape sequences force.
-  let run ← strRun
-  let acc := if acc.isEmpty then run else if run.isEmpty then acc else acc ++ run
-  let c ← peek!
-  if c == '"' then
-    skip
-    return acc
-  else if c == '\\' then
-    skip
-    go (acc.push (← escapedChar))
-  else
-    skip
-    fail "unexpected character in string"
+@[inline] partial def str : Parser String :=
+  go ""
+where
+  go (acc : String) : Parser String := do
+    -- Scan and copy the next run of unescaped characters in one allocation, only accumulating into
+    -- `acc` across the boundaries that escape sequences force.
+    let run ← strRun
+    let acc := if acc.isEmpty then run else acc ++ run
+    let c ← peek!
+    if c == '"' then
+      skip
+      return acc
+    else if c == '\\' then
+      skip
+      go (acc.push (← escapedChar))
+    else
+      skip
+      fail "unexpected character in string"
 
 
 partial def natCore (acc : Nat) : Parser Nat := do

--- a/src/Lean/Data/Json/Parser.lean
+++ b/src/Lean/Data/Json/Parser.lean
@@ -107,17 +107,13 @@ where
     -- `acc` across the boundaries that escape sequences force.
     let run ← strRun
     let acc := if acc.isEmpty then run else acc ++ run
-    let c ← peek!
+    let c ← any
     if c == '"' then
-      skip
       return acc
     else if c == '\\' then
-      skip
       go (acc.push (← escapedChar))
     else
-      skip
       fail "unexpected character in string"
-
 
 partial def natCore (acc : Nat) : Parser Nat := do
   if ← isEof then

--- a/src/Lean/Data/Json/Parser.lean
+++ b/src/Lean/Data/Json/Parser.lean
@@ -72,24 +72,50 @@ def escapedChar : Parser Char := do
       return ⟨val.toUInt32, Or.inr ⟨Nat.not_lt.mp h', Nat.lt_trans val.toFin.isLt (by decide)⟩⟩
   | _ => fail "illegal \\u escape"
 
-partial def strCore (acc : String) : Parser String := do
+/--
+Scans a maximal run of literal JSON string characters starting at `it`, i.e. characters other than
+`"`, `\`, or a control character below `U+0020`, and returns the position just past the run. This
+lets `str` copy unescaped substrings in a single allocation rather than character by character.
+-/
+def skipStrChars {s : String} (it : s.Pos) : s.Pos :=
+  if h : ¬it.IsAtEnd then
+    let c := it.get h
+    -- as to whether c.val > 0xffff should be split up and encoded with multiple \u,
+    -- the JSON standard is not definite: both directly printing the character
+    -- and encoding it with multiple \u is allowed. we choose the former.
+    if c != '"' && c != '\\' && 0x0020 <= c.val && c.val <= 0x10ffff then
+      skipStrChars (it.next h)
+    else
+      it
+  else
+    it
+termination_by it
+
+/--
+Copies the next maximal run of unescaped string characters in a single allocation, leaving the
+position at the terminating character (or end of input).
+-/
+@[inline] def strRun : Parser String := fun it =>
+  let stop := skipStrChars it.2
+  .success ⟨it.1, stop⟩ (String.extract it.2 stop)
+
+@[inline] partial def str : Parser String := go ""
+where go (acc : String) : Parser String := do
+  -- Scan and copy the next run of unescaped characters in one allocation, only accumulating into
+  -- `acc` across the boundaries that escape sequences force.
+  let run ← strRun
+  let acc := if acc.isEmpty then run else if run.isEmpty then acc else acc ++ run
   let c ← peek!
   if c == '"' then
     skip
     return acc
+  else if c == '\\' then
+    skip
+    go (acc.push (← escapedChar))
   else
-    let c ← any
-    if c == '\\' then
-      strCore (acc.push (← escapedChar))
-    -- as to whether c.val > 0xffff should be split up and encoded with multiple \u,
-    -- the JSON standard is not definite: both directly printing the character
-    -- and encoding it with multiple \u is allowed. we choose the former.
-    else if 0x0020 <= c.val && c.val <= 0x10ffff then
-      strCore (acc.push c)
-    else
-      fail "unexpected character in string"
+    skip
+    fail "unexpected character in string"
 
-@[inline] def str : Parser String := strCore ""
 
 partial def natCore (acc : Nat) : Parser Nat := do
   if ← isEof then


### PR DESCRIPTION
This PR implements a fast path for JSON string literal parsing.

We initially attempted this using an escape table in the style of Ruby in https://github.com/leanprover/lean4/pull/13443. However, this PR achieves basically the same performance without the table. We believe this might be because the table scanning code contains reference counting operations that scare LLVM.