### PR TITLE
fix: report unresolved instances from `Sym` pattern matching

### DIFF
--- a/src/Lean/Meta/Sym/Apply.lean
+++ b/src/Lean/Meta/Sym/Apply.lean
@@ -126,14 +126,15 @@ Applies a backward rule to a goal, returning new subgoals.
 2. Assigns the goal metavariable to the theorem application
 3. Returns new goals for unassigned arguments (per `resultPos`)
 
-Returns `.notApplicable` if unification fails.
+Returns `.failed` if unification fails, or if an instance argument could not be synthesized.
 -/
 public def BackwardRule.apply (mvarId : MVarId) (rule : BackwardRule) : SymM ApplyResult := mvarId.withContext do
   let decl ← mvarId.getDecl
   if let some result ← rule.pattern.unify? decl.type then
-    -- `mkResultPos` drops instance arguments from `resultPos`, assuming type class
-    -- resolution fills them. One that was neither synthesized nor unified makes
-    -- the rule inapplicable.
+    -- `mkResultPos` omits instance arguments from `resultPos`, assuming type class resolution
+    -- discharges them. If one was neither synthesized nor assigned by unification, the rule is
+    -- not applicable; assigning the goal anyway would leave a loose instance metavariable in the
+    -- proof term (surfacing later as a kernel unresolved-metavariable error).
     if let some varInfos := rule.pattern.varInfos? then
       for h : i in *...result.args.size do
         if varInfos.argsInfo[i]!.isInstance then

--- a/src/Lean/Meta/Sym/Apply.lean
+++ b/src/Lean/Meta/Sym/Apply.lean
@@ -131,6 +131,14 @@ Returns `.notApplicable` if unification fails.
 public def BackwardRule.apply (mvarId : MVarId) (rule : BackwardRule) : SymM ApplyResult := mvarId.withContext do
   let decl ← mvarId.getDecl
   if let some result ← rule.pattern.unify? decl.type then
+    -- `mkResultPos` drops instance arguments from `resultPos`, assuming type class
+    -- resolution fills them. One that was neither synthesized nor unified makes
+    -- the rule inapplicable.
+    if let some varInfos := rule.pattern.varInfos? then
+      for h : i in *...result.args.size do
+        if varInfos.argsInfo[i]!.isInstance then
+          if let .mvar m := result.args[i] then
+            unless (← m.isAssigned) do return .failed
     mvarId.assign (mkValue rule.expr rule.pattern result)
     return .goals <| rule.resultPos.map fun i =>
       result.args[i]!.mvarId!

--- a/src/Lean/Meta/Sym/Apply.lean
+++ b/src/Lean/Meta/Sym/Apply.lean
@@ -132,14 +132,10 @@ public def BackwardRule.apply (mvarId : MVarId) (rule : BackwardRule) : SymM App
   let decl ← mvarId.getDecl
   if let some result ← rule.pattern.unify? decl.type then
     -- `mkResultPos` omits instance arguments from `resultPos`, assuming type class resolution
-    -- discharges them. If one was neither synthesized nor assigned by unification, the rule is
-    -- not applicable; assigning the goal anyway would leave a loose instance metavariable in the
-    -- proof term (surfacing later as a kernel unresolved-metavariable error).
-    if let some varInfos := rule.pattern.varInfos? then
-      for h : i in *...result.args.size do
-        if varInfos.argsInfo[i]!.isInstance then
-          if let .mvar m := result.args[i] then
-            unless (← m.isAssigned) do return .failed
+    -- discharges them. An instance that could not be resolved is not a subgoal, so assigning the
+    -- goal anyway would leave a loose instance metavariable in the proof term (surfacing later as a
+    -- kernel unresolved-metavariable error). Report the rule as inapplicable instead.
+    unless result.unresolvedInsts.isEmpty do return .failed
     mvarId.assign (mkValue rule.expr rule.pattern result)
     return .goals <| rule.resultPos.map fun i =>
       result.args[i]!.mvarId!

--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -1016,7 +1016,12 @@ def instantiateLevelParamsS (e : Expr) (paramNames : List Name) (us : List Level
 
 inductive MkPreResultResult where
   | failed
-  | success (mvarsToCheckType : Array MVarId)
+  /--
+  `instMVars` are the metavariables created for instance arguments that `trySynthInstance` could
+  not discharge. They may still be assigned while processing pending constraints; any that remain
+  unassigned mean the pattern was not fully instantiated (see `main`).
+  -/
+  | success (mvarsToCheckType : Array MVarId) (instMVars : Array MVarId)
 
 def mkPreResult : UnifyM MkPreResultResult := do
   let us ← (← get).uAssignment.toList.mapM fun
@@ -1028,6 +1033,7 @@ def mkPreResult : UnifyM MkPreResultResult := do
   let tPending := (← get).tPending
   let mut args := #[]
   let mut mvarsToCheckType := #[]
+  let mut instMVars := #[]
   for h : i in *...eAssignment.size do
     if let .some val := eAssignment[i] then
       if tPending.contains i then
@@ -1050,12 +1056,15 @@ def mkPreResult : UnifyM MkPreResultResult := do
           continue
       let mvar ← mkFreshExprMVar type
       let mvar ← shareCommon mvar
+      if pattern.isInstance i then
+        -- Synthesis failed above; record the placeholder so `main` can verify it gets resolved.
+        instMVars := instMVars.push mvar.mvarId!
       if let some mask := (← read).pattern.checkTypeMask? then
         if mask[i]! then
           mvarsToCheckType := mvarsToCheckType.push mvar.mvarId!
       args := args.push mvar
   modify fun s => { s with args, us }
-  return .success mvarsToCheckType
+  return .success mvarsToCheckType instMVars
 
 def processPendingLevel : UnifyM Bool := do
   let uPending := (← get).uPending
@@ -1114,19 +1123,29 @@ abbrev UnifyM.run (pattern : Pattern) (unify : Bool) (zetaDelta : Bool) (k : Uni
 public structure MatchUnifyResult where
   us : List Level
   args : Array Expr
+  /--
+  Instance arguments that could not be synthesized, nor assigned while processing pending
+  constraints. `args` still holds a fresh, unassigned metavariable for each of them. A consumer that
+  splices `args` into a proof term (e.g. `BackwardRule.apply`) must treat a non-empty array as
+  failure; a purely structural matcher may ignore it.
+  -/
+  unresolvedInsts : Array MVarId := #[]
 
-def mkResult : UnifyM MatchUnifyResult := do
+def mkResult (unresolvedInsts : Array MVarId) : UnifyM MatchUnifyResult := do
   let s ← get
-  return { s with }
+  return { s with unresolvedInsts }
 
 def main (p : Pattern) (e : Expr) (unify : Bool) (zetaDelta : Bool) : SymM (Option (MatchUnifyResult)) :=
   UnifyM.run p unify zetaDelta do
     unless (← process p.pattern e) do return none
     match (← mkPreResult) with
     | .failed => return none
-    | .success mvarsToCheckType =>
+    | .success mvarsToCheckType instMVars =>
       unless (← processPending mvarsToCheckType) do return none
-      return some (← mkResult)
+      -- An instance may still be assigned while processing pending constraints; report only those
+      -- that remain unresolved so the caller decides whether that is fatal.
+      let unresolvedInsts ← instMVars.filterM fun m => return !(← m.isAssigned)
+      return some (← mkResult unresolvedInsts)
 
 /--
 Attempts to match expression `e` against pattern `p` using purely syntactic matching.
@@ -1139,8 +1158,9 @@ Matching fails if:
 - The term contains metavariables (use `unify?` instead)
 - Structural mismatch after reducible unfolding
 
-Instance arguments are deferred for later synthesis. Proof arguments are
-skipped via proof irrelevance.
+Instance arguments are synthesized (or assigned by unification). Any that cannot be resolved are
+reported in `MatchUnifyResult.unresolvedInsts` rather than silently left as loose metavariables in
+`args`. Proof arguments are skipped via proof irrelevance.
 -/
 public def Pattern.match? (p : Pattern) (e : Expr) (zetaDelta := true) : SymM (Option (MatchUnifyResult)) :=
   main p e (unify := false) (zetaDelta := zetaDelta)
@@ -1156,8 +1176,9 @@ Unlike `match?`, this handles terms containing metavariables by deferring
 constraints to Phase 2 unification. Use this when matching against goal
 expressions that may contain unsolved metavariables.
 
-Instance arguments are deferred for later synthesis. Proof arguments are
-skipped via proof irrelevance.
+Instance arguments are synthesized (or assigned by unification). Any that cannot be resolved are
+reported in `MatchUnifyResult.unresolvedInsts` rather than silently left as loose metavariables in
+`args`. Proof arguments are skipped via proof irrelevance.
 -/
 public def Pattern.unify? (p : Pattern) (e : Expr) (zetaDelta := true) : SymM (Option (MatchUnifyResult)) :=
   main p e (unify := true) (zetaDelta := zetaDelta)

--- a/tests/elab/sym_apply_bug.lean
+++ b/tests/elab/sym_apply_bug.lean
@@ -25,3 +25,9 @@ example (pre rhs : Nat → Prop) : PlainRel pre rhs := by
 
 example (pre rhs : Nat → Prop) : PlainRel pre rhs := by
   sym => apply plainFoo''
+
+-- An unsynthesizable instance argument makes `apply` fail rather than leaving a
+-- loose instance metavariable in the proof.
+/-- error: `apply` failed, rule is not applicable -/
+#guard_msgs in
+example : False := by sym => apply Inhabited.default

--- a/tests/elab/sym_apply_bug.lean
+++ b/tests/elab/sym_apply_bug.lean
@@ -1,3 +1,9 @@
+/-!
+Tests for `Lean.Meta.Sym.BackwardRule.apply`: a backward rule with an instance argument that
+cannot be synthesized must report the rule as inapplicable rather than leaving a loose instance
+metavariable in the proof term (which surfaces as a kernel unresolved-metavariable error).
+-/
+
 inductive PlainRel {α : Sort u} (lhs rhs : α) : Prop where
   | intro
 

--- a/tests/elab/sym_apply_synth_inst.lean
+++ b/tests/elab/sym_apply_synth_inst.lean
@@ -1,0 +1,24 @@
+import Std.Tactic.Do
+set_option warn.sorry false
+open Lean.Order
+
+opaque T : Type
+instance : PartialOrder T := sorry
+
+theorem nondep_le {σ α : Type u} [PartialOrder α] {f g : σ → α} :
+    (∀ x, f x ⊑ g x) → f ⊑ g := fun h => h
+
+theorem dep_le {σ : Sort u} {α : σ → Sort v} [∀ x, PartialOrder (α x)]
+    {f g : (x : σ) → α x} : (∀ x, f x ⊑ g x) → f ⊑ g := fun h => h
+
+#guard_msgs (error) in
+example (a b : Nat → T) : a ⊑ b := by
+  sym => apply nondep_le; sorry
+
+#guard_msgs (error) in
+example (a b : Nat → T) : a ⊑ b := by
+  sym => apply dep_le; sorry
+
+example (a b : Nat → T) : a ⊑ b := by
+  with_reducible apply dep_le
+  all_goals sorry


### PR DESCRIPTION
This PR fixes a bug where `sym => apply <rule>` could close a goal with a proof term containing a loose instance metavariable.
  
When a rule's instance argument could not be synthesized, `Pattern.unify?`/`match?` fabricated a fresh metavariable and returned it in `args` as if resolved, so `BackwardRule.apply` spliced it into the proof. Matching now records such instances instead of silently dropping them; `BackwardRule.apply` fails when that collection is non-empty.

Closes #14113