### PR TITLE
fix: canonicalize literals when creating `grind` patterns

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/EMatchTheorem.lean
+++ b/src/Lean/Meta/Tactic/Grind/EMatchTheorem.lean
@@ -393,6 +393,27 @@ private def dontCare := mkConst (Name.mkSimple "[grind_dontcare]")
 def mkGroundPattern (e : Expr) : Expr :=
   mkAnnotation `grind.ground_pat e
 
+/--
+Puts a parametric numeric literal in `grind` normal form.
+
+`grind` represents `BitVec` and `Fin` literals using `OfNat.ofNat` (see
+`isOfNatFinBitVecLiteral`), but a term may spell one as `BitVec.ofNat` (e.g., `1#2`) or
+`Fin.mk`. Ground patterns are internalized without full normalization, and a non-canonical
+literal reaching the E-graph breaks the invariant that distinct interpreted nodes denote
+distinct values, which `addEqStep` relies on to detect `valueInconsistency`.
+
+**TODO**: delete this function. The normalizer should do this, instead of enumerating literal
+kinds here. Waiting on the port of `Sym.dsimp` to `grind`. The same hardcoding is in
+`AC.mkStruct` for identity elements, and should be deleted with it.
+-/
+private def canonLit (e : Expr) : MetaM Expr := do
+  if e.isAppOf ``OfNat.ofNat then return e
+  if let some ⟨w, v⟩ ← getBitVecValue? e then
+    return (← mkNumeral (mkApp (mkConst ``BitVec) (mkNatLit w)) v.toNat)
+  if let some ⟨n, v⟩ ← getFinValue? e then
+    return (← mkNumeral (mkApp (mkConst ``Fin) (mkNatLit n)) v.val)
+  return e
+
 def groundPattern? (e : Expr) : Option Expr :=
   annotation? `grind.ground_pat e
 
@@ -691,7 +712,7 @@ where
           ```
           -/
           saveSymbolsAt arg
-        return mkGroundPattern arg
+        return mkGroundPattern (← canonLit arg)
     else match arg with
       | .bvar idx =>
         -- **Note** See comment at `ParentKind.genPattern`.

--- a/tests/elab/grind_bv_lit_canon.lean
+++ b/tests/elab/grind_bv_lit_canon.lean
@@ -1,0 +1,22 @@
+/-!
+Ground subterms of e-matching patterns are internalized after `preprocessLight`
+only, which does not put bit-vector literals in `grind` normal form. A `1#2`
+reaching the e-graph as `BitVec.ofNat` rather than `OfNat.ofNat` gave two
+interpreted nodes for one value, and merging them looked like a
+`valueInconsistency` to `addEqStep`.
+-/
+
+example (f g : Nat → BitVec 2) (h : ∀ n, f n = g n ||| 1#2) : f 0 = g 0 ||| 1#2 := by grind
+
+example (f g : Nat → BitVec 2) (h : ∀ n, f n = g n &&& 1#2) : f 0 = g 0 &&& 1#2 := by grind
+
+example (f g : Nat → BitVec 2) (h : ∀ n, f n = g n ||| 0#2) : f 0 = g 0 ||| 0#2 := by grind
+
+example (f g : Nat → BitVec 4) (h : ∀ n, f n = g n ||| 1#4) : f 0 = g 0 ||| 1#4 := by grind
+
+-- mixed spellings across hypothesis and goal
+example (f g : Nat → BitVec 2) (h : ∀ n, f n = g n ||| 1#2) :
+    f 0 = g 0 ||| (1 : BitVec 2) := by grind
+
+example (f g : Nat → BitVec 2) (h : ∀ n, f n = g n ||| (1 : BitVec 2)) :
+    f 0 = g 0 ||| 1#2 := by grind


### PR DESCRIPTION
This PR fixes a `grind` regression on goals that use a bit-vector literal written with `#` syntax under a quantifier, such as `example (f g : Nat → BitVec 2) (h : ∀ n, f n = g n ||| 1#2) : f 0 = g 0 ||| 1#2 := by grind`. The tactic failed with a kernel error instead of closing the goal.

Ground subterms of e-matching patterns are internalized after `preprocessLight` only, which does not put literals in `grind` normal form. A `1#2` reaching the E-graph as `BitVec.ofNat` rather than `OfNat.ofNat` produces two interpreted nodes for one value, and merging them looks like a `valueInconsistency` to `addEqStep`, which then closes the goal with an ill-typed proof term.

Ground patterns are now canonicalized when they are created. This is a stopgap: the normalizer should do it, once `Sym.dsimp` has been ported to `grind`.
