### PR TITLE
feat: lake: add `revDiscovery` policy to cache services

### DIFF
--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -460,6 +460,11 @@ artifacts. If no mappings are found, Lake will backtrack the Git history up to
 `--max-revs`, looking for a revision with mappings. If `--max-revs` is 0, Lake
 will search the repository's entire history (or as far as Git will allow).
 
+A service configured with `revDiscovery = \"head\"` does not backtrack: only the
+current commit's mapping is consulted, isolating the download to that exact
+revision. `--max-revs` does not apply to such a service and is ignored with a
+warning. An explicit `--rev` still selects the revision to look up.
+
 By default, Lake will download both the input-to-output mappings and the
 output artifacts for a package. By using `--mappings-only`, Lake will only
 download the mappings and delay downloading artifacts until they are needed.
@@ -603,7 +608,7 @@ def helpCacheServices :=
 USAGE:
   lake cache services
 
-Prints the name of each configured remote cache services (one per line).
+Prints the name of each configured remote cache service (one per line).
 Additional services can be added by modifying the system Lake configuration.
 The exact location of the this configuration file is system dependent and can
 be set by `LAKE_CONFIG`, but it is usually located at `~/.lake/config.toml`.
@@ -619,7 +624,17 @@ The configuration of the system cache could look something like the following:
   artifactEndpoint = \"https://my-s3.com/a0\"
   revisionEndpoint = \"https://my-s3.com/r0\"
 
-If no `cache.defaultService` is configured, Lake will use Reservoir by default."
+If no `cache.defaultService` is configured, Lake will use Reservoir by default.
+
+A service may also set `revDiscovery` to control how `cache get` finds a
+revision's mapping when no `--rev` is given:
+
+  revDiscovery = \"nearest\"   # walk Git history to the nearest cached revision (default)
+  revDiscovery = \"head\"      # only the current commit's mapping; no history walk
+
+With `head`, a build is only served the cache of the exact commit it is on; no
+other revision's mapping is consulted. `--max-revs` does not override this; it
+is ignored with a warning so the policy is always respected."
 
 def helpScriptCli :=
 "Manage Lake scripts

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -74,7 +74,7 @@ public structure LakeOptions where
   platform? : Option CachePlatform := none
   toolchain? : Option CacheToolchain := none
   rev? : Option GitRev := none
-  maxRevs : Nat := 100
+  maxRevs? : Option Nat := none
   shake : Shake.Args := {}
   builtinLint : BuiltinLint.Args := {}
   /-- Whether `lake lint` should also run builtin lints (via `--builtin-lint`). -/
@@ -322,7 +322,7 @@ def lakeLongOption : (opt : String) → CliM PUnit
 | "--max-revs" => do
   let some n ← (·.toNat?) <$> takeOptArg "--max-revs" "number of revisions"
     | error "argument to `--max-revs` should be a natural number"
-  modifyThe LakeOptions ({· with maxRevs := n})
+  modifyThe LakeOptions ({· with maxRevs? := some n})
 | "--log-level"   => do
   let outLv ← takeOptArg' "--log-level" "log level" LogLevel.ofString?
   modifyThe LakeOptions ({· with outLv? := outLv})
@@ -468,6 +468,44 @@ def serviceNotFound (service : String) (configuredServices : Array CacheServiceC
 def endpointDeprecation : String :=
    "configuring the cache service via environment variables is deprecated; use --service instead"
 
+/-- Default number of revisions the `nearest` policy backtracks when discovering a mapping. -/
+private def defaultMaxRevs : Nat := 100
+
+/--
+Discovers the cached mapping for `repo`'s current checkout under `policy`. Revisions
+are probed nearest-first with `lookup` (which yields `none` when a revision has no
+mapping); the first hit is returned, else a "not found" error labelled with `scope` is
+raised. `pkgName` labels diagnostics and `failLv` escalates warnings as usual.
+
+- `nearest` walks history from `HEAD`, bounded by `maxRevs?` (default `defaultMaxRevs`,
+  `0` = unbounded).
+- `head` consults only `HEAD`, so `maxRevs?` does not apply and is ignored with a
+  warning.
+-/
+private def discoverOutputs
+  (policy : RevDiscovery) (repo : GitRepo)
+  (maxRevs? : Option Nat) (failLv : LogLevel) (pkgName : String) (scope : CacheServiceScope)
+  (lookup : GitRev → LoggerIO (Option α))
+: LoggerIO α := do
+  match policy with
+  | .head =>
+    if maxRevs?.isSome then
+      logWarning s!"{pkgName}: `--max-revs` is ignored for a `head` service; \
+        only the current revision is consulted"
+      if failLv ≤ .warning then
+        failure
+    let some map ← (← repo.getHeadRevisions 1).findSomeM? lookup
+      | error s!"{scope}: no outputs found for the current revision"
+    return map
+  | .nearest =>
+    let n := maxRevs?.getD defaultMaxRevs
+    let revs ← repo.getHeadRevisions n
+    let some map ← revs.findSomeM? lookup
+      | let revisions :=
+          if n = 0 || revs.size < n then "for any revision" else s!"in {n} revisions from HEAD"
+        error s!"{scope}: no outputs found {revisions}"
+    return map
+
 protected def get : CliM PUnit := do
   processOptions lakeOption
   let opts ← getThe LakeOptions
@@ -586,15 +624,8 @@ where
             only artifacts for committed code will be downloaded"
           if opts.failLv ≤ .warning then
             failure
-        let n := opts.maxRevs
-        let revs ← repo.getHeadRevisions n
-        let map? ← revs.findSomeM? fun rev =>
+        discoverOutputs service.revDiscovery repo opts.maxRevs? opts.failLv pkg.prettyName remoteScope fun rev =>
           service.downloadRevisionOutputs? rev cache pkg.cacheScope remoteScope platform toolchain opts.forceDownload
-        let some map := map?
-          | let revisions :=
-              if n = 0 || revs.size < n then "for any revision" else s!"in {n} revisions from HEAD"
-            error s!"{remoteScope}: no outputs found {revisions}"
-        return map
     cache.writeMap pkg.cacheScope map service.name? (some remoteScope) overwrite
     unless opts.mappingsOnly do
       let descrs ← map.collectOutputDescrs

--- a/src/lake/Lake/Config/Cache.lean
+++ b/src/lake/Lake/Config/Cache.lean
@@ -546,6 +546,33 @@ instance : ToString CacheToolchain := ⟨CacheToolchain.toString⟩
 
 end CacheToolchain
 
+/-! ## Cache Service Revision Discovery -/
+
+/-- How `cache get` selects which revision's mapping to download when no `--rev` is given. -/
+public inductive RevDiscovery
+  /-- Walk the Git history from `HEAD`, taking the first revision with a mapping. -/
+  | nearest
+  /-- Use only `HEAD`'s mapping, so a build is served the cache of its exact revision. -/
+  | head
+deriving Inhabited
+
+namespace RevDiscovery
+
+public protected def toString (self : RevDiscovery) : String :=
+  match self with
+  | .nearest => "nearest"
+  | .head => "head"
+
+public instance : ToString RevDiscovery := ⟨RevDiscovery.toString⟩
+
+public def ofString? (s : String) : Option RevDiscovery :=
+  match s with
+  | "nearest" => some .nearest
+  | "head" => some .head
+  | _ => none
+
+end RevDiscovery
+
 /-! ## Remote Cache Service -/
 
 /-- **For internal use only.** -/
@@ -593,6 +620,7 @@ structure CacheServiceImpl where
     /- Reservoir -/
     isReservoir : Bool := false
     apiEndpoint : String := ""
+    revDiscovery : RevDiscovery := .nearest
     deriving Nonempty
 
 /--
@@ -618,12 +646,17 @@ namespace CacheService
 @[inline] public def isReservoir (service : CacheService) : Bool :=
   service.impl.isReservoir
 
+/-- Returns the revision discovery policy for this service. -/
+@[inline] public def revDiscovery (service : CacheService) : RevDiscovery :=
+  service.impl.revDiscovery
+
 /-! ### Constructors -/
 
 /-- Constructs a `CacheService` for a Reservoir endpoint. -/
 @[inline] public def reservoirService
   (apiEndpoint : String) (name? := some CacheServiceName.reservoir)
-: CacheService := .mk {name?, isReservoir := true, apiEndpoint}
+  (revDiscovery : RevDiscovery := .nearest)
+: CacheService := .mk {name?, isReservoir := true, apiEndpoint, revDiscovery}
 
 /-- Constructs a `CacheService` to upload artifacts and/or outputs to an S3 endpoint. -/
 @[inline] public def uploadService
@@ -633,7 +666,8 @@ namespace CacheService
 /-- Constructs a `CacheService` to download artifacts and/or outputs from an S3 endpoint. -/
 @[inline] public def downloadService
   (artifactEndpoint revisionEndpoint : String) (name? : Option CacheServiceName := none)
-: CacheService := .mk {name?, artifactEndpoint, revisionEndpoint}
+  (revDiscovery : RevDiscovery := .nearest)
+: CacheService := .mk {name?, artifactEndpoint, revisionEndpoint, revDiscovery}
 
 /-- Constructs a `CacheService` to download just artifacts from an S3 endpoint. -/
 @[inline] public def downloadArtsService

--- a/src/lake/Lake/Config/LakeConfig.lean
+++ b/src/lake/Lake/Config/LakeConfig.lean
@@ -33,6 +33,7 @@ public configuration CacheServiceConfig where
   apiEndpoint : String := ""
   artifactEndpoint : String := ""
   revisionEndpoint : String := ""
+  revDiscovery : RevDiscovery := .nearest
   deriving Inhabited
 
 public configuration CacheConfig where

--- a/src/lake/Lake/Load/Toml.lean
+++ b/src/lake/Lake/Load/Toml.lean
@@ -342,6 +342,14 @@ public protected def CacheServiceKind.decodeToml (v : Value) : EDecodeM CacheSer
 
 public instance : DecodeToml CacheServiceKind := ⟨CacheServiceKind.decodeToml⟩
 
+public protected def RevDiscovery.decodeToml (v : Value) : EDecodeM RevDiscovery := do
+  match RevDiscovery.ofString? (← v.decodeString) with
+  | some v => return v
+  | none =>
+    throwDecodeErrorAt v.ref s!"expected one of 'head', 'nearest'"
+
+public instance : DecodeToml RevDiscovery := ⟨RevDiscovery.decodeToml⟩
+
 /-! ## Package & Target Configuration Decoders -/
 
 public structure TomlFieldInfo (σ : Type) where
@@ -528,12 +536,13 @@ def loadLakeConfigCore (path : FilePath) (lakeEnv : Lake.Env) : LogIO LoadedLake
         match cfg.kind with
         | .reservoir => do
           let apiEndpoint ← validateUrl cfg.name "apiEndpoint" cfg.apiEndpoint
-          let service := .reservoirService apiEndpoint (some (.ofString cfg.name))
+          let service := .reservoirService apiEndpoint (some (.ofString cfg.name)) cfg.revDiscovery
           return map.insert (.mkSimple cfg.name) service
         | .s3 => do
           let artifactEndpoint ← validateUrl cfg.name "artifactEndpoint" cfg.artifactEndpoint
           let revisionEndpoint ← validateUrl cfg.name "revisionEndpoint" cfg.revisionEndpoint
-          let service :=  .downloadService artifactEndpoint revisionEndpoint (some (.ofString cfg.name))
+          let service := .downloadService artifactEndpoint revisionEndpoint
+            (some (.ofString cfg.name)) cfg.revDiscovery
           return map.insert (.mkSimple cfg.name) service
         | _ =>
           error s!"cache service `{cfg.name}` is missing field `kind`"

--- a/tests/lake/tests/cache/bad-rev-discovery.toml
+++ b/tests/lake/tests/cache/bad-rev-discovery.toml
@@ -1,0 +1,8 @@
+# A cache service with an unknown `revDiscovery` policy.
+
+[[cache.service]]
+name = "bad"
+type = "s3"
+artifactEndpoint = "http://example.com/a0"
+revisionEndpoint = "http://example.com/r0"
+revDiscovery = "bogus"

--- a/tests/lake/tests/cache/rev-discovery.toml
+++ b/tests/lake/tests/cache/rev-discovery.toml
@@ -1,0 +1,14 @@
+# Cache services with a non-default `revDiscovery` policy, for either kind of service.
+
+[[cache.service]]
+name = "s3-head"
+type = "s3"
+artifactEndpoint = "http://example.com/a0"
+revisionEndpoint = "http://example.com/r0"
+revDiscovery = "head"
+
+[[cache.service]]
+name = "reservoir-head"
+type = "reservoir"
+apiEndpoint = "http://example.com/api/v1"
+revDiscovery = "head"

--- a/tests/lake/tests/cache/test.sh
+++ b/tests/lake/tests/cache/test.sh
@@ -15,13 +15,25 @@ export LAKE_CACHE_DIR="$CACHE_DIR"
 test_exp ! -d "$CACHE_DIR"
 test_run cache clean
 
-# Test `lake cache services`
+# Verify `lake cache services` lists the configured service names, one per line
 LAKE_CONFIG=services.toml test_out_diff <(cat << EOF
 cdn
 bogus
 reservoir
 EOF
 ) cache services
+
+# Verify a `revDiscovery` policy is accepted on either kind of service
+LAKE_CONFIG=rev-discovery.toml test_out_diff <(cat << EOF
+s3-head
+reservoir-head
+reservoir
+EOF
+) cache services
+
+# Verify an unknown `revDiscovery` policy is rejected
+LAKE_CONFIG=bad-rev-discovery.toml \
+  test_err "expected one of 'head', 'nearest'" cache services
 
 # Verify packages without `enableArtifactCache` do not use the cache by default
 test_run build -f unset.toml Test:static

--- a/tests/lake/tests/cacheTransfer/services.toml
+++ b/tests/lake/tests/cacheTransfer/services.toml
@@ -10,6 +10,14 @@ type = "s3"
 artifactEndpoint = "%URL%/ok/a0"
 revisionEndpoint = "%URL%/ok/r0"
 
+# The same store, restricted to the mapping of the revision being built
+[[cache.service]]
+name = "okHead"
+type = "s3"
+artifactEndpoint = "%URL%/ok/a0"
+revisionEndpoint = "%URL%/ok/r0"
+revDiscovery = "head"
+
 [[cache.service]]
 name = "deny"
 type = "s3"

--- a/tests/lake/tests/cacheTransfer/test.sh
+++ b/tests/lake/tests/cacheTransfer/test.sh
@@ -308,6 +308,12 @@ test_err 'unexpected response' cache get --scope=test --service=denyArtifacts
 match_text 'AccessDenied' produced.out
 test_artifacts 0
 
+# Verify a `head` service serves the mapping of the revision being built
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+test_out 'downloaded artifact' cache get --scope=test --service=okHead
+test_artifacts "$NUM_ARTS"
+test_run build Test --no-build
+
 # Verify a rejected outputs download is reported
 test_cmd rm -rf .lake/build "$CACHE_DIR"
 test_err 'output lookup failed' cache get --scope=test --service=deny
@@ -315,8 +321,23 @@ test_err 'output lookup failed' cache get --scope=test --service=deny
 # Verify a revision without outputs is reported
 test_cmd git commit --allow-empty -m "no outputs"
 test_err 'no outputs found' cache get --scope=test --service=ok --max-revs=1
+# Verify a `head` service does not fall back to an earlier revision
+test_err 'no outputs found for the current revision' \
+  cache get --scope=test --service=okHead
+# Verify `--max-revs` does not override the policy: it is ignored, with a
+# warning that `--wfail` escalates to an error
+test_err 'no outputs found for the current revision' \
+  cache get --scope=test --service=okHead --max-revs=0
+test_err '`--max-revs` is ignored for a `head` service' \
+  cache get --scope=test --service=okHead --max-revs=0 --wfail
 # Verify the revision search finds the outputs of an earlier revision
 test_run cache get --scope=test --service=ok
+test_artifacts "$NUM_ARTS"
+test_run build Test --no-build
+
+# Verify `--rev` selects a revision regardless of the discovery policy
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+test_run cache get --scope=test --service=okHead --rev=HEAD~1
 test_artifacts "$NUM_ARTS"
 test_run build Test --no-build
 


### PR DESCRIPTION
This PR adds a `revDiscovery` setting to remote cache services that controls how `lake cache get` picks a revision's cached mapping: the default `nearest` walks Git history from `HEAD` to the closest cached revision (the existing behavior), while `head` serves only the current commit's mapping, isolating a build's cache to its exact revision.

For a `head` service, `--max-revs` does not apply and is ignored with a warning (escalatable to an error under `--wfail`). Set the policy per service in the system Lake config, e.g. `revDiscovery = "head"` under `[[cache.service]]`, for either an `s3` or `reservoir` service. `lake cache services` now annotates each service with its policy when it is not the default `nearest`.

Closes #14151