### PR TITLE
chore: avoid namespace pollution in `Lean.Data.Lsp.Communication`

### DIFF
--- a/src/Lean/Data/Lsp/Communication.lean
+++ b/src/Lean/Data/Lsp/Communication.lean
@@ -16,7 +16,7 @@ public section
 
 /-! Reading/writing LSP messages from/to IO handles. -/
 
-namespace IO.FS.Stream
+namespace IO.FS.Stream.Internal
 
 open Lean
 open Lean.JsonRpc
@@ -117,22 +117,22 @@ section
     h.flush
 
   def writeLspMessage (h : FS.Stream) (msg : Message) : IO Unit := do
-    h.writeSerializedLspMessage (toJson msg).compress
+    writeSerializedLspMessage h (toJson msg).compress
 
   def writeLspRequest (h : FS.Stream) (r : Request α) : IO Unit :=
-    h.writeLspMessage r
+    writeLspMessage h r
 
   def writeLspNotification (h : FS.Stream) (n : Notification α) : IO Unit :=
-    h.writeLspMessage n
+    writeLspMessage h n
 
   def writeLspResponse (h : FS.Stream) (r : Response α) : IO Unit :=
-    h.writeLspMessage r
+    writeLspMessage h r
 
   def writeLspResponseError (h : FS.Stream) (e : ResponseError Unit) : IO Unit :=
-    h.writeLspMessage (Message.responseError e.id e.code e.message none)
+    writeLspMessage h (Message.responseError e.id e.code e.message none)
 
   def writeLspResponseErrorWithData (h : FS.Stream) (e : ResponseError α) : IO Unit :=
-    h.writeLspMessage e
+    writeLspMessage h e
 end
 
-end IO.FS.Stream
+end IO.FS.Stream.Internal

--- a/src/Lean/Data/Lsp/Ipc.lean
+++ b/src/Lean/Data/Lsp/Ipc.lean
@@ -21,7 +21,7 @@ Used for testing the Lean server. -/
 
 namespace Lean.Lsp.Ipc
 
-open IO
+open IO FS.Stream.Internal
 open JsonRpc
 
 def ipcStdioConfig : Process.StdioConfig where
@@ -40,33 +40,33 @@ def stdout : IpcM FS.Stream := do
   return FS.Stream.ofHandle (←read).stdout
 
 def writeRequest (r : Request α) : IpcM Unit := do
-  (←stdin).writeLspRequest r
+  writeLspRequest (←stdin) r
 
 def writeNotification (n : Notification α) : IpcM Unit := do
-  (←stdin).writeLspNotification n
+  writeLspNotification (←stdin) n
 
 def shutdown (requestNo : Nat) : IpcM Unit := do
   let hIn ← stdout
   let hOut ← stdin
-  hOut.writeLspRequest ⟨requestNo, "shutdown", Json.null⟩
+  writeLspRequest hOut ⟨requestNo, "shutdown", Json.null⟩
   repeat
-    let shutMsg ← hIn.readLspMessage
+    let shutMsg ← readLspMessage hIn
     match shutMsg with
     | Message.response id result =>
       assert! result.isNull
       if id != requestNo then
         throw <| IO.userError s!"Expected id {requestNo}, got id {id}"
 
-      hOut.writeLspNotification ⟨"exit", Json.null⟩
+      writeLspNotification hOut ⟨"exit", Json.null⟩
       break
     | _ =>  -- ignore other messages in between.
       pure ()
 
 def readMessage : IpcM JsonRpc.Message := do
-  (←stdout).readLspMessage
+  readLspMessage (←stdout)
 
 def readRequestAs (expectedMethod : String) (α) [FromJson α] : IpcM (Request α) := do
-  (←stdout).readLspRequestAs expectedMethod α
+  readLspRequestAs (←stdout) expectedMethod α
 
 /--
 Reads response, discarding notifications and server-to-client requests in between.
@@ -75,7 +75,7 @@ if we do care about such notifications.
 -/
 partial def readResponseAs (expectedID : RequestID) (α) [FromJson α] :
     IpcM (Response α) := do
-  let m ← (←stdout).readLspMessage
+  let m ← readLspMessage (←stdout)
   match m with
   | Message.response id result =>
     if id == expectedID then

--- a/src/Lean/Server/FileWorker.lean
+++ b/src/Lean/Server/FileWorker.lean
@@ -50,7 +50,7 @@ command that the request is looking for and the request sends a "content changed
 namespace Lean.Server.FileWorker
 
 open Lsp
-open IO
+open IO FS.Stream.Internal
 open Snapshots
 open JsonRpc
 
@@ -522,7 +522,7 @@ section Initialization
 
           -- note that because of `server.reportDelayMs`, we cannot simply set `maxDocVersion` here
           -- as that would allow outdated messages to be reported until the delay is over
-        o.writeSerializedLspMessage serialized |>.catchExceptions (fun _ => pure ())
+        writeSerializedLspMessage o serialized |>.catchExceptions (fun _ => pure ())
       return chanOut
 
     getImportClosure? (snap : Language.Lean.InitialSnapshot) : Array Name := Id.run do
@@ -925,7 +925,7 @@ section MainLoop
   variable (hIn : FS.Stream) in
   partial def mainLoop : WorkerM Unit := do
     let mut st ← get
-    let msg ← hIn.readLspMessage
+    let msg ← readLspMessage hIn
     let filterFinishedTasks (acc : PendingRequestMap) (id : RequestID) (task : ServerTask (Except IO.Error Unit))
         : IO PendingRequestMap := do
       if ← task.hasFinished then
@@ -1035,8 +1035,8 @@ where
     return false
 
 def initAndRunWorker (i o e : FS.Stream) (opts : Options) : IO Unit := do
-  let initParams ← i.readLspRequestAs "initialize" InitializeParams
-  let ⟨_, param⟩ ← i.readLspNotificationAs "textDocument/didOpen" LeanDidOpenTextDocumentParams
+  let initParams ← readLspRequestAs i "initialize" InitializeParams
+  let ⟨_, param⟩ ← readLspNotificationAs i "textDocument/didOpen" LeanDidOpenTextDocumentParams
   let doc := param.textDocument
 
   let doc : DocumentMeta := {
@@ -1067,7 +1067,7 @@ def initAndRunWorker (i o e : FS.Stream) (opts : Options) : IO Unit := do
       throw err
 where
   writeErrorDiag (doc : DocumentMeta) (err : Error) : IO Unit := do
-    o.writeLspMessage <| mkPublishDiagnosticsNotification doc #[{
+    writeLspMessage o <| mkPublishDiagnosticsNotification doc #[{
       range := ⟨⟨0, 0⟩, ⟨1, 0⟩⟩,
       fullRange? := some ⟨⟨0, 0⟩, doc.text.utf8PosToLspPos doc.text.source.rawEndPos⟩
       severity? := DiagnosticSeverity.error

--- a/src/Lean/Server/Watchdog.lean
+++ b/src/Lean/Server/Watchdog.lean
@@ -69,7 +69,7 @@ state.
 
 namespace Lean.Server.Watchdog
 
-open IO
+open IO FS.Stream.Internal
 open Lsp
 open JsonRpc
 open System.Uri
@@ -406,7 +406,7 @@ section ServerM
 
   def readMessage : ServerM JsonRpc.Message := do
     let ctx ← read
-    let msg ← ctx.hIn.readLspMessage
+    let msg ← readLspMessage ctx.hIn
     if let some logChan := ctx.logData.chan? then
       logChan.sync.send <| .deserialized .clientToServer msg
     return msg
@@ -415,13 +415,13 @@ section ServerM
     let ctx ← read
     if let some logChan := ctx.logData.chan? then
       logChan.sync.send <| .deserialized .serverToClient msg
-    (← read).hOut.writeLspMessage msg
+    writeLspMessage (← read).hOut msg
 
   def writeSerializedMessage (msg : String) : ServerM Unit := do
     let ctx ← read
     if let some logChan := ctx.logData.chan? then
       logChan.sync.send <| .serialized .serverToClient msg
-    (← read).hOut.writeSerializedLspMessage msg
+    writeSerializedLspMessage (← read).hOut msg
 
   def updateFileWorkers (val : FileWorker) : ServerM Unit := do
     (←read).fileWorkersRef.modify (fun fileWorkers => fileWorkers.insert val.doc.uri val)
@@ -532,7 +532,7 @@ section ServerM
     if ! ((← fw.state.atomically get) matches .running) then
       return
     try
-      fw.stdin.writeLspResponse r
+      writeLspResponse fw.stdin r
     catch _ =>
       pure ()
 
@@ -540,7 +540,7 @@ section ServerM
     if ! ((← fw.state.atomically get) matches .running) then
       return
     try
-      fw.stdin.writeLspResponseError r
+      writeLspResponseError fw.stdin r
     catch _ =>
       pure ()
 
@@ -752,7 +752,7 @@ section ServerM
       while true do
         let msg ←
           try
-            fw.stdout.readLspMessageAsString
+            readLspMessageAsString fw.stdout
           catch _ =>
             let exitCode ← fw.waitForProc
             -- Remove surviving descendant processes, if any, such as from nested builds.
@@ -867,8 +867,8 @@ section ServerM
     updateFileWorkers fw
     let commTask ← forwardMessages fw
     let fw : FileWorker := { fw with commTask? := some commTask }
-    fw.stdin.writeLspRequest ⟨0, "initialize", st.initParams⟩
-    fw.stdin.writeLspNotification {
+    writeLspRequest fw.stdin ⟨0, "initialize", st.initParams⟩
+    writeLspNotification fw.stdin {
       method := "textDocument/didOpen"
       param  := {
         textDocument := {
@@ -885,7 +885,7 @@ section ServerM
     let reqQueue ← st.requestData.getRequestQueue m.uri
     for (_, msg) in reqQueue do
       try
-        fw.stdin.writeLspMessage msg
+        writeLspMessage fw.stdin msg
       catch _ =>
         setWorkerState fw .cannotWrite
         break
@@ -905,7 +905,7 @@ section ServerM
       -- Client closed stdout => Still ensure that file worker is terminated
       pure ()
     try
-      fw.stdin.writeLspMessage (Message.notification "exit" none)
+      writeLspMessage fw.stdin (Message.notification "exit" none)
     catch _ =>
       -- File worker crashed during termination => Treat it as terminated
       pure ()
@@ -932,7 +932,7 @@ section ServerM
       startFileWorker fw.doc
     | WorkerState.running =>
       try
-        fw.stdin.writeLspMessage msg
+        writeLspMessage fw.stdin msg
       catch _ =>
         setWorkerState fw .cannotWrite
 
@@ -1610,7 +1610,7 @@ def mkLeanServerCapabilities : ServerCapabilities := {
 def initAndRunWatchdogAux : ServerM Unit := do
   let st ← read
   try
-    discard $ st.hIn.readLspNotificationAs "initialized" InitializedParams
+    discard $ readLspNotificationAs st.hIn "initialized" InitializedParams
     writeMessage {
       id := RequestID.str "register_lean_watcher"
       method := "client/registerCapability"
@@ -1636,7 +1636,7 @@ def initAndRunWatchdogAux : ServerM Unit := do
   while true do
     let msg: JsonRpc.Message ←
       try
-        st.hIn.readLspMessage
+        readLspMessage st.hIn
       catch _ =>
         /-
         NOTE(WN): It looks like instead of sending the `exit` notification,
@@ -1733,8 +1733,8 @@ def initAndRunWatchdog (args : List String) (i o : FS.Stream) : IO Unit := do
   }
   let importData ← IO.mkRef ⟨Std.TreeMap.empty, Std.TreeMap.empty⟩
   let requestData ← RequestDataMutex.new
-  let initRequest ← i.readLspRequestAs "initialize" InitializeParams
-  o.writeLspResponse {
+  let initRequest ← readLspRequestAs i "initialize" InitializeParams
+  writeLspResponse o {
     id     := initRequest.id
     result := {
       capabilities := mkLeanServerCapabilities


### PR DESCRIPTION
This PR moves some declarations in `Lean.Data.Lsp.Communication` that were polluting the global `IO.FS.Stream` namespace into an internal namespace.