### PR TITLE
fix: prevent size_t overflow in object_compactor doubling

### DIFF
--- a/src/runtime/compact.cpp
+++ b/src/runtime/compact.cpp
@@ -165,7 +165,8 @@ void * object_compactor::alloc(size_t sz) {
     if (rem != 0)
         sz = sz + sizeof(void*) - rem;
     while (static_cast<char*>(m_end) + sz > m_capacity) {
-        size_t new_capacity = capacity()*2;
+        // Doubling can overflow `size_t` on 32-bit systems; grow exactly in that case.
+        size_t new_capacity = capacity() <= SIZE_MAX / 2 ? capacity() * 2 : size() + sz;
         void * new_begin = malloc(new_capacity);
         memcpy(new_begin, m_begin, size());
         m_end      = static_cast<char*>(new_begin) + size();


### PR DESCRIPTION
This PR prevents `size_t` overflow in `object_compactor::alloc`'s capacity doubling. **This is only an issue on 32-bit systems** (in practice wasm32); on 64-bit systems the required multi-exabyte compaction region cannot exist.

`capacity() * 2` wraps when the compactor region exceeds `SIZE_MAX / 2` (2 GB on wasm32, whose linear memory can reach 4 GB), after which `malloc` returns an undersized buffer and the `memcpy` of the existing contents writes past it. Reaching this needs roughly 3 GB of combined usage (the region plus the objects being compacted coexist), so it is marginal even on wasm32, but the wrap is arithmetically reachable. The fix grows to exactly the required size when doubling would overflow.

Part of a series fixing `size_t` overflow in the runtime's growth paths, found while reviewing https://github.com/leanprover/lean4/pull/14158 (feat: add ByteArray.copyWithin); siblings: https://github.com/leanprover/lean4/pull/14273 (`lean_byte_array_copy_slice`), https://github.com/leanprover/lean4/pull/14274 (`lean_sarray_ensure_capacity`), and https://github.com/leanprover/lean4/pull/14282 (string growth paths).

🤖 Prepared with Claude Code
