### PR TITLE
chore: warn about visibility on unnamed initializers

### DIFF
--- a/src/Lean/Elab/Declaration.lean
+++ b/src/Lean/Elab/Declaration.lean
@@ -362,7 +362,7 @@ def elabMutual : CommandElab := fun stx => do
       let `(Parser.Command.declModifiersT| $[$doc?:docComment]? $[@[$attrs?,*]]? $(vis?)? $[meta%$meta?]? $[unsafe%$unsafe?]?) := declModifiers
         | throwErrorAt declModifiers "invalid initialization command, unexpected modifiers"
       if let some vis := vis? then
-        throwErrorAt vis "visibility modifiers have no effect on unnamed initialize blocks"
+        logWarningAt vis "visibility modifiers have no effect on unnamed initialize blocks"
       let attrs := (attrs?.map (·.getElems)).getD #[]
       let attrs := attrs.push (← `(Lean.Parser.Term.attrInstance| $attrId:ident))
       elabCommand (← `($[$doc?:docComment]? @[no_expose, $[$attrs],*] private $[meta%$meta?]? $[unsafe%$unsafe?]? def initFn : IO Unit := do $doSeq))

--- a/src/Lean/Elab/Declaration.lean
+++ b/src/Lean/Elab/Declaration.lean
@@ -359,8 +359,10 @@ def elabMutual : CommandElab := fun stx => do
         @[no_expose] private $[meta%$meta?]? $[unsafe%$unsafe?]? def initFn : IO $type := with_decl_name% $(mkIdent fullId) do $doSeq
         $defStx:command))
     else
-      let `(Parser.Command.declModifiersT| $[$doc?:docComment]? $[@[$attrs?,*]]? $(_)? $[meta%$meta?]? $[unsafe%$unsafe?]?) := declModifiers
+      let `(Parser.Command.declModifiersT| $[$doc?:docComment]? $[@[$attrs?,*]]? $(vis?)? $[meta%$meta?]? $[unsafe%$unsafe?]?) := declModifiers
         | throwErrorAt declModifiers "invalid initialization command, unexpected modifiers"
+      if let some vis := vis? then
+        throwErrorAt vis "visibility modifiers have no effect on unnamed initialize blocks"
       let attrs := (attrs?.map (·.getElems)).getD #[]
       let attrs := attrs.push (← `(Lean.Parser.Term.attrInstance| $attrId:ident))
       elabCommand (← `($[$doc?:docComment]? @[no_expose, $[$attrs],*] private $[meta%$meta?]? $[unsafe%$unsafe?]? def initFn : IO Unit := do $doSeq))

--- a/src/Lean/Elab/InheritDoc.lean
+++ b/src/Lean/Elab/InheritDoc.lean
@@ -17,7 +17,7 @@ Uses documentation from a specified declaration.
 `@[inherit_doc decl]` is used to inherit the documentation from the declaration `decl`.
 -/
 @[builtin_doc]
-public builtin_initialize
+builtin_initialize
   registerBuiltinAttribute {
     name := `inherit_doc
     descr := "inherit documentation from a specified declaration"

--- a/src/lake/Lake/DSL/Attributes.lean
+++ b/src/lake/Lake/DSL/Attributes.lean
@@ -12,7 +12,7 @@ open Lean
 
 namespace Lake
 
-public builtin_initialize
+builtin_initialize
   registerBuiltinAttribute {
     ref             := by exact decl_name%
     name            := `test_runner

--- a/tests/pkg/user_attr/UserAttr/BlaAttr.lean
+++ b/tests/pkg/user_attr/UserAttr/BlaAttr.lean
@@ -26,7 +26,7 @@ public meta initialize fooAttr : ParametricAttribute (Nat × Bool) ←
 
 syntax (name := trace_add) "trace_add" : attr
 
-public meta initialize registerBuiltinAttribute {
+meta initialize registerBuiltinAttribute {
   name := `trace_add
   descr := "Simply traces when added, to debug double-application bugs"
   add   := fun decl _stx _kind => do
@@ -35,7 +35,7 @@ public meta initialize registerBuiltinAttribute {
 }
 
 syntax (name := myattr_beforeElaboration) "myattr_beforeElaboration" : attr
-public meta initialize registerBuiltinAttribute {
+meta initialize registerBuiltinAttribute {
   name := `myattr_beforeElaboration
   descr := "Simply traces when added, to debug application bugs"
   add decl _ _ := do
@@ -44,7 +44,7 @@ public meta initialize registerBuiltinAttribute {
   applicationTime := .beforeElaboration
 }
 syntax (name := myattr_afterTypeChecking) "myattr_afterTypeChecking" : attr
-public meta initialize registerBuiltinAttribute {
+meta initialize registerBuiltinAttribute {
   name := `myattr_afterTypeChecking
   descr := "Simply traces when added, to debug application bugs"
   add decl _ _ := do
@@ -53,7 +53,7 @@ public meta initialize registerBuiltinAttribute {
   applicationTime := .afterTypeChecking
 }
 syntax (name := myattr_afterCompilation) "myattr_afterCompilation" : attr
-public meta initialize registerBuiltinAttribute {
+meta initialize registerBuiltinAttribute {
   name := `myattr_afterCompilation
   descr := "Simply traces when added, to debug application bugs"
   add decl _ _ := do


### PR DESCRIPTION
This PR warns about `public/private` visibility modifiers on unnamed `initialize` blocks - they do not do anything which can be confusing.