### PR TITLE
feat: lake: cache get `--package` & stabilize `--rev`

### DIFF
--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -420,12 +420,13 @@ USAGE:
 
 OPTIONS:
   --max-revs=<n>                  backtrack up to n revisions (default: 100)
-  --rev=<commit-hash>             uses this exact revision to lookup artifacts
-  --service=<name>                cache service to fetch from
-  --repo=<github-repo>            GitHub repository of the package or a fork
-  --platform=<target-triple>      with Reservoir or --repo, sets the platform
-  --toolchain=<name>              with Reservoir or --repo, sets the toolchain
-  --scope=<remote-scope>          scope for a custom endpoint
+  --rev=<commit-hash>             lookup artifacts only for set revision
+  --package=<name>                fetch outputs for set package
+  --service=<name>                fetch outputs from set cache service
+  --repo=<github-repo>            GitHub repository of the package or its fork
+  --platform=<target-triple>      with Reservoir or --repo, set the platform
+  --toolchain=<name>              with Reservoir or --repo, set the toolchain
+  --scope=<remote-scope>          verbatim scope for a custom endpoint
   --mappings-only                 only download mappings, delay artifacts
   --force-download                redownload existing files
 
@@ -471,29 +472,29 @@ def helpCachePut :=
 USAGE:
   lake cache put <mappings> <scope-option>
 
-Uploads the input-to-output mappings contained in the specified file along
-with the corresponding output artifacts to a remote cache. The cache service
-used can be specified via the `--service` option. If not specified, Lake will use
-the system default, or error if none is configured. See the help page of
-`lake cache services` for more information on how to configure services.
-
-Files are uploaded using the AWS Signature Version 4 authentication protocol
-via `curl`. Thus, the service should generally be an S3-compatible bucket. The
-authentication key is set via the `LAKE_CACHE_KEY` environment variable.
-
-Since Lake does not currently use cryptographically secure hashes for
-artifacts and outputs, uploads to the cache are prefixed with a scope to avoid
-clashes. This scope is configured with the following options:
-
-  --scope=<remote-scope>          sets a fixed scope
-  --repo=<github-repo>            uses the repository + toolchain & platform
+OPTIONS:
+  --service=<name>                upload to set cache service
+  --scope=<remote-scope>          upload under set scope verbatim
+  --repo=<github-repo>            scope w/ repository + toolchain & platform
   --toolchain=<name>              with --repo, sets the toolchain
   --platform=<target-triple>      with --repo, sets the platform
 
-At least one of `--scope` or `--repo` must be set. If `--repo` is used, Lake
-will produce a scope by augmenting the repository with toolchain and platform
-information as it deems necessary. If `--scope` is set, Lake will use the
-specified scope verbatim.
+Uploads the input-to-output mappings contained in the specified file along
+with the corresponding output artifacts to a remote cache. The cache service
+used can be specified via the `--service` option. If not specified, Lake will
+use the system default, or error if none is configured. See the help page of
+`lake cache services` for more information on how to configure services.
+
+Files are uploaded using the AWS Signature Version 4 authentication protocol
+via `curl`. Thus, the service should generally be an S3-compatible bucket.
+The authentication key is set via the `LAKE_CACHE_KEY` environment variable.
+
+Since Lake does not currently use cryptographically secure hashes for
+artifacts and outputs, uploads to the cache are prefixed with a scope to
+avoid clashes. This is controlled by `--scope` or `--repo`. With `--repo`,
+Lake will produce a scope by augmenting the repository with toolchain and
+platform information as it deems necessary. With `--scope`, Lake will use
+the specified scope verbatim.
 
 Artifacts are uploaded to the artifact endpoint with a file name derived
 from their Lake content hash (and prefixed by the repository or scope).
@@ -563,16 +564,24 @@ USAGE:
   lake cache put-staged <staging-directory>
 
 OPTIONS:
-  --scope=<remote-scope>          verbatim scope
-  --repo=<github-repo>            scope with repository + toolchain & platform
-  --toolchain=<name>              with --repo, sets the toolchain
-  --platform=<target-triple>      with --repo, sets the platform
+  --rev=<commit-hash>             upload for set revision
+  --service=<name>                upload to set cache service
+  --scope=<remote-scope>          upload under set scope verbatim
+  --repo=<github-repo>            scope w/ repository + toolchain & platform
+  --toolchain=<name>              with --repo, set the toolchain
+  --platform=<target-triple>      with --repo, set the platform
 
 Works like `lake cache put` but uploads outputs from the staging directory
-instead of the Lake cache. Does not configure the workspace and thus does not
-execute arbitrary user code. However, because of this, the package's platform
-and toolchain settings will not be automatically detected and must be
-specified manually via `--platform` and `--toolchain` (if desired)."
+instead of the Lake cache.
+
+Does not configure the workspace and thus does not execute arbitrary user
+code. However, because of this, the package's platform and toolchain settings
+will not be automatically detected for `--repo` and must be specified manually
+via `--platform` and `--toolchain` (if needed).
+
+Lake will still, by default, detect the target revision from the package
+directory's current Git revision. To upload outputs for a different revision,
+specify it with `--rev`."
 
 def helpCacheClean :=
 "Removes ALL files from the local Lake cache

--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -453,7 +453,7 @@ package by a repository name, rather than the package's. This can be used to
 download outputs for a fork of the Reservoir package (if such artifacts are
 available). The `--platform` and `--toolchain` options can be used to download
 artifacts for a different platform/toolchain configuration than Lake detects.
-For a custom endpoint, the full prefix Lake uses can be set via  `--scope`.
+For a custom endpoint, the full prefix Lake uses can be set via `--scope`.
 
 If `--rev` is not set, Lake uses the package's current revision to lookup
 artifacts. If no mappings are found, Lake will backtrack the Git history up to
@@ -472,7 +472,7 @@ def helpCachePut :=
 "Upload build outputs from the Lake cache to a remote service
 
 USAGE:
-  lake cache put <mappings> <scope-option>
+  lake cache put <mappings>
 
 OPTIONS:
   --service=<name>                upload to set cache service

--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -432,8 +432,8 @@ OPTIONS:
 
 Downloads build outputs for packages in the workspace from a remote cache
 service. The cache service used can be specified via the `--service` option.
-Otherwise, Lake will the system default, or, if none is configured, Reservoir.
-See `lake cache services` for more information on how to configure services.
+Otherwise, Lake will use the configured default or, if none, Reservoir. See
+`lake cache services` for more information on how to configure services.
 
 By default, Lake will use Reservoir to download outputs for each
 dependency in the workspace (in order). Non-Reservoir dependencies will be
@@ -512,7 +512,7 @@ USAGE:
   lake cache add <mappings>
 
 OPTIONS:
-  --package=<name>                add outputs to set package
+  --package=<name>                add mappings to set package
   --service=<name>                cache service to fetch from on demand
   --scope=<remote-scope>          the prefix of artifacts within the service
   --repo=<github-repo>            for Reservoir, a GitHub repository scope

--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -435,18 +435,20 @@ service. The cache service used can be specified via the `--service` option.
 Otherwise, Lake will the system default, or, if none is configured, Reservoir.
 See `lake cache services` for more information on how to configure services.
 
-If an input-to-outputs mappings file, `--scope`, or `--repo` is provided,
-Lake will download build outputs for the root package. Otherwise, it will use
-Reservoir to download outputs for each dependency in the workspace (in order).
-Non-Reservoir dependencies will be skipped.
+By default, Lake will use Reservoir to download outputs for each
+dependency in the workspace (in order). Non-Reservoir dependencies will be
+skipped. If instead an input-to-outputs mappings file, `--scope`, or `--repo`
+is provided, Lake will default to downloading build outputs for the root
+package. In either case, if `--package` is specified, Lake will switch to
+only downloading outputs for it.
 
 To determine what to download, Lake searches for input-to-output mappings for
-a given build of the package via the cache service. This mapping is identified
+a given build of a package via the cache service. This mapping is identified
 by a Git revision and prefixed with a scope derived from the package's name,
 GitHub repository, Lean toolchain, and current platform. The exact configuration
 can be customized using options.
 
-For Reservoir, setting `--repo` will cause Lake to lookup outputs for the root
+For Reservoir, setting `--repo` will cause Lake to lookup outputs for the
 package by a repository name, rather than the package's. This can be used to
 download outputs for a fork of the Reservoir package (if such artifacts are
 available). The `--platform` and `--toolchain` options can be used to download
@@ -510,6 +512,7 @@ USAGE:
   lake cache add <mappings>
 
 OPTIONS:
+  --package=<name>                add outputs to set package
   --service=<name>                cache service to fetch from on demand
   --scope=<remote-scope>          the prefix of artifacts within the service
   --repo=<github-repo>            for Reservoir, a GitHub repository scope
@@ -517,7 +520,8 @@ OPTIONS:
 
 Reads a list of input-to-output mappings from the provided file and adds
 them to the local Lake cache. Mappings already in the cache are overwritten
-unless `--no-overwrite` is specified.
+unless `--no-overwrite` is specified. Mappings are added for the root package
+unless `--package` is specified.
 
 If `--service` is provided, the output artifacts can then be fetched lazily
 from that service during a Lake build. The service must either be `reservoir`
@@ -579,7 +583,7 @@ code. However, because of this, the package's platform and toolchain settings
 will not be automatically detected for `--repo` and must be specified manually
 via `--platform` and `--toolchain` (if needed).
 
-Lake will still, by default, detect the target revision from the package
+Lake will still, by default, detect the target revision from the workspace
 directory's current Git revision. To upload outputs for a different revision,
 specify it with `--rev`."
 

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -484,6 +484,10 @@ protected def get : CliM PUnit := do
   if let some file := mappings? then liftM (m := LoggerIO) do
     if opts.mappingsOnly then
       error "`--mappings-only` is not supported with a mappings file; use `lake cache add` instead"
+    if opts.rev?.isSome then
+      logWarning "the `--rev` option does nothing for `cache get` with a mappings file"
+      if opts.failLv ≤ .warning then
+        failure
     if opts.platform?.isSome || opts.toolchain?.isSome then
       logWarning "the `--platform` and `--toolchain` options do nothing for `cache get` with a mappings file"
       if opts.failLv ≤ .warning then
@@ -536,28 +540,14 @@ protected def get : CliM PUnit := do
         error "to use `cache get` with `--scope`, a custom endpoint must be set (not Reservoir); \
           if you instead want to download artifacts for a fork of the package, use `--repo`"
       let pkg := pkg?.getD ws.root
-      let platform := cachePlatform pkg platform
-      let toolchain := cacheToolchain pkg toolchain
-      let map ← id do
-        if let some rev := opts.rev? then
-          let repo := GitRepo.mk pkg.dir
-          let rev ← repo.resolveRevision rev
-          let some map ← service.downloadRevisionOutputs? rev cache pkg.cacheScope remoteScope platform toolchain
-            | error s!"{remoteScope}: outputs not found for revision {rev}"
-          return map
-        else
-          findOutputs cache service pkg remoteScope opts platform toolchain
-      cache.writeMap pkg.cacheScope map service.name? (some remoteScope) overwrite
-      unless opts.mappingsOnly do
-        let descrs ← map.collectOutputDescrs
-        service.downloadArtifacts descrs cache remoteScope opts.forceDownload
+      fetchOutputs cache service pkg remoteScope opts platform toolchain overwrite
     else if service.isReservoir then
-      if opts.rev?.isSome then
-        error "the `--rev` option is not supported for a Reservoir `cache get`"
       if let some pkg := pkg? then
         let some remoteScope := pkg.reservoirScope?
           | error s!"{pkg.prettyName}: not a Reservoir dependency and no `--scope` or `--repo` set"
-        fetchReservoir cache service pkg remoteScope opts platform toolchain overwrite
+        fetchOutputs cache service pkg remoteScope opts platform toolchain overwrite
+      else if opts.rev?.isSome then
+        error "the `--rev` option is not supported for a multi-package Reservoir `cache get`"
       else
         -- TODO: Parallelize?
         let ok ← ws.packages.foldlM (start := 1) (init := true) (m := LoggerIO) fun ok pkg => do
@@ -565,7 +555,7 @@ protected def get : CliM PUnit := do
             | logInfo s!"{pkg.prettyName}: skipping non-Reservoir dependency"
               return ok
           try
-            fetchReservoir cache service pkg remoteScope opts platform toolchain overwrite
+            fetchOutputs cache service pkg remoteScope opts platform toolchain overwrite
             return ok
           catch _ =>
             return false
@@ -580,30 +570,35 @@ where
     \n  LAKE_CACHE_REVISION_ENDPOINT={revisionEndpoint}\n\
     To use `cache get` with a custom endpoint, both environment variables \
     must be set to non-empty strings. To use Reservoir, neither should be set."
-  fetchReservoir cache service pkg remoteScope opts platform toolchain overwrite : LoggerIO Unit := do
+  fetchOutputs cache service pkg remoteScope opts platform toolchain overwrite : LoggerIO Unit := do
     let platform := cachePlatform pkg platform
     let toolchain := cacheToolchain pkg toolchain
-    let map ← findOutputs cache service pkg remoteScope opts platform toolchain
+    let map : CacheMap ← id do
+      let repo := GitRepo.mk pkg.dir
+      if let some rev := opts.rev? then
+        let rev ← repo.resolveRevision rev
+        let some map ← service.downloadRevisionOutputs? rev cache pkg.cacheScope remoteScope platform toolchain opts.forceDownload
+          | error s!"{remoteScope}: outputs not found for revision {rev}"
+        return map
+      else
+        if (← repo.hasDiff) then
+          logWarning s!"{pkg.prettyName}: package has changes; \
+            only artifacts for committed code will be downloaded"
+          if opts.failLv ≤ .warning then
+            failure
+        let n := opts.maxRevs
+        let revs ← repo.getHeadRevisions n
+        let map? ← revs.findSomeM? fun rev =>
+          service.downloadRevisionOutputs? rev cache pkg.cacheScope remoteScope platform toolchain opts.forceDownload
+        let some map := map?
+          | let revisions :=
+              if n = 0 || revs.size < n then "for any revision" else s!"in {n} revisions from HEAD"
+            error s!"{remoteScope}: no outputs found {revisions}"
+        return map
     cache.writeMap pkg.cacheScope map service.name? (some remoteScope) overwrite
     unless opts.mappingsOnly do
       let descrs ← map.collectOutputDescrs
       service.downloadArtifacts descrs cache remoteScope opts.forceDownload
-  findOutputs cache service pkg remoteScope opts platform toolchain : LoggerIO CacheMap := do
-    let repo := GitRepo.mk pkg.dir
-    if (← repo.hasDiff) then
-      logWarning s!"{pkg.prettyName}: package has changes; \
-        only artifacts for committed code will be downloaded"
-      if opts.failLv ≤ .warning then
-        failure
-    let n := opts.maxRevs
-    let revs ← repo.getHeadRevisions n
-    let map? ← revs.findSomeM? fun rev =>
-      service.downloadRevisionOutputs? rev cache pkg.cacheScope remoteScope platform toolchain opts.forceDownload
-    let some map := map?
-      | let revisions :=
-          if n = 0 || revs.size < n then "for any revision" else s!"in {n} revisions from HEAD"
-        error s!"{remoteScope}: no outputs found {revisions}"
-    return map
 
 private def computeUploadService
   (service? : Option String) (lakeEnv : Env) (lakeCfg : LoadedLakeConfig)

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -480,6 +480,10 @@ protected def get : CliM PUnit := do
   unless overwrite do
     -- artifacts of skipped mappings with `--no-overwrite` cannot be cleanly handled
     error "`--no-overwrite` is not supported for `cache get`"
+  let pkg? ← opts.package?.bindM fun pkgName => do
+    match ws.findPackageByName? <| stringToLegalOrSimpleName pkgName with
+    | some pkg => return some pkg
+    | none => throw <| CliError.unknownPackage pkgName
   if let some file := mappings? then liftM (m := LoggerIO) do
     if opts.mappingsOnly then
       error "`--mappings-only` is not supported with a mappings file; use `lake cache add` instead"
@@ -500,7 +504,8 @@ protected def get : CliM PUnit := do
       else
         return ws.defaultCacheService
     let map ← CacheMap.load file
-    cache.writeMap ws.root.cacheScope map service.name? (some remoteScope) overwrite
+    let localScope := pkg?.elim ws.root.cacheScope (·.cacheScope)
+    cache.writeMap localScope map service.name? (some remoteScope) overwrite
     let descrs ← map.collectOutputDescrs
     service.downloadArtifacts descrs cache remoteScope opts.forceDownload
   else
@@ -533,12 +538,7 @@ protected def get : CliM PUnit := do
         -- This is likely user error (they meant `--repo`) rather than something actually useful.
         error "to use `cache get` with `--scope`, a custom endpoint must be set (not Reservoir); \
           if you instead want to download artifacts for a fork of the package, use `--repo`"
-      let pkg ← id do
-        if let some pkgName := opts.package? then
-          match ws.findPackageByName? <| stringToLegalOrSimpleName pkgName with
-          | some pkg => return pkg
-          | none => throw <| CliError.unknownPackage pkgName
-        else return ws.root
+      let pkg := pkg?.getD ws.root
       let platform := cachePlatform pkg platform
       let toolchain := cacheToolchain pkg toolchain
       let map ← id do
@@ -555,11 +555,7 @@ protected def get : CliM PUnit := do
         let descrs ← map.collectOutputDescrs
         service.downloadArtifacts descrs cache remoteScope opts.forceDownload
     else if service.isReservoir then
-      if let some pkgName := opts.package? then
-        let pkg ← id do
-          match ws.findPackageByName? <| stringToLegalOrSimpleName pkgName with
-          | some pkg => return pkg
-          | none => throw <| CliError.unknownPackage pkgName
+      if let some pkg := pkg? then
         let some remoteScope := pkg.reservoirScope?
           | error s!"{pkg.prettyName}: not a Reservoir dependency and no `--scope` or `--repo` set"
         fetchReservoir cache service pkg remoteScope opts platform toolchain overwrite

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -480,10 +480,7 @@ protected def get : CliM PUnit := do
   unless overwrite do
     -- artifacts of skipped mappings with `--no-overwrite` cannot be cleanly handled
     error "`--no-overwrite` is not supported for `cache get`"
-  let pkg? ← opts.package?.bindM fun pkgName => do
-    match ws.findPackageByName? <| stringToLegalOrSimpleName pkgName with
-    | some pkg => return some pkg
-    | none => throw <| CliError.unknownPackage pkgName
+  let pkg? ← opts.package?.bindM (liftM <| parsePackageSpec ws ·)
   if let some file := mappings? then liftM (m := LoggerIO) do
     if opts.mappingsOnly then
       error "`--mappings-only` is not supported with a mappings file; use `lake cache add` instead"
@@ -555,6 +552,8 @@ protected def get : CliM PUnit := do
         let descrs ← map.collectOutputDescrs
         service.downloadArtifacts descrs cache remoteScope opts.forceDownload
     else if service.isReservoir then
+      if opts.rev?.isSome then
+        error "the `--rev` option is not supported for a Reservoir `cache get`"
       if let some pkg := pkg? then
         let some remoteScope := pkg.reservoirScope?
           | error s!"{pkg.prettyName}: not a Reservoir dependency and no `--scope` or `--repo` set"
@@ -671,6 +670,8 @@ protected def put : CliM PUnit := do
   let opts ← getThe LakeOptions
   let some scope := opts.scope?
     | error "the `--scope` or `--repo` option must be set"
+  if opts.package?.isSome then
+    error "the `--package` option is not supported for `cache put`"
   if opts.rev?.isSome then
     error "the `--rev` option is not supported for `cache put`; \
       to upload artifacts for different revisions, use the staging workflow, \
@@ -690,12 +691,11 @@ protected def put : CliM PUnit := do
 protected def add : CliM PUnit := do
   processOptions lakeOption
   let file ← takeArg "mappings"
-  let pkg? ← takeArg?
   let opts ← getThe LakeOptions
   noArgsRem do
   let cfg ← mkLoadConfig opts
   let ws ← loadWorkspace cfg
-  let pkg ← match pkg? with
+  let pkg ← match opts.package? with
     | some pkg => parsePackageSpec ws pkg
     | _ => pure ws.root
   let localScope := pkg.cacheScope
@@ -804,6 +804,8 @@ protected def putStaged : CliM PUnit := do
   let stagingDir ← FilePath.mk <$> takeArg "staging directory"
   let some scope := opts.scope?
     | error "the `--scope` or `--repo` option must be set"
+  if opts.package?.isSome then
+    error "the `--package` option does nothing for `cache put-staged`"
   noArgsRem do
   let cfg ← mkLoadConfig opts
   let lakeCfg ← loadLakeConfig cfg.lakeEnv

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -675,6 +675,10 @@ protected def put : CliM PUnit := do
   let opts ← getThe LakeOptions
   let some scope := opts.scope?
     | error "the `--scope` or `--repo` option must be set"
+  if opts.rev?.isSome then
+    error "the `--rev` option is not supported for `cache put`; \
+      to upload artifacts for different revisions, use the staging workflow, \
+      e.g., `lake cache stage` and `lake cache put-staged`"
   noArgsRem do
   let cfg ← mkLoadConfig opts
   let lakeEnv := cfg.lakeEnv

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -69,6 +69,7 @@ public structure LakeOptions where
   forceDownload : Bool := false
   mappingsOnly : Bool := false
   service? : Option String := none
+  package? : Option String := none
   scope? : Option CacheServiceScope := none
   platform? : Option CachePlatform := none
   toolchain? : Option CacheToolchain := none
@@ -291,6 +292,9 @@ def lakeLongOption : (opt : String) → CliM PUnit
 | "--force-download" => modifyThe LakeOptions ({· with forceDownload := true})
 | "--download-arts" => modifyThe LakeOptions ({· with mappingsOnly := false})
 | "--mappings-only" => modifyThe LakeOptions ({· with mappingsOnly := true})
+| "--package" => do
+  let pkgName ← takeOptArg "--package" "package name"
+  modifyThe LakeOptions ({· with package? := some pkgName})
 | "--service" => do
   let service ← takeOptArg "--service" "service name"
   modifyThe LakeOptions ({· with service? := some service})
@@ -529,12 +533,17 @@ protected def get : CliM PUnit := do
         -- This is likely user error (they meant `--repo`) rather than something actually useful.
         error "to use `cache get` with `--scope`, a custom endpoint must be set (not Reservoir); \
           if you instead want to download artifacts for a fork of the package, use `--repo`"
-      let pkg := ws.root
-      let repo := GitRepo.mk pkg.dir
+      let pkg ← id do
+        if let some pkgName := opts.package? then
+          match ws.findPackageByName? <| stringToLegalOrSimpleName pkgName with
+          | some pkg => return pkg
+          | none => throw <| CliError.unknownPackage pkgName
+        else return ws.root
       let platform := cachePlatform pkg platform
       let toolchain := cacheToolchain pkg toolchain
       let map ← id do
         if let some rev := opts.rev? then
+          let repo := GitRepo.mk pkg.dir
           let rev ← repo.resolveRevision rev
           let some map ← service.downloadRevisionOutputs? rev cache pkg.cacheScope remoteScope platform toolchain
             | error s!"{remoteScope}: outputs not found for revision {rev}"
@@ -546,24 +555,27 @@ protected def get : CliM PUnit := do
         let descrs ← map.collectOutputDescrs
         service.downloadArtifacts descrs cache remoteScope opts.forceDownload
     else if service.isReservoir then
-      -- TODO: Parallelize?
-      let ok ← ws.packages.foldlM (start := 1) (init := true) (m := LoggerIO) fun ok pkg => do
+      if let some pkgName := opts.package? then
+        let pkg ← id do
+          match ws.findPackageByName? <| stringToLegalOrSimpleName pkgName with
+          | some pkg => return pkg
+          | none => throw <| CliError.unknownPackage pkgName
         let some remoteScope := pkg.reservoirScope?
-          | logInfo s!"{pkg.prettyName}: skipping non-Reservoir dependency"
+          | error s!"{pkg.prettyName}: not a Reservoir dependency and no `--scope` or `--repo` set"
+        fetchReservoir cache service pkg remoteScope opts platform toolchain overwrite
+      else
+        -- TODO: Parallelize?
+        let ok ← ws.packages.foldlM (start := 1) (init := true) (m := LoggerIO) fun ok pkg => do
+          let some remoteScope := pkg.reservoirScope?
+            | logInfo s!"{pkg.prettyName}: skipping non-Reservoir dependency"
+              return ok
+          try
+            fetchReservoir cache service pkg remoteScope opts platform toolchain overwrite
             return ok
-        let platform := cachePlatform pkg platform
-        let toolchain := cacheToolchain pkg toolchain
-        try
-          let map ← findOutputs cache service pkg remoteScope opts platform toolchain
-          cache.writeMap pkg.cacheScope map service.name? (some remoteScope) overwrite
-          unless opts.mappingsOnly do
-            let descrs ← map.collectOutputDescrs
-            service.downloadArtifacts descrs cache remoteScope opts.forceDownload
-          return ok
-        catch _ =>
-          return false
-      unless ok do
-        error "failed to download artifacts for some dependencies"
+          catch _ =>
+            return false
+        unless ok do
+          error "failed to download artifacts for some dependencies"
     else
       error "to use `cache get` with a custom endpoint, the `--scope` or `--repo` option must be set"
 where
@@ -573,6 +585,14 @@ where
     \n  LAKE_CACHE_REVISION_ENDPOINT={revisionEndpoint}\n\
     To use `cache get` with a custom endpoint, both environment variables \
     must be set to non-empty strings. To use Reservoir, neither should be set."
+  fetchReservoir cache service pkg remoteScope opts platform toolchain overwrite : LoggerIO Unit := do
+    let platform := cachePlatform pkg platform
+    let toolchain := cacheToolchain pkg toolchain
+    let map ← findOutputs cache service pkg remoteScope opts platform toolchain
+    cache.writeMap pkg.cacheScope map service.name? (some remoteScope) overwrite
+    unless opts.mappingsOnly do
+      let descrs ← map.collectOutputDescrs
+      service.downloadArtifacts descrs cache remoteScope opts.forceDownload
   findOutputs cache service pkg remoteScope opts platform toolchain : LoggerIO CacheMap := do
     let repo := GitRepo.mk pkg.dir
     if (← repo.hasDiff) then
@@ -664,7 +684,7 @@ protected def put : CliM PUnit := do
   let platform := cachePlatform pkg (opts.platform?.getD .system)
   let toolchain := cacheToolchain pkg (opts.toolchain?.getD lakeEnv.cacheToolchain)
   let service ← computeUploadService opts.service? lakeEnv lakeCfg
-  let rev ← opts.rev?.getDM (computePackageRev pkg.dir)
+  let rev ← computePackageRev pkg.dir
   putCore rev file lakeCache.artifactDir service scope platform toolchain
 
 protected def add : CliM PUnit := do

--- a/tests/lake/tests/cacheTransfer/dep.toml
+++ b/tests/lake/tests/cacheTransfer/dep.toml
@@ -1,0 +1,18 @@
+name = "test"
+enableArtifactCache = true
+defaultTargets = ["Test"]
+
+[[lean_lib]]
+name = "Test"
+
+# A dependency Lake treats as a Reservoir package (i.e., it has a scope),
+# but sourced locally so that the test does not need the network
+[[require]]
+name = "dep"
+scope = "leanprover"
+path = "dep"
+
+# Example non-Reservoir dependency
+[[require]]
+name = "hello"
+path = "../../../examples/hello"

--- a/tests/lake/tests/cacheTransfer/dep/Dep.lean
+++ b/tests/lake/tests/cacheTransfer/dep/Dep.lean
@@ -1,0 +1,1 @@
+def dep := "dep"

--- a/tests/lake/tests/cacheTransfer/dep/lakefile.toml
+++ b/tests/lake/tests/cacheTransfer/dep/lakefile.toml
@@ -1,0 +1,6 @@
+name = "dep"
+# So that a build of this package on its own produces cacheable outputs
+enableArtifactCache = true
+
+[[lean_lib]]
+name = "Dep"

--- a/tests/lake/tests/cacheTransfer/test.sh
+++ b/tests/lake/tests/cacheTransfer/test.sh
@@ -35,7 +35,7 @@ PORT_FILE="$WORK_DIR/port"
 # Copy test data to a working directory to avoid initializing a Git repository
 # inside the checked-in source tree
 mkdir -p "$WORK_DIR"
-cp -r lakefile.toml non-reservoir.toml BadCurl.lean Test.lean Test "$WORK_DIR/"
+cp -r lakefile.toml non-reservoir.toml dep.toml BadCurl.lean Test.lean Test dep "$WORK_DIR/"
 cd "$WORK_DIR"
 
 echo "# SETUP"
@@ -83,6 +83,9 @@ export ELAN_TOOLCHAIN=
 NUM_ARTS=2
 NUM_REPLAY_ARTS=8
 
+# The `dep` package's library has a single module
+NUM_DEP_ARTS=1
+
 # Runs a command with the cache endpoints set through the environment,
 # which is the deprecated alternative to a configured service
 with_endpoints() {
@@ -123,12 +126,15 @@ test_err 'the `--platform` and `--toolchain` options do nothing' \
 test_err 'the `--platform` and `--toolchain` options do nothing' \
   cache get bogus.jsonl --scope='bogus' --toolchain='bogus' --wfail
 test_err 'a custom endpoint must be set (not Reservoir)' cache get --scope='bogus'
+test_err 'unknown package `bogus`' cache get --package='bogus'
 with_endpoints test_err 'the `--scope` or `--repo` option must be set' cache get
 LAKE_CACHE_ARTIFACT_ENDPOINT=bogus test_err 'both environment variables must be set' cache get
 LAKE_CACHE_REVISION_ENDPOINT=bogus test_err 'both environment variables must be set' cache get
 
 # Verify `cache put` rejects bad configurations
 with_endpoints test_err 'the `--scope` or `--repo` option must be set' cache put bogus.jsonl
+test_err 'the `--rev` option is not supported for `cache put`' \
+  cache put bogus.jsonl --scope='bogus' --rev=bogus
 test_err 'the `--service` option must be set' \
   cache put bogus.jsonl --scope='bogus'
 LAKE_CACHE_KEY= test_err 'the `--service` option must be set' \
@@ -164,6 +170,9 @@ test_err 'outputs not found for revision' \
 # Verify dependencies that are not on Reservoir are skipped
 test_run -f non-reservoir.toml update
 test_out 'hello: skipping non-Reservoir dependency' -f non-reservoir.toml cache get
+# Verify such a dependency is an error when selected with `--package`
+test_err 'hello: not a Reservoir dependency' \
+  -f non-reservoir.toml cache get --package=hello
 test_run update
 
 echo "# TRANSFER TESTS"
@@ -344,6 +353,40 @@ match_text "POST /ok/api/v1/repositories/leanprover/test/artifacts" "$SERVER_LOG
 test_artifacts "$NUM_ARTS"
 test_run build Test --no-build
 
+# Verify `--package` fetches a single dependency through Reservoir,
+# using that dependency's scope and revision
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+test_run -f dep.toml update
+test_run -d dep build Dep -o dep-outputs.jsonl
+test_run -d dep cache put dep-outputs.jsonl --repo=leanprover/dep
+test_cmd rm -rf dep/.lake/build .lake/build "$CACHE_DIR"
+: > "$SERVER_LOG"
+# The other dependencies are left alone, so none is reported as skipped
+test_not_out 'skipping non-Reservoir dependency' -f dep.toml cache get --package=dep
+match_text "POST /ok/api/v1/packages/leanprover/dep/artifacts" "$SERVER_LOG"
+test_exp -d "$CACHE_DIR/revisions/dep"
+test_artifacts "$NUM_DEP_ARTS"
+test_run -f dep.toml build @dep/Dep --no-build
+
+# Verify `--package` also selects the dependency for a custom endpoint scope,
+# where `--rev` resolves within that dependency's repository
+test_run -d dep cache put dep-outputs.jsonl --scope=dep
+test_cmd rm -rf dep/.lake/build .lake/build "$CACHE_DIR"
+test_run -f dep.toml cache get --package=dep --scope=dep --service=ok --rev=HEAD
+test_exp -d "$CACHE_DIR/revisions/dep"
+test_artifacts "$NUM_DEP_ARTS"
+test_run -f dep.toml build @dep/Dep --no-build
+
+# Verify `--package` selects the dependency for a mappings file as well,
+# which is otherwise loaded into the root package's local scope
+test_cmd rm -rf dep/.lake/build .lake/build "$CACHE_DIR"
+test_run -f dep.toml cache get dep-outputs.jsonl --package=dep --scope=dep --service=ok
+test_exp -d "$CACHE_DIR/outputs/dep"
+test_exp ! -e "$CACHE_DIR/outputs/test"
+test_artifacts "$NUM_DEP_ARTS"
+test_run -f dep.toml build @dep/Dep --no-build
+test_run update
+
 # Verify a malformed artifact URL lookup is reported
 test_cmd rm -rf .lake/build "$CACHE_DIR"
 test_err 'Incorrect number of results' cache get --repo=leanprover/test --service=badCount
@@ -368,5 +411,15 @@ test_run cache put-staged staging --scope=staged
 test_exp -f "$STORE_DIR/r0/staged/$REV.jsonl"
 test_cmd rm -rf .lake/build "$CACHE_DIR"
 test_run cache get --scope=staged --service=ok
+test_artifacts "$NUM_ARTS"
+test_run build Test --no-build
+
+# Verify staged outputs can be uploaded for another revision,
+# which `cache get --rev` then fetches instead of those of the head revision
+OLD_REV="$(git rev-parse HEAD~1)"
+test_run cache put-staged staging --scope=staged --rev="$OLD_REV"
+test_exp -f "$STORE_DIR/r0/staged/$OLD_REV.jsonl"
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+test_out "for revision $OLD_REV" cache get --scope=staged --service=ok --rev="$OLD_REV"
 test_artifacts "$NUM_ARTS"
 test_run build Test --no-build

--- a/tests/lake/tests/cacheTransfer/test.sh
+++ b/tests/lake/tests/cacheTransfer/test.sh
@@ -85,6 +85,7 @@ NUM_REPLAY_ARTS=8
 
 # The `dep` package's library has a single module
 NUM_DEP_ARTS=1
+NUM_DEP_REPLAY_ARTS=4
 
 # Runs a command with the cache endpoints set through the environment,
 # which is the deprecated alternative to a configured service
@@ -127,12 +128,16 @@ test_err 'the `--platform` and `--toolchain` options do nothing' \
   cache get bogus.jsonl --scope='bogus' --toolchain='bogus' --wfail
 test_err 'a custom endpoint must be set (not Reservoir)' cache get --scope='bogus'
 test_err 'unknown package `bogus`' cache get --package='bogus'
+test_err 'the `--rev` option is not supported for a Reservoir `cache get`' \
+  cache get --rev=bogus
 with_endpoints test_err 'the `--scope` or `--repo` option must be set' cache get
 LAKE_CACHE_ARTIFACT_ENDPOINT=bogus test_err 'both environment variables must be set' cache get
 LAKE_CACHE_REVISION_ENDPOINT=bogus test_err 'both environment variables must be set' cache get
 
 # Verify `cache put` rejects bad configurations
 with_endpoints test_err 'the `--scope` or `--repo` option must be set' cache put bogus.jsonl
+test_err 'the `--package` option is not supported for `cache put`' \
+  cache put bogus.jsonl --scope='bogus' --package='bogus'
 test_err 'the `--rev` option is not supported for `cache put`' \
   cache put bogus.jsonl --scope='bogus' --rev=bogus
 test_err 'the `--service` option must be set' \
@@ -147,6 +152,8 @@ LAKE_CACHE_REVISION_ENDPOINT=bogus test_err 'these environment variables must be
 # Verify `cache put-staged` rejects bad configurations
 with_endpoints test_err 'the `--scope` or `--repo` option must be set' \
   cache put-staged bogus
+test_err 'the `--package` option does nothing for `cache put-staged`' \
+  cache put-staged bogus --scope='bogus' --package='bogus'
 test_err 'the `--service` option must be set' \
   cache put-staged bogus --scope='bogus'
 LAKE_CACHE_KEY= test_err 'the `--service` option must be set' \
@@ -161,6 +168,9 @@ test_err '`--scope` and `--repo` require `--service`' \
   cache add bogus.jsonl --scope='bogus'
 test_err '`--scope` and `--repo` require `--service`' \
   cache add bogus.jsonl --repo='leanprover/bogus'
+test_err 'unknown package `bogus`' cache add bogus.jsonl --package='bogus'
+# The package is selected with `--package`, not a positional argument
+test_err 'unexpected arguments: bogus' cache add bogus.jsonl bogus
 
 # Verify a revision that cannot be resolved or has no outputs is reported
 test_err 'revision not found' cache get --repo='leanprover/bogus' --rev='bogus'
@@ -385,6 +395,14 @@ test_exp -d "$CACHE_DIR/outputs/dep"
 test_exp ! -e "$CACHE_DIR/outputs/test"
 test_artifacts "$NUM_DEP_ARTS"
 test_run -f dep.toml build @dep/Dep --no-build
+
+# Verify `cache add` attaches mappings to the selected package,
+# whose artifacts are then fetched on demand
+test_cmd rm -rf dep/.lake/build .lake/build "$CACHE_DIR"
+test_run -f dep.toml cache add dep-outputs.jsonl --package=dep --scope=dep --service=ok
+test_artifacts 0
+test_out 'downloaded artifact' -f dep.toml -v build @dep/Dep --no-build
+test_artifacts "$NUM_DEP_REPLAY_ARTS"
 test_run update
 
 # Verify a malformed artifact URL lookup is reported

--- a/tests/lake/tests/cacheTransfer/test.sh
+++ b/tests/lake/tests/cacheTransfer/test.sh
@@ -126,9 +126,11 @@ test_err 'the `--platform` and `--toolchain` options do nothing' \
   cache get bogus.jsonl --scope='bogus' --platform='bogus' --wfail
 test_err 'the `--platform` and `--toolchain` options do nothing' \
   cache get bogus.jsonl --scope='bogus' --toolchain='bogus' --wfail
+test_err 'the `--rev` option does nothing' \
+  cache get bogus.jsonl --scope='bogus' --rev='bogus' --wfail
 test_err 'a custom endpoint must be set (not Reservoir)' cache get --scope='bogus'
 test_err 'unknown package `bogus`' cache get --package='bogus'
-test_err 'the `--rev` option is not supported for a Reservoir `cache get`' \
+test_err 'the `--rev` option is not supported for a multi-package Reservoir `cache get`' \
   cache get --rev=bogus
 with_endpoints test_err 'the `--scope` or `--repo` option must be set' cache get
 LAKE_CACHE_ARTIFACT_ENDPOINT=bogus test_err 'both environment variables must be set' cache get
@@ -217,6 +219,9 @@ test_run build Test --no-build
 test_not_out 'downloading' cache get --scope=test --service=ok
 # Verify `--force-download` fetches them regardless
 test_out 'downloading build outputs' cache get --scope=test --service=ok --force-download
+# Verify it does so for a set revision as well
+test_out 'downloading build outputs' \
+  cache get --scope=test --service=ok --rev=HEAD --force-download
 
 # Verify a missing artifact fails the transfer,
 # leaving the artifacts that did transfer in the cache
@@ -375,6 +380,16 @@ test_cmd rm -rf dep/.lake/build .lake/build "$CACHE_DIR"
 test_not_out 'skipping non-Reservoir dependency' -f dep.toml cache get --package=dep
 match_text "POST /ok/api/v1/packages/leanprover/dep/artifacts" "$SERVER_LOG"
 test_exp -d "$CACHE_DIR/revisions/dep"
+test_artifacts "$NUM_DEP_ARTS"
+test_run -f dep.toml build @dep/Dep --no-build
+
+# Verify `--rev` looks up only that revision for the selected package,
+# rather than backtracking from its head revision
+test_cmd rm -rf dep/.lake/build .lake/build "$CACHE_DIR"
+test_err 'outputs not found for revision' \
+  -f dep.toml cache get --package=dep --rev=HEAD~1
+test_artifacts 0
+test_run -f dep.toml cache get --package=dep --rev=HEAD
 test_artifacts "$NUM_DEP_ARTS"
 test_run -f dep.toml build @dep/Dep --no-build
 


### PR DESCRIPTION
This PR adds the `--package` option for `lake cache get`, which fetches outputs for a specific package in the workspace (not just the root). This is particularly useful for downloading dependency outputs from a custom service. In addition, the undocumented `--rev` support has been removed from `put` and documented for `put-staged`. 

The use of `--rev` for `put` can be a footgun because Lake uses the toolchain and platform information of the currently loaded package in `put`. For `put-staged`, however, where these elements must be provided, it makes perfect sense (and is already in use in downstream).

The PR also removes an unused, undocumented second positional argument for `lake cache add` to specify the package, changing this to the new `--package` and documenting that.
