### PR TITLE
perf: skip instantiation for already-equal pending instances in Sym matching

### DIFF
--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -1033,6 +1033,10 @@ def processPendingInst : UnifyM Bool := do
   let us := (← get).us
   let args := (← get).args
   for (t, s) in iPending do
+    -- A pattern instance equal to the target's needs no level/beta instantiation or `isDefEq`:
+    -- it is closed and definitionally equal with nothing to assign. An internalized pattern that
+    -- shares its instance with the target hits this on every match.
+    if t == s then continue
     let t ← instantiateLevelParamsS t pattern.levelParams us
     let t ← instantiateRevBetaS t args
     unless (← isDefEqI t s) do


### PR DESCRIPTION
This PR skips the level and beta instantiation and the `isDefEq` check for a pending instance argument that is already equal to the target's. `processPendingInst` defers each instance argument and then internalizes it with `instantiateLevelParamsS` before confirming it is definitionally equal to the target's. When the two are already equal that instantiation is wasted work, since `isDefEq` confirms them regardless. Testing `t == s` up front skips it.

The test is syntactic equality rather than pointer equality, because the pattern reaching `processPendingInst` is not always internalized into the target's share table. Two kinds of pattern arrive here:

- Backward-rule patterns, which #14134 internalizes once per solve. Their instances are pointer-equal to the target's, so pointer equality alone would catch them.
- Spec-database patterns, against which `findSpecs` matches the program to select which spec applies. These live in the discrimination tree built at `@[spec]` registration and persist across solves, while the share table is per-solve, so they are never internalized. Their instance arguments, the `MonadStateOf`/`MonadReaderOf`/`MonadExceptOf` instances of `get`/`set`/`read`/`throw` and the like, are structurally identical to the target's but pointer-distinct, and they dominate: every program is matched against several candidate spec patterns.

Syntactic equality catches both. The spec-database instances, which pointer equality would miss, are the bulk of the saving, so the check pays off on the spec-heavy benchmarks rather than only the deep instance telescopes.

Benchmark wall-clock for the `mvcgen'` step (`tests/bench/mvcgen/sym`, single-threaded, quiet machine), stacked on #14134 and #14137:

| case | #14137 | + this PR |
| --- | --- | --- |
| ReaderState(1000) | 167 ms | 151 ms |
| AddSubCancelDeep(700) | 150 ms | 124 ms |
| AddSubCancel(1000) | 165 ms | 165 ms |
| GetThrowSet(600) | 108 ms | 108 ms |
| MatchIota(150) | 33 ms | 31 ms |
