### PR TITLE
feat: handle stacked dependent projections in `cbv` that compose into dependent projection

### DIFF
--- a/src/Lean/Meta/Tactic/Cbv/Main.lean
+++ b/src/Lean/Meta/Tactic/Cbv/Main.lean
@@ -193,7 +193,7 @@ def zetaReduce : Simproc := fun e => do
   trace[Debug.Meta.Tactic.cbv.reduce] "zeta:{indentExpr e}\n==>{indentExpr new}"
   return .step new (← Sym.mkEqRefl new)
 
-/-- Peels nested projections: for `e = base.π₁.…​.πₙ` returns the projection nodes
+/-- Peels nested projections: for `e = base.proj₁.....projₙ` returns the projection nodes
 outermost-first together with the innermost non-projection `base`. -/
 def peelProjSpine (e : Expr) (acc : Array Expr := #[]) : Array Expr × Expr :=
   match e with
@@ -201,13 +201,7 @@ def peelProjSpine (e : Expr) (acc : Array Expr := #[]) : Array Expr × Expr :=
   | _ => (acc, e)
 
 /--
-Last resort for a stuck projection tower `e = base.π₁.…​.πₙ` whose base only reaches
-constructor form through a propositional rewrite: no single projection level admits a
-homogeneous `Eq` proof, because the type of each intermediate dependent projection
-mentions the stuck base. But when the composite projection function `fun x => x.π₁.…​.πₙ`
-is non-dependent, `base.π₁.…​.πₙ = base'.π₁.…​.πₙ` is well-typed and provable by
-`congrArg` on the whole spine at once; the rewritten tower over the constructor form
-then collapses via `reduceProj?` on the next visit.
+Last resort for nested dependent projections, whose composite is non-dependent.
 -/
 def trySpineCongrArg (e : Expr) (cd : Bool) : Sym.Simp.SimpM Result := do
   let (projs, base) := peelProjSpine e
@@ -242,7 +236,7 @@ Recursively simplifies the struct inside a projection, then reduces the projecti
 For non-dependent projection types, uses `congrArg` to lift the proof.
 For dependent projection types, tries direct reduction first; if that fails and
 the original and rewritten struct are definitionally equal, falls back to `HCongr`.
-For a stuck tower of projections, tries `congrArg` with the composite projection
+For a stuck composite of projections, tries `congrArg` with the composite projection
 function via `trySpineCongrArg`.
 -/
 def handleProj : Simproc := fun e => do
@@ -256,6 +250,7 @@ def handleProj : Simproc := fun e => do
   let res ← simp struct
   match res with
   | .rfl _ cd =>
+    -- if we get stuck, we try if we have a composite of dependent projections, which is non-dependent
     let some reduced ← withCbvOpaqueGuard <| withDefault <| reduceProj? <| .proj typeName idx struct | do
       trySpineCongrArg e cd
 

--- a/src/Lean/Meta/Tactic/Cbv/Main.lean
+++ b/src/Lean/Meta/Tactic/Cbv/Main.lean
@@ -67,6 +67,11 @@ There are also places where we deviate from strict call-by-value semantics:
 - Dependent projections that cannot be rewritten via `congrArg` are reduced
   directly when possible. As a last resort, if the types on which the projection
   function depends are definitionally equal, we use `HCongr` to build the proof.
+  For a stuck tower of projections `base.π₁.…​.πₙ` over a base that is only
+  propositionally a constructor, we additionally try `congrArg` with the composite
+  projection function: even when the intermediate levels are dependent, the
+  composite is often non-dependent (e.g. `fun p => p.snd.len : … → Nat`) and the
+  whole spine can be rewritten in one step.
 
 ## Attributes
 
@@ -188,11 +193,57 @@ def zetaReduce : Simproc := fun e => do
   trace[Debug.Meta.Tactic.cbv.reduce] "zeta:{indentExpr e}\n==>{indentExpr new}"
   return .step new (← Sym.mkEqRefl new)
 
+/-- Peels nested projections: for `e = base.π₁.…​.πₙ` returns the projection nodes
+outermost-first together with the innermost non-projection `base`. -/
+def peelProjSpine (e : Expr) (acc : Array Expr := #[]) : Array Expr × Expr :=
+  match e with
+  | .proj _ _ struct => peelProjSpine struct (acc.push e)
+  | _ => (acc, e)
+
+/--
+Last resort for a stuck projection tower `e = base.π₁.…​.πₙ` whose base only reaches
+constructor form through a propositional rewrite: no single projection level admits a
+homogeneous `Eq` proof, because the type of each intermediate dependent projection
+mentions the stuck base. But when the composite projection function `fun x => x.π₁.…​.πₙ`
+is non-dependent, `base.π₁.…​.πₙ = base'.π₁.…​.πₙ` is well-typed and provable by
+`congrArg` on the whole spine at once; the rewritten tower over the constructor form
+then collapses via `reduceProj?` on the next visit.
+-/
+def trySpineCongrArg (e : Expr) (cd : Bool) : Sym.Simp.SimpM Result := do
+  let (projs, base) := peelProjSpine e
+  -- A single projection over an unchanged struct was already handled by `handleProj`.
+  if projs.size < 2 then
+    return .rfl (done := true) cd
+  let res ← simp base
+  let .step base' proof _ cd' := res
+    | return .rfl (done := true) (cd || res.isContextDependent)
+  let cd := cd || cd'
+  let mut congrArgFunBody := Expr.bvar 0
+  for p in projs.reverse do
+    let .proj typeName idx _ := p | unreachable!
+    congrArgFunBody := .proj typeName idx congrArgFunBody
+  let congrArgFun := mkLambda `x .default (← Sym.inferType base') congrArgFunBody
+  let congrArgFunType ← Sym.inferType congrArgFun
+  unless congrArgFunType.isArrow do
+    return .rfl (done := true) cd
+  let .forallE _ α β _ := congrArgFunType | unreachable!
+  let u ← Sym.getLevel α
+  let v ← Sym.getLevel β
+  let newProof := mkApp6 (mkConst ``congrArg [u, v]) α β base base' congrArgFun proof
+  let mut newE := base'
+  for p in projs.reverse do
+    newE ← p.updateProjS! newE
+  if Sym.isSameExpr newE e then
+    return .rfl (done := true) cd
+  return .step newE newProof cd
+
 /--
 Recursively simplifies the struct inside a projection, then reduces the projection.
 For non-dependent projection types, uses `congrArg` to lift the proof.
 For dependent projection types, tries direct reduction first; if that fails and
 the original and rewritten struct are definitionally equal, falls back to `HCongr`.
+For a stuck tower of projections, tries `congrArg` with the composite projection
+function via `trySpineCongrArg`.
 -/
 def handleProj : Simproc := fun e => do
   let Expr.proj typeName idx struct := e | return .rfl
@@ -206,7 +257,7 @@ def handleProj : Simproc := fun e => do
   match res with
   | .rfl _ cd =>
     let some reduced ← withCbvOpaqueGuard <| withDefault <| reduceProj? <| .proj typeName idx struct | do
-      return .rfl (done := true) cd
+      trySpineCongrArg e cd
 
     let reduced ← Sym.share reduced
     return .step reduced (← Sym.mkEqRefl reduced) cd

--- a/tests/elab/cbv_dep_proj.lean
+++ b/tests/elab/cbv_dep_proj.lean
@@ -12,11 +12,7 @@ axiom otherPair : Σ n : Nat, Fin (n + 1)
 
 example : otherPair.1 = 5 := by cbv
 
-/--
-error: unsolved goals
-⊢ otherPair.2.1 = 3
--/
-#guard_msgs in
+
 example : otherPair.2.val = 3 := by cbv
 
 -- Custom structure with a dependent field
@@ -30,11 +26,7 @@ axiom opaquePkg : DepPkg
 
 example : opaquePkg.n = 5 := by cbv
 
-/--
-error: unsolved goals
-⊢ opaquePkg.2.1 = 3
--/
-#guard_msgs in
+
 example : opaquePkg.val.val = 3 := by cbv
 
 -- Subtype: .val is non-dependent, so the rewrite goes through

--- a/tests/elab/cbv_stacked_proj.lean
+++ b/tests/elab/cbv_stacked_proj.lean
@@ -1,0 +1,53 @@
+/-!
+Tests `cbv` reduction of stacked projections over a dependent projection whose
+struct only reaches constructor form through a propositional rewrite (e.g. the
+equations of a well-founded recursive definition). No single projection level
+admits a homogeneous `Eq` proof — the type of the intermediate dependent
+projection mentions the stuck struct — but the composite projection function is
+non-dependent, so `cbv` can rewrite the whole projection spine at once via
+`congrArg`.
+-/
+
+structure Payload (α : Type) where
+  val : α
+  len : Nat
+
+/-- Well-founded recursion: unfolds only propositionally, never definitionally. -/
+def mkPayload : Nat → Σ α : Type, Payload α
+  | 0 => ⟨Bool, ⟨true, 0⟩⟩
+  | n + 1 => mkPayload n
+termination_by n => n
+
+-- Single non-dependent projection: handled by the per-level `congrArg` path.
+example : (mkPayload 3).fst = Bool := by cbv
+
+-- Non-dependent `.len` stacked over the dependent `.snd`: needs the spine path.
+example : (mkPayload 3).snd.len = 0 := by cbv
+
+structure Inner (α : Type) where
+  a : α
+  m : Nat
+
+structure Outer (α : Type) where
+  inn : Inner α
+  k : Nat
+
+def mkOuter : Nat → Σ α : Type, Outer α
+  | 0 => ⟨Bool, ⟨⟨true, 7⟩, 5⟩⟩
+  | n + 1 => mkOuter n
+termination_by n => n
+
+-- Three-level spine: both intermediate composites (`.snd`, `.snd.inn`) are dependent.
+example : (mkOuter 2).snd.inn.m = 7 := by cbv
+example : (mkOuter 2).snd.k = 5 := by cbv
+
+-- Stacked projections inside a larger ground computation.
+example : (mkOuter 2).snd.inn.m + (mkPayload 1).snd.len + (mkOuter 0).snd.k = 12 := by cbv
+
+-- Base is `@[cbv_opaque]`: kernel reduction of the projection is suppressed, so
+-- the constructor form is only available through the `@[cbv_eval]` rewrite.
+@[cbv_opaque] def opaquePayload : Σ α : Type, Payload α := ⟨Bool, ⟨true, 5⟩⟩
+
+@[cbv_eval] theorem opaquePayload_eq : opaquePayload = ⟨Bool, ⟨true, 5⟩⟩ := rfl
+
+example : opaquePayload.snd.len = 5 := by cbv


### PR DESCRIPTION
This PR allows `cbv` to handle stacks of dependent projections, whose composite is non-dependent. 