### PR TITLE
fix: recognize long list literals

### DIFF
--- a/src/Lean/Util/Recognizers.lean
+++ b/src/Lean/Util/Recognizers.lean
@@ -93,7 +93,9 @@ def isDIte (e : Expr) :=
 
 partial def listLit? (e : Expr) : Option (Expr × List Expr) :=
   let rec loop (e : Expr) (acc : List Expr) :=
-    if e.isAppOfArity' ``List.nil 1 then
+    if let .letE _ _ value body _ := e.consumeMData then
+      loop (body.instantiate1 value) acc
+    else if e.isAppOfArity' ``List.nil 1 then
       some (e.appArg!', acc.reverse)
     else if e.isAppOfArity' ``List.cons 3 then
       loop e.appArg!' (e.appFn!'.appArg!' :: acc)

--- a/tests/elab/issue7730.lean
+++ b/tests/elab/issue7730.lean
@@ -1,0 +1,18 @@
+import Lean
+
+open Lean Elab Command
+
+elab "#guard_list_lit " t:term : command => do
+  let e ← liftTermElabM do
+    Term.elabTerm t none
+  let some (_, elems) := e.listLit?
+    | throwError "not recognized as a list literal"
+  unless elems.length == 33 do
+    throwError "expected 33 elements, got {elems.length}"
+
+#guard_list_lit [
+  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+  11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+  21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+  31, 32
+]


### PR DESCRIPTION
This PR makes `Expr.listLit?` recognize list literals that use Lean's let-bound expansion for 33 or more elements.

Short list literals elaborate directly to nested `List.cons` applications. Longer literals are partitioned through intermediate `let` bindings to avoid deeply nested expressions, but the recognizer did not zeta-reduce those bindings and returned `none`.

Unwrap encountered `letE`s while traversing the literal and add a focused 33-element regression.

Closes #7730

## Validation

- Added `tests/elab/issue7730.lean`
- Exact PR-history search found no competing implementation
- Full Lean CI is the authoritative validation

## AI assistance

AI tools assisted with issue triage, source tracing, implementation, and regression preparation. I reviewed the list-literal macro threshold, recognizer behavior, and final diff.