### PR TITLE
feat: indexed `⨆`/`⨅` notation and `CompleteLattice` algebra instances

### DIFF
--- a/src/Std/Internal/Do/Assertion.lean
+++ b/src/Std/Internal/Do/Assertion.lean
@@ -9,7 +9,7 @@ prelude
 public import Init.Internal.Order
 public import Std.Internal.Do.Order.Basic
 public import Std.Internal.Do.Order.Frame
-public import Std.Internal.Do.Order.Lemmas
+public import Std.Internal.Do.Order.Instances
 universe u v w
 @[expose] public section
 

--- a/src/Std/Internal/Do/Order/Basic.lean
+++ b/src/Std/Internal/Do/Order/Basic.lean
@@ -88,6 +88,10 @@ theorem join_le (x y z : α) : x ⊑ z → y ⊑ z → x ⊔ y ⊑ z := by
 /-- Indexed infimum -/
 noncomputable def iInf {ι : Type v} (f : ι → α) : α := inf (fun x => ∃ i, f i = x)
 
+open Lean in
+@[inherit_doc iInf] scoped macro "⨅ " bs:Lean.explicitBinders ", " b:term : term => do
+  return ⟨← Lean.expandExplicitBinders ``iInf bs b⟩
+
 theorem iInf_le {ι : Type v} (f : ι → α) (i : ι) : iInf f ⊑ f i := by
   apply inf_le
   exact ⟨i, rfl⟩
@@ -119,6 +123,10 @@ theorem le_iInf {ι : Type v} (f : ι → α) (x : α) : (∀ i, x ⊑ f i) → 
 
 /-- Indexed supremum -/
 noncomputable def iSup {ι : Type v} (f : ι → α) : α := CompleteLattice.sup (fun x => ∃ i, f i = x)
+
+open Lean in
+@[inherit_doc iSup] scoped macro "⨆ " bs:Lean.explicitBinders ", " b:term : term => do
+  return ⟨← Lean.expandExplicitBinders ``iSup bs b⟩
 
 theorem le_iSup {ι : Type v} (f : ι → α) (i : ι) : f i ⊑ iSup f := by
   apply le_sup

--- a/src/Std/Internal/Do/Order/Instances.lean
+++ b/src/Std/Internal/Do/Order/Instances.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Graf
+-/
+module
+
+prelude
+public import Std.Internal.Do.Order.Lemmas
+
+public section
+
+/-!
+# Algebraic typeclass instances for `CompleteLattice`
+
+The order `⊑` is reflexive, transitive and antisymmetric, and meet and join are commutative,
+associative and idempotent monoid operations with units `⊤` and `⊥`. These instances expose that
+structure to the generic algebra in `Std` (`Std.Commutative`, `Std.Associative`, `Trans`, ...).
+-/
+
+namespace Std.Internal.Do.CompleteLattice
+
+open Lean.Order PartialOrder
+
+instance [CompleteLattice l] : Std.Refl (α := l) (· ⊑ ·) := ⟨fun _ => rel_refl⟩
+instance [CompleteLattice l] : Trans (· ⊑ · : l → l → Prop) (· ⊑ ·) (· ⊑ ·) := ⟨rel_trans⟩
+instance [CompleteLattice l] : Std.Antisymm (α := l) (· ⊑ ·) := ⟨fun _ _ => rel_antisymm⟩
+
+instance [CompleteLattice l] : Std.Commutative (α := l) (· ⊓ ·) := ⟨fun _ _ => meet_comm⟩
+instance [CompleteLattice l] : Std.Commutative (α := l) (· ⊔ ·) := ⟨fun _ _ => join_comm⟩
+instance [CompleteLattice l] : Std.Associative (α := l) (· ⊓ ·) := ⟨fun _ _ _ => meet_assoc⟩
+instance [CompleteLattice l] : Std.Associative (α := l) (· ⊔ ·) := ⟨fun _ _ _ => join_assoc⟩
+instance [CompleteLattice l] : Std.IdempotentOp (α := l) (· ⊓ ·) := ⟨fun _ => meet_self⟩
+instance [CompleteLattice l] : Std.IdempotentOp (α := l) (· ⊔ ·) := ⟨fun _ => join_self⟩
+instance [CompleteLattice l] : Std.LeftIdentity (· ⊓ ·) (⊤ : l) where
+instance [CompleteLattice l] : Std.RightIdentity (· ⊓ ·) (⊤ : l) where
+instance [CompleteLattice l] : Std.LeftIdentity (· ⊔ ·) (⊥ : l) where
+instance [CompleteLattice l] : Std.RightIdentity (· ⊔ ·) (⊥ : l) where
+instance [CompleteLattice l] : Std.LawfulIdentity (· ⊓ ·) (⊤ : l) where
+  left_id _ := top_meet
+  right_id _ := meet_top
+instance [CompleteLattice l] : Std.LawfulIdentity (· ⊔ ·) (⊥ : l) where
+  left_id _ := bot_join
+  right_id _ := join_bot
+
+end Std.Internal.Do.CompleteLattice


### PR DESCRIPTION
This PR adds two small, independent pieces of `Lean.Order.CompleteLattice` infrastructure used by the `Std.Internal.Do` verification framework.

First, Mathlib-style binder notation `⨆ i, f i` and `⨅ i, f i` (with multiple binders `⨆ i j, …`) for the indexed supremum and infimum.

Second, a new `Std.Internal.Do.Order.Instances` module registering the standard algebra of a complete lattice with the generic `Std` typeclasses: the order `⊑` is reflexive, transitive and antisymmetric (`Std.Refl`, `Trans`, `Std.Antisymm`), and meet and join are commutative, associative, idempotent operations with units `⊤` and `⊥` (`Std.Commutative`, `Std.Associative`, `Std.IdempotentOp`, `Std.LawfulIdentity`).
