### PR TITLE
fix: repair dead lean-manual:// links (Closes #14163)

### DIFF
--- a/src/Init/Control/Option.lean
+++ b/src/Init/Control/Option.lean
@@ -88,7 +88,7 @@ instance : Alternative (OptionT m) where
 Converts a computation from the underlying monad into one that could fail, even though it does not.
 
 This function is typically implicitly accessed via a `MonadLiftT` instance as part of [automatic
-lifting](lean-manual://section/monad-lifting).
+lifting](lean-manual://section/lifting-monads).
 -/
 @[always_inline, inline, expose] protected def lift (x : m α) : OptionT m α := OptionT.mk do
   return some (← x)

--- a/src/Init/Control/State.lean
+++ b/src/Init/Control/State.lean
@@ -147,7 +147,7 @@ protected def modifyGet (f : σ → α × σ) : StateT σ m α :=
 Runs an action from the underlying monad in the monad with state. The state is not modified.
 
 This function is typically implicitly accessed via a `MonadLiftT` instance as part of [automatic
-lifting](lean-manual://section/monad-lifting).
+lifting](lean-manual://section/lifting-monads).
 -/
 @[always_inline, inline, expose]
 protected def lift {α : Type u} (t : m α) : StateT σ m α :=

--- a/src/Init/Control/StateCps.lean
+++ b/src/Init/Control/StateCps.lean
@@ -80,7 +80,7 @@ instance : MonadAttach (StateCpsT ε m) := .trivial
 Runs an action from the underlying monad in the monad with state. The state is not modified.
 
 This function is typically implicitly accessed via a `MonadLiftT` instance as part of [automatic
-lifting](lean-manual://section/monad-lifting).
+lifting](lean-manual://section/lifting-monads).
 -/
 @[always_inline, inline, expose]
 protected def lift [Monad m] (x : m α) : StateCpsT σ m α :=

--- a/src/Init/Control/StateRef.lean
+++ b/src/Init/Control/StateRef.lean
@@ -55,7 +55,7 @@ variable {ω σ : Type} {m : Type → Type} {α : Type}
 Runs an action from the underlying monad in the monad with state. The state is not modified.
 
 This function is typically implicitly accessed via a `MonadLiftT` instance as part of [automatic
-lifting](lean-manual://section/monad-lifting).
+lifting](lean-manual://section/lifting-monads).
 -/
 @[always_inline, inline]
 protected def lift (x : m α) : StateRefT' ω σ m α :=

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -518,7 +518,7 @@ Given a relation `r : α → α → Prop` and a quotient `Quot r`, applying a fu
 requires a proof `a` that `f` respects `r`. In this case, `Quot.lift f a : Quot r → β` computes the
 same values as `f`.
 
-Lean's type theory includes a [definitional reduction](lean-manual://section/type-theory) from
+Lean's type theory includes a [definitional reduction](lean-manual://section/quotient-reduction) from
 `Quot.lift f h (Quot.mk r v)` to `f v`.
 
 `Quot.lift` is a built-in primitive:
@@ -4320,7 +4320,7 @@ In this class, `σ` is a `semiOutParam`, which means that it can influence the c
 `MonadState σ` provides the same operations, but requires that `σ` be inferable from `m`.
 
 The mutable state of a state monad is visible between multiple `do`-blocks or functions, unlike
-[local mutable state](lean-manual://section/do-notation-let-mut) in `do`-notation.
+[local mutable state](lean-manual://section/let-mut) in `do`-notation.
 -/
 class MonadStateOf (σ : semiOutParam (Type u)) (m : Type u → Type v) where
   /--
@@ -4385,7 +4385,7 @@ In this class, `σ` is an `outParam`, which means that it is inferred from `m`. 
 provides the same operations, but allows `σ` to influence instance synthesis.
 
 The mutable state of a state monad is visible between multiple `do`-blocks or functions, unlike
-[local mutable state](lean-manual://section/do-notation-let-mut) in `do`-notation.
+[local mutable state](lean-manual://section/let-mut) in `do`-notation.
 -/
 class MonadState (σ : outParam (Type u)) (m : Type u → Type v) where
   /--


### PR DESCRIPTION
This PR repairs three dead lean-manual:// section links in core docstrings, repointing each tag to an existing target in the manual's xref database:

    type-theory → quotient-reduction (Init/Prelude.lean, Quot.lift)
    do-notation-let-mut → let-mut (Init/Prelude.lean, 2 links)
    monad-lifting → lifting-monads (Init/Control/{State,StateCps,StateRef,Option}.lean, 4 links)

A scan of src/ found 7 dead links across these 3 tags; the other ~43 lean-manual:// links resolve. New targets verified against the nightly xref redirector and by existing in-tree usage (lifting-monads in Init/System/IO.lean).

Closes #14163.