### PR TITLE
fix: error instead of looping on a dependent assertion lattice in mvcgen'

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -193,8 +193,7 @@ private def normalizePre? (scope : VCGen.Scope) (goal : MVarId) (α pre target :
     return some (scope, [g])
   if let some (g, h) ← ofPropPreIntro? goal pre then
     return some ({ scope with lastLiftedPre? := some h }, [g])
-  if α.isForall then
-    return some (scope, [← introsExcessArgs goal])
+  if let some goal' ← introsExcessArgs goal then return some (scope, [goal'])
   if let some gs ← truePre? goal pre target then
     return some (scope, gs)
   if let some (g, h) ← barePreIntro? goal α pre then

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Util.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Util.lean
@@ -113,18 +113,21 @@ public def simpGoalTelescope (goal : MVarId) : VCGenM Sym.SimpGoalResult := do
 
 /--
 Introduce the excess state arguments of an entailment goal `pre ⊑ rhs` whose lattice type is a
-function type `σ₁ → … → σₙ → α`: repeatedly apply `stateArgIntroRule` (a backward rule for
-`Std.Internal.Do.le_of_forall_le`) and introduce the new state binder, until the lattice type is
-no longer a function type.
+function type `σ₁ → … → σₙ → α`: repeatedly apply `stateArgIntro` (a backward rule for
+`Lean.Order.le_of_forall_le`) and introduce the new state binder, until the lattice type is
+no longer a function type. Returns `none` when the carrier is not a function type (nothing to
+introduce); throws when the carrier is a function type that `le_of_forall_le` cannot peel, such as a
+dependent function lattice `(a : α) → β a → …`.
 -/
 public partial def introsExcessArgs (goal : MVarId) :
-    VCGenM MVarId := goal.withContext do
+    VCGenM (Option MVarId) := goal.withContext do
   let type ← goal.getType
-  let_expr PartialOrder.rel α _inst _pre _rhs := type | return goal
-  unless α.isForall do return goal
-  let .goals [goal] ← (← read).backwardRules.stateArgIntro.applyChecked goal | return goal
+  let_expr PartialOrder.rel α _inst _pre _rhs := type | return none
+  unless α.isForall do return none
+  let .goals [goal] ← (← read).backwardRules.stateArgIntro.applyChecked goal
+    | throwError "failed to apply {.ofConstName ``Lean.Order.le_of_forall_le} to goal{indentExpr type}"
   let goal ← introsHygienic goal
-  introsExcessArgs goal
+  return (← introsExcessArgs goal) <|> some goal
 
 /--
 Solves conjunctions whose leaves are `True` or `e₁ = e₂`, and returns a residual goal containing

--- a/tests/elab/mvcgenDepAssertionLattice.lean
+++ b/tests/elab/mvcgenDepAssertionLattice.lean
@@ -1,0 +1,60 @@
+import Std.Tactic.Do
+import Std.Internal.Do
+
+/-!
+Regression test for a *dependent* assertion language `(st : State) → st.Invariant → Prop`. Its order
+is the pointwise function order, but `mvcgen'`'s peel rule `le_of_forall_le` cannot currently be
+applied to a dependent function lattice. `mvcgen'` must report a clear error instead of looping until
+it runs out of heartbeats. Extracted from a user report.
+-/
+
+set_option mvcgen.warning false
+
+open Std.Internal.Do
+
+opaque State : Type
+opaque State.Invariant : State → Prop
+
+def Stateful (a : Type) := State → Option a × State
+
+instance : Monad Stateful where
+  pure x := fun st => (some x, st)
+  bind x f := fun st =>
+    let (xOptVal, stMid) := x st
+    match xOptVal with
+    | none => (none, stMid)
+    | some xVal => f xVal stMid
+
+def Stateful.run (x : Stateful a) (st : State) : Option a × State := x st
+
+instance : LawfulMonad Stateful :=
+  LawfulMonad.mk' Stateful
+    (id_map := by simp only [Functor.map, Function.comp_apply, id_eq]; intro _ x; funext; grind)
+    (pure_bind := by simp [pure, bind])
+    (bind_assoc := by intro _ _ _ x f g; simp only [bind]; funext; grind)
+
+/-- A dependent assertion language: the postcondition `Prop` may depend on a proof about the state.
+An `abbrev`, so the carrier unfolds to the dependent Pi and `Assertion`/`PartialOrder` are the generic
+pointwise function-lattice instances. -/
+abbrev StateProp := (st : State) → st.Invariant → Prop
+
+instance : WPMonad Stateful StateProp EPost⟨⟩ where
+  wpTrans f := ⟨fun post _epost =>
+    fun st _ =>
+      let (optRes, stOut) := f.run st
+      ∃ h : stOut.Invariant,
+      match optRes with
+      | none => True
+      | some res => post res stOut h⟩
+  wp_trans_pure x := by simp only [Lean.Order.PartialOrder.rel, pure, Stateful.run]; grind
+  wp_trans_bind x f := by simp only [Lean.Order.PartialOrder.rel, bind, Stateful.run]; grind
+  wp_trans_monotone x := by
+    simp only [PredTrans.monotone, Lean.Order.PartialOrder.rel, Stateful.run]; grind
+
+/--
+error: failed to apply Lean.Order.le_of_forall_le to goal
+  Lean.Order.PartialOrder.rel (fun x x_1 => True) (wp (pure PUnit.unit) (fun x x_1 x_2 => True) epost⟨⟩)
+-/
+#guard_msgs in
+example : Triple (fun _ _ => True) (pure () : Stateful Unit) (fun _ _ _ => True) epost⟨⟩ := by
+  mvcgen'


### PR DESCRIPTION
This PR makes `mvcgen'` report a clear error when an entailment's assertion lattice is a dependent function type such as `(a : α) → β a → Prop`, instead of looping until it runs out of heartbeats. The order is the ordinary pointwise function order; the limitation is that `mvcgen'`'s peel rule `Lean.Order.le_of_forall_le` cannot currently be applied to a dependent function lattice.

`introsExcessArgs` now returns `Option MVarId`: `none` when the carrier is not a function type (nothing to introduce), and it throws when a function-typed carrier cannot be peeled by `Lean.Order.le_of_forall_le`. `normalizePre?` matches on this `Option` rather than re-emitting the unchanged goal forever, so it no longer needs an `α.isForall` guard.