### PR TITLE
feat: lint on `open` statements within `namespace` which do not open all candidate namespaces

### DIFF
--- a/src/Init/Data/Fin/Lemmas.lean
+++ b/src/Init/Data/Fin/Lemmas.lean
@@ -152,7 +152,7 @@ attribute [scoped instance] instIntCast
 
 end IntCast
 
-open IntCast in
+open Fin.IntCast in
 theorem intCast_def {n : Nat} [NeZero n] (x : Int) :
     (x : Fin n) = if 0 ≤ x then Fin.ofNat n x.natAbs else -Fin.ofNat n x.natAbs := rfl
 

--- a/src/Lean/Compiler/LCNF/ToExpr.lean
+++ b/src/Lean/Compiler/LCNF/ToExpr.lean
@@ -78,7 +78,7 @@ where
 
 end ToExpr
 
-open ToExpr
+open Lean.Compiler.LCNF.ToExpr
 
 private def Arg.toExprM (arg : Arg pu) : ToExprM Expr :=
   return arg.toExpr.abstract' (← read) (← get)

--- a/src/Lean/Elab/Open.lean
+++ b/src/Lean/Elab/Open.lean
@@ -9,6 +9,7 @@ prelude
 public import Lean.Elab.Util
 public import Lean.Parser.Command
 meta import Lean.Parser.Command
+public import Lean.Linter.AmbiguousOpen
 import Init.Omega
 
 public section
@@ -75,22 +76,28 @@ def elabOpenDecl [MonadOptions m] [MonadResolveName m] [MonadInfoTree m] (stx : 
     match stx with
     | `(Parser.Command.openDecl| $nss*) =>
       for ns in nss do
-        for ns in (← resolveNamespace ns) do
+        let resolved ← resolveNamespace ns
+        Linter.checkAmbiguousOpen ns resolved
+        for ns in resolved do
           addOpenDecl (OpenDecl.simple ns [])
           activateScoped ns
     | `(Parser.Command.openDecl| scoped $nss*) =>
       for ns in nss do
-        for ns in (← resolveNamespace ns) do
+        let resolved ← resolveNamespace ns
+        Linter.checkAmbiguousOpen ns resolved
+        for ns in resolved do
           activateScoped ns
     | `(Parser.Command.openDecl| $ns ($ids*)) =>
       let nss ← resolveNamespace ns
+      Linter.checkAmbiguousOpen ns nss
       for idStx in ids do
         let declName ← resolveNameUsingNamespacesCore nss idStx
         if (← getInfoState).enabled then
           addConstInfo idStx declName
         addOpenDecl (OpenDecl.explicit idStx.getId declName)
-    | `(Parser.Command.openDecl| $ns hiding $ids*) =>
-      let ns ← resolveUniqueNamespace ns
+    | `(Parser.Command.openDecl| $nsStx hiding $ids*) =>
+      let ns ← resolveUniqueNamespace nsStx
+      Linter.checkAmbiguousOpen nsStx [ns]
       activateScoped ns
       for id in ids do
         let declName ← resolveId ns id
@@ -98,8 +105,9 @@ def elabOpenDecl [MonadOptions m] [MonadResolveName m] [MonadInfoTree m] (stx : 
           addConstInfo id declName
       let ids := ids.map (·.getId) |>.toList
       addOpenDecl (OpenDecl.simple ns ids)
-    | `(Parser.Command.openDecl| $ns renaming $[$froms -> $tos],*) =>
-      let ns ← resolveUniqueNamespace ns
+    | `(Parser.Command.openDecl| $nsStx renaming $[$froms -> $tos],*) =>
+      let ns ← resolveUniqueNamespace nsStx
+      Linter.checkAmbiguousOpen nsStx [ns]
       for («from», to) in froms.zip tos do
         let declName ← resolveId ns «from»
         if (← getInfoState).enabled then

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
@@ -24,7 +24,7 @@ side of `@[spec]` into the same database, and looking up the specs matching a pr
 
 namespace Lean.Elab.Tactic.Do.Internal
 
-open SpecAttr
+open Lean.Elab.Tactic.Do.Internal.SpecAttr
 
 /-- Returns `true` if `e` is already internalized into the current `SymM` share table, in which case
 `shareCommon e` returns `e` unchanged. -/

--- a/src/Lean/Elab/Tactic/Grind/Anchor.lean
+++ b/src/Lean/Elab/Tactic/Grind/Anchor.lean
@@ -7,7 +7,7 @@ module
 prelude
 public import Lean.Meta.Tactic.Grind.Types
 namespace Lean.Elab.Tactic.Grind
-open Meta Grind
+open Meta Lean.Meta.Grind
 
 public def elabAnchorRef (anchor : TSyntax `hexnum) : CoreM AnchorRef := do
   let numDigits := anchor.getHexNumSize

--- a/src/Lean/Elab/Tactic/Grind/Basic.lean
+++ b/src/Lean/Elab/Tactic/Grind/Basic.lean
@@ -324,7 +324,7 @@ def tryTactic (tac : GrindTacticM α) : GrindTacticM Bool := do
   catch _ =>
     pure false
 
-open Grind
+open Lean.Meta.Grind
 
 /-
 **Note**: Recall that `grind` uses the reducibility specified at `Config.reducible`

--- a/src/Lean/Elab/Tactic/Grind/BuiltinTactic.lean
+++ b/src/Lean/Elab/Tactic/Grind/BuiltinTactic.lean
@@ -83,7 +83,7 @@ def evalGrindSeq : GrindTactic := fun stx =>
 @[builtin_grind_tactic paren] def evalParen : GrindTactic := fun stx =>
   evalGrindTactic stx[1]
 
-open Meta Grind
+open Meta Lean.Meta.Grind
 
 @[builtin_grind_tactic finish] def evalFinish : GrindTactic := fun stx => withMainContext do
   let `(grind| finish $[$configItems]* $[only%$only]? $[[$params?,*]]?) := stx | throwUnsupportedSyntax

--- a/src/Lean/Elab/Tactic/Grind/Cbv.lean
+++ b/src/Lean/Elab/Tactic/Grind/Cbv.lean
@@ -8,7 +8,7 @@ prelude
 import Lean.Elab.Tactic.Grind.Basic
 import Lean.Meta.Tactic.Cbv.Main
 namespace Lean.Elab.Tactic.Grind
-open Meta Grind
+open Meta
 
 @[builtin_grind_tactic Parser.Tactic.Grind.symCbv] def evalSymCbv : GrindTactic := fun _ => withMainContext do
   ensureSym

--- a/src/Lean/Elab/Tactic/Grind/DSimp.lean
+++ b/src/Lean/Elab/Tactic/Grind/DSimp.lean
@@ -11,7 +11,7 @@ import Lean.Meta.Sym.DSimp.Variant
 import Lean.Meta.Sym.DSimp.Reduce
 import Lean.Meta.Sym.DSimp.DSimproc
 namespace Lean.Elab.Tactic.Grind
-open Meta Grind
+open Meta
 open Sym.DSimp
 
 def elabDSimpArgs (args? : Option (Array (TSyntax [`token.«*», `ident]))) : GrindTacticM DSimpArgs := do

--- a/src/Lean/Elab/Tactic/Grind/Filter.lean
+++ b/src/Lean/Elab/Tactic/Grind/Filter.lean
@@ -8,7 +8,7 @@ prelude
 public import Lean.Elab.Tactic.Grind.Basic
 public import Lean.Meta.Tactic.Grind.Filter
 namespace Lean.Elab.Tactic.Grind
-open Meta Grind
+open Meta Lean.Meta.Grind
 
 public partial def elabFilter (filter? : Option (TSyntax `grind_filter)) : GrindTacticM Filter := do
   let some filter := filter? | return .true

--- a/src/Lean/Elab/Tactic/Grind/Have.lean
+++ b/src/Lean/Elab/Tactic/Grind/Have.lean
@@ -11,7 +11,7 @@ import Lean.Meta.Tactic.Grind.MarkAccessible
 import Lean.Elab.SyntheticMVars
 import Lean.Meta.Tactic.Grind.Solve
 namespace Lean.Elab.Tactic.Grind
-open Meta Grind
+open Meta Lean.Meta.Grind
 
 /-- Elaborate `stx` in the current `MVarContext`. If given, the `expectedType` will be used to help
 elaboration but not enforced (use `elabTermEnsuringType` to enforce an expected type). -/

--- a/src/Lean/Elab/Tactic/Grind/Lint.lean
+++ b/src/Lean/Elab/Tactic/Grind/Lint.lean
@@ -29,7 +29,7 @@ builtin_initialize muteExt : SimplePersistentEnvExtension Name NameSet ←
     addImportedFn := mkStateFromImportedEntries (·.insert) {}
   }
 
-open Command Meta Grind
+open Command Meta Lean.Meta.Grind
 
 def checkEMatchTheorem (declName : Name) : CoreM Unit := do
   unless (← Grind.grindExt.isEMatchTheorem declName) do

--- a/src/Lean/Elab/Tactic/Grind/Rewrite.lean
+++ b/src/Lean/Elab/Tactic/Grind/Rewrite.lean
@@ -10,7 +10,7 @@ import Lean.Meta.Tactic.Rewrite
 import Lean.Meta.Tactic.Replace
 import Lean.Elab.SyntheticMVars
 namespace Lean.Elab.Tactic.Grind
-open Meta Grind
+open Meta Lean.Meta.Grind
 
 /--
 Rewrites the target of the main goal using `term`, and re-establishes the `sym` invariants

--- a/src/Lean/Elab/Tactic/Grind/Sym.lean
+++ b/src/Lean/Elab/Tactic/Grind/Sym.lean
@@ -19,7 +19,7 @@ import Lean.Meta.Tactic.Apply
 import Lean.Elab.Tactic.Location
 import Lean.Elab.SyntheticMVars
 namespace Lean.Elab.Tactic.Grind
-open Meta Grind
+open Meta
 
 private def evalIntroCore (internalize : Bool) (ids : TSyntaxArray `Lean.binderIdent) : GrindTacticM Unit := do
   ensureSym

--- a/src/Lean/Elab/Term/TermElabM.lean
+++ b/src/Lean/Elab/Term/TermElabM.lean
@@ -779,7 +779,7 @@ def traceAtCmdPos (cls : Name) (msg : Unit → MessageData) : TermElabM Unit :=
 def ppGoal (mvarId : MVarId) : TermElabM Format :=
   Meta.ppGoal mvarId
 
-open Level (LevelElabM)
+open Lean.Elab.Level (LevelElabM)
 
 def liftLevelM (x : LevelElabM α) : TermElabM α := do
   let ctx ← read

--- a/src/Lean/Linter.lean
+++ b/src/Lean/Linter.lean
@@ -7,6 +7,7 @@ module
 
 prelude
 public import Lean.Linter.Util
+public import Lean.Linter.AmbiguousOpen
 public import Lean.Linter.Builtin
 public import Lean.Linter.CheckUnivs
 public import Lean.Linter.ConstructorAsVariable

--- a/src/Lean/Linter/AmbiguousOpen.lean
+++ b/src/Lean/Linter/AmbiguousOpen.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Julia M. Himmel
+-/
+module
+
+prelude
+public import Lean.ResolveName
+public import Lean.Linter.Init
+
+public section
+
+namespace Lean.Linter
+
+register_builtin_option linter.ambiguousOpen : Bool := {
+  defValue := true
+  descr := "if true, warn when the namespace of an `open` declaration could also refer to a \
+    namespace that is silently not opened, e.g. `open B` inside `namespace A` only opens `A.B` \
+    even if the namespace `B` exists as well"
+}
+
+/--
+Collects all namespaces `p ++ id` where `p` is a prefix of `ns` (innermost first, ending with the
+root namespace). Unlike `ResolveName.resolveNamespaceUsingScope?`, this collects every match
+instead of only the innermost one, so that namespaces shadowed by the scope search are found.
+-/
+private def scopeCandidates (env : Environment) (id : Name) : Name → List Name
+  | ns@(.str p _) =>
+    let rest := scopeCandidates env id p
+    if env.isNamespace (ns ++ id) then (ns ++ id) :: rest else rest
+  | _ =>
+    let id := id.replacePrefix rootNamespace .anonymous
+    if env.isNamespace id then [id] else []
+
+/--
+Warns if the namespace identifier `nsStx` of an `open` declaration can also be interpreted as an
+existing namespace that the `open` declaration silently does not open. `resolved` must be the
+interpretations the `open` declaration actually uses, as returned by `resolveNamespace`.
+Shadowed interpretations whose declarations are accessible anyway — because the namespace is
+already opened without exceptions or encloses the current scope — are not reported.
+-/
+def checkAmbiguousOpen [Monad m] [MonadEnv m] [MonadOptions m] [MonadLog m]
+    [AddMessageContext m] [MonadResolveName m] (nsStx : Ident) (resolved : List Name) : m Unit := do
+  unless getLinterValue linter.ambiguousOpen (← getLinterOptions) do return
+  let .ident info _ id preresolved := nsStx.raw | return
+  -- Macro-generated `open` declarations cannot be fixed at the use site, so only lint
+  -- identifiers written in the original source.
+  let .original .. := info | return
+  -- Identifiers with preresolved namespaces are not resolved against the environment.
+  if preresolved.any fun | .namespace _ => true | _ => false then return
+  -- `resolveNamespace` can return duplicates, e.g. when several `open` declarations make the
+  -- same namespace visible.
+  let resolved := resolved.eraseDups
+  let env ← getEnv
+  let currNamespace ← getCurrNamespace
+  let openDecls ← getOpenDecls
+  -- Interpretations via `open` declarations are always contained in `resolved`, so only the
+  -- scope search can produce shadowed interpretations.
+  let candidates := scopeCandidates env id currNamespace
+  -- A namespace opened with `hiding` exceptions is not fully accessible, so it does not count.
+  let isAccessible (n : Name) : Bool :=
+    n.isPrefixOf currNamespace || openDecls.any fun
+      | .simple ns [] => ns == n
+      | _ => false
+  let shadowed := candidates.filter fun n => !resolved.contains n && !isAccessible n
+  if shadowed.isEmpty then return
+  let display (n : Name) : MessageData := m!"`{rootNamespace ++ n}`"
+  let displayAll (ns : List Name) : MessageData := MessageData.joinSep (ns.map display) ", "
+  -- A shadowed interpretation is a non-innermost scope match, so `currNamespace` is nonempty.
+  let shadowedNote :=
+    if shadowed.length == 1 then m!"{displayAll shadowed} is silently not opened"
+    else m!"{displayAll shadowed} are silently not opened"
+  let hint :=
+    m!" Specify the namespace unambiguously, e.g. `{rootNamespace ++ resolved.head!}`. The \
+      warning can sometimes also be addressed by moving the `open` outside of the surrounding \
+      `namespace`."
+  let msg :=
+    match resolved with
+    | [r] =>
+      m!"Ambiguous namespace `{id}`: it is interpreted as {display r} because this `open` occurs \
+        inside `namespace {currNamespace}`, while {shadowedNote}." ++ hint
+    | _ =>
+      m!"Ambiguous namespace `{id}`: this `open` refers to all of {displayAll resolved}, while \
+        {shadowedNote} because the `open` occurs inside `namespace {currNamespace}`." ++ hint
+  logLint linter.ambiguousOpen nsStx.raw msg
+
+end Lean.Linter

--- a/src/Lean/Meta/Sym/AbstractS.lean
+++ b/src/Lean/Meta/Sym/AbstractS.lean
@@ -9,7 +9,7 @@ public import Lean.Meta.Sym.SymM
 import Lean.Meta.Sym.ReplaceS
 import Init.Omega
 namespace Lean.Meta.Sym
-open Internal
+open Lean.Meta.Sym.Internal
 
 /--
 Helper function for implementing `abstractFVars` (and possible variants in the future).

--- a/src/Lean/Meta/Sym/AlphaShareBuilder.lean
+++ b/src/Lean/Meta/Sym/AlphaShareBuilder.lean
@@ -78,7 +78,7 @@ instance : MonadShareCommon AlphaShareBuilderM where
   assertShared := Builder.assertShared
   isDebugEnabled := read
 
-open MonadShareCommon (share1 assertShared)
+open Lean.Meta.Sym.Internal.MonadShareCommon (share1 assertShared)
 
 variable [MonadShareCommon m]
 

--- a/src/Lean/Meta/Sym/DSimp/App.lean
+++ b/src/Lean/Meta/Sym/DSimp/App.lean
@@ -11,7 +11,7 @@ import Lean.Meta.Sym.AlphaShareBuilder
 import Lean.Meta.Sym.ProofInstInfo
 import Init.Omega
 namespace Lean.Meta.Sym.DSimp
-open Internal
+open Lean.Meta.Sym.Internal
 
 /-!
 # Simplifying Application Arguments

--- a/src/Lean/Meta/Sym/DSimp/Main.lean
+++ b/src/Lean/Meta/Sym/DSimp/Main.lean
@@ -13,7 +13,7 @@ import Lean.Meta.Sym.DSimp.Forall
 import Lean.Meta.Sym.DSimp.Let
 import Lean.Meta.Sym.AlphaShareBuilder
 namespace Lean.Meta.Sym.DSimp
-open Internal
+open Lean.Meta.Sym.Internal
 
 def dsimpStep : DSimproc := fun e => do
   match e with

--- a/src/Lean/Meta/Sym/InstantiateS.lean
+++ b/src/Lean/Meta/Sym/InstantiateS.lean
@@ -9,7 +9,7 @@ public import Lean.Meta.Sym.SymM
 import Lean.Meta.Sym.LooseBVarsS
 import Init.Grind
 namespace Lean.Meta.Sym
-open Internal
+open Lean.Meta.Sym.Internal
 /--
 Similar to `Lean.Expr.instantiateRevRange`.
 It assumes the input is maximally shared, and ensures the output is too.

--- a/src/Lean/Meta/Sym/Intro.lean
+++ b/src/Lean/Meta/Sym/Intro.lean
@@ -11,7 +11,7 @@ import Lean.Meta.Sym.InstantiateS
 import Lean.Meta.Sym.IsClass
 import Lean.Meta.Sym.AlphaShareBuilder
 namespace Lean.Meta.Sym
-open Internal
+open Lean.Meta.Sym.Internal
 /--
 Efficient `intro` for symbolic simulation.
 

--- a/src/Lean/Meta/Sym/LooseBVarsS.lean
+++ b/src/Lean/Meta/Sym/LooseBVarsS.lean
@@ -8,7 +8,7 @@ prelude
 public import Lean.Meta.Sym.ReplaceS
 public section
 namespace Lean.Meta.Sym
-open Internal
+open Lean.Meta.Sym.Internal
 /--
 Lowers the loose bound variables `>= s` in `e` by `d`.
 That is, a loose bound variable `bvar i` with `i >= s` is mapped to `bvar (i-d)`.

--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -23,7 +23,7 @@ import Init.Data.List.MapIdx
 import Init.Data.Nat.Internal.Linear
 import Std.Do.Triple.Basic
 namespace Lean.Meta.Sym
-open Internal
+open Lean.Meta.Sym.Internal
 
 /-!
 This module implements efficient pattern matching and unification module for the symbolic simulation

--- a/src/Lean/Meta/Sym/ReplaceS.lean
+++ b/src/Lean/Meta/Sym/ReplaceS.lean
@@ -8,11 +8,11 @@ prelude
 public import Lean.Meta.Sym.AlphaShareBuilder
 import Init.Omega
 namespace Lean.Meta.Sym
-open Internal
+open Lean.Meta.Sym.Internal
 /-!
 A version of `replace_fn.h` that ensures the resulting expression is maximally shared.
 -/
-open Grind
+open Lean.Meta.Grind
 abbrev M := StateT (Std.HashMap (ExprPtr × Nat) Expr) AlphaShareBuilderM
 
 def save (key : ExprPtr × Nat) (r : Expr) : M Expr := do

--- a/src/Lean/Meta/Sym/Simp/App.lean
+++ b/src/Lean/Meta/Sym/Simp/App.lean
@@ -12,7 +12,7 @@ import Lean.Meta.Sym.InferType
 import Lean.Meta.Sym.Simp.CongrInfo
 import Init.Omega
 namespace Lean.Meta.Sym.Simp
-open Internal
+open Lean.Meta.Sym.Internal
 
 /-!
 # Simplifying Application Arguments and Congruence Lemma Application

--- a/src/Lean/Meta/Sym/Simp/ControlFlow.lean
+++ b/src/Lean/Meta/Sym/Simp/ControlFlow.lean
@@ -14,7 +14,7 @@ import Lean.Meta.WHNF
 import Lean.Meta.AppBuilder
 import Init.Sym.Lemmas
 namespace Lean.Meta.Sym.Simp
-open Internal
+open Lean.Meta.Sym.Internal
 
 /--
 Simplifies a non-dependent `if-then-else` expression.

--- a/src/Lean/Meta/Sym/Simp/Debug.lean
+++ b/src/Lean/Meta/Sym/Simp/Debug.lean
@@ -10,7 +10,7 @@ import Lean.Meta.Sym.Simp.Rewrite
 import Lean.Meta.Sym.Simp.Goal
 import Lean.Meta.Sym.Util
 namespace Lean.Meta.Sym
-open Simp
+open Lean.Meta.Sym.Simp
 /-!
 Helper functions for debugging purposes and creating tests.
 -/

--- a/src/Lean/Meta/Sym/Simp/Forall.lean
+++ b/src/Lean/Meta/Sym/Simp/Forall.lean
@@ -52,7 +52,7 @@ def mkForallCongrFor (xs : Array Expr) : MetaM Expr := do
   let result ← mkLambdaFVars #[p, q, h] result
   return result
 
-open Internal
+open Lean.Meta.Sym.Internal
 
 structure ArrowInfo where
   binderName : Name

--- a/src/Lean/Meta/Sym/Simp/Have.lean
+++ b/src/Lean/Meta/Sym/Simp/Have.lean
@@ -118,7 +118,7 @@ def collectFVarIdsAt (e : Expr) (fvarIdToPos : FVarIdMap Nat) : Array FVarId :=
     let pos₂ := fvarIdToPos.get! fvarId₂
     pos₁ < pos₂
 
-open Internal in
+open Lean.Meta.Sym.Internal in
 /--
 Build a chain of arrows `α₁ → α₂ → ... → αₙ → β` using the `mkForallS` wrapper
 (not `.forallE`) to preserve sharing.
@@ -201,7 +201,7 @@ def consumeForallN (type : Expr) (n : Nat) : Expr :=
   | 0 => type
   | n+1 => consumeForallN type.bindingBody! n
 
-open Internal in
+open Lean.Meta.Sym.Internal in
 /--
 Eliminate auxiliary applications `xᵢ' sᵢ₁ ... sᵢₖ` in the body when converting back to `have` form.
 
@@ -300,7 +300,7 @@ where
       fnUnivs := fnUnivs.reverse
       return { argUnivs, fnUnivs }
 
-open Internal in
+open Lean.Meta.Sym.Internal in
 /--
 Simplify a beta-application and generate a proof.
 

--- a/src/Lean/Meta/Sym/Simp/Main.lean
+++ b/src/Lean/Meta/Sym/Simp/Main.lean
@@ -15,7 +15,7 @@ import Lean.Meta.Sym.Simp.Forall
 namespace Lean.Meta.Sym.Simp
 builtin_initialize registerTraceClass `sym.simp.debug.cache
 
-open Internal
+open Lean.Meta.Sym.Internal
 
 def simpStep : Simproc := fun e => do
   match e with

--- a/src/Lean/Meta/Sym/Simp/Rewrite.lean
+++ b/src/Lean/Meta/Sym/Simp/Rewrite.lean
@@ -14,7 +14,7 @@ import Lean.Meta.Sym.InstantiateS
 import Lean.Meta.Sym.InstantiateMVarsS
 import Init.Data.Range.Polymorphic.Iterators
 namespace Lean.Meta.Sym.Simp
-open Grind
+open Lean.Meta.Grind
 
 /--
 Creates proof term for a rewriting step.

--- a/src/Lean/Meta/Tactic/Cbv/ControlFlow.lean
+++ b/src/Lean/Meta/Tactic/Cbv/ControlFlow.lean
@@ -37,7 +37,7 @@ corresponding branch.
 -/
 
 namespace Lean.Meta.Sym.Simp
-open Internal
+open Lean.Meta.Sym.Internal
 
 def isCbvNoncomputable (p : Name) : CoreM Bool := do
   let evalLemmas ← Tactic.Cbv.getCbvEvalLemmas p

--- a/src/Lean/PrettyPrinter/Delaborator/Builtins.lean
+++ b/src/Lean/PrettyPrinter/Delaborator/Builtins.lean
@@ -20,7 +20,7 @@ public section
 namespace Lean.PrettyPrinter.Delaborator
 open Lean.Meta
 open Lean.Parser.Term
-open SubExpr
+open Lean.PrettyPrinter.Delaborator.SubExpr
 open TSyntax.Compat
 
 /--

--- a/src/Lean/Server/FileWorker/Utils.lean
+++ b/src/Lean/Server/FileWorker/Utils.lean
@@ -16,7 +16,7 @@ public section
 
 namespace Lean.Server.FileWorker
 open Snapshots
-open IO
+open Lean.IO
 
 -- TEMP: translate from new heterogeneous snapshot tree to old homogeneous async list
 private partial def mkCmdSnaps (initSnap : Language.Lean.InitialSnapshot) :

--- a/src/Lean/Server/Utils.lean
+++ b/src/Lean/Server/Utils.lean
@@ -117,7 +117,7 @@ def replaceLspRange (text : FileMap) (r : Lsp.Range) (newText : String) : FileMa
   -- If this is ever a problem, we could store a second unnormalized FileMap, edit it, and normalize it here.
   (pre ++ newText.crlfToLf ++ post).toFileMap
 
-open IO
+open Lean.IO
 
 open Lsp
 

--- a/src/Std/Data/DTreeMap/AdditionalOperations.lean
+++ b/src/Std/Data/DTreeMap/AdditionalOperations.lean
@@ -27,7 +27,7 @@ variable {α : Type u} {β : α → Type v} {γ : α → Type w} {cmp : α → �
 
 namespace Std.DTreeMap
 local instance : Coe (Type v) (α → Type v) where coe γ := fun _ => γ
-open Internal (Impl)
+open Std.DTreeMap.Internal (Impl)
 
 /--
 Updates the values of the map by applying the given function to all mappings, keeping

--- a/src/Std/Data/DTreeMap/Basic.lean
+++ b/src/Std/Data/DTreeMap/Basic.lean
@@ -73,7 +73,7 @@ structure DTreeMap (α : Type u) (β : α → Type v) (cmp : α → α → Order
   wf : letI : Ord α := ⟨cmp⟩; inner.WF
 
 namespace DTreeMap
-open Internal (Impl)
+open Std.DTreeMap.Internal (Impl)
 
 local instance : Coe (Type v) (α → Type v) where coe γ := fun _ => γ
 

--- a/src/Std/Data/DTreeMap/Raw/AdditionalOperations.lean
+++ b/src/Std/Data/DTreeMap/Raw/AdditionalOperations.lean
@@ -25,7 +25,7 @@ universe u v w
 variable {α : Type u} {β : α → Type v} {γ : α → Type w} {cmp : α → α → Ordering}
 
 namespace Std.DTreeMap
-open Internal (Impl)
+open Std.DTreeMap.Internal (Impl)
 
 namespace Raw
 local instance : Coe (Type v) (α → Type v) where coe γ := fun _ => γ

--- a/src/Std/Data/DTreeMap/Raw/Basic.lean
+++ b/src/Std/Data/DTreeMap/Raw/Basic.lean
@@ -34,7 +34,7 @@ variable {α : Type u} {β : α → Type v} {cmp : α → α → Ordering}
 namespace Std
 
 namespace DTreeMap
-open Internal (Impl)
+open Std.DTreeMap.Internal (Impl)
 
 local instance : Coe (Type v) (α → Type v) where coe γ := fun _ => γ
 
@@ -72,7 +72,7 @@ structure Raw (α : Type u) (β : α → Type v) (_cmp : α → α → Ordering 
   inner : Internal.Impl α β
 
 namespace Raw
-open Internal (Impl)
+open Std.DTreeMap.Internal (Impl)
 
 /--
 Well-formedness predicate for tree maps. Users of `DTreeMap` will not need to interact with
@@ -662,7 +662,7 @@ def mergeWith [LawfulEqCmp cmp] (mergeFn : (a : α) → β a → β a → β a) 
   letI : Ord α := ⟨cmp⟩; ⟨t₁.inner.mergeWith! mergeFn t₂.inner⟩
 
 namespace Const
-open Internal (Impl)
+open Std.DTreeMap.Internal (Impl)
 
 variable {β : Type v}
 

--- a/src/Std/Data/Internal/List/Associative.lean
+++ b/src/Std/Data/Internal/List/Associative.lean
@@ -444,7 +444,7 @@ theorem DistinctKeys.def [BEq α] {l : List ((a : α) × β a)} :
   ⟨fun h => by simpa [keys_eq_map, List.pairwise_map] using h.distinct,
    fun h => ⟨by simpa [keys_eq_map, List.pairwise_map] using h⟩⟩
 
-open List
+open Std.Internal.List
 
 theorem DistinctKeys.perm_keys [BEq α] [PartialEquivBEq α] {l l' : List ((a : α) × β a)}
     (h : Perm (keys l') (keys l)) : DistinctKeys l → DistinctKeys l'

--- a/src/Std/Http/Data/Chunk.lean
+++ b/src/Std/Http/Data/Chunk.lean
@@ -21,7 +21,7 @@ Reference: https://www.rfc-editor.org/rfc/rfc9112.html#section-7.1
 -/
 
 namespace Std.Http
-open Internal Char
+open Std.Http.Internal
 
 set_option linter.all true
 

--- a/src/Std/Http/Data/Headers/Basic.lean
+++ b/src/Std/Http/Data/Headers/Basic.lean
@@ -26,7 +26,7 @@ namespace Std.Http
 
 set_option linter.all true
 
-open Internal
+open Std.Http.Internal
 
 /--
 Typeclass for typed HTTP headers that can be parsed from and serialized to header values.

--- a/src/Std/Http/Data/Headers/Name.lean
+++ b/src/Std/Http/Data/Headers/Name.lean
@@ -26,7 +26,7 @@ namespace Std.Http.Header
 
 set_option linter.all true
 
-open Internal Char
+open Std.Http.Internal
 
 /--
 Proposition asserting that a string is a valid HTTP header name: all characters are valid token

--- a/src/Std/Http/Data/Headers/Value.lean
+++ b/src/Std/Http/Data/Headers/Value.lean
@@ -24,7 +24,7 @@ namespace Std.Http.Header
 
 set_option linter.all true
 
-open Internal
+open Std.Http.Internal
 
 /--
 Proposition that asserts all characters in a string are valid for HTTP header values,

--- a/src/Std/Http/Data/Method.lean
+++ b/src/Std/Http/Data/Method.lean
@@ -29,7 +29,7 @@ namespace Std.Http
 
 set_option linter.all true
 
-open Internal
+open Std.Http.Internal
 
 /--
 A method is a verb that describes the action to be performed.

--- a/src/Std/Http/Data/Request.lean
+++ b/src/Std/Http/Data/Request.lean
@@ -104,7 +104,7 @@ instance : ToString Head where
     toString req.headers ++
     "\r\n"
 
-open Internal in
+open Std.Http.Internal in
 instance : Encode .v11 Head where
   encode buffer req :=
     let buffer := Encode.encode (v := .v11) buffer req.method

--- a/src/Std/Http/Data/Response.lean
+++ b/src/Std/Http/Data/Response.lean
@@ -89,7 +89,7 @@ instance : ToString Head where
     toString r.headers ++
     "\r\n"
 
-open Internal in
+open Std.Http.Internal in
 instance : Encode .v11 Head where
   encode buffer r :=
     let buffer := Encode.encode (v := .v11) buffer r.version

--- a/src/Std/Http/Data/Status.lean
+++ b/src/Std/Http/Data/Status.lean
@@ -24,7 +24,7 @@ namespace Std.Http
 
 set_option linter.all true
 
-open Internal
+open Std.Http.Internal
 
 /--
 A proposition stating that `s` is a valid HTTP reason phrase: every character passes

--- a/src/Std/Http/Data/URI/Basic.lean
+++ b/src/Std/Http/Data/URI/Basic.lean
@@ -36,7 +36,7 @@ namespace Std.Http
 
 set_option linter.all true
 
-open Internal Char
+open Std.Http.Internal _root_.Char Std.Http.Internal.Char
 
 namespace URI
 

--- a/src/Std/Http/Data/URI/Parser.lean
+++ b/src/Std/Http/Data/URI/Parser.lean
@@ -36,8 +36,8 @@ namespace Std.Http.URI.Parser
 
 set_option linter.all true
 
-open Internal Char
-open Std Internal Parsec ByteArray
+open Std.Http.Internal Std.Http.Internal.Char
+open Std Std.Internal Parsec Std.Internal.Parsec.ByteArray
 
 @[inline]
 private def tryOpt (p : Parser α) : Parser (Option α) :=

--- a/src/Std/Http/Internal/String.lean
+++ b/src/Std/Http/Internal/String.lean
@@ -22,7 +22,7 @@ parameter values and chunk extensions.
 
 namespace Std.Http.Internal
 
-open Char
+open Std.Http.Internal.Char
 
 set_option linter.all true
 

--- a/src/Std/Http/Protocol/H1/Writer.lean
+++ b/src/Std/Http/Protocol/H1/Writer.lean
@@ -28,7 +28,7 @@ namespace Std.Http.Protocol.H1
 
 set_option linter.all true
 
-open Internal
+open Std.Http.Internal
 
 /--
 The state of the `Writer` state machine.

--- a/src/Std/Time/Format.lean
+++ b/src/Std/Time/Format.lean
@@ -15,7 +15,7 @@ public section
 namespace Std
 namespace Time
 namespace Formats
-open Internal
+open Std.Time.Internal
 
 set_option linter.all true
 

--- a/src/Std/Time/Format/Basic.lean
+++ b/src/Std/Time/Format/Basic.lean
@@ -20,7 +20,7 @@ This module defines the `Formatter` types. It is based on the Java's `DateTimeFo
 
 namespace Std
 namespace Time
-open Internal
+open Std.Time.Internal
 open Std.Internal.Parsec.String
 open Std.Internal.Parsec Lean PlainTime PlainDate TimeZone DateTime
 

--- a/src/Std/Time/Format/DateFormat.lean
+++ b/src/Std/Time/Format/DateFormat.lean
@@ -14,7 +14,7 @@ public section
 namespace Std
 namespace Time
 
-open Internal
+open Std.Time.Internal
 
 set_option linter.all true
 

--- a/src/Std/Time/Format/Modifier.lean
+++ b/src/Std/Time/Format/Modifier.lean
@@ -17,7 +17,7 @@ This module defines the `Modifier` type and its sub-types, representing format p
 
 namespace Std
 namespace Time
-open Internal
+open Std.Time.Internal
 open Std.Internal.Parsec.String
 open Std.Internal.Parsec Lean PlainTime PlainDate TimeZone DateTime
 

--- a/src/Std/Time/Zoned/Database/Basic.lean
+++ b/src/Std/Time/Zoned/Database/Basic.lean
@@ -33,7 +33,7 @@ protected class Database (α : Type) where
   getLocalZoneRules : α → IO TimeZone.ZoneRules
 
 namespace TimeZone
-open Internal
+open Std.Time.Internal
 
 /--
 Converts a Boolean value to a corresponding `StdWall` type.

--- a/src/Std/Time/Zoned/Database/PosixTz.lean
+++ b/src/Std/Time/Zoned/Database/PosixTz.lean
@@ -16,7 +16,7 @@ POSIX TZ string parser for RFC 8536 §3.3 footer strings.
 public section
 
 namespace Std.Time.TimeZone
-open Internal
+open Std.Time.Internal
 
 set_option linter.all true
 

--- a/tests/elab/linter_ambiguous_open.lean
+++ b/tests/elab/linter_ambiguous_open.lean
@@ -1,0 +1,225 @@
+/-!
+Tests for the `linter.ambiguousOpen` linter, which warns when the namespace of an `open`
+declaration could also refer to a namespace that the `open` silently does not open, e.g.
+`open B` inside `namespace A` when both `B` and `A.B` exist, which opens only `A.B`.
+-/
+
+-- The test suite runs with `linter.all=false`, so enable the (default-on) linter explicitly.
+set_option linter.ambiguousOpen true
+
+namespace A.B
+def x := 1
+def z := 2
+end A.B
+
+namespace B
+def y := 3
+def z := 4
+end B
+
+/-! An unambiguous `open` does not warn, even though `A.B` exists (`A` is not opened). -/
+
+section
+#guard_msgs in
+open B
+end
+
+/-!
+`open A` followed by `open B` opens both `_root_.B` and `A.B`; since no interpretation is
+silently skipped, the linter does not warn.
+-/
+
+section
+open A
+#guard_msgs in
+open B
+-- Both namespaces are indeed opened:
+#guard x == 1
+#guard y == 3
+end
+
+section
+#guard_msgs in
+open A B
+end
+
+/-! Inside `namespace A`, `open B` silently refers to `A.B` only, shadowing `_root_.B`. -/
+
+namespace A
+/--
+warning: Ambiguous namespace `B`: it is interpreted as `_root_.A.B` because this `open` occurs inside `namespace A`, while `_root_.B` is silently not opened. Specify the namespace unambiguously, e.g. `_root_.A.B`. The warning can sometimes also be addressed by moving the `open` outside of the surrounding `namespace`.
+
+Note: This linter can be disabled with `set_option linter.ambiguousOpen false`
+-/
+#guard_msgs in
+open B
+-- Only `A.B` is opened:
+#guard x == 1
+end A
+
+/-!
+If the shadowed namespace is already opened, its declarations are accessible anyway and the
+linter does not warn.
+-/
+
+section
+open B
+namespace A
+#guard_msgs in
+open B
+#guard x == 1
+#guard y == 3
+end A
+end
+
+/-!
+If the shadowed namespace was opened with `hiding` exceptions, the hidden names remain
+inaccessible, so the linter still warns.
+-/
+
+section
+open B hiding y
+namespace A
+/--
+warning: Ambiguous namespace `B`: it is interpreted as `_root_.A.B` because this `open` occurs inside `namespace A`, while `_root_.B` is silently not opened. Specify the namespace unambiguously, e.g. `_root_.A.B`. The warning can sometimes also be addressed by moving the `open` outside of the surrounding `namespace`.
+
+Note: This linter can be disabled with `set_option linter.ambiguousOpen false`
+-/
+#guard_msgs in
+open B
+end A
+end
+
+/-!
+Likewise, a shadowed namespace enclosing the current scope is accessible anyway and does not
+cause a warning.
+-/
+
+namespace B.C.B
+def v := 6
+end B.C.B
+
+namespace B.C
+#guard_msgs in
+open B
+-- `B.C.B` is opened, and the enclosing `_root_.B` is accessible without `open`:
+#guard v == 6
+#guard y == 3
+end B.C
+
+/-!
+A single `open` can refer to several namespaces and still shadow another one; all silently
+skipped interpretations are reported.
+-/
+
+namespace C.B
+def u := 7
+end C.B
+
+namespace A
+open C
+/--
+warning: Ambiguous namespace `B`: this `open` refers to all of `_root_.A.B`, `_root_.C.B`, while `_root_.B` is silently not opened because the `open` occurs inside `namespace A`. Specify the namespace unambiguously, e.g. `_root_.A.B`. The warning can sometimes also be addressed by moving the `open` outside of the surrounding `namespace`.
+
+Note: This linter can be disabled with `set_option linter.ambiguousOpen false`
+-/
+#guard_msgs in
+open B
+#guard x == 1
+#guard u == 7
+end A
+
+/-! Disambiguated forms do not warn. -/
+
+namespace A
+#guard_msgs in
+open _root_.B
+#guard_msgs in
+open A.B
+end A
+
+/-! The linter can be disabled. -/
+
+namespace A
+set_option linter.ambiguousOpen false in
+#guard_msgs in
+open B
+end A
+
+/-! Other `open` variants are also linted. -/
+
+namespace A
+/--
+warning: Ambiguous namespace `B`: it is interpreted as `_root_.A.B` because this `open` occurs inside `namespace A`, while `_root_.B` is silently not opened. Specify the namespace unambiguously, e.g. `_root_.A.B`. The warning can sometimes also be addressed by moving the `open` outside of the surrounding `namespace`.
+
+Note: This linter can be disabled with `set_option linter.ambiguousOpen false`
+-/
+#guard_msgs in
+open B (x)
+
+/--
+warning: Ambiguous namespace `B`: it is interpreted as `_root_.A.B` because this `open` occurs inside `namespace A`, while `_root_.B` is silently not opened. Specify the namespace unambiguously, e.g. `_root_.A.B`. The warning can sometimes also be addressed by moving the `open` outside of the surrounding `namespace`.
+
+Note: This linter can be disabled with `set_option linter.ambiguousOpen false`
+-/
+#guard_msgs in
+open B hiding x
+
+/--
+warning: Ambiguous namespace `B`: it is interpreted as `_root_.A.B` because this `open` occurs inside `namespace A`, while `_root_.B` is silently not opened. Specify the namespace unambiguously, e.g. `_root_.A.B`. The warning can sometimes also be addressed by moving the `open` outside of the surrounding `namespace`.
+
+Note: This linter can be disabled with `set_option linter.ambiguousOpen false`
+-/
+#guard_msgs in
+open B renaming x -> x'
+
+/--
+warning: Ambiguous namespace `B`: it is interpreted as `_root_.A.B` because this `open` occurs inside `namespace A`, while `_root_.B` is silently not opened. Specify the namespace unambiguously, e.g. `_root_.A.B`. The warning can sometimes also be addressed by moving the `open` outside of the surrounding `namespace`.
+
+Note: This linter can be disabled with `set_option linter.ambiguousOpen false`
+-/
+#guard_msgs in
+open scoped B
+end A
+
+/-! `open ... in` at the term level is also linted. -/
+
+namespace A
+/--
+warning: Ambiguous namespace `B`: it is interpreted as `_root_.A.B` because this `open` occurs inside `namespace A`, while `_root_.B` is silently not opened. Specify the namespace unambiguously, e.g. `_root_.A.B`. The warning can sometimes also be addressed by moving the `open` outside of the surrounding `namespace`.
+
+Note: This linter can be disabled with `set_option linter.ambiguousOpen false`
+-/
+#guard_msgs in
+example : Nat := open B in x
+end A
+
+/-!
+Macro-generated `open` declarations (whose identifiers carry no original source info) are not
+linted, since the warning could not be addressed at the use site.
+-/
+
+namespace A
+macro "open_b_via_macro" : command => `(open $(Lean.mkIdent `B):ident)
+#guard_msgs in
+open_b_via_macro
+-- The macro-generated `open` still takes effect, opening `A.B`:
+#guard x == 1
+end A
+
+/-! Deeper shadowing: inside `namespace A.C`, candidates from several scope prefixes. -/
+
+namespace A.C.B
+def w := 5
+end A.C.B
+
+namespace A.C
+/--
+warning: Ambiguous namespace `B`: it is interpreted as `_root_.A.C.B` because this `open` occurs inside `namespace A.C`, while `_root_.A.B`, `_root_.B` are silently not opened. Specify the namespace unambiguously, e.g. `_root_.A.C.B`. The warning can sometimes also be addressed by moving the `open` outside of the surrounding `namespace`.
+
+Note: This linter can be disabled with `set_option linter.ambiguousOpen false`
+-/
+#guard_msgs in
+open B
+#guard w == 5
+end A.C


### PR DESCRIPTION
This PR adds a linter which warns on `open` statements which do not in fact open all namespaces which end in the given name.

Example:
```lean
def A.B.a1 : Nat := 0
def B.a2 : Nat := 0

namespace A
open B

#check a2
```

Here, we lint on `open B` since `_root_.B` is not actually opened.

This will help with fixing downstream fallout from adding new namespaces. Suppose we have just
```lean
def B.a2 : Nat := 0

namespace A
open B

#check a2
```

This compiles. Now suppose upstream adds `def A.B.a1 : Nat := 0`. Then the above snippet no longer compiles, with only an `unknown identifier` error on `a2`. With the new linter, we now also get a warning on the `open B` which  warns us that `_root_.B` is no longer imported, which should help with understanding the `unknown identifier` error (because usually from the context of the file it is quite clear that we want `_root_.B`, not `_root_.A.B`!).