### PR TITLE
fix: support dependent discriminant telescopes in mvcgen match splitting

### DIFF
--- a/src/Lean/Elab/Tactic/Do/VCGen/Split.lean
+++ b/src/Lean/Elab/Tactic/Do/VCGen/Split.lean
@@ -95,9 +95,15 @@ def withAbstract {n} {α} [MonadLiftT MetaM n] [MonadControlT MetaM n] [Monad n]
     let u ← liftMetaM <| getLevel resTy
     k (.dite <| mkApp5 (mkConst ``_root_.dite [u]) resTy c dec t e) #[c, dec, t, e]
   | .matcher matcherApp => do
-    let discrNamesTypes ← matcherApp.discrs.mapIdxM fun i discr => do
-      return ((`discr).appendIndexAfter (i+1), ← liftMetaM <| inferType discr)
-    withLocalDeclsDND discrNamesTypes fun discrs => do
+    -- Abstract the discriminants as a dependent telescope: a later discriminant's type may mention an earlier one.
+    let discrDecls := matcherApp.discrs.mapIdx fun i discr =>
+      ((`discr).appendIndexAfter (i+1), fun (prior : Array Expr) => liftMetaM do
+        let mut ty ← inferType discr
+        for j in *...i do
+          if matcherApp.discrs[j]!.isFVar then
+            ty := ty.replaceFVar matcherApp.discrs[j]! prior[j]!
+        return ty)
+    withLocalDeclsD discrDecls fun discrs => do
     -- Non-dependent motive: fun _ ... _ => mα
     let motive ← liftMetaM <| lambdaTelescope matcherApp.motive fun motiveArgs _ =>
       mkLambdaFVars motiveArgs resTy

--- a/tests/elab/mvcgenMatchDependentDiscr.lean
+++ b/tests/elab/mvcgenMatchDependentDiscr.lean
@@ -1,0 +1,37 @@
+import Std.Tactic.Do
+import Std.Internal.Do
+
+/-!
+Regression test for `mvcgen`/`mvcgen'` splitting a `match` whose discriminant telescope is
+dependent: a later discriminant's type mentions an earlier discriminant. Abstracting the matcher
+introduces the discriminant fvars as a dependent telescope, substituting each earlier original
+discriminant with its abstract counterpart, so the pre-splitter motive stays type-correct.
+-/
+
+set_option mvcgen.warning false
+
+/-- The second discriminant `h : 0 < n` mentions the first discriminant `n`. -/
+def prog (n : Nat) (h : 0 < n) : StateM Nat Unit := do
+  match n, h with
+  | m+1, _ => set m
+
+section
+open Lean.Order Std.Internal.Do
+
+example (n : Nat) (h : 0 < n) :
+    ⦃fun _ => True⦄ prog n h ⦃fun _ _ => True⦄ := by
+  unfold prog
+  mvcgen'
+  all_goals simp_all
+end
+
+-- Separate section: `Std.Do`'s `⦃ ⦄` notation clashes with the one above.
+section
+open Std.Do
+
+example (n : Nat) (h : 0 < n) :
+    ⦃⌜True⌝⦄ prog n h ⦃⇓ _ => ⌜True⌝⦄ := by
+  unfold prog
+  mvcgen
+  all_goals simp_all
+end


### PR DESCRIPTION
This PR fixes `mvcgen`/`mvcgen'` failing to split a `match` whose discriminant telescope is dependent, i.e. when a later discriminant's type mentions an earlier discriminant (such as `match n, h with` where `h : 0 < n`). Abstracting such a matcher previously produced an ill-typed pre-splitter motive.

When abstracting the matcher, the discriminant fvars are now introduced as a dependent telescope: each discriminant's type substitutes earlier original discriminants with their abstract counterparts.