### PR TITLE
feat: footprint-based frame inference for vcgen via @[frameproc]

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
@@ -60,6 +60,12 @@ public structure VCGen.BackwardRules where
   /-- The backward rule for `Lean.Order.ofProp_le`. Introduces an embedded pure
   precondition `⌜p⌝` on any complete lattice. -/
   ofPropPreIntro : BackwardRule
+  /-- The backward rule for `Lean.Order.ofProp_meet_le`. Introduces the guard of a
+  `⌜p⌝ ⊓ P` precondition on any complete lattice, leaving `P`. -/
+  ofPropMeetPreIntro : BackwardRule
+  /-- The backward rule for `Lean.Order.iSup_le`. Eliminates an `iSup` precondition,
+  leaving the pointwise entailment for `∀`-introduction. -/
+  iSupPreIntro : BackwardRule
   /-- The backward rule for `Lean.Order.true_le_of_top_le`. Replaces a `True` precondition
   with `⊤` on the `Prop` lattice. -/
   truePreIntro : BackwardRule
@@ -84,6 +90,8 @@ public def VCGen.mkBackwardRules : MetaM VCGen.BackwardRules := do
     stateArgIntro := ← mkBackwardRuleFromDecl ``Lean.Order.le_of_forall_le
     propPreIntro := ← mkBackwardRuleFromDecl ``Lean.Order.le_of_imp_top_le
     ofPropPreIntro := ← mkBackwardRuleFromDecl ``Lean.Order.ofProp_le
+    ofPropMeetPreIntro := ← mkBackwardRuleFromDecl ``Lean.Order.ofProp_meet_le
+    iSupPreIntro := ← mkBackwardRuleFromDecl ``Lean.Order.iSup_le
     truePreIntro := ← mkBackwardRuleFromDecl ``Lean.Order.true_le_of_top_le
     elimPre := ← mkBackwardRuleFromDecl ``Lean.Order.top_le_prop
     andIntro := ← mkBackwardRuleFromDecl ``And.intro
@@ -98,9 +106,6 @@ public structure VCGen.Context where
   /-- The `@[frameproc]` registry snapshot taken at frontend init. `solve` selects a procedure per
   program node by the node's monad. -/
   frameProcs : VCGen.FrameProcs := {}
-  /-- Lattice splits keyed by operator head, merging the built-in connectives with the registered
-  frame operators. Built once at frontend init; `splitLatticeOp?` looks a head up here. -/
-  latticeOps : Std.HashMap Name VCGen.LatticeOp := {}
   /-- User-customizable simp methods used to pre-simplify hypotheses. -/
   hypSimpMethods : Option Sym.Simp.Methods := none
   /-- The `trivial` config option: when `true` (default), `Driver.emitVC` runs
@@ -174,9 +179,9 @@ public structure VCGen.State where
   sound because it is a subterm of the hash-consed goal target.
   -/
   latticeBackwardRuleCache : Std.HashMap (ExprPtr × Nat) BackwardRule := {}
-  /-- Caches the `F`-abstract upper-adjoint frame rule (`op_wp_upperAdjoint_le_wp`), keyed by the
-  `WPMonad` instance and the number of excess state arguments. -/
-  frameBackwardRuleCache : Std.HashMap (ExprPtr × Nat) BackwardRule := {}
+  /-- Caches the frame rule (`WP.Frames.op_wp_upperAdjoint_le_wp`), keyed by the `WPMonad` instance
+  and the number of excess state arguments. -/
+  frameBackwardRuleCache : Std.HashMap (ExprPtr × Nat) FrameBackwardRule := {}
   /-- The frame database from the `frames` clause. -/
   frameDB : FrameDB := {}
   /--

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
@@ -106,6 +106,7 @@ public def work (scope : Scope) (goal : Grind.Goal) : VCGenM Unit := do
   let mut worklist : Array WorkItem := #[{ goal := { goal with mvarId }, scope }]
   while let some s := worklist.back? do
     worklist := worklist.pop
+    if ← s.goal.mvarId.isAssigned then continue
     let goal ← processHypotheses s.goal
     if goal.inconsistent then continue
     match ← solve s.scope goal.mvarId with

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Entails.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Entails.lean
@@ -95,8 +95,7 @@ public def splitLatticeOp? (goal : MVarId) (rhs : Expr) :
   -- Refold a meet upper adjoint to `F ⇨ Q` up front, so the dispatch below takes the clean `⇨` path.
   let (goal, rhs) := (← refoldHimpUpperAdjoint? goal rhs).getD (goal, rhs)
   let some headName := rhs.getAppFn.constName? | return none
-  -- A split applies only for a built-in connective or a registered frame operator.
-  let some op := (← read).latticeOps[headName]? | return none
+  let some op := latticeOps[headName]? | return none
   let rule ← mkLatticeOpRuleCached rhs op
   match ← rule.applyChecked goal with
   | .goals goals => return some goals

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/FrameProc.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/FrameProc.lean
@@ -7,33 +7,115 @@ module
 
 prelude
 public import Lean.Elab.Tactic.Do.Internal.VCGen.WPApp
+public import Lean.Meta.Sym.Apply
+public import Lean.Meta.Sym.AlphaShareBuilder
 import Std.Internal.Do.Order.Basic
 import Lean.Meta.AppBuilder
+import Lean.Meta.Sym.InferType
+import Lean.Meta.Tactic.Util
 
 /-!
 The metadata a frame inference procedure operates on: the `wp` application metadata `WPApp` and the
-`FrameProc` bundling an inference procedure with its frame operator and lattice-split rules.
+`FrameProc` bundling an inference procedure with its frame operator.
 `@[frameproc]` registration lives in `FrameProcAttr`.
 -/
 
-open Lean Meta Sym
+open Lean Meta Sym Sym.Internal
 
 namespace Lean.Elab.Tactic.Do.Internal
 
-/-- A frame inference procedure: given the resource type `R` of the applicable frame operator
-`op : R → Pred → Pred`, the goal's precondition, the `wp` metadata of a spec-ready program, and the
-spec's precondition instantiated at the call site (the RHS of the spec's precondition VC `pre ⊑ ·`),
-optionally produce a frame `F : R` to peel off. `none` leaves the spec to apply directly.
+/-- How the goal precondition frames through the frame operator: `vcgen` applies the frame rule with
+the `frame`, discharging the split VC `pre ⊑ (op frame residualPre) s⃗` with `proof` and leaving
+`proof`'s `subgoals`. `residualPre` is the solver-owned metavariable for the residual precondition,
+which the solver fills after the frame rule applies.
 
-The caller instantiates and hash-conses `F` before the speculative spec application's metavariable
-context is reset, so `F` may mention metavariables assigned during that application. -/
+Build a `FrameSplit` with `FrameSplit.withDischargedSplitVC` (proof supplied) or
+`FrameSplit.withDeferredSplitVC` (split VC left as one subgoal). -/
+public structure VCGen.FrameSplit where
+  /-- The framed resource. -/
+  frame : Expr
+  /-- A proof of the split VC `pre ⊑ (op frame residualPre) s⃗`. -/
+  splitVCProof : Expr
+  /-- The unassigned subgoals of `splitVCProof`. -/
+  subgoals : List MVarId
+
+/-- How the frame was requested: an `explicit` resource pinned by a `frames` clause, or the
+`implicit` spec precondition to infer the frame from. -/
+public inductive VCGen.FrameInferenceHint where
+  /-- Frame the given resource, pinned by a `frames` clause. -/
+  | explicit (frame : Expr)
+  /-- Infer the frame from the spec's precondition `specPre`, the right-hand side of the spec's
+  precondition VC `pre ⊑ specPre`. -/
+  | implicit (specPre : Expr)
+
+/-- The inputs to a `FrameInferenceProc`: the frame operator, the goal entailment relation, the
+precondition, how the frame was requested, and the residual metavariable. Extends the program's `wp`
+metadata (`WPApp`), so `Pred`, `excessArgs`, etc. are available directly. -/
+public structure VCGen.FrameInferenceInfo extends VCGen.WPApp where
+  /-- The applicable frame operator `op : R → Pred → Pred`. -/
+  op : Expr
+  /-- The goal's entailment relation `PartialOrder.rel α inst` (carrier and order instance applied);
+  apply it to two operands to build an entailment in the goal's order. -/
+  le : Expr
+  /-- What holds going in: the left-hand side of the goal entailment `pre ⊑ wp …`. -/
+  pre : Expr
+  /-- How the frame was requested: an `explicit` frame from a `frames` clause, or the `implicit` spec
+  precondition to infer it from. -/
+  hint : FrameInferenceHint
+  /-- Declaration name of the `@[spec]` theorem being applied, `none` for a local or syntactic spec.
+  A procedure can key a footprint off it, e.g. through an attribute keyed by spec name. -/
+  spec? : Option Name
+  /-- The residual precondition the program runs against once `frame` is framed off: in the split VC
+  `pre ⊑ op frame residualPre`, the complement of `frame` in `pre`. A solver-owned synthetic-opaque
+  metavariable the procedure must not assign; the solver fills it once the frame rule fixes it. -/
+  residualPre : Expr
+
+/-- The split VC proposition `pre ⊑ (op frame footprint) s⃗`: the frame operator applied to `frame`
+and `footprint`, then to the excess state arguments, entailed by `pre` in the goal's order. -/
+public def VCGen.FrameInferenceInfo.mkSplitVC (i : FrameInferenceInfo) (frame footprint : Expr) :
+    SymM Expr := do
+  let rhs ← mkAppNS (← mkAppNS i.op #[frame, footprint]) i.excessArgs
+  mkAppNS i.le #[i.pre, rhs]
+
+/-- A `FrameSplit` framing `frame` whose split VC `pre ⊑ (op frame residualPre) s⃗` is deferred as a
+fresh subgoal for the built-in lattice (meet) decomposition to split. -/
+public def VCGen.FrameSplit.withDeferredSplitVC (i : FrameInferenceInfo) (frame : Expr) :
+    SymM FrameSplit := do
+  let m ← mkFreshExprSyntheticOpaqueMVar (← i.mkSplitVC frame i.residualPre)
+  return { frame, splitVCProof := m, subgoals := [m.mvarId!] }
+
+/-- A `FrameSplit` framing `frame`, discharging the split VC `pre ⊑ (op frame residualPre) s⃗` with
+`splitVCProof` and leaving its `subgoals`. -/
+public def VCGen.FrameSplit.withDischargedSplitVC (frame splitVCProof : Expr)
+    (subgoals : List MVarId := []) : FrameSplit :=
+  { frame, splitVCProof, subgoals }
+
+/-- A frame backward rule together with the positions of its assignable subgoals in the applied
+rule's goal list: the schematic frame and the split VC `pre ⊑ (op frame W) s⃗`, where `W` is the
+weakest footprint baked into the rule. The positions are fixed at rule construction, so applying a
+`FrameSplit` assigns by index. -/
+public structure VCGen.FrameBackwardRule where
+  /-- The backward rule concluding `pre ⊑ wp x Q E s⃗`. -/
+  rule : Lean.Meta.Sym.BackwardRule
+  /-- Position of the split VC `pre ⊑ (op frame W) s⃗`. -/
+  splitVCIdx : Nat
+  /-- Position of the schematic frame (of type `R`). -/
+  frameIdx : Nat
+
+/-- A frame inference procedure: from a `FrameInferenceInfo` (whose `hint` says whether the frame is
+`explicit` or must be inferred from the spec precondition), optionally produce a `FrameSplit`; `none`
+leaves the spec to apply directly.
+
+The procedure produces the frame and a proof of the split VC `pre ⊑ (op frame residualPre) s⃗`; it
+must not assign `residualPre`, which the solver fills with the weakest footprint after the frame rule
+applies. Build the result with `FrameSplit.withDischargedSplitVC` (proof supplied) or
+`FrameSplit.withDeferredSplitVC` (split VC left as a subgoal). -/
 public abbrev VCGen.FrameInferenceProc :=
-  Expr → Expr → VCGen.WPApp → Expr → SymM (Option Expr)
+  VCGen.FrameInferenceInfo → SymM (Option VCGen.FrameSplit)
 
 /-- How to decompose a lattice operator `head … s⃗` on the RHS of an entailment: the distribution and
 unfolding `rewrites` that saturate it, and the terminal `⊑`-introduction `terminals` that close the
-reduced form. `head` keys the split in the `latticeOps` table. A built-in connective contributes an
-empty split (the shared built-in rewrites and terminals cover it); a frame operator adds its own. -/
+reduced form. `head` keys the split in the `latticeOps` table. -/
 public structure VCGen.LatticeOp where
   /-- Head constant of the operator this split decomposes. Keys the `latticeOps` table. -/
   head : Name
@@ -54,39 +136,41 @@ public structure VCGen.FrameProc where
   /-- Head constant of the program type (the monad) whose `wp` this procedure frames. Keys the
   procedure in the `byProg` index; `vcgen` consults it for a program with that head. -/
   prog : Name
-  /-- Builds the frame operator (head constant `op.head`) applied to the goal's assertion type. -/
+  /-- Builds the frame operator (head constant `opHead`) applied to the goal's assertion type. -/
   mkOpAppM : VCGen.WPApp → MetaM Expr
   /-- The resource type `R` of the operator `op : R → Pred → Pred`, i.e. the domain of `mkOpAppM`'s
   result. Provided directly so `vcgen` reads it without building the operator, which it does only when
   a frame actually applies. -/
   resourceTy : VCGen.WPApp → MetaM Expr
-  /-- The lattice split decomposing the frame operator on the RHS of an entailment. -/
-  op : VCGen.LatticeOp
-  /-- The frame inference metaprogram, or `none` for an operator framed only through an explicit
-  `frames` clause. -/
-  proc : Option VCGen.FrameInferenceProc
+  /-- Head constant of the frame operator, locating the split VC in the frame rule. -/
+  opHead : Name
+  /-- The frame inference metaprogram. -/
+  proc : VCGen.FrameInferenceProc
 
-/-- The registered frame inference procedures: `byProg` indexes the procedure by the program monad's
-head constant (selected per node in `solve`); `latticeOps` indexes each frame operator's split by
-its operator head (consulted by `splitLatticeOp?`). -/
+/-- The registered frame inference procedures, indexed by the program monad's head constant
+(selected per node in `solve`). -/
 public structure VCGen.FrameProcs where
   byProg : Std.HashMap Name VCGen.FrameProc := {}
-  latticeOps : Std.HashMap Name VCGen.LatticeOp := {}
 
 public instance : Inhabited VCGen.FrameProcs := ⟨{}⟩
 
 public def VCGen.FrameProcs.insert (s : FrameProcs) (fp : FrameProc) : FrameProcs :=
-  { byProg := s.byProg.insert fp.prog fp
-    latticeOps := s.latticeOps.insert fp.op.head fp.op }
+  { byProg := s.byProg.insert fp.prog fp }
 
-/-- The default frame operator: lattice meet `pre ⊓ F`, the Hoare frame every complete lattice carries.
-Framed only through an explicit `frames` clause (`proc := none`); used for a monad with no registered
-`@[frameproc]`. -/
+/-- Default meet frame procedure: frame the resource pinned by a `frames` clause, with the weakest
+footprint. -/
+public def VCGen.meetFrameInferenceProc : FrameInferenceProc := fun i => do
+  match i.hint with
+  | .explicit frame => return some (← FrameSplit.withDeferredSplitVC i frame)
+  | .implicit _ => return none
+
+/-- The default frame operator: lattice meet `pre ⊓ frame`, the Hoare frame every complete lattice carries.
+Framed only through an explicit `frames` clause; used for a monad with no registered `@[frameproc]`. -/
 public def VCGen.meetFrameProc : VCGen.FrameProc where
   prog := ``Lean.Order.meet
   mkOpAppM info := Meta.mkAppOptM ``Lean.Order.meet #[info.Pred, none]
   resourceTy info := pure info.Pred
-  op := { head := ``Lean.Order.meet }
-  proc := none
+  opHead := ``Lean.Order.meet
+  proc := meetFrameInferenceProc
 
 end Lean.Elab.Tactic.Do.Internal

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Frontend.lean
@@ -410,7 +410,6 @@ private def parseArgs (stx : Syntax) (goal : MVarId) : TermElabM ParsedArgs := g
   let ctx := { ctx with
     hypSimpMethods,
     frameProcs,
-    latticeOps := VCGen.mkLatticeOpTable frameProcs.latticeOps,
     trivial := config.trivial,
     useJP := config.jp,
     errorOnMissingSpec := config.errorOnMissingSpec,

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/LatticeOp.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/LatticeOp.lean
@@ -27,8 +27,8 @@ operator is saturated with distribution and unfolding rewrites, a terminal `⊑`
 fires on the reduced form, and any state arguments the terminal leaves over-applied are point-framed
 onto the precondition.
 
-A frame operator contributes its own rewrites and terminals through its `@[frameproc]`; the built-in
-seeds cover the lattice connectives `⊓`/`⇨`/`⌜·⌝`/`⊤`/`iInf` and the magic-wand residual `upperAdjoint`.
+The built-in splits cover the lattice connectives `⊓`/`⇨`/`⌜·⌝`/`⊤`/`iInf` and the magic-wand
+residual `upperAdjoint`.
 -/
 
 /-- The lattice meet `⊓`: distributes via `meet_apply`, closes with `le_meet`. -/
@@ -58,11 +58,10 @@ public def LatticeOp.iInf : LatticeOp :=
 public def builtinLatticeOps : Array LatticeOp :=
   #[.meet, .himp, .ofProp, .top, .upperAdjoint, .iInf]
 
-/-- The lattice-split table keyed by operator head, merging the built-in connectives with the
-registered frame operators' splits. -/
-public def mkLatticeOpTable (frameSplits : Std.HashMap Name LatticeOp) :
-    Std.HashMap Name LatticeOp :=
-  builtinLatticeOps.foldl (fun t s => t.insert s.head s) frameSplits
+/-- Lattice splits of the built-in connectives, keyed by operator head. `splitLatticeOp?` looks a
+head up here. -/
+public def latticeOps : Std.HashMap Name LatticeOp :=
+  builtinLatticeOps.foldl (fun t s => t.insert s.head s) {}
 
 /-- Index terminal lemmas by the head constant of their conclusion's RHS, recording the RHS argument
 count so a split can size the excess state arguments to point-frame. -/
@@ -93,8 +92,8 @@ private def saturateLatticeOp (rewrites : Array Name) (e : Expr) (fuel : Nat := 
   go step e₀ e₀ none fuel
 where
   go (step : Simp.Simproc) (e₀ cur : Expr) (proof? : Option Expr) : Nat → SymM (Expr × Option Expr)
-    | 0 => throwError "lattice saturation did not terminate; a registered `@[frameproc]` rewrite \
-        set is likely non-terminating on{indentExpr cur}"
+    | 0 => throwError "lattice saturation did not terminate; the rewrite set is likely \
+        non-terminating on{indentExpr cur}"
     | fuel + 1 => do
       match ← (step cur).run' with
       | .rfl .. => return (cur, proof?)
@@ -144,8 +143,7 @@ For `⊓`, produces `∀ a b s⃗ pre, pre ⊑ a s⃗ → pre ⊑ b s⃗ → pre
 -/
 public def mkLatticeOpRule (rhs : Expr) (op : LatticeOp) : SymM BackwardRule := do
   -- Merge the operator's own rewrites and terminal with the built-in connective seeds: saturation can
-  -- reduce to any built-in connective, so its rewrites and terminals are always in scope. On a head
-  -- clash the operator's own contribution wins: its rewrite is tried first, its terminal inserted last.
+  -- reduce to any built-in connective, so its rewrites and terminals are always in scope.
   let rewrites := builtinLatticeOps.foldl (· ++ ·.rewrites) op.rewrites
   let terminals ← mkLatticeTerminals
     (builtinLatticeOps.foldl (fun ts s => ts ++ s.terminal?.toArray) #[] ++ op.terminal?.toArray)
@@ -168,8 +166,8 @@ public def mkLatticeOpRule (rhs : Expr) (op : LatticeOp) : SymM BackwardRule := 
     let prf ←
       match (termProof?, eqProof?) with
       | (none, none) =>
-        throwError "frame operator `{op.head}` neither reduces nor has a registered terminal; its \
-          lattice split rule would be the identity"
+        throwError "lattice operator `{op.head}` neither reduces nor has a registered terminal; its \
+          split rule would be the identity"
       | (some termProof, none) => pure termProof
       | (_, some eqProof) =>
         -- Lift the saturation equality `rhs' = reduced` through `pre ⊑ ·`, turning the terminal proof of

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
@@ -87,12 +87,14 @@ Cached version of `mkFrameBackwardRule`.
 
 Cache key: `(instWP, excessArgs.size)` (the operator is determined by the monad).
 -/
-public def mkFrameBackwardRuleCached (op : Expr) (info : WPApp) : VCGenM BackwardRule := do
+public def mkFrameBackwardRuleCached (fp : FrameProc) (info : WPApp) :
+    VCGenM FrameBackwardRule := do
   let key := (ExprPtr.mk info.instWP, info.excessArgs.size)
   if let some rule := (← get).frameBackwardRuleCache[key]? then return rule
-  let rule ← (← mkFrameBackwardRule op info).shareCommon
-  modify fun st => { st with frameBackwardRuleCache := st.frameBackwardRuleCache.insert key rule }
-  return rule
+  let frule ← mkFrameBackwardRule fp info
+  let frule := { frule with rule := ← frule.rule.shareCommon }
+  modify fun st => { st with frameBackwardRuleCache := st.frameBackwardRuleCache.insert key frule }
+  return frule
 
 end VCGen
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
@@ -403,36 +403,51 @@ public def mkBackwardRuleForSplit
 
 /-! ## Frame rules -/
 
-/-- Move the frame variable to the front of a frame rule's subgoals. The frame is the sole subgoal
-another subgoal (the pre-VC and the `WP.Frames` condition) depends on, so applying the rule surfaces
-it first, ready to be assigned the inferred frame. -/
-private def hoistFrameVar (rule : BackwardRule) : MetaM BackwardRule := do
-  let p := rule.pattern
-  let aux := p.varTypes.mapIdx fun i _ => mkFVar ⟨.num `_frame_hoist i⟩
-  let dependsOn (i : Nat) : Bool := rule.resultPos.any fun j =>
-    j != i && (p.varTypes[j]!.instantiateRevRange 0 j aux).containsFVar aux[i]!.fvarId!
-  let some fIdx := rule.resultPos.find? dependsOn
-    | throwError "frame: could not locate the frame variable in the frame rule"
-  return { rule with resultPos := fIdx :: rule.resultPos.filter (· != fIdx) }
+/-- Locate the assignable subgoal positions of a frame backward rule: the split VC (the premise
+`pre ⊑ (op F W) s⃗`, found by `opHead`) and the frame `F` read off its right-hand side. -/
+private def analyzeFrameRule (rule : BackwardRule) (opHead : Name) (numExcess : Nat) :
+    MetaM FrameBackwardRule := do
+  -- The binder telescope of the rule type is the pattern telescope, so `xs` is indexed by the
+  -- entries of `resultPos`, which reorders the subgoal binders (non-dependent first) into the
+  -- applied rule's goal list.
+  let resultPos := rule.resultPos.toArray
+  forallTelescope (← Meta.inferType rule.expr) fun xs _ => do
+    let premiseType (listIdx : Nat) : MetaM Expr :=
+      Meta.inferType xs[resultPos[listIdx]!]!
+    let mut found := none
+    -- Find the opApp `op F W` in the split VC that looks like `pre ⊑ (op F W) s`
+    for i in [0:resultPos.size] do
+      let_expr Lean.Order.PartialOrder.rel _ _ _ rhs := (← premiseType i) | continue
+      let opApp := rhs.stripArgsN numExcess
+      if opApp.isAppOf opHead then
+        found := some (i, opApp)
+        break
+    let some (splitVCIdx, opApp) := found
+      | throwError "frame: could not locate the split VC in the frame rule for `{opHead}`"
+    let frameIdx := resultPos.idxOf (xs.idxOf opApp.appFn!.appArg!)
+    return { rule, splitVCIdx, frameIdx }
 
 /--
-The `F`-abstract upper-adjoint frame rule for a frame operator `op : R → Pred → Pred`.
+The frame backward rule for a frame operator `op : R → Pred → Pred`, built from the frame rule
+`WP.Frames.op_wp_upperAdjoint_le_wp`.
 
-The rule concludes `pre ⊑ wp prog Q E s⃗` from the framed precondition
-`pre ⊑ op F (wp prog (fun a => upperAdjoint (op F) (Q a)) E) s⃗` and the frame condition
-`WP.Frames op prog F`, with the frame `F` left schematic so a single rule serves every inferred frame.
-Its subgoals lead with `F`, so the caller assigns the inferred frame before decomposing the rest.
+The rule concludes `pre ⊑ wp prog Q E s⃗` from the split VC `pre ⊑ (op F W) s⃗` and the frame
+condition `WP.Frames op prog F`, with the frame `F` left schematic and the weakest footprint
+`W = wp prog (fun a => upperAdjoint (op F) (Q a)) E` baked in, so a single rule serves every inferred
+frame. `analyzeFrameRule` records the positions of the schematic slots.
 -/
-public def mkFrameBackwardRule (op : Expr) (info : WPApp) : MetaM BackwardRule := do
-  -- Pin the monad and the operator, leaving the frame `F`, program, and postconditions schematic;
-  -- `tryMkBackwardRuleFromSpec` turns them into rule parameters and `hoistFrameVar` surfaces `F`.
+public def mkFrameBackwardRule (fp : FrameProc) (info : WPApp) :
+    MetaM FrameBackwardRule := do
+  -- Pin the program and the operator, leaving everything else schematic;
+  -- `tryMkBackwardRuleFromSpec` turns the unassigned metavariables into rule parameters.
+  let op ← fp.mkOpAppM info
   let specProof ← mkAppOptM ``Std.Internal.Do.WP.Frames.op_wp_upperAdjoint_le_wp
     ((info.args.take 7).map some ++ #[none, some op, none])
   let some specThm ← mkSpecTheoremFromStx (← getRef) specProof
-    | throwError "frame: could not build the upper-adjoint frame spec for operator{indentExpr op}"
+    | throwError "frame: could not build the frame spec for operator{indentExpr op}"
   let some rule ← (tryMkBackwardRuleFromSpec specThm info).run
     | throwError "frame: could not build the frame rule for operator{indentExpr op}"
-  hoistFrameVar rule
+  analyzeFrameRule rule fp.opHead info.excessArgs.size
 
 end VCGen
 end Lean.Elab.Tactic.Do.Internal

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -147,6 +147,16 @@ private def liftedHypBare? (scope : VCGen.Scope) (goal : MVarId) (target : Expr)
     goal.assign hyp.toExpr
     return some []
 
+/-- Instantiate assigned head metavariables in the goal's entailment, so the shape tests in the
+following steps see the assigned form. -/
+private def instantiateGoal? (goal : MVarId) (target : Expr) : VCGenM (Option MVarId) := do
+  let_expr c@PartialOrder.rel α inst pre rhs := target | return none
+  let α' ← instantiateMVarsIfMVarAppS α
+  let pre' ← instantiateMVarsIfMVarAppS pre
+  let rhs' ← instantiateMVarsIfMVarAppS rhs
+  if isSameExpr α α' && isSameExpr pre pre' && isSameExpr rhs rhs' then return none
+  return some (← goal.replaceTargetDefEqFast (← mkAppNS c #[α', inst, pre', rhs']))
+
 /-- Strategy 5: cancel a redundant `P ⊓ ⊤` precondition via `meet_top_le_of_le`, leaving `P ⊑ rhs`.
 Such a precondition arises when `himp_complete` splits `⊤ ⊑ a ⇨ b` into `a ⊓ ⊤ ⊑ b`. -/
 private def stripMeetTopPre? (goal : MVarId) (pre : Expr) : VCGenM (Option MVarId) := do
@@ -163,6 +173,21 @@ private def ofPropPreIntro? (goal : MVarId) (pre : Expr) : VCGenM (Option (MVarI
   let_expr CompleteLattice.ofProp _l _inst φ := pre | return none
   if φ.isTrue then return none
   return some (← introPre (← read).backwardRules.ofPropPreIntro goal)
+
+/-- Strategy 5: lift the pure `φ` of a `⌜φ⌝ ⊓ P` precondition into the local context, leaving
+`P ⊑ rhs`. -/
+private def ofPropMeetPreIntro? (goal : MVarId) (pre : Expr) : VCGenM (Option (MVarId × FVarId)) := do
+  let_expr Lean.Order.meet _l _inst lhs _rest := pre | return none
+  let_expr CompleteLattice.ofProp _l' _inst' _φ := lhs | return none
+  return some (← introPre (← read).backwardRules.ofPropMeetPreIntro goal)
+
+/-- Strategy 5: eliminate an `iSup` precondition via `iSup_le`, leaving the pointwise entailment
+`∀ i, P i ⊑ rhs` for `∀`-introduction. -/
+private def iSupPreIntro? (goal : MVarId) (pre : Expr) : VCGenM (Option MVarId) := do
+  unless pre.isAppOfArity ``Lean.Order.iSup 4 do return none
+  let .goals [g] ← (← read).backwardRules.iSupPreIntro.applyChecked goal
+    | throwError "Failed to eliminate the `iSup` precondition of {goal}"
+  return some g
 
 /-- Strategy 7: move a bare `Prop` precondition `φ ⊑ rhs` into the local context via
 `le_of_imp_top_le`, leaving `⊤ ⊑ rhs`. Runs after `True` and `⊤` preconditions are handled, so
@@ -189,15 +214,19 @@ private def normalizePreToTop? (goal : MVarId) (pre target : Expr) : VCGenM (Opt
 /-- Phase 2: drive the precondition of `pre ⊑ rhs` toward `⊤`, lifting any pure content into the
 local context so a later spec application sees a `⊤` precondition. In order: cancel a redundant
 `⊓ ⊤`; lift an embedded `⌜φ⌝` (before state-argument introduction, which would otherwise leave
-`⌜φ⌝` applied to the introduced state); introduce excess state arguments; drop a `True`
-precondition; lift a bare `Prop` precondition. Returns the updated scope, recording any lifted
-hypothesis. -/
+`⌜φ⌝` applied to the introduced state); lift the guard of a `⌜φ⌝ ⊓ P`; eliminate an `iSup`;
+introduce excess state arguments; drop a `True` precondition; lift a bare `Prop` precondition.
+Returns the updated scope, recording any lifted hypothesis. -/
 private def normalizePre? (scope : VCGen.Scope) (goal : MVarId) (α pre target : Expr) :
     VCGenM (Option (VCGen.Scope × List MVarId)) := do
   if let some g ← stripMeetTopPre? goal pre then
     return some (scope, [g])
   if let some (g, h) ← ofPropPreIntro? goal pre then
     return some ({ scope with lastLiftedPre? := some h }, [g])
+  if let some (g, h) ← ofPropMeetPreIntro? goal pre then
+    return some ({ scope with lastLiftedPre? := some h }, [g])
+  if let some g ← iSupPreIntro? goal pre then
+    return some (scope, [g])
   if let some goal' ← introsExcessArgs goal then return some (scope, [goal'])
   if let some gs ← normalizePreToTop? goal pre target then
     return some (scope, gs)
@@ -404,31 +433,35 @@ public def matchFrame? (resourceTy : Expr) (info : WPApp) : VCGenM (Option Expr)
   modify fun s =>
     let entries := s.frameDB.entries.set! entry.srcIdx { entry with retired := true }
     { s with frameDB := { s.frameDB with entries } }
-  let F ← elabFrame resourceTy entry res
-  trace[Elab.Tactic.Do.vcgen] "`frames` matched {info.prog}; frame:{indentExpr F}"
-  return some F
+  let frame ← elabFrame resourceTy entry res
+  trace[Elab.Tactic.Do.vcgen] "`frames` matched {info.prog}; frame:{indentExpr frame}"
+  return some frame
 
-/-- True iff `post` is the post of a frame residual, `fun a => PreservesSup.upperAdjoint (op F) (Q a)`.
-The upper-adjoint frame rule leaves this shape behind, so a program with such a post is already framed
-and must not be framed again. -/
+/-- True iff `post` is the post of a frame residual, `fun a => PreservesSup.upperAdjoint (op frame) (Q a)`.
+The frame rule leaves this shape behind, so a program with such a post is already framed and must not
+be framed again. -/
 private def isFramedPost (post : Expr) : Bool :=
   let body := if post.isLambda then post.bindingBody! else post
   body.consumeMData.getAppFn.isConstOf ``Lean.Order.PreservesSup.upperAdjoint
 
-/-- Apply the upper-adjoint frame rule for `fp`'s operator and frame `F`, assigning the schematic frame
-variable to `F`. Returns the frame VCs, the frame condition `WP.Frames op prog F`, and the
-precondition that carries on to the program's own spec. Builds the operator here, since this runs only
-when a frame applies. -/
-private def applyFrameRule (goal : MVarId) (info : WPApp) (fp : FrameProc) (F : Expr) :
-    VCGenM (List MVarId) := do
-  let op ← fp.mkOpAppM info
-  let rule ← mkFrameBackwardRuleCached op info
-  let .goals (fGoal :: rest) ← rule.applyChecked goal m!"frame rule for{indentExpr info.prog}"
+/-- Apply the frame rule for `fp`'s operator and the inferred `FrameSplit`. Assign the frame slot,
+then read the weakest footprint `W` off the now-concrete split VC `pre ⊑ (op frame W) s⃗` and fill the
+solver-owned placeholder `residualPre` with it, so the procedure's proof (built against the
+placeholder) discharges the split VC. The proof's `subgoals` remain; the assigned slot goals are
+skipped by the worklist. -/
+private def applyFrameRule (goal : MVarId) (info : WPApp) (fp : FrameProc)
+    (residualPre : Expr) (split : FrameSplit) : VCGenM (List MVarId) := do
+  let frule ← mkFrameBackwardRuleCached fp info
+  let .goals goals ← frule.rule.applyChecked goal m!"frame rule for{indentExpr info.prog}"
     | throwError "frame: failed to apply rule for{indentExpr info.prog}"
-  -- `fGoal` is the schematic frame variable, of the operator's resource type `R`; `F` was inferred at
-  -- that same `R`, so it assigns directly without a definitional-equality check.
-  fGoal.assign F
-  return rest
+  let goals := goals.toArray
+  goals[frule.frameIdx]!.assign split.frame
+  let vcType ← goals[frule.splitVCIdx]!.getType
+  let_expr Lean.Order.PartialOrder.rel _ _ _ rhs := vcType
+    | throwError "frame: split VC is not an entailment{indentExpr vcType}"
+  residualPre.mvarId!.assign (rhs.stripArgsN info.excessArgs.size).appArg!
+  goals[frule.splitVCIdx]!.assign split.splitVCProof
+  return goals.toList ++ split.subgoals
 
 /-- The spec precondition instantiated at the call site: the right-hand side of the bare `pre ⊑ specPre`
 premise among a spec rule's subgoals. The post and exception VCs are `∀`-quantified, so the bare
@@ -441,17 +474,23 @@ private def specPreOf? (subgoals : List MVarId) : VCGenM (Option Expr) := do
       return some (← instantiateMVarsIfMVarAppS specPre)
   return none
 
+/-- Instantiate a `FrameSplit`'s data against the current metavariable context (and reshare). -/
+private def instantiateFrameSplit (split : FrameSplit) : VCGenM FrameSplit := do
+  return { split with
+           frame := ← instantiateMVarsS split.frame
+           splitVCProof := ← instantiateMVarsS split.splitVCProof }
+
 /--
 Handle a spec-ready program `info.prog`: select its `@[spec]` theorem and either frame or apply it.
 
 - A spec with a conjunctive precondition, or an already-framed residual, applies its spec directly.
-- Otherwise the frame operator for the monad is selected (the `@[frameproc]` registered for the
+- Otherwise the frame procedure for the monad is selected (the `@[frameproc]` registered for the
   program type, or the default meet frame). The choice is per node, since sub-programs may reach a
   different monad (e.g. a `monadLift`ed base call).
-- An explicit `frames` clause takes precedence, framing eagerly.
-- Failing that, the spec is applied speculatively and its precondition VC `pre ⊑ specPre` is handed to
-  the frame procedure: no frame keeps the application; a frame `F` rolls it back and applies the frame
-  rule instead, so the spec re-applies against the framed residual where its VCs are solvable.
+- An explicit `frames` clause elaborates a frame and passes it to the procedure.
+- Failing that, the spec is applied speculatively and its precondition VC's right-hand side is
+  handed to the procedure: no split keeps the application; a split rolls it back and applies the
+  frame rule instead, so the spec re-applies against the framed residual where its VCs are solvable.
 -/
 private def applyFrameOrSpec (scope : VCGen.Scope) (goal : MVarId) (pre : Expr) (info : WPApp) :
     VCGenM SolveResult := goal.withContext do
@@ -464,24 +503,32 @@ private def applyFrameOrSpec (scope : VCGen.Scope) (goal : MVarId) (pre : Expr) 
   let procs := (← read).frameProcs.byProg
   let fp := info.M.getAppFn.constName?.bind (procs[·]?) |>.getD meetFrameProc
   let resourceTy ← fp.resourceTy info
-  if let some F ← matchFrame? resourceTy info then
-    return .goals scope (← applyFrameRule goal info fp F)
-  let some proc := fp.proc | return ← applySpec scope goal info thm
-  -- Apply the spec speculatively, then let the frame procedure inspect its precondition VC. No frame
-  -- keeps the application; a frame rolls it back and frames instead.
-  let saved ← Meta.saveState
-  let .goals _ subgoals ← applySpec scope goal info thm
-    | throwError "vcgen: speculative spec application for{indentExpr info.prog} did not produce goals"
-  let frame? ← match ← specPreOf? subgoals with
-    | some specPre => proc resourceTy pre info specPre
-    | none => pure none
-  let some F := frame? | return .goals scope subgoals
-  -- Capture the frame before rolling back: `saved.restore` un-assigns the speculative metavariables,
-  -- so instantiate `F` against them now (and reshare).
-  let F ← instantiateMVarsS F
-  trace[Elab.Tactic.Do.vcgen] "`@[frameproc]` matched {info.prog}; frame:{indentExpr F}"
-  saved.restore
-  return .goals scope (← applyFrameRule goal info fp F)
+  let op ← fp.mkOpAppM info
+  -- The solver-owned metavariable for the residual precondition: the procedure builds the split VC
+  -- proof against it, and `applyFrameRule` fills it once the frame rule fixes the footprint.
+  let residualPre ← liftMetaM <| mkFreshExprSyntheticOpaqueMVar info.Pred
+  -- The goal's entailment relation `PartialOrder.rel α inst`, its two operands stripped.
+  let le := (← goal.getType).stripArgsN 2
+  -- The frame hint: `explicit` from a `frames` clause, otherwise `implicit`, reading the spec
+  -- precondition off a speculative spec application. That application is rolled back so the procedure
+  -- runs against the original goal; its `specPre` metavariables are frozen into a telescope and
+  -- reopened fresh in the restored context so they outlive the rollback.
+  let hint : FrameInferenceHint ← match ← matchFrame? resourceTy info with
+    | some frame => pure (.explicit frame)
+    | none =>
+      let saved ← Meta.saveState
+      let .goals _ subgoals ← applySpec scope goal info thm
+        | throwError "vcgen: speculative spec application for{indentExpr info.prog} did not produce goals"
+      let some specPre ← specPreOf? subgoals | return .goals scope subgoals
+      let specPreAbs ← Meta.abstractMVars (← instantiateMVarsS specPre)
+      saved.restore
+      let (_, _, specPre) ← Meta.openAbstractMVarsResult specPreAbs
+      pure (.implicit (← shareCommon specPre))
+  match ← fp.proc { info with op, pre, le, hint, spec? := thm.global?, residualPre } with
+  | none => applySpec scope goal info thm
+  | some split =>
+    trace[Elab.Tactic.Do.vcgen] "`@[frameproc]` matched {info.prog}; frame:{indentExpr split.frame}"
+    return .goals scope (← applyFrameRule goal info fp residualPre (← instantiateFrameSplit split))
 
 /--
 The main VC generation step. Operates on a plain `MVarId` with no knowledge of grind.
@@ -521,15 +568,10 @@ public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := g
   if let some g ← tripleUnfold? goal target then return .goals scope [g]
   if let some g ← bareWPToLe? goal target then return .goals scope [g]
   if let some gs ← liftedHypBare? scope goal target then return .goals scope gs
+  if let some g ← instantiateGoal? goal target then return .goals scope [g]
 
   let_expr PartialOrder.rel α inst pre rhs := target
     | return .stop (.noEntailment target)
-
-  -- A previous rule application may have assigned the entailment's sides to fresh metavariables
-  -- (e.g. a lattice-split operand). Instantiate those heads so the shape tests below see the
-  -- assigned form.
-  let pre ← instantiateMVarsIfMVarAppS pre
-  let rhs ← instantiateMVarsIfMVarAppS rhs
 
   -- Phase 2: close reflexive goals, then drive `pre` toward `⊤`, lifting any pure content so a
   -- later spec application sees a `⊤` precondition.

--- a/src/Std/Internal/Do/Order/Basic.lean
+++ b/src/Std/Internal/Do/Order/Basic.lean
@@ -313,7 +313,7 @@ theorem le_forall {α : Sort u} (p : Prop) (q : α → Prop)
   · intro ⟨i, hi⟩
     exact (le_iSup f i) hi
 
-@[simp] theorem meet_prop_eq_and (a b : Prop) : (a ⊓ b : Prop) = (a ∧ b) := by
+@[grind =, simp] theorem meet_prop_eq_and (a b : Prop) : (a ⊓ b : Prop) = (a ∧ b) := by
   apply propext
   constructor
   · intro hab
@@ -431,6 +431,11 @@ theorem le_ofProp [CompleteLattice l] (x : l) (p : Prop) : p → x ⊑ ⌜p⌝ :
 theorem ofProp_le [CompleteLattice l] (p : Prop) (rhs : l) :
     (p → (⊤ : l) ⊑ rhs) → ⌜p⌝ ⊑ rhs :=
   (CompleteLattice.ofProp_intro p rhs).mpr
+
+/-- `⌜p⌝ ⊓ x ⊑ rhs` reduces to assuming `p` and proving `x ⊑ rhs`. -/
+theorem ofProp_meet_le [CompleteLattice l] (p : Prop) (x rhs : l) :
+    (p → x ⊑ rhs) → ⌜p⌝ ⊓ x ⊑ rhs :=
+  (CompleteLattice.ofProp_intro_r p x rhs).mpr
 
 /-- Entailment between functions is pointwise. -/
 theorem le_iff_forall_le {σ : Type u} {α : Type v} [PartialOrder α] {f g : σ → α} :

--- a/src/Std/Internal/Do/WP/Frame.lean
+++ b/src/Std/Internal/Do/WP/Frame.lean
@@ -30,7 +30,7 @@ state identified by `F`. Other operators take a simpler resource, e.g. a cost co
 -/
 structure WP.Frames {R : Type t} (op : R → Pred → Pred) (x : Prog) (F : R) : Prop where
   /-- When `x` frames `(op F ·)`, `(op F ·)` commutes into the postcondition of `wp x`. -/
-  conj_wp_le_wp_conj : ∀ (Q : Value → Pred) (E : EPred),
+  op_wp_le_wp_op : ∀ (Q : Value → Pred) (E : EPred),
     op F (wp x Q E) ⊑ wp x (fun a => op F (Q a)) E
 
 /-- The framed spec `vcgen` applies for `x`, when each `op r` preserves `Sup`: framing `x` by `F`
@@ -40,7 +40,7 @@ theorem WP.Frames.op_wp_upperAdjoint_le_wp {R : Type t} (op : R → Pred → Pre
     ∀ Q E, op F (wp x (fun a => PreservesSup.upperAdjoint (op F) (Q a)) E) ⊑ wp x Q E := by
   intros
   apply PartialOrder.rel_trans
-  apply hframes.conj_wp_le_wp_conj
+  apply hframes.op_wp_le_wp_op
   apply WP.wp_consequence
   intro
   apply PreservesSup.upperAdjoint_le
@@ -52,7 +52,7 @@ theorem WP.Frames.le_frameClosure {R : Type t} (op : R → Pred → Pred) [∀ r
     (hpre : pre ⊑ wp x Q E) :
     pre ⊑ PreservesSup.frameClosure op (fun Q => wp x Q E) Q :=
   PreservesSup.le_frameClosure op (fun Q => wp x Q E)
-    (fun r Q' => (hframes r).conj_wp_le_wp_conj Q' E) hpre
+    (fun r Q' => (hframes r).op_wp_le_wp_op Q' E) hpre
 
 /-- If `wp` is built as `PreservesSup.frameClosure op` over a base post-transformer `f x E` (the frame
 rule internalized into `wp`), then every program frames every resource `F` with respect to `op`. -/
@@ -84,6 +84,38 @@ theorem WP.Frames.of_conjunctive {Prog : Type u} {Value : Type v} {Pred : Type w
     simp only [meet_apply]
     exact PartialOrder.rel_refl
 
+/-- Reinterpret a `WP` so its weakest precondition is the `PreservesSup.frameClosure` of the base
+wp over a family of `Sup`-preserving resource operators `op r`. -/
+@[instance_reducible] noncomputable def WP.of_frameClosure {R : Type t} (op : R → Pred → Pred)
+    [∀ r, PreservesSup (op r)] (base : WP Prog Value Pred EPred) : WP Prog Value Pred EPred where
+  wpTrans x := ⟨fun Q E => PreservesSup.frameClosure op (fun Q' => base.wp x Q' E) Q⟩
+  wp_trans_monotone x post post' epost epost' hE hP := by
+    simp only [PreservesSup.frameClosure]
+    refine CompleteLattice.iInf_mono fun r => PreservesSup.upperAdjoint_mono _ ?_
+    exact base.wp_consequence_econs x _ _ epost epost'
+      (fun a => PreservesSup.map_mono (op r) (hP a)) hE
+
+omit [WP Prog Value Pred EPred] in
+/-- Characterization of the `WP.of_frameClosure` weakest precondition: landing below it is landing
+below the base wp with every resource `op r` framed onto the pre- and postcondition. -/
+theorem WP.of_frameClosure_le_wp_iff {R : Type t} (op : R → Pred → Pred) [∀ r, PreservesSup (op r)]
+    (base : WP Prog Value Pred EPred) (x : Prog) (Q : Value → Pred) (E : EPred) (pre : Pred) :
+    pre ⊑ (WP.of_frameClosure op base).wp x Q E ↔
+      ∀ r, op r pre ⊑ base.wp x (fun a => op r (Q a)) E := by
+  show pre ⊑ PreservesSup.frameClosure op (fun Q' => base.wp x Q' E) Q ↔ _
+  exact PreservesSup.le_frameClosure_iff op _
+
+omit [WP Prog Value Pred EPred] in
+/-- Introduction rule for the weakest precondition of a `WP.of_frameClosure` interpretation,
+selected by the witness equation `heq`: land below the base wp with every resource framed on. -/
+theorem WP.le_wp_of_frameClosure_eq {R : Type t} {op : R → Pred → Pred} [∀ r, PreservesSup (op r)]
+    {base I : WP Prog Value Pred EPred} (heq : I = WP.of_frameClosure op base)
+    {x : Prog} {Q : Value → Pred} {E : EPred} {pre : Pred}
+    (h : ∀ r, op r pre ⊑ base.wp x (fun a => op r (Q a)) E) :
+    pre ⊑ I.wp x Q E := by
+  subst heq
+  exact (WP.of_frameClosure_le_wp_iff op base x Q E pre).mpr h
+
 /-- Reinterpret a `WPMonad m` so its weakest precondition is the `PreservesSup.frameClosure` of the
 base wp over a family of `Sup`-preserving resource operators `op r` that act by `comp` with unit `e`.
 The resource frame rule then holds by construction (`WP.Frames.of_frameClosure`). -/
@@ -93,13 +125,7 @@ The resource frame rule then holds by construction (`WP.Frames.of_frameClosure`)
     (hact : ∀ r r' a, op (comp r r') a = op r (op r' a)) (hunit : ∀ a, op e a = a)
     (base : WPMonad m P E) : WPMonad m P E where
   toLawfulMonad := base.toLawfulMonad
-  toWP _ :=
-    { wpTrans x := ⟨fun Q E' => PreservesSup.frameClosure op (fun Q' => WP.wp x Q' E') Q⟩
-      wp_trans_monotone x post post' epost epost' hE hP := by
-        simp only [PreservesSup.frameClosure]
-        refine CompleteLattice.iInf_mono fun r => PreservesSup.upperAdjoint_mono _ ?_
-        exact WP.wp_consequence_econs x _ _ epost epost'
-          (fun a => PreservesSup.map_mono (op r) (hP a)) hE }
+  toWP α := WP.of_frameClosure op (base.toWP α)
   pure_le_wp_pure x post E' := by
     show post x ⊑ PreservesSup.frameClosure op (fun Q' => WP.wp (pure x) Q' E') post
     refine (PreservesSup.le_frameClosure_iff op _).mpr fun r => ?_

--- a/tests/elab/vcgenDyLean.lean
+++ b/tests/elab/vcgenDyLean.lean
@@ -338,7 +338,7 @@ theorem always_frame
   (p: ProofTrace → Prop)
   : WP.Frames Lean.Order.meet f (Always' p)
 where
-  conj_wp_le_wp_conj Q E := by
+  op_wp_le_wp_op Q E := by
     simp only [PartialOrder.rel, my_meet_apply, and_imp, Subtype.forall]
     dsimp only [wp, Always', WP.wpTrans]
     simp [my_meet_apply]
@@ -376,24 +376,28 @@ public meta partial def collectAlways (e : Expr) : Array Expr :=
 
 /-- Frame inference for `Traceful`: gather the precondition's `Always' pᵢ` conjuncts and frame by a
 single `Always'` over their conjunction, `Always' (fun tr => p₁ tr ∧ … ∧ pₙ tr)`. -/
-public meta def dyLeanFrameProc : FrameInferenceProc := fun _R pre _info _specPre => do
-  match (collectAlways pre).toList with
-  | [] => return none
-  | [single] => return some single
-  | a :: rest =>
-    let preds := (a :: rest).map (·.appArg!)
-    let domTy := (← Meta.inferType preds.head!).bindingDomain!
-    let combined ← Meta.withLocalDeclD `tr domTy fun tr => do
-      let last :: initRev := (preds.map (fun p => (mkApp p tr).headBeta)).reverse | unreachable!
-      Meta.mkLambdaFVars #[tr] (initRev.foldl (fun acc x => mkApp (mkApp (mkConst ``And) x) acc) last)
-    return some (← shareCommon (mkApp a.appFn! combined))
+public meta def dyLeanFrameProc : FrameInferenceProc := fun i => do
+  let frame ← do
+    match i.hint with
+    | .explicit frame => pure frame
+    | .implicit _ => match (collectAlways i.pre).toList with
+      | [] => return none
+      | [single] => pure single
+      | a :: rest =>
+        let preds := (a :: rest).map (·.appArg!)
+        let domTy := (← Meta.inferType preds.head!).bindingDomain!
+        let combined ← Meta.withLocalDeclD `tr domTy fun tr => do
+          let last :: initRev := (preds.map (fun p => (mkApp p tr).headBeta)).reverse | unreachable!
+          Meta.mkLambdaFVars #[tr] (initRev.foldl (fun acc x => mkApp (mkApp (mkConst ``And) x) acc) last)
+        pure (← shareCommon (mkApp a.appFn! combined))
+  return some (← FrameSplit.withDeferredSplitVC i frame)
 
 @[frameproc] public meta def dyLeanFP : FrameProc where
   prog := ``Traceful
   mkOpAppM := fun info => Meta.mkAppOptM ``Lean.Order.meet #[info.Pred, none]
   resourceTy := fun info => pure info.Pred
-  op := { head := ``Lean.Order.meet }
-  proc := some dyLeanFrameProc
+  opHead := ``Lean.Order.meet
+  proc := dyLeanFrameProc
 end DyLeanFrameProc
 
 variable [ExecTraceTypes]

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -11,21 +11,40 @@ set_option mvcgen.warning false
 set_option grind.warning false
 
 /-!
-# A minimal separation logic for `vcgen` frame inference
+# A minimal separation logic for `vcgen` frame inference, with in-place list reverse
 
-A heap `Heap := Nat → Option Nat` with separating conjunction `∗` (disjoint union), magic wand `-∗`,
+A heap `Heap := Addr → Option Nat` with separating conjunction `∗` (disjoint union), magic wand `-∗`,
 and points-to `↦`. Unlike the lattice meet, `∗` is not cartesian: `l ↦ v ∗ l ↦ v = ⊥`. The frame
 operator is `∗` itself; its upper adjoint is the wand. `HeapM.wp` is the `frameClosure` of the base
-`StateM Heap` wp over `∗`, so every program frames every heap assertion by construction. The `iFrame`
-step is proved by hand, exposing where the frame-inference path does and does not fit `∗`.
+`StateM Heap` wp over `∗`, so every program frames every heap assertion by construction. The
+registered `@[frameproc]` cancels the framed resource out of the precondition (proof by `ac_rfl`),
+so `vcgen … with finish` closes the `iFrame` examples.
+
+The showcase is an in-place reverse of a null-terminated doubly-linked list. A node at address `p`
+stores next at `p`, prev at `p + 1`, and the payload at `p + 2`. The abstract contents are the
+`List Nat` of payloads, related to the heap by `IsList`; the program takes only a `head` pointer,
+so the list is ghost state in the specification. Framing an unrelated cell across the whole
+reverse is the `iFrame` moment at program scale.
+
+The file is laid out reusable-first: the programs, then the separation logic, then the derived
+lemmas, then the `@[frameproc]`, then the specifications.
 -/
 
-open Lean Order Meta Elab Tactic Sym Std Internal.Do Std.Internal.Do.CompleteLattice
+open Lean Order Meta Elab Tactic Sym Sym.Internal Std Internal.Do Std.Internal.Do.CompleteLattice
 
-/-! ## Heaps and the separation algebra -/
+/-! # Programs
 
-/-- A heap maps locations to optionally-present values. -/
-abbrev Heap := Nat → Option Nat
+The heap and its algebra, the heap state monad `HeapM`, and the pointer programs. No separation
+logic yet: these are plain stateful functions. -/
+
+/-! ## Heaps and their algebra -/
+
+/-- A machine address. Reducibly `Nat` so pointers read as `Addr` while sharing `Nat`'s instances
+and unifying with stored values (a link is a stored address). -/
+abbrev Addr := Nat
+
+/-- A heap maps addresses to optionally-present values. -/
+abbrev Heap := Addr → Option Nat
 
 /-- Two heaps are disjoint when no location is present in both. -/
 def Heap.disjoint (h₁ h₂ : Heap) : Prop := ∀ n, h₁ n = none ∨ h₂ n = none
@@ -34,12 +53,23 @@ def Heap.disjoint (h₁ h₂ : Heap) : Prop := ∀ n, h₁ n = none ∨ h₂ n =
 def Heap.union (h₁ h₂ : Heap) : Heap := fun n => (h₁ n).or (h₂ n)
 
 /-- The singleton heap holding `v` at `l`. -/
-def Heap.single (l v : Nat) : Heap := fun n => if n = l then some v else none
+def Heap.single (l : Addr) (v : Nat) : Heap := fun n => if n = l then some v else none
 
 /-- Overwrite location `l` with `w`. -/
-def Heap.update (h : Heap) (l w : Nat) : Heap := fun n => if n = l then some w else h n
+def Heap.update (h : Heap) (l : Addr) (w : Nat) : Heap := fun n => if n = l then some w else h n
 
-@[simp] theorem Heap.union_none_iff (h₁ h₂ : Heap) (n : Nat) :
+/-- Clear location `l`, keeping every other cell. -/
+def Heap.erase (h : Heap) (l : Addr) : Heap := fun n => if n = l then none else h n
+
+@[simp, grind =] theorem Heap.update_self (h : Heap) (l : Addr) (w : Nat) :
+    h.update l w l = some w := by
+  simp [Heap.update]
+
+@[simp, grind =] theorem Heap.erase_update (h : Heap) (l : Addr) (w : Nat) :
+    (h.update l w).erase l = h.erase l := by
+  funext n; simp only [Heap.erase, Heap.update]; by_cases hn : n = l <;> simp [hn]
+
+@[simp] theorem Heap.union_none_iff (h₁ h₂ : Heap) (n : Addr) :
     h₁.union h₂ n = none ↔ h₁ n = none ∧ h₂ n = none := by
   simp only [Heap.union]; cases h₁ n <;> simp
 
@@ -52,6 +82,12 @@ theorem Heap.union_comm {h₁ h₂ : Heap} (h : h₁.disjoint h₂) : h₁.union
 theorem Heap.union_assoc (h₁ h₂ h₃ : Heap) :
     (h₁.union h₂).union h₃ = h₁.union (h₂.union h₃) := by
   funext n; simp only [Heap.union]; cases h₁ n <;> rfl
+
+theorem Heap.none_union (h : Heap) : Heap.union (fun _ => none) h = h := by
+  funext n; simp [Heap.union]
+
+theorem Heap.union_none (h : Heap) : Heap.union h (fun _ => none) = h := by
+  funext n; simp only [Heap.union]; cases h n <;> rfl
 
 theorem Heap.disjoint_union_left {h₁ h₂ h₃ : Heap} :
     (h₁.union h₂).disjoint h₃ ↔ h₁.disjoint h₃ ∧ h₂.disjoint h₃ := by
@@ -67,6 +103,60 @@ theorem Heap.disjoint_union_right {h₁ h₂ h₃ : Heap} :
   · intro h; exact ⟨fun n => (h n).imp_right (·.1), fun n => (h n).imp_right (·.2)⟩
   · rintro ⟨ha, hb⟩ n; have := ha n; have := hb n; grind
 
+/-! ## The heap monad -/
+
+/-- The heap state monad. A `def` so it carries its own frame-internalizing `WP`. -/
+def HeapM (α : Type) : Type := StateM Heap α
+
+instance : Monad HeapM := inferInstanceAs (Monad (StateM Heap))
+instance : LawfulMonad HeapM := inferInstanceAs (LawfulMonad (StateM Heap))
+
+/-- A `HeapM` program as its underlying `StateM Heap` program, carrying the base wp. -/
+def HeapM.run {α : Type} (x : HeapM α) : StateM Heap α := x
+
+/-- A `StateM Heap` program as a `HeapM` program, carrying the frame-internalizing wp. -/
+def HeapM.mk {α : Type} (x : StateM Heap α) : HeapM α := x
+
+@[simp, grind =] theorem HeapM.run_mk {α : Type} (x : StateM Heap α) : (HeapM.mk x).run = x := rfl
+@[simp, grind =] theorem HeapM.mk_run {α : Type} (x : HeapM α) : HeapM.mk x.run = x := rfl
+
+/-! ## Pointer programs -/
+
+/-- The null address. -/
+def null : Addr := 0
+
+/-- Load the value at `l` (0 when absent). -/
+def load (l : Addr) : HeapM Nat :=
+  HeapM.mk <| modifyGet fun h => ((h l).getD 0, h)
+
+/-- Store `w` at location `l`. -/
+def store (l : Addr) (w : Nat) : HeapM Unit :=
+  HeapM.mk <| modifyGet fun h => ((), h.update l w)
+
+/-- Fuel-bounded reverse accumulator: only pointers in the program. At each cons cell, swap the
+next/prev links (`next := prev`, `prev := old next`). `fuel` bounds the remaining spine length. -/
+def reverse.go (fuel : Nat) (curr prev : Addr) : HeapM Addr :=
+  match fuel with
+  | 0 => pure prev
+  | fuel + 1 => do
+    if curr = null then
+      pure prev
+    else
+      let next ← load curr
+      store curr prev
+      store (curr + 1) next
+      reverse.go fuel next curr
+
+/-- In-place reverse with fuel `xs.length` in the specification. -/
+def reverse (fuel : Nat) (head : Addr) : HeapM Addr :=
+  reverse.go fuel head null
+
+/-! # The separation logic
+
+`HProp`, the connectives `∗`/`↦`/`-∗`, their algebra, the magic wand as upper adjoint, and the
+frame-internalizing weakest precondition that makes every `HeapM` program frame every heap
+assertion. -/
+
 /-! ## Heap assertions
 
 `HProp` is an opaque `def`, not `Heap → Prop`, so `vcgen` treats the heap as a resource dimension
@@ -76,25 +166,44 @@ def HProp : Type := Heap → Prop
 
 instance : CompleteLattice HProp := inferInstanceAs (CompleteLattice (Heap → Prop))
 
+/-- View an `HProp` as its underlying `Heap → Prop`, where the base `StateM Heap` proof reasons. -/
+def HProp.get (P : HProp) : Heap → Prop := P
+/-- Package a `Heap → Prop` as an `HProp`. -/
+def HProp.mk (p : Heap → Prop) : HProp := p
+
+@[simp, grind =] theorem HProp.get_mk (p : Heap → Prop) : (HProp.mk p).get = p := rfl
+@[simp, grind =] theorem HProp.mk_get (P : HProp) : HProp.mk P.get = P := rfl
+
 /-! ## The separation-logic connectives -/
 
 /-- The empty heap assertion. -/
-def emp : HProp := fun h => ∀ n, h n = none
+def emp : HProp := HProp.mk fun h => ∀ n, h n = none
 
 /-- The singleton heap assertion: the heap is exactly `l ↦ v`. -/
-def pointsTo (l v : Nat) : HProp := fun h => h = Heap.single l v
+def pointsTo (l : Addr) (v : Nat) : HProp := HProp.mk fun h => h = Heap.single l v
 
 /-- Separating conjunction: the heap splits into disjoint parts satisfying each side. -/
 def sepConj (P Q : HProp) : HProp :=
-  fun h => ∃ h₁ h₂, h₁.disjoint h₂ ∧ h = h₁.union h₂ ∧ P h₁ ∧ Q h₂
+  HProp.mk fun h => ∃ h₁ h₂, h₁.disjoint h₂ ∧ h = h₁.union h₂ ∧ P.get h₁ ∧ Q.get h₂
 
 /-- Magic wand: extending by any disjoint `P` heap yields a `Q` heap. -/
 def wand (P Q : HProp) : HProp :=
-  fun h => ∀ h', h.disjoint h' → P h' → Q (h.union h')
+  HProp.mk fun h => ∀ h', h.disjoint h' → P.get h' → Q.get (h.union h')
 
 @[inherit_doc pointsTo] local notation:70 l:max " ↦ " v:max => pointsTo l v
 @[inherit_doc sepConj] local infixr:65 " ∗ " => sepConj
 @[inherit_doc wand] local infixr:60 " -∗ " => wand
+
+@[simp, grind =] theorem emp_get (h : Heap) : emp.get h = ∀ n, h n = none := rfl
+@[simp, grind =] theorem pointsTo_get (l : Addr) (v : Nat) (h : Heap) :
+    (pointsTo l v).get h = (h = Heap.single l v) := rfl
+-- `sepConj_get`/`wand_get` unfold a connective into its existential-and-disjointness body, which
+-- `grind` cannot productively use; they stay plain lemmas, cited explicitly where a proof wants the
+-- unfolding. The focusing lemma `pointsTo_sepConj_get` is the `grind`-facing characterization of `∗`.
+theorem sepConj_get (P Q : HProp) (h : Heap) :
+    (P ∗ Q).get h = ∃ h₁ h₂, h₁.disjoint h₂ ∧ h = h₁.union h₂ ∧ P.get h₁ ∧ Q.get h₂ := rfl
+theorem wand_get (P Q : HProp) (h : Heap) :
+    (P -∗ Q).get h = ∀ h', h.disjoint h' → P.get h' → Q.get (h.union h') := rfl
 
 /-! ## The separation algebra laws -/
 
@@ -109,6 +218,7 @@ theorem emp_sepConj (a : HProp) : (emp ∗ a) = a := by
     exact ⟨fun _ => none, h, fun _ => Or.inl rfl,
       by funext n; simp only [Heap.union, Option.none_or], fun _ => rfl, ha⟩
 
+@[grind _=_]
 theorem sepConj_assoc (a b c : HProp) : ((a ∗ b) ∗ c) = (a ∗ (b ∗ c)) := by
   funext h
   apply propext
@@ -122,28 +232,94 @@ theorem sepConj_assoc (a b c : HProp) : ((a ∗ b) ∗ c) = (a ∗ (b ∗ c)) :=
     exact ⟨h₁.union h₂, h₃, Heap.disjoint_union_left.mpr ⟨hd13, hd23⟩,
       (Heap.union_assoc h₁ h₂ h₃).symm, ⟨h₁, h₂, hd12, rfl, ha, hb⟩, hc⟩
 
+@[grind =]
 theorem sepConj_comm (a b : HProp) : (a ∗ b) = (b ∗ a) := by
   funext h; apply propext
   constructor <;>
     · rintro ⟨h₁, h₂, hd, rfl, hp, hq⟩
       exact ⟨h₂, h₁, Heap.disjoint_comm hd, Heap.union_comm hd, hq, hp⟩
 
-/-! ## `∗` preserves sups and its upper adjoint is the wand -/
+theorem sepConj_emp (a : HProp) : (a ∗ emp) = a := by
+  rw [sepConj_comm, emp_sepConj]
+
+instance : Std.Associative (α := HProp) sepConj := ⟨sepConj_assoc⟩
+instance : Std.Commutative (α := HProp) sepConj := ⟨sepConj_comm⟩
+instance : Std.LawfulIdentity (α := HProp) sepConj emp where
+  left_id := emp_sepConj
+  right_id := sepConj_emp
+
+attribute [local grind ←] PartialOrder.rel_of_eq
+attribute [local grind ←] le_ofProp
+
+/-! ## Pure facts and existentials via the lattice
+
+`⌜φ⌝` (`ofProp`) is `⊤`/`⊥` and does not claim an empty heap. Separating pure (Iris `⌜φ⌝`) is
+`⌜φ⌝ ⊓ emp`. Existentials are the lattice `iSup` (`⨆`). -/
+
+noncomputable abbrev sepPure (φ : Prop) : HProp := ⌜φ⌝ ⊓ emp
+
+theorem sepPure_apply (φ : Prop) (h : Heap) : sepPure φ h ↔ φ ∧ emp h := by
+  constructor
+  · intro hp
+    refine ⟨?_, (meet_le_right (⌜φ⌝ : HProp) emp) h hp⟩
+    have hφ : (⌜φ⌝ : HProp) h := (meet_le_left (⌜φ⌝ : HProp) emp) h hp
+    simp only [CompleteLattice.ofProp] at hφ
+    split at hφ
+    · assumption
+    · exact False.elim <| (bot_le (x := (fun _ => False : HProp))) h hφ
+  · intro ⟨hφ, he⟩
+    exact (le_meet (emp : HProp) ⌜φ⌝ emp (le_ofProp emp φ hφ) PartialOrder.rel_refl) h he
+
+theorem sepPure_sepConj_iff (P : Prop) (Q : HProp) (h : Heap) :
+    (sepPure P ∗ Q) h ↔ P ∧ Q h := by
+  constructor
+  · rintro ⟨h₁, h₂, _, rfl, hp, hQ⟩
+    obtain ⟨hP, he⟩ := (sepPure_apply P h₁).mp hp
+    have : h₁.union h₂ = h₂ := by funext n; simp only [Heap.union, he n, Option.none_or]
+    exact ⟨hP, this.symm ▸ hQ⟩
+  · intro ⟨hP, hQ⟩
+    refine ⟨fun _ => none, h, fun _ => Or.inl rfl, (Heap.none_union h).symm, ?_, hQ⟩
+    exact (sepPure_apply P _).mpr ⟨hP, fun _ => rfl⟩
+
+@[grind =] theorem sepPure_true_eq_emp : sepPure True = emp := by
+  funext h; apply propext
+  simp [sepPure_apply]
+
+@[grind .] theorem sepPure_sepConj_le (P : Prop) (Q : HProp) : (sepPure P ∗ Q) ⊑ Q := by
+  intro h hh
+  exact (sepPure_sepConj_iff P Q h |>.mp hh).2
+
+@[grind ←] theorem sepPure_sepConj_le_of (φ : Prop) (Q R : HProp) (h : φ → Q ⊑ R) :
+    sepPure φ ∗ Q ⊑ R := by
+  intro heap hh
+  have ⟨hφ, hQ⟩ := (sepPure_sepConj_iff φ Q heap).mp hh
+  exact h hφ heap hQ
 
 /-- Pointwise characterization of the sup on `HProp`. -/
-theorem hprop_sup_apply (s : HProp → Prop) (h : Heap) :
-    CompleteLattice.sup s h = ∃ f, s f ∧ f h := by
+@[simp, grind =] theorem hprop_sup_apply (s : HProp → Prop) (h : Heap) :
+    (CompleteLattice.sup s : HProp).get h = ∃ f, s f ∧ f.get h := by
   apply propext
   constructor
-  · exact fun hh => sup_le s (x := fun h => ∃ f, s f ∧ f h)
+  · exact fun hh => sup_le s (x := HProp.mk fun h => ∃ f, s f ∧ f.get h)
       (fun f hf h' hfh' => ⟨f, hf, hfh'⟩) h hh
   · rintro ⟨f, hf, hfh⟩; exact le_sup (c := s) hf h hfh
+
+@[simp, grind =] theorem iSup_hprop_apply {α : Type} (P : α → HProp) (h : Heap) :
+    (iSup P : HProp).get h ↔ ∃ a, (P a).get h := by
+  simp only [iSup, hprop_sup_apply]
+  constructor
+  · rintro ⟨_, ⟨a, rfl⟩, ha⟩; exact ⟨a, ha⟩
+  · rintro ⟨a, ha⟩; exact ⟨P a, ⟨a, rfl⟩, ha⟩
+
+/-! ## The magic wand as upper adjoint -/
 
 instance (F : HProp) : PreservesSup (sepConj F) where
   map_sup s := by
     funext h
     apply propext
-    simp only [sepConj, hprop_sup_apply]
+    show (sepConj F (CompleteLattice.sup s)).get h ↔
+      (CompleteLattice.sup (fun y => ∃ x, s x ∧ y = sepConj F x)).get h
+    simp only [sepConj_get, hprop_sup_apply]
     constructor
     · rintro ⟨h₁, h₂, hd, rfl, hF, x, hx, hxh₂⟩
       exact ⟨sepConj F x, ⟨x, hx, rfl⟩, h₁, h₂, hd, rfl, hF, hxh₂⟩
@@ -167,16 +343,7 @@ theorem sepConj_upperAdjoint (F b : HProp) :
     exact ⟨h', h, Heap.disjoint_comm hdisj, Heap.union_comm hdisj, hF, hxh⟩
   · exact PreservesSup.le_upperAdjoint (sepConj F) (sepConj_wand_le F b)
 
-/-! ## The heap monad and its frame-internalizing weakest precondition -/
-
-/-- The heap state monad. A `def` so it carries its own frame-internalizing `WP`. -/
-def HeapM (α : Type) : Type := StateM Heap α
-
-instance : Monad HeapM := inferInstanceAs (Monad (StateM Heap))
-instance : LawfulMonad HeapM := inferInstanceAs (LawfulMonad (StateM Heap))
-
-/-- A `HeapM` program as its underlying `StateM Heap` program, carrying the base wp. -/
-def HeapM.run {α : Type} (x : HeapM α) : StateM Heap α := x
+/-! ## The frame-internalizing weakest precondition -/
 
 /-- The frame-internalizing weakest precondition: the `frameClosure` of the base `StateM Heap` wp
 over separating conjunction. -/
@@ -189,88 +356,330 @@ theorem frames_sepConj {α : Type} (x : HeapM α) (F : HProp) : WP.Frames sepCon
   WP.Frames.of_frameClosure sepConj sepConj sepConj_assoc
     ⟨fun y E Q' => WP.wp y.run Q' E, fun _ _ _ => rfl⟩
 
-/-! ## A heap operation and its spec -/
+/-- Triple introduction from the base `StateM Heap` interpretation: prove the base triple with an
+arbitrary frame `F` held on both sides. -/
+theorem HeapM.triple_of_triple_StateM_run {α : Type} {x : HeapM α} {pre : HProp} {Q : α → HProp}
+    (h : ∀ F : HProp, ⦃ (F ∗ pre).get ⦄ x.run ⦃ fun a => (F ∗ Q a).get ⦄) :
+    ⦃ pre ⦄ x ⦃ Q ⦄ :=
+  ⟨WP.le_wp_of_frameClosure_eq rfl fun F => (h F).1⟩
 
-/-- Store `w` at location `l`. -/
-def store (l w : Nat) : HeapM Unit :=
-  show StateM Heap Unit from modifyGet (fun h => ((), h.update l w))
+/-! # Derived lemmas
+
+Reusable entailments: points-to focusing, `∗`-monotonicity, and the doubly-linked-list predicate
+`IsList` with its introduction and elimination lemmas. -/
+
+/-! ## Points-to focusing -/
+
+/-- Points-to focusing: a heap satisfies `l ↦ v ∗ F` exactly when it holds `v` at `l` and its rest
+`s.erase l` satisfies `F`. The one lemma that unwraps `∗` into disjoint union; `Heap.update_self`
+and `Heap.erase_update` carry a cell update through it. -/
+@[grind =] theorem pointsTo_sepConj_get (l : Addr) (v : Nat) (F : HProp) (s : Heap) :
+    (l ↦ v ∗ F).get s ↔ s l = some v ∧ F.get (s.erase l) := by
+  simp only [sepConj_get, pointsTo_get]
+  constructor
+  · rintro ⟨_, h₂, hd, rfl, rfl, hF⟩
+    have hnone : h₂ l = none := (hd l).resolve_left (by simp [Heap.single])
+    refine ⟨by simp [Heap.union, Heap.single], ?_⟩
+    have : (Heap.single l v |>.union h₂).erase l = h₂ := by
+      funext n; simp only [Heap.erase, Heap.union, Heap.single]
+      by_cases hn : n = l <;> simp [hn, hnone]
+    rwa [this]
+  · rintro ⟨hsl, hF⟩
+    refine ⟨Heap.single l v, s.erase l, ?_, ?_, rfl, hF⟩
+    · intro n; by_cases hn : n = l
+      · subst hn; exact Or.inr (by simp [Heap.erase])
+      · exact Or.inl (by simp [Heap.single, hn])
+    · funext n; by_cases hn : n = l
+      · subst hn; simp [Heap.union, Heap.single, Heap.erase, hsl]
+      · simp [Heap.union, Heap.single, Heap.erase, hn]
+
+/-! ## Monotonicity -/
+
+/-- Monotonicity of `∗` in its right argument. -/
+theorem sepConj_mono_right (a : HProp) {b b' : HProp} (h : b ⊑ b') : a ∗ b ⊑ a ∗ b' :=
+  PreservesSup.map_mono (sepConj a) h
+
+/-! ## Doubly-linked lists
+
+`IsList xs back p` asserts that `p` roots a null-terminated doubly-linked list whose **payloads** are
+`xs`, and that the head cell's prev field equals `back`. A cons node at `p` stores next at `p`,
+prev at `p + 1`, and the head payload at `p + 2` (C field order; and `p ≠ null`). The program
+`reverse` takes only a head pointer; `xs` is ghost in the specification. -/
+
+/-- Pointwise characterization of an embedded-guard assertion. -/
+theorem ofProp_meet_apply (φ : Prop) (P : HProp) (h : Heap) : (⌜φ⌝ ⊓ P) h ↔ φ ∧ P h := by
+  constructor
+  · intro hp
+    refine ⟨?_, (meet_le_right (⌜φ⌝ : HProp) P) h hp⟩
+    have hφ : (⌜φ⌝ : HProp) h := (meet_le_left (⌜φ⌝ : HProp) P) h hp
+    simp only [CompleteLattice.ofProp] at hφ
+    split at hφ
+    · assumption
+    · exact False.elim <| (bot_le (x := (fun _ => False : HProp))) h hφ
+  · intro ⟨hφ, hP⟩
+    exact (le_meet P ⌜φ⌝ P (le_ofProp P φ hφ) PartialOrder.rel_refl) h hP
+
+/-- Doubly-linked list segment: payloads `xs`, head at `p`, head-prev `back`.
+Node layout: `p ↦ next ∗ (p+1) ↦ prev ∗ (p+2) ↦ payload`. -/
+noncomputable def IsList : List Nat → Addr → Addr → HProp
+  | [], _back, p => sepPure (p = null)
+  | v :: vs, back, p =>
+      ⌜p ≠ null⌝ ⊓ ⨆ n : Addr, p ↦ n ∗ (p + 1) ↦ back ∗ (p + 2) ↦ v ∗ IsList vs p n
+
+@[grind =] theorem IsList_nil_eq (back p : Addr) : IsList [] back p = sepPure (p = null) := rfl
+
+@[grind =] theorem IsList_cons_eq (v : Nat) (vs : List Nat) (back p : Addr) :
+    IsList (v :: vs) back p =
+      ⌜p ≠ null⌝ ⊓ ⨆ n : Addr, p ↦ n ∗ (p + 1) ↦ back ∗ (p + 2) ↦ v ∗ IsList vs p n := rfl
+
+@[grind =] theorem IsList_nil_null (back : Addr) : IsList [] back null = emp := by
+  funext h; apply propext
+  simp [IsList_nil_eq, sepPure_apply]
+
+theorem IsList_cons_elim {v : Nat} {vs : List Nat} {back p : Addr} {h : Heap}
+    (hl : IsList (v :: vs) back p h) :
+    p ≠ null ∧ ∃ n, (p ↦ n ∗ (p + 1) ↦ back ∗ (p + 2) ↦ v ∗ IsList vs p n) h := by
+  rw [IsList_cons_eq] at hl
+  exact ((ofProp_meet_apply _ _ _).mp hl).imp_right fun hh => (iSup_hprop_apply _ _).mp hh
+
+@[grind ←]
+theorem IsList_cons_intro (v : Nat) (n back : Addr) (vs : List Nat) (p : Addr) (hp : p ≠ null) :
+    (p ↦ n ∗ (p + 1) ↦ back ∗ (p + 2) ↦ v ∗ IsList vs p n) ⊑ IsList (v :: vs) back p := by
+  intro h hh
+  exact (ofProp_meet_apply _ _ _).mpr ⟨hp, (iSup_hprop_apply _ _).mpr ⟨n, hh⟩⟩
+
+/-- After rewriting next and prev, rebuild the cons cell onto the accumulator; the `curr ≠ null`
+guard reaches the context through precondition normalization, and `grind`'s AC theory for `∗`
+matches the statement against the association the framed `store`s leave in the VC. -/
+@[grind .]
+theorem reverse_store_handoff_le (v : Nat) (rest acc : List Nat) (curr next prev : Addr)
+    (hpne : curr ≠ null) :
+    IsList acc curr prev ∗ IsList rest curr next ∗ curr ↦ prev ∗ (curr + 1) ↦ next ∗ (curr + 2) ↦ v
+      ⊑ IsList rest curr next ∗ IsList (v :: acc) next curr := by
+  have heq :
+      (IsList acc curr prev ∗ IsList rest curr next ∗ curr ↦ prev ∗ (curr + 1) ↦ next ∗
+          (curr + 2) ↦ v) =
+        (IsList rest curr next ∗
+          (curr ↦ prev ∗ (curr + 1) ↦ next ∗ (curr + 2) ↦ v ∗ IsList acc curr prev)) := by
+    grind
+  rw [heq]
+  exact sepConj_mono_right _ (IsList_cons_intro v prev next acc curr hpne)
+
+/-- When the remaining segment is empty, `curr = null` and the accumulator is the whole result. -/
+@[grind .] theorem IsList_nil_acc_le (acc : List Nat) (curr prev : Addr) :
+    (sepPure (curr = null) ∗ IsList acc curr prev) ⊑ IsList acc null prev := by
+  intro h hh
+  have ⟨rfl, hacc⟩ := (sepPure_sepConj_iff (curr = null) (IsList acc curr prev) h).mp hh
+  exact hacc
+
+@[grind =] theorem IsList_append_nil (xs : List Nat) (back r : Addr) :
+    IsList (xs ++ ([] : List Nat)) back r = IsList xs back r := by
+  simp
+
+/-! # The frame inference procedure
+
+The `@[frameproc]` for `HeapM`: cancel the framed `∗` atoms out of the goal precondition and emit
+the leftover atoms as the footprint. -/
 
 open Lean.Elab.Tactic.Do.Internal Lean.Elab.Tactic.Do.Internal.VCGen
 
-/-- Storing overwrites the cell, framing every disjoint heap by construction. -/
-@[spec] theorem store_spec (l v w : Nat) :
-    ⦃ pointsTo l v ⦄ (store l w) ⦃ fun _ => pointsTo l w ⦄ := by
-  constructor
-  show (pointsTo l v) ⊑ PreservesSup.frameClosure sepConj
-    (fun Q' => WP.wp (store l w).run Q' ⊥) (fun _ => pointsTo l w)
-  refine (PreservesSup.le_frameClosure_iff sepConj _).mpr fun F => ?_
-  refine PartialOrder.rel_trans ?_
-    (WPMonad.le_wp_modifyGet_StateT_apply (m := Id) (fun h : Heap => ((), h.update l w)) _ _)
-  rintro h ⟨hF, _, hd, rfl, hFh, rfl⟩
-  refine ⟨hF, Heap.single l w, ?_, ?_, hFh, rfl⟩
-  · intro n; rcases hd n with h' | h'
-    · exact Or.inl h'
-    · right; simp only [Heap.single] at h' ⊢; grind
-  · funext n
-    simp only [Heap.update, Heap.union, Heap.single]
-    by_cases hn : n = l
-    · subst hn; have := hd n; simp only [Heap.single] at this; grind
-    · simp [hn]
-
-/-! ## Separation-logic structural lemmas for the frame split -/
-
-theorem sepConj_mono_r {a b b' : HProp} (h : b ⊑ b') : (a ∗ b) ⊑ (a ∗ b') := by
-  rintro heap ⟨h₁, h₂, hd, rfl, ha, hb⟩; exact ⟨h₁, h₂, hd, rfl, ha, h _ hb⟩
-
-/-- The frame introduction rule: to land in `F ∗ R`, cancel `F` off the right of the precondition
-and continue with the residual `R`. -/
-theorem sepConj_frame_r {pre₀ F R : HProp} (h : pre₀ ⊑ R) : (pre₀ ∗ F) ⊑ (F ∗ R) :=
-  PartialOrder.rel_trans (PartialOrder.rel_of_eq (sepConj_comm pre₀ F)) (sepConj_mono_r h)
-
-/-! ## The registered frame procedure for `∗` -/
-
-/-- Flatten a `∗`-tree into its atoms. -/
-partial def sepAtoms (e : Expr) : Array Expr :=
-  if e.isAppOf ``sepConj then sepAtoms e.appFn!.appArg! ++ sepAtoms e.appArg!
+/-- Flatten a separating conjunction after mvars are instantiated. -/
+partial def sepAtoms.go (e : Expr) : Array Expr :=
+  let e := e.consumeMData
+  if e.isAppOf ``sepConj then go e.appFn!.appArg! ++ go e.appArg!
   else #[e]
 
-/-- Automatic frame inference by domain difference: the spec's precondition `specPre` (a `∗` of atoms,
-its footprint) is cancelled from the actual precondition `pre`; the leftover atoms are the frame. `none`
-when the footprint does not match or nothing is left over, so the spec applies without a frame. -/
-def sepConjFrameProc : FrameInferenceProc := fun _R pre _info specPre => do
-  let mut rest := sepAtoms pre
-  for atom in sepAtoms specPre do
-    let some i ← rest.findIdxM? (isDefEqS atom ·) | return none
-    rest := rest.eraseIdxIfInBounds i
-  if rest.isEmpty then return none
-  return some (rest.pop.foldr (fun a acc => mkApp2 (mkConst ``sepConj) a acc) rest.back!)
+/-- Flatten a separating conjunction; instantiate mvars once at the root. -/
+def sepAtoms (e : Expr) : MetaM (Array Expr) :=
+  return sepAtoms.go (← instantiateMVars e)
 
-/-- The lattice split for `∗` is the terminal `sepConj_frame_r`: `pre ⊑ F ∗ R` cancels `F` from the
-precondition, leaving the residual `pre₀ ⊑ R`. -/
+def sepConjOfAtoms (atoms : Array Expr) : Expr :=
+  if atoms.isEmpty then mkConst ``emp
+  else atoms[1:].foldl (fun acc a => mkApp2 (mkConst ``sepConj) acc a) atoms[0]!
+
+/-- Match and remove `cancel` atoms from `pre`. Returns `(remaining, matched)` or `none`.
+
+Naïve by design: atoms match only up to `isDefEq`, so a footprint cancels a cell only when its address
+and value are already defeq to one in `pre`. A comprehensive frameproc would also match `pointsTo`s by
+address label with a non-defeq value. This suffices for the demo. -/
+def matchSepAtoms (pre cancel : Expr) : MetaM (Option (Array Expr × Array Expr)) := do
+  let mut rest ← sepAtoms pre
+  let mut matched : Array Expr := #[]
+  for atom in (← sepAtoms cancel) do
+    -- `withoutModifyingMCtx`: a failed near-miss must not pin schematic mvars.
+    let some i ← rest.findIdxM? fun cand => withoutModifyingMCtx (isDefEq atom cand)
+      | return none
+    matched := matched.push rest[i]!
+    rest := rest.eraseIdxIfInBounds i
+  return some (rest, matched)
+
+-- This demo's frame procedure runs in `SymM` but leans on `MetaM` here: `Meta.AC` closes the
+-- `∗`-rearrangement, and `isDefEq` matches atoms that may carry spec metavariables. It is worth it
+-- for a self-contained example; a production frameproc would want a `SymM`-native equivalent.
+def proveSepConjLe (pre rhs : Expr) : MetaM (Option Expr) := do
+  if ← isDefEq pre rhs then
+    return some (← mkAppM ``PartialOrder.rel_of_eq #[← mkEqRefl pre])
+  let eqTy ← mkEq pre rhs
+  let eqMVar ← mkFreshExprSyntheticOpaqueMVar eqTy
+  try
+    Lean.Meta.AC.rewriteUnnormalizedRefl eqMVar.mvarId!
+    let eq ← instantiateMVars eqMVar
+    return some (← mkAppM ``PartialOrder.rel_of_eq #[eq])
+  catch _ =>
+    return none
+
+/-- A `FrameSplit` cancelling `frame` off the precondition: the split VC `pre ⊑ frame ∗ residualPre`
+is `pre ⊑ frame ∗ footprint` (proved by AC-rearrangement of `∗`) composed by right-monotonicity with
+the emitted subgoal `footprint ⊑ residualPre`. -/
+def mkSepFrameSplit (i : FrameInferenceInfo) (frame footprint : Expr) : SymM FrameSplit := do
+  -- `.appArg!` reads the `frame ∗ ·` right-hand side off the split VC `mkSplitVC` builds.
+  let sepFF := (← i.mkSplitVC frame footprint).appArg!
+  match ← proveSepConjLe i.pre sepFF with
+  | none => FrameSplit.withDeferredSplitVC i frame
+  | some hcl =>
+    let sepFR := (← i.mkSplitVC frame i.residualPre).appArg!
+    let sub ← mkFreshExprSyntheticOpaqueMVar (← mkAppNS i.le #[footprint, i.residualPre])
+    let mono ← mkAppNS (← mkConstS ``sepConj_mono_right) #[frame, footprint, i.residualPre, sub]
+    let args := i.le.getAppArgs
+    let proof ← mkAppNS (← mkConstS ``PartialOrder.rel_trans i.le.getAppFn.constLevels!)
+      #[args[0]!, args[1]!, i.pre, sepFF, sepFR, hcl, mono]
+    return FrameSplit.withDischargedSplitVC frame proof [sub.mvarId!]
+
+/-- Automatic frame inference by domain difference: the spec's precondition's atoms (its footprint)
+are cancelled from the goal precondition's; the leftover atoms are the frame. A pinned `frames`
+resource cancels its own atoms instead, leaving the split VC open when they are missing. -/
+def sepConjFrameProc : FrameInferenceProc := fun i => do
+  -- Exercises `FrameInferenceInfo.spec?`: a real frameproc keys a footprint off the applied spec's
+  -- name. `probe_spec` isolates the report to the one test example below.
+  if i.spec? == some `probe_spec then
+    logInfo m!"framing for spec {i.spec?}"
+  match i.hint with
+  | .explicit frame =>
+    match ← matchSepAtoms i.pre frame with
+    | none => return some (← FrameSplit.withDeferredSplitVC i frame)
+    | some (rest, _) => return some (← mkSepFrameSplit i frame (sepConjOfAtoms rest))
+  | .implicit specPre =>
+    let some (rest, matched) ← matchSepAtoms i.pre specPre | return none
+    if rest.isEmpty then return none
+    return some (← mkSepFrameSplit i (sepConjOfAtoms rest) (sepConjOfAtoms matched))
+
 @[frameproc] def heapFP : FrameProc where
   prog := ``HeapM
   mkOpAppM := fun _ => pure (mkConst ``sepConj)
   resourceTy := fun _ => pure (mkConst ``HProp)
-  op := { head := ``sepConj, numConst := 0, terminal? := ``sepConj_frame_r }
-  proc := some sepConjFrameProc
+  opHead := ``sepConj
+  proc := sepConjFrameProc
 
-/-! ## The `iFrame` example: carry a disjoint cell across a `store`
+/-! # Specifications -/
 
-`vcgen` applies the `∗` frame gadget with the frame, fires the `sepConj_frame_r` split to cancel the
-framed cell from the precondition, and `finish` discharges the residual wand and the frame condition
-(`frames_sepConj`). The `∗` split reaches `vcgen` because `heapFP`/`sepSplit` declare `numParams := 0`:
-`sepConj` is monomorphic, with no carrier/instance prefix before its operands.
+/-! ## Primitive specs -/
 
-The frame is either inferred by `sepConjFrameProc` (the domain difference between the actual and the
-spec precondition) or supplied explicitly via the `frames` clause. -/
+/-- Storing overwrites the cell, framing every disjoint heap by construction. -/
+@[spec] theorem store_spec (l : Addr) (v w : Nat) :
+    ⦃ l ↦ v ⦄ (store l w) ⦃ fun _ => l ↦ w ⦄ := by
+  refine HeapM.triple_of_triple_StateM_run fun F => ?_
+  simp only [store, HeapM.run_mk]
+  vcgen with finish
 
-/-- Storing to `l1` carries the disjoint cell `l2 ↦ b` untouched, framed automatically by `vcgen`. This
-is the separation-logic move that would be `iFrame "Hl2"` in Iris. -/
-example (l1 l2 a b x : Nat) :
+/-- Loading returns the stored value and leaves the cell in place. -/
+@[spec] theorem load_spec (l : Addr) (v : Nat) :
+    ⦃ l ↦ v ⦄ (load l) ⦃ fun r => sepPure (r = v) ∗ l ↦ v ⦄ := by
+  refine HeapM.triple_of_triple_StateM_run fun F => ?_
+  simp only [load, HeapM.run_mk]
+  vcgen with finish
+
+/-! ## Framing examples -/
+
+example (l1 l2 : Addr) (a b x : Nat) :
     ⦃ l1 ↦ a ∗ l2 ↦ b ⦄ (store l1 x) ⦃ fun _ => l1 ↦ x ∗ l2 ↦ b ⦄ := by
   vcgen [store_spec] with finish
 
-/-- The same goal with the frame supplied explicitly. -/
-example (l1 l2 a b x : Nat) :
+example (l1 l2 : Addr) (a b x : Nat) :
     ⦃ l1 ↦ a ∗ l2 ↦ b ⦄ (store l1 x) ⦃ fun _ => l1 ↦ x ∗ l2 ↦ b ⦄ := by
-  vcgen [store_spec] frames | store l1 x => (pointsTo l2 b) with finish
+  vcgen [store_spec] frames | store l1 x => (l2 ↦ b) with finish
+
+example (l1 l2 : Addr) (a b : Nat) :
+    ⦃ l1 ↦ a ∗ l2 ↦ b ⦄ (load l1) ⦃ fun r => l2 ↦ b ∗ sepPure (r = a) ∗ l1 ↦ a ⦄ := by
+  vcgen [load_spec] with finish
+
+/-- A probe program with its own spec, used only to exercise `FrameInferenceInfo.spec`. -/
+def probe (l : Addr) : HeapM Unit := store l 0
+
+@[spec] theorem probe_spec (l : Addr) (v : Nat) : ⦃ l ↦ v ⦄ probe l ⦃ fun _ => l ↦ 0 ⦄ :=
+  store_spec l v 0
+
+-- Framing `probe l1` reports the applied spec `probe_spec`, read off `FrameInferenceInfo.spec`.
+/-- info: framing for spec some (probe_spec) -/
+#guard_msgs in
+example (l1 l2 : Addr) (a b : Nat) :
+    ⦃ l1 ↦ a ∗ l2 ↦ b ⦄ (probe l1) ⦃ fun _ => l1 ↦ 0 ∗ l2 ↦ b ⦄ := by
+  vcgen [probe_spec] with finish
+
+/-! ## In-place reverse -/
+
+/-- Load the next-pointer of a cons cell; the loaded value is the `IsList` witness.
+Higher priority than `load_spec` so `vcgen` prefers the `IsList`-shaped precondition. -/
+@[spec high] theorem load_next_IsList (v : Nat) (vs : List Nat) (back curr : Addr) :
+    ⦃ IsList (v :: vs) back curr ⦄
+      load curr
+    ⦃ fun next =>
+        ⌜curr ≠ null⌝ ⊓
+          (curr ↦ next ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗ IsList vs curr next) ⦄ := by
+  simp only [IsList_cons_eq]
+  vcgen [load_spec] with finish
+
+/-- Accumulator specification — both induction cases are `vcgen` scripts.
+Pre: remaining segment `xs` at `curr` with back-pointer `prev`, plus reversed segment `ys` at `prev`
+with back-pointer `curr`. -/
+@[spec] theorem reverse.go_spec (fuel : Nat) (rest acc : List Nat) (curr prev : Addr)
+    (hle : rest.length ≤ fuel) :
+    ⦃ IsList rest prev curr ∗ IsList acc curr prev ⦄
+      reverse.go fuel curr prev
+    ⦃ fun r => IsList (rest.reverse ++ acc) null r ⦄ := by
+  induction rest generalizing fuel curr prev acc with
+  | nil =>
+    cases fuel with
+    | zero =>
+      simp only [reverse.go, IsList_nil_eq, List.reverse_nil, List.nil_append]
+      vcgen with (try finish; try (exact IsList_nil_acc_le _ _ _))
+    | succ fuel =>
+      simp only [reverse.go, IsList_nil_eq, List.reverse_nil, List.nil_append]
+      -- `go` still branches on `curr = null`; the `≠` arm is absurd under `IsList []`.
+      split
+      · vcgen with (try finish; try (exact IsList_nil_acc_le _ _ _))
+      · rename_i hne
+        constructor
+        intro h hh
+        have ⟨hc, _⟩ :=
+          (sepPure_sepConj_iff (curr = null) (IsList acc curr prev) h).mp hh
+        exact (hne hc).elim
+  | cons v rest ih =>
+    match fuel, hle with
+    | 0, hle =>
+      simp at hle
+    | fuel + 1, hle =>
+      simp only [reverse.go, List.reverse_cons, List.append_assoc, List.singleton_append,
+        List.length_cons] at hle ⊢
+      -- `go` branches on `curr = null`; the `=` arm is absurd under `IsList (v :: rest)`.
+      split
+      · rename_i hc
+        constructor
+        intro h hh
+        obtain ⟨h₁, _, _, _, hl, _⟩ := hh
+        exact ((IsList_cons_elim hl).1 hc).elim
+      · -- Prefer `load_next_IsList`; IH after `generalizing` is `fuel acc curr prev`.
+        vcgen [-load_spec, load_next_IsList, store_spec,
+          fun next => ih fuel (v :: acc) next curr (Nat.le_of_succ_le_succ hle)] with
+          (try finish; try (exact reverse_store_handoff_le _ _ _ _ _ _))
+
+@[spec] theorem reverse_spec (xs : List Nat) (head : Addr) :
+    ⦃ IsList xs null head ⦄ reverse xs.length head ⦃ fun r => IsList xs.reverse null r ⦄ := by
+  simp only [reverse]
+  -- Pin `ys`/`prev` via an explicit accumulator instance of the schematic `@[spec]`.
+  vcgen [-reverse.go_spec, reverse.go_spec xs.length xs [] head null (Nat.le_refl _)] with
+    (try finish; try (simp [IsList_nil_null, sepConj_emp, IsList_append_nil]; finish))
+
+example (xs : List Nat) (head l : Addr) (v : Nat) :
+    ⦃ l ↦ v ∗ IsList xs null head ⦄ (reverse xs.length head)
+      ⦃ fun r => l ↦ v ∗ IsList xs.reverse null r ⦄ := by
+  vcgen [reverse_spec] with finish

--- a/tests/elab/vcgenTickFrames.lean
+++ b/tests/elab/vcgenTickFrames.lean
@@ -14,31 +14,33 @@ set_option grind.warning false
 # A frame-internalizing cost weakest precondition
 
 A cost transformer `TickT m := StateT Nat m` whose weakest precondition bakes in a *residuated* frame
-rule for a resource that is **not** the lattice meet. The resource is a `Nat` cost budget with
-separating conjunction `costConj r b = fun n => ⌜r ≤ n⌝ ⊓ b (n - r)` (hold `r` aside, run `b` on the
-rest) and magic wand `r -⋆ b = fun m => b (m + r)`. `TickT.wp` is the `PreservesSup.frameClosure` of
-the base wp over `costConj`, so every program frames every budget by construction, and a registered
-`@[frameproc]` lets plain `vcgen` infer and frame the budget across calls.
+rule for a resource that is **not** the lattice meet. The resource is a `Nat` tick counter with
+separating conjunction `costConj shift b = fun ticks => ⌜shift ≤ ticks⌝ ⊓ b (ticks - shift)`
+(Day convolution with a point mass: translate `b` by `shift`) and magic wand
+`shift -⋆ b = fun ticks => b (ticks + shift)`. `TickT.wp` is the `PreservesSup.frameClosure` of the
+base wp over `costConj`, so every program frames every shift by construction, and a registered
+`@[frameproc]` lets plain `vcgen` infer and frame the shift across calls.
 -/
 
-open Lean Order Meta Elab Tactic Sym Std Internal.Do Std.Internal.Do.CompleteLattice
+open Lean Order Meta Elab Tactic Sym Sym.Internal Std Internal.Do Std.Internal.Do.CompleteLattice
 
 /-! ## The cost separating conjunction -/
 
 variable {L : Type u} [CompleteLattice L]
 
-/-- The cost frame operator: hold the budget `r` aside and run `b` on the remaining cost.
-`costConj r b n` is `⌜r ≤ n⌝ ⊓ b (n - r)`: at least `r` cost available and `b` holds of the rest.
-This is separating conjunction for the `Nat` resource, over any assertion lattice. -/
-noncomputable def costConj (r : Nat) (b : Nat → L) : Nat → L := fun n => ⌜r ≤ n⌝ ⊓ b (n - r)
+/-- The cost separating conjunction: convolve `b` with a point mass at `shift`, translating `b` by
+`shift` ticks. `costConj shift b ticks` is `⌜shift ≤ ticks⌝ ⊓ b (ticks - shift)`: at least `shift`
+ticks available, and `b` holds of the rest. This is `∗` for the `Nat` resource. -/
+noncomputable def costConj (shift : Nat) (b : Nat → L) : Nat → L :=
+  fun ticks => ⌜shift ≤ ticks⌝ ⊓ b (ticks - shift)
 
 @[inherit_doc costConj] local infixr:67 " ⋆ " => costConj
 
 /-- Pointwise unfolding of `costConj`. As a `grind` normalization rule it eliminates `costConj`
-during preprocessing, so the applied form `costConj r b n s` reduces under any base state argument.
-Also builds the frame split rule. -/
-@[grind norm] theorem costConj_apply (r : Nat) (b : Nat → L) (n : Nat) :
-    costConj r b n = ⌜r ≤ n⌝ ⊓ b (n - r) := rfl
+during preprocessing, so the applied form `costConj shift b ticks s` reduces under any base state
+argument. Also builds the frame split rule. -/
+@[grind norm] theorem costConj_apply (shift : Nat) (b : Nat → L) (ticks : Nat) :
+    costConj shift b ticks = ⌜shift ≤ ticks⌝ ⊓ b (ticks - shift) := rfl
 
 /-- The guard `⌜p⌝ ⊓ ·` preserves arbitrary sups, for any complete lattice, because `⌜p⌝` is `⊤`/`⊥`. -/
 theorem ofProp_meet_sup (p : Prop) (X : L → Prop) :
@@ -58,11 +60,11 @@ theorem ofProp_meet_sup (p : Prop) (X : L → Prop) :
     rintro y ⟨x, hx, rfl⟩
     exact le_meet _ _ _ (meet_le_left _ _) (PartialOrder.rel_trans (meet_le_right _ _) (le_sup _ hx))
 
-instance (r : Nat) : PreservesSup (costConj (L := L) r) where
+instance (shift : Nat) : PreservesSup (costConj (L := L) shift) where
   map_sup s := by
-    funext n
-    show ⌜r ≤ n⌝ ⊓ (CompleteLattice.sup s) (n - r)
-      = CompleteLattice.sup (fun y => ∃ x, s x ∧ y = costConj r x) n
+    funext ticks
+    show ⌜shift ≤ ticks⌝ ⊓ (CompleteLattice.sup s) (ticks - shift)
+      = CompleteLattice.sup (fun y => ∃ x, s x ∧ y = costConj shift x) ticks
     simp only [sup_apply]
     rw [ofProp_meet_sup]
     congr 1
@@ -70,48 +72,51 @@ instance (r : Nat) : PreservesSup (costConj (L := L) r) where
     apply propext
     constructor
     · rintro ⟨w, ⟨f, hf, rfl⟩, rfl⟩
-      exact ⟨costConj r f, ⟨f, hf, rfl⟩, rfl⟩
+      exact ⟨costConj shift f, ⟨f, hf, rfl⟩, rfl⟩
     · rintro ⟨g, ⟨f, hf, rfl⟩, rfl⟩
-      exact ⟨f (n - r), ⟨f, hf, rfl⟩, rfl⟩
+      exact ⟨f (ticks - shift), ⟨f, hf, rfl⟩, rfl⟩
 
-/-- The cost magic wand: the upper adjoint of the slice `costConj r`, a plain shift
-`r -⋆ b = fun m => b (m + r)`. -/
+/-- The cost magic wand: the upper adjoint of `costConj shift`, the correlation
+`shift -⋆ b = fun ticks => b (ticks + shift)` translating `b` back up the counter. -/
 local notation:60 lhs:61 " -⋆ " rhs:61 => Lean.Order.PreservesSup.upperAdjoint (costConj lhs) rhs
 
-/-- The upper adjoint of `costConj r` is the cost magic wand `fun m => b (m + r)`, a shift of the
-budget back onto the counter. -/
+/-- The upper adjoint of `costConj shift` is the cost magic wand `fun ticks => b (ticks + shift)`,
+translating `b` back up the counter. -/
 @[grind =]
-theorem costConj_imp (r : Nat) (b : Nat → L) :
-    r -⋆ b = (fun m => b (m + r)) := by
+theorem costConj_imp (shift : Nat) (b : Nat → L) :
+    shift -⋆ b = (fun ticks => b (ticks + shift)) := by
   apply PartialOrder.rel_antisymm
   · unfold PreservesSup.upperAdjoint
     apply sup_le
-    intro x hx m
-    have := hx (m + r)
-    simp only [costConj, show m + r - r = m by omega] at this
+    intro x hx ticks
+    have := hx (ticks + shift)
+    simp only [costConj, show ticks + shift - shift = ticks by omega] at this
     exact PartialOrder.rel_trans (le_meet _ _ _ (le_ofProp _ _ (by omega)) PartialOrder.rel_refl) this
-  · refine PreservesSup.le_upperAdjoint (costConj r) (b := b) (x := fun m => b (m + r)) ?_
-    intro n
-    show (⌜r ≤ n⌝ ⊓ b (n - r + r)) ⊑ b n
+  · refine PreservesSup.le_upperAdjoint (costConj shift) (b := b)
+      (x := fun ticks => b (ticks + shift)) ?_
+    intro ticks
+    show (⌜shift ≤ ticks⌝ ⊓ b (ticks - shift + shift)) ⊑ b ticks
     rw [CompleteLattice.ofProp_intro_r]
     intro hle
-    rw [show n - r + r = n by omega]
+    rw [show ticks - shift + shift = ticks by omega]
 
-/-- The additive action law of `costConj`: composing two budgets `r` and `r'` is the same as holding
-them one after the other. -/
-theorem costConj_add (r r' : Nat) (a : Nat → L) :
-    costConj (r + r') a = costConj r (costConj r' a) := by
-  funext n
-  show ⌜r + r' ≤ n⌝ ⊓ a (n - (r + r')) = ⌜r ≤ n⌝ ⊓ (⌜r' ≤ n - r⌝ ⊓ a (n - r - r'))
+/-- The additive action law of `costConj`: composing two shifts `shift` and `shift'` is the same as
+translating one after the other. -/
+theorem costConj_add (shift shift' : Nat) (a : Nat → L) :
+    costConj (shift + shift') a = costConj shift (costConj shift' a) := by
+  funext ticks
+  show ⌜shift + shift' ≤ ticks⌝ ⊓ a (ticks - (shift + shift'))
+    = ⌜shift ≤ ticks⌝ ⊓ (⌜shift' ≤ ticks - shift⌝ ⊓ a (ticks - shift - shift'))
   rw [Nat.sub_sub, ← meet_assoc, ofProp_and,
-    show (r ≤ n ∧ r' ≤ n - r) = (r + r' ≤ n) from
+    show (shift ≤ ticks ∧ shift' ≤ ticks - shift) = (shift + shift' ≤ ticks) from
       propext ⟨fun ⟨_, _⟩ => by omega, fun h => ⟨by omega, by omega⟩⟩]
 
-/-- The unit of the `costConj` action: holding a zero budget is the identity. -/
+/-- The unit of the `costConj` action: a zero shift is the identity. -/
 theorem costConj_zero (a : Nat → L) : costConj 0 a = a := by
-  funext n
+  funext ticks
   rw [costConj_apply, Nat.sub_zero,
-    show (⌜0 ≤ n⌝ : L) = ⊤ from PartialOrder.rel_antisymm (le_top _) (top_le_ofProp _ (Nat.zero_le n)),
+    show (⌜0 ≤ ticks⌝ : L) = ⊤ from
+      PartialOrder.rel_antisymm (le_top _) (top_le_ofProp _ (Nat.zero_le ticks)),
     top_meet]
 
 /-! ## The cost transformer `TickT` and its weakest precondition -/
@@ -141,8 +146,8 @@ noncomputable def TickT.wp [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad
     {α : Type} (x : TickT m α) (Q : α → Nat → Pred) (E : EPred) : Nat → Pred :=
   PreservesSup.frameClosure costConj (WP.wp x.run · E) Q
 
-/-- The simp normal form for `TickT.wp`: the meet over all held budgets `r` of the base wp under the
-held-budget postcondition `⌜r ≤ m⌝ ⊓ Q a (m - r)`, offset by `r`. -/
+/-- The simp normal form for `TickT.wp`: the meet over all shifts `r` of the base wp under the
+shifted postcondition `⌜r ≤ m⌝ ⊓ Q a (m - r)`, offset by `r`. -/
 @[simp, grind =]
 theorem TickT.wp_apply_eq [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {α : Type} (x : TickT m α) (Q : α → Nat → Pred) (E : EPred) (n : Nat) :
@@ -160,8 +165,8 @@ theorem TickT.le_wp_tick [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m
 /-- A cost-*discarding* program: it throws away the accumulated cost, resetting the counter to `0`. -/
 def dropCost : TickM Unit := show StateM Nat Unit from set 0
 
-/-- `dropCost` resets the counter, so `TickT.wp dropCost Q n = False` for every `Q`: holding a budget
-of `1` leaves the unsatisfiable `1 ≤ 0`. The frame closure rejects programs that lose held cost. -/
+/-- `dropCost` resets the counter, so `TickT.wp dropCost Q n = False` for every `Q`: a shift
+of `1` leaves the unsatisfiable `1 ≤ 0`. The frame closure rejects programs that lose held ticks. -/
 example (Q : Unit → Nat → Prop) (E : EPost.Nil) (n : Nat) : TickT.wp dropCost Q E n = False := by
   rw [TickT.wp_apply_eq, iInf_prop_eq_forall]
   refine propext ⟨fun h => ?_, False.elim⟩
@@ -180,7 +185,7 @@ noncomputable instance TickT.instWPMonad [Assertion Pred] [Assertion EPred] [WPM
     WPMonad (TickT m) (Nat → Pred) EPred :=
   WPMonad.of_frameClosure (m := StateT Nat m) costConj costConj_add costConj_zero StateT.instWPMonad
 
-/-- The internalized frame rule: every program frames every budget `F` with respect to `costConj`. -/
+/-- The internalized frame rule: every program frames every shift `F` with respect to `costConj`. -/
 @[grind .]
 theorem frames_costConj [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {α : Type} (x : TickT m α) (F : Nat) : WP.Frames costConj x F :=
@@ -191,9 +196,9 @@ theorem frames_costConj [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred
 theorem tickFrames [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {α : Type} (x : TickT m α) (F : Nat) (Q : α → Nat → Pred) (E : EPred) :
     F ⋆ TickT.wp x Q E ⊑ TickT.wp x (fun a => F ⋆ Q a) E :=
-  (frames_costConj (Pred := Pred) (EPred := EPred) x F).conj_wp_le_wp_conj Q E
+  (frames_costConj (Pred := Pred) (EPred := EPred) x F).op_wp_le_wp_op Q E
 
-/-- The sharp cost spec for `tick`: it costs exactly one unit. Threads the held budget `r` through the
+/-- The sharp cost spec for `tick`: it costs exactly one unit. Threads the shift `r` through the
 base `tick` spec. -/
 theorem TickT.le_wp_tick' [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     (Q : Unit → Nat → Pred) (E : EPred) (n : Nat) :
@@ -208,8 +213,8 @@ theorem TickT.le_wp_tick' [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPr
 
 /-! ## End-to-end `vcgen` via a registered `@[frameproc]`
 
-`tickFrameProc` holds the current cost as the budget; the registered `costSplit` decomposes a
-`costConj` goal into a budget side goal and a cost-shifted residual. -/
+`tickFrameProc` shifts by the current tick count and emits the split VC in its `costConj_apply`
+meet form, so the built-in meet split yields the tick guard and the shifted residual. -/
 
 open Lean.Elab.Tactic.Do.Internal Lean.Elab.Tactic.Do.Internal.VCGen
 
@@ -220,33 +225,51 @@ open Lean.Elab.Tactic.Do.Internal Lean.Elab.Tactic.Do.Internal.VCGen
   intro n
   exact TickT.le_wp_tick' Q E n
 
-/-- The frame inference procedure: hold the budget given by the current cost, the first excess state
-argument of the `Nat → L` cost assertion. -/
-def tickFrameProc : FrameInferenceProc := fun _R _pre info _specPre => do
-  unless info.Pred.isArrow && info.Pred.bindingDomain!.isConstOf ``Nat do return none
-  let some cost := info.excessArgs[0]? | return none
-  -- Framing the whole cost leaves the residual budget `cost - cost`; skip when that normalizes to
-  -- `0` so the proc does not re-fire on its own residual.
-  let cost ← instantiateMVars cost
-  let thms := ({} : Lean.Meta.Sym.Simp.Theorems).insert
-    (← Lean.Meta.Sym.Simp.mkTheoremFromDecl ``Nat.sub_self)
-  let post := Lean.Meta.Sym.Simp.evalGround >> thms.rewrite
-  let cost := (← Lean.Meta.Sym.simp cost { post }).getResultExpr cost
-  if cost.nat? == some 0 then return none
-  return some cost
+/-- The frame inference procedure: shift by the pinned frame's amount, or by the whole current tick
+count (`i.excessArgs[0]`, the first excess state argument of the `Nat → L` cost assertion). It emits
+the split VC in the meet form `pre ⊑ (⌜shift ≤ ticks⌝ ⊓ residualPre (ticks - shift)) s⃗`; the built-in
+meet split turns this into the tick guard (closed by `grind`) and the shifted residual
+`pre ⊑ residualPre (ticks - shift) s⃗`. -/
+def tickFrameProc : FrameInferenceProc := fun i => do
+  unless i.Pred.isArrow && i.Pred.bindingDomain!.isConstOf ``Nat do return none
+  let some ticks := i.excessArgs[0]? | return none
+  let shift ← match i.hint with
+    | .explicit r => pure r
+    | .implicit _ => do
+      -- Shifting by the whole tick count leaves `ticks - ticks`; skip when that normalizes to `0` so
+      -- the proc does not re-fire on its own residual.
+      let ticks ← instantiateMVarsS ticks
+      let thms := ({} : Lean.Meta.Sym.Simp.Theorems).insert
+        (← Lean.Meta.Sym.Simp.mkTheoremFromDecl ``Nat.sub_self)
+      let post := Lean.Meta.Sym.Simp.evalGround >> thms.rewrite
+      pure ((← Lean.Meta.Sym.simp ticks { post }).getResultExpr ticks)
+  if shift.nat? == some 0 then return none
+  -- Emit the split VC `pre ⊑ (costConj shift residualPre ticks) s⃗` in its `costConj_apply`-reduced
+  -- meet form `pre ⊑ (⌜shift ≤ ticks⌝ ⊓ residualPre (ticks - shift)) s⃗` (definitionally equal), so the
+  -- built-in meet split decomposes it: the tick guard closes by `grind`, the residual re-applies.
+  let costL := i.op.getAppArgs[0]!
+  let costInst := i.op.getAppArgs[1]!
+  let us := i.op.getAppFn.constLevels!
+  let guard ← mkAppNS (← mkConstS ``CompleteLattice.ofProp us)
+    #[costL, costInst, ← mkAppNS (← mkConstS ``Nat.le) #[shift, ticks]]
+  let residual ← mkAppNS i.residualPre #[← mkAppNS (← mkConstS ``Nat.sub) #[ticks, shift]]
+  let meet ← mkAppNS (← mkConstS ``Lean.Order.meet us) #[costL, costInst, guard, residual]
+  let rhs ← mkAppNS meet (i.excessArgs.extract 1 i.excessArgs.size)
+  let m ← mkFreshExprSyntheticOpaqueMVar (← mkAppNS i.le #[i.pre, rhs])
+  return some (FrameSplit.withDischargedSplitVC shift m [m.mvarId!])
 
 /-- Register the cost frame inference procedure for `vcgen`, indexed by the `TickT` program type. The
 frame operator `costConj` is built at the base lattice `L` read off the assertion type `Nat → L`, so it
-frames the cost over any base monad. Its `costConj_apply` rewrite unfolds `costConj r b n` to
-`⌜r ≤ n⌝ ⊓ b (n - r)`, inheriting the built-in meet terminal. -/
+frames the cost over any base monad. `costConj_apply` unfolds `costConj r b n` to
+`⌜r ≤ n⌝ ⊓ b (n - r)` when discharging the split VC. -/
 @[frameproc] def tickFP : FrameProc where
   prog := ``TickT
   mkOpAppM := fun info => Meta.mkAppOptM ``costConj #[some info.Pred.bindingBody!, none]
   resourceTy := fun _ => pure (mkConst ``Nat)
-  op := { head := ``costConj, rewrites := #[``costConj_apply] }
-  proc := some tickFrameProc
+  opHead := ``costConj
+  proc := tickFrameProc
 
-/-- End-to-end: plain `vcgen` infers the budget, applies the `costConj` gadget, fires the registered
+/-- End-to-end: plain `vcgen` infers the shift, applies the `costConj` gadget, fires the registered
 `costSplit`, and the meet machinery closes the residual. -/
 example : ⦃ (⊤ : Nat → Prop) ⦄ (tick : TickM Unit) ⦃ fun _ => (⊤ : Nat → Prop) ⦄ := by
   vcgen with finish [top_apply]
@@ -268,7 +291,7 @@ run_meta do
   let _ ← SymM.run <| mkLatticeOpRule rhs { head := ``keepFrame, rewrites := #[``keepFrame_apply] }
 
 -- Stripped of its rewrite the operator neither reduces nor closes, so its split would be the identity.
-/-- error: frame operator `keepFrame` neither reduces nor has a registered terminal; its lattice split rule would be the identity -/
+/-- error: lattice operator `keepFrame` neither reduces nor has a registered terminal; its split rule would be the identity -/
 #guard_msgs in
 run_meta do
   let rhs ← Meta.mkAppM ``keepFrame #[mkNatLit 3, mkConst ``keepPred]
@@ -299,7 +322,7 @@ example {α : Type} (xs ys : List α) :
     (do tickList xs; tickList ys : TickT (StateM Nat) Unit) ⏱ (xs.length + ys.length) := by
   vcgen with finish
 
-/-- The same goal with an explicit `frames` clause naming each call's budget. -/
+/-- The same goal with an explicit `frames` clause naming each call's shift. -/
 example {α : Type} (xs ys : List α) :
     (do tickList xs; tickList ys : TickT (StateM Nat) Unit) ⏱ (xs.length + ys.length) := by
   vcgen frames


### PR DESCRIPTION
This PR reworks how a `@[frameproc]` procedure discharges its split verification condition so that frame inference scales to operators whose residual the built-in lattice split cannot decompose. A procedure for separating conjunction `∗` used to leave behind a `∗` that no split rule could discharge, halting `vcgen`; a procedure may now discharge its split VC however it wants, so separation-logic framing closes with `vcgen … with finish`.

A procedure builds its split VC `pre ⊑ (op frame residualPre) s⃗` against a solver-owned metavariable `residualPre` that the solver fills with the weakest footprint once the frame rule applies, and returns a `FrameSplit` that either carries its own proof of that VC or defers it as a subgoal for the built-in lattice decomposition.
