### PR TITLE
chore: harden kernel invariants

### DIFF
--- a/src/kernel/environment.cpp
+++ b/src/kernel/environment.cpp
@@ -234,11 +234,19 @@ environment environment::add_mutual(declaration const & d, bool check) const {
     /* Check declarations header */
     if (check) {
         type_checker checker(*this, diag.get(), safety);
+        name_set found;
         for (definition_val const & v : vs) {
             if (v.get_safety() != safety)
                 throw kernel_exception(*this, "invalid mutual definition, declarations must have the same safety annotation");
             if (v.get_lparams() != lparams)
                 throw kernel_exception(*this, "invalid mutual definition, declarations must have the same universe level parameters");
+            /* The `check_name` in `check_constant_val` only sees `*this`, where none of the block's
+               own names have been declared yet, so duplicates within the block need their own check.
+               Otherwise every member but the last would be added and then overwritten. */
+            if (found.contains(v.get_name()))
+                throw kernel_exception(*this, sstream() << "invalid mutual definition, duplicate declaration name '"
+                                       << v.get_name() << "'");
+            found.insert(v.get_name());
             check_constant_val(*this, v.to_constant_val(), checker);
         }
     }

--- a/src/kernel/inductive.cpp
+++ b/src/kernel/inductive.cpp
@@ -818,11 +818,18 @@ struct elim_nested_inductive_result {
         return optional<pair<expr, name>>(std::in_place, *nested, auxI_name);
     }
 
+    /* The conditions checked below are established by `elim_nested_inductive_fn`. They are tested
+       rather than asserted because violating them is not a wrong answer but an out-of-bounds read:
+       `binding_*` and `const_name` would fetch a field the expression does not have, and
+       `args.size() - m_params.size()` would underflow into the argument count of `mk_app`. */
     name restore_constructor_name(environment const & aux_env, name const & cnstr_name) const {
         optional<pair<expr, name>> p = get_nested_if_aux_constructor(aux_env, cnstr_name);
-        lean_assert(p);
+        if (!p)
+            throw kernel_exception(aux_env, sstream() << "failed to restore nested inductive types, '"
+                                   << cnstr_name << "' is not a constructor of an auxiliary type");
         expr const & I = get_app_fn(p->first);
-        lean_assert(is_constant(I));
+        if (!is_constant(I))
+            throw kernel_exception(aux_env, "failed to restore nested inductive types, nested occurrence is not an inductive type application");
         return cnstr_name.replace_prefix(p->second, const_name(I));
     }
 
@@ -831,7 +838,8 @@ struct elim_nested_inductive_result {
         buffer<expr> As;
         bool pi = is_pi(e);
         for (unsigned i = 0; i < m_params.size(); i++) {
-            lean_assert(is_pi(e) || is_lambda(e));
+            if (!is_pi(e) && !is_lambda(e))
+                throw kernel_exception(aux_env, "failed to restore nested inductive types, fewer binders than parameters");
             As.push_back(lctx.mk_local_decl(m_ngen, binding_name(e), binding_domain(e), binding_info(e)));
             e = instantiate(binding_body(e), As.back());
         }
@@ -846,7 +854,8 @@ struct elim_nested_inductive_result {
                     if (expr const * nested = m_aux2nested.find(const_name(fn))) {
                         buffer<expr> args;
                         get_app_args(t, args);
-                        lean_assert(args.size() >= m_params.size());
+                        if (args.size() < m_params.size())
+                            throw kernel_exception(aux_env, "failed to restore nested inductive types, auxiliary type is not applied to all parameters");
                         expr new_t = instantiate_rev(abstract(*nested, m_params.size(), m_params.data()), As.size(), As.data());
                         return some_expr(mk_app(new_t, args.size() - m_params.size(), args.data() + m_params.size()));
                     }
@@ -856,11 +865,13 @@ struct elim_nested_inductive_result {
                         /* `t` is a constructor-application of an auxiliary inductive type */
                         buffer<expr> args;
                         get_app_args(t, args);
-                        lean_assert(args.size() >= m_params.size());
+                        if (args.size() < m_params.size())
+                            throw kernel_exception(aux_env, "failed to restore nested inductive types, auxiliary constructor is not applied to all parameters");
                         expr new_nested = instantiate_rev(abstract(nested, m_params.size(), m_params.data()), As.size(), As.data());
                         buffer<expr> I_args;
                         expr I = get_app_args(new_nested, I_args);
-                        lean_assert(is_constant(I));
+                        if (!is_constant(I))
+                            throw kernel_exception(aux_env, "failed to restore nested inductive types, nested occurrence is not an inductive type application");
                         name new_fn_name = const_name(fn).replace_prefix(auxI_name, const_name(I));
                         expr new_fn = mk_constant(new_fn_name, const_levels(I));
                         expr new_t  = mk_app(mk_app(new_fn, I_args), args.size() - m_params.size(), args.data() + m_params.size());

--- a/src/kernel/quot.cpp
+++ b/src/kernel/quot.cpp
@@ -48,6 +48,12 @@ environment environment::add_quot() const {
     if (is_quot_initialized())
         return *this;
     check_eq_type(*this);
+    /* The `add_core` calls below overwrite, so a name already taken would be silently replaced,
+       leaving any declaration checked against the old constant ill typed. */
+    check_name(*quot_consts::g_quot);
+    check_name(*quot_consts::g_quot_mk);
+    check_name(*quot_consts::g_quot_lift);
+    check_name(*quot_consts::g_quot_ind);
     environment new_env = *this;
     name u_name("u");
     local_ctx lctx;

--- a/src/kernel/type_checker.cpp
+++ b/src/kernel/type_checker.cpp
@@ -6,6 +6,7 @@ Author: Leonardo de Moura
 */
 #include <utility>
 #include <vector>
+#include <limits>
 #include "runtime/interrupt.h"
 #include "runtime/sstream.h"
 #include "runtime/flet.h"
@@ -218,11 +219,26 @@ expr type_checker::infer_let(expr const & _e, bool infer_only) {
     return m_lctx.mk_pi(fvars, r, true);
 }
 
+/*
+Store the projection index in `result`, and return `false` if it does not fit.
+`nat::is_small` admits up to 63 bits, but projection indices are consumed as `unsigned`, so
+without the upper bound `.proj S 2^32 c` would be silently truncated into `.proj S 0 c`.
+*/
+static bool to_proj_idx(nat const & idx, unsigned & result) {
+    if (!idx.is_small())
+        return false;
+    size_t v = idx.get_small_value();
+    if (v > std::numeric_limits<unsigned>::max())
+        return false;
+    result = static_cast<unsigned>(v);
+    return true;
+}
+
 expr type_checker::infer_proj(expr const & e, bool infer_only) {
     expr type = whnf(infer_type_core(proj_expr(e), infer_only));
-    if (!proj_idx(e).is_small())
+    unsigned idx;
+    if (!to_proj_idx(proj_idx(e), idx))
         throw invalid_proj_exception(env(), m_lctx, e);
-    unsigned idx = proj_idx(e).get_small_value();
     buffer<expr> args;
     expr const & I = get_app_args(type, args);
     if (!is_constant(I))
@@ -386,9 +402,9 @@ optional<expr> type_checker::reduce_proj_core(expr c, name const & sname, unsign
 
 /* If `cheap == true`, then we don't perform delta-reduction when reducing major premise. */
 optional<expr> type_checker::reduce_proj(expr const & e, bool cheap_rec, bool cheap_proj) {
-    if (!proj_idx(e).is_small())
+    unsigned idx;
+    if (!to_proj_idx(proj_idx(e), idx))
         return none_expr();
-    unsigned idx = proj_idx(e).get_small_value();
     expr c;
     if (cheap_proj)
         c = whnf_core(proj_expr(e), cheap_rec, cheap_proj);
@@ -1024,8 +1040,8 @@ bool type_checker::lazy_delta_proj_reduction(expr & t_n, expr & s_n, name const 
         case reduction_status::DefEqual:   return true;
         case reduction_status::DefUnknown:
         case reduction_status::DefDiff:
-            if (idx.is_small()) {
-                unsigned i = idx.get_small_value();
+            unsigned i;
+            if (to_proj_idx(idx, i)) {
                 if (auto t = reduce_proj_core(t_n, sname, i)) {
                 if (auto s = reduce_proj_core(s_n, sname, i)) {
                     return is_def_eq_core(*t, *s);

--- a/src/kernel/type_checker.cpp
+++ b/src/kernel/type_checker.cpp
@@ -361,7 +361,7 @@ expr type_checker::whnf_fvar(expr const & e, bool cheap_rec, bool cheap_proj) {
 }
 
 /* Auxiliary method for `reduce_proj` */
-optional<expr> type_checker::reduce_proj_core(expr c, unsigned idx) {
+optional<expr> type_checker::reduce_proj_core(expr c, name const & sname, unsigned idx) {
     if (is_string_lit(c))
         c = whnf(string_lit_to_constructor(c));
     buffer<expr> args;
@@ -371,7 +371,13 @@ optional<expr> type_checker::reduce_proj_core(expr c, unsigned idx) {
     constant_info mk_info = env().get(const_name(mk));
     if (!mk_info.is_constructor())
         return none_expr();
-    unsigned nparams = mk_info.to_constructor_val().get_nparams();
+    constructor_val mk_val = mk_info.to_constructor_val();
+    /* `sname` selects which structure's field layout `idx` refers to, so a constructor of any other
+       inductive must not be projected. Only an ill-typed projection can reach this, since
+       `infer_proj` rejects a `sname` that disagrees with the projected expression's type. */
+    if (mk_val.get_induct() != sname)
+        return none_expr();
+    unsigned nparams = mk_val.get_nparams();
     if (nparams + idx < args.size())
         return some_expr(args[nparams + idx]);
     else
@@ -388,7 +394,7 @@ optional<expr> type_checker::reduce_proj(expr const & e, bool cheap_rec, bool ch
         c = whnf_core(proj_expr(e), cheap_rec, cheap_proj);
     else
         c = whnf(proj_expr(e));
-    return reduce_proj_core(c, idx);
+    return reduce_proj_core(c, proj_sname(e), idx);
 }
 
 static bool is_let_fvar(local_ctx const & lctx, expr const & e) {
@@ -1011,7 +1017,7 @@ Recall that the simpler approach used at `Meta.ExprDefEq` cannot be used in the
 kernel since it does not have access to reducibility annotations.
 The approach used here is more complicated, but it is also more powerful.
 */
-bool type_checker::lazy_delta_proj_reduction(expr & t_n, expr & s_n, nat const & idx) {
+bool type_checker::lazy_delta_proj_reduction(expr & t_n, expr & s_n, name const & sname, nat const & idx) {
     while (true) {
         switch (lazy_delta_reduction_step(t_n, s_n)) {
         case reduction_status::Continue:   break;
@@ -1020,8 +1026,8 @@ bool type_checker::lazy_delta_proj_reduction(expr & t_n, expr & s_n, nat const &
         case reduction_status::DefDiff:
             if (idx.is_small()) {
                 unsigned i = idx.get_small_value();
-                if (auto t = reduce_proj_core(t_n, i)) {
-                if (auto s = reduce_proj_core(s_n, i)) {
+                if (auto t = reduce_proj_core(t_n, sname, i)) {
+                if (auto s = reduce_proj_core(s_n, sname, i)) {
                     return is_def_eq_core(*t, *s);
                 }}
             }
@@ -1108,7 +1114,7 @@ bool type_checker::is_def_eq_core(expr const & t, expr const & s) {
     if (is_proj(t_n) && is_proj(s_n) && proj_sname(t_n) == proj_sname(s_n) && proj_idx(t_n) == proj_idx(s_n)) {
         expr t_c = proj_expr(t_n);
         expr s_c = proj_expr(s_n);
-        if (lazy_delta_proj_reduction(t_c, s_c, proj_idx(t_n)))
+        if (lazy_delta_proj_reduction(t_c, s_c, proj_sname(t_n), proj_idx(t_n)))
             return true;
     }
 

--- a/src/kernel/type_checker.h
+++ b/src/kernel/type_checker.h
@@ -71,7 +71,7 @@ private:
 
     enum class reduction_status { Continue, DefUnknown, DefEqual, DefDiff };
     optional<expr> reduce_recursor(expr const & e, bool cheap_rec, bool cheap_proj);
-    optional<expr> reduce_proj_core(expr c, unsigned idx);
+    optional<expr> reduce_proj_core(expr c, name const & sname, unsigned idx);
     optional<expr> reduce_proj(expr const & e, bool cheap_rec, bool cheap_proj);
     expr whnf_fvar(expr const & e, bool cheap_rec, bool cheap_proj);
     optional<constant_info> is_delta(expr const & e) const;
@@ -100,7 +100,7 @@ private:
     void cache_failure(expr const & t, expr const & s);
     reduction_status lazy_delta_reduction_step(expr & t_n, expr & s_n);
     lbool lazy_delta_reduction(expr & t_n, expr & s_n);
-    bool lazy_delta_proj_reduction(expr & t_n, expr & s_n, nat const & idx);
+    bool lazy_delta_proj_reduction(expr & t_n, expr & s_n, name const & sname, nat const & idx);
     bool is_def_eq_core(expr const & t, expr const & s);
     /** \brief Like \c check, but ignores undefined universes */
     expr check_ignore_undefined_universes(expr const & e);

--- a/tests/elab/kernelMutualDupName.lean
+++ b/tests/elab/kernelMutualDupName.lean
@@ -1,0 +1,41 @@
+import Lean
+
+/-!
+The kernel must reject a mutual block that declares the same name twice.
+
+`add_mutual` checked each member's name with `check_name`, which only looks at the pre-existing
+environment — the block's own names are not there yet. So a duplicate passed, every member was
+added in turn, and the last insert overwrote the others. The checks performed on the overwritten
+members were then meaningless.
+
+`add_mutual` rejects `safe` declarations outright, so the members here are `partial`.
+-/
+
+open Lean
+
+private def mkDefn (n : Name) (type value : Expr) : DefinitionVal :=
+  { name := n, levelParams := [], type, value, hints := .opaque, safety := .partial }
+
+/-- info: mutual block with distinct names: ok -/
+#guard_msgs in
+#eval show CoreM Unit from do
+  addDecl <| .mutualDefnDecl [
+    mkDefn `mdistinctA (mkConst ``Nat) (mkRawNatLit 0),
+    mkDefn `mdistinctB (mkConst ``Bool) (mkConst ``Bool.true)]
+  IO.println "mutual block with distinct names: ok"
+
+/--
+error: (kernel) invalid mutual definition, duplicate declaration name 'mdup'
+-/
+#guard_msgs in
+#eval show CoreM Unit from
+  addDecl <| .mutualDefnDecl [
+    mkDefn `mdup (mkConst ``Nat) (mkRawNatLit 0),
+    mkDefn `mdup (mkConst ``Bool) (mkConst ``Bool.true)]
+
+/-! A name already in the environment is still rejected by the pre-existing `check_name`. -/
+
+/-- error: (kernel) constant has already been declared 'mdistinctA' -/
+#guard_msgs in
+#eval show CoreM Unit from
+  addDecl <| .mutualDefnDecl [mkDefn `mdistinctA (mkConst ``Nat) (mkRawNatLit 0)]

--- a/tests/elab/kernelProjIdx.lean
+++ b/tests/elab/kernelProjIdx.lean
@@ -1,0 +1,71 @@
+import Lean
+
+/-!
+The kernel must reject a projection index that does not fit in the width it is handled at.
+
+`Expr.proj` stores an arbitrary-precision index, and the kernel guarded it with `nat::is_small`,
+which admits 63 bits, before narrowing it to `unsigned`. So `.proj P 2^32 p` was silently truncated
+into `.proj P 0 p` and accepted — typing and reduction agreed on the wrong field, and the kernel
+accepted a term that any checker using arbitrary-precision indices rejects.
+
+`4294967296` is `2^32`, the first index that aliased field `0`; `4294967297` aliased field `1`.
+
+Note that `Expr.proj` indices are 0-based while the pretty printer numbers fields from 1, so the
+expected messages below show each index one higher than it was written.
+-/
+
+open Lean
+
+structure P where
+  a : Nat
+  b : Nat
+
+private def p : Expr := mkApp2 (mkConst ``P.mk) (mkRawNatLit 7) (mkRawNatLit 9)
+
+private def kcheck (idx : Nat) : CoreM Unit := do
+  let t ← ofExceptKernelException (Kernel.check (← getEnv) {} (mkProj ``P idx p))
+  IO.println s!"idx {idx} : {t}"
+
+private def kwhnf (idx : Nat) : CoreM Unit := do
+  let r ← ofExceptKernelException (Kernel.whnf (← getEnv) {} (mkProj ``P idx p))
+  IO.println s!"idx {idx} ==> {r}"
+
+/-! Controls: in-range indices are unaffected. -/
+
+/-- info: idx 0 : Nat -/
+#guard_msgs in
+#eval kcheck 0
+
+/-- info: idx 0 ==> 7 -/
+#guard_msgs in
+#eval kwhnf 0
+
+/-- info: idx 1 ==> 9 -/
+#guard_msgs in
+#eval kwhnf 1
+
+/-! An index that fits but is out of bounds is rejected, as it always was. -/
+
+/--
+error: (kernel) invalid projection
+  (P.mk 7 9).3
+-/
+#guard_msgs in
+#eval kcheck 2
+
+/-! An index too wide for `unsigned` is now rejected too, rather than truncated. -/
+
+/--
+error: (kernel) invalid projection
+  (P.mk 7 9).4294967297
+-/
+#guard_msgs in
+#eval kcheck 4294967296
+
+/-- info: idx 4294967296 ==> (P.mk 7 9).4294967297 -/
+#guard_msgs in
+#eval kwhnf 4294967296
+
+/-- info: idx 4294967297 ==> (P.mk 7 9).4294967298 -/
+#guard_msgs in
+#eval kwhnf 4294967297

--- a/tests/elab/kernelProjSname.lean
+++ b/tests/elab/kernelProjSname.lean
@@ -1,0 +1,58 @@
+import Lean
+
+/-!
+The kernel must not reduce a projection whose structure name disagrees with the constructor it is
+applied to.
+
+`reduce_proj_core` used to select the field by index alone, so `.proj A 0 (B.mk 7)` reduced to `7`
+even though `A` and `B` are unrelated. `infer_proj` rejects such a projection, so it can only reach
+reduction from a declaration that was never checked; `debug.skipKernelTC` simulates that here.
+
+Each check is a pair differing only in the projection's structure name, which isolates the
+structure-name comparison from everything else in `reduce_proj_core`.
+-/
+
+open Lean
+
+structure A where
+  a : Nat
+
+structure B where
+  b : Nat
+
+private def kwhnf (e : Expr) : CoreM Expr := do
+  ofExceptKernelException (Kernel.whnf (← getEnv) {} e)
+
+/-! Planted declarations: the projection reaches reduction by delta-unfolding a definition value,
+which is the one path that is never re-inferred. -/
+
+private def plant (n : Name) (sname : Name) : CoreM Unit :=
+  addDecl <| .defnDecl {
+    name := n, levelParams := [], type := mkConst ``Nat
+    value := mkProj sname 0 (mkApp (mkConst ``B.mk) (mkRawNatLit 7))
+    hints := .abbrev, safety := .safe }
+
+set_option debug.skipKernelTC true in
+#eval do plant `viaB ``B; plant `viaA ``A
+
+/-- info: viaB ==> 7 -/
+#guard_msgs in
+#eval do IO.println s!"viaB ==> {← kwhnf (mkConst `viaB)}"
+
+/-- info: viaA ==> (B.mk 7).1 -/
+#guard_msgs in
+#eval do IO.println s!"viaA ==> {← kwhnf (mkConst `viaA)}"
+
+/-! String literals reach the same code path through `string_lit_to_constructor`, and are covered by
+the same comparison: the constructor it produces belongs to `String`. -/
+
+private def stuck (sname : Name) : CoreM Unit := do
+  IO.println s!"{sname} on a string literal stuck? {(← kwhnf (mkProj sname 0 (mkStrLit "ab"))).isProj}"
+
+/-- info: String on a string literal stuck? false -/
+#guard_msgs in
+#eval stuck ``String
+
+/-- info: A on a string literal stuck? true -/
+#guard_msgs in
+#eval stuck ``A

--- a/tests/elab_fail/kernelQuotNameCollision.lean
+++ b/tests/elab_fail/kernelQuotNameCollision.lean
@@ -1,0 +1,27 @@
+prelude
+
+/-!
+The kernel must reject `init_quot` when one of the quotient primitives is already declared.
+
+`add_quot` adds `Quot`, `Quot.mk`, `Quot.lift` and `Quot.ind` with a raw insert, so without a name
+check it silently replaced whatever occupied those names. A declaration checked against the old
+constant then stayed in the environment, ill typed and with no axiom dependency to show for it.
+
+`init_quot` runs here because a `prelude` module with no imports has not initialized the quotient
+module yet.
+
+**Note**: Comparator also catches this kind of exploit.
+-/
+
+inductive False : Prop
+
+inductive Eq : {α : Sort u} → α → α → Prop where
+  | refl (a : α) : Eq a a
+
+axiom Quot.lift : False
+
+theorem bad : False := Quot.lift
+
+init_quot
+
+#print axioms bad

--- a/tests/elab_fail/kernelQuotNameCollision.lean.out.expected
+++ b/tests/elab_fail/kernelQuotNameCollision.lean.out.expected
@@ -1,0 +1,2 @@
+kernelQuotNameCollision.lean:25:0-25:9: error: (kernel) constant has already been declared 'Quot.lift'
+'bad' depends on axioms: [Quot.lift]


### PR DESCRIPTION
This PR is a hardening pass over the kernel. None of these commits fixes a bug reachable from ordinary Lean code: each one takes an invariant the kernel already depends on and checks it locally instead of assuming it holds elsewhere. The intent is that a future mistake in a neighbouring part of the kernel surfaces as a clean error rather than being amplified.

- `add_quot` now checks that `Quot`, `Quot.mk`, `Quot.lift` and `Quot.ind` are undeclared, as every other declaration path already does. It used to insert them over whatever occupied those names, which only a module replacing the prelude can arrange, and which Comparator already reports.

- `reduce_proj_core` now compares the projection's structure name against the constructor it is applied to, instead of selecting the field by index alone. `infer_proj` rejects a mismatched name, so this can only be reached from a declaration that was never checked.

- Projection indices are now rejected unless they fit in the width the kernel handles them at. The guard admitted 63 bits and the consumers narrowed to 32, so `.proj S (2^32) c` was accepted as an alias for `.proj S 0 c`.

- `add_mutual` now rejects a block that declares the same name twice. The existing check only looked at the pre-existing environment, where the block's own names are not yet present, so every member but the last was added and then overwritten.

- The `lean_assert`s in the nested-inductive restoration are now kernel exceptions. They guard against out-of-bounds reads rather than wrong answers: in a release build the assertions vanish.
