### PR TITLE
refactor: generalize withForbidden to multiple forbidden tokens

### DIFF
--- a/src/Lean/Parser/Basic.lean
+++ b/src/Lean/Parser/Basic.lean
@@ -944,7 +944,7 @@ def mkTokenAndFixPos (startPos : String.Pos.Raw) (tk : Option Token) : ParserFn 
   match tk with
   | none    => s.mkErrorAt "token" startPos
   | some tk =>
-    if c.forbiddenTk? == some tk then
+    if c.forbiddenTks.contains tk then
       s.mkErrorAt "forbidden token" startPos
     else
       let leading   := c.mkEmptySubstringAt startPos
@@ -1578,7 +1578,9 @@ would be treated as an application.
 
 This parser has the same arity as `p` - it just forwards the results of `p`. -/
 @[builtin_doc] def withForbidden (tk : Token) (p : Parser) : Parser :=
-  adaptCacheableContext ({ · with forbiddenTk? := tk }) p
+  adaptCacheableContext
+    (fun c => if c.forbiddenTks.contains tk then c
+              else { c with forbiddenTks := c.forbiddenTks.push tk }) p
 
 /-- `withoutForbidden(p)` runs `p` disabling the "forbidden token" (see `withForbidden`), if any.
 This is usually used by bracketing constructs like `(...)` because there is no parsing ambiguity
@@ -1586,7 +1588,7 @@ inside these nested constructs.
 
 This parser has the same arity as `p` - it just forwards the results of `p`. -/
 @[builtin_doc] def withoutForbidden (p : Parser) : Parser :=
-  adaptCacheableContext ({ · with forbiddenTk? := none }) p
+  adaptCacheableContext ({ · with forbiddenTks := #[] }) p
 
 def eoiFn : ParserFn := fun c s =>
   let i := s.pos

--- a/src/Lean/Parser/Types.lean
+++ b/src/Lean/Parser/Types.lean
@@ -183,7 +183,7 @@ structure CacheableParserContext where
   quotDepth          : Nat := 0
   suppressInsideQuot : Bool := false
   savedPos?          : Option String.Pos.Raw := none
-  forbiddenTk?       : Option Token := none
+  forbiddenTks       : Array Token := #[]
   deriving BEq
 
 /-- Parser context updateable in `adaptUncacheableContextFn`. -/

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,6 +1,6 @@
 #include "util/options.h"
 
-// Should we test stage 2 and run update-stage0 on PR merge? NO
+// Should we test stage 2 and run update-stage0 on PR merge? YES
 // (change to "YES" to trigger)
 
 namespace lean {
@@ -16,18 +16,18 @@ options get_option_overrides() {
 
     // uncomment for ABI-breaking changes affecting meta code;
     // see also next option!
-    //opts = opts.update({"interpreter", "prefer_native"}, true);
+    opts = opts.update({"interpreter", "prefer_native"}, true);
 
     // uncomment when enabling `prefer_native` should also affect use
     // of built-in parsers in quotations; this is usually the case, but setting
     // both to `true` may be necessary for handling non-builtin parsers with
     // builtin elaborators
     // TODO: make consistent across stages
-    opts = opts.update({"internal", "parseQuotWithCurrentStage"}, true);
+    //opts = opts.update({"internal", "parseQuotWithCurrentStage"}, true);
 
     // changes to builtin parsers may also require uncommenting the following option if macros/syntax
     // with custom precheck hooks were affected
-    //opts = opts.update({"quotPrecheck"}, false);
+    opts = opts.update({"quotPrecheck"}, false);
 #endif
     return opts;
 }


### PR DESCRIPTION
This PR generalizes the parser's forbidden-token mechanism so that `withForbidden a (withForbidden b p)` forbids both `a` and `b`, where nesting previously kept only the innermost token.

`CacheableParserContext.forbiddenTk? : Option Token` becomes `forbiddenTks : Array Token`; `withForbidden` accumulates without duplicating and `withoutForbidden` clears.