### PR TITLE
chore: remove unnecessary `public meta import` on critical rebuild path

### DIFF
--- a/src/Std/Data/DHashMap/Internal/RawLemmas.lean
+++ b/src/Std/Data/DHashMap/Internal/RawLemmas.lean
@@ -12,7 +12,7 @@ public import Std.Data.DHashMap.Internal.WF
 import all Std.Data.DHashMap.Raw
 import all Std.Data.DHashMap.Basic
 import all Std.Data.DHashMap.RawDef
-public meta import Std.Data.DHashMap.Basic
+meta import Std.Data.DHashMap.Basic
 
 public section
 


### PR DESCRIPTION
Apparently a shake over-approximation
