### PR TITLE
perf: cache elaboration of section variables across commands

### DIFF
--- a/src/Lean/Elab/Command.lean
+++ b/src/Lean/Elab/Command.lean
@@ -13,6 +13,10 @@ public import Lean.Elab.SetOption
 import Lean.Elab.DeprecatedSyntax
 public import Lean.Linter.PersistentLintLog
 public meta import Lean.Parser.Command
+import Lean.Meta.Instances
+import Lean.Util.CollectLevelMVars
+import Lean.Util.ReplaceLevel
+import Lean.Util.Sorry
 
 public section
 
@@ -24,6 +28,37 @@ Opaque linter state. Similar to `EnvExtensionState` for environment extensions.
 opaque LinterStateSpec : (α : Type) × Inhabited α := ⟨Unit, ⟨()⟩⟩
 @[expose] def LinterState : Type := LinterStateSpec.fst
 instance : Inhabited LinterState := LinterStateSpec.snd
+
+/--
+Cached elaboration of the section variables (`Scope.varDecls`) of a scope.
+
+Every command that runs `runTermElabM` puts the section variables into its local context, and
+re-elaborating the binders for each command is costly: a binder type whose class takes
+instance-implicit arguments, such as `[Module R M]`, runs type-class synthesis on each
+elaboration. This cache stores the elaborated binders of one scope so that the commands of the
+scope can reuse them. See `Elab.cacheSectionVars` for the reuse conditions.
+-/
+structure SectionVarsCache where
+  /--
+  The scope the binders were elaborated in, compared by pointer identity. Every scope update
+  creates a new `Scope` value, so this comparison conservatively invalidates the cache whenever
+  the scope changes in any way (new `variable`, `open`, `set_option`, `universe`, `include`,
+  `omit`, or a scope push or pop).
+  -/
+  scope : Scope
+  /--
+  The value of `Meta.Instances.revision` at elaboration time. A new global instance can change
+  the instance-implicit arguments synthesized inside the binder types, so the cache is not
+  reused after the instance table changes.
+  -/
+  instancesRevision : Nat
+  /--
+  The elaborated binders as a closed `∀`-telescope with `Sort 0` as an arbitrary body,
+  one binder per entry of `Scope.varUIds`. Blocks that auto-bind implicit variables are not
+  cached. The level metavariables in the term are replaced with fresh ones on each reuse, so
+  each command can still constrain the universes of the section variables independently.
+  -/
+  telescope : Expr
 
 structure State where
   env            : Environment
@@ -39,6 +74,14 @@ structure State where
   snapshotTasks  : Array (Language.SnapshotTask Language.SnapshotTree) := #[]
   prevLinterStates : Option (Task (Array LinterState)) := none
   codeQualityEntryTasks : Array (Task (Array Linter.CodeQualityLogEntry)) := #[]
+  sectionVarsCache : Option SectionVarsCache := none
+  /--
+  The scope and instance-table revision of the last `runTermElabM` cache miss. The elaborated
+  binders are stored in `sectionVarsCache` only when the same scope and revision miss twice:
+  building the closed telescope can be costly, and a scope that never recurs (for example the
+  ephemeral scope of a `set_option ... in` prefix) would pay that cost without any reuse.
+  -/
+  sectionVarsLastMiss : Option (Scope × Nat) := none
   deriving Nonempty
 
 structure Context where
@@ -1020,9 +1063,81 @@ variable (n : Nat)
       IO.println s!"{← ppExpr x} : {← ppExpr (← inferType x)}"
 ```
 -/
+register_builtin_option Elab.cacheSectionVars : Bool := {
+  defValue := true
+  descr := "cache the elaboration of section variables (`variable` command binders) and reuse it \
+    across the commands of a scope instead of re-elaborating the binders for each command\
+    \n\
+    \nThe cache is invalidated by any scope change (`variable`, `open`, `set_option`, `universe`, \
+      `include`, `omit`, entering or ending a `section` or `namespace`) and by any change to the \
+      global instance table. One observable difference remains: a global declaration made between \
+      two commands of a scope does not change how the identifiers in the binder types of earlier \
+      `variable` commands resolve for the second command, whereas re-elaboration would resolve \
+      them again."
+}
+
+private unsafe def ptrEqScopeUnsafe (a b : Scope) : Bool := ptrEq a b
+
+/--
+Pointer-identity test for scopes, used to validate `SectionVarsCache`. The reference
+implementation conservatively returns `false`; a missed reuse only costs re-elaboration.
+-/
+@[implemented_by ptrEqScopeUnsafe]
+private def ptrEqScope (_ _ : Scope) : Bool := false
+
+/--
+Reuses the elaborated section variables in `cache`: reintroduces the binders of
+`cache.telescope` into the local context with fresh level metavariables and runs `elabFn`
+on the resulting free variables, without re-elaborating any binder syntax.
+-/
+private def withSectionVarsFromCache (cache : SectionVarsCache) (varUIds : Array Name)
+    (elabFn : Array Expr → TermElabM α) : TermElabM α := do
+  -- `Term.elabBinders` runs its continuation inside `universeConstraintsCheckpoint`, so the
+  -- reuse path must do the same: the checkpoint solves the pending universe constraints of the
+  -- command and reports the failures.
+  let act : TermElabM α :=
+    Term.universeConstraintsCheckpoint do
+      -- Give each command its own copy of the level metavariables, so that a command can still
+      -- constrain the universes of the section variables independently, as re-elaboration
+      -- would.
+      let lmvarIds := (collectLevelMVars {} cache.telescope).result
+      let mut subst := #[]
+      for id in lmvarIds do
+        subst := subst.push (id, ← Meta.mkFreshLevelMVar)
+      let telescope := cache.telescope.replaceLevel fun
+        | .mvar id => subst.findSome? fun (id', u) => if id' == id then some u else none
+        | _ => none
+      Meta.forallTelescope telescope fun xs _ => do
+        let mut sectionFVars := {}
+        for i in [:varUIds.size] do
+          sectionFVars := sectionFVars.insert varUIds[i]! xs[i]!
+        withReader ({ · with sectionFVars := sectionFVars }) do
+          Term.withoutAutoBoundImplicit <| elabFn xs
+  -- With `autoImplicit` enabled, `Term.withAutoBoundImplicit` runs its continuation one
+  -- recursion-depth frame deeper; mirror the frame so that depth-limited commands behave the
+  -- same with and without reuse.
+  if autoImplicit.get (← getOptions) then withIncRecDepth act else act
+
 def runTermElabM (elabFn : Array Expr → TermElabM α) : CommandElabM α := do
   let scope ← getScope
-  liftTermElabM <|
+  let cacheEnabled := Elab.cacheSectionVars.get scope.opts
+  let instancesRevision := (Meta.instanceExtension.getState (← getEnv)).revision
+  if cacheEnabled then
+    if let some cache := (← get).sectionVarsCache then
+      if ptrEqScope cache.scope scope && cache.instancesRevision == instancesRevision then
+        return (← liftTermElabM <| withSectionVarsFromCache cache scope.varUIds elabFn)
+  -- Store the elaborated binders only when the same scope misses twice (see
+  -- `State.sectionVarsLastMiss`).
+  let recurringMiss ←
+    match (← get).sectionVarsLastMiss with
+    | some (missScope, missRevision) =>
+      pure <| ptrEqScope missScope scope && missRevision == instancesRevision
+    | none => pure false
+  unless recurringMiss do
+    modify fun s => { s with sectionVarsLastMiss := some (scope, instancesRevision) }
+  let shouldSave := cacheEnabled && recurringMiss
+  let cacheRef ← IO.mkRef (none : Option SectionVarsCache)
+  let a ← liftTermElabM <|
     Term.withAutoBoundImplicit <|
       Term.elabBinders scope.varDecls fun xs => do
         -- We need to synthesize postponed terms because this is a checkpoint for the auto-bound implicit feature
@@ -1037,6 +1152,30 @@ def runTermElabM (elabFn : Array Expr → TermElabM α) : CommandElabM α := do
           Core.resetMessageLog
           let xs ← Term.addAutoBoundImplicits xs none
           if xs.all (·.isFVar) then
+            -- Cache the elaborated binders, except in the cases in which re-elaboration is not
+            -- reproducible from the telescope alone:
+            -- * an auto-bound implicit variable resolves to a global declaration of the same
+            --   name as soon as one appears, so its meaning can change between the commands of
+            --   the scope (`xs` has more entries than `varUIds` when auto-bound variables are
+            --   present);
+            -- * a postponed universe constraint from the binder types is re-created and solved
+            --   within each command, and the telescope does not capture it;
+            -- * a `_` placeholder in a binder type remains a metavariable that each command can
+            --   constrain independently;
+            -- * error recovery can leave `sorry` in the binder types;
+            -- * an auto-bound universe name (a growth of the level names) turns into a
+            --   differently named universe parameter when the reused level metavariable is
+            --   fresh.
+            if shouldSave && xs.size == scope.varUIds.size then
+              let telescope ← instantiateMVars (← Meta.mkForallFVars xs (mkSort Level.zero))
+              unless telescope.hasExprMVar || telescope.hasSorry ||
+                  !(← Meta.getPostponed).isEmpty ||
+                  (← Term.getLevelNames) != scope.levelNames do
+                cacheRef.set <| some {
+                  scope := scope
+                  instancesRevision := instancesRevision
+                  telescope := telescope
+                }
             Term.withoutAutoBoundImplicit <| elabFn xs
           else
             -- Abstract any mvars that appear in `xs` using `mkForallFVars` (the type `mkSort Level.zero` is an arbitrary placeholder)
@@ -1045,6 +1184,9 @@ def runTermElabM (elabFn : Array Expr → TermElabM α) : CommandElabM α := do
             let ctxType ← Meta.mkForallFVars' xs (mkSort Level.zero)
             Meta.withLCtx {} {} <| Meta.forallBoundedTelescope ctxType xs.size fun xs _ =>
               Term.withoutAutoBoundImplicit <| elabFn xs
+  if let some cache ← cacheRef.get then
+    modify fun s => { s with sectionVarsCache := some cache }
+  return a
 
 private def liftAttrM {α} (x : AttrM α) : CommandElabM α := do
   liftCoreM x

--- a/src/Lean/Elab/Command.lean
+++ b/src/Lean/Elab/Command.lean
@@ -30,35 +30,82 @@ opaque LinterStateSpec : (α : Type) × Inhabited α := ⟨Unit, ⟨()⟩⟩
 instance : Inhabited LinterState := LinterStateSpec.snd
 
 /--
-Cached elaboration of the section variables (`Scope.varDecls`) of a scope.
-
-Every command that runs `runTermElabM` puts the section variables into its local context, and
-re-elaborating the binders for each command is costly: a binder type whose class takes
-instance-implicit arguments, such as `[Module R M]`, runs type-class synthesis on each
-elaboration. This cache stores the elaborated binders of one scope so that the commands of the
-scope can reuse them. See `Elab.cacheSectionVars` for the reuse conditions.
+Identifies the elaboration context of the section variables of a scope. The section variables of
+two commands with the same key elaborate to the same binders.
 -/
-structure SectionVarsCache where
+structure SectionVarsCacheKey where
   /--
-  The scope the binders were elaborated in, compared by pointer identity. Every scope update
-  creates a new `Scope` value, so this comparison conservatively invalidates the cache whenever
-  the scope changes in any way (new `variable`, `open`, `set_option`, `universe`, `include`,
-  `omit`, or a scope push or pop).
+  The scope. The test of a key compares scopes by pointer identity. Every update of a scope makes
+  a new `Scope` value, so any change of the scope gives a different key.
   -/
   scope : Scope
   /--
-  The value of `Meta.Instances.revision` at elaboration time. A new global instance can change
-  the instance-implicit arguments synthesized inside the binder types, so the cache is not
-  reused after the instance table changes.
+  The revision of the instance table. A change of the table can change the arguments that the
+  elaboration of a binder type synthesizes.
   -/
   instancesRevision : Nat
   /--
-  The elaborated binders as a closed `∀`-telescope with `Sort 0` as an arbitrary body,
-  one binder per entry of `Scope.varUIds`. Blocks that auto-bind implicit variables are not
-  cached. The level metavariables in the term are replaced with fresh ones on each reuse, so
-  each command can still constrain the universes of the section variables independently.
+  The revision of the default instance table. A change of the table can also change the arguments
+  that the elaboration of a binder type synthesizes.
   -/
-  telescope : Expr
+  defaultInstancesRevision : Nat
+
+private unsafe def ptrEqScopeUnsafe (a b : Scope) : Bool := ptrEq a b
+
+/--
+Pointer-identity test for scopes. The reference implementation returns `false`. The test is
+therefore conservative, and a negative result only costs an elaboration.
+-/
+@[implemented_by ptrEqScopeUnsafe]
+private def ptrEqScope (_ _ : Scope) : Bool := false
+
+/-- Tests whether two keys agree. The test is conservative, because it compares the scopes by
+pointer identity. -/
+private def SectionVarsCacheKey.isSame (key key' : SectionVarsCacheKey) : Bool :=
+  ptrEqScope key.scope key'.scope
+    && key.instancesRevision == key'.instancesRevision
+    && key.defaultInstancesRevision == key'.defaultInstancesRevision
+
+/-- The outcome of the elaboration of the section variables of one key. -/
+inductive SectionVarsCacheResult where
+  /--
+  The binders as a closed `∀`-telescope with `Sort 0` as the body, and with one binder per entry
+  of `Scope.varUIds`, and the binder identifier of each binder. Each reuse replaces the level
+  metavariables with fresh ones, so every command constrains the universes of the section
+  variables on its own. A reuse reopens the telescope, which makes new free variables, and adds a
+  binder info node for each identifier.
+  -/
+  | telescope (telescope : Expr) (binderIds : Array Syntax)
+  /--
+  A telescope does not reproduce the elaboration of the binders. The commands of the key
+  elaborate the binders again, and they do not build a telescope again.
+  -/
+  | notReusable
+
+/-- The elaboration of the section variables of one key. -/
+structure SectionVarsCacheEntry where
+  /-- The key of the elaboration. -/
+  key : SectionVarsCacheKey
+  /-- The outcome of the elaboration. -/
+  result : SectionVarsCacheResult
+
+/--
+Cached elaboration of the section variables (`Scope.varDecls`) of a scope.
+
+Every command that runs `runTermElabM` puts the section variables into its local context. The
+elaboration of the binders for each command is costly, because the elaboration of a binder type
+can run type-class synthesis. The cache holds the binders of one key, and the commands with the
+same key reuse them. See `Elab.cacheSectionVars` for the conditions of the reuse.
+-/
+structure SectionVarsCache where
+  /-- The elaborated section variables, if the cache holds them. -/
+  entry? : Option SectionVarsCacheEntry := none
+  /--
+  The key of the last miss. The cache takes an entry only after the same key misses twice. The
+  construction of the telescope has a cost, and a key that does not recur gives no reuse.
+  -/
+  lastMiss? : Option SectionVarsCacheKey := none
+  deriving Inhabited
 
 structure State where
   env            : Environment
@@ -74,14 +121,7 @@ structure State where
   snapshotTasks  : Array (Language.SnapshotTask Language.SnapshotTree) := #[]
   prevLinterStates : Option (Task (Array LinterState)) := none
   codeQualityEntryTasks : Array (Task (Array Linter.CodeQualityLogEntry)) := #[]
-  sectionVarsCache : Option SectionVarsCache := none
-  /--
-  The scope and instance-table revision of the last `runTermElabM` cache miss. The elaborated
-  binders are stored in `sectionVarsCache` only when the same scope and revision miss twice:
-  building the closed telescope can be costly, and a scope that never recurs (for example the
-  ephemeral scope of a `set_option ... in` prefix) would pay that cost without any reuse.
-  -/
-  sectionVarsLastMiss : Option (Scope × Nat) := none
+  sectionVarsCache : SectionVarsCache := {}
   deriving Nonempty
 
 structure Context where
@@ -1065,81 +1105,87 @@ variable (n : Nat)
 -/
 register_builtin_option Elab.cacheSectionVars : Bool := {
   defValue := true
-  descr := "cache the elaboration of section variables (`variable` command binders) and reuse it \
-    across the commands of a scope instead of re-elaborating the binders for each command\
+  descr := "cache the elaboration of the section variables of a scope, and reuse it across the \
+    commands of the scope\
     \n\
-    \nThe cache is invalidated by any scope change (`variable`, `open`, `set_option`, `universe`, \
-      `include`, `omit`, entering or ending a `section` or `namespace`) and by any change to the \
-      global instance table. One observable difference remains: a global declaration made between \
-      two commands of a scope does not change how the identifiers in the binder types of earlier \
-      `variable` commands resolve for the second command, whereas re-elaboration would resolve \
-      them again."
+    \nThe cache approximates the elaboration of the binders in the current environment. It \
+      tracks the changes that can change the result of the type-class synthesis in the binder \
+      types, and it does not track the other changes. Any change of the scope invalidates the \
+      cache, and so does a change of the instance table or of the default instance table. Two \
+      differences remain. A declaration between two commands of a scope does not change how the \
+      identifiers in the binder types of earlier `variable` commands resolve, and a change of \
+      reducibility does not run the synthesis in the binder types again."
 }
 
-private unsafe def ptrEqScopeUnsafe (a b : Scope) : Bool := ptrEq a b
-
 /--
-Pointer-identity test for scopes, used to validate `SectionVarsCache`. The reference
-implementation conservatively returns `false`; a missed reuse only costs re-elaboration.
+Reuses the section variables of `entry`: reopens the telescope in the local context with fresh
+level metavariables, and runs `elabFn` on the free variables. It elaborates no binder syntax.
 -/
-@[implemented_by ptrEqScopeUnsafe]
-private def ptrEqScope (_ _ : Scope) : Bool := false
-
-/--
-Reuses the elaborated section variables in `cache`: reintroduces the binders of
-`cache.telescope` into the local context with fresh level metavariables and runs `elabFn`
-on the resulting free variables, without re-elaborating any binder syntax.
--/
-private def withSectionVarsFromCache (cache : SectionVarsCache) (varUIds : Array Name)
-    (elabFn : Array Expr → TermElabM α) : TermElabM α := do
-  -- `Term.elabBinders` runs its continuation inside `universeConstraintsCheckpoint`, so the
-  -- reuse path must do the same: the checkpoint solves the pending universe constraints of the
-  -- command and reports the failures.
+private def withSectionVarsFromCache (cachedTelescope : Expr) (binderIds : Array Syntax)
+    (varUIds : Array Name) (elabFn : Array Expr → TermElabM α) : TermElabM α := do
+  -- `Term.elabBinders` runs its continuation inside `universeConstraintsCheckpoint`. The reuse
+  -- path does the same, so that the command solves its universe constraints and reports the
+  -- failures.
   let act : TermElabM α :=
     Term.universeConstraintsCheckpoint do
-      -- Give each command its own copy of the level metavariables, so that a command can still
-      -- constrain the universes of the section variables independently, as re-elaboration
-      -- would.
-      let lmvarIds := (collectLevelMVars {} cache.telescope).result
+      -- Each command gets its own copy of the level metavariables, so that it constrains the
+      -- universes of the section variables on its own.
+      let lmvarIds := (collectLevelMVars {} cachedTelescope).result
       let mut subst := #[]
       for id in lmvarIds do
         subst := subst.push (id, ← Meta.mkFreshLevelMVar)
-      let telescope := cache.telescope.replaceLevel fun
+      let telescope := cachedTelescope.replaceLevel fun
         | .mvar id => subst.findSome? fun (id', u) => if id' == id then some u else none
         | _ => none
-      Meta.forallTelescope telescope fun xs _ => do
+      Meta.forallBoundedTelescope telescope varUIds.size fun xs _ => do
+        -- The free variables are new. The language server finds the binder of a free variable
+        -- through its info node, so add a node for each binder again.
+        for binderId in binderIds, x in xs do
+          Term.addLocalVarInfo binderId x
         let mut sectionFVars := {}
-        for i in [:varUIds.size] do
-          sectionFVars := sectionFVars.insert varUIds[i]! xs[i]!
+        for uid in varUIds, x in xs do
+          sectionFVars := sectionFVars.insert uid x
         withReader ({ · with sectionFVars := sectionFVars }) do
           Term.withoutAutoBoundImplicit <| elabFn xs
-  -- With `autoImplicit` enabled, `Term.withAutoBoundImplicit` runs its continuation one
-  -- recursion-depth frame deeper; mirror the frame so that depth-limited commands behave the
-  -- same with and without reuse.
+  -- `Term.withAutoBoundImplicit` runs its continuation one recursion-depth frame deeper when
+  -- `autoImplicit` is on. The reuse path mirrors the frame, so that the recursion depth agrees.
   if autoImplicit.get (← getOptions) then withIncRecDepth act else act
 
 def runTermElabM (elabFn : Array Expr → TermElabM α) : CommandElabM α := do
   let scope ← getScope
-  let cacheEnabled := Elab.cacheSectionVars.get scope.opts
-  let instancesRevision := (Meta.instanceExtension.getState (← getEnv)).revision
+  -- A scope without section variables has nothing to reuse, and the work of the cache would
+  -- cost more than the elaboration of the empty block.
+  let cacheEnabled := !scope.varDecls.isEmpty && Elab.cacheSectionVars.get scope.opts
+  -- The key of the entry to store, if this command must store one.
+  let mut saveKey? : Option SectionVarsCacheKey := none
   if cacheEnabled then
-    if let some cache := (← get).sectionVarsCache then
-      if ptrEqScope cache.scope scope && cache.instancesRevision == instancesRevision then
-        return (← liftTermElabM <| withSectionVarsFromCache cache scope.varUIds elabFn)
-  -- Store the elaborated binders only when the same scope misses twice (see
-  -- `State.sectionVarsLastMiss`).
-  let recurringMiss ←
-    match (← get).sectionVarsLastMiss with
-    | some (missScope, missRevision) =>
-      pure <| ptrEqScope missScope scope && missRevision == instancesRevision
-    | none => pure false
-  unless recurringMiss do
-    modify fun s => { s with sectionVarsLastMiss := some (scope, instancesRevision) }
-  let shouldSave := cacheEnabled && recurringMiss
-  let cacheRef ← IO.mkRef (none : Option SectionVarsCache)
+    let env ← getEnv
+    let key : SectionVarsCacheKey := {
+      scope
+      instancesRevision := (Meta.instanceExtension.getState env).revision
+      defaultInstancesRevision := (Meta.defaultInstanceExtension.getState env).revision
+    }
+    let cache := (← get).sectionVarsCache
+    let hit? := match cache.entry? with
+      | some entry => if entry.key.isSame key then some entry.result else none
+      | none => none
+    match hit? with
+    | some (.telescope telescope binderIds) =>
+      return (← liftTermElabM <|
+        withSectionVarsFromCache telescope binderIds scope.varUIds elabFn)
+    | some .notReusable => pure ()
+    | none =>
+      if cache.lastMiss?.any (·.isSame key) then
+        saveKey? := some key
+      else
+        modify fun s => { s with sectionVarsCache.lastMiss? := some key }
+  let entryRef ← IO.mkRef (none : Option SectionVarsCacheEntry)
   let a ← liftTermElabM <|
     Term.withAutoBoundImplicit <|
-      Term.elabBinders scope.varDecls fun xs => do
+      -- `elabBindersEx` also reports the binder syntax of each free variable. A later reuse
+      -- needs it for the binder info nodes.
+      Term.elabBindersEx scope.varDecls fun binders => do
+        let xs := binders.map (·.2)
         -- We need to synthesize postponed terms because this is a checkpoint for the auto-bound implicit feature
         -- If we don't use this checkpoint here, then auto-bound implicits in the postponed terms will not be handled correctly.
         Term.synthesizeSyntheticMVarsNoPostponing
@@ -1152,40 +1198,35 @@ def runTermElabM (elabFn : Array Expr → TermElabM α) : CommandElabM α := do
           Core.resetMessageLog
           let xs ← Term.addAutoBoundImplicits xs none
           if xs.all (·.isFVar) then
-            -- Cache the elaborated binders, except in the cases in which re-elaboration is not
-            -- reproducible from the telescope alone:
-            -- * an auto-bound implicit variable resolves to a global declaration of the same
-            --   name as soon as one appears, so its meaning can change between the commands of
-            --   the scope (`xs` has more entries than `varUIds` when auto-bound variables are
-            --   present);
-            -- * a postponed universe constraint from the binder types is re-created and solved
-            --   within each command, and the telescope does not capture it;
-            -- * a `_` placeholder in a binder type remains a metavariable that each command can
-            --   constrain independently;
-            -- * error recovery can leave `sorry` in the binder types;
-            -- * an auto-bound universe name (a growth of the level names) turns into a
-            --   differently named universe parameter when the reused level metavariable is
-            --   fresh.
-            if shouldSave && xs.size == scope.varUIds.size then
-              let telescope ← instantiateMVars (← Meta.mkForallFVars xs (mkSort Level.zero))
-              unless telescope.hasExprMVar || telescope.hasSorry ||
-                  !(← Meta.getPostponed).isEmpty ||
-                  (← Term.getLevelNames) != scope.levelNames do
-                cacheRef.set <| some {
-                  scope := scope
-                  instancesRevision := instancesRevision
-                  telescope := telescope
-                }
+            -- The telescope reproduces the elaboration only when the binders are closed and
+            -- final. An auto-bound variable can resolve to a later declaration, a metavariable
+            -- or a postponed universe constraint belongs to a single command, error recovery
+            -- leaves `sorry`, and a new universe name would change the parameter names.
+            if let some saveKey := saveKey? then
+              let result ←
+                if xs.size != scope.varUIds.size then
+                  pure .notReusable
+                else
+                  let telescope ← instantiateMVars (← Meta.mkForallFVars xs (mkSort Level.zero))
+                  if telescope.hasExprMVar || telescope.hasSorry ||
+                      !(← Meta.getPostponed).isEmpty ||
+                      (← Term.getLevelNames) != scope.levelNames then
+                    pure .notReusable
+                  else
+                    pure <| .telescope telescope (binders.map (·.1))
+              entryRef.set <| some { key := saveKey, result }
             Term.withoutAutoBoundImplicit <| elabFn xs
           else
+            if let some saveKey := saveKey? then
+              entryRef.set <| some { key := saveKey, result := .notReusable }
             -- Abstract any mvars that appear in `xs` using `mkForallFVars` (the type `mkSort Level.zero` is an arbitrary placeholder)
             -- and then rebuild the local context from scratch.
             -- Resetting prevents the local context from including the original fvars from `xs`.
             let ctxType ← Meta.mkForallFVars' xs (mkSort Level.zero)
             Meta.withLCtx {} {} <| Meta.forallBoundedTelescope ctxType xs.size fun xs _ =>
               Term.withoutAutoBoundImplicit <| elabFn xs
-  if let some cache ← cacheRef.get then
-    modify fun s => { s with sectionVarsCache := some cache }
+  if let some entry ← entryRef.get then
+    modify fun s => { s with sectionVarsCache.entry? := some entry }
   return a
 
 private def liftAttrM {α} (x : AttrM α) : CommandElabM α := do

--- a/src/Lean/Meta/Instances.lean
+++ b/src/Lean/Meta/Instances.lean
@@ -78,9 +78,8 @@ structure Instances where
   instanceNames : PHashMap Name InstanceEntry := {}
   erased        : PHashSet Name := {}
   /--
-  Counter incremented on every instance addition or erasure. Consumers such as
-  `Lean.Elab.Command.SectionVarsCache` compare revisions to detect that the instance table
-  is unchanged.
+  Counter of the changes of the table. A consumer compares two revisions to detect that the
+  table is unchanged.
   -/
   revision      : Nat := 0
   deriving Inhabited
@@ -391,10 +390,15 @@ abbrev PrioritySet := Std.TreeSet Nat (fun x y => compare y x)
 structure DefaultInstances where
   defaultInstances : NameMap (List (Name × Nat)) := {}
   priorities       : PrioritySet := {}
+  /--
+  Counter of the changes of the table. A consumer compares two revisions to detect that the
+  table is unchanged.
+  -/
+  revision         : Nat := 0
   deriving Inhabited
 
 def addDefaultInstanceEntry (d : DefaultInstances) (e : DefaultInstanceEntry) : DefaultInstances :=
-  let d := { d with priorities := d.priorities.insert e.priority }
+  let d := { d with priorities := d.priorities.insert e.priority, revision := d.revision + 1 }
   match d.defaultInstances.find? e.className with
   | some insts => { d with defaultInstances := d.defaultInstances.insert e.className <| (e.instanceName, e.priority) :: insts }
   | none       => { d with defaultInstances := d.defaultInstances.insert e.className [(e.instanceName, e.priority)] }

--- a/src/Lean/Meta/Instances.lean
+++ b/src/Lean/Meta/Instances.lean
@@ -77,15 +77,21 @@ structure Instances where
   discrTree     : InstanceTree := DiscrTree.empty
   instanceNames : PHashMap Name InstanceEntry := {}
   erased        : PHashSet Name := {}
+  /--
+  Counter incremented on every instance addition or erasure. Consumers such as
+  `Lean.Elab.Command.SectionVarsCache` compare revisions to detect that the instance table
+  is unchanged.
+  -/
+  revision      : Nat := 0
   deriving Inhabited
 
 def addInstanceEntry (d : Instances) (e : InstanceEntry) : Instances :=
   match e.globalName? with
-  | some n => { d with discrTree := d.discrTree.insertKeyValue e.keys e, instanceNames := d.instanceNames.insert n e, erased := d.erased.erase n }
-  | none   => { d with discrTree := d.discrTree.insertKeyValue e.keys e }
+  | some n => { d with discrTree := d.discrTree.insertKeyValue e.keys e, instanceNames := d.instanceNames.insert n e, erased := d.erased.erase n, revision := d.revision + 1 }
+  | none   => { d with discrTree := d.discrTree.insertKeyValue e.keys e, revision := d.revision + 1 }
 
 def Instances.eraseCore (d : Instances) (declName : Name) : Instances :=
-  { d with erased := d.erased.insert declName, instanceNames := d.instanceNames.erase declName }
+  { d with erased := d.erased.insert declName, instanceNames := d.instanceNames.erase declName, revision := d.revision + 1 }
 
 def Instances.erase [Monad m] [MonadError m] (d : Instances) (declName : Name) : m Instances := do
   unless d.instanceNames.contains declName do

--- a/tests/elab/sectionVarsCache.lean
+++ b/tests/elab/sectionVarsCache.lean
@@ -1,0 +1,135 @@
+/-! # Section variable cache tests
+
+`runTermElabM` caches the elaboration of section variables and reuses it for the commands of a
+scope (see `Elab.cacheSectionVars` and `Lean.Elab.Command.SectionVarsCache`). These tests check
+that the reuse is not observable, except for the documented resolution snapshot below.
+-/
+
+/-! A command can constrain the universe of a section variable without affecting the other
+commands of the scope: the cache re-instantiates the level metavariables for each command. -/
+
+section
+variable {M : Type _}
+
+theorem t1 (_h : M = Nat) : True := trivial
+theorem t2 : M = M := rfl
+
+/-- info: @t1 : ∀ {M : Type}, M = Nat → True -/
+#guard_msgs in #check @t1
+
+/-- info: @t2 : ∀ {M : Type u_1}, M = M -/
+#guard_msgs in #check @t2
+end
+
+/-! A `_` placeholder in a binder type is solved per command; such blocks are not cached. -/
+
+section
+variable (n : _)
+
+theorem t3 : n = (5 : Nat) → True := fun _ => trivial
+theorem t4 : n = "s" → True := fun _ => trivial
+
+/-- info: t3 : ∀ (n : Nat), n = 5 → True -/
+#guard_msgs in #check @t3
+
+/-- info: t4 : ∀ (n : String), n = "s" → True -/
+#guard_msgs in #check @t4
+end
+
+/-! A new instance invalidates the cache: the instance-implicit arguments inside binder types
+are re-synthesized after the instance table changes. -/
+
+class A (α : Type) where
+class B (α : Type) [A α] where
+
+instance a1 : A Nat := ⟨⟩
+
+section
+set_option linter.unusedSectionVars false
+
+variable [inst : B Nat]
+include inst
+
+theorem t5 : True := trivial
+
+instance (priority := high) a2 : A Nat := ⟨⟩
+
+theorem t6 : True := trivial
+
+/-- info: @t5 : ∀ [inst : @B Nat a1], True -/
+#guard_msgs in
+set_option pp.explicit true in #check @t5
+
+/-- info: @t6 : ∀ [inst : @B Nat a2], True -/
+#guard_msgs in
+set_option pp.explicit true in #check @t6
+end
+
+/-! The cache freezes how the identifiers in binder types resolve: a declaration made between
+two commands of a scope does not change the meaning of the section variables of earlier
+`variable` commands. Without the cache, `s2` would be about `Shadow.Nat`. -/
+
+namespace Shadow
+section
+variable (x : Nat)
+
+theorem s1 : x = x := rfl
+
+def Nat := Unit
+
+theorem s2 : x = x := rfl
+
+/-- info: s1 : ∀ (x : _root_.Nat), x = x -/
+#guard_msgs in #check @s1
+
+/-- info: s2 : ∀ (x : _root_.Nat), x = x -/
+#guard_msgs in #check @s2
+end
+end Shadow
+
+/-! The cache can be disabled. -/
+
+section
+set_option Elab.cacheSectionVars false
+
+variable (m : Nat)
+
+theorem t7 : m = m := rfl
+
+/-- info: t7 : ∀ (m : Nat), m = m -/
+#guard_msgs in #check @t7
+end
+
+/-! `include` and `omit` change the scope and so rebuild the cache. -/
+
+section
+variable {p : Nat} (hp : p = 0)
+
+include hp
+
+theorem t8 : p = 0 := hp
+
+theorem t9 : p + 0 = 0 := by rw [Nat.add_zero, hp]
+
+omit hp in
+theorem t10 : p = p := rfl
+
+/-- info: @t8 : ∀ {p : Nat}, p = 0 → p = 0 -/
+#guard_msgs in #check @t8
+
+/-- info: @t10 : ∀ {p : Nat}, p = p -/
+#guard_msgs in #check @t10
+end
+
+/-! An auto-bound universe name in a binder type disables the cache for the block, so the
+universe parameter names of the declarations do not change. -/
+
+section
+variable {γ : Sort u} (g : γ → γ)
+
+theorem t11 : ∀ x : γ, g x = g x := fun _ => rfl
+theorem t12 : ∀ x : γ, g x = g x := fun _ => rfl
+
+/-- info: @t12 : ∀ {γ : Sort u_1} (g : γ → γ) (x : γ), g x = g x -/
+#guard_msgs in #check @t12
+end

--- a/tests/elab/sectionVarsCache.lean
+++ b/tests/elab/sectionVarsCache.lean
@@ -1,12 +1,12 @@
 /-! # Section variable cache tests
 
-`runTermElabM` caches the elaboration of section variables and reuses it for the commands of a
-scope (see `Elab.cacheSectionVars` and `Lean.Elab.Command.SectionVarsCache`). These tests check
-that the reuse is not observable, except for the documented resolution snapshot below.
+`runTermElabM` caches the elaboration of the section variables and reuses it for the commands of
+a scope. See `Elab.cacheSectionVars` and `Lean.Elab.Command.SectionVarsCache`. These tests check
+that the reuse makes no observable difference, except for the resolution of the identifiers.
 -/
 
-/-! A command can constrain the universe of a section variable without affecting the other
-commands of the scope: the cache re-instantiates the level metavariables for each command. -/
+/-! A command constrains the universe of a section variable. The other commands of the scope keep
+their own universes, because the cache makes fresh level metavariables for each command. -/
 
 section
 variable {M : Type _}
@@ -21,7 +21,8 @@ theorem t2 : M = M := rfl
 #guard_msgs in #check @t2
 end
 
-/-! A `_` placeholder in a binder type is solved per command; such blocks are not cached. -/
+/-! Each command solves a `_` placeholder in a binder type on its own. The cache does not take
+such a block. -/
 
 section
 variable (n : _)
@@ -36,8 +37,8 @@ theorem t4 : n = "s" → True := fun _ => trivial
 #guard_msgs in #check @t4
 end
 
-/-! A new instance invalidates the cache: the instance-implicit arguments inside binder types
-are re-synthesized after the instance table changes. -/
+/-! A new instance invalidates the cache. The elaboration synthesizes the arguments in the binder
+types again. -/
 
 class A (α : Type) where
 class B (α : Type) [A α] where
@@ -65,9 +66,9 @@ set_option pp.explicit true in #check @t5
 set_option pp.explicit true in #check @t6
 end
 
-/-! The cache freezes how the identifiers in binder types resolve: a declaration made between
-two commands of a scope does not change the meaning of the section variables of earlier
-`variable` commands. Without the cache, `s2` would be about `Shadow.Nat`. -/
+/-! The cache keeps the resolution of the identifiers in the binder types. A declaration between
+two commands of a scope does not change the section variables of an earlier `variable` command.
+Without the cache, `s2` uses `Shadow.Nat`. -/
 
 namespace Shadow
 section
@@ -87,7 +88,7 @@ theorem s2 : x = x := rfl
 end
 end Shadow
 
-/-! The cache can be disabled. -/
+/-! The option disables the cache. -/
 
 section
 set_option Elab.cacheSectionVars false
@@ -100,7 +101,7 @@ theorem t7 : m = m := rfl
 #guard_msgs in #check @t7
 end
 
-/-! `include` and `omit` change the scope and so rebuild the cache. -/
+/-! `include` and `omit` change the scope. The cache takes a new entry. -/
 
 section
 variable {p : Nat} (hp : p = 0)
@@ -121,8 +122,8 @@ theorem t10 : p = p := rfl
 #guard_msgs in #check @t10
 end
 
-/-! An auto-bound universe name in a binder type disables the cache for the block, so the
-universe parameter names of the declarations do not change. -/
+/-! An auto-bound universe name in a binder type stops the cache for the block. The universe
+parameter names of the declarations stay the same. -/
 
 section
 variable {γ : Sort u} (g : γ → γ)
@@ -132,4 +133,121 @@ theorem t12 : ∀ x : γ, g x = g x := fun _ => rfl
 
 /-- info: @t12 : ∀ {γ : Sort u_1} (g : γ → γ) (x : γ), g x = g x -/
 #guard_msgs in #check @t12
+end
+
+/-! Type-class synthesis finds a section-variable instance in the commands that reuse the cached
+binders. -/
+
+class Cls (α : Type) where
+  val : α
+
+def clsVal (α : Type) [Cls α] : α := Cls.val
+
+section
+variable [inst : Cls Nat]
+include inst
+
+theorem i1 : clsVal Nat = clsVal Nat := rfl
+theorem i2 : clsVal Nat = clsVal Nat := rfl
+-- `i3` is the first command of the scope that reuses the cached binders.
+theorem i3 : clsVal Nat = clsVal Nat := rfl
+
+/-- info: @i3 : ∀ [inst : Cls Nat], clsVal Nat = clsVal Nat -/
+#guard_msgs in #check @i3
+end
+
+/-! The binder annotations of the section variables stay the same through the cached telescope. -/
+
+section
+variable {a : Nat} ⦃b : Nat⦄ (c : Nat)
+
+theorem b1 : a + b + c = a + b + c := rfl
+theorem b2 : a + b + c = a + b + c := rfl
+theorem b3 : a + b + c = a + b + c := rfl
+
+/-- info: @b3 : ∀ {a : Nat} ⦃b : Nat⦄ (c : Nat), a + b + c = a + b + c -/
+#guard_msgs in #check @b3
+end
+
+/-! An erasure of an instance also invalidates the cache. -/
+
+section
+set_option linter.unusedSectionVars false
+
+variable [inst : B Nat]
+include inst
+
+theorem e1 : True := trivial
+theorem e2 : True := trivial
+theorem e3 : True := trivial
+
+attribute [-instance] a2
+
+theorem e4 : True := trivial
+
+/-- info: @e4 : ∀ [inst : @B Nat a1], True -/
+#guard_msgs in
+set_option pp.explicit true in #check @e4
+end
+
+/-! The cache does not take a block that auto-binds an implicit variable. Each command elaborates
+the auto-bound binder again. -/
+
+section
+variable (g : γ → γ)
+
+theorem ab1 : ∀ x, g x = g x := fun _ => rfl
+theorem ab2 : ∀ x, g x = g x := fun _ => rfl
+theorem ab3 : ∀ x, g x = g x := fun _ => rfl
+
+/-- info: @ab3 : ∀ {γ : Sort u_1} (g : γ → γ) (x : γ), g x = g x -/
+#guard_msgs in #check @ab3
+end
+
+/-! A new default instance invalidates the cache. Default instances take part in the elaboration
+of the binder types. -/
+
+structure Wrap where
+  val : Nat
+
+instance wrapOfNat (n : Nat) : OfNat Wrap n := ⟨⟨n⟩⟩
+
+section
+set_option linter.unusedSectionVars false
+
+variable (h : 5 = 5)
+include h
+
+theorem di1 : True := trivial
+theorem di2 : True := trivial
+
+/-- info: di2 : (5 : Nat) = (5 : Nat) → True -/
+#guard_msgs in
+set_option pp.numericTypes true in #check @di2
+
+attribute [default_instance 2000] wrapOfNat
+
+theorem di3 : True := trivial
+
+/-- info: di3 : (5 : Wrap) = (5 : Wrap) → True -/
+#guard_msgs in
+set_option pp.numericTypes true in #check @di3
+end
+
+/-! A `set_option ... in` prefix makes a temporary scope. The commands after the prefix reuse the
+binders of the outer scope. -/
+
+section
+variable (y : Nat)
+
+theorem p1 : y = y := rfl
+theorem p2 : y = y := rfl
+
+set_option maxHeartbeats 400000 in
+theorem p3 : y = y := rfl
+
+theorem p4 : y = y := rfl
+
+/-- info: p4 : ∀ (y : Nat), y = y -/
+#guard_msgs in #check @p4
 end

--- a/tests/server_interactive/sectionVarsCacheInfo.lean
+++ b/tests/server_interactive/sectionVarsCacheInfo.lean
@@ -1,0 +1,22 @@
+/-! Go-to-definition and document highlight keep working on the section variables in the commands
+that reuse the cached elaboration. See `Elab.cacheSectionVars`.
+
+The cache takes an entry only after the same key misses twice, so `t3` is the first command that
+reuses it. A reuse reopens the telescope and makes new free variables, and `runTermElabM` adds a
+binder info node for each of them. -/
+
+section
+variable (x : Nat)
+
+theorem t1 : x = x := rfl
+
+theorem t2 : x = x := rfl
+
+theorem t3 : x = x := rfl
+           --^ textDocument/definition
+           --^ textDocument/documentHighlight
+
+def d4 : Nat := x
+              --^ textDocument/definition
+
+end

--- a/tests/server_interactive/sectionVarsCacheInfo.lean.out.expected
+++ b/tests/server_interactive/sectionVarsCacheInfo.lean.out.expected
@@ -1,0 +1,53 @@
+{"textDocument": {"uri": "file:///sectionVarsCacheInfo.lean"},
+ "position": {"line": 14, "character": 13}}
+[{"targetUri": "file:///sectionVarsCacheInfo.lean",
+  "targetSelectionRange":
+  {"start": {"line": 8, "character": 10}, "end": {"line": 8, "character": 11}},
+  "targetRange":
+  {"start": {"line": 8, "character": 10}, "end": {"line": 8, "character": 11}},
+  "originSelectionRange":
+  {"start": {"line": 14, "character": 13},
+   "end": {"line": 14, "character": 14}}}]
+{"textDocument": {"uri": "file:///sectionVarsCacheInfo.lean"},
+ "position": {"line": 14, "character": 13}}
+[{"range":
+  {"start": {"line": 8, "character": 10}, "end": {"line": 8, "character": 11}},
+  "kind": 1},
+ {"range":
+  {"start": {"line": 10, "character": 13},
+   "end": {"line": 10, "character": 14}},
+  "kind": 1},
+ {"range":
+  {"start": {"line": 10, "character": 17},
+   "end": {"line": 10, "character": 18}},
+  "kind": 1},
+ {"range":
+  {"start": {"line": 12, "character": 13},
+   "end": {"line": 12, "character": 14}},
+  "kind": 1},
+ {"range":
+  {"start": {"line": 12, "character": 17},
+   "end": {"line": 12, "character": 18}},
+  "kind": 1},
+ {"range":
+  {"start": {"line": 14, "character": 13},
+   "end": {"line": 14, "character": 14}},
+  "kind": 1},
+ {"range":
+  {"start": {"line": 14, "character": 17},
+   "end": {"line": 14, "character": 18}},
+  "kind": 1},
+ {"range":
+  {"start": {"line": 18, "character": 16},
+   "end": {"line": 18, "character": 17}},
+  "kind": 1}]
+{"textDocument": {"uri": "file:///sectionVarsCacheInfo.lean"},
+ "position": {"line": 18, "character": 16}}
+[{"targetUri": "file:///sectionVarsCacheInfo.lean",
+  "targetSelectionRange":
+  {"start": {"line": 8, "character": 10}, "end": {"line": 8, "character": 11}},
+  "targetRange":
+  {"start": {"line": 8, "character": 10}, "end": {"line": 8, "character": 11}},
+  "originSelectionRange":
+  {"start": {"line": 18, "character": 16},
+   "end": {"line": 18, "character": 17}}}]


### PR DESCRIPTION
This PR caches the elaboration of section variables. Before this change, `runTermElabM` elaborated the binders of every `variable` command in scope for each command. The elaboration of a binder type can run type-class synthesis, and every command of a section repeats that work. In long Mathlib sections, this cost reaches 20–30% of the instructions of a module (see the analysis in the discussion of leanprover-community/mathlib4#42214, which removes dead binders for this reason; live binders pay the same cost).

The cache holds the binders of the current scope as a closed telescope in the command state. A command reuses the telescope when the cache key agrees. The key holds the scope, the revision of the instance table and the revision of the default instance table, and `Meta.Instances` and `Meta.DefaultInstances` each get a `revision` counter for it. The key compares scopes by pointer identity, so any change of the scope gives a different key. Each reuse makes fresh level metavariables, so every command constrains the universes of the section variables on its own. The cache does not take a block when the elaboration auto-binds an implicit variable or a universe name, leaves a metavariable or a postponed universe constraint, or contains `sorry`. The reuse path repeats the universe checkpoint and the recursion depth of the elaboration path.

A reuse reopens the telescope, which makes new free variables. The language server finds the binder of a free variable through its info node, so `runTermElabM` adds a binder info node for each new free variable. It takes the binder syntax from `Term.elabBindersEx` and adds the nodes with `Term.addLocalVarInfo`. `MutualDef` uses the same pattern after it reopens the telescope of a declaration. Without the nodes, go-to-definition, document highlight and find-references stop working on the section variables.

A scope without section variables skips the cache, because it has nothing to reuse and the work of the cache costs more than the elaboration of the empty block. The cache also stores a negative outcome. A block whose elaboration a telescope cannot reproduce, for example a block that auto-binds a universe name with `Type*`, built and discarded a telescope for every command of the scope. The cache records the outcome once, and the later commands of the scope elaborate the binders without that work.

The cache is an approximation, not an exact replay. It tracks the changes of the environment that can change the result of the type-class synthesis in the binder types, and it does not track the other changes. A new instance or a new default instance therefore invalidates the cache. A declaration that shadows a name in a binder type does not invalidate it, and a change of reducibility does not either. The visible consequence is the resolution of identifiers: with the cache, a declaration between two commands of a scope does not change how the identifiers in the binder types of earlier `variable` commands resolve. Set the option `Elab.cacheSectionVars` to `false` for the old behavior.

This criterion needs a decision from the reviewers. No document states when the binder types of a `variable` command resolve, and the present behavior follows from the storage of the binders as syntax. The [`variable` command discussion](https://leanprover-community.github.io/archive/stream/270676-lean4/topic/Lean.204.20variable.20command.20discussion.html) on Zulip lists the current behavior as a defect, because the variables "elaborate to different expressions in different declarations", and it proposes a cache as one remedy. The cache removes that difference for identifiers and keeps it for instances. A full freeze is the other coherent option: it drops both revision counters and is simpler and faster, but it also stops a later instance from reaching an earlier binder, which is more likely to affect real code.

Validation: a differential run of all 3097 files in `tests/elab` with the option on and off converged to no behavioral differences. The remaining diffs are environmental (timings, backtrace addresses, random bytes, pointer values, task interleavings), one metavariable index in an error message (the test driver strips these), and the documented resolution change. The differential run also found the need for three of the guards above, which shows the method works. A microbenchmark (80 trivial theorems under 20 instance binders) drops from 0.17s to 0.08s, against a 0.07s floor without binders. No test of the suite depends on the old resolution behavior. A `!bench` run of an earlier revision measured -0.34% of the instructions of the build, with -10.45% for `Std.Data.DHashMap.Lemmas` and similar gains for the other `Std.Data` lemma modules. The same run showed small regressions for modules without section variables, and the two paragraphs above remove that cost.

`tests/elab/sectionVarsCache.lean` documents the invariants and the resolution change. It also covers the type-class synthesis that finds a section-variable instance on the reuse path, the binder annotations that survive the telescope, the addition and the erasure of an instance, the invalidation by a default instance, the blocks that the cache does not take, and the temporary scope of a `set_option ... in` prefix. `tests/server_interactive/sectionVarsCacheInfo.lean` checks go-to-definition and document highlight on a section variable in a command that reuses the cache.

This is a draft to run the Mathlib benchmarks through a `lean-pr-testing` toolchain and measure the real-world gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
