### PR TITLE
fix: internalise hypotheses eagerly in `vcgen … with finish`

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
@@ -106,7 +106,7 @@ public def work (scope : Scope) (goal : Grind.Goal) : VCGenM Unit := do
   let mut worklist : Array WorkItem := #[{ goal := { goal with mvarId }, scope }]
   while let some s := worklist.back? do
     worklist := worklist.pop
-    let goal := s.goal
+    let goal ← processHypotheses s.goal
     if goal.inconsistent then continue
     match ← solve s.scope goal.mvarId with
     | .stop _reason =>
@@ -116,11 +116,6 @@ public def work (scope : Scope) (goal : Grind.Goal) : VCGenM Unit := do
       -- from the worklist later see the invariant MVar already assigned.
       -- Non-invariant subgoals go to the worklist as usual and will eventually go through `emitVC`.
       let subgoals ← handleInvariantSubgoals subgoals
-      let goal ←
-        if subgoals.size > 1 then
-          processHypotheses goal
-        else
-          pure goal
       worklist := worklist ++ subgoals.reverse.map (fun mv =>
         { goal := { goal with mvarId := mv }, scope })
 

--- a/tests/elab/vcgenFinish.lean
+++ b/tests/elab/vcgenFinish.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Graf
+-/
+import Std.Internal.Do
+import Std.Tactic.Do
+
+/-!
+`vcgen … with finish` internalises each branch before solving it: a dead `match` branch leaves no
+metavariable (`f_group_finish`), and a lifted precondition reaches grind's E-graph (`eat_spec_finish`).
+-/
+
+open Std.Internal.Do Lean.Order
+set_option mvcgen.warning false
+set_option linter.unusedVariables false
+
+abbrev M := StateM (List Nat)
+
+def g : M Nat := pure 0
+
+def h : M Nat := do set (← get).tail; pure 0
+
+@[spec] theorem h_spec (s0 : List Nat) :
+    ⦃ fun s => s = s0 ⦄ h ⦃ fun r s => s = s0.tail ⦄ := by
+  vcgen [h] with finish
+
+def f : M Nat := do
+  match ← get with
+  | 0 :: cs => set cs; g
+  | _       => h
+
+theorem f_group_finish (e : Nat) (inner rest : List Nat)
+    (hEi : ⦃ fun s => s = inner ⦄ g ⦃ fun r s => r = e ∧ s = rest ⦄) :
+    ⦃ fun s => s = 0 :: inner ⦄ f ⦃ fun r s => r = e ∧ s = rest ⦄ := by
+  rw [f]; vcgen [hEi] with finish
+
+def eat : Nat → M Nat
+  | 0 => pure 0
+  | fuel + 1 => do
+    match ← get with
+    | x :: xs => set xs; let r ← eat fuel; pure (x + r)
+    | []      => pure 0
+
+theorem eat_spec_finish (s0 : List Nat) (fuel : Nat) (hfuel : s0.length < fuel) :
+    ⦃ fun s => s = s0 ⦄ eat fuel ⦃ fun r s => r = s0.sum ∧ s = [] ⦄ := by
+  induction fuel generalizing s0 with
+  | zero => omega
+  | succ fuel ih => vcgen [eat, ih] with finish


### PR DESCRIPTION
This PR fixes `vcgen … with finish` on a provably unreachable `match` branch: it no longer reports success while leaving an unassigned metavariable that the kernel rejects (`declaration has metavariables`), nor fails with `finish failed` on a verification condition whose proof needs a lifted precondition.

The fix here is to internalize hypotheses eagerly, when the corresponding subgoal is popped off `vcgen`'s worklist, rather than only do so when a split happens and otherwise defer to the `emitVC` leaf case. This means we'll see contradictions as early as possible rather than carrying on VC generation on a goal that could be closed as inconsistent.
