### PR TITLE
chore: reduce namespace pollution

### DIFF
--- a/src/Init/Data/Option/Lemmas.lean
+++ b/src/Init/Data/Option/Lemmas.lean
@@ -829,6 +829,9 @@ end choice
 theorem or_eq_right_of_none {o o' : Option α} (h : o = none) : o.or o' = o' := by
   cases h; simp
 
+theorem or_eq_left_of_isSome {o o' : Option α} : o.isSome = true → o.or o' = o := by
+  cases o <;> simp
+
 @[simp, grind =] theorem or_some {o : Option α} : o.or (some a) = some (o.getD a) := by
   cases o <;> rfl
 

--- a/src/Lean/Compiler/NameMangling.lean
+++ b/src/Lean/Compiler/NameMangling.lean
@@ -48,7 +48,7 @@ def mangleAux (s : String) (pos : s.Pos) (r : String) : String :=
     mangleAux s pos (pushHex 8 c.val (r ++ "_U"))
 termination_by pos
 
-public def mangle (s : String) : String :=
+public def Internal.mangle (s : String) : String :=
   mangleAux s s.startPos ""
 
 end String
@@ -120,7 +120,7 @@ def needDisambiguation (prev : Name) (next : String) : Bool :=
 def Name.mangleAux : Name → String
   | Name.anonymous => ""
   | Name.str p s =>
-    let m := String.mangle s
+    let m := String.Internal.mangle s
     match p with
     | Name.anonymous =>
       if checkDisambiguation m m.startPos then "00" ++ m else m
@@ -154,7 +154,7 @@ The mangled name of the name used to create the module initialization function.
 This also used for the library name of a module plugin.
 -/
 public def mkModuleInitializationStem (moduleName : Name) (pkg? : Option PkgId := none) : String :=
-  let pre := pkg?.elim "" (s!"{·.mangle}_")
+  let pre := pkg?.elim "" (s!"{String.Internal.mangle ·}_")
   moduleName.mangle pre
 
 public def mkModuleInitializationPrefix (phases : IRPhases) : String :=
@@ -167,7 +167,7 @@ public def mkModuleInitializationFunctionName (moduleName : Name) (pkg? : Option
   mkModuleInitializationPrefix phases ++ "initialize_" ++ mkModuleInitializationStem moduleName pkg?
 
 public def mkPackageSymbolPrefix (pkg? : Option PkgId) : String :=
-  pkg?.elim "l_" (s!"lp_{·.mangle}_")
+  pkg?.elim "l_" (s!"lp_{String.Internal.mangle ·}_")
 
 -- assumes `s` has been generated `Name.mangle n ""`
 def Name.demangleAux (s : String) (p₀ : s.Pos) (res : Name)

--- a/src/Lean/Elab/GuardMsgs.lean
+++ b/src/Lean/Elab/GuardMsgs.lean
@@ -22,11 +22,14 @@ See the docstrings on the individual commands.
 
 open Lean Parser.Tactic Elab Command
 
+namespace Lean
+
 register_builtin_option guard_msgs.diff : Bool := {
   defValue := true
   descr := "When true, show a diff between expected and actual messages if they don't match. "
 }
 
+end Lean
 
 namespace Lean.Elab.Tactic.GuardMsgs
 

--- a/src/Lean/Elab/PreDefinition/WF/Preprocess.lean
+++ b/src/Lean/Elab/PreDefinition/WF/Preprocess.lean
@@ -58,10 +58,14 @@ The simplifier is used to perform steps 2 (using simprocs) and 3 (using rewrite 
 
 open Lean Meta
 
+namespace Lean
+
 register_builtin_option wf.preprocess : Bool := {
   defValue := true
   descr := "pre-process definitions defined by well-founded recursion with the `wf_preprocess` simp set"
 }
+
+end Lean
 
 namespace Lean.Elab.WF
 

--- a/src/Lean/Elab/Tactic/AsAuxLemma.lean
+++ b/src/Lean/Elab/Tactic/AsAuxLemma.lean
@@ -12,6 +12,8 @@ public section
 
 open Lean Meta Elab Tactic Parser.Tactic
 
+namespace Lean.Elab.Tactic
+
 @[builtin_tactic as_aux_lemma]
 def elabAsAuxLemma : Lean.Elab.Tactic.Tactic
 | `(tactic| as_aux_lemma => $s) => withMainContext do
@@ -23,3 +25,5 @@ def elabAsAuxLemma : Lean.Elab.Tactic.Tactic
   let e ← mkAuxTheorem (← mvarId.getType) e
   mvarId.assign e
 | _ => throwError "Invalid as_aux_lemma syntax"
+
+end Lean.Elab.Tactic

--- a/src/Lean/Elab/Tactic/BoolToPropSimps.lean
+++ b/src/Lean/Elab/Tactic/BoolToPropSimps.lean
@@ -11,6 +11,10 @@ public import Lean.Meta.Tactic.Simp.Attr
 
 public section
 
+namespace Lean
+
 builtin_initialize bool_to_prop : Lean.Meta.SimpExtension ←
   Lean.Meta.registerSimpAttr `bool_to_prop
     "simp lemmas converting boolean expressions in terms of `decide` into propositional statements"
+
+end Lean

--- a/src/Lean/Elab/Tactic/Induction.lean
+++ b/src/Lean/Elab/Tactic/Induction.lean
@@ -18,11 +18,15 @@ import Lean.Meta.Tactic.Generalize
 
 public section
 
+namespace Lean
+
 register_builtin_option tactic.customEliminators : Bool := {
   defValue := true
   descr    := "enable using custom eliminators in the 'induction' and 'cases' tactics \
     defined using the '@[induction_eliminator]' and '@[cases_eliminator]' attributes"
 }
+
+end Lean
 
 end
 

--- a/src/Lean/Elab/Tactic/Simpa.lean
+++ b/src/Lean/Elab/Tactic/Simpa.lean
@@ -12,6 +12,8 @@ public import Lean.Elab.App
 
 public section
 
+namespace Lean
+
 /--
 Enables the 'unnecessary `simpa`' linter. This will report if a use of
 `simpa` could be proven using `simp` or `simp at h` instead.
@@ -20,6 +22,8 @@ register_option linter.unnecessarySimpa : Bool := {
   defValue := true
   descr := "enable the 'unnecessary simpa' linter"
 }
+
+end Lean
 
 namespace Lean.Elab.Tactic.Simpa
 

--- a/src/Lean/Elab/Tactic/TreeTacAttr.lean
+++ b/src/Lean/Elab/Tactic/TreeTacAttr.lean
@@ -12,5 +12,9 @@ public section
 
 open Lean.Meta
 
+namespace Std.Internal
+
 builtin_initialize treeTacExt : SimpExtension
   ← registerSimpAttr `Std.Internal.tree_tac "simp theorems used by internal DTreeMap lemmas"
+
+end Std.Internal

--- a/src/Lean/Meta/CasesInfo.lean
+++ b/src/Lean/Meta/CasesInfo.lean
@@ -11,6 +11,8 @@ import Init.Data.Range.Polymorphic.Iterators
 
 open Lean Meta
 
+namespace Lean
+
 /-!
 This modules defines the `CasesInfo` data structure and functions to obtain it.
 It contains information about the structure of casesOn-like functions, namely of
@@ -81,3 +83,5 @@ public def getCasesInfo? (declName : Name) : CoreM (Option CasesInfo) := do
             let ctorVal ← getConstInfoCtor ctorName
             return .ctor ctorName ctorVal.numFields
       return some { declName, indName, arity, discrPos, altsRange, altNumParams }
+
+end Lean

--- a/src/Lean/Meta/Constructions/CtorIdx.lean
+++ b/src/Lean/Meta/Constructions/CtorIdx.lean
@@ -14,6 +14,8 @@ import Lean.Linter.Deprecated
 
 open Lean Meta
 
+namespace Lean
+
 register_builtin_option genCtorIdx : Bool := {
   defValue := true
   descr    := "generate the `CtorIdx` functions for inductive datatypes"
@@ -113,3 +115,5 @@ public def mkCtorIdx (indName : Name) : MetaM Unit :=
         modifyEnv fun env => addProtected env aliasName
         setReducibleAttribute aliasName
         Lean.Linter.setDeprecated aliasName { newName? := some declName, since? := "2025-08-25" }
+
+end Lean

--- a/src/Lean/Meta/Constructions/RecOn.lean
+++ b/src/Lean/Meta/Constructions/RecOn.lean
@@ -13,6 +13,8 @@ public section
 
 open Lean Meta
 
+namespace Lean
+
 def mkRecOn (n : Name) : MetaM Unit := do
   let .recInfo recInfo ← getConstInfo (mkRecName n)
     | throwError "{mkRecName n} not a recinfo"
@@ -35,3 +37,5 @@ def mkRecOn (n : Name) : MetaM Unit := do
   setReducibleAttribute decl.name
   modifyEnv fun env => markAuxRecursor env decl.name
   modifyEnv fun env => addProtected env decl.name
+
+end Lean

--- a/src/Lean/Meta/HasNotBit.lean
+++ b/src/Lean/Meta/HasNotBit.lean
@@ -15,6 +15,8 @@ Utility functions around `Nat.hasNotBit`, used by sparse cases.
 
 open Lean Meta
 
+namespace Lean
+
 public def mkHasNotBit (e : Expr) (ns : Array Nat) : Expr := Id.run do
   let mut mask := 0
   for n in ns do
@@ -56,3 +58,5 @@ public def refutableHasNotBit? (e : Expr) : MetaM (Option Expr) := do
     else
       return none
   | _ => return none
+
+end Lean

--- a/src/Lean/Meta/NatTable.lean
+++ b/src/Lean/Meta/NatTable.lean
@@ -16,6 +16,8 @@ open Lean Meta
 This module provides builder for efficient `Nat → …` functions based on binary decision trees.
 -/
 
+namespace Lean
+
 /--
 Builds an expression of type `Nat → $type` that returns the `es[i]`, using binary search.
 The array must be non-empty.
@@ -34,3 +36,5 @@ public def mkNatLookupTable (i : Expr) (type : Expr) (es : Array Expr) : MetaM E
         let high ← go mid stop
         return mkApp4 (mkConst ``cond [u]) type (mkApp2 (mkConst ``Nat.ble) i (mkRawNatLit (mid-1))) low high
     go 0 es.size
+
+end Lean

--- a/src/Std/Data/Internal/List/Associative.lean
+++ b/src/Std/Data/Internal/List/Associative.lean
@@ -3508,9 +3508,6 @@ theorem getKey?_insertList_of_mem_of_not_mem [BEq α] [LawfulBEq α]
     List.getKey? k (insertList l toInsert) = some k := by
   simp only [List.getKey?_insertList_of_contains_eq_false_right not_contains, getKey?_eq_some contains]
 
-theorem _root_.Option.or_eq_left_of_isSome {o o' : Option α} : o.isSome = true → o.or o' = o := by
-  cases o <;> simp
-
 theorem insertListIfNew_perm_insertList [BEq α] [EquivBEq α] {l₁ l₂ : List ((a : α) × β a)}
     (hd₁ : DistinctKeys l₁) (hd₂ : DistinctKeys l₂) :
     List.Perm (insertListIfNew l₁ l₂) (insertList l₂ l₁) := by

--- a/tests/elab/demangling.lean
+++ b/tests/elab/demangling.lean
@@ -44,17 +44,17 @@ private def checkRoundTrip (label : String) (parts : List (String ⊕ Nat)) : IO
   checkName s!"roundtrip {label}" demangled name
 
 -- ============================================================================
--- String.mangle
+-- String.Internal.mangle
 -- ============================================================================
 
-#eval check "mangle alphanumeric" (String.mangle "hello") "hello"
-#eval check "mangle underscore" (String.mangle "a_b") "a__b"
-#eval check "mangle double underscore" (String.mangle "__") "____"
-#eval check "mangle dot" (String.mangle ".") "_x2e"
-#eval check "mangle a.b" (String.mangle "a.b") "a_x2eb"
-#eval check "mangle lambda" (String.mangle "\u03bb") "_u03bb"
-#eval check "mangle astral" (String.mangle (String.singleton (Char.ofNat 0x1d55c))) "_U0001d55c"
-#eval check "mangle empty" (String.mangle "") ""
+#eval check "mangle alphanumeric" (String.Internal.mangle "hello") "hello"
+#eval check "mangle underscore" (String.Internal.mangle "a_b") "a__b"
+#eval check "mangle double underscore" (String.Internal.mangle "__") "____"
+#eval check "mangle dot" (String.Internal.mangle ".") "_x2e"
+#eval check "mangle a.b" (String.Internal.mangle "a.b") "a_x2eb"
+#eval check "mangle lambda" (String.Internal.mangle "\u03bb") "_u03bb"
+#eval check "mangle astral" (String.Internal.mangle (String.singleton (Char.ofNat 0x1d55c))) "_U0001d55c"
+#eval check "mangle empty" (String.Internal.mangle "") ""
 
 -- ============================================================================
 -- Name.mangle
@@ -164,21 +164,21 @@ private def checkRoundTrip (label : String) (parts : List (String ⊕ Nat)) : IO
 -- ============================================================================
 
 #eval do
-  let mangled := Name.mangle `Lean.Meta.foo (s!"lp_{String.mangle "std"}_")
+  let mangled := Name.mangle `Lean.Meta.foo (s!"lp_{String.Internal.mangle "std"}_")
   checkSome "lp_ simple" (demangleSymbol mangled) "Lean.Meta.foo (std)"
 
 #eval do
-  let mangled := Name.mangle `Lean.Meta.foo (s!"lp_{String.mangle "my_pkg"}_")
+  let mangled := Name.mangle `Lean.Meta.foo (s!"lp_{String.Internal.mangle "my_pkg"}_")
   checkSome "lp_ underscore pkg" (demangleSymbol mangled) "Lean.Meta.foo (my_pkg)"
 
 #eval do
   -- Package with escaped chars (hyphen → _x2d): split must not break mid-escape
-  let mangled := Name.mangle `Lean.Meta.foo (s!"lp_{String.mangle "my-pkg"}_")
+  let mangled := Name.mangle `Lean.Meta.foo (s!"lp_{String.Internal.mangle "my-pkg"}_")
   checkSome "lp_ escaped pkg" (demangleSymbol mangled) "Lean.Meta.foo (my-pkg)"
 
 #eval do
   let name := mkName [.inl "_private", .inl "X", .inr 0, .inl "Y", .inl "foo"]
-  let mangled := name.mangle (s!"lp_{String.mangle "pkg"}_")
+  let mangled := name.mangle (s!"lp_{String.Internal.mangle "pkg"}_")
   checkSome "lp_ private decl" (demangleSymbol mangled) "Y.foo [private] (pkg)"
 
 -- ============================================================================
@@ -194,7 +194,7 @@ private def checkRoundTrip (label : String) (parts : List (String ⊕ Nat)) : IO
   checkSome "init l_ private" (demangleSymbol mangled) "[init] Y.foo [private]"
 
 #eval do
-  let mangled := Name.mangle `Lean.Meta.foo (s!"lp_{String.mangle "std"}_")
+  let mangled := Name.mangle `Lean.Meta.foo (s!"lp_{String.Internal.mangle "std"}_")
   checkSome "init lp_" (demangleSymbol ("_init_" ++ mangled))
     "[init] Lean.Meta.foo (std)"
 
@@ -208,7 +208,7 @@ private def checkRoundTrip (label : String) (parts : List (String ⊕ Nat)) : IO
   (demangleSymbol "initialize_l_Lean_Meta_foo") "[module_init] Lean.Meta.foo"
 
 #eval do
-  let mangled := Name.mangle `Lean.Meta.foo (s!"lp_{String.mangle "std"}_")
+  let mangled := Name.mangle `Lean.Meta.foo (s!"lp_{String.Internal.mangle "std"}_")
   checkSome "initialize lp_" (demangleSymbol ("initialize_" ++ mangled))
     "[module_init] Lean.Meta.foo (std)"
 


### PR DESCRIPTION
This PR moves various declarations that were polluting public namespaces into internal namespaces (like `Lean`).