### PR TITLE
fix: show correct tactic state in whitespace between tactics without incrementality

### DIFF
--- a/src/Lean/Elab/Tactic/BuiltinTactic.lean
+++ b/src/Lean/Elab/Tactic/BuiltinTactic.lean
@@ -72,7 +72,9 @@ where
     -- compare (trimmed) `tac` for `finished`/`next` reuse, focus on remainder of script
     Term.withNarrowedTacticReuse (stx := stx) (fun stx => (stx[0].unsetTrailing, mkNullNode stx.getArgs[1...*])) fun stxs => do
       let some snap := (← readThe Term.Context).tacSnap?
-        | do evalTactic tac; goOdd stxs
+        -- NOTE: make sure to use `untrimmedTac` in this non-incremental case since there is no
+        -- reuse opportunity anyway and we skip the whitespace save below
+        | do evalTactic untrimmedTac; goOdd stxs
       let mut reusableResult? := none
       let mut oldNext? := none
       if let some old := snap.old? then

--- a/tests/server_interactive/plainGoal.lean
+++ b/tests/server_interactive/plainGoal.lean
@@ -158,3 +158,16 @@ example (f : Nat → Nat) (n : Nat) (hf : ∀ x, f x = x + 0 + 1) : f n + 0 = 1 
                                          --^ $/lean/plainGoal
 
 end
+
+-- #14394: no improper whitespace trimming in non-incremental blocks
+example {a : Nat} (ha : a = 3) : a ≤ 4 := (by
+  rw [ha]
+
+--^ $/lean/plainGoal
+  sorry)
+
+example {a : Nat} (ha : a = 3) : a ≤ 4 := by
+  rw [ha]
+
+--^ $/lean/plainGoal
+  sorry

--- a/tests/server_interactive/plainGoal.lean.out.expected
+++ b/tests/server_interactive/plainGoal.lean.out.expected
@@ -210,3 +210,11 @@ null
 {"textDocument": {"uri": "file:///plainGoal.lean"},
  "position": {"line": 153, "character": 43}}
 {"rendered": "no goals", "goals": []}
+{"textDocument": {"uri": "file:///plainGoal.lean"},
+ "position": {"line": 164, "character": 2}}
+{"rendered": "```lean\na : Nat\nha : a = 3\n⊢ 3 ≤ 4\n```",
+ "goals": ["a : Nat\nha : a = 3\n⊢ 3 ≤ 4"]}
+{"textDocument": {"uri": "file:///plainGoal.lean"},
+ "position": {"line": 170, "character": 2}}
+{"rendered": "```lean\na : Nat\nha : a = 3\n⊢ 3 ≤ 4\n```",
+ "goals": ["a : Nat\nha : a = 3\n⊢ 3 ≤ 4"]}


### PR DESCRIPTION
Regression introduced in #12662.

Closes #14394.