### PR TITLE
feat: persist `logLintExt` data at `server` level

### DIFF
--- a/src/Lean/Linter/PersistentLintLog.lean
+++ b/src/Lean/Linter/PersistentLintLog.lean
@@ -27,12 +27,13 @@ builtin_initialize lintLogExt :
     mkInitial     := pure #[]
     addImportedFn := fun _ => pure #[]
     addEntryFn    := Array.push
-    exportEntriesFn := id
+    exportEntriesFnEx := fun _ entries =>
+      { exported := #[], server := entries, «private» := entries }
   }
 
 def getAllLints (env : Environment) : Array (Name × Array LintEntry) :=
   env.header.moduleNames.mapIdx fun i mod =>
-    (mod, lintLogExt.getModuleEntries env i)
+    (mod, lintLogExt.getModuleEntries env i (level := .server))
 
 instance : MonadFileMap (ReaderT FileMap BaseIO) := ⟨read⟩
 

--- a/src/lake/Lake/CLI/BuiltinLint.lean
+++ b/src/lake/Lake/CLI/BuiltinLint.lean
@@ -242,14 +242,12 @@ public def run (args : Args) : IO UInt32 := do
   for mod in mods do
     unsafe Lean.enableInitializersExecution
     -- Peek at the .olean header to learn whether `mod` participates in the module system.
-    -- If so, import at the public (`exported`) level, mirroring `processHeaderCore`.
+    -- If so, import at the server level level, mirroring `processHeaderCore`, while
+    -- exposing server-level data (i.e. the state of `lintLogExt`).
     let modFile ← findOLean mod
     let (modData, region) ← readModuleData modFile
     let isModule ← getIsModule modData
-    let level :=
-      if isModule then
-        if args.recordExceptions then OLeanLevel.server else OLeanLevel.exported
-      else OLeanLevel.private
+    let level := if isModule then OLeanLevel.server else OLeanLevel.private
     unsafe region.free
     let env ← importModules #[{ module := mod }, envLinterModule] {}
       (trustLevel := 1024) (loadExts := true) (level := level)

--- a/tests/lake/tests/builtin-lint-module/Main.lean
+++ b/tests/lake/tests/builtin-lint-module/Main.lean
@@ -4,6 +4,8 @@ public import Linters
 
 public def shouldBeFlaggedDummyMarker : Nat := 1
 
+private def shouldNotBeFlaggedPrivateDummyMarker : Nat := 2
+
 public def publicUnusedVarFixture : Nat :=
   let publicUnusedLet := 5
   3

--- a/tests/lake/tests/builtin-lint-module/test.sh
+++ b/tests/lake/tests/builtin-lint-module/test.sh
@@ -2,8 +2,8 @@
 source ../common.sh
 
 # Verifies `lake lint --builtin-lint` on module-system targets. The top-level
-# module is loaded at `OLeanLevel.exported` (the "public" level), and we want
-# both env-linter and text-linter (lintLogExt) results to be preserved.
+# module is loaded at `OLeanLevel.server`, and we want both env-linter and
+# text-linter (lintLogExt) results to be preserved.
 #
 # Uses a dummy env linter defined in `Linters.lean` so this test does not
 # couple to the behaviour of any production env linter (`defLemma`,
@@ -17,17 +17,18 @@ test_run lint --builtin-only Clean
 lake_out lint --builtin-only Main || true
 
 # Dummy env linter (default-on, name-only test) flags the public def. This
-# proves env linters still see imported public decls at `.exported`.
+# proves env linters still see imported public decls.
 match_pat 'shouldBeFlaggedDummyMarker' produced.out
 match_pat "name ends with 'DummyMarker'" produced.out
 
 # `linter.unusedVariables` (default-on) entries land in `lintLogExt` during
-# the build. `lintLogExt` writes uniform OLean entries, so its data must
-# survive loading at `.exported`. The warning on a *public* def is replayed:
+# the build. `lintLogExt` persists its entries at the `server` OLean level
+# (not `exported`), so they are only visible because the lint driver imports
+# at `.server`. The warning on a *public* def is replayed:
 match_pat 'Variable name `publicUnusedLet` is not explicitly referenced' produced.out
 
 # And — crucially — the warning on a *private* def is also replayed: even
-# though private decls are elided from `env.constants` at `.exported`, the
+# though private decls are elided from `env.constants` at `.server`, the
 # `lintLogExt` entry is keyed by module index, not by declaration, so the
-# text-linter warning survives the level change.
+# text-linter warning is still recoverable.
 match_pat 'Variable name `privateUnusedLet` is not explicitly referenced' produced.out

--- a/tests/lake/tests/builtin-lint-module/test.sh
+++ b/tests/lake/tests/builtin-lint-module/test.sh
@@ -21,6 +21,11 @@ lake_out lint --builtin-only Main || true
 match_pat 'shouldBeFlaggedDummyMarker' produced.out
 match_pat "name ends with 'DummyMarker'" produced.out
 
+# Private decls are elided from `env.constants` at `.server`, so env linters
+# must not see (and hence not flag) the private def, even though its name
+# also matches the dummy linter's pattern.
+no_match_pat 'shouldNotBeFlaggedPrivateDummyMarker' produced.out
+
 # `linter.unusedVariables` (default-on) entries land in `lintLogExt` during
 # the build. `lintLogExt` persists its entries at the `server` OLean level
 # (not `exported`), so they are only visible because the lint driver imports

--- a/tests/pkg/rebuild/run_test.sh
+++ b/tests/pkg/rebuild/run_test.sh
@@ -64,3 +64,7 @@ def matchTest : Nat -> Nat
   | n+1 => n
 EOF
 test_unchanged
+
+# Lint warnings (persisted in `lintLogExt`) do not matter.
+perl -p -i -e 's/def privd : Nat := 0/def privd : Nat := let unusedLintVar := 0; 0/' Rebuild/Basic.lean
+test_unchanged


### PR DESCRIPTION
This PR changes the level at which `logLintExt` data is persisted to `server`. Previously, it was all persisted at `public` level, thus causing negative performance regression. 