### PR TITLE
perf: prefetch import regions via `madvise`

### DIFF
--- a/src/Lean/CompactedRegion.lean
+++ b/src/Lean/CompactedRegion.lean
@@ -103,9 +103,14 @@ pointer fixup. The result is the root object reinterpreted at type `α` paired w
 `CompactedRegion`. Unsafe because `α` is type-erased at the extern boundary: it is the caller's
 responsibility to ensure `α` matches the type the data was saved at; mismatched types yield
 undefined behavior on use.
+
+If `prefault` is `true`, the OS is hinted (`madvise(MADV_WILLNEED)`) to read the whole mapping into
+the page cache asynchronously. This is worthwhile only when the caller will go on to read most of
+the region (e.g. an import that merges in all of a module's constants); for readers that touch a
+region only partially it would over-fetch.
 -/
 @[extern "lean_compacted_region_read"]
 public unsafe opaque CompactedRegion.read {α : Type} (fname : @& System.FilePath)
-    (depRegions : @& Array CompactedRegion) : IO (α × CompactedRegion)
+    (depRegions : @& Array CompactedRegion) (prefault : Bool := false) : IO (α × CompactedRegion)
 
 end Lean

--- a/src/Lean/Environment.lean
+++ b/src/Lean/Environment.lean
@@ -2043,7 +2043,9 @@ private def readModuleDataPartsOfMod (mod : Name) : IO (Array (ModuleData × Com
   let mFile ← findOLean mod
   unless (← mFile.pathExists) do
     throw <| IO.userError s!"object file '{mFile}' of module {mod} does not exist"
-  let main ← unsafe CompactedRegion.read (α := ModuleData) mFile #[]
+  -- `prefault`: the import const-map merge reads most of each main `.olean`, so warming the whole
+  -- region lets that otherwise-serial fault I/O overlap with the merge that follows.
+  let main ← unsafe CompactedRegion.read (α := ModuleData) mFile #[] (prefault := true)
   if !main.1.isModule then
     return #[main]
   -- Opportunistically load all available parts.

--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -451,7 +451,8 @@ static object * mk_compacted_region(b_obj_arg ofname, object * root,
 // root to be interpreted as — the C side does no type checking and the caller is responsible for
 // using a type compatible with what was saved (see `CompactedRegion.read`).
 // Supports both `v2` and `v3` formats.
-extern "C" LEAN_EXPORT object * lean_compacted_region_read(b_obj_arg ofname, b_obj_arg odep_regions, object *) {
+extern "C" LEAN_EXPORT object * lean_compacted_region_read(b_obj_arg ofname, b_obj_arg odep_regions,
+                                                           uint8 prefault, object *) {
     std::string olean_fn(lean_string_cstr(ofname));
     try {
         std::vector<region_view> dep_regions = extract_dep_regions(odep_regions);
@@ -560,6 +561,15 @@ extern "C" LEAN_EXPORT object * lean_compacted_region_read(b_obj_arg ofname, b_o
 #if __has_feature(address_sanitizer)
             __lsan_ignore_object(buffer);
 #endif
+#endif
+        }
+
+        // Asynchronously read the whole mapping into the page cache when requested. Worthwhile only
+        // when the caller will go on to read most of the region (a non-`mmap`/`malloc`+`read`
+        // buffer is already fully resident, so the hint is moot there).
+        if (prefault && is_mmap) {
+#if !defined(LEAN_WINDOWS) && defined(MADV_WILLNEED)
+            madvise(buffer, size, MADV_WILLNEED);
 #endif
         }
 


### PR DESCRIPTION
This PR hints the OS (`madvise(MADV_WILLNEED)`) to read each imported module's main `.olean` mapping into the page cache as the module is loaded, so that otherwise-serial fault I/O overlaps the constant-map merge that follows. For a cold-cache import this overlaps the dominant constant-data faulting and lowers load time.

`CompactedRegion.read` gains an opt-in `prefault` flag that issues the hint for memory-mapped regions; the sequential import read passes it for each module's main olean.