### PR TITLE
feat: add idxOf/getElem round-trip lemmas

### DIFF
--- a/src/Init/Data/List/Find.lean
+++ b/src/Init/Data/List/Find.lean
@@ -1144,6 +1144,21 @@ theorem idxOf_cons [BEq α] :
 @[simp] theorem idxOf_cons_self [BEq α] [ReflBEq α] {l : List α} : (a :: l).idxOf a = 0 := by
   simp [idxOf_cons]
 
+/-- Indexing a list at the position `idxOf x` recovers `x`, provided `x` occurs
+in the list. -/
+@[simp, grind =]
+theorem getElem_idxOf [BEq α] [LawfulBEq α] {x : α} {xs : List α}
+    (h : idxOf x xs < xs.length) : xs[xs.idxOf x] = x := by
+  induction xs with
+  | nil => simp at h
+  | cons a l ih =>
+    cases hax : a == x with
+    | true => simp only [idxOf_cons, hax, cond_true, getElem_cons_zero]; exact eq_of_beq hax
+    | false =>
+      simp only [idxOf_cons, hax, cond_false, getElem_cons_succ]
+      rw [idxOf_cons, hax, cond_false, length_cons] at h
+      exact ih (by omega)
+
 @[grind =]
 theorem idxOf_append [BEq α] [LawfulBEq α] {l₁ l₂ : List α} {a : α} :
     (l₁ ++ l₂).idxOf a = if a ∈ l₁ then l₁.idxOf a else l₂.idxOf a + l₁.length := by

--- a/src/Init/Data/List/Nat/Pairwise.lean
+++ b/src/Init/Data/List/Nat/Pairwise.lean
@@ -13,6 +13,7 @@ import Init.Data.List.Pairwise
 import Init.Data.List.Sublist
 import Init.Data.List.TakeDrop
 public import Init.Data.List.FinRange
+public import Init.Data.List.Find
 
 public section
 
@@ -93,5 +94,25 @@ theorem pairwise_le_finRange (n : Nat) : Pairwise (· ≤ ·) (finRange n) := by
 /-- The list `List.finRange n` has no duplicate entries. -/
 theorem nodup_finRange (n : Nat) : (finRange n).Nodup :=
   (pairwise_lt_finRange n).imp Fin.ne_of_lt
+
+/-- In a list with no duplicates, `idxOf` recovers the index of the element at
+each position. -/
+@[simp]
+theorem Nodup.idxOf_getElem [BEq α] [LawfulBEq α] {xs : List α} (H : Nodup xs)
+    (i : Nat) (h : i < xs.length) : idxOf xs[i] xs = i := by
+  induction xs generalizing i with
+  | nil => exact absurd h (Nat.not_lt_zero i)
+  | cons a l ih =>
+    rw [nodup_cons] at H
+    match i with
+    | 0 => rw [getElem_cons_zero, idxOf_cons_self]
+    | j + 1 =>
+      have hj : j < l.length := Nat.lt_of_succ_lt_succ h
+      have hne : (a == l[j]) = false := by
+        rw [beq_eq_false_iff_ne]
+        exact fun hc => H.1 (hc ▸ getElem_mem hj)
+      rw [getElem_cons_succ, idxOf_cons, hne, cond_false, ih H.2 j hj]
+
+grind_pattern Nodup.idxOf_getElem => Nodup xs, idxOf (xs[i]'h) xs
 
 end List


### PR DESCRIPTION
This PR adds the round-trip lemmas between `List.idxOf` and indexing: `List.getElem_idxOf` (`xs[xs.idxOf x] = x` when `x` occurs in `xs`) and `List.Nodup.idxOf_getElem` (`idxOf xs[i] xs = i` for a duplicate-free `xs`). These are currently only available in Batteries.
