### PR TITLE
feat: add builtin `@[lia]` attribute supplying a lemma set to the `lia` tactic

### DIFF
--- a/src/Init/Grind/Attr.lean
+++ b/src/Init/Grind/Attr.lean
@@ -317,5 +317,23 @@ Like `@[grind!]`, but also prints the pattern(s) selected by `grind`
 as info messages. Combines minimal subexpression selection with debugging output.
 -/
 syntax (name := grind!?) "grind!?" (ppSpace grindMod)? : attr
+
+/--
+Marks a theorem or definition for use by the `lia` (linear integer arithmetic) tactic.
+
+`lia` is `grind` restricted to the `cutsat` solver. It does not use the `@[grind]` lemma
+set, but `cutsat` benefits from a small amount of instantiation, e.g. of `Nat.max_def` and
+`Nat.min_def`. Lemmas tagged with `@[lia]` form a dedicated set that `lia` instantiates via
+E-matching, without enabling the much larger `@[grind]` set.
+
+The modifiers are the same as for `@[grind]`, e.g. `@[lia =]`, `@[lia ←]`, `@[lia →]`.
+-/
+syntax (name := lia) "lia" (ppSpace grindMod)? : attr
+/-- Like `@[lia]`, but enforces the minimal indexable subexpression condition (see `@[grind!]`). -/
+syntax (name := lia!) "lia!" (ppSpace grindMod)? : attr
+/-- Like `@[lia]`, but also prints the pattern(s) selected by `lia` as info messages. -/
+syntax (name := lia?) "lia?" (ppSpace grindMod)? : attr
+/-- Like `@[lia!]`, but also prints the pattern(s) selected by `lia` as info messages. -/
+syntax (name := lia!?) "lia!?" (ppSpace grindMod)? : attr
 end Attr
 end Lean.Parser

--- a/src/Init/Grind/Config.lean
+++ b/src/Init/Grind/Config.lean
@@ -271,16 +271,21 @@ structure NoopConfig extends Config where
   mbtc      := false
 
 /--
-A `grind` configuration that only uses `cutsat` and splitting.
+A `grind` configuration that only uses `cutsat`, splitting, and the `@[lia]` lemma set.
 
 Note: `cutsat` benefits from some amount of instantiation, e.g. `Nat.max_def`.
-We don't currently have a mechanism to enable only a small set of lemmas.
+Lemmas tagged with the `@[lia]` attribute are instantiated via E-matching when running
+`lia`, while the much larger `@[grind]` lemma set is left disabled. Tag lemmas with
+`@[lia =] theorem ...` (or `attribute [lia =] ...`) to add them to this set.
 -/
 -- This is a `structure` rather than `def` so we can use `declare_config_elab`.
 structure CutsatConfig extends NoopConfig where
   lia := true
   -- Allow the default number of splits.
   splits := ({} : Config).splits
+  -- Re-enable E-matching, so the `@[lia]` lemma set is instantiated.
+  -- The active theorem set is restricted to lemmas tagged `@[lia]`, not the full `@[grind]` set.
+  ematch := ({} : Config).ematch
 
 /--
 A `grind` configuration that only uses `linarith`.

--- a/src/Lean/Elab/Tactic/Grind/Main.lean
+++ b/src/Lean/Elab/Tactic/Grind/Main.lean
@@ -213,9 +213,12 @@ def elabGrindLocals (params : Grind.Params) : MetaM Grind.Params := do
   return params
 
 def mkGrindParams
-    (config : Grind.Config) (only : Bool) (ps : TSyntaxArray ``Parser.Tactic.grindParam) (mvarId : MVarId) :
+    (config : Grind.Config) (only : Bool) (ps : TSyntaxArray ``Parser.Tactic.grindParam) (mvarId : MVarId)
+    (extensions? : Option Grind.ExtensionStateArray := none) :
     TermElabM Grind.Params := do
-  let params ← if only then Grind.mkOnlyParams config else Grind.mkDefaultParams config
+  let params ← match extensions? with
+    | some extensions => Grind.mkParams config extensions
+    | none => if only then Grind.mkOnlyParams config else Grind.mkDefaultParams config
   let mut params ← elabGrindParams params ps (lax := config.lax) (only := only)
   if config.suggestions then
     let lsConfig : LibrarySuggestions.Config := { caller := some "grind" }
@@ -249,10 +252,11 @@ def grind
     (only : Bool)
     (ps   :  TSyntaxArray ``Parser.Tactic.grindParam)
     (seq? : Option (TSyntax `Lean.Parser.Tactic.Grind.grindSeq))
+    (extensions? : Option Grind.ExtensionStateArray := none)
     : TacticM Unit := do
   if (← checkTerminalAsSorry mvarId) then return ()
   mvarId.withContext do
-    let params ← mkGrindParams config only ps mvarId
+    let params ← mkGrindParams config only ps mvarId (extensions? := extensions?)
     let params := if Grind.grind.unusedLemmaThreshold.get (← getOptions) > 0 then
       { params with config.markInstances := true }
     else params
@@ -281,12 +285,13 @@ def evalGrindCore
     (only : Option Syntax)
     (params? : Option (Syntax.TSepArray `Lean.Parser.Tactic.grindParam ","))
     (seq? : Option (TSyntax `Lean.Parser.Tactic.Grind.grindSeq))
+    (extensions? : Option Grind.ExtensionStateArray := none)
     : TacticM Unit := do
   let only := only.isSome
   let params := if let some params := params? then params.getElems else #[]
   if Grind.grind.warning.get (← getOptions) then
     logWarningAt ref "The `grind` tactic is new and its behavior may change in the future. This project has used `set_option grind.warning true` to discourage its use."
-  grind (← getMainGoal) config only params seq?
+  grind (← getMainGoal) config only params seq? (extensions? := extensions?)
 
 /-- Position for the `[..]` child syntax in the `grind` tactic. -/
 def grindParamsPos := 3
@@ -449,7 +454,8 @@ def evalGrindTraceCore (stx : Syntax) (trace := true) (verbose := true) (useSorr
 @[builtin_tactic Lean.Parser.Tactic.lia] def evalLia : Tactic := fun stx => do
   let `(tactic| lia $config:optConfig) := stx | throwUnsupportedSyntax
   let config ← elabCutsatConfig config
-  evalGrindCore stx { config with } none none none
+  let extensions ← Grind.getLiaExtensions
+  evalGrindCore stx { config with } none none none (extensions? := some extensions)
 
 @[builtin_tactic Lean.Parser.Tactic.cutsat] def evalCutsat : Tactic := fun stx => do
   let `(tactic| cutsat $config:optConfig) := stx | throwUnsupportedSyntax
@@ -460,7 +466,8 @@ def evalGrindTraceCore (stx : Syntax) (trace := true) (verbose := true) (useSorr
   Tactic.TryThis.addSuggestion stx { suggestion := .tsyntax liaTac }
   -- Execute the same logic as lia
   let config ← elabCutsatConfig config
-  evalGrindCore stx { config with } none none none
+  let extensions ← Grind.getLiaExtensions
+  evalGrindCore stx { config with } none none none (extensions? := some extensions)
 
 @[builtin_tactic Lean.Parser.Tactic.grind_order] def evalOrder : Tactic := fun stx => do
   let `(tactic| grind_order $config:optConfig) := stx | throwUnsupportedSyntax

--- a/src/Lean/Meta/Tactic/Grind/Attr.lean
+++ b/src/Lean/Meta/Tactic/Grind/Attr.lean
@@ -248,6 +248,13 @@ def registerAttr (attrName : Name) (ref : Name := by exact decl_name%) : IO Exte
 
 builtin_initialize grindExt : Extension ← registerAttr `grind
 
+/--
+Extension backing the `@[lia]` attribute. It uses the same recording mechanism as `@[grind]`
+(see `registerAttr`), but provides a separate, smaller E-matching lemma set that the `lia`
+tactic instantiates (e.g. `Nat.max_def`), without enabling the full `@[grind]` set.
+-/
+builtin_initialize liaExt : Extension ← registerAttr `lia
+
 /-- Returns `true` is `declName` is a builtin split or has been tagged with `[grind]` attribute. -/
 def isGlobalSplit (declName : Name) : CoreM Bool := do
   let s := grindExt.getState (← getEnv)

--- a/src/Lean/Meta/Tactic/Grind/Main.lean
+++ b/src/Lean/Meta/Tactic/Grind/Main.lean
@@ -44,6 +44,17 @@ def getOnlyExtensionState : MetaM ExtensionState := do
     casesTypes, funCC, extThms
   }
 
+/--
+Returns the extensions used by the `lia` tactic.
+
+`lia` keeps the structural part of the default `grind` attribute (cases types, `funCC`,
+and extensionality theorems), but instead of the full `@[grind]` E-matching lemma set it
+only uses the dedicated `@[lia]` lemma set. This lets `cutsat` benefit from a small amount
+of instantiation (e.g. `Nat.max_def`) without pulling in everything tagged `@[grind]`.
+-/
+def getLiaExtensions : MetaM ExtensionStateArray := do
+  return #[← getOnlyExtensionState, liaExt.getState (← getEnv)]
+
 structure Params where
   config      : Grind.Config
   extensions  : ExtensionStateArray := #[]

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,5 +1,7 @@
 #include "util/options.h"
 
+// Trigger update-stage0 for: add builtin `lia` grind attribute (so it can be applied in `src/Init`)
+
 namespace lean {
 options get_default_options() {
     options opts;

--- a/tests/elab/lia_attr.lean
+++ b/tests/elab/lia_attr.lean
@@ -1,0 +1,33 @@
+/-!
+# The `@[lia]` attribute supplies a small lemma set to the `lia` tactic
+
+`lia` is `grind` restricted to the `cutsat` solver. It does not use the `@[grind]`
+lemma set, but lemmas tagged with `@[lia]` are instantiated via E-matching, so `cutsat`
+can see definitions such as `min`/`max`.
+-/
+
+-- Without any `@[lia]` lemmas, `lia` treats `min`/`max` as opaque and cannot finish.
+example (a b : Int) : min a b ≤ max a b := by
+  fail_if_success lia
+  grind
+
+-- Tagging the defining lemmas adds them to the `@[lia]` set, and now `lia` succeeds.
+attribute [lia =] Int.min_def Int.max_def Nat.min_def Nat.max_def
+
+example (a b : Int) : min a b ≤ max a b := by lia
+example (a b : Nat) : min a b ≤ max a b := by lia
+example (a b : Int) (h : a ≤ b) : max a b = b := by lia
+example (a b : Nat) : min a b ≤ a := by lia
+
+-- The `@[lia]` attribute also works on user lemmas, with the same modifiers as `@[grind]`.
+private def clamp (n : Int) : Int := if n ≤ 0 then 0 else n
+@[lia =] private theorem clamp_def (n : Int) : clamp n = if n ≤ 0 then 0 else n := rfl
+example (n : Int) : 0 ≤ clamp n := by lia
+
+-- The `@[grind]` lemma set stays disabled under `lia`: a `@[grind]`-only lemma is not used,
+-- so `lia` cannot unfold `g`, while `grind` can.
+private def g (n : Int) : Int := n + 1
+@[grind =] private theorem g_def (n : Int) : g n = n + 1 := rfl
+example (n : Int) : g n = n + 1 := by
+  fail_if_success lia
+  grind

--- a/tests/elab/lia_order_bug.lean
+++ b/tests/elab/lia_order_bug.lean
@@ -21,8 +21,6 @@ h : ¬1 ≤ k
     [prop] 2 ≤ k
   [eqc] False propositions
     [prop] 1 ≤ k
-  [limits] Thresholds reached
-    [limit] maximum number of E-matching rounds has been reached, threshold: `(ematch := 0)`
 -/
 #guard_msgs in
 example (k : Rat) (hk : 2 ≤ k) : 1 ≤ k := by lia

--- a/tests/elab/versoDocs.lean
+++ b/tests/elab/versoDocs.lean
@@ -309,13 +309,15 @@ error: Unknown attribute `int`
 Hint: Use a known attribute:
   • ini̲t
   • i̵n̵e̲x̲t
+  • i̵n̵t̵l̲i̲a̲
 ---
 error: Unknown attribute `samp`
 
 Hint: Use a known attribute:
   • s̵a̵m̵p̵s̲i̲m̲p̲
-  • s̵a̵m̵p̵s̲y̲m̲m̲
   • s̵a̵m̵p̵c̲s̲i̲m̲p̲
+  • s̵a̵m̵p̵s̲y̲m̲m̲
+  • s̵a̵m̵p̵l̲i̲a̲
 ---
 error: Unknown attribute `inlone`
 

--- a/tests/elab/versoDocs.lean.out.expected
+++ b/tests/elab/versoDocs.lean.out.expected
@@ -5,7 +5,7 @@ Nat.gcd.induction' {P : Nat → Nat → Prop} (m n : Nat) (H0 : ∀ (n : Nat), P
   (H1 : ∀ (m n : Nat), 0 < m → P (n % m) m → P m n) : P m n
 something : Unit
 yetMore' : Unit
-versoDocs.lean:631:43-631:53: warning: Code element could be more specific.
+versoDocs.lean:633:43-633:53: warning: Code element could be more specific.
 
 Hint: Insert a role to document it:
   • {̲l̲e̲a̲n̲}̲`-checked`


### PR DESCRIPTION
This PR adds a builtin `@[lia]` attribute that supplies a small E-matching lemma set to the `lia` tactic. Previously `lia` (the `cutsat`-only `grind` configuration) ran with E-matching disabled, so it could not see definitional lemmas such as `Nat.max_def`. Now `lia` instantiates only the lemmas tagged `@[lia]`, leaving the much larger `@[grind]` set disabled.

The attribute is wired exactly like `@[grind]` (syntax in `Init.Grind.Attr`, same `registerAttr` mechanism), so it is builtin and can be applied at `src/Init` definition sites. A follow-up PR will tag library lemmas such as `Nat.min_def` and `Nat.max_def`.

🤖 Prepared with Claude Code