### PR TITLE
chore: make builtin simproc helpers private

### DIFF
--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/BitVec.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/BitVec.lean
@@ -15,7 +15,7 @@ namespace BitVec
 open Lean Meta Simp
 
 /-- A bit-vector literal -/
-structure Literal where
+private structure Literal where
   /-- Size. -/
   n     : Nat
   /-- Actual value. -/
@@ -26,11 +26,11 @@ structure Literal where
 Try to convert `OfNat.ofNat`/`BitVec.OfNat` application into a
 bitvector literal.
 -/
-def fromExpr? (e : Expr) : SimpM (Option Literal) := do
+private def fromExpr? (e : Expr) : SimpM (Option Literal) := do
   let some ⟨n, value⟩ ← getBitVecValue? e | return none
   return some { n, value }
 
-def toExpr' (a : BitVec n) : SimpM Expr := do
+private def toExpr' (a : BitVec n) : SimpM Expr := do
   if (← Simp.getConfig).bitVecOfNat then
     return toExpr a
   else
@@ -39,7 +39,7 @@ def toExpr' (a : BitVec n) : SimpM Expr := do
 /--
 Helper function for reducing homogeneous unary bitvector operators.
 -/
-@[inline] def reduceUnary (declName : Name) (arity : Nat)
+@[inline] private def reduceUnary (declName : Name) (arity : Nat)
     (op : {n : Nat} → BitVec n → BitVec n) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some v ← fromExpr? e.appArg! | return .continue
@@ -48,7 +48,7 @@ Helper function for reducing homogeneous unary bitvector operators.
 /--
 Helper function for reducing homogeneous binary bitvector operators.
 -/
-@[inline] def reduceBin (declName : Name) (arity : Nat)
+@[inline] private def reduceBin (declName : Name) (arity : Nat)
     (op : {n : Nat} → BitVec n → BitVec n → BitVec n) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some v₁ ← fromExpr? e.appFn!.appArg! | return .continue
@@ -59,7 +59,7 @@ Helper function for reducing homogeneous binary bitvector operators.
     return .continue
 
 /-- Simplification procedure for `setWidth`, `zeroExtend` and `signExtend` on `BitVec`s. -/
-@[inline] def reduceExtend (declName : Name)
+@[inline] private def reduceExtend (declName : Name)
     (op : {n : Nat} → (m : Nat) → BitVec n → BitVec m) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName 3 do return .continue
   let some v ← fromExpr? e.appArg! | return .continue
@@ -69,7 +69,7 @@ Helper function for reducing homogeneous binary bitvector operators.
 /--
 Helper function for reducing bitvector functions such as `getLsb` and `getMsb`.
 -/
-@[inline] def reduceGetBit (declName : Name) (op : {n : Nat} → BitVec n → Nat → Bool) (e : Expr)
+@[inline] private def reduceGetBit (declName : Name) (op : {n : Nat} → BitVec n → Nat → Bool) (e : Expr)
     : SimpM DStep := do
   unless e.isAppOfArity declName 3 do return .continue
   let some v ← fromExpr? e.appFn!.appArg! | return .continue
@@ -80,7 +80,7 @@ Helper function for reducing bitvector functions such as `getLsb` and `getMsb`.
 /--
 Helper function for reducing bitvector functions such as `shiftLeft` and `rotateRight`.
 -/
-@[inline] def reduceShift (declName : Name) (arity : Nat)
+@[inline] private def reduceShift (declName : Name) (arity : Nat)
     (op : {n : Nat} → BitVec n → Nat → BitVec n) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some v ← fromExpr? e.appFn!.appArg! | return .continue
@@ -91,7 +91,7 @@ Helper function for reducing bitvector functions such as `shiftLeft` and `rotate
 Helper function for reducing `x <<< i` and `x >>> i` where `i` is a bitvector literal,
 into one that is a natural number literal.
 -/
-@[inline] def reduceShiftWithBitVecLit (declName : Name) (e : Expr) : SimpM DStep := do
+@[inline] private def reduceShiftWithBitVecLit (declName : Name) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName 6 do return .continue
   let v := e.appFn!.appArg!
   let some i ← fromExpr? e.appArg! | return .continue
@@ -100,7 +100,7 @@ into one that is a natural number literal.
 /--
 Helper function for reducing bitvector predicates.
 -/
-@[inline] def reduceBinPred (declName : Name) (arity : Nat)
+@[inline] private def reduceBinPred (declName : Name) (arity : Nat)
     (op : {n : Nat} → BitVec n → BitVec n → Bool) (e : Expr) : SimpM Step := do
   unless e.isAppOfArity declName arity do return .continue
   let some v₁ ← fromExpr? e.appFn!.appArg! | return .continue
@@ -111,7 +111,7 @@ Helper function for reducing bitvector predicates.
   else
     return .continue
 
-@[inline] def reduceBoolPred (declName : Name) (arity : Nat)
+@[inline] private def reduceBoolPred (declName : Name) (arity : Nat)
     (op : {n : Nat} → BitVec n → BitVec n → Bool) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some v₁ ← fromExpr? e.appFn!.appArg! | return .continue
@@ -342,7 +342,7 @@ builtin_dsimproc [simp, seval] reduceBitVecToFin (BitVec.toFin _)  := fun e => d
 Helper function for reducing `(x <<< i) <<< j` (and `(x >>> i) >>> j`) where `i` and `j` are
 natural number literals.
 -/
-@[inline] def reduceShiftShift (declName : Name) (thmName : Name) (e : Expr) : SimpM Step := do
+@[inline] private def reduceShiftShift (declName : Name) (thmName : Name) (e : Expr) : SimpM Step := do
   unless e.isAppOfArity declName 6 do return .continue
   let aux := e.appFn!.appArg!
   let some i ← Nat.fromExpr? e.appArg! | return .continue

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Char.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Char.lean
@@ -10,25 +10,30 @@ public import Lean.Meta.Tactic.Simp.BuiltinSimprocs.UInt
 
 public section
 
-namespace Char
-open Lean Meta Simp
+namespace Lean.Char
+open Meta Simp
 
 @[inherit_doc getCharValue?]
 def fromExpr? (e : Expr) : SimpM (Option Char) :=
   getCharValue? e
 
-@[inline] def reduceUnary [ToExpr α] (declName : Name) (op : Char → α) (arity : Nat := 1) (e : Expr) : SimpM DStep := do
+end Lean.Char
+
+namespace Char
+open Lean Meta Simp Lean.Char
+
+@[inline] private def reduceUnary [ToExpr α] (declName : Name) (op : Char → α) (arity : Nat := 1) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some c ← fromExpr? e.appArg! | return .continue
   return .done <| toExpr (op c)
 
-@[inline] def reduceBinPred (declName : Name) (arity : Nat) (op : Char → Char → Bool) (e : Expr) : SimpM Step := do
+@[inline] private def reduceBinPred (declName : Name) (arity : Nat) (op : Char → Char → Bool) (e : Expr) : SimpM Step := do
   unless e.isAppOfArity declName arity do return .continue
   let some n ← fromExpr? e.appFn!.appArg! | return .continue
   let some m ← fromExpr? e.appArg! | return .continue
   evalPropStep e (op n m)
 
-@[inline] def reduceBoolPred (declName : Name) (arity : Nat) (op : Char → Char → Bool) (e : Expr) : SimpM DStep := do
+@[inline] private def reduceBoolPred (declName : Name) (arity : Nat) (op : Char → Char → Bool) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some n ← fromExpr? e.appFn!.appArg! | return .continue
   let some m ← fromExpr? e.appArg! | return .continue

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Fin.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Fin.lean
@@ -14,28 +14,28 @@ public section
 namespace Fin
 open Lean Meta Simp
 
-structure Value where
+private structure Value where
   n     : Nat
   value : Fin n
   deriving DecidableEq, Repr
 
-def fromExpr? (e : Expr) : SimpM (Option Value) := do
+private def fromExpr? (e : Expr) : SimpM (Option Value) := do
   let some ⟨n, value⟩ ← getFinValue? e | return none
   return some { n, value }
 
-@[inline] def reduceOp (declName : Name) (arity : Nat) (f : Nat → Nat) (op : {n : Nat} → Fin n → Fin (f n)) (e : Expr) : SimpM DStep := do
+@[inline] private def reduceOp (declName : Name) (arity : Nat) (f : Nat → Nat) (op : {n : Nat} → Fin n → Fin (f n)) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some v ← fromExpr? e.appArg! | return .continue
   let v' := op v.value
   return .done <| toExpr v'
 
-@[inline] def reduceNatOp (declName : Name) (arity : Nat) (f : Nat → Nat) (op : (n : Nat) → Fin (f n)) (e : Expr) : SimpM DStep := do
+@[inline] private def reduceNatOp (declName : Name) (arity : Nat) (f : Nat → Nat) (op : (n : Nat) → Fin (f n)) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some v ← getNatValue? e.appArg! | return .continue
   let v' := op v
   return .done <| toExpr v'
 
-@[inline] def reduceBin (declName : Name) (arity : Nat) (op : {n : Nat} → Fin n → Fin n → Fin n) (e : Expr) : SimpM DStep := do
+@[inline] private def reduceBin (declName : Name) (arity : Nat) (op : {n : Nat} → Fin n → Fin n → Fin n) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some v₁ ← fromExpr? e.appFn!.appArg! | return .continue
   let some v₂ ← fromExpr? e.appArg! | return .continue
@@ -45,13 +45,13 @@ def fromExpr? (e : Expr) : SimpM (Option Value) := do
   else
     return .continue
 
-@[inline] def reduceBinPred (declName : Name) (arity : Nat) (op : Nat → Nat → Bool) (e : Expr) : SimpM Step := do
+@[inline] private def reduceBinPred (declName : Name) (arity : Nat) (op : Nat → Nat → Bool) (e : Expr) : SimpM Step := do
   unless e.isAppOfArity declName arity do return .continue
   let some v₁ ← fromExpr? e.appFn!.appArg! | return .continue
   let some v₂ ← fromExpr? e.appArg! | return .continue
   evalPropStep e (op v₁.value v₂.value)
 
-@[inline] def reduceBoolPred (declName : Name) (arity : Nat) (op : Nat → Nat → Bool) (e : Expr) : SimpM DStep := do
+@[inline] private def reduceBoolPred (declName : Name) (arity : Nat) (op : Nat → Nat → Bool) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some v₁ ← fromExpr? e.appFn!.appArg! | return .continue
   let some v₂ ← fromExpr? e.appArg! | return .continue

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Int.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Int.lean
@@ -9,36 +9,41 @@ public import Lean.Meta.Tactic.Simp.BuiltinSimprocs.Nat
 import Lean.Util.SafeExponentiation
 import Init.Data.Int.DivMod
 public section
-namespace Int
-open Lean Meta Simp
+namespace Lean.Int
+open Meta Simp
 
 def fromExpr? (e : Expr) : SimpM (Option Int) :=
   getIntValue? e
 
-@[inline] def reduceUnary (declName : Name) (arity : Nat) (op : Int → Int) (e : Expr) : SimpM DStep := do
+end Lean.Int
+
+namespace Int
+open Lean Meta Simp Lean.Int
+
+@[inline] private def reduceUnary (declName : Name) (arity : Nat) (op : Int → Int) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some n ← fromExpr? e.appArg! | return .continue
   return .done <| toExpr (op n)
 
-@[inline] def reduceBin (declName : Name) (arity : Nat) (op : Int → Int → Int) (e : Expr) : SimpM DStep := do
+@[inline] private def reduceBin (declName : Name) (arity : Nat) (op : Int → Int → Int) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some v₁ ← fromExpr? e.appFn!.appArg! | return .continue
   let some v₂ ← fromExpr? e.appArg! | return .continue
   return .done <| toExpr (op v₁ v₂)
 
-def reduceBinIntNatOp (name : Name) (op : Int → Nat → Int) (e : Expr) : SimpM DStep := do
+private def reduceBinIntNatOp (name : Name) (op : Int → Nat → Int) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity name 2 do return .continue
   let some v₁ ← getIntValue? e.appFn!.appArg! | return .continue
   let some v₂ ← getNatValue? e.appArg! | return .continue
   return .done <| toExpr (op v₁ v₂)
 
-@[inline] def reduceBinPred (declName : Name) (arity : Nat) (op : Int → Int → Bool) (e : Expr) : SimpM Step := do
+@[inline] private def reduceBinPred (declName : Name) (arity : Nat) (op : Int → Int → Bool) (e : Expr) : SimpM Step := do
   unless e.isAppOfArity declName arity do return .continue
   let some v₁ ← fromExpr? e.appFn!.appArg! | return .continue
   let some v₂ ← fromExpr? e.appArg! | return .continue
   evalPropStep e (op v₁ v₂)
 
-@[inline] def reduceBoolPred (declName : Name) (arity : Nat) (op : Int → Int → Bool) (e : Expr) : SimpM DStep := do
+@[inline] private def reduceBoolPred (declName : Name) (arity : Nat) (op : Int → Int → Bool) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some n ← fromExpr? e.appFn!.appArg! | return .continue
   let some m ← fromExpr? e.appArg! | return .continue
@@ -92,7 +97,7 @@ builtin_simproc [simp, seval] reduceNe  (( _ : Int) ≠ _)  := reduceBinPred ``N
 builtin_dsimproc [simp, seval] reduceBEq  (( _ : Int) == _)  := reduceBoolPred ``BEq.beq 4 (. == .)
 builtin_dsimproc [simp, seval] reduceBNe  (( _ : Int) != _)  := reduceBoolPred ``bne 4 (. != .)
 
-@[inline] def reduceNatCore (declName : Name) (op : Int → Nat) (e : Expr) : SimpM DStep := do
+@[inline] private def reduceNatCore (declName : Name) (op : Int → Nat) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName 1 do return .continue
   let some v ← fromExpr? e.appArg! | return .continue
   return .done <| mkNatLit (op v)

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/MethodSpecs.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/MethodSpecs.lean
@@ -14,7 +14,7 @@ import Lean.Meta.Tactic.Simp.Main
 
 open Lean Meta Simp
 
-def reduceMethod (opName : String) (e : Expr) : SimpM Simp.Step := do
+private def reduceMethod (opName : String) (e : Expr) : SimpM Simp.Step := do
   let xs := e.getAppArgsN 3
   let inst := xs[0]!
   let lhs := xs[1]!

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Nat.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Nat.lean
@@ -13,30 +13,35 @@ import Lean.Util.SafeExponentiation
 import Init.Data.Nat.Dvd
 import Init.Data.Nat.Simproc
 public section
-namespace Nat
-open Lean Meta Simp
+namespace Lean.Nat
+open Meta Simp
 
 def fromExpr? (e : Expr) : SimpM (Option Nat) :=
   getNatValue? e
 
-@[inline] def reduceUnary (declName : Name) (arity : Nat) (op : Nat → Nat) (e : Expr) : SimpM DStep := do
+end Lean.Nat
+
+namespace Nat
+open Lean Meta Simp Lean.Nat
+
+@[inline] private def reduceUnary (declName : Name) (arity : Nat) (op : Nat → Nat) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some n ← fromExpr? e.appArg! | return .continue
   return .done <| toExpr (op n)
 
-@[inline] def reduceBin (declName : Name) (arity : Nat) (op : Nat → Nat → Nat) (e : Expr) : SimpM DStep := do
+@[inline] private def reduceBin (declName : Name) (arity : Nat) (op : Nat → Nat → Nat) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some n ← fromExpr? e.appFn!.appArg! | return .continue
   let some m ← fromExpr? e.appArg! | return .continue
   return .done <| toExpr (op n m)
 
-@[inline] def reduceBinPred (declName : Name) (arity : Nat) (op : Nat → Nat → Bool) (e : Expr) : SimpM Step := do
+@[inline] private def reduceBinPred (declName : Name) (arity : Nat) (op : Nat → Nat → Bool) (e : Expr) : SimpM Step := do
   unless e.isAppOfArity declName arity do return .continue
   let some n ← fromExpr? e.appFn!.appArg! | return .continue
   let some m ← fromExpr? e.appArg! | return .continue
   evalPropStep e (op n m)
 
-@[inline] def reduceBoolPred (declName : Name) (arity : Nat) (op : Nat → Nat → Bool) (e : Expr) : SimpM DStep := do
+@[inline] private def reduceBoolPred (declName : Name) (arity : Nat) (op : Nat → Nat → Bool) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some n ← fromExpr? e.appFn!.appArg! | return .continue
   let some m ← fromExpr? e.appArg! | return .continue
@@ -174,22 +179,22 @@ private def mkOfDecideEqTrue (p : Expr) : MetaM Expr := do
   let d ← Meta.mkDecide p
   pure <| mkAppN (mkConst ``of_decide_eq_true) #[p, d.appArg!, (← Meta.mkEqRefl (mkConst ``true))]
 
-def applySimprocConst (expr : Expr) (nm : Name) (args : Array Expr) : SimpM Step := do
+private def applySimprocConst (expr : Expr) (nm : Name) (args : Array Expr) : SimpM Step := do
   unless (← getEnv).contains nm do return .continue
   let finProof := mkAppN (mkConst nm) args
   return .visit { expr, proof? := finProof, cache := true }
 
-inductive EqResult where
+private inductive EqResult where
 | decide (b : Bool) : EqResult
 | false (p : Expr) : EqResult
 | eq (x y : Expr) (p : Expr) : EqResult
 
-def applyEqLemma (e : Expr → EqResult) (lemmaName : Name) (args : Array Expr) : SimpM (Option EqResult) := do
+private def applyEqLemma (e : Expr → EqResult) (lemmaName : Name) (args : Array Expr) : SimpM (Option EqResult) := do
   unless (← getEnv).contains lemmaName do
     return none
   return .some (e (mkAppN (mkConst lemmaName) args))
 
-def reduceNatEqExpr (x y : Expr) : SimpM (Option EqResult):= do
+private def reduceNatEqExpr (x y : Expr) : SimpM (Option EqResult):= do
   /-
   **TODO**: These proofs rely too much on definitional equality.
   Example:
@@ -280,7 +285,7 @@ builtin_simproc [simp, seval] reduceBneDiff ((_ : Nat) != _) := fun e => do
     let q := mkAppN (mkConst ``Nat.Simproc.bneEqOfEqEq) #[x, y, u, v, p]
     return .visit { expr := mkBneNat u v, proof? := some q, cache := true }
 
-def reduceLTLE (nm : Name) (arity : Nat) (isLT : Bool) (e : Expr) : SimpM Step := do
+private def reduceLTLE (nm : Name) (arity : Nat) (isLT : Bool) (e : Expr) : SimpM Step := do
   unless e.isAppOfArity nm arity do
     return .continue
   let x := e.appFn!.appArg!

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/SInt.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/SInt.lean
@@ -23,26 +23,26 @@ let fromExpr := mkIdent `fromExpr
 `(
 namespace $typeName
 
-def $fromExpr (e : Expr) : SimpM (Option $typeName) := do
+private def $fromExpr (e : Expr) : SimpM (Option $typeName) := do
   if let some (n, _) ← getOfNatValue? e $(quote typeName.getId) then
     return some ($(mkIdent ofNat) n)
   let_expr Neg.neg _ _ a ← e | return none
   let some (n, _) ← getOfNatValue? a $(quote typeName.getId) | return none
   return some ($(mkIdent ofInt) (- n))
 
-@[inline] def reduceBin (declName : Name) (arity : Nat) (op : $typeName → $typeName → $typeName) (e : Expr) : SimpM DStep := do
+@[inline] private def reduceBin (declName : Name) (arity : Nat) (op : $typeName → $typeName → $typeName) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some n ← ($fromExpr e.appFn!.appArg!) | return .continue
   let some m ← ($fromExpr e.appArg!) | return .continue
   return .done <| toExpr (op n m)
 
-@[inline] def reduceBinPred (declName : Name) (arity : Nat) (op : $typeName → $typeName → Bool) (e : Expr) : SimpM Step := do
+@[inline] private def reduceBinPred (declName : Name) (arity : Nat) (op : $typeName → $typeName → Bool) (e : Expr) : SimpM Step := do
   unless e.isAppOfArity declName arity do return .continue
   let some n ← ($fromExpr e.appFn!.appArg!) | return .continue
   let some m ← ($fromExpr e.appArg!) | return .continue
   evalPropStep e (op n m)
 
-@[inline] def reduceBoolPred (declName : Name) (arity : Nat) (op : $typeName → $typeName → Bool) (e : Expr) : SimpM DStep := do
+@[inline] private def reduceBoolPred (declName : Name) (arity : Nat) (op : $typeName → $typeName → Bool) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some n ← ($fromExpr e.appFn!.appArg!) | return .continue
   let some m ← ($fromExpr e.appArg!) | return .continue

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/String.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/String.lean
@@ -14,7 +14,7 @@ public section
 namespace String
 open Lean Meta Simp
 
-def fromExpr? (e : Expr) : SimpM (Option String) := do
+private def fromExpr? (e : Expr) : SimpM (Option String) := do
   return getStringValue? e
 
 builtin_dsimproc [simp, seval] reduceAppend ((_ ++ _ : String)) := fun e => do
@@ -58,14 +58,14 @@ builtin_dsimproc_decl reduceToSingleton ((_ : String)) := fun e => do
   let [c] := l | return .continue
   return .done <| mkApp (mkConst ``String.singleton) (toExpr c)
 
-@[inline] def reduceBinPred (declName : Name) (arity : Nat) (op : String → String → Bool) (e : Expr) : SimpM Step := do
+@[inline] private def reduceBinPred (declName : Name) (arity : Nat) (op : String → String → Bool) (e : Expr) : SimpM Step := do
   unless e.isAppOfArity declName arity do return .continue
   let some n ← fromExpr? e.appFn!.appArg! | return .continue
   let some m ← fromExpr? e.appArg! | return .continue
   evalPropStep e (op n m)
 
 
-@[inline] def reduceBoolPred (declName : Name) (arity : Nat) (op : String → String → Bool) (e : Expr) : SimpM DStep := do
+@[inline] private def reduceBoolPred (declName : Name) (arity : Nat) (op : String → String → Bool) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some n ← fromExpr? e.appFn!.appArg! | return .continue
   let some m ← fromExpr? e.appArg! | return .continue

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/UInt.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/UInt.lean
@@ -21,23 +21,23 @@ let fromExpr := mkIdent `fromExpr
 `(
 namespace $typeName
 
-def $fromExpr (e : Expr) : SimpM (Option $typeName) := do
+private def $fromExpr (e : Expr) : SimpM (Option $typeName) := do
   let some (n, _) ← getOfNatValue? e $(quote typeName.getId) | return none
   return $(mkIdent ofNat) n
 
-@[inline] def reduceBin (declName : Name) (arity : Nat) (op : $typeName → $typeName → $typeName) (e : Expr) : SimpM DStep := do
+@[inline] private def reduceBin (declName : Name) (arity : Nat) (op : $typeName → $typeName → $typeName) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some n ← ($fromExpr e.appFn!.appArg!) | return .continue
   let some m ← ($fromExpr e.appArg!) | return .continue
   return .done <| toExpr (op n m)
 
-@[inline] def reduceBinPred (declName : Name) (arity : Nat) (op : $typeName → $typeName → Bool) (e : Expr) : SimpM Step := do
+@[inline] private def reduceBinPred (declName : Name) (arity : Nat) (op : $typeName → $typeName → Bool) (e : Expr) : SimpM Step := do
   unless e.isAppOfArity declName arity do return .continue
   let some n ← ($fromExpr e.appFn!.appArg!) | return .continue
   let some m ← ($fromExpr e.appArg!) | return .continue
   evalPropStep e (op n m)
 
-@[inline] def reduceBoolPred (declName : Name) (arity : Nat) (op : $typeName → $typeName → Bool) (e : Expr) : SimpM DStep := do
+@[inline] private def reduceBoolPred (declName : Name) (arity : Nat) (op : $typeName → $typeName → Bool) (e : Expr) : SimpM DStep := do
   unless e.isAppOfArity declName arity do return .continue
   let some n ← ($fromExpr e.appFn!.appArg!) | return .continue
   let some m ← ($fromExpr e.appArg!) | return .continue
@@ -95,7 +95,7 @@ However, we do reduce natural literals using the fact this opaque value is at le
 -/
 namespace USize
 
-def fromExpr (e : Expr) : SimpM (Option USize) := do
+private def fromExpr (e : Expr) : SimpM (Option USize) := do
   let some (n, _) ← getOfNatValue? e ``USize | return none
   return USize.ofNat n
 


### PR DESCRIPTION
This PR removes helper definitions used by the builtin simprocs for basic types from the respective namespaces.

For example, there is no longer a public `Nat.EqResult` that is visible after `import Lean`.

Of course, the simprocs themselves, which are part of the public API, are not changed.