### PR TITLE
fix: guard string growth paths against size_t overflow

### DIFF
--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -1978,7 +1978,10 @@ static object * string_ensure_capacity(object * o, size_t extra) {
     size_t sz  = string_size(o);
     size_t cap = string_capacity(o);
     if (sz + extra > cap) {
-        object * new_o = alloc_string(sz, cap + sz + extra, string_len(o));
+        // The amortizing `cap + sz + extra` can overflow `size_t` on 32-bit systems;
+        // fall back to the exact required capacity.
+        size_t new_cap = cap <= SIZE_MAX - (sz + extra) ? cap + sz + extra : sz + extra;
+        object * new_o = alloc_string(sz, new_cap, string_len(o));
         lean_assert(string_capacity(new_o) >= sz + extra);
         memcpy(w_string_cstr(new_o), string_cstr(o), sz);
         lean_dealloc(o, lean_string_byte_size(o));
@@ -2070,7 +2073,8 @@ std::string string_to_std(b_obj_arg o) {
 }
 
 static size_t mk_capacity(size_t sz) {
-    return sz*2;
+    // Doubling can overflow `size_t` on 32-bit systems; fall back to the exact size.
+    return sz <= SIZE_MAX / 2 ? sz * 2 : sz;
 }
 
 extern "C" LEAN_EXPORT object * lean_string_push(object * s, unsigned c) {
@@ -2096,6 +2100,10 @@ extern "C" LEAN_EXPORT object * lean_string_append(object * s1, object * s2) {
     size_t sz2      = lean_string_size(s2);
     size_t len1     = lean_string_len(s1);
     size_t len2     = lean_string_len(s2);
+    // `s1` and `s2` may alias, so `sz1 + sz2` is only bounded by twice the address
+    // space and can overflow on 32-bit systems; the result is then unrepresentable.
+    if (sz2 - 1 > SIZE_MAX - sz1)
+        lean_internal_panic_out_of_memory();
     size_t new_len  = len1 + len2;
     size_t new_sz   = sz1 + sz2 - 1;
     object * r;


### PR DESCRIPTION
This PR guards the string growth paths in the runtime against `size_t` overflow. **These are only issues on 32-bit systems** (in practice wasm32, whose linear memory can reach 4 GB while `SIZE_MAX` is 4 GB - 1); on 64-bit systems the required multi-exabyte strings cannot exist.

Three sites in `src/runtime/object.cpp`:

- `mk_capacity` doubles the requested size for amortized growth; `sz * 2` wraps for a string over `SIZE_MAX / 2` (2 GB on wasm32), so `lean_string_push` and `lean_string_append` allocate a capacity smaller than the size they then write. The fix falls back to the exact size.
- `string_ensure_capacity` grows to `cap + sz + extra`, roughly `2 * cap + extra`, which can wrap even though `cap + extra` cannot (both correspond to live buffers). The fix falls back to the exact required capacity `sz + extra`.
- `lean_string_append` computes `new_sz = sz1 + sz2 - 1` before its exclusivity branch, and in the shared branch `s1` may alias `s2` (appending a string to itself), so the sum is bounded only by twice the address space. A wrapped `new_sz` produces an undersized allocation followed by out-of-bounds `memcpy`s. The fix panics via the out-of-memory convention used by `lean_nat_to_size_t` for unrepresentable sizes.

Part of a series fixing `size_t` overflow in the runtime's growth paths, found while reviewing https://github.com/leanprover/lean4/pull/14158 (feat: add ByteArray.copyWithin); siblings: https://github.com/leanprover/lean4/pull/14273 (`lean_byte_array_copy_slice`) and https://github.com/leanprover/lean4/pull/14274 (`lean_sarray_ensure_capacity`), and https://github.com/leanprover/lean4/pull/14283 (`object_compactor`).

🤖 Prepared with Claude Code
