### PR TITLE
refactor: make the `Std.Internal.Do` loop invariant non-dependent

### DIFF
--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -84,12 +84,16 @@ open Lean.Meta
 
 /-- Rebuild the already-elaborated loop as a `forInWithInvariant` call carrying the `invariant`
 clause: `ForIn.forInWithInvariant`, or `ForIn'.forInWithInvariant'` for a membership-proof binder
-(`for h : x in xs`). The state tuple's layout is `[return?, mutVars…, unit?]`, so the invariant can
-name the loop's mutable variables directly; the early-return slot becomes a wildcard. -/
+(`for h : x in xs`). The clause binds the elements consumed so far and the elements remaining. The
+state tuple's layout is `[return?, mutVars…, unit?]`, so the invariant can name the loop's mutable
+variables directly; the early-return slot becomes a wildcard. -/
 private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
     (xs preS body σ : Expr) (loopMutVars : Array MutVar) (returnsEarly : Bool)
     (mi : MonadInfo) : DoElabM Expr := do
-  let `(doForInvariant| invariant $cursorBinders* => $invBody) := invClause | throwUnsupportedSyntax
+  let `(doForInvariant| invariant $listBinders* => $invBody) := invClause | throwUnsupportedSyntax
+  unless listBinders.size == 2 do
+    throwErrorAt invClause "The `invariant` clause takes two binders: the elements consumed so far \
+      and the elements remaining."
   let hole ← `(_)
   let mut binders : Array Term := #[]
   if returnsEarly then binders := binders.push hole
@@ -100,7 +104,7 @@ private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
     | #[b] => pure b
     | _    => `(⟨$binders,*⟩)
   let stateId := mkIdentFrom invClause (← mkFreshUserName `__s)
-  let invLam ← `(fun $cursorBinders* $stateId:ident =>
+  let invLam ← `(fun $listBinders* $stateId:ident =>
     match $stateId:ident with | $statePat => $invBody)
   -- The `forInWithInvariant` gadgets live downstream of this module, so they are referenced by an
   -- unresolved name that resolves in the user's context (which imports the metatheory).

--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -89,21 +89,21 @@ name the loop's mutable variables directly; the early-return slot becomes a wild
 private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
     (xs preS body σ : Expr) (loopMutVars : Array MutVar) (returnsEarly : Bool)
     (mi : MonadInfo) : DoElabM Expr := do
-  let `(doForInvariant| invariant $listBinders* => $invBody) := invClause | throwUnsupportedSyntax
-  unless listBinders.size == 2 do
+  let `(doForInvariant| invariant $binders* => $invBody) := invClause | throwUnsupportedSyntax
+  unless binders.size == 2 do
     throwErrorAt invClause "The `invariant` clause takes two binders: the elements consumed so far \
       and the elements remaining."
   let hole ← `(_)
-  let mut binders : Array Term := #[]
-  if returnsEarly then binders := binders.push hole
-  for mv in loopMutVars do binders := binders.push ⟨mv.ident.raw⟩
-  if returnsEarly && loopMutVars.isEmpty then binders := binders.push hole
-  let statePat : Term ← match binders with
+  let mut stateBinders : Array Term := #[]
+  if returnsEarly then stateBinders := stateBinders.push hole
+  for mv in loopMutVars do stateBinders := stateBinders.push ⟨mv.ident.raw⟩
+  if returnsEarly && loopMutVars.isEmpty then stateBinders := stateBinders.push hole
+  let statePat : Term ← match stateBinders with
     | #[]  => `(_)
     | #[b] => pure b
-    | _    => `(⟨$binders,*⟩)
+    | _    => `(⟨$stateBinders,*⟩)
   let stateId := mkIdentFrom invClause (← mkFreshUserName `__s)
-  let invLam ← `(fun $listBinders* $stateId:ident =>
+  let invLam ← `(fun $binders* $stateId:ident =>
     match $stateId:ident with | $statePat => $invBody)
   -- The `forInWithInvariant` gadgets live downstream of this module, so they are referenced by an
   -- unresolved name that resolves in the user's context (which imports the metatheory).

--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -84,9 +84,8 @@ open Lean.Meta
 
 /-- Rebuild the already-elaborated loop as a `forInWithInvariant` call carrying the `invariant`
 clause: `ForIn.forInWithInvariant`, or `ForIn'.forInWithInvariant'` for a membership-proof binder
-(`for h : x in xs`). The clause binds the elements consumed so far and the elements remaining. The
-state tuple's layout is `[return?, mutVars…, unit?]`, so the invariant can name the loop's mutable
-variables directly; the early-return slot becomes a wildcard. -/
+(`for h : x in xs`). The state tuple's layout is `[return?, mutVars…, unit?]`, so the invariant can
+name the loop's mutable variables directly; the early-return slot becomes a wildcard. -/
 private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
     (xs preS body σ : Expr) (loopMutVars : Array MutVar) (returnsEarly : Bool)
     (mi : MonadInfo) : DoElabM Expr := do

--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -84,7 +84,7 @@ open Lean.Meta
 
 /-- Rebuild the already-elaborated loop as a `forInWithInvariant` call carrying the `invariant`
 clause: `ForIn.forInWithInvariant`, or `ForIn'.forInWithInvariant'` for a membership-proof binder
-(`for h : x in xs`). The state tuple's layout is `[return?, mutVars…, unit?]`, so the invariant can
+(`for h : x in xs`). The mut tuple's layout is `[return?, mutVars…, unit?]`, so the invariant can
 name the loop's mutable variables directly; the early-return slot becomes a wildcard. -/
 private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
     (xs preS body σ : Expr) (loopMutVars : Array MutVar) (returnsEarly : Bool)
@@ -94,17 +94,17 @@ private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
     throwErrorAt invClause "The `invariant` clause takes two binders: the elements consumed so far \
       and the elements remaining."
   let hole ← `(_)
-  let mut stateBinders : Array Term := #[]
-  if returnsEarly then stateBinders := stateBinders.push hole
-  for mv in loopMutVars do stateBinders := stateBinders.push ⟨mv.ident.raw⟩
-  if returnsEarly && loopMutVars.isEmpty then stateBinders := stateBinders.push hole
-  let statePat : Term ← match stateBinders with
+  let mut mutBinders : Array Term := #[]
+  if returnsEarly then mutBinders := mutBinders.push hole
+  for mv in loopMutVars do mutBinders := mutBinders.push ⟨mv.ident.raw⟩
+  if returnsEarly && loopMutVars.isEmpty then mutBinders := mutBinders.push hole
+  let mutTuplePat : Term ← match mutBinders with
     | #[]  => `(_)
     | #[b] => pure b
-    | _    => `(⟨$stateBinders,*⟩)
-  let stateId := mkIdentFrom invClause (← mkFreshUserName `__s)
-  let invLam ← `(fun $binders* $stateId:ident =>
-    match $stateId:ident with | $statePat => $invBody)
+    | _    => `(⟨$mutBinders,*⟩)
+  let mutTupleBinder := mkIdentFrom invClause (← mkFreshUserName `__s)
+  let invLam ← `(fun $binders* $mutTupleBinder:ident =>
+    match $mutTupleBinder:ident with | $mutTuplePat => $invBody)
   -- The `forInWithInvariant` gadgets live downstream of this module, so they are referenced by an
   -- unresolved name that resolves in the user's context (which imports the metatheory).
   let gadget := if h?.isSome then `Std.Internal.Do.ForIn'.forInWithInvariant'

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Driver.lean
@@ -41,8 +41,8 @@ public def elabInvariant (invariantAlts : Std.HashMap Nat Syntax) (n : Nat) (mv 
           `(tactic| (rename_i $args*; exact $rhs))
       | _ => return false
     -- `withDefault`: the surrounding grind context forces reducible transparency,
-    -- under which the invariant's binder type (e.g. `List.Cursor _`) isn't
-    -- resolved enough for term elaboration of `xs.suffix.length` to succeed.
+    -- under which the invariant's type isn't resolved enough for term elaboration
+    -- of the alternative's right-hand side to succeed.
     withRef alt <| discard <| Meta.withDefault <| Lean.Elab.runTactic mv tac {} {}
     -- The tactic runs without throwing even when it fails to close the goal;
     -- check explicitly that the MVar got assigned.

--- a/src/Lean/Parser/Do.lean
+++ b/src/Lean/Parser/Do.lean
@@ -178,9 +178,9 @@ def doForDecl := leading_parser
   optional (atomic (ident >> " : ")) >> termParser >> " in " >>
     withForbiddens #["do", "invariant"] termParser
 /--
-The optional `invariant cur => e` clause of a `for` loop. The invariant annotates the loop so
-`vcgen` reads it from the program, with `cur` bound to the iteration cursor and mutable variables
-referenced by name.
+The optional `invariant pref suff => e` clause of a `for` loop. The invariant annotates the loop so
+`vcgen` reads it from the program, with `pref` bound to the elements consumed so far, `suff` to the
+elements remaining, and mutable variables referenced by name.
 -/
 def doForInvariant := leading_parser
   ppSpace >> nonReservedSymbol "invariant" >> withForbidden "do" basicFun

--- a/src/Std/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Do/Triple/SpecLemmas.lean
@@ -75,10 +75,6 @@ structure Cursor {α : Type u} (l : List α) : Type u where
   /-- Appending the prefix to the suffix yields the original list. -/
   property : «prefix» ++ suffix = l
 
-/-- Transports a cursor along an equality of the list it ranges over. -/
-@[inline] def Cursor.cast {α} {l l' : List α} (c : Cursor l) (h : l = l') : Cursor l' :=
-  ⟨c.prefix, c.suffix, h ▸ c.property⟩
-
 /--
 Creates a cursor at position `n` in the list `l`.
 The prefix contains the first `n` elements, and the suffix contains the remaining elements.

--- a/src/Std/Internal/Do/Gadget/ForIn.lean
+++ b/src/Std/Internal/Do/Gadget/ForIn.lean
@@ -34,136 +34,106 @@ variable [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
 set_option linter.unusedVariables false in
 /-- A `forIn` loop annotated with its loop invariant, which `vcgen` reads from the `inv` argument.
 It is definitionally `forIn xs init f`, so the annotation is erased at runtime. The invariant
-ranges over the loop's iteration cursor, viewed through `ForIn.toList`. -/
-@[inline] def ForIn.forInWithInvariant {ρ : Type w} [ForIn m ρ α] [ForIn Id ρ α] (xs : ρ) (init : β)
-    (f : α → β → m (ForInStep β)) (inv : Invariant (ForIn.toList xs) β Pred) : m β :=
+ranges over the elements consumed so far, the elements remaining, and the loop state. -/
+@[inline] def ForIn.forInWithInvariant {ρ : Type w} [ForIn m ρ α] (xs : ρ) (init : β)
+    (f : α → β → m (ForInStep β)) (inv : Invariant α β Pred) : m β :=
   forIn xs init f
 
 set_option linter.unusedVariables false in
 /-- A membership-aware `forIn'` loop annotated with its loop invariant, which `vcgen` reads from the
 `inv` argument. It is definitionally `forIn' xs init f`, so the annotation is erased at runtime. The
-invariant ranges over the loop's iteration cursor, viewed through `ForIn.toList`. -/
+invariant ranges over the elements consumed so far, the elements remaining, and the loop state. -/
 @[inline] def ForIn'.forInWithInvariant' {ρ : Type w} {d : Membership α ρ} [ForIn' m ρ α d]
-    [ForIn Id ρ α] (xs : ρ) (init : β) (f : (a : α) → a ∈ xs → β → m (ForInStep β))
-    (inv : Invariant (ForIn.toList xs) β Pred) : m β :=
+    (xs : ρ) (init : β) (f : (a : α) → a ∈ xs → β → m (ForInStep β))
+    (inv : Invariant α β Pred) : m β :=
   forIn' xs init f
-
-/-! ## Bridge lemmas
-
-`ForIn.toList xs` unfolds to the concrete list of each container, so the specifications below can
-present their cursors over that concrete list and keep `ForIn.toList` out of the verification
-conditions. -/
-
-private theorem foldl_push_toList {γ : Type u₁} (xs : List γ) (acc : Array γ) :
-    (xs.foldl (fun acc a => acc.push a) acc).toList = acc.toList ++ xs := by
-  induction xs generalizing acc with
-  | nil => simp
-  | cons a xs ih => rw [List.foldl_cons, ih, Array.toList_push]; simp
-
-theorem ForIn.toList_list {γ : Type u₁} (xs : List γ) : ForIn.toList xs = xs := by
-  simp only [ForIn.toList, ForIn.toArray, Id.run, List.forIn_pure_yield_eq_foldl]
-  change (List.foldl (fun acc a => acc.push a) #[] xs).toList = xs
-  rw [foldl_push_toList]; simp
-
-theorem ForIn.toList_range (r : Std.Legacy.Range) : ForIn.toList r = r.toList := by
-  simp only [ForIn.toList, ForIn.toArray, Id.run, Std.Legacy.Range.forIn_eq_forIn_range',
-    List.forIn_pure_yield_eq_foldl]
-  change (List.foldl (fun acc a => acc.push a) #[]
-    (List.range' r.start r.size r.step)).toList = r.toList
-  rw [foldl_push_toList]; simp [Std.Legacy.Range.toList, Std.Legacy.Range.size]
 
 /-! ## Specifications -/
 
 @[spec]
 theorem Spec.forInWithInvariant_list
     {xs : List α} {init : β} {f : α → β → m (ForInStep β)}
-    (inv : Invariant (ForIn.toList xs) β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : xs = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : xs = pref ++ cur :: suff) b,
       Triple
         (f cur b)
-        (inv ⟨pref, cur::suff, by simp [ForIn.toList_list, h]⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | .yield b' => inv ⟨pref ++ [cur], suff, by simp [ForIn.toList_list, h]⟩ b'
-          | .done b' => inv ⟨xs, [], by simp [ForIn.toList_list]⟩ b')
+          | .yield b' => inv (pref ++ [cur]) suff b'
+          | .done b' => inv xs [] b')
         epost) :
     Triple
       (ForIn.forInWithInvariant xs init f inv)
-      (inv ⟨[], xs, by simp [ForIn.toList_list]⟩ init)
-      (fun b => inv ⟨xs, [], by simp [ForIn.toList_list]⟩ b)
+      (inv [] xs init)
+      (fun b => inv xs [] b)
       epost := by
-  have key : ForIn.toList xs = xs := ForIn.toList_list xs
   unfold ForIn.forInWithInvariant
-  exact Spec.forIn_list (inv := fun c b => inv (c.cast key.symm) b) step
+  exact Spec.forIn_list inv step
 
 @[spec]
 theorem Spec.forInWithInvariant_range {β : Type u} {m : Type u → Type v} {Pred EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {xs : Std.Legacy.Range} {init : β} {f : Nat → β → m (ForInStep β)}
-    (inv : Invariant (ForIn.toList xs) β Pred)
+    (inv : Invariant Nat β Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur b)
-        (inv ⟨pref, cur::suff, by simp [ForIn.toList_range, h]⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | .yield b' => inv ⟨pref ++ [cur], suff, by simp [ForIn.toList_range, h]⟩ b'
-          | .done b' => inv ⟨xs.toList, [], by simp [ForIn.toList_range]⟩ b')
+          | .yield b' => inv (pref ++ [cur]) suff b'
+          | .done b' => inv xs.toList [] b')
         epost) :
     Triple
       (ForIn.forInWithInvariant xs init f inv)
-      (inv ⟨[], xs.toList, by simp [ForIn.toList_range]⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp [ForIn.toList_range]⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
-  have key : ForIn.toList xs = xs.toList := ForIn.toList_range xs
   unfold ForIn.forInWithInvariant
-  rw [show (forIn xs init f : m β) = forIn xs.toList init f by
-    simp [Std.Legacy.Range.forIn_eq_forIn_range', Std.Legacy.Range.toList, Std.Legacy.Range.size]]
-  exact Spec.forIn_list (inv := fun c b => inv (c.cast key.symm) b) step
+  exact Spec.forIn_range inv step
 
 @[spec]
 theorem Spec.forInWithInvariant'_list
     {xs : List α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
-    (inv : Invariant (ForIn.toList xs) β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs = pref ++ cur :: suff) b,
       Triple
         (f cur (by simp [h]) b)
-        (inv ⟨pref, cur::suff, by simp [ForIn.toList_list, h]⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | .yield b' => inv ⟨pref ++ [cur], suff, by simp [ForIn.toList_list, h]⟩ b'
-          | .done b' => inv ⟨xs, [], by simp [ForIn.toList_list]⟩ b')
+          | .yield b' => inv (pref ++ [cur]) suff b'
+          | .done b' => inv xs [] b')
         epost) :
     Triple
       (ForIn'.forInWithInvariant' xs init f inv)
-      (inv ⟨[], xs, by simp [ForIn.toList_list]⟩ init)
-      (fun b => inv ⟨xs, [], by simp [ForIn.toList_list]⟩ b)
+      (inv [] xs init)
+      (fun b => inv xs [] b)
       epost := by
-  have key : ForIn.toList xs = xs := ForIn.toList_list xs
   unfold ForIn'.forInWithInvariant'
-  exact Spec.forIn'_list (inv := fun c b => inv (c.cast key.symm) b) step
+  exact Spec.forIn'_list inv step
 
 @[spec]
 theorem Spec.forInWithInvariant'_range {β : Type u} {m : Type u → Type v} {Pred EPred : Type u}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {xs : Std.Legacy.Range} {init : β} {f : (a : Nat) → a ∈ xs → β → m (ForInStep β)}
-    (inv : Invariant (ForIn.toList xs) β Pred)
+    (inv : Invariant Nat β Pred)
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur (by simp [Std.Legacy.Range.mem_of_mem_range', h]) b)
-        (inv ⟨pref, cur::suff, by simp [ForIn.toList_range, h]⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | .yield b' => inv ⟨pref ++ [cur], suff, by simp [ForIn.toList_range, h]⟩ b'
-          | .done b' => inv ⟨xs.toList, [], by simp [ForIn.toList_range]⟩ b')
+          | .yield b' => inv (pref ++ [cur]) suff b'
+          | .done b' => inv xs.toList [] b')
         epost) :
     Triple
       (ForIn'.forInWithInvariant' xs init f inv)
-      (inv ⟨[], xs.toList, by simp [ForIn.toList_range]⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp [ForIn.toList_range]⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
-  have key : ForIn.toList xs = xs.toList := ForIn.toList_range xs
   unfold ForIn'.forInWithInvariant'
-  exact Spec.forIn'_range (inv := fun c b => inv (c.cast key.symm) b) step
+  exact Spec.forIn'_range inv step
 
 end Std.Internal.Do

--- a/src/Std/Internal/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Internal/Do/Triple/SpecLemmas.lean
@@ -622,8 +622,7 @@ variable [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
 
 /-- The type of loop invariants used by the specifications of `for ... in ...` loops.
 A loop invariant maps the elements consumed so far, the elements remaining, and the accumulator
-state to an assertion. The exception postcondition is specified separately as the spec's `epost`
-parameter. -/
+state to an assertion. -/
 @[spec_invariant_type, simp, grind =]
 def Invariant (α : Type u₁) (β : Type u₂) (Pred : Type uₚ) :=
   List α → List α → β → Pred

--- a/src/Std/Internal/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Internal/Do/Triple/SpecLemmas.lean
@@ -621,56 +621,57 @@ variable {α : Type u₁} {β : Type (max u₁ u₂)} {m : Type (max u₁ u₂) 
 variable [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
 
 /-- The type of loop invariants used by the specifications of `for ... in ...` loops.
-A loop invariant maps the iteration cursor and accumulator state to an assertion.
-The exception postcondition is specified separately as the spec's `epost` parameter. -/
+A loop invariant maps the elements consumed so far, the elements remaining, and the accumulator
+state to an assertion. The exception postcondition is specified separately as the spec's `epost`
+parameter. -/
 @[spec_invariant_type, simp, grind =]
-def Invariant {α : Type u₁} (xs : List α) (β : Type u₂) (Pred : Type uₚ) :=
-  List.Cursor xs → β → Pred
+def Invariant (α : Type u₁) (β : Type u₂) (Pred : Type uₚ) :=
+  List α → List α → β → Pred
 
 /-- An invariant combinator for loops with early return, for the new `do` elaborator which
 uses `Prod` for the state tuple: `onContinue` is the invariant while iterating, `onReturn`
 holds once the loop returned early with a value. -/
-noncomputable abbrev Invariant.withEarlyReturnNewDo {α : Type u₁} {xs : List α} {β : Type u₂}
+noncomputable abbrev Invariant.withEarlyReturnNewDo {α : Type u₁} {β : Type u₂}
     {γ : Type u₂} (Pred) [Assertion Pred]
-    (onContinue : List.Cursor xs → β → Pred)
+    (onContinue : List α → List α → β → Pred)
     (onReturn : γ → β → Pred) :
-    Invariant xs (Option γ × β) Pred :=
-  fun xs ⟨x, b⟩ =>
-        (⌜x = none⌝ ⊓ onContinue xs b)
-      ⊔ (iSup fun r => ⌜x = some r ∧ xs.suffix = []⌝ ⊓ onReturn r b)
+    Invariant α (Option γ × β) Pred :=
+  fun pref suff ⟨x, b⟩ =>
+        (⌜x = none⌝ ⊓ onContinue pref suff b)
+      ⊔ (iSup fun r => ⌜x = some r ∧ suff = []⌝ ⊓ onReturn r b)
 
 @[spec]
 theorem Spec.forIn'_list
     {xs : List α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
-    (inv : Invariant xs β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs = pref ++ cur :: suff) b,
       Triple
         (f cur (by simp [h]) b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-                 | .yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-                 | .done b' => inv ⟨xs, [], by simp⟩ b')
+                 | .yield b' => inv (pref ++ [cur]) suff b'
+                 | .done b' => inv xs [] b')
         epost) :
     Triple
       (forIn' xs init f)
-      (inv ⟨[], xs, rfl⟩ init)
-      (fun b => inv ⟨xs, [], by simp⟩ b)
+      (inv [] xs init)
+      (fun b => inv xs [] b)
       epost := by
-  suffices h : ∀ c,
+  suffices h : ∀ pref suff (hxs : xs = pref ++ suff),
       Triple
-        (forIn' (m:=m) c.suffix init (fun a ha => f a (by simp [←c.property, ha])))
-        (inv c init)
-        (fun b => inv ⟨xs, [], by simp⟩ b)
+        (forIn' (m:=m) suff init (fun a ha => f a (by simp [hxs, ha])))
+        (inv pref suff init)
+        (fun b => inv xs [] b)
         epost
-    from h ⟨[], xs, rfl⟩
-  rintro ⟨pref, suff, h⟩
+    from h [] xs rfl
+  intro pref suff hxs
   induction suff generalizing pref init
-  case nil => apply Triple.pure; simp [←h]; rfl
+  case nil => apply Triple.pure; simp [hxs]; rfl
   case cons x suff ih =>
     simp only [List.forIn'_cons]
     apply Triple.bind
-    case hx => exact step _ _ _ h.symm init
+    case hx => exact step _ _ _ hxs init
     case hf =>
       intro r
       split
@@ -678,9 +679,7 @@ theorem Spec.forIn'_list
         apply Triple.pure; rfl
       next b => -- .yield case
         simp
-        have := @ih b (pref ++ [x]) (by simp [h])
-        simp at this
-        exact this
+        exact @ih b (pref ++ [x]) (by simp [hxs])
 
 
 theorem Spec.forIn'_list_const_inv
@@ -694,7 +693,7 @@ theorem Spec.forIn'_list_const_inv
         (fun r => match r with | .yield b' => inv b' | .done b' => inv b')
         epost) :
     Triple (forIn' xs init f) (inv init) inv epost :=
-  Spec.forIn'_list (fun _ b => inv b)
+  Spec.forIn'_list (fun _ _ b => inv b)
     (fun _p c _s h b => step c (by rw [h]; exact List.mem_append_right _ (List.Mem.head _)) b)
 
 
@@ -702,20 +701,20 @@ theorem Spec.forIn'_list_const_inv
 @[spec]
 theorem Spec.forIn_list
     {xs : List α} {init : β} {f : α → β → m (ForInStep β)}
-    (inv : Invariant xs β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : xs = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : xs = pref ++ cur :: suff) b,
       Triple
         (f cur b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | .yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | .done b' => inv ⟨xs, [], by simp⟩ b')
+          | .yield b' => inv (pref ++ [cur]) suff b'
+          | .done b' => inv xs [] b')
         epost) :
     Triple
       (forIn xs init f)
-      (inv ⟨[], xs, rfl⟩ init)
-      (fun b => inv ⟨xs, [], by simp⟩ b)
+      (inv [] xs init)
+      (fun b => inv xs [] b)
       epost := by
   simp only [← forIn'_eq_forIn]
   exact Spec.forIn'_list inv step
@@ -731,24 +730,24 @@ theorem Spec.forIn_list_const_inv
         (fun r => match r with | .yield b' => inv b' | .done b' => inv b')
         epost) :
     Triple (forIn xs init f) (inv init) inv epost :=
-  Spec.forIn_list (fun _ b => inv b) (fun _p c _s _h b => step c b)
+  Spec.forIn_list (fun _ _ b => inv b) (fun _p c _s _h b => step c b)
 
 
 @[spec]
 theorem Spec.foldlM_list
     {xs : List α} {init : β} {f : β → α → m β}
-    (inv : Invariant xs β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : xs = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : xs = pref ++ cur :: suff) b,
       Triple
         (f b cur)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
-        (fun b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b')
+        (inv pref (cur::suff) b)
+        (fun b' => inv (pref ++ [cur]) suff b')
         epost) :
     Triple
       (List.foldlM f init xs)
-      (inv ⟨[], xs, rfl⟩ init)
-      (fun b => inv ⟨xs, [], by simp⟩ b)
+      (inv [] xs init)
+      (fun b => inv xs [] b)
       epost := by
   have : xs.foldlM f init = forIn xs init (fun a b => ForInStep.yield <$> f b a) := by
     simp [List.forIn_yield_eq_foldlM, id_map']
@@ -770,27 +769,27 @@ theorem Spec.foldlM_list_const_inv
         (fun b' => inv b')
         epost) :
     Triple (List.foldlM f init xs) (inv init) inv epost :=
-    Spec.foldlM_list (fun _ b => inv b) (fun _p c _s _h b => step c b)
+    Spec.foldlM_list (fun _ _ b => inv b) (fun _p c _s _h b => step c b)
 
 
 @[spec]
 theorem Spec.forIn'_range {β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {xs : Std.Legacy.Range} {init : β} {f : (a : Nat) → a ∈ xs → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant Nat β Pred)
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur (by simp [Std.Legacy.Range.mem_of_mem_range', h]) b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn' xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [Std.Legacy.Range.forIn'_eq_forIn'_range', Std.Legacy.Range.size, Std.Legacy.Range.size.eq_1]
   exact Spec.forIn'_list inv (fun c hcur b => step c hcur b)
@@ -800,20 +799,20 @@ theorem Spec.forIn'_range {β : Type u} {m : Type u → Type v} {Pred : Type u�
 theorem Spec.forIn_range {β : Type u} {m : Type u → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
     [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {xs : Std.Legacy.Range} {init : β} {f : Nat → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant Nat β Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [Std.Legacy.Range.forIn_eq_forIn_range', Std.Legacy.Range.size]
   exact Spec.forIn_list inv step
@@ -826,20 +825,20 @@ theorem Spec.forIn'_rcc {α β : Type u} {m : Type u → Type v} {Pred : Type u�
     [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
     {xs : Rcc α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur (by simp [← Rcc.mem_toList_iff_mem, h]) b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn' xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [Rcc.forIn'_eq_forIn'_toList]
   exact Spec.forIn'_list inv step
@@ -852,20 +851,20 @@ theorem Spec.forIn_rcc {α β : Type u} {m : Type u → Type v} {Pred : Type u�
     [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
     {xs : Rcc α} {init : β} {f : α → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [forIn]
   exact Spec.forIn'_rcc inv step
@@ -878,20 +877,20 @@ theorem Spec.forIn'_rco {α β : Type u} {m : Type u → Type v} {Pred : Type u�
     [LE α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLT α]
     {xs : Rco α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur (by simp [← Rco.mem_toList_iff_mem, h]) b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn' xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [Rco.forIn'_eq_forIn'_toList]
   exact Spec.forIn'_list inv step
@@ -904,20 +903,20 @@ theorem Spec.forIn_rco {α β : Type u} {m : Type u → Type v} {Pred : Type u�
     [LE α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLT α]
     {xs : Rco α} {init : β} {f : α → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [forIn]
   exact Spec.forIn'_rco inv step
@@ -930,20 +929,20 @@ theorem Spec.forIn'_rci {α β : Type u} {m : Type u → Type v} {Pred : Type u�
     [LE α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
     {xs : Rci α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur (by simp [← Rci.mem_toList_iff_mem, h]) b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn' xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [Rci.forIn'_eq_forIn'_toList]
   exact Spec.forIn'_list inv step
@@ -956,20 +955,20 @@ theorem Spec.forIn_rci {α β : Type u} {m : Type u → Type v} {Pred : Type u�
     [LE α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
     {xs : Rci α} {init : β} {f : α → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [forIn]
   exact Spec.forIn'_rci inv step
@@ -982,20 +981,20 @@ theorem Spec.forIn'_roc {α β : Type u} {m : Type u → Type v} {Pred : Type u�
     [LE α] [DecidableLE α] [LT α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLT α]
     {xs : Roc α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur (by simp [← Roc.mem_toList_iff_mem, h]) b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn' xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [Roc.forIn'_eq_forIn'_toList]
   exact Spec.forIn'_list inv step
@@ -1007,20 +1006,20 @@ theorem Spec.forIn_roc {α β : Type u} {m : Type u → Type v} {Pred : Type u�
     [LE α] [DecidableLE α] [LT α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLT α]
     {xs : Roc α} {init : β} {f : α → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [forIn]
   exact Spec.forIn'_roc inv step
@@ -1033,20 +1032,20 @@ theorem Spec.forIn'_roo {α β : Type u} {m : Type u → Type v} {Pred : Type u�
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
     {xs : Roo α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur (by simp [← Roo.mem_toList_iff_mem, h]) b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn' xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [Roo.forIn'_eq_forIn'_toList]
   exact Spec.forIn'_list inv step
@@ -1059,20 +1058,20 @@ theorem Spec.forIn_roo {α β : Type u} {m : Type u → Type v} {Pred : Type u�
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
     {xs : Roo α} {init : β} {f : α → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [forIn]
   exact Spec.forIn'_roo inv step
@@ -1085,20 +1084,20 @@ theorem Spec.forIn'_roi {α β : Type u} {m : Type u → Type v} {Pred : Type u�
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
     {xs : Roi α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur (by simp [← Roi.mem_toList_iff_mem, h]) b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn' xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [Roi.forIn'_eq_forIn'_toList]
   exact Spec.forIn'_list inv step
@@ -1111,20 +1110,20 @@ theorem Spec.forIn_roi {α β : Type u} {m : Type u → Type v} {Pred : Type u�
     [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
     {xs : Roi α} {init : β} {f : α → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [forIn]
   exact Spec.forIn'_roi inv step
@@ -1137,20 +1136,20 @@ theorem Spec.forIn'_ric {α β : Type u} {m : Type u → Type v} {Pred : Type u�
     [Least? α] [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α] [LawfulUpwardEnumerableLE α]
     {xs : Ric α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur (by simp [← Ric.mem_toList_iff_mem, h]) b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn' xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [Ric.forIn'_eq_forIn'_toList]
   exact Spec.forIn'_list inv step
@@ -1163,20 +1162,20 @@ theorem Spec.forIn_ric {α β : Type u} {m : Type u → Type v} {Pred : Type u�
     [Least? α] [LE α] [DecidableLE α] [UpwardEnumerable α] [Rxc.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α] [LawfulUpwardEnumerableLE α]
     {xs : Ric α} {init : β} {f : α → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [forIn]
   exact Spec.forIn'_ric inv step
@@ -1189,20 +1188,20 @@ theorem Spec.forIn'_rio {α β : Type u} {m : Type u → Type v} {Pred : Type u�
     [Least? α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α] [LawfulUpwardEnumerableLT α]
     {xs : Rio α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur (by simp [← Rio.mem_toList_iff_mem, h]) b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn' xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [Rio.forIn'_eq_forIn'_toList]
   exact Spec.forIn'_list inv step
@@ -1215,20 +1214,20 @@ theorem Spec.forIn_rio {α β : Type u} {m : Type u → Type v} {Pred : Type u�
     [Least? α] [LT α] [DecidableLT α] [UpwardEnumerable α] [Rxo.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α] [LawfulUpwardEnumerableLT α]
     {xs : Rio α} {init : β} {f : α → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [forIn]
   exact Spec.forIn'_rio inv step
@@ -1241,20 +1240,20 @@ theorem Spec.forIn'_rii {α β : Type u} {m : Type u → Type v} {Pred : Type u�
     [Least? α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α]
     {xs : Rii α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur (by simp [Rii.mem]) b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn' xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [Rii.forIn'_eq_forIn'_toList]
   exact Spec.forIn'_list inv step
@@ -1267,20 +1266,20 @@ theorem Spec.forIn_rii {α β : Type u} {m : Type u → Type v} {Pred : Type u�
     [Least? α] [UpwardEnumerable α] [Rxi.IsAlwaysFinite α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α]
     {xs : Rii α} {init : β} {f : α → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | ForInStep.yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | ForInStep.done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | ForInStep.yield b' => inv (pref ++ [cur]) suff b'
+          | ForInStep.done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   simp only [forIn]
   exact Spec.forIn'_rii inv step
@@ -1298,18 +1297,18 @@ theorem Spec.forIn_slice {δ : Type u} {m : Type u → Type w} {Pred : Type uₚ
     [Finite α Id]
     {init : δ} {f : β → δ → m (ForInStep δ)}
     {xs : Slice γ}
-    (inv : Invariant xs.toList δ Pred)
+    (inv : Invariant β δ Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | .yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | .done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | .yield b' => inv (pref ++ [cur]) suff b'
+          | .done b' => inv xs.toList [] b')
         epost) :
-    Triple (forIn xs init f) (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b) epost := by
+    Triple (forIn xs init f) (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b) epost := by
   simp only [← Slice.forIn_toList]
   exact Spec.forIn_list inv step
 
@@ -1323,18 +1322,18 @@ theorem Spec.forIn_iter {α β γ : Type u} {m : Type u → Type w} {Pred : Type
     [Iterator α Id β] [Finite α Id] [IteratorLoop α Id m] [LawfulIteratorLoop α Id m]
     {init : γ} {f : β → γ → m (ForInStep γ)}
     {it : Iter (α := α) β}
-    (inv : Invariant it.toList γ Pred)
+    (inv : Invariant β γ Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : it.toList = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : it.toList = pref ++ cur :: suff) b,
       Triple
         (f cur b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | .yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | .done b' => inv ⟨it.toList, [], by simp⟩ b')
+          | .yield b' => inv (pref ++ [cur]) suff b'
+          | .done b' => inv it.toList [] b')
         epost) :
-    Triple (forIn it init f) (inv ⟨[], it.toList, rfl⟩ init)
-      (fun b => inv ⟨it.toList, [], by simp⟩ b) epost := by
+    Triple (forIn it init f) (inv [] it.toList init)
+      (fun b => inv it.toList [] b) epost := by
   simp only [← Iter.forIn_toList]
   exact Spec.forIn_list inv step
 
@@ -1345,18 +1344,18 @@ theorem Spec.forIn_iterM_id {α β γ : Type u} {m : Type u → Type w} {Pred : 
     [Iterator α Id β] [Finite α Id] [IteratorLoop α Id m] [LawfulIteratorLoop α Id m]
     {init : γ} {f : β → γ → m (ForInStep γ)}
     {it : IterM (α := α) Id β}
-    (inv : Invariant it.toList.run γ Pred)
+    (inv : Invariant β γ Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : it.toList.run = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : it.toList.run = pref ++ cur :: suff) b,
       Triple
         (f cur b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | .yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | .done b' => inv ⟨it.toList.run, [], by simp⟩ b')
+          | .yield b' => inv (pref ++ [cur]) suff b'
+          | .done b' => inv it.toList.run [] b')
         epost) :
-    Triple (forIn it init f) (inv ⟨[], it.toList.run, rfl⟩ init)
-      (fun b => inv ⟨it.toList.run, [], by simp⟩ b) epost := by
+    Triple (forIn it init f) (inv [] it.toList.run init)
+      (fun b => inv it.toList.run [] b) epost := by
   conv in forIn it init f =>
     rw [← Iter.toIterM_toIter (it := it), ← Iter.forIn_eq_forIn_toIterM, ← Iter.forIn_toList,
       IterM.toList_toIter]
@@ -1369,16 +1368,16 @@ theorem Spec.foldM_iter {α β γ : Type u} {m : Type u → Type w} {Pred : Type
     [Iterator α Id β] [Finite α Id] [IteratorLoop α Id m] [LawfulIteratorLoop α Id m]
     {it : Iter (α := α) β}
     {init : γ} {f : γ → β → m γ}
-    (inv : Invariant it.toList γ Pred)
+    (inv : Invariant β γ Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : it.toList = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : it.toList = pref ++ cur :: suff) b,
       Triple
         (f b cur)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
-        (fun b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b')
+        (inv pref (cur::suff) b)
+        (fun b' => inv (pref ++ [cur]) suff b')
         epost) :
-    Triple (it.foldM f init) (inv ⟨[], it.toList, rfl⟩ init)
-      (fun b => inv ⟨it.toList, [], by simp⟩ b) epost := by
+    Triple (it.foldM f init) (inv [] it.toList init)
+      (fun b => inv it.toList [] b) epost := by
   rw [← Iter.foldlM_toList]
   exact Spec.foldlM_list inv step
 
@@ -1389,16 +1388,16 @@ theorem Spec.foldM_iterM_id {α β γ : Type u} {m : Type u → Type w} {Pred : 
     [Iterator α Id β] [Finite α Id] [IteratorLoop α Id m] [LawfulIteratorLoop α Id m]
     {it : IterM (α := α) Id β}
     {init : γ} {f : γ → β → m γ}
-    (inv : Invariant it.toList.run γ Pred)
+    (inv : Invariant β γ Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : it.toList.run = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : it.toList.run = pref ++ cur :: suff) b,
       Triple
         (f b cur)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
-        (fun b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b')
+        (inv pref (cur::suff) b)
+        (fun b' => inv (pref ++ [cur]) suff b')
         epost) :
-    Triple (it.foldM f init) (inv ⟨[], it.toList.run, rfl⟩ init)
-      (fun b => inv ⟨it.toList.run, [], by simp⟩ b) epost := by
+    Triple (it.foldM f init) (inv [] it.toList.run init)
+      (fun b => inv it.toList.run [] b) epost := by
   rw [← IterM.foldlM_toList]
   exact Spec.foldlM_list inv step
 
@@ -2249,40 +2248,40 @@ end Iterators
 
 @[spec]
 theorem Spec.forIn'_array {xs : Array α} {init : β} {f : (a : α) → a ∈ xs → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
     (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur (by simp [←Array.mem_toList_iff, h]) b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | .yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | .done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | .yield b' => inv (pref ++ [cur]) suff b'
+          | .done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn' xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   cases xs; simp; apply Spec.forIn'_list inv step
 
 
 @[spec]
 theorem Spec.forIn_array {xs : Array α} {init : β} {f : α → β → m (ForInStep β)}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f cur b)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
+        (inv pref (cur::suff) b)
         (fun r => match r with
-          | .yield b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b'
-          | .done b' => inv ⟨xs.toList, [], by simp⟩ b')
+          | .yield b' => inv (pref ++ [cur]) suff b'
+          | .done b' => inv xs.toList [] b')
         epost) :
     Triple
       (forIn xs init f)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   cases xs; simp; apply Spec.forIn_list inv step
 
@@ -2290,18 +2289,18 @@ theorem Spec.forIn_array {xs : Array α} {init : β} {f : α → β → m (ForIn
 @[spec]
 theorem Spec.foldlM_array
     {xs : Array α} {init : β} {f : β → α → m β}
-    (inv : Invariant xs.toList β Pred)
+    (inv : Invariant α β Pred)
     {epost : EPred}
-    (step : ∀ pref cur suff (h : xs.toList = pref ++ cur :: suff) b,
+    (step : ∀ pref cur suff (_h : xs.toList = pref ++ cur :: suff) b,
       Triple
         (f b cur)
-        (inv ⟨pref, cur::suff, h.symm⟩ b)
-        (fun b' => inv ⟨pref ++ [cur], suff, by simp [h]⟩ b')
+        (inv pref (cur::suff) b)
+        (fun b' => inv (pref ++ [cur]) suff b')
         epost) :
     Triple
       (Array.foldlM f init xs)
-      (inv ⟨[], xs.toList, rfl⟩ init)
-      (fun b => inv ⟨xs.toList, [], by simp⟩ b)
+      (inv [] xs.toList init)
+      (fun b => inv xs.toList [] b)
       epost := by
   cases xs; simp; apply Spec.foldlM_list inv step
 

--- a/tests/bench/vcgen/test_do_logic.lean
+++ b/tests/bench/vcgen/test_do_logic.lean
@@ -97,20 +97,20 @@ open Code
 theorem fib_triple : ⦃ True ⦄ fib_impl n ⦃ fun r => r = fib_spec n ⦄ := by
   unfold fib_impl
   vcgen
-  case inv1 => exact fun xs ⟨a, b⟩ =>
-    a = fib_spec xs.pos ∧ b = fib_spec (xs.pos + 1)
+  case inv1 => exact fun pref _ ⟨a, b⟩ =>
+    a = fib_spec pref.length ∧ b = fib_spec (pref.length + 1)
   all_goals grind
 
 theorem fib_triple_finish : ⦃ True ⦄ fib_impl n ⦃ fun r => r = fib_spec n ⦄ := by
   vcgen [fib_impl] invariants
-  | inv1 => fun xs ⟨a, b⟩ => a = fib_spec xs.pos ∧ b = fib_spec (xs.pos + 1)
+  | inv1 => fun pref _ ⟨a, b⟩ => a = fib_spec pref.length ∧ b = fib_spec (pref.length + 1)
   with finish
 
 theorem fib_triple_step : ⦃ True ⦄ fib_impl n ⦃ fun r => r = fib_spec n ⦄ := by
   unfold fib_impl
   vcgen (stepLimit := some 14)
-  case inv1 => exact fun xs ⟨a, b⟩ =>
-    a = fib_spec xs.pos ∧ b = fib_spec (xs.pos + 1)
+  case inv1 => exact fun pref _ ⟨a, b⟩ =>
+    a = fib_spec pref.length ∧ b = fib_spec (pref.length + 1)
   all_goals grind
 
 attribute [local spec] fib_triple in
@@ -127,12 +127,12 @@ theorem fib_impl_vcs
     (Q : Nat → Nat → Prop)
     (E : EPost.Nil)
     (I : (n : Nat) → (_ : ¬n = 0) →
-      Invariant [1:n].toList (Prod Nat Nat) Prop)
+      Invariant Nat (Prod Nat Nat) Prop)
     (ret : Q 0 0)
-    (loop_pre : ∀ n (hn : ¬n = 0), (I n hn) ⟨[], [1:n].toList, rfl⟩ (0, 1))
-    (loop_post : ∀ n (hn : ¬n = 0) r, (I n hn) ⟨[1:n].toList, [], by simp⟩ r ⊑ Q n r.2)
-    (loop_step : ∀ n (hn : ¬n = 0) r pref cur suff (h : [1:n].toList = pref ++ cur :: suff),
-                  (I n hn) ⟨pref, cur::suff, by simp[h]⟩ r ⊑ (I n hn) ⟨pref ++ [cur], suff, by simp[h]⟩ (r.2, r.1+r.2))
+    (loop_pre : ∀ n (hn : ¬n = 0), (I n hn) [] [1:n].toList (0, 1))
+    (loop_post : ∀ n (hn : ¬n = 0) r, (I n hn) [1:n].toList [] r ⊑ Q n r.2)
+    (loop_step : ∀ n (hn : ¬n = 0) r pref cur suff (_h : [1:n].toList = pref ++ cur :: suff),
+                  (I n hn) pref (cur::suff) r ⊑ (I n hn) (pref ++ [cur]) suff (r.2, r.1+r.2))
     : wp (fib_impl n) (Q n) E := by
   vcgen [fib_impl]
   case inv1 h => exact I n h
@@ -170,7 +170,7 @@ theorem mkFreshPair_triple :
 
 theorem sum_loop_spec : ⦃ True ⦄ sum_loop ⦃ fun r => r < 30 ⦄ := by
   vcgen [sum_loop]
-  case inv1 => exact fun c x => x = c.«prefix».sum
+  case inv1 => exact fun pref _ x => x = pref.sum
   all_goals grind
 
 theorem throwing_loop_spec :
@@ -179,19 +179,19 @@ theorem throwing_loop_spec :
   ⦃fun _ _ => False;
   epost⟨fun e s => e = 42 ∧ s = 4⟩⦄ := by
   vcgen [throwing_loop]
-  case inv1 => exact fun xs r s => r ≤ 4 ∧ s = 4 ∧ r + xs.suffix.sum > 4
+  case inv1 => exact fun _ suff r s => r ≤ 4 ∧ s = 4 ∧ r + suff.sum > 4
   all_goals (simp_all; try grind)
 
 theorem test_loop_break :
     ⦃ fun s => s = 42 ⦄ breaking_loop ⦃ fun r s => r > 4 ∧ s = 1 ⦄ := by
   vcgen [breaking_loop]
-  case inv1 => exact fun xs r s => (r ≤ 4 ∧ r = xs.prefix.sum ∨ r > 4) ∧ s = 42
+  case inv1 => exact fun pref _ r s => (r ≤ 4 ∧ r = pref.sum ∨ r > 4) ∧ s = 42
   all_goals grind
 
 theorem test_loop_early_return :
     ⦃ fun s => s = 4 ⦄ returning_loop ⦃ fun r s => r = 42 ∧ s = 4 ⦄ := by
   vcgen [returning_loop]
-  case inv1 => exact fun xs r s => (r.1 = none ∧ r.2 = xs.prefix.sum ∧ r.2 ≤ 4 ∨ r.1 = some 42 ∧ r.2 > 4) ∧ s = 4
+  case inv1 => exact fun pref _ r s => (r.1 = none ∧ r.2 = pref.sum ∧ r.2 ≤ 4 ∨ r.1 = some 42 ∧ r.2 > 4) ∧ s = 4
   all_goals grind
 
 theorem unfold_to_expose_match_spec :
@@ -217,7 +217,7 @@ theorem test_sum :
       pure x : Id _)
     ⦃ fun r => r < 30 ⦄ := by
   vcgen
-  case inv1 => exact fun c x => x = c.«prefix».sum
+  case inv1 => exact fun pref _ x => x = pref.sum
   all_goals grind
 
 theorem mspec_forwards_mvars {n : Nat} :
@@ -245,7 +245,7 @@ example (p : Nat → Prop) [DecidablePred p] (n : Nat) :
   case inv1 =>
     exact Invariant.withEarlyReturnNewDo
       (onReturn := fun ret _ => ⌜ret = false ∧ ¬ ∀ i < n, p i⌝)
-      (onContinue := fun xs _ => ⌜∀ i, i ∈ xs.prefix → p i⌝)
+      (onContinue := fun pref _ _ => ⌜∀ i, i ∈ pref → p i⌝)
   all_goals simp_all [-Classical.not_forall]; try grind
 
 end Automated
@@ -279,7 +279,7 @@ theorem max_and_sum_spec (xs : Array Nat) :
     ⦃ ∀ i, (h : i < xs.size) → xs[i] ≥ 0 ⦄
     max_and_sum xs ⦃ fun (m, s) => s ≤ m * xs.size ⦄ := by
   vcgen [max_and_sum]
-  case inv1 => exact fun c ⟨mx, s⟩ => s ≤ mx * c.pos
+  case inv1 => exact fun pref _ ⟨mx, s⟩ => s ≤ mx * pref.length
   all_goals simp_all +zetaDelta
   case vc3 =>
     rename_i hle hlt
@@ -378,7 +378,7 @@ theorem subarraySum_correct {xs : Subarray Nat} : subarraySum xs = xs.toList.sum
   generalize h : subarraySum xs = r
   apply Id.of_wp_run_eq h
   vcgen
-  case inv1 => exact fun c s => s = c.«prefix».sum
+  case inv1 => exact fun pref _ s => s = pref.sum
   all_goals simp_all +zetaDelta
 
 end Slices
@@ -412,14 +412,14 @@ theorem naive_expo_correct (x n : Nat) : naive_expo x n = x ^ n := by
   generalize h : naive_expo x n = r
   apply Id.of_wp_run_eq h
   vcgen
-  case inv1 => exact fun c y => y = x ^ c.pos
+  case inv1 => exact fun pref _ y => y = x ^ pref.length
   all_goals simp_all +zetaDelta [Nat.pow_add_one]
 
 theorem fast_expo_correct (x n : Nat) : fast_expo x n = x ^ n := by
   generalize h : fast_expo x n = r
   apply Id.of_wp_run_eq h
   vcgen
-  case inv1 => exact fun xs ⟨x', y, e⟩ => x' ^ e * y = x ^ n ∧ e ≤ n - xs.pos
+  case inv1 => exact fun pref _ ⟨x', y, e⟩ => x' ^ e * y = x ^ n ∧ e ≤ n - pref.length
   all_goals simp_all +zetaDelta
   case vc2 ih =>
     rw [← ih.1, ih.2, Nat.pow_zero, Nat.one_mul]
@@ -454,7 +454,7 @@ theorem forIn_eq_sum (xs : Array Nat) {m} [Monad m] [Assertion Pred] [Assertion 
       return sum : m _)
     ⦃ fun r => ⌜r = xs.sum⌝ ⦄ := by
   vcgen
-  case inv1 => exact fun cur n => ⌜n = cur.prefix.sum⌝
+  case inv1 => exact fun pref _ n => ⌜n = pref.sum⌝
   all_goals grind
 
 theorem forIn_map_eq_sum_add_size' (xs : Array Nat) {m} [Monad m] [Assertion Pred] [Assertion EPred]
@@ -465,7 +465,7 @@ theorem forIn_map_eq_sum_add_size' (xs : Array Nat) {m} [Monad m] [Assertion Pre
         sum := sum + n
       return sum) ⦃ fun r => ⌜r = xs.sum + xs.size⌝ ⦄ := by
   vcgen
-  case inv1 => exact fun cur n => ⌜n = cur.prefix.sum + cur.prefix.length⌝
+  case inv1 => exact fun pref _ n => ⌜n = pref.sum + pref.length⌝
   all_goals grind
 
 theorem forIn_map_eq_sum_add_size (xs : Array Nat) {m} [Monad m] [Assertion Pred] [Assertion EPred]
@@ -476,7 +476,7 @@ theorem forIn_map_eq_sum_add_size (xs : Array Nat) {m} [Monad m] [Assertion Pred
         sum := sum + n
       return sum) ⦃ fun r => ⌜r = xs.sum + xs.size⌝ ⦄ := by
   vcgen
-  case inv1 => exact fun cur n => ⌜n = cur.prefix.sum + cur.prefix.length⌝
+  case inv1 => exact fun pref _ n => ⌜n = pref.sum + pref.length⌝
   all_goals grind
 
 
@@ -488,7 +488,7 @@ theorem forIn_mapM_eq_sum_add_size (xs : Array Nat) {m} [Monad m] [MonadAttach m
         sum := sum + n
       return sum) ⦃ fun r => ⌜r = xs.sum + xs.size⌝ ⦄ := by
   vcgen
-  case inv1 => exact fun cur n => ⌜n = cur.prefix.sum + cur.prefix.length⌝
+  case inv1 => exact fun pref _ n => ⌜n = pref.sum + pref.length⌝
   all_goals grind
 
 theorem forIn_filterMapM_eq_sum_add_size (xs : Array Nat) {m}
@@ -499,14 +499,14 @@ theorem forIn_filterMapM_eq_sum_add_size (xs : Array Nat) {m}
         sum := sum + n
       return sum) ⦃ fun r => ⌜r = xs.sum + xs.size⌝ ⦄ := by
   vcgen
-  case inv1 => exact fun cur n => ⌜n = cur.prefix.sum + cur.prefix.length⌝
+  case inv1 => exact fun pref _ n => ⌜n = pref.sum + pref.length⌝
   all_goals grind
 
 theorem foldM_eq_sum (xs : Array Nat) {m} [Monad m] [LawfulMonad m]
     [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :
     ⦃ ⊤ ⦄ (xs.iter.foldM (m := m) (init := 0) (pure <| · + ·)) ⦃ fun r => ⌜r = xs.sum⌝ ⦄ := by
   vcgen
-  case inv1 => exact fun cur n => ⌜n = cur.prefix.sum⌝
+  case inv1 => exact fun pref _ n => ⌜n = pref.sum⌝
   all_goals grind
 
 end IteratorTests
@@ -571,7 +571,7 @@ example (p : Nat → Prop) [DecidablePred p] (n : Nat) :
   vcgen invariants
     · Invariant.withEarlyReturnNewDo
       (onReturn := fun ret _ => ⌜ret = false ∧ ¬ ∀ i < n, p i⌝)
-      (onContinue := fun xs _ => ⌜∀ i, i ∈ xs.prefix → p i⌝)
+      (onContinue := fun pref _ _ => ⌜∀ i, i ∈ pref → p i⌝)
   all_goals simp_all [-Classical.not_forall]; try grind
 
 -- Labelled form: `| inv1 => …`.
@@ -582,7 +582,7 @@ example (p : Nat → Prop) [DecidablePred p] (n : Nat) :
   vcgen invariants
     | inv1 => Invariant.withEarlyReturnNewDo
       (onReturn := fun ret _ => ⌜ret = false ∧ ¬ ∀ i < n, p i⌝)
-      (onContinue := fun xs _ => ⌜∀ i, i ∈ xs.prefix → p i⌝)
+      (onContinue := fun pref _ _ => ⌜∀ i, i ∈ pref → p i⌝)
   all_goals simp_all [-Classical.not_forall]; try grind
 
 end InvariantSyntaxTests

--- a/tests/elab/formatTerm.lean
+++ b/tests/elab/formatTerm.lean
@@ -15,7 +15,7 @@ def fmt (stx : CoreM Syntax) : CoreM Format := do PrettyPrinter.ppTerm ⟨← st
 #eval fmt `(do while c do pure ())
 #eval fmt `(do unless c do pure ())
 -- intrinsic-verification clauses: `invariant` inline with the loop, `requires`/`ensures` inline with `def`
-#eval fmt `(do for x in xs invariant cur => 0 ≤ acc do pure ())
+#eval fmt `(do for x in xs invariant pref suff => 0 ≤ acc do pure ())
 #eval fmt `(command| def clampLow (n lo : Nat) : Id Nat requires lo ≤ n ensures r => r = n := pure n)
 #eval fmt `(command| def g (x : Nat) requires x > 0 ensures r => r ≥ x := pure x)
 #eval fmt `(command| def h (x : Nat) : Id Nat ensures r => r = x := pure x

--- a/tests/elab/formatTerm.lean.out.expected
+++ b/tests/elab/formatTerm.lean.out.expected
@@ -47,7 +47,7 @@ do
   unless c✝ do
     pure✝ ()
 do
-  for x✝ in xs✝ invariant cur✝ => 0 ≤ acc✝ do
+  for x✝ in xs✝ invariant pref✝ suff✝ => 0 ≤ acc✝ do
     pure✝ ()
 def clampLow✝ (n✝ lo✝ : Nat✝) : Id✝ Nat✝ requires lo✝ ≤ n✝ ensures r✝ => r✝ = n✝ :=
   pure✝ n✝

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -86,6 +86,20 @@ def sumRangeMem (n : Nat) : Id Nat
 #guard_msgs (drop info) in
 #check @sumRangeMem.spec
 
+/-! ## An invariant over the monad's own state
+
+The invariant need not mention a mutable variable: here it constrains the `StateM` state. -/
+
+def sumIntoState (xs : List Nat) : StateM Nat Unit
+    requires (fun s => s = 0)
+    ensures _ => (fun s => s = xs.sum)
+  := do
+  for x in xs invariant pref _ => (fun s => s = pref.sum) do
+    modify (· + x)
+
+#guard_msgs (drop info) in
+#check @sumIntoState.spec
+
 /-! ## The contract telescope is transplanted faithfully to `f.spec`
 
 `f.spec` re-binds the definition's telescope verbatim, applies `f` to exactly the explicit arguments,

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -52,8 +52,8 @@ def findSmallest (s : Array Nat) : Id (Option Nat)
   else
     let mut minIndex := 0
     for i in [1:s.size]
-        invariant xs => minIndex < s.size ∧ s[minIndex]! ≤ s[0]! ∧
-                        ∀ j, j ∈ xs.prefix → s[minIndex]! ≤ s[j]!
+        invariant pref _ => minIndex < s.size ∧ s[minIndex]! ≤ s[0]! ∧
+                            ∀ j, j ∈ pref → s[minIndex]! ≤ s[j]!
       do
       if s[i]! < s[minIndex]! then
         minIndex := i
@@ -68,7 +68,7 @@ def findSmallest (s : Array Nat) : Id (Option Nat)
 def sumWithMem (xs : List Nat) : Id Nat
     ensures r => 0 ≤ r := do
   let mut acc := 0
-  for h : x in xs invariant cur => 0 ≤ acc do
+  for h : x in xs invariant _pref _suff => 0 ≤ acc do
     acc := acc + x
   return acc
 
@@ -79,7 +79,7 @@ def sumWithMem (xs : List Nat) : Id Nat
 def sumRangeMem (n : Nat) : Id Nat
     ensures r => 0 ≤ r := do
   let mut acc := 0
-  for h : i in [0:n] invariant cur => 0 ≤ acc do
+  for h : i in [0:n] invariant _pref _suff => 0 ≤ acc do
     acc := acc + i
   return acc
 
@@ -140,7 +140,7 @@ def sumEvens (xs : List Nat) : Id Nat
     ensures r => ∃ k, r = 2 * k
   := do
   let mut acc := 0
-  for x in xs invariant _cur => acc % 2 = 0 do
+  for x in xs invariant _pref _suff => acc % 2 = 0 do
     acc := acc + 2 * x
   return acc
 where finally

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -92,7 +92,7 @@ The invariant need not mention a mutable variable: here it constrains the `State
 
 def sumIntoState (xs : List Nat) : StateM Nat Unit
     requires (fun s => s = 0)
-    ensures _ => (fun s => s = xs.sum)
+    ensures _ s => s = xs.sum
   := do
   for x in xs invariant pref _ => (fun s => s = pref.sum) do
     modify (· + x)

--- a/tests/elab/intrinsicVerificationMissingImport.lean
+++ b/tests/elab/intrinsicVerificationMissingImport.lean
@@ -11,6 +11,6 @@ def f (x : Nat) : Id Nat requires x > 0 ensures r => r ≥ x := pure x
 #guard_msgs in
 def g (xs : List Nat) : Id Nat := do
   let mut acc := 0
-  for x in xs invariant cur => 0 ≤ acc do
+  for x in xs invariant pref suff => 0 ≤ acc do
     acc := acc + x
   return acc

--- a/tests/elab/vcgenSymBlock.lean
+++ b/tests/elab/vcgenSymBlock.lean
@@ -109,7 +109,7 @@ example :
     ⦃ fun r => r < 30 ⦄ := by
   sym =>
     vcgen invariants
-      · fun xs r => r + xs.suffix.length * 5 ≤ 25
+      · fun _pref suff r => r + suff.length * 5 ≤ 25
     <;> finish
 
 /-! ## `invariants?` (suggest mode) inside `sym =>` -/
@@ -143,7 +143,7 @@ example :
     ⦃ fun r => r < 30 ⦄ := by
   sym =>
     vcgen invariants
-      · fun xs r => r + xs.suffix.length * 5 ≤ 25
+      · fun _pref suff r => r + suff.length * 5 ≤ 25
     case vc3 b a x => finish
     case vc1 => tactic => simp +arith
     case vc2 x _ =>

--- a/tests/elab/vcgenTickFrames.lean
+++ b/tests/elab/vcgenTickFrames.lean
@@ -313,7 +313,7 @@ local macro_rules
 @[spec] theorem tickList_spec {α : Type} (xs : List α) : tickList xs ⏱ xs.length := by
   unfold tickList
   vcgen invariants
-  | inv1 => fun cursor _ n _ => n = cursor.pos
+  | inv1 => fun pref _ _ n _ => n = pref.length
   with finish
 
 /-- Two loops in sequence: `vcgen` infers and frames the second call by the cost the first accrued,

--- a/tests/elab_bench/verina.lean
+++ b/tests/elab_bench/verina.lean
@@ -211,8 +211,8 @@ theorem findSmallest_spec (s : Array Nat) :
   generalize h : (findSmallest s).run = r
   apply Id.of_wp_run_eq h
   vcgen [findSmallest] invariants
-  | inv1 => fun xs minIndex => minIndex < s.size ∧ s[minIndex]! ≤ s[0]! ∧
-      ∀ j, j ∈ xs.prefix → s[minIndex]! ≤ s[j]!
+  | inv1 => fun xpref _ minIndex => minIndex < s.size ∧ s[minIndex]! ≤ s[0]! ∧
+      ∀ j, j ∈ xpref → s[minIndex]! ≤ s[j]!
   with finish
 
 end E_findSmallest
@@ -285,7 +285,7 @@ theorem isGreater_spec (n : Int) (a : Array Int) (_h : a.size > 0) :
   generalize h : (isGreater n a).run = r
   apply Id.of_wp_run_eq h
   vcgen [isGreater] invariants
-  | inv1 => fun xs ok => ok = true ↔ (∀ j : Nat, j ∈ xs.prefix → a[j]! < n)
+  | inv1 => fun xpref _ ok => ok = true ↔ (∀ j : Nat, j ∈ xpref → a[j]! < n)
   with finish
 
 end E_isGreater
@@ -321,7 +321,7 @@ theorem isPrime_spec (n : Nat) (_h : 2 ≤ n) :
   generalize h : (isPrime n).run = r
   apply Id.of_wp_run_eq h
   vcgen [isPrime] invariants
-  | inv1 => fun xs composite => composite = false ↔ (∀ d : Nat, d ∈ xs.prefix → n % d ≠ 0)
+  | inv1 => fun xpref _ composite => composite = false ↔ (∀ d : Nat, d ∈ xpref → n % d ≠ 0)
   with (try finish)
   case vc2 => sorry
   case vc3 => sorry
@@ -571,12 +571,12 @@ theorem findEvenNumbers_spec (arr : Array Int) :
   generalize h : (findEvenNumbers arr).run = r
   apply Id.of_wp_run_eq h
   vcgen [findEvenNumbers] invariants
-  | inv1 => fun xs ⟨result, indices⟩ => xs.prefix.length ≤ arr.size ∧
+  | inv1 => fun xpref _ ⟨result, indices⟩ => xpref.length ≤ arr.size ∧
       (∀ x, x ∈ result → isEvenInt x = true) ∧
       (∀ x, isEvenInt x = false → result.count x = 0) ∧
-      (∀ x, isEvenInt x = true → result.count x = (arr.extract 0 xs.prefix.length).count x) ∧
+      (∀ x, isEvenInt x = true → result.count x = (arr.extract 0 xpref.length).count x) ∧
       indices.size = result.size ∧
-      (∀ k, k < indices.size → indices[k]! < xs.prefix.length) ∧
+      (∀ k, k < indices.size → indices[k]! < xpref.length) ∧
       (∀ k, k < indices.size → indices[k]! < arr.size) ∧
       (∀ k, k < indices.size → result[k]! = arr[indices[k]!]!) ∧
       (∀ k j, k < j → j < indices.size → indices[k]! < indices[j]!)
@@ -632,9 +632,9 @@ theorem findMajorityElement_spec (lst : List Int) :
   generalize h : (findMajorityElement lst).run = r
   apply Id.of_wp_run_eq h
   vcgen [findMajorityElement] invariants
-  | inv1 => fun xs ⟨found, candidate⟩ => (found = true → candidate ∈ lst ∧ isMajorityElement lst candidate) ∧
-      (found = false → ∀ k : Nat, k < xs.prefix.length → ¬isMajorityElement lst lst[k]!)
-  | inv2 pref cur suff hsplit b hinv => fun ys count => count = (lst.take ys.prefix.length).count lst[cur]!
+  | inv1 => fun xpref _ ⟨found, candidate⟩ => (found = true → candidate ∈ lst ∧ isMajorityElement lst candidate) ∧
+      (found = false → ∀ k : Nat, k < xpref.length → ¬isMajorityElement lst lst[k]!)
+  | inv2 pref cur suff hsplit b hinv => fun ypref _ count => count = (lst.take ypref.length).count lst[cur]!
   case vc7 => sorry
   case vc8 => sorry
   all_goals grind [List.take_length, List.length_range', List.take_succ_eq_append_getElem, -Array.extract_eq_pop, -Nat.min_def]
@@ -683,8 +683,8 @@ theorem ifPowerOfFour_spec (n : Nat) :
   generalize h : (ifPowerOfFour n).run = r
   apply Id.of_wp_run_eq h
   vcgen [ifPowerOfFour] invariants
-  | inv1 => fun xs current => current > 0 ∧ (isPowerOfFour n ↔ isPowerOfFour current) ∧
-      (isPowerOfFour n → ∃ e, current = 4 ^ e ∧ (e = 0 ∨ 4 ^ (e + xs.prefix.length) = n))
+  | inv1 => fun xpref _ current => current > 0 ∧ (isPowerOfFour n ↔ isPowerOfFour current) ∧
+      (isPowerOfFour n → ∃ e, current = 4 ^ e ∧ (e = 0 ∨ 4 ^ (e + xpref.length) = n))
   case vc4 => sorry
   all_goals grind [isPowerOfFour_iff_div_four, Nat.lt_pow_self, Nat.pow_succ, -Array.extract_eq_pop, -Nat.min_def]
 
@@ -718,7 +718,7 @@ theorem isSorted_spec (a : Array Int) :
   generalize h : (isSorted a).run = r
   apply Id.of_wp_run_eq h
   vcgen [isSorted] invariants
-  | inv1 => fun xs sorted => (sorted = true → ∀ k : Nat, k ∈ xs.prefix → k + 1 < a.size → a[k]! ≤ a[k + 1]!) ∧
+  | inv1 => fun xpref _ sorted => (sorted = true → ∀ k : Nat, k ∈ xpref → k + 1 < a.size → a[k]! ≤ a[k + 1]!) ∧
       (sorted = false → ∃ k : Nat, k + 1 < a.size ∧ a[k]! > a[k + 1]!)
   with finish
 
@@ -759,10 +759,10 @@ theorem isSublist_spec (sub : List Int) (main : List Int) :
   generalize h : (isSublist sub main).run = r
   apply Id.of_wp_run_eq h
   vcgen [isSublist] invariants
-  | inv1 => fun xs ⟨rest, found⟩ => rest <:+: main ∧
+  | inv1 => fun xpref _ ⟨rest, found⟩ => rest <:+: main ∧
       (found = true → sub <:+: main) ∧
       (sub <:+: main → found = true ∨ sub <:+: rest) ∧
-      (found = false → rest.length + xs.prefix.length ≤ main.length)
+      (found = false → rest.length + xpref.length ≤ main.length)
   with finish [List.eq_nil_of_infix_nil, List.length_drop, List.length_range',
     List.length_eq_zero_iff]
 
@@ -839,8 +839,8 @@ theorem mergeSorted_spec (a1 : Array Nat) (a2 : Array Nat)
   generalize h : (mergeSorted a1 a2).run = r
   apply Id.of_wp_run_eq h
   vcgen [mergeSorted] invariants
-  | inv1 => fun xs ⟨result, i, j⟩ => i ≤ a1.size ∧ j ≤ a2.size ∧
-      result.size = i + j ∧ result.size = xs.prefix.length ∧
+  | inv1 => fun xpref _ ⟨result, i, j⟩ => i ≤ a1.size ∧ j ≤ a2.size ∧
+      result.size = i + j ∧ result.size = xpref.length ∧
       isSorted result ∧
       (∀ v : Nat, result.count v = (a1.extract 0 i).count v + (a2.extract 0 j).count v) ∧
       (i < a1.size → ∀ p, p < result.size → result[p]! ≤ a1[i]!) ∧
@@ -945,9 +945,9 @@ theorem findMajorityElement_spec (lst : List Int) :
     ⦃ fun r => (hasMajorityElement lst → r ∈ lst ∧ isMajorityElement lst r) ∧
       (¬hasMajorityElement lst → r = -1) ⦄ := by
   vcgen [findMajorityElement] invariants
-  | inv1 => fun xs ⟨found, candidate⟩ => (found = true → candidate ∈ lst ∧ isMajorityElement lst candidate) ∧
-      (found = false → ∀ k : Nat, k < xs.prefix.length → ¬isMajorityElement lst lst[k]!)
-  | inv2 _ cur _ _ _ _ => fun ys count => count = (lst.take ys.prefix.length).count lst[cur]!
+  | inv1 => fun xpref _ ⟨found, candidate⟩ => (found = true → candidate ∈ lst ∧ isMajorityElement lst candidate) ∧
+      (found = false → ∀ k : Nat, k < xpref.length → ¬isMajorityElement lst lst[k]!)
+  | inv2 _ cur _ _ _ _ => fun ypref _ count => count = (lst.take ypref.length).count lst[cur]!
   case vc7 => sorry
   case vc8 => sorry
   all_goals grind [List.take_length, List.length_range', List.take_succ_eq_append_getElem, List.count_append, List.count_singleton, -Array.extract_eq_pop, -Nat.min_def]


### PR DESCRIPTION
This PR makes the loop invariant of `Std.Internal.Do` a plain function of the elements consumed so far and the elements remaining, rather than a cursor indexed by the list being iterated. The `for … invariant` clause binds two lists, `invariant pref suff => …`, and verification conditions mention them directly instead of `{ prefix := …, suffix := …, property := ⋯ }.prefix`.

`Invariant xs β Pred := List.Cursor xs → β → Pred` becomes `Invariant α β Pred := List α → List α → β → Pred`. The relation `pref ++ suff = xs` moves out of the type and into the hypotheses of the verification conditions, where it already appears. Dropping the index removes the `List.Cursor.cast` transports and the property proofs from the specification lemmas, and frees the `forInWithInvariant` gadgets from naming a list at all: taking `inv : Invariant α β Pred`, they no longer need the `ForIn.toList` bridge lemmas or the `[ForIn Id ρ α]` argument those required. `RepeatInvariant`, used for `repeatM`, was already non-dependent.

`Std.Do` is unchanged except for deleting `List.Cursor.cast`, which now has no use in either library.
