### PR TITLE
feat: add `[grind homo]` attribute

### DIFF
--- a/src/Init/Grind/Attr.lean
+++ b/src/Init/Grind/Attr.lean
@@ -198,6 +198,22 @@ Given an application `f a₁ a₂ … aₙ`, when `funCC := true`,
 -/
 syntax grindFunCC  := &"funCC"
 /--
+The `homo` modifier marks a theorem as a homomorphism rule for `grind`.
+
+Homomorphism rules translate terms from a source domain into a target domain that has a
+dedicated solver. A collection of homomorphism rules encodes an algebra homomorphism
+`h : A → B`: each rule states how `h` commutes with a source-domain operation, as in
+`h (f x y) = g (h x) (h y)`. Example: injecting bitvector operations into integer
+arithmetic using `BitVec.toNat`:
+```
+@[grind homo] theorem toNat_add (x y : BitVec w) :
+    (x + y).toNat = (x.toNat + y.toNat) % 2^w
+```
+The rules must be unconditional equations (or `Iff`s). They are applied to fixpoint
+outside the E-graph, and only the final result is internalized.
+-/
+syntax grindHomo   := &"homo"
+/--
 The `norm` modifier instructs `grind` to use a theorem as a normalization rule. That is,
 the theorem is applied during the preprocessing step.
 This feature is meant for advanced users who understand how the preprocessor and `grind`'s search
@@ -273,7 +289,7 @@ syntax grindMod :=
     grindEqBoth <|> grindEqRhs <|> grindEq <|> grindEqBwd <|> grindBwd
     <|> grindFwd <|> grindRL <|> grindLR <|> grindUsr <|> grindCasesEager
     <|> grindCases <|> grindIntro <|> grindExt <|> grindGen <|> grindSym <|> grindInj
-    <|> grindFunCC <|> grindNorm <|> grindUnfold <|> grindDef
+    <|> grindFunCC <|> grindHomo <|> grindNorm <|> grindUnfold <|> grindDef
 
 /--
 Marks a theorem or definition for use by the `grind` tactic.

--- a/src/Lean/Elab/Tactic/Grind/BuiltinTactic.lean
+++ b/src/Lean/Elab/Tactic/Grind/BuiltinTactic.lean
@@ -252,7 +252,7 @@ where
         elabEMatchTheorem declName (.default false) minIndexable
       else
         return thms.toArray
-    | .cases _ | .intro | .inj | .ext | .symbol _ | .funCC | .norm .. | .unfold =>
+    | .cases _ | .intro | .inj | .ext | .symbol _ | .funCC | .norm .. | .unfold | .homo =>
       throwError "invalid modifier"
 
 def logAnchor (c : SplitInfo) : TermElabM Unit := do

--- a/src/Lean/Elab/Tactic/Grind/Param.lean
+++ b/src/Lean/Elab/Tactic/Grind/Param.lean
@@ -147,7 +147,7 @@ def processTermParam (params : Grind.Params)
   checkNoRevert params
   let kind ← if let some mod := mod? then Grind.getAttrKindCore mod else pure .infer
   let kind ← match kind with
-    | .ematch .user | .cases _ | .intro | .inj | .ext | .symbol _ | .funCC | .norm .. | .unfold =>
+    | .ematch .user | .cases _ | .intro | .inj | .ext | .symbol _ | .funCC | .norm .. | .unfold | .homo =>
       throwError "invalid `grind` parameter, only global declarations are allowed with this kind of modifier"
     | .ematch kind => pure kind
     | .infer => pure <| .default false
@@ -263,6 +263,7 @@ def processParam (params : Grind.Params)
   | .funCC =>
     params := params.insertFunCC declName
   | .norm .. => throwError "normalization theorems should be registered using the `@[grind norm]` attribute"
+  | .homo => throwError "homomorphism rules should be registered using the `@[grind homo]` attribute"
   | .unfold => throwError "declarations to be unfolded during normalization should be registered using the `@[grind unfold]` attribute"
   return params
 

--- a/src/Lean/Meta/Sym/Simp/Attr.lean
+++ b/src/Lean/Meta/Sym/Simp/Attr.lean
@@ -19,6 +19,31 @@ def addSymSimpTheorem (ext : SymSimpExtension) (declName : Name) (attrKind : Att
   ext.add thm attrKind
 
 /--
+Adds a declaration to the given `Sym.Simp` theorem extension.
+When `declName` is a proposition, it is added as a rewrite theorem.
+When it is a definition, its equation theorems are added.
+`attrName` is only used in error messages.
+-/
+def addSymSimpDecl (ext : SymSimpExtension) (attrName : String) (declName : Name)
+    (attrKind : AttributeKind) : MetaM Unit := do
+  let info ← getAsyncConstInfo declName
+  if (← isProp info.sig.get.type) then
+    addSymSimpTheorem ext declName attrKind
+  else if info.kind matches .defn then
+    if (← Simp.ignoreEquations declName) then
+      throwError "Cannot add `{attrName}` attribute to `{.ofConstName declName}`: \
+        It is a reducible definition or projection. `Sym.simp` does not support unfolding."
+    else if let some eqns ← getEqnsFor? declName then
+      for eqn in eqns do
+        addSymSimpTheorem ext eqn attrKind
+    else
+      throwError "Cannot add `{attrName}` attribute to `{.ofConstName declName}`: \
+        No equation theorems found."
+  else
+    throwError "Cannot add `{attrName}` attribute to `{.ofConstName declName}`: \
+      It is not a proposition nor a definition with equation theorems."
+
+/--
 Creates a `Sym.Simp` attribute for a named theorem set.
 When a proposition is tagged, it is added as a rewrite theorem.
 When a definition is tagged, its equation theorems are added.
@@ -31,24 +56,7 @@ def mkSymSimpAttr (attrName : Name) (attrDescr : String) (ext : SymSimpExtension
     descr := attrDescr
     applicationTime := AttributeApplicationTime.afterCompilation
     add   := fun declName _ attrKind => do
-      let go : MetaM Unit := do
-        let info ← getAsyncConstInfo declName
-        if (← isProp info.sig.get.type) then
-          addSymSimpTheorem ext declName attrKind
-        else if info.kind matches .defn then
-          if (← Simp.ignoreEquations declName) then
-            throwError "Cannot add `{attrName}` attribute to `{.ofConstName declName}`: \
-              It is a reducible definition or projection. `Sym.simp` does not support unfolding."
-          else if let some eqns ← getEqnsFor? declName then
-            for eqn in eqns do
-              addSymSimpTheorem ext eqn attrKind
-          else
-            throwError "Cannot add `{attrName}` attribute to `{.ofConstName declName}`: \
-              No equation theorems found."
-        else
-          throwError "Cannot add `{attrName}` attribute to `{.ofConstName declName}`: \
-            It is not a proposition nor a definition with equation theorems."
-      discard <| go.run {} {}
+      discard <| (addSymSimpDecl ext (toString attrName) declName attrKind).run {} {}
     erase := fun _declName => do
       throwError "Erasing `Sym.simp` attributes is not supported yet."
   }

--- a/src/Lean/Meta/Tactic/Grind/Attr.lean
+++ b/src/Lean/Meta/Tactic/Grind/Attr.lean
@@ -9,6 +9,8 @@ public import Lean.Meta.Tactic.Grind.Injective
 public import Lean.Meta.Tactic.Grind.Cases
 public import Lean.Meta.Tactic.Grind.ExtAttr
 public import Lean.Meta.Tactic.Simp.Attr
+public import Lean.Meta.Tactic.Grind.Homo
+import Lean.Meta.Sym.Simp.Attr
 import Lean.ExtraModUses
 public section
 namespace Lean.Meta.Grind
@@ -26,6 +28,7 @@ inductive AttrKind where
   | funCC
   | norm (post : Bool) (inv : Bool)
   | unfold
+  | homo
 
 /-- Return theorem kind for `stx` of the form `Attr.grindThmMod` -/
 def getAttrKindCore (stx : Syntax) : CoreM AttrKind := do
@@ -59,6 +62,7 @@ def getAttrKindCore (stx : Syntax) : CoreM AttrKind := do
   | `(Parser.Attr.grindMod|norm ↑ ←) => return .norm true true
   | `(Parser.Attr.grindMod|norm ↓ ←) => return .norm (post := false) true
   | `(Parser.Attr.grindMod|unfold) => return .unfold
+  | `(Parser.Attr.grindMod|homo) => return .homo
   | `(Parser.Attr.grindMod|symbol $prio:prio) =>
     let some prio := prio.raw.isNatLit? | throwErrorAt prio "priority expected"
     return .symbol prio
@@ -179,6 +183,10 @@ private def mkGrindAttr (attrName : Name) (minIndexable : Bool) (showInfo : Bool
           throwError "declaration to unfold must be set using the default `[grind]` attribute"
         unless (← addDeclToUnfold normExt declName (post := false) (inv := false) (prio := eval_prio default) (attrKind := attrKind)) do
           throwError "cannot mark declaration to be unfolded by `grind`"
+      | .homo =>
+        unless attrName == `grind do
+          throwError "homomorphism rules must be set using the default `[grind]` attribute"
+        Sym.Simp.addSymSimpDecl homoExt "grind homo" declName attrKind
       | .cases eager => ext.addCasesAttr declName eager attrKind
       | .funCC => ext.addFunCCAttr declName attrKind
       | .ext => ext.addExtAttr declName attrKind

--- a/src/Lean/Meta/Tactic/Grind/Homo.lean
+++ b/src/Lean/Meta/Tactic/Grind/Homo.lean
@@ -1,0 +1,19 @@
+/-
+Copyright (c) 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+module
+prelude
+public import Lean.Meta.Sym.Simp.Theorems
+public section
+namespace Lean.Meta.Grind
+
+/-- Extension backing the `@[grind homo]` attribute. -/
+builtin_initialize homoExt : Sym.Simp.SymSimpExtension ← Sym.Simp.mkSymSimpExt
+
+/-- Returns the homomorphism rules tagged with the `[grind homo]` attribute. -/
+def getHomoTheorems : CoreM Sym.Simp.Theorems :=
+  homoExt.getTheorems
+
+end Lean.Meta.Grind

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,3 +1,4 @@
+// update me!
 #include "util/options.h"
 
 // Should we test stage 2 and run update-stage0 on PR merge? NO

--- a/tests/elab/grind_homo_attr.lean
+++ b/tests/elab/grind_homo_attr.lean
@@ -1,0 +1,55 @@
+import Lean
+
+/-!
+Tests for `[grind homo]` attribute registration. Homomorphism rules are registered in a
+`Sym.simp` theorem set retrievable via `Lean.Meta.Grind.getHomoTheorems`.
+-/
+
+open Lean Meta Grind
+
+def wu (x : BitVec 32) : Int := (x.toNat : Int)
+
+axiom wu_add (x y : BitVec 32) : wu (x + y) = (wu x + wu y) % 2^32
+axiom wu_mul (x y : BitVec 32) : wu (x * y) = (wu x * wu y) % 2^32
+axiom wu_eq (x y : BitVec 32) : (x = y) ↔ (wu x = wu y)
+
+attribute [grind homo] wu_add
+attribute [grind homo] wu_mul
+attribute [grind homo] wu_eq
+
+/-- Displays the `[grind homo]` rules matching `wu (x + x)` and `x = x`. -/
+def checkMatches : MetaM Unit := do
+  withLocalDeclD `x (mkApp (mkConst ``BitVec) (mkNatLit 32)) fun x => do
+    let thms ← getHomoTheorems
+    let add ← mkAppM ``wu #[← mkAppM ``HAdd.hAdd #[x, x]]
+    for thm in thms.getMatch add do
+      logInfo m!"{thm.expr}"
+    let eq ← mkEq x x
+    for thm in thms.getMatch eq do
+      logInfo m!"{thm.expr}"
+
+/--
+info: wu_add
+---
+info: fun x y => propext (wu_eq x y)
+-/
+#guard_msgs in
+run_meta checkMatches
+
+/-- error: homomorphism rules must be set using the default `[grind]` attribute -/
+#guard_msgs in
+attribute [lia homo] wu_add
+
+axiom bad : Nat
+
+/--
+error: Cannot add `grind homo` attribute to `bad`: It is not a proposition nor a definition with equation theorems.
+-/
+#guard_msgs in
+attribute [grind homo] bad
+
+/--
+error: homomorphism rules should be registered using the `@[grind homo]` attribute
+-/
+#guard_msgs in
+example : True := by grind [homo wu_add]


### PR DESCRIPTION
This PR adds the attribute `[grind homo]`. This is just the first step. We are going to use it to implement the approach described at 
https://hackmd.io/Qd0nkWdzQImVe7TDGSAGbA

It will replace the `ToInt` typeclasses used in `grind`. 

Andres Erbsen (@andres-erbsen) has already successfully tried and prototyped this approach at
https://github.com/AeneasVerif/kraken/pull/122

