### PR TITLE
feat: add `collectAxiomsMany` for batched axiom collection

### DIFF
--- a/src/Lean/Util/CollectAxioms.lean
+++ b/src/Lean/Util/CollectAxioms.lean
@@ -153,4 +153,27 @@ public def collectAxioms [Monad m] [MonadEnv m] (constName : Name) : m (Array Na
   return CollectAxioms.runM privateEnv do
     CollectAxioms.collectAndGet s.find? constName
 
+/--
+Collect the axioms transitively used by each constant in `decls`, sharing a single traversal
+across all of them: one `runM` (so the per-call environment setup is done once) and one `seen`
+cache (so the common dependency closure is walked once in total, not once per constant). This is
+far faster than mapping `collectAxioms` over many declarations, which rebuilds the cache and
+redoes the setup on every call.
+
+The result is positional: entry `i` holds the axioms used by `decls[i]`, with any axiom in
+`except` removed. The shared cache stores full (unfiltered) axiom sets, so `except` affects only
+the returned arrays; passing an allowlist therefore leaves just the "unexpected" axioms (often
+none) per declaration. This is the same shared-state collection the olean exporter performs
+internally (see `exportEntriesFnEx`).
+-/
+public def collectAxiomsMany [Monad m] [MonadEnv m]
+    (decls : Array Name) (except : NameSet := {}) : m (Array (Array Name)) := do
+  let env ← getEnv
+  let privateEnv := env.setExporting false
+  let s := exportedAxiomsExt.getState (asyncMode := .mainOnly) env
+  return CollectAxioms.runM privateEnv do
+    decls.mapM fun name => do
+      let axs ← CollectAxioms.collectAndGet s.find? name
+      return axs.filter (!except.contains ·)
+
 end Lean

--- a/tests/elab/collectAxioms.lean
+++ b/tests/elab/collectAxioms.lean
@@ -30,3 +30,14 @@ theorem one_add_one : 1 + 1 = 2 := by
 /-- info: 'one_add_one' depends on axioms: [one_add_one._native.native_decide.ax_1_1] -/
 #guard_msgs in
 #print axioms one_add_one
+
+-- `collectAxiomsMany` is the batched form: entry `i` matches `collectAxioms decls[i]`.
+/-- info: #[#[`A0, `A1, `A2], #[`A0], #[`A1]] -/
+#guard_msgs in
+#eval Lean.collectAxiomsMany #[``A2, ``A0, ``A1]
+
+-- `except` filters the per-declaration results (here removing the `A0`/`A1` axioms),
+-- while the shared cache still records the full sets.
+/-- info: #[#[`A2], #[], #[]] -/
+#guard_msgs in
+#eval Lean.collectAxiomsMany #[``A2, ``A0, ``A1] (except := ({} : Lean.NameSet).insert ``A0 |>.insert ``A1)


### PR DESCRIPTION
This PR adds `Lean.collectAxiomsMany`, which collects the axioms used by each of many declarations while sharing one traversal across all of them — a single `runM` (so the per-call environment setup is done once) and a single `seen` cache (so the common dependency closure is walked once in total, not once per declaration). This is the same shared-state collection the olean exporter already performs internally (`exportEntriesFnEx`), now exposed for callers that audit many declarations at once.

Mapping `collectAxioms` over a library instead rebuilds the cache and redoes the per-call setup (`setExporting`, the extension lookup, a fresh `runM`) on every call — about 77ms/declaration even with the precomputed dependencies from #13117. Replacing such a loop with `collectAxiomsMany` dropped a ~4400-declaration library's "every declaration uses only `{propext, Classical.choice, Quot.sound}`" audit from ~632s to ~10s in CI (in Tau Ceti).

The optional `except : NameSet` removes the listed axioms from each returned array — e.g. pass an allowlist to leave only the *unexpected* axioms, which for an audit is usually none. The shared cache stores full (unfiltered) sets, so `except` affects only the returned arrays, not cache reuse.

**One question for reviewers:** is the `except` parameter welcome, or would you prefer the minimal `collectAxiomsMany (decls : Array Name) : m (Array (Array Name))` with filtering left to callers? Happy to drop it.

:robot: Implemented with assistance from Claude Code (Anthropic).