### PR TITLE
fix: report `cbv` not `simp` when max steps exceeded

### DIFF
--- a/src/Lean/Meta/Sym/Simp/Main.lean
+++ b/src/Lean/Meta/Sym/Simp/Main.lean
@@ -45,7 +45,7 @@ set_option compiler.ignoreBorrowAnnotation true in
 def simpImpl (e₁ : Expr) : SimpM Result := withIncRecDepth do
   let numSteps := (← get).numSteps
   if numSteps >= (← getConfig).maxSteps then
-    throwError "`simp` failed: maximum number of steps exceeded"
+    throwError "`{(← getConfig).tacticName}` failed: maximum number of steps exceeded"
   let key : ExprPtr := { expr := e₁ }
   if let some result := (← get).persistentCache.find? key then
     trace[sym.simp.debug.cache] "persistent cache hit: {e₁}"

--- a/src/Lean/Meta/Sym/Simp/SimpM.lean
+++ b/src/Lean/Meta/Sym/Simp/SimpM.lean
@@ -106,6 +106,11 @@ structure Config where
   Prevents infinite loops when conditional rewrite rules trigger recursive discharge attempts.
   -/
   maxDischargeDepth : Nat := 2
+  /--
+  Tactic name shown in user-facing error messages (e.g. max-steps exceeded).
+  Callers such as `cbv` set this so errors name the outer tactic rather than `simp`.
+  -/
+  tacticName : Name := `simp
   deriving Inhabited
 
 /--

--- a/src/Lean/Meta/Tactic/Cbv/Main.lean
+++ b/src/Lean/Meta/Tactic/Cbv/Main.lean
@@ -116,6 +116,10 @@ public register_builtin_option cbv.maxSteps : Nat := {
   descr    := "Controls the maximum number of steps for the `cbv` tactic."
 }
 
+/-- `Sym.Simp.Config` for `cbv`, including the correct `tacticName` for error messages. -/
+def getCbvConfig : MetaM Sym.Simp.Config := do
+  return { maxSteps := cbv.maxSteps.get (← getOptions), tacticName := `cbv }
+
 def tryEquations : Simproc := fun e => do
   unless e.isApp do
     return .rfl
@@ -385,7 +389,7 @@ public def cbvEntry (e : Expr) : MetaM Result := do
       | .ok (Result.rfl ..)     => return m!"cbv: no change{indentExpr e}"
       | .error err              => return m!"cbv: {err.toMessageData}") do
   let simprocs ← getCbvSimprocs
-  let config : Sym.Simp.Config := { maxSteps := cbv.maxSteps.get (← getOptions) }
+  let config ← getCbvConfig
   let methods := mkCbvMethods simprocs
   let e ← Sym.unfoldReducible e
   Sym.SymM.run do
@@ -401,7 +405,7 @@ call-by-value evaluation, within the caller's `SymM` context.
 public def cbvGoalCore (mvarId : MVarId) : Sym.SymM (Option MVarId) := do
   -- See `cbvCore` for why the `shareCommon` invariant checks are disabled.
   Sym.withoutShareCommonChecks do
-  let config : Sym.Simp.Config := { maxSteps := cbv.maxSteps.get (← getOptions) }
+  let config ← getCbvConfig
   mvarId.withContext do
     let mut mvarIdNew := mvarId
     let target ← mvarIdNew.getType
@@ -432,7 +436,7 @@ public def cbvHyp (mvarId : MVarId) (fvarId : FVarId) : MetaM (Option MVarId) :=
   mvarId.withContext do
     let localDecl ← fvarId.getDecl
     let type ← instantiateMVars localDecl.type
-    let config : Sym.Simp.Config := { maxSteps := cbv.maxSteps.get (← getOptions) }
+    let config ← getCbvConfig
     let result ← withTraceNode `Meta.Tactic.cbv (fun
         | .ok (Result.step type' ..) => return m!"hypothesis `{localDecl.userName}`:{indentExpr type}\n==>{indentExpr type'}"
         | .ok (Result.rfl ..)        => return m!"hypothesis `{localDecl.userName}`: no change"
@@ -475,7 +479,7 @@ public def cbvDecideGoal (m : MVarId) : MetaM Unit := do
   withTraceNode `Meta.Tactic.cbv (fun
       | .ok ()   => return m!"decide_cbv: closed goal"
       | .error err => return m!"decide_cbv: {err.toMessageData}") do
-  let config : Sym.Simp.Config := { maxSteps := cbv.maxSteps.get (← getOptions) }
+  let config ← getCbvConfig
   Sym.SymM.run do
     let m ← Sym.preprocessMVar m
     let mType ← m.getType

--- a/tests/elab/cbv_max_steps.lean
+++ b/tests/elab/cbv_max_steps.lean
@@ -1,10 +1,10 @@
 -- Default limit works on a normal computation
 example : (List.replicate 10 1).length = 10 := by cbv
 
--- Low limit triggers "maximum number of steps exceeded"
+-- Low limit triggers "maximum number of steps exceeded" (reports `cbv`, not `simp`)
 set_option cbv.maxSteps 10 in
 /--
-error: `simp` failed: maximum number of steps exceeded
+error: `cbv` failed: maximum number of steps exceeded
 -/
 #guard_msgs (error) in
 example : (List.replicate 10 1).length = 10 := by cbv


### PR DESCRIPTION
This PR makes the max-steps exceeded error from the shared `Sym.Simp` engine use a configurable tactic name so `cbv` reports `` `cbv` failed: maximum number of steps exceeded `` instead of incorrectly naming `simp`.

## Motivation

`cbv` is implemented on top of `Lean.Meta.Sym.Simp`. When `cbv.maxSteps` is hit, the shared helper hard-coded:

```
`simp` failed: maximum number of steps exceeded
```

which is confusing for users of the `cbv` tactic (issue #13719).

## Changes

- Add `tacticName : Name := \`simp` to `Sym.Simp.Config`
- Use `tacticName` in the max-steps error in `simpImpl`
- Have `cbv` pass `tacticName := \`cbv` via `getCbvConfig`
- Update `tests/elab/cbv_max_steps.lean` to expect `` `cbv` ``

Closes #13719

## AI disclosure

Developed with assistance from an AI coding agent (Grok). Changes were reviewed by the human author before submission.