### PR TITLE
doc: clarify ApplyNewGoals dependency direction

### DIFF
--- a/src/Init/Meta/Defs.lean
+++ b/src/Init/Meta/Defs.lean
@@ -1694,9 +1694,10 @@ def Occurrences.isAll : Occurrences → Bool
 
 /--
 Controls which new mvars are turned in to goals by the `apply` tactic.
-- `nonDependentFirst`  mvars that don't depend on other goals appear first in the goal list.
-- `nonDependentOnly` only mvars that don't depend on other goals are added to goal list.
-- `all` all unassigned mvars are added to the goal list.
+- `nonDependentFirst`: metavariables that no other new goal depends on appear first in the goal list.
+  These goals may themselves depend on other new metavariables.
+- `nonDependentOnly`: only metavariables that no other new goal depends on are added to the goal list.
+- `all`: all unassigned metavariables are added to the goal list.
 -/
 -- TODO: Consider renaming to `Apply.NewGoals`
 inductive ApplyNewGoals where


### PR DESCRIPTION
This PR corrects the dependency direction described by the `ApplyNewGoals` docstring.

`partitionDependentMVars` classifies a metavariable as dependent when another new metavariable's type contains it. Therefore `nonDependentFirst` and `nonDependentOnly` concern goals that no other new goal depends on, not goals that themselves have no dependencies.

Clarify both variants and expand `mvars` to `metavariables` in the public documentation.

Closes #9376

## Validation

- Documentation-only source change
- Full Lean CI is the authoritative validation

## AI assistance

AI tools assisted with issue triage, duplicate-PR search, implementation inspection, and wording. I reviewed `partitionDependentMVars`, `reorderGoals`, and the final one-file diff.