### PR TITLE
chore: avoid namespace pollution while retaining dot notation

### DIFF
--- a/script/benchReelabRss.lean
+++ b/script/benchReelabRss.lean
@@ -1,6 +1,5 @@
 import Lean.Data.Lsp
 import Lean.Elab.Import
-open IO.FS.Stream.Internal
 open Lean
 open Lean.Lsp
 open Lean.JsonRpc
@@ -87,5 +86,5 @@ def main (args : List String) : IO Unit := do
     IO.println s!"measurement: avg-reelab-rss-delta {avgRSSDelta*1024} b"
 
     let _ ← Ipc.collectDiagnostics requestNo uri versionNo
-    writeLspMessage (← Ipc.stdin) (Message.notification "exit" none)
+    (← Ipc.stdin).writeLspMessage (Message.notification "exit" none)
     discard <| Ipc.waitForExit

--- a/src/Lean/Data/Lsp/Communication.lean
+++ b/src/Lean/Data/Lsp/Communication.lean
@@ -16,7 +16,9 @@ public section
 
 /-! Reading/writing LSP messages from/to IO handles. -/
 
-namespace IO.FS.Stream
+open IO
+
+namespace Lean.IO.FS.Stream
 
 open Lean
 open Lean.JsonRpc
@@ -135,4 +137,4 @@ section
     h.writeLspMessage e
 end
 
-end IO.FS.Stream
+end Lean.IO.FS.Stream

--- a/src/Lean/Data/Lsp/Communication.lean
+++ b/src/Lean/Data/Lsp/Communication.lean
@@ -16,7 +16,7 @@ public section
 
 /-! Reading/writing LSP messages from/to IO handles. -/
 
-namespace IO.FS.Stream.Internal
+namespace IO.FS.Stream
 
 open Lean
 open Lean.JsonRpc
@@ -117,22 +117,22 @@ section
     h.flush
 
   def writeLspMessage (h : FS.Stream) (msg : Message) : IO Unit := do
-    writeSerializedLspMessage h (toJson msg).compress
+    h.writeSerializedLspMessage (toJson msg).compress
 
   def writeLspRequest (h : FS.Stream) (r : Request α) : IO Unit :=
-    writeLspMessage h r
+    h.writeLspMessage r
 
   def writeLspNotification (h : FS.Stream) (n : Notification α) : IO Unit :=
-    writeLspMessage h n
+    h.writeLspMessage n
 
   def writeLspResponse (h : FS.Stream) (r : Response α) : IO Unit :=
-    writeLspMessage h r
+    h.writeLspMessage r
 
   def writeLspResponseError (h : FS.Stream) (e : ResponseError Unit) : IO Unit :=
-    writeLspMessage h (Message.responseError e.id e.code e.message none)
+    h.writeLspMessage (Message.responseError e.id e.code e.message none)
 
   def writeLspResponseErrorWithData (h : FS.Stream) (e : ResponseError α) : IO Unit :=
-    writeLspMessage h e
+    h.writeLspMessage e
 end
 
-end IO.FS.Stream.Internal
+end IO.FS.Stream

--- a/src/Lean/Data/Lsp/Ipc.lean
+++ b/src/Lean/Data/Lsp/Ipc.lean
@@ -19,9 +19,10 @@ public section
 /-! Provides an IpcM monad for interacting with an external LSP process.
 Used for testing the Lean server. -/
 
+open IO Lean
+
 namespace Lean.Lsp.Ipc
 
-open IO
 open JsonRpc
 
 def ipcStdioConfig : Process.StdioConfig where

--- a/src/Lean/Data/Lsp/Ipc.lean
+++ b/src/Lean/Data/Lsp/Ipc.lean
@@ -21,7 +21,7 @@ Used for testing the Lean server. -/
 
 namespace Lean.Lsp.Ipc
 
-open IO FS.Stream.Internal
+open IO
 open JsonRpc
 
 def ipcStdioConfig : Process.StdioConfig where
@@ -40,33 +40,33 @@ def stdout : IpcM FS.Stream := do
   return FS.Stream.ofHandle (←read).stdout
 
 def writeRequest (r : Request α) : IpcM Unit := do
-  writeLspRequest (←stdin) r
+  (←stdin).writeLspRequest r
 
 def writeNotification (n : Notification α) : IpcM Unit := do
-  writeLspNotification (←stdin) n
+  (←stdin).writeLspNotification n
 
 def shutdown (requestNo : Nat) : IpcM Unit := do
   let hIn ← stdout
   let hOut ← stdin
-  writeLspRequest hOut ⟨requestNo, "shutdown", Json.null⟩
+  hOut.writeLspRequest ⟨requestNo, "shutdown", Json.null⟩
   repeat
-    let shutMsg ← readLspMessage hIn
+    let shutMsg ← hIn.readLspMessage
     match shutMsg with
     | Message.response id result =>
       assert! result.isNull
       if id != requestNo then
         throw <| IO.userError s!"Expected id {requestNo}, got id {id}"
 
-      writeLspNotification hOut ⟨"exit", Json.null⟩
+      hOut.writeLspNotification ⟨"exit", Json.null⟩
       break
     | _ =>  -- ignore other messages in between.
       pure ()
 
 def readMessage : IpcM JsonRpc.Message := do
-  readLspMessage (←stdout)
+  (←stdout).readLspMessage
 
 def readRequestAs (expectedMethod : String) (α) [FromJson α] : IpcM (Request α) := do
-  readLspRequestAs (←stdout) expectedMethod α
+  (←stdout).readLspRequestAs expectedMethod α
 
 /--
 Reads response, discarding notifications and server-to-client requests in between.
@@ -75,7 +75,7 @@ if we do care about such notifications.
 -/
 partial def readResponseAs (expectedID : RequestID) (α) [FromJson α] :
     IpcM (Response α) := do
-  let m ← readLspMessage (←stdout)
+  let m ← (←stdout).readLspMessage
   match m with
   | Message.response id result =>
     if id == expectedID then

--- a/src/Lean/Data/Lsp/Utf16.lean
+++ b/src/Lean/Data/Lsp/Utf16.lean
@@ -16,15 +16,17 @@ public section
 /-! LSP uses UTF-16 for indexing, so we need to provide some primitives
 to interact with Lean strings using UTF-16 indices. -/
 
-namespace Char
+open Lean String
+
+namespace Lean.Char
 
 /-- Returns the number of bytes required to encode this `Char` in UTF-16. -/
 def utf16Size (c : Char) : UInt32 :=
   if c.val ≤ 0xFFFF then 1 else 2
 
-end Char
+end Lean.Char
 
-namespace String
+namespace Lean.String
 
 private def csize16 (c : Char) : Nat :=
   c.utf16Size.toNat
@@ -62,7 +64,7 @@ def codepointPosToUtf8PosFrom (s : String) : String.Pos.Raw → Nat → String.P
   | utf8pos, 0 => utf8pos
   | utf8pos, p+1 => codepointPosToUtf8PosFrom s (utf8pos.next s) p
 
-end String
+end Lean.String
 
 namespace Lean
 namespace FileMap

--- a/src/Lean/Data/Lsp/Utf16.lean
+++ b/src/Lean/Data/Lsp/Utf16.lean
@@ -16,18 +16,18 @@ public section
 /-! LSP uses UTF-16 for indexing, so we need to provide some primitives
 to interact with Lean strings using UTF-16 indices. -/
 
-namespace Char.Internal
+namespace Char
 
 /-- Returns the number of bytes required to encode this `Char` in UTF-16. -/
 def utf16Size (c : Char) : UInt32 :=
   if c.val ≤ 0xFFFF then 1 else 2
 
-end Char.Internal
+end Char
 
-namespace String.Internal
+namespace String
 
 private def csize16 (c : Char) : Nat :=
-  Char.Internal.utf16Size c |>.toNat
+  c.utf16Size.toNat
 
 def utf16Length (s : String) : Nat :=
   s.foldr (fun c acc => csize16 c + acc) 0
@@ -62,7 +62,7 @@ def codepointPosToUtf8PosFrom (s : String) : String.Pos.Raw → Nat → String.P
   | utf8pos, 0 => utf8pos
   | utf8pos, p+1 => codepointPosToUtf8PosFrom s (utf8pos.next s) p
 
-end String.Internal
+end String
 
 namespace Lean
 namespace FileMap
@@ -79,12 +79,12 @@ private def lineStartPos (text : FileMap) (line : Nat) : String.Pos.Raw :=
 from an LSP-style 0-indexed (ln, col) position. -/
 def lspPosToUtf8Pos (text : FileMap) (pos : Lsp.Position) : String.Pos.Raw :=
   let lineStartPos := lineStartPos text pos.line
-  let chr := String.Internal.utf16PosToCodepointPosFrom text.source pos.character lineStartPos
-  String.Internal.codepointPosToUtf8PosFrom text.source lineStartPos chr
+  let chr := text.source.utf16PosToCodepointPosFrom pos.character lineStartPos
+  text.source.codepointPosToUtf8PosFrom lineStartPos chr
 
 def leanPosToLspPos (text : FileMap) : Lean.Position → Lsp.Position
   | ⟨line, col⟩ =>
-    ⟨line - 1, String.Internal.codepointPosToUtf16PosFrom text.source col (lineStartPos text (line - 1))⟩
+    ⟨line - 1, text.source.codepointPosToUtf16PosFrom col (lineStartPos text (line - 1))⟩
 
 def utf8PosToLspPos (text : FileMap) (pos : String.Pos.Raw) : Lsp.Position :=
   text.leanPosToLspPos (text.toPosition pos)

--- a/src/Lean/Server/FileWorker.lean
+++ b/src/Lean/Server/FileWorker.lean
@@ -50,7 +50,8 @@ command that the request is looking for and the request sends a "content changed
 namespace Lean.Server.FileWorker
 
 open Lsp
-open IO
+open Lean
+open _root_.IO
 open Snapshots
 open JsonRpc
 

--- a/src/Lean/Server/FileWorker.lean
+++ b/src/Lean/Server/FileWorker.lean
@@ -50,7 +50,7 @@ command that the request is looking for and the request sends a "content changed
 namespace Lean.Server.FileWorker
 
 open Lsp
-open IO FS.Stream.Internal
+open IO
 open Snapshots
 open JsonRpc
 
@@ -522,7 +522,7 @@ section Initialization
 
           -- note that because of `server.reportDelayMs`, we cannot simply set `maxDocVersion` here
           -- as that would allow outdated messages to be reported until the delay is over
-        writeSerializedLspMessage o serialized |>.catchExceptions (fun _ => pure ())
+        o.writeSerializedLspMessage serialized |>.catchExceptions (fun _ => pure ())
       return chanOut
 
     getImportClosure? (snap : Language.Lean.InitialSnapshot) : Array Name := Id.run do
@@ -925,7 +925,7 @@ section MainLoop
   variable (hIn : FS.Stream) in
   partial def mainLoop : WorkerM Unit := do
     let mut st ← get
-    let msg ← readLspMessage hIn
+    let msg ← hIn.readLspMessage
     let filterFinishedTasks (acc : PendingRequestMap) (id : RequestID) (task : ServerTask (Except IO.Error Unit))
         : IO PendingRequestMap := do
       if ← task.hasFinished then
@@ -1035,8 +1035,8 @@ where
     return false
 
 def initAndRunWorker (i o e : FS.Stream) (opts : Options) : IO Unit := do
-  let initParams ← readLspRequestAs i "initialize" InitializeParams
-  let ⟨_, param⟩ ← readLspNotificationAs i "textDocument/didOpen" LeanDidOpenTextDocumentParams
+  let initParams ← i.readLspRequestAs "initialize" InitializeParams
+  let ⟨_, param⟩ ← i.readLspNotificationAs "textDocument/didOpen" LeanDidOpenTextDocumentParams
   let doc := param.textDocument
 
   let doc : DocumentMeta := {
@@ -1067,7 +1067,7 @@ def initAndRunWorker (i o e : FS.Stream) (opts : Options) : IO Unit := do
       throw err
 where
   writeErrorDiag (doc : DocumentMeta) (err : Error) : IO Unit := do
-    writeLspMessage o <| mkPublishDiagnosticsNotification doc #[{
+    o.writeLspMessage <| mkPublishDiagnosticsNotification doc #[{
       range := ⟨⟨0, 0⟩, ⟨1, 0⟩⟩,
       fullRange? := some ⟨⟨0, 0⟩, doc.text.utf8PosToLspPos doc.text.source.rawEndPos⟩
       severity? := DiagnosticSeverity.error

--- a/src/Lean/Server/FileWorker/SetupFile.lean
+++ b/src/Lean/Server/FileWorker/SetupFile.lean
@@ -12,9 +12,10 @@ public import Lean.Server.ServerTask
 
 public section
 
+open IO
+
 namespace Lean.Server.FileWorker
 
-open IO
 
 structure LakeSetupFileOutput where
     spawnArgs : Process.SpawnArgs

--- a/src/Lean/Server/References.lean
+++ b/src/Lean/Server/References.lean
@@ -198,7 +198,7 @@ def findRange? (self : ModuleRefs) (pos : Lsp.Position) (includeStop := false) :
 end Lean.Lsp.ModuleRefs
 
 namespace Lean.Server
-open IO
+open _root_.IO
 open Lsp
 open Elab
 

--- a/src/Lean/Server/Watchdog.lean
+++ b/src/Lean/Server/Watchdog.lean
@@ -69,7 +69,7 @@ state.
 
 namespace Lean.Server.Watchdog
 
-open IO FS.Stream.Internal
+open IO
 open Lsp
 open JsonRpc
 open System.Uri
@@ -406,7 +406,7 @@ section ServerM
 
   def readMessage : ServerM JsonRpc.Message := do
     let ctx ← read
-    let msg ← readLspMessage ctx.hIn
+    let msg ← ctx.hIn.readLspMessage
     if let some logChan := ctx.logData.chan? then
       logChan.sync.send <| .deserialized .clientToServer msg
     return msg
@@ -415,13 +415,13 @@ section ServerM
     let ctx ← read
     if let some logChan := ctx.logData.chan? then
       logChan.sync.send <| .deserialized .serverToClient msg
-    writeLspMessage (← read).hOut msg
+    (← read).hOut.writeLspMessage msg
 
   def writeSerializedMessage (msg : String) : ServerM Unit := do
     let ctx ← read
     if let some logChan := ctx.logData.chan? then
       logChan.sync.send <| .serialized .serverToClient msg
-    writeSerializedLspMessage (← read).hOut msg
+    (← read).hOut.writeSerializedLspMessage msg
 
   def updateFileWorkers (val : FileWorker) : ServerM Unit := do
     (←read).fileWorkersRef.modify (fun fileWorkers => fileWorkers.insert val.doc.uri val)
@@ -532,7 +532,7 @@ section ServerM
     if ! ((← fw.state.atomically get) matches .running) then
       return
     try
-      writeLspResponse fw.stdin r
+      fw.stdin.writeLspResponse r
     catch _ =>
       pure ()
 
@@ -540,7 +540,7 @@ section ServerM
     if ! ((← fw.state.atomically get) matches .running) then
       return
     try
-      writeLspResponseError fw.stdin r
+      fw.stdin.writeLspResponseError r
     catch _ =>
       pure ()
 
@@ -752,7 +752,7 @@ section ServerM
       while true do
         let msg ←
           try
-            readLspMessageAsString fw.stdout
+            fw.stdout.readLspMessageAsString
           catch _ =>
             let exitCode ← fw.waitForProc
             -- Remove surviving descendant processes, if any, such as from nested builds.
@@ -867,8 +867,8 @@ section ServerM
     updateFileWorkers fw
     let commTask ← forwardMessages fw
     let fw : FileWorker := { fw with commTask? := some commTask }
-    writeLspRequest fw.stdin ⟨0, "initialize", st.initParams⟩
-    writeLspNotification fw.stdin {
+    fw.stdin.writeLspRequest ⟨0, "initialize", st.initParams⟩
+    fw.stdin.writeLspNotification {
       method := "textDocument/didOpen"
       param  := {
         textDocument := {
@@ -885,7 +885,7 @@ section ServerM
     let reqQueue ← st.requestData.getRequestQueue m.uri
     for (_, msg) in reqQueue do
       try
-        writeLspMessage fw.stdin msg
+        fw.stdin.writeLspMessage msg
       catch _ =>
         setWorkerState fw .cannotWrite
         break
@@ -905,7 +905,7 @@ section ServerM
       -- Client closed stdout => Still ensure that file worker is terminated
       pure ()
     try
-      writeLspMessage fw.stdin (Message.notification "exit" none)
+      fw.stdin.writeLspMessage (Message.notification "exit" none)
     catch _ =>
       -- File worker crashed during termination => Treat it as terminated
       pure ()
@@ -932,7 +932,7 @@ section ServerM
       startFileWorker fw.doc
     | WorkerState.running =>
       try
-        writeLspMessage fw.stdin msg
+        fw.stdin.writeLspMessage msg
       catch _ =>
         setWorkerState fw .cannotWrite
 
@@ -1610,7 +1610,7 @@ def mkLeanServerCapabilities : ServerCapabilities := {
 def initAndRunWatchdogAux : ServerM Unit := do
   let st ← read
   try
-    discard $ readLspNotificationAs st.hIn "initialized" InitializedParams
+    discard $ st.hIn.readLspNotificationAs "initialized" InitializedParams
     writeMessage {
       id := RequestID.str "register_lean_watcher"
       method := "client/registerCapability"
@@ -1636,7 +1636,7 @@ def initAndRunWatchdogAux : ServerM Unit := do
   while true do
     let msg: JsonRpc.Message ←
       try
-        readLspMessage st.hIn
+        st.hIn.readLspMessage
       catch _ =>
         /-
         NOTE(WN): It looks like instead of sending the `exit` notification,
@@ -1733,8 +1733,8 @@ def initAndRunWatchdog (args : List String) (i o : FS.Stream) : IO Unit := do
   }
   let importData ← IO.mkRef ⟨Std.TreeMap.empty, Std.TreeMap.empty⟩
   let requestData ← RequestDataMutex.new
-  let initRequest ← readLspRequestAs i "initialize" InitializeParams
-  writeLspResponse o {
+  let initRequest ← i.readLspRequestAs "initialize" InitializeParams
+  o.writeLspResponse {
     id     := initRequest.id
     result := {
       capabilities := mkLeanServerCapabilities

--- a/src/Lean/Server/Watchdog.lean
+++ b/src/Lean/Server/Watchdog.lean
@@ -69,7 +69,8 @@ state.
 
 namespace Lean.Server.Watchdog
 
-open IO
+open Lean
+open _root_.IO
 open Lsp
 open JsonRpc
 open System.Uri


### PR DESCRIPTION
This PR reverts #14258, #14260 and #14262 in favor of a far superior solution based on #6189.