### PR TITLE
feat: `cbv` on arrays using a tree data structure

### DIFF
--- a/src/Init/Data/Bool.lean
+++ b/src/Init/Data/Bool.lean
@@ -709,6 +709,10 @@ end
 theorem Bool.rec_eq {α : Sort _} (b : Bool) {x y : α} : Bool.rec y x b = if b then x else y := by
   cases b <;> simp
 
+theorem Bool.rec_dep_eq {α : Sort u} (b : Bool) (t : b = true → α) (e : b = false → α) :
+    @Bool.rec (fun a => b = a → α) e t b rfl = if h : b then t h else e (by simpa using h) := by
+  cases b <;> simp
+
 /-! ### Deprecations -/
 
 @[deprecated Bool.eq_false_of_ne_true (since := "2026-07-24")]

--- a/src/Init/Sym.lean
+++ b/src/Init/Sym.lean
@@ -8,3 +8,4 @@ prelude
 public import Init.Sym.Lemmas
 public import Init.Sym.Simp.SimprocDSL
 public import Init.Sym.DSimp.DSimprocDSL
+public import Init.Sym.TreeArray

--- a/src/Init/Sym/TreeArray.lean
+++ b/src/Init/Sym/TreeArray.lean
@@ -1,0 +1,355 @@
+/-
+Copyright (c) 2026 Robin Arnez. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Arnez
+-/
+module
+prelude
+public import Init.Data.Vector.Lemmas
+import Init.Omega
+import Init.Data.Bool
+import Init.ByCases
+import Init.Data.Nat.Mod
+import Init.Data.List.Nat.Modify
+import Init.Data.Array.Bootstrap
+
+@[expose] public section
+
+namespace Lean.Sym
+
+/-- `FullBlock α n` is equivalent to `Vector α (2 ^ n)` -/
+inductive FullBlock (α : Type u) : Nat → Type u where
+  | single (x : α) : FullBlock α (nat_lit 0)
+  | split {n : Nat} (l r : FullBlock α n) : FullBlock α n.succ
+deriving Repr
+
+/-- `PartialBlock α n` is equivalent to `{ xs : Array α // xs.size.size = n }` -/
+inductive PartialBlock (α : Type u) : Nat → Type u where
+  | empty : PartialBlock α (nat_lit 0)
+  | split {n m : Nat} (l : FullBlock α n) (r : PartialBlock α m) (h : m.ble n) :
+    PartialBlock α n.succ
+deriving Repr
+
+@[cbv_opaque, no_expose]
+def FullBlock.toVector {α : Type u} {n : Nat} : FullBlock α n → Vector α (2 ^ n)
+  | .single x => #v[x]
+  | .split l r => (l.toVector ++ r.toVector).cast (by rw [Nat.two_pow_succ])
+
+@[cbv_opaque, no_expose]
+def PartialBlock.toArray {α : Type u} {n : Nat} : PartialBlock α n → Array α
+  | .empty => #[]
+  | .split l r h => l.toVector.toArray ++ r.toArray
+-- use well-founded recursion to make sure the kernel is not going to unfold this meaningfully
+termination_by x => sizeOf x
+
+noncomputable abbrev FullBlock.prependList {α : Type u} {n : Nat} :
+    FullBlock α n → List α → List α :=
+  FullBlock.rec List.cons fun {_n} _l _r lih rih acc => lih (rih acc)
+
+noncomputable abbrev PartialBlock.prependList {α : Type u} {n : Nat} :
+    PartialBlock α n → List α → List α :=
+  PartialBlock.rec (fun l => l) fun {_n _m} l _r _h ih acc => l.prependList (ih acc)
+
+theorem PartialBlock.emptyWithCapacity_eq {α : Type u} {n : Nat} :
+    Array.emptyWithCapacity n = (empty.toArray : Array α) := by simp [toArray]
+
+theorem FullBlock.prependList_eq {α : Type u} {n : Nat} {b : FullBlock α n} {l : List α} :
+    b.prependList l = b.toVector.toArray.toList ++ l := by
+  induction b generalizing l <;> simp_all [prependList, toVector]
+
+theorem PartialBlock.prependList_eq {α : Type u} {n : Nat} {b : PartialBlock α n} {l : List α} :
+    b.prependList l = b.toArray.toList ++ l := by
+  induction b generalizing l <;> simp_all [prependList, toArray, FullBlock.prependList_eq]
+
+theorem PartialBlock.arrayMk_eq {α : Type u} {n : Nat} {l : List α} {b : PartialBlock α n}
+    (h : b.prependList [] = l) : Array.mk l = b.toArray := by
+  simp_all [prependList_eq, ← Array.toList_inj]
+
+theorem PartialBlock.toList_toArray {α : Type u} {n : Nat} {b : PartialBlock α n} :
+    b.toArray.toList = b.prependList [] := by
+  simp_all [prependList_eq]
+
+noncomputable abbrev FullBlock.get {α : Type u} {n : Nat}
+    (x : FullBlock α n) (i : Nat) : α :=
+  x.rec (fun a => a) fun {n} _l _r lih rih =>
+    ((i.shiftRight n).mod (nat_lit 2)).rec lih fun _ _ => rih
+
+noncomputable abbrev FullBlock.modify {α : Type u} {n : Nat}
+    (x : FullBlock α n) (i : Nat) (f : α → α) : FullBlock α n :=
+  x.rec (fun a => .single (f a)) fun {n} l r lih rih =>
+    ((i.shiftRight n).mod (nat_lit 2)).rec (.split lih r) fun _ _ => .split l rih
+
+noncomputable abbrev PartialBlock.get? {α : Type u} {n : Nat}
+    (x : PartialBlock α n) : Nat → Option α :=
+  x.rec (fun _ => none) fun {n _m} l _r _h ih i =>
+    (((nat_lit 1).shiftLeft n).ble i).rec (some (l.get i))
+      (ih (i.sub ((nat_lit 1).shiftLeft n)))
+
+noncomputable abbrev PartialBlock.modify {α : Type u} {n : Nat}
+    (x : PartialBlock α n) (f : α → α) : Nat → PartialBlock α n :=
+  x.rec (fun _ => .empty) fun {n _m} l r h ih i =>
+    (((nat_lit 1).shiftLeft n).ble i).rec (.split (l.modify i f) r h)
+      (.split l (ih (i.sub ((nat_lit 1).shiftLeft n))) h)
+
+inductive PushResult (α : Type u) (n : Nat) where
+  | part (x : PartialBlock α n)
+  | full (x : FullBlock α n)
+
+noncomputable abbrev PartialBlock.push.full {α : Type u} {n m : Nat}
+    (l : FullBlock α n) (h : m.ble n) (b : FullBlock α m) :
+    PushResult α n.succ :=
+  (m.succ.ble n).rec (motive := fun b => m.succ.ble n = b → _)
+    (fun h =>
+      haveI : m = n := by simp_all [← Bool.not_eq_true]; omega
+      .full <| .split l (this.rec b))
+    (fun h => .part <| .split l (.split b .empty (by simp)) h) rfl
+
+noncomputable def PartialBlock.push {α : Type u} {n : Nat}
+    (b : PartialBlock α n) (val : α) : PushResult α n :=
+  b.rec (.full (.single val)) fun {_n _m} l _r h =>
+    PushResult.rec (fun r => .part <| .split l r h) (push.full l h)
+
+def PartialBlock.pushImpl {α : Type u} {n : Nat}
+    (b : PartialBlock α n) (val : α) : PushResult α n :=
+  match b with
+  | .empty => .full (.single val)
+  | @PartialBlock.split _ n m l r h =>
+    match pushImpl r val with
+    | .part x => .part <| .split l x h
+    | .full x =>
+      if h : m.succ.ble n then
+        .part <| .split l (.split x .empty (by simp)) h
+      else
+        haveI : m = n := by simp_all; omega
+        .full <| .split l (this.rec x)
+
+@[csimp]
+theorem PartialBlock.push_eq_pushImpl : @push = @pushImpl := by
+  funext α n b val
+  fun_induction pushImpl with simp_all [push, Bool.rec_dep_eq]
+
+theorem PartialBlock.push_spec {α : Type u} {n : Nat} (b : PartialBlock α n) (v : α) :
+    (match b.push v with | .part x => x.toArray | .full x => x.toVector.toArray) =
+      b.toArray.push v := by
+  rw [PartialBlock.push_eq_pushImpl]
+  induction b with
+  | empty => simp [PartialBlock.pushImpl, PartialBlock.toArray, FullBlock.toVector]
+  | @split n m l r h ih =>
+    simp only [Nat.succ_eq_add_one, PartialBlock.pushImpl]
+    generalize r.pushImpl v = b at ih
+    rcases b with b | b
+    · simp_all [PartialBlock.toArray]
+    · by_cases h : m + 1 ≤ n
+      · simp_all [PartialBlock.toArray]
+      · have : m = n := by simp_all; omega
+        subst this
+        simp_all [PartialBlock.toArray, -Nat.not_le, FullBlock.toVector]
+
+theorem PartialBlock.push_part {α : Type u} {n : Nat} {b b' : PartialBlock α n} {v : α}
+    (h : b.push v = .part b') : b.toArray.push v = b'.toArray := by
+  rw [← push_spec, h]
+
+theorem PartialBlock.push_full {α : Type u} {n : Nat}
+    {b : PartialBlock α n} {b' : FullBlock α n} {v : α}
+    (h : b.push v = .full b') : b.toArray.push v = (split b' empty (by simp)).toArray := by
+  simp [← push_spec, h, PartialBlock.toArray]
+
+noncomputable abbrev FullBlock.pop {α : Type u} {n : Nat} (b : FullBlock α n) : PartialBlock α n :=
+  b.rec (fun _ => .empty) fun {_n} l _r _lih rih => .split l rih (by simp)
+
+inductive PopResult (α : Type u) : Nat → Type u where
+  | empty : PopResult α (nat_lit 0)
+  | done {n : Nat} (x : PartialBlock α n) : PopResult α n
+  | shrink {n : Nat} (x : PartialBlock α n) : PopResult α n.succ
+
+noncomputable def PartialBlock.pop {α : Type u} {n : Nat} (b : PartialBlock α n) : PopResult α n :=
+  b.rec .empty fun {n m} l r h ih =>
+    ih.rec (fun _ => .shrink l.pop) (fun {m} r h => .done (.split l r h))
+      (fun {m} r h => .done (.split l r (by simp_all; omega))) h
+
+theorem FullBlock.toArray_pop {α : Type u} {n : Nat} (b : FullBlock α n) :
+    b.pop.toArray = b.toVector.toArray.pop := by
+  induction b with simp [toVector, PartialBlock.toArray, *]
+
+theorem PartialBlock.pop_spec {α : Type u} {n : Nat} (b : PartialBlock α n) :
+    match b.pop with
+    | .empty => b.toArray = #[]
+    | .done x => x.toArray = b.toArray.pop ∧ b.toArray ≠ #[]
+    | .shrink x => x.toArray = b.toArray.pop ∧ b.toArray ≠ #[] := by
+  induction b with
+  | empty => simp [pop, toArray]
+  | @split n m l r h ih =>
+    simp only [Nat.succ_eq_add_one, pop]
+    have (eq := a_eq) a := r.pop
+    rw [← a_eq] at ih
+    dsimp only [PartialBlock.pop] at a_eq
+    rw [← a_eq]
+    rcases a with _ | a | a <;> simp_all [FullBlock.toArray_pop, toArray]
+
+theorem PartialBlock.pop_toArray_empty {α : Type u} :
+    (toArray empty : Array α).pop = toArray empty := by simp [toArray]
+
+theorem PartialBlock.pop_done {α : Type u} {n : Nat} {b b' : PartialBlock α n}
+    (h : b.pop = .done b') : b.toArray.pop = b'.toArray := by
+  have := pop_spec b
+  simp_all
+
+theorem PartialBlock.pop_shrink {α : Type u} {n : Nat} {b : PartialBlock α n.succ}
+    {b' : PartialBlock α n} (h : b.pop = .shrink b') : b.toArray.pop = b'.toArray := by
+  have := pop_spec b
+  simp_all
+
+theorem Nat.rec_eq {α zero succ n} :
+    (Nat.rec zero succ n : α) =
+      if n = 0 then zero else succ (n - 1) (Nat.rec zero succ (n - 1)) := by
+  cases n <;> rfl
+
+theorem FullBlock.get_eq {α : Type u} {n : Nat} {b : FullBlock α n} (i : Nat) :
+    b.get i = b.toVector[i % 2 ^ n] := by
+  induction b with
+  | single => simp [Nat.mod_one, toVector]
+  | @split n l r lih rih =>
+    change (((i >>> n) % 2).rec (l.get i) (fun _ _ => r.get i) : α) = _
+    simp only [lih, rih, Nat.succ_eq_add_one, toVector, Vector.getElem_cast]
+    simp only [Nat.pow_succ, Nat.mod_mul, Nat.shiftRight_eq_div_pow]
+    rcases Nat.mod_two_eq_zero_or_one (i / 2 ^ n) with h | h <;>
+      simp [h, Nat.two_pow_pos, Nat.mod_lt, Nat.rec_eq]
+
+theorem PartialBlock.getElem?_toArray {α : Type u} {n : Nat} {b : PartialBlock α n} {i : Nat} :
+    b.toArray[i]? = b.get? i := by
+  induction b generalizing i with
+  | empty => simp [toArray]
+  | @split n m l r h ih =>
+    change _ = (((1 <<< n).ble i).rec (some (l.get i)) (r.get? (i - 1 <<< n)) : Option α)
+    simp +contextual [Bool.rec_eq, Nat.shiftLeft_eq, toArray, Array.getElem?_append, ← Nat.not_lt,
+      ih, FullBlock.get_eq, Nat.mod_eq_of_lt, ← dite_eq_ite]
+
+theorem PartialBlock.getElem_toArray_of_eq_some {α : Type u} {n : Nat} {b : PartialBlock α n}
+    {i : Nat} {x : α} (h : b.get? i = some x) (h' : i < b.toArray.size) : b.toArray[i]'h' = x := by
+  rw [← Option.some_inj, ← h, ← getElem?_pos, getElem?_toArray]
+
+theorem PartialBlock.getElem!_toArray_of_eq_some {α : Type u} [Inhabited α] {n : Nat}
+    {b : PartialBlock α n} {i : Nat} {x : α} (h : b.get? i = some x) :
+    b.toArray[i]! = x := by
+  rw [← getElem?_toArray] at h
+  rw [getElem!_def, h]
+
+theorem FullBlock.toArray_modify {α : Type u} {n : Nat} {b : FullBlock α n} {i : Nat} {f : α → α} :
+    (b.modify i f).toVector = b.toVector.set (i % 2 ^ n) (f b.toVector[i % 2 ^ n]) := by
+  induction b with
+  | single => simp [Nat.mod_one, toVector]
+  | @split n l r lih rih =>
+    change (((i >>> n) % 2).rec (.split (l.modify i f) r)
+      (fun _ _ => .split l (r.modify i f)) : FullBlock α n.succ).toVector = _
+    simp only [Nat.succ_eq_add_one, toVector, Vector.getElem_cast, ← Vector.toArray_inj,
+      Vector.toArray_set, Vector.toArray_cast, Vector.toArray_append]
+    simp only [Nat.pow_succ, Nat.shiftRight_eq_div_pow, Nat.mod_mul]
+    rcases Nat.mod_two_eq_zero_or_one (i / 2 ^ n) with h | h <;>
+      simp [h, Nat.two_pow_pos, Nat.mod_lt, Array.set_append_left, toVector, lih, rih]
+
+theorem PartialBlock.modify_toArray {α : Type u} {n : Nat} {b : PartialBlock α n}
+    {i : Nat} {f : α → α} : b.toArray.modify i f = (b.modify f i).toArray := by
+  simp only [← Array.toList_inj, Array.toList_modify]
+  induction b generalizing i with
+  | empty => simp [toArray]
+  | @split n m l r h ih =>
+    change _ = (((1 <<< n).ble i).rec (.split (l.modify i f) r h)
+      (.split l (r.modify f (i - 1 <<< n)) h) : PartialBlock α n.succ).toArray.toList
+    have : Inhabited α := ⟨l.get 0⟩
+    simp +contextual [Bool.rec_eq, Nat.shiftLeft_eq, toArray, List.getElem?_append,
+      List.modify_eq_set, ← dite_eq_ite, ← Nat.not_lt, apply_dite, FullBlock.toArray_modify,
+      ← ih, Nat.mod_eq_of_lt]
+
+theorem PartialBlock.setIfInBounds_toArray {α : Type u} {n : Nat} {b : PartialBlock α n}
+    {i : Nat} {x : α} : b.toArray.setIfInBounds i x = (b.modify (fun _ => x) i).toArray := by
+  ext j h h'
+  · simp [← modify_toArray]
+  · simp only [Array.size_setIfInBounds] at h
+    simp [← modify_toArray, Array.getElem_modify, Array.getElem_setIfInBounds, h]
+
+theorem PartialBlock.set_toArray {α : Type u} {n : Nat} {b : PartialBlock α n}
+    {i : Nat} {x : α} (h : i < b.toArray.size) :
+    b.toArray.set i x h = (b.modify (fun _ => x) i).toArray := by
+  ext <;> simp [← modify_toArray, Array.getElem_modify, Array.getElem_set]
+
+noncomputable def FullBlock.fill {α : Type u} (x : α) : (n : Nat) → FullBlock α n :=
+  Nat.rec (.single x) fun _n ih => .split ih ih
+
+noncomputable def natSize (n : Nat) : Nat :=
+  n.rec .zero fun _ _ => n.log2.succ
+
+theorem natSize_le_iff {a b : Nat} : natSize a ≤ b ↔ a < 2 ^ b := by
+  simp only [natSize, Nat.succ_eq_add_one, Nat.rec_eq]
+  split
+  · simp [Nat.two_pow_pos, *]
+  · simp [← Nat.log2_lt, Nat.add_one_le_iff, *]
+
+inductive ReplicateResult (α : Type u) (n : Nat) where
+  | mk (m : Nat) (h : m ≤ n) (x : PartialBlock α m)
+
+noncomputable def PartialBlock.replicate {α : Type u} (x : α) :
+    (n : Nat) → (m : Nat) → m.shiftRight n = 0 → ReplicateResult α n :=
+  Nat.rec (fun _ _ => .mk .zero .refl .empty) fun n ih m hm =>
+    if h : m.shiftRight n = 0 then
+      ⟨(ih m h).1, (ih m h).2.step, (ih m h).3⟩
+    else
+      haveI := ih (m.sub ((nat_lit 1).shiftLeft n)) ?_
+      .mk n.succ .refl (.split (.fill x n) this.3 (by simpa using this.2))
+where finally
+  simp_all [Nat.shiftRight_eq_div_pow, Nat.shiftLeft_eq, Nat.two_pow_succ, Nat.sub_lt_iff_lt_add]
+
+theorem FullBlock.toVector_fill {α : Type u} (x : α) (n : Nat) :
+    (fill x n).toVector = Vector.replicate (2 ^ n) x := by
+  induction n with simp_all [fill, toVector, ← Vector.toArray_inj, Nat.two_pow_succ]
+
+theorem PartialBlock.replicate_eq {α : Type u} (x : α) (n m : Nat)
+    (h : m.shiftRight n = nat_lit 0) :
+    Array.replicate m x = (PartialBlock.replicate x n m h).3.toArray := by
+  induction n generalizing m with
+  | zero =>
+    have (motive zero succ : _) : @Nat.rec motive zero succ 0 = zero := rfl
+    simp only [replicate]
+    rw [this]
+    simpa [toArray, Nat.rec_eq, this] using h
+  | succ k ih =>
+    simp only [replicate]
+    have (eq := f_eq) f := PartialBlock.replicate x k
+    rw [← f_eq] at ih
+    dsimp only [PartialBlock.replicate] at f_eq
+    rw [← f_eq]
+    by_cases h' : m.shiftRight k = 0
+    · rw [dite_eq_left h']
+      simp [← ih]
+    · rw [dite_eq_right h']
+      simp only [Nat.shiftRight_eq', Nat.shiftRight_eq_div_pow, Nat.div_eq_zero_iff,
+        Nat.pow_eq_zero, reduceCtorEq, ne_eq, false_and, false_or, Nat.not_lt] at h'
+      simp [toArray, FullBlock.toVector_fill, ← ih, Nat.shiftLeft_eq, h']
+
+noncomputable def PartialBlock.size {α : Type u} {n : Nat} : PartialBlock α n → Nat :=
+  PartialBlock.rec (nat_lit 0) fun {n _m} _l _r _h => Nat.add (Nat.shiftLeft (nat_lit 1) n)
+
+theorem PartialBlock.size_toArray {α : Type u} {n : Nat} (x : PartialBlock α n) :
+    x.toArray.size = x.size := by
+  induction x with simp [toArray, size, *, Nat.shiftLeft_eq]
+
+noncomputable abbrev FullBlock.map {α : Type u} {β : Type v} (f : α → β) :
+    {n : Nat} → (x : FullBlock α n) → FullBlock β n :=
+  FullBlock.rec (fun x => .single (f x)) (fun {_n} _l _r => FullBlock.split)
+
+noncomputable def PartialBlock.map {α : Type u} {β : Type v} (f : α → β) :
+    {n : Nat} → (x : PartialBlock α n) → PartialBlock β n :=
+  PartialBlock.rec .empty (fun {_n _m} l _r h ih => PartialBlock.split (l.map f) ih h)
+
+theorem FullBlock.toVector_map {α : Type u} {β : Type v} {n : Nat} (x : FullBlock α n)
+    (f : α → β) : (x.map f).toVector = x.toVector.map f := by
+  induction x with simp [toVector, ← Vector.toArray_inj, *]
+
+theorem PartialBlock.map_toArray {α : Type u} {β : Type v} {n : Nat} (x : PartialBlock α n)
+    (f : α → β) : x.toArray.map f = (x.map f).toArray := by
+  induction x with simp [toArray, map, FullBlock.toVector_map, *]
+
+attribute [cbv_opaque] Array.emptyWithCapacity Array.getInternal Array.get!Internal
+  Array.push Array.pop Array.modify Array.setIfInBounds Array.set Array.replicate Array.size
+  Array.map
+
+end Lean.Sym

--- a/src/Lean/Meta/Tactic/Cbv/BuiltinCbvSimprocs/Array.lean
+++ b/src/Lean/Meta/Tactic/Cbv/BuiltinCbvSimprocs/Array.lean
@@ -133,6 +133,15 @@ builtin_cbv_simproc ↓ simpPartialToArray (PartialBlock.toArray _) := fun e => 
   -- always simplified
   return .rfl (done := true)
 
+builtin_cbv_simproc cbv_eval simpArrayEmptyWithCapacity (Array.emptyWithCapacity _) := fun e => do
+  let_expr c@Array.emptyWithCapacity α n := e | return .rfl
+  let u := c.constLevels![0]!
+  let zero ← mkLitS (.natVal 0)
+  let block ← mkAppS (← mkConstS ``PartialBlock.empty [u]) α
+  let res ← mkAppS₃ (← mkConstS ``PartialBlock.toArray [u]) α zero block
+  let proof := mkApp2 (.const ``PartialBlock.emptyWithCapacity_eq [u]) α n
+  return .step res proof (done := true)
+
 builtin_cbv_simproc cbv_eval simpArrayMk (Array.mk _) := fun e => do
   let_expr c@Array.mk α list := e | return .rfl
   let some elems := getListLitElems list | return .rfl

--- a/src/Lean/Meta/Tactic/Cbv/BuiltinCbvSimprocs/Array.lean
+++ b/src/Lean/Meta/Tactic/Cbv/BuiltinCbvSimprocs/Array.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Wojciech Różowski
+Authors: Wojciech Różowski, Robin Arnez
 -/
 module
 
@@ -10,11 +10,18 @@ import Lean.Meta.Sym.Simp.SimpM
 import Lean.Meta.Sym.LitValues
 import Lean.Meta.Sym.InferType
 import Init.CbvSimproc
+import Init.Sym.TreeArray
 import Lean.Meta.Tactic.Cbv.CbvSimproc
 import Lean.Meta.Tactic.Cbv.Util
 import Init.GetElem
+import Init.Data.Array.OfFn
+import Lean.Meta.Sym.AlphaShareBuilder
+import Lean.Meta.AppBuilder
 
 namespace Lean.Meta.Tactic.Cbv
+
+open Sym.Simp Sym.Internal
+open Lean.Sym
 
 /-- Extract elements from an array literal (`Array.mk` applied to a list literal). -/
 def getArrayLitElems? (e : Expr) : Option <| Array Expr :=
@@ -22,6 +29,635 @@ def getArrayLitElems? (e : Expr) : Option <| Array Expr :=
   | Array.mk _ as => getListLitElems as
   | _ => none
 
+structure ArrayBuilderCtx where
+  mk' ::
+  u : Level
+  α : Expr
+  fullSingleFn : Expr -- Shared version of `@FullBlock.single α`
+  fullSplitFn : Expr -- Shared version of `@FullBlock.split α`
+  partialEmpty : Expr -- Shared version of `@PartialBlock.empty α`
+  partialSplitFn : Expr -- Shared version of `@PartialBlock.split α`
+  partialToArrayFn : Expr -- Shared version of `@PartialBlock.toArray α`
+  rflTrue : Expr -- Shared version of `rfl : true = true`
+
+def ArrayBuilderCtx.mk (u : Level) (α : Expr) : Sym.SymM ArrayBuilderCtx := do
+  return {
+    u, α
+    fullSingleFn := ← mkAppS (← mkConstS ``FullBlock.single [u]) α
+    fullSplitFn := ← mkAppS (← mkConstS ``FullBlock.split [u]) α
+    partialEmpty := ← mkAppS (← mkConstS ``PartialBlock.empty [u]) α
+    partialSplitFn := ← mkAppS (← mkConstS ``PartialBlock.split [u]) α
+    partialToArrayFn := ← mkAppS (← mkConstS ``PartialBlock.toArray [u]) α
+    rflTrue := ← Sym.share <| reflBoolTrue
+  }
+
+namespace ArrayBuilderCtx
+
+def fullSingle (ctx : ArrayBuilderCtx) (x : Expr) : Sym.SymM Expr := do
+  mkAppS ctx.fullSingleFn x
+
+def fullSplit (ctx : ArrayBuilderCtx) (n : Expr) (l r : Expr) : Sym.SymM Expr := do
+  mkAppS₃ ctx.fullSplitFn n l r
+
+def partialSplit (ctx : ArrayBuilderCtx) (n m : Expr) (l r : Expr) : Sym.SymM Expr := do
+  mkAppS₅ ctx.partialSplitFn n m l r ctx.rflTrue
+
+def toArray (ctx : ArrayBuilderCtx) (n : Expr) (x : Expr) : Sym.SymM Expr := do
+  mkAppS₂ ctx.partialToArrayFn n x
+
+/-- Creates a `FullBlock α n` consisting of the values in `elems[start...(start + 2^n)]` -/
+def mkFullOfArray (ctx : ArrayBuilderCtx) (lits : Array Expr)
+    (elems : Array Expr) (start : Nat) (n : Nat) : Sym.SymM Expr := do
+  match n with
+  | 0 => ctx.fullSingle elems[start]!
+  | k + 1 =>
+    ctx.fullSplit lits[k]!
+      (← ctx.mkFullOfArray lits elems start k)
+      (← ctx.mkFullOfArray lits elems (start + 1 <<< k) k)
+
+/--
+Returns `(n, block)` where `block : FullBlock α n` consists of the values in `elems[start...stop]`
+-/
+def mkPartialOfArray (ctx : ArrayBuilderCtx) (lits : Array Expr)
+    (elems : Array Expr) (start stop : Nat) : Sym.SymM (Nat × Expr) := do
+  if stop ≤ start then
+    return (0, ctx.partialEmpty)
+  let leftN := (stop - start).log2
+  let mid := start + 1 <<< leftN
+  let left ← ctx.mkFullOfArray lits elems start leftN
+  let (rightN, right) ← ctx.mkPartialOfArray lits elems mid stop
+  assert! rightN ≤ leftN
+  return (leftN + 1, ← ctx.partialSplit lits[leftN]! lits[rightN]! left right)
+termination_by stop - start
+decreasing_by simp_all [Nat.shiftLeft_eq]; have := Nat.two_pow_pos (stop - start).log2; omega
+
+def arrayToPartialBlock (ctx : ArrayBuilderCtx) (elems : Array Expr) : Sym.SymM (Expr × Expr) := do
+  let size := elems.size
+  let numNeededLits := size.log2 + 2
+  let lits ← Array.ofFnM fun i : Fin numNeededLits => mkLitS (.natVal i)
+  let (n, block) ← ctx.mkPartialOfArray lits elems 0 size
+  return (lits[n]!, block)
+
+/--
+Returns `(n, block)` where `block : FullBlock α n` consists of the values in `elems[start...stop]`
+-/
+def replicatePartial (ctx : ArrayBuilderCtx) (lits : Array Expr) (fulls : Array Expr)
+    (val : Expr) (size : Nat) : Sym.SymM (Nat × Expr) := do
+  if size = 0 then
+    return (0, ctx.partialEmpty)
+  let leftN := size.log2
+  let left := fulls[leftN]!
+  let (rightN, right) ← ctx.replicatePartial lits fulls val (size - 1 <<< leftN)
+  assert! rightN ≤ leftN
+  return (leftN + 1, ← ctx.partialSplit lits[leftN]! lits[rightN]! left right)
+termination_by size
+decreasing_by simp_all [Nat.shiftLeft_eq]; have := Nat.two_pow_pos size.log2; omega
+
+def replicateToPartialBlock (ctx : ArrayBuilderCtx) (val : Expr) (size : Nat) :
+    Sym.SymM (Expr × Expr) := do
+  let numNeededLits := size.log2 + 2
+  let numNeededFulls := size.log2 + 1
+  let lits ← Array.ofFnM fun i : Fin numNeededLits => mkLitS (.natVal i)
+  let mut fulls := #[← ctx.fullSingle val]
+  for i in 1...numNeededFulls do
+    fulls := fulls.push <| ← ctx.fullSplit lits[i - 1]! fulls.back! fulls.back!
+  let (n, block) ← ctx.replicatePartial lits fulls val size
+  return (lits[n]!, block)
+
+end ArrayBuilderCtx
+
+builtin_cbv_simproc ↓ simpPartialToArray (PartialBlock.toArray _) := fun e => do
+  let_expr PartialBlock.toArray _ _ _ := e | return .rfl
+  -- Don't visit `PartialBlock.toArray`
+  -- Note: we use as an invariant that the elements inside of a `PartialBlock` are
+  -- always simplified
+  return .rfl (done := true)
+
+builtin_cbv_simproc cbv_eval simpArrayMk (Array.mk _) := fun e => do
+  let_expr c@Array.mk α list := e | return .rfl
+  let some elems := getListLitElems list | return .rfl
+  let u : Level := c.constLevels![0]!
+  let ctx ← ArrayBuilderCtx.mk u α
+  let (n, block) ← ctx.arrayToPartialBlock elems
+  let proof := mkApp5 (.const ``PartialBlock.arrayMk_eq [u]) α n list block (← Sym.mkEqRefl list)
+  return .step (← ctx.toArray n block) proof (done := true)
+
+builtin_cbv_simproc cbv_eval simpArrayReplicate (Array.replicate _ _) := fun e => do
+  let_expr c@Array.replicate α sizeExpr val := e | return .rfl
+  let some size := Sym.getNatValue? sizeExpr | return .rfl
+  let u : Level := c.constLevels![0]!
+  let ctx ← ArrayBuilderCtx.mk u α
+  let (n, block) ← ctx.replicateToPartialBlock val size
+  let reflZero := mkApp2 (.const ``rfl [1]) (.const ``Nat []) (.lit (.natVal 0))
+  let proof := mkApp5 (.const ``PartialBlock.replicate_eq [u]) α val n sizeExpr reflZero
+  return .step (← ctx.toArray n block) proof (done := true)
+
+partial def extractFullBlockElems (x : Expr) (acc : Array Expr) :
+    OptionT Sym.SymM (Array Expr) := do
+  match_expr x with
+  | FullBlock.single _ val => return acc.push val
+  | FullBlock.split _ _ l r => extractFullBlockElems r (← extractFullBlockElems l acc)
+  | _ => failure
+
+partial def extractPartialBlockElems (x : Expr) (acc : Array Expr) :
+    OptionT Sym.SymM (Array Expr) := do
+  match_expr x with
+  | PartialBlock.empty _ => return acc
+  | PartialBlock.split _ _ _ l r _ => extractPartialBlockElems r (← extractFullBlockElems l acc)
+  | _ =>
+    trace[debug] "Failed `extractPartialBlockElems` at {x}"
+    failure
+
+builtin_cbv_simproc cbv_eval simpArrayToList (Array.toList _) := fun e => do
+  let_expr Array.toList _ xs := e | return .rfl
+  let_expr c@PartialBlock.toArray α n block := xs | return .rfl
+  let some elems ← (extractPartialBlockElems block #[]).run | return .rfl
+  let u : Level := c.constLevels![0]!
+  let nil ← mkAppS (← mkConstS ``List.nil [u]) α
+  let cons ← mkAppS (← mkConstS ``List.cons [u]) α
+  let mut list := nil
+  let mut i := elems.size
+  while i ≠ 0 do
+    i := i - 1
+    list ← mkAppS₂ cons elems[i]! list
+  let proof := mkApp3 (.const ``PartialBlock.toList_toArray [u]) α n block
+  let eq := mkApp3 (.const ``Eq [u.succ]) (.app (.const ``List [u]) α) e list
+  let proof := mkExpectedPropHint proof eq
+  return .step list proof (done := true)
+
+partial def partialBlockSize (x : Expr) (acc : Nat) : OptionT Sym.SymM Nat := do
+  match_expr x with
+  | PartialBlock.empty _ => return acc
+  | PartialBlock.split _ n _ _ r _ =>
+    let some val := n.rawNatLit? |
+      trace[debug] "Failed `partialBlockSize` at {x}"
+      failure
+    partialBlockSize r (acc + 1 <<< val)
+  | _ =>
+    trace[debug] "Failed `partialBlockSize` at {x}"
+    failure
+
+builtin_cbv_simproc cbv_eval simpArraySize (Array.size _) := fun e => do
+  let_expr Array.size _ xs := e | return .rfl
+  let_expr c@PartialBlock.toArray α n block := xs | return .rfl
+  let some size ← (partialBlockSize block 0).run | return .rfl
+  let u : Level := c.constLevels![0]!
+  let rhs ← Sym.share <| toExpr size
+  let actualRhs := mkApp3 (.const ``PartialBlock.size [u]) α n block
+  let proof := mkApp3 (.const ``PartialBlock.size_toArray [u]) α n block
+  let actualEq := mkApp3 (.const ``Eq [1]) (.const ``Nat []) e actualRhs
+  -- we need eager reduction here because we use `Nat.add` on terms that may contain free variables
+  let proof := mkApp2 (.const ``eagerReduce [0]) actualEq proof
+  let eq := mkApp3 (.const ``Eq [1]) (.const ``Nat []) e rhs
+  let proof := mkExpectedPropHint proof eq
+  return .step rhs proof (done := true)
+
+inductive ExprPushResult where
+  | part (e : Expr)
+  | full (e : Expr)
+
+@[inline]
+def ExprPushResult.toExpr (u : Level) (α : Expr) (n : Expr) (res : ExprPushResult) : Expr :=
+  match res with
+  | .part e => mkApp3 (.const ``PushResult.part [u]) α n e
+  | .full e => mkApp3 (.const ``PushResult.full [u]) α n e
+
+@[inline]
+def ExprPushResult.toProof (u : Level) (α : Expr) (n : Expr) (origBlock : Expr) (value : Expr)
+    (res : ExprPushResult) : Expr :=
+  let refl := mkApp2 (.const ``Eq.refl [u.succ]) (mkApp2 (.const ``PushResult [u]) α n)
+    (res.toExpr u α n)
+  match res with
+  | .part e => mkApp6 (.const ``PartialBlock.push_part [u]) α n origBlock e value refl
+  | .full e => mkApp6 (.const ``PartialBlock.push_full [u]) α n origBlock e value refl
+
+/--
+Given `x : PartialBlock α n` and `v : α`, returns `x.push v` as an `ExprPushResult`. Mimics the
+logic of `PartialBlock.push`.
+-/
+partial def partialBlockPush (x : Expr) (v : Expr) : OptionT Sym.SymM ExprPushResult := do
+  match_expr x with
+  | c@PartialBlock.empty α =>
+    let u := c.constLevels![0]!
+    return .full (← mkAppS₂ (← mkConstS ``FullBlock.single [u]) α v)
+  | c@PartialBlock.split α n m l r h =>
+    match ← partialBlockPush r v with
+    | .part block =>
+      -- partial block: just update the right-hand side
+      return .part <| ← mkAppS₂ x.appFn!.appFn! block h
+    | .full block =>
+      -- full block: either partial or full depending on the sizes
+      let some leftSize := n.rawNatLit? | failure
+      let some rightSize := m.rawNatLit? | failure
+      assert! rightSize ≤ leftSize
+      assert! h == reflBoolTrue
+      let u := c.constLevels![0]!
+      if leftSize = rightSize then
+        -- both are now equal sized full blocks: create a full block
+        return .full (← mkAppS₄ (← mkConstS ``FullBlock.split [u]) α n l block)
+      else
+        -- the right side is smaller: fit it into a new partial block
+        let split := x.getBoundedAppFn 5 -- @PartialBlock.split.{u} α
+        let empty ← mkAppS (← mkConstS ``PartialBlock.empty [u]) α
+        let rightBlock ← mkAppS₅ split m (← mkLitS (.natVal 0)) block empty h
+        return .part <| ← mkAppS₅ split n (← mkLitS (.natVal (rightSize + 1))) l rightBlock h
+  | _ => failure
+
+builtin_cbv_simproc cbv_eval simpArrayPush (Array.push _ _) := fun e => do
+  let_expr Array.push _ xs val := e | return .rfl
+  let_expr c@PartialBlock.toArray α n block := xs | return .rfl
+  let u : Level := c.constLevels![0]!
+  let some pushResult ← (partialBlockPush block val).run | return .rfl
+  let proof := pushResult.toProof u α n block val
+  let (n', newBlock) ← match pushResult with
+    | .part newBlock =>
+      -- already a partial block, nothing to do
+      pure (n, newBlock)
+    | .full newFullBlock =>
+      -- convert full block into partial block
+      let some size := n.rawNatLit? | failure
+      let empty ← mkAppS (← mkConstS ``PartialBlock.empty [u]) α
+      let newBlock ← mkAppS₆ (← mkConstS ``PartialBlock.split [u]) α n
+        (← mkLitS (.natVal 0)) newFullBlock empty (← Sym.share reflBoolTrue)
+      pure (← mkLitS (.natVal (size + 1)), newBlock)
+  let rhs ← mkAppS₃ (← mkConstS ``PartialBlock.toArray [u]) α n' newBlock
+  let eq := mkApp3 (.const ``Eq [u.succ]) (.app (.const ``Array [u]) α) e rhs
+  let proof := mkExpectedPropHint proof eq
+  return .step rhs proof (done := true)
+
+inductive ExprPopResult where
+  | empty
+  | done (e : Expr)
+  | shrink (e : Expr) (newN : Expr)
+
+@[inline]
+def ExprPopResult.toExpr (u : Level) (α : Expr) (n : Expr) (res : ExprPopResult) : Expr :=
+  match res with
+  | .empty => mkApp (.const ``PopResult.empty [u]) α
+  | .done e => mkApp3 (.const ``PopResult.done [u]) α n e
+  | .shrink e newN => mkApp3 (.const ``PopResult.shrink [u]) α newN e
+
+@[inline]
+def ExprPopResult.toProof (u : Level) (α : Expr) (n : Expr) (origBlock : Expr)
+    (res : ExprPopResult) : Expr :=
+  let refl := mkApp2 (.const ``Eq.refl [u.succ]) (mkApp2 (.const ``PopResult [u]) α n)
+    (res.toExpr u α n)
+  match res with
+  | .empty => .app (.const ``PartialBlock.pop_toArray_empty [u]) α
+  | .done e => mkApp5 (.const ``PartialBlock.pop_done [u]) α n origBlock e refl
+  | .shrink e newN => mkApp5 (.const ``PartialBlock.pop_shrink [u]) α newN origBlock e refl
+
+/-- Given `x : FullBlock α n`, returns `x.pop`. -/
+partial def fullBlockPop (x : Expr) : OptionT Sym.SymM Expr := do
+  match_expr x with
+  | c@FullBlock.single α _val => mkAppS (← mkConstS ``PartialBlock.empty c.constLevels!) α
+  | c@FullBlock.split α n l r =>
+    let r ← fullBlockPop r
+    mkAppS₆ (← mkConstS ``PartialBlock.split c.constLevels!) α n n l r (← Sym.share reflBoolTrue)
+  | _ => failure
+
+/--
+Given `x : PartialBlock α n`, returns `x.pop` as an `ExprPopResult`. Mimics the logic of
+`PartialBlock.pop`.
+-/
+partial def partialBlockPop (x : Expr) : OptionT Sym.SymM ExprPopResult := do
+  match_expr x with
+  | PartialBlock.empty _ => return .empty
+  | PartialBlock.split _ n _ l r h =>
+    match ← partialBlockPop r with
+    | .empty => return .shrink (← fullBlockPop l) n
+    | .done block =>
+      -- partial block of same size: just update the right-hand side
+      return .done <| ← mkAppS₂ x.appFn!.appFn! block h
+    | .shrink block newM =>
+      -- partial block of smaller size: just update the right-hand side
+      let split := x.getBoundedAppFn 4 -- @PartialBlock.split.{u} α n
+      assert! h == reflBoolTrue
+      return .done <| ← mkAppS₄ split newM l block h
+  | _ => failure
+
+builtin_cbv_simproc cbv_eval simpArrayPop (Array.pop _) := fun e => do
+  let_expr Array.pop _ xs := e | return .rfl
+  let_expr c@PartialBlock.toArray α n block := xs | return .rfl
+  let u : Level := c.constLevels![0]!
+  let some popResult ← (partialBlockPop block).run | return .rfl
+  let proof := popResult.toProof u α n block
+  let (n', newBlock) ← match popResult with
+    | .empty => pure (n, block) -- we only get .empty if the original was .empty
+    | .done newBlock => pure (n, newBlock)
+    | .shrink newBlock newN => pure (newN, newBlock)
+  let rhs ← mkAppS₃ (← mkConstS ``PartialBlock.toArray [u]) α n' newBlock
+  let eq := mkApp3 (.const ``Eq [u.succ]) (.app (.const ``Array [u]) α) e rhs
+  let proof := mkExpectedPropHint proof eq
+  return .step rhs proof (done := true)
+
+/-- Given `x : FullBlock α n` and `idx : Nat`, returns `x.get idx`. -/
+def fullBlockGet (x : Expr) (n : Nat) (idx : Nat) : OptionT Id Expr := do
+  match n with
+  | 0 =>
+    let_expr FullBlock.single _ val := x | failure
+    return val
+  | k + 1 =>
+    let_expr FullBlock.split _ _ l r := x | failure
+    fullBlockGet (if idx.testBit k then r else l) k idx
+
+/-- Given `x : PartialBlock α n` and `idx : Nat`, returns `x.get? idx`. -/
+partial def partialBlockGet (x : Expr) (idx : Nat) : OptionT Id (Option Expr) :=
+  match_expr x with
+  | PartialBlock.empty _ => return none
+  | PartialBlock.split _ n _ l r _ => do
+    let some n := n.rawNatLit? | failure
+    if idx < 1 <<< n then
+      fullBlockGet l n idx
+    else
+      partialBlockGet r (idx - 1 <<< n)
+  | _ => failure
+
+builtin_cbv_simproc cbv_eval simpArrayGetInternal (Array.getInternal _ _ _) := fun e => do
+  let_expr Array.getInternal _ xs idx hbounds := e | return .rfl
+  let_expr c@PartialBlock.toArray α n block := xs | return .rfl
+  let some idxVal := Sym.getNatValue? idx | return .rfl
+  let u : Level := c.constLevels![0]!
+  let some (some res) ← (partialBlockGet block idxVal).run | return .rfl
+  let some := mkApp2 (.const ``some [u]) α res
+  let someRefl := mkApp2 (.const ``Eq.refl [u.succ]) (.app (.const ``Option [u]) α) some
+  let proof := mkApp7 (.const ``PartialBlock.getElem_toArray_of_eq_some [u])
+    α n block idx res someRefl hbounds
+  return .step res proof (done := true)
+
+builtin_cbv_simproc cbv_eval simpArrayGet!Internal (Array.get!Internal _ _) := fun e => do
+  let_expr Array.get!Internal _ inhabited xs idx := e | return .rfl
+  let_expr c@PartialBlock.toArray α n block := xs | return .rfl
+  let some idxVal := Sym.getNatValue? idx | return .rfl
+  let u : Level := c.constLevels![0]!
+  let some (some res) ← (partialBlockGet block idxVal).run | return .rfl
+  let some := mkApp2 (.const ``some [u]) α res
+  let someRefl := mkApp2 (.const ``Eq.refl [u.succ]) (.app (.const ``Option [u]) α) some
+  let proof := mkApp7 (.const ``PartialBlock.getElem!_toArray_of_eq_some [u])
+    α inhabited n block idx res someRefl
+  return .step res proof (done := true)
+
+builtin_cbv_simproc cbv_eval simpArrayGetElem ((_ : Array _)[_]) := fun e => do
+  let_expr getElem _ _ _ _ _ xs idx hbounds := e | return .rfl
+  let_expr c@PartialBlock.toArray α n block := xs | return .rfl
+  let some idxVal := Sym.getNatValue? idx | return .rfl
+  let u : Level := c.constLevels![0]!
+  let some (some res) ← (partialBlockGet block idxVal).run | return .rfl
+  let some := mkApp2 (.const ``some [u]) α res
+  let someRefl := mkApp2 (.const ``Eq.refl [u.succ]) (.app (.const ``Option [u]) α) some
+  let proof := mkApp7 (.const ``PartialBlock.getElem_toArray_of_eq_some [u])
+    α n block idx res someRefl hbounds
+  return .step res proof (done := true)
+
+builtin_cbv_simproc cbv_eval simpArrayGetElem! ((_ : Array _)[_]!) := fun e => do
+  let_expr getElem! _ _ _ _ _ inhabited xs idx := e | return .rfl
+  let_expr c@PartialBlock.toArray α n block := xs | return .rfl
+  let some idxVal := Sym.getNatValue? idx | return .rfl
+  let u : Level := c.constLevels![0]!
+  let some (some res) ← (partialBlockGet block idxVal).run | return .rfl
+  let some := mkApp2 (.const ``some [u]) α res
+  let someRefl := mkApp2 (.const ``Eq.refl [u.succ]) (.app (.const ``Option [u]) α) some
+  let proof := mkApp7 (.const ``PartialBlock.getElem!_toArray_of_eq_some [u])
+    α inhabited n block idx res someRefl
+  return .step res proof (done := true)
+
+builtin_cbv_simproc cbv_eval simpArrayGetElem? ((_ : Array _)[_]?) := fun e => do
+  let_expr getElem? _ _ _ _ _ xs idx := e | return .rfl
+  let_expr c@PartialBlock.toArray α n block := xs | return .rfl
+  let some idxVal := Sym.getNatValue? idx | return .rfl
+  let u : Level := c.constLevels![0]!
+  let some res ← (partialBlockGet block idxVal).run | return .rfl
+  let rhs := match res with
+    | some res => mkApp2 (.const ``some [u]) α res
+    | none => .app (.const ``none [u]) α
+  let eq := mkApp3 (.const ``Eq [u.succ]) (.app (.const ``Option [u]) α) e rhs
+  let proof := mkApp4 (.const ``PartialBlock.getElem?_toArray [u]) α n block idx
+  let proof := mkExpectedPropHint proof eq
+  return .step rhs proof (done := true)
+
+/-- Given `x : FullBlock α n` and `idx : Nat`, returns `x.modify idx f`. -/
+@[specialize]
+def fullBlockModify (x : Expr) (n : Nat) (idx : Nat) (op : Expr → Expr) :
+    OptionT Sym.SymM Expr := do
+  match n with
+  | 0 =>
+    let_expr FullBlock.single _ val := x | failure
+    mkAppS x.appFn! (op val)
+  | k + 1 =>
+    let_expr FullBlock.split _ _ l r := x | failure
+    if idx.testBit k then
+      mkAppS x.appFn! (← fullBlockModify r k idx op)
+    else
+      mkAppS₂ x.appFn!.appFn! (← fullBlockModify l k idx op) r
+
+/-- Given `x : PartialBlock α n` and `idx : Nat`, returns `x.modify f idx`. -/
+@[specialize]
+partial def partialBlockModify (x : Expr) (idx : Nat) (op : Expr → Expr) :
+    OptionT Sym.SymM Expr :=
+  match_expr x with
+  | PartialBlock.empty _ => return x
+  | PartialBlock.split _ n _ l r h => do
+    let some n := n.rawNatLit? | failure
+    if idx < 1 <<< n then
+      mkAppS₃ (x.getBoundedAppFn 3) (← fullBlockModify l n idx op) r h
+    else
+      mkAppS₂ (x.getBoundedAppFn 2) (← partialBlockModify r (idx - 1 <<< n) op) h
+  | _ => failure
+
+/-- Given `x : FullBlock α n`, returns `x.map f`. -/
+partial def fullBlockMap (ctx : ArrayBuilderCtx) (x : Expr) (f : Expr) :
+    StateT (Std.HashMap Sym.ExprPtr Expr) (OptionT Sym.SymM) Expr := do
+  if let some res := (← get)[Sym.ExprPtr.mk x]? then
+    return res
+  match_expr x with
+  | FullBlock.single _ val =>
+    let res ← ctx.fullSingle (f.app val)
+    modify fun cache => cache.insert (Sym.ExprPtr.mk x) res
+    return res
+  | FullBlock.split _ n l r =>
+    let res ← ctx.fullSplit n (← fullBlockMap ctx l f) (← fullBlockMap ctx r f)
+    modify fun cache => cache.insert (Sym.ExprPtr.mk x) res
+    return res
+  | _ => failure
+
+/-- Given `x : PartialBlock α n` and `idx : Nat`, returns `x.modify f idx`. -/
+partial def partialBlockMap (ctx : ArrayBuilderCtx) (x : Expr) (f : Expr) :
+    StateT (Std.HashMap Sym.ExprPtr Expr) (OptionT Sym.SymM) Expr := do
+  match_expr x with
+  | PartialBlock.empty _ => return ctx.partialEmpty
+  | PartialBlock.split _ n m l r _ =>
+    ctx.partialSplit n m (← fullBlockMap ctx l f) (← partialBlockMap ctx r f)
+  | _ => failure
+
+def fullBlockSingleCongr {nm} (u : Level) (α : Expr) (val : Expr) (x : Expr)
+    (_h : x = mkApp2 (.const nm [u]) α val) (valRes : Sym.Simp.Result) :
+    Sym.SymM Sym.Simp.Result :=
+  match valRes with
+  | res@(.rfl ..) => return res
+  | .step val' proof _ cd =>
+    let fullBlockZero := mkApp2 (.const ``FullBlock [u]) α (.lit (.natVal 0))
+    let proof := mkApp6 (.const ``congrArg [u.succ, u.succ])
+      α fullBlockZero val val' x.appFn! proof
+    return .step (← mkAppS x.appFn! val') proof (done := true) cd
+
+def toArrayCongr (u : Level) (α : Expr) (n : Expr) (val : Expr) (x : Expr)
+    (valRes : Sym.Simp.Result) : Sym.SymM Sym.Simp.Result :=
+  match valRes with
+  | res@(.rfl ..) => return res
+  | .step val' proof _ cd =>
+    let partialBlock := mkApp2 (.const ``PartialBlock [u]) α n
+    let array := .app (.const ``Array [u]) α
+    let proof := mkApp6 (.const ``congrArg [u.succ, u.succ])
+      partialBlock array val val' x.appFn! proof
+    return .step (← mkAppS x.appFn! val') proof (done := true) cd
+
+def fullBlockSplitCongr {nm} (u : Level) (α : Expr) (n : Expr) (nval : Nat)
+    (l r : Expr) (x : Expr) (_h : x = mkApp4 (.const nm [u]) α n l r)
+    (lres rres : Sym.Simp.Result) : Sym.SymM Sym.Simp.Result :=
+  letI fullBlockSmaller := mkApp2 (.const ``FullBlock [u]) α n
+  letI fullBlockSelf := mkApp2 (.const ``FullBlock [u]) α (.lit (.natVal (nval + 1)))
+  letI fullBlockFun := .forallE `_ fullBlockSmaller fullBlockSelf .default
+  let f := x.appFn!.appFn!
+  match lres, rres with
+  | .rfl _ cd₁, .rfl _ cd₂ => return mkRflResult (done := true) (cd₁ || cd₂)
+  | .rfl _ cd₁, .step r' proof _ cd₂ =>
+    let proof := mkApp6 (.const ``congrArg [u.succ, u.succ])
+      fullBlockSmaller fullBlockSelf r r' x.appFn! proof
+    return .step (← mkAppS x.appFn! r') proof (done := true) (cd₁ || cd₂)
+  | .step l' proof _ cd₁, .rfl _ cd₂ =>
+    let proof := mkApp6 (.const ``congrArg [u.succ, u.succ])
+      fullBlockSmaller fullBlockFun l l' f proof
+    let proof := mkApp6 (.const ``congrFun' [u.succ, u.succ])
+      fullBlockSmaller fullBlockSelf (f.app l) (f.app l') proof r
+    return .step (← mkAppS₂ f l' r) proof (done := true) (cd₁ || cd₂)
+  | .step l' lproof _ cd₁, .step r' rproof _ cd₂ =>
+    let proof := mkApp6 (.const ``congrArg [u.succ, u.succ])
+      fullBlockSmaller fullBlockFun l l' f lproof
+    let proof := mkApp8 (.const ``congr [u.succ, u.succ])
+      fullBlockSmaller fullBlockSelf (f.app l) (f.app l') r r' proof rproof
+    return .step (← mkAppS₂ f l' r') proof (done := true) (cd₁ || cd₂)
+
+def partialBlockSplitCongr {nm} (u : Level) (α : Expr) (n m : Expr)
+    (l r : Expr) (h : Expr) (x : Expr) (_h : x = mkApp6 (.const nm [u]) α n m l r h)
+    (lres rres : Sym.Simp.Result) : Sym.SymM Sym.Simp.Result :=
+  let useCongrSimp (l' r' : Expr) (lproof rproof : Option Expr) (cd : Bool) : Sym.SymM Result := do
+    let lproof := lproof.getD (mkApp2 (.const ``Eq.refl [u.succ]) (mkApp2 (.const ``FullBlock [u]) α n) l)
+    let rproof := rproof.getD (mkApp2 (.const ``Eq.refl [u.succ]) (mkApp2 (.const ``PartialBlock [u]) α m) r)
+    let proof := mkApp10 (.const ``PartialBlock.split.congr_simp [u])
+      α n m l l' lproof r r' rproof h
+    let f := x.getBoundedAppFn 3
+    return .step (← mkAppS₃ f l' r' h) proof (done := true) cd
+  match lres, rres with
+  | .rfl _ cd₁, .rfl _ cd₂ => return mkRflResult (done := true) (cd₁ || cd₂)
+  | .rfl _ cd₁, .step r' proof _ cd₂ => useCongrSimp l r' none proof (cd₁ || cd₂)
+  | .step l' proof _ cd₁, .rfl _ cd₂ => useCongrSimp l' r proof none (cd₁ || cd₂)
+  | .step l' lproof _ cd₁, .step r' rproof _ cd₂ => useCongrSimp l' r' lproof rproof (cd₁ || cd₂)
+
+def targetedFullSimp (x : Expr) (n : Nat) (idx : Nat) : SimpM Result := do
+  match n with
+  | 0 =>
+    let (eq := heq) mkApp2 (.const nm [u]) α val := x | return .rfl (done := true)
+    unless nm == ``FullBlock.single do return .rfl (done := true)
+    fullBlockSingleCongr u α val x heq (← simp val)
+  | k + 1 =>
+    let (eq := heq) mkApp4 (.const nm [u]) α n l r := x | return .rfl (done := true)
+    unless nm == ``FullBlock.split do return .rfl (done := true)
+    if idx.testBit k then
+      fullBlockSplitCongr u α n k l r x heq .rfl (← targetedFullSimp r k (idx - 1 <<< k))
+    else
+      fullBlockSplitCongr u α n k l r x heq (← targetedFullSimp l k idx) .rfl
+
+partial def targetedPartialSimp (x : Expr) (idx : Nat) : SimpM Result := do
+  match heq : x with
+  | mkApp6 (.const nm [u]) α n m l r h =>
+    unless nm == ``PartialBlock.split do return .rfl (done := true)
+    let some nval := n.rawNatLit? | return .rfl (done := true)
+    if idx < 1 <<< nval then
+      let leftRes ← targetedFullSimp l nval idx
+      partialBlockSplitCongr u α n m l r h x heq leftRes .rfl
+    else
+      let rightRes ← targetedPartialSimp r (idx - 1 <<< nval)
+      partialBlockSplitCongr u α n m l r h x heq .rfl rightRes
+  | _ => return .rfl (done := true) -- including PartialBlock.empty
+
+def completeFullSimp (x : Expr) : StateT (Std.HashMap Sym.ExprPtr Result) SimpM Result := do
+  if let some res := (← get)[Sym.ExprPtr.mk x]? then
+    return res
+  match heq : x with
+  | mkApp2 (.const nm [u]) α val =>
+    unless nm == ``FullBlock.single do return .rfl (done := true)
+    let res ← fullBlockSingleCongr u α val x heq (← simp val)
+    modify fun cache => cache.insert (Sym.ExprPtr.mk x) res
+    return res
+  | mkApp4 (.const nm [u]) α n l r =>
+    unless nm == ``FullBlock.split do return .rfl (done := true)
+    let some k := n.rawNatLit? | return .rfl (done := true)
+    let res ← fullBlockSplitCongr u α n k l r x heq (← completeFullSimp l) (← completeFullSimp r)
+    modify fun cache => cache.insert (Sym.ExprPtr.mk x) res
+    return res
+  | _ => return .rfl (done := true)
+
+partial def completePartialSimp (x : Expr) :
+    StateT (Std.HashMap Sym.ExprPtr Result) SimpM Result := do
+  match heq : x with
+  | mkApp6 (.const nm [u]) α n m l r h =>
+    unless nm == ``PartialBlock.split do return .rfl (done := true)
+    let leftRes ← completeFullSimp l
+    let rightRes ← completePartialSimp r
+    partialBlockSplitCongr u α n m l r h x heq leftRes rightRes
+  | _ => return .rfl (done := true) -- including PartialBlock.empty
+
+builtin_cbv_simproc cbv_eval simpArraySet (Array.set _ _ _ _) := fun e => do
+  let_expr Array.set _ xs idx val hbounds := e | return .rfl
+  let_expr c@PartialBlock.toArray α n block := xs | return .rfl
+  let some idxVal := Sym.getNatValue? idx | return .rfl
+  let u : Level := c.constLevels![0]!
+  let some newBlock ← (partialBlockModify block idxVal fun _ => val).run | return .rfl
+  let rhs ← mkAppS₃ (← mkConstS ``PartialBlock.toArray [u]) α n newBlock
+  let eq := mkApp3 (.const ``Eq [u.succ]) (.app (.const ``Array [u]) α) e rhs
+  let proof := mkApp6 (.const ``PartialBlock.set_toArray [u]) α n block idx val hbounds
+  let proof := mkExpectedPropHint proof eq
+  return .step rhs proof (done := true)
+
+builtin_cbv_simproc cbv_eval simpArraySetIfInBounds (Array.setIfInBounds _ _ _) := fun e => do
+  let_expr Array.setIfInBounds _ xs idx val := e | return .rfl
+  let_expr c@PartialBlock.toArray α n block := xs | return .rfl
+  let some idxVal := Sym.getNatValue? idx | return .rfl
+  let u : Level := c.constLevels![0]!
+  let some newBlock ← (partialBlockModify block idxVal fun _ => val).run | return .rfl
+  let rhs ← mkAppS₃ (← mkConstS ``PartialBlock.toArray [u]) α n newBlock
+  let eq := mkApp3 (.const ``Eq [u.succ]) (.app (.const ``Array [u]) α) e rhs
+  let proof := mkApp5 (.const ``PartialBlock.setIfInBounds_toArray [u]) α n block idx val
+  let proof := mkExpectedPropHint proof eq
+  return .step rhs proof (done := true)
+
+builtin_cbv_simproc cbv_eval simpArrayModify (Array.modify _ _ _) := fun e => do
+  let_expr Array.modify _ xs idx fn := e | return .rfl
+  let_expr c@PartialBlock.toArray α n block := xs | return .rfl
+  let some idxVal := Sym.getNatValue? idx | return .rfl
+  let u : Level := c.constLevels![0]!
+  let some newBlock ← (partialBlockModify block idxVal fn.app).run | return .rfl
+  let rhs ← mkAppS₃ (← mkConstS ``PartialBlock.toArray [u]) α n newBlock
+  let eq := mkApp3 (.const ``Eq [u.succ]) (.app (.const ``Array [u]) α) e rhs
+  let proof := mkApp5 (.const ``PartialBlock.modify_toArray [u]) α n block idx fn
+  let proof := mkExpectedPropHint proof eq
+  mkEqTransResult e rhs proof (← toArrayCongr u α n newBlock rhs (← targetedPartialSimp newBlock idxVal))
+
+builtin_cbv_simproc cbv_eval simpArrayMap (Array.map _ _) := fun e => do
+  let_expr c@Array.map _ β fn xs := e | return .rfl
+  let_expr PartialBlock.toArray α n block := xs | return .rfl
+  let [u, v] := c.constLevels! | return .rfl
+  let builderCtx ← ArrayBuilderCtx.mk v β
+  let some newBlock ← (partialBlockMap builderCtx block fn).run' {} |>.run |
+    trace[debug] "Failed to map block at{indentExpr block}"
+    return .rfl
+  let rhs ← mkAppS₃ (← mkConstS ``PartialBlock.toArray [v]) β n newBlock
+  let eq := mkApp3 (.const ``Eq [v.succ]) (.app (.const ``Array [v]) β) e rhs
+  let proof := mkApp5 (.const ``PartialBlock.map_toArray [u, v]) α β n block fn
+  let proof := mkExpectedPropHint proof eq
+  mkEqTransResult e rhs proof (← toArrayCongr v β n newBlock rhs (← (completePartialSimp newBlock).run' {}))
+
+/-
 /-- Reduce `#[...][n]` for literal arrays and literal `Nat` indices. -/
 builtin_cbv_simproc cbv_eval simpArrayGetElem (@GetElem.getElem (Array _) Nat _ _ _ _ _ _) := fun e => do
   let_expr GetElem.getElem _ _ _ _ _ xs n _ := e | return .rfl
@@ -46,5 +682,6 @@ builtin_cbv_simproc cbv_eval simpArrayGetElem? (@GetElem?.getElem? (Array _) Nat
     else
       Sym.share <| mkApp (mkConst ``Option.none [u]) α
   return .step result (← Sym.mkEqRefl result)
+-/
 
 end Lean.Meta.Tactic.Cbv

--- a/tests/elab/cbv_array.lean
+++ b/tests/elab/cbv_array.lean
@@ -1,69 +1,84 @@
+module
+import all Init.Data.Array.QSort.Basic
+import all Init.Data.Array.Basic
 import Std
 
 -- Basic indexing
 theorem test1 : #[1, 2, 3][0] = 1 := by cbv
 
-/--
-info: theorem test1 : #[1, 2, 3][0] = 1 :=
-of_eq_true (Eq.trans (congrFun' (congrArg Eq (Eq.refl 1)) 1) (eq_self 1))
--/
-#guard_msgs in
-#print test1
-
 theorem test2 : #[1, 2, 3][2] = 3 := by cbv
-
-/--
-info: theorem test2 : #[1, 2, 3][2] = 3 :=
-of_eq_true (Eq.trans (congrFun' (congrArg Eq (Eq.refl 3)) 3) (eq_self 3))
--/
-#guard_msgs in
-#print test2
 
 -- Optional indexing (in bounds)
 theorem test3 : #[1, 2, 3][1]? = some 2 := by cbv
 
-/--
-info: theorem test3 : #[1, 2, 3][1]? = some 2 :=
-of_eq_true (Eq.trans (congrFun' (congrArg Eq (Eq.refl (some 2))) (some 2)) (eq_self (some 2)))
--/
-#guard_msgs in
-#print test3
-
 -- Optional indexing (out of bounds)
 theorem test4 : #[1, 2, 3][5]? = none := by cbv
-
-/--
-info: theorem test4 : #[1, 2, 3][5]? = none :=
-of_eq_true (Eq.trans (congrFun' (congrArg Eq (Eq.refl none)) none) (eq_self none))
--/
-#guard_msgs in
-#print test4
 
 -- Nested arrays
 theorem test5 : #[#[1, 2], #[3, 4]][1][0] = 3 := by cbv
 
-/--
-info: theorem test5 : #[#[1, 2], #[3, 4]][1][0] = 3 :=
-of_eq_true
-  (Eq.trans
-    (congrFun'
-      (congrArg Eq
-        (Eq.trans
-          (GetElem.getElem.congr_simp { toList := [{ toList := [1, 2] }, { toList := [3, 4] }] }[1] { toList := [3, 4] }
-            (Eq.refl { toList := [3, 4] }) 0 0 (Eq.refl 0) (of_decide_eq_true (id (Eq.refl true))))
-          (Eq.refl 3)))
-      3)
-    (eq_self 3))
--/
-#guard_msgs in
-#print test5
-
 -- Array of strings/other types
 theorem test6 : #["a", "b", "c"][0] = "a" := by cbv
 
-/--
-info: theorem test6 : #["a", "b", "c"][0] = "a" :=
-of_eq_true (Eq.trans (congrFun' (congrArg Eq (Eq.refl "a")) "a") (eq_self "a"))
--/
-#guard_msgs in
-#print test6
+theorem testSize : #[a, b, c].size = 3 := by cbv
+
+theorem testPush : #[a, b, c].push d = #[a, b, c, d] := by cbv
+
+def range (n : Nat) : Array Nat :=
+  match n with
+  | 0 => #[]
+  | k + 1 => (range k).push k
+
+def rangeReverse (n : Nat) (acc : Array Nat) : Array Nat :=
+  match n with
+  | 0 => acc
+  | k + 1 => rangeReverse k (acc.push k)
+
+set_option maxRecDepth 0
+set_option cbv.maxSteps 10000000
+
+theorem testRange : (range 2000).size = 2000 := by cbv
+
+theorem testReplicate : (Array.replicate (3 ^ 27) 0).size = 3 ^ 27 := by cbv
+
+theorem testSet : #[0, 1, 2, 3, 4].set 2 24 = #[0, 1, 24, 3, 4] := by cbv
+
+theorem testSetIfInBounds : #[0, 1, 2, 3, 4].setIfInBounds 2 24 = #[0, 1, 24, 3, 4] := by cbv
+
+theorem testModify : #[0, 1, 2, 3, 4].modify 2 (fun n => n + 22) = #[0, 1, 24, 3, 4] := by cbv
+
+theorem testMap : #[0, 1, 2, 3, 4].map (fun n => n + 22) = #[22, 23, 24, 25, 26] := by cbv
+
+theorem testMapGeneralized : #[0, 1, 2, 3, 4].map f = #[f 0, f 1, f 2, f 3, f 4] := by cbv
+
+theorem testMapReplicate : (Array.replicate (3 ^ 27) 0).map (· + 1) = Array.replicate (3 ^ 27) 1 := by cbv
+
+theorem testMapReplicateSet :
+    (Array.replicate (3 ^ 27) 0 |>.set! 1874317 90).map (· + 1) =
+      (Array.replicate (3 ^ 27) 1).set! 1874317 91 := by cbv
+
+def doMatch (x : Array Nat) : List Nat :=
+  match x with
+  | ⟨l⟩ => 3 :: l
+
+theorem testToList : (range 20).toList = List.range 20 := by cbv
+
+theorem testToList' : doMatch (range 20) = 3 :: List.range 20 := by cbv
+
+theorem testGet!Replicate : (Array.replicate (3 ^ 27) 0)[231489]! = 0 := by cbv
+
+theorem testGet?Replicate : (Array.replicate (3 ^ 27) 0)[231489]? = some 0 := by cbv
+
+theorem testGetReplicate : (Array.replicate (3 ^ 27) 0)[231489]'(by simp) = 0 := by cbv
+
+theorem testQSort : Array.qsort #[1, 8, 3, 2, 9, 0, 7, 13, 0, 0] = #[0, 0, 0, 1, 2, 3, 7, 8, 9, 13] := by cbv
+
+theorem testReverse : Array.reverse #[1, 2, 3, 4, 5] = #[5, 4, 3, 2, 1] := by cbv
+
+--theorem testQSortRange : Array.qsort (rangeReverse 300 #[]) = range 300 := by cbv
+
+theorem testFoldl : (range 1000).foldr (· + ·) 0 = 499500 := by cbv
+
+theorem testFoldlReplicate : (Array.replicate (3 ^ 27) 3).foldl (· + ·) 0 200 1200 = 3000 := by cbv
+
+theorem testBEq : range 5000 == range 5000 := by cbv


### PR DESCRIPTION
This PR adds special support for many `Array` operations in `cbv` by rewriting them to operations on `Lean.Sym.PartialBlock`, a tree data structure.