### PR TITLE
perf: compare `forbiddenTks` by pointer first in parser cache keys

### DIFF
--- a/src/Lean/Parser/Types.lean
+++ b/src/Lean/Parser/Types.lean
@@ -184,7 +184,15 @@ structure CacheableParserContext where
   suppressInsideQuot : Bool := false
   savedPos?          : Option String.Pos.Raw := none
   forbiddenTks       : Array Token := #[]
-  deriving BEq
+
+/-- Compares `forbiddenTks` by pointer first: contexts overwhelmingly share the array object (the
+empty default, or the array created on entering a `withForbidden` region), so parser-cache key
+comparisons skip the element walk. -/
+instance : BEq CacheableParserContext where
+  beq a b := a.prec == b.prec && a.quotDepth == b.quotDepth &&
+    a.suppressInsideQuot == b.suppressInsideQuot && a.savedPos? == b.savedPos? &&
+    withPtrEq a.forbiddenTks b.forbiddenTks (fun _ => a.forbiddenTks == b.forbiddenTks)
+      (fun h => by rw [h]; exact beq_self_eq_true _)
 
 /-- Parser context updateable in `adaptUncacheableContextFn`. -/
 structure ParserContextCore extends InputContext, ParserModuleContext, CacheableParserContext where


### PR DESCRIPTION
This PR replaces the derived `BEq` of `CacheableParserContext` with an instance that compares the `forbiddenTks` array by pointer before falling back to element comparison.

Parser cache keys hash only the position and parser name, so every cache probe resolves through this `BEq`. Contexts overwhelmingly share the same `forbiddenTks` object: the empty default outside forbidden-token regions, and the adapted array within one. The pointer check therefore succeeds on the hot path and removes the `Array.isEqv` walk from every cache probe.
