### PR TITLE
chore: disable binary stripping in release configuration

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,6 +9,9 @@
     {
       "name": "release",
       "displayName": "Release build config",
+      "cacheVariables": {
+        "STRIP_BINARIES": "OFF"
+      },
       "generator": "Unix Makefiles",
       "binaryDir": "${sourceDir}/build/release"
     },


### PR DESCRIPTION
This PR disables symbol stripping of our libleanshared.so in release mode again. As it turns out `--strip-unneeded` doesn't only strip symbols that we do not care about.