### PR TITLE
perf: pick compacted-region base addresses outside ASLR-occupied zones

### DIFF
--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -288,9 +288,14 @@ extern "C" LEAN_EXPORT object * lean_compacted_region_save(b_obj_arg ofname, b_o
         size_t base_addr = name(mod, true).hash();
         // x86-64 user space is currently limited to the lower 47 bits
         // (https://en.wikipedia.org/wiki/X86-64#Virtual_address_space_details).
-        // On Linux at least, the stack grows down from ~0x7fff... followed by shared libraries,
-        // so reserve a bit of space for them (0x7fff...-0x7f00... = 1TB).
-        base_addr = base_addr % 0x7f0000000000;
+        // Restrict the base to [0x080000000000, 0x550000000000). Above that window sit the PIE
+        // executable and heap (from `ELF_ET_DYN_BASE` = 0x5555... on Linux) and the top-down
+        // `mmap` area holding shared libraries, thread stacks, and allocator arenas; with
+        // high-entropy ASLR (`mmap_rnd_bits` = 32) the latter reaches down to ~0x7000....
+        // Below the window sit executable images and platform data such as the macOS dyld
+        // shared cache. A base inside any of those zones makes the load-time `mmap` fail
+        // depending on the run's ASLR offsets, forcing the pointer-relocation fallback.
+        base_addr = 0x080000000000 + base_addr % 0x4d0000000000;
         base_addr = base_addr & ~(ALIGN - 1);
         std::vector<region_view> dep_regions = extract_dep_regions(odep_regions);
         cs_obj = object_ref(mk_compactor(reinterpret_cast<void *>(base_addr),


### PR DESCRIPTION
This PR draws the base addresses recorded in compacted-region files from [0x080000000000, 0x550000000000) instead of [0, 0x7f0000000000), so that loading an `.olean` or incremental snapshot succeeds with a plain `mmap` at the recorded address instead of falling back to the pointer-relocation walk.

The previous window overlaps the zones ASLR populates: the PIE executable and heap above 0x555555554000, and the kernel's top-down `mmap` area holding shared libraries, thread stacks, and allocator arenas, which reaches down to about 0x700000000000 under high-entropy ASLR (`mmap_rnd_bits` = 32). A region base inside those zones fails the load-time `mmap` depending on the run's ASLR offsets, and a single failed dependency region forces relocating every pointer into it. `compiled/incr_header_load` shows the effect as bimodality: 454M instructions when every region maps at its recorded base, 826M and +70MiB resident when the relocation walk runs, with the slow mode hit in roughly a quarter of runs; an `mmap` trace census over 40 runs places every collision between 0x70… and 0x76…, inside thread-stack and arena reservations, and none inside the new window across ~196k fixed-address mappings.

Bases are baked into files at save time, so the change takes effect for newly written files; existing files load unchanged through the relocation fallback.
