### PR TITLE
chore: reduce namespace pollution

### DIFF
--- a/src/Lean/Data/Format.lean
+++ b/src/Lean/Data/Format.lean
@@ -12,7 +12,9 @@ public import Init.Data.Format.Instances
 public section
 universe u v
 
-namespace Std
+open Std.Format
+
+namespace Lean.Std
 namespace Format
 open Lean
 
@@ -35,20 +37,20 @@ register_builtin_option format.indent : Nat := {
   descr    := "indentation"
 }
 
-def pretty' (f : Format) (o : Options := {}) : String :=
+def pretty' (f : _root_.Std.Format) (o : Options := {}) : String :=
   pretty f (format.width.get o)
 
 end Format
-end Std
+end Lean.Std
 
 namespace Lean
 open Std
 
-export Std
+export _root_.Std
   (Format ToFormat Format.nest Format.nil Format.joinSep Format.line
    Format.sbracket Format.bracket Format.group Format.tag Format.pretty
    Format.fill Format.paren Format.join Format.align)
-export ToFormat (format)
+export _root_.Std.ToFormat (format)
 
 instance : ToFormat Name where
   format n := n.toString

--- a/src/Lean/Data/Format.lean
+++ b/src/Lean/Data/Format.lean
@@ -44,7 +44,6 @@ end Format
 end Lean.Std
 
 namespace Lean
-open Std
 
 export _root_.Std
   (Format ToFormat Format.nest Format.nil Format.joinSep Format.line Format.text

--- a/src/Lean/Data/Format.lean
+++ b/src/Lean/Data/Format.lean
@@ -47,7 +47,7 @@ namespace Lean
 open Std
 
 export _root_.Std
-  (Format ToFormat Format.nest Format.nil Format.joinSep Format.line
+  (Format ToFormat Format.nest Format.nil Format.joinSep Format.line Format.text
    Format.sbracket Format.bracket Format.group Format.tag Format.pretty
    Format.fill Format.paren Format.join Format.align)
 export _root_.Std.ToFormat (format)

--- a/src/Lean/Data/Json/FromToJson/Basic.lean
+++ b/src/Lean/Data/Json/FromToJson/Basic.lean
@@ -108,46 +108,53 @@ instance : ToJson String.Slice := ⟨fun s => s.copy⟩
 instance : FromJson System.FilePath := ⟨fun j => System.FilePath.mk <$> Json.getStr? j⟩
 instance : ToJson System.FilePath := ⟨fun p => p.toString⟩
 
-protected def _root_.Array.fromJson? [FromJson α] : Json → Except String (Array α)
+-- This is intentionally in the `Lean` namespace to avoid polluting the global namespace.
+protected def Array.fromJson? [FromJson α] : Json → Except String (Array α)
   | Json.arr a => a.mapM fromJson?
   | j          => throw s!"expected JSON array, got '{j}'"
 
 instance [FromJson α] : FromJson (Array α) where
   fromJson? := Array.fromJson?
 
-protected def _root_.Array.toJson [ToJson α] (a : Array α) : Json :=
+-- This is intentionally in the `Lean` namespace to avoid polluting the global namespace.
+protected def Array.toJson [ToJson α] (a : Array α) : Json :=
   Json.arr (a.map toJson)
 
 instance [ToJson α] : ToJson (Array α) where
   toJson := Array.toJson
 
-protected def _root_.List.fromJson? [FromJson α] (j : Json) : Except String (List α) :=
+-- This is intentionally in the `Lean` namespace to avoid polluting the global namespace.
+protected def List.fromJson? [FromJson α] (j : Json) : Except String (List α) :=
   (fromJson? j (α := Array α)).map Array.toList
 
 instance [FromJson α] : FromJson (List α) where
   fromJson? := List.fromJson?
 
-protected def _root_.List.toJson [ToJson α] (a : List α) : Json :=
+-- This is intentionally in the `Lean` namespace to avoid polluting the global namespace.
+protected def List.toJson [ToJson α] (a : List α) : Json :=
   toJson a.toArray
 
 instance [ToJson α] : ToJson (List α) where
   toJson := List.toJson
 
-protected def _root_.Option.fromJson? [FromJson α] : Json → Except String (Option α)
+-- This is intentionally in the `Lean` namespace to avoid polluting the global namespace.
+protected def Option.fromJson? [FromJson α] : Json → Except String (Option α)
   | Json.null => Except.ok none
   | j         => some <$> fromJson? j
 
 instance [FromJson α] : FromJson (Option α) where
   fromJson? := Option.fromJson?
 
-protected def _root_.Option.toJson [ToJson α] : Option α → Json
+-- This is intentionally in the `Lean` namespace to avoid polluting the global namespace.
+protected def Option.toJson [ToJson α] : Option α → Json
   | none   => Json.null
   | some a => toJson a
 
 instance [ToJson α] : ToJson (Option α) where
   toJson := Option.toJson
 
-protected def _root_.Prod.fromJson? {α : Type u} {β : Type v} [FromJson α] [FromJson β] : Json → Except String (α × β)
+-- This is intentionally in the `Lean` namespace to avoid polluting the global namespace.
+protected def Prod.fromJson? {α : Type u} {β : Type v} [FromJson α] [FromJson β] : Json → Except String (α × β)
   | Json.arr #[ja, jb] => do
     let ⟨a⟩ : ULift.{v} α := ← (fromJson? ja).map ULift.up
     let ⟨b⟩ : ULift.{u} β := ← (fromJson? jb).map ULift.up
@@ -157,7 +164,8 @@ protected def _root_.Prod.fromJson? {α : Type u} {β : Type v} [FromJson α] [F
 instance {α : Type u} {β : Type v} [FromJson α] [FromJson β] : FromJson (α × β) where
   fromJson? := Prod.fromJson?
 
-protected def _root_.Prod.toJson [ToJson α] [ToJson β] : α × β → Json
+-- This is intentionally in the `Lean` namespace to avoid polluting the global namespace.
+protected def Prod.toJson [ToJson α] [ToJson β] : α × β → Json
   | (a, b) => Json.arr #[toJson a, toJson b]
 
 instance [ToJson α] [ToJson β] : ToJson (α × β) where
@@ -210,7 +218,8 @@ def bignumFromJson? (j : Json) : Except String Nat := do
 def bignumToJson (n : Nat) : Json :=
   toString n
 
-protected def _root_.USize.fromJson? (j : Json) : Except String USize := do
+-- This is intentionally in the `Lean` namespace to avoid polluting the global namespace.
+protected def USize.fromJson? (j : Json) : Except String USize := do
   let n ← bignumFromJson? j
   if n ≥ USize.size then
     throw s!"value '{j}' is too large for `USize`"
@@ -222,7 +231,8 @@ instance : FromJson USize where
 instance : ToJson USize where
   toJson v := bignumToJson (USize.toNat v)
 
-protected def _root_.UInt64.fromJson? (j : Json) : Except String UInt64 := do
+-- This is intentionally in the `Lean` namespace to avoid polluting the global namespace.
+protected def UInt64.fromJson? (j : Json) : Except String UInt64 := do
   let n ← bignumFromJson? j
   if n ≥ UInt64.size then
     throw s!"value '{j}' is too large for `UInt64`"
@@ -234,7 +244,8 @@ instance : FromJson UInt64 where
 instance : ToJson UInt64 where
   toJson v := bignumToJson (UInt64.toNat v)
 
-protected def _root_.Float.toJson (x : Float) : Json :=
+-- This is intentionally in the `Lean` namespace to avoid polluting the global namespace.
+protected def Float.toJson (x : Float) : Json :=
   match JsonNumber.fromFloat? x with
   | Sum.inl e => Json.str e
   | Sum.inr n => Json.num n
@@ -242,7 +253,8 @@ protected def _root_.Float.toJson (x : Float) : Json :=
 instance : ToJson Float where
   toJson := Float.toJson
 
-protected def _root_.Float.fromJson? : Json → Except String Float
+-- This is intentionally in the `Lean` namespace to avoid polluting the global namespace.
+protected def Float.fromJson? : Json → Except String Float
   | (Json.str "Infinity") => Except.ok (1.0 / 0.0)
   | (Json.str "-Infinity") => Except.ok (-1.0 / 0.0)
   | (Json.str "NaN") => Except.ok (0.0 / 0.0)

--- a/src/Lean/Data/Json/Stream.lean
+++ b/src/Lean/Data/Json/Stream.lean
@@ -12,10 +12,11 @@ public import Lean.Data.Json.Printer
 
 public section
 
-namespace IO.FS.Stream
+open IO
+
+namespace Lean.IO.FS.Stream
 
 open Lean
-open IO
 
 def readUTF8 (h : FS.Stream) (nBytes : Nat) : IO String := do
   let bytes ← h.read (USize.ofNat nBytes)
@@ -32,4 +33,4 @@ def writeJson (h : FS.Stream) (j : Json) : IO Unit := do
   h.putStr j.compress
   h.flush
 
-end IO.FS.Stream
+end Lean.IO.FS.Stream

--- a/src/Lean/Elab/Deriving/Repr.lean
+++ b/src/Lean/Elab/Deriving/Repr.lean
@@ -15,7 +15,7 @@ public section
 namespace Lean.Elab.Deriving.Repr
 open Lean.Parser.Term
 open Meta
-open Std
+open _root_.Std
 
 def mkReprHeader (indVal : InductiveVal) : TermElabM Header := do
   let header ← mkHeader `Repr 1 indVal

--- a/src/Lean/Elab/Deriving/TypeName.lean
+++ b/src/Lean/Elab/Deriving/TypeName.lean
@@ -12,7 +12,7 @@ public import Lean.Elab.Deriving.Basic
 public section
 
 namespace Lean.Elab
-open Command Std Parser Term
+open Command Parser Term
 
 private def deriveTypeNameInstance (declNames : Array Name) : CommandElabM Bool := do
   for declName in declNames do

--- a/src/Lean/Elab/DocString.lean
+++ b/src/Lean/Elab/DocString.lean
@@ -17,7 +17,7 @@ set_option linter.missingDocs true
 namespace Lean.Doc
 
 open Lean Elab Term
-open Std
+open _root_.Std
 open scoped Lean.Doc.Syntax
 
 

--- a/src/Lean/Level.lean
+++ b/src/Lean/Level.lean
@@ -14,10 +14,11 @@ import Init.Data.Nat.Internal.Linear
 
 public section
 
+namespace Lean
+
+-- This is intentionally in the `Lean` namespace to avoid polluting the `Nat` namespace.
 def Nat.imax (n m : Nat) : Nat :=
   if m = 0 then 0 else Nat.max n m
-
-namespace Lean
 
 /--
  Cached hash code, cached results, and other data for `Level`.
@@ -670,7 +671,13 @@ def Level.find? (u : Level) (p : Level → Bool) : Option Level :=
 def Level.any (u : Level) (p : Level → Bool) : Bool :=
   u.find? p |>.isSome
 
-end Lean
+/--
+Converts a natural number to the corresponding `Lean.Level`.
 
+This is intentionally in the `Lean` namespace to avoid polluting the `Nat` namespace. Note that
+after `open Lean`, `n.toLevel` will work for `n : Nat`.
+-/
 abbrev Nat.toLevel (n : Nat) : Lean.Level :=
   Lean.Level.ofNat n
+
+end Lean

--- a/src/Lean/Linter/UnusedVariables.lean
+++ b/src/Lean/Linter/UnusedVariables.lean
@@ -78,7 +78,7 @@ foobar n -- not linted
 -/
 
 namespace Lean.Linter
-open Lean.Elab.Command Lean.Server Std
+open Lean.Elab.Command Lean.Server
 
 /-- Enables or disables all unused variable linter warnings -/
 register_builtin_option linter.unusedVariables : Bool := {

--- a/src/Lean/Meta/Tactic/AC/Main.lean
+++ b/src/Lean/Meta/Tactic/AC/Main.lean
@@ -16,7 +16,7 @@ public section
 namespace Lean.Meta.AC
 open Lean.Data.AC
 open Lean.Elab.Tactic
-open Std
+open _root_.Std
 
 abbrev ACExpr := Lean.Data.AC.Expr
 

--- a/src/Lean/PrettyPrinter/Parenthesizer.lean
+++ b/src/Lean/PrettyPrinter/Parenthesizer.lean
@@ -197,7 +197,7 @@ unsafe builtin_initialize combinatorParenthesizerAttribute : ParserCompiler.Comb
 namespace Parenthesizer
 
 open Lean.Core Parser
-open Std.Format
+open _root_.Std.Format
 
 def throwBacktrack {α} : ParenthesizerM α :=
 throw $ Exception.internal backtrackExceptionId

--- a/src/Lean/Server/FileWorker.lean
+++ b/src/Lean/Server/FileWorker.lean
@@ -47,11 +47,12 @@ If a task that the request task waits for is terminated, a change occurred somew
 command that the request is looking for and the request sends a "content changed" error.
 -/
 
+open IO
+
 namespace Lean.Server.FileWorker
 
 open Lsp
-open Lean IO
-open _root_.IO
+open Lean Lean.IO
 open Snapshots
 open JsonRpc
 

--- a/src/Lean/Server/FileWorker.lean
+++ b/src/Lean/Server/FileWorker.lean
@@ -50,7 +50,7 @@ command that the request is looking for and the request sends a "content changed
 namespace Lean.Server.FileWorker
 
 open Lsp
-open Lean
+open Lean IO
 open _root_.IO
 open Snapshots
 open JsonRpc

--- a/src/Lean/Server/References.lean
+++ b/src/Lean/Server/References.lean
@@ -218,6 +218,8 @@ structure Ilean where
 
 namespace Ilean
 
+open Lean.IO
+
 /-- Reads and parses the .ilean file at `path`. -/
 def load (path : System.FilePath) : IO Ilean := do
   let content ← FS.readFile path

--- a/src/Lean/Server/References.lean
+++ b/src/Lean/Server/References.lean
@@ -18,7 +18,7 @@ public section
 set_option linter.missingDocs true
 
 namespace Lean.Server
-open Lsp Lean.Elab Std
+open Lsp Lean.Elab
 
 /-- Converts an `Import` to its LSP-internal representation. -/
 def ImportInfo.ofImport (i : Import) : ImportInfo where

--- a/src/Lean/Server/Utils.lean
+++ b/src/Lean/Server/Utils.lean
@@ -15,7 +15,9 @@ public import Lean.Server.InfoUtils
 
 public section
 
-namespace IO
+open IO FS
+
+namespace Lean.IO
 
 /-- Throws an `IO.userError`. -/
 def throwServerError (err : String) : IO α :=
@@ -68,7 +70,7 @@ def withPrefix (a : Stream) (pre : String) : Stream :=
       a.putStr (pre ++ s) }
 
 end FS.Stream
-end IO
+end Lean.IO
 
 namespace Lean.Server
 

--- a/src/Lean/Server/Watchdog.lean
+++ b/src/Lean/Server/Watchdog.lean
@@ -69,7 +69,7 @@ state.
 
 namespace Lean.Server.Watchdog
 
-open Lean
+open Lean IO
 open _root_.IO
 open Lsp
 open JsonRpc

--- a/src/Lean/Server/Watchdog.lean
+++ b/src/Lean/Server/Watchdog.lean
@@ -67,10 +67,11 @@ right to add non-standard extensions in case they're needed, for example to comm
 state.
 -/
 
+open IO
+
 namespace Lean.Server.Watchdog
 
-open Lean IO
-open _root_.IO
+open Lean Lean.IO
 open Lsp
 open JsonRpc
 open System.Uri

--- a/src/Lean/Syntax.lean
+++ b/src/Lean/Syntax.lean
@@ -27,9 +27,6 @@ protected structure Lean.Syntax.Range where
   stop  : String.Pos.Raw
   deriving Inhabited, Repr, BEq, Hashable
 
-@[expose, deprecated Lean.Syntax.Range (since := "2025-10-20")]
-def String.Range := Lean.Syntax.Range
-
 def Lean.Syntax.Range.contains (r : Lean.Syntax.Range) (pos : String.Pos.Raw) (includeStop := false) : Bool :=
   r.start <= pos && (if includeStop then pos <= r.stop else pos < r.stop)
 
@@ -49,27 +46,13 @@ def Lean.Syntax.Range.includes (super sub : Lean.Syntax.Range)
       sub.stop <= super.stop
   )
 
-@[deprecated Lean.Syntax.Range.includes (since := "2025-10-20")]
-def String.Range.includes (super sub : Lean.Syntax.Range)
-    (includeSuperStop := false) (includeSubStop := false) : Bool :=
-  Lean.Syntax.Range.includes super sub includeSuperStop includeSubStop
-
 def Lean.Syntax.Range.overlaps (first second : Lean.Syntax.Range)
     (includeFirstStop := false) (includeSecondStop := false) : Bool :=
   (if includeFirstStop then second.start <= first.stop else second.start < first.stop) &&
     (if includeSecondStop then first.start <= second.stop else first.start < second.stop)
 
-@[deprecated Lean.Syntax.Range.overlaps (since := "2025-10-20")]
-def String.Range.overlaps (first second : Lean.Syntax.Range)
-    (includeFirstStop := false) (includeSecondStop := false) : Bool :=
-  Lean.Syntax.Range.overlaps first second includeFirstStop includeSecondStop
-
 def Lean.Syntax.Range.bsize (r : Lean.Syntax.Range) : Nat :=
   r.stop.byteIdx - r.start.byteIdx
-
-@[deprecated Lean.Syntax.Range.bsize (since := "2025-10-20")]
-def String.Range.bsize (r : Lean.Syntax.Range) : Nat :=
-  Lean.Syntax.Range.bsize r
 
 namespace Lean
 

--- a/src/Lean/Util/ProfilerServer.lean
+++ b/src/Lean/Util/ProfilerServer.lean
@@ -21,7 +21,7 @@ profile is loaded with a single command (a la `samply`).
 
 namespace Lean.Firefox
 
-open Std Async Http
+open _root_.Std Async Http
 
 /-- Best-effort: spawn the platform-specific "open this URL in the default browser" command. -/
 def openInBrowser (url : String) : IO Unit := do

--- a/src/Lean/Widget/Diff.lean
+++ b/src/Lean/Widget/Diff.lean
@@ -16,7 +16,7 @@ register_builtin_option showTacticDiff : Bool := {
   descr := "When true, interactive goals for tactics will be decorated with diffing information. "
 }
 
-open Server Std Lean SubExpr
+open Server Lean SubExpr
 
 /-- A marker for a point in the expression where a subexpression has been inserted.
 

--- a/tests/elab/whereCmd.lean
+++ b/tests/elab/whereCmd.lean
@@ -83,7 +83,7 @@ open Lean.Elab hiding TermElabM
 -/
 #guard_msgs in #where
 
-open Command Std
+open Command _root_.Std
 open _root_.Array renaming map -> listMap
 
 /--


### PR DESCRIPTION
This PR further reduces pollution of the namespaces belonging to basic types by putting declarations in the `Lean` namespace as appropriate.