### PR TITLE
perf: inline unsafe term helpers

### DIFF
--- a/src/Lean/Elab/BuiltinNotation.lean
+++ b/src/Lean/Elab/BuiltinNotation.lean
@@ -566,6 +566,7 @@ def elabUnsafe : TermElab := fun stx expectedType? =>
     if (← read).declName?.any (isMarkedMeta (← getEnv)) then
       modifyEnv (markMeta · unsafeFn)
       modifyEnv (markMeta · implName)
+    setInlineAttribute unsafeFn .alwaysInline
     compileDecls #[unsafeFn]
     addDecl <| Declaration.opaqueDecl {
       name        := implName

--- a/tests/elab/compile_unsafe_terms.lean
+++ b/tests/elab/compile_unsafe_terms.lean
@@ -1,0 +1,23 @@
+/-! This test shows that `unsafe` terms are properly inlined. -/
+
+@[inline]
+def eqLists (xs ys : List Nat) := unsafe ptrEq xs ys
+
+/--
+trace: [Compiler.result] size: 3
+    def test @&xs @&ys : UInt8 :=
+      let _x.1 := ptrAddrUnsafe ◾ xs;
+      let _x.2 := ptrAddrUnsafe ◾ ys;
+      let _x.3 := USize.decEq _x.1 _x.2;
+      return _x.3
+[Compiler.result] size: 4
+    def test._boxed xs ys : tagged :=
+      let res := test xs ys;
+      dec ys;
+      dec xs;
+      let r := box res;
+      return r
+-/
+#guard_msgs in
+set_option trace.Compiler.result true in
+def test (xs ys : List Nat) := eqLists xs ys


### PR DESCRIPTION
This PR ensures that `unsafe` terms get properly inlined. Previously having some unsafe term `t` occurring inline as `unsafe t` would create a separate auxiliary declaration that might not end up getting inlined.