### PR TITLE
fix: push a fresh InfoTree context for term-level `open ... in` and `set_option ... in`

### DIFF
--- a/src/Lean/Elab/BuiltinTerm.lean
+++ b/src/Lean/Elab/BuiltinTerm.lean
@@ -429,7 +429,7 @@ private def resynthInstImplicitArgs (type : Expr) : TermElabM Expr := do
     pushScope
     let openDecls ← elabOpenDecl decl
     withTheReader Core.Context (fun ctx => { ctx with openDecls := openDecls }) do
-      elabTerm e expectedType?
+      withSaveInfoContext <| elabTerm e expectedType?
   finally
     popScope
 
@@ -438,7 +438,7 @@ private def resynthInstImplicitArgs (type : Expr) : TermElabM Expr := do
   withRef stx[1] <| Elab.checkDeprecatedOption (stx[1].getId.eraseMacroScopes) decl
   withOptions (fun _ => options) do
     try
-      elabTerm stx[5] expectedType?
+      withSaveInfoContext <| elabTerm stx[5] expectedType?
     finally
       if stx[1].getId == `diagnostics then
         reportDiag

--- a/tests/server_interactive/issue14218.lean
+++ b/tests/server_interactive/issue14218.lean
@@ -1,0 +1,46 @@
+-- Regression test for #14218: `open ... in <term>` should update the completion
+-- context, so unqualified identifiers under the `open` complete against the opened
+-- namespace(s). The first three variants match the ones in the issue; the fourth
+-- exercises the analogous `set_option ... in <term>` case.
+
+namespace Foo14218
+opaque MyType : Type
+axiom aParticularName : MyType
+end Foo14218
+
+-- Variant 1: no local `open`. Completion offers `Foo14218.aParticularName`, and the
+-- item's `detail` uses the full type name `Foo14218.MyType`.
+example : Foo14218.MyType :=
+  aParticularNa
+             --^ completion
+#print ""
+
+-- Variant 2: `open ... in <command>`. Completion offers `aParticularName` (short),
+-- and `detail` shortens the type to `MyType`.
+open Foo14218 in
+example : Foo14218.MyType :=
+  aParticularNa
+             --^ completion
+#print ""
+
+-- Variant 3: `open ... in <term>`. Before the fix, the term elaborator did not push a
+-- context node into the InfoTree, so the completion at the marker saw the outer
+-- command's `openDecls` and offered the qualified name / qualified detail -- the bug
+-- the issue reports. After the fix, this variant matches variant 2.
+example : Foo14218.MyType :=
+  open Foo14218 in
+  aParticularNa
+             --^ completion
+#print ""
+
+-- Variant 4: `set_option ... in <term>` under a term-level `open ... in`. Same class
+-- of bug as variant 3 (the term-level `set_option` also did not push an InfoTree ctx
+-- node). Inside the `set_option pp.fullNames true in`, the completion item's `detail`
+-- should render the type fully qualified again (`Foo14218.MyType`) even though we
+-- would otherwise be shortening under `open`.
+example : Foo14218.MyType :=
+  open Foo14218 in
+  set_option pp.fullNames true in
+  aParticularNa
+             --^ completion
+#print ""

--- a/tests/server_interactive/issue14218.lean.out.expected
+++ b/tests/server_interactive/issue14218.lean.out.expected
@@ -1,0 +1,52 @@
+{"textDocument": {"uri": "file:///issue14218.lean"},
+ "position": {"line": 13, "character": 15}}
+{"items":
+ [{"label": "Foo14218.aParticularName",
+   "kind": 21,
+   "data":
+   ["file:///issue14218.lean", 13, 15, 0, "cFoo14218.aParticularName"]}],
+ "isIncomplete": false}
+Resolution of Foo14218.aParticularName:
+{"label": "Foo14218.aParticularName",
+ "kind": 21,
+ "detail": "Foo14218.MyType",
+ "data": ["file:///issue14218.lean", 13, 15, 0, "cFoo14218.aParticularName"]}
+{"textDocument": {"uri": "file:///issue14218.lean"},
+ "position": {"line": 21, "character": 15}}
+{"items":
+ [{"label": "aParticularName",
+   "kind": 21,
+   "data":
+   ["file:///issue14218.lean", 21, 15, 0, "cFoo14218.aParticularName"]}],
+ "isIncomplete": false}
+Resolution of aParticularName:
+{"label": "aParticularName",
+ "kind": 21,
+ "detail": "MyType",
+ "data": ["file:///issue14218.lean", 21, 15, 0, "cFoo14218.aParticularName"]}
+{"textDocument": {"uri": "file:///issue14218.lean"},
+ "position": {"line": 31, "character": 15}}
+{"items":
+ [{"label": "aParticularName",
+   "kind": 21,
+   "data":
+   ["file:///issue14218.lean", 31, 15, 0, "cFoo14218.aParticularName"]}],
+ "isIncomplete": false}
+Resolution of aParticularName:
+{"label": "aParticularName",
+ "kind": 21,
+ "detail": "MyType",
+ "data": ["file:///issue14218.lean", 31, 15, 0, "cFoo14218.aParticularName"]}
+{"textDocument": {"uri": "file:///issue14218.lean"},
+ "position": {"line": 43, "character": 15}}
+{"items":
+ [{"label": "aParticularName",
+   "kind": 21,
+   "data":
+   ["file:///issue14218.lean", 43, 15, 0, "cFoo14218.aParticularName"]}],
+ "isIncomplete": false}
+Resolution of aParticularName:
+{"label": "aParticularName",
+ "kind": 21,
+ "detail": "Foo14218.MyType",
+ "data": ["file:///issue14218.lean", 43, 15, 0, "cFoo14218.aParticularName"]}


### PR DESCRIPTION
This PR fixes autocompletion (and other InfoTree-driven consumers such as the interactive term goal and hover popups) to see the augmented `openDecls` and `options` when the cursor is under a term-level `open ... in <term>` or `set_option ... in <term>` scope. Previously both elaborators only updated the runtime `Core.Context` via `withTheReader` / `withOptions`, but did not push a corresponding `PartialContextInfo.commandCtx` node into the InfoTree; consumers therefore saw the outer command's `openDecls` / `options` and, for example, offered names fully-qualified even under a matching `open`, or rendered pretty-printed goals ignoring a local `set_option pp.fullNames true`.

Wraps the inner `elabTerm` call in `withSaveInfoContext`, the same helper used at command boundaries, so the info-tree subtree produced by the body is tagged with a `commandCtx` derived from the updated monad state.

Fixes #14218.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>