### PR TITLE
feat: make tactic `set_option` incremental

### DIFF
--- a/src/Lean/Elab/Tactic/BuiltinTactic.lean
+++ b/src/Lean/Elab/Tactic/BuiltinTactic.lean
@@ -205,12 +205,16 @@ private def getOptRotation (stx : Syntax) : Nat :=
   finally
     popScope
 
-@[builtin_tactic Parser.Tactic.set_option] def elabSetOption : Tactic := fun stx => do
+@[builtin_tactic Parser.Tactic.set_option, builtin_incremental]
+def elabSetOption : Tactic := fun stx => do
   let (options, decl) ← Elab.elabSetOption stx[1] stx[3]
   withRef stx[1] <| Elab.checkDeprecatedOption (stx[1].getId.eraseMacroScopes) decl
   withOptions (fun _ => options) do
     try
-      evalTactic stx[5]
+      -- disable incrementality for `diagnostics` as reuse would skip counter accumulation in
+      -- reused steps and thus under-report in `reportDiag` below
+      Term.withoutTacticIncrementality (stx[1].getId == `diagnostics) do
+        Term.withNarrowedArgTacticReuse (argIdx := 5) evalTactic stx
     finally
       if stx[1].getId == `diagnostics then
         reportDiag

--- a/tests/server_interactive/incrementalCombinator.lean
+++ b/tests/server_interactive/incrementalCombinator.lean
@@ -99,3 +99,22 @@ example (n : Nat) : n = n := by
   --^ sync
   --^ insert: "succ => sorry"
   --^ collectDiagnostics
+
+/-! `set_option ... in` should support incremental reuse in its body. -/
+-- RESET
+def setOption : True := by
+  set_option maxRecDepth 100 in
+  dbg_trace "so 0"
+  dbg_trace "so 1"
+  dbg_trace "so 2"
+               --^ sync
+               --^ insert: ".5"
+
+/-! Changing the option value should disable reuse in the body. -/
+-- RESET
+def setOptionValueChange : True := by
+  set_option maxRecDepth 100 in
+                          --^ sync
+                          --^ insert: "0"
+  dbg_trace "sov 0"
+  dbg_trace "sov 1"

--- a/tests/server_interactive/incrementalCombinator.lean.out.expected
+++ b/tests/server_interactive/incrementalCombinator.lean.out.expected
@@ -103,3 +103,11 @@ i 1.5
    "message": "declaration uses `sorry`",
    "fullRange":
    {"start": {"line": 1, "character": 0}, "end": {"line": 1, "character": 7}}}]}
+so 0
+so 1
+so 2
+so 2.5
+sov 0
+sov 1
+sov 0
+sov 1


### PR DESCRIPTION
This PR makes the `set_option ... in` tactic support incremental elaboration, so edits inside its tactic block reuse the results of unchanged leading tactics instead of re-running the whole block.