### PR TITLE
chore: fix three spell-check typos

### DIFF
--- a/src/lake/Lake/Build/Common.lean
+++ b/src/lake/Lake/Build/Common.lean
@@ -1053,7 +1053,7 @@ The executable will statically link in `linkObjs` (e.g., object files or
 static libraries) and dynamically link to `linkLibs` (and their transitive
 `deps`).
 
-By default, Lean will be statically linked to the exeutable.
+By default, Lean will be statically linked to the executable.
 If `sharedLean := true`, it will instead be dynamically linked.
 This means users of the resulting executable will need to have Lean's
 shared libraries on their system.
@@ -1078,7 +1078,7 @@ The executable will statically link in the results of `linkObjs` (e.g., object
 files or static libraries) and dynamically link to the results of `linkLibs`
 (and their transitive `deps`).
 
-By default, Lean will be statically linked to the exeutable.
+By default, Lean will be statically linked to the executable.
 If `sharedLean := true`, it will instead be dynamically linked.
 This means users of the resulting executable will need to have Lean's
 shared libraries on their system.

--- a/src/lake/Lake/Config/LeanExe.lean
+++ b/src/lake/Lake/Config/LeanExe.lean
@@ -77,7 +77,7 @@ The file name of binary executable
   self.config.supportInterpreter
 
 /--
-Additional link argyments to pass `leanc` when linking the module root
+Additional link arguments to pass `leanc` when linking the module root
 into a binary executable. This excludes the arguments already present in
 `self.root.linkArgs`.
 


### PR DESCRIPTION
This PR fixes spelling errors I ran across updating the reference manual for #14254 compatibility