### PR TITLE
perf: internalize backward-rule patterns into the matching table

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
@@ -40,6 +40,7 @@ public def mkBackwardRuleFromSpecCached (specThm : SpecTheorem) (info : WPInfo) 
   if let some rule := s[key]? then return rule
   let some rule ← withNewMCtxDepth <| tryMkBackwardRuleFromSpec specThm info |>.run
     | failure
+  let rule ← rule.shareCommon
   modify fun st => { st with specBackwardRuleCache := st.specBackwardRuleCache.insert key rule }
   return rule
 
@@ -59,6 +60,7 @@ public def mkBackwardRuleForSplitCached (splitInfo : SplitInfo) (info : WPInfo) 
   let s := (← get).splitBackwardRuleCache
   if let some rule := s[key]? then return rule
   let rule ← mkBackwardRuleForSplit splitInfo info
+  let rule ← rule.shareCommon
   modify fun st =>
     { st with splitBackwardRuleCache := st.splitBackwardRuleCache.insert key rule }
   return rule
@@ -75,6 +77,7 @@ public def mkBackwardRuleForLatticeCached (c : LatticeSplit) (as excessArgs : Ar
   let key := (c.applyLemma, asTypes.map ExprPtr.mk, excessArgs.size)
   if let some rule := s[key]? then return rule
   let rule ← c.mkBackwardRuleForLattice as excessArgs resultType?
+  let rule ← rule.shareCommon
   modify fun st => { st with latticeBackwardRuleCache := st.latticeBackwardRuleCache.insert key rule }
   return rule
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Util.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Util.lean
@@ -27,6 +27,27 @@ decomposes.
 namespace Lean.Elab.Tactic.Do.Internal
 
 /--
+Internalize a pattern's expressions into the current `SymM` share table.
+
+A pattern is built in `MetaM`, outside the `SymM` thread whose table holds the targets it matches
+against, so its closed subterms (the instance telescope of a `wp` application, for example) are
+equal to but distinct from the targets'. Internalizing the pattern once makes those subterms
+pointer-equal to every target internalized afterwards, so matching them no longer re-internalizes
+the same constant terms on every application.
+
+Designed for dot notation: `pattern.shareCommon`. Requires `open Lean.Elab.Tactic.Do.Internal`.
+-/
+public def _root_.Lean.Meta.Sym.Pattern.shareCommon (p : Pattern) : SymM Pattern := do
+  return { p with
+    pattern := ← Sym.shareCommon p.pattern
+    varTypes := ← p.varTypes.mapM Sym.shareCommon }
+
+/-- Internalize a backward rule's pattern into the current `SymM` share table. See
+`Pattern.shareCommon`. Designed for dot notation: `rule.shareCommon`. -/
+public def _root_.Lean.Meta.Sym.BackwardRule.shareCommon (rule : BackwardRule) : SymM BackwardRule :=
+  return { rule with pattern := ← rule.pattern.shareCommon }
+
+/--
 `VCGenM` wrapper around `BackwardRule.apply`. Behaves identically to
 `rule.apply goal` unless the application fails and `Context.debug` is on.
 In that case it retries on a fresh metavariable whose type is the


### PR DESCRIPTION
This PR speeds up `mvcgen'` matching by internalizing each backward rule's pattern into the `SymM` share table once, when the rule is cached, instead of re-internalizing its instance arguments on every match.

When the matcher unifies a rule against a goal, it defers the rule's instance arguments and then, for each one, internalizes it into the share table (via `instantiateLevelParamsS` in `processPendingInst`) before checking it is definitionally equal to the goal's instance. The instance arguments of a `wp` application form a large constant telescope (the `WP (m β) β …` instance plus the `Assertion`/`CompleteLattice` instances), identical at every spec match in a given monad. But a pattern is built in `MetaM`, outside the `SymM` thread whose table holds the goal, so the pattern's instances are pointer-distinct from the goal's and this internalization redoes the full traversal on every match.

`BackwardRule.shareCommon` internalizes the rule's pattern once, when it is cached, which turns that per-match re-internalization into constant time. The `SymM` table identifies a node by its children's pointer identity, so internalizing a term is O(1) when its children are already canonical and O(size) otherwise; once the pattern is internalized, every later internalization of its instances finds them already canonical and returns in O(1).

Worked example, `Spec.bind`: it fires once per `←` in a `do`-block, so a chain of `n` binds applies it `n` times. Its pattern is a `wp` application carrying the instance telescope (the `WP (m β) β …` instance is ~170 `Expr` nodes for a `ReaderT`/`StateT` stack, plus the two `Assertion` instances), the same constant term at every bind. Before this PR the pattern's non-internalized `WP` and `CompleteLattice` instances were re-internalized from scratch on every bind, costing `n × O(telescope)`; internalizing the rule once makes each subsequent match O(1), for `O(telescope) + n × O(1)`.

Benchmark wall-clock for the `mvcgen'` step (`tests/bench/mvcgen/sym`, single-threaded), before and after:

| case | before | after |
| --- | --- | --- |
| ReaderState(1000) | 444 ms | 183 ms |
| AddSubCancelDeep(700) | 644 ms | 175 ms |
| AddSubCancel(1000) | 306 ms | 174 ms |
| GetThrowSet(600) | 269 ms | 121 ms |
| MatchIota(150) | 66 ms | 35 ms |
