### PR TITLE
perf: work around non-linearity in ElimDead

### DIFF
--- a/src/Lean/Compiler/LCNF/ElimDead.lean
+++ b/src/Lean/Compiler/LCNF/ElimDead.lean
@@ -16,7 +16,8 @@ so we opt for a safe subset.
 
 namespace Lean.Compiler.LCNF
 
-public abbrev UsedLocalDecls := FVarIdHashSet
+-- This is sometimes used non-linearly, so use a tree set instead of a hash set.
+public abbrev UsedLocalDecls := FVarIdSet
 
 /--
 Collect set of (let) free variables in a LCNF value.


### PR DESCRIPTION
This PR aims to improve performance of the compiler for large do blocks, such as observed in `Grind.Arith.Linear.StructId`. It changes a hash set that is used non-linearly into a tree set.