### PR TITLE
chore: remove deprecated `toCtorIdx` alias for `ctorIdx`

### DIFF
--- a/src/Lean/Meta/Constructions/CtorIdx.lean
+++ b/src/Lean/Meta/Constructions/CtorIdx.lean
@@ -21,9 +21,6 @@ register_builtin_option genCtorIdx : Bool := {
   descr    := "generate the `CtorIdx` functions for inductive datatypes"
 }
 
-public def mkToCtorIdxName (indName : Name) : Name :=
-  Name.mkStr indName "toCtorIdx"
-
 public def mkCtorIdxName (indName : Name) : Name :=
   Name.mkStr indName "ctorIdx"
 
@@ -97,23 +94,5 @@ public def mkCtorIdx (indName : Name) : MetaM Unit :=
         modifyEnv (markMeta · declName)
       compileDecl decl
       enableRealizationsForConst declName
-
-      -- Deprecated alias for enumeration types (which used to have `toCtorIdx`)
-      if (← isEnumType indName) then
-        let aliasName := mkToCtorIdxName indName
-        addDecl (.defnDecl (← mkDefinitionValInferringUnsafe
-          (name        := aliasName)
-          (levelParams := info.levelParams)
-          (type        := declType)
-          (value       := mkConst declName us)
-          (hints       := ReducibilityHints.abbrev)
-        ))
-        if isMarkedMeta (← getEnv) indName then
-          modifyEnv (markMeta · aliasName)
-        compileDecls #[aliasName]
-        modifyEnv fun env => addToCompletionBlackList env aliasName
-        modifyEnv fun env => addProtected env aliasName
-        setReducibleAttribute aliasName
-        Lean.Linter.setDeprecated aliasName { newName? := some declName, since? := "2025-08-25" }
 
 end Lean

--- a/tests/elab/ctorIdx.lean
+++ b/tests/elab/ctorIdx.lean
@@ -88,14 +88,3 @@ inductive Eq' : α → α → Prop where | refl (a : α) : Eq' a a
 /-- error: Unknown constant `Eq'.ctorIdx` -/
 #guard_msgs in
 #print Eq'.ctorIdx
-
-
-set_option linter.deprecated true
-
--- Enumeration types get a deprecated alias, other types dont
-/-- info: Enum.toCtorIdx : Enum → Nat -/
-#guard_msgs in #check Enum.toCtorIdx
-/-- warning: `Enum.toCtorIdx` has been deprecated: Use `Enum.ctorIdx` instead -/
-#guard_msgs in example := Enum.toCtorIdx
-/-- error: Unknown identifier `Nonrec.toCtorIdx` -/
-#guard_msgs in #check Nonrec.toCtorIdx


### PR DESCRIPTION
This PR removes `toCtorIdx` which has been deprecated for almost a year by now.
