### PR TITLE
chore: initialize Lake plugin using `Lake.All` in core build

### DIFF
--- a/src/lakefile.toml.in
+++ b/src/lakefile.toml.in
@@ -81,7 +81,7 @@ globs = ["Lake.*"]
 defaultFacets = ["static", "static.export"]
 # Load the previous stage's lake native code into lake's build process in order to prevent ABI
 # breakages from affecting bootstrapping.
-weakLeanArgs = ["--plugin", "${PREV_STAGE}/${CMAKE_RELATIVE_LIBRARY_OUTPUT_DIRECTORY}/libLake_shared${CMAKE_SHARED_LIBRARY_SUFFIX}"]
+weakLeanArgs = ["--plugin", "${PREV_STAGE}/${CMAKE_RELATIVE_LIBRARY_OUTPUT_DIRECTORY}/libLake_shared${CMAKE_SHARED_LIBRARY_SUFFIX}=initialize_Lake_All"]
 
 [[lean_lib]]
 name = "LakeMain"


### PR DESCRIPTION
This PR uses the initializer for `Lake.All` (`initialize_Lake_All`) to initialize the Lake plugin for the core build. This ensures all modules within the plugin are initialized.
