### PR TITLE
chore: `LAKE_CACHE_EXTRA_ARGS`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1003,7 +1003,7 @@ add_custom_target(clean-olean DEPENDS clean-stdlib)
 if(USE_LAKE_CACHE)
   add_custom_target(
     cache-get
-    COMMAND ${PREV_STAGE}/bin/lake${CMAKE_EXECUTABLE_SUFFIX} cache get --repo=leanprover/lean4
+    COMMAND ${PREV_STAGE}/bin/lake${CMAKE_EXECUTABLE_SUFFIX} cache get --repo=leanprover/lean4 $$LAKE_CACHE_EXTRA_ARGS
   )
 endif()
 


### PR DESCRIPTION
use as in e.g.
```
make -C build/release cache-get -j$(nproc) LAKE_CACHE_EXTRA_ARGS="--rev $(jj show -r @- -T 'commit_id' --no-patch)"
```