### PR TITLE
refactor: split `registerParametricAttribute` into extension creation and registration

### DIFF
--- a/src/Lean/Attributes.lean
+++ b/src/Lean/Attributes.lean
@@ -260,14 +260,6 @@ structure ParametricAttributeImpl (α : Type) extends AttributeImplCore where
   filterExport : Environment → Name → α → Bool := fun env n _ =>
     env.contains (skipRealize := false) n
 
-/--
-Registers the persistent environment extension backing a parametric attribute.
-
-This takes the extension-relevant fields directly rather than a `ParametricAttributeImpl`, so the
-extension can be created independently of the attribute's `getParam`. This lets `getParam` consult
-the extension (via `getParam?`) for entries set on other declarations — see
-`registerParametricAttributeForExt`.
--/
 def registerParametricAttributeExt (ref : Name) (preserveOrder : Bool := false)
     (filterExport : Environment → Name → α → Bool := fun env n _ =>
       env.contains (skipRealize := false) n) :
@@ -288,13 +280,6 @@ def registerParametricAttributeExt (ref : Name) (preserveOrder : Bool := false)
     statsFn         := fun (_, m) => "parametric attribute" ++ Format.line ++ "number of local entries: " ++ format m.size
   }
 
-/--
-Registers a parametric attribute over an already-created extension `ext` (see
-`registerParametricAttributeExt`).
-
-`ext` must have been created with the same `preserveOrder` as `impl`, otherwise `getParam?` and the
-export logic will disagree on how entries are ordered.
--/
 def registerParametricAttributeForExt (impl : ParametricAttributeImpl α)
     (ext : PersistentEnvExtension (Name × α) (Name × α) (List Name × NameMap α)) :
     IO (ParametricAttribute α) := do
@@ -318,25 +303,34 @@ def registerParametricAttribute (impl : ParametricAttributeImpl α) : IO (Parame
 
 namespace ParametricAttribute
 
-def getParam? [Inhabited α] (attr : ParametricAttribute α) (env : Environment) (decl : Name) : Option α :=
+def getParamFromExt? [Inhabited α]
+    (ext : PersistentEnvExtension (Name × α) (Name × α) (List Name × NameMap α))
+    (preserveOrder : Bool) (env : Environment) (decl : Name) : Option α :=
   match env.getModuleIdxFor? decl with
   | some modIdx =>
-    let entry? := if attr.preserveOrder then
-      (attr.ext.getModuleEntries env modIdx).find? (·.1 == decl)
+    let entry? := if preserveOrder then
+      (ext.getModuleEntries env modIdx).find? (·.1 == decl)
     else
-      (attr.ext.getModuleEntries env modIdx).binSearch (decl, default) (fun a b => Name.quickLt a.1 b.1)
+      (ext.getModuleEntries env modIdx).binSearch (decl, default) (fun a b => Name.quickLt a.1 b.1)
     match entry? with
     | some (_, val) => some val
     | none          => none
-  | none        => (attr.ext.getState env).2.find? decl
+  | none        => (ext.getState env).2.find? decl
+
+def getParam? [Inhabited α] (attr : ParametricAttribute α) (env : Environment) (decl : Name) : Option α :=
+  getParamFromExt? attr.ext attr.preserveOrder env decl
+
+def setParamFromExt
+  (ext : PersistentEnvExtension (Name × α) (Name × α) (List Name × NameMap α)) (attr : AttributeImpl) (env : Environment) (decl : Name) (param : α) : Except String Environment :=
+  if (env.getModuleIdxFor? decl).isSome then
+    Except.error (s!"Failed to add parametric attribute `[{attr.name}]` to `{decl}`: Declaration is in an imported module")
+  else if ((ext.getState env).2.find? decl).isSome then
+    Except.error (s!"Failed to add parametric attribute `[{attr.name}]` to `{decl}`: Attribute has already been set")
+  else
+    Except.ok (ext.addEntry env (decl, param))
 
 def setParam (attr : ParametricAttribute α) (env : Environment) (decl : Name) (param : α) : Except String Environment :=
-  if (env.getModuleIdxFor? decl).isSome then
-    Except.error (s!"Failed to add parametric attribute `[{attr.attr.name}]` to `{decl}`: Declaration is in an imported module")
-  else if ((attr.ext.getState env).2.find? decl).isSome then
-    Except.error (s!"Failed to add parametric attribute `[{attr.attr.name}]` to `{decl}`: Attribute has already been set")
-  else
-    Except.ok (attr.ext.addEntry env (decl, param))
+  setParamFromExt attr.ext attr.attr env decl param
 
 end ParametricAttribute
 

--- a/src/Lean/Attributes.lean
+++ b/src/Lean/Attributes.lean
@@ -260,22 +260,44 @@ structure ParametricAttributeImpl (α : Type) extends AttributeImplCore where
   filterExport : Environment → Name → α → Bool := fun env n _ =>
     env.contains (skipRealize := false) n
 
-def registerParametricAttribute (impl : ParametricAttributeImpl α) : IO (ParametricAttribute α) := do
-  let ext : PersistentEnvExtension (Name × α) (Name × α) (List Name × NameMap α) ← registerPersistentEnvExtension {
-    name            := impl.ref
+/--
+Registers the persistent environment extension backing a parametric attribute.
+
+This takes the extension-relevant fields directly rather than a `ParametricAttributeImpl`, so the
+extension can be created independently of the attribute's `getParam`. This lets `getParam` consult
+the extension (via `getParam?`) for entries set on other declarations — see
+`registerParametricAttributeForExt`.
+-/
+def registerParametricAttributeExt (ref : Name) (preserveOrder : Bool := false)
+    (filterExport : Environment → Name → α → Bool := fun env n _ =>
+      env.contains (skipRealize := false) n) :
+    IO (PersistentEnvExtension (Name × α) (Name × α) (List Name × NameMap α)) :=
+  registerPersistentEnvExtension {
+    name            := ref
     mkInitial       := pure ([], {})
     addImportedFn   := fun _ => pure ([], {})
     addEntryFn      := fun (decls, m) (p : Name × α) => (p.1 :: decls, m.insert p.1 p.2)
     exportEntriesFnEx := fun env (decls, m) => Id.run do
-      let all := if impl.preserveOrder then
+      let all := if preserveOrder then
         decls.toArray.reverse.filterMap (fun n => return (n, ← m.find? n))
       else
         let r := m.foldl (fun a n p => a.push (n, p)) #[]
         r.qsort (fun a b => Name.quickLt a.1 b.1)
-      let exported := all.filter (fun ⟨n, a⟩ => impl.filterExport env n a)
+      let exported := all.filter (fun ⟨n, a⟩ => filterExport env n a)
       { exported, server := exported, «private» := all }
     statsFn         := fun (_, m) => "parametric attribute" ++ Format.line ++ "number of local entries: " ++ format m.size
   }
+
+/--
+Registers a parametric attribute over an already-created extension `ext` (see
+`registerParametricAttributeExt`).
+
+`ext` must have been created with the same `preserveOrder` as `impl`, otherwise `getParam?` and the
+export logic will disagree on how entries are ordered.
+-/
+def registerParametricAttributeForExt (impl : ParametricAttributeImpl α)
+    (ext : PersistentEnvExtension (Name × α) (Name × α) (List Name × NameMap α)) :
+    IO (ParametricAttribute α) := do
   let attrImpl : AttributeImpl := {
     impl.toAttributeImplCore with
     add   := fun decl stx kind => do
@@ -289,6 +311,10 @@ def registerParametricAttribute (impl : ParametricAttributeImpl α) : IO (Parame
   }
   registerBuiltinAttribute attrImpl
   pure { attr := attrImpl, ext, preserveOrder := impl.preserveOrder }
+
+def registerParametricAttribute (impl : ParametricAttributeImpl α) : IO (ParametricAttribute α) := do
+  let ext ← registerParametricAttributeExt (α := α) impl.ref impl.preserveOrder impl.filterExport
+  registerParametricAttributeForExt impl ext
 
 namespace ParametricAttribute
 


### PR DESCRIPTION
This PR splits `registerParametricAttribute` into two composable pieces so that a parametric attribute's `getParam` can consult the attribute's own extension for entries set on other declarations. 

`registerParametricAttributeExt` creates the backing environment extension from the extension-relevant fields alone (`ref`,`preserveOrder`, `filterExport`), and `registerParametricAttributeForExt` registers the attribute over a given extension. `registerParametricAttribute` is now the composition of the two, so existing callers are unaffected. This is a pure refactor with no behavior change.

 This is preparatory work for warning when `@[deprecated]` points at an already-deprecated declaration (#14336): the deprecation extension can be created first, letting the attribute's `getParam` look up whether the replacement name is itself deprecated.