### PR TITLE
chore: do not perform unnecessary type inference in `handleConst` step of `cbv`

### DIFF
--- a/src/Lean/Meta/Tactic/Cbv/Main.lean
+++ b/src/Lean/Meta/Tactic/Cbv/Main.lean
@@ -269,7 +269,9 @@ def handleConst : Simproc := fun e => do
   let .const n lvls := e | return .rfl
   let info ← getConstInfo n
   unless info.isDefinition do return .rfl
-  let eType ← Sym.inferType e
+  let eType := info.type
+  -- Fast path: a syntactically functional type cannot whnf to a non-function.
+  if eType matches .forallE .. then return .rfl
   let eType ← whnfD eType
   if eType matches .forallE .. then return .rfl
   unless info.hasValue && info.levelParams.length == lvls.length do return .rfl


### PR DESCRIPTION
This PR removes an unnecessary type inference happening in the `handleConst` step of `cbv` tactic.