### PR TITLE
fix: lake: do not quote string Lean option values

### DIFF
--- a/src/Lean/Util/LeanOptions.lean
+++ b/src/Lean/Util/LeanOptions.lean
@@ -61,7 +61,7 @@ instance : ToJson LeanOptionValue where
 
 /-- Formats the lean option value as a CLI flag argument. -/
 def LeanOptionValue.asCliFlagValue : (v : LeanOptionValue) → String
-  | (s : String) => s!"\"{s}\""
+  | (s : String) => s
   | (b : Bool)   => toString b
   | (n : Nat)    => toString n
 
@@ -95,7 +95,7 @@ instance : Append LeanOptions := ⟨LeanOptions.append⟩
 
 /-- Add the options from `new`, overriding those in `self`. -/
 def LeanOptions.appendArray (self : LeanOptions) (new : Array LeanOption) : LeanOptions :=
-  ⟨new.foldl (fun m {name, value} => m.insert name value) self.values⟩
+  ⟨new.foldl (fun m {name, value} => m.insert name optionValue) self.values⟩
 
 instance : HAppend LeanOptions (Array LeanOption) LeanOptions := ⟨LeanOptions.appendArray⟩
 

--- a/src/Lean/Util/LeanOptions.lean
+++ b/src/Lean/Util/LeanOptions.lean
@@ -95,7 +95,7 @@ instance : Append LeanOptions := ⟨LeanOptions.append⟩
 
 /-- Add the options from `new`, overriding those in `self`. -/
 def LeanOptions.appendArray (self : LeanOptions) (new : Array LeanOption) : LeanOptions :=
-  ⟨new.foldl (fun m {name, value} => m.insert name optionValue) self.values⟩
+  ⟨new.foldl (fun m {name, value} => m.insert name value) self.values⟩
 
 instance : HAppend LeanOptions (Array LeanOption) LeanOptions := ⟨LeanOptions.appendArray⟩
 

--- a/tests/elab/leanOptions.lean
+++ b/tests/elab/leanOptions.lean
@@ -1,5 +1,9 @@
-/-- String-valued Lean options are passed as direct subprocess arguments, so their CLI values must not contain shell quotes. -/
 import Lean.Util.LeanOptions
+
+/-!
+String-valued Lean options are passed as direct subprocess arguments, so their CLI values must not
+contain shell quotes.
+-/
 
 open Lean
 

--- a/tests/elab/leanOptions.lean
+++ b/tests/elab/leanOptions.lean
@@ -1,0 +1,7 @@
+/-- String-valued Lean options are passed as direct subprocess arguments, so their CLI values must not contain shell quotes. -/
+import Lean.Util.LeanOptions
+
+open Lean
+
+#guard (LeanOptionValue.ofString "two words").asCliFlagValue == "two words"
+#guard (LeanOption.mk `example (.ofString "two words")).asCliArg == "-Dexample=two words"

--- a/tests/lean/run/leanOptions.lean
+++ b/tests/lean/run/leanOptions.lean
@@ -1,6 +1,0 @@
-import Lean.Util.LeanOptions
-
-open Lean
-
-#guard (LeanOptionValue.ofString "two words").asCliFlagValue == "two words"
-#guard (LeanOption.mk `example (.ofString "two words")).asCliArg == "-Dexample=two words"

--- a/tests/lean/run/leanOptions.lean
+++ b/tests/lean/run/leanOptions.lean
@@ -1,0 +1,6 @@
+import Lean.Util.LeanOptions
+
+open Lean
+
+#guard (LeanOptionValue.ofString "two words").asCliFlagValue == "two words"
+#guard (LeanOption.mk `example (.ofString "two words")).asCliArg == "-Dexample=two words"


### PR DESCRIPTION
This PR stops Lake from adding literal quote characters to string-valued Lean options.

Lake passes Lean options directly as subprocess arguments. Quoting string values in `LeanOptionValue.asCliFlagValue` therefore makes the quote characters part of the option value.

Return string values unchanged and add guards for both the raw CLI value and the complete `-D` argument.

Closes #7517

## Validation

- Added focused guards in `tests/elab/leanOptions.lean`
- Full Lean CI validates the source and test suite

## AI assistance

AI tools assisted with issue triage, implementation, and test preparation. I reviewed the final diff.