### PR TITLE
perf: memoize stuck type class resolution queries

### DIFF
--- a/src/Lean/Meta/Basic.lean
+++ b/src/Lean/Meta/Basic.lean
@@ -390,6 +390,14 @@ structure Cache where
   inferType      : InferTypeCache := {}
   funInfo        : FunInfoCache := {}
   synthInstance  : SynthInstanceCache := {}
+  /--
+  Typeclass queries whose resolution got stuck on a metavariable (`isDefEqStuck`). Such queries
+  are retried whenever the elaborator makes any progress (see `synthesizeSyntheticMVars`), so
+  memoizing stuckness lets the retries fail fast instead of re-running the search setup each
+  time. If the blocking metavariable is assigned in the meantime, the retried query has a
+  different (more instantiated) key and is not affected by the memoized entry.
+  -/
+  synthStuck     : PHashSet SynthInstanceCacheKey := {}
   whnf           : WhnfCache := {}
   defEqTrans     : DefEqCache := {} -- transient cache for terms containing mvars or using nonstandard configuration options, it is frequently reset.
   defEqPerm      : DefEqCache := {} -- permanent cache for terms not containing mvars and using standard configuration options
@@ -653,13 +661,13 @@ def resetCache : MetaM Unit :=
   modifyCache fun _ => {}
 
 @[inline] def modifyInferTypeCache (f : InferTypeCache → InferTypeCache) : MetaM Unit :=
-  modifyCache fun ⟨ic, c1, c2, c3, c4, c5⟩ => ⟨f ic, c1, c2, c3, c4, c5⟩
+  modifyCache fun ⟨ic, c1, c2, c3, c4, c5, c6⟩ => ⟨f ic, c1, c2, c3, c4, c5, c6⟩
 
 @[inline] def modifyDefEqTransientCache (f : DefEqCache → DefEqCache) : MetaM Unit :=
-  modifyCache fun ⟨c1, c2, c3, c4, defeqTrans, c5⟩ => ⟨c1, c2, c3, c4, f defeqTrans, c5⟩
+  modifyCache fun ⟨c1, c2, c3, c4, c5, defeqTrans, c6⟩ => ⟨c1, c2, c3, c4, c5, f defeqTrans, c6⟩
 
 @[inline] def modifyDefEqPermCache (f : DefEqCache → DefEqCache) : MetaM Unit :=
-  modifyCache fun ⟨c1, c2, c3, c4, c5, defeqPerm⟩ => ⟨c1, c2, c3, c4, c5, f defeqPerm⟩
+  modifyCache fun ⟨c1, c2, c3, c4, c5, c6, defeqPerm⟩ => ⟨c1, c2, c3, c4, c5, c6, f defeqPerm⟩
 
 def mkExprConfigCacheKey (expr : Expr) : MetaM ExprConfigCacheKey :=
   return { expr, configKey := (← read).configKey }

--- a/src/Lean/Meta/SynthInstance.lean
+++ b/src/Lean/Meta/SynthInstance.lean
@@ -890,7 +890,14 @@ def synthInstanceCore? (type : Expr) (maxResultSize? : Option Nat := none) : Met
       trace[Meta.synthInstance] "result {result?} (cached)"
       return result?
     | none =>
+      if (← get).cache.synthStuck.contains cacheKey then
+        -- The same query already got stuck on a metavariable; the blocking metavariable is still
+        -- unassigned (otherwise the key would be more instantiated), so fail fast instead of
+        -- re-running the search.
+        trace[Meta.synthInstance.cache] "stuck (cached): {type}"
+        Meta.throwIsDefEqStuck
       trace[Meta.synthInstance.cache] "new: {type}"
+      try
       let abstResult? ← withNewMCtxDepth (allowLevelAssignments := true) do
         match kind with
         | .noMVars =>
@@ -920,6 +927,11 @@ def synthInstanceCore? (type : Expr) (maxResultSize? : Option Nat := none) : Met
       trace[Meta.synthInstance] "result {result?}"
       cacheResult cacheKey kind abstResult? result?
       return result?
+      catch e =>
+        if let .internal id _ := e then
+          if id == isDefEqStuckExceptionId then
+            modifyCache fun c => { c with synthStuck := c.synthStuck.insert cacheKey }
+        throw e
 
 def synthInstance? (type : Expr) (maxResultSize? : Option Nat := none) : MetaM (Option Expr) := do profileitM Exception "typeclass inference" (← getOptions) (decl := type.getAppFn.constName?.getD .anonymous) do
   synthInstanceCore? type maxResultSize?


### PR DESCRIPTION
Typeclass queries whose resolution gets stuck on an unassignable metavariable (`isDefEqStuck`) are retried by the elaborator whenever any progress is made (e.g. each `synthesizeSyntheticMVars` round), and each retry re-runs the full search setup — goal preprocessing, instance collection and priority-sorting via `getUnify` (which returns all instances of the class when the discriminating argument is a metavariable) — only to throw again on the first candidate. Measured on an early Mathlib slice, these doomed searches account for ~21% of all typeclass-search heartbeats (~800 heartbeats per call, 41K calls).

Stuckness is now memoized in a new transient `Meta.Cache.synthStuck` set: a repeated query with the same key fails fast with `isDefEqStuck` instead of re-running the search. This is sound with the lifetime of `Meta.Cache`: the cache key is built from the `instantiateMVars`-normalized goal, so once the blocking metavariable is assigned the retry uses a different key, and goal metavariables are never assignable inside the search regardless of the caller (`SynthInstance.main` runs in `withNewMCtxDepth`), so stuckness does not depend on the ambient depth. Instance table changes clear `Meta.Cache` as before.