### PR TITLE
feat: add ByteArray.copyWithin

### DIFF
--- a/src/Init/Data/ByteArray/Basic.lean
+++ b/src/Init/Data/ByteArray/Basic.lean
@@ -181,10 +181,11 @@ Copies the slice at `[srcOff, srcOff + len)` in {name}`a` to `[destOff, destOff 
 doubled when grown.
 
 This is equivalent to {lean}`a.copySlice srcOff a destOff len exact`, but when {name}`a` is not
-shared the copy is performed in place, even when the source and destination ranges overlap or the
-array is grown; the source range is read as it was before the copy. The argument {name}`a` is
-owned rather than borrowed to make this possible, whereas passing the same array as both source
-and destination of {name}`ByteArray.copySlice` always copies the whole array.
+shared the copy is performed within the existing buffer if its capacity suffices, and with a
+single reallocation otherwise, even when the source and destination ranges overlap; the source
+range is read as it was before the copy. The argument {name}`a` is owned rather than borrowed to
+make this possible, whereas passing the same array as both source and destination of
+{name}`ByteArray.copySlice` always copies the whole array.
 
 With {lean}`destOff = a.size` this appends the slice at `[srcOff, srcOff + len)` to the end of
 {name}`a`, the analogue of Rust's {lit}`Vec::extend_from_within`; as with

--- a/src/Init/Data/ByteArray/Basic.lean
+++ b/src/Init/Data/ByteArray/Basic.lean
@@ -176,6 +176,19 @@ theorem fastAppend_eq {a b : ByteArray} : a.fastAppend b = a ++ b := by
   simp [← append_eq_fastAppend]
 
 /--
+Appends the slice of {name}`a` with byte indices in `[start, start + len)` to the end of {name}`a`,
+ignoring any indices that are at or beyond the end of {name}`a`.
+
+When {name}`a` is not shared, this is done in place with a single allocation and a single copy, which
+is significantly faster than first extracting the slice and then appending it. The argument {name}`a`
+is owned rather than borrowed so that this in-place case is possible; this is the ByteArray analogue
+of Rust's Vec::extend_from_within.
+-/
+@[extern "lean_byte_array_copy_within"]
+def copyWithin (a : ByteArray) (start len : Nat) : ByteArray :=
+  a ++ a.extract start (start + len)
+
+/--
 Converts a packed array of bytes to a linked list.
 -/
 def toList (bs : ByteArray) : List UInt8 :=

--- a/src/Init/Data/ByteArray/Basic.lean
+++ b/src/Init/Data/ByteArray/Basic.lean
@@ -176,17 +176,23 @@ theorem fastAppend_eq {a b : ByteArray} : a.fastAppend b = a ++ b := by
   simp [← append_eq_fastAppend]
 
 /--
-Appends the slice of {name}`a` with byte indices in `[start, start + len)` to the end of {name}`a`,
-ignoring any indices that are at or beyond the end of {name}`a`.
+Copies the slice at `[srcOff, srcOff + len)` in {name}`a` to `[destOff, destOff + len)` in
+{name}`a`, growing {name}`a` if necessary. If {name}`exact` is {name}`false`, the capacity will be
+doubled when grown.
 
-When {name}`a` is not shared, this is done in place with a single allocation and a single copy, which
-is significantly faster than first extracting the slice and then appending it. The argument {name}`a`
-is owned rather than borrowed so that this in-place case is possible; this is the ByteArray analogue
-of Rust's Vec::extend_from_within.
+This is equivalent to {lean}`a.copySlice srcOff a destOff len exact`, but when {name}`a` is not
+shared the copy is performed in place, even when the source and destination ranges overlap or the
+array is grown; the source range is read as it was before the copy. The argument {name}`a` is
+owned rather than borrowed to make this possible, whereas passing the same array as both source
+and destination of {name}`ByteArray.copySlice` always copies the whole array.
+
+With {lean}`destOff = a.size` this appends the slice at `[srcOff, srcOff + len)` to the end of
+{name}`a`, the analogue of Rust's {lit}`Vec::extend_from_within`; as with
+{name}`ByteArray.copySlice`, pass {lit}`exact := false` when growing the array repeatedly.
 -/
 @[extern "lean_byte_array_copy_within"]
-def copyWithin (a : ByteArray) (start len : Nat) : ByteArray :=
-  a ++ a.extract start (start + len)
+def copyWithin (a : ByteArray) (srcOff destOff len : Nat) (exact : Bool := true) : ByteArray :=
+  a.copySlice srcOff a destOff len exact
 
 /--
 Converts a packed array of bytes to a linked list.

--- a/src/Init/Data/ByteArray/Basic.lean
+++ b/src/Init/Data/ByteArray/Basic.lean
@@ -139,7 +139,8 @@ appended at the end of {name}`dest`.
 
 When {name}`dest` is not shared, the copy is performed within its existing buffer if the capacity
 suffices, and with a single reallocation otherwise; the argument {name}`dest` is owned rather than
-borrowed to make this possible.
+borrowed to make this possible. To copy a slice of an array to a different position within the
+same array, use {lit}`ByteArray.copyWithin`.
 -/
 @[extern "lean_byte_array_copy_slice"]
 def copySlice (src : @& ByteArray) (srcOff : Nat) (dest : ByteArray) (destOff len : Nat) (exact : Bool := true) : ByteArray :=

--- a/src/Init/Data/ByteArray/Basic.lean
+++ b/src/Init/Data/ByteArray/Basic.lean
@@ -187,7 +187,7 @@ range is read as it was before the copy. The argument {name}`a` is owned rather 
 make this possible, whereas passing the same array as both source and destination of
 {name}`ByteArray.copySlice` always copies the whole array.
 
-With {lean}`destOff = a.size` this appends the slice at `[srcOff, srcOff + len)` to the end of
+With {lean}`destOff ≥ a.size` this appends the slice at `[srcOff, srcOff + len)` to the end of
 {name}`a`, the analogue of Rust's {lit}`Vec::extend_from_within`; as with
 {name}`ByteArray.copySlice`, pass {lit}`exact := false` when growing the array repeatedly.
 -/

--- a/src/Init/Data/ByteArray/Basic.lean
+++ b/src/Init/Data/ByteArray/Basic.lean
@@ -131,6 +131,15 @@ def isEmpty (s : ByteArray) : Bool :=
 Copies the slice at `[srcOff, srcOff + len)` in {name}`src` to `[destOff, destOff + len)` in
 {name}`dest`, growing {name}`dest` if necessary. If {name}`exact` is {name}`false`, the capacity
 will be doubled when grown.
+
+Out-of-bounds indices are clamped: if {name}`srcOff` is at or past the end of {name}`src`, then
+{name}`dest` is returned unchanged; {name}`len` is reduced so that the source slice ends at the
+end of {name}`src`; and if {name}`destOff` is at or past the end of {name}`dest`, the slice is
+appended at the end of {name}`dest`.
+
+When {name}`dest` is not shared, the copy is performed within its existing buffer if the capacity
+suffices, and with a single reallocation otherwise; the argument {name}`dest` is owned rather than
+borrowed to make this possible.
 -/
 @[extern "lean_byte_array_copy_slice"]
 def copySlice (src : @& ByteArray) (srcOff : Nat) (dest : ByteArray) (destOff len : Nat) (exact : Bool := true) : ByteArray :=

--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -2611,19 +2611,25 @@ extern "C" LEAN_EXPORT obj_res lean_byte_array_push(obj_arg a, uint8 b) {
     return r;
 }
 
-extern "C" LEAN_EXPORT obj_res lean_byte_array_copy_within(obj_arg a, obj_arg o_start, obj_arg o_len) {
+extern "C" LEAN_EXPORT obj_res lean_byte_array_copy_within(obj_arg a, obj_arg o_src_off, obj_arg o_dest_off, obj_arg o_len, bool exact) {
     size_t sz = lean_sarray_size(a);
-    size_t start = lean_nat_to_size_t(o_start);
-    if (start > sz)
-        start = sz;
-    size_t len = std::min(lean_nat_to_size_t(o_len), sz - start);
-    size_t new_sz = sz + len;
-    // `a` is owned, so it can be grown in place when exclusive (one allocation, one `memcpy`).
-    object * r = lean_sarray_ensure_exclusive(lean_sarray_ensure_capacity(a, new_sz, /* exact */ false));
+    size_t src_off = lean_nat_to_size_t(o_src_off);
+    if (src_off > sz) {
+        lean_dec(o_dest_off);
+        lean_dec(o_len);
+        return a;
+    }
+    size_t len = std::min(lean_nat_to_size_t(o_len), sz - src_off);
+    size_t dest_off = lean_nat_to_size_t(o_dest_off);
+    if (dest_off > sz) {
+        dest_off = sz;
+    }
+    size_t new_sz = std::max(sz, dest_off + len);
+    // `a` is owned, so when it is exclusive it can be modified (and grown) in place.
+    object * r = lean_sarray_ensure_exclusive(lean_sarray_ensure_capacity(a, new_sz, exact));
     lean_to_sarray(r)->m_size = new_sz;
-    // `r` is exclusive, and the source `[start, start + len)` and destination `[sz, sz + len)`
-    // ranges cannot overlap since `start + len <= sz`, so `memcpy` is safe.
-    memcpy(lean_sarray_cptr(r) + sz, lean_sarray_cptr(r) + start, len);
+    // The source and destination ranges may overlap, so use `memmove`.
+    memmove(lean_sarray_cptr(r) + dest_off, lean_sarray_cptr(r) + src_off, len);
     return r;
 }
 

--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -2611,6 +2611,22 @@ extern "C" LEAN_EXPORT obj_res lean_byte_array_push(obj_arg a, uint8 b) {
     return r;
 }
 
+extern "C" LEAN_EXPORT obj_res lean_byte_array_copy_within(obj_arg a, obj_arg o_start, obj_arg o_len) {
+    size_t sz = lean_sarray_size(a);
+    size_t start = lean_nat_to_size_t(o_start);
+    if (start > sz)
+        start = sz;
+    size_t len = std::min(lean_nat_to_size_t(o_len), sz - start);
+    size_t new_sz = sz + len;
+    // `a` is owned, so it can be grown in place when exclusive (one allocation, one `memcpy`).
+    object * r = lean_sarray_ensure_exclusive(lean_sarray_ensure_capacity(a, new_sz, /* exact */ false));
+    lean_to_sarray(r)->m_size = new_sz;
+    // `r` is exclusive, and the source `[start, start + len)` and destination `[sz, sz + len)`
+    // ranges cannot overlap since `start + len <= sz`, so `memcpy` is safe.
+    memcpy(lean_sarray_cptr(r) + sz, lean_sarray_cptr(r) + start, len);
+    return r;
+}
+
 extern "C" LEAN_EXPORT uint64_t lean_byte_array_hash(b_obj_arg a) {
     return hash_str(lean_sarray_size(a), lean_sarray_cptr(a), 11);
 }

--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -2624,6 +2624,8 @@ extern "C" LEAN_EXPORT obj_res lean_byte_array_copy_within(obj_arg a, obj_arg o_
     if (dest_off > sz) {
         dest_off = sz;
     }
+    if (len > SIZE_MAX - dest_off)
+        lean_internal_panic_out_of_memory();
     size_t new_sz = std::max(sz, dest_off + len);
     // `a` is owned, so when it is exclusive it can be modified (and grown) in place.
     object * r = lean_sarray_ensure_exclusive(lean_sarray_ensure_capacity(a, new_sz, exact));

--- a/tests/elab/bytearray_copyslice.lean
+++ b/tests/elab/bytearray_copyslice.lean
@@ -1,0 +1,40 @@
+import Lean.Util.TestExtern
+
+/-!
+Checks that the native implementation of `ByteArray.copySlice` agrees with its reference
+implementation on the index-clamping edge cases: `srcOff` at or past the end of `src` (which
+returns `dest` unchanged), `len` clamped to the end of `src`, and `destOff` at or past the end
+of `dest` (which appends). The in-bounds cases are covered in `2966.lean`.
+-/
+
+deriving instance DecidableEq for ByteArray
+
+-- srcOff = src.size: dest returned unchanged
+test_extern ByteArray.copySlice ⟨#[1,2,3]⟩ 3 ⟨#[4,5,6,7]⟩ 1 2
+-- srcOff past the end of src: dest returned unchanged (early-return path)
+test_extern ByteArray.copySlice ⟨#[1,2,3]⟩ 5 ⟨#[4,5,6,7]⟩ 1 2
+test_extern ByteArray.copySlice ⟨#[1,2,3]⟩ 5 ⟨#[4,5,6,7]⟩ 10 20
+-- len clamped to the end of src
+test_extern ByteArray.copySlice ⟨#[1,2,3]⟩ 1 ⟨#[4,5,6,7]⟩ 0 20
+test_extern ByteArray.copySlice ⟨#[1,2,3]⟩ 2 ⟨#[4,5,6,7]⟩ 3 20
+-- destOff = dest.size: append
+test_extern ByteArray.copySlice ⟨#[1,2,3]⟩ 0 ⟨#[4,5,6,7]⟩ 4 2
+-- destOff past the end of dest: clamped to an append
+test_extern ByteArray.copySlice ⟨#[1,2,3]⟩ 0 ⟨#[4,5,6,7]⟩ 9 2
+-- destOff past the end with len clamped
+test_extern ByteArray.copySlice ⟨#[1,2,3]⟩ 1 ⟨#[4,5,6,7]⟩ 9 20
+-- len = 0
+test_extern ByteArray.copySlice ⟨#[1,2,3]⟩ 1 ⟨#[4,5,6,7]⟩ 2 0
+test_extern ByteArray.copySlice ⟨#[1,2,3]⟩ 1 ⟨#[4,5,6,7]⟩ 9 0
+-- empty src
+test_extern ByteArray.copySlice ⟨#[]⟩ 0 ⟨#[4,5,6,7]⟩ 1 3
+test_extern ByteArray.copySlice ⟨#[]⟩ 2 ⟨#[4,5,6,7]⟩ 1 3
+-- empty dest
+test_extern ByteArray.copySlice ⟨#[1,2,3]⟩ 1 ⟨#[]⟩ 0 2
+test_extern ByteArray.copySlice ⟨#[1,2,3]⟩ 1 ⟨#[]⟩ 5 2
+-- both empty
+test_extern ByteArray.copySlice ⟨#[]⟩ 0 ⟨#[]⟩ 0 0
+-- exact := false
+test_extern ByteArray.copySlice ⟨#[1,2,3]⟩ 0 ⟨#[4,5,6,7]⟩ 4 2 false
+test_extern ByteArray.copySlice ⟨#[1,2,3]⟩ 5 ⟨#[4,5,6,7]⟩ 1 2 false
+test_extern ByteArray.copySlice ⟨#[1,2,3]⟩ 1 ⟨#[4,5,6,7]⟩ 9 20 false

--- a/tests/elab/bytearray_copywithin.lean
+++ b/tests/elab/bytearray_copywithin.lean
@@ -1,5 +1,11 @@
 import Lean.Util.TestExtern
 
+/-!
+Checks that the native implementation of `ByteArray.copyWithin` agrees with its reference
+implementation (`copySlice` with the same array as source and destination), across overlapping
+ranges in both directions, growth past the old size, and the index-clamping edge cases.
+-/
+
 deriving instance DecidableEq for ByteArray
 
 -- interior copy, non-overlapping ranges
@@ -19,12 +25,18 @@ test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 2 15 5
 -- len clamped to the end of the source
 test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 7 0 20
 test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 7 9 20
+-- append at the end with len clamped
+test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 7 10 20
 -- srcOff = size
 test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 10 0 3
+-- srcOff = size with destOff beyond the end
+test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 10 15 3
 -- srcOff beyond the end: no change
 test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 12 0 3
 -- len = 0
 test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 3 5 0
+-- len = 0 with destOff beyond the end
+test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 3 15 0
 -- empty array
 test_extern ByteArray.copyWithin ⟨#[]⟩ 0 0 0
 test_extern ByteArray.copyWithin ⟨#[]⟩ 1 2 3

--- a/tests/elab/bytearray_copywithin.lean
+++ b/tests/elab/bytearray_copywithin.lean
@@ -1,0 +1,33 @@
+import Lean.Util.TestExtern
+
+deriving instance DecidableEq for ByteArray
+
+-- interior copy, non-overlapping ranges
+test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 0 6 3
+-- overlapping ranges, source before destination
+test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 2 4 5
+-- overlapping ranges, destination before source
+test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 4 2 5
+-- srcOff = destOff
+test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 3 3 4
+-- append at the end
+test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 2 10 5
+-- overlapping ranges that grow the array
+test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 3 8 6
+-- destOff beyond the end is clamped to the end
+test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 2 15 5
+-- len clamped to the end of the source
+test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 7 0 20
+test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 7 9 20
+-- srcOff = size
+test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 10 0 3
+-- srcOff beyond the end: no change
+test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 12 0 3
+-- len = 0
+test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 3 5 0
+-- empty array
+test_extern ByteArray.copyWithin ⟨#[]⟩ 0 0 0
+test_extern ByteArray.copyWithin ⟨#[]⟩ 1 2 3
+-- exact := false
+test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 2 10 5 false
+test_extern ByteArray.copyWithin ⟨#[0,1,2,3,4,5,6,7,8,9]⟩ 4 2 5 false


### PR DESCRIPTION
This PR adds `ByteArray.copyWithin`, which copies the slice `[srcOff, srcOff + len)` of an array to `[destOff, destOff + len)` within the same array, growing it if necessary. It is equivalent to `a.copySlice srcOff a destOff len exact`, which is its reference implementation, but when the array is unshared the copy is performed with `memmove` within the existing buffer (or with a single reallocation, if the array grows past its capacity), even when the ranges overlap. Passing the same array as both `src` and `dest` of `copySlice` always copies the whole array, because the borrowed `src` forces reference counting to duplicate the buffer; `copyWithin` takes its argument owned precisely so that the exclusive case can mutate in place.

With `destOff ≥ a.size` this appends a slice of the array to itself, which is the analogue of Rust's `Vec::extend_from_within` and is the back-reference copy at the core of LZ77/DEFLATE decompression. An `@[extern]` prototype of that special case measured ~35% faster native `inflate` in lean-zip. Tests compare the native implementation against the reference implementation using `test_extern`, covering overlapping ranges in both directions, growth, and the clamping edge cases.

🤖 Prepared with Claude Code
