### PR TITLE
feat: `lean_initializing`

### DIFF
--- a/src/Lean/ImportingFlag.lean
+++ b/src/Lean/ImportingFlag.lean
@@ -38,6 +38,7 @@ def isInitializerExecutionEnabled : BaseIO Bool :=
 We say Lean is "initializing" when it is executing `builtin_initialize` declarations or importing modules.
 Recall that Lean executes `initialize` declarations while importing modules.
 -/
+@[export lean_initializing]
 def initializing : BaseIO Bool :=
   IO.initializing <||> importingRef.get
 

--- a/src/Lean/ImportingFlag.lean
+++ b/src/Lean/ImportingFlag.lean
@@ -38,7 +38,7 @@ def isInitializerExecutionEnabled : BaseIO Bool :=
 We say Lean is "initializing" when it is executing `builtin_initialize` declarations or importing modules.
 Recall that Lean executes `initialize` declarations while importing modules.
 -/
-@[export lean_initializing]
+@[export lean_initializing] -- for downstream FFI
 def initializing : BaseIO Bool :=
   IO.initializing <||> importingRef.get
 


### PR DESCRIPTION
This PR exports `Lean.initializing` as `lean_initializing`. This allows FFI code to inspect whether Lean is initializing, complementing the recently added `lean_set_initializing`.