### PR TITLE
fix: plug Nat argument leak in lean_byte_array_copy_slice

### DIFF
--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -2591,11 +2591,13 @@ extern "C" LEAN_EXPORT obj_res lean_byte_array_push(obj_arg a, uint8 b) {
     return r;
 }
 
-    extern "C" LEAN_EXPORT obj_res lean_byte_array_copy_slice(b_obj_arg src, obj_arg o_src_off, obj_arg dest, obj_arg o_dest_off, obj_arg o_len, bool exact) {
+extern "C" LEAN_EXPORT obj_res lean_byte_array_copy_slice(b_obj_arg src, obj_arg o_src_off, obj_arg dest, obj_arg o_dest_off, obj_arg o_len, bool exact) {
     size_t ssz = lean_sarray_size(src);
     size_t dsz = lean_sarray_size(dest);
     size_t src_off = lean_nat_to_size_t(o_src_off);
     if (src_off > ssz) {
+        lean_dec(o_dest_off);
+        lean_dec(o_len);
         return dest;
     }
     size_t len = std::min(lean_nat_to_size_t(o_len), ssz - src_off);


### PR DESCRIPTION
This PR fixes a memory leak in `lean_byte_array_copy_slice`. The `destOff` and `len` arguments are owned, but the early return taken when `srcOff` is past the end of `src` dropped them without decrementing their reference counts, leaking them whenever they are heap-allocated bignums (i.e. exceeding `2^63 - 1` on 64-bit systems). Scalar `Nat`s are unaffected, which is why this went unnoticed.

Demonstration that the leak is real, using the program below: it takes the early-return path (`srcOff = 1` on an empty `src`) with two freshly allocated bignum arguments per iteration. The bignum base is taken from the command line because a literal would be compiled to a persistent constant, which is exempt from reference counting.

```lean
def rss : IO Nat := do
  let status ← IO.FS.readFile "/proc/self/status"
  let some line := status.splitOn "\n" |>.find? (·.startsWith "VmRSS") | return 0
  return (String.ofList (line.toList.filter Char.isDigit)).toNat?.getD 0

def main (args : List String) : IO Unit := do
  let iters := (args[0]?.bind (·.toNat?)).getD 1000000
  let base := (args[1]?.bind (·.toNat?)).getD 0
  let src := ByteArray.mk #[]
  let mut dest := ByteArray.mk #[1, 2, 3]
  IO.println s!"RSS before: {← rss} kB"
  for i in [0:iters] do
    dest := src.copySlice 1 dest (base + i) (base + i + 1)
  IO.println s!"RSS after:  {← rss} kB"
```

Compiled and run for 10^7 iterations (`repro 10000000 18446744073709551616`), same stage1 toolchain with and without this fix (VmRSS before → after the loop):

| offsets | without fix | with fix |
| --- | --- | --- |
| bignum (`base = 2^64`) | 9020 kB → 1260924 kB | 8816 kB → 8912 kB |
| scalar (`base = 0`, control) | 8840 kB → 8888 kB | 8804 kB → 8840 kB |

The observed growth without the fix is roughly 128 bytes per call: two leaked `Nat` objects and their limb storage. As the control row shows, small `Nat` arguments (up to `2^63 - 1`) are scalars and never leaked. Offsets derived from real byte-array sizes are always scalar on 64-bit platforms, so this is essentially a hygiene fix, though huge `destOff`/`len` values can also arise from ordinary `Nat` arithmetic independent of any array's size (as in the repro, which uses an empty `src`).

🤖 Prepared with Claude Code
