### PR TITLE
feat: lake: configurable `MACOSX_DEPLOYMENT_TARGET`

### DIFF
--- a/src/lake/Lake/Build/Actions.lean
+++ b/src/lake/Lake/Build/Actions.lean
@@ -146,35 +146,28 @@ public def compileStaticLib
   let args := args.push libFile.toString ++ (← mkArgs libFile <| oFiles.map toString)
   proc {cmd := ar.toString, args}
 
-def getMacOSXDeploymentEnv : BaseIO (Array (String × Option String)) := do
-  -- It is difficult to identify the correct minor version here, leading to linking warnings like:
-  -- `ld64.lld: warning: /usr/lib/system/libsystem_kernel.dylib has version 13.5.0, which is newer than target minimum of 13.0.0`
-  -- In order to suppress these we set the MACOSX_DEPLOYMENT_TARGET variable into the far future.
-  if System.Platform.isOSX then
-    match (← IO.getEnv "MACOSX_DEPLOYMENT_TARGET") with
-    | some _ => return #[]
-    | none => return #[("MACOSX_DEPLOYMENT_TARGET", some "99.0")]
-  else
-    return #[]
-
 public def compileSharedLib
-  (libFile : FilePath) (linkArgs : Array String) (linker : FilePath := "cc")
+  (libFile : FilePath) (linkArgs : Array String)
+  (linker : FilePath := "cc") (macosxDeploymentTarget? : Option String := none)
 : LogIO Unit := do
   createParentDirs libFile
   proc {
     cmd := linker.toString
     args := #["-shared", "-o", libFile.toString] ++ (← mkArgs libFile linkArgs)
-    env := ← getMacOSXDeploymentEnv
+    -- See `BuildConfig.macosxDeploymentTarget?` for details
+    env := macosxDeploymentTarget?.elim #[] fun ver => #[("MACOSX_DEPLOYMENT_TARGET", some ver)]
   }
 
 public def compileExe
-  (binFile : FilePath) (linkArgs : Array String) (linker : FilePath := "cc")
+  (binFile : FilePath) (linkArgs : Array String)
+  (linker : FilePath := "cc") (macosxDeploymentTarget? : Option String := none)
 : LogIO Unit := do
   createParentDirs binFile
   proc {
     cmd := linker.toString
     args := #["-o", binFile.toString] ++ (← mkArgs binFile linkArgs)
-    env := ← getMacOSXDeploymentEnv
+    -- See `BuildConfig.macosxDeploymentTarget?` for details
+    env :=  macosxDeploymentTarget?.elim #[] fun ver => #[("MACOSX_DEPLOYMENT_TARGET", some ver)]
   }
 
 /-- Download a file using `curl`, clobbering any existing file. -/

--- a/src/lake/Lake/Build/Common.lean
+++ b/src/lake/Lake/Build/Common.lean
@@ -956,14 +956,19 @@ public def buildSharedLibSync
   (linkObjs : Array FilePath) (linkLibs : Array Dynlib)
   (args : Array String := #[]) (linker := "c++")
   (plugin := false) (linkDeps := Platform.isWindows)
+  (macosxDeploymentTarget? : Option String := none)
 : JobM Dynlib := do
   -- shared libraries are platform-dependent artifacts
   addPlatformTrace
+  let macosxDeploymentTarget? :=
+    macosxDeploymentTarget? <|> (← getMacOSXDeploymentTarget?)
+  if let some ver := macosxDeploymentTarget? then
+    addPureTrace ver "MACOSX_DEPLOYMENT_TARGET"
   -- Lean plugins are required to have a specific name
   -- and thus need to restored from the cache with that name
   let art ← buildArtifactUnlessUpToDate libFile (ext := sharedLibExt) (restore := true) do
     let baseArgs ← mkLinkArgs linkObjs linkLibs linkDeps
-    compileSharedLib libFile (baseArgs ++ args) linker
+    compileSharedLib libFile (baseArgs ++ args) linker macosxDeploymentTarget?
   return {name := libName, path := art.path, deps := linkLibs, plugin}
 
 /--
@@ -986,12 +991,14 @@ public def buildSharedLib
   (weakArgs traceArgs : Array String := #[]) (linker := "c++")
   (extraDepTrace : JobM _ := pure BuildTrace.nil)
   (plugin := false) (linkDeps := Platform.isWindows)
+  (macosxDeploymentTarget? : Option String := none)
 : SpawnM (Job Dynlib) :=
   (Job.collectArray linkObjs "linkObjs").bindM (sync := true) fun objs => do
   (Job.collectArray linkLibs "linkLibs").mapM fun libs => do
     addTrace (← extraDepTrace)
     addPureTrace traceArgs "traceArgs"
-    buildSharedLibSync libName libFile objs libs (weakArgs ++ traceArgs) linker plugin linkDeps
+    buildSharedLibSync libName libFile objs libs (weakArgs ++ traceArgs)
+      linker plugin linkDeps macosxDeploymentTarget?
 
 /--
 Build a shared library linking Lean by using the Lean toolchain's linker.
@@ -1010,6 +1017,7 @@ public def buildLeanSharedLibSync
   (linkObjs : Array FilePath) (linkLibs : Array Dynlib)
   (args : Array String := #[]) (plugin := false)
   (linkDeps := Platform.isWindows)
+  (macosxDeploymentTarget? : Option String := none)
 : JobM Dynlib := do
   addLeanTrace
   addPlatformTrace -- shared libraries are platform-dependent artifacts
@@ -1017,7 +1025,7 @@ public def buildLeanSharedLibSync
   -- and thus need to restored from the cache with that name
   let art ← buildArtifactUnlessUpToDate libFile (ext := sharedLibExt) (restore := true) do
     let args ← mkLeanLinkArgs linkObjs linkLibs args linkDeps (sharedLean := true)
-    compileSharedLib libFile args (← getLeanCc)
+    compileSharedLib libFile args (← getLeanCc) macosxDeploymentTarget?
   return {name := libName, path := art.path, deps := linkLibs, plugin}
 
 /--
@@ -1038,11 +1046,13 @@ public def buildLeanSharedLib
   (linkObjs : Array (Job FilePath)) (linkLibs : Array (Job Dynlib))
   (weakArgs traceArgs : Array String := #[]) (plugin := false)
   (linkDeps := Platform.isWindows)
+  (macosxDeploymentTarget? : Option String := none)
 : SpawnM (Job Dynlib) :=
   (Job.collectArray linkObjs "linkObjs").bindM (sync := true) fun objs => do
   (Job.collectArray linkLibs "linkLibs").mapM fun libs => do
     addPureTrace traceArgs "traceArgs"
-    buildLeanSharedLibSync libName libFile objs libs (weakArgs ++ traceArgs) plugin linkDeps
+    buildLeanSharedLibSync libName libFile objs libs (weakArgs ++ traceArgs)
+      plugin linkDeps macosxDeploymentTarget?
 
 /--
 Build an executable linking Lean by using the Lean toolchain's linker.
@@ -1061,12 +1071,18 @@ Additional arguments to the linker can be provided via `args`.
 public def buildLeanExeSync
   (exeFile : FilePath) (linkObjs : Array FilePath) (linkLibs : Array Dynlib)
   (args : Array String := #[]) (sharedLean : Bool := false)
+  (macosxDeploymentTarget? : Option String := none)
 : JobM FilePath := do
   addLeanTrace
-  addPlatformTrace -- executables are platform-dependent artifacts
+  -- executables are platform-dependent artifacts
+  addPlatformTrace
+  let macosxDeploymentTarget? :=
+    macosxDeploymentTarget? <|> (← getMacOSXDeploymentTarget?)
+  if let some ver := macosxDeploymentTarget? then
+    addPureTrace ver "MACOSX_DEPLOYMENT_TARGET"
   let art ← buildArtifactUnlessUpToDate exeFile (ext := FilePath.exeExtension) (exe := true) (restore := true) do
     let args ← mkLeanLinkArgs linkObjs linkLibs args (linkDeps := true) sharedLean
-    compileExe exeFile args (← getLeanCc)
+    compileExe exeFile args (← getLeanCc) macosxDeploymentTarget?
   return art.path
 
 /--
@@ -1088,8 +1104,9 @@ public def buildLeanExe
   (exeFile : FilePath)
   (linkObjs : Array (Job FilePath)) (linkLibs : Array (Job Dynlib))
   (weakArgs traceArgs : Array String := #[]) (sharedLean : Bool := false)
+  (macosxDeploymentTarget? : Option String := none)
 : SpawnM (Job FilePath) :=
   (Job.collectArray linkObjs "linkObjs").bindM (sync := true) fun objs => do
   (Job.collectArray linkLibs "linkLibs").mapM fun libs => do
     addPureTrace traceArgs "traceArgs"
-    buildLeanExeSync exeFile objs libs (weakArgs ++ traceArgs) sharedLean
+    buildLeanExeSync exeFile objs libs (weakArgs ++ traceArgs) sharedLean macosxDeploymentTarget?

--- a/src/lake/Lake/Build/Context.lean
+++ b/src/lake/Lake/Build/Context.lean
@@ -15,7 +15,7 @@ namespace Lake
 
 /-- Configuration options for a Lake build. -/
 public structure BuildConfig extends LogConfig where
-  /-- Use modification times for trace checking. -/
+  /-- Whether to use modification times for trace checking. -/
   oldMode : Bool := false
   /-- Whether to trust `.hash` files. -/
   trustHash : Bool := true
@@ -38,6 +38,28 @@ public structure BuildConfig extends LogConfig where
   linter-tagged warnings), without touching dependencies.
   -/
   leanOptOverrides : Lean.NameMap Lean.LeanOptions := {}
+  /--
+  The miniumum OS version to target on MacOS.
+
+  If a minimum is not set, linkers default the minimum to the host major version and
+  will emit warnings if any lineed libraries (including system libraries) exceed the minium.
+  Thus, the linker will complain when building on a system with an unset minimum and system
+  libraries which require a higher minor version.
+
+  ```
+  ld64.lld: warning: /usr/lib/system/libsystem_kernel.dylib has version 13.5.0, which is newer than target minimum of 13.0.0
+  ```
+
+  To silence such warnings, Lake sets this far into the future by default (e.g., `99.0`).
+  However, that itself can be wrong if a consumer of Lean library uses the minimum OS version
+  to determine compatibility (e.g., Python does this). The far-flung version would then
+  imply zero compatibility.
+
+  In such cases, the desired deployment target can be manually specified . Depending on
+  the desired scope, it can be set per-target, for all targets within a buld (with this),
+  or across all builds with the environment variable `MACOSX_DEPLOYMENT_TARGET`.
+  -/
+  macosxDeploymentTarget? : Option String := none
 
 /--
 Whether the build should show progress information.
@@ -85,16 +107,20 @@ public instance [Pure m] : MonadLift LakeM (BuildT m) where
 @[inline] public def getBuildConfig [Functor m] [MonadBuild m] : m BuildConfig :=
   (·.toBuildConfig) <$> getBuildContext
 
-@[inline] public def getIsOldMode [Functor m] [MonadBuild m] : m Bool :=
+@[inline, inherit_doc BuildConfig.oldMode]
+public def getIsOldMode [Functor m] [MonadBuild m] : m Bool :=
   (·.oldMode) <$> getBuildConfig
 
-@[inline] public def getTrustHash [Functor m] [MonadBuild m] : m Bool :=
+@[inline, inherit_doc BuildConfig.trustHash]
+public def getTrustHash [Functor m] [MonadBuild m] : m Bool :=
   (·.trustHash) <$> getBuildConfig
 
-@[inline] public def getNoBuild [Functor m] [MonadBuild m] : m Bool :=
+@[inline, inherit_doc BuildConfig.noBuild]
+public def getNoBuild [Functor m] [MonadBuild m] : m Bool :=
   (·.noBuild) <$> getBuildConfig
 
-@[inline] public def getVerbosity [Functor m] [MonadBuild m] : m Verbosity :=
+@[inline, inherit_doc BuildConfig.verbosity]
+public def getVerbosity [Functor m] [MonadBuild m] : m Verbosity :=
   (·.verbosity) <$> getBuildConfig
 
 @[inline] public def getIsVerbose [Functor m] [MonadBuild m] : m Bool :=
@@ -103,6 +129,11 @@ public instance [Pure m] : MonadLift LakeM (BuildT m) where
 @[inline] public def getIsQuiet [Functor m] [MonadBuild m] : m Bool :=
   (· == .quiet) <$> getVerbosity
 
-@[inline] public def getLeanOptOverrides [Functor m] [MonadBuild m]
+@[inline, inherit_doc BuildConfig.leanOptOverrides]
+public def getLeanOptOverrides [Functor m] [MonadBuild m]
     : m (Lean.NameMap Lean.LeanOptions) :=
   (·.leanOptOverrides) <$> getBuildConfig
+
+@[inline, inherit_doc BuildConfig.macosxDeploymentTarget?]
+public def getMacOSXDeploymentTarget? [Functor m] [MonadBuild m] : m (Option String) :=
+  (·.macosxDeploymentTarget?) <$> getBuildConfig

--- a/src/lake/Lake/Build/Run.lean
+++ b/src/lake/Lake/Build/Run.lean
@@ -336,7 +336,17 @@ def mkBuildContext'
   (ws : Workspace) (cfg : BuildConfig) (jobs : JobQueue)
 : BaseIO BuildContext := return {
   opaqueWs := ws
-  toBuildConfig := cfg
+  toBuildConfig := {cfg with
+    macosxDeploymentTarget? := ← id do
+      if System.Platform.isOSX then
+        match cfg.macosxDeploymentTarget? with
+        | some ver => return some ver
+        | none =>
+          -- TODO: Consider adding `MACOSX_DEPLOYMENT_TARGET` to `Lake.Env`
+          return some <| (← IO.getEnv "MACOSX_DEPLOYMENT_TARGET").getD "99.0"
+      else
+        return cfg.macosxDeploymentTarget?
+    }
   outputsRef? := ← id do
     if cfg.outputsFile?.isSome then
       some <$> CacheRef.mk


### PR DESCRIPTION
This PR makes the `MACOSX_DEPLOYMENT_TARGET` configurable via the Lake API -- both across a build and for custom builds of shared libraries or executables.  It also includes the target in traces, ensuring a rebuilding if the value changes (e.g., if the environment variable `MACOSX_DEPLOYMENT_TARGET` is set).
