### PR TITLE
feat: rename `[grind homo]` to `[grind hom]`

### DIFF
--- a/src/Init/Grind/Attr.lean
+++ b/src/Init/Grind/Attr.lean
@@ -198,7 +198,7 @@ Given an application `f a₁ a₂ … aₙ`, when `funCC := true`,
 -/
 syntax grindFunCC  := &"funCC"
 /--
-The `homo` modifier marks a theorem as a homomorphism rule for `grind`.
+The `hom` modifier marks a theorem as a homomorphism rule for `grind`.
 
 Homomorphism rules translate terms from a source domain into a target domain that has a
 dedicated solver. A collection of homomorphism rules encodes an algebra homomorphism
@@ -206,15 +206,15 @@ dedicated solver. A collection of homomorphism rules encodes an algebra homomorp
 `h (f x y) = g (h x) (h y)`. Example: injecting bitvector operations into integer
 arithmetic using `BitVec.toNat`:
 ```
-@[grind homo] theorem toNat_add (x y : BitVec w) :
+@[grind hom] theorem toNat_add (x y : BitVec w) :
     (x + y).toNat = (x.toNat + y.toNat) % 2^w
 ```
 The rules must be unconditional equations (or `Iff`s). They are applied to fixpoint
 outside the E-graph, and only the final result is internalized.
 -/
-syntax grindHomo   := &"homo"
+syntax grindHom    := &"hom"
 /--
-The `homo_pred` modifier marks a theorem as a homomorphism predicate for `grind`.
+The `hom_pred` modifier marks a theorem as a homomorphism predicate for `grind`.
 
 Homomorphism predicates are facts that `grind` instantiates eagerly for the terms it
 internalizes. The conclusion of the theorem must contain an application `f a₁ … aₙ`
@@ -224,13 +224,19 @@ the theorem is instantiated with the term's trailing arguments, and the resultin
 fact is asserted. Typical uses are range facts for injection functions, and
 translations of relations into a target domain. Examples:
 ```
-@[grind homo_pred] theorem BitVec.toNat_range (x : BitVec w) : x.toNat < 2^w
-@[grind homo_pred] theorem UInt8.le_iff (a b : UInt8) : a ≤ b ↔ a.toBitVec ≤ b.toBitVec
+@[grind hom_pred] theorem BitVec.toNat_range (x : BitVec w) : x.toNat < 2^w
+@[grind hom_pred] theorem UInt8.le_iff (a b : UInt8) : a ≤ b ↔ a.toBitVec ≤ b.toBitVec
 ```
 The first theorem is triggered by terms of the form `BitVec.toNat x`, and the second
 one by `a ≤ b` applications. `grind` uses the types of `a` and `b` to discard
 irrelevant instantiations.
 -/
+syntax grindHomPred := &"hom_pred"
+/-- Deprecated spelling of the `hom` modifier. It behaves like `hom` and will be
+removed. -/
+syntax grindHomo   := &"homo"
+/-- Deprecated spelling of the `hom_pred` modifier. It behaves like `hom_pred` and will
+be removed. -/
 syntax grindHomoPred := &"homo_pred"
 /--
 The `norm` modifier instructs `grind` to use a theorem as a normalization rule. That is,
@@ -308,7 +314,8 @@ syntax grindMod :=
     grindEqBoth <|> grindEqRhs <|> grindEq <|> grindEqBwd <|> grindBwd
     <|> grindFwd <|> grindRL <|> grindLR <|> grindUsr <|> grindCasesEager
     <|> grindCases <|> grindIntro <|> grindExt <|> grindGen <|> grindSym <|> grindInj
-    <|> grindFunCC <|> grindHomoPred <|> grindHomo <|> grindNorm <|> grindUnfold <|> grindDef
+    <|> grindFunCC <|> grindHomPred <|> grindHom <|> grindHomoPred <|> grindHomo
+    <|> grindNorm <|> grindUnfold <|> grindDef
 
 /--
 Marks a theorem or definition for use by the `grind` tactic.

--- a/src/Lean/Elab/Tactic/Grind/Param.lean
+++ b/src/Lean/Elab/Tactic/Grind/Param.lean
@@ -263,8 +263,8 @@ def processParam (params : Grind.Params)
   | .funCC =>
     params := params.insertFunCC declName
   | .norm .. => throwError "normalization theorems should be registered using the `@[grind norm]` attribute"
-  | .homo => throwError "homomorphism rules should be registered using the `@[grind homo]` attribute"
-  | .homoPred => throwError "homomorphism predicates should be registered using the `@[grind homo_pred]` attribute"
+  | .homo => throwError "homomorphism rules should be registered using the `@[grind hom]` attribute"
+  | .homoPred => throwError "homomorphism predicates should be registered using the `@[grind hom_pred]` attribute"
   | .unfold => throwError "declarations to be unfolded during normalization should be registered using the `@[grind unfold]` attribute"
   return params
 

--- a/src/Lean/Meta/Tactic/Grind/Attr.lean
+++ b/src/Lean/Meta/Tactic/Grind/Attr.lean
@@ -63,6 +63,8 @@ def getAttrKindCore (stx : Syntax) : CoreM AttrKind := do
   | `(Parser.Attr.grindMod|norm ↑ ←) => return .norm true true
   | `(Parser.Attr.grindMod|norm ↓ ←) => return .norm (post := false) true
   | `(Parser.Attr.grindMod|unfold) => return .unfold
+  | `(Parser.Attr.grindMod|hom) => return .homo
+  | `(Parser.Attr.grindMod|hom_pred) => return .homoPred
   | `(Parser.Attr.grindMod|homo) => return .homo
   | `(Parser.Attr.grindMod|homo_pred) => return .homoPred
   | `(Parser.Attr.grindMod|symbol $prio:prio) =>

--- a/src/Lean/Meta/Tactic/Grind/Homo.lean
+++ b/src/Lean/Meta/Tactic/Grind/Homo.lean
@@ -7,7 +7,6 @@ module
 prelude
 public import Lean.Meta.Sym.Simp.Theorems
 import Lean.Meta.Sym.Simp.Attr
-import Lean.Meta.DiscrTree.Util
 import Lean.Meta.AppBuilder
 public section
 namespace Lean.Meta.Grind
@@ -15,13 +14,13 @@ namespace Lean.Meta.Grind
 /-- Extension backing the `@[grind homo]` attribute. -/
 builtin_initialize homoExt : Sym.Simp.SymSimpExtension ← Sym.Simp.mkSymSimpExt
 
-/-- Returns the homomorphism rules tagged with the `[grind homo]` attribute. -/
+/-- Returns the homomorphism rules tagged with the `[grind hom]` attribute. -/
 def getHomoTheorems : CoreM Sym.Simp.Theorems :=
   homoExt.getTheorems
 
 /--
 Extension collecting the homomorphism *source types*: the head constants `F` of the
-types `τ = F …` for which a `[grind homo]` rule translates `Eq τ`. The engine marks
+types `τ = F …` for which a `[grind hom]` rule translates `Eq τ`. The engine marks
 terms of these types as solver terms so that the E-graph reports their equalities and
 disequalities (see `SolverExtension.markTerm`).
 -/
@@ -36,7 +35,7 @@ def getHomoSourceTypes : CoreM NameSet :=
   return homoSourceTypesExt.getState (← getEnv)
 
 /--
-Ensures a `[grind homo]` theorem can be applied by `Sym.simp` without a discharger.
+Ensures a `[grind hom]` theorem can be applied by `Sym.simp` without a discharger.
 Instance-implicit parameters are synthesized during rewriting and need not be
 determined by the left-hand side. Every other parameter must be inferable from the
 left-hand side: it must occur in the left-hand side itself (as in
@@ -76,12 +75,12 @@ def validateHomoTheorem (declName : Name) : MetaM Unit := do
       unless covered.contains x.fvarId! do
         let xType ← inferType x
         if (← isProp xType) then
-          throwError "invalid `[grind homo]` theorem, `{.ofConstName declName}` is conditional: \
+          throwError "invalid `[grind hom]` theorem, `{.ofConstName declName}` is conditional: \
             hypothesis{indentExpr xType}\nis not determined by the left-hand side and would have \
             to be discharged when the rule is applied. Homomorphism rules must be unconditional; \
             use E-matching attributes such as `[grind =]` or `[grind →]` for conditional theorems"
         else
-          throwError "invalid `[grind homo]` theorem, parameter `{x}` of \
+          throwError "invalid `[grind hom]` theorem, parameter `{x}` of \
             `{.ofConstName declName}` is not determined by the left-hand side of the rule"
 
 /--
@@ -100,22 +99,22 @@ private def checkEqInjection? (declName : Name) : MetaM (Option Name) := do
       | _ => concl
     let_expr Eq τ _ _ := lhs | return none
     let .const F _ := τ.getAppFn
-      | throwError "invalid `[grind homo]` theorem, the source type of the `=`-injection rule \
+      | throwError "invalid `[grind hom]` theorem, the source type of the `=`-injection rule \
           `{.ofConstName declName}` is not headed by a constant{indentExpr τ}\nhomomorphism rules \
           translate concrete types; generic injections cannot be tracked by the E-graph"
     return some F
 
 /--
-Validates and registers a `[grind homo]` theorem, recording the source type of
+Validates and registers a `[grind hom]` theorem, recording the source type of
 `=`-injection rules. See `validateHomoTheorem`.
 -/
 def addHomoAttr (declName : Name) (attrKind : AttributeKind) : MetaM Unit := do
-  Sym.Simp.addSymSimpDecl homoExt "grind homo" declName attrKind (validate := fun declName => do
+  Sym.Simp.addSymSimpDecl homoExt "grind hom" declName attrKind (validate := fun declName => do
     validateHomoTheorem declName
     if let some F ← checkEqInjection? declName then
       homoSourceTypesExt.add F attrKind)
 
-/-- A theorem tagged with the `[grind homo_pred]` attribute. -/
+/-- A theorem tagged with the `[grind hom_pred]` attribute. -/
 structure HomoPredTheorem where
   /-- Name of the theorem. -/
   declName : Name
@@ -124,7 +123,7 @@ structure HomoPredTheorem where
   arity : Nat
   deriving Inhabited, BEq
 
-/-- Map from trigger head symbol to the `[grind homo_pred]` theorems it activates. -/
+/-- Map from trigger head symbol to the `[grind hom_pred]` theorems it activates. -/
 abbrev HomoPredTheorems := NameMap (List HomoPredTheorem)
 
 /-- Extension backing the `@[grind homo_pred]` attribute. -/
@@ -134,12 +133,12 @@ builtin_initialize homoPredExt : SimpleScopedEnvExtension (Name × HomoPredTheor
     addEntry := fun s (key, thm) => s.insert key (thm :: (s.find? key).getD [])
   }
 
-/-- Returns the homomorphism predicates tagged with the `[grind homo_pred]` attribute. -/
+/-- Returns the homomorphism predicates tagged with the `[grind hom_pred]` attribute. -/
 def getHomoPredTheorems : CoreM HomoPredTheorems :=
   return homoPredExt.getState (← getEnv)
 
 /--
-Validates and registers a `[grind homo_pred]` theorem.
+Validates and registers a `[grind hom_pred]` theorem.
 The conclusion of the theorem must contain an application whose trailing arguments are
 exactly the theorem's explicit parameters. The head symbol of this application is the
 trigger for the theorem.
@@ -147,11 +146,11 @@ trigger for the theorem.
 def addHomoPredAttr (declName : Name) (attrKind : AttributeKind) : MetaM Unit := do
   let info ← getConstInfo declName
   unless (← isProp info.type) do
-    throwError "invalid `[grind homo_pred]` theorem, `{.ofConstName declName}` is not a proposition"
+    throwError "invalid `[grind hom_pred]` theorem, `{.ofConstName declName}` is not a proposition"
   forallTelescope info.type fun xs type => do
     let xsExplicit ← xs.filterM fun x => return (← getFVarLocalDecl x).binderInfo.isExplicit
     if xsExplicit.isEmpty then
-      throwError "invalid `[grind homo_pred]` theorem, `{.ofConstName declName}` must have \
+      throwError "invalid `[grind hom_pred]` theorem, `{.ofConstName declName}` must have \
         at least one explicit parameter; the trigger is inferred from an application whose \
         trailing arguments are the theorem's explicit parameters"
     let found? := type.find? fun e => Id.run do
@@ -160,12 +159,12 @@ def addHomoPredAttr (declName : Name) (attrKind : AttributeKind) : MetaM Unit :=
       if args.size < xsExplicit.size then return false
       return args.extract (args.size - xsExplicit.size) args.size == xsExplicit
     let some found := found?
-      | throwError "invalid `[grind homo_pred]` theorem, the conclusion of `{.ofConstName declName}` does not contain an application whose trailing arguments are the theorem's explicit parameters"
+      | throwError "invalid `[grind hom_pred]` theorem, the conclusion of `{.ofConstName declName}` does not contain an application whose trailing arguments are the theorem's explicit parameters"
     let .const key _ := found.getAppFn | unreachable!
     homoPredExt.add (key, { declName, arity := xsExplicit.size }) attrKind
 
 /--
-Returns the instances of the `[grind homo_pred]` theorems triggered by `e`.
+Returns the instances of the `[grind hom_pred]` theorems triggered by `e`.
 Each instance is a pair `(proof, prop)` where `proof : prop`. A registered theorem
 whose trigger matches `e`'s head symbol is instantiated with `e`'s trailing arguments;
 instantiations that fail to elaborate (e.g. because the argument types do not match)

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,3 +1,4 @@
+// update me!
 #include "util/options.h"
 
 // Should we test stage 2 and run update-stage0 on PR merge? NO

--- a/tests/elab/grind_hom_attr.lean
+++ b/tests/elab/grind_hom_attr.lean
@@ -1,13 +1,13 @@
 import Lean
 
 /-!
-Tests for `[grind homo]` attribute registration. Homomorphism rules are registered in a
+Tests for `[grind hom]` attribute registration. Homomorphism rules are registered in a
 `Sym.simp` theorem set retrievable via `Lean.Meta.Grind.getHomoTheorems`.
 -/
 
 open Lean Meta Grind
 
-/-- Custom source type so this test is independent of the `[grind homo]` rules in `Init`. -/
+/-- Custom source type so this test is independent of the `[grind hom]` rules in `Init`. -/
 structure W where
   val : Int
 
@@ -20,11 +20,11 @@ axiom wu_add (x y : W) : wu (x + y) = (wu x + wu y) % 2^32
 axiom wu_mul (x y : W) : wu (x * y) = (wu x * wu y) % 2^32
 axiom wu_eq (x y : W) : (x = y) ↔ (wu x = wu y)
 
-attribute [grind homo] wu_add
-attribute [grind homo] wu_mul
-attribute [grind homo] wu_eq
+attribute [grind hom] wu_add
+attribute [grind hom] wu_mul
+attribute [grind hom] wu_eq
 
-/-- Displays the `[grind homo]` rules matching `wu (x + x)` and `x = x`. -/
+/-- Displays the `[grind hom]` rules matching `wu (x + x)` and `x = x`. -/
 def checkMatches : MetaM Unit := do
   withLocalDeclD `x (mkConst ``W) fun x => do
     let thms ← getHomoTheorems
@@ -45,21 +45,21 @@ run_meta checkMatches
 
 /-- error: homomorphism rules must be set using the default `[grind]` attribute -/
 #guard_msgs in
-attribute [lia homo] wu_add
+attribute [lia hom] wu_add
 
 axiom bad : Nat
 
 /--
-error: Cannot add `grind homo` attribute to `bad`: It is not a proposition nor a definition with equation theorems.
+error: Cannot add `grind hom` attribute to `bad`: It is not a proposition nor a definition with equation theorems.
 -/
 #guard_msgs in
-attribute [grind homo] bad
+attribute [grind hom] bad
 
 /--
-error: homomorphism rules should be registered using the `@[grind homo]` attribute
+error: homomorphism rules should be registered using the `@[grind hom]` attribute
 -/
 #guard_msgs in
-example : True := by grind [homo wu_add]
+example : True := by grind [hom wu_add]
 
 /-! Conditional theorems are rejected: hypotheses that must be discharged are not
 supported. Hypotheses occurring in the conclusion (instantiated by matching) are fine. -/
@@ -67,19 +67,19 @@ supported. Hypotheses occurring in the conclusion (instantiated by matching) are
 axiom wu_cond (x y : W) (h : wu x = 0) : wu (x + y) = wu y
 
 /--
-error: invalid `[grind homo]` theorem, `wu_cond` is conditional: hypothesis
+error: invalid `[grind hom]` theorem, `wu_cond` is conditional: hypothesis
   wu x = 0
 is not determined by the left-hand side and would have to be discharged when the rule is applied. Homomorphism rules must be unconditional; use E-matching attributes such as `[grind =]` or `[grind →]` for conditional theorems
 -/
 #guard_msgs in
-attribute [grind homo] wu_cond
+attribute [grind hom] wu_cond
 
 def wcast (_h : True) (x : W) : W := x
 
 axiom wu_wcast (h : True) (x : W) : wu (wcast h x) = wu x
 
 #guard_msgs in
-attribute [grind homo] wu_wcast
+attribute [grind hom] wu_wcast
 
 /-! An instance-implicit parameter not occurring in the left-hand side is fine: it is
 synthesized during rewriting. In particular, `Prop`-valued instances such as `NeZero`
@@ -90,17 +90,17 @@ def wofNat (n : Nat) : W := ⟨n⟩
 axiom wu_ofNat (n : Nat) [NeZero n] : wu (wofNat n) = (n : Int)
 
 #guard_msgs in
-attribute [grind homo] wu_ofNat
+attribute [grind hom] wu_ofNat
 
 /-! A parameter occurring only in the right-hand side cannot be instantiated. -/
 
 axiom wu_rhs (x y : W) : wu x = wu (x + y)
 
 /--
-error: invalid `[grind homo]` theorem, parameter `y` of `wu_rhs` is not determined by the left-hand side of the rule
+error: invalid `[grind hom]` theorem, parameter `y` of `wu_rhs` is not determined by the left-hand side of the rule
 -/
 #guard_msgs in
-attribute [grind homo] wu_rhs
+attribute [grind hom] wu_rhs
 
 /-! Registering the `=`-injection rule `wu_eq` records `W` as a homomorphism source
 type. Generic injections over a variable type are rejected: the engine tracks source
@@ -115,12 +115,23 @@ axiom toI : ∀ {α : Type}, α → Int
 axiom toI_eq {α : Type} (a b : α) : (a = b) ↔ (toI a = toI b)
 
 /--
-error: invalid `[grind homo]` theorem, the source type of the `=`-injection rule `toI_eq` is not headed by a constant
+error: invalid `[grind hom]` theorem, the source type of the `=`-injection rule `toI_eq` is not headed by a constant
   α
 homomorphism rules translate concrete types; generic injections cannot be tracked by the E-graph
 -/
 #guard_msgs in
-attribute [grind homo] toI_eq
+attribute [grind hom] toI_eq
+
+/-! The deprecated spellings behave like `hom`/`hom_pred`. -/
+
+#guard_msgs in
+attribute [grind homo] wu_mul
+
+/--
+error: homomorphism rules should be registered using the `@[grind hom]` attribute
+-/
+#guard_msgs in
+example : True := by grind [homo wu_add]
 
 /-! `reset_grind_attrs%` clears the homo extension and the recorded source types. -/
 

--- a/tests/elab/grind_hom_lemmas.lean
+++ b/tests/elab/grind_hom_lemmas.lean
@@ -1,7 +1,7 @@
 import Lean
 
 /-!
-Tests that the `[grind homo]` environment extension is populated by the homomorphism
+Tests that the `[grind hom]` environment extension is populated by the homomorphism
 rules in `Init.Grind.Homo`. We check both direct retrieval (`getHomoTheorems` +
 `Theorems.getMatch`) and that the registered theorems can be used to perform
 rewriting: a small metaprogram applies the homomorphisms to fixpoint using `Sym.simp`
@@ -10,7 +10,7 @@ and verifies the generated proofs.
 
 open Lean Meta Lean.Meta.Sym Lean.Meta.Sym.Simp
 
-/-- Prints the `[grind homo]` rules matching the (instantiated) body of `declName`. -/
+/-- Prints the `[grind hom]` rules matching the (instantiated) body of `declName`. -/
 def showMatches (declName : Name) : MetaM Unit := do
   let value := (← getConstInfoDefn declName).value
   lambdaTelescope value fun _ body => SymM.run do
@@ -20,7 +20,7 @@ def showMatches (declName : Name) : MetaM Unit := do
       logInfo m!"{thm.expr}"
 
 /--
-Applies the `[grind homo]` rules to the body of `declName` to fixpoint using `Sym.simp`,
+Applies the `[grind hom]` rules to the body of `declName` to fixpoint using `Sym.simp`,
 prints the result, and checks the generated proof.
 -/
 def applyHomo (declName : Name) : MetaM Unit := do
@@ -139,7 +139,7 @@ run_meta applyHomo ``i64Eq
 /-! Homomorphism predicates from `Init.Grind.Homo`: range facts and relation
 translations are instantiated for representative terms via `mkHomoPredInstances`. -/
 
-/-- Instantiates the `[grind homo_pred]` theorems for the body of `declName`. -/
+/-- Instantiates the `[grind hom_pred]` theorems for the body of `declName`. -/
 def showPredInstances (declName : Name) : MetaM Unit := do
   let value := (← getConstInfoDefn declName).value
   lambdaTelescope value fun _ body => do

--- a/tests/elab/grind_hom_pred_attr.lean
+++ b/tests/elab/grind_hom_pred_attr.lean
@@ -1,7 +1,7 @@
 import Lean
 
 /-!
-Tests for `[grind homo_pred]` attribute registration. Homomorphism predicates are
+Tests for `[grind hom_pred]` attribute registration. Homomorphism predicates are
 registered in an environment extension mapping the trigger head symbol to the tagged
 theorems, retrievable via `Lean.Meta.Grind.getHomoPredTheorems`. The registered
 theorems can be instantiated for concrete terms via
@@ -22,12 +22,12 @@ axiom wu_lower (x : W) : 0 ≤ wu x
 axiom wu_upper (x : W) : wu x < 2^32
 axiom le_iff (a b : W) : a ≤ b ↔ wu a ≤ wu b
 
-attribute [grind homo_pred] wu_lower
-attribute [grind homo_pred] wu_upper
-attribute [grind homo_pred] le_iff
+attribute [grind hom_pred] wu_lower
+attribute [grind hom_pred] wu_upper
+attribute [grind hom_pred] le_iff
 
 /--
-Displays the `[grind homo_pred]` entries registered by this file. The extension also
+Displays the `[grind hom_pred]` entries registered by this file. The extension also
 contains the predicates from `Init.Grind.Homo`, so we only display the theorems
 declared at the root namespace (i.e. the ones in this file).
 -/
@@ -80,35 +80,35 @@ run_meta checkInstances
 
 /-! Error conditions. -/
 
-/-- error: invalid `[grind homo_pred]` theorem, `wu` is not a proposition -/
+/-- error: invalid `[grind hom_pred]` theorem, `wu` is not a proposition -/
 #guard_msgs in
-attribute [grind homo_pred] wu
+attribute [grind hom_pred] wu
 
 axiom not_covering (x : W) (n : Nat) : 0 ≤ wu x
 
 /--
-error: invalid `[grind homo_pred]` theorem, the conclusion of `not_covering` does not contain an application whose trailing arguments are the theorem's explicit parameters
+error: invalid `[grind hom_pred]` theorem, the conclusion of `not_covering` does not contain an application whose trailing arguments are the theorem's explicit parameters
 -/
 #guard_msgs in
-attribute [grind homo_pred] not_covering
+attribute [grind hom_pred] not_covering
 
 axiom all_implicit {a b : W} : a ≤ b ↔ wu a ≤ wu b
 
 /--
-error: invalid `[grind homo_pred]` theorem, `all_implicit` must have at least one explicit parameter; the trigger is inferred from an application whose trailing arguments are the theorem's explicit parameters
+error: invalid `[grind hom_pred]` theorem, `all_implicit` must have at least one explicit parameter; the trigger is inferred from an application whose trailing arguments are the theorem's explicit parameters
 -/
 #guard_msgs in
-attribute [grind homo_pred] all_implicit
+attribute [grind hom_pred] all_implicit
 
 /-- error: homomorphism predicates must be set using the default `[grind]` attribute -/
 #guard_msgs in
-attribute [lia homo_pred] wu_lower
+attribute [lia hom_pred] wu_lower
 
 /--
-error: homomorphism predicates should be registered using the `@[grind homo_pred]` attribute
+error: homomorphism predicates should be registered using the `@[grind hom_pred]` attribute
 -/
 #guard_msgs in
-example : True := by grind [homo_pred wu_lower]
+example : True := by grind [hom_pred wu_lower]
 
 /-! `reset_grind_attrs%` clears the homo_pred extension. -/
 


### PR DESCRIPTION
This PR renames the `[grind homo]` and `[grind homo_pred]` attribute modifiers to `[grind hom]` and `[grind hom_pred]`. The previous spellings remain as deprecated aliases with identical behavior, and will be removed once the standard library migrates to the new spellings in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)