### PR TITLE
chore: move `Injective.leftInverse` out of `grind` module

### DIFF
--- a/src/Init/Data/Function.lean
+++ b/src/Init/Data/Function.lean
@@ -6,6 +6,9 @@ Authors: Kim Morrison
 module
 prelude
 public import Init.Grind.Tactics
+import Init.NotationExtra
+import Init.Classical
+
 public section
 namespace Function
 
@@ -132,5 +135,25 @@ protected theorem LeftInverse.id {α β} {g : β → α} {f : α → β} (h : Le
 
 protected theorem RightInverse.id {α β} {g : β → α} {f : α → β} (h : RightInverse g f) : f ∘ g = id :=
   funext h
+
+theorem Injective.exists_leftInverse
+    {α β} {f : α → β} (hf : Injective f) [hα : Nonempty α] :
+    ∃ g : β → α, LeftInverse g f := by
+  classical
+  cases hα; next a0 =>
+  let g : β → α := fun b =>
+    if h : ∃ a, f a = b then Classical.choose h else a0
+  exists g
+  intro a
+  have h : ∃ a', f a' = f a := ⟨a, rfl⟩
+  have hfa : f (Classical.choose h) = f a := Classical.choose_spec h
+  have : Classical.choose h = a := hf hfa
+  simp [g, h, this]
+
+@[deprecated Injective.exists_leftInverse (since := "2026-07-06")]
+theorem Injective.leftInverse
+    {α β} (f : α → β) (hf : Injective f) [hα : Nonempty α] :
+    ∃ g : β → α, LeftInverse g f :=
+  hf.exists_leftInverse
 
 end Function

--- a/src/Init/Grind/Injective.lean
+++ b/src/Init/Grind/Injective.lean
@@ -12,25 +12,11 @@ public section
 namespace Lean.Grind
 open Function
 
-theorem _root_.Function.Injective.leftInverse
-    {α β} (f : α → β) (hf : Injective f) [hα : Nonempty α] :
-    ∃ g : β → α, LeftInverse g f := by
-  classical
-  cases hα; next a0 =>
-  let g : β → α := fun b =>
-    if h : ∃ a, f a = b then Classical.choose h else a0
-  exists g
-  intro a
-  have h : ∃ a', f a' = f a := ⟨a, rfl⟩
-  have hfa : f (Classical.choose h) = f a := Classical.choose_spec h
-  have : Classical.choose h = a := hf hfa
-  simp [g, h, this]
-
 noncomputable def leftInv {α : Sort u} {β : Sort v} (f : α → β) (hf : Injective f) [Nonempty α] : β → α :=
-  Classical.choose (hf.leftInverse f)
+  Classical.choose hf.exists_leftInverse
 
 theorem leftInv_eq {α : Sort u} {β : Sort v} (f : α → β) (hf : Injective f) [Nonempty α] (a : α) : leftInv f hf (f a) = a :=
-  Classical.choose_spec (hf.leftInverse f) a
+  Classical.choose_spec hf.exists_leftInverse a
 
 @[app_unexpander leftInv]
 meta def leftInvUnexpander : PrettyPrinter.Unexpander := fun stx => do


### PR DESCRIPTION
This PR moves the public declaration `Function.Injective.leftInverse` out of `Init.Grind` and into `Init.Data.Function`.

It is renamed to `Function.Injective.exists_leftInverse` along the way.