### PR TITLE
feat: accept term arguments in `vcgen [...]`

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Attr.lean
+++ b/src/Lean/Elab/Tactic/Do/Attr.lean
@@ -539,6 +539,20 @@ def mkSpecTheoremFromSimpDecl? (declName : Name) (prio : Nat) : MetaM (Option Sp
   return some { pattern, proof := .global declName, kind := .simp etaArgs, priority := prio }
 
 /--
+Create a `SpecTheorem` from an elaborated equational proof term `proof : ∀ xs, lhs = rhs`, keyed on
+the LHS. Mirrors `mkSpecTheoremFromSimpDecl?` for proofs supplied as terms rather than declaration
+names. Returns `none` for a no-op equation whose LHS key equals its RHS.
+-/
+def mkSpecTheoremFromSimpExpr? (ref : Syntax) (proof : Expr) (levelParams : List Name := [])
+    (prio : Nat := eval_prio default) : MetaM (Option SpecTheorem) := do
+  let (pattern, (eqTy, rhs)) ← Sym.mkPatternFromExprWithKey proof levelParams fun body => do
+    let_expr Eq eqTy lhs rhs := body | throwError "conclusion is not an equality{indentExpr body}"
+    return (lhs, (eqTy, rhs))
+  if pattern.pattern == rhs then return none
+  let (pattern, etaArgs) := etaExpandEqPattern pattern eqTy
+  return some { pattern, proof := .stx (← mkFreshId) ref proof, kind := .simp etaArgs, priority := prio }
+
+/--
 The unfold theorem `declName.eq_def` through which a definition in a simp set's `toUnfold`
 rewrites, the spec-database counterpart of `simp`'s delta unfolding. `none` for a recursive
 definition, whose unconditional unfolding would not terminate.
@@ -550,9 +564,10 @@ def unfoldSpecEqn? (declName : Name) : MetaM (Option Name) := do
 /--
 The spec theorems the simp entries `entries` contribute, the single place a `vcgen [...]` argument or
 an `attribute [spec] f` definition (through `mkSimpEntryOfDeclToUnfold`) turns into specs:
-- each `.thm` entry, keyed on its left-hand side (`mkSpecTheoremFromSimpDecl?`) at `prio`, skipping
-  wildcard-row equations guarded by an overlap hypothesis (as a spec such an equation matches any
-  call and strands the hypothesis as a verification condition),
+- each `.thm` entry, keyed on its left-hand side at `prio`, skipping wildcard-row equations guarded
+  by an overlap hypothesis (as a spec such an equation matches any call and strands the hypothesis as
+  a verification condition). A declaration equation is keyed via `mkSpecTheoremFromSimpDecl?`; an
+  equation supplied as a `vcgen [...]` term carries its proof directly (`mkSpecTheoremFromSimpExpr?`),
 - each `.toUnfold` definition through its unfold theorem `f.eq_def` (`unfoldSpecEqn?`) at priority
   `0`, below every equation, so a call with an opaque discriminant still rewrites to the underlying
   `match` expression, which `vcgen` then splits.
@@ -563,7 +578,8 @@ def simpSpecTheorems (entries : Array SimpEntry) (prio : Nat) : MetaM (Array Spe
   for entry in entries do
     match entry with
     | .thm thm =>
-      if let .decl declName .. := thm.origin then
+      match thm.origin with
+      | .decl declName .. =>
         try
           if hasOverlapHypothesis (← getConstInfo declName).type then
             trace[Elab.Tactic.Do.specAttr] "Skipping overlap-hypothesis equation {declName}"
@@ -571,6 +587,15 @@ def simpSpecTheorems (entries : Array SimpEntry) (prio : Nat) : MetaM (Array Spe
             result := result.push spec
         catch e =>
           trace[Elab.Tactic.Do.specAttr] "Failed to add simp spec {declName}: {e.toMessageData}"
+      | .stx .. =>
+        try
+          if hasOverlapHypothesis (← inferType thm.proof) then
+            trace[Elab.Tactic.Do.specAttr] "Skipping overlap-hypothesis equation {thm.origin.key}"
+          else if let some spec ← mkSpecTheoremFromSimpExpr? .missing thm.proof thm.levelParams.toList prio then
+            result := result.push spec
+        catch e =>
+          trace[Elab.Tactic.Do.specAttr] "Failed to add simp spec {thm.origin.key}: {e.toMessageData}"
+      | _ => pure ()
     | .toUnfold declName =>
       try
         if let some eqDef ← unfoldSpecEqn? declName then

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
@@ -48,6 +48,7 @@ public def mkContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := false) 
     TermElabM (VCGen.Context × VCGen.Scope) := do
   let mut specThms ← getSpecTheorems
   let mut simpStuff := #[]
+  let mut simpTermThms : Array SimpTheorem := #[]
   let mut starArg := false
   for arg in lemmas[1].getSepArgs do
     if arg.getKind == ``simpErase then
@@ -91,7 +92,28 @@ public def mkContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := false) 
           specThms := specThms.insert thm
         catch _ =>
           simpStuff := simpStuff.push ⟨arg⟩
-      | _ => withRef term <| throwError "Could not resolve spec theorem `{term}`"
+      | _ =>
+        -- A term that is not a bare identifier (e.g. `show l = r from h`, `foo x`, `@foo`).
+        -- Mirror `simp`: elaborate once, register a spec proof as a spec, and any other proof as a
+        -- simp lemma (which `addSimpSpecs` turns into an equational spec).
+        let thm? ← Term.withoutModifyingElabMetaStateWithInfo <| withRef term do
+          let e ← Term.elabTerm term .none
+          Term.synthesizeSyntheticMVars (postpone := .no) (ignoreStuckTC := true)
+          let e ← instantiateMVars e
+          if e.hasSyntheticSorry then
+            return none
+          let e := e.eta
+          if e.hasMVar then
+            let r ← abstractMVars e
+            return some (r.paramNames, r.expr)
+          else
+            return some (#[], e)
+        if let some (levelParams, proof) := thm? then
+          if let some thm ← mkSpecTheoremFromStx term proof then
+            specThms := specThms.insert thm
+          else
+            let thms ← mkSimpTheoremFromExpr (.stx (← mkFreshId) arg) levelParams proof
+            simpTermThms := simpTermThms ++ thms
     else if arg.getKind == ``simpStar then
       starArg := true
       simpStuff := simpStuff.push ⟨arg⟩
@@ -105,7 +127,9 @@ public def mkContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := false) 
     (eraseLocal := false)
     (simpTheorems := pure {})
     (ignoreStarArg := ignoreStarArg)
-  let simpThms := res.ctx.simpTheorems[0]?.getD {}
+  let mut simpThms := res.ctx.simpTheorems[0]?.getD {}
+  for thm in simpTermThms do
+    simpThms := simpThms.addSimpTheorem thm
   -- Add local spec hypotheses when `*` is used.
   if starArg && !ignoreStarArg then
     let fvars ← getPropHyps

--- a/tests/elab/vcgenTermArgs.lean
+++ b/tests/elab/vcgenTermArgs.lean
@@ -1,0 +1,44 @@
+import Std.Internal.Do
+import Std.Tactic.Do
+
+/-!
+Tests that `vcgen [...]` accepts arbitrary term arguments, mirroring `simp [...]`.
+A term proving a Hoare triple / `⊑ wp` spec is registered as a spec; any other proof is
+handled as a simp lemma (equation), exactly as `simp` would.
+-/
+
+set_option mvcgen.warning false
+
+open Lean.Order Std.Internal.Do
+
+/-! Equation term argument: `show lhs = rhs from h` rewrites an opaque program action. -/
+section
+opaque act : StateM Nat Unit
+
+example (h : act = pure ()) :
+    ⦃fun (_ : Nat) => True⦄ act ⦃fun _ _ => True⦄ := by
+  vcgen [show act = pure () from h] with finish
+end
+
+/-! Spec proof term argument built by a partially applied identifier `gspec 0`. -/
+section
+set_option warn.sorry false
+axiom G : StateM Nat Unit
+axiom gspec (n : Nat) : ⦃fun (_ : Nat) => True⦄ G ⦃fun _ m => m = m⦄
+
+example : ⦃fun (_ : Nat) => True⦄ G ⦃fun _ m => m = m⦄ := by
+  vcgen [gspec 0]
+end
+
+/-! Regression: a `def`'s equation as a bare identifier, and the same equation as the
+non-identifier term `@dep.eq_def`. -/
+section
+def dep (n : Option Nat) : Id Nat :=
+  match _h : n with | some y => pure (y + 1) | none => pure 2
+
+example (n : Option Nat) : ⦃ True ⦄ dep n ⦃ fun r => r > 0 ⦄ := by
+  vcgen [dep.eq_def] with finish
+
+example (n : Option Nat) : ⦃ True ⦄ dep n ⦃ fun r => r > 0 ⦄ := by
+  vcgen [@dep.eq_def] with finish
+end


### PR DESCRIPTION
This PR lets `vcgen [...]` accept arbitrary term arguments, not just bare identifiers, mirroring `simp [...]`. A term that proves a Hoare-triple or `⊑ wp` specification is registered as a spec, and any other term proof is handled as a simp lemma, so forms like `vcgen [show l = r from h]`, `vcgen [foo x]`, and `vcgen [@foo]` now work.

A non-identifier argument is elaborated once using the same pattern as `simp`, keeping info-tree registration for hovers. The resulting closed proof is tried as a spec via `mkSpecTheoremFromStx`; on failure it becomes a simp theorem folded into the per-call simp set. `simpSpecTheorems` now converts these term-provided (`.stx`-origin) simp theorems into equational specs through the new `mkSpecTheoremFromSimpExpr?`, which keys a `.simp` spec on the equation's left-hand side, applying the same overlap-hypothesis skip as the declaration path.
