### PR TITLE
fix: split universe levels for `le_of_forall_le` lemma

### DIFF
--- a/src/Std/Internal/Do/Order/Basic.lean
+++ b/src/Std/Internal/Do/Order/Basic.lean
@@ -414,11 +414,11 @@ theorem ofProp_le [CompleteLattice l] (p : Prop) (rhs : l) :
   (CompleteLattice.ofProp_intro p rhs).mpr
 
 /-- Entailment between functions is pointwise. -/
-theorem le_iff_forall_le {σ α : Type u} [PartialOrder α] {f g : σ → α} :
+theorem le_iff_forall_le {σ : Type u} {α : Type v} [PartialOrder α] {f g : σ → α} :
     (f ⊑ g) ↔ (∀ s, f s ⊑ g s) := Iff.rfl
 
 /-- Entailment between functions follows from pointwise entailment. -/
-theorem le_of_forall_le {σ α : Type u} [PartialOrder α] {f g : σ → α} :
+theorem le_of_forall_le {σ : Type u} {α : Type v} [PartialOrder α] {f g : σ → α} :
     (∀ s, f s ⊑ g s) → f ⊑ g := le_iff_forall_le.mpr
 
 /-- `⊤ ⊑ g` for a function `g` follows from pointwise `⊤ ⊑ g s`. -/


### PR DESCRIPTION
This PR makes some `mvcgen'` lemmas more universe-polymorphic. This is especially important when we work with a polymorphic monad stack. 
