### PR TITLE
feat: add ThreadSanitizer support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,7 @@ jobs:
               },
               {
                 "name": "Linux tsanitize",
-                "os": large ? "nscloud-ubuntu-24.04-amd64-8x16" : "ubuntu-latest",
+                "os": large ? "nscloud-ubuntu-24.04-amd64-32x64" : "ubuntu-latest",
                 "enabled": (level >= 2 || fsanitize) && target_stage < 2,
                 "test": true,
                 // turn off custom allocator & symbolic functions to make TSAN do its magic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,7 @@ jobs:
                 // We take a small subset of tests for tsan and run with reduced test parallelism.
                 // This is necessary as running tsan in parallel on all of our test suite would
                 // easily OOM the runner.
-                "CTEST_OPTIONS": "-j1 -E 'async_http_body|async_http_dispatch|async_http_encode|async_http_fuzz|async_http_response_framing|async_http_hang_regressions|task_iterators' -R 'elab/(async.*|sync_.*|task.*|bv_bitwise|net_addr|networkInterfaces|openssl|idbg.*|Process|handleLocking|ioNulBytes|ioRandomBytes|libuv|readDir|realPath|st_test|stateRef|grind_list_count|vcgenSymBlock|doControlInfoAggregate)'"
+                "CTEST_OPTIONS": "-j2 -E 'async_http_body|async_http_dispatch|async_http_encode|async_http_fuzz|async_http_response_framing|async_http_hang_regressions|task_iterators' -R '(compile/534)|(elab/(async.*|sync_.*|task.*|bv_bitwise|net_addr|networkInterfaces|openssl|idbg.*|Process|handleLocking|ioNulBytes|ioRandomBytes|libuv|readDir|realPath|st_test|stateRef|grind_list_count|vcgenSymBlock|doControlInfoAggregate))'"
               },
               {
                 "name": "macOS",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,9 @@ jobs:
         uses: actions/checkout@v6
         if: env.IS_NIGHTLY != 'true' && env.IS_LEAN4_REPO_TAG != 'true'
         with:
-          sparse-checkout: src/stdlib_flags.h,stage0/src/stdlib_flags.h
+          sparse-checkout: |
+            src/stdlib_flags.h
+            stage0/src/stdlib_flags.h
       - name: Set Nightly
         if: env.IS_NIGHTLY == 'true'
         id: set-nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,7 @@ jobs:
                 // We take a small subset of tests for tsan and run with reduced test parallelism.
                 // This is necessary as running tsan in parallel on all of our test suite would
                 // easily OOM the runner.
-                "CTEST_OPTIONS": "-R 'elab/(async.*|sync_.*|task.*|bv_bitwise|net_addr|networkInterfaces|openssl|idbg.*|Process|handleLocking|ioNulBytes|ioRandomBytes|libuv|readDir|realPath|st_test|stateRef|grind_list_count|vcgenSymBlock|doControlInfoAggregate)'"
+                "CTEST_OPTIONS": "-j1 -E 'async_http_body|async_http_dispatch|async_http_encode|async_http_fuzz|async_http_response_framing|async_http_hang_regressions|task_iterators' -R 'elab/(async.*|sync_.*|task.*|bv_bitwise|net_addr|networkInterfaces|openssl|idbg.*|Process|handleLocking|ioNulBytes|ioRandomBytes|libuv|readDir|realPath|st_test|stateRef|grind_list_count|vcgenSymBlock|doControlInfoAggregate)'"
               },
               {
                 "name": "macOS",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,10 +343,8 @@ jobs:
               },
               {
                 "name": "Linux tsanitize",
-                // Always run on large if available, more reliable regarding timeouts.
-                // Building stage 2 with tsanitize needs > 32GB.
-                "os": large ? (target_stage >= 2 ? "nscloud-ubuntu-24.04-amd64-32x64" : "nscloud-ubuntu-24.04-amd64-8x16") : "ubuntu-latest",
-                "enabled": level >= 2 || fsanitize,
+                "os": large ? "nscloud-ubuntu-24.04-amd64-8x16" : "ubuntu-latest",
+                "enabled": (level >= 2 || fsanitize) && target_stage < 2,
                 "test": true,
                 // turn off custom allocator & symbolic functions to make TSAN do its magic
                 "CMAKE_PRESET": "sanitize-thread",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
   # This job determines various settings for the following CI runs; see the `outputs` for details
   configure:
     runs-on: ubuntu-latest
+    env:
+      # don't schedule nightlies on forks
+      IS_NIGHTLY: ${{ (github.event_name == 'schedule' && github.repository == 'leanprover/lean4') || inputs.action == 'release nightly' }}
+      IS_LEAN4_REPO_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.repository == 'leanprover/lean4' }}
     outputs:
       # The build matrix, dynamically generated here
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -47,12 +51,16 @@ jobs:
       RELEASE_TAG: ${{ steps.set-release.outputs.RELEASE_TAG }}
 
     steps:
-      - name: Checkout
+      - name: Checkout (full)
         uses: actions/checkout@v6
-        # don't schedule nightlies on forks
-        if: github.event_name == 'schedule' && github.repository == 'leanprover/lean4' || inputs.action == 'release nightly' || (startsWith(github.ref, 'refs/tags/') && github.repository == 'leanprover/lean4')
+        if: env.IS_NIGHTLY == 'true' || env.IS_LEAN4_REPO_TAG == 'true'
+      - name: Checkout (sparse)
+        uses: actions/checkout@v6
+        if: env.IS_NIGHTLY != 'true' && env.IS_LEAN4_REPO_TAG != 'true'
+        with:
+          sparse-checkout: src/stdlib_flags.h,stage0/src/stdlib_flags.h
       - name: Set Nightly
-        if: github.event_name == 'schedule' && github.repository == 'leanprover/lean4' || inputs.action == 'release nightly'
+        if: env.IS_NIGHTLY == 'true'
         id: set-nightly
         run: |
           if [[ -n '${{ secrets.PUSH_NIGHTLY_TOKEN }}' ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,20 @@ jobs:
                 "CTEST_OPTIONS": "-E 'StackOverflow|interactive|async_select_channel|9366|elab/grind|pkg/|lake/|kernelMaxRecDepth|elab_bench/'"
               },
               {
+                "name": "Linux tsanitize",
+                // Always run on large if available, more reliable regarding timeouts.
+                // Building stage 2 with tsanitize needs > 32GB.
+                "os": large ? (target_stage >= 2 ? "nscloud-ubuntu-24.04-amd64-32x64" : "nscloud-ubuntu-24.04-amd64-8x16") : "ubuntu-latest",
+                "enabled": level >= 2 || fsanitize,
+                "test": true,
+                // turn off custom allocator & symbolic functions to make TSAN do its magic
+                "CMAKE_PRESET": "sanitize-thread",
+                // We take a small subset of tests for tsan and run with reduced test parallelism.
+                // This is necessary as running tsan in parallel on all of our test suite would
+                // easily OOM the runner.
+                "CTEST_OPTIONS": "-R 'elab/(async.*|sync_.*|task.*|bv_bitwise|net_addr|networkInterfaces|openssl|idbg.*|Process|handleLocking|ioNulBytes|ioRandomBytes|libuv|readDir|realPath|st_test|stateRef|grind_list_count|vcgenSymBlock|doControlInfoAggregate)'"
+              },
+              {
                 "name": "macOS",
                 "os": "macos-15-intel",
                 "release": true,

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -55,7 +55,7 @@
       "cacheVariables": {
         "LEAN_EXTRA_CXX_FLAGS": "-g3 -fsanitize=address,undefined -DLEAN_DEFAULT_THREAD_STACK_SIZE=16*1024*1024",
         "LEANC_EXTRA_CC_FLAGS": "-g3 -fsanitize=address,undefined",
-        "LEAN_EXTRA_LINKER_FLAGS": "-fsanitize=address,undefined -fsanitize-link-c++-runtime",
+        "LEAN_EXTRA_LINKER_FLAGS": "-fsanitize=address,undefined -fsanitize-link-c++-runtime -fuse-ld=lld",
         "STRIP_BINARIES": "OFF",
         "USE_MIMALLOC": "OFF",
         "BSYMBOLIC": "OFF",
@@ -64,13 +64,13 @@
       "generator": "Unix Makefiles",
       "binaryDir": "${sourceDir}/build/sanitize"
     },
-{
+    {
       "name": "sanitize-thread",
       "displayName": "Thread Sanitize build config",
       "cacheVariables": {
         "LEAN_EXTRA_CXX_FLAGS": "-g3 -fsanitize=thread",
         "LEANC_EXTRA_CC_FLAGS": "-g3 -fsanitize=thread",
-        "LEAN_EXTRA_LINKER_FLAGS": "-fsanitize=thread",
+        "LEAN_EXTRA_LINKER_FLAGS": "-fsanitize=thread -fuse-ld=lld",
         "STRIP_BINARIES": "OFF",
         "SMALL_ALLOCATOR": "OFF",
         "USE_MIMALLOC": "OFF",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -64,6 +64,21 @@
       "generator": "Unix Makefiles",
       "binaryDir": "${sourceDir}/build/sanitize"
     },
+{
+      "name": "sanitize-thread",
+      "displayName": "Thread Sanitize build config",
+      "cacheVariables": {
+        "LEAN_EXTRA_CXX_FLAGS": "-fsanitize=thread",
+        "LEANC_EXTRA_CC_FLAGS": "-fsanitize=thread",
+        "LEAN_EXTRA_LINKER_FLAGS": "-fsanitize=thread",
+        "STRIP_BINARIES": "OFF",
+        "SMALL_ALLOCATOR": "OFF",
+        "USE_MIMALLOC": "OFF",
+        "BSYMBOLIC": "OFF"
+      },
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build/sanitize-thread"
+    },
     {
       "name": "sandebug",
       "inherits": ["sanitize", "debug"],

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -139,6 +139,11 @@
       "inherits": "release"
     },
     {
+      "name": "sanitize-thread",
+      "configurePreset": "sanitize-thread",
+      "inherits": "release"
+    },
+    {
       "name": "sandebug",
       "configurePreset": "sandebug",
       "inherits": "release"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -68,8 +68,8 @@
       "name": "sanitize-thread",
       "displayName": "Thread Sanitize build config",
       "cacheVariables": {
-        "LEAN_EXTRA_CXX_FLAGS": "-fsanitize=thread",
-        "LEANC_EXTRA_CC_FLAGS": "-fsanitize=thread",
+        "LEAN_EXTRA_CXX_FLAGS": "-g3 -fsanitize=thread",
+        "LEANC_EXTRA_CC_FLAGS": "-g3 -fsanitize=thread",
         "LEAN_EXTRA_LINKER_FLAGS": "-fsanitize=thread",
         "STRIP_BINARIES": "OFF",
         "SMALL_ALLOCATOR": "OFF",

--- a/src/include/lean/lean.h
+++ b/src/include/lean/lean.h
@@ -327,6 +327,65 @@ static inline LEAN_ALWAYS_INLINE uint8_t lean_is_scalar(lean_object * o) { retur
 static inline lean_object * lean_box(size_t n) { return (lean_object*)(((size_t)(n) << 1) | 1); }
 static inline size_t lean_unbox(lean_object * o) { return (size_t)(o) >> 1; }
 
+/* Detect whether ThreadSanitizer is enabled (Clang via `__has_feature`, GCC via `__SANITIZE_THREAD__`). */
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+#define LEAN_TSAN
+#endif
+#endif
+#if defined(__SANITIZE_THREAD__)
+#define LEAN_TSAN
+#endif
+
+/* Under TSan we access `m_rc` through sequentially consistent atomics so that the otherwise
+   non-atomic single-threaded fast paths are not flagged as data races. The cast to `_Atomic(int)*`
+   mirrors `lean_get_rc_mt_addr`; `_Atomic(t)` expands to `std::atomic<t>` in C++. */
+#ifdef LEAN_TSAN
+#ifdef __cplusplus
+#define LEAN_RC_ATOMIC_LOAD(o)      std::atomic_load_explicit((_Atomic(int)*)(&(o)->m_rc), std::memory_order_seq_cst)
+#define LEAN_RC_ATOMIC_STORE(o, v)  std::atomic_store_explicit((_Atomic(int)*)(&(o)->m_rc), v, std::memory_order_seq_cst)
+#define LEAN_RC_ATOMIC_ADD(o, v)    std::atomic_fetch_add_explicit((_Atomic(int)*)(&(o)->m_rc), v, std::memory_order_seq_cst)
+#define LEAN_RC_ATOMIC_SUB(o, v)    std::atomic_fetch_sub_explicit((_Atomic(int)*)(&(o)->m_rc), v, std::memory_order_seq_cst)
+#else
+#define LEAN_RC_ATOMIC_LOAD(o)      atomic_load_explicit((_Atomic(int)*)(&(o)->m_rc), memory_order_seq_cst)
+#define LEAN_RC_ATOMIC_STORE(o, v)  atomic_store_explicit((_Atomic(int)*)(&(o)->m_rc), v, memory_order_seq_cst)
+#define LEAN_RC_ATOMIC_ADD(o, v)    atomic_fetch_add_explicit((_Atomic(int)*)(&(o)->m_rc), v, memory_order_seq_cst)
+#define LEAN_RC_ATOMIC_SUB(o, v)    atomic_fetch_sub_explicit((_Atomic(int)*)(&(o)->m_rc), v, memory_order_seq_cst)
+#endif
+#endif
+
+static inline int lean_internal_get_rc(lean_object* o) {
+#ifdef LEAN_TSAN
+    return LEAN_RC_ATOMIC_LOAD(o);
+#else
+    return o->m_rc;
+#endif
+}
+
+static inline void lean_internal_set_rc(lean_object* o, int rc) {
+#ifdef LEAN_TSAN
+    LEAN_RC_ATOMIC_STORE(o, rc);
+#else
+    o->m_rc = rc;
+#endif
+}
+
+static inline void lean_internal_add_rc(lean_object* o, int add) {
+#ifdef LEAN_TSAN
+    LEAN_RC_ATOMIC_ADD(o, add);
+#else
+    o->m_rc += add;
+#endif
+}
+
+static inline void lean_internal_sub_rc(lean_object* o, int sub) {
+#ifdef LEAN_TSAN
+    LEAN_RC_ATOMIC_SUB(o, sub);
+#else
+    o->m_rc -= sub;
+#endif
+}
+
 LEAN_EXPORT void lean_set_exit_on_panic(bool flag);
 /* Enable/disable panic messages */
 LEAN_EXPORT void lean_set_panic_messages(bool flag);
@@ -512,20 +571,20 @@ LEAN_EXPORT size_t lean_object_byte_size(lean_object * o);
 LEAN_EXPORT size_t lean_object_data_byte_size(lean_object * o);
 
 static inline bool lean_is_mt(lean_object * o) {
-    return o->m_rc < 0;
+    return lean_internal_get_rc(o) < 0;
 }
 
 static inline bool lean_is_st(lean_object * o) {
-    return o->m_rc > 0;
+    return lean_internal_get_rc(o) > 0;
 }
 
 /* We never update the reference counter of objects stored in compact regions and allocated at initialization time. */
 static inline bool lean_is_persistent(lean_object * o) {
-    return o->m_rc == 0;
+    return lean_internal_get_rc(o) == 0;
 }
 
 static inline bool lean_has_rc(lean_object * o) {
-    return o->m_rc != 0;
+    return lean_internal_get_rc(o) != 0;
 }
 
 static inline _Atomic(int) * lean_get_rc_mt_addr(lean_object* o) {
@@ -534,8 +593,8 @@ static inline _Atomic(int) * lean_get_rc_mt_addr(lean_object* o) {
 
 static inline void lean_inc_ref_n(lean_object * o, size_t n) {
     if (LEAN_LIKELY(lean_is_st(o))) {
-        o->m_rc += n;
-    } else if (o->m_rc != 0) {
+        lean_internal_add_rc(o, n);
+    } else if (lean_internal_get_rc(o) != 0) {
 #ifdef __cplusplus
         std::atomic_fetch_sub_explicit(lean_get_rc_mt_addr(o), n, std::memory_order_relaxed);
 #else
@@ -551,9 +610,9 @@ static inline void lean_inc_ref(lean_object * o) {
 LEAN_EXPORT void lean_dec_ref_cold(lean_object * o);
 
 static inline LEAN_ALWAYS_INLINE void lean_dec_ref(lean_object * o) {
-    if (LEAN_LIKELY(o->m_rc > 1)) {
-        o->m_rc--;
-    } else if (o->m_rc != 0) {
+    if (LEAN_LIKELY(lean_internal_get_rc(o) > 1)) {
+        lean_internal_sub_rc(o, 1);
+    } else if (lean_internal_get_rc(o) != 0) {
         lean_dec_ref_cold(o);
     }
 }
@@ -590,7 +649,7 @@ static inline lean_external_object * lean_to_external(lean_object * o) { assert(
 
 static inline bool lean_is_exclusive(lean_object * o) {
     if (LEAN_LIKELY(lean_is_st(o))) {
-        return o->m_rc == 1;
+        return lean_internal_get_rc(o) == 1;
     } else {
         return false;
     }
@@ -602,7 +661,7 @@ static inline uint8_t lean_is_exclusive_obj(lean_object * o) {
 
 static inline bool lean_is_shared(lean_object * o) {
     if (LEAN_LIKELY(lean_is_st(o))) {
-        return o->m_rc > 1;
+        return lean_internal_get_rc(o) > 1;
     } else {
         return false;
     }
@@ -612,7 +671,7 @@ LEAN_EXPORT void lean_mark_mt(lean_object * o);
 LEAN_EXPORT void lean_mark_persistent(lean_object * o);
 
 static inline void lean_set_st_header(lean_object * o, unsigned tag, unsigned other) {
-    o->m_rc       = 1;
+    lean_internal_set_rc(o, 1);
     o->m_tag      = tag;
     o->m_other    = other;
 #ifndef LEAN_MIMALLOC
@@ -627,7 +686,7 @@ static inline void lean_set_non_heap_header(lean_object * o, size_t sz, unsigned
     assert(sz > 0);
     assert(sz < (1ull << 16));
     assert(sz == 1 || !lean_is_big_object_tag(tag));
-    o->m_rc       = 0;
+    lean_internal_set_rc(o, 0);
     o->m_tag      = tag;
     o->m_other    = other;
     o->m_cs_sz    = sz;
@@ -3258,72 +3317,88 @@ typedef struct {
 LEAN_EXPORT lean_object* lean_obj_once_cold(lean_object** loc, lean_once_cell_t* tok, lean_object* (*init)(void));
 
 static inline lean_object* lean_obj_once(lean_object** loc, lean_once_cell_t* tok, lean_object* (*init)(void)) {
+#ifndef LEAN_TSAN
     if (LEAN_LIKELY(tok->state == 1)) {
         return *loc;
     }
+#endif
     return lean_obj_once_cold(loc, tok, init);
 }
 
 LEAN_EXPORT uint8_t lean_uint8_once_cold(uint8_t* loc, lean_once_cell_t* tok, uint8_t (*init)(void));
 
 static inline uint8_t lean_uint8_once(uint8_t* loc, lean_once_cell_t* tok, uint8_t (*init)(void)) {
+#ifndef LEAN_TSAN
     if (LEAN_LIKELY(tok->state == 1)) {
         return *loc;
     }
+#endif
     return lean_uint8_once_cold(loc, tok, init);
 }
 
 LEAN_EXPORT uint16_t lean_uint16_once_cold(uint16_t* loc, lean_once_cell_t* tok, uint16_t (*init)(void));
 
 static inline uint16_t lean_uint16_once(uint16_t* loc, lean_once_cell_t* tok, uint16_t (*init)(void)) {
+#ifndef LEAN_TSAN
     if (LEAN_LIKELY(tok->state == 1)) {
         return *loc;
     }
+#endif
     return lean_uint16_once_cold(loc, tok, init);
 }
 
 LEAN_EXPORT uint32_t lean_uint32_once_cold(uint32_t* loc, lean_once_cell_t* tok, uint32_t (*init)(void));
 
 static inline uint32_t lean_uint32_once(uint32_t* loc, lean_once_cell_t* tok, uint32_t (*init)(void)) {
+#ifndef LEAN_TSAN
     if (LEAN_LIKELY(tok->state == 1)) {
         return *loc;
     }
+#endif
     return lean_uint32_once_cold(loc, tok, init);
 }
 
 LEAN_EXPORT uint64_t lean_uint64_once_cold(uint64_t* loc, lean_once_cell_t* tok, uint64_t (*init)(void));
 
 static inline uint64_t lean_uint64_once(uint64_t* loc, lean_once_cell_t* tok, uint64_t (*init)(void)) {
+#ifndef LEAN_TSAN
     if (LEAN_LIKELY(tok->state == 1)) {
         return *loc;
     }
+#endif
     return lean_uint64_once_cold(loc, tok, init);
 }
 
 LEAN_EXPORT size_t lean_usize_once_cold(size_t* loc, lean_once_cell_t* tok, size_t (*init)(void));
 
 static inline size_t lean_usize_once(size_t* loc, lean_once_cell_t* tok, size_t (*init)(void)) {
+#ifndef LEAN_TSAN
     if (LEAN_LIKELY(tok->state == 1)) {
         return *loc;
     }
+#endif
     return lean_usize_once_cold(loc, tok, init);
 }
 
 LEAN_EXPORT float lean_float32_once_cold(float* loc, lean_once_cell_t* tok, float (*init)(void));
 
 static inline float lean_float32_once(float* loc, lean_once_cell_t* tok, float (*init)(void)) {
+#ifndef LEAN_TSAN
     if (LEAN_LIKELY(tok->state == 1)) {
         return *loc;
     }
+#endif
     return lean_float32_once_cold(loc, tok, init);
 }
 
 LEAN_EXPORT double lean_float_once_cold(double* loc, lean_once_cell_t* tok, double (*init)(void));
 
 static inline double lean_float_once(double* loc, lean_once_cell_t* tok, double (*init)(void)) {
+#ifndef LEAN_TSAN
     if (LEAN_LIKELY(tok->state == 1)) {
         return *loc;
     }
+#endif
     return lean_float_once_cold(loc, tok, init);
 }
 

--- a/src/include/lean/lean.h
+++ b/src/include/lean/lean.h
@@ -340,23 +340,14 @@ static inline size_t lean_unbox(lean_object * o) { return (size_t)(o) >> 1; }
 Under TSan we access `m_rc` through sequentially consistent atomics so that the otherwise
 non-atomic single-threaded fast paths are not flagged as data races.
 */
-#ifdef LEAN_TSAN
-#ifdef __cplusplus
-#define LEAN_RC_ATOMIC_LOAD(o)      std::atomic_load_explicit((_Atomic(int)*)(&(o)->m_rc), std::memory_order_seq_cst)
-#define LEAN_RC_ATOMIC_STORE(o, v)  std::atomic_store_explicit((_Atomic(int)*)(&(o)->m_rc), v, std::memory_order_seq_cst)
-#define LEAN_RC_ATOMIC_ADD(o, v)    std::atomic_fetch_add_explicit((_Atomic(int)*)(&(o)->m_rc), v, std::memory_order_seq_cst)
-#define LEAN_RC_ATOMIC_SUB(o, v)    std::atomic_fetch_sub_explicit((_Atomic(int)*)(&(o)->m_rc), v, std::memory_order_seq_cst)
-#else
-#define LEAN_RC_ATOMIC_LOAD(o)      atomic_load_explicit((_Atomic(int)*)(&(o)->m_rc), memory_order_seq_cst)
-#define LEAN_RC_ATOMIC_STORE(o, v)  atomic_store_explicit((_Atomic(int)*)(&(o)->m_rc), v, memory_order_seq_cst)
-#define LEAN_RC_ATOMIC_ADD(o, v)    atomic_fetch_add_explicit((_Atomic(int)*)(&(o)->m_rc), v, memory_order_seq_cst)
-#define LEAN_RC_ATOMIC_SUB(o, v)    atomic_fetch_sub_explicit((_Atomic(int)*)(&(o)->m_rc), v, memory_order_seq_cst)
-#endif
-#endif
 
 static inline int lean_internal_get_rc(lean_object* o) {
 #ifdef LEAN_TSAN
-    return LEAN_RC_ATOMIC_LOAD(o);
+#ifdef __cplusplus
+    return std::atomic_load_explicit((_Atomic(int)*)(&(o)->m_rc), std::memory_order_seq_cst);
+#else
+    return atomic_load_explicit((_Atomic(int)*)(&(o)->m_rc), memory_order_seq_cst);
+#endif
 #else
     return o->m_rc;
 #endif
@@ -364,7 +355,11 @@ static inline int lean_internal_get_rc(lean_object* o) {
 
 static inline void lean_internal_set_rc(lean_object* o, int rc) {
 #ifdef LEAN_TSAN
-    LEAN_RC_ATOMIC_STORE(o, rc);
+#ifdef __cplusplus
+    std::atomic_store_explicit((_Atomic(int)*)(&(o)->m_rc), rc, std::memory_order_seq_cst);
+#else
+    atomic_store_explicit((_Atomic(int)*)(&(o)->m_rc), rc, memory_order_seq_cst);
+#endif
 #else
     o->m_rc = rc;
 #endif
@@ -372,7 +367,11 @@ static inline void lean_internal_set_rc(lean_object* o, int rc) {
 
 static inline void lean_internal_add_rc(lean_object* o, int add) {
 #ifdef LEAN_TSAN
-    LEAN_RC_ATOMIC_ADD(o, add);
+#ifdef __cplusplus
+    std::atomic_fetch_add_explicit((_Atomic(int)*)(&(o)->m_rc), add, std::memory_order_seq_cst);
+#else
+    atomic_fetch_add_explicit((_Atomic(int)*)(&(o)->m_rc), add, memory_order_seq_cst);
+#endif
 #else
     o->m_rc += add;
 #endif
@@ -380,16 +379,15 @@ static inline void lean_internal_add_rc(lean_object* o, int add) {
 
 static inline void lean_internal_sub_rc(lean_object* o, int sub) {
 #ifdef LEAN_TSAN
-    LEAN_RC_ATOMIC_SUB(o, sub);
+#ifdef __cplusplus
+    std::atomic_fetch_sub_explicit((_Atomic(int)*)(&(o)->m_rc), sub, std::memory_order_seq_cst);
+#else
+    atomic_fetch_sub_explicit((_Atomic(int)*)(&(o)->m_rc), sub, memory_order_seq_cst);
+#endif
 #else
     o->m_rc -= sub;
 #endif
 }
-
-#undef LEAN_RC_ATOMIC_LOAD
-#undef LEAN_RC_ATOMIC_STORE
-#undef LEAN_RC_ATOMIC_ADD
-#undef LEAN_RC_ATOMIC_SUB
 
 LEAN_EXPORT void lean_set_exit_on_panic(bool flag);
 /* Enable/disable panic messages */

--- a/src/include/lean/lean.h
+++ b/src/include/lean/lean.h
@@ -327,7 +327,6 @@ static inline LEAN_ALWAYS_INLINE uint8_t lean_is_scalar(lean_object * o) { retur
 static inline lean_object * lean_box(size_t n) { return (lean_object*)(((size_t)(n) << 1) | 1); }
 static inline size_t lean_unbox(lean_object * o) { return (size_t)(o) >> 1; }
 
-/* Detect whether ThreadSanitizer is enabled (Clang via `__has_feature`, GCC via `__SANITIZE_THREAD__`). */
 #if defined(__has_feature)
 #if __has_feature(thread_sanitizer)
 #define LEAN_TSAN
@@ -337,9 +336,10 @@ static inline size_t lean_unbox(lean_object * o) { return (size_t)(o) >> 1; }
 #define LEAN_TSAN
 #endif
 
-/* Under TSan we access `m_rc` through sequentially consistent atomics so that the otherwise
-   non-atomic single-threaded fast paths are not flagged as data races. The cast to `_Atomic(int)*`
-   mirrors `lean_get_rc_mt_addr`; `_Atomic(t)` expands to `std::atomic<t>` in C++. */
+/*
+Under TSan we access `m_rc` through sequentially consistent atomics so that the otherwise
+non-atomic single-threaded fast paths are not flagged as data races.
+*/
 #ifdef LEAN_TSAN
 #ifdef __cplusplus
 #define LEAN_RC_ATOMIC_LOAD(o)      std::atomic_load_explicit((_Atomic(int)*)(&(o)->m_rc), std::memory_order_seq_cst)
@@ -385,6 +385,11 @@ static inline void lean_internal_sub_rc(lean_object* o, int sub) {
     o->m_rc -= sub;
 #endif
 }
+
+#undef LEAN_RC_ATOMIC_LOAD
+#undef LEAN_RC_ATOMIC_STORE
+#undef LEAN_RC_ATOMIC_ADD
+#undef LEAN_RC_ATOMIC_SUB
 
 LEAN_EXPORT void lean_set_exit_on_panic(bool flag);
 /* Enable/disable panic messages */
@@ -3317,88 +3322,72 @@ typedef struct {
 LEAN_EXPORT lean_object* lean_obj_once_cold(lean_object** loc, lean_once_cell_t* tok, lean_object* (*init)(void));
 
 static inline lean_object* lean_obj_once(lean_object** loc, lean_once_cell_t* tok, lean_object* (*init)(void)) {
-#ifndef LEAN_TSAN
     if (LEAN_LIKELY(tok->state == 1)) {
         return *loc;
     }
-#endif
     return lean_obj_once_cold(loc, tok, init);
 }
 
 LEAN_EXPORT uint8_t lean_uint8_once_cold(uint8_t* loc, lean_once_cell_t* tok, uint8_t (*init)(void));
 
 static inline uint8_t lean_uint8_once(uint8_t* loc, lean_once_cell_t* tok, uint8_t (*init)(void)) {
-#ifndef LEAN_TSAN
     if (LEAN_LIKELY(tok->state == 1)) {
         return *loc;
     }
-#endif
     return lean_uint8_once_cold(loc, tok, init);
 }
 
 LEAN_EXPORT uint16_t lean_uint16_once_cold(uint16_t* loc, lean_once_cell_t* tok, uint16_t (*init)(void));
 
 static inline uint16_t lean_uint16_once(uint16_t* loc, lean_once_cell_t* tok, uint16_t (*init)(void)) {
-#ifndef LEAN_TSAN
     if (LEAN_LIKELY(tok->state == 1)) {
         return *loc;
     }
-#endif
     return lean_uint16_once_cold(loc, tok, init);
 }
 
 LEAN_EXPORT uint32_t lean_uint32_once_cold(uint32_t* loc, lean_once_cell_t* tok, uint32_t (*init)(void));
 
 static inline uint32_t lean_uint32_once(uint32_t* loc, lean_once_cell_t* tok, uint32_t (*init)(void)) {
-#ifndef LEAN_TSAN
     if (LEAN_LIKELY(tok->state == 1)) {
         return *loc;
     }
-#endif
     return lean_uint32_once_cold(loc, tok, init);
 }
 
 LEAN_EXPORT uint64_t lean_uint64_once_cold(uint64_t* loc, lean_once_cell_t* tok, uint64_t (*init)(void));
 
 static inline uint64_t lean_uint64_once(uint64_t* loc, lean_once_cell_t* tok, uint64_t (*init)(void)) {
-#ifndef LEAN_TSAN
     if (LEAN_LIKELY(tok->state == 1)) {
         return *loc;
     }
-#endif
     return lean_uint64_once_cold(loc, tok, init);
 }
 
 LEAN_EXPORT size_t lean_usize_once_cold(size_t* loc, lean_once_cell_t* tok, size_t (*init)(void));
 
 static inline size_t lean_usize_once(size_t* loc, lean_once_cell_t* tok, size_t (*init)(void)) {
-#ifndef LEAN_TSAN
     if (LEAN_LIKELY(tok->state == 1)) {
         return *loc;
     }
-#endif
     return lean_usize_once_cold(loc, tok, init);
 }
 
 LEAN_EXPORT float lean_float32_once_cold(float* loc, lean_once_cell_t* tok, float (*init)(void));
 
 static inline float lean_float32_once(float* loc, lean_once_cell_t* tok, float (*init)(void)) {
-#ifndef LEAN_TSAN
     if (LEAN_LIKELY(tok->state == 1)) {
         return *loc;
     }
-#endif
     return lean_float32_once_cold(loc, tok, init);
 }
 
 LEAN_EXPORT double lean_float_once_cold(double* loc, lean_once_cell_t* tok, double (*init)(void));
 
 static inline double lean_float_once(double* loc, lean_once_cell_t* tok, double (*init)(void)) {
-#ifndef LEAN_TSAN
     if (LEAN_LIKELY(tok->state == 1)) {
         return *loc;
     }
-#endif
     return lean_float_once_cold(loc, tok, init);
 }
 

--- a/src/kernel/expr.h
+++ b/src/kernel/expr.h
@@ -384,7 +384,7 @@ inline bool is_constant(expr const & e, name const & n) { return is_const(e, n);
  * This should however be kept in mind if we start using `is_likely_unshared` in other contexts.
  */
 inline bool is_likely_unshared(expr const & e) {
-    return e.raw()->m_rc == 1 || e.raw()->m_rc == -1;
+    return lean_internal_get_rc(e.raw()) == 1 || lean_internal_get_rc(e.raw()) == -1;
 }
 
 }

--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -334,11 +334,11 @@ static inline lean_object * pop_back(lean_object * & todo) {
 static inline void dec(lean_object * o, lean_object* & todo) {
     if (lean_is_scalar(o))
         return;
-    if (LEAN_LIKELY(o->m_rc > 1)) {
-        o->m_rc--;
-    } else if (o->m_rc == 1) {
+    if (LEAN_LIKELY(lean_internal_get_rc(o) > 1)) {
+        lean_internal_sub_rc(o, 1);
+    } else if (lean_internal_get_rc(o) == 1) {
         push_back(todo, o);
-    } else if (o->m_rc == 0) {
+    } else if (lean_internal_get_rc(o) == 0) {
         return;
     } else if (std::atomic_fetch_add_explicit(lean_get_rc_mt_addr(o), 1, std::memory_order_acq_rel) == -1) {
         push_back(todo, o);
@@ -438,7 +438,7 @@ static void lean_del_core(object * o, object * & todo) {
 }
 
 extern "C" LEAN_EXPORT void lean_dec_ref_cold(lean_object * o) {
-    if (o->m_rc == 1 || std::atomic_fetch_add_explicit(lean_get_rc_mt_addr(o), 1, std::memory_order_acq_rel) == -1) {
+    if (lean_internal_get_rc(o) == 1 || std::atomic_fetch_add_explicit(lean_get_rc_mt_addr(o), 1, std::memory_order_acq_rel) == -1) {
 #ifdef LEAN_LAZY_RC
         push_back(g_to_free, o);
 #else
@@ -554,7 +554,7 @@ extern "C" LEAN_EXPORT void lean_mark_persistent(object * o) {
         object * o = todo.back();
         todo.pop_back();
         if (!lean_is_scalar(o) && lean_has_rc(o)) {
-            o->m_rc = 0;
+            lean_internal_set_rc(o, 0);
 #if defined(__has_feature)
 #if __has_feature(address_sanitizer)
             // do not report as leak
@@ -639,7 +639,7 @@ extern "C" LEAN_EXPORT void lean_mark_mt(object * o) {
         object * o = todo.back();
         todo.pop_back();
         if (!lean_is_scalar(o) && lean_is_st(o)) {
-            o->m_rc = -o->m_rc;
+            lean_internal_set_rc(o, -lean_internal_get_rc(o));
             uint8_t tag = lean_ptr_tag(o);
             if (tag <= LeanMaxCtorTag) {
                 object ** it  = lean_ctor_obj_cptr(o);
@@ -1127,7 +1127,7 @@ void deactivate_task(lean_task_object * t) {
 }
 
 static inline void lean_set_task_header(lean_object * o) {
-    o->m_rc       = -1;
+    lean_internal_set_rc(o, -1);
     o->m_tag      = LeanTask;
     o->m_other    = 0;
     o->m_cs_sz    = 0;

--- a/src/runtime/sharecommon.cpp
+++ b/src/runtime/sharecommon.cpp
@@ -308,7 +308,7 @@ lean_object * sharecommon_quick_fn::check_cache(lean_object * a) {
             lean_assert(lean_is_st(it->second));
             // We increment the reference counter because this object
             // will be returned by `lean_sharecommon_quick` or stored into a new object.
-            it->second->m_rc++;
+            lean_internal_add_rc(it->second, 1);
             return it->second;
         }
         if (m_check_set) {
@@ -316,7 +316,7 @@ lean_object * sharecommon_quick_fn::check_cache(lean_object * a) {
             if (it != m_set.end()) {
                 lean_object * result = *it;
                 lean_assert(lean_is_st(result));
-                result->m_rc++;
+                lean_internal_add_rc(result, 1);
                 return result;
             }
         }
@@ -329,7 +329,7 @@ lean_object * sharecommon_quick_fn::check_cache(lean_object * a) {
 */
 lean_object * sharecommon_quick_fn::save(lean_object * a, lean_object * new_a) {
     lean_assert(lean_is_st(new_a));
-    lean_assert(new_a->m_rc == 1);
+    lean_assert(lean_internal_get_rc(new_a) == 1);
     auto it = m_set.find(new_a);
     lean_object * result;
     if (it == m_set.end()) {
@@ -352,15 +352,15 @@ lean_object * sharecommon_quick_fn::save(lean_object * a, lean_object * new_a) {
         lean_dec_ref(new_a); // delete `new_a`
         // All objects in `m_set` are single threaded.
         lean_assert(lean_is_st(result));
-        result->m_rc++;
-        lean_assert(result->m_rc > 1);
+        lean_internal_add_rc(result, 1);
+        lean_assert(lean_internal_get_rc(result) > 1);
     }
     if (!lean_is_exclusive(a)) {
         // We only cache the result if `a` is a shared object.
         m_cache.insert(std::make_pair(a, result));
     }
-    lean_assert(result == new_a || result->m_rc > 1);
-    lean_assert(result != new_a || result->m_rc == 1);
+    lean_assert(result == new_a || lean_internal_get_rc(result) > 1);
+    lean_assert(result != new_a || lean_internal_get_rc(result) == 1);
     return result;
 }
 
@@ -378,7 +378,7 @@ lean_object * sharecommon_quick_fn::visit_terminal(lean_object * a) {
 
 lean_object * sharecommon_quick_fn::visit_array(lean_object * a) {
     lean_object * r = check_cache(a);
-    if (r != nullptr) { lean_assert(r->m_rc > 1); return r; }
+    if (r != nullptr) { lean_assert(lean_internal_get_rc(r) > 1); return r; }
 
     size_t sz = array_size(a);
     lean_array_object * new_a = (lean_array_object*)lean_alloc_array(sz, sz);
@@ -390,7 +390,7 @@ lean_object * sharecommon_quick_fn::visit_array(lean_object * a) {
 
 lean_object * sharecommon_quick_fn::visit_ctor(lean_object * a) {
     lean_object * r = check_cache(a);
-    if (r != nullptr) { lean_assert(r->m_rc > 1); return r; }
+    if (r != nullptr) { lean_assert(lean_internal_get_rc(r) > 1); return r; }
     unsigned num_objs      = lean_ctor_num_objs(a);
     unsigned tag           = lean_ptr_tag(a);
     unsigned sz            = lean_object_byte_size(a);


### PR DESCRIPTION
This PR adds support for compiling with thread sanitizer. This both increases memory consumption and slows lean down massively so we only run a very small subset of tests to remain in a reasonable time. Developers need to add additional tests to the set themselves.