### PR TITLE
fix: validate interpreted values before closing grind goals

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/Core.lean
+++ b/src/Lean/Meta/Tactic/Grind/Core.lean
@@ -81,7 +81,7 @@ private def closeGoalWithValuesEq (lhs rhs : Expr) : GoalM Unit := do
   let p ← mkEq lhs rhs
   let hp ← mkEqProof lhs rhs
   let d ← mkDecide p
-  unless (← isDefEq d (mkConst ``false)) do
+  unless (← withTransparency .all <| isDefEq d (mkConst ``false)) do
     return
   let pEqFalse := mkApp3 (mkConst ``eq_false_of_decide) p d.appArg! eagerReflBoolFalse
   let falseProof := mkApp4 (mkConst ``Eq.mp [Level.zero]) p (← getFalseExpr) pEqFalse hp

--- a/src/Lean/Meta/Tactic/Grind/Core.lean
+++ b/src/Lean/Meta/Tactic/Grind/Core.lean
@@ -81,6 +81,8 @@ private def closeGoalWithValuesEq (lhs rhs : Expr) : GoalM Unit := do
   let p ← mkEq lhs rhs
   let hp ← mkEqProof lhs rhs
   let d ← mkDecide p
+  unless (← isDefEq d (mkConst ``false)) do
+    return
   let pEqFalse := mkApp3 (mkConst ``eq_false_of_decide) p d.appArg! eagerReflBoolFalse
   let falseProof := mkApp4 (mkConst ``Eq.mp [Level.zero]) p (← getFalseExpr) pEqFalse hp
   closeGoal falseProof

--- a/tests/lean/grind/grind_bitvec_defeq.lean
+++ b/tests/lean/grind/grind_bitvec_defeq.lean
@@ -1,0 +1,5 @@
+import Lean
+
+-- Interpreted values with definitionally equal types must not be treated as distinct.
+example (i : BitVec (id 32)) (hne : i ≠ 0#32) : i ≠ 0 := by
+  grind


### PR DESCRIPTION
This PR prevents `grind` from treating syntactically distinct interpreted values as inconsistent when their decidable equality evaluates to true.

Closes #14521.

`closeGoalWithValuesEq` previously constructed a proof that `decide (lhs = rhs) = false` for every pair of distinct interpreted e-nodes with the same type. This is not valid when the values use definitionally equal type expressions such as `BitVec (id 32)` and `BitVec 32` but represent the same value. The new guard checks that the decision procedure actually reduces to `false` before constructing the contradiction proof.

A regression test covers the original `BitVec` example without `sorry`.

Validation:
- full independent stage1 build completed successfully (5047 jobs)
- `build/14521-make/stage1/bin/lean --root=. tests/lean/grind/grind_bitvec_defeq.lean` passes
- `git diff --check` passes