### PR TITLE
fix: use after free in String.extract for gigantic slices

### DIFF
--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -2383,6 +2383,7 @@ extern "C" LEAN_EXPORT uint8 lean_string_is_valid_pos(b_obj_arg s, b_obj_arg i0)
 extern "C" LEAN_EXPORT obj_res lean_string_utf8_extract(b_obj_arg s, b_obj_arg b0, b_obj_arg e0) {
     if (!lean_is_scalar(b0) || !lean_is_scalar(e0)) {
         /* See comment at string_utf8_get */
+        lean_inc(s);
         return s;
     }
     usize b = lean_unbox(b0);

--- a/tests/compile/extract_uaf.lean
+++ b/tests/compile/extract_uaf.lean
@@ -1,0 +1,14 @@
+/-! regression test for use after free on lean_string_extract -/
+
+def hugeEnd : String.Pos.Raw := ⟨2^70⟩
+@[noinline] def trim (s : String) := String.Pos.Raw.extract s ⟨1⟩ hugeEnd
+@[noinline] def heap (s : String) := s ++ "-heap-padding"
+
+def fill : Nat → Array String → Array String
+  | 0, a => a
+  | n+1, a => fill n (a.push (heap (toString (n % 10))))
+
+def main (args : List String) : IO Unit := do
+  let stale := trim (heap args[0]!)
+  let replacements := fill 64 #[]
+  IO.println (replacements[63]! ++ "|" ++ stale)

--- a/tests/compile/extract_uaf.lean.init.sh
+++ b/tests/compile/extract_uaf.lean.init.sh
@@ -1,0 +1,1 @@
+TEST_ARGS=( A )

--- a/tests/compile/extract_uaf.lean.out.expected
+++ b/tests/compile/extract_uaf.lean.out.expected
@@ -1,0 +1,1 @@
+0-heap-padding|A-heap-padding


### PR DESCRIPTION
This PR fixes a use after free in `String.Pos.Raw.extract` when calling it with gigantic slice
limits.

This only addresses the UAF part of #14684, the semantic divergence issue remains.
