### PR TITLE
fix: support for assigned mvars at `SymM` discr trees

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Attr.lean
+++ b/src/Lean/Elab/Tactic/Do/Attr.lean
@@ -367,7 +367,8 @@ structure SpecTheorems where
 
 /-- Insert `e`, keeping the higher priority when a spec with the same proof is already stored. -/
 def SpecTheorems.insert (d : SpecTheorems) (e : SpecTheorem) : SpecTheorems :=
-  let priority := (Sym.getMatch d.specs e.pattern.pattern).foldl (init := e.priority) fun pr s =>
+  -- Patterns contain no metavariables, so an empty `MetavarContext` suffices.
+  let priority := (Sym.getMatch {} d.specs e.pattern.pattern).foldl (init := e.priority) fun pr s =>
     if s.proof == e.proof then max pr s.priority else pr
   { d with specs := Sym.insertPattern d.specs e.pattern { e with priority } }
 

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -373,7 +373,7 @@ public def matchFrame? (fp : FrameProc) (info : WPApp) : VCGenM (Option Expr) :=
   let db := (← get).frameDB
   if db.entries.isEmpty then return none
   let mut best : Option (FrameEntry × Sym.MatchUnifyResult) := none
-  for srcIdx in Sym.getMatch db.tree info.prog do
+  for srcIdx in Sym.getMatch (← getMCtx) db.tree info.prog do
     let entry := db.entries[srcIdx]!
     if entry.retired then continue
     if let some res ← entry.pat.match? info.prog then

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/SpecDB.lean
@@ -111,7 +111,7 @@ public def SpecAttr.SpecTheorems.findSpecs (database : SpecTheorems) (e : Expr) 
     SymM (Array SpecTheorem) := do
   let e ← instantiateMVars e
   let e ← shareCommon e
-  let candidates := Sym.getMatch database.specs e
+  let candidates := Sym.getMatch (← getMCtx) database.specs e
   let candidates := candidates.filter fun spec => !database.erased.contains spec.proof
   -- It appears that insertion sort is *much* faster than qsort here.
   return candidates.insertionSort (·.priority > ·.priority)

--- a/src/Lean/Meta/Sym/Simp/DiscrTree.lean
+++ b/src/Lean/Meta/Sym/Simp/DiscrTree.lean
@@ -139,6 +139,24 @@ def getKey (e : Expr) : Key :=
   | .forallE ..       => .arrow
   | _ => .other
 
+/--
+If its head is an assigned metavariable, replaces it with its value,
+beta-reducing any applied arguments. Goal types may mention metavariables assigned after the
+goal was created (e.g. by `Pattern.unify?` or by solving a sibling subgoal), so retrieval must
+see through assignments; unassigned metavariables remain opaque atoms (`Key.other`). The result
+is used only for key computation and need not be maximally shared.
+-/
+partial def resolveAssignedMVars (mctx : MetavarContext) (e : Expr) : Expr :=
+  if e.hasExprMVar then
+    match e.getAppFn with
+    | .mvar mvarId =>
+      match mctx.getExprAssignmentCore? mvarId with
+      | some v => resolveAssignedMVars mctx (v.betaRev e.getAppRevArgs)
+      | none => e
+    | _ => e
+  else
+    e
+
 /-- Push `e` arguments/children into the `todo` stack.  -/
 def pushArgsTodo (todo : Array Expr) (e : Expr) : Array Expr :=
   match e with
@@ -147,7 +165,7 @@ def pushArgsTodo (todo : Array Expr) (e : Expr) : Array Expr :=
   | .mdata _ e => pushArgsTodo todo e
   | _ => todo
 
-partial def getMatchLoop (todo : Array Expr) (c : Trie α) (result : Array α) : Array α :=
+partial def getMatchLoop (mctx : MetavarContext) (todo : Array Expr) (c : Trie α) (result : Array α) : Array α :=
   match c with
   | .node vs cs =>
     let csize := cs.size
@@ -156,15 +174,15 @@ partial def getMatchLoop (todo : Array Expr) (c : Trie α) (result : Array α) :
     else if h : csize = 0 then
       result
     else
-      let e     := etaReduce todo.back!
+      let e     := resolveAssignedMVars mctx <| etaReduce todo.back!
       let todo  := todo.pop
       let first := cs[0] /- Recall that `Key.star` is the minimal key -/
       if csize = 1 then
         /- Special case: only one child node -/
         if first.1 == .star then
-          getMatchLoop todo first.2 result
+          getMatchLoop mctx todo first.2 result
         else if first.1 == getKey e then
-          getMatchLoop (pushArgsTodo todo e) first.2 result
+          getMatchLoop mctx (pushArgsTodo todo e) first.2 result
         else
           result
       else
@@ -172,24 +190,25 @@ partial def getMatchLoop (todo : Array Expr) (c : Trie α) (result : Array α) :
           Thus, `todo` is not used linearly when there is `Key.star` edge
           and there is an edge for `k` and `k != Key.star`. -/
         let result := if first.1 == .star then
-          getMatchLoop todo first.2 result
+          getMatchLoop mctx todo first.2 result
         else
           result
         match findKey? cs (getKey e) with
         | none   => result
-        | some c => getMatchLoop (pushArgsTodo todo e) c.2 result
+        | some c => getMatchLoop mctx (pushArgsTodo todo e) c.2 result
 
 /--
 Retrieves all values whose patterns match the expression `e`.
+`mctx` is used to resolve assigned metavariables during retrieval; see `resolveAssignedMVars`.
 -/
-public def getMatch (d : DiscrTree α) (e : Expr) : Array α :=
+public def getMatch (mctx : MetavarContext) (d : DiscrTree α) (e : Expr) : Array α :=
   let result := match d.root.find? .star with
   | none              => .mkEmpty initCapacity
   | some (.node vs _) => vs
-  let e := etaReduce e
+  let e := resolveAssignedMVars mctx <| etaReduce e
   match d.root.find? (getKey e) with
   | none   => result
-  | some c => getMatchLoop (pushArgsTodo #[] e) c result
+  | some c => getMatchLoop mctx (pushArgsTodo #[] e) c result
 
 /--
 Retrieves all values whose patterns match a prefix of `e`, along with the number of
@@ -198,9 +217,10 @@ extra (ignored) arguments.
 This is useful for rewriting: if a pattern matches `f x` but `e` is `f x y z`, we can
 still apply the rewrite and return `(value, 2)` indicating 2 extra arguments.
 -/
-public partial def getMatchWithExtra (d : DiscrTree α) (e : Expr) : Array (α × Nat) :=
-  let e := etaReduce e |>.consumeMData
-  let result := getMatch d e
+public partial def getMatchWithExtra (mctx : MetavarContext) (d : DiscrTree α) (e : Expr) : Array (α × Nat) :=
+  let e := resolveAssignedMVars mctx <| etaReduce e
+  let e := e.consumeMData
+  let result := getMatch mctx d e
   let result := result.map (·, 0)
   if !e.isApp then
     result
@@ -221,8 +241,12 @@ where
     | _               => false
 
   go (e : Expr) (numExtra : Nat) (result : Array (α × Nat)) : Array (α × Nat) :=
+<<<<<<< HEAD
     let result := result ++ (getMatch d e).map (., numExtra)
     let e := e.consumeMData
+=======
+    let result := result ++ (getMatch mctx d e).map (., numExtra)
+>>>>>>> f4b5789a1b (fix: handle assigned mvars at `SymM` discr trees)
     if e.isApp then
       go e.appFn! (numExtra + 1) result
     else

--- a/src/Lean/Meta/Sym/Simp/DiscrTree.lean
+++ b/src/Lean/Meta/Sym/Simp/DiscrTree.lean
@@ -241,12 +241,8 @@ where
     | _               => false
 
   go (e : Expr) (numExtra : Nat) (result : Array (α × Nat)) : Array (α × Nat) :=
-<<<<<<< HEAD
-    let result := result ++ (getMatch d e).map (., numExtra)
-    let e := e.consumeMData
-=======
     let result := result ++ (getMatch mctx d e).map (., numExtra)
->>>>>>> f4b5789a1b (fix: handle assigned mvars at `SymM` discr trees)
+    let e := e.consumeMData
     if e.isApp then
       go e.appFn! (numExtra + 1) result
     else

--- a/src/Lean/Meta/Sym/Simp/Rewrite.lean
+++ b/src/Lean/Meta/Sym/Simp/Rewrite.lean
@@ -99,7 +99,7 @@ public def Theorems.rewrite (thms : Theorems) (d : Discharger := dischargeNone) 
   -- and theorem B succeeds with cd=false, the result is still cd=true: in another
   -- context A might succeed (with higher priority) and produce a different result.
   let mut anyCD := false
-  for (thm, numExtra) in thms.getMatchWithExtra e do
+  for (thm, numExtra) in thms.getMatchWithExtra (← getMCtx) e do
     let result ← if numExtra == 0 then
       thm.rewrite e d
     else

--- a/src/Lean/Meta/Sym/Simp/Theorems.lean
+++ b/src/Lean/Meta/Sym/Simp/Theorems.lean
@@ -49,11 +49,11 @@ structure Theorems where
 def Theorems.insert (thms : Theorems) (thm : Theorem) : Theorems :=
   { thms with thms := insertPattern thms.thms thm.pattern thm }
 
-def Theorems.getMatch (thms : Theorems) (e : Expr) : Array Theorem :=
-  Sym.getMatch thms.thms e
+def Theorems.getMatch (thms : Theorems) (mctx : MetavarContext) (e : Expr) : Array Theorem :=
+  Sym.getMatch mctx thms.thms e
 
-def Theorems.getMatchWithExtra (thms : Theorems) (e : Expr) : Array (Theorem × Nat) :=
-  Sym.getMatchWithExtra thms.thms e
+def Theorems.getMatchWithExtra (thms : Theorems) (mctx : MetavarContext) (e : Expr) : Array (Theorem × Nat) :=
+  Sym.getMatchWithExtra mctx thms.thms e
 
 /--
 Check whether `lhs` and `rhs` (with `numVars` pattern variables represented as `.bvar` indices

--- a/src/Lean/Meta/Tactic/Cbv/CbvSimproc.lean
+++ b/src/Lean/Meta/Tactic/Cbv/CbvSimproc.lean
@@ -254,7 +254,7 @@ def getCbvSimprocs : CoreM CbvSimprocs :=
 
 def cbvSimprocDispatch (tree : DiscrTree CbvSimprocEntry)
     (erased : PHashSet Name) : Simproc := fun e => do
-  let candidates := Sym.getMatchWithExtra tree e
+  let candidates := Sym.getMatchWithExtra (← getMCtx) tree e
   if candidates.isEmpty then
     return .rfl
   for (entry, numExtra) in candidates do

--- a/tests/elab/grind_hom_attr.lean
+++ b/tests/elab/grind_hom_attr.lean
@@ -29,10 +29,10 @@ def checkMatches : MetaM Unit := do
   withLocalDeclD `x (mkConst ``W) fun x => do
     let thms ← getHomoTheorems
     let add ← mkAppM ``wu #[← mkAppM ``HAdd.hAdd #[x, x]]
-    for thm in thms.getMatch add do
+    for thm in thms.getMatch (← getMCtx) add do
       logInfo m!"{thm.expr}"
     let eq ← mkEq x x
-    for thm in thms.getMatch eq do
+    for thm in thms.getMatch (← getMCtx) eq do
       logInfo m!"{thm.expr}"
 
 /--

--- a/tests/elab/grind_hom_lemmas.lean
+++ b/tests/elab/grind_hom_lemmas.lean
@@ -16,7 +16,7 @@ def showMatches (declName : Name) : MetaM Unit := do
   lambdaTelescope value fun _ body => SymM.run do
     let body ← share body
     let thms ← Grind.getHomoTheorems
-    for thm in thms.getMatch body do
+    for thm in thms.getMatch (← getMCtx) body do
       logInfo m!"{thm.expr}"
 
 /--

--- a/tests/elab/sym_discrtree_assigned_mvars.lean
+++ b/tests/elab/sym_discrtree_assigned_mvars.lean
@@ -1,0 +1,23 @@
+import Lean.Meta.Sym
+import Std.Internal.Do
+
+/-!
+`Sym` discrimination-tree retrieval resolves assigned metavariables lazily.
+
+`Pattern.unify?` creates the metavariables for pattern variables before solving pending
+constraints, so subgoals returned by `Sym.BackwardRule.apply` can have stored types that
+mention assigned metavariables. Here, after `apply le_of_forall_le` and `intro`, the goal's
+stored carrier is such a metavariable. `le_pi_eq_forall`'s pattern requires an arrow in that
+position; retrieval must follow the assignment to find the theorem, otherwise `Sym.simp`
+fails with "made no progress". The matching layers below retrieval already resolve assigned
+metavariables.
+-/
+
+open Lean.Order
+
+example (f g : Nat → Nat → Prop) (h : ∀ a b, f a b ⊑ g a b) : f ⊑ g := by
+  sym =>
+    apply Lean.Order.le_of_forall_le
+    intro a
+    simp [Lean.Order.le_pi_eq_forall]
+    tactic => exact h a

--- a/tests/elab/sym_discrtree_eta.lean
+++ b/tests/elab/sym_discrtree_eta.lean
@@ -16,5 +16,5 @@ info: disc tree lookup match count: 1
   assert! e.appArg!.isLambda
   let pat ← mkPatternFromDecl ``stateT_P
   let dt := Sym.insertPattern (Lean.Meta.DiscrTree.empty (α := Unit)) pat ()
-  let nMatches := (Sym.getMatch dt e).size
+  let nMatches := (Sym.getMatch (← getMCtx) dt e).size
   logInfo m!"disc tree lookup match count: {nMatches}"

--- a/tests/elab/sym_eta_mwe.lean
+++ b/tests/elab/sym_eta_mwe.lean
@@ -42,7 +42,7 @@ info: GOOD: getMatch and brute-force agree
   let e ← instantiateMVars (← getConstInfo ``lookupTerm).value?.get!
   let e ← SymM.run (shareCommon e)
 
-  let treeResults := Sym.getMatch tree e
+  let treeResults := Sym.getMatch (← getMCtx) tree e
   let mut bruteResults : Array Name := #[]
   for (name, pat) in #[(``Spec.IterM.forIn_map, patMap), (``Spec.forIn_iterM_id, patGeneric)] do
     if let some _ ← SymM.run (pat.match? e) then

--- a/tests/elab/sym_issue_13416.lean
+++ b/tests/elab/sym_issue_13416.lean
@@ -35,5 +35,5 @@ info: disc tree lookup match count: 1
   guard dom.isLambda
   guard <| !(Lean.Expr.eta dom).isLambda
 
-  let nMatches := (tree.getMatchWithExtra lhs).size
+  let nMatches := (tree.getMatchWithExtra (← getMCtx) lhs).size
   logInfo m!"disc tree lookup match count: {nMatches}"

--- a/tests/pkg/homo/Homo/Init.lean
+++ b/tests/pkg/homo/Homo/Init.lean
@@ -114,9 +114,9 @@ Returns `true` if some theorem marked with `[grind_homo]` is applicable to `e`.
 
 Motivation: we don't want to start the simplifier and fail immediately.
 -/
-def isTarget (e : Expr) : CoreM Bool := do
+def isTarget (e : Expr) : MetaM Bool := do
   let thms ← getTheorems
-  return !(thms.getMatch e).isEmpty
+  return !(thms.getMatch (← getMCtx) e).isEmpty
 
 /--
 Internalization procedure for this module. See `homoExt.setMethods`


### PR DESCRIPTION
This PR ensures assigned metavariables are properly handled in the `SymM` discrimination tree module.

