### PR TITLE
fix: typecheck disabled debug assertions

### DIFF
--- a/src/Lean/Elab/BuiltinNotation.lean
+++ b/src/Lean/Elab/BuiltinNotation.lean
@@ -231,7 +231,7 @@ register_builtin_option debugAssertions : Bool := {
       if debugAssertions.get (← getOptions) then
         `(assert! $cond; $body)
       else
-        return body
+        `(let _ : Nonempty Bool := ⟨$cond⟩; $body)
     | _ => throwUnsupportedSyntax
 
 @[builtin_macro Lean.Parser.Term.dbgTrace]  def expandDbgTrace : Macro

--- a/tests/pkg/debug/invalid.lean
+++ b/tests/pkg/debug/invalid.lean
@@ -1,0 +1,6 @@
+/-!
+Checks that disabled `debug_assert!` conditions are still typechecked (#14453).
+-/
+
+def invalid : Unit :=
+  debug_assert! '1' + 2; ()

--- a/tests/pkg/debug/run_test.sh
+++ b/tests/pkg/debug/run_test.sh
@@ -1,4 +1,5 @@
 rm -rf .lake
 
+run_fail lake env lean invalid.lean
 run lake exe release
 run_fail lake exe debug


### PR DESCRIPTION
This PR makes `debug_assert!` typecheck its condition even when debug assertions are disabled, preventing invalid conditions from being silently accepted in release builds.

The disabled branch records the condition in an erased `Nonempty Bool` witness, preserving release runtime behavior while constraining the condition to `Bool`. The package regression test verifies that the same invalid condition is accepted by stage0 and rejected by stage1, while the existing release/debug runtime behavior remains unchanged.

Closes #14453

## Tests

- `make -C build/release -j4`
- `tests/with_stage1_test_env.sh tests/pkg/debug/run_test.sh`

## Changelog

- `changelog-language`