### PR TITLE
fix: used parsed docstring format regardless of local setting

### DIFF
--- a/src/Lean/DocString/Add.lean
+++ b/src/Lean/DocString/Add.lean
@@ -388,9 +388,10 @@ def makeDocStringVerso (declName : Name) : TermElabM Unit := do
 /--
 Adds a docstring to the environment.
 
-If the option `doc.verso` is `true`, the docstring is processed as a Verso docstring. Otherwise, it
-is considered a Markdown docstring, and documentation links are validated. To explicitly control
-whether the docstring is in Verso format, use `addDocStringOf` instead.
+Whether the docstring is processed as Verso or as Markdown is determined by the form of its syntax
+tree. To explicitly control whether the docstring is in Verso format, use `addDocStringOf` instead.
+
+Markdown docstrings have their documentation links validated.
 
 For Verso docstrings, `binders` should be the syntax of the parameters to the constant that is being
 documented, as a null node that contains a sequence of bracketed binders. It is used to allow
@@ -401,15 +402,17 @@ parameters. If no parameter binders are available, pass `Syntax.missing` or an e
 def addDocString
     (declName : Name) (binders : Syntax) (docComment : TSyntax `Lean.Parser.Command.docComment) :
     TermElabM Unit := do
-  addDocStringOf (doc.verso.get (← getOptions)) declName binders docComment
+  addDocStringOf (isVersoDocComment docComment) declName binders docComment
 
 /--
 Adds a docstring to the environment, if it is provided. If no docstring is provided, nothing
 happens.
 
-If the option `doc.verso` is `true`, the docstring is processed as a Verso docstring. Otherwise, it
-is considered a Markdown docstring, and documentation links are validated. To explicitly control
-whether the docstring is in Verso format, use `addDocStringOf` instead.
+Whether the docstring is processed as Verso or as Markdown is determined by its syntax tree, which
+reflects the `doc.verso` option at the docstring's parse site.  To explicitly control whether the
+docstring is in Verso format, use `addDocStringOf` instead.
+
+Markdown docstrings have their documentation links validated.
 
 For Verso docstrings, `binders` should be the syntax of the parameters to the constant that is being
 documented, as a null node that contains a sequence of bracketed binders. It is used to allow

--- a/src/Lean/DocString/Extension.lean
+++ b/src/Lean/DocString/Extension.lean
@@ -190,6 +190,12 @@ def getDocStringText [Monad m] [MonadError m] (stx : TSyntax `Lean.Parser.Comman
   | _ =>
     throwErrorAt stx "unexpected doc string{indentD stx}"
 
+/--
+Checks whether `stx` is a docstring that was parsed as Verso rather than Markdown.
+-/
+def isVersoDocComment (stx : TSyntax `Lean.Parser.Command.docComment) : Bool :=
+  stx.raw[1].isOfKind `Lean.Parser.Command.versoCommentBody
+
 
 
 /--

--- a/src/Lean/Elab/DeclModifiers.lean
+++ b/src/Lean/Elab/DeclModifiers.lean
@@ -126,9 +126,9 @@ structure Modifiers where
   /-- Input syntax, used for adjusting declaration range (unless missing) -/
   stx             : TSyntax ``Parser.Command.declModifiers := ⟨.missing⟩
   /--
-  The docstring, if present, and whether it's Verso.
+  The docstring, if present.
   -/
-  docString?      : Option (TSyntax ``Parser.Command.docComment × Bool) := none
+  docString?      : Option (TSyntax ``Parser.Command.docComment) := none
   visibility      : Visibility := Visibility.regular
   isProtected     : Bool := false
   computeKind     : ComputeKind := .regular
@@ -225,7 +225,7 @@ def elabModifiers (stx : TSyntax ``Parser.Command.declModifiers) : m Modifiers :
       RecKind.partial
     else
       RecKind.nonrec
-  let docString? := docCommentStx.getOptional?.map (TSyntax.mk ·, doc.verso.get (← getOptions))
+  let docString? := docCommentStx.getOptional?.map (TSyntax.mk ·)
   let visibility ← elabVisibility (visibilityStx.getOptional?.map (⟨·⟩))
   let isProtected := !protectedStx.isNone
   let attrs ← match attrsStx.getOptional? with
@@ -308,8 +308,8 @@ structure ExpandDeclIdResult where
   declName   : Name
   /-- Universe parameter names provided using the `universe` command and `.{...}` notation. -/
   levelNames : List Name
-  /-- The docstring, and whether it's Verso -/
-  docString? : Option (TSyntax ``Parser.Command.docComment × Bool)
+  /-- The docstring. -/
+  docString? : Option (TSyntax ``Parser.Command.docComment)
 
 open Lean.Elab.Term (TermElabM)
 

--- a/src/Lean/Elab/Declaration.lean
+++ b/src/Lean/Elab/Declaration.lean
@@ -135,8 +135,8 @@ def elabAxiom (modifiers : Modifiers) (stx : Syntax) : CommandElabM Unit := do
         Term.applyAttributesAt declName modifiers.attrs AttributeApplicationTime.afterTypeChecking
         if isExtern (← getEnv) declName then
           compileDecl decl
-        if let some (doc, isVerso) := docString? then
-          addDocStringOf isVerso declName binders doc
+        if let some doc := docString? then
+          addDocString declName binders doc
         Term.applyAttributesAt declName modifiers.attrs AttributeApplicationTime.afterCompilation
         withSaveInfoContext do  -- save new env with docstring and decl
           Term.addTermInfo' declId (← mkConstWithLevelParams declName) (isBinder := true)

--- a/src/Lean/Elab/DefView.lean
+++ b/src/Lean/Elab/DefView.lean
@@ -114,8 +114,8 @@ structure DefView where
   binders       : Syntax
   type?         : Option Syntax
   value         : Syntax
-  /-- The docstring, if present, and whether it's Verso -/
-  docString?    : Option (TSyntax ``Parser.Command.docComment × Bool)
+  /-- The docstring, if present. -/
+  docString?    : Option (TSyntax ``Parser.Command.docComment)
   /--
   Snapshot for incremental processing of this definition.
 

--- a/src/Lean/Elab/Inductive.lean
+++ b/src/Lean/Elab/Inductive.lean
@@ -54,7 +54,7 @@ private def inductiveSyntaxToView (modifiers : Modifiers) (decl : Syntax) (isCoi
         if ctorModifiers.docString?.isSome then
           logErrorAt leadingDocComment "Duplicate doc string"
         ctorModifiers := { ctorModifiers with
-          docString? := some (⟨leadingDocComment⟩, doc.verso.get (← getOptions)) }
+          docString? := some ⟨leadingDocComment⟩ }
       if ctorModifiers.isPrivate && modifiers.isPrivate then
         let hint ← do
           let .original .. := modifiersStx.getHeadInfo | pure .nil

--- a/src/Lean/Elab/LetRec.lean
+++ b/src/Lean/Elab/LetRec.lean
@@ -25,7 +25,7 @@ structure LetRecDeclView where
   mvar          : Expr -- auxiliary metavariable used to lift the 'let rec'
   valStx        : Syntax
   termination   : TerminationHints
-  docString?    : Option (TSyntax ``Parser.Command.docComment × Bool) := none
+  docString?    : Option (TSyntax ``Parser.Command.docComment) := none
 
 structure LetRecView where
   decls     : Array LetRecDeclView
@@ -34,9 +34,8 @@ structure LetRecView where
 /-  group ("let " >> nonReservedSymbol "rec ") >> sepBy1 (group (optional «attributes» >> letDecl)) ", " >> "; " >> termParser -/
 private def mkLetRecDeclView (letRec : Syntax) : TermElabM LetRecView := do
   let mut decls : Array LetRecDeclView := #[]
-  let isVerso := doc.verso.get (← getOptions)
   for attrDeclStx in letRec[1][0].getSepArgs do
-    let docStr? := attrDeclStx[0].getOptional?.map (TSyntax.mk ·, isVerso)
+    let docStr? := attrDeclStx[0].getOptional?.map (TSyntax.mk ·)
     let attrOptStx := attrDeclStx[1]
     let attrs ← if attrOptStx.isNone then pure #[] else elabDeclAttrs attrOptStx[0]
     let decl := attrDeclStx[2][0]

--- a/src/Lean/Elab/MutualInductive.lean
+++ b/src/Lean/Elab/MutualInductive.lean
@@ -104,8 +104,8 @@ structure InductiveView where
   ctors           : Array CtorView
   computedFields  : Array ComputedFieldView
   derivingClasses : Array DerivingClassView
-  /-- The declaration docstring, and whether it's Verso -/
-  docString?      : Option (TSyntax ``Lean.Parser.Command.docComment × Bool)
+  /-- The declaration docstring. -/
+  docString?      : Option (TSyntax ``Lean.Parser.Command.docComment)
   isCoinductive : Bool := false
   deriving Inhabited
 
@@ -1678,12 +1678,12 @@ private def elabInductiveViewsPostprocessing (views : Array InductiveView) :
   liftTermElabM <| Term.withDeclName view0.declName do withRef ref do
     for view in views do
       withRef view.declId do
-        if let some (doc, verso) := view.docString? then
-          addDocStringOf verso view.declName view.binders doc
+        if let some doc := view.docString? then
+          addDocString view.declName view.binders doc
       for ctor in view.ctors do
         withRef ctor.declId do
-          if let some (doc, verso) := ctor.modifiers.docString? then
-            addDocStringOf verso ctor.declName ctor.binders doc
+          if let some doc := ctor.modifiers.docString? then
+            addDocString ctor.declName ctor.binders doc
 
     for view in views do withRef view.declId <|
       unless (views.any (·.isCoinductive)) do

--- a/src/Lean/Elab/PreDefinition/Basic.lean
+++ b/src/Lean/Elab/PreDefinition/Basic.lean
@@ -163,9 +163,9 @@ docstring. If code generation will not occur, then it should be done after addin
 to the environment.
 -/
 def addPreDefDocs (docCtx : LocalContext × LocalInstances) (preDef : PreDefinition) : TermElabM Unit := do
-  if let some (doc, isVerso) := preDef.modifiers.docString? then
+  if let some doc := preDef.modifiers.docString? then
     withLCtx docCtx.1 docCtx.2 do
-      addDocStringOf isVerso preDef.declName preDef.binders doc
+      addDocString preDef.declName preDef.binders doc
 
 /--
 Adds constant info to the definition name. This should occur after executing post-compilation

--- a/src/Lean/Elab/Structure.lean
+++ b/src/Lean/Elab/Structure.lean
@@ -1581,8 +1581,8 @@ def elabStructureCommand : InductiveElabDescr where
                   for field in view.fields do
                     -- may not exist if overriding inherited field
                     if (← getEnv).contains field.declName then
-                      if let some (doc, isVerso) := field.modifiers.docString? then
-                        addDocStringOf isVerso field.declName field.binders doc
+                      if let some doc := field.modifiers.docString? then
+                        addDocString field.declName field.binders doc
                   -- Add terminfo after docstrings so hovers include the docstring.
                   withSaveInfoContext do
                     for field in view.fields do

--- a/src/Lean/Elab/Term/TermElabM.lean
+++ b/src/Lean/Elab/Term/TermElabM.lean
@@ -169,9 +169,9 @@ structure LetRecToLift where
   termination    : TerminationHints
   /-- The binders syntax for the declaration, used for docstring elaboration. -/
   binders        : Syntax := .missing
-  /-- The docstring, if present, and whether it's Verso. Docstring processing is deferred until the
-  declaration is added to the environment (needed for Verso docstrings to work). -/
-  docString?     : Option (TSyntax ``Lean.Parser.Command.docComment × Bool) := none
+  /-- The docstring, if present. Docstring processing is deferred until the declaration is added to
+  the environment (needed for Verso docstrings to work). -/
+  docString?     : Option (TSyntax ``Lean.Parser.Command.docComment) := none
   deriving Inhabited
 
 /--

--- a/tests/elab/versoDocMacroModeMismatch.lean
+++ b/tests/elab/versoDocMacroModeMismatch.lean
@@ -1,0 +1,109 @@
+import Lean
+
+/-!
+This test ensures that docstrings in syntax produced by macros are processed correctly, even in
+contexts where `doc.verso` has a different value that the quotation's parse site.
+
+All four combinations of (definition-site format) × (invocation-site format) are covered.
+-/
+
+open Lean Elab Command Doc
+
+private partial def inlineStr : Inline ElabInline → String
+  | .text s => s
+  | .code s => s!"code[{s}]"
+  | .emph xs => s!"emph[{String.join (xs.map inlineStr).toList}]"
+  | .bold xs => s!"bold[{String.join (xs.map inlineStr).toList}]"
+  | .concat xs | .link xs _ | .footnote _ xs => String.join (xs.map inlineStr).toList
+  | .other _ xs => s!"role[{String.join (xs.map inlineStr).toList}]"
+  | _ => ""
+
+private def blockKindAndText : Block ElabInline ElabBlock → String
+  | .para inlines => s!"para: {String.join (inlines.map inlineStr).toList}"
+  | .blockquote .. => "blockquote"
+  | .ul .. => "ul"
+  | .ol .. => "ol"
+  | .dl .. => "dl"
+  | .code .. => "code"
+  | .concat .. => "concat"
+  | .other .. => "other"
+
+/-- Dumps the stored docstring of `name`: the literal Markdown string, or the Verso block dump. -/
+elab "#dumpDoc " name:ident : command => do
+  let env ← getEnv
+  runTermElabM fun _ => do
+    let declName ← realizeGlobalConstNoOverloadWithInfo name
+    match (← findInternalDocString? env declName (includeBuiltin := true)) with
+    | none => logInfo "none"
+    | some (.inl md) => logInfo m!"markdown: {repr md}"
+    | some (.inr doc) => logInfo m!"verso: {String.intercalate "; " (doc.text.map blockKindAndText).toList}"
+
+/-
+A macro defined where `doc.verso` is off: its `/-- ... -/` is parsed as Markdown. `{x}` is literal
+text, not Verso role syntax.
+-/
+section
+set_option doc.verso false
+macro "mdMacro" nm:ident : command => `(/-- The set {x} is a singleton. -/ def $nm := 0)
+end
+
+/-
+A macro defined where `doc.verso` is on: its `/-- ... -/` is parsed as a Verso AST. `{lean}` is a
+role applied to inline code.
+-/
+section
+set_option doc.verso true
+macro "versoMacro" nm:ident : command => `(/-- Uses {lean}`Nat.succ`. -/ def $nm := 0)
+end
+
+-- Markdown definition site, Markdown invocation site: stored as Markdown.
+#guard_msgs in
+set_option doc.verso false in
+mdMacro caseMdMd
+
+/-- info: markdown: "The set {x} is a singleton. " -/
+#guard_msgs in #dumpDoc caseMdMd
+
+-- Markdown definition site, Verso invocation site: stored as Markdown (definition site wins). The
+-- literal `{x}` must not be re-parsed as Verso role syntax.
+#guard_msgs in
+set_option doc.verso true in
+mdMacro caseMdVerso
+
+/-- info: markdown: "The set {x} is a singleton. " -/
+#guard_msgs in #dumpDoc caseMdVerso
+
+-- Verso definition site, Markdown invocation site: stored as Verso (definition site wins). The Verso
+-- AST must not be handed to the Markdown text extractor.
+#guard_msgs in
+set_option doc.verso false in
+versoMacro caseVersoMd
+
+/-- info: verso: para: Uses role[code[Nat.succ]]. -/
+#guard_msgs in #dumpDoc caseVersoMd
+
+-- Verso definition site, Verso invocation site: stored as Verso.
+#guard_msgs in
+set_option doc.verso true in
+versoMacro caseVersoVerso
+
+/-- info: verso: para: Uses role[code[Nat.succ]]. -/
+#guard_msgs in #dumpDoc caseVersoVerso
+
+/-
+Sanity: ordinary (non-macro) declarations still store the form selected by `doc.verso` at their own
+site.
+-/
+set_option doc.verso false in
+/-- Uses {lean}`Nat.succ` literally. -/
+def plainMarkdown := 0
+
+/-- info: markdown: "Uses {lean}`Nat.succ` literally. " -/
+#guard_msgs in #dumpDoc plainMarkdown
+
+set_option doc.verso true in
+/-- Uses {lean}`Nat.succ`. -/
+def plainVerso := 0
+
+/-- info: verso: para: Uses role[code[Nat.succ]]. -/
+#guard_msgs in #dumpDoc plainVerso


### PR DESCRIPTION
This PR causes docstrings in macros to follow the value of the `doc.verso` option at the the macro's definition site, rather than its use site. Before, the use-site option was used, making it impossible to use macros in contexts where the option's value disagreed because the parsed format was incorrect. Now, the parsed format in the syntax is used regardless of the option's local setting.

Because the syntactic form of the docstring now fully determines its interpretation, the Boolean interpretation flag was also removed.
