### PR TITLE
fix: restore go-to-definition on `mut` variables after a `for` loop

### DIFF
--- a/src/Lean/Elab/BuiltinDo/Let.lean
+++ b/src/Lean/Elab/BuiltinDo/Let.lean
@@ -37,10 +37,7 @@ def LetOrReassign.checkMutVars (letOrReassign : LetOrReassign) (vars : Array Ide
 def LetOrReassign.registerReassignAliasInfo (letOrReassign : LetOrReassign) (vars : Array Ident) : DoElabM Unit := do
   if letOrReassign matches .reassign then
     for var in vars do
-      if let some baseMutVar ← findMutVar? var.getId then
-        let id := (← getFVarFromUserName var.getId).fvarId!
-        if id != baseMutVar.baseId then
-          pushInfoLeaf <| .ofFVarAliasInfo (baseMutVar.mkAliasInfo id)
+      registerMutVarAlias var.getId
 
 def elabDoLetOrReassignWith (hint : MessageData) (letOrReassign : LetOrReassign) (vars : Array Ident)
     (k : DoElabM Expr) (elabBody : (body : Term) → TermElabM Expr) : DoElabM Expr := do

--- a/src/Lean/Elab/Do/Basic.lean
+++ b/src/Lean/Elab/Do/Basic.lean
@@ -577,6 +577,16 @@ def DoElemCont.withDeadCodeFromInfo (dec : DoElemCont) (info : ControlInfo) : Do
   { dec with k := withDeadCode (if info.noFallthrough then .deadSemantically else .alive) dec.k }
 
 /--
+If `x` is a `mut` variable, record that its current binding aliases the original `let mut` binding,
+so that go-to-definition and find-references treat both as the same variable.
+-/
+def registerMutVarAlias (x : Name) : DoElabM Unit := do
+  if let some baseMutVar ← findMutVar? x then
+    let id := (← getFVarFromUserName x).fvarId!
+    if id != baseMutVar.baseId then
+      pushInfoLeaf <| .ofFVarAliasInfo (baseMutVar.mkAliasInfo id)
+
+/--
 Given a list of mut vars `vars` and an FVar `tupleVar` binding a tuple, bind the mut vars to the
 fields of the tuple and call `k` in the resulting local context.
 -/
@@ -588,16 +598,22 @@ where
     match vars with
     | []  => mkLetFVars letFVars (← k)
     | [x] =>
-      withLetDecl x tupleTy tuple fun x => do mkLetFVars (letFVars.push x) (← k)
+      withLetDecl x tupleTy tuple fun xf => do
+        registerMutVarAlias x
+        mkLetFVars (letFVars.push xf) (← k)
     | [x, y] =>
       let (fst, fstTy, snd, sndTy) ← getProdFields tuple tupleTy
-      withLetDecl x fstTy fst fun x =>
-      withLetDecl y sndTy snd fun y => do mkLetFVars (letFVars.push x |>.push y) (← k)
+      withLetDecl x fstTy fst fun xf =>
+      withLetDecl y sndTy snd fun yf => do
+        registerMutVarAlias x
+        registerMutVarAlias y
+        mkLetFVars (letFVars.push xf |>.push yf) (← k)
     | x :: xs => do
       let (fst, fstTy, snd, sndTy) ← getProdFields tuple tupleTy
-      withLetDecl x fstTy fst fun x => do
-      withLetDecl (← tupleVar.getUserName) sndTy snd fun r => do
-        go xs r.fvarId! sndTy (letFVars |>.push x |>.push r)
+      withLetDecl x fstTy fst fun xf => do
+        registerMutVarAlias x
+        withLetDecl (← tupleVar.getUserName) sndTy snd fun r => do
+          go xs r.fvarId! sndTy (letFVars |>.push xf |>.push r)
 
 /--
   Backtrackable state for the `TermElabM` monad.

--- a/tests/server_interactive/goToMutVarAfterFor.lean
+++ b/tests/server_interactive/goToMutVarAfterFor.lean
@@ -1,0 +1,10 @@
+/-! Go-to-definition on a `mut` variable referenced after a `for` loop resolves to its `let mut`
+declaration. -/
+--^ waitForILeans
+
+example : Id Nat := do
+  let mut myNat := 1
+  for i in [1,2,3] do
+    myNat := myNat + i
+  return myNat
+       --^ textDocument/definition

--- a/tests/server_interactive/goToMutVarAfterFor.lean.out.expected
+++ b/tests/server_interactive/goToMutVarAfterFor.lean.out.expected
@@ -1,0 +1,5 @@
+{"textDocument": {"uri": "file:///goToMutVarAfterFor.lean"},
+ "position": {"line": 8, "character": 9}}
+[{"uri": "file:///goToMutVarAfterFor.lean",
+  "range":
+  {"start": {"line": 5, "character": 10}, "end": {"line": 5, "character": 15}}}]


### PR DESCRIPTION
This PR makes go-to-definition and find-references work on a `let mut` variable that is referenced after a `for` loop (or any construct that threads mutable state through a tuple).

Recording that a fresh binding aliases the original `let mut` declaration is factored into `registerMutVarAlias`, shared by both sites that give a `mut` variable a new binding: reassignment and rebinding from the state tuple in `bindMutVarsFromTuple`. The latter previously omitted the alias, so the language server no longer connected a post-loop reference to its declaration.