### PR TITLE
chore: re-enable `grind_bitvec2.lean`, revert "chore: disable grind_bitvec2 benchmark (#14377)"

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -323,14 +323,7 @@ add_test_pile(
     sync_mutex.lean # Flaky
   ${ELAB_FIXTURES}
 )
-add_test_pile(
-  elab_bench
-  *.lean
-  BENCH
-  PART2
-  EXCEPT
-    grind_bitvec2.lean # Broken since #14371
-  ${ELAB_FIXTURES})
+add_test_pile(elab_bench *.lean BENCH PART2 ${ELAB_FIXTURES})
 add_test_pile(elab_fail *.lean ${ELAB_FIXTURES})
 add_test_pile(misc *.sh)
 add_test_pile(misc_bench *.sh BENCH PART2)


### PR DESCRIPTION
This PR re-renables a benchmark that was temporarily disabled.