### PR TITLE
feat: lake: run module code quality checks in `lake lint --code-quality`

### DIFF
--- a/src/Lean/Linter/CodeQuality/Frontend.lean
+++ b/src/Lean/Linter/CodeQuality/Frontend.lean
@@ -8,6 +8,7 @@ module
 prelude
 public import Init.System.FilePath
 public import Lean.Linter.CodeQuality.Basic
+public import Lean.Linter.Init
 public import Lean.Elab.InfoTree.Main
 import Lean.CoreM
 import Lean.Elab.Command
@@ -27,20 +28,31 @@ per package; each check sees the whole environment and is responsible for restri
 its metrics to the package named by the `PackageCheckContext` it receives. Registered
 checks are tracked by the `packageCheckExt` environment extension and are run
 concurrently, one task per check, by `runPackageChecks`, which combines all results
-into a single array of entries.
+into a single array of entries. A check that throws contributes no entries and is
+reported back to the driver in `PackageCheckResults.failures`.
 -/
 
 
 /-- Global inputs provided by the driver to every code quality check. -/
 structure PackageCheckContext where
+  /-- Root of the package being checked. A check should report metrics only for this package. -/
   pkgRoot : Name
+  /-- The package's modules that are present in the environment. -/
+  modules : Array Name := #[]
+  /-- The package's declarations that are present in the environment. -/
+  decls : Array Name := #[]
+  /-- The linter options in effect, as selected by the driver. -/
+  linterOptions : LinterOptions := { toOptions := {}, linterSets := {} }
   srcSearchPath : System.SearchPath := {}
 
 abbrev PackageCheck := PackageCheckContext → MetaM (Array Entry)
 
-structure NamedPackageCheck where
-  declName : Name
-  run : PackageCheck
+/-- The combined outcome of running a set of code quality checks. -/
+structure PackageCheckResults where
+  /-- The entries produced by the checks that succeeded. -/
+  entries : Array Entry
+  /-- The checks that threw, paired with their rendered error. -/
+  failures : Array (Name × String)
 
 def getPackageCheck (declName : Name) : CoreM PackageCheck := unsafe
   evalConstCheck PackageCheck ``PackageCheck declName
@@ -71,22 +83,28 @@ builtin_initialize registerBuiltinAttribute {
     modifyEnv fun env => packageCheckExt.addEntry env decl
 }
 
-def getPackageChecks : CoreM (Array NamedPackageCheck) := do
-  (packageCheckExt.getState (← getEnv)).mapM fun declName =>
-    return { declName, run := ← getPackageCheck declName }
+/-- The declaration names of the registered code quality checks, in registration order. -/
+def getPackageCheckNames : CoreM (Array Name) :=
+  return packageCheckExt.getState (← getEnv)
 
-def runPackageChecks (checks : Array NamedPackageCheck) (ctx : PackageCheckContext) :
-    CoreM (Array Entry) := do
-  let tasks ← checks.mapM fun check => do
-    (check.declName, ·) <$> (EIO.asTask <| (← Core.wrapAsync (fun _ =>
-      check.run ctx |>.run' Elab.Command.mkMetaContext
-    ) (cancelTk? := none)) ())
+/--
+Runs the named code quality checks concurrently, one task per check, and combines their results.
+The checks are resolved inside their own task, so a check that cannot be evaluated is reported as
+an ordinary failure rather than aborting the whole run.
+-/
+def runPackageChecks (checkNames : Array Name) (ctx : PackageCheckContext) :
+    CoreM PackageCheckResults := do
+  let tasks ← checkNames.mapM fun declName => do
+    let act : CoreM (Array Entry) := do
+      let check ← getPackageCheck declName
+      check ctx |>.run' Elab.Command.mkMetaContext
+    (declName, ·) <$> (EIO.asTask <| (← Core.wrapAsync (fun _ => act) (cancelTk? := none)) ())
   let mut entries := #[]
+  let mut failures := #[]
   for (declName, task) in tasks do
     match task.get with
     | .ok checkEntries => entries := entries ++ checkEntries
-    | .error err =>
-      IO.eprintln s!"code quality check `{declName}` failed: {← err.toMessageData.toString}"
-  return entries
+    | .error err => failures := failures.push (declName, ← err.toMessageData.toString)
+  return { entries, failures }
 
 end Lean.Linter.CodeQuality

--- a/src/lake/Lake/CLI/BuiltinLint.lean
+++ b/src/lake/Lake/CLI/BuiltinLint.lean
@@ -383,6 +383,41 @@ private def runEnvironmentLinters (args : Args) (linterOpts : Linter.LinterOptio
       return .codeQualityChecks codeQualityEntries
   return outcome
 
+/-- The result of running the registered code quality checks for one package. -/
+private structure PackageCheckOutcome where
+  /-- The entries produced by the checks that succeeded. -/
+  entries : Array CodeQuality.Entry
+  /-- Whether any check threw; such a check contributes no entries. -/
+  failed : Bool
+
+/--
+Runs the code quality checks registered with `@[package_code_quality_check]` over the package
+rooted at `pkgRoot`. Only checks reachable from the lint target's import closure are visible, the
+same constraint that applies to environment linters.
+
+Every check receives the package's modules and declarations, computed once here rather than by
+each check, along with the linter options and source search path in effect. Checks that throw are
+reported on stderr and make the caller exit nonzero; the entries of the remaining checks are still
+emitted.
+-/
+private def runCodeQualityChecks (linterOpts : Linter.LinterOptions) (sp : SearchPath)
+    (env : Environment) (pkgRoot : Name) : IO PackageCheckOutcome := do
+  let (outcome, _) ← CoreM.toIO (ctx := { fileName := "", fileMap := default }) (s := { env }) do
+    let checkNames ← CodeQuality.getPackageCheckNames
+    if checkNames.isEmpty then
+      return { entries := #[], failed := false }
+    let results ← CodeQuality.runPackageChecks checkNames {
+      pkgRoot
+      modules := env.header.moduleNames.filter pkgRoot.isPrefixOf
+      decls := ← Linter.EnvLinter.getDeclsInPackage pkgRoot
+      linterOptions := linterOpts
+      srcSearchPath := sp
+    }
+    for (declName, err) in results.failures do
+      IO.eprintln s!"error: code quality check `{declName}` failed: {err}"
+    return { entries := results.entries, failed := !results.failures.isEmpty }
+  return outcome
+
 public def run (args : Args) : IO UInt32 := do
   let mods := args.mods
   if mods.isEmpty then
@@ -394,6 +429,12 @@ public def run (args : Args) : IO UInt32 := do
 
   let mut anyFailed := false
   let mut anyUnlocated := false
+  -- Whether a registered code quality check threw (only meaningful in `codeQuality` mode, where
+  -- linter warnings are data rather than failures).
+  let mut anyCheckFailed := false
+  -- Package roots whose code quality checks have already been run. A check is per package, so
+  -- running it for two lint targets under the same root would emit duplicate entries.
+  let mut checkedRoots : NameSet := {}
 
   -- Accumulated exceptions to record (only populated when `args.recordExceptions` is set).
   let mut records : Array ExceptionRecord := #[]
@@ -442,7 +483,13 @@ public def run (args : Args) : IO UInt32 := do
     | .codeQualityChecks entries =>
       codeQualityEntries := codeQualityEntries ++ entries
 
-    unless args.mode == .codeQuality do
+    if args.mode == .codeQuality then
+      unless checkedRoots.contains mod.getRoot do
+        checkedRoots := checkedRoots.insert mod.getRoot
+        let checkOutcome ← runCodeQualityChecks linterOpts sp env mod.getRoot
+        codeQualityEntries := codeQualityEntries ++ checkOutcome.entries
+        if checkOutcome.failed then anyCheckFailed := true
+    else
       let deferredResults ← runDeferredChecks args linterOpts sp env mod.getRoot docCheckedModules
       docCheckedModules := deferredResults.checkedModules
       match deferredResults.outcome with
@@ -461,6 +508,6 @@ public def run (args : Args) : IO UInt32 := do
   | .codeQuality =>
     for entry in codeQualityEntries do
       IO.println <| toJson entry
-    return 0
+    return if anyCheckFailed then 1 else 0
 
 end Lake.BuiltinLint

--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -287,8 +287,12 @@ OPTIONS:
                         `set_option <linter> false in` exception by editing the
                         offending source files in place, silencing the warning
                         for that declaration. Implies `--builtin-lint`.
-  --code-quality        records each linter warning as a code quality check result
-                        and runs the registered code quality checks.
+  --code-quality        emit each linter warning as a code quality entry on
+                        stdout and run the code quality checks tagged
+                        `@[package_code_quality_check]` that are reachable from
+                        the lint target's imports. Linter warnings are data and
+                        do not fail the run; a check that throws is reported on
+                        stderr and exits nonzero.
                         Setting this flag will skip lint driver.
 
 A lint driver can be configured by either setting the `lintDriver` package

--- a/tests/elab/code_quality_check.lean
+++ b/tests/elab/code_quality_check.lean
@@ -4,8 +4,9 @@ import Lean
 Tests the code-quality check framework (`Lean.Linter.CodeQuality`): the
 `package_code_quality_check` attribute, the backing `packageCheckExt` environment extension,
 and the concurrent `runPackageChecks` driver producing a combined entry array. Checks
-receive a `PackageCheckContext` with driver-provided inputs such as the package root.
-A check that throws is reported on stderr and contributes no entries.
+receive a `PackageCheckContext` with driver-provided inputs such as the package root and
+the package's modules and declarations. A check that throws contributes no entries and is
+returned to the driver in `PackageCheckResults.failures`.
 -/
 
 open Lean Linter CodeQuality
@@ -28,6 +29,14 @@ public meta def dictMetric : PackageCheck := fun _ =>
 public meta def pkgRootMetric : PackageCheck := fun ctx =>
   return #[{ name := "pkgRootMetric", source := .module ctx.pkgRoot, value := .scalar 0.0 }]
 
+/-- Reports the sizes of the module and declaration lists the driver supplies. -/
+@[package_code_quality_check]
+public meta def contextMetric : PackageCheck := fun ctx =>
+  return #[{ name := "contextMetric", source := .module ctx.pkgRoot,
+             value := .dict (Std.TreeMap.empty
+               |>.insert "decls" ctx.decls.size.toFloat
+               |>.insert "modules" ctx.modules.size.toFloat) }]
+
 /-! ## Test: the extension tracks registered checks -/
 
 def testExtContains (name : Name) : CoreM Bool := do
@@ -41,40 +50,49 @@ def testExtContains (name : Name) : CoreM Bool := do
 #guard_msgs in
 #eval testExtContains `nonexistent
 
-/-! ## Test: getPackageChecks returns all registered checks, in registration order -/
+/-! ## Test: getPackageCheckNames returns all registered checks, in registration order -/
 
-def testGetPackageChecks : CoreM (Array Name) := do
-  return (← getPackageChecks).map (·.declName)
-
-/-- info: #[`dummyMetric, `dictMetric, `pkgRootMetric] -/
+/-- info: #[`dummyMetric, `dictMetric, `pkgRootMetric, `contextMetric] -/
 #guard_msgs in
-#eval testGetPackageChecks
+#eval getPackageCheckNames
 
 /-! ## Test: runPackageChecks combines all results into one entry array, threading the context -/
 
 def testRunPackageChecks : CoreM String := do
-  let entries ← runPackageChecks (← getPackageChecks) { pkgRoot := `MyPkg }
-  return (toJson entries).compress
+  let results ← runPackageChecks (← getPackageCheckNames)
+    { pkgRoot := `MyPkg, modules := #[`MyPkg, `MyPkg.A], decls := #[`MyPkg.foo] }
+  let failures := results.failures.map fun (declName, err) => s!"{declName}: {err}"
+  return s!"{(toJson results.entries).compress}\nfailures: {failures}"
 
 /--
-info: "[{\"name\":\"dummyMetric\",\"source\":{\"module\":{\"name\":\"MyModule\"}},\"value\":{\"scalar\":{\"value\":42}}},{\"name\":\"dummyMetric\",\"source\":{\"declaration\":{\"module\":\"MyModule\",\"name\":\"MyModule.foo\"}},\"value\":{\"scalar\":{\"value\":1}}},{\"name\":\"dictMetric\",\"source\":{\"module\":{\"name\":\"MyModule\"}},\"value\":{\"dict\":{\"dictionary\":{\"a\":1,\"b\":2}}}},{\"name\":\"pkgRootMetric\",\"source\":{\"module\":{\"name\":\"MyPkg\"}},\"value\":{\"scalar\":{\"value\":0}}}]"
+info: "[{\"name\":\"dummyMetric\",\"source\":{\"module\":{\"name\":\"MyModule\"}},\"value\":{\"scalar\":{\"value\":42}}},{\"name\":\"dummyMetric\",\"source\":{\"declaration\":{\"module\":\"MyModule\",\"name\":\"MyModule.foo\"}},\"value\":{\"scalar\":{\"value\":1}}},{\"name\":\"dictMetric\",\"source\":{\"module\":{\"name\":\"MyModule\"}},\"value\":{\"dict\":{\"dictionary\":{\"a\":1,\"b\":2}}}},{\"name\":\"pkgRootMetric\",\"source\":{\"module\":{\"name\":\"MyPkg\"}},\"value\":{\"scalar\":{\"value\":0}}},{\"name\":\"contextMetric\",\"source\":{\"module\":{\"name\":\"MyPkg\"}},\"value\":{\"dict\":{\"dictionary\":{\"decls\":1,\"modules\":2}}}}]\nfailures: #[]"
 -/
 #guard_msgs in
 #eval testRunPackageChecks
 
-/-! ## Test: a failing check is reported on stderr and skipped; other checks still run -/
+/-! ## Test: a failing check contributes no entries but is returned as a failure -/
 
 @[package_code_quality_check]
 public meta def failingMetric : PackageCheck := fun _ =>
   throwError "boom"
 
 /--
-info: code quality check `failingMetric` failed: boom
----
-info: "[{\"name\":\"dummyMetric\",\"source\":{\"module\":{\"name\":\"MyModule\"}},\"value\":{\"scalar\":{\"value\":42}}},{\"name\":\"dummyMetric\",\"source\":{\"declaration\":{\"module\":\"MyModule\",\"name\":\"MyModule.foo\"}},\"value\":{\"scalar\":{\"value\":1}}},{\"name\":\"dictMetric\",\"source\":{\"module\":{\"name\":\"MyModule\"}},\"value\":{\"dict\":{\"dictionary\":{\"a\":1,\"b\":2}}}},{\"name\":\"pkgRootMetric\",\"source\":{\"module\":{\"name\":\"MyPkg\"}},\"value\":{\"scalar\":{\"value\":0}}}]"
+info: "[{\"name\":\"dummyMetric\",\"source\":{\"module\":{\"name\":\"MyModule\"}},\"value\":{\"scalar\":{\"value\":42}}},{\"name\":\"dummyMetric\",\"source\":{\"declaration\":{\"module\":\"MyModule\",\"name\":\"MyModule.foo\"}},\"value\":{\"scalar\":{\"value\":1}}},{\"name\":\"dictMetric\",\"source\":{\"module\":{\"name\":\"MyModule\"}},\"value\":{\"dict\":{\"dictionary\":{\"a\":1,\"b\":2}}}},{\"name\":\"pkgRootMetric\",\"source\":{\"module\":{\"name\":\"MyPkg\"}},\"value\":{\"scalar\":{\"value\":0}}},{\"name\":\"contextMetric\",\"source\":{\"module\":{\"name\":\"MyPkg\"}},\"value\":{\"dict\":{\"dictionary\":{\"decls\":1,\"modules\":2}}}}]\nfailures: #[failingMetric: boom]"
 -/
 #guard_msgs in
 #eval testRunPackageChecks
+
+/-! ## Test: a check that cannot be evaluated is a failure, not an aborted run -/
+
+def testUnknownCheck : CoreM String := do
+  let results ← runPackageChecks #[`dummyMetric, `nonexistent] { pkgRoot := `MyPkg }
+  return s!"{results.entries.size} entries, failures: {results.failures.map (·.1)}"
+
+/--
+info: "2 entries, failures: #[nonexistent]"
+-/
+#guard_msgs in
+#eval testUnknownCheck
 
 /-! ## Test: a declaration that is not `meta` is rejected -/
 

--- a/tests/lake/tests/builtin-lint-code-quality/Checks.lean
+++ b/tests/lake/tests/builtin-lint-code-quality/Checks.lean
@@ -1,0 +1,27 @@
+import Lean.Linter.CodeQuality
+
+open Lean Linter CodeQuality
+
+/-! Code quality checks exercising the inputs the driver supplies in `PackageCheckContext`.
+They are picked up because `Violations.lean` imports this module: checks are discovered from the
+lint target's import closure. -/
+
+/-- The number of package modules in the environment. -/
+@[package_code_quality_check]
+public meta def moduleCount : PackageCheck := fun ctx =>
+  return #[{ name := "moduleCount", source := .module ctx.pkgRoot,
+             value := .scalar ctx.modules.size.toFloat }]
+
+/-- The number of package declarations whose name ends with `DummyMarker`. -/
+@[package_code_quality_check]
+public meta def dummyMarkerCount : PackageCheck := fun ctx =>
+  let count := ctx.decls.filter (·.toString.endsWith "DummyMarker") |>.size
+  return #[{ name := "dummyMarkerCount", source := .module ctx.pkgRoot,
+             value := .scalar count.toFloat }]
+
+/-- Whether the package root's source file is reachable via the supplied search path. -/
+@[package_code_quality_check]
+public meta def sourceReachable : PackageCheck := fun ctx => do
+  let found? ← SearchPath.findWithExt ctx.srcSearchPath "lean" ctx.pkgRoot
+  return #[{ name := "sourceReachable", source := .module ctx.pkgRoot,
+             value := .scalar (if found?.isSome then 1.0 else 0.0) }]

--- a/tests/lake/tests/builtin-lint-code-quality/FailingCheck.lean
+++ b/tests/lake/tests/builtin-lint-code-quality/FailingCheck.lean
@@ -1,0 +1,11 @@
+import Checks
+
+open Lean Linter CodeQuality
+
+/-! A separate lint target whose import closure contains a check that throws. Linting it exercises
+the failure path: the error is reported on stderr, the other checks' entries are still emitted, and
+`lake lint` exits nonzero. -/
+
+@[package_code_quality_check]
+public meta def failingCheck : PackageCheck := fun _ =>
+  throwError "boom"

--- a/tests/lake/tests/builtin-lint-code-quality/Violations.lean
+++ b/tests/lake/tests/builtin-lint-code-quality/Violations.lean
@@ -1,4 +1,5 @@
 import Linters
+import Checks
 import Violations.Sub
 
 -- Two `linter.unusedVariables` warnings (a text linter, default-on) in this

--- a/tests/lake/tests/builtin-lint-code-quality/expected.json
+++ b/tests/lake/tests/builtin-lint-code-quality/expected.json
@@ -1,5 +1,8 @@
 {"value":{"scalar":{"value":1}},"source":{"declaration":{"name":"Inner.nestedDummyMarker","module":"Violations"}},"name":"linter.dummyMarker"}
 {"value":{"scalar":{"value":1}},"source":{"declaration":{"name":"fooDummyMarker","module":"Violations"}},"name":"linter.dummyMarker"}
 {"value":{"scalar":{"value":1}},"source":{"declaration":{"name":"subDummyMarker","module":"Violations.Sub"}},"name":"linter.dummyMarker"}
+{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations"}},"name":"sourceReachable"}
 {"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations.Sub"}},"name":"linter.unusedVariables"}
 {"value":{"scalar":{"value":2}},"source":{"module":{"name":"Violations"}},"name":"linter.unusedVariables"}
+{"value":{"scalar":{"value":2}},"source":{"module":{"name":"Violations"}},"name":"moduleCount"}
+{"value":{"scalar":{"value":4}},"source":{"module":{"name":"Violations"}},"name":"dummyMarkerCount"}

--- a/tests/lake/tests/builtin-lint-code-quality/lakefile.toml
+++ b/tests/lake/tests/builtin-lint-code-quality/lakefile.toml
@@ -5,5 +5,11 @@ defaultTargets = ["Violations"]
 name = "Linters"
 
 [[lean_lib]]
+name = "Checks"
+
+[[lean_lib]]
+name = "FailingCheck"
+
+[[lean_lib]]
 name = "Violations"
 globs = "Violations.*"

--- a/tests/lake/tests/builtin-lint-code-quality/test.sh
+++ b/tests/lake/tests/builtin-lint-code-quality/test.sh
@@ -57,6 +57,13 @@ no_match_text 'suppressedDummyMarker' produced.json
 # Nothing outside the linted package leaks in (`Linters.lean` defines the linter).
 no_match_text '"module":"Linters"' produced.json
 
+# Registered checks reachable from the lint target's import closure (`Checks.lean`,
+# imported by `Violations.lean`) run alongside the linters:
+# `modules` holds the two package modules, not the imported `Linters`/`Checks`...
+match_text '{"value":{"scalar":{"value":2}},"source":{"module":{"name":"Violations"}},"name":"moduleCount"}' produced.json
+# ...and `srcSearchPath` resolves the package's sources.
+match_text '{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations"}},"name":"sourceReachable"}' produced.json
+
 # --- Linter selection. ---
 # `--lint-only` restricts the output to the explicitly enabled linters.
 lake_out lint --code-quality --lint-only=linter.dummyMarker Violations
@@ -70,7 +77,21 @@ collect_json
 no_match_text 'linter.unusedVariables' produced.json
 match_text 'fooDummyMarker' produced.json
 
-# --- No violations means no entries. ---
+# --- Checks are not gated by the linter selection. ---
+# Disabling every linter leaves exactly the entries of the registered checks.
 lake_out lint --code-quality --lint-only=-linter.all Violations
 collect_json
-test_cmd test ! -s produced.json
+no_match_text '"name":"linter.' produced.json
+match_text '"name":"moduleCount"' produced.json
+
+# --- A check that throws. ---
+# `FailingCheck` is a separate lint target whose closure adds a check that throws.
+# The failure is reported on stderr and makes `lake lint` exit 1, but the entries
+# of the checks that succeeded are still emitted.
+rc=0
+lake_out lint --code-quality FailingCheck || rc=$?
+test_cmd test "$rc" -eq 1
+match_text 'error: code quality check `failingCheck` failed: boom' produced.out
+collect_json
+# The package root is the lint target, so only its own module is counted.
+match_text '{"value":{"scalar":{"value":1}},"source":{"module":{"name":"FailingCheck"}},"name":"moduleCount"}' produced.json


### PR DESCRIPTION
This PR adds the support for running the module code quality checks through `lake lint --code-quality`.