### PR TITLE
fix: reduce binder types in reduceAll

### DIFF
--- a/src/Lean/Meta/Reduce.lean
+++ b/src/Lean/Meta/Reduce.lean
@@ -7,6 +7,7 @@ module
 
 prelude
 public import Lean.Meta.FunInfo
+import Lean.Meta.ExprTraverse
 import Init.Data.Range.Polymorphic.Iterators
 
 public section
@@ -39,8 +40,8 @@ partial def reduce (e : Expr) (explicitOnly skipTypes skipProofs := true) : Meta
             return mkRawNatLit (args[0]!.rawNatLit?.get! + 1)
           else
             return mkAppN f args
-        | Expr.lam ..        => lambdaTelescope e fun xs b => do mkLambdaFVars xs (← visit b)
-        | Expr.forallE ..    => forallTelescope e fun xs b => do mkForallFVars xs (← visit b)
+        | Expr.lam ..        => traverseLambda visit e
+        | Expr.forallE ..    => traverseForall visit e
         | Expr.proj n i s .. => return mkProj n i (← visit s)
         | _                  => return e
   visit e |>.run

--- a/tests/elab/issue6084.lean
+++ b/tests/elab/issue6084.lean
@@ -1,0 +1,12 @@
+import Lean
+
+open Lean Meta
+
+def Foo := True
+
+def Bar := Foo → Foo
+
+/-- info: True → True -/
+#guard_msgs in
+run_meta do
+  logInfo (← reduceAll (.const ``Bar []))


### PR DESCRIPTION
This PR makes `reduce` visit lambda and forall binder types when type reduction is enabled.

The previous lambda/forall cases opened the original binders and reduced only the body. Consequently, `reduceAll` could return an expression such as `Foo → True` even when `Foo` reduces to `True`.

Reuse the existing binder traversal helpers, which visit each domain and the body in the correct local context. The existing `skipTypes` guard preserves the default behavior of `reduce`.

Closes #6084

## Validation

- Added `tests/elab/issue6084.lean`
- Exact PR-history search found no competing implementation
- Full Lean CI is the authoritative validation

## AI assistance

AI tools assisted with issue triage, source inspection, implementation, and regression preparation. I reviewed the binder traversal helpers and final five-line production diff.