### PR TITLE
fix: don't error in defeq for missing unification hints

### DIFF
--- a/src/Lean/Meta/UnificationHint.lean
+++ b/src/Lean/Meta/UnificationHint.lean
@@ -116,7 +116,9 @@ where
     withTraceNode `Meta.isDefEq.hint
       (fun _ => return m!"hint {candidate} at {t} =?= {s}") do
     checkpointDefEq do
-      let cinfo ← getConstInfo candidate
+      -- the unification hint might only be imported privately and thus not available
+      -- in the public context
+      let some cinfo := (← getEnv).find? candidate | return false
       let us ← cinfo.levelParams.mapM fun _ => mkFreshLevelMVar
       let val ← instantiateValueLevelParams cinfo us
       let (xs, bis, body) ← lambdaMetaTelescope val

--- a/tests/elab/unifhintModule.lean
+++ b/tests/elab/unifhintModule.lean
@@ -1,0 +1,59 @@
+module
+
+/-!
+Test for `unif_hint` under the module system
+-/
+
+@[expose] public def Type1 := Fin
+@[expose] public def Type2 := Fin
+
+/-!
+`Type1` gets a public unification hint and `Type2` a private unification hint.
+-/
+
+unif_hint (n : Nat) where ⊢ Type1 n =?= Fin n
+
+local unif_hint (n : Nat) where ⊢ Type2 n =?= Fin n
+
+/-!
+Both unification hints work in a private context
+-/
+
+def privateTest1 (x : Fin 2) : Type1 2 := by with_reducible exact x
+def privateTest2 (x : Fin 2) : Type2 2 := by with_reducible exact x
+
+/-!
+The public hint also works in a public context
+-/
+
+@[expose]
+public def publicTest1 (x : Fin 2) : Type1 2 := by with_reducible exact x
+
+/-!
+The private hint does not work in a public context, producing a type mismatch error.
+
+It previously produced an unknown constant error, see https://github.com/leanprover/lean4/issues/14734
+-/
+
+/--
+error: Type mismatch
+  x
+has type
+  Fin 2
+but is expected to have type
+  Type2 2
+-/
+#guard_msgs in
+@[expose]
+public def publicTest2 (x : Fin 2) : Type2 2 := by with_reducible exact x
+
+/-!
+If the unification hint cannot be used but there is an alternative way to show definitional
+equality, definitional equality still succeeds.
+-/
+
+@[reducible, expose]
+public def Ignore (_α : Type) : Type := Unit
+
+@[expose]
+public def publicTest2' (x : Ignore (Fin 2)) : Ignore (Type2 2) := by with_reducible exact x


### PR DESCRIPTION
This PR fixes the handling of unification hints to not fail with an "unknown constant" error if the unification hint is not available in the current environment. This happens mostly when the unification hint is only imported privately but we are in a public context.

Closes #14734