### PR TITLE
perf: fast path for `grind`'s internal envelope type `Ring.OfSemiring.Q type`

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/Arith/CommRing/RingId.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/CommRing/RingId.lean
@@ -27,6 +27,74 @@ def getCommRingId? (type : Expr) : GoalM (Option Nat) := do
     return id?
 where
   go? : GoalM (Option Nat) := do
+    if type.isAppOfArity ``Grind.Ring.OfSemiring.Q 2 then
+      goQ? type.appFn!.appArg! type.appArg!
+    else
+      goCore?
+
+  /-
+  Fast path for `grind`'s internal envelope type `Ring.OfSemiring.Q base`.
+  -/
+  goQ? (base semiringInst : Expr) : GoalM (Option Nat) := do
+    -- `getCommSemiringId?` instantiates the envelope with `CommSemiring.toSemiring`;
+    -- fall back to the generic path otherwise.
+    let_expr Grind.CommSemiring.toSemiring _ commSemiringInst := semiringInst | goCore?
+    let some u ← getDecLevel? base | return none
+    let commRingInst := mkApp2 (mkConst ``Grind.CommRing.OfCommSemiring.ofCommSemiring [u]) base commSemiringInst
+    let ringInst := mkApp2 (mkConst ``Grind.CommRing.toRing [u]) type commRingInst
+    let semiringInstQ := mkApp2 (mkConst ``Grind.Ring.toSemiring [u]) type ringInst
+    let commSemiringInstQ := mkApp2 (mkConst ``Grind.CommRing.toCommSemiring [u]) type semiringInstQ
+    registerInstance (mkApp (mkConst ``Grind.CommRing [u]) type) commRingInst
+    registerInstance (mkApp (mkConst ``Grind.Ring [u]) type) ringInst
+    registerInstance (mkApp (mkConst ``Grind.Semiring [u]) type) semiringInstQ
+    registerInstance (mkApp (mkConst ``Grind.CommSemiring [u]) type) commSemiringInstQ
+    registerInstance (mkApp (mkConst ``Grind.NatModule [u]) type)
+      (mkApp2 (mkConst ``Grind.Semiring.toNatModule [u]) type semiringInstQ)
+    registerInstance (mkApp3 (mkConst ``HAdd [u, u, u]) type type type)
+      (mkApp2 (mkConst ``instHAdd [u]) type (mkApp2 (mkConst ``Grind.Semiring.toAdd [u]) type semiringInstQ))
+    registerInstance (mkApp3 (mkConst ``HMul [u, u, u]) type type type)
+      (mkApp2 (mkConst ``instHMul [u]) type (mkApp2 (mkConst ``Grind.Semiring.toMul [u]) type semiringInstQ))
+    registerInstance (mkApp3 (mkConst ``HSub [u, u, u]) type type type)
+      (mkApp2 (mkConst ``instHSub [u]) type (mkApp2 (mkConst ``Grind.Ring.toSub [u]) type ringInst))
+    registerInstance (mkApp (mkConst ``Neg [u]) type)
+      (mkApp2 (mkConst ``Grind.Ring.toNeg [u]) type ringInst)
+    registerInstance (mkApp3 (mkConst ``HPow [u, 0, u]) type Nat.mkType type)
+      (mkApp2 (mkConst ``Grind.Semiring.npow [u]) type semiringInstQ)
+    registerInstance (mkApp (mkConst ``NatCast [u]) type)
+      (mkApp2 (mkConst ``Grind.Semiring.natCast [u]) type semiringInstQ)
+    registerInstance (mkApp (mkConst ``IntCast [u]) type)
+      (mkApp2 (mkConst ``Grind.Ring.intCast [u]) type ringInst)
+    trace_goal[grind.ring] "new ring: {type}"
+    -- Premises on the base type for the conditional envelope instances.
+    let addRightCancelInst? ← do
+      let some addInst ← synthInstance? (mkApp (mkConst ``Add [u]) base) | pure none
+      synthInstance? (mkApp2 (mkConst ``Grind.AddRightCancel [u]) base addInst)
+    let charInst? ← do
+      let some addRightCancelInst := addRightCancelInst? | pure none
+      let some (baseCharInst, n) ← getIsCharInst? u base semiringInst | pure none
+      let inst := mkApp5 (mkConst ``Grind.Ring.OfSemiring.instIsCharPQOfAddRightCancel [u])
+        base (mkRawNatLit n) semiringInst addRightCancelInst baseCharInst
+      pure (some (inst, n))
+    let noZeroDivInst? ← do
+      let some addRightCancelInst := addRightCancelInst? | pure none
+      -- `getNoZeroDivInst?` synthesizes the `NatModule base` premise instead of using
+      -- `Semiring.toNatModule`, so this query is shared with the one issued for the
+      -- `IntModule.OfNatModule.Q base` envelope; the results are definitionally equal.
+      let some noZeroDivInst ← getNoZeroDivInst? u base | pure none
+      pure (some (mkApp4 (mkConst ``Grind.Ring.OfSemiring.instNoNatZeroDivisorsQOfAddRightCancel [u])
+        base semiringInst addRightCancelInst noZeroDivInst))
+    trace_goal[grind.ring] "NoNatZeroDivisors available: {noZeroDivInst?.isSome}"
+    trace_goal[grind.ring] "PowIdentity available: false"
+    let id := (← get').rings.size
+    let ring : CommRing := {
+      id, semiringId? := none, type, u, semiringInst := semiringInstQ, ringInst,
+      commSemiringInst := commSemiringInstQ,
+      commRingInst, charInst?, noZeroDivInst?, fieldInst? := none, powIdentityInst? := none,
+    }
+    modify' fun s => { s with rings := s.rings.push ring }
+    return some id
+
+  goCore? : GoalM (Option Nat) := do
     let u ← getDecLevel type
     let commRing := mkApp (mkConst ``Grind.CommRing [u]) type
     let some commRingInst ← synthInstance? commRing | return none


### PR DESCRIPTION
This PR implements a fast path for `grind`'s internal envelope type `Ring.OfSemiring.Q type`.
