### PR TITLE
fix: treat metavariables in the target as opaque atoms in `Sym.simp` rewriting

### DIFF
--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -274,6 +274,13 @@ structure UnifyM.Context where
   pattern   : Pattern
   unify     : Bool := true
   zetaDelta : Bool := true
+  /--
+  `mvarCounter` at the start of the match/unify operation. Metavariables with
+  `decl.index ≥ mvarCounterSaved` were created by this operation (for uncovered pattern
+  variables and instances); metavariables with a smaller index occur in the target term
+  and must be treated as opaque atoms when `unify := false`.
+  -/
+  mvarCounterSaved : Nat := 0
 
 structure UnifyM.State where
   eAssignment  : Array (Option Expr)   := #[]
@@ -1108,8 +1115,17 @@ def processPendingExpr (mvarsToCheckType : Array MVarId) : UnifyM Bool := do
   let args := (← get).args
   let unify := (← read).unify
   let zetaDelta := (← read).zetaDelta
+  -- **Note**: An arg can also be a metavariable *occurring in the target term* (bound to a
+  -- pattern variable). Those must not be assignable: assignments made here are discarded by
+  -- `withNewMCtxDepth` at `Theorem.rewrite`, and a match depending on them would be bogus.
+  -- Only metavariables created by this match (index ≥ `mvarCounterSaved`) are assignable.
+  let mvarCounterSaved := (← read).mvarCounterSaved
+  let mctx ← getMCtx
   let mvarsNew := if unify then #[] else args.filterMap fun
-    | .mvar mvarId => some mvarId
+    | .mvar mvarId =>
+      match mctx.findDecl? mvarId with
+      | some decl => if decl.index ≥ mvarCounterSaved then some mvarId else none
+      | none => none
     | _ => none
   DefEqM.run unify zetaDelta mvarsNew mvarsToCheckType do
     for (t, s) in ePending do
@@ -1128,7 +1144,8 @@ def processPending (mvarsToCheckType : Array MVarId) : UnifyM Bool := do
 abbrev UnifyM.run (pattern : Pattern) (unify : Bool) (zetaDelta : Bool) (k : UnifyM α) : SymM α := do
   let eAssignment := pattern.varTypes.map fun _ => none
   let uAssignment := pattern.levelParams.toArray.map fun _ => none
-  k { unify, zetaDelta, pattern } |>.run' { eAssignment, uAssignment }
+  let mvarCounterSaved := (← getMCtx).mvarCounter
+  k { unify, zetaDelta, pattern, mvarCounterSaved } |>.run' { eAssignment, uAssignment }
 
 public structure MatchUnifyResult where
   us : List Level
@@ -1164,8 +1181,10 @@ Returns `some result` if matching succeeds, where `result` contains:
 - `us`: Level assignments for the pattern's universe variables
 - `args`: Expression assignments for the pattern's bound variables
 
+Unassigned metavariables in `e` are treated as opaque atoms: a pattern variable can be
+bound to one, but it is never assigned. Use `unify?` to solve for metavariables in `e`.
+
 Matching fails if:
-- The term contains metavariables (use `unify?` instead)
 - Structural mismatch after reducible unfolding
 
 Instance arguments are synthesized (or assigned by unification). Any that cannot be resolved are

--- a/src/Lean/Meta/Sym/Simp/Rewrite.lean
+++ b/src/Lean/Meta/Sym/Simp/Rewrite.lean
@@ -37,6 +37,7 @@ public def Theorem.rewrite (thm : Theorem) (e : Expr) (d : Discharger := dischar
   Thus, we must ensure that all assigned variables have be instantiate.
   -/
   withNewMCtxDepth do
+  let mvarCounterSaved := (← getMCtx).mvarCounter
   if let some result ← thm.pattern.match? e then
     -- **Note**: Potential optimization: check whether pattern covers all variables.
     let mut args := result.args.toVector
@@ -53,16 +54,20 @@ public def Theorem.rewrite (thm : Theorem) (e : Expr) (d : Discharger := dischar
           args := args.set i arg
         else
           let decl ← mvarId.getDecl
-          match (← d decl.type) with
-          | .failed cd =>
-            isCD := isCD || cd
-            -- Failed to discharge hypothesis.
-            return mkRflResultCD isCD
-          | .solved val cd =>
-            isCD := isCD || cd
-            let val ← instantiateMVarsS val
-            mvarId.assign val
-            args := args.set i val
+          -- Metavariables created by `match?` (index ≥ `mvarCounterSaved`) stand for
+          -- hypotheses/instances not covered by the pattern and must be discharged.
+          -- Metavariables occurring in `e` itself are opaque atoms; leave them as-is.
+          if decl.index ≥ mvarCounterSaved then
+            match (← d decl.type) with
+            | .failed cd =>
+              isCD := isCD || cd
+              -- Failed to discharge hypothesis.
+              return mkRflResultCD isCD
+            | .solved val cd =>
+              isCD := isCD || cd
+              let val ← instantiateMVarsS val
+              mvarId.assign val
+              args := args.set i val
       else if arg.hasMVar then
         let arg ← instantiateMVarsS arg
         args := args.set i arg

--- a/tests/elab/sym_simp_mvar_target.lean
+++ b/tests/elab/sym_simp_mvar_target.lean
@@ -1,0 +1,61 @@
+import Lean
+set_option warn.sorry false
+
+/-!
+Tests for `Sym.simp` on target terms containing unassigned metavariables.
+Unassigned metavariables in the target must be treated as opaque atoms: a pattern
+variable can be bound to one, but the matcher must never assign it, and
+`Theorem.rewrite` must not confuse it with an undischarged hypothesis.
+-/
+
+open Lean Meta Sym Simp
+
+opaque p : (Nat → Prop) → Nat → Prop
+theorem p_apply (F : Nat → Prop) (x : Nat) : p F x = F x := sorry
+
+-- Rewriting fires on a target whose operand is an unassigned metavariable `?F`:
+-- the goal after `rotate_left` is `p ?F s = ?F s`.
+example (Q : Nat → Prop) (s : Nat) : ∃ F : Nat → Prop, (p F s) = (F s) := by
+  refine ⟨?_, ?_⟩
+  rotate_left
+  sym => simp [p_apply]
+  exact Q
+
+-- `Theorem.rewrite` on `p ?F s` steps to `?F s`, binding the pattern variable to the
+-- metavariable without treating its type as a side condition to discharge.
+/-- info: step: ?F s -/
+#guard_msgs in
+run_meta SymM.run do
+  let natProp := mkForall `x .default (mkConst ``Nat) (mkSort .zero)
+  withLocalDeclD `s (mkConst ``Nat) fun s => do
+    let F ← mkFreshExprMVar natProp (userName := `F)
+    let e ← shareCommon (mkApp2 (mkConst ``p) F s)
+    let thm ← mkTheoremFromDecl ``p_apply
+    let r ← SimpM.run' (thm.rewrite e)
+    match r with
+    | .step e' _ _ _ => logInfo m!"step: {e'}"
+    | _ => logInfo "rfl"
+
+-- A nonlinear pattern must NOT fire by unifying a target metavariable: `Nat.sub_self`
+-- on `?x - 5` would produce a step valid only under `?x := 5`, an assignment that is
+-- discarded by `withNewMCtxDepth`. The match must fail instead.
+/-- info: rfl -/
+#guard_msgs in
+run_meta SymM.run do
+  let x ← mkFreshExprMVar (mkConst ``Nat) (userName := `x)
+  let e ← shareCommon (← mkAppM ``HSub.hSub #[x, mkNatLit 5])
+  let thm ← mkTheoremFromDecl ``Nat.sub_self
+  let r ← SimpM.run' (thm.rewrite e)
+  match r with
+  | .step e' _ _ _ => logInfo m!"step: {e'}"
+  | _ => logInfo "rfl"
+
+-- The metavariable must remain unassigned after a failed nonlinear match attempt.
+/-- info: assigned: false -/
+#guard_msgs in
+run_meta SymM.run do
+  let x ← mkFreshExprMVar (mkConst ``Nat) (userName := `x)
+  let e ← shareCommon (← mkAppM ``HSub.hSub #[x, mkNatLit 5])
+  let thm ← mkTheoremFromDecl ``Nat.sub_self
+  discard <| SimpM.run' (thm.rewrite e)
+  logInfo m!"assigned: {← x.mvarId!.isAssigned}"


### PR DESCRIPTION
This PR fixes `Sym.simp` failing to rewrite terms containing unassigned metavariables, and prevents the matcher from unsoundly unifying such metavariables when matching nonlinear patterns.

`Theorem.rewrite` classified every unassigned metavariable in the argument list as an undischarged hypothesis, so a pattern variable bound to a metavariable occurring in the target caused the rewrite to bail out (reported by Sebastian Graf with the MWE below). Worse, `processPendingExpr` included target metavariables in `mvarsNew`, so a nonlinear pattern such as `n - n = 0` could fire on `?x - 5` by assigning `?x := 5` — an assignment silently discarded by `withNewMCtxDepth`, yielding a rewrite step that is not valid for the original term. Both sites now discriminate metavariables created during the match from metavariables occurring in the target using a `mvarCounter` snapshot: fresh ones are discharged as hypotheses or assigned during unification as before, while target metavariables are treated as opaque atoms that pattern variables may be bound to but that are never assigned.

MWE that failed with ```Sym.simp` made no progress`` and now succeeds:

```lean
import Std.Internal.Do.WP
open Lean.Order

example (Q : Nat → Prop) (s : Nat) : ∃ F : Nat → Prop, ((F ⇨ Q) s) = (F s ⇨ Q s) := by
  refine ⟨?_, ?_⟩
  rotate_left
  sym => simp [himp_apply]
  exact Q
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)