### PR TITLE
fix: lake: correct `Package.remoteUrl?` logic

### DIFF
--- a/src/lake/Lake/Config/Package.lean
+++ b/src/lake/Lake/Config/Package.lean
@@ -258,7 +258,7 @@ public def id? (self : Package) : Option PkgId :=
 
 /-- The packages `remoteUrl` as an `Option` (`none` if empty). -/
 @[inline] public def remoteUrl? (self : Package) : Option String :=
-  if self.remoteUrl.isEmpty then some self.remoteUrl else none
+  if self.remoteUrl.isEmpty then none else some self.remoteUrl
 
 /-- The package's `lakeDir` joined with its `buildArchive`. -/
 @[inline] public def buildArchiveFile (self : Package) : FilePath :=

--- a/tests/lake/tests/api/keys.lean
+++ b/tests/lake/tests/api/keys.lean
@@ -104,3 +104,9 @@ def stx  := (`@pkg : PartialBuildKey)
 
 -- Test coercion to a target
 def coe : Array (Target Dynlib) := #[`@pkg/tgt:facet]
+
+/-! ## Test Package URL Helpers -/
+
+#guard (default : Package).remoteUrl? == none
+#guard ({(default : Package) with remoteUrl := "https://example.com/test"}).remoteUrl? ==
+  some "https://example.com/test"


### PR DESCRIPTION
This PR fixes `Package.remoteUrl?` so an empty `remoteUrl` returns `none` and a non-empty `remoteUrl` returns `some remoteUrl`.

The previous implementation inverted the documented behavior, which could make `Package.getReleaseUrl` ignore configured remote URLs and block fallback to the Git remote.
