### PR TITLE
chore: move `MessageType` to `Lean.Lsp` namespace

### DIFF
--- a/src/Lean/Data/Lsp/Window.lean
+++ b/src/Lean/Data/Lsp/Window.lean
@@ -12,6 +12,8 @@ public section
 
 open Lean
 
+namespace Lean.Lsp
+
 inductive MessageType where
   | error
   | warning
@@ -50,3 +52,5 @@ structure ShowMessageRequestParams where
 
 @[expose] def ShowMessageResponse := Option MessageActionItem
   deriving FromJson, ToJson
+
+end Lean.Lsp


### PR DESCRIPTION
This PR moves the contents of the file `Lean/Data/Lsp/Window.lean`, which used to live in the root namespace, to `Lean.Lsp`.