### PR TITLE
fix: make Hoare `Triple` universe-polymorphic in its assertion type

### DIFF
--- a/src/Std/Internal/Do/Order/Basic.lean
+++ b/src/Std/Internal/Do/Order/Basic.lean
@@ -433,15 +433,15 @@ theorem ofProp_le [CompleteLattice l] (p : Prop) (rhs : l) :
   (CompleteLattice.ofProp_intro p rhs).mpr
 
 /-- Entailment between functions is pointwise. -/
-theorem le_iff_forall_le {σ α : Type u} [PartialOrder α] {f g : σ → α} :
+theorem le_iff_forall_le {σ : Type u} {α : Type v} [PartialOrder α] {f g : σ → α} :
     (f ⊑ g) ↔ (∀ s, f s ⊑ g s) := Iff.rfl
 
 /-- Entailment between functions follows from pointwise entailment. -/
-theorem le_of_forall_le {σ α : Type u} [PartialOrder α] {f g : σ → α} :
+theorem le_of_forall_le {σ : Type u} {α : Type v} [PartialOrder α] {f g : σ → α} :
     (∀ s, f s ⊑ g s) → f ⊑ g := le_iff_forall_le.mpr
 
 /-- `⊤ ⊑ g` for a function `g` follows from pointwise `⊤ ⊑ g s`. -/
-theorem top_le_of_forall_top_le {σ α : Type u} [CompleteLattice α] {g : σ → α} :
+theorem top_le_of_forall_top_le {σ : Type u} {α : Type v} [CompleteLattice α] {g : σ → α} :
     (∀ s, (⊤ : α) ⊑ g s) → (⊤ : σ → α) ⊑ g := by
   intro h s
   rw [top_apply]

--- a/src/Std/Internal/Do/Triple/Basic.lean
+++ b/src/Std/Internal/Do/Triple/Basic.lean
@@ -27,13 +27,13 @@ It is thus defined in terms of an instance `WPMonad m Pred EPred`.
 
 namespace Std.Internal.Do
 
-universe u v
-variable {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+universe u v w w'
+variable {Pred : Type w} {EPred : Type w'}
 
 /-- A Hoare triple for reasoning about programs. A Hoare triple `Triple x pre post epost`
 is a *specification* for `x`: if assertion `pre` holds before `x`, then postcondition `post` holds
 after running `x` (and `epost` handles any errors). -/
-structure Triple {Prog : Type v} {Value : Type u} [Assertion Pred] [Assertion EPred] (x : Prog) [WP Prog Value Pred EPred] (pre : Pred) (post : Value → Pred) (epost : EPred) : Prop where
+structure Triple {Prog : Type u} {Value : Type v} [Assertion Pred] [Assertion EPred] (x : Prog) [WP Prog Value Pred EPred] (pre : Pred) (post : Value → Pred) (epost : EPred) : Prop where
   /-- Construct a triple from a weakest precondition entailment. -/
   intro ::
   /-- The weakest precondition entailment witnessing the triple. -/
@@ -101,7 +101,7 @@ meta def unexpandTriple : Lean.PrettyPrinter.Unexpander
 
 namespace Triple
 
-variable {Prog : Type v} {Value : Type u} [Assertion Pred] [Assertion EPred]
+variable {Prog : Type u} {Value : Type v} [Assertion Pred] [Assertion EPred]
   [WP Prog Value Pred EPred]
 
 theorem iff {x : Prog} {pre : Pred} {post : Value → Pred} {epost : EPred} :
@@ -133,7 +133,7 @@ theorem entails_wp_of_post {x : Prog} {pre : Pred} {post post' : Value → Pred}
   iff_conseq.mp h _ _ PartialOrder.rel_refl hpost
 
 section Monad
-variable [Monad m] [WPMonad m Pred EPred]
+variable {m : Type v → Type u} [Monad m] [WPMonad m Pred EPred]
 
 theorem pure (a : α) (h : pre ⊑ post a) :
     Triple (pure (f := m) a) pre post epost :=

--- a/src/Std/Internal/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Internal/Do/Triple/SpecLemmas.lean
@@ -45,7 +45,7 @@ namespace Std.Internal.Do
 
 open Lean.Order
 
-universe u v
+universe u v w w'
 variable {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
 
 /-! # `Monad` -/
@@ -260,6 +260,9 @@ theorem Spec.adapt_ReaderT (f : ρ → ρ') (x : ReaderT ρ' m α) (post : α �
 
 /-! # `StateT` -/
 
+section StateTSpec
+variable {Pred : Type w} {EPred : Type w'} [Assertion Pred] [Assertion EPred]
+  [WPMonad m Pred EPred] {epost : EPred}
 
 @[spec]
 theorem Spec.get_StateT (post : σ → σ → Pred) :
@@ -286,6 +289,8 @@ theorem Spec.modifyGet_StateT (f : σ → α × σ) (post : α → σ → Pred) 
   Triple.intro (by intro s; simpa [MonadStateOf.modifyGet] using!
     (WPMonad.pure_le_wp_pure (m := m) (x := f s)
       (post := fun x => post x.fst x.snd) (epost := epost)))
+
+end StateTSpec
 
 /-! # Lifting `MonadStateOf` -/
 

--- a/src/Std/Internal/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Internal/Do/Triple/SpecLemmas.lean
@@ -52,6 +52,10 @@ variable {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
 
 variable [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
 
+section MonadSpec
+variable {Pred : Type w} {EPred : Type w'} [Assertion Pred] [Assertion EPred]
+  [WPMonad m Pred EPred]
+
 @[spec]
 theorem Spec.pure (a : α) :
     Triple (Pure.pure (f := m) a) (post a) post epost :=
@@ -72,6 +76,8 @@ theorem Spec.map (f : α → β) (x : m α) :
 theorem Spec.seq (x : m (α → β)) (y : m α) :
     Triple (x <*> y) (wp x (fun f => wp y (fun a => post (f a)) epost) epost) post epost :=
   Triple.seq x y (Triple.intro PartialOrder.rel_refl)
+
+end MonadSpec
 
 /-! # `MonadLift` -/
 
@@ -609,16 +615,16 @@ namespace Std.Internal.Do
 
 open Lean.Order
 
-universe u₁ u₂ v
+universe u₁ u₂ v uₚ uₑ
 
-variable {α : Type u₁} {β : Type (max u₁ u₂)} {m : Type (max u₁ u₂) → Type v} {Pred : Type (max u₁ u₂)} {EPred : Type (max u₁ u₂)}
+variable {α : Type u₁} {β : Type (max u₁ u₂)} {m : Type (max u₁ u₂) → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
 variable [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
 
 /-- The type of loop invariants used by the specifications of `for ... in ...` loops.
 A loop invariant maps the iteration cursor and accumulator state to an assertion.
 The exception postcondition is specified separately as the spec's `epost` parameter. -/
 @[spec_invariant_type, simp, grind =]
-def Invariant {α : Type u₁} (xs : List α) (β : Type u₂) (Pred : Type (max u₁ u₂)) :=
+def Invariant {α : Type u₁} (xs : List α) (β : Type u₂) (Pred : Type uₚ) :=
   List.Cursor xs → β → Pred
 
 /-- An invariant combinator for loops with early return, for the new `do` elaborator which
@@ -770,7 +776,7 @@ theorem Spec.foldlM_list_const_inv
 
 
 @[spec]
-theorem Spec.forIn'_range {β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn'_range {β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {xs : Std.Legacy.Range} {init : β} {f : (a : Nat) → a ∈ xs → β → m (ForInStep β)}
     (inv : Invariant xs.toList β Pred)
@@ -793,7 +799,7 @@ theorem Spec.forIn'_range {β : Type u} {m : Type u → Type v} {Pred : Type u} 
 
 
 @[spec]
-theorem Spec.forIn_range {β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn_range {β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {xs : Std.Legacy.Range} {init : β} {f : Nat → β → m (ForInStep β)}
     (inv : Invariant xs.toList β Pred)
@@ -817,7 +823,7 @@ theorem Spec.forIn_range {β : Type u} {m : Type u → Type v} {Pred : Type u} {
 open Std Std.PRange in
 
 @[spec]
-theorem Spec.forIn'_rcc {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn'_rcc {α β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
@@ -843,7 +849,7 @@ theorem Spec.forIn'_rcc {α β : Type u} {m : Type u → Type v} {Pred : Type u}
 open Std Std.PRange in
 
 @[spec]
-theorem Spec.forIn_rcc {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn_rcc {α β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
@@ -869,7 +875,7 @@ theorem Spec.forIn_rcc {α β : Type u} {m : Type u → Type v} {Pred : Type u} 
 open Std Std.PRange in
 
 @[spec]
-theorem Spec.forIn'_rco {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn'_rco {α β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LE α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLT α]
@@ -895,7 +901,7 @@ theorem Spec.forIn'_rco {α β : Type u} {m : Type u → Type v} {Pred : Type u}
 open Std Std.PRange in
 
 @[spec]
-theorem Spec.forIn_rco {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn_rco {α β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LE α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLT α]
@@ -921,7 +927,7 @@ theorem Spec.forIn_rco {α β : Type u} {m : Type u → Type v} {Pred : Type u} 
 open Std Std.PRange in
 
 @[spec]
-theorem Spec.forIn'_rci {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn'_rci {α β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LE α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
@@ -947,7 +953,7 @@ theorem Spec.forIn'_rci {α β : Type u} {m : Type u → Type v} {Pred : Type u}
 open Std Std.PRange in
 
 @[spec]
-theorem Spec.forIn_rci {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn_rci {α β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LE α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
@@ -973,7 +979,7 @@ theorem Spec.forIn_rci {α β : Type u} {m : Type u → Type v} {Pred : Type u} 
 open Std Std.PRange in
 
 @[spec]
-theorem Spec.forIn'_roc {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn'_roc {α β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LE α] [DecidableLE α] [LT α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLT α]
@@ -998,7 +1004,7 @@ theorem Spec.forIn'_roc {α β : Type u} {m : Type u → Type v} {Pred : Type u}
 
 open Std Std.PRange in
 
-theorem Spec.forIn_roc {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn_roc {α β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LE α] [DecidableLE α] [LT α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLT α]
@@ -1024,7 +1030,7 @@ theorem Spec.forIn_roc {α β : Type u} {m : Type u → Type v} {Pred : Type u} 
 open Std Std.PRange in
 
 @[spec]
-theorem Spec.forIn'_roo {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn'_roo {α β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
@@ -1050,7 +1056,7 @@ theorem Spec.forIn'_roo {α β : Type u} {m : Type u → Type v} {Pred : Type u}
 open Std Std.PRange in
 
 @[spec]
-theorem Spec.forIn_roo {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn_roo {α β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
@@ -1076,7 +1082,7 @@ theorem Spec.forIn_roo {α β : Type u} {m : Type u → Type v} {Pred : Type u} 
 open Std Std.PRange in
 
 @[spec]
-theorem Spec.forIn'_roi {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn'_roi {α β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
@@ -1102,7 +1108,7 @@ theorem Spec.forIn'_roi {α β : Type u} {m : Type u → Type v} {Pred : Type u}
 open Std Std.PRange in
 
 @[spec]
-theorem Spec.forIn_roi {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn_roi {α β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
@@ -1128,7 +1134,7 @@ theorem Spec.forIn_roi {α β : Type u} {m : Type u → Type v} {Pred : Type u} 
 open Std Std.PRange in
 
 @[spec]
-theorem Spec.forIn'_ric {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn'_ric {α β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Least? α] [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α] [LawfulUpwardEnumerableLE α]
@@ -1154,7 +1160,7 @@ theorem Spec.forIn'_ric {α β : Type u} {m : Type u → Type v} {Pred : Type u}
 open Std Std.PRange in
 
 @[spec]
-theorem Spec.forIn_ric {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn_ric {α β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Least? α] [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α] [LawfulUpwardEnumerableLE α]
@@ -1180,7 +1186,7 @@ theorem Spec.forIn_ric {α β : Type u} {m : Type u → Type v} {Pred : Type u} 
 open Std Std.PRange in
 
 @[spec]
-theorem Spec.forIn'_rio {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn'_rio {α β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Least? α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α] [LawfulUpwardEnumerableLT α]
@@ -1206,7 +1212,7 @@ theorem Spec.forIn'_rio {α β : Type u} {m : Type u → Type v} {Pred : Type u}
 open Std Std.PRange in
 
 @[spec]
-theorem Spec.forIn_rio {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn_rio {α β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Least? α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α] [LawfulUpwardEnumerableLT α]
@@ -1232,7 +1238,7 @@ theorem Spec.forIn_rio {α β : Type u} {m : Type u → Type v} {Pred : Type u} 
 open Std Std.PRange in
 
 @[spec]
-theorem Spec.forIn'_rii {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn'_rii {α β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Least? α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α]
@@ -1258,7 +1264,7 @@ theorem Spec.forIn'_rii {α β : Type u} {m : Type u → Type v} {Pred : Type u}
 open Std Std.PRange in
 
 @[spec]
-theorem Spec.forIn_rii {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn_rii {α β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Least? α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α]
@@ -1284,7 +1290,7 @@ theorem Spec.forIn_rii {α β : Type u} {m : Type u → Type v} {Pred : Type u} 
 open Std Std.Iterators in
 
 @[spec]
-theorem Spec.forIn_slice {δ : Type u} {m : Type u → Type w} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn_slice {δ : Type u} {m : Type u → Type w} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {γ : Type u'} {α β : Type u}
     [ToIterator (Slice γ) Id α β]
@@ -1314,7 +1320,7 @@ open Std Std.Iterators
 
 
 @[spec low]
-theorem Spec.forIn_iter {α β γ : Type u} {m : Type u → Type w} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn_iter {α β γ : Type u} {m : Type u → Type w} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Iterator α Id β] [Finite α Id] [IteratorLoop α Id m] [LawfulIteratorLoop α Id m]
     {init : γ} {f : β → γ → m (ForInStep γ)}
@@ -1336,7 +1342,7 @@ theorem Spec.forIn_iter {α β γ : Type u} {m : Type u → Type w} {Pred : Type
 
 
 @[spec low]
-theorem Spec.forIn_iterM_id {α β γ : Type u} {m : Type u → Type w} {Pred : Type u} {EPred : Type u}
+theorem Spec.forIn_iterM_id {α β γ : Type u} {m : Type u → Type w} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Iterator α Id β] [Finite α Id] [IteratorLoop α Id m] [LawfulIteratorLoop α Id m]
     {init : γ} {f : β → γ → m (ForInStep γ)}
@@ -1360,7 +1366,7 @@ theorem Spec.forIn_iterM_id {α β γ : Type u} {m : Type u → Type w} {Pred : 
 
 
 @[spec low]
-theorem Spec.foldM_iter {α β γ : Type u} {m : Type u → Type w} {Pred : Type u} {EPred : Type u}
+theorem Spec.foldM_iter {α β γ : Type u} {m : Type u → Type w} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Iterator α Id β] [Finite α Id] [IteratorLoop α Id m] [LawfulIteratorLoop α Id m]
     {it : Iter (α := α) β}
@@ -1380,7 +1386,7 @@ theorem Spec.foldM_iter {α β γ : Type u} {m : Type u → Type w} {Pred : Type
 
 
 @[spec low]
-theorem Spec.foldM_iterM_id {α β γ : Type u} {m : Type u → Type w} {Pred : Type u} {EPred : Type u}
+theorem Spec.foldM_iterM_id {α β γ : Type u} {m : Type u → Type w} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [Iterator α Id β] [Finite α Id] [IteratorLoop α Id m] [LawfulIteratorLoop α Id m]
     {it : IterM (α := α) Id β}
@@ -1402,7 +1408,7 @@ theorem Spec.foldM_iterM_id {α β γ : Type u} {m : Type u → Type w} {Pred : 
 @[spec]
 theorem Spec.IterM.forIn_filterMapWithPostcondition {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
@@ -1422,7 +1428,7 @@ theorem Spec.IterM.forIn_filterMapWithPostcondition {α β β₂ γ : Type w}
 @[spec]
 theorem Spec.IterM.forIn_filterMapM {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -1443,7 +1449,7 @@ theorem Spec.IterM.forIn_filterMapM {α β β₂ γ : Type w}
 @[spec]
 theorem Spec.IterM.forIn_filterMap {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [LawfulMonad m] [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m]
@@ -1461,7 +1467,7 @@ theorem Spec.IterM.forIn_filterMap {α β β₂ γ : Type w}
 @[spec]
 theorem Spec.IterM.forIn_mapWithPostcondition {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
@@ -1478,7 +1484,7 @@ theorem Spec.IterM.forIn_mapWithPostcondition {α β β₂ γ : Type w}
 @[spec]
 theorem Spec.IterM.forIn_mapM {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -1496,7 +1502,7 @@ theorem Spec.IterM.forIn_mapM {α β β₂ γ : Type w}
 @[spec]
 theorem Spec.IterM.forIn_map {α β β₂ γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [LawfulMonad m] [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorLoop α m n] [LawfulIteratorLoop α m n]
@@ -1510,7 +1516,7 @@ theorem Spec.IterM.forIn_map {α β β₂ γ : Type w}
 @[spec]
 theorem Spec.IterM.forIn_filterWithPostcondition {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
     [Iterator α m β] [Finite α m]
@@ -1527,7 +1533,7 @@ theorem Spec.IterM.forIn_filterWithPostcondition {α β γ : Type w}
 @[spec]
 theorem Spec.IterM.forIn_filterM {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
     [MonadLiftT m n] [LawfulMonadLiftT m n] [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -1545,7 +1551,7 @@ theorem Spec.IterM.forIn_filterM {α β γ : Type w}
 @[spec]
 theorem Spec.IterM.forIn_filter {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [LawfulMonad m] [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
     [Iterator α m β] [Finite α m] [IteratorLoop α m n] [LawfulIteratorLoop α m n]
@@ -1559,7 +1565,7 @@ theorem Spec.IterM.forIn_filter {α β γ : Type w}
 @[spec]
 theorem Spec.IterM.foldM_filterMapWithPostcondition {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α m β] [Finite α m]
     [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
@@ -1579,7 +1585,7 @@ theorem Spec.IterM.foldM_filterMapWithPostcondition {α β γ δ : Type w}
 @[spec]
 theorem Spec.IterM.foldM_filterMapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
@@ -1601,7 +1607,7 @@ theorem Spec.IterM.foldM_filterMapM {α β γ δ : Type w}
 @[spec]
 theorem Spec.IterM.foldM_mapWithPostcondition {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α m β] [Finite α m]
     [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
@@ -1619,7 +1625,7 @@ theorem Spec.IterM.foldM_mapWithPostcondition {α β γ δ : Type w}
 @[spec]
 theorem Spec.IterM.foldM_mapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
@@ -1639,7 +1645,7 @@ theorem Spec.IterM.foldM_mapM {α β γ δ : Type w}
 @[spec]
 theorem Spec.IterM.foldM_filterWithPostcondition {α β δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α m β] [Finite α m]
     [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α m n] [IteratorLoop α m o]
@@ -1657,7 +1663,7 @@ theorem Spec.IterM.foldM_filterWithPostcondition {α β δ : Type w}
 @[spec]
 theorem Spec.IterM.foldM_filterM {α β δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''} {o : Type w → Type w'''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
@@ -1677,7 +1683,7 @@ theorem Spec.IterM.foldM_filterM {α β δ : Type w}
 @[spec]
 theorem Spec.IterM.foldM_filterMap {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n]
     [LawfulIteratorLoop α m n]
@@ -1694,7 +1700,7 @@ theorem Spec.IterM.foldM_filterMap {α β γ δ : Type w}
 @[spec]
 theorem Spec.IterM.foldM_map {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n] [LawfulIteratorLoop α m n]
     [MonadLiftT m n] [LawfulMonadLiftT m n]
@@ -1708,7 +1714,7 @@ theorem Spec.IterM.foldM_map {α β γ δ : Type w}
 @[spec]
 theorem Spec.IterM.foldM_filter {α β δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α m β] [Finite α m] [Monad m] [Monad n] [LawfulMonad m] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α m n]
     [LawfulIteratorLoop α m n]
@@ -1723,7 +1729,7 @@ theorem Spec.IterM.foldM_filter {α β δ : Type w}
 @[spec]
 theorem Spec.IterM.fold_filterMapWithPostcondition {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
     [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
@@ -1741,7 +1747,7 @@ theorem Spec.IterM.fold_filterMapWithPostcondition {α β γ δ : Type w}
 @[spec]
 theorem Spec.IterM.fold_filterMapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
     [Monad n] [MonadAttach n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
@@ -1759,7 +1765,7 @@ theorem Spec.IterM.fold_filterMapM {α β γ δ : Type w}
 @[spec]
 theorem Spec.IterM.fold_mapWithPostcondition {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
     [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
@@ -1775,7 +1781,7 @@ theorem Spec.IterM.fold_mapWithPostcondition {α β γ δ : Type w}
 @[spec]
 theorem Spec.IterM.fold_mapM {α β γ δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
     [Monad n] [MonadAttach n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
@@ -1791,7 +1797,7 @@ theorem Spec.IterM.fold_mapM {α β γ δ : Type w}
 @[spec]
 theorem Spec.IterM.fold_filterWithPostcondition {α β δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
     [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
@@ -1807,7 +1813,7 @@ theorem Spec.IterM.fold_filterWithPostcondition {α β δ : Type w}
 @[spec]
 theorem Spec.IterM.fold_filterM {α β δ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α m β] [Finite α m]
     [Monad m] [LawfulMonad m]
     [Monad n] [MonadAttach n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
@@ -1823,7 +1829,7 @@ theorem Spec.IterM.fold_filterM {α β δ : Type w}
 @[spec]
 theorem Spec.IterM.fold_filterMap {α β γ δ : Type w}
     {m : Type w → Type w'}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α m β] [Finite α m] [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [IteratorLoop α m m] [LawfulIteratorLoop α m m]
     {f : β → Option γ} {g : δ → γ → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1839,7 +1845,7 @@ theorem Spec.IterM.fold_filterMap {α β γ δ : Type w}
 @[spec]
 theorem Spec.IterM.fold_map {α β γ δ : Type w}
     {m : Type w → Type w'}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α m β] [Finite α m] [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [IteratorLoop α m m] [LawfulIteratorLoop α m m]
     {f : β → γ} {g : δ → γ → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1852,7 +1858,7 @@ theorem Spec.IterM.fold_map {α β γ δ : Type w}
 @[spec]
 theorem Spec.IterM.fold_filter {α β δ : Type w}
     {m : Type w → Type w'}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α m β] [Finite α m] [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     [IteratorLoop α m m] [LawfulIteratorLoop α m m]
     {f : β → Bool} {g : δ → β → δ} {init : δ} {it : IterM (α := α) m β}
@@ -1865,7 +1871,7 @@ theorem Spec.IterM.fold_filter {α β δ : Type w}
 @[spec]
 theorem Spec.Iter.forIn_filterMapWithPostcondition {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β]
     [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadLiftT n o] [LawfulMonadLiftT n o] [Finite α Id]
@@ -1883,7 +1889,7 @@ theorem Spec.Iter.forIn_filterMapWithPostcondition {α β β₂ γ : Type w}
 @[spec]
 theorem Spec.Iter.forIn_filterMapM {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β]
     [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
@@ -1902,7 +1908,7 @@ theorem Spec.Iter.forIn_filterMapM {α β β₂ γ : Type w}
 @[spec]
 theorem Spec.Iter.forIn_filterMap {α β β₂ γ : Type w}
     {n : Type w → Type w'}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β]
     [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred] [Finite α Id]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
@@ -1919,7 +1925,7 @@ theorem Spec.Iter.forIn_filterMap {α β β₂ γ : Type w}
 @[spec]
 theorem Spec.Iter.forIn_mapWithPostcondition {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β]
     [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadLiftT n o] [LawfulMonadLiftT n o] [Finite α Id]
@@ -1934,7 +1940,7 @@ theorem Spec.Iter.forIn_mapWithPostcondition {α β β₂ γ : Type w}
 @[spec]
 theorem Spec.Iter.forIn_mapM {α β β₂ γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β]
     [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
@@ -1951,7 +1957,7 @@ theorem Spec.Iter.forIn_mapM {α β β₂ γ : Type w}
 @[spec]
 theorem Spec.Iter.forIn_map {α β β₂ γ : Type w}
     {n : Type w → Type w'}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β]
     [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [Finite α Id] [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
@@ -1965,7 +1971,7 @@ theorem Spec.Iter.forIn_map {α β β₂ γ : Type w}
 @[spec]
 theorem Spec.Iter.forIn_filterWithPostcondition {α β γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β]
     [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadLiftT n o] [LawfulMonadLiftT n o]
@@ -1980,7 +1986,7 @@ theorem Spec.Iter.forIn_filterWithPostcondition {α β γ : Type w}
 @[spec]
 theorem Spec.Iter.forIn_filterM {α β γ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β]
     [Monad n] [LawfulMonad n] [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [MonadAttach n] [WeaklyLawfulMonadAttach n]
@@ -1996,7 +2002,7 @@ theorem Spec.Iter.forIn_filterM {α β γ : Type w}
 @[spec]
 theorem Spec.Iter.forIn_filter {α β γ : Type w}
     {n : Type w → Type w'}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β]
     [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [Finite α Id] [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
@@ -2010,7 +2016,7 @@ theorem Spec.Iter.forIn_filter {α β γ : Type w}
 @[spec]
 theorem Spec.Iter.foldM_filterMapWithPostcondition {α β γ δ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [Monad o] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
@@ -2028,7 +2034,7 @@ theorem Spec.Iter.foldM_filterMapWithPostcondition {α β γ δ : Type w}
 @[spec]
 theorem Spec.Iter.foldM_filterMapM {α β γ δ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
     [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
@@ -2047,7 +2053,7 @@ theorem Spec.Iter.foldM_filterMapM {α β γ δ : Type w}
 @[spec]
 theorem Spec.Iter.foldM_mapWithPostcondition {α β γ δ : Type w}
     {m : Type w → Type w'''} {n : Type w → Type w'} {o : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β] [Finite α Id]
     [Monad m] [Monad n] [Monad o] [LawfulMonad m] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
@@ -2063,7 +2069,7 @@ theorem Spec.Iter.foldM_mapWithPostcondition {α β γ δ : Type w}
 @[spec]
 theorem Spec.Iter.foldM_mapM {α β γ δ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
     [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
@@ -2080,7 +2086,7 @@ theorem Spec.Iter.foldM_mapM {α β γ δ : Type w}
 @[spec]
 theorem Spec.Iter.foldM_filterWithPostcondition {α β δ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [Monad o] [LawfulMonad n] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
     [IteratorLoop α Id n] [IteratorLoop α Id o]
@@ -2096,7 +2102,7 @@ theorem Spec.Iter.foldM_filterWithPostcondition {α β δ : Type w}
 @[spec]
 theorem Spec.Iter.foldM_filterM {α β δ : Type w}
     {n : Type w → Type w'} {o : Type w → Type w''}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [MonadAttach n] [LawfulMonad n] [WeaklyLawfulMonadAttach n]
     [Monad o] [Assertion Pred] [Assertion EPred] [WPMonad o Pred EPred]
@@ -2113,7 +2119,7 @@ theorem Spec.Iter.foldM_filterM {α β δ : Type w}
 @[spec]
 theorem Spec.Iter.foldM_filterMap {α β γ δ : Type w}
     {n : Type w → Type w'}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β] [Finite α Id] [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n]
     [LawfulIteratorLoop α Id n]
@@ -2129,7 +2135,7 @@ theorem Spec.Iter.foldM_filterMap {α β γ δ : Type w}
 @[spec]
 theorem Spec.Iter.foldM_map {α β γ δ : Type w}
     {n : Type w → Type w'}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β] [Finite α Id] [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → γ} {g : δ → γ → n δ} {init : δ} {it : Iter (α := α) β}
@@ -2142,7 +2148,7 @@ theorem Spec.Iter.foldM_map {α β γ δ : Type w}
 @[spec]
 theorem Spec.Iter.foldM_filter {α β δ : Type w}
     {n : Type w → Type w'}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β] [Finite α Id] [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
     {f : β → Bool} {g : δ → β → n δ} {init : δ} {it : Iter (α := α) β}
@@ -2155,7 +2161,7 @@ theorem Spec.Iter.foldM_filter {α β δ : Type w}
 @[spec]
 theorem Spec.Iter.fold_filterMapWithPostcondition {α β γ δ : Type w}
     {n : Type w → Type w'}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
@@ -2171,7 +2177,7 @@ theorem Spec.Iter.fold_filterMapWithPostcondition {α β γ δ : Type w}
 @[spec]
 theorem Spec.Iter.fold_filterMapM {α β γ δ : Type w}
     {n : Type w → Type w'}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [MonadAttach n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
@@ -2187,7 +2193,7 @@ theorem Spec.Iter.fold_filterMapM {α β γ δ : Type w}
 @[spec]
 theorem Spec.Iter.fold_mapWithPostcondition {α β γ δ : Type w}
     {n : Type w → Type w'}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
@@ -2201,7 +2207,7 @@ theorem Spec.Iter.fold_mapWithPostcondition {α β γ δ : Type w}
 @[spec]
 theorem Spec.Iter.fold_mapM {α β γ δ : Type w}
     {n : Type w → Type w'}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [MonadAttach n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
@@ -2215,7 +2221,7 @@ theorem Spec.Iter.fold_mapM {α β γ δ : Type w}
 @[spec]
 theorem Spec.Iter.fold_filterWithPostcondition {α β δ : Type w}
     {n : Type w → Type w'}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
@@ -2229,7 +2235,7 @@ theorem Spec.Iter.fold_filterWithPostcondition {α β δ : Type w}
 @[spec]
 theorem Spec.Iter.fold_filterM {α β δ : Type w}
     {n : Type w → Type w'}
-    {Pred : Type w} {EPred : Type w}
+    {Pred : Type uₚ} {EPred : Type uₑ}
     [Iterator α Id β] [Finite α Id]
     [Monad n] [MonadAttach n] [WeaklyLawfulMonadAttach n] [Assertion Pred] [Assertion EPred] [WPMonad n Pred EPred]
     [IteratorLoop α Id n] [LawfulIteratorLoop α Id n]
@@ -2306,14 +2312,14 @@ The type of loop invariants used by the specifications of `for ... in ...` loops
 A loop invariant is a function mapping the current position and state to a lattice element.
 -/
 @[spec_invariant_type, simp, grind =]
-def StringInvariant (s : String) (β : Type u) (Pred : Type u) :=
+def StringInvariant (s : String) (β : Type u) (Pred : Type uₚ) :=
   s.Pos → β → Pred
 
 /-- An invariant combinator for `String` loops with early return, for the new `do` elaborator
 which uses `Prod` for the state tuple: `onContinue` is the invariant while iterating, `onReturn`
 holds once the loop returned early with a value. -/
 noncomputable abbrev StringInvariant.withEarlyReturnNewDo {s : String} {β : Type u} {γ : Type u}
-    (Pred : Type u) [Assertion Pred]
+    (Pred : Type uₚ) [Assertion Pred]
     (onContinue : s.Pos → β → Pred)
     (onReturn : γ → β → Pred) :
     StringInvariant s (Option γ × β) Pred :=
@@ -2363,14 +2369,14 @@ The type of loop invariants used by the specifications of `for ... in ...` loops
 A loop invariant is a function mapping the current position and state to a lattice element.
 -/
 @[spec_invariant_type, simp, grind =]
-def StringSliceInvariant (s : String.Slice) (β : Type u) (Pred : Type u) :=
+def StringSliceInvariant (s : String.Slice) (β : Type u) (Pred : Type uₚ) :=
   s.Pos → β → Pred
 
 /-- An invariant combinator for `String.Slice` loops with early return, for the new `do`
 elaborator which uses `Prod` for the state tuple: `onContinue` is the invariant while iterating,
 `onReturn` holds once the loop returned early with a value. -/
 noncomputable abbrev StringSliceInvariant.withEarlyReturnNewDo {s : String.Slice} {β : Type u}
-    {γ : Type u} (Pred : Type u) [Assertion Pred]
+    {γ : Type u} (Pred : Type uₚ) [Assertion Pred]
     (onContinue : s.Pos → β → Pred)
     (onReturn : γ → β → Pred) :
     StringSliceInvariant s (Option γ × β) Pred :=
@@ -2419,7 +2425,7 @@ section While
 
 universe u
 
-variable {α β : Type u} {m : Type u → Type v} {Pred : Type u} {EPred : Type u}
+variable {α β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
 variable [Monad m] [Lean.Order.MonadTail m] [Assertion Pred] [Assertion EPred]
   [WPMonad m Pred EPred]
 
@@ -2428,7 +2434,7 @@ An invariant for a `repeatM` loop, given as a predicate over the `α ⊕ β` cur
 `.inl a` is the `continue` case at `a`; `.inr b` is the `break` case with result `b`.
 -/
 @[spec_invariant_type, simp, grind =]
-def RepeatInvariant (α β : Type u) (Pred : Type u) :=
+def RepeatInvariant (α β : Type u) (Pred : Type uₚ) :=
   α ⊕ β → Pred
 
 /-- A termination measure for a `repeatM` loop. -/

--- a/tests/bench/vcgen/test_do_logic.lean
+++ b/tests/bench/vcgen/test_do_logic.lean
@@ -708,7 +708,8 @@ theorem incr_id (amounts : List Nat) :
 error: unsolved goals
 case vc1
 m : Type → Type u
-Pred EPred : Type
+Pred : Type u_1
+EPred : Type u_2
 inst✝³ : Monad m
 inst✝² : Assertion Pred
 inst✝¹ : Assertion EPred

--- a/tests/elab/vcgenFrames.lean
+++ b/tests/elab/vcgenFrames.lean
@@ -55,15 +55,7 @@ theorem frames_mkFreshNat [Monad m] [Assertion Pred] [Assertion EPred]
     (h : ∀ s a, P { s with fst := a } = P s) :
     WP.Frames (· ⊓ ·) (mkFreshNat : StateT AppState m Nat) P := by
   refine .of_conjunctive (fun E => ?_)
-  -- FIXME: use `vcgen [bumpSnd] with finish` here once the Pattern.match? level bug is fixed
-  intro s
-  unfold mkFreshNat
-  simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,
-    StateT.run_map, bind_pure_comp, map_pure]
-  refine PartialOrder.rel_trans ?_
-    (WPMonad.pure_le_wp_pure (m := m) (s.fst, s.fst + 1, s.snd) (fun x => P x.snd) E)
-  show P s ⊑ P (s.fst + 1, s.snd)
-  rw [h s (s.fst + 1)]
+  vcgen [mkFreshNat] with finish
 
 /-- `Id`-specialized `frames_mkFreshNat`. With the base monad ground, `grind` can derive a
 usable pattern, so registering it lets `finish` discharge the preservation VC. -/
@@ -114,15 +106,7 @@ theorem frames_mkFreshSnd [Monad m] [Assertion Pred] [Assertion EPred]
     (h : ∀ s a, P { s with snd := a } = P s) :
     WP.Frames (· ⊓ ·) (mkFreshSnd : StateT AppState m Nat) P := by
   refine .of_conjunctive (fun E => ?_)
-  -- FIXME: use `vcgen [bumpSnd] with finish` here once the Pattern.match? level bug is fixed
-  intro s
-  unfold mkFreshSnd
-  simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,
-    StateT.run_map, bind_pure_comp, map_pure]
-  refine PartialOrder.rel_trans ?_
-    (WPMonad.pure_le_wp_pure (m := m) (s.snd, s.fst, s.snd + 1) (fun x => P x.snd) E)
-  show P s ⊑ P (s.fst, s.snd + 1)
-  rw [h s (s.snd + 1)]
+  vcgen [mkFreshSnd] with finish
 
 /-- `Id`-specialized `frames_mkFreshSnd`, registered so `finish` discharges the preservation VC. -/
 @[grind .]
@@ -180,15 +164,7 @@ theorem frames_addFst [Monad m] [Assertion Pred] [Assertion EPred]
     (h : ∀ s a, P { s with fst := a } = P s) :
     WP.Frames (· ⊓ ·) (addFst k : StateT AppState m Nat) P := by
   refine .of_conjunctive (fun E => ?_)
-  -- FIXME: use `vcgen [bumpSnd] with finish` here once the Pattern.match? level bug is fixed
-  intro s
-  unfold addFst
-  simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,
-    StateT.run_map, bind_pure_comp, map_pure]
-  refine PartialOrder.rel_trans ?_
-    (WPMonad.pure_le_wp_pure (m := m) (s.fst, s.fst + k, s.snd) (fun x => P x.snd) E)
-  show P s ⊑ P (s.fst + k, s.snd)
-  rw [h s (s.fst + k)]
+  vcgen [addFst] with finish
 
 /-- `Id`-specialized `frames_addFst`, registered so `finish` discharges the preservation VC. -/
 @[grind .]
@@ -230,15 +206,7 @@ theorem frames_bumpSnd {σ : Type} [Monad m] [Assertion Pred] [Assertion EPred]
     (h : ∀ s a, P { s with snd := a } = P s) :
     WP.Frames (· ⊓ ·) (bumpSnd : StateT (σ × Nat) m Nat) P := by
   refine .of_conjunctive (fun E => ?_)
-  -- FIXME: use `vcgen [bumpSnd] with finish` here once the Pattern.match? level bug is fixed
-  intro s
-  unfold bumpSnd
-  simp only [StateT.wp_apply_eq, StateT.run_bind, StateT.run_get, StateT.run_modify,
-    StateT.run_map, bind_pure_comp, map_pure]
-  refine PartialOrder.rel_trans ?_
-    (WPMonad.pure_le_wp_pure (m := m) (s.snd, s.fst, s.snd + 1) (fun x => P x.snd) E)
-  show P s ⊑ P (s.fst, s.snd + 1)
-  rw [h s (s.snd + 1)]
+  vcgen [bumpSnd] with finish
 
 /-- `Id`-specialized `frames_bumpSnd` over an abstract state `σ`, registered so `finish`
 discharges the preservation VC. -/

--- a/tests/elab/vcgenFrames.lean
+++ b/tests/elab/vcgenFrames.lean
@@ -275,3 +275,25 @@ example [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
 
 example : ⦃ fun s => ⌜s.1 = 0 ∧ s.2 = 7⌝ ⦄ (mkFreshNat : StateM AppState Nat)
     ⦃ fun r s => ⌜r = 0 ∧ s.2 = 7⌝ ⦄ := recovers_snd
+
+/-! ## Assertion universe independent of the value universe
+
+`Pred` and `EPred` are quantified at their own universes `w`/`w'`, independent of the value type
+`Nat : Type 0`. `Triple`'s four independent universes admit such a spec, and `vcgen` reasons over
+the abstract assertion universe. -/
+
+/-- Only `get` and state-introduction, exercising `Spec.get_StateT` at an abstract assertion
+universe. -/
+example {m : Type → Type v} {Pred : Type w} {EPred : Type w'} [Monad m] [Assertion Pred]
+    [Assertion EPred] [WPMonad m Pred EPred] (P : Nat → Pred) :
+    ⦃P⦄ (get : StateT Nat m Nat) ⦃fun _ => P⦄ := by
+  vcgen
+
+/-- The lossy spec of `mkFreshNat` at an abstract assertion universe: `vcgen` threads
+`pure`/`bind`/`map`/`modifyGet`/`get` over `Pred : Type w`. -/
+example {m : Type → Type v} {Pred : Type w} {EPred : Type w'} [Monad m] [Assertion Pred]
+    [Assertion EPred] [WPMonad m Pred EPred] (n : Nat) :
+    ⦃ fun s => ⌜s.1 = n⌝ ⦄ (mkFreshNat : StateT AppState m Nat)
+    ⦃ fun r s => ⌜r = n ∧ s.1 = n + 1⌝ ⦄ := by
+  unfold mkFreshNat
+  vcgen <;> simp_all


### PR DESCRIPTION
This PR lets a Hoare `Triple` use an assertion type `Pred` at a universe independent of the program's value type, so specifications can quantify over assertions like `σ → Prop` while values stay at `Type 0`, and `vcgen` reasons over such specifications directly.
