### PR TITLE
fix: reject `sym` `apply` with an unresolved instance argument

### DIFF
--- a/src/Lean/Meta/Sym/Apply.lean
+++ b/src/Lean/Meta/Sym/Apply.lean
@@ -131,6 +131,14 @@ Returns `.notApplicable` if unification fails.
 public def BackwardRule.apply (mvarId : MVarId) (rule : BackwardRule) : SymM ApplyResult := mvarId.withContext do
   let decl ← mvarId.getDecl
   if let some result ← rule.pattern.unify? decl.type then
+    -- `mkResultPos` drops instance arguments from `resultPos`, assuming type class
+    -- resolution fills them. One that was neither synthesized nor unified makes
+    -- the rule inapplicable.
+    if let some varInfos := rule.pattern.varInfos? then
+      for h : i in *...result.args.size do
+        if varInfos.argsInfo[i]!.isInstance then
+          if let .mvar m := result.args[i] then
+            unless (← m.isAssigned) do return .failed
     mvarId.assign (mkValue rule.expr rule.pattern result)
     return .goals <| rule.resultPos.map fun i =>
       result.args[i]!.mvarId!

--- a/tests/elab/sym_apply_bug.lean
+++ b/tests/elab/sym_apply_bug.lean
@@ -25,3 +25,9 @@ example (pre rhs : Nat → Prop) : PlainRel pre rhs := by
 
 example (pre rhs : Nat → Prop) : PlainRel pre rhs := by
   sym => apply plainFoo''
+
+-- An unsynthesizable instance argument makes `apply` fail rather than leaving a
+-- loose instance metavariable in the proof.
+/-- error: `apply` failed, rule is not applicable -/
+#guard_msgs in
+example : False := by sym => apply Inhabited.default


### PR DESCRIPTION
`Lean.Meta.Sym.BackwardRule.apply` takes its subgoals from `mkResultPos`, which
drops instance arguments on the assumption that type class resolution discharges
them. When `trySynthInstance` fails for an instance argument and unification does
not assign it, `mkPreResult` substitutes a fresh metavariable that is neither
returned as a subgoal nor otherwise resolved. The goal was closed with a proof
carrying that metavariable, surfacing later as a kernel unresolved-metavariable
error.

`apply` now checks, when handing out the subgoals, that every instance argument is
assigned (synthesized or unified). An unassigned one makes the rule inapplicable.

```lean
example : False := by sym => apply Inhabited.default
```
reports `` `apply` failed, rule is not applicable ``.
