### PR TITLE
feat: lake: `presetup` module facet

### DIFF
--- a/src/lake/Lake/Build/Facets.lean
+++ b/src/lake/Lake/Build/Facets.lean
@@ -54,6 +54,12 @@ including transitive imports, plugins, and those specified by `needs`.
 -/
 builtin_facet setup : Module => ModuleSetup
 
+/-- The complete dependency trace of a module (as used by a module build). -/
+builtin_facet depTrace : Module => BuildTrace
+
+/-- The complete hash of a module's build dependencies (e.g., imports, source, plugins). -/
+builtin_facet depHash : Module => Hash
+
 /--
 This facet builds all of a module's dependencies,
 including transitive imports, plugins, and those specified by `needs`.

--- a/src/lake/Lake/Build/Infos.lean
+++ b/src/lake/Lake/Build/Infos.lean
@@ -80,6 +80,28 @@ builtin_facet input : Module => ModuleInput
 /-- The direct local imports of the Lean module. -/
 builtin_facet imports : Module => Array Module
 
+/-- Dynamic information computed about a module before building. -/
+public structure ModulePreSetup where
+  trace : BuildTrace
+  srcMTime : MTime
+  srcFile : FilePath
+  isModule : Bool
+  directImports : Array ModuleImport
+  directImportArts : NameMap ImportArtifacts
+  plugins : Array Dynlib
+  dynlibs : Array Dynlib
+  leanOptions : LeanOptions
+
+/--
+The computed dynamic configuration of a module.
+
+In the process, this facet will build all of a module's dependencies,
+including transitive imports, plugins, and those specified by `needs`.
+
+**For internal use only.**
+-/
+builtin_facet presetup : Module => ModulePreSetup
+
 /-- The transitive local imports of the Lean module. -/
 builtin_facet transImports : Module => Array Module
 
@@ -138,8 +160,17 @@ namespace Module
 @[inherit_doc precompileImportsFacet] public abbrev precompileImports (self : Module) :=
   self.facetCore precompileImportsFacet
 
+@[inherit_doc presetupFacet] public abbrev presetup  (self : Module) :=
+  self.facetCore presetupFacet
+
 @[inherit_doc setupFacet] public abbrev setup  (self : Module) :=
   self.facetCore setupFacet
+
+@[inherit_doc depTraceFacet] public abbrev depTrace (self : Module) :=
+  self.facetCore depTraceFacet
+
+@[inherit_doc depHashFacet] public abbrev depHash (self : Module) :=
+  self.facetCore depHashFacet
 
 @[inherit_doc depsFacet] public abbrev deps  (self : Module) :=
   self.facetCore depsFacet

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -530,7 +530,7 @@ Recursively build a module's dependencies, including:
 * Shared libraries (e.g., `extern_lib` targets or precompiled modules)
 * `extraDepTargets` of its library
 -/
-def Module.recFetchSetup (mod : Module) : FetchM (Job ModuleSetup) := ensureJob do
+def Module.recFetchPreSetup (mod : Module) : FetchM (Job ModulePreSetup) := ensureJob do
   /-
   Remark: Await extra target dependencies (e.g., cloud releases, `needs`) before any
   other module processing. This both enables the dependencies to effect these elements
@@ -544,7 +544,7 @@ def Module.recFetchSetup (mod : Module) : FetchM (Job ModuleSetup) := ensureJob 
   let extraDepJob ← mod.lib.extraDep.fetch
   discard extraDepJob.await
 
-  let headerJob ← mod.header.fetch
+  let inputJob ← mod.input.fetch
   /-
   Remark: We must build direct imports before we fetch the transitive
   precompiled imports so that errors in the import block of transitive imports
@@ -567,7 +567,7 @@ def Module.recFetchSetup (mod : Module) : FetchM (Job ModuleSetup) := ensureJob 
   let dynlibsJob ← mod.dynlibs.fetchIn mod.pkg "module dynlibs"
   let pluginsJob ← mod.plugins.fetchIn mod.pkg "module plugins"
 
-  headerJob.bindM (sync := true) fun header => do
+  inputJob.bindM (sync := true) fun input => do
   impInfoJob.bindM (sync := true) fun info => do
   newTrace
   impLibsJob.bindM (sync := true) fun impLibs => do
@@ -577,7 +577,7 @@ def Module.recFetchSetup (mod : Module) : FetchM (Job ModuleSetup) := ensureJob 
     let libTrace ← takeTrace
     let trace := BuildTrace.nil "deps"
     let depTrace := trace.mix extraDepJob.getTrace |>.mix info.trace
-    setTraceCaption s!"{mod.name.toString}:deps"
+    setTraceCaption s!"{mod.name.toString}"
     let libTrace := libTrace.withCaption "libs"
     let nilLibTrace :=
       BuildTrace.nil "libs"
@@ -591,24 +591,70 @@ def Module.recFetchSetup (mod : Module) : FetchM (Job ModuleSetup) := ensureJob 
     | some true => addTrace depTrace; addTrace nilLibTrace
     let {dynlibs, plugins} ← computeModuleDeps impLibs externLibs dynlibs plugins
     let extra := (← getLeanOptOverrides).find? mod.pkg.baseName |>.getD {}
+    let leanOptions := mod.leanOptions ++ extra
+    addLeanTrace
+    addTrace input.trace
+    addTrace <| traceOptions leanOptions "options"
+    addPureTrace input.header.isModule "isModule"
+    addPureTrace mod.name "Module.name"
+    addPureTrace mod.pkg.id? "Package.id?"
+    addPureTrace mod.leanArgs "Module.leanArgs"
     return {
-      name := mod.name
-      isModule := header.isModule
-      package? := mod.pkg.id?
-      imports? := none
-      importArts := info.directArts
-      dynlibs := dynlibs.map (·.path)
-      plugins := plugins.map (·.path)
-      options := mod.leanOptions ++ extra
+      trace := ← getTrace
+      srcFile := input.path
+      srcMTime := input.trace.mtime
+      isModule := input.header.isModule
+      directImports := input.imports
+      directImportArts := info.directArts
+      dynlibs, plugins, leanOptions
     }
+where
+  traceOptions (opts : LeanOptions) (caption := "opts") : BuildTrace :=
+    opts.values.foldl (init := .nil caption) fun t n v =>
+      let opt := s!"-D{n}={v.asCliFlagValue}"
+      t.mix <| .ofHash (pureHash opt) opt
 
-/-- The `ModuleFacetConfig` for the builtin `setupFacet`. -/
-public def Module.setupFacetConfig : ModuleFacetConfig setupFacet :=
-  mkFacetJobConfig recFetchSetup
+/-- The `ModuleFacetConfig` for the builtin `presetupFacet`. -/
+public def Module.presetupFacetConfig : ModuleFacetConfig presetupFacet :=
+  mkFacetJobConfig (buildable := false) recFetchPreSetup
+
+/-- The `ModuleFacetConfig` for the builtin `depTraceFacet`. -/
+public def Module.depTraceFacetConfig : ModuleFacetConfig depTraceFacet :=
+  mkFacetJobConfig (buildable := false) fun mod =>
+    return (← mod.presetup.fetch).map (·.trace)
+
+/-- The `ModuleFacetConfig` for the builtin `depHashFacet`. -/
+public def Module.depHashFacetConfig : ModuleFacetConfig depHashFacet :=
+  mkFacetJobConfig (buildable := false) fun mod =>
+    return (← mod.presetup.fetch).map (·.trace.hash)
 
 /-- The `ModuleFacetConfig` for the builtin `depsFacet`. -/
 public def Module.depsFacetConfig : ModuleFacetConfig depsFacet :=
-  mkFacetJobConfig fun mod => (·.toOpaque) <$> mod.setup.fetch
+  mkFacetJobConfig fun mod => (·.toOpaque) <$> mod.presetup.fetch
+
+def mkModuleSetup (mod : Module) (presetup : ModulePreSetup) : FetchM ModuleSetup := do
+  let importArts ← fetchTransImportArts
+    presetup.directImports presetup.directImportArts !presetup.isModule
+  return {
+    name := mod.name
+    isModule := presetup.isModule
+    package? := mod.pkg.id?
+    imports? := none
+    importArts
+    dynlibs := presetup.dynlibs.map (·.path)
+    plugins := presetup.plugins.map (·.path)
+    options := presetup.leanOptions
+  }
+
+/-- Recursively compute the contents of a `setup.json` for the module. -/
+def Module.recFetchSetup (mod : Module) : FetchM (Job ModuleSetup) := ensureJob do
+  withRegisterJob s!"{mod.name}:setup" do
+  (← mod.presetup.fetch).mapM fun presetup => do
+    mkModuleSetup mod presetup
+
+/-- The `ModuleFacetConfig` for the builtin `setupFacet`. -/
+public def Module.setupFacetConfig : ModuleFacetConfig setupFacet :=
+  mkFacetJobConfig (buildable := false) recFetchSetup
 
 /-- Remove all existing artifacts produced by the Lean build of the module. -/
 public def Module.clearOutputArtifacts (mod : Module) : IO PUnit := do
@@ -921,24 +967,17 @@ public def Module.ltarFacetConfig : ModuleFacetConfig ltarFacet :=
   mkFacetJobConfig recBuildLtar
 
 def Module.buildLean
-  (mod : Module) (depTrace : BuildTrace) (srcFile : FilePath) (setup : ModuleSetup)
-: JobM ModuleOutputArtifacts := buildAction depTrace mod.traceFile do
+  (mod : Module) (presetup : ModulePreSetup)
+: JobM ModuleOutputArtifacts := do buildAction (← getTrace) mod.traceFile do
   let args := mod.weakLeanArgs ++ mod.leanArgs
-  let relSrcFile := relPathFrom mod.pkg.dir srcFile
-  let directImports := (← (← mod.input.fetch).await).imports
-  let transImpArts ← fetchTransImportArts directImports setup.importArts !setup.isModule
-  let setup := {setup with importArts := transImpArts}
-  let arts := mod.mkArtifacts srcFile setup.isModule
+  let relSrcFile := relPathFrom mod.pkg.dir presetup.srcFile
+  let setup ← mkModuleSetup mod presetup
+  let arts := mod.mkArtifacts presetup.srcFile presetup.isModule
   mod.clearOutputArtifacts
-  compileLeanModule srcFile relSrcFile setup mod.setupFile arts args
+  compileLeanModule presetup.srcFile relSrcFile setup mod.setupFile arts args
     (← getLeanPath) (← getLean) (← getLeanir)
   mod.clearOutputHashes
   mod.computeArtifacts setup.isModule
-
-def traceOptions (opts : LeanOptions) (caption := "opts") : BuildTrace :=
-  opts.values.foldl (init := .nil caption) fun t n v =>
-    let opt := s!"-D{n}={v.asCliFlagValue}"
-    t.mix <| .ofHash (pureHash opt) opt
 
 /--
 Recursively build a Lean module.
@@ -947,30 +986,20 @@ all possible artifacts (e.g., `.olean`, `.ilean`, `.c`, `.bc`).
 -/
 def Module.recBuildLean (mod : Module) : FetchM (Job ModuleOutputArtifacts) := do
   /-
-  Remark: `withRegisterJob` must register `setupJob` to display module builds
-  in the job monitor. However, it must also include the fetching of both jobs to
+  Remark: `withRegisterJob` must register `presetupJob` to display module builds
+  in the job monitor. However, it must also include the fetching of the job to
   ensure all logs end up under its caption in the job monitor.
   -/
   withRegisterJob mod.name.toString do
-  let setupJob ← mod.setup.fetch
-  let leanJob ← mod.lean.fetch
-  setupJob.mapM fun setup => do
-    addLeanTrace
-    let srcFile ← leanJob.await
-    let srcTrace := leanJob.getTrace
-    addTrace srcTrace
-    addTrace <| traceOptions setup.options "options"
-    addPureTrace setup.isModule "isModule"
-    addPureTrace mod.name "Module.name"
-    addPureTrace mod.pkg.id? "Package.id?"
-    addPureTrace mod.leanArgs "Module.leanArgs"
-    setTraceCaption s!"{mod.name.toString}:leanArts"
-    let arts ← fetchCore setup srcFile srcTrace
+  let presetupJob ← mod.presetup.fetch
+  presetupJob.mapM fun presetup => do
+    setTrace presetup.trace
+    let arts ← fetchCore presetup
     let arts ← trackOutputsIfEnabled arts
     let arts ← adjustMTime arts
     return arts
 where
-  fetchFromCache? setup savedTrace restoreAll : JobM (ModuleOutputArtifacts ⊕ SavedTrace) := do
+  fetchFromCache? presetup savedTrace restoreAll : JobM (ModuleOutputArtifacts ⊕ SavedTrace) := do
     let inputHash := (← getTrace).hash
     let some ltarOrArts ← getArtifacts? inputHash savedTrace mod.pkg
       | return .inr savedTrace
@@ -988,7 +1017,7 @@ where
         -- end up in the build directory and, if writable, the cache
         let arts ← mod.restoreAllArtifacts {arts with ltar? := some ltar}
         if (← mod.pkg.isArtifactCacheWritable) then
-          let arts ← mod.cacheOutputArtifacts setup.isModule restoreAll
+          let arts ← mod.cacheOutputArtifacts presetup.isModule restoreAll
           -- Note: Cache service metadata is not preserved on an output update because it would
           -- result in downloading module outputs that are not available on the remote.
           (← getLakeCache).writeOutputs mod.pkg.cacheScope inputHash arts.descrs (overwrite := true)
@@ -1007,58 +1036,58 @@ where
         else
           mod.restoreNeededArtifacts arts
       return .inl arts
-  fetchCore setup srcFile srcTrace : JobM ModuleOutputArtifacts := do
+  fetchCore (presetup : ModulePreSetup) : JobM ModuleOutputArtifacts := do
     let depTrace ← getTrace
-    have : GetMTime Module := ⟨Module.getMTime (isModule := setup.isModule)⟩
-    have : CheckExists Module := ⟨Module.checkExists (isModule := setup.isModule)⟩
+    have : GetMTime Module := ⟨Module.getMTime (isModule := presetup.isModule)⟩
+    have : CheckExists Module := ⟨Module.checkExists (isModule := presetup.isModule)⟩
     let savedTrace ← readTraceFile mod.traceFile
     if (← mod.pkg.isArtifactCacheWritable) then
       let restore ← mod.pkg.restoreAllArtifacts
-      match (← fetchFromCache? setup savedTrace restore) with
+      match (← fetchFromCache? presetup savedTrace restore) with
       | .inl arts =>
         return arts
       | .inr savedTrace =>
-        let status ← savedTrace.replayIfUpToDate' (oldTrace := srcTrace.mtime) mod depTrace
+        let status ← savedTrace.replayIfUpToDate' (oldTrace := presetup.srcMTime) mod depTrace
         if status.isUpToDate then
-          unless (← mod.checkArtifactsExist setup.isModule) do
+          unless (← mod.checkArtifactsExist presetup.isModule) do
             -- Restoring from the archive stamps the trace with the current input
             -- hash, so only do it on a verified hash match; an mtime-only match
             -- leaves the hash unconfirmed, so rebuild instead.
             if status == .hashUpToDate then
               mod.unpackLtar mod.ltarFile depTrace.hash
             else
-              discard <| mod.buildLean depTrace srcFile setup
+              discard <| mod.buildLean presetup
         else
-          discard <| mod.buildLean depTrace srcFile setup
+          discard <| mod.buildLean presetup
         if status.isCacheable then
-          let arts ← mod.cacheOutputArtifacts setup.isModule restore
+          let arts ← mod.cacheOutputArtifacts presetup.isModule restore
           (← getLakeCache).writeOutputs mod.pkg.cacheScope depTrace.hash arts.descrs
           return arts
         else
-          mod.computeArtifacts setup.isModule
+          mod.computeArtifacts presetup.isModule
     else
-      let status ← savedTrace.replayIfUpToDate' (oldTrace := srcTrace.mtime) mod depTrace
+      let status ← savedTrace.replayIfUpToDate' (oldTrace := presetup.srcMTime) mod depTrace
       if status.isUpToDate then
-        unless (← mod.checkArtifactsExist setup.isModule) do
+        unless (← mod.checkArtifactsExist presetup.isModule) do
           -- As above: restore only on a verified hash match; an mtime-only match
           -- rebuilds instead.
           if status == .hashUpToDate then
             mod.unpackLtar mod.ltarFile depTrace.hash
           else
-            discard <| mod.buildLean depTrace srcFile setup
-        mod.computeArtifacts setup.isModule
+            discard <| mod.buildLean presetup
+        mod.computeArtifacts presetup.isModule
       else
         if (← mod.pkg.isArtifactCacheReadable) then
-          match (← fetchFromCache? setup savedTrace true) with
+          match (← fetchFromCache? presetup savedTrace true) with
           | .inl arts =>
               return arts
           | .inr savedTrace =>
-            if (← savedTrace.replayIfUpToDate (oldTrace := srcTrace.mtime) mod depTrace) then
-              mod.computeArtifacts setup.isModule
+            if (← savedTrace.replayIfUpToDate (oldTrace := presetup.srcMTime) mod depTrace) then
+              mod.computeArtifacts presetup.isModule
             else
-              mod.buildLean depTrace srcFile setup
+              mod.buildLean presetup
         else
-          mod.buildLean depTrace srcFile setup
+          mod.buildLean presetup
   trackOutputsIfEnabled arts : JobM ModuleOutputArtifacts := do
     if mod.pkg.isRoot then
       if let some ref := (← getBuildContext).outputsRef? then
@@ -1328,7 +1357,10 @@ public def Module.initFacetConfigs : DNameMap ModuleFacetConfig :=
   |>.insert transImportsFacet transImportsFacetConfig
   |>.insert precompileImportsFacet precompileImportsFacetConfig
   |>.insert importInfoFacet importInfoFacetConfig
+  |>.insert presetupFacet presetupFacetConfig
   |>.insert setupFacet setupFacetConfig
+  |>.insert depTraceFacet depTraceFacetConfig
+  |>.insert depHashFacet depHashFacetConfig
   |>.insert depsFacet depsFacetConfig
   |>.insert leanArtsFacet leanArtsFacetConfig
   |>.insert importArtsFacet importArtsFacetConfig

--- a/tests/lake/tests/query/pretty.lean
+++ b/tests/lake/tests/query/pretty.lean
@@ -1,0 +1,11 @@
+import Lean.Data.Json
+
+def main : IO UInt32 := do
+  let str ← (← IO.getStdin).readToEnd
+  match Lean.Json.parse str with
+  | .ok val =>
+    IO.print val.pretty
+    return 0
+  | .error e =>
+    IO.eprintln s!"Invalid JSON: {e}"
+    return 1

--- a/tests/lake/tests/query/test.sh
+++ b/tests/lake/tests/query/test.sh
@@ -7,6 +7,11 @@ source ../common.sh
 # Test the behavior of `lake query`
 # ---
 
+echo "# SETUP"
+
+# Ensure modules are built
+test_run build lib
+
 echo "# COMMON TESTS"
 
 # Test failure to build a query-only target
@@ -19,6 +24,14 @@ test_eq '"foo"' query foo --json
 # Test querying imports
 test_eq "B" query +A:imports
 test_eq '["C","B"]' query +A:transImports --json
+
+# Test querying a module's setup JSON
+$LAKE query +A:setup --json | $LAKE env lean --run pretty.lean |
+  diff -u --strip-trailing-cr .lake/build/ir/A.setup.json -
+
+# Test querying a module's dependency hash
+match_text $($LAKE query +A:depHash) .lake/build/lib/lean/A.trace
+test_eq "\"$($LAKE query +A:depHash)\"" query +A:depHash --json
 
 # Test querying deps
 $LAKE query :deps | diff -u --strip-trailing-cr <(cat << 'EOF'


### PR DESCRIPTION
This PR adds the `presetup`, `depTrace`, and `depHash` facets, which provide different views of a module's full set of dependencies. Also, the `setup` facet is no longer buildable on the CLI (as it produces JSON and not artifacts) and now includes full set of transitive import artifacts, fixing their absence from `lake lean`'s `setup.json`.

Implementation-wise, this PR splits the computation of a module's dependencies into the  `presetup` module facet. This facet is then feed into the module build and the `setup`, `depHash` , and `depTrace` facets. 


