### PR TITLE
feat: look for .ilean.mmap files on watchdog load

### DIFF
--- a/src/Lean/Server/References.lean
+++ b/src/Lean/Server/References.lean
@@ -216,6 +216,76 @@ structure Ilean where
   decls         : Lsp.Decls
   deriving FromJson, ToJson
 
+/--
+The contents of an `.ilean` file together with metadata.
+This data structure is intended to be stored on disk
+as a memory-mappable `CompactedRegion` file with an `.ilean.mmap` extension.
+
+(This is like an `.olean` file and unlike an `.ilean` file, which is JSON.)
+
+The `.ilean.hash` value is stored in a `CompactedIlean`
+so that any update that Lake makes to the `.ilean` file
+will cause the server to treat the contents of the `.ilean.mmap` file as stale.
+-/
+structure CompactedIlean extends Ilean where
+  /--
+  The `.ilean.hash` value for the stored `.ilean`, if it existed when the `CompactedIlean` was created.
+  The `.none` side of the `Option` is relevant for toolchain-distributed `.ilean` files do not have a corresponding `.ilean.hash` file.
+  -/
+  hash : Option UInt64
+
+/--
+Given `<path>.hash`, attempt to read the 64-bit hex value it contains.
+Duplicates, and needs to be kept functionally in sync with, `Lake.Hash.load?`.
+-/
+private def loadHash (hashFile : System.FilePath) : IO UInt64 := do
+  let contents ← FS.readBinFile hashFile
+  if contents.size != 16 then throw (.userError s!"hash file does not have expected form")
+
+  let mut result: UInt64 := 0
+  for byte in contents do
+    result := result.shiftLeft 4
+    if '0'.toUInt8 ≤ byte && byte ≤ '9'.toUInt8 then result := result + (byte - '0'.toUInt8).toUInt64
+    else if 'a'.toUInt8 ≤ byte && byte ≤ 'f'.toUInt8 then result := result + (byte - 'a'.toUInt8 + 10).toUInt64
+    else if 'A'.toUInt8 ≤ byte && byte ≤ 'F'.toUInt8 then result := result + (byte - 'A'.toUInt8 + 10).toUInt64
+    else throw (.userError s!"unexpected byte {byte} in hash")
+  return result
+
+/--
+The extension for a memory-mappable ilean file
+-/
+def CompactedIlean.ext := "ilean.mmap"
+
+/--
+Given a path `<path>.ilean`, attempt to read `<path>.ilean.mmap` as a `CompactedRegion` file
+that contains a `CompactedIlean`.
+
+This function uses the existence and contents of the `<path>.ilean.hash` file
+to avoid returning a value that does not represent the current contents of `<path>.ilean`.
+If `<path>.ilean.hash` does not exist, the `CompactedIlean` must include a hash value `.none`.
+If `<path>.ilean.hash` does exist, the `CompactedIlean` must include a hash value `.some h`,
+where `h` is the value in `<path>.ilean.hash`.
+
+Returns `.none` if the file does not exist,
+`.some ilean` if the file can be loaded as a `CompactedIlean` with the expected hash value.
+-/
+def CompactedIlean.load (ileanPath : System.FilePath) : IO (Option Ilean) := do
+  if ileanPath.extension ≠ .some "ilean" then throw (.userError s!"CompactedIlean.load: '{ileanPath}' not an .ilean")
+  let compactedIleanPath := ileanPath.withExtension CompactedIlean.ext
+  if not (← compactedIleanPath.pathExists) then return .none
+
+  let hashPath := ileanPath.addExtension "hash"
+
+  -- nb: ignoring the region means we can't unmap this ilean later
+  let (compactedIlean, _region) ← unsafe CompactedRegion.read (α := CompactedIlean) compactedIleanPath #[]
+  if let .some memHash := compactedIlean.hash then
+    if not (← hashPath.pathExists) then throw (.userError s!"CompactedIlean.load: '{compactedIleanPath}' expected '{hashPath}' to exist, but that file does not exist")
+    let fsHash ← loadHash hashPath
+    if memHash ≠ fsHash then throw (.userError s!"CompactedIlean.load: '{compactedIleanPath}' expects a .ilean.hash value {String.ofList <| Nat.toDigits 16 memHash.toNat}, but .ilean.hash contains {String.ofList <| Nat.toDigits 16 fsHash.toNat}")
+  else
+    if (← hashPath.pathExists) then throw (.userError s!"CompactedIlean.load: '{compactedIleanPath}' expected no '{hashPath}' to exist, but that file does exist")
+  return compactedIlean.toIlean
+
 namespace Ilean
 
 open Lean.IO

--- a/src/Lean/Server/References.lean
+++ b/src/Lean/Server/References.lean
@@ -232,10 +232,11 @@ def Ilean.loadCompacted (ileanPath : System.FilePath) : IO (Option Ilean) := do
   if ileanPath.extension ≠ .some "ilean" then throw (.userError s!"Ilean.loadCompacted: '{ileanPath}' not an .ilean")
 
   let compactedIleanPath := ileanPath.withExtension Ilean.compactedExt
-  if not (← compactedIleanPath.pathExists) then return .none
+  let .ok compactedModified := (← compactedIleanPath.metadata.toBaseIO) |>.map FS.Metadata.modified
+    | return .none -- assume file does not exist
 
   -- The strict inequality is important on systems like Nix that reset all timestamps to the epoch: we don't want that to be an error
-  if (← compactedIleanPath.metadata).modified < (← ileanPath.metadata).modified then
+  if compactedModified < (← ileanPath.metadata).modified then
     throw (.userError s!"Ilean.loadCompacted: {compactedIleanPath} is out of date compared to {ileanPath}")
 
   -- nb: ignoring the region means we can't unmap this ilean later

--- a/src/Lean/Server/References.lean
+++ b/src/Lean/Server/References.lean
@@ -217,74 +217,30 @@ structure Ilean where
   deriving FromJson, ToJson
 
 /--
-The contents of an `.ilean` file together with metadata.
-This data structure is intended to be stored on disk
-as a memory-mappable `CompactedRegion` file with an `.ilean.mmap` extension.
-
-(This is like an `.olean` file and unlike an `.ilean` file, which is JSON.)
-
-The `.ilean.hash` value is stored in a `CompactedIlean`
-so that any update that Lake makes to the `.ilean` file
-will cause the server to treat the contents of the `.ilean.mmap` file as stale.
--/
-structure CompactedIlean extends Ilean where
-  /--
-  The `.ilean.hash` value for the stored `.ilean`, if it existed when the `CompactedIlean` was created.
-  The `.none` side of the `Option` is relevant for toolchain-distributed `.ilean` files do not have a corresponding `.ilean.hash` file.
-  -/
-  hash : Option UInt64
-
-/--
-Given `<path>.hash`, attempt to read the 64-bit hex value it contains.
-Duplicates, and needs to be kept functionally in sync with, `Lake.Hash.load?`.
--/
-private def loadHash (hashFile : System.FilePath) : IO UInt64 := do
-  let contents ← FS.readBinFile hashFile
-  if contents.size != 16 then throw (.userError s!"hash file does not have expected form")
-
-  let mut result: UInt64 := 0
-  for byte in contents do
-    result := result.shiftLeft 4
-    if '0'.toUInt8 ≤ byte && byte ≤ '9'.toUInt8 then result := result + (byte - '0'.toUInt8).toUInt64
-    else if 'a'.toUInt8 ≤ byte && byte ≤ 'f'.toUInt8 then result := result + (byte - 'a'.toUInt8 + 10).toUInt64
-    else if 'A'.toUInt8 ≤ byte && byte ≤ 'F'.toUInt8 then result := result + (byte - 'A'.toUInt8 + 10).toUInt64
-    else throw (.userError s!"unexpected byte {byte} in hash")
-  return result
-
-/--
 The extension for a memory-mappable ilean file
 -/
-def CompactedIlean.ext := "ilean.mmap"
+def Ilean.compactedExt := "ilean.mmap"
 
 /--
-Given a path `<path>.ilean`, attempt to read `<path>.ilean.mmap` as a `CompactedRegion` file
-that contains a `CompactedIlean`.
+Given a path `<path>.ilean`, attempt to read `<path>.ilean.mmap` as a `CompactedRegion` file that contains an `Ilean`.
 
-This function uses the existence and contents of the `<path>.ilean.hash` file
-to avoid returning a value that does not represent the current contents of `<path>.ilean`.
-If `<path>.ilean.hash` does not exist, the `CompactedIlean` must include a hash value `.none`.
-If `<path>.ilean.hash` does exist, the `CompactedIlean` must include a hash value `.some h`,
-where `h` is the value in `<path>.ilean.hash`.
-
-Returns `.none` if the file does not exist,
-`.some ilean` if the file can be loaded as a `CompactedIlean` with the expected hash value.
+Returns `.none` if `<path>.ilean.mmap` does not exist.
+Returns `.some ilean` if `<path>.ilean.mmap` exists, has a timestamp >= `<path>.ilean`, and can be loaded as a `CompactRegion` containing an `Ilean`.
+Raises an `IO.Error` otherwise.
 -/
-def CompactedIlean.load (ileanPath : System.FilePath) : IO (Option Ilean) := do
-  if ileanPath.extension ≠ .some "ilean" then throw (.userError s!"CompactedIlean.load: '{ileanPath}' not an .ilean")
-  let compactedIleanPath := ileanPath.withExtension CompactedIlean.ext
+def Ilean.loadCompacted (ileanPath : System.FilePath) : IO (Option Ilean) := do
+  if ileanPath.extension ≠ .some "ilean" then throw (.userError s!"Ilean.loadCompacted: '{ileanPath}' not an .ilean")
+
+  let compactedIleanPath := ileanPath.withExtension Ilean.compactedExt
   if not (← compactedIleanPath.pathExists) then return .none
 
-  let hashPath := ileanPath.addExtension "hash"
+  -- The strict inequality is important on systems like Nix that reset all timestamps to the epoch: we don't want that to be an error
+  if (← compactedIleanPath.metadata).modified < (← ileanPath.metadata).modified then
+    throw (.userError s!"Ilean.loadCompacted: {compactedIleanPath} is out of date compared to {ileanPath}")
 
   -- nb: ignoring the region means we can't unmap this ilean later
-  let (compactedIlean, _region) ← unsafe CompactedRegion.read (α := CompactedIlean) compactedIleanPath #[]
-  if let .some memHash := compactedIlean.hash then
-    if not (← hashPath.pathExists) then throw (.userError s!"CompactedIlean.load: '{compactedIleanPath}' expected '{hashPath}' to exist, but that file does not exist")
-    let fsHash ← loadHash hashPath
-    if memHash ≠ fsHash then throw (.userError s!"CompactedIlean.load: '{compactedIleanPath}' expects a .ilean.hash value {String.ofList <| Nat.toDigits 16 memHash.toNat}, but .ilean.hash contains {String.ofList <| Nat.toDigits 16 fsHash.toNat}")
-  else
-    if (← hashPath.pathExists) then throw (.userError s!"CompactedIlean.load: '{compactedIleanPath}' expected no '{hashPath}' to exist, but that file does exist")
-  return compactedIlean.toIlean
+  let (compactedIlean, _region) ← unsafe CompactedRegion.read (α := Ilean) compactedIleanPath #[]
+  return .some compactedIlean
 
 namespace Ilean
 

--- a/src/Lean/Server/Watchdog.lean
+++ b/src/Lean/Server/Watchdog.lean
@@ -15,6 +15,7 @@ public import Lean.Server.Completion.CompletionUtils
 public import Init.Data.List.Sort
 public import Std.Sync.Channel
 public import Lean.Server.Logging
+import all Lean.Elab.ErrorUtils
 
 public section
 
@@ -1678,9 +1679,30 @@ results in requests that need references.
 def startLoadingReferences (referenceData : Std.Mutex ReferenceData) : IO Unit := do
   let task ← ServerTask.IO.asTask do
     let oleanSearchPath ← Lean.searchPathRef.get
+    let mut compactedIleanCount := 0
+    let mut compactedIleanErrors := 0
+    let mut visitedPaths : Std.HashSet System.FilePath := {}
     for path in ← oleanSearchPath.findAllWithExt "ilean" do
+      -- Avoid loading an ilean twice
+      let realPath ← FS.realPath path
+      if visitedPaths.contains realPath then continue
+      visitedPaths := visitedPaths.insert realPath
+
+      let compactedIlean : Option Ilean ← try
+          let .some compactedIlean ← CompactedIlean.load path | pure .none
+          compactedIleanCount := compactedIleanCount + 1
+          pure compactedIlean
+        catch _ =>
+          -- compacted ilean load errors should not be fatal, but we *should* log them
+          -- individually to help debug the global error message we give on error
+          compactedIleanErrors := compactedIleanErrors + 1
+          compactedIleanCount := compactedIleanCount + 1 -- errors mean there *was* a `.ilean.mmap` file, but something went wrong
+          pure .none
+
       try
-        let ilean ← Ilean.load path
+        let ilean ← match compactedIlean with
+          | .none => Ilean.load path
+          | .some il => pure il
         referenceData.atomically do
           let rd ← get
           let rd ← rd.modifyReferencesM (·.addIlean path ilean)
@@ -1690,6 +1712,8 @@ def startLoadingReferences (referenceData : Std.Mutex ReferenceData) : IO Unit :
         -- ilean load errors should not be fatal, but we *should* log them
         -- when we add logging to the server
         pure ()
+    if compactedIleanErrors > 0 then
+      (← getStderr).putStrLn s!"Attempted to load {compactedIleanCount} .{CompactedIlean.ext} {compactedIleanCount.plural "file"}, but failed to load {compactedIleanErrors} of them"
   referenceData.atomically <| modify fun rd =>
     { rd with loadingTask := task.mapCheap fun _ => () }
 

--- a/src/Lean/Server/Watchdog.lean
+++ b/src/Lean/Server/Watchdog.lean
@@ -1683,12 +1683,13 @@ def startLoadingReferences (referenceData : Std.Mutex ReferenceData) : IO Unit :
     let mut compactedIleanErrors := 0
     let mut visitedPaths : Std.HashSet System.FilePath := {}
     for path in ← oleanSearchPath.findAllWithExt "ilean" do
-      -- Avoid loading an ilean twice
-      let realPath ← FS.realPath path
-      if visitedPaths.contains realPath then continue
-      visitedPaths := visitedPaths.insert realPath
+      try
+        -- Avoid loading an ilean twice
+        let realPath ← FS.realPath path
+        if visitedPaths.contains realPath then continue
+        visitedPaths := visitedPaths.insert realPath
 
-      let compactedIlean : Option Ilean ← try
+        let compactedIlean : Option Ilean ← try
           let .some compactedIlean ← Ilean.loadCompacted path | pure .none
           compactedIleanCount := compactedIleanCount + 1
           pure compactedIlean
@@ -1699,7 +1700,6 @@ def startLoadingReferences (referenceData : Std.Mutex ReferenceData) : IO Unit :
           compactedIleanCount := compactedIleanCount + 1 -- errors mean there *was* a `.ilean.mmap` file, but something went wrong
           pure .none
 
-      try
         let ilean ← match compactedIlean with
           | .none => Ilean.load path
           | .some il => pure il

--- a/src/Lean/Server/Watchdog.lean
+++ b/src/Lean/Server/Watchdog.lean
@@ -1689,7 +1689,7 @@ def startLoadingReferences (referenceData : Std.Mutex ReferenceData) : IO Unit :
       visitedPaths := visitedPaths.insert realPath
 
       let compactedIlean : Option Ilean ← try
-          let .some compactedIlean ← CompactedIlean.load path | pure .none
+          let .some compactedIlean ← Ilean.loadCompacted path | pure .none
           compactedIleanCount := compactedIleanCount + 1
           pure compactedIlean
         catch _ =>
@@ -1713,7 +1713,7 @@ def startLoadingReferences (referenceData : Std.Mutex ReferenceData) : IO Unit :
         -- when we add logging to the server
         pure ()
     if compactedIleanErrors > 0 then
-      (← getStderr).putStrLn s!"Attempted to load {compactedIleanCount} .{CompactedIlean.ext} {compactedIleanCount.plural "file"}, but failed to load {compactedIleanErrors} of them"
+      (← getStderr).putStrLn s!"Attempted to load {compactedIleanCount} .{Ilean.compactedExt} {compactedIleanCount.plural "file"}, but failed to load {compactedIleanErrors} of them"
   referenceData.atomically <| modify fun rd =>
     { rd with loadingTask := task.mapCheap fun _ => () }
 

--- a/src/Lean/Server/Watchdog.lean
+++ b/src/Lean/Server/Watchdog.lean
@@ -1712,6 +1712,9 @@ def startLoadingReferences (referenceData : Std.Mutex ReferenceData) : IO Unit :
         -- ilean load errors should not be fatal, but we *should* log them
         -- when we add logging to the server
         pure ()
+
+    -- This warning message only makes sense if we're only building .ilean.mmap files for read-only toolchain and library files.
+    -- For other use cases, this will be too noisy.
     if compactedIleanErrors > 0 then
       (← getStderr).putStrLn s!"Attempted to load {compactedIleanCount} .{Ilean.compactedExt} {compactedIleanCount.plural "file"}, but failed to load {compactedIleanErrors} of them"
   referenceData.atomically <| modify fun rd =>


### PR DESCRIPTION
This PR introduces a new, memory-mapped route to loading `ilean` objects into memory. This feature should be treated as undocumented and subject to change without notice in future releases.

Lean4web and Workbench memory requirements are, at present, somewhat dominated by the watchdog's ileans. Mmapping ileans has a similar unshared-memory reduction to just deleting the ileans completely. (On live.lean-lang.org we've just deleted them, which slightly degrades the user experience.)

This design looks for `.ilean.mmap` files aside `.ilean` files one time, on watchdog start, and prefers the `.ilean.mmap` file if it has reports a last-modified time that is greater than or equal to the `.ilean`'s last-modified time. 

There's no mechanism for *creating* `.ilean.mmap` files, which is intentional: we only intend for this feature to be used for lean4web and workbench environments that we control at first so that we can back out of this design later on. (The [robsimmons/milean](https://github.com/robsimmons/milean) repository shows one way of building these.) Unless someone goes out of their way to create `.ilean.mmap` files in their `.lake` directories, this PR adds the cost of one failed file lookup per ilean. 

## Benchmarking

These numbers were generated with a slightly different design, but the changes I've made shouldn't make a difference here.

In my benchmarking (on OSX, with a mathlib nightly-testing 2026-07-15 compiled against this branch):  

 * Creating `.ilean.mmap` files for *just* the `.ilean` files in Mathlib: watchdog needs 1.1G memory -> watchdog needs 496M memory
 * Creating `.ilean.mmap` files for all `.ilean` files, including those in the core release: watchdog needs 1.1G memory -> watchdog needs 393M memory.

On Linux the effect is even more dramatic, taking us from 1.1G unshared memory for the watchdog to about 67M unshared memory for the watchdog. (This measurement includes the additional effect of 085ab16fb4e0 — without that change, Linux unshared memory usage "only" goes down to about 171M.)