### PR TITLE
feat: `grind` as `Sym.simp` discharger

### DIFF
--- a/src/Init/Sym/Simp/SimprocDSL.lean
+++ b/src/Init/Sym/Simp/SimprocDSL.lean
@@ -36,6 +36,7 @@ Dischargers attempt to prove side conditions of conditional rewrite rules.
 ### Primitives
 - `self` — recursive simplifier discharge (`dischargeSimpSelf`)
 - `none` — no discharge, only unconditional rewrites apply (`dischargeNone`)
+- `grind` — discharge using `grind` (`Grind.Goal.mkSymSimpDischarger`)
 -/
 
 declare_syntax_cat sym_simproc (behavior := both)
@@ -90,6 +91,14 @@ syntax (name := dischNone) "none" : sym_discharger
 
 /-- Parenthesized discharger expression. -/
 syntax (name := dischParen) "(" sym_discharger ")" : sym_discharger
+
+/--
+Calls `grind` to prove side conditions. The goal's internalized hypotheses (hypotheses are
+internalized when the `sym =>` block starts and by tactics such as `intro` and `internalize`)
+are shared across discharge attempts; the remaining local declarations (e.g., introduced by
+`Sym.simp` when entering binders) are internalized on each attempt.
+-/
+syntax (name := dischGrind) "grind" : sym_discharger
 
 end Lean.Parser.Sym.Simp
 

--- a/src/Lean/Elab/Tactic/Grind/SimprocDSLBuiltin.lean
+++ b/src/Lean/Elab/Tactic/Grind/SimprocDSLBuiltin.lean
@@ -12,6 +12,7 @@ import Lean.Meta.Sym.Simp.Telescope
 import Lean.Meta.Sym.Simp.ControlFlow
 import Lean.Meta.Sym.Simp.Forall
 import Lean.Meta.Sym.Simp.Rewrite
+import Lean.Meta.Sym.Grind
 namespace Lean.Elab.Tactic.Grind
 open Meta Sym.Simp
 
@@ -95,5 +96,11 @@ def elabDischNone : SymDischargerElab := fun _ =>
 def elabDischParen : SymDischargerElab := fun stx => do
   let `(sym_discharger| ( $d ) ) := stx | throwUnsupportedSyntax
   elabSymDischarger d
+
+@[builtin_sym_discharger dischGrind]
+def elabDischGrind : SymDischargerElab := fun _ => do
+  if (← getGoals).isEmpty then return dischargeNone
+  let goal ← getMainGoal
+  liftGrindM <| goal.mkSymSimpDischarger
 
 end Lean.Elab.Tactic.Grind

--- a/src/Lean/Meta/Sym/Grind.lean
+++ b/src/Lean/Meta/Sym/Grind.lean
@@ -8,10 +8,12 @@ prelude
 public import Lean.Meta.Tactic.Grind.Types
 public import Lean.Meta.Sym.Simp.SimpM
 public import Lean.Meta.Sym.Apply
+public import Lean.Meta.Sym.Simp.Discharger
 import Lean.Meta.Tactic.Grind.Main
 import Lean.Meta.Sym.Simp.Goal
 import Lean.Meta.Sym.Intro
 import Lean.Meta.Sym.Util
+import Lean.Meta.Sym.InstantiateMVarsS
 import Lean.Meta.Tactic.Grind.Solve
 import Lean.Meta.Tactic.Assumption
 namespace Lean.Meta.Grind
@@ -39,6 +41,10 @@ let .closed ← goal.grind | failure
 
 Operations like `introN`, `apply`, and `simp` run in `SymM` for performance.
 `internalize` and `grind` run in `GrindM` to access the E-graph.
+
+`Goal.mkSymSimpDischarger` creates a `Sym.simp` discharger that proves side conditions of
+conditional rewrite rules using `grind`, sharing the goal's internalized local context
+across discharge attempts.
 -/
 
 
@@ -125,5 +131,56 @@ Returns `true` on success.
 public def Goal.assumption (goal : Goal) : MetaM Bool := do
   -- **TODO**: add indexing
   goal.mvarId.assumptionCore
+
+/--
+Attempts to discharge the side condition `e` using `grind`, starting from `goal`'s state.
+
+`goal`'s local context must be a prefix of the current local context, and its hypotheses
+must have already been internalized (e.g., using `Goal.internalizeAll`). Only the remaining
+local declarations (e.g., hypotheses introduced by `Sym.simp` when entering binders) are
+internalized before invoking `grind`.
+
+Results are marked as context-dependent since `grind` uses the local context.
+Issues reported during the attempt are discarded because discharge attempts are speculative.
+-/
+def Goal.dischargeSymSimp (goal : Goal) (e : Expr) : GrindM Sym.Simp.DischargeResult := do
+  -- `e` may contain metavariables assigned while processing the same rewrite step
+  -- (e.g., hypotheses whose types mention previously discharged hypotheses).
+  let e ← Sym.instantiateMVarsS e
+  -- Issues live in the shared `Sym.State` (the base monad), not in the `Grind.State`
+  -- copy discarded by `mkSymSimpDischarger`. Restore them since attempts are speculative.
+  let savedIssues ← Sym.getIssues
+  try
+    let mvar ← mkFreshExprSyntheticOpaqueMVar e
+    let goal := { goal with mvarId := mvar.mvarId! }
+    let goal ← processHypotheses goal
+    if (← solve goal).isSome then
+      return .failed (contextDependent := true)
+    else
+      return .solved (← instantiateMVars mvar) (contextDependent := true)
+  finally
+    modifyThe Sym.State fun s => { s with issues := savedIssues }
+
+/--
+Creates a `Sym.simp` discharger that attempts to prove side conditions using `grind`.
+
+The discharger is parametrized by the `grind` methods, context, and state `s`. Each discharge
+attempt is terminal: it either produces a proof or fails. Thus, it runs `grind` on a copy of
+`s` on top of the ambient `SymM` state, and the resulting `grind` state is discarded.
+
+`goal` provides the initial `GoalState`. Internalizing the local context once (e.g., using
+`Goal.internalizeAll`) and sharing the resulting `GoalState` across discharge attempts avoids
+re-internalizing the common local context prefix for every side condition; only local
+declarations introduced after `goal` was created are internalized per attempt.
+-/
+def mkSymSimpDischarger (goal : Goal) (methods : MethodsRef) (ctx : Context) (s : State) : Sym.Simp.Discharger := fun e => do
+  goal.dischargeSymSimp e methods ctx |>.run' s
+
+/--
+Creates a `Sym.simp` discharger that attempts to prove side conditions using `grind`,
+capturing the current `grind` methods, context, and state. See `mkSymSimpDischarger`.
+-/
+public def Goal.mkSymSimpDischarger (goal : Goal) : GrindM Sym.Simp.Discharger := do
+  return Grind.mkSymSimpDischarger goal (← getMethodsRef) (← readThe Context) (← get)
 
 end Lean.Meta.Grind

--- a/tests/elab/sym_simp_grind_discharger.lean
+++ b/tests/elab/sym_simp_grind_discharger.lean
@@ -1,0 +1,177 @@
+import Lean
+
+/-!
+Tests for using `grind` as a `Sym.simp` discharger (`Grind.Goal.mkSymSimpDischarger`).
+
+The test defines a `simp_grind` tactic for `sym =>` mode: `Sym.simp` with the side
+conditions of conditional rewrite rules discharged by `grind`. The discharger shares a
+`GoalState` whose local context prefix has been internalized once (`Goal.internalizeAll`);
+each discharge attempt only internalizes the local declarations introduced after that
+(e.g., hypotheses introduced by `Sym.simp` when entering binders).
+-/
+
+open Lean Meta Elab Tactic.Grind
+
+syntax (name := symSimpGrind) "simp_grind" (" [" ident,* "]")? : grind
+
+-- Example for using `grind` discharger programmatically
+@[grind_tactic symSimpGrind] def evalSymSimpGrind : GrindTactic := fun stx => withMainContext do
+  ensureSym
+  let `(grind| simp_grind $[[ $[$extraIds],* ]]?) := stx | throwUnsupportedSyntax
+  let declNames ← (extraIds.getD #[]).mapM fun id => realizeGlobalConstNoOverload id
+  let goal ← getMainGoal
+  -- Internalize the remaining hypotheses once; the resulting state is shared by all
+  -- discharge attempts, which only internalize declarations introduced during `simp`.
+  let goal ← liftGrindM <| Grind.Goal.internalizeAll goal
+  if goal.inconsistent then
+    -- The goal was closed during internalization.
+    replaceMainGoal []
+    return
+  let d ← liftGrindM <| goal.mkSymSimpDischarger
+  let rewrite ← Sym.mkSimprocFor declNames d
+  let methods : Sym.Simp.Methods := {
+    pre  := Sym.Simp.simpControl.andThen Sym.Simp.simpArrowTelescope
+    post := Sym.Simp.evalGround.andThen rewrite
+  }
+  let result ← liftGrindM <| goal.mvarId.withContext do
+    Sym.simp (← goal.mvarId.getType) methods
+  match (← liftGrindM <| Sym.Simp.Result.toSimpGoalResult result goal.mvarId) with
+  | .closed => replaceMainGoal []
+  | .goal mvarId => replaceMainGoal [{ goal with mvarId }]
+  | .noProgress => throwError "`simp_grind` made no progress"
+
+opaque f : Nat → Nat
+opaque g : Nat → Nat
+axiom f_idem (a : Nat) (_h : 0 < a) : f (f a) = f a
+
+-- Side condition `0 < n` follows from `h : 5 ≤ n` by linear arithmetic;
+-- a plain assumption discharger would fail here.
+example (n : Nat) (h : 5 ≤ n) : f (f n) = f n := by
+  sym =>
+    simp_grind [f_idem]
+
+-- Ground side condition `0 < 3`.
+example : f (f 3) = f 3 := by
+  sym =>
+    simp_grind [f_idem]
+
+-- Side condition `0 < g n` requires instantiating the quantified hypothesis `h` (E-matching).
+example (n : Nat) (h : ∀ x, 0 < g x) : f (f (g n)) = f (g n) := by
+  sym =>
+    simp_grind [f_idem]
+
+opaque p : {P : Prop} → P → Nat
+
+-- The hypothesis `h : 5 ≤ n` is introduced by `Sym.simp` when entering the dependent
+-- binder, i.e., it is *not* part of the internalized local context prefix shared by all
+-- discharge attempts. (Note: non-dependent arrows are simplified non-contextually by
+-- `simpArrowTelescope`, so their antecedents never reach the discharger.)
+/--
+error: `sym` failed
+case grind
+n : Nat
+⊢ ∀ (h : 5 ≤ n), f n + p h = 0
+[grind] Goal diagnostics
+  [facts] Asserted facts
+-/
+#guard_msgs in
+example (n : Nat) : ∀ (h : 5 ≤ n), f (f n) + p h = 0 := by
+  sym =>
+    simp_grind [f_idem]
+
+-- Discharging `0 < m` needs both the internalized prefix hypothesis `h₁` and the
+-- binder-introduced hypothesis `h`.
+/--
+error: `sym` failed
+case grind
+n m : Nat
+h₁ : 2 ≤ n
+⊢ ∀ (h : n ≤ m), f m + p h = 0
+[grind] Goal diagnostics
+  [facts] Asserted facts
+    [prop] 2 ≤ n
+  [eqc] True propositions
+    [prop] 2 ≤ n
+-/
+#guard_msgs in
+example (n m : Nat) (h₁ : 2 ≤ n) : ∀ (h : n ≤ m), f (f m) + p h = 0 := by
+  sym =>
+    simp_grind [f_idem]
+
+-- Failure: `0 < n` cannot be discharged, so `f_idem` must not be applied.
+-- `Nat.add_zero` still fires, so `Sym.simp` makes progress and leaves the goal below.
+/--
+error: `sym` failed
+case grind
+n : Nat
+⊢ f (f n) = f n
+[grind] Goal diagnostics
+  [facts] Asserted facts
+-/
+#guard_msgs in
+example (n : Nat) : f (f n) + 0 = f n + 0 := by
+  sym =>
+    simp_grind [f_idem, Nat.add_zero]
+
+-- The side condition `0 < n` does not hold, but the hypotheses are contradictory.
+-- They are introduced without internalization, so the contradiction is only detected
+-- when `simp_grind` internalizes them, closing the goal.
+example (n : Nat) : n = 0 → n = 1 → f (f n) = f n := by
+  sym =>
+    intro (internalize := false) h₁ h₂
+    simp_grind [f_idem]
+
+-- Here the contradiction is only found by E-matching `h` during a discharge attempt.
+example (n : Nat) (h : ∀ x, g x = 0) (h₂ : g 5 = 1) : f (f n) = f n := by
+  sym =>
+    simp_grind [f_idem]
+
+opaque r : Nat → Nat → Prop
+axiom f_r (a w : Nat) (_h : r a w) : f (f a) = f a
+
+-- The value `w` is not covered by the pattern, so the discharger receives the non-Prop
+-- side condition `Nat`. `grind` fails gracefully (the hypotheses are consistent), and
+-- the rewrite is not applied.
+/--
+error: `simp_grind` made no progress
+-/
+#guard_msgs in
+example (n : Nat) : f (f n) = f n := by
+  sym =>
+    simp_grind [f_r]
+
+/-! ## The `with grind` discharger in the simproc DSL -/
+
+register_sym_simp fIdemGrind where
+  pre  := control >> arrow_telescope
+  post := ground >> rewrite [f_idem] with grind
+
+-- The hypotheses internalized when the `sym =>` block starts are shared by all
+-- discharge attempts.
+example (n : Nat) (h : 5 ≤ n) : f (f n) = f n := by
+  sym =>
+    simp fIdemGrind
+
+-- E-matching the internalized hypothesis `h` during a discharge attempt.
+example (n : Nat) (h : ∀ x, 0 < g x) : f (f (g n)) = f (g n) := by
+  sym =>
+    simp fIdemGrind
+
+-- Binder-introduced hypotheses are internalized per discharge attempt on top of the
+-- shared internalized prefix (`h₁`).
+/--
+error: `sym` failed
+case grind
+n m : Nat
+h₁ : 2 ≤ n
+⊢ ∀ (h : n ≤ m), f m + p h = 0
+[grind] Goal diagnostics
+  [facts] Asserted facts
+    [prop] 2 ≤ n
+  [eqc] True propositions
+    [prop] 2 ≤ n
+-/
+#guard_msgs in
+example (n m : Nat) (h₁ : 2 ≤ n) : ∀ (h : n ≤ m), f (f m) + p h = 0 := by
+  sym =>
+    simp fIdemGrind


### PR DESCRIPTION
This PR implements support for using `grind` to discharge hypotheses in conditional `Sym.simp` theorems.
