### PR TITLE
fix: reject a zero thread count

### DIFF
--- a/src/Lean/Shell.lean
+++ b/src/Lean/Shell.lean
@@ -301,6 +301,8 @@ def ShellOptions.process (opts : ShellOptions)
     let arg ← checkOptArg "j" optArg?
     let some numThreads := arg.toNat?
       | throwExpectedNumeric "j"
+    if numThreads == 0 then
+      throwExpectedPositive "j"
     if h : numThreads < UInt32.size then
       let numThreads := UInt32.ofNatLT numThreads h
       let forwardedArgs := opts.forwardedArgs.push s!"-j{arg}";
@@ -459,6 +461,9 @@ where
       throw 1
   @[inline] throwExpectedNumeric opt := do
     eprint s!"error: expected numeric argument for option '-{opt}'\n"
+    throw 1
+  @[inline] throwExpectedPositive opt := do
+    eprint s!"error: expected positive numeric argument for option '-{opt}'\n"
     throw 1
   @[inline] throwTooLarge opt := do
     eprint s!"error: argument value for '-{opt}' is too large\n"

--- a/tests/misc/threads_zero.sh
+++ b/tests/misc/threads_zero.sh
@@ -1,0 +1,11 @@
+set -euo pipefail
+
+out="${NAME}.out"
+trap 'rm -f "$out"' EXIT
+
+if lean -j0 >"$out" 2>&1; then
+  echo "lean -j0 unexpectedly succeeded" >&2
+  exit 1
+fi
+
+grep -Fx "error: expected positive numeric argument for option '-j'" "$out"


### PR DESCRIPTION
This PR rejects `-j0` / `--threads=0` during shell option processing instead of allowing an invalid task-manager size to reach the runtime.

The runtime requires a positive worker count in multithreaded builds. Add an explicit zero check alongside the existing numeric and upper-bound validation, with a focused `tests/misc` regression asserting a clean diagnostic and nonzero exit.

Closes #4927

## Validation

- Added `tests/misc/threads_zero.sh`
- The branch diff contains only the shell validation and focused CLI regression
- Full Lean CI is the authoritative validation

## AI assistance

AI tools assisted with issue triage, duplicate-PR search, implementation, and regression preparation. I reviewed the shell option path and final two-file diff.