### PR TITLE
fix: `finish?` in `sym =>` mode

### DIFF
--- a/src/Lean/Elab/Tactic/Grind/Trace.lean
+++ b/src/Lean/Elab/Tactic/Grind/Trace.lean
@@ -11,12 +11,39 @@ import Lean.Elab.Tactic.Grind.Param
 import Lean.Meta.Tactic.TryThis
 import Lean.Meta.Tactic.Grind.Finish
 import Lean.Meta.Tactic.Grind.CollectParams
+import Lean.Meta.Sym.Grind
 namespace Lean.Elab.Tactic.Grind
 open Meta
 open Meta.Grind
 
 def withTracing (x : GrindTacticM α) : GrindTacticM α := do
   withReader (fun ctx => { ctx with ctx.config.trace := true }) x
+
+/--
+In `sym =>` mode, the initialization performed on entry by `grind =>` (introductions +
+proof by contradiction + internalization) has not been applied to the goal. The `finish`
+action performs equivalent steps internally, but they are not recorded in the resulting
+script. This function applies the interactive `intros` and `by_contra` steps, and returns
+them so they can be included in the script suggested by `finish?`.
+-/
+private def symInit (goal : Goal) : GrindM (List TGrind × Goal) := do
+  let mut seq : List TGrind := []
+  let mut goal := goal
+  -- Introduce hypotheses, if any
+  let hygienic := tactic.hygienic.get (← getOptions)
+  if let .goal _ goalNew ← Goal.intros goal #[] hygienic then
+    goal ← Goal.internalizeAll goalNew
+    seq := seq ++ [← `(grind| intros)]
+  -- Apply proof by contradiction if the target is not already `False`
+  let target ← goal.mvarId.getType
+  unless target.isFalse do
+    let mvarId ← if (← isProp target) then pure goal.mvarId else goal.mvarId.exfalso
+    if let some mvarId ← mvarId.byContra? then
+      -- `byContra?` produces `⊢ ¬target → False`, introduce the negated hypothesis
+      let (_, mvarId) ← mvarId.intro1
+      goal ← Goal.internalizeAll { goal with mvarId }
+      seq := seq ++ [← `(grind| by_contra)]
+  return (seq, goal)
 
 @[builtin_grind_tactic finishTrace] def evalFinishTrace : GrindTactic := fun stx => do
   let `(grind| finish? $[$configItems]* $[only%$only]? $[[$params?,*]]?) := stx | throwUnsupportedSyntax
@@ -26,11 +53,14 @@ def withTracing (x : GrindTacticM α) : GrindTacticM α := do
     let a ← Action.mkFinish
     let goal ← getMainGoal
     let params := (← read).params
+    let sym := (← read).sym
     withTracing do
     let solved ← liftGrindM do
       let saved ← saveState
-      match (← a.run goal) with
+      let (initSeq, goal') ← if sym then symInit goal else pure ([], goal)
+      match (← a.run goal') with
       | .closed seq =>
+        let seq := initSeq ++ seq
         let finishTac ← mkFinishTactic seq
         let seq := Action.mkGrindSeq seq
         if (← Action.checkSeqAt saved goal [finishTac]) then

--- a/tests/elab/sym_finish_trace.lean
+++ b/tests/elab/sym_finish_trace.lean
@@ -1,0 +1,84 @@
+/-!
+Tests for `finish?` in `sym =>` mode (issue #13050).
+In `sym =>` mode, `grind`'s entry initialization (proof by contradiction + internalization)
+is not applied eagerly, so `finish?` must include the `by_contra` step in the suggested
+script for it to be replayable.
+-/
+
+/--
+info: Try these:
+  [apply] by_contra
+  [apply] finish only []
+-/
+#guard_msgs in
+example {a b : Nat} (h : a < b) (c : Nat) : a + c < b + c := by
+  sym => finish?
+
+-- The suggested script can be replayed
+example {a b : Nat} (h : a < b) (c : Nat) : a + c < b + c := by
+  sym => by_contra
+
+-- Hypotheses to be introduced are handled by an `intros` step
+/--
+info: Try these:
+  [apply] ⏎
+    intros
+    by_contra
+  [apply] finish only []
+-/
+#guard_msgs in
+example {a b : Nat} (c : Nat) : a < b → a + c < b + c := by
+  sym => finish?
+
+-- The suggested script can be replayed
+example {a b : Nat} (c : Nat) : a < b → a + c < b + c := by
+  sym =>
+    intros
+    by_contra
+
+/--
+info: Try these:
+  [apply] ⏎
+    by_contra
+    lia
+  [apply] finish only []
+-/
+#guard_msgs in
+example {a b : Nat} (h : a < b) (c : Nat) : a + c < b + c := by
+  sym -order => finish?
+
+/--
+info: Try these:
+  [apply] ⏎
+    intros
+    lia
+  [apply] finish only []
+-/
+#guard_msgs in
+example {a b : Nat} (h : a < b) (c : Nat) : ¬ a + c < b + c → False := by
+  sym -order => finish?
+
+/--
+info: Try these:
+  [apply] lia
+  [apply] finish only []
+-/
+#guard_msgs in
+example {a b : Nat} (h : a < b) (c : Nat) : a + c < b + c := by
+  sym -order => by_contra; finish?
+
+-- The suggested script can be replayed
+example {a b : Nat} (h : a < b) (c : Nat) : a + c < b + c := by
+  sym -order =>
+    by_contra
+    lia
+
+-- `finish?` in `grind =>` mode is not affected
+/--
+info: Try these:
+  [apply] lia
+  [apply] finish only []
+-/
+#guard_msgs in
+example {a b : Nat} (h : a < b) (c : Nat) : a + c < b + c := by
+  grind -order => finish?


### PR DESCRIPTION
This PR ensures that `finish?` adds `intros` and `by_contra`, when needed, to the resulting tactic script as preprocessing steps.

Closes #13050