### PR TITLE
fix: mark exported stubs of `partial` definitions as unsafe

### DIFF
--- a/src/Lean/AddDecl.lean
+++ b/src/Lean/AddDecl.lean
@@ -118,7 +118,7 @@ private def addDeclCore (decl : Declaration) (forceExpose : Bool) : CoreM Unit :
     | .defnDecl defn | .mutualDefnDecl [defn] =>
       if !forceExpose && (← getEnv).header.isModule && !(← getEnv).isExporting then
         trace[addDecl] "exporting definition {defn.name} as axiom"
-        exportedInfo? := some <| .axiomInfo { defn with isUnsafe := defn.safety == .unsafe }
+        exportedInfo? := some <| .axiomInfo { defn with isUnsafe := defn.safety != .safe }
       pure (defn.name, .defnInfo defn, .defn)
     | .opaqueDecl op =>
       if !forceExpose && (← getEnv).header.isModule && !(← getEnv).isExporting then

--- a/tests/pkg/module/Module/PartialExported.lean
+++ b/tests/pkg/module/Module/PartialExported.lean
@@ -1,0 +1,26 @@
+module
+
+public import Lean
+
+/-!
+Producer half of a regression test: a `partial` definition of type `False`, added directly through
+`addDecl`. Since the module is not `@[expose]`d, the definition is exported as an axiom stub, which
+must stay marked unsafe.
+-/
+
+open Lean
+
+public section
+
+run_meta do
+  let name := `partialFalse
+  addDecl (.mutualDefnDecl [{
+    name
+    levelParams := []
+    type := mkConst ``False
+    value := mkConst name
+    hints := .opaque
+    safety := .partial
+  }])
+
+end

--- a/tests/pkg/module/Module/PartialImported.lean
+++ b/tests/pkg/module/Module/PartialImported.lean
@@ -1,0 +1,15 @@
+module
+
+public import Module.PartialExported
+
+/-!
+A `partial` definition must not become usable in safe declarations just because it crossed a module
+boundary as an axiom stub.
+-/
+
+/--
+error: (kernel) invalid declaration, it uses unsafe declaration 'partialFalse'
+-/
+#guard_msgs in
+public theorem partialBoom : _root_.False :=
+  partialFalse

--- a/tests/pkg/module/run_test.sh
+++ b/tests/pkg/module/run_test.sh
@@ -3,3 +3,6 @@ LEAN_ABORT_ON_PANIC=1 lake build
 
 capture_fail lake lean Module/ConflictingImported.lean
 check_out_contains "already contains 'f'"
+
+# Not part of the `Module` root: the failed declaration is recovered as an axiom of type `False`.
+lake lean Module/PartialImported.lean


### PR DESCRIPTION
This PR fixes a soundness bug in the module system. A `partial` definition lost its `partial` marking when it crossed a module boundary, so downstream modules could use it from safe declarations. This issue can only be exploited using meta-programming.

When a module exports a definition whose body stays private, `addDeclCore` publishes an axiom stub in its place. The stub's `isUnsafe` flag was computed as `defn.safety == .unsafe`, which is false for `DefinitionSafety.partial`, so a `partial` definition was summarized as an ordinary safe axiom.
The fix computes it as `defn.safety != .safe` instead.
