### PR TITLE
perf: less aggressive e-matching for eraseIdx

### DIFF
--- a/src/Init/Data/Array/Erase.lean
+++ b/src/Init/Data/Array/Erase.lean
@@ -323,7 +323,6 @@ theorem eraseIdx_eq_eraseIdxIfInBounds {xs : Array α} {i : Nat} (h : i < xs.siz
     xs.eraseIdx i h = xs.eraseIdxIfInBounds i := by
   simp [eraseIdxIfInBounds, h]
 
-@[grind =]
 theorem eraseIdx_eq_take_drop_succ {xs : Array α} {i : Nat} (h) :
     xs.eraseIdx i h = xs.take i ++ xs.drop (i + 1) := by
   rcases xs with ⟨xs⟩
@@ -333,6 +332,9 @@ theorem eraseIdx_eq_take_drop_succ {xs : Array α} {i : Nat} (h) :
     List.size_toArray, List.append_toArray, mk.injEq, List.append_cancel_left_eq]
   rw [List.take_of_length_le]
   simp
+
+grind_pattern eraseIdx_eq_take_drop_succ => xs.eraseIdx i h, xs.take i
+grind_pattern eraseIdx_eq_take_drop_succ => xs.eraseIdx i h, xs.drop i
 
 @[grind =]
 theorem getElem?_eraseIdx {xs : Array α} {i : Nat} (h : i < xs.size) {j : Nat} :

--- a/src/Init/Data/List/Basic.lean
+++ b/src/Init/Data/List/Basic.lean
@@ -1593,9 +1593,9 @@ def eraseIdx : (l : List α) → (i : Nat) → List α
   | _::as, 0   => as
   | a::as, n+1 => a :: eraseIdx as n
 
-@[simp] theorem eraseIdx_nil : ([] : List α).eraseIdx i = [] := rfl
-@[simp] theorem eraseIdx_cons_zero : (a::as).eraseIdx 0 = as := rfl
-@[simp] theorem eraseIdx_cons_succ : (a::as).eraseIdx (i+1) = a :: as.eraseIdx i := rfl
+@[simp, grind =] theorem eraseIdx_nil : ([] : List α).eraseIdx i = [] := rfl
+@[simp, grind =] theorem eraseIdx_cons_zero : (a::as).eraseIdx 0 = as := rfl
+@[simp, grind =] theorem eraseIdx_cons_succ : (a::as).eraseIdx (i+1) = a :: as.eraseIdx i := rfl
 
 /-! Finding elements -/
 

--- a/src/Init/Data/List/Erase.lean
+++ b/src/Init/Data/List/Erase.lean
@@ -573,12 +573,14 @@ theorem length_eraseIdx_of_lt {l : List α} {i} (h : i < length l) :
 
 @[simp, grind =] theorem eraseIdx_zero {l : List α} : eraseIdx l 0 = l.tail := by cases l <;> rfl
 
-@[grind =]
 theorem eraseIdx_eq_take_drop_succ :
     ∀ (l : List α) (i : Nat), l.eraseIdx i = l.take i ++ l.drop (i + 1)
   | nil, _ => by simp
   | a::l, 0 => by simp
   | a::l, i + 1 => by simp [eraseIdx_eq_take_drop_succ l i]
+
+grind_pattern eraseIdx_eq_take_drop_succ => l.eraseIdx i, l.take i
+grind_pattern eraseIdx_eq_take_drop_succ => l.eraseIdx i, l.drop (i + 1)
 
 -- See `Init.Data.List.Nat.Erase` for `getElem?_eraseIdx` and `getElem_eraseIdx`.
 

--- a/src/Init/Data/Vector/Erase.lean
+++ b/src/Init/Data/Vector/Erase.lean
@@ -27,11 +27,13 @@ open Nat
 
 /-! ### eraseIdx -/
 
-@[grind =]
 theorem eraseIdx_eq_take_drop_succ {xs : Vector α n} {i : Nat} (h) :
     xs.eraseIdx i = (xs.take i ++ xs.drop (i + 1)).cast (by omega) := by
   rcases xs with ⟨xs, rfl⟩
   simp [Array.eraseIdx_eq_take_drop_succ, *]
+
+grind_pattern eraseIdx_eq_take_drop_succ => xs.eraseIdx i h, xs.take i
+grind_pattern eraseIdx_eq_take_drop_succ => xs.eraseIdx i h, xs.drop i
 
 @[grind =]
 theorem getElem?_eraseIdx {xs : Vector α n} {i : Nat} (h : i < n) {j : Nat} :


### PR DESCRIPTION
This PR reduces the aggressiveness of e-matching for `eraseIdx` by not automatically translating into `drop`/`take` anymore at every opportunity.