### PR TITLE
fix: stop using `cleanup` in `impossible` tactic

### DIFF
--- a/src/Lean/Elab/Tactic/Impossible.lean
+++ b/src/Lean/Elab/Tactic/Impossible.lean
@@ -8,7 +8,6 @@ module
 prelude
 public import Lean.Elab.Tactic.Basic
 public import Lean.Elab.ConfigEval
-public import Lean.Meta.Tactic.Cleanup
 public import Lean.Meta.Tactic.Revert
 public import Lean.Meta.Tactic.Intro
 public import Lean.Meta.Closure
@@ -32,10 +31,10 @@ private def mkImpossibleNegType (mainGoal : MVarId) (goalType : Expr)
     (cfg : Parser.Tactic.ImpossibleConfig) :
     MetaM (Expr × Array Name) := mainGoal.withContext do
   let dummy ← mkFreshExprSyntheticOpaqueMVar goalType
-  let cleaned ← dummy.mvarId!.cleanup
-  let (_, reverted) ← cleaned.revert
+  let dummyMVarId := dummy.mvarId!
+  let (_, reverted) ← dummyMVarId.revert
     (clearAuxDeclsInsteadOfRevert := true)
-    (← cleaned.getDecl).lctx.getFVarIds
+    (← dummyMVarId.getDecl).lctx.getFVarIds
   let revertedType ← reverted.getType
   let r ← Closure.mkValueTypeClosure revertedType (mkConst ``True)
     (zetaDelta := false)

--- a/src/Lean/Elab/Tactic/Impossible.lean
+++ b/src/Lean/Elab/Tactic/Impossible.lean
@@ -32,9 +32,13 @@ private def mkImpossibleNegType (mainGoal : MVarId) (goalType : Expr)
     MetaM (Expr × Array Name) := mainGoal.withContext do
   let dummy ← mkFreshExprSyntheticOpaqueMVar goalType
   let dummyMVarId := dummy.mvarId!
-  let (_, reverted) ← dummyMVarId.revert
+  let mut toRevert : Array FVarId := #[]
+  for fvarId in (← dummyMVarId.getDecl).lctx.getFVarIds do
+    unless (← fvarId.getDecl).isAuxDecl do
+      toRevert := toRevert.push fvarId
+  let (_, reverted) ← dummyMVarId.revert toRevert
+    (preserveOrder := true)
     (clearAuxDeclsInsteadOfRevert := true)
-    (← dummyMVarId.getDecl).lctx.getFVarIds
   let revertedType ← reverted.getType
   let r ← Closure.mkValueTypeClosure revertedType (mkConst ``True)
     (zetaDelta := false)

--- a/tests/elab/impossibleTactic.lean
+++ b/tests/elab/impossibleTactic.lean
@@ -33,6 +33,12 @@ example (n : Nat) : n = n + 1 := by
     intro h
     exact Nat.succ_ne_zero _ ((h 0).symm)
 
+-- The `impossible` tactic must not succeed on provable goals.
+#guard_msgs (drop error) in
+example (xs : List α) (h : xs.length > 0) : xs ≠ [] := by
+  intro h_empty
+  impossible by simp
+
 -- Expression metavariables in the goal are abstracted as additional binders;
 -- those are introduced into the local context *before* the user's tactic runs,
 -- with the negation pushed under the mvar binders but over the reverted ones.

--- a/tests/elab/impossibleTactic.lean
+++ b/tests/elab/impossibleTactic.lean
@@ -34,7 +34,11 @@ example (n : Nat) : n = n + 1 := by
     exact Nat.succ_ne_zero _ ((h 0).symm)
 
 -- The `impossible` tactic must not succeed on provable goals.
-#guard_msgs (drop error) in
+/--
+error: unsolved goals
+⊢ False
+-/
+#guard_msgs in
 example (xs : List α) (h : xs.length > 0) : xs ≠ [] := by
   intro h_empty
   impossible by simp


### PR DESCRIPTION
This PR fixes a bug where the `impossible` tactic could succeed on provable goals.

AI assistance: I used OpenAI Codex while preparing this PR.

see Zulip discussion: [#lean4 > Spurious firing of the impossible tactic](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Spurious.20firing.20of.20the.20impossible.20tactic/with/606927586)