### PR TITLE
fix: getUsedConstants should record projection type names

### DIFF
--- a/src/Lean/Util/FoldConsts.lean
+++ b/src/Lean/Util/FoldConsts.lean
@@ -22,6 +22,12 @@ unsafe structure State where
 unsafe abbrev FoldM := StateM State
 
 unsafe def fold {α : Type} (f : Name → α → α) (e : Expr) (acc : α) : FoldM α :=
+  let visitConst (c : Name) (acc : α) := do
+    if (← get).visitedConsts.contains c then
+      return acc
+    else
+      modify fun s => { s with visitedConsts := s.visitedConsts.insert c };
+      return f c acc
   let rec visit (e : Expr) (acc : α) : FoldM α := do
     if (← get).visited.contains e then
       return acc
@@ -32,13 +38,8 @@ unsafe def fold {α : Type} (f : Name → α → α) (e : Expr) (acc : α) : Fol
     | .mdata _ b         => visit b acc
     | .letE _ t v b _    => visit b (← visit v (← visit t acc))
     | .app f a           => visit a (← visit f acc)
-    | .proj _ _ b        => visit b acc
-    | .const c _         =>
-      if (← get).visitedConsts.contains c then
-        return acc
-      else
-        modify fun s => { s with visitedConsts := s.visitedConsts.insert c };
-        return f c acc
+    | .proj typeName _ b => visit b (← visitConst typeName acc)
+    | .const c _         => visitConst c acc
     | _ => return acc
   visit e acc
 

--- a/tests/elab/hidden_proj.lean
+++ b/tests/elab/hidden_proj.lean
@@ -1,0 +1,8 @@
+module
+import Lean.Util.FoldConsts
+
+open Lean Meta
+
+/-- info: #[`S, `S.mk] -/
+#guard_msgs in
+#eval Expr.getUsedConstants (.proj `S 0 (mkConst `S.mk))


### PR DESCRIPTION
This PR makes `Expr.getUsedConstants` collect the `typeName` field of `Expr.proj` so we get a full list of constants that are directly used.