### PR TITLE
chore: inline `LintVerbosity.medium` in builtin lint

### DIFF
--- a/src/Lean/Linter/EnvLinter/Frontend.lean
+++ b/src/Lean/Linter/EnvLinter/Frontend.lean
@@ -23,16 +23,6 @@ open Lean Meta
 
 namespace Lean.Linter.EnvLinter
 
-/-- Verbosity for the linter output. -/
-inductive LintVerbosity
-  /-- `low`: only print failing checks, print nothing on success. -/
-  | low
-  /-- `medium`: only print failing checks, print confirmation on success. -/
-  | medium
-  /-- `high`: print output of every check. -/
-  | high
-  deriving Inhabited, DecidableEq, Repr
-
 /--
 Getter for the registered environment linters. The result is sorted by the linter option name.
 -/
@@ -138,7 +128,7 @@ def formatLinterResults
     (decls : Array Name)
     (groupByFilename : Bool)
     (whereDesc : String)
-    (verbose : LintVerbosity) (numLinters : Nat) (useErrorFormat : Bool := false) :
+    (numLinters : Nat) (useErrorFormat : Bool := false) :
     CoreM MessageData := do
   let formattedResults ← results.filterMapM fun (linter, results) => do
     if !results.isEmpty then
@@ -148,15 +138,12 @@ def formatLinterResults
         else
           printWarnings results
       pure $ some m!"/- The `{linter.optName}` linter reports:\n{linter.errorsFound} -/\n{warnings}\n"
-    else if verbose = LintVerbosity.high then
-      pure $ some m!"/- OK: {linter.noErrorsFound} -/"
     else
       pure none
   let mut s := MessageData.joinSep formattedResults.toList Format.line
   let numAutoDecls := (← decls.filterM isAutoDeclOrPrivate_Internal).size
   let failed := results.map (·.2.size) |>.foldl (·+·) 0
-  unless verbose matches LintVerbosity.low do
-    s := m!"-- Found {failed} error{if failed == 1 then "" else "s"
+  s := m!"-- Found {failed} error{if failed == 1 then "" else "s"
       } in {decls.size - numAutoDecls} declarations (plus {
       numAutoDecls} automatically generated ones) {whereDesc
       } with {numLinters} linters\n\n{s}"

--- a/src/lake/Lake/CLI/BuiltinLint.lean
+++ b/src/lake/Lake/CLI/BuiltinLint.lean
@@ -321,7 +321,7 @@ public def run (args : Args) : IO UInt32 := do
           let fmtResults ←
             Linter.EnvLinter.formatLinterResults results decls
               (groupByFilename := true) (useErrorFormat := true)
-              s!"in {mod}" .medium linters.size
+              s!"in {mod}" linters.size
           IO.print (← fmtResults.toString)
         else unless textFailed do
           IO.println s!"-- Linting passed for {mod}."

--- a/tests/elab/env_linter.lean
+++ b/tests/elab/env_linter.lean
@@ -236,7 +236,7 @@ def testFormatResults : CoreM Format := do
   let results ← lintCore #[`badDef, `goodDef] linters
   let msg ← formatLinterResults results #[`badDef, `goodDef]
     (groupByFilename := false) (whereDesc := "in test")
-    (verbose := .medium) (numLinters := linters.size)
+    (numLinters := linters.size)
   return (← msg.format)
 
 /--
@@ -255,7 +255,7 @@ def testFormatResultsClean : CoreM Format := do
   let results ← lintCore #[`goodDef] linters
   let msg ← formatLinterResults results #[`goodDef]
     (groupByFilename := false) (whereDesc := "in test")
-    (verbose := .medium) (numLinters := linters.size)
+    (numLinters := linters.size)
   return (← msg.format)
 
 /--


### PR DESCRIPTION
This PR removes `LintVerbosity` from builtin environment linting and inlines the code path for `LintVerbosity.mendium`