### PR TITLE
feat: allow users to supply complex types to `bv_decide`

### DIFF
--- a/src/Init/Grind/Interactive.lean
+++ b/src/Init/Grind/Interactive.lean
@@ -389,16 +389,16 @@ This is a variant of `cbv` that only works in `sym =>` mode.
 syntax (name := symCbv) "cbv" : grind
 
 @[inherit_doc Lean.Parser.Tactic.bvNormalize]
-syntax (name := bvNormalize) "bv_normalize" optConfig : grind
+syntax (name := bvNormalize) "bv_normalize" optConfig (bvTypes)? : grind
 
 @[inherit_doc Lean.Parser.Tactic.bvDecide]
-syntax (name := bvDecide) "bv_decide" optConfig : grind
+syntax (name := bvDecide) "bv_decide" optConfig (bvTypes)? : grind
 
 @[inherit_doc Lean.Parser.Tactic.bvTrace]
-syntax (name := bvTrace) "bv_decide?" optConfig : grind
+syntax (name := bvTrace) "bv_decide?" optConfig (bvTypes)? : grind
 
 @[inherit_doc Lean.Parser.Tactic.bvCheck]
-syntax (name := bvCheck) "bv_check " optConfig str : grind
+syntax (name := bvCheck) "bv_check" optConfig (bvTypes)? ppSpace str : grind
 
 end Grind
 end Lean.Parser.Tactic

--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -1872,6 +1872,14 @@ The suggestions are printed in the order of their confidence, from highest to lo
 syntax (name := suggestions) "suggestions" : tactic
 
 /--
+`types [T₁, ..., Tₙ]` restricts the structure and enum inductive analysis of the `bv_decide` family
+of tactics to `T₁, ..., Tₙ`. Every other structure or enum inductive is treated as an opaque
+variable, even if the analysis would usually pick it up. This is useful to keep preprocessing
+tractable on goals that mention many types of which only a few matter for the proof.
+-/
+syntax bvTypes := &" types" " [" ident,* "]"
+
+/--
 This tactic works just like `bv_decide` but skips calling a SAT solver by using a proof that is
 already stored on disk. It is called with the name of an LRAT file in the same directory as the
 current Lean file:
@@ -1879,7 +1887,7 @@ current Lean file:
 bv_check "proof.lrat"
 ```
 -/
-syntax (name := bvCheck) "bv_check " optConfig str : tactic
+syntax (name := bvCheck) "bv_check" optConfig (bvTypes)? ppSpace str : tactic
 
 /--
 Close fixed-width `BitVec` and `Bool` goals by obtaining a proof from an external SAT solver and
@@ -1904,18 +1912,21 @@ In order to avoid calling a SAT solver every time, the proof can be cached with 
 If solving your problem relies inherently on using associativity or commutativity, consider enabling
 the `bv.ac_nf` option.
 
+`bv_decide types [T₁, ..., Tₙ]` restricts the analysis of structures and enum inductives to
+`T₁, ..., Tₙ`, treating all other ones as opaque variables.
+
 Note: `bv_decide` trusts the correctness of the code generator and adds a axioms asserting its result.
 
 Note: include `import Std.Tactic.BVDecide`
 -/
-syntax (name := bvDecide) "bv_decide" optConfig : tactic
+syntax (name := bvDecide) "bv_decide" optConfig (bvTypes)? : tactic
 
 /--
 Suggest a proof script for a `bv_decide` tactic call. Useful for caching LRAT proofs.
 
 Note: include `import Std.Tactic.BVDecide`
 -/
-syntax (name := bvTrace) "bv_decide?" optConfig : tactic
+syntax (name := bvTrace) "bv_decide?" optConfig (bvTypes)? : tactic
 
 /--
 Run the normalization procedure of `bv_decide` only. Sometimes this is enough to solve basic
@@ -1923,7 +1934,7 @@ Run the normalization procedure of `bv_decide` only. Sometimes this is enough to
 
 Note: include `import Std.Tactic.BVDecide`
 -/
-syntax (name := bvNormalize) "bv_normalize" optConfig : tactic
+syntax (name := bvNormalize) "bv_normalize" optConfig (bvTypes)? : tactic
 
 /--
 `massumption` is like `assumption`, but operating on a stateful `Std.Do.SPred` goal.

--- a/src/Lean/Elab/Tactic/BVDecide/BVCheck.lean
+++ b/src/Lean/Elab/Tactic/BVDecide/BVCheck.lean
@@ -35,9 +35,10 @@ def getSrcDir : TermElabM System.FilePath := do
     | throwError "cannot compute parent directory of `{srcPath}`"
   return srcDir
 
-def mkContext (lratPath : System.FilePath) (cfg : BVDecideConfig) : TermElabM TacticContext := do
+def mkContext (lratPath : System.FilePath) (cfg : BVDecideConfig)
+    (types : Option (Array Name) := none) : TermElabM TacticContext := do
   let lratPath := (← getSrcDir) / lratPath
-  TacticContext.new lratPath cfg
+  TacticContext.new lratPath cfg types
 
 @[inherit_doc Lean.Parser.Tactic.bvCheck]
 def bvCheck (g : MVarId) (hypotheses : Array Normalize.Hyp) (ctx : TacticContext) :
@@ -47,7 +48,7 @@ def bvCheck (g : MVarId) (hypotheses : Array Normalize.Hyp) (ctx : TacticContext
 
 def evalBvCheck (g : MVarId) (ctx : TacticContext) (warn : MetaM Unit) :
     Meta.Sym.SymM Unit := do
-  Normalize.PreProcessM.run' ctx.config g do
+  Normalize.PreProcessM.run' ctx.preProcessContext g do
     if ← Normalize.bvNormalize then
       warn
     else
@@ -56,13 +57,14 @@ def evalBvCheck (g : MVarId) (ctx : TacticContext) (warn : MetaM Unit) :
 open Lean.Meta.Tactic in
 @[builtin_tactic Lean.Parser.Tactic.bvCheck]
 def evalBvCheckTactic : Tactic := fun
-  | `(tactic| bv_check%$tk $cfgStx:optConfig $path:str) => do
+  | `(tactic| bv_check%$tk $cfgStx:optConfig $[$typesStx:bvTypes]? $path:str) => do
     ensureBvDecide
     let cfg ← elabBVDecideConfig cfgStx
-    let ctx ← mkContext path.getString cfg
+    let types ← elabBVDecideTypes typesStx
+    let ctx ← mkContext path.getString cfg types
     let g ← getMainGoal
     Meta.Sym.SymM.run <| evalBvCheck g ctx do
-      let bvNormalizeStx ← `(tactic| bv_normalize $cfgStx)
+      let bvNormalizeStx ← `(tactic| bv_normalize $cfgStx $[$typesStx:bvTypes]?)
       logWarning m!"This goal can be closed by only applying bv_normalize, no need to keep the LRAT proof around."
       TryThis.addSuggestion tk bvNormalizeStx (origSpan? := ← getRef)
   | _ => throwUnsupportedSyntax

--- a/src/Lean/Elab/Tactic/BVDecide/BVDecide.lean
+++ b/src/Lean/Elab/Tactic/BVDecide/BVDecide.lean
@@ -25,11 +25,12 @@ def ensureBvDecide : CoreM Unit := do
 
 @[builtin_tactic Lean.Parser.Tactic.bvDecide]
 def evalBvDecide : Tactic := fun
-  | `(tactic| bv_decide $cfg:optConfig) => do
+  | `(tactic| bv_decide $cfg:optConfig $[$types:bvTypes]?) => do
     ensureBvDecide
     let cfg ← elabBVDecideConfig cfg
+    let types ← elabBVDecideTypes types
     IO.FS.withTempFile fun _ lratFile => do
-      let cfg ← TacticContext.new lratFile cfg
+      let cfg ← TacticContext.new lratFile cfg types
       liftMetaFinishingTactic fun g => do
         discard <| Meta.Sym.SymM.run <| bvDecide g cfg
   | _ => throwUnsupportedSyntax

--- a/src/Lean/Elab/Tactic/BVDecide/BVTrace.lean
+++ b/src/Lean/Elab/Tactic/BVDecide/BVTrace.lean
@@ -33,9 +33,10 @@ def getLratFileName : TermElabM System.FilePath := do
   let pos := (← getFileMap).toPosition (← getRefPos)
   return s!"{baseName}-{declName}-{pos.line}-{pos.column}.lrat"
 
-def mkContext (cfg : BVDecideConfig) : TermElabM TacticContext := do
+def mkContext (cfg : BVDecideConfig) (types : Option (Array Name) := none) :
+    TermElabM TacticContext := do
   let lratPath ← getLratFileName
-  BVCheck.mkContext lratPath cfg
+  BVCheck.mkContext lratPath cfg types
 
 inductive TraceResult where
   | normalize
@@ -71,18 +72,20 @@ open Lean.Meta.Tactic in
 open Lean.Meta.Tactic.BVDecide in
 @[builtin_tactic Lean.Parser.Tactic.bvTrace]
 def evalBvTraceTactic : Tactic := fun
-  | `(tactic| bv_decide?%$tk $cfgStx:optConfig) => do
+  | `(tactic| bv_decide?%$tk $cfgStx:optConfig $[$typesStx:bvTypes]?) => do
     ensureBvDecide
     let cfg ← elabBVDecideConfig cfgStx
-    let ctx ← mkContext cfg
+    let types ← elabBVDecideTypes typesStx
+    let ctx ← mkContext cfg types
     let g ← getMainGoal
     Meta.Sym.SymM.run do
       match ← evalBvTrace g ctx with
       | .normalize =>
-        let normalizeStx ← `(tactic| bv_normalize $cfgStx:optConfig)
+        let normalizeStx ← `(tactic| bv_normalize $cfgStx:optConfig $[$typesStx:bvTypes]?)
         TryThis.addSuggestion tk normalizeStx (origSpan? := ← getRef)
       | .check lratFile =>
-        let bvCheckStx ← `(tactic| bv_check $cfgStx:optConfig $(quote lratFile.toString))
+        let bvCheckStx ←
+          `(tactic| bv_check $cfgStx:optConfig $[$typesStx:bvTypes]? $(quote lratFile.toString))
         TryThis.addSuggestion tk bvCheckStx (origSpan? := ← getRef)
   | _ => throwUnsupportedSyntax
 

--- a/src/Lean/Elab/Tactic/BVDecide/Normalize.lean
+++ b/src/Lean/Elab/Tactic/BVDecide/Normalize.lean
@@ -14,12 +14,13 @@ namespace Normalize
 
 @[builtin_tactic Lean.Parser.Tactic.bvNormalize]
 def evalBVNormalize : Tactic := fun
-  | `(tactic| bv_normalize $cfg:optConfig) => do
+  | `(tactic| bv_normalize $cfg:optConfig $[$types:bvTypes]?) => do
     ensureBvDecide
     let cfg ← Meta.Tactic.BVDecide.elabBVDecideConfig cfg
+    let types ← Meta.Tactic.BVDecide.elabBVDecideTypes types
     let g ← getMainGoal
     let (_, state) ← Meta.Sym.SymM.run do
-      Meta.Tactic.BVDecide.Normalize.bvNormalize.run cfg g
+      Meta.Tactic.BVDecide.Normalize.bvNormalize.run { config := cfg, restrictedTypes := types } g
     if ← state.goal.isAssigned then
       replaceMainGoal []
     else

--- a/src/Lean/Elab/Tactic/Grind/BVDecide.lean
+++ b/src/Lean/Elab/Tactic/Grind/BVDecide.lean
@@ -26,43 +26,47 @@ def elabBVDecideConfig (cfg : TSyntax `Lean.Parser.Tactic.optConfig) (goal : MVa
 open Meta.Tactic.BVDecide
 
 @[builtin_grind_tactic Parser.Tactic.Grind.bvDecide] def evalBvDecide : GrindTactic
-  | `(grind| bv_decide $cfg:optConfig) => do
+  | `(grind| bv_decide $cfg:optConfig $[$types:bvTypes]?) => do
     ensureSym
     BVDecide.ensureBvDecide
     let g ← getMainGoal
     let cfg ← elabBVDecideConfig cfg g.mvarId `bv_decide
+    let types ← elabBVDecideTypes types
     IO.FS.withTempFile fun _ lratFile => do
-      let cfg ← TacticContext.new lratFile cfg
+      let cfg ← TacticContext.new lratFile cfg types
       discard <| liftSymM <| bvDecide g.mvarId cfg
       replaceMainGoal []
   | _ => throwUnsupportedSyntax
 
 @[builtin_grind_tactic Parser.Tactic.Grind.bvTrace] def evalBvTrace : GrindTactic
-  | `(grind| bv_decide?%$tk $cfgStx:optConfig) => do
+  | `(grind| bv_decide?%$tk $cfgStx:optConfig $[$typesStx:bvTypes]?) => do
     ensureSym
     BVDecide.ensureBvDecide
     let g ← getMainGoal
     let cfg ← elabBVDecideConfig cfgStx g.mvarId `bv_decide?
-    let ctx ← BVDecide.BVTrace.mkContext cfg
+    let types ← elabBVDecideTypes typesStx
+    let ctx ← BVDecide.BVTrace.mkContext cfg types
     match ← liftSymM <| BVDecide.BVTrace.evalBvTrace g.mvarId ctx with
     | .normalize =>
-      let normalizeStx ← `(grind| bv_normalize $cfgStx:optConfig)
+      let normalizeStx ← `(grind| bv_normalize $cfgStx:optConfig $[$typesStx:bvTypes]?)
       Meta.Tactic.TryThis.addSuggestion tk normalizeStx (origSpan? := ← getRef)
     | .check lratFile =>
-      let bvCheckStx ← `(grind| bv_check $cfgStx:optConfig $(quote lratFile.toString))
+      let bvCheckStx ←
+        `(grind| bv_check $cfgStx:optConfig $[$typesStx:bvTypes]? $(quote lratFile.toString))
       Meta.Tactic.TryThis.addSuggestion tk bvCheckStx (origSpan? := ← getRef)
     replaceMainGoal []
   | _ => throwUnsupportedSyntax
 
 @[builtin_grind_tactic Parser.Tactic.Grind.bvCheck] def evalBvCheck : GrindTactic
-  | `(grind| bv_check%$tk $cfgStx:optConfig $path:str) => do
+  | `(grind| bv_check%$tk $cfgStx:optConfig $[$typesStx:bvTypes]? $path:str) => do
     ensureSym
     BVDecide.ensureBvDecide
     let g ← getMainGoal
     let cfg ← elabBVDecideConfig cfgStx g.mvarId `bv_check
-    let ctx ← BVDecide.BVCheck.mkContext path.getString cfg
+    let types ← elabBVDecideTypes typesStx
+    let ctx ← BVDecide.BVCheck.mkContext path.getString cfg types
     liftSymM <| BVDecide.BVCheck.evalBvCheck g.mvarId ctx do
-      let bvNormalizeStx ← `(grind| bv_normalize $cfgStx)
+      let bvNormalizeStx ← `(grind| bv_normalize $cfgStx $[$typesStx:bvTypes]?)
       logWarning m!"This goal can be closed by only applying bv_normalize, no need to keep the LRAT proof around."
       Meta.Tactic.TryThis.addSuggestion tk bvNormalizeStx (origSpan? := ← getRef)
     replaceMainGoal []
@@ -70,12 +74,14 @@ open Meta.Tactic.BVDecide
 
 @[builtin_grind_tactic Parser.Tactic.Grind.bvNormalize]
 def evalBVNormalize : GrindTactic := fun
-  | `(grind| bv_normalize $cfg:optConfig) => do
+  | `(grind| bv_normalize $cfg:optConfig $[$types:bvTypes]?) => do
     ensureSym
     BVDecide.ensureBvDecide
     let g ← getMainGoal
     let cfg ← elabBVDecideConfig cfg g.mvarId `bv_normalize
-    let (_, state) ← liftSymM <| Meta.Tactic.BVDecide.Normalize.bvNormalize.run cfg g.mvarId
+    let types ← elabBVDecideTypes types
+    let (_, state) ← liftSymM <|
+      Meta.Tactic.BVDecide.Normalize.bvNormalize.run { config := cfg, restrictedTypes := types } g.mvarId
     if ← state.goal.isAssigned then
       replaceMainGoal []
     else

--- a/src/Lean/Meta/Tactic/BVDecide/Attr.lean
+++ b/src/Lean/Meta/Tactic/BVDecide/Attr.lean
@@ -40,6 +40,34 @@ register_builtin_option sat.solver : String := {
 
 declare_config_elab elabBVDecideConfig Lean.Elab.Tactic.BVDecide.BVDecideConfig
 
+/--
+Elaborate the optional `types [T₁, ..., Tₙ]` clause of the `bv_decide` family of tactics. Returns
+`none` if the clause is absent, in which case the structure and enum analysis runs unrestricted.
+-/
+def elabBVDecideTypes (stx : Option (TSyntax ``Lean.Parser.Tactic.bvTypes)) :
+    CoreM (Option (Array Name)) := do
+  let some stx := stx | return none
+  let `(Lean.Parser.Tactic.bvTypes| types [$ids,*]) := stx
+    | throwErrorAt stx "unexpected `types` clause"
+  let mut types := #[]
+  for id in ids.getElems do
+    let declName ← Elab.realizeGlobalConstNoOverloadWithInfo id
+    unless (← isSupportedTypeAnalysisType declName) do
+      throwErrorAt id m!"`{declName}` cannot be used in a `types` clause, only non-recursive \
+        structures and enum inductives are supported"
+    unless types.contains declName do
+      types := types.push declName
+  return some types
+where
+  isSupportedTypeAnalysisType (declName : Name) : CoreM Bool := do
+    if ← isEnumType declName then
+      return true
+    let env ← getEnv
+    if !isStructure env declName then
+      return false
+    let .inductInfo info ← getConstInfo declName | return false
+    return !info.isRec
+
 builtin_initialize bvNormalizeExt : Sym.Simp.SymSimpExtension ←
   Sym.Simp.registerSymSimpAttr `bv_normalize "simp theorems used by bv_normalize"
 

--- a/src/Lean/Meta/Tactic/BVDecide/Main.lean
+++ b/src/Lean/Meta/Tactic/BVDecide/Main.lean
@@ -16,6 +16,10 @@ This module provides the implementation of the `bv_decide` frontend itself.
 -/
 namespace Lean.Meta.Tactic.BVDecide
 
+public def TacticContext.preProcessContext (ctx : TacticContext) : Normalize.PreProcessContext where
+  config := ctx.config
+  restrictedTypes := ctx.restrictedTypes
+
 def bvUnsat (g : MVarId) (hypotheses : Array Normalize.Hyp) (ctx : TacticContext) :
     Sym.SymM (Except CounterExample LratCert) :=
   M.run (hypotheses := hypotheses) do
@@ -36,7 +40,7 @@ Try to close `g` using a bitblaster. Return either a `CounterExample` if one is 
 if `g` is proven.
 -/
 public def bvDecide' (g : MVarId) (ctx : TacticContext) : Sym.SymM (Except CounterExample Result) := do
-  Normalize.PreProcessM.run' ctx.config g do
+  Normalize.PreProcessM.run' ctx.preProcessContext g do
     let solved ← Normalize.bvNormalize
     if solved then return .ok ⟨none⟩
 

--- a/src/Lean/Meta/Tactic/BVDecide/Normalize/Basic.lean
+++ b/src/Lean/Meta/Tactic/BVDecide/Normalize/Basic.lean
@@ -52,6 +52,12 @@ inductive MatchKind
   | enumWithDefault (info : InductiveVal) (ctors : Array ConstructorVal)
 
 /--
+The enum inductive that the match discriminates on.
+-/
+def MatchKind.getEnumInfo : MatchKind → InductiveVal
+  | .simpleEnum info .. | .enumWithDefault info .. => info
+
+/--
 Contains the result of the type analysis to be used in the structures and enums pass.
 -/
 structure TypeAnalysis where
@@ -111,6 +117,20 @@ instance : Hashable Hyp where
 instance : ToMessageData Hyp where
   toMessageData hyp := toMessageData hyp.type
 
+/--
+The immutable context of the `bv_normalize` preprocessing pipeline.
+-/
+structure PreProcessContext where
+  /--
+  The configuration that the tactic was called with.
+  -/
+  config : BVDecideConfig
+  /--
+  The types that the structure and enum analysis is restricted to, as provided by the `types`
+  clause. If this is `none` the analysis discovers the relevant types on its own.
+  -/
+  restrictedTypes : Option (Array Name) := none
+
 structure PreProcessState where
   /--
   Cache for the `Simp` component of the rewriter.
@@ -142,7 +162,7 @@ structure PreProcessState where
   -/
   didChange : Bool := false
 
-abbrev PreProcessM : Type → Type := ReaderT BVDecideConfig StateRefT PreProcessState Sym.SymM
+abbrev PreProcessM : Type → Type := ReaderT PreProcessContext StateRefT PreProcessState Sym.SymM
 
 namespace Hyp
 
@@ -162,7 +182,10 @@ end Hyp
 namespace PreProcessM
 
 @[inline]
-def getConfig : PreProcessM BVDecideConfig := read
+def getConfig : PreProcessM BVDecideConfig := return (← read).config
+
+@[inline]
+def getRestrictedTypes : PreProcessM (Option (Array Name)) := return (← read).restrictedTypes
 
 @[inline]
 def getGoal : PreProcessM MVarId := return (← get).goal
@@ -257,13 +280,13 @@ def markUninterestingConst (n : Name) : PreProcessM Unit := do
   modifyTypeAnalysis (fun s => { s with uninteresting := s.uninteresting.insert n })
 
 @[inline]
-def run (cfg : BVDecideConfig) (goal : MVarId) (x : PreProcessM α) :
+def run (ctx : PreProcessContext) (goal : MVarId) (x : PreProcessM α) :
     Sym.SymM (α × PreProcessState) := do
-  ReaderT.run x cfg |>.run { goal }
+  ReaderT.run x ctx |>.run { goal }
 
 @[inline]
-def run' (cfg : BVDecideConfig) (goal : MVarId) (x : PreProcessM α) : Sym.SymM α := do
-  ReaderT.run x cfg |>.run' { goal }
+def run' (ctx : PreProcessContext) (goal : MVarId) (x : PreProcessM α) : Sym.SymM α := do
+  ReaderT.run x ctx |>.run' { goal }
 
 def collectHypsFromGoal : PreProcessM Unit := do
   setDidChange

--- a/src/Lean/Meta/Tactic/BVDecide/Normalize/TypeAnalysis.lean
+++ b/src/Lean/Meta/Tactic/BVDecide/Normalize/TypeAnalysis.lean
@@ -135,17 +135,39 @@ public def addDefaultTypeAnalysisLemmas (methods : Sym.Simp.Methods) :
 
   return { methods with pre := methods.pre >> lemmas.rewrite }
 
+structure Context where
+  /--
+  Whether the user restricted the analysis to a fixed set of types through a `types` clause. In that
+  case the interesting structures and enums are seeded upfront and the analysis only discovers
+  matchers on top of them.
+  -/
+  restricted : Bool
+
+abbrev AnalysisM := ReaderT Context PreProcessM
+
 public partial def typeAnalysisPass : Pass where
   name := `typeAnalysis
   run' := do
-    checkContext (← PreProcessM.getGoal)
+    let restrictedTypes ← PreProcessM.getRestrictedTypes
+    if let some types := restrictedTypes then
+      seedRestrictedTypes types
+    checkContext (← PreProcessM.getGoal) |>.run { restricted := restrictedTypes.isSome }
     let analysis ← PreProcessM.getTypeAnalysis
     trace[Meta.Tactic.bv] m!"Type analysis found structures: {analysis.interestingStructures.toList}"
     trace[Meta.Tactic.bv] m!"Type analysis found enums: {analysis.interestingEnums.toList}"
     trace[Meta.Tactic.bv] m!"Type analysis found matchers: {analysis.interestingMatchers.keys}"
     return false
 where
-  checkContext (goal : MVarId) : PreProcessM Unit := do
+  seedRestrictedTypes (types : Array Name) : PreProcessM Unit := do
+    for type in types do
+      if ← isEnumType type then
+        PreProcessM.markInterestingEnum type
+      else if isStructure (← getEnv) type then
+        PreProcessM.markInterestingStructure type
+      else
+        throwError "`{type}` is neither a structure nor an enum inductive"
+
+  checkContext (goal : MVarId) : AnalysisM Unit := do
     goal.withContext do
       for decl in ← getLCtx do
         if !decl.isLet && !decl.isImplementationDetail then
@@ -155,7 +177,7 @@ where
       for hyp in ← PreProcessM.getHyps do
         analyzeType hyp.type
 
-  analyzeType (expr : Expr) : PreProcessM Unit := do
+  analyzeType (expr : Expr) : AnalysisM Unit := do
     expr.forEachWhere Expr.isConst fun e => do
       let .const declName .. := e | unreachable!
       discard <| analyzeConst declName
@@ -164,7 +186,7 @@ where
   Returns true if the const is something that we would like to see revealed by case splitting on
   structures that contain it.
   -/
-  analyzeConst (n : Name) : PreProcessM Bool := do
+  analyzeConst (n : Name) : AnalysisM Bool := do
     if isBuiltIn n then return true
 
     let analysis ← PreProcessM.getTypeAnalysis
@@ -173,7 +195,19 @@ where
     else if analysis.uninteresting.contains n || analysis.interestingMatchers.contains n then
       return false
 
-    if isStructure (← getEnv) n then
+    -- Matchers are discovered even in a restricted run as they may discriminate on one of the enums
+    -- that we were told to use.
+    if let some kind ← isSupportedMatch n then
+      let restricted := (← read).restricted
+      if !restricted || analysis.interestingEnums.contains kind.getEnumInfo.name then
+        PreProcessM.markInterestingMatcher n kind
+      else
+        PreProcessM.markUninterestingConst n
+      return false
+    else if (← read).restricted then
+      PreProcessM.markUninterestingConst n
+      return false
+    else if isStructure (← getEnv) n then
       if ← analyzeStructure n then
         PreProcessM.markInterestingStructure n
         return true
@@ -183,9 +217,6 @@ where
     else if ← isEnumType n then
       PreProcessM.markInterestingEnum n
       return true
-    else if let some kind ← isSupportedMatch n then
-      PreProcessM.markInterestingMatcher n kind
-      return false
     else
       PreProcessM.markUninterestingConst n
       return false
@@ -193,7 +224,7 @@ where
   /--
   Returns true if the structure is appropriate for case splitting and contains fields of interest.
   -/
-  analyzeStructure (n : Name) : PreProcessM Bool := do
+  analyzeStructure (n : Name) : AnalysisM Bool := do
     let constInfo ← getConstInfoInduct n
     if constInfo.isRec then
       return false
@@ -206,7 +237,7 @@ where
         return state || (← typeCasesRelevant (← arg.fvarId!.getType))
     return interesting
 
-  typeCasesRelevant (expr : Expr) : PreProcessM Bool := do
+  typeCasesRelevant (expr : Expr) : AnalysisM Bool := do
     let some const := expr.getAppFn.constName? | return false
     analyzeConst const
 

--- a/src/Lean/Meta/Tactic/BVDecide/TacticContext.lean
+++ b/src/Lean/Meta/Tactic/BVDecide/TacticContext.lean
@@ -29,9 +29,14 @@ structure TacticContext where
   solver : System.FilePath
   lratPath : System.FilePath
   config : BVDecideConfig
+  /--
+  The types that the structure and enum analysis is restricted to, as provided by the `types`
+  clause. If this is `none` the analysis discovers the relevant types on its own.
+  -/
+  restrictedTypes : Option (Array Name) := none
 
-def TacticContext.new (lratPath : System.FilePath) (config : BVDecideConfig) :
-    TermElabM TacticContext := do
+def TacticContext.new (lratPath : System.FilePath) (config : BVDecideConfig)
+    (restrictedTypes : Option (Array Name) := none) : TermElabM TacticContext := do
   let exprDef ← Lean.Elab.Term.mkAuxName `_expr_def
   let certDef ← Lean.Elab.Term.mkAuxName `_cert_def
   let reflectionDef ← Lean.Elab.Term.mkAuxName `_reflection_def
@@ -43,7 +48,8 @@ def TacticContext.new (lratPath : System.FilePath) (config : BVDecideConfig) :
     reflectionDef,
     solver,
     lratPath,
-    config
+    config,
+    restrictedTypes
   }
 where
   determineSolver : CoreM System.FilePath := do

--- a/tests/elab/bv_decide_types.lean
+++ b/tests/elab/bv_decide_types.lean
@@ -1,0 +1,97 @@
+import Std.Tactic.BVDecide
+
+/-!
+Tests for the `types [...]` clause of the `bv_decide` family of tactics, which restricts the
+structure and enum inductive analysis to the listed types.
+-/
+
+inductive Color where
+  | red
+  | green
+  | blue
+
+@[ext]
+structure Pair where
+  x : BitVec 8
+  y : BitVec 8
+
+def isRed (c : Color) : Bool :=
+  match c with
+  | .red => true
+  | _ => false
+
+example (a b : Pair) (c d : Color) (h1 : a = b) (h2 : c = d) : a.x = b.x ∧ d = c := by
+  bv_decide
+
+example (a b : Pair) (h : a = b) : a.x = b.x := by
+  bv_decide types [Pair]
+
+example (c d : Color) (h : c = d) : d = c := by
+  bv_decide types [Color]
+
+example (c : Color) (h : isRed c = true) : c = .red := by
+  simp only [isRed] at h
+  bv_decide types [Color]
+
+example (a b : Pair) (c d : Color) (h1 : a = b) (h2 : c = d) : a.x = b.x ∧ d = c := by
+  bv_decide types [Pair, Color]
+
+example (a b : Pair) (h : a = b) : a.x = b.x := by
+  bv_decide types [Pair, Pair]
+
+/--
+error: None of the hypotheses are in the supported BitVec fragment after applying preprocessing.
+There are three potential reasons for this:
+1. If you are using custom BitVec constructs simplify them to built-in ones.
+2. If your problem is using only built-in ones it might currently be out of reach.
+   Consider expressing it in terms of different operations that are better supported.
+3. The original goal was reduced to False and is thus invalid.
+-/
+#guard_msgs in
+example (c d : Color) (h : c = d) : d = c := by
+  bv_decide types [Pair]
+
+/--
+error: None of the hypotheses are in the supported BitVec fragment after applying preprocessing.
+There are three potential reasons for this:
+1. If you are using custom BitVec constructs simplify them to built-in ones.
+2. If your problem is using only built-in ones it might currently be out of reach.
+   Consider expressing it in terms of different operations that are better supported.
+3. The original goal was reduced to False and is thus invalid.
+-/
+#guard_msgs in
+example (c d : Color) (h : c = d) : d = c := by
+  bv_decide types []
+
+example (a b : Pair) (h : a = b) : a.x = b.x := by
+  sym =>
+    bv_normalize types [Pair]
+
+example (a b : Pair) (h : a = b) : a.x = b.x := by
+  sym =>
+    bv_decide types [Pair]
+
+/--
+error: `Nat` cannot be used in a `types` clause, only non-recursive structures and enum inductives are supported
+-/
+#guard_msgs in
+example (a b : Pair) (h : a = b) : a.x = b.x := by
+  bv_decide types [Nat]
+
+inductive Tagged where
+  | tag (x : BitVec 8)
+
+/--
+error: `Tagged` cannot be used in a `types` clause, only non-recursive structures and enum inductives are supported
+-/
+#guard_msgs in
+example (a b : Pair) (h : a = b) : a.x = b.x := by
+  bv_decide types [Tagged]
+
+/-- error: Unknown constant `DoesNotExist` -/
+#guard_msgs in
+example (a b : Pair) (h : a = b) : a.x = b.x := by
+  bv_decide types [DoesNotExist]
+
+-- `types` is not a reserved keyword.
+def types : Nat := 0


### PR DESCRIPTION
This PR adds support for restricting the set of complex types that `bv_decide` is going to analyze as a user. By default `bv_decide` guesses that enums and structures in its context might be relevant and tries to incorporate them into the solving process. Now users can supply a restricted set of types via `bv_decide types [MyEnum, MyStruct]`. `bv_decide` is only going to work these types and disable automated discovery once this option is passed.