### PR TITLE
fix: handle overlapping block comment terminators in fast import parser

### DIFF
--- a/src/Lean/Elab/ParseImportsFast.lean
+++ b/src/Lean/Elab/ParseImportsFast.lean
@@ -64,7 +64,7 @@ partial def finishCommentBlock (nesting : Nat) : Parser := fun input s =>
           if nesting == 1 then s.next input i
           else finishCommentBlock (nesting-1) input (s.next' input i h)
         else
-          finishCommentBlock nesting input (s.next' input i h)
+          finishCommentBlock nesting input (s.setPos i)
     else if curr == '/' then
       if h : i.atEnd input then eoi s
       else

--- a/tests/elab/parseImportsFastOverlappingComment.lean
+++ b/tests/elab/parseImportsFastOverlappingComment.lean
@@ -1,0 +1,12 @@
+import Lean.Elab.ParseImportsFast
+
+/-!
+Regression test for overlapping block comment terminators in the fast import parser.
+-/
+
+open Lean
+
+#eval do
+  let header ← parseImports' "/- --/ import Init\n" "<test>"
+  unless header.imports == #[({ module := `Init } : Import)] do
+    throw <| IO.userError "unexpected imports"

--- a/tests/elab/parseImportsFastOverlappingComment.lean
+++ b/tests/elab/parseImportsFastOverlappingComment.lean
@@ -7,6 +7,6 @@ Regression test for overlapping block comment terminators in the fast import par
 open Lean
 
 #eval do
-  let header ← parseImports' "/- --/ import Init\n" "<test>"
-  unless header.imports == #[({ module := `Init } : Import)] do
+  let header ← parseImports' "/- --/ import Foo.Bar\n" "<test>"
+  unless header.imports.any (·.module == `Foo.Bar) do
     throw <| IO.userError "unexpected imports"


### PR DESCRIPTION
This PR fixes `finishCommentBlock` so it does not skip a `-` when it is not followed by `/`.

The fast import parser could miss overlapping terminator candidates in sequences like `--/`: after the first `-` fails to form `-/`, the second `-` still needs to be checked as the start of a valid block comment terminator.

This restores the parser position before continuing, so the next scan step can recheck that character instead of accidentally skipping it.