### PR TITLE
feat: add hint to `unusedVariables` linter

### DIFF
--- a/src/Lean/Linter/UnusedVariables.lean
+++ b/src/Lean/Linter/UnusedVariables.lean
@@ -570,7 +570,13 @@ def unusedVariables : Linter where
 
     -- Sort the outputs by position
     for (declStx, userName) in unused.qsort (·.1.getPos?.get! < ·.1.getPos?.get!) do
-      logLint linter.unusedVariables declStx m!"Variable name `{userName}` is not explicitly referenced.\n\nThe binding can be removed (if unused) or named `_` (if used implicitly)."
+      let suggestion : Meta.Hint.Suggestion := s!"_{userName}"
+      let suggestion := { suggestion with span? := declStx }
+      let hint ← liftCoreM <| MessageData.hint
+        m!"The binding can be removed (if unused) or named `_` (if used implicitly). \
+          Alternatively, prefix the name with `_` to silence this warning:" #[suggestion]
+      logLint linter.unusedVariables declStx
+        (m!"Variable name `{userName}` is not explicitly referenced." ++ hint)
 
 builtin_initialize addLinter unusedVariables
 

--- a/src/Lean/Linter/UnusedVariables.lean
+++ b/src/Lean/Linter/UnusedVariables.lean
@@ -571,7 +571,7 @@ def unusedVariables : Linter where
     -- Sort the outputs by position
     for (declStx, userName) in unused.qsort (·.1.getPos?.get! < ·.1.getPos?.get!) do
       let suggestion : Meta.Hint.Suggestion := s!"_{userName}"
-      let suggestion := { suggestion with span? := declStx }
+      let suggestion := { suggestion with span? := declStx, diffGranularity := .none }
       let hint ← liftCoreM <| MessageData.hint
         m!"The binding can be removed (if unused) or named `_` (if used implicitly). \
           Alternatively, prefix the name with `_` to silence this warning:" #[suggestion]

--- a/tests/elab/13269.lean
+++ b/tests/elab/13269.lean
@@ -7,7 +7,8 @@ def bar [Foo] := 0
 /--
 warning: Variable name `x` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 -/

--- a/tests/elab/13269.lean
+++ b/tests/elab/13269.lean
@@ -8,7 +8,7 @@ def bar [Foo] := 0
 warning: Variable name `x` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲x
+  [apply] _x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 -/

--- a/tests/elab/grind_unnecessary_hypothesis.lean
+++ b/tests/elab/grind_unnecessary_hypothesis.lean
@@ -56,7 +56,7 @@ set_option linter.unusedVariables true
 warning: Variable name `hi` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲hi
+  [apply] _hi
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 -/

--- a/tests/elab/grind_unnecessary_hypothesis.lean
+++ b/tests/elab/grind_unnecessary_hypothesis.lean
@@ -55,7 +55,8 @@ set_option linter.unusedVariables true
 /--
 warning: Variable name `hi` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲hi
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 -/

--- a/tests/elab/guard_msgs.lean
+++ b/tests/elab/guard_msgs.lean
@@ -156,7 +156,8 @@ set_option linter.unusedVariables true
 /--
 warning: Variable name `n` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲n
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 -/
@@ -167,7 +168,8 @@ example (n : Nat) : True := trivial
 /--
 warning: Variable name `n` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲n
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 -/

--- a/tests/elab/guard_msgs.lean
+++ b/tests/elab/guard_msgs.lean
@@ -157,7 +157,7 @@ set_option linter.unusedVariables true
 warning: Variable name `n` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲n
+  [apply] _n
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 -/
@@ -169,7 +169,7 @@ example (n : Nat) : True := trivial
 warning: Variable name `n` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲n
+  [apply] _n
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 -/

--- a/tests/elab_fail/linterUnusedVariables.lean.out.expected
+++ b/tests/elab_fail/linterUnusedVariables.lean.out.expected
@@ -1,163 +1,163 @@
 linterUnusedVariables.lean:18:21-18:22: warning: Variable name `x` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲x
+  [apply] _x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:19:6-19:7: warning: Variable name `y` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲y
+  [apply] _y
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:24:8-24:9: warning: Variable name `x` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲x
+  [apply] _x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:40:5-40:6: warning: Variable name `x` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲x
+  [apply] _x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:45:5-45:6: warning: Variable name `x` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲x
+  [apply] _x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:48:7-48:8: warning: Variable name `x` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲x
+  [apply] _x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:51:8-51:9: warning: Variable name `x` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲x
+  [apply] _x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:55:9-55:10: warning: Variable name `z` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲z
+  [apply] _z
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:57:11-57:12: warning: Variable name `z` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲z
+  [apply] _z
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:62:14-62:15: warning: Variable name `y` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲y
+  [apply] _y
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:68:20-68:21: warning: Variable name `y` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲y
+  [apply] _y
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:73:34-73:38: warning: Variable name `inst` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲inst
+  [apply] _inst
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:114:25-114:26: warning: Variable name `x` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲x
+  [apply] _x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:115:6-115:7: warning: Variable name `y` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲y
+  [apply] _y
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:121:6-121:7: warning: Variable name `a` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲a
+  [apply] _a
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:131:26-131:27: warning: Variable name `z` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲z
+  [apply] _z
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:140:9-140:10: warning: Variable name `h` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲h
+  [apply] _h
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:154:8-154:9: warning: Variable name `y` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲y
+  [apply] _y
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:157:28-157:29: warning: Variable name `β` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲β
+  [apply] _β
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:158:7-158:8: warning: Variable name `x` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲x
+  [apply] _x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:168:6-168:7: warning: Variable name `s` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲s
+  [apply] _s
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:192:6-192:7: warning: Variable name `y` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲y
+  [apply] _y
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:202:19-202:20: warning: Variable name `x` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲x
+  [apply] _x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:206:6-206:7: warning: Variable name `y` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲y
+  [apply] _y
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:211:6-211:7: warning: Variable name `y` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲y
+  [apply] _y
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:216:6-216:7: warning: Variable name `y` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲y
+  [apply] _y
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:227:32-227:33: warning: Variable name `b` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲b
+  [apply] _b
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:245:27-245:28: error: don't know how to synthesize placeholder
@@ -177,6 +177,6 @@ linterUnusedVariables.lean:249:0-249:40: error: type of theorem `async` is not a
 linterUnusedVariables.lean:284:41-284:43: warning: Variable name `ha` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲ha
+  [apply] _ha
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`

--- a/tests/elab_fail/linterUnusedVariables.lean.out.expected
+++ b/tests/elab_fail/linterUnusedVariables.lean.out.expected
@@ -1,136 +1,163 @@
 linterUnusedVariables.lean:18:21-18:22: warning: Variable name `x` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:19:6-19:7: warning: Variable name `y` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲y
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:24:8-24:9: warning: Variable name `x` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:40:5-40:6: warning: Variable name `x` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:45:5-45:6: warning: Variable name `x` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:48:7-48:8: warning: Variable name `x` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:51:8-51:9: warning: Variable name `x` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:55:9-55:10: warning: Variable name `z` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲z
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:57:11-57:12: warning: Variable name `z` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲z
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:62:14-62:15: warning: Variable name `y` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲y
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:68:20-68:21: warning: Variable name `y` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲y
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:73:34-73:38: warning: Variable name `inst` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲inst
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:114:25-114:26: warning: Variable name `x` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:115:6-115:7: warning: Variable name `y` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲y
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:121:6-121:7: warning: Variable name `a` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲a
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:131:26-131:27: warning: Variable name `z` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲z
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:140:9-140:10: warning: Variable name `h` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲h
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:154:8-154:9: warning: Variable name `y` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲y
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:157:28-157:29: warning: Variable name `β` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲β
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:158:7-158:8: warning: Variable name `x` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:168:6-168:7: warning: Variable name `s` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲s
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:192:6-192:7: warning: Variable name `y` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲y
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:202:19-202:20: warning: Variable name `x` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲x
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:206:6-206:7: warning: Variable name `y` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲y
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:211:6-211:7: warning: Variable name `y` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲y
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:216:6-216:7: warning: Variable name `y` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲y
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:227:32-227:33: warning: Variable name `b` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲b
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 linterUnusedVariables.lean:245:27-245:28: error: don't know how to synthesize placeholder
@@ -149,6 +176,7 @@ linterUnusedVariables.lean:249:0-249:40: error: type of theorem `async` is not a
   Nat → Nat
 linterUnusedVariables.lean:284:41-284:43: warning: Variable name `ha` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲ha
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`

--- a/tests/elab_fail/warningAsError.lean.out.expected
+++ b/tests/elab_fail/warningAsError.lean.out.expected
@@ -4,6 +4,7 @@ warningAsError.lean:12:6-12:7: error: `g` has been deprecated: Use `f` instead
 1
 warningAsError.lean:15:7-15:13: error: Variable name `unused` is not explicitly referenced.
 
-The binding can be removed (if unused) or named `_` (if used implicitly).
+Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
+  _̲unused
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`

--- a/tests/elab_fail/warningAsError.lean.out.expected
+++ b/tests/elab_fail/warningAsError.lean.out.expected
@@ -5,6 +5,6 @@ warningAsError.lean:12:6-12:7: error: `g` has been deprecated: Use `f` instead
 warningAsError.lean:15:7-15:13: error: Variable name `unused` is not explicitly referenced.
 
 Hint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:
-  _̲unused
+  [apply] _unused
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`

--- a/tests/server_interactive/semanticTokens.lean.out.expected
+++ b/tests/server_interactive/semanticTokens.lean.out.expected
@@ -17,7 +17,7 @@
    "range":
    {"start": {"line": 3, "character": 6}, "end": {"line": 3, "character": 7}},
    "message":
-   "Variable name `y` is not explicitly referenced.\n\nThe binding can be removed (if unused) or named `_` (if used implicitly).\n\nNote: This linter can be disabled with `set_option linter.unusedVariables false`",
+   "Variable name `y` is not explicitly referenced.\n\nHint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:\n  _̲y\n\nNote: This linter can be disabled with `set_option linter.unusedVariables false`",
    "fullRange":
    {"start": {"line": 3, "character": 6}, "end": {"line": 3, "character": 7}}},
   {"source": "Lean 4",

--- a/tests/server_interactive/semanticTokens.lean.out.expected
+++ b/tests/server_interactive/semanticTokens.lean.out.expected
@@ -17,7 +17,7 @@
    "range":
    {"start": {"line": 3, "character": 6}, "end": {"line": 3, "character": 7}},
    "message":
-   "Variable name `y` is not explicitly referenced.\n\nHint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:\n  _̲y\n\nNote: This linter can be disabled with `set_option linter.unusedVariables false`",
+   "Variable name `y` is not explicitly referenced.\n\nHint: The binding can be removed (if unused) or named `_` (if used implicitly). Alternatively, prefix the name with `_` to silence this warning:\n  [apply] _y\n\nNote: This linter can be disabled with `set_option linter.unusedVariables false`",
    "fullRange":
    {"start": {"line": 3, "character": 6}, "end": {"line": 3, "character": 7}}},
   {"source": "Lean 4",


### PR DESCRIPTION
This PR adds a hint to a `unusedVariables` linter, suggesting to rename the unreferenced name with an underscore. 