### PR TITLE
fix: missing check at kernel inductive declaration

### DIFF
--- a/src/kernel/inductive.cpp
+++ b/src/kernel/inductive.cpp
@@ -796,11 +796,12 @@ static name * g_nested_fresh = nullptr;
 struct elim_nested_inductive_result {
     name_generator           m_ngen;
     buffer<expr>             m_params;
+    local_ctx                m_params_lctx; /* local context declaring the free vars in `m_params` (and in the `m_aux2nested` values). */
     name_map<expr>           m_aux2nested; /* mapping from auxiliary type to nested inductive type. */
     declaration              m_aux_decl;
 
-    elim_nested_inductive_result(name_generator const & ngen, buffer<expr> const & params, buffer<pair<expr, name>> const & nested_aux, declaration const & d):
-        m_ngen(ngen), m_params(params), m_aux_decl(d) {
+    elim_nested_inductive_result(name_generator const & ngen, buffer<expr> const & params, local_ctx const & params_lctx, buffer<pair<expr, name>> const & nested_aux, declaration const & d):
+        m_ngen(ngen), m_params(params), m_params_lctx(params_lctx), m_aux_decl(d) {
         for (pair<expr, name> const & p : nested_aux) {
             m_aux2nested.insert(p.second, p.first);
         }
@@ -1072,7 +1073,7 @@ struct elim_nested_inductive_fn {
             qhead++;
         }
         declaration aux_decl = mk_inductive_decl(ind_d.get_lparams(), ind_d.get_nparams(), inductive_types(m_new_types), ind_d.is_unsafe());
-        return elim_nested_inductive_result(m_ngen, m_params, m_nested_aux, aux_decl);
+        return elim_nested_inductive_result(m_ngen, m_params, m_params_lctx, m_nested_aux, aux_decl);
     }
 };
 
@@ -1122,6 +1123,16 @@ environment environment::add_inductive(declaration const & d) const {
         /* `d` did not contain nested inductive types. */
         return diag.update(aux_env);
     } else {
+        /* Type check the nested inductive applications `I Ds` that were replaced by auxiliary types.
+           The parametric arguments `Ds` do not appear in the auxiliary declaration, so they would
+           otherwise escape type checking. We check them now that the (mutual) inductive types being
+           declared are available in `aux_env`. */
+        {
+            type_checker tc(aux_env, res.m_params_lctx, diag.get(), inductive_decl(d).is_unsafe() ? definition_safety::unsafe : definition_safety::safe);
+            res.m_aux2nested.for_each([&](name const &, expr const & nested) {
+                    tc.check(nested, inductive_decl(d).get_lparams());
+                });
+        }
         /* Restore nested inductives. */
         inductive_decl ind_d(d);
         names all_ind_names = get_all_inductive_names(ind_d);

--- a/src/kernel/inductive.cpp
+++ b/src/kernel/inductive.cpp
@@ -1123,16 +1123,6 @@ environment environment::add_inductive(declaration const & d) const {
         /* `d` did not contain nested inductive types. */
         return diag.update(aux_env);
     } else {
-        /* Type check the nested inductive applications `I Ds` that were replaced by auxiliary types.
-           The parametric arguments `Ds` do not appear in the auxiliary declaration, so they would
-           otherwise escape type checking. We check them now that the (mutual) inductive types being
-           declared are available in `aux_env`. */
-        {
-            type_checker tc(aux_env, res.m_params_lctx, diag.get(), inductive_decl(d).is_unsafe() ? definition_safety::unsafe : definition_safety::safe);
-            res.m_aux2nested.for_each([&](name const &, expr const & nested) {
-                    tc.check(nested, inductive_decl(d).get_lparams());
-                });
-        }
         /* Restore nested inductives. */
         inductive_decl ind_d(d);
         names all_ind_names = get_all_inductive_names(ind_d);
@@ -1187,6 +1177,16 @@ environment environment::add_inductive(declaration const & d) const {
         }
         for (name const & aux_rec : aux_rec_names) {
             process_rec(aux_rec);
+        }
+        /* Type check the nested inductive applications `I Ds` that were replaced by auxiliary types.
+           The parametric arguments `Ds` do not appear in the auxiliary declaration, so they would
+           otherwise escape type checking. We check them at the end, using `new_env`, to avoid
+           type checking terms in an environment containing auxiliary declarations. */
+        {
+            type_checker tc(new_env, res.m_params_lctx, diag.get(), inductive_decl(d).is_unsafe() ? definition_safety::unsafe : definition_safety::safe);
+            res.m_aux2nested.for_each([&](name const &, expr const & nested) {
+                    tc.check(nested, inductive_decl(d).get_lparams());
+                });
         }
         return diag.update(new_env);
     }

--- a/tests/elab/issue_14576.lean
+++ b/tests/elab/issue_14576.lean
@@ -1,0 +1,67 @@
+import Lean
+open Lean Elab Command
+
+inductive P : Prop where | mk (b : Bool)
+structure C where b : Bool
+inductive W : Type where | mk (p : P)
+inductive L (α : Type) (b : Bool) : Type where | mk
+inductive T : Bool → Prop where | mk : T true
+
+def pad (e : Expr) (n : Nat) : Expr :=
+  mkApp (mkLambda `x .default (mkConst ``Nat) e) (.lit (.natVal n))
+
+meta def build : CommandElabM Unit := do
+  let f := pad (mkConst ``Bool.false) 78670
+  let t := pad (mkConst ``Bool.true) 24083
+  unless f.hash == t.hash && f.approxDepth == t.approxDepth do
+    throwError "hash collision failed"
+  let fw := mkApp (mkConst ``W.mk) (mkApp (mkConst ``P.mk) f)
+  let tw := mkApp (mkConst ``W.mk) (mkApp (mkConst ``P.mk) t)
+  let w := mkBVar 0
+  let Ew := mkApp (mkConst `E) w
+  let b := mkProj ``C 0 (mkProj ``C 0 w)
+  let l := mkApp2 (mkConst ``L) Ew b
+  let Et := mkForall `w .default (mkConst ``W) (mkSort 1)
+  let ct := mkForall `w .default (mkConst ``W) <|
+    mkForall `l .default l (mkApp (mkConst `E) (mkBVar 1))
+  liftCoreM <| addDecl <| .inductDecl [] 1 [{
+    name := `E, type := Et, ctors := [{ name := `E.mk, type := ct }] }] false
+  let Et := mkApp (mkConst `E) tw
+  let l := mkApp2 (mkConst ``L.mk) Et (mkConst ``Bool.true)
+  liftCoreM <| addDecl <| .defnDecl {
+    name := `e, levelParams := [], type := Et,
+    value := mkApp2 (mkConst `E.mk) tw l,
+    hints := .abbrev, safety := .safe }
+  liftCoreM <| addDecl <| .defnDecl {
+    name := `good', levelParams := [],
+    type := mkApp (mkConst ``T) t, value := mkConst ``T.mk,
+    hints := .abbrev, safety := .safe }
+  let Ef := mkApp (mkConst `E) fw
+  let Et := mkApp (mkConst `E) tw
+  let a := mkApp2 (mkConst `E.mk) fw (mkProj `E 0 (mkConst `e))
+  let tl := mkApp2 (mkConst ``L.mk) Et (mkConst ``Bool.true)
+  let b := mkApp2 (mkConst `E.mk) tw tl
+  let cT := mkApp2 (mkConst ``L) Et t
+  let c := mkApp (mkLambda `l .default cT (mkConst ``Unit.unit)) tl
+  let fl := mkApp2 (mkConst ``L.mk) Ef f
+  let d := mkApp2 (mkConst `E.mk) fw fl
+  let v := Expr.letE `a Ef a
+    (.letE `b Et b
+      (.letE `c (mkConst ``Unit) c
+        (.letE `d Ef d (mkConst `good') true) true) true) true
+  liftCoreM <| addDecl <| .thmDecl {
+    name := `bad, levelParams := [],
+    type := mkApp (mkConst ``T) f, value := v }
+
+elab "mkbug" : command => build
+
+/--
+error: (kernel) invalid projection
+  w.1
+-/
+#guard_msgs in
+mkbug
+
+/-- error: Unknown identifier `bad` -/
+#guard_msgs in
+theorem boom : False := nomatch (bad : T false)

--- a/tests/elab/issue_14576_min.lean
+++ b/tests/elab/issue_14576_min.lean
@@ -1,0 +1,30 @@
+import Lean
+open Lean Elab Command
+
+structure C where b : Bool
+inductive W : Type where | mk (p : Bool)
+inductive L (α : Type) (b : Bool) : Type where | mk
+
+meta def build : CommandElabM Unit := do
+  let w := mkBVar 0
+  let Ew := mkApp (mkConst `E) w
+  let b := mkProj ``C 0 (mkProj ``C 0 w)
+  let l := mkApp2 (mkConst ``L) Ew b
+  let Et := mkForall `w .default (mkConst ``W) (mkSort 1)
+  let ct := mkForall `w .default (mkConst ``W) <|
+    mkForall `l .default l (mkApp (mkConst `E) (mkBVar 1))
+  logInfo ct
+  liftCoreM <| addDecl <| .inductDecl [] 1 [{
+    name := `E, type := Et, ctors := [{ name := `E.mk, type := ct }] }] false
+  logInfo "E accepted"
+
+elab "mkbug" : command => build
+
+/--
+info: (w : W) → L (E w) w.1.1 → E w
+---
+error: (kernel) invalid projection
+  w.1
+-/
+#guard_msgs in
+mkbug


### PR DESCRIPTION
This PR fixes a kernel bug where a nested inductive datatype whose parametric arguments are ill typed could be accepted.

When eliminating a nested occurrence `I Ds is`, the parametric arguments `Ds` are dropped from the generated auxiliary types, so they used to escape type checking. We now type check them once the inductive types being declared are available.

Closes #14576
