### PR TITLE
perf: short-circuit Sym pattern matching on pointer equality

### DIFF
--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -474,6 +474,9 @@ def isAssignedMVar (e : Expr) : MetaM Bool :=
   | _            => return false
 
 partial def process (p : Expr) (e : Expr) : UnifyM Bool := do
+  -- A pattern subterm internalized into the same table as the target shares its pointer, so a
+  -- pointer match is a closed term equal to the target with no variables left to bind.
+  if isSameExpr p e then return true
   let e' := etaReduce e
   if !isSameExpr e e' then
     -- **Note**: We eagerly eta reduce patterns


### PR DESCRIPTION
This PR adds a pointer-equality fast path to the `Sym` pattern matcher: when a pattern subterm is pointer-equal to the target, it is a closed term equal to the target with no variables to bind, so matching succeeds immediately without traversing the subterm.

On its own this fires rarely, because patterns are built in a different hash-cons context than the targets. It pays off once patterns are internalized into the target's share table, as the backward-rule patterns (#14134) and the spec patterns (#14142) now are: their shared instance prefixes then match by pointer in constant time instead of being walked structurally.

The short-circuit fires overwhelmingly on the typeclass-instance telescopes of the monad operations. Once a spec pattern is internalized, the entire `@MonadStateOf.get σ m inst` application becomes pointer-shared with the program's `get`, so one pointer comparison replaces walking the whole instance argument. The saving per hit grows with monad-transformer depth: about 65 expression nodes skipped per `get` in a `ReaderT`/`StateT` stack, about 360 in a deeper `ExceptT`-over-`StateT` stack, which is why the deepest benchmark gains the most. The `ReaderT`/`ExceptT` transformer constructors inside those telescopes account for most of the remaining hits.

Benchmark wall-clock for the `mvcgen'` step (`tests/bench/mvcgen/sym`, single-threaded, min of 5), against the current master and with this PR on top:

| case | master | + this PR |
| --- | --- | --- |
| ReaderState(1000) | 170 ms | 151 ms |
| AddSubCancelDeep(700) | 144 ms | 118 ms |
| GetThrowSet(600) | 119 ms | 109 ms |
| MatchIota(150) | 33 ms | 30 ms |
