### PR TITLE
feat: bind assertion arguments inline in `requires` and `invariant`

### DIFF
--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -85,14 +85,19 @@ open Lean.Meta
 /-- Rebuild the already-elaborated loop as a `forInWithInvariant` call carrying the `invariant`
 clause: `ForIn.forInWithInvariant`, or `ForIn'.forInWithInvariant'` for a membership-proof binder
 (`for h : x in xs`). The mut tuple's layout is `[return?, mutVars…, unit?]`, so the invariant can
-name the loop's mutable variables directly; the early-return slot becomes a wildcard. -/
+name the loop's mutable variables directly; the early-return slot becomes a wildcard. Binders past
+the first two bind the arguments of the assertion itself. -/
 private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
     (xs preS body σ : Expr) (loopMutVars : Array MutVar) (returnsEarly : Bool)
     (mi : MonadInfo) : DoElabM Expr := do
   let `(doForInvariant| invariant $binders* => $invBody) := invClause | throwUnsupportedSyntax
-  unless binders.size == 2 do
-    throwErrorAt invClause "The `invariant` clause takes two binders: the elements consumed so far \
-      and the elements remaining."
+  unless binders.size ≥ 2 do
+    throwErrorAt invClause "The `invariant` clause takes at least two binders: the elements \
+      consumed so far and the elements remaining."
+  let loopBinders := binders.take 2
+  let assertionBinders := binders.extract 2
+  let invBody ← if assertionBinders.isEmpty then pure invBody else
+    `(fun $assertionBinders* => $invBody)
   let hole ← `(_)
   let mut mutBinders : Array Term := #[]
   if returnsEarly then mutBinders := mutBinders.push hole
@@ -103,7 +108,7 @@ private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
     | #[b] => pure b
     | _    => `(⟨$mutBinders,*⟩)
   let mutTupleBinder := mkIdentFrom invClause (← mkFreshUserName `__s)
-  let invLam ← `(fun $binders* $mutTupleBinder:ident =>
+  let invLam ← `(fun $loopBinders* $mutTupleBinder:ident =>
     match $mutTupleBinder:ident with | $mutTuplePat => $invBody)
   -- The `forInWithInvariant` gadgets live downstream of this module, so they are referenced by an
   -- unresolved name that resolves in the user's context (which imports the metatheory).

--- a/src/Lean/Elab/Tactic/Do/Contract.lean
+++ b/src/Lean/Elab/Tactic/Do/Contract.lean
@@ -104,6 +104,7 @@ add `import Std.Internal.Do` to use them."
   let args := sigBinders.flatMap contractBinderIdents
   let pre : Term ← if requiresStx.isNone then `(⊤) else
     match requiresStx[0] with
+    | `(requiresClause| requires $bs* => $p) => `(fun $bs* => $p)
     | `(requiresClause| requires $p) => pure p
     | _ => Macro.throwUnsupported
   let post : Term ← if ensuresStx.isNone then `(fun _ => ⊤) else

--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -129,9 +129,11 @@ def declId := leading_parser
 -- @[builtin_doc] -- FIXME: suppress the hover
 def declSig := leading_parser
   many (ppSpace >> (Term.binderIdent <|> Term.bracketedBinder)) >> Term.typeSpec
-/-- The `requires P` precondition clause of a `def` contract. -/
+/-- The `requires P` precondition clause of a `def` contract. The form `requires s => P s` binds the
+arguments of the assertion itself, such as the state of a state monad. -/
 def requiresClause := leading_parser
-  ppIndent (ppSpace >> nonReservedSymbol "requires" >> ppSpace >> withForbidden "ensures" termParser)
+  ppIndent (ppSpace >> nonReservedSymbol "requires" >>
+    withForbidden "ensures" (atomic Term.basicFun <|> (ppSpace >> termParser)))
 /-- The `ensures b => Q` postcondition clause of a `def` contract, binding the result `b`. -/
 def ensuresClause := leading_parser
   ppIndent (ppSpace >> nonReservedSymbol "ensures" >> Term.basicFun)

--- a/src/Lean/Parser/Do.lean
+++ b/src/Lean/Parser/Do.lean
@@ -178,9 +178,10 @@ def doForDecl := leading_parser
   optional (atomic (ident >> " : ")) >> termParser >> " in " >>
     withForbiddens #["do", "invariant"] termParser
 /--
-The optional `invariant pref suff => e` clause of a `for` loop. The invariant annotates the loop so
-`vcgen` reads it from the program, with `pref` bound to the elements consumed so far, `suff` to the
-elements remaining, and mutable variables referenced by name.
+The optional `invariant pref suff a b c => e` clause of a `for` loop. The invariant annotates the
+loop so `vcgen` reads it from the program, with `pref` bound to the elements consumed so far, `suff`
+to the elements remaining, and mutable variables referenced by name. Any further binders, here
+`a b c`, bind the arguments of the assertion itself, such as the state of a state monad.
 -/
 def doForInvariant := leading_parser
   ppSpace >> nonReservedSymbol "invariant" >> withForbidden "do" basicFun

--- a/tests/elab/formatTerm.lean
+++ b/tests/elab/formatTerm.lean
@@ -16,7 +16,9 @@ def fmt (stx : CoreM Syntax) : CoreM Format := do PrettyPrinter.ppTerm ⟨← st
 #eval fmt `(do unless c do pure ())
 -- intrinsic-verification clauses: `invariant` inline with the loop, `requires`/`ensures` inline with `def`
 #eval fmt `(do for x in xs invariant pref suff => 0 ≤ acc do pure ())
+#eval fmt `(do for x in xs invariant pref suff s => s ≤ acc do pure ())
 #eval fmt `(command| def clampLow (n lo : Nat) : Id Nat requires lo ≤ n ensures r => r = n := pure n)
+#eval fmt `(command| def k (x : Nat) requires s => s > x ensures r => r ≥ x := pure x)
 #eval fmt `(command| def g (x : Nat) requires x > 0 ensures r => r ≥ x := pure x)
 #eval fmt `(command| def h (x : Nat) : Id Nat ensures r => r = x := pure x
 where finally

--- a/tests/elab/formatTerm.lean.out.expected
+++ b/tests/elab/formatTerm.lean.out.expected
@@ -49,8 +49,13 @@ do
 do
   for x✝ in xs✝ invariant pref✝ suff✝ => 0 ≤ acc✝ do
     pure✝ ()
+do
+  for x✝ in xs✝ invariant pref✝ suff✝ s✝ => s✝ ≤ acc✝ do
+    pure✝ ()
 def clampLow✝ (n✝ lo✝ : Nat✝) : Id✝ Nat✝ requires lo✝ ≤ n✝ ensures r✝ => r✝ = n✝ :=
   pure✝ n✝
+def k✝ (x✝ : Nat✝) requires s✝ => s✝ > x✝ ensures r✝ => r✝ ≥ x✝ :=
+  pure✝ x✝
 def g✝ (x✝ : Nat✝) requires x✝ > 0 ensures r✝ => r✝ ≥ x✝ :=
   pure✝ x✝
 def h✝ (x✝ : Nat✝) : Id✝ Nat✝ ensures r✝ => r✝ = x✝ :=

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -91,14 +91,26 @@ def sumRangeMem (n : Nat) : Id Nat
 The invariant need not mention a mutable variable: here it constrains the `StateM` state. -/
 
 def sumIntoState (xs : List Nat) : StateM Nat Unit
-    requires (fun s => s = 0)
+    requires s => s = 0
     ensures _ s => s = xs.sum
   := do
-  for x in xs invariant pref _ => (fun s => s = pref.sum) do
+  for x in xs invariant pref _ s => s = pref.sum do
     modify (· + x)
 
 #guard_msgs (drop info) in
 #check @sumIntoState.spec
+
+/-! ## The `invariant` clause needs at least two binders -/
+
+/--
+error: The `invariant` clause takes at least two binders: the elements consumed so far and the elements remaining.
+-/
+#guard_msgs in
+example (xs : List Nat) : Id Nat := do
+  let mut acc := 0
+  for x in xs invariant _pref => 0 ≤ acc do
+    acc := acc + x
+  return acc
 
 /-! ## The contract telescope is transplanted faithfully to `f.spec`
 


### PR DESCRIPTION
This PR lets the `requires` and `invariant` clauses bind the arguments of the assertion itself, so a monad whose assertions are functions no longer needs an explicit `fun`. For a state monad, the state can be named directly:

```lean
def sumIntoState (xs : List Nat) : StateM Nat Unit
    requires s => s = 0
    ensures _ s => s = xs.sum
  := do
  for x in xs invariant pref _ s => s = pref.sum do
    modify (· + x)
```

`ensures` already behaved this way. `requires` now accepts either a binder form or a plain term, so `requires x > 0` is unaffected, and `invariant` accepts any number of binders beyond the first two, which remain the elements consumed and the elements remaining.
