### PR TITLE
fix: pass the message to dbgTraceIfShared borrowed

### DIFF
--- a/src/Init/Util.lean
+++ b/src/Init/Util.lean
@@ -24,7 +24,7 @@ def dbgTraceVal {α : Type u} [ToString α] (a : α) : α :=
 set_option linter.unusedVariables.funArgs false in
 /-- Display the given message if `a` is shared, that is, RC(a) > 1 -/
 @[never_extract, extern "lean_dbg_trace_if_shared"]
-def dbgTraceIfShared {α : Type u} (s : String) (a : α) : α := a
+def dbgTraceIfShared {α : Type u} (s : @& String) (a : α) : α := a
 
 /-- Print stack trace to stderr before evaluating given closure. Currently supported on Linux only. -/
 @[never_extract, extern "lean_dbg_stack_trace"]

--- a/src/include/lean/lean.h
+++ b/src/include/lean/lean.h
@@ -2922,7 +2922,7 @@ static inline float lean_unbox_float32(b_lean_obj_arg o) {
 
 LEAN_EXPORT lean_object * lean_dbg_trace(lean_obj_arg s, lean_obj_arg fn);
 LEAN_EXPORT lean_object * lean_dbg_sleep(uint32_t ms, lean_obj_arg fn);
-LEAN_EXPORT lean_object * lean_dbg_trace_if_shared(lean_obj_arg s, lean_obj_arg a);
+LEAN_EXPORT lean_object * lean_dbg_trace_if_shared(b_lean_obj_arg s, lean_obj_arg a);
 
 /* IO Helper functions */
 

--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -2795,7 +2795,7 @@ extern "C" LEAN_EXPORT object * lean_dbg_sleep(uint32 ms, obj_arg fn) {
     return lean_apply_1(fn, lean_box(0));
 }
 
-extern "C" LEAN_EXPORT object * lean_dbg_trace_if_shared(obj_arg s, obj_arg a) {
+extern "C" LEAN_EXPORT object * lean_dbg_trace_if_shared(b_obj_arg s, obj_arg a) {
     if (!lean_is_scalar(a) && !lean_is_exclusive(a)) {
         io_eprintln(mk_string(std::string("shared RC ") + lean_string_cstr(s)));
     }


### PR DESCRIPTION
This PR changes `dbgTraceIfShared` to take its message borrowed (`s : @& String`), with the matching `b_obj_arg`/`b_lean_obj_arg` adjustments in the runtime and header. The C implementation only reads the string and never consumed it, so the owned argument leaked on every call; the leak goes unnoticed in typical use because string literals are compiled to persistent constants, which are exempt from reference counting. A dynamically constructed message leaks once per call. Borrowing matches what the implementation actually does and spares callers a reference-count operation. Found while auditing the runtime for the pattern fixed in #14271.

Demonstration, with a fresh message built from the loop counter each iteration (`a` is a unique array throughout, so nothing is printed and the identity fast path is measured):

```lean
def main (args : List String) : IO Unit := do
  let iters := (args[0]?.bind (·.toNat?)).getD 1000000
  let mut acc : Array Nat := Array.mkEmpty 0
  for i in [0:iters] do
    acc := dbgTraceIfShared (toString i) (acc.push 0)
  IO.println s!"acc.size = {acc.size}"
```

For 5 * 10^6 iterations, VmRSS grows to 306 MB without this change and to 97 MB with it; the remaining growth is the 5-million-element array itself (about 90 MB including capacity slack), so the difference of roughly 210 MB is the leaked messages, about 42 bytes per call. (The baseline measurement used v4.30.0-rc1 and the fixed measurement a master-based stage1, since the borrow annotation changes the calling convention on both sides at once and does not permit a single-toolchain A/B.)

🤖 Prepared with Claude Code
