### PR TITLE
feat: add `forward_type_reference%` for negative type occurrences

### DIFF
--- a/src/Lean/Elab.lean
+++ b/src/Lean/Elab.lean
@@ -47,6 +47,7 @@ public import Lean.Elab.Notation
 public import Lean.Elab.Mixfix
 public import Lean.Elab.MacroRules
 public import Lean.Elab.BuiltinCommand
+public import Lean.Elab.ForwardTypeReference
 public import Lean.Elab.AssertExists
 public import Lean.Elab.Command.WithWeakNamespace
 public import Lean.Elab.BuiltinEvalCommand

--- a/src/Lean/Elab/Command.lean
+++ b/src/Lean/Elab/Command.lean
@@ -111,6 +111,11 @@ builtin_initialize lintersRef : IO.Ref (Array Linter) ← IO.mkRef #[]
 builtin_initialize moduleLintersRef : IO.Ref (Array ModuleLinter) ← IO.mkRef #[]
 builtin_initialize registerTraceClass `Elab.lint
 
+/-- Runs after each top-level command to bridge pending `forward_type_reference%` stand-ins to their
+now-defined targets. Installed by `Lean.Elab.ForwardTypeReference`. -/
+builtin_initialize forwardRefResolverRef : IO.Ref (Syntax → CommandElabM Unit) ←
+  IO.mkRef fun _ => pure ()
+
 def addLinter (l : Linter) : IO Unit := do
   let ls ← lintersRef.get
   lintersRef.set (ls.push l)
@@ -656,6 +661,11 @@ def elabCommandTopLevel (stx : Syntax) (cmds : Array Syntax := #[]) : CommandEla
     -- be the caller of this function and add new messages and info trees
     if let some snap := (← read).snap? then
       snap.new.resolve default
+
+  -- Bridge any `forward_type_reference%` whose target was just defined; env changes must persist,
+  -- so this runs outside the linters' `withoutModifyingEnv`.
+  withLogging do
+    (← forwardRefResolverRef.get) stx
 
   -- Run the linters, unless `#guard_msgs` is present, which is special and runs `elabCommandTopLevel` itself,
   -- so it is a "super-top-level" command. This is the only command that does this, so we just special case it here

--- a/src/Lean/Elab/ForwardTypeReference.lean
+++ b/src/Lean/Elab/ForwardTypeReference.lean
@@ -58,12 +58,27 @@ def withArgTelescope [Inhabited α] (argEs : Array Expr) (k : Array Expr → Ter
     TermElabM α :=
   withArgTelescopeAux argEs k 0 #[]
 
+/-- The names generated for a forward reference to `base`: the stand-in family, its witness, and the
+two casts with their `implemented_by` shims. -/
+def fwdRefNames (base : Name) : Array Name :=
+  #[base ++ `FwdRefPointed, base ++ `FwdRef,
+    base ++ `toFwdRefImpl, base ++ `toFwdRef,
+    base ++ `FwdRef ++ `fromFwdRefImpl, base ++ `FwdRef ++ `fromFwdRef]
+
 /-- Lazily declare a `base.FwdRef` family abstracting the use-site argument telescope and returning
 `Type u`, backed by an opaque `base.FwdRefPointed : NonemptyType.{u}`. -/
 def mkFwdRefFamily (base : Name) (argEs : Array Expr) (u : Level) : TermElabM Name := do
   let refName := base ++ `FwdRef
-  if (← getEnv).contains refName then return refName
   let pointedName := base ++ `FwdRefPointed
+  if (← getEnv).contains refName then
+    -- reuse only our own family, marked by the opaque witness; a bare `base.FwdRef` is a collision
+    if (← getEnv).contains pointedName then return refName
+    else throwError "`forward_type_reference%` cannot create `{refName}`: a declaration with that \
+      name already exists"
+  for n in fwdRefNames base do
+    if (← getEnv).contains n then
+      throwError "`forward_type_reference%` cannot create `{n}`: a declaration with that name \
+        already exists"
   withArgTelescope argEs fun xs => do
     -- generalize the telescope's universe mvars (e.g. an enclosing auto-bound universe) to params
     let famType ← instantiateMVars (← levelMVarToParam (← mkForallFVars xs (mkSort (.succ u))))
@@ -81,8 +96,9 @@ def mkFwdRefFamily (base : Name) (argEs : Array Expr) (u : Level) : TermElabM Na
     }
     return refName
 
-/-- Record `base` as an unresolved forward reference, unless already pending. -/
-def registerForwardRef (base : Name) (ref : Syntax) : TermElabM Unit :=
+/-- Record `base` as an unresolved forward reference, unless already bridged or already pending. -/
+def registerForwardRef (base : Name) (ref : Syntax) : TermElabM Unit := do
+  if (← getEnv).contains (base ++ `toFwdRef) then return
   modifyEnv fun env => forwardRefExt.modifyState env fun s =>
     if s.any (·.base == base) then s else s.push { base, ref }
 
@@ -108,8 +124,14 @@ def fwdRefArity (refName : Name) : CommandElabM Nat :=
     return xs.size
 
 /-- Bridge `base.FwdRef` to a now-defined `base`: a `Nonempty` instance plus the two opaque casts,
-re-deriving the shared telescope as autobound implicits. -/
-def bridgeForwardRef (base : Name) : CommandElabM Unit := do
+re-deriving the shared telescope as autobound implicits. `refStx` locates a collision report. -/
+def bridgeForwardRef (base : Name) (refStx : Syntax) : CommandElabM Unit := do
+  for n in #[base ++ `toFwdRefImpl, base ++ `toFwdRef,
+             base ++ `FwdRef ++ `fromFwdRefImpl, base ++ `FwdRef ++ `fromFwdRef] do
+    if (← getEnv).contains n then
+      logErrorAt refStx m!"`forward_type_reference%` cannot generate `{n}`: a declaration with \
+        that name already exists"
+      return
   let ref := base ++ `FwdRef
   let n ← fwdRefArity ref
   -- name declarations relative to the current namespace so they land at `base.*`
@@ -132,15 +154,15 @@ report references that were never defined. -/
 def resolveForwardTypeReferences (stx : Syntax) : CommandElabM Unit := do
   let entries := forwardRefExt.getState (← getEnv)
   if entries.isEmpty then return
-  let resolved (base : Name) : CommandElabM Bool := do
-    return (← getEnv).contains (base ++ `toFwdRef)
   let mut remaining : Array Lean.Elab.Term.ForwardRefEntry := #[]
+  let mut toBridge : Array Lean.Elab.Term.ForwardRefEntry := #[]
   for entry in entries do
-    if (← getEnv).contains entry.base && !(← resolved entry.base) then
-      bridgeForwardRef entry.base
-    unless ← resolved entry.base do
-      remaining := remaining.push entry
+    if (← getEnv).contains entry.base then toBridge := toBridge.push entry
+    else remaining := remaining.push entry
+  -- drop the now-defined references before bridging, so a bridge error is not retried per command
   modifyEnv (forwardRefExt.setState · remaining)
+  for entry in toBridge do
+    bridgeForwardRef entry.base entry.ref
   if Parser.isTerminalCommand stx then
     for entry in remaining do
       logErrorAt entry.ref m!"unresolved `forward_type_reference%`: '{entry.base}' is never defined"

--- a/src/Lean/Elab/ForwardTypeReference.lean
+++ b/src/Lean/Elab/ForwardTypeReference.lean
@@ -1,0 +1,150 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Graf
+-/
+module
+
+prelude
+public import Lean.Elab.Command
+
+/-!
+# `forward_type_reference%`
+
+`forward_type_reference% T a b` elaborates to an opaque stand-in `T.FwdRef a b` for a type `T a b`
+whose definition comes later in the file. Once `T` is defined, casts `T.toFwdRef` and
+`T.FwdRef.fromFwdRef` bridging `T` and `T.FwdRef` are generated automatically. Routing a negative
+self-occurrence through `T.FwdRef` lets a type carry it, mechanizing the hand-written
+`Simp.MethodsRef` pattern.
+-/
+
+public section
+
+namespace Lean.Elab.Term
+open Meta
+
+/-- A pending `forward_type_reference%` awaiting its target's definition. -/
+structure ForwardRefEntry where
+  /-- Anticipated name of the referenced type. -/
+  base : Name
+  /-- Reference syntax, for reporting an unresolved reference at end of file. -/
+  ref  : Syntax
+
+/-- Per-file registry of pending `forward_type_reference%` stand-ins. `mainOnly` suffices: the
+elaborator writes it only while elaborating a definition signature, which runs on the main branch. -/
+builtin_initialize forwardRefExt : EnvExtension (Array ForwardRefEntry) ←
+  registerEnvExtension (pure #[])
+
+/-- Result universe of a type whose expected type is `Sort (u+1)`; falls back to `0`. -/
+def fwdRefUniverse (expectedType? : Option Expr) : TermElabM Level := do
+  let some t := expectedType? | return .zero
+  match (← instantiateMVars (← whnf t)) with
+  | .sort l => match (← instantiateLevelMVars l) with
+               | .succ l' => return if l'.hasMVar then .zero else l'
+               | _ => return .zero
+  | _ => return .zero
+
+private partial def withArgTelescopeAux [Inhabited α] (argEs : Array Expr)
+    (k : Array Expr → TermElabM α) (i : Nat) (xs : Array Expr) : TermElabM α := do
+  if i < argEs.size then
+    let ty ← (List.range i).foldlM (init := ← inferType argEs[i]!) fun ty j =>
+      return (← kabstract ty argEs[j]!).instantiate1 xs[j]!
+    withLocalDeclD (.mkSimple s!"x{i}") ty fun x => withArgTelescopeAux argEs k (i+1) (xs.push x)
+  else k xs
+
+/-- Abstract `argEs` into a dependent telescope of fresh fvars, capturing dependencies between the
+arguments so a later `a : α` sees the earlier `α`. -/
+def withArgTelescope [Inhabited α] (argEs : Array Expr) (k : Array Expr → TermElabM α) :
+    TermElabM α :=
+  withArgTelescopeAux argEs k 0 #[]
+
+/-- Lazily declare a `base.FwdRef` family abstracting the use-site argument telescope and returning
+`Type u`, backed by an opaque `base.FwdRefPointed : NonemptyType.{u}`. -/
+def mkFwdRefFamily (base : Name) (argEs : Array Expr) (u : Level) : TermElabM Name := do
+  let refName := base ++ `FwdRef
+  if (← getEnv).contains refName then return refName
+  let pointedName := base ++ `FwdRefPointed
+  withArgTelescope argEs fun xs => do
+    -- generalize the telescope's universe mvars (e.g. an enclosing auto-bound universe) to params
+    let famType ← instantiateMVars (← levelMVarToParam (← mkForallFVars xs (mkSort (.succ u))))
+    let lvls := (collectLevelParams {} famType).params.toList
+    let nonemptyU := Lean.mkConst ``NonemptyType [u]
+    let inst ← synthInstance (← mkAppM ``Inhabited #[nonemptyU])
+    let witness ← mkAppOptM ``Inhabited.default #[nonemptyU, inst]
+    addDecl <| .opaqueDecl {
+      name := pointedName, levelParams := lvls, type := nonemptyU, value := witness, isUnsafe := false
+    }
+    let body := mkApp (Lean.mkConst ``NonemptyType.type [u]) (Lean.mkConst pointedName (lvls.map .param))
+    addDecl <| .defnDecl {
+      name := refName, levelParams := lvls, type := famType,
+      value := ← instantiateMVars (← mkLambdaFVars xs body), hints := .regular 0, safety := .safe
+    }
+    return refName
+
+/-- Record `base` as an unresolved forward reference, unless already pending. -/
+def registerForwardRef (base : Name) (ref : Syntax) : TermElabM Unit :=
+  modifyEnv fun env => forwardRefExt.modifyState env fun s =>
+    if s.any (·.base == base) then s else s.push { base, ref }
+
+@[builtin_term_elab Parser.Term.forwardTypeReference]
+def elabForwardTypeReference : TermElab := fun stx expectedType? => do
+  let argStxs := stx[2].getArgs
+  let argEs ← argStxs.mapM (elabTerm · none)
+  let base := (← getCurrNamespace) ++ stx[1].getId
+  let refName ← mkFwdRefFamily base argEs (← fwdRefUniverse expectedType?)
+  registerForwardRef base stx
+  -- re-elaborate as an ordinary application so universe unification is handled normally
+  let args : Array Term := argStxs.map (⟨·⟩)
+  elabTerm (← `($(mkIdent refName) $args*)) expectedType?
+
+end Lean.Elab.Term
+
+namespace Lean.Elab.Command
+open Lean.Elab.Term (forwardRefExt)
+
+/-- Number of telescope binders of the `refName` family. -/
+def fwdRefArity (refName : Name) : CommandElabM Nat :=
+  liftTermElabM do Meta.forallTelescopeReducing (← getConstInfo refName).type fun xs _ =>
+    return xs.size
+
+/-- Bridge `base.FwdRef` to a now-defined `base`: a `Nonempty` instance plus the two opaque casts,
+re-deriving the shared telescope as autobound implicits. -/
+def bridgeForwardRef (base : Name) : CommandElabM Unit := do
+  let ref := base ++ `FwdRef
+  let n ← fwdRefArity ref
+  -- name declarations relative to the current namespace so they land at `base.*`
+  let rel := base.replacePrefix (← getCurrNamespace) .anonymous
+  let relRef := rel ++ `FwdRef
+  let ps : Array Term := (Array.range n).map fun i => (mkIdent (.mkSimple s!"p{i+1}") : Term)
+  let bApp ← `($(mkIdent base) $ps*)
+  let rApp ← `($(mkIdent ref) $ps*)
+  let pointed := mkIdent (base ++ `FwdRefPointed)
+  let toImpl := mkIdent (rel ++ `toFwdRefImpl); let toRef := mkIdent (rel ++ `toFwdRef)
+  let frImpl := mkIdent (relRef ++ `fromFwdRefImpl); let frRef := mkIdent (relRef ++ `fromFwdRef)
+  elabCommand <| ← `(command| instance : Nonempty $rApp := ($pointed).property)
+  elabCommand <| ← `(command| unsafe def $toImpl (x : $bApp) : $rApp := unsafeCast x)
+  elabCommand <| ← `(command| @[implemented_by $toImpl] opaque $toRef (x : $bApp) : $rApp)
+  elabCommand <| ← `(command| unsafe def $frImpl [Nonempty $bApp] (x : $rApp) : $bApp := unsafeCast x)
+  elabCommand <| ← `(command| @[implemented_by $frImpl] opaque $frRef [Nonempty $bApp] (x : $rApp) : $bApp)
+
+/-- Bridge every pending `forward_type_reference%` whose target is now defined; at end of file,
+report references that were never defined. -/
+def resolveForwardTypeReferences (stx : Syntax) : CommandElabM Unit := do
+  let entries := forwardRefExt.getState (← getEnv)
+  if entries.isEmpty then return
+  let resolved (base : Name) : CommandElabM Bool := do
+    return (← getEnv).contains (base ++ `toFwdRef)
+  let mut remaining : Array Lean.Elab.Term.ForwardRefEntry := #[]
+  for entry in entries do
+    if (← getEnv).contains entry.base && !(← resolved entry.base) then
+      bridgeForwardRef entry.base
+    unless ← resolved entry.base do
+      remaining := remaining.push entry
+  modifyEnv (forwardRefExt.setState · remaining)
+  if Parser.isTerminalCommand stx then
+    for entry in remaining do
+      logErrorAt entry.ref m!"unresolved `forward_type_reference%`: '{entry.base}' is never defined"
+
+builtin_initialize forwardRefResolverRef.set resolveForwardTypeReferences
+
+end Lean.Elab.Command

--- a/src/Lean/Parser/Term.lean
+++ b/src/Lean/Parser/Term.lean
@@ -784,6 +784,12 @@ In particular, it is like a unary operation with a fixed parameter `b`, where on
 @[builtin_term_parser] def unop := leading_parser
   "unop% " >> ident >> ppSpace >> termParser maxPrec
 
+/-- `forward_type_reference% T a b` is an opaque stand-in `T.FwdRef a b` for a type `T a b` whose
+definition comes later in the file, with casts `T.toFwdRef`/`T.FwdRef.fromFwdRef` bridging `T` and
+its stand-in generated once `T` is defined. -/
+@[builtin_term_parser] def forwardTypeReference := leading_parser
+  "forward_type_reference% " >> ident >> many (ppSpace >> termParser maxPrec)
+
 @[builtin_term_parser] def forInMacro := leading_parser
   "for_in% " >> termParser maxPrec >> termParser maxPrec >> ppSpace >> termParser maxPrec
 @[builtin_term_parser] def forInMacro' := leading_parser

--- a/tests/elab/forward_type_reference.lean
+++ b/tests/elab/forward_type_reference.lean
@@ -1,0 +1,114 @@
+/-!
+Tests `forward_type_reference%`: an opaque stand-in `T.FwdRef` for a not-yet-defined type `T`, with
+`T.toFwdRef`/`T.FwdRef.fromFwdRef` casts auto-generated once `T` is defined. Covers monomorphic,
+parametric, universe-polymorphic, and dependent-telescope targets, a namespaced target, and the
+kernel rejection of the unlaundered form.
+-/
+
+abbrev Step := Nat
+abbrev BaseM := StateM Nat
+
+/-! ## Monomorphic target (the `Simp.MethodsRef` shape) -/
+
+abbrev SimpM := ReaderT (forward_type_reference% Methods) BaseM
+
+structure Methods where
+  pre : Nat → SimpM Step
+deriving Nonempty
+
+def getMethods : SimpM Methods := return Methods.FwdRef.fromFwdRef (← read)
+def runWith (m : Methods) (act : SimpM α) : α := (act (Methods.toFwdRef m)).run' 0
+def demo : Nat := runWith { pre := fun n => pure (n + 1) } do (← getMethods).pre 41
+
+/-- info: 42 -/
+#guard_msgs in #eval demo
+/-- info: 'demo' depends on axioms: [Classical.choice] -/
+#guard_msgs in #print axioms demo
+
+/-! ## Parametric target -/
+
+abbrev PSimpM (σ : Type) := ReaderT (forward_type_reference% PMethods σ) BaseM
+
+structure PMethods (σ : Type) where
+  pre : σ → PSimpM σ σ
+deriving Nonempty
+
+def pGet [Nonempty σ] : PSimpM σ (PMethods σ) := return PMethods.FwdRef.fromFwdRef (← read)
+def pRun (m : PMethods σ) (act : PSimpM σ β) : β := (act (PMethods.toFwdRef m)).run' 0
+def pDemo : Nat := pRun (σ := Nat) { pre := fun n => pure (n + 1) } do (← pGet).pre 41
+
+/-- info: 42 -/
+#guard_msgs in #eval pDemo
+/-- info: PMethods.FwdRef : Type → Type -/
+#guard_msgs in #check @PMethods.FwdRef
+
+/-! ## Universe-polymorphic target -/
+
+abbrev UM (σ : Type u) := ReaderT (forward_type_reference% UBox σ) (StateM Nat)
+
+structure UBox (σ : Type u) where
+  run : σ → UM σ PUnit
+deriving Nonempty
+
+/-- info: @UBox.toFwdRef : {p1 : Type u_1} → UBox p1 → UBox.FwdRef p1 -/
+#guard_msgs in #check @UBox.toFwdRef
+
+/-! ## Dependent telescope (a value/index parameter depending on a sibling) -/
+
+abbrev DM (α : Type) (a : α) := ReaderT (forward_type_reference% DBox α a) (StateM Nat)
+
+structure DBox (α : Type) (a : α) where
+  run : α → DM α a Nat
+deriving Nonempty
+
+/-- info: DBox.FwdRef : (x0 : Type) → x0 → Type -/
+#guard_msgs in #check @DBox.FwdRef
+
+def dGet [Nonempty α] : DM α a (DBox α a) := return DBox.FwdRef.fromFwdRef (← read)
+def dRun (m : DBox α a) (act : DM α a β) : β := (act (DBox.toFwdRef m)).run' 0
+def dDemo : Nat := dRun (α := Nat) (a := 7) { run := fun n => pure (n + 1) } do (← dGet).run 41
+
+/-- info: 42 -/
+#guard_msgs in #eval dDemo
+
+/-! ## Namespaced target: casts land at `Foo.Bar.*` -/
+
+namespace Foo
+
+abbrev NM := ReaderT (forward_type_reference% Bar) BaseM
+
+structure Bar where
+  run : Nat → NM Nat
+deriving Nonempty
+
+def nGet : NM Bar := return Bar.FwdRef.fromFwdRef (← read)
+def nRun (m : Bar) (act : NM β) : β := (act (Bar.toFwdRef m)).run' 0
+def nDemo : Nat := nRun { run := fun n => pure (n + 1) } do (← nGet).run 41
+
+/-- info: 42 -/
+#guard_msgs in #eval nDemo
+
+end Foo
+
+/-- info: Foo.Bar.toFwdRef : Foo.Bar → Foo.Bar.FwdRef -/
+#guard_msgs in #check @Foo.Bar.toFwdRef
+
+/-! ## Already-defined target: bridged in the same command -/
+
+structure Pre where
+  x : Nat
+deriving Nonempty
+
+abbrev PreM := ReaderT (forward_type_reference% Pre) BaseM
+
+/-- info: Pre.toFwdRef : Pre → Pre.FwdRef -/
+#guard_msgs in #check @Pre.toFwdRef
+
+/-! ## The laundering is load-bearing: the unlaundered form is kernel-rejected -/
+
+/--
+error: (kernel) arg #1 of 'BadMethods.mk' has a non positive occurrence of the datatypes being declared
+-/
+#guard_msgs in
+structure BadMethods where
+  pre : Nat → ReaderT BadMethods BaseM Step

--- a/tests/elab_fail/forward_type_reference_collision.lean
+++ b/tests/elab_fail/forward_type_reference_collision.lean
@@ -1,0 +1,14 @@
+/-!
+Tests that `forward_type_reference%` reports a clear error when one of the names it would generate is
+already declared, whether the clash predates the reference or appears before the target's definition.
+-/
+
+def A.FwdRef := Nat
+abbrev AM := ReaderT (forward_type_reference% A) (StateM Nat)
+
+def B.toFwdRef := Nat
+abbrev BM := ReaderT (forward_type_reference% B) (StateM Nat)
+
+abbrev CM := ReaderT (forward_type_reference% C) (StateM Nat)
+def C.toFwdRef := Nat
+structure C where c : Nat deriving Nonempty

--- a/tests/elab_fail/forward_type_reference_collision.lean.out.expected
+++ b/tests/elab_fail/forward_type_reference_collision.lean.out.expected
@@ -1,0 +1,3 @@
+forward_type_reference_collision.lean:7:22-7:47: error: `forward_type_reference%` cannot create `A.FwdRef`: a declaration with that name already exists
+forward_type_reference_collision.lean:10:22-10:47: error: `forward_type_reference%` cannot create `B.toFwdRef`: a declaration with that name already exists
+forward_type_reference_collision.lean:12:22-12:47: error: `forward_type_reference%` cannot generate `C.toFwdRef`: a declaration with that name already exists

--- a/tests/elab_fail/forward_type_reference_unresolved.lean
+++ b/tests/elab_fail/forward_type_reference_unresolved.lean
@@ -1,0 +1,4 @@
+/-!
+Tests that a `forward_type_reference%` whose target is never defined is reported at end of file.
+-/
+abbrev M := ReaderT (forward_type_reference% NeverDefined) (StateM Nat)

--- a/tests/elab_fail/forward_type_reference_unresolved.lean.out.expected
+++ b/tests/elab_fail/forward_type_reference_unresolved.lean.out.expected
@@ -1,0 +1,1 @@
+forward_type_reference_unresolved.lean:4:21-4:57: error: unresolved `forward_type_reference%`: 'NeverDefined' is never defined


### PR DESCRIPTION
This PR adds the term elaborator `forward_type_reference% T a b`, which elaborates to an opaque stand-in `T.FwdRef a b` for a type `T a b` whose definition comes later in the file. Once `T` is defined, the casts `T.toFwdRef` and `T.FwdRef.fromFwdRef` bridging `T` and its stand-in are generated automatically. Routing a negative self-occurrence through `T.FwdRef` lets a type carry it, mechanizing the hand-written `Simp.MethodsRef` pattern.

The stand-in `T.FwdRef` is an opaque type backed by `T.FwdRefPointed : NonemptyType`; the casts are `unsafeCast` behind `opaque` with `@[implemented_by]`, so `T` and `T.FwdRef` are bit-identical at runtime and abstract to the logic. The elaborator abstracts the use-site argument telescope, supporting parametric, universe-polymorphic, and dependent targets, and names the family under the current namespace. A per-file registry records pending references; a resolver runs after each top-level command via `elabCommandTopLevel`, bridging each target once it is defined and reporting references that are never defined at end of file.