### PR TITLE
feat: use linter framework for deferred docstring checks

### DIFF
--- a/src/Lean/DocString/Add.lean
+++ b/src/Lean/DocString/Add.lean
@@ -8,6 +8,7 @@ module
 
 prelude
 import Lean.Elab.DocString
+public import Lean.DocString.DeferredCheck
 public import Lean.DocString.Parser
 public import Lean.Elab.Term.TermElabM
 
@@ -174,13 +175,26 @@ def reportVersoParseFailure
 
 open Lean.Doc in
 /--
+The result of elaborating a Verso docstring, which consists of the docstring contents paired with a
+set of deferred checks.
+-/
+public structure VersoDocResult extends VersoDocString where
+  /--
+  Checks that cannot be carried out during elaboration, typically because they require information
+  that is not yet available.
+  -/
+  deferredChecks : Array DeferredCheck
+
+
+open Lean.Doc in
+/--
 Elaborates already-parsed Verso `blocks` for the specified declaration with interactive features
 disabled, reporting any elaboration messages at the current reference. When `fileMap?` is provided,
 message positions are interpreted against it.
 -/
 private def execVersoBlocks
     (declName : Name) (binders : Syntax) (blocks : Array Syntax) (fileMap? : Option FileMap) :
-    TermElabM (Array (Doc.Block ElabInline ElabBlock) × Array (Doc.Part ElabInline ElabBlock Empty)) := do
+    TermElabM VersoDocResult := do
   let msgs ← Core.getAndEmptyMessageLog
   let (val, msgs') ←
     try
@@ -195,7 +209,8 @@ private def execVersoBlocks
       Core.setMessageLog msgs
   for msg in msgs'.toArray do
     logAt (← getRef) msg.data (severity := msg.severity) (isSilent := msg.isSilent)
-  pure val
+  let ((text, subsections), deferredChecks) := val
+  pure { text, subsections, deferredChecks }
 
 open Lean.Doc in
 open Parser in
@@ -209,7 +224,7 @@ node that contains a sequence of bracketed binders, or an empty null node when n
 -/
 def versoDocStringOfText
     (declName : Name) (binders : Syntax) (docComment : String) :
-    TermElabM (Array (Doc.Block ElabInline ElabBlock) × Array (Doc.Part ElabInline ElabBlock Empty)) := do
+    TermElabM VersoDocResult := do
   let env ← getEnv
   let ictx : InputContext := .mk docComment (← getFileName)
   let text := ictx.fileMap
@@ -226,7 +241,7 @@ def versoDocStringOfText
   if !s.allErrors.isEmpty then
     for (_, _, err) in s.allErrors do
       logError err.toString
-    return (#[], #[])
+    return { text := #[], subsections := #[], deferredChecks := #[] }
   else
     execVersoBlocks declName binders s.stxStack.back.getArgs (fileMap? := some text)
 
@@ -244,15 +259,16 @@ are available, pass `Syntax.missing` or an empty null node.
 
 def versoDocString
     (declName : Name) (binders : Syntax) (docComment : TSyntax ``docComment) :
-    TermElabM (Array (Doc.Block ElabInline ElabBlock) × Array (Doc.Part ElabInline ElabBlock Empty)) := do
+    TermElabM VersoDocResult := do
   -- A docstring already parsed as Verso, or one re-parsable from its source range, supports
   -- interactive features. A macro-generated docstring has neither, so fall back to its text.
   let body := docComment.raw[1]
   if (body.getPos? (canonicalOnly := true)).isSome then
     -- Source positions are available, so re-parse from source for interactive features.
     if let some stx ← parseVersoDocString docComment then
-      Doc.elabBlocks (stx.getArgs.map (⟨·⟩)) |>.exec declName binders
-    else return (#[], #[])
+      let ((text, subsections), deferredChecks) ← Doc.elabBlocks (stx.getArgs.map (⟨·⟩)) |>.exec declName binders
+      return { text, subsections, deferredChecks }
+    else return { text := #[], subsections := #[], deferredChecks := #[] }
   else if body.isOfKind ``versoCommentBody then
     if body[0].isOfKind `Lean.Doc.Syntax.parseFailure then
       -- The markup failed to parse, so re-parse its text to report the error.
@@ -271,7 +287,7 @@ Parses and elaborates a Verso module docstring.
 -/
 def versoModDocString
     (range : DeclarationRange) (doc : TSyntax ``document) :
-    TermElabM VersoModuleDocs.Snippet := do
+    TermElabM (VersoModuleDocs.Snippet × Array Doc.DeferredCheck) := do
   let level := getMainVersoModuleDocs (← getEnv) |>.terminalNesting |>.map (· + 1)
   Doc.elabModSnippet range (doc.raw.getArgs.map (⟨·⟩)) (level.getD 0) |>.execForModule
 
@@ -284,7 +300,7 @@ interactive features are disabled.
 -/
 def versoDocStringFromString
     (declName : Name) (docComment : String) :
-    TermElabM (Array (Doc.Block ElabInline ElabBlock) × Array (Doc.Part ElabInline ElabBlock Empty)) :=
+    TermElabM VersoDocResult :=
   versoDocStringOfText declName (mkNullNode #[]) docComment
 
 /--
@@ -305,10 +321,11 @@ def addMarkdownDocString
   modifyEnv fun env => docStringExt.insert env declName docString.removeLeadingSpaces
 
 /--
-Adds an elaborated Verso docstring to the environment.
+Adds an elaborated Verso docstring to the environment, recording its `deferred` checks under this
+declaration as their `site`.
 -/
 def addVersoDocStringCore [Monad m] [MonadEnv m] [MonadLiftT BaseIO m] [MonadError m]
-    (declName : Name) (docs : VersoDocString) : m Unit := do
+    (declName : Name) (docs : VersoDocString) (deferred : Array Doc.DeferredCheck) : m Unit := do
   -- The decl name can be anonymous due to attempts to elaborate incomplete syntax. If the name is
   -- anonymous, the `MapDeclarationExtension.insert` panics due to not being on the right async
   -- branch. Better to just do nothing.
@@ -316,17 +333,23 @@ def addVersoDocStringCore [Monad m] [MonadEnv m] [MonadLiftT BaseIO m] [MonadErr
   unless (← getEnv).getModuleIdxFor? declName |>.isNone do
     throwError s!"invalid doc string, declaration '{declName}' is in an imported module"
   modifyEnv fun env =>
-    versoDocStringExt.insert env declName docs
+    let env := versoDocStringExt.insert env declName docs
+    deferred.foldl (init := env) fun env c =>
+      Doc.deferredCheckExt.addEntry env { c with site := .decl declName }
 
 /--
 Adds an elaborated Verso module docstring to the environment.
 -/
 def addVersoModDocStringCore [Monad m] [MonadEnv m] [MonadLiftT BaseIO m] [MonadError m]
-  (docs : VersoModuleDocs.Snippet) : m Unit := do
+  (docs : VersoModuleDocs.Snippet) (deferred : Array Doc.DeferredCheck) : m Unit := do
   if (getMainModuleDoc (← getEnv)).isEmpty then
+    -- The snippet's index is the number of snippets already present.
+    let n := (getMainVersoModuleDocs (← getEnv)).snippets.size
     match addVersoModuleDocSnippet (← getEnv) docs with
     | .error e => throwError "Error adding module docs: {indentD <| toMessageData e}"
-    | .ok env' => setEnv env'
+    | .ok env' =>
+      setEnv <| deferred.foldl (init := env') fun env c =>
+        Doc.deferredCheckExt.addEntry env { c with site := .moduleDoc n }
   else
     throwError m!"Can't add Verso-format module docs because there is already Markdown-format content present."
 
@@ -344,8 +367,8 @@ def addVersoDocString
     TermElabM Unit := do
   unless (← getEnv).getModuleIdxFor? declName |>.isNone do
     throwError s!"invalid doc string, declaration '{declName}' is in an imported module"
-  let (blocks, parts) ← versoDocString declName binders docComment
-  addVersoDocStringCore declName ⟨blocks, parts⟩
+  let { toVersoDocString, deferredChecks } ← versoDocString declName binders docComment
+  addVersoDocStringCore declName toVersoDocString deferredChecks
 
 /--
 Adds a Verso docstring to the environment from a string value, which disables the interactive
@@ -355,8 +378,8 @@ def addVersoDocStringFromString (declName : Name) (docComment : String) :
     TermElabM Unit := do
   unless (← getEnv).getModuleIdxFor? declName |>.isNone do
     throwError s!"invalid doc string, declaration '{declName}' is in an imported module"
-  let (blocks, parts) ← versoDocStringFromString declName docComment
-  addVersoDocStringCore declName ⟨blocks, parts⟩
+  let { toVersoDocString, deferredChecks } ← versoDocStringFromString declName docComment
+  addVersoDocStringCore declName toVersoDocString deferredChecks
 
 
 /--
@@ -439,5 +462,5 @@ are available, pass `Syntax.missing` or an empty null node.
 def addVersoModDocString
     (range : DeclarationRange) (docComment : TSyntax ``document) :
     TermElabM Unit := do
-  let snippet ← versoModDocString range docComment
-  addVersoModDocStringCore snippet
+  let (snippet, deferred) ← versoModDocString range docComment
+  addVersoModDocStringCore snippet deferred

--- a/src/Lean/DocString/DeferredCheck.lean
+++ b/src/Lean/DocString/DeferredCheck.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: David Thrane Christiansen
+-/
+module
+
+prelude
+public import Init.Dynamic
+public import Lean.Environment
+public import Lean.Data.OpenDecl
+public import Lean.Data.Options
+
+public section
+
+namespace Lean.Doc
+
+/--
+The docstring that a deferred check was recorded in. Identifies the docstring without a source
+position, so that editing unrelated text doesn't change the public information of the module.
+-/
+inductive DeferredCheckSite where
+  /-- The check was deferred in docstring of a declaration. -/
+  | decl (name : Name)
+  /-- The check was deferred from the `n`th module docstring of the module (0-indexed). -/
+  | moduleDoc (n : Nat)
+deriving Inhabited, Repr, BEq
+
+/--
+A recording of the fact that some kind of check could not be carried out when a docstring was
+elaborated, due to some missing information that is expected to be available in the future. This is
+used for forward references.
+
+The type of the value in `check` selects the handler that carries out the check.
+
+Source positions are not stored because they would shift with edits. Because deferred checks are
+part of the public information of a module, this would lead to needless rebuilds. The docstring is
+identified by `site`, the reference within it by `index`, and `sourceString` (the reference's source
+text) gives readable error messages even without an accurate location.
+-/
+structure DeferredCheck where
+  /-- The docstring or moduledoc in which the reference appears. -/
+  site : DeferredCheckSite
+  /-- The index of this reference into the deferred checks of its docstring, in source order. -/
+  index : Nat
+  /-- The reference's source text, to quote in error messages. -/
+  sourceString : String
+  /-- Modules that should be imported for the check to be meaningful (the reference's `scope`). -/
+  imports : Array Name
+  /-- The current namespace at the reference site. -/
+  currNamespace : Name
+  /-- The open declarations in scope at the reference site. -/
+  openDecls : List OpenDecl
+  /-- The options in effect at the reference site. -/
+  options : Options
+  /--
+  The check-specific data. The name of the type in the `Dynamic` determines which checks are to be
+  performed.
+   -/
+  check : Dynamic
+
+/--
+A collection of deferred docstring checks.
+
+While docstrings are part of the server olean for a module, deferred checks are part of the public
+information so they can be found by the linter.
+-/
+builtin_initialize deferredCheckExt :
+    PersistentEnvExtension DeferredCheck DeferredCheck (Array DeferredCheck) ←
+  registerPersistentEnvExtension {
+    mkInitial := pure #[]
+    addImportedFn := fun _ => pure #[]
+    addEntryFn := Array.push
+    exportEntriesFn := id
+    asyncMode := .sync
+  }
+
+end Lean.Doc

--- a/src/Lean/DocString/Extension.lean
+++ b/src/Lean/DocString/Extension.lean
@@ -8,6 +8,7 @@ module
 prelude
 public import Lean.DeclarationRange
 public import Lean.DocString.Types
+public import Lean.DocString.DeferredCheck
 public import Init.Data.String.Extra
 public import Init.Data.String.TakeDrop
 public import Init.Data.String.Search
@@ -30,13 +31,24 @@ Saved data that describes a custom inline element.
 The type of value contained within the `Dynamic` determines the interpretation of the custom
 element, including how it is rendered to Markdown for the language server.
 -/
-structure ElabInline where
-  val : Dynamic
+inductive ElabInline where
+  /--
+  A custom inline element. The type of the value in the `Dynamic` determines how it is interpreted
+  and rendered.
+  -/
+  | custom (val : Dynamic)
+  /--
+  A deferred check that lacked sufficient information when it was used (e.g. a forward references to
+  a name in a downstream module). The `index` identifies it among the docstring's deferred checks
+  that are stored in an environment extension. Inline and block deferred checks use the same
+  counter.
+  -/
+  | deferred (index : Nat)
 
 instance : Repr ElabInline where
-  reprPrec v _ :=
-    .group <| .nestD <|
-      .group (.nestD ("{ val :=" ++ .line ++ "Dynamic.mk " ++ repr v.val.typeName ++ " _ }"))
+  reprPrec v _ := match v with
+    | .custom val => .group <| "ElabInline.custom" ++ .line ++ "(.mk " ++ repr val.typeName ++ " _)"
+    | .deferred index => .group <| "ElabInline.deferred" ++ .line ++ repr index
 
 /--
 Saved data that describes a custom block element.
@@ -44,13 +56,56 @@ Saved data that describes a custom block element.
 The type of value contained within the `Dynamic` determines the interpretation of the custom
 element, including how it is rendered to Markdown for the language server.
 -/
-structure ElabBlock where
-  val : Dynamic
+inductive ElabBlock where
+  /--
+  A custom block element. The type of the value in the `Dynamic` determines how it is interpreted
+  and rendered.
+  -/
+  | custom (val : Dynamic)
+  /--
+  A deferred check that lacked sufficient information when it was used (e.g. a forward references to
+  a name in a downstream module). The `index` identifies it among the docstring's deferred checks
+  that are stored in an environment extension. Inline and block deferred checks use the same
+  counter.
+  -/
+  | deferred (index : Nat)
 
 instance : Repr ElabBlock where
-  reprPrec v _ :=
-    .group <| .nestD <|
-      .group (.nestD ("{ val :=" ++ .line ++ "Dynamic.mk " ++ repr v.val.typeName ++ " _ }"))
+  reprPrec v _ := match v with
+    | .custom val => .group <| "ElabBlock.custom" ++ .line ++ "(.mk " ++ repr val.typeName ++ " _)"
+    | .deferred index => .group <| "ElabBlock.deferred" ++ .line ++ repr index
+
+/--
+A custom inline element `val`. The type `α` determines how it is interpreted. In contexts where `α`
+is not understood, `content` is used as a fallback.
+-/
+@[inline] def Doc.Inline.custom {α} [TypeName α] (val : α)
+    (content : Array (Doc.Inline ElabInline)) : Doc.Inline ElabInline :=
+  .other (.custom (.mk val)) content
+
+/--
+An inline element with a deferred check. The `index` is a 0-based index into the current docstring's
+deferred checks, in source order. Block and inline deferred elements share a counter.
+-/
+@[inline] def Doc.Inline.deferred (index : Nat)
+    (content : Array (Doc.Inline ElabInline)) : Doc.Inline ElabInline :=
+  .other (.deferred index) content
+
+/--
+A custom block element `val`. The type `α` determines how it is interpreted. In contexts where `α`
+is not understood, `content` is used as a fallback.
+-/
+@[inline] def Doc.Block.custom {α} [TypeName α] (val : α)
+    (content : Array (Doc.Block ElabInline ElabBlock)) : Doc.Block ElabInline ElabBlock :=
+  .other (.custom (.mk val)) content
+
+/--
+A block element with a deferred check. The `index` is a 0-based index into the current docstring's
+deferred checks, in source order. Block and inline deferred elements share a counter.
+-/
+@[inline] def Doc.Block.deferred (index : Nat)
+    (content : Array (Doc.Block ElabInline ElabBlock)) : Doc.Block ElabInline ElabBlock :=
+  .other (.deferred index) content
 
 structure VersoDocString where
   text : Array (Doc.Block ElabInline ElabBlock)

--- a/src/Lean/DocString/Markdown.lean
+++ b/src/Lean/DocString/Markdown.lean
@@ -600,16 +600,22 @@ public def withRendererFallback (fallback : MarkdownM (Array String)) (act : Mar
 public instance : MarkdownInline ElabInline where
   toMarkdown go container content := do
     let fallback := do return joinInlines (← content.mapM go)
-    match (← inlineRendererFor container.val.typeName) with
-    | some r => withRendererFallback fallback (r go container.val content)
-    | none => fallback
+    match container with
+    | .deferred _ => fallback
+    | .custom val =>
+      match (← inlineRendererFor val.typeName) with
+      | some r => withRendererFallback fallback (r go val content)
+      | none => fallback
 
 public instance : MarkdownBlock ElabInline ElabBlock where
   toMarkdown goI goB container content := do
     let fallback := do return joinBlocks (← content.mapM goB)
-    match (← blockRendererFor container.val.typeName) with
-    | some r => withRendererFallback fallback (r goI goB container.val content)
-    | none => fallback
+    match container with
+    | .deferred _ => fallback
+    | .custom val =>
+      match (← blockRendererFor val.typeName) with
+      | some r => withRendererFallback fallback (r goI goB val content)
+      | none => fallback
 
 open Lean Doc ToMarkdown in
 public instance : ToMarkdown Lean.VersoDocString where

--- a/src/Lean/Elab/DocString.lean
+++ b/src/Lean/Elab/DocString.lean
@@ -27,23 +27,23 @@ private structure ElabLink where
   name : StrLit
 deriving TypeName
 
-private def delayLink (name : StrLit) : ElabInline where
-  val := .mk (ElabLink.mk name)
+private def delayLink (name : StrLit) : ElabInline :=
+  .custom (.mk (ElabLink.mk name))
 
 private structure ElabImage where
   alt : String
   name : StrLit
 deriving TypeName
 
-private def delayImage (alt : String) (name : StrLit) : ElabInline where
-  val := .mk (ElabImage.mk alt name)
+private def delayImage (alt : String) (name : StrLit) : ElabInline :=
+  .custom (.mk (ElabImage.mk alt name))
 
 private structure ElabFootnote where
   name : StrLit
 deriving TypeName
 
-private def delayFootnote (name : StrLit) : ElabInline where
-  val := .mk (ElabFootnote.mk name)
+private def delayFootnote (name : StrLit) : ElabInline :=
+  .custom (.mk (ElabFootnote.mk name))
 
 private structure Ref (α) where
   content : α
@@ -54,6 +54,8 @@ private structure Ref (α) where
 structure InternalState where
   private footnotes : HashMap String (Ref (Inline ElabInline)) := {}
   private urls : HashMap String (Ref String) := {}
+  /-- Deferred checks accumulated while elaborating the current docstring, in source order. -/
+  private deferred : Array DeferredCheck := #[]
 
 /--
 The state used by `DocM`.
@@ -140,9 +142,39 @@ instance : MonadLift TermElabM DocM where
       act
     return v
 
+/--
+Records a deferred check. Deferred checks represent a docstring task that can't be carried out at
+the elaboration site, such as resolving a forward reference. Recorded checks include the current
+namespace, open namespaces, and options, but not the local context.
+
+The origin site `ref` is used to record the origin of the deferred check. Returns the check's index
+within the current docstring, which the docstring's AST stores to refer back to it.
+
+The saved deferred check is not associated with the docstring or module doc until it is actually
+added to the environment. After this call, the internal state stores `Name.anonymous`.
+-/
+def addDeferredCheck (check : Dynamic) (imports : Array Name) (ref : Syntax) : DocM Nat := do
+  let fileMap ← getFileMap
+  let sourceString :=
+    match ref.getRange? with
+    | some ⟨s, e⟩ => String.Pos.Raw.extract fileMap.source s e
+    | none => ""
+  let index := (← getThe InternalState).deferred.size
+  let entry : DeferredCheck := {
+    site := .decl .anonymous
+    index
+    sourceString
+    imports
+    currNamespace := ← getCurrNamespace
+    openDecls := ← getOpenDecls
+    options := ← getOptions
+    check
+  }
+  modifyThe InternalState fun s => { s with deferred := s.deferred.push entry }
+  return index
+
 private structure ModuleDocstringState extends Lean.Doc.State where
   scopedExts : Array (ScopedEnvExtension EnvExtensionEntry EnvExtensionEntry EnvExtensionState)
-
 
 private builtin_initialize modDocstringStateExt : EnvExtension (Option ModuleDocstringState) ←
   registerEnvExtension (pure none)
@@ -203,16 +235,16 @@ private def withSaveRestoreTermState (act : TermElabM α) : TermElabM α := do
 Runs a documentation elaborator in the module docstring context.
 -/
 def DocM.execForModule (act : DocM α) (suggestionMode : SuggestionMode := .interactive) :
-    TermElabM α := withoutModifyingEnv do
+    TermElabM (α × Array DeferredCheck) := withoutModifyingEnv do
   let sc ← scopedEnvExtensionsRef.get
   let st ← getModState
   withSaveRestoreTermState do
     try
       scopedEnvExtensionsRef.set st.scopedExts
-      let ((v, _), docState) ←
+      let ((v, internalSt), docState) ←
         act.run { suggestionMode } |>.run {} |>.run st.toState
       checkUnsolvedDocMVars st.toState.lctx docState
-      pure v
+      pure (v, internalSt.deferred)
     finally
       scopedEnvExtensionsRef.set sc
 
@@ -223,7 +255,7 @@ environment.
 -/
 def DocM.exec (declName : Name) (binders : Syntax) (act : DocM α)
     (suggestionMode : SuggestionMode := .interactive) :
-    TermElabM α := withoutModifyingEnv do
+    TermElabM (α × Array DeferredCheck) := withoutModifyingEnv do
   let some ci := (← getEnv).constants.find? declName
     | throwError "Unknown constant {declName} when building docstring"
   withSaveRestoreTermState do
@@ -233,10 +265,10 @@ def DocM.exec (declName : Name) (binders : Syntax) (act : DocM α)
       let openDecls ← getOpenDecls
       let options ← getOptions
       let scopes := [{header := "", isPublic := true}]
-      let ((v, _), docState) ← withTheReader Meta.Context (fun ρ => { ρ with localInstances }) <|
+      let ((v, internalSt), docState) ← withTheReader Meta.Context (fun ρ => { ρ with localInstances }) <|
         act.run { suggestionMode } |>.run {} |>.run { scopes, openDecls, lctx, localInstances, options }
       checkUnsolvedDocMVars lctx docState
-      pure v
+      pure (v, internalSt.deferred)
     finally
       scopedEnvExtensionsRef.set sc
 where
@@ -1752,8 +1784,10 @@ partial def fixupInline (inl : Inline ElabInline) : DocM (Inline ElabInline) := 
   | .code s => pure (.code s)
   | .math mode s => pure (.math mode s)
   | .linebreak s => pure (.linebreak s)
-  | .other i@{ val } xs =>
-    if let some {name} := val.get? ElabLink then
+  | .other i xs =>
+    let some val := getCustom i
+      | .other i <$> xs.mapM fixupInline
+    if let some { name } := val.get? ElabLink then
       let nameStr := name.getString
       if let some r@{content := url, seen, .. } := (← getThe InternalState).urls[nameStr]? then
         unless seen do modifyThe InternalState fun st => { st with urls := st.urls.insert nameStr { r with seen := true } }
@@ -1761,7 +1795,7 @@ partial def fixupInline (inl : Inline ElabInline) : DocM (Inline ElabInline) := 
       else
         logErrorAt name "Reference not found"
         return .concat (← xs.mapM fixupInline)
-    else if let some {alt, name} := val.get? ElabImage then
+    else if let some { alt, name } := val.get? ElabImage then
       let nameStr := name.getString
       if let some r@{content := url, seen, ..} := (← getThe InternalState).urls[nameStr]? then
         unless seen do modifyThe InternalState fun st => { st with urls := st.urls.insert nameStr { r with seen := true } }
@@ -1769,9 +1803,9 @@ partial def fixupInline (inl : Inline ElabInline) : DocM (Inline ElabInline) := 
       else
         logErrorAt name "Reference not found"
         return .empty
-    else if let some {name} := val.get? ElabFootnote then
+    else if let some { name } := val.get? ElabFootnote then
       let nameStr := name.getString
-      if let some r@{content, seen, ..} := (← getThe InternalState).footnotes[nameStr]? then
+      if let some r@{ content, seen, .. } := (← getThe InternalState).footnotes[nameStr]? then
         unless seen do modifyThe InternalState fun st =>
           { st with footnotes := st.footnotes.insert nameStr { r with seen := true } }
         return .footnote nameStr #[← fixupInline content]
@@ -1780,6 +1814,10 @@ partial def fixupInline (inl : Inline ElabInline) : DocM (Inline ElabInline) := 
         return .empty
     else
       .other i <$> xs.mapM fixupInline
+where
+  getCustom : ElabInline → Option Dynamic
+    | .custom c => some c
+    | .deferred _ => none
 
 partial def fixupBlock (block : Block ElabInline ElabBlock) : DocM (Block ElabInline ElabBlock) := do
   match block with

--- a/src/Lean/Elab/DocString/Builtin.lean
+++ b/src/Lean/Elab/DocString/Builtin.lean
@@ -140,10 +140,15 @@ private def strLitRange [Monad m] [MonadFileMap m] (s : StrLit) : m Lean.Syntax.
 /--
 Checks that a name exists when it is expected to.
 -/
-meta def checkNameExists : PostponedCheckHandler := fun _ info => do
-  let some {name} := info.get? PostponedName
-    | throwError "Expected `{.ofConstName ``PostponedName}`, got `{.ofConstName info.typeName}`"
+-- The builtin attribute will be available after the next stage0 update. Get rid of the
+-- builtin_initialize line and uncomment the attribute line once that's happened.
+-- @[builtin_deferred_doc_check PostponedName]
+def checkNameExists : DeferredCheckHandler := fun d => do
+  let some ⟨name⟩ := d.get? PostponedName
+    | throwError "internal error: expected a `{.ofConstName ``PostponedName}`"
   discard <| realizeGlobalConstNoOverload (mkIdent name)
+
+builtin_initialize DeferredCheck.addBuiltinHandler ``PostponedName checkNameExists
 
 private def getQualified (x : Name) : DocM (Array Name) := do
   -- We don't want to check whether the empty name is a suffix of names
@@ -201,9 +206,7 @@ def name (full : Option Ident := none) (scope : DocScope := .local)
           expectedType? := some t
         }
         let data : Data.Local := {name := x, lctx := ← getLCtx, type := t, fvarId := e.fvarId!}
-        return .other {
-          val := .mk data
-        } #[.code s.getString]
+        return .custom data #[.code s.getString]
   match scope with
   | .local =>
     let x ←
@@ -226,19 +229,12 @@ def name (full : Option Ident := none) (scope : DocScope := .local)
               logErrorAt s m!"{err.toMessageData}{h}"
             else logErrorAt s m!"{err.toMessageData}"
             return .code s!"{n.raw.getId}"
-    return .other { val := .mk (Data.Const.mk x) } #[.code s.getString]
+    return .custom (Data.Const.mk x) #[.code s.getString]
   | .import xs =>
     let name :=
       if let some r := full then r.getId
       else x
-    -- There should be a reference to the future task saved here, so doc rendering tools can
-    -- create a link.
-    let val : PostponedCheck := {
-      handler := ``checkNameExists
-      imports := xs.map (⟨·⟩)
-      info := .mk { name : PostponedName }
-    }
-    return .other { val := .mk val } #[.code s.getString]
+    return .deferred (← addDeferredCheck (.mk (PostponedName.mk name)) xs (← getRef)) #[.code s.getString]
 
 private def similarNames (x : Name) (xs : Array Name) : Array Name := Id.run do
   let s := x.toString
@@ -292,7 +288,7 @@ def module (checked : flag true) (xs : TSyntaxArray `inline) : DocM (Inline Elab
         else m!"Either disable the existence check or use an imported module:".hint ss (ref? := some ref)
       logErrorAt n m!"Module is not transitively imported by the current module.{h}"
 
-  return .other {val := .mk (Data.ModuleName.mk x)} #[.code s.getString]
+  return .custom (Data.ModuleName.mk x) #[.code s.getString]
 
 
 private def introduceAntiquotes (stx : Syntax) : DocM Unit :=
@@ -342,9 +338,7 @@ def tactic (checked : flag true) (xs : TSyntaxArray `inline) : DocM (Inline Elab
       else
         let found := found[0]
         addConstInfo s found.internalName
-        return .other {
-            val := .mk { name := found.internalName : Data.Tactic}
-          } #[.code s.getString]
+        return .custom { name := found.internalName : Data.Tactic} #[.code s.getString]
       try
         let p := whitespace >> categoryParserFn `tactic
         let stx ← parseStrLit p s
@@ -394,9 +388,7 @@ def conv (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
     try
       let t ← getConvTactic s
       addConstInfo s t
-      return .other {
-          val := .mk { name := t : Data.ConvTactic}
-        } #[.code s.getString]
+      return .custom { name := t : Data.ConvTactic} #[.code s.getString]
     catch
       | e => exns := exns.push e
     try
@@ -426,7 +418,7 @@ def attr (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
         -- here `a` is of kind `attrInstance`, which is `("scoped" <|> "local")? attr`
         validateAttr a[1]
 
-      return .other {val := .mk <| Data.Attributes.mk stx} #[
+      return .custom (Data.Attributes.mk stx) #[
         .code s.getString
       ]
     catch
@@ -435,7 +427,7 @@ def attr (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
     try
       let stx ← parseStrLit attrParser.fn s
       validateAttr stx
-      return .other {val := .mk <| Data.Attribute.mk stx} #[
+      return .custom (Data.Attribute.mk stx) #[
         .code s.getString
       ]
     catch
@@ -492,7 +484,7 @@ def syntaxCat (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
   let x ← parseStrLit rawIdentFn s
   let c := x.getId
   if (← validateCat ⟨x⟩) then
-    return .other {val := .mk (Data.SyntaxCat.mk c)} #[.code (toString c)]
+    return .custom (Data.SyntaxCat.mk c) #[.code (toString c)]
   else
     return .code (toString c)
 
@@ -519,7 +511,7 @@ def «syntax» (cat : Ident) (xs : TSyntaxArray `inline) : DocM (Inline ElabInli
     let cat := cat.getId
     let stx ← parseStrLit (categoryParserFn cat) s
     introduceAntiquotes stx
-    return .other {val := .mk (Data.Syntax.mk cat stx)} #[.code s.getString]
+    return .custom (Data.Syntax.mk cat stx) #[.code s.getString]
   else
     return .code s.getString
 
@@ -996,7 +988,7 @@ def lean (name : Option Ident := none) (error warning : flag false) («show» : 
   if «show» then
     if h : trees.size > 0 then
       let hl := Data.LeanBlock.mk (← highlightSyntax trees (mkNullNode cmds))
-      return .other {val := .mk hl} #[.code code.getString]
+      return .custom hl #[.code code.getString]
     else
       return .code code.getString
   else
@@ -1131,7 +1123,7 @@ def leanRole (type : Option StrLit := none) (xs : TSyntaxArray `inline) : DocM (
     withoutErrToSorry <| discard <| elabExtraTerm stx[0] ty?
   if h : trees.size > 0 then
     let tm := Data.LeanTerm.mk (← highlightSyntax trees stx)
-    return .other {val := .mk tm} #[.code s.getString]
+    return .custom tm #[.code s.getString]
   else
     -- No info
     return .code s.getString
@@ -1152,7 +1144,7 @@ def leanTerm (code : StrLit) : DocM (Block ElabInline ElabBlock) := do
     withoutErrToSorry <| discard <| elabExtraTerm stx[0] ty?
   if h : trees.size > 0 then
     let tm := Data.LeanTerm.mk (← highlightSyntax trees stx)
-    return .other {val := .mk tm} #[.code code.getString]
+    return .custom tm #[.code code.getString]
   else
     -- No info
     return .code code.getString
@@ -1212,7 +1204,7 @@ def option (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
           (toString optionName, some <| .option optionName decl.declName), (" ", none),
           (valStr, some valHl)
         ]
-        return .other {val := .mk <| Data.SetOption.mk ⟨code⟩} #[
+        return .custom (Data.SetOption.mk ⟨code⟩) #[
           .code s.getString
         ]
       catch
@@ -1227,9 +1219,7 @@ def option (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
         let decl ← getOptionDecl optionName
         pushInfoLeaf <| .ofOptionInfo { stx, optionName, declName := decl.declName }
 
-        return .other {
-          val := .mk <| Data.Option.mk optionName decl.declName
-        } #[
+        return .custom (Data.Option.mk optionName decl.declName) #[
           .code s.getString
         ]
       catch
@@ -1280,7 +1270,7 @@ def assert' (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
     let mut code := (← highlightSyntax trees lhsStx) ++ " = " ++ (← highlightSyntax trees rhsStx)
     if let some tyStx := tyStx? then
       code := code ++ " : " ++ (← highlightSyntax trees tyStx)
-    return .other {val := .mk <| Data.LeanTerm.mk code} #[.code str]
+    return .custom (Data.LeanTerm.mk code) #[.code str]
   else
     -- No info
     return .code str
@@ -1301,7 +1291,7 @@ def assert (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
     | _ => throwErrorAt stx m!"Expected equality type"
   if trees.size > 0 then
     let tm := Data.LeanTerm.mk (← highlightSyntax trees stx)
-    return .other {val := .mk tm} #[.code s.getString]
+    return .custom tm #[.code s.getString]
   else
     -- No info
     return .code s.getString

--- a/src/Lean/Elab/DocString/Builtin/Keywords.lean
+++ b/src/Lean/Elab/DocString/Builtin/Keywords.lean
@@ -384,7 +384,7 @@ def kwImpl (cat : Ident := mkIdent .anonymous) (of : Ident := mkIdent .anonymous
       if let some h ← makeHint m!"Specify the syntax kind:" #[s!" (of := {k'})"] then
         logInfo h
 
-    return .other {val := .mk (Data.Atom.mk k catName)} #[.code s.getString]
+    return .custom (Data.Atom.mk k catName) #[.code s.getString]
 where
   categorySuggestions (c candidates) := Id.run do
     if c.isAnonymous then
@@ -443,14 +443,19 @@ public def kw? (cat : Ident := mkIdent .anonymous) (of : Ident := mkIdent .anony
 /--
 Checks that a syntax kind name exists.
 -/
-public meta def checkKindExists : PostponedCheckHandler := fun _ info => do
-  let some k := info.get? PostponedKind
-    | throwError "Expected a `{.ofConstName ``PostponedKind}` but got a `{.ofConstName info.typeName}`"
-  let k ← realizeGlobalConstNoOverload (mkIdent k.name)
+-- The builtin attribute will be available after the next stage0 update. Get rid of the
+-- builtin_initialize line and uncomment the attribute line once that's happened.
+-- @[builtin_deferred_doc_check PostponedKind]
+public def checkKindExists : DeferredCheckHandler := fun d => do
+  let some ⟨kindName⟩ := d.get? PostponedKind
+    | throwError "internal error: expected a `{.ofConstName ``PostponedKind}`"
+  let k ← realizeGlobalConstNoOverload (mkIdent kindName)
   let env ← getEnv
   let parsers := Lean.Parser.parserExtension.getState env
   unless parsers.kinds.contains k do
     throwError m!"Not a syntax kind: `{.ofConstName k}`"
+
+builtin_initialize DeferredCheck.addBuiltinHandler ``PostponedKind checkKindExists
 
 
 @[inherit_doc kw, builtin_doc_role]
@@ -481,8 +486,7 @@ public def kw! (of : Option Ident := none) (scope : DocScope := .local)
     unless parsers.kinds.contains k do
       logErrorAt s m!"Not a syntax kind: `{.ofConstName k}`"
   | .import xs =>
-    let postponed : PostponedCheck := {handler := ``checkKindExists, imports := xs.map (⟨·⟩), info := .mk (PostponedKind.mk of'.getId)}
-    return .other {val := .mk postponed } #[.code s.getString]
+    return .deferred (← addDeferredCheck (.mk (PostponedKind.mk of'.getId)) xs (← getRef)) #[.code s.getString]
 
   pure <| .code s.getString
 

--- a/src/Lean/Elab/DocString/Builtin/Postponed.lean
+++ b/src/Lean/Elab/DocString/Builtin/Postponed.lean
@@ -7,177 +7,24 @@ module
 prelude
 
 public import Lean.Elab.Term.TermElabM
+public import Lean.DocString.DeferredCheck
 
 set_option linter.missingDocs true
 
 public section
 
+/-- Enables the deferred checks recorded while elaborating Verso docstrings, such as forward
+references. -/
+register_builtin_option linter.doc.deferred : Bool := {
+  defValue := true
+  descr := "if true, run the deferred checks recorded while elaborating Verso docstrings"
+}
+
 namespace Lean.Doc
 open Lean Elab Term
 
 /--
-A name of an import that should be present for a delayed check.
--/
-structure PostponedImport : Type where
-  /-- The module to be imported -/
-  name : Name
-deriving BEq, Hashable, Repr
-
-instance : ToExpr PostponedImport where
-  toTypeExpr := .const ``PostponedImport []
-  toExpr | ⟨v⟩ => .app (.const ``PostponedImport.mk []) (toExpr v)
-
-instance : Ord PostponedImport where
-  compare
-    | ⟨x⟩, ⟨y⟩ => x.quickCmp y
-
-/--
-A postponed check for an inline docstring element.
--/
-structure PostponedCheck : Type where
-  /--
-  The handler to call to carry out the check. It should be a `PostponedCheckHandler.`
-  -/
-  handler : Name
-  /--
-  The imports that should be available when the test is carried out.
-  -/
-  imports : Array PostponedImport
-  /--
-  Information required to carry out the check.
-  -/
-  info : Dynamic
-deriving TypeName
-
-instance : Repr PostponedCheck where
-  reprPrec v _ := "{ handler := " ++ repr v.handler ++ ", imports := " ++ repr v.imports ++ "}"
-
-/--
-A procedure to carry out some postponed check from a docstring.
--/
-abbrev PostponedCheckHandler := (declName : Name) → (info : Dynamic) → TermElabM Unit
-
-private unsafe def getHandlerUnsafe (name : Name) : TermElabM PostponedCheckHandler :=
-  evalConstCheck PostponedCheckHandler ``PostponedCheckHandler name
-
-@[implemented_by getHandlerUnsafe]
-private opaque getHandler (name : Name) : TermElabM PostponedCheckHandler
-
-private structure Stats where
-  passed : Nat := 0
-  failed : Array Exception := #[]
-
-private def Stats.total (s : Stats) : Nat :=
-  s.passed + s.failed.size
-
-private abbrev CheckM := StateRefT Stats TermElabM
-
-private def runCheck (act : TermElabM Unit) : CheckM Unit := do
-  try
-    act
-    modify fun s => { s with passed := s.passed + 1 }
-  catch
-    | e =>
-      modify fun s => { s with failed := s.failed.push e }
-
-private partial def checkInlinePostponed (declName : Name) (inline : Inline ElabInline) : CheckM Unit := do
-  match inline with
-  | .other x is =>
-    if let some { handler, imports, info } := x.val.get? PostponedCheck then
-      for ⟨m⟩ in imports do
-        unless (← getEnv).header.moduleNames.contains m do
-          throwError "Check in `{.ofConstName declName}` requires that `{m}` is imported, but it is not."
-      runCheck <| (← getHandler handler) declName info
-    for i in is do
-      checkInlinePostponed declName i
-  | .concat is | .emph is | .bold is | .link is _ | .footnote _ is =>
-    for i in is do
-      checkInlinePostponed declName i
-  | .image .. | .linebreak .. | .text .. | .code .. | .math .. => pure ()
-
-private partial def checkBlockPostponed (declName : Name) (doc : Block ElabInline ElabBlock) : CheckM Unit := do
-  match doc with
-  | .other x bs =>
-    if let some { handler, imports, info } := x.val.get? PostponedCheck then
-      for ⟨m⟩ in imports do
-        unless (← getEnv).header.moduleNames.contains m do
-          throwError "Check in `{.ofConstName declName}` requires that `{m}` is imported, but it is not."
-      runCheck <| (← getHandler handler) declName info
-    for b in bs do
-      checkBlockPostponed declName b
-  | .concat bs | .blockquote bs =>
-    for b in bs do
-      checkBlockPostponed declName b
-  | .ul items | .ol _ items =>
-    for item in items do
-      for b in item.contents do
-        checkBlockPostponed declName b
-  | .dl items =>
-    for item in items do
-      for i in item.term do
-        checkInlinePostponed declName i
-      for b in item.desc do
-        checkBlockPostponed declName b
-  | .para is =>
-    for i in is do
-      checkInlinePostponed declName i
-  | .code .. => pure ()
-
-private partial def checkPartPostponed (declName : Name) (doc : Part ElabInline ElabBlock Empty) : CheckM Unit := do
-  for b in doc.content do
-    checkBlockPostponed declName b
-  for s in doc.subParts do
-    checkPartPostponed declName s
-
-private def checkDocStringPostponed (declName : Name) (doc : VersoDocString) : CheckM Unit := do
-  let {text, subsections} := doc
-  for b in text do
-    checkBlockPostponed declName b
-  for s in subsections do
-    checkPartPostponed declName s
-
-/--
-Runs the postponed checks in all docstrings, reporting on the result.
--/
-def checkPostponed : TermElabM Unit := do
-  let mut checked : Array (Name × Stats) := #[]
-  let st := versoDocStringExt.toEnvExtension.getState (← getEnv)
-  for (decl, docs) in ← getBuiltinVersoDocStrings do
-    let ((), out) ← checkDocStringPostponed decl docs |>.run {}
-    if out.total > 0 then
-      checked := checked.push (decl, out)
-  for mod in st.importedEntries do
-    for (decl, docs) in mod do
-      let ((), out) ← checkDocStringPostponed decl docs |>.run {}
-      if out.total > 0 then
-        checked := checked.push (decl, out)
-  for (decl, docs) in st.state do
-    let ((), out) ← checkDocStringPostponed decl docs |>.run {}
-    if out.total > 0 then
-      checked := checked.push (decl, out)
-
-  let msg : MessageData :=
-    .trace { cls := `checks } m!"Postponed checks: {checked.size} declarations, \
-        {checked.map (·.2.passed) |>.sum} passed, \
-        {checked.map (·.2.failed.size) |>.sum} failed" <|
-      checked.map fun (declName, stats) =>
-        .trace {cls := `check} m!"`{.ofConstName declName}`: \
-            {stats.passed} passed, \
-            {stats.failed.size} failed" <|
-          stats.failed.map (·.toMessageData)
-
-  logInfo msg
-
-/--
-A postponed check that a syntax kind name exists.
--/
-structure PostponedKind where
-  /-- The kind's name. -/
-  name : Name
-deriving TypeName
-
-/--
-A name that will be checked to exist later.
+A name that a deferred check will confirm exists.
 -/
 structure PostponedName where
   /--
@@ -185,3 +32,149 @@ structure PostponedName where
   -/
   name : Name
 deriving TypeName
+
+/--
+A syntax kind name that a deferred check will confirm exists.
+-/
+structure PostponedKind where
+  /--
+  The kind's name.
+  -/
+  name : Name
+deriving TypeName
+
+/--
+A handler that carries out a deferred docstring check, given the check's data. Each handler is
+expected to be applied to a single type name, rather than be able to handle any `Dynamic`.
+-/
+abbrev DeferredCheckHandler := Dynamic → CoreM Unit
+
+namespace DeferredCheck
+
+/--
+Maps the name of a deferred check's data (the value of `Dynamic.typeName`) to the declaration of its
+`DeferredCheckHandler`. The data type is the dispatch key, so at most one handler is registered per
+type.
+-/
+builtin_initialize handlerExt : SimplePersistentEnvExtension (Name × Name) (NameMap Name) ←
+  registerSimplePersistentEnvExtension {
+    addEntryFn := fun m (key, declName) => m.insert key declName
+    addImportedFn := fun nss =>
+      nss.foldl (init := {}) fun m ns =>
+        ns.foldl (init := m) fun m (key, declName) =>
+          m.insert key declName
+  }
+
+/--
+Builtin deferred check handlers, for bootstrapping. Maps a check's data type name to its handler,
+which is available before the defining module is imported.
+-/
+builtin_initialize builtinHandlers : IO.Ref (NameMap DeferredCheckHandler) ← IO.mkRef {}
+
+/--
+Adds a builtin deferred check handler.
+
+Should be run during initialization.
+-/
+def addBuiltinHandler (key : Name) (impl : DeferredCheckHandler) : IO Unit :=
+  builtinHandlers.modify (·.insert key impl)
+
+private unsafe def getHandlerUnsafe (declName : Name) : CoreM DeferredCheckHandler :=
+  evalConstCheck DeferredCheckHandler ``DeferredCheckHandler declName
+@[implemented_by getHandlerUnsafe]
+private opaque getHandler (declName : Name) : CoreM DeferredCheckHandler
+
+builtin_initialize registerBuiltinAttribute {
+  name := `deferred_doc_check
+  descr := "Registers a `DeferredCheckHandler` for deferred docstring checks whose data has the named type."
+  applicationTime := .afterCompilation
+  add := fun decl stx kind => do
+    unless kind == .global do
+      throwError "invalid attribute `deferred_doc_check`, must be global"
+    let key ←
+      if let `(attr|deferred_doc_check $x) := stx then
+        realizeGlobalConstNoOverload x
+      else
+        throwError "invalid `deferred_doc_check` syntax"
+    modifyEnv (handlerExt.addEntry · (key, decl))
+}
+
+builtin_initialize registerBuiltinAttribute {
+  name := `builtin_deferred_doc_check
+  descr := "Registers a builtin `DeferredCheckHandler` for deferred docstring checks whose data has the named type."
+  applicationTime := .afterCompilation
+  add := fun decl stx kind => do
+    unless kind == .global do
+      throwError "invalid attribute `builtin_deferred_doc_check`, must be global"
+    let key ←
+      if let `(attr|builtin_deferred_doc_check $x) := stx then
+        realizeGlobalConstNoOverload x
+      else
+        throwError "invalid `builtin_deferred_doc_check` syntax"
+    declareBuiltin decl <|
+      mkApp2 (.const ``addBuiltinHandler []) (toExpr key) (.const decl [])
+}
+
+/-- Re-enters the elaboration scope captured at a reference site. -/
+private def withScope (c : DeferredCheck) (act : CoreM α) : CoreM α :=
+  withTheReader Core.Context
+    (fun ctx => { ctx with
+      currNamespace := c.currNamespace, openDecls := c.openDecls, options := c.options })
+    act
+
+/--
+The deferred checks owned by modules satisfying `inPackage`.
+
+Each deferred check is paired with the module it was recorded in.
+-/
+private def collect (env : Environment) (inPackage : Name → Bool) :
+    Array (Name × DeferredCheck) := Id.run do
+  let mut out := #[]
+  for i in [0:env.header.moduleNames.size] do
+    let mod := env.header.moduleNames[i]!
+    if inPackage mod then
+      out := out ++ (deferredCheckExt.getModuleEntries env i).map (mod, ·)
+  let mod := env.mainModule
+  if inPackage mod then
+    out := out ++ (deferredCheckExt.getState env).map (mod, ·)
+  return out
+
+/--
+Runs the deferred docstring checks owned by modules satisfying `inPackage`.
+
+Returns the checks that failed together with the module they belong to and the error that each
+produced. `#[]` indicates success.
+
+Only checks that satisfy `shouldCheck` are run.
+-/
+def run (inPackage : Name → Bool) (shouldCheck : DeferredCheck → CoreM Bool := fun _ => pure true) :
+    CoreM (Array (Name × DeferredCheck × MessageData)) := do
+  let env ← getEnv
+  let handlers := handlerExt.getState env
+  let builtins ← builtinHandlers.get
+  let moduleNames : NameSet := env.header.moduleNames.foldl (·.insert ·) {}
+  let mut failures := #[]
+  for (mod, c) in collect env inPackage do
+    unless (← shouldCheck c) do continue
+    let missing := c.imports.filter (!moduleNames.contains ·)
+    if !missing.isEmpty then
+      failures := failures.push (mod, c,
+        m!"the check requires {missing.toList} to be imported, but they are not")
+    else
+      let handler? : Option DeferredCheckHandler ←
+        if let some impl := builtins.find? c.check.typeName then
+          pure (some impl)
+        else if let some declName := handlers.find? c.check.typeName then
+          pure (some (← getHandler declName))
+        else
+          pure none
+      match handler? with
+      | none =>
+        failures := failures.push (mod, c,
+          m!"no handler registered for deferred check `{c.check.typeName}`")
+      | some handler =>
+        try
+          withScope c (handler c.check)
+        catch e =>
+          failures := failures.push (mod, c, e.toMessageData)
+  return failures

--- a/src/lake/Lake/CLI/BuiltinLint.lean
+++ b/src/lake/Lake/CLI/BuiltinLint.lean
@@ -9,6 +9,7 @@ prelude
 public import Lean.Linter.EnvLinter
 public import Lean.Linter.PersistentLintLog
 import Lean.CoreM
+import Lean.Elab.DocString.Builtin.Postponed
 import Lake.Config.Workspace
 
 open Lean Lean.Core Meta
@@ -125,6 +126,9 @@ public def run (args : Args) : IO UInt32 := do
   -- Accumulated exceptions to record (only populated when `args.recordExceptions` is set).
   let mut records : Array ExceptionRecord := #[]
   let mut anyUnlocated := false
+  -- Modules whose deferred docstring checks have already been run. A module can appear in
+  -- several targets' import closures, so this runs each such module's checks only once.
+  let mut docCheckedModules : NameSet := {}
   for mod in mods do
     unsafe Lean.enableInitializersExecution
     -- Peek at the .olean header to learn whether `mod` participates in the module system.
@@ -220,6 +224,43 @@ public def run (args : Args) : IO UInt32 := do
       anyUnlocated := true
     if textFailed || declFailed then
       anyFailed := true
+
+    -- Runs deferred docstring checks (e.g. forward references) over this package's own modules.
+    -- These deferred checks may be found both in module docstrings and in declaration docstrings,
+    -- so a declaration-centric interface doesn't make sense. Because deferred checks capture their
+    -- local option values, the per-check predicate can honor a `set_option linter.doc.deferred`
+    -- by inspecting the captured values. The package-level toggle is read from the command-line
+    -- overrides: `--lint-only` requires explicit selection, otherwise the option defaults on but
+    -- honors an explicit `--linters=-linter.doc.deferred` (or `-linter.all`).
+    let deferredSelected :=
+      if args.lintOnly then
+        Lean.Linter.isLinterEnabledByOptions linter.doc.deferred.name linterOpts
+      else
+        Lean.Linter.getLinterValue linter.doc.deferred linterOpts
+    if !args.recordExceptions && deferredSelected then
+      let (deferredFailures, _) ← CoreM.toIO (ctx := { fileName := "", fileMap := default }) (s := { env }) do
+        let failures ← Lean.Doc.DeferredCheck.run
+          (fun m => mod.getRoot.isPrefixOf m && !docCheckedModules.contains m)
+          (shouldCheck := fun c =>
+            return Linter.getLinterValue linter.doc.deferred (← c.options.toLinterOptions))
+        failures.mapM fun (failMod, c, msg) => return (failMod, c.site, c.sourceString, ← msg.toString)
+      -- Mark this target's transitive imports that are in the package so later targets don't
+      -- re-run their checks.
+      for m in env.header.moduleNames do
+        if mod.getRoot.isPrefixOf m then
+          docCheckedModules := docCheckedModules.insert m
+      unless deferredFailures.isEmpty do
+        anyFailed := true
+        for (failMod, site, sourceString, msg) in deferredFailures do
+          let inDoc := match site with
+            | .decl n => s!"the docstring of `{n}`"
+            | .moduleDoc i => s!"module docstring #{i + 1}"
+          let context := if sourceString.isEmpty then "" else s!" ({sourceString})"
+          match ← sp.findWithExt "lean" failMod with
+          | some file =>
+            IO.eprintln s!"{file}: error: in {inDoc}{context}: {msg}"
+          | none =>
+            IO.eprintln s!"error: in module `{failMod}`, in {inDoc}{context}: {msg}"
 
   if args.recordExceptions then
     recordExceptionsToFiles records

--- a/src/lake/Lake/CLI/BuiltinLint.lean
+++ b/src/lake/Lake/CLI/BuiltinLint.lean
@@ -9,6 +9,7 @@ prelude
 public import Lean.Linter.EnvLinter
 public import Lean.Linter.PersistentLintLog
 import Lean.CoreM
+import Lean.DocString.Extension
 import Lean.Elab.DocString.Builtin.Postponed
 import Lake.Config.Workspace
 
@@ -112,6 +113,115 @@ private def recordExceptionsToFiles (records : Array ExceptionRecord) : IO Unit 
     if fileInserted > 0 then
       IO.println s!"recording {fileInserted} exception{if fileInserted == 1 then "" else "s"} in {file}"
       IO.FS.writeFile file ("\n".intercalate lines.toList)
+
+/--
+The source position used to insert an exception for a Verso docstring with a failed check. `failMod`
+is the module that recorded the deferred check.
+
+Requires an environment imported at the `server` olean level, which carries the declaration ranges
+and Verso module-doc snippets consulted here.
+-/
+private def deferredSitePos? (failMod : Name) (site : Doc.DeferredCheckSite) :
+    CoreM (Option Position) := do
+  match site with
+  | .decl n =>
+    return (← findDeclarationRanges? n).map (·.range.pos)
+  | .moduleDoc i =>
+    let some snippets := getVersoModuleDoc? (← getEnv) failMod | return none
+    return snippets[i]?.map (·.declarationRange.pos)
+
+/-- A deferred check site, described for error messages. -/
+private def describeSite : Doc.DeferredCheckSite → String
+  | .decl n => s!"the docstring of `{n}`"
+  | .moduleDoc i => s!"module docstring #{i + 1}"
+
+/-- The result of the deferred docstring check for one lint target, according to its mode. -/
+private inductive DeferredCheckOutcome where
+  /-- Reporting mode: failures were printed to stderr, and `failed` determines the exit code. -/
+  | reported (failed : Bool)
+  /--
+  Recording mode: `records` are the exceptions to write, and `unlocated` indicates that there were
+  failures whose position could not be resolved.
+  -/
+  | recorded (records : Array ExceptionRecord) (unlocated : Bool)
+
+/-- The result of the deferred docstring check pass for one lint target. -/
+private structure DeferredCheckResults where
+  /-- The mode-specific outcome of the pass. -/
+  outcome : DeferredCheckOutcome
+  /-- Modules whose deferred checks have now been run. -/
+  checkedModules : NameSet
+
+/--
+Runs deferred docstring checks (e.g. forward references) over the modules of the package rooted at
+`pkgRoot` that are imported by `env`. These deferred checks may be found both in module docstrings
+and in declaration docstrings, so a declaration-centric interface doesn't make sense. Because
+deferred checks capture their local option values, the per-check predicate can honor a `set_option
+linter.doc.deferred` by inspecting the captured values. The package-level toggle is read from the
+command-line overrides: `--lint-only` requires explicit selection, otherwise the option defaults on
+but honors an explicit `--linters=-linter.doc.deferred` (or `-linter.all`).
+
+`docCheckedModules` names the package modules whose checks earlier lint targets already ran; a
+module imported by several targets is thus checked only once. Its modules are skipped here, and the
+result's `checkedModules` extends it with the ones this target covered, to thread into the next
+target.
+
+Failures are reported on stderr, unless `args.recordExceptions` is set, in which case they are
+turned into exception records at the flagged docstring's positions for the caller to write.
+-/
+private def runDeferredChecks (args : Args) (linterOpts : Linter.LinterOptions) (sp : SearchPath)
+    (env : Environment) (pkgRoot : Name) (docCheckedModules : NameSet) :
+    IO DeferredCheckResults := do
+  let selected :=
+    if args.lintOnly then
+      Lean.Linter.isLinterEnabledByOptions linter.doc.deferred.name linterOpts
+    else
+      Lean.Linter.getLinterValue linter.doc.deferred linterOpts
+  unless selected do
+    let outcome := if args.recordExceptions then .recorded #[] false else .reported false
+    return { outcome, checkedModules := docCheckedModules }
+  let (outcome, _) ←
+      CoreM.toIO (ctx := { fileName := "", fileMap := default }) (s := { env }) do
+    let failures ← Lean.Doc.DeferredCheck.run
+      (fun m => pkgRoot.isPrefixOf m && !docCheckedModules.contains m)
+      (shouldCheck := fun c =>
+        return Linter.getLinterValue linter.doc.deferred (← c.options.toLinterOptions))
+    if args.recordExceptions then
+      let mut recs : Array ExceptionRecord := #[]
+      let mut unlocated := false
+      for (failMod, c, _) in failures do
+        match ← deferredSitePos? failMod c.site with
+        | some pos =>
+          match ← sp.findWithExt "lean" failMod with
+          | some file =>
+            recs := recs.push { file, pos, option := linter.doc.deferred.name }
+          | none =>
+            IO.eprintln s!"\
+              warning: could not locate source file for `{failMod}` \
+              to record a `{linter.doc.deferred.name}` exception"
+            unlocated := true
+        | none =>
+          IO.eprintln s!"\
+            warning: could not determine the position of {describeSite c.site} in `{failMod}`; \
+            cannot record a `{linter.doc.deferred.name}` exception"
+          unlocated := true
+      return DeferredCheckOutcome.recorded recs unlocated
+    else
+      for (failMod, c, msg) in failures do
+        let context := if c.sourceString.isEmpty then "" else s!" ({c.sourceString})"
+        match ← sp.findWithExt "lean" failMod with
+        | some file =>
+          IO.eprintln s!"{file}: error: in {describeSite c.site}{context}: {← msg.toString}"
+        | none =>
+          IO.eprintln s!"error: in module `{failMod}`, in {describeSite c.site}{context}: {← msg.toString}"
+      return DeferredCheckOutcome.reported !failures.isEmpty
+  -- Mark this target's transitive imports that are in the package so later targets don't re-run
+  -- their checks.
+  let mut checkedModules := docCheckedModules
+  for m in env.header.moduleNames do
+    if pkgRoot.isPrefixOf m then
+      checkedModules := checkedModules.insert m
+  return { outcome, checkedModules }
 
 public def run (args : Args) : IO UInt32 := do
   let mods := args.mods
@@ -225,42 +335,14 @@ public def run (args : Args) : IO UInt32 := do
     if textFailed || declFailed then
       anyFailed := true
 
-    -- Runs deferred docstring checks (e.g. forward references) over this package's own modules.
-    -- These deferred checks may be found both in module docstrings and in declaration docstrings,
-    -- so a declaration-centric interface doesn't make sense. Because deferred checks capture their
-    -- local option values, the per-check predicate can honor a `set_option linter.doc.deferred`
-    -- by inspecting the captured values. The package-level toggle is read from the command-line
-    -- overrides: `--lint-only` requires explicit selection, otherwise the option defaults on but
-    -- honors an explicit `--linters=-linter.doc.deferred` (or `-linter.all`).
-    let deferredSelected :=
-      if args.lintOnly then
-        Lean.Linter.isLinterEnabledByOptions linter.doc.deferred.name linterOpts
-      else
-        Lean.Linter.getLinterValue linter.doc.deferred linterOpts
-    if !args.recordExceptions && deferredSelected then
-      let (deferredFailures, _) ← CoreM.toIO (ctx := { fileName := "", fileMap := default }) (s := { env }) do
-        let failures ← Lean.Doc.DeferredCheck.run
-          (fun m => mod.getRoot.isPrefixOf m && !docCheckedModules.contains m)
-          (shouldCheck := fun c =>
-            return Linter.getLinterValue linter.doc.deferred (← c.options.toLinterOptions))
-        failures.mapM fun (failMod, c, msg) => return (failMod, c.site, c.sourceString, ← msg.toString)
-      -- Mark this target's transitive imports that are in the package so later targets don't
-      -- re-run their checks.
-      for m in env.header.moduleNames do
-        if mod.getRoot.isPrefixOf m then
-          docCheckedModules := docCheckedModules.insert m
-      unless deferredFailures.isEmpty do
-        anyFailed := true
-        for (failMod, site, sourceString, msg) in deferredFailures do
-          let inDoc := match site with
-            | .decl n => s!"the docstring of `{n}`"
-            | .moduleDoc i => s!"module docstring #{i + 1}"
-          let context := if sourceString.isEmpty then "" else s!" ({sourceString})"
-          match ← sp.findWithExt "lean" failMod with
-          | some file =>
-            IO.eprintln s!"{file}: error: in {inDoc}{context}: {msg}"
-          | none =>
-            IO.eprintln s!"error: in module `{failMod}`, in {inDoc}{context}: {msg}"
+    let deferredResults ← runDeferredChecks args linterOpts sp env mod.getRoot docCheckedModules
+    docCheckedModules := deferredResults.checkedModules
+    match deferredResults.outcome with
+    | .reported failed =>
+      if failed then anyFailed := true
+    | .recorded recs unlocated =>
+      records := records ++ recs
+      if unlocated then anyUnlocated := true
 
   if args.recordExceptions then
     recordExceptionsToFiles records

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,5 +1,7 @@
 #include "util/options.h"
 
+// CI: please update stage0 for me. Thanks in advance!
+
 namespace lean {
 options get_default_options() {
     options opts;

--- a/tests/elab/versoDocClass.lean
+++ b/tests/elab/versoDocClass.lean
@@ -56,10 +56,10 @@ def printVersoDocstring (name : Name) : CommandElabM Unit := do
 
 /--
 info: #[Lean.Doc.Block.para
-    #[Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.Const _ } #[Lean.Doc.Inline.code "Foo"],
+    #[Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.Const _) #[Lean.Doc.Inline.code "Foo"],
       Lean.Doc.Inline.text " is a type class."],
   Lean.Doc.Block.other
-    { val := Dynamic.mk `Lean.Doc.Data.LeanBlock _ }
+    ElabBlock.custom (.mk `Lean.Doc.Data.LeanBlock _)
     #[Lean.Doc.Block.code "instance : Foo := ⟨0, 1⟩\nexample [Foo] : Unit := ()\nexample : Nat := Foo.x\n"]]
 #[]
 -/
@@ -73,10 +73,10 @@ info: #[Lean.Doc.Block.para
 /--
 info: #[Lean.Doc.Block.para
     #[Lean.Doc.Inline.text "Uses ",
-      Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.Const _ } #[Lean.Doc.Inline.code "Foo"],
+      Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.Const _) #[Lean.Doc.Inline.code "Foo"],
       Lean.Doc.Inline.text " as a class:"],
   Lean.Doc.Block.other
-    { val := Dynamic.mk `Lean.Doc.Data.LeanBlock _ }
+    ElabBlock.custom (.mk `Lean.Doc.Data.LeanBlock _)
     #[Lean.Doc.Block.code "example [Foo] : Nat := Foo.y\n"]]
 #[]
 -/

--- a/tests/elab/versoDocCustomRenderer.lean
+++ b/tests/elab/versoDocCustomRenderer.lean
@@ -51,7 +51,7 @@ deriving TypeName
 /-- Includes another declaration's docstring. The target is looked up when rendering to Markdown. -/
 @[doc_role]
 meta def include_docstring (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
-  return .other { val := .mk (IncludeDoc.mk (← codeTargetName xs)) } #[]
+  return .custom (IncludeDoc.mk (← codeTargetName xs)) #[]
 
 /-- The renderer receives the decoded `IncludeDoc` directly, never a `Dynamic`. -/
 @[doc_inline_md]
@@ -84,7 +84,7 @@ deriving TypeName
 /-- Wraps its content in a custom element that has no renderer. -/
 @[doc_role]
 meta def passthrough (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
-  return .other { val := .mk Unrendered.mk } (← xs.mapM elabInline)
+  return .custom Unrendered.mk (← xs.mapM elabInline)
 
 /-- Fallback shows {passthrough}[the content] here. -/
 def Baz : Nat := 2
@@ -103,7 +103,7 @@ deriving TypeName
 /-- Wraps its content in an element rendered by a non-terminating renderer. -/
 @[doc_role]
 meta def slow (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
-  return .other { val := .mk Slow.mk } (← xs.mapM elabInline)
+  return .custom Slow.mk (← xs.mapM elabInline)
 
 @[doc_inline_md]
 meta def slowRender : InlineMdRendererOf Slow := fun _go _data _content => do
@@ -130,7 +130,7 @@ deriving TypeName
 /-- References a constant by its shortest name valid where the docstring is rendered. -/
 @[doc_role]
 meta def qualName (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
-  return .other { val := .mk (QualName.mk (← codeTargetName xs)) } #[]
+  return .custom (QualName.mk (← codeTargetName xs)) #[]
 
 @[doc_inline_md]
 meta def qualNameRender : InlineMdRendererOf QualName := fun _go data _content => do
@@ -174,7 +174,7 @@ deriving TypeName
 /-- Shows a declaration's signature, pretty-printed when the docstring is rendered. -/
 @[doc_role]
 meta def sig (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
-  return .other { val := .mk (SigData.mk (← codeTargetName xs)) } #[]
+  return .custom (SigData.mk (← codeTargetName xs)) #[]
 
 @[doc_inline_md]
 meta def sigRender : InlineMdRendererOf SigData := fun _go data _content => do
@@ -198,7 +198,7 @@ deriving TypeName
 /-- Wraps its content in an element whose renderer fails after rendering the content. -/
 @[doc_role]
 meta def leaky (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
-  return .other { val := .mk Leaky.mk } (← xs.mapM elabInline)
+  return .custom Leaky.mk (← xs.mapM elabInline)
 
 @[doc_inline_md]
 meta def leakyRender : InlineMdRendererOf Leaky := fun go _data content => do
@@ -236,7 +236,7 @@ meta abbrev AliasedSyn := Aliased
 /-- Stores an `Aliased` element, with distinct fallback content. -/
 @[doc_role]
 meta def aliased (_xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
-  return .other { val := .mk (Aliased.mk "rendered via alias") } #[.text "fallback"]
+  return .custom (Aliased.mk "rendered via alias") #[.text "fallback"]
 
 /-- The renderer is declared against the alias rather than `Aliased` itself. -/
 @[doc_inline_md]
@@ -260,7 +260,7 @@ deriving TypeName
 /-- A directive that wraps its blocks in a custom element. -/
 @[doc_directive]
 meta def banner (xs : TSyntaxArray `block) : DocM (Block ElabInline ElabBlock) := do
-  return .other { val := .mk Banner.mk } (← xs.mapM elabBlock)
+  return .custom Banner.mk (← xs.mapM elabBlock)
 
 /-- The renderer brackets the rendered block content. -/
 @[doc_block_md]
@@ -296,7 +296,7 @@ deriving TypeName
 /-- A directive whose element type has no Markdown renderer. -/
 @[doc_directive]
 meta def plainBlock (xs : TSyntaxArray `block) : DocM (Block ElabInline ElabBlock) := do
-  return .other { val := .mk PlainBlock.mk } (← xs.mapM elabBlock)
+  return .custom PlainBlock.mk (← xs.mapM elabBlock)
 
 /--
 :::plainBlock
@@ -318,7 +318,7 @@ deriving TypeName
 /-- A directive rendered by a non-terminating renderer. -/
 @[doc_directive]
 meta def slowBlock (xs : TSyntaxArray `block) : DocM (Block ElabInline ElabBlock) := do
-  return .other { val := .mk SlowBlock.mk } (← xs.mapM elabBlock)
+  return .custom SlowBlock.mk (← xs.mapM elabBlock)
 
 @[doc_block_md]
 meta def slowBlockRender : BlockMdRendererOf SlowBlock := fun _goI _goB _data _content => do

--- a/tests/elab/versoDocCustomRendererNonModule.lean
+++ b/tests/elab/versoDocCustomRendererNonModule.lean
@@ -50,7 +50,7 @@ deriving TypeName
 /-- Includes another declaration's docstring. The target is looked up when rendering to Markdown. -/
 @[doc_role]
 def include_docstring (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
-  return .other { val := .mk (IncludeDoc.mk (← codeTargetName xs)) } #[]
+  return .custom (IncludeDoc.mk (← codeTargetName xs)) #[]
 
 /-- The renderer receives the decoded `IncludeDoc` directly, never a `Dynamic`. -/
 @[doc_inline_md]
@@ -83,7 +83,7 @@ deriving TypeName
 /-- Wraps its content in a custom element that has no renderer. -/
 @[doc_role]
 def passthrough (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
-  return .other { val := .mk Unrendered.mk } (← xs.mapM elabInline)
+  return .custom Unrendered.mk (← xs.mapM elabInline)
 
 /-- Fallback shows {passthrough}[the content] here. -/
 def Baz : Nat := 2
@@ -102,7 +102,7 @@ deriving TypeName
 /-- Wraps its content in an element rendered by a non-terminating renderer. -/
 @[doc_role]
 def slow (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
-  return .other { val := .mk Slow.mk } (← xs.mapM elabInline)
+  return .custom Slow.mk (← xs.mapM elabInline)
 
 @[doc_inline_md]
 def slowRender : InlineMdRendererOf Slow := fun _go _data _content => do
@@ -129,7 +129,7 @@ deriving TypeName
 /-- References a constant by its shortest name valid where the docstring is rendered. -/
 @[doc_role]
 def qualName (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
-  return .other { val := .mk (QualName.mk (← codeTargetName xs)) } #[]
+  return .custom (QualName.mk (← codeTargetName xs)) #[]
 
 @[doc_inline_md]
 def qualNameRender : InlineMdRendererOf QualName := fun _go data _content => do
@@ -173,7 +173,7 @@ deriving TypeName
 /-- Shows a declaration's signature, pretty-printed when the docstring is rendered. -/
 @[doc_role]
 def sig (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
-  return .other { val := .mk (SigData.mk (← codeTargetName xs)) } #[]
+  return .custom (SigData.mk (← codeTargetName xs)) #[]
 
 @[doc_inline_md]
 def sigRender : InlineMdRendererOf SigData := fun _go data _content => do
@@ -197,7 +197,7 @@ deriving TypeName
 /-- Wraps its content in an element whose renderer fails after rendering the content. -/
 @[doc_role]
 def leaky (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
-  return .other { val := .mk Leaky.mk } (← xs.mapM elabInline)
+  return .custom Leaky.mk (← xs.mapM elabInline)
 
 @[doc_inline_md]
 def leakyRender : InlineMdRendererOf Leaky := fun go _data content => do
@@ -235,7 +235,7 @@ abbrev AliasedSyn := Aliased
 /-- Stores an `Aliased` element, with distinct fallback content. -/
 @[doc_role]
 def aliased (_xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
-  return .other { val := .mk (Aliased.mk "rendered via alias") } #[.text "fallback"]
+  return .custom (Aliased.mk "rendered via alias") #[.text "fallback"]
 
 /-- The renderer is declared against the alias rather than `Aliased` itself. -/
 @[doc_inline_md]
@@ -259,7 +259,7 @@ deriving TypeName
 /-- A directive that wraps its blocks in a custom element. -/
 @[doc_directive]
 def banner (xs : TSyntaxArray `block) : DocM (Block ElabInline ElabBlock) := do
-  return .other { val := .mk Banner.mk } (← xs.mapM elabBlock)
+  return .custom Banner.mk (← xs.mapM elabBlock)
 
 /-- The renderer brackets the rendered block content. -/
 @[doc_block_md]
@@ -295,7 +295,7 @@ deriving TypeName
 /-- A directive whose element type has no Markdown renderer. -/
 @[doc_directive]
 def plainBlock (xs : TSyntaxArray `block) : DocM (Block ElabInline ElabBlock) := do
-  return .other { val := .mk PlainBlock.mk } (← xs.mapM elabBlock)
+  return .custom PlainBlock.mk (← xs.mapM elabBlock)
 
 /--
 :::plainBlock
@@ -317,7 +317,7 @@ deriving TypeName
 /-- A directive rendered by a non-terminating renderer. -/
 @[doc_directive]
 def slowBlock (xs : TSyntaxArray `block) : DocM (Block ElabInline ElabBlock) := do
-  return .other { val := .mk SlowBlock.mk } (← xs.mapM elabBlock)
+  return .custom SlowBlock.mk (← xs.mapM elabBlock)
 
 @[doc_block_md]
 def slowBlockRender : BlockMdRendererOf SlowBlock := fun _goI _goB _data _content => do

--- a/tests/elab/versoDocDeferredCheckAttr.lean
+++ b/tests/elab/versoDocDeferredCheckAttr.lean
@@ -1,0 +1,60 @@
+import Lean.Elab.GuardMsgs
+import Lean.Elab.BuiltinEvalCommand
+import Lean.Elab.DocString.Builtin
+
+/-!
+Tests the non-builtin `@[deferred_doc_check]` attribute path: a custom doc role records a deferred
+check carrying a number, and a handler registered via the attribute confirms the number is greater
+than 5.
+-/
+
+open Lean Lean.Doc Elab Term
+open scoped Lean.Doc.Syntax
+
+/-- A deferred check that its number exceeds 5. -/
+structure GreaterThanFive where
+  n : Nat
+deriving TypeName
+
+@[deferred_doc_check GreaterThanFive]
+def checkGreaterThanFive : DeferredCheckHandler := fun d => do
+  let some ⟨n⟩ := d.get? GreaterThanFive
+    | throwError "internal error: expected a `GreaterThanFive`"
+  unless n > 5 do
+    throwError "{n} is not greater than 5"
+
+/-- Defers a check that the referenced number is greater than 5. -/
+@[doc_role]
+def gtFive (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
+  if h : xs.size = 1 then
+    match xs[0] with
+    | `(inline|code($s)) =>
+      let some n := s.getString.toNat? | throwErrorAt s "expected a number"
+      return .deferred (← addDeferredCheck (.mk (GreaterThanFive.mk n)) #[] (← getRef)) #[.code s.getString]
+    | other => throwErrorAt other "expected a number"
+  else
+    throwError "expected precisely one code argument"
+
+set_option doc.verso true
+
+/-- Big enough: {gtFive}`7`. -/
+def usesBig := 1
+
+/-- Too small: {gtFive}`3`. -/
+def usesSmall := 2
+
+/--
+info: FAIL usesSmall: 3 is not greater than 5
+-/
+#guard_msgs in
+#eval show TermElabM Unit from do
+  let m := (← getEnv).mainModule
+  let failures ← Lean.Doc.DeferredCheck.run (· == m)
+  if failures.isEmpty then
+    logInfo "all deferred checks passed"
+  else
+    for (_, c, msg) in failures do
+      let site := match c.site with
+        | .decl n => toString n
+        | .moduleDoc i => s!"module docstring #{i}"
+      logInfo m!"FAIL {site}: {msg}"

--- a/tests/elab/versoDocForwardRef.lean
+++ b/tests/elab/versoDocForwardRef.lean
@@ -1,0 +1,34 @@
+import Lean.Elab.GuardMsgs
+import Lean.Elab.BuiltinEvalCommand
+import Lean.Elab.DocString.Builtin
+
+/-!
+Tests that forward references in Verso docstrings record deferred checks, and that the checker
+runs them: a reference to an existing name passes, a reference to a missing name fails, both
+located at the referring declaration.
+-/
+
+set_option doc.verso true
+
+/-- A reference to {name (scope := "Init")}`Nat.succ`. -/
+def good := 1
+
+/-- A reference to {name (scope := "Init")}`Nat.doesNotExistXYZ`. -/
+def bad := 2
+
+open Lean Elab Term in
+/--
+info: FAIL bad: Unknown constant `Nat.doesNotExistXYZ`
+-/
+#guard_msgs in
+#eval show TermElabM Unit from do
+  let m := (← getEnv).mainModule
+  let failures ← Lean.Doc.DeferredCheck.run (· == m)
+  if failures.isEmpty then
+    logInfo "all deferred checks passed"
+  else
+    for (_, c, msg) in failures do
+      let site := match c.site with
+        | .decl n => toString n
+        | .moduleDoc i => s!"module docstring #{i}"
+      logInfo m!"FAIL {site}: {msg}"

--- a/tests/elab/versoDocForwardRefModuleDoc.lean
+++ b/tests/elab/versoDocForwardRefModuleDoc.lean
@@ -1,0 +1,30 @@
+import Lean.Elab.GuardMsgs
+import Lean.Elab.BuiltinEvalCommand
+import Lean.Elab.DocString.Builtin
+
+set_option doc.verso true
+
+/-!
+Tests that a forward reference in a module docstring is recorded against the module docstring rather
+than a declaration, and run by the checker with the snippet's index. The reference
+{name (scope := "Init")}`Nat.totallyMissingXYZ` does not resolve to a declaration.
+-/
+
+set_option doc.verso false
+
+open Lean Elab Term in
+/--
+info: FAIL module docstring #0: Unknown constant `Nat.totallyMissingXYZ`
+-/
+#guard_msgs in
+#eval show TermElabM Unit from do
+  let m := (← getEnv).mainModule
+  let failures ← Lean.Doc.DeferredCheck.run (· == m)
+  if failures.isEmpty then
+    logInfo "all deferred checks passed"
+  else
+    for (_, c, msg) in failures do
+      let site := match c.site with
+        | .decl n => toString n
+        | .moduleDoc i => s!"module docstring #{i}"
+      logInfo m!"FAIL {site}: {msg}"

--- a/tests/elab/versoDocForwardRefModuleDoc.lean
+++ b/tests/elab/versoDocForwardRefModuleDoc.lean
@@ -3,6 +3,9 @@ import Lean.Elab.BuiltinEvalCommand
 import Lean.Elab.DocString.Builtin
 
 set_option doc.verso true
+-- The test harness disables all linters on the command line; set the option explicitly so the
+-- checks capture it enabled unless a `set_option ... in` turns it off at the docstring.
+set_option linter.doc.deferred true
 
 /-!
 Tests that a forward reference in a module docstring is recorded against the module docstring rather
@@ -10,7 +13,34 @@ than a declaration, and run by the checker with the snippet's index. The referen
 {name (scope := "Init")}`Nat.totallyMissingXYZ` does not resolve to a declaration.
 -/
 
+set_option linter.doc.deferred false in
+/-!
+A second module docstring is elaborated under `set_option linter.doc.deferred false in`, to check
+for the option in the test.
+
+A suppressed reference: {name (scope := "Init")}`Nat.alsoTotallyMissingXYZ` does not resolve either.
+-/
+
 set_option doc.verso false
+
+open Lean Elab Term in
+/--
+info: FAIL module docstring #0: Unknown constant `Nat.totallyMissingXYZ`
+---
+info: FAIL module docstring #1: Unknown constant `Nat.alsoTotallyMissingXYZ`
+-/
+#guard_msgs in
+#eval show TermElabM Unit from do
+  let m := (← getEnv).mainModule
+  let failures ← Lean.Doc.DeferredCheck.run (· == m)
+  if failures.isEmpty then
+    logInfo "all deferred checks passed"
+  else
+    for (_, c, msg) in failures do
+      let site := match c.site with
+        | .decl n => toString n
+        | .moduleDoc i => s!"module docstring #{i}"
+      logInfo m!"FAIL {site}: {msg}"
 
 open Lean Elab Term in
 /--
@@ -20,6 +50,8 @@ info: FAIL module docstring #0: Unknown constant `Nat.totallyMissingXYZ`
 #eval show TermElabM Unit from do
   let m := (← getEnv).mainModule
   let failures ← Lean.Doc.DeferredCheck.run (· == m)
+    (shouldCheck := fun c =>
+      return Linter.getLinterValue linter.doc.deferred (← c.options.toLinterOptions))
   if failures.isEmpty then
     logInfo "all deferred checks passed"
   else

--- a/tests/elab/versoDocMetadata.lean
+++ b/tests/elab/versoDocMetadata.lean
@@ -24,7 +24,8 @@ partial def containsMetadataMatchingInline [Monad m] (inline : Doc.Inline ElabIn
   | .text .. | .image .. | .linebreak .. | .math .. | .code .. => pure false
   | .concat xs | .bold xs | .emph xs | .link xs _ | .footnote _ xs => xs.anyM (containsMetadataMatchingInline · p)
   | .other container content =>
-    p container.val <||> content.anyM (containsMetadataMatchingInline · p)
+    (match container with | .custom v => p v | .deferred _ => pure false) <||>
+      content.anyM (containsMetadataMatchingInline · p)
 
 
 partial def containsMetadataMatchingBlock [Monad m] (block : Doc.Block ElabInline ElabBlock) (p : Dynamic → m Bool) : m Bool :=
@@ -38,7 +39,8 @@ partial def containsMetadataMatchingBlock [Monad m] (block : Doc.Block ElabInlin
       dt.anyM (containsMetadataMatchingInline · p) <||> dd.anyM (containsMetadataMatchingBlock · p)
   | .para xs => xs.anyM (containsMetadataMatchingInline · p)
   | .other container content =>
-      p container.val <||> content.anyM (containsMetadataMatchingBlock · p)
+      (match container with | .custom v => p v | .deferred _ => pure false) <||>
+        content.anyM (containsMetadataMatchingBlock · p)
 
 partial def containsMetadataMatchingPart [Monad m] (part : Doc.Part ElabInline ElabBlock Empty) (p : Dynamic → m Bool) : m Bool :=
   part.title.anyM (containsMetadataMatchingInline · p) <||>

--- a/tests/elab/versoDocModuleFallback.lean
+++ b/tests/elab/versoDocModuleFallback.lean
@@ -19,7 +19,9 @@ info: Markdown:
 Verso:
 { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Module docs should parse as Verso here (fallback from ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.Option _ } #[Lean.Doc.Inline.code "doc.verso"],
+                Lean.Doc.Inline.other
+                  ElabInline.custom (.mk `Lean.Doc.Data.Option _)
+                  #[Lean.Doc.Inline.code "doc.verso"],
                 Lean.Doc.Inline.text ")."],
             Lean.Doc.Block.para
               #[Lean.Doc.Inline.bold #[Lean.Doc.Inline.text "Bold"], Lean.Doc.Inline.text " and ",

--- a/tests/elab/versoDocModuleGiven.lean
+++ b/tests/elab/versoDocModuleGiven.lean
@@ -50,11 +50,14 @@ Finds the highlighted code segments in an inline element.
 -/
 private partial def findInInline (name : Name) : Inline ElabInline → Array DocCode
   | .other container _ =>
-    if container.val.typeName == name then
-      if let some (lt : Data.LeanTerm) := container.val.get? Data.LeanTerm then
-        #[lt.term]
+    match container with
+    | .deferred _ => #[]
+    | .custom val =>
+      if val.typeName == name then
+        if let some (lt : Data.LeanTerm) := val.get? Data.LeanTerm then
+          #[lt.term]
+        else #[]
       else #[]
-    else #[]
   | .emph xs | .bold xs | .concat xs | .link xs _ | .footnote _ xs =>
     xs.flatMap (findInInline name)
   | .text .. | .code .. | .math .. | .linebreak .. | .image .. => #[]
@@ -64,13 +67,16 @@ Finds the highlighted code segments in a block element.
 -/
 private partial def findInBlock (name : Name) : Block ElabInline ElabBlock → Array DocCode
   | .other container _ =>
-    if container.val.typeName == name then
-      if let some (lb : Data.LeanBlock) := container.val.get? Data.LeanBlock then
-        #[lb.commands]
-      else if let some (lt : Data.LeanTerm) := container.val.get? Data.LeanTerm then
-        #[lt.term]
+    match container with
+    | .deferred _ => #[]
+    | .custom val =>
+      if val.typeName == name then
+        if let some (lb : Data.LeanBlock) := val.get? Data.LeanBlock then
+          #[lb.commands]
+        else if let some (lt : Data.LeanTerm) := val.get? Data.LeanTerm then
+          #[lt.term]
+        else #[]
       else #[]
-    else #[]
   | .para inlines => inlines.flatMap (findInInline name)
   | .concat blocks | .blockquote blocks => blocks.flatMap (findInBlock name)
   | .dl items => items.flatMap fun ⟨x, y⟩ => x.flatMap (findInInline name) ++ y.flatMap (findInBlock name)

--- a/tests/elab/versoDocs.lean
+++ b/tests/elab/versoDocs.lean
@@ -670,24 +670,30 @@ private def docCodeStr (dc : DocCode) : String :=
 
 private partial def findInInline (name : Name) : Inline ElabInline → Array DocCode
   | .other container _ =>
-    if container.val.typeName == name then
-      if let some (lt : Data.LeanTerm) := container.val.get? Data.LeanTerm then
-        #[lt.term]
+    match container with
+    | .deferred _ => #[]
+    | .custom val =>
+      if val.typeName == name then
+        if let some (lt : Data.LeanTerm) := val.get? Data.LeanTerm then
+          #[lt.term]
+        else #[]
       else #[]
-    else #[]
   | .emph xs | .bold xs | .concat xs | .link xs _ | .footnote _ xs =>
     xs.flatMap (findInInline name)
   | .text .. | .code .. | .math .. | .linebreak .. | .image .. => #[]
 
 private partial def findInBlock (name : Name) : Block ElabInline ElabBlock → Array DocCode
   | .other container _ =>
-    if container.val.typeName == name then
-      if let some (lb : Data.LeanBlock) := container.val.get? Data.LeanBlock then
-        #[lb.commands]
-      else if let some (lt : Data.LeanTerm) := container.val.get? Data.LeanTerm then
-        #[lt.term]
+    match container with
+    | .deferred _ => #[]
+    | .custom val =>
+      if val.typeName == name then
+        if let some (lb : Data.LeanBlock) := val.get? Data.LeanBlock then
+          #[lb.commands]
+        else if let some (lt : Data.LeanTerm) := val.get? Data.LeanTerm then
+          #[lt.term]
+        else #[]
       else #[]
-    else #[]
   | .para inlines => inlines.flatMap (findInInline name)
   | .concat blocks | .blockquote blocks => blocks.flatMap (findInBlock name)
   | .dl items => items.flatMap fun ⟨x, y⟩ => x.flatMap (findInInline name) ++ y.flatMap (findInBlock name)
@@ -767,8 +773,10 @@ open Doc Elab
 
 private partial def findSetOptionInInline : Inline ElabInline → Array DocCode
   | .other container _ =>
-    if let some (so : Data.SetOption) := container.val.get? Data.SetOption then
-      #[so.term]
+    if let .custom val := container then
+      if let some (so : Data.SetOption) := val.get? Data.SetOption then
+        #[so.term]
+      else #[]
     else #[]
   | .emph xs | .bold xs | .concat xs | .link xs _ | .footnote _ xs =>
     xs.flatMap findSetOptionInInline
@@ -867,8 +875,10 @@ open Doc Elab
 
 private partial def findAtomInInline : Inline ElabInline → Array (Name × Data.Atom)
   | .other container _ =>
-    if let some (a : Data.Atom) := container.val.get? Data.Atom then
-      #[(container.val.typeName, a)]
+    if let .custom val := container then
+      if let some (a : Data.Atom) := val.get? Data.Atom then
+        #[(val.typeName, a)]
+      else #[]
     else #[]
   | .emph xs | .bold xs | .concat xs | .link xs _ | .footnote _ xs =>
     xs.flatMap findAtomInInline

--- a/tests/elab/versoDocsMacro.lean
+++ b/tests/elab/versoDocsMacro.lean
@@ -31,7 +31,7 @@ defWithDoc macroGenerated
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Built on ",
                 Lean.Doc.Inline.other
-                  { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ }
+                  ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _)
                   #[Lean.Doc.Inline.code "Nat.succ"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
@@ -49,7 +49,7 @@ defBare macroBare
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Returns ",
                 Lean.Doc.Inline.other
-                  { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ }
+                  ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _)
                   #[Lean.Doc.Inline.code "Nat.succ"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
@@ -71,7 +71,7 @@ defCodeBlock macroCodeBlock
 /--
 info: { text := #[Lean.Doc.Block.para #[Lean.Doc.Inline.text "A code block:"],
             Lean.Doc.Block.other
-              { val := Dynamic.mk `Lean.Doc.Data.LeanBlock _ }
+              ElabBlock.custom (.mk `Lean.Doc.Data.LeanBlock _)
               #[Lean.Doc.Block.code "#check Nat.succ\n"]],
   subsections := #[] }
 -/

--- a/tests/elab/versoDocsWhere.lean
+++ b/tests/elab/versoDocsWhere.lean
@@ -64,7 +64,7 @@ info: { text := #[Lean.Doc.Block.para #[Lean.Doc.Inline.text "First inner functi
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Second inner function is ",
                 Lean.Doc.Inline.other
-                  { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ }
+                  ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _)
                   #[Lean.Doc.Inline.code "outer.inner2"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
@@ -82,7 +82,7 @@ def withType := helper
 /--
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "What is the type of ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.Const _ } #[Lean.Doc.Inline.code "helper"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.Const _) #[Lean.Doc.Inline.code "helper"],
                 Lean.Doc.Inline.text "?. "]],
   subsections := #[] }
 -/
@@ -103,7 +103,7 @@ def withParam := go 1
 /--
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Returns ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "n"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "n"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
 -/
@@ -121,7 +121,7 @@ def withParamNoType := go 1
 /--
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Returns ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "n"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "n"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
 -/
@@ -139,9 +139,9 @@ def withParams := go 1 2
 /--
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Sums ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "n"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "n"],
                 Lean.Doc.Inline.text " and ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "m"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "m"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
 -/
@@ -159,9 +159,9 @@ def withMixedParams := go 1 2
 /--
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Sums ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "n"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "n"],
                 Lean.Doc.Inline.text " and ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "m"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "m"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
 -/
@@ -178,7 +178,7 @@ def withLetRec : Nat :=
 /--
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Returns ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "n"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "n"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
 -/
@@ -195,7 +195,7 @@ def bareOne x := x + 5
 /--
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Returns ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "x"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "x"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
 -/
@@ -209,9 +209,9 @@ def bareMany x y := x + y + (0 : Nat)
 /--
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Sums ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "x"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "x"],
                 Lean.Doc.Inline.text " and ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "y"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "y"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
 -/
@@ -225,9 +225,9 @@ def bareMixed (x : Nat) y := x + y
 /--
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Sums ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "x"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "x"],
                 Lean.Doc.Inline.text " and ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "y"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "y"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
 -/
@@ -259,7 +259,7 @@ def withIdentHole := go 1 2
 /--
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Returns ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "x"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "x"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
 -/
@@ -275,7 +275,7 @@ def binderDefault (x : Nat := 0) := x
 /--
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Returns ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "x"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "x"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
 -/
@@ -289,7 +289,7 @@ def binderTacticDefault (x : Nat := by exact 0) := x
 /--
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Returns ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "x"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "x"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
 -/
@@ -303,7 +303,7 @@ def namedInstBinder [inst : Inhabited Nat] := (default : Nat)
 /--
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Uses ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "inst"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "inst"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
 -/
@@ -317,7 +317,7 @@ def strictImplicit ⦃x : Nat⦄ := (0 : Nat)
 /--
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Ignores ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "x"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "x"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
 -/
@@ -339,10 +339,10 @@ def orderMid := go "x" true 0
 /--
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.other
-                  { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ }
+                  ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _)
                   #[Lean.Doc.Inline.code "s.length"],
                 Lean.Doc.Inline.text " then ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "n + 1"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "n + 1"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
 -/
@@ -361,7 +361,7 @@ def orderEnds := go 0 "y" false
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Just ",
                 Lean.Doc.Inline.other
-                  { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ }
+                  ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _)
                   #[Lean.Doc.Inline.code "t.length"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
@@ -381,9 +381,9 @@ def captureLeadHole (c : Nat) := go 1 2
 /--
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Captures ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "c"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "c"],
                 Lean.Doc.Inline.text ", returns ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "y"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "y"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
 -/
@@ -398,7 +398,7 @@ def implicitHoleThenNamed {_ : Nat} (m : Nat) := m
 /--
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Returns ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "m"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "m"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
 -/
@@ -412,7 +412,7 @@ def strictImplicitHoleThenNamed ⦃_ : Nat⦄ (y : Nat) := y
 /--
 info: { text := #[Lean.Doc.Block.para
               #[Lean.Doc.Inline.text "Returns ",
-                Lean.Doc.Inline.other { val := Dynamic.mk `Lean.Doc.Data.LeanTerm _ } #[Lean.Doc.Inline.code "y"],
+                Lean.Doc.Inline.other ElabInline.custom (.mk `Lean.Doc.Data.LeanTerm _) #[Lean.Doc.Inline.code "y"],
                 Lean.Doc.Inline.text ". "]],
   subsections := #[] }
 -/

--- a/tests/lake/tests/builtin-lint-record-deferred/.gitignore
+++ b/tests/lake/tests/builtin-lint-record-deferred/.gitignore
@@ -1,0 +1,1 @@
+Violations.lean

--- a/tests/lake/tests/builtin-lint-record-deferred/clean.sh
+++ b/tests/lake/tests/builtin-lint-record-deferred/clean.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+rm -rf .lake
+rm -f lake-manifest.json produced.out Violations.lean

--- a/tests/lake/tests/builtin-lint-record-deferred/lakefile.toml
+++ b/tests/lake/tests/builtin-lint-record-deferred/lakefile.toml
@@ -1,0 +1,5 @@
+name = "lint-record-deferred"
+defaultTargets = ["Violations"]
+
+[[lean_lib]]
+name = "Violations"

--- a/tests/lake/tests/builtin-lint-record-deferred/lean-toolchain
+++ b/tests/lake/tests/builtin-lint-record-deferred/lean-toolchain
@@ -1,0 +1,1 @@
+../../../../build/release/stage1

--- a/tests/lake/tests/builtin-lint-record-deferred/setup.sh
+++ b/tests/lake/tests/builtin-lint-record-deferred/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# (Re)generate the pristine, un-annotated source that `--record-exceptions`
+# edits in place. Regenerating on every run keeps the test idempotent: the
+# checked-in tree never contains the recorded `set_option` lines, and a failed
+# run cannot leave a mutated file behind to poison the next one.
+cat > Violations.lean << 'EOF'
+module
+
+set_option doc.verso true
+
+/-! First module docstring: {name (scope := "Init")}`Nat.firstMissingXYZ` does not resolve. -/
+
+/-! Second module docstring: {name (scope := "Init")}`Nat.secondMissingXYZ` does not resolve. -/
+
+/-- Declaration docstring: {name (scope := "Init")}`Nat.declMissingXYZ` does not resolve. -/
+def declForwardRef : Nat := 0
+
+/-- Resolvable declaration docstring: {name (scope := "Init")}`Nat.zero` resolves fine. -/
+def goodForwardRef : Nat := 0
+EOF

--- a/tests/lake/tests/builtin-lint-record-deferred/test.sh
+++ b/tests/lake/tests/builtin-lint-record-deferred/test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+# Exercises `lake lint --record-exceptions` for deferred docstring checks
+# (`linter.doc.deferred`): a failing forward reference is silenced in place by
+# inserting a `set_option linter.doc.deferred false in` line before the flagged
+# docstring. Covers both site kinds:
+#   * a declaration docstring, recorded via `findDeclarationRanges?` (the
+#     declaration range starts at the `/--` line), and
+#   * Verso module docstrings, recorded via their snippet's declaration range;
+#     two snippets exercise a nonzero site index.
+
+./clean.sh
+./setup.sh
+
+marker='recorded by'
+
+# Asserts the recorded `set_option` for $1 is immediately followed by a line
+# mentioning $2 (i.e. it was inserted directly before that docstring).
+assert_precedes() {
+  echo "? '$1' precedes '$2'"
+  if grep -A1 -E "set_option $1 false in" Violations.lean | grep -qF -- "$2"; then
+    return 0
+  else
+    echo "FAILURE: '$1' exception was not inserted before '$2'"
+    cat Violations.lean
+    return 1
+  fi
+}
+
+# Asserts the docstring mentioning $1 got no recorded exception (the line before
+# it is not a `set_option ... false in`).
+assert_not_recorded() {
+  echo "? '$1' has no recorded exception"
+  if grep -B1 -F -- "$1" Violations.lean | grep -qE 'set_option .* false in'; then
+    echo "FAILURE: '$1' unexpectedly got a recorded exception"
+    cat Violations.lean
+    return 1
+  fi
+}
+
+# --- Baseline: the three unresolvable references fail; the resolvable one does not. ---
+lake_out lint --builtin-lint Violations || true
+match_pat 'Nat.firstMissingXYZ' produced.out
+match_pat 'Nat.secondMissingXYZ' produced.out
+match_pat 'Nat.declMissingXYZ' produced.out
+match_pat 'module docstring #1' produced.out
+match_pat 'module docstring #2' produced.out
+match_pat 'declForwardRef' produced.out
+# The resolvable reference produces no diagnostic.
+no_match_pat 'Nat\.zero' produced.out
+no_match_pat 'goodForwardRef' produced.out
+
+# --- Record exceptions. ---
+# It succeeds (exit 0) as long as every failing check could be located, even
+# though violations were found, and reports what it edited.
+lake_out lint --record-exceptions Violations
+match_pat 'recording 3 exceptions in .*Violations.lean' produced.out
+
+# --- The source now carries one `set_option ... false in` per failing check. ---
+# Each recorded line is tagged with the marker comment...
+test_cmd test "$(grep -c -- "$marker" Violations.lean)" = 3
+# ...and sits directly before the docstring it silences.
+assert_precedes 'linter.doc.deferred' 'Nat.firstMissingXYZ'
+assert_precedes 'linter.doc.deferred' 'Nat.secondMissingXYZ'
+assert_precedes 'linter.doc.deferred' 'Nat.declMissingXYZ'
+# The resolvable reference is left untouched.
+assert_not_recorded 'Nat.zero'
+
+# --- Re-linting now passes: every failing check is silenced. ---
+test_run lint --builtin-lint Violations
+lake_out lint --builtin-lint Violations
+no_match_pat 'MissingXYZ' produced.out
+
+# --- Idempotent: a second recording pass finds nothing new to record. ---
+lake_out lint --record-exceptions Violations || true
+no_match_pat 'recording .* exception' produced.out
+# The file is unchanged: still exactly three recorded exceptions, no duplicates.
+test_cmd test "$(grep -c -- "$marker" Violations.lean)" = 3

--- a/tests/lake/tests/builtin-lint/ForwardRef.lean
+++ b/tests/lake/tests/builtin-lint/ForwardRef.lean
@@ -11,3 +11,6 @@ def badForwardRef : Nat := 0
 set_option linter.doc.deferred false in
 /-- A suppressed unresolvable forward reference: {name (scope := "Init")}`Nat.suppressedMissingABC`. -/
 def suppressedForwardRef : Nat := 0
+
+set_option linter.doc.deferred false in
+/-! A suppressed module docstring reference: {name (scope := "Init")}`Nat.suppressedModuleDocDEF`. -/

--- a/tests/lake/tests/builtin-lint/ForwardRef.lean
+++ b/tests/lake/tests/builtin-lint/ForwardRef.lean
@@ -1,0 +1,13 @@
+module
+
+set_option doc.verso true
+
+/-- A resolvable forward reference: {name (scope := "Init")}`Nat.succ`. -/
+def goodForwardRef : Nat := 0
+
+/-- An unresolvable forward reference: {name (scope := "Init")}`Nat.totallyMissingXYZ`. -/
+def badForwardRef : Nat := 0
+
+set_option linter.doc.deferred false in
+/-- A suppressed unresolvable forward reference: {name (scope := "Init")}`Nat.suppressedMissingABC`. -/
+def suppressedForwardRef : Nat := 0

--- a/tests/lake/tests/builtin-lint/lakefile.toml
+++ b/tests/lake/tests/builtin-lint/lakefile.toml
@@ -20,3 +20,6 @@ name = "ExtraViolations"
 
 [[lean_lib]]
 name = "TextLints"
+
+[[lean_lib]]
+name = "ForwardRef"

--- a/tests/lake/tests/builtin-lint/test.sh
+++ b/tests/lake/tests/builtin-lint/test.sh
@@ -344,3 +344,24 @@ match_pat 'missing doc string for public def undocumentedInDep' produced.out
 # produces no entry for `Dep`.
 lake_out lint --builtin-only Dep || true
 no_match_pat 'missing doc string for public def undocumentedInDep' produced.out
+
+# --- Forward references in Verso docstrings (`linter.doc.deferred`) ---
+# `ForwardRef` has a resolvable reference (`Nat.succ`) and an unresolvable one
+# (`Nat.totallyMissingXYZ`). The unresolvable one fails the lint, reported in the
+# docstring of `badForwardRef`; the resolvable one produces no output.
+test_err 'Unknown constant' lint --builtin-only ForwardRef
+match_pat 'Nat.totallyMissingXYZ' produced.out
+match_pat 'badForwardRef' produced.out
+no_match_pat 'Nat\.succ' produced.out
+# A reference under `set_option linter.doc.deferred false in` is suppressed at its site.
+no_match_pat 'Nat\.suppressedMissingABC' produced.out
+no_match_pat 'suppressedForwardRef' produced.out
+
+# Disabling the linter on the command line suppresses the check.
+test_run lint --linters=-linter.doc.deferred ForwardRef
+
+# Under `--lint-only`, the check runs only when explicitly selected: an unrelated
+# spec passes despite the bad reference, while selecting it surfaces the error.
+test_run lint --lint-only=linter.unusedVariables ForwardRef
+test_err 'Unknown constant' lint --lint-only=linter.doc.deferred ForwardRef
+match_pat 'Nat.totallyMissingXYZ' produced.out

--- a/tests/lake/tests/builtin-lint/test.sh
+++ b/tests/lake/tests/builtin-lint/test.sh
@@ -356,6 +356,8 @@ no_match_pat 'Nat\.succ' produced.out
 # A reference under `set_option linter.doc.deferred false in` is suppressed at its site.
 no_match_pat 'Nat\.suppressedMissingABC' produced.out
 no_match_pat 'suppressedForwardRef' produced.out
+# The same suppression works for a module docstring.
+no_match_pat 'Nat\.suppressedModuleDocDEF' produced.out
 
 # Disabling the linter on the command line suppresses the check.
 test_run lint --linters=-linter.doc.deferred ForwardRef

--- a/tests/pkg/verso_doc_md/VersoDocMd/Defs.lean
+++ b/tests/pkg/verso_doc_md/VersoDocMd/Defs.lean
@@ -26,7 +26,7 @@ meta def codeTargetName (xs : TSyntaxArray `inline) : DocM Name :=
 /-- Includes another declaration's docstring. The target is looked up when rendering to Markdown. -/
 @[doc_role]
 meta def include_docstring (xs : TSyntaxArray `inline) : DocM (Inline ElabInline) := do
-  return .other { val := .mk (IncludeDoc.mk (← codeTargetName xs)) } #[]
+  return .custom (IncludeDoc.mk (← codeTargetName xs)) #[]
 
 /-- The renderer looks up and renders the target's docstring when the including docstring is shown. -/
 @[doc_inline_md]


### PR DESCRIPTION
This PR adapts the deferred docstring check mechanism to use the linter mechanism, presenting an interface akin to that of environment linters. This replaces custom CI setup with an already-used interface. Deferred checks are governed by the option `linter.doc.deferred`.

Breaking change: custom Verso docstring elements are now represented by a two-constructor type with cases for ordinary custom elements and deferred check elements.
