### PR TITLE
fix: lake: elide redundant "Lean exited with code 1" after diagnostics

### DIFF
--- a/src/lake/Lake/Build/Actions.lean
+++ b/src/lake/Lake/Build/Actions.lean
@@ -62,6 +62,7 @@ public def compileLeanModule
       ("LEAN_PATH", leanPath.toString)
     ]
   }
+  let outLogPos ← getLogPos
   unless out.stdout.isEmpty do
     let txt ← out.stdout.split '\n' |>.foldM (init := "") fun (txt : String) ln => do
       let ln := ln.copy
@@ -80,7 +81,15 @@ public def compileLeanModule
   unless out.stderr.isEmpty do
     logInfo s!"stderr:\n{out.stderr.trimAscii}"
   if out.exitCode ≠ 0 then
-    error s!"Lean exited with code {out.exitCode}"
+    -- Elide the generic "Lean exited with code 1" when Lean already reported
+    -- errors (the usual compiler-failure case). Keep it for other exit codes
+    -- (e.g. `#eval IO.Process.exit 3`) and when no error diagnostics appeared.
+    -- See https://github.com/leanprover/lean4/issues/10825
+    let hasErrors := (← getLog).takeFrom outLogPos |>.any (·.level matches .error)
+    if out.exitCode = 1 && hasErrors then
+      failure
+    else
+      error s!"Lean exited with code {out.exitCode}"
   if postponeCompile then
     if let (some irFile, some cFile) := (arts.ir?, arts.c?) then
       createParentDirs irFile

--- a/src/lake/Lake/Build/Actions.lean
+++ b/src/lake/Lake/Build/Actions.lean
@@ -80,16 +80,16 @@ public def compileLeanModule
       logInfo s!"stdout:\n{txt}"
   unless out.stderr.isEmpty do
     logInfo s!"stderr:\n{out.stderr.trimAscii}"
-  if out.exitCode ≠ 0 then
-    -- Elide the generic "Lean exited with code 1" when Lean already reported
-    -- errors (the usual compiler-failure case). Keep it for other exit codes
-    -- (e.g. `#eval IO.Process.exit 3`) and when no error diagnostics appeared.
-    -- See https://github.com/leanprover/lean4/issues/10825
-    let hasErrors := (← getLog).takeFrom outLogPos |>.any (·.level matches .error)
-    if out.exitCode = 1 && hasErrors then
-      failure
-    else
-      error s!"Lean exited with code {out.exitCode}"
+  -- Elide the generic "Lean exited with code 1" when Lean already
+  -- reported errors (the usual compiler-failure case). Keep it for other
+  -- nonzero codes, for code 1 without diagnostics, and for the anomalous
+  -- case where Lean logs errors but exits successfully.
+  -- See https://github.com/leanprover/lean4/issues/10825
+  let hasErrors := (← getLog).takeFrom outLogPos |>.any (·.level matches .error)
+  if out.exitCode = 1 && hasErrors then
+    failure
+  else if out.exitCode ≠ 0 || hasErrors then
+    error s!"Lean exited with code {out.exitCode}"
   if postponeCompile then
     if let (some irFile, some cFile) := (arts.ir?, arts.c?) then
       createParentDirs irFile

--- a/tests/lake/tests/leanExit/ErrorExit0.lean
+++ b/tests/lake/tests/leanExit/ErrorExit0.lean
@@ -1,0 +1,2 @@
+def bad : Nat := "not a Nat"
+#eval (IO.Process.exit 0 : IO Unit)

--- a/tests/lake/tests/leanExit/Exit1NoError.lean
+++ b/tests/lake/tests/leanExit/Exit1NoError.lean
@@ -1,0 +1,1 @@
+#eval (IO.Process.exit 1 : IO Unit)

--- a/tests/lake/tests/leanExit/Exit3.lean
+++ b/tests/lake/tests/leanExit/Exit3.lean
@@ -1,0 +1,1 @@
+#eval (IO.Process.exit 3 : IO Unit)

--- a/tests/lake/tests/leanExit/TypeError.lean
+++ b/tests/lake/tests/leanExit/TypeError.lean
@@ -1,0 +1,1 @@
+def bad : Nat := "not a Nat"

--- a/tests/lake/tests/leanExit/clean.sh
+++ b/tests/lake/tests/leanExit/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/leanExit/lakefile.toml
+++ b/tests/lake/tests/leanExit/lakefile.toml
@@ -1,0 +1,9 @@
+name = "leanExit"
+version = "0.1.0"
+defaultTargets = ["TypeError", "Exit3"]
+
+[[lean_lib]]
+name = "TypeError"
+
+[[lean_lib]]
+name = "Exit3"

--- a/tests/lake/tests/leanExit/lakefile.toml
+++ b/tests/lake/tests/leanExit/lakefile.toml
@@ -1,9 +1,15 @@
 name = "leanExit"
 version = "0.1.0"
-defaultTargets = ["TypeError", "Exit3"]
+defaultTargets = ["TypeError", "Exit1NoError", "ErrorExit0", "Exit3"]
 
 [[lean_lib]]
 name = "TypeError"
+
+[[lean_lib]]
+name = "Exit1NoError"
+
+[[lean_lib]]
+name = "ErrorExit0"
 
 [[lean_lib]]
 name = "Exit3"

--- a/tests/lake/tests/leanExit/test.sh
+++ b/tests/lake/tests/leanExit/test.sh
@@ -5,7 +5,9 @@ source ../common.sh
 
 # https://github.com/leanprover/lean4/issues/10825
 # When Lean already printed errors and exited with code 1, Lake should not
-# add the redundant "Lean exited with code 1" line.
+# add the redundant "Lean exited with code 1" line. Other exit codes remain
+# visible; if Lean ever logs errors while exiting 0, Lake reports code 0 to
+# distinguish that anomalous state from the intentionally elided code-1 case.
 
 echo "# TEST: elide exit-code noise on ordinary type errors"
 lake_out build TypeError || true

--- a/tests/lake/tests/leanExit/test.sh
+++ b/tests/lake/tests/leanExit/test.sh
@@ -4,21 +4,30 @@ source ../common.sh
 ./clean.sh
 
 # https://github.com/leanprover/lean4/issues/10825
-# When Lean already printed errors and exited with code 1, Lake should not
-# add the redundant "Lean exited with code 1" line. Other exit codes remain
-# visible; if Lean ever logs errors while exiting 0, Lake reports code 0 to
-# distinguish that anomalous state from the intentionally elided code-1 case.
+# Lake elides exit code 1 only when Lean already emitted error diagnostics.
+# Every other exit/diagnostic combination keeps an explicit exit-code message.
 
-echo "# TEST: elide exit-code noise on ordinary type errors"
+echo "# TEST: elide exit code 1 after diagnostics"
 lake_out build TypeError || true
 match_text "Type mismatch" produced.out
 no_match_text "Lean exited with code 1" produced.out
-# Build should still fail
 test_fails build TypeError
 
-echo "# TEST: keep exit-code message for non-1 exit codes"
+echo "# TEST: report exit code 1 without diagnostics"
+lake_out build Exit1NoError || true
+match_text "Lean exited with code 1" produced.out
+no_match_text "Type mismatch" produced.out
+test_fails build Exit1NoError
+
+echo "# TEST: report exit code 0 when diagnostics were emitted"
+lake_out build ErrorExit0 || true
+match_text "Type mismatch" produced.out
+match_text "Lean exited with code 0" produced.out
+test_fails build ErrorExit0
+
+echo "# TEST: report non-1 exit codes"
 lake_out build Exit3 || true
 match_text "Lean exited with code 3" produced.out
+test_fails build Exit3
 
-# Cleanup
 rm -f produced.out

--- a/tests/lake/tests/leanExit/test.sh
+++ b/tests/lake/tests/leanExit/test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+# https://github.com/leanprover/lean4/issues/10825
+# When Lean already printed errors and exited with code 1, Lake should not
+# add the redundant "Lean exited with code 1" line.
+
+echo "# TEST: elide exit-code noise on ordinary type errors"
+lake_out build TypeError || true
+match_text "Type mismatch" produced.outno_match_text "Lean exited with code 1" produced.out
+# Build should still fail
+test_fails build TypeError
+
+echo "# TEST: keep exit-code message for non-1 exit codes"
+lake_out build Exit3 || true
+match_text "Lean exited with code 3" produced.out
+
+# Cleanup
+rm -f produced.out

--- a/tests/lake/tests/leanExit/test.sh
+++ b/tests/lake/tests/leanExit/test.sh
@@ -9,7 +9,8 @@ source ../common.sh
 
 echo "# TEST: elide exit-code noise on ordinary type errors"
 lake_out build TypeError || true
-match_text "Type mismatch" produced.outno_match_text "Lean exited with code 1" produced.out
+match_text "Type mismatch" produced.out
+no_match_text "Lean exited with code 1" produced.out
 # Build should still fail
 test_fails build TypeError
 


### PR DESCRIPTION
This PR suppresses Lake's wrapper line `error: Lean exited with code 1` when `lean` has already emitted error-level diagnostics and exited with code 1, which is the usual type-error path and was pure noise next to the real errors.

To avoid ambiguity, exit code 0 is still reported when Lean emitted error diagnostics. Other nonzero exit codes are also always reported, and exit code 1 with no error diagnostics still produces the wrapper message so silent failures remain visible.

## Behavior

In `compileLeanModule`, after replaying Lean's JSON and stderr output:

| Lean exit code | Error diagnostics logged? | Lake message |
|---|---|---|
| `1` | yes | omitted; only the diagnostic is shown |
| `1` | no | `error: Lean exited with code 1` |
| `0` | yes | `error: Lean exited with code 0` |
| other nonzero | any | `error: Lean exited with code N` |
| `0` | no | success |

This follows the discussion on #10825 and maintainer feedback: elide only the common exit-code-1 case after diagnostics, while keeping every other anomalous exit visible.

## Test plan

The focused `tests/lake/tests/leanExit` fixture covers all requested combinations:

- exit 1 with diagnostics: keeps the real type error and omits the wrapper line
- exit 1 without diagnostics: reports `Lean exited with code 1`
- exit 0 with diagnostics: reports `Lean exited with code 0`
- exit 3 without diagnostics: reports `Lean exited with code 3`

Each unsuccessful target is also asserted to fail the Lake build.

Closes #10825

## AI assistance

AI tools assisted with issue triage, implementation, and test preparation. I reviewed the control flow, the four-case test matrix, and the final diff.