### PR TITLE
perf: `shareCommon` at `SymM`

### DIFF
--- a/src/Lean/Meta/Sym/AlphaShareBuilder.lean
+++ b/src/Lean/Meta/Sym/AlphaShareBuilder.lean
@@ -58,8 +58,8 @@ Helper function for lifting a `AlphaShareBuilderM` action to `GrindM`
 abbrev liftBuilderM (k : AlphaShareBuilderM α) : SymM α := do
   -- The builder functions are a trusted layer, so invariant checks are disabled.
   match (← runShareCommonM (k (← isDebugEnabled)) { env := (← getEnv) }) with
-  | some a => return a
-  | none => unreachable! -- checks are disabled
+  | .ok a => return a
+  | .error _ => unreachable! -- checks are disabled
 
 protected def Builder.share1 (e : Expr) : AlphaShareBuilderM Expr := do
   let prev := (← get).set.findD { expr := e } dummy

--- a/src/Lean/Meta/Sym/AlphaShareCommon.lean
+++ b/src/Lean/Meta/Sym/AlphaShareCommon.lean
@@ -104,6 +104,14 @@ structure Context where
 structure State where
   set : PHashSet AlphaKey := {}
 
+/--
+Cache used by `shareCommonAlpha` to avoid visiting the same subterm (by pointer) of a
+DAG-shaped input over and over again. It maps visited subterms to their maximally
+shared results. Note that the `ExprPtr` keys own their expressions, so the cached
+subterms are kept alive while the cache is alive and their pointers cannot be recycled.
+-/
+abbrev Cache := Std.HashMap ExprPtr Expr
+
 end AlphaShareCommon
 
 /--
@@ -115,9 +123,11 @@ kernel projections folded). Terms already in the state are never re-checked:
 membership certifies that a term was admitted before. On a throw, the state
 contains every term hash-consed before the failure; these terms individually
 satisfy the invariants, so callers should keep the partial state and retry after
-repairing the input term.
+repairing the input term. The error value is the `Cache` accumulated before the
+failure (empty for `shareCommonAlphaInc`, which does not use one); the retry can
+be seeded with it to avoid revisiting the subterms processed before the failure.
 -/
-abbrev AlphaShareCommonM := ReaderT AlphaShareCommon.Context (EStateM Unit AlphaShareCommon.State)
+abbrev AlphaShareCommonM := ReaderT AlphaShareCommon.Context (EStateM AlphaShareCommon.Cache AlphaShareCommon.State)
 
 /--
 Returns `true` if `ctx.checkReducible` is true and `declName` is reducible declaration that
@@ -194,16 +204,23 @@ private def go (e : Expr) : M Expr := do
       if (← read).checkProj then throw ()
       return e.updateProj! (← go b)
 
-/-- Similar to `shareCommon`, but handles alpha-equivalence. -/
-@[inline] def shareCommonAlpha (e : Expr) : AlphaShareCommonM Expr := fun ctx s =>
+/--
+Similar to `shareCommon`, but handles alpha-equivalence.
+
+`cache` may contain the results of a previous run that failed with a check violation
+(see `AlphaShareCommonM`); seeding the retry with it avoids revisiting the subterms
+that were processed before the failure.
+-/
+@[inline] def shareCommonAlpha (e : Expr) (cache : AlphaShareCommon.Cache := {}) : AlphaShareCommonM Expr := fun ctx s =>
   if let some r := s.set.find? { expr := e } then
     .ok r.expr s
   else
-    -- On error, we keep the partial state: terms hash-consed before the failure
-    -- individually satisfy the invariants, so a retry can reuse them.
-    match go e ctx { map := {}, set := s.set } with
+    -- On error, we keep the partial state and throw the accumulated cache: terms
+    -- hash-consed before the failure individually satisfy the invariants, so a
+    -- retry can reuse them.
+    match go e ctx { map := cache, set := s.set } with
     | .ok e { set, .. } => .ok e { set }
-    | .error _ { set, .. } => .error () { set }
+    | .error _ { map, set } => .error map { set }
 
 private def saveInc (e : Expr) : AlphaShareCommonM Expr := do
   let prev := (← get).set.findD { expr := e } dummy
@@ -254,7 +271,7 @@ where
       -- `e` is new. The check runs only here: set membership certifies that a
       -- term was admitted before, and re-checking admitted terms would repeat
       -- the repair on every call when the term was admitted with residual dirt.
-      if isReducible (← read) declName then throw ()
+      if isReducible (← read) declName then throw {}
       modify fun { set := set } => { set := set.insert { expr := e } }
       return e
     else
@@ -265,7 +282,7 @@ where
   | .lam _ d b _ => visitInc e (return e.updateLambdaE! (← go d) (← go b))
   | .mdata _ b => visitInc e (return e.updateMData! (← go b))
   | .proj _ _ b => visitInc e do
-      if (← read).checkProj then throw ()
+      if (← read).checkProj then throw {}
       return e.updateProj! (← go b)
 
 end Lean.Meta.Sym

--- a/src/Lean/Meta/Sym/SymM.lean
+++ b/src/Lean/Meta/Sym/SymM.lean
@@ -325,14 +325,15 @@ def getIntExpr : SymM Expr := return (← getSharedExprs).intExpr
 
 /--
 Runs an `AlphaShareCommonM` action over the `SymM` hash-consing state.
-Returns `none` on a check violation; the terms hash-consed before the failure
-are kept in the state, since they individually satisfy the invariants.
+On a check violation, returns the cache accumulated before the failure as `.error`;
+the terms hash-consed before the failure are kept in the state, since they
+individually satisfy the invariants.
 -/
-def runShareCommonM (k : AlphaShareCommonM α) (ctx : AlphaShareCommon.Context) : SymM (Option α) := do
+def runShareCommonM (k : AlphaShareCommonM α) (ctx : AlphaShareCommon.Context) : SymM (Except AlphaShareCommon.Cache α) := do
   let share ← modifyGet fun s => (s.share, { s with share := {} })
   match k ctx share with
-  | .ok a share => modify fun s => { s with share }; return some a
-  | .error _ share => modify fun s => { s with share }; return none
+  | .ok a share => modify fun s => { s with share }; return .ok a
+  | .error cache share => modify fun s => { s with share }; return .error cache
 
 /--
 Runs `x` with the `shareCommon` kernel-projection check disabled.
@@ -375,12 +376,14 @@ private def repairShareViolation (e : Expr) : SymM Expr := do
 Applies hash-consing to `e`. Recall that all expressions in a `grind` goal have
 been hash-consed. We perform this step before we internalize expressions.
 
-This function does not try to `unfoldReducible` and `foldProjs` like `shareCommon`
+This function does not try to `unfoldReducible` and `foldProjs` like `shareCommon`.
+`cache` may contain the results accumulated by a run of `shareCommon` that was
+interrupted by a check violation; see `repairAndShare`.
 -/
-def shareCommonWithoutChecks (e : Expr) : SymM Expr := do
-  match (← runShareCommonM (shareCommonAlpha e) { env := (← getEnv) }) with
-  | some e => return e
-  | none => unreachable!
+def shareCommonWithoutChecks (e : Expr) (cache : AlphaShareCommon.Cache := {}) : SymM Expr := do
+  match (← runShareCommonM (shareCommonAlpha e cache) { env := (← getEnv) }) with
+  | .ok e => return e
+  | .error _ => unreachable!
 
 /--
 Fallback used by `shareCommon` and `shareCommonInc` after a check violation:
@@ -390,13 +393,15 @@ eliminate all violations (e.g., a reducible definition that cannot be unfolded b
 of smart-unfolding blocking reduction), the term is admitted as-is; other parts of the
 system report this kind of issue.
 -/
-private def repairAndShare (e : Expr) : SymM Expr := do
+private def repairAndShare (e : Expr) (cache : AlphaShareCommon.Cache) : SymM Expr := do
   -- `unfoldReducible` and `foldProjs` enter binders using `Meta.transform`, which
   -- requires a closed term. Open terms are admitted without repair.
   -- assert! !e.hasLooseBVars
   if e.hasLooseBVars then throwError "internal error, expression has loose bound variables at `shareCommon`{indentExpr e}"
   let e ← repairShareViolation e
-  shareCommonWithoutChecks e
+  -- The repair only rebuilds the violating parts of the term, so the subterms visited
+  -- by the interrupted run still occur in `e` and their cached results remain valid.
+  shareCommonWithoutChecks e cache
 
 /--
 Applies hash-consing to `e`. Recall that all expressions in a `grind` goal have
@@ -410,8 +415,8 @@ found, the term is repaired using `unfoldReducible`/`foldProjs` and re-processed
 -/
 def shareCommon (e : Expr) : SymM Expr := do
   match (← runShareCommonM (shareCommonAlpha e) (← checkedShareCtx)) with
-  | some e => return e
-  | none => repairAndShare e
+  | .ok e => return e
+  | .error cache => repairAndShare e cache
 
 /--
 Incremental variant of `shareCommon` for expressions constructed from already-shared subterms.
@@ -433,11 +438,12 @@ let result ← shareCommonInc result -- efficiently restore sharing
 -/
 def shareCommonInc (e : Expr) : SymM Expr := do
   match (← runShareCommonM (shareCommonAlphaInc e) (← checkedShareCtx)) with
-  | some e => return e
-  | none =>
+  | .ok e => return e
+  | .error _ =>
     -- The repair destroys the pointer sharing that justified the incremental
-    -- variant, so we fall back to the full `shareCommonAlpha` pass.
-    repairAndShare e
+    -- variant, so we fall back to the full `shareCommonAlpha` pass. The incremental
+    -- variant does not use a cache, so there is nothing to reuse here.
+    repairAndShare e {}
 
 @[inherit_doc shareCommonInc]
 abbrev share (e : Expr) : SymM Expr :=


### PR DESCRIPTION
This PR ensures the `shareCommon` internal cache is reused at `repairAndShare`.
