### PR TITLE
refactor: decouple loop state and element universes in `Std.Internal.Do` specs

### DIFF
--- a/src/Std/Internal/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Internal/Do/Triple/SpecLemmas.lean
@@ -617,7 +617,7 @@ open Lean.Order
 
 universe u₁ u₂ v uₚ uₑ
 
-variable {α : Type u₁} {β : Type (max u₁ u₂)} {m : Type (max u₁ u₂) → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
+variable {α : Type u₁} {β : Type u₂} {m : Type u₂ → Type v} {Pred : Type uₚ} {EPred : Type uₑ}
 variable [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
 
 /-- The type of loop invariants used by the specifications of `for ... in ...` loops.


### PR DESCRIPTION
This PR lets a loop's state live in a different universe than its elements in the `Std.Internal.Do` specification lemmas.

The state was bound as ``β : Type (max u₁ u₂)`` over elements ``α : Type u₁``, so a specification generic in the container type had to solve ``max ?u₁ ?u₂ =?= max u v`` and failed to build a backward rule. Every previous instantiation is recovered at ``u₂ := max u₁ u₂``.