### PR TITLE
chore: skip fetching blobs in the "push tag" step of the PR release

### DIFF
--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -63,8 +63,8 @@ jobs:
         run: |
           git init --bare lean4.git
           git -C lean4.git remote add origin https://github.com/${{ github.repository_owner }}/lean4.git
-          git -C lean4.git fetch -n origin master
-          git -C lean4.git fetch -n origin "${{ steps.workflow-info.outputs.sourceHeadSha }}"
+          git -C lean4.git fetch -n --filter=blob:none origin master
+          git -C lean4.git fetch -n --filter=blob:none origin "${{ steps.workflow-info.outputs.sourceHeadSha }}"
 
           # Create both the original tag and the SHA-suffixed tag
           SHORT_SHA="${{ steps.workflow-info.outputs.sourceHeadSha }}"

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -63,8 +63,14 @@ jobs:
         run: |
           git init --bare lean4.git
           git -C lean4.git remote add origin https://github.com/${{ github.repository_owner }}/lean4.git
-          git -C lean4.git fetch -n --filter=blob:none origin master
-          git -C lean4.git fetch -n --filter=blob:none origin "${{ steps.workflow-info.outputs.sourceHeadSha }}"
+          if [ "${{ steps.workflow-info.outputs.pullRequestNumber }}" == "14124" ]; then
+            echo "PR ${{ steps.workflow-info.outputs.pullRequestNumber }}: using experimental --filter=blob:none fetch"
+            git -C lean4.git fetch -n --filter=blob:none origin master
+            git -C lean4.git fetch -n --filter=blob:none origin "${{ steps.workflow-info.outputs.sourceHeadSha }}"
+          else
+            git -C lean4.git fetch -n origin master
+            git -C lean4.git fetch -n origin "${{ steps.workflow-info.outputs.sourceHeadSha }}"
+          fi
 
           # Create both the original tag and the SHA-suffixed tag
           SHORT_SHA="${{ steps.workflow-info.outputs.sourceHeadSha }}"


### PR DESCRIPTION
This PR modifies the `git fetch` commands in the PR release so that they don't download the the massive blobs, hopefully speeding up the "push tag" step.