### PR TITLE
chore: report fractional milliseconds in the vcgen benchmark driver

### DIFF
--- a/tests/bench/vcgen/lib/Driver.lean
+++ b/tests/bench/vcgen/lib/Driver.lean
@@ -10,12 +10,17 @@ public import Std.Internal.Do
 public import Std.Internal.Do.Triple.SpecLemmas
 open Lean Parser Meta Elab Tactic Sym
 
+/-- Runs `k` and additionally returns its wall-clock time in hundredths of a millisecond. -/
 def timeItMs (k : MetaM α) : MetaM (α × UInt64) := do
   let startTime ← IO.monoNanosNow
   let a ← k
   let endTime ← IO.monoNanosNow
-  let ms := (endTime - startTime).toFloat / 1000000.0
-  return (a, ms.toUInt64)
+  return (a, ((endTime - startTime) / 10000).toUInt64)
+
+/-- Formats a time in hundredths of a millisecond as milliseconds with two decimal places. -/
+def fmtMs (hms : UInt64) : String :=
+  let frac := hms % 100
+  s!"{hms / 100}.{if frac < 10 then "0" else ""}{frac}"
 
 /-- Helper function for executing a tactic `k` for solving `$(goal) n`. -/
 def driver (goal : Name) (unfold : List Name) (n : Nat) (discharge : MetaM (TSyntax `tactic)) (k : MVarId → MetaM (List MVarId)) : MetaM Unit := do
@@ -30,7 +35,7 @@ def driver (goal : Name) (unfold : List Name) (n : Nat) (discharge : MetaM (TSyn
     | .goal mvarId => return mvarId
     | .noProgress => throwError "No progress when simping {mvarId}!"
     | .closed => throwError "Simp closed goal {mvarId}"
-  -- IO.println s!"time spent unfolding: {_unfoldMs} ms"
+  -- IO.println s!"time spent unfolding: {fmtMs _unfoldMs} ms"
   let (mvarIds, ms) ← timeItMs do k mvarId
   let discharge ← discharge
   let dischargePp ← PrettyPrinter.ppTactic discharge
@@ -47,14 +52,14 @@ def driver (goal : Name) (unfold : List Name) (n : Nat) (discharge : MetaM (TSyn
   let (_, kernelMs) ← timeItMs (checkWithKernel expr)
   let label := s!"{goal.getPrefix}({n}):"
   let pad := "".pushn ' ' (24 - min label.length 24)
-  let mut msg := s!"{label}{pad}{ms} ms"
+  let mut msg := s!"{label}{pad}{fmtMs ms} ms"
   if let some dischargeMs := dischargeMs? then
-    msg := msg ++ s!", {mvarIds.length} VCs by {dischargePp}: {dischargeMs} ms"
+    msg := msg ++ s!", {mvarIds.length} VCs by {dischargePp}: {fmtMs dischargeMs} ms"
   else
     msg := msg ++ s!", {mvarIds.length} VCs"
-  if instMs > 1000 then
-    msg := msg ++ s!", instantiate > 1000ms: {instMs} ms"
-  msg := msg ++ s!", kernel: {kernelMs} ms"
+  if instMs > 100000 then
+    msg := msg ++ s!", instantiate > 1000ms: {fmtMs instMs} ms"
+  msg := msg ++ s!", kernel: {fmtMs kernelMs} ms"
   IO.println msg
 
 def solveUsingTactic (goal : Name) (unfold : List Name) (n : Nat) (solve : MetaM (TSyntax `tactic)) (discharge : MetaM (TSyntax `tactic)) : MetaM Unit := do

--- a/tests/bench/vcgen/run_bench.sh
+++ b/tests/bench/vcgen/run_bench.sh
@@ -11,20 +11,20 @@ LEAN_NUM_THREADS=1 capture lake build BaselineBench
 cat "$CAPTURED.out.produced" >> vcgen.out
 
 # Parse lines like:
-#   AddSubCancel(1000):   528 ms, 1 VCs by grind: 245 ms, kernel: 446 ms
+#   AddSubCancel(1000):   528.42 ms, 1 VCs by grind: 245.13 ms, kernel: 446.07 ms
 # into JSONL measurements.
 python3 -c "
 import json, re, sys
 
 for line in open('vcgen.out'):
-    m = re.search(r'(\w+)\((\d+)\):\s+(\d+) ms.*kernel:\s+(\d+) ms', line)
+    m = re.search(r'(\w+)\((\d+)\):\s+([0-9.]+) ms.*kernel:\s+([0-9.]+) ms', line)
     if not m:
         continue
     case, n, vcgen_ms, kernel_ms = m.group(1), m.group(2), m.group(3), m.group(4)
     for phase, val in [('vcgen', vcgen_ms), ('kernel', kernel_ms)]:
         print(json.dumps({
             'metric': f'vcgen/{case}/{n}/{phase}//wall-clock',
-            'value': int(val) / 1000,
+            'value': float(val) / 1000,
             'unit': 's'
         }))
 " >> measurements.jsonl


### PR DESCRIPTION
This PR makes the vcgen benchmark driver report timings as milliseconds with two decimal places, so that sub-100ms measurements no longer quantize at the percent level, which radar's significance detection previously reported as spurious changes.

Motivating example: https://radar.lean-lang.org/repos/lean4/commits/f696c4686b327b271b3488d757dc4fcd80f298ce flags several-percent swings on a 24 ms kernel phase that are pure quantization noise of the integer millisecond report.

The driver now measures hundredths of a millisecond with integer arithmetic on the monotonic nanosecond clock, and the parser in run_bench.sh accepts fractional ms values.
