### PR TITLE
chore: type check the declarations produced by nested inductive restoration

### DIFF
--- a/src/kernel/inductive.cpp
+++ b/src/kernel/inductive.cpp
@@ -1157,6 +1157,7 @@ environment environment::add_inductive(declaration const & d) const {
         names aux_rec_names; name_map<name> aux_rec_name_map;
         std::tie(aux_rec_names, aux_rec_name_map) = mk_aux_rec_name_map(aux_env, d);
         environment new_env = *this;
+        buffer<name> new_rec_names;
         auto process_rec = [&](name const & rec_name) {
             name new_rec_name      = rec_name;
             if (name const * new_name = aux_rec_name_map.find(rec_name))
@@ -1180,6 +1181,7 @@ environment environment::add_inductive(declaration const & d) const {
                                                         all_ind_names, rec_val.get_nparams(), rec_val.get_nindices(), rec_val.get_nmotives(),
                                                         rec_val.get_nminors(), recursor_rules(new_rules),
                                                         rec_val.is_k(), rec_val.is_unsafe())));
+            new_rec_names.push_back(new_rec_name);
         };
         for (inductive_type const & ind_type : ind_d.get_types()) {
             constant_info ind_info = aux_env.get(ind_type.get_name());
@@ -1215,6 +1217,26 @@ environment environment::add_inductive(declaration const & d) const {
             res.m_aux2nested.for_each([&](name const &, expr const & nested) {
                     tc.check(nested, inductive_decl(d).get_lparams());
                 });
+        }
+        /* Re-check everything `restore_nested` rewrote: the constructor types, and the recursor
+           types and computation rules. The rewritten terms are not otherwise checked in `new_env`.
+           The preceding checks are expected to make this redundant; it is cheap and it keeps a
+           mistake in the restoration from reaching the environment. Note that the inductive types
+           themselves are added unchanged, so they need no check here. */
+        {
+            type_checker tc(new_env, diag.get(), inductive_decl(d).is_unsafe() ? definition_safety::unsafe : definition_safety::safe);
+            for (inductive_type const & ind_type : ind_d.get_types()) {
+                for (constructor const & cnstr : ind_type.get_cnstrs()) {
+                    tc.check(new_env.get(constructor_name(cnstr)).get_type(), inductive_decl(d).get_lparams());
+                }
+            }
+            for (name const & rec_name : new_rec_names) {
+                constant_info rec_info = new_env.get(rec_name);
+                tc.check(rec_info.get_type(), rec_info.get_lparams());
+                for (recursor_rule const & rule : rec_info.to_recursor_val().get_rules()) {
+                    tc.check(rule.get_rhs(), rec_info.get_lparams());
+                }
+            }
         }
         return diag.update(new_env);
     }


### PR DESCRIPTION
This PR makes the kernel re-check what it writes into the environment after eliminating a nested inductive. `restore_nested` rewrites the auxiliary types back into nested applications, and the resulting constructor types, recursor types, and recursor computation rules were added without being type checked.

The other checks in `add_inductive` are expected to make this redundant, and no declaration in the standard library or the test suite fails it. It is defense in depth against a mistake in the restoration reaching the environment: with the `_nested` prefix check from #14616 disabled, this check on its own rejects the reproducer for that issue, with the ill-typed application that was its root cause.

The inductive types themselves are added unchanged rather than restored, so they need no check. The cost is not measurable: on a file declaring 300 nested inductives, 5778/5532/5708/5731 ms with the check versus 5555/5598/5761/5780 ms without.
