### PR TITLE
fix: don't expose inferInstanceAs wrapping aux defs for non-exposed types

### DIFF
--- a/src/Lean/Elab/BuiltinTerm.lean
+++ b/src/Lean/Elab/BuiltinTerm.lean
@@ -400,7 +400,12 @@ private def resynthInstImplicitArgs (type : Expr) : TermElabM Expr := do
     -- Wrap instance so its type matches the expected type exactly.
     let logCompileErrors := !(← read).isNoncomputableSection && !(← read).declName?.any (Lean.isNoncomputable (← getEnv))
     let isMeta := (← read).declName?.any (isMarkedMeta (← getEnv))
+    -- The auxiliary definitions `wrapInstance` introduces bridge `type` and `expectedType`, so their
+    -- bodies are only well-typed when the definitions whose unfolding the bridge requires are
+    -- exposed (#14147).
+    let exposedDefEq ← withExporting <| isDefEqGuarded type expectedType
     wrapInstance inst expectedType (logCompileErrors := logCompileErrors) (isMeta := isMeta)
+      (exposeAux := exposedDefEq)
   else
     pure inst
   ensureHasType expectedType? inst

--- a/src/Lean/Meta/Closure.lean
+++ b/src/Lean/Meta/Closure.lean
@@ -432,13 +432,14 @@ end Closure
   returned where `u_i`s are universe parameters and metavariables `type` and `value` depend on,
   and `t_j`s are free and meta variables `type` and `value` depend on. -/
 def mkAuxDefinition (name : Name) (type : Expr) (value : Expr) (zetaDelta : Bool := false)
-    (compile : Bool := true) (logCompileErrors : Bool := true) : MetaM Expr := do
+    (compile : Bool := true) (logCompileErrors : Bool := true) (exposeBody : Bool := true) :
+    MetaM Expr := do
   let result ← Closure.mkValueTypeClosure type value zetaDelta
   let env ← getEnv
   let hints := ReducibilityHints.regular (getMaxHeight env result.value + 1)
   let decl := Declaration.defnDecl (← mkDefinitionValInferringUnsafe name result.levelParams.toList
     result.type result.value  hints)
-  addDecl decl
+  withExporting (isExporting := exposeBody) <| addDecl decl
   if compile then
     compileDecl decl (logErrors := logCompileErrors)
   return mkAppN (mkConst name result.levelArgs.toList) result.exprArgs

--- a/src/Lean/Meta/WrapInstance.lean
+++ b/src/Lean/Meta/WrapInstance.lean
@@ -144,7 +144,8 @@ Wrap an instance value so its type matches the expected type exactly.
 See the module docstring for the full algorithm specification.
 -/
 public partial def wrapInstance (inst expectedType : Expr) (compile : Bool := true)
-    (logCompileErrors : Bool := true) (isMeta : Bool := false) : MetaM Expr :=
+    (logCompileErrors : Bool := true) (isMeta : Bool := false) (exposeAux : Bool := true) :
+    MetaM Expr :=
   withTransparency .instances do
     return (← go (isEta := false) inst expectedType).get!
 -- If `isEta` is true, will return `none` if no sub-instance was found, i.e. eta-expansion had no
@@ -183,6 +184,7 @@ where go (inst expectedType : Expr) (isEta : Bool) : MetaM (Option Expr) := do
         if backward.inferInstanceAs.wrap.instances.get (← getOptions) then
           let name ← mkAuxDeclName
           let wrapped ← mkAuxDefinition name expectedType inst (compile := false)
+            (exposeBody := exposeAux)
           setReducibilityStatus name <|
             if (← withImplicit <| isDefEq expectedType instType) then
               .implicitReducible
@@ -277,7 +279,8 @@ where go (inst expectedType : Expr) (isEta : Bool) : MetaM (Option Expr) := do
             mvarId.assign arg
           else
             let name ← mkAuxDeclName
-            mvarId.assign (← mkAuxDefinition name argExpectedType arg (compile := false))
+            mvarId.assign (← mkAuxDefinition name argExpectedType arg (compile := false)
+              (exposeBody := exposeAux))
             setReducibilityStatus name <|
               if (← withImplicit <| isDefEq argExpectedType argType) then
                 .implicitReducible

--- a/tests/elab/inferInstanceAs.lean
+++ b/tests/elab/inferInstanceAs.lean
@@ -139,3 +139,45 @@ fun α [Super α] => { toMain0 := iMain0 α, c := Main1.c }
 -/
 #guard_msgs in
 #print iSuper
+
+/-! Wrapper aux defs in a `public section` must be exposed only when their bodies are well-typed in
+the exported environment, i.e. when the bridged type's body is itself exposed (#14147). -/
+
+public section
+
+def NotExposed := Nat
+
+noncomputable instance : Inhabited NotExposed := inferInstanceAs (Inhabited Nat)
+
+-- The instance stays exposed and references the wrapper aux def.
+/--
+info: @[instance_reducible, expose] def instInhabitedNotExposed : Inhabited NotExposed :=
+{ default := instInhabitedNotExposed._aux_1 }
+-/
+#guard_msgs in
+#print instInhabitedNotExposed
+
+-- The aux def's body bridges `NotExposed` and `Nat`, so it is kept out of the public scope (exported
+-- as a signature-only stub): a public `def`, neither `private` nor `@[expose]`, so the exposed
+-- instance above stays well-typed for importers without leaking `NotExposed`'s body.
+/--
+info: def instInhabitedNotExposed._aux_1 : NotExposed :=
+Nat.zero
+-/
+#guard_msgs in
+#print instInhabitedNotExposed._aux_1
+
+@[expose] def IsExposed := Nat
+
+noncomputable instance : Inhabited IsExposed := inferInstanceAs (Inhabited Nat)
+
+-- `IsExposed`'s body is exposed, so the aux def is well-typed in the exported environment and stays
+-- exposed.
+/--
+info: @[expose] def instInhabitedIsExposed._aux_1 : IsExposed :=
+Nat.zero
+-/
+#guard_msgs in
+#print instInhabitedIsExposed._aux_1
+
+end


### PR DESCRIPTION
This PR fixes `inferInstanceAs` marking its wrapper auxiliary definitions `@[expose]` even when their bodies are well-typed only in the private scope, which made instances defined via `inferInstanceAs` for types without an exposed body publicly ill-typed.

Fixes #14147