### PR TITLE
feat: add List.Nodup.length_le_of_subset

### DIFF
--- a/src/Init/Data/List/Perm.lean
+++ b/src/Init/Data/List/Perm.lean
@@ -482,6 +482,27 @@ theorem perm_ext_iff_of_nodup {l₁ l₂ : List α} (d₁ : Nodup l₁) (d₂ : 
   rw [d₁.count, d₂.count]
   simp only [h a]
 
+/-- A list with no duplicates that is a subset of another list is no longer than
+that list. -/
+theorem Nodup.length_le_of_subset {l₁ l₂ : List α}
+    (h₁ : l₁.Nodup) (hsub : l₁ ⊆ l₂) : l₁.length ≤ l₂.length := by
+  classical
+  induction l₁ generalizing l₂ with
+  | nil => simp
+  | cons a t ih =>
+    rw [nodup_cons] at h₁
+    have ha : a ∈ l₂ := hsub (mem_cons_self ..)
+    have htsub : t ⊆ l₂.erase a := by
+      intro x hx
+      have hxa : x ≠ a := fun h => h₁.1 (h ▸ hx)
+      exact (mem_erase_of_ne hxa).2 (hsub (mem_cons_of_mem _ hx))
+    have hih := ih h₁.2 htsub
+    have hlen : (l₂.erase a).length = l₂.length - 1 := by rw [length_erase]; simp [ha]
+    have hpos : 1 ≤ l₂.length := length_pos_of_mem ha
+    calc t.length + 1 ≤ (l₂.erase a).length + 1 := Nat.succ_le_succ hih
+      _ = (l₂.length - 1) + 1 := by rw [hlen]
+      _ = l₂.length := Nat.sub_add_cancel hpos
+
 theorem Perm.pairwise_iff {R : α → α → Prop} (S : ∀ {x y}, R x y → R y x) :
     ∀ {l₁ l₂ : List α} (_p : l₁ ~ l₂), Pairwise R l₁ ↔ Pairwise R l₂ :=
   suffices ∀ {l₁ l₂}, l₁ ~ l₂ → Pairwise R l₁ → Pairwise R l₂


### PR DESCRIPTION
This PR adds `List.Nodup.length_le_of_subset`: a duplicate-free list that is a subset of another list is no longer than that list. This is currently only available in Batteries (via the `Subperm` API); here it is proved directly by induction.
