### PR TITLE
feat: `rw` tactic for `sym =>` mode

### DIFF
--- a/src/Init/Grind/Interactive.lean
+++ b/src/Init/Grind/Interactive.lean
@@ -346,6 +346,20 @@ Only available in `sym =>` mode.
 -/
 syntax (name := symDSimp) "dsimp" (ppSpace colGt ident)? (" [" ("*" <|> ident),* "]")? : grind
 
+/--
+`rw [h₁, ..., hₙ]` rewrites the goal target using the given equations or iffs, left to right.
+Use `← h` to rewrite right to left. Only available in `sym =>` mode, and it only rewrites the
+target: in `sym =>` mode hypotheses are never modified.
+
+Premises of a conditional rewrite rule that cannot be resolved by unification or type class
+resolution become new goals.
+
+`rw` is **not** a high-performance tactic: it does not exploit the maximal sharing maintained
+by `sym =>` mode, and should be used for surgical changes to the goal, not for bulk
+simplification. Use `simp`/`dsimp` variants for that.
+-/
+syntax (name := symRw) "rw " rwRuleSeq : grind
+
 /-- `exact e` closes the main goal if its target type matches that of `e`. -/
 macro "exact " e:term : grind => `(grind| tactic => exact $e:term)
 

--- a/src/Lean/Elab/Tactic/Grind.lean
+++ b/src/Lean/Elab/Tactic/Grind.lean
@@ -16,6 +16,9 @@ public import Lean.Elab.Tactic.Grind.Lint
 public import Lean.Elab.Tactic.Grind.LintExceptions
 public import Lean.Elab.Tactic.Grind.Annotated
 public import Lean.Elab.Tactic.Grind.Sym
+public import Lean.Elab.Tactic.Grind.Rewrite
+public import Lean.Elab.Tactic.Grind.DSimp
+public import Lean.Elab.Tactic.Grind.Cbv
 public import Lean.Elab.Tactic.Grind.SimprocDSL
 public import Lean.Elab.Tactic.Grind.SimprocDSLBuiltin
 public import Lean.Elab.Tactic.Grind.RegisterSymSimp

--- a/src/Lean/Elab/Tactic/Grind/Basic.lean
+++ b/src/Lean/Elab/Tactic/Grind/Basic.lean
@@ -336,6 +336,16 @@ def liftGrindM (k : GrindM α) : GrindTacticM α := do
   modify fun s => { s with grindState, symState }
   return a
 
+/-- Lifts a `SymM` computation into `GrindTacticM`. -/
+def liftSymM (k : Sym.SymM α) : GrindTacticM α := do
+  -- GrindM := ... Sym.SymM, so SymM auto-lifts to GrindM
+  liftGrindM k
+
+/-- Throws an error unless the tactic is being executed in `sym =>` mode. -/
+def ensureSym : GrindTacticM Unit := do
+  unless (← read).sym do
+    throwError "tactic is only available in `sym =>` mode"
+
 def replaceMainGoal (goals : List Goal) : GrindTacticM Unit := do
   let goals := goals.filter fun goal => !goal.inconsistent
   let (_ :: goals') ← getGoals | throwNoGoalsToBeSolved

--- a/src/Lean/Elab/Tactic/Grind/Cbv.lean
+++ b/src/Lean/Elab/Tactic/Grind/Cbv.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+module
+prelude
+import Lean.Elab.Tactic.Grind.Basic
+import Lean.Meta.Tactic.Cbv.Main
+namespace Lean.Elab.Tactic.Grind
+open Meta Grind
+
+@[builtin_grind_tactic Parser.Tactic.Grind.symCbv] def evalSymCbv : GrindTactic := fun _ => withMainContext do
+  ensureSym
+  let goal ← getMainGoal
+  let result ← liftGrindM <|
+    Lean.Meta.Tactic.Cbv.cbvGoalCore goal.mvarId
+  match result with
+  | none => replaceMainGoal []
+  | some mvarId => replaceMainGoal [{ goal with mvarId }]
+
+end Lean.Elab.Tactic.Grind

--- a/src/Lean/Elab/Tactic/Grind/DSimp.lean
+++ b/src/Lean/Elab/Tactic/Grind/DSimp.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+module
+prelude
+import Lean.Elab.Tactic.Grind.Basic
+import Lean.Elab.Tactic.Grind.DSimprocDSL
+import Lean.Meta.Sym.DSimp.Variant
+import Lean.Meta.Sym.DSimp.Reduce
+import Lean.Meta.Sym.DSimp.DSimproc
+namespace Lean.Elab.Tactic.Grind
+open Meta Grind
+open Sym.DSimp
+
+def elabDSimpArgs (args? : Option (Array (TSyntax [`token.«*», `ident]))) : GrindTacticM DSimpArgs := do
+  let some args := args? | return {}
+  let mut fvarIds := #[]
+  let mut zetaDeltaAll := false
+  let lctx ← getLCtx
+  for arg in args do
+    if arg.raw.getKind == `ident then
+      if let some decl := lctx.findFromUserName? arg.raw.getId then
+        fvarIds := fvarIds.push decl.fvarId
+      else
+        -- TODO: add support for rfl-theorems and unfolding definitions
+        throwError "unknown identifier `{arg.raw.getId}`"
+    else
+      zetaDeltaAll := true
+  if !fvarIds.isEmpty && zetaDeltaAll then
+    throwError "invalid `dsimp` arguments, local declarations and `*` have been provided"
+  return { fvarIds, zetaDeltaAll }
+
+def addDSimpArgs (pre : DSimproc) (args : DSimpArgs) : DSimproc := Id.run do
+  let mut pre := pre
+  if args.zetaDeltaAll then
+    pre := pre >> zetaDeltaAll
+  unless args.fvarIds.isEmpty do
+    pre := pre >> zetaDelta (FVarIdSet.ofArray args.fvarIds)
+  return pre
+
+def mkDSimpDefaultMethods (args : DSimpArgs) : GrindTacticM Sym.DSimp.Methods := do
+  let pre  := beta >> dsimpProj >> dsimpMatch
+  let pre  := addDSimpArgs pre args
+  let post := evalGround
+  return { pre, post }
+
+def trivialDSimproc : DSimproc := fun _ =>
+  return .rfl
+
+def elabOptDSimproc (stx? : Option Syntax) : GrindTacticM DSimproc := do
+  let some stx := stx? | return trivialDSimproc
+  elabSymDSimproc stx
+
+def elabDSimpVariant (variantName : Name) (args : DSimpArgs) : GrindTacticM (Sym.DSimp.Methods × Sym.DSimp.Config) := do
+  if variantName.isAnonymous then
+    return (← mkDSimpDefaultMethods args, {})
+  let some v := Sym.DSimp.getSymDSimpVariant? (← getEnv) variantName
+    | throwError "unknown Sym.dsimp variant `{variantName}`"
+  let pre := addDSimpArgs (← elabOptDSimproc v.pre?) args
+  let post ← elabOptDSimproc v.post?
+  return ({ pre, post}, v.config)
+
+@[builtin_grind_tactic Parser.Tactic.Grind.symDSimp] def evalSymDSimp : GrindTactic := fun stx => withMainContext do
+  ensureSym
+  let `(grind| dsimp $[$variantId?]? $[[ $[$args],* ]]?) := stx | throwUnsupportedSyntax
+  let variantName := variantId?.map (·.getId) |>.getD .anonymous
+  let args ← elabDSimpArgs args
+  let cacheKey : DSimpCacheKey := { variant := variantName, args }
+  let dsimpState := (← get).cache.dsimpState[cacheKey]?.getD {}
+  let (methods, config) ← elabDSimpVariant variantName args
+  let goal ← getMainGoal
+  let (result, dsimpState) ← liftGrindM <| goal.withContext do
+    Sym.DSimp.DSimpM.run (Sym.DSimp.dsimp (← goal.mvarId.getType)) methods config dsimpState
+  modify fun s => { s with cache.dsimpState := s.cache.dsimpState.insert cacheKey dsimpState }
+  match result with
+  | .rfl _  => throwError "`Sym.dsimp` made no progress"
+  | .step target' _ =>
+    if target'.isTrue then
+      goal.mvarId.assign (mkConst ``True.intro)
+      replaceMainGoal []
+    else
+      let decl ← goal.mvarId.getDecl
+      let mvarNew ← mkFreshExprSyntheticOpaqueMVar target' decl.userName
+      goal.mvarId.assign mvarNew
+      replaceMainGoal [{ goal with mvarId := mvarNew.mvarId! }]
+
+end Lean.Elab.Tactic.Grind

--- a/src/Lean/Elab/Tactic/Grind/Rewrite.lean
+++ b/src/Lean/Elab/Tactic/Grind/Rewrite.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+module
+prelude
+import Lean.Elab.Tactic.Grind.Basic
+import Lean.Meta.Tactic.Rewrite
+import Lean.Meta.Tactic.Replace
+import Lean.Elab.SyntheticMVars
+namespace Lean.Elab.Tactic.Grind
+open Meta Grind
+
+/--
+Rewrites the target of the main goal using `term`, and re-establishes the `sym` invariants
+(reducible constants unfolded, maximal sharing) on the resulting target.
+Theorem premises that cannot be resolved by unification or type class resolution become
+new goals.
+-/
+private def rwTarget (symm : Bool) (term : Syntax) : GrindTacticM Unit := do
+  let goal ← getMainGoal
+  goal.withContext do
+    let mvarCounterSaved := (← getMCtx).mvarCounter
+    let r ← Term.withSynthesize do
+      let heq ← Term.elabTerm term none true
+      if heq.hasSyntheticSorry then
+        throwAbortTactic
+      unless (← occursCheck goal.mvarId heq) do
+        throwErrorAt term "Occurs check failed: Expression{indentExpr heq}\ncontains the goal {Expr.mvar goal.mvarId}"
+      /-
+      The target is in `sym` normal form (e.g., reducible constants have been unfolded), but the
+      given equation is not. We unfold reducible constants in its statement so that `kabstract`
+      key-matching can find occurrences of the lhs in the target, and the rhs requires less
+      normalization after the rewrite.
+      -/
+      let heqType ← instantiateMVars (← inferType heq)
+      let heqType' ← Sym.unfoldReducible heqType
+      let heq ← if isSameExpr heqType heqType' then pure heq else mkExpectedTypeHint heq heqType'
+      goal.mvarId.rewrite (← goal.mvarId.getType) heq symm
+    let mctx ← getMCtx
+    let mvarIds := r.mvarIds.filter fun mvarId => (mctx.getDecl mvarId |>.index) >= mvarCounterSaved
+    let eNew ← liftSymM <| Sym.preprocessExpr r.eNew
+    if eNew.hasExprMVar then
+      throwError "`rw` failed, resulting target contains metavariables{indentExpr eNew}"
+    let mvarId ← goal.mvarId.replaceTargetEq eNew r.eqProof
+    let mvarIds ← mvarIds.filterM fun mvarId => return !(← mvarId.isAssigned)
+    let sideGoals ← mvarIds.mapM fun mvarId => do
+      let target ← mvarId.getType
+      let target' ← liftSymM <| Sym.preprocessExpr target
+      if isSameExpr target target' then
+        -- The metavariable was created by `forallMetaTelescopeReducing` with kind `.natural`;
+        -- prevent it from being assigned by unification in later steps.
+        mvarId.setKind .syntheticOpaque
+        return { goal with mvarId }
+      else
+        let mvarId ← mvarId.replaceTargetDefEq target'
+        return { goal with mvarId }
+    replaceMainGoal ({ goal with mvarId } :: sideGoals)
+
+/--
+Closes the main goal if its target is `True` or a reflexive `Eq`/`Iff`/`HEq`.
+Since the target is maximally shared, reflexivity is detected using pointer equality.
+-/
+private def tryTrivialClose : GrindTacticM Unit := do
+  let goal ← getMainGoal
+  goal.withContext do
+    let target ← goal.mvarId.getType
+    if target.isTrue then
+      goal.mvarId.assign (mkConst ``True.intro)
+      replaceMainGoal []
+      return ()
+    let close (proof : Expr) : GrindTacticM Unit := do
+      goal.mvarId.assign proof
+      replaceMainGoal []
+    match_expr target with
+    | Eq α lhs rhs =>
+      if isSameExpr lhs rhs then
+        close <| mkApp2 (mkConst ``Eq.refl [← getLevel α]) α lhs
+    | Iff lhs rhs =>
+      if isSameExpr lhs rhs then
+        close <| mkApp (mkConst ``Iff.refl) lhs
+    | HEq α lhs β rhs =>
+      if isSameExpr α β && isSameExpr lhs rhs then
+        close <| mkApp2 (mkConst ``HEq.refl [← getLevel α]) α lhs
+    | _ => return ()
+
+@[builtin_grind_tactic Parser.Tactic.Grind.symRw] def evalSymRw : GrindTactic := fun stx => do
+  ensureSym
+  let `(grind| rw%$tk $s:rwRuleSeq) := stx | throwUnsupportedSyntax
+  let lbrak := s.raw[0]
+  let rules := s.raw[1]
+  -- show initial state up to (incl.) `[`
+  withTacticInfoContext (mkNullNode #[tk, lbrak]) (pure ())
+  for rule in rules.getSepArgs do
+    withTacticInfoContext rule do
+      withRef rule do
+        let symm := !rule[0].isNone
+        let term := rule[1]
+        rwTarget symm term
+  tryTrivialClose
+
+end Lean.Elab.Tactic.Grind

--- a/src/Lean/Elab/Tactic/Grind/Sym.lean
+++ b/src/Lean/Elab/Tactic/Grind/Sym.lean
@@ -7,7 +7,6 @@ module
 prelude
 import Lean.Elab.Tactic.Grind.Basic
 import Lean.Elab.Tactic.Grind.SimprocDSL
-import Lean.Elab.Tactic.Grind.DSimprocDSL
 import Lean.Meta.Sym.Grind
 import Lean.Meta.Sym.Simp.Variant
 import Lean.Meta.Sym.Simp.Rewrite
@@ -16,24 +15,11 @@ import Lean.Meta.Sym.Simp.Goal
 import Lean.Meta.Sym.Simp.Attr
 import Lean.Meta.Sym.Simp.ControlFlow
 import Lean.Meta.Sym.Simp.Forall
-import Lean.Meta.Sym.DSimp.Variant
-import Lean.Meta.Sym.DSimp.Reduce
-import Lean.Meta.Sym.DSimp.DSimproc
 import Lean.Meta.Tactic.Apply
-import Lean.Meta.Tactic.Cbv.Main
 import Lean.Elab.Tactic.Location
 import Lean.Elab.SyntheticMVars
 namespace Lean.Elab.Tactic.Grind
 open Meta Grind
-
-private def ensureSym : GrindTacticM Unit := do
-  unless (← read).sym do
-    throwError "tactic is only available in `sym =>` mode"
-
-/-- Lift a `SymM` computation into `GrindTacticM`. -/
-private def liftSymM (k : Sym.SymM α) : GrindTacticM α := do
-  -- GrindM := ... Sym.SymM, so SymM auto-lifts to GrindM
-  liftGrindM k
 
 private def evalIntroCore (internalize : Bool) (ids : TSyntaxArray `Lean.binderIdent) : GrindTacticM Unit := do
   ensureSym
@@ -219,92 +205,6 @@ def elabSimpVariant (variantName : Name) (extraThms : Array Theorem) : GrindTact
   | .closed => replaceMainGoal []
   | .goal mvarId => replaceMainGoal [{ goal with mvarId }]
   | .noProgress => throwError "`Sym.simp` made no progress"
-
-end
-
-section
-open Sym.DSimp
-
-def elabDSimpArgs (args? : Option (Array (TSyntax [`token.«*», `ident]))) : GrindTacticM DSimpArgs := do
-  let some args := args? | return {}
-  let mut fvarIds := #[]
-  let mut zetaDeltaAll := false
-  let lctx ← getLCtx
-  for arg in args do
-    if arg.raw.getKind == `ident then
-      if let some decl := lctx.findFromUserName? arg.raw.getId then
-        fvarIds := fvarIds.push decl.fvarId
-      else
-        -- TODO: add support for rfl-theorems and unfolding definitions
-        throwError "unknown identifier `{arg.raw.getId}`"
-    else
-      zetaDeltaAll := true
-  if !fvarIds.isEmpty && zetaDeltaAll then
-    throwError "invalid `dsimp` arguments, local declarations and `*` have been provided"
-  return { fvarIds, zetaDeltaAll }
-
-def addDSimpArgs (pre : DSimproc) (args : DSimpArgs) : DSimproc := Id.run do
-  let mut pre := pre
-  if args.zetaDeltaAll then
-    pre := pre >> zetaDeltaAll
-  unless args.fvarIds.isEmpty do
-    pre := pre >> zetaDelta (FVarIdSet.ofArray args.fvarIds)
-  return pre
-
-def mkDSimpDefaultMethods (args : DSimpArgs) : GrindTacticM Sym.DSimp.Methods := do
-  let pre  := beta >> dsimpProj >> dsimpMatch
-  let pre  := addDSimpArgs pre args
-  let post := evalGround
-  return { pre, post }
-
-def trivialDSimproc : DSimproc := fun _ =>
-  return .rfl
-
-def elabOptDSimproc (stx? : Option Syntax) : GrindTacticM DSimproc := do
-  let some stx := stx? | return trivialDSimproc
-  elabSymDSimproc stx
-
-def elabDSimpVariant (variantName : Name) (args : DSimpArgs) : GrindTacticM (Sym.DSimp.Methods × Sym.DSimp.Config) := do
-  if variantName.isAnonymous then
-    return (← mkDSimpDefaultMethods args, {})
-  let some v := Sym.DSimp.getSymDSimpVariant? (← getEnv) variantName
-    | throwError "unknown Sym.dsimp variant `{variantName}`"
-  let pre := addDSimpArgs (← elabOptDSimproc v.pre?) args
-  let post ← elabOptDSimproc v.post?
-  return ({ pre, post}, v.config)
-
-@[builtin_grind_tactic Parser.Tactic.Grind.symDSimp] def evalSymDSimp : GrindTactic := fun stx => withMainContext do
-  ensureSym
-  let `(grind| dsimp $[$variantId?]? $[[ $[$args],* ]]?) := stx | throwUnsupportedSyntax
-  let variantName := variantId?.map (·.getId) |>.getD .anonymous
-  let args ← elabDSimpArgs args
-  let cacheKey : DSimpCacheKey := { variant := variantName, args }
-  let dsimpState := (← get).cache.dsimpState[cacheKey]?.getD {}
-  let (methods, config) ← elabDSimpVariant variantName args
-  let goal ← getMainGoal
-  let (result, dsimpState) ← liftGrindM <| goal.withContext do
-    Sym.DSimp.DSimpM.run (Sym.DSimp.dsimp (← goal.mvarId.getType)) methods config dsimpState
-  modify fun s => { s with cache.dsimpState := s.cache.dsimpState.insert cacheKey dsimpState }
-  match result with
-  | .rfl _  => throwError "`Sym.dsimp` made no progress"
-  | .step target' _ =>
-    if target'.isTrue then
-      goal.mvarId.assign (mkConst ``True.intro)
-      replaceMainGoal []
-    else
-      let decl ← goal.mvarId.getDecl
-      let mvarNew ← mkFreshExprSyntheticOpaqueMVar target' decl.userName
-      goal.mvarId.assign mvarNew
-      replaceMainGoal [{ goal with mvarId := mvarNew.mvarId! }]
-
-@[builtin_grind_tactic Parser.Tactic.Grind.symCbv] def evalSymCbv : GrindTactic := fun _ => withMainContext do
-  ensureSym
-  let goal ← getMainGoal
-  let result ← liftGrindM <|
-    Lean.Meta.Tactic.Cbv.cbvGoalCore goal.mvarId
-  match result with
-  | none => replaceMainGoal []
-  | some mvarId => replaceMainGoal [{ goal with mvarId }]
 
 end
 

--- a/src/Lean/Meta/Sym/Util.lean
+++ b/src/Lean/Meta/Sym/Util.lean
@@ -88,7 +88,7 @@ public def foldProjs (e : Expr) : MetaM Expr := do
 /--
 Instantiates metavariables, unfold reducible, and applies `shareCommon`.
 -/
-def preprocessExpr (e : Expr) : SymM Expr := do
+public def preprocessExpr (e : Expr) : SymM Expr := do
   shareCommon (← unfoldReducible (← instantiateMVars e))
 
 /--

--- a/tests/elab/sym_rw.lean
+++ b/tests/elab/sym_rw.lean
@@ -1,0 +1,174 @@
+/-!
+Tests for the `rw` tactic in `sym =>` mode.
+`rw` only rewrites the goal target; in `sym =>` mode hypotheses are never modified.
+-/
+
+opaque myP : Nat → Prop
+opaque myQ : Nat → Prop
+opaque myF : Nat → Nat
+opaque myG : Nat → Nat
+
+axiom myF_eq (x : Nat) : myF x = myG x
+axiom myP_iff (x : Nat) : myP x ↔ myQ x
+axiom myF_eq_cond (x : Nat) : myP x → myF x = myG x
+
+/-! Basic rewrite with a local hypothesis -/
+
+/--
+trace: case grind
+a b : Nat
+h : a = b
+h' : myP b
+⊢ myP b
+-/
+#guard_msgs in
+example (a b : Nat) (h : a = b) (h' : myP b) : myP a := by
+  sym =>
+    rw [h]
+    show_goals
+    exact h'
+
+/-! Reverse direction -/
+
+/--
+trace: case grind
+a b : Nat
+h : a = b
+h' : myP a
+⊢ myP a
+-/
+#guard_msgs in
+example (a b : Nat) (h : a = b) (h' : myP a) : myP b := by
+  sym =>
+    rw [← h]
+    show_goals
+    exact h'
+
+/-! Global theorem with universally quantified variables -/
+
+/--
+trace: case grind
+a : Nat
+h : myP (myG a)
+⊢ myP (myG a)
+-/
+#guard_msgs in
+example (a : Nat) (h : myP (myG a)) : myP (myF a) := by
+  sym =>
+    rw [myF_eq]
+    show_goals
+    exact h
+
+/-! Multiple rules -/
+
+/--
+trace: case grind
+a b : Nat
+h : a = b
+h' : myP (myG b)
+⊢ myP (myG b)
+-/
+#guard_msgs in
+example (a b : Nat) (h : a = b) (h' : myP (myG b)) : myP (myF a) := by
+  sym =>
+    rw [myF_eq, h]
+    show_goals
+    exact h'
+
+/-! Goal closed by reflexivity after rewriting -/
+
+example (a b : Nat) (h : a = b) : myF a = myF b := by
+  sym =>
+    rw [h]
+
+/-! Iff rewrite -/
+
+/--
+trace: case grind
+a : Nat
+h : myQ a
+⊢ myQ a
+-/
+#guard_msgs in
+example (a : Nat) (h : myQ a) : myP a := by
+  sym =>
+    rw [myP_iff]
+    show_goals
+    exact h
+
+/-! Conditional rewrite: undischarged premise becomes a new goal -/
+
+/--
+trace: case grind
+a : Nat
+h : myP a
+h' : myP (myG a)
+⊢ myP (myG a)
+
+case grind
+a : Nat
+h : myP a
+h' : myP (myG a)
+⊢ myP a
+-/
+#guard_msgs in
+example (a : Nat) (h : myP a) (h' : myP (myG a)) : myP (myF a) := by
+  sym =>
+    rw [myF_eq_cond a]
+    show_goals
+    exact h'
+    exact h
+
+/-! Reducible definitions in the rewrite rule are unfolded before matching -/
+
+@[reducible] def myH (x : Nat) : Nat := myF x
+
+axiom myH_eq (x : Nat) : myH x = myG x
+
+/--
+trace: case grind
+a : Nat
+h : myP (myG a)
+⊢ myP (myG a)
+-/
+#guard_msgs in
+example (a : Nat) (h : myP (myG a)) : myP (myF a) := by
+  sym =>
+    rw [myH_eq] -- lhs `myH ?x` must match `myF a` after unfolding `myH`
+    show_goals
+    exact h
+
+/-! The result is properly normalized: `grind` can consume it via `finish` -/
+
+example (a b : Nat) (h : a = b) (h' : myP b) : myP a := by
+  sym =>
+    rw [h]
+    finish
+
+/-! Error: no occurrence of the pattern -/
+
+/--
+error: Tactic `rewrite` failed: Did not find an occurrence of the pattern
+  myG ?x✝
+in the target expression
+  myP a
+
+case grind
+a : Nat
+h : myP a
+⊢ myP a
+-/
+#guard_msgs in
+example (a : Nat) (h : myP a) : myP a := by
+  sym =>
+    rw [(myF_eq · |>.symm)]
+    exact h
+
+/-! Error: `rw` is only available in `sym =>` mode -/
+
+/--
+error: tactic is only available in `sym =>` mode
+-/
+#guard_msgs in
+example (a b : Nat) (h : a = b) (h' : myP b) : myP a := by
+  grind => rw [h]


### PR DESCRIPTION
This PR implements the `rw` tactic for `sym =>` mode. 
It also breaks `Lean/Elab/Tatic/Grind/Sym.lean` into smaller files.
