### PR TITLE
feat: enable `coreInternal` linter set

### DIFF
--- a/src/Init/Internal/Order/While.lean
+++ b/src/Init/Internal/Order/While.lean
@@ -34,6 +34,8 @@ private theorem repeatM.body_monotone_of_monadTail [Lean.Order.MonadTail m] [Non
     | .inl a' => h a'
     | .inr _ => Lean.Order.PartialOrder.rel_refl
 
+-- TODO: move out of `Internal`
+set_option linter.coreInternal.internalModule false in
 /-- One-step unfolding of `repeatM` for any `MonadTail m`. -/
 public theorem repeatM_eq_of_monadTail [Lean.Order.MonadTail m] [Nonempty β]
     {f : α → m (α ⊕ β)} (a : α) :

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Array.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Array.lean
@@ -13,6 +13,7 @@ public section
 namespace Array
 open Lean Meta Simp
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `#[...][n]` for `n` a `Nat` literal. -/
 builtin_dsimproc [simp, seval] reduceGetElem (@GetElem.getElem (Array _) Nat _ _ _ _ _ _) := fun e => do
   let_expr GetElem.getElem _ _ _ _ _ xs n _ ← e | return .continue
@@ -20,6 +21,7 @@ builtin_dsimproc [simp, seval] reduceGetElem (@GetElem.getElem (Array _) Nat _ _
   let some xs ← getArrayLit? xs | return .continue
   return .done <| xs[n]!
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `#[...][n]?` for `n` a `Nat` literal. -/
 builtin_dsimproc [simp, seval] reduceGetElem? (@GetElem?.getElem? (Array _) Nat _ _ _ _ _) := fun e => do
   let_expr GetElem?.getElem? _ _ α _ _ xs n ← e | return .continue
@@ -28,6 +30,7 @@ builtin_dsimproc [simp, seval] reduceGetElem? (@GetElem?.getElem? (Array _) Nat 
   let r ← if h : n < xs.size then mkSome α xs[n] else mkNone α
   return .done r
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `#[...][n]!` for `n` a `Nat` literal. -/
 builtin_dsimproc [simp, seval] reduceGetElem! (@GetElem?.getElem! (Array _) Nat _ _ _ _ _ _) := fun e => do
   let_expr GetElem?.getElem! _ _ α _ _ _ xs n ← e | return .continue

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/BitVec.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/BitVec.lean
@@ -123,52 +123,75 @@ Helper function for reducing bitvector predicates.
     return .continue
 
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for negation of `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceNeg ((- _ : BitVec _)) := reduceUnary ``Neg.neg 3 (- ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for bitwise not of `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceNot ((~~~ _ : BitVec _)) :=
   reduceUnary ``Complement.complement 3 (~~~ ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for absolute value of `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceAbs (BitVec.abs _) := reduceUnary ``BitVec.abs 2 BitVec.abs
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for bitwise and of `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceAnd ((_ &&& _ : BitVec _)) := reduceBin ``HAnd.hAnd 6 (· &&& ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for bitwise or of `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceOr ((_ ||| _ : BitVec _)) := reduceBin ``HOr.hOr 6 (· ||| ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for bitwise xor of `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceXOr ((_ ^^^ _ : BitVec _)) := reduceBin ``HXor.hXor 6 (· ^^^ ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for addition of `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceAdd ((_ + _ : BitVec _)) := reduceBin ``HAdd.hAdd 6 (· + ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for multiplication of `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceMul ((_ * _ : BitVec _)) := reduceBin ``HMul.hMul 6 (· * ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for subtraction of `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceSub ((_ - _ : BitVec _)) := reduceBin ``HSub.hSub 6 (· - ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for division of `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceDiv ((_ / _ : BitVec _)) := reduceBin ``HDiv.hDiv 6 (· / ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for the modulo operation on `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceMod ((_ % _ : BitVec _)) := reduceBin ``HMod.hMod 6 (· % ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for the unsigned modulo operation on `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceUMod ((umod _ _ : BitVec _)) := reduceBin ``umod 3 umod
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for unsigned division of `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceUDiv ((udiv _ _ : BitVec _)) := reduceBin ``udiv 3 udiv
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for division of `BitVec`s using the SMT-LIB conventions. -/
 builtin_dsimproc [simp, seval] reduceSMTUDiv ((smtUDiv _ _ : BitVec _)) := reduceBin ``smtUDiv 3 smtUDiv
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for the signed modulo operation on `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceSMod ((smod _ _ : BitVec _)) := reduceBin ``smod 3 smod
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for signed remainder of `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceSRem ((srem _ _ : BitVec _)) := reduceBin ``srem 3 srem
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for signed t-division of `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceSDiv ((sdiv _ _ : BitVec _)) := reduceBin ``sdiv 3 sdiv
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for signed division of `BitVec`s using the SMT-LIB conventions. -/
 builtin_dsimproc [simp, seval] reduceSMTSDiv ((smtSDiv _ _ : BitVec _)) := reduceBin ``smtSDiv 3 smtSDiv
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `getLsb` (lowest significant bit) on `BitVec`. -/
 builtin_dsimproc [simp, seval] reduceGetLsb (getLsbD _ _) := reduceGetBit ``getLsbD getLsbD
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `getMsb` (most significant bit) on `BitVec`. -/
 builtin_dsimproc [simp, seval] reduceGetMsb (getMsbD _ _) := reduceGetBit ``getMsbD getMsbD
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `clz` (count leading zeros) on `BitVec`. -/
 builtin_dsimproc [simp, seval] reduceClz (clz _) := reduceUnary ``BitVec.clz 2 BitVec.clz
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `cpop` (population count) on `BitVec`. -/
 builtin_dsimproc [simp, seval] reduceCpop (cpop _) := reduceUnary ``BitVec.cpop 2 BitVec.cpop
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `getElem`  on `BitVec`. -/
 builtin_dsimproc [simp, seval] reduceGetElem ((_ : BitVec _)[_]) := fun e => do
   let_expr getElem _coll _idx _elem _valid _inst v i _h  := e | return .continue
@@ -177,34 +200,44 @@ builtin_dsimproc [simp, seval] reduceGetElem ((_ : BitVec _)[_]) := fun e => do
   let b := v.value.getLsbD i
   return .done <| toExpr b
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for shift left on `BitVec`. -/
 builtin_dsimproc [simp, seval] reduceShiftLeft (BitVec.shiftLeft _ _) :=
   reduceShift ``BitVec.shiftLeft 3 BitVec.shiftLeft
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for unsigned shift right on `BitVec`. -/
 builtin_dsimproc [simp, seval] reduceUShiftRight (BitVec.ushiftRight _ _) :=
   reduceShift ``BitVec.ushiftRight 3 BitVec.ushiftRight
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for signed shift right on `BitVec`. -/
 builtin_dsimproc [simp, seval] reduceSShiftRight (BitVec.sshiftRight _ _) :=
   reduceShift ``BitVec.sshiftRight 3 BitVec.sshiftRight
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for shift left on `BitVec`. -/
 builtin_dsimproc [simp, seval] reduceHShiftLeft ((_ <<< _ : BitVec _)) :=
   reduceShift ``HShiftLeft.hShiftLeft 6 (· <<< ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for converting a shift with a bit-vector literal into a natural number literal. -/
 builtin_dsimproc [simp, seval] reduceHShiftLeft' ((_ <<< (_ : BitVec _) : BitVec _)) :=
   reduceShiftWithBitVecLit ``HShiftLeft.hShiftLeft
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for shift right on `BitVec`. -/
 builtin_dsimproc [simp, seval] reduceHShiftRight ((_ >>> _ : BitVec _)) :=
   reduceShift ``HShiftRight.hShiftRight 6 (· >>> ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for converting a shift with a bit-vector literal into a natural number literal. -/
 builtin_dsimproc [simp, seval] reduceHShiftRight' ((_ >>> (_ : BitVec _) : BitVec _)) :=
   reduceShiftWithBitVecLit ``HShiftRight.hShiftRight
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for rotate left on `BitVec`. -/
 builtin_dsimproc [simp, seval] reduceRotateLeft (BitVec.rotateLeft _ _) :=
   reduceShift ``BitVec.rotateLeft 3 BitVec.rotateLeft
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for rotate right on `BitVec`. -/
 builtin_dsimproc [simp, seval] reduceRotateRight (BitVec.rotateRight _ _) :=
   reduceShift ``BitVec.rotateRight 3 BitVec.rotateRight
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for append on `BitVec`. -/
 builtin_dsimproc [simp, seval] reduceAppend ((_ ++ _ : BitVec _)) := fun e => do
   let_expr HAppend.hAppend _ _ _ _ a b ← e | return .continue
@@ -212,6 +245,7 @@ builtin_dsimproc [simp, seval] reduceAppend ((_ ++ _ : BitVec _)) := fun e => do
   let some v₂ ← fromExpr? b | return .continue
   return .done <| (← toExpr' (v₁.value ++ v₂.value))
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for casting `BitVec`s along an equality of the size. -/
 builtin_dsimproc [simp, seval] reduceCast (cast _ _) := fun e => do
   let_expr cast _ m _ v ← e | return .continue
@@ -219,18 +253,21 @@ builtin_dsimproc [simp, seval] reduceCast (cast _ _) := fun e => do
   let some m ← Nat.fromExpr? m | return .continue
   return .done <| (← toExpr' (BitVec.ofNat m v.value.toNat))
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `BitVec.toNat`. -/
 builtin_dsimproc [simp, seval] reduceToNat (BitVec.toNat _) := fun e => do
   let_expr BitVec.toNat _ v ← e | return .continue
   let some v ← fromExpr? v | return .continue
   return .done <| mkNatLit v.value.toNat
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `BitVec.toInt`. -/
 builtin_dsimproc [simp, seval] reduceToInt (BitVec.toInt _) := fun e => do
   let_expr BitVec.toInt _ v ← e | return .continue
   let some v ← fromExpr? v | return .continue
   return .done <| toExpr v.value.toInt
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `BitVec.ofInt`. -/
 builtin_dsimproc [simp, seval] reduceOfInt (BitVec.ofInt _ _) := fun e => do
   let_expr BitVec.ofInt n i ← e | return .continue
@@ -238,6 +275,7 @@ builtin_dsimproc [simp, seval] reduceOfInt (BitVec.ofInt _ _) := fun e => do
   let some i ← Int.fromExpr? i | return .continue
   return .done <| (← toExpr' (BitVec.ofInt n i))
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for ensuring `BitVec.ofNat` literals are normalized. -/
 builtin_dsimproc [simp, seval] reduceOfNat (BitVec.ofNat _ _) := fun e => do
   let_expr BitVec.ofNat n v ← e | return .continue
@@ -258,6 +296,7 @@ builtin_dsimproc [simp, seval] reduceOfNat (BitVec.ofNat _ _) := fun e => do
     -/
     return .done (← mkNumeral (mkApp (mkConst ``BitVec) n) v)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /--
 Simplification procedure for ensuring `OfNat.ofNat` bitvector literals are normalized.
 For example, `(17 : BitVec 4)` is reduced to `(1 : BitVec 4)` when `bitVecOfNat := false`,
@@ -271,39 +310,52 @@ builtin_dsimproc [simp, seval] isValue ((OfNat.ofNat _ : BitVec _)) := fun e => 
     return .done e -- already normalized; `OfNat.ofNat` is the normal form when `bitVecOfNat := false`
   return .done (← toExpr' v)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `=` on `BitVec`s. -/
 builtin_simproc [simp, seval] reduceEq  (( _ : BitVec _) = _)  := reduceBinPred ``Eq 3 (. = .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `≠` on `BitVec`s. -/
 builtin_simproc [simp, seval] reduceNe  (( _ : BitVec _) ≠ _)  := reduceBinPred ``Ne 3 (. ≠ .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `==` on `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceBEq  (( _ : BitVec _) == _)  :=
   reduceBoolPred ``BEq.beq 4 (· == ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `!=` on `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceBNe  (( _ : BitVec _) != _)  :=
   reduceBoolPred ``bne 4 (· != ·)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `<` on `BitVec`s. -/
 builtin_simproc [simp, seval] reduceLT (( _ : BitVec _) < _)  := reduceBinPred ``LT.lt 4 (· < ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `≤` on `BitVec`s. -/
 builtin_simproc [simp, seval] reduceLE (( _ : BitVec _) ≤ _)  := reduceBinPred ``LE.le 4 (. ≤ .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `>` on `BitVec`s. -/
 builtin_simproc [simp, seval] reduceGT (( _ : BitVec _) > _)  := reduceBinPred ``GT.gt 4 (. > .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `≥` on `BitVec`s. -/
 builtin_simproc [simp, seval] reduceGE (( _ : BitVec _) ≥ _)  := reduceBinPred ``GE.ge 4 (. ≥ .)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for unsigned less than `ult` on `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceULT (BitVec.ult _ _) :=
   reduceBoolPred ``BitVec.ult 3 BitVec.ult
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for unsigned less than or equal `ule` on `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceULE (BitVec.ule _ _) :=
   reduceBoolPred ``BitVec.ule 3 BitVec.ule
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for signed less than `slt` on `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceSLT (BitVec.slt _ _) :=
   reduceBoolPred ``BitVec.slt 3 BitVec.slt
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for signed less than or equal `sle` on `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceSLE (BitVec.sle _ _) :=
   reduceBoolPred ``BitVec.sle 3 BitVec.sle
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `setWidth'` on `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceSetWidth' (setWidth' _ _) := fun e => do
   let_expr setWidth' _ w _ v ← e | return .continue
@@ -314,6 +366,7 @@ builtin_dsimproc [simp, seval] reduceSetWidth' (setWidth' _ _) := fun e => do
   else
     return .continue
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `shiftLeftZeroExtend` on `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceShiftLeftZeroExtend (shiftLeftZeroExtend _ _) := fun e => do
   let_expr shiftLeftZeroExtend _ v m ← e | return .continue
@@ -321,6 +374,7 @@ builtin_dsimproc [simp, seval] reduceShiftLeftZeroExtend (shiftLeftZeroExtend _ 
   let some m ← Nat.fromExpr? m | return .continue
   return .done <| (← toExpr' (v.value.shiftLeftZeroExtend m))
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `extractLsb'` on `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceExtractLsb' (extractLsb' _ _ _) := fun e => do
   let_expr extractLsb' _ start len v ← e | return .continue
@@ -329,6 +383,7 @@ builtin_dsimproc [simp, seval] reduceExtractLsb' (extractLsb' _ _ _) := fun e =>
   let some len ← Nat.fromExpr? len | return .continue
   return .done <| (← toExpr' (v.value.extractLsb' start len))
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `extractLsb` on `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceExtractLsb (extractLsb _ _ _) := fun e => do
   let_expr extractLsb _ hi lo v ← e | return .continue
@@ -337,6 +392,7 @@ builtin_dsimproc [simp, seval] reduceExtractLsb (extractLsb _ _ _) := fun e => d
   let some lo ← Nat.fromExpr? lo | return .continue
   return .done <| (← toExpr' (v.value.extractLsb hi lo))
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `replicate` on `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceReplicate (replicate _ _) := fun e => do
   let_expr replicate _ i v ← e | return .continue
@@ -344,27 +400,33 @@ builtin_dsimproc [simp, seval] reduceReplicate (replicate _ _) := fun e => do
   let some i ← Nat.fromExpr? i | return .continue
   return .done <| (← toExpr' (v.value.replicate i))
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `setWidth` on `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceSetWidth (setWidth _ _) := reduceExtend ``setWidth setWidth
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `zeroExtend` on `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceZeroExtend (zeroExtend _ _) := reduceExtend ``zeroExtend zeroExtend
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `signExtend` on `BitVec`s. -/
 builtin_dsimproc [simp, seval] reduceSignExtend (signExtend _ _) := reduceExtend ``signExtend signExtend
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `allOnes` -/
 builtin_dsimproc [simp, seval] reduceAllOnes (allOnes _) := fun e => do
   let_expr allOnes n ← e | return .continue
   let some n ← Nat.fromExpr? n | return .continue
   return .done <| (← toExpr' (allOnes n))
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceBitVecOfFin (BitVec.ofFin _)  := fun e => do
   let_expr BitVec.ofFin w v ← e | return .continue
   let some w ← evalNat w |>.run | return .continue
   let some ⟨_, v⟩ ← getFinValue? v | return .continue
   return .done <| (← toExpr' (BitVec.ofNat w v.val))
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceBitVecToFin (BitVec.toFin _)  := fun e => do
   let_expr BitVec.toFin _ v ← e | return .continue
   let some ⟨_, v⟩ ← getBitVecValue? v | return .continue
@@ -387,8 +449,10 @@ natural number literals.
   let proof ← mkEqSymm proof -- we rewrite (x <<< i) <<< j ↦ x <<< (i + j) [the opposite direction]
   return .visit { expr, proof? := some proof }
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc reduceShiftLeftShiftLeft (((_ <<< _ : BitVec _) <<< _ : BitVec _)) :=
   reduceShiftShift ``HShiftLeft.hShiftLeft ``shiftLeft_add
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc reduceShiftRightShiftRight (((_ >>> _ : BitVec _) >>> _ : BitVec _)) :=
   reduceShiftShift ``HShiftRight.hShiftRight ``shiftRight_add
 

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Char.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Char.lean
@@ -39,30 +39,50 @@ open Lean Meta Simp Lean.Char
   let some m ← fromExpr? e.appArg! | return .continue
   return .done <| toExpr (op n m)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceToLower (Char.toLower _) := reduceUnary ``Char.toLower Char.toLower
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceToUpper (Char.toUpper _) := reduceUnary ``Char.toUpper Char.toUpper
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceToNat (Char.toNat _) := reduceUnary ``Char.toNat Char.toNat
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceIsWhitespace (Char.isWhitespace _) := reduceUnary ``Char.isWhitespace Char.isWhitespace
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceIsUpper (Char.isUpper _) := reduceUnary ``Char.isUpper Char.isUpper
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceIsLower (Char.isLower _) := reduceUnary ``Char.isLower Char.isLower
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceIsAlpha (Char.isAlpha _) := reduceUnary ``Char.isAlpha Char.isAlpha
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceIsDigit (Char.isDigit _) := reduceUnary ``Char.isDigit Char.isDigit
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceIsAlphaNum (Char.isAlphanum _) := reduceUnary ``Char.isAlphanum Char.isAlphanum
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceToString (toString (_ : Char)) := reduceUnary ``toString toString 3
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceVal (Char.val _) := fun e => do
   let_expr Char.val arg ← e | return .continue
   let some c ← fromExpr? arg | return .continue
   return .done <| toExpr c.val
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceLT  (( _ : Char) < _)  := reduceBinPred ``LT.lt 4 (. < .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceLE  (( _ : Char) ≤ _)  := reduceBinPred ``LE.le 4 (. ≤ .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceGT  (( _ : Char) > _)  := reduceBinPred ``GT.gt 4 (. > .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceGE  (( _ : Char) ≥ _)  := reduceBinPred ``GE.ge 4 (. ≥ .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceEq  (( _ : Char) = _)  := reduceBinPred ``Eq 3 (. = .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceNe  (( _ : Char) ≠ _)  := reduceBinPred ``Ne 3 (. ≠ .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceBEq  (( _ : Char) == _)  := reduceBoolPred ``BEq.beq 4 (. == .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceBNe  (( _ : Char) != _)  := reduceBoolPred ``bne 4 (. != .)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /--
 Returns `.done` for Char values.
 
@@ -76,15 +96,18 @@ builtin_dsimproc ↓ [simp, seval] isValue (Char.ofNat _ ) := fun e => do
   unless (← fromExpr? e).isSome do return .continue
   return .done e
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceOfNatAux (Char.ofNatAux _ _) := fun e => do
   let_expr Char.ofNatAux n _ ← e | return .continue
   let some n ← Nat.fromExpr? n | return .continue
   return .done <| toExpr (Char.ofNat n)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceDefault ((default : Char)) := fun e => do
   let_expr default _ _ ← e | return .continue
   return .done <| toExpr (default : Char)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplifies `Nat.digitChar n = c` to `False` when `c` is a concrete character
 not in the range of `digitChar` (i.e., not one of `'0'`-`'9'`, `'a'`-`'f'`, `'*'`). -/
 builtin_simproc [simp, seval] Nat.reduceDigitCharEq (Nat.digitChar _ = _) := fun e => do
@@ -101,6 +124,7 @@ builtin_simproc [simp, seval] Nat.reduceDigitCharEq (Nat.digitChar _ = _) := fun
   let proof := mkApp2 (mkConst ``eq_false) e neProof
   return .done { expr := mkConst ``False, proof? := proof }
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplifies `c = Nat.digitChar n` to `False` when `c` is a concrete character
 not in the range of `digitChar` (i.e., not one of `'0'`-`'9'`, `'a'`-`'f'`, `'*'`). -/
 builtin_simproc [simp, seval] Nat.reduceEqDigitChar (_ = Nat.digitChar _) := fun e => do

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Core.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Core.lean
@@ -11,6 +11,7 @@ import Lean.Meta.CtorRecognizer
 public section
 open Lean Meta Simp
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc ↓ [simp, seval] reduceIte (ite _ _ _) := fun e => do
   let_expr f@ite α c i tb eb ← e | return .continue
   let r ← simp c
@@ -22,6 +23,7 @@ builtin_simproc ↓ [simp, seval] reduceIte (ite _ _ _) := fun e => do
     return .visit { expr := eb, proof? := pr }
   return .continue
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc ↓ [simp, seval] reduceDIte (dite _ _ _) := fun e => do
   let_expr f@dite α c i tb eb ← e | return .continue
   let r ← simp c
@@ -39,6 +41,7 @@ builtin_simproc ↓ [simp, seval] reduceDIte (dite _ _ _) := fun e => do
     return .visit { expr := eNew, proof? := prNew }
   return .continue
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc ↓ [simp, seval] dreduceIte (ite _ _ _) := fun e => do
   unless (← inDSimp) do
     -- If `simp` is not in `dsimp` mode, we should use `reduceIte`
@@ -64,6 +67,7 @@ builtin_dsimproc ↓ [simp, seval] dreduceIte (ite _ _ _) := fun e => do
     | _ => return .continue
   return .continue
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc ↓ [simp, seval] dreduceDIte (dite _ _ _) := fun e => do
   unless (← inDSimp) do
     -- If `simp` is not in `dsimp` mode, we should use `reduceDIte`
@@ -78,6 +82,7 @@ builtin_dsimproc ↓ [simp, seval] dreduceDIte (dite _ _ _) := fun e => do
     | _ => return .continue
   return .continue
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceCtorEq (_ = _) := fun e => withReducibleAndInstances do
   let_expr Eq _ lhs rhs ← e | return .continue
   match (← constructorApp'? lhs), (← constructorApp'? rhs) with

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/CtorIdx.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/CtorIdx.lean
@@ -12,6 +12,7 @@ import Lean.Meta.CtorRecognizer
 open Lean Meta Simp
 public section
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /--
 This simproc reduces `T.ctorIdx (T.con …)` to the constructor index.
 It does not take part in simp's discrimination tree index, so can be costly on large goals.

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Fin.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Fin.lean
@@ -62,32 +62,54 @@ The following code assumes users did not override the `Fin n` instances for the 
 If they do, they must disable the following `simprocs`.
 -/
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceSucc (Fin.succ _) := reduceOp ``Fin.succ 2 (· + 1) Fin.succ
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceRev (Fin.rev _) := reduceOp ``Fin.rev 2 (·) Fin.rev
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceLast (Fin.last _) := reduceNatOp ``Fin.last 1 (· + 1) Fin.last
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceAdd ((_ + _ : Fin _)) := reduceBin ``HAdd.hAdd 6 (· + ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceMul ((_ * _ : Fin _)) := reduceBin ``HMul.hMul 6 (· * ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceSub ((_ - _ : Fin _)) := reduceBin ``HSub.hSub 6 (· - ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceDiv ((_ / _ : Fin _)) := reduceBin ``HDiv.hDiv 6 (· / ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceMod ((_ % _ : Fin _)) := reduceBin ``HMod.hMod 6 (· % ·)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceAnd ((_ &&& _ : Fin _)) := reduceBin ``HAnd.hAnd 6 (· &&& ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceOr  ((_ ||| _ : Fin _)) := reduceBin ``HOr.hOr 6 (· ||| ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceXor ((_ ^^^ _ : Fin _)) := reduceBin ``HXor.hXor 6 (· ^^^ ·)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceShiftLeft ((_ <<< _ : Fin _))  := reduceBin ``HShiftLeft.hShiftLeft 6 (· <<< ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceShiftRight ((_ >>> _ : Fin _)) := reduceBin ``HShiftRight.hShiftRight 6 (· >>> ·)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceLT  (( _ : Fin _) < _)  := reduceBinPred ``LT.lt 4 (. < .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceLE  (( _ : Fin _) ≤ _)  := reduceBinPred ``LE.le 4 (. ≤ .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceGT  (( _ : Fin _) > _)  := reduceBinPred ``GT.gt 4 (. > .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceGE  (( _ : Fin _) ≥ _)  := reduceBinPred ``GE.ge 4 (. ≥ .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceEq  (( _ : Fin _) = _)  := reduceBinPred ``Eq 3 (. = .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceNe  (( _ : Fin _) ≠ _)  := reduceBinPred ``Ne 3 (. ≠ .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceBEq  (( _ : Fin _) == _)  := reduceBoolPred ``BEq.beq 4 (. == .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceBNe  (( _ : Fin _) != _)  := reduceBoolPred ``bne 4 (. != .)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for ensuring `Fin n` literals are normalized. -/
 builtin_dsimproc [simp, seval] isValue ((OfNat.ofNat _ : Fin _)) := fun e => do
   let_expr OfNat.ofNat _ m _ ← e | return .continue
@@ -99,6 +121,7 @@ builtin_dsimproc [simp, seval] isValue ((OfNat.ofNat _ : Fin _)) := fun e => do
     return .done e
   return .done <| toExpr v
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceFinMk (Fin.mk _ _)  := fun e => do
   let_expr Fin.mk n v _ ← e | return .continue
   let some n ← evalNat n |>.run | return .continue
@@ -109,35 +132,41 @@ builtin_dsimproc [simp, seval] reduceFinMk (Fin.mk _ _)  := fun e => do
   else
     return .continue
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceOfNat (Fin.ofNat _ _) := fun e => do
   unless e.isAppOfArity ``Fin.ofNat 3 do return .continue
   let some (n + 1) ← getNatValue? e.appFn!.appFn!.appArg! | return .continue
   let some k ← getNatValue? e.appArg! | return .continue
   return .done <| toExpr (Fin.ofNat (n + 1) k)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceCastSucc (Fin.castSucc _) := fun e => do
   unless e.isAppOfArity ``Fin.castSucc 2 do return .continue
   let some k ← fromExpr? e.appArg! | return .continue
   return .done <| toExpr (castSucc k.value)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceCastAdd (Fin.castAdd _ _) := fun e => do
   unless e.isAppOfArity ``Fin.castAdd 3 do return .continue
   let some m ← getNatValue? e.appFn!.appArg! | return .continue
   let some k ← fromExpr? e.appArg! | return .continue
   return .done <| toExpr (castAdd m k.value)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceAddNat (Fin.addNat _ _) := fun e => do
   unless e.isAppOfArity ``Fin.addNat 3 do return .continue
   let some k ← fromExpr? e.appFn!.appArg! | return .continue
   let some m ← getNatValue? e.appArg! | return .continue
   return .done <| toExpr (addNat k.value m)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceNatAdd (Fin.natAdd _ _) := fun e => do
   unless e.isAppOfArity ``Fin.natAdd 3 do return .continue
   let some m ← getNatValue? e.appFn!.appArg! | return .continue
   let some k ← fromExpr? e.appArg! | return .continue
   return .done <| toExpr (natAdd m k.value)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceCastLT (Fin.castLT _ _) := fun e => do
   unless e.isAppOfArity ``Fin.castLT 4 do return .continue
   let some n ← getNatValue? e.appFn!.appFn!.appFn!.appArg! | return .continue
@@ -147,6 +176,7 @@ builtin_dsimproc [simp, seval] reduceCastLT (Fin.castLT _ _) := fun e => do
   else
     return .continue
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceCastLE (Fin.castLE _ _) := fun e => do
   unless e.isAppOfArity ``Fin.castLE 4 do return .continue
   let some m ← getNatValue? e.appFn!.appFn!.appArg! | return .continue
@@ -158,6 +188,7 @@ builtin_dsimproc [simp, seval] reduceCastLE (Fin.castLE _ _) := fun e => do
 
 -- No simproc is needed for `Fin.cast`, as for explicit numbers `Fin.cast_refl` will apply.
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceSubNat (Fin.subNat _ _ _) := fun e => do
   unless e.isAppOfArity ``Fin.subNat 4 do return .continue
   let some m ← getNatValue? e.appFn!.appFn!.appArg! | return .continue
@@ -167,6 +198,7 @@ builtin_dsimproc [simp, seval] reduceSubNat (Fin.subNat _ _ _) := fun e => do
   else
     return .continue
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reducePred (Fin.pred _ _) := fun e => do
   unless e.isAppOfArity ``Fin.pred 3 do return .continue
   let some ⟨(_ + 1), i⟩ ← fromExpr? e.appFn!.appArg! | return .continue

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Int.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Int.lean
@@ -54,6 +54,7 @@ The following code assumes users did not override the `Int` instances for the ar
 If they do, they must disable the following `simprocs`.
 -/
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceNeg ((- _ : Int)) := fun e => do
   let_expr Neg.neg _ _ arg ← e | return .continue
   if arg.isAppOfArity ``OfNat.ofNat 3 then
@@ -63,23 +64,36 @@ builtin_dsimproc [simp, seval] reduceNeg ((- _ : Int)) := fun e => do
     let some v ← fromExpr? arg | return .continue
     return .done <| toExpr (- v)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Return `.done` for positive Int values. We don't want to unfold in the symbolic evaluator. -/
 builtin_dsimproc [seval] isPosValue ((OfNat.ofNat _ : Int)) := fun e => do
   let_expr OfNat.ofNat _ _ _ ← e | return .continue
   return .done e
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceAdd ((_ + _ : Int)) := reduceBin ``HAdd.hAdd 6 (· + ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceMul ((_ * _ : Int)) := reduceBin ``HMul.hMul 6 (· * ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceSub ((_ - _ : Int)) := reduceBin ``HSub.hSub 6 (· - ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceDiv ((_ / _ : Int)) := reduceBin ``HDiv.hDiv 6 (· / ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceMod ((_ % _ : Int)) := reduceBin ``HMod.hMod 6 (· % ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceTDiv (tdiv  _ _) := reduceBin ``Int.tdiv 2 Int.tdiv
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceTMod (tmod  _ _) := reduceBin ``Int.tmod 2 Int.tmod
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceFDiv (fdiv _ _) := reduceBin ``Int.fdiv 2 Int.fdiv
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceFMod (fmod _ _) := reduceBin ``Int.fmod 2 Int.fmod
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceBdiv (bdiv _ _) := reduceBinIntNatOp ``bdiv bdiv
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceBmod (bmod _ _) := reduceBinIntNatOp ``bmod bmod
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reducePow ((_ : Int) ^ (_ : Nat)) := fun e => do
   let_expr HPow.hPow _ _ _ _ a b ← e | return .continue
   let some v₁ ← fromExpr? a | return .continue
@@ -88,13 +102,21 @@ builtin_dsimproc [simp, seval] reducePow ((_ : Int) ^ (_ : Nat)) := fun e => do
   unless (← checkExponent v₂ (warning := warning)) do return .continue
   return .done <| toExpr (v₁ ^ v₂)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceLT  (( _ : Int) < _)  := reduceBinPred ``LT.lt 4 (. < .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceLE  (( _ : Int) ≤ _)  := reduceBinPred ``LE.le 4 (. ≤ .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceGT  (( _ : Int) > _)  := reduceBinPred ``GT.gt 4 (. > .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceGE  (( _ : Int) ≥ _)  := reduceBinPred ``GE.ge 4 (. ≥ .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceEq  (( _ : Int) = _)  := reduceBinPred ``Eq 3 (. = .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceNe  (( _ : Int) ≠ _)  := reduceBinPred ``Ne 3 (. ≠ .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceBEq  (( _ : Int) == _)  := reduceBoolPred ``BEq.beq 4 (. == .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceBNe  (( _ : Int) != _)  := reduceBoolPred ``bne 4 (. != .)
 
 @[inline] private def reduceNatCore (declName : Name) (op : Int → Nat) (e : Expr) : SimpM DStep := do
@@ -102,19 +124,24 @@ builtin_dsimproc [simp, seval] reduceBNe  (( _ : Int) != _)  := reduceBoolPred `
   let some v ← fromExpr? e.appArg! | return .continue
   return .done <| mkNatLit (op v)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceAbs (natAbs _) := reduceNatCore ``natAbs natAbs
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceToNat (Int.toNat _) := reduceNatCore ``Int.toNat Int.toNat
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceNegSucc (Int.negSucc _) := fun e => do
   let_expr Int.negSucc a ← e | return .continue
   let some a ← getNatValue? a | return .continue
   return .done <| toExpr (-(Int.ofNat a + 1))
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceOfNat (Int.ofNat _) := fun e => do
   let_expr Int.ofNat a ← e | return .continue
   let some a ← getNatValue? a | return .continue
   return .done <| toExpr (Int.ofNat a)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceDvd ((_ : Int) ∣ _) := fun e => do
   let_expr Dvd.dvd _ i a b ← e | return .continue
   unless ← matchesInstance i (mkConst ``instDvd) do return .continue
@@ -130,10 +157,12 @@ private def reduceNatCastCore (inst : Expr) (a : Expr) : SimpM DStep := do
   let_expr instNatCastInt ← inst | return .continue
   return .done <| toExpr (Int.ofNat a)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceNatCast ((NatCast.natCast _ : Int))  := fun e => do
   let_expr NatCast.natCast _ inst a ← e | return .continue
   reduceNatCastCore inst a
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceNatCast' ((Nat.cast _ : Int))  := fun e => do
   let_expr Nat.cast _ inst a ← e | return .continue
   reduceNatCastCore inst a

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/List.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/List.lean
@@ -13,6 +13,7 @@ public section
 namespace List
 open Lean Meta Simp
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for `List.replicate` applied to a `Nat` literal. -/
 -- We don't always want `List.replicate_succ` as a `simp` lemma,
 -- so we use this `dsimproc` to unfold `List.replicate` applied to literals.

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/MethodSpecs.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/MethodSpecs.lean
@@ -32,6 +32,7 @@ private def reduceMethod (opName : String) (e : Expr) : SimpM Simp.Step := do
 
 public section
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /--
 This simproc reduces `_ == _` when both arguments are constructor applications and the `BEq` instance
 in question has been annotated with `@[method_specs]`.
@@ -40,6 +41,7 @@ builtin_simproc_decl reduceBEq (_ == _) := fun e => do
   unless e.isAppOfArity ``BEq.beq 4 do return .continue
   reduceMethod "beq" e
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /--
 This simproc reduces `Ord.compare _ _` when both arguments are constructor applications and the
 `Ord` instance in question has been annotated with `@[method_specs]`.

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Nat.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Nat.lean
@@ -47,6 +47,7 @@ open Lean Meta Simp Lean.Nat
   let some m ← fromExpr? e.appArg! | return .continue
   return .done <| toExpr (op n m)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceSucc (Nat.succ _) := reduceUnary ``Nat.succ 1 (· + 1)
 
 /-
@@ -54,12 +55,18 @@ The following code assumes users did not override the `Nat` instances for the ar
 If they do, they must disable the following `simprocs`.
 -/
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceAdd ((_ + _ : Nat)) := reduceBin ``HAdd.hAdd 6 (· + ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceMul ((_ * _ : Nat)) := reduceBin ``HMul.hMul 6 (· * ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceSub ((_ - _ : Nat)) := reduceBin ``HSub.hSub 6 (· - ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceDiv ((_ / _ : Nat)) := reduceBin ``HDiv.hDiv 6 (· / ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceMod ((_ % _ : Nat)) := reduceBin ``HMod.hMod 6 (· % ·)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reducePow ((_ ^ _ : Nat)) := fun e => do
   let_expr HPow.hPow _ _ _ _ n m := e | return .continue
   let some n ← fromExpr? n | return .continue
@@ -68,22 +75,33 @@ builtin_dsimproc [simp, seval] reducePow ((_ ^ _ : Nat)) := fun e => do
   unless (← checkExponent m (warning := warning)) do return .continue
   return .done <| toExpr (n ^ m)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceAnd ((_ &&& _ : Nat)) := reduceBin ``HAnd.hAnd 6 (· &&& ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceXor ((_ ^^^ _ : Nat)) := reduceBin ``HXor.hXor 6 (· ^^^ ·)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceOr ((_ ||| _ : Nat)) := reduceBin ``HOr.hOr 6 (· ||| ·)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceShiftLeft ((_ <<< _ : Nat)) :=
   reduceBin ``HShiftLeft.hShiftLeft 6 (· <<< ·)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceShiftRight ((_ >>> _ : Nat)) :=
   reduceBin ``HShiftRight.hShiftRight 6 (· >>> ·)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceGcd (gcd _ _)       := reduceBin ``gcd 2 gcd
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceLT  (( _ : Nat) < _)  := reduceBinPred ``LT.lt 4 (. < .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceGT  (( _ : Nat) > _)  := reduceBinPred ``GT.gt 4 (. > .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceBEq  (( _ : Nat) == _)  := reduceBoolPred ``BEq.beq 4 (. == .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceBNe  (( _ : Nat) != _)  := reduceBoolPred ``bne 4 (. != .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 
 /-- Return `.done` for Nat values. We don't want to unfold in the symbolic evaluator. -/
 builtin_dsimproc [seval] isValue ((OfNat.ofNat _ : Nat)) := fun e => do
@@ -230,6 +248,7 @@ private def reduceNatEqExpr (x y : Expr) : SimpM (Option EqResult):= do
       let geProof ← mkOfDecideEqTrue (mkGENat xo yo)
       applyEqLemma (.eq zb yb) ``Nat.Simproc.add_eq_add_ge #[xb, yb, xo, yo, geProof]
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceEqDiff ((_ : Nat) = _) := fun e => do
   unless e.isAppOfArity ``Eq 3 do
     return .continue
@@ -251,6 +270,7 @@ builtin_simproc [simp, seval] reduceEqDiff ((_ : Nat) = _) := fun e => do
   | some (.eq x y p) =>
     return .visit { expr := mkEqNat x y,     proof? := some p, cache := true }
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceBeqDiff ((_ : Nat) == _) := fun e => do
   unless e.isAppOfArity ``BEq.beq 4 do
     return .continue
@@ -268,6 +288,7 @@ builtin_simproc [simp, seval] reduceBeqDiff ((_ : Nat) == _) := fun e => do
     let q := mkAppN (mkConst ``Nat.Simproc.beqEqOfEqEq) #[x, y, u, v, p]
     return .visit { expr := mkBEqNat u v, proof? := some q, cache := true }
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceBneDiff ((_ : Nat) != _) := fun e => do
   unless e.isAppOfArity ``bne 4 do
     return .continue
@@ -321,8 +342,10 @@ private def reduceLTLE (nm : Name) (arity : Nat) (isLT : Bool) (e : Expr) : Simp
       let geProof ← mkOfDecideEqTrue (mkGENat xo yo)
       applySimprocConst finExpr ``Nat.Simproc.add_le_add_ge  #[xb, yb, xo, yo, geProof]
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceLeDiff ((_ : Nat) ≤ _) := reduceLTLE ``LE.le 4 false
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceSubDiff ((_ - _ : Nat)) := fun e => do
   unless e.isAppOfArity ``HSub.hSub 6 do
     return .continue
@@ -358,6 +381,7 @@ builtin_simproc [simp, seval] reduceSubDiff ((_ - _ : Nat)) := fun e => do
       let geProof ← mkOfDecideEqTrue (mkGENat po no)
       applySimprocConst finExpr ``Nat.Simproc.add_sub_add_ge #[pb, nb, po, no, geProof]
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceDvd ((_ : Nat) ∣ _) := fun e => do
   let_expr Dvd.dvd _ i a b ← e | return .continue
   unless ← matchesInstance i (mkConst ``instDvd) do return .continue

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/SInt.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/SInt.lean
@@ -114,9 +114,15 @@ end $typeName
 
 end Lean
 
+-- The linter exemptions sit on the macro invocations because linters run once per top-level
+-- command and would not see a `set_option … in` inside the macro expansion.
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 declare_sint_simprocs Int8
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 declare_sint_simprocs Int16
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 declare_sint_simprocs Int32
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 declare_sint_simprocs Int64
 
 /-
@@ -125,6 +131,7 @@ However, we do reduce natural literals using the fact this opaque value is at le
 -/
 namespace ISize
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceToNatClampNeg (ISize.toNatClampNeg _) := fun e => do
   let_expr ISize.toNatClampNeg e ← e | return .continue
   if let some (n, _) ← getOfNatValue? e ``ISize then
@@ -142,6 +149,7 @@ builtin_simproc [simp, seval] reduceToNatClampNeg (ISize.toNatClampNeg _) := fun
   let p := mkApp2 (mkConst ``ISize.toNatClampNeg_neg_ofNat_of_le) e p
   return .done { expr := toExpr 0, proof? := p }
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceToInt (ISize.toInt _) := fun e => do
   let_expr ISize.toInt e ← e | return .continue
   if let some (n, _) ← getOfNatValue? e ``ISize then

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/String.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/String.lean
@@ -17,6 +17,7 @@ open Lean Meta Simp
 private def fromExpr? (e : Expr) : SimpM (Option String) := do
   return getStringValue? e
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceAppend ((_ ++ _ : String)) := fun e => do
   unless e.isAppOfArity ``HAppend.hAppend 6 do return .continue
   let some a ← fromExpr? e.appFn!.appArg! | return .continue
@@ -32,26 +33,31 @@ private partial def reduceListChar (e : Expr) (s : String) : SimpM DStep := do
   else
     return .continue
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceOfList (String.ofList _) := fun e => do
   unless e.isAppOfArity ``String.ofList 1 do return .continue
   reduceListChar e.appArg! ""
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceToList (String.toList _) := fun e => do
   unless e.isAppOfArity ``String.toList 1 do return .continue
   let some s ← fromExpr? e.appArg! | return .continue
   return .done <| toExpr s.toList
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reducePush (String.push _ _) := fun e => do
   unless e.isAppOfArity ``String.push 2 do return .continue
   let some n ← fromExpr? e.appFn!.appArg! | return .continue
   let some m ← Char.fromExpr? e.appArg! | return .continue
   return .done <| toExpr (n.push m)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceSingleton (String.singleton _) := fun e => do
   unless e.isAppOfArity ``String.singleton 1 do return .continue
   let some c ← Char.fromExpr? e.appArg! | return .continue
   return .done <| toExpr (String.singleton c)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc_decl reduceToSingleton ((_ : String)) := fun e => do
   let some s ← fromExpr? e | return .continue
   let l := s.toList
@@ -71,23 +77,31 @@ builtin_dsimproc_decl reduceToSingleton ((_ : String)) := fun e => do
   let some m ← fromExpr? e.appArg! | return .continue
   return .done <| toExpr (op n m)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceLT  (( _ : String) < _)  := reduceBinPred ``LT.lt 4 (. < .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceLE  (( _ : String) ≤ _)  := reduceBinPred ``LE.le 4 (. ≤ .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceGT  (( _ : String) > _)  := reduceBinPred ``GT.gt 4 (. > .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceGE  (( _ : String) ≥ _)  := reduceBinPred ``GE.ge 4 (. ≥ .)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceEq (( _ : String) = _) := fun e => do
   unless e.isAppOfArity ``Eq 3 do return .continue
   let some n ← fromExpr? e.appFn!.appArg! | return .continue
   let some m ← fromExpr? e.appArg! | return .continue
   evalEqPropStep e (n = m) (mkStringLitNeProof n m)
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceNe (( _ : String) ≠ _) := fun e => do
   unless e.isAppOfArity ``Ne 3 do return .continue
   let some n ← fromExpr? e.appFn!.appArg! | return .continue
   let some m ← fromExpr? e.appArg! | return .continue
   evalNePropStep e (n ≠ m) (mkStringLitNeProof n m)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceBEq  (( _ : String) == _)  := reduceBoolPred ``BEq.beq 4 (. == .)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceBNe  (( _ : String) != _)  := reduceBoolPred ``bne 4 (. != .)
 
 end String

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/UInt.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/UInt.lean
@@ -88,9 +88,15 @@ end $typeName
 
 end Lean
 
+-- The linter exemptions sit on the macro invocations because linters run once per top-level
+-- command and would not see a `set_option … in` inside the macro expansion.
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 declare_uint_simprocs UInt8
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 declare_uint_simprocs UInt16
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 declare_uint_simprocs UInt32
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 declare_uint_simprocs UInt64
 
 /-
@@ -103,6 +109,7 @@ private def fromExpr (e : Expr) : SimpM (Option USize) := do
   let some (n, _) ← getOfNatValue? e ``USize | return none
   return USize.ofNat n
 
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_simproc [simp, seval] reduceToNat (USize.toNat _) := fun e => do
   let_expr USize.toNat e ← e | return .continue
   let some (n, _) ← getOfNatValue? e ``USize | return .continue

--- a/src/Lean/Server/Test/Refs.lean
+++ b/src/Lean/Server/Test/Refs.lean
@@ -9,6 +9,9 @@ module
 prelude
 import Init.Prelude
 
+-- This needs to be top-level, but the only way to get this is to do the all-encompassing
+-- `import Lean`, so we just accept the pollution.
+set_option linter.coreInternal.internalModule false in
 public def LeanServerTestRefsTest0 := Nat
 
 public def Lean.Server.Test.LeanServerTestRefsTest0' := Nat

--- a/src/lakefile.toml.in
+++ b/src/lakefile.toml.in
@@ -43,6 +43,9 @@ nativeLibDir = "lib/lean"
 # Additional options derived from the CMake configuration
 moreLeanArgs = [${LEAN_EXTRA_OPTS_TOML}]
 
+# Enable core-only linters
+leanOptions.linter.coreInternal = true
+
 # Uncomment to limit number of reported errors further in case of overwhelming cmdline output
 #weakLeanArgs = ["-DmaxErrors=1"]
 

--- a/tests/server_interactive/findReferences.lean.out.expected
+++ b/tests/server_interactive/findReferences.lean.out.expected
@@ -18,13 +18,13 @@
   {"start": {"line": 9, "character": 13}, "end": {"line": 9, "character": 40}}},
  {"uri": "file:///src/Lean/Server/Test/Refs.lean",
   "range":
-  {"start": {"line": 17, "character": 11},
-   "end": {"line": 17, "character": 16}}},
+  {"start": {"line": 20, "character": 11},
+   "end": {"line": 20, "character": 16}}},
  {"uri": "file:///src/Lean/Server/Test/Refs.lean",
   "range":
-  {"start": {"line": 18, "character": 20},
-   "end": {"line": 18, "character": 25}}},
+  {"start": {"line": 21, "character": 20},
+   "end": {"line": 21, "character": 25}}},
  {"uri": "file:///src/Lean/Server/Test/Refs.lean",
   "range":
-  {"start": {"line": 19, "character": 20},
-   "end": {"line": 19, "character": 25}}}]
+  {"start": {"line": 22, "character": 20},
+   "end": {"line": 22, "character": 25}}}]

--- a/tests/server_interactive/incomingCallHierarchy.lean.out.expected
+++ b/tests/server_interactive/incomingCallHierarchy.lean.out.expected
@@ -45,11 +45,11 @@
 [{"item":
   {"uri": "file:///src/Lean/Server/Test/Refs.lean",
    "selectionRange":
-   {"start": {"line": 17, "character": 11},
-    "end": {"line": 17, "character": 16}},
+   {"start": {"line": 20, "character": 11},
+    "end": {"line": 20, "character": 16}},
    "range":
-   {"start": {"line": 17, "character": 11},
-    "end": {"line": 17, "character": 16}},
+   {"start": {"line": 20, "character": 11},
+    "end": {"line": 20, "character": 16}},
    "name": "Lean.Server.Test.Refs.Test1",
    "kind": 14,
    "data":
@@ -59,70 +59,70 @@
   [{"item":
     {"uri": "file:///src/Lean/Server/Test/Refs.lean",
      "selectionRange":
-     {"start": {"line": 18, "character": 11},
-      "end": {"line": 18, "character": 16}},
+     {"start": {"line": 21, "character": 11},
+      "end": {"line": 21, "character": 16}},
      "range":
-     {"start": {"line": 18, "character": 0},
-      "end": {"line": 18, "character": 25}},
+     {"start": {"line": 21, "character": 0},
+      "end": {"line": 21, "character": 25}},
      "name": "Lean.Server.Test.Refs.Test2",
      "kind": 14,
      "data":
      {"name": "Lean.Server.Test.Refs.Test2",
       "module": "Lean.Server.Test.Refs"}},
     "fromRanges":
-    [{"start": {"line": 18, "character": 20},
-      "end": {"line": 18, "character": 25}}],
+    [{"start": {"line": 21, "character": 20},
+      "end": {"line": 21, "character": 25}}],
     "children":
     [{"item":
       {"uri": "file:///src/Lean/Server/Test/Refs.lean",
        "selectionRange":
-       {"start": {"line": 20, "character": 11},
-        "end": {"line": 20, "character": 16}},
+       {"start": {"line": 23, "character": 11},
+        "end": {"line": 23, "character": 16}},
        "range":
-       {"start": {"line": 20, "character": 0},
-        "end": {"line": 20, "character": 25}},
+       {"start": {"line": 23, "character": 0},
+        "end": {"line": 23, "character": 25}},
        "name": "Lean.Server.Test.Refs.Test4",
        "kind": 14,
        "data":
        {"name": "Lean.Server.Test.Refs.Test4",
         "module": "Lean.Server.Test.Refs"}},
       "fromRanges":
-      [{"start": {"line": 20, "character": 20},
-        "end": {"line": 20, "character": 25}}],
+      [{"start": {"line": 23, "character": 20},
+        "end": {"line": 23, "character": 25}}],
       "children": []},
      {"item":
       {"uri": "file:///src/Lean/Server/Test/Refs.lean",
        "selectionRange":
-       {"start": {"line": 21, "character": 11},
-        "end": {"line": 21, "character": 16}},
+       {"start": {"line": 24, "character": 11},
+        "end": {"line": 24, "character": 16}},
        "range":
-       {"start": {"line": 21, "character": 0},
-        "end": {"line": 21, "character": 25}},
+       {"start": {"line": 24, "character": 0},
+        "end": {"line": 24, "character": 25}},
        "name": "Lean.Server.Test.Refs.Test5",
        "kind": 14,
        "data":
        {"name": "Lean.Server.Test.Refs.Test5",
         "module": "Lean.Server.Test.Refs"}},
       "fromRanges":
-      [{"start": {"line": 21, "character": 20},
-        "end": {"line": 21, "character": 25}}],
+      [{"start": {"line": 24, "character": 20},
+        "end": {"line": 24, "character": 25}}],
       "children": []}]},
    {"item":
     {"uri": "file:///src/Lean/Server/Test/Refs.lean",
      "selectionRange":
-     {"start": {"line": 19, "character": 11},
-      "end": {"line": 19, "character": 16}},
+     {"start": {"line": 22, "character": 11},
+      "end": {"line": 22, "character": 16}},
      "range":
-     {"start": {"line": 19, "character": 0},
-      "end": {"line": 19, "character": 25}},
+     {"start": {"line": 22, "character": 0},
+      "end": {"line": 22, "character": 25}},
      "name": "Lean.Server.Test.Refs.Test3",
      "kind": 14,
      "data":
      {"name": "Lean.Server.Test.Refs.Test3",
       "module": "Lean.Server.Test.Refs"}},
     "fromRanges":
-    [{"start": {"line": 19, "character": 20},
-      "end": {"line": 19, "character": 25}}],
+    [{"start": {"line": 22, "character": 20},
+      "end": {"line": 22, "character": 25}}],
     "children": []},
    {"item":
     {"uri": "file:///incomingCallHierarchy.lean",

--- a/tests/server_interactive/outgoingCallHierarchy.lean.out.expected
+++ b/tests/server_interactive/outgoingCallHierarchy.lean.out.expected
@@ -286,11 +286,11 @@
     [{"item":
       {"uri": "file:///src/Lean/Server/Test/Refs.lean",
        "selectionRange":
-       {"start": {"line": 28, "character": 11},
-        "end": {"line": 28, "character": 17}},
+       {"start": {"line": 31, "character": 11},
+        "end": {"line": 31, "character": 17}},
        "range":
-       {"start": {"line": 28, "character": 11},
-        "end": {"line": 28, "character": 17}},
+       {"start": {"line": 31, "character": 11},
+        "end": {"line": 31, "character": 17}},
        "name": "Lean.Server.Test.Refs.test10",
        "kind": 14,
        "data":
@@ -303,70 +303,70 @@
       [{"item":
         {"uri": "file:///src/Lean/Server/Test/Refs.lean",
          "selectionRange":
-         {"start": {"line": 27, "character": 11},
-          "end": {"line": 27, "character": 16}},
+         {"start": {"line": 30, "character": 11},
+          "end": {"line": 30, "character": 16}},
          "range":
-         {"start": {"line": 27, "character": 11},
-          "end": {"line": 27, "character": 16}},
+         {"start": {"line": 30, "character": 11},
+          "end": {"line": 30, "character": 16}},
          "name": "Lean.Server.Test.Refs.test9",
          "kind": 14,
          "data":
          {"name": "Lean.Server.Test.Refs.test9",
           "module": "Lean.Server.Test.Refs"}},
         "fromRanges":
-        [{"start": {"line": 28, "character": 21},
-          "end": {"line": 28, "character": 26}}],
+        [{"start": {"line": 31, "character": 21},
+          "end": {"line": 31, "character": 26}}],
         "children":
         [{"item":
           {"uri": "file:///src/Lean/Server/Test/Refs.lean",
            "selectionRange":
-           {"start": {"line": 25, "character": 11},
-            "end": {"line": 25, "character": 16}},
+           {"start": {"line": 28, "character": 11},
+            "end": {"line": 28, "character": 16}},
            "range":
-           {"start": {"line": 25, "character": 11},
-            "end": {"line": 25, "character": 16}},
+           {"start": {"line": 28, "character": 11},
+            "end": {"line": 28, "character": 16}},
            "name": "Lean.Server.Test.Refs.test7",
            "kind": 14,
            "data":
            {"name": "Lean.Server.Test.Refs.test7",
             "module": "Lean.Server.Test.Refs"}},
           "fromRanges":
-          [{"start": {"line": 27, "character": 20},
-            "end": {"line": 27, "character": 25}}],
+          [{"start": {"line": 30, "character": 20},
+            "end": {"line": 30, "character": 25}}],
           "children":
           [{"item":
             {"uri": "file:///src/Lean/Server/Test/Refs.lean",
              "selectionRange":
-             {"start": {"line": 23, "character": 17},
-              "end": {"line": 23, "character": 22}},
+             {"start": {"line": 26, "character": 17},
+              "end": {"line": 26, "character": 22}},
              "range":
-             {"start": {"line": 23, "character": 17},
-              "end": {"line": 23, "character": 22}},
+             {"start": {"line": 26, "character": 17},
+              "end": {"line": 26, "character": 22}},
              "name": "Lean.Server.Test.Refs.Test6",
              "kind": 14,
              "data":
              {"name": "Lean.Server.Test.Refs.Test6",
               "module": "Lean.Server.Test.Refs"}},
             "fromRanges":
-            [{"start": {"line": 25, "character": 19},
-              "end": {"line": 25, "character": 24}}],
+            [{"start": {"line": 28, "character": 19},
+              "end": {"line": 28, "character": 24}}],
             "children": []},
            {"item":
             {"uri": "file:///src/Lean/Server/Test/Refs.lean",
              "selectionRange":
-             {"start": {"line": 24, "character": 4},
-              "end": {"line": 24, "character": 6}},
+             {"start": {"line": 27, "character": 4},
+              "end": {"line": 27, "character": 6}},
              "range":
-             {"start": {"line": 24, "character": 4},
-              "end": {"line": 24, "character": 6}},
+             {"start": {"line": 27, "character": 4},
+              "end": {"line": 27, "character": 6}},
              "name": "Lean.Server.Test.Refs.Test6.mk",
              "kind": 14,
              "data":
              {"name": "Lean.Server.Test.Refs.Test6.mk",
               "module": "Lean.Server.Test.Refs"}},
             "fromRanges":
-            [{"start": {"line": 25, "character": 28},
-              "end": {"line": 25, "character": 31}}],
+            [{"start": {"line": 28, "character": 28},
+              "end": {"line": 28, "character": 31}}],
             "children": []}]}]}]},
      {"item":
       {"uri": "file:///outgoingCallHierarchy.lean",
@@ -694,11 +694,11 @@
       [{"item":
         {"uri": "file:///src/Lean/Server/Test/Refs.lean",
          "selectionRange":
-         {"start": {"line": 23, "character": 17},
-          "end": {"line": 23, "character": 22}},
+         {"start": {"line": 26, "character": 17},
+          "end": {"line": 26, "character": 22}},
          "range":
-         {"start": {"line": 23, "character": 17},
-          "end": {"line": 23, "character": 22}},
+         {"start": {"line": 26, "character": 17},
+          "end": {"line": 26, "character": 22}},
          "name": "Lean.Server.Test.Refs.Test6",
          "kind": 14,
          "data":

--- a/tests/server_interactive/workspaceSymbols.lean.out.expected
+++ b/tests/server_interactive/workspaceSymbols.lean.out.expected
@@ -12,35 +12,59 @@
   "location":
   {"uri": "file:///src/Lean/Server/Test/Refs.lean",
    "range":
-   {"start": {"line": 27, "character": 11},
-    "end": {"line": 27, "character": 16}}},
+   {"start": {"line": 30, "character": 11},
+    "end": {"line": 30, "character": 16}}},
   "kind": 14},
  {"tags": [],
   "name": "Lean.Server.Test.Refs.test8",
   "location":
   {"uri": "file:///src/Lean/Server/Test/Refs.lean",
    "range":
-   {"start": {"line": 26, "character": 11},
-    "end": {"line": 26, "character": 16}}},
+   {"start": {"line": 29, "character": 11},
+    "end": {"line": 29, "character": 16}}},
   "kind": 14},
  {"tags": [],
   "name": "Lean.Server.Test.Refs.test7",
   "location":
   {"uri": "file:///src/Lean/Server/Test/Refs.lean",
    "range":
-   {"start": {"line": 25, "character": 11},
-    "end": {"line": 25, "character": 16}}},
+   {"start": {"line": 28, "character": 11},
+    "end": {"line": 28, "character": 16}}},
   "kind": 14},
  {"tags": [],
   "name": "Lean.Server.Test.Refs.Test6",
   "location":
   {"uri": "file:///src/Lean/Server/Test/Refs.lean",
    "range":
-   {"start": {"line": 23, "character": 17},
-    "end": {"line": 23, "character": 22}}},
+   {"start": {"line": 26, "character": 17},
+    "end": {"line": 26, "character": 22}}},
   "kind": 14},
  {"tags": [],
   "name": "Lean.Server.Test.Refs.Test5",
+  "location":
+  {"uri": "file:///src/Lean/Server/Test/Refs.lean",
+   "range":
+   {"start": {"line": 24, "character": 11},
+    "end": {"line": 24, "character": 16}}},
+  "kind": 14},
+ {"tags": [],
+  "name": "Lean.Server.Test.Refs.Test4",
+  "location":
+  {"uri": "file:///src/Lean/Server/Test/Refs.lean",
+   "range":
+   {"start": {"line": 23, "character": 11},
+    "end": {"line": 23, "character": 16}}},
+  "kind": 14},
+ {"tags": [],
+  "name": "Lean.Server.Test.Refs.Test3",
+  "location":
+  {"uri": "file:///src/Lean/Server/Test/Refs.lean",
+   "range":
+   {"start": {"line": 22, "character": 11},
+    "end": {"line": 22, "character": 16}}},
+  "kind": 14},
+ {"tags": [],
+  "name": "Lean.Server.Test.Refs.Test2",
   "location":
   {"uri": "file:///src/Lean/Server/Test/Refs.lean",
    "range":
@@ -48,7 +72,7 @@
     "end": {"line": 21, "character": 16}}},
   "kind": 14},
  {"tags": [],
-  "name": "Lean.Server.Test.Refs.Test4",
+  "name": "Lean.Server.Test.Refs.Test1",
   "location":
   {"uri": "file:///src/Lean/Server/Test/Refs.lean",
    "range":
@@ -56,42 +80,18 @@
     "end": {"line": 20, "character": 16}}},
   "kind": 14},
  {"tags": [],
-  "name": "Lean.Server.Test.Refs.Test3",
-  "location":
-  {"uri": "file:///src/Lean/Server/Test/Refs.lean",
-   "range":
-   {"start": {"line": 19, "character": 11},
-    "end": {"line": 19, "character": 16}}},
-  "kind": 14},
- {"tags": [],
-  "name": "Lean.Server.Test.Refs.Test2",
-  "location":
-  {"uri": "file:///src/Lean/Server/Test/Refs.lean",
-   "range":
-   {"start": {"line": 18, "character": 11},
-    "end": {"line": 18, "character": 16}}},
-  "kind": 14},
- {"tags": [],
-  "name": "Lean.Server.Test.Refs.Test1",
-  "location":
-  {"uri": "file:///src/Lean/Server/Test/Refs.lean",
-   "range":
-   {"start": {"line": 17, "character": 11},
-    "end": {"line": 17, "character": 16}}},
-  "kind": 14},
- {"tags": [],
   "name": "Lean.Server.Test.Refs.test10",
   "location":
   {"uri": "file:///src/Lean/Server/Test/Refs.lean",
    "range":
-   {"start": {"line": 28, "character": 11},
-    "end": {"line": 28, "character": 17}}},
+   {"start": {"line": 31, "character": 11},
+    "end": {"line": 31, "character": 17}}},
   "kind": 14},
  {"tags": [],
   "name": "Lean.Server.Test.Refs.Test6.mk",
   "location":
   {"uri": "file:///src/Lean/Server/Test/Refs.lean",
    "range":
-   {"start": {"line": 24, "character": 4},
-    "end": {"line": 24, "character": 6}}},
+   {"start": {"line": 27, "character": 4},
+    "end": {"line": 27, "character": 6}}},
   "kind": 14}]


### PR DESCRIPTION
This PR enabled the `coreInternal` linter set in core, which currently consists of one linter `coreInternal.internalModule` (added in #14110).

A series of PRs in the last two weeks fixed most places where this linter originally would have fired. The linter is disabled on remaining cases. Almost all of these are builtin (d)simprocs, which are allowed to be declarations in the root namespace despite being declared in `Lean` (not `Init` or `Std`).