### PR TITLE
fix: lake: demote cache failures to `trace`

### DIFF
--- a/src/lake/Lake/Build/Common.lean
+++ b/src/lake/Lake/Build/Common.lean
@@ -521,17 +521,16 @@ stored in the cached input-to-content mapping.
 @[specialize] def getArtifactsUsingCache?
   [ResolveOutputs α] (inputHash : Hash) (pkg : Package)
 : JobM (Option α) := do
-  if let some out ← (← getLakeCache).readOutputs? pkg.cacheScope inputHash then
-    try
-      return some (← resolveOutputs out)
-    catch e =>
-      let log ← takeLogFrom e
-      let msg := s!"input '{inputHash.toString.take 7}' found in package artifact cache, \
-        but some output(s) have issues:"
-      let msg := log.entries.foldl (s!"{·}\n- {·.message}") msg
-      logWarning msg
-      return none
-  else
+  try
+    (← (← getLakeCache).readOutputs? pkg.cacheScope inputHash).mapM resolveOutputs
+  catch e =>
+    let log ← takeLogFrom e
+    let msg := s!"input '{inputHash.toString.take 7}' found in package artifact cache, \
+      but some output(s) have issues:"
+    let msg := log.entries.foldl (s!"{·}\n- {·.message}") msg
+    -- Must be `trace` to avoid breaking `--wfail` / `--iofail` builds
+    -- TODO: Figure out a way to split cache and build failures
+    logVerbose msg
     return none
 
 open ResolveOutputs in

--- a/src/lake/Lake/Config/Cache.lean
+++ b/src/lake/Lake/Config/Cache.lean
@@ -466,10 +466,9 @@ public def readOutputs? (cache : Cache) (scope : String) (inputHash : Hash) : Lo
   | .ok contents =>
     match Json.parse contents >>= fromJson? with
     | .ok out =>
-      return out
+      return some out
     | .error e =>
-      logWarning s!"{path}: invalid JSON: {e}"
-      return none
+      error s!"{path}: invalid JSON: {e}"
   | .error (.noFileOrDirectory ..) => return none
   | .error e => error s!"{path}: read failed: {e}"
 

--- a/tests/lake/tests/cache/test.sh
+++ b/tests/lake/tests/cache/test.sh
@@ -154,7 +154,7 @@ test_exp -f .lake/build/lib/lean/Test.ilean
 
 # Verify that things work properly if the cached artifact is removed
 test_cmd rm -f "$cache_art"
-test_out "⚠ [4/4] Replayed Test:c.o" build +Test:o -v --no-build
+test_out "Replayed Test:c.o" build +Test:o -v --no-build
 test_exp -f "$cache_art" # artifact should be re-cached
 test_cmd rm -r "$CACHE_DIR/outputs"
 test_out "Replayed Test:c.o" build +Test:o -v --no-build
@@ -336,7 +336,8 @@ test_cmd chmod 444 $CACHE_DIR/artifacts/*
 test_cmd rm -rf .lake/build/bin
 test_run exe test
 
-# Verify that invalid outputs do not break Lake
+# Verify that invalid outputs do not break Lake.
+# https://github.com/leanprover/lean4/issues/14670
 if command -v jq > /dev/null; then # skip if no jq found
   libPath=$($LAKE query Test:static)
   test_cmd rm -f $libPath
@@ -344,11 +345,11 @@ if command -v jq > /dev/null; then # skip if no jq found
   echo $inputHash
   test_cmd rm -f $libPath.trace
   echo bogus > "$CACHE_DIR/outputs/test/$inputHash.json"
-  test_out 'invalid JSON' build Test:static
+  test_out 'invalid JSON' build Test:static -v --iofail
   test_exp -f $libPath
   test_cmd rm -f $libPath $libPath.trace
   echo '"bogus"' > "$CACHE_DIR/outputs/test/$inputHash.json"
-  test_out 'some output(s) have issues' build Test:static
+  test_out 'some output(s) have issues' build Test:static -v --iofail
   test_exp -f $libPath
 fi
 


### PR DESCRIPTION
This PR demotes all cache-related failures during a build to `trace`-level messages. This ensures that builds run with `--wfail` or `--iofail` do not fail solely due to the cache.

It also makes `readOutputs?` fail on invalid JSON and catches such errors.

Closes #14670
