### PR TITLE
feat: more BitVec operations for `Sym.(D)Simp.evalGround`

### DIFF
--- a/src/Init/Sym/Lemmas.lean
+++ b/src/Init/Sym/Lemmas.lean
@@ -132,6 +132,7 @@ theorem BitVec.le_eq_false (a b : BitVec n) (h : decide (a ≤ b) = false) : (a 
 theorem String.le_eq_false (a b : String) (h : decide (a ≤ b) = false) : (a ≤ b) = False := by simp_all
 theorem Char.le_eq_false (a b : Char) (h : decide (a ≤ b) = false) : (a ≤ b) = False := by simp_all
 
+theorem Bool.eq_eq_true (a b : Bool) (h : decide (a = b) = true) : (a = b) = True := by simp_all
 theorem Nat.eq_eq_true (a b : Nat) (h : decide (a = b) = true) : (a = b) = True := by simp_all
 theorem Int.eq_eq_true (a b : Int) (h : decide (a = b) = true) : (a = b) = True := by simp_all
 theorem Rat.eq_eq_true (a b : Rat) (h : decide (a = b) = true) : (a = b) = True := by simp_all
@@ -148,6 +149,7 @@ theorem BitVec.eq_eq_true (a b : BitVec n) (h : decide (a = b) = true) : (a = b)
 theorem String.eq_eq_true (a b : String) (h : decide (a = b) = true) : (a = b) = True := by simp_all
 theorem Char.eq_eq_true (a b : Char) (h : decide (a = b) = true) : (a = b) = True := by simp_all
 
+theorem Bool.eq_eq_false (a b : Bool) (h : decide (a = b) = false) : (a = b) = False := by simp_all
 theorem Nat.eq_eq_false (a b : Nat) (h : decide (a = b) = false) : (a = b) = False := by simp_all
 theorem Int.eq_eq_false (a b : Int) (h : decide (a = b) = false) : (a = b) = False := by simp_all
 theorem Rat.eq_eq_false (a b : Rat) (h : decide (a = b) = false) : (a = b) = False := by simp_all

--- a/src/Lean/Meta/Sym/DSimp/EvalGround.lean
+++ b/src/Lean/Meta/Sym/DSimp/EvalGround.lean
@@ -7,6 +7,7 @@ module
 prelude
 public import Lean.Meta.Sym.DSimp.DSimpM
 import Lean.Meta.Sym.LitValues
+import Lean.Meta.Offset
 namespace Lean.Meta.Sym.DSimp
 
 /-!
@@ -27,6 +28,7 @@ abbrev evalUnary [ToExpr α] (toValue? : Expr → Option α) (op : α → α) (a
   let e ← share <| toExpr (op a)
   return .step e (done := true)
 
+abbrev evalUnaryBool : (op : Bool → Bool) → (a : Expr) → DSimpM Result := evalUnary getBoolValue?
 abbrev evalUnaryNat : (op : Nat → Nat) → (a : Expr) → DSimpM Result := evalUnary getNatValue?
 abbrev evalUnaryInt : (op : Int → Int) → (a : Expr) → DSimpM Result := evalUnary getIntValue?
 abbrev evalUnaryRat : (op : Rat → Rat) → (a : Expr) → DSimpM Result := evalUnary getRatValue?
@@ -55,6 +57,7 @@ abbrev evalBin [ToExpr α] (toValue? : Expr → Option α) (op : α → α → �
   let e ← share <| toExpr (op a b)
   return .step e (done := true)
 
+abbrev evalBinBool : (op : Bool → Bool → Bool) → (a b : Expr) → DSimpM Result := evalBin getBoolValue?
 abbrev evalBinNat : (op : Nat → Nat → Nat) → (a b : Expr) → DSimpM Result := evalBin getNatValue?
 abbrev evalBinInt : (op : Int → Int → Int) → (a b : Expr) → DSimpM Result := evalBin getIntValue?
 abbrev evalBinRat : (op : Rat → Rat → Rat) → (a b : Expr) → DSimpM Result := evalBin getRatValue?
@@ -300,6 +303,7 @@ abbrev evalBinBoolPred (toValue? : Expr → Option α) (op : α → α → Bool)
   let e ← share (toExpr r)
   return .step e (done := true)
 
+abbrev evalBinBoolPredBool : (op : Bool → Bool → Bool) → (a b : Expr) → DSimpM Result := evalBinBoolPred getBoolValue?
 abbrev evalBinBoolPredNat : (op : Nat → Nat → Bool) → (a b : Expr) → DSimpM Result := evalBinBoolPred getNatValue?
 abbrev evalBinBoolPredInt : (op : Int → Int → Bool) → (a b : Expr) → DSimpM Result := evalBinBoolPred getIntValue?
 abbrev evalBinBoolPredRat : (op : Rat → Rat → Bool) → (a b : Expr) → DSimpM Result := evalBinBoolPred getRatValue?
@@ -335,6 +339,7 @@ abbrev evalBinBoolPredBitVec (op : {n : Nat} → BitVec n → BitVec n → Bool)
 macro "declare_eval_bin_bool_pred" id:ident op:term : command =>
   `(def $id:ident (α : Expr) (a b : Expr) : DSimpM Result :=
   match_expr α with
+  | Bool => evalBinBoolPredBool $op a b
   | Nat => evalBinBoolPredNat $op a b
   | Int => evalBinBoolPredInt $op a b
   | Rat => evalBinBoolPredRat $op a b
@@ -353,6 +358,134 @@ macro "declare_eval_bin_bool_pred" id:ident op:term : command =>
 
 declare_eval_bin_bool_pred evalBEq (· == ·)
 declare_eval_bin_bool_pred evalBNe (· != ·)
+
+abbrev evalBitVecNatBitVec (op : {n : Nat} → BitVec n → Nat → BitVec n) (a i : Expr) : DSimpM Result := do
+  let some a := getBitVecValue? a | return .rfl
+  let some i := getNatValue? i | return .rfl
+  let e ← share <| toExpr <| op a.val i
+  return .step e (done := true)
+
+abbrev evalBitVecNatBool (op : {n : Nat} → BitVec n → Nat → Bool) (a i : Expr) : DSimpM Result := do
+  let some a := getBitVecValue? a | return .rfl
+  let some i := getNatValue? i | return .rfl
+  let e ← share <| toExpr <| op a.val i
+  return .step e (done := true)
+
+abbrev evalBitVecExtend (op : {n : Nat} → (v : Nat) → BitVec n → BitVec v) (v a : Expr) : DSimpM Result := do
+  let some v := getNatValue? v | return .rfl
+  let some a := getBitVecValue? a | return .rfl
+  let e ← share <| toExpr <| op v a.val
+  return .step e (done := true)
+
+def evalBitVecAppend (a b : Expr) : DSimpM Result := do
+  let some a := getBitVecValue? a | return .rfl
+  let some b := getBitVecValue? b | return .rfl
+  let e ← share <| toExpr (a.val ++ b.val)
+  return .step e (done := true)
+
+def evalBitVecCast (m a : Expr) : DSimpM Result := do
+  let some m := getNatValue? m | return .rfl
+  let some a := getBitVecValue? a | return .rfl
+  let e ← share <| toExpr <| BitVec.ofNat m a.val.toNat
+  return .step e (done := true)
+
+def evalBitVecShiftLeftZeroExtend (a m : Expr) : DSimpM Result := do
+  let some a := getBitVecValue? a | return .rfl
+  let some m := getNatValue? m | return .rfl
+  let e ← share <| toExpr <|a.val.shiftLeftZeroExtend m
+  return .step e (done := true)
+
+def evalBitVecExtractLsb' (start len a : Expr) : DSimpM Result := do
+  let some start := getNatValue? start | return .rfl
+  let some len := getNatValue? len | return .rfl
+  let some a := getBitVecValue? a | return .rfl
+  let e ← share <| toExpr <| a.val.extractLsb' start len
+  return .step e (done := true)
+
+def evalBitVecReplicate (i a : Expr) : DSimpM Result := do
+  let some i := getNatValue? i | return .rfl
+  let some a := getBitVecValue? a | return .rfl
+  let e ← share <| toExpr <| a.val.replicate i
+  return .step e (done := true)
+
+def evalBitVecAllOnes (n : Expr) : DSimpM Result := do
+  let some n := getNatValue? n | return .rfl
+  let e ← share <| toExpr <| BitVec.allOnes n
+  return .step e (done := true)
+
+def evalBitVecToNat (a : Expr) : DSimpM Result := do
+  let some a := getBitVecValue? a | return .rfl
+  let e ← share <| toExpr a.val.toNat
+  return .step e (done := true)
+
+def evalBitVecToInt (a : Expr) : DSimpM Result := do
+  let some a := getBitVecValue? a | return .rfl
+  let e ← share <| toExpr a.val.toInt
+  return .step e (done := true)
+
+def evalBitVecOfInt (n i : Expr) : DSimpM Result := do
+  let some n := getNatValue? n | return .rfl
+  let some i := getIntValue? i | return .rfl
+  let e ← share <| toExpr <| BitVec.ofInt n i
+  return .step e (done := true)
+
+def evalBitVecToFin (a : Expr) : DSimpM Result := do
+  let some a := getBitVecValue? a | return .rfl
+  let e ← share <| toExpr a.val.toFin
+  return .step e (done := true)
+
+def evalBitVecOfFin (n a : Expr) : DSimpM Result := do
+  let some n := getNatValue? n | return .rfl
+  let some a := getFinValue? a | return .rfl
+  let e ← share <| toExpr <| BitVec.ofNat n a.val.val
+  return .step e (done := true)
+
+def evalBitVecOfNat (n a : Expr) : DSimpM Result := do
+  let some a := getNatValue? a | return .rfl
+  if (getNatValue? n).isSome then return .rfl -- already in normal form
+  let some n ← evalNat n |>.run | return .rfl
+  let e ← share <| toExpr (BitVec.ofNat n a)
+  return .step e (done := true)
+
+def evalInt8ToBitVec (a : Expr) : DSimpM Result := do
+  let some v := getInt8Value? a | return .rfl
+  let e ← share <| toExpr v.toBitVec
+  return .step e (done := true)
+
+def evalInt16ToBitVec (a : Expr) : DSimpM Result := do
+  let some v := getInt16Value? a | return .rfl
+  let e ← share <| toExpr v.toBitVec
+  return .step e (done := true)
+
+def evalInt32ToBitVec (a : Expr) : DSimpM Result := do
+  let some v := getInt32Value? a | return .rfl
+  let e ← share <| toExpr v.toBitVec
+  return .step e (done := true)
+
+def evalInt64ToBitVec (a : Expr) : DSimpM Result := do
+  let some v := getInt64Value? a | return .rfl
+  let e ← share <| toExpr v.toBitVec
+  return .step e (done := true)
+
+def evalUInt8ToBitVec (a : Expr) : DSimpM Result := do
+  let some v := getUInt8Value? a | return .rfl
+  let e ← share <| toExpr v.toBitVec
+  return .step e (done := true)
+
+def evalUInt16ToBitVec (a : Expr) : DSimpM Result := do
+  let some v := getUInt16Value? a | return .rfl
+  let e ← share <| toExpr v.toBitVec
+  return .step e (done := true)
+
+def evalUInt32ToBitVec (a : Expr) : DSimpM Result := do
+  let some v := getUInt32Value? a | return .rfl
+  let e ← share <| toExpr v.toBitVec
+  return .step e (done := true)
+
+def evalUInt64ToBitVec (a : Expr) : DSimpM Result := do
+  let some v := getUInt64Value? a | return .rfl
+  let e ← share <| toExpr v.toBitVec
+  return .step e (done := true)
 
 public structure EvalStepConfig where
   maxExponent := 255
@@ -395,6 +528,63 @@ public def evalGround (config : EvalStepConfig := {}) : DSimproc := fun e =>
   | Int.bmod a b => evalIntBMod a b
   | BEq.beq α _ a b => evalBEq α a b
   | bne α _ a b => evalBNe α a b
+  | Bool.and x y => evalBinBool Bool.and x y
+  | Bool.or x y => evalBinBool Bool.or x y
+  | Bool.not x => evalUnaryBool Bool.not x
+  | HAppend.hAppend α _ _ _ a b =>
+    match_expr α with
+    | BitVec _ => evalBitVecAppend a b
+    | _ => return .rfl
+  | getElem α _ _ _ _ a i _ =>
+    match_expr α with
+    | BitVec _ => evalBitVecNatBool BitVec.getLsbD a i
+    | _ => return .rfl
+  | BitVec.append _ _ a b => evalBitVecAppend a b
+  | BitVec.shiftLeft _ a i => evalBitVecNatBitVec BitVec.shiftLeft a i
+  | BitVec.ushiftRight _ a i => evalBitVecNatBitVec BitVec.ushiftRight a i
+  | BitVec.sshiftRight _ a i => evalBitVecNatBitVec BitVec.sshiftRight a i
+  | BitVec.sshiftRight' _ _ a b => evalBinBitVec' BitVec.sshiftRight' a b
+  | BitVec.rotateLeft _ a i => evalBitVecNatBitVec BitVec.rotateLeft a i
+  | BitVec.rotateRight _ a i => evalBitVecNatBitVec BitVec.rotateRight a i
+  | BitVec.udiv _ a b => evalBinBitVec' BitVec.udiv a b
+  | BitVec.umod _ a b => evalBinBitVec' BitVec.umod a b
+  | BitVec.sdiv _ a b => evalBinBitVec' BitVec.sdiv a b
+  | BitVec.smod _ a b => evalBinBitVec' BitVec.smod a b
+  | BitVec.srem _ a b => evalBinBitVec' BitVec.srem a b
+  | BitVec.smtUDiv _ a b => evalBinBitVec' BitVec.smtUDiv a b
+  | BitVec.smtSDiv _ a b => evalBinBitVec' BitVec.smtSDiv a b
+  | BitVec.abs _ a => evalUnaryBitVec' BitVec.abs a
+  | BitVec.clz _ a => evalUnaryBitVec' BitVec.clz a
+  | BitVec.cpop _ a => evalUnaryBitVec' BitVec.cpop a
+  | BitVec.ult _ a b => evalBinBoolPredBitVec BitVec.ult a b
+  | BitVec.ule _ a b => evalBinBoolPredBitVec BitVec.ule a b
+  | BitVec.slt _ a b => evalBinBoolPredBitVec BitVec.slt a b
+  | BitVec.sle _ a b => evalBinBoolPredBitVec BitVec.sle a b
+  | BitVec.getLsbD _ a i => evalBitVecNatBool BitVec.getLsbD a i
+  | BitVec.getMsbD _ a i => evalBitVecNatBool BitVec.getMsbD a i
+  | BitVec.setWidth _ v a => evalBitVecExtend BitVec.setWidth v a
+  | BitVec.zeroExtend _ v a => evalBitVecExtend BitVec.zeroExtend v a
+  | BitVec.signExtend _ v a => evalBitVecExtend BitVec.signExtend v a
+  | BitVec.setWidth' _ w _ a => evalBitVecExtend BitVec.setWidth w a
+  | BitVec.cast _ m _ a => evalBitVecCast m a
+  | BitVec.shiftLeftZeroExtend _ a m => evalBitVecShiftLeftZeroExtend a m
+  | BitVec.extractLsb' _ start len a => evalBitVecExtractLsb' start len a
+  | BitVec.replicate _ i a => evalBitVecReplicate i a
+  | BitVec.allOnes n => evalBitVecAllOnes n
+  | BitVec.toNat _ a => evalBitVecToNat a
+  | BitVec.ofNat n a => evalBitVecOfNat n a
+  | BitVec.toInt _ a => evalBitVecToInt a
+  | BitVec.ofInt n i => evalBitVecOfInt n i
+  | BitVec.toFin _ a => evalBitVecToFin a
+  | BitVec.ofFin n a => evalBitVecOfFin n a
+  | Int8.toBitVec a => evalInt8ToBitVec a
+  | Int16.toBitVec a => evalInt16ToBitVec a
+  | Int32.toBitVec a => evalInt32ToBitVec a
+  | Int64.toBitVec a => evalInt64ToBitVec a
+  | UInt8.toBitVec a => evalUInt8ToBitVec a
+  | UInt16.toBitVec a => evalUInt16ToBitVec a
+  | UInt32.toBitVec a => evalUInt32ToBitVec a
+  | UInt64.toBitVec a => evalUInt64ToBitVec a
   | _  => return .rfl
 
 end Lean.Meta.Sym.DSimp

--- a/src/Lean/Meta/Sym/LitValues.lean
+++ b/src/Lean/Meta/Sym/LitValues.lean
@@ -83,4 +83,10 @@ def getStringValue? (e : Expr) : Option String :=
   | .lit (.strVal s) => some s
   | _ => none
 
+def getBoolValue? (e : Expr) : OptionT Id Bool := do
+  match e with
+  | .const ``Bool.true [] => return Bool.true
+  | .const ``Bool.false [] => return Bool.false
+  | _ => failure
+
 end Lean.Meta.Sym

--- a/src/Lean/Meta/Sym/Simp/EvalGround.lean
+++ b/src/Lean/Meta/Sym/Simp/EvalGround.lean
@@ -74,6 +74,7 @@ abbrev evalUnary [ToExpr α] (toValue? : Expr → Option α) (op : α → α) (a
   let e ← share <| toExpr (op a)
   return .step e (mkApp2 (mkConst ``Eq.refl [1]) (ToExpr.toTypeExpr (α := α)) e) (done := true)
 
+abbrev evalUnaryBool : (op : Bool → Bool) → (a : Expr) → SimpM Result := evalUnary getBoolValue?
 abbrev evalUnaryNat : (op : Nat → Nat) → (a : Expr) → SimpM Result := evalUnary getNatValue?
 abbrev evalUnaryInt : (op : Int → Int) → (a : Expr) → SimpM Result := evalUnary getIntValue?
 abbrev evalUnaryRat : (op : Rat → Rat) → (a : Expr) → SimpM Result := evalUnary getRatValue?
@@ -102,6 +103,7 @@ abbrev evalBin [ToExpr α] (toValue? : Expr → Option α) (op : α → α → �
   let e ← share <| toExpr (op a b)
   return .step e (mkApp2 (mkConst ``Eq.refl [1]) (ToExpr.toTypeExpr (α := α)) e) (done := true)
 
+abbrev evalBinBool : (op : Bool → Bool → Bool) → (a b : Expr) → SimpM Result := evalBin getBoolValue?
 abbrev evalBinNat : (op : Nat → Nat → Nat) → (a b : Expr) → SimpM Result := evalBin getNatValue?
 abbrev evalBinInt : (op : Int → Int → Int) → (a b : Expr) → SimpM Result := evalBin getIntValue?
 abbrev evalBinRat : (op : Rat → Rat → Rat) → (a b : Expr) → SimpM Result := evalBin getRatValue?
@@ -441,6 +443,7 @@ def evalEq (α : Expr) (a b : Expr) : SimpM Result :=
     let u ← getLevel α
     return .step e (mkApp2 (mkConst ``eq_self [u]) α a) (done := true)
   else match_expr α with
+  | Bool => evalBinPred getBoolValue? (mkConst ``Bool.eq_eq_true) (mkConst ``Bool.eq_eq_false) (. = .) a b
   | Nat => evalBinPred getNatValue? (mkConst ``Nat.eq_eq_true) (mkConst ``Nat.eq_eq_false) (. = .) a b
   | Int => evalBinPred getIntValue? (mkConst ``Int.eq_eq_true) (mkConst ``Int.eq_eq_false) (. = .) a b
   | Rat => evalBinPred getRatValue? (mkConst ``Rat.eq_eq_true) (mkConst ``Rat.eq_eq_false) (. = .) a b
@@ -471,6 +474,7 @@ abbrev evalBinBoolPred (toValue? : Expr → Option α) (op : α → α → Bool)
   let e ← share (toExpr r)
   return .step e (if r then eagerReflBoolTrue else eagerReflBoolFalse) (done := true)
 
+abbrev evalBinBoolPredBool : (op : Bool → Bool → Bool) → (a b : Expr) → SimpM Result := evalBinBoolPred getBoolValue?
 abbrev evalBinBoolPredNat : (op : Nat → Nat → Bool) → (a b : Expr) → SimpM Result := evalBinBoolPred getNatValue?
 abbrev evalBinBoolPredInt : (op : Int → Int → Bool) → (a b : Expr) → SimpM Result := evalBinBoolPred getIntValue?
 abbrev evalBinBoolPredRat : (op : Rat → Rat → Bool) → (a b : Expr) → SimpM Result := evalBinBoolPred getRatValue?
@@ -506,6 +510,7 @@ abbrev evalBinBoolPredBitVec (op : {n : Nat} → BitVec n → BitVec n → Bool)
 macro "declare_eval_bin_bool_pred" id:ident op:term : command =>
   `(def $id:ident (α : Expr) (a b : Expr) : SimpM Result :=
   match_expr α with
+  | Bool => evalBinBoolPredBool $op a b
   | Nat => evalBinBoolPredNat $op a b
   | Int => evalBinBoolPredInt $op a b
   | Rat => evalBinBoolPredRat $op a b
@@ -537,6 +542,10 @@ def evalNot (a : Expr) : SimpM Result :=
 
 abbrev mkRflBitVec (a : Expr) (n : Nat) : Expr :=
   mkApp2 (mkConst ``Eq.refl [1]) (mkApp (mkConst ``BitVec) (toExpr n)) a
+
+/-- Builds the type expression `BitVec w` from a width expression `w`. -/
+abbrev mkBitVecType (w : Expr) : Expr :=
+  mkApp (mkConst ``BitVec) w
 
 def evalInt8ToBitVec (a : Expr) : SimpM Result := do
   let some v ← getInt8Value? a |>.run | return .rfl
@@ -578,12 +587,6 @@ def evalUInt64ToBitVec (a : Expr) : SimpM Result := do
   let v ← share <| toExpr v.toBitVec
   return .step v (mkRflBitVec v 64) (done := true)
 
-def evalSetWidth (v x : Expr) : SimpM Result := do
-  let some v ← getNatValue? v |>.run | return .rfl
-  let some x := getBitVecValue? x | return .rfl
-  let x ← share <| toExpr <| x.val.setWidth v
-  return .step x (mkRflBitVec x v) (done := true)
-
 def evalBitVecToNat (a : Expr) : SimpM Result := do
   let some a := getBitVecValue? a | return .rfl
   let a ← share (toExpr a.val.toNat)
@@ -595,6 +598,86 @@ def evalBitVecOfNat (n a : Expr) : SimpM Result := do
   let some n ← evalNat n |>.run | return .rfl -- TODO: consider using dsimp
   let r ← share (toExpr (BitVec.ofNat n a))
   return .step r (mkRflBitVec r n) (done := true)
+
+def evalBitVecToInt (a : Expr) : SimpM Result := do
+  let some a := getBitVecValue? a | return .rfl
+  let e ← share <| toExpr <| BitVec.toInt a.val
+  return .step e (mkApp2 (mkConst ``Eq.refl [1]) Int.mkType e) (done := true)
+
+abbrev evalBitVecNatBool (op : {n : Nat} → BitVec n → Nat → Bool) (a i : Expr) : SimpM Result := do
+  let some a := getBitVecValue? a | return .rfl
+  let some i := getNatValue? i | return .rfl
+  let r := op a.val i
+  let e ← share (toExpr r)
+  return .step e (if r then eagerReflBoolTrue else eagerReflBoolFalse) (done := true)
+
+abbrev evalBitVecNatBitVec (αExpr : Expr) (op : {n : Nat} → BitVec n → Nat → BitVec n) (a i : Expr) :
+    SimpM Result := do
+  let some a := getBitVecValue? a | return .rfl
+  let some i := getNatValue? i | return .rfl
+  let e ← share <| toExpr <| op a.val i
+  return .step e (mkApp2 (mkConst ``Eq.refl [1]) αExpr e) (done := true)
+
+def evalBitVecAppend (a b : Expr) : SimpM Result := do
+  let some a := getBitVecValue? a | return .rfl
+  let some b := getBitVecValue? b | return .rfl
+  let e ← share <| toExpr <| a.val ++ b.val
+  return .step e (mkRflBitVec e (a.n + b.n)) (done := true)
+
+def evalBitVecCast (m a : Expr) : SimpM Result := do
+  let some a := getBitVecValue? a | return .rfl
+  let some m ← evalNat m |>.run | return .rfl
+  let e ← share <| toExpr <| BitVec.ofNat m a.val.toNat
+  return .step e (mkRflBitVec e m) (done := true)
+
+def evalBitVecExtend (op : {n : Nat} → (v : Nat) → BitVec n → BitVec v) (v a : Expr) : SimpM Result := do
+  let some a := getBitVecValue? a | return .rfl
+  let some v ← evalNat v |>.run | return .rfl
+  let e ← share <| toExpr <| op v a.val
+  return .step e (mkRflBitVec e v) (done := true)
+
+def evalBitVecExtractLsb' (start len a : Expr) : SimpM Result := do
+  let some a := getBitVecValue? a | return .rfl
+  let some start ← evalNat start |>.run | return .rfl
+  let some len ← evalNat len |>.run | return .rfl
+  let e ← share <| toExpr <| a.val.extractLsb' start len
+  return .step e (mkRflBitVec e len) (done := true)
+
+def evalBitVecReplicate (i a : Expr) : SimpM Result := do
+  let some a := getBitVecValue? a | return .rfl
+  let some i ← evalNat i |>.run | return .rfl
+  let e ← share <| toExpr <| a.val.replicate i
+  return .step e (mkRflBitVec e (a.n * i)) (done := true)
+
+def evalBitVecShiftLeftZeroExtend (a m : Expr) : SimpM Result := do
+  let some a := getBitVecValue? a | return .rfl
+  let some m ← evalNat m |>.run | return .rfl
+  let e ← share <| toExpr <| a.val.shiftLeftZeroExtend m
+  return .step e (mkRflBitVec e (a.n + m)) (done := true)
+
+def evalBitVecAllOnes (n : Expr) : SimpM Result := do
+  let some n ← evalNat n |>.run | return .rfl
+  let e ← share <| toExpr <| BitVec.allOnes n
+  return .step e (mkRflBitVec e n) (done := true)
+
+def evalBitVecOfInt (n i : Expr) : SimpM Result := do
+  let some n ← evalNat n |>.run | return .rfl
+  let some i := getIntValue? i | return .rfl
+  let e ← share <| toExpr <| BitVec.ofInt n i
+  return .step e (mkRflBitVec e n) (done := true)
+
+def evalBitVecToFin (a : Expr) : SimpM Result := do
+  let some a := getBitVecValue? a | return .rfl
+  let v := a.val.toFin
+  let e ← share <| toExpr v
+  let finType := mkApp (mkConst ``Fin) (toExpr (2 ^ a.n))
+  return .step e (mkApp2 (mkConst ``Eq.refl [1]) finType e) (done := true)
+
+def evalBitVecOfFin (n a : Expr) : SimpM Result := do
+  let some n ← evalNat n |>.run | return .rfl
+  let some a := getFinValue? a | return .rfl
+  let e ← share <| toExpr <| BitVec.ofNat n a.val.val
+  return .step e (mkRflBitVec e n) (done := true)
 
 public structure EvalStepConfig where
   maxExponent := 255
@@ -642,9 +725,55 @@ public def evalGround (config : EvalStepConfig := {}) : Simproc := fun e =>
   | BEq.beq α _ a b => evalBEq α a b
   | bne α _ a b => evalBNe α a b
   | Not a => evalNot a
-  | BitVec.setWidth _ v x => evalSetWidth v x
+  | Bool.and x y => evalBinBool Bool.and x y
+  | Bool.or x y => evalBinBool Bool.or x y
+  | Bool.not x => evalUnaryBool Bool.not x
+  | HAppend.hAppend α _ _ _ a b =>
+    match_expr α with
+    | BitVec _ => evalBitVecAppend a b
+    | _ => return .rfl
+  | getElem α _ _ _ _ a i _ =>
+    match_expr α with
+    | BitVec _ => evalBitVecNatBool BitVec.getLsbD a i
+    | _ => return .rfl
+  | BitVec.append _ _ a b => evalBitVecAppend a b
+  | BitVec.shiftLeft w a i => evalBitVecNatBitVec (mkBitVecType w) BitVec.shiftLeft a i
+  | BitVec.ushiftRight w a i => evalBitVecNatBitVec (mkBitVecType w) BitVec.ushiftRight a i
+  | BitVec.sshiftRight w a i => evalBitVecNatBitVec (mkBitVecType w) BitVec.sshiftRight a i
+  | BitVec.sshiftRight' n _ a b => evalBinBitVec' BitVec.sshiftRight' (mkBitVecType n) a b
+  | BitVec.rotateLeft w a i => evalBitVecNatBitVec (mkBitVecType w) BitVec.rotateLeft a i
+  | BitVec.rotateRight w a i => evalBitVecNatBitVec (mkBitVecType w) BitVec.rotateRight a i
+  | BitVec.udiv w a b => evalBinBitVec' BitVec.udiv (mkBitVecType w) a b
+  | BitVec.umod w a b => evalBinBitVec' BitVec.umod (mkBitVecType w) a b
+  | BitVec.sdiv w a b => evalBinBitVec' BitVec.sdiv (mkBitVecType w) a b
+  | BitVec.smod w a b => evalBinBitVec' BitVec.smod (mkBitVecType w) a b
+  | BitVec.srem w a b => evalBinBitVec' BitVec.srem (mkBitVecType w) a b
+  | BitVec.smtUDiv w a b => evalBinBitVec' BitVec.smtUDiv (mkBitVecType w) a b
+  | BitVec.smtSDiv w a b => evalBinBitVec' BitVec.smtSDiv (mkBitVecType w) a b
+  | BitVec.abs w a => evalUnaryBitVec' BitVec.abs (mkBitVecType w) a
+  | BitVec.clz w a => evalUnaryBitVec' BitVec.clz (mkBitVecType w) a
+  | BitVec.cpop w a => evalUnaryBitVec' BitVec.cpop (mkBitVecType w) a
+  | BitVec.ult _ a b => evalBinBoolPredBitVec BitVec.ult a b
+  | BitVec.ule _ a b => evalBinBoolPredBitVec BitVec.ule a b
+  | BitVec.slt _ a b => evalBinBoolPredBitVec BitVec.slt a b
+  | BitVec.sle _ a b => evalBinBoolPredBitVec BitVec.sle a b
+  | BitVec.getLsbD _ a i => evalBitVecNatBool BitVec.getLsbD a i
+  | BitVec.getMsbD _ a i => evalBitVecNatBool BitVec.getMsbD a i
+  | BitVec.setWidth _ v x => evalBitVecExtend BitVec.setWidth v x
+  | BitVec.zeroExtend _ v x => evalBitVecExtend BitVec.zeroExtend v x
+  | BitVec.signExtend _ v a => evalBitVecExtend BitVec.signExtend v a
+  | BitVec.setWidth' _ w _ a => evalBitVecExtend BitVec.setWidth w a
+  | BitVec.cast _ m _ a => evalBitVecCast m a
+  | BitVec.shiftLeftZeroExtend _ a m => evalBitVecShiftLeftZeroExtend a m
+  | BitVec.extractLsb' _ start len a => evalBitVecExtractLsb' start len a
+  | BitVec.replicate _ i a => evalBitVecReplicate i a
+  | BitVec.allOnes n => evalBitVecAllOnes n
   | BitVec.toNat _ a => evalBitVecToNat a
   | BitVec.ofNat n a => evalBitVecOfNat n a
+  | BitVec.toInt _ a => evalBitVecToInt a
+  | BitVec.ofInt n i => evalBitVecOfInt n i
+  | BitVec.toFin _ a => evalBitVecToFin a
+  | BitVec.ofFin n a => evalBitVecOfFin n a
   | Int8.toBitVec a => evalInt8ToBitVec a
   | Int16.toBitVec a => evalInt16ToBitVec a
   | Int32.toBitVec a => evalInt32ToBitVec a

--- a/tests/elab/sym_simp_2.lean
+++ b/tests/elab/sym_simp_2.lean
@@ -1,6 +1,8 @@
 import Lean
 open Lean Meta Elab Tactic
 
+/-! Unit tests for Sym.Simp.EvalGround. -/
+
 elab "sym_simp" : tactic => do
   let methods : Sym.Simp.Methods := { post := Sym.Simp.evalGround }
   liftMetaTactic1 fun mvarId => Sym.SymM.run do
@@ -91,6 +93,12 @@ example : -(1 : Fin 5) = 4 := by sym_simp
 
 -- BitVec
 example : (2 : BitVec 8) + 3 = 5 := by sym_simp
+example : (10 : BitVec 8) - 3 = 7 := by sym_simp
+example : (3 : BitVec 8) - 10 = 249 := by sym_simp  -- underflow
+example : (4 : BitVec 8) * 5 = 20 := by sym_simp
+example : (20 : BitVec 8) / 3 = 6 := by sym_simp
+example : (20 : BitVec 8) % 3 = 2 := by sym_simp
+example : -(1 : BitVec 8) = 255 := by sym_simp
 example : (0x0F : BitVec 8) &&& 0x3C = 0x0C := by sym_simp
 example : (0x0F : BitVec 8) ||| 0x30 = 0x3F := by sym_simp
 example : (0xFF : BitVec 8) ^^^ 0xAA = 0x55 := by sym_simp
@@ -98,6 +106,65 @@ example : ~~~(0x0F : BitVec 8) = 0xF0 := by sym_simp
 example : (1 : BitVec 8) <<< 4 = 16 := by sym_simp
 example : (0x80 : BitVec 8) >>> 4 = 0x08 := by sym_simp
 example : (100 : BitVec 8) + 200 = 44 := by sym_simp  -- overflow
+
+-- BitVec: append / indexing
+example : ((0xAB : BitVec 8) ++ (0xCD : BitVec 8)).toNat = 0xABCD := by sym_simp
+example : (0xAA : BitVec 8)[1] = true := by sym_simp
+
+-- BitVec: named shift/rotate functions
+example : BitVec.shiftLeft (1 : BitVec 8) 4 = 16 := by sym_simp
+example : BitVec.ushiftRight (0x80 : BitVec 8) 4 = 0x08 := by sym_simp
+example : BitVec.sshiftRight (0x80 : BitVec 8) 4 = 0xF8 := by sym_simp
+example : BitVec.sshiftRight' (0x80 : BitVec 8) (4 : BitVec 8) = 0xF8 := by sym_simp
+example : BitVec.rotateLeft (0x81 : BitVec 8) 1 = 0x03 := by sym_simp
+example : BitVec.rotateRight (0x81 : BitVec 8) 1 = 0xC0 := by sym_simp
+
+-- BitVec: division / remainder variants
+example : BitVec.udiv (20 : BitVec 8) 3 = 6 := by sym_simp
+example : BitVec.umod (20 : BitVec 8) 3 = 2 := by sym_simp
+example : BitVec.sdiv (0xEC : BitVec 8) 3 = 0xFA := by sym_simp   -- -20 / 3 = -6
+example : BitVec.smod (0xEC : BitVec 8) 3 = 1 := by sym_simp
+example : BitVec.srem (0xEC : BitVec 8) 3 = 0xFE := by sym_simp   -- -20 rem 3 = -2
+example : BitVec.smtUDiv (20 : BitVec 8) 0 = 0xFF := by sym_simp  -- division by zero
+example : BitVec.smtSDiv (0xEC : BitVec 8) 3 = 0xFA := by sym_simp
+
+-- BitVec: abs / bit-counting
+example : BitVec.abs (0xFB : BitVec 8) = 5 := by sym_simp  -- |-5|
+example : BitVec.clz (0x01 : BitVec 8) = 7 := by sym_simp
+example : BitVec.cpop (0xF0 : BitVec 8) = 4 := by sym_simp
+
+-- BitVec: bit access
+example : (0xAA : BitVec 8).getLsbD 1 = true := by sym_simp
+example : (0xAA : BitVec 8).getMsbD 0 = true := by sym_simp
+
+-- BitVec: width-changing operations
+example : (0xFF : BitVec 8).setWidth 4 = 0xF := by sym_simp
+example : (0xF : BitVec 4).zeroExtend 8 = 0x0F := by sym_simp
+example : (0xF : BitVec 4).signExtend 8 = 0xFF := by sym_simp
+example : BitVec.setWidth' (n := 4) (w := 8) (by omega) (0x0F : BitVec 4) = 0x0F := by sym_simp
+example : BitVec.cast (n := 4) (m := 4) rfl (0x0F : BitVec 4) = 0x0F := by sym_simp
+example : (BitVec.shiftLeftZeroExtend (0x0F : BitVec 4) 4).toNat = 0xF0 := by sym_simp
+example : BitVec.extractLsb' 4 4 (0xAB : BitVec 8) = 0xA := by sym_simp
+example : (BitVec.replicate 2 (0x0F : BitVec 4)).toNat = 0xFF := by sym_simp
+example : BitVec.allOnes 8 = 0xFF := by sym_simp
+
+-- BitVec: Nat/Int/Fin conversions
+example : (200 : BitVec 8).toNat = 200 := by sym_simp
+example : BitVec.ofNat 8 300 = 44 := by sym_simp  -- overflow
+example : (0xFF : BitVec 8).toInt = -1 := by sym_simp
+example : BitVec.ofInt 8 (-1) = 0xFF := by sym_simp
+example : (5 : BitVec 8).toFin = (5 : Fin 256) := by sym_simp
+example : BitVec.ofFin (w := 8) (5 : Fin 256) = 5 := by sym_simp
+
+-- BitVec: fixed-width conversions
+example : (-1 : Int8).toBitVec = 0xFF := by sym_simp
+example : (-1 : Int16).toBitVec = 0xFFFF := by sym_simp
+example : (-1 : Int32).toBitVec = 0xFFFFFFFF := by sym_simp
+example : (-1 : Int64).toBitVec = 0xFFFFFFFFFFFFFFFF := by sym_simp
+example : (255 : UInt8).toBitVec = 0xFF := by sym_simp
+example : (65535 : UInt16).toBitVec = 0xFFFF := by sym_simp
+example : (4294967295 : UInt32).toBitVec = 0xFFFFFFFF := by sym_simp
+example : (18446744073709551615 : UInt64).toBitVec = 0xFFFFFFFFFFFFFFFF := by sym_simp
 
 -- Predicates: Nat
 example : (2 < 3) = True := by sym_simp
@@ -146,7 +213,13 @@ example : ((-50 : Int8) > 50) = False := by sym_simp
 
 -- Predicates: BitVec
 example : ((5 : BitVec 8) < 10) = True := by sym_simp
+example : ((5 : BitVec 8) ≤ 5) = True := by sym_simp
 example : ((255 : BitVec 8) = 255) = True := by sym_simp
+example : ((5 : BitVec 8) ≠ 6) = True := by sym_simp
+example : BitVec.ult (5 : BitVec 8) 10 = true := by sym_simp
+example : BitVec.ule (5 : BitVec 8) 5 = true := by sym_simp
+example : BitVec.slt (0xFF : BitVec 8) 1 = true := by sym_simp  -- -1 < 1 (signed)
+example : BitVec.sle (0xFF : BitVec 8) 0xFF = true := by sym_simp
 
 -- Predicates: Fin
 example : ((2 : Fin 5) < 3) = True := by sym_simp
@@ -165,6 +238,15 @@ example : ((5 : Nat) != 6) = true := by sym_simp
 example : ((5 : Nat) != 5) = false := by sym_simp
 example : ((5 : Int) == 5) = true := by sym_simp
 example : ((0xFF : BitVec 8) == 255) = true := by sym_simp
+example : ((0xFF : BitVec 8) != 0) = true := by sym_simp
+
+-- Bool
+example : Bool.and true false = false := by sym_simp
+example : Bool.or false true = true := by sym_simp
+example : Bool.not true = false := by sym_simp
+example : (true == false) = false := by sym_simp
+example : (true != false) = true := by sym_simp
+example : (true = true) = True := by sym_simp
 
 -- Identity fast path (isSameExpr)
 example : ∀ n : Nat, (n = n) = True := by intro n; sym_simp


### PR DESCRIPTION
This PR adds additional `BitVec` operations to the set of operations supported by `Simp.Simp.evalGround` and `Sym.DSimp.evalGround`.