### PR TITLE
fix: lake: retry transient artifact transfer failures

### DIFF
--- a/src/lake/Lake/Config/Cache.lean
+++ b/src/lake/Lake/Config/Cache.lean
@@ -18,6 +18,8 @@ import Lake.Util.Proc
 import Lake.Util.Reservoir
 import Lake.Util.JsonObject
 import Lake.Util.IO
+import Std.Data.HashSet.Basic
+import Init.Data.Range.Polymorphic.Iterators
 import Init.System.Platform
 import Init.Data.String.Lemmas
 
@@ -741,13 +743,45 @@ structure TransferConfig where
   scope : CacheServiceScope
   infos : Array TransferInfo
   key : String := ""
+  /-- Whether this is the batch's last attempt, after which failures are not retried. -/
+  finalAttempt : Bool := true
 
 structure TransferState where
   didError : Bool := false
   numSuccesses : Nat := 0
+  /--
+  Transfers with a settled outcome: a success or a failure that a retry cannot
+  fix. A batch retries its unsettled transfers on its next attempt.
+  -/
+  settled : Std.HashSet Nat := {}
 
 @[inline] def tmpPath (path : FilePath) : FilePath :=
   path.addExtension "tmp"
+
+/--
+The default number of times a batch transfer is attempted: one initial attempt
+plus retries of the transfers that failed in ways a retry may fix (e.g., a
+dropped connection or a corrupted download). The `LAKE_CACHE_TRANSFER_ATTEMPTS`
+environment variable overrides this (minimum 1).
+-/
+def defaultTransferAttempts : Nat := 3
+
+def getTransferAttempts : BaseIO Nat := do
+  if let some v ← IO.getEnv "LAKE_CACHE_TRANSFER_ATTEMPTS" then
+    if let some n := v.toNat? then
+      return max 1 n
+  return defaultTransferAttempts
+
+/--
+Whether a transfer that failed with this HTTP status may succeed if retried.
+Covers the response codes `curl --retry` deems transient (408, 429, 500, 502,
+503, 504) plus a missing status, which indicates a dropped connection rather
+than a server rejection.
+-/
+def retryableStatus : Except String Nat → Bool
+  | .ok 408 | .ok 429 | .ok 500 | .ok 502 | .ok 503 | .ok 504 => true
+  | .ok _ => false
+  | .error _ => true
 
 partial def monitorTransfer
   (cfg : TransferConfig) (h hOut : IO.FS.Handle) (s : TransferState)
@@ -759,33 +793,52 @@ partial def monitorTransfer
     let s ← (·.2) <$> StateT.run (s := s) do
       match Json.parse line >>= fromJson? with
       | .ok (out : JsonObject) =>
-        let some info := getInfo? out
-          | logError s!"{cfg.scope}: unidentifiable transfer completed: {line.trimAscii}"
-            modify ({· with didError := true})
+        let some (i, info) := getInfo? out
+          | -- Tied to no transfer; an unreported transfer is unsettled,
+            -- so the batch's next attempt retries it
+            logWarning s!"{cfg.scope}: unidentifiable transfer completed: {line.trimAscii}"
             return
+        if (← get).settled.contains i then
+          logWarning s!"{cfg.scope}: duplicate report for a transfer: {line.trimAscii}"
+          return
         match out.get? "exitcode" with
         | .ok none
         | .ok (some 0) =>
           match out.get "http_code" with
           | .ok code@200
           | .ok code@201 =>
-            handleTransfer info code out line
+            handleTransfer i info code out line
           | code? =>
-            handleFailure info code? out line
-            modify ({· with didError := true})
+            handleFailure i info (retryableStatus code?) code? out line
         | _ =>
-          handleFailure info (out.get "http_code") out line
-          modify ({· with didError := true})
+          -- A nonzero exit code alongside a 2xx status means an incomplete
+          -- transfer (e.g., a connection dropped mid-body), which is retryable
+          handleFailure i info true (out.get "http_code") out line
       | .error e =>
-        logError s!"curl produced invalid JSON: {e}; received: {line.trimAscii}"
-        modify ({· with didError := true})
+        logWarning s!"curl produced invalid JSON: {e}; received: {line.trimAscii}"
     monitorTransfer cfg h hOut s
 where
   getInfo? out :=
     match out.getAs Nat "urlnum" with
-    | .ok i => cfg.infos[i]?
+    | .ok i => cfg.infos[i]?.map ((i, ·))
     | _ => none
-  handleTransfer info code out line : StateT TransferState LoggerIO Unit := do
+  /-- Marks a transfer's outcome as settled and successful. -/
+  recordSuccess (i : Nat) : StateT TransferState LoggerIO Unit :=
+    modify fun s => {s with
+      settled := s.settled.insert i, numSuccesses := s.numSuccesses + 1}
+  /--
+  Records a failed transfer. A retryable failure on a non-final attempt is
+  left unsettled, so the batch's next attempt retries it; its detail goes to
+  the verbose log, and the batch logs one warning per retry attempt. Any
+  other failure is an error and settles its transfer.
+  -/
+  recordFailure (i : Nat) (retryable : Bool) (msg : String) : StateT TransferState LoggerIO Unit := do
+    if retryable && !cfg.finalAttempt then
+      logVerbose msg
+    else
+      logError msg
+      modify fun s => {s with settled := s.settled.insert i, didError := true}
+  handleTransfer i info code out line : StateT TransferState LoggerIO Unit := do
     let {url, hash, path, extraPaths} := info
     match cfg.kind with
     | .get =>
@@ -799,11 +852,9 @@ where
         logDownload
         let actualHash := Hash.ofByteArray contents
         if actualHash != hash then
-          logError s!"{tmpPath}: downloaded artifact hash mismatch, got {actualHash}"
-          modify ({· with didError := true})
+          recordFailure i true s!"{tmpPath}: downloaded artifact hash mismatch, got {actualHash}"
         else if let .error e ← IO.FS.rename tmpPath path |>.toBaseIO then
-          logError s!"{path}: failed to persist temporary artifact: {e}"
-          modify ({· with didError := true})
+          recordFailure i true s!"{path}: failed to persist temporary artifact: {e}"
         else
           unless extraPaths.isEmpty do
             -- Note: No intra-cache hard links (breaks permissions/pruning), so we copy
@@ -811,20 +862,18 @@ where
               if let .error e ← IO.FS.writeBinFile extraPath contents |>.toBaseIO then
                 logError s!"{extraPath}: failed to copy artifact: {e}"
                 modify ({· with didError := true})
-          modify fun s => {s with numSuccesses := s.numSuccesses + 1}
+          recordSuccess i
       | .error (.noFileOrDirectory ..) =>
-        handleFailure info (.ok code) out line
-        modify ({· with didError := true})
+        handleFailure i info true (.ok code) out line
       | .error e =>
         logDownload
-        logError s!"{tmpPath}: failed to read downloaded artifact: {e}"
-        modify ({· with didError := true})
+        recordFailure i true s!"{tmpPath}: failed to read downloaded artifact: {e}"
     | .put =>
       logInfo s!"{cfg.scope}: uploaded artifact {hash}\
         \n  local path: {path}\
         \n  remote URL: {url}"
-      modify fun s => {s with numSuccesses := s.numSuccesses + 1}
-  handleFailure info code? out line : LoggerIO Unit := do
+      recordSuccess i
+  handleFailure i info retryable code? out line : StateT TransferState LoggerIO Unit := do
     let action := match cfg.kind with | .get => "download" | .put => "upload"
     let mut msg := s!"{cfg.scope}: failed to {action} artifact {info.hash}"
     if let .ok code := code? then
@@ -849,12 +898,13 @@ where
         if size > 0 then
           if let some resp := String.fromUTF8? (← hOut.read size.toUSize) then
             msg := s!"{msg}\nunexpected response:\n{resp}"
-    logError msg
+    recordFailure i retryable msg
     logVerbose s!"curl JSON: {line.trimAsciiEnd}"
 
-def transferArtifacts
+/-- Performs one attempt of a batch transfer: spawns `curl` and monitors its transfers. -/
+def runTransferAttempt
   (cfg : TransferConfig)
-: LoggerIO Unit := IO.FS.withTempFile fun h path => do
+: LoggerIO TransferState := IO.FS.withTempFile fun h path => do
   let args ← id do
     match cfg.kind with
     | .get =>
@@ -888,15 +938,34 @@ def transferArtifacts
   let s ← monitorTransfer cfg child.stderr child.stdout {}
   let rc ← child.wait
   let stdout ← child.stdout.readToEnd
-  let mut didError := s.didError
-  if s.numSuccesses < cfg.infos.size then
-    let action := match cfg.kind with | .get => "download" | .put => "upload"
-    logError s!"{cfg.scope}: failed to {action} some artifacts"
-    didError := true
   unless stdout.isEmpty do
     logWarning s!"{cfg.scope}: curl produced unexpected output:\n{stdout.trimAsciiEnd}"
   if rc != 0 then
-    logError s!"{cfg.scope}: curl exited with code {rc}"
+    -- Failures are settled per transfer; curl's own exit code is redundant
+    let msg := s!"{cfg.scope}: curl exited with code {rc}"
+    if cfg.finalAttempt then logWarning msg else logVerbose msg
+  return s
+
+def transferArtifacts (cfg : TransferConfig) : LoggerIO Unit := do
+  let attempts ← getTransferAttempts
+  let action := match cfg.kind with | .get => "download" | .put => "upload"
+  let mut didError := false
+  let mut numSuccesses := 0
+  let mut infos := cfg.infos
+  for attempt in [1:attempts+1] do
+    let finalAttempt := attempt == attempts
+    let s ← runTransferAttempt {cfg with infos, finalAttempt}
+    didError := didError || s.didError
+    numSuccesses := numSuccesses + s.numSuccesses
+    let retry := infos.zipIdx.filterMap fun (info, i) =>
+      if s.settled.contains i then none else some info
+    if retry.isEmpty then
+      break
+    infos := retry
+    unless finalAttempt do
+      logWarning s!"{cfg.scope}: retrying {retry.size} failed {action}(s) (attempt {attempt+1} of {attempts})"
+  if numSuccesses < cfg.infos.size then
+    logError s!"{cfg.scope}: failed to {action} some artifacts"
     didError := true
   if didError then
     failure

--- a/tests/lake/tests/cacheTransfer/server.py
+++ b/tests/lake/tests/cacheTransfer/server.py
@@ -16,6 +16,11 @@ a test picks one by pointing an endpoint at it (e.g. `.../corrupt/a0`):
   reset     disconnect without a response (curl writes no output file)
   empty     200 and a `Content-Length` but no body, for an object that is not
             in the store, so that curl leaves no output file to read
+  flaky     drop the first request for each object (as `reset`), then serve
+            and store normally, so that a retry succeeds
+  flakycorrupt
+            corrupt the first response for each object (as `corrupt`), then
+            serve normally, so that a retry succeeds
   badcount  Reservoir artifact URL lookup returns too few URLs
   apierror  Reservoir requests return an API error object
 
@@ -33,6 +38,7 @@ import argparse
 import json
 import os
 import sys
+import threading
 from enum import StrEnum
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import parse_qs, unquote, urlparse
@@ -47,6 +53,11 @@ DENY_BODY = (
 
 STORE = "."
 
+# Paths the per-path stateful fault modes (`flaky*`) have already seen.
+# Guarded by a lock: the threading server handles requests concurrently.
+SEEN_PATHS = set()
+SEEN_LOCK = threading.Lock()
+
 
 class Mode(StrEnum):
     """A fault mode, named by the first segment of a request path."""
@@ -57,6 +68,8 @@ class Mode(StrEnum):
     TRUNCATE = "truncate"
     RESET = "reset"
     EMPTY = "empty"
+    FLAKY = "flaky"
+    FLAKY_CORRUPT = "flakycorrupt"
     BAD_COUNT = "badcount"
     API_ERROR = "apierror"
 
@@ -123,6 +136,13 @@ class Handler(BaseHTTPRequestHandler):
         self.close_connection = True
         self.log("reset")
 
+    def first_request(self):
+        """Whether this is the first request for this path (fault mode included)."""
+        with SEEN_LOCK:
+            first = self.path not in SEEN_PATHS
+            SEEN_PATHS.add(self.path)
+            return first
+
     def serve(self, mode, path, ctype=None):
         try:
             with open(path, "rb") as f:
@@ -141,7 +161,7 @@ class Handler(BaseHTTPRequestHandler):
                 self.not_found("no such object: %s" % self.path)
             return
         ctype = ctype or content_type(path)
-        if mode == Mode.CORRUPT:
+        if mode == Mode.CORRUPT or (mode == Mode.FLAKY_CORRUPT and self.first_request()):
             data = data[:-1] + bytes([data[-1] ^ 0xFF]) if data else b"corrupt"
             self.respond(200, data, ctype)
         elif mode == Mode.TRUNCATE:
@@ -203,7 +223,7 @@ class Handler(BaseHTTPRequestHandler):
         mode, parts, query = self.parse()
         if mode is None:
             self.not_found("no fault mode in path: %s" % self.path)
-        elif mode == Mode.RESET:
+        elif mode == Mode.RESET or (mode == Mode.FLAKY and self.first_request()):
             self.reset()
         elif mode == Mode.DENY:
             self.deny()
@@ -232,7 +252,7 @@ class Handler(BaseHTTPRequestHandler):
         body = self.rfile.read(length)
         if mode is None:
             self.not_found("no fault mode in path: %s" % self.path)
-        elif mode == Mode.RESET:
+        elif mode == Mode.RESET or (mode == Mode.FLAKY and self.first_request()):
             self.reset()
         elif mode == Mode.DENY:
             self.deny()

--- a/tests/lake/tests/cacheTransfer/services.toml
+++ b/tests/lake/tests/cacheTransfer/services.toml
@@ -53,6 +53,18 @@ artifactEndpoint = "%URL%/empty/a0"
 revisionEndpoint = "%URL%/ok/r0"
 
 [[cache.service]]
+name = "flaky"
+type = "s3"
+artifactEndpoint = "%URL%/flaky/a0"
+revisionEndpoint = "%URL%/ok/r0"
+
+[[cache.service]]
+name = "flakyCorrupt"
+type = "s3"
+artifactEndpoint = "%URL%/flakycorrupt/a0"
+revisionEndpoint = "%URL%/ok/r0"
+
+[[cache.service]]
 name = "badCount"
 type = "reservoir"
 apiEndpoint = "%URL%/badcount/api/v1"

--- a/tests/lake/tests/cacheTransfer/test.sh
+++ b/tests/lake/tests/cacheTransfer/test.sh
@@ -204,9 +204,12 @@ test_out 'downloading build outputs' cache get --scope=test --service=ok --force
 test_cmd rm -rf .lake/build "$CACHE_DIR"
 MISSING="$(ls -1 "$STORE_DIR/a0/test" | head -1)"
 test_cmd mv "$STORE_DIR/a0/test/$MISSING" "$WORK_DIR/$MISSING"
+: > "$SERVER_LOG"
 test_err 'failed to download some artifacts' cache get --scope=test --service=ok
 match_text 'status code: 404' produced.out
 test_artifacts $((NUM_ARTS - 1))
+# A 404 is a settled failure: the request is not retried
+test_cmd_eq 1 grep -c "GET /ok/a0/test/$MISSING" "$SERVER_LOG"
 # Verify the failure did not poison the cache
 test_cmd mv "$WORK_DIR/$MISSING" "$STORE_DIR/a0/test/$MISSING"
 test_run cache get --scope=test --service=ok
@@ -229,8 +232,12 @@ test_artifacts 1
 
 # Verify a corrupted download is not adopted as an artifact
 test_cmd rm -rf .lake/build "$CACHE_DIR"
+: > "$SERVER_LOG"
 test_err 'hash mismatch' cache get --scope=test --service=corrupt
 test_artifacts 0
+# A download that is corrupted on every attempt is abandoned at the attempt limit
+CORRUPT_ART="$(ls -1 "$STORE_DIR/a0/test" | head -1)"
+test_cmd_eq 3 grep -c "GET /corrupt/a0/test/$CORRUPT_ART" "$SERVER_LOG"
 test_run cache get --scope=test --service=ok
 test_artifacts "$NUM_ARTS"
 test_run build Test --no-build
@@ -249,6 +256,77 @@ test_cmd rm -rf .lake/build "$CACHE_DIR"
 test_err 'failed to download artifact' cache get --scope=test --service=reset
 test_artifacts 0
 test_run cache get --scope=test --service=ok
+test_run build Test --no-build
+
+# Verify a batch retries transfers interrupted by a transient failure:
+# the first request for each artifact is dropped without a response,
+# which `curl --retry` does not retry on its own
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+: > "$SERVER_LOG"
+test_out 'retrying' cache get --scope=test --service=flaky
+test_artifacts "$NUM_ARTS"
+test_run build Test --no-build
+# Each artifact was requested twice: the dropped attempt and its retry
+FLAKY_ART="$(ls -1 "$STORE_DIR/a0/test" | head -1)"
+test_cmd_eq 2 grep -c "GET /flaky/a0/test/$FLAKY_ART" "$SERVER_LOG"
+
+# Verify a download that arrives corrupted once is retried
+# (a hash mismatch that `curl` itself cannot detect).
+# The detail of the recovered failure goes to the verbose log only.
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+test_out 'retrying' cache get --scope=test --service=flakyCorrupt
+no_match_text 'hash mismatch' produced.out
+test_artifacts "$NUM_ARTS"
+test_run build Test --no-build
+
+# Verify failed uploads are retried as well
+: > "$SERVER_LOG"
+test_out 'retrying' cache put outputs.jsonl --scope=flakyput --service=flaky
+test_artifacts "$NUM_ARTS" "$STORE_DIR/a0/flakyput"
+FLAKY_ART="$(ls -1 "$STORE_DIR/a0/flakyput" | head -1)"
+test_cmd_eq 2 grep -c "PUT /flaky/a0/flakyput/$FLAKY_ART" "$SERVER_LOG"
+
+# Verify a retry of part of a batch: with one artifact's fault consumed up
+# front, only the other arrives corrupted, and the retry re-requests just it
+# (under an index remapped from the full batch)
+test_run cache put outputs.jsonl --scope=test3
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+FLAKY_ART="$(ls -1 "$STORE_DIR/a0/test3" | head -1)"
+test_cmd curl -s -o /dev/null "$URL/flakycorrupt/a0/test3/$FLAKY_ART"
+test_out 'retrying 1 failed download' cache get --scope=test3 --service=flakyCorrupt
+test_artifacts "$NUM_ARTS"
+test_run build Test --no-build
+
+# Verify a batch that has a permanent failure and a transient failure:
+# the batch retries only the corrupted transfer, and the 404 fails the batch
+test_run cache put outputs.jsonl --scope=test4
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+MISSING="$(ls -1 "$STORE_DIR/a0/test4" | head -1)"
+test_cmd mv "$STORE_DIR/a0/test4/$MISSING" "$WORK_DIR/$MISSING"
+GOOD="$(ls -1 "$STORE_DIR/a0/test4" | head -1)"
+: > "$SERVER_LOG"
+test_err 'failed to download some artifacts' cache get --scope=test4 --service=flakyCorrupt
+match_text 'status code: 404' produced.out
+match_text 'retrying 1 failed download' produced.out
+test_artifacts 1
+# Lake requests the missing artifact once and does not retry it
+test_cmd_eq 1 grep -c "GET /flakycorrupt/a0/test4/$MISSING" "$SERVER_LOG"
+# Lake requests the corrupted artifact twice: once for each attempt
+test_cmd_eq 2 grep -c "GET /flakycorrupt/a0/test4/$GOOD" "$SERVER_LOG"
+# Restore the artifact and verify a full recovery
+test_cmd mv "$WORK_DIR/$MISSING" "$STORE_DIR/a0/test4/$MISSING"
+test_run cache get --scope=test4 --service=ok
+test_artifacts "$NUM_ARTS"
+test_run build Test --no-build
+
+# Verify `LAKE_CACHE_TRANSFER_ATTEMPTS` bounds a batch's attempts
+test_run cache put outputs.jsonl --scope=test2
+test_cmd rm -rf .lake/build "$CACHE_DIR"
+LAKE_CACHE_TRANSFER_ATTEMPTS=1 test_err 'failed to download some artifacts' \
+  cache get --scope=test2 --service=flaky
+# The failed attempt consumed each path's one fault, so a rerun succeeds
+test_run cache get --scope=test2 --service=flaky
+test_artifacts "$NUM_ARTS"
 test_run build Test --no-build
 
 # Verify the transfers that `curl` itself misreports,


### PR DESCRIPTION
This PR makes `lake cache get` and `lake cache put` retry the transfers in a batch that fail in a transient way, instead of failing the whole batch after one attempt. Lake attempts a batch up to 3 times; the `LAKE_CACHE_TRANSFER_ATTEMPTS` environment variable overrides this limit. A retry covers a connection that drops mid-transfer, a download whose bytes do not match the expected content hash, and the transient HTTP status codes (408, 429, 500, 502, 503, 504). A failure that a retry cannot fix, such as a 404, still fails the batch immediately.

One dropped connection could previously fail a batch of thousands of transfers. A mathlib CI run showed this: 2 of 8309 downloads hit a dropped HTTP/2 stream, and the whole `lake cache get` failed ([log](https://github.com/leanprover-community/mathlib4/actions/runs/31243452527/job/93071954037)). `curl --retry` does not cover these failures on its own: it retries only timeouts and a fixed set of response codes. It does not retry a connection that drops mid-body. It also cannot detect a corrupted body: without a `Content-Length`, a stream that ends early looks like a complete transfer, and only Lake's hash check catches it.

The console output stays quiet: each retry attempt logs one warning line, and the detail of a failure that will be retried goes to the verbose log. The final attempt logs the same errors as before. For the tests, the mock cache server gains two stateful fault modes: `flaky` drops the first request for each object, and `flakycorrupt` corrupts the first response for each object. New tests cover download and upload retries, the attempt limit, a retry of only part of a batch, a batch that has both a permanent and a transient failure, and that a 404 is not retried.

Closes #14739

🤖 Generated with [Claude Code](https://claude.com/claude-code)
