### PR TITLE
doc: convert pre-declaration comments into docstrings

### DIFF
--- a/src/Init/Data/BitVec/Lemmas.lean
+++ b/src/Init/Data/BitVec/Lemmas.lean
@@ -5948,7 +5948,7 @@ theorem getMsbD_abs {i : Nat} {x : BitVec w} :
     getMsbD (x.abs) i = if x.msb then getMsbD (-x) i else getMsbD x i := by
   by_cases h : x.msb <;> simp [BitVec.abs, h]
 
-/-
+/--
 The absolute value of `x : BitVec w` is naively a case split on the sign of `x`.
 However, recall that when `x = intMin w`, `-x = x`.
 Thus, the full value of `abs x` is computed by the case split:
@@ -5971,7 +5971,7 @@ theorem toInt_abs_eq_ite {x : BitVec w} :
 
 
 
-/-
+/--
 The absolute value of `x : BitVec w` is a case split on the sign of `x`, when `x ≠ intMin w`.
 This is a variant of `toInt_abs_eq_ite`.
 -/
@@ -6006,7 +6006,7 @@ theorem toInt_abs_eq_natAbs {x : BitVec w} : x.abs.toInt =
         exact msb_eq_false_iff_two_mul_lt.mp (by simp [h])
       omega
 
-/-
+/--
 The absolute value of `(x : BitVec w)`, when interpreted as an integer,
 is the absolute value of `x.toInt` when `(x ≠ intMin)`.
 -/

--- a/src/Init/Data/Iterators/Consumers/Access.lean
+++ b/src/Init/Data/Iterators/Consumers/Access.lean
@@ -46,7 +46,7 @@ def Iter.atIdxSlow? {α β} [Iterator α Id β]
 
 -- We provide the functional induction principle by hand because `atIdxSlow?` is implemented using
 -- `extrinsicFix₂` and not using well-founded recursion.
-/-
+/--
 An induction principle for `Iter.atIdxSlow?`.
 
 This lemma provides a functional induction principle for reasoning about `Iter.atIdxSlow? n it`.

--- a/src/Init/Data/List/Perm.lean
+++ b/src/Init/Data/List/Perm.lean
@@ -303,7 +303,7 @@ theorem countP_eq_countP_filter_add (l : List α) (p q : α → Bool) :
 theorem Perm.count_eq [BEq α] {l₁ l₂ : List α} (p : l₁ ~ l₂) (a) :
     count a l₁ = count a l₂ := p.countP_eq _
 
-/-
+/--
 This theorem is a variant of `Perm.foldl_eq` defined in Mathlib which uses typeclasses rather
 than the explicit `comm` argument.
 -/
@@ -323,7 +323,7 @@ theorem Perm.foldl_eq' {f : β → α → β} {l₁ l₂ : List α} (p : l₁ ~ 
     refine (IH₁ comm init).trans (IH₂ ?_ _)
     intros; apply comm <;> apply p₁.symm.subset <;> assumption
 
-/-
+/--
 This theorem is a variant of `Perm.foldr_eq` defined in Mathlib which uses typeclasses rather
 than the explicit `comm` argument.
 -/

--- a/src/Lean/Compiler/LCNF/ToLCNF.lean
+++ b/src/Lean/Compiler/LCNF/ToLCNF.lean
@@ -339,7 +339,7 @@ def withNewScope (x : M α) : M α := do
     }
     set saved
 
-/-
+/--
 Replace free variables in `type'` that occur in `toAny` into `◾`.
 Recall that we populate `toAny` with the free variable ids of fields that
 are type formers. This can happen when we have a field whose type is, for example, `Type u`.

--- a/src/Lean/Data/PrefixTree.lean
+++ b/src/Lean/Data/PrefixTree.lean
@@ -12,7 +12,7 @@ public section
 
 namespace Lean
 
-/- Similar to trie, but for arbitrary keys -/
+/-- Similar to trie, but for arbitrary keys -/
 inductive PrefixTreeNode (α : Type u) (β : Type v) (cmp : α → α → Ordering) where
   | Node : Option β → Std.TreeMap.Raw α (PrefixTreeNode α β cmp) cmp → PrefixTreeNode α β cmp
 

--- a/src/Lean/Elab/GuardMsgs.lean
+++ b/src/Lean/Elab/GuardMsgs.lean
@@ -162,7 +162,9 @@ ambiguities in the case the message already had that symbol).
 def revealTrailingWhitespace (s : String) : String :=
   s.replace "⏎\n" "⏎⏎\n" |>.replace "\t\n" "\t⏎\n" |>.replace " \n" " ⏎\n"
 
-/- The inverse of `revealTrailingWhitespace` -/
+/--
+The inverse of `revealTrailingWhitespace`. Removes `⏎` when it occurs at the end of a line.
+-/
 def removeTrailingWhitespaceMarker (s : String) : String :=
   s.replace "⏎\n" "\n"
 

--- a/src/Lean/Elab/PreDefinition/WF/Fix.lean
+++ b/src/Lean/Elab/PreDefinition/WF/Fix.lean
@@ -209,7 +209,7 @@ private def applyDefaultDecrTactic (mvarId : MVarId) : TermElabM Unit := do
   unless remainingGoals.isEmpty do
     Term.reportUnsolvedGoals remainingGoals
 
-/-
+/--
 Given an array of MVars, assign MVars with equal type and subsumed local context to each other.
 Returns those MVar that did not get assigned.
 -/

--- a/src/Lean/Elab/PreDefinition/WF/GuessLex.lean
+++ b/src/Lean/Elab/PreDefinition/WF/GuessLex.lean
@@ -482,7 +482,7 @@ def evalRecCall (callerName: Name) (decrTactic? : Option DecreasingBy) (callerMe
         continue
     return .no_idea
 
-/- A cache for `evalRecCall` -/
+/-- A cache for `evalRecCall` -/
 structure RecCallCache where mk'' ::
   callerName : Name
   decrTactic? : Option DecreasingBy

--- a/src/Lean/Level.lean
+++ b/src/Lean/Level.lean
@@ -307,14 +307,14 @@ def isAlreadyNormalizedCheap : Level → Bool
   | succ u  => isAlreadyNormalizedCheap u
   | _       => false
 
-/- Auxiliary function used at `normalize` -/
+/-- Auxiliary function used at `normalize` -/
 private def mkIMaxAux : Level → Level → Level
   | _,    zero   => zero
   | zero, u      => u
   | succ zero, u => u
   | u₁,   u₂     => if u₁ == u₂ then u₁ else mkLevelIMax u₁ u₂
 
-/- Auxiliary function used at `normalize` -/
+/-- Auxiliary function used at `normalize` -/
 @[specialize] private partial def getMaxArgsAux (normalize : Level → Level) : Level → Bool → Array Level → Array Level
   | max l₁ l₂, alreadyNormalized, lvls => getMaxArgsAux normalize l₂ alreadyNormalized (getMaxArgsAux normalize l₁ alreadyNormalized lvls)
   | l,           false,             lvls => getMaxArgsAux normalize (normalize l) true lvls
@@ -324,14 +324,15 @@ private def accMax (result : Level) (prev : Level) (offset : Nat) : Level :=
   if result.isZero then prev.addOffset offset
   else mkLevelMax result (prev.addOffset offset)
 
-/- Auxiliary function used at `normalize`.
+/--
+   Auxiliary function used at `normalize`.
    Remarks:
    - `lvls` are sorted using `normLt`
    - `extraK` is the outer offset of the `max` term. We will push it inside.
    - `i` is the current array index
    - `prev + prevK` is the "previous" level that has not been added to `result` yet.
    - `result` is the accumulator
- -/
+-/
 private partial def mkMaxAux (lvls : Array Level) (extraK : Nat) (i : Nat) (prev : Level) (prevK : Nat) (result : Level) : Level :=
   if h : i < lvls.size then
     let lvl   := lvls[i]
@@ -344,9 +345,10 @@ private partial def mkMaxAux (lvls : Array Level) (extraK : Nat) (i : Nat) (prev
   else
     accMax result prev (extraK + prevK)
 
-/-
+/--
   Auxiliary function for `normalize`. It assumes `lvls` has been sorted using `normLt`.
-  It finds the first position that is not an explicit universe. -/
+  It finds the first position that is not an explicit universe.
+-/
 private partial def skipExplicit (lvls : Array Level) (i : Nat) : Nat :=
   if h : i < lvls.size then
     let lvl := lvls[i]
@@ -369,7 +371,7 @@ private partial def isExplicitSubsumedAux (lvls : Array Level) (maxExplicit : Na
   else
     false
 
-/- Auxiliary function for `normalize`. See `isExplicitSubsumedAux` -/
+/-- Auxiliary function for `normalize`. See `isExplicitSubsumedAux` -/
 private def isExplicitSubsumed (lvls : Array Level) (firstNonExplicit : Nat) : Bool :=
   if firstNonExplicit == 0 then false
   else

--- a/src/Lean/Meta/ArgsPacker.lean
+++ b/src/Lean/Meta/ArgsPacker.lean
@@ -57,7 +57,7 @@ namespace Unary
 Helpers for iterated `PSigma`.
 -/
 
-/-
+/--
 Given a telescope of FVars of type `tᵢ`, iterates `PSigma` to produce the type
 `t₁ ⊗' t₂ …`.
 -/
@@ -331,7 +331,7 @@ def mkCodomain (types : Array Expr) (x : Expr) : MetaM Expr := do
     termination_by types.size - 1 - i
   go x 0
 
-/-
+/--
 Given types `(x : A) → R₁[x]` and `(z : B) → R₂[z]`, returns the type
 ```
 (x : A ⊕' B) → (match x with | .inl x => R₁[x] | .inr R₂[z]
@@ -355,7 +355,7 @@ def uncurryType (types : Array Expr) : MetaM Expr := do
     let codomain ← Mutual.mkCodomain types x
     mkForallFVars #[x] codomain
 
-/-
+/--
 Given types `(x : A) → R` and `(z : B) → R`, returns the type
 ```
 (x : A ⊕' B) → R
@@ -375,7 +375,7 @@ def uncurryTypeND (types : Array Expr) : MetaM Expr := do
   let domain ← packType (types.map (·.bindingDomain!))
   mkArrow domain codomain
 
-/-
+/--
 Iterated `PSum.casesOn`:
 Given a value `(x : A ⊕ C)` (which must be a FVar) and functions
 `alt₁ : (a : A) → codomain[inl a]` and `alt₂ : (b : B) → codomain[inr b]`,
@@ -435,7 +435,7 @@ def uncurryND (es : Array Expr) : MetaM Expr := do
     let value ← casesOn x codomain es.toList
     mkLambdaFVars #[x] value
 
-/-
+/--
 Given type `(A ⊕' C) → R` (possibly dependent), return types
 ```
 #[A → R, B → R]

--- a/src/Lean/Meta/Constructions/NoConfusion.lean
+++ b/src/Lean/Meta/Constructions/NoConfusion.lean
@@ -159,7 +159,7 @@ where
       | _, _, eqs => k eqs
 
 
-/-
+/--
 Variant of `withEqTelescope`, but when `xi = yi`, no variable is introduced, and `Eq.refl` is used
 for the expression, unless this is the last one. (This special case could be dropped if we do not
 generate no-confusion principles for constructors with only prop-valued fields.)

--- a/src/Lean/Meta/LazyDiscrTree.lean
+++ b/src/Lean/Meta/LazyDiscrTree.lean
@@ -160,7 +160,7 @@ def isNatOffset (fName : Name) (e : Expr) : MetaM Bool := do
   else
     return fName == ``Nat.succ && e.getAppNumArgs == 1
 
-/-
+/--
 This is a hook to determine if we should add an expression as a wildcard pattern.
 
 Clone of `Lean.Meta.DiscrTree.shouldAddAsStar`.  See it for more discussion.
@@ -261,7 +261,7 @@ def getKeyArgs (e : Expr) (isMatch root : Bool) :
   | .bvar _ | .letE _ _ _ _ _ | .lam _ _ _ _ | .mdata _ _ | .app _ _ | .sort _ =>
     return (.other, #[])
 
-/-
+/--
 Given an expression we are looking for patterns that match, return the key and sub-expressions.
 -/
 abbrev getMatchKeyArgs (e : Expr) (root : Bool) :
@@ -581,7 +581,7 @@ partial def appendResults (mr : MatchResult α) (a : Array α) : Array α :=
 
 end MatchResult
 
-/-
+/--
 A partial match captures the intermediate state of a match
 execution.
 
@@ -660,7 +660,7 @@ def getStarResult (root : Std.HashMap Key TrieIndex) : MatchM α (MatchResult α
     let (vs, _) ← evalNode idx
     pure <| ({} : MatchResult α).push (score := 1) vs
 
-/-
+/--
 Add partial match to cases if discriminator tree root map has potential matches.
 -/
 def pushRootCase (r : Std.HashMap Key TrieIndex) (k : Key) (args : Array Expr)

--- a/src/Lean/Meta/Match/MatcherApp/Transform.lean
+++ b/src/Lean/Meta/Match/MatcherApp/Transform.lean
@@ -188,7 +188,7 @@ def withUserNames {n} [MonadControlT MetaM n] [Monad n]
   {α} (fvars : Array Expr) (names : Array Name) (k : n α) : n α := do
   mapMetaM (withUserNamesImpl fvars names) k
 
-/-
+/--
 `Match.forallAltTelescope` lifted to a monad transformer
 (and only passing those arguments that we care about below)
 -/

--- a/src/Lean/Meta/SizeOf.lean
+++ b/src/Lean/Meta/SizeOf.lean
@@ -389,7 +389,7 @@ mutual
 
 end
 
-/- Prove SizeOf spec lemma of the form `sizeOf <ctor-application> = 1 + sizeOf <field_1> + ... + sizeOf <field_n> -/
+/-- Prove SizeOf spec lemma of the form `sizeOf <ctor-application> = 1 + sizeOf <field_1> + ... + sizeOf <field_n> -/
 partial def main (lhs rhs : Expr) : M Expr := do
   if (← isDefEq lhs rhs) then
     mkEqRefl rhs

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Nat.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Nat.lean
@@ -87,12 +87,12 @@ builtin_dsimproc [seval] isValue ((OfNat.ofNat _ : Nat)) := fun e => do
 
 /-- A literal natural number or a base + offset expression. -/
 private inductive NatOffset where
-  /- denotes expression definition equal to `n` -/
+  /-- denotes expression definition equal to `n` -/
   | const (n : Nat)
   /-- denotes `e + o` where `o` is expression definitionally equal to `n` -/
   | offset (e o : Expr) (n : Nat)
 
-/- Attempt to parse a `NatOffset` from an expression-/
+/-- Attempt to parse a `NatOffset` from an expression-/
 private partial def NatOffset.asOffset (e : Expr) : Meta.SimpM (Option (Expr × Nat)) := do
   if e.isAppOfArity ``HAdd.hAdd 6 then
     let inst := e.appFn!.appFn!.appArg!
@@ -117,7 +117,7 @@ private partial def NatOffset.asOffset (e : Expr) : Meta.SimpM (Option (Expr × 
   else
     pure none
 
-/- Attempt to parse a `NatOffset` from an expression-/
+/-- Attempt to parse a `NatOffset` from an expression-/
 private partial def NatOffset.fromExprAux (e : Expr) (inc : Nat) : Meta.SimpM (Option (Expr × Nat)) := do
   let e := e.consumeMData
   match ← asOffset e with
@@ -126,7 +126,7 @@ private partial def NatOffset.fromExprAux (e : Expr) (inc : Nat) : Meta.SimpM (O
   | none =>
     return if inc != 0 then some (e, inc) else none
 
-/- Attempt to parse a `NatOffset` from an expression-/
+/-- Attempt to parse a `NatOffset` from an expression-/
 private def NatOffset.fromExpr? (e : Expr) (inc : Nat := 0) : Meta.SimpM (Option NatOffset) := do
   match ← Nat.fromExpr? e with
   | some n => pure (some (const (n + inc)))

--- a/src/Lean/Parser/Tactic.lean
+++ b/src/Lean/Parser/Tactic.lean
@@ -20,7 +20,9 @@ builtin_initialize
   register_parser_alias tacticSeq
   register_parser_alias tacticSeqIndentGt
 
-/--
+-- Don't make this a docstring, because it shows up at unfortunate places
+-- in hovers and completion:
+/-
 This is a fallback tactic parser for any identifier which exists only
 to improve syntax error messages.
 ```

--- a/src/Lean/Parser/Tactic.lean
+++ b/src/Lean/Parser/Tactic.lean
@@ -20,7 +20,8 @@ builtin_initialize
   register_parser_alias tacticSeq
   register_parser_alias tacticSeqIndentGt
 
-/- This is a fallback tactic parser for any identifier which exists only
+/--
+This is a fallback tactic parser for any identifier which exists only
 to improve syntax error messages.
 ```
 example : True := by foo -- unknown tactic

--- a/src/Lean/Parser/Term.lean
+++ b/src/Lean/Parser/Term.lean
@@ -107,12 +107,13 @@ namespace Term
 @[builtin_term_parser] def byTactic := leading_parser:leadPrec
   ppAllowUngrouped >> "by " >> Tactic.tacticSeqIndentGt
 
-/-
+/--
   This is the same as `byTactic`, but it uses a different syntax kind. This is
   used by `show` and `suffices` instead of `byTactic` because these syntaxes don't
   support arbitrary terms where `byTactic` is accepted. Mathport uses this to e.g.
   safely find-replace `by exact $e` by `$e` in any context without causing
-  incorrect syntax when the full expression is `show $T by exact $e`. -/
+  incorrect syntax when the full expression is `show $T by exact $e`.
+-/
 def byTactic' := leading_parser
   "by " >> Tactic.tacticSeqIndentGt
 

--- a/src/Lean/Setup.lean
+++ b/src/Lean/Setup.lean
@@ -21,7 +21,7 @@ Data types used by Lean module headers and the `--setup` CLI.
 
 namespace Lean
 
-/- Abstract structure of an `import` statement. -/
+/-- Abstract structure of an {lit}`import` statement. -/
 structure Import where
   module     : Name
   /-- `import all`; whether to import and expose all data saved by the module. -/

--- a/src/Lean/Util/MonadCache.lean
+++ b/src/Lean/Util/MonadCache.lean
@@ -82,7 +82,7 @@ instance [Alternative m] : Alternative (MonadCacheT α β m) := inferInstanceAs 
 
 end MonadCacheT
 
-/- Similar to `MonadCacheT`, but using `StateT` instead of `StateRefT` -/
+/-- Similar to `MonadCacheT`, but using `StateT` instead of `StateRefT` -/
 @[expose] def MonadStateCacheT (α β : Type) (m : Type → Type) [BEq α] [Hashable α] := StateT (Std.HashMap α β) m
 
 namespace MonadStateCacheT

--- a/src/Std/Data/Iterators/Lemmas/Equivalence/Basic.lean
+++ b/src/Std/Data/Iterators/Lemmas/Equivalence/Basic.lean
@@ -68,7 +68,7 @@ noncomputable def IterM.stepAsHetT [Iterator α m β] [Monad m] (it : IterM (α 
     HetT m (IterStep (IterM (α := α) m β) β) :=
     ⟨it.IsPlausibleStep, inferInstance, (fun step => .deflate step.inflate) <$> it.step⟩
 
-/-
+/--
 Makes a step with a bundled iterator in the `HetT` monad.
 -/
 noncomputable def BundledIterM.step {β : Type w} {m : Type w → Type w'} [Monad m] [LawfulMonad m]

--- a/src/lake/Lake/Build/Infos.lean
+++ b/src/lake/Lake/Build/Infos.lean
@@ -218,7 +218,7 @@ end Module
 public abbrev Package.target (target : Name) (self : Package) : BuildInfo :=
   .target self target
 
-/-
+/--
 Build info for applying the specified facet to the package.
 It is the user's obligation to ensure the facet in question is a package facet.
 -/
@@ -271,7 +271,7 @@ end Package
 
 /-! #### Lean Library Infos -/
 
-/-
+/--
 Build info for applying the specified facet to the library.
 It is the user's obligation to ensure the facet in question is a library facet.
 -/
@@ -316,7 +316,7 @@ end LeanLib
 
 /-! #### Lean Executable Infos -/
 
-/-
+/--
 Build info for applying the specified facet to the executable.
 It is the user's obligation to ensure the facet in question is the executable facet.
 -/
@@ -329,7 +329,7 @@ public abbrev LeanExe.exe (self : LeanExe) : BuildInfo :=
 
 /-! #### External Library Infos -/
 
-/-
+/--
 Build info for applying the specified facet to the external library.
 It is the user's obligation to ensure the facet in question is an external library facet.
 -/
@@ -350,7 +350,7 @@ public abbrev ExternLib.dynlib (self : ExternLib) : BuildInfo :=
 
 /-! #### Input File & Directory Infos -/
 
-/-
+/--
 Build info for applying the specified facet to the input file.
 It is the user's obligation to ensure the facet in question is an external library facet.
 -/
@@ -361,7 +361,7 @@ public abbrev InputFile.facetCore (facet : Name) (self : InputFile) : BuildInfo 
 public abbrev InputFile.default (self : InputFile) : BuildInfo :=
   self.facetCore InputFile.defaultFacet
 
-/-
+/--
 Build info for applying the specified facet to the input directory.
 It is the user's obligation to ensure the facet in question is an external library facet.
 -/

--- a/src/lake/Lake/Build/Topological.lean
+++ b/src/lake/Lake/Build/Topological.lean
@@ -60,7 +60,7 @@ public abbrev FetchFnT (α : Type u) (β : Type v) (m : Type v → Type w) :=
 We can then use the such a monad as the basis for a fetch function itself.
 -/
 
-/-
+/--
 A `DFetchFn` that utilizes another `DFetchFn` equipped to the monad to
 fetch values. It is thus usually implemented recursively via some variation
 of the `recFetch` function below, hence the "rec" in both names.

--- a/src/lake/Lake/Build/Trace.lean
+++ b/src/lake/Lake/Build/Trace.lean
@@ -68,23 +68,23 @@ export MixTrace (mixTrace)
 section
 variable [MixTrace τ] [NilTrace τ]
 
-/- Combine a `List` of traces (left-to-right). -/
+/-- Combine a `List` of traces (left-to-right). -/
 public def mixTraceList (traces : List τ) : τ :=
   traces.foldl mixTrace nilTrace
 
-/- Combine an `Array` of traces (left-to-right). -/
+/-- Combine an `Array` of traces (left-to-right). -/
 public def mixTraceArray (traces : Array τ) : τ :=
   traces.foldl mixTrace nilTrace
 
 variable [ComputeTrace α m τ]
 
-/- Compute the trace of each element of a `List` and combine them (left-to-right). -/
+/-- Compute the trace of each element of a `List` and combine them (left-to-right). -/
 @[inline] public def computeListTrace [MonadLiftT m n] [Monad n] (as : List α) : n τ :=
   as.foldlM (fun ts t => return mixTrace ts (← computeTrace t)) nilTrace
 
 public instance [Monad m] : ComputeTrace (List α) m τ := ⟨computeListTrace⟩
 
-/- Compute the trace of each element of an `Array` and combine them (left-to-right). -/
+/-- Compute the trace of each element of an `Array` and combine them (left-to-right). -/
 @[inline] public def computeArrayTrace [MonadLiftT m n] [Monad n] (as : Array α) : n τ :=
   as.foldlM (fun ts t => return mixTrace ts (← computeTrace t)) nilTrace
 

--- a/src/lake/Lake/Config/Dependency.lean
+++ b/src/lake/Lake/Config/Dependency.lean
@@ -68,9 +68,9 @@ The source of a `Dependency`.
 That is, where Lake should look to materialize the dependency.
 -/
 public inductive DependencySrc where
-/- A package located at a fixed path relative to the dependent package's directory. -/
+/-- A package located at a fixed path relative to the dependent package's directory. -/
 | path (dir : FilePath)
-/- A package cloned from a Git repository available at a fixed Git `url`. -/
+/-- A package cloned from a Git repository available at a fixed Git `url`. -/
 | git (url : String) (rev : Option GitRev) (subDir : Option FilePath)
 deriving Inhabited, Repr
 

--- a/src/lake/Lake/Config/LeanLib.lean
+++ b/src/lake/Lake/Config/LeanLib.lean
@@ -226,14 +226,14 @@ That is, the package's `weakLeancArgs` plus the library's `weakLeancArgs`.
   self.pkg.weakLeancArgs ++ self.config.weakLeancArgs
 
 /--
-Additionl target objects to pass to `ar` when linking the static library.
+Additional target objects to pass to `ar` when linking the static library.
 That is, the package's `moreLinkObjs` plus the library's `moreLinkObjs`.
 -/
 @[inline] public def moreLinkObjs (self : LeanLib) : TargetArray FilePath :=
   self.pkg.moreLinkObjs ++ self.config.moreLinkObjs
 
-/-
-Additionl target libraries to are linked to the shared library.
+/--
+Additional target libraries to are linked to the shared library.
 That is, the package's `moreLinkLibs` plus the library's `moreLinkLibs`.
 -/
 @[inline] public def moreLinkLibs (self : LeanLib) : TargetArray Dynlib :=

--- a/src/lake/Lake/Config/Workspace.lean
+++ b/src/lake/Lake/Config/Workspace.lean
@@ -398,9 +398,9 @@ the workspace's {lean}`leanSrcPath` and Lake's {name (full := LakeInstall.srcDir
 public def augmentedLeanSrcPath (self : Workspace) : SearchPath :=
   self.leanSrcPath ++ self.lakeEnv.leanSrcPath
 
-/-
-The detected `sharedLibPathEnv` value of the environment augmented with
-the workspace's `libPath` and Lean installation's shared library directories.
+/--
+The detected {name}`sharedLibPathEnvVar` value of the environment augmented with
+the workspace's {name}`sharedLibPath` and Lean installation's shared library directories.
 
 The order is Lean's, the workspace's, and then the environment's.
 Lean's comes first because Lean needs to load its own shared libraries from this path.

--- a/src/lake/Lake/DSL/Syntax.lean
+++ b/src/lake/Lake/DSL/Syntax.lean
@@ -137,7 +137,7 @@ subdirectory is specified).
 public syntax fromClause :=
   " from " fromSource
 
-/-
+/--
 A `NameMap String` of Lake options used to configure the dependency.
 This is equivalent to passing `-K` options to the dependency on the command line.
 -/

--- a/src/lake/Lake/Load/Resolve.lean
+++ b/src/lake/Lake/Load/Resolve.lean
@@ -181,7 +181,7 @@ This function can be used to prove that Array-bounded recursion terminates.
 def guardBySize! [Pure m] [MonadError m] (as : Array α) : m (PLift (as.size ≤ Lean.maxSmallNat)) :=
   if h : as.size ≤ Lean.maxSmallNat then pure ⟨h⟩ else error "Array-bounded termination"
 
-/-
+/--
 Adds the package's dependencies to the workspace and then recursively vists
 each package in the dependency graph starting from `next`. Each dependency missing
 from the workspace is added to the workspace using the `resolve` function.

--- a/src/lake/Lake/Toml/Data/Dict.lean
+++ b/src/lake/Lake/Toml/Data/Dict.lean
@@ -19,7 +19,7 @@ open Lean
 
 namespace Lake.Toml
 
-/- An insertion-ordered key-value mapping backed by a red-black tree. -/
+/-- An insertion-ordered key-value mapping backed by a red-black tree. -/
 public structure RBDict (α : Type u) (β : Type v) (cmp : α → α → Ordering)  where
   items : Array (α × β)
   indices : Std.TreeMap α Nat cmp

--- a/src/lake/Lake/Toml/Grammar.lean
+++ b/src/lake/Lake/Toml/Grammar.lean
@@ -590,7 +590,7 @@ public def numeralAntiquot :=
   mkAntiquot "dateTime" `Lake.Toml.dateTime (anonymous := false) <|>
   mkAntiquot "numeral" `Lake.Toml.numeral (isPseudoKind := true)
 
-/- A value starting with a numeral. Either a TOML date-time, float, or integer. -/
+/-- A value starting with a numeral. Either a TOML date-time, float, or integer. -/
 public def numeral : Parser :=
   withAntiquot numeralAntiquot $ dynamicNode numeralFn
 

--- a/src/lake/Lake/Util/Log.lean
+++ b/src/lake/Lake/Util/Log.lean
@@ -268,7 +268,7 @@ public instance [Monad n] [MonadLiftT m n] : MonadLog (MonadLogT m n) where
 
 end MonadLogT
 
-/- A Lake log. An `Array` of log entries. -/
+/-- A Lake log. An `Array` of log entries. -/
 public structure Log where
   entries : Array LogEntry
   deriving Inhabited


### PR DESCRIPTION
This PR converts a number of comments that seem to have been clearly intended as docstrings into docstrings, avoiding those already converted in #13006.

See also #13007.
