### PR TITLE
test: add regression test for `grind?` dropping `cases` params

### DIFF
--- a/tests/elab/grind_13828.lean
+++ b/tests/elab/grind_13828.lean
@@ -1,0 +1,48 @@
+module
+
+/-!
+Regression test for #13828: `grind?` suggestions used to omit `cases` parameters
+(e.g., `cases Bool`), producing suggestions that failed during replay. The parameters
+marking types for case-splitting must be preserved in the suggestions.
+-/
+
+/--
+info: Try these:
+  [apply] grind only [#bd83, cases Bool]
+  [apply] grind only [cases Bool]
+  [apply] grind [cases Bool] => cases #bd83
+-/
+#guard_msgs (info) in
+example (f : Bool → Bool) (x : Bool) (h₁ : f true = true) (h₂ : f false = true) :
+    f (f (f x)) = f x := by
+  grind? only [cases Bool]
+
+/--
+info: Try these:
+  [apply] grind only [#bd83, #0173, cases Option]
+  [apply] grind only [cases Option]
+  [apply] grind [cases Option] => cases #bd83 <;> instantiate only [#0173]
+-/
+#guard_msgs (info) in
+example (x : Option Nat) : x = none ∨ ∃ n, x = some n := by
+  grind? [cases Option]
+
+/-! Check that the suggestions above actually work. -/
+
+example (f : Bool → Bool) (x : Bool) : f (f (f x)) = f x := by
+  cases h₁ : f true <;> cases h₂ : f false <;> grind only [#bd83, cases Bool]
+
+example (f : Bool → Bool) (x : Bool) : f (f (f x)) = f x := by
+  cases h₁ : f true <;> cases h₂ : f false <;> grind only [cases Bool]
+
+example (f : Bool → Bool) (x : Bool) : f (f (f x)) = f x := by
+  cases h₁ : f true <;> cases h₂ : f false <;> grind [cases Bool] => cases #bd83
+
+example (x : Option Nat) : x = none ∨ ∃ n, x = some n := by
+  grind only [#bd83, #0173, cases Option]
+
+example (x : Option Nat) : x = none ∨ ∃ n, x = some n := by
+  grind only [cases Option]
+
+example (x : Option Nat) : x = none ∨ ∃ n, x = some n := by
+  grind [cases Option] => cases #bd83 <;> instantiate only [#0173]


### PR DESCRIPTION
This PR adds a regression test for #13828: `grind?` suggestions used to omit `cases` parameters (e.g., `cases Bool`), producing suggestions that failed during replay. The issue was fixed by #14022, which preserves parameters that mark types for case-splitting. The test checks that `cases Bool` and `cases Option` appear in the suggestions for both examples from the issue, and that all suggested tactics replay successfully.

Closes #13828

🤖 Generated with [Claude Code](https://claude.com/claude-code)