### PR TITLE
chore: move some `Bool` functions

### DIFF
--- a/src/Init/Data/Bool.lean
+++ b/src/Init/Data/Bool.lean
@@ -667,3 +667,21 @@ but may be used locally.
 
 theorem Bool.rec_eq {α : Sort _} (b : Bool) {x y : α} : Bool.rec y x b = if b then x else y := by
   cases b <;> simp
+
+/-! ### Deprecations -/
+
+@[deprecated Bool.eq_false_of_ne_true (since := "2026-07-24")]
+theorem eq_false_of_ne_true {b : Bool} : b ≠ true → b = false :=
+  Bool.eq_false_of_ne_true
+
+@[deprecated Bool.eq_true_of_ne_false (since := "2026-07-24")]
+theorem eq_true_of_ne_false {b : Bool} : b ≠ false → b = true :=
+  Bool.eq_true_of_ne_false
+
+@[deprecated Bool.ne_false_of_eq_true (since := "2026-07-24")]
+theorem ne_false_of_eq_true {b : Bool} : b = true → b ≠ false :=
+  Bool.ne_false_of_eq_true
+
+@[deprecated Bool.ne_true_of_eq_false (since := "2026-07-24")]
+theorem ne_true_of_eq_false {b : Bool} : b = false → b ≠ true :=
+  Bool.ne_true_of_eq_false

--- a/src/Init/Data/Bool.lean
+++ b/src/Init/Data/Bool.lean
@@ -660,13 +660,13 @@ section
 
 open Internal
 
-@[simp] theorem Bool.and'_eq_and (a b : Bool) : a.and' b = a.and b := by
+@[simp] theorem Internal.Bool.and'_eq_and (a b : Bool) : a.and' b = a.and b := by
   cases a <;> simp [Bool.and']
 
-@[simp] theorem Bool.or'_eq_or (a b : Bool) : a.or' b = a.or b := by
+@[simp] theorem Internal.Bool.or'_eq_or (a b : Bool) : a.or' b = a.or b := by
   cases a <;> simp [Bool.or']
 
-@[simp] theorem Bool.not'_eq_not (a : Bool) : a.not' = a.not := by
+@[simp] theorem Internal.Bool.not'_eq_not (a : Bool) : a.not' = a.not := by
   cases a <;> simp [Bool.not']
 
 end

--- a/src/Init/Data/Bool.lean
+++ b/src/Init/Data/Bool.lean
@@ -647,14 +647,18 @@ but may be used locally.
 
 /-! ### Proof by reflection support  -/
 
-@[expose] protected noncomputable def Bool.and' (a b : Bool) : Bool :=
+@[expose] protected noncomputable def Internal.Bool.and' (a b : Bool) : Bool :=
   Bool.rec false b a
 
-@[expose] protected noncomputable def Bool.or' (a b : Bool) : Bool :=
+@[expose] protected noncomputable def Internal.Bool.or' (a b : Bool) : Bool :=
   Bool.rec b true a
 
-@[expose] protected noncomputable def Bool.not' (a : Bool) : Bool :=
+@[expose] protected noncomputable def Internal.Bool.not' (a : Bool) : Bool :=
   Bool.rec true false a
+
+section
+
+open Internal
 
 @[simp] theorem Bool.and'_eq_and (a b : Bool) : a.and' b = a.and b := by
   cases a <;> simp [Bool.and']
@@ -664,6 +668,8 @@ but may be used locally.
 
 @[simp] theorem Bool.not'_eq_not (a : Bool) : a.not' = a.not := by
   cases a <;> simp [Bool.not']
+
+end
 
 theorem Bool.rec_eq {α : Sort _} (b : Bool) {x y : α} : Bool.rec y x b = if b then x else y := by
   cases b <;> simp

--- a/src/Init/Data/Int/Linear.lean
+++ b/src/Init/Data/Int/Linear.lean
@@ -14,6 +14,9 @@ public import Init.Data.RArray
 import Init.Data.Int.Cooper
 import Init.Data.Int.LemmasAux
 public section
+
+open Internal
+
 namespace Int.Internal.Linear
 
 /-! Helper definitions and theorems for constructing linear arithmetic proofs. -/

--- a/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/FilterMap.lean
+++ b/src/Init/Data/Iterators/Lemmas/Combinators/Monadic/FilterMap.lean
@@ -296,8 +296,6 @@ private theorem bind_eq_bind_subtypeCasesOn'_optionPelim' [Monad m] [LawfulMonad
 
 end Internal
 
-open Internal
-
 theorem IterM.toList_mapWithPostcondition_eq_toList_filterMapWithPostcondition {α β γ : Type w}
     {m : Type w → Type w'} {n : Type w → Type w''}
     [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]

--- a/src/Init/Data/List/Find.lean
+++ b/src/Init/Data/List/Find.lean
@@ -634,7 +634,7 @@ theorem not_of_lt_findIdx {p : α → Bool} {xs : List α} {i : Nat} (h : i < xs
     have ho := h
     rw [findIdx_cons] at h
     have npx : p x = false := by
-      apply eq_false_of_ne_true
+      apply Bool.eq_false_of_ne_true
       intro y
       rw [y, cond_true] at h
       simp at h

--- a/src/Init/Data/List/Lemmas.lean
+++ b/src/Init/Data/List/Lemmas.lean
@@ -1262,7 +1262,7 @@ grind_pattern map_map => map g (map f l) where
     filter p (a :: l) = a :: filter p l := by rw [filter, pa]
 
 @[simp] theorem filter_cons_of_neg {p : α → Bool} {a : α} {l} (pa : ¬ p a) :
-    filter p (a :: l) = filter p l := by rw [filter, eq_false_of_ne_true pa]
+    filter p (a :: l) = filter p l := by rw [filter, Bool.eq_false_of_ne_true pa]
 
 @[grind =] theorem filter_cons :
     (x :: xs : List α).filter p = if p x then x :: (xs.filter p) else xs.filter p := by

--- a/src/Init/Grind/AC.lean
+++ b/src/Init/Grind/AC.lean
@@ -11,6 +11,8 @@ import Init.LawfulBEqTactics
 public import Init.Data.RArray
 import Init.Classical
 
+open Internal
+
 @[expose] public section
 
 namespace Lean.Grind.AC

--- a/src/Init/Grind/Ring/CommSolver.lean
+++ b/src/Init/Grind/Ring/CommSolver.lean
@@ -26,6 +26,8 @@ import Init.Data.Int.Repr
 
 @[expose] public section
 
+open Internal
+
 namespace Lean.Grind.CommRing
 /-!
 Data-structures, definitions and theorems for implementing the

--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -746,19 +746,19 @@ of other errors because the desired term was not constructed.
 @[extern "lean_sorry", never_extract]
 axiom sorryAx (α : Sort u) (synthetic : Bool) : α
 
-theorem eq_false_of_ne_true : {b : Bool} → Not (Eq b true) → Eq b false
+theorem Bool.eq_false_of_ne_true : {b : Bool} → Not (Eq b true) → Eq b false
   | true, h => False.elim (h rfl)
   | false, _ => rfl
 
-theorem eq_true_of_ne_false : {b : Bool} → Not (Eq b false) → Eq b true
+theorem Bool.eq_true_of_ne_false : {b : Bool} → Not (Eq b false) → Eq b true
   | true, _ => rfl
   | false, h => False.elim (h rfl)
 
-theorem ne_false_of_eq_true : {b : Bool} → Eq b true → Not (Eq b false)
+theorem Bool.ne_false_of_eq_true : {b : Bool} → Eq b true → Not (Eq b false)
   | true, _  => fun h => Bool.noConfusion h
   | false, h => Bool.noConfusion h
 
-theorem ne_true_of_eq_false : {b : Bool} → Eq b false → Not (Eq b true)
+theorem Bool.ne_true_of_eq_false : {b : Bool} → Eq b false → Not (Eq b true)
   | true, h  => Bool.noConfusion h
   | false, _ => fun h => Bool.noConfusion h
 
@@ -1030,11 +1030,11 @@ theorem decide_eq_false : [Decidable p] → Not p → Eq (decide p) false
 theorem of_decide_eq_true [inst : Decidable p] : Eq (decide p) true → p := fun h =>
   match (generalizing := false) inst with
   | isTrue  h₁ => h₁
-  | isFalse h₁ => absurd h (ne_true_of_eq_false (decide_eq_false h₁))
+  | isFalse h₁ => absurd h (Bool.ne_true_of_eq_false (decide_eq_false h₁))
 
 theorem of_decide_eq_false [inst : Decidable p] : Eq (decide p) false → Not p := fun h =>
   match (generalizing := false) inst with
-  | isTrue  h₁ => absurd h (ne_false_of_eq_true (decide_eq_true h₁))
+  | isTrue  h₁ => absurd h (Bool.ne_false_of_eq_true (decide_eq_true h₁))
   | isFalse h₁ => h₁
 
 theorem of_decide_eq_self_eq_true [inst : DecidableEq α] (a : α) : Eq (decide (Eq a a)) true :=

--- a/src/Lean/Meta/Sym/Simp/EvalGround.lean
+++ b/src/Lean/Meta/Sym/Simp/EvalGround.lean
@@ -530,7 +530,6 @@ macro "declare_eval_bin_bool_pred" id:ident op:term : command =>
 declare_eval_bin_bool_pred evalBEq (· == ·)
 declare_eval_bin_bool_pred evalBNe (· != ·)
 
-open Internal in
 def evalNot (a : Expr) : SimpM Result :=
   /-
   **Note**: We added `evalNot` because some abbreviations expanded into `Not`s.

--- a/src/Std/Data/DHashMap/Internal/WF.lean
+++ b/src/Std/Data/DHashMap/Internal/WF.lean
@@ -1038,7 +1038,7 @@ theorem toListModel_eraseₘ [BEq α] [Hashable α] [EquivBEq α] [LawfulHashabl
   split
   · exact toListModel_eraseₘaux m a h
   next h' =>
-    exact toListModel_perm_eraseKey_of_containsₘ_eq_false _ _ h (eq_false_of_ne_true h')
+    exact toListModel_perm_eraseKey_of_containsₘ_eq_false _ _ h (Bool.eq_false_of_ne_true h')
 
 theorem wfImp_eraseₘ [BEq α] [Hashable α] [EquivBEq α] [LawfulHashable α] {m : Raw₀ α β} {a : α}
     (h : Raw.WFImp m.1) : Raw.WFImp (m.eraseₘ a).1 := by

--- a/src/Std/Http/Data/Headers.lean
+++ b/src/Std/Http/Data/Headers.lean
@@ -24,7 +24,7 @@ namespace Std.Http
 
 set_option linter.all true
 
-open Std Internal
+open Std Std.Internal Http.Internal
 
 /--
 A structure for managing HTTP headers as key-value pairs.

--- a/src/Std/Http/Data/URI/Encoding.lean
+++ b/src/Std/Http/Data/URI/Encoding.lean
@@ -31,7 +31,7 @@ namespace Std.Http.URI
 
 set_option linter.all true
 
-open Internal Char
+open Http.Internal Char
 
 /--
 Checks if a byte is a valid character in a percent-encoded URI component. Valid characters are

--- a/src/Std/Http/Internal/IndexMultiMap.lean
+++ b/src/Std/Http/Internal/IndexMultiMap.lean
@@ -22,7 +22,7 @@ for fast key lookups. Each key always has at least one associated value.
 
 namespace Std.Internal
 
-open Std Internal
+open Std
 
 set_option linter.all true
 

--- a/src/Std/Http/Protocol/H1.lean
+++ b/src/Std/Http/Protocol/H1.lean
@@ -31,8 +31,7 @@ namespace Std.Http.Protocol.H1
 
 set_option linter.all true
 
-open Std Internal Parsec ByteArray
-open Internal
+open Std Std.Internal Http.Internal Parsec ByteArray
 
 /--
 Results from a single step of the state machine.

--- a/src/Std/Http/Protocol/H1/Config.lean
+++ b/src/Std/Http/Protocol/H1/Config.lean
@@ -22,8 +22,7 @@ namespace Std.Http.Protocol.H1
 
 set_option linter.all true
 
-open Std Internal Parsec ByteArray
-open Internal
+open Std Std.Internal Parsec ByteArray
 
 /--
 Connection limits and parser bounds configuration.

--- a/src/Std/Http/Protocol/H1/Parser.lean
+++ b/src/Std/Http/Protocol/H1/Parser.lean
@@ -18,7 +18,7 @@ reference used is https://httpwg.org/specs/rfc9112.html.
 
 namespace Std.Http.Protocol.H1
 
-open Std Internal Parsec ByteArray Internal Internal.Char
+open Std Std.Internal Parsec ByteArray Internal.Char
 
 set_option linter.all true
 

--- a/src/Std/Tactic/BVDecide/LRAT/Internal/Convert.lean
+++ b/src/Std/Tactic/BVDecide/LRAT/Internal/Convert.lean
@@ -121,7 +121,7 @@ theorem CNF.unsat_of_convertLRAT_unsat (cnf : CNF Nat) :
   intro assignment
   unfold CNF.convertLRAT at h1
   replace h1 := (unsat_of_cons_none_unsat _ h1) assignment
-  apply eq_false_of_ne_true
+  apply Bool.eq_false_of_ne_true
   intro h2
   apply h1
   simp only [Formula.formulaEntails_def, List.all_eq_true, decide_eq_true_eq]

--- a/src/Std/Time/Date/ValidDate.lean
+++ b/src/Std/Time/Date/ValidDate.lean
@@ -14,7 +14,7 @@ public section
 
 namespace Std
 namespace Time
-open Internal
+open Time.Internal
 open Month.Ordinal
 
 set_option linter.all true

--- a/src/Std/Time/DateTime.lean
+++ b/src/Std/Time/DateTime.lean
@@ -14,7 +14,7 @@ public section
 namespace Std
 namespace Time
 
-open Internal
+open Time.Internal
 
 /--
 Represents a date and time with timezone information.

--- a/src/Std/Time/DateTime/PlainDateTime.lean
+++ b/src/Std/Time/DateTime/PlainDateTime.lean
@@ -12,7 +12,7 @@ public section
 
 namespace Std
 namespace Time
-open Internal
+open Time.Internal
 
 set_option linter.all true
 

--- a/src/Std/Time/DateTime/Timestamp.lean
+++ b/src/Std/Time/DateTime/Timestamp.lean
@@ -14,7 +14,7 @@ public section
 
 namespace Std
 namespace Time
-open Internal
+open Time.Internal
 
 set_option linter.all true
 

--- a/src/Std/Time/Duration.lean
+++ b/src/Std/Time/Duration.lean
@@ -14,7 +14,7 @@ public section
 
 namespace Std
 namespace Time
-open Internal
+open Time.Internal
 
 set_option linter.all true
 

--- a/src/Std/Time/Zoned/RecurringRule.lean
+++ b/src/Std/Time/Zoned/RecurringRule.lean
@@ -19,7 +19,7 @@ Types for recurring DST transition rules, used by `ZoneRules` and produced by PO
 public section
 
 namespace Std.Time.TimeZone
-open Internal
+open Time.Internal
 
 /--
 Specifies how a DST transition date is expressed.

--- a/src/Std/Time/Zoned/ZoneRules.lean
+++ b/src/Std/Time/Zoned/ZoneRules.lean
@@ -16,7 +16,7 @@ public section
 namespace Std
 namespace Time
 namespace TimeZone
-open Internal
+open Time.Internal
 
 set_option linter.all true
 


### PR DESCRIPTION
This PR moves `eq_false_of_ne_true` into the `Bool` namespace to be consistent with all other `Bool` functions, and moves `Bool.and'` (a `grind` helper function) to `Internal.Bool.and'`.