### PR TITLE
perf: less aggressive {List,Array}.count e-matching

### DIFF
--- a/src/Init/Data/Array/Count.lean
+++ b/src/Init/Data/Array/Count.lean
@@ -213,9 +213,10 @@ theorem count_le_size {a : α} {xs : Array α} : count a xs ≤ xs.size := count
 
 grind_pattern count_le_size => count a xs, xs.size
 
-@[grind =]
 theorem count_eq_size_filter {a : α} {xs : Array α} : count a xs = (filter (· == a) xs).size := by
   simp [count, countP_eq_size_filter]
+
+grind_pattern count_eq_size_filter => count a xs, (filter _ xs).size
 
 theorem count_le_count_push {a b : α} {xs : Array α} : count a xs ≤ count a (xs.push b) := by
   simp [count_push]

--- a/src/Init/Data/List/Count.lean
+++ b/src/Init/Data/List/Count.lean
@@ -259,9 +259,10 @@ theorem count_eq_countP' {a : α} : count a = countP (· == a) := by
   funext l
   apply count_eq_countP
 
-@[grind =]
 theorem count_eq_length_filter {a : α} {l : List α} : count a l = (filter (· == a) l).length := by
   simp [count, countP_eq_length_filter]
+
+grind_pattern count_eq_length_filter => count a l, (filter _ l).length
 
 @[grind =]
 theorem count_tail : ∀ {l : List α} {a : α},

--- a/tests/elab/grind_lint_1.lean
+++ b/tests/elab/grind_lint_1.lean
@@ -101,12 +101,9 @@ info: Try this to display the actual theorem instances:
 /--
 info: instantiating `Array.back?_empty` triggers 17 additional `grind` theorem instantiations
 ---
-info: instantiating `Array.count_empty` triggers 19 additional `grind` theorem instantiations
----
 info: Try this:
   [apply] #grind_lint check  (min := 15) in Array
   #grind_lint inspect Array.back?_empty
-  #grind_lint inspect Array.count_empty
 -/
 #guard_msgs in
 #grind_lint check (min := 15) in Array


### PR DESCRIPTION
This PR reduces the aggressiveness of e-matching for `List.count` and `Array.count`. Previously, any invocation of count would directly trigger theory about filter. However, given that `count` has its own set of `grind` annotations, we believe that `count` should only start connecting with `filter`, when an invocation of `filter` is already available in the e-graph. This way we do not unnecessarily trigger `filter` theory from `count`.