### PR TITLE
fix: avoid compiler panic when deriving computable `Inhabited` in a `noncomputable section`

### DIFF
--- a/src/Lean/Elab/Deriving/Inhabited.lean
+++ b/src/Lean/Elab/Deriving/Inhabited.lean
@@ -131,8 +131,8 @@ where
         (hints       := ReducibilityHints.regular (getMaxHeight (← getEnv) auxVal + 1))
       if isMarkedMeta (← getEnv) inductiveTypeName then
         modifyEnv (markMeta · auxFunName)
-      unless (← read).isNoncomputableSection do
-        compileDecls #[auxFunName]
+      compileDecls #[auxFunName]
+        (logErrors := !(← read).isNoncomputableSection || isMarkedMeta (← getEnv) auxFunName)
       enableRealizationsForConst auxFunName
       trace[Elab.Deriving.inhabited] "defined {.ofConstName auxFunName}"
       let cmd ← mkInstanceCmdWith (mkIdent ctx.instName) usedInstIdxs (mkCIdent auxFunName)

--- a/tests/elab/derivingInhabited.lean
+++ b/tests/elab/derivingInhabited.lean
@@ -73,6 +73,15 @@ deriving Inhabited
 #with_exporting
 #reduce (default : PrivField)
 
+/-! Deriving a computable `Inhabited` inside a `noncomputable section` should not fail. -/
+
+namespace NoncompSection
+noncomputable section
+
+structure NCS where
+  a : Nat
+deriving Inhabited
+
 /-! ...which should not be compatible with explicit `@[expose]`. -/
 
 /--


### PR DESCRIPTION
This PR fixes a compiler panic that occurred when deriving a computable `Inhabited` instance for a type inside a `noncomputable section`.

The derived auxiliary default function was added to the environment but not compiled, while the still-computable instance referencing it was compiled, hitting an `unreachable!` in the `ExplicitBoxing` LCNF pass. The aux function is now always compiled like a regular `def`, suppressing errors in a `noncomputable section` so that a default depending on noncomputable code marks the aux (and hence the instance built from it) noncomputable instead of leaving it uncompiled while the computable instance still references it.