### PR TITLE
fix: do not pass an unitialized variable in `run_init`

### DIFF
--- a/src/library/ir_interpreter.cpp
+++ b/src/library/ir_interpreter.cpp
@@ -1126,7 +1126,7 @@ public:
 
     object * run_init(name const & decl, name const & init_decl) {
         try {
-            object * args[] = {};
+            object * args[] = { io_mk_world() };
             object * r = call_boxed(init_decl, 1, args);
             if (io_result_is_ok(r)) {
                 object * o = io_result_get_value(r);


### PR DESCRIPTION
This PR fixes a sanitizer warning where `initialize` functions were passed uninitialized memory as their `world` argument, by failing to call `io_mk_world`.

This was flagged by a memory sanitizer build.