### PR TITLE
test: lake: mock remote cache artifact transfers

### DIFF
--- a/src/lake/Lake/Build/Actions.lean
+++ b/src/lake/Lake/Build/Actions.lean
@@ -10,6 +10,7 @@ public import Lake.Util.Log
 import Lake.Util.Proc
 import Lake.Util.FilePath
 import Lake.Util.IO
+import Lake.Util.Url
 import Init.Data.String.Search
 import Init.Data.String.TakeDrop
 import Init.System.Platform
@@ -186,7 +187,7 @@ public def download
     createParentDirs file
   let args := #["-s", "-S", "-f", "-o", file.toString, "-L", url]
   let args := headers.foldl (init := args) (· ++ #["-H", ·])
-  proc (quiet := true) {cmd := "curl", args}
+  proc (quiet := true) {cmd := ← Internal.getCurl, args}
 
 /-- Unpack an archive `file` using `tar` into the directory `dir`. -/
 public def untar (file : FilePath) (dir : FilePath) (gzip := true) : LogIO PUnit := do

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -547,7 +547,7 @@ protected def get : CliM PUnit := do
       -- TODO: Parallelize?
       let ok ← ws.packages.foldlM (start := 1) (init := true) (m := LoggerIO) fun ok pkg => do
         let some remoteScope := pkg.reservoirScope?
-          | logInfo s!"{pkg.prettyName}: skipping non-Reservoir dependency`"
+          | logInfo s!"{pkg.prettyName}: skipping non-Reservoir dependency"
             return ok
         let platform := cachePlatform pkg platform
         let toolchain := cacheToolchain pkg toolchain

--- a/src/lake/Lake/Config/Cache.lean
+++ b/src/lake/Lake/Config/Cache.lean
@@ -564,7 +564,7 @@ def uploadS3
   (file : FilePath) (contentType : String) (url : String) (key : String)
 : LoggerIO Unit := do
   let out ← captureProc' {
-    cmd := "curl"
+    cmd := ← Internal.getCurl
     args := #[
       "-s", "-w", "%{stderr}%{json}\n",
       "--aws-sigv4", "aws:amz:auto:s3", "--user", key,
@@ -883,7 +883,7 @@ def transferArtifacts
         "-s", "-w", "%{stderr}%{json}\n", "--config", path.toString
       ]
   let child ← IO.Process.spawn {
-    cmd := "curl", args
+    cmd := ← Internal.getCurl, args
     stdout := .piped, stderr := .piped
   }
   let s ← monitorTransfer cfg child.stderr child.stdout {}
@@ -963,7 +963,7 @@ where
       ]
     let args := Reservoir.lakeHeaders.foldl (· ++ #["-H", ·]) args
     let spawnArgs := {
-      cmd := "curl", args := args.push url
+      cmd := ← Internal.getCurl, args := args.push url
       stdout := .piped, stderr := .piped
     }
     logVerbose (mkCmdLog spawnArgs)

--- a/src/lake/Lake/Util/Url.lean
+++ b/src/lake/Lake/Util/Url.lean
@@ -101,6 +101,14 @@ public def uriEncodeChar (c : Char) (s := "") : String :=
 public def uriEncode (s : String) (init := "") : String :=
   s.foldl (init := init) fun s c => uriEncodeChar c s
 
+/-- **For internal use only.** -/
+-- Currently only for test use.
+-- TODO: Move tracking to `Lake.Env` when feasible
+@[inline] public def Internal.getCurl : BaseIO String := do
+  -- Need to use a different `curl` on Windows where the system will
+  -- otherwise always prefer the OS-provided version over that in `PATH`.
+  return (← IO.getEnv "CURL").getD "curl"
+
 /--
 Performs a HTTP `GET` request of a URL (using `curl` with JSON output) and, if successful,
 return the body.  Otherwise, returns `none` on a 404 and errors on anything else.
@@ -113,7 +121,7 @@ public def getUrl?
       "--retry", "3" -- intermittent network errors can occur
   ]
   let args := headers.foldl (init := args) (· ++ #["-H", ·])
-  let out ← captureProc' {cmd := "curl", args := args.push url}
+  let out ← captureProc' {cmd := ← Internal.getCurl, args := args.push url}
   match Json.parse out.stderr >>= JsonObject.fromJson? with
   | .ok data =>
     let code ← id do
@@ -137,4 +145,4 @@ public def getUrl (url : String) (headers : Array String := #[]) : LogIO String 
       "--retry", "3" -- intermittent network errors can occur
   ]
   let args := headers.foldl (init := args) (· ++ #["-H", ·])
-  captureProc {cmd := "curl", args := args.push url}
+  captureProc {cmd := ← Internal.getCurl, args := args.push url}

--- a/tests/lake/tests/cache/online-test.sh
+++ b/tests/lake/tests/cache/online-test.sh
@@ -54,61 +54,6 @@ export ELAN_TOOLCHAIN=
 
 echo "# TESTS"
 
-# Test `--repo` validation
-test_err "must contain exactly one '/'" cache get --repo='invalid'
-test_err 'invalid characters in repository name' cache get --repo='!/invalid'
-
-# Test `--mappings-only` validation
-test_err '`--mappings-only` is not supported' cache get --mappings-only bogus.jsonl
-with_cdn_endpoints  test_err '`--mappings-only` requires services' cache get --mappings-only
-
-# Test `--service` validation
-test_err 'service `bogus` not found in system configuration' \
-  cache get --service='bogus'
-test_err 'service `bogus` not found in system configuration'\
-  cache put bogus.jsonl --scope='bogus' --service='bogus'
-
-# Test `cache get` command errors for bad configurations
-test_err '`--no-overwrite` is not supported for `cache get`' \
-  cache get --no-overwrite
-test_err 'the `--platform` and `--toolchain` options do nothing' \
-  cache get bogus.jsonl --scope='bogus' --platform='bogus' --wfail
-test_err 'the `--platform` and `--toolchain` options do nothing' \
-  cache get bogus.jsonl --scope='bogus' --toolchain='bogus' --wfail
-test_err 'a custom endpoint must be set (not Reservoir)' cache get --scope='bogus'
-with_cdn_endpoints test_err 'the `--scope` or `--repo` option must be set' cache get
-LAKE_CACHE_ARTIFACT_ENDPOINT=bogus test_err 'both environment variables must be set' cache get
-LAKE_CACHE_REVISION_ENDPOINT=bogus test_err 'both environment variables must be set' cache get
-
-# Test `cache put` command errors for bad configurations
-with_upload_endpoints test_err 'the `--scope` or `--repo` option must be set' cache put bogus.jsonl
-test_err 'the `--service` option must be set' \
-  cache put bogus.jsonl --scope='bogus'
-LAKE_CACHE_KEY= test_err 'the `--service` option must be set' \
-  cache put bogus.jsonl --scope='bogus'
-LAKE_CACHE_REVISION_ENDPOINT=bogus test_err 'these environment variables must be set' \
-  cache put bogus.jsonl --scope='bogus'
-LAKE_CACHE_REVISION_ENDPOINT=bogus test_err 'these environment variables must be set' \
-  cache put bogus.jsonl --scope='bogus'
-
-# Test `cache put-staged` command errors for bad configurations
-with_upload_endpoints test_err 'the `--scope` or `--repo` option must be set' \
-  cache put-staged bogus
-test_err 'the `--service` option must be set' \
-  cache put-staged bogus --scope='bogus'
-LAKE_CACHE_KEY= test_err 'the `--service` option must be set' \
-  cache put-staged bogus --scope='bogus'
-LAKE_CACHE_REVISION_ENDPOINT=bogus test_err 'these environment variables must be set' \
-  cache put-staged bogus --scope='bogus'
-LAKE_CACHE_REVISION_ENDPOINT=bogus test_err 'these environment variables must be set' \
-  cache put-staged bogus --scope='bogus'
-
-# Test `cache add` command errors for bad configurations
-test_err '`--scope` and `--repo` require `--service`' \
-  cache add bogus.jsonl --scope='bogus'
-test_err '`--scope` and `--repo` require `--service`' \
-  cache add bogus.jsonl --repo='leanprover/bogus'
-
 # Test revision failure (with Reservoir)
 REV=$(git rev-parse HEAD)
 test_err "revision not found" cache get --repo='leanprover/bogus' --rev='bogus'

--- a/tests/lake/tests/cacheTransfer/BadCurl.lean
+++ b/tests/lake/tests/cacheTransfer/BadCurl.lean
@@ -1,0 +1,40 @@
+-- Copyright (c) 2026 Lean FRO. All rights reserved.
+-- Released under Apache 2.0 license as described in the file LICENSE.
+-- Authors: Mac Malone, Claude Code
+
+/-!
+A `curl` that misreports its transfers, covering failures that no server
+response can produce. `BAD_CURL` selects the misreport, and the real `curl`
+at `REAL_CURL` performs whatever transfer still has to happen:
+
+* `quiet`: report no transfer at all, and exit successfully
+* `exitcode`: report every transfer as failed, leaving each output file
+  complete and correct
+* `nofile`: report every transfer as successful, having deleted the files it
+  wrote from `BAD_CURL_DIR`
+-/
+
+def getEnv (name : String) : IO String := do
+  let some value ← IO.getEnv name
+    | throw (IO.userError s!"{name} must be set")
+  return value
+
+def runCurl (args : List String) : IO IO.Process.Output := do
+  IO.Process.output {cmd := ← getEnv "REAL_CURL", args := args.toArray}
+
+def main (args : List String) : IO UInt32 := do
+  match ← IO.getEnv "BAD_CURL" with
+  | some "exitcode" =>
+    let out ← runCurl args
+    IO.print out.stdout
+    IO.eprint (out.stderr.replace "\"exitcode\":0," "\"exitcode\":18,")
+  | some "nofile" =>
+    let out ← runCurl args
+    -- Deleted before the report is written, so nothing can read them first
+    for entry in (← System.FilePath.readDir (← getEnv "BAD_CURL_DIR")) do
+      if entry.fileName.endsWith ".tmp" then
+        IO.FS.removeFile entry.path
+    IO.print out.stdout
+    IO.eprint out.stderr
+  | _ => pure ()
+  return 0

--- a/tests/lake/tests/cacheTransfer/Test.lean
+++ b/tests/lake/tests/cacheTransfer/Test.lean
@@ -1,0 +1,1 @@
+import Test.Basic

--- a/tests/lake/tests/cacheTransfer/Test/Basic.lean
+++ b/tests/lake/tests/cacheTransfer/Test/Basic.lean
@@ -1,0 +1,1 @@
+def basic := 0

--- a/tests/lake/tests/cacheTransfer/clean.sh
+++ b/tests/lake/tests/cacheTransfer/clean.sh
@@ -1,0 +1,1 @@
+rm -rf work produced.*

--- a/tests/lake/tests/cacheTransfer/lakefile.toml
+++ b/tests/lake/tests/cacheTransfer/lakefile.toml
@@ -1,0 +1,5 @@
+name = "test"
+enableArtifactCache = true
+
+[[lean_lib]]
+name = "Test"

--- a/tests/lake/tests/cacheTransfer/lakefile.toml
+++ b/tests/lake/tests/cacheTransfer/lakefile.toml
@@ -1,5 +1,12 @@
 name = "test"
 enableArtifactCache = true
+defaultTargets = ["Test"]
 
 [[lean_lib]]
 name = "Test"
+
+# A `curl` that reports no transfer at all.
+# Built on demand so that it is not part of a cached build.
+[[lean_exe]]
+name = "curl"
+root = "BadCurl"

--- a/tests/lake/tests/cacheTransfer/no-services.toml
+++ b/tests/lake/tests/cacheTransfer/no-services.toml
@@ -1,0 +1,2 @@
+# A system configuration with no cache service, as in a default installation.
+# Used to test the errors Lake reports when a service is required but not configured.

--- a/tests/lake/tests/cacheTransfer/non-reservoir.toml
+++ b/tests/lake/tests/cacheTransfer/non-reservoir.toml
@@ -1,0 +1,6 @@
+name = "test"
+
+# Example non-Reservoir dependency
+[[require]]
+name = "hello"
+path = "../../../examples/hello"

--- a/tests/lake/tests/cacheTransfer/server.py
+++ b/tests/lake/tests/cacheTransfer/server.py
@@ -14,6 +14,8 @@ a test picks one by pointing an endpoint at it (e.g. `.../corrupt/a0`):
   corrupt   200 with the right length but mutated bytes
   truncate  200 with a full `Content-Length` but half a body, then disconnect
   reset     disconnect without a response (curl writes no output file)
+  empty     200 and a `Content-Length` but no body, for an object that is not
+            in the store, so that curl leaves no output file to read
   badcount  Reservoir artifact URL lookup returns too few URLs
   apierror  Reservoir requests return an API error object
 
@@ -54,6 +56,7 @@ class Mode(StrEnum):
     CORRUPT = "corrupt"
     TRUNCATE = "truncate"
     RESET = "reset"
+    EMPTY = "empty"
     BAD_COUNT = "badcount"
     API_ERROR = "apierror"
 
@@ -125,7 +128,17 @@ class Handler(BaseHTTPRequestHandler):
             with open(path, "rb") as f:
                 data = f.read()
         except FileNotFoundError:
-            self.not_found("no such object: %s" % self.path)
+            if mode == Mode.EMPTY:
+                # Announcing a body that never arrives: curl reports HTTP 200
+                # yet never creates its output file
+                self.send_response(200)
+                self.send_header("Content-Type", ctype or content_type(path))
+                self.send_header("Content-Length", "100")
+                self.end_headers()
+                self.close_connection = True
+                self.log("no body")
+            else:
+                self.not_found("no such object: %s" % self.path)
             return
         ctype = ctype or content_type(path)
         if mode == Mode.CORRUPT:

--- a/tests/lake/tests/cacheTransfer/server.py
+++ b/tests/lake/tests/cacheTransfer/server.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Lean FRO. All rights reserved.
+# Released under Apache 2.0 license as described in the file LICENSE.
+# Authors: Mac Malone, Claude Code
+
+"""A mock remote artifact cache for `test.sh`.
+
+Serves an S3-style bucket (`GET`/`PUT` of `<store>/<path>`) and the part of the
+Reservoir API that Lake uses. Faults are selected by the first path segment, so
+a test picks one by pointing an endpoint at it (e.g. `.../corrupt/a0`):
+
+  ok        serve and store normally
+  deny      403 with an S3-style XML error body
+  corrupt   200 with the right length but mutated bytes
+  truncate  200 with a full `Content-Length` but half a body, then disconnect
+  reset     disconnect without a response (curl writes no output file)
+  badcount  Reservoir artifact URL lookup returns too few URLs
+  apierror  Reservoir requests return an API error object
+
+A fault that does not apply to a request kind (e.g. `badcount` on a `GET`)
+behaves as `ok`. Each request is logged to stdout as `<method> <path> -> <status>`.
+
+This is Python rather than `Std.Http` because `truncate` and `reset` are
+transport-level faults: a body cut short of its declared `Content-Length` and a
+closed connection with no response at all. A conforming response writer cannot
+emit either, so a Lean server would have to hand-roll HTTP/1.1 over `Std.Net.TCP`.
+Revisit if `Std.Http` gains a way to abort a response mid-body.
+"""
+
+import argparse
+import json
+import os
+import sys
+from enum import StrEnum
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, unquote, urlparse
+
+ARTIFACT_TYPE = "application/vnd.reservoir.artifact"
+MAP_TYPE = "application/vnd.reservoir.outputs+json-lines"
+
+DENY_BODY = (
+    b'<?xml version="1.0" encoding="UTF-8"?>\n'
+    b"<Error><Code>AccessDenied</Code><Message>mock denial</Message></Error>\n"
+)
+
+STORE = "."
+
+
+class Mode(StrEnum):
+    """A fault mode, named by the first segment of a request path."""
+
+    OK = "ok"
+    DENY = "deny"
+    CORRUPT = "corrupt"
+    TRUNCATE = "truncate"
+    RESET = "reset"
+    BAD_COUNT = "badcount"
+    API_ERROR = "apierror"
+
+
+def content_type(path):
+    if path.endswith(".art"):
+        return ARTIFACT_TYPE
+    elif path.endswith(".jsonl"):
+        return MAP_TYPE
+    else:
+        return "application/octet-stream"
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    # Requests are logged by the handlers below, which also know about the
+    # faults that never send a response.
+    def log_request(self, code="-", size="-"):
+        pass
+
+    def log_message(self, format, *args):
+        pass
+
+    def log(self, status):
+        print("%s %s -> %s" % (self.command, self.path, status), flush=True)
+
+    def parse(self):
+        """Split a path into its fault mode and the object path under it.
+
+        Returns no mode for a path that names no fault mode, which is a
+        misconfigured endpoint rather than a cache miss.
+        """
+        url = urlparse(self.path)
+        parts = [unquote(p) for p in url.path.split("/") if p]
+        if any(p in (os.curdir, os.pardir) or os.path.isabs(p) for p in parts):
+            return None, [], {}
+        try:
+            mode = Mode(parts[0]) if parts else None
+        except ValueError:
+            mode = None
+        if mode is None:
+            return None, [], {}
+        return mode, parts[1:], parse_qs(url.query)
+
+    def respond(self, status, body, ctype):
+        self.send_response(status)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+        self.log(status)
+
+    def not_found(self, message):
+        body = json.dumps({"error": {"status": 404, "message": message}})
+        self.respond(404, body.encode(), "application/json")
+
+    def deny(self):
+        self.respond(403, DENY_BODY, "application/xml")
+
+    def reset(self):
+        # Neither a response nor a body: `curl` reports an empty reply and,
+        # importantly, does not create its output file.
+        self.close_connection = True
+        self.log("reset")
+
+    def serve(self, mode, path, ctype=None):
+        try:
+            with open(path, "rb") as f:
+                data = f.read()
+        except FileNotFoundError:
+            self.not_found("no such object: %s" % self.path)
+            return
+        ctype = ctype or content_type(path)
+        if mode == Mode.CORRUPT:
+            data = data[:-1] + bytes([data[-1] ^ 0xFF]) if data else b"corrupt"
+            self.respond(200, data, ctype)
+        elif mode == Mode.TRUNCATE:
+            self.send_response(200)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data[: len(data) // 2])
+            self.close_connection = True
+            self.log("truncated")
+        else:
+            self.respond(200, data, ctype)
+
+    def find_revision(self, scope, rev):
+        """Locate a revision's outputs, ignoring any platform/toolchain path."""
+        root = os.path.join(STORE, "r0", *scope)
+        for dir, _, files in os.walk(root):
+            if rev + ".jsonl" in files:
+                return os.path.join(dir, rev + ".jsonl")
+        return None
+
+    def reservoir_get(self, mode, parts, query):
+        # `parts` is `<packages|repositories>/<owner>/<name>/<endpoint>`
+        scope, endpoint = parts[1:3], parts[3:]
+        if endpoint[:1] == ["build-outputs"]:
+            rev = query.get("rev", [""])[0]
+            path = self.find_revision(scope, rev)
+            if path is None:
+                self.not_found("no outputs for revision %s" % rev)
+            else:
+                self.serve(mode, path)
+        elif endpoint[:1] == ["artifacts"] and len(endpoint) == 2:
+            self.serve(mode, os.path.join(STORE, "a0", *(scope + endpoint[1:])))
+        else:
+            self.not_found("no such endpoint: %s" % self.path)
+
+    def reservoir_post(self, mode, parts):
+        # Lake fetches the storage URLs of a batch of artifacts in one request
+        scope, endpoint = parts[1:3], parts[3:]
+        if endpoint != ["artifacts"]:
+            self.not_found("no such endpoint: %s" % self.path)
+            return
+        length = int(self.headers.get("Content-Length", 0))
+        hashes = json.loads(self.rfile.read(length).decode())
+        if mode == Mode.API_ERROR:
+            body = {"error": {"status": 503, "message": "mock API error"}}
+        else:
+            host = self.headers.get("Host")
+            urls = [
+                "http://%s/%s/a0/%s/%s.art" % (host, mode, "/".join(scope), hash)
+                for hash in hashes
+            ]
+            if mode == Mode.BAD_COUNT:
+                urls = urls[:-1]
+            body = {"data": urls}
+        self.respond(200, json.dumps(body).encode(), "application/json")
+
+    def do_GET(self):
+        mode, parts, query = self.parse()
+        if mode is None:
+            self.not_found("no fault mode in path: %s" % self.path)
+        elif mode == Mode.RESET:
+            self.reset()
+        elif mode == Mode.DENY:
+            self.deny()
+        elif parts[:2] == ["api", "v1"]:
+            self.reservoir_get(mode, parts[2:], query)
+        else:
+            self.serve(mode, os.path.join(STORE, *parts))
+
+    def do_POST(self):
+        mode, parts, _ = self.parse()
+        if mode is None:
+            self.not_found("no fault mode in path: %s" % self.path)
+        elif mode == Mode.RESET:
+            self.reset()
+        elif mode == Mode.DENY:
+            self.deny()
+        elif parts[:2] == ["api", "v1"]:
+            self.reservoir_post(mode, parts[2:])
+        else:
+            self.not_found("no such endpoint: %s" % self.path)
+
+    def do_PUT(self):
+        mode, parts, _ = self.parse()
+        # The body is always consumed so that `curl` sees a complete exchange
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        if mode is None:
+            self.not_found("no fault mode in path: %s" % self.path)
+        elif mode == Mode.RESET:
+            self.reset()
+        elif mode == Mode.DENY:
+            self.deny()
+        else:
+            path = os.path.join(STORE, *parts)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "wb") as f:
+                f.write(body)
+            self.respond(200, b"", "application/xml")
+
+
+class Server(ThreadingHTTPServer):
+    daemon_threads = True
+
+    # Lake aborts transfers on error, which is not a server failure
+    def handle_error(self, request, client_address):
+        if not isinstance(sys.exception(), ConnectionError):
+            super().handle_error(request, client_address)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--store", required=True, help="directory to serve")
+    parser.add_argument(
+        "--port-file", required=True, help="where to write the bound port"
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    args = parser.parse_args()
+
+    global STORE
+    STORE = args.store
+    os.makedirs(STORE, exist_ok=True)
+
+    # Port 0 lets the OS pick a free port, so parallel tests cannot collide
+    server = Server((args.host, 0), Handler)
+    port = server.server_address[1]
+    # Written atomically so that a test can wait on the file to know the
+    # server is accepting connections
+    with open(args.port_file + ".tmp", "w") as f:
+        f.write("%s\n" % port)
+    os.replace(args.port_file + ".tmp", args.port_file)
+    print("serving %s on %s:%s" % (STORE, args.host, port), flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/lake/tests/cacheTransfer/services.toml
+++ b/tests/lake/tests/cacheTransfer/services.toml
@@ -1,0 +1,57 @@
+# A cache service for each fault mode of `server.py`.
+# `test.sh` replaces `%URL%` with the URL of the running mock server.
+
+[cache]
+defaultUploadService = "ok"
+
+[[cache.service]]
+name = "ok"
+type = "s3"
+artifactEndpoint = "%URL%/ok/a0"
+revisionEndpoint = "%URL%/ok/r0"
+
+[[cache.service]]
+name = "deny"
+type = "s3"
+artifactEndpoint = "%URL%/deny/a0"
+revisionEndpoint = "%URL%/deny/r0"
+
+[[cache.service]]
+name = "denyArtifacts"
+type = "s3"
+artifactEndpoint = "%URL%/deny/a0"
+revisionEndpoint = "%URL%/ok/r0"
+
+[[cache.service]]
+name = "denyRevisions"
+type = "s3"
+artifactEndpoint = "%URL%/ok/a0"
+revisionEndpoint = "%URL%/deny/r0"
+
+[[cache.service]]
+name = "corrupt"
+type = "s3"
+artifactEndpoint = "%URL%/corrupt/a0"
+revisionEndpoint = "%URL%/ok/r0"
+
+[[cache.service]]
+name = "truncate"
+type = "s3"
+artifactEndpoint = "%URL%/truncate/a0"
+revisionEndpoint = "%URL%/ok/r0"
+
+[[cache.service]]
+name = "reset"
+type = "s3"
+artifactEndpoint = "%URL%/reset/a0"
+revisionEndpoint = "%URL%/ok/r0"
+
+[[cache.service]]
+name = "badCount"
+type = "reservoir"
+apiEndpoint = "%URL%/badcount/api/v1"
+
+[[cache.service]]
+name = "apiError"
+type = "reservoir"
+apiEndpoint = "%URL%/apierror/api/v1"

--- a/tests/lake/tests/cacheTransfer/services.toml
+++ b/tests/lake/tests/cacheTransfer/services.toml
@@ -47,6 +47,12 @@ artifactEndpoint = "%URL%/reset/a0"
 revisionEndpoint = "%URL%/ok/r0"
 
 [[cache.service]]
+name = "empty"
+type = "s3"
+artifactEndpoint = "%URL%/empty/a0"
+revisionEndpoint = "%URL%/ok/r0"
+
+[[cache.service]]
 name = "badCount"
 type = "reservoir"
 apiEndpoint = "%URL%/badcount/api/v1"

--- a/tests/lake/tests/cacheTransfer/test.sh
+++ b/tests/lake/tests/cacheTransfer/test.sh
@@ -35,7 +35,7 @@ PORT_FILE="$WORK_DIR/port"
 # Copy test data to a working directory to avoid initializing a Git repository
 # inside the checked-in source tree
 mkdir -p "$WORK_DIR"
-cp -r lakefile.toml Test.lean Test "$WORK_DIR/"
+cp -r lakefile.toml BadCurl.lean Test.lean Test "$WORK_DIR/"
 cd "$WORK_DIR"
 
 echo "# SETUP"
@@ -133,6 +133,20 @@ test_run cache get --scope=test --service=ok
 test_artifacts "$NUM_ARTS"
 test_run build Test --no-build
 
+# Verify an artifact whose response carries no body is reported like any other
+# failed transfer, without discarding the artifacts that did transfer.
+# https://github.com/leanprover/lean4/issues/14698
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+ART="$(ls -1 "$STORE_DIR/a0/test" | head -1)"
+cat > empty-outputs.jsonl << EOF
+"$SCHEMA_VER"
+["aaaaaaaaaaaaaaaa","${ART%.art}.ltar"]
+["bbbbbbbbbbbbbbbb","0123456789abcdef.ltar"]
+EOF
+test_err 'failed to download some artifacts' cache get empty-outputs.jsonl \
+  --scope=test --service=empty
+test_artifacts 1
+
 # Verify a corrupted download is not adopted as an artifact
 test_cmd rm -rf .lake/build "$CACHE_DIR"
 test_err 'hash mismatch' cache get --scope=test --service=corrupt
@@ -156,6 +170,32 @@ test_err 'failed to download artifact' cache get --scope=test --service=reset
 test_artifacts 0
 test_run cache get --scope=test --service=ok
 test_run build Test --no-build
+
+# Verify the transfers that `curl` itself misreports,
+# which no server response can produce.
+# TODO: use a `CURL` environment variable for these if Lake gains one.
+test_run build curl
+BIN_DIR="$WORK_DIR/.lake/build/bin"
+CURL="$(type -P curl)"
+# Nothing reports an error here,
+# but the count of transfers detects it.
+test_cmd rm -rf "$CACHE_DIR"
+PATH="$BIN_DIR:$PATH" BAD_CURL=quiet test_err 'failed to download some artifacts' \
+  cache get outputs.jsonl --scope=test --service=ok
+test_artifacts 0
+# Every artifact arrives complete,
+# but the reported transfer error marks them unusable.
+test_cmd rm -rf "$CACHE_DIR"
+PATH="$BIN_DIR:$PATH" BAD_CURL=exitcode REAL_CURL="$CURL" \
+  test_err 'failed to download artifact' cache get outputs.jsonl --scope=test --service=ok
+test_artifacts 0
+# Every artifact is reported as transferred but none was written,
+# which must be reported rather than abort the batch
+# https://github.com/leanprover/lean4/issues/14698
+test_cmd rm -rf "$CACHE_DIR"
+PATH="$BIN_DIR:$PATH" BAD_CURL=nofile REAL_CURL="$CURL" BAD_CURL_DIR="$CACHE_DIR/artifacts" \
+  test_err 'failed to download some artifacts' cache get outputs.jsonl --scope=test --service=ok
+test_artifacts 0
 
 # Verify an error response is reported along with its body
 test_cmd rm -rf .lake/build "$CACHE_DIR"
@@ -190,6 +230,8 @@ test_run cache get dup-outputs.jsonl --scope=test --service=ok
 test_exp -f "$CACHE_DIR/artifacts/$HASH.o"
 test_exp -f "$CACHE_DIR/artifacts/$HASH.dup"
 test_cmd cmp -s "$CACHE_DIR/artifacts/$HASH.o" "$CACHE_DIR/artifacts/$HASH.dup"
+# Copies, not hard links, which would break cache permissions and pruning
+test_exp "$(stat_ch "$CACHE_DIR/artifacts/$HASH.dup")" = 1
 test_cmd_eq 1 grep -c "GET /ok/a0/test/$ART" "$SERVER_LOG"
 
 # Verify artifacts missing from the local cache are fetched on demand

--- a/tests/lake/tests/cacheTransfer/test.sh
+++ b/tests/lake/tests/cacheTransfer/test.sh
@@ -253,27 +253,28 @@ test_run build Test --no-build
 
 # Verify the transfers that `curl` itself misreports,
 # which no server response can produce.
-# TODO: use a `CURL` environment variable for these if Lake gains one.
+# Lake runs the `CURL` command, if set, which is the only way to reach the mock
+# on Windows, where `PATH` cannot shadow the system `curl`.
 test_run build curl
-BIN_DIR="$WORK_DIR/.lake/build/bin"
-CURL="$(type -P curl)"
+CURL_MOCK="$($LAKE query curl:exe)"
+CURL_REAL="$(type -P curl)"
 # Nothing reports an error here,
 # but the count of transfers detects it.
 test_cmd rm -rf "$CACHE_DIR"
-PATH="$BIN_DIR:$PATH" BAD_CURL=quiet test_err 'failed to download some artifacts' \
+CURL="$CURL_MOCK" BAD_CURL=quiet test_err 'failed to download some artifacts' \
   cache get outputs.jsonl --scope=test --service=ok
 test_artifacts 0
 # Every artifact arrives complete,
 # but the reported transfer error marks them unusable.
 test_cmd rm -rf "$CACHE_DIR"
-PATH="$BIN_DIR:$PATH" BAD_CURL=exitcode REAL_CURL="$CURL" \
+CURL="$CURL_MOCK" BAD_CURL=exitcode REAL_CURL="$CURL_REAL" \
   test_err 'failed to download artifact' cache get outputs.jsonl --scope=test --service=ok
 test_artifacts 0
 # Every artifact is reported as transferred but none was written,
 # which must be reported rather than abort the batch
 # https://github.com/leanprover/lean4/issues/14698
 test_cmd rm -rf "$CACHE_DIR"
-PATH="$BIN_DIR:$PATH" BAD_CURL=nofile REAL_CURL="$CURL" BAD_CURL_DIR="$CACHE_DIR/artifacts" \
+CURL="$CURL_MOCK" BAD_CURL=nofile REAL_CURL="$CURL_REAL" BAD_CURL_DIR="$CACHE_DIR/artifacts" \
   test_err 'failed to download some artifacts' cache get outputs.jsonl --scope=test --service=ok
 test_artifacts 0
 

--- a/tests/lake/tests/cacheTransfer/test.sh
+++ b/tests/lake/tests/cacheTransfer/test.sh
@@ -35,7 +35,7 @@ PORT_FILE="$WORK_DIR/port"
 # Copy test data to a working directory to avoid initializing a Git repository
 # inside the checked-in source tree
 mkdir -p "$WORK_DIR"
-cp -r lakefile.toml BadCurl.lean Test.lean Test "$WORK_DIR/"
+cp -r lakefile.toml non-reservoir.toml BadCurl.lean Test.lean Test "$WORK_DIR/"
 cd "$WORK_DIR"
 
 echo "# SETUP"
@@ -63,10 +63,12 @@ echo "URL=$URL"
 
 # Point the configured cache services at the mock server.
 # Copied after the commit above so that it does not dirty the work tree.
-cp "$TEST_DIR/services.toml" services.toml
+cp "$TEST_DIR/services.toml" "$TEST_DIR/no-services.toml" .
 sed_i "s|%URL%|$URL|g" services.toml
 
-export LAKE_CONFIG="$WORK_DIR/services.toml"
+# The option validation below expects no configured service, as in a default
+# installation; the transfer tests switch to the mock services
+export LAKE_CONFIG="$WORK_DIR/no-services.toml"
 export LAKE_CACHE_DIR="$CACHE_DIR"
 export LAKE_CACHE_KEY="mock:key"
 # Point the default (Reservoir) service at the mock server as well,
@@ -81,6 +83,14 @@ export ELAN_TOOLCHAIN=
 NUM_ARTS=2
 NUM_REPLAY_ARTS=8
 
+# Runs a command with the cache endpoints set through the environment,
+# which is the deprecated alternative to a configured service
+with_endpoints() {
+  LAKE_CACHE_ARTIFACT_ENDPOINT="$URL/ok/a0" \
+  LAKE_CACHE_REVISION_ENDPOINT="$URL/ok/r0" \
+  "$@"
+}
+
 # Counts artifacts, ignoring the temporary files a failed transfer leaves behind
 test_artifacts() {
   expected="$1"; dir="${2:-$CACHE_DIR/artifacts}"
@@ -89,7 +99,77 @@ test_artifacts() {
   test "$actual" = "$expected"
 }
 
-echo "# TESTS"
+echo "# VALIDATION TESTS"
+
+# Verify `--repo` validation
+test_err "must contain exactly one '/'" cache get --repo='invalid'
+test_err 'invalid characters in repository name' cache get --repo='!/invalid'
+
+# Verify `--mappings-only` validation
+test_err '`--mappings-only` is not supported' cache get --mappings-only bogus.jsonl
+with_endpoints test_err '`--mappings-only` requires services' cache get --mappings-only
+
+# Verify `--service` validation
+test_err 'service `bogus` not found in system configuration' \
+  cache get --service='bogus'
+test_err 'service `bogus` not found in system configuration' \
+  cache put bogus.jsonl --scope='bogus' --service='bogus'
+
+# Verify `cache get` rejects bad configurations
+test_err '`--no-overwrite` is not supported for `cache get`' \
+  cache get --no-overwrite
+test_err 'the `--platform` and `--toolchain` options do nothing' \
+  cache get bogus.jsonl --scope='bogus' --platform='bogus' --wfail
+test_err 'the `--platform` and `--toolchain` options do nothing' \
+  cache get bogus.jsonl --scope='bogus' --toolchain='bogus' --wfail
+test_err 'a custom endpoint must be set (not Reservoir)' cache get --scope='bogus'
+with_endpoints test_err 'the `--scope` or `--repo` option must be set' cache get
+LAKE_CACHE_ARTIFACT_ENDPOINT=bogus test_err 'both environment variables must be set' cache get
+LAKE_CACHE_REVISION_ENDPOINT=bogus test_err 'both environment variables must be set' cache get
+
+# Verify `cache put` rejects bad configurations
+with_endpoints test_err 'the `--scope` or `--repo` option must be set' cache put bogus.jsonl
+test_err 'the `--service` option must be set' \
+  cache put bogus.jsonl --scope='bogus'
+LAKE_CACHE_KEY= test_err 'the `--service` option must be set' \
+  cache put bogus.jsonl --scope='bogus'
+LAKE_CACHE_ARTIFACT_ENDPOINT=bogus test_err 'these environment variables must be set' \
+  cache put bogus.jsonl --scope='bogus'
+LAKE_CACHE_REVISION_ENDPOINT=bogus test_err 'these environment variables must be set' \
+  cache put bogus.jsonl --scope='bogus'
+
+# Verify `cache put-staged` rejects bad configurations
+with_endpoints test_err 'the `--scope` or `--repo` option must be set' \
+  cache put-staged bogus
+test_err 'the `--service` option must be set' \
+  cache put-staged bogus --scope='bogus'
+LAKE_CACHE_KEY= test_err 'the `--service` option must be set' \
+  cache put-staged bogus --scope='bogus'
+LAKE_CACHE_ARTIFACT_ENDPOINT=bogus test_err 'these environment variables must be set' \
+  cache put-staged bogus --scope='bogus'
+LAKE_CACHE_REVISION_ENDPOINT=bogus test_err 'these environment variables must be set' \
+  cache put-staged bogus --scope='bogus'
+
+# Verify `cache add` rejects bad configurations
+test_err '`--scope` and `--repo` require `--service`' \
+  cache add bogus.jsonl --scope='bogus'
+test_err '`--scope` and `--repo` require `--service`' \
+  cache add bogus.jsonl --repo='leanprover/bogus'
+
+# Verify a revision that cannot be resolved or has no outputs is reported
+test_err 'revision not found' cache get --repo='leanprover/bogus' --rev='bogus'
+test_err 'outputs not found for revision' \
+  cache get --repo='leanprover/bogus' --rev="$(git rev-parse HEAD)"
+
+# Verify dependencies that are not on Reservoir are skipped
+test_run -f non-reservoir.toml update
+test_out 'hello: skipping non-Reservoir dependency' -f non-reservoir.toml cache get
+test_run update
+
+echo "# TRANSFER TESTS"
+
+# The remaining tests transfer artifacts through the mock services
+export LAKE_CONFIG="$WORK_DIR/services.toml"
 
 # Build the package and record its outputs
 test_run build Test -o outputs.jsonl

--- a/tests/lake/tests/cacheTransfer/test.sh
+++ b/tests/lake/tests/cacheTransfer/test.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Lean FRO. All rights reserved.
+# Released under Apache 2.0 license as described in the file LICENSE.
+# Authors: Mac Malone, Claude Code
+source ../common.sh
+
+./clean.sh
+
+# Test artifact transfers to and from a remote cache using a mock server.
+# The online cache test covers the same operations against Reservoir,
+# but needs credentials and network access, so it cannot be run in CI.
+
+PYTHON="${PYTHON:-python3}"
+
+# The mock server and Lake's uploads have requirements CI may not satisfy
+if ! "$PYTHON" -c 'import sys; sys.exit(sys.version_info < (3, 11))' 2> /dev/null; then
+  echo "SKIPPED: $PYTHON 3.11 or later not found"
+  exit 0
+fi
+if ! curl --help all 2> /dev/null | grep -q -- '--aws-sigv4'; then
+  echo "SKIPPED: curl does not support '--aws-sigv4'"
+  exit 0
+fi
+
+# The cache map schema version (see `Lake.CacheMap.schemaVersion`)
+SCHEMA_VER=2026-03-17
+
+TEST_DIR="$(norm_path "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)")"
+WORK_DIR="$TEST_DIR/work"
+STORE_DIR="$WORK_DIR/store"
+CACHE_DIR="$WORK_DIR/cache"
+SERVER_LOG="$WORK_DIR/server.log"
+PORT_FILE="$WORK_DIR/port"
+
+# Copy test data to a working directory to avoid initializing a Git repository
+# inside the checked-in source tree
+mkdir -p "$WORK_DIR"
+cp -r lakefile.toml Test.lean Test "$WORK_DIR/"
+cd "$WORK_DIR"
+
+echo "# SETUP"
+
+# Since committing a Git repository to a Git repository is not well-supported,
+# We reinitialize the repository on each test.
+init_git
+
+# Serve the mock cache on a free port, recorded in `$PORT_FILE` once it is up
+"$PYTHON" "$TEST_DIR/server.py" --store "$STORE_DIR" --port-file "$PORT_FILE" \
+  >> "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+trap 'kill $SERVER_PID 2> /dev/null' EXIT
+# Since the server is a separate process, the port it binds has to be waited on
+while [ ! -s "$PORT_FILE" ]; do
+  if ! kill -0 "$SERVER_PID" 2> /dev/null; then
+    echo "FAILURE: the mock server exited"
+    cat "$SERVER_LOG"
+    exit 1
+  fi
+  sleep 0.1
+done
+URL="http://127.0.0.1:$(cat "$PORT_FILE")"
+echo "URL=$URL"
+
+# Point the configured cache services at the mock server.
+# Copied after the commit above so that it does not dirty the work tree.
+cp "$TEST_DIR/services.toml" services.toml
+sed_i "s|%URL%|$URL|g" services.toml
+
+export LAKE_CONFIG="$WORK_DIR/services.toml"
+export LAKE_CACHE_DIR="$CACHE_DIR"
+export LAKE_CACHE_KEY="mock:key"
+# Point the default (Reservoir) service at the mock server as well,
+# so that no part of this test can reach the network
+export RESERVOIR_API_URL="$URL/ok/api/v1"
+# Ensure Lake is run without a toolchain name
+# (so the toolchain does not end up in cache paths)
+export ELAN_TOOLCHAIN=
+
+# The `Test` library transfers one bundle per module, each of which a
+# build unpacks into an olean, an ilean, and a C file
+NUM_ARTS=2
+NUM_REPLAY_ARTS=8
+
+# Counts artifacts, ignoring the temporary files a failed transfer leaves behind
+test_artifacts() {
+  expected="$1"; dir="${2:-$CACHE_DIR/artifacts}"
+  actual="$({ ls -1 "$dir" 2> /dev/null || true; } | { grep -cv '\.tmp$' || true; })"
+  echo "? artifacts in $dir ($actual) = $expected"
+  test "$actual" = "$expected"
+}
+
+echo "# TESTS"
+
+# Build the package and record its outputs
+test_run build Test -o outputs.jsonl
+test_exp -s outputs.jsonl
+
+# Verify artifacts and outputs are uploaded to the default upload service
+test_run cache put outputs.jsonl --scope=test
+REV="$(git rev-parse HEAD)"
+test_exp -f "$STORE_DIR/r0/test/$REV.jsonl"
+test_cmd cmp -s outputs.jsonl "$STORE_DIR/r0/test/$REV.jsonl"
+test_artifacts "$NUM_ARTS" "$STORE_DIR/a0/test"
+
+# Verify a rejected artifact upload is reported
+test_err 'failed to upload artifact' cache put outputs.jsonl --scope=test --service=deny
+# Verify a rejected outputs upload is reported
+test_err 'failed to upload artifact' cache put outputs.jsonl --scope=test --service=denyRevisions
+
+# Verify a workspace can be restored from the remote cache
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+test_out 'downloaded artifact' cache get --scope=test --service=ok
+test_artifacts "$NUM_ARTS"
+test_exp -d "$CACHE_DIR/revisions/test"
+test_run build Test --no-build
+
+# Verify cached outputs and artifacts are not fetched again
+test_not_out 'downloading' cache get --scope=test --service=ok
+# Verify `--force-download` fetches them regardless
+test_out 'downloading build outputs' cache get --scope=test --service=ok --force-download
+
+# Verify a missing artifact fails the transfer,
+# leaving the artifacts that did transfer in the cache
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+MISSING="$(ls -1 "$STORE_DIR/a0/test" | head -1)"
+test_cmd mv "$STORE_DIR/a0/test/$MISSING" "$WORK_DIR/$MISSING"
+test_err 'failed to download some artifacts' cache get --scope=test --service=ok
+match_text 'status code: 404' produced.out
+test_artifacts $((NUM_ARTS - 1))
+# Verify the failure did not poison the cache
+test_cmd mv "$WORK_DIR/$MISSING" "$STORE_DIR/a0/test/$MISSING"
+test_run cache get --scope=test --service=ok
+test_artifacts "$NUM_ARTS"
+test_run build Test --no-build
+
+# Verify a corrupted download is not adopted as an artifact
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+test_err 'hash mismatch' cache get --scope=test --service=corrupt
+test_artifacts 0
+test_run cache get --scope=test --service=ok
+test_artifacts "$NUM_ARTS"
+test_run build Test --no-build
+
+# Verify a truncated download is detected even though its headers
+# report success (a status code alone does not imply a complete transfer)
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+test_err 'failed to download some artifacts' cache get --scope=test --service=truncate
+match_text 'status code: 200' produced.out
+test_artifacts 0
+test_run cache get --scope=test --service=ok
+test_run build Test --no-build
+
+# Verify a transfer that leaves no output file is reported
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+test_err 'failed to download artifact' cache get --scope=test --service=reset
+test_artifacts 0
+test_run cache get --scope=test --service=ok
+test_run build Test --no-build
+
+# Verify an error response is reported along with its body
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+test_err 'unexpected response' cache get --scope=test --service=denyArtifacts
+match_text 'AccessDenied' produced.out
+test_artifacts 0
+
+# Verify a rejected outputs download is reported
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+test_err 'output lookup failed' cache get --scope=test --service=deny
+
+# Verify a revision without outputs is reported
+test_cmd git commit --allow-empty -m "no outputs"
+test_err 'no outputs found' cache get --scope=test --service=ok --max-revs=1
+# Verify the revision search finds the outputs of an earlier revision
+test_run cache get --scope=test --service=ok
+test_artifacts "$NUM_ARTS"
+test_run build Test --no-build
+
+# Verify artifacts sharing a content hash are downloaded once
+# and copied locally for each extension
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+ART="$(ls -1 "$STORE_DIR/a0/test" | head -1)"
+HASH="${ART%.art}"
+cat > dup-outputs.jsonl << EOF
+"$SCHEMA_VER"
+["aaaaaaaaaaaaaaaa","$HASH.o"]
+["bbbbbbbbbbbbbbbb","$HASH.dup"]
+EOF
+: > "$SERVER_LOG"
+test_run cache get dup-outputs.jsonl --scope=test --service=ok
+test_exp -f "$CACHE_DIR/artifacts/$HASH.o"
+test_exp -f "$CACHE_DIR/artifacts/$HASH.dup"
+test_cmd cmp -s "$CACHE_DIR/artifacts/$HASH.o" "$CACHE_DIR/artifacts/$HASH.dup"
+test_cmd_eq 1 grep -c "GET /ok/a0/test/$ART" "$SERVER_LOG"
+
+# Verify artifacts missing from the local cache are fetched on demand
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+test_run cache get --scope=test --service=ok
+test_cmd rm -rf .lake/build "$CACHE_DIR/artifacts"
+test_out 'downloaded artifact' -v build Test --no-build
+test_artifacts "$NUM_REPLAY_ARTS"
+
+# Verify a corrupted on-demand fetch is reported
+test_cmd rm -rf .lake/build "$CACHE_DIR/artifacts"
+test_run cache add outputs.jsonl --scope=test --service=corrupt
+test_err 'hash mismatch' build Test --no-build
+test_artifacts 0
+
+# Verify a repository scope is uploaded under its platform and toolchain
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+test_run build Test -o outputs.jsonl
+REV="$(git rev-parse HEAD)"
+test_run cache put outputs.jsonl --repo=leanprover/test --platform=foo --toolchain=bar
+test_exp -f "$STORE_DIR/r0/leanprover/test/pt/foo/tc/bar/$REV.jsonl"
+test_run cache put outputs.jsonl --repo=leanprover/test
+
+# Verify a repository scope is downloaded through the Reservoir API
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+: > "$SERVER_LOG"
+test_out 'downloaded artifact' cache get --repo=leanprover/test
+match_text "POST /ok/api/v1/repositories/leanprover/test/artifacts" "$SERVER_LOG"
+test_artifacts "$NUM_ARTS"
+test_run build Test --no-build
+
+# Verify a malformed artifact URL lookup is reported
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+test_err 'Incorrect number of results' cache get --repo=leanprover/test --service=badCount
+# Verify a Reservoir API error is reported
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+test_err 'Reservoir error' cache get --repo=leanprover/test --service=apiError
+
+# Verify `--mappings-only` fetches outputs but no artifacts,
+# leaving the artifacts to be fetched on demand
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+: > "$SERVER_LOG"
+test_run cache get --repo=leanprover/test --mappings-only
+test_artifacts 0
+test_out 'downloaded artifact' -v build Test --no-build
+match_text "GET /ok/api/v1/repositories/leanprover/test/artifacts/" "$SERVER_LOG"
+test_artifacts "$NUM_REPLAY_ARTS"
+
+# Verify staged artifacts can be uploaded and downloaded
+test_cmd rm -rf staging
+test_run cache stage outputs.jsonl staging
+test_run cache put-staged staging --scope=staged
+test_exp -f "$STORE_DIR/r0/staged/$REV.jsonl"
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+test_run cache get --scope=staged --service=ok
+test_artifacts "$NUM_ARTS"
+test_run build Test --no-build

--- a/tests/lake/tests/common.sh
+++ b/tests/lake/tests/common.sh
@@ -222,7 +222,7 @@ test_err() {
   if match_text "$expected" produced.out; then
     if [ $rc == 0 ]; then
       echo "FAILURE: Lake unexpectedly succeeded"
-      return $rc
+      return 1
     fi
   else
     return 1

--- a/tests/lake/tests/ltarStable/.gitignore
+++ b/tests/lake/tests/ltarStable/.gitignore
@@ -1,0 +1,1 @@
+/Test/A.lean

--- a/tests/lake/tests/ltarStable/Test/A.lean
+++ b/tests/lake/tests/ltarStable/Test/A.lean
@@ -1,2 +1,0 @@
-module
-public def a : Nat := 1

--- a/tests/lake/tests/ltarStable/clean.sh
+++ b/tests/lake/tests/ltarStable/clean.sh
@@ -1,2 +1,1 @@
-[ -f Test/A.lean.bak ] && mv -f Test/A.lean.bak Test/A.lean
-rm -rf .lake lake-manifest.json out*.jsonl bundles*.txt staging*
+rm -rf .lake lake-manifest.json produced.* Test/A.lean

--- a/tests/lake/tests/ltarStable/test.sh
+++ b/tests/lake/tests/ltarStable/test.sh
@@ -3,39 +3,42 @@ source ../common.sh
 
 ./clean.sh
 
-#-------------------------------------------------------------------------------
-# Content-stable module archives via leantar -s (strip hash) and -j - (reinject).
-#  See https://github.com/leanprover/lean4/issues/13996.
-#-------------------------------------------------------------------------------
+# Test content-stable module archives via leantar -s (strip hash) and -j -
+# (reinject). See https://github.com/leanprover/lean4/issues/13996.
 
 # Hermetic, workspace-local artifact cache: an empty `LAKE_CACHE_DIR` disables the
 # system cache, so all artifacts and mappings live under `.lake/cache`. The package
 # enables the artifact cache and `restoreAllArtifacts` (see lakefile.toml).
 export LAKE_CACHE_DIR=
 
+# Create a Git-ignored `Test/A.lean` to edit later
+cat > Test/A.lean << 'EOF'
+module
+public def a : Nat := 1
+EOF
+
 # The set of bundle (`.ltar`) content hashes referenced by a mapping file.
 bundles() { grep -oE '[0-9a-f]{16}\.ltar' "$1" | sort -u; }
 
 # A build populates the cache and emits a mapping referencing bundles.
-test_run build -o out1.jsonl
+test_run build -o .lake/out1.jsonl
 test_cmd ls .lake/cache/artifacts/*.ltar
-bundles out1.jsonl > bundles1.txt
-test_exp -s bundles1.txt
+bundles .lake/out1.jsonl > .lake/bundles1.txt
+test_exp -s .lake/bundles1.txt
 
 # An input-only edit (comment appended) changes the input hash but no output, so
 # the bundle hashes are unchanged even though the mapping entry moves.
-cp Test/A.lean Test/A.lean.bak
 printf '\n-- a cosmetic comment; does not change any output\n' >> Test/A.lean
-test_run build -o out2.jsonl
-bundles out2.jsonl > bundles2.txt
-test_cmd diff bundles1.txt bundles2.txt
-test_cmd_fails diff out1.jsonl out2.jsonl
+test_run build -o .lake/out2.jsonl
+bundles .lake/out2.jsonl > .lake/bundles2.txt
+test_cmd diff .lake/bundles1.txt .lake/bundles2.txt
+test_cmd_fails diff .lake/out1.jsonl .lake/out2.jsonl
 
 # Consume a bundle-only cache: fetch, unpack with hash reinjection, verify.
-test_run cache stage out2.jsonl staging
-test_cmd ls staging/*.ltar
+test_run cache stage .lake/out2.jsonl .lake/staging
+test_cmd ls .lake/staging/*.ltar
 rm -rf .lake/cache .lake/build
-test_run cache unstage staging
+test_run cache unstage .lake/staging
 test_cmd_fails ls .lake/cache/artifacts/*.olean   # no individual artifacts present
 test_out "leantar" build -v                       # bundles are unpacked
 test_run build --no-build --rehash                # outputs verify as up-to-date
@@ -43,8 +46,8 @@ test_run build --no-build --rehash                # outputs verify as up-to-date
 # matches the mapping key the archive was fetched under.
 if command -v jq > /dev/null; then # skip if no jq found
   dep=$(jq -r '.depHash' .lake/build/lib/lean/Test/A.trace)
-  match_text "$dep" staging/outputs.jsonl
+  match_text "$dep" .lake/staging/outputs.jsonl
 fi
 
-./clean.sh
-echo "ltarStable: all checks passed"
+# Cleanup
+rm -f produced.out


### PR DESCRIPTION
This PR adds a Lake test which performs mock artifact transfers to/from a remote cache service using a mock Python HTTP server. This serves as an alternative to the existing online cache test which covers full integration with Reservoir but also requires secrets and network access and is thus ill-suited for CI.

**Test Cases**

* CLI validation for `cache get`, `put`, `put-staged`, and `add` from the online test
* `cache put`, `put-staged`, and `stage`, plus rejected artifact and outputs uploads
* `cache get` by `--scope` and by `--repo`, `--force-download`, `--mappings-only`, revision search and `--max-revs`, and platform- and toolchain-partitioned revision paths
* download failures: a missing artifact, a content hash mismatch, a body cut short of its declared `Content-Length`, a connection closed with no response, a response carrying no body at all, and an error response whose body is not an artifact
* misreported transfers: a `curl` that reports no transfer while claiming success, one that reports failure for artifacts that arrived complete, and one that reports success for artifacts it never wrote
* on-demand artifact fetches during a build, over both bucket and Reservoir URLs
* the Reservoir batch URL lookup, including a short result list and an API error object
* artifacts that share a content hash across extensions, which download once and are copied, not hard linked, into place
* #14698: a batch in which one artifact yields no output file must report "failed to download some artifacts" and retain the artifacts that did transfer, rather than abort on the missing file

Failure cases also assert exactly which artifacts remain in the local cache, and those that could poison it assert that a subsequent good fetch still succeeds.

Separately, this PR fixes `test_err` in the Lake test harness, which did not fail when a Lake invocation unexpectedly succeeded. All tests still pass, so no failures were obscured by this issue. It also removes a stray backtick in the non-Reservoir dependency warning and ensures the `ltarStable` test does not dirty the worktree.

🤖 Prepared with Claude Code