### PR TITLE
fix: enable HWASAN support in the runtime

### DIFF
--- a/src/include/lean/lean.h
+++ b/src/include/lean/lean.h
@@ -17,6 +17,12 @@ Author: Leonardo de Moura
 #include <lean/mimalloc.h>
 #endif
 
+#if defined(__has_feature)
+#if __has_feature(hwaddress_sanitizer)
+#include <sanitizer/hwasan_interface.h>
+#endif
+#endif
+
 #ifdef __cplusplus
 #include <atomic>
 #include <stdlib.h>
@@ -467,6 +473,20 @@ LEAN_EXPORT void lean_inc_heartbeat(void);
 void * malloc(size_t);  // avoid including big `stdlib.h`
 #endif
 
+static inline void * lean_malloc_non_tagged(size_t sz) {
+#if defined(__has_feature)
+#if __has_feature(hwaddress_sanitizer)
+    // LEAN_PTR_PACKING needs top bits.
+    // https://github.com/leanprover/lean4/issues/13113.
+    __hwasan_disable_allocator_tagging();
+    void* r = malloc(sz);
+    __hwasan_enable_allocator_tagging();
+    return r;
+#endif
+#endif
+    return malloc(sz);
+}
+
 static inline lean_object * lean_alloc_small_object(unsigned sz) {
     lean_inc_heartbeat();
 #ifdef LEAN_MIMALLOC
@@ -479,7 +499,7 @@ static inline lean_object * lean_alloc_small_object(unsigned sz) {
     o->m_cs_sz = sz;
     return o;
 #else
-    void * mem = malloc(sizeof(size_t) + sz);
+    void * mem = lean_malloc_non_tagged(sizeof(size_t) + sz);
     if (mem == 0) lean_internal_panic_out_of_memory();
     *(size_t*)mem = sz;
     return (lean_object*)((size_t*)mem + 1);

--- a/src/include/lean/lean.h
+++ b/src/include/lean/lean.h
@@ -476,8 +476,10 @@ void * malloc(size_t);  // avoid including big `stdlib.h`
 static inline void * lean_malloc_non_tagged(size_t sz) {
 #if defined(__has_feature)
 #if __has_feature(hwaddress_sanitizer)
-    // LEAN_PTR_PACKING needs top bits.
-    // https://github.com/leanprover/lean4/issues/13113.
+    // In order to justify setting `LEAN_PTR_PACKING_SAFE` to true,
+    // we must ensure that hwasan does not tag our object pointers.
+    // This limits the usefulness of hwasan for Lean itself, but at
+    // least allows it to be used on larger binaries containing Lean.
     __hwasan_disable_allocator_tagging();
     void* r = malloc(sz);
     __hwasan_enable_allocator_tagging();

--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -52,7 +52,7 @@ Authors: Leonardo de Moura, Gabriel Ebner, Sebastian Ullrich
 #endif
 
 #if defined(__has_feature)
-#if __has_feature(address_sanitizer)
+#if __has_feature(address_sanitizer) || __has_feature(hwaddress_sanitizer)
 #include <sanitizer/lsan_interface.h>
 #endif
 #endif
@@ -548,7 +548,7 @@ extern "C" LEAN_EXPORT object * lean_compacted_region_read(b_obj_arg ofname, b_o
         // report those objects as leaks. Register the mapping as a root region so LSan follows the
         // in-region refs. (The malloc fallback below is covered by `__lsan_ignore_object` instead.)
 #if defined(__has_feature)
-#if __has_feature(address_sanitizer)
+#if __has_feature(address_sanitizer) || __has_feature(hwaddress_sanitizer)
         if (is_mmap)
             __lsan_register_root_region(buffer, size);
 #endif
@@ -568,7 +568,7 @@ extern "C" LEAN_EXPORT object * lean_compacted_region_read(b_obj_arg ofname, b_o
             // never freed at all, so tell LeakSanitizer not to report it. Under `mmap` (the common
             // path) the buffer is not a heap allocation and needs no such treatment.
 #if defined(__has_feature)
-#if __has_feature(address_sanitizer)
+#if __has_feature(address_sanitizer) || __has_feature(hwaddress_sanitizer)
             __lsan_ignore_object(buffer);
 #endif
 #endif

--- a/src/runtime/io.cpp
+++ b/src/runtime/io.cpp
@@ -1622,14 +1622,14 @@ extern "C" LEAN_EXPORT obj_res lean_runtime_mark_persistent(obj_arg a) {
 }
 
 #if defined(__has_feature)
-#if __has_feature(address_sanitizer)
+#if __has_feature(address_sanitizer) || __has_feature(hwaddress_sanitizer)
 #include <sanitizer/lsan_interface.h>
 #endif
 #endif
 
 extern "C" LEAN_EXPORT obj_res lean_runtime_forget(obj_arg o) {
 #if defined(__has_feature)
-#if __has_feature(address_sanitizer)
+#if __has_feature(address_sanitizer) || __has_feature(hwaddress_sanitizer)
     __lsan_ignore_object(o);
 #endif
 #endif

--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -291,20 +291,14 @@ static inline lean_object * get_next(lean_object * o) {
 }
 
 // See the docstring on `lean_object*` for details about pointer packing.
-#if defined(__has_feature)
-    #if __has_feature(hwaddress_sanitizer)
-        #define LEAN_HAS_HWASAN 1
-    #endif
-#endif
-#if defined(LEAN_HAS_HWASAN) || defined(__SANITIZE_HWADDRESS__) || \
-    defined(__ARM_FEATURE_MEMORY_TAGGING)
+#if defined(__ARM_FEATURE_MEMORY_TAGGING)
     #define LEAN_PTR_PACKING_SAFE false
 #else
     #define LEAN_PTR_PACKING_SAFE true
 #endif
 
 static_assert(sizeof(void*) != 8 || LEAN_PTR_PACKING_SAFE,
-    "Cannot compile with HWASAN or ARM MTE enabled; on 64-bit machines, "
+    "ARM MTE support is not implemented; on 64-bit machines, "
     "the pointer packing in `set_next` truncates the top byte used by these features.\n"
     "See https://github.com/leanprover/lean4/issues/13113.");
 
@@ -366,7 +360,7 @@ extern "C" LEAN_EXPORT lean_object * lean_alloc_object(size_t sz) {
     o->m_cs_sz = 0;
     return o;
 #else
-    void * r = malloc(sz);
+    void * r = lean_malloc_non_tagged(sz);
     if (r == nullptr) lean_internal_panic_out_of_memory();
     return (lean_object*)r;
 #endif
@@ -546,7 +540,7 @@ static obj_res mark_persistent_fn(obj_arg o) {
 }
 
 #if defined(__has_feature)
-#if __has_feature(address_sanitizer)
+#if __has_feature(address_sanitizer) || __has_feature(hwaddress_sanitizer)
 #include <sanitizer/lsan_interface.h>
 #endif
 #endif
@@ -560,7 +554,7 @@ extern "C" LEAN_EXPORT void lean_mark_persistent(object * o) {
         if (!lean_is_scalar(o) && lean_has_rc(o)) {
             lean_internal_set_rc(o, 0);
 #if defined(__has_feature)
-#if __has_feature(address_sanitizer)
+#if __has_feature(address_sanitizer) || __has_feature(hwaddress_sanitizer)
             // do not report as leak
             // NOTE: Most persistent objects are actually reachable from global
             // variables up to the end of the process. However, this is *not*

--- a/src/runtime/platform.cpp
+++ b/src/runtime/platform.cpp
@@ -61,7 +61,7 @@ extern "C" LEAN_EXPORT uint8 lean_internal_has_llvm_backend(obj_arg) {
 
 extern "C" LEAN_EXPORT uint8 lean_internal_has_address_sanitizer(obj_arg) {
 #if defined(__has_feature)
-#if __has_feature(address_sanitizer)
+#if __has_feature(address_sanitizer) || __has_feature(hwaddress_sanitizer)
     return 1;
 #else
     return 0;


### PR DESCRIPTION
This PR allows Lean to be built with [hwasan](https://clang.llvm.org/docs/HardwareAssistedAddressSanitizerDesign.html).

Lean's pointer packing conflicts with HWASAN allocator tagging on 64-bit machines due to top bit usage.
Previously we just disabled builds altogether in this configuration.
With this PR, we instead disable HWASAN allocator tagging around `malloc` for Lean objects in the default allocator.
While this limits the usefulness of HWASAN for sanitization of lean itself, it at least means that larger applications that link Lean can still use hwasan on their own logic.

Also enable LSAN utilities when HWASAN is active and update `LEAN_PTR_PACKING_SAFE` to indicate HWASAN compatibility.

This partially addresses #13113.