### PR TITLE
feat: lake: trace-compatible `platformIndependent` settings

### DIFF
--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -579,10 +579,16 @@ def Module.recFetchSetup (mod : Module) : FetchM (Job ModuleSetup) := ensureJob 
     let depTrace := trace.mix extraDepJob.getTrace |>.mix info.trace
     setTraceCaption s!"{mod.name.toString}:deps"
     let libTrace := libTrace.withCaption "libs"
+    let nilLibTrace :=
+      BuildTrace.nil "libs"
+      |>.mix (.nil "import dynlibs")
+      |>.mix (.nil "package external libraries")
+      |>.mix (.nil "module dynlibs")
+      |>.mix (.nil "module plugins")
     match mod.platformIndependent with
     | none => addTrace depTrace; addTrace libTrace
     | some false => addTrace depTrace; addTrace libTrace; addPlatformTrace
-    | some true => addTrace depTrace
+    | some true => addTrace depTrace; addTrace nilLibTrace
     let {dynlibs, plugins} ← computeModuleDeps impLibs externLibs dynlibs plugins
     let extra := (← getLeanOptOverrides).find? mod.pkg.baseName |>.getD {}
     return {

--- a/tests/lake/tests/precompileLink/lakefile.lean
+++ b/tests/lake/tests/precompileLink/lakefile.lean
@@ -16,3 +16,6 @@ lean_exe orderTest
 lean_lib Downstream
 
 lean_lib LakeTest
+
+lean_lib PlatformIndependent where
+  platformIndependent := if get_config? platformIndependent |>.isSome then true else none

--- a/tests/lake/tests/precompileLink/test.sh
+++ b/tests/lake/tests/precompileLink/test.sh
@@ -14,7 +14,7 @@ test_run -v exe orderTest
 
 # Test that transitively importing a precompiled module
 # from a non-precompiled module works
-test_not_out '"pluginPaths":[]' -v setup-file ImportDownstream.lean
+test_not_out '"plugins":[]' -v setup-file ImportDownstream.lean
 test_run -v build Downstream
 
 # Test that `moreLinkArgs` are included when linking precompiled modules
@@ -31,6 +31,12 @@ test_cmd rm -f .lake/build/lib/lean/${PKG}_Foo_Bar.$SHARED_LIB_EXT
 test_run build -R -KplatformIndependent=true
 echo foo > .lake/build/lib/lean/${PKG}_Foo_Bar.$SHARED_LIB_EXT
 test_run build --rehash --no-build
+
+# Test that `platformIndependent` can toggled without a rebuild
+# if the library does not depend on any dynamic libraries
+test_run build -R +PlatformIndependent
+test_run build -R -KplatformIndependent=true +PlatformIndependent --no-build
+test_run build -R +PlatformIndependent --no-build
 
 # cleanup
 rm -f produced.out

--- a/tests/lake/tests/precompileLink/test.sh
+++ b/tests/lake/tests/precompileLink/test.sh
@@ -32,7 +32,7 @@ test_run build -R -KplatformIndependent=true
 echo foo > .lake/build/lib/lean/${PKG}_Foo_Bar.$SHARED_LIB_EXT
 test_run build --rehash --no-build
 
-# Test that `platformIndependent` can toggled without a rebuild
+# Test that `platformIndependent` can be toggled without a rebuild
 # if the library does not depend on any dynamic libraries
 test_run build -R +PlatformIndependent
 test_run build -R -KplatformIndependent=true +PlatformIndependent --no-build


### PR DESCRIPTION
This PR allows modules which do not depend on any dynamic libraries to toggle `platformIndependent` between `true` and unset without a rebuild.
