### PR TITLE
test: in-place append with a ramified spec in the vcgen separation logic demo

### DIFF
--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -156,9 +156,6 @@ def reverse.go (fuel : Nat) (curr prev : Addr) : HeapM Addr :=
 def reverse (fuel : Nat) (head : Addr) : HeapM Addr :=
   reverse.go fuel head null
 
-/-- Write the prev field of the node at `q`. -/
-def storePrev (q c : Addr) : HeapM Unit := store (q + 1) c
-
 /-- Fuel-bounded in-place append: walk to the last node of the list at `curr`, link its next
 pointer to `q`, and point `q`'s prev field back at it. -/
 def append (fuel : Nat) (curr q : Addr) : HeapM Unit :=
@@ -168,7 +165,7 @@ def append (fuel : Nat) (curr q : Addr) : HeapM Unit :=
     let next ← load curr
     if next = null then
       store curr q
-      storePrev q curr
+      store (q + 1) curr
     else
       append fuel next q
 
@@ -601,7 +598,7 @@ theorem append_step_le (v v' w : Nat) (rest' ws : List Nat) (back qb curr next q
 
 /-- Rebuild a cons cell around a rewritten prev field; the loaded next-pointer is the witness. -/
 @[grind ←]
-theorem storePrev_handoff (w : Nat) (ws : List Nat) (q c n : Addr) :
+theorem store_prev_handoff (w : Nat) (ws : List Nat) (q c n : Addr) :
     ((q ↦ n ∗ (q + 2) ↦ w) ∗ IsList ws q n) ∗ (q + 1) ↦ c ⊑
       ⨆ n', q ↦ n' ∗ (q + 1) ↦ c ∗ (q + 2) ↦ w ∗ IsList ws q n' := by
   refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_) (le_iSup _ n)
@@ -839,10 +836,11 @@ node into the wand (`wand_absorb`), and linking the last node discharges it by t
 lists are nonempty; the appended segment's head prev field is rewritten to the last node. -/
 
 /-- Rewrite the back-pointer of a cons cell by storing into its prev field. Not `@[spec]`: its
-program pattern would also match the exposed-node prev writes in `reverse.go`. -/
-theorem storePrev_IsList (w : Nat) (ws : List Nat) (qb q c : Addr) :
-    ⦃ IsList (w :: ws) qb q ⦄ storePrev q c ⦃ fun _ => IsList (w :: ws) c q ⦄ := by
-  simp only [storePrev, IsList_cons_eq]
+program pattern would also match the exposed-node prev write in `reverse.go`. Passed to `vcgen`
+where needed; the call-site priority ranks it above the global `store_spec`. -/
+theorem store_prev_IsList (w : Nat) (ws : List Nat) (qb q c : Addr) :
+    ⦃ IsList (w :: ws) qb q ⦄ store (q + 1) c ⦃ fun _ => IsList (w :: ws) c q ⦄ := by
+  simp only [IsList_cons_eq]
   vcgen [store_spec] with finish
 
 /-- Wand-style append specification: the continuation `R` receives the concatenated list once the
@@ -860,7 +858,7 @@ theorem append_spec (fuel : Nat) (v w : Nat) (rest ws : List Nat) (back qb curr 
       simp only [append, List.cons_append, List.nil_append]
       -- The `next ≠ null` arm is unreachable under `IsList []`; its recursive call takes the
       -- `⊥`-precondition spec and the arm closes by contradiction.
-      vcgen [-load_spec, load_next_IsList, store_spec, storePrev_IsList,
+      vcgen [-load_spec, load_next_IsList, store_prev_IsList,
         fun next => HeapM.triple_of_bot_pre (Q := fun _ => R) (append fuel next q)] with
         finish
   | cons v' rest' ih =>
@@ -870,7 +868,7 @@ theorem append_spec (fuel : Nat) (v w : Nat) (rest ws : List Nat) (back qb curr 
       simp only [append, List.cons_append]
       -- The `next = null` arm is unreachable under `IsList (v' :: rest')`; the recursive call
       -- takes the IH at the absorbed wand.
-      vcgen [-load_spec, load_next_IsList, store_spec, storePrev_IsList,
+      vcgen [-load_spec, load_next_IsList, store_prev_IsList,
         fun next => ih fuel v' curr next R (Nat.lt_of_succ_lt_succ hle)] with finish
 
 /-- Plain append specification, from `append_spec` at the trivial continuation. -/

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -479,10 +479,14 @@ theorem le_sepConj_wand_emp_wand_refl (X A : HProp) : X ⊑ X ∗ (A -∗ (emp -
 
 /-! ## Doubly-linked lists
 
-`IsList xs back p` asserts that `p` roots a null-terminated doubly-linked list whose **payloads** are
-`xs`, and that the head cell's prev field equals `back`. A cons node at `p` stores next at `p`,
-prev at `p + 1`, and the head payload at `p + 2` (C field order; and `p ≠ null`). The program
-`reverse` takes only a head pointer; `xs` is ghost in the specification. -/
+`IsList xs prev hd` asserts that `hd` roots a null-terminated doubly-linked list whose **payloads**
+are `xs`, and that `hd`'s prev field holds `prev`. A cons node at `hd` stores next at `hd`, prev at
+`hd + 1`, and the head payload at `hd + 2` (C field order; and `hd ≠ null`).
+
+The two address arguments name what the head node points at and what points at it: `hd` is where the
+segment starts, `prev` is the node before it. So the recursive occurrence reads
+`IsList vs hd next`, the tail starting at `next` with `hd` before it. The program `reverse` takes
+only a head pointer; `xs` is ghost in the specification. -/
 
 /-- Pointwise characterization of an embedded-guard assertion. -/
 theorem ofProp_meet_apply (φ : Prop) (P : HProp) (h : Heap) : (⌜φ⌝ ⊓ P) h ↔ φ ∧ P h := by
@@ -497,57 +501,61 @@ theorem ofProp_meet_apply (φ : Prop) (P : HProp) (h : Heap) : (⌜φ⌝ ⊓ P) 
   · intro ⟨hφ, hP⟩
     exact (le_meet P ⌜φ⌝ P (le_ofProp P φ hφ) PartialOrder.rel_refl) h hP
 
-/-- Doubly-linked list segment: payloads `xs`, head at `p`, head-prev `back`.
-Node layout: `p ↦ next ∗ (p+1) ↦ prev ∗ (p+2) ↦ payload`. -/
+/-- Doubly-linked list segment: payloads `xs`, head node at `hd`, preceded by `prev`.
+Node layout: `hd ↦ next ∗ (hd+1) ↦ prev ∗ (hd+2) ↦ payload`. -/
 noncomputable def IsList : List Nat → Addr → Addr → HProp
-  | [], _back, p => sepPure (p = null)
-  | v :: vs, back, p =>
-      ⌜p ≠ null⌝ ⊓ ⨆ n : Addr, p ↦ n ∗ (p + 1) ↦ back ∗ (p + 2) ↦ v ∗ IsList vs p n
+  | [], _prev, hd => sepPure (hd = null)
+  | v :: vs, prev, hd =>
+      ⌜hd ≠ null⌝ ⊓ ⨆ next : Addr,
+        hd ↦ next ∗ (hd + 1) ↦ prev ∗ (hd + 2) ↦ v ∗ IsList vs hd next
 
-@[grind =] theorem IsList_nil_eq (back p : Addr) : IsList [] back p = sepPure (p = null) := rfl
+@[grind =] theorem IsList_nil_eq (prev hd : Addr) : IsList [] prev hd = sepPure (hd = null) := rfl
 
-@[grind =] theorem IsList_cons_eq (v : Nat) (vs : List Nat) (back p : Addr) :
-    IsList (v :: vs) back p =
-      ⌜p ≠ null⌝ ⊓ ⨆ n : Addr, p ↦ n ∗ (p + 1) ↦ back ∗ (p + 2) ↦ v ∗ IsList vs p n := rfl
+@[grind =] theorem IsList_cons_eq (v : Nat) (vs : List Nat) (prev hd : Addr) :
+    IsList (v :: vs) prev hd =
+      ⌜hd ≠ null⌝ ⊓ ⨆ next : Addr,
+        hd ↦ next ∗ (hd + 1) ↦ prev ∗ (hd + 2) ↦ v ∗ IsList vs hd next := rfl
 
-@[grind =] theorem IsList_nil_null (back : Addr) : IsList [] back null = emp := by
+@[grind =] theorem IsList_nil_null (prev : Addr) : IsList [] prev null = emp := by
   funext h; apply propext
   simp [IsList_nil_eq, sepPure_apply]
 
-theorem IsList_cons_elim {v : Nat} {vs : List Nat} {back p : Addr} {h : Heap}
-    (hl : IsList (v :: vs) back p h) :
-    p ≠ null ∧ ∃ n, (p ↦ n ∗ (p + 1) ↦ back ∗ (p + 2) ↦ v ∗ IsList vs p n) h := by
+theorem IsList_cons_elim {v : Nat} {vs : List Nat} {prev hd : Addr} {h : Heap}
+    (hl : IsList (v :: vs) prev hd h) :
+    hd ≠ null ∧ ∃ next,
+      (hd ↦ next ∗ (hd + 1) ↦ prev ∗ (hd + 2) ↦ v ∗ IsList vs hd next) h := by
   rw [IsList_cons_eq] at hl
   exact ((ofProp_meet_apply _ _ _).mp hl).imp_right fun hh => (iSup_hprop_apply _ _).mp hh
 
 @[grind ←]
-theorem IsList_cons_intro (v : Nat) (n back : Addr) (vs : List Nat) (p : Addr) (hp : p ≠ null) :
-    (p ↦ n ∗ (p + 1) ↦ back ∗ (p + 2) ↦ v ∗ IsList vs p n) ⊑ IsList (v :: vs) back p := by
+theorem IsList_cons_intro (v : Nat) (next prev : Addr) (vs : List Nat) (hd : Addr)
+    (hhd : hd ≠ null) :
+    (hd ↦ next ∗ (hd + 1) ↦ prev ∗ (hd + 2) ↦ v ∗ IsList vs hd next) ⊑ IsList (v :: vs) prev hd := by
   intro h hh
-  exact (ofProp_meet_apply _ _ _).mpr ⟨hp, (iSup_hprop_apply _ _).mpr ⟨n, hh⟩⟩
+  exact (ofProp_meet_apply _ _ _).mpr ⟨hhd, (iSup_hprop_apply _ _).mpr ⟨next, hh⟩⟩
 
 /-- Open a segment known to be non-empty: the head node's three cells and the tail segment.
 Mirror of `IsList_cons_intro`. -/
-theorem IsList_ne_le (rest : List Nat) (back curr : Addr) (hcn : curr ≠ null) :
-    IsList rest back curr ⊑
-      ⨆ v, ⨆ vs, ⨆ n, sepPure (rest = v :: vs) ∗
-        (curr ↦ n ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗ IsList vs curr n) := by
-  match rest with
+theorem IsList_ne_le (xs : List Nat) (prev hd : Addr) (hhd : hd ≠ null) :
+    IsList xs prev hd ⊑
+      ⨆ v, ⨆ vs, ⨆ next, sepPure (xs = v :: vs) ∗
+        (hd ↦ next ∗ (hd + 1) ↦ prev ∗ (hd + 2) ↦ v ∗ IsList vs hd next) := by
+  match xs with
   | [] =>
     refine PartialOrder.rel_trans ?_ (bot_le _)
     intro h hh
-    exact (hcn ((sepPure_apply _ _).mp hh).1).elim
+    exact (hhd ((sepPure_apply _ _).mp hh).1).elim
   | v :: vs =>
     rw [IsList_cons_eq]
-    refine ofProp_meet_le_left fun _ => iSup_le _ _ fun n => ?_
-    refine le_iSup_of_le v (le_iSup_of_le vs (le_iSup_of_le n (PartialOrder.rel_of_eq ?_)))
+    refine ofProp_meet_le_left fun _ => iSup_le _ _ fun next => ?_
+    refine le_iSup_of_le v (le_iSup_of_le vs (le_iSup_of_le next (PartialOrder.rel_of_eq ?_)))
     rw [show (v :: vs = v :: vs) = True from propext ⟨fun _ => trivial, fun _ => rfl⟩,
       sepPure_true_eq_emp, emp_sepConj]
 
 /-- A segment rooted at `null` is empty. -/
-@[grind =] theorem IsList_null_eq (rest : List Nat) (back : Addr) :
-    IsList rest back null = sepPure (rest = []) := by
-  cases rest with
+@[grind =] theorem IsList_null_eq (xs : List Nat) (prev : Addr) :
+    IsList xs prev null = sepPure (xs = []) := by
+  cases xs with
   | nil => simp [IsList_nil_eq]
   | cons v vs =>
     refine PartialOrder.rel_antisymm ?_ ?_
@@ -587,20 +595,20 @@ theorem sepConj_le_bot_of_right (A : HProp) {B : HProp} (h : B ⊑ ⊥) : A ∗ 
 grind_pattern sepConj_le_bot_of_right => B ⊑ ⊥, A ∗ B
 
 /-- An empty segment pins its root to `null`. -/
-theorem IsList_nil_le_bot (curr next : Addr) (hne : next ≠ null) : IsList [] curr next ⊑ ⊥ := by
+theorem IsList_nil_le_bot (prev hd : Addr) (hhd : hd ≠ null) : IsList [] prev hd ⊑ ⊥ := by
   intro h hh
   rw [IsList_nil_eq] at hh
-  exact (hne ((sepPure_apply _ _).mp hh).1).elim
+  exact (hhd ((sepPure_apply _ _).mp hh).1).elim
 
-grind_pattern IsList_nil_le_bot => IsList [] curr next
+grind_pattern IsList_nil_le_bot => IsList [] prev hd
 
 /-- A cons segment cannot be rooted at `null`. -/
-theorem IsList_cons_null_le_bot (v : Nat) (vs : List Nat) (back : Addr) :
-    IsList (v :: vs) back null ⊑ ⊥ := by
+theorem IsList_cons_null_le_bot (v : Nat) (vs : List Nat) (prev : Addr) :
+    IsList (v :: vs) prev null ⊑ ⊥ := by
   intro h hh
   exact ((IsList_cons_elim hh).1 rfl).elim
 
-grind_pattern IsList_cons_null_le_bot => IsList (v :: vs) back null
+grind_pattern IsList_cons_null_le_bot => IsList (v :: vs) prev null
 
 /-- A contradictory precondition entails anything. Both patterns are needed: the conclusion alone
 matches every entailment goal, so the rule fires only once forward saturation has asserted `X ⊑ ⊥`
@@ -610,8 +618,8 @@ theorem le_of_le_bot {X : HProp} (h : X ⊑ ⊥) (C : HProp) : X ⊑ C :=
 
 grind_pattern _root_.le_of_le_bot => X ⊑ ⊥, X ⊑ C
 
-@[grind =] theorem IsList_append_nil (xs : List Nat) (back r : Addr) :
-    IsList (xs ++ ([] : List Nat)) back r = IsList xs back r := by
+@[grind =] theorem IsList_append_nil (xs : List Nat) (prev hd : Addr) :
+    IsList (xs ++ ([] : List Nat)) prev hd = IsList xs prev hd := by
   simp
 
 /-! # The frame inference procedure
@@ -851,25 +859,25 @@ one opens the node with `IsList_ne_le` and then applies the primitive spec. -/
 /-- Load the next-pointer of a list node known to be non-null: the segment must then be a cons,
 and the loaded value is its `IsList` witness. The shape hypothesis reaches `finish` from the
 branch condition in scope. -/
-theorem load_next_IsList_ne (rest : List Nat) (back curr : Addr) (hcn : curr ≠ null) :
-    ⦃ IsList rest back curr ⦄
-      load curr
-    ⦃ fun next => ⨆ v, ⨆ vs, ⌜rest = v :: vs⌝ ⊓
-        (curr ↦ next ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗ IsList vs curr next) ⦄ := by
-  refine ⟨PartialOrder.rel_trans (IsList_ne_le rest back curr hcn) ?_⟩
-  refine iSup_le _ _ fun v => iSup_le _ _ fun vs => iSup_le _ _ fun n => ?_
-  refine sepPure_sepConj_le_of _ _ _ fun hrest => ?_
-  subst hrest
+theorem load_next_IsList_ne (xs : List Nat) (prev hd : Addr) (hhd : hd ≠ null) :
+    ⦃ IsList xs prev hd ⦄
+      load hd
+    ⦃ fun next => ⨆ v, ⨆ vs, ⌜xs = v :: vs⌝ ⊓
+        (hd ↦ next ∗ (hd + 1) ↦ prev ∗ (hd + 2) ↦ v ∗ IsList vs hd next) ⦄ := by
+  refine ⟨PartialOrder.rel_trans (IsList_ne_le xs prev hd hhd) ?_⟩
+  refine iSup_le _ _ fun v => iSup_le _ _ fun vs => iSup_le _ _ fun next => ?_
+  refine sepPure_sepConj_le_of _ _ _ fun hxs => ?_
+  subst hxs
   vcgen [load_spec] with (try finish)
   refine PartialOrder.rel_trans ?_
     (le_iSup_of_le v (le_iSup_of_le vs
       (le_meet _ _ _ (le_ofProp _ _ rfl) PartialOrder.rel_refl)))
   grind
 
-/-- Rewrite the back-pointer of a list head known to be non-null. -/
-theorem store_prev_IsList_ne (ys : List Nat) (qb y c : Addr) (hy : y ≠ null) :
-    ⦃ IsList ys qb y ⦄ store (y + 1) c ⦃ fun _ => IsList ys c y ⦄ := by
-  refine ⟨PartialOrder.rel_trans (IsList_ne_le ys qb y hy) ?_⟩
+/-- Overwrite the prev field of a list head known to be non-null. -/
+theorem store_prev_IsList_ne (xs : List Nat) (prev hd prev' : Addr) (hhd : hd ≠ null) :
+    ⦃ IsList xs prev hd ⦄ store (hd + 1) prev' ⦃ fun _ => IsList xs prev' hd ⦄ := by
+  refine ⟨PartialOrder.rel_trans (IsList_ne_le xs prev hd hhd) ?_⟩
   vcgen [store_spec] with finish
 
 /-! ## In-place reverse -/

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -522,11 +522,10 @@ theorem reverse_store_handoff_le (v : Nat) (rest acc : List Nat) (curr next prev
 
 /-- Discharge the append wand at the last node: rebuild the cons cell onto the relinked appended
 segment (`IsList_cons_intro` with the new next-pointer `q`) and apply the counit. -/
-@[grind ←]
 theorem append_link_le (v w : Nat) (ws : List Nat) (back curr q next : Addr) (R : HProp)
     (hcn : curr ≠ null) (hnext : next = null) :
-    (((((IsList (v :: w :: ws) back curr -∗ R) ∗ (curr + 1) ↦ back) ∗ (curr + 2) ↦ v) ∗
-          IsList [] curr next) ∗ curr ↦ q) ∗ IsList (w :: ws) curr q
+    (IsList (v :: w :: ws) back curr -∗ R) ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗
+        IsList [] curr next ∗ curr ↦ q ∗ IsList (w :: ws) curr q
       ⊑ R := by
   subst hnext
   refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_)
@@ -535,16 +534,20 @@ theorem append_link_le (v w : Nat) (ws : List Nat) (back curr q next : Addr) (R 
       (sepConj_wand_le _ R))
   grind
 
+grind_pattern append_link_le => IsList (v :: w :: ws) back curr -∗ R, curr ↦ q, IsList [] curr next
+
 /-- Absorption of `⊥` by `∗`. -/
 theorem sepConj_bot_le (X : HProp) : X ∗ (⊥ : HProp) ⊑ ⊥ := by
   intro h hh
   obtain ⟨_, h₂, _, _, _, hb⟩ := hh
   exact ((bot_le (x := (fun _ => False : HProp))) h₂ hb).elim
 
-/-- Any entailment holds when the right `∗`-factor is contradictory. -/
-theorem sepConj_le_of_right_le_bot (A : HProp) {B : HProp} (h : B ⊑ ⊥) (C : HProp) : A ∗ B ⊑ C :=
-  PartialOrder.rel_trans
-    (PartialOrder.rel_trans (sepConj_mono_right A h) (sepConj_bot_le A)) (bot_le C)
+/-- Absorb a contradictory right `∗`-factor; forward saturation climbs the `∗` spine from a
+contradictory atom to the whole precondition. -/
+theorem sepConj_le_bot_of_right (A : HProp) {B : HProp} (h : B ⊑ ⊥) : A ∗ B ⊑ ⊥ :=
+  PartialOrder.rel_trans (sepConj_mono_right A h) (sepConj_bot_le A)
+
+grind_pattern sepConj_le_bot_of_right => B ⊑ ⊥, A ∗ B
 
 /-- An empty segment pins its root to `null`. -/
 theorem IsList_nil_le_bot (curr next : Addr) (hne : next ≠ null) : IsList [] curr next ⊑ ⊥ := by
@@ -552,32 +555,27 @@ theorem IsList_nil_le_bot (curr next : Addr) (hne : next ≠ null) : IsList [] c
   rw [IsList_nil_eq] at hh
   exact (hne ((sepPure_apply _ _).mp hh).1).elim
 
+grind_pattern IsList_nil_le_bot => IsList [] curr next
+
 /-- A cons segment cannot be rooted at `null`. -/
 theorem IsList_cons_null_le_bot (v : Nat) (vs : List Nat) (back : Addr) :
     IsList (v :: vs) back null ⊑ ⊥ := by
   intro h hh
   exact ((IsList_cons_elim hh).1 rfl).elim
 
-/-- A precondition holding `IsList [] curr next` is contradictory when `next ≠ null`;
-`grind`'s AC theory for `∗` isolates the segment on the right. -/
-@[grind ←]
-theorem sepConj_IsList_nil_ne_le (A : HProp) (curr next : Addr) (hne : next ≠ null) (C : HProp) :
-    A ∗ IsList [] curr next ⊑ C :=
-  sepConj_le_of_right_le_bot A (IsList_nil_le_bot curr next hne) C
+grind_pattern IsList_cons_null_le_bot => IsList (v :: vs) back null
 
-/-- A precondition holding a cons segment rooted at `null` is contradictory;
-`grind`'s AC theory for `∗` isolates the segment on the right. -/
+/-- A contradictory precondition entails anything; the premise is closed by the facts the forward
+saturation asserts. -/
 @[grind ←]
-theorem sepConj_IsList_cons_null_le (A : HProp) (v : Nat) (vs : List Nat) (back : Addr)
-    (C : HProp) : A ∗ IsList (v :: vs) back null ⊑ C :=
-  sepConj_le_of_right_le_bot A (IsList_cons_null_le_bot v vs back) C
+theorem le_of_le_bot {X : HProp} (h : X ⊑ ⊥) (C : HProp) : X ⊑ C :=
+  PartialOrder.rel_trans h (bot_le C)
 
 /-- The append induction step: absorb the visited node into the wand (`wand_absorb` via
 `IsList_cons_intro`), matching the recursive call's precondition. -/
-@[grind ←]
 theorem append_step_le (v v' w : Nat) (rest' ws : List Nat) (back qb curr next q : Addr)
     (R : HProp) (hcn : curr ≠ null) :
-    (IsList (w :: ws) qb q ∗ (IsList (v :: v' :: (rest' ++ w :: ws)) back curr -∗ R)) ∗
+    IsList (w :: ws) qb q ∗ (IsList (v :: v' :: (rest' ++ w :: ws)) back curr -∗ R) ∗
         curr ↦ next ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗ IsList (v' :: rest') curr next
       ⊑ IsList (v' :: rest') curr next ∗ IsList (w :: ws) qb q ∗
         (IsList (v' :: rest' ++ w :: ws) curr next -∗ R) := by
@@ -594,13 +592,18 @@ theorem append_step_le (v v' w : Nat) (rest' ws : List Nat) (back qb curr next q
       (PartialOrder.rel_of_eq ?_)) <;>
     grind
 
+grind_pattern append_step_le =>
+  IsList (v :: v' :: (rest' ++ w :: ws)) back curr -∗ R, IsList (w :: ws) qb q,
+  IsList (v' :: rest') curr next
+
 /-- Rebuild a cons cell around a rewritten prev field; the loaded next-pointer is the witness. -/
-@[grind ←]
 theorem store_prev_handoff (w : Nat) (ws : List Nat) (q c n : Addr) :
-    ((q ↦ n ∗ (q + 2) ↦ w) ∗ IsList ws q n) ∗ (q + 1) ↦ c
+    q ↦ n ∗ (q + 2) ↦ w ∗ IsList ws q n ∗ (q + 1) ↦ c
       ⊑ ⨆ n', q ↦ n' ∗ (q + 1) ↦ c ∗ (q + 2) ↦ w ∗ IsList ws q n' := by
   refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_) (le_iSup _ n)
   grind
+
+grind_pattern store_prev_handoff => (q + 1) ↦ c, (q + 2) ↦ w, IsList ws q n
 
 /-- When the remaining segment is empty, `curr = null` and the accumulator is the whole result. -/
 @[grind .] theorem IsList_nil_acc_le (acc : List Nat) (curr prev : Addr) :

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -882,9 +882,9 @@ theorem store_prev_IsList_ne (xs : List Nat) (prev hd prev' : Addr) (hhd : hd �
 
 /-! ## In-place reverse -/
 
-/-- Loop invariant for `reverse` at loop state `(prev, curr)`: the unvisited segment `rest` hangs
-off `curr` with back-pointer `prev`, the reversed prefix `acc` sits at `prev` with back-pointer
-`curr`, and the remaining iteration budget `n` bounds `rest`. -/
+/-- Loop invariant for `reverse` at loop state `(prev, curr)`: the unvisited segment `rest` starts
+at `curr` preceded by `prev`, the reversed prefix `acc` starts at `prev` preceded by `curr`, and the
+remaining iteration budget `n` bounds `rest`. -/
 noncomputable abbrev ReverseLoopInv (xs : List Nat) (n : Nat) (b : Addr × Addr) : HProp :=
   ⨆ rest, ⨆ acc, ⌜rest.length ≤ n ∧ rest.reverse ++ acc = xs.reverse⌝ ⊓
     (IsList rest b.1 b.2 ∗ IsList acc b.2 b.1)
@@ -963,51 +963,51 @@ last node discharges the prefix wand and the continuation wand by the counit. -/
 
 /-- Loop invariant for `append` at loop state `(t, u)`: `t` is the last visited node with
 next-pointer `u` and some prev-pointer `pt`, the unvisited segment `rest` hangs off `u`, a wand
-absorbs the visited prefix back into the whole first list, the second list and the continuation
+absorbs the visited prefix xprev into the whole first list, the second list and the continuation
 `K` ride along untouched, and the remaining iteration budget `n` bounds `rest`. -/
-noncomputable abbrev AppendLoopInv (xs ys : List Nat) (back qb x y : Addr) (K : HProp)
+noncomputable abbrev AppendLoopInv (xs ys : List Nat) (xprev yprev x y : Addr) (K : HProp)
     (n : Nat) (b : Addr × Addr) : HProp :=
   ⨆ v, ⨆ rest, ⨆ pt,
     ⌜rest.length ≤ n ∧ b.1 ≠ null⌝ ⊓
       (b.1 ↦ b.2 ∗ (b.1 + 1) ↦ pt ∗ (b.1 + 2) ↦ v ∗ IsList rest b.1 b.2 ∗
-        (IsList (v :: rest ++ ys) pt b.1 -∗ IsList (xs ++ ys) back x) ∗
-        IsList ys qb y ∗ K)
+        (IsList (v :: rest ++ ys) pt b.1 -∗ IsList (xs ++ ys) xprev x) ∗
+        IsList ys yprev y ∗ K)
 
 /-- Enter the append loop: the head node is the visited prefix and the prefix wand is the
 identity. -/
-@[grind .] theorem append_entry_le (v : Nat) (rest xs ys : List Nat) (back qb x y u₀ : Addr)
+@[grind .] theorem append_entry_le (v : Nat) (rest xs ys : List Nat) (xprev yprev x y u₀ : Addr)
     (K : HProp) (n : Nat) (hxs : xs = v :: rest) (hx : x ≠ null) (hlen : xs.length ≤ n) :
-    (IsList ys qb y ∗ K) ∗ x ↦ u₀ ∗ (x + 1) ↦ back ∗ (x + 2) ↦ v ∗ IsList rest x u₀
-      ⊑ AppendLoopInv xs ys back qb x y K n (x, u₀) := by
+    (IsList ys yprev y ∗ K) ∗ x ↦ u₀ ∗ (x + 1) ↦ xprev ∗ (x + 2) ↦ v ∗ IsList rest x u₀
+      ⊑ AppendLoopInv xs ys xprev yprev x y K n (x, u₀) := by
   refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
-      x ↦ u₀ ∗ (x + 1) ↦ back ∗ (x + 2) ↦ v ∗ IsList rest x u₀ ∗ IsList ys qb y ∗ K)) ?_
+      x ↦ u₀ ∗ (x + 1) ↦ xprev ∗ (x + 2) ↦ v ∗ IsList rest x u₀ ∗ IsList ys yprev y ∗ K)) ?_
   · grind
-  refine le_iSup_of_le v (le_iSup_of_le rest (le_iSup_of_le back ?_))
+  refine le_iSup_of_le v (le_iSup_of_le rest (le_iSup_of_le xprev ?_))
   refine le_meet _ _ _ (le_ofProp _ _ ⟨by grind, hx⟩) ?_
   refine PartialOrder.rel_trans
-    (le_sepConj_wand_refl _ (IsList (v :: rest ++ ys) back x)) ?_
+    (le_sepConj_wand_refl _ (IsList (v :: rest ++ ys) xprev x)) ?_
   subst hxs
   exact PartialOrder.rel_of_eq (by grind)
 
 grind_pattern append_entry_le =>
-  IsList rest x u₀, (x + 1) ↦ back, (x + 2) ↦ v, IsList ys qb y,
-  IsList (xs ++ ys) back x -∗ K, xs.length ≤ n
+  IsList rest x u₀, (x + 1) ↦ xprev, (x + 2) ↦ v, IsList ys yprev y,
+  IsList (xs ++ ys) xprev x -∗ K, xs.length ≤ n
 
 /-- One append iteration: absorb the visited node into the prefix wand (`wand_absorb`) and
 re-establish the loop invariant on the rest. -/
 @[grind .] theorem append_yield_le (v w : Nat) (rest rest' xs ys : List Nat)
-    (back qb x y pt t u u' : Addr) (K : HProp) (n : Nat)
+    (xprev yprev x y pt t u u' : Addr) (K : HProp) (n : Nat)
     (ht : t ≠ null) (hu : u ≠ null) (hrest : rest = w :: rest')
     (hlen : rest.length ≤ n + 1) :
     (t ↦ u ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v ∗
-        (IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) back x) ∗ IsList ys qb y ∗ K) ∗
+        (IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) xprev x) ∗ IsList ys yprev y ∗ K) ∗
       u ↦ u' ∗ (u + 1) ↦ t ∗ (u + 2) ↦ w ∗ IsList rest' u u'
-      ⊑ AppendLoopInv xs ys back qb x y K n (u, u') := by
+      ⊑ AppendLoopInv xs ys xprev yprev x y K n (u, u') := by
   subst hrest
   refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
       t ↦ u ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v ∗ u ↦ u' ∗ (u + 1) ↦ t ∗ (u + 2) ↦ w ∗
-        IsList rest' u u' ∗ (IsList (v :: (w :: rest') ++ ys) pt t -∗ IsList (xs ++ ys) back x) ∗
-        IsList ys qb y ∗ K)) ?_
+        IsList rest' u u' ∗ (IsList (v :: (w :: rest') ++ ys) pt t -∗ IsList (xs ++ ys) xprev x) ∗
+        IsList ys yprev y ∗ K)) ?_
   · grind
   refine le_iSup_of_le w (le_iSup_of_le rest' (le_iSup_of_le t ?_))
   refine le_meet _ _ _ (le_ofProp _ _ ⟨by grind, hu⟩) ?_
@@ -1017,25 +1017,25 @@ re-establish the loop invariant on the rest. -/
       (IsList_cons_intro v u pt ((w :: rest') ++ ys) t ht)
     grind
   refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
-      (u ↦ u' ∗ (u + 1) ↦ t ∗ (u + 2) ↦ w ∗ IsList rest' u u' ∗ IsList ys qb y ∗ K) ∗
+      (u ↦ u' ∗ (u + 1) ↦ t ∗ (u + 2) ↦ w ∗ IsList rest' u u' ∗ IsList ys yprev y ∗ K) ∗
         ((t ↦ u ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v) ∗
-          (IsList (v :: (w :: rest') ++ ys) pt t -∗ IsList (xs ++ ys) back x)))) ?_
+          (IsList (v :: (w :: rest') ++ ys) pt t -∗ IsList (xs ++ ys) xprev x)))) ?_
   · grind
   · refine PartialOrder.rel_trans (sepConj_mono_right _ (wand_absorb habs)) ?_
     exact PartialOrder.rel_of_eq (by grind)
 
 /-- Break out of the append loop: `u = null` forces the unvisited segment empty, so the invariant
 holds at the exhausted budget. -/
-@[grind .] theorem append_done_le (v : Nat) (rest xs ys : List Nat) (back qb x y pt t u : Addr)
+@[grind .] theorem append_done_le (v : Nat) (rest xs ys : List Nat) (xprev yprev x y pt t u : Addr)
     (K : HProp) (ht : t ≠ null) (hu : u = null) :
     t ↦ u ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v ∗ IsList rest t u ∗
-        (IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) back x) ∗ IsList ys qb y ∗ K
-      ⊑ AppendLoopInv xs ys back qb x y K ([] : List Nat).length (t, u) := by
+        (IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) xprev x) ∗ IsList ys yprev y ∗ K
+      ⊑ AppendLoopInv xs ys xprev yprev x y K ([] : List Nat).length (t, u) := by
   subst hu
   rw [IsList_null_eq]
   refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
       sepPure (rest = []) ∗ (t ↦ null ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v ∗
-        (IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) back x) ∗ IsList ys qb y ∗ K))) ?_
+        (IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) xprev x) ∗ IsList ys yprev y ∗ K))) ?_
   · grind
   refine sepPure_sepConj_le_of _ _ _ fun hrest => ?_
   subst hrest
@@ -1047,11 +1047,11 @@ holds at the exhausted budget. -/
 
 /-- Discharge both wands at the last node: rebuild the cons cell onto the relinked second list,
 apply the prefix wand's counit, then the continuation wand's. -/
-@[grind .] theorem append_link_le (v : Nat) (rest xs ys : List Nat) (back x y pt t u : Addr)
+@[grind .] theorem append_link_le (v : Nat) (rest xs ys : List Nat) (xprev x y pt t u : Addr)
     (K : HProp) (ht : t ≠ null) (hlen : rest.length ≤ 0) :
     ((t + 1) ↦ pt ∗ (t + 2) ↦ v ∗ IsList rest t u ∗
-        (IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) back x) ∗
-        (IsList (xs ++ ys) back x -∗ K) ∗ t ↦ y) ∗
+        (IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) xprev x) ∗
+        (IsList (xs ++ ys) xprev x -∗ K) ∗ t ↦ y) ∗
       IsList ys t y
       ⊑ K := by
   have hrest : rest = [] := by grind
@@ -1059,14 +1059,14 @@ apply the prefix wand's counit, then the continuation wand's. -/
   rw [IsList_nil_eq]
   refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
       sepPure (u = null) ∗ (t ↦ y ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v ∗
-        (IsList (v :: [] ++ ys) pt t -∗ IsList (xs ++ ys) back x) ∗ IsList ys t y ∗
-        (IsList (xs ++ ys) back x -∗ K)))) ?_
+        (IsList (v :: [] ++ ys) pt t -∗ IsList (xs ++ ys) xprev x) ∗ IsList ys t y ∗
+        (IsList (xs ++ ys) xprev x -∗ K)))) ?_
   · grind
   refine sepPure_sepConj_le_of _ _ _ fun _hu => ?_
   refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
       ((t ↦ y ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v ∗ IsList ys t y) ∗
-        (IsList (v :: [] ++ ys) pt t -∗ IsList (xs ++ ys) back x)) ∗
-      (IsList (xs ++ ys) back x -∗ K))) ?_
+        (IsList (v :: [] ++ ys) pt t -∗ IsList (xs ++ ys) xprev x)) ∗
+      (IsList (xs ++ ys) xprev x -∗ K))) ?_
   · grind
   · refine PartialOrder.rel_trans
       (sepConj_mono_left _ (PartialOrder.rel_trans
@@ -1076,17 +1076,17 @@ apply the prefix wand's counit, then the continuation wand's. -/
 
 grind_pattern append_link_le =>
   (t + 1) ↦ pt, (t + 2) ↦ v, IsList rest t u,
-  IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) back x,
-  IsList (xs ++ ys) back x -∗ K, IsList ys t y, t ↦ y
+  IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) xprev x,
+  IsList (xs ++ ys) xprev x -∗ K, IsList ys t y, t ↦ y
 
 /-- The `y = null` link: the second list is empty, and storing `null` into the last node's next
 field leaves the first list intact. -/
 @[grind .] theorem append_link_null_le (v : Nat) (rest xs ys : List Nat)
-    (back qb x y pt t u : Addr) (K : HProp)
+    (xprev yprev x y pt t u : Addr) (K : HProp)
     (ht : t ≠ null) (hlen : rest.length ≤ 0) (hy : y = null) :
     ((t + 1) ↦ pt ∗ (t + 2) ↦ v ∗ IsList rest t u ∗
-        (IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) back x) ∗ IsList ys qb y ∗
-        (IsList (xs ++ ys) back x -∗ K)) ∗ t ↦ y
+        (IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) xprev x) ∗ IsList ys yprev y ∗
+        (IsList (xs ++ ys) xprev x -∗ K)) ∗ t ↦ y
       ⊑ K := by
   have hrest : rest = [] := by grind
   subst hrest
@@ -1094,15 +1094,15 @@ field leaves the first list intact. -/
   rw [IsList_nil_eq, IsList_null_eq]
   refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
       sepPure (u = null) ∗ sepPure (ys = []) ∗ (t ↦ null ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v ∗
-        (IsList (v :: [] ++ ys) pt t -∗ IsList (xs ++ ys) back x) ∗
-        (IsList (xs ++ ys) back x -∗ K)))) ?_
+        (IsList (v :: [] ++ ys) pt t -∗ IsList (xs ++ ys) xprev x) ∗
+        (IsList (xs ++ ys) xprev x -∗ K)))) ?_
   · grind
   refine sepPure_sepConj_le_of _ _ _ fun _hu => sepPure_sepConj_le_of _ _ _ fun hys => ?_
   subst hys
   refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
       ((t ↦ null ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v ∗ IsList [] t null) ∗
-        (IsList (v :: [] ++ []) pt t -∗ IsList (xs ++ []) back x)) ∗
-      (IsList (xs ++ []) back x -∗ K))) ?_
+        (IsList (v :: [] ++ []) pt t -∗ IsList (xs ++ []) xprev x)) ∗
+      (IsList (xs ++ []) xprev x -∗ K))) ?_
   · grind
   · refine PartialOrder.rel_trans
       (sepConj_mono_left _ (PartialOrder.rel_trans
@@ -1112,56 +1112,56 @@ field leaves the first list intact. -/
 
 grind_pattern append_link_null_le =>
   (t + 1) ↦ pt, (t + 2) ↦ v, IsList rest t u,
-  IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) back x,
-  IsList (xs ++ ys) back x -∗ K, IsList ys qb y, t ↦ y
+  IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) xprev x,
+  IsList (xs ++ ys) xprev x -∗ K, IsList ys yprev y, t ↦ y
 
 /-- The empty-first-list branch: the continuation receives the second list unchanged. -/
-@[grind .] theorem append_nil_le (xs ys : List Nat) (back qb y : Addr) (K : HProp) :
-    IsList xs back null ∗ IsList ys qb y ∗ (IsList (xs ++ ys) qb y -∗ K)
+@[grind .] theorem append_nil_le (xs ys : List Nat) (xprev yprev y : Addr) (K : HProp) :
+    IsList xs xprev null ∗ IsList ys yprev y ∗ (IsList (xs ++ ys) yprev y -∗ K)
       ⊑ K := by
   rw [IsList_null_eq]
   refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
-      sepPure (xs = []) ∗ (IsList ys qb y ∗ (IsList (xs ++ ys) qb y -∗ K)))) ?_
+      sepPure (xs = []) ∗ (IsList ys yprev y ∗ (IsList (xs ++ ys) yprev y -∗ K)))) ?_
   · grind
   · refine sepPure_sepConj_le_of _ _ _ fun hxs => ?_
     subst hxs
     exact sepConj_wand_le _ _
 
 /-- Ramified append specification: the schematic postcondition `Q` is received through a wand at
-the known result and back-pointer. -/
-theorem append_spec (fuel : Nat) (xs ys : List Nat) (back qb x y : Addr) (Q : Addr → HProp)
+the returned head and the node preceding it. -/
+theorem append_spec (fuel : Nat) (xs ys : List Nat) (xprev yprev x y : Addr) (Q : Addr → HProp)
     (hle : xs.length ≤ fuel) :
-    ⦃ IsList xs back x ∗ IsList ys qb y ∗
-        (IsList (xs ++ ys) (if x = null then qb else back) (if x = null then y else x) -∗
+    ⦃ IsList xs xprev x ∗ IsList ys yprev y ∗
+        (IsList (xs ++ ys) (if x = null then yprev else xprev) (if x = null then y else x) -∗
           Q (if x = null then y else x)) ⦄
       append fuel x y
     ⦃ Q ⦄ := by
   by_cases hx : x = null
   · subst hx
-    have hb : (if null = null then qb else back) = qb := by grind
+    have hb : (if null = null then yprev else xprev) = yprev := by grind
     have hr : (if null = null then y else null) = y := by grind
     rw [hb, hr]
     simp only [append, reduceIte]
     vcgen with finish
-  · have hb : (if x = null then qb else back) = back := by grind
+  · have hb : (if x = null then yprev else xprev) = xprev := by grind
     have hr : (if x = null then y else x) = x := by grind
     rw [hb, hr]
     have hlen' : xs.length ≤ (ForIn.toList [:fuel]).length := by grind
     vcgen [append, load_next_IsList_ne, store_prev_IsList_ne] invariants
       | inv1 => fun _ suff b =>
-          AppendLoopInv xs ys back qb x y (IsList (xs ++ ys) back x -∗ Q x) suff.length b
+          AppendLoopInv xs ys xprev yprev x y (IsList (xs ++ ys) xprev x -∗ Q x) suff.length b
       with finish
 
 /-- Plain append specification, from `append_spec` at the trivial continuation. -/
-@[spec] theorem append_concat (xs ys : List Nat) (back qb x y : Addr) :
-    ⦃ IsList xs back x ∗ IsList ys qb y ⦄
+@[spec] theorem append_concat (xs ys : List Nat) (xprev yprev x y : Addr) :
+    ⦃ IsList xs xprev x ∗ IsList ys yprev y ⦄
       append xs.length x y
-    ⦃ fun r => IsList (xs ++ ys) (if x = null then qb else back) r ⦄ := by
+    ⦃ fun r => IsList (xs ++ ys) (if x = null then yprev else xprev) r ⦄ := by
   vcgen [append_spec] with finish
 
 /-- Framing an unrelated cell across the whole append. -/
-example (l : Addr) (z : Nat) (xs ys : List Nat) (back qb x y : Addr) :
-    ⦃ l ↦ z ∗ IsList xs back x ∗ IsList ys qb y ⦄
+example (l : Addr) (z : Nat) (xs ys : List Nat) (xprev yprev x y : Addr) :
+    ⦃ l ↦ z ∗ IsList xs xprev x ∗ IsList ys yprev y ⦄
       append xs.length x y
-    ⦃ fun r => l ↦ z ∗ IsList (xs ++ ys) (if x = null then qb else back) r ⦄ := by
+    ⦃ fun r => l ↦ z ∗ IsList (xs ++ ys) (if x = null then yprev else xprev) r ⦄ := by
   vcgen [append_concat] with finish

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -456,7 +456,6 @@ theorem le_sepConj_wand_refl₂ (X Y A : HProp) : X ∗ Y ⊑ X ∗ Y ∗ (A -�
     (PartialOrder.rel_of_eq (sepConj_assoc X Y (A -∗ A)))
 
 /-- Attach the trivial wand at an `emp`-framed residual post. -/
-@[grind ←]
 theorem le_sepConj_wand_emp_wand_refl (X A : HProp) : X ⊑ X ∗ (A -∗ (emp -∗ A)) :=
   PartialOrder.rel_trans (PartialOrder.rel_of_eq (sepConj_emp X).symm)
     (sepConj_mono_right X (le_wand A emp (emp -∗ A)
@@ -726,11 +725,24 @@ def mkEmpFrameSplit (i : FrameInferenceInfo) (matched : Array Expr) (wandAtom : 
   let empFoot ← mkAppNS sepConjE #[empE, footprint]
   let empRes ← mkAppNS sepConjE #[empE, mkMVar residualPre]
   let sub1 ← mkFreshExprSyntheticOpaqueMVar (← mkAppNS le #[footprint, mkMVar residualPre])
-  let sub2 ← mkFreshExprSyntheticOpaqueMVar (← mkAppNS le #[← i.pre, empFoot])
   let mono ← mkAppNS (← mkConstS ``sepConj_mono_right) #[empE, footprint, mkMVar residualPre, sub1]
   let args := le.getAppArgs
-  let proof ← mkAppNS (← mkConstS ``PartialOrder.rel_trans le.getAppFn.constLevels!)
-    #[args[0]!, args[1]!, ← i.pre, empFoot, empRes, sub2, mono]
+  let relTrans ← mkConstS ``PartialOrder.rel_trans le.getAppFn.constLevels!
+  let mkTrans (x y z h₁ h₂ : Expr) : SymM Expr :=
+    mkAppNS relTrans #[args[0]!, args[1]!, x, y, z, h₁, h₂]
+  let pre ← i.pre
+  -- A trivial continuation (the wand's argument is the residual post itself) discharges
+  -- `pre ⊑ emp ∗ footprint` in place: attach the trivial wand, then reassociate.
+  let G := sepConjG.appArg!
+  if isSameExpr G b then
+    let preW ← mkAppNS sepConjE #[pre, wrapped]
+    if let some q3 ← proveSepConjLe preW empFoot then
+      let q2 ← mkAppNS (← mkConstS ``le_sepConj_wand_emp_wand_refl) #[pre, G]
+      let toFoot ← mkTrans pre preW empFoot q2 q3
+      let proof ← mkTrans pre empFoot empRes toFoot mono
+      return some (FrameSplit.withDischargedSplitVC empE residualPre proof [sub1.mvarId!])
+  let sub2 ← mkFreshExprSyntheticOpaqueMVar (← mkAppNS le #[pre, empFoot])
+  let proof ← mkTrans pre empFoot empRes sub2 mono
   return some (FrameSplit.withDischargedSplitVC empE residualPre proof
     [sub2.mvarId!, sub1.mvarId!])
 

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -11,7 +11,7 @@ set_option mvcgen.warning false
 set_option grind.warning false
 
 /-!
-# A minimal separation logic for `vcgen` frame inference, with in-place list reverse
+# A minimal separation logic for `vcgen` frame inference, with in-place list reverse and append
 
 A heap `Heap := Addr → Option Nat` with separating conjunction `∗` (disjoint union), magic wand `-∗`,
 and points-to `↦`. Unlike the lattice meet, `∗` is not cartesian: `l ↦ v ∗ l ↦ v = ⊥`. The frame
@@ -26,10 +26,15 @@ stores next at `p`, prev at `p + 1`, and the payload at `p + 2`. The abstract co
 so the list is ghost state in the specification. Framing an unrelated cell across the whole
 reverse is the `iFrame` moment at program scale.
 
-A second showcase is an in-place append with its specification carried as a wand (SF Verifiable C,
-"Magic wand, partial data structure"): the traversal absorbs each visited node into the wand
-(`wand_absorb`), the wand rides the frame through every call, and linking the last node discharges
-it by the counit of the `∗ ⊣ -∗` adjunction.
+A second showcase is an in-place append after the C original in SF Verifiable C ("Magic wand,
+partial data structure"): a loop walks to the last node, its invariant carrying the visited prefix
+in a wand. Each iteration absorbs a node into the wand (`wand_absorb`), and linking the last node
+discharges it by the counit of the `∗ ⊣ -∗` adjunction. The specification is ramified: the
+schematic post `Q` is received through a second wand at the known result, so `append_concat`
+follows by direct application.
+
+Both programs are fuel-bounded `for` loops, verified against `Spec.forIn_range` with explicitly
+instantiated loop invariants.
 
 The file is laid out reusable-first: the programs, then the separation logic, then the derived
 lemmas, then the `@[frameproc]`, then the specifications.
@@ -138,36 +143,40 @@ def load (l : Addr) : HeapM Nat :=
 def store (l : Addr) (w : Nat) : HeapM Unit :=
   HeapM.mk <| modifyGet fun h => ((), h.update l w)
 
-/-- Fuel-bounded reverse accumulator: only pointers in the program. At each cons cell, swap the
-next/prev links (`next := prev`, `prev := old next`). `fuel` bounds the remaining spine length. -/
-def reverse.go (fuel : Nat) (curr prev : Addr) : HeapM Addr :=
-  match fuel with
-  | 0 => pure prev
-  | fuel + 1 => do
+/-- In-place reverse: walk the spine, swapping each node's next/prev links (`next := prev`,
+`prev := old next`). The loop is fuel-bounded; `xs.length` iterations suffice. -/
+def reverse (fuel : Nat) (head : Addr) : HeapM Addr := do
+  let mut prev := null
+  let mut curr := head
+  for _ in [0:fuel] do
     if curr = null then
-      pure prev
-    else
-      let next ← load curr
-      store curr prev
-      store (curr + 1) next
-      reverse.go fuel next curr
-
-/-- In-place reverse with fuel `xs.length` in the specification. -/
-def reverse (fuel : Nat) (head : Addr) : HeapM Addr :=
-  reverse.go fuel head null
-
-/-- Fuel-bounded in-place append: walk to the last node of the list at `curr`, link its next
-pointer to `q`, and point `q`'s prev field back at it. -/
-def append (fuel : Nat) (curr q : Addr) : HeapM Unit :=
-  match fuel with
-  | 0 => pure ()
-  | fuel + 1 => do
+      break
     let next ← load curr
-    if next = null then
-      store curr q
-      store (q + 1) curr
-    else
-      append fuel next q
+    store curr prev
+    store (curr + 1) next
+    prev := curr
+    curr := next
+  pure prev
+
+/-- In-place append, after the C original in SF Verifiable C: return the second list if the first
+is empty; otherwise walk `t`/`u` to the last node of the first list, link it to `y`, point `y`'s
+prev field back at it, and return the first list's head. The loop is fuel-bounded; `xs.length`
+iterations suffice. -/
+def append (fuel : Nat) (x y : Addr) : HeapM Addr := do
+  if x = null then
+    pure y
+  else
+    let mut t := x
+    let mut u ← load t
+    for _ in [0:fuel] do
+      if u = null then
+        break
+      t := u
+      u ← load t
+    store t y
+    if y ≠ null then
+      store (y + 1) t
+    pure x
 
 /-! # The separation logic
 
@@ -517,6 +526,18 @@ theorem IsList_cons_intro (v : Nat) (n back : Addr) (vs : List Nat) (p : Addr) (
   intro h hh
   exact (ofProp_meet_apply _ _ _).mpr ⟨hp, (iSup_hprop_apply _ _).mpr ⟨n, hh⟩⟩
 
+/-- A segment rooted at `null` is empty. -/
+@[grind =] theorem IsList_null_eq (rest : List Nat) (back : Addr) :
+    IsList rest back null = sepPure (rest = []) := by
+  cases rest with
+  | nil => simp [IsList_nil_eq]
+  | cons v vs =>
+    refine PartialOrder.rel_antisymm ?_ ?_
+    · intro h hh
+      exact ((IsList_cons_elim hh).1 rfl).elim
+    · intro h hh
+      exact absurd ((sepPure_apply _ _).mp hh).1 (by simp)
+
 /-- After rewriting next and prev, rebuild the cons cell onto the accumulator; the `curr ≠ null`
 guard reaches the context through precondition normalization, and `grind`'s AC theory for `∗`
 matches the statement against the association the framed `store`s leave in the VC. -/
@@ -533,22 +554,6 @@ theorem reverse_store_handoff_le (v : Nat) (rest acc : List Nat) (curr next prev
     grind
   rw [heq]
   exact sepConj_mono_right _ (IsList_cons_intro v prev next acc curr hpne)
-
-/-- Discharge the append wand at the last node: rebuild the cons cell onto the relinked appended
-segment (`IsList_cons_intro` with the new next-pointer `q`) and apply the counit. -/
-theorem append_link_le (v w : Nat) (ws : List Nat) (back curr q next : Addr) (R : HProp)
-    (hcn : curr ≠ null) (hnext : next = null) :
-    (IsList (v :: w :: ws) back curr -∗ R) ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗
-        IsList [] curr next ∗ curr ↦ q ∗ IsList (w :: ws) curr q
-      ⊑ R := by
-  subst hnext
-  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_)
-    (PartialOrder.rel_trans
-      (sepConj_mono_left _ (IsList_cons_intro v q back (w :: ws) curr hcn))
-      (sepConj_wand_le _ R))
-  grind
-
-grind_pattern append_link_le => IsList (v :: w :: ws) back curr -∗ R, curr ↦ q, IsList [] curr next
 
 /-- Absorption of `⊥` by `∗`. -/
 theorem sepConj_bot_le (X : HProp) : X ∗ (⊥ : HProp) ⊑ ⊥ := by
@@ -584,47 +589,6 @@ saturation asserts. -/
 @[grind ←]
 theorem le_of_le_bot {X : HProp} (h : X ⊑ ⊥) (C : HProp) : X ⊑ C :=
   PartialOrder.rel_trans h (bot_le C)
-
-/-- The append induction step: absorb the visited node into the wand (`wand_absorb` via
-`IsList_cons_intro`), matching the recursive call's precondition. -/
-theorem append_step_le (v v' w : Nat) (rest' ws : List Nat) (back qb curr next q : Addr)
-    (R : HProp) (hcn : curr ≠ null) :
-    IsList (w :: ws) qb q ∗ (IsList (v :: v' :: (rest' ++ w :: ws)) back curr -∗ R) ∗
-        curr ↦ next ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗ IsList (v' :: rest') curr next
-      ⊑ IsList (v' :: rest') curr next ∗ IsList (w :: ws) qb q ∗
-        (IsList (v' :: rest' ++ w :: ws) curr next -∗ R) := by
-  have habs : IsList (v' :: rest' ++ w :: ws) curr next ∗
-        curr ↦ next ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v
-      ⊑ IsList (v :: v' :: (rest' ++ w :: ws)) back curr := by
-    refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_)
-      (IsList_cons_intro v next back (v' :: (rest' ++ w :: ws)) curr hcn)
-    grind
-  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_)
-    (PartialOrder.rel_trans
-      (sepConj_mono_right (IsList (v' :: rest') curr next ∗ IsList (w :: ws) qb q)
-        (wand_absorb (G := R) habs))
-      (PartialOrder.rel_of_eq ?_)) <;>
-    grind
-
-grind_pattern append_step_le =>
-  IsList (v :: v' :: (rest' ++ w :: ws)) back curr -∗ R, IsList (w :: ws) qb q,
-  IsList (v' :: rest') curr next
-
-/-- Rebuild a cons cell around a rewritten prev field; the loaded next-pointer is the witness. -/
-theorem store_prev_handoff (w : Nat) (ws : List Nat) (q c n : Addr) :
-    q ↦ n ∗ (q + 2) ↦ w ∗ IsList ws q n ∗ (q + 1) ↦ c
-      ⊑ ⨆ n', q ↦ n' ∗ (q + 1) ↦ c ∗ (q + 2) ↦ w ∗ IsList ws q n' := by
-  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_) (le_iSup _ n)
-  grind
-
-grind_pattern store_prev_handoff => (q + 1) ↦ c, (q + 2) ↦ w, IsList ws q n
-
-/-- When the remaining segment is empty, `curr = null` and the accumulator is the whole result. -/
-@[grind .] theorem IsList_nil_acc_le (acc : List Nat) (curr prev : Addr) :
-    (sepPure (curr = null) ∗ IsList acc curr prev) ⊑ IsList acc null prev := by
-  intro h hh
-  have ⟨rfl, hacc⟩ := (sepPure_sepConj_iff (curr = null) (IsList acc curr prev) h).mp hh
-  exact hacc
 
 @[grind =] theorem IsList_append_nil (xs : List Nat) (back r : Addr) :
     IsList (xs ++ ([] : List Nat)) back r = IsList xs back r := by
@@ -710,29 +674,30 @@ def mkSepFrameSplit (i : FrameInferenceInfo) (frame footprint : Expr) : SymM Fra
     return FrameSplit.withDischargedSplitVC frame residualPre proof [sub.mvarId!]
 
 /-- Frame `emp` for a *ramified* spec: a spec with schematic postcondition `Q` that auto-frames by
-receiving `Q` through a wand in its precondition, `⦃ P ∗ (G -∗ Q ⟨⟩) ⦄ x ⦃ Q ⦄`. The goal
-precondition has no wand atom, so such a spec never matches outright.
+receiving `Q` through a wand in its precondition, `⦃ P ∗ (G -∗ Q r₀) ⦄ x ⦃ Q ⦄` with `r₀` the
+spec's known result. The goal precondition has no wand atom, so such a spec never matches
+outright.
 
-Worked example: goal `A ∗ B ⊑ wp (append n curr q) Q` against the ramified append spec, whose
-precondition is `?A ∗ ?B ∗ (?G -∗ Q ⟨⟩)` after the schematic post unifies.
-- `matchSepAtoms` pairs `?A`/`?B` with `A`/`B`, committing the assignments (which also pin `?G`),
-  and reports the wand `G -∗ Q ⟨⟩` unmatched; it arrives here as `wandAtom`.
+Worked example: goal `A ∗ B ⊑ wp (append fuel x y) Q` against `append_spec`, whose precondition
+is `?A ∗ ?B ∗ (?G -∗ Q ?r₀)` after the schematic post unifies.
+- `matchSepAtoms` pairs `?A`/`?B` with `A`/`B`, committing the assignments (which also pin `?G`
+  and `?r₀`), and reports the wand `G -∗ Q r₀` unmatched; it arrives here as `wandAtom`.
 - The `footprint` mirrors the spec precondition at the `emp`-framed residual post:
-  `A ∗ B ∗ (G -∗ (emp -∗ Q ⟨⟩))`.
+  `A ∗ B ∗ (G -∗ (emp -∗ Q r₀))`.
 - The split VC `A ∗ B ⊑ emp ∗ residualPre` is discharged as
   `rel_trans (rel_trans q₂ q₃) (sepConj_mono_right sub₁)`:
   `q₂ : A ∗ B ⊑ (A ∗ B) ∗ (G -∗ (emp -∗ G))` attaches the trivial wand
-  (`le_sepConj_wand_emp_wand_refl`; valid because `G` is the post at `⟨⟩`),
+  (`le_sepConj_wand_emp_wand_refl`; valid because `G` is the post at `r₀`),
   `q₃` reassociates and inserts `emp` (AC with identity), and
   `sub₁ : footprint ⊑ residualPre` is the sole surviving subgoal.
 - The solver fills `residualPre` with the residual weakest precondition, whose post is the
   `emp`-framed `fun a => emp -∗ Q a`. On `sub₁` the spec applies directly, and its precondition VC
   pits the footprint against the spec precondition at that same post: the same term up to the
   spec's schematics, so it closes by unification, pinning the schematics to the goal's values.
-- What remains for the user: the spec's side premises (for append, `rest.length < fuel`) and the
+- What remains for the user: the spec's side premises (for append, `xs.length ≤ fuel`) and the
   `WP.Frames` condition for `emp`, both closed by `finish`.
 
-A wand whose argument differs from the post at `⟨⟩` leaves `pre ⊑ emp ∗ footprint` as a second
+A wand whose argument differs from the post at `r₀` leaves `pre ⊑ emp ∗ footprint` as a second
 subgoal in place of `q₂`/`q₃`. -/
 def mkEmpFrameSplit (i : FrameInferenceInfo) (matched : Array Expr) (wandAtom : Expr) :
     SymM (Option FrameSplit) := do
@@ -782,7 +747,7 @@ are cancelled from the goal precondition's, and the leftover atoms are the frame
 precondition `l1 ↦ a ∗ l2 ↦ b` against `store_spec`'s `?l ↦ ?v` cancels `l1 ↦ a` (pinning
 `?l := l1`, `?v := a`), frames `l2 ↦ b`, and proves the split VC by AC-rearrangement. A pinned
 `frames` resource cancels its own atoms instead, leaving the split VC open when they are missing.
-A spec whose only uncancelled atom is a wand `?G -∗ Q ⟨⟩` is ramified and goes to
+A spec whose only uncancelled atom is a wand `?G -∗ Q ?r₀` is ramified and goes to
 `mkEmpFrameSplit`. -/
 def sepConjFrameProc : FrameInferenceProc := fun i => do
   -- Exercises `FrameInferenceInfo.spec?`: a real frameproc keys a footprint off the applied spec's
@@ -859,67 +824,93 @@ example (l1 l2 : Addr) (a b : Nat) :
 
 /-! ## In-place reverse -/
 
-/-- Load the next-pointer of a cons cell; the loaded value is the `IsList` witness.
-Higher priority than `load_spec` so `vcgen` prefers the `IsList`-shaped precondition. -/
-@[spec high] theorem load_next_IsList (v : Nat) (vs : List Nat) (back curr : Addr) :
-    ⦃ IsList (v :: vs) back curr ⦄
+/-- Load the next-pointer of a list node known to be non-null: the segment must then be a cons,
+and the loaded value is its `IsList` witness. The shape hypothesis reaches `finish` from the
+branch condition in scope. -/
+theorem load_next_IsList_ne (rest : List Nat) (back curr : Addr) (hcn : curr ≠ null) :
+    ⦃ IsList rest back curr ⦄
       load curr
-    ⦃ fun next =>
-        ⌜curr ≠ null⌝ ⊓
-          (curr ↦ next ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗ IsList vs curr next) ⦄ := by
-  simp only [IsList_cons_eq]
-  vcgen [load_spec] with finish
+    ⦃ fun next => ⨆ v, ⨆ vs, ⌜rest = v :: vs⌝ ⊓
+        (curr ↦ next ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗ IsList vs curr next) ⦄ := by
+  match rest with
+  | [] =>
+    exact ⟨PartialOrder.rel_trans (IsList_nil_le_bot back curr hcn)
+      (PartialOrder.rel_trans (bot_le _) (HeapM.triple_of_bot_pre (Q := _) (load curr)).le_wp)⟩
+  | v :: vs =>
+    simp only [IsList_cons_eq]
+    vcgen [load_spec] with (try finish)
+    refine PartialOrder.rel_trans ?_
+      (le_iSup_of_le v (le_iSup_of_le vs
+        (le_meet _ _ _ (le_ofProp _ _ rfl) PartialOrder.rel_refl)))
+    grind
 
-/-- Accumulator specification — both induction cases are `vcgen` scripts.
-Pre: remaining segment `xs` at `curr` with back-pointer `prev`, plus reversed segment `ys` at `prev`
-with back-pointer `curr`. -/
-@[spec] theorem reverse.go_spec (fuel : Nat) (rest acc : List Nat) (curr prev : Addr)
-    (hle : rest.length ≤ fuel) :
-    ⦃ IsList rest prev curr ∗ IsList acc curr prev ⦄
-      reverse.go fuel curr prev
-    ⦃ fun r => IsList (rest.reverse ++ acc) null r ⦄ := by
-  induction rest generalizing fuel curr prev acc with
-  | nil =>
-    cases fuel with
-    | zero =>
-      simp only [reverse.go, IsList_nil_eq, List.reverse_nil, List.nil_append]
-      vcgen with (try finish; try (exact IsList_nil_acc_le _ _ _))
-    | succ fuel =>
-      simp only [reverse.go, IsList_nil_eq, List.reverse_nil, List.nil_append]
-      -- `go` still branches on `curr = null`; the `≠` arm is absurd under `IsList []`.
-      split
-      · vcgen with (try finish; try (exact IsList_nil_acc_le _ _ _))
-      · rename_i hne
-        constructor
-        intro h hh
-        have ⟨hc, _⟩ :=
-          (sepPure_sepConj_iff (curr = null) (IsList acc curr prev) h).mp hh
-        exact (hne hc).elim
-  | cons v rest ih =>
-    match fuel, hle with
-    | 0, hle =>
-      simp at hle
-    | fuel + 1, hle =>
-      simp only [reverse.go, List.reverse_cons, List.append_assoc, List.singleton_append,
-        List.length_cons] at hle ⊢
-      -- `go` branches on `curr = null`; the `=` arm is absurd under `IsList (v :: rest)`.
-      split
-      · rename_i hc
-        constructor
-        intro h hh
-        obtain ⟨h₁, _, _, _, hl, _⟩ := hh
-        exact ((IsList_cons_elim hl).1 hc).elim
-      · -- Prefer `load_next_IsList`; IH after `generalizing` is `fuel acc curr prev`.
-        vcgen [-load_spec, load_next_IsList, store_spec,
-          fun next => ih fuel (v :: acc) next curr (Nat.le_of_succ_le_succ hle)] with
-          (try finish; try (exact reverse_store_handoff_le _ _ _ _ _ _))
+/-- Loop invariant for `reverse` at loop state `(prev, curr)`: the unvisited segment `rest` hangs
+off `curr` with back-pointer `prev`, the reversed prefix `acc` sits at `prev` with back-pointer
+`curr`, and the remaining iteration budget `n` bounds `rest`. -/
+noncomputable abbrev reverseLoopInv (xs : List Nat) (n : Nat) (b : Addr × Addr) : HProp :=
+  ⨆ rest, ⨆ acc, ⌜rest.length ≤ n ∧ rest.reverse ++ acc = xs.reverse⌝ ⊓
+    (IsList rest b.1 b.2 ∗ IsList acc b.2 b.1)
 
-@[spec] theorem reverse_spec (xs : List Nat) (head : Addr) :
-    ⦃ IsList xs null head ⦄ reverse xs.length head ⦃ fun r => IsList xs.reverse null r ⦄ := by
-  simp only [reverse]
-  -- Pin `ys`/`prev` via an explicit accumulator instance of the schematic `@[spec]`.
-  vcgen [-reverse.go_spec, reverse.go_spec xs.length xs [] head null (Nat.le_refl _)] with
-    (try finish; try (simp [IsList_nil_null, sepConj_emp, IsList_append_nil]; finish))
+/-- Enter the reverse loop: the whole list is unvisited and the accumulator is empty. -/
+@[grind .] theorem reverse_entry_le (xs : List Nat) (n : Nat) (head : Addr)
+    (hle : xs.length ≤ n) :
+    IsList xs null head ⊑ reverseLoopInv xs n (null, head) := by
+  refine le_iSup_of_le xs (le_iSup_of_le [] ?_)
+  refine le_meet _ _ _ (le_ofProp _ _ ⟨hle, by simp⟩) ?_
+  show IsList xs null head ⊑ IsList xs null head ∗ IsList [] head null
+  exact PartialOrder.rel_of_eq (by rw [IsList_nil_null, sepConj_emp])
+
+/-- One reverse iteration: rebuild the visited cons cell onto the accumulator
+(`reverse_store_handoff_le`) and re-establish the loop invariant on the rest. -/
+@[grind .] theorem reverse_yield_le (xs vs acc : List Nat) (v : Nat) (n : Nat)
+    (prev curr next : Addr) (hcn : curr ≠ null) (hlen : (v :: vs).length ≤ n + 1)
+    (hrev : (v :: vs).reverse ++ acc = xs.reverse) :
+    (IsList acc curr prev ∗ (curr + 2) ↦ v ∗ IsList vs curr next ∗ curr ↦ prev) ∗
+      (curr + 1) ↦ next
+      ⊑ reverseLoopInv xs n (curr, next) := by
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
+      IsList acc curr prev ∗ IsList vs curr next ∗ curr ↦ prev ∗ (curr + 1) ↦ next ∗
+        (curr + 2) ↦ v)) ?_
+  · grind
+  refine PartialOrder.rel_trans (reverse_store_handoff_le v vs acc curr next prev hcn) ?_
+  refine le_iSup_of_le vs (le_iSup_of_le (v :: acc) ?_)
+  refine le_meet _ _ _ (le_ofProp _ _ ⟨by grind, by grind⟩) PartialOrder.rel_refl
+
+/-- Break out of the reverse loop: `curr = null` forces the unvisited segment empty, so the
+invariant holds at any remaining budget. -/
+@[grind .] theorem reverse_done_le (xs rest acc : List Nat) (prev curr : Addr)
+    (hcn : curr = null) (hrev : rest.reverse ++ acc = xs.reverse) :
+    IsList rest prev curr ∗ IsList acc curr prev
+      ⊑ reverseLoopInv xs ([] : List Nat).length (prev, curr) := by
+  subst hcn
+  rw [IsList_null_eq]
+  refine sepPure_sepConj_le_of _ _ _ fun hrest => ?_
+  subst hrest
+  refine le_iSup_of_le [] (le_iSup_of_le acc ?_)
+  refine le_meet _ _ _ (le_ofProp _ _ ⟨by simp, by simpa using hrev⟩) ?_
+  show IsList acc null prev ⊑ IsList [] prev null ∗ IsList acc null prev
+  exact PartialOrder.rel_of_eq (by rw [IsList_nil_null, emp_sepConj])
+
+/-- Exit the reverse loop: the exhausted budget forces the unvisited segment empty, which pins
+`curr = null` and makes the accumulator the whole reversal. -/
+@[grind .] theorem reverse_exit_le (xs rest acc : List Nat) (prev curr : Addr)
+    (hlen : rest.length ≤ 0) (hrev : rest.reverse ++ acc = xs.reverse) :
+    IsList rest prev curr ∗ IsList acc curr prev ⊑ IsList xs.reverse null prev := by
+  have hrest : rest = [] := by grind
+  subst hrest
+  rw [IsList_nil_eq]
+  refine sepPure_sepConj_le_of _ _ _ fun hcn => ?_
+  subst hcn
+  have hacc : acc = xs.reverse := by grind
+  exact PartialOrder.rel_of_eq (by rw [hacc])
+
+@[spec] theorem reverse_spec (fuel : Nat) (xs : List Nat) (head : Addr)
+    (hle : xs.length ≤ fuel) :
+    ⦃ IsList xs null head ⦄ reverse fuel head ⦃ fun r => IsList xs.reverse null r ⦄ := by
+  vcgen [reverse, -Spec.forIn_range,
+    Spec.forIn_range (m := HeapM)
+      (inv := fun _ suff b => reverseLoopInv xs suff.length b),
+    -load_spec, load_next_IsList_ne] with finish
 
 example (xs : List Nat) (head l : Addr) (v : Nat) :
     ⦃ l ↦ v ∗ IsList xs null head ⦄ (reverse xs.length head)
@@ -928,56 +919,244 @@ example (xs : List Nat) (head l : Addr) (v : Nat) :
 
 /-! ## Wand-style append
 
-The append specification carries its continuation as a wand: walking the list absorbs each visited
-node into the wand (`wand_absorb`), and linking the last node discharges it by the counit. Both
-lists are nonempty; the appended segment's head prev field is rewritten to the last node. -/
+The append specification is *ramified*: a schematic postcondition `Q` received through a wand in
+the precondition, at the known result `if x = null then y else x`. The loop invariant exposes the
+last visited node and carries a wand absorbing the visited prefix (`wand_absorb`); linking the
+last node discharges the prefix wand and the continuation wand by the counit. -/
 
-/-- Rewrite the back-pointer of a cons cell by storing into its prev field. Not `@[spec]`: its
-program pattern would also match the exposed-node prev write in `reverse.go`. Passed to `vcgen`
-where needed; the call-site priority ranks it above the global `store_spec`. -/
+/-- Rebuild a cons cell around a rewritten prev field; the loaded next-pointer is the witness. -/
+theorem store_prev_handoff (w : Nat) (ws : List Nat) (q c n : Addr) :
+    q ↦ n ∗ (q + 2) ↦ w ∗ IsList ws q n ∗ (q + 1) ↦ c
+      ⊑ ⨆ n', q ↦ n' ∗ (q + 1) ↦ c ∗ (q + 2) ↦ w ∗ IsList ws q n' := by
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_) (le_iSup _ n)
+  grind
+
+grind_pattern store_prev_handoff => (q + 1) ↦ c, (q + 2) ↦ w, IsList ws q n
+
+/-- Rewrite the back-pointer of a cons cell by storing into its prev field. -/
 theorem store_prev_IsList (w : Nat) (ws : List Nat) (qb q c : Addr) :
     ⦃ IsList (w :: ws) qb q ⦄ store (q + 1) c ⦃ fun _ => IsList (w :: ws) c q ⦄ := by
   simp only [IsList_cons_eq]
   vcgen [store_spec] with finish
 
-/-- Wand-style append specification: the schematic postcondition `Q` receives the concatenated list
-through the wand once the traversal ends. The prefix walked so far lives in the wand. -/
-theorem append_spec (fuel : Nat) (v w : Nat) (rest ws : List Nat) (back qb curr q : Addr)
-    (Q : Unit → HProp) (hle : rest.length < fuel) :
-    ⦃ IsList (v :: rest) back curr ∗ IsList (w :: ws) qb q ∗
-        (IsList ((v :: rest) ++ w :: ws) back curr -∗ Q ⟨⟩) ⦄
-      append fuel curr q
+/-- Rewrite the back-pointer of a list head known to be non-null. The shape hypothesis reaches
+`finish` from the branch condition in scope. -/
+theorem store_prev_IsList_ne (ys : List Nat) (qb y c : Addr) (hy : y ≠ null) :
+    ⦃ IsList ys qb y ⦄ store (y + 1) c ⦃ fun _ => IsList ys c y ⦄ := by
+  match ys with
+  | [] =>
+    exact ⟨PartialOrder.rel_trans (IsList_nil_le_bot qb y hy)
+      (PartialOrder.rel_trans (bot_le _)
+        (HeapM.triple_of_bot_pre (Q := _) (store (y + 1) c)).le_wp)⟩
+  | w :: ws => exact store_prev_IsList w ws qb y c
+
+/-- The ramified continuation of `append_spec`: `Q` received through a wand at the known result
+and back-pointer. -/
+noncomputable abbrev appendCont (xs ys : List Nat) (back qb x y : Addr) (Q : Addr → HProp) :
+    HProp :=
+  IsList (xs ++ ys) (if x = null then qb else back) (if x = null then y else x) -∗
+    Q (if x = null then y else x)
+
+/-- Loop invariant for `append` at loop state `(t, u)`: `t` is the last visited node with
+next-pointer `u` and some prev-pointer `pt`, the unvisited segment `rest` hangs off `u`, a wand
+absorbs the visited prefix back into the whole first list, the second list and the continuation
+`K` ride along untouched, and the remaining iteration budget `n` bounds `rest`. -/
+noncomputable abbrev appendLoopInv (xs ys : List Nat) (back qb x y : Addr) (K : HProp)
+    (n : Nat) (b : Addr × Addr) : HProp :=
+  ⨆ v, ⨆ rest, ⨆ pt,
+    ⌜rest.length ≤ n ∧ b.1 ≠ null⌝ ⊓
+      (b.1 ↦ b.2 ∗ (b.1 + 1) ↦ pt ∗ (b.1 + 2) ↦ v ∗ IsList rest b.1 b.2 ∗
+        (IsList (v :: rest ++ ys) pt b.1 -∗ IsList (xs ++ ys) back x) ∗
+        IsList ys qb y ∗ K)
+
+/-- Enter the append loop: the head node is the visited prefix and the prefix wand is the
+identity. -/
+@[grind .] theorem append_entry_le (v : Nat) (rest xs ys : List Nat) (back qb x y u₀ : Addr)
+    (K : HProp) (n : Nat) (hxs : xs = v :: rest) (hx : x ≠ null) (hlen : xs.length ≤ n) :
+    (IsList ys qb y ∗ K) ∗ x ↦ u₀ ∗ (x + 1) ↦ back ∗ (x + 2) ↦ v ∗ IsList rest x u₀
+      ⊑ appendLoopInv xs ys back qb x y K n (x, u₀) := by
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
+      x ↦ u₀ ∗ (x + 1) ↦ back ∗ (x + 2) ↦ v ∗ IsList rest x u₀ ∗ IsList ys qb y ∗ K)) ?_
+  · grind
+  refine le_iSup_of_le v (le_iSup_of_le rest (le_iSup_of_le back ?_))
+  refine le_meet _ _ _ (le_ofProp _ _ ⟨by grind, hx⟩) ?_
+  refine PartialOrder.rel_trans
+    (le_sepConj_wand_refl _ (IsList (v :: rest ++ ys) back x)) ?_
+  subst hxs
+  exact PartialOrder.rel_of_eq (by grind)
+
+grind_pattern append_entry_le =>
+  IsList rest x u₀, (x + 1) ↦ back, (x + 2) ↦ v, IsList ys qb y,
+  IsList (xs ++ ys) back x -∗ K, xs.length ≤ n
+
+/-- One append iteration: absorb the visited node into the prefix wand (`wand_absorb`) and
+re-establish the loop invariant on the rest. -/
+@[grind .] theorem append_yield_le (v w : Nat) (rest rest' xs ys : List Nat)
+    (back qb x y pt t u u' : Addr) (K : HProp) (n : Nat)
+    (ht : t ≠ null) (hu : u ≠ null) (hrest : rest = w :: rest')
+    (hlen : rest.length ≤ n + 1) :
+    (t ↦ u ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v ∗
+        (IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) back x) ∗ IsList ys qb y ∗ K) ∗
+      u ↦ u' ∗ (u + 1) ↦ t ∗ (u + 2) ↦ w ∗ IsList rest' u u'
+      ⊑ appendLoopInv xs ys back qb x y K n (u, u') := by
+  subst hrest
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
+      t ↦ u ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v ∗ u ↦ u' ∗ (u + 1) ↦ t ∗ (u + 2) ↦ w ∗
+        IsList rest' u u' ∗ (IsList (v :: (w :: rest') ++ ys) pt t -∗ IsList (xs ++ ys) back x) ∗
+        IsList ys qb y ∗ K)) ?_
+  · grind
+  refine le_iSup_of_le w (le_iSup_of_le rest' (le_iSup_of_le t ?_))
+  refine le_meet _ _ _ (le_ofProp _ _ ⟨by grind, hu⟩) ?_
+  have habs : IsList ((w :: rest') ++ ys) t u ∗ (t ↦ u ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v)
+      ⊑ IsList (v :: (w :: rest') ++ ys) pt t := by
+    refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_)
+      (IsList_cons_intro v u pt ((w :: rest') ++ ys) t ht)
+    grind
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
+      (u ↦ u' ∗ (u + 1) ↦ t ∗ (u + 2) ↦ w ∗ IsList rest' u u' ∗ IsList ys qb y ∗ K) ∗
+        ((t ↦ u ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v) ∗
+          (IsList (v :: (w :: rest') ++ ys) pt t -∗ IsList (xs ++ ys) back x)))) ?_
+  · grind
+  · refine PartialOrder.rel_trans (sepConj_mono_right _ (wand_absorb habs)) ?_
+    exact PartialOrder.rel_of_eq (by grind)
+
+/-- Break out of the append loop: `u = null` forces the unvisited segment empty, so the invariant
+holds at the exhausted budget. -/
+@[grind .] theorem append_done_le (v : Nat) (rest xs ys : List Nat) (back qb x y pt t u : Addr)
+    (K : HProp) (ht : t ≠ null) (hu : u = null) :
+    t ↦ u ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v ∗ IsList rest t u ∗
+        (IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) back x) ∗ IsList ys qb y ∗ K
+      ⊑ appendLoopInv xs ys back qb x y K ([] : List Nat).length (t, u) := by
+  subst hu
+  rw [IsList_null_eq]
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
+      sepPure (rest = []) ∗ (t ↦ null ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v ∗
+        (IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) back x) ∗ IsList ys qb y ∗ K))) ?_
+  · grind
+  refine sepPure_sepConj_le_of _ _ _ fun hrest => ?_
+  subst hrest
+  refine le_iSup_of_le v (le_iSup_of_le [] (le_iSup_of_le pt ?_))
+  refine le_meet _ _ _ (le_ofProp _ _ ⟨by simp, ht⟩) ?_
+  refine PartialOrder.rel_of_eq ?_
+  rw [IsList_nil_null]
+  grind
+
+/-- Discharge both wands at the last node: rebuild the cons cell onto the relinked second list,
+apply the prefix wand's counit, then the continuation wand's. -/
+@[grind .] theorem append_link_le (v : Nat) (rest xs ys : List Nat) (back x y pt t u : Addr)
+    (K : HProp) (ht : t ≠ null) (hlen : rest.length ≤ 0) :
+    ((t + 1) ↦ pt ∗ (t + 2) ↦ v ∗ IsList rest t u ∗
+        (IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) back x) ∗
+        (IsList (xs ++ ys) back x -∗ K) ∗ t ↦ y) ∗
+      IsList ys t y
+      ⊑ K := by
+  have hrest : rest = [] := by grind
+  subst hrest
+  rw [IsList_nil_eq]
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
+      sepPure (u = null) ∗ (t ↦ y ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v ∗
+        (IsList (v :: [] ++ ys) pt t -∗ IsList (xs ++ ys) back x) ∗ IsList ys t y ∗
+        (IsList (xs ++ ys) back x -∗ K)))) ?_
+  · grind
+  refine sepPure_sepConj_le_of _ _ _ fun _hu => ?_
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
+      ((t ↦ y ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v ∗ IsList ys t y) ∗
+        (IsList (v :: [] ++ ys) pt t -∗ IsList (xs ++ ys) back x)) ∗
+      (IsList (xs ++ ys) back x -∗ K))) ?_
+  · grind
+  · refine PartialOrder.rel_trans
+      (sepConj_mono_left _ (PartialOrder.rel_trans
+        (sepConj_mono_left _ (IsList_cons_intro v y pt ys t ht))
+        (sepConj_wand_le _ _))) ?_
+    exact sepConj_wand_le _ _
+
+grind_pattern append_link_le =>
+  (t + 1) ↦ pt, (t + 2) ↦ v, IsList rest t u,
+  IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) back x,
+  IsList (xs ++ ys) back x -∗ K, IsList ys t y, t ↦ y
+
+/-- The `y = null` link: the second list is empty, and storing `null` into the last node's next
+field leaves the first list intact. -/
+@[grind .] theorem append_link_null_le (v : Nat) (rest xs ys : List Nat)
+    (back qb x y pt t u : Addr) (K : HProp)
+    (ht : t ≠ null) (hlen : rest.length ≤ 0) (hy : y = null) :
+    ((t + 1) ↦ pt ∗ (t + 2) ↦ v ∗ IsList rest t u ∗
+        (IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) back x) ∗ IsList ys qb y ∗
+        (IsList (xs ++ ys) back x -∗ K)) ∗ t ↦ y
+      ⊑ K := by
+  have hrest : rest = [] := by grind
+  subst hrest
+  subst hy
+  rw [IsList_nil_eq, IsList_null_eq]
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
+      sepPure (u = null) ∗ sepPure (ys = []) ∗ (t ↦ null ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v ∗
+        (IsList (v :: [] ++ ys) pt t -∗ IsList (xs ++ ys) back x) ∗
+        (IsList (xs ++ ys) back x -∗ K)))) ?_
+  · grind
+  refine sepPure_sepConj_le_of _ _ _ fun _hu => sepPure_sepConj_le_of _ _ _ fun hys => ?_
+  subst hys
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
+      ((t ↦ null ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v ∗ IsList [] t null) ∗
+        (IsList (v :: [] ++ []) pt t -∗ IsList (xs ++ []) back x)) ∗
+      (IsList (xs ++ []) back x -∗ K))) ?_
+  · grind
+  · refine PartialOrder.rel_trans
+      (sepConj_mono_left _ (PartialOrder.rel_trans
+        (sepConj_mono_left _ (IsList_cons_intro v null pt [] t ht))
+        (sepConj_wand_le _ _))) ?_
+    exact sepConj_wand_le _ _
+
+grind_pattern append_link_null_le =>
+  (t + 1) ↦ pt, (t + 2) ↦ v, IsList rest t u,
+  IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) back x,
+  IsList (xs ++ ys) back x -∗ K, IsList ys qb y, t ↦ y
+
+/-- The empty-first-list branch: the continuation receives the second list unchanged. -/
+@[grind .] theorem append_nil_le (xs ys : List Nat) (back qb y : Addr) (K : HProp) :
+    IsList xs back null ∗ IsList ys qb y ∗ (IsList (xs ++ ys) qb y -∗ K)
+      ⊑ K := by
+  rw [IsList_null_eq]
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
+      sepPure (xs = []) ∗ (IsList ys qb y ∗ (IsList (xs ++ ys) qb y -∗ K)))) ?_
+  · grind
+  · refine sepPure_sepConj_le_of _ _ _ fun hxs => ?_
+    subst hxs
+    exact sepConj_wand_le _ _
+
+/-- Ramified append specification: the schematic postcondition `Q` is received through a wand at
+the known result and back-pointer. -/
+theorem append_spec (fuel : Nat) (xs ys : List Nat) (back qb x y : Addr) (Q : Addr → HProp)
+    (hle : xs.length ≤ fuel) :
+    ⦃ IsList xs back x ∗ IsList ys qb y ∗ appendCont xs ys back qb x y Q ⦄
+      append fuel x y
     ⦃ Q ⦄ := by
-  induction rest generalizing v fuel curr back Q with
-  | nil =>
-    match fuel, hle with
-    | fuel + 1, _ =>
-      simp only [append, List.cons_append, List.nil_append]
-      -- The `next ≠ null` arm is unreachable under `IsList []`; its recursive call takes the
-      -- `⊥`-precondition spec and the arm closes by contradiction.
-      vcgen [-load_spec, load_next_IsList, store_prev_IsList,
-        fun next => HeapM.triple_of_bot_pre (Q := Q) (append fuel next q)] with
-        finish
-  | cons v' rest' ih =>
-    match fuel, hle with
-    | fuel + 1, hle =>
-      simp only [List.length_cons] at hle
-      simp only [append, List.cons_append]
-      -- The `next = null` arm is unreachable under `IsList (v' :: rest')`; the recursive call
-      -- takes the IH at the absorbed wand.
-      vcgen [-load_spec, load_next_IsList, store_prev_IsList,
-        fun next => ih fuel v' curr next Q (Nat.lt_of_succ_lt_succ hle)] with finish
+  by_cases hx : x = null
+  · subst hx
+    have hb : (if null = null then qb else back) = qb := by grind
+    have hr : (if null = null then y else null) = y := by grind
+    rw [appendCont, hb, hr]
+    simp only [append, reduceIte]
+    vcgen with finish
+  · have hb : (if x = null then qb else back) = back := by grind
+    have hr : (if x = null then y else x) = x := by grind
+    rw [appendCont, hb, hr]
+    have hlen' : xs.length ≤ ([:fuel] : Std.Legacy.Range).toList.length := by grind
+    vcgen [append, -Spec.forIn_range,
+      Spec.forIn_range (m := HeapM)
+        (inv := fun _ suff b =>
+          appendLoopInv xs ys back qb x y (IsList (xs ++ ys) back x -∗ Q x) suff.length b),
+      -load_spec, load_next_IsList_ne, store_prev_IsList_ne] with finish
 
 /-- Plain append specification, from `append_spec` at the trivial continuation. -/
-@[spec] theorem append_concat (v w : Nat) (rest ws : List Nat) (back qb curr q : Addr) :
-    ⦃ IsList (v :: rest) back curr ∗ IsList (w :: ws) qb q ⦄
-      append (rest.length + 1) curr q
-    ⦃ fun _ => IsList ((v :: rest) ++ w :: ws) back curr ⦄ := by
+@[spec] theorem append_concat (xs ys : List Nat) (back qb x y : Addr) :
+    ⦃ IsList xs back x ∗ IsList ys qb y ⦄
+      append xs.length x y
+    ⦃ fun r => IsList (xs ++ ys) (if x = null then qb else back) r ⦄ := by
   vcgen [append_spec] with finish
 
 /-- Framing an unrelated cell across the whole append. -/
-example (l : Addr) (z v w : Nat) (rest ws : List Nat) (back qb curr q : Addr) :
-    ⦃ l ↦ z ∗ IsList (v :: rest) back curr ∗ IsList (w :: ws) qb q ⦄
-      append (rest.length + 1) curr q
-    ⦃ fun _ => l ↦ z ∗ IsList ((v :: rest) ++ w :: ws) back curr ⦄ := by
+example (l : Addr) (z : Nat) (xs ys : List Nat) (back qb x y : Addr) :
+    ⦃ l ↦ z ∗ IsList xs back x ∗ IsList ys qb y ⦄
+      append xs.length x y
+    ⦃ fun r => l ↦ z ∗ IsList (xs ++ ys) (if x = null then qb else back) r ⦄ := by
   vcgen [append_concat] with finish

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -950,13 +950,6 @@ theorem store_prev_IsList_ne (ys : List Nat) (qb y c : Addr) (hy : y ≠ null) :
         (HeapM.triple_of_bot_pre (Q := _) (store (y + 1) c)).le_wp)⟩
   | w :: ws => exact store_prev_IsList w ws qb y c
 
-/-- The ramified continuation of `append_spec`: `Q` received through a wand at the known result
-and back-pointer. -/
-noncomputable abbrev appendCont (xs ys : List Nat) (back qb x y : Addr) (Q : Addr → HProp) :
-    HProp :=
-  IsList (xs ++ ys) (if x = null then qb else back) (if x = null then y else x) -∗
-    Q (if x = null then y else x)
-
 /-- Loop invariant for `append` at loop state `(t, u)`: `t` is the last visited node with
 next-pointer `u` and some prev-pointer `pt`, the unvisited segment `rest` hangs off `u`, a wand
 absorbs the visited prefix back into the whole first list, the second list and the continuation
@@ -1127,19 +1120,21 @@ grind_pattern append_link_null_le =>
 the known result and back-pointer. -/
 theorem append_spec (fuel : Nat) (xs ys : List Nat) (back qb x y : Addr) (Q : Addr → HProp)
     (hle : xs.length ≤ fuel) :
-    ⦃ IsList xs back x ∗ IsList ys qb y ∗ appendCont xs ys back qb x y Q ⦄
+    ⦃ IsList xs back x ∗ IsList ys qb y ∗
+        (IsList (xs ++ ys) (if x = null then qb else back) (if x = null then y else x) -∗
+          Q (if x = null then y else x)) ⦄
       append fuel x y
     ⦃ Q ⦄ := by
   by_cases hx : x = null
   · subst hx
     have hb : (if null = null then qb else back) = qb := by grind
     have hr : (if null = null then y else null) = y := by grind
-    rw [appendCont, hb, hr]
+    rw [hb, hr]
     simp only [append, reduceIte]
     vcgen with finish
   · have hb : (if x = null then qb else back) = back := by grind
     have hr : (if x = null then y else x) = x := by grind
-    rw [appendCont, hb, hr]
+    rw [hb, hr]
     have hlen' : xs.length ≤ ([:fuel] : Std.Legacy.Range).toList.length := by grind
     vcgen [append, -Spec.forIn_range,
       Spec.forIn_range (m := HeapM)

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -693,38 +693,33 @@ def mkSepFrameSplit (i : FrameInferenceInfo) (frame footprint : Expr) : SymM Fra
       #[args[0]!, args[1]!, ← i.pre, sepFF, sepFR, hcl, mono]
     return FrameSplit.withDischargedSplitVC frame residualPre proof [sub.mvarId!]
 
-/-- Frame `emp` when the spec is ramified.
-
-A ramified spec keeps its postcondition schematic and hands what it establishes to the caller
-through a wand in its own precondition:
+/-- Frame `emp` for a spec that carries its postcondition through a wand,
 
     ⦃ P ∗ (G -∗ Q r₀) ⦄ x ⦃ Q ⦄
 
-`P` is consumed, `G` is established (for `append_spec`, the concatenated list), `r₀` is the result.
-The caller's remaining resources reach `Q` through its proof of the wand, so the spec needs no
-frame.
+where `Q` is schematic, `G` is what the spec establishes and `r₀` is the result it returns.
+Cancelling the `∗`-factors of that precondition against those of the goal pairs off `P` and leaves
+`G -∗ Q r₀`, which reaches this procedure as `wandAtom`.
 
-Atom cancellation cannot apply it. `G -∗ Q r₀` is an obligation rather than a resource, so the goal
-holds no atom to cancel it against and it is the one atom left over.
+For `append_spec` at goal `A ∗ B ⊑ wp (append fuel x y) Q`, the precondition is
+`?A ∗ ?B ∗ (?G -∗ Q ?r₀)` and `matchSepAtoms` assigns `?A := A`, `?B := B`, pinning `?G` and `?r₀`.
+The frame rule at frame `emp` re-posts the goal at `fun a => emp -∗ Q a`, so
 
-Framing `emp` still routes the application through the frame rule, which re-posts the goal at
-`fun a => emp -∗ Q a` and re-applies the spec there. Spelling the footprint at that same post makes
-the re-application close by unification, pinning the spec's schematics to the goal's values.
+    footprint := A ∗ B ∗ (G -∗ (emp -∗ Q r₀))
 
-On goal `A ∗ B ⊑ wp (append fuel x y) Q`, against a spec precondition `?A ∗ ?B ∗ (?G -∗ Q ?r₀)`:
+and the split VC `A ∗ B ⊑ emp ∗ residualPre` is `rel_trans (rel_trans q₂ q₃) (sepConj_mono_right
+sub₁)` for
 
-* `matchSepAtoms` pairs `?A`/`?B` with `A`/`B`, which pins `?G` and `?r₀`, and reports the wand as
-  `wandAtom`.
-* `footprint := A ∗ B ∗ (G -∗ (emp -∗ Q r₀))`.
-* The split VC `A ∗ B ⊑ emp ∗ residualPre` is `rel_trans (rel_trans q₂ q₃) (sepConj_mono_right
-  sub₁)`. `q₂` attaches the trivial wand `G -∗ (emp -∗ G)` (`le_sepConj_wand_emp_wand_refl`,
-  available because `G` is the post at `r₀`), `q₃` reassociates and inserts the `emp`, and
-  `sub₁ : footprint ⊑ residualPre` survives.
-* `sub₁` closes when the spec re-applies, leaving the spec's side premises (for `append`,
-  `xs.length ≤ fuel`) and `WP.Frames` for `emp` to `finish`.
+    q₂   : A ∗ B ⊑ (A ∗ B) ∗ (G -∗ (emp -∗ G))            le_sepConj_wand_emp_wand_refl at G = Q r₀
+    q₃   : (A ∗ B) ∗ (G -∗ (emp -∗ G)) = emp ∗ footprint   associativity, commutativity, `emp`
+    sub₁ : footprint ⊑ residualPre
 
-A wand whose argument is not the post at `r₀` loses `q₂`/`q₃` and leaves `pre ⊑ emp ∗ footprint`
-as a second subgoal. -/
+`residualPre` receives `wp (append fuel x y) (fun a => emp -∗ Q a)`, and re-applying the spec
+against it produces the precondition VC `footprint ⊑ A ∗ B ∗ (G -∗ (emp -∗ Q r₀))`. Both sides
+agree, so unification closes it and assigns `?A`, `?B`, `?G`, `?r₀`. `finish` receives
+`xs.length ≤ fuel` and `WP.Frames sepConj (append fuel x y) emp`.
+
+At `G ≠ Q r₀`, `q₂` and `q₃` become a subgoal `pre ⊑ emp ∗ footprint`. -/
 def mkEmpFrameSplit (i : FrameInferenceInfo) (matched : Array Expr) (wandAtom : Expr) :
     SymM (Option FrameSplit) := do
   let wandAtom ← instantiateMVarsS wandAtom

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -602,11 +602,13 @@ theorem IsList_cons_null_le_bot (v : Nat) (vs : List Nat) (back : Addr) :
 
 grind_pattern IsList_cons_null_le_bot => IsList (v :: vs) back null
 
-/-- A contradictory precondition entails anything; the premise is closed by the facts the forward
-saturation asserts. -/
-@[grind ←]
+/-- A contradictory precondition entails anything. Both patterns are needed: the conclusion alone
+matches every entailment goal, so the rule fires only once forward saturation has asserted `X ⊑ ⊥`
+for the goal's own precondition. -/
 theorem le_of_le_bot {X : HProp} (h : X ⊑ ⊥) (C : HProp) : X ⊑ C :=
   PartialOrder.rel_trans h (bot_le C)
+
+grind_pattern _root_.le_of_le_bot => X ⊑ ⊥, X ⊑ C
 
 @[grind =] theorem IsList_append_nil (xs : List Nat) (back r : Addr) :
     IsList (xs ++ ([] : List Nat)) back r = IsList xs back r := by
@@ -691,32 +693,49 @@ def mkSepFrameSplit (i : FrameInferenceInfo) (frame footprint : Expr) : SymM Fra
       #[args[0]!, args[1]!, ← i.pre, sepFF, sepFR, hcl, mono]
     return FrameSplit.withDischargedSplitVC frame residualPre proof [sub.mvarId!]
 
-/-- Frame `emp` for a *ramified* spec: a spec with schematic postcondition `Q` that auto-frames by
-receiving `Q` through a wand in its precondition, `⦃ P ∗ (G -∗ Q r₀) ⦄ x ⦃ Q ⦄` with `r₀` the
-spec's known result. The goal precondition has no wand atom, so such a spec never matches
-outright.
+/-- Note [Framing a ramified spec]
 
-Worked example: goal `A ∗ B ⊑ wp (append fuel x y) Q` against `append_spec`, whose precondition
-is `?A ∗ ?B ∗ (?G -∗ Q ?r₀)` after the schematic post unifies.
-- `matchSepAtoms` pairs `?A`/`?B` with `A`/`B`, committing the assignments (which also pin `?G`
-  and `?r₀`), and reports the wand `G -∗ Q r₀` unmatched; it arrives here as `wandAtom`.
-- The `footprint` mirrors the spec precondition at the `emp`-framed residual post:
-  `A ∗ B ∗ (G -∗ (emp -∗ Q r₀))`.
-- The split VC `A ∗ B ⊑ emp ∗ residualPre` is discharged as
-  `rel_trans (rel_trans q₂ q₃) (sepConj_mono_right sub₁)`:
-  `q₂ : A ∗ B ⊑ (A ∗ B) ∗ (G -∗ (emp -∗ G))` attaches the trivial wand
-  (`le_sepConj_wand_emp_wand_refl`; valid because `G` is the post at `r₀`),
-  `q₃` reassociates and inserts `emp` (AC with identity), and
-  `sub₁ : footprint ⊑ residualPre` is the sole surviving subgoal.
-- The solver fills `residualPre` with the residual weakest precondition, whose post is the
-  `emp`-framed `fun a => emp -∗ Q a`. On `sub₁` the spec applies directly, and its precondition VC
-  pits the footprint against the spec precondition at that same post: the same term up to the
-  spec's schematics, so it closes by unification, pinning the schematics to the goal's values.
-- What remains for the user: the spec's side premises (for append, `xs.length ≤ fuel`) and the
-  `WP.Frames` condition for `emp`, both closed by `finish`.
+A ramified spec does not state its postcondition. It takes a schematic `Q`, states what it really
+establishes as a resource `G`, and hands `G` to `Q` through a wand sitting in its own precondition:
 
-A wand whose argument differs from the post at `r₀` leaves `pre ⊑ emp ∗ footprint` as a second
-subgoal in place of `q₂`/`q₃`. -/
+    ⦃ P ∗ (G -∗ Q r₀) ⦄ x ⦃ Q ⦄
+
+Here `P` is what the spec consumes, `G` is what it produces (for `append_spec`, the concatenated
+list), and `r₀` is the result it returns. The point of writing a spec this way is that it frames
+itself: whatever the caller owns besides `P` can be carried into `Q` by the caller's own proof of
+the wand, so no frame ever has to be named.
+
+That is also why the ordinary cancellation path cannot apply such a spec. Frame inference works by
+cancelling the spec's precondition atoms against the goal's, and the wand atom `G -∗ Q r₀` has no
+counterpart in the goal: it is not a resource the caller holds, it is an obligation the caller
+discharges. Cancellation therefore leaves exactly one uncancelled atom, and it is always the wand.
+
+The way out is to frame nothing at all. `emp` is a legitimate frame, and framing it still routes the
+application through the frame rule, which is what we want, because the frame rule replaces the goal's
+post `Q` by the `emp`-framed residual post and then re-applies the spec against it. If the footprint
+we hand back is the spec's own precondition spelled at that residual post, the re-application closes
+by unification, and unification is what pins the spec's schematics to the goal's values.
+
+Worked example. The goal is `A ∗ B ⊑ wp (append fuel x y) Q` and the spec's precondition, once the
+schematic post has unified, is `?A ∗ ?B ∗ (?G -∗ Q ?r₀)`.
+
+* `matchSepAtoms` pairs `?A`/`?B` with `A`/`B` and commits the assignments, which also pins `?G` and
+  `?r₀`. It reports the wand unmatched, and it arrives here as `wandAtom`.
+* We build `footprint = A ∗ B ∗ (G -∗ (emp -∗ Q r₀))`, the spec precondition with its wand rewrapped
+  at the `emp`-framed post.
+* The split VC `A ∗ B ⊑ emp ∗ residualPre` is proved by
+  `rel_trans (rel_trans q₂ q₃) (sepConj_mono_right sub₁)`, where `q₂` attaches the trivial wand
+  `G -∗ (emp -∗ G)` (`le_sepConj_wand_emp_wand_refl`, applicable because `G` coincides with the post
+  at `r₀`), `q₃` reassociates and inserts the `emp`, and `sub₁ : footprint ⊑ residualPre` is left
+  over.
+* The solver fills `residualPre` with the residual weakest precondition, whose post is
+  `fun a => emp -∗ Q a`. On `sub₁` the spec applies directly and its precondition VC is the footprint
+  against that same spelling, identical up to the spec's schematics, so it closes by unification.
+* The user is left with the spec's side premises, for `append` that is `xs.length ≤ fuel`, and the
+  `WP.Frames` condition for `emp`. `finish` closes both.
+
+When the wand's argument is not the post at `r₀` the trivial wand is unavailable, and `q₂`/`q₃` are
+replaced by a second subgoal `pre ⊑ emp ∗ footprint`. -/
 def mkEmpFrameSplit (i : FrameInferenceInfo) (matched : Array Expr) (wandAtom : Expr) :
     SymM (Option FrameSplit) := do
   let wandAtom ← instantiateMVarsS wandAtom
@@ -840,7 +859,10 @@ example (l1 l2 : Addr) (a b : Nat) :
     ⦃ l1 ↦ a ∗ l2 ↦ b ⦄ (probe l1) ⦃ fun _ => l1 ↦ 0 ∗ l2 ↦ b ⦄ := by
   vcgen [probe_spec] with finish
 
-/-! ## In-place reverse -/
+/-! ## `IsList` node access
+
+Both loops reach a cell through an `IsList` segment rather than through a points-to atom, so each
+one opens the node with `IsList_ne_le` and then applies the primitive spec. -/
 
 /-- Load the next-pointer of a list node known to be non-null: the segment must then be a cons,
 and the loaded value is its `IsList` witness. The shape hypothesis reaches `finish` from the
@@ -860,17 +882,25 @@ theorem load_next_IsList_ne (rest : List Nat) (back curr : Addr) (hcn : curr ≠
       (le_meet _ _ _ (le_ofProp _ _ rfl) PartialOrder.rel_refl)))
   grind
 
+/-- Rewrite the back-pointer of a list head known to be non-null. -/
+theorem store_prev_IsList_ne (ys : List Nat) (qb y c : Addr) (hy : y ≠ null) :
+    ⦃ IsList ys qb y ⦄ store (y + 1) c ⦃ fun _ => IsList ys c y ⦄ := by
+  refine ⟨PartialOrder.rel_trans (IsList_ne_le ys qb y hy) ?_⟩
+  vcgen [store_spec] with finish
+
+/-! ## In-place reverse -/
+
 /-- Loop invariant for `reverse` at loop state `(prev, curr)`: the unvisited segment `rest` hangs
 off `curr` with back-pointer `prev`, the reversed prefix `acc` sits at `prev` with back-pointer
 `curr`, and the remaining iteration budget `n` bounds `rest`. -/
-noncomputable abbrev reverseLoopInv (xs : List Nat) (n : Nat) (b : Addr × Addr) : HProp :=
+noncomputable abbrev ReverseLoopInv (xs : List Nat) (n : Nat) (b : Addr × Addr) : HProp :=
   ⨆ rest, ⨆ acc, ⌜rest.length ≤ n ∧ rest.reverse ++ acc = xs.reverse⌝ ⊓
     (IsList rest b.1 b.2 ∗ IsList acc b.2 b.1)
 
 /-- Enter the reverse loop: the whole list is unvisited and the accumulator is empty. -/
 @[grind .] theorem reverse_entry_le (xs : List Nat) (n : Nat) (head : Addr)
     (hle : xs.length ≤ n) :
-    IsList xs null head ⊑ reverseLoopInv xs n (null, head) := by
+    IsList xs null head ⊑ ReverseLoopInv xs n (null, head) := by
   refine le_iSup_of_le xs (le_iSup_of_le [] ?_)
   refine le_meet _ _ _ (le_ofProp _ _ ⟨hle, by simp⟩) ?_
   show IsList xs null head ⊑ IsList xs null head ∗ IsList [] head null
@@ -883,7 +913,7 @@ noncomputable abbrev reverseLoopInv (xs : List Nat) (n : Nat) (b : Addr × Addr)
     (hrev : (v :: vs).reverse ++ acc = xs.reverse) :
     (IsList acc curr prev ∗ (curr + 2) ↦ v ∗ IsList vs curr next ∗ curr ↦ prev) ∗
       (curr + 1) ↦ next
-      ⊑ reverseLoopInv xs n (curr, next) := by
+      ⊑ ReverseLoopInv xs n (curr, next) := by
   refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
       IsList acc curr prev ∗ IsList vs curr next ∗ curr ↦ prev ∗ (curr + 1) ↦ next ∗
         (curr + 2) ↦ v)) ?_
@@ -897,7 +927,7 @@ invariant holds at any remaining budget. -/
 @[grind .] theorem reverse_done_le (xs rest acc : List Nat) (prev curr : Addr)
     (hcn : curr = null) (hrev : rest.reverse ++ acc = xs.reverse) :
     IsList rest prev curr ∗ IsList acc curr prev
-      ⊑ reverseLoopInv xs ([] : List Nat).length (prev, curr) := by
+      ⊑ ReverseLoopInv xs ([] : List Nat).length (prev, curr) := by
   subst hcn
   rw [IsList_null_eq]
   refine sepPure_sepConj_le_of _ _ _ fun hrest => ?_
@@ -924,7 +954,7 @@ invariant holds at any remaining budget. -/
     (hle : xs.length ≤ fuel) :
     ⦃ IsList xs null head ⦄ reverse fuel head ⦃ fun r => IsList xs.reverse null r ⦄ := by
   vcgen [reverse, load_next_IsList_ne] invariants
-    | inv1 => fun _ suff b => reverseLoopInv xs suff.length b
+    | inv1 => fun _ suff b => ReverseLoopInv xs suff.length b
     with finish
 
 example (xs : List Nat) (head l : Addr) (v : Nat) :
@@ -939,17 +969,11 @@ the precondition, at the known result `if x = null then y else x`. The loop inva
 last visited node and carries a wand absorbing the visited prefix (`wand_absorb`); linking the
 last node discharges the prefix wand and the continuation wand by the counit. -/
 
-/-- Rewrite the back-pointer of a list head known to be non-null. -/
-theorem store_prev_IsList_ne (ys : List Nat) (qb y c : Addr) (hy : y ≠ null) :
-    ⦃ IsList ys qb y ⦄ store (y + 1) c ⦃ fun _ => IsList ys c y ⦄ := by
-  refine ⟨PartialOrder.rel_trans (IsList_ne_le ys qb y hy) ?_⟩
-  vcgen [store_spec] with finish
-
 /-- Loop invariant for `append` at loop state `(t, u)`: `t` is the last visited node with
 next-pointer `u` and some prev-pointer `pt`, the unvisited segment `rest` hangs off `u`, a wand
 absorbs the visited prefix back into the whole first list, the second list and the continuation
 `K` ride along untouched, and the remaining iteration budget `n` bounds `rest`. -/
-noncomputable abbrev appendLoopInv (xs ys : List Nat) (back qb x y : Addr) (K : HProp)
+noncomputable abbrev AppendLoopInv (xs ys : List Nat) (back qb x y : Addr) (K : HProp)
     (n : Nat) (b : Addr × Addr) : HProp :=
   ⨆ v, ⨆ rest, ⨆ pt,
     ⌜rest.length ≤ n ∧ b.1 ≠ null⌝ ⊓
@@ -962,7 +986,7 @@ identity. -/
 @[grind .] theorem append_entry_le (v : Nat) (rest xs ys : List Nat) (back qb x y u₀ : Addr)
     (K : HProp) (n : Nat) (hxs : xs = v :: rest) (hx : x ≠ null) (hlen : xs.length ≤ n) :
     (IsList ys qb y ∗ K) ∗ x ↦ u₀ ∗ (x + 1) ↦ back ∗ (x + 2) ↦ v ∗ IsList rest x u₀
-      ⊑ appendLoopInv xs ys back qb x y K n (x, u₀) := by
+      ⊑ AppendLoopInv xs ys back qb x y K n (x, u₀) := by
   refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
       x ↦ u₀ ∗ (x + 1) ↦ back ∗ (x + 2) ↦ v ∗ IsList rest x u₀ ∗ IsList ys qb y ∗ K)) ?_
   · grind
@@ -986,7 +1010,7 @@ re-establish the loop invariant on the rest. -/
     (t ↦ u ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v ∗
         (IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) back x) ∗ IsList ys qb y ∗ K) ∗
       u ↦ u' ∗ (u + 1) ↦ t ∗ (u + 2) ↦ w ∗ IsList rest' u u'
-      ⊑ appendLoopInv xs ys back qb x y K n (u, u') := by
+      ⊑ AppendLoopInv xs ys back qb x y K n (u, u') := by
   subst hrest
   refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
       t ↦ u ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v ∗ u ↦ u' ∗ (u + 1) ↦ t ∗ (u + 2) ↦ w ∗
@@ -1014,7 +1038,7 @@ holds at the exhausted budget. -/
     (K : HProp) (ht : t ≠ null) (hu : u = null) :
     t ↦ u ∗ (t + 1) ↦ pt ∗ (t + 2) ↦ v ∗ IsList rest t u ∗
         (IsList (v :: rest ++ ys) pt t -∗ IsList (xs ++ ys) back x) ∗ IsList ys qb y ∗ K
-      ⊑ appendLoopInv xs ys back qb x y K ([] : List Nat).length (t, u) := by
+      ⊑ AppendLoopInv xs ys back qb x y K ([] : List Nat).length (t, u) := by
   subst hu
   rw [IsList_null_eq]
   refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
@@ -1133,7 +1157,7 @@ theorem append_spec (fuel : Nat) (xs ys : List Nat) (back qb x y : Addr) (Q : Ad
     have hlen' : xs.length ≤ ([:fuel] : Std.Legacy.Range).toList.length := by grind
     vcgen [append, load_next_IsList_ne, store_prev_IsList_ne] invariants
       | inv1 => fun _ suff b =>
-          appendLoopInv xs ys back qb x y (IsList (xs ++ ys) back x -∗ Q x) suff.length b
+          AppendLoopInv xs ys back qb x y (IsList (xs ++ ys) back x -∗ Q x) suff.length b
       with finish
 
 /-- Plain append specification, from `append_spec` at the trivial continuation. -/

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -166,6 +166,7 @@ def append (fuel : Nat) (curr q : Addr) : HeapM Unit :=
     if next = null then
       store curr q
       store (q + 1) curr
+      pure ()
     else
       append fuel next q
 
@@ -526,7 +527,8 @@ segment (`IsList_cons_intro` with the new next-pointer `q`) and apply the counit
 theorem append_link_le (v w : Nat) (ws : List Nat) (back curr q next : Addr) (R : HProp)
     (hcn : curr ≠ null) (hnext : next = null) :
     (((((IsList (v :: w :: ws) back curr -∗ R) ∗ (curr + 1) ↦ back) ∗ (curr + 2) ↦ v) ∗
-        IsList [] curr next) ∗ curr ↦ q) ∗ IsList (w :: ws) curr q ⊑ R := by
+          IsList [] curr next) ∗ curr ↦ q) ∗ IsList (w :: ws) curr q
+      ⊑ R := by
   subst hnext
   refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_)
     (PartialOrder.rel_trans
@@ -540,6 +542,11 @@ theorem sepConj_bot_le (X : HProp) : X ∗ (⊥ : HProp) ⊑ ⊥ := by
   obtain ⟨_, h₂, _, _, _, hb⟩ := hh
   exact ((bot_le (x := (fun _ => False : HProp))) h₂ hb).elim
 
+/-- Any entailment holds when the right `∗`-factor is contradictory. -/
+theorem sepConj_le_of_right_le_bot (A : HProp) {B : HProp} (h : B ⊑ ⊥) (C : HProp) : A ∗ B ⊑ C :=
+  PartialOrder.rel_trans
+    (PartialOrder.rel_trans (sepConj_mono_right A h) (sepConj_bot_le A)) (bot_le C)
+
 /-- An empty segment pins its root to `null`. -/
 theorem IsList_nil_le_bot (curr next : Addr) (hne : next ≠ null) : IsList [] curr next ⊑ ⊥ := by
   intro h hh
@@ -552,27 +559,19 @@ theorem IsList_cons_null_le_bot (v : Nat) (vs : List Nat) (back : Addr) :
   intro h hh
   exact ((IsList_cons_elim hh).1 rfl).elim
 
-/-- A precondition holding `IsList [] curr next` is contradictory when `next ≠ null`. -/
+/-- A precondition holding `IsList [] curr next` is contradictory when `next ≠ null`;
+`grind`'s AC theory for `∗` isolates the segment on the right. -/
 @[grind ←]
-theorem IsList_nil_ne_le_bot (S S₁ S₂ S₃ : HProp) (curr next : Addr) (hne : next ≠ null) :
-    S ∗ S₁ ∗ S₂ ∗ S₃ ∗ IsList [] curr next ⊑ ⊥ := by
-  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_)
-    (PartialOrder.rel_trans
-      (sepConj_mono_right (S ∗ S₁ ∗ S₂ ∗ S₃) (IsList_nil_le_bot curr next hne))
-      (sepConj_bot_le _))
-  grind
+theorem sepConj_IsList_nil_ne_le (A : HProp) (curr next : Addr) (hne : next ≠ null) (C : HProp) :
+    A ∗ IsList [] curr next ⊑ C :=
+  sepConj_le_of_right_le_bot A (IsList_nil_le_bot curr next hne) C
 
-/-- A precondition holding `IsList (v' :: rest') curr next` is contradictory when `next = null`. -/
+/-- A precondition holding a cons segment rooted at `null` is contradictory;
+`grind`'s AC theory for `∗` isolates the segment on the right. -/
 @[grind ←]
-theorem append_cons_absurd (S₁ S₂ S₃ : HProp) (v' : Nat) (rest' : List Nat) (curr next : Addr)
-    (R : HProp) (hnext : next = null) :
-    ((S₁ ∗ IsList (v' :: rest') curr next) ∗ S₂) ∗ S₃ ⊑ R := by
-  subst hnext
-  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_)
-    (PartialOrder.rel_trans
-      (sepConj_mono_right (S₁ ∗ S₂ ∗ S₃) (IsList_cons_null_le_bot v' rest' curr))
-      (PartialOrder.rel_trans (sepConj_bot_le _) (bot_le R)))
-  grind
+theorem sepConj_IsList_cons_null_le (A : HProp) (v : Nat) (vs : List Nat) (back : Addr)
+    (C : HProp) : A ∗ IsList (v :: vs) back null ⊑ C :=
+  sepConj_le_of_right_le_bot A (IsList_cons_null_le_bot v vs back) C
 
 /-- The append induction step: absorb the visited node into the wand (`wand_absorb` via
 `IsList_cons_intro`), matching the recursive call's precondition. -/
@@ -580,12 +579,12 @@ theorem append_cons_absurd (S₁ S₂ S₃ : HProp) (v' : Nat) (rest' : List Nat
 theorem append_step_le (v v' w : Nat) (rest' ws : List Nat) (back qb curr next q : Addr)
     (R : HProp) (hcn : curr ≠ null) :
     (IsList (w :: ws) qb q ∗ (IsList (v :: v' :: (rest' ++ w :: ws)) back curr -∗ R)) ∗
-        curr ↦ next ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗ IsList (v' :: rest') curr next ⊑
-      IsList (v' :: rest') curr next ∗ IsList (w :: ws) qb q ∗
+        curr ↦ next ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗ IsList (v' :: rest') curr next
+      ⊑ IsList (v' :: rest') curr next ∗ IsList (w :: ws) qb q ∗
         (IsList (v' :: rest' ++ w :: ws) curr next -∗ R) := by
   have habs : IsList (v' :: rest' ++ w :: ws) curr next ∗
-      (curr ↦ next ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v) ⊑
-        IsList (v :: v' :: (rest' ++ w :: ws)) back curr := by
+        curr ↦ next ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v
+      ⊑ IsList (v :: v' :: (rest' ++ w :: ws)) back curr := by
     refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_)
       (IsList_cons_intro v next back (v' :: (rest' ++ w :: ws)) curr hcn)
     grind
@@ -599,8 +598,8 @@ theorem append_step_le (v v' w : Nat) (rest' ws : List Nat) (back qb curr next q
 /-- Rebuild a cons cell around a rewritten prev field; the loaded next-pointer is the witness. -/
 @[grind ←]
 theorem store_prev_handoff (w : Nat) (ws : List Nat) (q c n : Addr) :
-    ((q ↦ n ∗ (q + 2) ↦ w) ∗ IsList ws q n) ∗ (q + 1) ↦ c ⊑
-      ⨆ n', q ↦ n' ∗ (q + 1) ↦ c ∗ (q + 2) ↦ w ∗ IsList ws q n' := by
+    ((q ↦ n ∗ (q + 2) ↦ w) ∗ IsList ws q n) ∗ (q + 1) ↦ c
+      ⊑ ⨆ n', q ↦ n' ∗ (q + 1) ↦ c ∗ (q + 2) ↦ w ∗ IsList ws q n' := by
   refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_) (le_iSup _ n)
   grind
 
@@ -843,15 +842,15 @@ theorem store_prev_IsList (w : Nat) (ws : List Nat) (qb q c : Addr) :
   simp only [IsList_cons_eq]
   vcgen [store_spec] with finish
 
-/-- Wand-style append specification: the continuation `R` receives the concatenated list once the
-traversal ends. The prefix walked so far lives in the wand. -/
+/-- Wand-style append specification: the schematic postcondition `Q` receives the concatenated list
+through the wand once the traversal ends. The prefix walked so far lives in the wand. -/
 theorem append_spec (fuel : Nat) (v w : Nat) (rest ws : List Nat) (back qb curr q : Addr)
-    (R : HProp) (hle : rest.length < fuel) :
+    (Q : Unit → HProp) (hle : rest.length < fuel) :
     ⦃ IsList (v :: rest) back curr ∗ IsList (w :: ws) qb q ∗
-        (IsList ((v :: rest) ++ w :: ws) back curr -∗ R) ⦄
+        (IsList ((v :: rest) ++ w :: ws) back curr -∗ Q ()) ⦄
       append fuel curr q
-    ⦃ fun _ => R ⦄ := by
-  induction rest generalizing v fuel curr back R with
+    ⦃ Q ⦄ := by
+  induction rest generalizing v fuel curr back Q with
   | nil =>
     match fuel, hle with
     | fuel + 1, _ =>
@@ -859,7 +858,7 @@ theorem append_spec (fuel : Nat) (v w : Nat) (rest ws : List Nat) (back qb curr 
       -- The `next ≠ null` arm is unreachable under `IsList []`; its recursive call takes the
       -- `⊥`-precondition spec and the arm closes by contradiction.
       vcgen [-load_spec, load_next_IsList, store_prev_IsList,
-        fun next => HeapM.triple_of_bot_pre (Q := fun _ => R) (append fuel next q)] with
+        fun next => HeapM.triple_of_bot_pre (Q := Q) (append fuel next q)] with
         finish
   | cons v' rest' ih =>
     match fuel, hle with
@@ -869,15 +868,14 @@ theorem append_spec (fuel : Nat) (v w : Nat) (rest ws : List Nat) (back qb curr 
       -- The `next = null` arm is unreachable under `IsList (v' :: rest')`; the recursive call
       -- takes the IH at the absorbed wand.
       vcgen [-load_spec, load_next_IsList, store_prev_IsList,
-        fun next => ih fuel v' curr next R (Nat.lt_of_succ_lt_succ hle)] with finish
+        fun next => ih fuel v' curr next Q (Nat.lt_of_succ_lt_succ hle)] with finish
 
 /-- Plain append specification, from `append_spec` at the trivial continuation. -/
 @[spec] theorem append_concat (v w : Nat) (rest ws : List Nat) (back qb curr q : Addr) :
     ⦃ IsList (v :: rest) back curr ∗ IsList (w :: ws) qb q ⦄
       append (rest.length + 1) curr q
     ⦃ fun _ => IsList ((v :: rest) ++ w :: ws) back curr ⦄ := by
-  vcgen [append_spec (rest.length + 1) v w rest ws back qb curr q
-    (IsList ((v :: rest) ++ w :: ws) back curr) (Nat.lt_succ_self _)] with finish
+  vcgen [append_spec (rest.length + 1) v w rest ws back qb] with finish
 
 /-- Framing an unrelated cell across the whole append. -/
 example (l : Addr) (z v w : Nat) (rest ws : List Nat) (back qb curr q : Addr) :

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -526,6 +526,24 @@ theorem IsList_cons_intro (v : Nat) (n back : Addr) (vs : List Nat) (p : Addr) (
   intro h hh
   exact (ofProp_meet_apply _ _ _).mpr ⟨hp, (iSup_hprop_apply _ _).mpr ⟨n, hh⟩⟩
 
+/-- Open a segment known to be non-empty: the head node's three cells and the tail segment.
+Mirror of `IsList_cons_intro`. -/
+theorem IsList_ne_le (rest : List Nat) (back curr : Addr) (hcn : curr ≠ null) :
+    IsList rest back curr ⊑
+      ⨆ v, ⨆ vs, ⨆ n, sepPure (rest = v :: vs) ∗
+        (curr ↦ n ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗ IsList vs curr n) := by
+  match rest with
+  | [] =>
+    refine PartialOrder.rel_trans ?_ (bot_le _)
+    intro h hh
+    exact (hcn ((sepPure_apply _ _).mp hh).1).elim
+  | v :: vs =>
+    rw [IsList_cons_eq]
+    refine ofProp_meet_le_left fun _ => iSup_le _ _ fun n => ?_
+    refine le_iSup_of_le v (le_iSup_of_le vs (le_iSup_of_le n (PartialOrder.rel_of_eq ?_)))
+    rw [show (v :: vs = v :: vs) = True from propext ⟨fun _ => trivial, fun _ => rfl⟩,
+      sepPure_true_eq_emp, emp_sepConj]
+
 /-- A segment rooted at `null` is empty. -/
 @[grind =] theorem IsList_null_eq (rest : List Nat) (back : Addr) :
     IsList rest back null = sepPure (rest = []) := by
@@ -832,17 +850,15 @@ theorem load_next_IsList_ne (rest : List Nat) (back curr : Addr) (hcn : curr ≠
       load curr
     ⦃ fun next => ⨆ v, ⨆ vs, ⌜rest = v :: vs⌝ ⊓
         (curr ↦ next ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗ IsList vs curr next) ⦄ := by
-  match rest with
-  | [] =>
-    exact ⟨PartialOrder.rel_trans (IsList_nil_le_bot back curr hcn)
-      (PartialOrder.rel_trans (bot_le _) (HeapM.triple_of_bot_pre (Q := _) (load curr)).le_wp)⟩
-  | v :: vs =>
-    simp only [IsList_cons_eq]
-    vcgen [load_spec] with (try finish)
-    refine PartialOrder.rel_trans ?_
-      (le_iSup_of_le v (le_iSup_of_le vs
-        (le_meet _ _ _ (le_ofProp _ _ rfl) PartialOrder.rel_refl)))
-    grind
+  refine ⟨PartialOrder.rel_trans (IsList_ne_le rest back curr hcn) ?_⟩
+  refine iSup_le _ _ fun v => iSup_le _ _ fun vs => iSup_le _ _ fun n => ?_
+  refine sepPure_sepConj_le_of _ _ _ fun hrest => ?_
+  subst hrest
+  vcgen [load_spec] with (try finish)
+  refine PartialOrder.rel_trans ?_
+    (le_iSup_of_le v (le_iSup_of_le vs
+      (le_meet _ _ _ (le_ofProp _ _ rfl) PartialOrder.rel_refl)))
+  grind
 
 /-- Loop invariant for `reverse` at loop state `(prev, curr)`: the unvisited segment `rest` hangs
 off `curr` with back-pointer `prev`, the reversed prefix `acc` sits at `prev` with back-pointer
@@ -923,31 +939,11 @@ the precondition, at the known result `if x = null then y else x`. The loop inva
 last visited node and carries a wand absorbing the visited prefix (`wand_absorb`); linking the
 last node discharges the prefix wand and the continuation wand by the counit. -/
 
-/-- Rebuild a cons cell around a rewritten prev field; the loaded next-pointer is the witness. -/
-theorem store_prev_handoff (w : Nat) (ws : List Nat) (q c n : Addr) :
-    q ↦ n ∗ (q + 2) ↦ w ∗ IsList ws q n ∗ (q + 1) ↦ c
-      ⊑ ⨆ n', q ↦ n' ∗ (q + 1) ↦ c ∗ (q + 2) ↦ w ∗ IsList ws q n' := by
-  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_) (le_iSup _ n)
-  grind
-
-grind_pattern store_prev_handoff => (q + 1) ↦ c, (q + 2) ↦ w, IsList ws q n
-
-/-- Rewrite the back-pointer of a cons cell by storing into its prev field. -/
-theorem store_prev_IsList (w : Nat) (ws : List Nat) (qb q c : Addr) :
-    ⦃ IsList (w :: ws) qb q ⦄ store (q + 1) c ⦃ fun _ => IsList (w :: ws) c q ⦄ := by
-  simp only [IsList_cons_eq]
-  vcgen [store_spec] with finish
-
-/-- Rewrite the back-pointer of a list head known to be non-null. The shape hypothesis reaches
-`finish` from the branch condition in scope. -/
+/-- Rewrite the back-pointer of a list head known to be non-null. -/
 theorem store_prev_IsList_ne (ys : List Nat) (qb y c : Addr) (hy : y ≠ null) :
     ⦃ IsList ys qb y ⦄ store (y + 1) c ⦃ fun _ => IsList ys c y ⦄ := by
-  match ys with
-  | [] =>
-    exact ⟨PartialOrder.rel_trans (IsList_nil_le_bot qb y hy)
-      (PartialOrder.rel_trans (bot_le _)
-        (HeapM.triple_of_bot_pre (Q := _) (store (y + 1) c)).le_wp)⟩
-  | w :: ws => exact store_prev_IsList w ws qb y c
+  refine ⟨PartialOrder.rel_trans (IsList_ne_le ys qb y hy) ?_⟩
+  vcgen [store_spec] with finish
 
 /-- Loop invariant for `append` at loop state `(t, u)`: `t` is the last visited node with
 next-pointer `u` and some prev-pointer `pt`, the unvisited segment `rest` hangs off `u`, a wand

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -693,49 +693,38 @@ def mkSepFrameSplit (i : FrameInferenceInfo) (frame footprint : Expr) : SymM Fra
       #[args[0]!, args[1]!, ← i.pre, sepFF, sepFR, hcl, mono]
     return FrameSplit.withDischargedSplitVC frame residualPre proof [sub.mvarId!]
 
-/-- Note [Framing a ramified spec]
+/-- Frame `emp` when the spec is ramified.
 
-A ramified spec does not state its postcondition. It takes a schematic `Q`, states what it really
-establishes as a resource `G`, and hands `G` to `Q` through a wand sitting in its own precondition:
+A ramified spec keeps its postcondition schematic and hands what it establishes to the caller
+through a wand in its own precondition:
 
     ⦃ P ∗ (G -∗ Q r₀) ⦄ x ⦃ Q ⦄
 
-Here `P` is what the spec consumes, `G` is what it produces (for `append_spec`, the concatenated
-list), and `r₀` is the result it returns. The point of writing a spec this way is that it frames
-itself: whatever the caller owns besides `P` can be carried into `Q` by the caller's own proof of
-the wand, so no frame ever has to be named.
+`P` is consumed, `G` is established (for `append_spec`, the concatenated list), `r₀` is the result.
+The caller's remaining resources reach `Q` through its proof of the wand, so the spec needs no
+frame.
 
-That is also why the ordinary cancellation path cannot apply such a spec. Frame inference works by
-cancelling the spec's precondition atoms against the goal's, and the wand atom `G -∗ Q r₀` has no
-counterpart in the goal: it is not a resource the caller holds, it is an obligation the caller
-discharges. Cancellation therefore leaves exactly one uncancelled atom, and it is always the wand.
+Atom cancellation cannot apply it. `G -∗ Q r₀` is an obligation rather than a resource, so the goal
+holds no atom to cancel it against and it is the one atom left over.
 
-The way out is to frame nothing at all. `emp` is a legitimate frame, and framing it still routes the
-application through the frame rule, which is what we want, because the frame rule replaces the goal's
-post `Q` by the `emp`-framed residual post and then re-applies the spec against it. If the footprint
-we hand back is the spec's own precondition spelled at that residual post, the re-application closes
-by unification, and unification is what pins the spec's schematics to the goal's values.
+Framing `emp` still routes the application through the frame rule, which re-posts the goal at
+`fun a => emp -∗ Q a` and re-applies the spec there. Spelling the footprint at that same post makes
+the re-application close by unification, pinning the spec's schematics to the goal's values.
 
-Worked example. The goal is `A ∗ B ⊑ wp (append fuel x y) Q` and the spec's precondition, once the
-schematic post has unified, is `?A ∗ ?B ∗ (?G -∗ Q ?r₀)`.
+On goal `A ∗ B ⊑ wp (append fuel x y) Q`, against a spec precondition `?A ∗ ?B ∗ (?G -∗ Q ?r₀)`:
 
-* `matchSepAtoms` pairs `?A`/`?B` with `A`/`B` and commits the assignments, which also pins `?G` and
-  `?r₀`. It reports the wand unmatched, and it arrives here as `wandAtom`.
-* We build `footprint = A ∗ B ∗ (G -∗ (emp -∗ Q r₀))`, the spec precondition with its wand rewrapped
-  at the `emp`-framed post.
-* The split VC `A ∗ B ⊑ emp ∗ residualPre` is proved by
-  `rel_trans (rel_trans q₂ q₃) (sepConj_mono_right sub₁)`, where `q₂` attaches the trivial wand
-  `G -∗ (emp -∗ G)` (`le_sepConj_wand_emp_wand_refl`, applicable because `G` coincides with the post
-  at `r₀`), `q₃` reassociates and inserts the `emp`, and `sub₁ : footprint ⊑ residualPre` is left
-  over.
-* The solver fills `residualPre` with the residual weakest precondition, whose post is
-  `fun a => emp -∗ Q a`. On `sub₁` the spec applies directly and its precondition VC is the footprint
-  against that same spelling, identical up to the spec's schematics, so it closes by unification.
-* The user is left with the spec's side premises, for `append` that is `xs.length ≤ fuel`, and the
-  `WP.Frames` condition for `emp`. `finish` closes both.
+* `matchSepAtoms` pairs `?A`/`?B` with `A`/`B`, which pins `?G` and `?r₀`, and reports the wand as
+  `wandAtom`.
+* `footprint := A ∗ B ∗ (G -∗ (emp -∗ Q r₀))`.
+* The split VC `A ∗ B ⊑ emp ∗ residualPre` is `rel_trans (rel_trans q₂ q₃) (sepConj_mono_right
+  sub₁)`. `q₂` attaches the trivial wand `G -∗ (emp -∗ G)` (`le_sepConj_wand_emp_wand_refl`,
+  available because `G` is the post at `r₀`), `q₃` reassociates and inserts the `emp`, and
+  `sub₁ : footprint ⊑ residualPre` survives.
+* `sub₁` closes when the spec re-applies, leaving the spec's side premises (for `append`,
+  `xs.length ≤ fuel`) and `WP.Frames` for `emp` to `finish`.
 
-When the wand's argument is not the post at `r₀` the trivial wand is unavailable, and `q₂`/`q₃` are
-replaced by a second subgoal `pre ⊑ emp ∗ footprint`. -/
+A wand whose argument is not the post at `r₀` loses `q₂`/`q₃` and leaves `pre ⊑ emp ∗ footprint`
+as a second subgoal. -/
 def mkEmpFrameSplit (i : FrameInferenceInfo) (matched : Array Expr) (wandAtom : Expr) :
     SymM (Option FrameSplit) := do
   let wandAtom ← instantiateMVarsS wandAtom

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -166,7 +166,6 @@ def append (fuel : Nat) (curr q : Addr) : HeapM Unit :=
     if next = null then
       store curr q
       store (q + 1) curr
-      pure ()
     else
       append fuel next q
 
@@ -847,7 +846,7 @@ through the wand once the traversal ends. The prefix walked so far lives in the 
 theorem append_spec (fuel : Nat) (v w : Nat) (rest ws : List Nat) (back qb curr q : Addr)
     (Q : Unit → HProp) (hle : rest.length < fuel) :
     ⦃ IsList (v :: rest) back curr ∗ IsList (w :: ws) qb q ∗
-        (IsList ((v :: rest) ++ w :: ws) back curr -∗ Q ()) ⦄
+        (IsList ((v :: rest) ++ w :: ws) back curr -∗ Q ⟨⟩) ⦄
       append fuel curr q
     ⦃ Q ⦄ := by
   induction rest generalizing v fuel curr back Q with

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -1146,7 +1146,7 @@ theorem append_spec (fuel : Nat) (xs ys : List Nat) (back qb x y : Addr) (Q : Ad
   · have hb : (if x = null then qb else back) = back := by grind
     have hr : (if x = null then y else x) = x := by grind
     rw [hb, hr]
-    have hlen' : xs.length ≤ ([:fuel] : Std.Legacy.Range).toList.length := by grind
+    have hlen' : xs.length ≤ (ForIn.toList [:fuel]).length := by grind
     vcgen [append, load_next_IsList_ne, store_prev_IsList_ne] invariants
       | inv1 => fun _ suff b =>
           AppendLoopInv xs ys back qb x y (IsList (xs ++ ys) back x -∗ Q x) suff.length b

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -703,10 +703,31 @@ def mkSepFrameSplit (i : FrameInferenceInfo) (frame footprint : Expr) : SymM Fra
       #[args[0]!, args[1]!, ← i.pre, sepFF, sepFR, hcl, mono]
     return FrameSplit.withDischargedSplitVC frame residualPre proof [sub.mvarId!]
 
-/-- Frame `emp` for a spec precondition that adds a wand to the goal's atoms: the footprint mirrors
-the spec precondition (matched goal atoms in spec order, then the wand with its conclusion rewrapped
-at the `emp`-framed residual post). The split VC `pre ⊑ emp ∗ residualPre` factors through
-`pre ⊑ emp ∗ footprint`, left as a subgoal. -/
+/-- Frame `emp` for a *ramified* spec: a spec with schematic postcondition `Q` that auto-frames by
+receiving `Q` through a wand in its precondition, `⦃ P ∗ (G -∗ Q ⟨⟩) ⦄ x ⦃ Q ⦄`. The goal
+precondition has no wand atom, so such a spec never matches outright.
+
+Worked example: goal `A ∗ B ⊑ wp (append n curr q) Q` against the ramified append spec, whose
+precondition is `?A ∗ ?B ∗ (?G -∗ Q ⟨⟩)` after the schematic post unifies.
+- `matchSepAtoms` pairs `?A`/`?B` with `A`/`B`, committing the assignments (which also pin `?G`),
+  and reports the wand `G -∗ Q ⟨⟩` unmatched; it arrives here as `wandAtom`.
+- The `footprint` mirrors the spec precondition at the `emp`-framed residual post:
+  `A ∗ B ∗ (G -∗ (emp -∗ Q ⟨⟩))`.
+- The split VC `A ∗ B ⊑ emp ∗ residualPre` is discharged as
+  `rel_trans (rel_trans q₂ q₃) (sepConj_mono_right sub₁)`:
+  `q₂ : A ∗ B ⊑ (A ∗ B) ∗ (G -∗ (emp -∗ G))` attaches the trivial wand
+  (`le_sepConj_wand_emp_wand_refl`; valid because `G` is the post at `⟨⟩`),
+  `q₃` reassociates and inserts `emp` (AC with identity), and
+  `sub₁ : footprint ⊑ residualPre` is the sole surviving subgoal.
+- The solver fills `residualPre` with the residual weakest precondition, whose post is the
+  `emp`-framed `fun a => emp -∗ Q a`. On `sub₁` the spec applies directly, and its precondition VC
+  pits the footprint against the spec precondition at that same post: the same term up to the
+  spec's schematics, so it closes by unification, pinning the schematics to the goal's values.
+- What remains for the user: the spec's side premises (for append, `rest.length < fuel`) and the
+  `WP.Frames` condition for `emp`, both closed by `finish`.
+
+A wand whose argument differs from the post at `⟨⟩` leaves `pre ⊑ emp ∗ footprint` as a second
+subgoal in place of `q₂`/`q₃`. -/
 def mkEmpFrameSplit (i : FrameInferenceInfo) (matched : Array Expr) (wandAtom : Expr) :
     SymM (Option FrameSplit) := do
   let wandAtom ← instantiateMVarsS wandAtom
@@ -766,10 +787,7 @@ def sepConjFrameProc : FrameInferenceProc := fun i => do
       if rest.isEmpty then return none
       return some (← mkSepFrameSplit i (← sepConjOfAtoms rest) (← sepConjOfAtoms matched))
     | (#[], matched, #[wandAtom]) =>
-      -- Everything matched except a wand: frame `emp` and mirror the spec's precondition as the
-      -- footprint, with the wand's conclusion rewrapped at the `emp`-framed residual post. The
-      -- re-application against the residual then closes its precondition VC by unification,
-      -- instantiating the spec's schematics at the goal's values.
+      -- Everything matched except a wand: a ramified spec.
       mkEmpFrameSplit i matched wandAtom
     | _ => return none
 

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -204,8 +204,13 @@ def pointsTo (l : Addr) (v : Nat) : HProp := HProp.mk fun h => h = Heap.single l
 def sepConj (P Q : HProp) : HProp :=
   HProp.mk fun h => ∃ h₁ h₂, h₁.disjoint h₂ ∧ h = h₁.union h₂ ∧ P.get h₁ ∧ Q.get h₂
 
+/-- Magic wand: the upper adjoint of the separating conjunction `P ∗ ·`. The adjoint construction
+is an implementation detail; `wand_def` is the interface. -/
+noncomputable def wand (P Q : HProp) : HProp := PreservesSup.upperAdjoint (sepConj P) Q
+
 @[inherit_doc pointsTo] local notation:70 l:max " ↦ " v:max => pointsTo l v
 @[inherit_doc sepConj] local infixr:65 " ∗ " => sepConj
+@[inherit_doc wand] local infixr:60 " -∗ " => wand
 
 @[simp, grind =] theorem emp_get (h : Heap) : emp.get h = ∀ n, h n = none := rfl
 @[simp, grind =] theorem pointsTo_get (l : Addr) (v : Nat) (h : Heap) :
@@ -215,6 +220,37 @@ def sepConj (P Q : HProp) : HProp :=
 -- unfolding. The focusing lemma `pointsTo_sepConj_get` is the `grind`-facing characterization of `∗`.
 theorem sepConj_get (P Q : HProp) (h : Heap) :
     (P ∗ Q).get h = ∃ h₁ h₂, h₁.disjoint h₂ ∧ h = h₁.union h₂ ∧ P.get h₁ ∧ Q.get h₂ := rfl
+
+/-- The wand's interface: extending by any disjoint `P` heap yields a `Q` heap. -/
+theorem wand_def (P Q : HProp) :
+    (P -∗ Q) = HProp.mk fun h => ∀ h', h.disjoint h' → P.get h' → Q.get (h.union h') := by
+  apply PartialOrder.rel_antisymm
+  · unfold wand PreservesSup.upperAdjoint
+    apply sup_le
+    intro x hx h hxh h' hdisj hF
+    exact hx (h.union h') ⟨h', h, Heap.disjoint_comm hdisj, Heap.union_comm hdisj, hF, hxh⟩
+  · unfold wand PreservesSup.upperAdjoint
+    refine le_sup (c := fun x => sepConj P x ⊑ Q) ?_
+    rintro k ⟨h₁, h₂, hd, rfl, hP, hx⟩
+    have := hx h₁ (Heap.disjoint_comm hd) hP
+    rwa [Heap.union_comm (Heap.disjoint_comm hd)] at this
+
+theorem wand_get (P Q : HProp) (h : Heap) :
+    (P -∗ Q).get h = ∀ h', h.disjoint h' → P.get h' → Q.get (h.union h') := by
+  rw [wand_def]; rfl
+
+/-- The counit of the adjunction `F ∗ · ⊣ F -∗ ·`. -/
+theorem sepConj_wand_le (F b : HProp) : (F ∗ (F -∗ b)) ⊑ b := by
+  rw [wand_def]
+  rintro h ⟨h₁, h₂, hd, rfl, hF, hw⟩
+  have := hw h₁ (Heap.disjoint_comm hd) hF
+  rwa [Heap.union_comm (Heap.disjoint_comm hd)] at this
+
+/-- Adjunction introduction: to land below a wand, frame its argument onto the entailment. -/
+theorem le_wand (F X G : HProp) (h : F ∗ X ⊑ G) : X ⊑ F -∗ G := by
+  rw [wand_def]
+  intro k hX h' hdisj hF
+  exact h (k.union h') ⟨h', k, Heap.disjoint_comm hdisj, Heap.union_comm hdisj, hF, hX⟩
 
 /-! ## The separation algebra laws -/
 
@@ -338,36 +374,6 @@ instance (F : HProp) : PreservesSup (sepConj F) where
       exact ⟨sepConj F x, ⟨x, hx, rfl⟩, h₁, h₂, hd, rfl, hF, hxh₂⟩
     · rintro ⟨f, ⟨x, hx, rfl⟩, h₁, h₂, hd, rfl, hF, hxh₂⟩
       exact ⟨h₁, h₂, hd, rfl, hF, x, hx, hxh₂⟩
-
-/-- Magic wand: the upper adjoint of the separating conjunction `P ∗ ·`. An abbreviation, so
-`vcgen`'s built-in `upperAdjoint` decomposition applies to it on the right-hand side of an
-entailment. -/
-noncomputable abbrev wand (P Q : HProp) : HProp := PreservesSup.upperAdjoint (sepConj P) Q
-
-@[inherit_doc wand] local infixr:60 " -∗ " => wand
-
-/-- The counit of the adjunction `F ∗ · ⊣ F -∗ ·`. -/
-theorem sepConj_wand_le (F b : HProp) : (F ∗ (F -∗ b)) ⊑ b :=
-  PreservesSup.upperAdjoint_le (sepConj F) b
-
-/-- Adjunction introduction: to land below a wand, frame its argument onto the entailment. -/
-theorem le_wand (F X G : HProp) (h : F ∗ X ⊑ G) : X ⊑ F -∗ G :=
-  PreservesSup.le_upperAdjoint (sepConj F) h
-
-/-- Pointwise characterization of the wand, from the adjunction laws. -/
-theorem wand_get (P Q : HProp) (h : Heap) :
-    (P -∗ Q).get h = ∀ h', h.disjoint h' → P.get h' → Q.get (h.union h') := by
-  apply propext
-  constructor
-  · intro hw h' hdisj hP
-    exact sepConj_wand_le P Q (h.union h')
-      ⟨h', h, Heap.disjoint_comm hdisj, Heap.union_comm hdisj, hP, hw⟩
-  · intro hw
-    refine le_wand P (HProp.mk fun k => ∀ h', k.disjoint h' → P.get h' → Q.get (k.union h')) Q
-      ?_ h hw
-    rintro k ⟨h₁, h₂, hd, rfl, hP, hx⟩
-    have := hx h₁ (Heap.disjoint_comm hd) hP
-    rwa [Heap.union_comm (Heap.disjoint_comm hd)] at this
 
 /-! ## The frame-internalizing weakest precondition -/
 
@@ -731,14 +737,19 @@ subgoal in place of `q₂`/`q₃`. -/
 def mkEmpFrameSplit (i : FrameInferenceInfo) (matched : Array Expr) (wandAtom : Expr) :
     SymM (Option FrameSplit) := do
   let wandAtom ← instantiateMVarsS wandAtom
-  -- `wandAtom = upperAdjoint (sepConj G) b`; rewrap `b` as `emp -∗ b` to mirror the residual post.
-  let #[alpha, instCL, sepConjG, b] := wandAtom.getAppArgs | return none
+  -- `wandAtom = G -∗ b`; rewrap `b` at the `emp`-framed residual post.
+  unless wandAtom.isAppOfArity ``wand 2 do return none
   if wandAtom.hasExprMVar then return none
-  let uaFn := wandAtom.getAppFn
+  let G := wandAtom.appFn!.appArg!
+  let b := wandAtom.appArg!
   let empE ← mkConstS ``emp
+  -- The inner wrapper mirrors the residual post the frame rule builds, in the frame rule's own
+  -- spelling (`PreservesSup.upperAdjoint`), so the re-application's precondition VC closes by
+  -- unification.
   let sepConjEmp ← mkAppNS (← mkConstS ``sepConj) #[empE]
-  let inner ← mkAppNS uaFn #[alpha, instCL, sepConjEmp, b]
-  let wrapped ← mkAppNS uaFn #[alpha, instCL, sepConjG, inner]
+  let inner ← shareCommon (← Meta.mkAppOptM ``Lean.Order.PreservesSup.upperAdjoint
+    #[none, none, some sepConjEmp, some b])
+  let wrapped ← mkAppNS (← mkConstS ``wand) #[G, inner]
   let footprint ← sepConjOfAtoms (matched.push wrapped)
   let le ← i.le
   let residualPre ← i.mkResidualPre
@@ -754,7 +765,6 @@ def mkEmpFrameSplit (i : FrameInferenceInfo) (matched : Array Expr) (wandAtom : 
   let pre ← i.pre
   -- A trivial continuation (the wand's argument is the residual post itself) discharges
   -- `pre ⊑ emp ∗ footprint` in place: attach the trivial wand, then reassociate.
-  let G := sepConjG.appArg!
   if isSameExpr G b then
     let preW ← mkAppNS sepConjE #[pre, wrapped]
     if let some q3 ← proveSepConjLe preW empFoot then

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -544,19 +544,6 @@ theorem IsList_ne_le (rest : List Nat) (back curr : Addr) (hcn : curr ≠ null) 
     rw [show (v :: vs = v :: vs) = True from propext ⟨fun _ => trivial, fun _ => rfl⟩,
       sepPure_true_eq_emp, emp_sepConj]
 
-/-- Choose the witness of a `⨆`-shaped precondition out of a non-empty segment: opening the node
-exposes its next-pointer, which is the value the cell holds. The `⨆` body stays schematic, so this
-serves `load` and `store` alike. -/
-theorem IsList_le_iSup (rest : List Nat) (back curr : Addr) (f : Addr → HProp)
-    (hcn : curr ≠ null)
-    (h : ∀ v vs n, rest = v :: vs →
-      (curr ↦ n ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗ IsList vs curr n) ⊑ f n) :
-    IsList rest back curr ⊑ ⨆ n, f n := by
-  refine PartialOrder.rel_trans (IsList_ne_le rest back curr hcn) ?_
-  refine iSup_le _ _ fun v => iSup_le _ _ fun vs => iSup_le _ _ fun n => ?_
-  refine sepPure_sepConj_le_of _ _ _ fun hrest => ?_
-  exact le_iSup_of_le n (h v vs n hrest)
-
 /-- A segment rooted at `null` is empty. -/
 @[grind =] theorem IsList_null_eq (rest : List Nat) (back : Addr) :
     IsList rest back null = sepPure (rest = []) := by
@@ -813,61 +800,38 @@ def sepConjFrameProc : FrameInferenceProc := fun i => do
 /-! ## Primitive specs -/
 
 /-- Storing overwrites the cell, framing every disjoint heap by construction. -/
-@[spec] theorem store_spec_default (l : Addr) (v w : Nat) :
+@[spec] theorem store_spec (l : Addr) (v w : Nat) :
     ⦃ l ↦ v ⦄ (store l w) ⦃ fun _ => l ↦ w ⦄ := by
   refine HeapM.triple_of_triple_StateM_run fun F => ?_
   simp only [store, HeapM.run_mk]
   vcgen with finish
 
 /-- Loading returns the stored value and leaves the cell in place. -/
-@[spec] theorem load_spec_default (l : Addr) (v : Nat) :
+@[spec] theorem load_spec (l : Addr) (v : Nat) :
     ⦃ l ↦ v ⦄ (load l) ⦃ fun r => sepPure (r = v) ∗ l ↦ v ⦄ := by
   refine HeapM.triple_of_triple_StateM_run fun F => ?_
   simp only [load, HeapM.run_mk]
   vcgen with finish
 
-/-- Weakest precondition of `store`. The cell's current value is bound by the `⨆`, so an entailment
-proof chooses it per heap rather than having to name it up front, and the continuation receives the
-updated cell through the wand. -/
-theorem store_spec (l : Addr) (w : Nat) (Q : Unit → HProp) :
-    ⦃ ⨆ v, l ↦ v ∗ (l ↦ w -∗ Q ⟨⟩) ⦄ (store l w) ⦃ Q ⦄ := by
-  refine ⟨iSup_le _ _ fun v => ?_⟩
-  vcgen [store_spec_default l v w] with (try finish)
-  exact PartialOrder.rel_trans (PartialOrder.rel_of_eq (sepConj_comm _ _)) (sepConj_wand_le _ _)
-
-/-- Weakest precondition of `load`. The stored value is bound by the `⨆`, and the continuation
-receives the cell back through the wand at that value. -/
-theorem load_spec (l : Addr) (Q : Nat → HProp) :
-    ⦃ ⨆ v, l ↦ v ∗ (l ↦ v -∗ Q v) ⦄ (load l) ⦃ Q ⦄ := by
-  refine ⟨iSup_le _ _ fun v => ?_⟩
-  vcgen [load_spec_default l v] with (try finish)
-  rename_i r
-  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
-    sepPure (r = v) ∗ (l ↦ v ∗ (l ↦ v -∗ Q v)))) ?_
-  · grind
-  refine sepPure_sepConj_le_of _ _ _ fun hr => ?_
-  subst hr
-  exact sepConj_wand_le _ _
-
 /-! ## Framing examples -/
 
 example (l1 l2 : Addr) (a b x : Nat) :
     ⦃ l1 ↦ a ∗ l2 ↦ b ⦄ (store l1 x) ⦃ fun _ => l1 ↦ x ∗ l2 ↦ b ⦄ := by
-  vcgen [store_spec_default] with finish
+  vcgen [store_spec] with finish
 
 example (l1 l2 : Addr) (a b x : Nat) :
     ⦃ l1 ↦ a ∗ l2 ↦ b ⦄ (store l1 x) ⦃ fun _ => l1 ↦ x ∗ l2 ↦ b ⦄ := by
-  vcgen [store_spec_default] frames | store l1 x => (l2 ↦ b) with finish
+  vcgen [store_spec] frames | store l1 x => (l2 ↦ b) with finish
 
 example (l1 l2 : Addr) (a b : Nat) :
     ⦃ l1 ↦ a ∗ l2 ↦ b ⦄ (load l1) ⦃ fun r => l2 ↦ b ∗ sepPure (r = a) ∗ l1 ↦ a ⦄ := by
-  vcgen [load_spec_default] with finish
+  vcgen [load_spec] with finish
 
 /-- A probe program with its own spec, used only to exercise `FrameInferenceInfo.spec`. -/
 def probe (l : Addr) : HeapM Unit := store l 0
 
 @[spec] theorem probe_spec (l : Addr) (v : Nat) : ⦃ l ↦ v ⦄ probe l ⦃ fun _ => l ↦ 0 ⦄ :=
-  store_spec_default l v 0
+  store_spec l v 0
 
 -- Framing `probe l1` reports the applied spec `probe_spec`, read off `FrameInferenceInfo.spec`.
 /-- info: framing for spec some (probe_spec) -/
@@ -879,21 +843,22 @@ example (l1 l2 : Addr) (a b : Nat) :
 /-! ## In-place reverse -/
 
 /-- Load the next-pointer of a list node known to be non-null: the segment must then be a cons,
-and the loaded value is its `IsList` witness. A specialization of `load_spec`, whose `⨆` witness
-`IsList_le_iSup` reads off the opened node. -/
+and the loaded value is its `IsList` witness. The shape hypothesis reaches `finish` from the
+branch condition in scope. -/
 theorem load_next_IsList_ne (rest : List Nat) (back curr : Addr) (hcn : curr ≠ null) :
     ⦃ IsList rest back curr ⦄
       load curr
     ⦃ fun next => ⨆ v, ⨆ vs, ⌜rest = v :: vs⌝ ⊓
         (curr ↦ next ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗ IsList vs curr next) ⦄ := by
-  refine ⟨PartialOrder.rel_trans (IsList_le_iSup rest back curr _ hcn fun v vs n hrest => ?_)
-    (load_spec curr _).le_wp⟩
-  refine sepConj_mono_right _ (le_wand _ _ _ ?_)
-  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
-    curr ↦ n ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗ IsList vs curr n)) ?_
-  · grind
-  exact le_iSup_of_le v (le_iSup_of_le vs
-    (le_meet _ _ _ (le_ofProp _ _ hrest) PartialOrder.rel_refl))
+  refine ⟨PartialOrder.rel_trans (IsList_ne_le rest back curr hcn) ?_⟩
+  refine iSup_le _ _ fun v => iSup_le _ _ fun vs => iSup_le _ _ fun n => ?_
+  refine sepPure_sepConj_le_of _ _ _ fun hrest => ?_
+  subst hrest
+  vcgen [load_spec] with (try finish)
+  refine PartialOrder.rel_trans ?_
+    (le_iSup_of_le v (le_iSup_of_le vs
+      (le_meet _ _ _ (le_ofProp _ _ rfl) PartialOrder.rel_refl)))
+  grind
 
 /-- Loop invariant for `reverse` at loop state `(prev, curr)`: the unvisited segment `rest` hangs
 off `curr` with back-pointer `prev`, the reversed prefix `acc` sits at `prev` with back-pointer
@@ -974,24 +939,11 @@ the precondition, at the known result `if x = null then y else x`. The loop inva
 last visited node and carries a wand absorbing the visited prefix (`wand_absorb`); linking the
 last node discharges the prefix wand and the continuation wand by the counit. -/
 
-/-- Rewrite the back-pointer of a list head known to be non-null. A specialization of
-`store_spec`, whose `⨆` witness is the node's current prev field. -/
+/-- Rewrite the back-pointer of a list head known to be non-null. -/
 theorem store_prev_IsList_ne (ys : List Nat) (qb y c : Addr) (hy : y ≠ null) :
     ⦃ IsList ys qb y ⦄ store (y + 1) c ⦃ fun _ => IsList ys c y ⦄ := by
-  refine ⟨PartialOrder.rel_trans ?_ (store_spec (y + 1) c _).le_wp⟩
-  refine PartialOrder.rel_trans (IsList_ne_le ys qb y hy) ?_
-  refine iSup_le _ _ fun v => iSup_le _ _ fun vs => iSup_le _ _ fun n => ?_
-  refine sepPure_sepConj_le_of _ _ _ fun hys => ?_
-  refine le_iSup_of_le qb ?_
-  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
-    (y + 1) ↦ qb ∗ (y ↦ n ∗ (y + 2) ↦ v ∗ IsList vs y n))) ?_
-  · grind
-  refine sepConj_mono_right _ (le_wand _ _ _ ?_)
-  subst hys
-  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
-    y ↦ n ∗ (y + 1) ↦ c ∗ (y + 2) ↦ v ∗ IsList vs y n)) ?_
-  · grind
-  exact IsList_cons_intro v n c vs y hy
+  refine ⟨PartialOrder.rel_trans (IsList_ne_le ys qb y hy) ?_⟩
+  vcgen [store_spec] with finish
 
 /-- Loop invariant for `append` at loop state `(t, u)`: `t` is the last visited node with
 next-pointer `u` and some prev-pointer `pt`, the unvisited segment `rest` hangs off `u`, a wand

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -544,6 +544,19 @@ theorem IsList_ne_le (rest : List Nat) (back curr : Addr) (hcn : curr ≠ null) 
     rw [show (v :: vs = v :: vs) = True from propext ⟨fun _ => trivial, fun _ => rfl⟩,
       sepPure_true_eq_emp, emp_sepConj]
 
+/-- Choose the witness of a `⨆`-shaped precondition out of a non-empty segment: opening the node
+exposes its next-pointer, which is the value the cell holds. The `⨆` body stays schematic, so this
+serves `load` and `store` alike. -/
+theorem IsList_le_iSup (rest : List Nat) (back curr : Addr) (f : Addr → HProp)
+    (hcn : curr ≠ null)
+    (h : ∀ v vs n, rest = v :: vs →
+      (curr ↦ n ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗ IsList vs curr n) ⊑ f n) :
+    IsList rest back curr ⊑ ⨆ n, f n := by
+  refine PartialOrder.rel_trans (IsList_ne_le rest back curr hcn) ?_
+  refine iSup_le _ _ fun v => iSup_le _ _ fun vs => iSup_le _ _ fun n => ?_
+  refine sepPure_sepConj_le_of _ _ _ fun hrest => ?_
+  exact le_iSup_of_le n (h v vs n hrest)
+
 /-- A segment rooted at `null` is empty. -/
 @[grind =] theorem IsList_null_eq (rest : List Nat) (back : Addr) :
     IsList rest back null = sepPure (rest = []) := by
@@ -800,38 +813,61 @@ def sepConjFrameProc : FrameInferenceProc := fun i => do
 /-! ## Primitive specs -/
 
 /-- Storing overwrites the cell, framing every disjoint heap by construction. -/
-@[spec] theorem store_spec (l : Addr) (v w : Nat) :
+@[spec] theorem store_spec_default (l : Addr) (v w : Nat) :
     ⦃ l ↦ v ⦄ (store l w) ⦃ fun _ => l ↦ w ⦄ := by
   refine HeapM.triple_of_triple_StateM_run fun F => ?_
   simp only [store, HeapM.run_mk]
   vcgen with finish
 
 /-- Loading returns the stored value and leaves the cell in place. -/
-@[spec] theorem load_spec (l : Addr) (v : Nat) :
+@[spec] theorem load_spec_default (l : Addr) (v : Nat) :
     ⦃ l ↦ v ⦄ (load l) ⦃ fun r => sepPure (r = v) ∗ l ↦ v ⦄ := by
   refine HeapM.triple_of_triple_StateM_run fun F => ?_
   simp only [load, HeapM.run_mk]
   vcgen with finish
 
+/-- Weakest precondition of `store`. The cell's current value is bound by the `⨆`, so an entailment
+proof chooses it per heap rather than having to name it up front, and the continuation receives the
+updated cell through the wand. -/
+theorem store_spec (l : Addr) (w : Nat) (Q : Unit → HProp) :
+    ⦃ ⨆ v, l ↦ v ∗ (l ↦ w -∗ Q ⟨⟩) ⦄ (store l w) ⦃ Q ⦄ := by
+  refine ⟨iSup_le _ _ fun v => ?_⟩
+  vcgen [store_spec_default l v w] with (try finish)
+  exact PartialOrder.rel_trans (PartialOrder.rel_of_eq (sepConj_comm _ _)) (sepConj_wand_le _ _)
+
+/-- Weakest precondition of `load`. The stored value is bound by the `⨆`, and the continuation
+receives the cell back through the wand at that value. -/
+theorem load_spec (l : Addr) (Q : Nat → HProp) :
+    ⦃ ⨆ v, l ↦ v ∗ (l ↦ v -∗ Q v) ⦄ (load l) ⦃ Q ⦄ := by
+  refine ⟨iSup_le _ _ fun v => ?_⟩
+  vcgen [load_spec_default l v] with (try finish)
+  rename_i r
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
+    sepPure (r = v) ∗ (l ↦ v ∗ (l ↦ v -∗ Q v)))) ?_
+  · grind
+  refine sepPure_sepConj_le_of _ _ _ fun hr => ?_
+  subst hr
+  exact sepConj_wand_le _ _
+
 /-! ## Framing examples -/
 
 example (l1 l2 : Addr) (a b x : Nat) :
     ⦃ l1 ↦ a ∗ l2 ↦ b ⦄ (store l1 x) ⦃ fun _ => l1 ↦ x ∗ l2 ↦ b ⦄ := by
-  vcgen [store_spec] with finish
+  vcgen [store_spec_default] with finish
 
 example (l1 l2 : Addr) (a b x : Nat) :
     ⦃ l1 ↦ a ∗ l2 ↦ b ⦄ (store l1 x) ⦃ fun _ => l1 ↦ x ∗ l2 ↦ b ⦄ := by
-  vcgen [store_spec] frames | store l1 x => (l2 ↦ b) with finish
+  vcgen [store_spec_default] frames | store l1 x => (l2 ↦ b) with finish
 
 example (l1 l2 : Addr) (a b : Nat) :
     ⦃ l1 ↦ a ∗ l2 ↦ b ⦄ (load l1) ⦃ fun r => l2 ↦ b ∗ sepPure (r = a) ∗ l1 ↦ a ⦄ := by
-  vcgen [load_spec] with finish
+  vcgen [load_spec_default] with finish
 
 /-- A probe program with its own spec, used only to exercise `FrameInferenceInfo.spec`. -/
 def probe (l : Addr) : HeapM Unit := store l 0
 
 @[spec] theorem probe_spec (l : Addr) (v : Nat) : ⦃ l ↦ v ⦄ probe l ⦃ fun _ => l ↦ 0 ⦄ :=
-  store_spec l v 0
+  store_spec_default l v 0
 
 -- Framing `probe l1` reports the applied spec `probe_spec`, read off `FrameInferenceInfo.spec`.
 /-- info: framing for spec some (probe_spec) -/
@@ -843,22 +879,21 @@ example (l1 l2 : Addr) (a b : Nat) :
 /-! ## In-place reverse -/
 
 /-- Load the next-pointer of a list node known to be non-null: the segment must then be a cons,
-and the loaded value is its `IsList` witness. The shape hypothesis reaches `finish` from the
-branch condition in scope. -/
+and the loaded value is its `IsList` witness. A specialization of `load_spec`, whose `⨆` witness
+`IsList_le_iSup` reads off the opened node. -/
 theorem load_next_IsList_ne (rest : List Nat) (back curr : Addr) (hcn : curr ≠ null) :
     ⦃ IsList rest back curr ⦄
       load curr
     ⦃ fun next => ⨆ v, ⨆ vs, ⌜rest = v :: vs⌝ ⊓
         (curr ↦ next ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗ IsList vs curr next) ⦄ := by
-  refine ⟨PartialOrder.rel_trans (IsList_ne_le rest back curr hcn) ?_⟩
-  refine iSup_le _ _ fun v => iSup_le _ _ fun vs => iSup_le _ _ fun n => ?_
-  refine sepPure_sepConj_le_of _ _ _ fun hrest => ?_
-  subst hrest
-  vcgen [load_spec] with (try finish)
-  refine PartialOrder.rel_trans ?_
-    (le_iSup_of_le v (le_iSup_of_le vs
-      (le_meet _ _ _ (le_ofProp _ _ rfl) PartialOrder.rel_refl)))
-  grind
+  refine ⟨PartialOrder.rel_trans (IsList_le_iSup rest back curr _ hcn fun v vs n hrest => ?_)
+    (load_spec curr _).le_wp⟩
+  refine sepConj_mono_right _ (le_wand _ _ _ ?_)
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
+    curr ↦ n ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗ IsList vs curr n)) ?_
+  · grind
+  exact le_iSup_of_le v (le_iSup_of_le vs
+    (le_meet _ _ _ (le_ofProp _ _ hrest) PartialOrder.rel_refl))
 
 /-- Loop invariant for `reverse` at loop state `(prev, curr)`: the unvisited segment `rest` hangs
 off `curr` with back-pointer `prev`, the reversed prefix `acc` sits at `prev` with back-pointer
@@ -939,11 +974,24 @@ the precondition, at the known result `if x = null then y else x`. The loop inva
 last visited node and carries a wand absorbing the visited prefix (`wand_absorb`); linking the
 last node discharges the prefix wand and the continuation wand by the counit. -/
 
-/-- Rewrite the back-pointer of a list head known to be non-null. -/
+/-- Rewrite the back-pointer of a list head known to be non-null. A specialization of
+`store_spec`, whose `⨆` witness is the node's current prev field. -/
 theorem store_prev_IsList_ne (ys : List Nat) (qb y c : Addr) (hy : y ≠ null) :
     ⦃ IsList ys qb y ⦄ store (y + 1) c ⦃ fun _ => IsList ys c y ⦄ := by
-  refine ⟨PartialOrder.rel_trans (IsList_ne_le ys qb y hy) ?_⟩
-  vcgen [store_spec] with finish
+  refine ⟨PartialOrder.rel_trans ?_ (store_spec (y + 1) c _).le_wp⟩
+  refine PartialOrder.rel_trans (IsList_ne_le ys qb y hy) ?_
+  refine iSup_le _ _ fun v => iSup_le _ _ fun vs => iSup_le _ _ fun n => ?_
+  refine sepPure_sepConj_le_of _ _ _ fun hys => ?_
+  refine le_iSup_of_le qb ?_
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
+    (y + 1) ↦ qb ∗ (y ↦ n ∗ (y + 2) ↦ v ∗ IsList vs y n))) ?_
+  · grind
+  refine sepConj_mono_right _ (le_wand _ _ _ ?_)
+  subst hys
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq (?_ : _ =
+    y ↦ n ∗ (y + 1) ↦ c ∗ (y + 2) ↦ v ∗ IsList vs y n)) ?_
+  · grind
+  exact IsList_cons_intro v n c vs y hy
 
 /-- Loop invariant for `append` at loop state `(t, u)`: `t` is the last visited node with
 next-pointer `u` and some prev-pointer `pt`, the unvisited segment `rest` hangs off `u`, a wand

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -778,8 +778,12 @@ def mkEmpFrameSplit (i : FrameInferenceInfo) (matched : Array Expr) (wandAtom : 
     [sub2.mvarId!, sub1.mvarId!])
 
 /-- Automatic frame inference by domain difference: the spec's precondition's atoms (its footprint)
-are cancelled from the goal precondition's; the leftover atoms are the frame. A pinned `frames`
-resource cancels its own atoms instead, leaving the split VC open when they are missing. -/
+are cancelled from the goal precondition's, and the leftover atoms are the frame. Example: goal
+precondition `l1 ↦ a ∗ l2 ↦ b` against `store_spec`'s `?l ↦ ?v` cancels `l1 ↦ a` (pinning
+`?l := l1`, `?v := a`), frames `l2 ↦ b`, and proves the split VC by AC-rearrangement. A pinned
+`frames` resource cancels its own atoms instead, leaving the split VC open when they are missing.
+A spec whose only uncancelled atom is a wand `?G -∗ Q ⟨⟩` is ramified and goes to
+`mkEmpFrameSplit`. -/
 def sepConjFrameProc : FrameInferenceProc := fun i => do
   -- Exercises `FrameInferenceInfo.spec?`: a real frameproc keys a footprint off the applied spec's
   -- name. `probe_spec` isolates the report to the one test example below.

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -204,24 +204,17 @@ def pointsTo (l : Addr) (v : Nat) : HProp := HProp.mk fun h => h = Heap.single l
 def sepConj (P Q : HProp) : HProp :=
   HProp.mk fun h => ∃ h₁ h₂, h₁.disjoint h₂ ∧ h = h₁.union h₂ ∧ P.get h₁ ∧ Q.get h₂
 
-/-- Magic wand: extending by any disjoint `P` heap yields a `Q` heap. -/
-def wand (P Q : HProp) : HProp :=
-  HProp.mk fun h => ∀ h', h.disjoint h' → P.get h' → Q.get (h.union h')
-
 @[inherit_doc pointsTo] local notation:70 l:max " ↦ " v:max => pointsTo l v
 @[inherit_doc sepConj] local infixr:65 " ∗ " => sepConj
-@[inherit_doc wand] local infixr:60 " -∗ " => wand
 
 @[simp, grind =] theorem emp_get (h : Heap) : emp.get h = ∀ n, h n = none := rfl
 @[simp, grind =] theorem pointsTo_get (l : Addr) (v : Nat) (h : Heap) :
     (pointsTo l v).get h = (h = Heap.single l v) := rfl
--- `sepConj_get`/`wand_get` unfold a connective into its existential-and-disjointness body, which
--- `grind` cannot productively use; they stay plain lemmas, cited explicitly where a proof wants the
+-- `sepConj_get` unfolds the connective into its existential-and-disjointness body, which `grind`
+-- cannot productively use; it stays a plain lemma, cited explicitly where a proof wants the
 -- unfolding. The focusing lemma `pointsTo_sepConj_get` is the `grind`-facing characterization of `∗`.
 theorem sepConj_get (P Q : HProp) (h : Heap) :
     (P ∗ Q).get h = ∃ h₁ h₂, h₁.disjoint h₂ ∧ h = h₁.union h₂ ∧ P.get h₁ ∧ Q.get h₂ := rfl
-theorem wand_get (P Q : HProp) (h : Heap) :
-    (P -∗ Q).get h = ∀ h', h.disjoint h' → P.get h' → Q.get (h.union h') := rfl
 
 /-! ## The separation algebra laws -/
 
@@ -346,22 +339,35 @@ instance (F : HProp) : PreservesSup (sepConj F) where
     · rintro ⟨f, ⟨x, hx, rfl⟩, h₁, h₂, hd, rfl, hF, hxh₂⟩
       exact ⟨h₁, h₂, hd, rfl, hF, x, hx, hxh₂⟩
 
-/-- The counit of the adjunction `F ∗ · ⊣ F -∗ ·`. -/
-theorem sepConj_wand_le (F b : HProp) : (F ∗ (F -∗ b)) ⊑ b := by
-  rintro h ⟨h₁, h₂, hd, rfl, hF, hw⟩
-  have := hw h₁ (Heap.disjoint_comm hd) hF
-  rwa [Heap.union_comm (Heap.disjoint_comm hd)] at this
+/-- Magic wand: the upper adjoint of the separating conjunction `P ∗ ·`. An abbreviation, so
+`vcgen`'s built-in `upperAdjoint` decomposition applies to it on the right-hand side of an
+entailment. -/
+noncomputable abbrev wand (P Q : HProp) : HProp := PreservesSup.upperAdjoint (sepConj P) Q
 
-/-- The upper adjoint of `F ∗ ·` is the magic wand `F -∗ ·`. -/
-theorem sepConj_upperAdjoint (F b : HProp) :
-    PreservesSup.upperAdjoint (sepConj F) b = (F -∗ b) := by
-  apply PartialOrder.rel_antisymm
-  · unfold PreservesSup.upperAdjoint
-    apply sup_le
-    intro x hx h hxh h' hdisj hF
-    apply hx (h.union h')
-    exact ⟨h', h, Heap.disjoint_comm hdisj, Heap.union_comm hdisj, hF, hxh⟩
-  · exact PreservesSup.le_upperAdjoint (sepConj F) (sepConj_wand_le F b)
+@[inherit_doc wand] local infixr:60 " -∗ " => wand
+
+/-- The counit of the adjunction `F ∗ · ⊣ F -∗ ·`. -/
+theorem sepConj_wand_le (F b : HProp) : (F ∗ (F -∗ b)) ⊑ b :=
+  PreservesSup.upperAdjoint_le (sepConj F) b
+
+/-- Adjunction introduction: to land below a wand, frame its argument onto the entailment. -/
+theorem le_wand (F X G : HProp) (h : F ∗ X ⊑ G) : X ⊑ F -∗ G :=
+  PreservesSup.le_upperAdjoint (sepConj F) h
+
+/-- Pointwise characterization of the wand, from the adjunction laws. -/
+theorem wand_get (P Q : HProp) (h : Heap) :
+    (P -∗ Q).get h = ∀ h', h.disjoint h' → P.get h' → Q.get (h.union h') := by
+  apply propext
+  constructor
+  · intro hw h' hdisj hP
+    exact sepConj_wand_le P Q (h.union h')
+      ⟨h', h, Heap.disjoint_comm hdisj, Heap.union_comm hdisj, hP, hw⟩
+  · intro hw
+    refine le_wand P (HProp.mk fun k => ∀ h', k.disjoint h' → P.get h' → Q.get (k.union h')) Q
+      ?_ h hw
+    rintro k ⟨h₁, h₂, hd, rfl, hP, hx⟩
+    have := hx h₁ (Heap.disjoint_comm hd) hP
+    rwa [Heap.union_comm (Heap.disjoint_comm hd)] at this
 
 /-! ## The frame-internalizing weakest precondition -/
 
@@ -432,11 +438,6 @@ theorem sepConj_mono_left {a a' : HProp} (b : HProp) (h : a ⊑ a') : a ∗ b �
 
 /-! ## Wand algebra -/
 
-/-- Adjunction introduction: to land below a wand, frame its argument onto the entailment. -/
-theorem le_wand (F X G : HProp) (h : F ∗ X ⊑ G) : X ⊑ F -∗ G := by
-  rw [← sepConj_upperAdjoint]
-  exact PreservesSup.le_upperAdjoint (sepConj F) h
-
 /-- Absorb a resource into a wand: `C` extends the wand's argument from `B` down to `A`. -/
 theorem wand_absorb {A B C G : HProp} (h : A ∗ C ⊑ B) : C ∗ (B -∗ G) ⊑ A -∗ G := by
   refine le_wand _ _ _ ?_
@@ -453,6 +454,14 @@ theorem le_sepConj_wand_refl (X A : HProp) : X ⊑ X ∗ (A -∗ A) :=
 theorem le_sepConj_wand_refl₂ (X Y A : HProp) : X ∗ Y ⊑ X ∗ Y ∗ (A -∗ A) :=
   PartialOrder.rel_trans (le_sepConj_wand_refl (X ∗ Y) A)
     (PartialOrder.rel_of_eq (sepConj_assoc X Y (A -∗ A)))
+
+/-- Attach the trivial wand at an `emp`-framed residual post. -/
+@[grind ←]
+theorem le_sepConj_wand_emp_wand_refl (X A : HProp) : X ⊑ X ∗ (A -∗ (emp -∗ A)) :=
+  PartialOrder.rel_trans (PartialOrder.rel_of_eq (sepConj_emp X).symm)
+    (sepConj_mono_right X (le_wand A emp (emp -∗ A)
+      (le_wand emp (A ∗ emp) A
+        (PartialOrder.rel_of_eq (by rw [emp_sepConj, sepConj_emp])))))
 
 /-! ## Doubly-linked lists
 
@@ -637,23 +646,28 @@ def sepConjOfAtoms (atoms : Array Expr) : SymM Expr := do
   if atoms.isEmpty then mkConstS ``emp
   else
     let op ← mkConstS ``sepConj
-    atoms[1:].foldlM (fun acc a => mkAppNS op #[acc, a]) atoms[0]!
+    atoms.pop.foldrM (fun a acc => mkAppNS op #[a, acc]) atoms.back!
 
-/-- Match and remove `cancel` atoms from `pre`. Returns `(remaining, matched)` or `none`.
+/-- Match and remove `cancel` atoms from `pre`. Returns the remaining `pre` atoms, the matched
+`pre` atoms in `cancel` order, and the unmatched `cancel` atoms. Successful pairings are committed,
+so the caller sees the schematics of the matched `cancel` atoms instantiated at the goal's values.
 
 Naïve by design: atoms match only up to `isDefEq`, so a footprint cancels a cell only when its address
 and value are already defeq to one in `pre`. A comprehensive frameproc would also match `pointsTo`s by
 address label with a non-defeq value. This suffices for the demo. -/
-def matchSepAtoms (pre cancel : Expr) : MetaM (Option (Array Expr × Array Expr)) := do
+def matchSepAtoms (pre cancel : Expr) : MetaM (Array Expr × Array Expr × Array Expr) := do
   let mut rest ← sepAtoms pre
   let mut matched : Array Expr := #[]
+  let mut unmatched : Array Expr := #[]
   for atom in (← sepAtoms cancel) do
     -- `withoutModifyingMCtx`: a failed near-miss must not pin schematic mvars.
-    let some i ← rest.findIdxM? fun cand => withoutModifyingMCtx (isDefEq atom cand)
-      | return none
-    matched := matched.push rest[i]!
-    rest := rest.eraseIdxIfInBounds i
-  return some (rest, matched)
+    match ← rest.findIdxM? fun cand => withoutModifyingMCtx (isDefEq atom cand) with
+    | some i =>
+      discard <| isDefEq atom rest[i]!
+      matched := matched.push rest[i]!
+      rest := rest.eraseIdxIfInBounds i
+    | none => unmatched := unmatched.push atom
+  return (rest, matched, unmatched)
 
 -- This demo's frame procedure runs in `SymM` but leans on `MetaM` here: `Meta.AC` closes the
 -- `∗`-rearrangement, and `isDefEq` matches atoms that may carry spec metavariables. It is worth it
@@ -690,6 +704,36 @@ def mkSepFrameSplit (i : FrameInferenceInfo) (frame footprint : Expr) : SymM Fra
       #[args[0]!, args[1]!, ← i.pre, sepFF, sepFR, hcl, mono]
     return FrameSplit.withDischargedSplitVC frame residualPre proof [sub.mvarId!]
 
+/-- Frame `emp` for a spec precondition that adds a wand to the goal's atoms: the footprint mirrors
+the spec precondition (matched goal atoms in spec order, then the wand with its conclusion rewrapped
+at the `emp`-framed residual post). The split VC `pre ⊑ emp ∗ residualPre` factors through
+`pre ⊑ emp ∗ footprint`, left as a subgoal. -/
+def mkEmpFrameSplit (i : FrameInferenceInfo) (matched : Array Expr) (wandAtom : Expr) :
+    SymM (Option FrameSplit) := do
+  let wandAtom ← instantiateMVarsS wandAtom
+  -- `wandAtom = upperAdjoint (sepConj G) b`; rewrap `b` as `emp -∗ b` to mirror the residual post.
+  let #[alpha, instCL, sepConjG, b] := wandAtom.getAppArgs | return none
+  if wandAtom.hasExprMVar then return none
+  let uaFn := wandAtom.getAppFn
+  let empE ← mkConstS ``emp
+  let sepConjEmp ← mkAppNS (← mkConstS ``sepConj) #[empE]
+  let inner ← mkAppNS uaFn #[alpha, instCL, sepConjEmp, b]
+  let wrapped ← mkAppNS uaFn #[alpha, instCL, sepConjG, inner]
+  let footprint ← sepConjOfAtoms (matched.push wrapped)
+  let le ← i.le
+  let residualPre ← i.mkResidualPre
+  let sepConjE ← mkConstS ``sepConj
+  let empFoot ← mkAppNS sepConjE #[empE, footprint]
+  let empRes ← mkAppNS sepConjE #[empE, mkMVar residualPre]
+  let sub1 ← mkFreshExprSyntheticOpaqueMVar (← mkAppNS le #[footprint, mkMVar residualPre])
+  let sub2 ← mkFreshExprSyntheticOpaqueMVar (← mkAppNS le #[← i.pre, empFoot])
+  let mono ← mkAppNS (← mkConstS ``sepConj_mono_right) #[empE, footprint, mkMVar residualPre, sub1]
+  let args := le.getAppArgs
+  let proof ← mkAppNS (← mkConstS ``PartialOrder.rel_trans le.getAppFn.constLevels!)
+    #[args[0]!, args[1]!, ← i.pre, empFoot, empRes, sub2, mono]
+  return some (FrameSplit.withDischargedSplitVC empE residualPre proof
+    [sub2.mvarId!, sub1.mvarId!])
+
 /-- Automatic frame inference by domain difference: the spec's precondition's atoms (its footprint)
 are cancelled from the goal precondition's; the leftover atoms are the frame. A pinned `frames`
 resource cancels its own atoms instead, leaving the split VC open when they are missing. -/
@@ -701,13 +745,21 @@ def sepConjFrameProc : FrameInferenceProc := fun i => do
   match i.providedFrame? with
   | some frame =>
     match ← matchSepAtoms (← i.pre) frame with
-    | none => return some (← FrameSplit.withDeferredSplitVC i frame)
-    | some (rest, _) => return some (← mkSepFrameSplit i frame (← sepConjOfAtoms rest))
+    | (rest, _, #[]) => return some (← mkSepFrameSplit i frame (← sepConjOfAtoms rest))
+    | _ => return some (← FrameSplit.withDeferredSplitVC i frame)
   | none =>
     let some specPre ← i.specPre? | return none
-    let some (rest, matched) ← matchSepAtoms (← i.pre) specPre | return none
-    if rest.isEmpty then return none
-    return some (← mkSepFrameSplit i (← sepConjOfAtoms rest) (← sepConjOfAtoms matched))
+    match ← matchSepAtoms (← i.pre) specPre with
+    | (rest, matched, #[]) =>
+      if rest.isEmpty then return none
+      return some (← mkSepFrameSplit i (← sepConjOfAtoms rest) (← sepConjOfAtoms matched))
+    | (#[], matched, #[wandAtom]) =>
+      -- Everything matched except a wand: frame `emp` and mirror the spec's precondition as the
+      -- footprint, with the wand's conclusion rewrapped at the `emp`-framed residual post. The
+      -- re-application against the residual then closes its precondition VC by unification,
+      -- instantiating the spec's schematics at the goal's values.
+      mkEmpFrameSplit i matched wandAtom
+    | _ => return none
 
 @[frameproc] def heapFP : FrameProc where
   prog := ``HeapM
@@ -877,7 +929,7 @@ theorem append_spec (fuel : Nat) (v w : Nat) (rest ws : List Nat) (back qb curr 
     ⦃ IsList (v :: rest) back curr ∗ IsList (w :: ws) qb q ⦄
       append (rest.length + 1) curr q
     ⦃ fun _ => IsList ((v :: rest) ++ w :: ws) back curr ⦄ := by
-  vcgen [append_spec (rest.length + 1) v w rest ws back qb] with finish
+  vcgen [append_spec] with finish
 
 /-- Framing an unrelated cell across the whole append. -/
 example (l : Addr) (z v w : Nat) (rest ws : List Nat) (back qb curr q : Addr) :

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -907,10 +907,9 @@ invariant holds at any remaining budget. -/
 @[spec] theorem reverse_spec (fuel : Nat) (xs : List Nat) (head : Addr)
     (hle : xs.length ≤ fuel) :
     ⦃ IsList xs null head ⦄ reverse fuel head ⦃ fun r => IsList xs.reverse null r ⦄ := by
-  vcgen [reverse, -Spec.forIn_range,
-    Spec.forIn_range (m := HeapM)
-      (inv := fun _ suff b => reverseLoopInv xs suff.length b),
-    -load_spec, load_next_IsList_ne] with finish
+  vcgen [reverse, load_next_IsList_ne] invariants
+    | inv1 => fun _ suff b => reverseLoopInv xs suff.length b
+    with finish
 
 example (xs : List Nat) (head l : Addr) (v : Nat) :
     ⦃ l ↦ v ∗ IsList xs null head ⦄ (reverse xs.length head)
@@ -1136,11 +1135,10 @@ theorem append_spec (fuel : Nat) (xs ys : List Nat) (back qb x y : Addr) (Q : Ad
     have hr : (if x = null then y else x) = x := by grind
     rw [hb, hr]
     have hlen' : xs.length ≤ ([:fuel] : Std.Legacy.Range).toList.length := by grind
-    vcgen [append, -Spec.forIn_range,
-      Spec.forIn_range (m := HeapM)
-        (inv := fun _ suff b =>
-          appendLoopInv xs ys back qb x y (IsList (xs ++ ys) back x -∗ Q x) suff.length b),
-      -load_spec, load_next_IsList_ne, store_prev_IsList_ne] with finish
+    vcgen [append, load_next_IsList_ne, store_prev_IsList_ne] invariants
+      | inv1 => fun _ suff b =>
+          appendLoopInv xs ys back qb x y (IsList (xs ++ ys) back x -∗ Q x) suff.length b
+      with finish
 
 /-- Plain append specification, from `append_spec` at the trivial continuation. -/
 @[spec] theorem append_concat (xs ys : List Nat) (back qb x y : Addr) :

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -26,6 +26,11 @@ stores next at `p`, prev at `p + 1`, and the payload at `p + 2`. The abstract co
 so the list is ghost state in the specification. Framing an unrelated cell across the whole
 reverse is the `iFrame` moment at program scale.
 
+A second showcase is an in-place append with its specification carried as a wand (SF Verifiable C,
+"Magic wand, partial data structure"): the traversal absorbs each visited node into the wand
+(`wand_absorb`), the wand rides the frame through every call, and linking the last node discharges
+it by the counit of the `∗ ⊣ -∗` adjunction.
+
 The file is laid out reusable-first: the programs, then the separation logic, then the derived
 lemmas, then the `@[frameproc]`, then the specifications.
 -/
@@ -151,6 +156,22 @@ def reverse.go (fuel : Nat) (curr prev : Addr) : HeapM Addr :=
 def reverse (fuel : Nat) (head : Addr) : HeapM Addr :=
   reverse.go fuel head null
 
+/-- Write the prev field of the node at `q`. -/
+def storePrev (q c : Addr) : HeapM Unit := store (q + 1) c
+
+/-- Fuel-bounded in-place append: walk to the last node of the list at `curr`, link its next
+pointer to `q`, and point `q`'s prev field back at it. -/
+def append (fuel : Nat) (curr q : Addr) : HeapM Unit :=
+  match fuel with
+  | 0 => pure ()
+  | fuel + 1 => do
+    let next ← load curr
+    if next = null then
+      store curr q
+      storePrev q curr
+    else
+      append fuel next q
+
 /-! # The separation logic
 
 `HProp`, the connectives `∗`/`↦`/`-∗`, their algebra, the magic wand as upper adjoint, and the
@@ -207,6 +228,7 @@ theorem wand_get (P Q : HProp) (h : Heap) :
 
 /-! ## The separation algebra laws -/
 
+@[grind =]
 theorem emp_sepConj (a : HProp) : (emp ∗ a) = a := by
   funext h
   apply propext
@@ -239,6 +261,7 @@ theorem sepConj_comm (a b : HProp) : (a ∗ b) = (b ∗ a) := by
     · rintro ⟨h₁, h₂, hd, rfl, hp, hq⟩
       exact ⟨h₂, h₁, Heap.disjoint_comm hd, Heap.union_comm hd, hq, hp⟩
 
+@[grind =]
 theorem sepConj_emp (a : HProp) : (a ∗ emp) = a := by
   rw [sepConj_comm, emp_sepConj]
 
@@ -363,10 +386,16 @@ theorem HeapM.triple_of_triple_StateM_run {α : Type} {x : HeapM α} {pre : HPro
     ⦃ pre ⦄ x ⦃ Q ⦄ :=
   ⟨WP.le_wp_of_frameClosure_eq rfl fun F => (h F).1⟩
 
+/-- The unreachable-branch spec: any postcondition holds from a `⊥` precondition. Passed to `vcgen`
+for a call in a branch whose verification conditions are contradictory. -/
+theorem HeapM.triple_of_bot_pre {α : Type} {Q : α → HProp} (x : HeapM α) :
+    ⦃ (⊥ : HProp) ⦄ x ⦃ Q ⦄ :=
+  ⟨bot_le _⟩
+
 /-! # Derived lemmas
 
-Reusable entailments: points-to focusing, `∗`-monotonicity, and the doubly-linked-list predicate
-`IsList` with its introduction and elimination lemmas. -/
+Reusable entailments: points-to focusing, `∗`-monotonicity, the wand algebra, and the
+doubly-linked-list predicate `IsList` with its introduction and elimination lemmas. -/
 
 /-! ## Points-to focusing -/
 
@@ -398,6 +427,35 @@ and `Heap.erase_update` carry a cell update through it. -/
 /-- Monotonicity of `∗` in its right argument. -/
 theorem sepConj_mono_right (a : HProp) {b b' : HProp} (h : b ⊑ b') : a ∗ b ⊑ a ∗ b' :=
   PreservesSup.map_mono (sepConj a) h
+
+/-- Monotonicity of `∗` in its left argument. -/
+theorem sepConj_mono_left {a a' : HProp} (b : HProp) (h : a ⊑ a') : a ∗ b ⊑ a' ∗ b := by
+  rw [sepConj_comm a b, sepConj_comm a' b]
+  exact sepConj_mono_right b h
+
+/-! ## Wand algebra -/
+
+/-- Adjunction introduction: to land below a wand, frame its argument onto the entailment. -/
+theorem le_wand (F X G : HProp) (h : F ∗ X ⊑ G) : X ⊑ F -∗ G := by
+  rw [← sepConj_upperAdjoint]
+  exact PreservesSup.le_upperAdjoint (sepConj F) h
+
+/-- Absorb a resource into a wand: `C` extends the wand's argument from `B` down to `A`. -/
+theorem wand_absorb {A B C G : HProp} (h : A ∗ C ⊑ B) : C ∗ (B -∗ G) ⊑ A -∗ G := by
+  refine le_wand _ _ _ ?_
+  rw [← sepConj_assoc]
+  exact PartialOrder.rel_trans (sepConj_mono_left _ h) (sepConj_wand_le B G)
+
+/-- Attach a trivial wand: `X` entails itself alongside `A -∗ A`. -/
+theorem le_sepConj_wand_refl (X A : HProp) : X ⊑ X ∗ (A -∗ A) :=
+  PartialOrder.rel_trans (PartialOrder.rel_of_eq (sepConj_emp X).symm)
+    (sepConj_mono_right X (le_wand A emp A (PartialOrder.rel_of_eq (sepConj_emp A))))
+
+/-- `le_sepConj_wand_refl` behind two resources, matching a spec precondition's association. -/
+@[grind ←]
+theorem le_sepConj_wand_refl₂ (X Y A : HProp) : X ∗ Y ⊑ X ∗ Y ∗ (A -∗ A) :=
+  PartialOrder.rel_trans (le_sepConj_wand_refl (X ∗ Y) A)
+    (PartialOrder.rel_of_eq (sepConj_assoc X Y (A -∗ A)))
 
 /-! ## Doubly-linked lists
 
@@ -464,6 +522,90 @@ theorem reverse_store_handoff_le (v : Nat) (rest acc : List Nat) (curr next prev
     grind
   rw [heq]
   exact sepConj_mono_right _ (IsList_cons_intro v prev next acc curr hpne)
+
+/-- Discharge the append wand at the last node: rebuild the cons cell onto the relinked appended
+segment (`IsList_cons_intro` with the new next-pointer `q`) and apply the counit. -/
+@[grind ←]
+theorem append_link_le (v w : Nat) (ws : List Nat) (back curr q next : Addr) (R : HProp)
+    (hcn : curr ≠ null) (hnext : next = null) :
+    (((((IsList (v :: w :: ws) back curr -∗ R) ∗ (curr + 1) ↦ back) ∗ (curr + 2) ↦ v) ∗
+        IsList [] curr next) ∗ curr ↦ q) ∗ IsList (w :: ws) curr q ⊑ R := by
+  subst hnext
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_)
+    (PartialOrder.rel_trans
+      (sepConj_mono_left _ (IsList_cons_intro v q back (w :: ws) curr hcn))
+      (sepConj_wand_le _ R))
+  grind
+
+/-- Absorption of `⊥` by `∗`. -/
+theorem sepConj_bot_le (X : HProp) : X ∗ (⊥ : HProp) ⊑ ⊥ := by
+  intro h hh
+  obtain ⟨_, h₂, _, _, _, hb⟩ := hh
+  exact ((bot_le (x := (fun _ => False : HProp))) h₂ hb).elim
+
+/-- An empty segment pins its root to `null`. -/
+theorem IsList_nil_le_bot (curr next : Addr) (hne : next ≠ null) : IsList [] curr next ⊑ ⊥ := by
+  intro h hh
+  rw [IsList_nil_eq] at hh
+  exact (hne ((sepPure_apply _ _).mp hh).1).elim
+
+/-- A cons segment cannot be rooted at `null`. -/
+theorem IsList_cons_null_le_bot (v : Nat) (vs : List Nat) (back : Addr) :
+    IsList (v :: vs) back null ⊑ ⊥ := by
+  intro h hh
+  exact ((IsList_cons_elim hh).1 rfl).elim
+
+/-- A precondition holding `IsList [] curr next` is contradictory when `next ≠ null`. -/
+@[grind ←]
+theorem IsList_nil_ne_le_bot (S S₁ S₂ S₃ : HProp) (curr next : Addr) (hne : next ≠ null) :
+    S ∗ S₁ ∗ S₂ ∗ S₃ ∗ IsList [] curr next ⊑ ⊥ := by
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_)
+    (PartialOrder.rel_trans
+      (sepConj_mono_right (S ∗ S₁ ∗ S₂ ∗ S₃) (IsList_nil_le_bot curr next hne))
+      (sepConj_bot_le _))
+  grind
+
+/-- A precondition holding `IsList (v' :: rest') curr next` is contradictory when `next = null`. -/
+@[grind ←]
+theorem append_cons_absurd (S₁ S₂ S₃ : HProp) (v' : Nat) (rest' : List Nat) (curr next : Addr)
+    (R : HProp) (hnext : next = null) :
+    ((S₁ ∗ IsList (v' :: rest') curr next) ∗ S₂) ∗ S₃ ⊑ R := by
+  subst hnext
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_)
+    (PartialOrder.rel_trans
+      (sepConj_mono_right (S₁ ∗ S₂ ∗ S₃) (IsList_cons_null_le_bot v' rest' curr))
+      (PartialOrder.rel_trans (sepConj_bot_le _) (bot_le R)))
+  grind
+
+/-- The append induction step: absorb the visited node into the wand (`wand_absorb` via
+`IsList_cons_intro`), matching the recursive call's precondition. -/
+@[grind ←]
+theorem append_step_le (v v' w : Nat) (rest' ws : List Nat) (back qb curr next q : Addr)
+    (R : HProp) (hcn : curr ≠ null) :
+    (IsList (w :: ws) qb q ∗ (IsList (v :: v' :: (rest' ++ w :: ws)) back curr -∗ R)) ∗
+        curr ↦ next ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v ∗ IsList (v' :: rest') curr next ⊑
+      IsList (v' :: rest') curr next ∗ IsList (w :: ws) qb q ∗
+        (IsList (v' :: rest' ++ w :: ws) curr next -∗ R) := by
+  have habs : IsList (v' :: rest' ++ w :: ws) curr next ∗
+      (curr ↦ next ∗ (curr + 1) ↦ back ∗ (curr + 2) ↦ v) ⊑
+        IsList (v :: v' :: (rest' ++ w :: ws)) back curr := by
+    refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_)
+      (IsList_cons_intro v next back (v' :: (rest' ++ w :: ws)) curr hcn)
+    grind
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_)
+    (PartialOrder.rel_trans
+      (sepConj_mono_right (IsList (v' :: rest') curr next ∗ IsList (w :: ws) qb q)
+        (wand_absorb (G := R) habs))
+      (PartialOrder.rel_of_eq ?_)) <;>
+    grind
+
+/-- Rebuild a cons cell around a rewritten prev field; the loaded next-pointer is the witness. -/
+@[grind ←]
+theorem storePrev_handoff (w : Nat) (ws : List Nat) (q c n : Addr) :
+    ((q ↦ n ∗ (q + 2) ↦ w) ∗ IsList ws q n) ∗ (q + 1) ↦ c ⊑
+      ⨆ n', q ↦ n' ∗ (q + 1) ↦ c ∗ (q + 2) ↦ w ∗ IsList ws q n' := by
+  refine PartialOrder.rel_trans (PartialOrder.rel_of_eq ?_) (le_iSup _ n)
+  grind
 
 /-- When the remaining segment is empty, `curr = null` and the accumulator is the whole result. -/
 @[grind .] theorem IsList_nil_acc_le (acc : List Nat) (curr prev : Addr) :
@@ -689,3 +831,59 @@ example (xs : List Nat) (head l : Addr) (v : Nat) :
     ⦃ l ↦ v ∗ IsList xs null head ⦄ (reverse xs.length head)
       ⦃ fun r => l ↦ v ∗ IsList xs.reverse null r ⦄ := by
   vcgen [reverse_spec] with finish
+
+/-! ## Wand-style append
+
+The append specification carries its continuation as a wand: walking the list absorbs each visited
+node into the wand (`wand_absorb`), and linking the last node discharges it by the counit. Both
+lists are nonempty; the appended segment's head prev field is rewritten to the last node. -/
+
+/-- Rewrite the back-pointer of a cons cell by storing into its prev field. Not `@[spec]`: its
+program pattern would also match the exposed-node prev writes in `reverse.go`. -/
+theorem storePrev_IsList (w : Nat) (ws : List Nat) (qb q c : Addr) :
+    ⦃ IsList (w :: ws) qb q ⦄ storePrev q c ⦃ fun _ => IsList (w :: ws) c q ⦄ := by
+  simp only [storePrev, IsList_cons_eq]
+  vcgen [store_spec] with finish
+
+/-- Wand-style append specification: the continuation `R` receives the concatenated list once the
+traversal ends. The prefix walked so far lives in the wand. -/
+theorem append_spec (fuel : Nat) (v w : Nat) (rest ws : List Nat) (back qb curr q : Addr)
+    (R : HProp) (hle : rest.length < fuel) :
+    ⦃ IsList (v :: rest) back curr ∗ IsList (w :: ws) qb q ∗
+        (IsList ((v :: rest) ++ w :: ws) back curr -∗ R) ⦄
+      append fuel curr q
+    ⦃ fun _ => R ⦄ := by
+  induction rest generalizing v fuel curr back R with
+  | nil =>
+    match fuel, hle with
+    | fuel + 1, _ =>
+      simp only [append, List.cons_append, List.nil_append]
+      -- The `next ≠ null` arm is unreachable under `IsList []`; its recursive call takes the
+      -- `⊥`-precondition spec and the arm closes by contradiction.
+      vcgen [-load_spec, load_next_IsList, store_spec, storePrev_IsList,
+        fun next => HeapM.triple_of_bot_pre (Q := fun _ => R) (append fuel next q)] with
+        finish
+  | cons v' rest' ih =>
+    match fuel, hle with
+    | fuel + 1, hle =>
+      simp only [List.length_cons] at hle
+      simp only [append, List.cons_append]
+      -- The `next = null` arm is unreachable under `IsList (v' :: rest')`; the recursive call
+      -- takes the IH at the absorbed wand.
+      vcgen [-load_spec, load_next_IsList, store_spec, storePrev_IsList,
+        fun next => ih fuel v' curr next R (Nat.lt_of_succ_lt_succ hle)] with finish
+
+/-- Plain append specification, from `append_spec` at the trivial continuation. -/
+@[spec] theorem append_concat (v w : Nat) (rest ws : List Nat) (back qb curr q : Addr) :
+    ⦃ IsList (v :: rest) back curr ∗ IsList (w :: ws) qb q ⦄
+      append (rest.length + 1) curr q
+    ⦃ fun _ => IsList ((v :: rest) ++ w :: ws) back curr ⦄ := by
+  vcgen [append_spec (rest.length + 1) v w rest ws back qb curr q
+    (IsList ((v :: rest) ++ w :: ws) back curr) (Nat.lt_succ_self _)] with finish
+
+/-- Framing an unrelated cell across the whole append. -/
+example (l : Addr) (z v w : Nat) (rest ws : List Nat) (back qb curr q : Addr) :
+    ⦃ l ↦ z ∗ IsList (v :: rest) back curr ∗ IsList (w :: ws) qb q ⦄
+      append (rest.length + 1) curr q
+    ⦃ fun _ => l ↦ z ∗ IsList ((v :: rest) ++ w :: ws) back curr ⦄ := by
+  vcgen [append_concat] with finish


### PR DESCRIPTION
This PR adds an in-place doubly-linked list append to the vcgen separation-logic test, after the C original in SF Verifiable C.

`append_spec` is "ramified", as in "The Ramifications of Sharing in Data Structures": the schematic postcondition arrives through a wand at the known result, `⦃ IsList xs xprev x ∗ IsList ys yprev y ∗ (IsList (xs ++ ys) prev₀ hd₀ -∗ Q hd₀) ⦄ append fuel x y ⦃ Q ⦄`, where `hd₀` is the returned head and `prev₀` the node preceding it, so the spec auto-frames and is easily applied by `vcgen` given the supporting frameproc.