### PR TITLE
doc: update parse function documentation

### DIFF
--- a/src/Std/Time/Format/Basic.lean
+++ b/src/Std/Time/Format/Basic.lean
@@ -1410,13 +1410,13 @@ def builderParser (format: FormatString) (config : FormatConfig) (func: FormatTy
   go format func
 
 /--
-Parses the input string into a `ZoneDateTime`.
+Parses the input string into a `DateTime`.
 -/
 def parse (format : GenericFormat aw) (input : String) : Except String DateTime :=
   (parser format.string format.config aw <* eof).run input
 
 /--
-Parses the input string into a `ZoneDateTime` and panics if its wrong.
+Parses the input string into a `DateTime` and panics if its wrong.
 -/
 def parse! (format : GenericFormat aw) (input : String) : DateTime :=
   match parse format input with


### PR DESCRIPTION
This PR updates the docstrings for `Std.Time.GenericFormat.parse` and `Std.Time.GenericFormat.parse!` to say that they parse into `DateTime`, matching their return types.

Codex (OpenAI's coding agent) was used to draft the PR description.

Closes #14173
