### PR TITLE
perf: slightly faster `UInt8.toAsciiLower`

### DIFF
--- a/src/Init/Data/UInt/Basic.lean
+++ b/src/Init/Data/UInt/Basic.lean
@@ -186,7 +186,8 @@ lowercase value, otherwise leave it untouched.
 -/
 @[inline]
 def UInt8.toAsciiLower (b : UInt8) : UInt8 :=
-  if b >= 65 && b <= 90 then (b + 32) else b
+  -- Branchless: `b - 65 < 26` iff `b` is an uppercase ASCII letter, thanks to wraparound.
+  b + ((decide (b - 65 < 26)).toUInt8 <<< 5)
 
 /-- Converts a `Fin UInt16.size` into the corresponding `UInt16`. -/
 @[inline] def UInt16.ofFin (a : Fin UInt16.size) : UInt16 := ⟨⟨a⟩⟩

--- a/src/Init/Data/UInt/Basic.lean
+++ b/src/Init/Data/UInt/Basic.lean
@@ -186,7 +186,8 @@ lowercase value, otherwise leave it untouched.
 -/
 @[inline]
 def UInt8.toAsciiLower (b : UInt8) : UInt8 :=
-  -- Branchless: `b - 65 < 26` iff `b` is an uppercase ASCII letter, thanks to wraparound.
+  -- LLVM also manages to turn the naive `if` into branchless code, but this implementation happens
+  -- to generate slighly better assembly.
   b + ((decide (b - 65 < 26)).toUInt8 <<< 5)
 
 /-- Converts a `Fin UInt16.size` into the corresponding `UInt16`. -/


### PR DESCRIPTION
This PR changes the implementation of `UInt8.toAsciiLower` to something which generates slightly faster assembly.