### PR TITLE
feat: support a destructuring binder on a `for … invariant` loop

### DIFF
--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -83,15 +83,37 @@ open Lean.Meta
     `(doElem| do $doElems*)
   | _ => Macro.throwUnsupported
 
+/-- Synthesize the class that the `invariant` clause's specification is stated over, reporting the
+container that lacks it rather than the gadget that goes unsolved later. -/
+private def checkPureForIn (invClause : Syntax) (h? : Option Syntax) (xs α : Expr) (mi : MonadInfo) :
+    DoElabM Unit := do
+  let cls := if h?.isSome then `Std.Internal.PureForIn' else `Std.Internal.PureForIn
+  unless (← getEnv).contains cls do return
+  let ρ ← instantiateMVars (← inferType xs)
+  let α ← instantiateMVars α
+  let m ← instantiateMVars mi.m
+  if ρ.hasExprMVar || α.hasExprMVar || m.hasExprMVar then return
+  let ok ←
+    try
+      let ty ← Term.elabType <| ←
+        `($(mkIdent cls) $(← Term.exprToSyntax m) $(← Term.exprToSyntax ρ) $(← Term.exprToSyntax α))
+      pure ((← trySynthInstance ty) matches .some _)
+    catch _ => pure false
+  unless ok do
+    throwErrorAt invClause "The `invariant` clause needs {.ofConstName cls} for{indentExpr ρ}\n\
+      which states that iterating it produces its elements without effects. Loop over a container \
+      that provides the instance, or state the invariant in the proof instead."
+
 /-- Rebuild the already-elaborated loop as a `forInWithInvariant` call carrying the `invariant`
 clause: `ForIn.forInWithInvariant`, or `ForIn'.forInWithInvariant'` for a membership-proof binder
 (`for h : x in xs`). The mut tuple's layout is `[return?, mutVars…, unit?]`, so the invariant can
 name the loop's mutable variables directly; the early-return slot becomes a wildcard. Binders past
 the first two bind the arguments of the assertion itself. -/
 private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
-    (xs preS body σ : Expr) (loopMutVars : Array MutVar) (returnsEarly : Bool)
+    (xs α preS body σ : Expr) (loopMutVars : Array MutVar) (returnsEarly : Bool)
     (mi : MonadInfo) : DoElabM Expr := do
   let `(doForInvariant| invariant $binders* => $invBody) := invClause | throwUnsupportedSyntax
+  checkPureForIn invClause h? xs α mi
   unless binders.size ≥ 2 do
     throwErrorAt invClause "The `invariant` clause takes at least two binders: the elements \
       consumed so far and the elements remaining."
@@ -223,7 +245,8 @@ private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
 
   let forIn ← match inv? with
     | none => pure (mkApp app body)
-    | some invClause => mkForInWithInvariant invClause h? xs preS body σ loopMutVars info.returnsEarly mi
+    | some invClause =>
+      mkForInWithInvariant invClause h? xs α preS body σ loopMutVars info.returnsEarly mi
 
   let γ := (← read).doBlockResultType
   let rest ←

--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -83,26 +83,18 @@ open Lean.Meta
     `(doElem| do $doElems*)
   | _ => Macro.throwUnsupported
 
-/-- Synthesize the class that the `invariant` clause's specification is stated over, reporting the
-container that lacks it rather than the gadget that goes unsolved later. -/
+/-- Demand the class that the `invariant` clause's specification is stated over, so that the
+container that lacks it is reported at the clause. -/
 private def checkPureForIn (invClause : Syntax) (h? : Option Syntax) (xs α : Expr) (mi : MonadInfo) :
-    DoElabM Unit := do
+    DoElabM Unit := withRef invClause do
   let cls := if h?.isSome then `Std.Internal.PureForIn' else `Std.Internal.PureForIn
   unless (← getEnv).contains cls do return
-  let ρ ← instantiateMVars (← inferType xs)
-  let α ← instantiateMVars α
-  let m ← instantiateMVars mi.m
-  if ρ.hasExprMVar || α.hasExprMVar || m.hasExprMVar then return
-  let ok ←
-    try
-      let ty ← Term.elabType <| ←
-        `($(mkIdent cls) $(← Term.exprToSyntax m) $(← Term.exprToSyntax ρ) $(← Term.exprToSyntax α))
-      pure ((← trySynthInstance ty) matches .some _)
-    catch _ => pure false
-  unless ok do
-    throwErrorAt invClause "The `invariant` clause needs {.ofConstName cls} for{indentExpr ρ}\n\
-      which states that iterating it produces its elements without effects. Loop over a container \
-      that provides the instance, or state the invariant in the proof instead."
+  let ty ← Term.elabType <| ←
+    `($(mkIdent cls) $(← Term.exprToSyntax mi.m) $(← Term.exprToSyntax (← inferType xs))
+      $(← Term.exprToSyntax α))
+  discard <| Term.mkInstMVar ty
+    (extraErrorMsg? := m!"The `invariant` clause is stated over this class, which says that \
+      iterating the container produces its elements without effects.")
 
 /-- Rebuild the already-elaborated loop as a `forInWithInvariant` call carrying the `invariant`
 clause: `ForIn.forInWithInvariant`, or `ForIn'.forInWithInvariant'` for a membership-proof binder

--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -25,10 +25,10 @@ open Lean.Meta
     -- This is the target form of the expander, handled by `elabDoFor` below.
     Macro.throwUnsupported
   | `(doFor| for%$tk $decls:doForDecl,* $[$inv:doForInvariant]? do $body) =>
-    if let some inv := inv then
-      Macro.throwErrorAt inv "The `invariant` clause is only supported on `for x in xs do …` \
-        with a single identifier binder."
     let decls := decls.getElems
+    if let some inv := inv then
+      if decls.size > 1 then
+        Macro.throwErrorAt inv "The `invariant` clause takes a `for` loop over a single collection."
     let `(doForDecl| $[$h? : ]? $pattern in $xs) := decls[0]! | Macro.throwUnsupported
     let mut doElems := #[]
     let mut body := body
@@ -78,7 +78,8 @@ open Lean.Meta
           | some ($y, s') =>
             $s:ident := s'
             do $body)
-    doElems := doElems.push (← `(doSeqItem| for%$tk $[$h? : ]? $x:ident in $xs do $body))
+    doElems := doElems.push
+      (← `(doSeqItem| for%$tk $[$h? : ]? $x:ident in $xs $[$inv:doForInvariant]? do $body))
     `(doElem| do $doElems*)
   | _ => Macro.throwUnsupported
 

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -208,12 +208,36 @@ for the `invariant` clause to work. -/
 def sumValues (m : Std.HashMap Nat Nat) : Id Nat
     ensures r => 0 ≤ r := do
   let mut s := 0
-  for kv in m invariant _pref _suff => 0 ≤ s do
-    s := s + kv.2
+  for (_k, v) in m invariant _pref _suff => 0 ≤ s do
+    s := s + v
   return s
 
 #guard_msgs (drop info) in
 #check @sumValues.spec
+
+/-! The binder may destructure, here over a list of pairs. -/
+
+def sumSnd (xs : List (Nat × Nat)) : Id Nat
+    ensures r => 0 ≤ r := do
+  let mut s := 0
+  for (_a, b) in xs invariant _pref _suff => 0 ≤ s do
+    s := s + b
+  return s
+
+#guard_msgs (drop info) in
+#check @sumSnd.spec
+
+/-! A loop over several collections takes no invariant. -/
+
+/--
+error: The `invariant` clause takes a `for` loop over a single collection.
+-/
+#guard_msgs in
+example (xs ys : List Nat) : Id Nat := do
+  let mut n := 0
+  for x in xs, y in ys invariant _pref _suff => 0 ≤ n do
+    n := n + x + y
+  return n
 
 /-! ## The contract telescope is transplanted faithfully to `f.spec`
 

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -242,9 +242,11 @@ example (xs ys : List Nat) : Id Nat := do
 /-! ## A container without a `PureForIn` instance is reported at the clause -/
 
 /--
-error: The `invariant` clause needs Std.Internal.PureForIn for
-  String
-which states that iterating it produces its elements without effects. Loop over a container that provides the instance, or state the invariant in the proof instead.
+error: failed to synthesize instance of type class
+  Std.Internal.PureForIn Id String Char
+The `invariant` clause is stated over this class, which says that iterating the container produces its elements without effects.
+
+Hint: Type class instance resolution failures can be inspected with the `set_option trace.Meta.synthInstance true` command.
 -/
 #guard_msgs in
 example (s : String) : Id Nat := do

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -64,29 +64,6 @@ def findSmallest (s : Array Nat) : Id (Option Nat)
 #guard_msgs (drop info) in
 #check @findSmallest.spec
 
-/-! ## A contract over a membership-proof binder (`for h : x in xs invariant …`) -/
-
-def sumWithMem (xs : List Nat) : Id Nat
-    ensures r => 0 ≤ r := do
-  let mut acc := 0
-  for h : x in xs invariant _pref _suff => 0 ≤ acc do
-    acc := acc + x
-  return acc
-
-#guard_msgs (drop info) in
-#check @sumWithMem.spec
-
--- The membership binder also works over a legacy `Range`.
-def sumRangeMem (n : Nat) : Id Nat
-    ensures r => 0 ≤ r := do
-  let mut acc := 0
-  for h : i in [0:n] invariant _pref _suff => 0 ≤ acc do
-    acc := acc + i
-  return acc
-
-#guard_msgs (drop info) in
-#check @sumRangeMem.spec
-
 /-! ## An invariant over the monad's own state
 
 The invariant need not mention a mutable variable: here it constrains the `StateM` state. -/
@@ -178,7 +155,9 @@ example (xs : List Nat) : Id Nat := do
     acc := acc + x
   return acc
 
-/-! ## A loop over an `Array`, with and without a membership-proof binder -/
+/-! ## A loop over an `Array`, with and without a membership-proof binder
+
+The membership binder (`for h : x in xs`) is covered here rather than per container. -/
 
 def sumArray (xs : Array Nat) : Id Nat
     ensures r => r = xs.toList.sum := do
@@ -203,7 +182,7 @@ def sumArrayMem (xs : Array Nat) : Id Nat
 /-! ## A loop over a `HashMap`, through its `PureForIn` instance
 
 The container needs no specification of its own: stating that its loop is effect-free is enough
-for the `invariant` clause to work. -/
+for the `invariant` clause to work, and the binder may destructure. -/
 
 def sumValues (m : Std.HashMap Nat Nat) : Id Nat
     ensures r => 0 ≤ r := do
@@ -215,31 +194,14 @@ def sumValues (m : Std.HashMap Nat Nat) : Id Nat
 #guard_msgs (drop info) in
 #check @sumValues.spec
 
-/-! The binder may destructure, here over a list of pairs. -/
-
-def sumSnd (xs : List (Nat × Nat)) : Id Nat
-    ensures r => 0 ≤ r := do
-  let mut s := 0
-  for (_a, b) in xs invariant _pref _suff => 0 ≤ s do
-    s := s + b
-  return s
-
-#guard_msgs (drop info) in
-#check @sumSnd.spec
-
 /-! A loop over several collections takes no invariant. -/
 
-/--
-error: The `invariant` clause takes a `for` loop over a single collection.
--/
+/-- error: The `invariant` clause takes a `for` loop over a single collection. -/
 #guard_msgs in
-example (xs ys : List Nat) : Id Nat := do
-  let mut n := 0
-  for x in xs, y in ys invariant _pref _suff => 0 ≤ n do
-    n := n + x + y
-  return n
+example (xs ys : List Nat) : Id Unit := do
+  for _ in xs, _ in ys invariant _ _ => True do pure ()
 
-/-! ## A container without a `PureForIn` instance is reported at the clause -/
+/-! A container whose loop is not effect-free is reported at the clause. -/
 
 /--
 error: failed to synthesize instance of type class
@@ -249,11 +211,8 @@ The `invariant` clause is stated over this class, which says that iterating the 
 Hint: Type class instance resolution failures can be inspected with the `set_option trace.Meta.synthInstance true` command.
 -/
 #guard_msgs in
-example (s : String) : Id Nat := do
-  let mut n := 0
-  for _c in s invariant _pref _suff => 0 ≤ n do
-    n := n + 1
-  return n
+example (s : String) : Id Unit := do
+  for _c in s invariant _ _ => True do pure ()
 
 /-! ## The contract telescope is transplanted faithfully to `f.spec`
 

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -239,6 +239,20 @@ example (xs ys : List Nat) : Id Nat := do
     n := n + x + y
   return n
 
+/-! ## A container without a `PureForIn` instance is reported at the clause -/
+
+/--
+error: The `invariant` clause needs Std.Internal.PureForIn for
+  String
+which states that iterating it produces its elements without effects. Loop over a container that provides the instance, or state the invariant in the proof instead.
+-/
+#guard_msgs in
+example (s : String) : Id Nat := do
+  let mut n := 0
+  for _c in s invariant _pref _suff => 0 ≤ n do
+    n := n + 1
+  return n
+
 /-! ## The contract telescope is transplanted faithfully to `f.spec`
 
 `f.spec` re-binds the definition's telescope verbatim, applies `f` to exactly the explicit arguments,


### PR DESCRIPTION
This PR lets a `for` loop that destructures its binder carry an `invariant` clause, so a loop over a map may bind `(k, v)` and still state its invariant. A container that the clause cannot verify is reported where the clause appears, naming the `PureForIn` instance it lacks, instead of surfacing later as a `vcgen` gadget with no applicable specification.
