### PR TITLE
fix: the error message for `mvcgen' with <tac>`

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
@@ -330,6 +330,22 @@ def evalSymMVCGen' : Lean.Elab.Tactic.Grind.GrindTactic := fun stx => do
     return invGoals ++ result.vcs.toList
   Lean.Elab.Tactic.Grind.replaceMainGoal newGoals
 
+/-- Validate the optional `with` clause of `mvcgen'`. It must be a `grind`-mode step so it can share
+`mvcgen'`'s internalised E-graph; the `mvcgenWith` category's `tactic` alternative is a catch-all
+that exists only so a non-`grind` step is reported here with a helpful error rather than a raw
+`expected grind` parser error. -/
+private def elabMvcgenWith (w? : Option (TSyntax `mvcgenWith)) :
+    TacticM (Option (TSyntax `grind)) :=
+  match w? with
+  | none   => return none
+  | some w =>
+    if w.raw.getKind == ``Lean.Parser.Tactic.mvcgenWithGrind then
+      return some ⟨w.raw[0]⟩
+    else
+      throwErrorAt w
+        m!"`mvcgen' … with` expects a `grind`-mode discharging step, not a general tactic"
+          ++ MessageData.hint' m!"Examples: `mvcgen' … with finish`, `mvcgen' … with intro`."
+
 /-- Tactic-level `mvcgen'`. Reuses the grind-mode implementation by re-quoting the
 input as `Grind.mvcgen' …` and running it inside a `GrindTacticM` context built
 without `withProtectedMCtx`, so leftover `Grind.Goal`s flow back as the new tactic
@@ -338,18 +354,19 @@ grind step share an internalised E-graph with `mvcgen'`. -/
 @[builtin_tactic Lean.Parser.Tactic.mvcgen']
 public def elabMVCGen' : Tactic := fun stx => withMainContext do
   let `(tactic| mvcgen'%$tk $cfg:optConfig $[[$lems,*]]? $[until $u:term]? $(invs)?
-        $[simplifying_assumptions $(sa)? $[[$thms,*]]?]? $[with $g:grind]?) := stx
+        $[simplifying_assumptions $(sa)? $[[$thms,*]]?]? $[with $w:mvcgenWith]?) := stx
     | throwUnsupportedSyntax
+  let g? ← elabMvcgenWith w
   -- Without `with`, no downstream grind step will read the E-graph, so opt out of
   -- internalisation; `with` keeps the default `internalize := true`.
-  let cfg ← match g with
+  let cfg ← match g? with
     | some _ => pure cfg
     | none   => do
         let off ← `(optConfig| -internalize)
         pure (Lean.Parser.Tactic.appendConfig off cfg)
   let core ← `(grind| mvcgen'%$tk $cfg:optConfig $[[$lems,*]]? $[until $u:term]? $(invs)?
         $[simplifying_assumptions $(sa)? $[[$thms,*]]?]?)
-  let step ← match g with
+  let step ← match g? with
     | some g => `(grind| $core <;> $g)
     | none   => pure core
   let goal ← getMainGoal

--- a/src/Std/Tactic/Do/Syntax.lean
+++ b/src/Std/Tactic/Do/Syntax.lean
@@ -441,13 +441,24 @@ syntax (name := mvcgenHint) "mvcgen?" optConfig
 -- mode to share the internalised goal context with the user-supplied grind step (the only
 -- way to do so from tactic mode). `$g` is a single grind-mode step, so passing a
 -- multi-step sequence requires explicit grouping (e.g. `with (s₁; s₂)`).
+
+/--
+The discharging step in `mvcgen' … with`. It is a single `grind`-mode tactic (e.g. `finish`,
+`intro`) so it can share `mvcgen'`'s internalised E-graph. The `tactic` alternative is a
+lower-priority catch-all so that a non-`grind` step (e.g. `with grind`, `with simp`) still parses
+and the elaborator can report a helpful error instead of a raw `expected grind` parser error.
+-/
+declare_syntax_cat mvcgenWith
+syntax (name := mvcgenWithGrind) grind : mvcgenWith
+syntax (name := mvcgenWithTactic) (priority := low) tactic : mvcgenWith
+
 @[tactic_alt Lean.Parser.Tactic.mvcgen'Macro]
 syntax (name := mvcgen') "mvcgen'" optConfig
   (" [" withoutPosition((simpStar <|> simpErase <|> simpLemma),*,?) "] ")?
   (&" until " term)?
   (invariantAlts)?
   (&" simplifying_assumptions" (ppSpace colGt ident)? (" [" ident,* "]")?)?
-  (&" with " grind)? : tactic
+  (&" with " mvcgenWith)? : tactic
 
 namespace Grind
 

--- a/tests/bench/mvcgen/sym/test_do_logic.lean
+++ b/tests/bench/mvcgen/sym/test_do_logic.lean
@@ -752,3 +752,21 @@ theorem countdown_spec (n : Nat) :
   all_goals grind
 
 end RepeatInvariantOfInvariantAndBreak
+namespace WithGrindError
+
+/-! The `with` clause of `mvcgen'` only accepts a `grind`-mode step (e.g. `finish`, `intro`). A
+general tactic such as `grind` parses but is rejected with a helpful error in the elaborator,
+rather than a raw `unexpected identifier; expected grind` parser error. -/
+
+def trivial_test (n : Nat) : Id Nat := pure n
+
+/--
+error: `mvcgen' … with` expects a `grind`-mode discharging step, not a general tactic
+
+Hint: Examples: `mvcgen' … with finish`, `mvcgen' … with intro`.
+-/
+#guard_msgs in
+example : ⦃ True ⦄ trivial_test 0 ⦃fun r => r = 0⦄ := by
+  mvcgen' [trivial_test] with grind
+
+end WithGrindError


### PR DESCRIPTION
This PR fixes the error message for `mvcegn' ... with <tac>`. The main motivation for doing so is when we write `mvcgen' with grind` the error message user sees is `unexpected identifier; expected grind`, which cannot be more confusing. That happens because we except a `grind` sequence, syntax category for which is called `grind`. 
I am defining a separate syntax category for discharger tactic called `mvcgenWith`, and throw a more meaningful exception if it is a tactic.
