### PR TITLE
feat: `lean_set_initializing`

### DIFF
--- a/src/Lean/ImportingFlag.lean
+++ b/src/Lean/ImportingFlag.lean
@@ -59,4 +59,15 @@ def withImporting (x : IO α) : IO α :=
     importingRef.set false
     runInitializersRef.set false
 
+/--
+Toggle the "importing" flag.
+
+This is intended for C code that needs to emulate multiple `withImporting` calls.
+As with `withImporting`, users must make sure there is only one execution thread accessing
+the global references.
+-/
+@[export lean_set_initializing]
+private def setInitializing (b : Bool) : IO Unit :=
+  importingRef.set b
+
 end Lean

--- a/src/Lean/ImportingFlag.lean
+++ b/src/Lean/ImportingFlag.lean
@@ -67,7 +67,7 @@ As with `withImporting`, users must make sure there is only one execution thread
 the global references.
 -/
 @[export lean_set_initializing]
-private def setInitializing (b : Bool) : IO Unit :=
+private def setInitializing (b : Bool) : BaseIO Unit :=
   importingRef.set b
 
 end Lean


### PR DESCRIPTION
This PR exports a `lean_set_initializing` symbol for users of Lean that need to emulate multiple `withImporting` calls from a C FFI.

Nerodia (a Lean to Python FFI) will use this to initialize extension modules on a Python `import` under a mutex.