### PR TITLE
feat: allow several `invariant` clauses on a `for` loop

### DIFF
--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -21,12 +21,12 @@ open Lean.Meta
 
 @[builtin_macro Lean.Parser.Term.doFor] def expandDoFor : Macro := fun stx => do
   match stx with
-  | `(doFor| for $[$_ : ]? $_:ident in $_ $[$_inv:doForInvariant]? do $_) =>
+  | `(doFor| for $[$_ : ]? $_:ident in $_ $_inv:doForInvariant* do $_) =>
     -- This is the target form of the expander, handled by `elabDoFor` below.
     Macro.throwUnsupported
-  | `(doFor| for%$tk $decls:doForDecl,* $[$inv:doForInvariant]? do $body) =>
-    if let some inv := inv then
-      Macro.throwErrorAt inv "The `invariant` clause is only supported on `for x in xs do …` \
+  | `(doFor| for%$tk $decls:doForDecl,* $invs:doForInvariant* do $body) =>
+    if let some inv := invs[0]? then
+      Macro.throwErrorAt inv.raw "The `invariant` clause is only supported on `for x in xs do …` \
         with a single identifier binder."
     let decls := decls.getElems
     let `(doForDecl| $[$h? : ]? $pattern in $xs) := decls[0]! | Macro.throwUnsupported
@@ -83,13 +83,14 @@ open Lean.Meta
   | _ => Macro.throwUnsupported
 
 /-- Rebuild the already-elaborated loop as a `forInWithInvariant` call carrying the `invariant`
-clause: `ForIn.forInWithInvariant`, or `ForIn'.forInWithInvariant'` for a membership-proof binder
+clauses: `ForIn.forInWithInvariant`, or `ForIn'.forInWithInvariant'` for a membership-proof binder
 (`for h : x in xs`). The state tuple's layout is `[return?, mutVars…, unit?]`, so the invariant can
-name the loop's mutable variables directly; the early-return slot becomes a wildcard. -/
-private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
+name the loop's mutable variables directly; the early-return slot becomes a wildcard. Several
+clauses turn into the pointwise meet of one invariant per clause. -/
+private def mkForInWithInvariant (invClauses : Array Syntax) (h? : Option Syntax)
     (xs preS body σ : Expr) (loopMutVars : Array MutVar) (returnsEarly : Bool)
     (mi : MonadInfo) : DoElabM Expr := do
-  let `(doForInvariant| invariant $cursorBinders* => $invBody) := invClause | throwUnsupportedSyntax
+  let ref := invClauses[0]!
   let hole ← `(_)
   let mut binders : Array Term := #[]
   if returnsEarly then binders := binders.push hole
@@ -99,22 +100,34 @@ private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
     | #[]  => `(_)
     | #[b] => pure b
     | _    => `(⟨$binders,*⟩)
-  let stateId := mkIdentFrom invClause (← mkFreshUserName `__s)
-  let invLam ← `(fun $cursorBinders* $stateId:ident =>
-    match $stateId:ident with | $statePat => $invBody)
+  -- Each clause becomes an invariant of its own, binding the cursor with the clause's binders and
+  -- the loop's mutable variables with the state pattern.
+  let mkInv (invClause : Syntax) : DoElabM Term := do
+    let `(doForInvariant| invariant $cursorBinders* => $invBody) := invClause | throwUnsupportedSyntax
+    let stateId := mkIdentFrom invClause (← mkFreshUserName `__s)
+    `(fun $cursorBinders* $stateId:ident =>
+      match $stateId:ident with | $statePat => $invBody)
+  let mut invLam ← mkInv invClauses[0]!
+  if invClauses.size > 1 then
+    let cursorId := mkIdentFrom ref (← mkFreshUserName `__cur)
+    let stateId := mkIdentFrom ref (← mkFreshUserName `__s)
+    let mut conj ← `($invLam $cursorId $stateId)
+    for invClause in invClauses[1...*] do
+      conj ← `($(mkIdent `Lean.Order.meet) $conj ($(← mkInv invClause) $cursorId $stateId))
+    invLam ← `(fun $cursorId:ident $stateId:ident => $conj)
   -- The `forInWithInvariant` gadgets live downstream of this module, so they are referenced by an
   -- unresolved name that resolves in the user's context (which imports the metatheory).
   let gadget := if h?.isSome then `Std.Internal.Do.ForIn'.forInWithInvariant'
     else `Std.Internal.Do.ForIn.forInWithInvariant
   unless (← getEnv).contains gadget do
-    throwErrorAt invClause
+    throwErrorAt ref
       "the `invariant` clause elaborates to a `vcgen` gadget; add `import Std.Internal.Do` to use it."
   let call ← `($(mkIdent gadget)
     $(← Term.exprToSyntax xs) $(← Term.exprToSyntax preS) $(← Term.exprToSyntax body) $invLam)
   Term.elabTermEnsuringType call (mkApp mi.m σ)
 
 @[builtin_doElem_elab Lean.Parser.Term.doFor] def elabDoFor : DoElab := fun stx dec => do
-  let `(doFor| for%$tk $[$h? : ]? $x:ident in $xs $[$inv?:doForInvariant]? do $body) := stx
+  let `(doFor| for%$tk $[$h? : ]? $x:ident in $xs $invs:doForInvariant* do $body) := stx
     | throwUnsupportedSyntax
   let dec ← dec.ensureUnitAt tk
   checkMutVarsForShadowing #[x]
@@ -212,9 +225,11 @@ private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
     -- Elaborate the loop body, which must have result type `PUnit`, just like the whole `for` loop.
     elabDoSeq body { dec with k := continueCont, kind := .duplicable }
 
-  let forIn ← match inv? with
-    | none => pure (mkApp app body)
-    | some invClause => mkForInWithInvariant invClause h? xs preS body σ loopMutVars info.returnsEarly mi
+  let forIn ←
+    if invs.isEmpty then
+      pure (mkApp app body)
+    else
+      mkForInWithInvariant (invs.map (·.raw)) h? xs preS body σ loopMutVars info.returnsEarly mi
 
   let γ := (← read).doBlockResultType
   let rest ←

--- a/src/Lean/Elab/Do/InferControlInfo.lean
+++ b/src/Lean/Elab/Do/InferControlInfo.lean
@@ -185,7 +185,7 @@ partial def ofElem (stx : DoElem) : TermElabM ControlInfo := do
   | `(doElem| unless $_ do $elseSeq) =>
     ControlInfo.alternative {} <$> ofSeq elseSeq
   -- For/Repeat
-  | `(doElem| for $[$[$_ :]? $_ in $_],* $[$_:doForInvariant]? do $bodySeq) =>
+  | `(doElem| for $[$[$_ :]? $_ in $_],* $_:doForInvariant* do $bodySeq) =>
     let info ← ofSeq bodySeq
     return { info with  -- keep only reassigns and returnsEarly
       numRegularExits := 1,

--- a/src/Lean/Elab/Do/Legacy.lean
+++ b/src/Lean/Elab/Do/Legacy.lean
@@ -1563,7 +1563,7 @@ mutual
      `doFor` is of the form
      ```
      def doForDecl := leading_parser termParser >> " in " >> withForbidden "do" termParser
-     def doFor := leading_parser "for " >> sepBy1 doForDecl ", " >> optional doForInvariant >> " do " >> doSeq
+     def doFor := leading_parser "for " >> sepBy1 doForDecl ", " >> many doForInvariant >> " do " >> doSeq
      ```
   -/
   partial def doForToCode (doFor : Syntax) (doElems : List Syntax) : M CodeBlock := do

--- a/src/Lean/Parser/Do.lean
+++ b/src/Lean/Parser/Do.lean
@@ -178,12 +178,13 @@ def doForDecl := leading_parser
   optional (atomic (ident >> " : ")) >> termParser >> " in " >>
     withForbiddens #["do", "invariant"] termParser
 /--
-The optional `invariant cur => e` clause of a `for` loop. The invariant annotates the loop so
+An `invariant cur => e` clause of a `for` loop. The invariant annotates the loop so
 `vcgen` reads it from the program, with `cur` bound to the iteration cursor and mutable variables
-referenced by name.
+referenced by name. A loop may carry several clauses, each binding its own `cur`; they are conjoined
+into the loop's invariant.
 -/
 def doForInvariant := leading_parser
-  ppSpace >> nonReservedSymbol "invariant" >> withForbidden "do" basicFun
+  ppLine >> nonReservedSymbol "invariant" >> withForbiddens #["do", "invariant"] basicFun
 /--
 `for x in e do s` iterates over `e` assuming `e`'s type has an instance of the `ForIn` typeclass.
 `break` and `continue` are supported inside `for` loops.
@@ -192,7 +193,7 @@ until at least one of them is exhausted.
 The types of `e2` etc. must implement the `Std.ToStream` typeclass.
 -/
 @[builtin_doElem_parser] def doFor    := leading_parser
-  "for " >> sepBy1 doForDecl ", " >> optional doForInvariant >> " do " >> doSeq
+  "for " >> sepBy1 doForDecl ", " >> ppIndent (many doForInvariant) >> " do " >> doSeq
 
 def dependentParam := leading_parser
   atomic ("(" >> nonReservedSymbol "dependent") >> " := " >>
@@ -342,7 +343,7 @@ They expand into `do unless ...`, `do for ...`, `do try ...`, and `do return ...
 @[builtin_term_parser] def termUnless := leading_parser
   "unless " >> withForbidden "do" termParser >> " do " >> doSeq
 @[builtin_term_parser] def termFor := leading_parser
-  "for " >> sepBy1 doForDecl ", " >> optional doForInvariant >> " do " >> doSeq
+  "for " >> sepBy1 doForDecl ", " >> ppIndent (many doForInvariant) >> " do " >> doSeq
 @[builtin_term_parser] def termTry    := leading_parser
   "try " >> doSeq >> many (doCatch <|> doCatchMatch) >> optional doFinally
 /--

--- a/src/Std/Internal/Do/Order/Basic.lean
+++ b/src/Std/Internal/Do/Order/Basic.lean
@@ -313,7 +313,7 @@ theorem le_forall {α : Sort u} (p : Prop) (q : α → Prop)
   · intro ⟨i, hi⟩
     exact (le_iSup f i) hi
 
-@[simp] theorem meet_prop_eq_and (a b : Prop) : (a ⊓ b : Prop) = (a ∧ b) := by
+@[grind =, simp] theorem meet_prop_eq_and (a b : Prop) : (a ⊓ b : Prop) = (a ∧ b) := by
   apply propext
   constructor
   · intro hab

--- a/tests/elab/formatTerm.lean
+++ b/tests/elab/formatTerm.lean
@@ -16,6 +16,7 @@ def fmt (stx : CoreM Syntax) : CoreM Format := do PrettyPrinter.ppTerm ⟨← st
 #eval fmt `(do unless c do pure ())
 -- intrinsic-verification clauses: `invariant` inline with the loop, `require`/`ensures` inline with `def`
 #eval fmt `(do for x in xs invariant cur => 0 ≤ acc do pure ())
+#eval fmt `(do for x in xs invariant cur => 0 ≤ acc invariant j => acc ≤ 1 do pure ())
 #eval fmt `(command| def clampLow (n lo : Nat) : Id Nat require lo ≤ n ensures r => r = n := pure n)
 #eval fmt `(command| def g (x : Nat) require x > 0 ensures r => r ≥ x := pure x)
 

--- a/tests/elab/formatTerm.lean.out.expected
+++ b/tests/elab/formatTerm.lean.out.expected
@@ -47,7 +47,13 @@ do
   unless c✝ do
     pure✝ ()
 do
-  for x✝ in xs✝ invariant cur✝ => 0 ≤ acc✝ do
+  for x✝ in xs✝
+      invariant cur✝ => 0 ≤ acc✝ do
+    pure✝ ()
+do
+  for x✝ in xs✝
+      invariant cur✝ => 0 ≤ acc✝
+      invariant j✝ => acc✝ ≤ 1 do
     pure✝ ()
 def clampLow✝ (n✝ lo✝ : Nat✝) : Id✝ Nat✝ require lo✝ ≤ n✝ ensures r✝ => r✝ = n✝ :=
   pure✝ n✝

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -66,6 +66,39 @@ def sumRangeMem (n : Nat) : Id Nat
 #guard_msgs (drop info) in
 #check @sumRangeMem.spec
 
+/-! ## Several `invariant` clauses are conjoined into the loop's invariant -/
+
+def countAndDouble (xs : List Nat) : Id (Nat × Nat)
+    ensures r => r.1 = xs.length ∧ r.2 = 2 * xs.length := do
+  let mut n := 0
+  let mut twice := 0
+  for x in xs
+      invariant cur => n = cur.prefix.length
+      invariant cur => twice = 2 * cur.prefix.length
+    do
+    n := n + 1
+    twice := twice + 2
+  return (n, twice)
+
+#guard_msgs (drop info) in
+#check @countAndDouble.spec
+
+-- Each clause binds its own cursor and may name the loop's mutable variables.
+def sumSteps (xs : List Nat) : Id Nat
+    ensures r => 0 ≤ r := do
+  let mut acc := 0
+  let mut steps := 0
+  for h : x in xs
+      invariant cur => 0 ≤ acc
+      invariant seen => steps = seen.prefix.length
+    do
+    acc := acc + x
+    steps := steps + 1
+  return acc
+
+#guard_msgs (drop info) in
+#check @sumSteps.spec
+
 /-! ## The contract telescope is transplanted faithfully to `f.spec`
 
 `f.spec` re-binds the definition's telescope verbatim, applies `f` to exactly the explicit arguments,


### PR DESCRIPTION
This PR lets a `for` loop in `do` notation carry several `invariant` clauses, each on its own line. They are conjoined into the loop's invariant, and each clause binds its own cursor variable and may name the loop's mutable variables.

```lean
def countAndDouble (xs : List Nat) : Id (Nat × Nat)
    ensures r => r.1 = xs.length ∧ r.2 = 2 * xs.length := do
  let mut n := 0
  let mut twice := 0
  for x in xs
      invariant cur => n = cur.prefix.length
      invariant cur => twice = 2 * cur.prefix.length
    do
    n := n + 1
    twice := twice + 2
  return (n, twice)
```

The clauses are conjoined in the elaborator by the pointwise meet of the assertion lattice, so the loop gadget still receives exactly one `Invariant`. `meet_prop_eq_and` becomes a `grind` rewrite so that a conjoined invariant over the `Prop` assertion lattice splits in the verification conditions, matching its siblings `top_prop_eq`, `bot_prop_eq`, and `ofProp_prop_eq`. A clause body is parsed with `invariant` forbidden, so a following clause ends the preceding body. The pretty printer puts each clause on its own line, indented under the `for`.
