### PR TITLE
chore: lake: overhaul benchmarks & add precompile variants

### DIFF
--- a/tests/lake_bench/inundation/lakefile.lean
+++ b/tests/lake_bench/inundation/lakefile.lean
@@ -2,6 +2,7 @@ import Lake
 open Lake DSL
 
 def test := get_config? test |>.getD "Test" |>.capitalize
+def precompile := get_config? precompile >>= envToBool? |>.getD false
 
 package inundation where
   buildDir := defaultBuildDir / test
@@ -10,6 +11,7 @@ package inundation where
 lean_lib Inundation where
   srcDir := "test"
   roots := #[.mkSimple test]
+  precompileModules := precompile
 
 script nop :=
   return 0

--- a/tests/lake_bench/inundation/lakefile.lean
+++ b/tests/lake_bench/inundation/lakefile.lean
@@ -53,9 +53,9 @@ USAGE:
 -/
 script mkBuild (args : List String) := do
   let argc := args.length
-  let some layers := if h : argc > 0 then args[0].toNat? else some 40
+  let some layers := if h : argc > 0 then args[0].toNat? else some 20
     | return 1
-  let some width  := if h : argc > 1 then args[1].toNat? else some 40
+  let some width  := if h : argc > 1 then args[1].toNat? else some 20
     | return 1
 
   let mkImportsFor (layer : Nat) := Id.run do

--- a/tests/lake_bench/inundation/lakefile.lean
+++ b/tests/lake_bench/inundation/lakefile.lean
@@ -2,6 +2,9 @@ import Lake
 open Lake DSL
 
 def test := get_config? test |>.getD "Test" |>.capitalize
+def testName := Lean.Name.mkSimple test
+def layers := get_config? layers >>= (·.toNat?) |>.getD 20
+def width := get_config? width >>= (·.toNat?) |>.getD 20
 def precompile := get_config? precompile >>= envToBool? |>.getD false
 
 package inundation where
@@ -10,17 +13,60 @@ package inundation where
 @[default_target]
 lean_lib Inundation where
   srcDir := "test"
-  roots := #[.mkSimple test]
+  roots := #[testName]
   precompileModules := precompile
 
-script nop :=
-  return 0
+/- Vary the number of libraries (e.g., for precompilation) -/
+section
 
 partial def num2letters (n : Nat) : String :=
   if n >= 26 then
     num2letters (n / 26 - 1) ++ num2letters (n % 26)
   else
     Char.toString <| .ofNat <| 'A'.toNat + n
+
+def testRoots (lo hi : Nat) :=
+  (lo...(min hi layers)).toArray.map (testName.str ∘ num2letters)
+
+lean_lib InundationD where
+  srcDir := "test"
+  roots := testRoots 0 4
+  precompileModules := precompile
+
+meta if layers > 4 then
+lean_lib InundationH where
+  srcDir := "test"
+  roots := testRoots 4 8
+  precompileModules := precompile
+
+meta if layers > 8 then
+lean_lib InundationL where
+  srcDir := "test"
+  roots := testRoots 8 12
+  precompileModules := precompile
+
+meta if layers > 12 then
+lean_lib InundationP where
+  srcDir := "test"
+  roots := testRoots 12 16
+  precompileModules := precompile
+
+meta if layers > 16 then
+lean_lib InundationT where
+  srcDir := "test"
+  roots := testRoots 16 20
+  precompileModules := precompile
+
+meta if layers > 20 then
+lean_lib InundationY where
+  srcDir := "test"
+  roots := testRoots 20 24
+  precompileModules := precompile
+
+end
+
+script nop :=
+  return 0
 
 /--
 Generate multiple configurations for the configuration test.
@@ -49,19 +95,13 @@ script mkTree (args : List String) := do
 Generate imports for a build test.
 
 USAGE:
-  lake run [-Ktest=<dir>] mkBuild [<layers>] [<width>]
+  lake run [-Ktest=<dir>] [-Klayers=<n>] [-Kwidth=<n>] mkBuild
 -/
-script mkBuild (args : List String) := do
-  let argc := args.length
-  let some layers := if h : argc > 0 then args[0].toNat? else some 20
-    | return 1
-  let some width  := if h : argc > 1 then args[1].toNat? else some 20
-    | return 1
-
+script mkBuild := do
   let mkImportsFor (layer : Nat) := Id.run do
     let mut out := ""
     for idx in *...width do
-      out := out ++ s!"import {test}.{num2letters layer}{idx}\n"
+      out := out ++ s!"import {test}.{num2letters layer}.M{idx}\n"
     return out
   let mkImportsAt (layer : Nat) :=
     if let .succ prev := layer then mkImportsFor prev else ""
@@ -74,9 +114,11 @@ script mkBuild (args : List String) := do
     | e => throw e
   IO.FS.createDirAll (testDir / test)
   for layer in *...layers do
+    let layerDir := testDir / test / num2letters layer
+    IO.FS.createDir layerDir
+    IO.FS.writeFile (layerDir.addExtension "lean") (mkImportsFor layer)
     for idx in *...width do
-      IO.FS.writeFile (testDir / test / s!"{num2letters layer}{idx}.lean") <|
-        mkImportsAt layer
+      IO.FS.writeFile (layerDir / s!"M{idx}.lean") (mkImportsAt layer)
   IO.FS.writeFile (testDir / s!"{test}.lean") (mkImportsAt layers)
 
   return 0

--- a/tests/lake_bench/inundation/run_bench.sh
+++ b/tests/lake_bench/inundation/run_bench.sh
@@ -1,38 +1,50 @@
 PREFIX="lake/inundation"
 rm -f measurements.jsonl
 
-echo "Running $PREFIX/build clean"
-cp lakefile.lean lakefile-clean.lean
-lake -f lakefile-clean.lean -R -K test=Clean run mkBuild
-lake -f lakefile-clean.lean build
-"$TEST_DIR/measure.py" -t "$PREFIX/build clean" -d -a -- \
-  bash -c "lake -f lakefile-clean.lean clean && lake -f lakefile-clean.lean build"
+echo "Running $PREFIX"
+rm -rf .lake lake-manifest.json test
+lake -R run mkBuild
 
 echo "Running $PREFIX/build no-op"
-cp lakefile.lean lakefile-nop.lean
-lake -f lakefile-nop.lean -R -K test=Nop run mkBuild
-lake -f lakefile-nop.lean build
+lake -R clean
+lake build
 "$TEST_DIR/measure.py" -t "$PREFIX/build no-op" -d -a -- \
-  lake -f lakefile-nop.lean build
+  lake build
+
+echo "Running $PREFIX/build clean"
+lake -R clean
+"$TEST_DIR/measure.py" -t "$PREFIX/build clean" -d -a -- \
+  lake build
+
+echo "Running $PREFIX/build precompile no-op"
+lake -R -K precompile=true clean
+lake build
+"$TEST_DIR/measure.py" -t "$PREFIX/build precompile no-op" -d -a -- \
+  lake build
+
+echo "Running $PREFIX/build precompile clean"
+lake -R -K precompile=true clean
+"$TEST_DIR/measure.py" -t "$PREFIX/build precompile clean" -d -a -- \
+  lake build
 
 echo "Running $PREFIX/config elab"
-cp lakefile.lean lakefile-rc.lean
+lake -R run nop
 "$TEST_DIR/measure.py" -t "$PREFIX/config elab" -d -a -- \
-  lake -f lakefile-rc.lean -R run nop
+  lake -R run nop
 
 echo "Running $PREFIX/config import"
-lake run nop
+lake -R run nop
 "$TEST_DIR/measure.py" -t "$PREFIX/config import" -d -a -- \
   lake run nop
 
 echo "Running $PREFIX/config tree"
-lake run mkTree
+lake -R run mkTree
 lake -d test/tree update
 "$TEST_DIR/measure.py" -t "$PREFIX/config tree" -d -a -- \
   lake -d test/tree run nop
 
 echo "Running $PREFIX/env"
-lake env true
+lake -R env true
 "$TEST_DIR/measure.py" -t "$PREFIX/env" -d -a -- \
   lake env true
 

--- a/tests/lake_bench/inundation/run_bench.sh
+++ b/tests/lake_bench/inundation/run_bench.sh
@@ -16,15 +16,15 @@ lake -R clean
 "$TEST_DIR/measure.py" -t "$PREFIX/build/clean" -d -a -- \
   lake build
 
-echo "Running $PREFIX/build/precompile+no-op"
+echo "Running $PREFIX/build/precompile/no-op"
 lake -R -K precompile=true clean
 lake build
-"$TEST_DIR/measure.py" -t "$PREFIX/build/precompile+no-op" -d -a -- \
+"$TEST_DIR/measure.py" -t "$PREFIX/build/precompile/no-op" -d -a -- \
   lake build
 
-echo "Running $PREFIX/build/precompile+clean"
+echo "Running $PREFIX/build/precompile/clean"
 lake -R -K precompile=true clean
-"$TEST_DIR/measure.py" -t "$PREFIX/build/precompile+clean" -d -a -- \
+"$TEST_DIR/measure.py" -t "$PREFIX/build/precompile/clean" -d -a -- \
   lake build
 
 echo "Running $PREFIX/config/elab"

--- a/tests/lake_bench/inundation/run_bench.sh
+++ b/tests/lake_bench/inundation/run_bench.sh
@@ -5,42 +5,42 @@ echo "Running $PREFIX"
 rm -rf .lake lake-manifest.json test
 lake -R run mkBuild
 
-echo "Running $PREFIX/build no-op"
+echo "Running $PREFIX/build/no-op"
 lake -R clean
 lake build
-"$TEST_DIR/measure.py" -t "$PREFIX/build no-op" -d -a -- \
+"$TEST_DIR/measure.py" -t "$PREFIX/build/no-op" -d -a -- \
   lake build
 
-echo "Running $PREFIX/build clean"
+echo "Running $PREFIX/build/clean"
 lake -R clean
-"$TEST_DIR/measure.py" -t "$PREFIX/build clean" -d -a -- \
+"$TEST_DIR/measure.py" -t "$PREFIX/build/clean" -d -a -- \
   lake build
 
-echo "Running $PREFIX/build precompile no-op"
+echo "Running $PREFIX/build/precompile+no-op"
 lake -R -K precompile=true clean
 lake build
-"$TEST_DIR/measure.py" -t "$PREFIX/build precompile no-op" -d -a -- \
+"$TEST_DIR/measure.py" -t "$PREFIX/build/precompile+no-op" -d -a -- \
   lake build
 
-echo "Running $PREFIX/build precompile clean"
+echo "Running $PREFIX/build/precompile+clean"
 lake -R -K precompile=true clean
-"$TEST_DIR/measure.py" -t "$PREFIX/build precompile clean" -d -a -- \
+"$TEST_DIR/measure.py" -t "$PREFIX/build/precompile+clean" -d -a -- \
   lake build
 
-echo "Running $PREFIX/config elab"
+echo "Running $PREFIX/config/elab"
 lake -R run nop
-"$TEST_DIR/measure.py" -t "$PREFIX/config elab" -d -a -- \
+"$TEST_DIR/measure.py" -t "$PREFIX/config/elab" -d -a -- \
   lake -R run nop
 
-echo "Running $PREFIX/config import"
+echo "Running $PREFIX/config/import"
 lake -R run nop
-"$TEST_DIR/measure.py" -t "$PREFIX/config import" -d -a -- \
+"$TEST_DIR/measure.py" -t "$PREFIX/config/import" -d -a -- \
   lake run nop
 
-echo "Running $PREFIX/config tree"
+echo "Running $PREFIX/config/tree"
 lake -R run mkTree
 lake -d test/tree update
-"$TEST_DIR/measure.py" -t "$PREFIX/config tree" -d -a -- \
+"$TEST_DIR/measure.py" -t "$PREFIX/config/tree" -d -a -- \
   lake -d test/tree run nop
 
 echo "Running $PREFIX/env"


### PR DESCRIPTION
This PR overhauls the Lake  `inundation` benchmark suite and adds new variants of `no-op` and `clean` that run with `precompileModules := true`.

The layers and width of the benchmark have been halved, and Inundation now has multiple sub-libraries. The previous clean build was already quite long, and the new precompiled version is longer. Shrinking the size brings the benchmarks down to reasonable time budget of 5-10s. 

Since these changes invalidate most of the benchmarks anyway, they have been renamed slightly to better fit the naming conventions of other measurements.  The scripts themselves have also been cleaned up to remove leftover artifacts from the previous benchmark harness and to ensure the benchmarks remain correct regardless of order or repetition.