### PR TITLE
feat: namespace pollution linter for core

### DIFF
--- a/src/Lean/Linter.lean
+++ b/src/Lean/Linter.lean
@@ -26,3 +26,4 @@ public import Lean.Linter.EnvLinter
 public import Lean.Linter.PersistentLintLog
 public import Lean.Linter.Extra
 public import Lean.Linter.TacticTypeCheck
+public import Lean.Linter.CoreInternal

--- a/src/Lean/Linter/CoreInternal.lean
+++ b/src/Lean/Linter/CoreInternal.lean
@@ -1,0 +1,21 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Julia M. Himmel
+-/
+module
+
+prelude
+public import Lean.Linter.InternalModule
+
+namespace Lean.Linter
+
+/-- Record the core-internal linters as members of the `linter.coreInternal` set, so that they
+pick up the set-membership fallback in `getLinterValue`. The `linter.coreInternal` option itself
+is registered as a builtin option in `Lean.Linter.Init`. -/
+builtin_initialize
+  addBuiltinLinterSet `linter.coreInternal <|
+    NameSet.empty
+      |>.insert `linter.internalModule
+
+end Lean.Linter

--- a/src/Lean/Linter/CoreInternal.lean
+++ b/src/Lean/Linter/CoreInternal.lean
@@ -16,6 +16,6 @@ is registered as a builtin option in `Lean.Linter.Init`. -/
 builtin_initialize
   addBuiltinLinterSet `linter.coreInternal <|
     NameSet.empty
-      |>.insert `linter.internalModule
+      |>.insert `linter.coreInternal.internalModule
 
 end Lean.Linter

--- a/src/Lean/Linter/Init.lean
+++ b/src/Lean/Linter/Init.lean
@@ -107,6 +107,12 @@ register_builtin_option linter.extra : Bool := {
     only available via `lake lint`. An extra linter early-returns unless this option is true."
 }
 
+register_builtin_option linter.coreInternal : Bool := {
+  defValue := false
+  descr := "enables the set of core-internal linters — linters that enforce conventions of the \
+    Lean repository itself and are not intended for use by non-core projects."
+}
+
 /--
 Global registry of options associated with environment linters.
 These are precisely options, whose value will be snapshotted during `addDecl`.

--- a/src/Lean/Linter/InternalModule.lean
+++ b/src/Lean/Linter/InternalModule.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Julia M. Himmel
+-/
+module
+
+prelude
+public import Lean.Linter.Basic
+public import Lean.Linter.Util
+public import Lean.PrivateName
+
+public section
+
+namespace Lean.Linter
+open Elab Command
+
+/--
+Enables the Lean core `internalModule` linter, which warns when a module considered "internal"
+declares a declaration that is not itself "internal".
+
+The intent is that declarations living in internal modules (for example, anything under the
+`Lean` namespace, or the `omega`/`grind` implementation modules) stay internal, rather than
+becoming part of a project's public API by accident.
+
+This linter is off by default and is not intended for use by non-core projects. It is a member
+of the `linter.coreInternal` set, so it can also be enabled via `set_option linter.coreInternal
+true`.
+-/
+register_builtin_option linter.internalModule : Bool := {
+  defValue := false
+  descr := "enable the `internalModule` linter, which warns when a module considered \
+    \"internal\" declares a declaration that is not itself \"internal\"."
+}
+
+namespace InternalModule
+
+/-- A module or declaration is internal if one of its name components is one of these strings. -/
+def internalNameComponents : Array String := #["Internal"]
+
+/-- Whether one of the components of `n` is in `internalNameComponents`. -/
+def hasInternalNameComponent : Name → Bool
+  | .str p s => internalNameComponents.contains s || hasInternalNameComponent p
+  | .num p _ => hasInternalNameComponent p
+  | .anonymous => false
+
+/-- A module is internal if it is (a submodule of) one of these modules. -/
+def internalModulePrefixes : Array Name :=
+  #[`Init.Omega, `Init.Grind, `Lean, `Lake,
+    -- only used by `tests/pkg/internal_module_linter`
+    `IMLinterTest]
+
+/-- Whether `mod` is an "internal" module, i.e. one whose declarations should stay internal. -/
+def isInternalModule (mod : Name) : Bool :=
+  hasInternalNameComponent mod || internalModulePrefixes.any (·.isPrefixOf mod)
+
+/-- A declaration is internal if it lives in (a namespace under) one of these namespaces. -/
+def internalDeclNamespaces : Array Name := #[`Lean, `Lake]
+
+/-- Whether `declName` is an "internal" declaration. -/
+def isInternalDecl (declName : Name) : Bool :=
+  isPrivateName declName ||
+    internalDeclNamespaces.any (·.isPrefixOf declName) ||
+    hasInternalNameComponent declName
+
+@[inherit_doc linter.internalModule]
+def internalModuleLinter : Linter where run := withSetOptionIn fun _ => do
+  if (← get).messages.hasErrors then return
+  unless getLinterValue linter.internalModule (← getLinterOptions) do return
+  let env ← getEnv
+  let mainModule := env.mainModule
+  -- The linter only constrains declarations introduced by internal modules.
+  unless isInternalModule mainModule do return
+  let mut seen : NameSet := {}
+  for t in ← getInfoTrees do
+    for declName in getNewDecls t do
+      if seen.contains declName then continue
+      seen := seen.insert declName
+      unless env.contains declName do continue
+      if isInternalDecl declName then continue
+      logLint linter.internalModule (← getRef)
+        m!"`{.ofConstName declName}` is a non-internal declaration in the internal module \
+          `{mainModule}`; declarations in internal modules should themselves be internal.\n\
+          \n\
+          Make the declaration private, or put it into an internal namespace, or, if the declaration \
+          is supposed to be part of the standard library, move it into a file that is part of the \
+          standard library.\n\
+          \n\
+          For core-specific helper functions about basic types, recall that after `open Lean`, a \
+          declaration like `Lean.List.foo` will be available for generalized field notation on lists."
+
+builtin_initialize addLinter internalModuleLinter
+
+end InternalModule
+end Lean.Linter

--- a/src/Lean/Linter/InternalModule.lean
+++ b/src/Lean/Linter/InternalModule.lean
@@ -27,7 +27,7 @@ This linter is off by default and is not intended for use by non-core projects. 
 of the `linter.coreInternal` set, so it can also be enabled via `set_option linter.coreInternal
 true`.
 -/
-register_builtin_option linter.internalModule : Bool := {
+register_builtin_option linter.coreInternal.internalModule : Bool := {
   defValue := false
   descr := "enable the `internalModule` linter, which warns when a module considered \
     \"internal\" declares a declaration that is not itself \"internal\"."
@@ -63,10 +63,10 @@ def isInternalDecl (declName : Name) : Bool :=
     internalDeclNamespaces.any (·.isPrefixOf declName) ||
     hasInternalNameComponent declName
 
-@[inherit_doc linter.internalModule]
+@[inherit_doc linter.coreInternal.internalModule]
 def internalModuleLinter : Linter where run := withSetOptionIn fun _ => do
   if (← get).messages.hasErrors then return
-  unless getLinterValue linter.internalModule (← getLinterOptions) do return
+  unless getLinterValue linter.coreInternal.internalModule (← getLinterOptions) do return
   let env ← getEnv
   let mainModule := env.mainModule
   -- The linter only constrains declarations introduced by internal modules.
@@ -78,7 +78,7 @@ def internalModuleLinter : Linter where run := withSetOptionIn fun _ => do
       seen := seen.insert declName
       unless env.contains declName do continue
       if isInternalDecl declName then continue
-      logLint linter.internalModule (← getRef)
+      logLint linter.coreInternal.internalModule (← getRef)
         m!"`{.ofConstName declName}` is a non-internal declaration in the internal module \
           `{mainModule}`; declarations in internal modules should themselves be internal.\n\
           \n\

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,7 +1,15 @@
 #include "util/options.h"
 
-// Should we test stage 2 and run update-stage0 on PR merge? NO
-// (change to "YES" to trigger)
+/*
+ ______________________
+< Please update stage0 >
+ ----------------------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||
+*/
 
 namespace lean {
 options get_option_overrides() {

--- a/tests/pkg/internal_module_linter/Helpers/Internal.lean
+++ b/tests/pkg/internal_module_linter/Helpers/Internal.lean
@@ -1,0 +1,7 @@
+/-!
+Tests that the `internalModule` linter considers a module internal when `Internal` is one of its
+name components, independently of `internalModulePrefixes`.
+-/
+
+-- warns: non-internal declaration in a module with an `Internal` name component
+def helpersLeaky := 8

--- a/tests/pkg/internal_module_linter/IMLinterTest.lean
+++ b/tests/pkg/internal_module_linter/IMLinterTest.lean
@@ -1,0 +1,23 @@
+/-!
+Tests for the `internalModule` linter. The module name `IMLinterTest` matches a test-only entry
+in `Lean.Linter.InternalModule.internalModulePrefixes`, so this module is considered internal
+and the linter should flag every non-internal declaration in it.
+-/
+
+-- warns: a plain declaration is not internal
+def leaky := 1
+
+-- warns: "Internal" as a mere substring of a name component is not enough
+def myInternalHelper := 2
+
+-- no warning: private declarations are internal
+private def privateHelper := 3
+
+-- no warning: the `Lean` namespace is internal
+def Lean.pkgTestHelper := 4
+
+-- no warning: `Internal` is a component of the declaration name
+def Internal.helper := 5
+
+-- no warning: the `Internal` component may occur anywhere in the name
+def Impl.Internal.deepHelper := 6

--- a/tests/pkg/internal_module_linter/IMLinterTest/Sub.lean
+++ b/tests/pkg/internal_module_linter/IMLinterTest/Sub.lean
@@ -1,0 +1,7 @@
+/-!
+Tests that the `internalModule` linter also fires in submodules of a module matching
+`internalModulePrefixes` (here the test-only prefix `IMLinterTest`).
+-/
+
+-- warns: non-internal declaration in a submodule of an internal module
+def subLeaky := 5

--- a/tests/pkg/internal_module_linter/IMLinterTest/ViaSet.lean
+++ b/tests/pkg/internal_module_linter/IMLinterTest/ViaSet.lean
@@ -1,0 +1,12 @@
+/-!
+Tests that the `internalModule` linter can be enabled via the `linter.coreInternal` linter set:
+this module is built with only `linter.coreInternal = true` (see the `SetMain` library in the
+lakefile), without setting `linter.internalModule` itself.
+-/
+
+-- warns: the linter is enabled through the `linter.coreInternal` set
+def viaSetLeaky := 9
+
+-- no warning: explicitly disabling the linter takes precedence over the enabled set
+set_option linter.internalModule false in
+def viaSetDisabled := 10

--- a/tests/pkg/internal_module_linter/IMLinterTest/ViaSet.lean
+++ b/tests/pkg/internal_module_linter/IMLinterTest/ViaSet.lean
@@ -1,12 +1,12 @@
 /-!
 Tests that the `internalModule` linter can be enabled via the `linter.coreInternal` linter set:
 this module is built with only `linter.coreInternal = true` (see the `SetMain` library in the
-lakefile), without setting `linter.internalModule` itself.
+lakefile), without setting `linter.coreInternal.internalModule` itself.
 -/
 
 -- warns: the linter is enabled through the `linter.coreInternal` set
 def viaSetLeaky := 9
 
 -- no warning: explicitly disabling the linter takes precedence over the enabled set
-set_option linter.internalModule false in
+set_option linter.coreInternal.internalModule false in
 def viaSetDisabled := 10

--- a/tests/pkg/internal_module_linter/Regular.lean
+++ b/tests/pkg/internal_module_linter/Regular.lean
@@ -1,0 +1,7 @@
+/-!
+Tests that the `internalModule` linter stays silent in a module that is not internal, even with
+the linter enabled.
+-/
+
+-- no warning: `Regular` is not an internal module
+def regularDef := 7

--- a/tests/pkg/internal_module_linter/UsesInternalHelpers.lean
+++ b/tests/pkg/internal_module_linter/UsesInternalHelpers.lean
@@ -1,0 +1,7 @@
+/-!
+Tests that the `internalModule` linter does not consider a module internal merely because its
+name contains "Internal" as a substring; `Internal` must be a whole name component.
+-/
+
+-- no warning: `UsesInternalHelpers` is not an internal module
+def substringLeaky := 7

--- a/tests/pkg/internal_module_linter/lakefile.toml
+++ b/tests/pkg/internal_module_linter/lakefile.toml
@@ -1,0 +1,18 @@
+name = "internal_module_linter"
+defaultTargets = ["Main"]
+
+[[lean_lib]]
+name = "Main"
+roots = [
+  "IMLinterTest",
+  "IMLinterTest.Sub",
+  "Helpers.Internal",
+  "UsesInternalHelpers",
+  "Regular",
+]
+leanOptions = { linter.internalModule = true }
+
+[[lean_lib]]
+name = "SetMain"
+roots = ["IMLinterTest.ViaSet"]
+leanOptions = { linter.coreInternal = true }

--- a/tests/pkg/internal_module_linter/lakefile.toml
+++ b/tests/pkg/internal_module_linter/lakefile.toml
@@ -10,7 +10,7 @@ roots = [
   "UsesInternalHelpers",
   "Regular",
 ]
-leanOptions = { linter.internalModule = true }
+leanOptions = { linter.coreInternal.internalModule = true }
 
 [[lean_lib]]
 name = "SetMain"

--- a/tests/pkg/internal_module_linter/lean-toolchain
+++ b/tests/pkg/internal_module_linter/lean-toolchain
@@ -1,0 +1,1 @@
+../../../build/release/stage1

--- a/tests/pkg/internal_module_linter/run_test.sh
+++ b/tests/pkg/internal_module_linter/run_test.sh
@@ -1,0 +1,30 @@
+rm -rf .lake
+
+# Build all test modules; the `Main` lib enables `linter.internalModule` directly via
+# `leanOptions` in the lakefile, the `SetMain` lib enables only the `linter.coreInternal` set.
+capture lake build Main SetMain
+
+# `IMLinterTest` is an internal module via a test-only entry in `internalModulePrefixes`.
+check_out_contains '`leaky` is a non-internal declaration in the internal module `IMLinterTest`'
+
+# "Internal" as a mere substring of a declaration-name component does not make it internal.
+check_out_contains '`myInternalHelper` is a non-internal declaration in the internal module `IMLinterTest`'
+
+# Submodules of an `internalModulePrefixes` entry are internal, too.
+check_out_contains '`subLeaky` is a non-internal declaration in the internal module `IMLinterTest.Sub`'
+
+# `Helpers.Internal` is an internal module via its `Internal` name component.
+check_out_contains '`helpersLeaky` is a non-internal declaration in the internal module `Helpers.Internal`'
+
+# The linter also fires when enabled via the `linter.coreInternal` set instead of directly.
+check_out_contains '`viaSetLeaky` is a non-internal declaration in the internal module `IMLinterTest.ViaSet`'
+
+# Internal declarations (private, `Lean` namespace, `Internal` name component) must not be
+# flagged, and neither must declarations in non-internal modules: `UsesInternalHelpers` only
+# contains "Internal" as a substring of a component, and `Regular` does not match at all.
+# `viaSetDisabled` sets `linter.internalModule false` locally, which overrides the enabled set.
+for decl in privateHelper pkgTestHelper Internal.helper Impl.Internal.deepHelper substringLeaky regularDef viaSetDisabled; do
+  if grep -Fq "\`$decl\`" "$CAPTURED.out.produced"; then
+    fail "$decl should not trigger the internalModule linter"
+  fi
+done

--- a/tests/pkg/internal_module_linter/run_test.sh
+++ b/tests/pkg/internal_module_linter/run_test.sh
@@ -1,6 +1,6 @@
 rm -rf .lake
 
-# Build all test modules; the `Main` lib enables `linter.internalModule` directly via
+# Build all test modules; the `Main` lib enables `linter.coreInternal.internalModule` directly via
 # `leanOptions` in the lakefile, the `SetMain` lib enables only the `linter.coreInternal` set.
 capture lake build Main SetMain
 
@@ -22,7 +22,7 @@ check_out_contains '`viaSetLeaky` is a non-internal declaration in the internal 
 # Internal declarations (private, `Lean` namespace, `Internal` name component) must not be
 # flagged, and neither must declarations in non-internal modules: `UsesInternalHelpers` only
 # contains "Internal" as a substring of a component, and `Regular` does not match at all.
-# `viaSetDisabled` sets `linter.internalModule false` locally, which overrides the enabled set.
+# `viaSetDisabled` sets `linter.coreInternal.internalModule false` locally, which overrides the enabled set.
 for decl in privateHelper pkgTestHelper Internal.helper Impl.Internal.deepHelper substringLeaky regularDef viaSetDisabled; do
   if grep -Fq "\`$decl\`" "$CAPTURED.out.produced"; then
     fail "$decl should not trigger the internalModule linter"


### PR DESCRIPTION
This PR adds a linter aiming to detect namespace pollution committed within the Lean core distribution.

The linter is part of a new `linter.coreInternal` set which, as the name suggests, contains linters which are means for use in core only. A follow-up PR will enable this linter set in core.