### PR TITLE
fix: lake: gracefully handle curl and IO errors during transfer

### DIFF
--- a/src/lake/Lake/Config/Cache.lean
+++ b/src/lake/Lake/Config/Cache.lean
@@ -747,11 +747,8 @@ structure TransferState where
   didError : Bool := false
   numSuccesses : Nat := 0
 
-def createExtraPaths (path : FilePath) (extraPaths : Array FilePath) : IO Unit := do
-  -- Note: No intra-cache hard links (breaks permissions/pruning), so we copy
-  let contents ← IO.FS.readBinFile path
-  for extraPath in extraPaths do
-    IO.FS.writeBinFile extraPath contents
+@[inline] def tmpPath (path : FilePath) : FilePath :=
+  path.addExtension "tmp"
 
 partial def monitorTransfer
   (cfg : TransferConfig) (h hOut : IO.FS.Handle) (s : TransferState)
@@ -763,34 +760,22 @@ partial def monitorTransfer
     let s ← (·.2) <$> StateT.run (s := s) do
       match Json.parse line >>= fromJson? with
       | .ok (out : JsonObject) =>
-        let some info@{url, hash, path, extraPaths} := getInfo? out
+        let some info := getInfo? out
           | logError s!"{cfg.scope}: unidentifiable transfer completed: {line.trimAscii}"
             modify ({· with didError := true})
             return
-        match out.get "http_code" with
-        | .ok 200
-        | .ok 201 =>
-          match cfg.kind with
-          | .get =>
-            logInfo s!"{cfg.scope}: downloaded artifact {hash}\
-              \n  local path: {path}\
-              \n  remote URL: {url}"
-            let actualHash ← computeFileHash path
-            if actualHash != hash then
-              logError s!"{path}: downloaded artifact hash mismatch, got {actualHash}"
-              IO.FS.removeFile path
-              modify ({· with didError := true})
-            else
-              unless extraPaths.isEmpty do
-                createExtraPaths path extraPaths
-              modify fun s => {s with numSuccesses := s.numSuccesses + 1}
-          | .put =>
-            logInfo s!"{cfg.scope}: uploaded artifact {hash}\
-              \n  local path: {path}\
-              \n  remote URL: {url}"
-            modify fun s => {s with numSuccesses := s.numSuccesses + 1}
-        | code? =>
-          handleFailure info code? out line
+        match out.get? "exitcode" with
+        | .ok none
+        | .ok (some 0) =>
+          match out.get "http_code" with
+          | .ok code@200
+          | .ok code@201 =>
+            handleTransfer info code out line
+          | code? =>
+            handleFailure info code? out line
+            modify ({· with didError := true})
+        | _ =>
+          handleFailure info (out.get "http_code") out line
           modify ({· with didError := true})
       | .error e =>
         logError s!"curl produced invalid JSON: {e}; received: {line.trimAscii}"
@@ -801,6 +786,45 @@ where
     match out.getAs Nat "urlnum" with
     | .ok i => cfg.infos[i]?
     | _ => none
+  handleTransfer info code out line : StateT TransferState LoggerIO Unit := do
+    let {url, hash, path, extraPaths} := info
+    match cfg.kind with
+    | .get =>
+      let logDownload :=
+        logInfo s!"{cfg.scope}: downloaded artifact {hash}\
+          \n  local path: {path}\
+          \n  remote URL: {url}"
+      let tmpPath := tmpPath path
+      match (← IO.FS.readBinFile tmpPath |>.toBaseIO) with
+      | .ok contents =>
+        logDownload
+        let actualHash := Hash.ofByteArray contents
+        if actualHash != hash then
+          logError s!"{tmpPath}: downloaded artifact hash mismatch, got {actualHash}"
+          modify ({· with didError := true})
+        else if let .error e ← IO.FS.rename tmpPath path |>.toBaseIO then
+          logError s!"{path}: failed to persist temporary artifact: {e}"
+          modify ({· with didError := true})
+        else
+          unless extraPaths.isEmpty do
+            -- Note: No intra-cache hard links (breaks permissions/pruning), so we copy
+            for extraPath in extraPaths do
+              if let .error e ← IO.FS.writeBinFile extraPath contents |>.toBaseIO then
+                logError s!"{extraPath}: failed to copy artifact: {e}"
+                modify ({· with didError := true})
+          modify fun s => {s with numSuccesses := s.numSuccesses + 1}
+      | .error (.noFileOrDirectory ..) =>
+        handleFailure info (.ok code) out line
+        modify ({· with didError := true})
+      | .error e =>
+        logDownload
+        logError s!"{tmpPath}: failed to read downloaded artifact: {e}"
+        modify ({· with didError := true})
+    | .put =>
+      logInfo s!"{cfg.scope}: uploaded artifact {hash}\
+        \n  local path: {path}\
+        \n  remote URL: {url}"
+      modify fun s => {s with numSuccesses := s.numSuccesses + 1}
   handleFailure info code? out line : LoggerIO Unit := do
     let action := match cfg.kind with | .get => "download" | .put => "upload"
     let mut msg := s!"{cfg.scope}: failed to {action} artifact {info.hash}"
@@ -813,14 +837,14 @@ where
       \n  remote URL: {info.url}"
     match cfg.kind with
     | .get =>
+      let tmpPath := tmpPath info.path
       unless code? matches .ok 404 do -- ignore response bodies on 404s
         if let .ok size := out.getAs Nat "size_download" then
           if size > 0 then
             if let .ok contentType := out.getAs String "content_type" then
               if contentType != artifactContentType then
-                if let .ok resp ← IO.FS.readFile info.path |>.toBaseIO then
+                if let .ok resp ← IO.FS.readFile tmpPath |>.toBaseIO then
                   msg := s!"{msg}\nunexpected response:\n{resp}"
-      removeFileIfExists info.path
     | .put =>
       if let .ok size := out.getAs Nat "size_download" then
         if size > 0 then
@@ -836,8 +860,10 @@ def transferArtifacts
     match cfg.kind with
     | .get =>
       cfg.infos.forM fun info => do
+        let tmpPath := tmpPath info.path
+        removeFileIfExists tmpPath
         h.putStrLn s!"url = {info.url.quote}"
-        h.putStrLn s!"-o {info.path.toString.quote}"
+        h.putStrLn s!"-o {tmpPath.toString.quote}"
       h.flush
       return #[
         "-Z", "-X", "GET", "-L",
@@ -873,7 +899,7 @@ def transferArtifacts
   if rc != 0 then
     logError s!"{cfg.scope}: curl exited with code {rc}"
     didError := true
-  if s.didError then
+  if didError then
     failure
 
 private def reservoirArtifactsUrl (service : CacheService) (scope : CacheServiceScope) : String :=
@@ -920,6 +946,11 @@ public def downloadArtifacts
   IO.FS.createDirAll cache.artifactDir
   transferArtifacts {scope, infos, kind := .get}
 where
+  createExtraPaths path extraPaths := do
+    -- Note: No intra-cache hard links (breaks permissions/pruning), so we copy
+    let contents ← IO.FS.readBinFile path
+    for extraPath in extraPaths do
+      IO.FS.writeBinFile extraPath contents
   fetchUrls url infos := IO.FS.withTempFile fun h path => do
     let body := Json.arr <| infos.map (toJson ·.hash)
     h.putStr body.compress


### PR DESCRIPTION
This PR fixes a number of ways a failed artifact transfer in `lake cache get` / `lake cache put` could fail to be recorded or could lead to an early abort of the entire transfer batch. Sometimes this would leave a corrupted artifact in the local Lake cache, which could break downstream builds.

The transfer now handles any form of IO error with a custom error message, cross-references with curl's reported `exitcode` to determine errors, and stores downloaded artifacts in a sibling `.tmp` file before doing an atomic rename.

🤖 Diagnosed and reviewed by Claude Code