### PR TITLE
chore: CI: update adaptation PR labels

### DIFF
--- a/.github/workflows/adaptation-pr.yml
+++ b/.github/workflows/adaptation-pr.yml
@@ -9,12 +9,14 @@ on:
       - reopened
       - converted_to_draft
       - ready_for_review
+      - synchronize
 
 jobs:
-  main:
+  create-adaptation-pr:
     runs-on: ubuntu-slim
     if: >
       github.repository == 'leanprover/lean4'
+      && github.event.action != 'synchronize'
       && (github.event.action != 'labeled' || github.event.label.name == 'downstream')
     steps:
       # Determine the PR toolchain tag (see `pr-release.yml` for how it is
@@ -72,6 +74,7 @@ jobs:
           fetch-depth: 0
 
       - name: Create adaptation PR
+        id: create-adaptation-pr
         uses: leanprover/downstream-lean4/.downstream/actions/adaptation-pr-create@master
         with:
           app-token: ${{ steps.app-token.outputs.token }}
@@ -81,3 +84,40 @@ jobs:
           downstream-repo: leanprover/downstream-lean4
           downstream-clone: downstream
           override-toolchain: ${{ steps.toolchain.outputs.toolchain }}
+
+      - name: Add toolchain-available label to adaptation PR
+        if: fromJSON(steps.toolchain.outputs.exists) && steps.create-adaptation-pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ADAPTATION_PR: ${{ steps.create-adaptation-pr.outputs.number }}
+        run: gh pr edit "$ADAPTATION_PR" --repo leanprover/downstream-lean4 --add-label toolchain-available
+
+  remove-toolchain-available:
+    runs-on: ubuntu-slim
+    if: >
+      github.repository == 'leanprover/lean4'
+      && github.event.action == 'synchronize'
+      && contains(github.event.pull_request.labels.*.name, 'downstream')
+    steps:
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.DOWNSTREAM_LEAN4_APP_CLIENT_ID }}
+          private-key: ${{ secrets.DOWNSTREAM_LEAN4_APP_PRIVATE_KEY }}
+          repositories: downstream-lean4
+
+      - name: Find adaptation PR
+        id: find-adaptation-pr
+        uses: leanprover/downstream-lean4/.downstream/actions/adaptation-pr-find@master
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          upstream-pr: ${{ github.event.pull_request.number }}
+          downstream-repo: leanprover/downstream-lean4
+
+      - name: Remove toolchain-available label from adaptation PR
+        if: steps.find-adaptation-pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ADAPTATION_PR: ${{ steps.find-adaptation-pr.outputs.number }}
+        run: gh pr edit "$ADAPTATION_PR" --repo leanprover/downstream-lean4 --remove-label toolchain-available

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -659,6 +659,7 @@ jobs:
           fetch-depth: 0
 
       - name: Create adaptation PR
+        id: create-adaptation-pr
         if: ${{ steps.workflow-info.outputs.pullRequestNumber != '' }}
         uses: leanprover/downstream-lean4/.downstream/actions/adaptation-pr-create@master
         with:
@@ -669,3 +670,10 @@ jobs:
           downstream-repo: leanprover/downstream-lean4
           downstream-clone: downstream
           override-toolchain: leanprover/lean4-pr-releases:pr-release-${{ steps.workflow-info.outputs.pullRequestNumber }}-${{ env.SHORT_SHA }}
+
+      - name: Add toolchain-available label to adaptation PR
+        if: ${{ steps.workflow-info.outputs.pullRequestNumber != '' && steps.create-adaptation-pr.outputs.number != '' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ADAPTATION_PR: ${{ steps.create-adaptation-pr.outputs.number }}
+        run: gh pr edit "$ADAPTATION_PR" --repo leanprover/downstream-lean4 --add-label toolchain-available


### PR DESCRIPTION
This PR automatically adds the `toolchain-available` label to adaptation PRs once the PR toolchain has been updated in the adaptation PR, and removes it again whenever new commits are pushed to the original PR. This label is then used to block radar bench commands in the adaptation PR until changes from the original PR have finished trickling down.