### PR TITLE
feat: complete the `[grind hom]` rename

### DIFF
--- a/src/Init/Grind/Attr.lean
+++ b/src/Init/Grind/Attr.lean
@@ -232,12 +232,6 @@ one by `a ≤ b` applications. `grind` uses the types of `a` and `b` to discard
 irrelevant instantiations.
 -/
 syntax grindHomPred := &"hom_pred"
-/-- Deprecated spelling of the `hom` modifier. It behaves like `hom` and will be
-removed. -/
-syntax grindHomo   := &"homo"
-/-- Deprecated spelling of the `hom_pred` modifier. It behaves like `hom_pred` and will
-be removed. -/
-syntax grindHomoPred := &"homo_pred"
 /--
 The `norm` modifier instructs `grind` to use a theorem as a normalization rule. That is,
 the theorem is applied during the preprocessing step.
@@ -314,7 +308,7 @@ syntax grindMod :=
     grindEqBoth <|> grindEqRhs <|> grindEq <|> grindEqBwd <|> grindBwd
     <|> grindFwd <|> grindRL <|> grindLR <|> grindUsr <|> grindCasesEager
     <|> grindCases <|> grindIntro <|> grindExt <|> grindGen <|> grindSym <|> grindInj
-    <|> grindFunCC <|> grindHomPred <|> grindHom <|> grindHomoPred <|> grindHomo
+    <|> grindFunCC <|> grindHomPred <|> grindHom
     <|> grindNorm <|> grindUnfold <|> grindDef
 
 /--

--- a/src/Init/Grind/Homo/BitVec.lean
+++ b/src/Init/Grind/Homo/BitVec.lean
@@ -16,7 +16,7 @@ The unsigned fragment is injected into `Nat` via `BitVec.toNat`, and the signed
 fragment into `Int` via `BitVec.toInt`.
 -/
 
-attribute [grind homo]
+attribute [grind hom]
   BitVec.toNat_add BitVec.toNat_sub BitVec.toNat_mul BitVec.toNat_udiv BitVec.toNat_umod
   BitVec.toNat_neg BitVec.toNat_and BitVec.toNat_or BitVec.toNat_xor
   BitVec.toNat_shiftLeft BitVec.toNat_ushiftRight BitVec.toNat_append
@@ -33,14 +33,14 @@ attribute [grind homo]
 
 /-! Homomorphism predicates: range facts for the injection functions, instantiated by
 `grind` for the terms it internalizes. The `2 * toInt` bounds are restated with an
-explicit parameter, as required by the `[grind homo_pred]` trigger inference. -/
+explicit parameter, as required by the `[grind hom_pred]` trigger inference. -/
 
-attribute [grind homo_pred] BitVec.isLt
+attribute [grind hom_pred] BitVec.isLt
 
-@[grind homo_pred] theorem Lean.Grind.BitVec.neg_two_pow_le_two_mul_toInt {w : Nat} (x : BitVec w) :
+@[grind hom_pred] theorem Lean.Grind.BitVec.neg_two_pow_le_two_mul_toInt {w : Nat} (x : BitVec w) :
     -2^w ≤ 2 * x.toInt :=
   _root_.BitVec.le_two_mul_toInt
 
-@[grind homo_pred] theorem Lean.Grind.BitVec.two_mul_toInt_lt_two_pow {w : Nat} (x : BitVec w) :
+@[grind hom_pred] theorem Lean.Grind.BitVec.two_mul_toInt_lt_two_pow {w : Nat} (x : BitVec w) :
     2 * x.toInt < 2^w :=
   _root_.BitVec.two_mul_toInt_lt

--- a/src/Init/Grind/Homo/Fin.lean
+++ b/src/Init/Grind/Homo/Fin.lean
@@ -15,19 +15,19 @@ Homomorphism rules for `Fin` used by the `grind` tactic.
 The injection function is `Fin.val`.
 -/
 
-attribute [grind homo]
+attribute [grind hom]
   Fin.val_add Fin.val_mul Fin.val_sub Fin.val_mod Fin.val_zero Fin.val_succ Fin.val_neg'
   Fin.div_val Fin.and_val Fin.or_val Fin.xor_val Fin.shiftLeft_val Fin.shiftRight_val
   Fin.val_ofNat Fin.le_def Fin.lt_def
 
-@[grind homo] theorem Lean.Grind.Fin.eq_iff_val_eq {n : Nat} (a b : Fin n) : a = b ↔ a.val = b.val :=
+@[grind hom] theorem Lean.Grind.Fin.eq_iff_val_eq {n : Nat} (a b : Fin n) : a = b ↔ a.val = b.val :=
   ⟨Fin.val_eq_of_eq, Fin.eq_of_val_eq⟩
 
-@[grind homo] theorem Lean.Grind.Fin.val_ite {n : Nat} (c : Prop) [Decidable c] (x y : Fin n) :
+@[grind hom] theorem Lean.Grind.Fin.val_ite {n : Nat} (c : Prop) [Decidable c] (x y : Fin n) :
     (if c then x else y).val = if c then x.val else y.val := by
   split <;> rfl
 
 /-! Homomorphism predicate: the range fact for `Fin.val`, instantiated by `grind` for
 the terms it internalizes. -/
 
-attribute [grind homo_pred] Fin.isLt
+attribute [grind hom_pred] Fin.isLt

--- a/src/Init/Grind/Homo/ISize.lean
+++ b/src/Init/Grind/Homo/ISize.lean
@@ -17,7 +17,7 @@ Homomorphism rules for `ISize` used by the `grind` tactic.
 The injection function is `ISize.toBitVec`.
 -/
 
-attribute [grind homo]
+attribute [grind hom]
   ISize.toBitVec_add ISize.toBitVec_sub ISize.toBitVec_mul ISize.toBitVec_div ISize.toBitVec_mod
   ISize.toBitVec_and ISize.toBitVec_or ISize.toBitVec_xor ISize.toBitVec_shiftLeft ISize.toBitVec_shiftRight
   ISize.toBitVec_zero ISize.toBitVec_one ISize.toBitVec_not ISize.toBitVec_neg
@@ -25,8 +25,8 @@ attribute [grind homo]
   ISize.toBitVec_ofNat
   ISize.toBitVec_toInt8 ISize.toBitVec_toInt16 ISize.toBitVec_toInt32 ISize.toBitVec_toInt64 ISize.toBitVec_toUSize
 
-@[grind homo] theorem Lean.Grind.ISize.toInt_eq_toBitVec_toInt (x : ISize) : x.toInt = x.toBitVec.toInt := rfl
+@[grind hom] theorem Lean.Grind.ISize.toInt_eq_toBitVec_toInt (x : ISize) : x.toInt = x.toBitVec.toInt := rfl
 
 /-! Translations of `≤` and `<` into the target domain. -/
 
-attribute [grind homo] ISize.le_iff_toInt_le ISize.lt_iff_toInt_lt
+attribute [grind hom] ISize.le_iff_toInt_le ISize.lt_iff_toInt_lt

--- a/src/Init/Grind/Homo/Int.lean
+++ b/src/Init/Grind/Homo/Int.lean
@@ -22,7 +22,7 @@ arithmetic, and the `%`-cleanup rules remove redundant modular wrappers produced
 by injections into `Int`.
 -/
 
-attribute [grind homo]
+attribute [grind hom]
   Int.natCast_add Int.natCast_mul Int.natCast_pow
   Int.shiftLeft_eq Int.shiftRight_eq_div_pow
   Int.ofNat_toNat Int.toNat_sub'
@@ -30,8 +30,8 @@ attribute [grind homo]
   Int.emod_sub_emod Int.sub_emod_emod
   Int.emod_emod
 
-@[grind homo] theorem Lean.Grind.Int.emod_mul_emod (m n k : Int) : m % n * k % n = m * k % n := by
+@[grind hom] theorem Lean.Grind.Int.emod_mul_emod (m n k : Int) : m % n * k % n = m * k % n := by
   rw [Int.mul_emod, Int.emod_emod, ← Int.mul_emod]
 
-@[grind homo] theorem Lean.Grind.Int.mul_emod_emod (m n k : Int) : m * (n % k) % k = m * n % k := by
+@[grind hom] theorem Lean.Grind.Int.mul_emod_emod (m n k : Int) : m * (n % k) % k = m * n % k := by
   rw [Int.mul_emod, Int.emod_emod, ← Int.mul_emod]

--- a/src/Init/Grind/Homo/Int16.lean
+++ b/src/Init/Grind/Homo/Int16.lean
@@ -17,7 +17,7 @@ Homomorphism rules for `Int16` used by the `grind` tactic.
 The injection function is `Int16.toBitVec`.
 -/
 
-attribute [grind homo]
+attribute [grind hom]
   Int16.toBitVec_add Int16.toBitVec_sub Int16.toBitVec_mul Int16.toBitVec_div Int16.toBitVec_mod
   Int16.toBitVec_and Int16.toBitVec_or Int16.toBitVec_xor Int16.toBitVec_shiftLeft Int16.toBitVec_shiftRight
   Int16.toBitVec_zero Int16.toBitVec_one Int16.toBitVec_not Int16.toBitVec_neg
@@ -25,8 +25,8 @@ attribute [grind homo]
   Int16.toBitVec_ofNat
   Int16.toBitVec_toInt8 Int16.toBitVec_toInt32 Int16.toBitVec_toInt64 Int16.toBitVec_toISize Int16.toBitVec_toUInt16
 
-@[grind homo] theorem Lean.Grind.Int16.toInt_eq_toBitVec_toInt (x : Int16) : x.toInt = x.toBitVec.toInt := rfl
+@[grind hom] theorem Lean.Grind.Int16.toInt_eq_toBitVec_toInt (x : Int16) : x.toInt = x.toBitVec.toInt := rfl
 
 /-! Translations of `≤` and `<` into the target domain. -/
 
-attribute [grind homo] Int16.le_iff_toInt_le Int16.lt_iff_toInt_lt
+attribute [grind hom] Int16.le_iff_toInt_le Int16.lt_iff_toInt_lt

--- a/src/Init/Grind/Homo/Int32.lean
+++ b/src/Init/Grind/Homo/Int32.lean
@@ -17,7 +17,7 @@ Homomorphism rules for `Int32` used by the `grind` tactic.
 The injection function is `Int32.toBitVec`.
 -/
 
-attribute [grind homo]
+attribute [grind hom]
   Int32.toBitVec_add Int32.toBitVec_sub Int32.toBitVec_mul Int32.toBitVec_div Int32.toBitVec_mod
   Int32.toBitVec_and Int32.toBitVec_or Int32.toBitVec_xor Int32.toBitVec_shiftLeft Int32.toBitVec_shiftRight
   Int32.toBitVec_zero Int32.toBitVec_one Int32.toBitVec_not Int32.toBitVec_neg
@@ -25,8 +25,8 @@ attribute [grind homo]
   Int32.toBitVec_ofNat
   Int32.toBitVec_toInt8 Int32.toBitVec_toInt16 Int32.toBitVec_toInt64 Int32.toBitVec_toISize Int32.toBitVec_toUInt32
 
-@[grind homo] theorem Lean.Grind.Int32.toInt_eq_toBitVec_toInt (x : Int32) : x.toInt = x.toBitVec.toInt := rfl
+@[grind hom] theorem Lean.Grind.Int32.toInt_eq_toBitVec_toInt (x : Int32) : x.toInt = x.toBitVec.toInt := rfl
 
 /-! Translations of `≤` and `<` into the target domain. -/
 
-attribute [grind homo] Int32.le_iff_toInt_le Int32.lt_iff_toInt_lt
+attribute [grind hom] Int32.le_iff_toInt_le Int32.lt_iff_toInt_lt

--- a/src/Init/Grind/Homo/Int64.lean
+++ b/src/Init/Grind/Homo/Int64.lean
@@ -17,7 +17,7 @@ Homomorphism rules for `Int64` used by the `grind` tactic.
 The injection function is `Int64.toBitVec`.
 -/
 
-attribute [grind homo]
+attribute [grind hom]
   Int64.toBitVec_add Int64.toBitVec_sub Int64.toBitVec_mul Int64.toBitVec_div Int64.toBitVec_mod
   Int64.toBitVec_and Int64.toBitVec_or Int64.toBitVec_xor Int64.toBitVec_shiftLeft Int64.toBitVec_shiftRight
   Int64.toBitVec_zero Int64.toBitVec_one Int64.toBitVec_not Int64.toBitVec_neg
@@ -25,8 +25,8 @@ attribute [grind homo]
   Int64.toBitVec_ofNat
   Int64.toBitVec_toInt8 Int64.toBitVec_toInt16 Int64.toBitVec_toInt32 Int64.toBitVec_toISize Int64.toBitVec_toUInt64
 
-@[grind homo] theorem Lean.Grind.Int64.toInt_eq_toBitVec_toInt (x : Int64) : x.toInt = x.toBitVec.toInt := rfl
+@[grind hom] theorem Lean.Grind.Int64.toInt_eq_toBitVec_toInt (x : Int64) : x.toInt = x.toBitVec.toInt := rfl
 
 /-! Translations of `≤` and `<` into the target domain. -/
 
-attribute [grind homo] Int64.le_iff_toInt_le Int64.lt_iff_toInt_lt
+attribute [grind hom] Int64.le_iff_toInt_le Int64.lt_iff_toInt_lt

--- a/src/Init/Grind/Homo/Int8.lean
+++ b/src/Init/Grind/Homo/Int8.lean
@@ -17,7 +17,7 @@ Homomorphism rules for `Int8` used by the `grind` tactic.
 The injection function is `Int8.toBitVec`.
 -/
 
-attribute [grind homo]
+attribute [grind hom]
   Int8.toBitVec_add Int8.toBitVec_sub Int8.toBitVec_mul Int8.toBitVec_div Int8.toBitVec_mod
   Int8.toBitVec_and Int8.toBitVec_or Int8.toBitVec_xor Int8.toBitVec_shiftLeft Int8.toBitVec_shiftRight
   Int8.toBitVec_zero Int8.toBitVec_one Int8.toBitVec_not Int8.toBitVec_neg
@@ -25,8 +25,8 @@ attribute [grind homo]
   Int8.toBitVec_ofNat
   Int8.toBitVec_toInt16 Int8.toBitVec_toInt32 Int8.toBitVec_toInt64 Int8.toBitVec_toISize Int8.toBitVec_toUInt8
 
-@[grind homo] theorem Lean.Grind.Int8.toInt_eq_toBitVec_toInt (x : Int8) : x.toInt = x.toBitVec.toInt := rfl
+@[grind hom] theorem Lean.Grind.Int8.toInt_eq_toBitVec_toInt (x : Int8) : x.toInt = x.toBitVec.toInt := rfl
 
 /-! Translations of `≤` and `<` into the target domain. -/
 
-attribute [grind homo] Int8.le_iff_toInt_le Int8.lt_iff_toInt_lt
+attribute [grind hom] Int8.le_iff_toInt_le Int8.lt_iff_toInt_lt

--- a/src/Init/Grind/Homo/List.lean
+++ b/src/Init/Grind/Homo/List.lean
@@ -20,7 +20,7 @@ Homomorphism rules for `List` used by the `grind` tactic.
 The injection function is `List.length`.
 -/
 
-attribute [grind homo]
+attribute [grind hom]
   List.length_nil List.length_cons List.length_append List.length_drop List.length_take
   List.length_reverse List.length_map List.length_replicate List.length_tail List.length_concat
   List.length_zipWith List.length_zip List.length_set List.length_insertIdx List.length_eraseIdx

--- a/src/Init/Grind/Homo/Nat.lean
+++ b/src/Init/Grind/Homo/Nat.lean
@@ -17,7 +17,7 @@ decomposes bitwise operations, and the `%`-cleanup rules remove the redundant
 modular wrappers produced by the `BitVec.toNat` injection.
 -/
 
-attribute [grind homo]
+attribute [grind hom]
   Nat.shiftLeft_eq Nat.shiftRight_eq_div_pow
   Nat.mod_add_mod Nat.add_mod_mod Nat.mod_mul_mod Nat.mul_mod_mod
   Nat.testBit_and Nat.testBit_or Nat.testBit_xor

--- a/src/Init/Grind/Homo/UInt16.lean
+++ b/src/Init/Grind/Homo/UInt16.lean
@@ -17,7 +17,7 @@ Homomorphism rules for `UInt16` used by the `grind` tactic.
 The injection function is `UInt16.toBitVec`.
 -/
 
-attribute [grind homo]
+attribute [grind hom]
   UInt16.toBitVec_add UInt16.toBitVec_sub UInt16.toBitVec_mul UInt16.toBitVec_div UInt16.toBitVec_mod
   UInt16.toBitVec_and UInt16.toBitVec_or UInt16.toBitVec_xor UInt16.toBitVec_shiftLeft UInt16.toBitVec_shiftRight
   UInt16.toBitVec_zero UInt16.toBitVec_one UInt16.toBitVec_not UInt16.toBitVec_neg
@@ -25,8 +25,8 @@ attribute [grind homo]
   UInt16.toBitVec_ofNat UInt16.toBitVec_ofNat'
   UInt16.toBitVec_toUInt8 UInt16.toBitVec_toUInt32 UInt16.toBitVec_toUInt64 UInt16.toBitVec_toUSize UInt16.toBitVec_toInt16
 
-@[grind homo] theorem Lean.Grind.UInt16.toNat_eq_toBitVec_toNat (x : UInt16) : x.toNat = x.toBitVec.toNat := rfl
+@[grind hom] theorem Lean.Grind.UInt16.toNat_eq_toBitVec_toNat (x : UInt16) : x.toNat = x.toBitVec.toNat := rfl
 
 /-! Translations of `≤` and `<` into the target domain. -/
 
-attribute [grind homo] UInt16.le_iff_toBitVec_le UInt16.lt_iff_toBitVec_lt
+attribute [grind hom] UInt16.le_iff_toBitVec_le UInt16.lt_iff_toBitVec_lt

--- a/src/Init/Grind/Homo/UInt32.lean
+++ b/src/Init/Grind/Homo/UInt32.lean
@@ -17,7 +17,7 @@ Homomorphism rules for `UInt32` used by the `grind` tactic.
 The injection function is `UInt32.toBitVec`.
 -/
 
-attribute [grind homo]
+attribute [grind hom]
   UInt32.toBitVec_add UInt32.toBitVec_sub UInt32.toBitVec_mul UInt32.toBitVec_div UInt32.toBitVec_mod
   UInt32.toBitVec_and UInt32.toBitVec_or UInt32.toBitVec_xor UInt32.toBitVec_shiftLeft UInt32.toBitVec_shiftRight
   UInt32.toBitVec_zero UInt32.toBitVec_one UInt32.toBitVec_not UInt32.toBitVec_neg
@@ -25,8 +25,8 @@ attribute [grind homo]
   UInt32.toBitVec_ofNat UInt32.toBitVec_ofNat'
   UInt32.toBitVec_toUInt8 UInt32.toBitVec_toUInt16 UInt32.toBitVec_toUInt64 UInt32.toBitVec_toUSize UInt32.toBitVec_toInt32
 
-@[grind homo] theorem Lean.Grind.UInt32.toNat_eq_toBitVec_toNat (x : UInt32) : x.toNat = x.toBitVec.toNat := rfl
+@[grind hom] theorem Lean.Grind.UInt32.toNat_eq_toBitVec_toNat (x : UInt32) : x.toNat = x.toBitVec.toNat := rfl
 
 /-! Translations of `≤` and `<` into the target domain. -/
 
-attribute [grind homo] UInt32.le_iff_toBitVec_le UInt32.lt_iff_toBitVec_lt
+attribute [grind hom] UInt32.le_iff_toBitVec_le UInt32.lt_iff_toBitVec_lt

--- a/src/Init/Grind/Homo/UInt64.lean
+++ b/src/Init/Grind/Homo/UInt64.lean
@@ -17,7 +17,7 @@ Homomorphism rules for `UInt64` used by the `grind` tactic.
 The injection function is `UInt64.toBitVec`.
 -/
 
-attribute [grind homo]
+attribute [grind hom]
   UInt64.toBitVec_add UInt64.toBitVec_sub UInt64.toBitVec_mul UInt64.toBitVec_div UInt64.toBitVec_mod
   UInt64.toBitVec_and UInt64.toBitVec_or UInt64.toBitVec_xor UInt64.toBitVec_shiftLeft UInt64.toBitVec_shiftRight
   UInt64.toBitVec_zero UInt64.toBitVec_one UInt64.toBitVec_not UInt64.toBitVec_neg
@@ -25,8 +25,8 @@ attribute [grind homo]
   UInt64.toBitVec_ofNat UInt64.toBitVec_ofNat'
   UInt64.toBitVec_toUInt8 UInt64.toBitVec_toUInt16 UInt64.toBitVec_toUInt32 UInt64.toBitVec_toUSize UInt64.toBitVec_toInt64
 
-@[grind homo] theorem Lean.Grind.UInt64.toNat_eq_toBitVec_toNat (x : UInt64) : x.toNat = x.toBitVec.toNat := rfl
+@[grind hom] theorem Lean.Grind.UInt64.toNat_eq_toBitVec_toNat (x : UInt64) : x.toNat = x.toBitVec.toNat := rfl
 
 /-! Translations of `≤` and `<` into the target domain. -/
 
-attribute [grind homo] UInt64.le_iff_toBitVec_le UInt64.lt_iff_toBitVec_lt
+attribute [grind hom] UInt64.le_iff_toBitVec_le UInt64.lt_iff_toBitVec_lt

--- a/src/Init/Grind/Homo/UInt8.lean
+++ b/src/Init/Grind/Homo/UInt8.lean
@@ -17,7 +17,7 @@ Homomorphism rules for `UInt8` used by the `grind` tactic.
 The injection function is `UInt8.toBitVec`.
 -/
 
-attribute [grind homo]
+attribute [grind hom]
   UInt8.toBitVec_add UInt8.toBitVec_sub UInt8.toBitVec_mul UInt8.toBitVec_div UInt8.toBitVec_mod
   UInt8.toBitVec_and UInt8.toBitVec_or UInt8.toBitVec_xor UInt8.toBitVec_shiftLeft UInt8.toBitVec_shiftRight
   UInt8.toBitVec_zero UInt8.toBitVec_one UInt8.toBitVec_not UInt8.toBitVec_neg
@@ -25,8 +25,8 @@ attribute [grind homo]
   UInt8.toBitVec_ofNat UInt8.toBitVec_ofNat'
   UInt8.toBitVec_toUInt16 UInt8.toBitVec_toUInt32 UInt8.toBitVec_toUInt64 UInt8.toBitVec_toUSize UInt8.toBitVec_toInt8
 
-@[grind homo] theorem Lean.Grind.UInt8.toNat_eq_toBitVec_toNat (x : UInt8) : x.toNat = x.toBitVec.toNat := rfl
+@[grind hom] theorem Lean.Grind.UInt8.toNat_eq_toBitVec_toNat (x : UInt8) : x.toNat = x.toBitVec.toNat := rfl
 
 /-! Translations of `≤` and `<` into the target domain. -/
 
-attribute [grind homo] UInt8.le_iff_toBitVec_le UInt8.lt_iff_toBitVec_lt
+attribute [grind hom] UInt8.le_iff_toBitVec_le UInt8.lt_iff_toBitVec_lt

--- a/src/Init/Grind/Homo/USize.lean
+++ b/src/Init/Grind/Homo/USize.lean
@@ -17,7 +17,7 @@ Homomorphism rules for `USize` used by the `grind` tactic.
 The injection function is `USize.toBitVec`.
 -/
 
-attribute [grind homo]
+attribute [grind hom]
   USize.toBitVec_add USize.toBitVec_sub USize.toBitVec_mul USize.toBitVec_div USize.toBitVec_mod
   USize.toBitVec_and USize.toBitVec_or USize.toBitVec_xor USize.toBitVec_shiftLeft USize.toBitVec_shiftRight
   USize.toBitVec_zero USize.toBitVec_one USize.toBitVec_not USize.toBitVec_neg
@@ -25,8 +25,8 @@ attribute [grind homo]
   USize.toBitVec_ofNat USize.toBitVec_ofNat'
   USize.toBitVec_toUInt8 USize.toBitVec_toUInt16 USize.toBitVec_toUInt32 USize.toBitVec_toUInt64 USize.toBitVec_toISize
 
-@[grind homo] theorem Lean.Grind.USize.toNat_eq_toBitVec_toNat (x : USize) : x.toNat = x.toBitVec.toNat := rfl
+@[grind hom] theorem Lean.Grind.USize.toNat_eq_toBitVec_toNat (x : USize) : x.toNat = x.toBitVec.toNat := rfl
 
 /-! Translations of `≤` and `<` into the target domain. -/
 
-attribute [grind homo] USize.le_iff_toBitVec_le USize.lt_iff_toBitVec_lt
+attribute [grind hom] USize.le_iff_toBitVec_le USize.lt_iff_toBitVec_lt

--- a/src/Lean/Meta/Tactic/Grind/Attr.lean
+++ b/src/Lean/Meta/Tactic/Grind/Attr.lean
@@ -65,8 +65,6 @@ def getAttrKindCore (stx : Syntax) : CoreM AttrKind := do
   | `(Parser.Attr.grindMod|unfold) => return .unfold
   | `(Parser.Attr.grindMod|hom) => return .homo
   | `(Parser.Attr.grindMod|hom_pred) => return .homoPred
-  | `(Parser.Attr.grindMod|homo) => return .homo
-  | `(Parser.Attr.grindMod|homo_pred) => return .homoPred
   | `(Parser.Attr.grindMod|symbol $prio:prio) =>
     let some prio := prio.raw.isNatLit? | throwErrorAt prio "priority expected"
     return .symbol prio

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,3 +1,4 @@
+// update me!
 #include "util/options.h"
 
 // Should we test stage 2 and run update-stage0 on PR merge? NO

--- a/tests/elab/grind_hom_attr.lean
+++ b/tests/elab/grind_hom_attr.lean
@@ -122,17 +122,6 @@ homomorphism rules translate concrete types; generic injections cannot be tracke
 #guard_msgs in
 attribute [grind hom] toI_eq
 
-/-! The deprecated spellings behave like `hom`/`hom_pred`. -/
-
-#guard_msgs in
-attribute [grind homo] wu_mul
-
-/--
-error: homomorphism rules should be registered using the `@[grind hom]` attribute
--/
-#guard_msgs in
-example : True := by grind [homo wu_add]
-
 /-! `reset_grind_attrs%` clears the homo extension and the recorded source types. -/
 
 reset_grind_attrs%


### PR DESCRIPTION
This PR migrates the standard library to the `[grind hom]` and `[grind hom_pred]` attribute modifiers and removes the deprecated `[grind homo]` and `[grind homo_pred]` spellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)