### PR TITLE
feat: add an `assert` do element for intrinsic verification

### DIFF
--- a/src/Lean/Elab/Do/InferControlInfo.lean
+++ b/src/Lean/Elab/Do/InferControlInfo.lean
@@ -225,6 +225,8 @@ partial def ofElem (stx : DoElem) : TermElabM ControlInfo := do
   | `(doElem| dbg_trace $_) => return .pure
   | `(doElem| assert! $_) => return .pure
   | `(doElem| debug_assert! $_) => return .pure
+  -- Names the parser directly because stage0's `doElem` category has no `assert` element.
+  | `(doAssertion| assert $_) => return .pure
   -- match_expr and let_expr
   | `(doElem| match_expr $[(meta := false)]? $_ with $[| $_:matchExprPat => $rhsSeqs]* | _ => $elseSeq) =>
     let mut info ← ofSeq elseSeq

--- a/src/Lean/Elab/Tactic/Do/Contract.lean
+++ b/src/Lean/Elab/Tactic/Do/Contract.lean
@@ -9,17 +9,20 @@ prelude
 public import Std.Tactic.Do.Syntax
 public import Std.Internal.Do
 public import Lean.Elab.Util
+public import Lean.Elab.Do.Basic
 import Lean.DocString.Extension
 meta import Lean.Parser.Command
 meta import Lean.Parser.Term
+meta import Lean.Parser.Do
 import Init.Syntax
 import Init.Grind.Interactive
 
 /-!
-# `requires`/`ensures` contracts on `def`
+# Intrinsic verification syntax
 
 A definition carrying `requires P` / `ensures b => Q` clauses expands to the plain definition plus a
-`vcgen`-proven, `@[spec]`-tagged specification theorem `f.spec`.
+`vcgen`-proven, `@[spec]`-tagged specification theorem `f.spec`. An `assert` element in a `do` block
+elaborates to the assertion gadget that `vcgen` proves in the course of that theorem.
 -/
 
 public section
@@ -134,5 +137,20 @@ discharge them in a `where finally | spec => ...` section of the definition"⟩
       | done
       | fail $msg)
   return mkNullNode #[cleanDeclaration, thm]
+
+open Lean.Elab.Do Lean.Parser.Term in
+@[builtin_doElem_elab Lean.Parser.Term.doAssertion]
+def elabDoAssertion : DoElab := fun stx dec => do
+  let tk := stx.raw[0]
+  let as : Term ← match stx with
+    | `(doAssertion| assert $f:basicFun) => `(fun $f:basicFun)
+    | `(doAssertion| assert $p:term) => pure p
+    | _ => throwUnsupportedSyntax
+  unless (← getEnv).contains ``assertGadget do
+    throwErrorAt tk
+      "the `assert` element elaborates to a `vcgen` gadget; add `import Std.Internal.Do` to use it."
+  let dec ← dec.ensureUnitAt tk
+  let e ← Term.elabTermEnsuringType (← `($(mkCIdent ``assertGadget) $as)) (← mkMonadApp (← mkPUnit))
+  dec.mkBindUnlessPure e
 
 end Lean.Elab.Tactic.Do

--- a/src/Lean/Parser/Do.lean
+++ b/src/Lean/Parser/Do.lean
@@ -300,6 +300,14 @@ with debug assertions enabled (see the `debugAssertions` option).
 -/
 @[builtin_doElem_parser] def doDebugAssert := leading_parser:leadPrec
   "debug_assert! " >> termParser
+/--
+`assert P` states that `P` holds at this point in the program. The form `assert s => P s` binds the
+arguments of the assertion itself, such as the state of a state monad. `vcgen` reads the assertion
+from the program and proves it; at runtime the element does nothing.
+-/
+@[builtin_doElem_parser default+10] def doAssertion := leading_parser:leadPrec
+  nonReservedSymbol "assert" (includeIdent := true) >>
+    (atomic basicFun <|> (ppSpace >> termParser))
 
 @[builtin_doElem_parser] def doRepeat      := leading_parser
   "repeat " >> doSeq

--- a/src/Std/Internal/Do/Triple/Gadget.lean
+++ b/src/Std/Internal/Do/Triple/Gadget.lean
@@ -24,15 +24,16 @@ set_option linter.unusedVariables false in
 
 /-- A no-op computation used as a verification gadget to inject assertions into the program.
 
-The `name` parameter is used by VCGen to name the introduced hypothesis. The `as` parameter
-is the assertion to be checked. At runtime, `assertGadget` is simply `pure ⟨⟩`. -/
-def assertGadget [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] (name : Name) (as : Pred) : m PUnit := pure ⟨⟩
+The `as` parameter is the assertion to be checked. At runtime, `assertGadget` is simply
+`pure ⟨⟩`. -/
+def assertGadget [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] (as : Pred) : m PUnit := pure ⟨⟩
 
 /-- Specification for `assertGadget`: the precondition requires both the assertion `as` and
 the Heyting implication `as ⇨ post ⟨⟩`, ensuring the assertion holds and the postcondition
 follows from it. -/
-theorem Spec.assertGadget (name : Name) (as : Pred) [∀ a : Pred, PreservesSup (meet a)] :
-  Triple (Std.Internal.Do.assertGadget (m := m) name as) (as ⊓ (as ⇨ post ⟨⟩)) post epost := by
+@[spec]
+theorem Spec.assertGadget (as : Pred) [∀ a : Pred, PreservesSup (meet a)] :
+  Triple (Std.Internal.Do.assertGadget (m := m) as) (as ⊓ (as ⇨ post ⟨⟩)) post epost := by
   simpa [Std.Internal.Do.assertGadget] using
     (Triple.pure (m := m) (pre := as ⊓ (as ⇨ post ⟨⟩)) (post := post) (epost := epost)
       (a := ⟨⟩) (h := meet_himp_le))

--- a/tests/elab/formatTerm.lean
+++ b/tests/elab/formatTerm.lean
@@ -15,6 +15,8 @@ def fmt (stx : CoreM Syntax) : CoreM Format := do PrettyPrinter.ppTerm ⟨← st
 #eval fmt `(do while c do pure ())
 #eval fmt `(do unless c do pure ())
 -- intrinsic-verification clauses: `invariant` inline with the loop, `requires`/`ensures` inline with `def`
+#eval fmt `(do assert 0 ≤ acc)
+#eval fmt `(do assert s => s ≤ acc)
 #eval fmt `(do for x in xs invariant pref suff => 0 ≤ acc do pure ())
 #eval fmt `(do for x in xs invariant pref suff s => s ≤ acc do pure ())
 #eval fmt `(command| def clampLow (n lo : Nat) : Id Nat requires lo ≤ n ensures r => r = n := pure n)

--- a/tests/elab/formatTerm.lean.out.expected
+++ b/tests/elab/formatTerm.lean.out.expected
@@ -47,6 +47,10 @@ do
   unless c✝ do
     pure✝ ()
 do
+  assert 0 ≤ acc✝
+do
+  assert s✝ => s✝ ≤ acc✝
+do
   for x✝ in xs✝ invariant pref✝ suff✝ => 0 ≤ acc✝ do
     pure✝ ()
 do

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -100,6 +100,71 @@ def sumIntoState (xs : List Nat) : StateM Nat Unit
 #guard_msgs (drop info) in
 #check @sumIntoState.spec
 
+/-! ## `assert` states a property at a point in the program
+
+The bare form asserts a term; the binder form binds the assertion's own arguments, such as the
+state of a state monad. -/
+
+def assertDouble (n : Nat) : Id Nat
+    requires n > 0
+    ensures r => r ≥ 2
+  := do
+  let d := 2 * n
+  assert d ≥ 2
+  return d
+
+#guard_msgs (drop info) in
+#check @assertDouble.spec
+
+def assertIntoState (xs : List Nat) : StateM Nat Unit
+    requires s => s = 0
+    ensures _ s => s = xs.sum
+  := do
+  assert s => s = 0
+  for x in xs invariant pref _ s => s = pref.sum do
+    modify (· + x)
+
+#guard_msgs (drop info) in
+#check @assertIntoState.spec
+
+/-! The binders accept a type ascription, as in `fun`. -/
+
+def assertAscribed (xs : List Nat) : StateM Nat Unit
+    requires s => s = 0
+    ensures _ s => s = xs.sum
+  := do
+  assert s : Nat => s = 0
+  for x in xs invariant pref _ s => s = pref.sum do
+    modify (· + x)
+
+#guard_msgs (drop info) in
+#check @assertAscribed.spec
+
+/-! An assertion that does not follow is reported like any other undischarged condition. -/
+
+/--
+error: unproved verification conditions for the contract of `assertUnprovable`; discharge them in a `where finally | spec => ...` section of the definition
+case vc1
+n : Nat
+⊢ 0 < n
+-/
+#guard_msgs in
+def assertUnprovable (n : Nat) : Id Nat
+    ensures r => r = n
+  := do
+  assert n > 0
+  return n
+
+/-! `assert!` keeps its runtime meaning: it tests a `Bool` and panics, with no gadget involved. -/
+
+def runtimeAssert (n : Nat) : Id Nat := do
+  assert! n > 0
+  return n
+
+/-- info: 3 -/
+#guard_msgs in
+#eval runtimeAssert 3
+
 /-! ## The `invariant` clause needs at least two binders -/
 
 /--

--- a/tests/elab/intrinsicVerificationMissingImport.lean
+++ b/tests/elab/intrinsicVerificationMissingImport.lean
@@ -1,5 +1,6 @@
-/-! A `def` contract or a `for … invariant` clause used without the `Std` metatheory reports a
-helpful error naming the missing import, rather than a downstream elaboration failure. -/
+/-! A `def` contract, a `for … invariant` clause or an `assert` element used without the `Std`
+metatheory reports a helpful error naming the missing import, rather than a downstream elaboration
+failure. -/
 
 /--
 error: `requires`/`ensures` contracts elaborate to a `vcgen`-proved specification theorem; add `import Std.Internal.Do` to use them.
@@ -14,3 +15,9 @@ def g (xs : List Nat) : Id Nat := do
   for x in xs invariant pref suff => 0 ≤ acc do
     acc := acc + x
   return acc
+
+/-- error: the `assert` element elaborates to a `vcgen` gadget; add `import Std.Internal.Do` to use it. -/
+#guard_msgs in
+def h (n : Nat) : Id Nat := do
+  assert n > 0
+  return n


### PR DESCRIPTION
This PR adds an `assert` element to `do` notation for intrinsic verification. `assert P` states that `P` holds at that point in the program; `assert s => P s` binds the arguments of the assertion itself, such as the state of a state monad, using the same binders `fun` accepts. `vcgen` reads the assertion from the program and proves it as a verification condition; at runtime the element does nothing.

The parser is `Lean.Parser.Term.doAssertion`, distinct from the existing `doAssert` of `assert!`. It leads with `nonReservedSymbol "assert" (includeIdent := true)` at priority `default+10`, so a bare `assert` in statement position wins the equal-length tie against `doExpr`; `assert!` is the longer token, so the tokenizer never offers `assert` there. The clause body follows `requiresClause`: `atomic Term.basicFun <|> (ppSpace >> termParser)`.

The element elaborates to `Std.Internal.Do.assertGadget`, and reports a missing-import error when `Std.Internal.Do` is absent. `assertGadget` loses its unused `name` parameter, and its specification `Spec.assertGadget` is now tagged `@[spec]` so `vcgen` finds it.
