### PR TITLE
fix: kernel to check opaque values for fvars

### DIFF
--- a/src/kernel/environment.cpp
+++ b/src/kernel/environment.cpp
@@ -214,6 +214,7 @@ environment environment::add_opaque(declaration const & d, bool check) const {
     if (check) {
         type_checker checker(*this, diag.get());
         check_constant_val(*this, v.to_constant_val(), checker);
+        check_no_metavar_no_fvar(*this, v.get_name(), v.get_value());
         expr val_type = checker.check(v.get_value(), v.get_lparams());
         if (!checker.is_def_eq(val_type, v.get_type()))
             throw definition_type_mismatch_exception(*this, d, val_type);

--- a/tests/elab/issue14484.lean
+++ b/tests/elab/issue14484.lean
@@ -1,0 +1,35 @@
+import Lean
+open Lean
+
+private def cachePrimingType : Expr :=
+  let falseE := mkConst ``False
+  let falseToFalse := .forallE `h falseE falseE .default
+  let identity := .lam `h falseE (.bvar 0) .default
+  .app (.lam `_ falseToFalse falseE .default) identity
+
+/--
+info: kernel accepted opaqueFVarCacheFalse : False
+---
+error: (kernel) declaration has free variables 'opaqueFVarCacheFalse', expression: ⏎
+  _kernel_fresh.2
+-/
+#guard_msgs in
+run_meta
+  let name := `opaqueFVarCacheFalse
+  addDecl <| .opaqueDecl {
+    name
+    levelParams := []
+    type := cachePrimingType
+    value := .fvar { name := .num `_kernel_fresh 2 }
+    isUnsafe := false
+  }
+  logInfo m!"kernel accepted {name} : False"
+
+theorem assumptionFreeFalse : False := opaqueFVarCacheFalse
+
+/-- info: 'opaqueFVarCacheFalse' depends on axioms: [opaqueFVarCacheFalse, sorryAx] -/
+#guard_msgs in
+#print axioms opaqueFVarCacheFalse
+/-- info: 'assumptionFreeFalse' depends on axioms: [assumptionFreeFalse] -/
+#guard_msgs in
+#print axioms assumptionFreeFalse


### PR DESCRIPTION
This PR fixes a kernel unsoundness: just as for definitions and theorems, an `opaque` declaration's value must not contain fvars.

This was discovered by Patrick Hulin with the help of GPT-5.6 Sol.

The impact of this bug is that a malicious metaprogram can prove `False`, by first seeding the kernel's type checker cache for a free variable, and then refering to that free variable from the body of an `opaque`. See #14484 for an example.

Because the export format used by comparator [cannot even express an fvar](https://github.com/leanprover/lean4export/blob/af5aa64bb914c3c2c781f378088dbd38acf4f804/Export.lean#L160), the “[gold standard for validating proofs](https://lean-lang.org/doc/reference/latest/ValidatingProofs/#validating-comparator)” is – luckily – not affected. And even if it were, users who use comparator with nanoda as a second independent checker would be safe, as [the bug does not exist in nanoda](https://github.com/ammkrn/nanoda_lib/blob/f58f2f6d535e189a40fcb02ede8eb95f97a92d37/src/tc.rs#L169).

This bug can only be exploited by meta programs running in the same process. Such malicious meta programs can do nefarious things; this is known and unavoidable. So while we have a genuine kernel unsoundness at hand, it does not lead to new attack vectors in practice.

Fixes #14484
