### PR TITLE
fix: give call-site `vcgen [f]` arguments the explicit-spec priority

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
@@ -109,7 +109,7 @@ public def mkContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := false) 
           else
             return some (#[], e)
         if let some (levelParams, proof) := thm? then
-          if let some thm ← mkSpecTheoremFromStx term proof then
+          if let some thm ← mkSpecTheoremFromStx term proof explicitSpecPrio then
             specThms := specThms.insert thm
           else
             let thms ← mkSimpTheoremFromExpr (.stx (← mkFreshId) arg) levelParams proof

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
@@ -102,7 +102,7 @@ public def addSimpSpecs (database : SpecTheorems) (simpThms : SimpTheorems) :
   -- entry; feed both back to `simpSpecTheorems` as the `SimpEntry`s the definition would produce.
   let entries := simpThms.post.values.map (SimpEntry.thm ·)
     ++ simpThms.toUnfold.toList.toArray.map (SimpEntry.toUnfold ·)
-  for newSpec in ← simpSpecTheorems entries (eval_prio default) do
+  for newSpec in ← simpSpecTheorems entries explicitSpecPrio do
     specs := Sym.insertPattern specs newSpec.pattern newSpec
   return { specs, erased }
 

--- a/tests/elab/vcgenAmbientLocalSpec.lean
+++ b/tests/elab/vcgenAmbientLocalSpec.lean
@@ -9,6 +9,8 @@ outrank default specs does not shadow a call-site spec, while a priority above t
 `viaBinder`, `viaHave`, and `viaStar` prove one goal three ways, checking that a named spec wins over
 the ambient spec collected from the same hypothesis. `namedBeatsSpec`, `specHighLoses`, and
 `specHighestWins` isolate the banding against `@[spec]`, `@[spec high]`, and a priority above the band.
+`unfoldBeatsSpec` checks that a bracketed definition is unfolded ahead of a lossy `@[spec]` keyed on
+the same program, including when the program's state type is a variable.
 -/
 
 open Std.Internal.Do Lean.Order
@@ -45,7 +47,7 @@ theorem viaBinder (b : Nat) (rest : List Char) (f : Nat)
     ∀ acc, ⦃ fun s => s = '+' :: (enc b ++ rest) ⦄ tail (f + 1) acc
       ⦃ fun r s => r = acc + b ∧ s = rest ⦄ := by
   intro acc; rw [tail]
-  vcgen (errorOnMissingSpec := false) [hItem, hstop] <;> grind
+  vcgen [hItem, hstop] <;> grind
 
 theorem viaHave (b : Nat) (rest : List Char) (f : Nat)
     (H : ItemSpec b) (hplus : ¬ rest.head? = some '+') :
@@ -55,7 +57,7 @@ theorem viaHave (b : Nat) (rest : List Char) (f : Nat)
   have hItem := H rest f
   have hstop := fun acc => tail_stop rest f acc hplus
   rw [tail]
-  vcgen (errorOnMissingSpec := false) [hItem, hstop] <;> grind
+  vcgen [hItem, hstop] <;> grind
 
 -- `*` pulls the quantified `H` into the spec set, but the named `hItem` still outranks it.
 theorem viaStar (b : Nat) (rest : List Char) (f : Nat)
@@ -66,7 +68,7 @@ theorem viaStar (b : Nat) (rest : List Char) (f : Nat)
   have hItem := H rest f
   have hstop := fun acc => tail_stop rest f acc hplus
   rw [tail]
-  vcgen (errorOnMissingSpec := false) [hItem, hstop, *] <;> grind
+  vcgen [hItem, hstop, *] <;> grind
 
 -- `leaf` is opaque so `vcgen` must consult a spec rather than compute the program.
 opaque leaf : StateM Nat Nat
@@ -76,7 +78,7 @@ opaque leaf : StateM Nat Nat
 -- A named local spec is chosen over a registered `@[spec]` that also matches `leaf`.
 theorem namedBeatsSpec (hNamed : ⦃ fun _ => True ⦄ leaf ⦃ fun r _ => r = 7 ⦄) :
     ⦃ fun _ => True ⦄ leaf ⦃ fun r _ => r = 7 ⦄ := by
-  vcgen (errorOnMissingSpec := false) [hNamed] <;> grind
+  vcgen [hNamed] <;> grind
 
 @[spec high] axiom leaf_high : ⦃ fun _ => True ⦄ leaf ⦃ fun _ _ => True ⦄
 
@@ -84,11 +86,33 @@ theorem namedBeatsSpec (hNamed : ⦃ fun _ => True ⦄ leaf ⦃ fun r _ => r = 7
 -- local is still chosen.
 theorem specHighLoses (hNamed : ⦃ fun _ => True ⦄ leaf ⦃ fun r _ => r = 7 ⦄) :
     ⦃ fun _ => True ⦄ leaf ⦃ fun r _ => r = 7 ⦄ := by
-  vcgen (errorOnMissingSpec := false) [hNamed] <;> grind
+  vcgen [hNamed] <;> grind
+
+-- A spec supplied as a term rather than a bare identifier still enters the call-site band, so it
+-- outranks the `@[spec high]`.
+theorem termBeatsSpecHigh (hNamed : ⦃ fun _ => True ⦄ leaf ⦃ fun r _ => r = 7 ⦄) :
+    ⦃ fun _ => True ⦄ leaf ⦃ fun r _ => r = 7 ⦄ := by
+  vcgen [show ⦃ fun _ => True ⦄ leaf ⦃ fun r _ => r = 7 ⦄ from hNamed] <;> grind
 
 @[spec high + 30] axiom leaf_above : ⦃ fun _ => True ⦄ leaf ⦃ fun r _ => r = 7 ⦄
 
 -- A priority above the call-site band still overrides a named local.
 theorem specHighestWins (hNamed : ⦃ fun _ => True ⦄ leaf ⦃ fun _ _ => True ⦄) :
     ⦃ fun _ => True ⦄ leaf ⦃ fun r _ => r = 7 ⦄ := by
-  vcgen (errorOnMissingSpec := false) [hNamed] <;> grind
+  vcgen [hNamed] <;> grind
+
+@[irreducible] def bumpSnd {σ : Type} : StateM (σ × Nat) Nat := do
+  let n ← Prod.snd <$> get
+  modify (fun s => (s.1, s.2 + 1))
+  pure n
+
+@[spec] theorem bumpSnd_lossy {σ : Type} (o : Nat) :
+    ⦃ fun s => s.2 = o ⦄ (bumpSnd : StateM (σ × Nat) Nat) ⦃ fun r s => r = o ∧ s.2 = o + 1 ⦄ := by
+  unfold bumpSnd; vcgen <;> grind
+
+-- A bracketed definition is unfolded ahead of the lossy `@[spec]` on the same program, recovering
+-- `s.1`, which the spec drops. The variable state `σ × Nat` keys the unfolding and the spec alike.
+theorem unfoldBeatsSpec {σ : Type} (a : σ) :
+    ⦃ fun s => s.1 = a ⦄ (bumpSnd : StateM (σ × Nat) Nat) ⦃ fun _ s => s.1 = a ⦄ := by
+  fail_if_success (vcgen <;> grind)
+  vcgen [bumpSnd] <;> grind


### PR DESCRIPTION
This PR makes every `vcgen [f]` argument enter the spec database at the call-site priority band, so a definition to unfold or a spec supplied as a term outranks an ambient `@[spec]` on the same program.

Two paths dropped the band and inserted at the default priority: the equational and unfold specs `addSimpSpecs` derives from a call's simp-style arguments, and a spec supplied as a compound term (`vcgen [show … from h]`, `[f x]`) through `mkSpecTheoremFromStx`. Both now use `explicitSpecPrio`, the band a bracketed identifier already receives, so a bracketed definition's unfolding and a term spec both outrank a plain `@[spec]` or `@[spec high]` keyed on the same program, including when the program's state type is a variable and the entries share a discrimination-tree key.

