### PR TITLE
fix: `getModuleEntries (level := .server)` should work even outside server mode in combination with `import all`

### DIFF
--- a/src/Lean/Environment.lean
+++ b/src/Lean/Environment.lean
@@ -2005,8 +2005,9 @@ private def ImportedModule.mainModule? (self : ImportedModule) : Option ModuleDa
 /-- The module data that should be used for server purposes. -/
 private def ImportedModule.serverData? (self : ImportedModule) (level : OLeanLevel) :
     Option ModuleData :=
-  -- fall back to `exported` outside the server
-  self.getData? (if level ≥ .server then level else .exported)
+  -- allow unconditional access under `import all`, otherwise fall back to `exported` outside the
+  -- server
+  self.getData? (if self.importAll then .private else if level ≥ .server then level else .exported)
 
 /-- The module data that should be used for accessing IR for interpretation. -/
 private def ImportedModule.interpData? (self : ImportedModule) (level : OLeanLevel) :

--- a/tests/elab/findPrivateDocString.lean
+++ b/tests/elab/findPrivateDocString.lean
@@ -1,0 +1,12 @@
+module
+
+import Lean
+import all Init.Prelude
+
+/-! Docstrings from .olean.server should be visible even on the cmdline when `import all`ed. -/
+
+open Lean
+
+/-- info: true -/
+#guard_msgs in
+#eval show MetaM _ from return (← findDocString? (← getEnv) ``Nat).isSome


### PR DESCRIPTION
This PR fixes language server-oriented API such as `findDocString?` that sources its information from `.olean.server` under the module system to also work on the cmdline if the module in question is imported with `all`.