### PR TITLE
chore: deprecate `letFun`

### DIFF
--- a/src/Init.lean
+++ b/src/Init.lean
@@ -48,3 +48,4 @@ public import Init.BinderNameHint
 public import Init.Task
 public import Init.MethodSpecsSimp
 public import Init.LawfulBEqTactics
+public import Init.LetFun

--- a/src/Init/LetFun.lean
+++ b/src/Init/LetFun.lean
@@ -1,0 +1,21 @@
+/-
+Copyright (c) 2020 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura, Mario Carneiro
+-/
+module
+
+prelude
+
+import Init.Notation
+
+/--
+`letFun v (fun x => b)` is a function version of `have x := v; b`.
+This is equal to `(fun x => b) v`, so the value of `x` is not accessible to `b`.
+This is in contrast to `let x := v; b`, where the value of `x` is accessible to `b`.
+
+This used to be the way `have`/`let_fun` syntax was encoded,
+and there used to be special support for `letFun` in WHNF and `simp`.
+-/
+@[deprecated "Use `have` instead." (since := "2026-07-23")]
+public def letFun {α : Sort u} {β : α → Sort v} (v : α) (f : (x : α) → β x) : β v := f v

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -155,15 +155,6 @@ Examples:
 @[inline] def Function.const {α : Sort u} (β : Sort v) (a : α) : β → α :=
   fun _ => a
 
-/--
-`letFun v (fun x => b)` is a function version of `have x := v; b`.
-This is equal to `(fun x => b) v`, so the value of `x` is not accessible to `b`.
-This is in contrast to `let x := v; b`, where the value of `x` is accessible to `b`.
-
-This used to be the way `have`/`let_fun` syntax was encoded,
-and there used to be special support for `letFun` in WHNF and `simp`.
--/
-def letFun {α : Sort u} {β : α → Sort v} (v : α) (f : (x : α) → β x) : β v := f v
 
 set_option checkBinderAnnotations false in
 /--

--- a/src/Lean/Meta/AppBuilder.lean
+++ b/src/Lean/Meta/AppBuilder.lean
@@ -36,25 +36,6 @@ def mkExpectedTypeHint (e : Expr) (expectedType : Expr) : MetaM Expr := do
   let u ← getLevel expectedType
   return mkExpectedTypeHintCore e expectedType u
 
-/--
-`mkLetFun x v e` creates `letFun v (fun x => e)`.
-The expression `x` can either be a free variable or a metavariable, and the function suitably abstracts `x` in `e`.
--/
-@[deprecated mkLetFVars (since := "2026-06-29")]
-def mkLetFun (x : Expr) (v : Expr) (e : Expr) : MetaM Expr := do
-  -- If `x` is an `ldecl`, then the result of `mkLambdaFVars` is a let expression.
-  let ensureLambda : Expr → Expr
-    | .letE n t _ b _ => .lam n t b .default
-    | e@(.lam ..)     => e
-    | _               => unreachable!
-  let f ← ensureLambda <$> mkLambdaFVars (usedLetOnly := false) #[x] e
-  let ety ← inferType e
-  let α ← inferType x
-  let β ← ensureLambda <$> mkLambdaFVars (usedLetOnly := false) #[x] ety
-  let u1 ← getLevel α
-  let u2 ← getLevel ety
-  return mkAppN (.const ``letFun [u1, u2]) #[α, β, v, f]
-
 /-- Returns `a = b`. -/
 def mkEq (a b : Expr) : MetaM Expr := do
   let aType ← inferType a


### PR DESCRIPTION
This PR deprecates the `letFun` function, which went out of use in #9086 a year ago.