### PR TITLE
feat: add hint to `deprecated` linter (draft)

### DIFF
--- a/src/Lean/Elab/Term/TermElabM.lean
+++ b/src/Lean/Elab/Term/TermElabM.lean
@@ -2114,9 +2114,9 @@ def isLetRecAuxMVar (mvarId : MVarId) : TermElabM Bool := do
   trace[Elab.letrec] "mvarId root: {mkMVar mvarId}"
   return (← get).letRecsToLift.any (·.mvarId == mvarId)
 
-public def checkDeprecatedCore (constName : Name) : TermElabM Unit := do
+public def checkDeprecatedCore (constName : Name) (allowSuggestion : Bool := true) : TermElabM Unit := do
   if (← read).checkDeprecated then
-    Linter.checkDeprecated constName
+    Linter.checkDeprecated constName allowSuggestion
 
 /--
   Create an `Expr.const` using the given name and explicit levels.
@@ -2126,7 +2126,7 @@ public def checkDeprecatedCore (constName : Name) : TermElabM Unit := do
   If `checkDeprecated := true`, then `Linter.checkDeprecated` is invoked.
 -/
 def mkConst (constName : Name) (explicitLevels : List Level := []) : TermElabM Expr := do
-  checkDeprecatedCore constName
+  checkDeprecatedCore constName (allowSuggestion := false)
   let cinfo ← getConstVal constName
   if explicitLevels.length > cinfo.levelParams.length then
     throwError "too many explicit universe levels for `{constName}`"

--- a/src/Lean/Linter/Deprecated.lean
+++ b/src/Lean/Linter/Deprecated.lean
@@ -10,6 +10,7 @@ public import Lean.Meta.Basic
 import Lean.Linter.Init
 import Lean.Elab.InfoTree.Main
 import Lean.ExtraModUses
+import Lean.Meta.Hint
 import Init.Omega
 
 public section
@@ -64,7 +65,18 @@ def getDeprecatedNewName (env : Environment) (declName : Name) : Option Name := 
   (← deprecatedAttr.getParam? env declName).newName?
 
 open Meta in
-def checkDeprecated (declName : Name) : MetaM Unit := do
+
+private def mkDeprecationHint? (declName newName : Name) : MetaM (Option MessageData) := do
+  let ref ← getRef
+  let .ident _ _ writtenName _ := ref | return none
+  if writtenName.hasMacroScopes then return none
+  unless (ref.getRange? (canonicalOnly := true)).isSome do return none
+  unless (← resolveGlobalName writtenName) == [(declName, [])] do return none
+  let some replacement ← unresolveNameGlobalAvoidingLocals? newName | return none
+  return some (← m!"Replace the deprecated name:".hint #[replacement.toString] (ref? := some ref))
+
+open Meta in
+def checkDeprecated (declName : Name) (allowSuggestion : Bool := true) : MetaM Unit := do
   if getLinterValue linter.deprecated (← getLinterOptions) then
     let some attr := deprecatedAttr.getParam? (← getEnv) declName | pure ()
     let extraMsg ← match attr.text?, attr.newName? with
@@ -77,7 +89,8 @@ def checkDeprecated (declName : Name) : MetaM Unit := do
         let newPfx := newName.getPrefix
         let some oldDecl := env.find? declName | pure msg
         let some newDecl := env.find? newName | pure msg
-        if !(← withReducible <| isDefEqGuarded oldDecl.type newDecl.type) then
+        let sameType ← withReducible <| isDefEqGuarded oldDecl.type newDecl.type
+        if !sameType then
           msg := msg ++ .note m!"The updated constant has a different type:{indentExpr newDecl.type}\
             \ninstead of{indentExpr oldDecl.type}"
         unless oldPfx.isAnonymous do
@@ -93,6 +106,9 @@ def checkDeprecated (declName : Name) : MetaM Unit := do
             let pfxCompStr := if _ : pfxComps.length > 1 then m!"at least the last component `{pfxComps[0]}` of " else ""
             msg := msg ++ .note m!"`{.ofConstName newName true}` is protected. References to this \
               constant must include {pfxCompStr}its prefix `{newPfx}` even when inside its namespace."
+        if allowSuggestion && sameType && oldDecl.levelParams == newDecl.levelParams then
+          if let some hint ← mkDeprecationHint? declName newName then
+            msg := msg ++ hint
         pure msg
     logWarning <| .tagged ``deprecatedAttr <|
       m!"`{.ofConstName declName true}` has been deprecated" ++ extraMsg

--- a/tests/elab/7993.lean
+++ b/tests/elab/7993.lean
@@ -28,6 +28,9 @@ end Foo
 warning: `Foo.foo` has been deprecated: Use `Foo.bar` instead
 
 Note: `Foo.bar` is protected. References to this constant must include its prefix `Foo` even when inside its namespace.
+
+Hint: Replace the deprecated name:
+  f̵o̵o̵F̲o̲o̲.̲b̲a̲r̲
 -/
 #guard_msgs in
 open Foo in
@@ -85,6 +88,9 @@ end A.B
 warning: `A.B.D` has been deprecated: Use `A.B.C` instead
 
 Note: `A.B.C` is protected. References to this constant must include at least the last component `B` of its prefix `A.B` even when inside its namespace.
+
+Hint: Replace the deprecated name:
+  D̵B̲.̲C̲
 -/
 #guard_msgs in
 open A B in

--- a/tests/elab/ctorIdx.lean
+++ b/tests/elab/ctorIdx.lean
@@ -95,7 +95,12 @@ set_option linter.deprecated true
 -- Enumeration types get a deprecated alias, other types dont
 /-- info: Enum.toCtorIdx : Enum → Nat -/
 #guard_msgs in #check Enum.toCtorIdx
-/-- warning: `Enum.toCtorIdx` has been deprecated: Use `Enum.ctorIdx` instead -/
+/--
+warning: `Enum.toCtorIdx` has been deprecated: Use `Enum.ctorIdx` instead
+
+Hint: Replace the deprecated name:
+  E̵n̵u̵m̵.̵t̵o̵C̵t̵o̵r̵I̵d̵x̵E̲n̲u̲m̲.̲c̲t̲o̲r̲I̲d̲x̲
+-/
 #guard_msgs in example := Enum.toCtorIdx
 /-- error: Unknown identifier `Nonrec.toCtorIdx` -/
 #guard_msgs in #check Nonrec.toCtorIdx

--- a/tests/elab/deprecated_hint_universes.lean
+++ b/tests/elab/deprecated_hint_universes.lean
@@ -1,3 +1,11 @@
+/-!
+Tests that the `linter.deprecated` replacement hint is only offered when the replacement binds
+the same universe parameters in the same order: explicit universe arguments at the use site are
+positional and survive the in-place textual replacement.
+-/
+
+set_option linter.deprecated true
+
 def new1.{u,v} : Sort u → Sort v → Nat := fun _ _ => 0
 
 @[deprecated new1 (since:="")]

--- a/tests/elab/deprecated_hint_universes.lean
+++ b/tests/elab/deprecated_hint_universes.lean
@@ -1,0 +1,22 @@
+def new1.{u,v} : Sort u → Sort v → Nat := fun _ _ => 0
+
+@[deprecated new1 (since:="")]
+def old1.{u, v} : Sort u → Sort v → Nat := fun _ _ => 0
+
+/--
+warning: `old1` has been deprecated: Use `new1` instead
+
+Hint: Replace the deprecated name:
+  o̵l̵d̵n̲e̲w̲1
+-/
+#guard_msgs in
+def test1 : Prop → Type → Nat := old1.{0,1}
+
+def new2.{u,v} : Sort u → Sort v → Nat := fun _ _ => 0
+
+@[deprecated new2 (since:="")]
+def old2.{v, u} : Sort u → Sort v → Nat := fun _ _ => 0
+
+/-- warning: `old2` has been deprecated: Use `new2` instead -/
+#guard_msgs in
+def test2 : Prop → Type → Nat := old2.{1,0}

--- a/tests/elab/redundantDeprecatedWarnings.lean
+++ b/tests/elab/redundantDeprecatedWarnings.lean
@@ -51,7 +51,12 @@ def myFun (n : Nat) : Nat := Id.run do
 instance : BEq Nat where
   beq m n := m == baz n
 
-/-- warning: `baz` has been deprecated: Use `foo` instead -/
+/--
+warning: `baz` has been deprecated: Use `foo` instead
+
+Hint: Replace the deprecated name:
+  b̵a̵z̵f̲o̲o̲
+-/
 #guard_msgs in
 mutual
   inductive NotDep : Prop where

--- a/tests/elab_fail/deprecated.lean.out.expected
+++ b/tests/elab_fail/deprecated.lean.out.expected
@@ -2,6 +2,9 @@ deprecated.lean:5:2-5:14: warning: `[deprecated]` attribute should specify the d
 deprecated.lean:8:2-8:12: warning: `[deprecated]` attribute should specify either a new name or a deprecation message
 deprecated.lean:8:2-8:12: warning: `[deprecated]` attribute should specify the date or library version at which the deprecation was introduced, using `(since := "...")`
 deprecated.lean:11:6-11:7: warning: `f` has been deprecated: Use `g` instead
+
+Hint: Replace the deprecated name:
+  f̵g̲
 2
 deprecated.lean:13:6-13:7: warning: `h` has been deprecated
 1

--- a/tests/elab_fail/warningAsError.lean.out.expected
+++ b/tests/elab_fail/warningAsError.lean.out.expected
@@ -1,6 +1,12 @@
 warningAsError.lean:8:6-8:7: warning: `g` has been deprecated: Use `f` instead
+
+Hint: Replace the deprecated name:
+  g̵f̲
 1
 warningAsError.lean:12:6-12:7: error: `g` has been deprecated: Use `f` instead
+
+Hint: Replace the deprecated name:
+  g̵f̲
 1
 warningAsError.lean:15:7-15:13: error: Variable name `unused` is not explicitly referenced.
 


### PR DESCRIPTION
This PR adds a clickable hint to `deprecated` linter, whenever a replacement is possible and type correct. 