### PR TITLE
perf: inline `mi_malloc_small` fast path

### DIFF
--- a/src/include/lean/lean.h
+++ b/src/include/lean/lean.h
@@ -463,12 +463,29 @@ static inline unsigned lean_get_slot_idx(unsigned sz) {
 
 LEAN_EXPORT void lean_inc_heartbeat(void);
 
+/* The heartbeat counter is bumped on every small-object allocation, so the increment is exposed
+   here rather than paid for as a call. `initial-exec` reduces it to a `%fs`-relative add and lets
+   the compiler share the thread-pointer load between the allocations of a single function; it is
+   valid because the counter lives in the runtime, which is never itself dynamically loaded late. */
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(_WIN32) && !defined(__EMSCRIPTEN__)
+#define LEAN_HEARTBEAT_TLS __attribute__((tls_model("initial-exec")))
+LEAN_EXPORT extern __thread uint64_t lean_heartbeat LEAN_HEARTBEAT_TLS;
+#endif
+
+static inline void lean_inc_heartbeat_inline(void) {
+#ifdef LEAN_HEARTBEAT_TLS
+    lean_heartbeat++;
+#else
+    lean_inc_heartbeat();
+#endif
+}
+
 #ifndef __cplusplus
 void * malloc(size_t);  // avoid including big `stdlib.h`
 #endif
 
 static inline lean_object * lean_alloc_small_object(unsigned sz) {
-    lean_inc_heartbeat();
+    lean_inc_heartbeat_inline();
 #ifdef LEAN_MIMALLOC
     // HACK: emulate behavior of small allocator to avoid `leangz` breakage for now
     // NOTE: `sz` is known at compile time for most callers

--- a/src/include/lean/lean.h
+++ b/src/include/lean/lean.h
@@ -484,13 +484,43 @@ static inline void lean_inc_heartbeat_inline(void) {
 void * malloc(size_t);  // avoid including big `stdlib.h`
 #endif
 
+/* MEASUREMENT PATCH, NOT FOR MERGE. Replicates mimalloc's small-allocation fast path inline so
+   that the call, the frame, the argument shuffle and the (already performed) size rounding fold
+   away, and so the size-class index becomes a constant displacement. Enabled by building with
+   `-DLEAN_MI_INLINE_FASTPATH`; see the commit message for the two blockers that stop this being
+   shippable as written.
+
+   The offsets are read off the vendored mimalloc build: `mi_theap_t.pages_free_direct` at 0x118
+   indexed by byte size, `mi_page_t.free` at 0x8, `mi_page_t.used` (uint16) at 0x10. They are only
+   valid because this build sets MI_SECURE=0 and MI_PADDING=0, so there is neither free-list
+   encoding nor a padding canary. */
+#if defined(LEAN_EXPORTING) && defined(LEAN_MI_INLINE_FASTPATH)
+/* `mi_theap_get_default` is public API, so no hidden mimalloc symbol is needed to obtain the
+   theap; only the pop below relies on the layout, since `mi_theap_t` is opaque publicly. */
+extern __thread void * lean_mi_theap LEAN_HEARTBEAT_TLS;
+LEAN_EXPORT void * lean_mi_malloc_small_slow(size_t sz);
+static inline void * lean_mi_malloc_small_fast(size_t sz) {
+    char * theap = (char *)lean_mi_theap;
+    char * page = *(char **)(theap + 0x118 + sz);
+    void ** block = *(void ***)(page + 0x8);
+    if (LEAN_UNLIKELY(block == 0)) return lean_mi_malloc_small_slow(sz);
+    *(void **)(page + 0x8) = *block;
+    (*(unsigned short *)(page + 0x10))++;
+    *block = 0;
+    return (void *)block;
+}
+#define LEAN_MI_MALLOC_SMALL(sz) lean_mi_malloc_small_fast(sz)
+#else
+#define LEAN_MI_MALLOC_SMALL(sz) mi_malloc_small(sz)
+#endif
+
 static inline lean_object * lean_alloc_small_object(unsigned sz) {
     lean_inc_heartbeat_inline();
 #ifdef LEAN_MIMALLOC
     // HACK: emulate behavior of small allocator to avoid `leangz` breakage for now
     // NOTE: `sz` is known at compile time for most callers
     sz = lean_align(sz, LEAN_OBJECT_SIZE_DELTA);
-    void * mem = sz <= MI_SMALL_SIZE_MAX ? mi_malloc_small(sz) : mi_malloc(sz);
+    void * mem = sz <= MI_SMALL_SIZE_MAX ? LEAN_MI_MALLOC_SMALL(sz) : mi_malloc(sz);
     if (mem == 0) lean_internal_panic_out_of_memory();
     lean_object * o = (lean_object*)mem;
     o->m_cs_sz = sz;

--- a/src/lakefile.toml.in
+++ b/src/lakefile.toml.in
@@ -50,7 +50,7 @@ leanOptions.linter.coreInternal = true
 #weakLeanArgs = ["-DmaxErrors=1"]
 
 # CMake's `LEANC_EXTRA_CC_FLAGS`
-moreLeancArgs = [${LEAN_MORE_LEANC_ARGS_TOML}]
+moreLeancArgs = ["-DLEAN_MI_INLINE_FASTPATH", "-DLEAN_MI_REV=5", ${LEAN_MORE_LEANC_ARGS_TOML}]
 
 # CMake's `LEANC_INTERNAL_FLAGS`
 weakLeancArgs = [${LEAN_WEAK_LEANC_ARGS_TOML}]

--- a/src/runtime/alloc.cpp
+++ b/src/runtime/alloc.cpp
@@ -23,14 +23,20 @@ void initialize_alloc() {
 void finalize_alloc() {
 }
 
-LEAN_THREAD_VALUE(uint64_t, g_heartbeat, 0);
+extern "C" {
+#ifdef LEAN_HEARTBEAT_TLS
+LEAN_EXPORT __thread uint64_t lean_heartbeat LEAN_HEARTBEAT_TLS = 0;
+#else
+LEAN_THREAD_VALUE(uint64_t, lean_heartbeat, 0);
+#endif
+}
 
 void set_heartbeats(uint64_t count) {
-    g_heartbeat = count;
+    lean_heartbeat = count;
 }
 
 void add_heartbeats(uint64_t count) {
-    g_heartbeat += count;
+    lean_heartbeat += count;
 }
 
 extern "C" LEAN_EXPORT void lean_inc_heartbeat() {
@@ -38,7 +44,7 @@ extern "C" LEAN_EXPORT void lean_inc_heartbeat() {
 }
 
 uint64_t get_num_heartbeats() {
-    return g_heartbeat;
+    return lean_heartbeat;
 }
 
 }

--- a/src/runtime/alloc.cpp
+++ b/src/runtime/alloc.cpp
@@ -43,6 +43,40 @@ extern "C" LEAN_EXPORT void lean_inc_heartbeat() {
     add_heartbeats(1);
 }
 
+#if defined(LEAN_MIMALLOC) && defined(LEAN_HEARTBEAT_TLS)
+/* Stand-in for a real theap, used as the initial value of the per-thread cache below so that the
+   inline fast path in `lean.h` never has to test for a null cache. Every size class resolves to a
+   page whose free list is empty, which sends the caller down the slow path, and that installs the
+   real theap. Only the two fields the fast path reads are modelled, and neither is ever written,
+   since the write only happens once a block has been popped. Being a constant initialiser this
+   covers every thread, including ones that never run any Lean initialisation. */
+static void * g_mi_empty_page[4] = { 0, 0, 0, 0 };   /* the `free` field, at offset 8, is null */
+
+#define LEAN_MI_P1  ((void *)g_mi_empty_page)
+#define LEAN_MI_P8  LEAN_MI_P1, LEAN_MI_P1, LEAN_MI_P1, LEAN_MI_P1, LEAN_MI_P1, LEAN_MI_P1, LEAN_MI_P1, LEAN_MI_P1
+#define LEAN_MI_P64 LEAN_MI_P8, LEAN_MI_P8, LEAN_MI_P8, LEAN_MI_P8, LEAN_MI_P8, LEAN_MI_P8, LEAN_MI_P8, LEAN_MI_P8
+
+static struct {
+    char   m_prefix[0x118];
+    void * m_pages_free_direct[MI_SMALL_SIZE_MAX / sizeof(void *) + 1];
+} g_mi_empty_theap = { { 0 }, { LEAN_MI_P64, LEAN_MI_P64, LEAN_MI_P1 } };
+
+static_assert(MI_SMALL_SIZE_MAX / sizeof(void *) + 1 == 129,
+              "size-class table shape changed; the empty-theap stand-in must be resized");
+
+extern "C" {
+LEAN_EXPORT __thread void * lean_mi_theap LEAN_HEARTBEAT_TLS = &g_mi_empty_theap;
+
+/* Kept out of line so the inline fast path never writes to `lean_mi_theap`: a write would keep the
+   thread-pointer address live across the call and cost the caller two extra callee-saved spills. */
+LEAN_EXPORT void * lean_mi_malloc_small_slow(size_t sz) {
+    void * p = mi_malloc_small(sz);
+    lean_mi_theap = mi_theap_get_default();
+    return p;
+}
+}
+#endif
+
 uint64_t get_num_heartbeats() {
     return lean_heartbeat;
 }


### PR DESCRIPTION
Reaches into mimalloc internals so should definitely NOT be landed here