### PR TITLE
fix: don't resynthesize unwrapped nested proofs in the grind canonicalizer

### DIFF
--- a/src/Lean/Meta/Sym/Canon.lean
+++ b/src/Lean/Meta/Sym/Canon.lean
@@ -295,6 +295,15 @@ where
     the same instances.
     -/
     let type ← inferType e
+    if !(← read).insideType && (← isProp type) then
+      /-
+      `e` is a nested proof lacking the `Grind.nestedProof` wrapper (wrapped ones are handled
+      by `canonInstProp`). Preprocessing wraps every closed nested proof, so an unwrapped one
+      can only occur in a binder body that `markNestedSubsingletons` skipped. Resynthesizing
+      it here could produce a closed proof lacking the wrapper, and congruence closure would
+      then treat it as distinct from wrapped occurrences of the same instance. See issue #13655.
+      -/
+      return e
     let type' ← canonInsideType' type
     canonInstCore e type' report
 

--- a/tests/elab/grind_13655.lean
+++ b/tests/elab/grind_13655.lean
@@ -1,0 +1,63 @@
+/-!
+Regression test for issue #13655: the canonicalizer resynthesized an instance-implicit
+`Nonempty α` proof occurring in a forall body skipped by `markNestedSubsingletons`,
+producing a closed nested proof lacking the `Grind.nestedProof` wrapper. The resulting
+enode was distinct from the correctly wrapped occurrences, and congruence closure failed
+to detect the contradiction.
+-/
+set_option warn.sorry false
+namespace Mwe
+
+opaque P {α : Type} (a : α) : Prop
+
+/--
+`f` carries a `Nonempty α` instance-implicit argument.
+The canonicalizer resynthesizes it if possible.
+-/
+opaque f {α : Type} [_n : Nonempty α] (a : α) : α := sorry
+
+opaque aux {α : Type} (a : α) (_h : P a) : α := sorry
+
+inductive Mem {α : Type} : α → List α → Prop where
+  | head {a : α} {as : List α} : Mem a (a :: as)
+  | tail {a b : α} {as : List α} : Mem a as → Mem a (b :: as)
+
+@[simp] theorem mem_f_dep {α : Type} (a : α) (_h : P a) :
+    haveI : Nonempty α := ⟨aux a _h⟩
+    Mem (f a) [a] := sorry
+
+grind_pattern mem_f_dep => Mem (@f α ⟨aux a _h⟩ a) [a]
+
+@[simp] theorem mem_f_indep [n : Nonempty α] (a : α) (_h : P a) :
+    Mem (f a) [a] := sorry
+
+grind_pattern mem_f_indep => Mem (f a) [a]
+
+end Mwe
+open Mwe
+
+/--
+The `Nonempty α` proof in `mem_f_dep`'s body captures `_h`, so `markNestedSubsingletons`
+skips the body. The canonicalizer must not resynthesize the unwrapped proof; the forall
+stays dependent, and the instantiated body is preprocessed (and wrapped) by
+`propagateForallPropUp`.
+-/
+example {α : Type} [Nonempty α] (x c : α)
+    (hc : (f x) = c)
+    (this : P x)
+    (notMem : ¬ Mem c [x]) : False := by
+  grind only [usr mem_f_dep]
+
+/-- Same as above, but the `Nonempty α` instance cannot be resynthesized. -/
+example {α : Type} (x c : α)
+    (hc : (haveI : Nonempty α := sorry; f x) = c)
+    (this : P x)
+    (notMem : ¬ Mem c [x]) : False := by
+  grind only [usr mem_f_dep]
+
+/-- The `Nonempty α` proof in `mem_f_indep`'s body is closed, so it is wrapped eagerly. -/
+example [Nonempty α] (x c : α)
+    (hc : (f x) = c)
+    (this : P x)
+    (notMem : ¬ Mem c [x]) : False := by
+  grind only [usr mem_f_indep]


### PR DESCRIPTION
This PR fixes a `grind` bug where the canonicalizer could resynthesize a propositional instance (e.g. `Nonempty α`) occurring in a binder body skipped by preprocessing, producing a closed nested proof lacking the `Grind.nestedProof` wrapper. Congruence closure then treated the term as distinct from correctly wrapped occurrences of the same application, and `grind` missed valid contradictions. Closes #13655.

The preprocessing step `markNestedSubsingletons` wraps every closed nested proof with `Grind.nestedProof`, but skips forall bodies with loose bound variables; such bodies are re-preprocessed by `propagateForallPropUp` when instantiated. Resynthesizing an unwrapped proof inside such a body could remove the dependency on the bound variable, and the now-closed body was then internalized via the non-dependent fast path without re-preprocessing. The fix makes `canonInst'` keep unwrapped `Prop`-typed instances unchanged in term positions: the forall stays dependent, and the slow path re-preprocesses the instantiated body consistently. Behavior inside types is unchanged, where instances are deliberately unwrapped and resynthesized for structural agreement.

Thanks to @datokrat for the detailed analysis in the issue report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)