### PR TITLE
fix: try the next `@[spec]` candidate when a spec rule does not apply

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -38,8 +38,8 @@ public inductive SolveResult.StopReason where
   | noEntailment (target : Expr)
   /-- The target was of the form `pre ⊑ rhs`, but we couldn't make further progress. -/
   | noProgress (pre rhs : Expr)
-  /-- No spec was found for the program `e` in `pre ⊑ wp e post epost s₁ ... sₙ`. Candidates
-  were `thms`, but none matched the monad. Reached only when `errorOnMissingSpec` is `false`. -/
+  /-- No spec applicable to the program `e` in `pre ⊑ wp e post epost s₁ ... sₙ` was found; `thms`
+  are the candidates that were tried. Reached only when `errorOnMissingSpec` is `false`. -/
   | noSpecFound (e : Expr) (monad : Expr) (thms : Array SpecTheorem)
 
 /-- The result of one `solve` step of VC generation. -/
@@ -313,8 +313,8 @@ private def wpHeadReduce? (goal : MVarId) (info : WPApp) :
   let prog ← betaRevS f' info.prog.getAppRevArgs
   return some (← replaceProgDefEq goal info prog)
 
-/-- Stop or raise on a program with no matching spec. With `errorOnMissingSpec` (default), raise a
-hard error naming the program and any candidate specs; otherwise stop and emit the goal as a VC. -/
+/-- Stop or raise on a program with no applicable spec. With `errorOnMissingSpec` (default), raise a
+hard error naming the program and the candidate specs; otherwise stop and emit the goal as a VC. -/
 private def stopOrErrorOnMissingSpec (prog monad : Expr) (thms : Array SpecTheorem) :
     VCGenM SolveResult := do
   unless (← read).errorOnMissingSpec do
@@ -322,54 +322,30 @@ private def stopOrErrorOnMissingSpec (prog monad : Expr) (thms : Array SpecTheor
   if thms.isEmpty then
     throwError "No spec found for program {prog}."
   else
-    throwError "No spec matching the monad {monad} found for program {prog}. \
+    throwError "No spec applicable to program {prog} in monad {monad}. \
       Candidates were {thms.map (·.proof)}."
 
-/-- Select the highest-priority `@[spec]` theorem matching `info.prog` and compile its backward rule
-(construction is cached), or a stop result when no spec matches or no rule fits the goal's monad.
-Hands `findSpecs` the sole reference to the spec database so its in-place pattern internalization
-does not copy the discrimination tree, then threads the updated database back into the returned
-scope. -/
-private def compileSpecRule (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
-    VCGenM (Except SolveResult (VCGen.Scope × SpecTheorem × BackwardRule)) := do
-  let specs := scope.specs
-  let scope := { scope with specs := default }
-  let (result, specs) ← SpecTheorems.findSpecs specs info.prog
-  let scope := { scope with specs }
-  let thm ← match result with
-    | .ok thm => pure thm
-    | .error thms => return .error (← stopOrErrorOnMissingSpec info.prog info.M thms)
-  let some rule ←
-    try
-      mkBackwardRuleFromSpecCached thm info |>.run
-    catch ex =>
-      throwError "Failed to construct rule {thm.proof} for {indentExpr info.prog}\n\
-        error: {ex.toMessageData}\n\
-        target:{indentExpr (← goal.getType)}\n\
-        Pred:{indentExpr info.Pred}\n\
-        excessArgs: {info.excessArgs}"
-    | return .error (← stopOrErrorOnMissingSpec info.prog info.M #[thm])
-  return .ok (scope, thm, rule)
+/-- Compile the backward rule of the `@[spec]` theorem `thm` for the goal's `wp` application
+(construction is cached), or `none` when no rule fits the goal's monad. -/
+private def compileSpecRule (goal : MVarId) (info : WPApp) (thm : SpecTheorem) :
+    VCGenM (Option BackwardRule) := do
+  try
+    mkBackwardRuleFromSpecCached thm info |>.run
+  catch ex =>
+    throwError "Failed to construct rule {thm.proof} for {indentExpr info.prog}\n\
+      error: {ex.toMessageData}\n\
+      target:{indentExpr (← goal.getType)}\n\
+      Pred:{indentExpr info.Pred}\n\
+      excessArgs: {info.excessArgs}"
 
-/-- Apply the backward `rule` of the selected `@[spec]` theorem `thm`, returning its subgoals.
-Reached from `applySpec`. -/
-private def applySpecRule (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) (thm : SpecTheorem)
-    (rule : BackwardRule) : VCGenM SolveResult := do
+/-- Apply the backward `rule` of the selected `@[spec]` theorem `thm`, returning its subgoals, or
+`none` when the rule does not apply. Reached from `applySpec`. -/
+private def applySpecRule? (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) (thm : SpecTheorem)
+    (rule : BackwardRule) : VCGenM (Option SolveResult) := do
   trace[Elab.Tactic.Do.vcgen] "Applying spec {thm.proof} for {info.prog}. Excess args: {info.excessArgs}"
   let .goals goals ← rule.applyChecked goal m!"spec rule for{indentExpr info.prog}"
-    | do
-      -- The discrimination tree over-approximates, so a selected spec may not unify with the program
-      -- (e.g. an offset-keyed equation against a variable discriminant). That is no matching spec, not
-      -- a rule failure. A spec whose pattern does match yet whose rule fails to apply is a genuine bug.
-      unless ← thm.patternMatches info.prog do
-        return ← stopOrErrorOnMissingSpec info.prog info.M #[thm]
-      let ruleType ← Meta.inferType rule.expr
-      throwError "Failed to apply rule {thm.proof} for {indentExpr info.prog}\n\
-        target:{indentExpr (← goal.getType)}\n\
-        Pred:{indentExpr info.Pred}\n\
-        excessArgs: {info.excessArgs}\n\
-        rule type:{indentExpr ruleType}"
-  return .goals scope goals
+    | return none
+  return some (.goals scope goals)
 
 /-- True iff the program matches the `until` pattern, in which case VC generation stops at this
 goal. -/
@@ -460,7 +436,8 @@ private def applyFrameRule (goal : MVarId) (info : WPApp) (fp : FrameProc)
   return goals.toList ++ split.subgoals
 
 /--
-Handle a spec-ready program `info.prog`: select its `@[spec]` theorem and either frame or apply it.
+Apply the selected `@[spec]` theorem `thm` to a spec-ready program `info.prog`, framing first when a
+frame procedure produces a split.
 
 - A spec with a conjunctive precondition, or an already-framed residual, applies its spec directly.
 - Otherwise the frame procedure for the monad is selected (the `@[frameproc]` registered for the
@@ -471,13 +448,10 @@ Handle a spec-ready program `info.prog`: select its `@[spec]` theorem and either
   `FrameInferenceInfo.specPre?`: no split applies the spec directly; a split applies the frame rule
   instead, so the spec re-applies against the framed residual where its VCs are solvable.
 -/
-private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
-    VCGenM SolveResult := goal.withContext do
-  let (scope, thm, specRule) ← match ← compileSpecRule scope goal info with
-    | .ok res => pure res
-    | .error res => return res
+private def frameOrApplySpec? (scope : VCGen.Scope) (goal : MVarId) (info : WPApp)
+    (thm : SpecTheorem) (specRule : BackwardRule) : VCGenM (Option SolveResult) := do
   if thm.conjunctivePre || isFramedPost info.post then
-    return ← applySpecRule scope goal info thm specRule
+    return ← applySpecRule? scope goal info thm specRule
   let procs := (← read).frameProcs.byProg
   let fp := info.M.getAppFn.constName?.bind (procs[·]?) |>.getD meetFrameProc
   let providedFrame? ← matchFrame? fp info
@@ -485,10 +459,28 @@ private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
     { info with goal, providedFrame?, spec? := thm.global?, specRule,
                 mkOpApp := do shareCommon (← fp.mkOpAppM info) }
   match ← fp.proc inferInfo with
-  | none => applySpecRule scope goal info thm specRule
+  | none => applySpecRule? scope goal info thm specRule
   | some split =>
     trace[Elab.Tactic.Do.vcgen] "`@[frameproc]` matched {info.prog}; frame:{indentExpr split.frame}"
-    return .goals scope (← applyFrameRule goal info fp (← split.instantiateMVarsS))
+    return some (.goals scope (← applyFrameRule goal info fp (← split.instantiateMVarsS)))
+
+/--
+Handle a spec-ready program `info.prog`: apply the highest-priority `@[spec]` theorem whose backward
+rule applies to the goal.
+
+A candidate is passed over when no rule fits the goal's monad or when the rule does not apply, so a
+spec guarded by an instance the call site does not provide gives way to a less general one, as does a
+spurious candidate of the over-approximating discrimination tree.
+-/
+private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
+    VCGenM SolveResult := goal.withContext do
+  let candidates ← SpecTheorems.findSpecs scope.specs info.prog
+  for thm in candidates do
+    if let some rule ← compileSpecRule goal info thm then
+      if let some res ← frameOrApplySpec? scope goal info thm rule then
+        return res
+    trace[Elab.Tactic.Do.vcgen] "Failed to apply spec {thm.proof} for {info.prog}"
+  stopOrErrorOnMissingSpec info.prog info.M candidates
 
 /--
 The main VC generation step. Operates on a plain `MVarId` with no knowledge of grind.

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -429,7 +429,6 @@ rule does not apply.
 -/
 private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) (thm : SpecTheorem) :
     VCGenM (Option SolveResult) := do
-  -- Rule construction is cached.
   let some specRule ←
     try
       mkBackwardRuleFromSpecCached thm info |>.run

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -338,15 +338,6 @@ private def compileSpecRule (goal : MVarId) (info : WPApp) (thm : SpecTheorem) :
       Pred:{indentExpr info.Pred}\n\
       excessArgs: {info.excessArgs}"
 
-/-- Apply the backward `rule` of the selected `@[spec]` theorem `thm`, returning its subgoals, or
-`none` when the rule does not apply. Reached from `applySpec`. -/
-private def applySpecRule? (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) (thm : SpecTheorem)
-    (rule : BackwardRule) : VCGenM (Option SolveResult) := do
-  trace[Elab.Tactic.Do.vcgen] "Applying spec {thm.proof} for {info.prog}. Excess args: {info.excessArgs}"
-  let .goals goals ← rule.applyChecked goal m!"spec rule for{indentExpr info.prog}"
-    | return none
-  return some (.goals scope goals)
-
 /-- True iff the program matches the `until` pattern, in which case VC generation stops at this
 goal. -/
 private def matchesUntilPattern (prog : Expr) : VCGenM Bool := do
@@ -437,7 +428,7 @@ private def applyFrameRule (goal : MVarId) (info : WPApp) (fp : FrameProc)
 
 /--
 Apply the selected `@[spec]` theorem `thm` to a spec-ready program `info.prog`, framing first when a
-frame procedure produces a split.
+frame procedure produces a split. `none` when `thm`'s backward rule does not apply.
 
 - A spec with a conjunctive precondition, or an already-framed residual, applies its spec directly.
 - Otherwise the frame procedure for the monad is selected (the `@[frameproc]` registered for the
@@ -448,21 +439,22 @@ frame procedure produces a split.
   `FrameInferenceInfo.specPre?`: no split applies the spec directly; a split applies the frame rule
   instead, so the spec re-applies against the framed residual where its VCs are solvable.
 -/
-private def frameOrApplySpec? (scope : VCGen.Scope) (goal : MVarId) (info : WPApp)
-    (thm : SpecTheorem) (specRule : BackwardRule) : VCGenM (Option SolveResult) := do
-  if thm.conjunctivePre || isFramedPost info.post then
-    return ← applySpecRule? scope goal info thm specRule
-  let procs := (← read).frameProcs.byProg
-  let fp := info.M.getAppFn.constName?.bind (procs[·]?) |>.getD meetFrameProc
-  let providedFrame? ← matchFrame? fp info
-  let inferInfo : FrameInferenceInfo :=
-    { info with goal, providedFrame?, spec? := thm.global?, specRule,
-                mkOpApp := do shareCommon (← fp.mkOpAppM info) }
-  match ← fp.proc inferInfo with
-  | none => applySpecRule? scope goal info thm specRule
-  | some split =>
-    trace[Elab.Tactic.Do.vcgen] "`@[frameproc]` matched {info.prog}; frame:{indentExpr split.frame}"
-    return some (.goals scope (← applyFrameRule goal info fp (← split.instantiateMVarsS)))
+private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) (thm : SpecTheorem)
+    (specRule : BackwardRule) : VCGenM (Option SolveResult) := do
+  unless thm.conjunctivePre || isFramedPost info.post do
+    let procs := (← read).frameProcs.byProg
+    let fp := info.M.getAppFn.constName?.bind (procs[·]?) |>.getD meetFrameProc
+    let providedFrame? ← matchFrame? fp info
+    let inferInfo : FrameInferenceInfo :=
+      { info with goal, providedFrame?, spec? := thm.global?, specRule,
+                  mkOpApp := do shareCommon (← fp.mkOpAppM info) }
+    if let some split ← fp.proc inferInfo then
+      trace[Elab.Tactic.Do.vcgen] "`@[frameproc]` matched {info.prog}; frame:{indentExpr split.frame}"
+      return some (.goals scope (← applyFrameRule goal info fp (← split.instantiateMVarsS)))
+  trace[Elab.Tactic.Do.vcgen] "Applying spec {thm.proof} for {info.prog}. Excess args: {info.excessArgs}"
+  let .goals goals ← specRule.applyChecked goal m!"spec rule for{indentExpr info.prog}"
+    | return none
+  return some (.goals scope goals)
 
 /--
 Handle a spec-ready program `info.prog`: apply the highest-priority `@[spec]` theorem whose backward
@@ -472,12 +464,12 @@ A candidate is passed over when no rule fits the goal's monad or when the rule d
 spec guarded by an instance the call site does not provide gives way to a less general one, as does a
 spurious candidate of the over-approximating discrimination tree.
 -/
-private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
+private def applySpecs (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
     VCGenM SolveResult := goal.withContext do
   let candidates ← SpecTheorems.findSpecs scope.specs info.prog
   for thm in candidates do
     if let some rule ← compileSpecRule goal info thm then
-      if let some res ← frameOrApplySpec? scope goal info thm rule then
+      if let some res ← applySpec scope goal info thm rule then
         return res
     trace[Elab.Tactic.Do.vcgen] "Failed to apply spec {thm.proof} for {info.prog}"
   stopOrErrorOnMissingSpec info.prog info.M candidates
@@ -531,7 +523,7 @@ public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := g
   if let some (scope, gs) ← normalizePre? scope goal α pre target then return .goals scope gs
 
   -- Collect new local specs before any strategy that may emit multiple subgoals
-  -- (`wpMatch?`, `splitLatticeOp?`) or apply a registered spec (`applySpecRule`).
+  -- (`wpMatch?`, `splitLatticeOp?`) or apply a registered spec (`applySpec`).
   let scope ← scope.collectLocalSpecs goal
 
   -- Phase 3: shape the `rhs` (reduce an EPost projection, decompose a lattice connective or a
@@ -565,7 +557,7 @@ public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := g
     let f := info.prog.getAppFn
     if f.isConst || f.isFVar then
       VCGen.burnOne
-      return ← applySpec scope goal info
+      return ← applySpecs scope goal info
     throwError "Failed to decompose weakest precondition for {info.prog}. This should not happen."
 
   return .stop (.noProgress pre rhs)

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -325,19 +325,6 @@ private def stopOrErrorOnMissingSpec (prog monad : Expr) (thms : Array SpecTheor
     throwError "No spec applicable to program {prog} in monad {monad}. \
       Candidates were {thms.map (·.proof)}."
 
-/-- Compile the backward rule of the `@[spec]` theorem `thm` for the goal's `wp` application
-(construction is cached), or `none` when no rule fits the goal's monad. -/
-private def compileSpecRule (goal : MVarId) (info : WPApp) (thm : SpecTheorem) :
-    VCGenM (Option BackwardRule) := do
-  try
-    mkBackwardRuleFromSpecCached thm info |>.run
-  catch ex =>
-    throwError "Failed to construct rule {thm.proof} for {indentExpr info.prog}\n\
-      error: {ex.toMessageData}\n\
-      target:{indentExpr (← goal.getType)}\n\
-      Pred:{indentExpr info.Pred}\n\
-      excessArgs: {info.excessArgs}"
-
 /-- True iff the program matches the `until` pattern, in which case VC generation stops at this
 goal. -/
 private def matchesUntilPattern (prog : Expr) : VCGenM Bool := do
@@ -428,7 +415,8 @@ private def applyFrameRule (goal : MVarId) (info : WPApp) (fp : FrameProc)
 
 /--
 Apply the selected `@[spec]` theorem `thm` to a spec-ready program `info.prog`, framing first when a
-frame procedure produces a split. `none` when `thm`'s backward rule does not apply.
+frame procedure produces a split. `none` when no backward rule fits the goal's monad, or when the
+rule does not apply.
 
 - A spec with a conjunctive precondition, or an already-framed residual, applies its spec directly.
 - Otherwise the frame procedure for the monad is selected (the `@[frameproc]` registered for the
@@ -439,8 +427,19 @@ frame procedure produces a split. `none` when `thm`'s backward rule does not app
   `FrameInferenceInfo.specPre?`: no split applies the spec directly; a split applies the frame rule
   instead, so the spec re-applies against the framed residual where its VCs are solvable.
 -/
-private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) (thm : SpecTheorem)
-    (specRule : BackwardRule) : VCGenM (Option SolveResult) := do
+private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) (thm : SpecTheorem) :
+    VCGenM (Option SolveResult) := do
+  -- Rule construction is cached.
+  let some specRule ←
+    try
+      mkBackwardRuleFromSpecCached thm info |>.run
+    catch ex =>
+      throwError "Failed to construct rule {thm.proof} for {indentExpr info.prog}\n\
+        error: {ex.toMessageData}\n\
+        target:{indentExpr (← goal.getType)}\n\
+        Pred:{indentExpr info.Pred}\n\
+        excessArgs: {info.excessArgs}"
+    | return none
   unless thm.conjunctivePre || isFramedPost info.post do
     let procs := (← read).frameProcs.byProg
     let fp := info.M.getAppFn.constName?.bind (procs[·]?) |>.getD meetFrameProc
@@ -468,9 +467,8 @@ private def applySpecs (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
     VCGenM SolveResult := goal.withContext do
   let candidates ← SpecTheorems.findSpecs scope.specs info.prog
   for thm in candidates do
-    if let some rule ← compileSpecRule goal info thm then
-      if let some res ← applySpec scope goal info thm rule then
-        return res
+    if let some res ← applySpec scope goal info thm then
+      return res
     trace[Elab.Tactic.Do.vcgen] "Failed to apply spec {thm.proof} for {info.prog}"
   stopOrErrorOnMissingSpec info.prog info.M candidates
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
@@ -26,11 +26,6 @@ namespace Lean.Elab.Tactic.Do.Internal
 
 open Lean.Elab.Tactic.Do.Internal.SpecAttr
 
-/-- Returns `true` if `e` is already internalized into the current `SymM` share table, in which case
-`shareCommon e` returns `e` unchanged. -/
-public def _root_.Lean.Meta.Sym.isShared (e : Expr) : SymM Bool :=
-  return (← get).share.set.contains { expr := e }
-
 /--
 Internalizes the pattern's expressions into the current `SymM` share table.
 
@@ -76,13 +71,6 @@ public def SpecAttr.SpecTheorem.instantiate (specThm : SpecTheorem) :
 public def SpecAttr.SpecTheorem.global? (specThm : SpecTheorem) : Option Name :=
   match specThm.proof with | .global decl => some decl | _ => none
 
-/-- True iff the spec's pattern unifies with the program, mirroring the match performed in
-`findSpecs`. Distinguishes a spurious discrimination-tree candidate, whose pattern does not unify,
-from a spec whose pattern matches yet whose backward rule fails to apply. -/
-public def SpecAttr.SpecTheorem.patternMatches (specThm : SpecTheorem) (prog : Expr) : SymM Bool :=
-  withNewMCtxDepth do
-    return (← specThm.pattern.match? prog).isSome
-
 namespace VCGen
 
 /--
@@ -117,33 +105,15 @@ end VCGen
 
 /--
 Look up `SpecTheorem`s in the `@[spec]` database.
-Takes all specs that match the given program `e` and sorts by descending priority.
+Takes all specs the discrimination tree holds for the program `e` and sorts by descending priority.
 -/
 public def SpecAttr.SpecTheorems.findSpecs (database : SpecTheorems) (e : Expr) :
-    SymM (Except (Array SpecTheorem) SpecTheorem × SpecTheorems) := do
+    SymM (Array SpecTheorem) := do
   let e ← instantiateMVars e
   let e ← shareCommon e
   let candidates := Sym.getMatch database.specs e
   let candidates := candidates.filter fun spec => !database.erased.contains spec.proof
-  if h : candidates.size = 1 then
-    have : 0 < candidates.size := h ▸ Nat.zero_lt_one
-    return (.ok candidates[0], database)
   -- It appears that insertion sort is *much* faster than qsort here.
-  let candidates := candidates.insertionSort (·.priority > ·.priority)
-  let mut database := database
-  for spec in candidates do
-    -- Match against the internalized pattern so its instance arguments are pointer-equal to the
-    -- program's. A spec is internalized the first time it is tried and stored back in the database,
-    -- so later lookups find it already in the share table and skip the work.
-    let mut spec := spec
-    unless ← isShared spec.pattern.pattern do
-      spec := { spec with pattern := ← spec.pattern.shareCommon }
-      -- Take sole ownership of the discrimination tree before inserting so the update is in place.
-      let specs := database.specs
-      database := { database with specs := default }
-      database := { database with specs := Sym.insertPattern specs spec.pattern spec }
-    let some _res ← spec.pattern.match? e | continue
-    return (.ok spec, database)
-  return (.error candidates, database)
+  return candidates.insertionSort (·.priority > ·.priority)
 
 end Lean.Elab.Tactic.Do.Internal

--- a/tests/elab/vcgenSpecInstDischarge.lean
+++ b/tests/elab/vcgenSpecInstDischarge.lean
@@ -1,0 +1,57 @@
+import Std.Tactic.Do
+import Std.Internal.Do
+
+/-!
+`vcgen` tries the `@[spec]` theorems matching a program in descending priority order and applies the
+first one whose backward rule applies. A spec guarded by an instance the call site does not provide
+is passed over for the next candidate.
+-/
+
+set_option mvcgen.warning false
+set_option warn.sorry false
+
+open Std.Internal.Do Lean.Order
+
+class Missing (ρ : Type) : Prop
+
+class Provided (ρ : Type) : Prop
+
+instance : Provided (List Nat) := ⟨⟩
+
+opaque run {ρ : Type} (xs : ρ) (init : Nat) : Id Nat
+
+@[spec] theorem spec_run_list {xs : List Nat} {init : Nat} :
+    ⦃⌜True⌝⦄ run xs init ⦃fun r => ⌜r = 1⌝⦄ := sorry
+
+@[spec high] theorem spec_run_missing {ρ : Type} [Missing ρ] {xs : ρ} {init : Nat} :
+    ⦃⌜True⌝⦄ run xs init ⦃fun r => ⌜r = 2⌝⦄ := sorry
+
+-- The higher-priority `spec_run_missing` needs `Missing (List Nat)`, so `spec_run_list` applies.
+example : ⦃⌜True⌝⦄ run [1, 2, 3] 0 ⦃fun r => ⌜r = 1⌝⦄ := by
+  vcgen
+
+opaque tick {ρ : Type} (xs : ρ) : Id Nat
+
+@[spec] theorem spec_tick_list {xs : List Nat} : ⦃⌜True⌝⦄ tick xs ⦃fun r => ⌜r = 1⌝⦄ := sorry
+
+@[spec high] theorem spec_tick_provided {ρ : Type} [Provided ρ] {xs : ρ} :
+    ⦃⌜True⌝⦄ tick xs ⦃fun r => ⌜r = 2⌝⦄ := sorry
+
+-- `Provided (List Nat)` is available, so the higher-priority `spec_tick_provided` wins.
+example : ⦃⌜True⌝⦄ tick [1, 2, 3] ⦃fun r => ⌜r = 2⌝⦄ := by
+  vcgen
+
+opaque solo {ρ : Type} (xs : ρ) : Id Nat
+
+@[spec] theorem spec_solo_missing {ρ : Type} [Missing ρ] {xs : ρ} :
+    ⦃⌜True⌝⦄ solo xs ⦃fun r => ⌜r = 1⌝⦄ := sorry
+
+/-- error: No spec applicable to program solo [1, 2, 3] in monad Id. Candidates were [SpecProof.global spec_solo_missing]. -/
+#guard_msgs in
+example : ⦃⌜True⌝⦄ solo [1, 2, 3] ⦃fun r => ⌜r = 1⌝⦄ := by
+  vcgen
+
+-- Without `errorOnMissingSpec` the goal is emitted as a VC instead.
+example : ⦃⌜True⌝⦄ solo [1, 2, 3] ⦃fun r => ⌜r = 1⌝⦄ := by
+  vcgen -errorOnMissingSpec
+  all_goals sorry

--- a/tests/elab/vcgenSpecInstDischarge.lean
+++ b/tests/elab/vcgenSpecInstDischarge.lean
@@ -50,8 +50,3 @@ opaque solo {ρ : Type} (xs : ρ) : Id Nat
 #guard_msgs in
 example : ⦃⌜True⌝⦄ solo [1, 2, 3] ⦃fun r => ⌜r = 1⌝⦄ := by
   vcgen
-
--- Without `errorOnMissingSpec` the goal is emitted as a VC instead.
-example : ⦃⌜True⌝⦄ solo [1, 2, 3] ⦃fun r => ⌜r = 1⌝⦄ := by
-  vcgen -errorOnMissingSpec
-  all_goals sorry

--- a/tests/elab/vcgenUnfoldMatchDef.lean
+++ b/tests/elab/vcgenUnfoldMatchDef.lean
@@ -52,7 +52,7 @@ attribute [local spec] wild in
 example (n m : Option Nat) : ⦃ True ⦄ wild n m ⦃ fun r => r > 0 ⦄ := by
   vcgen with finish
 
-/-- error: No spec matching the monad Id found for program recf n. Candidates were [SpecProof.global recf.eq_2]. -/
+/-- error: No spec applicable to program recf n in monad Id. Candidates were [SpecProof.global recf.eq_2]. -/
 #guard_msgs (whitespace := lax) in
 example (n : Nat) : ⦃ True ⦄ recf n ⦃ fun r => r > 0 ⦄ := by
   vcgen [recf] with finish


### PR DESCRIPTION
This PR makes `vcgen` try the `@[spec]` theorems matching a program in priority order and apply the first one that fits the goal, so a spec whose instance argument the call site cannot synthesize no longer shadows a more specific one.

`findSpecs` returns all candidates for the program and `applySpec` applies them in turn, skipping any whose backward rule does not fit the goal's monad or does not apply. Nothing needs restoring between attempts, since a rule's conclusion is unified against the goal alone and a failed application leaves it untouched. The pattern internalization in `findSpecs` sped up the match that used to decide this, and goes with it.

It is overall a nice simplification and also speeds up some benchmarks.
