### PR TITLE
perf: optimize `ToJson` derive handler

### DIFF
--- a/src/Lean/Data/Json/FromToJson/Basic.lean
+++ b/src/Lean/Data/Json/FromToJson/Basic.lean
@@ -282,6 +282,11 @@ def opt [ToJson α] (k : String) : Option α → List (String × Json)
   | none   => []
   | some o => [⟨k, toJson o⟩]
 
+-- used by the `ToJson` deriving handler
+def optInsert [ToJson α] (m : Std.TreeMap.Raw String Json) (k : String) : Option α → Std.TreeMap.Raw String Json
+  | none   => m
+  | some o => m.insert k (toJson o)
+
 /-- Returns the string value or single key name, if any. -/
 def getTag? : Json → Option String
   | .str tag => some tag

--- a/src/Lean/Elab/Deriving/FromToJson.lean
+++ b/src/Lean/Elab/Deriving/FromToJson.lean
@@ -33,12 +33,17 @@ def mkJsonField (n : Name) : CoreM (Bool × Term) := do
 
 def mkToJsonBodyForStruct (header : Header) (indName : Name) : TermElabM Term := do
   let fields := getStructureFieldsFlattened (← getEnv) indName (includeSubobjectFields := false)
-  let fields ← fields.mapM fun field => do
+  let target := mkIdent header.targetNames[0]!
+  -- Build the underlying `Std.TreeMap.Raw` directly, inserting one field at a time, to avoid
+  -- constructing an intermediate `List` and converting it via `mkObj`/`ofList`.
+  let mut acc ← `(Std.TreeMap.Raw.empty)
+  for field in fields do
     let (isOptField, nm) ← mkJsonField field
-    let target := mkIdent header.targetNames[0]!
-    if isOptField then ``(opt $nm $target.$(mkIdent field))
-    else ``([($nm, toJson ($target).$(mkIdent field))])
-  `(mkObj <| List.flatten [$fields,*])
+    if isOptField then
+      acc ← ``(optInsert $acc $nm ($target).$(mkIdent field))
+    else
+      acc ← ``(Std.TreeMap.Raw.insert $acc $nm (toJson ($target).$(mkIdent field)))
+  `(Json.obj <| $acc)
 
 def mkToJsonBodyForInduct (ctx : Context) (header : Header) (indName : Name) : TermElabM Term := do
   let indVal ← getConstInfoInduct indName


### PR DESCRIPTION
Partially evaluate `mkObj` call to avoid allocations