### PR TITLE
chore: re-add `cbv at`, but now adhering to `SymM` invariants

### DIFF
--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -2373,9 +2373,17 @@ It reduces terms by unfolding definitions using their defining equations and
 applying matcher equations. The unfolding is propositional, so `cbv` also works
 with functions defined via well-founded recursion or partial fixpoints.
 
-`cbv` reduces the goal type using call-by-value evaluation. For equation goals
-(`lhs = rhs`), `cbv` automatically attempts `refl` after reduction to close the
-goal.
+`cbv` reduces the goal type (and optionally hypothesis types) using call-by-value
+evaluation. For equation goals (`lhs = rhs`), `cbv` automatically attempts `refl`
+after reduction to close the goal.
+
+`cbv` supports the standard `at` location syntax:
+- `cbv` — reduce the goal target
+- `cbv at h` — reduce hypothesis `h`
+- `cbv at h |-` — reduce hypothesis `h` and the goal target
+- `cbv at *` — reduce the goal target and all non-dependent propositional hypotheses
+
+If a hypothesis reduces to `False`, the goal is closed immediately.
 
 `cbv` is not a finishing tactic in general: it may leave a new (simpler) goal.
 
@@ -2383,7 +2391,7 @@ The proofs produced by `cbv` only use the three standard axioms.
 In particular, they do not require trust in the correctness of the code
 generator.
 -/
-syntax (name := cbv) "cbv" : tactic
+syntax (name := cbv) "cbv" (location)? : tactic
 
 /--
 `decide_cbv` is a finishing tactic that closes goals of the form `p`, where `p`

--- a/src/Lean/Elab/Tactic/Cbv.lean
+++ b/src/Lean/Elab/Tactic/Cbv.lean
@@ -8,6 +8,7 @@ module
 prelude
 public import Lean.Meta.Tactic.Cbv
 public import Lean.Meta.Tactic
+public import Lean.Elab.Tactic.Location
 
 public section
 
@@ -15,13 +16,34 @@ namespace Lean.Elab.Tactic.Cbv
 
 open Lean.Meta.Tactic.Cbv
 
+/-- Reduces the type of hypothesis `fvarId` using `cbv`, in its own `SymM` session. -/
+def cbvLocalDecl (fvarId : FVarId) : TacticM Unit :=
+  liftMetaTactic fun mvarId => do
+    match (← cbvHyp mvarId fvarId) with
+    | .none => return []
+    | .some newGoal => return [newGoal]
+
+/-- Reduces the goal target using `cbv`, in its own `SymM` session. -/
+def cbvTarget : TacticM Unit :=
+  liftMetaTactic fun mvarId => do
+    match (← cbvGoal mvarId) with
+    | .none => return []
+    | .some newGoal => return [newGoal]
+
 @[builtin_tactic Lean.Parser.Tactic.cbv] def evalCbv : Tactic := fun stx => withMainContext do
   if cbv.warning.get (← getOptions) then
     logWarningAt stx "The `cbv` usage warning option is enabled. Disable it by setting `set_option cbv.warning false`."
-  liftMetaTactic fun mvar => do
-    match (← cbvGoal mvar) with
-    | .none => return []
-    | .some newGoal => return [newGoal]
+  let loc := expandOptLocation stx[1]
+  let wildcardHyps? ← match loc with
+    | .wildcard => some <$> (← getMainGoal).getNondepPropHyps
+    | _ => pure none
+  withLocation loc
+    (atLocal := fun fvarId => do
+      if let some wildcardHyps := wildcardHyps? then
+        unless wildcardHyps.contains fvarId do return
+      cbvLocalDecl fvarId)
+    (atTarget := cbvTarget)
+    (failed := fun _ => throwError "`cbv` failed")
 
 @[builtin_tactic Lean.Parser.Tactic.decide_cbv] def evalDecideCbv : Tactic := fun stx =>
   match stx with

--- a/src/Lean/Meta/Tactic/Cbv/Main.lean
+++ b/src/Lean/Meta/Tactic/Cbv/Main.lean
@@ -99,6 +99,7 @@ is marked done regardless of whether a rule fires. Otherwise it tries in order:
 
 - `cbvEntry`: reduces a single expression (used by `conv => cbv`)
 - `cbvGoal`: reduces the goal target (used by the `cbv` tactic)
+- `cbvHyp`: reduces a hypothesis type (used by `cbv at`)
 - `cbvDecideGoal`: reduces `decide P = true` and closes or errors (used by `decide_cbv`)
 -/
 
@@ -421,6 +422,34 @@ public def cbvGoalCore (mvarId : MVarId) : Sym.SymM (Option MVarId) := do
     let s ← Meta.saveState
     try mvarIdNew.refl; return none
     catch _ => s.restore; return some mvarIdNew
+
+/--
+Reduce the type of hypothesis `fvarId` using call-by-value evaluation, in its own
+`SymM` session (like `conv at h => cbv`). The local context is only mutated after
+the session ends, so the `SymM` incrementality invariant is preserved.
+-/
+public def cbvHyp (mvarId : MVarId) (fvarId : FVarId) : MetaM (Option MVarId) :=
+  mvarId.withContext do
+    let localDecl ← fvarId.getDecl
+    let type ← instantiateMVars localDecl.type
+    let config : Sym.Simp.Config := { maxSteps := cbv.maxSteps.get (← getOptions) }
+    let result ← withTraceNode `Meta.Tactic.cbv (fun
+        | .ok (Result.step type' ..) => return m!"hypothesis `{localDecl.userName}`:{indentExpr type}\n==>{indentExpr type'}"
+        | .ok (Result.rfl ..)        => return m!"hypothesis `{localDecl.userName}`: no change"
+        | .error err                 => return m!"hypothesis `{localDecl.userName}`: {err.toMessageData}") do
+      let type ← Sym.unfoldReducible type
+      Sym.SymM.run do
+        Sym.withoutShareCommonChecks do
+          let type ← Sym.shareCommon type
+          cbvCore type config
+    match result with
+    | .rfl .. => return some mvarId
+    | .step type' proof _ _ =>
+      if type'.isFalse then
+        mvarId.assign (← mkFalseElim (← mvarId.getType) (← mkEqMP proof localDecl.toExpr))
+        return none
+      else
+        return some (← mvarId.replaceLocalDecl fvarId type' proof).mvarId
 
 /--
 Reduce the goal target using call-by-value evaluation.

--- a/tests/elab/cbv_at.lean
+++ b/tests/elab/cbv_at.lean
@@ -1,0 +1,110 @@
+/-!
+Tests for the `cbv at` location syntax: reducing hypotheses (`at h`), hypotheses
+plus target (`at h |-`), and the wildcard (`at *`), which visits the target and
+all non-dependent propositional hypotheses. Each location is reduced in its own
+`SymM` session, and hypotheses keep their position in the local context.
+-/
+
+set_option linter.unusedVariables false
+
+/--
+trace: h : True
+⊢ True
+-/
+#guard_msgs in
+example (h : 2 + 3 = 5) : True := by
+  cbv at h
+  trace_state
+  trivial
+
+-- False equation in hypothesis: goal is closed automatically
+example (h : 2 + 3 = 6) : 42 = 0 := by
+  cbv at h
+
+-- `cbv at h |-` — reduces both hypothesis and target
+example (h : 2 + 3 = 5) : 1 + 1 = 2 := by
+  cbv at h |-
+
+-- Multiple explicit hypotheses
+/--
+trace: h₁ h₂ : True
+⊢ True
+-/
+#guard_msgs in
+example (h₁ : 2 + 3 = 5) (h₂ : 1 + 1 = 2) : True := by
+  cbv at h₁ h₂
+  trace_state
+  trivial
+
+/--
+trace: h₁ h₂ : True
+⊢ False
+---
+warning: declaration uses `sorry`
+-/
+#guard_msgs in
+example (h₁ : 2 + 3 = 5) (h₂ : 1 + 1 = 2) : False := by
+  cbv at *
+  trace_state
+  sorry
+
+-- Reduces hypothesis but not target when only hypothesis is specified
+/-- warning: declaration uses `sorry` -/
+#guard_msgs in
+example (h : (fun x => x + 1) 0 = 1) : 2 + 2 = 5 := by
+  cbv at h
+  sorry
+
+-- Hypotheses keep their position in the local context
+/--
+trace: n : Nat
+h₁ : True
+h₂ : n = 0
+⊢ n = 0
+-/
+#guard_msgs in
+example (n : Nat) (h₁ : 2 + 3 = 5) (h₂ : n = 0) : n = 0 := by
+  cbv at h₁
+  trace_state
+  exact h₂
+
+-- `at *` skips hypotheses that other hypotheses depend on: `p` stays unreduced
+-- (it would become `True` if visited) because `h` mentions it. `h` itself is a
+-- non-dependent proposition, so it is reduced, as is `h'`.
+/--
+trace: p : 2 + 3 = 5
+h h' : True
+⊢ True
+-/
+#guard_msgs in
+example (p : 2 + 3 = 5) (h : p = p) (h' : 1 + 1 = 2) : True := by
+  cbv at *
+  trace_state
+  trivial
+
+-- `at *` skips non-propositional hypotheses: `x` would become `Fin 5` if visited
+/--
+trace: x : Fin (2 + 3)
+h : True
+⊢ True
+-/
+#guard_msgs in
+example (x : Fin (2 + 3)) (h : 1 + 1 = 2) : True := by
+  cbv at *
+  trace_state
+  trivial
+
+-- `at *` skips hypotheses occurring in the target: `q` stays unreduced. The
+-- target `P q` is still visited but has no reduction.
+/--
+trace: P : 2 + 3 = 5 → Prop
+q : 2 + 3 = 5
+hp : P q
+h : True
+⊢ P q
+-/
+#guard_msgs in
+example (P : (2 + 3 = 5) → Prop) (q : 2 + 3 = 5) (hp : P q) (h : 1 + 1 = 2) : P q := by
+  cbv at *
+  trace_state
+  exact hp


### PR DESCRIPTION
This PR adds `cbv at` feature to run `cbv` on local hypotheses, but now it is safe with respect to `SymM` invariants, namely, each `cbv` call (to a local hypothesis) is contained within a single `SymM` context, which remains incremental 