### PR TITLE
fix: make String.toList semireducible

### DIFF
--- a/src/Init/Data/String/Basic.lean
+++ b/src/Init/Data/String/Basic.lean
@@ -237,7 +237,7 @@ Examples:
  * `"".toList = []`
  * `"\n".toList = ['\n']`
 -/
-@[extern "lean_string_data", expose, implicit_reducible]
+@[extern "lean_string_data", expose]
 def String.toList (s : String) : List Char :=
   (String.Internal.toArray s).toList
 


### PR DESCRIPTION
This PR makes `String.toList` semireducible because unfolding it throws the definitional equality checker deep into the weeds of its internal implementation.