### PR TITLE
fix: boostrapping issue in `grind`

### DIFF
--- a/src/Init/Data/BitVec/Bootstrap.lean
+++ b/src/Init/Data/BitVec/Bootstrap.lean
@@ -65,7 +65,10 @@ theorem toNat_cast (h : w = v) (x : BitVec w) : (x.cast h).toNat = x.toNat := rf
 @[simp, bitvec_to_nat, grind =]
 theorem toNat_ofFin (x : Fin (2^n)) : (BitVec.ofFin x).toNat = x.val := rfl
 
-@[simp, grind =] theorem toNat_ofNatLT (x : Nat) (p : x < 2^w) : (x#'p).toNat = x := rfl
+-- The `[grind =]` attribute is attached in `Init.Data.BitVec.Lemmas` because the pattern must
+-- be normalized with respect to the `grind` normalization theorem `ofNatLT_eq_ofNat`, which is
+-- only activated in `Init.Grind.Norm`.
+@[simp] theorem toNat_ofNatLT (x : Nat) (p : x < 2^w) : (x#'p).toNat = x := rfl
 
 @[simp, grind =] theorem toNat_cons (b : Bool) (x : BitVec w) :
     (cons b x).toNat = (b.toNat <<< w) ||| x.toNat := by
@@ -173,5 +176,8 @@ theorem cons_induction {motive : (w : Nat) → BitVec w → Prop} (nil : motive 
     rw [← cons_msb_setWidth x]
     apply cons
     apply ih
+
+theorem ofNatLT_eq_ofNat {w : Nat} {n : Nat} (hn) : BitVec.ofNatLT n hn = BitVec.ofNat w n :=
+  eq_of_toNat_eq (by simp [Nat.mod_eq_of_lt hn])
 
 end BitVec

--- a/src/Init/Data/BitVec/Lemmas.lean
+++ b/src/Init/Data/BitVec/Lemmas.lean
@@ -16,6 +16,7 @@ import Init.Data.List.Nat.TakeDrop
 public import Init.Data.BitVec.Basic
 import Init.ByCases
 import Init.Data.BitVec.Bootstrap
+import Init.Grind.Norm  -- shake: keep (`grind` norm theorems must be active when the patterns of the `[grind =]` theorems about `BitVec.ofNatLT` below are computed)
 import Init.Data.Int.Bitwise.Lemmas
 import Init.Data.Int.DivMod.Lemmas
 import Init.Data.Int.LemmasAux
@@ -328,6 +329,11 @@ theorem ofBool_eq_iff_eq : ∀ {b b' : Bool}, BitVec.ofBool b = BitVec.ofBool b'
 @[simp] theorem ofBool_xor_ofBool : ofBool b ^^^ ofBool b' = ofBool (b ^^ b') := by
   cases b <;> cases b' <;> rfl
 
+-- The attribute is attached here (instead of at the declaration in `Init.Data.BitVec.Bootstrap`)
+-- because the pattern must be normalized with respect to the `grind` normalization theorem
+-- `ofNatLT_eq_ofNat`.
+attribute [grind =] BitVec.toNat_ofNatLT
+
 @[simp, grind =] theorem getLsbD_ofNatLT {n : Nat} (x : Nat) (lt : x < 2^n) (i : Nat) :
   getLsbD (x#'lt) i = x.testBit i := by
   simp [getLsbD, BitVec.ofNatLT]
@@ -335,9 +341,6 @@ theorem ofBool_eq_iff_eq : ∀ {b b' : Bool}, BitVec.ofBool b = BitVec.ofBool b'
 @[simp, grind =] theorem getMsbD_ofNatLT {n x i : Nat} (h : x < 2^n) :
     getMsbD (x#'h) i = (decide (i < n) && x.testBit (n - 1 - i)) := by
   simp [getMsbD, getLsbD]
-
-theorem ofNatLT_eq_ofNat {w : Nat} {n : Nat} (hn) : BitVec.ofNatLT n hn = BitVec.ofNat w n :=
-  eq_of_toNat_eq (by simp [Nat.mod_eq_of_lt hn])
 
 @[simp, grind =] theorem toFin_ofNat (x : Nat) : toFin (BitVec.ofNat w x) = Fin.ofNat (2^w) x := rfl
 

--- a/src/Init/Data/OfScientific.lean
+++ b/src/Init/Data/OfScientific.lean
@@ -6,32 +6,13 @@ Authors: Leonardo de Moura
 module
 
 prelude
+public import Init.Data.OfScientific.Basic
 public import Init.Data.Float.Float32
 import Init.Data.Nat.Log2
 import Init.Meta
 import Init.Data.Array.Lemmas
 
 public section
-
-/-- For decimal and scientific numbers (e.g., `1.23`, `3.12e10`).
-   Examples:
-   - `1.23` is syntax for `OfScientific.ofScientific (nat_lit 123) true (nat_lit 2)`
-   - `121e100` is syntax for `OfScientific.ofScientific (nat_lit 121) false (nat_lit 100)`
-
-   Note the use of `nat_lit`; there is no wrapping `OfNat.ofNat` in the resulting term.
--/
-class OfScientific (α : Type u) where
-  /--
-  Produces a value from the given mantissa, exponent sign, and decimal exponent. For the exponent
-  sign, `true` indicates a negative exponent.
-
-   Examples:
-   - `1.23` is syntax for `OfScientific.ofScientific (nat_lit 123) true (nat_lit 2)`
-   - `121e100` is syntax for `OfScientific.ofScientific (nat_lit 121) false (nat_lit 100)`
-
-   Note the use of `nat_lit`; there is no wrapping `OfNat.ofNat` in the resulting term.
-  -/
-  ofScientific (mantissa : Nat) (exponentSign : Bool) (decimalExponent : Nat) : α
 
 /--
 Precomputed values of `10 ^ e` for `0 ≤ e ≤ 22`. In this range, the values can be represented

--- a/src/Init/Data/OfScientific/Basic.lean
+++ b/src/Init/Data/OfScientific/Basic.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2020 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+module
+
+prelude
+public import Init.Prelude
+
+public section
+
+/-- For decimal and scientific numbers (e.g., `1.23`, `3.12e10`).
+   Examples:
+   - `1.23` is syntax for `OfScientific.ofScientific (nat_lit 123) true (nat_lit 2)`
+   - `121e100` is syntax for `OfScientific.ofScientific (nat_lit 121) false (nat_lit 100)`
+
+   Note the use of `nat_lit`; there is no wrapping `OfNat.ofNat` in the resulting term.
+-/
+class OfScientific (α : Type u) where
+  /--
+  Produces a value from the given mantissa, exponent sign, and decimal exponent. For the exponent
+  sign, `true` indicates a negative exponent.
+
+   Examples:
+   - `1.23` is syntax for `OfScientific.ofScientific (nat_lit 123) true (nat_lit 2)`
+   - `121e100` is syntax for `OfScientific.ofScientific (nat_lit 121) false (nat_lit 100)`
+
+   Note the use of `nat_lit`; there is no wrapping `OfNat.ofNat` in the resulting term.
+  -/
+  ofScientific (mantissa : Nat) (exponentSign : Bool) (decimalExponent : Nat) : α

--- a/src/Init/Data/Rat/Basic.lean
+++ b/src/Init/Data/Rat/Basic.lean
@@ -7,7 +7,7 @@ module
 
 prelude
 public import Init.Data.Nat.Coprime
-public import Init.Data.OfScientific
+public import Init.Data.OfScientific.Basic
 public import Init.Data.Int.DivMod.Basic
 public import Init.Data.String.Defs
 public import Init.Data.ToString.Macro

--- a/src/Init/Grind/Norm.lean
+++ b/src/Init/Grind/Norm.lean
@@ -11,6 +11,7 @@ public import Init.Data.Rat.Lemmas  -- shake: keep (used in `init_grind_norm`)
 public import Init.Grind.Ring.OfScientific  -- shake: keep (used in `init_grind_norm`)
 public import Init.Data.Int.Pow  -- shake: keep (used in `init_grind_norm`)
 public import Init.Data.Int.DivMod.Lemmas  -- shake: keep (used in `init_grind_norm`)
+public import Init.Data.BitVec.Bootstrap  -- shake: keep (used in `init_grind_norm`)
 public import Init.Omega
 import Init.ByCases
 public section

--- a/src/Init/Grind/Ring/OfScientific.lean
+++ b/src/Init/Grind/Ring/OfScientific.lean
@@ -7,7 +7,7 @@ module
 
 prelude
 public import Init.Grind.Ring.Field
-public import Init.Data.OfScientific
+public import Init.Data.OfScientific.Basic
 
 public section
 


### PR DESCRIPTION
This PR fixes a bootstrapping issue in the `grind` normalizer. The `BitVec.ofNatLT` normalization theorem must be added to the `grind` normalization set **before** we process `Init/Data/BitVec/Lemmas.lean`. Otherwise, patterns are not properly normalized.
