### PR TITLE
feat: add HTTP client foundation and configuration

### DIFF
--- a/src/Std/Http.lean
+++ b/src/Std/Http.lean
@@ -8,5 +8,188 @@ module
 prelude
 public import Std.Http.Server
 public import Std.Http.Client
+public import Std.Http.Test.Helpers
 
 public section
+
+/-!
+# HTTP Library
+
+A low-level HTTP/1.1 server implementation for Lean. This library provides a pure,
+sans-I/O protocol implementation that can be used with the `Async` library or with
+custom connection handlers.
+
+## Overview
+
+This module provides a complete HTTP/1.1 server implementation with support for:
+
+- Request/response handling with directional streaming bodies
+- Keep-alive connections
+- Chunked transfer encoding
+- Header validation and management
+- Configurable timeouts and limits
+
+**Sans I/O Architecture**: The core protocol logic doesn't perform any actual I/O itself -
+it just defines how data should be processed. This separation allows the protocol implementation
+to remain pure and testable, while different transports (TCP sockets, mock clients) handle
+the actual reading and writing of bytes.
+
+## Quick Start
+
+The main entry point is `Server.serve`, which starts an HTTP/1.1 server. Implement the
+`Server.Handler` type class to define how the server handles requests, errors, and
+`Expect: 100-continue` headers:
+
+```lean
+import Std.Http
+
+open Std Async
+open Std Http Server
+
+structure MyHandler
+
+instance : Handler MyHandler where
+  onRequest _ req := do
+    Response.ok |>.text "Hello, World!"
+
+def main : IO Unit := Async.block do
+  let addr : Net.SocketAddress := .v4 ⟨.ofParts 127 0 0 1, 8080⟩
+  let server ← Server.serve addr MyHandler.mk
+  server.waitShutdown
+```
+
+## Working with Requests
+
+Incoming requests are represented by `Request Body.Stream`, which bundles the request
+line, parsed headers, and a lazily-consumed body. Headers are available immediately,
+while the body can be streamed or collected on demand, allowing handlers to process both
+small and large payloads efficiently.
+
+### Reading Headers
+
+```lean
+def handler (req : Request Body.Stream) : ContextAsync (Response Body.Stream) := do
+  -- Access request method and URI
+  let method := req.head.method      -- Method.get, Method.post, etc.
+  let uri := req.head.uri            -- RequestTarget
+
+  -- Read a specific header
+  if let some contentType := req.head.headers.get? (.mk "content-type") then
+    IO.println s!"Content-Type: {contentType}"
+
+  Response.ok |>.text "OK"
+```
+
+### URI Query Semantics
+
+`RequestTarget.query` is parsed using form-style key/value conventions (`k=v&...`), and `+` is decoded as a
+space in query components. If you need RFC 3986 opaque query handling, use the raw request target string
+(`toString req.head.uri`) and parse it with custom logic.
+
+### Reading the Request Body
+
+The request body is exposed as `Body.Stream`, which can be consumed incrementally or
+collected into memory. The `readAll` method reads the entire body, with an optional size
+limit to protect against unbounded payloads.
+
+```lean
+def handler (req : Request Body.Stream) : ContextAsync (Response Body.Stream) := do
+  -- Collect entire body as a String
+  let bodyStr : String ← req.body.readAll
+
+  -- Or with a maximum size limit
+  let bodyStr : String ← req.body.readAll (maximumSize := some 1024)
+
+  Response.ok |>.text s!"Received: {bodyStr}"
+```
+
+## Building Responses
+
+Responses are constructed using a builder API that starts from a status code and adds
+headers and a body. Common helpers exist for text, HTML, JSON, and binary responses, while
+still allowing full control over status codes and header values.
+
+Response builders produce `Async (Response Body.Stream)`.
+
+```lean
+-- Text response
+Response.ok |>.text "Hello!"
+
+-- HTML response
+Response.ok |>.html "<h1>Hello!</h1>"
+
+-- JSON response
+Response.ok |>.json "{\"key\": \"value\"}"
+
+-- Binary response
+Response.ok |>.bytes someByteArray
+
+-- Custom status
+Response.new |>.status .created |>.text "Resource created"
+
+-- With custom headers
+Response.ok
+  |>.header! "X-Custom-Header" "value"
+  |>.header! "Cache-Control" "no-cache"
+  |>.text "Response with headers"
+```
+
+### Streaming Responses
+
+For large responses or server-sent events, use streaming:
+
+```lean
+def handler (req : Request Body.Stream) : ContextAsync (Response Body.Stream) := do
+  Response.ok
+    |>.header! "Content-Type" "text/plain"
+    |>.stream fun stream => do
+      for i in [0:10] do
+        stream.send { data := s!"chunk {i}\n".toUTF8 }
+        Async.sleep 1000
+      stream.close
+```
+
+## Server Configuration
+
+Configure server behavior with `Config`:
+
+```lean
+def config : Config := {
+  maxRequests := 10000000,
+  lingeringTimeout := 5000,
+}
+
+let server ← Server.serve addr MyHandler.mk config
+```
+
+## Handler Type Class
+
+Implement `Server.Handler` to define how the server processes events. The class has three
+methods, all with default implementations:
+
+- `onRequest` — called for each incoming request; returns a response inside `ContextAsync`
+- `onFailure` — called when an error occurs while processing a request
+- `onContinue` — called when a request includes an `Expect: 100-continue` header; return
+  `true` to accept the body or `false` to reject it
+
+```lean
+structure MyHandler where
+  greeting : String
+
+instance : Handler MyHandler where
+  onRequest self req := do
+    Response.ok |>.text self.greeting
+
+  onFailure self err := do
+    IO.eprintln s!"Error: {err}"
+```
+
+The handler methods operate in the following monads:
+
+- `onRequest` uses `ContextAsync` — an asynchronous monad (`ReaderT CancellationContext Async`) that provides:
+  - Full access to `Async` operations (spawning tasks, sleeping, concurrent I/O)
+  - A `CancellationContext` tied to the client connection — when the client disconnects, the
+    context is cancelled, allowing your handler to detect this and stop work early
+- `onFailure` uses `Async`
+- `onContinue` uses `Async`
+-/

--- a/src/Std/Http/Client.lean
+++ b/src/Std/Http/Client.lean
@@ -6,7 +6,12 @@ Authors: Sofia Rodrigues
 module
 
 prelude
-public import Std.Http.Server
-public import Std.Http.Client
+public import Std.Http.Client.Config
 
 public section
+
+namespace Std.Http
+
+set_option linter.all true
+
+end Std.Http

--- a/src/Std/Http/Client.lean
+++ b/src/Std/Http/Client.lean
@@ -6,7 +6,11 @@ Authors: Sofia Rodrigues
 module
 
 prelude
+public import Std.Http.Client.Authenticator
 public import Std.Http.Client.Config
+public import Std.Http.Client.CookieHandler
+public import Std.Http.Client.Error
+public import Std.Http.Client.Proxy
 
 public section
 

--- a/src/Std/Http/Client/Authenticator.lean
+++ b/src/Std/Http/Client/Authenticator.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sofia Rodrigues
+-/
+module
+
+prelude
+public import Std.Async
+public import Std.Http.Data
+
+public section
+
+/-!
+# Authentication
+
+This module defines `Challenge`, the `401`/`407` challenge a peer issues, and `Authenticator`, the
+policy that answers it with credentials.
+
+Reference: https://www.rfc-editor.org/rfc/rfc9110.html#section-11
+-/
+
+namespace Std.Http.Client
+
+open Std.Async
+
+set_option linter.all true
+
+/--
+Whether an authentication challenge came from the origin server or from a proxy.
+-/
+inductive Challenge.Kind where
+
+  /--
+  A `401 Unauthorized` from the origin server, answered in `Authorization`.
+  -/
+  | server
+
+  /--
+  A `407 Proxy Authentication Required` from a proxy, answered in `Proxy-Authorization`.
+  -/
+  | proxy
+deriving Inhabited, Repr, BEq
+
+/--
+An authentication challenge an `Authenticator` is asked to answer.
+-/
+structure Challenge where
+
+  /--
+  Whether the origin server or a proxy issued the challenge.
+  -/
+  kind : Challenge.Kind
+
+  /--
+  The origin the challenged request was sent to.
+  -/
+  origin : URI.Origin
+
+  /--
+  The request target that was challenged.
+  -/
+  target : RequestTarget
+
+  /--
+  Headers of the challenging response. The challenge itself is carried by `challengeHeader`, which
+  may appear more than once when the peer offers a choice of schemes.
+  -/
+  headers : Headers
+deriving Repr
+
+namespace Challenge
+
+/--
+The response header carrying this challenge.
+-/
+def challengeHeader : Challenge → Header.Name
+  | { kind := .server, .. } => .wwwAuthenticate
+  | { kind := .proxy, .. } => .proxyAuthenticate
+
+/--
+The request header an answer to this challenge is sent in.
+-/
+def credentialHeader : Challenge → Header.Name
+  | { kind := .server, .. } => .authorization
+  | { kind := .proxy, .. } => .proxyAuthorization
+
+/--
+The challenges offered by the peer, in the order they were received.
+-/
+def offered (challenge : Challenge) : Array Header.Value :=
+  challenge.headers.getAll? challenge.challengeHeader
+  |>.getD #[]
+
+end Challenge
+
+/--
+Supplies credentials in response to a `401` or `407`. The client retries the request once with the
+returned value in `Challenge.credentialHeader`; returning `none` declines the challenge and reports
+the response as-is.
+
+The result is the full credential field value (`"Basic dXNlcjpwdw=="`, `"Bearer …"`, a `Digest`
+response, …), so an authenticator is free to implement any scheme.
+-/
+structure Authenticator where
+
+  /--
+  The credentials answering `challenge`, or `none` to decline it.
+  -/
+  authenticate : Challenge → Async (Option Header.Value)
+
+namespace Authenticator
+
+/--
+Answers every challenge with the same credential.
+-/
+def const (credential : Header.Value) : Authenticator where
+  authenticate _ := pure (some credential)
+
+/--
+Declines the challenges rejected by `accepts`, deferring to `authenticator` for the rest. Use it to
+scope credentials to one origin or to server challenges only.
+-/
+def restrict (authenticator : Authenticator) (accepts : Challenge → Bool) : Authenticator where
+  authenticate challenge :=
+    if accepts challenge then authenticator.authenticate challenge else pure none
+
+end Authenticator
+
+end Std.Http.Client

--- a/src/Std/Http/Client/Config.lean
+++ b/src/Std/Http/Client/Config.lean
@@ -8,15 +8,19 @@ module
 prelude
 public import Std.Time
 public import Std.Http.Protocol.H1
+public import Std.Http.Client.Authenticator
+public import Std.Http.Client.CookieHandler
+public import Std.Http.Client.Proxy
 
 public section
 
 /-!
 # Config
 
-This module exposes the `Config` structure describing timeouts, connection,
-and header configurations for an HTTP client, the typed `Error` reported by
-client operations, and per-request `RequestOverrides`.
+This module exposes the `Config` structure describing the timeouts, connection limits, and header
+limits of an HTTP client, together with the per-request `RequestOverrides` that shadow it. The
+policy hooks a `Config` points at live in their own modules: `Authenticator`, `CookieHandler`, and
+`ProxySelector`.
 -/
 
 namespace Std.Http.Client
@@ -27,88 +31,6 @@ set_option linter.all true
 A strictly positive duration in milliseconds, used for client timeouts.
 -/
 abbrev Timeout := { x : Time.Millisecond.Offset // 0 < x }
-
-/--
-An error produced by the HTTP client. Connection-level failures (`connect`, `closed`, and a peer
-that vanished mid-exchange) are eligible for automatic retry of idempotent requests; all other cases
-are reported to the caller as-is.
--/
-inductive Error where
-
-  /--
-  DNS resolution or transport connection establishment failed.
-  -/
-  | connect (message : String)
-
-  /--
-  The request exceeded its timeout.
-  -/
-  | timeout
-
-  /--
-  The connection was closed or shut down before the exchange completed.
-  -/
-  | closed (message : String)
-
-  /--
-  The peer violated the HTTP protocol.
-  -/
-  | protocol (error : Protocol.H1.Error)
-
-  /--
-  The response body exceeded `Config.maxResponseBodySize`.
-  -/
-  | bodyLimitExceeded
-
-  /--
-  The request could not be constructed (for example, the URL named no host).
-  -/
-  | invalidRequest (message : String)
-
-  /--
-  Any other I/O failure, e.g. raised by a middleware or a user-supplied body.
-  -/
-  | io (error : IO.Error)
-deriving Inhabited
-
-namespace Error
-
-instance : ToString Error where
-  toString
-    | .connect msg => "connect: " ++ msg
-    | .timeout => "request timeout"
-    | .closed msg => msg
-    | .protocol e => toString e
-    | .bodyLimitExceeded => "response body exceeds maximum allowed size"
-    | .invalidRequest msg => msg
-    | .io e => toString e
-
-/--
-Renders this error as an `IO.Error` for callers working in `Async`.
--/
-def toIOError (e : Error) : IO.Error :=
-  .userError (toString e)
-
-/--
-Returns the success value, throwing the typed `Error` as an `IO.Error` otherwise. The `send` variant
-at each client layer uses this to unwrap the result of the corresponding `trySend`.
--/
-def throwOrPure {α : Type} : Except Error α → Std.Async.Async α
-  | .ok a => pure a
-  | .error e => throw e.toIOError
-
-/--
-`true` for connection-level failures that are safe to retry on a fresh connection (the request
-provably produced no application-level effect, or the method is idempotent).
-`Protocol.H1.Error.connectionClosed` is retryable: it is the stale keep-alive race, where the
-server closed a pooled connection just as it was reused.
--/
-def isRetryable : Error → Bool
-  | .connect _ | .closed _ => true
-  | .protocol e => e == Protocol.H1.Error.connectionClosed
-  | .timeout | .bodyLimitExceeded | .invalidRequest _ | .io _ => false
-
-end Error
 
 /--
 Per-request overrides for settings that otherwise come from the client-wide `Config`.
@@ -203,22 +125,23 @@ structure Config where
   maxRedirects : Nat := 10
 
   /--
-  When `true`, automatic redirect following is restricted to requests whose
-  original method is safe (RFC 9110 §9.2.1: GET, HEAD, OPTIONS, TRACE).
-  Redirects for unsafe methods (POST, PUT, DELETE, PATCH, …) are not followed
-  automatically — the response is returned as-is for the caller to handle.
-
-  Defaults to `false` so that the standard 301/302 POST→GET downgrade and
-  307/308 method-preserving redirects work out of the box.
+  Chooses the proxy for each origin. When a request is routed through an HTTP proxy its URI is
+  rewritten to absolute-form (`GET http://host/path HTTP/1.1`).
+  Defaults to connecting every origin directly.
   -/
-  onlySafeRedirects : Bool := false
+  proxySelector : ProxySelector := .direct
 
   /--
-  Optional HTTP proxy address as `(host, port)`.
-  When set, all TCP connections are routed through this proxy and
-  request URIs are rewritten to absolute-form (`GET http://host/path HTTP/1.1`).
+  Supplies credentials when a server answers `401` or a proxy answers `407`.
+  `none` (default) reports those responses to the caller unanswered.
   -/
-  proxy : Option (String × UInt16) := none
+  authenticator : Option Authenticator := none
+
+  /--
+  Stores and replays cookies across requests.
+  `none` (default) neither sends nor retains cookies.
+  -/
+  cookieHandler : Option CookieHandler := none
 
   /--
   Maximum number of bytes allowed in a single response body.

--- a/src/Std/Http/Client/Config.lean
+++ b/src/Std/Http/Client/Config.lean
@@ -119,7 +119,7 @@ structure RequestOverrides where
   /--
   Overrides `Config.requestTimeout` for this request.
   -/
-  timeout : Option Timeout := none
+  requestTimeout : Option Timeout := none
 
   /--
   Overrides `Config.maxRedirects` for this request. `some 0` disables redirect following.
@@ -155,7 +155,7 @@ structure Config where
   This is a per-read idle timeout, not a wall-clock limit on the total request duration; use
   `requestTimeout` to bound the full exchange.
   -/
-  readTimeout : Time.Millisecond.Offset := 30000
+  readTimeout : Timeout := ⟨30000, by decide⟩
 
   /--
   How long an idle connection may sit in the pool before it is closed. Only relevant when

--- a/src/Std/Http/Client/Config.lean
+++ b/src/Std/Http/Client/Config.lean
@@ -1,0 +1,250 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sofia Rodrigues
+-/
+module
+
+prelude
+public import Std.Time
+public import Std.Http.Protocol.H1
+
+public section
+
+/-!
+# Config
+
+This module exposes the `Config` structure describing timeouts, connection,
+and header configurations for an HTTP client, the typed `Error` reported by
+client operations, and per-request `RequestOverrides`.
+-/
+
+namespace Std.Http.Client
+
+set_option linter.all true
+
+/--
+A strictly positive duration in milliseconds, used for client timeouts.
+-/
+abbrev Timeout := { x : Time.Millisecond.Offset // 0 < x }
+
+/--
+An error produced by the HTTP client. Connection-level failures (`connect`, `closed`, and a peer
+that vanished mid-exchange) are eligible for automatic retry of idempotent requests; all other cases
+are reported to the caller as-is.
+-/
+inductive Error where
+
+  /--
+  DNS resolution or transport connection establishment failed.
+  -/
+  | connect (message : String)
+
+  /--
+  The request exceeded its timeout.
+  -/
+  | timeout
+
+  /--
+  The connection was closed or shut down before the exchange completed.
+  -/
+  | closed (message : String)
+
+  /--
+  The peer violated the HTTP protocol.
+  -/
+  | protocol (error : Protocol.H1.Error)
+
+  /--
+  The response body exceeded `Config.maxResponseBodySize`.
+  -/
+  | bodyLimitExceeded
+
+  /--
+  The request could not be constructed (for example, the URL named no host).
+  -/
+  | invalidRequest (message : String)
+
+  /--
+  Any other I/O failure, e.g. raised by a middleware or a user-supplied body.
+  -/
+  | io (error : IO.Error)
+deriving Inhabited
+
+namespace Error
+
+instance : ToString Error where
+  toString
+    | .connect msg => "connect: " ++ msg
+    | .timeout => "request timeout"
+    | .closed msg => msg
+    | .protocol e => toString e
+    | .bodyLimitExceeded => "response body exceeds maximum allowed size"
+    | .invalidRequest msg => msg
+    | .io e => toString e
+
+/--
+Renders this error as an `IO.Error` for callers working in `Async`.
+-/
+def toIOError (e : Error) : IO.Error :=
+  .userError (toString e)
+
+/--
+Returns the success value, throwing the typed `Error` as an `IO.Error` otherwise. The `send` variant
+at each client layer uses this to unwrap the result of the corresponding `trySend`.
+-/
+def throwOrPure {α : Type} : Except Error α → Std.Async.Async α
+  | .ok a => pure a
+  | .error e => throw e.toIOError
+
+/--
+`true` for connection-level failures that are safe to retry on a fresh connection (the request
+provably produced no application-level effect, or the method is idempotent).
+`Protocol.H1.Error.connectionClosed` is retryable: it is the stale keep-alive race, where the
+server closed a pooled connection just as it was reused.
+-/
+def isRetryable : Error → Bool
+  | .connect _ | .closed _ => true
+  | .protocol e => e == Protocol.H1.Error.connectionClosed
+  | .timeout | .bodyLimitExceeded | .invalidRequest _ | .io _ => false
+
+end Error
+
+/--
+Per-request overrides for settings that otherwise come from the client-wide `Config`.
+A `none` field defers to the configured value.
+-/
+structure RequestOverrides where
+
+  /--
+  Overrides `Config.requestTimeout` for this request.
+  -/
+  timeout : Option Timeout := none
+
+  /--
+  Overrides `Config.maxRedirects` for this request. `some 0` disables redirect following.
+  -/
+  maxRedirects : Option Nat := none
+
+/--
+Client connection configuration.
+-/
+structure Config where
+  /--
+  Maximum number of requests per connection (for keep-alive).
+  -/
+  maxRequestsPerConnection : Nat := 1000
+
+  /--
+  Maximum number of headers allowed per response.
+  -/
+  maxResponseHeaders : Nat := 200
+
+  /--
+  Maximum size of a single header name in bytes.
+  -/
+  maxHeaderNameSize : Nat := 256
+
+  /--
+  Maximum size of a single header value in bytes.
+  -/
+  maxHeaderValueSize : Nat := 16384
+
+  /--
+  Maximum time to wait for the next chunk of data on an open connection before declaring it stale.
+  This is a per-read idle timeout, not a wall-clock limit on the total request duration; use
+  `requestTimeout` to bound the full exchange.
+  -/
+  readTimeout : Time.Millisecond.Offset := 30000
+
+  /--
+  How long an idle connection may sit in the pool before it is closed. Only relevant when
+  `enableKeepAlive` is `true`. This is distinct from `readTimeout`: `readTimeout` fires mid-read;
+  `keepAliveTimeout` fires while the connection is parked waiting for the next request.
+  -/
+  keepAliveTimeout : Timeout := ⟨4000, by decide⟩
+
+  /--
+  Timeout for the request lifecycle (send + receive) per connection.
+  DNS resolution and TCP connect are not covered by this timeout; see `connectTimeout`.
+  -/
+  requestTimeout : Timeout := ⟨120000, by decide⟩
+
+  /--
+  Timeout for establishing a new connection, covering DNS resolution and the transport
+  connect. Complements `requestTimeout`, which starts only once a connection exists.
+  -/
+  connectTimeout : Timeout := ⟨30000, by decide⟩
+
+  /--
+  Whether to enable keep-alive connections.
+  -/
+  enableKeepAlive : Bool := true
+
+  /--
+  Maximum number of bytes to receive in a single read call.
+  -/
+  maxRecvChunkSize : Nat := 16384
+
+  /--
+  Default buffer size for request payloads.
+  -/
+  defaultRequestBufferSize : Nat := 16384
+
+  /--
+  The user-agent string to send by default.
+  -/
+  userAgent : Option Header.Value := some (.mk "lean-http/1.1")
+
+  /--
+  Maximum number of redirects to follow automatically.
+  Set to `0` to disable automatic redirect following.
+  -/
+  maxRedirects : Nat := 10
+
+  /--
+  When `true`, automatic redirect following is restricted to requests whose
+  original method is safe (RFC 9110 §9.2.1: GET, HEAD, OPTIONS, TRACE).
+  Redirects for unsafe methods (POST, PUT, DELETE, PATCH, …) are not followed
+  automatically — the response is returned as-is for the caller to handle.
+
+  Defaults to `false` so that the standard 301/302 POST→GET downgrade and
+  307/308 method-preserving redirects work out of the box.
+  -/
+  onlySafeRedirects : Bool := false
+
+  /--
+  Optional HTTP proxy address as `(host, port)`.
+  When set, all TCP connections are routed through this proxy and
+  request URIs are rewritten to absolute-form (`GET http://host/path HTTP/1.1`).
+  -/
+  proxy : Option (String × UInt16) := none
+
+  /--
+  Maximum number of bytes allowed in a single response body.
+  When `some n`, reading more than `n` bytes from the body resolves the current
+  request with an error and closes the connection.
+  `none` (default) imposes no limit.
+  -/
+  maxResponseBodySize : Option Nat := none
+
+  /--
+  Maximum number of bytes drained from an intermediate redirect response body
+  before the redirected request is sent.
+  -/
+  redirectBodyDrainLimit : Nat := 1024 * 1024
+
+namespace Config
+
+/--
+Converts to HTTP/1.1 protocol configuration.
+-/
+def toH1Config (config : Config) : Std.Http.Protocol.H1.Config where
+  maxMessages := config.maxRequestsPerConnection
+  maxHeaders := config.maxResponseHeaders
+  maxHeaderNameLength := config.maxHeaderNameSize
+  maxHeaderValueLength := config.maxHeaderValueSize
+  enableKeepAlive := config.enableKeepAlive
+  agentName := config.userAgent
+
+end Std.Http.Client.Config

--- a/src/Std/Http/Client/Config.lean
+++ b/src/Std/Http/Client/Config.lean
@@ -237,6 +237,16 @@ structure Config where
 namespace Config
 
 /--
+Total header-block allowance implied by the client's own limits: `maxResponseHeaders` field lines,
+each as long as `maxHeaderNameSize` and `maxHeaderValueSize` permit, plus the four bytes `": "` and
+`CRLF` contribute per line. Deriving it keeps those three settings jointly reachable — the machine's
+own aggregate default is smaller than they describe, so a response well inside all of them would
+otherwise be rejected.
+-/
+def headerBlockSize (config : Config) : Nat :=
+  config.maxResponseHeaders * (config.maxHeaderNameSize + config.maxHeaderValueSize + 4)
+
+/--
 Converts to HTTP/1.1 protocol configuration.
 -/
 def toH1Config (config : Config) : Std.Http.Protocol.H1.Config where
@@ -244,7 +254,11 @@ def toH1Config (config : Config) : Std.Http.Protocol.H1.Config where
   maxHeaders := config.maxResponseHeaders
   maxHeaderNameLength := config.maxHeaderNameSize
   maxHeaderValueLength := config.maxHeaderValueSize
+  maxHeaderBytes := config.headerBlockSize
   enableKeepAlive := config.enableKeepAlive
   agentName := config.userAgent
+  maxBodySize := 2 ^ 64
+  maxChunkSize := 2 ^ 64
+  maxBufferedBodyBytes := some (64 * 1024 * 1024)
 
 end Std.Http.Client.Config

--- a/src/Std/Http/Client/CookieHandler.lean
+++ b/src/Std/Http/Client/CookieHandler.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sofia Rodrigues
+-/
+module
+
+prelude
+public import Std.Async
+public import Std.Http.Data
+
+public section
+
+/-!
+# Cookie Handling
+
+This module defines `CookieHandler`, the policy a client consults to attach cookies to outgoing
+requests and to retain the ones responses set.
+
+Reference: https://www.rfc-editor.org/rfc/rfc6265.html
+-/
+
+namespace Std.Http.Client
+
+open Std.Async
+
+set_option linter.all true
+
+/--
+Stores cookies received from responses and supplies them back on later requests. The client calls
+`store` on every response it receives and `load` on every request it sends, including each hop of a
+redirect chain, so a handler sees cross-origin hops as separate origins.
+
+Cookies are exchanged as raw header values rather than a parsed cookie type: it is the handler that
+decides how `Set-Cookie` attributes are interpreted.
+-/
+structure CookieHandler where
+
+  /--
+  The `Cookie` header values to attach to a request for `origin` and `target`.
+  -/
+  load : URI.Origin → RequestTarget → Async (Array Header.Value)
+
+  /--
+  Records the `Set-Cookie` headers of a response received from `origin` for `target`. The full
+  response header block is passed so that attributes can be interpreted against headers such as
+  `Date`.
+  -/
+  store : URI.Origin → RequestTarget → Headers → Async Unit
+
+end Std.Http.Client

--- a/src/Std/Http/Client/Error.lean
+++ b/src/Std/Http/Client/Error.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sofia Rodrigues
+-/
+module
+
+prelude
+public import Std.Async
+public import Std.Http.Protocol.H1.Error
+
+public section
+
+/-!
+# Client Errors
+
+This module defines `Error`, the typed failure reported by every HTTP client operation, along with
+the retry classification the client uses to decide whether a failed exchange may be replayed on a
+fresh connection.
+-/
+
+namespace Std.Http.Client
+
+open Std.Async
+
+set_option linter.all true
+
+/--
+An error produced by the HTTP client. Connection-level failures (`connect`, `closed`, and a peer
+that vanished mid-exchange) are eligible for automatic retry of idempotent requests; all other cases
+are reported to the caller as-is.
+-/
+inductive Error where
+
+  /--
+  DNS resolution or transport connection establishment failed.
+  -/
+  | connect (message : String)
+
+  /--
+  The request exceeded its timeout.
+  -/
+  | timeout
+
+  /--
+  The connection was closed or shut down before the exchange completed.
+  -/
+  | closed (message : String)
+
+  /--
+  The peer violated the HTTP protocol.
+  -/
+  | protocol (error : Protocol.H1.Error)
+
+  /--
+  The response body exceeded `Config.maxResponseBodySize`.
+  -/
+  | bodyLimitExceeded
+
+  /--
+  The request could not be constructed (for example, the URL named no host).
+  -/
+  | invalidRequest (message : String)
+
+  /--
+  Any other I/O failure, e.g. raised by a middleware or a user-supplied body.
+  -/
+  | io (error : IO.Error)
+deriving Inhabited
+
+namespace Error
+
+instance : ToString Error where
+  toString
+    | .connect msg => "connect: " ++ msg
+    | .timeout => "request timeout"
+    | .closed msg => msg
+    | .protocol e => toString e
+    | .bodyLimitExceeded => "response body exceeds maximum allowed size"
+    | .invalidRequest msg => msg
+    | .io e => toString e
+
+/--
+Renders this error as an `IO.Error` for callers working in `Async`.
+-/
+def toIOError (e : Error) : IO.Error :=
+  .userError (toString e)
+
+/--
+Returns the success value, throwing the typed `Error` as an `IO.Error` otherwise. The `send` variant
+at each client layer uses this to unwrap the result of the corresponding `trySend`.
+-/
+def throwOrPure {α : Type} : Except Error α → Async α
+  | .ok a => pure a
+  | .error e => throw e.toIOError
+
+/--
+`true` for connection-level failures that are safe to retry on a fresh connection (the request
+provably produced no application-level effect, or the method is idempotent).
+`Protocol.H1.Error.connectionClosed` is retryable: it is the stale keep-alive race, where the
+server closed a pooled connection just as it was reused.
+-/
+def isRetryable : Error → Bool
+  | .connect _ | .closed _ => true
+  | .protocol e => e == Protocol.H1.Error.connectionClosed
+  | .timeout | .bodyLimitExceeded | .invalidRequest _ | .io _ => false
+
+end Error
+
+end Std.Http.Client

--- a/src/Std/Http/Client/Proxy.lean
+++ b/src/Std/Http/Client/Proxy.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sofia Rodrigues
+-/
+module
+
+prelude
+public import Std.Http.Data
+
+public section
+
+/-!
+# Proxy Selection
+
+This module defines `Proxy`, the transport endpoint a request is dispatched to, and `ProxySelector`,
+the policy that picks one per origin.
+-/
+
+namespace Std.Http.Client
+
+set_option linter.all true
+
+/--
+Where a request's transport connection is established.
+-/
+inductive Proxy where
+
+  /--
+  Connect straight to the request's own origin.
+  -/
+  | direct
+
+  /--
+  Connect to an HTTP proxy at `host:port` instead of the origin.
+  -/
+  | http (host : String) (port : UInt16)
+deriving Inhabited, Repr, BEq
+
+/--
+Chooses the proxy to use for each origin the client connects to. Selection is a pure function of the
+origin, so a selector that consults the environment or a configuration file should read it once
+while being built.
+-/
+structure ProxySelector where
+
+  /--
+  The proxy to route connections to `origin` through.
+  -/
+  select : URI.Origin → Proxy
+
+namespace ProxySelector
+
+/--
+Connects every origin directly.
+-/
+def direct : ProxySelector where
+  select _ := .direct
+
+instance : Inhabited ProxySelector := ⟨direct⟩
+
+/--
+Routes every origin through the HTTP proxy at `host:port`.
+-/
+def of (host : String) (port : UInt16) : ProxySelector where
+  select _ := .http host port
+
+/--
+Connects directly to the origins satisfying `bypass`, deferring to `selector` for the rest.
+-/
+def bypassing (selector : ProxySelector) (bypass : URI.Origin → Bool) : ProxySelector where
+  select origin := if bypass origin then .direct else selector.select origin
+
+end ProxySelector
+
+end Std.Http.Client

--- a/src/Std/Http/Data/Body/Stream.lean
+++ b/src/Std/Http/Data/Body/Stream.lean
@@ -760,3 +760,24 @@ def stream
   return Response.Builder.body builder s
 
 end Response.Builder
+
+namespace Response
+open Async
+
+/--
+Reads the entire response body and decodes it as a UTF-8 string.
+When `maximumSize` is given, reading more than that many bytes throws an error.
+-/
+def text (response : Response Body.Stream)
+    (maximumSize : Option UInt64 := none) : Async String :=
+  response.body.readAll (maximumSize := maximumSize)
+
+/--
+Reads the entire response body as raw bytes.
+When `maximumSize` is given, reading more than that many bytes throws an error.
+-/
+def bytes (response : Response Body.Stream)
+    (maximumSize : Option UInt64 := none) : Async ByteArray :=
+  response.body.readAll (maximumSize := maximumSize)
+
+end Response

--- a/src/Std/Http/Data/Body/Stream.lean
+++ b/src/Std/Http/Data/Body/Stream.lean
@@ -770,7 +770,7 @@ When `maximumSize` is given, reading more than that many bytes throws an error.
 -/
 def text (response : Response Body.Stream)
     (maximumSize : Option UInt64 := none) : Async String :=
-  response.body.readAll (maximumSize := maximumSize)
+  response.body.readAll maximumSize
 
 /--
 Reads the entire response body as raw bytes.
@@ -778,6 +778,6 @@ When `maximumSize` is given, reading more than that many bytes throws an error.
 -/
 def bytes (response : Response Body.Stream)
     (maximumSize : Option UInt64 := none) : Async ByteArray :=
-  response.body.readAll (maximumSize := maximumSize)
+  response.body.readAll maximumSize
 
 end Response

--- a/src/Std/Http/Data/Headers/Name.lean
+++ b/src/Std/Http/Data/Headers/Name.lean
@@ -205,6 +205,16 @@ Standard Proxy-Authorization header name
 def proxyAuthorization : Header.Name := .mk "proxy-authorization"
 
 /--
+Standard WWW-Authenticate header name
+-/
+def wwwAuthenticate : Header.Name := .mk "www-authenticate"
+
+/--
+Standard Proxy-Authenticate header name
+-/
+def proxyAuthenticate : Header.Name := .mk "proxy-authenticate"
+
+/--
 Standard Content-Encoding header name
 -/
 def contentEncoding : Header.Name := .mk "content-encoding"

--- a/src/Std/Http/Data/Method.lean
+++ b/src/Std/Http/Data/Method.lean
@@ -355,6 +355,19 @@ Reference: https://httpwg.org/specs/rfc9110.html#safe.methods
 def isSafe (m : Method) : Bool :=
   m == .get || m == .head || m == .options || m == .trace
 
+/--
+Returns `false` for HTTP methods whose semantics do not anticipate request content, i.e. the ones
+RFC 9110 §8.6 tells a user agent not to send a `Content-Length` for when the request carries none.
+For requests the absence of both `Content-Length` and `Transfer-Encoding` already means "no
+content", so the field would carry no information.
+
+A request that does carry content is still framed regardless of its method.
+
+Reference: https://httpwg.org/specs/rfc9110.html#field.content-length
+-/
+def anticipatesContent (m : Method) : Bool :=
+  !(m == .get || m == .head || m == .delete || m == .options || m == .trace || m == .connect)
+
 instance : ToString Method where
   toString
     | .acl => "ACL"

--- a/src/Std/Http/Data/Request.lean
+++ b/src/Std/Http/Data/Request.lean
@@ -187,6 +187,19 @@ def headerOpt (builder : Builder) (key : Header.Name) (value : Option Header.Val
   | none => builder
 
 /--
+Injects a default `Host` header derived from `host` and `port` unless the builder
+already carries a `Host` header. When `port` matches the scheme's default
+(80 for `http`, 443 for `https`) the port is omitted from the header value.
+-/
+def hostDefault (builder : Builder) (scheme : URI.Scheme) (host : URI.Host) (port : UInt16) : Builder :=
+  if builder.line.headers.contains Header.Name.host then
+    builder
+  else
+    match Header.Value.ofString? (URI.Origin.hostHeader { scheme, host, port }) with
+    | some value => builder.header Header.Name.host value
+    | none => builder
+
+/--
 Inserts a typed extension value into the request being built.
 -/
 def extension (builder : Builder) [TypeName α] (data : α) : Builder :=

--- a/src/Std/Http/Data/Response.lean
+++ b/src/Std/Http/Data/Response.lean
@@ -102,6 +102,18 @@ instance : Encode .v11 Head where
     buffer.writeString "\r\n"
 
 /--
+The response's status code.
+-/
+def status {β : Type} (response : Response β) : Status :=
+  response.line.status
+
+/--
+`true` if the response status is a 2xx success code.
+-/
+def isSuccess {β : Type} (response : Response β) : Bool :=
+  response.line.status.isSuccess
+
+/--
 Creates a new HTTP Response builder with default head (status: 200 OK, version: HTTP/1.1).
 -/
 def new : Builder := { }

--- a/src/Std/Http/Data/URI.lean
+++ b/src/Std/Http/Data/URI.lean
@@ -140,6 +140,15 @@ def originTarget (uri : URI) : RequestTarget :=
   .originForm uri.path uri.query
 
 /--
+Splits this URI into the `(scheme, host, port, origin-form target)` tuple a client needs to
+dispatch a request to the referenced origin, or `none` when the URI has no authority (and hence no
+host to connect to). The port falls back to the scheme's default when the authority leaves it
+implicit.
+-/
+def toOriginRequest? (uri : URI) : Option (URI.Scheme × URI.Host × UInt16 × RequestTarget) :=
+  uri.host?.map fun host => (uri.scheme, host, uri.port, uri.originTarget)
+
+/--
 Attempts to parse a `URI` from the given string.
 -/
 @[inline]

--- a/src/Std/Http/Protocol/H1.lean
+++ b/src/Std/Http/Protocol/H1.lean
@@ -446,7 +446,8 @@ metadata) so a stalled consumer cannot accumulate unbounded pending input.
 -/
 @[inline]
 private def maxBufferedInputBytes (config : Config) : Nat :=
-  config.maxBodySize + config.maxHeaderBytes + config.maxStartLineLength + config.maxChunkLineLength
+  config.maxBufferedBodyBytes.getD config.maxBodySize
+    + config.maxHeaderBytes + config.maxStartLineLength + config.maxChunkLineLength
 
 /--
 Accumulates successfully accepted body bytes into the reader accounting.
@@ -768,8 +769,15 @@ private def writeHead (messageHead : Message.Head dir.swap) (machine : Machine d
           |>.erase Header.Name.transferEncoding
       else
         normalizeFramingHeaders headers size
-    | .sending, _ =>
-      normalizeFramingHeaders headers size
+    | .sending, messageHead =>
+      -- RFC 9110 §8.6: a user agent SHOULD NOT send `Content-Length` when the request carries no
+      -- content and the method does not anticipate any. A caller that asked for framing headers
+      -- explicitly still gets them normalized.
+      if size == .fixed 0 ∧ ¬messageHead.method.anticipatesContent
+          ∧ ¬hasFramingHeaders messageHead then
+        headers
+      else
+        normalizeFramingHeaders headers size
 
   let state : Writer.State :=
     match size with
@@ -1239,6 +1247,51 @@ partial def processWrite (machine : Machine dir) : Machine dir :=
     machine
 
 end
+
+/--
+`true` while the writer is producing an outgoing message body, i.e. the head has been flushed and
+the body is neither finished nor abandoned.
+-/
+def isWritingBody (machine : Machine dir) : Bool :=
+  match machine.writer.state with
+  | .writingBodyFixed _ | .writingBodyChunked | .writingBodyClosingFrame => true
+  | _ => false
+
+/--
+`true` when the peer has answered in full and will not read the rest of the outgoing body
+(`Connection: close`, an exhausted keep-alive quota). Pumping the remainder would stall the
+exchange until a timeout, so the caller should `abandonOutgoingBody` instead.
+-/
+def peerWillNotReadBody (machine : Machine dir) : Bool :=
+  !machine.keepAlive && machine.isWritingBody
+
+/--
+`true` when abandoning the outgoing body now would leave the framing the head already announced
+unfulfilled: declared bytes still owed under `Content-Length`, or a chunked body whose terminating
+zero chunk was never written.
+-/
+private def abandoningTruncatesBody (machine : Machine dir) : Bool :=
+  match machine.writer.state with
+  | .writingBodyFixed n => n > 0
+  | .writingBodyChunked | .writingBodyClosingFrame => true
+  | _ => false
+
+/--
+Abandons the current outgoing body after the peer has already provided the
+response that makes sending it unnecessary.
+
+Keep-alive is withdrawn whenever the head already announced framing that the abandoned body does
+not fulfil. The peer is still counting the declared bytes, so the next request written to this
+connection would be read as the body of this one (RFC 9112 §6.3); only closing resynchronizes.
+-/
+def abandonOutgoingBody (machine : Machine dir) : Machine dir :=
+  let truncated := machine.abandoningTruncatesBody
+  let machine := machine.modifyWriter (fun writer =>
+    { writer with
+      userData := .empty
+      userDataBytes := 0
+      userClosedBody := true })
+  completeWriterMessage (if truncated then machine.disableKeepAlive else machine)
 
 /-- Maps a reader failure to an HTTP status code. -/
 private def errorResponseStatus (error : H1.Error) : Status :=

--- a/src/Std/Http/Protocol/H1/Config.lean
+++ b/src/Std/Http/Protocol/H1/Config.lean
@@ -121,6 +121,15 @@ structure Config where
   maxBodySize : Nat := 64 * 1024 * 1024
 
   /--
+  Upper bound on unread body input the reader retains in memory at once, on top of its header and
+  chunk-line allowances. `none` derives the bound from `maxBodySize`, which is what a peer whose
+  body limit is also its memory limit wants. Set it explicitly when `maxBodySize` is deliberately
+  large — an HTTP client streaming an arbitrarily long download, say — but buffering against a slow
+  consumer must still be bounded.
+  -/
+  maxBufferedBodyBytes : Option Nat := none
+
+  /--
   Maximum length of reason phrase (default: 512 bytes).
   -/
   maxReasonPhraseLength : Nat := 512

--- a/src/Std/Http/Protocol/H1/Parser.lean
+++ b/src/Std/Http/Protocol/H1/Parser.lean
@@ -51,12 +51,30 @@ def isOwsByte (c : UInt8) : Bool :=
 -- Parser blocks
 
 /--
+Like `optional (attempt parser)`, except that an `eof` failure is re-raised rather than reported as
+"no item".
+
+Running out of input means the parser has not yet decided whether an item is there. The incremental
+readers turn `eof` into a request for more bytes and retry the parse from the same position, so
+reporting it as the end of the list would let a half-received item be mistaken for the end of one.
+-/
+@[inline]
+def optionalItem {α : Type} (parser : Parser α) : Parser (Option α) := fun it =>
+  match parser it with
+  | .success rem res => .success rem (some res)
+  | .error _ .eof => .error it .eof
+  | .error _ _ => .success it none
+
+/--
 Repeatedly applies `parser` until it returns `none` or the `maxCount` limit is
 exceeded. Returns the collected results as an array.
+
+A `parser` that fails on exhausted input propagates that failure, so an item split across two reads
+is re-parsed once the rest arrives instead of ending the list early.
 -/
 partial def manyItems {α : Type} (parser : Parser (Option α)) (maxCount : Nat) : Parser (Array α) := do
   let rec go (acc : Array α) : Parser (Array α) := do
-    let step ← optional <| attempt do
+    let step ← optionalItem do
       match ← parser with
       | none => fail "end of items"
       | some x => return x
@@ -400,7 +418,7 @@ Parses the size and extensions of a chunk.
 -/
 public def parseChunkSize (limits : H1.Config) : Parser (Nat × Array (Chunk.ExtensionName × Option Chunk.ExtensionValue)) := do
   let size ← hex
-  let ext ← manyItems (optional (attempt (parseChunkExt limits))) limits.maxChunkExtensions
+  let ext ← manyItems (optionalItem (parseChunkExt limits)) limits.maxChunkExtensions
   crlf
   return (size, ext)
 

--- a/src/Std/Http/Protocol/H1/Redirect.lean
+++ b/src/Std/Http/Protocol/H1/Redirect.lean
@@ -340,9 +340,7 @@ Returns `.done` when:
   redirect codes defined by RFC 2616),
 * no `Location` header is present,
 * the `Location` value does not parse as a URI-reference (RFC 9110 §10.2.2),
-* the target resolves to a non-`http(s)` scheme (SSRF guard), or
-* `onlySafeRedirects` is `true` and the original method is not safe
-  (RFC 9110 §9.2.1: GET, HEAD, OPTIONS, TRACE).
+* the target resolves to a non-`http(s)` scheme (SSRF guard).
 
 Returns `.follow plan` otherwise. The caller is expected to drain the redirect response body and,
 when `plan.bodyAction == .replay`, reset the original body before dispatching the rewritten request.
@@ -361,7 +359,6 @@ def decideRedirect
     (current : URI.Origin)
     (request : Request.Head)
     (bodyReplayable : Bool)
-    (onlySafeRedirects : Bool)
     (responseVersion : Version)
     (status : Status)
     (responseHeaders : Headers)
@@ -385,11 +382,6 @@ def decideRedirect
   -- 300 Multiple Choices may name a preferred `Location`, but RFC 9110 §15.4.1 leaves
   -- the choice to the user agent, so we deliberately decline to auto-select one.
   if status == .useProxy || status == .unused || status == .notModified || status == .multipleChoices then
-    return .done
-
-  -- RFC 2616 §10.3: automatic redirection needs to be done with care for methods not known to be
-  -- safe, as defined in Section 9.2.1, since the user might not wish to redirect an unsafe request.
-  if onlySafeRedirects && !request.method.isSafe then
     return .done
 
   let some locationValue := responseHeaders.get? .location

--- a/tests/elab/async_http_client_config.lean
+++ b/tests/elab/async_http_client_config.lean
@@ -1,0 +1,111 @@
+import Std.Http
+
+/-!
+Exercises the client-side policy hooks in `Std.Http.Client.Config`: `ProxySelector`,
+`Authenticator`, and `CookieHandler`. Each `#guard`/`#eval` asserts an observable outcome of a
+selector or handler; a failing assertion throws.
+-/
+
+open Std.Http Std.Http.Client Std.Async
+
+private def hostName (host : String) : URI.Host :=
+  match URI.DomainName.ofString? host with
+  | some name => .name name
+  | none => panic! s!"invalid domain name: {host}"
+
+private def mkOrigin (scheme : String) (host : String) (port : UInt16) : URI.Origin :=
+  { scheme := URI.Scheme.ofString! scheme, host := hostName host, port }
+
+private def example80 : URI.Origin := mkOrigin "http" "example.com" 80
+private def internal80 : URI.Origin := mkOrigin "http" "internal.corp" 80
+private def secure443 : URI.Origin := mkOrigin "https" "example.com" 443
+
+private def target : RequestTarget := .originForm { segments := #[], absolute := true } none
+
+/-! ## `ProxySelector` -/
+
+-- `direct` never proxies.
+#guard ProxySelector.direct.select example80 == Proxy.direct
+#guard ProxySelector.direct.select secure443 == Proxy.direct
+
+-- `of` proxies every origin through one endpoint.
+#guard (ProxySelector.of "proxy.example" 8080).select example80 == Proxy.http "proxy.example" 8080
+#guard (ProxySelector.of "proxy.example" 8080).select secure443 == Proxy.http "proxy.example" 8080
+
+-- `bypassing` overrides the underlying selector with a direct connection.
+private def corpProxy : ProxySelector :=
+  (ProxySelector.of "proxy.example" 8080).bypassing fun o => toString o.host == "internal.corp"
+
+#guard corpProxy.select internal80 == Proxy.direct
+#guard corpProxy.select example80 == Proxy.http "proxy.example" 8080
+
+-- The default `Config` makes no proxy connections.
+#guard ({} : Client.Config).proxySelector.select example80 == Proxy.direct
+
+/-! ## `Challenge` -/
+
+private def serverChallenge : Challenge :=
+  { kind := .server, origin := example80, target, headers := Headers.empty }
+
+private def proxyChallenge : Challenge :=
+  { kind := .proxy, origin := example80, target, headers := Headers.empty }
+
+-- A challenge names the header it was read from and the header its answer is sent in.
+#guard serverChallenge.challengeHeader == Header.Name.wwwAuthenticate
+#guard serverChallenge.credentialHeader == Header.Name.authorization
+#guard proxyChallenge.challengeHeader == Header.Name.proxyAuthenticate
+#guard proxyChallenge.credentialHeader == Header.Name.proxyAuthorization
+
+-- `offered` reads every challenge of the matching kind, ignoring the other kind's header.
+private def bothChallenges : Headers :=
+  ((Headers.empty.insert .wwwAuthenticate (.mk "Basic realm=\"a\"")).insert
+    .wwwAuthenticate (.mk "Bearer")).insert .proxyAuthenticate (.mk "Basic realm=\"p\"")
+
+#guard ({ serverChallenge with headers := bothChallenges } : Challenge).offered.map (·.value)
+  == #["Basic realm=\"a\"", "Bearer"]
+#guard ({ proxyChallenge with headers := bothChallenges } : Challenge).offered.map (·.value)
+  == #["Basic realm=\"p\""]
+#guard serverChallenge.offered.isEmpty
+
+/-! ## `Authenticator` -/
+
+private def token : Header.Value := .mk "Bearer abc123"
+
+-- `const` answers every challenge with the same credential.
+#eval show IO Unit from do
+  let value ← (Authenticator.const token).authenticate serverChallenge |>.block
+  unless value.map (·.value) == some "Bearer abc123" do
+    throw <| IO.userError "const authenticator must answer a server challenge"
+  let value ← (Authenticator.const token).authenticate proxyChallenge |>.block
+  unless value.map (·.value) == some "Bearer abc123" do
+    throw <| IO.userError "const authenticator must answer a proxy challenge"
+
+-- `restrict` declines challenges rejected by the predicate.
+#eval show IO Unit from do
+  let serverOnly := (Authenticator.const token).restrict (·.kind == Challenge.Kind.server)
+  let value ← serverOnly.authenticate serverChallenge |>.block
+  unless value.isSome do
+    throw <| IO.userError "restrict must keep challenges accepted by the predicate"
+  let value ← serverOnly.authenticate proxyChallenge |>.block
+  unless value.isNone do
+    throw <| IO.userError "restrict must decline challenges rejected by the predicate"
+
+-- No authenticator is configured by default.
+#guard ({} : Client.Config).authenticator.isNone
+
+/-! ## `CookieHandler` -/
+
+-- A handler observes `store` and replays what it recorded from `load`.
+#eval show IO Unit from do
+  let jar ← IO.mkRef (#[] : Array Header.Value)
+  let handler : CookieHandler :=
+    { load := fun _ _ => return (← jar.get),
+      store := fun _ _ headers => jar.modify (· ++ (headers.getAll? .setCookie).getD #[]) }
+  let response := (Headers.empty.insert .setCookie (.mk "a=1")).insert .setCookie (.mk "b=2")
+  handler.store example80 target response |>.block
+  let sent ← handler.load example80 target |>.block
+  unless sent.map (·.value) == #["a=1", "b=2"] do
+    throw <| IO.userError s!"cookie handler replayed {sent.map (·.value)}"
+
+-- No cookie handler is configured by default.
+#guard ({} : Client.Config).cookieHandler.isNone

--- a/tests/elab/async_http_redirect.lean
+++ b/tests/elab/async_http_redirect.lean
@@ -60,105 +60,102 @@ private def isReplayBody : RedirectBodyAction → Bool
 /-! ## Terminal responses (`.done`) -/
 
 -- A non-3xx status is never a redirect.
-#guard isDone (decideRedirect origin (mkReq .get) false false .v11 .ok (withLocation "/x"))
+#guard isDone (decideRedirect origin (mkReq .get) false .v11 .ok (withLocation "/x"))
 
 -- A 3xx status with no `Location` header cannot be followed.
-#guard isDone (decideRedirect origin (mkReq .get) false false .v11 .found Headers.empty)
+#guard isDone (decideRedirect origin (mkReq .get) false .v11 .found Headers.empty)
 
 -- SSRF guard: a `Location` resolving to a non-http(s) scheme is rejected.
-#guard isDone (decideRedirect origin (mkReq .get) false false .v11 .found (withLocation "file:///etc/passwd"))
+#guard isDone (decideRedirect origin (mkReq .get) false .v11 .found (withLocation "file:///etc/passwd"))
 
 -- 305 Use Proxy / 306 Unused / 304 Not Modified / 300 Multiple Choices are terminal.
-#guard isDone (decideRedirect origin (mkReq .get) false false .v11 .useProxy (withLocation "/x"))
-#guard isDone (decideRedirect origin (mkReq .get) false false .v11 .unused (withLocation "/x"))
-#guard isDone (decideRedirect origin (mkReq .get) false false .v11 .notModified (withLocation "/x"))
-#guard isDone (decideRedirect origin (mkReq .get) false false .v11 .multipleChoices (withLocation "/x"))
-
--- `onlySafeRedirects` blocks redirects of unsafe methods.
-#guard isDone (decideRedirect origin (mkReq .post) false true .v11 .found (withLocation "/x"))
+#guard isDone (decideRedirect origin (mkReq .get) false .v11 .useProxy (withLocation "/x"))
+#guard isDone (decideRedirect origin (mkReq .get) false .v11 .unused (withLocation "/x"))
+#guard isDone (decideRedirect origin (mkReq .get) false .v11 .notModified (withLocation "/x"))
+#guard isDone (decideRedirect origin (mkReq .get) false .v11 .multipleChoices (withLocation "/x"))
 
 -- 301/302 only auto-follow GET/HEAD/POST; other unsafe methods are terminal.
-#guard isDone (decideRedirect origin (mkReq .put) false false .v11 .movedPermanently (withLocation "/x"))
+#guard isDone (decideRedirect origin (mkReq .put) false .v11 .movedPermanently (withLocation "/x"))
 
 -- 307/308 preserve the method, so a non-GET/HEAD request with a non-replayable body is terminal.
-#guard isDone (decideRedirect origin (mkReq .post) false false .v11 .temporaryRedirect (withLocation "/x"))
+#guard isDone (decideRedirect origin (mkReq .post) false .v11 .temporaryRedirect (withLocation "/x"))
 
 -- HTTP/1.0 only defines 301/302; HTTP/1.1-only codes (e.g. 303) must not auto-follow.
-#guard isDone (decideRedirect origin (mkReq .get) false false .v10 .seeOther (withLocation "/x"))
+#guard isDone (decideRedirect origin (mkReq .get) false .v10 .seeOther (withLocation "/x"))
 
 /-! ## Followed redirects: method selection -/
 
 -- Same-origin 302 on GET: method preserved, target rewritten to origin-form, empty body.
-#guard match plan? (decideRedirect origin (mkReq .get) false false .v11 .found (withLocation "/next")) with
+#guard match plan? (decideRedirect origin (mkReq .get) false .v11 .found (withLocation "/next")) with
   | some p => p.method == .get && !p.isCrossOrigin && toString p.target == "/next" && isEmptyBody p.bodyAction
   | none => false
 
 -- HTTP/1.0 302 on GET is followed.
-#guard match plan? (decideRedirect origin (mkReq .get) false false .v10 .found (withLocation "/x")) with
+#guard match plan? (decideRedirect origin (mkReq .get) false .v10 .found (withLocation "/x")) with
   | some _ => true
   | none => false
 
 -- 303 See Other downgrades to GET with an empty body.
-#guard match plan? (decideRedirect origin (mkReq .post) false false .v11 .seeOther (withLocation "/next")) with
+#guard match plan? (decideRedirect origin (mkReq .post) false .v11 .seeOther (withLocation "/next")) with
   | some p => p.method == .get && isEmptyBody p.bodyAction
   | none => false
 
 -- 301/302 on POST downgrade to GET under HTTP/1.1.
-#guard match plan? (decideRedirect origin (mkReq .post) false false .v11 .movedPermanently (withLocation "/x")) with
+#guard match plan? (decideRedirect origin (mkReq .post) false .v11 .movedPermanently (withLocation "/x")) with
   | some p => p.method == .get
   | none => false
 
 -- HTTP/1.0 301 preserves POST (with a replayable body so it is followed).
-#guard match plan? (decideRedirect origin (mkReq .post (version := .v10)) true false .v10 .movedPermanently (withLocation "/x")) with
+#guard match plan? (decideRedirect origin (mkReq .post (version := .v10)) true .v10 .movedPermanently (withLocation "/x")) with
   | some p => p.method == .post && isReplayBody p.bodyAction
   | none => false
 
 -- HTTP/1.0 301 preserves POST, so a NON-replayable body must make it terminal: the method is kept,
 -- so it would otherwise be followed with a `.replay` action that the body cannot satisfy.
-#guard isDone (decideRedirect origin (mkReq .post (version := .v10)) false false .v10 .movedPermanently (withLocation "/x"))
+#guard isDone (decideRedirect origin (mkReq .post (version := .v10)) false .v10 .movedPermanently (withLocation "/x"))
 
 -- 307 preserves POST and replays the body when replayable.
-#guard match plan? (decideRedirect origin (mkReq .post) true false .v11 .temporaryRedirect (withLocation "/x")) with
+#guard match plan? (decideRedirect origin (mkReq .post) true .v11 .temporaryRedirect (withLocation "/x")) with
   | some p => p.method == .post && isReplayBody p.bodyAction
   | none => false
 
 -- 307 on GET is followed with the method preserved.
-#guard match plan? (decideRedirect origin (mkReq .get) false false .v11 .temporaryRedirect (withLocation "/x")) with
+#guard match plan? (decideRedirect origin (mkReq .get) false .v11 .temporaryRedirect (withLocation "/x")) with
   | some p => p.method == .get
   | none => false
 
 -- 303 See Other preserves HEAD (RFC 9110 §15.4.4: 303 may be retrieved with GET or HEAD), so a
 -- HEAD request must not be downgraded to GET.
-#guard match plan? (decideRedirect origin (mkReq .head) false false .v11 .seeOther (withLocation "/next")) with
+#guard match plan? (decideRedirect origin (mkReq .head) false .v11 .seeOther (withLocation "/next")) with
   | some p => p.method == .head && isEmptyBody p.bodyAction
   | none => false
 
 /-! ## Target rewriting -/
 
 -- Absolute-path `Location` replaces the path.
-#guard match plan? (decideRedirect origin (mkReq .get) false false .v11 .found (withLocation "/x")) with
+#guard match plan? (decideRedirect origin (mkReq .get) false .v11 .found (withLocation "/x")) with
   | some p => toString p.target == "/x"
   | none => false
 
 -- Relative-path `Location` is merged against the base path (`/a/b` + `c` → `/a/c`).
-#guard match plan? (decideRedirect origin (mkReq .get) false false .v11 .found (withLocation "c")) with
+#guard match plan? (decideRedirect origin (mkReq .get) false .v11 .found (withLocation "c")) with
   | some p => toString p.target == "/a/c"
   | none => false
 
 -- Cross-origin absolute `Location` keeps absolute-form on the wire.
-#guard match plan? (decideRedirect origin (mkReq .get credHeaders) false false .v11 .found (withLocation "http://other.com/x")) with
+#guard match plan? (decideRedirect origin (mkReq .get credHeaders) false .v11 .found (withLocation "http://other.com/x")) with
   | some p => p.isCrossOrigin && toString p.target == "http://other.com/x"
   | none => false
 
 -- The fragment of an absolute `Location` is never placed on the wire (RFC 9112 §3.2).
-#guard match plan? (decideRedirect origin (mkReq .get) false false .v11 .found (withLocation "http://other.com/x#frag")) with
+#guard match plan? (decideRedirect origin (mkReq .get) false .v11 .found (withLocation "http://other.com/x#frag")) with
   | some p => toString p.target == "http://other.com/x"
   | none => false
 
 /-! ## Header scrubbing -/
 
 -- Cross-origin hop strips credential headers and rewrites Host to the new origin.
-#guard match plan? (decideRedirect origin (mkReq .get credHeaders) false false .v11 .found (withLocation "http://other.com/x")) with
+#guard match plan? (decideRedirect origin (mkReq .get credHeaders) false .v11 .found (withLocation "http://other.com/x")) with
   | some p =>
       !p.headers.contains .authorization
         && !p.headers.contains .cookie
@@ -166,18 +163,18 @@ private def isReplayBody : RedirectBodyAction → Bool
   | none => false
 
 -- Same-origin hop keeps credential headers.
-#guard match plan? (decideRedirect origin (mkReq .get credHeaders) false false .v11 .found (withLocation "/next")) with
+#guard match plan? (decideRedirect origin (mkReq .get credHeaders) false .v11 .found (withLocation "/next")) with
   | some p => p.headers.contains .authorization && p.headers.contains .cookie && !p.isCrossOrigin
   | none => false
 
 -- Changing the method to GET strips resource-specific content headers.
-#guard match plan? (decideRedirect origin (mkReq .post contentHeaders) false false .v11 .seeOther (withLocation "/next")) with
+#guard match plan? (decideRedirect origin (mkReq .post contentHeaders) false .v11 .seeOther (withLocation "/next")) with
   | some p => p.method == .get && !p.headers.contains .contentType && !p.headers.contains .contentLength
   | none => false
 
 -- A cross-origin hop on a request that carried no `Host` header leaves the plan without one:
 -- `rewriteHostHeader` only rewrites an existing `Host`, so supplying it is the caller's job.
-#guard match plan? (decideRedirect origin (mkReq .get) false false .v11 .found (withLocation "http://other.com/x")) with
+#guard match plan? (decideRedirect origin (mkReq .get) false .v11 .found (withLocation "http://other.com/x")) with
   | some p => p.isCrossOrigin && !p.headers.contains .host
   | none => false
 
@@ -191,7 +188,7 @@ info: "crossorigin: false, target: /next"
 -/
 #guard_msgs in
 #eval
-  match plan? (decideRedirect origin (mkReq .get) false false .v11 .found (withLocation "//example.com/next")) with
+  match plan? (decideRedirect origin (mkReq .get) false .v11 .found (withLocation "//example.com/next")) with
     | some p => s!"crossorigin: {p.isCrossOrigin}, target: {toString p.target}"
     | none => "no plan"
 
@@ -207,7 +204,7 @@ info: "target: /a/b?old=1"
 -/
 #guard_msgs in
 #eval
-  match plan? (decideRedirect origin queryReq false false .v11 .found (withLocation "#frag")) with
+  match plan? (decideRedirect origin queryReq false .v11 .found (withLocation "#frag")) with
   | some p => s!"target: {toString p.target}"
   | none => "no plan"
 
@@ -218,7 +215,7 @@ info: "target: /a/b?a=2"
 -/
 #guard_msgs in
 #eval
-  match plan? (decideRedirect origin queryReq false false .v11 .found (withLocation "?a=2")) with
+  match plan? (decideRedirect origin queryReq false .v11 .found (withLocation "?a=2")) with
   | some p => s!"target: {toString p.target}"
   | none => "no plan"
 
@@ -233,7 +230,7 @@ info: "methodIsGet: true, transferEncoding: false"
 -/
 #guard_msgs in
 #eval
-  match plan? (decideRedirect origin (mkReq .post sameOriginHopHeaders) false false .v11 .seeOther (withLocation "/next")) with
+  match plan? (decideRedirect origin (mkReq .post sameOriginHopHeaders) false .v11 .seeOther (withLocation "/next")) with
   | some p => s!"methodIsGet: {p.method == Method.get}, transferEncoding: {p.headers.contains .transferEncoding}"
   | none => "no plan"
 
@@ -251,28 +248,25 @@ info: "connection: false, x-hop: false"
 -/
 #guard_msgs in
 #eval
-  match plan? (decideRedirect origin (mkReq .get connectionNominatedHeaders) false false .v11 .found (withLocation "/next")) with
+  match plan? (decideRedirect origin (mkReq .get connectionNominatedHeaders) false .v11 .found (withLocation "/next")) with
   | some p => s!"connection: {p.headers.contains .connection}, x-hop: {p.headers.contains xHop}"
   | none => "no plan"
 
 /-! ## 303 with unsafe non-GET/HEAD methods -/
 
--- RFC 9110 §15.4.4: 303 applies to any method, retrieved with GET. With `onlySafeRedirects = false`
+-- RFC 9110 §15.4.4: 303 applies to any method, retrieved with GET, so
 -- a PUT/DELETE/PATCH receiving 303 is followed and rewritten to GET with an empty body.
-#guard match plan? (decideRedirect origin (mkReq .put) false false .v11 .seeOther (withLocation "/x")) with
+#guard match plan? (decideRedirect origin (mkReq .put) false .v11 .seeOther (withLocation "/x")) with
   | some p => p.method == .get && isEmptyBody p.bodyAction
   | none => false
 
-#guard match plan? (decideRedirect origin (mkReq .delete) false false .v11 .seeOther (withLocation "/x")) with
+#guard match plan? (decideRedirect origin (mkReq .delete) false .v11 .seeOther (withLocation "/x")) with
   | some p => p.method == .get && isEmptyBody p.bodyAction
   | none => false
 
-#guard match plan? (decideRedirect origin (mkReq .patch) false false .v11 .seeOther (withLocation "/x")) with
+#guard match plan? (decideRedirect origin (mkReq .patch) false .v11 .seeOther (withLocation "/x")) with
   | some p => p.method == .get && isEmptyBody p.bodyAction
   | none => false
-
--- `onlySafeRedirects = true` blocks the same PUT+303 since PUT is not a safe method.
-#guard isDone (decideRedirect origin (mkReq .put) false true .v11 .seeOther (withLocation "/x"))
 
 /-! ## `Status.isRedirection` boundaries -/
 


### PR DESCRIPTION
This PR adds the basic structure for the HTTP client, including client configuration, possible errors, and small changes to other modules.

- Foundation: #14546
- Connection: #14547
- Agent: #14548