### PR TITLE
refactor: name the contract precondition clause `requires`

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Contract.lean
+++ b/src/Lean/Elab/Tactic/Do/Contract.lean
@@ -16,9 +16,9 @@ import Init.Syntax
 import Init.Grind.Interactive
 
 /-!
-# `require`/`ensures` contracts on `def`
+# `requires`/`ensures` contracts on `def`
 
-A definition carrying `require P` / `ensures b => Q` clauses expands to the plain definition plus a
+A definition carrying `requires P` / `ensures b => Q` clauses expands to the plain definition plus a
 `vcgen`-proven, `@[spec]`-tagged specification theorem `f.spec`.
 -/
 
@@ -72,7 +72,7 @@ private def extractSpecSection (v : Syntax) : MacroM (Option Syntax × Syntax) :
   let wf' := wf.setArg 2 (mkNullNode others)
   return (some specs[0]![3], setPath v path (mkNullNode #[wd.setArg 2 (mkNullNode #[wf'])]))
 
-/-- Expand a `def` carrying `require`/`ensures` clauses into the plain `def` plus a spec theorem
+/-- Expand a `def` carrying `requires`/`ensures` clauses into the plain `def` plus a spec theorem
 `@[spec] theorem f.spec : ⦃P⦄ f args ⦃fun b => Q⦄` proved by `vcgen`. A
 `where finally | spec => steps` section supplies `grind`-mode steps for the verification
 conditions `finish` leaves open. -/
@@ -81,19 +81,19 @@ def expandDefContract : Macro := fun stx => do
   let decl := stx[1]
   unless decl.isOfKind ``Lean.Parser.Command.definition do Macro.throwUnsupported
   -- `definition = "def "(0) >> declId(1) >> optDeclSig(2) >> (declVal <|> contractDeclVal)(3) >> …`
-  -- `contractDeclVal = optional requireClause(0) >> optional ensuresClause(1) >> declVal(2)`
+  -- `contractDeclVal = optional requiresClause(0) >> optional ensuresClause(1) >> declVal(2)`
   let val := decl[3]
   unless val.isOfKind ``Lean.Parser.Command.contractDeclVal do Macro.throwUnsupported
-  let requireStx := val[0]
+  let requiresStx := val[0]
   let ensuresStx := val[1]
   -- Replace the contract-carrying value with its inner `declVal` so the `def` elaborates normally.
-  if requireStx.isNone && ensuresStx.isNone then
+  if requiresStx.isNone && ensuresStx.isNone then
     return stx.setArg 1 (decl.setArg 3 val[2])
   let (specStep?, strippedVal) ← extractSpecSection val[2]
   let cleanDeclaration := stx.setArg 1 (decl.setArg 3 strippedVal)
   unless (← Macro.hasDecl ``Std.Internal.Do.Triple) do
-    Macro.throwErrorAt (if requireStx.isNone then ensuresStx else requireStx)
-      "`require`/`ensures` contracts elaborate to a `vcgen`-proved specification theorem; \
+    Macro.throwErrorAt (if requiresStx.isNone then ensuresStx else requiresStx)
+      "`requires`/`ensures` contracts elaborate to a `vcgen`-proved specification theorem; \
 add `import Std.Internal.Do` to use them."
   let sig := decl[2]
   let fId : Ident := ⟨decl[1][0]⟩
@@ -102,9 +102,9 @@ add `import Std.Internal.Do` to use them."
   let binders : TSyntaxArray [`ident, ``Lean.Parser.Term.hole, ``Lean.Parser.Term.bracketedBinder] :=
     sigBinders.map (⟨·⟩)
   let args := sigBinders.flatMap contractBinderIdents
-  let pre : Term ← if requireStx.isNone then `(⊤) else
-    match requireStx[0] with
-    | `(requireClause| require $p) => pure p
+  let pre : Term ← if requiresStx.isNone then `(⊤) else
+    match requiresStx[0] with
+    | `(requiresClause| requires $p) => pure p
     | _ => Macro.throwUnsupported
   let post : Term ← if ensuresStx.isNone then `(fun _ => ⊤) else
     match ensuresStx[0] with

--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -129,18 +129,18 @@ def declId := leading_parser
 -- @[builtin_doc] -- FIXME: suppress the hover
 def declSig := leading_parser
   many (ppSpace >> (Term.binderIdent <|> Term.bracketedBinder)) >> Term.typeSpec
-/-- The `require P` precondition clause of a `def` contract. -/
-def requireClause := leading_parser
-  ppIndent (ppSpace >> nonReservedSymbol "require" >> ppSpace >> withForbidden "ensures" termParser)
+/-- The `requires P` precondition clause of a `def` contract. -/
+def requiresClause := leading_parser
+  ppIndent (ppSpace >> nonReservedSymbol "requires" >> ppSpace >> withForbidden "ensures" termParser)
 /-- The `ensures b => Q` postcondition clause of a `def` contract, binding the result `b`. -/
 def ensuresClause := leading_parser
   ppIndent (ppSpace >> nonReservedSymbol "ensures" >> Term.basicFun)
-/-- The `: type` of a `def`. It may carry contract clauses, so we forbid `require`/`ensures` in the type. -/
-def defTypeSpec := withForbiddens #["require", "ensures"] Term.typeSpec
+/-- The `: type` of a `def`. It may carry contract clauses, so we forbid `requires`/`ensures` in the type. -/
+def defTypeSpec := withForbiddens #["requires", "ensures"] Term.typeSpec
 /-- `optDeclSig` matches the signature of a declaration with optional type: a list of binders and then possibly `: type` -/
 -- @[builtin_doc] -- FIXME: suppress the hover
 def optDeclSig := leading_parser
-  withForbiddens #["require", "ensures"]
+  withForbiddens #["requires", "ensures"]
     (many (ppSpace >> (Term.binderIdent <|> Term.bracketedBinder))) >>
   optional defTypeSpec
 /-- Right-hand side of a `:=` in a declaration, a term. -/
@@ -194,12 +194,12 @@ def whereStructInst  := leading_parser
   -- Issue #753 shows an example that fails to be parsed when we used `Term.whereDecls`.
   withAntiquot (mkAntiquot "declVal" decl_name% (isPseudoKind := true)) <|
     declValSimple <|> declValEqns <|> whereStructInst
-/-- `require P`/`ensures b => Q` contract clauses followed by the value of a `def`. Tried only
+/-- `requires P`/`ensures b => Q` contract clauses followed by the value of a `def`. Tried only
 after `declVal` fails, so contract-free definitions parse without probing for the clauses.
 `withoutInfo` avoids collecting `declVal`'s tokens and kinds a second time at startup; they are
 already registered through the `declVal` alternative of `definition`. -/
 def contractDeclVal := leading_parser
-  optional requireClause >> optional ensuresClause >> withoutInfo declVal
+  optional requiresClause >> optional ensuresClause >> withoutInfo declVal
 def «abbrev»         := leading_parser
   "abbrev " >> declId >> ppIndent optDeclSig >> declVal
 def derivingClass    := leading_parser

--- a/tests/elab/formatTerm.lean
+++ b/tests/elab/formatTerm.lean
@@ -14,10 +14,10 @@ def fmt (stx : CoreM Syntax) : CoreM Format := do PrettyPrinter.ppTerm ⟨← st
 #eval fmt `(do let mut acc := 0; for x in xs do acc := acc + x; return acc)
 #eval fmt `(do while c do pure ())
 #eval fmt `(do unless c do pure ())
--- intrinsic-verification clauses: `invariant` inline with the loop, `require`/`ensures` inline with `def`
+-- intrinsic-verification clauses: `invariant` inline with the loop, `requires`/`ensures` inline with `def`
 #eval fmt `(do for x in xs invariant cur => 0 ≤ acc do pure ())
-#eval fmt `(command| def clampLow (n lo : Nat) : Id Nat require lo ≤ n ensures r => r = n := pure n)
-#eval fmt `(command| def g (x : Nat) require x > 0 ensures r => r ≥ x := pure x)
+#eval fmt `(command| def clampLow (n lo : Nat) : Id Nat requires lo ≤ n ensures r => r = n := pure n)
+#eval fmt `(command| def g (x : Nat) requires x > 0 ensures r => r ≥ x := pure x)
 #eval fmt `(command| def h (x : Nat) : Id Nat ensures r => r = x := pure x
 where finally
   | spec => skip)

--- a/tests/elab/formatTerm.lean.out.expected
+++ b/tests/elab/formatTerm.lean.out.expected
@@ -49,9 +49,9 @@ do
 do
   for x✝ in xs✝ invariant cur✝ => 0 ≤ acc✝ do
     pure✝ ()
-def clampLow✝ (n✝ lo✝ : Nat✝) : Id✝ Nat✝ require lo✝ ≤ n✝ ensures r✝ => r✝ = n✝ :=
+def clampLow✝ (n✝ lo✝ : Nat✝) : Id✝ Nat✝ requires lo✝ ≤ n✝ ensures r✝ => r✝ = n✝ :=
   pure✝ n✝
-def g✝ (x✝ : Nat✝) require x✝ > 0 ensures r✝ => r✝ ≥ x✝ :=
+def g✝ (x✝ : Nat✝) requires x✝ > 0 ensures r✝ => r✝ ≥ x✝ :=
   pure✝ x✝
 def h✝ (x✝ : Nat✝) : Id✝ Nat✝ ensures r✝ => r✝ = x✝ :=
   pure✝ x✝

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -1,6 +1,6 @@
 import Std.Internal.Do
 
-/-! Tests for `def` contracts. A `def` carrying `require`/`ensures` clauses elaborates to the
+/-! Tests for `def` contracts. A `def` carrying `requires`/`ensures` clauses elaborates to the
 definition plus an `@[spec]`-tagged `f.spec` Hoare triple that `vcgen` proves automatically; a
 `for … invariant` clause inside the body supplies the loop invariant it needs. New cases go here. -/
 
@@ -13,7 +13,7 @@ activate by itself. A clause left out defaults to `⊤`, which prints as the con
 while its notation is out of scope. -/
 
 def clampLow (n lo : Nat) : Id Nat
-    require lo ≤ n
+    requires lo ≤ n
     ensures r => r = n
   := pure n
 
@@ -30,7 +30,7 @@ def onlyEnsures (n : Nat) : Id Nat
 #check @onlyEnsures.spec
 
 def onlyRequire (n : Nat) : Id Nat
-    require 0 ≤ n
+    requires 0 ≤ n
   := pure n
 
 /-- info: onlyRequire.spec : ∀ (n : Nat), ⦃ 0 ≤ n ⦄ onlyRequire n ⦃ fun x => Lean.Order.top ⦄ -/
@@ -89,11 +89,11 @@ def sumRangeMem (n : Nat) : Id Nat
 /-! ## The contract telescope is transplanted faithfully to `f.spec`
 
 `f.spec` re-binds the definition's telescope verbatim, applies `f` to exactly the explicit arguments,
-and uses `⊤` for an omitted `require`. These cover implicit, instance, strict-implicit, and autobound
+and uses `⊤` for an omitted `requires`. These cover implicit, instance, strict-implicit, and autobound
 binders, and a contract written without a `: type` ascription. -/
 
 def specImplicit {α : Type} [Inhabited α] (x : α) (n : Nat) : Id α
-    require n > 0
+    requires n > 0
     ensures r => r = x :=
   pure x
 
@@ -102,7 +102,7 @@ def specImplicit {α : Type} [Inhabited α] (x : α) (n : Nat) : Id α
 #check @specImplicit.spec
 
 def specAutobound (v : Vector Nat n) : Id Nat
-    require n > 0
+    requires n > 0
     ensures r => r = n :=
   pure v.size
 
@@ -119,7 +119,7 @@ def specStrict ⦃α : Type⦄ [Inhabited α] (x : α) : Id α
 #check @specStrict.spec
 
 def specNoType (x : Nat)
-    require x > 0
+    requires x > 0
     ensures r => r ≥ x :=
   (pure x : Id Nat)
 

--- a/tests/elab/intrinsicVerificationMissingImport.lean
+++ b/tests/elab/intrinsicVerificationMissingImport.lean
@@ -2,10 +2,10 @@
 helpful error naming the missing import, rather than a downstream elaboration failure. -/
 
 /--
-error: `require`/`ensures` contracts elaborate to a `vcgen`-proved specification theorem; add `import Std.Internal.Do` to use them.
+error: `requires`/`ensures` contracts elaborate to a `vcgen`-proved specification theorem; add `import Std.Internal.Do` to use them.
 -/
 #guard_msgs in
-def f (x : Nat) : Id Nat require x > 0 ensures r => r ≥ x := pure x
+def f (x : Nat) : Id Nat requires x > 0 ensures r => r ≥ x := pure x
 
 /-- error: the `invariant` clause elaborates to a `vcgen` gadget; add `import Std.Internal.Do` to use it. -/
 #guard_msgs in


### PR DESCRIPTION
This PR spells the precondition clause of a `def` contract `requires`, pairing with `ensures`.

The parser declaration `Lean.Parser.Command.requireClause` is renamed to `requiresClause` accordingly.
