### PR TITLE
chore: move `Nat.elimOffset` to internal namespace

### DIFF
--- a/src/Init/Data/Nat/Internal/Linear.lean
+++ b/src/Init/Data/Nat/Internal/Linear.lean
@@ -543,7 +543,7 @@ theorem Expr.eq_of_toNormPoly_eq (ctx : Context) (e e' : Expr) (h : e.toNormPoly
 
 end Internal.Linear
 
-def elimOffset {α : Sort u} (a b k : Nat) (h₁ : a + k = b + k) (h₂ : a = b → α) : α :=
+def Internal.elimOffset {α : Sort u} (a b k : Nat) (h₁ : a + k = b + k) (h₂ : a = b → α) : α :=
   h₂ (Nat.add_right_cancel h₁)
 
 end Nat

--- a/src/Lean/Meta/Match/MatchEqs.lean
+++ b/src/Lean/Meta/Match/MatchEqs.lean
@@ -52,9 +52,9 @@ private def substSomeVar (mvarId : MVarId) : MetaM (Array MVarId) := mvarId.with
   throwError "substSomeVar failed"
 
 private def unfoldElimOffset (mvarId : MVarId) : MetaM MVarId := do
-  if Option.isNone <| (← mvarId.getType).find? fun e => e.isConstOf ``Nat.elimOffset then
-    throwError "goal's target does not contain `Nat.elimOffset`"
-  mvarId.deltaTarget (· == ``Nat.elimOffset)
+  if Option.isNone <| (← mvarId.getType).find? fun e => e.isConstOf ``Nat.Internal.elimOffset then
+    throwError "goal's target does not contain `Nat.Internal.elimOffset`"
+  mvarId.deltaTarget (· == ``Nat.Internal.elimOffset)
 
 /--
 Helper method for proving a conditional equational theorem associated with an alternative of

--- a/src/Lean/Meta/Tactic/UnifyEq.lean
+++ b/src/Lean/Meta/Tactic/UnifyEq.lean
@@ -81,7 +81,7 @@ def unifyEq? (mvarId : MVarId) (eqFVarId : FVarId) (subst : FVarSubst := {})
             throwError "Dependent elimination failed: Failed to solve equation{indentExpr eqDecl.type}"
         /- Special support for offset equalities -/
         let injectionOffset? (a b : Expr) := do
-          unless (← getEnv).contains ``Nat.elimOffset do return none
+          unless (← getEnv).contains ``Nat.Internal.elimOffset do return none
           let some (xa, ka) ← toOffset? a | return none
           let some (xb, kb) ← toOffset? b | return none
           if ka == 0 || kb == 0 then return none -- use default noConfusion
@@ -96,7 +96,7 @@ def unifyEq? (mvarId : MVarId) (eqFVarId : FVarId) (subst : FVarSubst := {})
           let newTarget ← mkArrow (← mkEq x y) target
           let tag ← mvarId.getTag
           let newMVar ← mkFreshExprSyntheticOpaqueMVar newTarget tag
-          let val := mkAppN (mkConst ``Nat.elimOffset [u]) #[target, x, y, mkNatLit k, eqDecl.toExpr, newMVar]
+          let val := mkAppN (mkConst ``Nat.Internal.elimOffset [u]) #[target, x, y, mkNatLit k, eqDecl.toExpr, newMVar]
           mvarId.assign val
           let mvarId ← newMVar.mvarId!.tryClear eqDecl.fvarId
           return some mvarId

--- a/tests/elab/depElim1.lean.out.expected
+++ b/tests/elab/depElim1.lean.out.expected
@@ -39,7 +39,7 @@ fun α motive n xs ys h_1 h_2 =>
             Vec.casesOn (motive := fun a_2 x => n_1 + 1 = a_2 → ys ≍ x → motive (n_1 + 1) (Vec.cons a a_1) ys) ys
               (fun h => False.elim ⋯)
               (fun {n} a_2 a_3 h =>
-                n_1.elimOffset n 1 h fun x =>
+                Nat.Internal.elimOffset n_1 n 1 h fun x =>
                   Eq.ndrec (motive := fun {n} =>
                     (a_4 : Vec α n) → ys ≍ Vec.cons a_2 a_4 → motive (n_1 + 1) (Vec.cons a a_1) ys)
                     (fun a_4 h => ⋯ ▸ h_2 n_1 a a_1 a_2 a_4) x a_3)


### PR DESCRIPTION
This PR moves `Nat.elimOffset`, which is an auxiliary function used by the equation compiler, into an internal namespace.
