### PR TITLE
fix: recognize sorts as `Prop` up to universe normalization

### DIFF
--- a/src/kernel/inductive.h
+++ b/src/kernel/inductive.h
@@ -67,7 +67,9 @@ inline expr to_cnstr_when_structure(environment const & env, name const & induct
     expr e_type = whnf(infer_type(e));
     if (!is_constant(get_app_fn(e_type), induct_name))
         return e;
-    if (whnf(infer_type(e_type)) == mk_Prop())
+    expr s = whnf(infer_type(e_type));
+    // See `type_checker::is_prop`: zero must be tested up to normalization, e.g. `imax 1 0` is `Prop`.
+    if (is_sort(s) && normalizes_to_zero(sort_level(s)))
         return e;
     return expand_eta_struct(env, e_type, e);
 }

--- a/src/kernel/level.cpp
+++ b/src/kernel/level.cpp
@@ -171,6 +171,21 @@ bool is_not_zero(level const & l) {
     lean_unreachable(); // LCOV_EXCL_LINE
 }
 
+bool normalizes_to_zero(level const & l) {
+    switch (kind(l)) {
+    case level_kind::Zero:
+        return true;
+    case level_kind::Param: case level_kind::MVar: case level_kind::Succ:
+        return false;
+    case level_kind::Max:
+        return normalizes_to_zero(max_lhs(l)) && normalizes_to_zero(max_rhs(l));
+    case level_kind::IMax:
+        // `mk_imax` returns its right argument whenever that argument is `zero`.
+        return normalizes_to_zero(imax_rhs(l));
+    }
+    lean_unreachable(); // LCOV_EXCL_LINE
+}
+
 bool is_lt(level const & a, level const & b, bool use_hash) {
     if (is_eqp(a, b))              return false;
     unsigned da = get_depth(a);

--- a/src/kernel/level.h
+++ b/src/kernel/level.h
@@ -197,6 +197,11 @@ std::ostream & operator<<(std::ostream & out, level const & l);
     in \c l, l[A] != zero. */
 bool is_not_zero(level const & l);
 
+/** \brief Return true iff \c normalize(l) is \c zero, without building the normal form.
+    Unlike \c is_not_zero, this is a statement about \c l itself rather than about all of its
+    instantiations, so it fails for parameters and metavariables. */
+bool normalizes_to_zero(level const & l);
+
 /** \brief Convert a list of universe level parameter names into a list of levels. */
 levels lparams_to_levels(names const & ps);
 

--- a/src/kernel/type_checker.cpp
+++ b/src/kernel/type_checker.cpp
@@ -326,7 +326,11 @@ expr type_checker::ensure_pi(expr const & e, expr const & s) {
 
 /** \brief Return true iff \c e is a proposition */
 bool type_checker::is_prop(expr const & e) {
-    return whnf(infer_type(e)) == mk_Prop();
+    expr s = whnf(infer_type(e));
+    // The level must be tested for zero up to normalization: `imax 1 0` denotes `Prop` without
+    // being syntactically `zero`. Comparing `s` against `Prop` syntactically instead would let
+    // `infer_proj` extract non-proof data out of a proof, contradicting proof irrelevance.
+    return is_sort(s) && normalizes_to_zero(sort_level(s));
 }
 
 /** \brief Apply normalizer extensions to \c e.

--- a/tests/elab/kernelImaxProp.lean
+++ b/tests/elab/kernelImaxProp.lean
@@ -1,0 +1,46 @@
+import Lean.CoreM
+import Lean.AddDecl
+
+/-!
+The kernel must recognize a sort as `Prop` up to level normalization.
+
+`KMWeird : Sort (imax 1 0)` is a proposition: `imax 1 0` normalizes to `0`. The
+inductive is therefore legitimate, and the kernel is right to allow its `Bool`
+field, exactly as it would for any other inductive predicate. What must not be
+allowed is projecting that field back out, since proof irrelevance equates
+`KMWeird.mk false` and `KMWeird.mk true`.
+-/
+
+open Lean
+
+#eval show CoreM Unit from
+  addDecl <| .inductDecl [] 0 [
+    { name := `KMDummy
+      type := .sort .zero
+      ctors := [{ name := `KMDummy.intro, type := .const `KMDummy [] }] },
+    { name := `KMWeird
+      type := .sort (.imax (.succ .zero) .zero)
+      ctors := [{ name := `KMWeird.mk
+                  type := .forallE `value (.const ``Bool []) (.const `KMWeird []) .default }] }
+  ] false
+
+def KMAsProp : Prop := KMWeird
+
+theorem kmLeft : KMAsProp := KMWeird.mk false
+theorem kmRight : KMAsProp := KMWeird.mk true
+
+/-- The inductive really is a proposition, so proof irrelevance applies. -/
+theorem kmProofIrrel : kmLeft = kmRight := rfl
+
+/--
+error: (kernel) invalid projection
+  proof.1
+-/
+#guard_msgs in
+#eval addDecl <| .defnDecl {
+  name := `kmLeak
+  levelParams := []
+  type := .forallE `proof (.const ``KMAsProp []) (.const ``Bool []) .default
+  value := .lam `proof (.const ``KMAsProp []) (.proj `KMWeird 0 (.bvar 0)) .default
+  hints := .abbrev
+  safety := .safe }


### PR DESCRIPTION
This PR fixes a kernel bug: a type whose sort is `Prop` only after universe normalization, such as `Sort (imax 1 0)`, was not recognized as a proposition, so the kernel allowed a non-proof field to be projected out of a proof. Such a declaration cannot be written in surface syntax and can only be produced with metaprogramming, and `nanoda` rejects it.

Because proof irrelevance equates any two proofs of such a type, projecting a `Bool` field out of two of them gives `false = true`, and hence `False` with no axiom dependencies. The elaborator blocks this by eagerly normalizing levels.

`type_checker::is_prop` compared `whnf(infer_type(e))` against `Prop` syntactically. The level `imax 1 0` is definitionally `0`, so a type in `Sort (imax 1 0)` really is a proposition and proof irrelevance applies to it, but `is_prop` answered `false` and `infer_proj` therefore skipped its `Prop` restriction. The fix tests the level for zero up to normalization instead.

