### PR TITLE
refactor: `USize`/`ISize` handling in `bv_decide`

### DIFF
--- a/src/Init/Data/SInt.lean
+++ b/src/Init/Data/SInt.lean
@@ -11,6 +11,7 @@ public import Init.Data.SInt.Float
 public import Init.Data.SInt.Float32
 public import Init.Data.SInt.Lemmas
 public import Init.Data.SInt.Bitwise
+public import Init.Data.SInt.IntToBitVec
 
 public section
 

--- a/src/Init/Data/SInt/Basic.lean
+++ b/src/Init/Data/SInt/Basic.lean
@@ -1620,6 +1620,22 @@ Obtain the `BitVec` that contains the 2's complement representation of the `ISiz
 theorem ISize.toBitVec.inj : {x y : ISize} → x.toBitVec = y.toBitVec → x = y
   | ⟨⟨_⟩⟩, ⟨⟨_⟩⟩, rfl => rfl
 
+/--
+Convert an `ISize` to `BitVec 32`, assuming that the system bit-width is 32.
+
+This operation is intended for proof purposes.
+-/
+def ISize.toBitVec32 (a : ISize) (h : System.Platform.numBits = 32) : BitVec 32 :=
+  h ▸ a.toBitVec
+
+/--
+Convert an `ISize` to `BitVec 64`, assuming that the system bit-width is 64.
+
+This operation is intended for proof purposes.
+-/
+def ISize.toBitVec64 (a : ISize) (h : System.Platform.numBits = 64) : BitVec 64 :=
+  h ▸ a.toBitVec
+
 /-- Obtains the `ISize` that is 2's complement equivalent to the `USize`. -/
 @[inline] def USize.toISize (i : USize) : ISize := ISize.ofUSize i
 

--- a/src/Init/Data/SInt/Basic.lean
+++ b/src/Init/Data/SInt/Basic.lean
@@ -1626,7 +1626,7 @@ Convert an `ISize` to `BitVec 32`, assuming that the system bit-width is 32.
 This operation is intended for proof purposes.
 -/
 def ISize.toBitVec32 (a : ISize) (h : System.Platform.numBits = 32) : BitVec 32 :=
-  h ▸ a.toBitVec
+  a.toBitVec.cast h
 
 /--
 Convert an `ISize` to `BitVec 64`, assuming that the system bit-width is 64.
@@ -1634,7 +1634,7 @@ Convert an `ISize` to `BitVec 64`, assuming that the system bit-width is 64.
 This operation is intended for proof purposes.
 -/
 def ISize.toBitVec64 (a : ISize) (h : System.Platform.numBits = 64) : BitVec 64 :=
-  h ▸ a.toBitVec
+  a.toBitVec.cast h
 
 /-- Obtains the `ISize` that is 2's complement equivalent to the `USize`. -/
 @[inline] def USize.toISize (i : USize) : ISize := ISize.ofUSize i

--- a/src/Init/Data/SInt/Bitwise.lean
+++ b/src/Init/Data/SInt/Bitwise.lean
@@ -18,21 +18,29 @@ import Init.System.Platform
 
 public section
 
+open Lean in
 set_option hygiene false in
-macro "declare_bitwise_int_theorems" typeName:ident bits:term:arg : command =>
-`(
+macro "declare_bitwise_int_theorems" typeName:ident bits:term:arg : command => do
+  let isISize := typeName.getId == ``ISize
+  let mut cmds ← Syntax.getArgs <$> `(
 namespace $typeName
 
-@[simp, int_toBitVec] protected theorem toBitVec_not {a : $typeName} : (~~~a).toBitVec = ~~~a.toBitVec := (rfl)
-@[simp, int_toBitVec] protected theorem toBitVec_and (a b : $typeName) : (a &&& b).toBitVec = a.toBitVec &&& b.toBitVec := (rfl)
-@[simp, int_toBitVec] protected theorem toBitVec_or (a b : $typeName) : (a ||| b).toBitVec = a.toBitVec ||| b.toBitVec := (rfl)
-@[simp, int_toBitVec] protected theorem toBitVec_xor (a b : $typeName) : (a ^^^ b).toBitVec = a.toBitVec ^^^ b.toBitVec := (rfl)
-@[simp, int_toBitVec] protected theorem toBitVec_shiftLeft (a b : $typeName) : (a <<< b).toBitVec = a.toBitVec <<< (b.toBitVec.smod $bits) := (rfl)
-@[simp, int_toBitVec] protected theorem toBitVec_shiftRight (a b : $typeName) : (a >>> b).toBitVec = a.toBitVec.sshiftRight' (b.toBitVec.smod $bits) := (rfl)
-@[simp, int_toBitVec] protected theorem toBitVec_abs (a : $typeName) : a.abs.toBitVec = a.toBitVec.abs := (rfl)
+@[simp] protected theorem toBitVec_not {a : $typeName} : (~~~a).toBitVec = ~~~a.toBitVec := (rfl)
+@[simp] protected theorem toBitVec_and (a b : $typeName) : (a &&& b).toBitVec = a.toBitVec &&& b.toBitVec := (rfl)
+@[simp] protected theorem toBitVec_or (a b : $typeName) : (a ||| b).toBitVec = a.toBitVec ||| b.toBitVec := (rfl)
+@[simp] protected theorem toBitVec_xor (a b : $typeName) : (a ^^^ b).toBitVec = a.toBitVec ^^^ b.toBitVec := (rfl)
+@[simp] protected theorem toBitVec_shiftLeft (a b : $typeName) : (a <<< b).toBitVec = a.toBitVec <<< (b.toBitVec.smod $bits) := (rfl)
+@[simp] protected theorem toBitVec_shiftRight (a b : $typeName) : (a >>> b).toBitVec = a.toBitVec.sshiftRight' (b.toBitVec.smod $bits) := (rfl)
+@[simp] protected theorem toBitVec_abs (a : $typeName) : a.abs.toBitVec = a.toBitVec.abs := (rfl)
 
-end $typeName
-)
+  )
+  unless isISize do
+    let names := #[`toBitVec_not, `toBitVec_and, `toBitVec_or, `toBitVec_xor, `toBitVec_shiftLeft,
+      `toBitVec_shiftRight, `toBitVec_abs]
+    let idents := names.map fun n => mkIdent (typeName.getId ++ n)
+    cmds := cmds.push <| ← `(attribute [int_toBitVec] $idents*)
+  cmds := cmds.push <| ← `(end $typeName)
+  return ⟨mkNullNode cmds⟩
 declare_bitwise_int_theorems Int8 8
 declare_bitwise_int_theorems Int16 16
 declare_bitwise_int_theorems Int32 32
@@ -55,7 +63,7 @@ theorem Bool.toBitVec_toInt32 {b : Bool} : b.toInt32.toBitVec = (BitVec.ofBool b
 theorem Bool.toBitVec_toInt64 {b : Bool} : b.toInt64.toBitVec = (BitVec.ofBool b).setWidth 64 := by
   cases b <;> simp [toInt64]
 
-@[simp, int_toBitVec]
+@[simp]
 theorem Bool.toBitVec_toISize {b : Bool} :
     b.toISize.toBitVec = (BitVec.ofBool b).setWidth System.Platform.numBits := by
   cases b

--- a/src/Init/Data/SInt/IntToBitVec.lean
+++ b/src/Init/Data/SInt/IntToBitVec.lean
@@ -1,0 +1,427 @@
+/-
+Copyright (c) 2026 Lean FRO LLC or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Henrik Böving
+-/
+module
+
+prelude
+public import Init.Data.SInt.Lemmas
+public import Init.Data.SInt.Bitwise
+public import Init.Data.UInt.IntToBitVec
+
+public section
+
+theorem ISize.toBitVec32_eq_toBitVec (a : ISize) (h : System.Platform.numBits = 32) :
+    a.toBitVec32 h = h ▸ a.toBitVec := rfl
+
+theorem ISize.toBitVec64_eq_toBitVec (a : ISize) (h : System.Platform.numBits = 64) :
+    a.toBitVec64 h = h ▸ a.toBitVec := rfl
+
+/-! ## `numBits = 32` -/
+
+@[int_toBitVec]
+theorem ISize.le_iff_toBitVec32_sle {a b : ISize} (h : System.Platform.numBits = 32) :
+    a ≤ b ↔ (a.toBitVec32 h).sle (b.toBitVec32 h) := by
+  simp only [ISize.le_iff_toBitVec_sle, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.lt_iff_toBitVec32_slt {a b : ISize} (h : System.Platform.numBits = 32) :
+    a < b ↔ (a.toBitVec32 h).slt (b.toBitVec32 h) := by
+  simp only [ISize.lt_iff_toBitVec_slt, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.eq_iff_toBitVec32_eq {a b : ISize} (h : System.Platform.numBits = 32) :
+    a = b ↔ a.toBitVec32 h = b.toBitVec32 h := by
+  simp only [ISize.eq_iff_toBitVec_eq, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.ne_iff_toBitVec32_ne {a b : ISize} (h : System.Platform.numBits = 32) :
+    a ≠ b ↔ a.toBitVec32 h ≠ b.toBitVec32 h := by
+  simp only [ISize.ne_iff_toBitVec_ne, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_ofNat (n : Nat) (h : System.Platform.numBits = 32) :
+    toBitVec32 (no_index (OfNat.ofNat n)) h = BitVec.ofNat _ n := by
+  simp only [ISize.toBitVec_ofNat, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_ofInt (i : Int) (h : System.Platform.numBits = 32) :
+    (ISize.ofInt i).toBitVec32 h = BitVec.ofInt _ i := by
+  simp only [ISize.toBitVec_ofInt, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_add {a b : ISize} (h : System.Platform.numBits = 32) :
+    (a + b).toBitVec32 h = a.toBitVec32 h + b.toBitVec32 h := by
+  simp only [ISize.toBitVec_add, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_sub {a b : ISize} (h : System.Platform.numBits = 32) :
+    (a - b).toBitVec32 h = a.toBitVec32 h - b.toBitVec32 h := by
+  simp only [ISize.toBitVec_sub, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_mul {a b : ISize} (h : System.Platform.numBits = 32) :
+    (a * b).toBitVec32 h = a.toBitVec32 h * b.toBitVec32 h := by
+  simp only [ISize.toBitVec_mul, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_div {a b : ISize} (h : System.Platform.numBits = 32) :
+    (a / b).toBitVec32 h = (a.toBitVec32 h).sdiv (b.toBitVec32 h) := by
+  simp only [ISize.toBitVec_div, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_mod {a b : ISize} (h : System.Platform.numBits = 32) :
+    (a % b).toBitVec32 h = (a.toBitVec32 h).srem (b.toBitVec32 h) := by
+  simp only [ISize.toBitVec_mod, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_neg {a : ISize} (h : System.Platform.numBits = 32) :
+    (-a).toBitVec32 h = -a.toBitVec32 h := by
+  simp only [ISize.toBitVec_neg, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_toInt8 (n : ISize) (h : System.Platform.numBits = 32) :
+    n.toInt8.toBitVec = (n.toBitVec32 h).signExtend 8 := by
+  simp only [ISize.toBitVec_toInt8, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_toInt16 (n : ISize) (h : System.Platform.numBits = 32) :
+    n.toInt16.toBitVec = (n.toBitVec32 h).signExtend 16 := by
+  simp only [ISize.toBitVec_toInt16, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_toInt32 (n : ISize) (h : System.Platform.numBits = 32) :
+    n.toInt32.toBitVec = (n.toBitVec32 h).signExtend 32 := by
+  simp only [ISize.toBitVec_toInt32, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_toInt64 (n : ISize) (h : System.Platform.numBits = 32) :
+    n.toInt64.toBitVec = (n.toBitVec32 h).signExtend 64 := by
+  simp only [ISize.toBitVec_toInt64, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_toUSize (n : ISize) (h : System.Platform.numBits = 32) :
+    n.toUSize.toBitVec32 h = n.toBitVec32 h := by
+  simp only [ISize.toBitVec_toUSize, USize.toBitVec32_eq_toBitVec, ISize.toBitVec32_eq_toBitVec]
+
+@[int_toBitVec]
+theorem USize.toBitVec32_toISize (n : USize) (h : System.Platform.numBits = 32) :
+    n.toISize.toBitVec32 h = n.toBitVec32 h := by
+  simp only [USize.toBitVec_toISize, USize.toBitVec32_eq_toBitVec, ISize.toBitVec32_eq_toBitVec]
+
+@[int_toBitVec]
+theorem Int8.toBitVec32_toISize (n : Int8) (h : System.Platform.numBits = 32) :
+    n.toISize.toBitVec32 h = n.toBitVec.signExtend 32 := by
+  simp only [Int8.toBitVec_toISize, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem Int16.toBitVec32_toISize (n : Int16) (h : System.Platform.numBits = 32) :
+    n.toISize.toBitVec32 h = n.toBitVec.signExtend 32 := by
+  simp only [Int16.toBitVec_toISize, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem Int32.toBitVec32_toISize (n : Int32) (h : System.Platform.numBits = 32) :
+    n.toISize.toBitVec32 h = n.toBitVec.signExtend 32 := by
+  simp only [Int32.toBitVec_toISize, ISize.toBitVec32_eq_toBitVec]
+  generalize System.Platform.numBits = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem Int64.toBitVec32_toISize (n : Int64) (h : System.Platform.numBits = 32) :
+    n.toISize.toBitVec32 h = n.toBitVec.signExtend 32 := by
+  simp only [Int64.toBitVec_toISize, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_ofBitVec (n) (h : System.Platform.numBits = 32) :
+    (ISize.ofBitVec n).toBitVec32 h = n.cast h := by
+  simp only [ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_minValue (h : System.Platform.numBits = 32) :
+    ISize.minValue.toBitVec32 h = BitVec.intMin 32 := by
+  simp only [ISize.toBitVec_minValue, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_maxValue (h : System.Platform.numBits = 32) :
+    ISize.maxValue.toBitVec32 h = BitVec.intMax 32 := by
+  simp only [ISize.toBitVec_maxValue, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem Bool.toBitVec32_toISize {b : Bool} (h : System.Platform.numBits = 32) :
+    b.toISize.toBitVec32 h = (BitVec.ofBool b).setWidth 32 := by
+  simp only [Bool.toBitVec_toISize, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+/-! ## `numBits = 64` -/
+
+@[int_toBitVec]
+theorem ISize.le_iff_toBitVec64_sle {a b : ISize} (h : System.Platform.numBits = 64) :
+    a ≤ b ↔ (a.toBitVec64 h).sle (b.toBitVec64 h) := by
+  simp only [ISize.le_iff_toBitVec_sle, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.lt_iff_toBitVec64_slt {a b : ISize} (h : System.Platform.numBits = 64) :
+    a < b ↔ (a.toBitVec64 h).slt (b.toBitVec64 h) := by
+  simp only [ISize.lt_iff_toBitVec_slt, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.eq_iff_toBitVec64_eq {a b : ISize} (h : System.Platform.numBits = 64) :
+    a = b ↔ a.toBitVec64 h = b.toBitVec64 h := by
+  simp only [ISize.eq_iff_toBitVec_eq, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.ne_iff_toBitVec64_ne {a b : ISize} (h : System.Platform.numBits = 64) :
+    a ≠ b ↔ a.toBitVec64 h ≠ b.toBitVec64 h := by
+  simp only [ISize.ne_iff_toBitVec_ne, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_ofNat (n : Nat) (h : System.Platform.numBits = 64) :
+    toBitVec64 (no_index (OfNat.ofNat n)) h = BitVec.ofNat _ n := by
+  simp only [ISize.toBitVec_ofNat, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_ofInt (i : Int) (h : System.Platform.numBits = 64) :
+    (ISize.ofInt i).toBitVec64 h = BitVec.ofInt _ i := by
+  simp only [ISize.toBitVec_ofInt, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_add {a b : ISize} (h : System.Platform.numBits = 64) :
+    (a + b).toBitVec64 h = a.toBitVec64 h + b.toBitVec64 h := by
+  simp only [ISize.toBitVec_add, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_sub {a b : ISize} (h : System.Platform.numBits = 64) :
+    (a - b).toBitVec64 h = a.toBitVec64 h - b.toBitVec64 h := by
+  simp only [ISize.toBitVec_sub, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_mul {a b : ISize} (h : System.Platform.numBits = 64) :
+    (a * b).toBitVec64 h = a.toBitVec64 h * b.toBitVec64 h := by
+  simp only [ISize.toBitVec_mul, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_div {a b : ISize} (h : System.Platform.numBits = 64) :
+    (a / b).toBitVec64 h = (a.toBitVec64 h).sdiv (b.toBitVec64 h) := by
+  simp only [ISize.toBitVec_div, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_mod {a b : ISize} (h : System.Platform.numBits = 64) :
+    (a % b).toBitVec64 h = (a.toBitVec64 h).srem (b.toBitVec64 h) := by
+  simp only [ISize.toBitVec_mod, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_neg {a : ISize} (h : System.Platform.numBits = 64) :
+    (-a).toBitVec64 h = -a.toBitVec64 h := by
+  simp only [ISize.toBitVec_neg, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_toInt8 (n : ISize) (h : System.Platform.numBits = 64) :
+    n.toInt8.toBitVec = (n.toBitVec64 h).signExtend 8 := by
+  simp only [ISize.toBitVec_toInt8, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_toInt16 (n : ISize) (h : System.Platform.numBits = 64) :
+    n.toInt16.toBitVec = (n.toBitVec64 h).signExtend 16 := by
+  simp only [ISize.toBitVec_toInt16, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_toInt32 (n : ISize) (h : System.Platform.numBits = 64) :
+    n.toInt32.toBitVec = (n.toBitVec64 h).signExtend 32 := by
+  simp only [ISize.toBitVec_toInt32, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_toInt64 (n : ISize) (h : System.Platform.numBits = 64) :
+    n.toInt64.toBitVec = (n.toBitVec64 h).signExtend 64 := by
+  simp only [ISize.toBitVec_toInt64, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_toUSize (n : ISize) (h : System.Platform.numBits = 64) :
+    n.toUSize.toBitVec64 h = n.toBitVec64 h := by
+  simp only [ISize.toBitVec_toUSize, USize.toBitVec64_eq_toBitVec, ISize.toBitVec64_eq_toBitVec]
+
+@[int_toBitVec]
+theorem USize.toBitVec64_toISize (n : USize) (h : System.Platform.numBits = 64) :
+    n.toISize.toBitVec64 h = n.toBitVec64 h := by
+  simp only [USize.toBitVec_toISize, USize.toBitVec64_eq_toBitVec, ISize.toBitVec64_eq_toBitVec]
+
+@[int_toBitVec]
+theorem Int8.toBitVec64_toISize (n : Int8) (h : System.Platform.numBits = 64) :
+    n.toISize.toBitVec64 h = n.toBitVec.signExtend 64 := by
+  simp only [Int8.toBitVec_toISize, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem Int16.toBitVec64_toISize (n : Int16) (h : System.Platform.numBits = 64) :
+    n.toISize.toBitVec64 h = n.toBitVec.signExtend 64 := by
+  simp only [Int16.toBitVec_toISize, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem Int32.toBitVec64_toISize (n : Int32) (h : System.Platform.numBits = 64) :
+    n.toISize.toBitVec64 h = n.toBitVec.signExtend 64 := by
+  simp only [Int32.toBitVec_toISize, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem Int64.toBitVec64_toISize (n : Int64) (h : System.Platform.numBits = 64) :
+    n.toISize.toBitVec64 h = n.toBitVec.signExtend 64 := by
+  simp only [Int64.toBitVec_toISize, ISize.toBitVec64_eq_toBitVec]
+  generalize System.Platform.numBits = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_ofBitVec (n) (h : System.Platform.numBits = 64) :
+    (ISize.ofBitVec n).toBitVec64 h = n.cast h := by
+  simp only [ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_minValue (h : System.Platform.numBits = 64) :
+    ISize.minValue.toBitVec64 h = BitVec.intMin 64 := by
+  simp only [ISize.toBitVec_minValue, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_maxValue (h : System.Platform.numBits = 64) :
+    ISize.maxValue.toBitVec64 h = BitVec.intMax 64 := by
+  simp only [ISize.toBitVec_maxValue, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem Bool.toBitVec64_toISize {b : Bool} (h : System.Platform.numBits = 64) :
+    b.toISize.toBitVec64 h = (BitVec.ofBool b).setWidth 64 := by
+  simp only [Bool.toBitVec_toISize, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl

--- a/src/Init/Data/SInt/IntToBitVec.lean
+++ b/src/Init/Data/SInt/IntToBitVec.lean
@@ -13,10 +13,10 @@ public import Init.Data.UInt.IntToBitVec
 public section
 
 theorem ISize.toBitVec32_eq_toBitVec (a : ISize) (h : System.Platform.numBits = 32) :
-    a.toBitVec32 h = h ▸ a.toBitVec := rfl
+    a.toBitVec32 h = a.toBitVec.cast h := rfl
 
 theorem ISize.toBitVec64_eq_toBitVec (a : ISize) (h : System.Platform.numBits = 64) :
-    a.toBitVec64 h = h ▸ a.toBitVec := rfl
+    a.toBitVec64 h = a.toBitVec.cast h := rfl
 
 /-! ## `numBits = 32` -/
 
@@ -112,6 +112,64 @@ theorem ISize.toBitVec32_mod {a b : ISize} (h : System.Platform.numBits = 32) :
 theorem ISize.toBitVec32_neg {a : ISize} (h : System.Platform.numBits = 32) :
     (-a).toBitVec32 h = -a.toBitVec32 h := by
   simp only [ISize.toBitVec_neg, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_not {a : ISize} (h : System.Platform.numBits = 32) :
+    (~~~a).toBitVec32 h = ~~~a.toBitVec32 h := by
+  simp only [ISize.toBitVec_not, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_and (a b : ISize) (h : System.Platform.numBits = 32) :
+    (a &&& b).toBitVec32 h = a.toBitVec32 h &&& b.toBitVec32 h := by
+  simp only [ISize.toBitVec_and, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_or (a b : ISize) (h : System.Platform.numBits = 32) :
+    (a ||| b).toBitVec32 h = a.toBitVec32 h ||| b.toBitVec32 h := by
+  simp only [ISize.toBitVec_or, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_xor (a b : ISize) (h : System.Platform.numBits = 32) :
+    (a ^^^ b).toBitVec32 h = a.toBitVec32 h ^^^ b.toBitVec32 h := by
+  simp only [ISize.toBitVec_xor, ISize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_shiftLeft (a b : ISize) (h : System.Platform.numBits = 32) :
+    (a <<< b).toBitVec32 h = a.toBitVec32 h <<< ((b.toBitVec32 h).smod 32) := by
+  simp only [toBitVec32_eq_toBitVec, ISize.toBitVec_shiftLeft, BitVec.natCast_eq_ofNat,
+    BitVec.shiftLeft_eq', BitVec.ofNat_eq_ofNat]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_shiftRight (a b : ISize) (h : System.Platform.numBits = 32) :
+    (a >>> b).toBitVec32 h = (a.toBitVec32 h).sshiftRight' ((b.toBitVec32 h).smod 32) := by
+  simp only [toBitVec32_eq_toBitVec, ISize.toBitVec_shiftRight, BitVec.natCast_eq_ofNat,
+    BitVec.sshiftRight_eq', BitVec.ofNat_eq_ofNat]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_abs (a : ISize) (h : System.Platform.numBits = 32) :
+    a.abs.toBitVec32 h = (a.toBitVec32 h).abs := by
+  simp only [ISize.toBitVec_abs, ISize.toBitVec32_eq_toBitVec]
   generalize 32 = x at *
   subst h
   rfl
@@ -316,6 +374,64 @@ theorem ISize.toBitVec64_mod {a b : ISize} (h : System.Platform.numBits = 64) :
 theorem ISize.toBitVec64_neg {a : ISize} (h : System.Platform.numBits = 64) :
     (-a).toBitVec64 h = -a.toBitVec64 h := by
   simp only [ISize.toBitVec_neg, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_not {a : ISize} (h : System.Platform.numBits = 64) :
+    (~~~a).toBitVec64 h = ~~~a.toBitVec64 h := by
+  simp only [ISize.toBitVec_not, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_and (a b : ISize) (h : System.Platform.numBits = 64) :
+    (a &&& b).toBitVec64 h = a.toBitVec64 h &&& b.toBitVec64 h := by
+  simp only [ISize.toBitVec_and, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_or (a b : ISize) (h : System.Platform.numBits = 64) :
+    (a ||| b).toBitVec64 h = a.toBitVec64 h ||| b.toBitVec64 h := by
+  simp only [ISize.toBitVec_or, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_xor (a b : ISize) (h : System.Platform.numBits = 64) :
+    (a ^^^ b).toBitVec64 h = a.toBitVec64 h ^^^ b.toBitVec64 h := by
+  simp only [ISize.toBitVec_xor, ISize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_shiftLeft (a b : ISize) (h : System.Platform.numBits = 64) :
+    (a <<< b).toBitVec64 h = a.toBitVec64 h <<< ((b.toBitVec64 h).smod 64) := by
+  simp only [toBitVec64_eq_toBitVec, ISize.toBitVec_shiftLeft, BitVec.natCast_eq_ofNat,
+    BitVec.shiftLeft_eq', BitVec.ofNat_eq_ofNat]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_shiftRight (a b : ISize) (h : System.Platform.numBits = 64) :
+    (a >>> b).toBitVec64 h = (a.toBitVec64 h).sshiftRight' ((b.toBitVec64 h).smod 64) := by
+  simp only [toBitVec64_eq_toBitVec, ISize.toBitVec_shiftRight, BitVec.natCast_eq_ofNat,
+    BitVec.sshiftRight_eq', BitVec.ofNat_eq_ofNat]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_abs (a : ISize) (h : System.Platform.numBits = 64) :
+    a.abs.toBitVec64 h = (a.toBitVec64 h).abs := by
+  simp only [ISize.toBitVec_abs, ISize.toBitVec64_eq_toBitVec]
   generalize 64 = x at *
   subst h
   rfl

--- a/src/Init/Data/SInt/Lemmas.lean
+++ b/src/Init/Data/SInt/Lemmas.lean
@@ -29,11 +29,12 @@ open Std
 open Lean in
 set_option hygiene false in
 macro "declare_int_theorems" typeName:ident _bits:term:arg : command => do
+  let isISize := typeName.getId == ``ISize
   let mut cmds ← Syntax.getArgs <$> `(
   namespace $typeName
 
-  @[int_toBitVec] theorem le_iff_toBitVec_sle {a b : $typeName} : a ≤ b ↔ a.toBitVec.sle b.toBitVec := Iff.rfl
-  @[int_toBitVec] theorem lt_iff_toBitVec_slt {a b : $typeName} : a < b ↔ a.toBitVec.slt b.toBitVec := Iff.rfl
+  theorem le_iff_toBitVec_sle {a b : $typeName} : a ≤ b ↔ a.toBitVec.sle b.toBitVec := Iff.rfl
+  theorem lt_iff_toBitVec_slt {a b : $typeName} : a < b ↔ a.toBitVec.slt b.toBitVec := Iff.rfl
 
   theorem toBitVec_inj {a b : $typeName} : a.toBitVec = b.toBitVec ↔ a = b :=
     ⟨toBitVec.inj, (· ▸ rfl)⟩
@@ -43,21 +44,26 @@ macro "declare_int_theorems" typeName:ident _bits:term:arg : command => do
     ofBitVec_inj.symm
   theorem ne_iff_ofBitVec_ne {a b : BitVec $_bits} : a ≠ b ↔ ofBitVec a ≠ ofBitVec b := by
     simp [ofBitVec_inj]
-  @[int_toBitVec] theorem eq_iff_toBitVec_eq {a b : $typeName} : a = b ↔ a.toBitVec = b.toBitVec :=
+  theorem eq_iff_toBitVec_eq {a b : $typeName} : a = b ↔ a.toBitVec = b.toBitVec :=
     toBitVec_inj.symm
-  @[int_toBitVec] theorem ne_iff_toBitVec_ne {a b : $typeName} : a ≠ b ↔ a.toBitVec ≠ b.toBitVec :=
+  theorem ne_iff_toBitVec_ne {a b : $typeName} : a ≠ b ↔ a.toBitVec ≠ b.toBitVec :=
     Decidable.not_iff_not.2 eq_iff_toBitVec_eq
   @[simp] theorem toBitVec_ofNat' {n : Nat} : toBitVec (ofNat n) = BitVec.ofNat _ n := (rfl)
-  @[simp, int_toBitVec] theorem toBitVec_ofNat {n : Nat} : toBitVec (no_index (OfNat.ofNat n)) = OfNat.ofNat n := (rfl)
+  @[simp] theorem toBitVec_ofNat {n : Nat} : toBitVec (no_index (OfNat.ofNat n)) = OfNat.ofNat n := (rfl)
 
-  @[simp, int_toBitVec] protected theorem toBitVec_add {a b : $typeName} : (a + b).toBitVec = a.toBitVec + b.toBitVec := (rfl)
-  @[simp, int_toBitVec] protected theorem toBitVec_sub {a b : $typeName} : (a - b).toBitVec = a.toBitVec - b.toBitVec := (rfl)
-  @[simp, int_toBitVec] protected theorem toBitVec_mul {a b : $typeName} : (a * b).toBitVec = a.toBitVec * b.toBitVec := (rfl)
-  @[simp, int_toBitVec] protected theorem toBitVec_div {a b : $typeName} : (a / b).toBitVec = a.toBitVec.sdiv b.toBitVec := (rfl)
-  @[simp, int_toBitVec] protected theorem toBitVec_mod {a b : $typeName} : (a % b).toBitVec = a.toBitVec.srem b.toBitVec := (rfl)
+  @[simp] protected theorem toBitVec_add {a b : $typeName} : (a + b).toBitVec = a.toBitVec + b.toBitVec := (rfl)
+  @[simp] protected theorem toBitVec_sub {a b : $typeName} : (a - b).toBitVec = a.toBitVec - b.toBitVec := (rfl)
+  @[simp] protected theorem toBitVec_mul {a b : $typeName} : (a * b).toBitVec = a.toBitVec * b.toBitVec := (rfl)
+  @[simp] protected theorem toBitVec_div {a b : $typeName} : (a / b).toBitVec = a.toBitVec.sdiv b.toBitVec := (rfl)
+  @[simp] protected theorem toBitVec_mod {a b : $typeName} : (a % b).toBitVec = a.toBitVec.srem b.toBitVec := (rfl)
 
-  end $typeName
   )
+  unless isISize do
+    let names := #[`le_iff_toBitVec_sle, `lt_iff_toBitVec_slt, `eq_iff_toBitVec_eq, `ne_iff_toBitVec_ne,
+      `toBitVec_ofNat, `toBitVec_add, `toBitVec_sub, `toBitVec_mul, `toBitVec_div, `toBitVec_mod]
+    let idents := names.map fun n => mkIdent (typeName.getId ++ n)
+    cmds := cmds.push <| ← `(attribute [int_toBitVec] $idents*)
+  cmds := cmds.push <| ← `(end $typeName)
   return ⟨mkNullNode cmds⟩
 
 declare_int_theorems Int8 8
@@ -81,7 +87,7 @@ theorem ISize.toInt_inj {x y : ISize} : x.toInt = y.toInt ↔ x = y := ⟨ISize.
 @[simp, int_toBitVec] theorem Int16.toBitVec_neg (x : Int16) : (-x).toBitVec = -x.toBitVec := (rfl)
 @[simp, int_toBitVec] theorem Int32.toBitVec_neg (x : Int32) : (-x).toBitVec = -x.toBitVec := (rfl)
 @[simp, int_toBitVec] theorem Int64.toBitVec_neg (x : Int64) : (-x).toBitVec = -x.toBitVec := (rfl)
-@[simp, int_toBitVec] theorem ISize.toBitVec_neg (x : ISize) : (-x).toBitVec = -x.toBitVec := (rfl)
+@[simp] theorem ISize.toBitVec_neg (x : ISize) : (-x).toBitVec = -x.toBitVec := (rfl)
 
 @[simp] theorem Int8.toBitVec_zero : toBitVec 0 = 0#8 := (rfl)
 @[simp] theorem Int16.toBitVec_zero : toBitVec 0 = 0#16 := (rfl)
@@ -99,7 +105,7 @@ theorem ISize.toBitVec_one : (1 : ISize).toBitVec = 1#System.Platform.numBits :=
 @[simp, int_toBitVec] theorem Int16.toBitVec_ofInt (i : Int) : (ofInt i).toBitVec = BitVec.ofInt _ i := (rfl)
 @[simp, int_toBitVec] theorem Int32.toBitVec_ofInt (i : Int) : (ofInt i).toBitVec = BitVec.ofInt _ i := (rfl)
 @[simp, int_toBitVec] theorem Int64.toBitVec_ofInt (i : Int) : (ofInt i).toBitVec = BitVec.ofInt _ i := (rfl)
-@[simp, int_toBitVec] theorem ISize.toBitVec_ofInt (i : Int) : (ofInt i).toBitVec = BitVec.ofInt _ i := (rfl)
+@[simp] theorem ISize.toBitVec_ofInt (i : Int) : (ofInt i).toBitVec = BitVec.ofInt _ i := (rfl)
 
 @[simp] protected theorem Int8.neg_zero : -(0 : Int8) = 0 := (rfl)
 @[simp] protected theorem Int16.neg_zero : -(0 : Int16) = 0 := (rfl)
@@ -267,7 +273,7 @@ theorem ISize.toInt_maxValue : ISize.maxValue.toInt = 2 ^ (System.Platform.numBi
 @[simp, int_toBitVec] theorem UInt16.toBitVec_toInt16 (x : UInt16) : x.toInt16.toBitVec = x.toBitVec := (rfl)
 @[simp, int_toBitVec] theorem UInt32.toBitVec_toInt32 (x : UInt32) : x.toInt32.toBitVec = x.toBitVec := (rfl)
 @[simp, int_toBitVec] theorem UInt64.toBitVec_toInt64 (x : UInt64) : x.toInt64.toBitVec = x.toBitVec := (rfl)
-@[simp, int_toBitVec] theorem USize.toBitVec_toISize (x : USize) : x.toISize.toBitVec = x.toBitVec := (rfl)
+@[simp] theorem USize.toBitVec_toISize (x : USize) : x.toISize.toBitVec = x.toBitVec := (rfl)
 
 @[simp] theorem Int8.ofBitVec_uInt8ToBitVec (x : UInt8) : Int8.ofBitVec x.toBitVec = x.toInt8 := (rfl)
 @[simp] theorem Int16.ofBitVec_uInt16ToBitVec (x : UInt16) : Int16.ofBitVec x.toBitVec = x.toInt16 := (rfl)
@@ -311,12 +317,12 @@ theorem ISize.toInt_maxValue : ISize.maxValue.toInt = 2 ^ (System.Platform.numBi
 @[simp, int_toBitVec] theorem Int64.toBitVec_toInt8 (x : Int64) : x.toInt8.toBitVec = x.toBitVec.signExtend 8 := (rfl)
 @[simp, int_toBitVec] theorem Int64.toBitVec_toInt16 (x : Int64) : x.toInt16.toBitVec = x.toBitVec.signExtend 16 := (rfl)
 @[simp, int_toBitVec] theorem Int64.toBitVec_toInt32 (x : Int64) : x.toInt32.toBitVec = x.toBitVec.signExtend 32 := (rfl)
-@[simp, int_toBitVec] theorem Int64.toBitVec_toISize (x : Int64) : x.toISize.toBitVec = x.toBitVec.signExtend System.Platform.numBits := (rfl)
+@[simp] theorem Int64.toBitVec_toISize (x : Int64) : x.toISize.toBitVec = x.toBitVec.signExtend System.Platform.numBits := (rfl)
 
-@[simp, int_toBitVec] theorem ISize.toBitVec_toInt8 (x : ISize) : x.toInt8.toBitVec = x.toBitVec.signExtend 8 := (rfl)
-@[simp, int_toBitVec] theorem ISize.toBitVec_toInt16 (x : ISize) : x.toInt16.toBitVec = x.toBitVec.signExtend 16 := (rfl)
-@[simp, int_toBitVec] theorem ISize.toBitVec_toInt32 (x : ISize) : x.toInt32.toBitVec = x.toBitVec.signExtend 32 := (rfl)
-@[simp, int_toBitVec] theorem ISize.toBitVec_toInt64 (x : ISize) : x.toInt64.toBitVec = x.toBitVec.signExtend 64 := (rfl)
+@[simp] theorem ISize.toBitVec_toInt8 (x : ISize) : x.toInt8.toBitVec = x.toBitVec.signExtend 8 := (rfl)
+@[simp] theorem ISize.toBitVec_toInt16 (x : ISize) : x.toInt16.toBitVec = x.toBitVec.signExtend 16 := (rfl)
+@[simp] theorem ISize.toBitVec_toInt32 (x : ISize) : x.toInt32.toBitVec = x.toBitVec.signExtend 32 := (rfl)
+@[simp] theorem ISize.toBitVec_toInt64 (x : ISize) : x.toInt64.toBitVec = x.toBitVec.signExtend 64 := (rfl)
 
 theorem Int8.toInt_lt (x : Int8) : x.toInt < 2 ^ 7 := Int.lt_of_mul_lt_mul_left BitVec.two_mul_toInt_lt (by decide)
 theorem Int8.le_toInt (x : Int8) : -2 ^ 7 ≤ x.toInt := Int.le_of_mul_le_mul_left BitVec.le_two_mul_toInt (by decide)
@@ -503,7 +509,7 @@ theorem ISize.toFin_toBitVec (x : ISize) : x.toBitVec.toFin = x.toUSize.toFin :=
 @[simp, int_toBitVec] theorem Int16.toBitVec_toUInt16 (x : Int16) : x.toUInt16.toBitVec = x.toBitVec := (rfl)
 @[simp, int_toBitVec] theorem Int32.toBitVec_toUInt32 (x : Int32) : x.toUInt32.toBitVec = x.toBitVec := (rfl)
 @[simp, int_toBitVec] theorem Int64.toBitVec_toUInt64 (x : Int64) : x.toUInt64.toBitVec = x.toBitVec := (rfl)
-@[simp, int_toBitVec] theorem ISize.toBitVec_toUSize (x : ISize) : x.toUSize.toBitVec = x.toBitVec := (rfl)
+@[simp] theorem ISize.toBitVec_toUSize (x : ISize) : x.toUSize.toBitVec = x.toBitVec := (rfl)
 
 @[simp] theorem UInt8.ofBitVec_int8ToBitVec (x : Int8) : UInt8.ofBitVec x.toBitVec = x.toUInt8 := (rfl)
 @[simp] theorem UInt16.ofBitVec_int16ToBitVec (x : Int16) : UInt16.ofBitVec x.toBitVec = x.toUInt16 := (rfl)
@@ -997,7 +1003,7 @@ theorem USize.toISize_ofNatLT {n : Nat} (hn) : (USize.ofNatLT n hn).toISize = IS
 @[simp, int_toBitVec] theorem Int16.toBitVec_ofBitVec (b) : (Int16.ofBitVec b).toBitVec = b := (rfl)
 @[simp, int_toBitVec] theorem Int32.toBitVec_ofBitVec (b) : (Int32.ofBitVec b).toBitVec = b := (rfl)
 @[simp, int_toBitVec] theorem Int64.toBitVec_ofBitVec (b) : (Int64.ofBitVec b).toBitVec = b := (rfl)
-@[simp, int_toBitVec] theorem ISize.toBitVec_ofBitVec (b) : (ISize.ofBitVec b).toBitVec = b := (rfl)
+@[simp] theorem ISize.toBitVec_ofBitVec (b) : (ISize.ofBitVec b).toBitVec = b := (rfl)
 
 theorem Int8.toBitVec_ofIntClamp {n : Int} (h₁ : Int8.minValue.toInt ≤ n) (h₂ : n ≤ Int8.maxValue.toInt) :
     (Int8.ofIntClamp n).toBitVec = BitVec.ofInt _ n := by
@@ -1277,7 +1283,7 @@ theorem Int64.toISize_ofIntClamp {n : Int} (h₁ : -2 ^ 63 ≤ n) (h₂ : n < 2 
 @[simp, int_toBitVec] theorem Int16.toBitVec_minValue : minValue.toBitVec = BitVec.intMin _ := (rfl)
 @[simp, int_toBitVec] theorem Int32.toBitVec_minValue : minValue.toBitVec = BitVec.intMin _ := (rfl)
 @[simp, int_toBitVec] theorem Int64.toBitVec_minValue : minValue.toBitVec = BitVec.intMin _ := (rfl)
-@[simp, int_toBitVec] theorem ISize.toBitVec_minValue : minValue.toBitVec = BitVec.intMin _ :=
+@[simp] theorem ISize.toBitVec_minValue : minValue.toBitVec = BitVec.intMin _ :=
   BitVec.eq_of_toInt_eq (by rw [toInt_toBitVec, toInt_minValue,
     BitVec.toInt_intMin_of_pos (by cases System.Platform.numBits_eq <;> simp_all)])
 
@@ -1285,7 +1291,7 @@ theorem Int64.toISize_ofIntClamp {n : Int} (h₁ : -2 ^ 63 ≤ n) (h₂ : n < 2 
 @[simp, int_toBitVec] theorem Int16.toBitVec_maxValue : maxValue.toBitVec = BitVec.intMax _ := (rfl)
 @[simp, int_toBitVec] theorem Int32.toBitVec_maxValue : maxValue.toBitVec = BitVec.intMax _ := (rfl)
 @[simp, int_toBitVec] theorem Int64.toBitVec_maxValue : maxValue.toBitVec = BitVec.intMax _ := (rfl)
-@[simp, int_toBitVec] theorem ISize.toBitVec_maxValue : maxValue.toBitVec = BitVec.intMax _ :=
+@[simp] theorem ISize.toBitVec_maxValue : maxValue.toBitVec = BitVec.intMax _ :=
   BitVec.eq_of_toInt_eq (by rw [toInt_toBitVec, toInt_maxValue, BitVec.toInt_intMax])
 
 @[simp] theorem Int16.toInt8_neg (x : Int16) : (-x).toInt8 = -x.toInt8 := Int8.toBitVec.inj (by simp)

--- a/src/Init/Data/UInt.lean
+++ b/src/Init/Data/UInt.lean
@@ -11,3 +11,4 @@ public import Init.Data.UInt.Basic
 public import Init.Data.UInt.Log2
 public import Init.Data.UInt.Lemmas
 public import Init.Data.UInt.Bitwise
+public import Init.Data.UInt.IntToBitVec

--- a/src/Init/Data/UInt/Basic.lean
+++ b/src/Init/Data/UInt/Basic.lean
@@ -940,15 +940,15 @@ Convert a `USize` to `BitVec 32`, assuming that the system bit-width is 32.
 This operation is intended for proof purposes.
 -/
 def USize.toBitVec32 (a : USize) (h : System.Platform.numBits = 32) : BitVec 32 :=
-  h ▸ a.toBitVec
+  a.toBitVec.cast h
 
 /--
-Convert a `USize` to `BitVec 64`, assuming that the system bit-width is 32.
+Convert a `USize` to `BitVec 64`, assuming that the system bit-width is 64.
 
 This operation is intended for proof purposes.
 -/
 def USize.toBitVec64 (a : USize) (h : System.Platform.numBits = 64) : BitVec 64 :=
-  h ▸ a.toBitVec
+  a.toBitVec.cast h
 
 instance : Mul USize       := ⟨USize.mul⟩
 instance : Pow USize Nat   := ⟨USize.pow⟩

--- a/src/Init/Data/UInt/Basic.lean
+++ b/src/Init/Data/UInt/Basic.lean
@@ -934,6 +934,22 @@ This function is overridden at runtime with an efficient implementation.
 def USize.toUInt64 (a : USize) : UInt64 :=
   UInt64.ofNatLT a.toBitVec.toNat (Nat.lt_of_lt_of_le a.toBitVec.isLt USize.size_le)
 
+/--
+Convert a `USize` to `BitVec 32`, assuming that the system bit-width is 32.
+
+This operation is intended for proof purposes.
+-/
+def USize.toBitVec32 (a : USize) (h : System.Platform.numBits = 32) : BitVec 32 :=
+  h ▸ a.toBitVec
+
+/--
+Convert a `USize` to `BitVec 64`, assuming that the system bit-width is 32.
+
+This operation is intended for proof purposes.
+-/
+def USize.toBitVec64 (a : USize) (h : System.Platform.numBits = 64) : BitVec 64 :=
+  h ▸ a.toBitVec
+
 instance : Mul USize       := ⟨USize.mul⟩
 instance : Pow USize Nat   := ⟨USize.pow⟩
 instance : Mod USize       := ⟨USize.mod⟩

--- a/src/Init/Data/UInt/Bitwise.lean
+++ b/src/Init/Data/UInt/Bitwise.lean
@@ -20,26 +20,33 @@ import Init.System.Platform
 
 public section
 
+open Lean in
 set_option hygiene false in
-macro "declare_bitwise_uint_theorems" typeName:ident bits:term:arg : command =>
-`(
+macro "declare_bitwise_uint_theorems" typeName:ident bits:term:arg : command => do
+  let isUSize := typeName.getId == ``USize
+  let mut cmds ← Syntax.getArgs <$> `(
 namespace $typeName
 
-@[simp, int_toBitVec] protected theorem toBitVec_not {a : $typeName} : (~~~a).toBitVec = ~~~a.toBitVec := (rfl)
-@[simp, int_toBitVec] protected theorem toBitVec_and (a b : $typeName) : (a &&& b).toBitVec = a.toBitVec &&& b.toBitVec := (rfl)
-@[simp, int_toBitVec] protected theorem toBitVec_or (a b : $typeName) : (a ||| b).toBitVec = a.toBitVec ||| b.toBitVec := (rfl)
-@[simp, int_toBitVec] protected theorem toBitVec_xor (a b : $typeName) : (a ^^^ b).toBitVec = a.toBitVec ^^^ b.toBitVec := (rfl)
-@[simp, int_toBitVec] protected theorem toBitVec_shiftLeft (a b : $typeName) : (a <<< b).toBitVec = a.toBitVec <<< (b.toBitVec % $bits) := (rfl)
-@[simp, int_toBitVec] protected theorem toBitVec_shiftRight (a b : $typeName) : (a >>> b).toBitVec = a.toBitVec >>> (b.toBitVec % $bits) := (rfl)
+@[simp] protected theorem toBitVec_not {a : $typeName} : (~~~a).toBitVec = ~~~a.toBitVec := (rfl)
+@[simp] protected theorem toBitVec_and (a b : $typeName) : (a &&& b).toBitVec = a.toBitVec &&& b.toBitVec := (rfl)
+@[simp] protected theorem toBitVec_or (a b : $typeName) : (a ||| b).toBitVec = a.toBitVec ||| b.toBitVec := (rfl)
+@[simp] protected theorem toBitVec_xor (a b : $typeName) : (a ^^^ b).toBitVec = a.toBitVec ^^^ b.toBitVec := (rfl)
+@[simp] protected theorem toBitVec_shiftLeft (a b : $typeName) : (a <<< b).toBitVec = a.toBitVec <<< (b.toBitVec % $bits) := (rfl)
+@[simp] protected theorem toBitVec_shiftRight (a b : $typeName) : (a >>> b).toBitVec = a.toBitVec >>> (b.toBitVec % $bits) := (rfl)
 
 @[simp] protected theorem toNat_and (a b : $typeName) : (a &&& b).toNat = a.toNat &&& b.toNat := by simp [toNat, -toNat_toBitVec]
 @[simp] protected theorem toNat_or (a b : $typeName) : (a ||| b).toNat = a.toNat ||| b.toNat := by simp [toNat, -toNat_toBitVec]
 @[simp] protected theorem toNat_xor (a b : $typeName) : (a ^^^ b).toNat = a.toNat ^^^ b.toNat := by simp [toNat, -toNat_toBitVec]
 @[simp] protected theorem toNat_shiftLeft (a b : $typeName) : (a <<< b).toNat = a.toNat <<< (b.toNat % $bits) % 2 ^ $bits := by simp [toNat, -toNat_toBitVec]
 @[simp] protected theorem toNat_shiftRight (a b : $typeName) : (a >>> b).toNat = a.toNat >>> (b.toNat % $bits) := by simp [toNat, -toNat_toBitVec]
-
-end $typeName
-)
+  )
+  unless isUSize do
+    let names := #[`toBitVec_not, `toBitVec_and, `toBitVec_or, `toBitVec_xor, `toBitVec_shiftLeft,
+      `toBitVec_shiftRight]
+    let idents := names.map fun n => mkIdent (typeName.getId ++ n)
+    cmds := cmds.push <| ← `(attribute [int_toBitVec] $idents*)
+  cmds := cmds.push <| ← `(end $typeName)
+  return ⟨mkNullNode cmds⟩
 declare_bitwise_uint_theorems UInt8 8
 declare_bitwise_uint_theorems UInt16 16
 declare_bitwise_uint_theorems UInt32 32
@@ -66,7 +73,7 @@ theorem Bool.toBitVec_toUInt64 {b : Bool} :
     b.toUInt64.toBitVec = (BitVec.ofBool b).setWidth 64 := by
   cases b <;> simp [toUInt64]
 
-@[simp, int_toBitVec]
+@[simp]
 theorem Bool.toBitVec_toUSize {b : Bool} :
     b.toUSize.toBitVec = (BitVec.ofBool b).setWidth System.Platform.numBits := by
   cases b

--- a/src/Init/Data/UInt/IntToBitVec.lean
+++ b/src/Init/Data/UInt/IntToBitVec.lean
@@ -12,10 +12,10 @@ public import Init.Data.UInt.Bitwise
 public section
 
 theorem USize.toBitVec32_eq_toBitVec (a : USize) (h : System.Platform.numBits = 32) :
-    a.toBitVec32 h = h ▸ a.toBitVec := rfl
+    a.toBitVec32 h = a.toBitVec.cast h := rfl
 
 theorem USize.toBitVec64_eq_toBitVec (a : USize) (h : System.Platform.numBits = 64) :
-    a.toBitVec64 h = h ▸ a.toBitVec := rfl
+    a.toBitVec64 h = a.toBitVec.cast h := rfl
 
 /-! ## `numBits = 32` -/
 
@@ -108,6 +108,56 @@ theorem USize.toBitVec32_neg {a : USize} (h : System.Platform.numBits = 32) :
   rfl
 
 @[int_toBitVec]
+theorem USize.toBitVec32_not {a : USize} (h : System.Platform.numBits = 32) :
+    (~~~a).toBitVec32 h = ~~~a.toBitVec32 h := by
+  simp only [USize.toBitVec_not, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_and (a b : USize) (h : System.Platform.numBits = 32) :
+    (a &&& b).toBitVec32 h = a.toBitVec32 h &&& b.toBitVec32 h := by
+  simp only [USize.toBitVec_and, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_or (a b : USize) (h : System.Platform.numBits = 32) :
+    (a ||| b).toBitVec32 h = a.toBitVec32 h ||| b.toBitVec32 h := by
+  simp only [USize.toBitVec_or, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_xor (a b : USize) (h : System.Platform.numBits = 32) :
+    (a ^^^ b).toBitVec32 h = a.toBitVec32 h ^^^ b.toBitVec32 h := by
+  simp only [USize.toBitVec_xor, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_shiftLeft (a b : USize) (h : System.Platform.numBits = 32) :
+    (a <<< b).toBitVec32 h = a.toBitVec32 h <<< (b.toBitVec32 h % 32) := by
+  simp only [toBitVec32_eq_toBitVec, USize.toBitVec_shiftLeft, BitVec.natCast_eq_ofNat,
+    BitVec.ofNat_eq_ofNat]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_shiftRight (a b : USize) (h : System.Platform.numBits = 32) :
+    (a >>> b).toBitVec32 h = a.toBitVec32 h >>> (b.toBitVec32 h % 32) := by
+  simp only [toBitVec32_eq_toBitVec, USize.toBitVec_shiftRight, BitVec.natCast_eq_ofNat,
+    BitVec.ofNat_eq_ofNat]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
 theorem USize.toBitVec32_toUInt8 (n : USize) (h : System.Platform.numBits = 32) :
     n.toUInt8.toBitVec = (n.toBitVec32 h).setWidth 8 := by
   simp only [USize.toBitVec_toUInt8, USize.toBitVec32_eq_toBitVec]
@@ -191,9 +241,6 @@ theorem USize.toBitVec32_ofFin (n : Fin USize.size) (h : System.Platform.numBits
 theorem USize.toBitVec32_ofBitVec (n) (h : System.Platform.numBits = 32) :
     (USize.ofBitVec n).toBitVec32 h = n.cast h := by
   simp only [USize.toBitVec32_eq_toBitVec]
-  generalize 32 = x at *
-  subst h
-  rfl
 
 @[int_toBitVec]
 theorem USize.toBitVec32_pow (a : USize) (n : Nat) (h : System.Platform.numBits = 32) :
@@ -302,6 +349,56 @@ theorem USize.toBitVec64_neg {a : USize} (h : System.Platform.numBits = 64) :
   rfl
 
 @[int_toBitVec]
+theorem USize.toBitVec64_not {a : USize} (h : System.Platform.numBits = 64) :
+    (~~~a).toBitVec64 h = ~~~a.toBitVec64 h := by
+  simp only [USize.toBitVec_not, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_and (a b : USize) (h : System.Platform.numBits = 64) :
+    (a &&& b).toBitVec64 h = a.toBitVec64 h &&& b.toBitVec64 h := by
+  simp only [USize.toBitVec_and, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_or (a b : USize) (h : System.Platform.numBits = 64) :
+    (a ||| b).toBitVec64 h = a.toBitVec64 h ||| b.toBitVec64 h := by
+  simp only [USize.toBitVec_or, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_xor (a b : USize) (h : System.Platform.numBits = 64) :
+    (a ^^^ b).toBitVec64 h = a.toBitVec64 h ^^^ b.toBitVec64 h := by
+  simp only [USize.toBitVec_xor, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_shiftLeft (a b : USize) (h : System.Platform.numBits = 64) :
+    (a <<< b).toBitVec64 h = a.toBitVec64 h <<< (b.toBitVec64 h % 64) := by
+  simp only [toBitVec64_eq_toBitVec, USize.toBitVec_shiftLeft, BitVec.natCast_eq_ofNat,
+    BitVec.ofNat_eq_ofNat]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_shiftRight (a b : USize) (h : System.Platform.numBits = 64) :
+    (a >>> b).toBitVec64 h = a.toBitVec64 h >>> (b.toBitVec64 h % 64) := by
+  simp only [toBitVec64_eq_toBitVec, USize.toBitVec_shiftRight, BitVec.natCast_eq_ofNat,
+    BitVec.ofNat_eq_ofNat]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
 theorem USize.toBitVec64_toUInt8 (n : USize) (h : System.Platform.numBits = 64) :
     n.toUInt8.toBitVec = (n.toBitVec64 h).setWidth 8 := by
   simp only [USize.toBitVec_toUInt8, USize.toBitVec64_eq_toBitVec]
@@ -385,9 +482,6 @@ theorem USize.toBitVec64_ofFin (n : Fin USize.size) (h : System.Platform.numBits
 theorem USize.toBitVec64_ofBitVec (n) (h : System.Platform.numBits = 64) :
     (USize.ofBitVec n).toBitVec64 h = n.cast h := by
   simp only [USize.toBitVec64_eq_toBitVec]
-  generalize 64 = x at *
-  subst h
-  rfl
 
 @[int_toBitVec]
 theorem USize.toBitVec64_pow (a : USize) (n : Nat) (h : System.Platform.numBits = 64) :

--- a/src/Init/Data/UInt/IntToBitVec.lean
+++ b/src/Init/Data/UInt/IntToBitVec.lean
@@ -1,0 +1,406 @@
+/-
+Copyright (c) 2026 Lean FRO LLC or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Henrik Böving
+-/
+module
+
+prelude
+public import Init.Data.UInt.Lemmas
+public import Init.Data.UInt.Bitwise
+
+public section
+
+theorem USize.toBitVec32_eq_toBitVec (a : USize) (h : System.Platform.numBits = 32) :
+    a.toBitVec32 h = h ▸ a.toBitVec := rfl
+
+theorem USize.toBitVec64_eq_toBitVec (a : USize) (h : System.Platform.numBits = 64) :
+    a.toBitVec64 h = h ▸ a.toBitVec := rfl
+
+/-! ## `numBits = 32` -/
+
+@[int_toBitVec]
+theorem USize.le_iff_toBitVec32_le {a b : USize} (h : System.Platform.numBits = 32) :
+    a ≤ b ↔ a.toBitVec32 h ≤ b.toBitVec32 h := by
+  simp only [USize.le_iff_toBitVec_le, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.lt_iff_toBitVec32_lt {a b : USize} (h : System.Platform.numBits = 32) :
+    a < b ↔ a.toBitVec32 h < b.toBitVec32 h := by
+  simp only [USize.lt_iff_toBitVec_lt, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.eq_iff_toBitVec32_eq {a b : USize} (h : System.Platform.numBits = 32) :
+    a = b ↔ a.toBitVec32 h = b.toBitVec32 h := by
+  simp only [USize.eq_iff_toBitVec_eq, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.ne_iff_toBitVec32_ne {a b : USize} (h : System.Platform.numBits = 32) :
+    a ≠ b ↔ a.toBitVec32 h ≠ b.toBitVec32 h := by
+  simp only [USize.ne_iff_toBitVec_ne, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_ofNat (n : Nat) (h : System.Platform.numBits = 32) :
+    toBitVec32 (no_index (OfNat.ofNat n)) h = BitVec.ofNat _ n := by
+  simp only [USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_add {a b : USize} (h : System.Platform.numBits = 32) :
+    (a + b).toBitVec32 h = a.toBitVec32 h + b.toBitVec32 h := by
+  simp only [USize.toBitVec_add, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_sub {a b : USize} (h : System.Platform.numBits = 32) :
+    (a - b).toBitVec32 h = a.toBitVec32 h - b.toBitVec32 h := by
+  simp only [USize.toBitVec_sub, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_mul {a b : USize} (h : System.Platform.numBits = 32) :
+    (a * b).toBitVec32 h = a.toBitVec32 h * b.toBitVec32 h := by
+  simp only [USize.toBitVec_mul, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_div {a b : USize} (h : System.Platform.numBits = 32) :
+    (a / b).toBitVec32 h = a.toBitVec32 h / b.toBitVec32 h := by
+  simp only [USize.toBitVec_div, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_mod {a b : USize} (h : System.Platform.numBits = 32) :
+    (a % b).toBitVec32 h = a.toBitVec32 h % b.toBitVec32 h := by
+  simp only [USize.toBitVec_mod, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_neg {a : USize} (h : System.Platform.numBits = 32) :
+    (-a).toBitVec32 h = -a.toBitVec32 h := by
+  simp only [USize.toBitVec_neg, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_toUInt8 (n : USize) (h : System.Platform.numBits = 32) :
+    n.toUInt8.toBitVec = (n.toBitVec32 h).setWidth 8 := by
+  simp only [USize.toBitVec_toUInt8, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_toUInt16 (n : USize) (h : System.Platform.numBits = 32) :
+    n.toUInt16.toBitVec = (n.toBitVec32 h).setWidth 16 := by
+  simp only [USize.toBitVec_toUInt16, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_toUInt32 (n : USize) (h : System.Platform.numBits = 32) :
+    n.toUInt32.toBitVec = (n.toBitVec32 h).setWidth 32 := by
+  simp only [USize.toBitVec_toUInt32, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_toUInt64 (n : USize) (h : System.Platform.numBits = 32) :
+    n.toUInt64.toBitVec = (n.toBitVec32 h).setWidth 64 := by
+  simp only [USize.toBitVec_toUInt64, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem UInt8.toBitVec32_toUSize (n : UInt8) (h : System.Platform.numBits = 32) :
+    n.toUSize.toBitVec32 h = n.toBitVec.setWidth 32 := by
+  simp only [UInt8.toBitVec_toUSize, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem UInt16.toBitVec32_toUSize (n : UInt16) (h : System.Platform.numBits = 32) :
+    n.toUSize.toBitVec32 h = n.toBitVec.setWidth 32 := by
+  simp only [UInt16.toBitVec_toUSize, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem UInt32.toBitVec32_toUSize (n : UInt32) (h : System.Platform.numBits = 32) :
+    n.toUSize.toBitVec32 h = n.toBitVec := by
+  simp only [UInt32.toBitVec_toUSize, USize.toBitVec32_eq_toBitVec]
+  generalize System.Platform.numBits = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem UInt64.toBitVec32_toUSize (n : UInt64) (h : System.Platform.numBits = 32) :
+    n.toUSize.toBitVec32 h = n.toBitVec.setWidth 32 := by
+  simp only [UInt64.toBitVec_toUSize, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_ofNatLT {n : Nat} (hn : n < USize.size) (h : System.Platform.numBits = 32) :
+    (USize.ofNatLT n hn).toBitVec32 h = BitVec.ofNatLT n (h ▸ hn) := by
+  simp only [USize.toBitVec_ofNatLT, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_ofFin (n : Fin USize.size) (h : System.Platform.numBits = 32) :
+    (USize.ofFin n).toBitVec32 h = BitVec.ofFin (h ▸ n) := by
+  simp only [USize.toBitVec_ofFin, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_ofBitVec (n) (h : System.Platform.numBits = 32) :
+    (USize.ofBitVec n).toBitVec32 h = n.cast h := by
+  simp only [USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_pow (a : USize) (n : Nat) (h : System.Platform.numBits = 32) :
+    (a ^ n).toBitVec32 h = a.toBitVec32 h ^ n := by
+  simp only [USize.toBitVec_pow, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem Bool.toBitVec32_toUSize {b : Bool} (h : System.Platform.numBits = 32) :
+    b.toUSize.toBitVec32 h = (BitVec.ofBool b).setWidth 32 := by
+  simp only [Bool.toBitVec_toUSize, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+/-! ## `numBits = 64` -/
+
+@[int_toBitVec]
+theorem USize.le_iff_toBitVec64_le {a b : USize} (h : System.Platform.numBits = 64) :
+    a ≤ b ↔ a.toBitVec64 h ≤ b.toBitVec64 h := by
+  simp only [USize.le_iff_toBitVec_le, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.lt_iff_toBitVec64_lt {a b : USize} (h : System.Platform.numBits = 64) :
+    a < b ↔ a.toBitVec64 h < b.toBitVec64 h := by
+  simp only [USize.lt_iff_toBitVec_lt, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.eq_iff_toBitVec64_eq {a b : USize} (h : System.Platform.numBits = 64) :
+    a = b ↔ a.toBitVec64 h = b.toBitVec64 h := by
+  simp only [USize.eq_iff_toBitVec_eq, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.ne_iff_toBitVec64_ne {a b : USize} (h : System.Platform.numBits = 64) :
+    a ≠ b ↔ a.toBitVec64 h ≠ b.toBitVec64 h := by
+  simp only [USize.ne_iff_toBitVec_ne, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_ofNat (n : Nat) (h : System.Platform.numBits = 64) :
+    toBitVec64 (no_index (OfNat.ofNat n)) h = BitVec.ofNat _ n := by
+  simp only [USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_add {a b : USize} (h : System.Platform.numBits = 64) :
+    (a + b).toBitVec64 h = a.toBitVec64 h + b.toBitVec64 h := by
+  simp only [USize.toBitVec_add, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_sub {a b : USize} (h : System.Platform.numBits = 64) :
+    (a - b).toBitVec64 h = a.toBitVec64 h - b.toBitVec64 h := by
+  simp only [USize.toBitVec_sub, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_mul {a b : USize} (h : System.Platform.numBits = 64) :
+    (a * b).toBitVec64 h = a.toBitVec64 h * b.toBitVec64 h := by
+  simp only [USize.toBitVec_mul, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_div {a b : USize} (h : System.Platform.numBits = 64) :
+    (a / b).toBitVec64 h = a.toBitVec64 h / b.toBitVec64 h := by
+  simp only [USize.toBitVec_div, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_mod {a b : USize} (h : System.Platform.numBits = 64) :
+    (a % b).toBitVec64 h = a.toBitVec64 h % b.toBitVec64 h := by
+  simp only [USize.toBitVec_mod, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_neg {a : USize} (h : System.Platform.numBits = 64) :
+    (-a).toBitVec64 h = -a.toBitVec64 h := by
+  simp only [USize.toBitVec_neg, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_toUInt8 (n : USize) (h : System.Platform.numBits = 64) :
+    n.toUInt8.toBitVec = (n.toBitVec64 h).setWidth 8 := by
+  simp only [USize.toBitVec_toUInt8, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_toUInt16 (n : USize) (h : System.Platform.numBits = 64) :
+    n.toUInt16.toBitVec = (n.toBitVec64 h).setWidth 16 := by
+  simp only [USize.toBitVec_toUInt16, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_toUInt32 (n : USize) (h : System.Platform.numBits = 64) :
+    n.toUInt32.toBitVec = (n.toBitVec64 h).setWidth 32 := by
+  simp only [USize.toBitVec_toUInt32, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_toUInt64 (n : USize) (h : System.Platform.numBits = 64) :
+    n.toUInt64.toBitVec = (n.toBitVec64 h).setWidth 64 := by
+  simp only [USize.toBitVec_toUInt64, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem UInt8.toBitVec64_toUSize (n : UInt8) (h : System.Platform.numBits = 64) :
+    n.toUSize.toBitVec64 h = n.toBitVec.setWidth 64 := by
+  simp only [UInt8.toBitVec_toUSize, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem UInt16.toBitVec64_toUSize (n : UInt16) (h : System.Platform.numBits = 64) :
+    n.toUSize.toBitVec64 h = n.toBitVec.setWidth 64 := by
+  simp only [UInt16.toBitVec_toUSize, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem UInt32.toBitVec64_toUSize (n : UInt32) (h : System.Platform.numBits = 64) :
+    n.toUSize.toBitVec64 h = n.toBitVec.setWidth 64 := by
+  simp only [UInt32.toBitVec_toUSize, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem UInt64.toBitVec64_toUSize (n : UInt64) (h : System.Platform.numBits = 64) :
+    n.toUSize.toBitVec64 h = n.toBitVec := by
+  simp only [UInt64.toBitVec_toUSize, USize.toBitVec64_eq_toBitVec]
+  generalize System.Platform.numBits = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_ofNatLT {n : Nat} (hn : n < USize.size) (h : System.Platform.numBits = 64) :
+    (USize.ofNatLT n hn).toBitVec64 h = BitVec.ofNatLT n (h ▸ hn) := by
+  simp only [USize.toBitVec_ofNatLT, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_ofFin (n : Fin USize.size) (h : System.Platform.numBits = 64) :
+    (USize.ofFin n).toBitVec64 h = BitVec.ofFin (h ▸ n) := by
+  simp only [USize.toBitVec_ofFin, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_ofBitVec (n) (h : System.Platform.numBits = 64) :
+    (USize.ofBitVec n).toBitVec64 h = n.cast h := by
+  simp only [USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_pow (a : USize) (n : Nat) (h : System.Platform.numBits = 64) :
+    (a ^ n).toBitVec64 h = a.toBitVec64 h ^ n := by
+  simp only [USize.toBitVec_pow, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem Bool.toBitVec64_toUSize {b : Bool} (h : System.Platform.numBits = 64) :
+    b.toUSize.toBitVec64 h = (BitVec.ofBool b).setWidth 64 := by
+  simp only [Bool.toBitVec_toUSize, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl

--- a/src/Init/Data/UInt/Lemmas.lean
+++ b/src/Init/Data/UInt/Lemmas.lean
@@ -28,6 +28,7 @@ open Std
 open Lean in
 set_option hygiene false in
 macro "declare_uint_theorems" typeName:ident bits:term:arg : command => do
+  let isUSize := typeName.getId == ``USize
   let mut cmds ← Syntax.getArgs <$> `(
   namespace $typeName
 
@@ -62,9 +63,9 @@ macro "declare_uint_theorems" typeName:ident bits:term:arg : command => do
   theorem toNat_ofNat_of_lt {n : Nat} (h : n < size) : toNat (OfNat.ofNat n) = n :=
     toNat_ofNat_of_lt' h
 
-  @[int_toBitVec] theorem le_iff_toBitVec_le {a b : $typeName} : a ≤ b ↔ a.toBitVec ≤ b.toBitVec := .rfl
+  theorem le_iff_toBitVec_le {a b : $typeName} : a ≤ b ↔ a.toBitVec ≤ b.toBitVec := .rfl
 
-  @[int_toBitVec] theorem lt_iff_toBitVec_lt {a b : $typeName} : a < b ↔ a.toBitVec < b.toBitVec := .rfl
+  theorem lt_iff_toBitVec_lt {a b : $typeName} : a < b ↔ a.toBitVec < b.toBitVec := .rfl
 
   theorem le_iff_toNat_le {a b : $typeName} : a ≤ b ↔ a.toNat ≤ b.toNat := .rfl
 
@@ -101,7 +102,6 @@ macro "declare_uint_theorems" typeName:ident bits:term:arg : command => do
     Iff.intro eq_of_toBitVec_eq toBitVec_eq_of_eq
 
   open $typeName (eq_of_toBitVec_eq toBitVec_eq_of_eq) in
-  @[int_toBitVec]
   protected theorem eq_iff_toBitVec_eq {a b : $typeName} : a = b ↔ a.toBitVec = b.toBitVec :=
     Iff.intro toBitVec_eq_of_eq eq_of_toBitVec_eq
 
@@ -123,7 +123,6 @@ macro "declare_uint_theorems" typeName:ident bits:term:arg : command => do
     fun h' => absurd (toBitVec_eq_of_eq h') h
 
   open $typeName (ne_of_toBitVec_ne toBitVec_ne_of_ne) in
-  @[int_toBitVec]
   protected theorem ne_iff_toBitVec_ne {a b : $typeName} : a ≠ b ↔ a.toBitVec ≠ b.toBitVec :=
     Iff.intro toBitVec_ne_of_ne ne_of_toBitVec_ne
 
@@ -199,18 +198,18 @@ instance : LawfulOrderLT $typeName where
   @[simp]
   theorem toFin_ofNat (n : Nat) : toFin (no_index (OfNat.ofNat n)) = OfNat.ofNat n := (rfl)
 
-  @[simp, int_toBitVec]
+  @[simp]
   theorem toBitVec_ofNat (n : Nat) : toBitVec (no_index (OfNat.ofNat n)) = BitVec.ofNat _ n := (rfl)
 
   @[simp]
   theorem ofBitVec_ofNat (n : Nat) : ofBitVec (BitVec.ofNat _ n) = OfNat.ofNat n := (rfl)
 
-  @[simp, int_toBitVec] protected theorem toBitVec_add {a b : $typeName} : (a + b).toBitVec = a.toBitVec + b.toBitVec := (rfl)
-  @[simp, int_toBitVec] protected theorem toBitVec_sub {a b : $typeName} : (a - b).toBitVec = a.toBitVec - b.toBitVec := (rfl)
-  @[simp, int_toBitVec] protected theorem toBitVec_mul {a b : $typeName} : (a * b).toBitVec = a.toBitVec * b.toBitVec := (rfl)
-  @[simp, int_toBitVec] protected theorem toBitVec_div {a b : $typeName} : (a / b).toBitVec = a.toBitVec / b.toBitVec := (rfl)
-  @[simp, int_toBitVec] protected theorem toBitVec_mod {a b : $typeName} : (a % b).toBitVec = a.toBitVec % b.toBitVec := (rfl)
-  @[simp, int_toBitVec] protected theorem toBitVec_neg {a : $typeName} : (-a).toBitVec = -a.toBitVec := (rfl)
+  @[simp] protected theorem toBitVec_add {a b : $typeName} : (a + b).toBitVec = a.toBitVec + b.toBitVec := (rfl)
+  @[simp] protected theorem toBitVec_sub {a b : $typeName} : (a - b).toBitVec = a.toBitVec - b.toBitVec := (rfl)
+  @[simp] protected theorem toBitVec_mul {a b : $typeName} : (a * b).toBitVec = a.toBitVec * b.toBitVec := (rfl)
+  @[simp] protected theorem toBitVec_div {a b : $typeName} : (a / b).toBitVec = a.toBitVec / b.toBitVec := (rfl)
+  @[simp] protected theorem toBitVec_mod {a b : $typeName} : (a % b).toBitVec = a.toBitVec % b.toBitVec := (rfl)
+  @[simp] protected theorem toBitVec_neg {a : $typeName} : (-a).toBitVec = -a.toBitVec := (rfl)
 
   )
   if let some nbits := bits.raw.isNatLit? then
@@ -238,6 +237,12 @@ instance : LawfulOrderLT $typeName where
     if nbits < 64 then
       cmds := cmds.push <| ←
         `(@[simp] theorem toNat_toUInt64 (x : $typeName) : x.toUInt64.toNat = x.toNat := (rfl))
+  unless isUSize do
+    let names := #[`le_iff_toBitVec_le, `lt_iff_toBitVec_lt, `eq_iff_toBitVec_eq, `ne_iff_toBitVec_ne,
+      `toBitVec_ofNat, `toBitVec_add, `toBitVec_sub, `toBitVec_mul, `toBitVec_div, `toBitVec_mod,
+      `toBitVec_neg]
+    let idents := names.map fun n => mkIdent (typeName.getId ++ n)
+    cmds := cmds.push <| ← `(attribute [int_toBitVec] $idents*)
   cmds := cmds.push <| ← `(end $typeName)
   return ⟨mkNullNode cmds⟩
 
@@ -446,22 +451,22 @@ theorem USize.size_dvd_uInt64Size : USize.size ∣ UInt64.size := by cases USize
 @[simp, int_toBitVec] theorem UInt16.toBitVec_toUInt8 (n : UInt16) : n.toUInt8.toBitVec = n.toBitVec.setWidth 8 := (rfl)
 @[simp, int_toBitVec] theorem UInt32.toBitVec_toUInt8 (n : UInt32) : n.toUInt8.toBitVec = n.toBitVec.setWidth 8 := (rfl)
 @[simp, int_toBitVec] theorem UInt64.toBitVec_toUInt8 (n : UInt64) : n.toUInt8.toBitVec = n.toBitVec.setWidth 8 := (rfl)
-@[simp, int_toBitVec] theorem USize.toBitVec_toUInt8 (n : USize) : n.toUInt8.toBitVec = n.toBitVec.setWidth 8 := BitVec.eq_of_toNat_eq (by simp)
+@[simp] theorem USize.toBitVec_toUInt8 (n : USize) : n.toUInt8.toBitVec = n.toBitVec.setWidth 8 := BitVec.eq_of_toNat_eq (by simp)
 
 @[simp, int_toBitVec] theorem UInt8.toBitVec_toUInt16 (n : UInt8) : n.toUInt16.toBitVec = n.toBitVec.setWidth 16 := (rfl)
 @[simp, int_toBitVec] theorem UInt32.toBitVec_toUInt16 (n : UInt32) : n.toUInt16.toBitVec = n.toBitVec.setWidth 16 := (rfl)
 @[simp, int_toBitVec] theorem UInt64.toBitVec_toUInt16 (n : UInt64) : n.toUInt16.toBitVec = n.toBitVec.setWidth 16 := (rfl)
-@[simp, int_toBitVec] theorem USize.toBitVec_toUInt16 (n : USize) : n.toUInt16.toBitVec = n.toBitVec.setWidth 16 := BitVec.eq_of_toNat_eq (by simp)
+@[simp] theorem USize.toBitVec_toUInt16 (n : USize) : n.toUInt16.toBitVec = n.toBitVec.setWidth 16 := BitVec.eq_of_toNat_eq (by simp)
 
 @[simp, int_toBitVec] theorem UInt8.toBitVec_toUInt32 (n : UInt8) : n.toUInt32.toBitVec = n.toBitVec.setWidth 32 := (rfl)
 @[simp, int_toBitVec] theorem UInt16.toBitVec_toUInt32 (n : UInt16) : n.toUInt32.toBitVec = n.toBitVec.setWidth 32 := (rfl)
 @[simp, int_toBitVec] theorem UInt64.toBitVec_toUInt32 (n : UInt64) : n.toUInt32.toBitVec = n.toBitVec.setWidth 32 := (rfl)
-@[simp, int_toBitVec] theorem USize.toBitVec_toUInt32 (n : USize) : n.toUInt32.toBitVec = n.toBitVec.setWidth 32 := BitVec.eq_of_toNat_eq (by simp)
+@[simp] theorem USize.toBitVec_toUInt32 (n : USize) : n.toUInt32.toBitVec = n.toBitVec.setWidth 32 := BitVec.eq_of_toNat_eq (by simp)
 
 @[simp, int_toBitVec] theorem UInt8.toBitVec_toUInt64 (n : UInt8) : n.toUInt64.toBitVec = n.toBitVec.setWidth 64 := (rfl)
 @[simp, int_toBitVec] theorem UInt16.toBitVec_toUInt64 (n : UInt16) : n.toUInt64.toBitVec = n.toBitVec.setWidth 64 := (rfl)
 @[simp, int_toBitVec] theorem UInt32.toBitVec_toUInt64 (n : UInt32) : n.toUInt64.toBitVec = n.toBitVec.setWidth 64 := (rfl)
-@[simp, int_toBitVec] theorem USize.toBitVec_toUInt64 (n : USize) : n.toUInt64.toBitVec = n.toBitVec.setWidth 64 :=
+@[simp] theorem USize.toBitVec_toUInt64 (n : USize) : n.toUInt64.toBitVec = n.toBitVec.setWidth 64 :=
   BitVec.eq_of_toNat_eq (by simp)
 
 @[simp, int_toBitVec] theorem UInt8.toBitVec_toUSize (n : UInt8) : n.toUSize.toBitVec = n.toBitVec.setWidth System.Platform.numBits :=
@@ -470,7 +475,7 @@ theorem USize.size_dvd_uInt64Size : USize.size ∣ UInt64.size := by cases USize
   BitVec.eq_of_toNat_eq (by simp)
 @[simp, int_toBitVec] theorem UInt32.toBitVec_toUSize (n : UInt32) : n.toUSize.toBitVec = n.toBitVec.setWidth System.Platform.numBits :=
   BitVec.eq_of_toNat_eq (by simp)
-@[simp, int_toBitVec] theorem UInt64.toBitVec_toUSize (n : UInt64) : n.toUSize.toBitVec = n.toBitVec.setWidth System.Platform.numBits :=
+@[simp] theorem UInt64.toBitVec_toUSize (n : UInt64) : n.toUSize.toBitVec = n.toBitVec.setWidth System.Platform.numBits :=
   BitVec.eq_of_toNat_eq (by simp)
 
 @[simp] theorem UInt8.ofNatLT_toNat (n : UInt8) : UInt8.ofNatLT n.toNat n.toNat_lt = n := (rfl)
@@ -951,20 +956,20 @@ theorem USize.toFin_ofNatClamp_of_le {n : Nat} (hn : USize.size ≤ n) :
     (UInt32.ofNatLT n hn).toBitVec = BitVec.ofNatLT n hn := (rfl)
 @[simp, int_toBitVec] theorem UInt64.toBitVec_ofNatLT {n : Nat} (hn : n < UInt64.size) :
     (UInt64.ofNatLT n hn).toBitVec = BitVec.ofNatLT n hn := (rfl)
-@[simp, int_toBitVec] theorem USize.toBitVec_ofNatLT {n : Nat} (hn : n < USize.size) :
+@[simp] theorem USize.toBitVec_ofNatLT {n : Nat} (hn : n < USize.size) :
     (USize.ofNatLT n hn).toBitVec = BitVec.ofNatLT n hn := (rfl)
 
 @[simp, int_toBitVec] theorem UInt8.toBitVec_ofFin (n : Fin UInt8.size) : (UInt8.ofFin n).toBitVec = BitVec.ofFin n := (rfl)
 @[simp, int_toBitVec] theorem UInt16.toBitVec_ofFin (n : Fin UInt16.size) : (UInt16.ofFin n).toBitVec = BitVec.ofFin n := (rfl)
 @[simp, int_toBitVec] theorem UInt32.toBitVec_ofFin (n : Fin UInt32.size) : (UInt32.ofFin n).toBitVec = BitVec.ofFin n := (rfl)
 @[simp, int_toBitVec] theorem UInt64.toBitVec_ofFin (n : Fin UInt64.size) : (UInt64.ofFin n).toBitVec = BitVec.ofFin n := (rfl)
-@[simp, int_toBitVec] theorem USize.toBitVec_ofFin (n : Fin USize.size) : (USize.ofFin n).toBitVec = BitVec.ofFin n := (rfl)
+@[simp] theorem USize.toBitVec_ofFin (n : Fin USize.size) : (USize.ofFin n).toBitVec = BitVec.ofFin n := (rfl)
 
 @[simp, int_toBitVec] theorem UInt8.toBitVec_ofBitVec (n) : (UInt8.ofBitVec n).toBitVec = n := (rfl)
 @[simp, int_toBitVec] theorem UInt16.toBitVec_ofBitVec (n) : (UInt16.ofBitVec n).toBitVec = n := (rfl)
 @[simp, int_toBitVec] theorem UInt32.toBitVec_ofBitVec (n) : (UInt32.ofBitVec n).toBitVec = n := (rfl)
 @[simp, int_toBitVec] theorem UInt64.toBitVec_ofBitVec (n) : (UInt64.ofBitVec n).toBitVec = n := (rfl)
-@[simp, int_toBitVec] theorem USize.toBitVec_ofBitVec (n) : (USize.ofBitVec n).toBitVec = n := (rfl)
+@[simp] theorem USize.toBitVec_ofBitVec (n) : (USize.ofBitVec n).toBitVec = n := (rfl)
 
 theorem UInt8.toBitVec_ofNatClamp_of_lt {n : Nat} (hn : n < UInt8.size) :
     (UInt8.ofNatClamp n).toBitVec = BitVec.ofNatLT n hn :=
@@ -3223,7 +3228,7 @@ protected theorem USize.pow_succ (x : USize) (n : Nat) : x ^ (n + 1) = x ^ n * x
   induction n <;> simp [*, UInt32.pow_succ, BitVec.pow_succ]
 @[simp, int_toBitVec] protected theorem UInt64.toBitVec_pow (a : UInt64) (n : Nat) : (a ^ n).toBitVec = a.toBitVec ^ n := by
   induction n <;> simp [*, UInt64.pow_succ, BitVec.pow_succ]
-@[simp, int_toBitVec] protected theorem USize.toBitVec_pow (a : USize) (n : Nat) : (a ^ n).toBitVec = a.toBitVec ^ n := by
+@[simp] protected theorem USize.toBitVec_pow (a : USize) (n : Nat) : (a ^ n).toBitVec = a.toBitVec ^ n := by
   induction n <;> simp [*, USize.pow_succ, BitVec.pow_succ]
 
 @[simp] protected theorem UInt8.ofBitVec_pow (a : BitVec 8) (n : Nat) : ofBitVec (a ^ n) = ofBitVec a ^ n := by

--- a/src/Lean/Meta/Tactic/BVDecide/Counterexample.lean
+++ b/src/Lean/Meta/Tactic/BVDecide/Counterexample.lean
@@ -204,6 +204,16 @@ where
           return (x, toExpr <| Int64.ofBitVec (h ▸ value.bv))
         else
           throwError m!"Value for Int64 was not 64 bit but {value.w} bit"
+      | ISize.toBitVec32 x _ =>
+        if value.w = 32 then
+          return (x, toExpr <| ISize.ofInt value.bv.toInt)
+        else
+          throwError m!"Value for ISize was not 32 bit but {value.w} bit"
+      | ISize.toBitVec64 x _ =>
+        if value.w = 64 then
+          return (x, toExpr <| ISize.ofInt value.bv.toInt)
+        else
+          throwError m!"Value for ISize was not 64 bit but {value.w} bit"
       | _ =>
         match var with
         | .app (.const (.str p s) levels) arg =>

--- a/src/Lean/Meta/Tactic/BVDecide/Counterexample.lean
+++ b/src/Lean/Meta/Tactic/BVDecide/Counterexample.lean
@@ -174,6 +174,16 @@ where
           return (x, toExpr <| UInt64.ofBitVec (h ▸ value.bv))
         else
           throwError m!"Value for UInt64 was not 64 bit but {value.w} bit"
+      | USize.toBitVec32 x _ =>
+        if value.w = 32 then
+          return (x, toExpr <| USize.ofNat value.bv.toNat)
+        else
+          throwError m!"Value for USize was not 32 bit but {value.w} bit"
+      | USize.toBitVec64 x _ =>
+        if value.w = 64 then
+          return (x, toExpr <| USize.ofNat value.bv.toNat)
+        else
+          throwError m!"Value for USize was not 64 bit but {value.w} bit"
       | Int8.toBitVec x =>
         if h : value.w = 8 then
           return (x, toExpr <| Int8.ofBitVec (h ▸ value.bv))

--- a/src/Lean/Meta/Tactic/BVDecide/Normalize/IntToBitVec.lean
+++ b/src/Lean/Meta/Tactic/BVDecide/Normalize/IntToBitVec.lean
@@ -66,97 +66,26 @@ public def intToBitVecPass : Pass where
       (simpTheorems := #[intToBvThms])
       (congrTheorems := (← getSimpCongrTheorems))
 
+    let numBitsEq? ← findNumBitsEq goal
+    let discharge? :=
+      if let some (width, proof) := numBitsEq? then
+        some <| fun prop => do
+          let prop ← instantiateMVars prop
+          let_expr Eq _ lhs rhs := prop | return none
+          unless lhs.isConstOf ``System.Platform.numBits do return none
+          let some val ← getNatValue? rhs | return none
+          unless width == val do return none
+          return some proof
+      else
+        none
+
     let hyps ← goal.getNondepPropHyps
-    let ⟨result?, _⟩ ← simpGoal goal (ctx := simpCtx) (fvarIdsToSimp := hyps)
+    let ⟨result?, _⟩ ← simpGoal goal (ctx := simpCtx) (fvarIdsToSimp := hyps) (discharge? := discharge?)
     let some (_, goal) := result? | return none
-    handleSize goal |>.run' {}
+    return goal
 where
-  handleSize (goal : MVarId) : M MVarId := do
-    if ← detectSize goal then
-      replaceSize goal
-    else
-      return goal
-
-  detectSize (goal : MVarId) : M Bool := do
-    goal.withContext do
-      for hyp in ← getPropHyps do
-        (← instantiateMVars (← hyp.getType)).forEachWhere
-          (stopWhenVisited := true)
-          (fun e =>
-            (e.isAppOfArity ``USize.toBitVec 1 || e.isAppOfArity ``ISize.toBitVec 1) &&
-            !e.hasLooseBVars)
-          fun e => do
-            M.addSizeTerm e
-            M.addSizeHyp hyp
-
-      return !(← get).relevantTerms.isEmpty
-
   /--
-  Turn `goal` into a goal containing `BitVec const` instead of `USize`/`ISize`.
-  -/
-  replaceSize (goal : MVarId) : M MVarId := do
-    if let some (numBits, numBitsEq) ← findNumBitsEq goal then
-      goal.withContext do
-        let relevantHyps := (← get).relevantHyps.toArray.map mkFVar
-        let relevantTerms := (← get).relevantTerms.toArray
-        let (app, abstractedHyps) ← liftMkBindingM <| MetavarContext.revert relevantHyps goal true
-        let newMVar := app.getAppFn.mvarId!
-        let targetType ← newMVar.getType
-        /-
-        newMVar has type : h1 → h2 → ... → False`
-        This code computes a motive of the form:
-        ```
-        fun z _ => ∀ (x_1 : BitVec z) (x_2 : BitVec z) ..., h1 → h2 → ... → False
-        ```
-        Where:
-        - all terms from `relevantTerms` in the implication are substituted by `x_1`, ...
-        - all occurrences of `numBits` are substituted by `z`
-
-        Additionally we compute a new metavariable with type:
-        ```
-        ∀ (x_1 : BitVec const) (x_2 : BitVec const) ..., h1 → h2 → ... → False
-        ```
-        with all occurrences of `numBits` substituted by const. This meta variable is going to become
-        the next goal
-        -/
-        let (motive, newGoalType) ←
-          withLocalDeclD `z (mkConst ``Nat) fun z => do
-            let otherArgType := mkApp3 (mkConst ``Eq [1]) (mkConst ``Nat) (toExpr numBits) z
-            withLocalDeclD `h otherArgType fun other => do
-              let argType := mkApp (mkConst ``BitVec) z
-              let argTypes := relevantTerms.map (fun _ => (`x, argType))
-              let innerMotiveType ←
-                withLocalDeclsDND argTypes fun args => do
-                  let mut subst : Std.HashMap Expr Expr := Std.HashMap.emptyWithCapacity (args.size + 1)
-                  subst := subst.insert (mkConst ``System.Platform.numBits) z
-                  for term in relevantTerms, arg in args do
-                    subst := subst.insert term arg
-                  let motiveType := targetType.replace subst.get?
-                  mkForallFVars args motiveType
-              let newGoalType := innerMotiveType.replaceFVar z (toExpr numBits)
-              let motive ← mkLambdaFVars #[z, other] innerMotiveType
-              return (motive, newGoalType)
-        let mut newGoal := (← mkFreshExprMVar newGoalType).mvarId!
-        let casesOn := mkApp6 (mkConst ``Eq.casesOn [0, 1])
-          (mkConst ``Nat)
-          (toExpr numBits)
-          motive
-          (mkConst ``System.Platform.numBits)
-          numBitsEq
-          (mkMVar newGoal)
-        goal.assign <| mkAppN casesOn (relevantTerms ++ abstractedHyps)
-        -- remove all of the hold hypotheses about USize.toBitVec/ISize.toBitVec to prevent
-        -- false counter examples
-        (newGoal, _) ← newGoal.tryClearMany' (abstractedHyps.map Expr.fvarId!)
-        -- intro both the new `BitVec const` as well as all hypotheses about them
-        (_, newGoal) ← newGoal.introN (relevantTerms.size + abstractedHyps.size)
-        return newGoal
-    else
-      logWarning m!"Detected USize/ISize in the goal but no hypothesis about System.Platform.numBits, consider case splitting on {mkConst ``System.Platform.numBits_eq}"
-      return goal
-
-  /--
-  Builds an expression of type: `const = System.Platform.numBits` from the hypotheses in the context
+  Builds an expression of type: `System.Platform.numBits = const` from the hypotheses in the context
   if possible.
   -/
   findNumBitsEq (goal : MVarId) : MetaM (Option (Nat × Expr)) := do
@@ -166,10 +95,10 @@ where
         | Eq eqTyp lhs rhs =>
           if lhs.isConstOf ``System.Platform.numBits then
             let some val ← getNatValue? rhs | return none
-            return some (val, mkApp4 (mkConst ``Eq.symm [1]) eqTyp lhs rhs (mkFVar hyp))
+            return some (val, mkFVar hyp)
           else if rhs.isConstOf ``System.Platform.numBits then
             let some val ← getNatValue? lhs | return none
-            return some (val, mkFVar hyp)
+            return some (val, mkApp4 (mkConst ``Eq.symm [1]) eqTyp lhs rhs (mkFVar hyp))
         | _ => continue
       return none
 

--- a/tests/elab/bv_sint.lean
+++ b/tests/elab/bv_sint.lean
@@ -65,14 +65,13 @@ example (a b c : ISize) (h1 : a < b) (h2 : b < c) : a < c := by
   cases System.Platform.numBits_eq <;> bv_decide
 
 /--
-warning: Detected USize/ISize in the goal but no hypothesis about System.Platform.numBits, consider case splitting on System.Platform.numBits_eq
----
-warning: declaration uses `sorry`
+error: The prover found a counterexample, consider the following assignment:
+a = -1
+b = -1
 -/
 #guard_msgs in
-example (a b : ISize) : a + b > a := by
-  bv_normalize
-  sorry
+example (a b : ISize) (h : System.Platform.numBits = 64) : a + b > a := by
+  bv_decide
 
 example (h : 32 = System.Platform.numBits) (a b c : ISize) (h1 : a < b) (h2 : b < c) : a < c := by
   bv_decide

--- a/tests/elab/bv_sint.lean
+++ b/tests/elab/bv_sint.lean
@@ -75,3 +75,18 @@ example (a b : ISize) (h : System.Platform.numBits = 64) : a + b > a := by
 
 example (h : 32 = System.Platform.numBits) (a b c : ISize) (h1 : a < b) (h2 : b < c) : a < c := by
   bv_decide
+
+/-! ISize arithmetic operations -/
+example (a b : ISize) (h : System.Platform.numBits = 64) : a + b = b + a := by bv_decide
+example (a : ISize) (h : System.Platform.numBits = 64) : a - a = 0 := by bv_decide
+example (a : ISize) (h : System.Platform.numBits = 64) : -a + a = 0 := by bv_decide
+example (a : ISize) (h : System.Platform.numBits = 64) : a / 1 = a := by bv_decide
+example (a : ISize) (h : System.Platform.numBits = 64) : a % 1 = 0 := by bv_decide
+
+/-! ISize bitwise operations -/
+example (a b : ISize) (h : System.Platform.numBits = 64) : a &&& b = b &&& a := by bv_decide
+example (a b : ISize) (h : System.Platform.numBits = 64) : a ||| b = b ||| a := by bv_decide
+example (a b : ISize) (h : System.Platform.numBits = 64) : a ^^^ b = b ^^^ a := by bv_decide
+example (a : ISize) (h : System.Platform.numBits = 64) : ~~~(~~~a) = a := by bv_decide
+example (a : ISize) (h : System.Platform.numBits = 64) : a <<< (0 : ISize) = a := by bv_decide
+example (a : ISize) (h : System.Platform.numBits = 64) : a >>> (0 : ISize) = a := by bv_decide

--- a/tests/elab/bv_uint.lean
+++ b/tests/elab/bv_uint.lean
@@ -65,14 +65,13 @@ example (a b c : USize) (h1 : a < b) (h2 : b < c) : a < c := by
   cases System.Platform.numBits_eq <;> bv_decide
 
 /--
-warning: Detected USize/ISize in the goal but no hypothesis about System.Platform.numBits, consider case splitting on System.Platform.numBits_eq
----
-warning: declaration uses `sorry`
+error: The prover found a counterexample, consider the following assignment:
+a = 18446744073709551615
+b = 18446744073709551615
 -/
 #guard_msgs in
-example (a b : USize) : a + b > a := by
-  bv_normalize
-  sorry
+example (a b : USize) (h : System.Platform.numBits = 64) : a + b > a := by
+  bv_decide
 
 example (h : 32 = System.Platform.numBits) (a b c : USize) (h1 : a < b) (h2 : b < c) : a < c := by
   bv_decide

--- a/tests/elab/bv_uint.lean
+++ b/tests/elab/bv_uint.lean
@@ -88,6 +88,21 @@ example (n : Int64) : n.toUInt64.toInt64 = n := by bv_decide
 
 example {b : UInt8} (h : b &&& 0x80 == 0) : b < 0x80 := by bv_decide
 
+/-! USize arithmetic operations -/
+example (a b : USize) (h : System.Platform.numBits = 64) : a + b = b + a := by bv_decide
+example (a : USize) (h : System.Platform.numBits = 64) : a - a = 0 := by bv_decide
+example (a : USize) (h : System.Platform.numBits = 64) : -a + a = 0 := by bv_decide
+example (a : USize) (h : System.Platform.numBits = 64) : a / 1 = a := by bv_decide
+example (a : USize) (h : System.Platform.numBits = 64) : a % 1 = 0 := by bv_decide
+
+/-! USize bitwise operations -/
+example (a b : USize) (h : System.Platform.numBits = 64) : a &&& b = b &&& a := by bv_decide
+example (a b : USize) (h : System.Platform.numBits = 64) : a ||| b = b ||| a := by bv_decide
+example (a b : USize) (h : System.Platform.numBits = 64) : a ^^^ b = b ^^^ a := by bv_decide
+example (a : USize) (h : System.Platform.numBits = 64) : ~~~(~~~a) = a := by bv_decide
+example (a : USize) (h : System.Platform.numBits = 64) : a <<< (0 : USize) = a := by bv_decide
+example (a : USize) (h : System.Platform.numBits = 64) : a >>> (0 : USize) = a := by bv_decide
+
 example (x y z: UInt8) (h1 : x == y) (h2 : y == z) : x == z := by bv_decide
 example (x y z: UInt16) (h1 : x == y) (h2 : y == z) : x == z := by bv_decide
 example (x y z: UInt32) (h1 : x == y) (h2 : y == z) : x == z := by bv_decide

--- a/tests/elab/int_toBitVec.lean
+++ b/tests/elab/int_toBitVec.lean
@@ -10,8 +10,8 @@ example (a b c d e : UInt32) : ((a + (b * c)) = (b - d / e)) ↔ (a.toBitVec + b
 example (a b c d e : UInt64) : ((a + (b * c)) = (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec = b.toBitVec - d.toBitVec / e.toBitVec) := by
   simp only [int_toBitVec]
 
-example (a b c d e : USize) : ((a + (b * c)) = (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec = b.toBitVec - d.toBitVec / e.toBitVec) := by
-  simp only [int_toBitVec]
+example (a b c d e : USize) (h : System.Platform.numBits = 64) : ((a + (b * c)) = (b - d / e)) ↔ (a.toBitVec64 h + b.toBitVec64 h * c.toBitVec64 h = b.toBitVec64 h - d.toBitVec64 h / e.toBitVec64 h) := by
+  simp only [int_toBitVec, h]
 
 example (a b c d e : UInt8) : ((a + (b * c)) < (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec < b.toBitVec - d.toBitVec / e.toBitVec) := by
   simp only [int_toBitVec]
@@ -25,8 +25,8 @@ example (a b c d e : UInt32) : ((a + (b * c)) < (b - d / e)) ↔ (a.toBitVec + b
 example (a b c d e : UInt64) : ((a + (b * c)) < (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec < b.toBitVec - d.toBitVec / e.toBitVec) := by
   simp only [int_toBitVec]
 
-example (a b c d e : USize) : ((a + (b * c)) < (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec < b.toBitVec - d.toBitVec / e.toBitVec) := by
-  simp only [int_toBitVec]
+example (a b c d e : USize) (h : System.Platform.numBits = 64) : ((a + (b * c)) < (b - d / e)) ↔ (a.toBitVec64 h + b.toBitVec64 h * c.toBitVec64 h < b.toBitVec64 h - d.toBitVec64 h / e.toBitVec64 h) := by
+  simp only [int_toBitVec, h]
 
 example (a b c d e : UInt8) : ((a + (b * c)) ≤ (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec ≤ b.toBitVec - d.toBitVec / e.toBitVec) := by
   simp only [int_toBitVec]
@@ -40,5 +40,5 @@ example (a b c d e : UInt32) : ((a + (b * c)) ≤ (b - d / e)) ↔ (a.toBitVec +
 example (a b c d e : UInt64) : ((a + (b * c)) ≤ (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec ≤ b.toBitVec - d.toBitVec / e.toBitVec) := by
   simp only [int_toBitVec]
 
-example (a b c d e : USize) : ((a + (b * c)) ≤ (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec ≤ b.toBitVec - d.toBitVec / e.toBitVec) := by
-  simp only [int_toBitVec]
+example (a b c d e : USize) (h : System.Platform.numBits = 64) : ((a + (b * c)) ≤ (b - d / e)) ↔ (a.toBitVec64 h + b.toBitVec64 h * c.toBitVec64 h ≤ b.toBitVec64 h - d.toBitVec64 h / e.toBitVec64 h) := by
+  simp only [int_toBitVec, h]


### PR DESCRIPTION
This PR refactors the way that `bv_decide` handles `USize` and `ISize`. This is necessary for `SymM` support in `bv_decide` because calling `revert` in `SymM` is illegal.

Instead of building a custom motive to replace `USize`/`ISize` constants with `BitVec` ones, it now uses a modified `int_toBitVec` simp set. For all fixed width `IntX` this still contains the original lemmas. For `USize`/`ISize` it contains lemmas that convert to `BitVec 32` or `BitVec 64`, conditionally on which of the two assumptions is available. Through this `USize`/`ISize` already get converted to fixed-width `BitVec` in the `int_toBitVec` `simp` pass in `bv_decide`.