### PR TITLE
test: recalibrate vcgen benchmark sizes

### DIFF
--- a/tests/bench/vcgen/vcgen_add_sub_cancel.lean
+++ b/tests/bench/vcgen/vcgen_add_sub_cancel.lean
@@ -15,5 +15,5 @@ set_option maxRecDepth 10000
 set_option maxHeartbeats 10000000
 
 #eval runBenchUsingTactic ``Goal [``loop, ``step] `(tactic| vcgen) `(tactic| grind)
-  [100, 500, 1000]
+  [200, 1200, 2200]
   -- [1000]

--- a/tests/bench/vcgen/vcgen_add_sub_cancel_deep.lean
+++ b/tests/bench/vcgen/vcgen_add_sub_cancel_deep.lean
@@ -15,5 +15,5 @@ set_option maxRecDepth 10000
 set_option maxHeartbeats 10000000
 
 #eval runBenchUsingTactic ``Goal [``loop, ``step] `(tactic| vcgen) `(tactic| grind)
-  [100, 400, 700]
+  [100, 500, 900]
   -- [1000]

--- a/tests/bench/vcgen/vcgen_add_sub_cancel_simp.lean
+++ b/tests/bench/vcgen/vcgen_add_sub_cancel_simp.lean
@@ -15,4 +15,4 @@ set_option maxRecDepth 10000
 set_option maxHeartbeats 10000000
 
 #eval runBenchUsingTactic ``Goal [``loop, ``step] `(tactic| vcgen) `(tactic| grind)
-  [100, 250, 400]
+  [100, 400, 700]

--- a/tests/bench/vcgen/vcgen_get_throw_set.lean
+++ b/tests/bench/vcgen/vcgen_get_throw_set.lean
@@ -15,5 +15,5 @@ set_option maxRecDepth 10000
 set_option maxHeartbeats 10000000
 
 #eval runBenchUsingTactic ``Goal [``loop, ``step] `(tactic| vcgen) `(tactic| sorry)
-  [100, 350, 600]
+  [200, 500, 800]
   -- [1000]

--- a/tests/bench/vcgen/vcgen_get_throw_set_grind.lean
+++ b/tests/bench/vcgen/vcgen_get_throw_set_grind.lean
@@ -20,4 +20,4 @@ set_option maxHeartbeats 100000000
 -- `simplifying_assumptions [Nat.add_assoc]` here speeds up grind and kernel checking by a factor
 -- of 2 because long chains `s + 1 + ... + 1` are collapsed into `s + n`.
 #eval runBenchUsingTactic ``GetThrowSetGrind.Goal [``loop, ``step] `(tactic| vcgen simplifying_assumptions [Nat.add_assoc] with finish) `(tactic| fail)
-  [50, 100, 150]
+  [100, 200, 300]

--- a/tests/bench/vcgen/vcgen_match_split.lean
+++ b/tests/bench/vcgen/vcgen_match_split.lean
@@ -15,4 +15,4 @@ set_option maxRecDepth 10000
 set_option maxHeartbeats 10000000
 
 #eval runBenchUsingTactic ``Goal [``loop, ``step] `(tactic| vcgen) `(tactic| sorry)
-  [50, 100, 150]
+  [500, 1000, 1500]

--- a/tests/bench/vcgen/vcgen_pure_precond.lean
+++ b/tests/bench/vcgen/vcgen_pure_precond.lean
@@ -11,7 +11,7 @@ set_option mvcgen.warning false
 open Lean Parser Meta Elab Tactic Sym Std Do
 open PurePrecond
 
-set_option maxRecDepth 10000
+set_option maxRecDepth 100000
 set_option maxHeartbeats 10000000
 
 example : Goal 10 := by
@@ -19,4 +19,4 @@ example : Goal 10 := by
   vcgen
 
 #eval runBenchUsingTactic ``Goal [``loop, ``step] `(tactic| vcgen) `(tactic| fail)
-  [100, 400, 700]
+  [400, 2400, 4400]

--- a/tests/bench/vcgen/vcgen_reader_state.lean
+++ b/tests/bench/vcgen/vcgen_reader_state.lean
@@ -15,5 +15,5 @@ set_option maxRecDepth 10000
 set_option maxHeartbeats 10000000
 
 #eval runBenchUsingTactic ``Goal [``loop, ``step] `(tactic| vcgen) `(tactic| sorry) -- grind scales superlinearly here
-  [100, 500, 1000]
+  [600, 1600, 2600]
   -- [1000]


### PR DESCRIPTION
This PR retunes the three input sizes of each vcgen benchmark so the largest size runs in 1 to 2 seconds of total wall-clock time.

Each benchmark uses an equally spaced triple n1, n2, n3 (so n3 = 2*(n2-n1)+n1), with all sizes multiples of 100 and 100 <= n1 <= n3/3. The largest size now lands between 1 and 2 seconds of combined vcgen, discharge, and kernel time. This was also true back when I first added these benchmarks, so the changed input sizes of this commit are a testament to the speedups we achieved. AddSubCancel stays below the n=2600 point where `grind` discharge exceeds the recursion limit. PurePrecond raises `maxRecDepth` to 100000 so its largest size elaborates.