### PR TITLE
fix: report a missing spec for an un-steppable `vcgen` program head

### DIFF
--- a/src/Lean/Elab/Tactic/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/VCGen/Solve.lean
@@ -654,10 +654,6 @@ public def solve (scope : Scope) (goal : MVarId) : VCGenM SolveResult := goal.wi
     if f.isConst || f.isFVar then
       burnOne
       return ← applySpecs scope goal info
-    -- The program head is a term no spec keys on: a bare `fun s => …` left by a `monadLift` of an
-    -- anonymous state transformer, whose reflexive lift `monadLift_refl` rewrites to the underlying
-    -- function. Report it as a missing spec, the same result `findSpec` yields for a constant head
-    -- with no registered spec.
     return ← stopOrErrorOnMissingSpec info.prog info.M #[]
 
   return .stop (.noProgress pre rhs)

--- a/src/Lean/Elab/Tactic/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/VCGen/Solve.lean
@@ -654,7 +654,11 @@ public def solve (scope : Scope) (goal : MVarId) : VCGenM SolveResult := goal.wi
     if f.isConst || f.isFVar then
       burnOne
       return ← applySpecs scope goal info
-    throwError "Failed to decompose weakest precondition for {info.prog}. This should not happen."
+    -- The program head is a term no spec keys on: a bare `fun s => …` left by a `monadLift` of an
+    -- anonymous state transformer, whose reflexive lift `monadLift_refl` rewrites to the underlying
+    -- function. Report it as a missing spec, the same result `findSpec` yields for a constant head
+    -- with no registered spec.
+    return ← stopOrErrorOnMissingSpec info.prog info.M #[]
 
   return .stop (.noProgress pre rhs)
 

--- a/tests/elab/vcgenLiftAnonymousTransformer.lean
+++ b/tests/elab/vcgenLiftAnonymousTransformer.lean
@@ -1,0 +1,46 @@
+import Std.Tactic.Do
+import Std.Internal.Do
+
+/-!
+`vcgen [liftMach]` unfolds `liftMach c` to `liftM (fun s => match c s.machine with …)`, a `monadLift`
+of an anonymous state transformer. The `monadLift` spec chain rewrites this down to the bare
+`fun s => match c s.machine with …`, a program whose head is a lambda that no spec keys on. `vcgen`
+reports it as a missing spec, the same result it gives for a constant head with no registered spec,
+rather than a hard "This should not happen" failure.
+-/
+
+open Std.Internal.Do
+
+set_option mvcgen.warning false
+
+structure Sys where
+  machine : Nat
+
+abbrev Base := EStateM Unit Nat
+abbrev M := ReaderT Unit (StateT Unit (EStateM Unit Sys))
+
+/-- Lift a `Base` computation over `Sys.machine`, via the anonymous state transformer
+`fun s => match c s.machine with …`. -/
+def liftMach {α} (c : Base α) : M α :=
+  liftM (m := EStateM Unit Sys) (fun s => match c s.machine with
+    | .ok a m => .ok a { s with machine := m }
+    | .error e m => .error e { s with machine := m })
+
+def prog : M Unit := do
+  let v ← liftMach (get : Base Nat)
+  liftMach (set v)
+
+section
+variable (Q : Unit → Unit → Unit → Sys → Prop) (E : Unit → Sys → Prop)
+
+/--
+error: No spec found for program fun s =>
+  match get s.machine with
+  | EStateM.Result.ok a m => EStateM.Result.ok a { machine := m }
+  | EStateM.Result.error e m => EStateM.Result.error e { machine := m }.
+-/
+#guard_msgs (whitespace := lax) in
+theorem prog_spec : ⦃ fun r n s => Q () r n s ⦄ prog ⦃ Q; E ⦄ := by
+  vcgen [prog, liftMach]
+
+end

--- a/tests/elab/vcgenLiftAnonymousTransformer.lean
+++ b/tests/elab/vcgenLiftAnonymousTransformer.lean
@@ -2,11 +2,13 @@ import Std.Tactic.Do
 import Std.Internal.Do
 
 /-!
-`vcgen [liftMach]` unfolds `liftMach c` to `liftM (fun s => match c s.machine with …)`, a `monadLift`
-of an anonymous state transformer. The `monadLift` spec chain rewrites this down to the bare
-`fun s => match c s.machine with …`, a program whose head is a lambda that no spec keys on. `vcgen`
-reports it as a missing spec, the same result it gives for a constant head with no registered spec,
-rather than a hard "This should not happen" failure.
+`liftMach` coerces the anonymous state transformer `fun s => match c s.machine with …` into
+`EStateM Unit Sys` by definitional unfolding alone: `EStateM` is a reducible function type, so
+no constructor marks the monad boundary. `vcgen [liftMach]` unfolds `liftMach c` to a `monadLift`
+of that bare function, and the `monadLift` spec chain rewrites it down to the lambda itself, a
+program whose head no spec keys on. `vcgen` reports it as a missing spec, the same result it
+gives for a constant head with no registered spec, rather than a hard "This should not happen"
+failure.
 -/
 
 open Std.Internal.Do

--- a/tests/elab/vcgenLiftAnonymousTransformer.lean
+++ b/tests/elab/vcgenLiftAnonymousTransformer.lean
@@ -1,5 +1,5 @@
 import Std.Tactic.Do
-import Std.Internal.Do
+import Std.WP
 
 /-!
 `liftMach` coerces the anonymous state transformer `fun s => match c s.machine with …` into
@@ -11,9 +11,8 @@ gives for a constant head with no registered spec, rather than a hard "This shou
 failure.
 -/
 
-open Std.Internal.Do
-
-set_option mvcgen.warning false
+set_option experimental.vcgen true
+open Std.WP
 
 structure Sys where
   machine : Nat


### PR DESCRIPTION
This PR makes `vcgen` report `No spec found for program …` when the program head is one that no strategy steps and no spec keys on, such as the bare `fun s => …` left by unfolding a `liftM` of an anonymous state transformer. Previously this failed with `Failed to decompose weakest precondition … This should not happen`. 