### PR TITLE
perf: compute vcgen frame inference inputs on demand

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
@@ -202,7 +202,7 @@ public structure VCGen.State where
   /--
   Remaining VC-generation steps. Initialized from `Context.config.stepLimit` (or
   `.unlimited` when no limit is set). Decremented at each successful program-shape
-  step (`tryLetHoist`, `trySplit`, `tryFvarZeta`, `applySpecRule`). When exhausted,
+  step (`tryLetHoist`, `trySplit`, `tryFvarZeta`, `applySpec`). When exhausted,
   `solve` short-circuits and emits the current goal as a VC.
   -/
   fuel : Lean.Elab.Tactic.Do.Fuel := .unlimited

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
@@ -202,7 +202,7 @@ public structure VCGen.State where
   /--
   Remaining VC-generation steps. Initialized from `Context.config.stepLimit` (or
   `.unlimited` when no limit is set). Decremented at each successful program-shape
-  step (`tryLetHoist`, `trySplit`, `tryFvarZeta`, `applySpec`). When exhausted,
+  step (`tryLetHoist`, `trySplit`, `tryFvarZeta`, `applySpecRule`). When exhausted,
   `solve` short-circuits and emits the current goal as a VC.
   -/
   fuel : Lean.Elab.Tactic.Do.Fuel := .unlimited

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/FrameProc.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/FrameProc.lean
@@ -96,12 +96,9 @@ public def VCGen.FrameInferenceInfo.specPre? (i : FrameInferenceInfo) : SymM (Op
     let some specPre ← subgoals.findSomeM? fun g => do
         let ty ← g.getType
         let_expr Lean.Order.PartialOrder.rel _ _ _ specPre := ty | return none
-        -- An assigned head metavariable would hide `specPre`'s operator from the procedure, which
-        -- dispatches on the head (e.g. flattening a `∗` chain); nested metavariables are resolved
-        -- by the procedure's own unification.
-        return some (← instantiateMVarsIfMVarAppS specPre)
+        return some specPre
       | return none
-    some <$> Meta.abstractMVars (← instantiateMVarsS specPre)
+    some <$> Meta.abstractMVars (← instantiateMVars specPre)
   let some abs := abs? | return none
   let (_, _, specPre) ← Meta.openAbstractMVarsResult abs
   return some (← shareCommon specPre)

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/FrameProc.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/FrameProc.lean
@@ -36,14 +36,24 @@ Build a `FrameSplit` with `FrameSplit.withDischargedSplitVC` (proof supplied) or
 public structure VCGen.FrameSplit where
   /-- The framed resource. -/
   frame : Expr
+  /-- The residual precondition the program runs against once `frame` is framed off: in the split VC
+  `pre ⊑ op frame residualPre`, the complement of `frame` in `pre`. A solver-owned synthetic-opaque
+  metavariable the procedure must not assign; the solver fills it once the frame rule fixes it. -/
+  residualPre : Expr
   /-- A proof of the split VC `pre ⊑ (op frame residualPre) s⃗`. -/
   splitVCProof : Expr
   /-- The unassigned subgoals of `splitVCProof`. -/
   subgoals : List MVarId
 
-/-- The inputs to a `FrameInferenceProc`: the goal, how the frame was requested, the spec being
-applied, and the residual metavariable. Extends the program's `wp` metadata (`WPApp`), so `Pred`,
-`excessArgs`, etc. are available directly. -/
+/-- Instantiate a `FrameSplit`'s data against the current metavariable context (and reshare). -/
+public def VCGen.FrameSplit.instantiateMVarsS (split : FrameSplit) : SymM FrameSplit :=
+  return { split with
+           frame := ← Sym.instantiateMVarsS split.frame
+           splitVCProof := ← Sym.instantiateMVarsS split.splitVCProof }
+
+/-- The inputs to a `FrameInferenceProc`: the goal, how the frame was requested, and the spec being
+applied. Extends the program's `wp` metadata (`WPApp`), so `Pred`, `excessArgs`, etc. are available
+directly. -/
 public structure VCGen.FrameInferenceInfo extends VCGen.WPApp where
   /-- The entailment goal `pre ⊑ wp …` the frame rule or spec applies to. -/
   goal : MVarId
@@ -55,10 +65,9 @@ public structure VCGen.FrameInferenceInfo extends VCGen.WPApp where
   spec? : Option Name
   /-- The backward rule of the `@[spec]` theorem being applied. -/
   specRule : Lean.Meta.Sym.BackwardRule
-  /-- The residual precondition the program runs against once `frame` is framed off: in the split VC
-  `pre ⊑ op frame residualPre`, the complement of `frame` in `pre`. A solver-owned synthetic-opaque
-  metavariable the procedure must not assign; the solver fills it once the frame rule fixes it. -/
-  residualPre : Expr
+  /-- Builds the frame operator `op : R → Pred → Pred`; the selected procedure's
+  `FrameProc.mkOpAppM`. -/
+  mkOp : VCGen.WPApp → MetaM Expr
 
 /-- The goal's entailment relation `PartialOrder.rel α inst` (carrier and order instance applied);
 apply it to two operands to build an entailment in the goal's order. -/
@@ -69,47 +78,58 @@ public def VCGen.FrameInferenceInfo.le (i : FrameInferenceInfo) : SymM Expr :=
 public def VCGen.FrameInferenceInfo.pre (i : FrameInferenceInfo) : SymM Expr :=
   return (← i.goal.getType).appFn!.appArg!
 
+/-- The frame operator `op : R → Pred → Pred`, built by `mkOp` and hash-consed. -/
+public def VCGen.FrameInferenceInfo.op (i : FrameInferenceInfo) : SymM Expr := do
+  shareCommon (← i.mkOp i.toWPApp)
+
+/-- A fresh residual-precondition metavariable for a `FrameSplit`: solver-owned and
+synthetic-opaque; the procedure builds the split VC against it and must not assign it. -/
+public def VCGen.FrameInferenceInfo.mkResidualPre (i : FrameInferenceInfo) : SymM Expr :=
+  mkFreshExprSyntheticOpaqueMVar i.Pred
+
 /-- The spec precondition instantiated at the call site, read off a speculative application of
 `specRule` to `goal` that is rolled back: the precondition VC's metavariables are frozen into a
 telescope and reopened fresh in the restored context, so they outlive the rollback. `none` when the
 rule does not apply or leaves no precondition VC. -/
 public def VCGen.FrameInferenceInfo.specPre? (i : FrameInferenceInfo) : SymM (Option Expr) := do
-  let saved ← Meta.saveState
-  let .goals subgoals ← i.specRule.apply i.goal | return none
-  -- The precondition VC is the bare `pre ⊑ specPre` premise among the subgoals; the post and
-  -- exception VCs are `∀`-quantified.
-  let specPre? ← subgoals.findSomeM? fun g => do
-    let ty ← g.getType
-    let_expr Lean.Order.PartialOrder.rel _ _ _ specPre := ty | return none
-    -- Resolve only an assigned head mvar so the procedure's head test (`isAppOf`) sees the real
-    -- operator; nested mvars are resolved by the procedure's own unification.
-    return some (← instantiateMVarsIfMVarAppS specPre)
-  let some specPre := specPre? | do saved.restore; return none
-  let abs ← Meta.abstractMVars (← instantiateMVarsS specPre)
-  saved.restore
+  let abs? ← Meta.withoutModifyingMCtx do
+    let .goals subgoals ← i.specRule.apply i.goal | return none
+    -- The precondition VC is the bare `pre ⊑ specPre` premise among the subgoals; the post and
+    -- exception VCs are `∀`-quantified.
+    let some specPre ← subgoals.findSomeM? fun g => do
+        let ty ← g.getType
+        let_expr Lean.Order.PartialOrder.rel _ _ _ specPre := ty | return none
+        -- Resolve only an assigned head mvar so the procedure's head test (`isAppOf`) sees the real
+        -- operator; nested mvars are resolved by the procedure's own unification.
+        return some (← instantiateMVarsIfMVarAppS specPre)
+      | return none
+    some <$> Meta.abstractMVars (← instantiateMVarsS specPre)
+  let some abs := abs? | return none
   let (_, _, specPre) ← Meta.openAbstractMVarsResult abs
   return some (← shareCommon specPre)
 
-/-- The split VC proposition `pre ⊑ (op frame footprint) s⃗`: the frame operator `op : R → Pred → Pred`
-applied to `frame` and `footprint`, then to the excess state arguments, entailed by `pre` in the
-goal's order. `op`, `frame` and `footprint` must be hash-consed (`shareCommon`); the result is. -/
-public def VCGen.FrameInferenceInfo.mkSplitVCS (i : FrameInferenceInfo) (op frame footprint : Expr) :
+/-- The split VC proposition `pre ⊑ (op frame footprint) s⃗`: the frame operator applied to `frame`
+and `footprint`, then to the excess state arguments, entailed by `pre` in the goal's order. `frame`
+and `footprint` must be hash-consed (`shareCommon`); the result is. -/
+public def VCGen.FrameInferenceInfo.mkSplitVCS (i : FrameInferenceInfo) (frame footprint : Expr) :
     SymM Expr := do
-  let rhs ← mkAppNS (← mkAppNS op #[frame, footprint]) i.excessArgs
-  mkAppNS (← i.le) #[← i.pre, rhs]
+  let rhs ← mkAppNS (← mkAppNS (← i.op) #[frame, footprint]) i.excessArgs
+  let ty ← i.goal.getType
+  mkAppNS (ty.stripArgsN 2) #[ty.appFn!.appArg!, rhs]
 
 /-- A `FrameSplit` framing `frame` whose split VC `pre ⊑ (op frame residualPre) s⃗` is deferred as a
 fresh subgoal for the built-in lattice (meet) decomposition to split. -/
-public def VCGen.FrameSplit.withDeferredSplitVC (i : FrameInferenceInfo) (op frame : Expr) :
+public def VCGen.FrameSplit.withDeferredSplitVC (i : FrameInferenceInfo) (frame : Expr) :
     SymM FrameSplit := do
-  let m ← mkFreshExprSyntheticOpaqueMVar (← i.mkSplitVCS op frame i.residualPre)
-  return { frame, splitVCProof := m, subgoals := [m.mvarId!] }
+  let residualPre ← i.mkResidualPre
+  let m ← mkFreshExprSyntheticOpaqueMVar (← i.mkSplitVCS frame residualPre)
+  return { frame, residualPre, splitVCProof := m, subgoals := [m.mvarId!] }
 
 /-- A `FrameSplit` framing `frame`, discharging the split VC `pre ⊑ (op frame residualPre) s⃗` with
 `splitVCProof` and leaving its `subgoals`. -/
-public def VCGen.FrameSplit.withDischargedSplitVC (frame splitVCProof : Expr)
+public def VCGen.FrameSplit.withDischargedSplitVC (frame residualPre splitVCProof : Expr)
     (subgoals : List MVarId := []) : FrameSplit :=
-  { frame, splitVCProof, subgoals }
+  { frame, residualPre, splitVCProof, subgoals }
 
 /-- A frame backward rule together with the positions of its assignable subgoals in the applied
 rule's goal list: the schematic frame and the split VC `pre ⊑ (op frame W) s⃗`, where `W` is the
@@ -179,12 +199,10 @@ public def VCGen.FrameProcs.insert (s : FrameProcs) (fp : FrameProc) : FrameProc
   { byProg := s.byProg.insert fp.prog fp }
 
 /-- Default frame inference procedure, agnostic of the frame operator: frame the resource pinned by
-a `frames` clause, with the weakest footprint. `mkOp` builds the frame operator, invoked only when a
-frame is pinned. -/
-public def VCGen.defaultFrameInferenceProc (mkOp : WPApp → MetaM Expr) : FrameInferenceProc :=
-  fun i => do
-    let some frame := i.providedFrame? | return none
-    return some (← FrameSplit.withDeferredSplitVC i (← shareCommon (← mkOp i.toWPApp)) frame)
+a `frames` clause, with the weakest footprint. -/
+public def VCGen.defaultFrameInferenceProc : FrameInferenceProc := fun i => do
+  let some frame := i.providedFrame? | return none
+  return some (← FrameSplit.withDeferredSplitVC i frame)
 
 /-- The lattice meet operator over the goal's assertion type. -/
 private def meetOp (info : VCGen.WPApp) : MetaM Expr :=
@@ -197,6 +215,6 @@ public def VCGen.meetFrameProc : VCGen.FrameProc where
   mkOpAppM := meetOp
   mkResourceTy info := pure info.Pred
   opHead := ``Lean.Order.meet
-  proc := defaultFrameInferenceProc meetOp
+  proc := defaultFrameInferenceProc
 
 end Lean.Elab.Tactic.Do.Internal

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/FrameProc.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/FrameProc.lean
@@ -11,7 +11,9 @@ public import Lean.Meta.Sym.Apply
 public import Lean.Meta.Sym.AlphaShareBuilder
 import Std.Internal.Do.Order.Basic
 import Lean.Meta.AppBuilder
+import Lean.Meta.AbstractMVars
 import Lean.Meta.Sym.InferType
+import Lean.Meta.Sym.InstantiateMVarsS
 import Lean.Meta.Tactic.Util
 
 /-!
@@ -39,49 +41,68 @@ public structure VCGen.FrameSplit where
   /-- The unassigned subgoals of `splitVCProof`. -/
   subgoals : List MVarId
 
-/-- How the frame was requested: an `explicit` resource pinned by a `frames` clause, or the
-`implicit` spec precondition to infer the frame from. -/
-public inductive VCGen.FrameInferenceHint where
-  /-- Frame the given resource, pinned by a `frames` clause. -/
-  | explicit (frame : Expr)
-  /-- Infer the frame from the spec's precondition `specPre`, the right-hand side of the spec's
-  precondition VC `pre ⊑ specPre`. -/
-  | implicit (specPre : Expr)
-
-/-- The inputs to a `FrameInferenceProc`: the frame operator, the goal entailment relation, the
-precondition, how the frame was requested, and the residual metavariable. Extends the program's `wp`
-metadata (`WPApp`), so `Pred`, `excessArgs`, etc. are available directly. -/
+/-- The inputs to a `FrameInferenceProc`: the goal, how the frame was requested, the spec being
+applied, and the residual metavariable. Extends the program's `wp` metadata (`WPApp`), so `Pred`,
+`excessArgs`, etc. are available directly. -/
 public structure VCGen.FrameInferenceInfo extends VCGen.WPApp where
-  /-- The applicable frame operator `op : R → Pred → Pred`. -/
-  op : Expr
-  /-- The goal's entailment relation `PartialOrder.rel α inst` (carrier and order instance applied);
-  apply it to two operands to build an entailment in the goal's order. -/
-  le : Expr
-  /-- What holds going in: the left-hand side of the goal entailment `pre ⊑ wp …`. -/
-  pre : Expr
-  /-- How the frame was requested: an `explicit` frame from a `frames` clause, or the `implicit` spec
-  precondition to infer it from. -/
-  hint : FrameInferenceHint
+  /-- The entailment goal `pre ⊑ wp …` the frame rule or spec applies to. -/
+  goal : MVarId
+  /-- The frame pinned by a matching `frames` clause, or `none` to infer the frame, e.g. from the
+  precondition or from `specPre?`. -/
+  providedFrame? : Option Expr
   /-- Declaration name of the `@[spec]` theorem being applied, `none` for a local or syntactic spec.
   A procedure can key a footprint off it, e.g. through an attribute keyed by spec name. -/
   spec? : Option Name
+  /-- The backward rule of the `@[spec]` theorem being applied. -/
+  specRule : Lean.Meta.Sym.BackwardRule
   /-- The residual precondition the program runs against once `frame` is framed off: in the split VC
   `pre ⊑ op frame residualPre`, the complement of `frame` in `pre`. A solver-owned synthetic-opaque
   metavariable the procedure must not assign; the solver fills it once the frame rule fixes it. -/
   residualPre : Expr
 
-/-- The split VC proposition `pre ⊑ (op frame footprint) s⃗`: the frame operator applied to `frame`
-and `footprint`, then to the excess state arguments, entailed by `pre` in the goal's order. -/
-public def VCGen.FrameInferenceInfo.mkSplitVC (i : FrameInferenceInfo) (frame footprint : Expr) :
+/-- The goal's entailment relation `PartialOrder.rel α inst` (carrier and order instance applied);
+apply it to two operands to build an entailment in the goal's order. -/
+public def VCGen.FrameInferenceInfo.le (i : FrameInferenceInfo) : SymM Expr :=
+  return (← i.goal.getType).stripArgsN 2
+
+/-- What holds going in: the left-hand side of the goal entailment `pre ⊑ wp …`. -/
+public def VCGen.FrameInferenceInfo.pre (i : FrameInferenceInfo) : SymM Expr :=
+  return (← i.goal.getType).appFn!.appArg!
+
+/-- The spec precondition instantiated at the call site, read off a speculative application of
+`specRule` to `goal` that is rolled back: the precondition VC's metavariables are frozen into a
+telescope and reopened fresh in the restored context, so they outlive the rollback. `none` when the
+rule does not apply or leaves no precondition VC. -/
+public def VCGen.FrameInferenceInfo.specPre? (i : FrameInferenceInfo) : SymM (Option Expr) := do
+  let saved ← Meta.saveState
+  let .goals subgoals ← i.specRule.apply i.goal | return none
+  -- The precondition VC is the bare `pre ⊑ specPre` premise among the subgoals; the post and
+  -- exception VCs are `∀`-quantified.
+  let specPre? ← subgoals.findSomeM? fun g => do
+    let ty ← g.getType
+    let_expr Lean.Order.PartialOrder.rel _ _ _ specPre := ty | return none
+    -- Resolve only an assigned head mvar so the procedure's head test (`isAppOf`) sees the real
+    -- operator; nested mvars are resolved by the procedure's own unification.
+    return some (← instantiateMVarsIfMVarAppS specPre)
+  let some specPre := specPre? | do saved.restore; return none
+  let abs ← Meta.abstractMVars (← instantiateMVarsS specPre)
+  saved.restore
+  let (_, _, specPre) ← Meta.openAbstractMVarsResult abs
+  return some (← shareCommon specPre)
+
+/-- The split VC proposition `pre ⊑ (op frame footprint) s⃗`: the frame operator `op : R → Pred → Pred`
+applied to `frame` and `footprint`, then to the excess state arguments, entailed by `pre` in the
+goal's order. `op`, `frame` and `footprint` must be hash-consed (`shareCommon`); the result is. -/
+public def VCGen.FrameInferenceInfo.mkSplitVCS (i : FrameInferenceInfo) (op frame footprint : Expr) :
     SymM Expr := do
-  let rhs ← mkAppNS (← mkAppNS i.op #[frame, footprint]) i.excessArgs
-  mkAppNS i.le #[i.pre, rhs]
+  let rhs ← mkAppNS (← mkAppNS op #[frame, footprint]) i.excessArgs
+  mkAppNS (← i.le) #[← i.pre, rhs]
 
 /-- A `FrameSplit` framing `frame` whose split VC `pre ⊑ (op frame residualPre) s⃗` is deferred as a
 fresh subgoal for the built-in lattice (meet) decomposition to split. -/
-public def VCGen.FrameSplit.withDeferredSplitVC (i : FrameInferenceInfo) (frame : Expr) :
+public def VCGen.FrameSplit.withDeferredSplitVC (i : FrameInferenceInfo) (op frame : Expr) :
     SymM FrameSplit := do
-  let m ← mkFreshExprSyntheticOpaqueMVar (← i.mkSplitVC frame i.residualPre)
+  let m ← mkFreshExprSyntheticOpaqueMVar (← i.mkSplitVCS op frame i.residualPre)
   return { frame, splitVCProof := m, subgoals := [m.mvarId!] }
 
 /-- A `FrameSplit` framing `frame`, discharging the split VC `pre ⊑ (op frame residualPre) s⃗` with
@@ -102,9 +123,9 @@ public structure VCGen.FrameBackwardRule where
   /-- Position of the schematic frame (of type `R`). -/
   frameIdx : Nat
 
-/-- A frame inference procedure: from a `FrameInferenceInfo` (whose `hint` says whether the frame is
-`explicit` or must be inferred from the spec precondition), optionally produce a `FrameSplit`; `none`
-leaves the spec to apply directly.
+/-- A frame inference procedure: from a `FrameInferenceInfo` (whose `providedFrame?` carries the
+frame of a matching `frames` clause, if any), optionally produce a `FrameSplit`; `none` leaves the
+spec to apply directly.
 
 The procedure produces the frame and a proof of the split VC `pre ⊑ (op frame residualPre) s⃗`; it
 must not assign `residualPre`, which the solver fills with the weakest footprint after the frame rule
@@ -136,14 +157,14 @@ public structure VCGen.FrameProc where
   /-- Head constant of the program type (the monad) whose `wp` this procedure frames. Keys the
   procedure in the `byProg` index; `vcgen` consults it for a program with that head. -/
   prog : Name
+  /-- Head constant of the frame operator, locating the split VC in the frame rule. -/
+  opHead : Name
   /-- Builds the frame operator (head constant `opHead`) applied to the goal's assertion type. -/
   mkOpAppM : VCGen.WPApp → MetaM Expr
   /-- The resource type `R` of the operator `op : R → Pred → Pred`, i.e. the domain of `mkOpAppM`'s
   result. Provided directly so `vcgen` reads it without building the operator, which it does only when
   a frame actually applies. -/
-  resourceTy : VCGen.WPApp → MetaM Expr
-  /-- Head constant of the frame operator, locating the split VC in the frame rule. -/
-  opHead : Name
+  mkResourceTy : VCGen.WPApp → MetaM Expr
   /-- The frame inference metaprogram. -/
   proc : VCGen.FrameInferenceProc
 
@@ -157,20 +178,25 @@ public instance : Inhabited VCGen.FrameProcs := ⟨{}⟩
 public def VCGen.FrameProcs.insert (s : FrameProcs) (fp : FrameProc) : FrameProcs :=
   { byProg := s.byProg.insert fp.prog fp }
 
-/-- Default meet frame procedure: frame the resource pinned by a `frames` clause, with the weakest
-footprint. -/
-public def VCGen.meetFrameInferenceProc : FrameInferenceProc := fun i => do
-  match i.hint with
-  | .explicit frame => return some (← FrameSplit.withDeferredSplitVC i frame)
-  | .implicit _ => return none
+/-- Default frame inference procedure, agnostic of the frame operator: frame the resource pinned by
+a `frames` clause, with the weakest footprint. `mkOp` builds the frame operator, invoked only when a
+frame is pinned. -/
+public def VCGen.defaultFrameInferenceProc (mkOp : WPApp → MetaM Expr) : FrameInferenceProc :=
+  fun i => do
+    let some frame := i.providedFrame? | return none
+    return some (← FrameSplit.withDeferredSplitVC i (← shareCommon (← mkOp i.toWPApp)) frame)
+
+/-- The lattice meet operator over the goal's assertion type. -/
+private def meetOp (info : VCGen.WPApp) : MetaM Expr :=
+  Meta.mkAppOptM ``Lean.Order.meet #[info.Pred, none]
 
 /-- The default frame operator: lattice meet `pre ⊓ frame`, the Hoare frame every complete lattice carries.
 Framed only through an explicit `frames` clause; used for a monad with no registered `@[frameproc]`. -/
 public def VCGen.meetFrameProc : VCGen.FrameProc where
   prog := ``Lean.Order.meet
-  mkOpAppM info := Meta.mkAppOptM ``Lean.Order.meet #[info.Pred, none]
-  resourceTy info := pure info.Pred
+  mkOpAppM := meetOp
+  mkResourceTy info := pure info.Pred
   opHead := ``Lean.Order.meet
-  proc := meetFrameInferenceProc
+  proc := defaultFrameInferenceProc meetOp
 
 end Lean.Elab.Tactic.Do.Internal

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/FrameProc.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/FrameProc.lean
@@ -37,9 +37,9 @@ public structure VCGen.FrameSplit where
   /-- The framed resource. -/
   frame : Expr
   /-- The residual precondition the program runs against once `frame` is framed off: in the split VC
-  `pre ⊑ op frame residualPre`, the complement of `frame` in `pre`. A solver-owned synthetic-opaque
-  metavariable the procedure must not assign; the solver fills it once the frame rule fixes it. -/
-  residualPre : Expr
+  `pre ⊑ op frame residualPre`, the complement of `frame` in `pre`. Allocated by `mkResidualPre`,
+  left unassigned by the procedure; `applyFrameRule` fills it once the frame rule fixes it. -/
+  residualPre : MVarId
   /-- A proof of the split VC `pre ⊑ (op frame residualPre) s⃗`. -/
   splitVCProof : Expr
   /-- The unassigned subgoals of `splitVCProof`. -/
@@ -65,9 +65,9 @@ public structure VCGen.FrameInferenceInfo extends VCGen.WPApp where
   spec? : Option Name
   /-- The backward rule of the `@[spec]` theorem being applied. -/
   specRule : Lean.Meta.Sym.BackwardRule
-  /-- Builds the frame operator `op : R → Pred → Pred`; the selected procedure's
+  /-- Builds the frame operator `op : R → Pred → Pred`, hash-consed; the selected procedure's
   `FrameProc.mkOpAppM`. -/
-  mkOp : VCGen.WPApp → MetaM Expr
+  mkOpApp : SymM Expr
 
 /-- The goal's entailment relation `PartialOrder.rel α inst` (carrier and order instance applied);
 apply it to two operands to build an entailment in the goal's order. -/
@@ -78,14 +78,10 @@ public def VCGen.FrameInferenceInfo.le (i : FrameInferenceInfo) : SymM Expr :=
 public def VCGen.FrameInferenceInfo.pre (i : FrameInferenceInfo) : SymM Expr :=
   return (← i.goal.getType).appFn!.appArg!
 
-/-- The frame operator `op : R → Pred → Pred`, built by `mkOp` and hash-consed. -/
-public def VCGen.FrameInferenceInfo.op (i : FrameInferenceInfo) : SymM Expr := do
-  shareCommon (← i.mkOp i.toWPApp)
-
-/-- A fresh residual-precondition metavariable for a `FrameSplit`: solver-owned and
-synthetic-opaque; the procedure builds the split VC against it and must not assign it. -/
-public def VCGen.FrameInferenceInfo.mkResidualPre (i : FrameInferenceInfo) : SymM Expr :=
-  mkFreshExprSyntheticOpaqueMVar i.Pred
+/-- A fresh residual-precondition metavariable for a `FrameSplit`: synthetic-opaque; the procedure
+builds the split VC against it and leaves it unassigned. -/
+public def VCGen.FrameInferenceInfo.mkResidualPre (i : FrameInferenceInfo) : SymM MVarId :=
+  return (← mkFreshExprSyntheticOpaqueMVar i.Pred).mvarId!
 
 /-- The spec precondition instantiated at the call site, read off a speculative application of
 `specRule` to `goal` that is rolled back: the precondition VC's metavariables are frozen into a
@@ -94,13 +90,15 @@ rule does not apply or leaves no precondition VC. -/
 public def VCGen.FrameInferenceInfo.specPre? (i : FrameInferenceInfo) : SymM (Option Expr) := do
   let abs? ← Meta.withoutModifyingMCtx do
     let .goals subgoals ← i.specRule.apply i.goal | return none
-    -- The precondition VC is the bare `pre ⊑ specPre` premise among the subgoals; the post and
-    -- exception VCs are `∀`-quantified.
+    -- The precondition VC is the only bare `pre ⊑ specPre` entailment among the rule's subgoals;
+    -- the postcondition and exception-postcondition VCs are `∀`-quantified over the result value
+    -- and the state arguments.
     let some specPre ← subgoals.findSomeM? fun g => do
         let ty ← g.getType
         let_expr Lean.Order.PartialOrder.rel _ _ _ specPre := ty | return none
-        -- Resolve only an assigned head mvar so the procedure's head test (`isAppOf`) sees the real
-        -- operator; nested mvars are resolved by the procedure's own unification.
+        -- An assigned head metavariable would hide `specPre`'s operator from the procedure, which
+        -- dispatches on the head (e.g. flattening a `∗` chain); nested metavariables are resolved
+        -- by the procedure's own unification.
         return some (← instantiateMVarsIfMVarAppS specPre)
       | return none
     some <$> Meta.abstractMVars (← instantiateMVarsS specPre)
@@ -113,7 +111,7 @@ and `footprint`, then to the excess state arguments, entailed by `pre` in the go
 and `footprint` must be hash-consed (`shareCommon`); the result is. -/
 public def VCGen.FrameInferenceInfo.mkSplitVCS (i : FrameInferenceInfo) (frame footprint : Expr) :
     SymM Expr := do
-  let rhs ← mkAppNS (← mkAppNS (← i.op) #[frame, footprint]) i.excessArgs
+  let rhs ← mkAppNS (← mkAppNS (← i.mkOpApp) #[frame, footprint]) i.excessArgs
   let ty ← i.goal.getType
   mkAppNS (ty.stripArgsN 2) #[ty.appFn!.appArg!, rhs]
 
@@ -122,13 +120,13 @@ fresh subgoal for the built-in lattice (meet) decomposition to split. -/
 public def VCGen.FrameSplit.withDeferredSplitVC (i : FrameInferenceInfo) (frame : Expr) :
     SymM FrameSplit := do
   let residualPre ← i.mkResidualPre
-  let m ← mkFreshExprSyntheticOpaqueMVar (← i.mkSplitVCS frame residualPre)
+  let m ← mkFreshExprSyntheticOpaqueMVar (← i.mkSplitVCS frame (mkMVar residualPre))
   return { frame, residualPre, splitVCProof := m, subgoals := [m.mvarId!] }
 
 /-- A `FrameSplit` framing `frame`, discharging the split VC `pre ⊑ (op frame residualPre) s⃗` with
 `splitVCProof` and leaving its `subgoals`. -/
-public def VCGen.FrameSplit.withDischargedSplitVC (frame residualPre splitVCProof : Expr)
-    (subgoals : List MVarId := []) : FrameSplit :=
+public def VCGen.FrameSplit.withDischargedSplitVC (frame : Expr) (residualPre : MVarId)
+    (splitVCProof : Expr) (subgoals : List MVarId := []) : FrameSplit :=
   { frame, residualPre, splitVCProof, subgoals }
 
 /-- A frame backward rule together with the positions of its assignable subgoals in the applied

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -339,7 +339,7 @@ private def compileSpecRule (scope : VCGen.Scope) (goal : MVarId) (info : WPApp)
   let thm ← match result with
     | .ok thm => pure thm
     | .error thms => return (thms, none)
-  let rule? ←
+  let some rule ←
     try
       mkBackwardRuleFromSpecCached thm info |>.run
     catch ex =>
@@ -348,7 +348,7 @@ private def compileSpecRule (scope : VCGen.Scope) (goal : MVarId) (info : WPApp)
         target:{indentExpr (← goal.getType)}\n\
         Pred:{indentExpr info.Pred}\n\
         excessArgs: {info.excessArgs}"
-  let some rule := rule? | return (#[thm], none)
+    | return (#[thm], none)
   return (#[thm], some (scope, thm, rule))
 
 /-- Apply the backward `rule` of the selected `@[spec]` theorem `thm`, returning its subgoals.

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -463,17 +463,6 @@ private def applyFrameRule (goal : MVarId) (info : WPApp) (fp : FrameProc)
   goals[frule.splitVCIdx]!.assign split.splitVCProof
   return goals.toList ++ split.subgoals
 
-/-- The spec precondition instantiated at the call site: the right-hand side of the bare `pre ⊑ specPre`
-premise among a spec rule's subgoals. The post and exception VCs are `∀`-quantified, so the bare
-entailment is the precondition VC. -/
-private def specPreOf? (subgoals : List MVarId) : VCGenM (Option Expr) := do
-  for g in subgoals do
-    if let some (_, _, _, specPre) := (← g.getType).app4? ``Lean.Order.PartialOrder.rel then
-      -- Resolve only an assigned head mvar so the procedure's head test (`isAppOf`) sees the real
-      -- operator; nested mvars are resolved by the procedure's own unification.
-      return some (← instantiateMVarsIfMVarAppS specPre)
-  return none
-
 /-- Instantiate a `FrameSplit`'s data against the current metavariable context (and reshare). -/
 private def instantiateFrameSplit (split : FrameSplit) : VCGenM FrameSplit := do
   return { split with
@@ -492,7 +481,7 @@ Handle a spec-ready program `info.prog`: select its `@[spec]` theorem and either
   handed to the procedure: no split keeps the application; a split rolls it back and applies the
   frame rule instead, so the spec re-applies against the framed residual where its VCs are solvable.
 -/
-private def applyFrameOrSpec (scope : VCGen.Scope) (goal : MVarId) (pre : Expr) (info : WPApp) :
+private def applyFrameOrSpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
     VCGenM SolveResult := goal.withContext do
   let (scope, spec) ← findSpec scope info.prog info.M
   let thm ← match spec with
@@ -502,29 +491,17 @@ private def applyFrameOrSpec (scope : VCGen.Scope) (goal : MVarId) (pre : Expr) 
     return ← applySpec scope goal info thm
   let procs := (← read).frameProcs.byProg
   let fp := info.M.getAppFn.constName?.bind (procs[·]?) |>.getD meetFrameProc
-  let resourceTy ← fp.resourceTy info
-  let op ← fp.mkOpAppM info
+  let resourceTy ← fp.mkResourceTy info
+  let providedFrame? ← matchFrame? resourceTy info
+  -- The spec's backward rule, so the procedure can speculatively apply it (construction is cached;
+  -- the direct application below reuses it). A spec whose rule cannot be built has no frame to
+  -- infer; `applySpec` reports it.
+  let specRule? ← try mkBackwardRuleFromSpecCached thm info |>.run catch _ => pure none
+  let some specRule := specRule? | return ← applySpec scope goal info thm
   -- The solver-owned metavariable for the residual precondition: the procedure builds the split VC
   -- proof against it, and `applyFrameRule` fills it once the frame rule fixes the footprint.
   let residualPre ← liftMetaM <| mkFreshExprSyntheticOpaqueMVar info.Pred
-  -- The goal's entailment relation `PartialOrder.rel α inst`, its two operands stripped.
-  let le := (← goal.getType).stripArgsN 2
-  -- The frame hint: `explicit` from a `frames` clause, otherwise `implicit`, reading the spec
-  -- precondition off a speculative spec application. That application is rolled back so the procedure
-  -- runs against the original goal; its `specPre` metavariables are frozen into a telescope and
-  -- reopened fresh in the restored context so they outlive the rollback.
-  let hint : FrameInferenceHint ← match ← matchFrame? resourceTy info with
-    | some frame => pure (.explicit frame)
-    | none =>
-      let saved ← Meta.saveState
-      let .goals _ subgoals ← applySpec scope goal info thm
-        | throwError "vcgen: speculative spec application for{indentExpr info.prog} did not produce goals"
-      let some specPre ← specPreOf? subgoals | return .goals scope subgoals
-      let specPreAbs ← Meta.abstractMVars (← instantiateMVarsS specPre)
-      saved.restore
-      let (_, _, specPre) ← Meta.openAbstractMVarsResult specPreAbs
-      pure (.implicit (← shareCommon specPre))
-  match ← fp.proc { info with op, pre, le, hint, spec? := thm.global?, residualPre } with
+  match ← fp.proc { info with goal, providedFrame?, spec? := thm.global?, specRule, residualPre } with
   | none => applySpec scope goal info thm
   | some split =>
     trace[Elab.Tactic.Do.vcgen] "`@[frameproc]` matched {info.prog}; frame:{indentExpr split.frame}"
@@ -613,7 +590,7 @@ public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := g
     let f := info.prog.getAppFn
     if f.isConst || f.isFVar then
       VCGen.burnOne
-      return ← applyFrameOrSpec scope goal pre info
+      return ← applyFrameOrSpec scope goal info
     throwError "Failed to decompose weakest precondition for {info.prog}. This should not happen."
 
   return .stop (.noProgress pre rhs)

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -345,21 +345,24 @@ private def specPatternMatches (thm : SpecTheorem) (prog : Expr) : SymM Bool :=
   withNewMCtxDepth do
     return (← thm.pattern.match? prog).isSome
 
-/-- Apply the cached backward rule of the selected `@[spec]` theorem `thm`, returning its subgoals, or
-a stop result when no rule matches the goal's monad. Reached from `applyFrameOrSpec`. -/
-private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) (thm : SpecTheorem) :
-    VCGenM SolveResult := do
+/-- The backward rule of the `@[spec]` theorem `thm` for the goal (construction is cached), or
+`none` when no rule matches the goal's monad. -/
+private def compileSpecRule (goal : MVarId) (info : WPApp) (thm : SpecTheorem) :
+    VCGenM (Option BackwardRule) := do
+  try
+    mkBackwardRuleFromSpecCached thm info |>.run
+  catch ex =>
+    throwError "Failed to construct rule {thm.proof} for {indentExpr info.prog}\n\
+      error: {ex.toMessageData}\n\
+      target:{indentExpr (← goal.getType)}\n\
+      Pred:{indentExpr info.Pred}\n\
+      excessArgs: {info.excessArgs}"
+
+/-- Apply the backward `rule` of the selected `@[spec]` theorem `thm`, returning its subgoals.
+Reached from `applyFrameOrSpec`. -/
+private def applySpecRule (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) (thm : SpecTheorem)
+    (rule : BackwardRule) : VCGenM SolveResult := do
   trace[Elab.Tactic.Do.vcgen] "Applying spec {thm.proof} for {info.prog}. Excess args: {info.excessArgs}"
-  let some rule ←
-    try
-      mkBackwardRuleFromSpecCached thm info |>.run
-    catch ex =>
-      throwError "Failed to construct rule {thm.proof} for {indentExpr info.prog}\n\
-        error: {ex.toMessageData}\n\
-        target:{indentExpr (← goal.getType)}\n\
-        Pred:{indentExpr info.Pred}\n\
-        excessArgs: {info.excessArgs}"
-    | return ← stopOrErrorOnMissingSpec info.prog info.M #[thm]
   let .goals goals ← rule.applyChecked goal m!"spec rule for{indentExpr info.prog}"
     | do
       -- The discrimination tree over-approximates, so a selected spec may not unify with the program
@@ -487,22 +490,19 @@ private def applyFrameOrSpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp
   let thm ← match spec with
     | .ok thm => pure thm
     | .error res => return res
+  let some specRule ← compileSpecRule goal info thm
+    | return ← stopOrErrorOnMissingSpec info.prog info.M #[thm]
   if thm.conjunctivePre || isFramedPost info.post then
-    return ← applySpec scope goal info thm
+    return ← applySpecRule scope goal info thm specRule
   let procs := (← read).frameProcs.byProg
   let fp := info.M.getAppFn.constName?.bind (procs[·]?) |>.getD meetFrameProc
   let resourceTy ← fp.mkResourceTy info
   let providedFrame? ← matchFrame? resourceTy info
-  -- The spec's backward rule, so the procedure can speculatively apply it (construction is cached;
-  -- the direct application below reuses it). A spec whose rule cannot be built has no frame to
-  -- infer; `applySpec` reports it.
-  let specRule? ← try mkBackwardRuleFromSpecCached thm info |>.run catch _ => pure none
-  let some specRule := specRule? | return ← applySpec scope goal info thm
   -- The solver-owned metavariable for the residual precondition: the procedure builds the split VC
   -- proof against it, and `applyFrameRule` fills it once the frame rule fixes the footprint.
   let residualPre ← liftMetaM <| mkFreshExprSyntheticOpaqueMVar info.Pred
   match ← fp.proc { info with goal, providedFrame?, spec? := thm.global?, specRule, residualPre } with
-  | none => applySpec scope goal info thm
+  | none => applySpecRule scope goal info thm specRule
   | some split =>
     trace[Elab.Tactic.Do.vcgen] "`@[frameproc]` matched {info.prog}; frame:{indentExpr split.frame}"
     return .goals scope (← applyFrameRule goal info fp residualPre (← instantiateFrameSplit split))
@@ -556,7 +556,7 @@ public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := g
   if let some (scope, gs) ← normalizePre? scope goal α pre target then return .goals scope gs
 
   -- Collect new local specs before any strategy that may emit multiple subgoals
-  -- (`wpMatch?`, `splitLatticeOp?`) or apply a registered spec (`applySpec`).
+  -- (`wpMatch?`, `splitLatticeOp?`) or apply a registered spec (`applySpecRule`).
   let scope ← scope.collectLocalSpecs goal
 
   -- Phase 3: shape the `rhs` (reduce an EPost projection, decompose a lattice connective or a

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -456,7 +456,7 @@ private def applyFrameRule (goal : MVarId) (info : WPApp) (fp : FrameProc)
   let vcType ← goals[frule.splitVCIdx]!.getType
   let_expr Lean.Order.PartialOrder.rel _ _ _ rhs := vcType
     | throwError "frame: split VC is not an entailment{indentExpr vcType}"
-  split.residualPre.mvarId!.assign (rhs.stripArgsN info.excessArgs.size).appArg!
+  split.residualPre.assign (rhs.stripArgsN info.excessArgs.size).appArg!
   goals[frule.splitVCIdx]!.assign split.splitVCProof
   return goals.toList ++ split.subgoals
 
@@ -483,7 +483,8 @@ private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
   let fp := info.M.getAppFn.constName?.bind (procs[·]?) |>.getD meetFrameProc
   let providedFrame? ← matchFrame? fp info
   let inferInfo : FrameInferenceInfo :=
-    { info with goal, providedFrame?, spec? := thm.global?, specRule, mkOp := fp.mkOpAppM }
+    { info with goal, providedFrame?, spec? := thm.global?, specRule,
+                mkOpApp := do shareCommon (← fp.mkOpAppM info) }
   match ← fp.proc inferInfo with
   | none => applySpecRule scope goal info thm specRule
   | some split =>

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -349,7 +349,7 @@ private def compileSpecRule (scope : VCGen.Scope) (goal : MVarId) (info : WPApp)
         Pred:{indentExpr info.Pred}\n\
         excessArgs: {info.excessArgs}"
     | return (#[thm], none)
-  return (#[thm], some (scope, thm, rule))
+  return (#[], some (scope, thm, rule))
 
 /-- Apply the backward `rule` of the selected `@[spec]` theorem `thm`, returning its subgoals.
 Reached from `applySpec`. -/

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -338,14 +338,14 @@ Hands `findSpecs` the sole reference to the spec database so its in-place patter
 does not copy the discrimination tree, then threads the updated database back into the returned
 scope. -/
 private def compileSpecRule (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
-    VCGenM (VCGen.Scope × Except SolveResult (SpecTheorem × BackwardRule)) := do
+    VCGenM (Except SolveResult (VCGen.Scope × SpecTheorem × BackwardRule)) := do
   let specs := scope.specs
   let scope := { scope with specs := default }
   let (result, specs) ← SpecTheorems.findSpecs specs info.prog
   let scope := { scope with specs }
   let thm ← match result with
     | .ok thm => pure thm
-    | .error thms => return (scope, .error (← stopOrErrorOnMissingSpec info.prog info.M thms))
+    | .error thms => return .error (← stopOrErrorOnMissingSpec info.prog info.M thms)
   let rule? ←
     try
       mkBackwardRuleFromSpecCached thm info |>.run
@@ -356,8 +356,8 @@ private def compileSpecRule (scope : VCGen.Scope) (goal : MVarId) (info : WPApp)
         Pred:{indentExpr info.Pred}\n\
         excessArgs: {info.excessArgs}"
   let some rule := rule?
-    | return (scope, .error (← stopOrErrorOnMissingSpec info.prog info.M #[thm]))
-  return (scope, .ok (thm, rule))
+    | return .error (← stopOrErrorOnMissingSpec info.prog info.M #[thm])
+  return .ok (scope, thm, rule)
 
 /-- Apply the backward `rule` of the selected `@[spec]` theorem `thm`, returning its subgoals.
 Reached from `applySpec`. -/
@@ -487,8 +487,7 @@ Handle a spec-ready program `info.prog`: select its `@[spec]` theorem and either
 -/
 private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
     VCGenM SolveResult := goal.withContext do
-  let (scope, spec) ← compileSpecRule scope goal info
-  let (thm, specRule) ← match spec with
+  let (scope, thm, specRule) ← match ← compileSpecRule scope goal info with
     | .ok res => pure res
     | .error res => return res
   if thm.conjunctivePre || isFramedPost info.post then

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -326,19 +326,19 @@ private def stopOrErrorOnMissingSpec (prog monad : Expr) (thms : Array SpecTheor
       Candidates were {thms.map (·.proof)}."
 
 /-- Select the highest-priority `@[spec]` theorem matching `info.prog` and compile its backward rule
-(construction is cached), or a stop result when no spec matches or no rule fits the goal's monad.
-Hands `findSpecs` the sole reference to the spec database so its in-place pattern internalization
-does not copy the discrimination tree, then threads the updated database back into the returned
-scope. -/
+(construction is cached); `none` when no spec matches or no rule fits the goal's monad, with the
+candidate theorems alongside for error reporting. Hands `findSpecs` the sole reference to the spec
+database so its in-place pattern internalization does not copy the discrimination tree, then threads
+the updated database back into the returned scope. -/
 private def compileSpecRule (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
-    VCGenM (Except SolveResult (VCGen.Scope × SpecTheorem × BackwardRule)) := do
+    VCGenM (Array SpecTheorem × Option (VCGen.Scope × SpecTheorem × BackwardRule)) := do
   let specs := scope.specs
   let scope := { scope with specs := default }
   let (result, specs) ← SpecTheorems.findSpecs specs info.prog
   let scope := { scope with specs }
   let thm ← match result with
     | .ok thm => pure thm
-    | .error thms => return .error (← stopOrErrorOnMissingSpec info.prog info.M thms)
+    | .error thms => return (thms, none)
   let rule? ←
     try
       mkBackwardRuleFromSpecCached thm info |>.run
@@ -348,9 +348,8 @@ private def compileSpecRule (scope : VCGen.Scope) (goal : MVarId) (info : WPApp)
         target:{indentExpr (← goal.getType)}\n\
         Pred:{indentExpr info.Pred}\n\
         excessArgs: {info.excessArgs}"
-  let some rule := rule?
-    | return .error (← stopOrErrorOnMissingSpec info.prog info.M #[thm])
-  return .ok (scope, thm, rule)
+  let some rule := rule? | return (#[thm], none)
+  return (#[thm], some (scope, thm, rule))
 
 /-- Apply the backward `rule` of the selected `@[spec]` theorem `thm`, returning its subgoals.
 Reached from `applySpec`. -/
@@ -474,9 +473,9 @@ Handle a spec-ready program `info.prog`: select its `@[spec]` theorem and either
 -/
 private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
     VCGenM SolveResult := goal.withContext do
-  let (scope, thm, specRule) ← match ← compileSpecRule scope goal info with
-    | .ok res => pure res
-    | .error res => return res
+  let (thms, compiled?) ← compileSpecRule scope goal info
+  let some (scope, thm, specRule) := compiled?
+    | return ← stopOrErrorOnMissingSpec info.prog info.M thms
   if thm.conjunctivePre || isFramedPost info.post then
     return ← applySpecRule scope goal info thm specRule
   let procs := (← read).frameProcs.byProg

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -326,19 +326,19 @@ private def stopOrErrorOnMissingSpec (prog monad : Expr) (thms : Array SpecTheor
       Candidates were {thms.map (·.proof)}."
 
 /-- Select the highest-priority `@[spec]` theorem matching `info.prog` and compile its backward rule
-(construction is cached); `none` when no spec matches or no rule fits the goal's monad, with the
-candidate theorems alongside for error reporting. Hands `findSpecs` the sole reference to the spec
-database so its in-place pattern internalization does not copy the discrimination tree, then threads
-the updated database back into the returned scope. -/
+(construction is cached), or a stop result when no spec matches or no rule fits the goal's monad.
+Hands `findSpecs` the sole reference to the spec database so its in-place pattern internalization
+does not copy the discrimination tree, then threads the updated database back into the returned
+scope. -/
 private def compileSpecRule (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
-    VCGenM (Array SpecTheorem × Option (VCGen.Scope × SpecTheorem × BackwardRule)) := do
+    VCGenM (Except SolveResult (VCGen.Scope × SpecTheorem × BackwardRule)) := do
   let specs := scope.specs
   let scope := { scope with specs := default }
   let (result, specs) ← SpecTheorems.findSpecs specs info.prog
   let scope := { scope with specs }
   let thm ← match result with
     | .ok thm => pure thm
-    | .error thms => return (thms, none)
+    | .error thms => return .error (← stopOrErrorOnMissingSpec info.prog info.M thms)
   let some rule ←
     try
       mkBackwardRuleFromSpecCached thm info |>.run
@@ -348,8 +348,8 @@ private def compileSpecRule (scope : VCGen.Scope) (goal : MVarId) (info : WPApp)
         target:{indentExpr (← goal.getType)}\n\
         Pred:{indentExpr info.Pred}\n\
         excessArgs: {info.excessArgs}"
-    | return (#[thm], none)
-  return (#[], some (scope, thm, rule))
+    | return .error (← stopOrErrorOnMissingSpec info.prog info.M #[thm])
+  return .ok (scope, thm, rule)
 
 /-- Apply the backward `rule` of the selected `@[spec]` theorem `thm`, returning its subgoals.
 Reached from `applySpec`. -/
@@ -473,9 +473,9 @@ Handle a spec-ready program `info.prog`: select its `@[spec]` theorem and either
 -/
 private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
     VCGenM SolveResult := goal.withContext do
-  let (thms, compiled?) ← compileSpecRule scope goal info
-  let some (scope, thm, specRule) := compiled?
-    | return ← stopOrErrorOnMissingSpec info.prog info.M thms
+  let (scope, thm, specRule) ← match ← compileSpecRule scope goal info with
+    | .ok res => pure res
+    | .error res => return res
   if thm.conjunctivePre || isFramedPost info.post then
     return ← applySpecRule scope goal info thm specRule
   let procs := (← read).frameProcs.byProg

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -325,13 +325,6 @@ private def stopOrErrorOnMissingSpec (prog monad : Expr) (thms : Array SpecTheor
     throwError "No spec matching the monad {monad} found for program {prog}. \
       Candidates were {thms.map (·.proof)}."
 
-/-- True iff the spec's pattern unifies with the program, mirroring the match performed in
-`findSpecs`. Distinguishes a spurious discrimination-tree candidate, whose pattern does not unify,
-from a spec whose pattern matches yet whose backward rule fails to apply. -/
-private def specPatternMatches (thm : SpecTheorem) (prog : Expr) : SymM Bool :=
-  withNewMCtxDepth do
-    return (← thm.pattern.match? prog).isSome
-
 /-- Select the highest-priority `@[spec]` theorem matching `info.prog` and compile its backward rule
 (construction is cached), or a stop result when no spec matches or no rule fits the goal's monad.
 Hands `findSpecs` the sole reference to the spec database so its in-place pattern internalization
@@ -369,7 +362,7 @@ private def applySpecRule (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) (
       -- The discrimination tree over-approximates, so a selected spec may not unify with the program
       -- (e.g. an offset-keyed equation against a variable discriminant). That is no matching spec, not
       -- a rule failure. A spec whose pattern does match yet whose rule fails to apply is a genuine bug.
-      unless ← specPatternMatches thm info.prog do
+      unless ← thm.patternMatches info.prog do
         return ← stopOrErrorOnMissingSpec info.prog info.M #[thm]
       let ruleType ← Meta.inferType rule.expr
       throwError "Failed to apply rule {thm.proof} for {indentExpr info.prog}\n\
@@ -410,10 +403,9 @@ records the pattern-variable assignments and the user sees them in the side goal
 private def elabFrame (resourceTy : Expr) (entry : FrameEntry) (res : Sym.MatchUnifyResult) :
     VCGenM Expr := do
   let mut decls : Array (Name × Expr × Expr) := #[]
-  for h : i in [0:entry.varNames.size] do
-    if let some nm := entry.varNames[i] then
-      if h2 : i < res.args.size then
-        decls := decls.push (nm, ← Meta.inferType res.args[i]!, res.args[i]!)
+  for nm? in entry.varNames, arg in res.args do
+    if let some nm := nm? then
+      decls := decls.push (nm, ← Meta.inferType arg, arg)
   Meta.withDefault <| withLetDeclsDND decls fun fvs => do
     let frameExpr ← Lean.Elab.Term.TermElabM.run' do
       let e ← Lean.Elab.Term.elabTermEnsuringType entry.frameStx (some resourceTy)
@@ -422,9 +414,11 @@ private def elabFrame (resourceTy : Expr) (entry : FrameEntry) (res : Sym.MatchU
     instantiateMVarsS frameExpr
 
 /-- Find an unretired `frames` alternative matching the program (earliest source order wins),
-elaborate its frame at the resource type `resourceTy`, and retire it so it applies at most once. -/
-public def matchFrame? (resourceTy : Expr) (info : WPApp) : VCGenM (Option Expr) := do
+elaborate its frame at the resource type of `fp`'s operator, and retire it so it applies at most
+once. -/
+public def matchFrame? (fp : FrameProc) (info : WPApp) : VCGenM (Option Expr) := do
   let db := (← get).frameDB
+  if db.entries.isEmpty then return none
   let mut best : Option (FrameEntry × Sym.MatchUnifyResult) := none
   for srcIdx in Sym.getMatch db.tree info.prog do
     let entry := db.entries[srcIdx]!
@@ -437,7 +431,7 @@ public def matchFrame? (resourceTy : Expr) (info : WPApp) : VCGenM (Option Expr)
   modify fun s =>
     let entries := s.frameDB.entries.set! entry.srcIdx { entry with retired := true }
     { s with frameDB := { s.frameDB with entries } }
-  let frame ← elabFrame resourceTy entry res
+  let frame ← elabFrame (← fp.mkResourceTy info) entry res
   trace[Elab.Tactic.Do.vcgen] "`frames` matched {info.prog}; frame:{indentExpr frame}"
   return some frame
 
@@ -450,11 +444,10 @@ private def isFramedPost (post : Expr) : Bool :=
 
 /-- Apply the frame rule for `fp`'s operator and the inferred `FrameSplit`. Assign the frame slot,
 then read the weakest footprint `W` off the now-concrete split VC `pre ⊑ (op frame W) s⃗` and fill the
-solver-owned placeholder `residualPre` with it, so the procedure's proof (built against the
-placeholder) discharges the split VC. The proof's `subgoals` remain; the assigned slot goals are
-skipped by the worklist. -/
+split's `residualPre` with it, so the procedure's proof (built against that metavariable) discharges
+the split VC. The proof's `subgoals` remain; the assigned slot goals are skipped by the worklist. -/
 private def applyFrameRule (goal : MVarId) (info : WPApp) (fp : FrameProc)
-    (residualPre : Expr) (split : FrameSplit) : VCGenM (List MVarId) := do
+    (split : FrameSplit) : VCGenM (List MVarId) := do
   let frule ← mkFrameBackwardRuleCached fp info
   let .goals goals ← frule.rule.applyChecked goal m!"frame rule for{indentExpr info.prog}"
     | throwError "frame: failed to apply rule for{indentExpr info.prog}"
@@ -463,15 +456,9 @@ private def applyFrameRule (goal : MVarId) (info : WPApp) (fp : FrameProc)
   let vcType ← goals[frule.splitVCIdx]!.getType
   let_expr Lean.Order.PartialOrder.rel _ _ _ rhs := vcType
     | throwError "frame: split VC is not an entailment{indentExpr vcType}"
-  residualPre.mvarId!.assign (rhs.stripArgsN info.excessArgs.size).appArg!
+  split.residualPre.mvarId!.assign (rhs.stripArgsN info.excessArgs.size).appArg!
   goals[frule.splitVCIdx]!.assign split.splitVCProof
   return goals.toList ++ split.subgoals
-
-/-- Instantiate a `FrameSplit`'s data against the current metavariable context (and reshare). -/
-private def instantiateFrameSplit (split : FrameSplit) : VCGenM FrameSplit := do
-  return { split with
-           frame := ← instantiateMVarsS split.frame
-           splitVCProof := ← instantiateMVarsS split.splitVCProof }
 
 /--
 Handle a spec-ready program `info.prog`: select its `@[spec]` theorem and either frame or apply it.
@@ -494,16 +481,14 @@ private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
     return ← applySpecRule scope goal info thm specRule
   let procs := (← read).frameProcs.byProg
   let fp := info.M.getAppFn.constName?.bind (procs[·]?) |>.getD meetFrameProc
-  let resourceTy ← fp.mkResourceTy info
-  let providedFrame? ← matchFrame? resourceTy info
-  -- The solver-owned metavariable for the residual precondition: the procedure builds the split VC
-  -- proof against it, and `applyFrameRule` fills it once the frame rule fixes the footprint.
-  let residualPre ← liftMetaM <| mkFreshExprSyntheticOpaqueMVar info.Pred
-  match ← fp.proc { info with goal, providedFrame?, spec? := thm.global?, specRule, residualPre } with
+  let providedFrame? ← matchFrame? fp info
+  let inferInfo : FrameInferenceInfo :=
+    { info with goal, providedFrame?, spec? := thm.global?, specRule, mkOp := fp.mkOpAppM }
+  match ← fp.proc inferInfo with
   | none => applySpecRule scope goal info thm specRule
   | some split =>
     trace[Elab.Tactic.Do.vcgen] "`@[frameproc]` matched {info.prog}; frame:{indentExpr split.frame}"
-    return .goals scope (← applyFrameRule goal info fp residualPre (← instantiateFrameSplit split))
+    return .goals scope (← applyFrameRule goal info fp (← split.instantiateMVarsS))
 
 /--
 The main VC generation step. Operates on a plain `MVarId` with no knowledge of grind.

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -359,7 +359,7 @@ private def compileSpecRule (goal : MVarId) (info : WPApp) (thm : SpecTheorem) :
       excessArgs: {info.excessArgs}"
 
 /-- Apply the backward `rule` of the selected `@[spec]` theorem `thm`, returning its subgoals.
-Reached from `applyFrameOrSpec`. -/
+Reached from `applySpec`. -/
 private def applySpecRule (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) (thm : SpecTheorem)
     (rule : BackwardRule) : VCGenM SolveResult := do
   trace[Elab.Tactic.Do.vcgen] "Applying spec {thm.proof} for {info.prog}. Excess args: {info.excessArgs}"
@@ -480,11 +480,11 @@ Handle a spec-ready program `info.prog`: select its `@[spec]` theorem and either
   program type, or the default meet frame). The choice is per node, since sub-programs may reach a
   different monad (e.g. a `monadLift`ed base call).
 - An explicit `frames` clause elaborates a frame and passes it to the procedure.
-- Failing that, the spec is applied speculatively and its precondition VC's right-hand side is
-  handed to the procedure: no split keeps the application; a split rolls it back and applies the
-  frame rule instead, so the spec re-applies against the framed residual where its VCs are solvable.
+- Failing that, the procedure may read the spec's precondition through
+  `FrameInferenceInfo.specPre?`: no split applies the spec directly; a split applies the frame rule
+  instead, so the spec re-applies against the framed residual where its VCs are solvable.
 -/
-private def applyFrameOrSpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
+private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
     VCGenM SolveResult := goal.withContext do
   let (scope, spec) ← findSpec scope info.prog info.M
   let thm ← match spec with
@@ -590,7 +590,7 @@ public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := g
     let f := info.prog.getAppFn
     if f.isConst || f.isFVar then
       VCGen.burnOne
-      return ← applyFrameOrSpec scope goal info
+      return ← applySpec scope goal info
     throwError "Failed to decompose weakest precondition for {info.prog}. This should not happen."
 
   return .stop (.noProgress pre rhs)

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -325,19 +325,6 @@ private def stopOrErrorOnMissingSpec (prog monad : Expr) (thms : Array SpecTheor
     throwError "No spec matching the monad {monad} found for program {prog}. \
       Candidates were {thms.map (·.proof)}."
 
-/-- Select the highest-priority `@[spec]` theorem matching `prog`, or a stop result when none matches.
-Hands `findSpecs` the sole reference to the spec database so its in-place pattern internalization does
-not copy the discrimination tree, then threads the updated database back into the returned scope. -/
-private def findSpec (scope : VCGen.Scope) (prog monad : Expr) :
-    VCGenM (VCGen.Scope × Except SolveResult SpecTheorem) := do
-  let specs := scope.specs
-  let scope := { scope with specs := default }
-  let (result, specs) ← SpecTheorems.findSpecs specs prog
-  let scope := { scope with specs }
-  match result with
-  | .ok thm => return (scope, .ok thm)
-  | .error thms => return (scope, .error (← stopOrErrorOnMissingSpec prog monad thms))
-
 /-- True iff the spec's pattern unifies with the program, mirroring the match performed in
 `findSpecs`. Distinguishes a spurious discrimination-tree candidate, whose pattern does not unify,
 from a spec whose pattern matches yet whose backward rule fails to apply. -/
@@ -345,18 +332,32 @@ private def specPatternMatches (thm : SpecTheorem) (prog : Expr) : SymM Bool :=
   withNewMCtxDepth do
     return (← thm.pattern.match? prog).isSome
 
-/-- The backward rule of the `@[spec]` theorem `thm` for the goal (construction is cached), or
-`none` when no rule matches the goal's monad. -/
-private def compileSpecRule (goal : MVarId) (info : WPApp) (thm : SpecTheorem) :
-    VCGenM (Option BackwardRule) := do
-  try
-    mkBackwardRuleFromSpecCached thm info |>.run
-  catch ex =>
-    throwError "Failed to construct rule {thm.proof} for {indentExpr info.prog}\n\
-      error: {ex.toMessageData}\n\
-      target:{indentExpr (← goal.getType)}\n\
-      Pred:{indentExpr info.Pred}\n\
-      excessArgs: {info.excessArgs}"
+/-- Select the highest-priority `@[spec]` theorem matching `info.prog` and compile its backward rule
+(construction is cached), or a stop result when no spec matches or no rule fits the goal's monad.
+Hands `findSpecs` the sole reference to the spec database so its in-place pattern internalization
+does not copy the discrimination tree, then threads the updated database back into the returned
+scope. -/
+private def compileSpecRule (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
+    VCGenM (VCGen.Scope × Except SolveResult (SpecTheorem × BackwardRule)) := do
+  let specs := scope.specs
+  let scope := { scope with specs := default }
+  let (result, specs) ← SpecTheorems.findSpecs specs info.prog
+  let scope := { scope with specs }
+  let thm ← match result with
+    | .ok thm => pure thm
+    | .error thms => return (scope, .error (← stopOrErrorOnMissingSpec info.prog info.M thms))
+  let rule? ←
+    try
+      mkBackwardRuleFromSpecCached thm info |>.run
+    catch ex =>
+      throwError "Failed to construct rule {thm.proof} for {indentExpr info.prog}\n\
+        error: {ex.toMessageData}\n\
+        target:{indentExpr (← goal.getType)}\n\
+        Pred:{indentExpr info.Pred}\n\
+        excessArgs: {info.excessArgs}"
+  let some rule := rule?
+    | return (scope, .error (← stopOrErrorOnMissingSpec info.prog info.M #[thm]))
+  return (scope, .ok (thm, rule))
 
 /-- Apply the backward `rule` of the selected `@[spec]` theorem `thm`, returning its subgoals.
 Reached from `applySpec`. -/
@@ -486,12 +487,10 @@ Handle a spec-ready program `info.prog`: select its `@[spec]` theorem and either
 -/
 private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
     VCGenM SolveResult := goal.withContext do
-  let (scope, spec) ← findSpec scope info.prog info.M
-  let thm ← match spec with
-    | .ok thm => pure thm
+  let (scope, spec) ← compileSpecRule scope goal info
+  let (thm, specRule) ← match spec with
+    | .ok res => pure res
     | .error res => return res
-  let some specRule ← compileSpecRule goal info thm
-    | return ← stopOrErrorOnMissingSpec info.prog info.M #[thm]
   if thm.conjunctivePre || isFramedPost info.post then
     return ← applySpecRule scope goal info thm specRule
   let procs := (← read).frameProcs.byProg

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
@@ -76,6 +76,13 @@ public def SpecAttr.SpecTheorem.instantiate (specThm : SpecTheorem) :
 public def SpecAttr.SpecTheorem.global? (specThm : SpecTheorem) : Option Name :=
   match specThm.proof with | .global decl => some decl | _ => none
 
+/-- True iff the spec's pattern unifies with the program, mirroring the match performed in
+`findSpecs`. Distinguishes a spurious discrimination-tree candidate, whose pattern does not unify,
+from a spec whose pattern matches yet whose backward rule fails to apply. -/
+public def SpecAttr.SpecTheorem.patternMatches (specThm : SpecTheorem) (prog : Expr) : SymM Bool :=
+  withNewMCtxDepth do
+    return (← specThm.pattern.match? prog).isSome
+
 namespace VCGen
 
 /--

--- a/tests/elab/vcgenDyLean.lean
+++ b/tests/elab/vcgenDyLean.lean
@@ -390,8 +390,7 @@ public meta def dyLeanFrameProc : FrameInferenceProc := fun i => do
           let last :: initRev := (preds.map (fun p => (mkApp p tr).headBeta)).reverse | unreachable!
           Meta.mkLambdaFVars #[tr] (initRev.foldl (fun acc x => mkApp (mkApp (mkConst ``And) x) acc) last)
         pure (← shareCommon (mkApp a.appFn! combined))
-  let op ← shareCommon (← Lean.Meta.mkAppOptM ``Lean.Order.meet #[i.Pred, none])
-  return some (← FrameSplit.withDeferredSplitVC i op frame)
+  return some (← FrameSplit.withDeferredSplitVC i frame)
 
 @[frameproc] public meta def dyLeanFP : FrameProc where
   prog := ``Traceful

--- a/tests/elab/vcgenDyLean.lean
+++ b/tests/elab/vcgenDyLean.lean
@@ -378,9 +378,9 @@ public meta partial def collectAlways (e : Expr) : Array Expr :=
 single `Always'` over their conjunction, `Always' (fun tr => p₁ tr ∧ … ∧ pₙ tr)`. -/
 public meta def dyLeanFrameProc : FrameInferenceProc := fun i => do
   let frame ← do
-    match i.hint with
-    | .explicit frame => pure frame
-    | .implicit _ => match (collectAlways i.pre).toList with
+    match i.providedFrame? with
+    | some frame => pure frame
+    | none => match (collectAlways (← i.pre)).toList with
       | [] => return none
       | [single] => pure single
       | a :: rest =>
@@ -390,12 +390,13 @@ public meta def dyLeanFrameProc : FrameInferenceProc := fun i => do
           let last :: initRev := (preds.map (fun p => (mkApp p tr).headBeta)).reverse | unreachable!
           Meta.mkLambdaFVars #[tr] (initRev.foldl (fun acc x => mkApp (mkApp (mkConst ``And) x) acc) last)
         pure (← shareCommon (mkApp a.appFn! combined))
-  return some (← FrameSplit.withDeferredSplitVC i frame)
+  let op ← shareCommon (← Lean.Meta.mkAppOptM ``Lean.Order.meet #[i.Pred, none])
+  return some (← FrameSplit.withDeferredSplitVC i op frame)
 
 @[frameproc] public meta def dyLeanFP : FrameProc where
   prog := ``Traceful
   mkOpAppM := fun info => Meta.mkAppOptM ``Lean.Order.meet #[info.Pred, none]
-  resourceTy := fun info => pure info.Pred
+  mkResourceTy := fun info => pure info.Pred
   opHead := ``Lean.Order.meet
   proc := dyLeanFrameProc
 end DyLeanFrameProc

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -534,20 +534,20 @@ def proveSepConjLe (pre rhs : Expr) : MetaM (Option Expr) := do
 is `pre ⊑ frame ∗ footprint` (proved by AC-rearrangement of `∗`) composed by right-monotonicity with
 the emitted subgoal `footprint ⊑ residualPre`. -/
 def mkSepFrameSplit (i : FrameInferenceInfo) (frame footprint : Expr) : SymM FrameSplit := do
-  let op ← mkConstS ``sepConj
-  -- `.appArg!` reads the `frame ∗ ·` right-hand side off the split VC `mkSplitVC` builds.
-  let sepFF := (← i.mkSplitVCS op frame footprint).appArg!
+  -- `.appArg!` reads the `frame ∗ ·` right-hand side off the split VC `mkSplitVCS` builds.
+  let sepFF := (← i.mkSplitVCS frame footprint).appArg!
   match ← proveSepConjLe (← i.pre) sepFF with
-  | none => FrameSplit.withDeferredSplitVC i op frame
+  | none => FrameSplit.withDeferredSplitVC i frame
   | some hcl =>
     let le ← i.le
-    let sepFR := (← i.mkSplitVCS op frame i.residualPre).appArg!
-    let sub ← mkFreshExprSyntheticOpaqueMVar (← mkAppNS le #[footprint, i.residualPre])
-    let mono ← mkAppNS (← mkConstS ``sepConj_mono_right) #[frame, footprint, i.residualPre, sub]
+    let residualPre ← i.mkResidualPre
+    let sepFR := (← i.mkSplitVCS frame residualPre).appArg!
+    let sub ← mkFreshExprSyntheticOpaqueMVar (← mkAppNS le #[footprint, residualPre])
+    let mono ← mkAppNS (← mkConstS ``sepConj_mono_right) #[frame, footprint, residualPre, sub]
     let args := le.getAppArgs
     let proof ← mkAppNS (← mkConstS ``PartialOrder.rel_trans le.getAppFn.constLevels!)
       #[args[0]!, args[1]!, ← i.pre, sepFF, sepFR, hcl, mono]
-    return FrameSplit.withDischargedSplitVC frame proof [sub.mvarId!]
+    return FrameSplit.withDischargedSplitVC frame residualPre proof [sub.mvarId!]
 
 /-- Automatic frame inference by domain difference: the spec's precondition's atoms (its footprint)
 are cancelled from the goal precondition's; the leftover atoms are the frame. A pinned `frames`
@@ -560,7 +560,7 @@ def sepConjFrameProc : FrameInferenceProc := fun i => do
   match i.providedFrame? with
   | some frame =>
     match ← matchSepAtoms (← i.pre) frame with
-    | none => return some (← FrameSplit.withDeferredSplitVC i (← mkConstS ``sepConj) frame)
+    | none => return some (← FrameSplit.withDeferredSplitVC i frame)
     | some (rest, _) => return some (← mkSepFrameSplit i frame (← sepConjOfAtoms rest))
   | none =>
     let some specPre ← i.specPre? | return none

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -541,9 +541,10 @@ def mkSepFrameSplit (i : FrameInferenceInfo) (frame footprint : Expr) : SymM Fra
   | some hcl =>
     let le ← i.le
     let residualPre ← i.mkResidualPre
-    let sepFR := (← i.mkSplitVCS frame residualPre).appArg!
-    let sub ← mkFreshExprSyntheticOpaqueMVar (← mkAppNS le #[footprint, residualPre])
-    let mono ← mkAppNS (← mkConstS ``sepConj_mono_right) #[frame, footprint, residualPre, sub]
+    let residualPreE := mkMVar residualPre
+    let sepFR := (← i.mkSplitVCS frame residualPreE).appArg!
+    let sub ← mkFreshExprSyntheticOpaqueMVar (← mkAppNS le #[footprint, residualPreE])
+    let mono ← mkAppNS (← mkConstS ``sepConj_mono_right) #[frame, footprint, residualPreE, sub]
     let args := le.getAppArgs
     let proof ← mkAppNS (← mkConstS ``PartialOrder.rel_trans le.getAppFn.constLevels!)
       #[args[0]!, args[1]!, ← i.pre, sepFF, sepFR, hcl, mono]

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -493,9 +493,11 @@ partial def sepAtoms.go (e : Expr) : Array Expr :=
 def sepAtoms (e : Expr) : MetaM (Array Expr) :=
   return sepAtoms.go (← instantiateMVars e)
 
-def sepConjOfAtoms (atoms : Array Expr) : Expr :=
-  if atoms.isEmpty then mkConst ``emp
-  else atoms[1:].foldl (fun acc a => mkApp2 (mkConst ``sepConj) acc a) atoms[0]!
+def sepConjOfAtoms (atoms : Array Expr) : SymM Expr := do
+  if atoms.isEmpty then mkConstS ``emp
+  else
+    let op ← mkConstS ``sepConj
+    atoms[1:].foldlM (fun acc a => mkAppNS op #[acc, a]) atoms[0]!
 
 /-- Match and remove `cancel` atoms from `pre`. Returns `(remaining, matched)` or `none`.
 
@@ -532,17 +534,19 @@ def proveSepConjLe (pre rhs : Expr) : MetaM (Option Expr) := do
 is `pre ⊑ frame ∗ footprint` (proved by AC-rearrangement of `∗`) composed by right-monotonicity with
 the emitted subgoal `footprint ⊑ residualPre`. -/
 def mkSepFrameSplit (i : FrameInferenceInfo) (frame footprint : Expr) : SymM FrameSplit := do
+  let op ← mkConstS ``sepConj
   -- `.appArg!` reads the `frame ∗ ·` right-hand side off the split VC `mkSplitVC` builds.
-  let sepFF := (← i.mkSplitVC frame footprint).appArg!
-  match ← proveSepConjLe i.pre sepFF with
-  | none => FrameSplit.withDeferredSplitVC i frame
+  let sepFF := (← i.mkSplitVCS op frame footprint).appArg!
+  match ← proveSepConjLe (← i.pre) sepFF with
+  | none => FrameSplit.withDeferredSplitVC i op frame
   | some hcl =>
-    let sepFR := (← i.mkSplitVC frame i.residualPre).appArg!
-    let sub ← mkFreshExprSyntheticOpaqueMVar (← mkAppNS i.le #[footprint, i.residualPre])
+    let le ← i.le
+    let sepFR := (← i.mkSplitVCS op frame i.residualPre).appArg!
+    let sub ← mkFreshExprSyntheticOpaqueMVar (← mkAppNS le #[footprint, i.residualPre])
     let mono ← mkAppNS (← mkConstS ``sepConj_mono_right) #[frame, footprint, i.residualPre, sub]
-    let args := i.le.getAppArgs
-    let proof ← mkAppNS (← mkConstS ``PartialOrder.rel_trans i.le.getAppFn.constLevels!)
-      #[args[0]!, args[1]!, i.pre, sepFF, sepFR, hcl, mono]
+    let args := le.getAppArgs
+    let proof ← mkAppNS (← mkConstS ``PartialOrder.rel_trans le.getAppFn.constLevels!)
+      #[args[0]!, args[1]!, ← i.pre, sepFF, sepFR, hcl, mono]
     return FrameSplit.withDischargedSplitVC frame proof [sub.mvarId!]
 
 /-- Automatic frame inference by domain difference: the spec's precondition's atoms (its footprint)
@@ -553,20 +557,21 @@ def sepConjFrameProc : FrameInferenceProc := fun i => do
   -- name. `probe_spec` isolates the report to the one test example below.
   if i.spec? == some `probe_spec then
     logInfo m!"framing for spec {i.spec?}"
-  match i.hint with
-  | .explicit frame =>
-    match ← matchSepAtoms i.pre frame with
-    | none => return some (← FrameSplit.withDeferredSplitVC i frame)
-    | some (rest, _) => return some (← mkSepFrameSplit i frame (sepConjOfAtoms rest))
-  | .implicit specPre =>
-    let some (rest, matched) ← matchSepAtoms i.pre specPre | return none
+  match i.providedFrame? with
+  | some frame =>
+    match ← matchSepAtoms (← i.pre) frame with
+    | none => return some (← FrameSplit.withDeferredSplitVC i (← mkConstS ``sepConj) frame)
+    | some (rest, _) => return some (← mkSepFrameSplit i frame (← sepConjOfAtoms rest))
+  | none =>
+    let some specPre ← i.specPre? | return none
+    let some (rest, matched) ← matchSepAtoms (← i.pre) specPre | return none
     if rest.isEmpty then return none
-    return some (← mkSepFrameSplit i (sepConjOfAtoms rest) (sepConjOfAtoms matched))
+    return some (← mkSepFrameSplit i (← sepConjOfAtoms rest) (← sepConjOfAtoms matched))
 
 @[frameproc] def heapFP : FrameProc where
   prog := ``HeapM
   mkOpAppM := fun _ => pure (mkConst ``sepConj)
-  resourceTy := fun _ => pure (mkConst ``HProp)
+  mkResourceTy := fun _ => pure (mkConst ``HProp)
   opHead := ``sepConj
   proc := sepConjFrameProc
 

--- a/tests/elab/vcgenTickFrames.lean
+++ b/tests/elab/vcgenTickFrames.lean
@@ -247,17 +247,18 @@ def tickFrameProc : FrameInferenceProc := fun i => do
   -- Emit the split VC `pre ⊑ (costConj shift residualPre ticks) s⃗` in its `costConj_apply`-reduced
   -- meet form `pre ⊑ (⌜shift ≤ ticks⌝ ⊓ residualPre (ticks - shift)) s⃗` (definitionally equal), so the
   -- built-in meet split decomposes it: the tick guard closes by `grind`, the residual re-applies.
-  let op ← shareCommon (← Meta.mkAppOptM ``costConj #[some i.Pred.bindingBody!, none])
+  let op ← i.op
   let costL := op.getAppArgs[0]!
   let costInst := op.getAppArgs[1]!
   let us := op.getAppFn.constLevels!
+  let residualPre ← i.mkResidualPre
   let guard ← mkAppNS (← mkConstS ``CompleteLattice.ofProp us)
     #[costL, costInst, ← mkAppNS (← mkConstS ``Nat.le) #[shift, ticks]]
-  let residual ← mkAppNS i.residualPre #[← mkAppNS (← mkConstS ``Nat.sub) #[ticks, shift]]
+  let residual ← mkAppNS residualPre #[← mkAppNS (← mkConstS ``Nat.sub) #[ticks, shift]]
   let meet ← mkAppNS (← mkConstS ``Lean.Order.meet us) #[costL, costInst, guard, residual]
   let rhs ← mkAppNS meet (i.excessArgs.extract 1 i.excessArgs.size)
   let m ← mkFreshExprSyntheticOpaqueMVar (← mkAppNS (← i.le) #[← i.pre, rhs])
-  return some (FrameSplit.withDischargedSplitVC shift m [m.mvarId!])
+  return some (FrameSplit.withDischargedSplitVC shift residualPre m [m.mvarId!])
 
 /-- Register the cost frame inference procedure for `vcgen`, indexed by the `TickT` program type. The
 frame operator `costConj` is built at the base lattice `L` read off the assertion type `Nat → L`, so it

--- a/tests/elab/vcgenTickFrames.lean
+++ b/tests/elab/vcgenTickFrames.lean
@@ -233,9 +233,9 @@ meet split turns this into the tick guard (closed by `grind`) and the shifted re
 def tickFrameProc : FrameInferenceProc := fun i => do
   unless i.Pred.isArrow && i.Pred.bindingDomain!.isConstOf ``Nat do return none
   let some ticks := i.excessArgs[0]? | return none
-  let shift ← match i.hint with
-    | .explicit r => pure r
-    | .implicit _ => do
+  let shift ← match i.providedFrame? with
+    | some r => pure r
+    | none => do
       -- Shifting by the whole tick count leaves `ticks - ticks`; skip when that normalizes to `0` so
       -- the proc does not re-fire on its own residual.
       let ticks ← instantiateMVarsS ticks
@@ -247,15 +247,16 @@ def tickFrameProc : FrameInferenceProc := fun i => do
   -- Emit the split VC `pre ⊑ (costConj shift residualPre ticks) s⃗` in its `costConj_apply`-reduced
   -- meet form `pre ⊑ (⌜shift ≤ ticks⌝ ⊓ residualPre (ticks - shift)) s⃗` (definitionally equal), so the
   -- built-in meet split decomposes it: the tick guard closes by `grind`, the residual re-applies.
-  let costL := i.op.getAppArgs[0]!
-  let costInst := i.op.getAppArgs[1]!
-  let us := i.op.getAppFn.constLevels!
+  let op ← shareCommon (← Meta.mkAppOptM ``costConj #[some i.Pred.bindingBody!, none])
+  let costL := op.getAppArgs[0]!
+  let costInst := op.getAppArgs[1]!
+  let us := op.getAppFn.constLevels!
   let guard ← mkAppNS (← mkConstS ``CompleteLattice.ofProp us)
     #[costL, costInst, ← mkAppNS (← mkConstS ``Nat.le) #[shift, ticks]]
   let residual ← mkAppNS i.residualPre #[← mkAppNS (← mkConstS ``Nat.sub) #[ticks, shift]]
   let meet ← mkAppNS (← mkConstS ``Lean.Order.meet us) #[costL, costInst, guard, residual]
   let rhs ← mkAppNS meet (i.excessArgs.extract 1 i.excessArgs.size)
-  let m ← mkFreshExprSyntheticOpaqueMVar (← mkAppNS i.le #[i.pre, rhs])
+  let m ← mkFreshExprSyntheticOpaqueMVar (← mkAppNS (← i.le) #[← i.pre, rhs])
   return some (FrameSplit.withDischargedSplitVC shift m [m.mvarId!])
 
 /-- Register the cost frame inference procedure for `vcgen`, indexed by the `TickT` program type. The
@@ -265,7 +266,7 @@ frames the cost over any base monad. `costConj_apply` unfolds `costConj r b n` t
 @[frameproc] def tickFP : FrameProc where
   prog := ``TickT
   mkOpAppM := fun info => Meta.mkAppOptM ``costConj #[some info.Pred.bindingBody!, none]
-  resourceTy := fun _ => pure (mkConst ``Nat)
+  mkResourceTy := fun _ => pure (mkConst ``Nat)
   opHead := ``costConj
   proc := tickFrameProc
 

--- a/tests/elab/vcgenTickFrames.lean
+++ b/tests/elab/vcgenTickFrames.lean
@@ -247,14 +247,14 @@ def tickFrameProc : FrameInferenceProc := fun i => do
   -- Emit the split VC `pre ⊑ (costConj shift residualPre ticks) s⃗` in its `costConj_apply`-reduced
   -- meet form `pre ⊑ (⌜shift ≤ ticks⌝ ⊓ residualPre (ticks - shift)) s⃗` (definitionally equal), so the
   -- built-in meet split decomposes it: the tick guard closes by `grind`, the residual re-applies.
-  let op ← i.op
+  let op ← i.mkOpApp
   let costL := op.getAppArgs[0]!
   let costInst := op.getAppArgs[1]!
   let us := op.getAppFn.constLevels!
   let residualPre ← i.mkResidualPre
   let guard ← mkAppNS (← mkConstS ``CompleteLattice.ofProp us)
     #[costL, costInst, ← mkAppNS (← mkConstS ``Nat.le) #[shift, ticks]]
-  let residual ← mkAppNS residualPre #[← mkAppNS (← mkConstS ``Nat.sub) #[ticks, shift]]
+  let residual ← mkAppNS (mkMVar residualPre) #[← mkAppNS (← mkConstS ``Nat.sub) #[ticks, shift]]
   let meet ← mkAppNS (← mkConstS ``Lean.Order.meet us) #[costL, costInst, guard, residual]
   let rhs ← mkAppNS meet (i.excessArgs.extract 1 i.excessArgs.size)
   let m ← mkFreshExprSyntheticOpaqueMVar (← mkAppNS (← i.le) #[← i.pre, rhs])


### PR DESCRIPTION
This PR restores `vcgen` spec application performance regressed by #14529. Frame inference inputs are computed only when a frame inference procedure consumes them, so applying a spec with no frame to infer costs what it did before frame inference.