### PR TITLE
feat: `DecidableEq Float`

### DIFF
--- a/src/Init/Data/Float/Float.lean
+++ b/src/Init/Data/Float/Float.lean
@@ -43,6 +43,8 @@ structure Float where
 attribute [extern "lean_float_to_bits"] Float.toModel
 attribute [extern "lean_float_of_bits"] Float.ofModel
 
+deriving instance DecidableEq for Float
+
 instance : Nonempty Float :=
   ⟨⟨default⟩⟩
 

--- a/src/Init/Data/Float/Float32.lean
+++ b/src/Init/Data/Float/Float32.lean
@@ -43,6 +43,8 @@ structure Float32 where
 attribute [extern "lean_float32_to_bits"] Float32.toModel
 attribute [extern "lean_float32_of_bits"] Float32.ofModel
 
+deriving instance DecidableEq for Float32
+
 instance : Nonempty Float32 :=
   ⟨⟨default⟩⟩
 

--- a/src/Init/Data/Float/Model/Float.lean
+++ b/src/Init/Data/Float/Model/Float.lean
@@ -36,7 +36,7 @@ structure Float.Model where
   toBits : UInt64
   /-- The underlying bit pattern is valid according to the IEEE `binary64` format. -/
   valid : Float.Model.Format.binary64.Valid toBits.toBitVec
-
+deriving DecidableEq
 namespace Float.Model
 
 /-- Unpack a `Float.Model` into the corresponding `UnpackedFloat`. -/

--- a/src/Init/Data/Float/Model/Float.lean
+++ b/src/Init/Data/Float/Model/Float.lean
@@ -37,6 +37,7 @@ structure Float.Model where
   /-- The underlying bit pattern is valid according to the IEEE `binary64` format. -/
   valid : Float.Model.Format.binary64.Valid toBits.toBitVec
 deriving DecidableEq
+
 namespace Float.Model
 
 /-- Unpack a `Float.Model` into the corresponding `UnpackedFloat`. -/

--- a/src/Init/Data/Float/Model/Float32.lean
+++ b/src/Init/Data/Float/Model/Float32.lean
@@ -37,6 +37,7 @@ structure Float32.Model where
   toBits : UInt32
   /-- The underlying bit pattern is valid according to the IEEE `binary32` format. -/
   valid : Float.Model.Format.binary32.Valid toBits.toBitVec
+deriving DecidableEq
 
 namespace Float32.Model
 

--- a/tests/elab/floatEquality.lean
+++ b/tests/elab/floatEquality.lean
@@ -1,0 +1,43 @@
+/-!
+Tests for the `DecidableEq Float` and `BEq Float` instances
+-/
+
+/-- info: false -/
+#guard_msgs in
+#eval 0.1 == 0.2
+
+/-- info: true -/
+#guard_msgs in
+#eval 0.1 == 0.1
+
+/-- info: true -/
+#guard_msgs in
+#eval 0.1 == 0.100000000000000001
+
+/-- info: true -/
+#guard_msgs in
+#eval 0.0 == -0.0
+
+/-- info: false -/
+#guard_msgs in
+#eval (0.0 / 0.0) == (0.0 / 0.0)
+
+/-- info: false -/
+#guard_msgs in
+#eval 0.1 = 0.2
+
+/-- info: true -/
+#guard_msgs in
+#eval 0.1 = 0.1
+
+/-- info: true -/
+#guard_msgs in
+#eval 0.1 = 0.100000000000000001
+
+/-- info: false -/
+#guard_msgs in
+#eval 0.0 = -0.0
+
+/-- info: true -/
+#guard_msgs in
+#eval (0.0 / 0.0) = (0.0 / 0.0)


### PR DESCRIPTION
This PR implements a `DecidableEq Float` instance, which checks for equality of the underlying bit patterns.

This differs from the `BEq Float` instance: `NaN == NaN` is false, `NaN = NaN` is true, `0.0 == -0.0` is true, `0.0 = -0.0` is false.