### PR TITLE
feat: improve support for offsets in `SymM` matcher/unifier

### DIFF
--- a/src/Lean/Meta/Sym/Offset.lean
+++ b/src/Lean/Meta/Sym/Offset.lean
@@ -33,6 +33,28 @@ def Offset.inc : Offset → Nat → Offset
   | .num k,   k' => .num (k+k')
   | .add e k, k' => .add e (k+k')
 
+-- **Note**: This function assumes `e` is a `Nat`, and instances were not overloaded.
+private partial def evalNat? (e : Expr) : OptionT Id Nat :=
+  match e with
+  | .lit (.natVal n)     => some n
+  | .mdata _ e           => evalNat? e
+  | .const ``Nat.zero .. => some 0
+  | .app ..              => visit e
+  | .mvar ..             => visit e
+  | _                    => failure
+where
+  visit (e : Expr) : Option Nat :=
+    match_expr e with
+    | OfNat.ofNat _ n _ => evalNat? n
+    | Nat.succ a => return (← evalNat? a) + 1
+    | HAdd.hAdd _ _ _ _ a b => return (← evalNat? a) + (← evalNat? b)
+    | HSub.hSub _ _ _ _ a b => return (← evalNat? a) - (← evalNat? b)
+    | HMul.hMul _ _ _ _ a b => return (← evalNat? a) * (← evalNat? b)
+    | HDiv.hDiv _ _ _ _ a b => return (← evalNat? a) / (← evalNat? b)
+    | HMod.hMod _ _ _ _ a b => return (← evalNat? a) % (← evalNat? b)
+    -- **Note**: no support for pow to ensure overflow does not happen.
+    | _ => failure
+
 /--
 Returns `some offset` if `e` is an offset term. That is, it is of the form
 - `Nat.succ a`, OR
@@ -46,7 +68,7 @@ partial def isOffset? (e : Expr) : OptionT Id Offset :=
     return get a |>.inc 1
   | HAdd.hAdd α _ _ _ a b => do
     guard (α.isConstOf ``Nat)
-    let n ← getNatValue? b
+    let n ← evalNat? b
     return get a |>.inc n
   | _ => failure
 where
@@ -58,15 +80,14 @@ def isOffset?' (declName : Name) (p : Expr) : OptionT Id Offset := do
   guard (declName == ``Nat.succ || declName == ``HAdd.hAdd)
   isOffset? p
 
+private def isNatType (e : Expr) : Bool :=
+  e.isConstOf ``Nat
+
 /--  Returns `true` if `e` is an offset term.-/
 partial def isOffset (e : Expr) : Bool :=
   match_expr e with
   | Nat.succ _ => true
-  | HAdd.hAdd α _ _ _ _ b =>
-    α.isConstOf ``Nat &&
-    match_expr b with
-    | OfNat.ofNat _ n _ => (n matches .lit (.natVal _))
-    | _ => false
+  | HAdd.hAdd α _ _ _ _ b => isNatType α && (evalNat? b).isSome
   | _ => false
 
 /-- Variant of `isOffset?` that first checks if `declName` is `Nat.succ` or `HAdd.hAdd`. -/
@@ -89,5 +110,22 @@ partial def toOffset (e : Expr) : Offset :=
     let .lit (.natVal n) := n | .add e 0
     .num n
   | _ => .add e 0
+
+private def isNatExpr (e : Expr) : Bool :=
+  match_expr e with
+  | OfNat.ofNat α _ _ => isNatType α
+  | Nat.succ _ => true
+  | HAdd.hAdd _ _ α _ _ _ => isNatType α
+  | HSub.hSub _ _ α _ _ _ => isNatType α
+  | HMul.hMul _ _ α _ _ _ => isNatType α
+  | HDiv.hDiv _ _ α _ _ _ => isNatType α
+  | HMod.hMod _ _ α _ _ _ => isNatType α
+  | _ => false
+
+def isNatValue? (e : Expr) : Option Nat :=
+  if isNatExpr e then
+    evalNat? e
+  else
+    none
 
 end Lean.Meta.Sym

--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -520,7 +520,7 @@ Examples:
 def isQuasiOffsetCnstr (p : Expr) (e : Expr) : Bool :=
   match_expr p with
   | HAdd.hAdd _ _ _ _ _ k =>
-    k.hasLooseBVars && ((getNatValue? e).isSome || (isOffset? e).isSome)
+    k.hasLooseBVars && ((isNatValue? e).isSome || (isOffset? e).isSome)
   | _ => false
 
 partial def process (p : Expr) (e : Expr) : UnifyM Bool := do

--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -507,6 +507,22 @@ def isAssignedMVar (e : Expr) : MetaM Bool :=
   | .mvar mvarId => mvarId.isAssigned
   | _            => return false
 
+/--
+Returns `true` if the mismatched constraint `p =?= e` should be postponed because it may
+become solvable after other arguments assign the pattern variables in `p`. This is the case
+when `p` is `t + k` with pattern variables in `k`, and `e` is a numeral or an offset.
+
+Examples:
+- `3 + (1 + #1) =?= 5`
+- `#1 + #2 =?= 4`
+- `(#1 + 1) + #2 =?= t + 3`
+-/
+def isQuasiOffsetCnstr (p : Expr) (e : Expr) : Bool :=
+  match_expr p with
+  | HAdd.hAdd _ _ _ _ _ k =>
+    k.hasLooseBVars && ((getNatValue? e).isSome || (isOffset? e).isSome)
+  | _ => false
+
 partial def process (p : Expr) (e : Expr) : UnifyM Bool := do
   -- A pattern subterm internalized into the same table as the target shares its pointer, so a
   -- pointer match is a closed term equal to the target with no variables left to bind.
@@ -588,6 +604,10 @@ where
       return true
     else if let some p' := isOffset?' declName p then
       processOffset p' (toOffset e)
+    else if isQuasiOffsetCnstr p e then
+      -- Postpone: constraint may become an offset one after pattern variables are assigned.
+      pushPending p e
+      return true
     else if let some e' := isOffset? e then
       processOffset (toOffset p) e'
     else

--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -951,6 +951,47 @@ def isDefEqApp (tFn : Expr) (t : Expr) (s : Expr) (_ : tFn = t.getAppFn) : DefEq
   let numArgs := t.getAppNumArgs
   isDefEqAppWithInfo t s (numArgs - 1) info
 
+/--
+Structural counterpart of `Meta.isDefEqOffset`: solves `Nat` offset/numeral constraints such as
+`8 + 8 =?= 16`, `3 + (1 + 1) =?= 5`, and `?m + 1 =?= 16` using `isNatValue?` and `isOffset?`
+instead of general reduction. Constraints of this form reach `isDefEqMain` when `process`
+postpones a quasi-offset constraint (see `isQuasiOffsetCnstr`) and it is later checked with the
+pattern variables instantiated.
+
+Returns `.undef` if the constraint is not about `Nat` offsets/numerals; a `.false` result is
+definitive because `Sym` assumes canonical forms.
+-/
+def isDefEqOffset (t s : Expr) : DefEqM LBool := do
+  match isNatValue? t, isNatValue? s with
+  | some v₁, some v₂ =>
+    return if v₁ == v₂ then .true else .false
+  | some v₁, none =>
+    -- `v₁ =?= s' + k₂`
+    let some (.add s' k₂) := isOffset? s | return .undef
+    if k₂ ≤ v₁ then
+      toLBoolM <| isDefEqMain (← share (mkNatLit (v₁ - k₂))) s'
+    else
+      return .false
+  | none, some v₂ =>
+    -- `t' + k₁ =?= v₂`
+    let some (.add t' k₁) := isOffset? t | return .undef
+    if k₁ ≤ v₂ then
+      toLBoolM <| isDefEqMain t' (← share (mkNatLit (v₂ - k₁)))
+    else
+      return .false
+  | none, none =>
+    -- `t' + k₁ =?= s' + k₂`
+    let some (.add t' k₁) := isOffset? t | return .undef
+    let some (.add s' k₂) := isOffset? s | return .undef
+    if k₁ == k₂ then
+      toLBoolM <| isDefEqMain t' s'
+    else if k₁ < k₂ then
+      if k₁ == 0 then return .undef
+      toLBoolM <| isDefEqMain t' (← share (mkNatAdd s' (mkNatLit (k₂ - k₁))))
+    else
+      if k₂ == 0 then return .undef
+      toLBoolM <| isDefEqMain (← share (mkNatAdd t' (mkNatLit (k₁ - k₂)))) s'
+
 set_option compiler.ignoreBorrowAnnotation true in
 /--
 `isDefEqMain` implementation.
@@ -1010,6 +1051,7 @@ def isDefEqMainImpl (t : Expr) (s : Expr) : DefEqM Bool := do
     else
     whenUndefDo (tryAssignMillerPattern tFn t s rfl) do
     whenUndefDo (tryAssignMillerPattern sFn s t rfl) do
+    whenUndefDo (isDefEqOffset t s) do
     if let .fvar fvarId₁ := t then
       unless (← read).zetaDelta do return false
       let some val₁ ← fvarId₁.getValue? | return false

--- a/tests/elab/sym_simp_no_index.lean
+++ b/tests/elab/sym_simp_no_index.lean
@@ -1,0 +1,96 @@
+import Std.Tactic.BVDecide
+import Lean
+set_option warn.sorry false
+
+/-!
+Tests for `Sym` pattern matching against constant-folded targets.
+
+`no_index` annotations (e.g. `BitVec (no_index _)` in `bv_normalize` theorems such as
+`Std.Tactic.BVDecide.Normalize.BitVec.append_const_right`) make the discrimination tree emit
+wildcard keys, so retrieval succeeds. The matcher must then solve `Nat` constraints such as
+`w1 + w2 =?= 16` where the target width was constant-folded: `process` postpones such
+quasi-offset constraints (see `isQuasiOffsetCnstr`) until phase 1 assigns the pattern
+variables, and the instantiated constraint (e.g. `8 + 8 =?= 16`) is solved by `isDefEqOffset`,
+the structural counterpart of `Meta.isDefEqOffset`.
+-/
+
+open Lean Meta Lean.Meta.Sym Lean.Meta.Sym.Simp
+
+def target1 (a : BitVec 8) : BitVec 24 := (a ++ 1#8) ++ 2#8
+
+def target2 (a : BitVec 8) : BitVec 24 := 1#8 ++ (2#8 ++ a)
+
+/-- Rewrites the value of `declName` with `thmName` after constant folding ground subterms. -/
+def check (declName thmName : Name) : MetaM Unit := do
+  let value := (← getConstInfoDefn declName).value
+  lambdaTelescope value fun _ body => do SymM.run do
+    let thm ← mkTheoremFromDecl thmName
+    let thms := ({} : Theorems).insert thm
+    let methods : Methods := { post := thms.rewrite }
+    let body ← share body
+    let body ← dsimp body { pre := DSimp.evalGround }
+    let r ← simp body methods {}
+    logInfo m!"before: {body}\nafter:  {Result.getResultExpr body r}"
+
+/--
+info: before: a ++ 1#8 ++ 2#8
+after:  BitVec.cast ⋯ (a ++ (1#8 ++ 2#8))
+-/
+#guard_msgs in
+run_meta check ``target1 ``Std.Tactic.BVDecide.Normalize.BitVec.append_const_right
+
+/--
+info: before: 1#8 ++ (2#8 ++ a)
+after:  BitVec.cast ⋯ (1#8 ++ 2#8 ++ a)
+-/
+#guard_msgs in
+run_meta check ``target2 ``Std.Tactic.BVDecide.Normalize.BitVec.append_const_left
+
+/-!
+Minimal `Nat`-only regression: `x` is bound by the first argument, and the annotated
+`x + x` must then match the folded literal `16`. Without `no_index` the discrimination
+tree would not even retrieve the theorem.
+-/
+
+opaque p2 : Nat → Nat → Prop
+theorem p2_thm (x : Nat) : p2 x (no_index (x + x)) = True := sorry
+
+/-- info: step: True -/
+#guard_msgs in
+run_meta SymM.run do
+  let e ← share (mkApp2 (mkConst ``p2) (mkNatLit 8) (mkNatLit 16))
+  let thm ← mkTheoremFromDecl ``p2_thm
+  let r ← SimpM.run' (thm.rewrite e)
+  match r with
+  | .step e' _ _ _ => logInfo m!"step: {e'}"
+  | _ => logInfo "rfl"
+
+-- The nonlinear constraint must still fail when the arithmetic does not hold.
+/-- info: rfl -/
+#guard_msgs in
+run_meta SymM.run do
+  let e ← share (mkApp2 (mkConst ``p2) (mkNatLit 8) (mkNatLit 17))
+  let thm ← mkTheoremFromDecl ``p2_thm
+  let r ← SimpM.run' (thm.rewrite e)
+  match r with
+  | .step e' _ _ _ => logInfo m!"step: {e'}"
+  | _ => logInfo "rfl"
+
+/-! `isDefEqS` folds ground `Nat` arithmetic via `isDefEqOffset`. -/
+
+/--
+info: 8 + 8 =?= 16: true
+---
+info: 8 + 8 =?= 17: false
+---
+info: x + 2 =?= x + 1 + 1: true
+-/
+#guard_msgs in
+run_meta SymM.run do
+  let add8 ← share (← mkAppM ``HAdd.hAdd #[mkNatLit 8, mkNatLit 8])
+  logInfo m!"8 + 8 =?= 16: {← isDefEqS add8 (← share (mkNatLit 16))}"
+  logInfo m!"8 + 8 =?= 17: {← isDefEqS add8 (← share (mkNatLit 17))}"
+  withLocalDeclD `x (mkConst ``Nat) fun x => do
+    let lhs ← share (← mkAppM ``HAdd.hAdd #[x, mkNatLit 2])
+    let rhs ← share (← mkAppM ``HAdd.hAdd #[← mkAppM ``HAdd.hAdd #[x, mkNatLit 1], mkNatLit 1])
+    logInfo m!"x + 2 =?= x + 1 + 1: {← isDefEqS lhs rhs}"


### PR DESCRIPTION
This PR improves the support for offsets in `SymM` matcher/unifier. See new test for example that could not be handled.
