### PR TITLE
fix: avoid expensive `isDefEqD` in `grind`

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/MatchCond.lean
+++ b/src/Lean/Meta/Tactic/Grind/MatchCond.lean
@@ -319,6 +319,15 @@ where
       return none
 
 /--
+Returns `true` if `e` looks like a `match`-pattern instance: a metavariable (pattern
+variable), a constructor application, or a literal value.
+-/
+private def isPatternLike (e : Expr) : GoalM Bool := do
+  if e.getAppFn.isMVar then return true
+  if (← isConstructorApp? e).isSome then return true
+  isLitValue e
+
+/--
 Given a `match`-expression condition `e` that is known to be equal to `True`,
 try to close the goal by proving `False`. We use the following to example to illustrate
 the purpose of this function.
@@ -357,11 +366,25 @@ partial def tryToProveFalse (e : Expr) : GoalM Unit := do
       if target then
         let some (α?, lhs, rhs) := isEqHEq? (← inferType arg)
           | return none
-        let lhs' ← go lhs
-        trace[grind.debug.matchCond.proveFalse] "{lhs'} =?= {rhs}"
-        unless (← isDefEqD lhs' rhs) do
-          return none
         let isHEq := α?.isSome
+        let rhs ← instantiateMVars rhs
+        let lhs' ← if (← pure !rhs.hasExprMVar <&&> isEqv lhs rhs) then
+          -- The congruence closure already knows that `lhs = rhs`.
+          pure rhs
+        else
+          let lhs' ← go lhs
+          trace[grind.debug.matchCond.proveFalse] "{lhs'} =?= {rhs}"
+          /-
+          `rhs` is pattern-like for actual `match`-expression conditions. For hypotheses that
+          merely have the shape of a condition (e.g., `h : a = b → False` where `b` is not a
+          constructor application), `isDefEqD` may trigger arbitrarily expensive reductions
+          trying to decide `a =?= b`. See issue #14441.
+          -/
+          unless (← isPatternLike rhs) do
+            return none
+          unless (← isDefEqD lhs' rhs) do
+            return none
+          pure lhs'
         let some lhsEqLhs' ← if isHEq then proveHEq? lhs lhs' else proveEq? lhs lhs'
           | return none
         unless (← isDefEq arg lhsEqLhs') do

--- a/tests/elab/grind_14441.lean
+++ b/tests/elab/grind_14441.lean
@@ -1,0 +1,27 @@
+/-!
+Regression test for issue #14441: a hypothesis such as `h : a = b → False` has the shape of a
+`match`-expression condition, so `grind` processes it using the `Grind.MatchCond` machinery.
+`tryToProveFalse` then invoked `isDefEqD a b` with default transparency, triggering an
+arbitrarily expensive `whnf` reduction (here: unfolding a 256-element `Array.ofFn`).
+Now the congruence closure is consulted first, and the `isDefEq` fallback only runs when the
+equation's right-hand side is pattern-like (metavariable, constructor application, or literal).
+-/
+
+def init (x : Nat) : Array Nat := Array.ofFn (n := 256) (fun _ => x)
+
+-- The goal follows from `hneg h`; no `whnf` reduction of `init` should happen.
+set_option maxHeartbeats 1000 in
+example (c0 c1 : Nat)
+    (h    : init c0 = init c1)
+    (hneg : init c0 = init c1 → False) :
+    False := by
+  grind
+
+-- The mere presence of `hneg` must not trigger the reduction either.
+set_option linter.unusedVariables false in
+set_option maxHeartbeats 1000 in
+example (c0 c1 : Nat) (a : Nat)
+    (hneg : init c0 = init c1 → False)
+    (h2 : a = 1) :
+    a = 1 := by
+  grind


### PR DESCRIPTION
This PR ensures `grind` doesn't timeout checking for definitionally equality while trying to propagate `match`-expressions conditions.

Closes #14441
