### PR TITLE
chore: CI: create adaptation PRs regardless of PR target

### DIFF
--- a/.github/workflows/adaptation-pr.yml
+++ b/.github/workflows/adaptation-pr.yml
@@ -3,7 +3,6 @@ name: Adaptation PR
 
 on:
   pull_request_target:
-    branches: [master]
     types:
       - labeled
       - closed


### PR DESCRIPTION
Sometimes, merge conflicts between downstream-green and master will prevent CI from running, meaning no adaptation PR will be created. In those cases, the workaround is to target downstream-green temporarily so CI can run and build a toolchain for the adaptation PR. This PR makes that workaround possible.
