### PR TITLE
feat: gate `prelude` behind the `bootstrap.prelude` option

### DIFF
--- a/src/Lean/Elab/Import.lean
+++ b/src/Lean/Elab/Import.lean
@@ -26,6 +26,11 @@ def HeaderSyntax.startPos (header : HeaderSyntax) : String.Pos.Raw :=
 def HeaderSyntax.isModule (header : HeaderSyntax) : Bool :=
   !header.raw[0].isNone
 
+def HeaderSyntax.preludeTk? (header : HeaderSyntax) : Option Syntax :=
+  match header with
+  | `(Parser.Module.header| $[module%$_]? $[prelude%$preludeTk]? $_*) => preludeTk
+  | _ => none
+
 def HeaderSyntax.imports (stx : HeaderSyntax) (includeInit : Bool := true) : Array Import :=
   match stx with
   | `(Parser.Module.header| $[module%$moduleTk]? $[prelude%$preludeTk]? $importsStx*) =>
@@ -135,6 +140,41 @@ where
       go parent messages
     | .num parent _, messages => go parent messages
 
+register_builtin_option bootstrap.prelude : Bool := {
+  defValue := false
+  descr := "allow `prelude` in the module header, which is only safe for bootstrapping as the runtime and kernel rely on specific properties of `Init` declarations."
+}
+
+/--
+Value of `bootstrap.prelude`, also accepting the `weak.` spelling the stage builds must use until
+stage 0 knows the option. `reparseOptions` only canonicalizes that spelling once imports have been
+loaded, which is after this check.
+-/
+private def getBootstrapPrelude (opts : Options) : Bool :=
+  bootstrap.prelude.get opts ||
+    match opts.find? (`weak ++ bootstrap.prelude.name) with
+    | some (.ofBool b)   => b
+    | some (.ofString s) => s == "true"
+    | _                  => false
+
+/-- Reports use of `prelude` unless it has been enabled via `bootstrap.prelude`. -/
+def checkPrelude
+    (header? : Option HeaderSyntax) (opts : Options) (inputCtx : Parser.InputContext)
+    (messages : MessageLog) : MessageLog := Id.run do
+  if getBootstrapPrelude opts then
+    return messages
+  if let some header := header? then
+    if let some tk := header.preludeTk? then
+      let pos := tk.getPos?.getD header.startPos
+      return messages.add {
+        fileName := inputCtx.fileName
+        pos := inputCtx.fileMap.toPosition pos
+        endPos := inputCtx.fileMap.toPosition <| tk.getTailPos?.getD pos
+        severity := .error
+        data := s!"`prelude` is reserved for bootstrapping the Lean standard library (`bootstrap.prelude` must be set)"
+      }
+  return messages
+
 def processHeaderCore
     (startPos : String.Pos.Raw) (imports : Array Import) (isModule : Bool)
     (opts : Options) (messages : MessageLog) (inputCtx : Parser.InputContext)
@@ -163,6 +203,7 @@ def processHeaderCore
   let env := env.setMainModule mainModule |>.setModulePackage package?
   let messages := checkDeprecatedImports env imports opts inputCtx startPos messages headerStx? origHeaderStx?
   let messages := checkModuleNamePortability mainModule inputCtx startPos messages
+  let messages := checkPrelude headerStx? opts inputCtx messages
   return (env, messages)
 
 /--

--- a/src/Lean/Server/Test/Runner.lean
+++ b/src/Lean/Server/Test/Runner.lean
@@ -735,11 +735,12 @@ def processLine (line : String) : RunnerM Unit := do
 partial def main (args : List String) : IO Unit := do
   let args := args.toArray
   let isProject := args[0]?.any (· == "-p")
+  let opts := #["-DstderrAsMessages=false", "-Dexperimental.module=true", "-Dbootstrap.prelude=true"]
   let (ipcCmd, ipcArgs) :=
     if isProject then
-      ("lake", #["serve", "--", "-DstderrAsMessages=false", "-Dexperimental.module=true"])
+      ("lake", #["serve", "--"] ++ opts)
     else
-      ("lean", #["--server", "-DstderrAsMessages=false", "-Dexperimental.module=true"])
+      ("lean", #["--server"] ++ opts)
   let path := if args.size == 1 then args[0]! else args[1]!
   let uri := s!"file:///{path}"
   -- We want `dbg_trace` tactics to write directly to stderr instead of being caught in reuse

--- a/src/lake/Lake/Load/Workspace.lean
+++ b/src/lake/Lake/Load/Workspace.lean
@@ -54,6 +54,27 @@ public def loadWorkspaceRoot (config : LoadConfig) : LogIO Workspace := do
   }
 
 /--
+Module name roots owned by the Lean toolchain.
+
+A workspace library providing one of these shadows the toolchain's own modules for every module in
+the workspace, because Lake resolves imports against the workspace before the search path. In the
+case of `Init` that replaces the prelude implicitly imported by every module, so only packages that
+are Lean itself (`bootstrap`) may declare them.
+-/
+def reservedModuleRoots : Array Name := #[`Init, `Std, `Lean, `Lake]
+
+/-- Errors if a non-`bootstrap` package declares a library rooted at a reserved module name. -/
+def Workspace.validateModuleRoots (self : Workspace) : LoggerIO PUnit := do
+  for pkg in self.packages do
+    if pkg.bootstrap then
+      continue
+    for lib in pkg.leanLibs do
+      for root in lib.roots do
+        if reservedModuleRoots.contains root.getRoot then
+          error s!"{pkg.prettyName}: library '{lib.name}' is rooted at '{root}', which is reserved \
+            for the Lean toolchain"
+
+/--
 Load a `Workspace` for a Lake package by
 elaborating its configuration file and resolving its dependencies.
 If `updateDeps` is true, updates the manifest before resolving dependencies.
@@ -61,12 +82,15 @@ If `updateDeps` is true, updates the manifest before resolving dependencies.
 public def loadWorkspace (config : LoadConfig) : LoggerIO Workspace := do
   let {reconfigure, leanOpts, updateDeps, updateToolchain, packageOverrides, ..} := config
   let ws ← loadWorkspaceRoot config
-  if updateDeps then
-    ws.updateAndMaterialize {} leanOpts updateToolchain
-  else if let some manifest ← Manifest.load? ws.manifestFile then
-    ws.materializeDeps manifest leanOpts reconfigure packageOverrides
-  else
-    ws.updateAndMaterialize {} leanOpts updateToolchain
+  let ws ←
+    if updateDeps then
+      ws.updateAndMaterialize {} leanOpts updateToolchain
+    else if let some manifest ← Manifest.load? ws.manifestFile then
+      ws.materializeDeps manifest leanOpts reconfigure packageOverrides
+    else
+      ws.updateAndMaterialize {} leanOpts updateToolchain
+  ws.validateModuleRoots
+  return ws
 
 /-- Updates the manifest for the loaded Lake workspace (see `updateAndMaterialize`). -/
 public def updateManifest

--- a/src/lakefile.toml.in
+++ b/src/lakefile.toml.in
@@ -46,6 +46,11 @@ moreLeanArgs = [${LEAN_EXTRA_OPTS_TOML}]
 # Enable core-only linters
 leanOptions.linter.coreInternal = true
 
+# Core is the only code allowed to use `prelude`. A `leanOption` rather than a `moreLeanArg` so that
+# it also reaches the language server, which is configured from the module setup. `weak` because
+# stage 0 does not know the option yet; it can be dropped after the next `update-stage0`.
+leanOptions.weak.bootstrap.prelude = true
+
 # Uncomment to limit number of reported errors further in case of overwhelming cmdline output
 #weakLeanArgs = ["-DmaxErrors=1"]
 

--- a/tests/compile/run_test.sh
+++ b/tests/compile/run_test.sh
@@ -18,7 +18,7 @@ if [[ -n $DO_COMPILE ]]; then
   echo "Compiling and executing lean file"
   run_before "$1"
 
-  lean --c="$1.c" -Dcompiler.postponeCompile=false "${TEST_LEAN_ARGS[@]}" "$1" || fail "Failed to compile $1 into $1.c"
+  lean --c="$1.c" -Dcompiler.postponeCompile=false -Dbootstrap.prelude=true "${TEST_LEAN_ARGS[@]}" "$1" || fail "Failed to compile $1 into $1.c"
   leanc ${LEANC_OPTS-} -O3 -DNDEBUG -o "$1.out" "${TEST_LEANC_ARGS[@]}" "$1.c" || fail "Failed to compile $1.c"
 
   capture_only "$1" \
@@ -35,7 +35,7 @@ if [[ -n $DO_INTERPRET ]]; then
   run_before "$1"
 
   capture_only "$1" \
-    lean -Dlinter.all=false "${TEST_LEANI_ARGS[@]}" --run "$1" "${TEST_ARGS[@]}"
+    lean -Dlinter.all=false -Dbootstrap.prelude=true "${TEST_LEANI_ARGS[@]}" --run "$1" "${TEST_ARGS[@]}"
   normalize_measurements
   check_out_file
   check_exit_is "${TEST_EXIT:-0}"

--- a/tests/compile_bench/identifier_completion.lean
+++ b/tests/compile_bench/identifier_completion.lean
@@ -7,7 +7,7 @@ def mkCompletionRequest (id : Nat) : JsonRpc.Request Json :=
   { id, method := "textDocument/completion", param }
 
 def main : IO Unit := do
-  Ipc.runWith "lean" #["--server"] do
+  Ipc.runWith "lean" #["--server", "-Dbootstrap.prelude=true"] do
     let hIn ← Ipc.stdin
     hIn.write (← FS.readBinFile "identifier_completion.lean.dir/initialization.log")
     hIn.flush

--- a/tests/elab/run_test.sh
+++ b/tests/elab/run_test.sh
@@ -6,7 +6,7 @@ maybe_use_lean_header_snapshot "$1"
 # Elab.inServer to allow for arbitrary `#eval`
 # compiler.postponeCompile for immediate trace output
 capture_only "$1" \
-  lean --root=.. -DprintMessageEndPos=true -Dlinter.all=false -DElab.inServer=true -Dcompiler.postponeCompile=false "${TEST_LEAN_ARGS[@]}" "$1"
+  lean --root=.. -DprintMessageEndPos=true -Dlinter.all=false -DElab.inServer=true -Dcompiler.postponeCompile=false -Dbootstrap.prelude=true "${TEST_LEAN_ARGS[@]}" "$1"
 normalize_mvar_suffixes
 normalize_reference_urls
 normalize_measurements

--- a/tests/elab/whereCmdModule.lean
+++ b/tests/elab/whereCmdModule.lean
@@ -8,6 +8,7 @@ import Lean
 set_option internal.cmdlineSnapshots false
 set_option printMessageEndPos false
 set_option Elab.inServer false
+set_option bootstrap.prelude false
 
 /-- info: -- In root namespace with initial scope -/
 #guard_msgs in #where

--- a/tests/elab_fail/preludeWithoutOption.lean
+++ b/tests/elab_fail/preludeWithoutOption.lean
@@ -1,0 +1,6 @@
+module
+
+prelude
+
+/-! `prelude` is rejected unless `bootstrap.prelude` is set; see `bootstrapSorry.lean` for the
+enabled case. -/

--- a/tests/elab_fail/preludeWithoutOption.lean.init.sh
+++ b/tests/elab_fail/preludeWithoutOption.lean.init.sh
@@ -1,0 +1,2 @@
+# the point of this test is that `prelude` is rejected without the option
+TEST_LEAN_ARGS+=(-Dbootstrap.prelude=false)

--- a/tests/elab_fail/preludeWithoutOption.lean.out.expected
+++ b/tests/elab_fail/preludeWithoutOption.lean.out.expected
@@ -1,0 +1,1 @@
+preludeWithoutOption.lean:3:0-3:7: error: `prelude` is reserved for bootstrapping the Lean standard library (`bootstrap.prelude` must be set)

--- a/tests/elab_fail/run_test.sh
+++ b/tests/elab_fail/run_test.sh
@@ -5,7 +5,7 @@ maybe_use_lean_header_snapshot "$1"
 # `--root` to infer same private names as in the server
 # Elab.inServer to allow for arbitrary `#eval`
 capture_only "$1" \
-  lean --root=.. -DprintMessageEndPos=true -Dlinter.all=false -DElab.inServer=true "${TEST_LEAN_ARGS[@]}" "$1"
+  lean --root=.. -DprintMessageEndPos=true -Dlinter.all=false -DElab.inServer=true -Dbootstrap.prelude=true "${TEST_LEAN_ARGS[@]}" "$1"
 normalize_mvar_suffixes
 normalize_reference_urls
 normalize_measurements

--- a/tests/lake/examples/bootstrap/lakefile.lean
+++ b/tests/lake/examples/bootstrap/lakefile.lean
@@ -3,6 +3,8 @@ open System Lake DSL
 
 package lake where
   srcDir := ".." / ".." / ".." / ".." / "src" / "lake"
+  bootstrap := true
+  leanOptions := #[⟨`bootstrap.prelude, true⟩]
 
 lean_lib Lake
 

--- a/tests/lake/lakefile.toml
+++ b/tests/lake/lakefile.toml
@@ -1,6 +1,8 @@
 name = "lake"
 srcDir = "../../src/lake"
 defaultTargets = ["Lake", "lake"]
+bootstrap = true
+leanOptions.bootstrap.prelude = true
 
 [[lean_lib]]
 name = "Lake"

--- a/tests/pkg/leanchecker/lakefile.toml
+++ b/tests/pkg/leanchecker/lakefile.toml
@@ -4,3 +4,4 @@ defaultTargets = ["LeanCheckerTests"]
 [[lean_lib]]
 name = "LeanCheckerTests"
 globs = ["LeanCheckerTests.+"]
+leanOptions.bootstrap.prelude = true

--- a/tests/pkg/module/lakefile.toml
+++ b/tests/pkg/module/lakefile.toml
@@ -4,4 +4,4 @@ defaultTargets = ["Module"]
 [[lean_lib]]
 name = "Module"
 # Elab.inServer to allow for arbitrary `#eval`
-leanOptions = { Elab.inServer = true }
+leanOptions = { Elab.inServer = true, bootstrap.prelude = true }


### PR DESCRIPTION
This PR gates the use of the `prelude` module header keyword behind a new option `bootstrap.prelude`. `prelude` is supposed to be used while building Lean only as the kernel and the runtime may rely on declarations normally contributed by `Init` to behave as expected. Lake is additionally adjusted to reject libraries that may shadow built-in ones.

Note that this does not really affect comparator's threat model as we already assume the solution olean/export to be completely untrusted, i.e. it might not uphold any elaboration-side restrictions.