### PR TITLE
doc: clarify Nat.toDigits for base one

### DIFF
--- a/src/Init/Data/Repr.lean
+++ b/src/Init/Data/Repr.lean
@@ -205,14 +205,17 @@ def toDigitsCore (base : Nat) : Nat → Nat → List Char → List Char
     else toDigitsCore base fuel n' (d::ds)
 
 /--
-Returns the decimal representation of a natural number as a list of digit characters in the given
-base. If the base is greater than `16` then `'*'` is returned for digits greater than `0xf`.
+Returns a natural number as a list of digit characters in the given base. Conventional positional
+representations require `base > 1`. For `base = 1`, the implementation returns `n + 1` zero
+characters, which is not unary notation. If the base is greater than `16` then `'*'` is returned for
+digits greater than `0xf`.
 
 Examples:
 * `Nat.toDigits 10 0xff = ['2', '5', '5']`
 * `Nat.toDigits 8 0xc = ['1', '4']`
 * `Nat.toDigits 16 0xcafe = ['c', 'a', 'f', 'e']`
 * `Nat.toDigits 80 200 = ['2', '*']`
+* `Nat.toDigits 1 2 = ['0', '0', '0']`
 -/
 def toDigits (base : Nat) (n : Nat) : List Char :=
   toDigitsCore base (n+1) n []


### PR DESCRIPTION
This PR documents the behavior of `Nat.toDigits` outside the conventional positional-base domain.

The existing docstring described every output as a representation in the requested base, but `base = 1` returns `n + 1` zero characters rather than unary notation. Clarify that conventional positional representations require `base > 1` and add the concrete base-1 example from the issue.

Closes #8686

## Validation

- Documentation-only source change
- The documented result follows directly from the current `toDigitsCore` recursion
- Full Lean CI is the authoritative validation

## AI assistance

AI tools assisted with issue triage, duplicate-PR search, source inspection, and wording. I reviewed the current implementation and final one-file diff.