### PR TITLE
fix: preserve inj parameters in grind? suggestions

### DIFF
--- a/src/Lean/Elab/Tactic/Grind/Main.lean
+++ b/src/Lean/Elab/Tactic/Grind/Main.lean
@@ -393,7 +393,9 @@ def evalGrindTraceCore (stx : Syntax) (trace := true) (verbose := true) (useSorr
     if let some (_, _ :: _) := (← resolveLocalName id.getId) then
       return true
     else if let some mod := mod? then
-      return (← Grind.getAttrKindCore mod) matches .cases _
+      match ← Grind.getAttrKindCore mod with
+      | .ematch _ => return false
+      | _ => return true
     else
       let declName? ← try pure (some (← realizeGlobalConstNoOverload id)) catch _ => pure none
       if let some declName := declName? then

--- a/tests/elab/grind_question_mark_suggestions.lean
+++ b/tests/elab/grind_question_mark_suggestions.lean
@@ -21,3 +21,18 @@ info: Try these:
 #guard_msgs in
 example {x y : Nat} (h : x = y) : x = f y := by
   grind? +suggestions [f]
+
+def addThree (n : Nat) := n + 3
+
+theorem addThree_inj : Function.Injective addThree := by
+  intro a b h
+  simp [addThree] at h
+  exact h
+
+/--
+info: Try this:
+  [apply] grind only [inj addThree_inj]
+-/
+#guard_msgs in
+example (a b : Nat) (h : addThree a = addThree b) : a = b := by
+  grind? [inj addThree_inj]


### PR DESCRIPTION
This PR preserves explicit non-E-matching modifiers (such as `cases`) when `grind?` reconstructs its suggested replacement script.

`grind?` reconstructed E-matching parameters from the generated proof script, but kept only explicit `cases` modifiers. As a result, `[inj theorem]` could prove the goal while being omitted from the suggested replacement.

Preserve explicit non-E-matching modifiers when building suggestions. E-matching parameters remain reconstructed from collected proof steps.

Adds a focused regression test expecting `grind only [inj addThree_inj]`.

Closes #14573

## Validation

- Added a guard-message regression in `tests/elab/grind_question_mark_suggestions.lean`
- Full Lean CI will validate the core change

## AI assistance

AI tools assisted with issue triage, implementation, and test preparation. I reviewed the control flow and the final diff.
