### PR TITLE
feat: record `[grind homo]` source types

### DIFF
--- a/src/Lean/Elab/Tactic/Grind/Main.lean
+++ b/src/Lean/Elab/Tactic/Grind/Main.lean
@@ -146,6 +146,7 @@ def elabResetGrindAttrs : CommandElab := fun _ => liftTermElabM do
   modifyEnv fun env => Grind.grindExt.modifyState env fun ext => { ext with casesTypes := {}, inj := {}, ematch := {} }
   modifyEnv fun env => Grind.homoExt.modifyState env fun _ => {}
   modifyEnv fun env => Grind.homoPredExt.modifyState env fun _ => {}
+  modifyEnv fun env => Grind.homoSourceTypesExt.modifyState env fun _ => {}
 
 open Command Term in
 @[builtin_command_elab Lean.Parser.Command.initGrindNorm]

--- a/src/Lean/Meta/Tactic/Grind/Attr.lean
+++ b/src/Lean/Meta/Tactic/Grind/Attr.lean
@@ -188,7 +188,7 @@ private def mkGrindAttr (attrName : Name) (minIndexable : Bool) (showInfo : Bool
       | .homo =>
         unless attrName == `grind do
           throwError "homomorphism rules must be set using the default `[grind]` attribute"
-        Sym.Simp.addSymSimpDecl homoExt "grind homo" declName attrKind (validate := validateHomoTheorem)
+        addHomoAttr declName attrKind
       | .homoPred =>
         unless attrName == `grind do
           throwError "homomorphism predicates must be set using the default `[grind]` attribute"

--- a/src/Lean/Meta/Tactic/Grind/Homo.lean
+++ b/src/Lean/Meta/Tactic/Grind/Homo.lean
@@ -6,6 +6,8 @@ Authors: Leonardo de Moura
 module
 prelude
 public import Lean.Meta.Sym.Simp.Theorems
+import Lean.Meta.Sym.Simp.Attr
+import Lean.Meta.DiscrTree.Util
 import Lean.Meta.AppBuilder
 public section
 namespace Lean.Meta.Grind
@@ -16,6 +18,22 @@ builtin_initialize homoExt : Sym.Simp.SymSimpExtension ← Sym.Simp.mkSymSimpExt
 /-- Returns the homomorphism rules tagged with the `[grind homo]` attribute. -/
 def getHomoTheorems : CoreM Sym.Simp.Theorems :=
   homoExt.getTheorems
+
+/--
+Extension collecting the homomorphism *source types*: the head constants `F` of the
+types `τ = F …` for which a `[grind homo]` rule translates `Eq τ`. The engine marks
+terms of these types as solver terms so that the E-graph reports their equalities and
+disequalities (see `SolverExtension.markTerm`).
+-/
+builtin_initialize homoSourceTypesExt : SimpleScopedEnvExtension Name NameSet ←
+  registerSimpleScopedEnvExtension {
+    initial  := {}
+    addEntry := fun s n => s.insert n
+  }
+
+/-- Returns the head constants of the homomorphism source types. -/
+def getHomoSourceTypes : CoreM NameSet :=
+  return homoSourceTypesExt.getState (← getEnv)
 
 /--
 Ensures a `[grind homo]` theorem can be applied by `Sym.simp` without a discharger.
@@ -65,6 +83,37 @@ def validateHomoTheorem (declName : Name) : MetaM Unit := do
         else
           throwError "invalid `[grind homo]` theorem, parameter `{x}` of \
             `{.ofConstName declName}` is not determined by the left-hand side of the rule"
+
+/--
+If `declName` is an `=`-injection rule — a rule whose left-hand side is an equality
+`Eq τ _ _` — checks that its source type `τ` is headed by a constant `F` and returns
+`F`. The engine marks terms as solver terms by the head constant of their type; a rule
+over a variable type (e.g. a class-generic injection `(a = b) ↔ toI a = toI b`) has no
+head constant, and would silently never fire on asserted equalities.
+-/
+private def checkEqInjection? (declName : Name) : MetaM (Option Name) := do
+  let info ← getConstInfo declName
+  forallTelescope info.type fun _ concl => do
+    let lhs := match_expr concl with
+      | Eq _ lhs _ => lhs
+      | Iff lhs _ => lhs
+      | _ => concl
+    let_expr Eq τ _ _ := lhs | return none
+    let .const F _ := τ.getAppFn
+      | throwError "invalid `[grind homo]` theorem, the source type of the `=`-injection rule \
+          `{.ofConstName declName}` is not headed by a constant{indentExpr τ}\nhomomorphism rules \
+          translate concrete types; generic injections cannot be tracked by the E-graph"
+    return some F
+
+/--
+Validates and registers a `[grind homo]` theorem, recording the source type of
+`=`-injection rules. See `validateHomoTheorem`.
+-/
+def addHomoAttr (declName : Name) (attrKind : AttributeKind) : MetaM Unit := do
+  Sym.Simp.addSymSimpDecl homoExt "grind homo" declName attrKind (validate := fun declName => do
+    validateHomoTheorem declName
+    if let some F ← checkEqInjection? declName then
+      homoSourceTypesExt.add F attrKind)
 
 /-- A theorem tagged with the `[grind homo_pred]` attribute. -/
 structure HomoPredTheorem where

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,3 +1,4 @@
+// update me!
 #include "util/options.h"
 
 // Should we test stage 2 and run update-stage0 on PR merge? NO

--- a/tests/elab/grind_homo_attr.lean
+++ b/tests/elab/grind_homo_attr.lean
@@ -102,9 +102,33 @@ error: invalid `[grind homo]` theorem, parameter `y` of `wu_rhs` is not determin
 #guard_msgs in
 attribute [grind homo] wu_rhs
 
-/-! `reset_grind_attrs%` clears the homo extension. -/
+/-! Registering the `=`-injection rule `wu_eq` records `W` as a homomorphism source
+type. Generic injections over a variable type are rejected: the engine tracks source
+terms by the head constant of their type. -/
+
+/-- info: true -/
+#guard_msgs in
+run_meta logInfo m!"{(← getHomoSourceTypes).contains ``W}"
+
+axiom toI : ∀ {α : Type}, α → Int
+
+axiom toI_eq {α : Type} (a b : α) : (a = b) ↔ (toI a = toI b)
+
+/--
+error: invalid `[grind homo]` theorem, the source type of the `=`-injection rule `toI_eq` is not headed by a constant
+  α
+homomorphism rules translate concrete types; generic injections cannot be tracked by the E-graph
+-/
+#guard_msgs in
+attribute [grind homo] toI_eq
+
+/-! `reset_grind_attrs%` clears the homo extension and the recorded source types. -/
 
 reset_grind_attrs%
 
 #guard_msgs in
 run_meta checkMatches
+
+/-- info: false -/
+#guard_msgs in
+run_meta logInfo m!"{(← getHomoSourceTypes).contains ``W}"


### PR DESCRIPTION
This PR records the homomorphism source types of a `[grind homo]` theorem set: when an `=`-injection rule (a rule translating `Eq τ`) is registered, the head constant of `τ` is added to a new environment extension, and rules whose source type is not headed by a constant are rejected. The source types identify the terms the `grind` homomorphism engine must track in the E-graph. The `reset_grind_attrs%` command clears the new extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)