### PR TITLE
feat: make Fin.foldl reduce in the kernel

### DIFF
--- a/src/Init/Data/Fin/Fold.lean
+++ b/src/Init/Data/Fin/Fold.lean
@@ -24,9 +24,9 @@ nesting to the left.
 Example:
  * `Fin.foldl 3 (· + ·.val) (0 : Nat) = ((0 + (0 : Fin 3).val) + (1 : Fin 3).val) + (2 : Fin 3).val`
 -/
-@[inline] def foldl (n) (f : α → Fin n → α) (init : α) : α := loop init 0 where
-  /-- Inner loop for `Fin.foldl`. `Fin.foldl.loop n f x i = f (f (f x i) ...) (n-1)`  -/
-  @[specialize] loop (x : α) (i : Nat) : α :=
+@[inline, expose] def foldl (n) (f : α → Fin n → α) (init : α) : α := loop init 0 where
+  /-- Inner loop for `Fin.foldl`. `Fin.foldl.loop n f x i = f (f (f x i) ...) (n-1)`. -/
+  @[specialize, semireducible] loop (x : α) (i : Nat) : α :=
     if h : i < n then loop (f x ⟨i, h⟩) (i+1) else x
   termination_by n - i
 

--- a/tests/elab/finFoldKernelReduce.lean
+++ b/tests/elab/finFoldKernelReduce.lean
@@ -1,0 +1,5 @@
+module
+
+-- `Fin.foldl` and `Fin.foldr` reduce in the kernel.
+example : Fin.foldl 8 (fun a i => a + i.val) 0 = 28 := by decide
+example : Fin.foldr 8 (fun i a => a + i.val) 0 = 28 := by decide


### PR DESCRIPTION
This PR makes `Fin.foldl` reduce in the kernel by marking its inner `loop` `semireducible` (well-founded definitions are `irreducible` by default) and exposing `foldl`, so the kernel's special support for well-founded recursion on `Nat` applies. Previously `Fin.foldl` got stuck under `decide`/`#reduce`/`Decidable`, unlike the already-reducing `Fin.foldr`:

```lean
example : Fin.foldl 8 (fun a i => a + i.val) 0 = 28 := by decide  -- now succeeds
```

The definition and all lemmas are unchanged.
