### PR TITLE
feat: do not show deprecated syntax warnings inside of deprecated definitions

### DIFF
--- a/src/Lean/Elab/Tactic/Basic.lean
+++ b/src/Lean/Elab/Tactic/Basic.lean
@@ -202,7 +202,8 @@ partial def evalTactic (stx : Syntax) : TacticM Unit := do
         Term.withoutTacticIncrementality true <| withTacticInfoContext stx do
           stx.getArgs.forM evalTactic
       else withTraceNode `Elab.step (fun _ => return stx) (tag := stx.getKind.toString) do
-        checkDeprecatedSyntax stx (← readThe Term.Context).macroStack
+        if (← readThe Term.Context).checkDeprecated then
+          checkDeprecatedSyntax stx (← readThe Term.Context).macroStack
         let evalFns := tacticElabAttribute.getEntries (← getEnv) stx.getKind
         let macros  := macroAttribute.getEntries (← getEnv) stx.getKind
         if evalFns.isEmpty && macros.isEmpty then

--- a/src/Lean/Elab/Term/TermElabM.lean
+++ b/src/Lean/Elab/Term/TermElabM.lean
@@ -1826,7 +1826,8 @@ private partial def elabTermAux (expectedType? : Option Expr) (catchExPostpone :
     withTraceNode `Elab.step (fun _ => return m!"expected type: {expectedType?}, term\n{stx}")
       (tag := stx.getKind.toString) do
     checkSystem "elaborator"
-    checkDeprecatedSyntax stx (← read).macroStack
+    if (← read).checkDeprecated then
+      checkDeprecatedSyntax stx (← read).macroStack
     let env ← getEnv
     let result ← match (← liftMacroM (expandMacroImpl? env stx)) with
     | some (decl, stxNew?) =>

--- a/tests/elab/deprecated_syntax.lean
+++ b/tests/elab/deprecated_syntax.lean
@@ -82,3 +82,14 @@ myDepCmd
 
 -- Test 10: missing since emits a warning
 deprecated_syntax Lean.Parser.Term.show
+
+-- Test 11: deprecated syntax inside a `@[deprecated]` definition → no warning,
+-- matching the suppression rule for deprecated constants (RFC #8942)
+@[deprecated "use something else" (since := "2026-07-24")]
+def deprecatedUsesOldTerm : Nat := oldThing
+
+@[deprecated "use something else" (since := "2026-07-24")]
+theorem deprecatedUsesOldTac : True := by myDepTac
+
+-- Test 11b: the same syntax outside a deprecated definition still warns
+def freshUsesOldTerm : Nat := oldThing

--- a/tests/elab/deprecated_syntax.lean.out.expected
+++ b/tests/elab/deprecated_syntax.lean.out.expected
@@ -30,3 +30,6 @@ Note: This linter can be disabled with `set_option linter.deprecated.syntax fals
 42 : Nat
 42 : Nat
 deprecated_syntax.lean:84:0-84:39: warning: `deprecated_syntax` should specify the date or library version at which the deprecation was introduced, using `(since := "...")`
+deprecated_syntax.lean:95:30-95:38: warning: syntax 'termOldThing' has been deprecated: use `42` instead
+
+Note: This linter can be disabled with `set_option linter.deprecated.syntax false`


### PR DESCRIPTION
This PR changes the way deprecates syntax warnings are displayed. Inside of definitions, which are themselves deprecated, deprecated syntax warnings are silenced. 