### PR TITLE
chore: disable check for `since` field in deprecations

### DIFF
--- a/src/Lean/Linter/Deprecated.lean
+++ b/src/Lean/Linter/Deprecated.lean
@@ -43,8 +43,9 @@ builtin_initialize deprecatedAttr : ParametricAttribute DeprecationEntry ←
       let since? := since?.map TSyntax.getString
       if id?.isNone && text?.isNone then
         logWarning "`[deprecated]` attribute should specify either a new name or a deprecation message"
-      if since?.isNone then
-        logWarning "`[deprecated]` attribute should specify the date or library version at which the deprecation was introduced, using `(since := \"...\")`"
+      -- TODO: reenable after bootstrapping dance.
+      -- if since?.isNone then
+      --   logWarning "`[deprecated]` attribute should specify the date or library version at which the deprecation was introduced, using `(since := \"...\")`"
       return { newName?, text?, since? }
   }
 

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,7 +1,15 @@
 #include "util/options.h"
 
-// [ ] Check box to force CI to test stage 2 and run update-stage0 on PR merge
-// (any other change to this file will do the same; ALL changes should be made to the stage0/ copy)
+/*
+ ______________________
+< Please update stage0 >
+ ----------------------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||
+*/
 
 namespace lean {
 options get_option_overrides() {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -325,7 +325,7 @@ add_test_pile(
   ${ELAB_FIXTURES}
 )
 add_test_pile(elab_bench *.lean BENCH PART2 ${ELAB_FIXTURES})
-add_test_pile
+add_test_pile(
   elab_fail
   *.lean
   EXCEPT

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -321,10 +321,17 @@ add_test_pile(
   EXCEPT
     async_select_channel.lean # Flaky
     sync_mutex.lean # Flaky
+    4636.lean # #14566
   ${ELAB_FIXTURES}
 )
 add_test_pile(elab_bench *.lean BENCH PART2 ${ELAB_FIXTURES})
-add_test_pile(elab_fail *.lean ${ELAB_FIXTURES})
+add_test_pile
+  elab_fail
+  *.lean
+  EXCEPT
+    deprecated.lean # #14566
+  ${ELAB_FIXTURES}
+)
 add_test_pile(misc *.sh)
 add_test_pile(misc_bench *.sh BENCH PART2)
 add_test_pile(server *.lean)


### PR DESCRIPTION
This PR disables the check for the `since` field in deprecations in anticipation of an upcoming bootstrapping contortion.

It will be reenabled after the bootstrapping dance is over.