### PR TITLE
fix: clean missing-spec error when a selected `vcgen` spec fails to apply

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -309,6 +309,13 @@ private def findSpec (scope : VCGen.Scope) (prog monad : Expr) :
   | .ok thm => return (scope, .ok thm)
   | .error thms => return (scope, .error (← stopOrErrorOnMissingSpec prog monad thms))
 
+/-- True iff the spec's pattern unifies with the program, mirroring the match performed in
+`findSpecs`. Distinguishes a spurious discrimination-tree candidate, whose pattern does not unify,
+from a spec whose pattern matches yet whose backward rule fails to apply. -/
+private def specPatternMatches (thm : SpecTheorem) (prog : Expr) : SymM Bool :=
+  withNewMCtxDepth do
+    return (← thm.pattern.match? prog).isSome
+
 /-- Apply the cached backward rule of the selected `@[spec]` theorem `thm`, returning its subgoals, or
 a stop result when no rule matches the goal's monad. Reached from `applyFrameOrSpec`. -/
 private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) (thm : SpecTheorem) :
@@ -326,6 +333,11 @@ private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) (thm 
     | return ← stopOrErrorOnMissingSpec info.prog info.M #[thm]
   let .goals goals ← rule.applyChecked goal m!"spec rule for{indentExpr info.prog}"
     | do
+      -- The discrimination tree over-approximates, so a selected spec may not unify with the program
+      -- (e.g. an offset-keyed equation against a variable discriminant). That is no matching spec, not
+      -- a rule failure. A spec whose pattern does match yet whose rule fails to apply is a genuine bug.
+      unless ← specPatternMatches thm info.prog do
+        return ← stopOrErrorOnMissingSpec info.prog info.M #[thm]
       let ruleType ← Meta.inferType rule.expr
       throwError "Failed to apply rule {thm.proof} for {indentExpr info.prog}\n\
         target:{indentExpr (← goal.getType)}\n\

--- a/tests/elab/vcgenUnfoldMatchDef.lean
+++ b/tests/elab/vcgenUnfoldMatchDef.lean
@@ -52,17 +52,7 @@ attribute [local spec] wild in
 example (n m : Option Nat) : ⦃ True ⦄ wild n m ⦃ fun r => r > 0 ⦄ := by
   vcgen with finish
 
-/--
-error: Failed to apply rule SpecProof.global recf.eq_2 for
-  recf n
-target:
-  ⊤ ⊑ wp (recf n) (LT.lt 0) ⊥
-Pred:
-  Prop
-excessArgs: []
-rule type:
-  ∀ (Pre : Prop) (n_2 : Nat) (Q : Nat → Prop) (E : EPost⟨⟩), Pre ⊑ wp (recf n_2) Q E → Pre ⊑ wp (recf n_2.succ) Q E
--/
+/-- error: No spec matching the monad Id found for program recf n. Candidates were [SpecProof.global recf.eq_2]. -/
 #guard_msgs (whitespace := lax) in
 example (n : Nat) : ⦃ True ⦄ recf n ⦃ fun r => r > 0 ⦄ := by
   vcgen [recf] with finish


### PR DESCRIPTION
This PR makes `vcgen` report a clean missing-spec error when the spec it selects for a program turns out not to unify with it, instead of dumping the internal backward rule and its type.

The spec discrimination tree over-approximates, so a sole candidate returned by spec selection may not unify with the program. When the selected rule fails to apply, `applySpec` now matches the spec's pattern against the program: if the pattern does not unify, it routes through the same missing-spec handling as every other unmatched-spec case; if the pattern does unify, the rule failure is a genuine bug and the original hard error is preserved. The improvement is covered by the updated `recf` expectation in `tests/elab/vcgenUnfoldMatchDef.lean`.
