### PR TITLE
feat: lemmas about `Nat.nextPowerOfTwo`

### DIFF
--- a/src/Init/Data/Nat/Power2.lean
+++ b/src/Init/Data/Nat/Power2.lean
@@ -8,3 +8,4 @@ module
 prelude
 public import Init.Data.Nat.Power2.Basic
 public import Init.Data.Nat.Power2.Lemmas
+public import Init.Data.Nat.Power2.Bitwise

--- a/src/Init/Data/Nat/Power2/Basic.lean
+++ b/src/Init/Data/Nat/Power2/Basic.lean
@@ -46,6 +46,7 @@ A natural number `n` is a power of two if there exists some `k : Nat` such that 
 -/
 def isPowerOfTwo (n : Nat) := ∃ k, n = 2 ^ k
 
+@[simp]
 theorem isPowerOfTwo_one : isPowerOfTwo 1 :=
   ⟨0, by decide⟩
 
@@ -58,17 +59,5 @@ theorem pos_of_isPowerOfTwo (h : isPowerOfTwo n) : n > 0 := by
   rw [h]
   apply Nat.pow_pos
   decide
-
-theorem isPowerOfTwo_nextPowerOfTwo (n : Nat) : n.nextPowerOfTwo.isPowerOfTwo := by
-  apply isPowerOfTwo_go
-  apply isPowerOfTwo_one
-where
-  isPowerOfTwo_go (power : Nat) (h₁ : power > 0) (h₂ : power.isPowerOfTwo) : (nextPowerOfTwo.go n power h₁).isPowerOfTwo := by
-    unfold nextPowerOfTwo.go
-    split
-    . exact isPowerOfTwo_go (power*2) (Nat.mul_pos h₁ (by decide)) (Nat.isPowerOfTwo_mul_two_of_isPowerOfTwo h₂)
-    . assumption
-  termination_by n - power
-  decreasing_by simp_wf; apply nextPowerOfTwo_dec <;> assumption
 
 end Nat

--- a/src/Init/Data/Nat/Power2/Bitwise.lean
+++ b/src/Init/Data/Nat/Power2/Bitwise.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 George Rennie. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: George Rennie
+-/
+module
+
+prelude
+import all Init.Data.Nat.Power2.Basic
+public import Init.Data.Nat.Log2
+public import Init.Data.Nat.Power2.Basic
+public import Init.PropLemmas
+import Init.ByCases
+import Init.Data.Int.Pow
+import Init.Data.Nat.Bitwise.Lemmas
+import Init.Data.Nat.Lemmas
+import Init.Omega
+import Init.RCases
+import Init.Data.Nat.Power2.Lemmas
+
+public section
+
+/-!
+# Further lemmas about `Nat.isPowerOfTwo`, with the convenience of having bitwise lemmas available.
+-/
+
+namespace Nat
+
+theorem and_sub_one_testBit_log2 {n : Nat} (h : n ≠ 0) (hpow2 : ¬n.isPowerOfTwo) :
+    (n &&& (n - 1)).testBit n.log2 := by
+  rw [testBit_and, Bool.and_eq_true]
+  constructor
+  · exact testBit_log2 (by omega)
+  · by_cases n = 2^n.log2
+    · rw [isPowerOfTwo, not_exists] at hpow2
+      have := hpow2 n.log2
+      trivial
+    · have := log2_eq_iff (n := n) (k := n.log2) (by omega)
+      have : (n - 1).log2 = n.log2 := by rw [log2_eq_iff] <;> omega
+      rw [←this]
+      exact testBit_log2 (by omega)
+
+theorem and_sub_one_eq_zero_iff_isPowerOfTwo {n : Nat} (h : n ≠ 0) :
+    (n &&& (n - 1)) = 0 ↔ n.isPowerOfTwo := by
+  constructor
+  · intro hbitwise
+    false_or_by_contra
+    rename_i hpow2
+    have := and_sub_one_testBit_log2 h hpow2
+    rwa [hbitwise, zero_testBit n.log2, Bool.false_eq_true] at this
+  · intro hpow2
+    rcases hpow2 with ⟨_, hpow2⟩
+    rw [hpow2, and_two_pow_sub_one_eq_mod, mod_self]
+
+theorem ne_zero_and_sub_one_eq_zero_iff_isPowerOfTwo {n : Nat} :
+    ((n ≠ 0) ∧ (n &&& (n - 1)) = 0) ↔ n.isPowerOfTwo := by
+  match h : n with
+  | 0 => simp [not_isPowerOfTwo_zero]
+  | n + 1 => simp; exact and_sub_one_eq_zero_iff_isPowerOfTwo (by omega)
+
+@[inline]
+instance {n : Nat} : Decidable n.isPowerOfTwo :=
+  decidable_of_iff _ ne_zero_and_sub_one_eq_zero_iff_isPowerOfTwo
+
+end Nat

--- a/src/Init/Data/Nat/Power2/Lemmas.lean
+++ b/src/Init/Data/Nat/Power2/Lemmas.lean
@@ -1,70 +1,78 @@
 /-
-Copyright (c) George Rennie. All rights reserved.
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: George Rennie
+Authors: Julia M. Himmel, Adomas Baliuka
 -/
 module
 
 prelude
-import all Init.Data.Nat.Power2.Basic
-public import Init.Data.Nat.Log2
 public import Init.Data.Nat.Power2.Basic
-public import Init.PropLemmas
+import all Init.Data.Nat.Power2.Basic
 import Init.ByCases
-import Init.Data.Int.Pow
-import Init.Data.Nat.Bitwise.Lemmas
 import Init.Data.Nat.Lemmas
 import Init.Omega
 import Init.RCases
 
 public section
 
-/-!
-# Further lemmas about `Nat.isPowerOfTwo`, with the convenience of having bitwise lemmas available.
--/
-
 namespace Nat
 
+@[simp]
 theorem not_isPowerOfTwo_zero : ¬isPowerOfTwo 0 := by
   rw [isPowerOfTwo, not_exists]
   intro x
   have := one_le_pow x 2 (by decide)
   omega
 
-theorem and_sub_one_testBit_log2 {n : Nat} (h : n ≠ 0) (hpow2 : ¬n.isPowerOfTwo) :
-    (n &&& (n - 1)).testBit n.log2 := by
-  rw [testBit_and, Bool.and_eq_true]
-  constructor
-  · exact testBit_log2 (by omega)
-  · by_cases n = 2^n.log2
-    · rw [isPowerOfTwo, not_exists] at hpow2
-      have := hpow2 n.log2
-      trivial
-    · have := log2_eq_iff (n := n) (k := n.log2) (by omega)
-      have : (n - 1).log2 = n.log2 := by rw [log2_eq_iff] <;> omega
-      rw [←this]
-      exact testBit_log2 (by omega)
+private theorem ne_zero_of_isPowerOfTwo {n : Nat} (h : n.isPowerOfTwo) : n ≠ 0 := by
+  rintro rfl
+  simp at h
 
-theorem and_sub_one_eq_zero_iff_isPowerOfTwo {n : Nat} (h : n ≠ 0) :
-    (n &&& (n - 1)) = 0 ↔ n.isPowerOfTwo := by
-  constructor
-  · intro hbitwise
-    false_or_by_contra
-    rename_i hpow2
-    have := and_sub_one_testBit_log2 h hpow2
-    rwa [hbitwise, zero_testBit n.log2, Bool.false_eq_true] at this
-  · intro hpow2
-    rcases hpow2 with ⟨_, hpow2⟩
-    rw [hpow2, and_two_pow_sub_one_eq_mod, mod_self]
+private theorem le_of_isPowerOfTwo_of_lt_two_mul {k n m : Nat} (hn : n.isPowerOfTwo)
+    (hm : m.isPowerOfTwo) (hn₂ : n < 2 * k) (hm₁ : k ≤ m) : n ≤ m := by
+  obtain ⟨n, rfl⟩ := hn
+  obtain ⟨m, rfl⟩ := hm
+  rw [Nat.pow_le_pow_iff_right (by omega), Nat.le_iff_lt_add_one,
+    ← Nat.pow_lt_pow_iff_right (by decide : 1 < 2), Nat.pow_add_one']
+  exact Nat.lt_of_lt_of_le hn₂ (Nat.mul_le_mul_left _ hm₁)
 
-theorem ne_zero_and_sub_one_eq_zero_iff_isPowerOfTwo {n : Nat} :
-    ((n ≠ 0) ∧ (n &&& (n - 1)) = 0) ↔ n.isPowerOfTwo := by
-  match h : n with
-  | 0 => simp [not_isPowerOfTwo_zero]
-  | n + 1 => simp; exact and_sub_one_eq_zero_iff_isPowerOfTwo (by omega)
+theorem nextPowerOfTwo_eq_iff {n m : Nat} :
+    n.nextPowerOfTwo = m ↔ n ≤ m ∧ m.isPowerOfTwo ∧ ∀ k, n ≤ k → k.isPowerOfTwo → m ≤ k := by
+  rw [nextPowerOfTwo]
+  suffices ∀ l h, l.isPowerOfTwo → l < 2 * n →
+      (nextPowerOfTwo.go n l h = m ↔
+        n ≤ m ∧ m.isPowerOfTwo ∧ ∀ k, n ≤ k → k.isPowerOfTwo → m ≤ k) by
+    obtain (rfl|hn) := Nat.eq_zero_or_pos n
+    · simp only [nextPowerOfTwo.go, not_lt_zero, ↓reduceIte, zero_le, forall_const, true_and]
+      refine ⟨fun h => ?_, fun ⟨h₁, h₂⟩ => ?_⟩
+      · simp +contextual [← h, ← Nat.not_lt, ne_zero_of_isPowerOfTwo]
+      · exact Nat.le_antisymm (by simp [← Nat.not_lt, ne_zero_of_isPowerOfTwo, h₁]) (h₂ _ (by simp))
+    · exact this _ _ (by simp) (by omega)
+  intro l hl₁ hl₂ hln
+  fun_induction nextPowerOfTwo.go with
+  | case1 p hp₁ hp₂ ih =>
+    apply ih
+    · exact isPowerOfTwo_mul_two_of_isPowerOfTwo hl₂
+    · rw [Nat.mul_comm]
+      exact Nat.mul_lt_mul_of_pos_left hp₂ (by omega)
+  | case2 p hp₁ hp₂ =>
+    refine ⟨?_, fun ⟨h₁, h₂, h₃⟩ => ?_⟩
+    · rintro rfl
+      exact ⟨by omega, hl₂, fun k hk₁ hk₂ => le_of_isPowerOfTwo_of_lt_two_mul hl₂ hk₂ hln hk₁⟩
+    · exact Nat.le_antisymm (le_of_isPowerOfTwo_of_lt_two_mul hl₂ h₂ hln h₁) (h₃ _ (by omega) hl₂)
 
-@[inline]
-instance {n : Nat} : Decidable n.isPowerOfTwo :=
-  decidable_of_iff _ ne_zero_and_sub_one_eq_zero_iff_isPowerOfTwo
+@[simp]
+theorem le_nextPowerOfTwo (n : Nat) : n ≤ n.nextPowerOfTwo :=
+  (nextPowerOfTwo_eq_iff.1 rfl).1
+
+theorem nextPowerOfTwo_le {n m : Nat} (hn : n ≤ m) (hm : m.isPowerOfTwo) : n.nextPowerOfTwo ≤ m :=
+  (nextPowerOfTwo_eq_iff.1 rfl).2.2 _ hn hm
+
+theorem nextPowerOfTwo_eq_self {n : Nat} (h : n.isPowerOfTwo) : n.nextPowerOfTwo = n :=
+ nextPowerOfTwo_eq_iff.2 (by simp +contextual [h])
+
+@[simp]
+theorem isPowerOfTwo_nextPowerOfTwo (n : Nat) : n.nextPowerOfTwo.isPowerOfTwo :=
+  (nextPowerOfTwo_eq_iff.1 rfl).2.1
 
 end Nat

--- a/src/Std/Data/DHashMap/Internal/Defs.lean
+++ b/src/Std/Data/DHashMap/Internal/Defs.lean
@@ -11,6 +11,7 @@ public import Std.Data.DHashMap.RawDef
 public import Std.Data.Internal.List.Defs
 public import Std.Data.DHashMap.Internal.Index
 public import Init.Data.Nat.Power2.Basic
+import Init.Data.Nat.Power2.Lemmas
 import Init.Data.List.Impl
 import Init.Omega
 


### PR DESCRIPTION
This PR adds somme lemmas about `Nat.nextPowerOfTwo`.

These lemmas were suggested by Adomas Baliuka at [#lean4 > Adding lemmas for &#96;Nat.nextPowerOfTwo&#96;](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Adding.20lemmas.20for.20.60Nat.2EnextPowerOfTwo.60/with/611309278).

The diff is a bit chaotic because we're moving the material that used to live in `Lemmas.lean` to `Bitwise.lean` and use `Lemmas.lean` as a home for the new results.