### PR TITLE
refactor: replace grind proofs in Vector.Algebra

### DIFF
--- a/src/Init/Data/Vector/Algebra.lean
+++ b/src/Init/Data/Vector/Algebra.lean
@@ -37,10 +37,21 @@ instance [Add α] : Add (Vector α n) := ⟨add⟩
 theorem getElem_add [Add α] (xs ys : Vector α n) (i : Nat) (h : i < n) : (xs + ys)[i] = xs[i] + ys[i] := by
   erw [getElem_zipWith]
 
-theorem add_zero [Zero α] [Add α] (add_zero : ∀ x : α, x + 0 = x) (xs : Vector α n) : xs + 0 = xs := by grind
-theorem zero_add [Zero α] [Add α] (zero_add : ∀ x : α, 0 + x = x) (xs : Vector α n) : 0 + xs = xs := by grind
-theorem add_comm [Add α] (add_comm : ∀ x y : α, x + y = y + x) (xs ys : Vector α n) : xs + ys = ys + xs := by grind
-theorem add_assoc [Add α] (add_assoc : ∀ x y z : α, (x + y) + z = x + (y + z)) (xs ys zs : Vector α n) : (xs + ys) + zs = xs + (ys + zs) := by grind
+theorem add_zero [Zero α] [Add α] (add_zero : ∀ x : α, x + 0 = x) (xs : Vector α n) : xs + 0 = xs := by
+  ext i h
+  simpa only [getElem_add, getElem_zero] using add_zero xs[i]
+
+theorem zero_add [Zero α] [Add α] (zero_add : ∀ x : α, 0 + x = x) (xs : Vector α n) : 0 + xs = xs := by
+  ext i h
+  simpa only [getElem_add, getElem_zero] using zero_add xs[i]
+
+theorem add_comm [Add α] (add_comm : ∀ x y : α, x + y = y + x) (xs ys : Vector α n) : xs + ys = ys + xs := by
+  ext i h
+  simpa only [getElem_add] using add_comm xs[i] ys[i]
+
+theorem add_assoc [Add α] (add_assoc : ∀ x y z : α, (x + y) + z = x + (y + z)) (xs ys zs : Vector α n) : (xs + ys) + zs = xs + (ys + zs) := by
+  ext i h
+  simpa only [getElem_add] using add_assoc xs[i] ys[i] zs[i]
 
 /-- Componentwise negation of vectors. -/
 def neg [Neg α] (xs : Vector α n) : Vector α n :=
@@ -52,8 +63,13 @@ instance [Neg α] : Neg (Vector α n) := ⟨neg⟩
 theorem getElem_neg [Neg α] (xs : Vector α n) (i : Nat) (h : i < n) : (-xs)[i] = -xs[i] := by
   erw [getElem_map]
 
-theorem neg_zero [Zero α] [Neg α] (neg_zero : -(0 : α) = 0) : -(0 : Vector α n) = 0 := by grind
-theorem neg_add_cancel [Zero α] [Add α] [Neg α] (neg_add_cancel : ∀ x : α, -x + x = 0) (xs : Vector α n) : -xs + xs = 0 := by grind
+theorem neg_zero [Zero α] [Neg α] (neg_zero : -(0 : α) = 0) : -(0 : Vector α n) = 0 := by
+  ext i h
+  simpa only [getElem_neg, getElem_zero] using neg_zero
+
+theorem neg_add_cancel [Zero α] [Add α] [Neg α] (neg_add_cancel : ∀ x : α, -x + x = 0) (xs : Vector α n) : -xs + xs = 0 := by
+  ext i h
+  simpa only [getElem_add, getElem_neg, getElem_zero] using neg_add_cancel xs[i]
 
 /-- Componentwise subtraction of vectors. -/
 def sub [Sub α] (xs ys : Vector α n) : Vector α n :=
@@ -65,7 +81,9 @@ instance [Sub α] : Sub (Vector α n) := ⟨sub⟩
 theorem getElem_sub [Sub α] (xs ys : Vector α n) (i : Nat) (h : i < n) : (xs - ys)[i] = xs[i] - ys[i] := by
   erw [getElem_zipWith]
 
-theorem sub_eq_add_neg [Sub α] [Add α] [Neg α] (sub_eq_add_neg : ∀ x y : α, x - y = x + -y) (xs ys : Vector α n) : xs - ys = xs + -ys := by grind
+theorem sub_eq_add_neg [Sub α] [Add α] [Neg α] (sub_eq_add_neg : ∀ x y : α, x - y = x + -y) (xs ys : Vector α n) : xs - ys = xs + -ys := by
+  ext i h
+  simpa only [getElem_sub, getElem_add, getElem_neg] using sub_eq_add_neg xs[i] ys[i]
 
 /-- Componentwise multiplication of vectors. -/
 def mul [Mul α] (xs ys : Vector α n) : Vector α n :=
@@ -86,12 +104,29 @@ attribute [local instance] instMul
 theorem getElem_mul [Mul α] (xs ys : Vector α n) (i : Nat) (h : i < n) : (xs * ys)[i] = xs[i] * ys[i] := by
   erw [getElem_zipWith]
 
-theorem mul_zero [Zero α] [Mul α] (mul_zero : ∀ x : α, x * 0 = 0) (xs : Vector α n) : xs * 0 = 0 := by grind
-theorem zero_mul [Zero α] [Mul α] (zero_mul : ∀ x : α, 0 * x = 0) (xs : Vector α n) : 0 * xs = 0 := by grind
-theorem mul_comm [Mul α] (mul_comm : ∀ x y : α, x * y = y * x) (xs ys : Vector α n) : xs * ys = ys * xs := by grind
-theorem mul_assoc [Mul α] (mul_assoc : ∀ x y z : α, x * (y * z) = (x * y) * z) (xs ys zs : Vector α n) : (xs * ys) * zs = xs * (ys * zs) := by grind
-theorem left_distrib [Add α] [Mul α] (left_distrib : ∀ x y z : α, x * (y + z) = x * y + x * z) (xs ys zs : Vector α n) : xs * (ys + zs) = xs * ys + xs * zs := by grind
-theorem right_distrib [Add α] [Mul α] (right_distrib : ∀ x y z : α, (x + y) * z = x * z + y * z) (xs ys zs : Vector α n) : (xs + ys) * zs = xs * zs + ys * zs := by grind
+theorem mul_zero [Zero α] [Mul α] (mul_zero : ∀ x : α, x * 0 = 0) (xs : Vector α n) : xs * 0 = 0 := by
+  ext i h
+  simpa only [getElem_mul, getElem_zero] using mul_zero xs[i]
+
+theorem zero_mul [Zero α] [Mul α] (zero_mul : ∀ x : α, 0 * x = 0) (xs : Vector α n) : 0 * xs = 0 := by
+  ext i h
+  simpa only [getElem_mul, getElem_zero] using zero_mul xs[i]
+
+theorem mul_comm [Mul α] (mul_comm : ∀ x y : α, x * y = y * x) (xs ys : Vector α n) : xs * ys = ys * xs := by
+  ext i h
+  simpa only [getElem_mul] using mul_comm xs[i] ys[i]
+
+theorem mul_assoc [Mul α] (mul_assoc : ∀ x y z : α, x * (y * z) = (x * y) * z) (xs ys zs : Vector α n) : (xs * ys) * zs = xs * (ys * zs) := by
+  ext i h
+  simpa only [getElem_mul] using (mul_assoc xs[i] ys[i] zs[i]).symm
+
+theorem left_distrib [Add α] [Mul α] (left_distrib : ∀ x y z : α, x * (y + z) = x * y + x * z) (xs ys zs : Vector α n) : xs * (ys + zs) = xs * ys + xs * zs := by
+  ext i h
+  simpa only [getElem_mul, getElem_add] using left_distrib xs[i] ys[i] zs[i]
+
+theorem right_distrib [Add α] [Mul α] (right_distrib : ∀ x y z : α, (x + y) * z = x * z + y * z) (xs ys zs : Vector α n) : (xs + ys) * zs = xs * zs + ys * zs := by
+  ext i h
+  simpa only [getElem_mul, getElem_add] using right_distrib xs[i] ys[i] zs[i]
 
 end mul
 
@@ -105,10 +140,21 @@ instance [HMul α β γ] : HMul α (Vector β n) (Vector γ n) := ⟨hmul⟩
 theorem getElem_hmul [HMul α β γ] (c : α) (xs : Vector β n) (i : Nat) (h : i < n) : (c * xs)[i] = c * xs[i] := by
   erw [getElem_map]
 
-theorem hmul_zero [Zero β] [Zero γ] [HMul α β γ] (hmul_zero : ∀ c : α, c * (0 : β) = 0) (c : α) : c * (0 : Vector β n) = 0 := by grind
-theorem zero_hmul [Zero α] [Zero β] [Zero γ] [HMul α β γ] (zero_hmul : ∀ c : β, (0 : α) * c = 0) (c : Vector β n) : (0 : α) * c = 0 := by grind
-theorem hmul_add [Add β] [Add γ] [HMul α β γ] (hmul_add : ∀ c : α, ∀ x y : β, c * (x + y) = c * x + c * y) (c : α) (xs ys : Vector β n) : c * (xs + ys) = c * xs + c * ys := by grind
-theorem add_hmul [Add α] [Add β] [Add γ] [HMul α β γ] (add_hmul : ∀ c d : α, ∀ x : β, (c + d) * x = c * x + d * x) (c d : α) (xs : Vector β n) : (c + d) * xs = c * xs + d * xs := by grind
+theorem hmul_zero [Zero β] [Zero γ] [HMul α β γ] (hmul_zero : ∀ c : α, c * (0 : β) = 0) (c : α) : c * (0 : Vector β n) = 0 := by
+  ext i h
+  simpa only [getElem_hmul, getElem_zero] using hmul_zero c
+
+theorem zero_hmul [Zero α] [Zero β] [Zero γ] [HMul α β γ] (zero_hmul : ∀ c : β, (0 : α) * c = 0) (c : Vector β n) : (0 : α) * c = 0 := by
+  ext i h
+  simpa only [getElem_hmul, getElem_zero] using zero_hmul c[i]
+
+theorem hmul_add [Add β] [Add γ] [HMul α β γ] (hmul_add : ∀ c : α, ∀ x y : β, c * (x + y) = c * x + c * y) (c : α) (xs ys : Vector β n) : c * (xs + ys) = c * xs + c * ys := by
+  ext i h
+  simpa only [getElem_hmul, getElem_add] using hmul_add c xs[i] ys[i]
+
+theorem add_hmul [Add α] [Add β] [Add γ] [HMul α β γ] (add_hmul : ∀ c d : α, ∀ x : β, (c + d) * x = c * x + d * x) (c d : α) (xs : Vector β n) : (c + d) * xs = c * xs + d * xs := by
+  ext i h
+  simpa only [getElem_hmul, getElem_add] using add_hmul c d xs[i]
 
 /-- Componentwise scalar multiplication of vectors. -/
 def smul [SMul α β] (c : α) (xs : Vector β n) : Vector β n :=
@@ -120,11 +166,25 @@ instance [SMul α β] : SMul α (Vector β n) := ⟨smul⟩
 theorem getElem_smul [SMul α β] (c : α) (xs : Vector β n) (i : Nat) (h : i < n) : (c • xs)[i] = c • xs[i] := by
   erw [getElem_map]
 
-theorem smul_zero [Zero β] [SMul α β] (smul_zero : ∀ c : α, c • (0 : β) = 0) (c : α) : c • (0 : Vector β n) = 0 := by grind
-theorem zero_smul [Zero α] [Zero β] [SMul α β] (zero_smul : ∀ c : β, (0 : α) • c = 0) (c : Vector β n) : (0 : α) • c = 0 := by grind
-theorem smul_add [Add β] [SMul α β] (smul_add : ∀ c : α, ∀ x y : β, c • (x + y) = c • x + c • y) (c : α) (xs ys : Vector β n) : c • (xs + ys) = c • xs + c • ys := by grind
-theorem add_smul [Add α] [Add β] [SMul α β] (add_smul : ∀ c d : α, ∀ x : β, (c + d) • x = c • x + d • x) (c d : α) (xs : Vector β n) : (c + d) • xs = c • xs + d • xs := by grind
-theorem mul_smul [Mul α] [SMul α β] (mul_smul : ∀ c d : α, ∀ x : β, (c * d) • x = c • (d • x)) (c : α) (xs : Vector β n) : (c * d) • xs = c • (d • xs) := by grind
+theorem smul_zero [Zero β] [SMul α β] (smul_zero : ∀ c : α, c • (0 : β) = 0) (c : α) : c • (0 : Vector β n) = 0 := by
+  ext i h
+  simpa only [getElem_smul, getElem_zero] using smul_zero c
+
+theorem zero_smul [Zero α] [Zero β] [SMul α β] (zero_smul : ∀ c : β, (0 : α) • c = 0) (c : Vector β n) : (0 : α) • c = 0 := by
+  ext i h
+  simpa only [getElem_smul, getElem_zero] using zero_smul c[i]
+
+theorem smul_add [Add β] [SMul α β] (smul_add : ∀ c : α, ∀ x y : β, c • (x + y) = c • x + c • y) (c : α) (xs ys : Vector β n) : c • (xs + ys) = c • xs + c • ys := by
+  ext i h
+  simpa only [getElem_smul, getElem_add] using smul_add c xs[i] ys[i]
+
+theorem add_smul [Add α] [Add β] [SMul α β] (add_smul : ∀ c d : α, ∀ x : β, (c + d) • x = c • x + d • x) (c d : α) (xs : Vector β n) : (c + d) • xs = c • xs + d • xs := by
+  ext i h
+  simpa only [getElem_smul, getElem_add] using add_smul c d xs[i]
+
+theorem mul_smul [Mul α] [SMul α β] (mul_smul : ∀ c d : α, ∀ x : β, (c * d) • x = c • (d • x)) (c : α) (xs : Vector β n) : (c * d) • xs = c • (d • xs) := by
+  ext i h
+  simpa only [getElem_smul] using mul_smul c d xs[i]
 
 section grind_instances
 

--- a/tests/elab/grind_vector.lean
+++ b/tests/elab/grind_vector.lean
@@ -1,4 +1,25 @@
 module
+
+/-!
+Tests for `grind` support for vectors, including componentwise algebraic operations.
+-/
+
 example [BEq α] (xs ys : Vector α n) : (xs.toList == ys.toList) = (xs == ys) := by grind
 
 example [LT α] {xs ys : Vector α n} : xs.toList < ys.toList ↔ xs < ys := by grind
+
+example (xs ys zs : Vector Nat n) : (xs + ys) + zs = xs + (ys + zs) := by grind
+
+example (xs : Vector Int n) : -xs + xs = 0 := by grind
+
+section
+
+attribute [local instance] Vector.instMul
+
+example (xs ys zs : Vector Nat n) : xs * (ys + zs) = xs * ys + xs * zs := by grind
+
+end
+
+example (c d : Nat) (xs : Vector Nat n) : (c + d) • xs = c • xs + d • xs := by grind
+
+example (c : Nat) (xs ys : Vector Nat n) : c * (xs + ys) = c * xs + c * ys := by grind


### PR DESCRIPTION
This PR replaces uses of `grind` in the vector algebra theorem proofs with explicit componentwise proofs, reducing reliance on automation without changing the API.

Each proof now uses vector extensionality and applies the corresponding scalar algebra law to each component with an explicit simp set. The existing `@[grind]` annotations and `Lean.Grind` algebra instances remain unchanged, with focused vector algebra examples added to `grind_vector.lean` to cover that integration.
