### PR TITLE
fix: support for `Expr.mdata` at `SymM` matcher

### DIFF
--- a/src/Lean/Meta/Sym/Pattern.lean
+++ b/src/Lean/Meta/Sym/Pattern.lean
@@ -527,9 +527,9 @@ partial def process (p : Expr) (e : Expr) : UnifyM Bool := do
   -- A pattern subterm internalized into the same table as the target shares its pointer, so a
   -- pointer match is a closed term equal to the target with no variables left to bind.
   if isSameExpr p e then return true
-  let e' := etaReduce e
+  let e' := etaReduce e |>.consumeMData
   if !isSameExpr e e' then
-    -- **Note**: We eagerly eta reduce patterns
+    -- **Note**: We eagerly eta reduce patterns and consume mdata
     process p e'
   else match p with
   | .bvar bidx => assignExpr bidx e
@@ -615,7 +615,7 @@ where
 
   processAppWithInfo (p : Expr) (e : Expr) (i : Nat) (info : ProofInstInfo) : UnifyM Bool := do
     let .app fp ap := p | if e.isApp then return false else process p e
-    let .app fe ae := e | checkLetVar p e
+    let .app fe ae := e.consumeMData | checkLetVar p e
     unless (← processAppWithInfo fp fe (i - 1) info) do return false
     if h : i < info.argsInfo.size then
       let argInfo := info.argsInfo[i]
@@ -636,7 +636,7 @@ where
 
   processAppDefault (p : Expr) (e : Expr) : UnifyM Bool := do
     let .app fp ap := p | if e.isApp then return false else process p e
-    let .app fe ae := e | checkLetVar p e
+    let .app fe ae := e.consumeMData | checkLetVar p e
     unless (← processAppDefault fp fe) do return false
     process ap ae
 

--- a/src/Lean/Meta/Sym/Simp/App.lean
+++ b/src/Lean/Meta/Sym/Simp/App.lean
@@ -116,9 +116,13 @@ public def simpOverApplied (e : Expr) (numArgs : Nat) (simpFn : Expr → SimpM R
     if i == 0 then
       simpFn e
     else
-      let i := i - 1
       match h : e with
+      | .mdata _ b =>
+        -- `getMatchWithExtra` counts applications through `mdata`, so peel it without consuming `i`.
+        -- The wrapper is dropped from the result; the proof still applies since `mdata` is transparent.
+        visit b i
       | .app f a =>
+        let i := i - 1
         let fr ← visit f i
         let .forallE _ α β _ ← whnfD (← inferType f) | unreachable!
         if !β.hasLooseBVars then

--- a/src/Lean/Meta/Sym/Simp/DiscrTree.lean
+++ b/src/Lean/Meta/Sym/Simp/DiscrTree.lean
@@ -132,10 +132,10 @@ abbrev findKey? (cs : Array (Key × Trie α)) (k : Key) : Option (Key × Trie α
   cs.binSearch (k, default) (fun a b => a.1 < b.1)
 
 def getKey (e : Expr) : Key :=
-  match e.getAppFn with
+  match e.getAppFn' with
   | .lit v            => .lit v
-  | .const declName _ => .const declName e.getAppNumArgs
-  | .fvar fvarId      => .fvar fvarId e.getAppNumArgs
+  | .const declName _ => .const declName e.getAppNumArgs'
+  | .fvar fvarId      => .fvar fvarId e.getAppNumArgs'
   | .forallE ..       => .arrow
   | _ => .other
 
@@ -144,6 +144,7 @@ def pushArgsTodo (todo : Array Expr) (e : Expr) : Array Expr :=
   match e with
   | .app f a => pushArgsTodo (todo.push a) f
   | .forallE _ d b _ => todo.push b |>.push d
+  | .mdata _ e => pushArgsTodo todo e
   | _ => todo
 
 partial def getMatchLoop (todo : Array Expr) (c : Trie α) (result : Array α) : Array α :=
@@ -198,7 +199,7 @@ This is useful for rewriting: if a pattern matches `f x` but `e` is `f x y z`, w
 still apply the rewrite and return `(value, 2)` indicating 2 extra arguments.
 -/
 public partial def getMatchWithExtra (d : DiscrTree α) (e : Expr) : Array (α × Nat) :=
-  let e := etaReduce e
+  let e := etaReduce e |>.consumeMData
   let result := getMatch d e
   let result := result.map (·, 0)
   if !e.isApp then
@@ -221,6 +222,7 @@ where
 
   go (e : Expr) (numExtra : Nat) (result : Array (α × Nat)) : Array (α × Nat) :=
     let result := result ++ (getMatch d e).map (., numExtra)
+    let e := e.consumeMData
     if e.isApp then
       go e.appFn! (numExtra + 1) result
     else

--- a/tests/elab/sym_simp_mdata.lean
+++ b/tests/elab/sym_simp_mdata.lean
@@ -1,0 +1,31 @@
+import Std.Tactic.BVDecide
+import Lean
+set_option warn.sorry false
+
+open Lean Meta Sym Sym.Simp
+
+theorem notNot (a : Bool) : (!!a) = a := by simp
+
+theorem negToNot (a : Bool) : (¬(a = true)) = ((!a) = true) := by simp
+
+def runSymSimp (e : Expr) : MetaM Expr := SymM.run do
+  let methods ← mkMethods #[``notNot, ``negToNot]
+  let e ← preprocessExpr e
+  let (r, _) ← SimpM.run (Sym.Simp.simp e) methods
+  return Result.getResultExpr e r
+
+/--
+info: plain:   (!b) = true
+---
+info: wrapped: (!b) = true
+-/
+#guard_msgs in
+run_meta do
+  withLocalDeclD `b (mkConst ``Bool) fun b => do
+    -- `(!!b) = true`
+    let inner := mkApp3 (mkConst ``Eq [1]) (mkConst ``Bool)
+      (mkApp (mkConst ``Bool.not) (mkApp (mkConst ``Bool.not) b)) (mkConst ``Bool.true)
+    let plain   := mkApp (mkConst ``Not) inner
+    let wrapped := mkApp (mkConst ``Not) (mkAnnotation `noImplicitLambda inner)
+    logInfo m!"plain:   {← runSymSimp plain}"
+    logInfo m!"wrapped: {← runSymSimp wrapped}"


### PR DESCRIPTION
This PR ensures that the `SymM` matcher/unifier does not get confused by `Expr.mdata`.
