### PR TITLE
fix: missing `check_no_metavar_no_fvar` checks at `inductive.cpp`

### DIFF
--- a/src/kernel/inductive.cpp
+++ b/src/kernel/inductive.cpp
@@ -1115,6 +1115,15 @@ static pair<names, name_map<name>> mk_aux_rec_name_map(environment const & aux_e
 }
 
 environment environment::add_inductive(declaration const & d) const {
+    /* Reject metavariables and free variables in declaration. */
+    {
+        inductive_decl ind_d(d);
+        for (inductive_type const & ind_type : ind_d.get_types()) {
+            check_no_metavar_no_fvar(*this, ind_type.get_name(), ind_type.get_type());
+            for (constructor const & cnstr : ind_type.get_cnstrs())
+                check_no_metavar_no_fvar(*this, constructor_name(cnstr), constructor_type(cnstr));
+        }
+    }
     elim_nested_inductive_result res = elim_nested_inductive_fn(*this, d)();
     unsigned nnested = res.m_aux2nested.size();
     scoped_diagnostics diag(*this, true);


### PR DESCRIPTION
This PR adds a missing `check_no_metavar_no_fvar` checks to the kernel inductive type module. Without it, users could use metaprogramming to sneak in nested inductive declarations containing free variables or metavariables. Note that Comparator would catch this exploit, since lean4export refuses to export declarations containing free variables or metavariables.
