### PR TITLE
feat: make `bv_decide` available in `sym` mode

### DIFF
--- a/src/Init/Grind/Interactive.lean
+++ b/src/Init/Grind/Interactive.lean
@@ -387,5 +387,18 @@ generator.
 This is a variant of `cbv` that only works in `sym =>` mode.
 -/
 syntax (name := symCbv) "cbv" : grind
+
+@[inherit_doc Lean.Parser.Tactic.bvNormalize]
+syntax (name := bvNormalize) "bv_normalize" optConfig : grind
+
+@[inherit_doc Lean.Parser.Tactic.bvDecide]
+syntax (name := bvDecide) "bv_decide" optConfig : grind
+
+@[inherit_doc Lean.Parser.Tactic.bvTrace]
+syntax (name := bvTrace) "bv_decide?" optConfig : grind
+
+@[inherit_doc Lean.Parser.Tactic.bvCheck]
+syntax (name := bvCheck) "bv_check " optConfig str : grind
+
 end Grind
 end Lean.Parser.Tactic

--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -1872,6 +1872,16 @@ The suggestions are printed in the order of their confidence, from highest to lo
 syntax (name := suggestions) "suggestions" : tactic
 
 /--
+This tactic works just like `bv_decide` but skips calling a SAT solver by using a proof that is
+already stored on disk. It is called with the name of an LRAT file in the same directory as the
+current Lean file:
+```
+bv_check "proof.lrat"
+```
+-/
+syntax (name := bvCheck) "bv_check " optConfig str : tactic
+
+/--
 Close fixed-width `BitVec` and `Bool` goals by obtaining a proof from an external SAT solver and
 verifying it inside Lean. The solvable goals are currently limited to
 - the Lean equivalent of [`QF_BV`](https://smt-lib.org/logics-all.shtml#QF_BV)
@@ -1898,18 +1908,14 @@ Note: `bv_decide` trusts the correctness of the code generator and adds a axioms
 
 Note: include `import Std.Tactic.BVDecide`
 -/
-macro (name := bvDecideMacro) (priority:=low) "bv_decide" optConfig : tactic =>
-  Macro.throwError "to use `bv_decide`, please include `import Std.Tactic.BVDecide`"
-
+syntax (name := bvDecide) "bv_decide" optConfig : tactic
 
 /--
 Suggest a proof script for a `bv_decide` tactic call. Useful for caching LRAT proofs.
 
 Note: include `import Std.Tactic.BVDecide`
 -/
-macro (name := bvTraceMacro) (priority:=low) "bv_decide?" optConfig : tactic =>
-  Macro.throwError "to use `bv_decide?`, please include `import Std.Tactic.BVDecide`"
-
+syntax (name := bvTrace) "bv_decide?" optConfig : tactic
 
 /--
 Run the normalization procedure of `bv_decide` only. Sometimes this is enough to solve basic
@@ -1917,9 +1923,7 @@ Run the normalization procedure of `bv_decide` only. Sometimes this is enough to
 
 Note: include `import Std.Tactic.BVDecide`
 -/
-macro (name := bvNormalizeMacro) (priority:=low) "bv_normalize" optConfig : tactic =>
-  Macro.throwError "to use `bv_normalize`, please include `import Std.Tactic.BVDecide`"
-
+syntax (name := bvNormalize) "bv_normalize" optConfig : tactic
 
 /--
 `massumption` is like `assumption`, but operating on a stateful `Std.Do.SPred` goal.

--- a/src/Lean/Elab/Tactic/BVDecide/BVCheck.lean
+++ b/src/Lean/Elab/Tactic/BVDecide/BVCheck.lean
@@ -45,22 +45,26 @@ def bvCheck (g : MVarId) (hypotheses : Array Normalize.Hyp) (ctx : TacticContext
   M.run (hypotheses := hypotheses) do
     discard <| closeWithBVReflection g (lratChecker ctx)
 
+def evalBvCheck (g : MVarId) (ctx : TacticContext) (warn : MetaM Unit) :
+    Meta.Sym.SymM Unit := do
+  Normalize.PreProcessM.run' ctx.config g do
+    if ← Normalize.bvNormalize then
+      warn
+    else
+      bvCheck (← Normalize.PreProcessM.getGoal) (← Normalize.PreProcessM.getHyps) ctx
 
 open Lean.Meta.Tactic in
 @[builtin_tactic Lean.Parser.Tactic.bvCheck]
-def evalBvCheck : Tactic := fun
+def evalBvCheckTactic : Tactic := fun
   | `(tactic| bv_check%$tk $cfgStx:optConfig $path:str) => do
+    ensureBvDecide
     let cfg ← elabBVDecideConfig cfgStx
     let ctx ← mkContext path.getString cfg
-    liftMetaFinishingTactic fun g => do
-      Meta.Sym.SymM.run do
-        Normalize.PreProcessM.run' cfg g do
-          if ← Normalize.bvNormalize then
-            let bvNormalizeStx ← `(tactic| bv_normalize $cfgStx)
-            logWarning m!"This goal can be closed by only applying bv_normalize, no need to keep the LRAT proof around."
-            TryThis.addSuggestion tk bvNormalizeStx (origSpan? := ← getRef)
-          else
-            bvCheck (← Normalize.PreProcessM.getGoal) (← Normalize.PreProcessM.getHyps) ctx
+    let g ← getMainGoal
+    Meta.Sym.SymM.run <| evalBvCheck g ctx do
+      let bvNormalizeStx ← `(tactic| bv_normalize $cfgStx)
+      logWarning m!"This goal can be closed by only applying bv_normalize, no need to keep the LRAT proof around."
+      TryThis.addSuggestion tk bvNormalizeStx (origSpan? := ← getRef)
   | _ => throwUnsupportedSyntax
 
 end BVCheck

--- a/src/Lean/Elab/Tactic/BVDecide/BVDecide.lean
+++ b/src/Lean/Elab/Tactic/BVDecide/BVDecide.lean
@@ -18,14 +18,20 @@ namespace Lean.Elab.Tactic.BVDecide
 
 open Meta.Tactic.BVDecide
 
+def ensureBvDecide : CoreM Unit := do
+  let env ← getEnv
+  if (env.getModuleIdx? `Std.Tactic.BVDecide).isNone then
+    throwError "to use `bv_decide`, please include `import Std.Tactic.BVDecide`"
+
 @[builtin_tactic Lean.Parser.Tactic.bvDecide]
 def evalBvDecide : Tactic := fun
   | `(tactic| bv_decide $cfg:optConfig) => do
+    ensureBvDecide
     let cfg ← elabBVDecideConfig cfg
     IO.FS.withTempFile fun _ lratFile => do
       let cfg ← TacticContext.new lratFile cfg
       liftMetaFinishingTactic fun g => do
-        discard <| bvDecide g cfg
+        discard <| Meta.Sym.SymM.run <| bvDecide g cfg
   | _ => throwUnsupportedSyntax
 
 end Lean.Elab.Tactic.BVDecide

--- a/src/Lean/Elab/Tactic/BVDecide/BVTrace.lean
+++ b/src/Lean/Elab/Tactic/BVDecide/BVTrace.lean
@@ -18,6 +18,9 @@ This module contains the implementation of `bv_decide?`.
 namespace Lean.Elab.Tactic.BVDecide
 namespace BVTrace
 
+open Std.Tactic.BVDecide.LRAT
+open Lean.Meta.Tactic
+open Lean.Meta.Tactic.BVDecide
 
 -- TODO: think of a more maintainable file pattern for this stuff.
 /--
@@ -30,42 +33,57 @@ def getLratFileName : TermElabM System.FilePath := do
   let pos := (← getFileMap).toPosition (← getRefPos)
   return s!"{baseName}-{declName}-{pos.line}-{pos.column}.lrat"
 
-open Std.Tactic.BVDecide.LRAT in
+def mkContext (cfg : BVDecideConfig) : TermElabM TacticContext := do
+  let lratPath ← getLratFileName
+  BVCheck.mkContext lratPath cfg
+
+inductive TraceResult where
+  | normalize
+  | check (path : System.FilePath)
+
+def evalBvTrace (g : MVarId) (ctx : TacticContext) : Meta.Sym.SymM TraceResult := do
+  let trace ← g.withContext do
+    bvDecide g { ctx with config := { ctx.config with trimProofs := false } }
+  /-
+  Ideally trace.lratCert would be the `ByteArray` version of the proof already and we just write
+  it. This isn't yet possible so instead we do the following:
+  1. Produce the proof in the tactic.
+  2. Skip trimming it in the tactic.
+  3. Run trimming on the LRAT file that was produced by the SAT solver directly, emitting the
+     correct binary format according to `sat.binaryProofs`.
+  TODO: Fix this hack:
+  1. Introduce `ByteArray` literals to the kernel.
+  2. Just return the fully trimmed proof in the format desired by the configuration from `bvDecide`.
+  3. Write it to the file directly.
+  -/
+  match trace.lratCert with
+  | none =>
+    return .normalize
+  | some .. =>
+    if ctx.config.trimProofs then
+      let proof ← loadLRATProof ctx.lratPath
+      let trimmed ← IO.ofExcept <| LRAT.trim proof
+      dumpLRATProof ctx.lratPath trimmed ctx.config.binaryProofs
+    let some lratFile := ctx.lratPath.fileName | throwError "could not find file name"
+    return .check lratFile
+
 open Lean.Meta.Tactic in
 open Lean.Meta.Tactic.BVDecide in
 @[builtin_tactic Lean.Parser.Tactic.bvTrace]
-def evalBvTrace : Tactic := fun
+def evalBvTraceTactic : Tactic := fun
   | `(tactic| bv_decide?%$tk $cfgStx:optConfig) => do
-    let cfg := { (← elabBVDecideConfig cfgStx) with trimProofs := false }
-    let lratFile : System.FilePath ← BVTrace.getLratFileName
-    let ctx ← BVCheck.mkContext lratFile cfg
+    ensureBvDecide
+    let cfg ← elabBVDecideConfig cfgStx
+    let ctx ← mkContext cfg
     let g ← getMainGoal
-    let trace ← g.withContext do
-      bvDecide g ctx
-    /-
-    Ideally trace.lratCert would be the `ByteArray` version of the proof already and we just write
-    it. This isn't yet possible so instead we do the following:
-    1. Produce the proof in the tactic.
-    2. Skip trimming it in the tactic.
-    3. Run trimming on the LRAT file that was produced by the SAT solver directly, emitting the
-       correct binary format according to `sat.binaryProofs`.
-    TODO: Fix this hack:
-    1. Introduce `ByteArray` literals to the kernel.
-    2. Just return the fully trimmed proof in the format desired by the configuration from `bvDecide`.
-    3. Write it to the file directly.
-    -/
-    match trace.lratCert with
-    | none =>
-      let normalizeStx ← `(tactic| bv_normalize)
-      TryThis.addSuggestion tk normalizeStx (origSpan? := ← getRef)
-    | some .. =>
-      if ctx.config.trimProofs then
-        let lratPath := (← BVCheck.getSrcDir) / lratFile
-        let proof ← loadLRATProof lratPath
-        let trimmed ← IO.ofExcept <| LRAT.trim proof
-        dumpLRATProof lratPath trimmed cfg.binaryProofs
-      let bvCheckStx ← `(tactic| bv_check $cfgStx:optConfig $(quote lratFile.toString))
-      TryThis.addSuggestion tk bvCheckStx (origSpan? := ← getRef)
+    Meta.Sym.SymM.run do
+      match ← evalBvTrace g ctx with
+      | .normalize =>
+        let normalizeStx ← `(tactic| bv_normalize $cfgStx:optConfig)
+        TryThis.addSuggestion tk normalizeStx (origSpan? := ← getRef)
+      | .check lratFile =>
+        let bvCheckStx ← `(tactic| bv_check $cfgStx:optConfig $(quote lratFile.toString))
+        TryThis.addSuggestion tk bvCheckStx (origSpan? := ← getRef)
   | _ => throwUnsupportedSyntax
 
 end BVTrace

--- a/src/Lean/Elab/Tactic/BVDecide/Normalize.lean
+++ b/src/Lean/Elab/Tactic/BVDecide/Normalize.lean
@@ -7,6 +7,7 @@ module
 prelude
 public import Lean.Meta.Tactic.BVDecide.Normalize
 import Lean.Meta.Sym.Util
+import Lean.Elab.Tactic.BVDecide.BVDecide
 
 namespace Lean.Elab.Tactic.BVDecide
 namespace Normalize
@@ -14,6 +15,7 @@ namespace Normalize
 @[builtin_tactic Lean.Parser.Tactic.bvNormalize]
 def evalBVNormalize : Tactic := fun
   | `(tactic| bv_normalize $cfg:optConfig) => do
+    ensureBvDecide
     let cfg ← Meta.Tactic.BVDecide.elabBVDecideConfig cfg
     let g ← getMainGoal
     let (_, state) ← Meta.Sym.SymM.run do

--- a/src/Lean/Elab/Tactic/Grind.lean
+++ b/src/Lean/Elab/Tactic/Grind.lean
@@ -25,3 +25,4 @@ public import Lean.Elab.Tactic.Grind.RegisterSymSimp
 public import Lean.Elab.Tactic.Grind.DSimprocDSL
 public import Lean.Elab.Tactic.Grind.DSimprocDSLBuiltin
 public import Lean.Elab.Tactic.Grind.RegisterSymDSimp
+public import Lean.Elab.Tactic.Grind.BVDecide

--- a/src/Lean/Elab/Tactic/Grind/BVDecide.lean
+++ b/src/Lean/Elab/Tactic/Grind/BVDecide.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Henrik Böving
+-/
+module
+
+prelude
+import Lean.Elab.Tactic.Grind.Basic
+import Lean.Meta.Tactic.BVDecide.Main
+import Lean.Elab.Tactic.BVDecide.BVTrace
+import Lean.Meta.Tactic.BVDecide.Normalize
+
+/-!
+This module provides the implementation of the `bv_decide` family of tactics in `sym =>` mode.
+-/
+
+namespace Lean.Elab.Tactic.Grind
+
+def elabBVDecideConfig (cfg : TSyntax `Lean.Parser.Tactic.optConfig) (goal : MVarId)
+    (elaborator : Name) : TermElabM BVDecide.BVDecideConfig := do
+  Meta.Tactic.BVDecide.elabBVDecideConfig cfg
+    |>.run { elaborator }
+    |>.run' { goals := [goal] }
+
+open Meta.Tactic.BVDecide
+
+@[builtin_grind_tactic Parser.Tactic.Grind.bvDecide] def evalBvDecide : GrindTactic
+  | `(grind| bv_decide $cfg:optConfig) => do
+    ensureSym
+    BVDecide.ensureBvDecide
+    let g ← getMainGoal
+    let cfg ← elabBVDecideConfig cfg g.mvarId `bv_decide
+    IO.FS.withTempFile fun _ lratFile => do
+      let cfg ← TacticContext.new lratFile cfg
+      discard <| liftSymM <| bvDecide g.mvarId cfg
+      replaceMainGoal []
+  | _ => throwUnsupportedSyntax
+
+@[builtin_grind_tactic Parser.Tactic.Grind.bvTrace] def evalBvTrace : GrindTactic
+  | `(grind| bv_decide?%$tk $cfgStx:optConfig) => do
+    ensureSym
+    BVDecide.ensureBvDecide
+    let g ← getMainGoal
+    let cfg ← elabBVDecideConfig cfgStx g.mvarId `bv_decide?
+    let ctx ← BVDecide.BVTrace.mkContext cfg
+    match ← liftSymM <| BVDecide.BVTrace.evalBvTrace g.mvarId ctx with
+    | .normalize =>
+      let normalizeStx ← `(grind| bv_normalize $cfgStx:optConfig)
+      Meta.Tactic.TryThis.addSuggestion tk normalizeStx (origSpan? := ← getRef)
+    | .check lratFile =>
+      let bvCheckStx ← `(grind| bv_check $cfgStx:optConfig $(quote lratFile.toString))
+      Meta.Tactic.TryThis.addSuggestion tk bvCheckStx (origSpan? := ← getRef)
+    replaceMainGoal []
+  | _ => throwUnsupportedSyntax
+
+@[builtin_grind_tactic Parser.Tactic.Grind.bvCheck] def evalBvCheck : GrindTactic
+  | `(grind| bv_check%$tk $cfgStx:optConfig $path:str) => do
+    ensureSym
+    BVDecide.ensureBvDecide
+    let g ← getMainGoal
+    let cfg ← elabBVDecideConfig cfgStx g.mvarId `bv_check
+    let ctx ← BVDecide.BVCheck.mkContext path.getString cfg
+    liftSymM <| BVDecide.BVCheck.evalBvCheck g.mvarId ctx do
+      let bvNormalizeStx ← `(grind| bv_normalize $cfgStx)
+      logWarning m!"This goal can be closed by only applying bv_normalize, no need to keep the LRAT proof around."
+      Meta.Tactic.TryThis.addSuggestion tk bvNormalizeStx (origSpan? := ← getRef)
+    replaceMainGoal []
+  | _ => throwUnsupportedSyntax
+
+@[builtin_grind_tactic Parser.Tactic.Grind.bvNormalize]
+def evalBVNormalize : GrindTactic := fun
+  | `(grind| bv_normalize $cfg:optConfig) => do
+    ensureSym
+    BVDecide.ensureBvDecide
+    let g ← getMainGoal
+    let cfg ← elabBVDecideConfig cfg g.mvarId `bv_normalize
+    let (_, state) ← liftSymM <| Meta.Tactic.BVDecide.Normalize.bvNormalize.run cfg g.mvarId
+    if ← state.goal.isAssigned then
+      replaceMainGoal []
+    else
+      throwError "`bv_normalize` failed to close the goal"
+  | _ => throwUnsupportedSyntax
+
+end Lean.Elab.Tactic.Grind

--- a/src/Lean/Meta/Tactic/BVDecide/Main.lean
+++ b/src/Lean/Meta/Tactic/BVDecide/Main.lean
@@ -35,20 +35,19 @@ public structure Result where
 Try to close `g` using a bitblaster. Return either a `CounterExample` if one is found or a `Result`
 if `g` is proven.
 -/
-public def bvDecide' (g : MVarId) (ctx : TacticContext) : MetaM (Except CounterExample Result) := do
-  Sym.SymM.run do
-    Normalize.PreProcessM.run' ctx.config g do
-      let solved ← Normalize.bvNormalize
-      if solved then return .ok ⟨none⟩
+public def bvDecide' (g : MVarId) (ctx : TacticContext) : Sym.SymM (Except CounterExample Result) := do
+  Normalize.PreProcessM.run' ctx.config g do
+    let solved ← Normalize.bvNormalize
+    if solved then return .ok ⟨none⟩
 
-      match ← bvUnsat (← Normalize.PreProcessM.getGoal) (← Normalize.PreProcessM.getHyps) ctx with
-      | .ok lratCert => return .ok ⟨some lratCert⟩
-      | .error counterExample => return .error counterExample
+    match ← bvUnsat (← Normalize.PreProcessM.getGoal) (← Normalize.PreProcessM.getHyps) ctx with
+    | .ok lratCert => return .ok ⟨some lratCert⟩
+    | .error counterExample => return .error counterExample
 
 /--
 Call `bvDecide'` and throw a pretty error if a counter example ends up being produced.
 -/
-public def bvDecide (g : MVarId) (ctx : TacticContext) : MetaM Result := do
+public def bvDecide (g : MVarId) (ctx : TacticContext) : Sym.SymM Result := do
   match ← bvDecide' g ctx with
   | .ok result => return result
   | .error counterExample =>

--- a/src/Std/Tactic/BVDecide/Syntax.lean
+++ b/src/Std/Tactic/BVDecide/Syntax.lean
@@ -97,31 +97,3 @@ structure BVDecideConfig where
   solverMode : SolverMode := .proof
 
 end Lean.Elab.Tactic.BVDecide
-
-
-namespace Lean.Parser
-
-namespace Tactic
-
-/--
-This tactic works just like `bv_decide` but skips calling a SAT solver by using a proof that is
-already stored on disk. It is called with the name of an LRAT file in the same directory as the
-current Lean file:
-```
-bv_check "proof.lrat"
-```
--/
-syntax (name := bvCheck) "bv_check " optConfig str : tactic
-
-@[tactic_alt bvDecideMacro]
-syntax (name := bvDecide) "bv_decide" optConfig : tactic
-
-
-@[tactic_alt bvTraceMacro]
-syntax (name := bvTrace) "bv_decide?" optConfig : tactic
-
-@[tactic_alt bvNormalizeMacro]
-syntax (name := bvNormalize) "bv_normalize" optConfig : tactic
-
-end Tactic
-end Lean.Parser

--- a/tests/elab/bv_import.lean
+++ b/tests/elab/bv_import.lean
@@ -1,0 +1,13 @@
+/-! Tests import error messages for bv_decide -/
+
+
+/-- error: to use `bv_decide`, please include `import Std.Tactic.BVDecide` -/
+#guard_msgs in
+example (x : BitVec 8) : x - 1 + 1 = x := by
+  bv_decide
+
+/-- error: to use `bv_decide`, please include `import Std.Tactic.BVDecide` -/
+#guard_msgs in
+example (x : BitVec 8) : x - 1 + 1 = x := by
+  sym =>
+    bv_decide

--- a/tests/elab/bv_sym.lean
+++ b/tests/elab/bv_sym.lean
@@ -1,0 +1,28 @@
+import Std.Tactic.BVDecide
+
+/-!
+Test for `bv_decide` in `sym =>` mode.
+-/
+
+def optimized (x : BitVec 32) : BitVec 32 :=
+  let x := x - ((x >>> 1) &&& 0x55555555);
+  let x := (x &&& 0x33333333) + ((x >>> 2) &&& 0x33333333);
+  let x := (x + (x >>> 4)) &&& 0x0F0F0F0F;
+  let x := x + (x >>> 8);
+  let x := x + (x >>> 16);
+  x &&& 0x0000003F
+
+example : optimized x = BitVec.cpop x := by
+  sym =>
+    simp [optimized.eq_def]
+    bv_decide
+
+example {x : BitVec 16} : x + 1 - 1 = x := by
+  sym =>
+    bv_normalize
+
+/-- error: tactic is only available in `sym =>` mode -/
+#guard_msgs in
+example {x : BitVec 16} : x + 1 - 1 = x := by
+  grind =>
+    bv_normalize


### PR DESCRIPTION
This PR makes `bv_decide` available from within `sym =>` mode.