### PR TITLE
fix: `String.Pos.Raw.extract` model/runtime mismatch

### DIFF
--- a/src/Init/Data/String/Basic.lean
+++ b/src/Init/Data/String/Basic.lean
@@ -783,7 +783,7 @@ If `b`'s offset is greater than or equal to that of `e`, then the resulting stri
 
 If possible, prefer `String.slice`, which avoids the allocation.
 -/
-@[extern "lean_string_utf8_extract"]
+@[extern "lean_string_utf8_extract_fast"]
 def extract {s : @& String} (b e : @& s.Pos) : String where
   toByteArray := s.toByteArray.extract b.offset.byteIdx e.offset.byteIdx
   isValidUTF8 := b.isValidUTF8_extract e

--- a/src/Init/Data/String/Basic.lean
+++ b/src/Init/Data/String/Basic.lean
@@ -2997,17 +2997,17 @@ The result is `""` if the start position is greater than or equal to the end pos
 start position is at the end of the string. If either position is invalid (that is, if either points
 at the middle of a multi-byte UTF-8 character) then the result is unspecified.
 
-This is a legacy function. The recommended alternative is `String.Pos.extract`, but usually
+This is a legacy function. The recommended alternative is `String.extract`, but usually
 it is even better to operate on `String.Slice` instead and call `String.Slice.copy` (only) if
 required.
 
 Examples:
-* `"red green blue".extract ⟨0⟩ ⟨3⟩ = "red"`
-* `"red green blue".extract ⟨3⟩ ⟨0⟩ = ""`
-* `"red green blue".extract ⟨0⟩ ⟨100⟩ = "red green blue"`
-* `"red green blue".extract ⟨4⟩ ⟨100⟩ = "green blue"`
-* `"L∃∀N".extract ⟨1⟩ ⟨2⟩ = "∃∀N"`
-* `"L∃∀N".extract ⟨2⟩ ⟨100⟩ = ""`
+* `String.Pos.Raw.extract "red green blue" ⟨0⟩ ⟨3⟩ = "red"`
+* `String.Pos.Raw.extract "red green blue" ⟨3⟩ ⟨0⟩ = ""`
+* `String.Pos.Raw.extract "red green blue" ⟨0⟩ ⟨100⟩ = "red green blue"`
+* `String.Pos.Raw.extract "red green blue" ⟨4⟩ ⟨100⟩ = "green blue"`
+* `String.Pos.Raw.extract "L∃∀N" ⟨1⟩ ⟨2⟩ = "∃∀N"`
+* `String.Pos.Raw.extract "L∃∀N" ⟨2⟩ ⟨100⟩ = ""`
 -/
 @[extern "lean_string_utf8_extract", expose]
 def Pos.Raw.extract : (@& String) → (@& Pos.Raw) → (@& Pos.Raw) → String

--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -2380,14 +2380,19 @@ extern "C" LEAN_EXPORT uint8 lean_string_is_valid_pos(b_obj_arg s, b_obj_arg i0)
     return is_utf8_first_byte(str[i]);
 }
 
-extern "C" LEAN_EXPORT obj_res lean_string_utf8_extract(b_obj_arg s, b_obj_arg b0, b_obj_arg e0) {
-    if (!lean_is_scalar(b0) || !lean_is_scalar(e0)) {
-        /* See comment at string_utf8_get */
-        lean_inc(s);
-        return s;
-    }
+extern "C" LEAN_EXPORT obj_res lean_string_utf8_extract_fast(b_obj_arg s, b_obj_arg b0, b_obj_arg e0) {
     usize b = lean_unbox(b0);
     usize e = lean_unbox(e0);
+    if (b >= e) return lean_mk_string_unchecked("", 0, 0);
+    char const * str = lean_string_cstr(s);
+    return lean_mk_string_from_bytes_unchecked(str + b, e - b);
+}
+
+extern "C" LEAN_EXPORT obj_res lean_string_utf8_extract(b_obj_arg s, b_obj_arg b0, b_obj_arg e0) {
+    // Clamp b0 and e0 to usize values: Non-scalar values are out of bounds here (see lean_string_utf8_get)
+    // Values that are out of bounds all behave the same, so clamping is enough here
+    usize b = lean_is_scalar(b0) ? lean_unbox(b0) : LEAN_MAX_SMALL_NAT;
+    usize e = lean_is_scalar(e0) ? lean_unbox(e0) : LEAN_MAX_SMALL_NAT;
     char const * str = lean_string_cstr(s);
     usize sz = lean_string_size(s) - 1;
     if (b >= e || b >= sz) return lean_mk_string_unchecked("", 0, 0);

--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -2393,7 +2393,7 @@ extern "C" LEAN_EXPORT obj_res lean_string_utf8_extract_fast(b_obj_arg s, b_obj_
 extern "C" LEAN_EXPORT obj_res lean_string_utf8_extract(b_obj_arg s, b_obj_arg b0, b_obj_arg e0) {
     /* Replace non-scalar values with SIZE_MAX:
     Non-scalar values are out of bounds here (see comment at string_utf8_get),
-    including SIZE_MAX, and values that are out of bounds all behave the same */
+    including SIZE_MAX, and values that are out of bounds all behave the same here */
     usize b = lean_is_scalar(b0) ? lean_unbox(b0) : SIZE_MAX;
     usize e = lean_is_scalar(e0) ? lean_unbox(e0) : SIZE_MAX;
     char const * str = lean_string_cstr(s);

--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -2383,16 +2383,19 @@ extern "C" LEAN_EXPORT uint8 lean_string_is_valid_pos(b_obj_arg s, b_obj_arg i0)
 extern "C" LEAN_EXPORT obj_res lean_string_utf8_extract_fast(b_obj_arg s, b_obj_arg b0, b_obj_arg e0) {
     usize b = lean_unbox(b0);
     usize e = lean_unbox(e0);
+    lean_assert(b <= lean_string_size(s) - 1);
+    lean_assert(e <= lean_string_size(s) - 1);
     if (b >= e) return lean_mk_string_unchecked("", 0, 0);
     char const * str = lean_string_cstr(s);
     return lean_mk_string_from_bytes_unchecked(str + b, e - b);
 }
 
 extern "C" LEAN_EXPORT obj_res lean_string_utf8_extract(b_obj_arg s, b_obj_arg b0, b_obj_arg e0) {
-    // Clamp b0 and e0 to usize values: Non-scalar values are out of bounds here (see lean_string_utf8_get)
-    // Values that are out of bounds all behave the same, so clamping is enough here
-    usize b = lean_is_scalar(b0) ? lean_unbox(b0) : LEAN_MAX_SMALL_NAT;
-    usize e = lean_is_scalar(e0) ? lean_unbox(e0) : LEAN_MAX_SMALL_NAT;
+    /* Replace non-scalar values with SIZE_MAX:
+    Non-scalar values are out of bounds here (see comment at string_utf8_get),
+    including SIZE_MAX, and values that are out of bounds all behave the same */
+    usize b = lean_is_scalar(b0) ? lean_unbox(b0) : SIZE_MAX;
+    usize e = lean_is_scalar(e0) ? lean_unbox(e0) : SIZE_MAX;
     char const * str = lean_string_cstr(s);
     usize sz = lean_string_size(s) - 1;
     if (b >= e || b >= sz) return lean_mk_string_unchecked("", 0, 0);

--- a/tests/compile/extract_uaf.lean.out.expected
+++ b/tests/compile/extract_uaf.lean.out.expected
@@ -1,1 +1,1 @@
-0-heap-padding|A-heap-padding
+0-heap-padding|-heap-padding

--- a/tests/elab/string.lean
+++ b/tests/elab/string.lean
@@ -208,7 +208,7 @@ Behavior of `String.next` (`lean_string_utf8_next`) in special cases (see issue 
 #test String.Pos.Raw.extract "red green blue" ⟨0⟩ ⟨2 ^ 100⟩ = "red green blue"
 #test String.Pos.Raw.extract "red green blue" ⟨4⟩ ⟨2 ^ 100⟩ = "green blue"
 #test String.Pos.Raw.extract "L∃∀N" ⟨1⟩ ⟨2⟩ = "∃∀N"
-#test String.Pos.Raw.extract "L∃∀N" ⟨1⟩ ⟨1⟩ = ""
+#test String.Pos.Raw.extract "L∃∀N" ⟨3⟩ ⟨2⟩ = ""
 #test String.Pos.Raw.extract "L∃∀N" ⟨2⟩ ⟨100⟩ = ""
 #test String.Pos.Raw.extract "L∃∀N" ⟨2 ^ 100⟩ ⟨1⟩ = ""
 #test String.Pos.Raw.extract "L∃∀N" ⟨2 ^ 100⟩ ⟨2 ^ 101⟩ = ""

--- a/tests/elab/string.lean
+++ b/tests/elab/string.lean
@@ -1,6 +1,7 @@
 module
 
 meta import Init.Data.String
+import all Init.Data.String.Basic
 
 /-!
 # Tests for `String` functions
@@ -199,3 +200,18 @@ Behavior of `String.next` (`lean_string_utf8_next`) in special cases (see issue 
 #test ("L∃∀N".pos ⟨1⟩ (by decide)).prev?.map (·.offset) = some ⟨0⟩
 #test ("L∃∀N".pos ⟨0⟩ (by decide)).prev? = none
 #test ("L∃∀N".pos ⟨1⟩ (by decide)).prev!.offset = ⟨0⟩
+
+#test String.Pos.Raw.extract "red green blue" ⟨0⟩ ⟨3⟩ = "red"
+#test String.Pos.Raw.extract "red green blue" ⟨3⟩ ⟨0⟩ = ""
+#test String.Pos.Raw.extract "red green blue" ⟨0⟩ ⟨100⟩ = "red green blue"
+#test String.Pos.Raw.extract "red green blue" ⟨4⟩ ⟨100⟩ = "green blue"
+#test String.Pos.Raw.extract "red green blue" ⟨0⟩ ⟨2 ^ 100⟩ = "red green blue"
+#test String.Pos.Raw.extract "red green blue" ⟨4⟩ ⟨2 ^ 100⟩ = "green blue"
+#test String.Pos.Raw.extract "L∃∀N" ⟨1⟩ ⟨2⟩ = "∃∀N"
+#test String.Pos.Raw.extract "L∃∀N" ⟨1⟩ ⟨1⟩ = ""
+#test String.Pos.Raw.extract "L∃∀N" ⟨2⟩ ⟨100⟩ = ""
+#test String.Pos.Raw.extract "L∃∀N" ⟨2 ^ 100⟩ ⟨1⟩ = ""
+#test String.Pos.Raw.extract "L∃∀N" ⟨2 ^ 100⟩ ⟨2 ^ 101⟩ = ""
+
+#test "red green blue".extract (String.pos _ ⟨0⟩ (by decide)) (String.pos _ ⟨3⟩ (by decide)) = "red"
+#test "red green blue".extract (String.pos _ ⟨4⟩ (by decide)) (String.pos _ ⟨14⟩ (by decide)) = "green blue"


### PR DESCRIPTION
This PR the model/runtime mismatch in `String.Pos.Raw.extract` and adds a faster variant (`lean_string_utf8_extract_fast`) for `String.extract` that assumes that the positions are valid positions.

Closes #14684
