### PR TITLE
chore: reduce namespace pollution

### DIFF
--- a/src/Lean/Data/Array.lean
+++ b/src/Lean/Data/Array.lean
@@ -10,7 +10,7 @@ import Init.Data.Stream
 public import Init.Data.Range.Polymorphic.Nat
 public import Init.Data.Range.Polymorphic.Iterators
 
-namespace Array
+namespace Lean.Array
 
 /-!
 This module contains utility functions involving Arrays that are useful in a few places
@@ -91,4 +91,4 @@ public def zipMasked {α} (mask : Array Bool) (xs ys : Array α) : Array α := I
         panic! "zipMaskedArray: not enough elements in xs"
   return zs
 
-end Array
+end Lean.Array

--- a/src/Lean/Data/AssocList.lean
+++ b/src/Lean/Data/AssocList.lean
@@ -115,6 +115,6 @@ instance [Monad m] : ForIn m (AssocList α β) (α × β) where
 
 end Lean.AssocList
 
-def List.toAssocList' {α : Type u} {β : Type v} : List (α × β) → Lean.AssocList α β
+def Lean.List.toAssocList' {α : Type u} {β : Type v} : List (α × β) → Lean.AssocList α β
   | []          => Lean.AssocList.nil
   | (a,b) :: es => Lean.AssocList.cons a b (toAssocList' es)

--- a/src/Lean/Data/LBool.lean
+++ b/src/Lean/Data/LBool.lean
@@ -10,6 +10,8 @@ public import Init.Data.ToString.Basic
 
 public section
 
+open Lean
+
 namespace Lean
 
 inductive LBool where
@@ -38,12 +40,12 @@ instance : ToString LBool := ⟨toString⟩
 
 end LBool
 
-end Lean
+def Bool.toLBool : Bool → LBool
+  | true  => LBool.true
+  | false => LBool.false
 
-def Bool.toLBool : Bool → Lean.LBool
-  | true  => Lean.LBool.true
-  | false => Lean.LBool.false
-
-@[inline] def toLBoolM {m : Type → Type} [Monad m] (x : m Bool) : m Lean.LBool := do
+@[inline] def toLBoolM {m : Type → Type} [Monad m] (x : m Bool) : m LBool := do
   let b ← x
   pure b.toLBool
+
+end Lean

--- a/src/Lean/Data/LOption.lean
+++ b/src/Lean/Data/LOption.lean
@@ -11,6 +11,8 @@ public import Init.Data.String.Basic
 public section
 universe u
 
+open Lean
+
 namespace Lean
 
 inductive LOption (α : Type u) where
@@ -29,12 +31,12 @@ def LOption.toOption : LOption α → Option α
   | .some a => .some a
   | _ => .none
 
-end Lean
-
-def Option.toLOption {α : Type u} : Option α → Lean.LOption α
+def Option.toLOption {α : Type u} : Option α → LOption α
   | none   => .none
   | some a => .some a
 
-@[inline] def toLOptionM {α} {m : Type → Type} [Monad m] (x : m (Option α)) : m (Lean.LOption α) := do
+@[inline] def toLOptionM {α} {m : Type → Type} [Monad m] (x : m (Option α)) : m (LOption α) := do
   let b ← x
   return b.toLOption
+
+end Lean

--- a/src/Lean/Data/PersistentArray.lean
+++ b/src/Lean/Data/PersistentArray.lean
@@ -397,10 +397,6 @@ def mkPersistentArray {α : Type u} (n : Nat) (v : α) : PArray α :=
 @[inline] def mkPArray {α : Type u} (n : Nat) (v : α) : PArray α :=
   mkPersistentArray n v
 
-end Lean
-
-open Lean (PersistentArray)
-
 /--
 Converts a list to a persistent array.
 -/
@@ -412,3 +408,5 @@ def List.toPArray' {α : Type u} (xs : List α) : PersistentArray α :=
 
 def Array.toPArray' {α : Type u} (xs : Array α) : PersistentArray α :=
   xs.foldl (init := .empty) fun p x => p.push x
+
+end Lean

--- a/src/Lean/Data/SMap.lean
+++ b/src/Lean/Data/SMap.lean
@@ -115,7 +115,7 @@ def toList (m : SMap α β) : List (α × β) :=
 
 end SMap
 
-def _root_.List.toSMap [BEq α] [Hashable α] (es : List (α × β)) : SMap α β :=
+def List.toSMap [BEq α] [Hashable α] (es : List (α × β)) : SMap α β :=
   es.foldl (init := {}) fun s (a, b) => s.insert a b
 
 instance {_ : BEq α} {_ : Hashable α} [Repr α] [Repr β] : Repr (SMap α β) where

--- a/src/Lean/Data/SSet.lean
+++ b/src/Lean/Data/SSet.lean
@@ -43,10 +43,10 @@ def toList (m : SSet α) : List α :=
 
 end SSet
 
-end Lean
-
-def List.toSSet [BEq α] [Hashable α] (es : List α) : Lean.SSet α :=
+def List.toSSet [BEq α] [Hashable α] (es : List α) : SSet α :=
   es.foldl (init := {}) fun s a => s.insert a
 
-instance {_ : BEq α} {_ : Hashable α} [Repr α] : Repr (Lean.SSet α) where
+instance {_ : BEq α} {_ : Hashable α} [Repr α] : Repr (SSet α) where
   reprPrec v prec := Repr.addAppParen (reprArg v.toList ++ ".toSSet") prec
+
+end Lean

--- a/src/Lean/Elab/Frontend.lean
+++ b/src/Lean/Elab/Frontend.lean
@@ -83,7 +83,7 @@ partial def processCommands : FrontendM Unit := do
 
 end Frontend
 
-open Frontend
+open Lean Frontend
 
 structure IncrementalState extends State where
   inputCtx    : Parser.InputContext

--- a/src/Lean/Elab/PreDefinition/WF/Fix.lean
+++ b/src/Lean/Elab/PreDefinition/WF/Fix.lean
@@ -17,7 +17,7 @@ public import Lean.Util.HasConstCache
 public section
 
 namespace Lean.Elab.WF
-open Meta
+open Lean Meta
 
 register_builtin_option debug.definition.wf.replaceRecApps : Bool := {
     defValue := false

--- a/src/Lean/Elab/Tactic/Grind/Param.lean
+++ b/src/Lean/Elab/Tactic/Grind/Param.lean
@@ -10,7 +10,7 @@ import Lean.Meta.Tactic.Grind.ForallProp
 import Lean.Elab.Tactic.Grind.Anchor
 import Lean.Elab.SyntheticMVars
 namespace Lean.Elab.Tactic
-open Meta
+open Lean Meta
 
 /-!
 `grind` parameter elaboration

--- a/src/Lean/Language/Lean.lean
+++ b/src/Lean/Language/Lean.lean
@@ -228,6 +228,8 @@ the tactic snapshot at hand *and all further snapshots* so that we can cancel th
 of waiting for elaboration to visit those later snapshots.
 -/
 
+open Lean
+
 set_option linter.missingDocs true
 
 namespace Lean.Language.Lean

--- a/src/Lean/Meta/ExprDefEq.lean
+++ b/src/Lean/Meta/ExprDefEq.lean
@@ -11,6 +11,8 @@ import Lean.Meta.WHNF
 public section
 namespace Lean.Meta
 
+open Lean
+
 register_builtin_option backward.isDefEq.lazyProjDelta : Bool := {
   defValue := true
   descr    := "use lazy delta reduction when solving unification constrains of the form `(f a).i =?= (g b).i`"

--- a/src/Lean/Meta/InferType.lean
+++ b/src/Lean/Meta/InferType.lean
@@ -14,6 +14,8 @@ public section
 
 namespace Lean
 
+open Lean
+
 /--
 Auxiliary function for instantiating the loose bound variables in `e` with `args[start...stop]`.
 This function is similar to `instantiateRevRange`, but it applies beta-reduction when

--- a/src/Lean/Meta/Offset.lean
+++ b/src/Lean/Meta/Offset.lean
@@ -12,6 +12,8 @@ import Lean.Util.SafeExponentiation
 public section
 namespace Lean.Meta
 
+open Lean
+
 private abbrev withInstantiatedMVars (e : Expr) (k : Expr → OptionT MetaM α) : OptionT MetaM α := do
   let eNew ← instantiateMVars e
   if eNew.getAppFn.isMVar then

--- a/src/Lean/Meta/Tactic/Grind/Arith/Cutsat/Util.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Cutsat/Util.lean
@@ -30,6 +30,8 @@ end Int.Internal.Linear
 
 namespace Lean.Meta.Grind.Arith.Cutsat
 
+open Lean
+
 def get' : GoalM State := do
   cutsatExt.getState
 

--- a/src/Lean/Meta/Tactic/Grind/Arith/Linear/Util.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Linear/Util.lean
@@ -11,6 +11,8 @@ import Init.Data.Int.Gcd
 public section
 namespace Lean.Meta.Grind.Arith.Linear
 
+open Lean
+
 def getZero : LinearM Expr :=
   return (← getStruct).zero
 

--- a/src/Lean/Meta/Tactic/Rewrites.lean
+++ b/src/Lean/Meta/Tactic/Rewrites.lean
@@ -17,6 +17,7 @@ public section
 
 namespace Lean.Meta.Rewrites
 
+open Lean
 open Lean.Meta.LazyDiscrTree (InitEntry MatchResult)
 open Lean.Meta.SolveByElim
 

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/SInt.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/SInt.lean
@@ -13,6 +13,8 @@ public section
 
 open Lean Meta Simp
 
+namespace Lean
+
 macro "declare_sint_simprocs" typeName:ident : command =>
 let ofNat := typeName.getId ++ `ofNat
 let ofInt := typeName.getId ++ `ofInt
@@ -109,6 +111,8 @@ builtin_dsimproc [seval] isValue ((OfNat.ofNat _ : $typeName)) := fun e => do
 
 end $typeName
 )
+
+end Lean
 
 declare_sint_simprocs Int8
 declare_sint_simprocs Int16

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/UInt.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/UInt.lean
@@ -13,6 +13,8 @@ public section
 
 open Lean Meta Simp
 
+namespace Lean
+
 macro "declare_uint_simprocs" typeName:ident : command =>
 let ofNat := typeName.getId ++ `ofNat
 let ofNatLT := mkIdent (typeName.getId ++ `ofNatLT)
@@ -83,6 +85,8 @@ builtin_dsimproc [seval] isValue ((OfNat.ofNat _ : $typeName)) := fun e => do
 
 end $typeName
 )
+
+end Lean
 
 declare_uint_simprocs UInt8
 declare_uint_simprocs UInt16

--- a/src/Lean/Server/FileWorker/RequestHandling.lean
+++ b/src/Lean/Server/FileWorker/RequestHandling.lean
@@ -20,6 +20,7 @@ public import Lean.Widget.Diff
 public section
 
 namespace Lean.Server.FileWorker
+open Lean
 open Lsp
 open RequestM
 open Snapshots

--- a/src/Lean/Server/FileWorker/Utils.lean
+++ b/src/Lean/Server/FileWorker/Utils.lean
@@ -15,6 +15,7 @@ public import Std.Sync.Mutex
 public section
 
 namespace Lean.Server.FileWorker
+open Lean
 open Snapshots
 open IO
 

--- a/src/Lean/Server/Requests.lean
+++ b/src/Lean/Server/Requests.lean
@@ -19,6 +19,8 @@ public import Std.Sync.Mutex
 
 public section
 
+open Lean
+
 /-- Checks whether `r` contains `hoverPos`, taking into account EOF according to `text`. -/
 def Lean.FileMap.rangeContainsHoverPos (text : Lean.FileMap) (r : Lean.Syntax.Range)
     (hoverPos : String.Pos.Raw) (includeStop := false) : Bool :=

--- a/src/Lean/Server/ServerTask.lean
+++ b/src/Lean/Server/ServerTask.lean
@@ -146,4 +146,4 @@ def cancel (t : ServerTask α) : BaseIO Unit :=
 
 end Lean.Server.ServerTask
 
-def Task.asServerTask (t : Task α) : Lean.Server.ServerTask α := .mk t
+def Lean.Task.asServerTask (t : Task α) : Lean.Server.ServerTask α := .mk t

--- a/src/lake/Lake/Util/Opaque.lean
+++ b/src/lake/Lake/Util/Opaque.lean
@@ -29,7 +29,7 @@ public opaque mk.{v,u} {α : Type u} (a : α) : POpaque.{v} :=
   unsafe unsafeCast a
 
 /-- Cast away a value's type and universe. -/
-public abbrev _root_.Opaque.mk {α : Type u} (a : α) : Opaque := POpaque.mk a
+public abbrev _root_.Lake.Opaque.mk {α : Type u} (a : α) : Opaque := POpaque.mk a
 
 /--
 Cast an opaque value to a specific type.

--- a/tests/elab/PArray_forM.lean
+++ b/tests/elab/PArray_forM.lean
@@ -2,6 +2,7 @@ import Lean.Data.PersistentArray
 /-!
 Test `PersistentArray.forM` with nonzero start position.
 -/
+open Lean
 
 def mk (n : Nat) : Lean.PersistentArray Nat :=
   List.range n |>.toPArray'

--- a/tests/elab/forInPArray.lean
+++ b/tests/elab/forInPArray.lean
@@ -1,4 +1,5 @@
 import Lean.Data.PersistentArray
+open Lean
 
 def check (x : IO Nat) (expected : IO Nat) : IO Unit := do
 unless (← x) == (← expected) do

--- a/tests/elab/funInfoBug.lean
+++ b/tests/elab/funInfoBug.lean
@@ -1,4 +1,5 @@
 import Lean.Data.AssocList
+open Lean
 
 def l : List (Prod Nat Nat) := [(1, 1), (2, 2)]
 #eval l -- works

--- a/tests/elab/funInfoBug.lean.out.expected
+++ b/tests/elab/funInfoBug.lean.out.expected
@@ -1,2 +1,2 @@
 [(1, 1), (2, 2)]
-Lean.AssocList.cons 1 1 (Lean.AssocList.cons 2 2 Lean.AssocList.nil)
+AssocList.cons 1 1 (AssocList.cons 2 2 AssocList.nil)

--- a/tests/elab/parray1.lean
+++ b/tests/elab/parray1.lean
@@ -1,4 +1,5 @@
 import Lean.Data.PersistentArray
+open Lean
 
 def check [BEq α] (as : List α) : Bool :=
   as.toPArray'.foldr (.::.) [] == as

--- a/tests/elab/whereCmd.lean
+++ b/tests/elab/whereCmd.lean
@@ -84,7 +84,7 @@ open Lean.Elab hiding TermElabM
 #guard_msgs in #where
 
 open Command Std
-open Array renaming map -> listMap
+open _root_.Array renaming map -> listMap
 
 /--
 info: open Lean Lean.Meta


### PR DESCRIPTION
This PR further reduces pollution of the namespaces belonging to basic types by putting declarations in the `Lean` namespace as appropriate.