### PR TITLE
fix: avoid recursive object compaction

### DIFF
--- a/src/runtime/compact.cpp
+++ b/src/runtime/compact.cpp
@@ -37,6 +37,8 @@ Author: Leonardo de Moura
 
 namespace lean {
 
+static constexpr size_t g_compactor_max_recursion_depth = 1024;
+
 struct max_sharing_key {
     size_t m_offset;
     size_t m_size;
@@ -232,6 +234,36 @@ object_offset object_compactor::to_offset(object * o) {
 }
 
 object_offset object_compactor::compact(object * o) {
+    lean_assert(!lean_is_scalar(o));
+    if (m_compact_depth < g_compactor_max_recursion_depth) {
+        struct depth_scope {
+            size_t & m_depth;
+            depth_scope(size_t & depth): m_depth(depth) { m_depth++; }
+            ~depth_scope() { m_depth--; }
+        };
+        depth_scope scope(m_compact_depth);
+#ifdef LEAN_TAG_COUNTERS
+        g_tag_counters[lean_ptr_tag(o)]++;
+#endif
+        switch (lean_ptr_tag(o)) {
+        case LeanClosure:         return insert_closure(o);
+        case LeanArray:           return insert_array(o);
+        case LeanScalarArray:     return insert_sarray(o);
+        case LeanString:          return insert_string(o);
+        case LeanMPZ:             return insert_mpz(o);
+        case LeanThunk:           return insert_thunk(o);
+        case LeanTask:            return insert_task(o);
+        case LeanPromise:         return insert_promise(o);
+        case LeanRef:             return insert_ref(o);
+        case LeanExternal:        throw exception("external objects cannot be compacted");
+        case LeanReserved:        lean_unreachable();
+        default:                  return insert_constructor(o);
+        }
+    }
+    return compact_iterative(o);
+}
+
+object_offset object_compactor::compact_iterative(object * o) {
     lean_assert(!lean_is_scalar(o));
     enum class frame_kind { ctor, array, thunk, task, promise, ref, closure };
     struct frame {

--- a/src/runtime/compact.cpp
+++ b/src/runtime/compact.cpp
@@ -233,23 +233,212 @@ object_offset object_compactor::to_offset(object * o) {
 
 object_offset object_compactor::compact(object * o) {
     lean_assert(!lean_is_scalar(o));
+    enum class frame_kind { ctor, array, thunk, task, promise, ref, closure };
+    struct frame {
+        object * m_obj;
+        frame_kind m_kind;
+        size_t m_next;
+        size_t m_base;
+    };
+    std::vector<frame> stack;
+    auto push = [&](object * o) {
+        lean_assert(!lean_is_scalar(o));
+        lean_assert(m_obj_table.find(o) == m_obj_table.end());
 #ifdef LEAN_TAG_COUNTERS
-    g_tag_counters[lean_ptr_tag(o)]++;
+        g_tag_counters[lean_ptr_tag(o)]++;
 #endif
-    switch (lean_ptr_tag(o)) {
-    case LeanClosure:         return insert_closure(o);
-    case LeanArray:           return insert_array(o);
-    case LeanScalarArray:     return insert_sarray(o);
-    case LeanString:          return insert_string(o);
-    case LeanMPZ:             return insert_mpz(o);
-    case LeanThunk:           return insert_thunk(o);
-    case LeanTask:            return insert_task(o);
-    case LeanPromise:         return insert_promise(o);
-    case LeanRef:             return insert_ref(o);
-    case LeanExternal:        throw exception("external objects cannot be compacted");
-    case LeanReserved:        lean_unreachable();
-    default:                  return insert_constructor(o);
+        switch (lean_ptr_tag(o)) {
+        case LeanClosure: {
+            if (!m_allow_closures) {
+                throw exception("Closures cannot be compacted (unless explicitly calling "
+                                "`CompactedRegion.save (allowClosures := true)`). One possible cause of this error is "
+                                "trying to store a function in a persistent environment extension.");
+            }
+            size_t base = m_tmp.size();
+            m_tmp.resize(base + lean_closure_num_fixed(o));
+            stack.push_back({o, frame_kind::closure, 0, base});
+            break;
+        }
+        case LeanArray: {
+            size_t base = m_tmp.size();
+            m_tmp.resize(base + array_size(o));
+            stack.push_back({o, frame_kind::array, 0, base});
+            break;
+        }
+        case LeanScalarArray: insert_sarray(o); break;
+        case LeanString:      insert_string(o); break;
+        case LeanMPZ:         insert_mpz(o); break;
+        case LeanThunk: {
+            size_t base = m_tmp.size();
+            m_tmp.resize(base + 1);
+            stack.push_back({o, frame_kind::thunk, 0, base});
+            break;
+        }
+        case LeanTask: {
+            size_t base = m_tmp.size();
+            m_tmp.resize(base + 1);
+            stack.push_back({o, frame_kind::task, 0, base});
+            break;
+        }
+        case LeanPromise: {
+            size_t base = m_tmp.size();
+            m_tmp.resize(base + 1);
+            stack.push_back({o, frame_kind::promise, 0, base});
+            break;
+        }
+        case LeanRef: {
+            size_t base = m_tmp.size();
+            m_tmp.resize(base + 1);
+            stack.push_back({o, frame_kind::ref, 0, base});
+            break;
+        }
+        case LeanExternal: throw exception("external objects cannot be compacted");
+        case LeanReserved: lean_unreachable();
+        default: {
+            unsigned num_objs = lean_ctor_num_objs(o);
+            size_t base = m_tmp.size();
+            m_tmp.resize(base + num_objs);
+            stack.push_back({o, frame_kind::ctor, 0, base});
+            break;
+        }
+        }
+    };
+    auto get_child_offset = [&](object * child, object_offset & off) {
+        if (lean_is_scalar(child)) {
+            off = child;
+            return true;
+        }
+        auto it = m_obj_table.find(child);
+        if (it != m_obj_table.end()) {
+            off = it->second;
+            return true;
+        }
+        if (!m_dep_regions.empty() && !lean_has_rc(child)) {
+            char * addr = reinterpret_cast<char *>(child);
+            std::vector<region_view>::iterator upper = std::upper_bound(
+                m_dep_regions.begin(), m_dep_regions.end(), addr,
+                [](char * a, region_view const & r) { return a < static_cast<char *>(r.begin); });
+            if (upper != m_dep_regions.begin()) {
+                region_view const & region = *(upper - 1);
+                char * region_end = static_cast<char *>(region.begin) + region.size;
+                if (addr < region_end) {
+                    off = reinterpret_cast<object_offset>(
+                        reinterpret_cast<size_t>(region.base_addr) + (addr - static_cast<char *>(region.begin)));
+                    m_obj_table.insert(std::make_pair(child, off));
+                    return true;
+                }
+            }
+        }
+        push(child);
+        return false;
+    };
+    push(o);
+    while (!stack.empty()) {
+        frame & f = stack.back();
+        object * curr = f.m_obj;
+        object_offset c;
+        switch (f.m_kind) {
+        case frame_kind::ctor: {
+            unsigned num_objs = lean_ctor_num_objs(curr);
+            if (f.m_next < num_objs) {
+                object * child = cnstr_get(curr, f.m_next);
+                if (get_child_offset(child, c))
+                    m_tmp[f.m_base + f.m_next++] = c;
+                break;
+            }
+            object * new_o = copy_object(curr);
+            for (unsigned i = 0; i < num_objs; i++)
+                lean_ctor_set(new_o, i, m_tmp[f.m_base + i]);
+            m_tmp.resize(f.m_base);
+            save_max_sharing(curr, new_o, lean_object_byte_size(curr));
+            stack.pop_back();
+            break;
+        }
+        case frame_kind::array: {
+            size_t sz = array_size(curr);
+            if (f.m_next < sz) {
+                object * child = array_get(curr, f.m_next);
+                if (get_child_offset(child, c))
+                    m_tmp[f.m_base + f.m_next++] = c;
+                break;
+            }
+            size_t obj_sz = lean_usize_add_checked(sizeof(lean_array_object), lean_usize_mul_checked(sizeof(void*), sz));
+            lean_array_object * new_o = (lean_array_object*)alloc(obj_sz);
+            lean_set_non_heap_header_for_big((lean_object*)new_o, LeanArray, 0);
+            new_o->m_size     = sz;
+            new_o->m_capacity = sz;
+            for (size_t i = 0; i < sz; i++)
+                lean_array_set_core((lean_object*)new_o, i, m_tmp[f.m_base + i]);
+            m_tmp.resize(f.m_base);
+            save_max_sharing(curr, (lean_object*)new_o, obj_sz);
+            stack.pop_back();
+            break;
+        }
+        case frame_kind::thunk:
+        case frame_kind::task:
+        case frame_kind::promise:
+        case frame_kind::ref: {
+            object * child = f.m_kind == frame_kind::thunk ? lean_thunk_get(curr) :
+                f.m_kind == frame_kind::task ? lean_task_get(curr) :
+                f.m_kind == frame_kind::promise ? (object *)lean_to_promise(curr)->m_result :
+                lean_to_ref(curr)->m_value;
+            if (f.m_next == 0) {
+                if (get_child_offset(child, c)) {
+                    m_tmp[f.m_base] = c;
+                    f.m_next = 1;
+                }
+                break;
+            }
+            if (f.m_kind == frame_kind::thunk) {
+                size_t sz = sizeof(lean_thunk_object);
+                object * r = copy_object(curr, sz);
+                lean_to_thunk(r)->m_value = m_tmp[f.m_base];
+                save_max_sharing(curr, r, sz);
+            } else if (f.m_kind == frame_kind::task) {
+                size_t sz = sizeof(lean_task_object);
+                object * r = copy_object(curr, sz);
+                lean_assert(lean_to_task(r)->m_imp == nullptr);
+                lean_to_task(r)->m_value = m_tmp[f.m_base];
+                save_max_sharing(curr, r, sz);
+            } else if (f.m_kind == frame_kind::promise) {
+                size_t sz = sizeof(lean_promise_object);
+                object * r = copy_object(curr, sz);
+                lean_to_promise(r)->m_result = (lean_task_object *)m_tmp[f.m_base];
+                save_max_sharing(curr, r, sz);
+            } else {
+                size_t sz = sizeof(lean_ref_object);
+                object * r = copy_object(curr, sz);
+                lean_to_ref(r)->m_value = m_tmp[f.m_base];
+                save(curr, r);
+            }
+            m_tmp.resize(f.m_base);
+            stack.pop_back();
+            break;
+        }
+        case frame_kind::closure: {
+            unsigned n = lean_closure_num_fixed(curr);
+            if (f.m_next < n) {
+                object * child = lean_closure_arg_cptr(curr)[f.m_next];
+                if (get_child_offset(child, c))
+                    m_tmp[f.m_base + f.m_next++] = c;
+                break;
+            }
+            object * r = copy_object(curr);
+            for (unsigned i = 0; i < n; i++)
+                lean_closure_arg_cptr(r)[i] = m_tmp[f.m_base + i];
+            m_tmp.resize(f.m_base);
+            size_t fn_field_off = reinterpret_cast<char *>(&lean_to_closure(r)->m_fun)
+                                  - reinterpret_cast<char *>(m_begin);
+            m_closure_offsets.push_back(fn_field_off);
+            save(curr, r);
+            stack.pop_back();
+            break;
+        }
+        }
     }
+    auto it = m_obj_table.find(o);
+    lean_assert(it != m_obj_table.end());
+    return it->second;
 }
 
 object * object_compactor::copy_object(object * o, size_t sz) {

--- a/src/runtime/compact.h
+++ b/src/runtime/compact.h
@@ -63,8 +63,7 @@ class LEAN_EXPORT object_compactor {
     object_offset save(object * o, object * new_o);
     object_offset save_max_sharing(object * o, object * new_o, size_t new_o_sz);
     object_offset to_offset(object * o);
-    // Compacts a not-yet-seen heap object (and, recursively, its children),
-    // returning its offset. Dispatches on the object's tag.
+    // Compacts a not-yet-seen heap object and its children, returning its offset.
     object_offset compact(object * o);
     void insert_terminator(object * o);
     object * copy_object(object * o, size_t sz = 0);

--- a/src/runtime/compact.h
+++ b/src/runtime/compact.h
@@ -52,6 +52,8 @@ class LEAN_EXPORT object_compactor {
     // Buffer-relative byte offsets of every compacted closure's `m_fun` field
     std::vector<size_t> m_closure_offsets;
     bool m_allow_closures = false;
+    // Current recursive compaction depth before falling back to the explicit work stack.
+    size_t m_compact_depth = 0;
     // On-disk base address used for `mmap`ing compacted regions without relocations
     // References within the compacted region are rewritten by subtracting `m_begin` and adding `m_base_addr`
     // In the simplest case `base_addr == nullptr`, we get region-relative pointers
@@ -65,6 +67,7 @@ class LEAN_EXPORT object_compactor {
     object_offset to_offset(object * o);
     // Compacts a not-yet-seen heap object and its children, returning its offset.
     object_offset compact(object * o);
+    object_offset compact_iterative(object * o);
     void insert_terminator(object * o);
     object * copy_object(object * o, size_t sz = 0);
     object_offset insert_constructor(object * o);

--- a/tests/compile/compactor_deep_list.lean
+++ b/tests/compile/compactor_deep_list.lean
@@ -1,0 +1,29 @@
+import Lean.CompactedRegion
+
+open Lean
+
+/-!
+Regression test that `CompactedRegion.save` can compact a deep constructor chain without
+exhausting the native call stack. The long `List Nat` forces the object compactor to walk through
+many nested cons cells before writing the file.
+-/
+
+def depth : Nat := 20000
+
+def mkDeepList (n : Nat) : List Nat := Id.run do
+  let mut xs := []
+  for i in [0:n] do
+    xs := i :: xs
+  return xs
+
+unsafe def main : IO UInt32 := do
+  let tmpFile : System.FilePath := "./_tmp_compactor_deep_list.olean"
+  let xs := mkDeepList depth
+  let _ ← CompactedRegion.save tmpFile `CompactorDeepList xs #[] none
+  let (ys, _region) ← CompactedRegion.read (α := List Nat) tmpFile #[]
+  unless ys.length == depth do
+    throw <| IO.userError s!"round-trip length mismatch: expected {depth}, got {ys.length}"
+  unless ys.head? == some (depth - 1) do
+    throw <| IO.userError "round-trip head mismatch"
+  IO.FS.removeFile tmpFile
+  return 0


### PR DESCRIPTION
This PR fixes recursive object compaction so deeply nested objects do not exhaust the native stack when saving compacted regions.

The runtime object compactor previously walked object fields recursively, so compacting a long constructor chain could recurse once per object and overflow the C stack.

This keeps the existing recursive fast path for ordinary object graphs and falls back to an explicit work stack once compaction gets deeply nested, preserving compacted-region behavior while avoiding stack exhaustion.