### PR TITLE
fix: activate CompleteLattice→CCPO under open Std.Internal.Do

### DIFF
--- a/src/Std/Internal/Do/Triple/Basic.lean
+++ b/src/Std/Internal/Do/Triple/Basic.lean
@@ -61,6 +61,10 @@ private meta def hintProgram (c : Term) (m? : Option Term) : MacroM Term :=
   | some m => `(($c : $m _))
   | none => if isSplitProgram c.raw then `(($c : (_ : _ → _) _)) else pure c
 
+-- Make `CompleteLattice → CCPO` (hence `⊥` / `Lean.Order.bot`) available under
+-- `open Std.Internal.Do`, so Hoare triple notation does not require `open Lean.Order`.
+attribute [scoped instance] Lean.Order.instCCPO_std
+
 /-- Hoare triple notation without exception postcondition (defaults to `⊥`). An optional `(m := …)`
 after the precondition ascribes the program to monad `…`. -/
 scoped syntax:60 (name := tripleNotation)

--- a/tests/elab/vcgenHaveGoalMData.lean
+++ b/tests/elab/vcgenHaveGoalMData.lean
@@ -2,11 +2,12 @@ import Std.Internal.Do
 import Std.Tactic.Do
 
 /-! A tactic `have`/`let`/`suffices` wraps the goal in `noImplicitLambda` `mdata` (via
-`refine_lift no_implicit_lambda% …`). `vcgen` must read the program type through that annotation. -/
+`refine_lift no_implicit_lambda% …`). `vcgen` must read the program type through that annotation.
+Also checks that `⦃…⦄` elaborates with only `open Std.Internal.Do` (no `open Lean.Order`). -/
 
 set_option mvcgen.warning false
 
-open Std.Internal.Do Lean.Order
+open Std.Internal.Do
 
 example : ⦃fun _ => True⦄ (pure 1 : StateM Nat Nat) ⦃fun _ _ => True⦄ := by
   have _h : True := trivial


### PR DESCRIPTION
This PR scopes `Lean.Order.instCCPO_std` into `Std.Internal.Do` so Hoare triple notation (which defaults the exception postcondition to `⊥`) elaborates after `open Std.Internal.Do` without also requiring `open Lean.Order`.

Previously `⦃ P ⦄ x ⦃ Q ⦄` expanded to `Triple … Lean.Order.bot`, and synthesizing `CCPO` for the exception postcondition required the scoped `CompleteLattice → CCPO` instance from `Lean.Order`. Opening only `Std.Internal.Do` (as needed for the notation) left that instance inactive and failed with `failed to synthesize Lean.Order.CCPO EPost⟨⟩`. The fix uses `attribute [scoped instance]` so the same instance is also activated by `open Std.Internal.Do`.