### PR TITLE
feat: cost metrics for the grind e-matching graph

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/EMatchDiagnostics.lean
+++ b/src/Lean/Meta/Tactic/Grind/EMatchDiagnostics.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Henrik Böving
+-/
+module
+prelude
+public import Lean.Meta.Tactic.Grind.Types
+import Init.Data.List.Sort
+
+/-!
+This module implements analysis tools for e-matching instantiation graphs. They are used to provide
+the user insights on potential issues with e-matching in a proof.
+-/
+
+namespace Lean.Meta.Grind
+
+structure NodeInfo where
+  children : Std.HashSet EMatchDiagNode
+  lctx : LocalContext
+  deriving Inhabited
+
+structure InstGraph where
+  info : Std.HashMap EMatchDiagNode NodeInfo := {}
+  deriving Inhabited
+
+namespace InstGraph
+
+def registerNode (graph : InstGraph) (info : EMatchDiagInfo) : InstGraph :=
+  { graph with info := graph.info.insert info.target { children := {}, lctx := info.lctx } }
+
+def addEdge (graph : InstGraph) (src dst : EMatchDiagNode) : InstGraph :=
+  { graph with
+      info := graph.info.modify src fun info => { info with children := info.children.insert dst }
+  }
+
+def ofTrace (trace : Array EMatchDiagInfo) : InstGraph := Id.run do
+  let mut graph := trace.foldl (init := {}) registerNode
+  for entry in trace do
+    for source in entry.sources do
+      graph := graph.addEdge source entry.target
+  return graph
+
+end InstGraph
+
+abbrev GraphM := ReaderT InstGraph MetaM
+
+def formatCost (cost : Float) : String :=
+  let tenths := (cost * 10).round.toUInt64.toNat
+  s!"{tenths / 10}.{tenths % 10}"
+
+def mkBranchingMessages (cost : Std.HashMap EMatchDiagNode Float) : GraphM (Option MessageData) := do
+  let limit := grind.ematch.diagnostics.branchThreshold.get (← getOptions)
+  let nodes := (← read).info.toList
+    |>.filter (·.2.children.size ≥ limit)
+    |>.mergeSort fun lhs rhs => Prod.lexLt (rhs.2.children.size, cost[rhs.1]!) (lhs.2.children.size, cost[lhs.1]!)
+  if nodes.isEmpty then return none
+
+  let mut msgs := #[]
+  for (node, { children, lctx }) in nodes do
+    let childrenCount := children.size
+    msgs := msgs.push <| ← withLCtx' lctx do
+      let children ← children.toArray.mapM fun c => do
+        withLCtx' (← read).info[c]!.lctx do
+          addMessageContext <| .trace { cls := `thm } m!"{c.origin.pp}: {← inferType c.proof}" #[]
+      let t := .trace { cls := `thm } m!"{node.origin.pp}: {← inferType node.proof} has {childrenCount} direct follow up instances" children
+      addMessageContext t
+
+  return some <| .trace { cls := `thm } "Excessively Branching Instances" msgs
+
+def mkCostMessages (diag : Array EMatchDiagInfo) :
+    GraphM (Option MessageData × Std.HashMap EMatchDiagNode Float):= do
+  let acc := Std.HashMap.ofArray <| (← read).info.keysArray.map (·, 1.0)
+  let costs := diag.foldr (init := acc) fun v acc => Id.run do
+    let mut acc := acc
+    let costV : Float := acc[v.target]!
+    let numParents := v.sources.length.toFloat
+    for parent in v.sources do
+      acc := acc.modify parent (· + costV / numParents)
+    return acc
+  let limit := grind.ematch.diagnostics.costThreshold.get (← getOptions) |>.toFloat
+  let nodes := (← read).info.toList
+    |>.filter (costs[·.1]! ≥ limit)
+    |>.mergeSort (fun lhs rhs => costs[rhs.1]! ≤ costs[lhs.1]!)
+  if nodes.isEmpty then return (none, costs)
+
+  let mut msgs := #[]
+  for (node, info) in nodes do
+    msgs := msgs.push <| ← withLCtx' info.lctx do
+      addMessageContext <| .trace { cls := `thm } m!"{node.origin.pp} : {← inferType node.proof} ↦ {formatCost costs[node]!}" #[]
+  let msg := .trace { cls := `thm } "High Cost Instances" msgs
+  return (some msg, costs)
+
+def countersWithOriginToMessageData (header : String) (cls : Name) (data : Array (Origin × Name × Nat)) : MetaM MessageData := do
+  let data := data.qsort fun (_, n₁, c₁) (_, n₂, c₂) => if c₁ == c₂ then Name.lt n₁ n₂ else c₁ > c₂
+  let data ← data.mapM fun (origin, name, counter) =>
+    match origin with
+    | .decl _ => return .trace { cls } m!"{.ofConstName name} ↦ {counter}" #[]
+    | _ => return .trace { cls } m!"{name} ↦ {counter}" #[]
+  return .trace { cls } header data
+
+def counterMsgs (counters : Counters) : MetaM MessageData :=
+  let counters := counters.thm.toArray.map fun (origin, c) => Id.run do
+    match origin with
+    | .fvar fvarId =>
+      let some userName := counters.fvarUserNames.find? fvarId | unreachable!
+      return (origin, userName, c)
+    | .decl n => return (origin, n, c)
+    | .local n => return (origin, n, c)
+    | .stx n _ => return (origin, n, c)
+  countersWithOriginToMessageData "Theorem Instance Count" `thm counters
+
+public def mkEMatchDiagMessages (trace : PArray EMatchDiagInfo) (counters : Counters) :
+    MetaM (Option MessageData) := do
+  let mut msgs := #[]
+
+  unless counters.thm.isEmpty do
+    msgs := msgs.push (← counterMsgs counters)
+
+  unless trace.isEmpty do
+    let trace := trace.toArray
+    let graph := InstGraph.ofTrace trace
+
+    let (msg?, cost) ← ReaderT.run (mkCostMessages trace) graph
+    if let some msg := msg? then msgs := msgs.push msg
+
+    let msg? ← ReaderT.run (mkBranchingMessages cost) graph
+    if let some msg := msg? then msgs := msgs.push msg
+
+  if msgs.isEmpty then return none
+
+  return some <| .trace { cls := `ematch } "E-matching Diagnostics" msgs
+
+end Lean.Meta.Grind

--- a/src/Lean/Meta/Tactic/Grind/Main.lean
+++ b/src/Lean/Meta/Tactic/Grind/Main.lean
@@ -26,6 +26,7 @@ import Lean.Meta.Tactic.Grind.LawfulEqCmp
 import Lean.Meta.Tactic.Grind.ReflCmp
 import Lean.Meta.Tactic.Grind.PP
 import Lean.Meta.Tactic.Grind.Core
+import Lean.Meta.Tactic.Grind.EMatchDiagnostics
 public section
 namespace Lean.Meta.Grind
 
@@ -194,14 +195,6 @@ private def countersToMessageData (header : String) (cls : Name) (data : Array (
     return .trace { cls } m!"{.ofConstName declName} ↦ {counter}" #[]
   return .trace { cls } header data
 
-private def countersWithOriginToMessageData (header : String) (cls : Name) (data : Array (Origin × Name × Nat)) : MetaM MessageData := do
-  let data := data.qsort fun (_, n₁, c₁) (_, n₂, c₂) => if c₁ == c₂ then Name.lt n₁ n₂ else c₁ > c₂
-  let data ← data.mapM fun (origin, name, counter) =>
-    match origin with
-    | .decl _ => return .trace { cls } m!"{.ofConstName name} ↦ {counter}" #[]
-    | _ => return .trace { cls } m!"{name} ↦ {counter}" #[]
-  return .trace { cls } header data
-
 private def splitDiagInfoToMessageData (ss : Array SplitDiagInfo) : MetaM MessageData := do
   let env  ← getEnv
   let mctx ← getMCtx
@@ -217,20 +210,13 @@ private def splitDiagInfoToMessageData (ss : Array SplitDiagInfo) : MetaM Messag
   return .trace { cls } "Case splits" data
 
 -- Diagnostics information for the whole search
-private def mkGlobalDiag (cs : Counters) (simp : Simp.Stats) (ss : PArray SplitDiagInfo) : MetaM (Option MessageData) := do
+private def mkGlobalDiag (cs : Counters) (simp : Simp.Stats) (ss : PArray SplitDiagInfo)
+    (ematchDiags : PArray EMatchDiagInfo) : MetaM (Option MessageData) := do
   -- We do not report `cases` applications on builtin types
   let cases := cs.case.toList.toArray.filter fun (declName, _) => !isBuiltinEagerCases declName
   let mut msgs := #[]
-  unless cs.thm.isEmpty do
-    let thms := cs.thm.toList.toArray.map fun (origin, c) => Id.run do
-      match origin with
-      | .fvar fvarId =>
-        let some userName := cs.fvarUserNames.find? fvarId | unreachable!
-        return (origin, userName, c)
-      | .decl n => return (origin, n, c)
-      | .local n => return (origin, n, c)
-      | .stx n _ => return (origin, n, c)
-    msgs := msgs.push <| (← countersWithOriginToMessageData "E-Matching instances" `thm thms)
+  if let some msg ← mkEMatchDiagMessages ematchDiags cs then
+    msgs := msgs.push <| msg
   let ss := ss.toArray.filter fun { numCases, .. } => numCases > 1
   unless ss.isEmpty do
     msgs := msgs.push <| (← splitDiagInfoToMessageData ss)
@@ -261,7 +247,7 @@ def Result.toMessageData (result : Result) : MetaM MessageData := do
     -/
     unless issues.isEmpty do
       msgs := msgs ++ [.trace { cls := `grind } "Issues" issues.reverse.toArray]
-    if let some msg ← mkGlobalDiag result.counters result.simp result.splitDiags then
+    if let some msg ← mkGlobalDiag result.counters result.simp result.splitDiags result.ematchDiags then
       msgs := msgs ++ [msg]
   return MessageData.joinSep msgs m!"\n"
 
@@ -382,7 +368,7 @@ def mkResult (params : Params) (failure? : Option Goal) : GrindM Result := do
   if failure?.isNone then
     -- If there are no failures and diagnostics are enabled, we still report the performance counters.
     if (← isDiagnosticsEnabled) then
-      if let some msg ← mkGlobalDiag counters simp splitDiags then
+      if let some msg ← mkGlobalDiag counters simp splitDiags ematchDiags then
         logInfo msg
   return { failure?, issues, config := params.config, counters, simp, splitDiags, ematchDiags }
 

--- a/src/Lean/Meta/Tactic/Grind/Types.lean
+++ b/src/Lean/Meta/Tactic/Grind/Types.lean
@@ -89,6 +89,16 @@ register_builtin_option grind.ematch.diagnostics : Bool := {
   descr    := "enable E-matching theorem instantiation diagnostics"
 }
 
+register_builtin_option grind.ematch.diagnostics.costThreshold : Nat := {
+  defValue := 10
+  descr    := "report E-matching instances that were at least this costly (roughly the size of their transitive closure of follow up instances)"
+}
+
+register_builtin_option grind.ematch.diagnostics.branchThreshold : Nat := {
+  defValue := 10
+  descr    := "report E-matching instances that participated in at least this many other instances directly"
+}
+
 /--
 Anchors are used to reference terms, local theorems, and case-splits in the `grind` state.
 We also use anchors to prune the search space when they are provided as `grind` parameters

--- a/tests/elab/grind_ctor_ematch.lean
+++ b/tests/elab/grind_ctor_ematch.lean
@@ -48,9 +48,10 @@ h : ¬Even 16
   [limits] Thresholds reached
     [limit] maximum number of E-matching rounds has been reached, threshold: `(ematch := 5)`
 [grind] Diagnostics
-  [thm] E-Matching instances
-    [thm] Even.plus_two ↦ 5
-    [thm] Even.zero ↦ 1
+  [ematch] E-matching Diagnostics
+    [thm] Theorem Instance Count
+      [thm] Even.plus_two ↦ 5
+      [thm] Even.zero ↦ 1
 -/
 #guard_msgs (error) in
 example : Even 16 := by

--- a/tests/elab/grind_ematch_diag_2.lean
+++ b/tests/elab/grind_ematch_diag_2.lean
@@ -1,0 +1,428 @@
+module
+
+public section
+
+/-! This module tests the new grind ematching diagnostics through a small example ported from Viper -/
+
+axiom Slice : Type
+axiom Address : Type
+axiom Heap : Type
+
+axiom slot : Slice → Nat → Address
+axiom lookup : Heap → Address → Nat
+axiom next : Address → Address
+
+set_option warn.sorry false
+
+
+theorem inj : ∀ slice i j, i ≠ j → slot slice i ≠ slot slice j := sorry
+
+grind_pattern inj => slot slice i, slot slice j where
+  i =/= j
+
+theorem next_def : ∀ slice i, next (slot slice i) = slot slice (i + 1) := sorry
+
+grind_pattern next_def => slot slice i
+
+axiom heap : Heap
+axiom s : Slice
+axiom idx : Nat
+axiom len : Nat
+
+theorem sorted : ∀ i, i < len → lookup heap (slot s i) ≤ lookup heap (next (slot s i)) := sorry
+
+grind_pattern sorted => lookup heap (slot s i)
+
+/--
+error: `grind` failed
+case grind.1.1.1.1.1.1.1
+h1 : idx < len
+h : lookup heap (next (slot s idx)) ≤ lookup heap (slot s idx)
+h_1 : idx + 2 ≤ len
+h_2 : idx + 3 ≤ len
+h_3 : idx + 4 ≤ len
+h_4 : idx + 5 ≤ len
+h_5 : idx + 6 ≤ len
+h_6 : idx + 7 ≤ len
+h_7 : idx + 8 ≤ len
+⊢ False
+[grind] Goal diagnostics
+  [facts] Asserted facts
+    [prop] idx + 1 ≤ len
+    [prop] lookup heap (next (slot s idx)) ≤ lookup heap (slot s idx)
+    [prop] next (slot s idx) = slot s (idx + 1)
+    [prop] idx + 1 ≤ len → lookup heap (slot s idx) ≤ lookup heap (next (slot s idx))
+    [prop] next (slot s (idx + 1)) = slot s (idx + 2)
+    [prop] ¬slot s (idx + 1) = slot s idx
+    [prop] ¬slot s idx = slot s (idx + 1)
+    [prop] idx + 2 ≤ len → lookup heap (slot s (idx + 1)) ≤ lookup heap (next (slot s (idx + 1)))
+    [prop] next (slot s (idx + 2)) = slot s (idx + 3)
+    [prop] ¬slot s (idx + 2) = slot s idx
+    [prop] ¬slot s (idx + 2) = slot s (idx + 1)
+    [prop] ¬slot s idx = slot s (idx + 2)
+    [prop] ¬slot s (idx + 1) = slot s (idx + 2)
+    [prop] idx + 3 ≤ len → lookup heap (slot s (idx + 2)) ≤ lookup heap (next (slot s (idx + 2)))
+    [prop] next (slot s (idx + 3)) = slot s (idx + 4)
+    [prop] ¬slot s (idx + 3) = slot s idx
+    [prop] ¬slot s (idx + 3) = slot s (idx + 1)
+    [prop] ¬slot s (idx + 3) = slot s (idx + 2)
+    [prop] ¬slot s idx = slot s (idx + 3)
+    [prop] ¬slot s (idx + 1) = slot s (idx + 3)
+    [prop] ¬slot s (idx + 2) = slot s (idx + 3)
+    [prop] idx + 4 ≤ len → lookup heap (slot s (idx + 3)) ≤ lookup heap (next (slot s (idx + 3)))
+    [prop] next (slot s (idx + 4)) = slot s (idx + 5)
+    [prop] ¬slot s (idx + 4) = slot s idx
+    [prop] ¬slot s (idx + 4) = slot s (idx + 1)
+    [prop] ¬slot s (idx + 4) = slot s (idx + 2)
+    [prop] ¬slot s (idx + 4) = slot s (idx + 3)
+    [prop] ¬slot s idx = slot s (idx + 4)
+    [prop] ¬slot s (idx + 1) = slot s (idx + 4)
+    [prop] ¬slot s (idx + 2) = slot s (idx + 4)
+    [prop] ¬slot s (idx + 3) = slot s (idx + 4)
+    [prop] idx + 5 ≤ len → lookup heap (slot s (idx + 4)) ≤ lookup heap (next (slot s (idx + 4)))
+    [prop] idx + 2 ≤ len
+    [prop] next (slot s (idx + 5)) = slot s (idx + 6)
+    [prop] ¬slot s (idx + 5) = slot s idx
+    [prop] ¬slot s (idx + 5) = slot s (idx + 1)
+    [prop] ¬slot s (idx + 5) = slot s (idx + 2)
+    [prop] ¬slot s (idx + 5) = slot s (idx + 3)
+    [prop] ¬slot s (idx + 5) = slot s (idx + 4)
+    [prop] ¬slot s idx = slot s (idx + 5)
+    [prop] ¬slot s (idx + 1) = slot s (idx + 5)
+    [prop] ¬slot s (idx + 2) = slot s (idx + 5)
+    [prop] ¬slot s (idx + 3) = slot s (idx + 5)
+    [prop] ¬slot s (idx + 4) = slot s (idx + 5)
+    [prop] idx + 6 ≤ len → lookup heap (slot s (idx + 5)) ≤ lookup heap (next (slot s (idx + 5)))
+    [prop] next (slot s (idx + 6)) = slot s (idx + 7)
+    [prop] ¬slot s (idx + 6) = slot s idx
+    [prop] ¬slot s (idx + 6) = slot s (idx + 1)
+    [prop] ¬slot s (idx + 6) = slot s (idx + 2)
+    [prop] ¬slot s (idx + 6) = slot s (idx + 3)
+    [prop] ¬slot s (idx + 6) = slot s (idx + 4)
+    [prop] ¬slot s (idx + 6) = slot s (idx + 5)
+    [prop] ¬slot s idx = slot s (idx + 6)
+    [prop] ¬slot s (idx + 1) = slot s (idx + 6)
+    [prop] ¬slot s (idx + 2) = slot s (idx + 6)
+    [prop] ¬slot s (idx + 3) = slot s (idx + 6)
+    [prop] ¬slot s (idx + 4) = slot s (idx + 6)
+    [prop] ¬slot s (idx + 5) = slot s (idx + 6)
+    [prop] idx + 7 ≤ len → lookup heap (slot s (idx + 6)) ≤ lookup heap (next (slot s (idx + 6)))
+    [prop] next (slot s (idx + 7)) = slot s (idx + 8)
+    [prop] ¬slot s (idx + 7) = slot s idx
+    [prop] ¬slot s (idx + 7) = slot s (idx + 1)
+    [prop] ¬slot s (idx + 7) = slot s (idx + 2)
+    [prop] ¬slot s (idx + 7) = slot s (idx + 3)
+    [prop] ¬slot s (idx + 7) = slot s (idx + 4)
+    [prop] ¬slot s (idx + 7) = slot s (idx + 5)
+    [prop] ¬slot s (idx + 7) = slot s (idx + 6)
+    [prop] ¬slot s idx = slot s (idx + 7)
+    [prop] ¬slot s (idx + 1) = slot s (idx + 7)
+    [prop] ¬slot s (idx + 2) = slot s (idx + 7)
+    [prop] ¬slot s (idx + 3) = slot s (idx + 7)
+    [prop] ¬slot s (idx + 4) = slot s (idx + 7)
+    [prop] ¬slot s (idx + 5) = slot s (idx + 7)
+    [prop] ¬slot s (idx + 6) = slot s (idx + 7)
+    [prop] idx + 8 ≤ len → lookup heap (slot s (idx + 7)) ≤ lookup heap (next (slot s (idx + 7)))
+    [prop] idx + 3 ≤ len
+    [prop] idx + 4 ≤ len
+    [prop] idx + 5 ≤ len
+    [prop] idx + 6 ≤ len
+    [prop] idx + 7 ≤ len
+    [prop] idx + 8 ≤ len
+  [eqc] True propositions
+    [prop] lookup heap (next (slot s idx)) ≤ lookup heap (slot s idx)
+    [prop] idx + 1 ≤ len
+    [prop] lookup heap (slot s idx) ≤ lookup heap (next (slot s idx))
+    [prop] idx + 1 ≤ len → lookup heap (slot s idx) ≤ lookup heap (next (slot s idx))
+    [prop] lookup heap (slot s (idx + 1)) ≤ lookup heap (next (slot s (idx + 1)))
+    [prop] idx + 2 ≤ len
+    [prop] idx + 2 ≤ len → lookup heap (slot s (idx + 1)) ≤ lookup heap (next (slot s (idx + 1)))
+    [prop] lookup heap (slot s (idx + 2)) ≤ lookup heap (next (slot s (idx + 2)))
+    [prop] idx + 3 ≤ len
+    [prop] idx + 3 ≤ len → lookup heap (slot s (idx + 2)) ≤ lookup heap (next (slot s (idx + 2)))
+    [prop] lookup heap (slot s (idx + 3)) ≤ lookup heap (next (slot s (idx + 3)))
+    [prop] idx + 4 ≤ len
+    [prop] idx + 4 ≤ len → lookup heap (slot s (idx + 3)) ≤ lookup heap (next (slot s (idx + 3)))
+    [prop] lookup heap (slot s (idx + 4)) ≤ lookup heap (next (slot s (idx + 4)))
+    [prop] idx + 5 ≤ len
+    [prop] idx + 5 ≤ len → lookup heap (slot s (idx + 4)) ≤ lookup heap (next (slot s (idx + 4)))
+    [prop] lookup heap (slot s (idx + 5)) ≤ lookup heap (next (slot s (idx + 5)))
+    [prop] idx + 6 ≤ len
+    [prop] idx + 6 ≤ len → lookup heap (slot s (idx + 5)) ≤ lookup heap (next (slot s (idx + 5)))
+    [prop] lookup heap (slot s (idx + 6)) ≤ lookup heap (next (slot s (idx + 6)))
+    [prop] idx + 7 ≤ len
+    [prop] idx + 7 ≤ len → lookup heap (slot s (idx + 6)) ≤ lookup heap (next (slot s (idx + 6)))
+    [prop] lookup heap (slot s (idx + 7)) ≤ lookup heap (next (slot s (idx + 7)))
+    [prop] idx + 8 ≤ len
+    [prop] idx + 8 ≤ len → lookup heap (slot s (idx + 7)) ≤ lookup heap (next (slot s (idx + 7)))
+  [eqc] False propositions
+    [prop] slot s idx = slot s (idx + 1)
+    [prop] slot s (idx + 1) = slot s idx
+    [prop] slot s idx = slot s (idx + 2)
+    [prop] slot s (idx + 1) = slot s (idx + 2)
+    [prop] slot s (idx + 2) = slot s idx
+    [prop] slot s (idx + 2) = slot s (idx + 1)
+    [prop] slot s idx = slot s (idx + 3)
+    [prop] slot s (idx + 1) = slot s (idx + 3)
+    [prop] slot s (idx + 2) = slot s (idx + 3)
+    [prop] slot s (idx + 3) = slot s idx
+    [prop] slot s (idx + 3) = slot s (idx + 1)
+    [prop] slot s (idx + 3) = slot s (idx + 2)
+    [prop] slot s idx = slot s (idx + 4)
+    [prop] slot s (idx + 1) = slot s (idx + 4)
+    [prop] slot s (idx + 2) = slot s (idx + 4)
+    [prop] slot s (idx + 3) = slot s (idx + 4)
+    [prop] slot s (idx + 4) = slot s idx
+    [prop] slot s (idx + 4) = slot s (idx + 1)
+    [prop] slot s (idx + 4) = slot s (idx + 2)
+    [prop] slot s (idx + 4) = slot s (idx + 3)
+    [prop] slot s idx = slot s (idx + 5)
+    [prop] slot s (idx + 1) = slot s (idx + 5)
+    [prop] slot s (idx + 2) = slot s (idx + 5)
+    [prop] slot s (idx + 3) = slot s (idx + 5)
+    [prop] slot s (idx + 4) = slot s (idx + 5)
+    [prop] slot s (idx + 5) = slot s idx
+    [prop] slot s (idx + 5) = slot s (idx + 1)
+    [prop] slot s (idx + 5) = slot s (idx + 2)
+    [prop] slot s (idx + 5) = slot s (idx + 3)
+    [prop] slot s (idx + 5) = slot s (idx + 4)
+    [prop] slot s idx = slot s (idx + 6)
+    [prop] slot s (idx + 1) = slot s (idx + 6)
+    [prop] slot s (idx + 2) = slot s (idx + 6)
+    [prop] slot s (idx + 3) = slot s (idx + 6)
+    [prop] slot s (idx + 4) = slot s (idx + 6)
+    [prop] slot s (idx + 5) = slot s (idx + 6)
+    [prop] slot s (idx + 6) = slot s idx
+    [prop] slot s (idx + 6) = slot s (idx + 1)
+    [prop] slot s (idx + 6) = slot s (idx + 2)
+    [prop] slot s (idx + 6) = slot s (idx + 3)
+    [prop] slot s (idx + 6) = slot s (idx + 4)
+    [prop] slot s (idx + 6) = slot s (idx + 5)
+    [prop] slot s idx = slot s (idx + 7)
+    [prop] slot s (idx + 1) = slot s (idx + 7)
+    [prop] slot s (idx + 2) = slot s (idx + 7)
+    [prop] slot s (idx + 3) = slot s (idx + 7)
+    [prop] slot s (idx + 4) = slot s (idx + 7)
+    [prop] slot s (idx + 5) = slot s (idx + 7)
+    [prop] slot s (idx + 6) = slot s (idx + 7)
+    [prop] slot s (idx + 7) = slot s idx
+    [prop] slot s (idx + 7) = slot s (idx + 1)
+    [prop] slot s (idx + 7) = slot s (idx + 2)
+    [prop] slot s (idx + 7) = slot s (idx + 3)
+    [prop] slot s (idx + 7) = slot s (idx + 4)
+    [prop] slot s (idx + 7) = slot s (idx + 5)
+    [prop] slot s (idx + 7) = slot s (idx + 6)
+  [eqc] Equivalence classes
+    [eqc] {next (slot s idx), slot s (idx + 1)}
+    [eqc] {lookup heap (next (slot s idx)), lookup heap (slot s idx), lookup heap (slot s (idx + 1))}
+    [eqc] {next (slot s (idx + 1)), slot s (idx + 2)}
+    [eqc] {lookup heap (next (slot s (idx + 1))), lookup heap (slot s (idx + 2))}
+    [eqc] {next (slot s (idx + 2)), slot s (idx + 3)}
+    [eqc] {lookup heap (next (slot s (idx + 2))), lookup heap (slot s (idx + 3))}
+    [eqc] {next (slot s (idx + 3)), slot s (idx + 4)}
+    [eqc] {lookup heap (next (slot s (idx + 3))), lookup heap (slot s (idx + 4))}
+    [eqc] {next (slot s (idx + 4)), slot s (idx + 5)}
+    [eqc] {lookup heap (next (slot s (idx + 4))), lookup heap (slot s (idx + 5))}
+    [eqc] {next (slot s (idx + 5)), slot s (idx + 6)}
+    [eqc] {lookup heap (next (slot s (idx + 5))), lookup heap (slot s (idx + 6))}
+    [eqc] {next (slot s (idx + 6)), slot s (idx + 7)}
+    [eqc] {lookup heap (next (slot s (idx + 6))), lookup heap (slot s (idx + 7))}
+    [eqc] {next (slot s (idx + 7)), slot s (idx + 8)}
+    [eqc] others
+      [eqc] {↑(lookup heap (next (slot s idx))), ↑(lookup heap (slot s idx)), ↑(lookup heap (slot s (idx + 1)))}
+      [eqc] {↑(lookup heap (next (slot s (idx + 1)))), ↑(lookup heap (slot s (idx + 2)))}
+      [eqc] {↑(lookup heap (next (slot s (idx + 2)))), ↑(lookup heap (slot s (idx + 3)))}
+      [eqc] {↑(lookup heap (next (slot s (idx + 3)))), ↑(lookup heap (slot s (idx + 4)))}
+      [eqc] {↑(lookup heap (next (slot s (idx + 4)))), ↑(lookup heap (slot s (idx + 5)))}
+      [eqc] {↑(lookup heap (next (slot s (idx + 5)))), ↑(lookup heap (slot s (idx + 6)))}
+      [eqc] {↑(lookup heap (next (slot s (idx + 6)))), ↑(lookup heap (slot s (idx + 7)))}
+  [cases] Case analyses
+    [cases] [1/2]: idx + 2 ≤ len
+      [cases] source: E-matching `sorted`
+    [cases] [1/2]: idx + 3 ≤ len
+      [cases] source: E-matching `sorted`
+    [cases] [1/2]: idx + 4 ≤ len
+      [cases] source: E-matching `sorted`
+    [cases] [1/2]: idx + 5 ≤ len
+      [cases] source: E-matching `sorted`
+    [cases] [1/2]: idx + 6 ≤ len
+      [cases] source: E-matching `sorted`
+    [cases] [1/2]: idx + 7 ≤ len
+      [cases] source: E-matching `sorted`
+    [cases] [1/2]: idx + 8 ≤ len
+      [cases] source: E-matching `sorted`
+  [ematch] E-matching patterns
+    [thm] next_def: [slot #1 #0]
+    [thm] inj: [slot #3 #2, slot #3 #1]
+    [thm] sorted: [lookup `[heap] (slot `[s] #1)]
+  [cutsat] Assignment satisfying linear constraints
+    [assign] idx := 0
+    [assign] len := 8
+    [assign] lookup heap (next (slot s idx)) := 0
+    [assign] lookup heap (slot s idx) := 0
+    [assign] lookup heap (next (slot s (idx + 1))) := 0
+    [assign] lookup heap (slot s (idx + 1)) := 0
+    [assign] lookup heap (next (slot s (idx + 2))) := 0
+    [assign] lookup heap (slot s (idx + 2)) := 0
+    [assign] lookup heap (next (slot s (idx + 3))) := 0
+    [assign] lookup heap (slot s (idx + 3)) := 0
+    [assign] lookup heap (next (slot s (idx + 4))) := 0
+    [assign] lookup heap (slot s (idx + 4)) := 0
+    [assign] lookup heap (next (slot s (idx + 5))) := 0
+    [assign] lookup heap (slot s (idx + 5)) := 0
+    [assign] lookup heap (next (slot s (idx + 6))) := 0
+    [assign] lookup heap (slot s (idx + 6)) := 0
+    [assign] lookup heap (next (slot s (idx + 7))) := 0
+    [assign] lookup heap (slot s (idx + 7)) := 0
+  [ring] Ring `Int`
+    [basis] Basis
+      [_] ↑(lookup heap (next (slot s idx))) + -1 * ↑(lookup heap (slot s idx)) = 0
+      [_] ↑(lookup heap (slot s idx)) + -1 * ↑(lookup heap (slot s (idx + 1))) = 0
+      [_] ↑(lookup heap (next (slot s (idx + 1)))) + -1 * ↑(lookup heap (slot s (idx + 2))) = 0
+      [_] ↑(lookup heap (next (slot s (idx + 2)))) + -1 * ↑(lookup heap (slot s (idx + 3))) = 0
+      [_] ↑(lookup heap (next (slot s (idx + 3)))) + -1 * ↑(lookup heap (slot s (idx + 4))) = 0
+      [_] ↑(lookup heap (next (slot s (idx + 4)))) + -1 * ↑(lookup heap (slot s (idx + 5))) = 0
+      [_] ↑(lookup heap (next (slot s (idx + 5)))) + -1 * ↑(lookup heap (slot s (idx + 6))) = 0
+      [_] ↑(lookup heap (next (slot s (idx + 6)))) + -1 * ↑(lookup heap (slot s (idx + 7))) = 0
+  [limits] Thresholds reached
+    [limit] maximum term generation has been reached, threshold: `(gen := 8)`
+[grind] Diagnostics
+  [ematch] E-matching Diagnostics
+    [thm] Theorem Instance Count
+      [thm] inj ↦ 56
+      [thm] next_def ↦ 8
+      [thm] sorted ↦ 8
+    [thm] High Cost Instances
+      [thm] next_def : next (slot s idx) = slot s (idx + 1) ↦ 69.0
+      [thm] next_def : next (slot s (idx + 1)) = slot s (idx + 1 + 1) ↦ 60.0
+      [thm] next_def : next (slot s (idx + 2)) = slot s (idx + 2 + 1) ↦ 50.0
+      [thm] next_def : next (slot s (idx + 3)) = slot s (idx + 3 + 1) ↦ 40.1
+      [thm] next_def : next (slot s (idx + 4)) = slot s (idx + 4 + 1) ↦ 30.1
+      [thm] next_def : next (slot s (idx + 5)) = slot s (idx + 5 + 1) ↦ 20.3
+      [thm] next_def : next (slot s (idx + 6)) = slot s (idx + 6 + 1) ↦ 10.5
+    [thm] Excessively Branching Instances
+      [thm] next_def: next (slot s (idx + 1)) = slot s (idx + 1 + 1) has 16 direct follow up instances
+        [thm] sorted: idx + 2 < len → lookup heap (slot s (idx + 2)) ≤ lookup heap (next (slot s (idx + 2)))
+        [thm] inj: idx + 2 ≠ idx + 7 → slot s (idx + 2) ≠ slot s (idx + 7)
+        [thm] inj: idx + 2 ≠ idx + 5 → slot s (idx + 2) ≠ slot s (idx + 5)
+        [thm] inj: idx ≠ idx + 2 → slot s idx ≠ slot s (idx + 2)
+        [thm] inj: idx + 6 ≠ idx + 2 → slot s (idx + 6) ≠ slot s (idx + 2)
+        [thm] inj: idx + 1 ≠ idx + 2 → slot s (idx + 1) ≠ slot s (idx + 2)
+        [thm] inj: idx + 2 ≠ idx + 6 → slot s (idx + 2) ≠ slot s (idx + 6)
+        [thm] inj: idx + 2 ≠ idx + 1 → slot s (idx + 2) ≠ slot s (idx + 1)
+        [thm] inj: idx + 2 ≠ idx + 4 → slot s (idx + 2) ≠ slot s (idx + 4)
+        [thm] inj: idx + 2 ≠ idx + 3 → slot s (idx + 2) ≠ slot s (idx + 3)
+        [thm] inj: idx + 5 ≠ idx + 2 → slot s (idx + 5) ≠ slot s (idx + 2)
+        [thm] inj: idx + 7 ≠ idx + 2 → slot s (idx + 7) ≠ slot s (idx + 2)
+        [thm] inj: idx + 2 ≠ idx → slot s (idx + 2) ≠ slot s idx
+        [thm] inj: idx + 3 ≠ idx + 2 → slot s (idx + 3) ≠ slot s (idx + 2)
+        [thm] next_def: next (slot s (idx + 2)) = slot s (idx + 2 + 1)
+        [thm] inj: idx + 4 ≠ idx + 2 → slot s (idx + 4) ≠ slot s (idx + 2)
+      [thm] next_def: next (slot s (idx + 2)) = slot s (idx + 2 + 1) has 16 direct follow up instances
+        [thm] inj: idx + 3 ≠ idx + 5 → slot s (idx + 3) ≠ slot s (idx + 5)
+        [thm] next_def: next (slot s (idx + 3)) = slot s (idx + 3 + 1)
+        [thm] inj: idx + 1 ≠ idx + 3 → slot s (idx + 1) ≠ slot s (idx + 3)
+        [thm] inj: idx + 4 ≠ idx + 3 → slot s (idx + 4) ≠ slot s (idx + 3)
+        [thm] inj: idx + 3 ≠ idx → slot s (idx + 3) ≠ slot s idx
+        [thm] sorted: idx + 3 < len → lookup heap (slot s (idx + 3)) ≤ lookup heap (next (slot s (idx + 3)))
+        [thm] inj: idx ≠ idx + 3 → slot s idx ≠ slot s (idx + 3)
+        [thm] inj: idx + 5 ≠ idx + 3 → slot s (idx + 5) ≠ slot s (idx + 3)
+        [thm] inj: idx + 3 ≠ idx + 6 → slot s (idx + 3) ≠ slot s (idx + 6)
+        [thm] inj: idx + 3 ≠ idx + 1 → slot s (idx + 3) ≠ slot s (idx + 1)
+        [thm] inj: idx + 2 ≠ idx + 3 → slot s (idx + 2) ≠ slot s (idx + 3)
+        [thm] inj: idx + 6 ≠ idx + 3 → slot s (idx + 6) ≠ slot s (idx + 3)
+        [thm] inj: idx + 3 ≠ idx + 2 → slot s (idx + 3) ≠ slot s (idx + 2)
+        [thm] inj: idx + 7 ≠ idx + 3 → slot s (idx + 7) ≠ slot s (idx + 3)
+        [thm] inj: idx + 3 ≠ idx + 7 → slot s (idx + 3) ≠ slot s (idx + 7)
+        [thm] inj: idx + 3 ≠ idx + 4 → slot s (idx + 3) ≠ slot s (idx + 4)
+      [thm] next_def: next (slot s (idx + 3)) = slot s (idx + 3 + 1) has 16 direct follow up instances
+        [thm] inj: idx + 4 ≠ idx + 1 → slot s (idx + 4) ≠ slot s (idx + 1)
+        [thm] sorted: idx + 4 < len → lookup heap (slot s (idx + 4)) ≤ lookup heap (next (slot s (idx + 4)))
+        [thm] inj: idx + 5 ≠ idx + 4 → slot s (idx + 5) ≠ slot s (idx + 4)
+        [thm] inj: idx ≠ idx + 4 → slot s idx ≠ slot s (idx + 4)
+        [thm] next_def: next (slot s (idx + 4)) = slot s (idx + 4 + 1)
+        [thm] inj: idx + 4 ≠ idx → slot s (idx + 4) ≠ slot s idx
+        [thm] inj: idx + 1 ≠ idx + 4 → slot s (idx + 1) ≠ slot s (idx + 4)
+        [thm] inj: idx + 4 ≠ idx + 3 → slot s (idx + 4) ≠ slot s (idx + 3)
+        [thm] inj: idx + 7 ≠ idx + 4 → slot s (idx + 7) ≠ slot s (idx + 4)
+        [thm] inj: idx + 4 ≠ idx + 5 → slot s (idx + 4) ≠ slot s (idx + 5)
+        [thm] inj: idx + 2 ≠ idx + 4 → slot s (idx + 2) ≠ slot s (idx + 4)
+        [thm] inj: idx + 4 ≠ idx + 7 → slot s (idx + 4) ≠ slot s (idx + 7)
+        [thm] inj: idx + 6 ≠ idx + 4 → slot s (idx + 6) ≠ slot s (idx + 4)
+        [thm] inj: idx + 4 ≠ idx + 6 → slot s (idx + 4) ≠ slot s (idx + 6)
+        [thm] inj: idx + 3 ≠ idx + 4 → slot s (idx + 3) ≠ slot s (idx + 4)
+        [thm] inj: idx + 4 ≠ idx + 2 → slot s (idx + 4) ≠ slot s (idx + 2)
+      [thm] next_def: next (slot s (idx + 4)) = slot s (idx + 4 + 1) has 16 direct follow up instances
+        [thm] inj: idx + 2 ≠ idx + 5 → slot s (idx + 2) ≠ slot s (idx + 5)
+        [thm] inj: idx + 3 ≠ idx + 5 → slot s (idx + 3) ≠ slot s (idx + 5)
+        [thm] inj: idx + 5 ≠ idx + 4 → slot s (idx + 5) ≠ slot s (idx + 4)
+        [thm] inj: idx + 7 ≠ idx + 5 → slot s (idx + 7) ≠ slot s (idx + 5)
+        [thm] inj: idx + 5 ≠ idx + 1 → slot s (idx + 5) ≠ slot s (idx + 1)
+        [thm] inj: idx + 1 ≠ idx + 5 → slot s (idx + 1) ≠ slot s (idx + 5)
+        [thm] inj: idx + 5 ≠ idx + 7 → slot s (idx + 5) ≠ slot s (idx + 7)
+        [thm] inj: idx + 5 ≠ idx + 6 → slot s (idx + 5) ≠ slot s (idx + 6)
+        [thm] next_def: next (slot s (idx + 5)) = slot s (idx + 5 + 1)
+        [thm] inj: idx + 4 ≠ idx + 5 → slot s (idx + 4) ≠ slot s (idx + 5)
+        [thm] inj: idx + 5 ≠ idx + 3 → slot s (idx + 5) ≠ slot s (idx + 3)
+        [thm] inj: idx + 5 ≠ idx + 2 → slot s (idx + 5) ≠ slot s (idx + 2)
+        [thm] inj: idx ≠ idx + 5 → slot s idx ≠ slot s (idx + 5)
+        [thm] sorted: idx + 5 < len → lookup heap (slot s (idx + 5)) ≤ lookup heap (next (slot s (idx + 5)))
+        [thm] inj: idx + 5 ≠ idx → slot s (idx + 5) ≠ slot s idx
+        [thm] inj: idx + 6 ≠ idx + 5 → slot s (idx + 6) ≠ slot s (idx + 5)
+      [thm] next_def: next (slot s (idx + 5)) = slot s (idx + 5 + 1) has 16 direct follow up instances
+        [thm] inj: idx + 7 ≠ idx + 6 → slot s (idx + 7) ≠ slot s (idx + 6)
+        [thm] inj: idx + 6 ≠ idx + 2 → slot s (idx + 6) ≠ slot s (idx + 2)
+        [thm] inj: idx + 6 ≠ idx + 7 → slot s (idx + 6) ≠ slot s (idx + 7)
+        [thm] inj: idx + 6 ≠ idx + 1 → slot s (idx + 6) ≠ slot s (idx + 1)
+        [thm] inj: idx ≠ idx + 6 → slot s idx ≠ slot s (idx + 6)
+        [thm] inj: idx + 2 ≠ idx + 6 → slot s (idx + 2) ≠ slot s (idx + 6)
+        [thm] sorted: idx + 6 < len → lookup heap (slot s (idx + 6)) ≤ lookup heap (next (slot s (idx + 6)))
+        [thm] inj: idx + 6 ≠ idx → slot s (idx + 6) ≠ slot s idx
+        [thm] next_def: next (slot s (idx + 6)) = slot s (idx + 6 + 1)
+        [thm] inj: idx + 5 ≠ idx + 6 → slot s (idx + 5) ≠ slot s (idx + 6)
+        [thm] inj: idx + 3 ≠ idx + 6 → slot s (idx + 3) ≠ slot s (idx + 6)
+        [thm] inj: idx + 6 ≠ idx + 4 → slot s (idx + 6) ≠ slot s (idx + 4)
+        [thm] inj: idx + 6 ≠ idx + 3 → slot s (idx + 6) ≠ slot s (idx + 3)
+        [thm] inj: idx + 1 ≠ idx + 6 → slot s (idx + 1) ≠ slot s (idx + 6)
+        [thm] inj: idx + 4 ≠ idx + 6 → slot s (idx + 4) ≠ slot s (idx + 6)
+        [thm] inj: idx + 6 ≠ idx + 5 → slot s (idx + 6) ≠ slot s (idx + 5)
+      [thm] next_def: next (slot s (idx + 6)) = slot s (idx + 6 + 1) has 16 direct follow up instances
+        [thm] inj: idx + 2 ≠ idx + 7 → slot s (idx + 2) ≠ slot s (idx + 7)
+        [thm] inj: idx + 7 ≠ idx + 6 → slot s (idx + 7) ≠ slot s (idx + 6)
+        [thm] inj: idx ≠ idx + 7 → slot s idx ≠ slot s (idx + 7)
+        [thm] inj: idx + 7 ≠ idx + 5 → slot s (idx + 7) ≠ slot s (idx + 5)
+        [thm] inj: idx + 1 ≠ idx + 7 → slot s (idx + 1) ≠ slot s (idx + 7)
+        [thm] inj: idx + 6 ≠ idx + 7 → slot s (idx + 6) ≠ slot s (idx + 7)
+        [thm] next_def: next (slot s (idx + 7)) = slot s (idx + 7 + 1)
+        [thm] inj: idx + 5 ≠ idx + 7 → slot s (idx + 5) ≠ slot s (idx + 7)
+        [thm] inj: idx + 7 ≠ idx + 4 → slot s (idx + 7) ≠ slot s (idx + 4)
+        [thm] inj: idx + 7 ≠ idx → slot s (idx + 7) ≠ slot s idx
+        [thm] inj: idx + 4 ≠ idx + 7 → slot s (idx + 4) ≠ slot s (idx + 7)
+        [thm] inj: idx + 7 ≠ idx + 2 → slot s (idx + 7) ≠ slot s (idx + 2)
+        [thm] inj: idx + 7 ≠ idx + 3 → slot s (idx + 7) ≠ slot s (idx + 3)
+        [thm] sorted: idx + 7 < len → lookup heap (slot s (idx + 7)) ≤ lookup heap (next (slot s (idx + 7)))
+        [thm] inj: idx + 7 ≠ idx + 1 → slot s (idx + 7) ≠ slot s (idx + 1)
+        [thm] inj: idx + 3 ≠ idx + 7 → slot s (idx + 3) ≠ slot s (idx + 7)
+      [thm] next_def: next (slot s idx) = slot s (idx + 1) has 15 direct follow up instances
+        [thm] inj: idx + 4 ≠ idx + 1 → slot s (idx + 4) ≠ slot s (idx + 1)
+        [thm] inj: idx + 1 ≠ idx + 7 → slot s (idx + 1) ≠ slot s (idx + 7)
+        [thm] inj: idx + 1 ≠ idx + 2 → slot s (idx + 1) ≠ slot s (idx + 2)
+        [thm] inj: idx + 5 ≠ idx + 1 → slot s (idx + 5) ≠ slot s (idx + 1)
+        [thm] inj: idx + 6 ≠ idx + 1 → slot s (idx + 6) ≠ slot s (idx + 1)
+        [thm] inj: idx + 1 ≠ idx + 4 → slot s (idx + 1) ≠ slot s (idx + 4)
+        [thm] inj: idx + 1 ≠ idx + 5 → slot s (idx + 1) ≠ slot s (idx + 5)
+        [thm] inj: idx + 1 ≠ idx + 3 → slot s (idx + 1) ≠ slot s (idx + 3)
+        [thm] next_def: next (slot s (idx + 1)) = slot s (idx + 1 + 1)
+        [thm] inj: idx ≠ idx + 1 → slot s idx ≠ slot s (idx + 1)
+        [thm] inj: idx + 2 ≠ idx + 1 → slot s (idx + 2) ≠ slot s (idx + 1)
+        [thm] inj: idx + 3 ≠ idx + 1 → slot s (idx + 3) ≠ slot s (idx + 1)
+        [thm] inj: idx + 1 ≠ idx + 6 → slot s (idx + 1) ≠ slot s (idx + 6)
+        [thm] inj: idx + 1 ≠ idx → slot s (idx + 1) ≠ slot s idx
+        [thm] inj: idx + 7 ≠ idx + 1 → slot s (idx + 7) ≠ slot s (idx + 1)
+-/
+#guard_msgs in
+set_option grind.ematch.diagnostics true in
+example (h1 : idx < len) :
+    -- Actually false, but this is a slow failure
+    lookup heap (slot s idx) < lookup heap (next (slot s idx)) := by
+  grind

--- a/tests/elab/grind_sort_eqc.lean
+++ b/tests/elab/grind_sort_eqc.lean
@@ -40,9 +40,10 @@ h_2 : ¬f x = g x x
   [limits] Thresholds reached
     [limit] maximum term generation has been reached, threshold: `(gen := 3)`
 [grind] Diagnostics
-  [thm] E-Matching instances
-    [thm] feq ↦ 3
-    [thm] geq ↦ 1
+  [ematch] E-matching Diagnostics
+    [thm] Theorem Instance Count
+      [thm] feq ↦ 3
+      [thm] geq ↦ 1
 -/
 #guard_msgs (error) in
 example [Inhabited α] [Add α] [One α] (x z y : α) : g y z = z → g z y = g y x → f x = g x x := by
@@ -99,9 +100,10 @@ h_2 : ¬f (f x) = g x x
   [limits] Thresholds reached
     [limit] maximum term generation has been reached, threshold: `(gen := 2)`
 [grind] Diagnostics
-  [thm] E-Matching instances
-    [thm] feq ↦ 3
-    [thm] geq ↦ 1
+  [ematch] E-matching Diagnostics
+    [thm] Theorem Instance Count
+      [thm] feq ↦ 3
+      [thm] geq ↦ 1
 -/
 #guard_msgs (error) in
 example (x z y : Int) : g y z = z → g z y = g y x → f (f x) = g x x := by

--- a/tests/elab/maxSuggestionsTest.lean
+++ b/tests/elab/maxSuggestionsTest.lean
@@ -59,9 +59,10 @@ h : ¬P 3
   [eqc] False propositions
     [prop] P 3
 [grind] Diagnostics
-  [thm] E-Matching instances
-    [thm] p1 ↦ 1
-    [thm] p2 ↦ 1
+  [ematch] E-matching Diagnostics
+    [thm] Theorem Instance Count
+      [thm] p1 ↦ 1
+      [thm] p2 ↦ 1
 -/
 #guard_msgs in
 example : P 3 := by grind +suggestions (maxSuggestions := some 2)


### PR DESCRIPTION
This PR introduces new cost metrics for `grind`'s e-matching graph that can be optionally enabled in its diagnostics via `set_option grind.ematch.diagnostics true`. `grind` is now able to detect:
- individual instances that have a lot of direct follow up children. Configurable via `grind.ematch.diagnostics.branchThreshold`
- instances that participated in a large, transitive closure of follow up instances. For this `grind` computes a cost metric that is roughly equivalent to the size of the transitive closure but fairly distributed among multiple parents. Configurable via `grind.ematch.diagnostics.costThreshold`. The metric is based on the cost heuristic of https://github.com/viperproject/smt-scope.

The precise cost thresholds probably need to be tuned further down the line.