### PR TITLE
feat: make `bv_decide`'s embedded constraints pass more aggressive

### DIFF
--- a/src/Lean/Meta/Tactic/BVDecide/Normalize/EmbeddedConstraint.lean
+++ b/src/Lean/Meta/Tactic/BVDecide/Normalize/EmbeddedConstraint.lean
@@ -12,19 +12,32 @@ public import Lean.Meta.Tactic.BVDecide.Normalize.Basic
 /-!
 This module contains the implementation of the embedded constraint substitution pass in the fixpoint
 pipeline, substituting hypotheses of the form `h : x = true` in other hypotheses.
-
-
 -/
 
 namespace Lean.Meta.Tactic.BVDecide
 namespace Normalize
 
-def embeddedConstraintProc (minDepth : UInt32) (hypMap : PersistentHashMap Sym.ExprPtr Expr) :
+structure HypInfo where
+  /--
+  Proof of the original hypothesis, either `e = true` or `!e = true`, depending on `negated`.
+  -/
+  proof : Expr
+  /--
+  Whether the original hypothesis is of the shape `e` or `!e`.
+  -/
+  negated : Bool
+
+def embeddedConstraintProc (minDepth : UInt32) (hypMap : PersistentHashMap Sym.ExprPtr HypInfo) :
     Sym.Simp.Simproc := fun e => do
   if e.approxDepth < minDepth then
     return .rfl (done := true)
-  let some proof := hypMap.find? ⟨e⟩ | return .rfl
-  return .step (← Sym.share <| toExpr Bool.true) proof (done := true) (contextDependent := true)
+  let some { proof, negated } := hypMap.find? ⟨e⟩ | return .rfl
+  if negated then
+    let proof :=
+      mkApp2 (mkConst ``Std.Tactic.BVDecide.Normalize.Bool.eq_false_of_not_eq_true) e proof
+    return .step (← Sym.share <| toExpr Bool.false) proof (done := true)
+  else
+    return .step (← Sym.share <| toExpr Bool.true) proof (done := true)
 
 /--
 Substitute embedded constraints. That is look for hypotheses of the form `h : x = true` and use
@@ -37,7 +50,7 @@ public def embeddedConstraintPass : Pass where
     let goal ← PreProcessM.getGoal
     goal.withContext do
       let hyps ← PreProcessM.getHyps
-      let mut relevantHypsMap : PersistentHashMap Sym.ExprPtr Expr := {}
+      let mut relevantHypsMap : PersistentHashMap Sym.ExprPtr HypInfo := {}
       let mut relevantHypsIdxMap : Std.HashMap Nat Sym.ExprPtr := {}
       let mut seen : Std.HashSet Sym.ExprPtr := {}
       let mut minDepth := UInt32.size
@@ -46,11 +59,15 @@ public def embeddedConstraintPass : Pass where
         let type := hyp.type
         let_expr Eq _ lhs rhs := type | continue
         let_expr Bool.true := rhs | continue
+        let (lhs, negated) :=
+          match_expr lhs with
+          | Bool.not inner => (inner, true)
+          | _ => (lhs, false)
         if !seen.contains ⟨lhs⟩ then
           seen := seen.insert ⟨lhs⟩
           relevantHypsIdxMap := relevantHypsIdxMap.insert idx ⟨lhs⟩
           minDepth := minDepth.min lhs.approxDepth.toNat
-          relevantHypsMap := relevantHypsMap.insert ⟨lhs⟩ hyp.value
+          relevantHypsMap := relevantHypsMap.insert ⟨lhs⟩ ⟨hyp.value, negated⟩
 
       trace[Meta.Tactic.bv] m!"Chose min depth at: {minDepth}"
       if relevantHypsMap.isEmpty then

--- a/src/Std/Tactic/BVDecide/Normalize/Bool.lean
+++ b/src/Std/Tactic/BVDecide/Normalize/Bool.lean
@@ -35,6 +35,9 @@ attribute [bv_normalize] Bool.xor_not_self
 attribute [bv_normalize] Bool.not_not
 attribute [bv_normalize] Bool.cond_not
 
+theorem Bool.eq_false_of_not_eq_true {b : Bool} (h : (!b) = true) : b = false :=
+  by decide +revert
+
 @[bv_normalize]
 theorem ite_eq_cond {b : Bool} {x y : α} : (if b = true then x else y) = (bif b then x else y) := by
   rw [cond_eq_ite]

--- a/src/Std/Tactic/BVDecide/Normalize/Canonicalize.lean
+++ b/src/Std/Tactic/BVDecide/Normalize/Canonicalize.lean
@@ -26,7 +26,7 @@ theorem BitVec.eq_to_beq (a b : BitVec w) : (a = b) = ((a == b) = true) := by
   simp
 
 @[bv_normalize]
-theorem BitVec.ne_to_beq (a b : BitVec w) : (a ≠ b) = ((!(a == b)) = true) := by
+theorem BitVec.ne_to_beq (a b : BitVec w) : (¬a = b) = ((!(a == b)) = true) := by
   simp
 
 theorem Bool.eq_to_beq (a b : Bool) : (a = b) = ((a == b) = true) := by simp
@@ -44,7 +44,7 @@ theorem Bool.neg_to_not (a : Bool) : (¬a) = ((!a) = true) := by
   simp
 
 @[bv_normalize]
-theorem Bool.ne_to_beq (a b : Bool) : (a ≠ b) = ((!(a == b)) = true) := by
+theorem Bool.ne_to_beq (a b : Bool) : (¬a = b) = ((!(a == b)) = true) := by
   simp
 
 @[bv_normalize]

--- a/tests/elab/bv_embedded_constraints.lean
+++ b/tests/elab/bv_embedded_constraints.lean
@@ -1,0 +1,13 @@
+import Std
+
+/-!
+This tests the behavior of the embedded constraints pass in `bv_decide`.
+-/
+
+example (a b : Bool) (h : a = true) : (a || b) = true := by bv_normalize
+
+example (a b : Bool) (h : (!a) = true) : (!a || b) = true := by bv_normalize
+
+example (a : Bool) (h1 : (!a) = true) (x y z : BitVec 32) (h3 : y = z) :
+    (if a then x else y) = z := by
+  bv_normalize


### PR DESCRIPTION
This PR makes `bv_decide`'s embedded constraints pass understand both `a = true` and `(!a) = true` correctly. This allows us to solve slightly more problems in pre-processing.