### PR TITLE
feat: accept match alternatives in an `ensures` clause

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Contract.lean
+++ b/src/Lean/Elab/Tactic/Do/Contract.lean
@@ -108,12 +108,12 @@ add `import Std.Internal.Do` to use them."
   let pre : Term ← if requiresStx.isNone then `(⊤) else
     match requiresStx[0] with
     | `(requiresClause| requires $f:basicFun) => `(fun $f:basicFun)
-    | `(requiresClause| requires $alts:matchAlts) => `(fun $alts:matchAlts)
     | `(requiresClause| requires $p:term) => pure p
     | _ => Macro.throwUnsupported
   let post : Term ← if ensuresStx.isNone then `(fun _ => ⊤) else
     match ensuresStx[0] with
     | `(ensuresClause| ensures $f:basicFun) => `(fun $f:basicFun)
+    | `(ensuresClause| ensures $alts:matchAlts) => `(fun $alts:matchAlts)
     | _ => Macro.throwUnsupported
   let msg : TSyntax `str := ⟨Syntax.mkStrLit <|
     if specStep?.isSome then

--- a/src/Lean/Elab/Tactic/Do/Contract.lean
+++ b/src/Lean/Elab/Tactic/Do/Contract.lean
@@ -108,6 +108,7 @@ add `import Std.Internal.Do` to use them."
   let pre : Term ← if requiresStx.isNone then `(⊤) else
     match requiresStx[0] with
     | `(requiresClause| requires $f:basicFun) => `(fun $f:basicFun)
+    | `(requiresClause| requires $alts:matchAlts) => `(fun $alts:matchAlts)
     | `(requiresClause| requires $p:term) => pure p
     | _ => Macro.throwUnsupported
   let post : Term ← if ensuresStx.isNone then `(fun _ => ⊤) else

--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -134,8 +134,7 @@ arguments of the assertion itself, such as the state of a state monad. -/
 def requiresClause := leading_parser
   ppIndent (ppLine >> nonReservedSymbol "requires" >>
     withForbidden "ensures" (atomic Term.basicFun <|> (ppSpace >> termParser)))
-/-- The `ensures b => Q` postcondition clause of a `def` contract, binding the result `b`. It is
-written like a `fun`, so `ensures | pat => Q` states the postcondition per shape of the result. -/
+/-- The `ensures b => Q` postcondition clause of a `def` contract, binding the result `b`. -/
 def ensuresClause := leading_parser
   ppIndent (ppLine >> nonReservedSymbol "ensures" >>
     (Term.basicFun <|> ppIndent Term.matchAlts))

--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -129,11 +129,12 @@ def declId := leading_parser
 -- @[builtin_doc] -- FIXME: suppress the hover
 def declSig := leading_parser
   many (ppSpace >> (Term.binderIdent <|> Term.bracketedBinder)) >> Term.typeSpec
-/-- The `requires P` precondition clause of a `def` contract. The form `requires s => P s` binds the
-arguments of the assertion itself, such as the state of a state monad. -/
+/-- The `requires P` precondition clause of a `def` contract. The forms `requires s => P s` and
+`requires | pat => P` are written like a `fun`, binding the arguments of the assertion itself, such
+as the state of a state monad. -/
 def requiresClause := leading_parser
   ppIndent (ppSpace >> nonReservedSymbol "requires" >>
-    withForbidden "ensures" (atomic Term.basicFun <|> (ppSpace >> termParser)))
+    withForbidden "ensures" (atomic Term.basicFun <|> Term.matchAlts <|> (ppSpace >> termParser)))
 /-- The `ensures b => Q` postcondition clause of a `def` contract, binding the result `b`. -/
 def ensuresClause := leading_parser
   ppIndent (ppSpace >> nonReservedSymbol "ensures" >> Term.basicFun)

--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -129,15 +129,16 @@ def declId := leading_parser
 -- @[builtin_doc] -- FIXME: suppress the hover
 def declSig := leading_parser
   many (ppSpace >> (Term.binderIdent <|> Term.bracketedBinder)) >> Term.typeSpec
-/-- The `requires P` precondition clause of a `def` contract. The forms `requires s => P s` and
-`requires | pat => P` are written like a `fun`, binding the arguments of the assertion itself, such
-as the state of a state monad. -/
+/-- The `requires P` precondition clause of a `def` contract. The form `requires s => P s` binds the
+arguments of the assertion itself, such as the state of a state monad. -/
 def requiresClause := leading_parser
-  ppIndent (ppSpace >> nonReservedSymbol "requires" >>
-    withForbidden "ensures" (atomic Term.basicFun <|> Term.matchAlts <|> (ppSpace >> termParser)))
-/-- The `ensures b => Q` postcondition clause of a `def` contract, binding the result `b`. -/
+  ppIndent (ppLine >> nonReservedSymbol "requires" >>
+    withForbidden "ensures" (atomic Term.basicFun <|> (ppSpace >> termParser)))
+/-- The `ensures b => Q` postcondition clause of a `def` contract, binding the result `b`. It is
+written like a `fun`, so `ensures | pat => Q` states the postcondition per shape of the result. -/
 def ensuresClause := leading_parser
-  ppIndent (ppSpace >> nonReservedSymbol "ensures" >> Term.basicFun)
+  ppIndent (ppLine >> nonReservedSymbol "ensures" >>
+    (Term.basicFun <|> ppIndent Term.matchAlts))
 /-- The `: type` of a `def`. It may carry contract clauses, so we forbid `requires`/`ensures` in the type. -/
 def defTypeSpec := withForbiddens #["requires", "ensures"] Term.typeSpec
 /-- `optDeclSig` matches the signature of a declaration with optional type: a list of binders and then possibly `: type` -/

--- a/tests/elab/formatTerm.lean
+++ b/tests/elab/formatTerm.lean
@@ -22,11 +22,7 @@ def fmt (stx : CoreM Syntax) : CoreM Format := do PrettyPrinter.ppTerm ⟨← st
 #eval fmt `(command| def clampLow (n lo : Nat) : Id Nat requires lo ≤ n ensures r => r = n := pure n)
 #eval fmt `(command| def k (x : Nat) requires s => s > x ensures r => r ≥ x := pure x)
 #eval fmt `(command| def g (x : Nat) requires x > 0 ensures r => r ≥ x := pure x)
-#eval fmt `(command| def m (x : Nat) requires | (a, b) => a + b = x ensures r => r ≥ x := pure x)
-#eval fmt `(command| def m2 (x : Nat) requires
-  | (0, b) => b = x
-  | (a, _) => a = x
-  ensures r => r ≥ x := pure x)
+#eval fmt `(command| def m (x : Nat) requires x > 0 ensures | 0 => False | (n+1) => n ≥ x := pure x)
 #eval fmt `(command| def h (x : Nat) : Id Nat ensures r => r = x := pure x
 where finally
   | spec => skip)

--- a/tests/elab/formatTerm.lean
+++ b/tests/elab/formatTerm.lean
@@ -22,6 +22,11 @@ def fmt (stx : CoreM Syntax) : CoreM Format := do PrettyPrinter.ppTerm ⟨← st
 #eval fmt `(command| def clampLow (n lo : Nat) : Id Nat requires lo ≤ n ensures r => r = n := pure n)
 #eval fmt `(command| def k (x : Nat) requires s => s > x ensures r => r ≥ x := pure x)
 #eval fmt `(command| def g (x : Nat) requires x > 0 ensures r => r ≥ x := pure x)
+#eval fmt `(command| def m (x : Nat) requires | (a, b) => a + b = x ensures r => r ≥ x := pure x)
+#eval fmt `(command| def m2 (x : Nat) requires
+  | (0, b) => b = x
+  | (a, _) => a = x
+  ensures r => r ≥ x := pure x)
 #eval fmt `(command| def h (x : Nat) : Id Nat ensures r => r = x := pure x
 where finally
   | spec => skip)

--- a/tests/elab/formatTerm.lean.out.expected
+++ b/tests/elab/formatTerm.lean.out.expected
@@ -62,6 +62,13 @@ def k✝ (x✝ : Nat✝) requires s✝ => s✝ > x✝ ensures r✝ => r✝ ≥ x
   pure✝ x✝
 def g✝ (x✝ : Nat✝) requires x✝ > 0 ensures r✝ => r✝ ≥ x✝ :=
   pure✝ x✝
+def m✝ (x✝ : Nat✝) requires
+    | (a✝, b✝) => a✝ + b✝ = x✝ ensures r✝ => r✝ ≥ x✝ :=
+  pure✝ x✝
+def m2✝ (x✝ : Nat✝) requires
+    | (0, b✝) => b✝ = x✝
+    | (a✝, _) => a✝ = x✝ ensures r✝ => r✝ ≥ x✝ :=
+  pure✝ x✝
 def h✝ (x✝ : Nat✝) : Id✝ Nat✝ ensures r✝ => r✝ = x✝ :=
   pure✝ x✝
 where

--- a/tests/elab/formatTerm.lean.out.expected
+++ b/tests/elab/formatTerm.lean.out.expected
@@ -56,20 +56,26 @@ do
 do
   for x✝ in xs✝ invariant pref✝ suff✝ s✝ => s✝ ≤ acc✝ do
     pure✝ ()
-def clampLow✝ (n✝ lo✝ : Nat✝) : Id✝ Nat✝ requires lo✝ ≤ n✝ ensures r✝ => r✝ = n✝ :=
+def clampLow✝ (n✝ lo✝ : Nat✝) : Id✝ Nat✝
+    requires lo✝ ≤ n✝
+    ensures r✝ => r✝ = n✝ :=
   pure✝ n✝
-def k✝ (x✝ : Nat✝) requires s✝ => s✝ > x✝ ensures r✝ => r✝ ≥ x✝ :=
+def k✝ (x✝ : Nat✝)
+    requires s✝ => s✝ > x✝
+    ensures r✝ => r✝ ≥ x✝ :=
   pure✝ x✝
-def g✝ (x✝ : Nat✝) requires x✝ > 0 ensures r✝ => r✝ ≥ x✝ :=
+def g✝ (x✝ : Nat✝)
+    requires x✝ > 0
+    ensures r✝ => r✝ ≥ x✝ :=
   pure✝ x✝
-def m✝ (x✝ : Nat✝) requires
-    | (a✝, b✝) => a✝ + b✝ = x✝ ensures r✝ => r✝ ≥ x✝ :=
+def m✝ (x✝ : Nat✝)
+    requires x✝ > 0
+    ensures
+      | 0 => False✝
+      | (n✝ + 1) => n✝ ≥ x✝ :=
   pure✝ x✝
-def m2✝ (x✝ : Nat✝) requires
-    | (0, b✝) => b✝ = x✝
-    | (a✝, _) => a✝ = x✝ ensures r✝ => r✝ ≥ x✝ :=
-  pure✝ x✝
-def h✝ (x✝ : Nat✝) : Id✝ Nat✝ ensures r✝ => r✝ = x✝ :=
+def h✝ (x✝ : Nat✝) : Id✝ Nat✝
+    ensures r✝ => r✝ = x✝ :=
   pure✝ x✝
 where
 finally

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -248,21 +248,18 @@ def ensuresAscribed (n : Nat) : Id Nat
 #guard_msgs in
 #check @ensuresAscribed.spec
 
-/-! ## A `requires` clause written with match alternatives
+/-! ## An `ensures` clause written with match alternatives
 
-The clause is a `fun`, so it may destructure the arguments of the assertion, here the state of a
-state monad. -/
+The clause is a `fun`, so it may state the postcondition per shape of the result. -/
 
-def requiresMatch (n : Nat) : StateM (Nat × Nat) Nat
-    requires
-      | (a, b) => a = 0 ∧ b = n
-    ensures r _ => r = n
-  := do
-  let (a, b) ← get
-  return a + b
+def halve (n : Nat) : Id (Option Nat)
+    ensures
+      | none => False
+      | some v => 2 * v ≤ n
+  := pure (some (n / 2))
 
 #guard_msgs (drop info) in
-#check @requiresMatch.spec
+#check @halve.spec
 
 /-! ## The contract telescope is transplanted faithfully to `f.spec`
 

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -248,6 +248,22 @@ def ensuresAscribed (n : Nat) : Id Nat
 #guard_msgs in
 #check @ensuresAscribed.spec
 
+/-! ## A `requires` clause written with match alternatives
+
+The clause is a `fun`, so it may destructure the arguments of the assertion, here the state of a
+state monad. -/
+
+def requiresMatch (n : Nat) : StateM (Nat × Nat) Nat
+    requires
+      | (a, b) => a = 0 ∧ b = n
+    ensures r _ => r = n
+  := do
+  let (a, b) ← get
+  return a + b
+
+#guard_msgs (drop info) in
+#check @requiresMatch.spec
+
 /-! ## The contract telescope is transplanted faithfully to `f.spec`
 
 `f.spec` re-binds the definition's telescope verbatim, applies `f` to exactly the explicit arguments,


### PR DESCRIPTION
This PR lets the `ensures` clause of a `def` contract be written like a `fun`, so a postcondition may be stated per shape of the result: `ensures | none => False | some v => 2 * v ≤ n`. A contract clause now also starts on its own line when pretty printed, as it is written in source.

`ensuresClause` gains `Term.matchAlts` as an alternative and `expandDefContract` wraps it in the `fun` that becomes the postcondition of the specification theorem. I decided to keep `requires` as is, because matching on state arguments of the assertion is not a use case I intend to support.