### PR TITLE
feat: error on self-deprecation

### DIFF
--- a/src/Init/Data/Iterators/Consumers/Monadic/Loop.lean
+++ b/src/Init/Data/Iterators/Consumers/Monadic/Loop.lean
@@ -347,7 +347,7 @@ It is equivalent to `it.toList.foldl`.
 
 This function is deprecated. Instead of `it.allowNontermination.fold`, use `it.fold`.
 -/
-@[always_inline, inline, deprecated IterM.Partial.fold (since := "2025-12-04")]
+@[always_inline, inline, deprecated IterM.fold (since := "2025-12-04")]
 def IterM.Partial.fold {m : Type w → Type w'} {α : Type w} {β : Type w} {γ : Type w}
     [Monad m] [Iterator α m β] [IteratorLoop α m m] (f : γ → β → γ) (init : γ)
     (it : IterM.Partial (α := α) m β) : m γ :=

--- a/src/Lean/Linter/Deprecated.lean
+++ b/src/Lean/Linter/Deprecated.lean
@@ -31,10 +31,12 @@ builtin_initialize deprecatedAttr : ParametricAttribute DeprecationEntry ←
   registerParametricAttribute {
     name := `deprecated
     descr := "mark declaration as deprecated",
-    getParam := fun _ stx => do
+    getParam := fun declName stx => do
       let `(attr| deprecated $[$id?]? $[$text?]? $[(since := $since?)]?) := stx
         | throwError "Invalid `[deprecated]` attribute syntax"
       let newName? ← id?.mapM Elab.realizeGlobalConstNoOverloadWithInfo
+      if newName? == some declName then
+        throwError "Invalid `[deprecated]` attribute: `{.ofConstName declName true}` cannot be deprecated in favor of itself"
       if let some newName := newName? then
         recordExtraModUseFromDecl (isMeta := false) newName
       let text? := text?.map TSyntax.getString

--- a/src/Std/Http/Data/Headers/Name.lean
+++ b/src/Std/Http/Data/Headers/Name.lean
@@ -73,7 +73,7 @@ theorem beq_eq {x y : Name} : (x == y) = (x.value == y.value) :=
   rfl
 
 set_option linter.extra.dupNamespace false in
-@[deprecated beq_eq (since := "2026-06-04")]
+@[deprecated Header.Name.beq_eq (since := "2026-06-04")]
 theorem Name.beq_eq {x y : Name} : (x == y) = (x.value == y.value) :=
   Header.Name.beq_eq
 

--- a/tests/elab/deprecatedSelf.lean
+++ b/tests/elab/deprecatedSelf.lean
@@ -1,0 +1,39 @@
+/-!
+Tests that a `@[deprecated]` attribute whose replacement is the annotated declaration
+itself is rejected as an error.
+-/
+
+/--
+error: Invalid `[deprecated]` attribute: `foo` cannot be deprecated in favor of itself
+-/
+#guard_msgs in
+@[deprecated foo (since := "2026-07-09")]
+def foo := 1
+
+def bar := 1
+
+/--
+error: Invalid `[deprecated]` attribute: `bar` cannot be deprecated in favor of itself
+-/
+#guard_msgs in
+attribute [deprecated bar (since := "2026-07-09")] bar
+
+-- Deprecating in favor of a different declaration still works.
+def baz := 1
+
+@[deprecated baz (since := "2026-07-09")]
+def oldBaz := 1
+
+namespace A
+
+/-- error: Invalid `[deprecated]` attribute: `A.a` cannot be deprecated in favor of itself -/
+#guard_msgs in
+@[deprecated A.a (since := "2026-07-09")]
+def a := 1
+
+/-- error: Invalid `[deprecated]` attribute: `A.b` cannot be deprecated in favor of itself -/
+#guard_msgs in
+@[deprecated b (since := "2026-07-09")]
+def b := 1
+
+end A


### PR DESCRIPTION
This PR makes the `@[deprecated]` attribute error when deprecating a declaration in favor of itself.