### PR TITLE
refactor: give the `⦃ … ⦄` notation a single exceptional-postcondition slot

### DIFF
--- a/src/Std/Internal/Do/Triple/Basic.lean
+++ b/src/Std/Internal/Do/Triple/Basic.lean
@@ -68,10 +68,13 @@ scoped syntax:60 (name := tripleNotation)
 /-- Hoare triple notation with a binder for the return value. -/
 scoped syntax:60 (name := tripleBinderNotation)
   "⦃ " term " ⦄ " (atomic("(" ident " := ") term ")")? term " ⦃ " ident ", " term " ⦄" : term
-/-- Hoare triple notation with explicit exception postconditions:
-`⦃ P ⦄ x ⦃ Q; E₁; … ⦄ := Triple x P Q epost⟨E₁, …⟩`. -/
+/-- Hoare triple notation with an exception postcondition:
+`⦃ P ⦄ x ⦃ Q; E ⦄ := Triple x P Q E`. -/
 scoped syntax:60 (name := tripleEPost)
-  "⦃ " term " ⦄ " (atomic("(" ident " := ") term ")")? term " ⦃ " term "; " sepBy1(term, "; ") " ⦄" : term
+  "⦃ " term " ⦄ " (atomic("(" ident " := ") term ")")? term " ⦃ " term "; " term " ⦄" : term
+/-- Hoare triple notation with a binder for the return value and an exception postcondition. -/
+scoped syntax:60 (name := tripleBinderEPost)
+  "⦃ " term " ⦄ " (atomic("(" ident " := ") term ")")? term " ⦃ " ident ", " term "; " term " ⦄" : term
 
 macro_rules (kind := tripleNotation)
   | `(⦃ $P ⦄ $[(m := $m)]? $c ⦃ $Q ⦄) => do `(Triple $(← hintProgram c m) $P $Q Lean.Order.bot)
@@ -79,15 +82,17 @@ macro_rules (kind := tripleBinderNotation)
   | `(⦃ $P ⦄ $[(m := $m)]? $c ⦃ $v, $Q ⦄) => do
       `(Triple $(← hintProgram c m) $P (fun $v => $Q) Lean.Order.bot)
 macro_rules (kind := tripleEPost)
-  | `(⦃ $P ⦄ $[(m := $m)]? $c ⦃ $Q; $Es;* ⦄) => do `(Triple $(← hintProgram c m) $P $Q epost⟨$Es,*⟩)
+  | `(⦃ $P ⦄ $[(m := $m)]? $c ⦃ $Q; $E ⦄) => do `(Triple $(← hintProgram c m) $P $Q $E)
+macro_rules (kind := tripleBinderEPost)
+  | `(⦃ $P ⦄ $[(m := $m)]? $c ⦃ $v, $Q; $E ⦄) => do
+      `(Triple $(← hintProgram c m) $P (fun $v => $Q) $E)
 
 /-- Pretty-print `Triple` applications back as `⦃ … ⦄` notation. -/
 @[app_unexpander Triple]
 meta def unexpandTriple : Lean.PrettyPrinter.Unexpander
-  | `($(_) $c $P $Q epost⟨$Es,*⟩) =>
-    if Es.getElems.isEmpty then throw () else `(⦃ $P ⦄ $c ⦃ $Q; $Es;* ⦄)
   | `($(_) $c $P $Q ⊥) => `(⦃ $P ⦄ $c ⦃ $Q ⦄)
   | `($(_) $c $P $Q Lean.Order.bot) => `(⦃ $P ⦄ $c ⦃ $Q ⦄)
+  | `($(_) $c $P $Q $E) => `(⦃ $P ⦄ $c ⦃ $Q; $E ⦄)
   | _ => throw ()
 
 namespace Triple

--- a/tests/bench/vcgen/cases/Cases/AddSubCancel.lean
+++ b/tests/bench/vcgen/cases/Cases/AddSubCancel.lean
@@ -19,13 +19,13 @@ set_option mvcgen.warning false
 @[spec high] theorem spec_get_StateT {m : Type u → Type v} {Pred EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {σ : Type u} (post : σ → σ → Pred) (epost : EPred) :
-    Triple (get : StateT σ m σ) (fun s => post s s) post epost := by
+    ⦃ fun s => post s s ⦄ (get : StateT σ m σ) ⦃ post; epost ⦄ := by
   vcgen
 
 @[spec high] theorem spec_set_StateT' {m : Type u → Type v} {Pred EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {σ : Type u} (s : σ) (post : PUnit → σ → Pred) (epost : EPred) :
-    Triple (set s : StateT σ m PUnit) (fun _ => post ⟨⟩ s) post epost := by
+    ⦃ fun _ => post ⟨⟩ s ⦄ (set s : StateT σ m PUnit) ⦃ post; epost ⦄ := by
   vcgen
 
 def step (v : Nat) : StateM Nat Unit := do

--- a/tests/bench/vcgen/cases/Cases/DiteSplit.lean
+++ b/tests/bench/vcgen/cases/Cases/DiteSplit.lean
@@ -15,7 +15,7 @@ set_option mvcgen.warning false
 abbrev M := ExceptT String <| StateM Nat
 
 @[spec high] theorem spec_throw (e : String) {post : α → Nat → Prop} :
-    ⦃epost e⦄ (throw (m := M) e) ⦃post; epost⦄ := ⟨PartialOrder.rel_refl⟩
+    ⦃epost e⦄ (throw (m := M) e) ⦃post; epost⟨epost⟩⦄ := ⟨PartialOrder.rel_refl⟩
 
 @[spec high] theorem spec_set (x : Nat) {post : PUnit → Nat → Prop} :
     ⦃fun _ => post ⟨⟩ x⦄ (set (m := M) x) ⦃post⦄ := ⟨PartialOrder.rel_refl⟩

--- a/tests/bench/vcgen/cases/Cases/GetThrowSet.lean
+++ b/tests/bench/vcgen/cases/Cases/GetThrowSet.lean
@@ -18,7 +18,7 @@ abbrev M := ExceptT String <| StateM Nat
 -- Partially evaluated specs for best performance.
 
 @[spec high] theorem spec_throw (e : String) {post : α → Nat → Prop} :
-    ⦃epost e⦄ (throw (m := M) e) ⦃post; epost⦄ := ⟨PartialOrder.rel_refl⟩
+    ⦃epost e⦄ (throw (m := M) e) ⦃post; epost⟨epost⟩⦄ := ⟨PartialOrder.rel_refl⟩
 
 @[spec high] theorem spec_set (x : Nat) :
     ⦃fun _ => post ⟨⟩ x⦄ (set (m := M) x) ⦃post⦄ := by

--- a/tests/bench/vcgen/cases/Cases/LetBinding.lean
+++ b/tests/bench/vcgen/cases/Cases/LetBinding.lean
@@ -17,13 +17,13 @@ set_option mvcgen.warning false
 @[spec high] theorem spec_get_StateT {m : Type u → Type v} {Pred EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {σ : Type u} (post : σ → σ → Pred) (epost : EPred) :
-    Triple (get : StateT σ m σ) (fun s => post s s) post epost := by
+    ⦃ fun s => post s s ⦄ (get : StateT σ m σ) ⦃ post; epost ⦄ := by
   vcgen
 
 @[spec high] theorem spec_set_StateT' {m : Type u → Type v} {Pred EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {σ : Type u} (s : σ) (post : PUnit → σ → Pred) (epost : EPred) :
-    Triple (set s : StateT σ m PUnit) (fun _ => post ⟨⟩ s) post epost := by
+    ⦃ fun _ => post ⟨⟩ s ⦄ (set s : StateT σ m PUnit) ⦃ post; epost ⦄ := by
   vcgen
 
 def step (v : Nat) : StateM Nat Unit := do

--- a/tests/bench/vcgen/cases/Cases/MatchIota.lean
+++ b/tests/bench/vcgen/cases/Cases/MatchIota.lean
@@ -17,7 +17,7 @@ set_option mvcgen.warning false
 abbrev M := ExceptT String <| StateM Nat
 
 @[spec high] theorem spec_throw (e : String) {post : α → Nat → Prop} :
-    ⦃epost e⦄ (throw (m := M) e) ⦃post; epost⦄ := ⟨PartialOrder.rel_refl⟩
+    ⦃epost e⦄ (throw (m := M) e) ⦃post; epost⟨epost⟩⦄ := ⟨PartialOrder.rel_refl⟩
 
 @[spec high] theorem spec_set (x : Nat) {post : PUnit → Nat → Prop} :
     ⦃fun _ => post ⟨⟩ x⦄ (set (m := M) x) ⦃post⦄ := ⟨PartialOrder.rel_refl⟩

--- a/tests/bench/vcgen/cases/Cases/MatchSplit.lean
+++ b/tests/bench/vcgen/cases/Cases/MatchSplit.lean
@@ -18,7 +18,7 @@ set_option mvcgen.warning false
 abbrev M := ExceptT String <| StateM Nat
 
 @[spec high] theorem spec_throw (e : String) {post : α → Nat → Prop} :
-    ⦃epost e⦄ (throw (m := M) e) ⦃post; epost⦄ := ⟨PartialOrder.rel_refl⟩
+    ⦃epost e⦄ (throw (m := M) e) ⦃post; epost⟨epost⟩⦄ := ⟨PartialOrder.rel_refl⟩
 
 @[spec high] theorem spec_set (x : Nat) {post : PUnit → Nat → Prop} :
     ⦃fun _ => post ⟨⟩ x⦄ (set (m := M) x) ⦃post⦄ := ⟨PartialOrder.rel_refl⟩

--- a/tests/bench/vcgen/test_do_logic.lean
+++ b/tests/bench/vcgen/test_do_logic.lean
@@ -177,7 +177,7 @@ theorem throwing_loop_spec :
   ⦃fun s => s = 4⦄
   throwing_loop
   ⦃fun _ _ => False;
-  fun e s => e = 42 ∧ s = 4⦄ := by
+  epost⟨fun e s => e = 42 ∧ s = 4⟩⦄ := by
   vcgen [throwing_loop]
   case inv1 => exact fun xs r s => r ≤ 4 ∧ s = 4 ∧ r + xs.suffix.sum > 4
   all_goals (simp_all; try grind)
@@ -687,8 +687,7 @@ def incr (n : Nat) : StateT Nat m PUnit := modify (· + n)
 @[spec]
 theorem Spec.incr
     (post : PUnit → Nat → Pred) (epost : EPred) (n : Nat) :
-    Triple (incr n : StateT Nat m PUnit)
-      (fun s => post ⟨⟩ (s + n)) post epost := by
+    ⦃ fun s => post ⟨⟩ (s + n) ⦄ (incr n : StateT Nat m PUnit) ⦃ post; epost ⦄ := by
   vcgen [TopBetaReduction.incr]; rfl
 
 /--

--- a/tests/elab/vcgenDepAssertionLattice.lean
+++ b/tests/elab/vcgenDepAssertionLattice.lean
@@ -71,5 +71,5 @@ error: failed to apply Lean.Order.le_of_forall_le to goal
   Lean.Order.PartialOrder.rel (fun x x_1 => True) (wp (pure PUnit.unit) (fun x x_1 x_2 => True) epost⟨⟩)
 -/
 #guard_msgs in
-example : Triple (pure () : Stateful Unit) (fun _ _ => True) (fun _ _ _ => True) epost⟨⟩ := by
+example : ⦃ fun _ _ => True ⦄ (pure () : Stateful Unit) ⦃ fun _ _ _ => True; epost⟨⟩ ⦄ := by
   vcgen


### PR DESCRIPTION
This PR changes the Hoare-triple notation so `;` introduces the exceptional postcondition as a single `EPred` term rather than a list of exception cases wrapped in `epost⟨…⟩`. This lets the notation express an `epost` variable or any `EPred`, and makes `epost⟨…⟩` an ordinary explicit constructor written in that slot.