### PR TITLE
chore: `typeChanced` syntax for deprecated attribute

### DIFF
--- a/src/Init/Notation.lean
+++ b/src/Init/Notation.lean
@@ -621,16 +621,26 @@ scoped syntax (name := withAnnotateTerm) "with_annotate_term " rawStx ppSpace te
 syntax (name := modCast) "mod_cast " term : term
 
 /--
+Indicates that a deprecated declaration's replacement intentionally has a different type.
+
+The `configItem` parsers are not available here, so we hand-roll this.
+-/
+syntax deprecatedTypeChanged :=
+  (" +" noWs &"typeChanged") <|> (atomic(" (" &"typeChanged" " := ") &"true" ")")
+
+/--
 The attribute `@[deprecated]` on a declaration indicates that the declaration
 is discouraged for use in new code, and/or should be migrated away from in
 existing code. It may be removed in a future version of the library.
 
 * `@[deprecated myBetterDef]` means that `myBetterDef` is the suggested replacement.
 * `@[deprecated myBetterDef "use myBetterDef instead"]` allows customizing the deprecation message.
+* `@[deprecated myBetterDef +typeChanged]` indicates that the replacement intentionally has a
+  different type. `(typeChanged := true)` is an equivalent syntax.
 * `@[deprecated (since := "2024-04-21")]` records when the deprecation was first applied.
 -/
 syntax (name := deprecated) "deprecated" (ppSpace ident)? (ppSpace str)?
-    (" (" &"since" " := " str ")")? : attr
+    (deprecatedTypeChanged)? (" (" &"since" " := " str ")")? : attr
 
 /--
 The attribute `@[deprecated_arg old new]` marks a named parameter as deprecated.

--- a/src/Lean/Data/Options.lean
+++ b/src/Lean/Data/Options.lean
@@ -231,7 +231,7 @@ macro (name := registerBuiltinOption) doc?:(docComment)? vis?:(visibility)? "reg
   `($[$doc?]? $[$vis?:visibility]? builtin_initialize $name : Lean.Option $type ← Lean.Option.register $(quote name.getId) $decl)
 
 private meta def declWithDeprecation (attr : Syntax) (type decl : Term) : MacroM Term := do
-  let `(attr| deprecated $[$id?]? $[$text?]? $[(since := $since?)]?) := attr | return decl
+  let `(attr| deprecated $[$id?]? $[$text?]? $[$_typeChanged?]? $[(since := $since?)]?) := attr | return decl
   let since : Term ← match since? with | some s => pure s | none => `("")
   let text : Term ← match text? with | some text => `(some $text) | none => `(none)
   let newName : Term ← match id? with | some id => `(some ($id).name) | none => `(none)

--- a/src/Lean/Linter/Deprecated.lean
+++ b/src/Lean/Linter/Deprecated.lean
@@ -32,7 +32,7 @@ builtin_initialize deprecatedAttr : ParametricAttribute DeprecationEntry ←
     name := `deprecated
     descr := "mark declaration as deprecated",
     getParam := fun declName stx => do
-      let `(attr| deprecated $[$id?]? $[$text?]? $[(since := $since?)]?) := stx
+      let `(attr| deprecated $[$id?]? $[$text?]? $[$typeChanged?]? $[(since := $since?)]?) := stx
         | throwError "Invalid `[deprecated]` attribute syntax"
       let newName? ← id?.mapM Elab.realizeGlobalConstNoOverloadWithInfo
       if newName? == some declName then

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,7 +1,15 @@
 #include "util/options.h"
 
-// [ ] Check box to force CI to test stage 2 and run update-stage0 on PR merge
-// (any other change to this file will do the same; ALL changes should be made to the stage0/ copy)
+/*
+ ______________________
+< Please update stage0 >
+ ----------------------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||
+*/
 
 namespace lean {
 options get_option_overrides() {


### PR DESCRIPTION
This PR adds `@[deprecated newName +typeChanged (since := "bla")]` syntax.

It doesn't do anything with the syntax yet.