### PR TITLE
perf: don't type check if no let decls are being referenced

### DIFF
--- a/src/Lean/Meta/Closure.lean
+++ b/src/Lean/Meta/Closure.lean
@@ -170,7 +170,8 @@ def preprocess (e : Expr) : ClosureM Expr := do
   let ctx ← read
   -- If we are not zetaDelta-expanding let-decls, then we use `check` to find
   -- which let-decls are dependent. We say a let-decl is dependent if its lambda abstraction is type incorrect.
-  if !ctx.zetaDelta then
+  let lctx ← getLCtx
+  if !ctx.zetaDelta && (e.hasMVar || e.hasAnyFVar fun f => (lctx.find? f).any (·.hasValue)) then
     check e
   pure e
 

--- a/tests/elab/ack.lean
+++ b/tests/elab/ack.lean
@@ -91,8 +91,6 @@ trace: [simp] Diagnostics
   use `set_option diagnostics.threshold <num>` to control threshold for reporting counters
 ---
 trace: [diag] Diagnostics
-  [def_eq] heuristic for solving `f a =?= f b` (max: 60, num: 1):
-    [def_eq] ack ↦ 60
   [kernel] unfolded declarations (max: 174, num: 3):
     [kernel] OfNat.ofNat ↦ 174
     [kernel] Add.add ↦ 58


### PR DESCRIPTION
This PR optimizes `mkValueTypeClosure` to not type check the expressions if they don't refer to let declarations. The type check step only exists to detect which let declarations are actually non-dependent so if they are no let declarations involved, this step can simply be skipped.
