### PR TITLE
fix: preserve binder names in lambdaMetaTelescope

### DIFF
--- a/src/Lean/Meta/Basic.lean
+++ b/src/Lean/Meta/Basic.lean
@@ -1807,9 +1807,9 @@ where
       finalize ()
     else
       match type with
-      | .lam _ d b bi =>
+      | .lam n d b bi =>
         let d     := d.instantiateRevRange j mvars.size mvars
-        let mvar ← mkFreshExprMVar d
+        let mvar ← mkFreshExprMVar d (userName := n)
         let mvars := mvars.push mvar
         let bis   := bis.push bi
         process mvars bis j b

--- a/tests/elab/issue14264.lean
+++ b/tests/elab/issue14264.lean
@@ -1,0 +1,11 @@
+import Lean
+
+open Lean Meta
+
+/-- info: fun {a} => a -/
+#guard_msgs in
+run_meta
+  let e := Expr.lam `a (.sort 0) (.bvar 0) .default
+  let (mvars, _, e) ← lambdaMetaTelescope e
+  let e ← mkLambdaFVars mvars e
+  logInfo m!"{e}"


### PR DESCRIPTION
This PR preserves lambda binder names when `lambdaMetaTelescope` creates fresh metavariables.

The function previously discarded each `.lam` user name and called `mkFreshExprMVar` without a `userName`, so reconstructing the lambda produced generated names such as `x` instead of the original binder name.

Pass the lambda binder name to `mkFreshExprMVar` and add the issue reproducer as a regression test.

Closes #14264

## Validation

- Added `tests/elab/issue14264.lean`
- Full Lean CI is the authoritative validation

## AI assistance

AI tools assisted with issue triage, duplicate-PR search, patch preparation, and regression setup. I reviewed the current implementation and final two-file diff.