### PR TITLE
fix: refine `return` in dependent `do`-`match` branches

### DIFF
--- a/src/Lean/Elab/BuiltinDo/Match.lean
+++ b/src/Lean/Elab/BuiltinDo/Match.lean
@@ -33,7 +33,7 @@ private def elabDoSeqWithRefinedType (type : Expr) (doSeq : DoSeq) (dec : DoElem
   trace[Elab.do.match] "newDoBlockResultType: {newDoBlockResultType}"
   -- The `doBlockResultType` *is* the continuation's return type, since it is duplicable.
   let dec := { dec with resultType := newDoBlockResultType }
-  withDoBlockResultType newDoBlockResultType (elabDoSeq doSeq dec)
+  withRefinedResultType newDoBlockResultType (elabDoSeq doSeq dec)
 
 /--
 Expand a `doMatch` into a term-level `match`. We do this for `match_syntax` and

--- a/src/Lean/Elab/Do/Basic.lean
+++ b/src/Lean/Elab/Do/Basic.lean
@@ -711,6 +711,18 @@ def withDoBlockResultType (doBlockResultType : Expr) (k : DoElabM α) : DoElabM 
   withReader (fun ctx => { ctx with doBlockResultType }) k
 
 /--
+Refine the result type of the `do` block and its `return` continuation for the scope of `k`,
+as needed for a dependent `match` branch where a bare `return` targets the refined branch type.
+
+Relies on the `return` continuation result type coinciding with the `do` block result type, which
+holds for the tail-position dependent `match` this serves.
+-/
+def withRefinedResultType (doBlockResultType : Expr) (k : DoElabM α) : DoElabM α := do
+  let contInfo := (← read).contInfo.toContInfo
+  let contInfo := { contInfo with returnCont.resultType := doBlockResultType }
+  withReader (fun ctx => { ctx with doBlockResultType, contInfo := contInfo.toContInfoRef }) k
+
+/--
 Prepare the context for elaborating the body of a loop.
 This includes setting the return continuation, break continuation, continue continuation, as
 well as the changed result type of the `do` block in the loop body.

--- a/tests/elab/doMatchDependent.lean
+++ b/tests/elab/doMatchDependent.lean
@@ -38,3 +38,27 @@ example (x : Nat) (n : Fin (x + 1)) : Id Bool := do
     | 42 => pure 40
     | _ => pure 0
   return y % 2 == 0
+
+-- A bare `return` in a dependent branch targets the refined branch type.
+example (n : Nat) : Id (Fin (n + 1)) := do
+  match (dependent := true) n with
+  | 0 => return 0
+  | _k + 1 => return 1
+
+-- The same holds through a nested `do`.
+example (n : Nat) : Id (Fin (n + 1)) := do
+  match (dependent := true) n with
+  | 0 => do return 0
+  | _k + 1 => do return 1
+
+-- And through a parenthesized `do` block.
+example (n : Nat) : Id (Fin (n + 1)) := do
+  match (dependent := true) n with
+  | 0 => (do return 0)
+  | _k + 1 => (do return 1)
+
+-- The refinement holds under further control flow inside the branch.
+example (n : Nat) : Id (Fin (n + 1)) := do
+  match (dependent := true) n with
+  | 0 => if true then return 0 else return 0
+  | _k + 1 => return 1


### PR DESCRIPTION
This PR makes a bare `return` inside a `match (dependent := true)` branch of a `do` block target the dependently-refined branch type, so a branch like `| 0 => return 0` type-checks against the refined `do`-block result type without wrapping it in a nested `(do …)`.

The dependent-branch elaborator refined the `do`-block result type but left the `return` continuation's result type unchanged, so `return` produced a value of the unrefined result type. It now refines the `return` continuation as well. This is sound because a dependent `do`-`match` is only admitted when its result type equals the `do`-block result type, so the match is in tail position and `return` yields the branch's out-flowing value.