### PR TITLE
perf: inline the per-allocation heartbeat increment

### DIFF
--- a/src/include/lean/lean.h
+++ b/src/include/lean/lean.h
@@ -463,12 +463,29 @@ static inline unsigned lean_get_slot_idx(unsigned sz) {
 
 LEAN_EXPORT void lean_inc_heartbeat(void);
 
+/* The heartbeat counter is bumped on every small-object allocation, so the increment is exposed
+   here rather than paid for as a call. `initial-exec` reduces it to a `%fs`-relative add and lets
+   the compiler share the thread-pointer load between the allocations of a single function; it is
+   valid because the counter lives in the runtime, which is never itself dynamically loaded late. */
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(_WIN32) && !defined(__EMSCRIPTEN__)
+#define LEAN_HEARTBEAT_TLS __attribute__((tls_model("initial-exec")))
+LEAN_EXPORT extern __thread uint64_t lean_heartbeat LEAN_HEARTBEAT_TLS;
+#endif
+
+static inline void lean_inc_heartbeat_inline(void) {
+#ifdef LEAN_HEARTBEAT_TLS
+    lean_heartbeat++;
+#else
+    lean_inc_heartbeat();
+#endif
+}
+
 #ifndef __cplusplus
 void * malloc(size_t);  // avoid including big `stdlib.h`
 #endif
 
 static inline lean_object * lean_alloc_small_object(unsigned sz) {
-    lean_inc_heartbeat();
+    lean_inc_heartbeat_inline();
 #ifdef LEAN_MIMALLOC
     // HACK: emulate behavior of small allocator to avoid `leangz` breakage for now
     // NOTE: `sz` is known at compile time for most callers

--- a/src/runtime/alloc.cpp
+++ b/src/runtime/alloc.cpp
@@ -23,14 +23,20 @@ void initialize_alloc() {
 void finalize_alloc() {
 }
 
-LEAN_THREAD_VALUE(uint64_t, g_heartbeat, 0);
+extern "C" {
+#ifdef LEAN_HEARTBEAT_TLS
+LEAN_EXPORT __thread uint64_t lean_heartbeat LEAN_HEARTBEAT_TLS = 0;
+#else
+LEAN_THREAD_VALUE(uint64_t, lean_heartbeat, 0);
+#endif
+}
 
 void set_heartbeats(uint64_t count) {
-    g_heartbeat = count;
+    lean_heartbeat = count;
 }
 
 void add_heartbeats(uint64_t count) {
-    g_heartbeat += count;
+    lean_heartbeat += count;
 }
 
 extern "C" LEAN_EXPORT void lean_inc_heartbeat() {
@@ -38,7 +44,7 @@ extern "C" LEAN_EXPORT void lean_inc_heartbeat() {
 }
 
 uint64_t get_num_heartbeats() {
-    return g_heartbeat;
+    return lean_heartbeat;
 }
 
 }


### PR DESCRIPTION
Every small-object allocation called out to `lean_inc_heartbeat` just to bump a thread-local counter, which showed up as 1.8% of cycles on the `simp_local` elaboration benchmark. The counter is now declared in `lean.h` with the `initial-exec` TLS model, so `lean_alloc_small_object` increments it directly: a call plus six instructions per allocation becomes a single `incq %fs:(reg)`, and the compiler hoists the thread-pointer load so that all allocations in a function share it. About 168k call sites disappear from `libleanshared.so`.

`lean_inc_heartbeat` stays exported and keeps updating the same counter, so objects compiled against an older header still work. The inline path is used only on GCC and Clang outside Windows and emscripten; elsewhere the out-of-line call is kept.