### PR TITLE
perf: borrow annotation on `Syntax.structEq`

### DIFF
--- a/src/Init/Meta/Defs.lean
+++ b/src/Init/Meta/Defs.lean
@@ -512,8 +512,12 @@ namespace Syntax
 
 deriving instance BEq for Syntax.Preresolved
 
+/-
+The annotations are necessary because this calls the bootstrapping helper for Substring which does
+not have borrowing annotations.
+-/
 /-- Compare syntax structures modulo source info. -/
-partial def structEq : Syntax → Syntax → Bool
+partial def structEq : @&Syntax → @&Syntax → Bool
   | Syntax.missing, Syntax.missing => true
   | Syntax.node _ k args, Syntax.node _ k' args' => k == k' && args.isEqv args' structEq
   | Syntax.atom _ val, Syntax.atom _ val' => val == val'


### PR DESCRIPTION
This PR adds proper borrow annotations to `Syntax.structEq`. They are needed because it is so early in bootstrapping that it routes through `Substring`'s bootstrapping wrappers without borrow annotations. They are relevant because `Syntax.structEq` ends up getting called transitively from `alphaEq`.