### PR TITLE
fix: ci: early exit rebootstrap on no change to stage0

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -347,9 +347,10 @@ jobs:
           git config user.email "stage0@lean-fro.org"
           git config user.name "update-stage0"
           make -C build update-stage0
-          git commit --allow-empty -m "chore: update-stage0"
-          # with a new stage0, the old stage0 githash no longer applies
-          unset LEAN_GITHASH
+          # An empty commit changes `Lean.githash` without changing the stage0 tree hash that keys
+          # Lake's traces, leaving stage 1 `.olean`s stale with respect to the rebuilt binaries. If
+          # stage0 is unchanged, there is nothing to rebootstrap anyway, so exit early.
+          git diff --cached --quiet -- stage0 && exit 0 || git commit -m "chore: update-stage0"
           time make -C build -j$NPROC
           time ctest --preset ${{ matrix.CMAKE_PRESET || 'release' }} --test-dir build/stage1 -j$NPROC
         if: matrix.check-rebootstrap

--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -348,6 +348,8 @@ jobs:
           git config user.name "update-stage0"
           make -C build update-stage0
           git commit --allow-empty -m "chore: update-stage0"
+          # with a new stage0, the old stage0 githash no longer applies
+          unset LEAN_GITHASH
           time make -C build -j$NPROC
           time ctest --preset ${{ matrix.CMAKE_PRESET || 'release' }} --test-dir build/stage1 -j$NPROC
         if: matrix.check-rebootstrap

--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -352,6 +352,9 @@ jobs:
           # stage0 is unchanged, there is nothing to rebootstrap anyway, so exit early.
           git diff --cached --quiet -- stage0 && exit 0 || git commit -m "chore: update-stage0"
           time make -C build -j$NPROC
+          # Set Lake's githash to the new stage0 hash used during the build (for the tests).
+          # Updating `GITHUB_ENV` would only apply to future steps (which do not need it).
+          export LEAN_GITHASH=$(cat build/stage1/lake-githash)
           time ctest --preset ${{ matrix.CMAKE_PRESET || 'release' }} --test-dir build/stage1 -j$NPROC
         if: matrix.check-rebootstrap
       - name: CCache stats

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -627,7 +627,7 @@ endif()
 
 # The stage0 tree hash. For non-release builds this is embedded as `Lean.githash`.
 # It is also the githash Lake always needs to use for its traces. It is passed via `LEAN_GITHASH`
-# in `stdlib.make` and propagated to the cache steps by CI. This esnures that stage1 `.olean`s stay
+# in `stdlib.make` and propagated to the cache steps by CI. This ensures that stage1 `.olean`s stay
 # reusable across commits that do not touch stage0.
 execute_process(
   COMMAND git rev-parse HEAD:stage0


### PR DESCRIPTION
This PR early exits "Check rebootstrap" when a rebootstrap does not change stage0 (e.g., in the CI job for an `update-stage0` commit or for a subsequent commit that makes no core changes).

After #14486, an empty commit changes `Lean.githash` without changing the stage0 tree hash that keys Lake's traces, leaving stage 1 `.olean`s stale with respect to the rebuilt binaries. This leads to an incompatible header failure when attempting to read the old oleans with the new `lean`. 

This is solved by aborting the "Check rebootstrap" when the commit would be empty. If stage0 did not change, there is nothing to rebootstrap anyway, so running it previously was just a waste of time.

The PR also sets the `LEAN_GITHASH` on a rebootstrap to the new stage0 hash, ensuring any `lake` invocations in the tests invalidate leftover stale builds keyed on the old githash. This should not occur (tests should clear previous outputs before running). Nonetheless, a failure here is hard to diagnose, so this is done defensively.

🤖 Prepared with Claude Code