### PR TITLE
chore: fix `addBuiltinLinterSet` docstring

### DIFF
--- a/src/Lean/Linter/Init.lean
+++ b/src/Lean/Linter/Init.lean
@@ -47,8 +47,10 @@ participate in `getLinterValue` like any user-declared set.
 -/
 builtin_initialize builtinLinterSetsRef : IO.Ref (Array (Name × NameSet)) ← IO.mkRef #[]
 
-/-- Register a builtin linter set entry. Only valid during initialization;
-use `register_builtin_linter_set` rather than calling this directly. -/
+/-- 
+  Register a builtin linter set entry. 
+  Only valid during initialization.
+-/
 def addBuiltinLinterSet (setName : Name) (linterNames : NameSet) : IO Unit := do
   builtinLinterSetsRef.modify (·.push (setName, linterNames))
 


### PR DESCRIPTION
This PR fixes the docstring of `addBuiltinLinterSet `