### PR TITLE
perf: cache and canonicalize lifts of substituted values in instantiateMVars

### DIFF
--- a/src/library/instantiate_mvars.cpp
+++ b/src/library/instantiate_mvars.cpp
@@ -375,8 +375,8 @@ class instantiate_delayed_fn {
 
     /* Memo for `lift_loose_bvars(value, d)` applied to fvar-substitution
        values in `lookup_fvar`; see comment there. `lift_loose_bvars` is a
-       pure function of (value, d), so a global memo is sound. Keeps the keyed
-       exprs alive for the lifetime of the pass, so raw-pointer keys remain
+       pure function of (value, d), so a global memo is sound. The keyed
+       exprs are retained via `m_saved`, so the raw-pointer keys remain
        valid. */
     std::unordered_map<cache_key, expr, key_hasher> m_lift_cache;
 
@@ -506,6 +506,11 @@ class instantiate_delayed_fn {
         if (lit != m_lift_cache.end())
             return optional<expr>(lit->second);
         expr lifted = lift_loose_bvars(v, d);
+        /* Retain the input: the raw-pointer key must not dangle. The
+           substitution entry holding `v` can be dropped while the cache
+           entry lives on, and only lifted copies of `v` may survive in the
+           output. */
+        m_saved.push_back(v);
         m_lift_cache.insert(mk_pair(key, lifted));
         return optional<expr>(lifted);
     }

--- a/src/library/instantiate_mvars.cpp
+++ b/src/library/instantiate_mvars.cpp
@@ -353,6 +353,133 @@ public:
    values cannot be written back.
    ============================================================================ */
 
+/* ============================================================================
+   Lifting of fvar-substitution values, with pass-lifetime caching and origin
+   tracking (issue #14329).
+
+   Pass 2 substitutes fvars by values that may contain loose bvars of
+   enclosing binders; every occurrence of such an fvar at a deeper binder
+   depth needs the value lifted by the depth difference. This class
+   encapsulates `lift_loose_bvars` for these values such that each lift is
+   materialized only once:
+
+   * Results are cached for the lifetime of the pass, keyed by
+     (node, cutoff, amount), so all occurrences at the same depth — also of
+     values shared between substitution entries — share one copy.
+
+   * Whole-value results are indexed back to their origin (`m_origin`):
+     `r ↦ (v, s)` records `r = lift_loose_bvars(v, s)`. Lifting `r` again by
+     `d` then redirects to the canonical lift of `v` by `s + d` instead of
+     copying the copy. Without this, substitution values that embed lifted
+     copies of earlier values (as chains of `MVarId.assert`-introduced
+     hypotheses produce) would re-copy those embedded copies at every level,
+     and the copies compound multiplicatively.
+
+   The origin redirect requires all loose bvars of `r` to be shifted, which
+   holds iff the cutoff at the redirect is ≤ s (a whole-value lift by `s` has
+   all its loose bvars ≥ s). Since substitution values always stem from
+   enclosing scopes, their embedded copies sit at binder depths ≤ their
+   accumulated shift, so the condition always holds in this pass; if it does
+   not, the code falls back to the structural copy, which is correct but
+   unshared — the redirect is a pure sharing optimization.
+   ============================================================================ */
+
+class lift_fn {
+    struct key {
+        lean_object * m_ptr;
+        unsigned      m_cutoff;
+        unsigned      m_amount;
+        bool operator==(key const & other) const {
+            return m_ptr == other.m_ptr && m_cutoff == other.m_cutoff && m_amount == other.m_amount;
+        }
+    };
+    struct key_hasher {
+        std::size_t operator()(key const & k) const {
+            return hash(hash((size_t)k.m_ptr >> 3, k.m_cutoff), k.m_amount);
+        }
+    };
+    lean::unordered_map<key, expr, key_hasher> m_cache;
+
+    /* result node ↦ (origin, amount), for whole-value (cutoff 0) results
+       only: interior results leave their sub-cutoff bvars alone, so they have
+       no context-free identity to index. Keys are retained by the
+       corresponding `m_cache` entries, origins by the map values. */
+    lean::unordered_map<lean_object *, std::pair<expr, unsigned>> m_origin;
+
+    /* Retain inputs of raw-pointer keys: a substitution value can be dropped
+       while its cache entry lives on, and address reuse would make a later
+       lookup return an unrelated expression. */
+    std::vector<expr> m_saved;
+
+    expr apply(expr const & e, unsigned cutoff, unsigned amount) {
+        /* No loose bvars at or above the cutoff — also covers closed
+           subterms. (`get_loose_bvar_range` is cached in the header.) */
+        if (cutoff >= get_loose_bvar_range(e))
+            return e;
+        if (is_bvar(e)) /* range check guarantees bvar_idx(e) ≥ cutoff */
+            return mk_bvar(bvar_idx(e) + nat(amount));
+
+        /* Origin redirect; see the class comment. */
+        {
+            auto it = m_origin.find(e.raw());
+            if (it != m_origin.end() && cutoff <= it->second.second)
+                return apply(it->second.first, 0, it->second.second + amount);
+        }
+
+        key k{e.raw(), cutoff, amount};
+        /* Whole-value results are looked up once per occurrence of the
+           corresponding fvar regardless of the node's reference count, so
+           always cache them; gate interior nodes on sharing as usual. */
+        bool cache_it = cutoff == 0 || !is_likely_unshared(e);
+        if (cache_it) {
+            auto it = m_cache.find(k);
+            if (it != m_cache.end())
+                return it->second;
+        }
+
+        expr r;
+        switch (e.kind()) {
+        case expr_kind::Const: case expr_kind::Sort:
+        case expr_kind::BVar:  case expr_kind::Lit:
+        case expr_kind::MVar:  case expr_kind::FVar:
+            lean_unreachable(); /* no loose bvars, or handled above */
+        case expr_kind::MData:
+            r = update_mdata(e, apply(mdata_expr(e), cutoff, amount));
+            break;
+        case expr_kind::Proj:
+            r = update_proj(e, apply(proj_expr(e), cutoff, amount));
+            break;
+        case expr_kind::App:
+            r = update_app(e, apply(app_fn(e), cutoff, amount),
+                              apply(app_arg(e), cutoff, amount));
+            break;
+        case expr_kind::Pi: case expr_kind::Lambda:
+            r = update_binding(e, apply(binding_domain(e), cutoff, amount),
+                                  apply(binding_body(e), cutoff + 1, amount));
+            break;
+        case expr_kind::Let:
+            r = update_let(e, apply(let_type(e), cutoff, amount),
+                              apply(let_value(e), cutoff, amount),
+                              apply(let_body(e), cutoff + 1, amount));
+            break;
+        }
+        if (cache_it) {
+            m_saved.push_back(e);
+            m_cache.insert(mk_pair(k, r));
+        }
+        if (cutoff == 0)
+            m_origin.insert(mk_pair(r.raw(), mk_pair(e, amount)));
+        return r;
+    }
+
+public:
+    expr operator()(expr const & e, unsigned amount) {
+        if (amount == 0)
+            return e;
+        return apply(e, 0, amount);
+    }
+};
+
 struct fvar_subst_entry {
     unsigned depth;
     unsigned scope;
@@ -373,12 +500,8 @@ class instantiate_delayed_fn {
     typedef std::pair<lean_object *, unsigned> cache_key;
     scope_cache<cache_key, expr, key_hasher> m_cache;
 
-    /* Memo for `lift_loose_bvars(value, d)` applied to fvar-substitution
-       values in `lookup_fvar`; see comment there. `lift_loose_bvars` is a
-       pure function of (value, d), so a global memo is sound. The keyed
-       exprs are retained via `m_saved`, so the raw-pointer keys remain
-       valid. */
-    std::unordered_map<cache_key, expr, key_hasher> m_lift_cache;
+    /* Lift cache for fvar-substitution values; see `lift_fn`. */
+    lift_fn m_lift;
 
     /* After visit() returns, this holds the maximum fvar-substitution
        scope that contributed to the result — i.e., the outermost scope at which the
@@ -488,31 +611,10 @@ class instantiate_delayed_fn {
         unsigned d = m_depth - it->second.depth;
         if (d == 0)
             return optional<expr>(it->second.value);
-        expr const & v = it->second.value;
-        if (!has_loose_bvars(v))
-            return optional<expr>(v);
-        if (is_bvar(v)) /* single node: lifting directly is cheaper than the memo */
-            return optional<expr>(mk_bvar(bvar_idx(v) + nat(d)));
-        /* Memoize lifted copies: without this, every occurrence of the fvar at
-           a deeper binder depth creates a fresh copy of the (open) substituted
-           value. Occurrences of a hypothesis introduced via `MVarId.assert` +
-           `intro` (e.g. `MVarId.note`, `replaceLocalDecl`, `simp at h`)
-           produce exactly this shape, and the copies can compound
-           multiplicatively along chains of delayed-assigned MVars
-           (issue #14329). With the memo, all occurrences at the same binder
-           depth share one lifted copy. */
-        auto key = std::make_pair(v.raw(), d);
-        auto lit = m_lift_cache.find(key);
-        if (lit != m_lift_cache.end())
-            return optional<expr>(lit->second);
-        expr lifted = lift_loose_bvars(v, d);
-        /* Retain the input: the raw-pointer key must not dangle. The
-           substitution entry holding `v` can be dropped while the cache
-           entry lives on, and only lifted copies of `v` may survive in the
-           output. */
-        m_saved.push_back(v);
-        m_lift_cache.insert(mk_pair(key, lifted));
-        return optional<expr>(lifted);
+        /* Lift through the pass-lifetime cache so that every lift of a
+           substitution value is materialized only once (issue #14329);
+           see `lift_fn`. */
+        return optional<expr>(m_lift(it->second.value, d));
     }
 
     /* Get a direct MVar assignment. Visit it to resolve delayed-assigned

--- a/src/library/instantiate_mvars.cpp
+++ b/src/library/instantiate_mvars.cpp
@@ -375,13 +375,16 @@ public:
      hypotheses produce) would re-copy those embedded copies at every level,
      and the copies compound multiplicatively.
 
-   The origin redirect requires all loose bvars of `r` to be shifted, which
-   holds iff the cutoff at the redirect is ≤ s (a whole-value lift by `s` has
-   all its loose bvars ≥ s). Since substitution values always stem from
-   enclosing scopes, their embedded copies sit at binder depths ≤ their
-   accumulated shift, so the condition always holds in this pass; if it does
-   not, the code falls back to the structural copy, which is correct but
-   unshared — the redirect is a pure sharing optimization.
+   Correctness of the origin redirect is local: `r = lift_loose_bvars(v, s)`
+   has all its loose bvars ≥ s, so if the cutoff at the redirect is ≤ s — the
+   guard checks this — the shift applies to all of them and the composition
+   is exact. The redirect must also fire at cutoff > 0: an occurrence under a
+   binder within a substituted value places its lifted copy at the
+   corresponding depth inside the value, and skipping the redirect there
+   would re-copy the copy at every level again. When the guard fails
+   (substitution values always stem from enclosing scopes, so it should not),
+   the code falls back to the structural copy, which is correct but
+   unshared.
    ============================================================================ */
 
 class lift_fn {
@@ -418,8 +421,10 @@ class lift_fn {
         if (is_bvar(e)) /* range check guarantees bvar_idx(e) ≥ cutoff */
             return mk_bvar(bvar_idx(e) + nat(amount));
 
-        /* Origin redirect; see the class comment. */
-        {
+        /* Origin redirect; see the class comment. Registered nodes are also
+           cached, so their reference count is at least 2 once they are
+           embedded anywhere; this makes the lookup free for unshared nodes. */
+        if (!is_likely_unshared(e)) {
             auto it = m_origin.find(e.raw());
             if (it != m_origin.end() && cutoff <= it->second.second)
                 return apply(it->second.first, 0, it->second.second + amount);

--- a/src/library/instantiate_mvars.cpp
+++ b/src/library/instantiate_mvars.cpp
@@ -413,8 +413,6 @@ class lift_fn {
     std::vector<expr> m_saved;
 
     expr apply(expr const & e, unsigned cutoff, unsigned amount) {
-        /* No loose bvars at or above the cutoff — also covers closed
-           subterms. (`get_loose_bvar_range` is cached in the header.) */
         if (cutoff >= get_loose_bvar_range(e))
             return e;
         if (is_bvar(e)) /* range check guarantees bvar_idx(e) ≥ cutoff */
@@ -612,9 +610,6 @@ class instantiate_delayed_fn {
         unsigned d = m_depth - it->second.depth;
         if (d == 0)
             return optional<expr>(it->second.value);
-        /* Lift through the pass-lifetime cache so that every lift of a
-           substitution value is materialized only once (issue #14329);
-           see `lift_fn`. */
         return optional<expr>(m_lift(it->second.value, d));
     }
 

--- a/src/library/instantiate_mvars.cpp
+++ b/src/library/instantiate_mvars.cpp
@@ -400,9 +400,10 @@ class lift_fn {
     };
     lean::unordered_map<key, expr, key_hasher> m_cache;
 
-    /* result node ↦ (origin, amount), for whole-value (cutoff 0) results
-       only: interior results leave their sub-cutoff bvars alone, so they have
-       no context-free identity to index. Keys are retained by the
+    /* result node ↦ (origin, amount): records `result = lift(origin, amount)`.
+       We could also record interior (cutoff > 0) results, including their
+       cutoff and using them only on a matching cutoff, but we only need this
+       for cutoff 0, and it is simpler this way. Keys are retained by the
        corresponding `m_cache` entries, origins by the map values. */
     lean::unordered_map<lean_object *, std::pair<expr, unsigned>> m_origin;
 

--- a/src/library/instantiate_mvars.cpp
+++ b/src/library/instantiate_mvars.cpp
@@ -373,6 +373,13 @@ class instantiate_delayed_fn {
     typedef std::pair<lean_object *, unsigned> cache_key;
     scope_cache<cache_key, expr, key_hasher> m_cache;
 
+    /* Memo for `lift_loose_bvars(value, d)` applied to fvar-substitution
+       values in `lookup_fvar`; see comment there. `lift_loose_bvars` is a
+       pure function of (value, d), so a global memo is sound. Keeps the keyed
+       exprs alive for the lifetime of the pass, so raw-pointer keys remain
+       valid. */
+    std::unordered_map<cache_key, expr, key_hasher> m_lift_cache;
+
     /* After visit() returns, this holds the maximum fvar-substitution
        scope that contributed to the result — i.e., the outermost scope at which the
        result is valid and can be cached. Updated monotonically (via max) through
@@ -481,7 +488,26 @@ class instantiate_delayed_fn {
         unsigned d = m_depth - it->second.depth;
         if (d == 0)
             return optional<expr>(it->second.value);
-        return optional<expr>(lift_loose_bvars(it->second.value, d));
+        expr const & v = it->second.value;
+        if (!has_loose_bvars(v))
+            return optional<expr>(v);
+        if (is_bvar(v)) /* single node: lifting directly is cheaper than the memo */
+            return optional<expr>(mk_bvar(bvar_idx(v) + nat(d)));
+        /* Memoize lifted copies: without this, every occurrence of the fvar at
+           a deeper binder depth creates a fresh copy of the (open) substituted
+           value. Occurrences of a hypothesis introduced via `MVarId.assert` +
+           `intro` (e.g. `MVarId.note`, `replaceLocalDecl`, `simp at h`)
+           produce exactly this shape, and the copies can compound
+           multiplicatively along chains of delayed-assigned MVars
+           (issue #14329). With the memo, all occurrences at the same binder
+           depth share one lifted copy. */
+        auto key = std::make_pair(v.raw(), d);
+        auto lit = m_lift_cache.find(key);
+        if (lit != m_lift_cache.end())
+            return optional<expr>(lit->second);
+        expr lifted = lift_loose_bvars(v, d);
+        m_lift_cache.insert(mk_pair(key, lifted));
+        return optional<expr>(lifted);
     }
 
     /* Get a direct MVar assignment. Visit it to resolve delayed-assigned

--- a/tests/elab/issue14329a.lean
+++ b/tests/elab/issue14329a.lean
@@ -1,0 +1,119 @@
+import Lean
+
+/-!
+Regression test for the same-binder-depth part of #14329: the fused
+`instantiateMVars` (#12233) substitutes fvars by values that may contain loose
+bvars of enclosing binders, and every occurrence at a deeper binder depth
+received a fresh `lift_loose_bvars` copy of the value. Hypotheses introduced
+via `MVarId.assert`+`intro` (as done by `MVarId.note`, `replaceLocalDecl`,
+`simp at h`, ...) and referenced several times produce exactly this shape, and
+the copies compound multiplicatively along the chain of delayed assignments.
+
+Each step below adds binder depth (`obtain` from an existential) and asserts a
+hypothesis whose proof references the previous step's hypothesis three times —
+all at the same binder depth, so memoizing the lifted copies makes all three
+occurrences share one copy. With the memo this elaborates instantly; without
+it, it needs around 3^40 expression nodes and runs out of memory.
+
+The variant where the references sit at several different binder depths (which
+memoization alone does not cover) is `issue14329b.lean`.
+-/
+
+open Lean Elab Tactic in
+/-- Introduce `h := e` via `MVarId.note` (i.e. `assert` + `intro`), like many
+tactics do; unlike the `have` tactic, this makes the proof term a delayed-mvar
+application argument that `instantiateMVars` substitutes into the use sites. -/
+elab "note_ " x:ident " := " t:term : tactic => withMainContext do
+  let e ← elabTerm t none
+  let g ← (← getMainGoal).note x.getId e
+  replaceMainGoal [g.2]
+
+axiom S : Type
+axiom Rel : S → S → Prop
+axiom ex : ∀ (s : S), ∃ t, Rel s t
+axiom comb : ∀ {a b : S}, Rel a b → Rel a b → Rel a b → Rel a b
+
+theorem test (s0 : S) : True := by
+  obtain ⟨t, ht⟩ := ex s0
+  note_ h := comb ht ht ht
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb h h h
+  trivial

--- a/tests/elab/issue14329b.lean
+++ b/tests/elab/issue14329b.lean
@@ -17,6 +17,10 @@ times, from several different binder depths. Memoizing the lifted copies (see
 are fresh objects the memo has no key for, so they still compound. With
 sharing preserved this elaborates instantly; otherwise it needs an exponential
 number of expression nodes and runs out of memory.
+
+The second theorem references the previous hypothesis from inside lambdas, so
+its lifted copies sit under binders within the substituted value; this checks
+that sharing is preserved for copies embedded at nonzero binder depth as well.
 -/
 
 open Lean Elab Tactic in
@@ -120,4 +124,51 @@ theorem test2 (s0 : S) : True := by
   note_ ha := comb ha hb ha
   obtain ⟨t, ht⟩ := ex t
   note_ hb := comb ha hb hb
+  trivial
+
+axiom comb2 : ∀ {a b : S}, (S → Rel a b) → (S → S → Rel a b) → Rel a b → Rel a b
+
+theorem test3 (s0 : S) : True := by
+  obtain ⟨t, ht⟩ := ex s0
+  note_ h := comb2 (fun _ => ht) (fun _ _ => ht) ht
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
+  obtain ⟨t, ht⟩ := ex t
+  note_ h := comb2 (fun _ => h) (fun _ _ => h) h
   trivial

--- a/tests/elab/issue14329b.lean
+++ b/tests/elab/issue14329b.lean
@@ -1,0 +1,123 @@
+import Lean
+
+/-!
+Regression test for #14329: the fused two-pass `instantiateMVars` (#12233) lost
+sharing when a hypothesis introduced via `MVarId.assert`+`intro` (as done by
+`MVarId.note`, `replaceLocalDecl`, `simp at h`, ...) is referenced several times
+from deeper binder scopes. The pending value's occurrences of the hypothesis
+fvar were each replaced by a fresh `lift_loose_bvars` copy of the (open)
+substituted value, so per-step copies compounded multiplicatively and the final
+instantiation was exponential in the number of steps (observed as OOM in
+LNSym's `sym_n` tactic).
+
+Each step below adds binder depth (`obtain` from an existential) and asserts
+two hypotheses whose proofs reference the previous step's hypotheses three
+times, from several different binder depths. Memoizing the lifted copies (see
+`issue14329a.lean` for that variant) does not help here: the copies of copies
+are fresh objects the memo has no key for, so they still compound. With
+sharing preserved this elaborates instantly; otherwise it needs an exponential
+number of expression nodes and runs out of memory.
+-/
+
+open Lean Elab Tactic in
+/-- Introduce `h := e` via `MVarId.note` (i.e. `assert` + `intro`), like many
+tactics do; unlike the `have` tactic, this makes the proof term a delayed-mvar
+application argument that `instantiateMVars` substitutes into the use sites. -/
+elab "note_ " x:ident " := " t:term : tactic => withMainContext do
+  let e ← elabTerm t none
+  let g ← (← getMainGoal).note x.getId e
+  replaceMainGoal [g.2]
+
+axiom S : Type
+axiom Rel : S → S → Prop
+axiom ex : ∀ (s : S), ∃ t, Rel s t
+axiom comb : ∀ {a b : S}, Rel a b → Rel a b → Rel a b → Rel a b
+
+/-- Pattern where the previous step's hypotheses are referenced from several
+different binder depths: this defeats plain memoization of the lifted copies,
+so the copies compound even with a `(value, lift amount)` memo. -/
+theorem test2 (s0 : S) : True := by
+  obtain ⟨t, ht⟩ := ex s0
+  note_ ha := comb ht ht ht
+  note_ hb := comb ht ht ht
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  obtain ⟨t, ht⟩ := ex t
+  note_ ha := comb ha hb ha
+  obtain ⟨t, ht⟩ := ex t
+  note_ hb := comb ha hb hb
+  trivial

--- a/tests/elab_bench/delayed_lift.lean
+++ b/tests/elab_bench/delayed_lift.lean
@@ -1,0 +1,49 @@
+import Lean
+
+/-!
+This benchmark exercises `instantiateMVars` on chains of hypotheses introduced
+via `MVarId.assert`+`intro` (as done by `MVarId.note`, `replaceLocalDecl`,
+`simp at h`, ...) whose proofs reference the previous hypothesis several times,
+from different binder depths and from inside lambdas. Resolving the delayed
+assignments substitutes these hypothesis proofs into their use sites, lifted
+to the respective binder depth, and the lifted copies must be shared for the
+instantiated proof term to stay small (issue #14329).
+
+Each step destructures an existential (adding binder depth) and notes a new
+hypothesis whose proof references the previous one three times.
+-/
+
+set_option maxHeartbeats 40000000
+
+axiom S : Type
+axiom Rel : S → S → Prop
+axiom s0 : S
+axiom rel0 : Rel s0 s0
+axiom ex : ∀ (s : S), ∃ t, Rel s t
+axiom comb : ∀ {a b : S}, (S → Rel a b) → (S → S → Rel a b) → Rel a b → Rel a b
+
+open Lean Meta
+
+-- n=1000 is calibrated to take roughly 1s total elaboration time.
+-- Use a small n unless TEST_BENCH=1, so that the test suite runs quickly.
+run_meta do
+  let bench := (← IO.getEnv "TEST_BENCH") == some "1"
+  let n := if bench then 1000 else 15
+  let g0 ← mkFreshExprSyntheticOpaqueMVar (mkConst ``True)
+  let mut g := g0.mvarId!
+  let mut t : Expr := mkConst ``s0
+  let mut h : Expr := mkConst ``rel0
+  for _ in [0:n] do
+    let (hexFVar, g') ← g.note `hex (mkApp (mkConst ``ex) t)
+    let #[sub] ← g'.cases hexFVar | failure
+    g := sub.mvarId
+    t := sub.fields[0]!
+    let val ← g.withContext do
+      let lam1 := mkLambda `x .default (mkConst ``S) h
+      let lam2 := mkLambda `x .default (mkConst ``S) (mkLambda `y .default (mkConst ``S) h)
+      mkAppM ``comb #[lam1, lam2, h]
+    let (hFVar, g'') ← g.note `h val
+    g := g''
+    h := mkFVar hFVar
+  g.assign (mkConst ``True.intro)
+  discard <| instantiateMVars g0


### PR DESCRIPTION
This PR fixes an exponential blowup (time and memory, typically surfacing as an out-of-memory failure) in `instantiateMVars` on proof terms that repeatedly reference hypotheses introduced via `MVarId.assert`/`intro` — as done by `MVarId.note`, `replaceLocalDecl`, `simp at h`, and, per step, by LNSym's `sym_n` tactic. Fixes #14329.

Since #12233, `instantiateMVars` resolves delayed metavariable assignments in a single fused pass that carries an fvar substitution through the chain. The substituted values can contain loose bvars of enclosing binders, so every occurrence of such an fvar at a deeper binder depth needs the value lifted by the depth difference, and `lift_loose_bvars` materializes a fresh copy each time. Because substitution values have all enclosing substitutions already applied, they physically embed the lifted copies made for earlier hypotheses, so lifting them copies those again: with each step referencing the previous step's hypotheses k times, the copies compound to k^N nodes. In the LNSym reproduction this means ~4x growth per simulated instruction and an OOM at 12 steps.

This PR routes all lifting of substitution values through a single lift implementation with a cache that lives for the whole pass: results are memoized per (node, cutoff, amount), so all occurrences of a value at the same depth — including values shared between substitution entries — share one copy, and whole-value results are indexed back to their origin, so lifting an already-lifted value redirects to one canonical copy per (origin, cumulative amount) instead of copying the copy. Together this materializes every lift at most once, which bounds the instantiated term by one copy per distinct cumulative depth and restores linear behavior on the workloads above. The origin redirect is a pure sharing optimization: it fires only when the cutoff at the redirect is at most the recorded shift — in which case all loose bvars of the copy are shifted and the composition `lift d ∘ lift s = lift (s + d)` is exact — and otherwise falls back to the structural copy, which is always correct. The implementation follows the patterns of `lift_loose_bvars` and `replace_rec_fn`: subtree pruning via the cached loose-bvar range, sharing-gated caching of interior nodes, allocation-free rebuilds via `update_*`, and retention of the expressions behind raw-pointer cache keys.

Verified against the LNSym reproduction from #14329: the instantiated proof term is back to linear size (matching the v4.29 node counts), and the full 27-step popcount32 probe elaborates in about 1.2s where it previously exceeded 41GB. The two reproducer patterns are added as `tests/elab/issue14329a.lean` (occurrences at one binder depth, covered by memoization alone) and `tests/elab/issue14329b.lean` (occurrences at several binder depths, requiring the origin redirect). Instruction-count A/B on the `elab_bench` suite (same compiler, sources with and without the patch) is neutral within ±0.2%, including the benchmarks #12233 was built for (`delayed_assign`, `delayed_sharing`, `bv_decide_*`, `big_struct_dep`), and the full test suite passes against both stage 1 and stage 2 with a clean stage 2 stdlib build.

The mathlib benchmarks show one significant change: `Mathlib.CategoryTheory.Limits.FilteredColimitCommutesFiniteLimit` drops by 26.2G instructions (-55%), to below its historical minimum. This is the bounded version of the same defect: the module's instruction count had regressed from ~24G to ~30G exactly when nightly-testing first picked up #12233, and further to ~47G with nightly-2026-04-16. Its two proofs (Borceux's Theorem 2.13.4) are long element-chasing scripts that interleave existential destructuring (`obtain ⟨...⟩ := IsFiltered.sup_exists ...`, adding binder depth) with hypothesis rewriting (`simp only [...] at h`, i.e. assert-introduced hypotheses), and then reference those hypotheses several times from deeper in the proof (e.g. `h` feeding four `(h j).choose*` definitions) — so the lifted copies of their large proof terms were duplicated at every level, costing a factor of about 2 on this file, where the longer mechanically generated chains of LNSym's `sym_n` in #14329 grow exponentially and fail outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)