### PR TITLE
feat: teach grind more about {Array,Vector,List}.count and membership

### DIFF
--- a/src/Init/Data/Array/Count.lean
+++ b/src/Init/Data/Array/Count.lean
@@ -270,6 +270,8 @@ theorem not_mem_of_count_eq_zero {a : α} {xs : Array α} (h : count a xs = 0) :
 theorem count_eq_zero {xs : Array α} : count a xs = 0 ↔ a ∉ xs :=
   ⟨not_mem_of_count_eq_zero, count_eq_zero_of_not_mem⟩
 
+grind_pattern count_eq_zero => a ∈ xs, count a xs
+
 theorem count_eq_size {xs : Array α} : count a xs = xs.size ↔ ∀ b ∈ xs, a = b := by
   rw [count, countP_eq_size]
   refine ⟨fun h b hb => Eq.symm ?_, fun h b hb => ?_⟩

--- a/src/Init/Data/List/Count.lean
+++ b/src/Init/Data/List/Count.lean
@@ -351,6 +351,8 @@ theorem not_mem_of_count_eq_zero {a : α} {l : List α} (h : count a l = 0) : a 
 theorem count_eq_zero {l : List α} : count a l = 0 ↔ a ∉ l :=
   ⟨not_mem_of_count_eq_zero, count_eq_zero_of_not_mem⟩
 
+grind_pattern count_eq_zero => a ∈ l, count a l
+
 theorem count_eq_length {l : List α} : count a l = l.length ↔ ∀ b ∈ l, a = b := by
   rw [count, countP_eq_length]
   refine ⟨fun h b hb => Eq.symm ?_, fun h b hb => ?_⟩

--- a/src/Init/Data/Vector/Count.lean
+++ b/src/Init/Data/Vector/Count.lean
@@ -234,6 +234,8 @@ theorem not_mem_of_count_eq_zero {a : α} {xs : Vector α n} (h : count a xs = 0
 theorem count_eq_zero {xs : Vector α n} : count a xs = 0 ↔ a ∉ xs :=
   ⟨not_mem_of_count_eq_zero, count_eq_zero_of_not_mem⟩
 
+grind_pattern count_eq_zero => a ∈ xs, count a xs
+
 theorem count_eq_size {xs : Vector α n} : count a xs = n ↔ ∀ b ∈ xs, a = b := by
   rcases xs with ⟨xs, rfl⟩
   simp [Array.count_eq_size]


### PR DESCRIPTION
This PR teaches grind about the fact that it might be interesting to work with `count a xs = 0 ↔ a ∉ xs` once `count a xs` and `a ∈ xs` have appeared in the e-graph.