### PR TITLE
feat: add `[grind homo_pred]` attribute

### DIFF
--- a/src/Init/Grind/Attr.lean
+++ b/src/Init/Grind/Attr.lean
@@ -214,6 +214,25 @@ outside the E-graph, and only the final result is internalized.
 -/
 syntax grindHomo   := &"homo"
 /--
+The `homo_pred` modifier marks a theorem as a homomorphism predicate for `grind`.
+
+Homomorphism predicates are facts that `grind` instantiates eagerly for the terms it
+internalizes. The conclusion of the theorem must contain an application `f a₁ … aₙ`
+whose trailing arguments are exactly the theorem's explicit parameters; the head
+symbol `f` becomes the trigger. Whenever `grind` internalizes a term with head `f`,
+the theorem is instantiated with the term's trailing arguments, and the resulting
+fact is asserted. Typical uses are range facts for injection functions, and
+translations of relations into a target domain. Examples:
+```
+@[grind homo_pred] theorem BitVec.toNat_range (x : BitVec w) : x.toNat < 2^w
+@[grind homo_pred] theorem UInt8.le_iff (a b : UInt8) : a ≤ b ↔ a.toBitVec ≤ b.toBitVec
+```
+The first theorem is triggered by terms of the form `BitVec.toNat x`, and the second
+one by `a ≤ b` applications. `grind` uses the types of `a` and `b` to discard
+irrelevant instantiations.
+-/
+syntax grindHomoPred := &"homo_pred"
+/--
 The `norm` modifier instructs `grind` to use a theorem as a normalization rule. That is,
 the theorem is applied during the preprocessing step.
 This feature is meant for advanced users who understand how the preprocessor and `grind`'s search
@@ -289,7 +308,7 @@ syntax grindMod :=
     grindEqBoth <|> grindEqRhs <|> grindEq <|> grindEqBwd <|> grindBwd
     <|> grindFwd <|> grindRL <|> grindLR <|> grindUsr <|> grindCasesEager
     <|> grindCases <|> grindIntro <|> grindExt <|> grindGen <|> grindSym <|> grindInj
-    <|> grindFunCC <|> grindHomo <|> grindNorm <|> grindUnfold <|> grindDef
+    <|> grindFunCC <|> grindHomoPred <|> grindHomo <|> grindNorm <|> grindUnfold <|> grindDef
 
 /--
 Marks a theorem or definition for use by the `grind` tactic.

--- a/src/Lean/Elab/Tactic/Grind/BuiltinTactic.lean
+++ b/src/Lean/Elab/Tactic/Grind/BuiltinTactic.lean
@@ -252,7 +252,7 @@ where
         elabEMatchTheorem declName (.default false) minIndexable
       else
         return thms.toArray
-    | .cases _ | .intro | .inj | .ext | .symbol _ | .funCC | .norm .. | .unfold | .homo =>
+    | .cases _ | .intro | .inj | .ext | .symbol _ | .funCC | .norm .. | .unfold | .homo | .homoPred =>
       throwError "invalid modifier"
 
 def logAnchor (c : SplitInfo) : TermElabM Unit := do

--- a/src/Lean/Elab/Tactic/Grind/Param.lean
+++ b/src/Lean/Elab/Tactic/Grind/Param.lean
@@ -147,7 +147,7 @@ def processTermParam (params : Grind.Params)
   checkNoRevert params
   let kind ← if let some mod := mod? then Grind.getAttrKindCore mod else pure .infer
   let kind ← match kind with
-    | .ematch .user | .cases _ | .intro | .inj | .ext | .symbol _ | .funCC | .norm .. | .unfold | .homo =>
+    | .ematch .user | .cases _ | .intro | .inj | .ext | .symbol _ | .funCC | .norm .. | .unfold | .homo | .homoPred =>
       throwError "invalid `grind` parameter, only global declarations are allowed with this kind of modifier"
     | .ematch kind => pure kind
     | .infer => pure <| .default false
@@ -264,6 +264,7 @@ def processParam (params : Grind.Params)
     params := params.insertFunCC declName
   | .norm .. => throwError "normalization theorems should be registered using the `@[grind norm]` attribute"
   | .homo => throwError "homomorphism rules should be registered using the `@[grind homo]` attribute"
+  | .homoPred => throwError "homomorphism predicates should be registered using the `@[grind homo_pred]` attribute"
   | .unfold => throwError "declarations to be unfolded during normalization should be registered using the `@[grind unfold]` attribute"
   return params
 

--- a/src/Lean/Meta/Tactic/Grind/Attr.lean
+++ b/src/Lean/Meta/Tactic/Grind/Attr.lean
@@ -29,6 +29,7 @@ inductive AttrKind where
   | norm (post : Bool) (inv : Bool)
   | unfold
   | homo
+  | homoPred
 
 /-- Return theorem kind for `stx` of the form `Attr.grindThmMod` -/
 def getAttrKindCore (stx : Syntax) : CoreM AttrKind := do
@@ -63,6 +64,7 @@ def getAttrKindCore (stx : Syntax) : CoreM AttrKind := do
   | `(Parser.Attr.grindMod|norm ↓ ←) => return .norm (post := false) true
   | `(Parser.Attr.grindMod|unfold) => return .unfold
   | `(Parser.Attr.grindMod|homo) => return .homo
+  | `(Parser.Attr.grindMod|homo_pred) => return .homoPred
   | `(Parser.Attr.grindMod|symbol $prio:prio) =>
     let some prio := prio.raw.isNatLit? | throwErrorAt prio "priority expected"
     return .symbol prio
@@ -187,6 +189,10 @@ private def mkGrindAttr (attrName : Name) (minIndexable : Bool) (showInfo : Bool
         unless attrName == `grind do
           throwError "homomorphism rules must be set using the default `[grind]` attribute"
         Sym.Simp.addSymSimpDecl homoExt "grind homo" declName attrKind
+      | .homoPred =>
+        unless attrName == `grind do
+          throwError "homomorphism predicates must be set using the default `[grind]` attribute"
+        addHomoPredAttr declName attrKind
       | .cases eager => ext.addCasesAttr declName eager attrKind
       | .funCC => ext.addFunCCAttr declName attrKind
       | .ext => ext.addExtAttr declName attrKind

--- a/src/Lean/Meta/Tactic/Grind/Homo.lean
+++ b/src/Lean/Meta/Tactic/Grind/Homo.lean
@@ -6,6 +6,7 @@ Authors: Leonardo de Moura
 module
 prelude
 public import Lean.Meta.Sym.Simp.Theorems
+import Lean.Meta.AppBuilder
 public section
 namespace Lean.Meta.Grind
 
@@ -15,5 +16,71 @@ builtin_initialize homoExt : Sym.Simp.SymSimpExtension ← Sym.Simp.mkSymSimpExt
 /-- Returns the homomorphism rules tagged with the `[grind homo]` attribute. -/
 def getHomoTheorems : CoreM Sym.Simp.Theorems :=
   homoExt.getTheorems
+
+/-- A theorem tagged with the `[grind homo_pred]` attribute. -/
+structure HomoPredTheorem where
+  /-- Name of the theorem. -/
+  declName : Name
+  /-- Number of explicit parameters. The theorem is instantiated with the trailing
+  `arity` arguments of the triggering application. -/
+  arity : Nat
+  deriving Inhabited, BEq
+
+/-- Map from trigger head symbol to the `[grind homo_pred]` theorems it activates. -/
+abbrev HomoPredTheorems := NameMap (List HomoPredTheorem)
+
+/-- Extension backing the `@[grind homo_pred]` attribute. -/
+builtin_initialize homoPredExt : SimpleScopedEnvExtension (Name × HomoPredTheorem) HomoPredTheorems ←
+  registerSimpleScopedEnvExtension {
+    initial  := {}
+    addEntry := fun s (key, thm) => s.insert key (thm :: (s.find? key).getD [])
+  }
+
+/-- Returns the homomorphism predicates tagged with the `[grind homo_pred]` attribute. -/
+def getHomoPredTheorems : CoreM HomoPredTheorems :=
+  return homoPredExt.getState (← getEnv)
+
+/--
+Validates and registers a `[grind homo_pred]` theorem.
+The conclusion of the theorem must contain an application whose trailing arguments are
+exactly the theorem's explicit parameters. The head symbol of this application is the
+trigger for the theorem.
+-/
+def addHomoPredAttr (declName : Name) (attrKind : AttributeKind) : MetaM Unit := do
+  let info ← getConstInfo declName
+  unless (← isProp info.type) do
+    throwError "invalid `[grind homo_pred]` theorem, `{.ofConstName declName}` is not a proposition"
+  forallTelescope info.type fun xs type => do
+    let xsExplicit ← xs.filterM fun x => return (← getFVarLocalDecl x).binderInfo.isExplicit
+    let found? := type.find? fun e => Id.run do
+      unless e.isApp && e.getAppFn.isConst do return false
+      let args := e.getAppArgs
+      if args.size < xsExplicit.size then return false
+      return args.extract (args.size - xsExplicit.size) args.size == xsExplicit
+    let some found := found?
+      | throwError "invalid `[grind homo_pred]` theorem, the conclusion of `{.ofConstName declName}` does not contain an application whose trailing arguments are the theorem's explicit parameters"
+    let .const key _ := found.getAppFn | unreachable!
+    homoPredExt.add (key, { declName, arity := xsExplicit.size }) attrKind
+
+/--
+Returns the instances of the `[grind homo_pred]` theorems triggered by `e`.
+Each instance is a pair `(proof, prop)` where `proof : prop`. A registered theorem
+whose trigger matches `e`'s head symbol is instantiated with `e`'s trailing arguments;
+instantiations that fail to elaborate (e.g. because the argument types do not match)
+are discarded.
+-/
+def mkHomoPredInstances (e : Expr) : MetaM (Array (Expr × Expr)) := do
+  let .const declName _ := e.getAppFn | return #[]
+  let some thms := (← getHomoPredTheorems).find? declName | return #[]
+  let args := e.getAppArgs
+  let mut result := #[]
+  for thm in thms do
+    if args.size ≥ thm.arity then
+      try
+        let proof ← mkAppM thm.declName (args.extract (args.size - thm.arity) args.size)
+        result := result.push (proof, ← inferType proof)
+      catch _ =>
+        pure ()
+  return result
 
 end Lean.Meta.Grind

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,3 +1,4 @@
+// update me!
 #include "util/options.h"
 
 // Should we test stage 2 and run update-stage0 on PR merge? NO

--- a/tests/elab/grind_homo_pred_attr.lean
+++ b/tests/elab/grind_homo_pred_attr.lean
@@ -1,0 +1,98 @@
+import Lean
+
+/-!
+Tests for `[grind homo_pred]` attribute registration. Homomorphism predicates are
+registered in an environment extension mapping the trigger head symbol to the tagged
+theorems, retrievable via `Lean.Meta.Grind.getHomoPredTheorems`. The registered
+theorems can be instantiated for concrete terms via
+`Lean.Meta.Grind.mkHomoPredInstances`.
+-/
+
+open Lean Meta Grind
+
+structure W where
+  val : Int
+
+instance : Add W := ⟨fun a b => ⟨a.val + b.val⟩⟩
+instance : LE W := ⟨fun a b => a.val ≤ b.val⟩
+
+def wu (x : W) : Int := x.val
+
+axiom wu_lower (x : W) : 0 ≤ wu x
+axiom wu_upper (x : W) : wu x < 2^32
+axiom le_iff (a b : W) : a ≤ b ↔ wu a ≤ wu b
+
+attribute [grind homo_pred] wu_lower
+attribute [grind homo_pred] wu_upper
+attribute [grind homo_pred] le_iff
+
+/-- Displays the contents of the `[grind homo_pred]` extension. -/
+def showPredMap : MetaM Unit := do
+  let map ← getHomoPredTheorems
+  for (key, thms) in map do
+    for thm in thms do
+      logInfo m!"{key} -> {thm.declName} (arity {thm.arity})"
+
+/--
+info: LE.le -> le_iff (arity 2)
+---
+info: wu -> wu_upper (arity 1)
+---
+info: wu -> wu_lower (arity 1)
+-/
+#guard_msgs in
+run_meta showPredMap
+
+/--
+Instantiates the registered predicates for `wu (x + y)`, `x ≤ y` (over `W`), and
+`(0 : Int) ≤ 0`. The last one triggers `le_iff`, but the instantiation fails because
+the arguments are not of type `W`, so no fact is produced for it.
+-/
+def checkInstances : MetaM Unit := do
+  withLocalDeclD `x (mkConst ``W) fun x => do
+  withLocalDeclD `y (mkConst ``W) fun y => do
+    let e ← mkAppM ``wu #[← mkAppM ``HAdd.hAdd #[x, y]]
+    for (proof, prop) in ← mkHomoPredInstances e do
+      Meta.check proof
+      logInfo m!"{prop}"
+    let e ← mkAppM ``LE.le #[x, y]
+    for (proof, prop) in ← mkHomoPredInstances e do
+      Meta.check proof
+      logInfo m!"{prop}"
+    let e ← mkAppM ``LE.le #[toExpr (0 : Int), toExpr (0 : Int)]
+    for (_, prop) in ← mkHomoPredInstances e do
+      logInfo m!"unexpected: {prop}"
+
+/--
+info: wu (x + y) < 2 ^ 32
+---
+info: 0 ≤ wu (x + y)
+---
+info: x ≤ y ↔ wu x ≤ wu y
+-/
+#guard_msgs in
+run_meta checkInstances
+
+/-! Error conditions. -/
+
+/-- error: invalid `[grind homo_pred]` theorem, `wu` is not a proposition -/
+#guard_msgs in
+attribute [grind homo_pred] wu
+
+axiom not_covering (x : W) (n : Nat) : 0 ≤ wu x
+
+/--
+error: invalid `[grind homo_pred]` theorem, the conclusion of `not_covering` does not contain an application whose trailing arguments are the theorem's explicit parameters
+-/
+#guard_msgs in
+attribute [grind homo_pred] not_covering
+
+/-- error: homomorphism predicates must be set using the default `[grind]` attribute -/
+#guard_msgs in
+attribute [lia homo_pred] wu_lower
+
+/--
+error: homomorphism predicates should be registered using the `@[grind homo_pred]` attribute
+-/
+#guard_msgs in
+example : True := by grind [homo_pred wu_lower]


### PR DESCRIPTION
This PR adds the attribute `[grind homo_pred]`. This attribute is used for a separate mechanism which complements `[grind homo]`. It is not a rewrite set but an eager fact injector keyed by head symbol. Where `[grind homo]`` rules translate terms, `[grind homo_pred]` theorems generate new facts about terms the moment they enter the E-graph.

See #14446