### PR TITLE
feat: logical model for `Float` / `Float32` <-> `IntN` / `ISize` conversions

### DIFF
--- a/src/Init/Data/SInt/Float.lean
+++ b/src/Init/Data/SInt/Float.lean
@@ -20,9 +20,10 @@ If the `Float` is larger than the maximum value for `Int8` (including `Inf`), re
 `Int8` (i.e. `Int8.maxValue`). If it is smaller than the minimum value for `Int8` (including `-Inf`),
 returns the minimum value of `Int8` (i.e. `Int8.minValue`). If it is `NaN`, returns `0`.
 
-This function does not reduce in the kernel.
+This function has a logical model in terms of `Float.Model`.
 -/
-@[extern "lean_float_to_int8"] opaque Float.toInt8 : Float → Int8
+@[extern "lean_float_to_int8"] def Float.toInt8 : Float → Int8 :=
+  fun a => a.toModel.toInt8
 /--
 Truncates a floating-point number to the nearest 16-bit signed integer, rounding towards zero.
 
@@ -31,9 +32,10 @@ value of `Int16` (i.e. `Int16.maxValue`). If it is smaller than the minimum valu
 (including `-Inf`), returns the minimum value of `Int16` (i.e. `Int16.minValue`). If it is `NaN`,
 returns `0`.
 
-This function does not reduce in the kernel.
+This function has a logical model in terms of `Float.Model`.
 -/
-@[extern "lean_float_to_int16"] opaque Float.toInt16 : Float → Int16
+@[extern "lean_float_to_int16"] def Float.toInt16 : Float → Int16 :=
+  fun a => a.toModel.toInt16
 /--
 Truncates a floating-point number to the nearest 32-bit signed integer, rounding towards zero.
 
@@ -42,9 +44,10 @@ value of `Int32` (i.e. `Int32.maxValue`). If it is smaller than the minimum valu
 (including `-Inf`), returns the minimum value of `Int32` (i.e. `Int32.minValue`). If it is `NaN`,
 returns `0`.
 
-This function does not reduce in the kernel.
+This function has a logical model in terms of `Float.Model`.
 -/
-@[extern "lean_float_to_int32"] opaque Float.toInt32 : Float → Int32
+@[extern "lean_float_to_int32"] def Float.toInt32 : Float → Int32 :=
+  fun a => a.toModel.toInt32
 /--
 Truncates a floating-point number to the nearest 64-bit signed integer, rounding towards zero.
 
@@ -53,9 +56,10 @@ value of `Int64` (i.e. `Int64.maxValue`). If it is smaller than the minimum valu
 (including `-Inf`), returns the minimum value of `Int64` (i.e. `Int64.minValue`). If it is `NaN`,
 returns `0`.
 
-This function does not reduce in the kernel.
+This function has a logical model in terms of `Float.Model`.
 -/
-@[extern "lean_float_to_int64"] opaque Float.toInt64 : Float → Int64
+@[extern "lean_float_to_int64"] def Float.toInt64 : Float → Int64 :=
+  fun a => a.toModel.toInt64
 /--
 Truncates a floating-point number to the nearest word-sized signed integer, rounding towards zero.
 
@@ -64,28 +68,20 @@ value of `ISize` (i.e. `ISize.maxValue`). If it is smaller than the minimum valu
 (including `-Inf`), returns the minimum value of `ISize` (i.e. `ISize.minValue`). If it is `NaN`,
 returns `0`.
 
-This function does not reduce in the kernel.
+This function has a logical model in terms of `Float.Model`.
 -/
-@[extern "lean_float_to_isize"] opaque Float.toISize : Float → ISize
+@[extern "lean_float_to_isize"] def Float.toISize : Float → ISize :=
+  fun a => a.toModel.toISize
 
-/--
-Obtains the `Float` whose value is the same as the given `Int8`.
-
-This function does not reduce in the kernel.
--/
-@[extern "lean_int8_to_float"] opaque Int8.toFloat (n : Int8) : Float
-/--
-Obtains the `Float` whose value is the same as the given `Int16`.
-
-This function does not reduce in the kernel.
--/
-@[extern "lean_int16_to_float"] opaque Int16.toFloat (n : Int16) : Float
-/--
-Obtains the `Float` whose value is the same as the given `Int32`.
-
-This function does not reduce in the kernel.
--/
-@[extern "lean_int32_to_float"] opaque Int32.toFloat (n : Int32) : Float
+/-- Obtains the `Float` whose value is the same as the given `Int8`. -/
+@[extern "lean_int8_to_float"] def Int8.toFloat (n : Int8) : Float :=
+  .ofModel (.ofInt8 n)
+/-- Obtains the `Float` whose value is the same as the given `Int16`. -/
+@[extern "lean_int16_to_float"] def Int16.toFloat (n : Int16) : Float :=
+  .ofModel (.ofInt16 n)
+/-- Obtains the `Float` whose value is the same as the given `Int32`. -/
+@[extern "lean_int32_to_float"] def Int32.toFloat (n : Int32) : Float :=
+  .ofModel (.ofInt32 n)
 /--
 Obtains a `Float` whose value is near the given `Int64`.
 
@@ -93,10 +89,11 @@ It will be exactly the value of the given `Int64` if such a `Float` exists. If n
 exists, the returned value will either be the smallest `Float` that is larger than the given value,
 or the largest `Float` that is smaller than the given value.
 
-
-This function does not reduce in the kernel.
+This function has a logical model in terms of `Float.Model`, but is overridden at runtime with an
+efficient implementation.
 -/
-@[extern "lean_int64_to_float"] opaque Int64.toFloat (n : Int64) : Float
+@[extern "lean_int64_to_float"] def Int64.toFloat (n : Int64) : Float :=
+  .ofModel (.ofInt64 n)
 /--
 Obtains a `Float` whose value is near the given `ISize`.
 
@@ -104,6 +101,8 @@ It will be exactly the value of the given `ISize` if such a `Float` exists. If n
 exists, the returned value will either be the smallest `Float` that is larger than the given value,
 or the largest `Float` that is smaller than the given value.
 
-This function does not reduce in the kernel.
+This function has a logical model in terms of `Float.Model`, but is overridden at runtime with an
+efficient implementation.
 -/
-@[extern "lean_isize_to_float"] opaque ISize.toFloat (n : ISize) : Float
+@[extern "lean_isize_to_float"] def ISize.toFloat (n : ISize) : Float :=
+  .ofModel (.ofISize n)

--- a/src/Init/Data/SInt/Float32.lean
+++ b/src/Init/Data/SInt/Float32.lean
@@ -20,9 +20,10 @@ If the `Float` is larger than the maximum value for `Int8` (including `Inf`), re
 `Int8` (i.e. `Int8.maxValue`). If it is smaller than the minimum value for `Int8` (including `-Inf`),
 returns the minimum value of `Int8` (i.e. `Int8.minValue`). If it is `NaN`, returns `0`.
 
-This function does not reduce in the kernel.
+This function has a logical model in terms of `Float32.Model`.
 -/
-@[extern "lean_float32_to_int8"] opaque Float32.toInt8 : Float32 → Int8
+@[extern "lean_float32_to_int8"] def Float32.toInt8 : Float32 → Int8 :=
+  fun a => a.toModel.toInt8
 /--
 Truncates a floating-point number to the nearest 16-bit signed integer, rounding towards zero.
 
@@ -31,9 +32,10 @@ value of `Int16` (i.e. `Int16.maxValue`). If it is smaller than the minimum valu
 (including `-Inf`), returns the minimum value of `Int16` (i.e. `Int16.minValue`). If it is `NaN`,
 returns `0`.
 
-This function does not reduce in the kernel.
+This function has a logical model in terms of `Float32.Model`.
 -/
-@[extern "lean_float32_to_int16"] opaque Float32.toInt16 : Float32 → Int16
+@[extern "lean_float32_to_int16"] def Float32.toInt16 : Float32 → Int16 :=
+  fun a => a.toModel.toInt16
 /--
 Truncates a floating-point number to the nearest 32-bit signed integer, rounding towards zero.
 
@@ -42,9 +44,10 @@ value of `Int32` (i.e. `Int32.maxValue`). If it is smaller than the minimum valu
 (including `-Inf`), returns the minimum value of `Int32` (i.e. `Int32.minValue`). If it is `NaN`,
 returns `0`.
 
-This function does not reduce in the kernel.
+This function has a logical model in terms of `Float32.Model`.
 -/
-@[extern "lean_float32_to_int32"] opaque Float32.toInt32 : Float32 → Int32
+@[extern "lean_float32_to_int32"] def Float32.toInt32 : Float32 → Int32 :=
+  fun a => a.toModel.toInt32
 /--
 Truncates a floating-point number to the nearest 64-bit signed integer, rounding towards zero.
 
@@ -53,9 +56,10 @@ value of `Int64` (i.e. `Int64.maxValue`). If it is smaller than the minimum valu
 (including `-Inf`), returns the minimum value of `Int64` (i.e. `Int64.minValue`). If it is `NaN`,
 returns `0`.
 
-This function does not reduce in the kernel.
+This function has a logical model in terms of `Float32.Model`.
 -/
-@[extern "lean_float32_to_int64"] opaque Float32.toInt64 : Float32 → Int64
+@[extern "lean_float32_to_int64"] def Float32.toInt64 : Float32 → Int64 :=
+  fun a => a.toModel.toInt64
 /--
 Truncates a floating-point number to the nearest word-sized signed integer, rounding towards zero.
 
@@ -64,22 +68,17 @@ value of `ISize` (i.e. `ISize.maxValue`). If it is smaller than the minimum valu
 (including `-Inf`), returns the minimum value of `ISize` (i.e. `ISize.minValue`). If it is `NaN`,
 returns `0`.
 
-This function does not reduce in the kernel.
+This function has a logical model in terms of `Float32.Model`.
 -/
-@[extern "lean_float32_to_isize"] opaque Float32.toISize : Float32 → ISize
+@[extern "lean_float32_to_isize"] def Float32.toISize : Float32 → ISize :=
+  fun a => a.toModel.toISize
 
-/--
-Obtains the `Float32` whose value is the same as the given `Int8`.
-
-This function does not reduce in the kernel.
--/
-@[extern "lean_int8_to_float32"] opaque Int8.toFloat32 (n : Int8) : Float32
-/--
-Obtains the `Float32` whose value is the same as the given `Int16`.
-
-This function does not reduce in the kernel.
--/
-@[extern "lean_int16_to_float32"] opaque Int16.toFloat32 (n : Int16) : Float32
+/-- Obtains the `Float32` whose value is the same as the given `Int8`. -/
+@[extern "lean_int8_to_float32"] def Int8.toFloat32 (n : Int8) : Float32 :=
+  .ofModel (.ofInt8 n)
+/-- Obtains the `Float32` whose value is the same as the given `Int16`. -/
+@[extern "lean_int16_to_float32"] def Int16.toFloat32 (n : Int16) : Float32 :=
+  .ofModel (.ofInt16 n)
 /--
 Obtains a `Float32` whose value is near the given `Int32`.
 
@@ -87,9 +86,11 @@ It will be exactly the value of the given `Int32` if such a `Float32` exists. If
 exists, the returned value will either be the smallest `Float32` that is larger than the given
 value, or the largest `Float32` that is smaller than the given value.
 
-This function does not reduce in the kernel.
+This function has a logical model in terms of `Float32.Model`, but is overridden at runtime with an
+efficient implementation.
 -/
-@[extern "lean_int32_to_float32"] opaque Int32.toFloat32 (n : Int32) : Float32
+@[extern "lean_int32_to_float32"] def Int32.toFloat32 (n : Int32) : Float32 :=
+  .ofModel (.ofInt32 n)
 /--
 Obtains a `Float32` whose value is near the given `Int64`.
 
@@ -97,9 +98,11 @@ It will be exactly the value of the given `Int64` if such a `Float32` exists. If
 exists, the returned value will either be the smallest `Float32` that is larger than the given
 value, or the largest `Float32` that is smaller than the given value.
 
-This function does not reduce in the kernel.
+This function has a logical model in terms of `Float32.Model`, but is overridden at runtime with an
+efficient implementation.
 -/
-@[extern "lean_int64_to_float32"] opaque Int64.toFloat32 (n : Int64) : Float32
+@[extern "lean_int64_to_float32"] def Int64.toFloat32 (n : Int64) : Float32 :=
+  .ofModel (.ofInt64 n)
 /--
 Obtains a `Float32` whose value is near the given `ISize`.
 
@@ -107,6 +110,8 @@ It will be exactly the value of the given `ISize` if such a `Float32` exists. If
 exists, the returned value will either be the smallest `Float32` that is larger than the given
 value, or the largest `Float32` that is smaller than the given value.
 
-This function does not reduce in the kernel.
+This function has a logical model in terms of `Float32.Model`, but is overridden at runtime with an
+efficient implementation.
 -/
-@[extern "lean_isize_to_float32"] opaque ISize.toFloat32 (n : ISize) : Float32
+@[extern "lean_isize_to_float32"] def ISize.toFloat32 (n : ISize) : Float32 :=
+  .ofModel (.ofISize n)


### PR DESCRIPTION
This PR redefines `IntN.toFloat` and `Float.ofIntN` (and the corresponding `Float32` and `ISize` functions) in terms of `Float.Model` and `Float32.Model`. The model already existed but was not used because of an oversight.