### PR TITLE
feat: add a warning for adding a `deprecated` attribute to `register_option`

### DIFF
--- a/src/Lean/Linter/Deprecated.lean
+++ b/src/Lean/Linter/Deprecated.lean
@@ -10,6 +10,7 @@ public import Lean.Meta.Basic
 import Lean.Linter.Init
 import Lean.Elab.InfoTree.Main
 import Lean.ExtraModUses
+import Lean.Compiler.InitAttr
 import Init.Omega
 
 public section
@@ -31,9 +32,13 @@ builtin_initialize deprecatedAttr : ParametricAttribute DeprecationEntry ←
   registerParametricAttribute {
     name := `deprecated
     descr := "mark declaration as deprecated",
-    getParam := fun _ stx => do
+    getParam := fun declName stx => do
       let `(attr| deprecated $[$id?]? $[$text?]? $[(since := $since?)]?) := stx
         | throwError "Invalid `[deprecated]` attribute syntax"
+      if let some info := (← getEnv).find? declName then
+        if info.type.isAppOf ``Lean.Option && (getRegularInitFnNameFor? (← getEnv) declName).isSome then
+          logWarning m!"`{.ofConstName declName true}` is an option; deprecate it using the \
+            `deprecation?` field of its definition instead of the `[deprecated]` attribute"
       let newName? ← id?.mapM Elab.realizeGlobalConstNoOverloadWithInfo
       if let some newName := newName? then
         recordExtraModUseFromDecl (isMeta := false) newName

--- a/tests/elab/deprecatedOptionWarning.lean
+++ b/tests/elab/deprecatedOptionWarning.lean
@@ -1,0 +1,18 @@
+module
+
+public import Lean.Data.Options
+
+public register_option linter.style.whitespace : Bool := {
+  defValue := false
+  descr := "enable the whitespace linter"
+}
+
+/--
+warning: `linter.style.commandStart` is an option; deprecate it using the `deprecation?` field of its definition instead of the `[deprecated]` attribute
+-/
+#guard_msgs in
+@[deprecated linter.style.whitespace (since := "2026-01-07")]
+public register_option linter.style.commandStart : Bool := {
+  defValue := false
+  descr := "deprecated: use the `linter.style.whitespace` option instead"
+}


### PR DESCRIPTION
This PR adds a warning when the `[deprecated]` attribute is applied to an option declared with `register_option`. Options should be deprecated through the `deprecation?` field of their definition instead, and the warning points users to that mechanism.