### PR TITLE
fix: do not zeta reduce rhs of `sym` equational theorems

### DIFF
--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -108,21 +108,21 @@ def isUVar? (n : Name) : Option Nat := Id.run do
   return some idx
 
 /-- Helper function for implementing `mkPatternFromDecl` and `mkEqPatternFromDecl` -/
-def preprocessDeclPattern (declName : Name) : MetaM (List Name × Expr) := do
+def preprocessDeclPattern (declName : Name) (zetaReduceLHSOnly := false) : MetaM (List Name × Expr) := do
   let info ← getConstInfo declName
   let levelParams := info.levelParams.mapIdx fun i _ => Name.num uvarPrefix i
   let us := levelParams.map mkLevelParam
   let type ← instantiateTypeLevelParams info.toConstantVal us
-  let type ← preprocessType type
+  let type ← preprocessType type (zetaReduceLHSOnly := zetaReduceLHSOnly)
   let type ← normalizeLevels type
   return (levelParams, type)
 
-def preprocessExprPattern (e : Expr) (levelParams₀ : List Name) : MetaM (List Name × Expr) := do
+def preprocessExprPattern (e : Expr) (levelParams₀ : List Name) (zetaReduceLHSOnly := false) : MetaM (List Name × Expr) := do
   let type ← inferType e
   let levelParams := levelParams₀.mapIdx fun i _ => Name.num uvarPrefix i
   let us := levelParams.map mkLevelParam
   let type := type.instantiateLevelParams levelParams₀ us
-  let type ← preprocessType type
+  let type ← preprocessType type (zetaReduceLHSOnly := zetaReduceLHSOnly)
   let type ← normalizeLevels type
   return (levelParams, type)
 
@@ -241,8 +241,8 @@ For a theorem `∀ x₁ ... xₙ, type`, returns a pattern matching the first co
 with `n` pattern variables.
 -/
 @[inline]
-public def mkPatternFromDeclWithKey (declName : Name) (selectKey : Expr → MetaM (Expr × α)) : MetaM (Pattern × α) := do
-  let (levelParams, type) ← preprocessDeclPattern declName
+public def mkPatternFromDeclWithKey (declName : Name) (selectKey : Expr → MetaM (Expr × α)) (zetaReduceLHSOnly := false) : MetaM (Pattern × α) := do
+  let (levelParams, type) ← preprocessDeclPattern declName zetaReduceLHSOnly
   mkPatternFromTypeWithKey levelParams type selectKey
 
 /--
@@ -250,8 +250,8 @@ Like `mkPatternFromDeclWithKey`, but for a complex proof expression instead of t
 theorem.
 -/
 @[inline]
-public def mkPatternFromExprWithKey (e : Expr) (levelParams : List Name := []) (selectKey : Expr → MetaM (Expr × α)) : MetaM (Pattern × α) := do
-  let (levelParams, type) ← preprocessExprPattern e levelParams
+public def mkPatternFromExprWithKey (e : Expr) (levelParams : List Name := []) (selectKey : Expr → MetaM (Expr × α)) (zetaReduceLHSOnly := false) : MetaM (Pattern × α) := do
+  let (levelParams, type) ← preprocessExprPattern e levelParams zetaReduceLHSOnly
   mkPatternFromTypeWithKey levelParams type selectKey
 
 /--
@@ -266,7 +266,7 @@ For a theorem `∀ x₁ ... xₙ, lhs = rhs`, returns a pattern matching `lhs` w
 Throws an error if the theorem's conclusion is not an equality.
 -/
 public def mkEqPatternFromDecl (declName : Name) : MetaM (Pattern × Expr) := do
-  mkPatternFromDeclWithKey declName fun type => do
+  mkPatternFromDeclWithKey declName (zetaReduceLHSOnly := true) fun type => do
     let_expr Eq _ lhs rhs := type | throwError "conclusion is not a equality{indentExpr type}"
     return (lhs, rhs)
 

--- a/src/Lean/Meta/Sym/ProofInstInfo.lean
+++ b/src/Lean/Meta/Sym/ProofInstInfo.lean
@@ -14,10 +14,17 @@ namespace Lean.Meta.Sym
 /--
 Preprocesses types that used for pattern matching and unification.
 -/
-public def preprocessType (type : Expr) : MetaM Expr := do
+public def preprocessType (type : Expr) (zetaReduceLHSOnly := false) : MetaM Expr := do
   let type ← Sym.unfoldReducible type
   let type ← Core.betaReduce type
-  let type ← zetaReduce type
+  let type ← if zetaReduceLHSOnly then
+    forallTelescope type fun xs body => do
+      match_expr body with
+      | f@Eq α lhs rhs => mkForallFVars xs <| mkApp3 f α (← zetaReduce lhs) rhs
+      | f@Iff lhs rhs => mkForallFVars xs <| mkApp2 f (← zetaReduce lhs) rhs
+      | _ => zetaReduce type
+  else
+    zetaReduce type
   etaReduceAll type
 
 /--

--- a/src/Lean/Meta/Sym/Simp/Theorems.lean
+++ b/src/Lean/Meta/Sym/Simp/Theorems.lean
@@ -145,14 +145,14 @@ where
       mkLambdaFVars xs (← wrap h)
 
 def mkTheoremFromDecl (declName : Name) : MetaM Theorem := do
-  let (pattern, (rhs, adaptation)) ← mkPatternFromDeclWithKey declName selectEqKey
+  let (pattern, (rhs, adaptation)) ← mkPatternFromDeclWithKey declName selectEqKey (zetaReduceLHSOnly := true)
   let expr ← wrapProof pattern.varTypes.size (mkConst declName) adaptation
   let perm := isPerm pattern.varTypes.size pattern.pattern rhs
   return { expr, pattern, rhs, perm }
 
 /-- Create a `Theorem` from a proof expression. Handles equalities, `¬`, `↔`, and propositions. -/
 def mkTheoremFromExpr (e : Expr) : MetaM Theorem := do
-  let (pattern, (rhs, adaptation)) ← mkPatternFromExprWithKey e [] selectEqKey
+  let (pattern, (rhs, adaptation)) ← mkPatternFromExprWithKey e [] selectEqKey (zetaReduceLHSOnly := true)
   let expr ← wrapProof pattern.varTypes.size e adaptation
   let perm := isPerm pattern.varTypes.size pattern.pattern rhs
   return { expr, pattern, rhs, perm }

--- a/tests/elab/sym_simp_zeta.lean
+++ b/tests/elab/sym_simp_zeta.lean
@@ -1,0 +1,36 @@
+import Std.Tactic.Do
+
+/-!
+`Sym.simp` rewrite theorems must preserve nondep `let`s (e.g. do-notation `__do_jp`
+join points) in their RHS. Previously `preprocessType` zeta-reduced the whole theorem
+type, inlining the join points before `mvcgen +jp` could detect them. The LHS/pattern
+is still zeta-reduced (matching requires `let`-free patterns).
+-/
+
+open Std.Do
+
+set_option warn.sorry false
+
+def step (n : Nat) : Id Nat := do
+  let mut x := 0
+  if n > 0 then x := x + 1 else x := x + 2
+  return x
+
+/--
+trace: case grind
+n : Nat
+⊢ ⦃⌜True⌝⦄
+    have x := 0;
+    have __do_jp := fun __r => pure;
+    if 0 < n then
+      have x := x + 1;
+      __do_jp PUnit.unit x
+    else
+      have x := x + 2;
+      __do_jp PUnit.unit x ⦃(fun x => ⌜True⌝, ExceptConds.false)⦄
+-/
+#guard_msgs (trace) in
+example : ⦃⌜True⌝⦄ step n ⦃⇓ _ => ⌜True⌝⦄ := by
+  sym =>
+    simp [step.eq_def]
+    tactic => trace_state; sorry


### PR DESCRIPTION
This PR ensures the RHS of equational theorems is not zeta reduced during preprocessing. This issue was affecting vcgen (see new test by @sgraf812 ).

