### PR TITLE
perf: keep Lean's heap on transparent huge pages across purges

### DIFF
--- a/src/runtime/alloc.cpp
+++ b/src/runtime/alloc.cpp
@@ -18,6 +18,13 @@ Author: Leonardo de Moura
 namespace lean {
 
 void initialize_alloc() {
+#ifdef LEAN_MIMALLOC
+    // Raise the minimal purge size to the platform's large page size: a `MADV_DONTNEED` over a
+    // smaller range shatters a transparent-huge-page-backed region back into base pages, and Lean
+    // frees far more than it returns to the OS. `set_default` keeps `MIMALLOC_ALLOW_THP` in the
+    // environment authoritative.
+    mi_option_set_default(mi_option_allow_thp, 2);
+#endif
 }
 
 void finalize_alloc() {

--- a/src/runtime/alloc.cpp
+++ b/src/runtime/alloc.cpp
@@ -19,11 +19,10 @@ namespace lean {
 
 void initialize_alloc() {
 #ifdef LEAN_MIMALLOC
-    // Raise the minimal purge size to the platform's large page size: a `MADV_DONTNEED` over a
-    // smaller range shatters a transparent-huge-page-backed region back into base pages, and Lean
-    // frees far more than it returns to the OS. `set_default` keeps `MIMALLOC_ALLOW_THP` in the
-    // environment authoritative.
-    mi_option_set_default(mi_option_allow_thp, 2);
+    // MEASUREMENT PROBE, DO NOT MERGE: `0` disables transparent huge pages for Lean entirely, so a
+    // benchmark run compares THP-off against the stock THP-on baseline. Locally that costs 2.7% of
+    // cycles; no regression means the benchmark machine has no THP and this option is inert there.
+    mi_option_set_default(mi_option_allow_thp, 0);
 #endif
 }
 


### PR DESCRIPTION
This PR keeps more of Lean's heap backed by transparent huge pages, reducing dTLB misses and page faults during elaboration. Meaning it gets faster.

mimalloc purges with `MADV_DONTNEED`, which shatters a THP-backed region back into 4 KiB pages whenever the purged range is smaller than a huge page. Setting `allow_thp=2` raises `minimal_purge_size` to the platform large-page size so those sub-huge-page purges are skipped. Expressed as `allow_thp=2` rather than a literal size because it resolves to `_mi_os_large_page_size()` and so adapts per platform. `mi_option_set_default` leaves `MIMALLOC_ALLOW_THP` in the environment authoritative.

Measured on `tests/elab_bench/riscv-ast.lean` (`-j1`, 16 interleaved rounds): dTLB-load-misses -45.7%, page faults -56%, cycles -1.2% median with peak RSS unchanged. On a 32-process batch of all `elab_bench` files: -0.5% wall for +3% peak system memory.
