### PR TITLE
fix: deadlock using `Selectable.combine`

### DIFF
--- a/src/Std/Async/Select.lean
+++ b/src/Std/Async/Select.lean
@@ -208,15 +208,12 @@ Creates a `Selector` that performs fair and data-loss free multiplexing on multi
 This allows the multiplexing operation to be composed with other selectors.
 -/
 def Selectable.combine (selectables : Array (Selectable α)) : IO (Selector α) := do
-  if selectables.isEmpty then
-    throw <| .userError "Selectable.one requires at least one Selectable"
-
-  let seed := UInt64.toNat (ByteArray.toUInt64LE! (← IO.getRandomBytes 8))
-  let gen := mkStdGen seed
-  let selectables := shuffleIt selectables gen
-
   return {
     tryFn := do
+      let seed := UInt64.toNat (ByteArray.toUInt64LE! (← IO.getRandomBytes 8))
+      let gen := mkStdGen seed
+      let selectables := shuffleIt selectables gen
+
       for selectable in selectables do
         if let some val ← selectable.selector.tryFn then
           let result ← selectable.cont val
@@ -224,12 +221,16 @@ def Selectable.combine (selectables : Array (Selectable α)) : IO (Selector α) 
       return none
 
     registerFn := fun waiter => do
+      let gate ← IO.Promise.new
+
+      let seed := UInt64.toNat (ByteArray.toUInt64LE! (← IO.getRandomBytes 8))
+      let gen := mkStdGen seed
+      let selectables := shuffleIt selectables gen
+
       for selectable in selectables do
         let waiterPromise ← IO.Promise.new
         let derivedWaiter := Waiter.mk waiter.finished waiterPromise
         selectable.selector.registerFn derivedWaiter
-
-        let barrier ← IO.Promise.new
 
         discard <| IO.bindTask (t := waiterPromise.result?) fun res? => do
           match res? with
@@ -238,7 +239,7 @@ def Selectable.combine (selectables : Array (Selectable α)) : IO (Selector α) 
             let async : Async _ := do
               let mainPromise := waiter.promise
 
-              await barrier
+              await gate
               for selectable in selectables do
                 selectable.selector.unregisterFn
 
@@ -249,6 +250,8 @@ def Selectable.combine (selectables : Array (Selectable α)) : IO (Selector α) 
               catch e =>
                 mainPromise.resolve (.error e)
             async.toBaseIO
+
+      gate.resolve ()
 
     unregisterFn := do
       for selectable in selectables do

--- a/src/Std/Async/Select.lean
+++ b/src/Std/Async/Select.lean
@@ -148,7 +148,7 @@ partial def Selectable.one (selectables : Array (Selectable α)) : Async α := d
     let waiter := Waiter.mk finished waiterPromise
     selectable.selector.registerFn waiter
 
-    discard <| IO.bindTask (t := waiterPromise.result?) (sync := true) fun res? => do
+    discard <| IO.bindTask (t := waiterPromise.result?) fun res? => do
       match res? with
       | none =>
         /-

--- a/tests/elab/async_select_combine.lean
+++ b/tests/elab/async_select_combine.lean
@@ -1,0 +1,30 @@
+import Std.Async
+import Std.Sync.Channel
+
+open Std.Async
+open Std (CloseableChannel)
+
+def testLateFire : IO (Option Nat) := do
+  let ch ← CloseableChannel.new (α := Nat)
+  discard <| IO.asTask (prio := .dedicated) do
+    IO.sleep 50
+    ch.send 1
+  let sel ← Selectable.combine #[.case ch.recvSelector fun n? => return n?]
+  Async.block do
+    Selectable.one #[.case sel fun n? => return n?]
+
+/-- info: some 1 -/
+#guard_msgs in
+#eval testLateFire
+
+/-- A value already ready before selection should be delivered immediately. -/
+def testReady : IO (Option Nat) := do
+  let ch ← CloseableChannel.new (α := Nat)
+  ch.sync.send 1
+  let sel ← Selectable.combine #[.case ch.recvSelector fun n? => return n?]
+  Async.block do
+    Selectable.one #[.case sel fun n? => return n?]
+
+/-- info: some 1 -/
+#guard_msgs in
+#eval testReady

--- a/tests/elab/async_select_combine.lean
+++ b/tests/elab/async_select_combine.lean
@@ -17,7 +17,6 @@ def testLateFire : IO (Option Nat) := do
 #guard_msgs in
 #eval testLateFire
 
-/-- A value already ready before selection should be delivered immediately. -/
 def testReady : IO (Option Nat) := do
   let ch ← CloseableChannel.new (α := Nat)
   ch.sync.send 1


### PR DESCRIPTION
This PR fixes the deadlock using `Selectable.combine` and also fixes a simple problem with recursive mutexes in `Selectable.one`. This PR fixes #14090