### PR TITLE
feat: float literals in match patterns

### DIFF
--- a/src/Init/Data/Float/Float.lean
+++ b/src/Init/Data/Float/Float.lean
@@ -43,6 +43,8 @@ structure Float where
 attribute [extern "lean_float_to_bits"] Float.toModel
 attribute [extern "lean_float_of_bits"] Float.ofModel
 
+deriving instance DecidableEq for Float
+
 instance : Nonempty Float :=
   ⟨⟨default⟩⟩
 

--- a/src/Init/Data/Float/Float32.lean
+++ b/src/Init/Data/Float/Float32.lean
@@ -43,6 +43,8 @@ structure Float32 where
 attribute [extern "lean_float32_to_bits"] Float32.toModel
 attribute [extern "lean_float32_of_bits"] Float32.ofModel
 
+deriving instance DecidableEq for Float32
+
 instance : Nonempty Float32 :=
   ⟨⟨default⟩⟩
 

--- a/src/Init/Data/Float/Model/Float.lean
+++ b/src/Init/Data/Float/Model/Float.lean
@@ -36,7 +36,7 @@ structure Float.Model where
   toBits : UInt64
   /-- The underlying bit pattern is valid according to the IEEE `binary64` format. -/
   valid : Float.Model.Format.binary64.Valid toBits.toBitVec
-
+deriving DecidableEq
 namespace Float.Model
 
 /-- Unpack a `Float.Model` into the corresponding `UnpackedFloat`. -/

--- a/src/Init/Data/Float/Model/Float.lean
+++ b/src/Init/Data/Float/Model/Float.lean
@@ -37,6 +37,7 @@ structure Float.Model where
   /-- The underlying bit pattern is valid according to the IEEE `binary64` format. -/
   valid : Float.Model.Format.binary64.Valid toBits.toBitVec
 deriving DecidableEq
+
 namespace Float.Model
 
 /-- Unpack a `Float.Model` into the corresponding `UnpackedFloat`. -/

--- a/src/Init/Data/Float/Model/Float32.lean
+++ b/src/Init/Data/Float/Model/Float32.lean
@@ -37,6 +37,7 @@ structure Float32.Model where
   toBits : UInt32
   /-- The underlying bit pattern is valid according to the IEEE `binary32` format. -/
   valid : Float.Model.Format.binary32.Valid toBits.toBitVec
+deriving DecidableEq
 
 namespace Float32.Model
 

--- a/src/Lean/Meta/LitValues.lean
+++ b/src/Lean/Meta/LitValues.lean
@@ -131,6 +131,55 @@ def getUInt64Value? (e : Expr) : MetaM (Option UInt64) := OptionT.run do
   let (n, _) ← getOfNatValue? e ``UInt64
   return UInt64.ofNat n
 
+/-- Return `some b` if `e` is the boolean literal `true` or `false`. -/
+private def getBoolLit? (e : Expr) : Option Bool :=
+  match e.consumeMData with
+  | .const ``Bool.true _  => some true
+  | .const ``Bool.false _ => some false
+  | _ => none
+
+/-- Recognize a non-negated `Float` literal: an `OfScientific` or `OfNat` application. -/
+private def getFloatLit? (e : Expr) : MetaM (Option Float) := OptionT.run do
+  match_expr e with
+  | OfScientific.ofScientific type _ m s exp =>
+    guard ((← whnfD type).isConstOf ``Float)
+    let some s := getBoolLit? s | failure
+    return Float.ofScientific (← getNatValue? m) s (← getNatValue? exp)
+  | _ =>
+    let (n, _) ← getOfNatValue? e ``Float
+    return Float.ofNat n
+
+/--
+Return `some v` if `e` is a `Float` literal: an `OfScientific` or `OfNat` application, or `Neg.neg`
+of either (e.g. `-1.5`).
+-/
+def getFloatValue? (e : Expr) : MetaM (Option Float) := do
+  if let some v ← getFloatLit? e then return some v
+  let_expr Neg.neg _ _ a ← e | return none
+  let some v ← getFloatLit? a | return none
+  return some (-v)
+
+/-- Recognize a non-negated `Float32` literal: an `OfScientific` or `OfNat` application. -/
+private def getFloat32Lit? (e : Expr) : MetaM (Option Float32) := OptionT.run do
+  match_expr e with
+  | OfScientific.ofScientific type _ m s exp =>
+    guard ((← whnfD type).isConstOf ``Float32)
+    let some s := getBoolLit? s | failure
+    return Float32.ofScientific (← getNatValue? m) s (← getNatValue? exp)
+  | _ =>
+    let (n, _) ← getOfNatValue? e ``Float32
+    return Float32.ofNat n
+
+/--
+Return `some v` if `e` is a `Float32` literal: an `OfScientific` or `OfNat` application, or `Neg.neg`
+of either (e.g. `-1.5`).
+-/
+def getFloat32Value? (e : Expr) : MetaM (Option Float32) := do
+  if let some v ← getFloat32Lit? e then return some v
+  let_expr Neg.neg _ _ a ← e | return none
+  let some v ← getFloat32Lit? a | return none
+  return some (-v)
+
 -- TODO: extensibility
 
 /--
@@ -149,6 +198,8 @@ def normLitValue (e : Expr) : MetaM Expr := do
   if let some n ← getUInt16Value? e then return toExpr n
   if let some n ← getUInt32Value? e then return toExpr n
   if let some n ← getUInt64Value? e then return toExpr n
+  -- `Float`/`Float32` literals are left untouched: there is no `ToExpr` instance for them, and their
+  -- only canonical form would be `Float.ofBits`, which is less legible than the original literal.
   return e
 
 /--
@@ -166,6 +217,8 @@ def isLitValue (e : Expr) : MetaM Bool := do
   if (← getUInt16Value? e).isSome then return true
   if (← getUInt32Value? e).isSome then return true
   if (← getUInt64Value? e).isSome then return true
+  if (← getFloatValue? e).isSome then return true
+  if (← getFloat32Value? e).isSome then return true
   return false
 
 /--

--- a/src/Lean/Meta/Match/Value.lean
+++ b/src/Lean/Meta/Match/Value.lean
@@ -25,6 +25,8 @@ def isMatchValue (e : Expr) : MetaM Bool := do
   if (← getUInt16Value? e).isSome then return true
   if (← getUInt32Value? e).isSome then return true
   if (← getUInt64Value? e).isSome then return true
+  if (← getFloatValue? e).isSome then return true
+  if (← getFloat32Value? e).isSome then return true
   return false
 
 end Lean.Meta

--- a/tests/elab/floatEquality.lean
+++ b/tests/elab/floatEquality.lean
@@ -1,0 +1,43 @@
+/-!
+Tests for the `DecidableEq Float` and `BEq Float` instances
+-/
+
+/-- info: false -/
+#guard_msgs in
+#eval 0.1 == 0.2
+
+/-- info: true -/
+#guard_msgs in
+#eval 0.1 == 0.1
+
+/-- info: true -/
+#guard_msgs in
+#eval 0.1 == 0.100000000000000001
+
+/-- info: true -/
+#guard_msgs in
+#eval 0.0 == -0.0
+
+/-- info: false -/
+#guard_msgs in
+#eval (0.0 / 0.0) == (0.0 / 0.0)
+
+/-- info: false -/
+#guard_msgs in
+#eval 0.1 = 0.2
+
+/-- info: true -/
+#guard_msgs in
+#eval 0.1 = 0.1
+
+/-- info: true -/
+#guard_msgs in
+#eval 0.1 = 0.100000000000000001
+
+/-- info: false -/
+#guard_msgs in
+#eval 0.0 = -0.0
+
+/-- info: true -/
+#guard_msgs in
+#eval (0.0 / 0.0) = (0.0 / 0.0)

--- a/tests/elab/match_float.lean
+++ b/tests/elab/match_float.lean
@@ -1,0 +1,82 @@
+/-!
+Tests that the `match` compiler treats `Float` and `Float32` literals as match values, just like
+`String`, `UInt64`, etc.
+
+Matching uses the `DecidableEq` instance (propositional, bit-pattern equality), *not* IEEE `BEq`.
+These differ: `BEq` says `0.0 == -0.0` and `NaN != NaN`, whereas the match compiler distinguishes
+`0.0` from `-0.0` (different bit patterns) and would treat `NaN` as equal to itself.
+-/
+
+-- The match compiler relies on this instance (bit equality), which disagrees with IEEE `BEq`.
+example : ((0.0 : Float) == (-0.0 : Float)) = true := rfl   -- IEEE `BEq`: equal
+#guard (0.0 : Float) ≠ (-0.0 : Float)                       -- `DecidableEq`: not equal
+
+def isFiveOh : Float → Bool
+  | 5 => true
+  | 6.0 => true
+  | _ => false
+
+/-- info: true -/
+#guard_msgs in #eval isFiveOh 5.0
+/-- info: true -/
+#guard_msgs in #eval isFiveOh 6.0
+/-- info: false -/
+#guard_msgs in #eval isFiveOh 7.0
+
+-- `0.0` and `-0.0` are distinct patterns (distinct bit patterns), demonstrating that the match
+-- compiles to `DecidableEq` and not IEEE `BEq` (which would consider them equal).
+def signOfZero : Float → String
+  | 0.0 => "positive zero"
+  | -0.0 => "negative zero"
+  | _ => "nonzero"
+
+/-- info: "positive zero" -/
+#guard_msgs in #eval signOfZero 0.0
+/-- info: "negative zero" -/
+#guard_msgs in #eval signOfZero (-0.0)
+/-- info: "nonzero" -/
+#guard_msgs in #eval signOfZero 1.0
+
+-- Negative (`Neg.neg`) literal patterns.
+def classify : Float → String
+  | -1.5 => "minus one and a half"
+  | 2 => "two"
+  | -3 => "minus three"
+  | _ => "other"
+
+/-- info: "minus one and a half" -/
+#guard_msgs in #eval classify (-1.5)
+/-- info: "two" -/
+#guard_msgs in #eval classify 2.0
+/-- info: "minus three" -/
+#guard_msgs in #eval classify (-3.0)
+/-- info: "other" -/
+#guard_msgs in #eval classify 4.0
+
+def classify32 : Float32 → String
+  | 1.5 => "onehalf"
+  | -2 => "minustwo"
+  | _ => "other"
+
+/-- info: "onehalf" -/
+#guard_msgs in #eval classify32 1.5
+/-- info: "minustwo" -/
+#guard_msgs in #eval classify32 (-2.0)
+/-- info: "other" -/
+#guard_msgs in #eval classify32 3.0
+
+-- `match h : f with` gives `h` the clean type `f = <literal>`; no model/bit-pattern internals leak.
+-- (The type-ascription mismatch reveals the actual type of `h`.)
+/--
+error: Type mismatch
+  h
+has type
+  f = 6.0
+but is expected to have type
+  True
+-/
+#guard_msgs in
+example (f : Float) : Bool :=
+  match h : f with
+  | 6.0 => (h : True)
+  | _ => false

--- a/tests/elab/match_float.lean
+++ b/tests/elab/match_float.lean
@@ -80,3 +80,11 @@ example (f : Float) : Bool :=
   match h : f with
   | 6.0 => (h : True)
   | _ => false
+
+-- no warning for overlaps due to lack of normalization for Float literals:
+
+#guard_msgs in
+example : Float → Bool
+  | 5 => true
+  | 5.0 => false
+  | _ => false


### PR DESCRIPTION
This PR lets `match` use `Float` and `Float32` literals as patterns, just like `String`, `UInt64`, and other literal types. The compiler compares the scrutinee against each literal using the type's `DecidableEq` instance (bit-pattern equality), so e.g. `0.0` and `-0.0` are distinct patterns. Negative literals such as `-1.5` are supported.

The recognizers `getFloatValue?`/`getFloat32Value?` handle the `OfScientific`, `OfNat`, and negated forms, and are registered in both `isMatchValue` (so the match compiler treats them as value patterns) and `isLitValue` (so `grind` reasons about the resulting matches consistently). `normLitValue` leaves floats untouched, since there is no `ToExpr` instance for them.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>