### PR TITLE
doc: drop internal-lemma references from `repeatM` docstrings

### DIFF
--- a/src/Init/Internal/Order/While.lean
+++ b/src/Init/Internal/Order/While.lean
@@ -15,13 +15,12 @@ set_option linter.missingDocs true
 /-!
 # Order-theoretic unfolding for `repeatM`
 
-This module exposes the user-facing one-step unfolding lemma `repeatM_eq_of_monadTail`,
-which holds for any monad with a `Lean.Order.MonadTail` instance. It works by exhibiting
-the order-theoretic least fixed point `Lean.Order.fix (repeatM.body f)` and feeding it to
-the module-internal `repeatM_eq`.
+This module proves the one-step unfolding lemma `repeatM.Internal.eq_of_monadTail`,
+which holds for any monad with a `Lean.Order.MonadTail` instance. It exhibits the
+order-theoretic least fixed point `Lean.Order.fix (repeatM.body f)` and feeds it to
+`repeatM_eq`.
 
-The lemma does not appear in `Init.While` itself to keep that module's import closure
-small; clients that want to unfold `repeatM`/`Loop.forIn` should import this file.
+Unfolding `repeatM`/`Lean.Loop.forIn` requires importing this module.
 -/
 
 variable {α : Type u} {m : Type u → Type v} [Monad m]
@@ -34,14 +33,16 @@ private theorem repeatM.body_monotone_of_monadTail [Lean.Order.MonadTail m] [Non
     | .inl a' => h a'
     | .inr _ => Lean.Order.PartialOrder.rel_refl
 
--- TODO: move out of `Internal`
-set_option linter.coreInternal.internalModule false in
+namespace repeatM.Internal
+
 /-- One-step unfolding of `repeatM` for any `MonadTail m`. -/
-public theorem repeatM_eq_of_monadTail [Lean.Order.MonadTail m] [Nonempty β]
+public theorem eq_of_monadTail [Lean.Order.MonadTail m] [Nonempty β]
     {f : α → m (α ⊕ β)} (a : α) :
     repeatM f a = repeatM.body f (repeatM f) a :=
   have hMono := repeatM.body_monotone_of_monadTail f
   repeatM_eq a ⟨Lean.Order.fix (repeatM.body f) hMono, (Lean.Order.fix_eq hMono).symm⟩
+
+end repeatM.Internal
 
 namespace Lean
 
@@ -54,7 +55,7 @@ public theorem Loop.forIn_eq_of_monadTail [LawfulMonad m] [Lean.Order.MonadTail 
       | .yield val => Loop.forIn l val f) := by
   haveI : Nonempty β := ⟨b⟩
   show repeatM _ b = _
-  rw [repeatM_eq_of_monadTail]; unfold repeatM.body; rw [bind_assoc]
+  rw [repeatM.Internal.eq_of_monadTail]; unfold repeatM.body; rw [bind_assoc]
   exact bind_congr fun
     | .done _  => by simp
     | .yield _ => by simp [Loop.forIn]

--- a/src/Init/While.lean
+++ b/src/Init/While.lean
@@ -12,10 +12,7 @@ public import Init.Classical
 /-!
 # `repeatM`
 
-`repeatM f a` iterates `f : α → m (α ⊕ β)`, recursing on `.inl` and terminating on
-`.inr`. The public unfolding lemma `repeatM_eq_of_monadTail`, which requires a
-`Lean.Order.MonadTail m` instance, lives in `Init.Internal.Order.While` to keep this
-module's import closure small.
+`repeatM f a` iterates `f : α → m (α ⊕ β)`, recursing on `.inl` and terminating on `.inr`.
 -/
 
 variable {α : Type u} {m : Type u → Type v} [Monad m]
@@ -68,17 +65,13 @@ Can be removed once `repeatM.impl` optimizes to the same code.
 @[specialize] private partial def repeatM.erased [Nonempty β] (f : α → m (α ⊕ β)) (a : α) : m β :=
   repeatM.body f (repeatM.erased f ·) a
 
-/--
-`repeatM f a` iterates `f` at `a`, recursing on `.inl` and terminating on `.inr`.
-
-Its unfolding lemma is `repeatM_eq_of_monadTail`.
--/
+/-- `repeatM f a` iterates `f` at `a`, recursing on `.inl` and terminating on `.inr`. -/
 @[implemented_by repeatM.erased] -- See comment above `repeatM.erased`.
 public def repeatM [Nonempty β] (f : α → m (α ⊕ β)) (a : α) : m β :=
   (repeatM.impl f a).val
 
--- This lemma is intentionally private. Users are expected to unfold using
--- `repeatM_eq_of_monadTail` instead.
+-- Intentionally private: unfolding `repeatM` needs a `MonadTail m` instance and is done
+-- in `Init.Internal.Order.While`.
 private theorem repeatM_eq [Nonempty β] {f : α → m (α ⊕ β)} (a : α)
     (h : ∃ g, repeatM.body f g = g) :
     repeatM f a = repeatM.body f (repeatM f) a := by

--- a/src/Std/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Do/Triple/SpecLemmas.lean
@@ -2272,7 +2272,7 @@ theorem Spec.repeatM
   induction n using Nat.strongRecOn with
   | _ n ih =>
     intro a
-    rw [repeatM_eq_of_monadTail (f := f) a]
+    rw [_root_.repeatM.Internal.eq_of_monadTail (f := f) a]
     refine Triple.bind (f := fun x => match x with
       | .inl a' => _root_.repeatM f a' | .inr a' => Pure.pure a')
       (f a) (step a n) ?_

--- a/src/Std/Internal/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Internal/Do/Triple/SpecLemmas.lean
@@ -2466,7 +2466,7 @@ theorem Spec.repeatM
   induction n using Nat.strongRecOn with
   | _ n ih =>
     intro a hle
-    rw [repeatM_eq_of_monadTail (f := f) a]
+    rw [_root_.repeatM.Internal.eq_of_monadTail (f := f) a]
     refine Triple.bind (f := fun x => match x with
       | .inl a' => _root_.repeatM f a'
       | .inr b => Pure.pure b)


### PR DESCRIPTION
This PR removes references to the unfolding lemma from the `repeatM` docstrings and moves that lemma into the `repeatM.Internal` namespace.

The lemma `repeatM_eq_of_monadTail` becomes `repeatM.Internal.eq_of_monadTail`, which places it in an internal namespace and lets the `coreInternal.internalModule` linter run unsuppressed on `Init.Internal.Order.While`. Nesting under `repeatM` rather than a top-level `Internal` avoids shadowing the `Internal` namespaces that other modules open.