### PR TITLE
doc: remove circularity from #eval docstring

### DIFF
--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -560,7 +560,8 @@ Use `#check_assertions!` to only show unsatisfied assertions.
 @[builtin_command_parser] def checkAssertions := leading_parser
   "#check_assertions" >> optional "!"
 /--
-`#eval e` evaluates the expression `e` by compiling and evaluating it.
+`#eval e` evaluates the expression `e` by compiling it and running the compiled code. It then
+prints the resulting value.
 
 * The command attempts to use `ToExpr`, `Repr`, or `ToString` instances to print the result.
 * If `e` is a monadic value of type `m ty`, then the command tries to adapt the monad `m`


### PR DESCRIPTION
This PR removes the term "evaluate" from the description of how `#eval` in fact evaluates.

Closes #13753.
