### PR TITLE
refactor: model DTreeMap mergeWith for simp_to_model

### DIFF
--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -46,6 +46,10 @@ macro_rules
 | `(tactic| wf_trivial) => `(tactic|
     (first
     | assumption | apply Ordered.distinctKeys
+    | apply List.Const.distinctKeys_mergeWith
+    | apply ordered_mergeWith | apply Const.ordered_mergeWith
+    | exact WF.mergeWith (by assumption)
+    | exact WF.constMergeWith (by assumption)
     | apply WF.ordered | apply WF.balanced | apply WF.empty
     | apply WF.insert | apply WF.insertIfNew
     | apply WF.erase | apply WF.insertMany
@@ -65,7 +69,7 @@ theorem compare_ne_iff_beq_eq_false {a b : α} :
 
 private meta def helperLemmaNames : Array Name :=
   #[``compare_eq_iff_beq, ``compare_beq_eq_beq, ``compare_ne_iff_beq_eq_false,
-    ``Bool.not_eq_true, ``mem_iff_contains]
+    ``Bool.not_eq_true, ``mem_iff_contains, ``Const.getValue?_toListModel_mergeWith]
 
 private meta def modifyMap : Std.HashMap Name Name :=
   .ofList
@@ -81,7 +85,10 @@ private meta def modifyMap : Std.HashMap Name Name :=
      (`alter, ``toListModel_alter),
      (`Const.alter, ``Const.toListModel_alter),
      (`modify, ``toListModel_modify),
-     (`Const.modify, ``Const.toListModel_modify)]
+     (`Const.modify, ``Const.toListModel_modify),
+     (`Const.mergeWith, ``Const.toListModel_mergeWith),
+     (`Std.DTreeMap.Internal.Impl.Const.mergeWith, ``Const.toListModel_mergeWith),
+     (`Const.mergeWith!, ``Const.toListModel_mergeWith!)]
 
 private meta def queryMap : Std.DHashMap Name (fun _ => Name × Array (MacroM (TSyntax `term))) :=
   .ofList

--- a/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
@@ -2074,6 +2074,41 @@ theorem WF.constMergeWith! {β : Type v} {_ : Ord α} {mergeFn} {t₁ t₂ : Imp
   rw [← Const.mergeWith_eq_mergeWith! h.balanced]
   exact h.constMergeWith
 
+/-- Internal implementation detail of the tree map. -/
+theorem Const.toListModel_mergeWith! {β : Type v} {_ : Ord α} [TransOrd α]
+    [BEq α] [LawfulBEqOrd α]
+    (f : α → β → β → β) (t₁ t₂ : Impl α β) (h₁ : t₁.WF) :
+    (Const.mergeWith! f t₁ t₂).toListModel.Perm
+      (Std.Internal.List.Const.mergeWith f t₁.toListModel t₂.toListModel) := by
+  unfold Const.mergeWith!
+  rw [foldl_eq_foldl]
+  induction t₂.toListModel generalizing t₁ with
+  | nil => rfl
+  | cons hd tl ih =>
+    simp only [List.foldl_cons, Std.Internal.List.Const.mergeWith]
+    refine (ih _ (h₁.constAlter!)).trans ?_
+    exact Std.Internal.List.Const.mergeWith_of_perm_first f tl
+      h₁.constAlter!.ordered.distinctKeys (Const.toListModel_alter! h₁.balanced h₁.ordered)
+
+/-- Internal implementation detail of the tree map. -/
+theorem Const.toListModel_mergeWith {β : Type v} {_ : Ord α} [TransOrd α]
+    [BEq α] [LawfulBEqOrd α]
+    (f : α → β → β → β) (t₁ t₂ : Impl α β) (h₁ : t₁.WF) :
+    (Const.mergeWith f t₁ t₂ h₁.balanced).impl.toListModel.Perm
+      (Std.Internal.List.Const.mergeWith f t₁.toListModel t₂.toListModel) := by
+  simpa only [Const.mergeWith_eq_mergeWith!] using Const.toListModel_mergeWith! f t₁ t₂ h₁
+
+/-- Internal implementation detail of the tree map. -/
+theorem Const.getValue?_toListModel_mergeWith {β : Type v} {_ : Ord α} [TransOrd α]
+    [BEq α] [LawfulBEqOrd α] (f : α → β → β → β) (t₁ t₂ : Impl α β)
+    (h₁ : t₁.WF) (k : α) :
+    Std.Internal.List.getValue? k
+        (Const.mergeWith f t₁ t₂ h₁.balanced).impl.toListModel =
+      Std.Internal.List.getValue? k
+        (Std.Internal.List.Const.mergeWith f t₁.toListModel t₂.toListModel) := by
+  exact Std.Internal.List.getValue?_of_perm
+    h₁.constMergeWith.ordered.distinctKeys (Const.toListModel_mergeWith f t₁ t₂ h₁)
+
 /-!
 ### filterMap
 -/

--- a/src/Std/Data/Internal/List/Associative.lean
+++ b/src/Std/Data/Internal/List/Associative.lean
@@ -4704,6 +4704,73 @@ theorem getValue?_alterKey [EquivBEq α] (k k' : α) (f : Option β → Option �
     next hsome =>
       simp only [getValue?_insertEntry, heq, Bool.false_eq_true, reduceIte]
 
+/-- Internal implementation detail of the tree map. -/
+def mergeWith [BEq α] (f : α → β → β → β)
+    (l₁ l₂ : List ((_ : α) × β)) : List ((_ : α) × β) :=
+  l₂.foldl (fun l ⟨k, v₂⟩ => alterKey k (fun
+    | none => some v₂
+    | some v₁ => some (f k v₁ v₂)) l) l₁
+
+/-- Internal implementation detail of the tree map. -/
+theorem mergeWith_of_perm_first [EquivBEq α] (f : α → β → β → β)
+    (l₂ : List ((_ : α) × β)) {l₁ l₁' : List ((_ : α) × β)}
+    (h₁ : DistinctKeys l₁) (h : l₁.Perm l₁') :
+    (mergeWith f l₁ l₂).Perm (mergeWith f l₁' l₂) := by
+  induction l₂ generalizing l₁ l₁' with
+  | nil => exact h
+  | cons hd tl ih =>
+    simp only [mergeWith, List.foldl_cons]
+    apply ih
+    · rw [alterKey]
+      split
+      · exact h₁.eraseKey
+      · exact h₁.insertEntry
+    · exact alterKey_of_perm h₁ h
+
+/-- Internal implementation detail of the tree map. -/
+theorem distinctKeys_mergeWith [EquivBEq α] (f : α → β → β → β)
+    (l₂ : List ((_ : α) × β)) {l₁ : List ((_ : α) × β)} (h₁ : DistinctKeys l₁) :
+    DistinctKeys (mergeWith f l₁ l₂) := by
+  induction l₂ generalizing l₁ with
+  | nil => exact h₁
+  | cons hd tl ih =>
+    simp only [mergeWith, List.foldl_cons]
+    apply ih
+    rw [alterKey]
+    split
+    · exact h₁.eraseKey
+    · exact h₁.insertEntry
+
+/-- Internal implementation detail of the tree map. -/
+theorem getValue?_mergeWith [LawfulBEq α] (f : α → β → β → β)
+    (k : α) {l₁ l₂ : List ((_ : α) × β)}
+    (h₁ : DistinctKeys l₁) (h₂ : DistinctKeys l₂) :
+    getValue? k (mergeWith f l₁ l₂) =
+      Option.merge (f k) (getValue? k l₁) (getValue? k l₂) := by
+  induction l₂ generalizing l₁ with
+  | nil => simp [mergeWith]
+  | cons hd tl ih =>
+    rw [mergeWith, List.foldl_cons]
+    change getValue? k (mergeWith f (alterKey hd.1
+      (fun | none => some hd.2 | some v₁ => some (f hd.1 v₁ hd.2)) l₁) tl) = _
+    have h₁' : DistinctKeys (alterKey hd.1
+        (fun | none => some hd.2 | some v₁ => some (f hd.1 v₁ hd.2)) l₁) := by
+      rw [alterKey]
+      split
+      · exact h₁.eraseKey
+      · exact h₁.insertEntry
+    rw [ih h₁' h₂.tail]
+    rw [getValue?_alterKey hd.1 k _ l₁ h₁]
+    by_cases heq : (hd.1 == k) = true
+    · have htail : getValue? k tl = none := by
+        rw [getValue?_eq_none]
+        have hnot := h₂.containsKey_eq_false
+        simpa [beq_iff_eq.mp heq] using hnot
+      simp [getValue?_cons_of_true heq, htail, beq_iff_eq.mp heq]
+      cases getValue? k l₁ <;> rfl
+    · have heq' : (hd.1 == k) = false := by simpa only [Bool.not_eq_true] using heq
+      simp [getValue?_cons_of_false heq', heq']
+
 theorem getValue_alterKey [EquivBEq α] (k k' : α) (f : Option β → Option β) (l : List ((_ : α) × β))
     (hl : DistinctKeys l) (hc : containsKey k' (alterKey k f l)) :
     getValue k' (alterKey k f l) hc =


### PR DESCRIPTION
This PR adds list-model support for `Const.mergeWith` and teaches `simp_to_model` to use it.

The new lemmas establish distinct keys, permutation preservation, pointwise lookup semantics, and the implementation-to-model bridge for `mergeWith`/`mergeWith!`. The tactic metadata then recognizes the public and internal `Const.mergeWith` forms and discharges their well-formedness obligations.

This is the Std-side prerequisite for replacing the bespoke `TreeMap.mergeWith` proof in leanprover-community/iris-lean#127 with a direct `simp_to_model` proof.

Validation performed on the patch and current PR branch:

- native Lean v4.32 release build from the patch's pinned source base
- clean rebase and diff review against current `master`
- focused downstream `simp_to_model` bridge checker
- full downstream Iris-Lean build
- independent theorem-signature and proof-safety checker

AI assistance was used to investigate and draft the change. The final proof structure was manually reviewed, and all checks listed above passed.

Related to #11807.
