### PR TITLE
fix: theorem activation when using multiple `grind` attributes

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/Theorems.lean
+++ b/src/Lean/Meta/Tactic/Grind/Theorems.lean
@@ -184,10 +184,19 @@ abbrev TheoremsArray (α : Type) := Array (Theorems α)
 
 @[specialize]
 def TheoremsArray.retrieve? (s : TheoremsArray α) (sym : Name) : Option (List α × TheoremsArray α) := Id.run do
-  for h : i in *...s.size do
-    if let some (thms, a) ← s[i].retrieve? sym then
-      return some (thms, s.set i a)
-  return none
+  /-
+  We must scan all elements. Multiple elements may contain theorems associated with `sym`.
+  Moreover, `TheoremsArray.insert` always reinserts partially activated theorems into the
+  first element, and they may shadow entries with the same key in later elements. See issue #13725.
+  -/
+  let mut result := []
+  let mut s := s
+  for i in *...s.size do
+    if let some (thms, a) := s[i]!.retrieve? sym then
+      result := result ++ thms
+      s := s.set! i a
+  if result.isEmpty then return none
+  return some (result, s)
 
 def TheoremsArray.insert [TheoremLike α] (s : TheoremsArray α) (thm : α) : TheoremsArray α := Id.run do
   if s.isEmpty then

--- a/tests/pkg/user_attr/UserAttr.lean
+++ b/tests/pkg/user_attr/UserAttr.lean
@@ -1,5 +1,6 @@
 import UserAttr.Tst
 import UserAttr.MetaUser
+import UserAttr.Grind13725
 
 open Lean
 

--- a/tests/pkg/user_attr/UserAttr/BlaAttr.lean
+++ b/tests/pkg/user_attr/UserAttr/BlaAttr.lean
@@ -63,3 +63,5 @@ public meta initialize registerBuiltinAttribute {
 }
 
 register_grind_attr my_grind
+
+register_grind_attr compact_set

--- a/tests/pkg/user_attr/UserAttr/Grind13725.lean
+++ b/tests/pkg/user_attr/UserAttr/Grind13725.lean
@@ -1,0 +1,35 @@
+module
+
+public import UserAttr.BlaAttr
+
+/-!
+Regression test for issue #13725: `grind only [compact_set]` stopped using `closure_set1`
+after the unrelated lemma `P_closure_set2` was tagged with the same custom `grind` attribute.
+The partially activated `P_closure_set2` was reinserted into the first element of the
+theorem array under the symbol `closure`, shadowing `closure_set1` stored in the
+extension's element under the same key.
+-/
+
+def Set (α : Type _) : Type _ := α → Prop
+def P {α} (_s : Set α) : Prop := True
+def closure {α} (s : Set α) : Set α := s
+
+def set1 {α} (_a : α) : Set α := fun _ ↦ False
+def set2 {α} (_a : α) : Set α := fun _ ↦ False
+def ℝ := Bool
+
+@[compact_set =]
+theorem closure_set1 (a : ℝ) : closure (set1 a) = set1 a := by
+  simp [closure]
+
+@[compact_set .]
+theorem P_set1 {a : ℝ} : P (set1 a) := by trivial
+
+#guard_msgs in
+example (a : ℝ) : P (closure (set1 a)) := by grind only [compact_set]
+
+@[compact_set .]
+theorem P_closure_set2 {a : ℝ} : P (closure (set2 a)) := by trivial
+
+#guard_msgs in
+example (a : ℝ) : P (closure (set1 a)) := by grind only [compact_set]


### PR DESCRIPTION
This PR fixes `grind` dropping E-matching theorems from custom `grind` attributes when a partially activated theorem was reinserted under the same symbol.

Closes #13725