### PR TITLE
chore: rename `IO.AsyncList` to `Lean.AsyncList`

### DIFF
--- a/src/Lean/Server/AsyncList.lean
+++ b/src/Lean/Server/AsyncList.lean
@@ -11,7 +11,7 @@ public import Lean.Server.ServerTask
 
 public section
 
-namespace IO
+namespace Lean
 
 universe u v
 
@@ -137,4 +137,4 @@ where
 
 end AsyncList
 
-end IO
+end Lean


### PR DESCRIPTION
This PR renames `IO.AsyncList` to `Lean.AsyncList` to avoid polluting the public `IO` namespace.