### PR TITLE
fix: `mkTheoremFromDecl` from `SymM`

### DIFF
--- a/src/Lean/Meta/Sym/Simp/Theorems.lean
+++ b/src/Lean/Meta/Sym/Simp/Theorems.lean
@@ -132,20 +132,26 @@ Wrap a proof expression according to the adaptation applied to its type.
 Given a proof `h : <original type>`, returns a proof of the adapted equality.
 This wrapping must be applied AFTER the proof has been applied to its quantified arguments.
 -/
-private def wrapProof (numVars : Nat) (expr : Expr) (adaptation : EqAdaptation) : MetaM Expr :=
+private def wrapProof (pattern : Pattern) (expr : Expr) (adaptation : EqAdaptation) : MetaM Expr :=
   match adaptation with
   | .eq => return expr
   | .eqFalse =>
-    wrapInner numVars expr fun h => mkAppM ``eq_false #[h]
+    wrapInner pattern expr fun h => mkAppM ``eq_false #[h]
   | .iff =>
-    wrapInner numVars expr fun h => mkAppM ``propext #[h]
+    wrapInner pattern expr fun h => mkAppM ``propext #[h]
   | .eqTrue =>
-    wrapInner numVars expr fun h => mkAppM ``eq_true #[h]
+    wrapInner pattern expr fun h => mkAppM ``eq_true #[h]
 where
-  /-- Wraps the innermost application of `expr` (after `numVars` arguments) with `wrap`. -/
-  wrapInner (numVars : Nat) (expr : Expr) (wrap : Expr → MetaM Expr) : MetaM Expr := do
+  /-- Wraps the innermost application of `expr` (after the pattern variables) with `wrap`. -/
+  wrapInner (pattern : Pattern) (expr : Expr) (wrap : Expr → MetaM Expr) : MetaM Expr := do
+    -- For a named theorem, `expr` is a constant with the universe levels elided (see the
+    -- `mkValue` fast path). Instantiate it with the pattern's level params so that `inferType`
+    -- succeeds, and `mkValue` can later substitute the matched levels.
+    let expr := match expr with
+      | .const declName [] => mkConst declName (pattern.levelParams.map mkLevelParam)
+      | _ => expr
     let type ← inferType expr
-    forallBoundedTelescope type numVars fun xs _ => do
+    forallBoundedTelescope type pattern.varTypes.size fun xs _ => do
       let h := mkAppN expr xs
       mkLambdaFVars xs (← wrap h)
 
@@ -167,7 +173,7 @@ private def mkRhsVarMask (numVars : Nat) (rhs : Expr) : Nat := Id.run do
 
 def mkTheoremFromDecl (declName : Name) : MetaM Theorem := do
   let (pattern, (rhs, adaptation)) ← mkPatternFromDeclWithKey declName selectEqKey (zetaReduceLHSOnly := true)
-  let expr ← wrapProof pattern.varTypes.size (mkConst declName) adaptation
+  let expr ← wrapProof pattern (mkConst declName) adaptation
   let perm := isPerm pattern.varTypes.size pattern.pattern rhs
   let rhsVarMask := mkRhsVarMask pattern.varTypes.size rhs
   return { expr, pattern, rhs, perm, rhsVarMask }
@@ -175,7 +181,7 @@ def mkTheoremFromDecl (declName : Name) : MetaM Theorem := do
 /-- Create a `Theorem` from a proof expression. Handles equalities, `¬`, `↔`, and propositions. -/
 def mkTheoremFromExpr (e : Expr) : MetaM Theorem := do
   let (pattern, (rhs, adaptation)) ← mkPatternFromExprWithKey e [] selectEqKey (zetaReduceLHSOnly := true)
-  let expr ← wrapProof pattern.varTypes.size e adaptation
+  let expr ← wrapProof pattern e adaptation
   let perm := isPerm pattern.varTypes.size pattern.pattern rhs
   let rhsVarMask := mkRhsVarMask pattern.varTypes.size rhs
   return { expr, pattern, rhs, perm, rhsVarMask }

--- a/tests/elab/sym_simp_univ_poly_thm.lean
+++ b/tests/elab/sym_simp_univ_poly_thm.lean
@@ -1,0 +1,67 @@
+import Lean
+
+/-!
+`Sym.Simp.mkTheoremFromDecl` must accept universe-polymorphic theorems whose conclusion is not
+an equality (`↔`, `¬`, plain propositions). It used to fail with "incorrect number of universe
+levels" because the proof constant was created without universe levels before being wrapped by
+`eq_true`/`eq_false`/`propext`. Reported by Henrik Böving with `Foo.ext_iff` below.
+-/
+
+open Lean Meta Sym Simp
+
+@[ext]
+structure Foo (α : Type u) where
+  x : α
+  y : BitVec 8
+
+/-- `↔` conclusion, the reported case. -/
+theorem foo_ext_iff (a b : Foo α) : a = b ↔ a.x = b.x ∧ a.y = b.y := Foo.ext_iff
+
+/-- `¬` conclusion. -/
+theorem some_ne_none (a : α) : ¬ (some a = none) := nofun
+
+axiom Q : {α : Sort u} → α → Prop
+
+/-- Plain propositional conclusion. -/
+axiom my_Q {α : Sort u} (a : α) : Q a
+
+axiom a : Foo Nat
+axiom b : Foo Nat
+axiom n : Nat
+
+def test (declName : Name) (e : Expr) : MetaM Unit := SymM.run do
+  let thm ← mkTheoremFromDecl declName
+  let e ← shareCommon e
+  let r ← SimpM.run' (thm.rewrite e)
+  match r with
+  | .step e' proof _ _ =>
+    check proof
+    logInfo m!"step: {e'}"
+  | _ => throwError "expected the rewrite to fire"
+
+def fooNat : Expr := mkApp (mkConst ``Foo [0]) (mkConst ``Nat)
+
+/-- info: step: a.x = b.x ∧ a.y = b.y -/
+#guard_msgs in
+set_option sym.debug true in
+run_meta test ``Foo.ext_iff (mkApp3 (mkConst ``Eq [1]) fooNat (mkConst ``a) (mkConst ``b))
+
+/-- info: step: a.x = b.x ∧ a.y = b.y -/
+#guard_msgs in
+set_option sym.debug true in
+run_meta test ``foo_ext_iff (mkApp3 (mkConst ``Eq [1]) fooNat (mkConst ``a) (mkConst ``b))
+
+def someEqNone : Expr := mkApp3 (mkConst ``Eq [1])
+  (mkApp (mkConst ``Option [0]) (mkConst ``Nat))
+  (mkApp2 (mkConst ``Option.some [0]) (mkConst ``Nat) (mkConst ``n))
+  (mkApp (mkConst ``Option.none [0]) (mkConst ``Nat))
+
+/-- info: step: False -/
+#guard_msgs in
+set_option sym.debug true in
+run_meta test ``some_ne_none someEqNone
+
+/-- info: step: True -/
+#guard_msgs in
+set_option sym.debug true in
+run_meta test ``my_Q (mkApp2 (mkConst ``Q [1]) (mkConst ``Nat) (mkConst ``n))


### PR DESCRIPTION
This PR fixes a bug in `mkTheoremFromDecl` in `SymM`. It did not correctly handled polymorphic theorems that require adapters.
