### PR TITLE
fix: avoid the non-thread-safe `strerror` in `lean_decode_io_error`

### DIFF
--- a/src/runtime/io.cpp
+++ b/src/runtime/io.cpp
@@ -165,32 +165,33 @@ extern "C" LEAN_EXPORT obj_res lean_decode_io_error(int errnum, b_lean_obj_arg f
 
 extern "C" LEAN_EXPORT obj_res lean_decode_uv_error(int errnum, b_lean_obj_arg fname) {
     object * details = mk_string(uv_strerror(errnum));
+    int approx_posix_errnum = approx_posix_errnum;
     switch (errnum) {
     case UV_EINTR:
         lean_assert(fname != nullptr);
         inc_ref(fname);
-        return lean_mk_io_error_interrupted(fname, errnum, details);
+        return lean_mk_io_error_interrupted(fname, approx_posix_errnum, details);
     /* LibUV does not map EDOM, ENOEXEC and ENOSTR as of version 1.48.0 */
     case UV_ELOOP: case UV_ENAMETOOLONG: case UV_EDESTADDRREQ:
     case UV_EBADF: case UV_EINVAL: case UV_EILSEQ:
     case UV_ENOTCONN: case UV_ENOTSOCK:
         if (fname == nullptr) {
-            return lean_mk_io_error_invalid_argument(errnum, details);
+            return lean_mk_io_error_invalid_argument(approx_posix_errnum, details);
         } else {
             inc_ref(fname);
-            return lean_mk_io_error_invalid_argument_file(fname, errnum, details);
+            return lean_mk_io_error_invalid_argument_file(fname, approx_posix_errnum, details);
         }
     case UV_ENOENT:
         lean_assert(fname != nullptr);
         inc_ref(fname);
-        return lean_mk_io_error_no_file_or_directory(fname, errnum, details);
+        return lean_mk_io_error_no_file_or_directory(fname, approx_posix_errnum, details);
     case UV_EACCES: case UV_EROFS: case UV_ECONNABORTED: case UV_EFBIG:
     case UV_EPERM:
         if (fname == nullptr) {
-            return lean_mk_io_error_permission_denied(errnum, details);
+            return lean_mk_io_error_permission_denied(approx_posix_errnum, details);
         } else {
             inc_ref(fname);
-            return lean_mk_io_error_permission_denied_file(fname, errnum, details);
+            return lean_mk_io_error_permission_denied_file(fname, approx_posix_errnum, details);
         }
     /* LibUV does not map ENOLCK and ENOSR as of version 1.48.0 */
     case UV_EMFILE: case UV_ENFILE: case UV_ENOSPC:
@@ -198,18 +199,18 @@ extern "C" LEAN_EXPORT obj_res lean_decode_uv_error(int errnum, b_lean_obj_arg f
     case UV_EMSGSIZE: case UV_ENOBUFS:
     case UV_ENOMEM:
         if (fname == nullptr) {
-            return lean_mk_io_error_resource_exhausted(errnum, details);
+            return lean_mk_io_error_resource_exhausted(approx_posix_errnum, details);
         } else {
             inc_ref(fname);
-            return lean_mk_io_error_resource_exhausted_file(fname, errnum, details);
+            return lean_mk_io_error_resource_exhausted_file(fname, approx_posix_errnum, details);
         }
     /* LibUV does not map EBADMSG as of version 1.48.0 */
     case UV_EISDIR: case UV_ENOTDIR:
         if (fname == nullptr) {
-            return lean_mk_io_error_inappropriate_type(errnum, details);
+            return lean_mk_io_error_inappropriate_type(approx_posix_errnum, details);
         } else {
             inc_ref(fname);
-            return lean_mk_io_error_inappropriate_type_file(fname, errnum, details);
+            return lean_mk_io_error_inappropriate_type_file(fname, approx_posix_errnum, details);
         }
     /* LibUV does not map ECHILD as of version 1.48.0 */
     case UV_ENXIO: case UV_EHOSTUNREACH: case UV_ENETUNREACH:
@@ -219,53 +220,53 @@ extern "C" LEAN_EXPORT obj_res lean_decode_uv_error(int errnum, b_lean_obj_arg f
 #endif
     case UV_ESRCH:
         if (fname == nullptr) {
-            return lean_mk_io_error_no_such_thing(errnum, details);
+            return lean_mk_io_error_no_such_thing(approx_posix_errnum, details);
         } else {
             inc_ref(fname);
-            return lean_mk_io_error_no_such_thing_file(fname, errnum, details);
+            return lean_mk_io_error_no_such_thing_file(fname, approx_posix_errnum, details);
         }
     /* LibUV does not map EINPROGRESS as of version 1.48.0 */
     case UV_EEXIST: case UV_EISCONN:
         if (fname == nullptr) {
-            return lean_mk_io_error_already_exists(errnum, details);
+            return lean_mk_io_error_already_exists(approx_posix_errnum, details);
         } else {
             inc_ref(fname);
-            return lean_mk_io_error_already_exists_file(fname, errnum, details);
+            return lean_mk_io_error_already_exists_file(fname, approx_posix_errnum, details);
         }
     case UV_EIO:
         lean_assert(fname == nullptr);
-        return lean_mk_io_error_hardware_fault(errnum, details);
+        return lean_mk_io_error_hardware_fault(approx_posix_errnum, details);
     case UV_ENOTEMPTY:
         lean_assert(fname == nullptr);
-        return lean_mk_io_error_unsatisfied_constraints(errnum, details);
+        return lean_mk_io_error_unsatisfied_constraints(approx_posix_errnum, details);
     case UV_ENOTTY:
         lean_assert(fname == nullptr);
-        return lean_mk_io_error_illegal_operation(errnum, details);
+        return lean_mk_io_error_illegal_operation(approx_posix_errnum, details);
     /* LibUV does not map EIDRM, ENETRESET and ENOLINK as of version 1.48.0 */
     case UV_ECONNRESET: case UV_ENETDOWN:
     case UV_EPIPE:
         lean_assert(fname == nullptr);
-        return lean_mk_io_error_resource_vanished(errnum, details);
+        return lean_mk_io_error_resource_vanished(approx_posix_errnum, details);
     case UV_EPROTO: case UV_EPROTONOSUPPORT: case UV_EPROTOTYPE:
         lean_assert(fname == nullptr);
-        return lean_mk_io_error_protocol_error(errnum, details);
+        return lean_mk_io_error_protocol_error(approx_posix_errnum, details);
     /* LibUV does not map ETIME as of version 1.48.0 */
     case UV_ETIMEDOUT:
         lean_assert(fname == nullptr);
-        return lean_mk_io_error_time_expired(errnum, details);
+        return lean_mk_io_error_time_expired(approx_posix_errnum, details);
     /* LibUV does not map EDEADLK as of version 1.48.0 */
     case UV_EADDRINUSE: case UV_EBUSY: case UV_ETXTBSY:
         lean_assert(fname == nullptr);
-        return lean_mk_io_error_resource_busy(errnum, details);
+        return lean_mk_io_error_resource_busy(approx_posix_errnum, details);
     case UV_EADDRNOTAVAIL: case UV_EAFNOSUPPORT: case UV_ENODEV:
     case UV_ENOPROTOOPT: case UV_ENOSYS: case UV_ENOTSUP:
     case UV_ERANGE: case UV_ESPIPE: case UV_EXDEV:
         lean_assert(fname == nullptr);
-        return lean_mk_io_error_unsupported_operation(errnum, details);
+        return lean_mk_io_error_unsupported_operation(approx_posix_errnum, details);
     case UV_EFAULT:
     default:
         lean_assert(fname == nullptr);
-        return lean_mk_io_error_other_error(errnum, details);
+        return lean_mk_io_error_other_error(approx_posix_errnum, details);
     }
 }
 

--- a/src/runtime/io.cpp
+++ b/src/runtime/io.cpp
@@ -160,105 +160,11 @@ static FILE * io_get_handle(lean_object * hfile) {
 }
 
 extern "C" LEAN_EXPORT obj_res lean_decode_io_error(int errnum, b_lean_obj_arg fname) {
-    object * details = mk_string(strerror(errnum));
-    // Keep in sync with lean_decode_uv_error below
-    switch (errnum) {
-    case EINTR:
-        lean_assert(fname != nullptr);
-        inc_ref(fname);
-        return lean_mk_io_error_interrupted(fname, errnum, details);
-    case ELOOP: case ENAMETOOLONG: case EDESTADDRREQ:
-    case EBADF: case EDOM: case EINVAL: case EILSEQ:
-    case ENOEXEC: case ENOSTR: case ENOTCONN:
-    case ENOTSOCK:
-        if (fname == nullptr) {
-            return lean_mk_io_error_invalid_argument(errnum, details);
-        } else {
-            inc_ref(fname);
-            return lean_mk_io_error_invalid_argument_file(fname, errnum, details);
-        }
-    case ENOENT:
-        lean_assert(fname != nullptr);
-        inc_ref(fname);
-        return lean_mk_io_error_no_file_or_directory(fname, errnum, details);
-    case EACCES: case EROFS: case ECONNABORTED: case EFBIG:
-    case EPERM:
-        if (fname == nullptr) {
-            return lean_mk_io_error_permission_denied(errnum, details);
-        } else {
-            inc_ref(fname);
-            return lean_mk_io_error_permission_denied_file(fname, errnum, details);
-        }
-    case EMFILE: case ENFILE: case ENOSPC:
-    case E2BIG:  case EAGAIN: case EMLINK:
-    case EMSGSIZE: case ENOBUFS: case ENOLCK:
-    case ENOMEM: case ENOSR:
-        if (fname == nullptr) {
-            return lean_mk_io_error_resource_exhausted(errnum, details);
-        } else {
-            inc_ref(fname);
-            return lean_mk_io_error_resource_exhausted_file(fname, errnum, details);
-        }
-    case EISDIR: case EBADMSG: case ENOTDIR:
-        if (fname == nullptr) {
-            return lean_mk_io_error_inappropriate_type(errnum, details);
-        } else {
-            inc_ref(fname);
-            return lean_mk_io_error_inappropriate_type_file(fname, errnum, details);
-        }
-    case ENXIO: case EHOSTUNREACH: case ENETUNREACH:
-    case ECHILD: case ECONNREFUSED: case ENODATA:
-    case ENOMSG: case ESRCH:
-        if (fname == nullptr) {
-            return lean_mk_io_error_no_such_thing(errnum, details);
-        } else {
-            inc_ref(fname);
-            return lean_mk_io_error_no_such_thing_file(fname, errnum, details);
-        }
-    case EEXIST: case EINPROGRESS: case EISCONN:
-        if (fname == nullptr) {
-            return lean_mk_io_error_already_exists(errnum, details);
-        } else {
-            inc_ref(fname);
-            return lean_mk_io_error_already_exists_file(fname, errnum, details);
-        }
-    case EIO:
-        lean_assert(fname == nullptr);
-        return lean_mk_io_error_hardware_fault(errnum, details);
-    case ENOTEMPTY:
-        lean_assert(fname == nullptr);
-        return lean_mk_io_error_unsatisfied_constraints(errnum, details);
-    case ENOTTY:
-        lean_assert(fname == nullptr);
-        return lean_mk_io_error_illegal_operation(errnum, details);
-    case ECONNRESET: case EIDRM: case ENETDOWN: case ENETRESET:
-    case ENOLINK: case EPIPE:
-        lean_assert(fname == nullptr);
-        return lean_mk_io_error_resource_vanished(errnum, details);
-    case EPROTO: case EPROTONOSUPPORT: case EPROTOTYPE:
-        lean_assert(fname == nullptr);
-        return lean_mk_io_error_protocol_error(errnum, details);
-    case ETIME: case ETIMEDOUT:
-        lean_assert(fname == nullptr);
-        return lean_mk_io_error_time_expired(errnum, details);
-    case EADDRINUSE: case EBUSY: case EDEADLK: case ETXTBSY:
-        lean_assert(fname == nullptr);
-        return lean_mk_io_error_resource_busy(errnum, details);
-    case EADDRNOTAVAIL: case EAFNOSUPPORT: case ENODEV:
-    case ENOPROTOOPT: case ENOSYS: case EOPNOTSUPP:
-    case ERANGE: case ESPIPE: case EXDEV:
-        lean_assert(fname == nullptr);
-        return lean_mk_io_error_unsupported_operation(errnum, details);
-    case EFAULT:
-    default:
-        lean_assert(fname == nullptr);
-        return lean_mk_io_error_other_error(errnum, details);
-    }
+    return lean_decode_uv_error(uv_translate_sys_error(errnum), fname);
 }
 
 extern "C" LEAN_EXPORT obj_res lean_decode_uv_error(int errnum, b_lean_obj_arg fname) {
     object * details = mk_string(uv_strerror(errnum));
-    // Keep in sync with lean_decode_io_error above
     switch (errnum) {
     case UV_EINTR:
         lean_assert(fname != nullptr);

--- a/src/runtime/io.cpp
+++ b/src/runtime/io.cpp
@@ -165,7 +165,7 @@ extern "C" LEAN_EXPORT obj_res lean_decode_io_error(int errnum, b_lean_obj_arg f
 
 extern "C" LEAN_EXPORT obj_res lean_decode_uv_error(int errnum, b_lean_obj_arg fname) {
     object * details = mk_string(uv_strerror(errnum));
-    int approx_posix_errnum = approx_posix_errnum;
+    int approx_posix_errnum = -errnum;
     switch (errnum) {
     case UV_EINTR:
         lean_assert(fname != nullptr);


### PR DESCRIPTION
This PR prevents possible corruption if two threads simultaneously call `lean_decode_io_error`. It also changes the semantics of `osCode` in `IO.Error`, such that it emulates posix `errno` rather than forwarding uv error codes cast to unsigned integers.

Recall that `strerror` is not thread-safe.

This also removes the need to maintain two separate error lookups.

Zulip: [#lean4 > Signedness of IO.Error's osCode and libuv @ 💬](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Signedness.20of.20IO.2EError.27s.20osCode.20and.20libuv/near/611212153)