### PR TITLE
fix: reject declarations naming the kernel's `_nested` auxiliary types

### DIFF
--- a/src/kernel/inductive.cpp
+++ b/src/kernel/inductive.cpp
@@ -1114,14 +1114,33 @@ static pair<names, name_map<name>> mk_aux_rec_name_map(environment const & aux_e
     return mk_pair(names(old_rec_names), rec_map);
 }
 
+/* The auxiliary types created by `elim_nested_inductive_fn` live under `_nested` and exist only in the
+   temporary environment used to eliminate nested inductives. A declaration naming one is reaching into
+   that environment, where it can be given a type it does not have once the nested types are restored. */
+static void check_no_nested_aux(environment const & env, name const & n, expr const & e) {
+    /* `proj` is included because its structure name is resolved too: the kernel rewrites nested
+       occurrences in the constructor to the auxiliary type, so a projection naming that type matches
+       without the declaration ever mentioning it as a constant. */
+    if (find(e, [](expr const & e, unsigned) {
+                return (is_constant(e) && is_prefix_of(*g_nested, const_name(e))) ||
+                       (is_proj(e) && is_prefix_of(*g_nested, proj_sname(e)));
+            })) {
+        throw kernel_exception(env, sstream() << "invalid declaration '" << n
+                               << "', it uses the reserved prefix '" << *g_nested << "'");
+    }
+}
+
 environment environment::add_inductive(declaration const & d) const {
-    /* Reject metavariables and free variables in declaration. */
+    /* Reject metavariables, free variables, and references to auxiliary declarations. */
     {
         inductive_decl ind_d(d);
         for (inductive_type const & ind_type : ind_d.get_types()) {
             check_no_metavar_no_fvar(*this, ind_type.get_name(), ind_type.get_type());
-            for (constructor const & cnstr : ind_type.get_cnstrs())
+            check_no_nested_aux(*this, ind_type.get_name(), ind_type.get_type());
+            for (constructor const & cnstr : ind_type.get_cnstrs()) {
                 check_no_metavar_no_fvar(*this, constructor_name(cnstr), constructor_type(cnstr));
+                check_no_nested_aux(*this, constructor_name(cnstr), constructor_type(cnstr));
+            }
         }
     }
     elim_nested_inductive_result res = elim_nested_inductive_fn(*this, d)();

--- a/tests/elab/kernelNestedAuxName.lean
+++ b/tests/elab/kernelNestedAuxName.lean
@@ -1,0 +1,40 @@
+import Lean.CoreM
+import Lean.AddDecl
+
+/-!
+The kernel must reject declarations that name its `_nested` auxiliary types.
+
+Those types exist only in the temporary environment used to eliminate nested
+inductives. A constructor referring to one is checked there, but `restore_nested`
+then rewrites the name back to the nested type, which can have a different
+universe, leaving a stored constructor type that is ill typed.
+-/
+
+open Lean
+
+/--
+error: (kernel) invalid declaration 'KNAux.mk', it uses the reserved prefix '_nested'
+-/
+#guard_msgs in
+#eval addDecl <| .inductDecl [] 0 [
+  { name := `KNAux
+    type := .sort .zero
+    ctors := [{ name := `KNAux.mk
+                type := .forallE `x
+                  (.app (.const `_nested.KNHost_1 [.zero]) (.const ``True []))
+                  (.const `KNAux []) .default }] }] false
+
+-- A `proj` names its structure type, and the kernel rewrites nested occurrences in the
+-- constructor to the auxiliary type, so this reaches that type without naming it as a constant.
+/--
+error: (kernel) invalid declaration 'KNProj.mk', it uses the reserved prefix '_nested'
+-/
+#guard_msgs in
+#eval addDecl <| .inductDecl [] 0 [
+  { name := `KNProj
+    type := .sort .zero
+    ctors := [{ name := `KNProj.mk
+                type := .forallE `x (.const ``Nat [])
+                  (.forallE `y (.proj `_nested.KNHost_1 0 (.bvar 0))
+                    (.const `KNProj []) .default)
+                  .default }] }] false


### PR DESCRIPTION
This PR fixes a kernel bug: an inductive declaration could reference one of the auxiliary types the kernel generates when eliminating nested inductives, and end up with a stored constructor type that is ill typed. Such a declaration can only be produced with metaprogramming.

The auxiliary types live under `_nested` and exist only in the temporary environment used for the elimination. A constructor naming one is checked there, but `restore_nested` then rewrites the name back to the nested type, which can live in a different universe. Combined with proof irrelevance, the resulting ill-typed constructor makes two distinct functions look like proofs of the same proposition, and `equiv_manager` closes them transitively, giving `False` with no axiom dependencies.

The kernel now rejects the reserved prefix, alongside the existing checks for metavariables and free variables. Both `Expr.const` names and `Expr.proj` structure names are covered: the kernel rewrites nested occurrences in the constructor to the auxiliary type, so a projection can reach that type without the declaration naming it as a constant.
