### PR TITLE
perf: fold `UInt*.ofNatLT` applied to literals

### DIFF
--- a/src/Lean/Compiler/LCNF/Simp/ConstantFold.lean
+++ b/src/Lean/Compiler/LCNF/Simp/ConstantFold.lean
@@ -480,6 +480,15 @@ def Folder.ofNat (f : Nat → LitValue) (args : Array (Arg .pure)) : FolderM (Op
   let some value ← getNatLit fvarId | return none
   return some (.lit (f value))
 
+/--
+Folder for `ofNatLT` operations on fixed-sized integer types. The bound is a proof and carries no
+runtime content, so only the numeral matters.
+-/
+def Folder.ofNatLT (f : Nat → LitValue) (args : Array (Arg .pure)) : FolderM (Option (LetValue .pure)) := do
+  let #[.fvar fvarId, _] := args | return none
+  let some value ← getNatLit fvarId | return none
+  return some (.lit (f value))
+
 def Folder.toNat (args : Array (Arg .pure)) : FolderM (Option (LetValue .pure)) := do
   let #[.fvar fvarId] := args | return none
   let some (.lit lit) ← findLetValue? (pu := .pure) fvarId | return none
@@ -590,6 +599,10 @@ def conversionFolders : List (Name × Folder) := [
   (``UInt64.ofNat, Folder.ofNat (fun v => .uint64 (UInt64.ofNat v))),
   (``USize.ofNat, Folder.ofNat (fun v => .usize (UInt64.ofNat v))),
   (``Char.ofNat, Folder.ofNat (fun v => .uint32 (Char.ofNat v).val)),
+  (``UInt8.ofNatLT, Folder.ofNatLT (fun v => .uint8 (UInt8.ofNat v))),
+  (``UInt16.ofNatLT, Folder.ofNatLT (fun v => .uint16 (UInt16.ofNat v))),
+  (``UInt32.ofNatLT, Folder.ofNatLT (fun v => .uint32 (UInt32.ofNat v))),
+  (``UInt64.ofNatLT, Folder.ofNatLT (fun v => .uint64 (UInt64.ofNat v))),
   (``UInt8.toNat, Folder.toNat),
   (``UInt16.toNat, Folder.toNat),
   (``UInt32.toNat, Folder.toNat),


### PR DESCRIPTION
`UInt64.ofNatLT` and its siblings carry `@[extern "lean_uint64_of_nat"]` but were missing from the LCNF constant folder's conversion table, which registers `UInt64.ofNat` and friends. An application to a numeral therefore survived to code generation, where it became a closed term memoised in a `once` cell plus a `Nat` round-trip.

That is what made `Name.hash Name.anonymous`, which is `UInt64.ofNatLT 1723 _`, a lazily-initialised constant rather than the literal `1723`. Reading it from `Name.quickCmpImpl` left that function non-leaf, so clang could not shrink-wrap its hot hash-compare path and spilled four callee-saved registers on every call; prologue and epilogue accounted for about 27% of the function's samples in an elaboration profile.

`USize.ofNatLT` is deliberately left out, since `USize.size` is platform-dependent and folding to a fixed-width literal is not obviously sound for a 32-bit target.