### PR TITLE
feat: optionally let Sym.dsimp rewrite in instances

### DIFF
--- a/src/Lean/Meta/Sym/DSimp/App.lean
+++ b/src/Lean/Meta/Sym/DSimp/App.lean
@@ -26,6 +26,7 @@ In some cases, users may want to reduce proofs to eliminate dependencies. Users 
 accomplish this by rewriting their own simproc.
 - **Skip instance arguments.** Instances are not usually meaningful
   to simplify structurally. Moreover, we would be producing non-standard instances.
+  This behavior may be overriden by the dsimp configuration.
 
 Both classes are read from `ProofInstInfo` (per-`declName`, cached in `SymM`). When the
 head is not a `.const` (e.g. an `.fvar`-headed application), we have no signature info
@@ -50,12 +51,13 @@ where
     if i = 0 then return .rfl
     let .app f a := e | unreachable!
     let fr ← go argsInfo? (i - 1) f
+    let simpInInstances := (← getConfig).instances
     let skip : Bool :=
       match argsInfo? with
       | some ai =>
         if h : i - 1 < ai.size then
           let { isProof, isInstance } := ai[i - 1]
-          isProof || isInstance
+          isProof || (isInstance && !simpInInstances)
         else
           false  -- over-applied: no info, rewrite
       | none => false

--- a/src/Lean/Meta/Sym/DSimp/DSimpM.lean
+++ b/src/Lean/Meta/Sym/DSimp/DSimpM.lean
@@ -22,6 +22,13 @@ to return the simplified expression.
 structure Config where
   /-- Maximum number of steps that can be performed by the simplifier. -/
   maxSteps : Nat := 100_000
+  /--
+  If `instances` is `true`, `dsimp` will visit instance arguments.
+  This is set to `false` by default as simplifying in instances is usually not meaningful and we
+  want to avoid producing non-standard instances. However, in certain situations simplifying in
+  instances can aid with making more terms syntactically equal.
+  -/
+  instances : Bool := false
   deriving Inhabited
 
 /--


### PR DESCRIPTION
This PR adds an option for `Sym.dsimp` to rewrite in instances. This is usually not desirable as it can lead to non-standard instances. However, we might for example want to rewrite ground terms in instances to make more terms syntactically equal.