### PR TITLE
feat: `case =>` tactic in `sym =>` mode

### DIFF
--- a/src/Init/Grind/Interactive.lean
+++ b/src/Init/Grind/Interactive.lean
@@ -191,6 +191,15 @@ sequence of `grind` tactics.
 macro dot:unicode("· ", ". ") s:grindSeq : grind => `(grind| next%$dot =>%$dot $s:grindSeq )
 
 /--
+* `case tag => tac` focuses on the goal with case name `tag` and solves it using `tac`,
+  or else fails.
+* `case tag x₁ ... xₙ => tac` additionally renames the `n` most recent hypotheses
+  with inaccessible names to the given names.
+* `case tag₁ | tag₂ => tac` is equivalent to `(case tag₁ => tac); (case tag₂ => tac)`.
+-/
+syntax (name := «case») "case " sepBy1(caseArg, " | ") " => " grindSeq : grind
+
+/--
 `any_goals tac` applies the tactic `tac` to every goal,
 concatenating the resulting goals for successful tactic applications.
 If the tactic fails on all of the goals, the entire `any_goals` tactic fails.

--- a/src/Lean/Elab/Tactic/Grind/BuiltinTactic.lean
+++ b/src/Lean/Elab/Tactic/Grind/BuiltinTactic.lean
@@ -427,6 +427,52 @@ public def renameInaccessibles (mvarId : MVarId) (hs : TSyntaxArray ``binderIden
     evalGrindTactic stx[3]
   setGoals goals
 
+/--
+Searches `goals` for one whose case tag matches `tag`, using the same heuristic as the
+standard `case` tactic: prefer an exact match, then a suffix match, then a prefix match.
+-/
+private def findGrindTag? (goals : List Goal) (tag : Name) : GrindTacticM (Option Goal) := do
+  let byName (p : Name → Name → Bool) : GrindTacticM (Option Goal) :=
+    goals.findM? fun g => return p tag (← g.mvarId.getDecl).userName.eraseMacroScopes
+  if let some g ← byName (· == ·) then return some g
+  if let some g ← byName (·.isSuffixOf ·) then return some g
+  byName (·.isPrefixOf ·)
+
+/--
+Returns the goal selected by the case tag `tag` together with the remaining goals.
+If `tag` is a hole (`_`), the main goal is selected.
+-/
+private def getCaseGoal (tag : TSyntax ``binderIdent) : GrindTacticM (Goal × List Goal) := do
+  let gs ← getUnsolvedGoals
+  if let `(binderIdent| $tagId:ident) := tag then
+    let tagId := tagId.getId.eraseMacroScopes
+    let some g ← findGrindTag? gs tagId | notFound gs tagId
+    return (g, gs.filter (·.mvarId != g.mvarId))
+  else
+    let g ← getMainGoal
+    return (g, gs.filter (·.mvarId != g.mvarId))
+where
+  notFound {α} (available : List Goal) (tag : Name) : GrindTacticM α := do
+    let names := (← available.mapM fun g => return (← g.mvarId.getDecl).userName)
+      |>.filter (· != .anonymous) |>.eraseDups
+    let hint := match names with
+      | []      => m!"There are no cases to select."
+      | [name]  => m!"The only available case tag is `{name}`."
+      | names   => m!"Available tags: {MessageData.joinSep (names.map (m!"`{·}`")) ", "}"
+    throwError "Case tag `{tag}` not found.\n{hint}"
+
+@[builtin_grind_tactic «case»] def evalCase : GrindTactic := fun stx => do
+  let `(grind| case%$caseTk $[$tags $hss*]|* =>%$arr $seq:grindSeq) := stx | throwUnsupportedSyntax
+  for tag in tags, hs in hss do
+    let (goal, goals) ← getCaseGoal tag
+    let mvarId ← renameInaccessibles goal.mvarId hs
+    let goal := { goal with mvarId }
+    setGoals [goal]
+    goal.mvarId.setTag Name.anonymous
+    withCaseRef arr seq <| closeUsingOrAdmit <| withTacticInfoContext (mkNullNode #[caseTk, arr]) <|
+      evalGrindTactic seq
+    setGoals goals
+
 @[builtin_grind_tactic nestedTacticCore] def evalNestedTactic : GrindTactic := fun stx => do
   let `(grind| tactic%$tacticTk =>%$arr $seq:tacticSeq) := stx | throwUnsupportedSyntax
   let goal ← getMainGoal

--- a/src/Lean/Elab/Tactic/Grind/BuiltinTactic.lean
+++ b/src/Lean/Elab/Tactic/Grind/BuiltinTactic.lean
@@ -419,6 +419,7 @@ public def renameInaccessibles (mvarId : MVarId) (hs : TSyntaxArray ``binderIden
 @[builtin_grind_tactic «next»] def evalNext : GrindTactic := fun stx => do
   let `(grind| next%$nextTk $hs* =>%$arr $seq:grindSeq) := stx | throwUnsupportedSyntax
   let goal :: goals ← getUnsolvedGoals | throwNoGoalsToBeSolved
+  -- **Note**: `renameInaccessibles` resets cached anchors.
   let mvarId ← renameInaccessibles goal.mvarId hs
   let goal := { goal with mvarId }
   setGoals [goal]
@@ -465,6 +466,7 @@ where
   let `(grind| case%$caseTk $[$tags $hss*]|* =>%$arr $seq:grindSeq) := stx | throwUnsupportedSyntax
   for tag in tags, hs in hss do
     let (goal, goals) ← getCaseGoal tag
+    -- **Note**: `renameInaccessibles` resets cached anchors.
     let mvarId ← renameInaccessibles goal.mvarId hs
     let goal := { goal with mvarId }
     setGoals [goal]

--- a/tests/elab/vcgenSymBlock.lean
+++ b/tests/elab/vcgenSymBlock.lean
@@ -130,3 +130,21 @@ theorem mySum_suggest (l : List Nat) : mySum l = l.sum := by
   sym =>
     vcgen [mySum] invariants?
     all_goals tactic => admit
+
+/-! ## Selecting `vcgen` goals by their `vc<n>` tags with `case` -/
+
+example :
+    ⦃ (True : Prop) ⦄
+    (do
+      let mut x := 0
+      for i in [1:5] do
+        x := x + i
+      pure x : Id Nat)
+    ⦃ fun r => r < 30 ⦄ := by
+  sym =>
+    vcgen invariants
+      · fun xs r => r + xs.suffix.length * 5 ≤ 25
+    case vc3 b a x => finish
+    case vc1 => tactic => simp +arith
+    case vc2 x _ =>
+      tactic => show x < 30; grind


### PR DESCRIPTION
This PR implements the `case => ..` tactic in `sym =>` mode. It is relevant for `vcgen` (see new test). The new feature tries to simulate the `case => ..` tactic in regular tactic mode. 