### PR TITLE
chore: fix const_fold benchmark

### DIFF
--- a/tests/compile_bench/const_fold.lean.init.sh
+++ b/tests/compile_bench/const_fold.lean.init.sh
@@ -4,4 +4,8 @@ if [[ -n $TEST_BENCH ]]; then
   TEST_ARGS=( 23 )
 fi
 
+# When interpreted
 set_stack_size_to_maximum
+
+# When compiled
+export LEAN_STACK_SIZE_KB=4194304


### PR DESCRIPTION
This PR fixes the const_fold benchmark on some machines.

As far as I can tell, the ulimit approach did not work here, but we never noticed because the actual memory usage stayed *just* below the default stack size limit. Something about my dev machine pushed it over the limit (probably a difference between the gcc it uses on my machine vs the llvm it uses on the bench machine), so it just stack overflowed every time I tried to run it.