### PR TITLE
feat: defer stuck exceptions from `isDefEqApp`'s `isDefEqOnFailure` fallback

### DIFF
--- a/src/Lean/Meta/ExprDefEq.lean
+++ b/src/Lean/Meta/ExprDefEq.lean
@@ -2161,21 +2161,17 @@ where
 
 /--
   Given applications `t` and `s` that are in WHNF (modulo the current transparency setting),
-  check whether they are definitionally equal or not.
+  check whether they are definitionally equal or not by comparing functions and arguments.
+  On failure, the caller is responsible for invoking `isDefEqOnFailure`.
 -/
 private def isDefEqApp (t s : Expr) : MetaM Bool := do
   let tFn := t.getAppFn
   let sFn := s.getAppFn
   if tFn.isConst && sFn.isConst && tFn.constName! == sFn.constName! then
     /- See comment at `tryHeuristic` explaining why we process arguments before universe levels. -/
-    if (← checkpointDefEq (isDefEqArgs tFn t.getAppArgs s.getAppArgs <&&> isListLevelDefEqAux tFn.constLevels! sFn.constLevels!)) then
-      return true
-    else
-      isDefEqOnFailure t s
-  else if (← checkpointDefEq (Meta.isExprDefEqAux tFn s.getAppFn <&&> isDefEqArgs tFn t.getAppArgs s.getAppArgs)) then
-    return true
+    checkpointDefEq (isDefEqArgs tFn t.getAppArgs s.getAppArgs <&&> isListLevelDefEqAux tFn.constLevels! sFn.constLevels!)
   else
-    isDefEqOnFailure t s
+    checkpointDefEq (Meta.isExprDefEqAux tFn s.getAppFn <&&> isDefEqArgs tFn t.getAppArgs s.getAppArgs)
 
 /-- Return `true` if the type of the given expression is an inductive datatype with a single constructor with no fields. -/
 private def isDefEqUnitLike (t : Expr) (s : Expr) : MetaM Bool := do

--- a/src/Lean/Meta/ExprDefEq.lean
+++ b/src/Lean/Meta/ExprDefEq.lean
@@ -2208,13 +2208,23 @@ private def isDefEqUnitLike (t : Expr) (s : Expr) : MetaM Bool := do
   The `whnf` procedure has support for unfolding class projections when the
   transparency mode is set to `.instances` or `.implicit`. This method ensures the
   behavior of `whnf` and `isDefEq` is consistent in those transparency modes.
+
+  A failed comparison of the unfolded terms is conclusive only if neither term contains
+  metavariables: unfolding the class projections removes the shape `getStuckMVar?` needs to
+  detect an unsynthesized instance in an argument, so a failure may just mean that we are stuck.
+  We therefore report it as `.undef` and let `isDefEqOnFailure` inspect the original terms.
 -/
 private def isDefEqProjInst (t : Expr) (s : Expr) : MetaM LBool := do
   unless (← getTransparency) matches .instances | .implicit do return .undef
   let t? ← unfoldProjInstWhenInstances? t
   let s? ← unfoldProjInstWhenInstances? s
   if t?.isSome || s?.isSome then
-    toLBoolM <| Meta.isExprDefEqAux (t?.getD t) (s?.getD s)
+    if !t.hasExprMVar && !s.hasExprMVar then
+      toLBoolM <| Meta.isExprDefEqAux (t?.getD t) (s?.getD s)
+    else if (← checkpointDefEq (Meta.isExprDefEqAux (t?.getD t) (s?.getD s))) then
+      return .true
+    else
+      return .undef
   else
     return .undef
 

--- a/src/Lean/Meta/ExprDefEq.lean
+++ b/src/Lean/Meta/ExprDefEq.lean
@@ -83,15 +83,21 @@ register_builtin_option backward.isDefEq.implicitBump : Bool := {
 }
 
 /--
-When `true`, `isDefEqApp` invokes `isDefEqOnFailure` itself, in addition to the invocation at the
-end of `isExprDefEqExpensive`. This also means that `isDefEqProjInst`, `isDefEqStringLit` and
-`isDefEqUnitLike` run between the two invocations instead of before the single one.
+Controls how a failing comparison of two applications invokes `isDefEqOnFailure`.
+
+**Original behavior (`true`):** once before `isDefEqProjInst`, `isDefEqStringLit` and
+`isDefEqUnitLike`, and once again after them, querying the unification hint discrimination tree
+four times instead of two. A stuck abort raised by the first invocation escapes immediately, so
+the three heuristics in between never run.
+
+**New behavior (`false`, the default):** once, before those heuristics. A stuck abort is deferred
+until they have had their chance, and re-raised if they all decline.
 -/
 register_builtin_option backward.isDefEq.appOnFailure : Bool := {
   defValue := false
   descr    := "if true, run the `isDefEq` failure fallback (stuck-metavariable resolution and \
-  unification hints) once inside `isDefEqApp` and once more at the end of `isExprDefEqExpensive`, \
-  instead of only once"
+  unification hints) both before and after the remaining `isExprDefEqExpensive` heuristics, \
+  instead of only before them"
 }
 
 register_builtin_option trace.Meta.isDefEq.printTransparency : Bool := {
@@ -2174,24 +2180,16 @@ where
 /--
   Given applications `t` and `s` that are in WHNF (modulo the current transparency setting),
   check whether they are definitionally equal or not by comparing functions and arguments.
-  On failure, the caller is responsible for invoking `isDefEqOnFailure`, unless
-  `backward.isDefEq.appOnFailure` is set.
+  On failure, the caller is responsible for invoking `isDefEqOnFailure`.
 -/
 private def isDefEqApp (t s : Expr) : MetaM Bool := do
   let tFn := t.getAppFn
   let sFn := s.getAppFn
-  let result ←
-    if tFn.isConst && sFn.isConst && tFn.constName! == sFn.constName! then
-      /- See comment at `tryHeuristic` explaining why we process arguments before universe levels. -/
-      checkpointDefEq (isDefEqArgs tFn t.getAppArgs s.getAppArgs <&&> isListLevelDefEqAux tFn.constLevels! sFn.constLevels!)
-    else
-      checkpointDefEq (Meta.isExprDefEqAux tFn s.getAppFn <&&> isDefEqArgs tFn t.getAppArgs s.getAppArgs)
-  if result then
-    return true
-  else if backward.isDefEq.appOnFailure.get (← getOptions) then
-    isDefEqOnFailure t s
+  if tFn.isConst && sFn.isConst && tFn.constName! == sFn.constName! then
+    /- See comment at `tryHeuristic` explaining why we process arguments before universe levels. -/
+    checkpointDefEq (isDefEqArgs tFn t.getAppArgs s.getAppArgs <&&> isListLevelDefEqAux tFn.constLevels! sFn.constLevels!)
   else
-    return false
+    checkpointDefEq (Meta.isExprDefEqAux tFn s.getAppFn <&&> isDefEqArgs tFn t.getAppArgs s.getAppArgs)
 
 /-- Return `true` if the type of the given expression is an inductive datatype with a single constructor with no fields. -/
 private def isDefEqUnitLike (t : Expr) (s : Expr) : MetaM Bool := do
@@ -2208,25 +2206,38 @@ private def isDefEqUnitLike (t : Expr) (s : Expr) : MetaM Bool := do
   The `whnf` procedure has support for unfolding class projections when the
   transparency mode is set to `.instances` or `.implicit`. This method ensures the
   behavior of `whnf` and `isDefEq` is consistent in those transparency modes.
-
-  A failed comparison of the unfolded terms is conclusive only if neither term contains
-  metavariables: unfolding the class projections removes the shape `getStuckMVar?` needs to
-  detect an unsynthesized instance in an argument, so a failure may just mean that we are stuck.
-  We therefore report it as `.undef` and let `isDefEqOnFailure` inspect the original terms.
 -/
 private def isDefEqProjInst (t : Expr) (s : Expr) : MetaM LBool := do
   unless (← getTransparency) matches .instances | .implicit do return .undef
   let t? ← unfoldProjInstWhenInstances? t
   let s? ← unfoldProjInstWhenInstances? s
   if t?.isSome || s?.isSome then
-    if !t.hasExprMVar && !s.hasExprMVar then
-      toLBoolM <| Meta.isExprDefEqAux (t?.getD t) (s?.getD s)
-    else if (← checkpointDefEq (Meta.isExprDefEqAux (t?.getD t) (s?.getD s))) then
-      return .true
-    else
-      return .undef
+    toLBoolM <| Meta.isExprDefEqAux (t?.getD t) (s?.getD s)
   else
     return .undef
+
+/--
+Remaining heuristics for a failing comparison of two applications.
+
+`isDefEqOnFailure` runs before `isDefEqProjInst`, `isDefEqStringLit` and `isDefEqUnitLike` because
+those unfold the class projections that `getStuckMVar?` needs to see an unsynthesized instance in
+an argument position. A stuck abort is not authoritative here — one of the three may still close
+the goal — so it is deferred and re-raised only if they all decline.
+-/
+private def isDefEqAppOnFailure (t : Expr) (s : Expr) : MetaM Bool := do
+  let saved ← saveState
+  -- `none` records a deferred `isDefEqStuck`
+  let r? ← catchInternalId isDefEqStuckExceptionId (some <$> isDefEqOnFailure t s) fun _ => do
+    saved.restore
+    return none
+  if r? == some true then return true
+  if (← whenUndefDo (isDefEqProjInst t s) do
+        whenUndefDo (isDefEqStringLit t s) do
+        isDefEqUnitLike t s) then
+    return true
+  if r?.isNone then
+    Meta.throwIsDefEqStuck
+  return false
 
 private def isExprDefEqExpensive (t : Expr) (s : Expr) : MetaM Bool := do
   whenUndefDo (isDefEqEta t s) do
@@ -2249,8 +2260,16 @@ private def isExprDefEqExpensive (t : Expr) (s : Expr) : MetaM Bool := do
       return true
     if t.isConst && s.isConst then
       if t.constName! == s.constName! then isListLevelDefEqAux t.constLevels! s.constLevels! else return false
-    else if (← pure t.isApp <&&> pure s.isApp <&&> isDefEqApp t s) then
-      return true
+    else if (← pure t.isApp <&&> pure s.isApp) then
+      if (← isDefEqApp t s) then return true
+      if backward.isDefEq.appOnFailure.get (← getOptions) then
+        if (← isDefEqOnFailure t s) then return true
+        whenUndefDo (isDefEqProjInst t s) do
+        whenUndefDo (isDefEqStringLit t s) do
+        if (← isDefEqUnitLike t s) then return true else
+        isDefEqOnFailure t s
+      else
+        isDefEqAppOnFailure t s
     else
       whenUndefDo (isDefEqProjInst t s) do
       whenUndefDo (isDefEqStringLit t s) do

--- a/src/Lean/Meta/ExprDefEq.lean
+++ b/src/Lean/Meta/ExprDefEq.lean
@@ -82,6 +82,18 @@ register_builtin_option backward.isDefEq.implicitBump : Bool := {
   not just instance-implicit ones"
 }
 
+/--
+When `true`, `isDefEqApp` invokes `isDefEqOnFailure` itself, in addition to the invocation at the
+end of `isExprDefEqExpensive`. This also means that `isDefEqProjInst`, `isDefEqStringLit` and
+`isDefEqUnitLike` run between the two invocations instead of before the single one.
+-/
+register_builtin_option backward.isDefEq.appOnFailure : Bool := {
+  defValue := false
+  descr    := "if true, run the `isDefEq` failure fallback (stuck-metavariable resolution and \
+  unification hints) once inside `isDefEqApp` and once more at the end of `isExprDefEqExpensive`, \
+  instead of only once"
+}
+
 register_builtin_option trace.Meta.isDefEq.printTransparency : Bool := {
   defValue := false
   descr    := "if true, prefix `Meta.isDefEq` `=?=` trace messages with the current transparency level"
@@ -2162,16 +2174,24 @@ where
 /--
   Given applications `t` and `s` that are in WHNF (modulo the current transparency setting),
   check whether they are definitionally equal or not by comparing functions and arguments.
-  On failure, the caller is responsible for invoking `isDefEqOnFailure`.
+  On failure, the caller is responsible for invoking `isDefEqOnFailure`, unless
+  `backward.isDefEq.appOnFailure` is set.
 -/
 private def isDefEqApp (t s : Expr) : MetaM Bool := do
   let tFn := t.getAppFn
   let sFn := s.getAppFn
-  if tFn.isConst && sFn.isConst && tFn.constName! == sFn.constName! then
-    /- See comment at `tryHeuristic` explaining why we process arguments before universe levels. -/
-    checkpointDefEq (isDefEqArgs tFn t.getAppArgs s.getAppArgs <&&> isListLevelDefEqAux tFn.constLevels! sFn.constLevels!)
+  let result ←
+    if tFn.isConst && sFn.isConst && tFn.constName! == sFn.constName! then
+      /- See comment at `tryHeuristic` explaining why we process arguments before universe levels. -/
+      checkpointDefEq (isDefEqArgs tFn t.getAppArgs s.getAppArgs <&&> isListLevelDefEqAux tFn.constLevels! sFn.constLevels!)
+    else
+      checkpointDefEq (Meta.isExprDefEqAux tFn s.getAppFn <&&> isDefEqArgs tFn t.getAppArgs s.getAppArgs)
+  if result then
+    return true
+  else if backward.isDefEq.appOnFailure.get (← getOptions) then
+    isDefEqOnFailure t s
   else
-    checkpointDefEq (Meta.isExprDefEqAux tFn s.getAppFn <&&> isDefEqArgs tFn t.getAppArgs s.getAppArgs)
+    return false
 
 /-- Return `true` if the type of the given expression is an inductive datatype with a single constructor with no fields. -/
 private def isDefEqUnitLike (t : Expr) (s : Expr) : MetaM Bool := do

--- a/src/Lean/Meta/ExprDefEq.lean
+++ b/src/Lean/Meta/ExprDefEq.lean
@@ -83,21 +83,20 @@ register_builtin_option backward.isDefEq.implicitBump : Bool := {
 }
 
 /--
-Controls how a failing comparison of two applications invokes `isDefEqOnFailure`.
+Controls what happens if a definitional equality check is stuck on a metavariable after a failing
+comparison of two applications if the `isDefEqStuckEx` setting is enabled (e.g. during instance
+search).
 
-**Original behavior (`true`):** once before `isDefEqProjInst`, `isDefEqStringLit` and
-`isDefEqUnitLike`, and once again after them, querying the unification hint discrimination tree
-four times instead of two. A stuck abort raised by the first invocation escapes immediately, so
-the three heuristics in between never run.
+With the old behavior (`true`), the stuck exception simply bubbles up, aborting the definitional
+equality check. With the new behavior (`false`), Lean first tries to apply the remaining heuristics
+and only throws if those don't help either.
 
-**New behavior (`false`, the default):** once, before those heuristics. A stuck abort is deferred
-until they have had their chance, and re-raised if they all decline.
+Besides being expected to succeed more often, the new behavior is usually faster because it calls
+`isDefEqOnFailure` only once.
 -/
-register_builtin_option backward.isDefEq.appOnFailure : Bool := {
+register_builtin_option backward.isDefEq.throwOnStuckAfterApp : Bool := {
   defValue := false
-  descr    := "if true, run the `isDefEq` failure fallback (stuck-metavariable resolution and \
-  unification hints) both before and after the remaining `isExprDefEqExpensive` heuristics, \
-  instead of only before them"
+  descr    := "if true, immediately throw a stuck exception"
 }
 
 register_builtin_option trace.Meta.isDefEq.printTransparency : Bool := {
@@ -2217,27 +2216,47 @@ private def isDefEqProjInst (t : Expr) (s : Expr) : MetaM LBool := do
     return .undef
 
 /--
-Remaining heuristics for a failing comparison of two applications.
+The special cases tried *after* the main `isExprDefEqExpensive` machinery has failed, as opposed
+to the early ones (`isDefEqNative`, `isDefEqNat`, `isDefEqOffset`).
 
-`isDefEqOnFailure` runs before `isDefEqProjInst`, `isDefEqStringLit` and `isDefEqUnitLike` because
-those unfold the class projections that `getStuckMVar?` needs to see an unsynthesized instance in
-an argument position. A stuck abort is not authoritative here — one of the three may still close
-the goal — so it is deferred and re-raised only if they all decline.
+`.false` means one of them decided the terms are *not* definitionally equal, and must not be read
+as "declined". `.undef` means they all declined — note that `isDefEqUnitLike` returning `false`
+is a decline (the rule does not apply), not a negative verdict, hence `.undef`.
 -/
-private def isDefEqAppOnFailure (t : Expr) (s : Expr) : MetaM Bool := do
-  let saved ← saveState
-  -- `none` records a deferred `isDefEqStuck`
-  let r? ← catchInternalId isDefEqStuckExceptionId (some <$> isDefEqOnFailure t s) fun _ => do
-    saved.restore
-    return none
-  if r? == some true then return true
-  if (← whenUndefDo (isDefEqProjInst t s) do
-        whenUndefDo (isDefEqStringLit t s) do
-        isDefEqUnitLike t s) then
-    return true
-  if r?.isNone then
-    Meta.throwIsDefEqStuck
-  return false
+private def isDefEqLateSpecialCases (t s : Expr) : MetaM LBool := do
+  match (← isDefEqProjInst t s) with
+  | .undef =>
+    match (← isDefEqStringLit t s) with
+    | .undef => return if (← isDefEqUnitLike t s) then .true else .undef
+    | r      => return r
+  | r => return r
+
+/--
+Fallback for a failing comparison of two applications; see `backward.isDefEq.throwOnStuckAfterApp`
+for the two behaviors.
+
+In the new behavior, `isDefEqOnFailure` runs before `isDefEqLateSpecialCases` because those
+unfold the class projections that `getStuckMVar?` needs to see.
+When `isDefEqOnFailure` throws a stuck exception, one of the late special cases may
+still close the goal, so the exception is suppressed and re-thrown only if the special cases don't
+succeed.
+-/
+private def isDefEqAppFallback (t : Expr) (s : Expr) : MetaM Bool := do
+  if backward.isDefEq.throwOnStuckAfterApp.get (← getOptions) then
+    if (← isDefEqOnFailure t s) then return true
+    whenUndefDo (isDefEqLateSpecialCases t s) do
+    isDefEqOnFailure t s
+  else
+    let saved ← saveState
+    -- `none` records a deferred `isDefEqStuck`
+    let r? ← catchInternalId isDefEqStuckExceptionId (some <$> isDefEqOnFailure t s) fun _ => do
+      saved.restore
+      return none
+    if r? == some true then return true
+    if (← isDefEqLateSpecialCases t s) matches .true then return true
+    if r?.isNone then
+      Meta.throwIsDefEqStuck
+    return false
 
 private def isExprDefEqExpensive (t : Expr) (s : Expr) : MetaM Bool := do
   whenUndefDo (isDefEqEta t s) do
@@ -2262,18 +2281,9 @@ private def isExprDefEqExpensive (t : Expr) (s : Expr) : MetaM Bool := do
       if t.constName! == s.constName! then isListLevelDefEqAux t.constLevels! s.constLevels! else return false
     else if (← pure t.isApp <&&> pure s.isApp) then
       if (← isDefEqApp t s) then return true
-      if backward.isDefEq.appOnFailure.get (← getOptions) then
-        if (← isDefEqOnFailure t s) then return true
-        whenUndefDo (isDefEqProjInst t s) do
-        whenUndefDo (isDefEqStringLit t s) do
-        if (← isDefEqUnitLike t s) then return true else
-        isDefEqOnFailure t s
-      else
-        isDefEqAppOnFailure t s
+      isDefEqAppFallback t s
     else
-      whenUndefDo (isDefEqProjInst t s) do
-      whenUndefDo (isDefEqStringLit t s) do
-      if (← isDefEqUnitLike t s) then return true else
+      whenUndefDo (isDefEqLateSpecialCases t s) do
       isDefEqOnFailure t s
 
 inductive DefEqCacheKind where

--- a/tests/elab/isDefEqCheckAssignmentBug.lean.out.expected
+++ b/tests/elab/isDefEqCheckAssignmentBug.lean.out.expected
@@ -28,10 +28,6 @@
         [Meta.isDefEq.onFailure] ❌️ ReaderT Elab.Command.Context
               (StateRefT' IO.RealWorld Elab.Command.State
                 (EIO Exception)) =?= ReaderT Context (StateRefT' IO.RealWorld State CoreM)
-        [Meta.isDefEq.onFailure] ❌️ ReaderT Elab.Command.Context
-              (StateRefT' IO.RealWorld Elab.Command.State
-                (EIO Exception)) =?= ReaderT Context (StateRefT' IO.RealWorld State CoreM)
-  [Meta.isDefEq.onFailure] ❌️ MonadEvalT MetaM Elab.Command.CommandElabM =?= MonadEvalT ?m ?m
   [Meta.isDefEq.onFailure] ❌️ MonadEvalT MetaM Elab.Command.CommandElabM =?= MonadEvalT ?m ?m
 [Meta.isDefEq] ✅️ MonadEvalT MetaM Elab.Command.CommandElabM =?= MonadEvalT ?m ?m
   [Meta.isDefEq] ✅️ MetaM =?= ?m
@@ -78,9 +74,6 @@
         [Meta.isDefEq] ❌️ Elab.Term.Context =?= Context
         [Meta.isDefEq.onFailure] ❌️ ReaderT Elab.Term.Context
               (StateRefT' IO.RealWorld Elab.Term.State MetaM) =?= ReaderT Context (StateRefT' IO.RealWorld State CoreM)
-        [Meta.isDefEq.onFailure] ❌️ ReaderT Elab.Term.Context
-              (StateRefT' IO.RealWorld Elab.Term.State MetaM) =?= ReaderT Context (StateRefT' IO.RealWorld State CoreM)
-  [Meta.isDefEq.onFailure] ❌️ MonadEvalT MetaM Elab.TermElabM =?= MonadEvalT ?m ?m
   [Meta.isDefEq.onFailure] ❌️ MonadEvalT MetaM Elab.TermElabM =?= MonadEvalT ?m ?m
 [Meta.isDefEq] ✅️ MonadEvalT MetaM Elab.TermElabM =?= MonadEvalT ?m ?m
   [Meta.isDefEq] ✅️ MetaM =?= ?m
@@ -183,10 +176,6 @@
                 [Meta.isDefEq.onFailure] ❌️ ST.Ref IO.RealWorld Elab.Term.State =?= Context
               [Meta.isDefEq.onFailure] ❌️ ReaderT (ST.Ref IO.RealWorld Elab.Term.State) MetaM
                     α =?= ReaderT Context (StateRefT' IO.RealWorld State CoreM) α
-              [Meta.isDefEq.onFailure] ❌️ ReaderT (ST.Ref IO.RealWorld Elab.Term.State) MetaM
-                    α =?= ReaderT Context (StateRefT' IO.RealWorld State CoreM) α
-  [Meta.isDefEq.onFailure] ❌️ MonadEvalT MetaM
-        (StateRefT' IO.RealWorld Elab.Term.State MetaM) =?= MonadEvalT ?m ?m
   [Meta.isDefEq.onFailure] ❌️ MonadEvalT MetaM
         (StateRefT' IO.RealWorld Elab.Term.State MetaM) =?= MonadEvalT ?m ?m
 [Meta.isDefEq] ✅️ MonadEvalT MetaM (StateRefT' IO.RealWorld Elab.Term.State MetaM) =?= MonadEvalT ?m ?m


### PR DESCRIPTION
This PR changes definitional equality and unification heuristics. Before `isDefEqApp`'s fallback throws a stuck exception, it tries the remaining few heuristics, and only if they don't succeed, the exception is thrown. This PR at the same time improves performance and robustness of unification and instance search. This change is a preparation for #14624. The backward compatibility flag `set_option backward.isDefEq.throwOnStuckAfterApp true` restores the old behavior.

Old behavior:
`isExprDefEqExpensive` ends with a speculative congruence check (`isDefEqApp`) followed by three heuristics.

```lean
    if t.isConst && s.isConst then
      if t.constName! == s.constName! then isListLevelDefEqAux t.constLevels! s.constLevels! else return false
    else if (← pure t.isApp <&&> pure s.isApp <&&> isDefEqApp t s) then
      return true
    else
      whenUndefDo (isDefEqProjInst t s) do
      whenUndefDo (isDefEqStringLit t s) do
      if (← isDefEqUnitLike t s) then return true else
      isDefEqOnFailure t s
```

When `isDefEqApp`'s congruence check fails, it also calls `isDefEqOnFailure` internally.
The latter function, among other things, looks for stuck metavariables and tries to get them unstuck by synthesizing them. If that fails, `isDefEqOnFailure` usually just returns `false`, but during instance search, Lean instead throws a stuck exception.
Because `isDefEqOnFailure` is already called at the end of `isDefEqApp`, a stuck exception can interrupt the defeq logic before the last three heuristics have been tried.

New behavior:
1. Potential stuck exceptions from the early `isDefEqOnFailure` are only caught and only re-thrown if the remaining three heuristics do not succeed in unifying the two expressions. This change makes it more likely that `isExprDefEqExpensive` succeeds without a stuck exception.
2. The tail-call `isDefEqOnFailure` is removed. This change is *not* fully behavior-preserving either: The previous failed heuristics (the early `isDefEqOnFailure`, `isDefEqUnitLike`, ...) could have made progress by assigning metavariables, so that the second call to `isDefEqOnFailure` might succeed/throw where the first did not. However, no breakage in Mathlib was observed, and it is hard to conceive that depending on progress from failed checks would be a good idea.

Consequences:
1. No breakage observed downstream.
2. This change is a preparation for #14624, addressing an issue where a `HMul.hMul x y =?= Mul.mul x y` check failed because an early stuck exception prevented the `isDefEqProjInst` heuristic. The linked PR contains a test case for this issue.
3. Clear performance improvement, probably caused by the removal of the second, quasi-redundant `isDefEqOnFailure`.