### PR TITLE
fix: pin `LEAN_GITHASH` for core Lake builds

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -100,23 +100,35 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-multilib g++-multilib ccache libuv1-dev:i386 libssl-dev:i386 pkgconf:i386
         if: matrix.cmultilib
-      - name: Restore Cache
-        id: restore-cache
+      - name: Restore CCache
+        id: restore-ccache
         uses: actions/cache/restore@v6
         with:
-          # NOTE: must be in sync with `save` below and with `restore-cache` in `update-stage0.yml`
+          # NOTE: must be in sync with `save` below and with "Restore CCache" in `update-stage0.yml`
+          path: .ccache
+          key: ${{ matrix.name }}-build-v5-${{ github.sha }}
+          # fall back to (latest) previous cache
+          restore-keys: |
+            ${{ matrix.name }}-build-v5
+      - name: Restore Stage 1 Cache
+        id: restore-stage1
+        if: matrix.lake-actions-cache
+        uses: actions/cache/restore@v6
+        with:
+          # NOTE: must be in sync with `save` below and with "Restore Stage 1 Cache" in `update-stage0.yml`
           path: |
-            .ccache
-            ${{ matrix.lake-actions-cache && 'build/stage1/**/*.trace
+            build/stage1/**/*.trace
             build/stage1/**/*.olean*
             build/stage1/**/*.ilean
             build/stage1/**/*.ir
             build/stage1/**/*.c
-            build/stage1/**/*.c.o*' || '' }}
-          key: ${{ matrix.name }}-build-v4-${{ github.sha }}
-          # fall back to (latest) previous cache
-          restore-keys: |
-            ${{ matrix.name }}-build-v4
+            build/stage1/**/*.c.o*
+          key: ${{ matrix.name }}-stage1-v1-${{ github.sha }}
+          # Cross-commit fallback is only sound for lenient readers: release binaries embed the
+          # commit githash and enforce it when loading `.olean`s (`CHECK_OLEAN_VERSION`), so
+          # `.olean`s built at another commit must never enter a release build tree even though
+          # the stage0-tree-hash-keyed Lake traces would accept them.
+          restore-keys: ${{ !matrix.release && format('{0}-stage1-v1', matrix.name) || '' }}
       # open nix-shell once for initial setup
       - name: Setup
         run: |
@@ -141,9 +153,13 @@ jobs:
           # affect CI
           OPTIONS=(-DWFAIL=ON -DLEAN_HEADER_SNAPSHOTS=ON)
           if [[ -n '${{ matrix.release }}' ]]; then
-            # this also enables githash embedding into stage 1 library, which prohibits reusing
-            # `.olean`s across commits, so we don't do it in the fast non-release CI
+            # Embeds the githash into stage 1 library and checks it.
+            # This prohibits reusing `.olean`s from any build not so stamped,
+            # so we don't do it in the fast non-release CI.
             OPTIONS+=(-DCHECK_OLEAN_VERSION=ON)
+            # Replace the system-wide cache with a job-level one to avoid ingesting mismatched
+            # oleans from other builds on self-hosted runners.
+            echo "LAKE_CACHE_DIR=" >> "$GITHUB_ENV"
           fi
           if [[ -n '${{ matrix.cross_target }}' ]]; then
             # used by `prepare-llvm`
@@ -203,22 +219,28 @@ jobs:
           time make -C build $TARGET_STAGE -j$NPROC
       # Should be done as early as possible and in particular *before* "Check rebootstrap" which
       # changes the state of stage1/
-      - name: Save Cache
+      - name: Save CCache
         # Caching on cancellation created some mysterious issues perhaps related to improper build
         # shutdown
-        if: steps.restore-cache.outputs.cache-hit != 'true' && !cancelled()
+        if: steps.restore-ccache.outputs.cache-hit != 'true' && !cancelled()
+        uses: actions/cache/save@v6
+        with:
+          # NOTE: must be in sync with `restore` above
+          path: .ccache
+          key: ${{ steps.restore-ccache.outputs.cache-primary-key }}
+      - name: Save Stage 1 Cache
+        if: matrix.lake-actions-cache && steps.restore-stage1.outputs.cache-hit != 'true' && !cancelled()
         uses: actions/cache/save@v6
         with:
           # NOTE: must be in sync with `restore` above
           path: |
-            .ccache
-            ${{ matrix.lake-actions-cache && 'build/stage1/**/*.trace
+            build/stage1/**/*.trace
             build/stage1/**/*.olean*
             build/stage1/**/*.ilean
             build/stage1/**/*.ir
             build/stage1/**/*.c
-            build/stage1/**/*.c.o*' || '' }}
-          key: ${{ steps.restore-cache.outputs.cache-primary-key }}
+            build/stage1/**/*.c.o*
+          key: ${{ steps.restore-stage1.outputs.cache-primary-key }}
       - id: upload-lake-cache
         name: Upload Lake Cache
         # Caching on cancellation created some mysterious issues perhaps related to improper build

--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -270,9 +270,10 @@ jobs:
       - name: Restore Build
         if: steps.upload-lake-cache.outcome == 'success'
         run: |
-          build/stage0/bin/lake cache clean
           rm -rf build/stage1
           mv build/stage1.bak build/stage1
+          cd src
+          ../build/stage0/bin/lake cache clean
       - name: Install
         run: |
           make -C build/$TARGET_STAGE install

--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -173,6 +173,9 @@ jobs:
         run: |
           ulimit -c unlimited  # coredumps
           time make -C build stage1-configure -j$NPROC
+          # Key every subsequent Lake invocation's cache trace the same way as the CMake-driven
+          # stdlib build, using the githash the stage1 configure emitted (see `src/CMakeLists.txt`).
+          echo "LEAN_GITHASH=$(cat build/stage1/lake-githash)" >> "$GITHUB_ENV"
       - name: Check for stage0 update
         id: check-stage0
         # A stage0 update replaces the bootstrap compiler, which invalidates every Lake artifact

--- a/.github/workflows/update-stage0.yml
+++ b/.github/workflows/update-stage0.yml
@@ -61,23 +61,33 @@ jobs:
       if: env.should_update_stage0 == 'yes'
       run: |
         echo "NPROC=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)" >> $GITHUB_ENV
-    - name: Restore Cache
+    - name: Restore CCache
       if: env.should_update_stage0 == 'yes'
       uses: actions/cache/restore@v6
       with:
-        # NOTE: must be in sync with `restore-cache` in `build-template.yml`
+        # NOTE: must be in sync with `restore-ccache` in `build-template.yml`
+        path: .ccache
+        key: Linux release-build-v5-${{ github.sha }}
+        # fall back to (latest) previous cache
+        restore-keys: |
+          Linux release-build-v5
+    - name: Restore Stage 1 Cache
+      if: env.should_update_stage0 == 'yes'
+      uses: actions/cache/restore@v6
+      with:
+        # NOTE: must be in sync with `restore-stage1` in `build-template.yml`.
+        # Unlike the release job there, cross-commit fallback is sound here: this build does not set
+        # `CHECK_OLEAN_VERSION`, so it may reuse `.olean`s stamped with another commit's githash.
         path: |
-          .ccache
           build/stage1/**/*.trace
           build/stage1/**/*.olean*
           build/stage1/**/*.ilean
           build/stage1/**/*.ir
           build/stage1/**/*.c
           build/stage1/**/*.c.o*
-        key: Linux release-build-v4-${{ github.sha }}
-        # fall back to (latest) previous cache
+        key: Linux release-stage1-v1-${{ github.sha }}
         restore-keys: |
-          Linux release-build-v4
+          Linux release-stage1-v1
     - if: env.should_update_stage0 == 'yes'
       name: Configure Build
       # sync options with `Linux release` to ensure cache reuse

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -621,6 +621,58 @@ if(MULTI_THREAD AND NOT MSVC AND NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
   string(APPEND LEAN_EXTRA_LINKER_FLAGS " -pthread")
 endif()
 
+# The stage0 tree hash. For non-release builds this is embedded as `Lean.githash`.
+# It is also the githash Lake always needs to use for its traces. It is passed via `LEAN_GITHASH`
+# in `stdlib.make` and propagated to the cache steps by CI. This esnures that stage1 `.olean`s stay
+# reusable across commits that do not touch stage0.
+execute_process(
+  COMMAND git rev-parse HEAD:stage0
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  OUTPUT_VARIABLE LAKE_LEAN_GITHASH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  # Failure is handled below (jj fallback, then a fatal error when the cache needs it).
+  ERROR_QUIET
+)
+# Fallback for jj workspaces where git cannot find .git directly.
+# Use `jj git root` to find the backing git repo, then `jj log` to
+# resolve the current workspace's commit (git HEAD points to the root
+# workspace, not the current one).
+if("${LAKE_LEAN_GITHASH}" STREQUAL "")
+  find_program(JJ_EXECUTABLE jj)
+  if(JJ_EXECUTABLE)
+    execute_process(
+      COMMAND "${JJ_EXECUTABLE}" git root
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+      OUTPUT_VARIABLE _jj_git_dir
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+      RESULT_VARIABLE _jj_git_root_result
+    )
+    execute_process(
+      COMMAND "${JJ_EXECUTABLE}" log -r @ --no-graph -T "commit_id"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+      OUTPUT_VARIABLE _jj_commit
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+      RESULT_VARIABLE _jj_rev_result
+    )
+    if(_jj_git_root_result EQUAL 0 AND _jj_rev_result EQUAL 0)
+      execute_process(
+        COMMAND git --git-dir "${_jj_git_dir}" rev-parse "${_jj_commit}:stage0"
+        OUTPUT_VARIABLE LAKE_LEAN_GITHASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+    endif()
+  endif()
+endif()
+# A missing or wrong hash would silently break cache correctness (misses, or worse, mismatched
+# reuse), so fail loudly when the cache is enabled.
+if(USE_LAKE_CACHE AND "${LAKE_LEAN_GITHASH}" STREQUAL "")
+  message(FATAL_ERROR "Failed to determine the stage0 tree hash required to key the Lake artifact cache")
+endif()
+# Emitted so CI can propagate the same value to the standalone cache upload/download steps.
+file(WRITE "${CMAKE_BINARY_DIR}/lake-githash" "${LAKE_LEAN_GITHASH}")
+
 # Git HASH
 if(USE_GITHASH)
   include(GetGitRevisionDescription)
@@ -633,48 +685,9 @@ if(USE_GITHASH)
   endif()
 else()
   if(USE_LAKE AND STAGE EQUAL 0)
-    # we need to embed *some* hash for Lake to invalidate stage 1 on stage 0 changes
-    execute_process(
-      COMMAND git ls-tree HEAD "${CMAKE_CURRENT_SOURCE_DIR}/../../stage0" --object-only
-      OUTPUT_VARIABLE GIT_SHA1
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-    # Fallback for jj workspaces where git cannot find .git directly.
-    # Use `jj git root` to find the backing git repo, then `jj log` to
-    # resolve the current workspace's commit (git HEAD points to the root
-    # workspace, not the current one).
-    if("${GIT_SHA1}" STREQUAL "")
-      find_program(JJ_EXECUTABLE jj)
-      if(JJ_EXECUTABLE)
-        execute_process(
-          COMMAND "${JJ_EXECUTABLE}" git root
-          WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-          OUTPUT_VARIABLE _jj_git_dir
-          OUTPUT_STRIP_TRAILING_WHITESPACE
-          ERROR_QUIET
-          RESULT_VARIABLE _jj_git_root_result
-        )
-        execute_process(
-          COMMAND "${JJ_EXECUTABLE}" log -r @ --no-graph -T "commit_id"
-          WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-          OUTPUT_VARIABLE _jj_commit
-          OUTPUT_STRIP_TRAILING_WHITESPACE
-          ERROR_QUIET
-          RESULT_VARIABLE _jj_rev_result
-        )
-        if(_jj_git_root_result EQUAL 0 AND _jj_rev_result EQUAL 0)
-          execute_process(
-            COMMAND git --git-dir "${_jj_git_dir}" ls-tree "${_jj_commit}" stage0 --object-only
-            OUTPUT_VARIABLE GIT_SHA1
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-          )
-        endif()
-      endif()
-    endif()
+    # Embed the stage0 tree hash so Lake invalidates stage 1 on stage 0 changes.
+    set(GIT_SHA1 "${LAKE_LEAN_GITHASH}")
     message(STATUS "stage0 sha1: ${GIT_SHA1}")
-    # Now that we've prepared the information for the next stage, we can forget that we will use
-    # Lake in the future as we won't use it in this stage
-    set(USE_LAKE OFF)
   else()
     set(GIT_SHA1 "")
   endif()

--- a/src/stdlib.make.in
+++ b/src/stdlib.make.in
@@ -54,7 +54,7 @@ ifeq "${USE_LAKE}" "ON"
 
 # build in parallel
 Init:
-	${PREV_STAGE}/bin/lake build -f ${CMAKE_BINARY_DIR}/lakefile.toml ${LEAN_EXTRA_LAKE_OPTS} $(LAKE_EXTRA_ARGS)
+	LEAN_GITHASH=${LAKE_LEAN_GITHASH} ${PREV_STAGE}/bin/lake build -f ${CMAKE_BINARY_DIR}/lakefile.toml ${LEAN_EXTRA_LAKE_OPTS} $(LAKE_EXTRA_ARGS)
 
 Std Lean Lake Leanc LeanChecker LeanIR: Init
 

--- a/tests/bench/vcgen/run_test.sh
+++ b/tests/bench/vcgen/run_test.sh
@@ -1,1 +1,2 @@
+rm -rf .lake
 lake test

--- a/tests/pkg/stateful_linter/run_test.sh
+++ b/tests/pkg/stateful_linter/run_test.sh
@@ -1,2 +1,2 @@
-rm -rf .lake/build
+rm -rf .lake
 lake build


### PR DESCRIPTION
This PR restores reuse of the Lake artifact cache across core CI builds. 

Since #13759, the `Linux Lake (Cached)` job downloaded the cache but still rebuilt everything, because the cache trace is keyed on `Lean.githash`, which is the commit hash on the release job that produces the cache, but the stage0 tree hash on the non-release job that consumes it. To fix this, the Lean trace Lake uses is overriden via `LEAN_GITHASH` to be  the stage0 tree hash (rather than whatever `Lean.githash` may be). This ensures so stage1 `.olean`s are reusable across commits that do not touch stage0. The override affects only the cache trace, not the compiled `.olean`s, which still embed the same `Lean.githash`.

Release builds cannot reuse `.olean`s embedded with a different `Lean.githash`. Nonetheless, this change would allow Lake to reuse them if they have the same stage0. To avoid this, restoring `.olean`s from the cache is now completely disabled for release builds. In practice, this is pure savings, as the `.olean`s restored from the cache during release builds were unused anyway due to the mismatched githash.

Implementation-wise, CMake serves as the single source of truth for `LEAN_GITHASH`: it computes the stage0 tree hash once, embeds it as the non-release `Lean.githash` (as before), and passes it to Lake as `LEAN_GITHASH` for the core build (via `stdlib.make`). CI reads the file and sets `LEAN_GITHASH` in the CI job environment so that the standalone `lake cache` steps use the same key. The hash is computed with `git rev-parse HEAD:stage0` rather than the previous `git ls-tree HEAD "{}/../../stage0" --object-only`, because it is now also needed at stage 1 where that relative path does not apply. Both commands return the same tree object hash.

🤖 Prepared with Claude Code
