### PR TITLE
fix: strip mdata from the program in `vcgen`

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -216,6 +216,12 @@ private def replaceProgDefEq (goal : MVarId) (info : WPInfo) (prog : Expr) :
   let newTarget ← mkAppNS target.getAppFn (relArgs.set! (relArgs.size - 1) rhs)
   goal.replaceTargetDefEq newTarget
 
+/-- Strip an `mdata` wrapper (such as the `save_info` annotation left by spec elaboration)
+from the program in `goal`'s target, so the remaining strategies see the bare term. -/
+private def wpConsumeMData? (goal : MVarId) (info : WPInfo) : VCGenM (Option MVarId) := do
+  let .mdata .. := info.prog | return none
+  return some (← replaceProgDefEq goal info info.prog.consumeMData)
+
 /-- Strategy 11a: hoist or zeta-substitute a `let` from the program head. -/
 private def wpLet? (goal : MVarId) (info : WPInfo) : VCGenM (Option MVarId) := do
   let .letE name type val body nondep := info.prog.getAppFn | return none
@@ -501,6 +507,8 @@ public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := g
     -- Stop if the program matches the `until` pattern.
     if ← matchesUntilPattern info.m info.prog then
       return .stop (.untilPatternMatched info.m)
+    if let some g ← wpConsumeMData? goal info then
+      return .goals scope [g]
     if let some g ← wpLet? goal info then
       VCGen.burnOne
       return .goals scope [g]

--- a/tests/elab/vcgenMDataProgram.lean
+++ b/tests/elab/vcgenMDataProgram.lean
@@ -1,0 +1,49 @@
+import Std.Internal.Do
+import Lean
+import Std
+import Std.Tactic.Do
+
+set_option mvcgen.warning false
+
+/-! `vcgen` must classify a program wrapped in an `mdata` node, such as the
+`save_info` annotation left behind by spec elaboration. -/
+
+open Std.Internal.Do Lean.Order
+
+/-- Wrap a term in a `save_info` `mdata` node, exactly what spec elaboration leaves behind. -/
+syntax "mdata% " term : term
+
+open Lean Elab Term in
+elab_rules : term <= ty
+  | `(mdata% $t) => do
+    return .mdata (KVMap.empty.insert `save_info (.ofNat 1)) (← elabTerm t ty)
+
+-- `match` program.
+example (c : Bool) :
+    ⦃fun _ => True⦄ (mdata% (match c with | true => pure 1 | false => pure 2) : StateM Nat Nat)
+    ⦃fun _ _ => True⦄ := by
+  vcgen
+
+-- Bare `pure` program.
+example :
+    ⦃fun _ => True⦄ (mdata% (pure 1) : StateM Nat Nat)
+    ⦃fun _ _ => True⦄ := by
+  vcgen
+
+-- `ite` program.
+example (c : Bool) :
+    ⦃fun _ => True⦄ (mdata% (if c then pure 1 else pure 2) : StateM Nat Nat)
+    ⦃fun _ _ => True⦄ := by
+  vcgen
+
+-- `let` program.
+example :
+    ⦃fun _ => True⦄ (mdata% (let x := 1; pure x) : StateM Nat Nat)
+    ⦃fun _ _ => True⦄ := by
+  vcgen
+
+-- `do` bind sequence over state operations.
+example :
+    ⦃fun _ => True⦄ (mdata% (do let x ← get; modify (· + x); pure x) : StateM Nat Nat)
+    ⦃fun _ _ => True⦄ := by
+  vcgen


### PR DESCRIPTION
This PR lets `vcgen` handle a program wrapped in an `mdata` node, such as the `save_info` annotation left behind by spec elaboration, instead of failing with an internal error.

`getWPInfo?` extracts the program component of a `wp` application verbatim, so an `mdata` wrapper hides the program's head from every decomposition strategy and the goal falls through to the "This should not happen" error. A new normalization step consumes the `mdata` on the program in the goal before the other `wp` strategies run.