### PR TITLE
feat: add a `frames` clause to `vcgen`

### DIFF
--- a/src/Init/Internal/Order/Basic.lean
+++ b/src/Init/Internal/Order/Basic.lean
@@ -52,7 +52,7 @@ class PartialOrder (α : Sort u) where
 
 @[inherit_doc] scoped infix:50 " ⊑ " => PartialOrder.rel
 
-attribute [grind ←] PartialOrder.rel_refl
+attribute [grind .] PartialOrder.rel_refl
 
 section PartialOrder
 

--- a/src/Init/Internal/Order/Basic.lean
+++ b/src/Init/Internal/Order/Basic.lean
@@ -52,6 +52,8 @@ class PartialOrder (α : Sort u) where
 
 @[inherit_doc] scoped infix:50 " ⊑ " => PartialOrder.rel
 
+attribute [grind ←] PartialOrder.rel_refl
+
 section PartialOrder
 
 variable {α  : Sort u} [PartialOrder α]

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
@@ -24,25 +24,47 @@ The `VCGenM` monad: its read-only `Context` (a fixed bundle of pre-built
 (rule caches, accumulated invariants/VCs, simp cache).
 -/
 
-/-- A lazily elaborated `until` pattern, stored behind an `IO.Ref` so the first `force` caches its
-result. The pattern is elaborated against the monad of the first program encountered in `solve`
-(supplied as the expected type). -/
-public inductive UntilPatternThunk where
-  /-- Not yet elaborated; `elabFn m` elaborates the pattern against the program monad `m`. -/
-  | deferred (elabFn : Expr → MetaM Sym.Pattern)
+/-- A value elaborated lazily in `MetaM` against the monad of the first program encountered in
+`solve` (supplied as the expected type), then cached. Used for the `until` pattern
+(`Deferred Sym.Pattern`, behind an `IO.Ref` in the `Context`) and the `frames` database
+(`Deferred FrameDB`, in the `State`). -/
+public inductive Deferred (α : Type) where
+  /-- Not yet elaborated; `elabFn m` elaborates against the program monad `m`. -/
+  | deferred (elabFn : Expr → MetaM α)
   /-- Already elaborated and cached. -/
-  | elaborated (pat : Sym.Pattern)
+  | elaborated (value : α)
 
-/-- Force the thunk in `ref` against the program monad `m`, elaborating, tracing, and caching the
-pattern on first use; later calls return the cached pattern. -/
-public def UntilPatternThunk.force (ref : IO.Ref UntilPatternThunk) (m : Expr) : MetaM Sym.Pattern := do
-  match ← ref.get with
-  | .elaborated pat => return pat
+/-- Force `d` against the program monad `m`, elaborating on first use and caching the result via
+`writeback`; later calls return the cached value. `writeback` stores into the slot `d` came from:
+an `IO.Ref.set` for the `until` pattern in the `Context`, a `modify` for the `frames` `State` field. -/
+public def Deferred.force {α : Type} {n : Type → Type} [Monad n] [MonadLiftT MetaM n]
+    (d : Deferred α) (writeback : Deferred α → n Unit) (m : Expr) : n α := do
+  match d with
+  | .elaborated a => return a
   | .deferred elabFn =>
-    let pat ← elabFn m
-    trace[Elab.Tactic.Do.vcgen] "`until` pattern elaborated to {pat.pattern}"
-    ref.set (.elaborated pat)
-    return pat
+    let a ← elabFn m
+    writeback (.elaborated a)
+    return a
+
+/-- A single elaborated `frames` alternative: its program pattern, the binder name of each pattern
+variable (`none` for `_`, index-aligned with `pat.varTypes`), the raw frame term (elaborated in the
+matched goal's context), the source position (a precedence tiebreak among matches, and its index
+into `FrameDB.entries`), and whether it has already been applied. -/
+public structure FrameEntry where
+  pat : Sym.Pattern
+  varNames : Array (Option Name)
+  frameStx : Syntax
+  srcIdx : Nat
+  /-- Set once this alternative has been applied, so it frames at most one occurrence. -/
+  retired : Bool := false
+  deriving Inhabited
+
+/-- The materialized frame database: program patterns keyed in a discrimination tree to the `srcIdx`
+of the matching alternative, alongside the alternatives themselves in source order. Materialized once
+in `State.frameDB?`; thereafter only the `retired` flags of `entries` change. -/
+public structure FrameDB where
+  tree : DiscrTree Nat := .empty
+  entries : Array FrameEntry := #[]
 
 /--
 Common metadata for a goal whose right-hand side is a weakest-precondition application
@@ -154,7 +176,7 @@ public structure VCGen.Context where
   invariantAlts : Std.HashMap Nat Syntax := {}
   /-- The `until` pattern: when `some ref`, VC generation stops and emits the current goal as a VC
   once the program in `wp⟦e⟧` matches the (lazily elaborated) pattern, before applying a spec. -/
-  untilPat? : Option (IO.Ref UntilPatternThunk) := none
+  untilPat? : Option (IO.Ref (Deferred Sym.Pattern)) := none
 
 public structure VCGen.Scope where
   /-- Spec database in scope: globals plus locals from in-scope hypotheses. -/
@@ -196,6 +218,13 @@ public structure VCGen.State where
   structurally. This is sound because they are subterms of the hash-consed goal target.
   -/
   latticeBackwardRuleCache : Std.HashMap (Name × Array ExprPtr × Nat) BackwardRule := {}
+  /--
+  The frame database, elaborated lazily against the first program's monad on first use. The
+  discrimination tree is fixed; a matched alternative is retired in place by setting
+  `FrameEntry.retired`, so each applies at most once (first match wins) and a program whose
+  alternative is retired is framed no further and reaches the normal `applySpec` path.
+  -/
+  frameDB? : Option (Deferred FrameDB) := none
   /--
   Holes of type `Invariant` that have been generated so far.
   -/

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
@@ -136,6 +136,8 @@ public structure Result where
   avoid spurious "alt does not match any invariant" warnings for inline-consumed
   alts. -/
   inlineHandledInvariants : Std.HashSet Nat := {}
+  /-- Frame terms of `frames` alternatives whose program pattern matched no program. -/
+  unmatchedFrames : Array Syntax := #[]
 
 /--
 Generate verification conditions for a goal of the form `pre ⊑ wp e post epost s₁ ... sₙ` by repeatedly
@@ -145,18 +147,24 @@ Return the VCs and invariant goals.
 `stepLimit?`, when `some n`, seeds the fuel counter to `n`; when `none`, fuel is unlimited.
 -/
 public partial def run (goal : Grind.Goal) (ctx : Context) (scope : VCGen.Scope)
-    (stepLimit? : Option Nat := none) : Grind.GrindM Result := do
-  let initState : State := { fuel := match stepLimit? with | some n => .limited n | none => .unlimited }
+    (stepLimit? : Option Nat := none) (frameDB? : Option (Deferred FrameDB) := none) :
+    Grind.GrindM Result := do
+  let initState : State :=
+    { fuel := match stepLimit? with | some n => .limited n | none => .unlimited, frameDB? }
   let ((), state) ← StateRefT'.run (ReaderT.run (work scope goal) ctx) initState
   _ ← state.invariants.mapIdxM fun idx mv => do
     mv.setTag (Name.mkSimple ("inv" ++ toString (idx + 1)))
   _ ← state.vcs.mapIdxM fun idx g => do
     g.mvarId.setTag (Name.mkSimple ("vc" ++ toString (idx + 1)) ++ (← g.mvarId.getTag).eraseMacroScopes)
   let vcs ← state.vcs.filterM (not <$> ·.mvarId.isAssigned)
+  let unmatchedFrames := match state.frameDB? with
+    | some (.elaborated db) => db.entries.filterMap fun e => if e.retired then none else some e.frameStx
+    | _ => #[]
   return {
     invariants := state.invariants,
     vcs,
-    inlineHandledInvariants := state.inlineHandledInvariants }
+    inlineHandledInvariants := state.inlineHandledInvariants,
+    unmatchedFrames }
 
 end VCGen
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
@@ -251,7 +251,6 @@ private structure ParsedArgs where
   ctx : VCGen.Context
   scope : VCGen.Scope
   invariantAlts? : Option (Std.HashMap Nat Syntax)
-  /-- Deferred `frames` database, seeded into `State.frameDB?` so retirement can mutate it. -/
   frameDB? : Option (Deferred FrameDB)
 
 /-- Build a `Sym.Pattern` from `e` by abstracting the metavariables `xs` into pattern variables.

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
@@ -251,6 +251,8 @@ private structure ParsedArgs where
   ctx : VCGen.Context
   scope : VCGen.Scope
   invariantAlts? : Option (Std.HashMap Nat Syntax)
+  /-- Deferred `frames` database, seeded into `State.frameDB?` so retirement can mutate it. -/
+  frameDB? : Option (Deferred FrameDB)
 
 /-- Build a `Sym.Pattern` from `e` by abstracting the metavariables `xs` into pattern variables.
 `checkTypeMask?` is `none` because `until` holes appear as function arguments, whose types the
@@ -267,22 +269,62 @@ private def mkUntilPattern (xs : Array Expr) (e : Expr) : MetaM Sym.Pattern := d
   let varInfos? ← Sym.mkProofInstArgInfo? xs
   return { levelParams := [], varTypes, pattern, fnInfos, varInfos?, checkTypeMask? := none }
 
+/-- Capture the current elaboration context for a deferred pattern elaboration. The returned action
+runs `k` against the first program's monad `m`, restoring the captured local context, ignoring
+type-class failures, and disabling `sorry` elaboration, while keeping info trees so hovers work on
+the pattern. Shared by `elabUntilPattern` and `elabFrameDB`. -/
+private def withDeferredElab (k : Expr → TermElabM α) : TermElabM (Expr → MetaM α) := do
+  let lctx ← getLCtx
+  let localInsts ← getLocalInstances
+  return fun m =>
+    withLCtx lctx localInsts <| Term.TermElabM.run' <|
+      Term.withoutModifyingElabMetaStateWithInfo <|
+      withTheReader Term.Context ({ · with ignoreTCFailures := true }) <|
+      Term.withoutErrToSorry <| k m
+
+/-- Elaborate a program pattern term `p` against the program monad `m` (expected type `m _`, so
+overloaded heads resolve), returning its pattern variables (the collected metavariables: holes and
+synthetic holes) and the resulting `Sym.Pattern`. -/
+private def elabProgPattern (m : Expr) (p : Term) : TermElabM (Array Expr × Sym.Pattern) := do
+  let e ← instantiateMVars (← Term.elabTerm p (some (mkApp m (← mkFreshTypeMVar))))
+  let xs := (e.collectMVars {}).result.map Expr.mvar
+  return (xs, ← mkUntilPattern xs e)
+
 /-- Build a deferred `until` pattern (holes `_` allowed, as in `conv in $t`). The pattern term is
 elaborated lazily when the first program is seen in `solve`, using that program's monad `m` as the
 expected type (`m _`) so overloaded heads resolve; the result is cached. The holes become pattern
 variables. -/
-private def elabUntilPattern (p : Term) : TermElabM (IO.Ref UntilPatternThunk) := do
-  let lctx ← getLCtx
-  let localInsts ← getLocalInstances
-  IO.mkRef <| UntilPatternThunk.deferred fun m =>
-    withLCtx lctx localInsts <| Term.TermElabM.run' <|
-      -- Restore the metavariable state but keep info trees, so hovers work on the pattern.
-      Term.withoutModifyingElabMetaStateWithInfo <| withRef p <|
-      withTheReader Term.Context ({ · with ignoreTCFailures := true }) <|
-      Term.withoutErrToSorry do
-        let e ← instantiateMVars (← Term.elabTerm p (some (mkApp m (← mkFreshTypeMVar))))
-        let xs := (e.collectMVars {}).result.map Expr.mvar
-        mkUntilPattern xs e
+private def elabUntilPattern (p : Term) : TermElabM (IO.Ref (Deferred Sym.Pattern)) := do
+  IO.mkRef <| .deferred <| ← withDeferredElab fun m => withRef p do
+    return (← elabProgPattern m p).2
+
+/-- Build a deferred `frames` database. Each alternative's program pattern (a head applied to
+binder/`_` arguments) is elaborated lazily against the first program's monad `m`, like the `until`
+pattern; a named binder `x` becomes a synthetic hole `?x` so its name can be recovered and bound to
+the matched argument when the frame term is elaborated in `solve`. -/
+private def elabFrameDB (alts : Array Syntax) : TermElabM (Deferred FrameDB) := do
+  return .deferred <| ← withDeferredElab fun m => do
+    let mut tree : DiscrTree Nat := .empty
+    let mut entries : Array FrameEntry := #[]
+    for h : i in [0:alts.size] do
+      let alt := alts[i]
+      let `(frameAlt| | $head:ident $args* => $frame) := alt
+        | throwErrorAt alt "Expected a `frames` alternative `| f a _ c => frame`."
+      -- Named binders become synthetic holes `?x`; `_` stays a plain hole.
+      let argTerms ← args.mapM fun arg => do
+        match arg with
+        | `(binderIdent| $x:ident) =>
+          pure (⟨Syntax.node .none ``Lean.Parser.Term.syntheticHole #[mkAtom "?", x.raw]⟩ : Term)
+        | _ => `(_)
+      let progPat ← `($head $argTerms*)
+      let (xs, pat) ← withRef alt <| elabProgPattern m progPat
+      let varNames ← xs.mapM fun x => do
+        let nm := (← x.mvarId!.getDecl).userName
+        return if nm.isAnonymous then none else some nm
+      entries := entries.push { pat, varNames, frameStx := frame, srcIdx := i }
+      tree := Sym.insertPattern tree pat i
+      trace[Elab.Tactic.Do.vcgen] "`frames` pattern elaborated to {pat.pattern}"
+    return { tree, entries }
 
 /-- Parse `vcgen` arguments. -/
 private def parseArgs (stx : Syntax) (goal : MVarId) : TermElabM ParsedArgs := goal.withContext do
@@ -298,8 +340,9 @@ private def parseArgs (stx : Syntax) (goal : MVarId) : TermElabM ParsedArgs := g
   -- distinguish "default true" from "user-set true"); not yet wired.
   let (ctx, scope) ← VCGen.mkContext stx[2] goal
   let untilPat? ← if stx[3].isNone then pure none else some <$> elabUntilPattern ⟨stx[3][1]⟩
-  let hypSimpMethods ← elabSimplifyingAssumptions stx[5]
-  let invariantAlts? ← parseInvariantMap stx[4]
+  let frameDB? ← if stx[4].isNone then pure none else some <$> elabFrameDB stx[4][1].getArgs
+  let invariantAlts? ← parseInvariantMap stx[5]
+  let hypSimpMethods ← elabSimplifyingAssumptions stx[6]
   let ctx := { ctx with
     hypSimpMethods,
     trivial := config.trivial,
@@ -309,7 +352,7 @@ private def parseArgs (stx : Syntax) (goal : MVarId) : TermElabM ParsedArgs := g
     internalize := config.internalize,
     invariantAlts := invariantAlts?.getD {},
     untilPat? }
-  return { config, ctx, scope, invariantAlts? }
+  return { config, ctx, scope, invariantAlts?, frameDB? }
 
 /-- `vcgen` step inside `sym => …` blocks. -/
 @[builtin_grind_tactic Lean.Parser.Tactic.Grind.vcgen]
@@ -317,13 +360,15 @@ def evalSymVCGen : Lean.Elab.Tactic.Grind.GrindTactic := fun stx => do
   let goal ← Lean.Elab.Tactic.Grind.getMainGoal
   let args ← parseArgs stx goal.mvarId
   let result ← Lean.Elab.Tactic.Grind.liftGrindM do
-    let result ← VCGen.run goal args.ctx args.scope args.config.stepLimit
+    let result ← VCGen.run goal args.ctx args.scope args.config.stepLimit (frameDB? := args.frameDB?)
     if let some alts := args.invariantAlts? then
       elabRemainingInvariants alts result.invariants result.inlineHandledInvariants
     return result
+  if let some frameStx := result.unmatchedFrames[0]? then
+    throwErrorAt frameStx "`frames` alternative matched no program in the goal"
   if args.invariantAlts?.isNone then
     runTacticM (goals := result.invariants.toList) <|
-      elabInvariants stx[4] result.invariants (suggestInvariant (result.vcs.map (·.mvarId)))
+      elabInvariants stx[5] result.invariants (suggestInvariant (result.vcs.map (·.mvarId)))
   let invariants ← result.invariants.filterM (not <$> ·.isAssigned)
   let newGoals ← Lean.Elab.Tactic.Grind.liftGrindM do
     let invGoals ← invariants.toList.mapM Grind.mkGoalCore
@@ -353,7 +398,7 @@ goals. The optional `with $g:grind` clause runs as `<;> $g` and lets the user-su
 grind step share an internalised E-graph with `vcgen`. -/
 @[builtin_tactic Lean.Parser.Tactic.vcgen]
 public def elabVCGen : Tactic := fun stx => withMainContext do
-  let `(tactic| vcgen%$tk $cfg:optConfig $[[$lems,*]]? $[until $u:term]? $(invs)?
+  let `(tactic| vcgen%$tk $cfg:optConfig $[[$lems,*]]? $[until $u:term]? $[frames $fas*]? $(invs)?
         $[simplifying_assumptions $(sa)? $[[$thms,*]]?]? $[with $w:vcgenDischarge]?) := stx
     | throwUnsupportedSyntax
   let g? ← elabVCGenDischarge w
@@ -364,7 +409,7 @@ public def elabVCGen : Tactic := fun stx => withMainContext do
     | none   => do
         let off ← `(optConfig| -internalize)
         pure (Lean.Parser.Tactic.appendConfig off cfg)
-  let core ← `(grind| vcgen%$tk $cfg:optConfig $[[$lems,*]]? $[until $u:term]? $(invs)?
+  let core ← `(grind| vcgen%$tk $cfg:optConfig $[[$lems,*]]? $[until $u:term]? $[frames $fas*]? $(invs)?
         $[simplifying_assumptions $(sa)? $[[$thms,*]]?]?)
   let step ← match g? with
     | some g => `(grind| $core <;> $g)

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -338,7 +338,8 @@ private def matchesUntilPattern (m prog : Expr) : VCGenM Bool := do
 
 /-- `let`-declaration analogue of `withLocalDeclsDND`: brings each `name : type := value` into scope
 (types and values mutually independent), then runs `k` with the new free variables. -/
-@[inline] private def withLetDeclsDND (declInfos : Array (Name × Expr × Expr))
+@[inline]
+private def withLetDeclsDND (declInfos : Array (Name × Expr × Expr))
     (k : Array Expr → VCGenM Expr) : VCGenM Expr :=
   loop #[]
 where
@@ -356,13 +357,12 @@ pattern variable bound to the subterm the pattern matched. The bindings are intr
 assignments and the user sees them in the side goals. -/
 private def elabFrame (entry : FrameEntry) (res : Sym.MatchUnifyResult) (info : WPInfo) :
     VCGenM Expr := do
-  let mut named : Array (Name × Expr) := #[]
+  let mut decls : Array (Name × Expr × Expr) := #[]
   for h : i in [0:entry.varNames.size] do
     if let some nm := entry.varNames[i] then
       if h2 : i < res.args.size then
-        named := named.push (nm, res.args[i])
-  let declInfos ← named.mapM fun (nm, v) => do return (nm, ← Meta.inferType v, v)
-  Meta.withDefault <| withLetDeclsDND declInfos fun fvs => do
+        decls := decls.push (nm, ← Meta.inferType res.args[i]!, res.args[i]!)
+  Meta.withDefault <| withLetDeclsDND decls fun fvs => do
     let frameExpr ← Lean.Elab.Term.TermElabM.run' do
       let e ← Lean.Elab.Term.elabTermEnsuringType entry.frameStx (some info.Pred)
       Lean.Elab.Term.synthesizeSyntheticMVarsNoPostponing
@@ -400,31 +400,29 @@ inductive FrameResult where
   The caller applies the program's own spec to `goal` with the (possibly updated) `info`. -/
   | notFramed (goal : MVarId) (info : WPInfo)
 
-/-- Frame dispatcher for a spec-ready program `info.prog`:
-* if the program is `skipFrame x` (the residual of an already-applied frame), strip the marker by
-  updating `info.prog` to `x` and report `.notFramed`, so framing happens at most once per
-  occurrence;
-* otherwise, if a `frames` alternative matches, apply `meet_wp_imp_le_wp_skipFrame` with the matched
-  frame pinned as an artificial per-call spec (built through `tryMkBackwardRuleFromSpec`, so excess
-  args are baked in at base level): the precondition `F ⊓ wp (skipFrame prog) (F ⇨ Q)` splits into the
-  frame VC `· ⊑ F` and the `skipFrame`-marked residual, and `Preserving prog (F ⊓ ·)` becomes a VC;
-  reported as `.framed`;
-* otherwise report `.notFramed`. -/
+/--
+Frame dispatcher for a spec-ready program `info.prog`:
+* If the program is `skipFrame x` (the residual of an already-applied frame), strip the marker and
+  report `.notFramed`, so framing happens at most once per occurrence.
+* If no `frames` alternative matches, report `.notFramed`.
+* Otherwise, apply `meet_wp_imp_le_wp_skipFrame` with the matched
+  frame as an artificial per-call spec.
+  The precondition `F ⊓ wp (skipFrame prog) (F ⇨ Q)` splits into the
+  frame VC `· ⊑ F` and the `skipFrame`-marked Frame-enhanced program,
+  and the frame condition VC `Preserving prog (F ⊓ ·)` becomes another VC, reported as `.framed`.
+-/
 private def applyFrame (scope : VCGen.Scope) (goal : MVarId) (info : WPInfo) :
     VCGenM FrameResult := goal.withContext do
-  if info.prog.getAppFn.isConstOf ``Std.Internal.Do.skipFrame then
+  if info.prog.getAppFn.isConstOf ``Std.Internal.Do.Gadget.skipFrame then
     let strippedProg := info.prog.appArg!
     let goal ← replaceProgDefEq goal info strippedProg
     return .notFramed goal { info with args := info.args.set! 7 strippedProg }
   let some F ← matchFrame? info
     | return .notFramed goal info
-  -- Pin the matched frame `F` (and the `Frame` instance) in `meet_wp_imp_le_wp_skipFrame`, leaving the
-  -- program, postcondition, and frame condition schematic, then run the result through the ordinary
-  -- spec-to-rule machinery as an artificial per-call spec.
   -- Apply the program's own `wp` arguments (`info.args.take 7`: program type, value, assertions,
   -- `WP` instance) and the matched frame `F`, letting `mkAppOptM` synthesize the `Frame` instance
   -- against the assertion's own `CompleteLattice` so it shares the structure the program's `wp` uses.
-  let specProof ← Meta.mkAppOptM ``Std.Internal.Do.meet_wp_imp_le_wp_skipFrame
+  let specProof ← Meta.mkAppOptM ``Std.Internal.Do.Gadget.meet_wp_imp_le_wp_skipFrame
     ((info.args.take 7).map some ++ #[none, some F])
   let some specThm ← mkSpecTheoremFromStx (← getRef) specProof
     | throwError "frame: could not build spec from meet_wp_imp_le_wp_skipFrame for{indentExpr info.prog}"

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -409,7 +409,7 @@ Frame dispatcher for a spec-ready program `info.prog`:
   frame as an artificial per-call spec.
   The precondition `F ⊓ wp (skipFrame prog) (F ⇨ Q)` splits into the
   frame VC `· ⊑ F` and the `skipFrame`-marked Frame-enhanced program,
-  and the frame condition VC `Preserving prog (F ⊓ ·)` becomes another VC, reported as `.framed`.
+  and the frame condition VC `Frames prog F` becomes another VC, reported as `.framed`.
 -/
 private def applyFrame (scope : VCGen.Scope) (goal : MVarId) (info : WPInfo) :
     VCGenM FrameResult := goal.withContext do

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -412,7 +412,7 @@ inductive FrameResult where
 * otherwise report `.notFramed`. -/
 private def applyFrame (scope : VCGen.Scope) (goal : MVarId) (info : WPInfo) :
     VCGenM FrameResult := goal.withContext do
-  if info.prog.getAppFn.isConstOf ``Std.Internal.Do.WP.skipFrame then
+  if info.prog.getAppFn.isConstOf ``Std.Internal.Do.skipFrame then
     let strippedProg := info.prog.appArg!
     let goal ← replaceProgDefEq goal info strippedProg
     return .notFramed goal { info with args := info.args.set! 7 strippedProg }
@@ -424,7 +424,7 @@ private def applyFrame (scope : VCGen.Scope) (goal : MVarId) (info : WPInfo) :
   -- Apply the program's own `wp` arguments (`info.args.take 7`: program type, value, assertions,
   -- `WP` instance) and the matched frame `F`, letting `mkAppOptM` synthesize the `Frame` instance
   -- against the assertion's own `CompleteLattice` so it shares the structure the program's `wp` uses.
-  let specProof ← Meta.mkAppOptM ``Std.Internal.Do.WP.meet_wp_imp_le_wp_skipFrame
+  let specProof ← Meta.mkAppOptM ``Std.Internal.Do.meet_wp_imp_le_wp_skipFrame
     ((info.args.take 7).map some ++ #[none, some F])
   let some specThm ← mkSpecTheoremFromStx (← getRef) specProof
     | throwError "frame: could not build spec from meet_wp_imp_le_wp_skipFrame for{indentExpr info.prog}"

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -207,16 +207,17 @@ private def normalizePre? (scope : VCGen.Scope) (goal : MVarId) (α pre target :
   return none
 
 /-- Replace the program in `goal`'s target with `prog` (which must be definitionally equal). -/
-private def replaceProgDefEq (goal : MVarId) (target : Expr) (info : WPInfo) (prog : Expr) :
+private def replaceProgDefEq (goal : MVarId) (info : WPInfo) (prog : Expr) :
     VCGenM MVarId := do
   let wp ← mkAppNS info.head <| info.args.set! 7 prog
   let rhs ← mkAppNS wp info.excessArgs
+  let target ← goal.getType
   let relArgs := target.getAppArgs
   let newTarget ← mkAppNS target.getAppFn (relArgs.set! (relArgs.size - 1) rhs)
   goal.replaceTargetDefEq newTarget
 
 /-- Strategy 11a: hoist or zeta-substitute a `let` from the program head. -/
-private def wpLet? (goal : MVarId) (target : Expr) (info : WPInfo) : VCGenM (Option MVarId) := do
+private def wpLet? (goal : MVarId) (info : WPInfo) : VCGenM (Option MVarId) := do
   let .letE name type val body nondep := info.prog.getAppFn | return none
   let appArgs := info.prog.getAppRevArgs
   throwIfUnsupportedJP name val
@@ -224,12 +225,13 @@ private def wpLet? (goal : MVarId) (target : Expr) (info : WPInfo) : VCGenM (Opt
     trace[Elab.Tactic.Do.vcgen] "let-zeta-dup: {name}"
     let body' ← Sym.instantiateRevBetaS body #[val]
     let prog ← mkAppRevS body' appArgs
-    return some (← replaceProgDefEq goal target info prog)
+    return some (← replaceProgDefEq goal info prog)
   else
     trace[Elab.Tactic.Do.vcgen] "let-hoist: {name}"
     let prog ← mkAppRevS body appArgs
     let wp ← mkAppNS info.head <| info.args.set! 7 prog
     let rhs ← mkAppNS wp info.excessArgs
+    let target ← goal.getType
     let relArgs := target.getAppArgs
     let target ← mkAppNS target.getAppFn (relArgs.set! (relArgs.size - 1) rhs)
     let target := Expr.letE name type val target nondep
@@ -240,12 +242,12 @@ private def wpLet? (goal : MVarId) (target : Expr) (info : WPInfo) : VCGenM (Opt
 
 /-- Strategy 11b: split an `ite`/`dite`/match program, or iota-reduce a matcher with a concrete
 discriminant. -/
-private def wpMatch? (goal : MVarId) (target : Expr) (info : WPInfo) :
+private def wpMatch? (goal : MVarId) (info : WPInfo) :
     VCGenM (Option (List MVarId)) := do
   let some splitInfo ← liftMetaM <| Lean.Elab.Tactic.Do.getSplitInfo? info.prog | return none
   if splitInfo matches .matcher .. then
     if let some prog ← liftMetaM <| withReducible <| reduceRecMatcher? info.prog then
-      return some [← replaceProgDefEq goal target info (← shareCommonInc prog)]
+      return some [← replaceProgDefEq goal info (← shareCommonInc prog)]
   let rule ← mkBackwardRuleForSplitCached splitInfo info
   let .goals goals ← rule.applyChecked goal m!"split rule for{indentExpr info.prog}"
     | throwError "Failed to apply split rule for {indentExpr info.prog}"
@@ -258,24 +260,24 @@ private def wpMatch? (goal : MVarId) (target : Expr) (info : WPInfo) :
   return some simpGoals.toList
 
 /-- Strategy 11c: zeta-unfold a local let-bound fvar used as the program head. -/
-private def wpFVarZeta? (goal : MVarId) (target : Expr) (info : WPInfo) :
+private def wpFVarZeta? (goal : MVarId) (info : WPInfo) :
     VCGenM (Option MVarId) := do
   let f := info.prog.getAppFn
   let some fvarId := f.fvarId? | return none
   let some val ← fvarId.getValue? | return none
   trace[Elab.Tactic.Do.vcgen] "fvar-zeta: {(← fvarId.getUserName)}"
   let prog ← shareCommonInc (val.betaRev info.prog.getAppRevArgs)
-  return some (← replaceProgDefEq goal target info prog)
+  return some (← replaceProgDefEq goal info prog)
 
 /-- Strategy 11d: reduce a projection head in the program. -/
-private def wpHeadReduce? (goal : MVarId) (target : Expr) (info : WPInfo) :
+private def wpHeadReduce? (goal : MVarId) (info : WPInfo) :
     VCGenM (Option MVarId) := do
   let f := info.prog.getAppFn
   unless f matches .proj .. do return none
   let some f' ← withReducibleAndInstances (reduceProj? f) | return none
   let f' ← shareCommon (← liftMetaM <| unfoldReducible f')
   let prog ← betaRevS f' info.prog.getAppRevArgs
-  return some (← replaceProgDefEq goal target info prog)
+  return some (← replaceProgDefEq goal info prog)
 
 /-- Stop or raise on a program with no matching spec. With `errorOnMissingSpec` (default), raise a
 hard error naming the program and any candidate specs; otherwise stop and emit the goal as a VC. -/
@@ -291,7 +293,7 @@ private def stopOrErrorOnMissingSpec (prog monad : Expr) (thms : Array SpecTheor
 
 /-- Strategy 11e: look up a registered `@[spec]` theorem (triple or simp) for the program head
 and apply its cached backward rule. -/
-private def applySpec (scope : VCGen.Scope) (goal : MVarId) (target : Expr) (info : WPInfo) :
+private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPInfo) :
     VCGenM SolveResult := do
   trace[Elab.Tactic.Do.vcgen] "Applying a spec for {info.prog}. Excess args: {info.excessArgs}"
   -- Hand `findSpecs` the sole reference to the database so its in-place pattern internalization
@@ -310,7 +312,7 @@ private def applySpec (scope : VCGen.Scope) (goal : MVarId) (target : Expr) (inf
     catch ex =>
       throwError "Failed to construct rule {thm.proof} for {indentExpr info.prog}\n\
         error: {ex.toMessageData}\n\
-        target:{indentExpr target}\n\
+        target:{indentExpr (← goal.getType)}\n\
         Pred:{indentExpr info.Pred}\n\
         excessArgs: {info.excessArgs}"
     | stopOrErrorOnMissingSpec info.prog info.m #[thm]
@@ -318,7 +320,7 @@ private def applySpec (scope : VCGen.Scope) (goal : MVarId) (target : Expr) (inf
     | do
       let ruleType ← Meta.inferType rule.expr
       throwError "Failed to apply rule {thm.proof} for {indentExpr info.prog}\n\
-        target:{indentExpr target}\n\
+        target:{indentExpr (← goal.getType)}\n\
         Pred:{indentExpr info.Pred}\n\
         excessArgs: {info.excessArgs}\n\
         rule type:{indentExpr ruleType}"
@@ -328,11 +330,109 @@ private def applySpec (scope : VCGen.Scope) (goal : MVarId) (target : Expr) (inf
 monad), in which case VC generation stops at this goal. -/
 private def matchesUntilPattern (m prog : Expr) : VCGenM Bool := do
   let some ref := (← read).untilPat? | return false
-  let pat ← UntilPatternThunk.force ref m
+  let pat ← (← ref.get).force ref.set m
   if (← pat.match? prog).isSome then
     trace[Elab.Tactic.Do.vcgen] "`until` pattern matched program {prog}; stopping"
     return true
   return false
+
+/-- `let`-declaration analogue of `withLocalDeclsDND`: brings each `name : type := value` into scope
+(types and values mutually independent), then runs `k` with the new free variables. -/
+@[inline] private def withLetDeclsDND (declInfos : Array (Name × Expr × Expr))
+    (k : Array Expr → VCGenM Expr) : VCGenM Expr :=
+  loop #[]
+where
+  loop (acc : Array Expr) : VCGenM Expr := do
+    if h : acc.size < declInfos.size then
+      let (name, type, value) := declInfos[acc.size]
+      Meta.withLetDecl name type value fun fv => loop (acc.push fv)
+    else
+      k acc
+  termination_by declInfos.size - acc.size
+
+/-- Elaborate a matched `frames` alternative's frame term at type `info.Pred`, with each named
+pattern variable bound to the subterm the pattern matched. The bindings are introduced as
+`let`-declarations carrying the matched value, so the resulting frame records the pattern-variable
+assignments and the user sees them in the side goals. -/
+private def elabFrame (entry : FrameEntry) (res : Sym.MatchUnifyResult) (info : WPInfo) :
+    VCGenM Expr := do
+  let mut named : Array (Name × Expr) := #[]
+  for h : i in [0:entry.varNames.size] do
+    if let some nm := entry.varNames[i] then
+      if h2 : i < res.args.size then
+        named := named.push (nm, res.args[i])
+  let declInfos ← named.mapM fun (nm, v) => do return (nm, ← Meta.inferType v, v)
+  Meta.withDefault <| withLetDeclsDND declInfos fun fvs => do
+    let frameExpr ← Lean.Elab.Term.TermElabM.run' do
+      let e ← Lean.Elab.Term.elabTermEnsuringType entry.frameStx (some info.Pred)
+      Lean.Elab.Term.synthesizeSyntheticMVarsNoPostponing
+      instantiateMVars e
+    mkLetFVars fvs frameExpr
+
+/-- Find an unretired `frames` alternative matching the program (earliest source order wins) and
+elaborate its frame, retiring the alternative so it applies at most once. The frame DB is
+materialized into `State` on first use; retirement sets `FrameEntry.retired` in place. -/
+private def matchFrame? (info : WPInfo) : VCGenM (Option Expr) := do
+  let some deferred := (← get).frameDB? | return none
+  let db ← deferred.force (fun d => modify fun s => { s with frameDB? := some d }) info.m
+  let mut best : Option (FrameEntry × Sym.MatchUnifyResult) := none
+  for srcIdx in Sym.getMatch db.tree info.prog do
+    let entry := db.entries[srcIdx]!
+    if entry.retired then continue
+    if let some res ← entry.pat.match? info.prog then
+      match best with
+      | none => best := some (entry, res)
+      | some (b, _) => if entry.srcIdx < b.srcIdx then best := some (entry, res)
+  let some (entry, res) := best | return none
+  modify fun s => { s with frameDB? := s.frameDB?.map fun
+    | .elaborated db =>
+      .elaborated { db with entries := db.entries.set! entry.srcIdx { entry with retired := true } }
+    | d => d }
+  let F ← elabFrame entry res info
+  trace[Elab.Tactic.Do.vcgen] "`frames` matched {info.prog}; frame:{indentExpr F}"
+  return some F
+
+/-- The outcome of the frame dispatcher `applyFrame`. -/
+inductive FrameResult where
+  /-- A `frames` alternative matched `info.prog` and was applied; these are its subgoals. -/
+  | framed (scope : VCGen.Scope) (subgoals : List MVarId)
+  /-- No frame applies: either no alternative matched, or a `skipFrame` residual was stripped.
+  The caller applies the program's own spec to `goal` with the (possibly updated) `info`. -/
+  | notFramed (goal : MVarId) (info : WPInfo)
+
+/-- Frame dispatcher for a spec-ready program `info.prog`:
+* if the program is `skipFrame x` (the residual of an already-applied frame), strip the marker by
+  updating `info.prog` to `x` and report `.notFramed`, so framing happens at most once per
+  occurrence;
+* otherwise, if a `frames` alternative matches, apply `meet_wp_imp_le_wp_skipFrame` with the matched
+  frame pinned as an artificial per-call spec (built through `tryMkBackwardRuleFromSpec`, so excess
+  args are baked in at base level): the precondition `F ⊓ wp (skipFrame prog) (F ⇨ Q)` splits into the
+  frame VC `· ⊑ F` and the `skipFrame`-marked residual, and `Preserving prog (F ⊓ ·)` becomes a VC;
+  reported as `.framed`;
+* otherwise report `.notFramed`. -/
+private def applyFrame (scope : VCGen.Scope) (goal : MVarId) (info : WPInfo) :
+    VCGenM FrameResult := goal.withContext do
+  if info.prog.getAppFn.isConstOf ``Std.Internal.Do.WP.skipFrame then
+    let strippedProg := info.prog.appArg!
+    let goal ← replaceProgDefEq goal info strippedProg
+    return .notFramed goal { info with args := info.args.set! 7 strippedProg }
+  let some F ← matchFrame? info
+    | return .notFramed goal info
+  -- Pin the matched frame `F` (and the `Frame` instance) in `meet_wp_imp_le_wp_skipFrame`, leaving the
+  -- program, postcondition, and frame condition schematic, then run the result through the ordinary
+  -- spec-to-rule machinery as an artificial per-call spec.
+  -- Apply the program's own `wp` arguments (`info.args.take 7`: program type, value, assertions,
+  -- `WP` instance) and the matched frame `F`, letting `mkAppOptM` synthesize the `Frame` instance
+  -- against the assertion's own `CompleteLattice` so it shares the structure the program's `wp` uses.
+  let specProof ← Meta.mkAppOptM ``Std.Internal.Do.WP.meet_wp_imp_le_wp_skipFrame
+    ((info.args.take 7).map some ++ #[none, some F])
+  let some specThm ← mkSpecTheoremFromStx (← getRef) specProof
+    | throwError "frame: could not build spec from meet_wp_imp_le_wp_skipFrame for{indentExpr info.prog}"
+  let some rule ← (tryMkBackwardRuleFromSpec specThm info).run
+    | throwError "frame: failed to build rule for{indentExpr info.prog}"
+  let .goals subgoals ← rule.applyChecked goal m!"frame rule for{indentExpr info.prog}"
+    | throwError "frame: failed to apply rule for{indentExpr info.prog}"
+  return .framed scope subgoals
 
 /--
 The main VC generation step. Operates on a plain `MVarId` with no knowledge of grind.
@@ -403,22 +503,24 @@ public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := g
     -- Stop if the program matches the `until` pattern.
     if ← matchesUntilPattern info.m info.prog then
       return .stop (.untilPatternMatched info.m)
-    if let some g ← wpLet? goal target info then
+    if let some g ← wpLet? goal info then
       VCGen.burnOne
       return .goals scope [g]
-    if let some gs ← wpMatch? goal target info then
+    if let some gs ← wpMatch? goal info then
       VCGen.burnOne
       return .goals scope gs
-    if let some g ← wpFVarZeta? goal target info then
+    if let some g ← wpFVarZeta? goal info then
       VCGen.burnOne
       return .goals scope [g]
-    if let some g ← wpHeadReduce? goal target info then
+    if let some g ← wpHeadReduce? goal info then
       VCGen.burnOne
       return .goals scope [g]
     let f := info.prog.getAppFn
     if f.isConst || f.isFVar then
       VCGen.burnOne
-      return ← applySpec scope goal target info
+      match ← applyFrame scope goal info with
+      | .framed scope subgoals => return .goals scope subgoals
+      | .notFramed goal info => return ← applySpec scope goal info
     throwError "Failed to decompose weakest precondition for {info.prog}. This should not happen."
 
   return .stop (.noProgress pre rhs)

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -396,13 +396,13 @@ private def matchFrame? (info : WPInfo) : VCGenM (Option Expr) := do
 inductive FrameResult where
   /-- A `frames` alternative matched `info.prog` and was applied; these are its subgoals. -/
   | framed (scope : VCGen.Scope) (subgoals : List MVarId)
-  /-- No frame applies: either no alternative matched, or a `skipFrame` residual was stripped.
+  /-- No frame applies: either no alternative matched, or a `skipFrame` marker was stripped.
   The caller applies the program's own spec to `goal` with the (possibly updated) `info`. -/
   | notFramed (goal : MVarId) (info : WPInfo)
 
 /--
 Frame dispatcher for a spec-ready program `info.prog`:
-* If the program is `skipFrame x` (the residual of an already-applied frame), strip the marker and
+* If the program is `skipFrame x` (an already-framed program), strip the marker and
   report `.notFramed`, so framing happens at most once per occurrence.
 * If no `frames` alternative matches, report `.notFramed`.
 * Otherwise, apply `meet_wp_imp_le_wp_skipFrame` with the matched

--- a/src/Std/Internal/Do/Order/Basic.lean
+++ b/src/Std/Internal/Do/Order/Basic.lean
@@ -150,12 +150,12 @@ theorem iSup_le {ι : Type v} (f : ι → α) (x : α) : (∀ i, f i ⊑ x) → 
 /-- Pointwise characterization of `CompleteLattice.sup` on function lattices:
 `(sup c) s = sup (fun y => ∃ f, c f ∧ f s = y)`. -/
 theorem sup_apply
-    {σ : Type v} {β : Type w} [CompleteLattice β]
-    (c : (σ → β) → Prop) (s : σ) :
+    {σ : Type v} {β : σ → Type w} [∀ s, CompleteLattice (β s)]
+    (c : (∀ s, β s) → Prop) (s : σ) :
     CompleteLattice.sup c s = CompleteLattice.sup (fun y => ∃ f, c f ∧ f s = y) := by
   apply PartialOrder.rel_antisymm
   · -- sup c s ⊑ sup {y | ∃ f ∈ c, f s = y}
-    let g : σ → β := fun t => CompleteLattice.sup (fun y => ∃ f, c f ∧ f t = y)
+    let g : ∀ t, β t := fun t => CompleteLattice.sup (fun y => ∃ f, c f ∧ f t = y)
     have hg : CompleteLattice.sup c ⊑ g := by
       apply sup_le
       intro f hf t
@@ -170,15 +170,15 @@ theorem sup_apply
 
 /-- Pointwise characterization of binary meet on function lattices. -/
 @[simp] theorem meet_apply
-    {σ : Type v} {β : Type w} [CompleteLattice β]
-    (a b : σ → β) (s : σ) :
+    {σ : Type v} {β : σ → Type w} [∀ s, CompleteLattice (β s)]
+    (a b : ∀ s, β s) (s : σ) :
     (a ⊓ b) s = a s ⊓ b s := by
   apply PartialOrder.rel_antisymm
   · apply le_meet
     · exact (meet_le_left a b) s
     · exact (meet_le_right a b) s
   · classical
-    let f : σ → β := fun t => if t = s then a t ⊓ b t else ⊥
+    let f : ∀ t, β t := fun t => if t = s then a t ⊓ b t else ⊥
     have hf_left : f ⊑ a := by
       intro t
       simp only [f]

--- a/src/Std/Internal/Do/Order/Frame.lean
+++ b/src/Std/Internal/Do/Order/Frame.lean
@@ -96,6 +96,22 @@ instance : Frame Prop where
       subst p
       exact ⟨hp.1, x, hsx, hp.2⟩
 
+/-- A dependent function lattice into frames is a frame; the frame law holds pointwise. This makes the
+iterated function lattices `σ₁ → … → Prop` frames. -/
+instance instFramePi {σ : Type v} {β : σ → Type u} [∀ s, CompleteLattice (β s)] [∀ s, Frame (β s)] :
+    Frame (∀ s, β s) where
+  meet_sup a s := by
+    funext t
+    rw [meet_apply, sup_apply, sup_apply, Frame.meet_sup (a := a t)]
+    congr 1
+    funext w
+    apply propext
+    constructor
+    · rintro ⟨v, ⟨f, hf, hft⟩, rfl⟩
+      exact ⟨a ⊓ f, ⟨f, hf, rfl⟩, by rw [meet_apply, hft]⟩
+    · rintro ⟨g, ⟨x, hx, rfl⟩, hgt⟩
+      exact ⟨x t, ⟨x, hx, rfl⟩, by rw [← hgt, meet_apply]⟩
+
 /-- Pointwise characterization of Heyting implication on function lattices. -/
 @[simp] theorem himp_apply
     {σ : Type v} {β : Type u} [CompleteLattice β]

--- a/src/Std/Internal/Do/WP.lean
+++ b/src/Std/Internal/Do/WP.lean
@@ -7,6 +7,9 @@ module
 
 prelude
 public import Std.Internal.Do.WP.Basic
+public import Std.Internal.Do.WP.Conjunctive
+public import Std.Internal.Do.WP.Frame
+public import Std.Internal.Do.WP.FrameGadget
 public import Std.Internal.Do.WP.Lemmas
 
 set_option linter.missingDocs true

--- a/src/Std/Internal/Do/WP/Conjunctive.lean
+++ b/src/Std/Internal/Do/WP/Conjunctive.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Graf
+-/
+module
+
+prelude
+public import Std.Internal.Do.WP.Basic
+public import Std.Internal.Do.Order.Lemmas
+universe u v w z
+@[expose] public section
+
+set_option linter.missingDocs true
+
+open Lean.Order Std.Internal.Do
+
+namespace Std.Internal.Do
+
+/-- `wp x` is sub-conjunctive: a meet of postconditions maps below the `wp` of their meet. A
+healthiness condition of the `WP` interpretation; it holds for the base interpretations and lifts
+through the transformers. -/
+class WPConjunctive (Prog : Type u) (Value : outParam (Type v)) (Pred : outParam (Type w))
+    (EPred : outParam (Type z)) [Assertion Pred] [Assertion EPred] [WP Prog Value Pred EPred] where
+  /-- A meet of postconditions maps below the `wp` of their meet. -/
+  wp_meet_wp_le (x : Prog) (Q₁ Q₂ : Value → Pred) (E : EPred) :
+    wp x Q₁ E ⊓ wp x Q₂ E ⊑ wp x (Q₁ ⊓ Q₂) E
+
+/-- `Id` is conjunctive: its `wp` is evaluation at the result. -/
+instance Id.instWPConjunctive {α : Type u} : WPConjunctive (Id α) α Prop EPost.Nil where
+  wp_meet_wp_le x Q₁ Q₂ E := by simp only [wp, WP.wpTrans, meet_apply]; exact PartialOrder.rel_refl
+
+/-- `Option` is conjunctive: its `wp` is evaluation at the result. -/
+instance Option.instWPConjunctive {α : Type u} : WPConjunctive (Option α) α Prop Prop where
+  wp_meet_wp_le x Q₁ Q₂ E := by
+    cases x <;>
+      simp only [meet_apply, wp, WP.wpTrans, Option.elim] <;>
+      first | exact PartialOrder.rel_refl | exact meet_le_left _ _
+
+/-- `Except ε` is conjunctive: its `wp` is evaluation at the result. -/
+instance Except.instWPConjunctive {ε α : Type u} :
+    WPConjunctive (Except ε α) α Prop EPost⟨ε → Prop⟩ where
+  wp_meet_wp_le x Q₁ Q₂ E := by
+    cases x <;>
+      simp only [meet_apply, wp, WP.wpTrans] <;>
+      first | exact PartialOrder.rel_refl | exact meet_le_left _ _
+
+/-- `EStateM` is conjunctive: its `wp` is evaluation at the result. -/
+instance EStateM.instWPConjunctive {ε σ α : Type} :
+    WPConjunctive (EStateM ε σ α) α (σ → Prop) (ε → σ → Prop) where
+  wp_meet_wp_le x Q₁ Q₂ E := by
+    intro s
+    simp only [meet_apply, wp, WP.wpTrans]
+    cases x s <;> first | exact PartialOrder.rel_refl | exact meet_le_left _ _
+
+/-- `StateT` lifts conjunctivity from its base monad. -/
+instance StateT.instWPConjunctive {m : Type u → Type v} {σ : Type u} {Pred : Type w} {EPred : Type z}
+    {α : Type u} [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+    [WPConjunctive (m (α × σ)) (α × σ) Pred EPred] :
+    WPConjunctive (StateT σ m α) α (σ → Pred) EPred where
+  wp_meet_wp_le x Q₁ Q₂ E := by
+    intro s
+    simp only [meet_apply, StateT.wp_apply_eq]
+    refine PartialOrder.rel_trans
+      (WPConjunctive.wp_meet_wp_le (x.run s) (fun p => Q₁ p.1 p.2) (fun p => Q₂ p.1 p.2) E)
+      (WP.wp_consequence _ _ _ _ ?_)
+    intro p
+    simp only [meet_apply]
+    exact PartialOrder.rel_refl
+
+/-- `ReaderT` lifts conjunctivity from its base monad. -/
+instance ReaderT.instWPConjunctive {m : Type u → Type v} {ρ : Type u} {Pred : Type w} {EPred : Type z}
+    {α : Type u} [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+    [WPConjunctive (m α) α Pred EPred] :
+    WPConjunctive (ReaderT ρ m α) α (ρ → Pred) EPred where
+  wp_meet_wp_le x Q₁ Q₂ E := by
+    intro r
+    simp only [meet_apply, ReaderT.wp_apply_eq]
+    refine PartialOrder.rel_trans
+      (WPConjunctive.wp_meet_wp_le (x.run r) (fun a => Q₁ a r) (fun a => Q₂ a r) E)
+      (WP.wp_consequence _ _ _ _ ?_)
+    intro a
+    simp only [meet_apply]
+    exact PartialOrder.rel_refl
+
+/-- `OptionT` lifts conjunctivity from its base monad. -/
+instance OptionT.instWPConjunctive {m : Type u → Type v} {Pred : Type u} {EPred : Type z}
+    {α : Type u} [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+    [WPConjunctive (m (Option α)) (Option α) Pred EPred] :
+    WPConjunctive (OptionT m α) α Pred (EPost.Cons Pred EPred) where
+  wp_meet_wp_le x Q₁ Q₂ E := by
+    simp only [OptionT.wp_apply_eq]
+    refine PartialOrder.rel_trans
+      (WPConjunctive.wp_meet_wp_le x.run (E.pushOption Q₁) (E.pushOption Q₂) E.tail)
+      (WP.wp_consequence _ _ _ _ ?_)
+    intro o
+    cases o <;>
+      simp only [meet_apply, EPost.Cons.pushOption] <;>
+      first | exact PartialOrder.rel_refl | exact meet_le_left _ _
+
+/-- `ExceptT` lifts conjunctivity from its base monad. -/
+instance ExceptT.instWPConjunctive {m : Type u → Type v} {ε α : Type u} {Pred : Type w}
+    {EPred : Type z} [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+    [WPConjunctive (m (Except ε α)) (Except ε α) Pred EPred] :
+    WPConjunctive (ExceptT ε m α) α Pred (EPost.Cons (ε → Pred) EPred) where
+  wp_meet_wp_le x Q₁ Q₂ E := by
+    simp only [ExceptT.wp_apply_eq]
+    refine PartialOrder.rel_trans
+      (WPConjunctive.wp_meet_wp_le x.run (E.pushExcept Q₁) (E.pushExcept Q₂) E.tail)
+      (WP.wp_consequence _ _ _ _ ?_)
+    intro e
+    cases e <;>
+      simp only [meet_apply, EPost.Cons.pushExcept] <;>
+      first | exact PartialOrder.rel_refl | exact meet_le_left _ _
+
+end Std.Internal.Do

--- a/src/Std/Internal/Do/WP/Frame.lean
+++ b/src/Std/Internal/Do/WP/Frame.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Graf
+-/
+module
+
+prelude
+public import Std.Internal.Do.WP.Basic
+public import Std.Internal.Do.WP.Conjunctive
+public import Std.Internal.Do.Order.Lemmas
+universe u v w z
+@[expose] public section
+
+set_option linter.missingDocs true
+
+open Lean.Order Std.Internal.Do
+
+namespace Std.Internal.Do
+
+namespace WP
+
+variable {Prog : Type u} {Value : Type v} {Pred : Type w} {EPred : Type z}
+  [Assertion Pred] [Assertion EPred] [WP Prog Value Pred EPred]
+
+/--
+`x` preserves the frame operator `frame` (example: `F ⊓ ·`): `frame` commutes into the
+postcondition of `wp x` for every postcondition. The side condition discharged when framing a spec
+for `x`.
+-/
+def Preserving (x : Prog) (frame : Pred → Pred) : Prop :=
+  ∀ (Q : Value → Pred) (E : EPred), frame (wp x Q E) ⊑ wp x (fun a => frame (Q a)) E
+
+/-- When `x` preserves `F`, meeting with `F` commutes into the postcondition of `wp x`. -/
+theorem meet_wp_le_wp_meet [Frame Pred] {x : Prog} {F : Pred} {Q : Value → Pred} {E : EPred}
+    (hframe : Preserving x (F ⊓ ·)) :
+    F ⊓ wp x Q E ⊑ wp x (fun r => F ⊓ Q r) E :=
+  hframe Q E
+
+/-- The framed spec `vcgen` applies for `x`: residualizing the postcondition through `F ⇨ ·` makes
+`F ⊓ wp x (F ⇨ Q)` a precondition for `wp x Q`. -/
+theorem meet_wp_imp_le_wp [Frame Pred] {x : Prog} {F : Pred} {Q : Value → Pred} {E : EPred}
+    (hframe : Preserving x (F ⊓ ·)) :
+    F ⊓ wp x (fun a => F ⇨ Q a) E ⊑ wp x Q E :=
+  PartialOrder.rel_trans (meet_wp_le_wp_meet hframe)
+    (wp_consequence x _ Q E (fun _ => CompleteLattice.meet_himp_le))
+
+end WP
+
+end Std.Internal.Do
+
+namespace Std.Internal.Do
+
+/-- A meet frame `(F ⊓ ·)` is preserved by `x` when `x` preserves `F` and `wp x` is conjunctive:
+the side condition reduces to the preservation triple `F ⊑ wp x (fun _ => F)`. -/
+theorem WP.Preserving.of_meet {m : Type u → Type v} {Pred : Type w} {EPred : Type z}
+    {α : Type u} [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+    [WPConjunctive (m α) α Pred EPred] (x : m α) (F : Pred) (h : ∀ E, F ⊑ wp x (fun _ => F) E) :
+    WP.Preserving x (F ⊓ ·) := by
+  intro Q E
+  refine PartialOrder.rel_trans (y := wp x (fun _ => F) E ⊓ wp x Q E) ?_ ?_
+  · exact le_meet _ _ _ (PartialOrder.rel_trans (meet_le_left _ _) (h E)) (meet_le_right _ _)
+  · refine PartialOrder.rel_trans (WPConjunctive.wp_meet_wp_le x (fun _ => F) Q E)
+      (WP.wp_consequence _ _ _ _ ?_)
+    intro a
+    simp only [meet_apply]
+    exact PartialOrder.rel_refl
+
+end Std.Internal.Do

--- a/src/Std/Internal/Do/WP/Frame.lean
+++ b/src/Std/Internal/Do/WP/Frame.lean
@@ -29,9 +29,8 @@ For stateful `Pred`, this means that running `x` preserves the state identified 
 def WP.Frames (x : Prog) (F : Pred) : Prop :=
   ∀ (Q : Value → Pred) (E : EPred), F ⊓ wp x Q E ⊑ wp x (fun a => F ⊓ Q a) E
 
-/-- `x` frames a meet frame `F` when `x` frames `F` and `wp x` is conjunctive:
-the side condition reduces to the preservation triple `F ⊑ wp x (fun _ => F)`. -/
-theorem WP.Frames.of_meet {Prog : Type u} {Value : Type v} {Pred : Type w} {EPred : Type z}
+/-- If `wp x` is conjunctive, then `x` frames `F` when `F` holds before and after running `x`. -/
+theorem WP.Frames.of_wp_conjunctive {Prog : Type u} {Value : Type v} {Pred : Type w} {EPred : Type z}
     [Assertion Pred] [Assertion EPred] [WP Prog Value Pred EPred]
     [WPConjunctive Prog Value Pred EPred] {x : Prog} {F : Pred} (h : ∀ E, F ⊑ wp x (fun _ => F) E) :
     WP.Frames x F := by

--- a/src/Std/Internal/Do/WP/Frame.lean
+++ b/src/Std/Internal/Do/WP/Frame.lean
@@ -22,18 +22,19 @@ variable {Prog : Type u} {Value : Type v} {Pred : Type w} {EPred : Type z}
   [Assertion Pred] [Assertion EPred] [WP Prog Value Pred EPred]
 
 /--
-`x` preserves the frame `F`: `F` commutes into the postcondition of `wp x` for every postcondition.
-The side condition discharged when framing a spec for `x`.
+`x` frames `F`: meeting with `F` commutes into the postcondition of `wp x` for every postcondition.
+
+For stateful `Pred`, this means that running `x` preserves the state identified by `F`.
 -/
-def WP.Preserving (x : Prog) (F : Pred) : Prop :=
+def WP.Frames (x : Prog) (F : Pred) : Prop :=
   ∀ (Q : Value → Pred) (E : EPred), F ⊓ wp x Q E ⊑ wp x (fun a => F ⊓ Q a) E
 
-/-- A meet frame `(F ⊓ ·)` is preserved by `x` when `x` preserves `F` and `wp x` is conjunctive:
+/-- `x` frames a meet frame `F` when `x` frames `F` and `wp x` is conjunctive:
 the side condition reduces to the preservation triple `F ⊑ wp x (fun _ => F)`. -/
-theorem WP.Preserving.of_meet {Prog : Type u} {Value : Type v} {Pred : Type w} {EPred : Type z}
+theorem WP.Frames.of_meet {Prog : Type u} {Value : Type v} {Pred : Type w} {EPred : Type z}
     [Assertion Pred] [Assertion EPred] [WP Prog Value Pred EPred]
     [WPConjunctive Prog Value Pred EPred] {x : Prog} {F : Pred} (h : ∀ E, F ⊑ wp x (fun _ => F) E) :
-    WP.Preserving x F := by
+    WP.Frames x F := by
   intro Q E
   refine PartialOrder.rel_trans (y := wp x (fun _ => F) E ⊓ wp x Q E) ?_ ?_
   · exact le_meet _ _ _ (PartialOrder.rel_trans (meet_le_left _ _) (h E)) (meet_le_right _ _)
@@ -43,16 +44,16 @@ theorem WP.Preserving.of_meet {Prog : Type u} {Value : Type v} {Pred : Type w} {
     simp only [meet_apply]
     exact PartialOrder.rel_refl
 
-/-- When `x` preserves `F`, meeting with `F` commutes into the postcondition of `wp x`. -/
+/-- When `x` frames `F`, meeting with `F` commutes into the postcondition of `wp x`. -/
 theorem meet_wp_le_wp_meet {x : Prog} {F : Pred} {Q : Value → Pred} {E : EPred}
-    (hframe : WP.Preserving x F) :
+    (hframe : WP.Frames x F) :
     F ⊓ wp x Q E ⊑ wp x (fun r => F ⊓ Q r) E :=
   hframe Q E
 
 /-- The framed spec `vcgen` applies for `x`: residualizing the postcondition through `F ⇨ ·` makes
 `F ⊓ wp x (F ⇨ Q)` a precondition for `wp x Q`. -/
 theorem meet_wp_imp_le_wp [Frame Pred] {x : Prog} {F : Pred} {Q : Value → Pred} {E : EPred}
-    (hframe : WP.Preserving x F) :
+    (hframe : WP.Frames x F) :
     F ⊓ wp x (fun a => F ⇨ Q a) E ⊑ wp x Q E :=
   PartialOrder.rel_trans (meet_wp_le_wp_meet hframe)
     (WP.wp_consequence x _ Q E (fun _ => CompleteLattice.meet_himp_le))

--- a/src/Std/Internal/Do/WP/Frame.lean
+++ b/src/Std/Internal/Do/WP/Frame.lean
@@ -49,8 +49,8 @@ theorem meet_wp_le_wp_meet {x : Prog} {F : Pred} {Q : Value → Pred} {E : EPred
     F ⊓ wp x Q E ⊑ wp x (fun r => F ⊓ Q r) E :=
   hframe Q E
 
-/-- The framed spec `vcgen` applies for `x`: residualizing the postcondition through `F ⇨ ·` makes
-`F ⊓ wp x (F ⇨ Q)` a precondition for `wp x Q`. -/
+/-- The framed spec `vcgen` applies for `x`: `F ⊓ wp x (fun a => F ⇨ Q a)` is a precondition for
+`wp x Q`. -/
 theorem meet_wp_imp_le_wp [Frame Pred] {x : Prog} {F : Pred} {Q : Value → Pred} {E : EPred}
     (hframe : WP.Frames x F) :
     F ⊓ wp x (fun a => F ⇨ Q a) E ⊑ wp x Q E :=

--- a/src/Std/Internal/Do/WP/Frame.lean
+++ b/src/Std/Internal/Do/WP/Frame.lean
@@ -18,45 +18,22 @@ open Lean.Order Std.Internal.Do
 
 namespace Std.Internal.Do
 
-namespace WP
-
 variable {Prog : Type u} {Value : Type v} {Pred : Type w} {EPred : Type z}
   [Assertion Pred] [Assertion EPred] [WP Prog Value Pred EPred]
 
 /--
-`x` preserves the frame operator `frame` (example: `F ⊓ ·`): `frame` commutes into the
-postcondition of `wp x` for every postcondition. The side condition discharged when framing a spec
-for `x`.
+`x` preserves the frame `F`: `F` commutes into the postcondition of `wp x` for every postcondition.
+The side condition discharged when framing a spec for `x`.
 -/
-def Preserving (x : Prog) (frame : Pred → Pred) : Prop :=
-  ∀ (Q : Value → Pred) (E : EPred), frame (wp x Q E) ⊑ wp x (fun a => frame (Q a)) E
-
-/-- When `x` preserves `F`, meeting with `F` commutes into the postcondition of `wp x`. -/
-theorem meet_wp_le_wp_meet [Frame Pred] {x : Prog} {F : Pred} {Q : Value → Pred} {E : EPred}
-    (hframe : Preserving x (F ⊓ ·)) :
-    F ⊓ wp x Q E ⊑ wp x (fun r => F ⊓ Q r) E :=
-  hframe Q E
-
-/-- The framed spec `vcgen` applies for `x`: residualizing the postcondition through `F ⇨ ·` makes
-`F ⊓ wp x (F ⇨ Q)` a precondition for `wp x Q`. -/
-theorem meet_wp_imp_le_wp [Frame Pred] {x : Prog} {F : Pred} {Q : Value → Pred} {E : EPred}
-    (hframe : Preserving x (F ⊓ ·)) :
-    F ⊓ wp x (fun a => F ⇨ Q a) E ⊑ wp x Q E :=
-  PartialOrder.rel_trans (meet_wp_le_wp_meet hframe)
-    (wp_consequence x _ Q E (fun _ => CompleteLattice.meet_himp_le))
-
-end WP
-
-end Std.Internal.Do
-
-namespace Std.Internal.Do
+def WP.Preserving (x : Prog) (F : Pred) : Prop :=
+  ∀ (Q : Value → Pred) (E : EPred), F ⊓ wp x Q E ⊑ wp x (fun a => F ⊓ Q a) E
 
 /-- A meet frame `(F ⊓ ·)` is preserved by `x` when `x` preserves `F` and `wp x` is conjunctive:
 the side condition reduces to the preservation triple `F ⊑ wp x (fun _ => F)`. -/
-theorem WP.Preserving.of_meet {m : Type u → Type v} {Pred : Type w} {EPred : Type z}
-    {α : Type u} [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
-    [WPConjunctive (m α) α Pred EPred] (x : m α) (F : Pred) (h : ∀ E, F ⊑ wp x (fun _ => F) E) :
-    WP.Preserving x (F ⊓ ·) := by
+theorem WP.Preserving.of_meet {Prog : Type u} {Value : Type v} {Pred : Type w} {EPred : Type z}
+    [Assertion Pred] [Assertion EPred] [WP Prog Value Pred EPred]
+    [WPConjunctive Prog Value Pred EPred] {x : Prog} {F : Pred} (h : ∀ E, F ⊑ wp x (fun _ => F) E) :
+    WP.Preserving x F := by
   intro Q E
   refine PartialOrder.rel_trans (y := wp x (fun _ => F) E ⊓ wp x Q E) ?_ ?_
   · exact le_meet _ _ _ (PartialOrder.rel_trans (meet_le_left _ _) (h E)) (meet_le_right _ _)
@@ -66,4 +43,16 @@ theorem WP.Preserving.of_meet {m : Type u → Type v} {Pred : Type w} {EPred : T
     simp only [meet_apply]
     exact PartialOrder.rel_refl
 
-end Std.Internal.Do
+/-- When `x` preserves `F`, meeting with `F` commutes into the postcondition of `wp x`. -/
+theorem meet_wp_le_wp_meet {x : Prog} {F : Pred} {Q : Value → Pred} {E : EPred}
+    (hframe : WP.Preserving x F) :
+    F ⊓ wp x Q E ⊑ wp x (fun r => F ⊓ Q r) E :=
+  hframe Q E
+
+/-- The framed spec `vcgen` applies for `x`: residualizing the postcondition through `F ⇨ ·` makes
+`F ⊓ wp x (F ⇨ Q)` a precondition for `wp x Q`. -/
+theorem meet_wp_imp_le_wp [Frame Pred] {x : Prog} {F : Pred} {Q : Value → Pred} {E : EPred}
+    (hframe : WP.Preserving x F) :
+    F ⊓ wp x (fun a => F ⇨ Q a) E ⊑ wp x Q E :=
+  PartialOrder.rel_trans (meet_wp_le_wp_meet hframe)
+    (WP.wp_consequence x _ Q E (fun _ => CompleteLattice.meet_himp_le))

--- a/src/Std/Internal/Do/WP/FrameGadget.lean
+++ b/src/Std/Internal/Do/WP/FrameGadget.lean
@@ -19,11 +19,11 @@ namespace Std.Internal.Do.Gadget
 variable {Prog : Type u} {Value : Type v} {Pred : Type w} {EPred : Type z}
   [Assertion Pred] [Assertion EPred] [WP Prog Value Pred EPred]
 
-/-- Marks the residual program of an applied frame so `frames` patterns do not re-match it.
+/-- Marks an already-framed program so `frames` patterns do not re-match it.
 Stripped by `vcgen` before the real spec applies. -/
 def skipFrame {α : Sort u} (a : α) : α := a
 
-/-- `meet_wp_imp_le_wp` with the residual program wrapped in `skipFrame`, the per-call spec `vcgen`
+/-- `meet_wp_imp_le_wp` with the program wrapped in `skipFrame`, the per-call spec `vcgen`
 applies for a framed program. The frame `F` is the first explicit argument so that `vcgen` can
 partially apply it (pinning `F`) and feed the result through the ordinary spec machinery, leaving
 `x`, `epost`, `Q`, and `hframe` schematic. -/

--- a/src/Std/Internal/Do/WP/FrameGadget.lean
+++ b/src/Std/Internal/Do/WP/FrameGadget.lean
@@ -16,8 +16,6 @@ open Lean.Order
 
 namespace Std.Internal.Do
 
-namespace WP
-
 variable {Prog : Type u} {Value : Type v} {Pred : Type w} {EPred : Type z}
   [Assertion Pred] [Assertion EPred] [WP Prog Value Pred EPred]
 
@@ -31,10 +29,8 @@ partially apply it (pinning `F`) and feed the result through the ordinary spec m
 `x`, `epost`, `Q`, and `hframe` schematic. -/
 theorem meet_wp_imp_le_wp_skipFrame [Frame Pred] (F : Pred) (x : Prog)
   (epost : EPred) (Q : Value → Pred)
-    (hframe : Preserving x (F ⊓ ·)) :
+    (hframe : WP.Preserving x F) :
     F ⊓ wp (skipFrame x) (fun a => F ⇨ Q a) epost ⊑ wp x Q epost :=
   meet_wp_imp_le_wp (Q := Q) hframe
-
-end WP
 
 end Std.Internal.Do

--- a/src/Std/Internal/Do/WP/FrameGadget.lean
+++ b/src/Std/Internal/Do/WP/FrameGadget.lean
@@ -14,7 +14,7 @@ set_option linter.missingDocs true
 
 open Lean.Order
 
-namespace Std.Internal.Do
+namespace Std.Internal.Do.Gadget
 
 variable {Prog : Type u} {Value : Type v} {Pred : Type w} {EPred : Type z}
   [Assertion Pred] [Assertion EPred] [WP Prog Value Pred EPred]
@@ -28,9 +28,9 @@ applies for a framed program. The frame `F` is the first explicit argument so th
 partially apply it (pinning `F`) and feed the result through the ordinary spec machinery, leaving
 `x`, `epost`, `Q`, and `hframe` schematic. -/
 theorem meet_wp_imp_le_wp_skipFrame [Frame Pred] (F : Pred) (x : Prog)
-  (epost : EPred) (Q : Value → Pred)
+  (E : EPred) (Q : Value → Pred)
     (hframe : WP.Preserving x F) :
-    F ⊓ wp (skipFrame x) (fun a => F ⇨ Q a) epost ⊑ wp x Q epost :=
-  meet_wp_imp_le_wp (Q := Q) hframe
+    F ⊓ wp (skipFrame x) (fun a => F ⇨ Q a) E ⊑ wp x Q E :=
+  meet_wp_imp_le_wp hframe
 
-end Std.Internal.Do
+end Std.Internal.Do.Gadget

--- a/src/Std/Internal/Do/WP/FrameGadget.lean
+++ b/src/Std/Internal/Do/WP/FrameGadget.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Graf
+-/
+module
+
+prelude
+public import Std.Internal.Do.WP.Frame
+universe u v w z
+@[expose] public section
+
+set_option linter.missingDocs true
+
+open Lean.Order
+
+namespace Std.Internal.Do
+
+namespace WP
+
+variable {Prog : Type u} {Value : Type v} {Pred : Type w} {EPred : Type z}
+  [Assertion Pred] [Assertion EPred] [WP Prog Value Pred EPred]
+
+/-- Marks the residual program of an applied frame so `frames` patterns do not re-match it.
+Stripped by `vcgen` before the real spec applies. -/
+def skipFrame {α : Sort u} (a : α) : α := a
+
+/-- `meet_wp_imp_le_wp` with the residual program wrapped in `skipFrame`, the per-call spec `vcgen`
+applies for a framed program. The frame `F` is the first explicit argument so that `vcgen` can
+partially apply it (pinning `F`) and feed the result through the ordinary spec machinery, leaving
+`x`, `epost`, `Q`, and `hframe` schematic. -/
+theorem meet_wp_imp_le_wp_skipFrame [Frame Pred] (F : Pred) (x : Prog)
+  (epost : EPred) (Q : Value → Pred)
+    (hframe : Preserving x (F ⊓ ·)) :
+    F ⊓ wp (skipFrame x) (fun a => F ⇨ Q a) epost ⊑ wp x Q epost :=
+  meet_wp_imp_le_wp (Q := Q) hframe
+
+end WP
+
+end Std.Internal.Do

--- a/src/Std/Internal/Do/WP/FrameGadget.lean
+++ b/src/Std/Internal/Do/WP/FrameGadget.lean
@@ -29,7 +29,7 @@ partially apply it (pinning `F`) and feed the result through the ordinary spec m
 `x`, `epost`, `Q`, and `hframe` schematic. -/
 theorem meet_wp_imp_le_wp_skipFrame [Frame Pred] (F : Pred) (x : Prog)
   (E : EPred) (Q : Value → Pred)
-    (hframe : WP.Preserving x F) :
+    (hframe : WP.Frames x F) :
     F ⊓ wp (skipFrame x) (fun a => F ⇨ Q a) E ⊑ wp x Q E :=
   meet_wp_imp_le_wp hframe
 

--- a/src/Std/Tactic/Do/Syntax.lean
+++ b/src/Std/Tactic/Do/Syntax.lean
@@ -413,6 +413,14 @@ docstring for `mvcgen`.
 syntax invariantAlts := invariantsKW withPosition((colGe (invariantDotAlt <|> invariantCaseAlt))*)
 
 /--
+A single `frames` alternative `| f a _ c => frame`: a program pattern (a head identifier applied to
+binder or `_` arguments, matched like the `until` pattern) and the frame assertion to apply when the
+spec for that program is used during VC generation. The named binders (e.g. `a`, `c`) are in scope
+in `frame`, bound to the matched arguments.
+-/
+syntax frameAlt := ppDedent(ppLine) "| " ident (ppSpace colGt binderIdent)* " => " (colGe term)
+
+/--
 In induction alternative, which can have 1 or more cases on the left
 and `_`, `?_`, or a tactic sequence after the `=>`.
 -/
@@ -456,6 +464,7 @@ syntax (name := vcgenDischargeTactic) (priority := low) tactic : vcgenDischarge
 syntax (name := vcgen) "vcgen" optConfig
   (" [" withoutPosition((simpStar <|> simpErase <|> simpLemma),*,?) "] ")?
   (&" until " term)?
+  (&" frames " withPosition((colGe frameAlt)+))?
   (invariantAlts)?
   (&" simplifying_assumptions" (ppSpace colGt ident)? (" [" ident,* "]")?)?
   (&" with " vcgenDischarge)? : tactic
@@ -467,6 +476,7 @@ steps using `<;>` instead. -/
 syntax (name := vcgen) "vcgen" optConfig
   (" [" withoutPosition((simpStar <|> simpErase <|> simpLemma),*,?) "] ")?
   (&" until " term)?
+  (&" frames " withPosition((colGe frameAlt)+))?
   (invariantAlts)?
   (&" simplifying_assumptions" (ppSpace colGt ident)? (" [" ident,* "]")?)?
   : grind

--- a/tests/elab/vcgenFrames.lean
+++ b/tests/elab/vcgenFrames.lean
@@ -66,13 +66,12 @@ theorem frames_mkFreshNat [Monad m] [Assertion Pred] [Assertion EPred]
 
 /-- `Id`-specialized `frames_mkFreshNat`. With the base monad ground, `grind` can derive a
 usable pattern, so registering it lets `finish` discharge the preservation VC. -/
+@[grind .]
 theorem frames_mkFreshNat_Id [Assertion Pred] [Assertion EPred]
     [WPMonad Id Pred EPred] [∀ β, WPConjunctive (Id β) β Pred EPred] {P : AppState → Pred}
     (h : ∀ s a, P { s with fst := a } = P s) :
     WP.Frames (mkFreshNat : StateT AppState Id Nat) P :=
   frames_mkFreshNat h
-
-grind_pattern frames_mkFreshNat_Id => WP.Frames (mkFreshNat : StateT AppState Id Nat) P
 
 /-- The frame recovers `s.2`, which the lossy spec dropped. The `fail_if_success` confirms the frame
 is doing the work: without it, `grind` cannot close the lost `s.2 = 7`. -/
@@ -124,13 +123,12 @@ theorem frames_mkFreshSnd [Monad m] [Assertion Pred] [Assertion EPred]
   rw [h s (s.snd + 1)]
 
 /-- `Id`-specialized `frames_mkFreshSnd`, registered so `finish` discharges the preservation VC. -/
+@[grind .]
 theorem frames_mkFreshSnd_Id [Assertion Pred] [Assertion EPred]
     [WPMonad Id Pred EPred] [∀ β, WPConjunctive (Id β) β Pred EPred] {P : AppState → Pred}
     (h : ∀ s a, P { s with snd := a } = P s) :
     WP.Frames (mkFreshSnd : StateT AppState Id Nat) P :=
   frames_mkFreshSnd h
-
-grind_pattern frames_mkFreshSnd_Id => WP.Frames (mkFreshSnd : StateT AppState Id Nat) P
 
 /-- Mirror of `recovers_snd`: frame the complementary (`fst`) footprint. -/
 theorem recovers_fst [Assertion Pred] [Assertion EPred] [WPMonad Id Pred EPred]
@@ -190,13 +188,12 @@ theorem frames_addFst [Monad m] [Assertion Pred] [Assertion EPred]
   rw [h s (s.fst + k)]
 
 /-- `Id`-specialized `frames_addFst`, registered so `finish` discharges the preservation VC. -/
+@[grind .]
 theorem frames_addFst_Id [Assertion Pred] [Assertion EPred]
     [WPMonad Id Pred EPred] [∀ β, WPConjunctive (Id β) β Pred EPred] {P : AppState → Pred} {k : Nat}
     (h : ∀ s a, P { s with fst := a } = P s) :
     WP.Frames (addFst k : StateT AppState Id Nat) P :=
   frames_addFst h
-
-grind_pattern frames_addFst_Id => WP.Frames (addFst k : StateT AppState Id Nat) P
 
 /-- The frame `fun s => ⌜s.2 = j⌝` references the matched argument `j`, so `elabFrame` introduces
 `let j := k` and the assignment is recovered in the postcondition. -/
@@ -241,13 +238,12 @@ theorem frames_bumpSnd {σ : Type} [Monad m] [Assertion Pred] [Assertion EPred]
 
 /-- `Id`-specialized `frames_bumpSnd` over an abstract state `σ`, registered so `finish`
 discharges the preservation VC. -/
+@[grind .]
 theorem frames_bumpSnd_Id {σ : Type} [Assertion Pred] [Assertion EPred]
     [WPMonad Id Pred EPred] [∀ β, WPConjunctive (Id β) β Pred EPred] {P : σ × Nat → Pred}
     (h : ∀ s a, P { s with snd := a } = P s) :
     WP.Frames (bumpSnd : StateT (σ × Nat) Id Nat) P :=
   frames_bumpSnd h
-
-grind_pattern frames_bumpSnd_Id => WP.Frames (bumpSnd : StateT (σ × Nat) Id Nat) P
 
 /-- The frame recovers `s.1 = a` for an abstract `a : σ`, which the lossy spec dropped. -/
 theorem recovers_fst_poly {σ : Type} [Assertion Pred] [Assertion EPred]

--- a/tests/elab/vcgenFrames.lean
+++ b/tests/elab/vcgenFrames.lean
@@ -18,7 +18,7 @@ A `frames` alternative attaches a state assertion `F` to a matched program whose
 frame precondition and the `Frames` side goal, and recovers `F` in the postcondition.
 
 The `Frames` side goal is established by `frames_mkFreshNat`, which reduces it through
-`WP.Frames.of_meet` to a preservation triple `F ⊑ wp x (fun _ => F)` (using `WPConjunctive`
+`WP.Frames.of_wp_conjunctive` to a preservation triple `F ⊑ wp x (fun _ => F)` (using `WPConjunctive`
 for the monad); `mkFreshNat` writes only `fst`, so it preserves any `snd`-fact.
 
 The `recovers_*` proofs run at the `Id` base monad and register the `_Id` specializations of these
@@ -49,12 +49,12 @@ theorem mkFreshNat_spec_lossy [Monad m] [Assertion Pred] [Assertion EPred] [WPMo
   vcgen <;> simp_all
 
 /-- `mkFreshNat` frames any `P` outside its `fst` footprint. The frame condition reduces through
-`of_meet` to the preservation triple, which holds since `mkFreshNat` overwrites only `fst`. -/
+`of_wp_conjunctive` to the preservation triple, which holds since `mkFreshNat` overwrites only `fst`. -/
 theorem frames_mkFreshNat [Monad m] [Assertion Pred] [Assertion EPred]
     [WPMonad m Pred EPred] [∀ β, WPConjunctive (m β) β Pred EPred] {P : AppState → Pred}
     (h : ∀ s a, P { s with fst := a } = P s) :
     WP.Frames (mkFreshNat : StateT AppState m Nat) P := by
-  refine .of_meet (fun E => ?_)
+  refine .of_wp_conjunctive (fun E => ?_)
   intro s
   unfold mkFreshNat
   simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,
@@ -113,7 +113,7 @@ theorem frames_mkFreshSnd [Monad m] [Assertion Pred] [Assertion EPred]
     [WPMonad m Pred EPred] [∀ β, WPConjunctive (m β) β Pred EPred] {P : AppState → Pred}
     (h : ∀ s a, P { s with snd := a } = P s) :
     WP.Frames (mkFreshSnd : StateT AppState m Nat) P := by
-  refine .of_meet (fun E => ?_)
+  refine .of_wp_conjunctive (fun E => ?_)
   intro s
   unfold mkFreshSnd
   simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,
@@ -179,7 +179,7 @@ theorem frames_addFst [Monad m] [Assertion Pred] [Assertion EPred]
     [WPMonad m Pred EPred] [∀ β, WPConjunctive (m β) β Pred EPred] {P : AppState → Pred} {k : Nat}
     (h : ∀ s a, P { s with fst := a } = P s) :
     WP.Frames (addFst k : StateT AppState m Nat) P := by
-  refine .of_meet (fun E => ?_)
+  refine .of_wp_conjunctive (fun E => ?_)
   intro s
   unfold addFst
   simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,
@@ -229,7 +229,7 @@ theorem frames_bumpSnd {σ : Type} [Monad m] [Assertion Pred] [Assertion EPred]
     [WPMonad m Pred EPred] [∀ β, WPConjunctive (m β) β Pred EPred] {P : σ × Nat → Pred}
     (h : ∀ s a, P { s with snd := a } = P s) :
     WP.Frames (bumpSnd : StateT (σ × Nat) m Nat) P := by
-  refine .of_meet (fun E => ?_)
+  refine .of_wp_conjunctive (fun E => ?_)
   intro s
   unfold bumpSnd
   simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,

--- a/tests/elab/vcgenFrames.lean
+++ b/tests/elab/vcgenFrames.lean
@@ -15,15 +15,15 @@ set_option grind.warning false
 
 A `frames` alternative attaches a state assertion `F` to a matched program whose registered spec is
 *lossy* (drops a fact about state it does not touch). `vcgen` applies the framed spec, emits the
-frame precondition and the `Preserving` side goal, and recovers `F` in the postcondition.
+frame precondition and the `Frames` side goal, and recovers `F` in the postcondition.
 
-The `Preserving` side goal is established by `preserving_mkFreshNat`, which reduces it through
-`WP.Preserving.of_meet` to a preservation triple `F ⊑ wp x (fun _ => F)` (using `WPConjunctive`
+The `Frames` side goal is established by `frames_mkFreshNat`, which reduces it through
+`WP.Frames.of_meet` to a preservation triple `F ⊑ wp x (fun _ => F)` (using `WPConjunctive`
 for the monad); `mkFreshNat` writes only `fst`, so it preserves any `snd`-fact.
 
 The `recovers_*` proofs run at the `Id` base monad and register the `_Id` specializations of these
 lemmas with `grind`. With the monad ground, `grind` derives a usable E-matching pattern, so the
-discharge step `with finish` closes every VC, including the `Preserving` side goal.
+discharge step `with finish` closes every VC, including the `Frames` side goal.
 -/
 
 open Lean Order Meta Elab Tactic Sym Std Internal.Do
@@ -50,10 +50,10 @@ theorem mkFreshNat_spec_lossy [Monad m] [Assertion Pred] [Assertion EPred] [WPMo
 
 /-- `mkFreshNat` frames any `P` outside its `fst` footprint. The frame condition reduces through
 `of_meet` to the preservation triple, which holds since `mkFreshNat` overwrites only `fst`. -/
-theorem preserving_mkFreshNat [Monad m] [Assertion Pred] [Assertion EPred]
+theorem frames_mkFreshNat [Monad m] [Assertion Pred] [Assertion EPred]
     [WPMonad m Pred EPred] [∀ β, WPConjunctive (m β) β Pred EPred] {P : AppState → Pred}
     (h : ∀ s a, P { s with fst := a } = P s) :
-    WP.Preserving (mkFreshNat : StateT AppState m Nat) P := by
+    WP.Frames (mkFreshNat : StateT AppState m Nat) P := by
   refine .of_meet (fun E => ?_)
   intro s
   unfold mkFreshNat
@@ -64,15 +64,15 @@ theorem preserving_mkFreshNat [Monad m] [Assertion Pred] [Assertion EPred]
   show P s ⊑ P (s.fst + 1, s.snd)
   rw [h s (s.fst + 1)]
 
-/-- `Id`-specialized `preserving_mkFreshNat`. With the base monad ground, `grind` can derive a
+/-- `Id`-specialized `frames_mkFreshNat`. With the base monad ground, `grind` can derive a
 usable pattern, so registering it lets `finish` discharge the preservation VC. -/
-theorem preserving_mkFreshNat_Id [Assertion Pred] [Assertion EPred]
+theorem frames_mkFreshNat_Id [Assertion Pred] [Assertion EPred]
     [WPMonad Id Pred EPred] [∀ β, WPConjunctive (Id β) β Pred EPred] {P : AppState → Pred}
     (h : ∀ s a, P { s with fst := a } = P s) :
-    WP.Preserving (mkFreshNat : StateT AppState Id Nat) P :=
-  preserving_mkFreshNat h
+    WP.Frames (mkFreshNat : StateT AppState Id Nat) P :=
+  frames_mkFreshNat h
 
-grind_pattern preserving_mkFreshNat_Id => WP.Preserving (mkFreshNat : StateT AppState Id Nat) P
+grind_pattern frames_mkFreshNat_Id => WP.Frames (mkFreshNat : StateT AppState Id Nat) P
 
 /-- The frame recovers `s.2`, which the lossy spec dropped. The `fail_if_success` confirms the frame
 is doing the work: without it, `grind` cannot close the lost `s.2 = 7`. -/
@@ -109,10 +109,10 @@ theorem mkFreshSnd_spec_lossy [Monad m] [Assertion Pred] [Assertion EPred] [WPMo
   vcgen <;> simp_all
 
 /-- `mkFreshSnd` frames any `P` outside its `snd` footprint. -/
-theorem preserving_mkFreshSnd [Monad m] [Assertion Pred] [Assertion EPred]
+theorem frames_mkFreshSnd [Monad m] [Assertion Pred] [Assertion EPred]
     [WPMonad m Pred EPred] [∀ β, WPConjunctive (m β) β Pred EPred] {P : AppState → Pred}
     (h : ∀ s a, P { s with snd := a } = P s) :
-    WP.Preserving (mkFreshSnd : StateT AppState m Nat) P := by
+    WP.Frames (mkFreshSnd : StateT AppState m Nat) P := by
   refine .of_meet (fun E => ?_)
   intro s
   unfold mkFreshSnd
@@ -123,14 +123,14 @@ theorem preserving_mkFreshSnd [Monad m] [Assertion Pred] [Assertion EPred]
   show P s ⊑ P (s.fst, s.snd + 1)
   rw [h s (s.snd + 1)]
 
-/-- `Id`-specialized `preserving_mkFreshSnd`, registered so `finish` discharges the preservation VC. -/
-theorem preserving_mkFreshSnd_Id [Assertion Pred] [Assertion EPred]
+/-- `Id`-specialized `frames_mkFreshSnd`, registered so `finish` discharges the preservation VC. -/
+theorem frames_mkFreshSnd_Id [Assertion Pred] [Assertion EPred]
     [WPMonad Id Pred EPred] [∀ β, WPConjunctive (Id β) β Pred EPred] {P : AppState → Pred}
     (h : ∀ s a, P { s with snd := a } = P s) :
-    WP.Preserving (mkFreshSnd : StateT AppState Id Nat) P :=
-  preserving_mkFreshSnd h
+    WP.Frames (mkFreshSnd : StateT AppState Id Nat) P :=
+  frames_mkFreshSnd h
 
-grind_pattern preserving_mkFreshSnd_Id => WP.Preserving (mkFreshSnd : StateT AppState Id Nat) P
+grind_pattern frames_mkFreshSnd_Id => WP.Frames (mkFreshSnd : StateT AppState Id Nat) P
 
 /-- Mirror of `recovers_snd`: frame the complementary (`fst`) footprint. -/
 theorem recovers_fst [Assertion Pred] [Assertion EPred] [WPMonad Id Pred EPred]
@@ -175,10 +175,10 @@ theorem addFst_spec_lossy [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad 
   vcgen <;> simp_all
 
 /-- `addFst k` frames any `P` outside its `fst` footprint. -/
-theorem preserving_addFst [Monad m] [Assertion Pred] [Assertion EPred]
+theorem frames_addFst [Monad m] [Assertion Pred] [Assertion EPred]
     [WPMonad m Pred EPred] [∀ β, WPConjunctive (m β) β Pred EPred] {P : AppState → Pred} {k : Nat}
     (h : ∀ s a, P { s with fst := a } = P s) :
-    WP.Preserving (addFst k : StateT AppState m Nat) P := by
+    WP.Frames (addFst k : StateT AppState m Nat) P := by
   refine .of_meet (fun E => ?_)
   intro s
   unfold addFst
@@ -189,14 +189,14 @@ theorem preserving_addFst [Monad m] [Assertion Pred] [Assertion EPred]
   show P s ⊑ P (s.fst + k, s.snd)
   rw [h s (s.fst + k)]
 
-/-- `Id`-specialized `preserving_addFst`, registered so `finish` discharges the preservation VC. -/
-theorem preserving_addFst_Id [Assertion Pred] [Assertion EPred]
+/-- `Id`-specialized `frames_addFst`, registered so `finish` discharges the preservation VC. -/
+theorem frames_addFst_Id [Assertion Pred] [Assertion EPred]
     [WPMonad Id Pred EPred] [∀ β, WPConjunctive (Id β) β Pred EPred] {P : AppState → Pred} {k : Nat}
     (h : ∀ s a, P { s with fst := a } = P s) :
-    WP.Preserving (addFst k : StateT AppState Id Nat) P :=
-  preserving_addFst h
+    WP.Frames (addFst k : StateT AppState Id Nat) P :=
+  frames_addFst h
 
-grind_pattern preserving_addFst_Id => WP.Preserving (addFst k : StateT AppState Id Nat) P
+grind_pattern frames_addFst_Id => WP.Frames (addFst k : StateT AppState Id Nat) P
 
 /-- The frame `fun s => ⌜s.2 = j⌝` references the matched argument `j`, so `elabFrame` introduces
 `let j := k` and the assignment is recovered in the postcondition. -/
@@ -225,10 +225,10 @@ theorem bumpSnd_spec_lossy {σ : Type} [Monad m] [Assertion Pred] [Assertion EPr
   vcgen <;> simp_all
 
 /-- `bumpSnd` frames any `P` outside its `snd` footprint, over an abstract state `σ`. -/
-theorem preserving_bumpSnd {σ : Type} [Monad m] [Assertion Pred] [Assertion EPred]
+theorem frames_bumpSnd {σ : Type} [Monad m] [Assertion Pred] [Assertion EPred]
     [WPMonad m Pred EPred] [∀ β, WPConjunctive (m β) β Pred EPred] {P : σ × Nat → Pred}
     (h : ∀ s a, P { s with snd := a } = P s) :
-    WP.Preserving (bumpSnd : StateT (σ × Nat) m Nat) P := by
+    WP.Frames (bumpSnd : StateT (σ × Nat) m Nat) P := by
   refine .of_meet (fun E => ?_)
   intro s
   unfold bumpSnd
@@ -239,15 +239,15 @@ theorem preserving_bumpSnd {σ : Type} [Monad m] [Assertion Pred] [Assertion EPr
   show P s ⊑ P (s.fst, s.snd + 1)
   rw [h s (s.snd + 1)]
 
-/-- `Id`-specialized `preserving_bumpSnd` over an abstract state `σ`, registered so `finish`
+/-- `Id`-specialized `frames_bumpSnd` over an abstract state `σ`, registered so `finish`
 discharges the preservation VC. -/
-theorem preserving_bumpSnd_Id {σ : Type} [Assertion Pred] [Assertion EPred]
+theorem frames_bumpSnd_Id {σ : Type} [Assertion Pred] [Assertion EPred]
     [WPMonad Id Pred EPred] [∀ β, WPConjunctive (Id β) β Pred EPred] {P : σ × Nat → Pred}
     (h : ∀ s a, P { s with snd := a } = P s) :
-    WP.Preserving (bumpSnd : StateT (σ × Nat) Id Nat) P :=
-  preserving_bumpSnd h
+    WP.Frames (bumpSnd : StateT (σ × Nat) Id Nat) P :=
+  frames_bumpSnd h
 
-grind_pattern preserving_bumpSnd_Id => WP.Preserving (bumpSnd : StateT (σ × Nat) Id Nat) P
+grind_pattern frames_bumpSnd_Id => WP.Frames (bumpSnd : StateT (σ × Nat) Id Nat) P
 
 /-- The frame recovers `s.1 = a` for an abstract `a : σ`, which the lossy spec dropped. -/
 theorem recovers_fst_poly {σ : Type} [Assertion Pred] [Assertion EPred]

--- a/tests/elab/vcgenFrames.lean
+++ b/tests/elab/vcgenFrames.lean
@@ -50,8 +50,8 @@ theorem mkFreshNat_spec_lossy [Monad m] [Assertion Pred] [Assertion EPred] [WPMo
 theorem preserving_mkFreshNat [Monad m] [Assertion Pred] [Assertion EPred]
     [WPMonad m Pred EPred] [∀ β, WPConjunctive (m β) β Pred EPred] {P : AppState → Pred}
     (h : ∀ s a, P { s with fst := a } = P s) :
-    WP.Preserving (mkFreshNat : StateT AppState m Nat) (P ⊓ ·) := by
-  refine .of_meet (mkFreshNat : StateT AppState m Nat) P (fun E => ?_)
+    WP.Preserving (mkFreshNat : StateT AppState m Nat) P := by
+  refine .of_meet (fun E => ?_)
   intro s
   unfold mkFreshNat
   simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,
@@ -68,8 +68,8 @@ theorem recovers_snd [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pre
     ⦃ fun s => ⌜s.1 = 0 ∧ s.2 = 7⌝ ⦄ (mkFreshNat : StateT AppState m Nat)
     ⦃ fun r s => ⌜r = 0 ∧ s.2 = 7⌝ ⦄ := by
   fail_if_success (vcgen <;> grind)
-  vcgen frames | mkFreshNat => fun s => ⌜s.2 = 7⌝ <;>
-    first | exact preserving_mkFreshNat (by grind) | grind
+  vcgen frames | mkFreshNat => fun s => ⌜s.2 = 7⌝ with try finish
+  exact preserving_mkFreshNat (by grind)
 
 /-- Two calls, two alternatives: consume-once frames each `mkFreshNat` exactly once. -/
 theorem recovers_snd_pair [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
@@ -100,8 +100,8 @@ theorem mkFreshSnd_spec_lossy [Monad m] [Assertion Pred] [Assertion EPred] [WPMo
 theorem preserving_mkFreshSnd [Monad m] [Assertion Pred] [Assertion EPred]
     [WPMonad m Pred EPred] [∀ β, WPConjunctive (m β) β Pred EPred] {P : AppState → Pred}
     (h : ∀ s a, P { s with snd := a } = P s) :
-    WP.Preserving (mkFreshSnd : StateT AppState m Nat) (P ⊓ ·) := by
-  refine .of_meet (mkFreshSnd : StateT AppState m Nat) P (fun E => ?_)
+    WP.Preserving (mkFreshSnd : StateT AppState m Nat) P := by
+  refine .of_meet (fun E => ?_)
   intro s
   unfold mkFreshSnd
   simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,
@@ -162,8 +162,8 @@ theorem addFst_spec_lossy [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad 
 theorem preserving_addFst [Monad m] [Assertion Pred] [Assertion EPred]
     [WPMonad m Pred EPred] [∀ β, WPConjunctive (m β) β Pred EPred] {P : AppState → Pred} {k : Nat}
     (h : ∀ s a, P { s with fst := a } = P s) :
-    WP.Preserving (addFst k : StateT AppState m Nat) (P ⊓ ·) := by
-  refine .of_meet (addFst k : StateT AppState m Nat) P (fun E => ?_)
+    WP.Preserving (addFst k : StateT AppState m Nat) P := by
+  refine .of_meet (fun E => ?_)
   intro s
   unfold addFst
   simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,
@@ -204,8 +204,8 @@ theorem bumpSnd_spec_lossy {σ : Type} [Monad m] [Assertion Pred] [Assertion EPr
 theorem preserving_bumpSnd {σ : Type} [Monad m] [Assertion Pred] [Assertion EPred]
     [WPMonad m Pred EPred] [∀ β, WPConjunctive (m β) β Pred EPred] {P : σ × Nat → Pred}
     (h : ∀ s a, P { s with snd := a } = P s) :
-    WP.Preserving (bumpSnd : StateT (σ × Nat) m Nat) (P ⊓ ·) := by
-  refine .of_meet (bumpSnd : StateT (σ × Nat) m Nat) P (fun E => ?_)
+    WP.Preserving (bumpSnd : StateT (σ × Nat) m Nat) P := by
+  refine .of_meet (fun E => ?_)
   intro s
   unfold bumpSnd
   simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,

--- a/tests/elab/vcgenFrames.lean
+++ b/tests/elab/vcgenFrames.lean
@@ -1,0 +1,244 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Graf
+-/
+import Lean
+import Std.Internal
+import Std.Tactic.Do
+
+set_option mvcgen.warning false
+set_option grind.warning false
+
+/-!
+# Tests for the `vcgen … frames` clause
+
+A `frames` alternative attaches a state assertion `F` to a matched program whose registered spec is
+*lossy* (drops a fact about state it does not touch). `vcgen` applies the framed spec, emits the
+frame precondition and the `Preserving` side goal, and recovers `F` in the postcondition.
+
+The base monad is polymorphic, so the only handle on `mkFreshNat` is its lossy spec. The
+`Preserving` side goal is discharged by `preserving_mkFreshNat`, which reduces it through
+`WP.Preserving.of_meet` to a preservation triple `F ⊑ wp x (fun _ => F)` (using `WPConjunctive`
+for the monad); `mkFreshNat` writes only `fst`, so it preserves any `snd`-fact.
+-/
+
+open Lean Order Meta Elab Tactic Sym Std Internal.Do
+
+abbrev AppState := Nat × Nat
+
+@[irreducible] def mkFreshNat [Monad m] [MonadStateOf AppState m] : m Nat := do
+  let n ← Prod.fst <$> get
+  modify (fun s => (s.1 + 1, s.2))
+  pure n
+
+def mkFreshPair [Monad m] [MonadStateOf AppState m] : m (Nat × Nat) := do
+  let a ← mkFreshNat
+  let b ← mkFreshNat
+  pure (a, b)
+
+/-- Lossy spec: says nothing about `s.2`. -/
+@[spec]
+theorem mkFreshNat_spec_lossy [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+    ⦃ fun s => ⌜s.1 = n⌝ ⦄ (mkFreshNat : StateT AppState m Nat)
+    ⦃ fun r s => ⌜r = n ∧ s.1 = n + 1⌝ ⦄ := by
+  unfold mkFreshNat
+  vcgen <;> simp_all
+
+/-- `mkFreshNat` frames any `P` outside its `fst` footprint. The frame condition reduces through
+`of_meet` to the preservation triple, which holds since `mkFreshNat` overwrites only `fst`. -/
+theorem preserving_mkFreshNat [Monad m] [Assertion Pred] [Assertion EPred]
+    [WPMonad m Pred EPred] [∀ β, WPConjunctive (m β) β Pred EPred] {P : AppState → Pred}
+    (h : ∀ s a, P { s with fst := a } = P s) :
+    WP.Preserving (mkFreshNat : StateT AppState m Nat) (P ⊓ ·) := by
+  refine .of_meet (mkFreshNat : StateT AppState m Nat) P (fun E => ?_)
+  intro s
+  unfold mkFreshNat
+  simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,
+    StateT.run_map, bind_pure_comp, map_pure]
+  refine PartialOrder.rel_trans ?_
+    (WPMonad.pure_le_wp_pure (m := m) (s.fst, s.fst + 1, s.snd) (fun x => P x.snd) E)
+  show P s ⊑ P (s.fst + 1, s.snd)
+  rw [h s (s.fst + 1)]
+
+/-- The frame recovers `s.2`, which the lossy spec dropped. The `fail_if_success` confirms the frame
+is doing the work: without it, `grind` cannot close the lost `s.2 = 7`. -/
+theorem recovers_snd [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+    [∀ β, WPConjunctive (m β) β Pred EPred] [Frame Pred] :
+    ⦃ fun s => ⌜s.1 = 0 ∧ s.2 = 7⌝ ⦄ (mkFreshNat : StateT AppState m Nat)
+    ⦃ fun r s => ⌜r = 0 ∧ s.2 = 7⌝ ⦄ := by
+  fail_if_success (vcgen <;> grind)
+  vcgen frames | mkFreshNat => fun s => ⌜s.2 = 7⌝ <;>
+    first | exact preserving_mkFreshNat (by grind) | grind
+
+/-- Two calls, two alternatives: consume-once frames each `mkFreshNat` exactly once. -/
+theorem recovers_snd_pair [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+    [∀ β, WPConjunctive (m β) β Pred EPred] [Frame Pred] :
+    ⦃ fun s => ⌜s.1 = 0 ∧ s.2 = 7⌝ ⦄ (mkFreshPair : StateT AppState m (Nat × Nat))
+    ⦃ fun p s => ⌜p.1 = 0 ∧ s.2 = 7⌝ ⦄ := by
+  vcgen [mkFreshPair] frames
+  | mkFreshNat => fun s => ⌜s.2 = 7⌝
+  | mkFreshNat => fun s => ⌜s.2 = 7⌝
+  all_goals first | exact preserving_mkFreshNat (by grind) | grind
+
+/-! ## Complementary footprint: an operation that writes `snd` -/
+
+@[irreducible] def mkFreshSnd [Monad m] [MonadStateOf AppState m] : m Nat := do
+  let n ← Prod.snd <$> get
+  modify (fun s => (s.1, s.2 + 1))
+  pure n
+
+/-- Lossy spec: says nothing about `s.1`. -/
+@[spec]
+theorem mkFreshSnd_spec_lossy [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+    ⦃ fun s => ⌜s.2 = o⌝ ⦄ (mkFreshSnd : StateT AppState m Nat)
+    ⦃ fun r s => ⌜r = o ∧ s.2 = o + 1⌝ ⦄ := by
+  unfold mkFreshSnd
+  vcgen <;> simp_all
+
+/-- `mkFreshSnd` frames any `P` outside its `snd` footprint. -/
+theorem preserving_mkFreshSnd [Monad m] [Assertion Pred] [Assertion EPred]
+    [WPMonad m Pred EPred] [∀ β, WPConjunctive (m β) β Pred EPred] {P : AppState → Pred}
+    (h : ∀ s a, P { s with snd := a } = P s) :
+    WP.Preserving (mkFreshSnd : StateT AppState m Nat) (P ⊓ ·) := by
+  refine .of_meet (mkFreshSnd : StateT AppState m Nat) P (fun E => ?_)
+  intro s
+  unfold mkFreshSnd
+  simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,
+    StateT.run_map, bind_pure_comp, map_pure]
+  refine PartialOrder.rel_trans ?_
+    (WPMonad.pure_le_wp_pure (m := m) (s.snd, s.fst, s.snd + 1) (fun x => P x.snd) E)
+  show P s ⊑ P (s.fst, s.snd + 1)
+  rw [h s (s.snd + 1)]
+
+/-- Mirror of `recovers_snd`: frame the complementary (`fst`) footprint. -/
+theorem recovers_fst [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+    [∀ β, WPConjunctive (m β) β Pred EPred] [Frame Pred] :
+    ⦃ fun s => ⌜s.1 = 5 ∧ s.2 = 0⌝ ⦄ (mkFreshSnd : StateT AppState m Nat)
+    ⦃ fun r s => ⌜r = 0 ∧ s.1 = 5⌝ ⦄ := by
+  fail_if_success (vcgen <;> grind)
+  vcgen frames | mkFreshSnd => fun s => ⌜s.1 = 5⌝ <;>
+    first | exact preserving_mkFreshSnd (by grind) | grind
+
+/-! ## Two distinct framed operations in one program -/
+
+def mkFreshMixed [Monad m] [MonadStateOf AppState m] : m (Nat × Nat) := do
+  let a ← mkFreshNat
+  let b ← mkFreshSnd
+  pure (a, b)
+
+/-- `mkFreshNat` (writes `fst`) and `mkFreshSnd` (writes `snd`) are framed by different alternatives:
+each recovers the component the other op's lossy spec would drop. -/
+theorem recovers_both [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+    [∀ β, WPConjunctive (m β) β Pred EPred] [Frame Pred] :
+    ⦃ fun s => ⌜s.1 = 0 ∧ s.2 = 7⌝ ⦄ (mkFreshMixed : StateT AppState m (Nat × Nat))
+    ⦃ fun p s => ⌜s.1 = 1 ∧ s.2 = 8⌝ ⦄ := by
+  vcgen [mkFreshMixed] frames
+  | mkFreshNat => fun s => ⌜s.2 = 7⌝
+  | mkFreshSnd => fun s => ⌜s.1 = 1⌝
+  all_goals
+    first
+      | exact preserving_mkFreshNat (by grind)
+      | exact preserving_mkFreshSnd (by grind)
+      | grind
+
+/-! ## Named pattern variable referenced by the frame -/
+
+/-- `addFst k` writes `fst`, leaving `snd` untouched, and takes an explicit argument. -/
+@[irreducible] def addFst (k : Nat) [Monad m] [MonadStateOf AppState m] : m Nat := do
+  let n ← Prod.fst <$> get
+  modify (fun s => (s.1 + k, s.2))
+  pure n
+
+/-- Lossy spec: says nothing about `s.2`. -/
+@[spec]
+theorem addFst_spec_lossy [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
+    ⦃ fun s => ⌜s.1 = n⌝ ⦄ (addFst k : StateT AppState m Nat)
+    ⦃ fun r s => ⌜r = n ∧ s.1 = n + k⌝ ⦄ := by
+  unfold addFst
+  vcgen <;> simp_all
+
+/-- `addFst k` frames any `P` outside its `fst` footprint. -/
+theorem preserving_addFst [Monad m] [Assertion Pred] [Assertion EPred]
+    [WPMonad m Pred EPred] [∀ β, WPConjunctive (m β) β Pred EPred] {P : AppState → Pred} {k : Nat}
+    (h : ∀ s a, P { s with fst := a } = P s) :
+    WP.Preserving (addFst k : StateT AppState m Nat) (P ⊓ ·) := by
+  refine .of_meet (addFst k : StateT AppState m Nat) P (fun E => ?_)
+  intro s
+  unfold addFst
+  simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,
+    StateT.run_map, bind_pure_comp, map_pure]
+  refine PartialOrder.rel_trans ?_
+    (WPMonad.pure_le_wp_pure (m := m) (s.fst, s.fst + k, s.snd) (fun x => P x.snd) E)
+  show P s ⊑ P (s.fst + k, s.snd)
+  rw [h s (s.fst + k)]
+
+/-- The frame `fun s => ⌜s.2 = j⌝` references the matched argument `j`, so `elabFrame` introduces
+`let j := k` and the assignment is recovered in the postcondition. -/
+theorem recovers_with_arg [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+    [∀ β, WPConjunctive (m β) β Pred EPred] [Frame Pred] :
+    ⦃ fun s => ⌜s.1 = 0 ∧ s.2 = k⌝ ⦄ (addFst k : StateT AppState m Nat)
+    ⦃ fun r s => ⌜r = 0 ∧ s.2 = k⌝ ⦄ := by
+  fail_if_success (vcgen <;> grind)
+  vcgen frames | addFst j => fun s => ⌜s.2 = j⌝ <;>
+    first | exact preserving_addFst (by grind) | grind
+
+/-! ## Polymorphic state type at a fixed universe -/
+
+/-- Writes the `Nat` component of a `σ × Nat` state, for an abstract `σ : Type`. -/
+@[irreducible] def bumpSnd {σ : Type} [Monad m] : StateT (σ × Nat) m Nat := do
+  let n ← Prod.snd <$> get
+  modify (fun s => (s.1, s.2 + 1))
+  pure n
+
+/-- Lossy spec: says nothing about `s.1`. -/
+@[spec]
+theorem bumpSnd_spec_lossy {σ : Type} [Monad m] [Assertion Pred] [Assertion EPred]
+    [WPMonad m Pred EPred] :
+    ⦃ fun s => ⌜s.2 = o⌝ ⦄ (bumpSnd : StateT (σ × Nat) m Nat)
+    ⦃ fun r s => ⌜r = o ∧ s.2 = o + 1⌝ ⦄ := by
+  unfold bumpSnd
+  vcgen <;> simp_all
+
+/-- `bumpSnd` frames any `P` outside its `snd` footprint, over an abstract state `σ`. -/
+theorem preserving_bumpSnd {σ : Type} [Monad m] [Assertion Pred] [Assertion EPred]
+    [WPMonad m Pred EPred] [∀ β, WPConjunctive (m β) β Pred EPred] {P : σ × Nat → Pred}
+    (h : ∀ s a, P { s with snd := a } = P s) :
+    WP.Preserving (bumpSnd : StateT (σ × Nat) m Nat) (P ⊓ ·) := by
+  refine .of_meet (bumpSnd : StateT (σ × Nat) m Nat) P (fun E => ?_)
+  intro s
+  unfold bumpSnd
+  simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,
+    StateT.run_map, bind_pure_comp, map_pure]
+  refine PartialOrder.rel_trans ?_
+    (WPMonad.pure_le_wp_pure (m := m) (s.snd, s.fst, s.snd + 1) (fun x => P x.snd) E)
+  show P s ⊑ P (s.fst, s.snd + 1)
+  rw [h s (s.snd + 1)]
+
+/-- The frame recovers `s.1 = a` for an abstract `a : σ`, which the lossy spec dropped. -/
+theorem recovers_fst_poly {σ : Type} [Monad m] [Assertion Pred] [Assertion EPred]
+    [WPMonad m Pred EPred] [∀ β, WPConjunctive (m β) β Pred EPred] [Frame Pred] {a : σ} :
+    ⦃ fun s => ⌜s.1 = a ∧ s.2 = 0⌝ ⦄ (bumpSnd : StateT (σ × Nat) m Nat)
+    ⦃ fun r s => ⌜r = 0 ∧ s.1 = a⌝ ⦄ := by
+  fail_if_success (vcgen <;> grind)
+  vcgen frames | bumpSnd => fun s => ⌜s.1 = a⌝ <;>
+    first | exact preserving_bumpSnd (by grind) | grind
+
+/-! ## Unmatched frame alternatives are rejected -/
+
+-- A `frames` alternative whose program pattern matches no program in the goal is an error
+-- (`mkFreshSnd` does not occur in the program).
+/--
+error: `frames` alternative matched no program in the goal
+-/
+#guard_msgs in
+example [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+    [∀ β, WPConjunctive (m β) β Pred EPred] [Frame Pred] :
+    ⦃ fun s => ⌜s.1 = 0 ∧ s.2 = 7⌝ ⦄ (mkFreshNat : StateT AppState m Nat)
+    ⦃ fun r s => ⌜r = 0 ∧ s.2 = 7⌝ ⦄ := by
+  vcgen frames | mkFreshSnd => fun s => ⌜s.2 = 7⌝
+
+/-! ## The polymorphic frame lemmas instantiate at a concrete monad -/
+
+example : ⦃ fun s => ⌜s.1 = 0 ∧ s.2 = 7⌝ ⦄ (mkFreshNat : StateM AppState Nat)
+    ⦃ fun r s => ⌜r = 0 ∧ s.2 = 7⌝ ⦄ := recovers_snd

--- a/tests/elab/vcgenFrames.lean
+++ b/tests/elab/vcgenFrames.lean
@@ -55,6 +55,7 @@ theorem frames_mkFreshNat [Monad m] [Assertion Pred] [Assertion EPred]
     (h : ∀ s a, P { s with fst := a } = P s) :
     WP.Frames (mkFreshNat : StateT AppState m Nat) P := by
   refine .of_wp_conjunctive (fun E => ?_)
+  -- FIXME: use `vcgen [bumpSnd] with finish` here once the Pattern.match? level bug is fixed
   intro s
   unfold mkFreshNat
   simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,
@@ -113,6 +114,7 @@ theorem frames_mkFreshSnd [Monad m] [Assertion Pred] [Assertion EPred]
     (h : ∀ s a, P { s with snd := a } = P s) :
     WP.Frames (mkFreshSnd : StateT AppState m Nat) P := by
   refine .of_wp_conjunctive (fun E => ?_)
+  -- FIXME: use `vcgen [bumpSnd] with finish` here once the Pattern.match? level bug is fixed
   intro s
   unfold mkFreshSnd
   simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,
@@ -178,6 +180,7 @@ theorem frames_addFst [Monad m] [Assertion Pred] [Assertion EPred]
     (h : ∀ s a, P { s with fst := a } = P s) :
     WP.Frames (addFst k : StateT AppState m Nat) P := by
   refine .of_wp_conjunctive (fun E => ?_)
+  -- FIXME: use `vcgen [bumpSnd] with finish` here once the Pattern.match? level bug is fixed
   intro s
   unfold addFst
   simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,
@@ -227,6 +230,7 @@ theorem frames_bumpSnd {σ : Type} [Monad m] [Assertion Pred] [Assertion EPred]
     (h : ∀ s a, P { s with snd := a } = P s) :
     WP.Frames (bumpSnd : StateT (σ × Nat) m Nat) P := by
   refine .of_wp_conjunctive (fun E => ?_)
+  -- FIXME: use `vcgen [bumpSnd] with finish` here once the Pattern.match? level bug is fixed
   intro s
   unfold bumpSnd
   simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,

--- a/tests/elab/vcgenFrames.lean
+++ b/tests/elab/vcgenFrames.lean
@@ -17,10 +17,13 @@ A `frames` alternative attaches a state assertion `F` to a matched program whose
 *lossy* (drops a fact about state it does not touch). `vcgen` applies the framed spec, emits the
 frame precondition and the `Preserving` side goal, and recovers `F` in the postcondition.
 
-The base monad is polymorphic, so the only handle on `mkFreshNat` is its lossy spec. The
-`Preserving` side goal is discharged by `preserving_mkFreshNat`, which reduces it through
+The `Preserving` side goal is established by `preserving_mkFreshNat`, which reduces it through
 `WP.Preserving.of_meet` to a preservation triple `F ⊑ wp x (fun _ => F)` (using `WPConjunctive`
 for the monad); `mkFreshNat` writes only `fst`, so it preserves any `snd`-fact.
+
+The `recovers_*` proofs run at the `Id` base monad and register the `_Id` specializations of these
+lemmas with `grind`. With the monad ground, `grind` derives a usable E-matching pattern, so the
+discharge step `with finish` closes every VC, including the `Preserving` side goal.
 -/
 
 open Lean Order Meta Elab Tactic Sym Std Internal.Do
@@ -61,25 +64,34 @@ theorem preserving_mkFreshNat [Monad m] [Assertion Pred] [Assertion EPred]
   show P s ⊑ P (s.fst + 1, s.snd)
   rw [h s (s.fst + 1)]
 
+/-- `Id`-specialized `preserving_mkFreshNat`. With the base monad ground, `grind` can derive a
+usable pattern, so registering it lets `finish` discharge the preservation VC. -/
+theorem preserving_mkFreshNat_Id [Assertion Pred] [Assertion EPred]
+    [WPMonad Id Pred EPred] [∀ β, WPConjunctive (Id β) β Pred EPred] {P : AppState → Pred}
+    (h : ∀ s a, P { s with fst := a } = P s) :
+    WP.Preserving (mkFreshNat : StateT AppState Id Nat) P :=
+  preserving_mkFreshNat h
+
+grind_pattern preserving_mkFreshNat_Id => WP.Preserving (mkFreshNat : StateT AppState Id Nat) P
+
 /-- The frame recovers `s.2`, which the lossy spec dropped. The `fail_if_success` confirms the frame
 is doing the work: without it, `grind` cannot close the lost `s.2 = 7`. -/
-theorem recovers_snd [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
-    [∀ β, WPConjunctive (m β) β Pred EPred] [Frame Pred] :
-    ⦃ fun s => ⌜s.1 = 0 ∧ s.2 = 7⌝ ⦄ (mkFreshNat : StateT AppState m Nat)
+theorem recovers_snd [Assertion Pred] [Assertion EPred] [WPMonad Id Pred EPred]
+    [∀ β, WPConjunctive (Id β) β Pred EPred] [Frame Pred] :
+    ⦃ fun s => ⌜s.1 = 0 ∧ s.2 = 7⌝ ⦄ (mkFreshNat : StateT AppState Id Nat)
     ⦃ fun r s => ⌜r = 0 ∧ s.2 = 7⌝ ⦄ := by
   fail_if_success (vcgen <;> grind)
-  vcgen frames | mkFreshNat => fun s => ⌜s.2 = 7⌝ with try finish
-  exact preserving_mkFreshNat (by grind)
+  vcgen frames | mkFreshNat => fun s => ⌜s.2 = 7⌝ with finish
 
 /-- Two calls, two alternatives: consume-once frames each `mkFreshNat` exactly once. -/
-theorem recovers_snd_pair [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
-    [∀ β, WPConjunctive (m β) β Pred EPred] [Frame Pred] :
-    ⦃ fun s => ⌜s.1 = 0 ∧ s.2 = 7⌝ ⦄ (mkFreshPair : StateT AppState m (Nat × Nat))
+theorem recovers_snd_pair [Assertion Pred] [Assertion EPred] [WPMonad Id Pred EPred]
+    [∀ β, WPConjunctive (Id β) β Pred EPred] [Frame Pred] :
+    ⦃ fun s => ⌜s.1 = 0 ∧ s.2 = 7⌝ ⦄ (mkFreshPair : StateT AppState Id (Nat × Nat))
     ⦃ fun p s => ⌜p.1 = 0 ∧ s.2 = 7⌝ ⦄ := by
   vcgen [mkFreshPair] frames
   | mkFreshNat => fun s => ⌜s.2 = 7⌝
   | mkFreshNat => fun s => ⌜s.2 = 7⌝
-  all_goals first | exact preserving_mkFreshNat (by grind) | grind
+  with finish
 
 /-! ## Complementary footprint: an operation that writes `snd` -/
 
@@ -111,14 +123,22 @@ theorem preserving_mkFreshSnd [Monad m] [Assertion Pred] [Assertion EPred]
   show P s ⊑ P (s.fst, s.snd + 1)
   rw [h s (s.snd + 1)]
 
+/-- `Id`-specialized `preserving_mkFreshSnd`, registered so `finish` discharges the preservation VC. -/
+theorem preserving_mkFreshSnd_Id [Assertion Pred] [Assertion EPred]
+    [WPMonad Id Pred EPred] [∀ β, WPConjunctive (Id β) β Pred EPred] {P : AppState → Pred}
+    (h : ∀ s a, P { s with snd := a } = P s) :
+    WP.Preserving (mkFreshSnd : StateT AppState Id Nat) P :=
+  preserving_mkFreshSnd h
+
+grind_pattern preserving_mkFreshSnd_Id => WP.Preserving (mkFreshSnd : StateT AppState Id Nat) P
+
 /-- Mirror of `recovers_snd`: frame the complementary (`fst`) footprint. -/
-theorem recovers_fst [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
-    [∀ β, WPConjunctive (m β) β Pred EPred] [Frame Pred] :
-    ⦃ fun s => ⌜s.1 = 5 ∧ s.2 = 0⌝ ⦄ (mkFreshSnd : StateT AppState m Nat)
+theorem recovers_fst [Assertion Pred] [Assertion EPred] [WPMonad Id Pred EPred]
+    [∀ β, WPConjunctive (Id β) β Pred EPred] [Frame Pred] :
+    ⦃ fun s => ⌜s.1 = 5 ∧ s.2 = 0⌝ ⦄ (mkFreshSnd : StateT AppState Id Nat)
     ⦃ fun r s => ⌜r = 0 ∧ s.1 = 5⌝ ⦄ := by
   fail_if_success (vcgen <;> grind)
-  vcgen frames | mkFreshSnd => fun s => ⌜s.1 = 5⌝ <;>
-    first | exact preserving_mkFreshSnd (by grind) | grind
+  vcgen frames | mkFreshSnd => fun s => ⌜s.1 = 5⌝ with finish
 
 /-! ## Two distinct framed operations in one program -/
 
@@ -129,18 +149,14 @@ def mkFreshMixed [Monad m] [MonadStateOf AppState m] : m (Nat × Nat) := do
 
 /-- `mkFreshNat` (writes `fst`) and `mkFreshSnd` (writes `snd`) are framed by different alternatives:
 each recovers the component the other op's lossy spec would drop. -/
-theorem recovers_both [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
-    [∀ β, WPConjunctive (m β) β Pred EPred] [Frame Pred] :
-    ⦃ fun s => ⌜s.1 = 0 ∧ s.2 = 7⌝ ⦄ (mkFreshMixed : StateT AppState m (Nat × Nat))
+theorem recovers_both [Assertion Pred] [Assertion EPred] [WPMonad Id Pred EPred]
+    [∀ β, WPConjunctive (Id β) β Pred EPred] [Frame Pred] :
+    ⦃ fun s => ⌜s.1 = 0 ∧ s.2 = 7⌝ ⦄ (mkFreshMixed : StateT AppState Id (Nat × Nat))
     ⦃ fun p s => ⌜s.1 = 1 ∧ s.2 = 8⌝ ⦄ := by
   vcgen [mkFreshMixed] frames
   | mkFreshNat => fun s => ⌜s.2 = 7⌝
   | mkFreshSnd => fun s => ⌜s.1 = 1⌝
-  all_goals
-    first
-      | exact preserving_mkFreshNat (by grind)
-      | exact preserving_mkFreshSnd (by grind)
-      | grind
+  with finish
 
 /-! ## Named pattern variable referenced by the frame -/
 
@@ -173,15 +189,23 @@ theorem preserving_addFst [Monad m] [Assertion Pred] [Assertion EPred]
   show P s ⊑ P (s.fst + k, s.snd)
   rw [h s (s.fst + k)]
 
+/-- `Id`-specialized `preserving_addFst`, registered so `finish` discharges the preservation VC. -/
+theorem preserving_addFst_Id [Assertion Pred] [Assertion EPred]
+    [WPMonad Id Pred EPred] [∀ β, WPConjunctive (Id β) β Pred EPred] {P : AppState → Pred} {k : Nat}
+    (h : ∀ s a, P { s with fst := a } = P s) :
+    WP.Preserving (addFst k : StateT AppState Id Nat) P :=
+  preserving_addFst h
+
+grind_pattern preserving_addFst_Id => WP.Preserving (addFst k : StateT AppState Id Nat) P
+
 /-- The frame `fun s => ⌜s.2 = j⌝` references the matched argument `j`, so `elabFrame` introduces
 `let j := k` and the assignment is recovered in the postcondition. -/
-theorem recovers_with_arg [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
-    [∀ β, WPConjunctive (m β) β Pred EPred] [Frame Pred] :
-    ⦃ fun s => ⌜s.1 = 0 ∧ s.2 = k⌝ ⦄ (addFst k : StateT AppState m Nat)
+theorem recovers_with_arg [Assertion Pred] [Assertion EPred] [WPMonad Id Pred EPred]
+    [∀ β, WPConjunctive (Id β) β Pred EPred] [Frame Pred] :
+    ⦃ fun s => ⌜s.1 = 0 ∧ s.2 = k⌝ ⦄ (addFst k : StateT AppState Id Nat)
     ⦃ fun r s => ⌜r = 0 ∧ s.2 = k⌝ ⦄ := by
   fail_if_success (vcgen <;> grind)
-  vcgen frames | addFst j => fun s => ⌜s.2 = j⌝ <;>
-    first | exact preserving_addFst (by grind) | grind
+  vcgen frames | addFst j => fun s => ⌜s.2 = j⌝ with finish
 
 /-! ## Polymorphic state type at a fixed universe -/
 
@@ -215,14 +239,23 @@ theorem preserving_bumpSnd {σ : Type} [Monad m] [Assertion Pred] [Assertion EPr
   show P s ⊑ P (s.fst, s.snd + 1)
   rw [h s (s.snd + 1)]
 
+/-- `Id`-specialized `preserving_bumpSnd` over an abstract state `σ`, registered so `finish`
+discharges the preservation VC. -/
+theorem preserving_bumpSnd_Id {σ : Type} [Assertion Pred] [Assertion EPred]
+    [WPMonad Id Pred EPred] [∀ β, WPConjunctive (Id β) β Pred EPred] {P : σ × Nat → Pred}
+    (h : ∀ s a, P { s with snd := a } = P s) :
+    WP.Preserving (bumpSnd : StateT (σ × Nat) Id Nat) P :=
+  preserving_bumpSnd h
+
+grind_pattern preserving_bumpSnd_Id => WP.Preserving (bumpSnd : StateT (σ × Nat) Id Nat) P
+
 /-- The frame recovers `s.1 = a` for an abstract `a : σ`, which the lossy spec dropped. -/
-theorem recovers_fst_poly {σ : Type} [Monad m] [Assertion Pred] [Assertion EPred]
-    [WPMonad m Pred EPred] [∀ β, WPConjunctive (m β) β Pred EPred] [Frame Pred] {a : σ} :
-    ⦃ fun s => ⌜s.1 = a ∧ s.2 = 0⌝ ⦄ (bumpSnd : StateT (σ × Nat) m Nat)
+theorem recovers_fst_poly {σ : Type} [Assertion Pred] [Assertion EPred]
+    [WPMonad Id Pred EPred] [∀ β, WPConjunctive (Id β) β Pred EPred] [Frame Pred] {a : σ} :
+    ⦃ fun s => ⌜s.1 = a ∧ s.2 = 0⌝ ⦄ (bumpSnd : StateT (σ × Nat) Id Nat)
     ⦃ fun r s => ⌜r = 0 ∧ s.1 = a⌝ ⦄ := by
   fail_if_success (vcgen <;> grind)
-  vcgen frames | bumpSnd => fun s => ⌜s.1 = a⌝ <;>
-    first | exact preserving_bumpSnd (by grind) | grind
+  vcgen frames | bumpSnd => fun s => ⌜s.1 = a⌝ with finish
 
 /-! ## Unmatched frame alternatives are rejected -/
 


### PR DESCRIPTION
This PR adds a `frames` clause to the `vcgen` tactic that attaches a state assertion (a frame) to a matched program, so facts about state the program leaves untouched survive a call whose registered spec drops them.

A `frames` alternative `| prog_pattern => F` applies the program's spec under the frame `F`: `vcgen` emits the frame precondition `pre ⊑ F`, recovers `F` in the postcondition, and emits a `WP.Frames prog F` side goal stating that running `prog` preserves `F`. Program patterns reuse the `until`-pattern machinery, and each alternative applies at most once (first match wins).

The frame condition is proved by `WP.Frames.of_wp_conjunctive`, which reduces it to a preservation triple `F ⊑ wp x (fun _ => F)` given the new `WPConjunctive` healthiness class.
