### PR TITLE
chore: avoid `grind` in core

### DIFF
--- a/src/Init/Data/Char/Ordinal.lean
+++ b/src/Init/Data/Char/Ordinal.lean
@@ -216,7 +216,9 @@ theorem succ?_eq {c : Char} : c.succ? = (c.ordinal.addNat? 1).map Char.ofOrdinal
       · simp only [UInt32.ofNatLT_toNat, dite_eq_ite, left_eq_ite_iff, Nat.not_lt,
           Nat.reduceLeDiff, UInt32.left_eq_add]
         grind [UInt32.lt_iff_toNat_lt]
-      · grind
+      · rename_i hn
+        simp only [UInt32.lt_iff_toNat_lt, UInt32.toNat_ofNat] at h hn
+        omega
     · simp [coe_ordinal, -toNat_val]
       grind [UInt32.lt_iff_toNat_lt]
   | case2 =>
@@ -228,7 +230,9 @@ theorem succ?_eq {c : Char} : c.succ? = (c.ordinal.addNat? 1).map Char.ofOrdinal
     · simp only [coe_ordinal, Option.map_some, Option.some.injEq, Char.ext_iff, val_ofOrdinal,
         UInt32.ofNatLT_add, UInt32.reduceOfNatLT]
       split
-      · grind
+      · rename_i h1 h2 _ h3
+        simp only [← UInt32.toNat_inj, UInt32.lt_iff_toNat_lt, UInt32.toNat_ofNat] at h1 h2 h3
+        omega
       · rw [dif_neg]
         · simp only [← UInt32.toNat_inj, UInt32.toNat_add, UInt32.reduceToNat, Nat.reducePow,
             UInt32.toNat_ofNatLT, Nat.mod_add_mod]

--- a/src/Init/Data/Range/Polymorphic/Fin.lean
+++ b/src/Init/Data/Range/Polymorphic/Fin.lean
@@ -9,6 +9,7 @@ prelude
 public import Init.Data.Range.Polymorphic.Instances
 public import Init.Data.Fin.OverflowAware
 import Init.Grind
+import Init.ByCases
 import Init.Data.Fin.Lemmas
 import Init.Data.Int.OfNat
 import Init.Data.Nat.Internal.Linear
@@ -70,9 +71,24 @@ theorem rxcHasSize_eq :
     Rxc.HasSize.size (α := Fin n) = fun (lo hi : Fin n) => (hi + 1 - lo : Nat) := rfl
 
 instance : Rxc.LawfulHasSize (Fin n) where
-  size_eq_zero_of_not_le bound x := by grind
-  size_eq_one_of_succ?_eq_none lo hi := by grind
-  size_eq_succ_of_succ?_eq_some lo hi x := by grind
+  size_eq_zero_of_not_le bound x h := by
+    simp only [rxcHasSize_eq, Fin.le_def] at h ⊢
+    omega
+  size_eq_one_of_succ?_eq_none lo hi h h' := by
+    simp only [pRangeSucc?_eq, Fin.addNat?_eq_dif] at h'
+    simp only [rxcHasSize_eq, Fin.le_def] at h ⊢
+    by_cases hc : (lo : Nat) + 1 < n
+    · simp [hc] at h'
+    · have := hi.isLt
+      omega
+  size_eq_succ_of_succ?_eq_some lo hi x h h' := by
+    simp only [pRangeSucc?_eq, Fin.addNat?_eq_dif] at h'
+    by_cases hc : (lo : Nat) + 1 < n
+    · simp only [hc, dif_pos, Option.some.injEq] at h'
+      subst h'
+      simp only [rxcHasSize_eq, Fin.le_def] at h ⊢
+      omega
+    · simp [hc] at h'
 
 instance : Rxc.IsAlwaysFinite (Fin n) := inferInstance
 

--- a/src/Std/Http/Internal/Char.lean
+++ b/src/Std/Http/Internal/Char.lean
@@ -103,7 +103,20 @@ def quotedStringChar (c : Char) : Bool :=
 theorem quotedStringChar_lt_0x80 : quotedStringChar c → c < '\x80' := by
   simp [quotedStringChar, qdtext, quotedPairChar]
   split <;> simp only [true_or, Char.reduceLT, imp_self]
-  grind [→ Char.le_def.mp, Char.lt_def.mpr, vchar]
+  intro h
+  have hc : c ≤ '~' := by
+    rcases h with ((h | ⟨_, h⟩) | ⟨_, h⟩) | h | h
+    · nomatch h
+    · exact Char.le_trans h (by decide)
+    · exact h
+    · nomatch h
+    · simp only [vchar, ge_iff_le, Bool.decide_and, Bool.and_eq_true, decide_eq_true_eq] at h
+      exact h.2
+  have h80 : ('~' : Char) < '\x80' := by decide
+  rw [Char.lt_def, UInt32.lt_iff_toNat_lt]
+  rw [Char.le_def, UInt32.le_iff_toNat_le] at hc
+  rw [Char.lt_def, UInt32.lt_iff_toNat_lt] at h80
+  omega
 
 private theorem not_quotedStringChar_ofNat_aux :
     ∀ c : Nat, c < 128 → ¬(qdtext (Char.ofNat c)) ∧ ¬((Char.ofNat c = '\"') ∨ (Char.ofNat c = '\\')) →


### PR DESCRIPTION
This PR removes `grind` instances that creates bootstrapping issues when moving from `ToInt` to `[grind homo]` and `[grind homo_pred]`.
