### PR TITLE
chore: ci: no `continue-on-error` for "Upload Lake Cache"

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -256,7 +256,6 @@ jobs:
           LAKE_CACHE_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ENDPOINT }}/a1
           LAKE_CACHE_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_ENDPOINT }}/r1
         timeout-minutes: 20 # prevent excessive hanging from network issues
-        continue-on-error: true
       - name: Verify Lake Cache
         if: steps.upload-lake-cache.outcome == 'success'
         run: |


### PR DESCRIPTION
This PR makes errors in the "Upload Lake Cache"  build step fail the job. An analysis of 100 recent master commits showed that this job is stable and never errored, so it should now be reasonable to gate builds on.