### PR TITLE
fix: overwrite of known size after `Builder.stream` generator execution

### DIFF
--- a/src/Std/Http/Data/Body/Stream.lean
+++ b/src/Std/Http/Data/Body/Stream.lean
@@ -664,12 +664,15 @@ error so consumers observe the failure instead of a clean end-of-stream.
 -/
 def stream (gen : Stream → Async Unit) : Async Stream := do
   let s ← mkStream
+  s.setKnownSize (some .chunked)
+
   background <| do
     try
       gen s
       s.close
     catch err =>
       s.closeWithError err
+
   return s
 
 /--
@@ -737,7 +740,6 @@ def stream
     (gen : Body.Stream → Async Unit) :
     Async (Request Body.Stream) := do
   let s ← Body.stream gen
-  s.setKnownSize (some .chunked)
 
   return Request.Builder.body builder s
 
@@ -754,7 +756,6 @@ def stream
     (gen : Body.Stream → Async Unit) :
     Async (Response Body.Stream) := do
   let s ← Body.stream gen
-  s.setKnownSize (some .chunked)
 
   return Response.Builder.body builder s
 

--- a/tests/elab/async_http_dispatch.lean
+++ b/tests/elab/async_http_dispatch.lean
@@ -178,6 +178,36 @@ open Std Http Internal Test
       assertContains r "response0" *>
       assertContains r "response1")
 
+  check "Response.stream defaults to chunked"
+    (raw := mkGetClose "/stream-builder-default")
+    (handler := fun _ => do
+      let res ← Response.ok.stream fun s => do
+        s.send <| Chunk.ofByteArray "hello".toUTF8
+        s.send <| Chunk.ofByteArray "world".toUTF8
+      return (res : Response Body.Any))
+    (expect := fun r =>
+      assertStatus r "HTTP/1.1 200" *>
+      assertContains r "Transfer-Encoding: chunked" *>
+      assertContains r "hello" *>
+      assertContains r "world")
+
+  check "setKnownSize inside Response.stream overrides the chunked default"
+    (raw := mkGetClose "/stream-builder-sized")
+    (handler := fun _ => do
+      let ready : Std.Channel Unit ← Std.Channel.new
+      let res ← Response.ok.stream fun s => do
+        s.setKnownSize (some (.fixed 10))
+        let _ ← ready.send ()
+        s.send <| Chunk.ofByteArray "abcde".toUTF8
+        s.send <| Chunk.ofByteArray "fghij".toUTF8
+      let _ ← Selectable.one #[.case ready.recvSelector pure]
+      return (res : Response Body.Any))
+    (expect := fun r =>
+      assertStatus r "HTTP/1.1 200" *>
+      assertContains r "Content-Length: 10" *>
+      assertAbsent r "Transfer-Encoding: chunked" *>
+      assertContains r "abcdefghij")
+
   check "fixed-length overflow: output stops at announced length"
     (raw := mkGetClose "/overflow")
     (handler := fun _ => do


### PR DESCRIPTION
This PR fixes a possible time-sensitive overwrite of the known size by the `Builder.stream` functions.