### PR TITLE
feat: add linter for simp arguments triggering TC synthesis at every subterm

### DIFF
--- a/src/Init/Data/Int/DivMod/Lemmas.lean
+++ b/src/Init/Data/Int/DivMod/Lemmas.lean
@@ -2981,7 +2981,7 @@ protected theorem dvd_eq_true_of_mod_eq_zero {a b : Int} (h : b % a == 0) : (a â
   simp [Int.dvd_of_emod_eq_zero, eq_of_beq h]
 
 protected theorem dvd_eq_false_of_mod_ne_zero {a b : Int} (h : b % a != 0) : (a âˆ£ b) = False := by
-  simp [eq_of_beq] at h
+  simp at h
   simp [Int.dvd_iff_emod_eq_zero, h]
 
 theorem ext_ediv_emod {n a b : Int} (h0 : a / n = b / n) (h1 : a % n = b % n) : a = b :=

--- a/src/Lean/Elab/Tactic/Simp.lean
+++ b/src/Lean/Elab/Tactic/Simp.lean
@@ -265,6 +265,55 @@ def ElabSimpArgResult.simpTheorems : ElabSimpArgResult → Array SimpTheorem
     return thms
   | _ => #[]
 
+register_builtin_option linter.blanketSimpArgs : Bool := {
+  defValue := true,
+  descr := "enable the linter that warns about `simp` arguments retrieved at every subterm.\n\
+    \n\
+    Matching the left-hand side of `eq_zero {α} [Zero α] [Subsingleton α] (a : α) : a = 0` against \
+    a subterm assigns `α` to the type of that subterm, so `simp [eq_zero]` synthesizes `Zero` and \
+    `Subsingleton` at every subterm it visits. Write `simp [eq_zero (α := Nat)]` or \
+    `simp [eq_zero n]` to determine them once instead."
+}
+
+/-- The side of `concl` that `simp` rewrites, when `concl` is an equality, an `Iff` or an `HEq`. -/
+private def lhsOf? (concl : Expr) : Option Expr :=
+  if let some (_, lhs, _) := concl.eq? then some lhs
+  else if let some (lhs, _) := concl.iff? then some lhs
+  else if let some (_, lhs, _, _) := concl.heq? then some lhs
+  else none
+
+/--
+Whether `simp` retrieves `thm` at every visited subterm and synthesizes instances at each match.
+
+Matching the left-hand side of `eq_zero {α} [Zero α] [Subsingleton α] (a : α) : a = 0` against a
+subterm assigns `α` to the type of that subterm, so every match succeeds and queries `Zero` and
+`Subsingleton` at a type not seen before.
+-/
+private def isBlanketSimpTheorem (thm : SimpTheorem) : MetaM Bool := do
+  match thm.keys with
+  | #[.star] =>
+    forallTelescope (← inferType (← thm.getValue)) fun xs concl => do
+      let some lhs := lhsOf? concl | return false
+      unless lhs.isFVar && xs.contains lhs do return false
+      let lhsType ← lhs.fvarId!.getType
+      unless lhsType.isSort || (lhsType.isFVar && xs.contains lhsType) do return false
+      xs.anyM fun x => do
+        let decl ← x.fvarId!.getDecl
+        return decl.binderInfo == .instImplicit || (← isProp decl.type)
+  | _ => return false
+
+/-- Warns about each argument in `simpArgs` that `simp` retrieves at every visited subterm. -/
+def warnBlanketSimpArgs (simpArgs : Array (Syntax × ElabSimpArgResult)) : MetaM Unit := do
+  unless Linter.getLinterValue linter.blanketSimpArgs (← Linter.getLinterOptions) do return
+  for (ref, arg) in simpArgs do
+    if ← arg.simpTheorems.anyM isBlanketSimpTheorem then
+      Linter.logLint linter.blanketSimpArgs ref
+        m!"The left-hand side of this theorem is a variable, so `simp` retrieves the theorem \
+          at every visited subterm and synthesizes its instance arguments at each \
+          match:{indentD ref}\n\
+          Fixing the implicit arguments, as in `(α := Nat)`, or applying the theorem to a \
+          term synthesizes those instances once instead, while the theorem is elaborated."
+
 private def elabDeclToUnfoldOrTheorem (config : Meta.ConfigWithKey) (id : Origin)
     (e : Expr) (post : Bool) (inv : Bool) (kind : SimpKind) : MetaM ElabSimpArgResult := do
   if e.isConst then
@@ -468,6 +517,7 @@ def elabSimpArgs (stx : Syntax) (ctx : Simp.Context) (simprocs : Simp.SimprocsAr
         if !ignoreStarArg && starArg then
           ctx ← applyStarArg ctx
 
+        warnBlanketSimpArgs args
         return { ctx, simprocs, simpArgs := args}
     -- If recovery is disabled, then we want simp argument elaboration failures to be exceptions.
     -- This affects `addSimpTheorem`.

--- a/tests/elab/blanketSimpArgs.lean
+++ b/tests/elab/blanketSimpArgs.lean
@@ -1,0 +1,66 @@
+/-!
+  # The `linter.blanketSimpArgs` linter
+
+  The left-hand side of `eq_zero` below is the variable `a`, so `simp [eq_zero]` retrieves
+  `eq_zero` at every subterm it visits and synthesizes `OfNat` and `Subsingleton` instances at
+  each match. Writing `eq_zero (α := α)` or `eq_zero x` synthesizes those instances once instead,
+  while elaborating the argument.
+-/
+
+-- The test harness runs with `linter.all=false`.
+set_option linter.blanketSimpArgs true
+
+theorem eq_zero {α : Type} [OfNat α 0] [Subsingleton α] (a : α) : a = (0 : α) :=
+  Subsingleton.elim ..
+
+/--
+warning: The left-hand side of this theorem is a variable, so `simp` retrieves the theorem at every visited subterm and synthesizes its instance arguments at each match:
+  eq_zero
+Fixing the implicit arguments, as in `(α := Nat)`, or applying the theorem to a term synthesizes those instances once instead, while the theorem is elaborated.
+
+Note: This linter can be disabled with `set_option linter.blanketSimpArgs false`
+-/
+#guard_msgs in
+example {α : Type} [OfNat α 0] [Subsingleton α] (x : α) : x = 0 := by
+  simp [eq_zero]
+
+-- Fixing the implicit arguments determines the side conditions once, so the argument is
+-- confined to that type.
+#guard_msgs in
+example {α : Type} [OfNat α 0] [Subsingleton α] (x : α) : x = 0 := by
+  simp [eq_zero (α := α)]
+
+-- Applying the theorem to a term likewise.
+#guard_msgs in
+example {α : Type} [OfNat α 0] [Subsingleton α] (x : α) : x = 0 := by
+  simp [eq_zero x]
+
+-- A left-hand side of fixed type only matches subterms of that type, so the instance surviving
+-- elaboration is synthesized at one type throughout.
+class Foo (n : Nat) : Prop where dummy : True
+instance : Foo 0 := ⟨trivial⟩
+
+theorem ground_inst [Foo 0] (a : Nat) : a + 0 = a := Nat.add_zero a
+
+#guard_msgs in
+example (n : Nat) : n + 0 = n := by
+  simp [ground_inst]
+
+-- An ordinary rewrite has a head symbol in its key.
+#guard_msgs in
+example (n : Nat) : id n = n := by
+  simp [id_eq]
+
+-- Definitions passed to `simp` are unfolded rather than used as rewrites, so a result type
+-- that is a variable, as in `Or.by_cases`, does not make them blanket rewrites.
+def fallback {α : Type} [Inhabited α] (_ : Nat) : α := default
+
+#guard_msgs in
+example : fallback (α := Nat) 3 = default := by
+  simp [fallback]
+
+-- The linter can be turned off.
+set_option linter.blanketSimpArgs false in
+#guard_msgs in
+example {α : Type} [OfNat α 0] [Subsingleton α] (x : α) : x = 0 := by
+  simp [eq_zero]


### PR DESCRIPTION
This PR adds the `linter.blanketSimpArgs` linter, which warns about a `simp` argument whose left-hand side is a variable, such as `eq_zero {α} [OfNat α 0] [Subsingleton α] (a : α) : a = 0`. Such an argument is tried at every subterm and synthesizes its instances at each match, which can dominate the elaboration time of a proof; the warning suggests determining those instances at the use site instead, by fixing the implicit arguments or applying the theorem to a term.

The check runs where `simp` arguments are elaborated. See also https://github.com/leanprover-community/mathlib4/pull/42056/, where this linter was first proposed and rejected because of its overhead. Hooking directly into the elaborator is much more efficient, by contrast.
