### PR TITLE
feat: add `[grind homo]` and `[grind homo_pred]`

### DIFF
--- a/src/Init/Grind.lean
+++ b/src/Init/Grind.lean
@@ -28,3 +28,4 @@ public import Init.Grind.Lint
 public import Init.Grind.Annotated
 public import Init.Grind.FieldNormNum
 public import Init.Grind.Config
+public import Init.Grind.Homo

--- a/src/Init/Grind/Homo.lean
+++ b/src/Init/Grind/Homo.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2026 Andres Erbsen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andres Erbsen, Leonardo de Moura
+-/
+module
+prelude
+public import Init.Grind.Homo.BitVec
+public import Init.Grind.Homo.Fin
+public import Init.Grind.Homo.Nat
+public import Init.Grind.Homo.Int
+public import Init.Grind.Homo.List
+public import Init.Grind.Homo.UInt8
+public import Init.Grind.Homo.UInt16
+public import Init.Grind.Homo.UInt32
+public import Init.Grind.Homo.UInt64
+public import Init.Grind.Homo.USize
+public import Init.Grind.Homo.Int8
+public import Init.Grind.Homo.Int16
+public import Init.Grind.Homo.Int32
+public import Init.Grind.Homo.Int64
+public import Init.Grind.Homo.ISize

--- a/src/Init/Grind/Homo/BitVec.lean
+++ b/src/Init/Grind/Homo/BitVec.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 Andres Erbsen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andres Erbsen, Leonardo de Moura
+-/
+module
+prelude
+import Init.Grind.Attr
+public import Init.Data.BitVec.Bootstrap
+public import Init.Data.BitVec.Lemmas
+public import Init.Data.BitVec.Bitblast
+
+/-!
+Homomorphism rules for `BitVec` used by the `grind` tactic.
+The unsigned fragment is injected into `Nat` via `BitVec.toNat`, and the signed
+fragment into `Int` via `BitVec.toInt`.
+-/
+
+attribute [grind homo]
+  BitVec.toNat_add BitVec.toNat_sub BitVec.toNat_mul BitVec.toNat_udiv BitVec.toNat_umod
+  BitVec.toNat_neg BitVec.toNat_and BitVec.toNat_or BitVec.toNat_xor
+  BitVec.toNat_shiftLeft BitVec.toNat_ushiftRight BitVec.toNat_append
+  BitVec.toNat_ofNat BitVec.ofNat_toNat BitVec.toNat_setWidth
+  BitVec.toNat_eq BitVec.le_def BitVec.lt_def
+  BitVec.sle_iff_toInt_le BitVec.slt_iff_toInt_lt
+  BitVec.toInt_add BitVec.toInt_sub BitVec.toInt_mul BitVec.toInt_neg
+  BitVec.toInt_not BitVec.toInt_shiftLeft BitVec.toInt_sshiftRight
+  BitVec.toInt_sdiv BitVec.toInt_srem BitVec.toInt_smod
+  BitVec.setWidth_eq
+  BitVec.xor_allOnes BitVec.allOnes_and BitVec.and_allOnes BitVec.not_zero
+  BitVec.zero_and BitVec.and_zero BitVec.zero_or BitVec.or_zero
+  BitVec.zero_xor BitVec.xor_zero BitVec.xor_self
+
+/-! Homomorphism predicates: range facts for the injection functions, instantiated by
+`grind` for the terms it internalizes. The `2 * toInt` bounds are restated with an
+explicit parameter, as required by the `[grind homo_pred]` trigger inference. -/
+
+attribute [grind homo_pred] BitVec.isLt
+
+@[grind homo_pred] theorem Lean.Grind.BitVec.neg_two_pow_le_two_mul_toInt {w : Nat} (x : BitVec w) :
+    -2^w ≤ 2 * x.toInt :=
+  _root_.BitVec.le_two_mul_toInt
+
+@[grind homo_pred] theorem Lean.Grind.BitVec.two_mul_toInt_lt_two_pow {w : Nat} (x : BitVec w) :
+    2 * x.toInt < 2^w :=
+  _root_.BitVec.two_mul_toInt_lt

--- a/src/Init/Grind/Homo/Fin.lean
+++ b/src/Init/Grind/Homo/Fin.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 Andres Erbsen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andres Erbsen, Leonardo de Moura
+-/
+module
+prelude
+import Init.Grind.Attr
+public import Init.Data.Fin.Lemmas
+public import Init.Data.Fin.Bitwise
+public section
+
+/-!
+Homomorphism rules for `Fin` used by the `grind` tactic.
+The injection function is `Fin.val`.
+-/
+
+attribute [grind homo]
+  Fin.val_add Fin.val_mul Fin.val_sub Fin.val_mod Fin.val_zero Fin.val_succ Fin.val_neg'
+  Fin.div_val Fin.and_val Fin.or_val Fin.xor_val Fin.shiftLeft_val Fin.shiftRight_val
+  Fin.val_ofNat Fin.le_def Fin.lt_def
+
+@[grind homo] theorem Lean.Grind.Fin.eq_iff_val_eq {n : Nat} (a b : Fin n) : a = b ↔ a.val = b.val :=
+  ⟨Fin.val_eq_of_eq, Fin.eq_of_val_eq⟩
+
+@[grind homo] theorem Lean.Grind.Fin.val_ite {n : Nat} (c : Prop) [Decidable c] (x y : Fin n) :
+    (if c then x else y).val = if c then x.val else y.val := by
+  split <;> rfl
+
+/-! Homomorphism predicate: the range fact for `Fin.val`, instantiated by `grind` for
+the terms it internalizes. -/
+
+attribute [grind homo_pred] Fin.isLt

--- a/src/Init/Grind/Homo/ISize.lean
+++ b/src/Init/Grind/Homo/ISize.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 Andres Erbsen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andres Erbsen, Leonardo de Moura
+-/
+module
+prelude
+import Init.Grind.Attr
+public import Init.Data.UInt.Lemmas
+public import Init.Data.UInt.Bitwise
+public import Init.Data.SInt.Lemmas
+public import Init.Data.SInt.Bitwise
+public section
+
+/-!
+Homomorphism rules for `ISize` used by the `grind` tactic.
+The injection function is `ISize.toBitVec`.
+-/
+
+attribute [grind homo]
+  ISize.toBitVec_add ISize.toBitVec_sub ISize.toBitVec_mul ISize.toBitVec_div ISize.toBitVec_mod
+  ISize.toBitVec_and ISize.toBitVec_or ISize.toBitVec_xor ISize.toBitVec_shiftLeft ISize.toBitVec_shiftRight
+  ISize.toBitVec_zero ISize.toBitVec_one ISize.toBitVec_not ISize.toBitVec_neg
+  ISize.eq_iff_toBitVec_eq
+  ISize.toBitVec_ofNat
+  ISize.toBitVec_toInt8 ISize.toBitVec_toInt16 ISize.toBitVec_toInt32 ISize.toBitVec_toInt64 ISize.toBitVec_toUSize
+
+@[grind homo] theorem Lean.Grind.ISize.toInt_eq_toBitVec_toInt (x : ISize) : x.toInt = x.toBitVec.toInt := rfl
+
+/-! Translations of `≤` and `<` into the target domain. -/
+
+attribute [grind homo] ISize.le_iff_toInt_le ISize.lt_iff_toInt_lt

--- a/src/Init/Grind/Homo/Int.lean
+++ b/src/Init/Grind/Homo/Int.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2026 Andres Erbsen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andres Erbsen, Leonardo de Moura
+-/
+module
+prelude
+import Init.Grind.Attr
+public import Init.Data.Int.Lemmas
+public import Init.Data.Int.Order
+public import Init.Data.Int.LemmasAux
+public import Init.Data.Int.Pow
+public import Init.Data.Int.Bitwise.Lemmas
+public import Init.Data.Int.DivMod.Bootstrap
+public import Init.Data.Int.DivMod.Lemmas
+public section
+
+/-!
+Homomorphism rules for `Int` used by the `grind` tactic.
+The `natCast` rules inject `Nat` operations into `Int`, shifts are normalized to
+arithmetic, and the `%`-cleanup rules remove redundant modular wrappers produced
+by injections into `Int`.
+-/
+
+attribute [grind homo]
+  Int.natCast_add Int.natCast_mul Int.natCast_pow
+  Int.shiftLeft_eq Int.shiftRight_eq_div_pow
+  Int.ofNat_toNat Int.toNat_sub'
+  Int.emod_add_emod Int.add_emod_emod
+  Int.emod_sub_emod Int.sub_emod_emod
+  Int.emod_emod
+
+@[grind homo] theorem Lean.Grind.Int.emod_mul_emod (m n k : Int) : m % n * k % n = m * k % n := by
+  rw [Int.mul_emod, Int.emod_emod, ← Int.mul_emod]
+
+@[grind homo] theorem Lean.Grind.Int.mul_emod_emod (m n k : Int) : m * (n % k) % k = m * n % k := by
+  rw [Int.mul_emod, Int.emod_emod, ← Int.mul_emod]

--- a/src/Init/Grind/Homo/Int16.lean
+++ b/src/Init/Grind/Homo/Int16.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 Andres Erbsen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andres Erbsen, Leonardo de Moura
+-/
+module
+prelude
+import Init.Grind.Attr
+public import Init.Data.UInt.Lemmas
+public import Init.Data.UInt.Bitwise
+public import Init.Data.SInt.Lemmas
+public import Init.Data.SInt.Bitwise
+public section
+
+/-!
+Homomorphism rules for `Int16` used by the `grind` tactic.
+The injection function is `Int16.toBitVec`.
+-/
+
+attribute [grind homo]
+  Int16.toBitVec_add Int16.toBitVec_sub Int16.toBitVec_mul Int16.toBitVec_div Int16.toBitVec_mod
+  Int16.toBitVec_and Int16.toBitVec_or Int16.toBitVec_xor Int16.toBitVec_shiftLeft Int16.toBitVec_shiftRight
+  Int16.toBitVec_zero Int16.toBitVec_one Int16.toBitVec_not Int16.toBitVec_neg
+  Int16.eq_iff_toBitVec_eq
+  Int16.toBitVec_ofNat
+  Int16.toBitVec_toInt8 Int16.toBitVec_toInt32 Int16.toBitVec_toInt64 Int16.toBitVec_toISize Int16.toBitVec_toUInt16
+
+@[grind homo] theorem Lean.Grind.Int16.toInt_eq_toBitVec_toInt (x : Int16) : x.toInt = x.toBitVec.toInt := rfl
+
+/-! Translations of `≤` and `<` into the target domain. -/
+
+attribute [grind homo] Int16.le_iff_toInt_le Int16.lt_iff_toInt_lt

--- a/src/Init/Grind/Homo/Int32.lean
+++ b/src/Init/Grind/Homo/Int32.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 Andres Erbsen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andres Erbsen, Leonardo de Moura
+-/
+module
+prelude
+import Init.Grind.Attr
+public import Init.Data.UInt.Lemmas
+public import Init.Data.UInt.Bitwise
+public import Init.Data.SInt.Lemmas
+public import Init.Data.SInt.Bitwise
+public section
+
+/-!
+Homomorphism rules for `Int32` used by the `grind` tactic.
+The injection function is `Int32.toBitVec`.
+-/
+
+attribute [grind homo]
+  Int32.toBitVec_add Int32.toBitVec_sub Int32.toBitVec_mul Int32.toBitVec_div Int32.toBitVec_mod
+  Int32.toBitVec_and Int32.toBitVec_or Int32.toBitVec_xor Int32.toBitVec_shiftLeft Int32.toBitVec_shiftRight
+  Int32.toBitVec_zero Int32.toBitVec_one Int32.toBitVec_not Int32.toBitVec_neg
+  Int32.eq_iff_toBitVec_eq
+  Int32.toBitVec_ofNat
+  Int32.toBitVec_toInt8 Int32.toBitVec_toInt16 Int32.toBitVec_toInt64 Int32.toBitVec_toISize Int32.toBitVec_toUInt32
+
+@[grind homo] theorem Lean.Grind.Int32.toInt_eq_toBitVec_toInt (x : Int32) : x.toInt = x.toBitVec.toInt := rfl
+
+/-! Translations of `≤` and `<` into the target domain. -/
+
+attribute [grind homo] Int32.le_iff_toInt_le Int32.lt_iff_toInt_lt

--- a/src/Init/Grind/Homo/Int64.lean
+++ b/src/Init/Grind/Homo/Int64.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 Andres Erbsen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andres Erbsen, Leonardo de Moura
+-/
+module
+prelude
+import Init.Grind.Attr
+public import Init.Data.UInt.Lemmas
+public import Init.Data.UInt.Bitwise
+public import Init.Data.SInt.Lemmas
+public import Init.Data.SInt.Bitwise
+public section
+
+/-!
+Homomorphism rules for `Int64` used by the `grind` tactic.
+The injection function is `Int64.toBitVec`.
+-/
+
+attribute [grind homo]
+  Int64.toBitVec_add Int64.toBitVec_sub Int64.toBitVec_mul Int64.toBitVec_div Int64.toBitVec_mod
+  Int64.toBitVec_and Int64.toBitVec_or Int64.toBitVec_xor Int64.toBitVec_shiftLeft Int64.toBitVec_shiftRight
+  Int64.toBitVec_zero Int64.toBitVec_one Int64.toBitVec_not Int64.toBitVec_neg
+  Int64.eq_iff_toBitVec_eq
+  Int64.toBitVec_ofNat
+  Int64.toBitVec_toInt8 Int64.toBitVec_toInt16 Int64.toBitVec_toInt32 Int64.toBitVec_toISize Int64.toBitVec_toUInt64
+
+@[grind homo] theorem Lean.Grind.Int64.toInt_eq_toBitVec_toInt (x : Int64) : x.toInt = x.toBitVec.toInt := rfl
+
+/-! Translations of `≤` and `<` into the target domain. -/
+
+attribute [grind homo] Int64.le_iff_toInt_le Int64.lt_iff_toInt_lt

--- a/src/Init/Grind/Homo/Int8.lean
+++ b/src/Init/Grind/Homo/Int8.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 Andres Erbsen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andres Erbsen, Leonardo de Moura
+-/
+module
+prelude
+import Init.Grind.Attr
+public import Init.Data.UInt.Lemmas
+public import Init.Data.UInt.Bitwise
+public import Init.Data.SInt.Lemmas
+public import Init.Data.SInt.Bitwise
+public section
+
+/-!
+Homomorphism rules for `Int8` used by the `grind` tactic.
+The injection function is `Int8.toBitVec`.
+-/
+
+attribute [grind homo]
+  Int8.toBitVec_add Int8.toBitVec_sub Int8.toBitVec_mul Int8.toBitVec_div Int8.toBitVec_mod
+  Int8.toBitVec_and Int8.toBitVec_or Int8.toBitVec_xor Int8.toBitVec_shiftLeft Int8.toBitVec_shiftRight
+  Int8.toBitVec_zero Int8.toBitVec_one Int8.toBitVec_not Int8.toBitVec_neg
+  Int8.eq_iff_toBitVec_eq
+  Int8.toBitVec_ofNat
+  Int8.toBitVec_toInt16 Int8.toBitVec_toInt32 Int8.toBitVec_toInt64 Int8.toBitVec_toISize Int8.toBitVec_toUInt8
+
+@[grind homo] theorem Lean.Grind.Int8.toInt_eq_toBitVec_toInt (x : Int8) : x.toInt = x.toBitVec.toInt := rfl
+
+/-! Translations of `≤` and `<` into the target domain. -/
+
+attribute [grind homo] Int8.le_iff_toInt_le Int8.lt_iff_toInt_lt

--- a/src/Init/Grind/Homo/List.lean
+++ b/src/Init/Grind/Homo/List.lean
@@ -1,0 +1,29 @@
+/-
+Copyright (c) 2026 Andres Erbsen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andres Erbsen, Leonardo de Moura
+-/
+module
+prelude
+import Init.Grind.Attr
+public import Init.Data.List.Lemmas
+public import Init.Data.List.TakeDrop
+public import Init.Data.List.Nat.TakeDrop
+public import Init.Data.List.Nat.InsertIdx
+public import Init.Data.List.Nat.Modify
+public import Init.Data.List.Erase
+public import Init.Data.List.Zip
+public section
+
+/-!
+Homomorphism rules for `List` used by the `grind` tactic.
+The injection function is `List.length`.
+-/
+
+attribute [grind homo]
+  List.length_nil List.length_cons List.length_append List.length_drop List.length_take
+  List.length_reverse List.length_map List.length_replicate List.length_tail List.length_concat
+  List.length_zipWith List.length_zip List.length_set List.length_insertIdx List.length_eraseIdx
+  List.length_modify List.length_singleton List.length_dropLast List.length_dropLast_cons
+  List.length_replace
+  List.drop_drop List.take_take

--- a/src/Init/Grind/Homo/Nat.lean
+++ b/src/Init/Grind/Homo/Nat.lean
@@ -1,0 +1,34 @@
+/-
+Copyright (c) 2026 Andres Erbsen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andres Erbsen, Leonardo de Moura
+-/
+module
+prelude
+import Init.Grind.Attr
+public import Init.Data.Nat.Lemmas
+public import Init.Data.Nat.Bitwise.Lemmas
+public section
+
+/-!
+Homomorphism rules for `Nat` used by the `grind` tactic.
+These are target-domain rules: shifts are normalized to arithmetic, `testBit`
+decomposes bitwise operations, and the `%`-cleanup rules remove the redundant
+modular wrappers produced by the `BitVec.toNat` injection.
+-/
+
+attribute [grind homo]
+  Nat.shiftLeft_eq Nat.shiftRight_eq_div_pow
+  Nat.mod_add_mod Nat.add_mod_mod Nat.mod_mul_mod Nat.mul_mod_mod
+  Nat.testBit_and Nat.testBit_or Nat.testBit_xor
+  Nat.testBit_shiftLeft Nat.testBit_shiftRight
+  Nat.zero_testBit Nat.testBit_one_eq_true_iff_self_eq_zero
+  Nat.testBit_two_pow_sub_one Nat.testBit_mod_two_pow
+  Nat.testBit_two_pow_mul
+
+/-
+`Nat.testBit_two_pow_mul_add` is intentionally not part of this set: its hypothesis
+`a < 2^n` would have to be discharged when the rule is applied, and homomorphism rules
+are applied without a discharger. Conditional theorems like this one should be
+registered for E-matching instead.
+-/

--- a/src/Init/Grind/Homo/UInt16.lean
+++ b/src/Init/Grind/Homo/UInt16.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 Andres Erbsen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andres Erbsen, Leonardo de Moura
+-/
+module
+prelude
+import Init.Grind.Attr
+public import Init.Data.UInt.Lemmas
+public import Init.Data.UInt.Bitwise
+public import Init.Data.SInt.Lemmas
+public import Init.Data.SInt.Bitwise
+public section
+
+/-!
+Homomorphism rules for `UInt16` used by the `grind` tactic.
+The injection function is `UInt16.toBitVec`.
+-/
+
+attribute [grind homo]
+  UInt16.toBitVec_add UInt16.toBitVec_sub UInt16.toBitVec_mul UInt16.toBitVec_div UInt16.toBitVec_mod
+  UInt16.toBitVec_and UInt16.toBitVec_or UInt16.toBitVec_xor UInt16.toBitVec_shiftLeft UInt16.toBitVec_shiftRight
+  UInt16.toBitVec_zero UInt16.toBitVec_one UInt16.toBitVec_not UInt16.toBitVec_neg
+  UInt16.eq_iff_toBitVec_eq
+  UInt16.toBitVec_ofNat UInt16.toBitVec_ofNat'
+  UInt16.toBitVec_toUInt8 UInt16.toBitVec_toUInt32 UInt16.toBitVec_toUInt64 UInt16.toBitVec_toUSize UInt16.toBitVec_toInt16
+
+@[grind homo] theorem Lean.Grind.UInt16.toNat_eq_toBitVec_toNat (x : UInt16) : x.toNat = x.toBitVec.toNat := rfl
+
+/-! Translations of `≤` and `<` into the target domain. -/
+
+attribute [grind homo] UInt16.le_iff_toBitVec_le UInt16.lt_iff_toBitVec_lt

--- a/src/Init/Grind/Homo/UInt32.lean
+++ b/src/Init/Grind/Homo/UInt32.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 Andres Erbsen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andres Erbsen, Leonardo de Moura
+-/
+module
+prelude
+import Init.Grind.Attr
+public import Init.Data.UInt.Lemmas
+public import Init.Data.UInt.Bitwise
+public import Init.Data.SInt.Lemmas
+public import Init.Data.SInt.Bitwise
+public section
+
+/-!
+Homomorphism rules for `UInt32` used by the `grind` tactic.
+The injection function is `UInt32.toBitVec`.
+-/
+
+attribute [grind homo]
+  UInt32.toBitVec_add UInt32.toBitVec_sub UInt32.toBitVec_mul UInt32.toBitVec_div UInt32.toBitVec_mod
+  UInt32.toBitVec_and UInt32.toBitVec_or UInt32.toBitVec_xor UInt32.toBitVec_shiftLeft UInt32.toBitVec_shiftRight
+  UInt32.toBitVec_zero UInt32.toBitVec_one UInt32.toBitVec_not UInt32.toBitVec_neg
+  UInt32.eq_iff_toBitVec_eq
+  UInt32.toBitVec_ofNat UInt32.toBitVec_ofNat'
+  UInt32.toBitVec_toUInt8 UInt32.toBitVec_toUInt16 UInt32.toBitVec_toUInt64 UInt32.toBitVec_toUSize UInt32.toBitVec_toInt32
+
+@[grind homo] theorem Lean.Grind.UInt32.toNat_eq_toBitVec_toNat (x : UInt32) : x.toNat = x.toBitVec.toNat := rfl
+
+/-! Translations of `≤` and `<` into the target domain. -/
+
+attribute [grind homo] UInt32.le_iff_toBitVec_le UInt32.lt_iff_toBitVec_lt

--- a/src/Init/Grind/Homo/UInt64.lean
+++ b/src/Init/Grind/Homo/UInt64.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 Andres Erbsen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andres Erbsen, Leonardo de Moura
+-/
+module
+prelude
+import Init.Grind.Attr
+public import Init.Data.UInt.Lemmas
+public import Init.Data.UInt.Bitwise
+public import Init.Data.SInt.Lemmas
+public import Init.Data.SInt.Bitwise
+public section
+
+/-!
+Homomorphism rules for `UInt64` used by the `grind` tactic.
+The injection function is `UInt64.toBitVec`.
+-/
+
+attribute [grind homo]
+  UInt64.toBitVec_add UInt64.toBitVec_sub UInt64.toBitVec_mul UInt64.toBitVec_div UInt64.toBitVec_mod
+  UInt64.toBitVec_and UInt64.toBitVec_or UInt64.toBitVec_xor UInt64.toBitVec_shiftLeft UInt64.toBitVec_shiftRight
+  UInt64.toBitVec_zero UInt64.toBitVec_one UInt64.toBitVec_not UInt64.toBitVec_neg
+  UInt64.eq_iff_toBitVec_eq
+  UInt64.toBitVec_ofNat UInt64.toBitVec_ofNat'
+  UInt64.toBitVec_toUInt8 UInt64.toBitVec_toUInt16 UInt64.toBitVec_toUInt32 UInt64.toBitVec_toUSize UInt64.toBitVec_toInt64
+
+@[grind homo] theorem Lean.Grind.UInt64.toNat_eq_toBitVec_toNat (x : UInt64) : x.toNat = x.toBitVec.toNat := rfl
+
+/-! Translations of `≤` and `<` into the target domain. -/
+
+attribute [grind homo] UInt64.le_iff_toBitVec_le UInt64.lt_iff_toBitVec_lt

--- a/src/Init/Grind/Homo/UInt8.lean
+++ b/src/Init/Grind/Homo/UInt8.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 Andres Erbsen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andres Erbsen, Leonardo de Moura
+-/
+module
+prelude
+import Init.Grind.Attr
+public import Init.Data.UInt.Lemmas
+public import Init.Data.UInt.Bitwise
+public import Init.Data.SInt.Lemmas
+public import Init.Data.SInt.Bitwise
+public section
+
+/-!
+Homomorphism rules for `UInt8` used by the `grind` tactic.
+The injection function is `UInt8.toBitVec`.
+-/
+
+attribute [grind homo]
+  UInt8.toBitVec_add UInt8.toBitVec_sub UInt8.toBitVec_mul UInt8.toBitVec_div UInt8.toBitVec_mod
+  UInt8.toBitVec_and UInt8.toBitVec_or UInt8.toBitVec_xor UInt8.toBitVec_shiftLeft UInt8.toBitVec_shiftRight
+  UInt8.toBitVec_zero UInt8.toBitVec_one UInt8.toBitVec_not UInt8.toBitVec_neg
+  UInt8.eq_iff_toBitVec_eq
+  UInt8.toBitVec_ofNat UInt8.toBitVec_ofNat'
+  UInt8.toBitVec_toUInt16 UInt8.toBitVec_toUInt32 UInt8.toBitVec_toUInt64 UInt8.toBitVec_toUSize UInt8.toBitVec_toInt8
+
+@[grind homo] theorem Lean.Grind.UInt8.toNat_eq_toBitVec_toNat (x : UInt8) : x.toNat = x.toBitVec.toNat := rfl
+
+/-! Translations of `≤` and `<` into the target domain. -/
+
+attribute [grind homo] UInt8.le_iff_toBitVec_le UInt8.lt_iff_toBitVec_lt

--- a/src/Init/Grind/Homo/USize.lean
+++ b/src/Init/Grind/Homo/USize.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 Andres Erbsen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andres Erbsen, Leonardo de Moura
+-/
+module
+prelude
+import Init.Grind.Attr
+public import Init.Data.UInt.Lemmas
+public import Init.Data.UInt.Bitwise
+public import Init.Data.SInt.Lemmas
+public import Init.Data.SInt.Bitwise
+public section
+
+/-!
+Homomorphism rules for `USize` used by the `grind` tactic.
+The injection function is `USize.toBitVec`.
+-/
+
+attribute [grind homo]
+  USize.toBitVec_add USize.toBitVec_sub USize.toBitVec_mul USize.toBitVec_div USize.toBitVec_mod
+  USize.toBitVec_and USize.toBitVec_or USize.toBitVec_xor USize.toBitVec_shiftLeft USize.toBitVec_shiftRight
+  USize.toBitVec_zero USize.toBitVec_one USize.toBitVec_not USize.toBitVec_neg
+  USize.eq_iff_toBitVec_eq
+  USize.toBitVec_ofNat USize.toBitVec_ofNat'
+  USize.toBitVec_toUInt8 USize.toBitVec_toUInt16 USize.toBitVec_toUInt32 USize.toBitVec_toUInt64 USize.toBitVec_toISize
+
+@[grind homo] theorem Lean.Grind.USize.toNat_eq_toBitVec_toNat (x : USize) : x.toNat = x.toBitVec.toNat := rfl
+
+/-! Translations of `≤` and `<` into the target domain. -/
+
+attribute [grind homo] USize.le_iff_toBitVec_le USize.lt_iff_toBitVec_lt

--- a/src/Lean/Meta/Tactic/Grind/Homo.lean
+++ b/src/Lean/Meta/Tactic/Grind/Homo.lean
@@ -101,6 +101,10 @@ def addHomoPredAttr (declName : Name) (attrKind : AttributeKind) : MetaM Unit :=
     throwError "invalid `[grind homo_pred]` theorem, `{.ofConstName declName}` is not a proposition"
   forallTelescope info.type fun xs type => do
     let xsExplicit ← xs.filterM fun x => return (← getFVarLocalDecl x).binderInfo.isExplicit
+    if xsExplicit.isEmpty then
+      throwError "invalid `[grind homo_pred]` theorem, `{.ofConstName declName}` must have \
+        at least one explicit parameter; the trigger is inferred from an application whose \
+        trailing arguments are the theorem's explicit parameters"
     let found? := type.find? fun e => Id.run do
       unless e.isApp && e.getAppFn.isConst do return false
       let args := e.getAppArgs

--- a/tests/elab/grind_homo_attr.lean
+++ b/tests/elab/grind_homo_attr.lean
@@ -7,11 +7,18 @@ Tests for `[grind homo]` attribute registration. Homomorphism rules are register
 
 open Lean Meta Grind
 
-def wu (x : BitVec 32) : Int := (x.toNat : Int)
+/-- Custom source type so this test is independent of the `[grind homo]` rules in `Init`. -/
+structure W where
+  val : Int
 
-axiom wu_add (x y : BitVec 32) : wu (x + y) = (wu x + wu y) % 2^32
-axiom wu_mul (x y : BitVec 32) : wu (x * y) = (wu x * wu y) % 2^32
-axiom wu_eq (x y : BitVec 32) : (x = y) ↔ (wu x = wu y)
+instance : Add W := ⟨fun a b => ⟨a.val + b.val⟩⟩
+instance : Mul W := ⟨fun a b => ⟨a.val * b.val⟩⟩
+
+def wu (x : W) : Int := x.val
+
+axiom wu_add (x y : W) : wu (x + y) = (wu x + wu y) % 2^32
+axiom wu_mul (x y : W) : wu (x * y) = (wu x * wu y) % 2^32
+axiom wu_eq (x y : W) : (x = y) ↔ (wu x = wu y)
 
 attribute [grind homo] wu_add
 attribute [grind homo] wu_mul
@@ -19,7 +26,7 @@ attribute [grind homo] wu_eq
 
 /-- Displays the `[grind homo]` rules matching `wu (x + x)` and `x = x`. -/
 def checkMatches : MetaM Unit := do
-  withLocalDeclD `x (mkApp (mkConst ``BitVec) (mkNatLit 32)) fun x => do
+  withLocalDeclD `x (mkConst ``W) fun x => do
     let thms ← getHomoTheorems
     let add ← mkAppM ``wu #[← mkAppM ``HAdd.hAdd #[x, x]]
     for thm in thms.getMatch add do
@@ -57,7 +64,7 @@ example : True := by grind [homo wu_add]
 /-! Conditional theorems are rejected: hypotheses that must be discharged are not
 supported. Hypotheses occurring in the conclusion (instantiated by matching) are fine. -/
 
-axiom wu_cond (x y : BitVec 32) (h : wu x = 0) : wu (x + y) = wu y
+axiom wu_cond (x y : W) (h : wu x = 0) : wu (x + y) = wu y
 
 /--
 error: invalid `[grind homo]` theorem, `wu_cond` is conditional: hypothesis
@@ -67,9 +74,9 @@ is not determined by the left-hand side and would have to be discharged when the
 #guard_msgs in
 attribute [grind homo] wu_cond
 
-def wcast (_h : True) (x : BitVec 32) : BitVec 32 := x
+def wcast (_h : True) (x : W) : W := x
 
-axiom wu_wcast (h : True) (x : BitVec 32) : wu (wcast h x) = wu x
+axiom wu_wcast (h : True) (x : W) : wu (wcast h x) = wu x
 
 #guard_msgs in
 attribute [grind homo] wu_wcast
@@ -78,14 +85,16 @@ attribute [grind homo] wu_wcast
 synthesized during rewriting. In particular, `Prop`-valued instances such as `NeZero`
 must not be reported as conditional hypotheses. -/
 
-axiom wu_ofNat (n : Nat) [NeZero n] : wu (BitVec.ofNat 32 n) = (n : Int)
+def wofNat (n : Nat) : W := ⟨n⟩
+
+axiom wu_ofNat (n : Nat) [NeZero n] : wu (wofNat n) = (n : Int)
 
 #guard_msgs in
 attribute [grind homo] wu_ofNat
 
 /-! A parameter occurring only in the right-hand side cannot be instantiated. -/
 
-axiom wu_rhs (x y : BitVec 32) : wu x = wu (x + y)
+axiom wu_rhs (x y : W) : wu x = wu (x + y)
 
 /--
 error: invalid `[grind homo]` theorem, parameter `y` of `wu_rhs` is not determined by the left-hand side of the rule

--- a/tests/elab/grind_homo_lemmas.lean
+++ b/tests/elab/grind_homo_lemmas.lean
@@ -1,0 +1,211 @@
+import Lean
+
+/-!
+Tests that the `[grind homo]` environment extension is populated by the homomorphism
+rules in `Init.Grind.Homo`. We check both direct retrieval (`getHomoTheorems` +
+`Theorems.getMatch`) and that the registered theorems can be used to perform
+rewriting: a small metaprogram applies the homomorphisms to fixpoint using `Sym.simp`
+and verifies the generated proofs.
+-/
+
+open Lean Meta Lean.Meta.Sym Lean.Meta.Sym.Simp
+
+/-- Prints the `[grind homo]` rules matching the (instantiated) body of `declName`. -/
+def showMatches (declName : Name) : MetaM Unit := do
+  let value := (← getConstInfoDefn declName).value
+  lambdaTelescope value fun _ body => SymM.run do
+    let body ← share body
+    let thms ← Grind.getHomoTheorems
+    for thm in thms.getMatch body do
+      logInfo m!"{thm.expr}"
+
+/--
+Applies the `[grind homo]` rules to the body of `declName` to fixpoint using `Sym.simp`,
+prints the result, and checks the generated proof.
+-/
+def applyHomo (declName : Name) : MetaM Unit := do
+  let value := (← getConstInfoDefn declName).value
+  lambdaTelescope value fun _ body => SymM.run do
+    let thms ← Grind.getHomoTheorems
+    let methods : Methods := { pre := thms.rewrite, post := thms.rewrite }
+    let body ← share body
+    let r ← simp body methods {}
+    let result := Result.getResultExpr body r
+    logInfo m!"{body}\n==>\n{result}"
+    if let .step _ proof _ _ := r then
+      Meta.check proof
+      unless (← isDefEq (← Meta.inferType proof) (← mkEq body result)) do
+        throwError "proof type mismatch"
+
+/-! Extension population: representative operations retrieve the expected rules. -/
+
+def bvAdd (x y : BitVec 8) : Nat := (x + y).toNat
+def u8Mul (x y : UInt8) : BitVec 8 := (x * y).toBitVec
+def finSub (n : Nat) (a b : Fin n) : Nat := (a - b).val
+
+/--
+info: @BitVec.toNat_add
+-/
+#guard_msgs in
+run_meta showMatches ``bvAdd
+
+/--
+info: UInt8.toBitVec_ofNat
+---
+info: @UInt8.toBitVec_mul
+-/
+#guard_msgs in
+run_meta showMatches ``u8Mul
+
+/--
+info: @Fin.val_sub
+-/
+#guard_msgs in
+run_meta showMatches ``finSub
+
+/-! Rewriting with the registered homomorphisms. -/
+
+/-- The worked example from the design: cleanup rules remove nested `% 2^8` wrappers. -/
+def bvCleanup (x y z : BitVec 8) : Prop := (x + y + z).toNat = 0
+
+def u8Eq (x y z : UInt8) : Prop := (x + y) * z = z
+
+def u8ToNat (x y : UInt8) : Prop := (x + y).toNat = x.toNat
+
+def finEq (n : Nat) (a b : Fin n) : Prop := a + b = b
+
+def listLen (l₁ l₂ : List Nat) : Prop := (l₁ ++ l₂).length = l₁.length
+
+def intCast (a b : Nat) : Prop := ((a + b * a : Nat) : Int) = 0
+
+def i64Eq (a b : Int64) : Prop := a * b = b
+
+/--
+info: (x + y + z).toNat = 0
+==>
+(x.toNat + y.toNat + z.toNat) % 2 ^ 8 = 0
+-/
+#guard_msgs in
+run_meta applyHomo ``bvCleanup
+
+/--
+info: (x + y) * z = z
+==>
+(x.toBitVec.toNat + y.toBitVec.toNat) * z.toBitVec.toNat % 2 ^ 8 = z.toBitVec.toNat
+-/
+#guard_msgs in
+run_meta applyHomo ``u8Eq
+
+/--
+info: (x + y).toNat = x.toNat
+==>
+(x.toBitVec.toNat + y.toBitVec.toNat) % 2 ^ 8 = x.toBitVec.toNat
+-/
+#guard_msgs in
+run_meta applyHomo ``u8ToNat
+
+/--
+info: a + b = b
+==>
+(↑a + ↑b) % n = ↑b
+-/
+#guard_msgs in
+run_meta applyHomo ``finEq
+
+/--
+info: (l₁ ++ l₂).length = l₁.length
+==>
+l₁.length + l₂.length = l₁.length
+-/
+#guard_msgs in
+run_meta applyHomo ``listLen
+
+/--
+info: ↑(a + b * a) = 0
+==>
+↑a + ↑b * ↑a = 0
+-/
+#guard_msgs in
+run_meta applyHomo ``intCast
+
+/--
+info: a * b = b
+==>
+a.toBitVec.toNat * b.toBitVec.toNat % 2 ^ 64 = b.toBitVec.toNat
+-/
+#guard_msgs in
+run_meta applyHomo ``i64Eq
+
+/-! Homomorphism predicates from `Init.Grind.Homo`: range facts and relation
+translations are instantiated for representative terms via `mkHomoPredInstances`. -/
+
+/-- Instantiates the `[grind homo_pred]` theorems for the body of `declName`. -/
+def showPredInstances (declName : Name) : MetaM Unit := do
+  let value := (← getConstInfoDefn declName).value
+  lambdaTelescope value fun _ body => do
+    for (proof, prop) in ← Grind.mkHomoPredInstances body do
+      Meta.check proof
+      logInfo m!"{prop}"
+
+def bvToNat (x y : BitVec 8) : Nat := (x + y).toNat
+def bvToInt (x : BitVec 8) : Int := x.toInt
+def u8Le (x y : UInt8) : Prop := x ≤ y
+def finVal (n : Nat) (a : Fin n) : Nat := a.val
+def i64Lt (a b : Int64) : Prop := a < b
+
+/--
+info: (x + y).toNat < 2 ^ 8
+-/
+#guard_msgs in
+run_meta showPredInstances ``bvToNat
+
+/--
+info: 2 * x.toInt < 2 ^ 8
+---
+info: -2 ^ 8 ≤ 2 * x.toInt
+-/
+#guard_msgs in
+run_meta showPredInstances ``bvToInt
+
+/--
+info: x ≤ y
+==>
+x.toBitVec.toNat ≤ y.toBitVec.toNat
+-/
+#guard_msgs in
+run_meta applyHomo ``u8Le
+
+/--
+info: ↑a < n
+-/
+#guard_msgs in
+run_meta showPredInstances ``finVal
+
+/--
+info: a < b
+==>
+a.toBitVec.toInt < b.toBitVec.toInt
+-/
+#guard_msgs in
+run_meta applyHomo ``i64Lt
+
+/-! Signed bitvector comparisons are translated into `Int`. -/
+
+def bvSle (x y : BitVec 8) : Prop := x.sle y
+def bvSlt (x y : BitVec 8) : Prop := x.slt y
+
+/--
+info: x.sle y = true
+==>
+x.toInt ≤ y.toInt
+-/
+#guard_msgs in
+run_meta applyHomo ``bvSle
+
+/--
+info: x.slt y = true
+==>
+x.toInt < y.toInt
+-/
+#guard_msgs in
+run_meta applyHomo ``bvSlt

--- a/tests/elab/grind_homo_pred_attr.lean
+++ b/tests/elab/grind_homo_pred_attr.lean
@@ -26,12 +26,17 @@ attribute [grind homo_pred] wu_lower
 attribute [grind homo_pred] wu_upper
 attribute [grind homo_pred] le_iff
 
-/-- Displays the contents of the `[grind homo_pred]` extension. -/
+/--
+Displays the `[grind homo_pred]` entries registered by this file. The extension also
+contains the predicates from `Init.Grind.Homo`, so we only display the theorems
+declared at the root namespace (i.e. the ones in this file).
+-/
 def showPredMap : MetaM Unit := do
   let map ← getHomoPredTheorems
   for (key, thms) in map do
     for thm in thms do
-      logInfo m!"{key} -> {thm.declName} (arity {thm.arity})"
+      if thm.declName.getPrefix.isAnonymous then
+        logInfo m!"{key} -> {thm.declName} (arity {thm.arity})"
 
 /--
 info: LE.le -> le_iff (arity 2)
@@ -86,6 +91,14 @@ error: invalid `[grind homo_pred]` theorem, the conclusion of `not_covering` doe
 -/
 #guard_msgs in
 attribute [grind homo_pred] not_covering
+
+axiom all_implicit {a b : W} : a ≤ b ↔ wu a ≤ wu b
+
+/--
+error: invalid `[grind homo_pred]` theorem, `all_implicit` must have at least one explicit parameter; the trigger is inferred from an application whose trailing arguments are the theorem's explicit parameters
+-/
+#guard_msgs in
+attribute [grind homo_pred] all_implicit
 
 /-- error: homomorphism predicates must be set using the default `[grind]` attribute -/
 #guard_msgs in


### PR DESCRIPTION
This PR annotates theorems for `BitVec`, `Fin`, and fixed (signed and unsigned) integers using then new  `[grind homo]` and `[grind homo_pred]` attributes. This PR is based on the prototype implemented by Andres Erbsen at https://github.com/AeneasVerif/kraken/pull/122

TODO: implement support for `[grind homo]` and `[grind homo_ext]` in `grind` and delete `ToInt` machinery.
