### PR TITLE
fix: reconfigure on an unparsable config trace instead of erroring

### DIFF
--- a/src/lake/Lake/Load/Lean/Elab.lean
+++ b/src/lake/Lake/Load/Lean/Elab.lean
@@ -262,7 +262,14 @@ public def importConfigFile (cfg : LoadConfig) : LogIO Environment := do
     else
       h.lock (exclusive := false)
       let contents ← h.readToEnd
-      let errMsg := "compiled configuration is invalid; run with '-R' to reconfigure"
+      /-
+      An unreadable trace (unparsable, or missing even the `options` field) is no
+      more informative than a missing one, so reconfigure — as we already do for a
+      stale, wrong-toolchain, or partially-malformed trace — rather than failing
+      and demanding a manual `-R`. This recovers automatically from a corrupt trace,
+      e.g. the NUL-filled size placeholder an interrupted or crashed configure can
+      leave behind (a killed process never flushes the buffered trace contents).
+      -/
       match Json.parse contents with
       | .ok json =>
         match fromJson? json with
@@ -281,9 +288,9 @@ public def importConfigFile (cfg : LoadConfig) : LogIO Environment := do
           | .ok (opts : NameMap String) =>
             elabConfig (← acquireTrace h) opts
           | .error _ =>
-            error errMsg
+            elabConfig (← acquireTrace h) cfg.lakeOpts
       | .error _ =>
-        error errMsg
+        elabConfig (← acquireTrace h) cfg.lakeOpts
   if (← traceFile.pathExists) then
     validateTrace <| ← IO.FS.Handle.mk traceFile .read
   else

--- a/src/lake/Lake/Load/Lean/Elab.lean
+++ b/src/lake/Lake/Load/Lean/Elab.lean
@@ -262,14 +262,6 @@ public def importConfigFile (cfg : LoadConfig) : LogIO Environment := do
     else
       h.lock (exclusive := false)
       let contents ← h.readToEnd
-      /-
-      An unreadable trace (unparsable, or missing even the `options` field) is no
-      more informative than a missing one, so reconfigure — as we already do for a
-      stale, wrong-toolchain, or partially-malformed trace — rather than failing
-      and demanding a manual `-R`. This recovers automatically from a corrupt trace,
-      e.g. the NUL-filled size placeholder an interrupted or crashed configure can
-      leave behind (a killed process never flushes the buffered trace contents).
-      -/
       match Json.parse contents with
       | .ok json =>
         match fromJson? json with


### PR DESCRIPTION
This PR makes Lake reconfigure when it cannot read the configuration trace, instead of aborting with `error: compiled configuration is invalid; run with '-R' to reconfigure`. `importConfigFile` already reconfigures automatically for a stale, wrong-toolchain, or partially-malformed trace; an unparsable trace is no more informative than a missing one, so it is now handled the same way — routed into the same `elabConfig (← acquireTrace h) …` path — recovering on its own rather than requiring a manual `-R`. When the trace has no usable `options` field it falls back to `cfg.lakeOpts`, the same options value the fresh-configure branch uses when no trace exists.

How the corrupt trace arises: Lake writes the trace to a buffered handle and `truncate`s (setting the file size without flushing) before the slow elaboration, so a `lake` process killed mid-configure leaves the trace as a NUL-byte size placeholder. Reproduce the resulting state directly:

```console
$ lake build                                        # healthy
$ printf '%184s' ' ' > .lake/config/*/lakefile.olean.trace   # unreadable trace
$ lake build   # before: error "...invalid; run with '-R'..." (exit 1);  after: reconfigures and builds
```

This complements #14284, which flushes the trace so an interrupted configure does not write a corrupt one in the first place. That fix prevents new corruption; this one recovers traces that are already corrupt — from an interruption before #14284, a crash mid-flush, or filesystem issues.

🤖 Prepared using Claude+Codex
