### PR TITLE
fix: keep type ascriptions on contract clause binders

### DIFF
--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -104,6 +104,9 @@ the first two bind the arguments of the assertion itself. -/
 private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
     (xs α preS body σ : Expr) (loopMutVars : Array MutVar) (returnsEarly : Bool)
     (mi : MonadInfo) : DoElabM Expr := do
+  if let `(doForInvariant| invariant $_* : $ty => $_) := invClause then
+    throwErrorAt ty "The `invariant` clause takes no type ascription covering all its binders; \
+      ascribe the type on an individual binder, as in `invariant (pref : List α) suff => ...`."
   let `(doForInvariant| invariant $binders* => $invBody) := invClause | throwUnsupportedSyntax
   checkPureForIn invClause h? xs α mi
   unless binders.size ≥ 2 do

--- a/src/Lean/Elab/Tactic/Do/Contract.lean
+++ b/src/Lean/Elab/Tactic/Do/Contract.lean
@@ -107,12 +107,12 @@ add `import Std.Internal.Do` to use them."
   let args := sigBinders.flatMap contractBinderIdents
   let pre : Term ← if requiresStx.isNone then `(⊤) else
     match requiresStx[0] with
-    | `(requiresClause| requires $bs* => $p) => `(fun $bs* => $p)
-    | `(requiresClause| requires $p) => pure p
+    | `(requiresClause| requires $f:basicFun) => `(fun $f:basicFun)
+    | `(requiresClause| requires $p:term) => pure p
     | _ => Macro.throwUnsupported
   let post : Term ← if ensuresStx.isNone then `(fun _ => ⊤) else
     match ensuresStx[0] with
-    | `(ensuresClause| ensures $bs* => $q) => `(fun $bs* => $q)
+    | `(ensuresClause| ensures $f:basicFun) => `(fun $f:basicFun)
     | _ => Macro.throwUnsupported
   let msg : TSyntax `str := ⟨Syntax.mkStrLit <|
     if specStep?.isSome then

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -214,6 +214,40 @@ Hint: Type class instance resolution failures can be inspected with the `set_opt
 example (s : String) : Id Unit := do
   for _c in s invariant _ _ => True do pure ()
 
+/-! ## The `invariant` clause ascribes types per binder
+
+An ascription after the binder list would cover the loop binders and the assertion binders alike. -/
+
+/--
+error: The `invariant` clause takes no type ascription covering all its binders; ascribe the type on an individual binder, as in `invariant (pref : List α) suff => ...`.
+-/
+#guard_msgs in
+example (xs : List Nat) : Id Nat := do
+  let mut acc := 0
+  for x in xs invariant pref suff : List Nat => 0 ≤ acc do
+    acc := acc + x
+  return acc
+
+/-! ## The clause binders accept a type ascription, as in `fun` -/
+
+def requiresAscribed (xs : List Nat) : StateM Nat Unit
+    requires s : Nat => s = 0
+    ensures _ s => s = xs.sum
+  := do
+  for x in xs invariant pref _ s => s = pref.sum do
+    modify (· + x)
+
+#guard_msgs (drop info) in
+#check @requiresAscribed.spec
+
+def ensuresAscribed (n : Nat) : Id Nat
+    ensures r : Nat => r ≥ n
+  := pure n
+
+/-- info: ensuresAscribed.spec : ∀ (n : Nat), ⦃ ⊤ ⦄ ensuresAscribed n ⦃ fun r => r ≥ n ⦄ -/
+#guard_msgs in
+#check @ensuresAscribed.spec
+
 /-! ## The contract telescope is transplanted faithfully to `f.spec`
 
 `f.spec` re-binds the definition's telescope verbatim, applies `f` to exactly the explicit arguments,


### PR DESCRIPTION
This PR makes the `requires`, `ensures` and `invariant` clauses accept a type ascription on their binders, as `fun` does: `requires s : Nat => s = 0` now elaborates as a binder form instead of being read as a term. An ascription covering all binders of an `invariant` clause is reported as an error, since its first two binders are the loop's consumed prefix and remaining suffix.
