### PR TITLE
fix: `preprocessType` in `SymM` should not perform `zetaDelta` by default

### DIFF
--- a/src/Lean/Meta/Sym/ProofInstInfo.lean
+++ b/src/Lean/Meta/Sym/ProofInstInfo.lean
@@ -14,17 +14,17 @@ namespace Lean.Meta.Sym
 /--
 Preprocesses types that used for pattern matching and unification.
 -/
-public def preprocessType (type : Expr) (zetaReduceLHSOnly := false) : MetaM Expr := do
+public def preprocessType (type : Expr) (zetaReduceLHSOnly := false) (zetaDelta := false) : MetaM Expr := do
   let type ← Sym.unfoldReducible type
   let type ← Core.betaReduce type
   let type ← if zetaReduceLHSOnly then
     forallTelescope type fun xs body => do
       match_expr body with
-      | f@Eq α lhs rhs => mkForallFVars xs <| mkApp3 f α (← zetaReduce lhs) rhs
-      | f@Iff lhs rhs => mkForallFVars xs <| mkApp2 f (← zetaReduce lhs) rhs
-      | _ => zetaReduce type
+      | f@Eq α lhs rhs => mkForallFVars xs <| mkApp3 f α (← zetaReduce lhs (zetaDelta := zetaDelta)) rhs
+      | f@Iff lhs rhs => mkForallFVars xs <| mkApp2 f (← zetaReduce lhs (zetaDelta := zetaDelta)) rhs
+      | _ => zetaReduce type (zetaDelta := zetaDelta)
   else
-    zetaReduce type
+    zetaReduce type (zetaDelta := zetaDelta)
   etaReduceAll type
 
 /--

--- a/tests/elab/sym_preprocessType_zetaDelta.lean
+++ b/tests/elab/sym_preprocessType_zetaDelta.lean
@@ -1,0 +1,31 @@
+import Lean.Meta.Sym
+
+/-!
+`Sym.preprocessType` must not zeta-delta ambient let-bound fvars unless explicitly
+requested (`zetaDelta := false` by default). Regression test from Sebastian Graf's
+vcgen `+jp` report: a spec keyed on `@f joinParams`, where `f` is a join point
+introduced by `Sym.introN`, was re-keyed on the join-point body because
+`preprocessType` unfolded `f`.
+-/
+
+open Lean Meta Sym
+
+/-- info: [dependent ldecl: isNondep=false] preprocessType: f✝ 3 = f✝ 3 -/
+#guard_msgs in
+run_meta do
+  -- Build the goal `have f : Nat → Nat := fun x => x; True` by hand.
+  -- This is a nondep `letE`, i.e., what `+jp` join points look like in a goal.
+  let nat := mkConst ``Nat
+  let arrow : Expr := .forallE `_ nat nat .default
+  let val ← withLocalDeclD `x nat fun x => mkLambdaFVars #[x] x
+  let target := Expr.letE `f arrow val (mkConst ``True) (nondep := true)
+  let mvar ← mkFreshExprMVar target
+  SymM.run do
+    let .goal newDecls newGoal ← Sym.introN mvar.mvarId! 1 | return
+    -- `Sym.introN` leaves `f` as a dependent ldecl. `preprocessType`
+    -- must keep `f 3` as is; it used to zeta-delta it to `3`.
+    newGoal.withContext do
+      let f := mkFVar newDecls[0]!
+      let ty ← mkEq (mkApp f (mkNatLit 3)) (mkApp f (mkNatLit 3))
+      let nd := ((← getLCtx).find? newDecls[0]!).get!.isNondep
+      logInfo m!"[dependent ldecl: isNondep={nd}] preprocessType: {← Sym.preprocessType ty}"


### PR DESCRIPTION
This PR fixes `preprocessType` in `SymM`. It must not perform `zetaDelta` by default.
