### PR TITLE
fix: guard against size_t overflow in lean_byte_array_copy_slice

### DIFF
--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -2603,8 +2603,8 @@ extern "C" LEAN_EXPORT obj_res lean_byte_array_push(obj_arg a, uint8 b) {
     if (dest_off > dsz) {
         dest_off = dsz;
     }
-    // `src` and `dest` may alias, so `dest_off + len` is only bounded by twice the address
-    // space and can overflow on 32-bit systems; the result is then unrepresentable.
+    // Unlike pointer arrays, a byte array's size can exceed `LEAN_MAX_SMALL_NAT` (elements are
+    // 1 byte), so with `src`/`dest` aliasing `dest_off + len` can overflow on 32-bit systems.
     if (len > SIZE_MAX - dest_off)
         lean_internal_panic_out_of_memory();
     size_t new_dsz = std::max(dsz, dest_off + len);

--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -2603,6 +2603,10 @@ extern "C" LEAN_EXPORT obj_res lean_byte_array_push(obj_arg a, uint8 b) {
     if (dest_off > dsz) {
         dest_off = dsz;
     }
+    // `src` and `dest` may alias, so `dest_off + len` is only bounded by twice the address
+    // space and can overflow on 32-bit systems; the result is then unrepresentable.
+    if (len > SIZE_MAX - dest_off)
+        lean_internal_panic_out_of_memory();
     size_t new_dsz = std::max(dsz, dest_off + len);
     object * r = lean_sarray_ensure_exclusive(lean_sarray_ensure_capacity(dest, new_dsz, exact));
     lean_to_sarray(r)->m_size = new_dsz;


### PR DESCRIPTION
This PR guards `lean_byte_array_copy_slice` against `size_t` overflow when computing `destOff + len`. **This is only an issue on 32-bit systems** (in practice wasm32); on 64-bit systems the overflow would require an 8 EB array and is unreachable.

For two distinct arrays the sum is safe, since the sizes of live buffers cannot together exceed the address space. But `src` and `dest` may be the same array (`ByteArray.copyWithin`'s reference implementation does exactly this), and then `destOff + len` is bounded only by twice the array size, wrapping when the array exceeds `SIZE_MAX / 2`: 2 GB on wasm32, whose linear memory can reach 4 GB. The wrapped value leaves `new_dsz` too small while `memcpy` still writes `len` bytes at `destOff`, an out-of-bounds write past the buffer. The guard panics via the out-of-memory convention already used by `lean_nat_to_size_t` for sizes that cannot be represented.

Found while reviewing https://github.com/leanprover/lean4/pull/14158 (feat: add ByteArray.copyWithin), which ships the same guard in `lean_byte_array_copy_within`. The sibling doubling overflow in `lean_sarray_ensure_capacity` is fixed in https://github.com/leanprover/lean4/pull/14274.

🤖 Prepared with Claude Code
