### PR TITLE
perf: memoize lifted copies of substituted values in instantiateMVars

### DIFF
--- a/src/library/instantiate_mvars.cpp
+++ b/src/library/instantiate_mvars.cpp
@@ -375,8 +375,8 @@ class instantiate_delayed_fn {
 
     /* Memo for `lift_loose_bvars(value, d)` applied to fvar-substitution
        values in `lookup_fvar`; see comment there. `lift_loose_bvars` is a
-       pure function of (value, d), so a global memo is sound. Keeps the keyed
-       exprs alive for the lifetime of the pass, so raw-pointer keys remain
+       pure function of (value, d), so a global memo is sound. The keyed
+       exprs are retained via `m_saved`, so the raw-pointer keys remain
        valid. */
     std::unordered_map<cache_key, expr, key_hasher> m_lift_cache;
 
@@ -506,6 +506,11 @@ class instantiate_delayed_fn {
         if (lit != m_lift_cache.end())
             return optional<expr>(lit->second);
         expr lifted = lift_loose_bvars(v, d);
+        /* Retain the input: the raw-pointer key must not dangle. The
+           substitution entry holding `v` can be dropped while the cache
+           entry lives on, and only lifted copies of `v` may survive in the
+           output. */
+        m_saved.push_back(v);
         m_lift_cache.insert(mk_pair(key, lifted));
         return optional<expr>(lifted);
     }

--- a/src/library/instantiate_mvars.cpp
+++ b/src/library/instantiate_mvars.cpp
@@ -373,6 +373,13 @@ class instantiate_delayed_fn {
     typedef std::pair<lean_object *, unsigned> cache_key;
     scope_cache<cache_key, expr, key_hasher> m_cache;
 
+    /* Memo for `lift_loose_bvars(value, d)` applied to fvar-substitution
+       values in `lookup_fvar`; see comment there. `lift_loose_bvars` is a
+       pure function of (value, d), so a global memo is sound. Keeps the keyed
+       exprs alive for the lifetime of the pass, so raw-pointer keys remain
+       valid. */
+    std::unordered_map<cache_key, expr, key_hasher> m_lift_cache;
+
     /* After visit() returns, this holds the maximum fvar-substitution
        scope that contributed to the result — i.e., the outermost scope at which the
        result is valid and can be cached. Updated monotonically (via max) through
@@ -481,7 +488,26 @@ class instantiate_delayed_fn {
         unsigned d = m_depth - it->second.depth;
         if (d == 0)
             return optional<expr>(it->second.value);
-        return optional<expr>(lift_loose_bvars(it->second.value, d));
+        expr const & v = it->second.value;
+        if (!has_loose_bvars(v))
+            return optional<expr>(v);
+        if (is_bvar(v)) /* single node: lifting directly is cheaper than the memo */
+            return optional<expr>(mk_bvar(bvar_idx(v) + nat(d)));
+        /* Memoize lifted copies: without this, every occurrence of the fvar at
+           a deeper binder depth creates a fresh copy of the (open) substituted
+           value. Occurrences of a hypothesis introduced via `MVarId.assert` +
+           `intro` (e.g. `MVarId.note`, `replaceLocalDecl`, `simp at h`)
+           produce exactly this shape, and the copies can compound
+           multiplicatively along chains of delayed-assigned MVars
+           (issue #14329). With the memo, all occurrences at the same binder
+           depth share one lifted copy. */
+        auto key = std::make_pair(v.raw(), d);
+        auto lit = m_lift_cache.find(key);
+        if (lit != m_lift_cache.end())
+            return optional<expr>(lit->second);
+        expr lifted = lift_loose_bvars(v, d);
+        m_lift_cache.insert(mk_pair(key, lifted));
+        return optional<expr>(lifted);
     }
 
     /* Get a direct MVar assignment. Visit it to resolve delayed-assigned

--- a/tests/elab/issue14329a.lean
+++ b/tests/elab/issue14329a.lean
@@ -1,0 +1,119 @@
+import Lean
+
+/-!
+Regression test for the same-binder-depth part of #14329: the fused
+`instantiateMVars` (#12233) substitutes fvars by values that may contain loose
+bvars of enclosing binders, and every occurrence at a deeper binder depth
+received a fresh `lift_loose_bvars` copy of the value. Hypotheses introduced
+via `MVarId.assert`+`intro` (as done by `MVarId.note`, `replaceLocalDecl`,
+`simp at h`, ...) and referenced several times produce exactly this shape, and
+the copies compound multiplicatively along the chain of delayed assignments.
+
+Each step below adds binder depth (`obtain` from an existential) and asserts a
+hypothesis whose proof references the previous step's hypothesis three times —
+all at the same binder depth, so memoizing the lifted copies makes all three
+occurrences share one copy. With the memo this elaborates instantly; without
+it, it needs around 3^40 expression nodes and runs out of memory.
+
+The variant where the references sit at several different binder depths (which
+memoization alone does not cover) is `issue14329b.lean`.
+-/
+
+open Lean Elab Tactic in
+/-- Introduce `h := e` via `MVarId.note` (i.e. `assert` + `intro`), like many
+tactics do; unlike the `have` tactic, this makes the proof term a delayed-mvar
+application argument that `instantiateMVars` substitutes into the use sites. -/
+elab "note_ " x:ident " := " t:term : tactic => withMainContext do
+  let e ← elabTerm t none
+  let g ← (← getMainGoal).note x.getId e
+  replaceMainGoal [g.2]
+
+axiom S : Type
+axiom Rel : S → S → Prop
+axiom ex : ∀ (s : S), ∃ t, Rel s t
+axiom comb : ∀ {a b : S}, Rel a b → Rel a b → Rel a b → Rel a b
+
+theorem test (s0 : S) : True := by
+  obtain ⟨t, ht⟩ := ex s0
+  note_ h := comb ht ht ht
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  trivial


### PR DESCRIPTION
This PR memoizes, per (value, lift amount), the `lift_loose_bvars` copies that `instantiateMVars` makes when substituting an fvar whose substitution value contains loose bvars of enclosing binders. Previously every occurrence of such an fvar at a deeper binder depth received a fresh copy of the value; with the memo, all occurrences at the same binder depth share one copy. This addresses part of #14329: hypotheses introduced via `MVarId.assert`/`intro` (as done by `MVarId.note`, `replaceLocalDecl`, `simp at h`, ...) and referenced several times produce exactly this shape, and the per-occurrence copies compound multiplicatively along chains of delayed-assigned mvars.

This does not yet cover references at several *different* binder depths (copies of copies are fresh objects the memo has no key for, so they still compound); that part, which the LNSym reproduction of #14329 also needs, is addressed separately in #14514.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JrR3ks4WxS2jbDB6ooKDea
