### PR TITLE
chore: lake: import all Lake modules in `Lake.All`

### DIFF
--- a/src/lake/Lake/All.lean
+++ b/src/lake/Lake/All.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2026 Mac Malone. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mac Malone
+-/
+module
+
+prelude
+public import Lake
+public import Lake.Build
+public import Lake.CLI
+public import Lake.Config
+public import Lake.DSL
+public import Lake.Load
+public import Lake.Reservoir
+public import Lake.Toml
+public import Lake.Util
+public import Lake.Version
+
+/-! # `Lake.All`
+
+This module imports (and thus initializes) every Lake module. Its existence is important for the
+Lean core build. Users of the Lake DSL are expected to import `Lake` instead in configuration files.
+It imports a smaller set of modules better targeted to that use (excluding things like the CLI).
+-/

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,6 +1,6 @@
 #include "util/options.h"
 
-// Should we test stage 2 and run update-stage0 on PR merge? NO
+// Should we test stage 2 and run update-stage0 on PR merge? YES
 // (change to "YES" to trigger)
 
 namespace lean {


### PR DESCRIPTION
This PR adds `Lake.All` module which imports (and thus initializes) every module in Lake.

After this PR is merged and stage0 is updated, this module's initializer will be used when loading the Lake plugin in the core build. This will fix potential bootstrapping issues caused by uninitialized Lake modules.
