### PR TITLE
fix: restore sharing for discharged hypothesis proofs that occur in the result in `Sym.simp`

### DIFF
--- a/src/Lean/Meta/Sym/Simp/Discharger.lean
+++ b/src/Lean/Meta/Sym/Simp/Discharger.lean
@@ -55,6 +55,8 @@ Given a proposition `e : Prop`, returns:
 
 Both carry a `contextDependent` flag indicating whether context-dependent
 information was used during the attempt.
+
+The returned proof is not required to be maximally shared.
 -/
 public abbrev Discharger := Expr → SimpM DischargeResult
 

--- a/src/Lean/Meta/Sym/Simp/Rewrite.lean
+++ b/src/Lean/Meta/Sym/Simp/Rewrite.lean
@@ -65,7 +65,13 @@ public def Theorem.rewrite (thm : Theorem) (e : Expr) (d : Discharger := dischar
               return mkRflResultCD isCD
             | .solved val cd =>
               isCD := isCD || cd
-              let val ← instantiateMVarsS val
+              -- Dischargers are not required to return maximally shared proofs. Sharing is
+              -- needed only when the hypothesis occurs in `rhs`, and the proof consequently
+              -- becomes part of the resulting term.
+              let val ← if thm.rhsVarMask.testBit i then
+                shareCommon (← instantiateMVars val)
+              else
+                instantiateMVars val
               mvarId.assign val
               args := args.set i val
       else if arg.hasMVar then

--- a/src/Lean/Meta/Sym/Simp/Theorems.lean
+++ b/src/Lean/Meta/Sym/Simp/Theorems.lean
@@ -11,6 +11,7 @@ import Lean.Meta.Sym.Simp.DiscrTree
 import Lean.Meta.AppBuilder
 import Lean.ExtraModUses
 import Init.Omega
+import Init.Data.Range.Polymorphic.Iterators
 public section
 namespace Lean.Meta.Sym.Simp
 
@@ -30,7 +31,11 @@ structure Theorem where
   /-- If `true`, the theorem is a permutation rule (e.g., `x + y = y + x`).
   Rewriting is only applied when the result is strictly less than the input
   (using `acLt`), preventing infinite loops. -/
-  perm    : Bool := false
+  perm    : Bool
+  /-- Bitmask of the pattern variables that occur in `rhs`: bit `i` is set iff pattern
+  variable `i` occurs in `rhs`. `Theorem.rewrite` uses it to detect hypothesis proofs that
+  become part of the resulting term and must consequently be maximally shared. -/
+  rhsVarMask : Nat
   deriving Inhabited
 
 instance : BEq Theorem where
@@ -144,18 +149,36 @@ where
       let h := mkAppN expr xs
       mkLambdaFVars xs (← wrap h)
 
+/--
+Computes the bitmask of the pattern variables occurring in `rhs`.
+Pattern variable `i` corresponds to the loose bound variable `numVars - 1 - i` in `rhs`.
+See `Theorem.rewrite`.
+-/
+private def mkRhsVarMask (numVars : Nat) (rhs : Expr) : Nat := Id.run do
+  let mut mask := 0
+  for i in *...numVars do
+    /-
+    **Note**: We are potentially scanning the `rhs` multiple times. We assume this is ok here
+    because the `rhs` is usually small, and we cache the loose bvar range in `Expr`.
+    -/
+    if rhs.hasLooseBVar (numVars - 1 - i) then
+      mask := mask ||| (1 <<< i)
+  return mask
+
 def mkTheoremFromDecl (declName : Name) : MetaM Theorem := do
   let (pattern, (rhs, adaptation)) ← mkPatternFromDeclWithKey declName selectEqKey (zetaReduceLHSOnly := true)
   let expr ← wrapProof pattern.varTypes.size (mkConst declName) adaptation
   let perm := isPerm pattern.varTypes.size pattern.pattern rhs
-  return { expr, pattern, rhs, perm }
+  let rhsVarMask := mkRhsVarMask pattern.varTypes.size rhs
+  return { expr, pattern, rhs, perm, rhsVarMask }
 
 /-- Create a `Theorem` from a proof expression. Handles equalities, `¬`, `↔`, and propositions. -/
 def mkTheoremFromExpr (e : Expr) : MetaM Theorem := do
   let (pattern, (rhs, adaptation)) ← mkPatternFromExprWithKey e [] selectEqKey (zetaReduceLHSOnly := true)
   let expr ← wrapProof pattern.varTypes.size e adaptation
   let perm := isPerm pattern.varTypes.size pattern.pattern rhs
-  return { expr, pattern, rhs, perm }
+  let rhsVarMask := mkRhsVarMask pattern.varTypes.size rhs
+  return { expr, pattern, rhs, perm, rhsVarMask }
 
 /--
 Environment extension storing a set of `Sym.Simp` theorems.

--- a/tests/elab/sym_rewrite_discharge_sharing.lean
+++ b/tests/elab/sym_rewrite_discharge_sharing.lean
@@ -1,0 +1,46 @@
+import Lean
+set_option warn.sorry false
+
+/-!
+`Theorem.rewrite` must restore maximal sharing for discharger-provided proofs that occur
+in the theorem's `rhs`: the proof becomes part of the resulting term, which must satisfy
+the `SymM` sharing invariant (checked by `sym.debug`). Dischargers are not required to
+return maximally shared proofs.
+-/
+
+open Lean Meta Sym Simp
+
+axiom foo : True ∧ True → Prop
+axiom P : Prop
+axiom Q : Prop
+
+/-- The discharged hypothesis `h` occurs in the `rhs`. -/
+theorem thm1 (h : True ∧ True) : P = foo h := sorry
+
+/-- The discharged hypothesis `h` does not occur in the `rhs`. -/
+theorem thm2 (_h : True ∧ True) : P = Q := sorry
+
+/-- Returns a proof that is not maximally shared. -/
+def discharger : Discharger := fun _ =>
+  return .solved <| mkApp4 (mkConst ``And.intro)
+    (mkConst ``True) (mkConst ``True) (mkConst ``True.intro) (mkConst ``True.intro)
+
+def test (declName : Name) : MetaM Unit := SymM.run do
+  let thm ← mkTheoremFromDecl declName
+  let e ← shareCommon (mkConst ``P)
+  let r ← SimpM.run' (thm.rewrite e discharger)
+  match r with
+  | .step e' proof _ _ =>
+    check proof
+    logInfo m!"step: {e'}"
+  | _ => throwError "expected the rewrite to fire"
+
+/-- info: step: foo ⋯ -/
+#guard_msgs in
+set_option sym.debug true in
+run_meta test ``thm1
+
+/-- info: step: Q -/
+#guard_msgs in
+set_option sym.debug true in
+run_meta test ``thm2


### PR DESCRIPTION
This PR fixes a maximal-sharing violation in `Sym.simp`: when a conditional rewrite discharged a hypothesis that occurs in the theorem's right-hand side., the discharger-provided proof was spliced into the resulting term without restoring maximal sharing, violating the `SymM` sharing invariant (detected by `sym.debug`). Dischargers are not required to return maximally shared proofs. This issue was reported by @hargoniX 

`Theorem` now stores `rhsVarMask`, a bitmask computed once at theorem construction that records which theorem variables occur in the right-hand side. During rewriting, `Theorem.rewrite` applies `shareCommon` to a discharged hypothesis proof only when the corresponding bit is set, i.e., only when the proof becomes part of the resulting term. 
