### PR TITLE
fix: parameter references in Verso docstrings

### DIFF
--- a/src/Lean/DocString/Add.lean
+++ b/src/Lean/DocString/Add.lean
@@ -173,48 +173,43 @@ def reportVersoParseFailure
     }
 
 open Lean.Doc in
-open Lean.Parser.Command in
 /--
-Elaborates a Verso docstring for the specified declaration, which should already be present in the
-environment.
-
-`binders` should be the syntax of the parameters to the constant that is being documented, as a null
-node that contains a sequence of bracketed binders. It is used to allow interactive features such as
-document highlights and “find references” to work for documented parameters. If no parameter binders
-are available, pass `Syntax.missing` or an empty null node.
+Elaborates already-parsed Verso `blocks` for the specified declaration with interactive features
+disabled, reporting any elaboration messages at the current reference. When `fileMap?` is provided,
+message positions are interpreted against it.
 -/
-
-def versoDocString
-    (declName : Name) (binders : Syntax) (docComment : TSyntax ``docComment) :
+private def execVersoBlocks
+    (declName : Name) (binders : Syntax) (blocks : Array Syntax) (fileMap? : Option FileMap) :
     TermElabM (Array (Doc.Block ElabInline ElabBlock) × Array (Doc.Part ElabInline ElabBlock Empty)) := do
-  if let some stx ← parseVersoDocString docComment then
-    Doc.elabBlocks (stx.getArgs.map (⟨·⟩)) |>.exec declName binders
-  else return (#[], #[])
-
-open Lean.Doc Parser in
-open Lean.Parser.Command in
-/--
-Parses and elaborates a Verso module docstring.
--/
-def versoModDocString
-    (range : DeclarationRange) (doc : TSyntax ``document) :
-    TermElabM VersoModuleDocs.Snippet := do
-  let level := getMainVersoModuleDocs (← getEnv) |>.terminalNesting |>.map (· + 1)
-  Doc.elabModSnippet range (doc.raw.getArgs.map (⟨·⟩)) (level.getD 0) |>.execForModule
-
-
+  let msgs ← Core.getAndEmptyMessageLog
+  let (val, msgs') ←
+    try
+      let act := (Doc.elabBlocks (blocks.map (⟨·⟩))).exec declName binders (suggestionMode := .batch)
+      let val ←
+        Elab.withEnableInfoTree false <|
+          match fileMap? with
+          | some fileMap => withTheReader Core.Context ({· with fileMap }) act
+          | none => act
+      pure (val, ← Core.getAndEmptyMessageLog)
+    finally
+      Core.setMessageLog msgs
+  for msg in msgs'.toArray do
+    logAt (← getRef) msg.data (severity := msg.severity) (isSilent := msg.isSilent)
+  pure val
 
 open Lean.Doc in
 open Parser in
 /--
-Adds a Verso docstring to the specified declaration, which should already be present in the
-environment. The docstring is added from a string value, rather than syntax, which means that the
-interactive features are disabled.
--/
-def versoDocStringFromString
-    (declName : Name) (docComment : String) :
-    TermElabM (Array (Doc.Block ElabInline ElabBlock) × Array (Doc.Part ElabInline ElabBlock Empty)) := do
+Parses a Verso docstring from its text and elaborates it for the specified declaration. Because the
+text carries no source positions, interactive features are disabled and any messages are reported at
+the current reference.
 
+`binders` should be the syntax of the parameters to the constant that is being documented, as a null
+node that contains a sequence of bracketed binders, or an empty null node when none are available.
+-/
+def versoDocStringOfText
+    (declName : Name) (binders : Syntax) (docComment : String) :
+    TermElabM (Array (Doc.Block ElabInline ElabBlock) × Array (Doc.Part ElabInline ElabBlock Empty)) := do
   let env ← getEnv
   let ictx : InputContext := .mk docComment (← getFileName)
   let text := ictx.fileMap
@@ -229,27 +224,68 @@ def versoDocStringFromString
   let s := Doc.Parser.document.run ictx pmctx (getTokenTable env) s
 
   if !s.allErrors.isEmpty then
-    for (pos, _, err) in s.allErrors do
+    for (_, _, err) in s.allErrors do
       logError err.toString
     return (#[], #[])
   else
-    let stx := s.stxStack.back
-    let stx := stx.getArgs
-    let msgs ← Core.getAndEmptyMessageLog
-    let (val, msgs') ←
-      try
-        let range? := (← getRef).getRange?
-        let val ←
-          Elab.withEnableInfoTree false <| withTheReader Core.Context ({· with fileMap := text}) <|
-            (Doc.elabBlocks (stx.map (⟨·⟩))).exec declName (mkNullNode #[]) (suggestionMode := .batch)
-        let msgs' ← Core.getAndEmptyMessageLog
-        pure (val, msgs')
-      finally
-        Core.setMessageLog msgs
-    -- Adjust messages to show them at the call site
-    for msg in msgs'.toArray do
-      logAt (← getRef) msg.data (severity := msg.severity)
-    pure val
+    execVersoBlocks declName binders s.stxStack.back.getArgs (fileMap? := some text)
+
+open Lean.Doc in
+open Lean.Parser.Command in
+/--
+Elaborates a Verso docstring for the specified declaration, which should already be present in the
+environment.
+
+`binders` should be the syntax of the parameters to the constant that is being documented, as a null
+node that contains a sequence of bracketed binders. It is used to allow interactive features such as
+document highlights and “find references” to work for documented parameters. If no parameter binders
+are available, pass `Syntax.missing` or an empty null node.
+-/
+
+def versoDocString
+    (declName : Name) (binders : Syntax) (docComment : TSyntax ``docComment) :
+    TermElabM (Array (Doc.Block ElabInline ElabBlock) × Array (Doc.Part ElabInline ElabBlock Empty)) := do
+  -- A docstring already parsed as Verso, or one re-parsable from its source range, supports
+  -- interactive features. A macro-generated docstring has neither, so fall back to its text.
+  let body := docComment.raw[1]
+  if (body.getPos? (canonicalOnly := true)).isSome then
+    -- Source positions are available, so re-parse from source for interactive features.
+    if let some stx ← parseVersoDocString docComment then
+      Doc.elabBlocks (stx.getArgs.map (⟨·⟩)) |>.exec declName binders
+    else return (#[], #[])
+  else if body.isOfKind ``versoCommentBody then
+    if body[0].isOfKind `Lean.Doc.Syntax.parseFailure then
+      -- The markup failed to parse, so re-parse its text to report the error.
+      versoDocStringOfText declName binders body[0][0].getAtomVal
+    else
+      -- A docstring parsed as Verso by a macro, with positions stripped.
+      execVersoBlocks declName binders body[0].getArgs (fileMap? := none)
+  else
+    -- A plain-text doc comment without source positions; parse and elaborate from its text.
+    versoDocStringOfText declName binders docComment.getDocString
+
+open Lean.Doc Parser in
+open Lean.Parser.Command in
+/--
+Parses and elaborates a Verso module docstring.
+-/
+def versoModDocString
+    (range : DeclarationRange) (doc : TSyntax ``document) :
+    TermElabM VersoModuleDocs.Snippet := do
+  let level := getMainVersoModuleDocs (← getEnv) |>.terminalNesting |>.map (· + 1)
+  Doc.elabModSnippet range (doc.raw.getArgs.map (⟨·⟩)) (level.getD 0) |>.execForModule
+
+
+
+/--
+Adds a Verso docstring to the specified declaration, which should already be present in the
+environment. The docstring is added from a string value, rather than syntax, which means that the
+interactive features are disabled.
+-/
+def versoDocStringFromString
+    (declName : Name) (docComment : String) :
+    TermElabM (Array (Doc.Block ElabInline ElabBlock) × Array (Doc.Part ElabInline ElabBlock Empty)) :=
+  versoDocStringOfText declName (mkNullNode #[]) docComment
 
 /--
 Adds a Markdown docstring to the environment, validating documentation links.

--- a/src/Lean/Elab/DocString.lean
+++ b/src/Lean/Elab/DocString.lean
@@ -274,7 +274,12 @@ where
           localInstances := localInstances.push {className := c, fvar := .fvar fv}
 
         if let some (some x') := x then
-          if x'.getId == y then
+          if x'.getKind == ``hole then
+            -- A `_` parameter has no name, so it matches no binder. Drop it from the cursor
+            -- and align the remaining parameters by name; each lifted binder, including
+            -- captured variables, is introduced under its own name below.
+            x := none
+          else if x'.getId == y then
             lctx := lctx.mkLocalDecl fv y ty
             Meta.withLCtx lctx localInstances <|
               addTermInfo' x' (.fvar fv) (lctx? := some lctx) (expectedType? := ty)
@@ -301,7 +306,10 @@ where
     | ``instBinder =>
       let x := binderStx[1][0]
       if x.isMissing then pure #[none] else pure #[some x]
-    | _ => throwErrorAt binderStx "Couldn't interpret binder {binderStx}"
+    | k =>
+      -- A parameter bound by an unbracketed identifier or `_`, as in `def f x` or `where go _`.
+      if k == identKind || k == ``hole then pure #[some binderStx]
+      else throwErrorAt binderStx "Couldn't interpret binder {binderStx}"
   getNames (ids : Syntax) : TermElabM (Array (Option Syntax)) :=
     ids.getArgs.mapM fun x =>
       if x.getKind == identKind || x.getKind == ``hole then
@@ -1209,7 +1217,11 @@ unsafe def roleExpandersForUnsafe (roleName : Ident) :
     let builtins := (← builtinDocRoles.get).get? x |>.getD #[]
     return (← names.mapM (fun x => do return (x, ← evalConst _ x))) ++ builtins
   else
-    let x := roleName.getId
+    -- Builtin roles are not necessarily in the environment at a
+    -- quotation site, so they aren't in the preresolved list. They
+    -- must also be looked up by their plain name, erasing any macro
+    -- scopes a quotation introduced.
+    let x := roleName.getId.eraseMacroScopes
     let hasBuiltin ← resolveBuiltinDocName (← builtinDocRoles.get) x
     return hasBuiltin.toArray.flatten
 
@@ -1228,7 +1240,7 @@ unsafe def codeBlockExpandersForUnsafe (codeBlockName : Ident) :
     let names' := (← builtinDocCodeBlocks.get).get? x |>.getD #[]
     return (← names.mapM (fun x => do return (x, ← evalConst _ x))) ++ names'
   else
-    let x := codeBlockName.getId
+    let x := codeBlockName.getId.eraseMacroScopes
     let hasBuiltin ← resolveBuiltinDocName (← builtinDocCodeBlocks.get) x
     return hasBuiltin.toArray.flatten
 
@@ -1247,7 +1259,7 @@ unsafe def directiveExpandersForUnsafe (directiveName : Ident) :
     let names' := (← builtinDocDirectives.get).get? x |>.getD #[]
     return (← names.mapM (fun x => do return (x, ← evalConst _ x))) ++ names'
   else
-    let x := directiveName.getId
+    let x := directiveName.getId.eraseMacroScopes
     let hasBuiltin ← resolveBuiltinDocName (← builtinDocDirectives.get) x
     return hasBuiltin.toArray.flatten
 
@@ -1265,7 +1277,7 @@ unsafe def commandExpandersForUnsafe (commandName : Ident) :
     let names' := (← builtinDocCommands.get).get? x |>.getD #[]
     return (← names.mapM (fun x => do return (x, ← evalConst _ x))) ++ names'
   else
-    let x := commandName.getId
+    let x := commandName.getId.eraseMacroScopes
     let hasBuiltin :=
       (← builtinDocCommands.get).get? x <|> (← builtinDocCommands.get).get? (`Lean.Doc ++ x)
     return hasBuiltin.toArray.flatten

--- a/src/Lean/Elab/DocString/Builtin.lean
+++ b/src/Lean/Elab/DocString/Builtin.lean
@@ -907,6 +907,20 @@ deriving TypeName
 
 
 /--
+Runs `act` with info trees enabled, returning its result together with the info trees it produced.
+The document's prior info trees are restored afterward; the trees from `act` are added to the
+document only when its info trees were already enabled.
+-/
+def withHighlightingInfoTrees (act : DocM α) : DocM (α × PersistentArray InfoTree) := do
+  let enabled := (← getInfoState).enabled
+  let outer ← getResetInfoTrees
+  let a ← withEnableInfoTree true <| withSaveInfoContext act
+  let trees ← getInfoTrees
+  modifyInfoState fun st => { st with trees := if enabled then outer ++ trees else outer }
+  return (a, trees)
+
+
+/--
 Elaborates a sequence of Lean commands as examples.
 
 To make examples self-contained, elaboration ignores the surrounding section scopes. Modifications
@@ -920,19 +934,24 @@ The flags `error` and `warning` indicate that an error or warning is expected in
 @[builtin_doc_code_block]
 def lean (name : Option Ident := none) (error warning : flag false) («show» : flag true) (code : StrLit) :
     DocM (Block ElabInline ElabBlock) := do
-  let text ← getFileMap
   let env ← getEnv
-  let p := andthenFn whitespace (categoryParserFnImpl `command)
-  -- TODO fallback for non-original syntax
-  let pos := code.raw.getPos? true |>.get!
-  let endPos := code.raw.getTailPos? true |>.get!
-  let endPos := if endPos ≤ text.source.rawEndPos then endPos else text.source.rawEndPos
-  let ictx :=
-    mkInputContext text.source (← getFileName)
-      (endPos := endPos) (endPos_valid := by simp only [endPos]; split <;> simp [*])
+  -- Parse from the file when source positions are available, otherwise from the literal's own
+  -- contents (e.g. for a docstring that came from a macro).
+  let (text, ictx, pos) ←
+    if let some pos := code.raw.getPos? true then
+      let text ← getFileMap
+      let endPos := code.raw.getTailPos? true |>.getD text.source.rawEndPos
+      let endPos := if endPos ≤ text.source.rawEndPos then endPos else text.source.rawEndPos
+      pure (text,
+        mkInputContext text.source (← getFileName)
+          (endPos := endPos) (endPos_valid := by simp only [endPos]; split <;> simp [*]),
+        pos)
+    else
+      let ictx := mkInputContext code.getString (← getFileName)
+      pure (ictx.fileMap, ictx, (0 : String.Pos.Raw))
   let cctx : Command.Context := {fileName := ← getFileName, fileMap := text, snap? := none, cancelTk? := none}
   let scopes := (← get).scopes
-  let (cmds, cmdState, trees) ← withSaveInfoContext do
+  let ((cmds, cmdState), trees) ← withHighlightingInfoTrees do
     let mut cmdState : Command.State := { env, maxRecDepth := ← MonadRecDepth.getMaxRecDepth, scopes }
     let mut pstate : Parser.ModuleParserState := {
       pos
@@ -954,8 +973,7 @@ def lean (name : Option Ident := none) (error warning : flag false) («show» : 
 
     for t in cmdState.infoState.trees do
       pushInfoTree t
-    let trees := (← getInfoTrees)
-    pure (cmds, cmdState, trees)
+    pure (cmds, cmdState)
 
   let mut output := #[]
   for msg in cmdState.messages.toArray do
@@ -1098,7 +1116,7 @@ Treats the provided term as Lean syntax in the documentation's scope.
 def leanRole (type : Option StrLit := none) (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
   let s ← onlyCode xs
   let stx ← parseStrLit leanTermContents s
-  withSaveInfoContext do
+  let (_, trees) ← withHighlightingInfoTrees do
     let ty? ←
       withoutErrToSorry <| do
       if stx[1][1].isMissing then -- no colon
@@ -1111,7 +1129,6 @@ def leanRole (type : Option StrLit := none) (xs : TSyntaxArray `inline) : DocM (
           logErrorAt t m!"Ignoring `{s.getString}` in favor of type provided after colon"
         some <$> elabType stx[1][1]
     withoutErrToSorry <| discard <| elabExtraTerm stx[0] ty?
-  let trees := (← getInfoTrees)
   if h : trees.size > 0 then
     let tm := Data.LeanTerm.mk (← highlightSyntax trees stx)
     return .other {val := .mk tm} #[.code s.getString]
@@ -1125,7 +1142,7 @@ Treats the provided term as Lean syntax in the documentation's scope.
 @[builtin_doc_code_block]
 def leanTerm (code : StrLit) : DocM (Block ElabInline ElabBlock) := do
   let stx ← parseStrLit leanTermContents code
-  withSaveInfoContext do
+  let (_, trees) ← withHighlightingInfoTrees do
     let ty? ←
       withoutErrToSorry <|
       if stx[1][1].isMissing then -- no colon
@@ -1133,7 +1150,6 @@ def leanTerm (code : StrLit) : DocM (Block ElabInline ElabBlock) := do
       else -- type after colon
         some <$> elabType stx[1][1]
     withoutErrToSorry <| discard <| elabExtraTerm stx[0] ty?
-  let trees := (← getInfoTrees)
   if h : trees.size > 0 then
     let tm := Data.LeanTerm.mk (← highlightSyntax trees stx)
     return .other {val := .mk tm} #[.code code.getString]
@@ -1249,7 +1265,7 @@ def assert' (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
   let lhsStx ← parseStrLit assertTermContents lhsCode
   let rhsStx ← parseStrLit assertTermContents rhsCode
   let tyStx? ← tyCode?.mapM (parseStrLit assertTermContents)
-  withSaveInfoContext do
+  let (_, trees) ← withHighlightingInfoTrees do
     let ty? ← withoutErrToSorry <|
       match tyStx? with
       | some tyStx => some <$> elabType tyStx
@@ -1260,7 +1276,6 @@ def assert' (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
       throwError m!"Expected {lhs} = {rhs}, which is {← Meta.whnf lhs} = {← Meta.whnf rhs}, reducing to {← Meta.reduceAll lhs} = {← Meta.reduceAll rhs} but they are not equal."
   let str := lhsCode.getString ++ " = " ++ rhsCode.getString ++
     (tyCode?.map (" : " ++ ·.getString) |>.getD "")
-  let trees ← getInfoTrees
   if trees.size > 0 then
     let mut code := (← highlightSyntax trees lhsStx) ++ " = " ++ (← highlightSyntax trees rhsStx)
     if let some tyStx := tyStx? then
@@ -1277,14 +1292,13 @@ Asserts that an equality holds.
 def assert (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
   let s ← onlyCode xs
   let stx ← parseStrLit termParser.fn s
-  withSaveInfoContext do
+  let (_, trees) ← withHighlightingInfoTrees do
     let ty ← withoutErrToSorry <| elabType stx
     match_expr (← Meta.whnf ty) with
     | Eq _ lhs rhs =>
       unless (← Meta.isDefEq lhs rhs) do
         throwErrorAt stx m!"Expected {lhs} = {rhs}, but they are not definitionally equal"
     | _ => throwErrorAt stx m!"Expected equality type"
-  let trees ← getInfoTrees
   if trees.size > 0 then
     let tm := Data.LeanTerm.mk (← highlightSyntax trees stx)
     return .other {val := .mk tm} #[.code s.getString]

--- a/src/Lean/Elab/DocString/Builtin/Parsing.lean
+++ b/src/Lean/Elab/DocString/Builtin/Parsing.lean
@@ -23,7 +23,24 @@ private def strLitRange [Monad m] [MonadFileMap m] (s : StrLit) : m Lean.Syntax.
 variable [Monad m] [MonadFileMap m] [MonadEnv m]
 variable [MonadError m] [AddMessageContext m] [MonadLog m] [MonadOptions m]
 
+/--
+Parses a string literal's contents directly from its decoded value rather than from the source file.
+This is used when the literal has no source position, as in a docstring that came from a macro.
+-/
+private def parseFromContents (p : ParserFn) (contents : String) : m Syntax := do
+  let env ← getEnv
+  let ictx := mkInputContext contents (← getFileName)
+  let s := p.run ictx { env, options := ← getOptions } (getTokenTable env) (mkParserState contents)
+  if !s.allErrors.isEmpty then
+    throwError (s.toErrorMsg ictx)
+  else if ictx.atEnd s.pos then
+    pure s.stxStack.back
+  else
+    throwError ((s.mkError "end of input").toErrorMsg ictx)
+
 def parseStrLit (p : ParserFn) (s : StrLit) : m Syntax := do
+  if (s.raw.getPos? (canonicalOnly := true)).isNone then
+    return ← parseFromContents p s.getString
   let text ← getFileMap
   let env ← getEnv
   let ⟨pos, endPos⟩ ← strLitRange s
@@ -43,6 +60,8 @@ def parseStrLit (p : ParserFn) (s : StrLit) : m Syntax := do
     throwError ((s.mkError "end of input").toErrorMsg ictx)
 
 def parseQuotedStrLit (p : ParserFn) (strLit : StrLit) : m Syntax := do
+  if (strLit.raw.getPos? (canonicalOnly := true)).isNone then
+    return ← parseFromContents p strLit.getString
   let text ← getFileMap
   let env ← getEnv
   let ⟨pos, _⟩ ← strLitRange strLit
@@ -100,6 +119,18 @@ where
     return n
 
 def parseStrLit' (p : ParserFn) (s : StrLit) : m (Syntax × Bool) := do
+  if (s.raw.getPos? (canonicalOnly := true)).isNone then
+    let contents := s.getString
+    let env ← getEnv
+    let ictx := mkInputContext contents (← getFileName)
+    let st := p.run ictx { env, options := ← getOptions } (getTokenTable env) (mkParserState contents)
+    let err ←
+      if !st.allErrors.isEmpty then
+        logError (st.toErrorMsg ictx); pure true
+      else if !ictx.atEnd st.pos then
+        logError ((st.mkError "end of input").toErrorMsg ictx); pure true
+      else pure false
+    return (st.stxStack.back, err)
   let text ← getFileMap
   let env ← getEnv
   let endPos := s.raw.getTailPos? true |>.get!

--- a/tests/elab/versoDocsMacro.lean
+++ b/tests/elab/versoDocsMacro.lean
@@ -1,0 +1,83 @@
+import Lean
+/-!
+# Verso docstrings on macro-generated declarations
+
+A docstring produced by a macro is already parsed as Verso but carries no source positions, so it
+is elaborated from the stored syntax and its contents are parsed from their text. Role names refer
+to a global vocabulary, so macro scopes introduced by the quotation are ignored when resolving them.
+References to globals resolve and code is highlighted; references to the declaration's own
+parameters do not resolve, since the reference text does not share the binders' hygiene.
+-/
+
+section
+
+open Lean Elab Command
+
+deriving instance Repr for VersoDocString
+
+def printVersoDocstring (x : Name) : CommandElabM Unit := do
+  match ← findInternalDocString? (← getEnv) x with
+  | none => throwError m!"No docstring for {.ofConstName x}"
+  | some (.inl md) => throwError m!"Only a Markdown docstring for {.ofConstName x}:\n{md}"
+  | some (.inr v) => IO.println (repr v)
+
+end
+
+set_option doc.verso true
+
+-- A macro-generated declaration with a Verso docstring referencing a global constant.
+macro "defWithDoc" nm:ident : command => `(
+  /-- Built on {lean}`Nat.succ`. -/
+  def $nm := 0)
+defWithDoc macroGenerated
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.text "Built on ",
+                Lean.Doc.Inline.other
+                  { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ }
+                  #[Lean.Doc.Inline.code "Nat.succ"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``macroGenerated
+
+-- A macro-generated declaration whose parameter is written as a bare identifier.
+macro "defBare" nm:ident : command => `(
+  /-- Returns {lean}`Nat.succ`. -/
+  def $nm x := x + 1)
+defBare macroBare
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.text "Returns ",
+                Lean.Doc.Inline.other
+                  { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ }
+                  #[Lean.Doc.Inline.code "Nat.succ"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``macroBare
+
+-- A macro-generated docstring containing a `lean` code block whose commands are elaborated.
+macro "defCodeBlock" nm:ident : command => `(
+/--
+A code block:
+```lean
+#check Nat.succ
+```
+-/
+def $nm := 0)
+defCodeBlock macroCodeBlock
+
+/--
+info: { text := #[Lean.Doc.Block.para #[Lean.Doc.Inline.text "A code block:"],
+            Lean.Doc.Block.other
+              { val := Dynamic.mk `Lean.Doc.Data.LeanBlock _ }
+              #[Lean.Doc.Block.code "#check Nat.succ\n"]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``macroCodeBlock

--- a/tests/elab/versoDocsMacro.lean
+++ b/tests/elab/versoDocsMacro.lean
@@ -2,11 +2,7 @@ import Lean
 /-!
 # Verso docstrings on macro-generated declarations
 
-A docstring produced by a macro is already parsed as Verso but carries no source positions, so it
-is elaborated from the stored syntax and its contents are parsed from their text. Role names refer
-to a global vocabulary, so macro scopes introduced by the quotation are ignored when resolving them.
-References to globals resolve and code is highlighted; references to the declaration's own
-parameters do not resolve, since the reference text does not share the binders' hygiene.
+This test ensures that Verso docstrings in macro-generated definitions respect hygiene for role names.
 -/
 
 section

--- a/tests/elab/versoDocsWhere.lean
+++ b/tests/elab/versoDocsWhere.lean
@@ -1,8 +1,10 @@
 import Lean
 /-!
-# Verso Docstrings on `where`-clause declarations
+# Verso docstrings on local declarations with parameters
 
-This test checks that Verso docstrings work correctly on declarations in a `where` clause.
+This test checks that Verso docstrings work correctly on declarations in a `where` clause or
+`let rec`, including ones whose parameters are written as unbracketed identifiers or `_` rather
+than parenthesized binders.
 
 -/
 
@@ -86,3 +88,346 @@ info: { text := #[Lean.Doc.Block.para
 -/
 #guard_msgs in
 #eval printVersoDocstring ``withType.helper
+
+
+-- Inner definitions whose parameters are written as bare identifiers rather
+-- than parenthesized binders must also accept Verso docstrings.
+
+-- Bare parameter with a return-type annotation
+/-- Outer 1. -/
+def withParam := go 1
+  where
+  /-- Returns {lean}`n`. -/
+  go n : Nat := n
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.text "Returns ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "n"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``withParam.go
+
+
+-- Bare parameter with no return-type annotation
+/-- Outer 2. -/
+def withParamNoType := go 1
+  where
+  /-- Returns {lean}`n`. -/
+  go n := n
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.text "Returns ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "n"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``withParamNoType.go
+
+
+-- Multiple bare parameters
+/-- Outer 3. -/
+def withParams := go 1 2
+  where
+  /-- Sums {lean}`n` and {lean}`m`. -/
+  go n m := n + m
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.text "Sums ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "n"],
+                Lean.Doc.Inline.text " and ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "m"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``withParams.go
+
+
+-- Mix of parenthesized and bare parameters
+/-- Outer 4. -/
+def withMixedParams := go 1 2
+  where
+  /-- Sums {lean}`n` and {lean}`m`. -/
+  go (n : Nat) m := n + m
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.text "Sums ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "n"],
+                Lean.Doc.Inline.text " and ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "m"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``withMixedParams.go
+
+
+-- `let rec` with a bare parameter
+/-- Outer 5. -/
+def withLetRec : Nat :=
+  let rec /-- Returns {lean}`n`. -/ go n := n
+  go 1
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.text "Returns ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "n"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``withLetRec.go
+
+
+-- Bare parameters on a top-level definition, with the parameter type inferred
+-- from the body.
+
+/-- Returns {lean}`x`. -/
+def bareOne x := x + 5
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.text "Returns ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "x"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``bareOne
+
+
+/-- Sums {lean}`x` and {lean}`y`. -/
+def bareMany x y := x + y + (0 : Nat)
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.text "Sums ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "x"],
+                Lean.Doc.Inline.text " and ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "y"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``bareMany
+
+
+/-- Sums {lean}`x` and {lean}`y`. -/
+def bareMixed (x : Nat) y := x + y
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.text "Sums ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "x"],
+                Lean.Doc.Inline.text " and ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "y"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``bareMixed
+
+
+-- A bare parameter may also be a hole `_`.
+
+/-- Outer 6. -/
+def withHole := go 1
+  where
+  /-- Hole parameter. -/
+  go _ := 5
+
+/--
+info: { text := #[Lean.Doc.Block.para #[Lean.Doc.Inline.text "Hole parameter. "]], subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``withHole.go
+
+
+/-- Outer 7. -/
+def withIdentHole := go 1 2
+  where
+  /-- Returns {lean}`x`. -/
+  go x _ := x
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.text "Returns ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "x"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``withIdentHole.go
+
+
+-- Bracketed binders: default values, tactic defaults, named instance binders, and strict implicits.
+
+/-- Returns {lean}`x`. -/
+def binderDefault (x : Nat := 0) := x
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.text "Returns ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "x"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``binderDefault
+
+
+/-- Returns {lean}`x`. -/
+def binderTacticDefault (x : Nat := by exact 0) := x
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.text "Returns ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "x"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``binderTacticDefault
+
+
+/-- Uses {lean}`inst`. -/
+def namedInstBinder [inst : Inhabited Nat] := (default : Nat)
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.text "Uses ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "inst"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``namedInstBinder
+
+
+/-- Ignores {lean}`x`. -/
+def strictImplicit ⦃x : Nat⦄ := (0 : Nat)
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.text "Ignores ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "x"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``strictImplicit
+
+
+-- Holes interspersed among named parameters of distinct types. The references are
+-- type-sensitive (`String.length`, `Nat` addition), so a parameter associated with the
+-- wrong position would fail to elaborate.
+
+-- A hole between a `String` and a `Nat` parameter.
+/-- Outer 8. -/
+def orderMid := go "x" true 0
+  where
+  /-- {lean}`s.length` then {lean}`n + 1`. -/
+  go (s : String) _ (n : Nat) := (s, n)
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.other
+                  { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ }
+                  #[Lean.Doc.Inline.code "s.length"],
+                Lean.Doc.Inline.text " then ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "n + 1"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``orderMid.go
+
+
+-- Holes at both ends, around a `String` parameter.
+/-- Outer 9. -/
+def orderEnds := go 0 "y" false
+  where
+  /-- Just {lean}`t.length`. -/
+  go _ (t : String) _ := t
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.text "Just ",
+                Lean.Doc.Inline.other
+                  { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ }
+                  #[Lean.Doc.Inline.code "t.length"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``orderEnds.go
+
+
+-- A `where` helper with a leading `_` parameter that also captures an outer variable. The
+-- captured variable stays in scope under its own name, and the named parameter resolves.
+/-- Outer 10. -/
+def captureLeadHole (c : Nat) := go 1 2
+  where
+  /-- Captures {lean}`c`, returns {lean}`y`. -/
+  go _ y := y + c
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.text "Captures ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "c"],
+                Lean.Doc.Inline.text ", returns ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "y"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``captureLeadHole.go
+
+
+-- A `_` in a bracketed binder followed by a named explicit parameter; the named one resolves.
+/-- Returns {lean}`m`. -/
+def implicitHoleThenNamed {_ : Nat} (m : Nat) := m
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.text "Returns ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "m"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``implicitHoleThenNamed
+
+
+/-- Returns {lean}`y`. -/
+def strictImplicitHoleThenNamed ⦃_ : Nat⦄ (y : Nat) := y
+
+/--
+info: { text := #[Lean.Doc.Block.para
+              #[Lean.Doc.Inline.text "Returns ",
+                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "y"],
+                Lean.Doc.Inline.text ". "]],
+  subsections := #[] }
+-/
+#guard_msgs in
+#eval printVersoDocstring ``strictImplicitHoleThenNamed
+
+
+-- A `_` parameter binds under an inaccessible name even when the surrounding type ascribes
+-- a name to that position. Resolution stays limited to the typed binders, so the reference
+-- to `n` reports an unknown identifier.
+/--
+error: Unknown identifier `n`
+-/
+#guard_msgs in
+def holeNotInScope : (n : Nat) → Nat := go
+  where
+  /-- ref {lean}`n` -/
+  go _ := 2


### PR DESCRIPTION
This PR fixes a bug where references to parameters by names failed for unbracketed binders, in the presence of `_` parameters, and in macro-generated declarations.

Parameters are introduced by walking the declaration's binders, matching them up to the elaborated type. Cases were missing for bare identifiers and `_`.
