### PR TITLE
fix: reject oversized JSON exponents before Nat.pow

### DIFF
--- a/src/Lean/Data/Json/Parser.lean
+++ b/src/Lean/Data/Json/Parser.lean
@@ -190,7 +190,7 @@ def exponent (value : JsonNumber) : Parser JsonNumber := do
       else
         if c = '+' then skip
         let n ← natMaybeZero
-        if n > USize.size then fail "exp too large"
+        if n ≥ UInt32.size then fail "exp too large"
         return value.shiftl n
     else
       return value

--- a/tests/elab/jsonLargeExponent.lean
+++ b/tests/elab/jsonLargeExponent.lean
@@ -1,0 +1,5 @@
+import Lean.Data.Json
+
+#guard match Lean.Json.parse "3E9999999993" with
+  | .error _ => true
+  | .ok _ => false


### PR DESCRIPTION
This PR rejects JSON exponents at or above `UInt32.size` before they reach `Nat.pow`, preventing an internal panic on oversized exponents.

Positive JSON exponents are materialized through `JsonNumber.shiftl`, which calls `Nat.pow`. The runtime accepts exponents only through `UInt32.max`, but the parser compared against `USize.size`, allowing larger values to reach an internal panic.

Reject exponents at `UInt32.size` before shifting and add a regression for the reported input.

Closes #13987

## Validation

- Added `tests/elab/jsonLargeExponent.lean`
- Full Lean CI will validate the parser and regression

## AI assistance

AI tools assisted with issue triage, implementation, and test preparation. I reviewed the runtime bound and final diff.
