### PR TITLE
chore: `IteratorLoop` instance for tree maps

### DIFF
--- a/src/Std/Data/DTreeMap/Internal/Zipper.lean
+++ b/src/Std/Data/DTreeMap/Internal/Zipper.lean
@@ -367,6 +367,10 @@ def Zipper.FinitenessRelation : FinitenessRelation (Zipper α β) Id where
 public instance Zipper.instFinite : Finite (Zipper α β) Id :=
   .of_finitenessRelation Zipper.FinitenessRelation
 
+public instance Zipper.instIteratorLoop {m : Type (max u v) → Type w} [Monad m] :
+    IteratorLoop (Zipper α β) Id m :=
+  .defaultImplementation
+
 public def Zipper.iter (t : Zipper α β) : Iter (α := Zipper α β) ((a : α) × β a) := ⟨t⟩
 
 public def Zipper.iterOfTree (t : Impl α β) : Iter (α := Zipper α β) ((a : α) × β a) :=
@@ -478,6 +482,11 @@ def RxcIterator.FinitenessRelation [Ord α] : FinitenessRelation (RxcIterator α
 
 public instance instFinite [Ord α] : Finite (RxcIterator α β) Id :=
   .of_finitenessRelation RxcIterator.FinitenessRelation
+
+public instance RxcIterator.instIteratorLoop [Ord α]
+    {m : Type (max u v) → Type w} [Monad m] :
+    IteratorLoop (RxcIterator α β) Id m :=
+  .defaultImplementation
 
 @[simp]
 theorem RxcIterator.step_done [Ord α] {upper : α} : ({ iter := .done, upper := upper } : RxcIterator α β).step = .done := rfl
@@ -606,6 +615,11 @@ def RxoIterator.instFinitenessRelation [Ord α] : FinitenessRelation (RxoIterato
 
 public instance Rxo.instFinite [Ord α] : Finite (RxoIterator α β) Id :=
   .of_finitenessRelation RxoIterator.instFinitenessRelation
+
+public instance RxoIterator.instIteratorLoop [Ord α]
+    {m : Type (max u v) → Type w} [Monad m] :
+    IteratorLoop (RxoIterator α β) Id m :=
+  .defaultImplementation
 
 @[simp]
 theorem RxoIterator.step_done [Ord α] {upper : α} : ({ iter := .done, upper := upper } : RxoIterator α β).step = .done := rfl

--- a/tests/elab/hashMapIteratorLoop.lean
+++ b/tests/elab/hashMapIteratorLoop.lean
@@ -1,0 +1,77 @@
+module
+
+import Std.Data.HashMap.Iterator
+
+/-!
+Tests that all hash map iterators can be consumed by `for` loops.
+-/
+
+open Std
+
+private def dHashMapRaw : DHashMap.Raw Nat (fun _ => Nat) :=
+  .ofList [⟨1, 2⟩, ⟨2, 4⟩, ⟨3, 6⟩]
+
+/-- info: (12, 6, 12) -/
+#guard_msgs in
+#eval Id.run do
+  let mut entrySum := 0
+  for entry in dHashMapRaw.iter do
+    entrySum := entrySum + entry.2
+  let mut keySum := 0
+  for key in dHashMapRaw.keysIter do
+    keySum := keySum + key
+  let mut valueSum := 0
+  for value in dHashMapRaw.valuesIter do
+    valueSum := valueSum + value
+  return (entrySum, keySum, valueSum)
+
+private def dHashMap : DHashMap Nat (fun _ => Nat) :=
+  .ofList [⟨1, 2⟩, ⟨2, 4⟩, ⟨3, 6⟩]
+
+/-- info: (12, 6, 12) -/
+#guard_msgs in
+#eval Id.run do
+  let mut entrySum := 0
+  for entry in dHashMap.iter do
+    entrySum := entrySum + entry.2
+  let mut keySum := 0
+  for key in dHashMap.keysIter do
+    keySum := keySum + key
+  let mut valueSum := 0
+  for value in dHashMap.valuesIter do
+    valueSum := valueSum + value
+  return (entrySum, keySum, valueSum)
+
+private def hashMapRaw : HashMap.Raw Nat Nat :=
+  .ofList [(1, 2), (2, 4), (3, 6)]
+
+/-- info: (12, 6, 12) -/
+#guard_msgs in
+#eval Id.run do
+  let mut entrySum := 0
+  for (_, value) in hashMapRaw.iter do
+    entrySum := entrySum + value
+  let mut keySum := 0
+  for key in hashMapRaw.keysIter do
+    keySum := keySum + key
+  let mut valueSum := 0
+  for value in hashMapRaw.valuesIter do
+    valueSum := valueSum + value
+  return (entrySum, keySum, valueSum)
+
+private def hashMap : HashMap Nat Nat :=
+  .ofList [(1, 2), (2, 4), (3, 6)]
+
+/-- info: (12, 6, 12) -/
+#guard_msgs in
+#eval Id.run do
+  let mut entrySum := 0
+  for (_, value) in hashMap.iter do
+    entrySum := entrySum + value
+  let mut keySum := 0
+  for key in hashMap.keysIter do
+    keySum := keySum + key
+  let mut valueSum := 0
+  for value in hashMap.valuesIter do
+    valueSum := valueSum + value
+  return (entrySum, keySum, valueSum)

--- a/tests/elab/treeMapIteratorLoop.lean
+++ b/tests/elab/treeMapIteratorLoop.lean
@@ -1,0 +1,116 @@
+module
+
+import Std.Data.DTreeMap.Iterator
+import Std.Data.TreeMap.Raw.Iterator
+import Std.Data.TreeMap.Slice
+import Std.Data.TreeSet.Raw.Iterator
+import Std.Data.TreeSet.Raw.Slice
+
+/-!
+Tests that all tree map iterator implementations support loop-based consumers.
+-/
+
+open Std Std.Iterators
+
+example {α : Type u} {β : α → Type v} {m : Type (max u v) → Type w} [Monad m] :
+    IteratorLoop (DTreeMap.Internal.Zipper α β) Id m :=
+  inferInstance
+
+example {α : Type u} {β : α → Type v} {m : Type (max u v) → Type w} [Monad m] :
+    LawfulIteratorLoop (DTreeMap.Internal.Zipper α β) Id m :=
+  inferInstance
+
+example {α : Type u} {β : α → Type v} [Ord α]
+    {m : Type (max u v) → Type w} [Monad m] :
+    IteratorLoop (DTreeMap.Internal.RxcIterator α β) Id m :=
+  inferInstance
+
+example {α : Type u} {β : α → Type v} [Ord α]
+    {m : Type (max u v) → Type w} [Monad m] :
+    LawfulIteratorLoop (DTreeMap.Internal.RxcIterator α β) Id m :=
+  inferInstance
+
+example {α : Type u} {β : α → Type v} [Ord α]
+    {m : Type (max u v) → Type w} [Monad m] :
+    IteratorLoop (DTreeMap.Internal.RxoIterator α β) Id m :=
+  inferInstance
+
+example {α : Type u} {β : α → Type v} [Ord α]
+    {m : Type (max u v) → Type w} [Monad m] :
+    LawfulIteratorLoop (DTreeMap.Internal.RxoIterator α β) Id m :=
+  inferInstance
+
+private def dTreeMap : DTreeMap Nat (fun _ => Nat) :=
+  .ofList [⟨1, 2⟩, ⟨2, 4⟩, ⟨3, 6⟩]
+
+/-- info: 12 -/
+#guard_msgs in
+#eval Id.run do
+  let mut sum := 0
+  for entry in dTreeMap.iter do
+    sum := sum + entry.2
+  return sum
+
+private def dTreeMapRaw : DTreeMap.Raw Nat (fun _ => Nat) :=
+  .ofList [⟨1, 2⟩, ⟨2, 4⟩, ⟨3, 6⟩]
+
+/-- info: (12, 6, 12) -/
+#guard_msgs in
+#eval Id.run do
+  let mut entrySum := 0
+  for entry in dTreeMapRaw.iter do
+    entrySum := entrySum + entry.2
+  let mut keySum := 0
+  for key in dTreeMapRaw.keysIter do
+    keySum := keySum + key
+  let mut valueSum := 0
+  for value in dTreeMapRaw.valuesIter do
+    valueSum := valueSum + value
+  return (entrySum, keySum, valueSum)
+
+private def treeMap : TreeMap Nat Nat :=
+  .ofList [(1, 2), (2, 4), (3, 6)]
+
+/-- info: 6 -/
+#guard_msgs in
+#eval Id.run do
+  let mut sum := 0
+  for (_, value) in treeMap[*...=2].iter do
+    sum := sum + value
+  return sum
+
+private def treeMapRaw : TreeMap.Raw Nat Nat :=
+  .ofList [(1, 2), (2, 4), (3, 6)]
+
+/-- info: (12, 6, 12) -/
+#guard_msgs in
+#eval Id.run do
+  let mut entrySum := 0
+  for (_, value) in treeMapRaw.iter do
+    entrySum := entrySum + value
+  let mut keySum := 0
+  for key in treeMapRaw.keysIter do
+    keySum := keySum + key
+  let mut valueSum := 0
+  for value in treeMapRaw.valuesIter do
+    valueSum := valueSum + value
+  return (entrySum, keySum, valueSum)
+
+private def treeSet : TreeSet.Raw Nat :=
+  .ofList [1, 2, 3]
+
+/-- info: 6 -/
+#guard_msgs in
+#eval Id.run do
+  let mut sum := 0
+  for value in treeSet.iter do
+    sum := sum + value
+  return sum
+
+/-- info: 3 -/
+#guard_msgs in
+#eval Id.run do
+  let mut sum := 0
+  for value in treeSet[*...<3].iter do
+    sum := sum + value
+  return sum


### PR DESCRIPTION
This PR adds an `IteratorLoop` instance for the three iterator types used by tree maps, namely `Zipper`, `RxcIterator` and `RxoIterator`.

In practice, the missing instances were only a problem for dependent maps, in all other cases, the iterator we expose is a `MapIterator`, which always comes with an `IteratorLoop` instance regardless of the underlying iterator.