### PR TITLE
fix: respect `pp.instantiateMVars` while pretty-printing goals

### DIFF
--- a/src/Lean/Meta/PPGoal.lean
+++ b/src/Lean/Meta/PPGoal.lean
@@ -74,6 +74,7 @@ def getGoalPrefix (mvarDecl : MetavarDecl) : String :=
   else
     "⊢ "
 
+-- This should be kept in sync with Lean.Widget.goalToInteractive
 def ppGoal (mvarId : MVarId) : MetaM Format := do
   match (← getMCtx).findDecl? mvarId with
   | none          => return "unknown goal"

--- a/src/Lean/Meta/PPGoal.lean
+++ b/src/Lean/Meta/PPGoal.lean
@@ -7,6 +7,7 @@ module
 
 prelude
 public import Lean.Meta.InferType
+import Lean.PrettyPrinter.Delaborator.Options
 
 public section
 
@@ -80,59 +81,62 @@ def ppGoal (mvarId : MVarId) : MetaM Format := do
     let indent         := 2 -- Use option
     let ppAuxDecls     := pp.auxDecls.get (← getOptions)
     let ppImplDetailHyps := pp.implementationDetailHyps.get (← getOptions)
+    -- We use instantiateMVars for two reasons: comparing types of variables for grouping them
+    -- and judging the size of let values for `pp.showLetValues.threshold`. Both of these calls
+    -- need to be conditional on this option. Otherwise, we just use `ppExpr`s built-in
+    -- handling of `pp.instantiateMVars`
+    let ppInstantiateMVars := pp.instantiateMVars.get (← getOptions)
     -- Heuristic: synthetic opaque metavariables are only used by tactics,
     -- and tactics should always be creating synthetic opaque metavariables for new goals.
     let tactic         := mvarDecl.kind.isSyntheticOpaque
     let lctx           := mvarDecl.lctx
-    let lctx           := lctx.sanitizeNames.run' { options := (← getOptions) }
+    let lctx           := lctx.sanitizeNames.run' { options := (← getOptions) } |>.run
     withLCtx lctx mvarDecl.localInstances do
-      -- The following two `let rec`s are being used to control the generated code size.
-      -- Then should be remove after we rewrite the compiler in Lean
-      let rec pushPending (ids : List Name) (type? : Option Expr) (fmt : Format) : MetaM Format := do
+      let pushPending (ids : List Name) (type? : Option Expr) (fmt : Format) : MetaM Format := do
         if ids.isEmpty then
           return fmt
         else
           let fmt := addLine fmt
-          match type? with
-          | none      => return fmt
-          | some type =>
-            let typeFmt ← ppExpr type
-            return fmt ++ (Format.joinSep ids.reverse (format " ") ++ " :" ++ Format.nest indent (Format.line ++ typeFmt)).group
-      let rec ppVars (varNames : List Name) (prevType? : Option Expr) (fmt : Format) (localDecl : LocalDecl) : MetaM (List Name × Option Expr × Format) := do
+          let some type := type? | unreachable!
+          let typeFmt ← ppExpr type
+          return fmt ++ (Format.joinSep ids.reverse (format " ") ++ " :" ++ Format.nest indent (Format.line ++ typeFmt)).group
+      let mut varNames : List Name := []
+      let mut prevType? : Option Expr := none
+      let mut fmt : Format := .nil
+      for localDecl in lctx do
+        if !ppAuxDecls && localDecl.isAuxDecl || !ppImplDetailHyps && localDecl.isImplementationDetail then
+          continue
         match localDecl with
         | .cdecl _ _ varName type ..
         | .ldecl _ _ varName type (nondep := true) .. =>
           let varName := varName.simpMacroScopes
-          let type ← instantiateMVars type
+          let type ← if ppInstantiateMVars then instantiateMVars type else pure type
           if prevType? == none || prevType? == some type then
-            return (varName :: varNames, some type, fmt)
-          else do
-            let fmt ← pushPending varNames prevType? fmt
-            return ([varName], some type, fmt)
+            varNames := varName :: varNames
+            prevType? := some type
+          else
+            fmt ← pushPending varNames prevType? fmt
+            varNames := [varName]
+            prevType? := some type
         | .ldecl _ _ varName type val (nondep := false) .. => do
           let varName := varName.simpMacroScopes
-          let fmt ← pushPending varNames prevType? fmt
-          let fmt  := addLine fmt
-          let type ← instantiateMVars type
+          fmt ← pushPending varNames prevType? fmt
+          fmt := addLine fmt
           let typeFmt ← ppExpr type
           let mut fmtElem  := format varName ++ " : " ++ typeFmt
-          let val ← instantiateMVars val
+          let val ← if ppInstantiateMVars then instantiateMVars val else pure val
           if ← ppGoal.shouldShowLetValue tactic val then
             let valFmt ← ppExpr val
             fmtElem := fmtElem ++ " :=" ++ Format.nest indent (Format.line ++ valFmt)
           else
             fmtElem := fmtElem ++ " := ⋯"
-          let fmt := fmt ++ fmtElem.group
-          return ([], none, fmt)
-      let (varNames, type?, fmt) ← lctx.foldlM (init := ([], none, Format.nil)) fun (varNames, prevType?, fmt) (localDecl : LocalDecl) =>
-         if !ppAuxDecls && localDecl.isAuxDecl || !ppImplDetailHyps && localDecl.isImplementationDetail then
-           return (varNames, prevType?, fmt)
-         else
-           ppVars varNames prevType? fmt localDecl
-      let fmt ← pushPending varNames type? fmt
-      let fmt := addLine fmt
-      let typeFmt ← ppExpr (← instantiateMVars mvarDecl.type)
-      let fmt := fmt ++ getGoalPrefix mvarDecl ++ Format.nest indent typeFmt
+          fmt := fmt ++ fmtElem.group
+          varNames := []
+          prevType? := none
+      fmt ← pushPending varNames prevType? fmt
+      fmt := addLine fmt
+      let typeFmt ← ppExpr mvarDecl.type
+      fmt := fmt ++ getGoalPrefix mvarDecl ++ Format.nest indent typeFmt
       match mvarDecl.userName with
       | Name.anonymous => return fmt
       | name           => return "case " ++ format name.eraseMacroScopes ++ "\n" ++ fmt

--- a/src/Lean/Meta/Tactic/Util.lean
+++ b/src/Lean/Meta/Tactic/Util.lean
@@ -7,7 +7,7 @@ module
 
 prelude
 public import Lean.Util.ForEachExprWhere
-public import Lean.Meta.PPGoal
+public import Lean.Meta.InferType
 import Lean.Meta.AppBuilder
 
 public section

--- a/src/Lean/Util/PPExt.lean
+++ b/src/Lean/Util/PPExt.lean
@@ -8,6 +8,7 @@ module
 prelude
 public import Lean.Elab.InfoTree.Types
 import Init.Data.Format.Macro
+import Lean.PrettyPrinter.Delaborator.Options
 
 public section
 
@@ -68,7 +69,7 @@ builtin_initialize ppExt : EnvExtension PPFns ←
 
 def ppExprWithInfos (ctx : PPContext) (e : Expr) : BaseIO FormatWithInfos := do
   if pp.raw.get ctx.opts then
-    let e := instantiateMVarsCore ctx.mctx e |>.1
+    let e := if pp.instantiateMVars.get ctx.opts then instantiateMVarsCore ctx.mctx e |>.1 else e
     return format (toString e)
   else
     match (← ppExt.getState ctx.env |>.ppExprWithInfos ctx e |>.toBaseIO) with

--- a/src/Lean/Widget/Diff.lean
+++ b/src/Lean/Widget/Diff.lean
@@ -206,7 +206,9 @@ def diffHypothesesBundle (useAfter : Bool) (ctx₀  : LocalContext) (h₁ : Inte
     if !(ctx₀.contains fvid) then
       if let some decl₀ := ctx₀.findFromUserName? (.mkSimple ppName) then
         -- on ctx₀ there is an fvar with the same name as this one.
-        let t₀ ← instantiateMVars decl₀.type
+        let mut t₀ := decl₀.type
+        if getPPInstantiateMVars (← getOptions) then
+          t₀ ← instantiateMVars t₀
         return ← withTypeDiff t₀ h₁
       else
         if useAfter then
@@ -219,7 +221,9 @@ where
   withTypeDiff (t₀ : Expr) (h₁ : InteractiveHypothesisBundle) : MetaM InteractiveHypothesisBundle := do
     let some x₁ := h₁.fvarIds[0]?
       | throwError "internal error: empty fvar list!"
-    let t₁ ← instantiateMVars =<< inferType (Expr.fvar x₁)
+    let mut t₁ ← inferType (Expr.fvar x₁)
+    if getPPInstantiateMVars (← getOptions) then
+      t₁ ← instantiateMVars t₁
     let tδ ← exprDiff t₀ t₁ useAfter
     let c₁ ← addDiffTags useAfter tδ h₁.type
     return {h₁ with type := c₁}
@@ -238,10 +242,14 @@ def diffInteractiveGoal (useAfter : Bool) (g₀ : MVarId) (i₁ : InteractiveGoa
   let hs₁ ← diffHypotheses useAfter lctx₀ i₁.hyps
   let i₁ := {i₁ with hyps := hs₁}
   let g₁ := i₁.mvarId
-  let t₀ ← instantiateMVars <|← inferType (Expr.mvar g₀)
+  let mut t₀ ← inferType (Expr.mvar g₀)
+  if getPPInstantiateMVars (← getOptions) then
+    t₀ ← instantiateMVars t₀
   let some md₁ := (← getMCtx).findDecl? g₁
     | throwError "Unknown goal {g₁}"
-  let t₁ ← instantiateMVars md₁.type
+  let mut t₁ := md₁.type
+  if getPPInstantiateMVars (← getOptions) then
+    t₁ ← instantiateMVars t₁
   let tδ ← exprDiff t₀ t₁ useAfter
   let c₁ ← addDiffTags useAfter tδ i₁.type
   let i₁ := {i₁ with type := c₁, isInserted? := false}

--- a/src/Lean/Widget/InteractiveGoal.lean
+++ b/src/Lean/Widget/InteractiveGoal.lean
@@ -160,6 +160,7 @@ open Meta in
 def goalToInteractive (mvarId : MVarId) : MetaM InteractiveGoal := do
   let ppAuxDecls := pp.auxDecls.get (← getOptions)
   let ppImplDetailHyps := pp.implementationDetailHyps.get (← getOptions)
+  let ppInstantiateMVars := pp.instantiateMVars.get (← getOptions)
   withGoalCtx mvarId fun lctx mvarDecl => do
     -- See comment in `Lean.Meta.ppGoal` about this synthetic opaque heuristic.
     let tactic := mvarDecl.kind.isSyntheticOpaque
@@ -185,7 +186,7 @@ def goalToInteractive (mvarId : MVarId) : MetaM InteractiveGoal := do
           -- so the `userName`s of local hypotheses are already pretty-printed
           -- and it suffices to simply `toString` them.
           let varName := toString varName
-          let type ← instantiateMVars type
+          let type ← if ppInstantiateMVars then instantiateMVars type else pure type
           if prevType? == none || prevType? == some type then
             varNames := varNames.push (varName, fvarId)
           else
@@ -195,14 +196,12 @@ def goalToInteractive (mvarId : MVarId) : MetaM InteractiveGoal := do
         | LocalDecl.ldecl _index fvarId varName type val (nondep := false) .. => do
           let varName := toString varName
           hyps ← pushPending varNames prevType? hyps
-          let type ← instantiateMVars type
-          let val ← instantiateMVars val
+          let val ← if ppInstantiateMVars then instantiateMVars val else pure val
           hyps ← addInteractiveHypothesisBundle hyps #[(varName, fvarId)] type val tactic
           varNames := #[]
           prevType? := none
     hyps ← pushPending varNames prevType? hyps
-    let goalTp ← instantiateMVars mvarDecl.type
-    let goalFmt ← ppExprTagged goalTp
+    let goalFmt ← ppExprTagged mvarDecl.type
     let userName? := match mvarDecl.userName with
       | Name.anonymous => none
       | name           => some <| toString name.eraseMacroScopes


### PR DESCRIPTION
This PR fixes goal pretty-printing to only `instantiateMVars` if `pp.instantiateMVars` is active.

Closes #14275