### PR TITLE
fix: assign proof-valued inferred instances

### DIFF
--- a/src/Lean/Meta/Tactic/Util.lean
+++ b/src/Lean/Meta/Tactic/Util.lean
@@ -158,6 +158,8 @@ def _root_.Lean.MVarId.inferInstance (mvarId : MVarId) : MetaM Unit := mvarId.wi
   let synthVal ← synthInstance (← mvarId.getType)
   unless (← isDefEq (mkMVar mvarId) synthVal) do
     throwTacticEx `infer_instance mvarId "`infer_instance` tactic failed to assign instance"
+  unless (← mvarId.isAssigned) do
+    mvarId.assign synthVal
 
 inductive TacticResultCNM where
   | closed

--- a/tests/elab/issue2054.lean
+++ b/tests/elab/issue2054.lean
@@ -1,0 +1,15 @@
+import Lean
+
+open Lean Elab Tactic
+
+elab "my_infer_instance" : tactic => do
+  (← getMainGoal).inferInstance
+  replaceMainGoal []
+
+class Foo : Prop where
+  trivial : True
+
+instance : Foo := ⟨True.intro⟩
+
+example : Foo := by
+  my_infer_instance


### PR DESCRIPTION
This PR ensures `MVarId.inferInstance` actually assigns the goal when the synthesized instance is proof-valued.

For propositions, proof irrelevance can make `isDefEq (mkMVar mvarId) synthVal` succeed without assigning `mvarId`. `inferInstance` then returned successfully, and a caller that removed the goal produced a declaration containing an unresolved metavariable.

After successful definitional equality, explicitly assign the synthesized value only when the goal remains unassigned. The regression is the concrete custom-tactic reproducer from #2054.

Closes #2054

## Validation

- Added `tests/elab/issue2054.lean`
- Exact PR-history search found no competing implementation
- Full Lean CI is the authoritative validation

## AI assistance

AI tools assisted with issue triage, source inspection, implementation, and regression preparation. I reviewed the proof-irrelevance path and final two-line production diff.