### PR TITLE
fix: flush config trace before truncating so an interrupted configure is recoverable

### DIFF
--- a/src/lake/Lake/Load/Lean/Elab.lean
+++ b/src/lake/Lake/Load/Lean/Elab.lean
@@ -246,6 +246,10 @@ public def importConfigFile (cfg : LoadConfig) : LogIO Environment := do
       h.putStrLn <| Json.pretty <| toJson
         {platform := System.Platform.target, leanHash := cfg.lakeEnv.leanGithash,
           configHash, idx := cfg.pkgIdx, name := cfg.pkgName, options := lakeOpts : ConfigTrace}
+      -- Flush before `truncate` (which sets the file size without flushing buffered
+      -- writes) and before the slow elaboration below, so a process killed
+      -- mid-elaboration leaves a valid trace rather than a NUL-byte size placeholder.
+      h.flush
       h.truncate
       let env ← elabConfigFile
         cfg.pkgIdx cfg.pkgName cfg.pkgDir lakeOpts cfg.leanOpts cfg.configFile


### PR DESCRIPTION
This PR makes an interrupted Lake configuration recoverable. `importConfigFile` writes the compiled-configuration trace to a buffered handle and then calls `IO.FS.Handle.truncate` — which sets the file size but does not flush buffered writes, as its own docstring notes — before the potentially slow configuration elaboration. A `lake` process killed in that window (an interrupted or cancelled build) leaves the trace on disk as a NUL-byte size placeholder with no `.olean`, so later invocations fail with `error: compiled configuration is invalid; run with '-R' to reconfigure`. Flushing the complete trace before truncating and elaborating means an interruption instead leaves a valid trace and no `.olean`, which Lake's existing up-to-date check already treats as a trigger to reconfigure automatically.

Reproduce (Lake 5.0.0 / Lean 4.30.0-rc2) — a `run_io` config widens the interrupt window to make the kill deterministic; any interruption during configure does the same:

```lean
-- lakefile.lean
import Lake
open Lake DSL
def slow : IO (Array String) := do IO.sleep 3000; return #[]
package repro where
  moreLinkArgs := run_io slow
@[default_target] lean_exe repro where root := `Main
```
```console
$ lake build            # healthy
$ lake build & sleep 1; kill -9 %1          # SIGKILL during configure
$ ls .lake/config/*/                        # lakefile.olean.trace present (184 NUL bytes), no lakefile.olean
$ lake build
error: compiled configuration is invalid; run with '-R' to reconfigure   # exit 1; only `lake build -R` recovers
```

This prevents a corrupt trace from being produced; it does not recover one that is already corrupt (from an interruption before this fix, a crash mid-flush, or a filesystem issue). The companion PR #14285 reroutes an unparsable trace into the same reconfigure path Lake already uses for a stale trace, covering those.

🤖 Prepared using Claude+Codex
