### PR TITLE
feat: generalize `MonadTail (StateT σ m)` instance

### DIFF
--- a/src/Init/Internal/Order/MonadTail.lean
+++ b/src/Init/Internal/Order/MonadTail.lean
@@ -48,11 +48,16 @@ instance : MonadTail Id where
   instCCPO _ := inferInstanceAs (CCPO (FlatOrder (b := Classical.ofNonempty)))
   bind_mono_right h := h _
 
-instance {σ : Type u} {m : Type u → Type v} [Monad m] [MonadTail m] [Nonempty σ] :
+instance {σ : Type u} {m : Type u → Type v} [Monad m] [MonadTail m] :
     MonadTail (StateT σ m) where
-  instCCPO α := inferInstanceAs (CCPO (σ → m (α × σ)))
+  instCCPO α :=
+    letI : CCPO (σ → m (α × σ)) := @instCCPOPi _ _ fun s =>
+      haveI : Nonempty σ := ⟨s⟩
+      MonadTail.instCCPO _
+    inferInstanceAs (CCPO (σ → m (α × σ)))
   bind_mono_right h := by
     intro s
+    have : Nonempty σ := ⟨s⟩
     show StateT.bind _ _ s ⊑ StateT.bind _ _ s
     simp only [StateT.bind]
     apply MonadTail.bind_mono_right (m := m)

--- a/tests/elab/while_extrinsic.lean
+++ b/tests/elab/while_extrinsic.lean
@@ -132,3 +132,24 @@ example (n m : Nat) (h : n ≤ m) (heven : n % 2 = 0) (hmeven : m % 2 = 0) (h : 
     | .inl i => spred(⌜i % 2 = 0 ∧ i ≤ m⌝)
     | .inr i => spred(⌜i % 2 = 0 ∧ p i⌝)
   with grind
+
+/-!
+The specification for `while` works for a `StateT` even if the state doesn't have a `Nonempty`
+instance.
+-/
+
+structure State where
+  n : Nat
+
+def stateWithoutNonemptyInstance : StateM State Nat := do
+  while (← get).n > 0 do
+    modify fun state => { n := state.n - 1 }
+  return (← get).n
+
+example : ⦃⌜True⌝⦄ stateWithoutNonemptyInstance ⦃⇓ n => ⌜n = 0⌝⦄ := by
+  mvcgen [stateWithoutNonemptyInstance] invariants
+  | inv1 => fun _ s => ULift.up s.n
+  | inv2 => ⇓ r => match r with
+    | .inl i => spred(⌜True⌝)
+    | .inr i => spred(fun s => ⌜s.n = 0⌝)
+  with grind


### PR DESCRIPTION
This PR generalizes the `MonadTail (StateT σ m)` instance to work without needing `Nonempty σ`. This means that proving specifications about `while` with a `StateT` monad now works even if there is no `Nonempty` instance for the state type.