### PR TITLE
feat: add `invariant` clause to `while` loops in `do` notation

### DIFF
--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -82,23 +82,60 @@ open Lean.Meta
     `(doElem| do $doElems*)
   | _ => Macro.throwUnsupported
 
-/-- Rebuild the already-elaborated loop as a `forInWithInvariant` call carrying the `invariant`
-clause: `ForIn.forInWithInvariant`, or `ForIn'.forInWithInvariant'` for a membership-proof binder
-(`for h : x in xs`). The state tuple's layout is `[return?, mutVars…, unit?]`, so the invariant can
-name the loop's mutable variables directly; the early-return slot becomes a wildcard. -/
-private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
-    (xs preS body σ : Expr) (loopMutVars : Array MutVar) (returnsEarly : Bool)
-    (mi : MonadInfo) : DoElabM Expr := do
-  let `(doForInvariant| invariant $cursorBinders* => $invBody) := invClause | throwUnsupportedSyntax
+/-- The already-elaborated pieces of a loop, handed to the builder of an `invariant` clause's
+`vcgen` gadget. -/
+structure LoopGadgetArgs where
+  /-- The collection being iterated. -/
+  xs : Expr
+  /-- The initial state tuple. -/
+  init : Expr
+  /-- The loop body, a function from the element and the state tuple to a `ForInStep`. -/
+  body : Expr
+  /-- The type of the state tuple. -/
+  σ : Expr
+  /-- The mutable variables carried through the loop, in state-tuple order. -/
+  loopMutVars : Array MutVar
+  /-- Whether the state tuple carries an early-return slot. -/
+  returnsEarly : Bool
+  /-- The monad of the surrounding `do` block. -/
+  mi : MonadInfo
+
+/-- The pattern matching the loop's state tuple. Its layout is `[return?, mutVars…, unit?]`, so an
+annotation can name the loop's mutable variables directly; the early-return slot and the filler
+become wildcards. -/
+private def LoopGadgetArgs.statePat (args : LoopGadgetArgs) : DoElabM Term := do
   let hole ← `(_)
   let mut binders : Array Term := #[]
-  if returnsEarly then binders := binders.push hole
-  for mv in loopMutVars do binders := binders.push ⟨mv.ident.raw⟩
-  if returnsEarly && loopMutVars.isEmpty then binders := binders.push hole
-  let statePat : Term ← match binders with
-    | #[]  => `(_)
-    | #[b] => pure b
-    | _    => `(⟨$binders,*⟩)
+  if args.returnsEarly then binders := binders.push hole
+  for mv in args.loopMutVars do binders := binders.push ⟨mv.ident.raw⟩
+  if args.returnsEarly && args.loopMutVars.isEmpty then binders := binders.push hole
+  match binders with
+  | #[]  => `(_)
+  | #[b] => pure b
+  | _    => `(⟨$binders,*⟩)
+
+/-- Abstract `e` over the loop's state tuple, so that `e` may refer to the loop's mutable variables
+by name. -/
+private def LoopGadgetArgs.mkStateFun (args : LoopGadgetArgs) (ref : Syntax) (e : Term) :
+    DoElabM Term := do
+  let statePat ← args.statePat
+  let stateId := mkIdentFrom ref (← mkFreshUserName `__s)
+  `(fun $stateId:ident => match $stateId:ident with | $statePat => $e)
+
+/-- Check that the `vcgen` gadget `gadget` is available in the user's context, which requires the
+metatheory to be imported. -/
+private def checkGadget (ref : Syntax) (gadget : Name) : DoElabM Unit := do
+  unless (← getEnv).contains gadget do
+    throwErrorAt ref
+      "the `invariant` clause elaborates to a `vcgen` gadget; add `import Std.Internal.Do` to use it."
+
+/-- Rebuild the already-elaborated loop as a `forInWithInvariant` call carrying the `invariant`
+clause: `ForIn.forInWithInvariant`, or `ForIn'.forInWithInvariant'` for a membership-proof binder
+(`for h : x in xs`). -/
+private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
+    (args : LoopGadgetArgs) : DoElabM Expr := do
+  let `(doForInvariant| invariant $cursorBinders* => $invBody) := invClause | throwUnsupportedSyntax
+  let statePat ← args.statePat
   let stateId := mkIdentFrom invClause (← mkFreshUserName `__s)
   let invLam ← `(fun $cursorBinders* $stateId:ident =>
     match $stateId:ident with | $statePat => $invBody)
@@ -106,16 +143,36 @@ private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
   -- unresolved name that resolves in the user's context (which imports the metatheory).
   let gadget := if h?.isSome then `Std.Internal.Do.ForIn'.forInWithInvariant'
     else `Std.Internal.Do.ForIn.forInWithInvariant
-  unless (← getEnv).contains gadget do
-    throwErrorAt invClause
-      "the `invariant` clause elaborates to a `vcgen` gadget; add `import Std.Internal.Do` to use it."
-  let call ← `($(mkIdent gadget)
-    $(← Term.exprToSyntax xs) $(← Term.exprToSyntax preS) $(← Term.exprToSyntax body) $invLam)
-  Term.elabTermEnsuringType call (mkApp mi.m σ)
+  checkGadget invClause gadget
+  let call ← `($(mkIdent gadget) $(← Term.exprToSyntax args.xs) $(← Term.exprToSyntax args.init)
+    $(← Term.exprToSyntax args.body) $invLam)
+  Term.elabTermEnsuringType call (mkApp args.mi.m args.σ)
 
-@[builtin_doElem_elab Lean.Parser.Term.doFor] def elabDoFor : DoElab := fun stx dec => do
-  let `(doFor| for%$tk $[$h? : ]? $x:ident in $xs $[$inv?:doForInvariant]? do $body) := stx
+/-- Rebuild the already-elaborated `while` loop as a `Loop.forInWithInvariant` call carrying the
+`invariant` clause's invariant and measure together with the negated loop condition `guard`. -/
+def mkWhileWithInvariant (invClause : Syntax) (guard : Term) (args : LoopGadgetArgs) :
+    DoElabM Expr := do
+  let `(doWhileInvariant| invariant $invBody $[$dec?:doWhileDecreasing]?) := invClause
     | throwUnsupportedSyntax
+  let some dec := dec?
+    | throwErrorAt invClause "A `while` loop's `invariant` clause needs a termination measure. \
+        Append `decreasing e`, where `e : Nat` strictly decreases on every iteration."
+  let `(doWhileDecreasing| decreasing $measureBody) := dec | throwUnsupportedSyntax
+  let invLam ← args.mkStateFun invClause invBody
+  let measureLam ← args.mkStateFun dec measureBody
+  let exitLam ← args.mkStateFun guard (← `(¬ $guard))
+  let gadget := `Std.Internal.Do.Loop.forInWithInvariant
+  checkGadget invClause gadget
+  let call ← `($(mkIdent gadget) $(← Term.exprToSyntax args.xs) $(← Term.exprToSyntax args.init)
+    $(← Term.exprToSyntax args.body) $measureLam $invLam $exitLam)
+  Term.elabTermEnsuringType call (mkApp args.mi.m args.σ)
+
+/-- Elaborate a `ForIn` loop over `xs` binding `x` (and optionally the membership proof `h?`) with
+body `body`. When `mkGadget?` is given, the elaborated loop is rebuilt as the `vcgen` gadget it
+returns instead of a plain `ForIn.forIn` application. `while` loops elaborate through here as a loop
+over `Loop.mk`. -/
+def elabForLoop (tk : Syntax) (h? : Option Ident) (x : Ident) (xs : Term) (body : DoSeq)
+    (mkGadget? : Option (LoopGadgetArgs → DoElabM Expr)) (dec : DoElemCont) : DoElabM Expr := do
   let dec ← dec.ensureUnitAt tk
   checkMutVarsForShadowing #[x]
   let uα ← mkFreshLevelMVar
@@ -212,9 +269,10 @@ private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
     -- Elaborate the loop body, which must have result type `PUnit`, just like the whole `for` loop.
     elabDoSeq body { dec with k := continueCont, kind := .duplicable }
 
-  let forIn ← match inv? with
+  let forIn ← match mkGadget? with
     | none => pure (mkApp app body)
-    | some invClause => mkForInWithInvariant invClause h? xs preS body σ loopMutVars info.returnsEarly mi
+    | some mkGadget =>
+      mkGadget { xs, init := preS, body, σ, loopMutVars, returnsEarly := info.returnsEarly, mi }
 
   let γ := (← read).doBlockResultType
   let rest ←
@@ -233,3 +291,9 @@ private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
           dec.continueWithUnit
 
   mkBindApp σ γ forIn rest
+
+@[builtin_doElem_elab Lean.Parser.Term.doFor] def elabDoFor : DoElab := fun stx dec => do
+  let `(doFor| for%$tk $[$h? : ]? $x:ident in $xs $[$inv?:doForInvariant]? do $body) := stx
+    | throwUnsupportedSyntax
+  let mkGadget? := inv?.map fun invClause args => mkForInWithInvariant invClause h? args
+  elabForLoop tk h? x xs body mkGadget? dec

--- a/src/Lean/Elab/BuiltinDo/Repeat.lean
+++ b/src/Lean/Elab/BuiltinDo/Repeat.lean
@@ -40,6 +40,35 @@ remove the following code without breaking the do block's type.
   | `(doElem| while%$tk $cond:doIfCond do $seq) => `(doElem| repeat%$tk if $cond:doIfCond then $seq else break)
   | _ => Macro.throwUnsupported
 
+/--
+Builtin do-element elaborator for `while … invariant` (syntax kind `Lean.Parser.Term.doWhile`).
+
+A `while` without an `invariant` clause is expanded by the macro `expandDoWhile`. The annotated form
+expands the same way, but hands the annotation to `elabForLoop`, which rebuilds the loop as the
+`Loop.forInWithInvariant` gadget that `vcgen` reads. What holds after such a loop is the invariant
+together with the negated loop condition, so control must leave the loop through a failing
+condition; `break` and early `return` in the body are rejected.
+-/
+@[builtin_doElem_elab Lean.Parser.Term.doWhile] def elabDoWhile : DoElab := fun stx dec => do
+  let `(doElem| while%$tk $cond:doIfCond $inv:doWhileInvariant do $seq) := stx
+    | throwUnsupportedSyntax
+  let guard : Term ← match cond with
+    | `(doIfProp| $[$_ :]? $guard:term) => pure guard
+    | _ => throwErrorAt inv "The `invariant` clause is only supported on a `while` loop whose \
+        condition is a proposition."
+  let info ← inferControlInfoSeq seq
+  if info.breaks || info.returnsEarly then
+    throwErrorAt inv "The assertion that holds after a `while` loop with an `invariant` clause is \
+      the invariant together with the negated loop condition, so control has to leave the loop \
+      through a failing condition. Restructure the body to leave through the loop condition, or \
+      drop the `invariant` clause."
+  let x ← Term.mkFreshIdent tk
+  let body ← `(doSeq| if $cond:doIfCond then $seq else break)
+  let expanded ← `(doElem| for%$tk $x:ident in Loop.mk do $body)
+  Term.withMacroExpansion stx expanded <| withRef expanded <|
+    elabForLoop tk none x (← `(Loop.mk)) body
+      (some fun args => mkWhileWithInvariant inv guard args) dec
+
 @[builtin_macro Lean.Parser.Term.doRepeatUntil] def expandDoRepeatUntil : Macro
   | `(doElem| repeat%$tk $seq until $cond) => `(doElem| repeat%$tk do $seq:doSeq; if $cond then break)
   | _ => Macro.throwUnsupported

--- a/src/Lean/Elab/Do/InferControlInfo.lean
+++ b/src/Lean/Elab/Do/InferControlInfo.lean
@@ -184,7 +184,16 @@ partial def ofElem (stx : DoElem) : TermElabM ControlInfo := do
     return thenInfo.alternative info
   | `(doElem| unless $_ do $elseSeq) =>
     ControlInfo.alternative {} <$> ofSeq elseSeq
-  -- For/Repeat
+  -- For/While/Repeat
+  | `(doElem| while $_:doIfCond $[$_:doWhileInvariant]? do $bodySeq) =>
+    -- Only an annotated `while` reaches here; the plain form is expanded by `expandDoWhile` above.
+    let info ← ofSeq bodySeq
+    return { info with  -- keep only reassigns and returnsEarly
+      numRegularExits := 1,
+      continues := false,
+      breaks := false,
+      noFallthrough := false,
+    }
   | `(doElem| for $[$[$_ :]? $_ in $_],* $[$_:doForInvariant]? do $bodySeq) =>
     let info ← ofSeq bodySeq
     return { info with  -- keep only reassigns and returnsEarly

--- a/src/Lean/Parser/Do.lean
+++ b/src/Lean/Parser/Do.lean
@@ -302,8 +302,22 @@ with debug assertions enabled (see the `debugAssertions` option).
 
 @[builtin_doElem_parser] def doRepeat      := leading_parser
   "repeat " >> doSeq
+/-- The `decreasing m` part of a `while` loop's `invariant` clause, supplying the termination
+measure `m`. -/
+def doWhileDecreasing := leading_parser
+  ppSpace >> nonReservedSymbol "decreasing" >> withForbidden "do" termParser
+/--
+The optional `invariant e decreasing m` clause of a `while` loop. The clause annotates the loop so
+`vcgen` reads it from the program. The invariant `e` holds before every test of the loop condition
+and refers to mutable variables by name; what holds after the loop is `e` together with the negated
+loop condition. The measure `m` is a `Nat` that strictly decreases on every iteration.
+-/
+def doWhileInvariant := leading_parser
+  ppSpace >> nonReservedSymbol "invariant" >>
+    withForbiddens #["do", "decreasing"] termParser >> optional doWhileDecreasing
 @[builtin_doElem_parser] def doWhile       := leading_parser
-  "while " >> withForbidden "do" doIfCond >> " do " >> doSeq
+  "while " >> withForbiddens #["do", "invariant"] doIfCond >> optional doWhileInvariant >>
+  " do " >> doSeq
 @[builtin_doElem_parser] def doRepeatUntil := leading_parser
   "repeat " >> doSeq >> ppDedent ppLine >> "until " >> termParser
 

--- a/src/Std/Internal/Do.lean
+++ b/src/Std/Internal/Do.lean
@@ -9,3 +9,4 @@ prelude
 public import Std.Internal.Do.WP
 public import Std.Internal.Do.Triple
 public import Std.Internal.Do.Gadget.ForIn
+public import Std.Internal.Do.Gadget.While

--- a/src/Std/Internal/Do/Gadget/While.lean
+++ b/src/Std/Internal/Do/Gadget/While.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Graf
+-/
+module
+
+prelude
+public import Std.Internal.Do.Triple.SpecLemmas
+
+/-!
+# `while` loop-invariant gadget
+
+`Loop.forInWithInvariant` annotates a `while` loop with its termination measure, its loop invariant
+and the negation of its loop condition, so that `vcgen` reads all three from the program. The gadget
+comes first, then the `@[spec]` specification that restates `Spec.forIn_loop` for the annotation.
+-/
+
+@[expose] public section
+
+namespace Std.Internal.Do
+
+open Lean.Order
+
+universe u v uₚ uₑ
+variable {β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
+variable [Monad m] [MonadTail m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
+
+set_option linter.unusedVariables false in
+/-- A `while` loop annotated with the data `vcgen` needs to verify it: a `Nat`-valued termination
+`measure` that strictly decreases on every iteration, the loop invariant `inv` that holds before
+every test of the loop condition, and `onExit`, the negated loop condition that holds once the loop
+is left. It is definitionally `forIn l init f`, so the annotation is erased at runtime. -/
+@[inline] def Loop.forInWithInvariant (l : Lean.Loop) (init : β) (f : Unit → β → m (ForInStep β))
+    (measure : RepeatVariant β) (inv : β → Pred) (onExit : β → Prop) : m β :=
+  forIn l init f
+
+/-- Specification for an annotated `while` loop. The step `Triple` either continues with a strictly
+smaller measure and the invariant restored, or leaves the loop with the invariant and `onExit`. -/
+@[spec]
+theorem Spec.forInWithInvariant_loop {l : Lean.Loop} {init : β} {f : Unit → β → m (ForInStep β)}
+    (measure : RepeatVariant β) (inv : β → Pred) (onExit : β → Prop)
+    (einv : EPred)
+    (step : ∀ b,
+      Triple
+        (f () b)
+        (inv b)
+        (fun r => match r with
+          | .yield b' => ⌜measure b' < measure b⌝ ⊓ inv b'
+          | .done b' => inv b' ⊓ ⌜onExit b'⌝)
+        einv) :
+    Triple
+      (Loop.forInWithInvariant l init f measure inv onExit)
+      (inv init)
+      (fun b => inv b ⊓ ⌜onExit b⌝)
+      einv := by
+  unfold Loop.forInWithInvariant
+  exact Spec.forIn_loop measure
+    (fun c => match c with | .inl b => inv b | .inr b => inv b ⊓ ⌜onExit b⌝) einv step
+
+end Std.Internal.Do

--- a/tests/elab/formatTerm.lean
+++ b/tests/elab/formatTerm.lean
@@ -16,6 +16,7 @@ def fmt (stx : CoreM Syntax) : CoreM Format := do PrettyPrinter.ppTerm ⟨← st
 #eval fmt `(do unless c do pure ())
 -- intrinsic-verification clauses: `invariant` inline with the loop, `require`/`ensures` inline with `def`
 #eval fmt `(do for x in xs invariant cur => 0 ≤ acc do pure ())
+#eval fmt `(do while i < n invariant i ≤ n decreasing n - i do pure ())
 #eval fmt `(command| def clampLow (n lo : Nat) : Id Nat require lo ≤ n ensures r => r = n := pure n)
 #eval fmt `(command| def g (x : Nat) require x > 0 ensures r => r ≥ x := pure x)
 

--- a/tests/elab/formatTerm.lean.out.expected
+++ b/tests/elab/formatTerm.lean.out.expected
@@ -49,6 +49,9 @@ do
 do
   for x✝ in xs✝ invariant cur✝ => 0 ≤ acc✝ do
     pure✝ ()
+do
+  while i✝ < n✝ invariant i✝ ≤ n✝ decreasing n✝ - i✝ do
+    pure✝ ()
 def clampLow✝ (n✝ lo✝ : Nat✝) : Id✝ Nat✝ require lo✝ ≤ n✝ ensures r✝ => r✝ = n✝ :=
   pure✝ n✝
 def g✝ (x✝ : Nat✝) require x✝ > 0 ensures r✝ => r✝ ≥ x✝ :=

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -3,7 +3,8 @@ import Std.Tactic.Do
 
 /-! Tests for `def` contracts. A `def` carrying `require`/`ensures` clauses elaborates to the
 definition plus an `@[spec]`-tagged `f.spec` Hoare triple that `vcgen` proves automatically; a
-`for … invariant` clause inside the body supplies the loop invariant it needs. New cases go here. -/
+`for … invariant` or `while … invariant` clause inside the body supplies the loop invariant it
+needs. New cases go here. -/
 
 open Std.Internal.Do Lean.Order
 
@@ -32,6 +33,67 @@ def findSmallest (s : Array Nat) : Id (Option Nat)
 -- The contract synthesizes an `@[spec]`-tagged `findSmallest.spec` Hoare triple.
 #guard_msgs (drop info) in
 #check @findSmallest.spec
+
+/-! ## A `while … invariant … decreasing` loop, proved with no manual steps
+
+The invariant holds before every test of the loop condition. What holds after the loop is the
+invariant together with the negated condition, which is how `i = n` becomes available below. -/
+
+def countUp (n : Nat) : Id Nat
+    ensures r => r = n
+  := do
+  let mut i := 0
+  while i < n invariant i ≤ n decreasing n - i do
+    i := i + 1
+  return i
+
+#guard_msgs (drop info) in
+#check @countUp.spec
+
+def differenceMinMax (a : Array Int) : Id Int
+    require a.size ≠ 0
+    ensures r => 0 ≤ r
+  := do
+  let mut mn := a[0]!
+  let mut mx := a[0]!
+  let mut i := 1
+  while i < a.size invariant mn ≤ mx decreasing a.size - i do
+    if a[i]! < mn then mn := a[i]!
+    if a[i]! > mx then mx := a[i]!
+    i := i + 1
+  return mx - mn
+
+#guard_msgs (drop info) in
+#check @differenceMinMax.spec
+
+-- The annotation is erased at runtime, and the loop elaborates outside `Id` as well.
+def sumUpTo (n : Nat) : StateM Nat Unit := do
+  let mut i := 0
+  while i < n invariant i ≤ n decreasing n - i do
+    modify (· + i)
+    i := i + 1
+
+#guard ((sumUpTo 5).run 0).2 = 10
+#guard Id.run (differenceMinMax #[3, 1, 4, 1, 5]) = 4
+
+/-- error: A `while` loop's `invariant` clause needs a termination measure. Append `decreasing e`, where `e : Nat` strictly decreases on every iteration. -/
+#guard_msgs in
+example (n : Nat) : Id Nat := do
+  let mut i := 0
+  while i < n invariant i ≤ n do
+    i := i + 1
+  return i
+
+/--
+error: The assertion that holds after a `while` loop with an `invariant` clause is the invariant together with the negated loop condition, so control has to leave the loop through a failing condition. Restructure the body to leave through the loop condition, or drop the `invariant` clause.
+-/
+#guard_msgs in
+example (n : Nat) : Id Nat := do
+  let mut i := 0
+  while i < n invariant i ≤ n decreasing n - i do
+    if i = 3 then break
+    i := i + 1
+  return i
 
 /-! ## `require` + `ensures` -/
 


### PR DESCRIPTION
This PR lets a `while` loop in `do` notation carry its own verification annotation: `while c invariant e decreasing m do body`. The invariant `e` holds before every test of the loop condition and refers to mutable variables by name; what holds after the loop is `e` together with the negated loop condition. `vcgen` reads both from the program, so a `def` with a `require`/`ensures` contract around such a loop verifies with no manual proof steps. This mirrors the `invariant` clause on `for` loops.

The clause proves total correctness, which is why the `decreasing` measure is mandatory. `Triple x pre post epost` is the entailment `pre ⊑ wp x post epost`, and `wp` is exact: for `Id`, `Lean.Order.MonadTail Id` orders `Id β` as a `FlatOrder` whose `⊥` is an arbitrary junk value, so a diverging loop still denotes a value and `wp` assigns it a definite postcondition. A partial-correctness rule would therefore let a diverging `while` establish `False`. `Spec.repeatM` and `Spec.forIn_loop` take a measure for the same reason, and the extrinsic `mvcgen` form in `tests/elab/while_extrinsic.lean` already supplies one.

`break` and early `return` in the body of an annotated `while` are rejected, since both leave the loop while the condition still holds and so cannot establish the loop's exit assertion.

Implementation: an annotated `while` bypasses the `expandDoWhile` macro. The new `elabDoWhile` expands it the same way, to `for _ in Loop.mk do if c then body else break`, but hands the annotation to `elabForLoop`, factored out of `elabDoFor`, which rebuilds the loop as `Std.Internal.Do.Loop.forInWithInvariant`. That gadget is definitionally `forIn l init f` and carries the measure, the invariant and the negated condition as closures over the loop's mutable-variable tuple; `Spec.forInWithInvariant_loop` restates `Spec.forIn_loop` for it.
