### PR TITLE
feat: display deprecated module warnings in the right positions

### DIFF
--- a/src/Lean/Elab/Import.lean
+++ b/src/Lean/Elab/Import.lean
@@ -66,17 +66,22 @@ def checkDeprecatedImports
     : MessageLog := Id.run do
   let mut opts := opts
   let mut ignoreDeprecatedImports : NameSet := {}
+  -- Position of each `import` statement, so warnings point at the offending import rather than
+  -- the start of the header.
+  let mut importPositions : NameMap String.Pos.Raw := {}
   if let some headerStx := origHeaderStx? <|> headerStx? then
     match headerStx with
     | `(Parser.Module.header| $[module%$moduleTk]? $[prelude%$_]? $importsStx*) =>
       if moduleTk.any (·.getTrailing?.any (·.toString.contains "deprecated_module: ignore")) then
         opts := linter.deprecated.module.set opts false
       for impStx in importsStx do
-        if impStx.raw.getTrailing?.any (·.toString.contains "deprecated_module: ignore") then
-          match impStx with
-          | `(Parser.Module.import| $[public%$_]? $[meta%$_]? import $[all%$_]? $n) =>
+        match impStx with
+        | `(Parser.Module.import| $[public%$_]? $[meta%$_]? import $[all%$_]? $n) =>
+          if impStx.raw.getTrailing?.any (·.toString.contains "deprecated_module: ignore") then
             ignoreDeprecatedImports := ignoreDeprecatedImports.insert n.getId
-          | _ => pure ()
+          if let some pos := impStx.raw.getPos? then
+            importPositions := importPositions.insert n.getId pos
+        | _ => pure ()
     | _ => pure ()
   if !linter.deprecated.module.get opts then
     return messages
@@ -88,10 +93,10 @@ def checkDeprecatedImports
     | some idx =>
       match env.getDeprecatedModuleByIdx? idx with
       | some entry =>
-        let pos := inputCtx.fileMap.toPosition startPos
+        let pos := importPositions.find? imp.module |>.getD startPos
         messages.add {
           fileName := inputCtx.fileName
-          pos := pos
+          pos := inputCtx.fileMap.toPosition pos
           severity := .warning
           data := .tagged ``deprecatedModuleExt <| formatDeprecatedModuleWarning env idx imp.module entry
         }

--- a/src/Lean/Elab/Import.lean
+++ b/src/Lean/Elab/Import.lean
@@ -66,8 +66,6 @@ def checkDeprecatedImports
     : MessageLog := Id.run do
   let mut opts := opts
   let mut ignoreDeprecatedImports : NameSet := {}
-  -- Position of each `import` statement, so warnings point at the offending import rather than
-  -- the start of the header.
   let mut importPositions : NameMap String.Pos.Raw := {}
   if let some headerStx := origHeaderStx? <|> headerStx? then
     match headerStx with

--- a/tests/pkg/deprecated_module/DeprecatedModule/Consumer.lean
+++ b/tests/pkg/deprecated_module/DeprecatedModule/Consumer.lean
@@ -1,3 +1,5 @@
+module
+
 import DeprecatedModule.GoodModule
 import DeprecatedModule.Old
 import DeprecatedModule.OldNoMessage

--- a/tests/pkg/deprecated_module/DeprecatedModule/Consumer.lean
+++ b/tests/pkg/deprecated_module/DeprecatedModule/Consumer.lean
@@ -1,4 +1,3 @@
-module
-
+import DeprecatedModule.GoodModule
 import DeprecatedModule.Old
 import DeprecatedModule.OldNoMessage

--- a/tests/pkg/deprecated_module/DeprecatedModule/GoodModule.lean
+++ b/tests/pkg/deprecated_module/DeprecatedModule/GoodModule.lean
@@ -1,0 +1,3 @@
+module
+
+def good : Nat := 42

--- a/tests/pkg/deprecated_module/lakefile.toml
+++ b/tests/pkg/deprecated_module/lakefile.toml
@@ -6,6 +6,7 @@ name = "Main"
 roots = [
   "DeprecatedModule.New",
   "DeprecatedModule.Old",
+  "DeprecatedModule.GoodModule",
   "DeprecatedModule.OldNoMessage",
   "DeprecatedModule.OldDouble",
   "DeprecatedModule.Transitive",

--- a/tests/pkg/deprecated_module/lean-toolchain
+++ b/tests/pkg/deprecated_module/lean-toolchain
@@ -1,0 +1,1 @@
+../../../build/release/stage1

--- a/tests/pkg/deprecated_module/run_test.sh
+++ b/tests/pkg/deprecated_module/run_test.sh
@@ -11,6 +11,11 @@ check_out_contains "import DeprecatedModule.New"
 # Without-message format: deprecation with replacement imports but no custom message
 check_out_contains "'DeprecatedModule.OldNoMessage' has been deprecated: please replace this import by"
 
+# Warnings are anchored at the offending import statement, not the start of the header:
+# Consumer imports the non-deprecated GoodModule on line 1, Old on line 2, OldNoMessage on line 3
+check_out_contains "DeprecatedModule/Consumer.lean:2:0: use DeprecatedModule.New instead"
+check_out_contains "DeprecatedModule/Consumer.lean:3:0: 'DeprecatedModule.OldNoMessage' has been deprecated"
+
 # OldDouble has two deprecated_module commands — second triggers duplicate warning
 check_out_contains "module is already marked as deprecated"
 
@@ -18,7 +23,7 @@ check_out_contains "module is already marked as deprecated"
 # (covered implicitly: if transitive warnings leaked, we'd see extra output)
 
 # ConsumerIgnoreOne: "deprecated_module: ignore" on Old import only — OldNoMessage should still warn
-check_out_contains "ConsumerIgnoreOne.lean:1:0: 'DeprecatedModule.OldNoMessage' has been deprecated"
+check_out_contains "ConsumerIgnoreOne.lean:4:0: 'DeprecatedModule.OldNoMessage' has been deprecated"
 
 # ConsumerIgnoreOnlyImport: single import with "deprecated_module: ignore" — no warning
 if grep -Fq "ConsumerIgnoreOnlyImport.lean" "$CAPTURED.out.produced"; then
@@ -27,8 +32,8 @@ fi
 
 # ConsumerIgnoreLastImport: "deprecated_module: ignore" on last import (Old) — OldNoMessage should
 # still warn, but Old should be suppressed
-check_out_contains "ConsumerIgnoreLastImport.lean:1:0: 'DeprecatedModule.OldNoMessage' has been deprecated"
-if grep -Fq "ConsumerIgnoreLastImport.lean:1:0: 'DeprecatedModule.Old' has been deprecated" "$CAPTURED.out.produced"; then
+check_out_contains "ConsumerIgnoreLastImport.lean:3:0: 'DeprecatedModule.OldNoMessage' has been deprecated"
+if grep -Eq "ConsumerIgnoreLastImport\.lean:[0-9]+:[0-9]+: use DeprecatedModule\.New instead" "$CAPTURED.out.produced"; then
   fail "ConsumerIgnoreLastImport should not warn about Old (annotated with deprecated_module: ignore)"
 fi
 

--- a/tests/pkg/deprecated_module/run_test.sh
+++ b/tests/pkg/deprecated_module/run_test.sh
@@ -12,9 +12,8 @@ check_out_contains "import DeprecatedModule.New"
 check_out_contains "'DeprecatedModule.OldNoMessage' has been deprecated: please replace this import by"
 
 # Warnings are anchored at the offending import statement, not the start of the header:
-# Consumer imports the non-deprecated GoodModule on line 1, Old on line 2, OldNoMessage on line 3
-check_out_contains "DeprecatedModule/Consumer.lean:2:0: use DeprecatedModule.New instead"
-check_out_contains "DeprecatedModule/Consumer.lean:3:0: 'DeprecatedModule.OldNoMessage' has been deprecated"
+check_out_contains "DeprecatedModule/Consumer.lean:4:0: use DeprecatedModule.New instead"
+check_out_contains "DeprecatedModule/Consumer.lean:5:0: 'DeprecatedModule.OldNoMessage' has been deprecated"
 
 # OldDouble has two deprecated_module commands — second triggers duplicate warning
 check_out_contains "module is already marked as deprecated"


### PR DESCRIPTION
This PR changes the handling of deprecated module warnings. Previously, deprecation warnings were displayed at the syntax ref corresponding to the first command of the file. Now, headers are re-parsed and used to extract correct position for displaying the deprecation warning.