### PR TITLE
refactor: move initialization functions to `BaseIO`

### DIFF
--- a/src/Lean/ImportingFlag.lean
+++ b/src/Lean/ImportingFlag.lean
@@ -27,18 +27,18 @@ Remark: Compacted module regions must not be freed when using this flag as the
   cached initializer results may reference objects in them.
 Remark: The Lean frontend executes this method at startup time.
 -/
-@[export lean_enable_initializer_execution]
-unsafe def enableInitializersExecution : IO Unit :=
+@[inline, export lean_enable_initializer_execution]
+unsafe def enableInitializersExecution : BaseIO Unit :=
   runInitializersRef.set true
 
-def isInitializerExecutionEnabled : IO Bool :=
+@[inline] def isInitializerExecutionEnabled : BaseIO Bool :=
   runInitializersRef.get
 
 /--
 We say Lean is "initializing" when it is executing `builtin_initialize` declarations or importing modules.
 Recall that Lean executes `initialize` declarations while importing modules.
 -/
-def initializing : IO Bool :=
+@[inline] def initializing : BaseIO Bool :=
   IO.initializing <||> importingRef.get
 
 /--
@@ -51,7 +51,7 @@ This is true in the Lean frontend where we process the `import` commands at the 
 of the execution only. Users must make sure that when `importModules` is used, there is only
 one execution thread accessing the global references.
 -/
-def withImporting (x : IO α) : IO α :=
+@[inline] def withImporting (x : IO α) : IO α :=
   try
     importingRef.set true
     x
@@ -66,8 +66,8 @@ This is intended for C code that needs to emulate multiple `withImporting` calls
 As with `withImporting`, users must make sure there is only one execution thread accessing
 the global references.
 -/
-@[export lean_set_initializing]
-private def setInitializing (b : Bool) : BaseIO Unit :=
-  importingRef.set b
+@[inline, export lean_set_initializing]
+private def setInitializing (initializing : Bool) : BaseIO Unit :=
+  importingRef.set initializing
 
 end Lean

--- a/src/Lean/ImportingFlag.lean
+++ b/src/Lean/ImportingFlag.lean
@@ -27,18 +27,18 @@ Remark: Compacted module regions must not be freed when using this flag as the
   cached initializer results may reference objects in them.
 Remark: The Lean frontend executes this method at startup time.
 -/
-@[inline, export lean_enable_initializer_execution]
+@[export lean_enable_initializer_execution]
 unsafe def enableInitializersExecution : BaseIO Unit :=
   runInitializersRef.set true
 
-@[inline] def isInitializerExecutionEnabled : BaseIO Bool :=
+def isInitializerExecutionEnabled : BaseIO Bool :=
   runInitializersRef.get
 
 /--
 We say Lean is "initializing" when it is executing `builtin_initialize` declarations or importing modules.
 Recall that Lean executes `initialize` declarations while importing modules.
 -/
-@[inline] def initializing : BaseIO Bool :=
+def initializing : BaseIO Bool :=
   IO.initializing <||> importingRef.get
 
 /--
@@ -51,7 +51,7 @@ This is true in the Lean frontend where we process the `import` commands at the 
 of the execution only. Users must make sure that when `importModules` is used, there is only
 one execution thread accessing the global references.
 -/
-@[inline] def withImporting (x : IO α) : IO α :=
+def withImporting (x : IO α) : IO α :=
   try
     importingRef.set true
     x
@@ -66,7 +66,7 @@ This is intended for C code that needs to emulate multiple `withImporting` calls
 As with `withImporting`, users must make sure there is only one execution thread accessing
 the global references.
 -/
-@[inline, export lean_set_initializing]
+@[export lean_set_initializing]
 private def setInitializing (initializing : Bool) : BaseIO Unit :=
   importingRef.set initializing
 

--- a/src/util/shell.cpp
+++ b/src/util/shell.cpp
@@ -319,7 +319,7 @@ extern "C" LEAN_EXPORT int lean_main(int argc, char ** argv) {
         std::cerr << "error: " << ex.what() << std::endl;
         return 1;
     }
-    consume_io_result(lean_enable_initializer_execution());
+    lean_enable_initializer_execution();
 
     // Default the configured thread stack size from the environment as in `lean_run_main`;
     // `--tstack` below overrides it.


### PR DESCRIPTION
This PR moves `Lean.initializing`, `enableInitializersExecution`, and `isInitializerExecutionEnabled` to `BaseIO` from `IO`. 

**Breaking change:** `lean_enable_initializer_execution` now returns a scalar rather than a non-scalar value (due to the move from `IO` to `BaseIO`), so its result should no longer be manged with `lean_Io_result` functions or decremented with `lean_dec_ref`. Failure to adapt will likely produce a segfault.
