### PR TITLE
refactor: make `int_toBitVec` SymM compatible

### DIFF
--- a/src/Lean/Meta/Tactic/BVDecide/Attr.lean
+++ b/src/Lean/Meta/Tactic/BVDecide/Attr.lean
@@ -9,7 +9,9 @@ prelude
 public import Lean.Elab.Tactic.Basic
 public import Lean.Meta.Tactic.Simp
 public import Std.Tactic.BVDecide.Syntax
+public import Lean.Meta.Sym.Simp.Theorems
 import Lean.Elab.ConfigEval
+import Lean.Meta.Sym.Simp.Attr
 
 public section
 
@@ -41,8 +43,26 @@ declare_config_elab elabBVDecideConfig Lean.Elab.Tactic.BVDecide.BVDecideConfig
 builtin_initialize bvNormalizeExt : Meta.SimpExtension ←
   Meta.registerSimpAttr `bv_normalize "simp theorems used by bv_normalize"
 
-builtin_initialize intToBitVecExt : Meta.SimpExtension ←
-  Meta.registerSimpAttr `int_toBitVec "simp theorems used to convert UIntX/IntX statements into BitVec ones"
+def symIntToBitVecName : Name := `int_toBitVec_sym
+def metaIntToBitVecName : Name := `int_toBitVec_meta
+
+builtin_initialize symIntToBitVecExt : Sym.Simp.SymSimpExtension ←
+  Sym.Simp.registerSymSimpAttr symIntToBitVecName "sym simp theorems used to convert UIntX/IntX statements into BitVec ones"
+
+builtin_initialize metaIntToBitVecExt : Meta.SimpExtension ←
+  Meta.registerSimpAttr metaIntToBitVecName "meta simp theorems used to convert UIntX/IntX statements into BitVec ones"
+
+builtin_initialize
+  registerBuiltinAttribute {
+    name := `int_toBitVec
+    descr := "simp theorems used to convert UIntX/IntX statements into BitVec ones"
+    add := fun declName stx attrKind => do
+      let env ← getEnv
+      let metaImpl ← IO.ofExcept <| getAttributeImpl env metaIntToBitVecName
+      metaImpl.add declName stx attrKind
+      let symImpl ← IO.ofExcept <| getAttributeImpl env symIntToBitVecName
+      symImpl.add declName stx attrKind
+  }
 
 /-- Builtin `bv_normalize` simprocs. -/
 builtin_initialize builtinBVNormalizeSimprocsRef : IO.Ref Meta.Simp.Simprocs ← IO.mkRef {}

--- a/src/Lean/Meta/Tactic/BVDecide/Normalize/Enums.lean
+++ b/src/Lean/Meta/Tactic/BVDecide/Normalize/Enums.lean
@@ -441,7 +441,7 @@ public partial def enumsPass : Pass where
 
       -- same for fixed integers
       if cfg.fixedInt then
-        relevantLemmas := relevantLemmas.push (← intToBitVecExt.getTheorems)
+        relevantLemmas := relevantLemmas.push (← metaIntToBitVecExt.getTheorems)
 
       let simpCtx ← Simp.mkContext
         (config := {

--- a/src/Lean/Meta/Tactic/BVDecide/Normalize/IntToBitVec.lean
+++ b/src/Lean/Meta/Tactic/BVDecide/Normalize/IntToBitVec.lean
@@ -53,7 +53,7 @@ end M
 public def intToBitVecPass : Pass where
   name := `intToBitVec
   run' goal := do
-    let intToBvThms ← intToBitVecExt.getTheorems
+    let intToBvThms ← metaIntToBitVecExt.getTheorems
     let cfg ← PreProcessM.getConfig
     let simpCtx ← Simp.mkContext
       (config := {

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,5 +1,7 @@
 #include "util/options.h"
 
+// update thy
+
 namespace lean {
 options get_default_options() {
     options opts;

--- a/tests/elab/int_toBitVec.lean
+++ b/tests/elab/int_toBitVec.lean
@@ -1,44 +1,44 @@
 example (a b c d e : UInt8) : ((a + (b * c)) = (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec = b.toBitVec - d.toBitVec / e.toBitVec) := by
-  simp only [int_toBitVec]
+  simp only [int_toBitVec_meta]
 
 example (a b c d e : UInt16) : ((a + (b * c)) = (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec = b.toBitVec - d.toBitVec / e.toBitVec) := by
-  simp only [int_toBitVec]
+  simp only [int_toBitVec_meta]
 
 example (a b c d e : UInt32) : ((a + (b * c)) = (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec = b.toBitVec - d.toBitVec / e.toBitVec) := by
-  simp only [int_toBitVec]
+  simp only [int_toBitVec_meta]
 
 example (a b c d e : UInt64) : ((a + (b * c)) = (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec = b.toBitVec - d.toBitVec / e.toBitVec) := by
-  simp only [int_toBitVec]
+  simp only [int_toBitVec_meta]
 
 example (a b c d e : USize) (h : System.Platform.numBits = 64) : ((a + (b * c)) = (b - d / e)) ↔ (a.toBitVec64 h + b.toBitVec64 h * c.toBitVec64 h = b.toBitVec64 h - d.toBitVec64 h / e.toBitVec64 h) := by
-  simp only [int_toBitVec, h]
+  simp only [int_toBitVec_meta, h]
 
 example (a b c d e : UInt8) : ((a + (b * c)) < (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec < b.toBitVec - d.toBitVec / e.toBitVec) := by
-  simp only [int_toBitVec]
+  simp only [int_toBitVec_meta]
 
 example (a b c d e : UInt16) : ((a + (b * c)) < (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec < b.toBitVec - d.toBitVec / e.toBitVec) := by
-  simp only [int_toBitVec]
+  simp only [int_toBitVec_meta]
 
 example (a b c d e : UInt32) : ((a + (b * c)) < (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec < b.toBitVec - d.toBitVec / e.toBitVec) := by
-  simp only [int_toBitVec]
+  simp only [int_toBitVec_meta]
 
 example (a b c d e : UInt64) : ((a + (b * c)) < (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec < b.toBitVec - d.toBitVec / e.toBitVec) := by
-  simp only [int_toBitVec]
+  simp only [int_toBitVec_meta]
 
 example (a b c d e : USize) (h : System.Platform.numBits = 64) : ((a + (b * c)) < (b - d / e)) ↔ (a.toBitVec64 h + b.toBitVec64 h * c.toBitVec64 h < b.toBitVec64 h - d.toBitVec64 h / e.toBitVec64 h) := by
-  simp only [int_toBitVec, h]
+  simp only [int_toBitVec_meta, h]
 
 example (a b c d e : UInt8) : ((a + (b * c)) ≤ (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec ≤ b.toBitVec - d.toBitVec / e.toBitVec) := by
-  simp only [int_toBitVec]
+  simp only [int_toBitVec_meta]
 
 example (a b c d e : UInt16) : ((a + (b * c)) ≤ (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec ≤ b.toBitVec - d.toBitVec / e.toBitVec) := by
-  simp only [int_toBitVec]
+  simp only [int_toBitVec_meta]
 
 example (a b c d e : UInt32) : ((a + (b * c)) ≤ (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec ≤ b.toBitVec - d.toBitVec / e.toBitVec) := by
-  simp only [int_toBitVec]
+  simp only [int_toBitVec_meta]
 
 example (a b c d e : UInt64) : ((a + (b * c)) ≤ (b - d / e)) ↔ (a.toBitVec + b.toBitVec * c.toBitVec ≤ b.toBitVec - d.toBitVec / e.toBitVec) := by
-  simp only [int_toBitVec]
+  simp only [int_toBitVec_meta]
 
 example (a b c d e : USize) (h : System.Platform.numBits = 64) : ((a + (b * c)) ≤ (b - d / e)) ↔ (a.toBitVec64 h + b.toBitVec64 h * c.toBitVec64 h ≤ b.toBitVec64 h - d.toBitVec64 h / e.toBitVec64 h) := by
-  simp only [int_toBitVec, h]
+  simp only [int_toBitVec_meta, h]


### PR DESCRIPTION
This PR makes `int_toBitVec` SymM compatible by splitting it into a SymM and a MetaM simp set. Existing users of `int_toBitVec` should now use `int_toBitVec_meta` in their `simp` invocation instead. 