### PR TITLE
fix: align `Lean/Level.lean` and `kernel/level.cpp` normalization rules

### DIFF
--- a/src/Lean/Level.lean
+++ b/src/Lean/Level.lean
@@ -542,7 +542,7 @@ def simpLevelMax' (u v : Level) (d : Level) : Level :=
 @[inline] private def mkLevelIMaxCore (u v : Level) (elseK : Unit → Level) : Level :=
   if v.isNeverZero then mkLevelMax' u v
   else if v.isZero then v
-  else if u.isZero then v
+  else if u.isZero || u == .succ .zero then v -- imax 0 u = imax 1 u = u
   else if u == v then u
   else elseK ()
 

--- a/src/kernel/level.cpp
+++ b/src/kernel/level.cpp
@@ -91,6 +91,10 @@ level mk_max(level const & l1, level const & l2)  {
         return l2;  // if l2 == (max l1 l'), then max l1 l2 == l2
     } else if (is_max(l1) && (max_lhs(l1) == l2 || max_rhs(l1) == l2)) {
         return l1;  // if l1 == (max l2 l'), then max l1 l2 == l1
+    } else if (is_explicit(l2) && to_offset(l1).second >= to_explicit(l2)) {
+        return l1;  // if l2 = k explicit and l1 has offset >= k, then max l1 l2 == l1
+    } else if (is_explicit(l1) && to_offset(l2).second >= to_explicit(l1)) {
+        return l2;  // if l1 = k explicit and l2 has offset >= k, then max l1 l2 == l2
     } else {
         auto p1 = to_offset(l1);
         auto p2 = to_offset(l2);

--- a/tests/elab/kernelLevel.lean
+++ b/tests/elab/kernelLevel.lean
@@ -1,0 +1,19 @@
+import Lean.CoreM
+
+/-! Regression tests for kernel `Level` operations via `Kernel.check`/`Kernel.whnf`. -/
+
+universe u_1
+
+open Lean
+
+/--
+info: Lean.Expr.sort (Lean.Level.succ (Lean.Level.succ (Lean.Level.param `u_1)))
+-/
+#guard_msgs in
+#eval show CoreM Expr from do
+  let env ← getEnv
+  let u : Level := .param `u_1
+  let ty := Expr.forallE `x (.sort (.succ u)) (.sort (.succ .zero)) .default
+  let some t := (Kernel.check env {} ty).toOption | return default
+  -- `mk_max (succ (succ u_1)) 2`: was `max (succ (succ u_1)) 2`, now `succ (succ u_1)` (subsumes rule)
+  return t

--- a/tests/elab/level.lean
+++ b/tests/elab/level.lean
@@ -7,3 +7,9 @@ open Lean
 #guard mkLevelMax (mkLevelSucc Level.zero) Level.zero != mkLevelSucc Level.zero
 #guard mkLevelMax (mkLevelSucc Level.zero) Level.zero == mkLevelMax (mkLevelSucc Level.zero) Level.zero
 #guard Level.geq (.max (.param `u) (.param `v)) (.imax (.param `u) (.param `v))
+
+-- `mkLevelIMax' 1 u = u` (matches C++ `mk_imax`'s `is_one(l1)` case).
+#guard mkLevelIMax' (mkLevelSucc Level.zero) (Level.param `u) == Level.param `u
+
+-- `max (succ u) 1 = succ u` under the `subsumes` rule.
+#guard mkLevelMax' (mkLevelSucc (Level.param `u)) (mkLevelSucc Level.zero) == mkLevelSucc (Level.param `u)

--- a/tests/elab_fail/1781.lean.out.expected
+++ b/tests/elab_fail/1781.lean.out.expected
@@ -1,5 +1,5 @@
 1781.lean:24:0-24:59: error: (kernel) declaration type mismatch, 'Univ'' has type
-  Type ((imax 1 u) + 1)
+  Type (u + 1)
 but it is expected to have type
-  Type (imax 1 u)
+  Type u
 Univ : Type


### PR DESCRIPTION
This PR aligns the `Level` normalization rules in `Lean/Level.lean` (stdlib) and `kernel/level.cpp` (kernel) so that both produce the same normalized `Level` for the same input.

Specifically, `mk_max` in `src/kernel/level.cpp` gains the "one operand is explicit and the other's offset dominates" simplification (e.g. `max (succ u_1) 1 → succ u_1`, which the stdlib's `mkLevelMaxCore` already performed), and `mkLevelIMaxCore` in `src/Lean/Level.lean` gains the `imax 1 u = u` case that C++'s `mk_imax` already had (via `is_one(l1)`). Both simplifications are semantics-preserving; the goal is only to make the two implementations agree so that downstream expression hashes computed by different tools (elaborator, `#reduce`, `lean4lean`, other kernel reimplementations) match on a fixed input.
