### PR TITLE
feat: deprecate options via deprecated tag

### DIFF
--- a/src/Lean/Data/Options.lean
+++ b/src/Lean/Data/Options.lean
@@ -228,7 +228,27 @@ protected def register [KVMap.Value α] (name : Name) (decl : Lean.Option.Decl �
 macro (name := registerBuiltinOption) doc?:(docComment)? vis?:(visibility)? "register_builtin_option" name:ident " : " type:term " := " decl:term : command =>
   `($[$doc?]? $[$vis?:visibility]? builtin_initialize $name : Lean.Option $type ← Lean.Option.register $(quote name.getId) $decl)
 
-macro (name := registerOption) mods:declModifiers "register_option" name:ident " : " type:term " := " decl:term : command =>
+private meta def declWithDeprecation (attr : Syntax) (type decl : Term) : MacroM Term := do
+  let `(attr| deprecated $[$_]? $[$text?]? $[(since := $since?)]?) := attr | return decl
+  let since : Term ← match since? with | some s => pure s | none => `("")
+  match text? with
+  | some text => `({ ($decl : Lean.Option.Decl $type) with deprecation? := some { since := $since, text? := some $text } })
+  | none      => `({ ($decl : Lean.Option.Decl $type) with deprecation? := some { since := $since } })
+
+macro (name := registerOption) mods:declModifiers "register_option" name:ident " : " type:term " := " decl:term : command => do
+  let attr? := mods.raw.find? (·.isOfKind ``Lean.deprecated)
+  -- The `deprecation?` field is internal: it is populated from the `@[deprecated]` attribute below.
+  let field? := decl.raw.find? (·.getId == `deprecation?)
+  let decl ← match attr?, field? with
+    | some _, some field =>
+      Macro.throwErrorAt field "remove the `deprecation?` field: it is populated automatically from \
+        the option's `@[deprecated]` attribute"
+    | none, some field =>
+      Macro.throwErrorAt field "do not set the `deprecation?` field directly; it is an internal \
+        implementation detail. Deprecate the option with a `@[deprecated \"...\" (since := \"...\")]` \
+        attribute instead"
+    | some attr, none => declWithDeprecation attr type decl
+    | none, none => pure decl
   `($mods:declModifiers initialize $name : Lean.Option $type ← Lean.Option.register $(quote name.getId) $decl)
 
 end Option

--- a/src/Lean/Data/Options.lean
+++ b/src/Lean/Data/Options.lean
@@ -85,6 +85,8 @@ end Options
 structure OptionDeprecation where
   since    : String
   text?    : Option String := none
+  /-- The option to use instead, taken from the `@[deprecated <name>]` attribute. -/
+  newName? : Option Name := none
   deriving Inhabited
 
 structure OptionDecl where
@@ -229,11 +231,12 @@ macro (name := registerBuiltinOption) doc?:(docComment)? vis?:(visibility)? "reg
   `($[$doc?]? $[$vis?:visibility]? builtin_initialize $name : Lean.Option $type ← Lean.Option.register $(quote name.getId) $decl)
 
 private meta def declWithDeprecation (attr : Syntax) (type decl : Term) : MacroM Term := do
-  let `(attr| deprecated $[$_]? $[$text?]? $[(since := $since?)]?) := attr | return decl
+  let `(attr| deprecated $[$id?]? $[$text?]? $[(since := $since?)]?) := attr | return decl
   let since : Term ← match since? with | some s => pure s | none => `("")
-  match text? with
-  | some text => `({ ($decl : Lean.Option.Decl $type) with deprecation? := some { since := $since, text? := some $text } })
-  | none      => `({ ($decl : Lean.Option.Decl $type) with deprecation? := some { since := $since } })
+  let text : Term ← match text? with | some text => `(some $text) | none => `(none)
+  let newName : Term ← match id? with | some id => `(some ($id).name) | none => `(none)
+  `({ ($decl : Lean.Option.Decl $type) with
+      deprecation? := some { since := $since, text? := $text, newName? := $newName } })
 
 macro (name := registerOption) mods:declModifiers "register_option" name:ident " : " type:term " := " decl:term : command => do
   let attr? := mods.raw.find? (·.isOfKind ``Lean.deprecated)

--- a/src/Lean/Elab/SetOption.lean
+++ b/src/Lean/Elab/SetOption.lean
@@ -90,9 +90,10 @@ variable {m : Type → Type} [Monad m] [MonadOptions m] [MonadLog m] [AddMessage
 def checkDeprecatedOption (optionName : Name) (decl : OptionDecl) : m Unit := do
   unless linter.deprecated.options.get (← getOptions) do return
   let some dep := decl.deprecation? | return
-  let extraMsg := match dep.text? with
-    | some text => m!": {text}"
-    | none => m!""
+  let extraMsg := match dep.text?, dep.newName? with
+    | some text, _ => m!": {text}"
+    | none, some newName => m!": Use `{newName}` instead"
+    | none, none => m!""
   logWarning m!"`{optionName}` has been deprecated{extraMsg}"
 
 end Lean.Elab

--- a/tests/elab/deprecate_option_meta.lean
+++ b/tests/elab/deprecate_option_meta.lean
@@ -1,0 +1,47 @@
+import Lean.Data.Options
+
+/-!
+Options are deprecated with a `@[deprecated]` attribute on `register_option`, which warns on
+meta-code references to the option. `register_option` mirrors the attribute's message and `since`
+into the option's internal `deprecation?` field so that `set_option` also warns (the `set_option`
+side requires the option to be registered in an imported module; see `deprecatedOptions.lean`).
+
+The `deprecation?` field is an internal implementation detail: setting it directly on
+`register_option` is an error.
+-/
+
+open Lean
+
+-- The harness runs with `linter.all` disabled; re-enable the deprecation linter explicitly.
+set_option linter.deprecated true
+
+-- A `@[deprecated]` attribute makes meta-code references to the option warn.
+@[deprecated "use `myOwn.newOpt` instead" (since := "2026-01-15")]
+register_option myOwn.deprecatedOpt : Bool := { defValue := true, descr := "an option" }
+
+/-- warning: `myOwn.deprecatedOpt` has been deprecated: use `myOwn.newOpt` instead -/
+#guard_msgs in
+def usesDeprecatedOpt (o : Options) : Bool := myOwn.deprecatedOpt.get o
+
+-- A non-deprecated option does not warn.
+register_option myOwn.plainOpt : Nat := { defValue := 3, descr := "a plain option" }
+
+#guard_msgs in
+def usesPlainOpt (o : Options) : Nat := myOwn.plainOpt.get o
+
+-- Setting `deprecation?` directly is an error: it is internal and populated from the attribute.
+/--
+error: do not set the `deprecation?` field directly; it is an internal implementation detail. Deprecate the option with a `@[deprecated "..." (since := "...")]` attribute instead
+-/
+#guard_msgs in
+register_option myOwn.badFieldOnly : Bool :=
+  { defValue := true, descr := "d", deprecation? := some { since := "2026-01-15" } }
+
+-- Providing both the attribute and the field is also an error: the field is redundant.
+/--
+error: remove the `deprecation?` field: it is populated automatically from the option's `@[deprecated]` attribute
+-/
+#guard_msgs in
+@[deprecated "msg" (since := "2026-01-15")]
+register_option myOwn.badBoth : Bool :=
+  { defValue := true, descr := "d", deprecation? := some { since := "2026-01-15" } }

--- a/tests/elab/deprecate_option_meta.lean
+++ b/tests/elab/deprecate_option_meta.lean
@@ -2,8 +2,9 @@ import Lean.Data.Options
 
 /-!
 Options are deprecated with a `@[deprecated]` attribute on `register_option`, which warns on
-meta-code references to the option. `register_option` mirrors the attribute's message and `since`
-into the option's internal `deprecation?` field so that `set_option` also warns (the `set_option`
+meta-code references to the option. `register_option` mirrors the attribute's replacement name,
+message, and `since` into the option's internal `deprecation?` field so that `set_option` also warns
+(the `set_option`
 side requires the option to be registered in an imported module; see `deprecatedOptions.lean`).
 
 The `deprecation?` field is an internal implementation detail: setting it directly on
@@ -28,6 +29,16 @@ register_option myOwn.plainOpt : Nat := { defValue := 3, descr := "a plain optio
 
 #guard_msgs in
 def usesPlainOpt (o : Options) : Nat := myOwn.plainOpt.get o
+
+-- A `@[deprecated <name>]` attribute names a replacement option instead of a custom message.
+register_option myOwn.newOpt : Bool := { defValue := true, descr := "the replacement option" }
+
+@[deprecated myOwn.newOpt (since := "2026-01-15")]
+register_option myOwn.deprecatedByName : Bool := { defValue := true, descr := "an option" }
+
+/-- warning: `myOwn.deprecatedByName` has been deprecated: Use `myOwn.newOpt` instead -/
+#guard_msgs in
+def usesDeprecatedByName (o : Options) : Bool := myOwn.deprecatedByName.get o
 
 -- Setting `deprecation?` directly is an error: it is internal and populated from the attribute.
 /--

--- a/tests/pkg/deprecated_option/DeprecatedOption/Def.lean
+++ b/tests/pkg/deprecated_option/DeprecatedOption/Def.lean
@@ -1,21 +1,20 @@
 import Lean
 
 -- Deprecated option without custom text
-register_option test.deprecated.plain : Bool := {
-  defValue := false
-  descr := "A test option."
-  deprecation? := some { since := "2026-04-01" }
-}
-
--- Deprecated option with custom text
-register_option test.deprecated.withText : Nat := {
-  defValue := 42
-  descr := "Another test option."
-  deprecation? := some { since := "2026-04-01", text? := some "use `test.newOption` instead" }
-}
-
--- Non-deprecated option (for comparison)
 register_option test.notDeprecated : Bool := {
   defValue := true
   descr := "A non-deprecated test option."
+}
+
+@[deprecated test.notDeprecated (since := "2026-04-01")]
+register_option test.deprecated.plain : Bool := {
+  defValue := false
+  descr := "A test option."
+}
+
+-- Deprecated option with custom text
+@[deprecated "use `test.newOption` instead" (since := "2026-06-01")]
+register_option test.deprecated.withText : Nat := {
+  defValue := 42
+  descr := "Another test option."
 }

--- a/tests/pkg/deprecated_option/DeprecatedOption/Use.lean
+++ b/tests/pkg/deprecated_option/DeprecatedOption/Use.lean
@@ -1,8 +1,8 @@
 import DeprecatedOption.Def
 
--- Cross-file: deprecated option without custom text
+-- Cross-file: deprecated option pointing at a replacement option
 /--
-warning: `test.deprecated.plain` has been deprecated
+warning: `test.deprecated.plain` has been deprecated: Use `test.notDeprecated` instead
 -/
 #guard_msgs in
 set_option test.deprecated.plain true
@@ -20,7 +20,7 @@ set_option test.notDeprecated false
 
 -- set_option ... in block
 /--
-warning: `test.deprecated.plain` has been deprecated
+warning: `test.deprecated.plain` has been deprecated: Use `test.notDeprecated` instead
 -/
 #guard_msgs in
 set_option test.deprecated.plain true in
@@ -36,7 +36,7 @@ example := 0
 
 -- Nested deprecated options in set_option ... in blocks
 /--
-warning: `test.deprecated.plain` has been deprecated
+warning: `test.deprecated.plain` has been deprecated: Use `test.notDeprecated` instead
 ---
 warning: `test.deprecated.withText` has been deprecated: use `test.newOption` instead
 -/
@@ -47,7 +47,7 @@ example := 0
 
 -- Tactic context
 /--
-warning: `test.deprecated.plain` has been deprecated
+warning: `test.deprecated.plain` has been deprecated: Use `test.notDeprecated` instead
 -/
 #guard_msgs in
 example : True := by


### PR DESCRIPTION
This PR changes the way we deprecate user-registered options (added via `register_option`). To ensure we get warnings both when interacting with option using `set_option` and in meta code, we require the deprecation to happen via `@[deprecated]` attribute, and we populate the internal `deprecation?` field using the information from that attribute.