### PR TITLE
fix: lake: `leanExit` test flakiness

### DIFF
--- a/tests/lake/run_test.sh
+++ b/tests/lake/run_test.sh
@@ -9,4 +9,6 @@ LAKE=${LAKE:-$(lake query lake)}
 
 # Run the test
 TEST_DIR="$1"; shift
-$LAKE env bash -c "cd "$TEST_DIR" && source test.sh"
+CMD1="cd \"$TEST_DIR\" && ./test.sh"
+CMD2='rc=$?; echo "EXIT: $rc"; exit $rc'
+$LAKE env bash -c "$CMD1; $CMD2"

--- a/tests/lake/tests/leanExit/ErrorExit0.lean
+++ b/tests/lake/tests/leanExit/ErrorExit0.lean
@@ -1,2 +1,18 @@
-def bad : Nat := "not a Nat"
-#eval (IO.Process.exit 0 : IO Unit)
+import Lean
+
+open Lean Elab Command in
+-- Lean will not reliably report messages before an early exit
+-- via `IO.Process.exit`, so we fabricate the desired behavior.
+-- `#exit` is reliable, but it does not accept an exit code.
+run_cmd
+  let log ← liftCoreM do
+    logError "Type mismatch"
+    Core.getAndEmptyMessageLog
+  -- We escape `run_cmd` capturing output by spawning a task
+  -- https://github.com/leanprover/lean4/issues/426
+  -- If fixed, stdout could also be hackily acquired on import by
+  -- `initialize realStdout : IO.FS.Stream ← IO.getStdout`
+  let t ← IO.asTask <| log.unreported.forM fun msg => do
+    IO.println (← msg.toJson).compress
+  IO.ofExcept (← IO.wait t)
+  IO.Process.exit (α := Unit) 0

--- a/tests/lake/tests/leanExit/test.sh
+++ b/tests/lake/tests/leanExit/test.sh
@@ -15,19 +15,19 @@ test_fails build TypeError
 
 echo "# TEST: report exit code 1 without diagnostics"
 lake_out build Exit1NoError || true
-match_text "Lean exited with code 1" produced.out
+match_text "error: Lean exited with code 1" produced.out
 no_match_text "Type mismatch" produced.out
 test_fails build Exit1NoError
 
 echo "# TEST: report exit code 0 when diagnostics were emitted"
 lake_out build ErrorExit0 || true
 match_text "Type mismatch" produced.out
-match_text "Lean exited with code 0" produced.out
+match_text "error: Lean exited with code 0" produced.out
 test_fails build ErrorExit0
 
 echo "# TEST: report non-1 exit codes"
 lake_out build Exit3 || true
-match_text "Lean exited with code 3" produced.out
+match_text "error: Lean exited with code 3" produced.out
 test_fails build Exit3
 
 rm -f produced.out


### PR DESCRIPTION
This PR fixes flakiness in `leanExit` caused by `lean` not reliably reporting diagnostics before an early exit. To do so, it relies on a hack to flush a message to `lean`'s real standard output before calling `IO.Process.exit`.

It also adds exit code reporting to the `tests/lake/run_test.sh` script.
