### PR TITLE
feat: add `cbv` annotations to `HashMap`/`HashSet` operations

### DIFF
--- a/src/Std/Data/HashMap/Lemmas.lean
+++ b/src/Std/Data/HashMap/Lemmas.lean
@@ -1199,7 +1199,7 @@ theorem all_keys [LawfulHashable α] [EquivBEq α] {p : α → Bool} :
 
 variable {ρ : Type w} [ForIn Id ρ (α × β)]
 
-@[simp, grind =]
+@[simp, grind =, cbv_eval]
 theorem insertMany_nil :
     insertMany m [] = m :=
   ext DHashMap.Const.insertMany_nil
@@ -1209,7 +1209,7 @@ theorem insertMany_list_singleton {k : α} {v : β} :
     insertMany m [⟨k, v⟩] = m.insert k v :=
   ext DHashMap.Const.insertMany_list_singleton
 
-@[grind _=_]
+@[grind _=_, cbv_eval]
 theorem insertMany_cons {l : List (α × β)} {k : α} {v : β} :
     insertMany m (⟨k, v⟩ :: l) = insertMany (m.insert k v) l :=
   ext DHashMap.Const.insertMany_cons
@@ -2425,6 +2425,7 @@ theorem ofList_singleton {k : α} {v : β} :
     ofList (⟨k, v⟩ :: tl) = insertMany ((∅ : HashMap α β).insert k v) tl :=
   ext DHashMap.Const.ofList_cons
 
+@[cbv_eval]
 theorem ofList_eq_insertMany_empty {l : List (α × β)} :
     ofList l = insertMany (∅ : HashMap α β) l :=
   ext DHashMap.Const.ofList_eq_insertMany_empty
@@ -2551,7 +2552,7 @@ theorem size_ofList_le [EquivBEq α] [LawfulHashable α]
 
 grind_pattern size_ofList_le => (ofList l).size
 
-@[simp, grind =]
+@[simp, grind =, cbv_eval]
 theorem ofArray_eq_ofList (a : Array (α × β)) :
     ofArray a = ofList a.toList := by
   apply ext

--- a/src/Std/Data/HashSet/Lemmas.lean
+++ b/src/Std/Data/HashSet/Lemmas.lean
@@ -214,7 +214,7 @@ theorem size_le_size_erase [EquivBEq α] [LawfulHashable α] {k : α} :
     m.size ≤ (m.erase k).size + 1 :=
   HashMap.size_le_size_erase
 
-@[simp, grind =]
+@[simp, grind =, cbv_eval]
 theorem get?_emptyWithCapacity {a : α} {c} : (emptyWithCapacity c : HashSet α).get? a = none :=
   HashMap.getKey?_emptyWithCapacity
 
@@ -226,7 +226,7 @@ theorem get?_of_isEmpty [EquivBEq α] [LawfulHashable α] {a : α} :
     m.isEmpty = true → m.get? a = none :=
   HashMap.getKey?_of_isEmpty
 
-@[grind =] theorem get?_insert [EquivBEq α] [LawfulHashable α] {k a : α} :
+@[grind =, cbv_eval] theorem get?_insert [EquivBEq α] [LawfulHashable α] {k a : α} :
     (m.insert k).get? a = if k == a ∧ ¬k ∈ m then some k else m.get? a :=
   HashMap.getKey?_insertIfNew
 
@@ -321,7 +321,7 @@ theorem get_congr [EquivBEq α] [LawfulHashable α] {k₁ k₂ : α} (h : k₁ =
 theorem get_eq [LawfulBEq α] {k : α} (h : k ∈ m) : m.get k h = k :=
   HashMap.getKey_eq h
 
-@[simp, grind =]
+@[simp, grind =, cbv_eval]
 theorem get!_emptyWithCapacity [Inhabited α] {a : α} {c} : (emptyWithCapacity c : HashSet α).get! a = default :=
   HashMap.getKey!_emptyWithCapacity
 
@@ -333,7 +333,7 @@ theorem get!_of_isEmpty [Inhabited α] [EquivBEq α] [LawfulHashable α] {a : α
     m.isEmpty = true → m.get! a = default :=
   HashMap.getKey!_of_isEmpty
 
-@[grind =] theorem get!_insert [Inhabited α] [EquivBEq α] [LawfulHashable α] {k a : α} :
+@[grind =, cbv_eval] theorem get!_insert [Inhabited α] [EquivBEq α] [LawfulHashable α] {k a : α} :
     (m.insert k).get! a = if k == a ∧ ¬k ∈ m then k else m.get! a :=
   HashMap.getKey!_insertIfNew
 
@@ -380,7 +380,7 @@ theorem get!_eq_of_contains [LawfulBEq α] [Inhabited α] {k : α} (h : m.contai
 theorem get!_eq_of_mem [LawfulBEq α] [Inhabited α] {k : α} (h : k ∈ m) : m.get! k = k :=
   HashMap.getKey!_eq_of_mem h
 
-@[simp, grind =]
+@[simp, grind =, cbv_eval]
 theorem getD_emptyWithCapacity {a fallback : α} {c} : (emptyWithCapacity c : HashSet α).getD a fallback = fallback :=
   HashMap.getKeyD_emptyWithCapacity
 
@@ -392,7 +392,7 @@ theorem getD_of_isEmpty [EquivBEq α] [LawfulHashable α] {a fallback : α} :
     m.isEmpty = true → m.getD a fallback = fallback :=
   HashMap.getKeyD_of_isEmpty
 
-@[grind =] theorem getD_insert [EquivBEq α] [LawfulHashable α] {k a fallback : α} :
+@[grind =, cbv_eval] theorem getD_insert [EquivBEq α] [LawfulHashable α] {k a fallback : α} :
     (m.insert k).getD a fallback = if k == a ∧ ¬k ∈ m then k else m.getD a fallback :=
   HashMap.getKeyD_insertIfNew
 
@@ -636,7 +636,7 @@ theorem all_eq_false_iff_exists_mem [LawfulBEq α] {p : α → Bool} :
 
 variable {ρ : Type v} [ForIn Id ρ α]
 
-@[simp, grind =]
+@[simp, grind =, cbv_eval]
 theorem insertMany_nil :
     insertMany m [] = m :=
   ext HashMap.insertManyIfNewUnit_nil
@@ -646,7 +646,7 @@ theorem insertMany_list_singleton {k : α} :
     insertMany m [k] = m.insert k :=
   ext HashMap.insertManyIfNewUnit_list_singleton
 
-@[grind _=_] theorem insertMany_cons {l : List α} {k : α} :
+@[grind _=_, cbv_eval] theorem insertMany_cons {l : List α} {k : α} :
     insertMany m (k :: l) = insertMany (m.insert k) l :=
   ext HashMap.insertManyIfNewUnit_cons
 
@@ -1260,7 +1260,7 @@ end Diff
 
 section
 
-@[simp, grind =]
+@[simp, grind =, cbv_eval]
 theorem ofArray_eq_ofList (a : Array α) :
     ofArray a = ofList a.toList := by
   apply ext
@@ -1281,6 +1281,7 @@ theorem ofList_singleton {k : α} :
       insertMany ((∅ : HashSet α).insert hd) tl :=
   ext HashMap.unitOfList_cons
 
+@[cbv_eval]
 theorem ofList_eq_insertMany_empty {l : List α} :
     ofList l = insertMany (∅ : HashSet α) l :=
   ext HashMap.unitOfList_eq_insertManyIfNewUnit_empty

--- a/tests/elab/cbv_hashmap_ofList.lean
+++ b/tests/elab/cbv_hashmap_ofList.lean
@@ -1,0 +1,26 @@
+import Std
+
+open Std
+
+attribute [cbv_opaque] HashMap.insert HashMap.emptyWithCapacity
+
+example : ((HashMap.ofList [] : HashMap String Nat) |>.get? "1") = .none := by
+  cbv
+
+example : ((HashMap.ofArray #[] : HashMap String Nat) |>.get? "1") = .none := by
+  cbv
+
+example : (Std.HashMap.ofList [("1", 1)] |>.get? "1") = some 1 := by
+  cbv
+
+example : (Std.HashMap.ofList [("1", 1), ("2", 2)] |>.get? "2") = some 2 := by
+  cbv
+
+example : (Std.HashMap.ofArray #[("1", 1), ("2", 2)] |>.get? "2") = some 2 := by
+  cbv
+
+example : ((HashSet.ofList [] : HashSet String) |>.contains "1") = false := by
+  cbv
+
+example : ((HashSet.ofList ["2","1"] : HashSet String) |>.contains "1") = true := by
+  cbv


### PR DESCRIPTION
This PR adds missing `cbv_eval` annotations to `ofList`/`ofArray`, `get!`, `getD`, `insert` operations on `HashMap`/`HashSet`.