### PR TITLE
fix: add missing space before `do` in `for` loop pretty-printing

### DIFF
--- a/src/Lean/Parser/Do.lean
+++ b/src/Lean/Parser/Do.lean
@@ -184,7 +184,7 @@ until at least one of them is exhausted.
 The types of `e2` etc. must implement the `Std.ToStream` typeclass.
 -/
 @[builtin_doElem_parser] def doFor    := leading_parser
-  "for " >> sepBy1 doForDecl ", " >> "do " >> doSeq
+  "for " >> sepBy1 doForDecl ", " >> " do " >> doSeq
 
 def dependentParam := leading_parser
   atomic ("(" >> nonReservedSymbol "dependent") >> " := " >>

--- a/tests/elab/formatTerm.lean
+++ b/tests/elab/formatTerm.lean
@@ -10,6 +10,10 @@ def fmt (stx : CoreM Syntax) : CoreM Format := do PrettyPrinter.ppTerm ⟨← st
 #eval fmt `(if c then do t else if c then do t else do e) -- FIXME: make this cascade better?
 #eval fmt `(do if c then t else e)
 #eval fmt `(do if c then t else if c then t else e)
+#eval fmt `(do for x in xs do pure ())
+#eval fmt `(do let mut acc := 0; for x in xs do acc := acc + x; return acc)
+#eval fmt `(do while c do pure ())
+#eval fmt `(do unless c do pure ())
 
 #eval fmt `(def foo := by
   · skip; skip

--- a/tests/elab/formatTerm.lean.out.expected
+++ b/tests/elab/formatTerm.lean.out.expected
@@ -32,6 +32,20 @@ do
     t✝
   else
     e✝
+do
+  for x✝ in xs✝ do
+    pure✝ ()
+do
+  let mut acc✝ := 0;
+  for x✝ in xs✝ do
+    acc✝ := acc✝ + x✝;
+    return acc✝
+do
+  while c✝ do
+    pure✝ ()
+do
+  unless c✝ do
+    pure✝ ()
 def foo✝ := by
   · skip; skip
   · skip; skip


### PR DESCRIPTION
This PR makes a `for` do-element pretty-print with a space before `do`. The do-element `for` parser emitted `"do "` with no leading space, so reformatting a `for … do` block glued the range to the keyword (`for x in xs do` printed as `for x in xsdo`). Every sibling do-keyword (`while`, `unless`, term-level `for`) already emits ` do `; this aligns `for`.

A small formatter test parses a `for … do` block and pins the spaced output.
