### PR TITLE
feat: lake: `getLeanSharedDynlibs`

### DIFF
--- a/src/lake/Lake/Config/InstallPath.lean
+++ b/src/lake/Lake/Config/InstallPath.lean
@@ -147,8 +147,7 @@ public structure LeanInstall where
   ccLinkSharedFlags := linkSharedFlags
   deriving Inhabited, Repr
 
-@[deprecated "sharedDynlib" (since := "2026-06-29")]
-public abbrev LeanInstall.sharedLib (self : LeanInstall) : FilePath :=
+@[inline] public def LeanInstall.sharedLib (self : LeanInstall) : FilePath :=
   self.sharedDynlib.path
 
 @[deprecated "sharedDynlibs" (since := "2026-06-29")]

--- a/src/lake/Lake/Config/InstallPath.lean
+++ b/src/lake/Lake/Config/InstallPath.lean
@@ -112,7 +112,6 @@ public def leanSharedDynlib (sysroot : FilePath) : Dynlib :=
   (leanSharedDynlibs sysroot)[(0 : USize)]'size_leanSharedDynlibs_pos
 
 /-- `libleanshared` file name. -/
-@[deprecated "leanSharedDynlib" (since := "2026-06-29")]
 public def leanSharedLib : FilePath :=
   FilePath.addExtension "libleanshared" sharedLibExt
 

--- a/src/lake/Lake/Config/InstallPath.lean
+++ b/src/lake/Lake/Config/InstallPath.lean
@@ -10,6 +10,7 @@ public import Lean.Compiler.FFI
 public import Lake.Config.Dynlib
 public import Lake.Config.Defaults
 public import Lake.Util.NativeLib
+import Init.Data.UInt.Lemmas
 import Init.Data.String.Modify
 import Init.System.Platform
 
@@ -84,11 +85,39 @@ public def leanSharedLibDir (sysroot : FilePath) :=
   else
     sysroot / "lib" / "lean"
 
+/-- The entire set of core shared libraries in a Lean installation. -/
+public def leanSharedDynlibs (sysroot : FilePath) : Array Dynlib :=
+  -- libLake_shared links against the split libs on all platforms,
+  -- so they must be included in the bundle even when they are empty stubs.
+  if System.Platform.isWindows then libs winLib else libs unixLib
+where
+  @[inline] winLib name deps :=
+    -- On Windows, libraries are in `bin` and link to one another
+    {name, path := sysroot / "bin" / s!"lib{name}.dll", deps}
+  @[inline] unixLib name _ :=
+     -- On Unix, libraries are in `lean/lib` and are independent
+    {name, path := sysroot / "lib" / "lean" / s!"lib{name}.{sharedLibExt}"}
+  @[inline] libs f :=
+    let init := f "Init_shared" #[]
+    let lean1 := f "leanshared_1" #[init]
+    let lean2 := f  "leanshared_2" #[lean1, init]
+    let lean := f "leanshared" #[lean2, lean1, init]
+    #[lean, lean2, lean1, init]
+
+theorem size_leanSharedDynlibs_pos : 0 < (leanSharedDynlibs sysroot).size := by
+  unfold leanSharedDynlibs; split <;> simp [leanSharedDynlibs.libs]
+
+/-- The primary core shared library (i.e., `libleanshared`) in a Lean installation. -/
+public def leanSharedDynlib (sysroot : FilePath) : Dynlib :=
+  (leanSharedDynlibs sysroot)[(0 : USize)]'size_leanSharedDynlibs_pos
+
 /-- `libleanshared` file name. -/
-public def leanSharedLib  :=
+@[deprecated "leanSharedDynlib" (since := "2026-06-29")]
+public def leanSharedLib : FilePath :=
   FilePath.addExtension "libleanshared" sharedLibExt
 
 /-- `Init` shared library file name. -/
+@[deprecated "leanSharedDynlibs" (since := "2026-06-29")]
 public def initSharedLib : FilePath :=
   FilePath.addExtension "libInit_shared" sharedLibExt
 
@@ -105,8 +134,8 @@ public structure LeanInstall where
   leanir := leanirExe sysroot
   leanc := leancExe sysroot
   leantar := leantarExe sysroot
-  sharedLib := leanSharedLibDir sysroot / leanSharedLib
-  initSharedLib := leanSharedLibDir sysroot / initSharedLib
+  sharedDynlibs := leanSharedDynlibs sysroot
+  sharedDynlib := leanSharedDynlib sysroot
   ar : FilePath := "ar"
   cc : FilePath := "cc"
   customCc : Bool := true
@@ -117,6 +146,14 @@ public structure LeanInstall where
   ccLinkStaticFlags := linkStaticFlags
   ccLinkSharedFlags := linkSharedFlags
   deriving Inhabited, Repr
+
+@[deprecated "sharedDynlib" (since := "2026-06-29")]
+public abbrev LeanInstall.sharedLib (self : LeanInstall) : FilePath :=
+  self.sharedDynlib.path
+
+@[deprecated "sharedDynlibs" (since := "2026-06-29")]
+public nonrec def LeanInstall.initSharedLib (self : LeanInstall) : FilePath :=
+  leanSharedLibDir self.sysroot / initSharedLib
 
 /--
 A `SearchPath` including the Lean installation's shared library directories
@@ -162,11 +199,16 @@ public def LakeInstall.ofLean (lean : LeanInstall) : LakeInstall where
   srcDir := lean.srcDir / "lake"
   binDir := lean.binDir
   libDir := lean.leanLibDir
-  sharedDynlib :=
-    let lib := s!"libLake_shared.{sharedLibExt}"
-    let path := if Platform.isWindows then lean.binDir / lib else lean.leanLibDir / lib
-    {name := "Lake_shared", path}
   lake := lean.binDir / lakeExe
+  sharedDynlib := {
+    name := "Lake_shared"
+    deps := lean.sharedDynlibs
+    path :=
+      if Platform.isWindows then
+        lean.binDir / "libLake_shared.dll"
+      else
+        lean.leanLibDir / s!"libLake_shared.{sharedLibExt}"
+    }
 
 /-! ## Detection Functions -/
 

--- a/src/lake/Lake/Config/Monad.lean
+++ b/src/lake/Lake/Config/Monad.lean
@@ -308,8 +308,17 @@ variable [Functor m]
 @[inline] public def getLeantar : m FilePath :=
   (·.leantar) <$> getLeanInstall
 
+/-- Returns the primary core shared library (i.e., {lit}`libleanshared`) in the detected Lean installation. -/
+@[inline] public def getLeanSharedDynlib : m Dynlib :=
+  (·.sharedDynlib) <$> getLeanInstall
+
+/-- Returns the core shared libraries in the detected Lean installation. -/
+@[inline] public def getLeanSharedDynlibs : m (Array Dynlib) :=
+  (·.sharedDynlibs) <$> getLeanInstall
+
 /-- Returns the path of the {lit}`libleanshared` library in the detected Lean installation. -/
-@[inline] public def getLeanSharedLib : m FilePath :=
+@[inline, deprecated "getLeanSharedDynlib" (since := "2026-06-29")]
+public def getLeanSharedLib : m FilePath :=
   (·.sharedLib) <$> getLeanInstall
 
 /-- Get the path of the {lit}`ar` binary in the detected Lean installation. -/

--- a/src/lake/Lake/Config/Monad.lean
+++ b/src/lake/Lake/Config/Monad.lean
@@ -308,7 +308,10 @@ variable [Functor m]
 @[inline] public def getLeantar : m FilePath :=
   (·.leantar) <$> getLeanInstall
 
-/-- Returns the primary core shared library (i.e., {lit}`libleanshared`) in the detected Lean installation. -/
+/--
+Returns the primary core shared library
+(i.e., {lit}`libleanshared`) in the detected Lean installation.
+-/
 @[inline] public def getLeanSharedDynlib : m Dynlib :=
   (·.sharedDynlib) <$> getLeanInstall
 
@@ -316,8 +319,10 @@ variable [Functor m]
 @[inline] public def getLeanSharedDynlibs : m (Array Dynlib) :=
   (·.sharedDynlibs) <$> getLeanInstall
 
-/-- Returns the path of the {lit}`libleanshared` library in the detected Lean installation. -/
-@[inline, deprecated "getLeanSharedDynlib" (since := "2026-06-29")]
+/--
+Returns the path of the primary core shared library
+(i.e., {lit}`libleanshared`) in the detected Lean installation.
+-/
 public def getLeanSharedLib : m FilePath :=
   (·.sharedLib) <$> getLeanInstall
 

--- a/src/lake/Lake/Config/Monad.lean
+++ b/src/lake/Lake/Config/Monad.lean
@@ -323,7 +323,7 @@ Returns the primary core shared library
 Returns the path of the primary core shared library
 (i.e., {lit}`libleanshared`) in the detected Lean installation.
 -/
-public def getLeanSharedLib : m FilePath :=
+@[inline] public def getLeanSharedLib : m FilePath :=
   (·.sharedLib) <$> getLeanInstall
 
 /-- Get the path of the {lit}`ar` binary in the detected Lean installation. -/


### PR DESCRIPTION
This PR adds API for retrieving the complete set of core dynamic libraries. In current terms, these are `libleanshared`, `libleanshared_1`, and `libleanshared_2`. and `libInit_shared`. These libraries have different interdependencies on Windows and Unix, so they are modelled with `Dynlib` in order to track this information.
