### PR TITLE
feat: tag `min`/`max` definitions with `@[lia]`

### DIFF
--- a/src/Init/Data/Int/Order.lean
+++ b/src/Init/Data/Int/Order.lean
@@ -389,9 +389,9 @@ protected theorem le_iff_lt_add_one {a b : Int} : a ≤ b ↔ a < b + 1 := by
 
 /- ### min and max -/
 
-@[grind =] protected theorem min_def (n m : Int) : min n m = if n ≤ m then n else m := rfl
+@[grind =, lia =] protected theorem min_def (n m : Int) : min n m = if n ≤ m then n else m := rfl
 
-@[grind =] protected theorem max_def (n m : Int) : max n m = if n ≤ m then m else n := rfl
+@[grind =, lia =] protected theorem max_def (n m : Int) : max n m = if n ≤ m then m else n := rfl
 
 end Int
 namespace Lean.Meta.Grind.Lia

--- a/src/Init/Data/Nat/Basic.lean
+++ b/src/Init/Data/Nat/Basic.lean
@@ -871,7 +871,7 @@ Examples:
 -/
 protected abbrev min (n m : Nat) := min n m
 
-@[grind =] protected theorem min_def {n m : Nat} : min n m = if n ≤ m then n else m := rfl
+@[grind =, lia =] protected theorem min_def {n m : Nat} : min n m = if n ≤ m then n else m := rfl
 
 instance : Max Nat := maxOfLe
 
@@ -888,7 +888,7 @@ Examples:
 -/
 protected abbrev max (n m : Nat) := max n m
 
-@[grind =] protected theorem max_def {n m : Nat} : max n m = if n ≤ m then m else n := rfl
+@[grind =, lia =] protected theorem max_def {n m : Nat} : max n m = if n ≤ m then m else n := rfl
 
 
 /-! # Auxiliary theorems for well-founded recursion -/

--- a/tests/elab/lia_attr.lean
+++ b/tests/elab/lia_attr.lean
@@ -6,21 +6,21 @@ lemma set, but lemmas tagged with `@[lia]` are instantiated via E-matching, so `
 can see definitions such as `min`/`max`.
 -/
 
--- Without any `@[lia]` lemmas, `lia` treats `min`/`max` as opaque and cannot finish.
-example (a b : Int) : min a b ≤ max a b := by
-  fail_if_success lia
-  grind
-
--- Tagging the defining lemmas adds them to the `@[lia]` set, and now `lia` succeeds.
-attribute [lia =] Int.min_def Int.max_def Nat.min_def Nat.max_def
-
+-- `Nat.min_def`/`Nat.max_def`/`Int.min_def`/`Int.max_def` are tagged `@[lia]`, so `lia`
+-- proves goals involving `min`/`max` out of the box.
 example (a b : Int) : min a b ≤ max a b := by lia
 example (a b : Nat) : min a b ≤ max a b := by lia
 example (a b : Int) (h : a ≤ b) : max a b = b := by lia
 example (a b : Nat) : min a b ≤ a := by lia
 
 -- The `@[lia]` attribute also works on user lemmas, with the same modifiers as `@[grind]`.
+-- Without a `@[lia]` lemma, `lia` treats `clamp` as opaque and cannot finish.
 private def clamp (n : Int) : Int := if n ≤ 0 then 0 else n
+example (n : Int) : 0 ≤ clamp n := by
+  fail_if_success lia
+  unfold clamp; split <;> omega
+
+-- Tagging the defining lemma adds it to the `@[lia]` set, and now `lia` succeeds.
 @[lia =] private theorem clamp_def (n : Int) : clamp n = if n ≤ 0 then 0 else n := rfl
 example (n : Int) : 0 ≤ clamp n := by lia
 


### PR DESCRIPTION
This PR tags `Nat.min_def`, `Nat.max_def`, `Int.min_def`, and `Int.max_def` with the `@[lia]` attribute, so the `lia` tactic instantiates them via E-matching and can prove goals involving `min`/`max` out of the box. This addresses the most common case where `omega` could previously be replaced by `lia` but `lia` could not see the `min`/`max` definitions, requiring a fall back to the full `grind` tactic.

The `@[lia]` attribute itself was added in https://github.com/leanprover/lean4/pull/14098.

🤖 Prepared with Claude Code