### PR TITLE
fix: allow restoring erased simp attributes

### DIFF
--- a/src/Lean/Meta/Tactic/Simp/Attr.lean
+++ b/src/Lean/Meta/Tactic/Simp/Attr.lean
@@ -10,6 +10,9 @@ public section
 namespace Lean.Meta
 open Simp
 
+private def uneraseSimpOrigin (ext : SimpExtension) (origin : Origin) : CoreM Unit := do
+  modifyEnv fun env => ext.modifyState env fun s => s.unerase origin
+
 /--
 Marks `declName` to be unfolded in the given `SimpExtension`.
 -/
@@ -19,10 +22,12 @@ def addDeclToUnfold (ext : SimpExtension) (declName : Name) (post inv : Bool) (p
       throwError m!"Invalid `←` modifier: `{.ofConstName declName}` is a declaration name to be unfolded"
         ++ .note m!"The simplifier will automatically unfold definitions marked with the `[simp]` \
                     attribute, but it will not \"refold\" them"
+    uneraseSimpOrigin ext (.decl declName)
     if (← Simp.ignoreEquations declName) then
       ext.add (SimpEntry.toUnfold declName) attrKind
     else if let some eqns ← getEqnsFor? declName then
       for eqn in eqns do
+        uneraseSimpOrigin ext (.decl eqn post false)
         addSimpTheorem ext eqn post (inv := false) attrKind prio
       ext.add (SimpEntry.toUnfoldThms declName eqns) attrKind
       if (← Simp.unfoldEvenWithEqns declName) then
@@ -51,6 +56,7 @@ def mkSimpAttr (attrName : Name) (attrDescr : String) (ext : SimpExtension)
           let inv := !stx[2].isNone
           let prio ← getAttrParamOptPrio stx[3]
           if (← isProp info.sig.get.type) then
+            uneraseSimpOrigin ext (.decl declName post inv)
             addSimpTheorem ext declName post (inv := inv) attrKind prio
           else unless (← addDeclToUnfold ext declName post inv prio attrKind) do
             throwError m!"Cannot add `simp` attribute to `{.ofConstName declName}`: It is not a proposition nor a definition (to unfold)"

--- a/tests/elab/eraseSimp.lean
+++ b/tests/elab/eraseSimp.lean
@@ -41,8 +41,8 @@ example : P5868 a5868 b5868 := by simp
 
 attribute [-simp] a5868_eq_b5868
 
-/-- error: simp made no progress -/
-#guard_msgs in
+/-- error: `simp` made no progress -/
+#guard_msgs (error) in
 example : P5868 a5868 b5868 := by simp
 
 attribute [simp] a5868_eq_b5868

--- a/tests/elab/eraseSimp.lean
+++ b/tests/elab/eraseSimp.lean
@@ -27,3 +27,24 @@ theorem ex4 {a b : Nat} (h₁ : a = b) : 0 + a = b := by
   fail_if_success simp [-Nat.zero_add]
   rw [Nat.zero_add]
   assumption
+
+axiom a5868 : Nat
+axiom b5868 : Nat
+axiom a5868_eq_b5868 : a5868 = b5868
+
+axiom P5868 : Nat → Nat → Prop
+@[simp] axiom P5868_b : P5868 b5868 b5868
+
+attribute [simp] a5868_eq_b5868
+
+example : P5868 a5868 b5868 := by simp
+
+attribute [-simp] a5868_eq_b5868
+
+/-- error: simp made no progress -/
+#guard_msgs in
+example : P5868 a5868 b5868 := by simp
+
+attribute [simp] a5868_eq_b5868
+
+example : P5868 a5868 b5868 := by simp

--- a/tests/elab/issue5828.lean
+++ b/tests/elab/issue5828.lean
@@ -22,19 +22,20 @@ attribute [-simp] a_eq_b
 /-- error: `simp` made no progress -/
 #guard_msgs in example : P a b := by simp
 
--- Re-adding an attribute after [-simp] does not work, see
+-- Re-adding an attribute after `[-simp]` restores it, see
 -- https://github.com/leanprover/lean4/issues/5868
 
 attribute [simp] a_eq_b
 
-/-- error: `simp` made no progress -/
+/--
+error: unsolved goals
+⊢ P b b
+-/
 #guard_msgs in example : P a b := by simp
 
--- so this test use new copies of `a_eq_b` for now
+-- Re-adding the converse direction replaces the current direction
 
-axiom a_eq_b_2 : a = b
-
-attribute [simp ←] a_eq_b_2
+attribute [simp ←] a_eq_b
 
 /--
 error: unsolved goals
@@ -44,17 +45,15 @@ error: unsolved goals
 
 -- Removing the attribute works, no matter the direction
 
-attribute [-simp] a_eq_b_2
+attribute [-simp] a_eq_b
 
 /-- error: `simp` made no progress -/
 #guard_msgs in example : P a b := by simp
 
--- Setting one should erase the other
+-- Setting one direction should erase the other
 
-axiom a_eq_b_3 : a = b
-
-attribute [simp ←] a_eq_b_3
-attribute [simp] a_eq_b_3
+attribute [simp ←] a_eq_b
+attribute [simp] a_eq_b
 
 /--
 error: unsolved goals
@@ -62,16 +61,9 @@ error: unsolved goals
 -/
 #guard_msgs in example : P a b := by simp
 
+-- The converse can be restored after it was erased
 
--- The erasure is sticky:
-attribute [simp ←] a_eq_b_3
-/-- error: `simp` made no progress -/
-#guard_msgs in example : P a b := by simp
-
-axiom a_eq_b_4 : a = b
-
-attribute [simp] a_eq_b_4
-attribute [simp ←] a_eq_b_4
+attribute [simp ←] a_eq_b
 
 /--
 error: unsolved goals
@@ -79,6 +71,7 @@ error: unsolved goals
 -/
 #guard_msgs in example : P a b := by simp
 
+attribute [-simp] a_eq_b
 
 -- Some more error conditions
 


### PR DESCRIPTION
This PR lets an explicit `attribute [simp]` restore a theorem or definition after `attribute [-simp]` erased it in the current environment.

Simp erasure records an origin in a separate tombstone set. Re-adding the corresponding simp entry populated the theorem data again but left that tombstone in place, so the simplifier continued to ignore it.

Clear the matching tombstone when the attribute handler explicitly re-adds a proposition, definition, or generated equation theorem. The existing erase-simp test now includes the reproducer from #5868.

Closes #5868

## Validation

- Extended `tests/elab/eraseSimp.lean`
- Exact PR-history search found no active competing implementation
- Full Lean CI is the authoritative validation

## AI assistance

AI tools assisted with issue triage, extension-state analysis, implementation, and regression preparation. I reviewed the tombstone semantics, reverse simp origins, definition equation entries, and final diff.