### PR TITLE
perf: skip re-attempting pending TC mvars with unchanged instantiated goals (quadratic resumption, #14448)

### DIFF
--- a/src/Lean/Elab/SyntheticMVars.lean
+++ b/src/Lean/Elab/SyntheticMVars.lean
@@ -76,8 +76,19 @@ private def resumePostponed (savedContext : SavedContext) (stx : Syntax) (mvarId
 /--
   Similar to `synthesizeInstMVarCore`, but makes sure that `instMVar` local context and instances
   are used. It also logs any error message produced. -/
+register_builtin_option Elab.tcSkipUnchanged : Bool := {
+  defValue := false
+  descr := "skip re-attempting a pending typeclass metavariable whose instantiated goal     type is unchanged since its last failed attempt (the outcome is deterministic in the     goal, so re-attempting is wasted work; the resumption loop is otherwise quadratic in     the number of chained pending instances)"
+}
+
 private def synthesizePendingInstMVar (instMVar : MVarId) (extraErrorMsg? : Option MessageData := none): TermElabM Bool :=
   instMVar.withContext do
+    if Elab.tcSkipUnchanged.get (← getOptions) then
+      let type ← instantiateMVars (← instMVar.getType)
+      if let some prev := (← get).tcSynthAttempt.get? instMVar then
+        if prev == type then
+          return false
+      modify fun s => { s with tcSynthAttempt := s.tcSynthAttempt.insert instMVar type }
     try
       synthesizeInstMVarCore instMVar (extraErrorMsg? := extraErrorMsg?)
     catch

--- a/src/Lean/Elab/Term/TermElabM.lean
+++ b/src/Lean/Elab/Term/TermElabM.lean
@@ -181,6 +181,11 @@ structure State where
   levelNames        : List Name       := []
   syntheticMVars    : MVarIdMap SyntheticMVarDecl := {}
   pendingMVars      : List MVarId := {}
+  /-- Last instantiated goal type per still-pending `.typeClass` mvar whose synthesis
+  attempt failed; used (option `Elab.tcSkipUnchanged`) to skip re-attempts when the
+  goal is unchanged — the resumption loop otherwise re-tries every pending TC mvar
+  after each single success, which is quadratic in chained-literal statements. -/
+  tcSynthAttempt    : MVarIdMap Expr := {}
   /-- List of errors associated to a metavariable that are shown to the user if the metavariable could not be fully instantiated -/
   mvarErrorInfos    : List MVarErrorInfo := []
   /-- List of data to be able to localize universe level metavariable errors to particular expressions. -/


### PR DESCRIPTION
Fixes the quadratic re-attempt behavior described in #14448.

`Elab.synthesizeSyntheticMVars`' resumption loop re-attempts every pending `.typeClass` synthetic metavariable whenever any single one makes progress; chained literal statements resolve one mvar per pass, giving O(k²) underdetermined `synthInstance` attempts per command (~101 ms/command at 16 chained literals on master, quadratic scaling ×3.3–3.7 per doubling; see the issue for the full series and linear controls).

**Change**: memoize per pending `.typeClass` mvar the instantiated goal type at its last failed attempt (`Term.State.tcSynthAttempt : MVarIdMap Expr`); skip the re-attempt when the instantiated goal is unchanged. `synthInstance` is deterministic in the instantiated goal for a fixed env/local-instance context, so the skip elides only attempts whose outcome is already known — pending mvars stay pending, and resolution happens exactly when the goal actually changes.

Gated behind `Elab.tcSkipUnchanged` (default **false**) so it can be evaluated safely; intended to become default-on if accepted (happy to drop the option or flip the default per maintainer preference).

**Evidence** (this branch, on top of 25ba8c3d):

| k (chained literals) | per-command, off | per-command, on |
|---|---|---|
| 4 | 7.38 ms | 3.41 ms |
| 16 | 100.8 ms | **21.4 ms (4.7×)** |

- oleans **byte-identical** with the option on vs off; on-vs-on deterministic
- failing proofs produce identical errors
- on a 4.34.0-pre fork: Batteries corpus builds clean with the option on (188 oleans, oleans byte-identical on `Batteries.Data.List.Lemmas`); real numeral-dense Mathlib module (`NumberTheory.PythagoreanTriples`) −7.4 % wall; isolated-literal modules neutral (win is specific to the chained-literal regime)