### PR TITLE
fix: prefer explicitly supplied specs over ambient local specs in vcgen

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Attr.lean
+++ b/src/Lean/Elab/Tactic/Do/Attr.lean
@@ -352,13 +352,24 @@ instance : BEq SpecTheorem where
 
 abbrev SpecEntry := SpecTheorem
 
+/-- Priority for a spec named explicitly in a `vcgen [...]` argument list. -/
+def explicitSpecPrio : Nat := eval_prio high + 20
+
+/-- Priority for a local hypothesis pulled into `vcgen`'s spec set by `*`. -/
+def starSpecPrio : Nat := eval_prio high + 10
+
 structure SpecTheorems where
   specs : DiscrTree SpecTheorem := DiscrTree.empty
   erased : PHashSet SpecProof := {}
   deriving Inhabited
 
+/-- Insert `e`, keeping the higher priority when a spec with the same proof is already stored, so
+re-inserting a spec at a lower band never demotes it. The stored `SpecTheorem` is the single source
+of truth for the priority; `Sym.getMatch` retrieves the current entries for `e`'s program. -/
 def SpecTheorems.insert (d : SpecTheorems) (e : SpecTheorem) : SpecTheorems :=
-  { d with specs := Sym.insertPattern d.specs e.pattern e }
+  let priority := (Sym.getMatch d.specs e.pattern.pattern).foldl (init := e.priority) fun pr s =>
+    if s.proof == e.proof then max pr s.priority else pr
+  { d with specs := Sym.insertPattern d.specs e.pattern { e with priority } }
 
 def SpecTheorems.isErased (d : SpecTheorems) (thmId : SpecProof) : Bool :=
   d.erased.contains thmId

--- a/src/Lean/Elab/Tactic/Do/Attr.lean
+++ b/src/Lean/Elab/Tactic/Do/Attr.lean
@@ -363,9 +363,7 @@ structure SpecTheorems where
   erased : PHashSet SpecProof := {}
   deriving Inhabited
 
-/-- Insert `e`, keeping the higher priority when a spec with the same proof is already stored, so
-re-inserting a spec at a lower band never demotes it. The stored `SpecTheorem` is the single source
-of truth for the priority; `Sym.getMatch` retrieves the current entries for `e`'s program. -/
+/-- Insert `e`, keeping the higher priority when a spec with the same proof is already stored. -/
 def SpecTheorems.insert (d : SpecTheorems) (e : SpecTheorem) : SpecTheorems :=
   let priority := (Sym.getMatch d.specs e.pattern.pattern).foldl (init := e.priority) fun pr s =>
     if s.proof == e.proof then max pr s.priority else pr

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
@@ -79,14 +79,14 @@ public def mkContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := false) 
       match ← Term.resolveId? term (withInfo := true) <|> Term.elabCDotFunctionAlias? ⟨term⟩ with
       | some (.const declName _) =>
         try
-          let some thm ← mkSpecTheoremFromConst declName
+          let some thm ← mkSpecTheoremFromConst declName explicitSpecPrio
             | throwError "not a spec theorem"
           specThms := specThms.insert thm
         catch _ =>
           simpStuff := simpStuff.push ⟨arg⟩
       | some (.fvar fvar) =>
         try
-          let some thm ← mkSpecTheoremFromLocal fvar
+          let some thm ← mkSpecTheoremFromLocal fvar explicitSpecPrio
             | throwError "not a spec theorem"
           specThms := specThms.insert thm
         catch _ =>
@@ -112,7 +112,7 @@ public def mkContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := false) 
     for fvar in fvars do
       unless specThms.isErased (.local fvar) do
         try
-          if let some thm ← mkSpecTheoremFromLocal fvar then
+          if let some thm ← mkSpecTheoremFromLocal fvar starSpecPrio then
             specThms := specThms.insert thm
         catch _ => continue
   let backwardRules ← VCGen.mkBackwardRules

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
@@ -104,7 +104,7 @@ public def addSimpSpecs (database : SpecTheorems) (simpThms : SimpTheorems) :
     ++ simpThms.toUnfold.toList.toArray.map (SimpEntry.toUnfold ·)
   for newSpec in ← simpSpecTheorems entries (eval_prio default) do
     specs := Sym.insertPattern specs newSpec.pattern newSpec
-  return { database with specs, erased }
+  return { specs, erased }
 
 end VCGen
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
@@ -104,7 +104,7 @@ public def addSimpSpecs (database : SpecTheorems) (simpThms : SimpTheorems) :
     ++ simpThms.toUnfold.toList.toArray.map (SimpEntry.toUnfold ·)
   for newSpec in ← simpSpecTheorems entries (eval_prio default) do
     specs := Sym.insertPattern specs newSpec.pattern newSpec
-  return { specs, erased }
+  return { database with specs, erased }
 
 end VCGen
 

--- a/tests/elab/vcgenAmbientLocalSpec.lean
+++ b/tests/elab/vcgenAmbientLocalSpec.lean
@@ -6,13 +6,9 @@ import Std.Tactic.Do
 from an ambient hypothesis. The call-site bands sit just above `high`, so an `@[spec high]` used to
 outrank default specs does not shadow a call-site spec, while a priority above the band still does.
 
-`viaBinder`, `viaHave`, and `viaStar` prove the same goal from the same sub-specs. In `viaHave`/
-`viaStar` the concrete `item` spec is a local `have` derived from the quantified hypothesis `H`,
-which is also collected as an ambient spec for `item`. The named `hItem` must be chosen over `H`:
-selecting `H` instantiates its precondition `s = enc b ++ rest` with a fresh `rest` metavariable, and
-matching it against the post-`+` state leaves a frame metavariable `¬ cs = enc b ++ ?vc` that `grind`
-cannot solve through the opaque `enc b`. The recursive, fuel-matched `tail` places the `item` call
-where such a frame arises. `namedBeatsAmbient` and `specAnnotationWins` isolate the banding.
+`viaBinder`, `viaHave`, and `viaStar` prove one goal three ways, checking that a named spec wins over
+the ambient spec collected from the same hypothesis. `namedBeatsSpec`, `specHighLoses`, and
+`specHighestWins` isolate the banding against `@[spec]`, `@[spec high]`, and a priority above the band.
 -/
 
 open Std.Internal.Do Lean.Order

--- a/tests/elab/vcgenAmbientLocalSpec.lean
+++ b/tests/elab/vcgenAmbientLocalSpec.lean
@@ -1,0 +1,98 @@
+import Std.Internal.Do
+import Std.Tactic.Do
+
+/-! `vcgen` ranks the specs available at a call site into priority bands: a spec named in the
+`vcgen [...]` list outranks a local hypothesis pulled in by `*`, which outranks a spec collected
+from an ambient hypothesis. The call-site bands sit just above `high`, so an `@[spec high]` used to
+outrank default specs does not shadow a call-site spec, while a priority above the band still does.
+
+`viaBinder`, `viaHave`, and `viaStar` prove the same goal from the same sub-specs. In `viaHave`/
+`viaStar` the concrete `item` spec is a local `have` derived from the quantified hypothesis `H`,
+which is also collected as an ambient spec for `item`. The named `hItem` must be chosen over `H`:
+selecting `H` instantiates its precondition `s = enc b ++ rest` with a fresh `rest` metavariable, and
+matching it against the post-`+` state leaves a frame metavariable `¬ cs = enc b ++ ?vc` that `grind`
+cannot solve through the opaque `enc b`. The recursive, fuel-matched `tail` places the `item` call
+where such a frame arises. `namedBeatsAmbient` and `specAnnotationWins` isolate the banding.
+-/
+
+open Std.Internal.Do Lean.Order
+set_option mvcgen.warning false
+set_option linter.unusedVariables false
+
+abbrev P := ExceptT String (StateM (List Char))
+
+opaque enc : Nat → List Char
+
+def item (fuel : Nat) : P Nat := do
+  match ← get with
+  | [] => throw "eof"
+  | _ :: cs => set cs; pure fuel
+
+def tail (fuel : Nat) (acc : Nat) : P Nat := do
+  match ← get with
+  | '+' :: cs =>
+    match fuel with
+    | 0 => throw "out of fuel"
+    | fuel + 1 => set cs; let x ← item fuel; tail fuel (acc + x)
+  | _ => pure acc
+
+theorem tail_stop (rest : List Char) (fuel acc : Nat) (h : rest.head? ≠ some '+') :
+    ⦃ fun s => s = rest ⦄ tail fuel acc ⦃ fun r s => r = acc ∧ s = rest ⦄ := by
+  rw [tail]; vcgen (errorOnMissingSpec := false) <;> grind
+
+abbrev ItemSpec (b : Nat) : Prop :=
+  ∀ rest fuel, ⦃ fun s => s = enc b ++ rest ⦄ item fuel ⦃ fun r s => r = b ∧ s = rest ⦄
+
+theorem viaBinder (b : Nat) (rest : List Char) (f : Nat)
+    (hItem : ⦃ fun s => s = enc b ++ rest ⦄ item f ⦃ fun r s => r = b ∧ s = rest ⦄)
+    (hstop : ∀ acc, ⦃ fun s => s = rest ⦄ tail f acc ⦃ fun r s => r = acc ∧ s = rest ⦄) :
+    ∀ acc, ⦃ fun s => s = '+' :: (enc b ++ rest) ⦄ tail (f + 1) acc
+      ⦃ fun r s => r = acc + b ∧ s = rest ⦄ := by
+  intro acc; rw [tail]
+  vcgen (errorOnMissingSpec := false) [hItem, hstop] <;> grind
+
+theorem viaHave (b : Nat) (rest : List Char) (f : Nat)
+    (H : ItemSpec b) (hplus : ¬ rest.head? = some '+') :
+    ∀ acc, ⦃ fun s => s = '+' :: (enc b ++ rest) ⦄ tail (f + 1) acc
+      ⦃ fun r s => r = acc + b ∧ s = rest ⦄ := by
+  intro acc
+  have hItem := H rest f
+  have hstop := fun acc => tail_stop rest f acc hplus
+  rw [tail]
+  vcgen (errorOnMissingSpec := false) [hItem, hstop] <;> grind
+
+-- `*` pulls the quantified `H` into the spec set, but the named `hItem` still outranks it.
+theorem viaStar (b : Nat) (rest : List Char) (f : Nat)
+    (H : ItemSpec b) (hplus : ¬ rest.head? = some '+') :
+    ∀ acc, ⦃ fun s => s = '+' :: (enc b ++ rest) ⦄ tail (f + 1) acc
+      ⦃ fun r s => r = acc + b ∧ s = rest ⦄ := by
+  intro acc
+  have hItem := H rest f
+  have hstop := fun acc => tail_stop rest f acc hplus
+  rw [tail]
+  vcgen (errorOnMissingSpec := false) [hItem, hstop, *] <;> grind
+
+-- `leaf` is opaque so `vcgen` must consult a spec rather than compute the program.
+opaque leaf : StateM Nat Nat
+
+@[spec] axiom leaf_default : ⦃ fun _ => True ⦄ leaf ⦃ fun _ _ => True ⦄
+
+-- A named local spec is chosen over a registered `@[spec]` that also matches `leaf`.
+theorem namedBeatsSpec (hNamed : ⦃ fun _ => True ⦄ leaf ⦃ fun r _ => r = 7 ⦄) :
+    ⦃ fun _ => True ⦄ leaf ⦃ fun r _ => r = 7 ⦄ := by
+  vcgen (errorOnMissingSpec := false) [hNamed] <;> grind
+
+@[spec high] axiom leaf_high : ⦃ fun _ => True ⦄ leaf ⦃ fun _ _ => True ⦄
+
+-- A `high` annotation, which outranks default specs, does not shadow a named local: the named
+-- local is still chosen.
+theorem specHighLoses (hNamed : ⦃ fun _ => True ⦄ leaf ⦃ fun r _ => r = 7 ⦄) :
+    ⦃ fun _ => True ⦄ leaf ⦃ fun r _ => r = 7 ⦄ := by
+  vcgen (errorOnMissingSpec := false) [hNamed] <;> grind
+
+@[spec high + 30] axiom leaf_above : ⦃ fun _ => True ⦄ leaf ⦃ fun r _ => r = 7 ⦄
+
+-- A priority above the call-site band still overrides a named local.
+theorem specHighestWins (hNamed : ⦃ fun _ => True ⦄ leaf ⦃ fun _ _ => True ⦄) :
+    ⦃ fun _ => True ⦄ leaf ⦃ fun r _ => r = 7 ⦄ := by
+  vcgen (errorOnMissingSpec := false) [hNamed] <;> grind


### PR DESCRIPTION
This PR makes `vcgen` prefer a spec named in a `vcgen [...]` argument over one collected from an ambient local hypothesis, and prefer `foo` over a hypothesis pulled in by `*` in `vcgen [foo, *]`, so the spec you supply at a call site wins when several match.

The spec database replaced a duplicate proof entry regardless of priority, so re-collecting an explicitly supplied spec demoted it and let an ambient hypothesis be selected instead. Insertion now keeps the higher priority for a proof already stored, and the call-site categories get distinct bands just above `high`: a named `vcgen [foo]` spec at `high + 20`, a `*` hypothesis at `high + 10`, an `@[spec]` annotation at its annotated priority, and an ambient hypothesis at `low`. This keeps a common `@[spec high]` from shadowing a call-site spec while a higher priority still overrides.