### PR TITLE
fix: `grind` filter syntax

### DIFF
--- a/src/Init/Grind/Interactive.lean
+++ b/src/Init/Grind/Interactive.lean
@@ -48,7 +48,9 @@ syntax grindFilter := (colGt grind_filter)?
 A `grind` tactic is a program which receives a `grind` goal. -/
 declare_syntax_cat grind (behavior := both)
 
-syntax grindStep := grind ("|" (colGt ppSpace grind_filter)?)?
+-- The `colGt` before `"|"` prevents the step from consuming a `|` that belongs to an enclosing
+-- tactic (e.g. the next alternative of a `match`, see issue #13822).
+syntax grindStep := grind (colGt "|" (colGt ppSpace grind_filter)?)?
 
 syntax grindSeq1Indented := sepBy1IndentSemicolon(grindStep)
 syntax grindSeqBracketed := "{" withoutPosition(sepByIndentSemicolon(grindStep)) "}"

--- a/tests/elab/grind_13822.lean
+++ b/tests/elab/grind_13822.lean
@@ -1,0 +1,36 @@
+/-!
+Regression test for #13822: `grind => seq` used to fail to parse inside a `match`
+alternative because the optional goal-filter `|` of a `grind` step consumed the `|`
+starting the next `match` alternative. The `|` must now be indented past the start
+of the `grind` sequence.
+-/
+
+def x := 1
+
+example : x = 1 := by
+  match true with
+  | true => grind => instantiate only [x]
+  | false => rfl
+
+example : x = 1 := by
+  match true with
+  | true => rfl
+  | false => grind => instantiate only [x]
+
+-- `first` alternatives separated by `|` used to be consumed as well.
+example : x = 1 := by
+  first
+  | grind => instantiate only [x]
+  | rfl
+
+-- Goal-state filters on the same line as the step still parse.
+example : x = 1 := by
+  match true with
+  | true => grind => instantiate only [x] | gen ≤ 1
+  | false => rfl
+
+-- A bare trailing `|` on the same line still parses.
+example : x = 1 := by
+  match true with
+  | true => grind => instantiate only [x] |
+  | false => rfl


### PR DESCRIPTION
This PR fixes the `grind` filter syntax. It prevented `grind =>` from being used nested in `match` expressions.

Closes #13822
