### PR TITLE
refactor: remove funext dependency from Classical.em, drop Quot.sound

### DIFF
--- a/src/Init/Classical.lean
+++ b/src/Init/Classical.lean
@@ -36,28 +36,20 @@ theorem choose_spec {α : Sort u} {p : α → Prop} (h : ∃ x, p x) : p (choose
 theorem em (p : Prop) : p ∨ ¬p :=
   let U := (p, True)
   let V := (True, p)
-  let f : Prop × Prop → Bool → Prop :=
-    fun p b => bif b then p.2 else p.1
+  let f (p : Prop × Prop) (b : Bool) : Prop := bif b then p.2 else p.1
   have exU : ∃ x, f U x := ⟨true, trivial⟩
   have exV : ∃ x, f V x := ⟨false, trivial⟩
   let u : Bool := choose exU
   let v : Bool := choose exV
   have u_def : f U u := choose_spec exU
   have v_def : f V v := choose_spec exV
-  have huvp : u ≠ v ∨ p :=
+  have huvp : p ∨ u ≠ v :=
     match u, v with
-    | false, _ => Or.inr u_def
-    | _, true => Or.inr v_def
-    | true, false => Or.inl Bool.noConfusion
-  have p_implies_uv : p → u = v :=
-    fun hp =>
-    have hUV : U = V := by simp [hp, U, V]
-    have h₀ : ∀ exU exV, choose exU = choose exV := by
-      rw [hUV]; intros; rfl
-    h₀ ..
-  match huvp with
-  | Or.inl hne => Or.inr (mt p_implies_uv hne)
-  | Or.inr h   => Or.inl h
+    | false, _ => Or.inl u_def
+    | _, true => Or.inl v_def
+    | true, false => Or.inr Bool.noConfusion
+  have p_implies_uv : p → u = v := (by simp [·, u, v, U, V])
+  huvp.imp_right (mt p_implies_uv)
 
 theorem exists_true_of_nonempty {α : Sort u} : Nonempty α → ∃ _ : α, True
   | ⟨x⟩ => ⟨x, trivial⟩

--- a/src/Init/Classical.lean
+++ b/src/Init/Classical.lean
@@ -32,34 +32,27 @@ noncomputable def choose {α : Sort u} {p : α → Prop} (h : ∃ x, p x) : α :
 theorem choose_spec {α : Sort u} {p : α → Prop} (h : ∃ x, p x) : p (choose h) :=
   (indefiniteDescription p h).property
 
-/-- **Diaconescu's theorem**: excluded middle from choice, Function extensionality and propositional extensionality. -/
+/-- **Diaconescu's theorem**: excluded middle from choice and propositional extensionality. -/
 theorem em (p : Prop) : p ∨ ¬p :=
-  let U (x : Prop) : Prop := x = True ∨ p
-  let V (x : Prop) : Prop := x = False ∨ p
-  have exU : ∃ x, U x := ⟨True, Or.inl rfl⟩
-  have exV : ∃ x, V x := ⟨False, Or.inl rfl⟩
-  let u : Prop := choose exU
-  let v : Prop := choose exV
-  have u_def : U u := choose_spec exU
-  have v_def : V v := choose_spec exV
+  let U := (p, True)
+  let V := (True, p)
+  let f : Prop × Prop → Bool → Prop :=
+    fun p b => bif b then p.2 else p.1
+  have exU : ∃ x, f U x := ⟨true, trivial⟩
+  have exV : ∃ x, f V x := ⟨false, trivial⟩
+  let u : Bool := choose exU
+  let v : Bool := choose exV
+  have u_def : f U u := choose_spec exU
+  have v_def : f V v := choose_spec exV
   have not_uv_or_p : u ≠ v ∨ p :=
-    match u_def, v_def with
-    | Or.inr h, _ => Or.inr h
-    | _, Or.inr h => Or.inr h
-    | Or.inl hut, Or.inl hvf =>
-      have hne : u ≠ v := by simp [hvf, hut]
-      Or.inl hne
+    match u, v with
+    | false, _ => Or.inr u_def
+    | _, true => Or.inr v_def
+    | true, false => Or.inl Bool.noConfusion
   have p_implies_uv : p → u = v :=
     fun hp =>
-    have hpred : U = V :=
-      funext fun x =>
-        have hl : (x = True ∨ p) → (x = False ∨ p) :=
-          fun _ => Or.inr hp
-        have hr : (x = False ∨ p) → (x = True ∨ p) :=
-          fun _ => Or.inr hp
-        show (x = True ∨ p) = (x = False ∨ p) from
-          propext (Iff.intro hl hr)
-    have h₀ : ∀ exU exV, @choose _ U exU = @choose _ V exV := by
+    have hpred : U = V := by simp [hp, U, V]
+    have h₀ : ∀ exU exV, choose exU = choose exV := by
       rw [hpred]; intros; rfl
     show u = v from h₀ _ _
   match not_uv_or_p with

--- a/src/Init/Classical.lean
+++ b/src/Init/Classical.lean
@@ -45,9 +45,9 @@ theorem em (p : Prop) : p ∨ ¬p :=
   have v_def : f V v := choose_spec exV
   have huvp : p ∨ u ≠ v :=
     match u, v with
-    | false, _ => Or.inl u_def
-    | _, true => Or.inl v_def
-    | true, false => Or.inr Bool.noConfusion
+    | false, _ => .inl u_def
+    | _, true => .inl v_def
+    | true, false => .inr Bool.noConfusion
   have p_implies_uv : p → u = v := (by simp [·, u, v, U, V])
   huvp.imp_right (mt p_implies_uv)
 

--- a/src/Init/Classical.lean
+++ b/src/Init/Classical.lean
@@ -44,18 +44,18 @@ theorem em (p : Prop) : p ∨ ¬p :=
   let v : Bool := choose exV
   have u_def : f U u := choose_spec exU
   have v_def : f V v := choose_spec exV
-  have not_uv_or_p : u ≠ v ∨ p :=
+  have huvp : u ≠ v ∨ p :=
     match u, v with
     | false, _ => Or.inr u_def
     | _, true => Or.inr v_def
     | true, false => Or.inl Bool.noConfusion
   have p_implies_uv : p → u = v :=
     fun hp =>
-    have hpred : U = V := by simp [hp, U, V]
+    have hUV : U = V := by simp [hp, U, V]
     have h₀ : ∀ exU exV, choose exU = choose exV := by
-      rw [hpred]; intros; rfl
-    show u = v from h₀ _ _
-  match not_uv_or_p with
+      rw [hUV]; intros; rfl
+    h₀ ..
+  match huvp with
   | Or.inl hne => Or.inr (mt p_implies_uv hne)
   | Or.inr h   => Or.inl h
 


### PR DESCRIPTION
This PR removes the usage of funext in the proof of excluded-middle (Diaconescu's theorem). As a result, the dependency on the axiom `Quot.sound` disappears from `em`.

This small refactoring is inspired by [this MO question](https://mathoverflow.net/questions/486335/diaconescus-theorem-in-type-theory-without-propositional-extensionality) by Jean Abou Samra.

It also makes the proof substantially simpler while keeping the original structure.

**Before**

```lean
#print axioms em
'Classical.em' depends on axioms: [propext, choice, Quot.sound]
```

**After**

```lean
#print axioms em
'Classical.em' depends on axioms: [propext, choice]
```