### PR TITLE
chore: check the structure name when comparing projections in the kernel

### DIFF
--- a/src/kernel/equiv_manager.cpp
+++ b/src/kernel/equiv_manager.cpp
@@ -100,7 +100,8 @@ bool equiv_manager::is_equiv_core(expr const & a, expr const & b) {
         result = is_equiv_core(mdata_expr(a), mdata_expr(b));
         break;
     case expr_kind::Proj:
-        result = is_equiv_core(proj_expr(a), proj_expr(b)) && proj_idx(a) == proj_idx(b);
+        result = proj_sname(a) == proj_sname(b) && proj_idx(a) == proj_idx(b) &&
+            is_equiv_core(proj_expr(a), proj_expr(b));
         break;
     case expr_kind::Let:
         result =

--- a/src/kernel/type_checker.cpp
+++ b/src/kernel/type_checker.cpp
@@ -1105,7 +1105,7 @@ bool type_checker::is_def_eq_core(expr const & t, expr const & s) {
     if (is_fvar(t_n) && is_fvar(s_n) && fvar_name(t_n) == fvar_name(s_n))
         return true;
 
-    if (is_proj(t_n) && is_proj(s_n) && proj_idx(t_n) == proj_idx(s_n)) {
+    if (is_proj(t_n) && is_proj(s_n) && proj_sname(t_n) == proj_sname(s_n) && proj_idx(t_n) == proj_idx(s_n)) {
         expr t_c = proj_expr(t_n);
         expr s_c = proj_expr(s_n);
         if (lazy_delta_proj_reduction(t_c, s_c, proj_idx(t_n)))


### PR DESCRIPTION
This PR makes the kernel compare the structure name when deciding whether two projection expressions are definitionally equal. Both `type_checker::is_def_eq_core` and `equiv_manager::is_equiv_core` compared only the projection index and the projected expression, ignoring `proj_sname`.

This is not an exploitable bug: every projection in a submitted declaration passes through `infer_proj`, which rejects a structure name that does not match the projected expression's type, and projections constructed by the kernel during reduction always carry the correct name. So two projections reaching def-eq can only disagree on the structure name if one of them is ill-typed. The check turns that global invariant into a local one: after #14577 closed the nested-inductive path that let unchecked projections into the environment (#14576), these comparisons were the remaining places where a future injection bug could have been amplified into a def-eq attack surface.

There is no completeness loss for well-typed terms, since identical projected expressions force identical structure names.
