### PR TITLE
chore: disable grind_bitvec2 benchmark

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -323,7 +323,14 @@ add_test_pile(
     sync_mutex.lean # Flaky
   ${ELAB_FIXTURES}
 )
-add_test_pile(elab_bench *.lean BENCH PART2 ${ELAB_FIXTURES})
+add_test_pile(
+  elab_bench
+  *.lean
+  BENCH
+  PART2
+  EXCEPT
+    grind_bitvec2.lean # Broken since #14371
+  ${ELAB_FIXTURES})
 add_test_pile(elab_fail *.lean ${ELAB_FIXTURES})
 add_test_pile(misc *.sh)
 add_test_pile(misc_bench *.sh BENCH PART2)

--- a/tests/elab_bench/grind_bitvec2.lean
+++ b/tests/elab_bench/grind_bitvec2.lean
@@ -1,9 +1,6 @@
 module
 set_option linter.unusedSimpArgs false
 
-/-
-TODO: Temporarily disabled; broke due to #14371
-
 open BitVec
 
 namespace BitVec'
@@ -4546,4 +4543,3 @@ theorem sle_eq_ule_of_msb_eq {x y : BitVec w} (h : x.msb = y.msb) : x.sle y = x.
   simp [BitVec.sle_eq_ule, h]
 
 end BitVec'
--/

--- a/tests/elab_bench/grind_bitvec2.lean
+++ b/tests/elab_bench/grind_bitvec2.lean
@@ -1,6 +1,9 @@
 module
 set_option linter.unusedSimpArgs false
 
+/-
+TODO: Temporarily disabled; broke due to #14371
+
 open BitVec
 
 namespace BitVec'
@@ -4543,3 +4546,4 @@ theorem sle_eq_ule_of_msb_eq {x y : BitVec w} (h : x.msb = y.msb) : x.sle y = x.
   simp [BitVec.sle_eq_ule, h]
 
 end BitVec'
+-/


### PR DESCRIPTION
This PR temporarily disables the `grind_bitvec2` benchmark that broke after #14371 