### PR TITLE
RFC/draft: linear `instantiateMVars` for delayed-assignment chains with shared subterms

### DIFF
--- a/src/library/instantiate_mvars.cpp
+++ b/src/library/instantiate_mvars.cpp
@@ -385,6 +385,70 @@ class instantiate_delayed_fn {
     name_set m_already_normalized;
     std::vector<expr> m_saved;
 
+    /* Fast path for the delayed-assignment collapse. A subterm that contains no
+       fvar currently being abstracted (and no mvar) is returned unchanged at
+       every binder depth, so it is memoized per pointer rather than per
+       (pointer, depth). This turns the collapse of a long delayed chain over a
+       shared, fvar-stable subterm from quadratic into linear.
+
+       m_abstracted_fvars grows monotonically with the fvars of each crossed
+       delayed-assigned MVar. m_free_of_abstracted memoizes, per pointer, whether
+       a subterm is free of all of them. m_encountered records every fvar the
+       freeness scan has seen, so abstracting an fvar that already appeared (the
+       revert-an-outer-fvar case) can invalidate the now-stale memo. */
+    name_set m_abstracted_fvars;
+    name_set m_encountered;
+    lean::unordered_map<lean_object *, bool> m_free_of_abstracted;
+
+    bool free_of_abstracted(expr const & e) {
+        if (!has_fvar(e))
+            return true;
+        if (is_shared(e)) {
+            auto it = m_free_of_abstracted.find(e.raw());
+            if (it != m_free_of_abstracted.end())
+                return it->second;
+        }
+        bool r = free_of_abstracted_core(e);
+        if (is_shared(e))
+            m_free_of_abstracted.insert(mk_pair(e.raw(), r));
+        return r;
+    }
+
+    bool free_of_abstracted_core(expr const & e) {
+        switch (e.kind()) {
+        case expr_kind::FVar: {
+            name const & fid = fvar_name(e);
+            m_encountered.insert(fid);
+            return !m_abstracted_fvars.contains(fid);
+        }
+        case expr_kind::App: {
+            /* Visit both children unconditionally (no && short-circuit) so
+               every fvar is recorded in m_encountered. */
+            bool f = free_of_abstracted(app_fn(e));
+            bool a = free_of_abstracted(app_arg(e));
+            return f && a;
+        }
+        case expr_kind::Lambda: case expr_kind::Pi: {
+            bool d = free_of_abstracted(binding_domain(e));
+            bool b = free_of_abstracted(binding_body(e));
+            return d && b;
+        }
+        case expr_kind::Let: {
+            bool t = free_of_abstracted(let_type(e));
+            bool v = free_of_abstracted(let_value(e));
+            bool b = free_of_abstracted(let_body(e));
+            return t && v && b;
+        }
+        case expr_kind::MData:
+            return free_of_abstracted(mdata_expr(e));
+        case expr_kind::Proj:
+            return free_of_abstracted(proj_expr(e));
+        default:
+            /* Sort, Const, Lit, MVar, BVar carry no fvars. */
+            return true;
+        }
+    }
+
     /* Resolvability caches — persistent across all delayed-assigned MVar
        resolutions. A pending MVar is resolvable if its assigned value
        (normalized by pass 1) would become MVar-free after resolution: all
@@ -528,6 +592,7 @@ class instantiate_delayed_fn {
         struct saved_entry { name key; bool had_old; fvar_subst_entry old; };
         std::vector<saved_entry> saved_entries;
         saved_entries.reserve(fvar_count);
+        bool must_invalidate = false;
         for (size_t i = 0; i < fvar_count; i++) {
             name const & fid = fvar_name(fvars[i]);
             auto old_it = m_fvar_subst.find(fid);
@@ -537,7 +602,17 @@ class instantiate_delayed_fn {
                 saved_entries.push_back({fid, false, {0, 0, expr()}});
             }
             m_fvar_subst[fid] = {m_depth, m_cache.scope(), args[args.size() - 1 - i]};
+            /* Grow the abstracted-fvar set. If this fvar already appeared in a
+               freeness scan, a cached "free" verdict may now be stale, so drop
+               the memo. This never fires for freshly-introduced binders. */
+            if (!m_abstracted_fvars.contains(fid)) {
+                m_abstracted_fvars.insert(fid);
+                if (m_encountered.contains(fid))
+                    must_invalidate = true;
+            }
         }
+        if (must_invalidate)
+            m_free_of_abstracted.clear();
 
         /* Get the pending MVar's value directly — it must be assigned (pass 1
            pre-normalized it). No write-back: we are in inner mode. */
@@ -628,7 +703,12 @@ public:
         : m_mctx(mctx), m_depth(0), m_result_scope(0) {}
 
     expr visit(expr const & e) {
-        if ((!has_fvar(e) || in_outer_mode()) && !has_expr_mvar(e))
+        /* In inner mode, a subterm free of every abstracted fvar (and of mvars)
+           is unchanged at any depth; free_of_abstracted memoizes this per
+           pointer, so shared such subterms are not re-traversed once per depth.
+           It is only consulted in inner mode, keeping the outer-mode fast path
+           (and the memo's soundness invariant) intact. */
+        if (!has_expr_mvar(e) && (in_outer_mode() || free_of_abstracted(e)))
             return e;
 
         bool shared = false;

--- a/tests/elab/instMVarsDelayedShared.lean
+++ b/tests/elab/instMVarsDelayedShared.lean
@@ -1,0 +1,41 @@
+import Lean
+open Lean Meta
+
+/-!
+Regression test for `instantiateMVars` on a chain of delayed-assigned
+metavariables whose binder domains share a subterm that carries a free
+variable (`c`) but none of the abstracted binders.
+
+Introducing `n` binders one at a time builds an `n`-long delayed-assignment
+chain. Each binder domain `sₖ = sₖ` shares the accumulator `sₖ = 1 + sₖ₋₁`
+anchored at the context-local `c`, so the closed proof is linear in `n` after
+hash-consing. Collapsing the chain must stay linear: the shared, binder-free
+domains are returned unchanged at every depth via a per-pointer fast path.
+
+This checks correctness of that fast path: the materialized proof must be
+type-correct (a wrongly skipped substitution would leave a dangling variable).
+-/
+
+def buildAndCheck (n : Nat) : MetaM Bool :=
+  withLocalDeclD `c (mkConst ``Nat) fun c => do
+    let one := mkNatLit 1
+    let mut s := mkApp2 (mkConst ``Nat.add) one c
+    let mut domains : Array Expr := #[]
+    for _ in [0:n] do
+      domains := domains.push (← mkEq s s)
+      s := mkApp2 (mkConst ``Nat.add) one s
+    let sn := s
+    let type ← domains.foldrM (fun d acc => mkArrow d acc) (← mkEq sn sn)
+    let mv ← mkFreshExprSyntheticOpaqueMVar type
+    let mut g := mv.mvarId!
+    for _ in [0:n] do
+      let (_, g') ← g.intro1
+      g := g'
+    g.assign (← g.withContext (mkEqRefl sn))
+    let prf ← instantiateMVars (mkMVar mv.mvarId!)
+    Meta.check prf
+    isTypeCorrect prf
+
+#eval do
+  let ok ← buildAndCheck 400
+  IO.println s!"type correct: {ok}"

--- a/tests/elab/instMVarsDelayedShared.lean.out.expected
+++ b/tests/elab/instMVarsDelayedShared.lean.out.expected
@@ -1,0 +1,1 @@
+type correct: true


### PR DESCRIPTION
**Status: RFC / draft, WIP.** Correctness has been checked on a slice of the
existing suite (see Testing), but not the full `tests/`. Feedback on the
approach and on the soundness argument for the reverted-fvar case is welcome
before this is polished.

## Problem

`Lean.instantiateMVars` is Θ(N²) when it materializes a proof built by
introducing N binders one at a time (a chain of N nested *delayed* metavariable
assignments), even when the maximally-shared result is Θ(N).

Pass 2 of `src/library/instantiate_mvars.cpp` (`instantiate_delayed_fn`)
collapses the delayed chain with a cache keyed on `(expr.raw(), m_depth)` — the
binder depth. Its depth-independent early exit is

```cpp
if ((!has_fvar(e) || in_outer_mode()) && !has_expr_mvar(e))
    return e;
```

A subterm that is shared across many binder depths but carries a **free**
variable that is *not* among the binders being abstracted has `has_fvar(e) ==
true`, so in inner mode the early exit never fires. It is a cache miss at each
of the N depths and is re-traversed once per depth ⇒ Θ(N²), while the traversal
changes nothing (every `update_*` returns the original pointer) and the output
stays Θ(N). The delayed collapse abstracts *fvars*, and `looseBVarRange` (a bvar
notion) cannot detect fvar-freeness, so the existing machinery cannot skip it.

## Reproducer

`tests/elab/instMVarsDelayedShared.lean` (added here) is the correctness
distillation. The performance shape is captured by this telescope: a fixed
context-local `c : Nat`, a shared accumulator `sₖ = 1 + sₖ₋₁` anchored at `c`,
and one binder per level whose domain is `sₖ = sₖ`. The chain is pointer-shared
across all depths, so the closed proof `fun h₀ … h_{n-1} => Eq.refl sₙ` is Θ(N)
after hash-consing.

```lean
def run (n : Nat) (dep : Bool) : MetaM Nat :=
  withLocalDeclD `c (mkConst ``Nat) fun c => do
    let one := mkNatLit 1
    let mut s := mkApp2 (mkConst ``Nat.add) one c        -- s₀ = 1 + c
    let mut domains : Array Expr := #[]
    for _ in [0:n] do
      let d ← if dep then mkEq s s else mkEq (mkNatLit 0) (mkNatLit 0)
      domains := domains.push d
      s := mkApp2 (mkConst ``Nat.add) one s              -- sₖ = 1 + sₖ₋₁
    let sn := s
    let type ← domains.foldrM (fun d acc => mkArrow d acc) (← mkEq sn sn)
    let mv ← mkFreshExprSyntheticOpaqueMVar type
    let mut g := mv.mvarId!
    for _ in [0:n] do
      let (_, g') ← g.intro1                             -- N-long delayed chain
      g := g'
    g.assign (← g.withContext (mkEqRefl sn))
    let t0 ← IO.monoNanosNow
    let _ ← instantiateMVars (mkMVar mv.mvarId!)         -- the only timed call
    return ((← IO.monoNanosNow) - t0) / 1000
```

`dep := true` puts the shared chain in every binder domain (visited at N growing
depths); `dep := false` puts it only in the leaf (one depth). Both proofs are
Θ(N); only the materialization cost differs. The finalized term passes
`Meta.check`.

## Before / after

`instantiateMVars` time (µs), same machine, `dep := true` (the pathological
case) vs `dep := false` (linear control):

| N   | before, dep | before, control | after, dep | after, control |
|-----|-------------|-----------------|------------|----------------|
| 100 | 1407        | 107             | 179        | 149            |
| 200 | 5281        | 201             | 423        | 299            |
| 400 | 31867       | 442             | 943        | 677            |
| 800 | 60523       | 967             | 2739       | 3104           |

Before: `dep` grows ~quadratically (1407 → 60523 over 8× N ≈ 43×) and is 62× the
control at N = 800. After: `dep` grows linearly and tracks the control. ≈ 22×
faster at N = 800, with the gap widening in N.

## Algorithm

Add a per-pointer fast path to the delayed collapse, replacing the `!has_fvar`
disjunct in inner mode with a *free-of-abstracted-fvars* test cached per pointer
(not per depth):

- `m_abstracted_fvars`: the set of fvars actually being abstracted, grown
  monotonically with the fvars of each delayed assignment as the chain is
  crossed.
- `m_free_of_abstracted`: a per-pointer memo of `free(e) = "e contains no fvar
  in m_abstracted_fvars"`. It is syntactic and depth-independent, so it holds one
  entry per DAG node and total work over it is linear.
- The early exit becomes
  `!has_expr_mvar(e) && (in_outer_mode() || free_of_abstracted(e))`. `free` is
  consulted only in inner mode, so the outer-mode fast path is unchanged.

**Soundness under a reverted outer fvar.** `free(e)` may only be cached as
"true" for a node that genuinely avoids every fvar that is *ever* abstracted. In
the common case (freshly introduced, single-scope binders) an abstracted fvar is
reachable only behind the delayed MVar that abstracts it, so it enters
`m_abstracted_fvars` before any node containing it is scanned, and no stale
"true" is possible. The general `elimMVarDeps` `toRevert` path can abstract an
*outer* fvar that already appeared. To stay sound the freeness scan records every
fvar it encounters in `m_encountered`; when crossing a delayed MVar adds an fvar
that is already in `m_encountered`, the freeness memo is dropped. `free` is only
consulted (and thus only ever creates entries) in inner mode, where every
encountered fvar is recorded, so any harmful "true" entry is always caught. For
freshly-introduced binders `m_abstracted_fvars ∩ m_encountered = ∅` at each
crossing, so this never fires and there is zero overhead.

## Testing

Built and verified locally; **not** a full `tests/` run.

- Built `libleanshared` (stage1) with the change and re-ran the reproducer: the
  `dep := true` case goes from quadratic to linear (numbers above), and the
  materialized term passes `Meta.check` / `isTypeCorrect` at N = 200 and N = 400.
- Ran a slice of `tests/elab` against the rebuilt toolchain, all passing with
  byte-exact output: the delayed-assignment / dependent-elimination stress tests
  `depElim1`, `1179b`, and the `scope_cache` formal-verification file
  `scopeCacheProofs`, plus `abstractMVars`, `bindersAbstractingUnassignedMVars`,
  `elabAsElim`, `customEliminators`, `doMatchDependent`, `convPatternMatchIssue`,
  and a further random sample of 30 `tests/elab` files — 49 files total, 0
  failures.
- Added `tests/elab/instMVarsDelayedShared.lean`, a deterministic correctness
  regression that materializes the shared delayed chain and asserts the result is
  type-correct.

Not yet run: the full `tests/` suite and CI. A dedicated timing regression is not
included, since the setup cost of the reproducer (N `intro1` calls) dominates at
the N where a quadratic collapse would be reliably distinguishable by a wall-clock
threshold.
