### PR TITLE
chore: add bench metric for longest (re-)build path instructions

### DIFF
--- a/tests/bench/build/README.md
+++ b/tests/bench/build/README.md
@@ -23,6 +23,11 @@ The following metrics are collected from `lakeprof report`:
 - `build/lakeprof/longest build path//wall-clock`
 - `build/lakeprof/longest rebuild path//wall-clock`
 
+The following metrics are collected from a combination of `lakeprof report` and the per-module instructions:
+
+- `build/lakeprof/longest build path//instructions`
+- `build/lakeprof/longest rebuild path//instructions`
+
 The following metrics are collected individually for each module:
 
 - `build/module/<name>//lines`

--- a/tests/bench/build/lakeprof_measurements.py
+++ b/tests/bench/build/lakeprof_measurements.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+# Derives the `build/lakeprof/*` measurements from `lakeprof report` and the
+# existing contents of the measurements file. The results are appended back onto
+# the measurements file.
+#
+# Must be run from the src dir so that lakeprof can collect the metadata it
+# needs.
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def save_measurement(
+    output: Path, metric: str, value: float, unit: str | None = None
+) -> None:
+    data = {"metric": metric, "value": value}
+    if unit is not None:
+        data["unit"] = unit
+    with open(output, "a") as f:
+        f.write(f"{json.dumps(data)}\n")
+
+
+def load_instructions_per_module(output: Path) -> dict[str, float]:
+    pattern = re.compile(r"build/module/(.*)//instructions")
+    instructions: dict[str, float] = {}
+    with open(output) as f:
+        for line in f:
+            data = json.loads(line)
+            if match := pattern.fullmatch(data["metric"]):
+                instructions[match.group(1)] = data["value"]
+    return instructions
+
+
+@dataclass
+class Row:
+    time: float
+    time_frac: float
+    cum_time: float
+    cum_time_frac: float
+    module: str
+
+
+def lakeprof_report(*args: str) -> list[Row]:
+    result = subprocess.run(
+        ["lakeprof", "report", *args, "-j"], capture_output=True, encoding="utf-8"
+    )
+    if result.returncode != 0:
+        print(result.stdout, end="", file=sys.stdout)
+        print(result.stderr, end="", file=sys.stderr)
+        sys.exit(result.returncode)
+    return [Row(*row) for row in json.loads(result.stdout)]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("out", type=Path)
+    args = parser.parse_args()
+    out: Path = args.out
+
+    instructions = load_instructions_per_module(out)
+
+    for flag, name in [("-p", "longest build path"), ("-r", "longest rebuild path")]:
+        rows = lakeprof_report(flag)
+
+        # Total wall-clock time, as reported by lakeprof
+        save_measurement(
+            out, f"build/lakeprof/{name}//wall-clock", rows[-1].cum_time, "s"
+        )
+
+        # Total instructions, computed from lakeprof's modules and our own measurements
+        total_instructions = sum(instructions.get(row.module, 0) for row in rows)
+        save_measurement(
+            out, f"build/lakeprof/{name}//instructions", total_instructions
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/bench/build/run_bench.sh
+++ b/tests/bench/build/run_bench.sh
@@ -43,6 +43,5 @@ echo ">"
 mv lakeprof.log "$SRC_DIR"
 pushd "$SRC_DIR"
 lakeprof report -prc > lakeprof_report.txt
-lakeprof report -pj | jq '{metric: "build/lakeprof/longest build path//wall-clock", value: .[-1][2], unit: "s"}' -c >> "$OUT"
-lakeprof report -rj | jq '{metric: "build/lakeprof/longest rebuild path//wall-clock", value: .[-1][2], unit: "s"}' -c >> "$OUT"
+"$TEST_DIR/bench/build/lakeprof_measurements.py" "$OUT"
 popd


### PR DESCRIPTION
We currently have wall-clock timings for the longest build path and rebuild path, but those are fairly noisy and regressions can easily go undetected. This PR adds instruction count based metrics as well, which should be less noisy.