### PR TITLE
fix: check universe parameters in mutual definitions

### DIFF
--- a/src/kernel/environment.cpp
+++ b/src/kernel/environment.cpp
@@ -230,12 +230,15 @@ environment environment::add_mutual(declaration const & d, bool check) const {
     definition_safety safety = head(vs).get_safety();
     if (safety == definition_safety::safe)
         throw kernel_exception(*this, "invalid mutual definition, declaration is not tagged as unsafe/partial");
+    names const & lparams = head(vs).get_lparams();
     /* Check declarations header */
     if (check) {
         type_checker checker(*this, diag.get(), safety);
         for (definition_val const & v : vs) {
             if (v.get_safety() != safety)
                 throw kernel_exception(*this, "invalid mutual definition, declarations must have the same safety annotation");
+            if (v.get_lparams() != lparams)
+                throw kernel_exception(*this, "invalid mutual definition, declarations must have the same universe level parameters");
             check_constant_val(*this, v.to_constant_val(), checker);
         }
     }

--- a/tests/elab/mutualLevelParams.lean
+++ b/tests/elab/mutualLevelParams.lean
@@ -1,0 +1,29 @@
+import Lean.CoreM
+import Lean.AddDecl
+
+/-!
+The kernel must reject a mutual definition whose members disagree on their
+universe level parameters.
+
+`add_mutual` shares one `type_checker` across all members, and the infer-type
+cache is keyed on the expression alone, not on the level parameters in scope.
+So the member declaring `u` must be checked first: it populates the cache for
+`Sort u → Sort u`, and without this check the second member would hit that
+entry and never run `check_level`, entering the environment with an undeclared
+universe parameter in its type.
+-/
+
+open Lean
+
+private def ty : Expr := .forallE `x (.sort (.param `u)) (.sort (.param `u)) .default
+private def val : Expr := .lam `x (.sort (.param `u)) (.bvar 0) .default
+
+/--
+error: (kernel) invalid mutual definition, declarations must have the same universe level parameters
+-/
+#guard_msgs in
+#eval addDecl <| .mutualDefnDecl [
+  { name := `mutA, levelParams := [`u], type := ty, value := val,
+    hints := .opaque, safety := .partial },
+  { name := `mutB, levelParams := [], type := ty, value := val,
+    hints := .opaque, safety := .partial }]


### PR DESCRIPTION
This PR checks that declarations in a mutual block use the same universe parameters. The elaborator already enforces this invariant, but meta-programming can bypass it.
