### PR TITLE
refactor: structure handling in bv_decide

### DIFF
--- a/src/Lean/Meta/Tactic/BVDecide/Normalize/Structures.lean
+++ b/src/Lean/Meta/Tactic/BVDecide/Normalize/Structures.lean
@@ -8,21 +8,25 @@ module
 prelude
 public import Lean.Meta.Tactic.BVDecide.Normalize.TypeAnalysis
 import Lean.Meta.Tactic.BVDecide.Normalize.ApplyControlFlow
-import Lean.Meta.Injective
-import Lean.Meta.Tactic.Cases
+import Lean.Meta.Tactic.Ext
 
 /-!
 This module contains the implementation of the pre processing pass for automatically splitting up
 structures containing information about supported types into individual parts recursively.
 
-The implementation runs cases recursively on all "interesting" types where a type is interesting if
-it is a non recursive structure and at least one of the following conditions hold:
+The implementation operates on all "interesting" types where a type is interesting if it is a non
+recursive structure and at least one of the following conditions hold:
 - it contains something of type `BitVec`/`UIntX`/`IntX`/`Bool`
 - it is parametrized by an interesting type
 - it contains another interesting type
-Afterwards we also:
-- apply relevant `injEq` theorems to support at least equality for these types out of the box.
-- push projections of relevant types inside of `ite` and `cond`.
+
+For these it:
+1. Iterates over all variables in the local context that have an interesting type. For these it
+   recursively asserts all of the contained hypotheses as local facts
+2. It post-processes with a custom simp-set that:
+   - runs `ext_iff` lemmas if available in order to handle equality on structures
+   - runs simprocs to bubble applications of projections onto control flow operators such as `ite`
+     or `cond` into the control flow
 -/
 
 namespace Lean.Meta.Tactic.BVDecide
@@ -30,24 +34,22 @@ namespace Normalize
 
 /--
 Add simp lemmas that we want to apply to structures that we find interesting to `simprocs` and
-`lemmas`.
+`theorems`.
 -/
-public def addStructureSimpLemmas (simprocs : Simprocs) (lemmas : SimpTheoremsArray) :
+public def addStructureSimpLemmas (simprocs : Simprocs) (theorems : SimpTheoremsArray) :
     PreProcessM (Simprocs × SimpTheoremsArray) := do
   let mut simprocs := simprocs
-  let mut lemmas := lemmas
+  let mut theorems := theorems
   let interesting := (← PreProcessM.getTypeAnalysis).interestingStructures
   let env ← getEnv
   for const in interesting do
     let constInfo ← getConstInfoInduct const
-    let ctorName := (← getConstInfoCtor constInfo.ctors.head!).name
-    let lemmaName := mkInjectiveEqTheoremNameFor ctorName
-    if (← getEnv).find? lemmaName |>.isSome then
-      trace[Meta.Tactic.bv] m!"Using injEq lemma: {lemmaName}"
-      lemmas ← lemmas.addTheorem (.decl lemmaName) (mkConst lemmaName)
+    if let some extIffThm ← findExtIff? constInfo then
+      trace[Meta.Tactic.bv] m!"Using ext_iff: {extIffThm}"
+      theorems ← theorems.addTheorem (.decl extIffThm) (mkConst extIffThm)
     let fields := (getStructureInfo env const).fieldNames.size
     let numParams := constInfo.numParams
-    for proj in *...fields do
+    for proj in 0...fields do
       -- We use the simprocs with pre such that we push in projections eagerly in order to
       -- potentially not have to simplify complex structure expressions that we only project one
       -- element out of.
@@ -55,23 +57,64 @@ public def addStructureSimpLemmas (simprocs : Simprocs) (lemmas : SimpTheoremsAr
       simprocs := simprocs.addCore path ``applyIteSimproc false (.inl applyIteSimproc)
       let path := mkApplyProjControlDiscrPath const numParams proj ``cond 4
       simprocs := simprocs.addCore path ``applyCondSimproc false (.inl applyCondSimproc)
-  return (simprocs, lemmas)
+  return (simprocs, theorems)
+where
+  findExtIff? (info : InductiveVal) : MetaM (Option Name) := do
+    let pat ← mkConstAppWithMVars info.name
+    let thms ← Ext.getExtTheorems pat
+    if thms.isEmpty then return none
+    let .str root s := thms[0]!.declName | return none
+    let extIffThm := .str root (s ++ "_iff")
+    unless (← getEnv).contains extIffThm do return none
+    return some extIffThm
+
+  /--
+  Constructs `declName ?m.1 ?m.2 ...` as a synthetic discr tree pattern for ext theorems associated
+  with `declName`.
+  -/
+  mkConstAppWithMVars (declName : Name) : MetaM Expr := do
+    let c ← mkConstWithFreshMVarLevels declName
+    let (mvars, _, _) ← forallMetaTelescopeReducing (← inferType c)
+    return mkAppN c mvars
 
 public partial def structuresPass : Pass where
   name := `structures
   run' goal := do
     let interesting := (← PreProcessM.getTypeAnalysis).interestingStructures
     if interesting.isEmpty then return goal
-    let goals ← goal.casesRec fun decl => do
-      if decl.isLet || decl.isImplementationDetail then
-        return false
-      else
-        let some const := (← instantiateMVars decl.type).getAppFn.constName? | return false
-        return interesting.contains const
+    goal.withContext do
+      let mut worklist := #[]
+      for decl in ← getLCtx do
+        if decl.isLet || decl.isImplementationDetail then
+          continue
+        let .const const us := decl.type.getAppFn | continue
+        if interesting.contains const then
+          worklist := worklist.push (mkFVar decl.fvarId, const, us, decl.type.getAppArgs)
 
-    match goals with
-    | [goal] => postprocess goal
-    | _ => throwError "structures preprocessor generated more than 1 goal"
+      let mut newHyps : Array Hypothesis := #[]
+      let env ← getEnv
+      while h : 0 < worklist.size do
+        let (value, structConst, us, params) := worklist.back
+        worklist := worklist.pop
+        let fields := (getStructureInfo env structConst).fieldNames.size
+        let constInfo ← getConstInfoInduct structConst
+        let ctorInfo ← getConstInfoCtor constInfo.ctors.head!
+        for proj in 0...fields do
+          let projValue ← mkProjFn ctorInfo us params proj value
+          let projType ← inferType projValue
+          if ← Meta.isProp projType then
+            newHyps := newHyps.push {
+              userName := `h
+              type := projType
+              value := projValue
+            }
+          else
+            let .const const us := projType.getAppFn | continue
+            if interesting.contains const then
+              worklist := worklist.push (projValue, const, us, projType.getAppArgs)
+
+      let (_, goal) ← goal.assertHypotheses newHyps
+      postprocess goal
 where
   postprocess (goal : MVarId) : PreProcessM (Option MVarId) := do
     goal.withContext do

--- a/tests/elab/bv_enums.lean
+++ b/tests/elab/bv_enums.lean
@@ -36,6 +36,7 @@ info: Ex1.State.eq_iff_enumToBitVec_eq✝ (x y : State) : x = y ↔ x.enumToBitV
 #guard_msgs in
 #check State.enumToBitVec_le
 
+@[ext]
 structure Pair where
   x : BitVec 16
   s : State

--- a/tests/elab/bv_parametric_struct.lean
+++ b/tests/elab/bv_parametric_struct.lean
@@ -5,6 +5,7 @@ The `Byte` type can have any bitwidth `w`. It carries a two's complement integer
 value of width `w` and a per-bit poison mask modeling bitwise delayed undefined
 behavior.
 -/
+@[ext]
 structure Byte (w : Nat) where
   /-- A two's complement integer value of width `w`. -/
   val : BitVec w

--- a/tests/elab/bv_structures.lean
+++ b/tests/elab/bv_structures.lean
@@ -71,6 +71,7 @@ end Ex5
 
 namespace Ex6
 
+@[ext]
 structure Pair where
   x : BitVec 32
   y : BitVec 32
@@ -85,9 +86,11 @@ end Ex6
 
 namespace Ex7
 
+@[ext]
 structure Single where
   z : BitVec 32
 
+@[ext]
 structure Pair where
   x : BitVec 32
   y : Single
@@ -102,9 +105,11 @@ end Ex7
 
 namespace Ex8
 
+@[ext]
 structure Single where
   z : BitVec 32
 
+@[ext]
 structure Pair extends Single where
   x : BitVec 32
 
@@ -135,6 +140,7 @@ end Ex9
 
 namespace Ex10
 
+@[ext]
 structure Pair where
   x : BitVec 16
   y : BitVec 16


### PR DESCRIPTION
This PR changes the way that structures are handled by `bv_decide`. Previously support for equality of structures in `bv_decide` was limited. Now it will use the `ext_iff` lemmas if available and otherwise not reason about equality of structures. This change should increase the reasoning power of `bv_decide` on structures. However, this is a breaking change and might require users to annotated previously existing structures with `@[ext]` or otherwise define and tag extensionality lemmas for them.

The motivation for this is that the approach of running `cases` on everything is not going to be compatible with `SymM` so the mechanism needs to be refactored. The easiest way to account for not doing `cases` is to run `ext_iff` on everything relevant. The mechanism for using hypotheses hidden in local structures remains.