### PR TITLE
fix: enforce set notation per-element indentation

### DIFF
--- a/src/Init/NotationExtra.lean
+++ b/src/Init/NotationExtra.lean
@@ -335,6 +335,15 @@ macro:50 e:term:51 " matches " p:sepBy1(term:51, " | ") : term =>
 end Lean
 
 /-- `{ a, b, c }` syntax, powered by the `Singleton` and `Insert` typeclasses. -/
+/-
+We use `withPosition` despite the parenthesized context because
+```
+{ aaa
+  bbb }
+```
+otherwise could be either a two-field structure or a singleton set, which seems way too confusing
+even when the elaborator can disambiguate the two.
+-/
 syntax "{" withPosition(term),+ "}" : term
 
 macro_rules

--- a/src/Init/NotationExtra.lean
+++ b/src/Init/NotationExtra.lean
@@ -335,7 +335,7 @@ macro:50 e:term:51 " matches " p:sepBy1(term:51, " | ") : term =>
 end Lean
 
 /-- `{ a, b, c }` syntax, powered by the `Singleton` and `Insert` typeclasses. -/
-syntax "{" term,+ "}" : term
+syntax "{" withPosition(term),+ "}" : term
 
 macro_rules
   | `({$x:term}) => `(singleton $x)


### PR DESCRIPTION
This PR enforces that elements of singleton notation need to indent e.g. nested application arguments, as otherwise the overlap with structure notation is simply too confusing for both humans and the upcoming formatter (would require blocking on elaboration).