### PR TITLE
feat: add `wait_for_expected_type%` term elaborator

### DIFF
--- a/src/Lean/Elab/BuiltinTerm.lean
+++ b/src/Lean/Elab/BuiltinTerm.lean
@@ -157,6 +157,13 @@ private def getMVarFromUserName (ident : Syntax) : MetaM Expr := do
     elabTerm b expectedType?
   | _ => throwUnsupportedSyntax
 
+@[builtin_term_elab «waitForExpectedType»] def elabWaitForExpectedType : TermElab := fun stx expectedType? => do
+  match stx with
+  | `(wait_for_expected_type% $e) =>
+    tryPostponeIfNoneOrMVar expectedType?
+    elabTerm e expectedType?
+  | _ => throwUnsupportedSyntax
+
 register_builtin_option tactic.tryOnEmptyBy : Bool := {
   defValue := false
   descr    := "when an empty `by` block is encountered interactively, run `try?` to suggest \

--- a/src/Lean/Parser/Term.lean
+++ b/src/Lean/Parser/Term.lean
@@ -866,6 +866,10 @@ If `x` cannot be cleared (due to dependencies), it will keep `x` without failing
   "wait_if_type_contains_mvar% " >> "?" >> ident >> "; " >> termParser
 @[builtin_term_parser] def waitIfContainsMVar := leading_parser
   "wait_if_contains_mvar% " >> "?" >> ident >> "; " >> termParser
+/-- `wait_for_expected_type% e` elaborates `e` against its expected type, postponing while that type
+is an unassigned metavariable so an `outParam` determined by instance synthesis is resolved first. -/
+@[builtin_term_parser] def waitForExpectedType := leading_parser
+  "wait_for_expected_type% " >> termParser
 
 @[builtin_term_parser] def defaultOrOfNonempty := leading_parser
   "default_or_ofNonempty% " >> optional "unsafe"

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -23,6 +23,7 @@ options get_default_options() {
 
     opts = opts.update({"pp", "rawOnError"}, true);
 
+    // trigger update-stage0 for the `wait_if_mvar%` builtin term elaborator
 #endif
     return opts;
 }

--- a/tests/elab/waitForExpectedType.lean
+++ b/tests/elab/waitForExpectedType.lean
@@ -1,0 +1,23 @@
+/-!
+Tests for the `wait_for_expected_type%` term elaborator. It postpones elaborating its argument while the
+expected type is an unassigned metavariable, so an `outParam` determined by instance synthesis is
+resolved first. Here that keeps the folded carrier `Carrier` folded instead of having the argument
+unfold it into `Nat → Nat`.
+-/
+
+def Carrier : Type := Nat → Nat
+class Sel (α : Type) (β : outParam Type) where
+instance : Sel Unit Carrier := ⟨⟩
+def sel {α β} [Sel α β] (_ : α) (g : β) : β := g
+
+/-- info: sel () fun n => n : Carrier -/
+#guard_msgs in
+#check sel () (wait_for_expected_type% (fun n => n))
+
+/-- info: sel () fun n => n : Nat → Nat -/
+#guard_msgs in
+#check sel () (fun n => n)
+
+/-- info: 5 : Nat -/
+#guard_msgs in
+#check wait_for_expected_type% (5 : Nat)


### PR DESCRIPTION
This PR adds the `wait_for_expected_type%` term elaborator, which elaborates its argument against the expected type but postpones while that type is an unassigned metavariable. This lets a notation defer an assertion until an `outParam` is resolved by instance synthesis, so a bare lambda checks against the folded carrier instead of unfolding it into a pointwise function lattice.