### PR TITLE
fix: read `vcgen` goal type through a tactic `have`/`let` annotation

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
@@ -140,6 +140,7 @@ program type is returned, so deep embeddings key on their own head. Returns `non
 exposes no program. -/
 public def inferProgType? (goalType : Expr) : MetaM (Option Expr) := withReducible do
   forallTelescopeReducing goalType fun _ body => do
+    let body := body.consumeMData
     let progTy? : Option Expr :=
       if let some info := isWPApp? body then
         some info.Prog

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -55,6 +55,12 @@ private def isDuplicable (e : Expr) : Bool := match e with
   | .lam .. | .forallE .. | .letE .. => false
   | .app .. => e.isAppOf ``OfNat.ofNat
 
+/-- Strip an annotation, such as the `noImplicitLambda` metadata a tactic `have`/`let`/`suffices`
+leaves on the goal, so later strategies and the backward rules they invoke see the bare target. -/
+private def consumeMData? (goal : MVarId) (target : Expr) : VCGenM (Option MVarId) := do
+  unless target.isMData do return none
+  return some (← goal.replaceTargetDefEqFast target.consumeMData)
+
 /-- Strategy 1: simp the target, then introduce binders if the target is a `∀`. -/
 private def forallIntro? (goal : MVarId) (target : Expr) : VCGenM (Option (List MVarId)) := do
   unless target.isForall do return none
@@ -505,6 +511,7 @@ public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := g
   trace[Elab.Tactic.Do.vcgen] "🎯 Target: {target}"
 
   -- Phase 1: simplify `target` until it is of the form `pre ⊑ rhs`.
+  if let some g ← consumeMData? goal target then return .goals scope [g]
   if let some gs ← forallIntro? goal target then return .goals scope gs
   if let some g ← targetLetIntro? goal target then return .goals scope [g]
   if let some g ← tripleUnfold? goal target then return .goals scope [g]

--- a/tests/elab/vcgenHaveGoalMData.lean
+++ b/tests/elab/vcgenHaveGoalMData.lean
@@ -1,0 +1,17 @@
+import Std.Internal.Do
+import Std.Tactic.Do
+
+/-! A tactic `have`/`let`/`suffices` wraps the goal in `noImplicitLambda` `mdata` (via
+`refine_lift no_implicit_lambda% …`). `vcgen` must read the program type through that annotation. -/
+
+set_option mvcgen.warning false
+
+open Std.Internal.Do Lean.Order
+
+example : ⦃fun _ => True⦄ (pure 1 : StateM Nat Nat) ⦃fun _ _ => True⦄ := by
+  have _h : True := trivial
+  vcgen
+
+example : ⦃fun _ => True⦄ (pure 1 : StateM Nat Nat) ⦃fun _ _ => True⦄ := by
+  let _n : Nat := 0
+  vcgen


### PR DESCRIPTION
This PR makes `vcgen` work after a preceding tactic `have`, `let`, or `suffices`, which previously failed with "vcgen: could not determine the program type of the goal".

Those tactics desugar through `refine_lift no_implicit_lambda% …`, wrapping the resulting goal type in a `noImplicitLambda` `mdata` node. `vcgen` classifies the goal by its head, which the annotation hid: `inferProgType?` returned `none`, and the goal-shape dispatch in `solve` fell through so the whole triple was emitted as an untouched VC. Both now consume the metadata before inspecting the head.