### PR TITLE
fix: `partial_fixpoint` error on nested recursive calls

### DIFF
--- a/src/Lean/Elab/PreDefinition/PartialFixpoint/Main.lean
+++ b/src/Lean/Elab/PreDefinition/PartialFixpoint/Main.lean
@@ -24,13 +24,10 @@ open Lean.Order
 private def replaceRecApps (recFnNames : Array Name) (fixedParamPerms : FixedParamPerms) (f : Expr) (e : Expr) : MetaM Expr := do
   assert! recFnNames.size = fixedParamPerms.perms.size
   let t ← inferType f
-  return e.replace fun e => do
-    let fn := e.getAppFn
-    guard fn.isConst
-    let idx ← recFnNames.idxOf? fn.constName!
-    let args := e.getAppArgs
+  Meta.transform e fun e => e.withApp fun fn args => do
+    let some idx := fn.constName?.bind (recFnNames.idxOf? ·) | return .continue
     let varying := fixedParamPerms.perms[idx]!.pickVarying args
-    return mkAppN (PProdN.proj recFnNames.size idx t f) varying
+    return .continue (mkAppN (PProdN.proj recFnNames.size idx t f) varying)
 
 /--
 For pretty error messages:
@@ -115,7 +112,9 @@ def partialFixpoint (docCtx : LocalContext × LocalInstances) (preDefs : Array P
       mkLambdaFVars xs inst
 
   let declNames := preDefs.map (·.declName)
-  let fixedParamPerms ← getFixedParamPerms preDefs
+  let fixedParamPerms ← withoutModifyingEnv do
+    preDefs.forM (addAsAxiom ·)
+    getFixedParamPerms preDefs
   fixedParamPerms.perms[0]!.forallTelescope preDefs[0]!.type fun fixedArgs => do
     -- Either: ∀ x y, CCPO (rᵢ x y)
     -- Or:     ∀ x y, CompleteLattice (rᵢ x y)

--- a/tests/elab/partial_fixpoint_f91b.lean
+++ b/tests/elab/partial_fixpoint_f91b.lean
@@ -1,0 +1,18 @@
+/-!
+Tests that a non-monadic, non-tail-recursive `partial_fixpoint` definition (nested recursive call
+`f91 (f91 …)`) reports a helpful monotonicity error rather than a confusing `Unknown constant`
+error. Previously the fixed-parameter analysis and the functor construction failed to descend into
+the arguments of a recursive call, leaving the not-yet-defined constant behind.
+-/
+
+/--
+error: Could not prove 'f91' to be monotone in its recursive calls:
+  Cannot eliminate recursive call `f91 (n + 11)` enclosed in
+    f91 (f91 (n + 11))
+-/
+#guard_msgs in
+def f91 (n : Nat) : Nat :=
+  if n > 100
+    then n - 10
+    else f91 (f91 (n + 11))
+partial_fixpoint


### PR DESCRIPTION
This PR makes `partial_fixpoint` report a helpful monotonicity error instead of a confusing `Unknown constant` error when a non-monadic definition uses a nested recursive call (e.g. `f (f x)`), which requires the function to be tail recursive.

Two steps of the elaboration failed to descend into the arguments of a recursive call, tripping over the not-yet-defined constant inside the nested call: the fixed-parameter analysis (`getFixedParamPerms`), which now runs with the recursive functions added as axioms like the other callers already do, and `replaceRecApps`, which now uses `Meta.transform` so it also rewrites recursive calls nested in arguments.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
