### PR TITLE
feat: maintain `SymM` term invariants at `shareCommon`

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
@@ -151,7 +151,10 @@ public partial def run (goal : Grind.Goal) (ctx : Context) (scope : VCGen.Scope)
     Grind.GrindM Result := do
   let initState : State :=
     { fuel := match stepLimit? with | some n => .limited n | none => .unlimited, frameDB? }
-  let ((), state) ← StateRefT'.run (ReaderT.run (work scope goal) ctx) initState
+  -- VCGen temporarily violates the `SymM` folded-projections invariant: `reduceHead?`
+  -- exposes kernel projections in intermediate terms and restores the invariant in its
+  -- final result, so the `shareCommon` kernel-projection check is disabled.
+  let ((), state) ← Sym.withoutFoldProjsCheck <| StateRefT'.run (ReaderT.run (work scope goal) ctx) initState
   _ ← state.invariants.mapIdxM fun idx mv => do
     mv.setTag (Name.mkSimple ("inv" ++ toString (idx + 1)))
   _ ← state.vcs.mapIdxM fun idx g => do

--- a/src/Lean/Meta/Sym/AlphaShareBuilder.lean
+++ b/src/Lean/Meta/Sym/AlphaShareBuilder.lean
@@ -56,10 +56,10 @@ abbrev AlphaShareBuilderM := ReaderT Bool AlphaShareCommonM
 Helper function for lifting a `AlphaShareBuilderM` action to `GrindM`
 -/
 abbrev liftBuilderM (k : AlphaShareBuilderM α) : SymM α := do
-  let share ← modifyGet fun s => (s.share, { s with share := {} })
-  let (a, share) := k (← isDebugEnabled) share
-  modify fun s => { s with share }
-  return a
+  -- The builder functions are a trusted layer, so invariant checks are disabled.
+  match (← runShareCommonM (k (← isDebugEnabled)) { env := (← getEnv) }) with
+  | some a => return a
+  | none => unreachable! -- checks are disabled
 
 protected def Builder.share1 (e : Expr) : AlphaShareBuilderM Expr := do
   let prev := (← get).set.findD { expr := e } dummy

--- a/src/Lean/Meta/Sym/AlphaShareCommon.lean
+++ b/src/Lean/Meta/Sym/AlphaShareCommon.lean
@@ -6,6 +6,10 @@ Authors: Leonardo de Moura
 module
 prelude
 public import Lean.Meta.Sym.ExprPtr
+public import Lean.Environment
+import Init.Grind.Util
+import Lean.ReducibilityAttrs
+import Lean.ProjFns
 public section
 namespace Lean.Meta.Sym
 
@@ -49,6 +53,27 @@ private def alphaEq (e₁ e₂ : Expr) : Bool := Id.run do
     let .proj n₂ i₂ b₂ := e₂ | false
     n₁ == n₂ && i₁ == i₂ && isSameExpr b₁ b₂
 
+/--
+Returns `true` if `declName` is the name of a grind helper declaration that
+should not be unfolded by `unfoldReducible`. `Grind.EqMatch` and `Grind.MatchCond`
+are `abbrev`s, but they are gadgets that must survive until the corresponding
+propagators consume them.
+-/
+def isGrindGadget (declName : Name) : Bool :=
+  declName == ``Grind.EqMatch || declName == ``Grind.MatchCond
+
+/--
+Returns `true` if `declName` is a reducible constant that the `unfoldReducible`
+preprocessing step must unfold.
+
+Projection functions are excluded even though they are `reducible` by default:
+unfolding them produces kernel projections, which the `foldProjs` preprocessing
+step folds back into projection function applications.
+-/
+def isUnfoldReducibleCandidate (env : Environment) (declName : Name) : Bool :=
+  getReducibilityStatusCore env declName matches .reducible
+    && !isGrindGadget declName && !env.isProjectionFn declName
+
 structure AlphaKey where
   expr : Expr
 
@@ -58,16 +83,54 @@ instance : Hashable AlphaKey where
 instance : BEq AlphaKey where
   beq k₁ k₂ := private alphaEq k₁.expr k₂.expr
 
-structure AlphaShareCommon.State where
+namespace AlphaShareCommon
+
+/-- Readonly context for `AlphaShareCommonM`. -/
+structure Context where
+  env : Environment
+  /--
+  When `true`, `shareCommonAlpha` and `shareCommonAlphaInc` throw when hash-consing
+  a new reducible constant that the `unfoldReducible` preprocessing step should
+  have unfolded (see `isUnfoldReducibleCandidate`).
+  -/
+  checkReducible : Bool := false
+  /--
+  When `true`, `shareCommonAlpha` and `shareCommonAlphaInc` throw when hash-consing
+  a new kernel projection (`Expr.proj`), which the `foldProjs` preprocessing step
+  should have folded.
+  -/
+  checkProj : Bool := false
+
+structure State where
   set : PHashSet AlphaKey := {}
 
-abbrev AlphaShareCommonM := StateM AlphaShareCommon.State
+end AlphaShareCommon
+
+/--
+Monad for hash-consing expressions up to alpha-equivalence.
+
+When checks are enabled in the context, hash-consing throws if a **new** term
+violates the `SymM` representation invariants (reducible constants unfolded,
+kernel projections folded). Terms already in the state are never re-checked:
+membership certifies that a term was admitted before. On a throw, the state
+contains every term hash-consed before the failure; these terms individually
+satisfy the invariants, so callers should keep the partial state and retry after
+repairing the input term.
+-/
+abbrev AlphaShareCommonM := ReaderT AlphaShareCommon.Context (EStateM Unit AlphaShareCommon.State)
+
+/--
+Returns `true` if `ctx.checkReducible` is true and `declName` is reducible declaration that
+should be unfolded.
+-/
+private def isReducible (ctx : AlphaShareCommon.Context) (declName : Name) : Bool :=
+  ctx.checkReducible && isUnfoldReducibleCandidate ctx.env declName
 
 private structure State where
   map : Std.HashMap ExprPtr Expr := {}
   set : PHashSet AlphaKey := {}
 
-private abbrev M := StateM State
+private abbrev M := ReaderT AlphaShareCommon.Context (EStateM Unit State)
 
 private def dummy : AlphaKey := { expr := mkConst `__dummy__}
 
@@ -109,10 +172,17 @@ private abbrev visit (e : Expr) (k : M Expr) : M Expr := do
 
 private def go (e : Expr) : M Expr := do
   match e with
-  | .bvar .. | .mvar .. | .const .. | .fvar .. | .sort .. | .lit .. =>
+  | .bvar .. | .mvar .. | .fvar .. | .sort .. | .lit .. =>
     if let some r := (← get).set.find? { expr := e } then
       return r.expr
     else
+      modify fun { set, map } => { set := set.insert { expr := e }, map }
+      return e
+  | .const declName _ =>
+    if let some r := (← get).set.find? { expr := e } then
+      return r.expr
+    else
+      if isReducible (← read) declName then throw ()
       modify fun { set, map } => { set := set.insert { expr := e }, map }
       return e
   | .app f a => visit e (return e.updateApp! (← go f) (← go a))
@@ -120,15 +190,20 @@ private def go (e : Expr) : M Expr := do
   | .forallE _ d b _ => visit e (return e.updateForallE! (← go d) (← go b))
   | .lam _ d b _ => visit e (return e.updateLambdaE! (← go d) (← go b))
   | .mdata _ b => visit e (return e.updateMData! (← go b))
-  | .proj _ _ b => visit e (return e.updateProj! (← go b))
+  | .proj _ _ b => visit e do
+      if (← read).checkProj then throw ()
+      return e.updateProj! (← go b)
 
 /-- Similar to `shareCommon`, but handles alpha-equivalence. -/
-@[inline] def shareCommonAlpha (e : Expr) : AlphaShareCommonM Expr := fun s =>
+@[inline] def shareCommonAlpha (e : Expr) : AlphaShareCommonM Expr := fun ctx s =>
   if let some r := s.set.find? { expr := e } then
-    (r.expr, s)
+    .ok r.expr s
   else
-    let (e, { set, .. }) := go e |>.run { map := {}, set := s.set }
-    (e, ⟨set⟩)
+    -- On error, we keep the partial state: terms hash-consed before the failure
+    -- individually satisfy the invariants, so a retry can reuse them.
+    match go e ctx { map := {}, set := s.set } with
+    | .ok e { set, .. } => .ok e { set }
+    | .error _ { set, .. } => .error () { set }
 
 private def saveInc (e : Expr) : AlphaShareCommonM Expr := do
   let prev := (← get).set.findD { expr := e } dummy
@@ -172,12 +247,25 @@ let result ← shareCommonAlphaInc result -- efficiently restore sharing
 where
   go (e : Expr) : AlphaShareCommonM Expr := do
   match e with
-  | .bvar .. | .mvar .. | .const .. | .fvar .. | .sort .. | .lit .. => saveInc e
+  | .bvar .. | .mvar .. | .fvar .. | .sort .. | .lit .. => saveInc e
+  | .const declName _ =>
+    let prev := (← get).set.findD { expr := e } dummy
+    if isSameExpr prev.expr dummy.expr then
+      -- `e` is new. The check runs only here: set membership certifies that a
+      -- term was admitted before, and re-checking admitted terms would repeat
+      -- the repair on every call when the term was admitted with residual dirt.
+      if isReducible (← read) declName then throw ()
+      modify fun { set := set } => { set := set.insert { expr := e } }
+      return e
+    else
+      return prev.expr
   | .app f a => visitInc e (return e.updateApp! (← go f) (← go a))
   | .letE _ t v b _ => visitInc e (return e.updateLetE! (← go t) (← go v) (← go b))
   | .forallE _ d b _ => visitInc e (return e.updateForallE! (← go d) (← go b))
   | .lam _ d b _ => visitInc e (return e.updateLambdaE! (← go d) (← go b))
   | .mdata _ b => visitInc e (return e.updateMData! (← go b))
-  | .proj _ _ b => visitInc e (return e.updateProj! (← go b))
+  | .proj _ _ b => visitInc e do
+      if (← read).checkProj then throw ()
+      return e.updateProj! (← go b)
 
 end Lean.Meta.Sym

--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -1013,9 +1013,16 @@ def noPending : UnifyM Bool := do
   let s ← get
   return s.ePending.isEmpty && s.uPending.isEmpty && s.iPending.isEmpty
 
-def instantiateLevelParamsS (e : Expr) (paramNames : List Name) (us : List Level) : SymM Expr :=
-  -- We do not assume `e` is maximally shared
-  shareCommon (e.instantiateLevelParams paramNames us)
+def instantiateLevelParamsS (e : Expr) (paramNames : List Name) (us : List Level) : SymM Expr := do
+  /-
+  We do not assume `e` is maximally shared.
+  **Note:** We disable checks here because `e` may contain loose bound variables,
+  and the repair procedure only works on closed terms. This is ok because this
+  function only creates temporary terms for performing definitional equality tests
+  and synthesizing instances (see `mkPreResult`). These terms are not internalized;
+  terms that survive into the goal go through checked entry points.
+  -/
+  shareCommonWithoutChecks (e.instantiateLevelParams paramNames us)
 
 inductive MkPreResultResult where
   | failed

--- a/src/Lean/Meta/Sym/SymM.lean
+++ b/src/Lean/Meta/Sym/SymM.lean
@@ -7,6 +7,9 @@ module
 prelude
 public import Lean.Meta.Sym.AlphaShareCommon
 public import Lean.Meta.CongrTheorems
+public import Lean.Meta.Transform
+import Lean.Meta.WHNF
+import Lean.Meta.AppBuilder
 public section
 namespace Lean.Meta.Sym
 
@@ -140,6 +143,19 @@ structure SharedExprs where
 structure Config where
   /-- When `true`, issues are collected during proof search and reported on failure. -/
   verbose : Bool := true
+  /--
+  When `true`, `shareCommon` maintains the `SymM` invariant that reducible constants
+  have been eagerly unfolded: if a new term contains one, `shareCommon` unfolds it
+  before adding the term to the table of maximally shared terms.
+  -/
+  enforceUnfoldReducible : Bool := true
+  /--
+  When `true`, `shareCommon` maintains the `SymM` invariant that kernel projections
+  have been folded into projection function applications: if a new term contains one,
+  `shareCommon` folds it before adding the term to the table of maximally shared terms.
+  `cbv` disables this check because it processes kernel projections natively.
+  -/
+  enforceFoldProjs : Bool := true
   deriving Inhabited
 
 /-- Readonly context for the symbolic computation framework. -/
@@ -202,6 +218,65 @@ structure State where
 
 abbrev SymM := ReaderT Context <| StateRefT State MetaM
 
+/--
+Auxiliary function for implementing `unfoldReducible` and `unfoldReducibleSimproc`.
+Performs a single step.
+-/
+public def unfoldReducibleStep (e : Expr) : MetaM TransformStep := do
+  let .const declName _ := e.getAppFn | return .continue
+  unless isUnfoldReducibleCandidate (← getEnv) declName do return .continue
+  let some v ← unfoldDefinition? e | return .continue
+  return .visit v
+
+def isUnfoldReducibleTarget (e : Expr) : CoreM Bool := do
+  let env ← getEnv
+  return Option.isSome <| e.find? fun e =>
+    if let .const declName _ := e then
+      isUnfoldReducibleCandidate env declName
+    else
+      false
+
+/--
+Unfolds all `reducible` declarations occurring in `e`.
+This is meant as a preprocessing step. It does **not** guarantee maximally shared terms
+-/
+public def unfoldReducible (e : Expr) : MetaM Expr := do
+  if !(← isUnfoldReducibleTarget e) then return e
+  Meta.transform e (pre := unfoldReducibleStep)
+
+/--
+Converts nested `Expr.proj`s into projection applications if possible.
+The structural simplifier and pattern matcher do not handle kernel projection
+terms; this preprocessing step folds them into projection function applications.
+-/
+public def foldProjs (e : Expr) : MetaM Expr := do
+  if Option.isNone <| e.find? fun e => e.isProj then return e
+  let post (e : Expr) := do
+    let .proj structName idx s := e | return .done e
+    let some info := getStructureInfo? (← getEnv) structName |
+      trace[sym.issues] "found `Expr.proj` but `{structName}` is not marked as structure{indentExpr e}"
+      return .done e
+    if h : idx < info.fieldNames.size then
+      let fieldName := info.fieldNames[idx]
+      /-
+      In the test `grind_cat.lean`, the following operation fails if we are not using default
+      transparency. We get the following error.
+      ```
+      error: AppBuilder for 'mkProjection', structure expected
+        T
+      has type
+        F ⟶ G
+      ```
+      We should make `mkProjection` more robust.
+
+      The `mkProjection` function may create new kernel projections. So, we must use `.visit`.
+      -/
+      return .visit (← withDefault <| mkProjection s fieldName)
+    else
+      trace[sym.issues] "found `Expr.proj` with invalid field index `{idx}`{indentExpr e}"
+      return .done e
+  Meta.transform e (post := post)
+
 private def mkSharedExprs : AlphaShareCommonM SharedExprs := do
   let falseExpr  ← shareCommonAlphaInc <| mkConst ``False
   let trueExpr   ← shareCommonAlphaInc  <| mkConst ``True
@@ -213,7 +288,10 @@ private def mkSharedExprs : AlphaShareCommonM SharedExprs := do
   return { falseExpr, trueExpr, bfalseExpr, btrueExpr, natZExpr, ordEqExpr, intExpr }
 
 def SymM.run (x : SymM α) : MetaM α := do
-  let (sharedExprs, share) := mkSharedExprs |>.run {}
+  let (sharedExprs, share) ←
+    match mkSharedExprs { env := (← getEnv) } {} with
+    | .ok sharedExprs share => pure (sharedExprs, share)
+    | .error .. => unreachable! -- checks are disabled
   let debug := sym.debug.get (← getOptions)
   let extensions ← SymExtensions.mkInitialStates
   x { sharedExprs } |>.run' { debug, share, extensions }
@@ -246,14 +324,94 @@ def getOrderingEqExpr : SymM Expr := return (← getSharedExprs).ordEqExpr
 def getIntExpr : SymM Expr := return (← getSharedExprs).intExpr
 
 /--
+Runs an `AlphaShareCommonM` action over the `SymM` hash-consing state.
+Returns `none` on a check violation; the terms hash-consed before the failure
+are kept in the state, since they individually satisfy the invariants.
+-/
+def runShareCommonM (k : AlphaShareCommonM α) (ctx : AlphaShareCommon.Context) : SymM (Option α) := do
+  let share ← modifyGet fun s => (s.share, { s with share := {} })
+  match k ctx share with
+  | .ok a share => modify fun s => { s with share }; return some a
+  | .error _ share => modify fun s => { s with share }; return none
+
+/--
+Runs `x` with the `shareCommon` kernel-projection check disabled.
+Use this to wrap code that temporarily violates the `SymM` folded-projections
+invariant, e.g., a head reducer that exposes kernel projections in intermediate
+terms and restores the invariant in its final result.
+-/
+def withoutFoldProjsCheck [MonadWithReaderOf Context m] (x : m α) : m α :=
+  withTheReader Context (fun ctx => { ctx with
+    config.enforceFoldProjs := false }) x
+
+def withoutShareCommonChecks [MonadWithReaderOf Context m] (x : m α) : m α :=
+  withTheReader Context (fun ctx => { ctx with
+    config.enforceFoldProjs := false, config.enforceUnfoldReducible := false }) x
+
+/-- Returns the `AlphaShareCommon` context with the checks enabled by the current configuration. -/
+private def checkedShareCtx : SymM AlphaShareCommon.Context := do
+  let config := (← readThe Context).config
+  return {
+    env            := (← getEnv)
+    checkReducible := config.enforceUnfoldReducible
+    checkProj      := config.enforceFoldProjs
+  }
+
+/--
+Restores the `SymM` invariants enabled in the current configuration.
+The final `unfoldReducible` is needed because `foldProjs` can introduce fresh reducible
+constants: `mkProjection` recovers structure parameters from `inferType`, and those types
+come from environment signatures that were never preprocessed.
+-/
+private def repairShareViolation (e : Expr) : SymM Expr := do
+  let config := (← readThe Context).config
+  let mut e := e
+  if config.enforceUnfoldReducible then e ← unfoldReducible e
+  if config.enforceFoldProjs then e ← foldProjs e
+  if config.enforceUnfoldReducible then e ← unfoldReducible e
+  return e
+
+/--
 Applies hash-consing to `e`. Recall that all expressions in a `grind` goal have
 been hash-consed. We perform this step before we internalize expressions.
+
+This function does not try to `unfoldReducible` and `foldProjs` like `shareCommon`
+-/
+def shareCommonWithoutChecks (e : Expr) : SymM Expr := do
+  match (← runShareCommonM (shareCommonAlpha e) { env := (← getEnv) }) with
+  | some e => return e
+  | none => unreachable!
+
+/--
+Fallback used by `shareCommon` and `shareCommonInc` after a check violation:
+repairs the term and re-runs the full hash-consing pass with checks disabled, so
+this second pass always succeeds. In the exotic case where the repair does not
+eliminate all violations (e.g., a reducible definition that cannot be unfolded because
+of smart-unfolding blocking reduction), the term is admitted as-is; other parts of the
+system report this kind of issue.
+-/
+private def repairAndShare (e : Expr) : SymM Expr := do
+  -- `unfoldReducible` and `foldProjs` enter binders using `Meta.transform`, which
+  -- requires a closed term. Open terms are admitted without repair.
+  -- assert! !e.hasLooseBVars
+  if e.hasLooseBVars then throwError "internal error, expression has loose bound variables at `shareCommon`{indentExpr e}"
+  let e ← repairShareViolation e
+  shareCommonWithoutChecks e
+
+/--
+Applies hash-consing to `e`. Recall that all expressions in a `grind` goal have
+been hash-consed. We perform this step before we internalize expressions.
+
+Depending on the current configuration, this function also maintains the `SymM`
+invariants that reducible constants have been unfolded and kernel projections folded.
+The checks are node-local and are only performed on terms that have not been
+hash-consed before, so already-shared subterms cost nothing. When a violation is
+found, the term is repaired using `unfoldReducible`/`foldProjs` and re-processed.
 -/
 def shareCommon (e : Expr) : SymM Expr := do
-  let share ← modifyGet fun s => (s.share, { s with share := {} })
-  let (e, share) := shareCommonAlpha e share
-  modify fun s => { s with share }
-  return e
+  match (← runShareCommonM (shareCommonAlpha e) (← checkedShareCtx)) with
+  | some e => return e
+  | none => repairAndShare e
 
 /--
 Incremental variant of `shareCommon` for expressions constructed from already-shared subterms.
@@ -274,10 +432,12 @@ let result ← shareCommonInc result -- efficiently restore sharing
 ```
 -/
 def shareCommonInc (e : Expr) : SymM Expr := do
-  let share ← modifyGet fun s => (s.share, { s with share := {} })
-  let (e, share) := shareCommonAlphaInc e share
-  modify fun s => { s with share }
-  return e
+  match (← runShareCommonM (shareCommonAlphaInc e) (← checkedShareCtx)) with
+  | some e => return e
+  | none =>
+    -- The repair destroys the pointer sharing that justified the incremental
+    -- variant, so we fall back to the full `shareCommonAlpha` pass.
+    repairAndShare e
 
 @[inherit_doc shareCommonInc]
 abbrev share (e : Expr) : SymM Expr :=

--- a/src/Lean/Meta/Sym/Util.lean
+++ b/src/Lean/Meta/Sym/Util.lean
@@ -7,89 +7,18 @@ module
 prelude
 public import Lean.Meta.Sym.SymM
 public import Lean.Meta.Transform
-import Init.Grind.Util
-import Lean.Meta.WHNF
-import Lean.Meta.AppBuilder
 import Lean.Util.ForEachExpr
 namespace Lean.Meta.Sym
 
 /--
-Returns `true` if `declName` is the name of a grind helper declaration that
-should not be unfolded by `unfoldReducible`.
--/
-def isGrindGadget (declName : Name) : Bool :=
-  declName == ``Grind.EqMatch
-
-/--
-Auxiliary function for implementing `unfoldReducible` and `unfoldReducibleSimproc`.
-Performs a single step.
--/
-public def unfoldReducibleStep (e : Expr) : MetaM TransformStep := do
-  let .const declName _ := e.getAppFn | return .continue
-  unless (← isReducible declName) do return .continue
-  if isGrindGadget declName then return .continue
-  -- See comment at isUnfoldReducibleTarget.
-  if (← getEnv).isProjectionFn declName then return .continue
-  let some v ← unfoldDefinition? e | return .continue
-  return .visit v
-
-def isUnfoldReducibleTarget (e : Expr) : CoreM Bool := do
-  let env ← getEnv
-  return Option.isSome <| e.find? fun e => Id.run do
-    let .const declName _ := e | return false
-    if getReducibilityStatusCore env declName matches .reducible then
-      -- Remark: it is wasteful to unfold projection functions since
-      -- kernel projections are folded again in the `foldProjs` preprocessing step.
-      return !isGrindGadget declName && !env.isProjectionFn declName
-    else
-      return false
-
-/--
-Unfolds all `reducible` declarations occurring in `e`.
-This is meant as a preprocessing step. It does **not** guarantee maximally shared terms
--/
-public def unfoldReducible (e : Expr) : MetaM Expr := do
-  if !(← isUnfoldReducibleTarget e) then return e
-  Meta.transform e (pre := unfoldReducibleStep)
-
-/--
-Converts nested `Expr.proj`s into projection applications if possible.
-The structural simplifier and pattern matcher do not handle kernel projection
-terms; this preprocessing step folds them into projection function applications.
--/
-public def foldProjs (e : Expr) : MetaM Expr := do
-  if Option.isNone <| e.find? fun e => e.isProj then return e
-  let post (e : Expr) := do
-    let .proj structName idx s := e | return .done e
-    let some info := getStructureInfo? (← getEnv) structName |
-      trace[sym.issues] "found `Expr.proj` but `{structName}` is not marked as structure{indentExpr e}"
-      return .done e
-    if h : idx < info.fieldNames.size then
-      let fieldName := info.fieldNames[idx]
-      /-
-      In the test `grind_cat.lean`, the following operation fails if we are not using default
-      transparency. We get the following error.
-      ```
-      error: AppBuilder for 'mkProjection', structure expected
-        T
-      has type
-        F ⟶ G
-      ```
-      We should make `mkProjection` more robust.
-
-      The `mkProjection` function may create new kernel projections. So, we must use `.visit`.
-      -/
-      return .visit (← withDefault <| mkProjection s fieldName)
-    else
-      trace[sym.issues] "found `Expr.proj` with invalid field index `{idx}`{indentExpr e}"
-      return .done e
-  Meta.transform e (post := post)
-
-/--
-Instantiates metavariables, unfold reducible, and applies `shareCommon`.
+Instantiates metavariables and applies `shareCommon`, which maintains the `SymM`
+invariants enabled in the current configuration (see `Sym.Config`).
 -/
 public def preprocessExpr (e : Expr) : SymM Expr := do
-  shareCommon (← unfoldReducible (← instantiateMVars e))
+  -- This function relies on `shareCommon` to unfold reducible constants, so the
+  -- corresponding check must not have been disabled (e.g., via `withoutShareCommonChecks`).
+  assert! (← getConfig).enforceUnfoldReducible
+  shareCommon (← instantiateMVars e)
 
 /--
 Helper function that removes gaps, instantiate metavariables, and applies `shareCommon`.

--- a/src/Lean/Meta/Tactic/Cbv/Main.lean
+++ b/src/Lean/Meta/Tactic/Cbv/Main.lean
@@ -313,11 +313,22 @@ def cbvPost (simprocs : CbvSimprocs) : Simproc :=
 def mkCbvMethods (simprocs : CbvSimprocs) : Methods :=
   { pre := cbvPre simprocs, post := cbvPost simprocs }
 
+/--
+Core `cbv` evaluator. It disables the `shareCommon` invariant checks for the duration
+of the evaluation: `cbv` processes kernel projections natively, so they must not be
+folded into projection function applications, and it continuously constructs fresh
+terms from environment signatures (congruence proofs, `inferType` results) containing
+reducible constants such as `Eq.ndrec` and `Unit`, so each occurrence would trigger a
+full-term repair pass. The checks are disabled here (and in `cbvGoalCore`) rather than
+via the `SymM.run` configuration because `cbv` may run inside an enclosing `SymM`
+session (e.g., inside a `sym` block).
+-/
 def cbvCore (e : Expr) (config : Sym.Simp.Config := {}) : Sym.SymM Result := do
-  let simprocs ← getCbvSimprocs
-  let methods := mkCbvMethods simprocs
-  SimpM.run' (methods := methods) (config := config)
-    <| simp e
+  Sym.withoutShareCommonChecks do
+    let simprocs ← getCbvSimprocs
+    let methods := mkCbvMethods simprocs
+    SimpM.run' (methods := methods) (config := config)
+      <| simp e
 
 /-- Reduce a single expression. Unfolds reducibles, shares subterms, then runs the
 simplifier with `cbvPre`/`cbvPost`. Used by `conv => cbv`. -/
@@ -331,8 +342,10 @@ public def cbvEntry (e : Expr) : MetaM Result := do
   let methods := mkCbvMethods simprocs
   let e ← Sym.unfoldReducible e
   Sym.SymM.run do
-    let e ← Sym.shareCommon e
-    SimpM.run' (simp e) (methods := methods) (config := config)
+    -- See `cbvCore` for why the `shareCommon` invariant checks are disabled.
+    Sym.withoutShareCommonChecks do
+      let e ← Sym.shareCommon e
+      SimpM.run' (simp e) (methods := methods) (config := config)
 
 /--
 Core of `cbvGoal`: reduces the selected hypotheses and/or target of an already
@@ -340,6 +353,8 @@ preprocessed `mvarId` using call-by-value evaluation, within the caller's `SymM`
 -/
 public def cbvGoalCore (mvarId : MVarId) (simplifyTarget : Bool := true)
     (fvarIdsToSimp : Array FVarId := #[]) : Sym.SymM (Option MVarId) := do
+  -- See `cbvCore` for why the `shareCommon` invariant checks are disabled.
+  Sym.withoutShareCommonChecks do
   let config : Sym.Simp.Config := { maxSteps := cbv.maxSteps.get (← getOptions) }
   mvarId.withContext do
     let mut mvarIdNew := mvarId

--- a/src/Lean/Meta/Tactic/Grind/Internalize.lean
+++ b/src/Lean/Meta/Tactic/Grind/Internalize.lean
@@ -185,7 +185,9 @@ private def mkENode' (e : Expr) (generation : Nat) (funCC := false) : GoalM Unit
 private partial def internalizePattern (pattern : Expr) (generation : Nat) (origin : Origin) : GoalM Expr := do
   -- Recall that it is important to ensure patterns are maximally shared since
   -- we assume that in functions such as `getAppsOf` in `EMatch.lean`
-  go (← shareCommon pattern)
+  -- **Note**: We disable `shareCommonChecks` because patterns contain
+  -- loose bound variables and repair cannot be performed.
+  go (← Sym.shareCommonWithoutChecks pattern)
 where
   go (pattern : Expr) : GoalM Expr := do
     if pattern.isBVar || isPatternDontCare pattern then

--- a/tests/elab/sym_share_invariants.lean
+++ b/tests/elab/sym_share_invariants.lean
@@ -1,0 +1,118 @@
+import Lean
+
+/-! # Tests for `Sym.shareCommon` invariant enforcement
+
+`Sym.shareCommon` maintains the `SymM` invariants that reducible constants have
+been unfolded and kernel projections folded. These tests exercise the check and
+repair path directly via `SymM`: terms violating the invariants are repaired
+before entering the table of maximally shared terms, and already-admitted terms
+are not re-processed. -/
+
+open Lean Meta Sym
+
+abbrev myAbbrev (x : Nat) : Nat := x + 1
+
+structure Point where
+  x : Nat
+  y : Nat
+
+/-- Asserts `e` contains no reducible constant that `unfoldReducible` should have unfolded. -/
+private def assertNoReducible (e : Expr) : MetaM Unit := do
+  let env ← getEnv
+  let bad? := e.find? fun e =>
+    if let .const declName _ := e then
+      isUnfoldReducibleCandidate env declName
+    else
+      false
+  assert! bad?.isNone
+
+/-- Asserts `e` contains no kernel projection. -/
+private def assertNoProj (e : Expr) : MetaM Unit := do
+  assert! (e.find? Expr.isProj).isNone
+
+/-! ## Reducible constants are unfolded by `shareCommon` -/
+
+/-- info: 5 + 1 -/
+#guard_msgs in
+run_meta SymM.run do
+  let e := mkApp (mkConst ``myAbbrev) (mkNatLit 5)
+  let e ← shareCommon e
+  assertNoReducible e
+  e.checkMaxShared
+  logInfo m!"{e}"
+
+/-! ## ... also under binders -/
+
+/-- info: fun x => x + 1 -/
+#guard_msgs in
+run_meta SymM.run do
+  let e := mkLambda `x .default (mkConst ``Nat) (mkApp (mkConst ``myAbbrev) (mkBVar 0))
+  let e ← shareCommon e
+  assertNoReducible e
+  e.checkMaxShared
+  logInfo m!"{e}"
+
+/-! ## Kernel projections are folded by `shareCommon`; the projection function
+       `Point.x` is reducible but must **not** be unfolded (it would expose the
+       kernel projection again) -/
+
+/-- info: { x := 1, y := 2 }.x -/
+#guard_msgs in
+run_meta SymM.run do
+  let p := mkApp2 (mkConst ``Point.mk) (mkNatLit 1) (mkNatLit 2)
+  let e := Expr.proj ``Point 0 p
+  let e ← shareCommon e
+  assertNoProj e
+  assert! (e.find? fun e => e.isConstOf ``Point.x).isSome
+  e.checkMaxShared
+  logInfo m!"{e}"
+
+/-! ## Both violations in a single term -/
+
+/-- info: { x := 5 + 1, y := 2 }.y -/
+#guard_msgs in
+run_meta SymM.run do
+  let p := mkApp2 (mkConst ``Point.mk) (mkApp (mkConst ``myAbbrev) (mkNatLit 5)) (mkNatLit 2)
+  let e := Expr.proj ``Point 1 p
+  let e ← shareCommon e
+  assertNoReducible e
+  assertNoProj e
+  e.checkMaxShared
+  logInfo m!"{e}"
+
+/-! ## `shareCommonInc` repairs too (falls back to the full pass) -/
+
+/-- info: 7 + 1 -/
+#guard_msgs in
+run_meta SymM.run do
+  let seven ← shareCommon (mkNatLit 7)
+  let e := mkApp (mkConst ``myAbbrev) seven
+  let e ← shareCommonInc e
+  assertNoReducible e
+  e.checkMaxShared
+  logInfo m!"{e}"
+
+/-! ## Checks disabled: `withoutFoldProjsCheck` admits kernel projections (`cbv`/`vcgen` style) -/
+
+/-- info: ok -/
+#guard_msgs in
+run_meta SymM.run do
+  withoutFoldProjsCheck do
+    let p := mkApp2 (mkConst ``Point.mk) (mkNatLit 1) (mkNatLit 2)
+    let e := Expr.proj ``Point 0 p
+    let e ← shareCommon e
+    assert! e.isProj
+    e.checkMaxShared
+    logInfo "ok"
+
+/-! ## Clean terms take the fast path and are unchanged -/
+
+/-- info: Nat.succ 3 -/
+#guard_msgs in
+run_meta SymM.run do
+  let e := mkApp (mkConst ``Nat.succ) (mkNatLit 3)
+  let e₁ ← shareCommon e
+  let e₂ ← shareCommon e₁
+  assert! isSameExpr e₁ e₂
+  e₁.checkMaxShared
+  logInfo m!"{e₁}"


### PR DESCRIPTION
This PR makes `shareCommon` maintain the `SymM` representation invariants used by `grind` and `Sym.simp`: reducible constants are eagerly unfolded, and kernel projections are folded into projection function applications. These invariants were previously established only by the `grind` preprocessor and were easy to violate from user simprocs and internal code paths (e.g., `Sym.inferType` returns types from environment signatures that were never preprocessed), producing silent E-matching and indexing failures. Violations are now detected when terms enter the table of maximally shared terms and repaired automatically.

Two scoped combinators disable the checks for `SymM` clients that have their own term discipline. `cbv` disables both checks in `cbvCore`/`cbvGoalCore`: it processes kernel projections natively, and it continuously constructs fresh terms from environment signatures containing reducible constants such as `Eq.ndrec` and `Unit` (measured on the `cbv_aes` benchmark), so each occurrence would trigger a full-term repair pass. The `Std.Do` VC generator disables only the kernel-projection check via `withoutFoldProjsCheck`: its head reducer exposes kernel projections in intermediate terms and restores the invariant in its final results. Scoped combinators are used instead of a `SymM.run` configuration because these tactics may run inside an enclosing `SymM` session (e.g., `cbv` inside a `sym` block).

The new checks exposed a bug: `Grind.MatchCond` is a reducible `abbrev` but was not protected by `isGrindGadget` (only `Grind.EqMatch` was), so unfolding it disables the match-condition propagator. `isGrindGadget` now covers both gadgets.

`preprocessExpr` is simplified to rely on `shareCommon` for unfolding reducible constants, and asserts that the corresponding check is enabled in the current configuration. The new test `tests/elab/sym_share_invariants.lean` exercises the detection and repair paths, the projection-function carve-out, and the scoped opt-out.
