### PR TITLE
chore: simplify `bif` to `if`

### DIFF
--- a/src/Init/Data/Array/Lemmas.lean
+++ b/src/Init/Data/Array/Lemmas.lean
@@ -1488,7 +1488,7 @@ theorem filter_map {f : β → α} {xs : Array β} : filter p (map f xs) = map f
   simp [List.filter_map]
 
 theorem map_filter_eq_foldl {f : α → β} {p : α → Bool} {xs : Array α} :
-    map f (filter p xs) = foldl (fun acc x => bif p x then acc.push (f x) else acc) #[] xs := by
+    map f (filter p xs) = foldl (fun acc x => if p x then acc.push (f x) else acc) #[] xs := by
   rcases xs with ⟨xs⟩
   apply ext'
   simp only [List.size_toArray, List.filter_toArray', List.map_toArray, List.foldl_toArray']

--- a/src/Init/Data/Array/Monadic.lean
+++ b/src/Init/Data/Array/Monadic.lean
@@ -284,9 +284,9 @@ namespace List
   | cons x xs ih =>
     congr; funext b
     cases b
-    · simp only [Bool.false_eq_true, ↓reduceIte, pure_bind, cond_false]
+    · simp only [Bool.false_eq_true, ↓reduceIte, pure_bind]
       exact ih acc
-    · simp only [↓reduceIte, ← reverse_cons, pure_bind, cond_true]
+    · simp only [↓reduceIte, ← reverse_cons, pure_bind]
       exact ih (x :: acc)
 
 /-- Variant of `filterM_toArray` with a side condition for the stop position. -/

--- a/src/Init/Data/BitVec/Lemmas.lean
+++ b/src/Init/Data/BitVec/Lemmas.lean
@@ -5016,8 +5016,8 @@ theorem getLsbD_rotateLeftAux_of_ge {x : BitVec w} {r : Nat} {i : Nat} (hi : i �
 /-- When `r < w`, we give a formula for `(x.rotateLeft r).getLsbD i`. -/
 theorem getLsbD_rotateLeft_of_le {x : BitVec w} {r i : Nat} (hr: r < w) :
     (x.rotateLeft r).getLsbD i =
-      cond (i < r)
-      (x.getLsbD (w - r + i))
+      if i < r then
+      (x.getLsbD (w - r + i)) else
       (decide (i < w) && x.getLsbD (i - r)) := by
   · rw [rotateLeft_eq_rotateLeftAux_of_lt hr]
     by_cases h : i < r
@@ -5027,8 +5027,8 @@ theorem getLsbD_rotateLeft_of_le {x : BitVec w} {r i : Nat} (hr: r < w) :
 @[simp, grind =]
 theorem getLsbD_rotateLeft {x : BitVec w} {r i : Nat}  :
     (x.rotateLeft r).getLsbD i =
-      cond (i < r % w)
-      (x.getLsbD (w - (r % w) + i))
+      if i < r % w then
+      (x.getLsbD (w - (r % w) + i)) else
       (decide (i < w) && x.getLsbD (i - (r % w))) := by
   rcases w with ⟨rfl, w⟩
   · simp
@@ -5184,8 +5184,8 @@ theorem rotateRight_mod_eq_rotateRight {x : BitVec w} {r : Nat} :
 /-- When `r < w`, we give a formula for `(x.rotateRight r).getLsb i`. -/
 theorem getLsbD_rotateRight_of_lt {x : BitVec w} {r i : Nat} (hr: r < w) :
     (x.rotateRight r).getLsbD i =
-      cond (i < w - r)
-      (x.getLsbD (r + i))
+      if i < w - r then
+      (x.getLsbD (r + i)) else
       (decide (i < w) && x.getLsbD (i - (w - r))) := by
   · rw [rotateRight_eq_rotateRightAux_of_lt hr]
     by_cases h : i < w - r
@@ -5195,8 +5195,8 @@ theorem getLsbD_rotateRight_of_lt {x : BitVec w} {r i : Nat} (hr: r < w) :
 @[simp, grind =]
 theorem getLsbD_rotateRight {x : BitVec w} {r i : Nat} :
     (x.rotateRight r).getLsbD i =
-      cond (i < w - (r % w))
-      (x.getLsbD ((r % w) + i))
+      if i < w - (r % w) then
+      (x.getLsbD ((r % w) + i)) else
       (decide (i < w) && x.getLsbD (i - (w - (r % w)))) := by
   rcases w with ⟨rfl, w⟩
   · simp

--- a/src/Init/Data/BitVec/Lemmas.lean
+++ b/src/Init/Data/BitVec/Lemmas.lean
@@ -455,7 +455,7 @@ theorem getElem?_succ_ofBool (b : Bool) (i : Nat) : (ofBool b)[i + 1]? = none :=
 theorem getLsbD_ofBool (b : Bool) (i : Nat) : (ofBool b).getLsbD i = ((i = 0) && b) := by
   rcases b with rfl | rfl
   · simp [ofBool]
-  · simp only [ofBool, ofNat_eq_ofNat, cond_true, getLsbD_ofNat, Bool.and_true]
+  · simp only [ofBool, ofNat_eq_ofNat, Bool.cond_true, getLsbD_ofNat, Bool.and_true]
     by_cases hi : i = 0 <;> simp [hi] <;> omega
 
 @[simp]

--- a/src/Init/Data/Bool.lean
+++ b/src/Init/Data/Bool.lean
@@ -526,21 +526,24 @@ theorem exists_bool {p : Bool → Prop} : (∃ b, p b) ↔ p false ∨ p true :=
 
 /-! ### cond -/
 
+theorem cond_true  {α : Sort u} {a b : α} : cond true  a b = a := rfl
+theorem cond_false {α : Sort u} {a b : α} : cond false a b = b := rfl
+
+@[simp]
 theorem cond_eq_ite {α} (b : Bool) (t e : α) : cond b t e = if b then t else e := by
-  cases b <;> simp
+  cases b <;> simp [Bool.cond_true, Bool.cond_false]
 
 @[deprecated cond_eq_ite (since := "2025-10-29")]
 theorem cond_eq_if : (bif b then x else y) = (if b then x else y) := cond_eq_ite b x y
 
-@[simp] theorem cond_not (b : Bool) (t e : α) : cond (!b) t e = cond b e t := by
+theorem cond_not (b : Bool) (t e : α) : cond (!b) t e = cond b e t := by
   cases b <;> rfl
 
-@[simp] theorem cond_self (c : Bool) (t : α) : cond c t t = t := by cases c <;> rfl
+theorem cond_self (c : Bool) (t : α) : cond c t t = t := by simp
 
-/-- If the return values are propositions, there is no harm in simplifying a `bif` to an `if`. -/
-@[simp] theorem cond_prop {b : Bool} {p q : Prop} :
+theorem cond_prop {b : Bool} {p q : Prop} :
     (bif b then p else q) ↔ if b then p else q := by
-  cases b <;> simp
+  simp
 
 /-
 This is a simp rule in Mathlib, but results in non-confluence that is difficult
@@ -557,48 +560,51 @@ operations like `cond` to a mix of `Prop` and `Bool`.
 -/
 theorem cond_decide {α} (p : Prop) [Decidable p] (t e : α) :
     cond (decide p) t e = if p then t else e := by
-  simp [cond_eq_ite]
+  simp
 
-@[simp] theorem cond_eq_ite_iff {a : Bool} {p : Prop} [h : Decidable p] {x y u v : α} :
-  (cond a x y = ite p u v) ↔ ite a x y = ite p u v := by
-  simp [Bool.cond_eq_ite]
+theorem cond_eq_ite_iff {a : Bool} {p : Prop} [h : Decidable p] {x y u v : α} :
+    (cond a x y = ite p u v) ↔ ite a x y = ite p u v := by
+  simp
 
-@[simp] theorem ite_eq_cond_iff {p : Prop} {a : Bool} [h : Decidable p] {x y u v : α} :
-  (ite p x y = cond a u v) ↔ ite p x y = ite a u v := by
-  simp [Bool.cond_eq_ite]
+theorem ite_eq_cond_iff {p : Prop} {a : Bool} [h : Decidable p] {x y u v : α} :
+    (ite p x y = cond a u v) ↔ ite p x y = ite a u v := by
+  simp
 
-@[simp] theorem cond_eq_true_distrib : ∀(c t f : Bool),
+theorem cond_eq_true_distrib : ∀(c t f : Bool),
     (cond c t f = true) = ite (c = true) (t = true) (f = true) := by
-  decide
+  simp
 
-@[simp] theorem cond_eq_false_distrib : ∀(c t f : Bool),
-    (cond c t f = false) = ite (c = true) (t = false) (f = false) := by decide
+theorem cond_eq_false_distrib : ∀(c t f : Bool),
+    (cond c t f = false) = ite (c = true) (t = false) (f = false) := by
+  simp
 
-protected theorem cond_true  {α : Sort u} {a b : α} : cond true  a b = a := cond_true  a b
-protected theorem cond_false {α : Sort u} {a b : α} : cond false a b = b := cond_false a b
+@[deprecated Bool.cond_true (since := "2026-07-28")]
+theorem _root_.cond_true (a b : α) : cond true a b = a := rfl
+@[deprecated Bool.cond_false (since := "2026-07-28")]
+theorem _root_.cond_false (a b : α) : cond false a b = b := rfl
 
-@[simp] theorem cond_true_left   : ∀(c f : Bool), cond c true f  = ( c || f) := by decide
-@[simp] theorem cond_false_left  : ∀(c f : Bool), cond c false f = (!c && f) := by decide
-@[simp] theorem cond_true_right  : ∀(c t : Bool), cond c t true  = (!c || t) := by decide
-@[simp] theorem cond_false_right : ∀(c t : Bool), cond c t false = ( c && t) := by decide
+theorem cond_true_left   : ∀(c f : Bool), cond c true f  = ( c || f) := by simp
+theorem cond_false_left  : ∀(c f : Bool), cond c false f = (!c && f) := by simp
+theorem cond_true_right  : ∀(c t : Bool), cond c t true  = (!c || t) := by simp
+theorem cond_false_right : ∀(c t : Bool), cond c t false = ( c && t) := by simp
 
 -- These restore confluence between the above lemmas and `cond_not`.
-@[simp] theorem cond_not_self_left  : ∀ (c b : Bool), cond c (!c) b = (!c && b) := by decide
+theorem cond_not_self_left  : ∀ (c b : Bool), cond c (!c) b = (!c && b) := by simp
 
 @[deprecated Bool.cond_not_self_left (since := "2026-07-21")]
 theorem cond_then_not_self (c : Bool) (b : Bool) : (bif c then !c else b) = (!c && b) := Bool.cond_not_self_left c b
 
-@[simp] theorem cond_not_self_right : ∀ (c b : Bool), cond c b (!c) = (!c || b) := by decide
+theorem cond_not_self_right : ∀ (c b : Bool), cond c b (!c) = (!c || b) := by simp
 
 @[deprecated Bool.cond_not_self_right (since := "2026-07-21")]
 theorem cond_else_not_self (c : Bool) (b : Bool) : (bif c then b else !c) = (!c || b) := Bool.cond_not_self_right c b
 
-@[simp] theorem cond_self_left  : ∀ (c b : Bool), cond c c b = (c || b) := by decide
+theorem cond_self_left  : ∀ (c b : Bool), cond c c b = (c || b) := by simp
 
 @[deprecated Bool.cond_self_left (since := "2026-07-21")]
 theorem cond_then_self (c : Bool) (b : Bool) : (bif c then c else b) = (c || b) := Bool.cond_self_left c b
 
-@[simp] theorem cond_self_right : ∀ (c b : Bool), cond c b c = (c && b) := by decide
+theorem cond_self_right : ∀ (c b : Bool), cond c b c = (c && b) := by simp
 
 @[deprecated Bool.cond_self_right (since := "2026-07-21")]
 theorem cond_else_self (c : Bool) (b : Bool) : (bif c then b else c) = (c && b) := Bool.cond_self_right c b

--- a/src/Init/Data/Int/Linear.lean
+++ b/src/Init/Data/Int/Linear.lean
@@ -497,10 +497,10 @@ theorem Expr.denote_toPoly'_go (ctx : Context) (e : Expr) :
   (toPoly'.go k e p).denote ctx = k * e.denote ctx + p.denote ctx := by
     induction k, e using Expr.toPoly'.go.induct generalizing p with
   | case1 k k' h =>
-    simp only [toPoly'.go, h, cond_true]
+    simp only [toPoly'.go, h, Bool.cond_true]
     simp [eq_of_beq h]
   | case2 k k' h =>
-    simp only [toPoly'.go, h, cond_false]
+    simp only [toPoly'.go, h, Bool.cond_false]
     simp
   | case3 k i => simp [toPoly'.go]
   | case4 k a b iha ihb => simp [toPoly'.go, iha, ihb]
@@ -512,10 +512,10 @@ theorem Expr.denote_toPoly'_go (ctx : Context) (e : Expr) :
     simp only [toPoly'.go, h]
     simp [eq_of_beq h]
   | case7 k a k' h ih =>
-    simp only [toPoly'.go, h, cond_false]
+    simp only [toPoly'.go, h, Bool.cond_false]
     simpa [denote, ← Int.mul_assoc] using ih
   | case9 k a h h ih =>
-    simp only [toPoly'.go, h, cond_false]
+    simp only [toPoly'.go, h, Bool.cond_false]
     simp only [mul_def, denote]
     rw [Int.mul_comm (denote _ _) _]
     simpa [Int.mul_assoc] using ih

--- a/src/Init/Data/List/Basic.lean
+++ b/src/Init/Data/List/Basic.lean
@@ -1575,7 +1575,7 @@ Examples:
 -/
 def eraseP (p : α → Bool) : List α → List α
   | [] => []
-  | a :: l => bif p a then l else a :: eraseP p l
+  | a :: l => if p a then l else a :: eraseP p l
 
 /-! ### eraseIdx -/
 
@@ -1700,7 +1700,7 @@ Examples:
   /-- Auxiliary for `findIdx`: `findIdx.go p l n = findIdx p l + n` -/
   @[specialize] go : List α → Nat → Nat
   | [], n => n
-  | a :: l, n => bif p a then n else go l (n + 1)
+  | a :: l, n => if p a then n else go l (n + 1)
 
 @[simp, grind =] theorem findIdx_nil {p : α → Bool} : [].findIdx p = 0 := rfl
 
@@ -1805,7 +1805,7 @@ Examples:
   /-- Auxiliary for `countP`: `countP.go p l acc = countP p l + acc`. -/
   @[specialize] go : List α → Nat → Nat
   | [], acc => acc
-  | x :: xs, acc => bif p x then go xs (acc + 1) else go xs acc
+  | x :: xs, acc => if p x then go xs (acc + 1) else go xs acc
 
 /-! ### count -/
 

--- a/src/Init/Data/List/Count.lean
+++ b/src/Init/Data/List/Count.lean
@@ -49,9 +49,7 @@ protected theorem countP_go_eq_add {l} : countP.go p l n = n + countP.go p l 0 :
     if h : p hd then simp [h, Nat.add_assoc] else simp [h]
 
 @[simp] theorem countP_cons_of_pos {l} (pa : p a) : countP p (a :: l) = countP p l + 1 := by
-  have : countP.go p (a :: l) 0 = countP.go p l 1 := show cond .. = _ by rw [pa]; rfl
-  unfold countP
-  rw [this, Nat.add_comm, List.countP_go_eq_add]
+  simp [countP, countP.go, pa, List.countP_go_eq_add (n := 1), Nat.add_comm]
 
 @[simp] theorem countP_cons_of_neg {l} (pa : ¬p a) : countP p (a :: l) = countP p l := by
   simp [countP, countP.go, pa]

--- a/src/Init/Data/List/Erase.lean
+++ b/src/Init/Data/List/Erase.lean
@@ -38,7 +38,7 @@ open Nat
 @[simp, grind =] theorem eraseP_nil : [].eraseP p = [] := rfl
 
 @[grind =] theorem eraseP_cons {a : α} {l : List α} :
-    (a :: l).eraseP p = bif p a then l else a :: l.eraseP p := rfl
+    (a :: l).eraseP p = if p a then l else a :: l.eraseP p := rfl
 
 @[simp] theorem eraseP_cons_of_pos {l : List α} {p} (h : p a) : (a :: l).eraseP p = l := by
   simp [eraseP_cons, h]
@@ -55,7 +55,7 @@ theorem eraseP_of_forall_not {l : List α} (h : ∀ a, a ∈ l → ¬p a) : l.er
   induction xs with
   | nil => simp
   | cons x xs ih =>
-    simp only [eraseP_cons, cond_eq_ite]
+    simp only [eraseP_cons]
     split <;> rename_i h
     · simp only [reduceCtorEq, cons.injEq, false_or]
       constructor
@@ -175,8 +175,7 @@ theorem eraseP_filterMap {f : α → Option β} : ∀ {l : List α},
       rw [h, eraseP_cons]
       by_cases w : p b
       · simp [w]
-      · simp only [w, cond_false]
-        rw [filterMap_cons_some h, eraseP_filterMap]
+      · simp [w, filterMap_cons_some h, eraseP_filterMap]
 
 @[grind =]
 theorem eraseP_filter {f : α → Bool} {l : List α} :
@@ -322,6 +321,7 @@ theorem eraseP_eq_eraseIdx {xs : List α} {p : α → Bool} :
     · simp [h]
     · simp only [h]
       rw [ih]
+      simp only [Bool.false_eq_true, ↓reduceIte]
       split <;> simp [*]
 
 /-! ### erase -/
@@ -349,7 +349,6 @@ theorem erase_eq_eraseP' (a : α) (l : List α) : l.erase a = l.eraseP (· == a)
   · simp
   next b t ih =>
     rw [erase_cons, eraseP_cons, ih]
-    if h : b == a then simp [h] else simp [h]
 
 -- The arguments are intentionally explicit.
 theorem erase_eq_eraseP [LawfulBEq α] (a : α) : ∀ (l : List α), l.erase a = l.eraseP (a == ·)

--- a/src/Init/Data/List/Find.lean
+++ b/src/Init/Data/List/Find.lean
@@ -698,7 +698,7 @@ theorem findIdx_append {p : α → Bool} {l₁ l₂ : List α} :
     simp only [findIdx_cons, length_cons, cons_append]
     by_cases h : p x
     · simp [h]
-    · simp only [h, ih, cond_eq_ite, Bool.false_eq_true, ↓reduceIte, add_one_lt_add_one_iff]
+    · simp only [h, ih, Bool.false_eq_true, ↓reduceIte, add_one_lt_add_one_iff]
       split <;> simp [Nat.add_assoc]
 
 theorem IsPrefix.findIdx_le {l₁ l₂ : List α} {p : α → Bool} (h : l₁ <+: l₂) :
@@ -728,7 +728,7 @@ theorem findIdx_le_findIdx {l : List α} {p q : α → Bool} (h : ∀ x ∈ l, p
   induction l with
   | nil => simp
   | cons x xs ih =>
-    simp only [findIdx_cons, cond_eq_ite]
+    simp only [findIdx_cons]
     split
     · simp
     · split
@@ -781,10 +781,10 @@ theorem findIdx?_eq_some_iff_findIdx_eq {xs : List α} {p : α → Bool} {i : Na
   | cons x xs ih =>
     simp only [findIdx?_cons, findIdx_cons]
     split
-    · simp_all [cond_eq_ite]
+    · simp_all
       rintro rfl
       exact zero_lt_succ xs.length
-    · simp_all [cond_eq_ite, and_assoc]
+    · simp_all [and_assoc]
       constructor
       · rintro ⟨a, lt, rfl, rfl⟩
         simp_all [Nat.succ_lt_succ_iff]

--- a/src/Init/Data/List/Find.lean
+++ b/src/Init/Data/List/Find.lean
@@ -555,7 +555,7 @@ where
     | nil => unfold findIdx.go; exact Nat.succ_eq_add_one n
     | cons hd tl =>
       unfold findIdx.go
-      cases p hd <;> simp only [cond_false, cond_true]
+      cases p hd <;> simp only [Bool.false_eq_true, ↓reduceIte]
       exact findIdx_go_succ p tl (n + 1)
 
 @[simp] theorem findIdx_singleton {a : α} {p : α → Bool} : [a].findIdx p = if p a then 0 else 1 := by
@@ -579,7 +579,7 @@ theorem findIdx_lt_length_of_exists {xs : List α} (h : ∃ x ∈ xs, p x) :
   | cons x xs ih =>
     by_cases p x
     · simp_all only [forall_exists_index, and_imp, mem_cons, exists_eq_or_imp, true_or,
-        findIdx_cons, cond_true, length_cons]
+        findIdx_cons, length_cons]
       apply Nat.succ_pos
     · simp_all [findIdx_cons, Nat.succ_lt_succ_iff]
       obtain ⟨x', m', h'⟩ := h
@@ -636,9 +636,9 @@ theorem not_of_lt_findIdx {p : α → Bool} {xs : List α} {i : Nat} (h : i < xs
     have npx : p x = false := by
       apply Bool.eq_false_of_ne_true
       intro y
-      rw [y, cond_true] at h
+      rw [y] at h
       simp at h
-    simp [npx, cond_false] at h
+    simp [npx] at h
     cases i.eq_zero_or_pos with
     | inl e => simpa [e, Fin.zero_eta, get_cons_zero]
     | inr e =>
@@ -1137,7 +1137,7 @@ The lemmas below should be made consistent with those for `findIdx` (and proved 
 
 @[grind =]
 theorem idxOf_cons [BEq α] :
-    (x :: xs : List α).idxOf y = bif x == y then 0 else xs.idxOf y + 1 := by
+    (x :: xs : List α).idxOf y = if x == y then 0 else xs.idxOf y + 1 := by
   dsimp [idxOf]
   simp [findIdx_cons]
 
@@ -1153,10 +1153,10 @@ theorem getElem_idxOf [BEq α] [LawfulBEq α] {x : α} {xs : List α}
   | nil => simp at h
   | cons a l ih =>
     cases hax : a == x with
-    | true => simp only [idxOf_cons, hax, cond_true, getElem_cons_zero]; exact eq_of_beq hax
+    | true => simp only [idxOf_cons, hax]; exact eq_of_beq hax
     | false =>
-      simp only [idxOf_cons, hax, cond_false, getElem_cons_succ]
-      rw [idxOf_cons, hax, cond_false, length_cons] at h
+      simp only [idxOf_cons, hax]
+      rw [idxOf_cons, hax, ite_eq_right (by simp), length_cons] at h
       exact ih (by omega)
 
 @[grind =]
@@ -1174,7 +1174,7 @@ theorem idxOf_eq_length [BEq α] [LawfulBEq α] {l : List α} (h : a ∉ l) : l.
   | nil => rfl
   | cons x xs ih =>
     simp only [mem_cons, not_or] at h
-    simp only [idxOf_cons, cond_eq_ite, beq_iff_eq]
+    simp only [idxOf_cons, beq_iff_eq]
     split <;> simp_all
 
 theorem idxOf_lt_length_of_mem [BEq α] [EquivBEq α] {l : List α} (h : a ∈ l) : l.idxOf a < l.length := by
@@ -1184,7 +1184,7 @@ theorem idxOf_lt_length_of_mem [BEq α] [EquivBEq α] {l : List α} (h : a ∈ l
     simp only [mem_cons] at h
     obtain rfl | h := h
     · simp
-    · simp only [idxOf_cons, cond_eq_ite, length_cons]
+    · simp only [idxOf_cons, length_cons]
       specialize ih h
       split
       · exact zero_lt_succ xs.length

--- a/src/Init/Data/List/Find.lean
+++ b/src/Init/Data/List/Find.lean
@@ -544,7 +544,7 @@ private theorem findIdx?_go_eq {p : α → Bool} {xs : List α} {i : Nat} :
 
 @[grind =]
 theorem findIdx_cons {p : α → Bool} {b : α} {l : List α} :
-    (b :: l).findIdx p = bif p b then 0 else (l.findIdx p) + 1 := by
+    (b :: l).findIdx p = if p b then 0 else (l.findIdx p) + 1 := by
   cases H : p b with
   | true => simp [H, findIdx, findIdx.go]
   | false => simp [H, findIdx, findIdx.go, findIdx_go_succ]
@@ -596,7 +596,6 @@ theorem findIdx_eq_length {p : α → Bool} {xs : List α} :
   | nil => simp_all
   | cons x xs ih =>
     rw [findIdx_cons, length_cons]
-    simp only [cond_eq_ite]
     split <;> simp_all
 
 theorem findIdx_eq_length_of_false {p : α → Bool} {xs : List α} (h : ∀ x ∈ xs, p x = false) :

--- a/src/Init/Data/List/Lemmas.lean
+++ b/src/Init/Data/List/Lemmas.lean
@@ -1374,7 +1374,7 @@ theorem foldr_filter {p : α → Bool} {f : α → β → β} {l : List α} {ini
   | cons a l IH => by_cases h : p (f a) <;> simp [*]
 
 theorem map_filter_eq_foldr {f : α → β} {p : α → Bool} {as : List α} :
-    map f (filter p as) = foldr (fun a bs => bif p a then f a :: bs else bs) [] as := by
+    map f (filter p as) = foldr (fun a bs => if p a then f a :: bs else bs) [] as := by
   induction as with
   | nil => rfl
   | cons head _ ih =>

--- a/src/Init/Data/List/Nat/Pairwise.lean
+++ b/src/Init/Data/List/Nat/Pairwise.lean
@@ -97,7 +97,7 @@ theorem Nodup.idxOf_getElem [BEq α] [LawfulBEq α] {xs : List α} (H : Nodup xs
       have hne : (a == l[j]) = false := by
         rw [beq_eq_false_iff_ne]
         exact fun hc => H.1 (hc ▸ getElem_mem hj)
-      rw [getElem_cons_succ, idxOf_cons, hne, cond_false, ih H.2 j hj]
+      simp [getElem_cons_succ, idxOf_cons, hne, ih H.2 j hj]
 
 grind_pattern Nodup.idxOf_getElem => Nodup xs, idxOf (xs[i]'h) xs
 

--- a/src/Init/Data/List/Nat/TakeDrop.lean
+++ b/src/Init/Data/List/Nat/TakeDrop.lean
@@ -512,7 +512,7 @@ theorem false_of_mem_take_findIdx {xs : List α} {p : α → Bool} (h : x ∈ xs
   | cons x xs ih =>
     cases i
     · simp
-    · simp only [take_succ_cons, findIdx_cons, ih, cond_eq_ite]
+    · simp only [take_succ_cons, findIdx_cons, ih]
       split
       · simp
       · rw [Nat.add_min_add_right]
@@ -522,7 +522,7 @@ theorem false_of_mem_take_findIdx {xs : List α} {p : α → Bool} (h : x ∈ xs
   induction xs with
   | nil => simp
   | cons x xs ih =>
-    simp [findIdx_cons, cond_eq_ite]
+    simp [findIdx_cons]
     split <;> split <;> simp_all [Nat.add_min_add_right]
 
 /-! ### findIdx? -/
@@ -546,7 +546,7 @@ theorem takeWhile_eq_take_findIdx_not {xs : List α} {p : α → Bool} :
   induction xs with
   | nil => simp
   | cons x xs ih =>
-    simp only [takeWhile_cons, ih, findIdx_cons, cond_eq_ite, Bool.not_eq_eq_eq_not, Bool.not_true]
+    simp only [takeWhile_cons, ih, findIdx_cons, Bool.not_eq_eq_eq_not, Bool.not_true]
     split <;> simp_all
 
 theorem dropWhile_eq_drop_findIdx_not {xs : List α} {p : α → Bool} :
@@ -554,7 +554,7 @@ theorem dropWhile_eq_drop_findIdx_not {xs : List α} {p : α → Bool} :
   induction xs with
   | nil => simp
   | cons x xs ih =>
-    simp only [dropWhile_cons, ih, findIdx_cons, cond_eq_ite, Bool.not_eq_eq_eq_not, Bool.not_true]
+    simp only [dropWhile_cons, ih, findIdx_cons, Bool.not_eq_eq_eq_not, Bool.not_true]
     split <;> simp_all
 
 /-! ### rotateLeft -/

--- a/src/Init/Data/List/SplitOn/Basic.lean
+++ b/src/Init/Data/List/SplitOn/Basic.lean
@@ -45,7 +45,7 @@ noncomputable def splitOnP.go (p : α → Bool) (l acc : List α) : List (List �
 def splitOnPTR (p : α → Bool) (l : List α) : List (List α) := go l #[] #[] where
   @[specialize] go : List α → Array α → Array (List α) → List (List α)
   | [], acc, r => r.toListAppend [acc.toList]
-  | a :: t, acc, r => bif p a then go t #[] (r.push acc.toList) else go t (acc.push a) r
+  | a :: t, acc, r => if p a then go t #[] (r.push acc.toList) else go t (acc.push a) r
 
 @[csimp] theorem splitOnP_eq_splitOnPTR : @splitOnP = @splitOnPTR := by
   funext α P l

--- a/src/Init/Data/Nat/Internal/Linear.lean
+++ b/src/Init/Data/Nat/Internal/Linear.lean
@@ -10,6 +10,7 @@ public import Init.Data.RArray
 import Init.LawfulBEqTactics
 import Init.ByCases
 import Init.Data.Prod
+import Init.Data.Bool
 
 public section
 
@@ -218,9 +219,9 @@ theorem Poly.denote_insert (ctx : Context) (k : Nat) (v : Var) (p : Poly) :
     by_cases h₁ : Nat.blt v v'
     · simp [h₁]
     · by_cases h₂ : Nat.beq v v'
-      · simp only [insert, h₁, h₂, cond_false, cond_true]
+      · simp only [insert, h₁, h₂, Bool.cond_false, Bool.cond_true]
         simp [Nat.eq_of_beq_eq_true h₂]
-      · simp only [insert, h₁, h₂, cond_false]
+      · simp only [insert, h₁, h₂, Bool.cond_false]
         simp [denote_insert]
 
 attribute [local simp] Poly.denote_insert
@@ -269,12 +270,12 @@ theorem Poly.denote_eq_cancelAux (ctx : Context) (fuel : Nat) (m₁ m₂ r₁ r�
     simp
     split <;> try (simp at h; try assumption)
     rename_i k₁ v₁ m₁ k₂ v₂ m₂
-    by_cases hltv : Nat.blt v₁ v₂ <;> simp [hltv]
+    by_cases hltv : Nat.blt v₁ v₂ <;> simp [Nat.blt_eq ▸ hltv]
     · apply ih; simp [denote_eq] at h |-; assumption
-    · by_cases hgtv : Nat.blt v₂ v₁ <;> simp [hgtv]
+    · by_cases hgtv : Nat.blt v₂ v₁ <;> simp [Nat.blt_eq ▸ hgtv]
       · apply ih; simp [denote_eq] at h |-; assumption
       · have heqv : v₁ = v₂ := eq_of_not_blt_eq_true hltv hgtv; subst heqv
-        by_cases hltk : Nat.blt k₁ k₂ <;> simp [hltk]
+        by_cases hltk : Nat.blt k₁ k₂ <;> simp [Nat.blt_eq ▸ hltk]
         · apply ih
           simp [denote_eq] at h |-
           have haux : k₁ * Var.denote ctx v₁ ≤ k₂ * Var.denote ctx v₁ := Nat.mul_le_mul_right _ (Nat.le_of_lt (Nat.blt_eq.mp hltk))
@@ -282,7 +283,7 @@ theorem Poly.denote_eq_cancelAux (ctx : Context) (fuel : Nat) (m₁ m₂ r₁ r�
           apply Eq.symm
           apply Nat.sub_eq_of_eq_add
           simp [h]
-        · by_cases hgtk : Nat.blt k₂ k₁ <;> simp [hgtk]
+        · by_cases hgtk : Nat.blt k₂ k₁ <;> simp [Nat.blt_eq ▸ hgtk]
           · apply ih
             simp [denote_eq] at h |-
             have haux : k₂ * Var.denote ctx v₁ ≤ k₁ * Var.denote ctx v₁ := Nat.mul_le_mul_right _ (Nat.le_of_lt (Nat.blt_eq.mp hgtk))
@@ -303,19 +304,19 @@ theorem Poly.of_denote_eq_cancelAux (ctx : Context) (fuel : Nat) (m₁ m₂ r₁
     simp at h
     split at h <;> (try simp; assumption)
     rename_i k₁ v₁ m₁ k₂ v₂ m₂
-    by_cases hltv : Nat.blt v₁ v₂ <;> simp [hltv] at h
+    by_cases hltv : Nat.blt v₁ v₂ <;> simp [Nat.blt_eq ▸ hltv] at h
     · have ih := ih (h := h); simp [denote_eq] at ih ⊢; assumption
-    · by_cases hgtv : Nat.blt v₂ v₁ <;> simp [hgtv] at h
+    · by_cases hgtv : Nat.blt v₂ v₁ <;> simp [Nat.blt_eq ▸ hgtv] at h
       · have ih := ih (h := h); simp [denote_eq] at ih ⊢; assumption
       · have heqv : v₁ = v₂ := eq_of_not_blt_eq_true hltv hgtv; subst heqv
-        by_cases hltk : Nat.blt k₁ k₂ <;> simp [hltk] at h
+        by_cases hltk : Nat.blt k₁ k₂ <;> simp [Nat.blt_eq ▸ hltk] at h
         · have ih := ih (h := h); simp [denote_eq] at ih ⊢
           have haux : k₁ * Var.denote ctx v₁ ≤ k₂ * Var.denote ctx v₁ := Nat.mul_le_mul_right _ (Nat.le_of_lt (Nat.blt_eq.mp hltk))
           rw [Nat.mul_sub_right_distrib, ← Nat.add_assoc, ← Nat.add_sub_assoc haux] at ih
           have ih := Nat.eq_add_of_sub_eq (Nat.le_trans haux (Nat.le_add_left ..)) ih.symm
           simp at ih
           rw [ih]
-        · by_cases hgtk : Nat.blt k₂ k₁ <;> simp [hgtk] at h
+        · by_cases hgtk : Nat.blt k₂ k₁ <;> simp [Nat.blt_eq ▸ hgtk] at h
           · have ih := ih (h := h); simp [denote_eq] at ih ⊢
             have haux : k₂ * Var.denote ctx v₁ ≤ k₁ * Var.denote ctx v₁ := Nat.mul_le_mul_right _ (Nat.le_of_lt (Nat.blt_eq.mp hgtk))
             rw [Nat.mul_sub_right_distrib, ← Nat.add_assoc, ← Nat.add_sub_assoc haux] at ih
@@ -347,19 +348,19 @@ theorem Poly.denote_le_cancelAux (ctx : Context) (fuel : Nat) (m₁ m₂ r₁ r�
     simp
     split <;> try (simp at h; assumption)
     rename_i k₁ v₁ m₁ k₂ v₂ m₂
-    by_cases hltv : Nat.blt v₁ v₂ <;> simp [hltv]
+    by_cases hltv : Nat.blt v₁ v₂ <;> simp [Nat.blt_eq ▸ hltv]
     · apply ih; simp [denote_le] at h |-; assumption
-    · by_cases hgtv : Nat.blt v₂ v₁ <;> simp [hgtv]
+    · by_cases hgtv : Nat.blt v₂ v₁ <;> simp [Nat.blt_eq ▸ hgtv]
       · apply ih; simp [denote_le] at h |-; assumption
       · have heqv : v₁ = v₂ := eq_of_not_blt_eq_true hltv hgtv; subst heqv
-        by_cases hltk : Nat.blt k₁ k₂ <;> simp [hltk]
+        by_cases hltk : Nat.blt k₁ k₂ <;> simp [Nat.blt_eq ▸ hltk]
         · apply ih
           simp [denote_le] at h |-
           have haux : k₁ * Var.denote ctx v₁ ≤ k₂ * Var.denote ctx v₁ := Nat.mul_le_mul_right _ (Nat.le_of_lt (Nat.blt_eq.mp hltk))
           rw [Nat.mul_sub_right_distrib, ← Nat.add_assoc, ← Nat.add_sub_assoc haux]
           apply Nat.le_sub_of_add_le
           simp [h]
-        · by_cases hgtk : Nat.blt k₂ k₁ <;> simp [hgtk]
+        · by_cases hgtk : Nat.blt k₂ k₁ <;> simp [Nat.blt_eq ▸ hgtk]
           · apply ih
             simp [denote_le] at h |-
             have haux : k₂ * Var.denote ctx v₁ ≤ k₁ * Var.denote ctx v₁ := Nat.mul_le_mul_right _ (Nat.le_of_lt (Nat.blt_eq.mp hgtk))
@@ -381,19 +382,19 @@ theorem Poly.of_denote_le_cancelAux (ctx : Context) (fuel : Nat) (m₁ m₂ r₁
     simp at h
     split at h <;> try (simp; assumption)
     rename_i k₁ v₁ m₁ k₂ v₂ m₂
-    by_cases hltv : Nat.blt v₁ v₂ <;> simp [hltv] at h
+    by_cases hltv : Nat.blt v₁ v₂ <;> simp [Nat.blt_eq ▸ hltv] at h
     · have ih := ih (h := h); simp [denote_le] at ih ⊢; assumption
-    · by_cases hgtv : Nat.blt v₂ v₁ <;> simp [hgtv] at h
+    · by_cases hgtv : Nat.blt v₂ v₁ <;> simp [Nat.blt_eq ▸ hgtv] at h
       · have ih := ih (h := h); simp [denote_le] at ih ⊢; assumption
       · have heqv : v₁ = v₂ := eq_of_not_blt_eq_true hltv hgtv; subst heqv
-        by_cases hltk : Nat.blt k₁ k₂ <;> simp [hltk] at h
+        by_cases hltk : Nat.blt k₁ k₂ <;> simp [Nat.blt_eq ▸ hltk] at h
         · have ih := ih (h := h); simp [denote_le] at ih ⊢
           have haux : k₁ * Var.denote ctx v₁ ≤ k₂ * Var.denote ctx v₁ := Nat.mul_le_mul_right _ (Nat.le_of_lt (Nat.blt_eq.mp hltk))
           rw [Nat.mul_sub_right_distrib, ← Nat.add_assoc, ← Nat.add_sub_assoc haux] at ih
           have := Nat.add_le_of_le_sub (Nat.le_trans haux (Nat.le_add_left ..)) ih
           simp at this
           exact this
-        · by_cases hgtk : Nat.blt k₂ k₁ <;> simp [hgtk] at h
+        · by_cases hgtk : Nat.blt k₂ k₁ <;> simp [Nat.blt_eq ▸ hgtk] at h
           · have ih := ih (h := h); simp [denote_le] at ih ⊢
             have haux : k₂ * Var.denote ctx v₁ ≤ k₁ * Var.denote ctx v₁ := Nat.mul_le_mul_right _ (Nat.le_of_lt (Nat.blt_eq.mp hgtk))
             rw [Nat.mul_sub_right_distrib, ← Nat.add_assoc, ← Nat.add_sub_assoc haux] at ih
@@ -431,13 +432,13 @@ theorem Expr.denote_toPoly_go (ctx : Context) (e : Expr) :
   | case5 k k' a h => simp [toPoly.go, eq_of_beq h]
   | case6 k a k' h ih =>
     simp only [toPoly.go, denote, mul_eq]
-    simp [h, cond_false, ih, Nat.mul_assoc]
+    simp [h, ih, Nat.mul_assoc]
   | case7 k a k' h =>
     simp only [toPoly.go, denote, mul_eq]
     simp [eq_of_beq h]
   | case8 k a k' h ih =>
     simp only [toPoly.go, denote, mul_eq]
-    simp [h, cond_false, ih, Nat.mul_assoc]
+    simp [h, ih, Nat.mul_assoc]
 
 theorem Expr.denote_toPoly (ctx : Context) (e : Expr) : e.toPoly.denote ctx = e.denote ctx := by
   simp [toPoly, Expr.denote_toPoly_go]
@@ -504,7 +505,7 @@ theorem Poly.of_isNonZero (ctx : Context) {p : Poly} (h : isNonZero p = true) : 
 theorem PolyCnstr.eq_false_of_isUnsat (ctx : Context) {c : PolyCnstr} : c.isUnsat → c.denote ctx = False := by
   cases c; rename_i eq lhs rhs
   simp [isUnsat]
-  by_cases he : eq = true <;> simp [he, denote, Poly.denote_eq, Poly.denote_le, -and_imp]
+  by_cases he : eq = true <;> simp [he, Poly.denote_eq, Poly.denote_le, -and_imp]
   · intro
       | Or.inl ⟨h₁, h₂⟩ => simp [Poly.of_isZero, h₁]; have := Nat.ne_zero_of_lt (Poly.of_isNonZero ctx h₂); simp [this.symm]
       | Or.inr ⟨h₁, h₂⟩ => simp [Poly.of_isZero, h₂]; have := Nat.ne_zero_of_lt (Poly.of_isNonZero ctx h₁); simp [this]
@@ -515,7 +516,7 @@ theorem PolyCnstr.eq_false_of_isUnsat (ctx : Context) {c : PolyCnstr} : c.isUnsa
 theorem PolyCnstr.eq_true_of_isValid (ctx : Context) {c : PolyCnstr} : c.isValid → c.denote ctx = True := by
   cases c; rename_i eq lhs rhs
   simp [isValid]
-  by_cases he : eq = true <;> simp [he, denote, Poly.denote_eq, Poly.denote_le, -and_imp]
+  by_cases he : eq = true <;> simp [he, Poly.denote_eq, Poly.denote_le, -and_imp]
   · intro ⟨h₁, h₂⟩
     simp [Poly.of_isZero, h₁, h₂]
   · intro h
@@ -523,18 +524,15 @@ theorem PolyCnstr.eq_true_of_isValid (ctx : Context) {c : PolyCnstr} : c.isValid
 
 theorem ExprCnstr.eq_false_of_isUnsat (ctx : Context) (c : ExprCnstr) (h : c.toNormPoly.isUnsat) : c.denote ctx = False := by
   have := PolyCnstr.eq_false_of_isUnsat ctx h
-  simp [-eq_iff_iff] at this
-  assumption
+  rwa [denote_toNormPoly] at this
 
 theorem ExprCnstr.eq_true_of_isValid (ctx : Context) (c : ExprCnstr) (h : c.toNormPoly.isValid) : c.denote ctx = True := by
   have := PolyCnstr.eq_true_of_isValid ctx h
-  simp [-eq_iff_iff] at this
-  assumption
+  rwa [denote_toNormPoly] at this
 
 theorem ExprCnstr.eq_of_toNormPoly_eq (ctx : Context) (c d : ExprCnstr) (h : c.toNormPoly == d.toPoly) : c.denote ctx = d.denote ctx := by
   have h := congrArg (PolyCnstr.denote ctx) (eq_of_beq h)
-  simp [-eq_iff_iff] at h
-  assumption
+  rwa [denote_toNormPoly, denote_toPoly] at h
 
 theorem Expr.eq_of_toNormPoly_eq (ctx : Context) (e e' : Expr) (h : e.toNormPoly == e'.toPoly) : e.denote ctx = e'.denote ctx := by
   have h := congrArg (Poly.denote ctx) (eq_of_beq h)

--- a/src/Init/Data/Option/Lemmas.lean
+++ b/src/Init/Data/Option/Lemmas.lean
@@ -845,6 +845,10 @@ theorem or_eq_left_of_isSome {o o' : Option α} : o.isSome = true → o.or o' = 
 theorem or_none : or o none = o := by
   cases o <;> rfl
 
+theorem or_eq_ite : or o o' = if o.isSome then o else o' := by
+  cases o <;> simp
+
+@[deprecated or_eq_ite (since := "2026-07-29")]
 theorem or_eq_bif : or o o' = bif o.isSome then o else o' := by
   cases o <;> rfl
 

--- a/src/Init/Grind/Ring/CommSolver.lean
+++ b/src/Init/Grind/Ring/CommSolver.lean
@@ -360,7 +360,7 @@ theorem Mon.revlex_k_eq_revlex (m₁ m₂ : Mon) : m₁.revlex_k m₂ = m₁.rev
   induction fuel generalizing m₁ m₂
   next => rfl
   next =>
-    simp [revlexFuel]; split <;> try rfl
+    simp [revlexFuel, -cond_eq_ite]; split <;> try rfl
     next ih _ _ pw₁ m₁ pw₂ m₂ =>
       simp only [cond_eq_ite, beq_iff_eq]
       split

--- a/src/Init/SimpLemmas.lean
+++ b/src/Init/SimpLemmas.lean
@@ -420,9 +420,6 @@ theorem not_decide_eq_true [h : Decidable p] : ((!decide p) = true) = ¬ p := by
 
 @[simp] theorem heq_eq_eq (a b : α) : (a ≍ b) = (a = b) := propext <| Iff.intro eq_of_heq heq_of_eq
 
-@[simp] theorem cond_true (a b : α) : cond true a b = a := rfl
-@[simp] theorem cond_false (a b : α) : cond false a b = b := rfl
-
 theorem beq_self_eq_true [BEq α] [ReflBEq α] (a : α) : (a == a) = true := BEq.rfl
 theorem beq_self_eq_true' [DecidableEq α] (a : α) : (a == a) = true := BEq.rfl
 

--- a/src/Std/Data/DHashMap/Internal/AssocList/Lemmas.lean
+++ b/src/Std/Data/DHashMap/Internal/AssocList/Lemmas.lean
@@ -98,7 +98,7 @@ theorem getEntry?_eq [BEq α] {l : AssocList α β} {a : α} :
   induction l
   · simp only [getEntry?, toList_nil, getEntry?_nil]
   next k v t ih =>
-    simp only [getEntry?, ih, toList_cons, getEntry?_cons, Bool.ite_eq_cond_iff]
+    simp only [getEntry?, ih, toList_cons, getEntry?_cons]
 
 @[simp]
 theorem getEntryD_eq [BEq α] {l : AssocList α β} {a : α} {fallback : (a : α) × β a} :
@@ -106,7 +106,7 @@ theorem getEntryD_eq [BEq α] {l : AssocList α β} {a : α} {fallback : (a : α
   induction l
   · simp only [getEntryD, toList_nil, getEntryD_nil]
   next k v t ih =>
-    simp only [getEntryD, ih, toList_cons, getEntryD_cons, Bool.ite_eq_cond_iff]
+    simp only [getEntryD, ih, toList_cons, getEntryD_cons]
 
 @[simp]
 theorem getEntry!_eq [BEq α] {l : AssocList α β} {a : α} [Inhabited ((a : α) × β a)] :
@@ -114,7 +114,7 @@ theorem getEntry!_eq [BEq α] {l : AssocList α β} {a : α} [Inhabited ((a : α
   induction l
   · simp only [getEntry!, toList_nil, getEntry!_nil]
   next k v t ih =>
-    simp only [getEntry!, ih, toList_cons, List.getEntry!_cons, Bool.ite_eq_cond_iff]
+    simp only [getEntry!, ih, toList_cons, List.getEntry!_cons]
 
 @[simp]
 theorem getCastD_eq [BEq α] [LawfulBEq α] {l : AssocList α β} {a : α} {fallback : β a} :
@@ -130,7 +130,7 @@ theorem getD_eq {β : Type v} [BEq α] {l : AssocList α (fun _ => β)} {a : α}
   induction l
   · simp [getD, List.getValueD]
   · simp_all [getD, List.getValueD, List.getValueD, List.getValue?_cons,
-      Bool.apply_cond (fun x => Option.getD x fallback)]
+      apply_ite (fun x => Option.getD x fallback)]
 
 @[simp]
 theorem panicWithPosWithDecl_eq [Inhabited α] {modName declName line col msg} :
@@ -149,8 +149,7 @@ theorem get!_eq {β : Type v} [BEq α] [Inhabited β] {l : AssocList α (fun _ =
     l.get! a = getValue! a l.toList := by
   induction l
   · simp [get!, List.getValue!]
-  · simp_all [get!, List.getValue!, List.getValue!, List.getValue?_cons,
-      Bool.apply_cond Option.get!]
+  · simp_all [get!, List.getValue!, List.getValue!, List.getValue?_cons, apply_ite Option.get!]
 
 @[simp]
 theorem getKey?_eq [BEq α] {l : AssocList α β} {a : α} :
@@ -169,14 +168,14 @@ theorem getKeyD_eq [BEq α] {l : AssocList α β} {a fallback : α} :
     l.getKeyD a fallback = List.getKeyD a l.toList fallback := by
   induction l
   · simp [getKeyD, List.getKeyD]
-  · simp_all [getKeyD, List.getKeyD, Bool.apply_cond (fun x => Option.getD x fallback)]
+  · simp_all [getKeyD, List.getKeyD, apply_ite (fun x => Option.getD x fallback)]
 
 @[simp]
 theorem getKey!_eq [BEq α] [Inhabited α] {l : AssocList α β} {a : α} :
     l.getKey! a = List.getKey! a l.toList := by
   induction l
   · simp [getKey!, List.getKey!]
-  · simp_all [getKey!, List.getKey!, Bool.apply_cond Option.get!]
+  · simp_all [getKey!, List.getKey!, apply_ite Option.get!]
 
 @[simp]
 theorem toList_replace [BEq α] {l : AssocList α β} {a : α} {b : β a} :

--- a/src/Std/Data/DHashMap/Internal/WF.lean
+++ b/src/Std/Data/DHashMap/Internal/WF.lean
@@ -931,7 +931,7 @@ theorem toListModel_insertIfNewₘ [BEq α] [Hashable α] [EquivBEq α] [LawfulH
     (h : Raw.WFImp m.1) {a : α} {b : β a} :
     Perm (toListModel (m.insertIfNewₘ a b).1.buckets)
       (insertEntryIfNew a b (toListModel m.1.buckets)) := by
-  rw [insertIfNewₘ, insertEntryIfNew, containsₘ_eq_containsKey h, cond_eq_ite]
+  rw [insertIfNewₘ, insertEntryIfNew, containsₘ_eq_containsKey h]
   split
   next h' => exact Perm.refl _
   next h' => exact (toListModel_expandIfNecessary _).trans (toListModel_consₘ m h a b)

--- a/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/WF/Lemmas.lean
@@ -1028,7 +1028,7 @@ theorem ordered_insertIfNew [Ord α] [TransOrd α] {k : α} {v : β k} {l : Impl
 theorem toListModel_insertIfNew [Ord α] [TransOrd α] [BEq α] [LawfulBEqOrd α] {k : α} {v : β k}
     {l : Impl α β} (hlb : l.Balanced) (hlo : l.Ordered) :
     (l.insertIfNew k v hlb).impl.toListModel.Perm (insertEntryIfNew k v l.toListModel) := by
-  simp only [Impl.insertIfNew, insertEntryIfNew, cond_eq_ite, contains_eq_containsKey hlo]
+  simp only [Impl.insertIfNew, insertEntryIfNew, contains_eq_containsKey hlo]
   split
   · rfl
   · refine (toListModel_insert hlb hlo).trans ?_
@@ -1413,7 +1413,7 @@ theorem toListModel_alterₘ [Ord α] [TransOrd α] [BEq α] [LawfulBEqOrd α] {
     cases f none <;> rfl
   · simp only [Cell.Const.alter, Cell.ofOption, Const.alterKey, Option.toList_some]
     have := OrientedCmp.eq_symm <| hl l rfl
-    simp only [getValue?, compare_eq_iff_beq.mp this, cond_eq_ite, reduceIte]
+    simp only [getValue?, compare_eq_iff_beq.mp this, reduceIte]
     cases f _
     · simp [eraseKey, compare_eq_iff_beq.mp this]
     · simp [insertEntry, containsKey, replaceEntry, compare_eq_iff_beq.mp this]

--- a/src/Std/Data/Internal/List/Associative.lean
+++ b/src/Std/Data/Internal/List/Associative.lean
@@ -55,17 +55,17 @@ theorem assoc_induction {motive : List ((a : α) × β a) → Prop} (nil : motiv
 /-- Internal implementation detail of the hash map -/
 def getEntry? [BEq α] (a : α) : List ((a : α) × β a) → Option ((a : α) × β a)
   | [] => none
-  | ⟨k, v⟩ :: l => bif k == a then some ⟨k, v⟩ else getEntry? a l
+  | ⟨k, v⟩ :: l => if k == a then some ⟨k, v⟩ else getEntry? a l
 
 /-- Internal implementation detail of the hash map -/
 def getEntryD [BEq α] (a : α) (fallback : (a : α) × β a) : List ((a : α) × β a) → (a : α) × β a
   | [] => fallback
-  | ⟨k, v⟩ :: l => bif k == a then ⟨k, v⟩ else getEntryD a fallback l
+  | ⟨k, v⟩ :: l => if k == a then ⟨k, v⟩ else getEntryD a fallback l
 
 /-- Internal implementation detail of the hash map -/
 def getEntry! [BEq α] (a : α) [Inhabited ((a : α) × β a)] : List ((a : α) × β a) → (a : α) × β a
   | [] => panic! "key is not present in associative list"
-  | ⟨k, v⟩ :: l => bif k == a then ⟨k, v⟩ else getEntry! a l
+  | ⟨k, v⟩ :: l => if k == a then ⟨k, v⟩ else getEntry! a l
 
 @[simp] theorem getEntry?_nil [BEq α] {a : α} :
     getEntry? a ([] : List ((a : α) × β a)) = none := (rfl)
@@ -77,7 +77,7 @@ def getEntry! [BEq α] (a : α) [Inhabited ((a : α) × β a)] : List ((a : α) 
     getEntry! a ([] : List ((a : α) × β a)) = default := (rfl)
 
 theorem getEntry?_cons [BEq α] {l : List ((a : α) × β a)} {k a : α} {v : β k} :
-    getEntry? a (⟨k, v⟩ :: l) = bif k == a then some ⟨k, v⟩ else getEntry? a l := (rfl)
+    getEntry? a (⟨k, v⟩ :: l) = if k == a then some ⟨k, v⟩ else getEntry? a l := (rfl)
 
 theorem getEntry?_eq_find [BEq α] {k : α} {l : List ((a : α) × β a)} :
     getEntry? k l = l.find? (·.1 == k) := by
@@ -99,7 +99,7 @@ theorem getEntry?_cons_self [BEq α] [ReflBEq α] {l : List ((a : α) × β a)} 
   getEntry?_cons_of_true BEq.rfl
 
 theorem getEntryD_cons [BEq α] {l : List ((a : α) × β a)} {k a : α} {v : β k} {fallback : (a : α) × β a} :
-    getEntryD a fallback (⟨k, v⟩ :: l) = bif k == a then ⟨k, v⟩ else getEntryD a fallback l := (rfl)
+    getEntryD a fallback (⟨k, v⟩ :: l) = if k == a then ⟨k, v⟩ else getEntryD a fallback l := (rfl)
 
 theorem getEntryD_cons_of_true [BEq α] {l : List ((a : α) × β a)} {k a : α} {v : β k} {fallback : (a : α) × β a}
     (h : k == a) : getEntryD a fallback (⟨k, v⟩ :: l) = ⟨k, v⟩ := by
@@ -115,7 +115,7 @@ theorem getEntryD_cons_self [BEq α] [ReflBEq α] {l : List ((a : α) × β a)} 
   getEntryD_cons_of_true BEq.rfl
 
 theorem getEntry!_cons [BEq α] {l : List ((a : α) × β a)} {k a : α} {v : β k} [Inhabited ((a : α) × β a)] :
-    getEntry! a (⟨k, v⟩ :: l) = bif k == a then ⟨k, v⟩ else getEntry! a l := (rfl)
+    getEntry! a (⟨k, v⟩ :: l) = if k == a then ⟨k, v⟩ else getEntry! a l := (rfl)
 
 theorem getEntry!_cons_of_true [BEq α] {l : List ((a : α) × β a)} {k a : α} {v : β k} [Inhabited ((a : α) × β a)]
     (h : k == a) : getEntry! a (⟨k, v⟩ :: l) = ⟨k, v⟩ := by
@@ -183,7 +183,7 @@ theorem getEntry?_eq_some_iff [BEq α] [EquivBEq α] {l : List ((a : α) × β a
   induction l using assoc_induction with
   | nil => simp
   | cons lk lv tail ih =>
-    simp only [getEntry?_cons, cond_eq_ite, List.mem_cons]
+    simp only [getEntry?_cons, List.mem_cons]
     split
     · rename_i hlkk
       simp only [Option.some.injEq]
@@ -221,11 +221,11 @@ variable {β : Type v}
 /-- Internal implementation detail of the hash map -/
 @[expose] def getValue? [BEq α] (a : α) : List ((_ : α) × β) → Option β
   | [] => none
-  | ⟨k, v⟩ :: l => bif k == a then some v else getValue? a l
+  | ⟨k, v⟩ :: l => if k == a then some v else getValue? a l
 
 @[simp] theorem getValue?_nil [BEq α] {a : α} : getValue? a ([] : List ((_ : α) × β)) = none := rfl
 theorem getValue?_cons [BEq α] {l : List ((_ : α) × β)} {k a : α} {v : β} :
-    getValue? a (⟨k, v⟩ :: l) = bif k == a then some v else getValue? a l := rfl
+    getValue? a (⟨k, v⟩ :: l) = if k == a then some v else getValue? a l := rfl
 
 theorem getValue?_cons_of_true [BEq α] {l : List ((_ : α) × β)} {k a : α} {v : β} (h : k == a) :
     getValue? a (⟨k, v⟩ :: l) = some v := by
@@ -577,13 +577,8 @@ theorem getEntry_cons [BEq α] {l : List ((a : α) × β a)} {k a : α} {v : β 
         getEntry a l (containsKey_of_containsKey_cons (k := k) h (Bool.eq_false_iff.2 h')) := by
   rw [getEntry, Option.get_congr getEntry?_cons]
   split
-  case _ =>
-    rename_i h
-    simp [h]
-  case _ =>
-    rename_i h
-    simp [h]
-    rw [getEntry]
+  case _ => simp
+  case _ => simp [getEntry]
 
 theorem getEntry_congr [BEq α] [PartialEquivBEq α] {l : List ((a : α) × β a)} {a b : α}
     (h : a == b) {h₁ h₂} : getEntry a l h₁ = getEntry b l h₂ := by
@@ -615,7 +610,7 @@ theorem getEntry_mem [BEq α] {l : List ((a : α) × β a)} {k : α} {h} :
   induction l using assoc_induction with
   | nil => contradiction
   | cons k v l ih =>
-    simp only [getEntry?_cons, cond_eq_ite]
+    simp only [getEntry?_cons]
     split
     · exact List.mem_cons_self
     · simp only [List.mem_cons]
@@ -673,8 +668,7 @@ theorem getValue_cons_of_false [BEq α] {l : List ((_ : α) × β)} {k a : α} {
 theorem getValue_cons [BEq α] {l : List ((_ : α) × β)} {k a : α} {v : β} {h} :
     getValue a (⟨k, v⟩ :: l) h = if h' : k == a then v
       else getValue a l (containsKey_of_containsKey_cons (k := k) h (Bool.eq_false_iff.2 h')) := by
-  rw [← Option.some_inj, ← getValue?_eq_some_getValue, getValue?_cons, apply_dite Option.some,
-    cond_eq_ite]
+  rw [← Option.some_inj, ← getValue?_eq_some_getValue, getValue?_cons, apply_dite Option.some]
   split
   · rfl
   · exact getValue?_eq_some_getValue _
@@ -897,13 +891,13 @@ end
 /-- Internal implementation detail of the hash map -/
 def getKey? [BEq α] (a : α) : List ((a : α) × β a) → Option α
   | [] => none
-  | ⟨k, _⟩ :: l => bif k == a then some k else getKey? a l
+  | ⟨k, _⟩ :: l => if k == a then some k else getKey? a l
 
 @[simp] theorem getKey?_nil [BEq α] {a : α} :
     getKey? a ([] : List ((a : α) × β a)) = none := (rfl)
 
 @[simp] theorem getKey?_cons [BEq α] {l : List ((a : α) × β a)} {k a : α} {v : β k} :
-    getKey? a (⟨k, v⟩ :: l) = bif k == a then some k else getKey? a l := (rfl)
+    getKey? a (⟨k, v⟩ :: l) = if k == a then some k else getKey? a l := (rfl)
 
 theorem getKey?_cons_of_true [BEq α] {l : List ((a : α) × β a)} {k a : α} {v : β k} (h : k == a) :
     getKey? a (⟨k, v⟩ :: l) = some k := by
@@ -943,7 +937,7 @@ theorem getKey?_beq [BEq α] {l : List ((a : α) × β a)} {a : α} :
   induction l using assoc_induction with
   | nil => rfl
   | cons k v l ih =>
-    rw [getKey?_cons, cond_eq_ite]
+    rw [getKey?_cons]
     split <;> assumption
 
 theorem getKey?_congr [BEq α] [EquivBEq α] {l : List ((a : α) × β a)}
@@ -963,7 +957,7 @@ theorem getEntry?_eq_some_iff_getKey?_eq_some_getValue?_eq_some [BEq α] {β : T
   induction l with
   | nil => simp
   | cons hd tl ih =>
-    simp [getEntry?, getKey?, getValue?, cond_eq_ite]
+    simp [getEntry?, getKey?, getValue?]
     split
     · rename_i h
       simp [Sigma.ext_iff]
@@ -988,8 +982,7 @@ theorem getKey?_eq_some_getKey [BEq α] {l : List ((a : α) × β a)} {a : α} (
 theorem getKey_cons [BEq α] {l : List ((a : α) × β a)} {k a : α} {v : β k} {h} :
     getKey a (⟨k, v⟩ :: l) h = if h' : k == a then k
       else getKey a l (containsKey_of_containsKey_cons (k := k) h (Bool.eq_false_iff.2 h')) := by
-  rw [← Option.some_inj, ← getKey?_eq_some_getKey, getKey?_cons, apply_dite Option.some,
-    cond_eq_ite]
+  rw [← Option.some_inj, ← getKey?_eq_some_getKey, getKey?_cons, apply_dite Option.some]
   split
   · rfl
   · exact getKey?_eq_some_getKey _
@@ -1172,7 +1165,7 @@ theorem getEntry?_eq_getValueCast? [BEq α] [LawfulBEq α] {l : List ((a : α) �
   induction l using assoc_induction with
   | nil => rfl
   | cons k v l ih =>
-    simp only [getEntry?_cons, getValueCast?_cons, cond_eq_ite]
+    simp only [getEntry?_cons, getValueCast?_cons]
     split
     · rename_i h
       simp only [beq_iff_eq] at h
@@ -1196,12 +1189,12 @@ theorem getEntry_eq_getKey_getValue [BEq α] {β : Type v} {l : List ((_ : α) �
 /-- Internal implementation detail of the hash map -/
 def replaceEntry [BEq α] (k : α) (v : β k) : List ((a : α) × β a) → List ((a : α) × β a)
   | [] => []
-  | ⟨k', v'⟩ :: l => bif k' == k then ⟨k, v⟩ :: l else ⟨k', v'⟩ :: replaceEntry k v l
+  | ⟨k', v'⟩ :: l => if k' == k then ⟨k, v⟩ :: l else ⟨k', v'⟩ :: replaceEntry k v l
 
 @[simp] theorem replaceEntry_nil [BEq α] {k : α} {v : β k} : replaceEntry k v [] = [] := (rfl)
 theorem replaceEntry_cons [BEq α] {l : List ((a : α) × β a)} {k k' : α} {v : β k} {v' : β k'} :
     replaceEntry k v (⟨k', v'⟩ :: l) =
-      bif k' == k then ⟨k, v⟩ :: l else ⟨k', v'⟩ :: replaceEntry k v l := (rfl)
+      if k' == k then ⟨k, v⟩ :: l else ⟨k', v'⟩ :: replaceEntry k v l := (rfl)
 
 theorem replaceEntry_cons_of_true [BEq α] {l : List ((a : α) × β a)} {k k' : α} {v : β k}
     {v' : β k'} (h : k' == k) : replaceEntry k v (⟨k', v'⟩ :: l) = ⟨k, v⟩ :: l := by
@@ -1225,7 +1218,7 @@ theorem isEmpty_replaceEntry [BEq α] {l : List ((a : α) × β a)} {k : α} {v 
     (replaceEntry k v l).isEmpty = l.isEmpty := by
   induction l using assoc_induction
   · simp
-  · simp only [replaceEntry_cons, cond_eq_ite, List.isEmpty_cons]
+  · simp only [replaceEntry_cons, List.isEmpty_cons]
     split <;> simp
 
 theorem mem_replaceEntry_of_beq_eq_false [BEq α] [EquivBEq α] {a : α} {b : β a}
@@ -1234,7 +1227,7 @@ theorem mem_replaceEntry_of_beq_eq_false [BEq α] [EquivBEq α] {a : α} {b : β
   induction l
   · simp only [replaceEntry_nil]
   next ih =>
-    simp only [replaceEntry, cond_eq_ite]
+    simp only [replaceEntry]
     split
     next h =>
       simp only [List.mem_cons, Sigma.ext_iff]
@@ -1310,7 +1303,7 @@ theorem mem_getEntry [BEq α] {l : List ((a : α) × β a)} {k : α} (hl : conta
   induction l using assoc_induction
   · simp at hl
   next k' v' l ih =>
-    simp [getEntry, getEntry?_cons, cond_eq_ite]
+    simp [getEntry, getEntry?_cons]
     split
     · simp
     · simp only [containsKey_cons, Bool.or_eq_true] at hl
@@ -1327,7 +1320,7 @@ theorem mem_replaceEntry_of_true [BEq α] [PartialEquivBEq α] {l : List ((a : �
 @[simp]
 theorem length_replaceEntry [BEq α] {l : List ((a : α) × β a)} {k : α} {v : β k} :
     (replaceEntry k v l).length = l.length := by
-  induction l using assoc_induction <;> simp_all [replaceEntry_cons, Bool.apply_cond List.length]
+  induction l using assoc_induction <;> simp_all [replaceEntry_cons, apply_ite List.length]
 
 section
 
@@ -1380,12 +1373,12 @@ theorem getKey?_replaceEntry [BEq α] [PartialEquivBEq α] {l : List ((a : α) �
 /-- Internal implementation detail of the hash map -/
 def eraseKey [BEq α] (k : α) : List ((a : α) × β a) → List ((a : α) × β a)
   | [] => []
-  | ⟨k', v'⟩ :: l => bif k' == k then l else ⟨k', v'⟩ :: eraseKey k l
+  | ⟨k', v'⟩ :: l => if k' == k then l else ⟨k', v'⟩ :: eraseKey k l
 
 @[simp] theorem eraseKey_nil [BEq α] {k : α} : eraseKey k ([] : List ((a : α) × β a)) = [] := (rfl)
 
 theorem eraseKey_cons [BEq α] {l : List ((a : α) × β a)} {k k' : α} {v' : β k'} :
-    eraseKey k (⟨k', v'⟩ :: l) = bif k' == k then l else ⟨k', v'⟩ :: eraseKey k l := (rfl)
+    eraseKey k (⟨k', v'⟩ :: l) = if k' == k then l else ⟨k', v'⟩ :: eraseKey k l := (rfl)
 
 theorem eraseKey_cons_of_beq [BEq α] {l : List ((a : α) × β a)} {k k' : α} {v' : β k'}
     (h : k' == k) : eraseKey k (⟨k', v'⟩ :: l) = l :=
@@ -1415,7 +1408,6 @@ theorem mem_eraseKey_of_key_beq_eq_false [BEq α] {a : α}
   · simp only [eraseKey_nil]
   next ih =>
     simp only [eraseKey, List.mem_cons]
-    rw [cond_eq_ite]
     split
     next h =>
       rw [iff_or_self, Sigma.ext_iff]
@@ -1446,7 +1438,7 @@ theorem length_eraseKey [BEq α] {l : List ((a : α) × β a)} {k : α} :
   next k' v' t ih =>
     rw [eraseKey_cons, containsKey_cons]
     cases k' == k
-    · rw [cond_false, Bool.false_or, List.length_cons, ih]
+    · rw [ite_eq_right (by simp), Bool.false_or, List.length_cons, ih]
       cases h : containsKey k t
       · simp
       · simp only [List.length_cons, Nat.add_sub_cancel, ite_true]
@@ -1500,7 +1492,7 @@ theorem getEntry?_of_mem [BEq α] [PartialEquivBEq α]
 
 /-- Internal implementation detail of the hash map -/
 def insertEntry [BEq α]  (k : α) (v : β k) (l : List ((a : α) × β a)) : List ((a : α) × β a) :=
-  bif containsKey k l then replaceEntry k v l else ⟨k, v⟩ :: l
+  if containsKey k l then replaceEntry k v l else ⟨k, v⟩ :: l
 
 @[simp]
 theorem insertEntry_nil [BEq α] {k : α} {v : β k} :
@@ -1510,14 +1502,14 @@ theorem insertEntry_nil [BEq α] {k : α} {v : β k} :
 theorem insertEntry_cons_of_false [BEq α] {l : List ((a : α) × β a)} {k k' : α} {v : β k}
     {v' : β k'} (h : (k' == k) = false) :
     Perm (insertEntry k v (⟨k', v'⟩ :: l)) (⟨k', v'⟩ :: insertEntry k v l) := by
-  simp only [insertEntry, containsKey_cons, h, Bool.false_or, cond_eq_ite]
+  simp only [insertEntry, containsKey_cons, h, Bool.false_or]
   split
   · rw [replaceEntry_cons_of_false h]
   · apply Perm.swap
 
 theorem insertEntry_cons_of_beq [BEq α] {l : List ((a : α) × β a)} {k k' : α} {v : β k} {v' : β k'}
     (h : k' == k) : insertEntry k v (⟨k', v'⟩ :: l) = ⟨k, v⟩ :: l := by
-  simp_all only [insertEntry, containsKey_cons, Bool.true_or, cond_true, replaceEntry_cons_of_true]
+  simp_all only [insertEntry, containsKey_cons, Bool.true_or, ite_true, replaceEntry_cons_of_true]
 
 @[simp]
 theorem insertEntry_cons_self [BEq α] [ReflBEq α] {l : List ((a : α) × β a)} {k : α} {v : β k} :
@@ -1535,7 +1527,7 @@ theorem insertEntry_of_containsKey_eq_false [BEq α] {l : List ((a : α) × β a
 theorem mem_insertEntry_of_key_beq_eq_false [BEq α] [EquivBEq α] {a : α} {b : β a}
     {l : List ((a : α) × β a)} (p : (a : α) × β a)
     (hne : (p.1 == a) = false) : p ∈ insertEntry a b l ↔ p ∈ l := by
-  simp only [insertEntry, cond_eq_ite]
+  simp only [insertEntry]
   split
   · exact mem_replaceEntry_of_beq_eq_false p hne
   · simp only [List.mem_cons, or_iff_right_iff_imp, Sigma.ext_iff]
@@ -1564,7 +1556,7 @@ theorem isEmpty_insertEntry [BEq α] {l : List ((a : α) × β a)} {k : α} {v :
 
 theorem length_insertEntry [BEq α] {l : List ((a : α) × β a)} {k : α} {v : β k} :
     (insertEntry k v l).length = if containsKey k l then l.length else l.length + 1 := by
-  simp [insertEntry, Bool.apply_cond List.length]
+  simp [insertEntry, apply_ite List.length]
 
 theorem length_le_length_insertEntry [BEq α] {l : List ((a : α) × β a)} {k : α} {v : β k} :
     l.length ≤ (insertEntry k v l).length := by
@@ -1608,7 +1600,7 @@ theorem getEntry?_insertEntry [BEq α] [PartialEquivBEq α] {l : List ((a : α) 
     {v : β k} :
     getEntry? a (insertEntry k v l) = if k == a then some ⟨k, v⟩ else getEntry? a l := by
   cases hl : containsKey k l
-  · rw [insertEntry_of_containsKey_eq_false hl, getEntry?_cons, cond_eq_ite]
+  · rw [insertEntry_of_containsKey_eq_false hl, getEntry?_cons]
   · simp [insertEntry_of_containsKey hl, getEntry?_replaceEntry, hl]
 
 theorem getValueCast?_insertEntry [BEq α] [LawfulBEq α] {l : List ((a : α) × β a)} {k a : α}
@@ -1764,7 +1756,7 @@ theorem getKey_insertEntry_self [BEq α] [EquivBEq α] {l : List ((a : α) × β
 
 /-- Internal implementation detail of the hash map -/
 def insertEntryIfNew [BEq α] (k : α) (v : β k) (l : List ((a : α) × β a)) : List ((a : α) × β a) :=
-  bif containsKey k l then l else ⟨k, v⟩ :: l
+  if containsKey k l then l else ⟨k, v⟩ :: l
 
 theorem insertEntryIfNew_of_containsKey [BEq α] {l : List ((a : α) × β a)} {k : α} {v : β k}
     (h : containsKey k l) : insertEntryIfNew k v l = l := by
@@ -1777,7 +1769,7 @@ theorem insertEntryIfNew_of_containsKey_eq_false [BEq α] {l : List ((a : α) ×
 theorem DistinctKeys.insertEntryIfNew [BEq α] [PartialEquivBEq α] {k : α} {v : β k}
     {l : List ((a : α) × β a)} (h : DistinctKeys l) :
     DistinctKeys (insertEntryIfNew k v l) := by
-  simp only [Std.Internal.List.insertEntryIfNew, cond_eq_ite]
+  simp only [Std.Internal.List.insertEntryIfNew]
   split
   · exact h
   · rw [distinctKeys_cons_iff]
@@ -1918,7 +1910,7 @@ theorem getKeyD_insertEntryIfNew [BEq α] [PartialEquivBEq α] {l : List ((a : �
 
 theorem length_insertEntryIfNew [BEq α] {l : List ((a : α) × β a)} {k : α} {v : β k} :
     (insertEntryIfNew k v l).length = if containsKey k l then l.length else l.length + 1 := by
-  simp [insertEntryIfNew, Bool.apply_cond List.length]
+  simp [insertEntryIfNew, apply_ite List.length]
 
 theorem length_le_length_insertEntryIfNew [BEq α] {l : List ((a : α) × β a)} {k : α} {v : β k} :
     l.length ≤ (insertEntryIfNew k v l).length := by
@@ -2571,8 +2563,8 @@ theorem eraseKey_append_of_containsKey_right_eq_false [BEq α] {l l' : List ((a 
   next k' v' t ih =>
     rw [List.cons_append, eraseKey_cons, eraseKey_cons]
     cases k' == k
-    · rw [cond_false, cond_false, ih, List.cons_append]
-    · rw [cond_true, cond_true]
+    · simp [ih, List.cons_append]
+    · simp
 
 theorem mem_iff_getValueCast?_eq_some [BEq α] [LawfulBEq α] {k : α} {v : β k}
     {l : List ((a : α) × β a)} (h : DistinctKeys l) :
@@ -2651,7 +2643,7 @@ theorem find?_map_toProd_eq_some_iff_getKey?_eq_some_and_getValue?_eq_some [BEq 
   | nil => simp
   | cons hd tl ih =>
     simp only [List.map_cons, List.find?_cons_eq_some, Prod.mk.injEq, Bool.not_eq_eq_eq_not,
-      Bool.not_true, getKey?, cond_eq_ite, getValue?]
+      Bool.not_true, getKey?, getValue?]
     by_cases hdfst_k: hd.fst == k
     · simp only [hdfst_k, true_and, Bool.true_eq_false, false_and, or_false, ↓reduceIte,
       Option.some.injEq]
@@ -3985,7 +3977,7 @@ theorem insertListIfNewUnit_perm_of_perm_first [BEq α] [EquivBEq α] {l1 l2 : L
   | cons hd tl ih =>
     simp only [insertListIfNewUnit]
     apply ih
-    · simp only [insertEntryIfNew, cond_eq_ite]
+    · simp only [insertEntryIfNew]
       have contains_eq : containsKey hd l1 = containsKey hd l2 := containsKey_of_perm h
       rw [contains_eq]
       by_cases contains_hd: containsKey hd l2 = true
@@ -4016,11 +4008,11 @@ theorem getEntry?_insertListIfNewUnit [BEq α] [PartialEquivBEq α] {l : List ((
     cases hhd : hd == k
     · simp
     · cases hc : containsKey hd l
-      · simp only [Bool.not_false, Bool.and_self, ↓reduceIte, Option.some_or, cond_true,
+      · simp only [Bool.not_false, Bool.and_self, ↓reduceIte, Option.some_or,
           Option.or_some, Option.some.injEq]
         rw [getEntry?_eq_none.2, Option.getD_none]
         rwa [← containsKey_congr hhd]
-      · simp only [Bool.not_true, Bool.and_false, Bool.false_eq_true, ↓reduceIte, cond_true,
+      · simp only [Bool.not_true, Bool.and_false, Bool.false_eq_true, ↓reduceIte,
           Option.or_some]
         rw [containsKey_congr hhd, containsKey_eq_isSome_getEntry?] at hc
         obtain ⟨v, hv⟩ := Option.isSome_iff_exists.1 hc
@@ -4245,8 +4237,8 @@ theorem getValue?_list_unit [BEq α] {l : List ((_ : α) × Unit)} {k : α} :
   induction l with
   | nil => simp
   | cons hd tl ih =>
-    simp only [getValue?, containsKey, Bool.or_eq_true, Bool.cond_eq_ite_iff]
-    by_cases hd_k: (hd.fst == k) = true
+    simp only [getValue?, containsKey, Bool.or_eq_true]
+    by_cases hd_k : (hd.fst == k) = true
     · simp [hd_k]
     · simp [hd_k, ih]
 
@@ -4833,7 +4825,7 @@ theorem isEmpty_modifyKey [BEq α] [LawfulBEq α] (k : α) (f : β k → β k) (
   match l with
   | [] => simp [modifyKey]
   | a :: as =>
-    simp only [modifyKey, replaceEntry, cond_eq_ite]
+    simp only [modifyKey, replaceEntry]
     repeat' split <;> simp
 
 theorem length_modifyKey [BEq α] [LawfulBEq α] (k : α) (f : β k → β k) (l : List ((a : α) × β a)) :
@@ -5011,7 +5003,7 @@ theorem isEmpty_modifyKey (k : α) (f : β → β) (l : List ((_ : α) × β)) :
   match l with
   | [] => simp [modifyKey]
   | a :: as =>
-    simp only [modifyKey, replaceEntry, cond_eq_ite]
+    simp only [modifyKey, replaceEntry]
     repeat' split <;> simp
 
 theorem modifyKey_eq_alterKey (k : α) (f : β → β) (l : List ((_ : α) × β)) :
@@ -5253,7 +5245,7 @@ theorem getEntry?_filterMap' [BEq α] [EquivBEq α]
   induction l using assoc_induction with
   | nil => rfl
   | cons k' v l ih =>
-    simp only [getEntry?, cond_eq_ite]
+    simp only [getEntry?]
     simp only [distinctKeys_cons_iff] at hl
     specialize ih hl.1
     specialize hf ⟨k', v⟩
@@ -5264,12 +5256,14 @@ theorem getEntry?_filterMap' [BEq α] [EquivBEq α]
       split
       · simp only [ih, ‹f _ = _›, Option.bind_none, getEntry?_eq_none.mpr hl.2]
       · rw [‹f _ = _›, Option.all_some, BEq.congr_right h] at hf
-        rw [getEntry?_cons, hf, ‹f _ = _›, cond_true]
+        rw [getEntry?_cons, hf, ‹f _ = _›]
+        simp
     · simp only [List.filterMap_cons]
       split
       · exact ih
       · rw [‹f _ = _›, Option.all_some] at hf
-        rw [getEntry?_cons, BEq.congr_left hf, (Bool.not_eq_true (_ == _)).mp ‹_›, ih, cond_false]
+        rw [getEntry?_cons, BEq.congr_left hf, (Bool.not_eq_true (_ == _)).mp ‹_›, ih]
+        simp
 
 theorem getEntry?_map' [BEq α] [EquivBEq α]
     {f : ((a : α) × β a) → ((a : α) × γ a)}
@@ -6982,7 +6976,8 @@ theorem insertEntry_perm_filter [BEq α] [EquivBEq α]
   rw [insertEntry]
   by_cases eq : containsKey k l
   case neg =>
-    simp only [eq, cond_false, Bool.not_eq_true, Bool.decide_eq_false, List.perm_cons]
+    simp only [eq, Bool.false_eq_true, ↓reduceIte, Bool.not_eq_true, Bool.decide_eq_false,
+      List.perm_cons]
     suffices (List.filter (fun x => !k == x.fst) l) = l by rw [this]
     simp only [List.filter_eq_self, Bool.not_eq_eq_eq_not, Bool.not_true]
     intro ⟨e₁,e₂⟩ mem
@@ -6994,7 +6989,7 @@ theorem insertEntry_perm_filter [BEq α] [EquivBEq α]
       contradiction
     case neg => simp [h]
   case pos =>
-    simp only [eq, cond_true, Bool.not_eq_true, Bool.decide_eq_false]
+    simp only [eq, Bool.not_eq_true, Bool.decide_eq_false]
     induction l
     case nil => simp at eq
     case cons h t ih =>
@@ -7002,7 +6997,7 @@ theorem insertEntry_perm_filter [BEq α] [EquivBEq α]
       rw [distinctKeys_cons_iff] at hl
       by_cases heq : (h.fst == k)
       case pos =>
-        simp only [heq, cond_true, BEq.symm heq, Bool.true_eq_false, ↓reduceIte, List.perm_cons]
+        simp only [heq, BEq.symm heq, Bool.true_eq_false, ↓reduceIte, List.perm_cons]
         suffices (List.filter (fun x => !k == x.fst) t) = t by rw [this]
         simp only [List.filter_eq_self, Bool.not_eq_eq_eq_not, Bool.not_true]
         intro ⟨e₁, e₂⟩ mem
@@ -7136,10 +7131,10 @@ theorem getKey?_filter_key [BEq α] [EquivBEq α]
     specialize ih hl.tail
     simp only [getKey?_cons, List.filter_cons]
     split
-    · simp only [getKey?_cons, ih, cond_eq_ite, apply_ite (Option.filter f), Option.filter_some,
+    · simp only [getKey?_cons, ih, apply_ite (Option.filter f), Option.filter_some,
         ‹f k'›, ↓reduceIte]
     · replace hl := hl.containsKey_eq_false
-      simp only [ih, cond_eq_ite]
+      simp only [ih]
       split
       · rw [containsKey_congr ‹_›] at hl
         simp only [getKey?_eq_none hl, Option.filter_none, Option.filter_some, eq_false ‹_›,
@@ -7335,7 +7330,7 @@ theorem length_filter_containsKey_of_length_right [BEq α] [EquivBEq α]
             simp [heq2]
           case neg =>
             simp only [Bool.not_eq_true] at heq2
-            simp only [heq2, cond_false, List.length_cons]
+            simp only [heq2]
             apply ih'
             . rw [List.distinctKeys_cons_iff] at hl₂
               exact hl₂.1
@@ -7427,7 +7422,7 @@ theorem size_add_size_eq_size_insertList_add_size_filter_containsKey [BEq α] [E
     simp [insertListIfNew, List.filter_cons]
     split
     case isTrue hyp =>
-      simp only [insertEntryIfNew, hyp, cond_true, List.length_cons]
+      simp only [insertEntryIfNew, hyp, List.length_cons, ite_true]
       specialize ih (by rw [List.distinctKeys_cons_iff] at hl₁; exact hl₁.1) hl₂
       omega
     case isFalse hyp =>
@@ -7484,7 +7479,7 @@ theorem length_filter_containsKey_le [BEq α] [EquivBEq α]
             simp [heq2]
           case neg =>
             simp only [Bool.not_eq_true] at heq2
-            simp only [heq2, cond_false, List.length_cons]
+            simp only [heq2]
             apply ih'
             . rw [List.distinctKeys_cons_iff] at dl₁
               exact dl₁.1
@@ -8343,7 +8338,7 @@ theorem replaceEntry_eq_map [Ord α] [TransOrd α] [BEq α] [LawfulBEqOrd α] {k
   induction l with
   | nil => rfl
   | cons e es ih =>
-    simp only [replaceEntry, cond_eq_ite, List.map_cons]
+    simp only [replaceEntry, List.map_cons]
     split
     · rename_i heq
       simp only [List.cons.injEq, true_and]
@@ -8386,9 +8381,11 @@ theorem minEntry?_insertEntry [Ord α] [TransOrd α] [BEq α] [LawfulBEqOrd α] 
         | some w => if compare k w.fst |>.isLE then ⟨k, v⟩ else w) := by
   simp only [insertEntry]
   cases h : containsKey k l
-  · simp only [cond_false, minEntry?_cons, Option.some.injEq]
+  · simp only [Bool.false_eq_true, ↓reduceIte]
+    simp only [minEntry?_cons, Option.some.injEq]
     rfl
-  · rw [cond_true, minEntry?_replaceEntry hl, Option.map_eq_some_iff]
+  · simp only [↓reduceIte]
+    rw [minEntry?_replaceEntry hl, Option.map_eq_some_iff]
     have := isSome_minEntry?_of_contains ‹_›
     simp only [Option.isSome_iff_exists] at this
     obtain ⟨a, ha⟩ := this
@@ -8618,7 +8615,7 @@ theorem minEntry?_insertEntryIfNew [Ord α] [TransOrd α] [BEq α] [LawfulBEqOrd
         | some e => if compare k e.1 = .lt then ⟨k, v⟩ else e) := by
   simp [insertEntryIfNew]
   cases hc : containsKey k l
-  · simp only [cond_false, minEntry?_cons, Option.some.injEq]
+  · simp only [Bool.false_eq_true, ↓reduceIte, minEntry?_cons, Option.some.injEq]
     cases he : minEntry? l
     · simp
     · rename_i e
@@ -8631,7 +8628,7 @@ theorem minEntry?_insertEntryIfNew [Ord α] [TransOrd α] [BEq α] [LawfulBEqOrd
         · contradiction
         · simp_all [minKey?]
       · simp
-  · simp only [cond_true]
+  · simp only [↓reduceIte]
     have := isSome_minEntry?_of_containsKey hc
     cases h : minEntry? l
     · simp_all

--- a/tests/elab/bool_simp.lean
+++ b/tests/elab/bool_simp.lean
@@ -386,4 +386,4 @@ variable [Decidable u]
 #check_simp if u then u else q ~> ¬u → q
 #check_simp if u then q else u ~> u ∧ q
 #check_simp if u then q else q  ~> q
-#check_simp cond b c d !~>
+#check_simp cond b c d ~> if b then c else d


### PR DESCRIPTION
This PR turns `cond_eq_ite` into a `simp` lemma.

This means that users of `cond` now automatically benefit from the better lemma coverage of `ite`.

We also prefer `if` over `bif` in some definitions, establishing the pattern of using `ite` instead of `cond` unless there is a demonstrated benefit to using `cond`.