### PR TITLE
fix: `benchReelab` script

### DIFF
--- a/script/benchReelabRss.lean
+++ b/script/benchReelabRss.lean
@@ -1,5 +1,6 @@
 import Lean.Data.Lsp
 import Lean.Elab.Import
+open IO.FS.Stream.Internal
 open Lean
 open Lean.Lsp
 open Lean.JsonRpc
@@ -86,5 +87,5 @@ def main (args : List String) : IO Unit := do
     IO.println s!"measurement: avg-reelab-rss-delta {avgRSSDelta*1024} b"
 
     let _ ← Ipc.collectDiagnostics requestNo uri versionNo
-    (← Ipc.stdin).writeLspMessage (Message.notification "exit" none)
+    writeLspMessage (← Ipc.stdin) (Message.notification "exit" none)
     discard <| Ipc.waitForExit


### PR DESCRIPTION
This PR fixes a compilation failure in a benchmark introduced in an earlier PR.