### PR TITLE
feat: propagate set_option to parsers

### DIFF
--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -862,7 +862,7 @@ def initializeKeyword := leading_parser
   optional (atomic (ident >> Term.typeSpec >> ppSpace >> Term.leftArrow)) >> Term.doSeq
 
 @[builtin_command_parser] def «in»  := trailing_parser
-  withOpen (ppDedent (" in" >> ppLine >> commandParser))
+  withOpen (withSetOption (ppDedent (" in" >> ppLine >> commandParser)))
 
 /--
 Adds a docstring to an existing declaration, replacing any existing docstring.
@@ -1023,7 +1023,8 @@ It makes the given namespaces available in the term `e`.
 It sets the option `opt` to the value `val` in the term `e`.
 -/
 @[builtin_term_parser] def «set_option» := leading_parser:leadPrec
-  "set_option " >> identWithPartialTrailingDot >> ppSpace >> Command.optionValue >> " in " >> termParser
+  "set_option " >> identWithPartialTrailingDot >> ppSpace >> Command.optionValue >>
+    withSetOptionValue (" in " >> termParser)
 end Term
 
 namespace Tactic
@@ -1035,7 +1036,8 @@ but it opens a namespace only within the tactics `tacs`. -/
 /-- `set_option opt val in tacs` (the tactic) acts like `set_option opt val` at the command level,
 but it sets the option only within the tactics `tacs`. -/
 @[builtin_tactic_parser] def «set_option» := leading_parser:leadPrec
-  "set_option " >> identWithPartialTrailingDot >> ppSpace >> Command.optionValue >> " in " >> tacticSeq
+  "set_option " >> identWithPartialTrailingDot >> ppSpace >> Command.optionValue >>
+    withSetOptionValue (" in " >> tacticSeq)
 end Tactic
 
 end Parser

--- a/src/Lean/Parser/Extension.lean
+++ b/src/Lean/Parser/Extension.lean
@@ -649,6 +649,59 @@ def withOpenDeclFn (p : ParserFn) : ParserFn := fun c s =>
 @[inline] def withOpenDecl : Parser → Parser := withFn withOpenDeclFn
 
 /--
+Converts the syntax of a value from a `set_option` to a `DataValue`, matching the forms accepted by
+the `optionValue` parser. Returns `none` for an unrecognized value, in which case the option is left
+unchanged during parsing and the error is reported during elaboration.
+-/
+private def optionValueToDataValue? (val : Syntax) : Option DataValue :=
+  if let some s := val.isStrLit? then some (.ofString s)
+  else if let some n := val.isNatLit? then some (.ofNat n)
+  else if let .atom _ "true" := val then some (.ofBool true)
+  else if let .atom _ "false" := val then some (.ofBool false)
+  else none
+
+/-- Sets the option named by `nameStx` to the value parsed from `valStx` in the parser context. -/
+private def withSetOptionValueFnCore (nameStx valStx : Syntax) (p : ParserFn) : ParserFn :=
+  match optionValueToDataValue? valStx with
+  | some v =>
+    adaptUncacheableContextFn (insertOption v) p
+  | none => p
+where
+  insertOption v c := { c with
+    options := c.options.insert nameStx.getId.eraseMacroScopes v
+  }
+
+/--
+If the parsing stack's last element is a `set_option` command, then its value is set in the context
+while parsing `p`.
+-/
+def withSetOptionFn (p : ParserFn) : ParserFn := fun c s =>
+  if s.stxStack.size > 0 then
+    let stx := s.stxStack.back
+    if stx.getKind == `Lean.Parser.Command.set_option then
+      withSetOptionValueFnCore stx[1] stx[3] p c s
+    else
+      p c s
+  else
+    p c s
+
+@[inline] def withSetOption : Parser → Parser := withFn withSetOptionFn
+
+/--
+If the parsing stack ends with an the option name and value, then the option is set in the context
+while parsing `p`. The value is the top of the stack and the name is the identifier two entries
+below it.
+-/
+def withSetOptionValueFn (p : ParserFn) : ParserFn := fun c s =>
+  let sz := s.stxStack.size
+  if sz ≥ 3 then
+    withSetOptionValueFnCore (s.stxStack.get! (sz - 3)) s.stxStack.back p c s
+  else
+    p c s
+
+@[inline] def withSetOptionValue : Parser → Parser := withFn withSetOptionValueFn
+
+/--
 Helper environment extension that gives us access to built-in aliases in pure parser functions.
 -/
 builtin_initialize aliasExtension : EnvExtension (NameMap ParserAliasValue) ←

--- a/src/Lean/Parser/Extra.lean
+++ b/src/Lean/Parser/Extra.lean
@@ -26,7 +26,7 @@ attribute [run_builtin_parser_attribute_hooks]
   unicodeSymbol nonReservedSymbol
   withCache withResetCache withPosition withPositionAfterLinebreak withoutPosition withForbidden withoutForbidden setExpected
   incQuotDepth decQuotDepth suppressInsideQuot evalInsideQuot
-  withOpen withOpenDecl
+  withOpen withOpenDecl withSetOption withSetOptionValue
   dbgTraceState
 
 /-- The parser `optional(p)`, or `(p)?`, parses `p` if it succeeds,

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,5 +1,7 @@
 #include "util/options.h"
 
+// Dear CI, please update stage0
+
 namespace lean {
 options get_default_options() {
     options opts;

--- a/tests/elab/versoDocSetOptionIn.lean
+++ b/tests/elab/versoDocSetOptionIn.lean
@@ -1,0 +1,64 @@
+import Lean.Elab.Command
+
+/-!
+Tests that `set_option doc.verso true in <command>` results in `<command>` being parsed with
+docstrings in Verso format, just as `open X in <command>` enables scoped parsers from X.
+-/
+
+open Lean Elab Command
+
+/-- Reports whether `name`'s docstring was parsed as Verso markup or as plain Markdown. -/
+elab "#doc_kind " name:ident : command => do
+  let env ← getEnv
+  runTermElabM fun _ => do
+    let declName ← realizeGlobalConstNoOverloadWithInfo name
+    match (← findInternalDocString? env declName (includeBuiltin := true)) with
+    | some (.inl _) => logInfo "markdown"
+    | some (.inr _) => logInfo "verso"
+    | none          => logInfo "none"
+
+set_option doc.verso true in
+/--
+# Verso header
+
+Some *emphasis*.
+-/
+def withVerso := 1
+
+/-- Plain `markdown` docstring. -/
+def withoutVerso := 2
+
+set_option doc.verso true
+set_option doc.verso false in
+set_option doc.verso true in
+set_option doc.verso false in
+/-- Plain `markdown` docstring. -/
+def withoutVersoMore := 2
+set_option doc.verso false
+
+set_option pp.all true in set_option doc.verso true in
+/--
+# Nested
+-/
+def nested := 3
+
+/-- info: verso -/
+#guard_msgs in #doc_kind withVerso
+
+/-- info: markdown -/
+#guard_msgs in #doc_kind withoutVerso
+
+/-- info: markdown -/
+#guard_msgs in #doc_kind withoutVersoMore
+
+/-- info: verso -/
+#guard_msgs in #doc_kind nested
+
+/--
+error: Can't add Verso-format module docs because there is already Markdown-format content present.
+-/
+#guard_msgs in
+set_option doc.verso true in
+/-!
+Not allowed - wrong format for module.
+-/


### PR DESCRIPTION
This PR propagates the values of options from set_option ... in ... forms used in commands, terms, and tactics into the parsing of the body. This means that Verso syntax can be more conveniently enabled or disabled, and brings `set_option ... in ...` semantically in line with `open ... in ...`.
