### PR TITLE
feat: grind propagators that evaluate BitVec operations on literals

### DIFF
--- a/src/Init/Grind/Lemmas.lean
+++ b/src/Init/Grind/Lemmas.lean
@@ -7,6 +7,7 @@ module
 prelude
 public import Init.Grind.Ring.Basic
 public import Init.NotationExtra
+public import Init.GetElem
 import Init.ByCases
 import Init.Classical
 import Init.Data.Bool
@@ -192,6 +193,26 @@ theorem Nat.xor_congr {a b : Nat} {k₁ k₂ k : Nat} (h₁ : a = k₁) (h₂ : 
 theorem Nat.or_congr {a b : Nat} {k₁ k₂ k : Nat} (h₁ : a = k₁) (h₂ : b = k₂) : k == k₁ ||| k₂ → a ||| b = k := by simp_all
 theorem Nat.shiftLeft_congr {a b : Nat} {k₁ k₂ k : Nat} (h₁ : a = k₁) (h₂ : b = k₂) : k == k₁ <<< k₂ → a <<< b = k := by simp_all
 theorem Nat.shiftRight_congr {a b : Nat} {k₁ k₂ k : Nat} (h₁ : a = k₁) (h₂ : b = k₂) : k == k₁ >>> k₂ → a >>> b = k := by simp_all
+
+/-! Literal evaluation propagators -/
+
+theorem eval_congr₁ {α : Sort u} {β : Sort v} {f : α → β} {a a' : α} {b : β}
+    (h₁ : a = a') (h₂ : f a' = b) : f a = b := by
+  subst h₁; exact h₂
+
+theorem eval_congr₂ {α₁ : Sort u} {α₂ : Sort v} {β : Sort w} {f : α₁ → α₂ → β}
+    {a₁ a₁' : α₁} {a₂ a₂' : α₂} {b : β}
+    (h₁ : a₁ = a₁') (h₂ : a₂ = a₂') (h₃ : f a₁' a₂' = b) : f a₁ a₂ = b := by
+  subst h₁; subst h₂; exact h₃
+
+/-
+**Note**: the universe parameter order in the following theorem must match
+`GetElem.getElem` since the propagators reuse its level list.
+-/
+theorem getElem_congr {coll : Type u} {idx : Type v} {elem : Type w} {valid : coll → idx → Prop}
+    [GetElem coll idx elem valid] {as bs : coll} {i j : idx} {w₁ : valid as i} {a : elem}
+    (h₁ : as = bs) (h₂ : i = j) (h₃ : ∀ w₂ : valid bs j, bs[j]'w₂ = a) : as[i]'w₁ = a := by
+  subst h₁; subst h₂; exact h₃ w₁
 
 /-! Semiring propagators -/
 

--- a/src/Lean/Meta/Tactic/Grind.lean
+++ b/src/Lean/Meta/Tactic/Grind.lean
@@ -16,6 +16,7 @@ public import Lean.Meta.Tactic.Grind.MarkNestedSubsingletons
 public import Lean.Meta.Tactic.Grind.Inv
 public import Lean.Meta.Tactic.Grind.Proof
 public import Lean.Meta.Tactic.Grind.Propagate
+public import Lean.Meta.Tactic.Grind.BitVec
 public import Lean.Meta.Tactic.Grind.PP
 public import Lean.Meta.Tactic.Grind.Simp
 public import Lean.Meta.Tactic.Grind.Ctor

--- a/src/Lean/Meta/Tactic/Grind/AC/Util.lean
+++ b/src/Lean/Meta/Tactic/Grind/AC/Util.lean
@@ -147,6 +147,21 @@ where
       let identityType := mkApp3 (mkConst ``Std.LawfulIdentity [u]) α op neutral
       if let some identityInst ← synthInstance? identityType then
         let neutral ← instantiateExprMVars neutral
+        /-
+        **Note**: `Std.LawfulIdentity` instances may spell the identity element in a form
+        that is not in `grind` normal form. Example: the `BitVec` instances use `0#n`
+        (i.e., `BitVec.ofNat n 0`), but the `grind` normalizer represents bit-vector literals
+        using `OfNat.ofNat`. Internalizing a non-canonical literal violates the invariant that
+        interpreted nodes are canonical: `grind` assumes distinct interpreted nodes denote
+        distinct values (see `valueInconsistency` at `addEqStep`). We cannot `simp`-normalize
+        `neutral` here: the result would be only propositionally equal to the identity element
+        fixed by `identityInst`, and we need a definitionally equal term.
+        We hardcode the bit-vector case for now. **TODO**: fix this properly in a separate commit.
+        -/
+        let neutral ← if let some ⟨w, v⟩ ← getBitVecValue? neutral then
+          mkNumeral (mkApp (mkConst ``BitVec) (mkNatLit w)) v.toNat
+        else
+          pure neutral
         let neutral ← preprocessLight neutral
         internalize neutral (← getGeneration op)
         pure (some identityInst, some neutral)

--- a/src/Lean/Meta/Tactic/Grind/BitVec.lean
+++ b/src/Lean/Meta/Tactic/Grind/BitVec.lean
@@ -1,0 +1,250 @@
+/-
+Copyright (c) 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+module
+prelude
+import Init.Grind
+import Init.Data.BitVec.Basic
+import Lean.Meta.LitValues
+import Lean.ToExpr
+import Lean.Meta.Tactic.Grind.Simp
+public import Lean.Meta.Tactic.Grind.PropagatorAttr
+public section
+namespace Lean.Meta.Grind
+
+/-!
+Propagators that evaluate structural `BitVec` operations on literals.
+
+The arguments are matched modulo equalities: given `x = 42#64`, the propagator for
+`extractLsb'` asserts `BitVec.extractLsb' 63 32 x = 0#32`. The proofs combine the generic
+congruence theorems `Grind.eval_congr₁`/`Grind.eval_congr₂` with an `Eq.refl` hypothesis
+discharged by kernel reduction. Arguments that occur in the *result type* (widths, extract
+bounds, `replicate` counts) must be syntactic literals; the remaining arguments only need to
+be equal to literals.
+
+We deliberately skip:
+- arithmetic operations and comparisons (`+`, `*`, `-`, `/`, `%`, division variants, `<`, `≤`):
+  they are handled by `cutsat`;
+- `setWidth'` and `shiftLeftZeroExtend` (rare, and their argument order does not fit the
+  suffix-application scheme used by the congruence theorems);
+- `BitVec.cast`, `ofFin`/`toFin`.
+-/
+
+private def mkBVLit (n : Nat) (v : BitVec n) : GoalM Expr := do
+  -- **Note**: `grind` uses `OfNat.ofNat` instead of `BitVec.ofNat` representation.
+  shareCommon (← mkNumeral (mkApp (mkConst ``BitVec) (mkNatLit n)) v.toNat)
+
+private def mkBoolLit (b : Bool) : GoalM Expr :=
+  shareCommon (toExpr b)
+
+/-- Returns the `BitVec` literal in the equivalence class root of `x`, if any. -/
+private def getBV? (x : Expr) : GoalM (Option ((n : Nat) × BitVec n)) := do
+  getBitVecValue? (← getRoot x)
+
+/--
+Given `e = f a` where the last argument `a` is matched modulo equalities, pushes `e = b`
+where `b` is the literal computed by `eval` from `a`'s equivalence class root.
+-/
+private def unaryOp (e : Expr) (eval : Expr → GoalM (Option Expr)) : GoalM Unit := do
+  let a := e.appArg!
+  let aRoot ← getRoot a
+  let some b ← eval aRoot | return ()
+  internalize b 0
+  let eType ← inferType e
+  let proof := mkApp6 (mkConst ``Grind.eval_congr₁ [1, 1]) (← inferType a) eType e.appFn! a aRoot b
+  let proof := mkApp2 proof (← mkEqProof a aRoot) (mkApp2 (mkConst ``Eq.refl [1]) eType b)
+  pushEq e b proof
+
+/--
+Given `e = f a₁ a₂` where the last two arguments are matched modulo equalities, pushes
+`e = b` where `b` is the literal computed by `eval` from the equivalence class roots.
+-/
+private def binOp (e : Expr) (eval : Expr → Expr → GoalM (Option Expr)) : GoalM Unit := do
+  let a₂ := e.appArg!
+  let a₁ := e.appFn!.appArg!
+  let r₁ ← getRoot a₁
+  let r₂ ← getRoot a₂
+  let some b ← eval r₁ r₂ | return ()
+  internalize b 0
+  let eType ← inferType e
+  let proof := mkApp9 (mkConst ``Grind.eval_congr₂ [1, 1, 1]) (← inferType a₁) (← inferType a₂) eType e.appFn!.appFn! a₁ r₁ a₂ r₂ b
+  let proof := mkApp3 proof (← mkEqProof a₁ r₁) (← mkEqProof a₂ r₂) (mkApp2 (mkConst ``Eq.refl [1]) eType b)
+  pushEq e b proof
+
+/-- Table entry for `op : BitVec n → BitVec n` with head `declName` and the given arity. -/
+@[inline] private def unaryBV (declName : Name) (arity : Nat)
+    (op : {n : Nat} → BitVec n → BitVec n) (e : Expr) : GoalM Unit := do
+  unless e.isAppOfArity declName arity do return ()
+  unaryOp e fun r => do
+    let some ⟨n, v⟩ ← getBitVecValue? r | return none
+    some <$> mkBVLit n (op v)
+
+/-- Table entry for `op : (m : Nat) → BitVec n → BitVec m` where `m` is argument 1. -/
+@[inline] private def extendBV (declName : Name)
+    (op : {n : Nat} → (m : Nat) → BitVec n → BitVec m) (e : Expr) : GoalM Unit := do
+  unless e.isAppOfArity declName 3 do return ()
+  let some m ← getNatValue? (e.getArg! 1) | return ()  -- occurs in the result type
+  unaryOp e fun r => do
+    let some ⟨_, v⟩ ← getBitVecValue? r | return none
+    some <$> mkBVLit m (op m v)
+
+/-- Table entry for extract-like `op : (i j : Nat) → BitVec n → BitVec m`. -/
+@[inline] private def extractBV (declName : Name)
+    (op : {n : Nat} → (i j : Nat) → BitVec n → (m : Nat) × BitVec m) (e : Expr) : GoalM Unit := do
+  unless e.isAppOfArity declName 4 do return ()
+  let some i ← getNatValue? (e.getArg! 1) | return ()  -- occurs in the result type
+  let some j ← getNatValue? (e.getArg! 2) | return ()
+  unaryOp e fun r => do
+    let some ⟨_, v⟩ ← getBitVecValue? r | return none
+    let ⟨m, w⟩ := op i j v
+    some <$> mkBVLit m w
+
+/-- Table entry for `op : BitVec n → BitVec n → BitVec n` (e.g. `&&&`) with a `BitVec` type guard. -/
+@[inline] private def binBV (declName : Name) (arity : Nat)
+    (op : {n : Nat} → BitVec n → BitVec n → BitVec n) (e : Expr) : GoalM Unit := do
+  unless e.isAppOfArity declName arity do return ()
+  binOp e fun r₁ r₂ => do
+    let some ⟨n₁, v₁⟩ ← getBitVecValue? r₁ | return none
+    let some ⟨n₂, v₂⟩ ← getBitVecValue? r₂ | return none
+    if h : n₁ = n₂ then
+      some <$> mkBVLit n₁ (op v₁ (h ▸ v₂))
+    else
+      return none
+
+/-- Table entry for `op : BitVec n → Nat → BitVec n` (shifts, rotations). -/
+@[inline] private def shiftBV (declName : Name) (arity : Nat)
+    (op : {n : Nat} → BitVec n → Nat → BitVec n) (e : Expr) : GoalM Unit := do
+  unless e.isAppOfArity declName arity do return ()
+  binOp e fun r₁ r₂ => do
+    let some ⟨n, v⟩ ← getBitVecValue? r₁ | return none
+    let some i ← getNatValue? r₂ | return none
+    some <$> mkBVLit n (op v i)
+
+/-- Table entry for `op : BitVec n → Nat → Bool` (`getLsbD`, `getMsbD`). -/
+@[inline] private def getBitBV (declName : Name)
+    (op : {n : Nat} → BitVec n → Nat → Bool) (e : Expr) : GoalM Unit := do
+  unless e.isAppOfArity declName 3 do return ()
+  binOp e fun r₁ r₂ => do
+    let some ⟨_, v⟩ ← getBitVecValue? r₁ | return none
+    let some i ← getNatValue? r₂ | return none
+    some <$> mkBoolLit (op v i)
+
+/-! The table. -/
+
+builtin_grind_propagator propagateBVNot ↑Complement.complement :=
+  unaryBV ``Complement.complement 3 (~~~ ·)
+builtin_grind_propagator propagateBVClz ↑BitVec.clz := unaryBV ``BitVec.clz 2 BitVec.clz
+builtin_grind_propagator propagateBVCpop ↑BitVec.cpop := unaryBV ``BitVec.cpop 2 BitVec.cpop
+
+builtin_grind_propagator propagateBVMsb ↑BitVec.msb := fun e => do
+  unless e.isAppOfArity ``BitVec.msb 2 do return ()
+  unaryOp e fun r => do
+    let some ⟨_, v⟩ ← getBitVecValue? r | return none
+    some <$> mkBoolLit v.msb
+
+builtin_grind_propagator propagateBVToNat ↑BitVec.toNat := fun e => do
+  unless e.isAppOfArity ``BitVec.toNat 2 do return ()
+  unaryOp e fun r => do
+    let some ⟨_, v⟩ ← getBitVecValue? r | return none
+    some <$> shareCommon (mkNatLit v.toNat)
+
+builtin_grind_propagator propagateBVToInt ↑BitVec.toInt := fun e => do
+  unless e.isAppOfArity ``BitVec.toInt 2 do return ()
+  unaryOp e fun r => do
+    let some ⟨_, v⟩ ← getBitVecValue? r | return none
+    some <$> shareCommon (mkIntLit v.toInt)
+
+builtin_grind_propagator propagateBVOfNat ↑BitVec.ofNat := fun e => do
+  unless e.isAppOfArity ``BitVec.ofNat 2 do return ()
+  let some w ← getNatValue? (e.getArg! 0) | return ()  -- occurs in the result type
+  unaryOp e fun r => do
+    let some n ← getNatValue? r | return none
+    some <$> mkBVLit w (BitVec.ofNat w n)
+
+builtin_grind_propagator propagateBVOfInt ↑BitVec.ofInt := fun e => do
+  unless e.isAppOfArity ``BitVec.ofInt 2 do return ()
+  let some w ← getNatValue? (e.getArg! 0) | return ()  -- occurs in the result type
+  unaryOp e fun r => do
+    let some i ← getIntValue? r | return none
+    some <$> mkBVLit w (BitVec.ofInt w i)
+
+builtin_grind_propagator propagateBVSetWidth ↑BitVec.setWidth := extendBV ``BitVec.setWidth BitVec.setWidth
+builtin_grind_propagator propagateBVSignExtend ↑BitVec.signExtend := extendBV ``BitVec.signExtend BitVec.signExtend
+
+builtin_grind_propagator propagateBVExtractLsb' ↑BitVec.extractLsb' :=
+  extractBV ``BitVec.extractLsb' fun start len v => ⟨len, v.extractLsb' start len⟩
+builtin_grind_propagator propagateBVExtractLsb ↑BitVec.extractLsb :=
+  extractBV ``BitVec.extractLsb fun hi lo v => ⟨hi - lo + 1, v.extractLsb hi lo⟩
+
+builtin_grind_propagator propagateBVReplicate ↑BitVec.replicate := fun e => do
+  unless e.isAppOfArity ``BitVec.replicate 3 do return ()
+  let some i ← getNatValue? (e.getArg! 1) | return ()  -- occurs in the result type
+  unaryOp e fun r => do
+    let some ⟨n, v⟩ ← getBitVecValue? r | return none
+    some <$> mkBVLit (n * i) (v.replicate i)
+
+builtin_grind_propagator propagateBVAnd ↑HAnd.hAnd := binBV ``HAnd.hAnd 6 (· &&& ·)
+builtin_grind_propagator propagateBVOr ↑HOr.hOr := binBV ``HOr.hOr 6 (· ||| ·)
+builtin_grind_propagator propagateBVXor ↑HXor.hXor := binBV ``HXor.hXor 6 (· ^^^ ·)
+
+builtin_grind_propagator propagateBVAppend ↑HAppend.hAppend := fun e => do
+  unless e.isAppOfArity ``HAppend.hAppend 6 do return ()
+  unless (← inferType e).isAppOf ``BitVec do return ()
+  binOp e fun r₁ r₂ => do
+    let some ⟨n₁, v₁⟩ ← getBitVecValue? r₁ | return none
+    let some ⟨n₂, v₂⟩ ← getBitVecValue? r₂ | return none
+    some <$> mkBVLit (n₁ + n₂) (v₁ ++ v₂)
+
+builtin_grind_propagator propagateBVShiftLeft ↑BitVec.shiftLeft :=
+  shiftBV ``BitVec.shiftLeft 3 BitVec.shiftLeft
+builtin_grind_propagator propagateBVUShiftRight ↑BitVec.ushiftRight :=
+  shiftBV ``BitVec.ushiftRight 3 BitVec.ushiftRight
+builtin_grind_propagator propagateBVSShiftRight ↑BitVec.sshiftRight :=
+  shiftBV ``BitVec.sshiftRight 3 BitVec.sshiftRight
+builtin_grind_propagator propagateBVRotateLeft ↑BitVec.rotateLeft :=
+  shiftBV ``BitVec.rotateLeft 3 BitVec.rotateLeft
+builtin_grind_propagator propagateBVRotateRight ↑BitVec.rotateRight :=
+  shiftBV ``BitVec.rotateRight 3 BitVec.rotateRight
+
+/-- `x <<< i` and `x >>> i` where the shift amount is a `Nat` or a `BitVec`. -/
+@[inline] private def hShiftBV (declName : Name)
+    (op : {n : Nat} → BitVec n → Nat → BitVec n) (e : Expr) : GoalM Unit := do
+  unless e.isAppOfArity declName 6 do return ()
+  binOp e fun r₁ r₂ => do
+    let some ⟨n, v⟩ ← getBitVecValue? r₁ | return none
+    if let some i ← getNatValue? r₂ then
+      some <$> mkBVLit n (op v i)
+    else if let some ⟨_, w⟩ ← getBitVecValue? r₂ then
+      some <$> mkBVLit n (op v w.toNat)
+    else
+      return none
+
+builtin_grind_propagator propagateBVHShiftLeft ↑HShiftLeft.hShiftLeft :=
+  hShiftBV ``HShiftLeft.hShiftLeft (· <<< ·)
+builtin_grind_propagator propagateBVHShiftRight ↑HShiftRight.hShiftRight :=
+  hShiftBV ``HShiftRight.hShiftRight (· >>> ·)
+
+builtin_grind_propagator propagateBVGetLsbD ↑BitVec.getLsbD := getBitBV ``BitVec.getLsbD BitVec.getLsbD
+builtin_grind_propagator propagateBVGetMsbD ↑BitVec.getMsbD := getBitBV ``BitVec.getMsbD BitVec.getMsbD
+
+builtin_grind_propagator propagateBVGetElem ↑GetElem.getElem := fun e => do
+  let_expr f@GetElem.getElem coll idx elem valid inst x i w := e | return ()
+  unless inst.isAppOf ``BitVec.instGetElemNatBoolLt do return ()
+  let iRoot ← getRoot i
+  let some iv ← getNatValue? iRoot | return ()
+  let xRoot ← getRoot x
+  let some ⟨n, v⟩ ← getBitVecValue? xRoot | return ()
+  unless iv < n do return ()
+  let b ← mkBoolLit (v.getLsbD iv)
+  internalize b 0
+  -- `(fun w₂ : valid xRoot iRoot => Eq.refl b) : ∀ w₂, xRoot[iRoot]'w₂ = b` by kernel reduction
+  let h₃ := mkLambda `w .default ((mkApp2 valid xRoot iRoot).headBeta)
+    (mkApp2 (mkConst ``Eq.refl [1]) elem b)
+  let proof := mkApp6 (mkConst ``Grind.getElem_congr f.constLevels!) coll idx elem valid inst x
+  let proof := mkApp5 proof xRoot i iRoot w b
+  let proof := mkApp3 proof (← mkEqProof x xRoot) (← mkEqProof i iRoot) h₃
+  pushEq e b proof
+
+end Lean.Meta.Grind

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/BitVec.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/BitVec.lean
@@ -329,6 +329,14 @@ builtin_dsimproc [simp, seval] reduceExtractLsb' (extractLsb' _ _ _) := fun e =>
   let some len ← Nat.fromExpr? len | return .continue
   return .done <| (← toExpr' (v.value.extractLsb' start len))
 
+/-- Simplification procedure for `extractLsb` on `BitVec`s. -/
+builtin_dsimproc [simp, seval] reduceExtractLsb (extractLsb _ _ _) := fun e => do
+  let_expr extractLsb _ hi lo v ← e | return .continue
+  let some v ← fromExpr? v | return .continue
+  let some hi ← Nat.fromExpr? hi | return .continue
+  let some lo ← Nat.fromExpr? lo | return .continue
+  return .done <| (← toExpr' (v.value.extractLsb hi lo))
+
 /-- Simplification procedure for `replicate` on `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceReplicate (replicate _ _) := fun e => do
   let_expr replicate _ i v ← e | return .continue

--- a/tests/elab/grind_bitvec_lit_eval.lean
+++ b/tests/elab/grind_bitvec_lit_eval.lean
@@ -1,0 +1,94 @@
+module
+
+/-!
+Tests for `grind` evaluation of structural `BitVec` operations on literals, including modulo
+equalities: given `x = 42#64`, `grind` propagates values for `extractLsb'`, `setWidth`,
+bitwise operations, shifts, bit accessors, `toNat`, etc. applied to `x`. Arithmetic operations
+and comparisons are covered by `cutsat` and are included here as regression tests.
+-/
+
+/-! Henrik's examples (Zulip): ground and modulo-equality extract operations. -/
+
+example : BitVec.extractLsb 63 32 42#64 = 0#32 := by grind
+example : BitVec.extractLsb' 63 32 42#64 = 0#32 := by grind
+example {x : BitVec 64} (h : x = 42#64) : BitVec.extractLsb 63 32 x = 0#32 := by grind
+example {x : BitVec 64} (h : x = 42#64) : BitVec.extractLsb' 63 32 x = 0#32 := by grind
+example : BitVec.extractLsb 63 32 (0#64 + 42#64) = 0#32 := by grind
+example : BitVec.extractLsb' 63 32 (0#64 + 42#64) = 0#32 := by grind
+example {x : BitVec 64} (h : x = 0#64 + 42#64) : BitVec.extractLsb 63 32 x = 0#32 := by grind
+example {x : BitVec 64} (h : x = 0#64 + 42#64) : BitVec.extractLsb' 63 32 x = 0#32 := by grind
+
+
+/-! Arithmetic and comparisons: handled by `cutsat`, not the propagators. -/
+
+example {x : BitVec 64} (h : x = 42#64) : x + 1#64 = 43#64 := by grind
+example {x : BitVec 64} (h : x = 42#64) : 2#64 * x = 84#64 := by grind
+example {x : BitVec 64} (h : x = 42#64) : x < 43#64 := by grind
+example {x : BitVec 64} (h : x = 42#64) : x ≤ 42#64 := by grind
+
+/-! Conversions. -/
+
+example {x : BitVec 64} (h : x = 42#64) : x.toNat = 42 := by grind
+example {x : BitVec 8} (h : x = 255#8) : x.toInt = -1 := by grind
+example {n : Nat} (h : n = 300) : BitVec.ofNat 8 n = 44#8 := by grind
+example {i : Int} (h : i = -1) : BitVec.ofInt 8 i = 255#8 := by grind
+
+/-! Bitwise operations. -/
+
+example {x : BitVec 64} (h : x = 42#64) : x &&& 15#64 = 10#64 := by grind
+example {x : BitVec 64} (h : x = 42#64) : x ||| 1#64 = 43#64 := by grind
+example {x : BitVec 64} (h : x = 42#64) : x ^^^ 42#64 = 0#64 := by grind
+example {x : BitVec 8} (h : x = 0#8) : ~~~x = 255#8 := by grind
+example {x y : BitVec 64} (h₁ : x = 42#64) (h₂ : y = 15#64) : x &&& y = 10#64 := by grind
+
+/-! Shifts and rotations. -/
+
+example {x : BitVec 64} (h : x = 42#64) : x >>> 1 = 21#64 := by grind
+example {x : BitVec 64} (h : x = 42#64) : x <<< 1 = 84#64 := by grind
+example {x : BitVec 64} (h : x = 42#64) : x >>> 1#64 = 21#64 := by grind
+example {x : BitVec 64} (h : x = 42#64) (i : Nat) (h' : i = 1) : x <<< i = 84#64 := by grind
+example {x : BitVec 8} (h : x = 129#8) : x.rotateLeft 1 = 3#8 := by grind
+example {x : BitVec 8} (h : x = 3#8) : x.rotateRight 1 = 129#8 := by grind
+
+/-! Bit accessors. -/
+
+example {x : BitVec 64} (h : x = 42#64) : x.getLsbD 1 = true := by grind
+example {x : BitVec 64} (h : x = 42#64) : x.getLsbD 0 = false := by grind
+example {x : BitVec 64} (h : x = 42#64) : x.getMsbD 0 = false := by grind
+example {x : BitVec 64} (h : x = 42#64) (h' : 1 < 64) : x[1] = true := by grind
+example {x : BitVec 8} (h : x = 255#8) : x.msb = true := by grind
+
+/-! Width changing operations. -/
+
+example {x : BitVec 64} (h : x = 42#64) : x.setWidth 32 = 42#32 := by grind
+example {x : BitVec 64} (h : x = 42#64) : BitVec.signExtend 128 x = 42#128 := by grind
+example {x : BitVec 8} (h : x = 255#8) : BitVec.signExtend 16 x = 65535#16 := by grind
+
+/-! Append and replicate. -/
+
+example {x : BitVec 64} (h : x = 42#64) : x ++ x = 0x000000000000002a000000000000002a#128 := by grind
+example {x : BitVec 8} (h : x = 1#8) : BitVec.replicate 2 x = 257#16 := by grind
+
+/-! Misc unary operations. -/
+
+example {x : BitVec 8} (h : x = 1#8) : x.clz = 7#8 := by grind
+example {x : BitVec 8} (h : x = 255#8) : x.cpop = 8#8 := by grind
+
+/-! Chained: the propagated value feeds further propagation. -/
+
+example {x : BitVec 64} {y : BitVec 32} (h₁ : x = 42#64) (h₂ : y = BitVec.extractLsb' 0 32 x) :
+    y &&& 2#32 = 2#32 := by grind
+
+/-! The index/argument being only *equal* to a literal. -/
+
+example {x : BitVec 64} (h : x = 42#64) (i : Nat) (hi : i = 1) : x.getLsbD i = true := by grind
+
+/-!
+Regression test: the `ofNat` propagator merges `BitVec.ofNat`-spelled literals (e.g. the
+`Std.LawfulIdentity` neutral elements internalized by the AC module) with canonical `OfNat`
+literals. This used to trigger a kernel error because the AC module internalized the neutral
+element of `|||` in a non-canonical form, violating the invariant that interpreted nodes
+are canonical.
+-/
+
+example (x y : BitVec 64) : (x ||| y) &&& x = x := by grind


### PR DESCRIPTION
This PR implements `grind` propagators that evaluate `BitVec` operations on literals

Example:
```lean
example : BitVec.extractLsb 63 32 42#64 = 0#32 := by grind
example : BitVec.extractLsb' 63 32 42#64 = 0#32 := by grind
example {x : BitVec 64} (h : x = 42#64) : BitVec.extractLsb 63 32 x = 0#32 := by grind
example {x : BitVec 64} (h : x = 42#64) : BitVec.extractLsb' 63 32 x = 0#32 := by grind
example : BitVec.extractLsb 63 32 (0#64 + 42#64) = 0#32 := by grind
example : BitVec.extractLsb' 63 32 (0#64 + 42#64) = 0#32 := by grind
example {x : BitVec 64} (h : x = 0#64 + 42#64) : BitVec.extractLsb 63 32 x = 0#32 := by grind
example {x : BitVec 64} (h : x = 0#64 + 42#64) : BitVec.extractLsb' 63 32 x = 0#32 := by grind
```