### PR TITLE
fix: split `∀` and `iInf` on the RHS of `vcgen` entailments

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
@@ -74,6 +74,9 @@ public structure VCGen.BackwardRules where
   /-- The backward rule for `meet_top_le_of_le`. Cancels a redundant `⊓ ⊤` on the left of an
   entailment, turning `P ⊓ ⊤ ⊑ Q` into `P ⊑ Q`. -/
   meetTop : BackwardRule
+  /-- The backward rule for `Lean.Order.le_forall`. Splits a `∀`/`→` on the RHS of a `Prop`
+  entailment. -/
+  forallIntro : BackwardRule
 
 /-- Build the backward rules used by `solve` from their underlying lemmas. -/
 public def VCGen.mkBackwardRules : MetaM VCGen.BackwardRules := do
@@ -87,6 +90,7 @@ public def VCGen.mkBackwardRules : MetaM VCGen.BackwardRules := do
     andIntro := ← mkBackwardRuleFromDecl ``And.intro
     refl := ← mkBackwardRuleFromDecl ``Lean.Order.PartialOrder.rel_refl
     meetTop := ← mkBackwardRuleFromDecl ``Std.Internal.Do.CompleteLattice.meet_top_le_of_le
+    forallIntro := ← mkBackwardRuleFromDecl ``Lean.Order.le_forall
   }
 
 public structure VCGen.Context where
@@ -171,15 +175,6 @@ public structure VCGen.State where
   sound because it is a subterm of the hash-consed goal target.
   -/
   latticeBackwardRuleCache : Std.HashMap (ExprPtr × Nat) BackwardRule := {}
-  /--
-  A cache mapping `∀`-RHS splits to their backward rule, keyed by the binder domain (held concrete
-  in the rule) and the total argument count (0 for a bare `Prop` forall; non-zero when a Pi into a
-  function lattice is applied to excess state arguments).
-
-  The binder domain is keyed by `ExprPtr`, so lookups compare it by pointer rather than structurally.
-  This is sound because it is a subterm of the hash-consed goal target.
-  -/
-  forallBackwardRuleCache : Std.HashMap (ExprPtr × Nat) BackwardRule := {}
   /-- Caches the `F`-abstract upper-adjoint frame rule (`op_wp_upperAdjoint_le_wp`), keyed by the
   `WPMonad` instance and the number of excess state arguments. -/
   frameBackwardRuleCache : Std.HashMap (ExprPtr × Nat) BackwardRule := {}

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
@@ -171,6 +171,15 @@ public structure VCGen.State where
   sound because it is a subterm of the hash-consed goal target.
   -/
   latticeBackwardRuleCache : Std.HashMap (ExprPtr × Nat) BackwardRule := {}
+  /--
+  A cache mapping `∀`-RHS splits to their backward rule, keyed by the binder domain (held concrete
+  in the rule) and the total argument count (0 for a bare `Prop` forall; non-zero when a Pi into a
+  function lattice is applied to excess state arguments).
+
+  The binder domain is keyed by `ExprPtr`, so lookups compare it by pointer rather than structurally.
+  This is sound because it is a subterm of the hash-consed goal target.
+  -/
+  forallBackwardRuleCache : Std.HashMap (ExprPtr × Nat) BackwardRule := {}
   /-- Caches the `F`-abstract upper-adjoint frame rule (`op_wp_upperAdjoint_le_wp`), keyed by the
   `WPMonad` instance and the number of excess state arguments. -/
   frameBackwardRuleCache : Std.HashMap (ExprPtr × Nat) BackwardRule := {}

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
@@ -74,8 +74,7 @@ public structure VCGen.BackwardRules where
   /-- The backward rule for `meet_top_le_of_le`. Cancels a redundant `⊓ ⊤` on the left of an
   entailment, turning `P ⊓ ⊤ ⊑ Q` into `P ⊑ Q`. -/
   meetTop : BackwardRule
-  /-- The backward rule for `Lean.Order.le_forall`. Splits a `∀`/`→` on the RHS of a `Prop`
-  entailment. -/
+  /-- The backward rule for `le_forall`. Splits a `∀`/`→` on the RHS of a `Prop` entailment. -/
   forallIntro : BackwardRule
 
 /-- Build the backward rules used by `solve` from their underlying lemmas. -/

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Entails.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Entails.lean
@@ -82,7 +82,7 @@ private def refoldHimpUpperAdjoint? (goal : MVarId) (rhs : Expr) :
     return some (← goal.replaceTargetDefEqFast newTarget, rhs')
 
 /--
-Decompose a supported lattice connective (`⊓`, `⇨`, `⌜p⌝`, `⊤`) or a registered frame operator on the
+Decompose a supported lattice connective (`⊓`, `⇨`, `⌜p⌝`, `⊤`, `iInf`) or a registered frame operator on the
 RHS of `pre ⊑ rhs` by saturating it with the built-in and `@[frameproc]` rewrites, closing it with a
 terminal, and point-framing any excess state arguments. Returns `none` if the head is neither a
 built-in connective nor a frame operator, or its rule does not apply.
@@ -98,6 +98,21 @@ public def splitLatticeOp? (goal : MVarId) (rhs : Expr) :
   -- A split applies only for a built-in connective or a registered frame operator.
   let some op := (← read).latticeOps[headName]? | return none
   let rule ← mkLatticeOpRuleCached rhs op
+  match ← rule.applyChecked goal with
+  | .goals goals => return some goals
+  | .failed => return none
+
+/--
+Decompose a `∀`/`→` on the RHS of a `Prop` entailment `pre ⊑ (∀ x, q x)` via the cached
+`le_forall` backward rule. Returns `none` if the RHS is not a `Prop`-valued forall, or the rule
+does not apply. Forall-like goals on a `Pi` assertion lattice should use the `iInf` lattice op
+(after `fun_forall_eq_iInf`) instead, which point-frames excess state arguments.
+-/
+public def splitForallLe? (goal : MVarId) (rhs : Expr) :
+    VCGenM (Option (List MVarId)) := do
+  unless rhs.isForall do return none
+  unless (← Meta.inferType rhs).isProp do return none
+  let rule ← mkForallLeRuleCached rhs
   match ← rule.applyChecked goal with
   | .goals goals => return some goals
   | .failed => return none

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Entails.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Entails.lean
@@ -102,18 +102,12 @@ public def splitLatticeOp? (goal : MVarId) (rhs : Expr) :
   | .goals goals => return some goals
   | .failed => return none
 
-/--
-Decompose a `∀`/`→` on the RHS of a `Prop` entailment `pre ⊑ (∀ x, q x)` via the cached
-`le_forall` backward rule. Returns `none` if the RHS is not a `Prop`-valued forall, or the rule
-does not apply. Forall-like goals on a `Pi` assertion lattice should use the `iInf` lattice op
-(after `fun_forall_eq_iInf`) instead, which point-frames excess state arguments.
--/
+/-- Decompose a `∀`/`→` on the RHS of `pre ⊑ (∀ x, q x)` via `le_forall`. -/
 public def splitForallLe? (goal : MVarId) (rhs : Expr) :
     VCGenM (Option (List MVarId)) := do
   unless rhs.isForall do return none
   unless (← Meta.inferType rhs).isProp do return none
-  let rule ← mkForallLeRuleCached rhs
-  match ← rule.applyChecked goal with
+  match ← (← read).backwardRules.forallIntro.applyChecked goal with
   | .goals goals => return some goals
   | .failed => return none
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Entails.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Entails.lean
@@ -106,7 +106,6 @@ public def splitLatticeOp? (goal : MVarId) (rhs : Expr) :
 public def splitForallLe? (goal : MVarId) (rhs : Expr) :
     VCGenM (Option (List MVarId)) := do
   unless rhs.isForall do return none
-  unless (← Meta.inferType rhs).isProp do return none
   match ← (← read).backwardRules.forallIntro.applyChecked goal with
   | .goals goals => return some goals
   | .failed => return none

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/LatticeOp.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/LatticeOp.lean
@@ -49,9 +49,7 @@ public def LatticeOp.top : LatticeOp :=
 public def LatticeOp.upperAdjoint : LatticeOp :=
   { head := ``Lean.Order.PreservesSup.upperAdjoint,
     terminal? := ``Lean.Order.PreservesSup.le_upperAdjoint }
-/-- Indexed infimum `iInf`/`⨅`: distributes via `iInf_apply`, closes with `le_iInf`. The index type
-`ι` is held constant (`numConst := 3` for `α`/instance/`ι`) so the operand `f` and excess state
-arguments stay schematic. -/
+/-- Indexed infimum `iInf`/`⨅`: distributes via `iInf_apply`, closes with `le_iInf`. -/
 public def LatticeOp.iInf : LatticeOp :=
   { head := ``Lean.Order.iInf, numConst := 3,
     rewrites := #[``Lean.Order.iInf_apply], terminal? := ``Lean.Order.le_iInf }
@@ -182,29 +180,6 @@ public def mkLatticeOpRule (rhs : Expr) (op : LatticeOp) : SymM BackwardRule := 
         pure (mkApp eqMp termProof)
     let res ← abstractMVars prf
     mkBackwardRuleFromExpr res.expr res.paramNames.toList
-
-/--
-Build a reusable backward rule decomposing `pre ⊑ (∀ x, q x)` on the `Prop` lattice. The binder
-domain is held concrete; `q` and `pre` are schematic. Mirrors `mkLatticeOpRule` (schematic operands,
-`mkPointFrameApply` terminal, `abstractMVars`) so the rule is cached per binder domain rather than
-installed as a single static `BackwardRule`.
-
-Produces `∀ q pre, (∀ x, pre ⊑ q x) → pre ⊑ (∀ x, q x)`. Forall-like goals on a `Pi` assertion
-lattice (with excess state arguments) go through the `iInf` lattice op instead, via
-`fun_forall_eq_iInf`.
--/
-public def mkForallLeRule (rhs : Expr) : SymM BackwardRule := do
-  let .forallE n α _body bi := rhs
-    | throwError "forall-le rule expects a bare `∀`{indentExpr rhs}"
-  unless (← Meta.inferType rhs).isProp do
-    throwError "forall-le rule expects a `Prop`-valued right-hand side{indentExpr rhs}"
-  let q ← mkFreshExprMVar (← mkArrow α (mkSort .zero))
-  let forallCore ← withLocalDecl n bi α fun x => do
-    mkForallFVars #[x] (mkApp q x)
-  let pre ← mkFreshExprMVar (mkSort .zero)
-  let prf ← mkPointFrameApply ``Lean.Order.le_forall forallCore pre []
-  let res ← abstractMVars prf
-  mkBackwardRuleFromExpr res.expr res.paramNames.toList
 
 end VCGen
 end Lean.Elab.Tactic.Do.Internal

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/LatticeOp.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/LatticeOp.lean
@@ -28,7 +28,7 @@ fires on the reduced form, and any state arguments the terminal leaves over-appl
 onto the precondition.
 
 A frame operator contributes its own rewrites and terminals through its `@[frameproc]`; the built-in
-seeds cover the lattice connectives `⊓`/`⇨`/`⌜·⌝`/`⊤` and the magic-wand residual `upperAdjoint`.
+seeds cover the lattice connectives `⊓`/`⇨`/`⌜·⌝`/`⊤`/`iInf` and the magic-wand residual `upperAdjoint`.
 -/
 
 /-- The lattice meet `⊓`: distributes via `meet_apply`, closes with `le_meet`. -/
@@ -49,10 +49,16 @@ public def LatticeOp.top : LatticeOp :=
 public def LatticeOp.upperAdjoint : LatticeOp :=
   { head := ``Lean.Order.PreservesSup.upperAdjoint,
     terminal? := ``Lean.Order.PreservesSup.le_upperAdjoint }
+/-- Indexed infimum `iInf`/`⨅`: distributes via `iInf_apply`, closes with `le_iInf`. The index type
+`ι` is held constant (`numConst := 3` for `α`/instance/`ι`) so the operand `f` and excess state
+arguments stay schematic. -/
+public def LatticeOp.iInf : LatticeOp :=
+  { head := ``Lean.Order.iInf, numConst := 3,
+    rewrites := #[``Lean.Order.iInf_apply], terminal? := ``Lean.Order.le_iInf }
 
 /-- The built-in connective splits, whose rewrites and terminals seed every saturation. -/
 public def builtinLatticeOps : Array LatticeOp :=
-  #[.meet, .himp, .ofProp, .top, .upperAdjoint]
+  #[.meet, .himp, .ofProp, .top, .upperAdjoint, .iInf]
 
 /-- The lattice-split table keyed by operator head, merging the built-in connectives with the
 registered frame operators' splits. -/
@@ -177,6 +183,28 @@ public def mkLatticeOpRule (rhs : Expr) (op : LatticeOp) : SymM BackwardRule := 
     let res ← abstractMVars prf
     mkBackwardRuleFromExpr res.expr res.paramNames.toList
 
+/--
+Build a reusable backward rule decomposing `pre ⊑ (∀ x, q x)` on the `Prop` lattice. The binder
+domain is held concrete; `q` and `pre` are schematic. Mirrors `mkLatticeOpRule` (schematic operands,
+`mkPointFrameApply` terminal, `abstractMVars`) so the rule is cached per binder domain rather than
+installed as a single static `BackwardRule`.
+
+Produces `∀ q pre, (∀ x, pre ⊑ q x) → pre ⊑ (∀ x, q x)`. Forall-like goals on a `Pi` assertion
+lattice (with excess state arguments) go through the `iInf` lattice op instead, via
+`fun_forall_eq_iInf`.
+-/
+public def mkForallLeRule (rhs : Expr) : SymM BackwardRule := do
+  let .forallE n α _body bi := rhs
+    | throwError "forall-le rule expects a bare `∀`{indentExpr rhs}"
+  unless (← Meta.inferType rhs).isProp do
+    throwError "forall-le rule expects a `Prop`-valued right-hand side{indentExpr rhs}"
+  let q ← mkFreshExprMVar (← mkArrow α (mkSort .zero))
+  let forallCore ← withLocalDecl n bi α fun x => do
+    mkForallFVars #[x] (mkApp q x)
+  let pre ← mkFreshExprMVar (mkSort .zero)
+  let prf ← mkPointFrameApply ``Lean.Order.le_forall forallCore pre []
+  let res ← abstractMVars prf
+  mkBackwardRuleFromExpr res.expr res.paramNames.toList
 
 end VCGen
 end Lean.Elab.Tactic.Do.Internal

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
@@ -83,6 +83,22 @@ public def mkLatticeOpRuleCached (rhs : Expr) (op : LatticeOp) :
   return rule
 
 /--
+Cached construction of a `∀`-RHS split rule for `pre ⊑ (∀ x, q x) …`. On a cache miss, builds the
+rule via `mkForallLeRule` (schematic `q`/`pre`, point-framing of excess state args).
+
+Cache key: `(binder domain, arg count)`.
+-/
+public def mkForallLeRuleCached (rhs : Expr) : VCGenM BackwardRule := do
+  let fn := rhs.getAppFn
+  let .forallE _ α _ _ := fn
+    | throwError "forall-le cache expects a `∀` head{indentExpr rhs}"
+  let key := (ExprPtr.mk α, rhs.getAppNumArgs)
+  if let some rule := (← get).forallBackwardRuleCache[key]? then return rule
+  let rule ← (← mkForallLeRule rhs).shareCommon
+  modify fun st => { st with forallBackwardRuleCache := st.forallBackwardRuleCache.insert key rule }
+  return rule
+
+/--
 Cached version of `mkFrameBackwardRule`.
 
 Cache key: `(instWP, excessArgs.size)` (the operator is determined by the monad).

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
@@ -83,22 +83,6 @@ public def mkLatticeOpRuleCached (rhs : Expr) (op : LatticeOp) :
   return rule
 
 /--
-Cached construction of a `∀`-RHS split rule for `pre ⊑ (∀ x, q x) …`. On a cache miss, builds the
-rule via `mkForallLeRule` (schematic `q`/`pre`, point-framing of excess state args).
-
-Cache key: `(binder domain, arg count)`.
--/
-public def mkForallLeRuleCached (rhs : Expr) : VCGenM BackwardRule := do
-  let fn := rhs.getAppFn
-  let .forallE _ α _ _ := fn
-    | throwError "forall-le cache expects a `∀` head{indentExpr rhs}"
-  let key := (ExprPtr.mk α, rhs.getAppNumArgs)
-  if let some rule := (← get).forallBackwardRuleCache[key]? then return rule
-  let rule ← (← mkForallLeRule rhs).shareCommon
-  modify fun st => { st with forallBackwardRuleCache := st.forallBackwardRuleCache.insert key rule }
-  return rule
-
-/--
 Cached version of `mkFrameBackwardRule`.
 
 Cache key: `(instWP, excessArgs.size)` (the operator is determined by the monad).

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -541,7 +541,7 @@ public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := g
   let scope ← scope.collectLocalSpecs goal
 
   -- Phase 3: shape the `rhs` (reduce an EPost projection, decompose a lattice connective or a
-  -- `Prop`-forall, then discharge a residual entailment against the lifted hypothesis).
+  -- forall, then discharge a residual entailment against the lifted hypothesis).
   if let some g ← reduceEPostHead? goal target α inst pre rhs then return .goals scope [g]
   if let some gs ← splitLatticeOp? goal rhs then return .goals scope gs
   if let some gs ← splitForallLe? goal rhs then return .goals scope gs

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -540,10 +540,11 @@ public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := g
   -- (`wpMatch?`, `splitLatticeOp?`) or apply a registered spec (`applySpec`).
   let scope ← scope.collectLocalSpecs goal
 
-  -- Phase 3: shape the `rhs` (reduce an EPost projection, decompose a lattice connective), then
-  -- discharge a residual entailment against the lifted hypothesis.
+  -- Phase 3: shape the `rhs` (reduce an EPost projection, decompose a lattice connective or a
+  -- `Prop`-forall, then discharge a residual entailment against the lifted hypothesis).
   if let some g ← reduceEPostHead? goal target α inst pre rhs then return .goals scope [g]
   if let some gs ← splitLatticeOp? goal rhs then return .goals scope gs
+  if let some gs ← splitForallLe? goal rhs then return .goals scope gs
   if let some gs ← liftedHyp? scope goal α pre rhs then return .goals scope gs
 
   -- Phase 4: wp decomposition. The program-shape steps below all consume one unit of fuel

--- a/src/Std/Internal/Do/Order/Basic.lean
+++ b/src/Std/Internal/Do/Order/Basic.lean
@@ -299,28 +299,10 @@ theorem true_le_of_top_le (x : Prop) : ((⊤ : Prop) ⊑ x) → (True : Prop) �
   · intro hall
     exact (le_iInf f (x := ∀ i, f i) (fun i h => h i)) hall
 
-/-- Introduction rule for a `∀` on the RHS of a `Prop` entailment: prove the binder-wise
-entailments `p ⊑ q x`, then reassemble. Dual to using `le_iInf` after rewriting through
-`iInf_prop_eq_forall`; needed because raw `∀`/`→` have no constant head for `splitLatticeOp?`. -/
+/-- Introduction rule for a `∀` on the RHS of a `Prop` entailment. -/
 theorem le_forall {α : Sort u} (p : Prop) (q : α → Prop)
     (h : ∀ x, p ⊑ q x) : p ⊑ (∀ x, q x) :=
   fun hp x => h x hp
-
-/-- Function-lattice form of `le_forall`: `p ⊑ fun s => ∀ x, q x s`. Together with point-framing of
-excess state arguments this is the `Pi` analogue of `le_forall`; definitionally `le_iInf` after
-`fun_forall_eq_iInf`. -/
-theorem le_fun_forall {α : Sort u} {σ : Type v} (q : α → σ → Prop) (p : σ → Prop)
-    (h : ∀ x, p ⊑ q x) : p ⊑ (fun s => ∀ x, q x s) := by
-  intro s hs x
-  exact h x s hs
-
-/-- A state-indexed family of `Prop`-foralls is an indexed infimum. Lets `vcgen` rewrite
-`fun s => ∀ i, f i s` into `iInf f` so the `iInf` lattice split (and its point-framing of excess
-state arguments) applies on any `Pi` assertion lattice. -/
-theorem fun_forall_eq_iInf {ι : Type v} {σ : Type w} (f : ι → σ → Prop) :
-    (fun s => ∀ i, f i s) = iInf f := by
-  funext s
-  rw [iInf_apply, iInf_prop_eq_forall]
 
 @[simp] theorem iSup_prop_eq_exists {ι : Type u} (f : ι → Prop) :
     (iSup f : Prop) = (∃ i, f i) := by

--- a/src/Std/Internal/Do/Order/Basic.lean
+++ b/src/Std/Internal/Do/Order/Basic.lean
@@ -299,6 +299,29 @@ theorem true_le_of_top_le (x : Prop) : ((⊤ : Prop) ⊑ x) → (True : Prop) �
   · intro hall
     exact (le_iInf f (x := ∀ i, f i) (fun i h => h i)) hall
 
+/-- Introduction rule for a `∀` on the RHS of a `Prop` entailment: prove the binder-wise
+entailments `p ⊑ q x`, then reassemble. Dual to using `le_iInf` after rewriting through
+`iInf_prop_eq_forall`; needed because raw `∀`/`→` have no constant head for `splitLatticeOp?`. -/
+theorem le_forall {α : Sort u} (p : Prop) (q : α → Prop)
+    (h : ∀ x, p ⊑ q x) : p ⊑ (∀ x, q x) :=
+  fun hp x => h x hp
+
+/-- Function-lattice form of `le_forall`: `p ⊑ fun s => ∀ x, q x s`. Together with point-framing of
+excess state arguments this is the `Pi` analogue of `le_forall`; definitionally `le_iInf` after
+`fun_forall_eq_iInf`. -/
+theorem le_fun_forall {α : Sort u} {σ : Type v} (q : α → σ → Prop) (p : σ → Prop)
+    (h : ∀ x, p ⊑ q x) : p ⊑ (fun s => ∀ x, q x s) := by
+  intro s hs x
+  exact h x s hs
+
+/-- A state-indexed family of `Prop`-foralls is an indexed infimum. Lets `vcgen` rewrite
+`fun s => ∀ i, f i s` into `iInf f` so the `iInf` lattice split (and its point-framing of excess
+state arguments) applies on any `Pi` assertion lattice. -/
+theorem fun_forall_eq_iInf {ι : Type v} {σ : Type w} (f : ι → σ → Prop) :
+    (fun s => ∀ i, f i s) = iInf f := by
+  funext s
+  rw [iInf_apply, iInf_prop_eq_forall]
+
 @[simp] theorem iSup_prop_eq_exists {ι : Type u} (f : ι → Prop) :
     (iSup f : Prop) = (∃ i, f i) := by
   apply propext

--- a/tests/elab/vcgenForallRhs.lean
+++ b/tests/elab/vcgenForallRhs.lean
@@ -1,0 +1,108 @@
+import Std.Tactic.Do
+import Std.Internal.Do
+
+/-!
+`vcgen` must split a raw `∀`/`→` on the RHS of a `Prop` entailment (`le_forall`) and an `iInf` on
+any `Pi` assertion lattice (`iInf_apply` + `le_iInf`), including when the `iInf` is applied to excess
+state arguments.
+-/
+
+set_option mvcgen.warning false
+
+open Std.Internal.Do
+open Lean.Order
+
+/-! ## Raw `∀` on the `Prop` lattice -/
+
+inductive Lang where
+  | nat (n : Nat)
+  | add (l r : Lang)
+
+inductive IsValue : Lang → Prop where
+  | nat : IsValue (.nat _n)
+
+def Value : Type _ := { l : Lang // IsValue l }
+
+axiom wp : Lang → (Value → Prop) → Prop
+axiom wp_mono : ∀ (post post' : Value → Prop),
+  (∀ (x : Value), post x → post' x) → wp x post → wp x post'
+axiom wp_nat : ∀ {n : Nat} {Φ : Value → Prop}, Φ ⟨.nat n, .nat⟩ → wp (Lang.nat n) Φ
+axiom wp_add : ∀ {l r : Lang} {Φ : Value → Prop},
+  wp l (fun vl => wp r (fun vr => ∀ nl nr,
+    vl.val = Lang.nat nl → vr.val = Lang.nat nr → Φ ⟨.nat (nl + nr), .nat⟩)) →
+  wp (Lang.add l r) Φ
+
+instance instWP_Lang : WP Lang Value Prop EPost.Nil where
+  wpTrans l := ⟨fun Φ _ => wp l Φ⟩
+  wp_trans_monotone x := by
+    simp [PredTrans.monotone, Lean.Order.PartialOrder.rel]
+    intros; apply wp_mono <;> trivial
+
+@[spec]
+theorem spec_nat {n : Nat} {Φ : Value → Prop} : ⦃ Φ ⟨.nat n, .nat⟩ ⦄ (Lang.nat n) ⦃ Φ; epost⟨⟩⦄ :=
+  Triple.iff.mpr wp_nat
+
+@[spec]
+theorem spec_add {l r} {Φ : Value → Prop} :
+    ⦃ Std.Internal.Do.wp l
+        (fun vl => Std.Internal.Do.wp r
+          (fun vr => ∀ nl nr, vl.val = Lang.nat nl → vr.val = Lang.nat nr →
+            Φ ⟨.nat (nl + nr), .nat⟩) epost⟨⟩) epost⟨⟩ ⦄
+      (Lang.add l r) ⦃ Φ; epost⟨⟩⦄ := by
+  refine Triple.iff.mpr ?_
+  simp only [Lean.Order.le_prop_eq_imp]
+  intro h; exact wp_add h
+
+example : ⦃ True ⦄ Lang.add (.add (.nat 1) (.nat 2)) (.nat 3) ⦃ fun v => v.val = Lang.nat 6 ⦄ := by
+  vcgen <;> grind
+
+/-! ## `iInf` on a `Pi` assertion lattice, with excess state arguments -/
+
+/-- Separate program type so the `Nat → Prop` `WP` instance does not compete with `instWP_Lang`. -/
+inductive LangS where
+  | nat (n : Nat)
+  | add (l r : LangS)
+
+inductive IsValueS : LangS → Prop where
+  | nat : IsValueS (.nat _n)
+
+def ValueS : Type _ := { l : LangS // IsValueS l }
+
+axiom wpS : LangS → (ValueS → Nat → Prop) → Nat → Prop
+axiom wpS_mono : ∀ (x : LangS) (post post' : ValueS → Nat → Prop),
+  (∀ v s, post v s → post' v s) → ∀ s, wpS x post s → wpS x post' s
+axiom wpS_nat : ∀ {n : Nat} {Φ : ValueS → Nat → Prop} {s : Nat},
+  Φ ⟨.nat n, .nat⟩ s → wpS (LangS.nat n) Φ s
+axiom wpS_add : ∀ {l r} {Φ : ValueS → Nat → Prop} {s : Nat},
+  wpS l (fun vl s => wpS r (fun vr s =>
+    (iInf fun nl => iInf fun nr =>
+      ⌜vl.val = LangS.nat nl⌝ ⇨ ⌜vr.val = LangS.nat nr⌝ ⇨ Φ ⟨.nat (nl + nr), .nat⟩) s) s) s →
+  wpS (LangS.add l r) Φ s
+
+instance instWP_LangS : WP LangS ValueS (Nat → Prop) EPost.Nil where
+  wpTrans l := ⟨fun Φ _ => wpS l Φ⟩
+  wp_trans_monotone x := by
+    simp [PredTrans.monotone, Lean.Order.PartialOrder.rel]
+    intros; apply wpS_mono <;> trivial
+
+@[spec]
+theorem spec_nat_s {n : Nat} {Φ : ValueS → Nat → Prop} :
+    ⦃ Φ ⟨.nat n, .nat⟩ ⦄ (LangS.nat n) ⦃ Φ; epost⟨⟩⦄ := by
+  refine Triple.iff.mpr ?_
+  intro s hs; exact wpS_nat hs
+
+@[spec]
+theorem spec_add_s {l r} {Φ : ValueS → Nat → Prop} :
+    ⦃ Std.Internal.Do.wp l
+        (fun vl => Std.Internal.Do.wp r
+          (fun vr => iInf fun nl => iInf fun nr =>
+            ⌜vl.val = LangS.nat nl⌝ ⇨ ⌜vr.val = LangS.nat nr⌝ ⇨
+              Φ ⟨.nat (nl + nr), .nat⟩) epost⟨⟩) epost⟨⟩ ⦄
+      (LangS.add l r) ⦃ Φ; epost⟨⟩⦄ := by
+  refine Triple.iff.mpr ?_
+  intro s h; exact wpS_add h
+
+example : ⦃ fun _ => True ⦄
+    LangS.add (.add (.nat 1) (.nat 2)) (.nat 3)
+    ⦃ fun v _ => v.val = LangS.nat 6 ⦄ := by
+  vcgen <;> grind


### PR DESCRIPTION
This PR teaches `vcgen` to decompose a raw `∀`/`→` on the RHS of a `Prop` entailment and an `iInf` on any `Pi` assertion lattice.

A bare `Prop` forall has no constant head, so `splitLatticeOp?` cannot fire. `vcgen` now builds a cached `le_forall` backward rule using the same schematic/point-frame construction as lattice ops. Independently, `iInf` is registered as a built-in lattice op with `iInf_apply`/`le_iInf`, so goals such as `pre ⊑ (iInf f) s⃗` distribute through the state and introduce binder-wise subgoals.