### PR TITLE
feat: `grind` reads a loop's measure through the states of the assertions

### DIFF
--- a/src/Std/Internal/Do/Triple/SpecLemmas.lean
+++ b/src/Std/Internal/Do/Triple/SpecLemmas.lean
@@ -1918,6 +1918,62 @@ the lexicographic order for products.
     [WellFoundedRelation γ] (f : α → Fun) (a : α) (n : γ) :
     (ofMeasure (Pred := Pred) f).EvalsTo a n = NondetFun.EvalsTo (f a) n := rfl
 
+/-! Fixed-arity specializations of `evalsTo_ofMeasure` at a lattice tower ending in `Prop`, in the
+manner of `CompleteLattice.ofProp_apply_1` and its siblings: the ground instances leave every
+parameter recoverable from the trigger, so these are usable `@[grind =]` lemmas where the general
+`NondetFun.evalsTo_apply` is not. The `pure` family is for a measure whose value depends on the
+cursor alone, as in `ofMeasure fun i => n - i`, which `NondetFun` interprets as that value. -/
+
+@[grind =] theorem evalsTo_ofMeasure_apply_1 {α : Type} {σ₁ : Type} {γ : Type}
+    [WellFoundedRelation γ] (f : α → σ₁ → γ) (a : α) (n : γ) (s₁ : σ₁) :
+    (ofMeasure (Pred := σ₁ → Prop) f).EvalsTo a n s₁ = (f a s₁ = n) := by
+  simp
+
+@[grind =] theorem evalsTo_ofMeasure_apply_2 {α : Type} {σ₁ σ₂ : Type} {γ : Type}
+    [WellFoundedRelation γ] (f : α → σ₁ → σ₂ → γ) (a : α) (n : γ) (s₁ : σ₁) (s₂ : σ₂) :
+    (ofMeasure (Pred := σ₁ → σ₂ → Prop) f).EvalsTo a n s₁ s₂ = (f a s₁ s₂ = n) := by
+  simp
+
+@[grind =] theorem evalsTo_ofMeasure_apply_3 {α : Type} {σ₁ σ₂ σ₃ : Type} {γ : Type}
+    [WellFoundedRelation γ] (f : α → σ₁ → σ₂ → σ₃ → γ) (a : α) (n : γ) (s₁ : σ₁) (s₂ : σ₂) (s₃ : σ₃) :
+    (ofMeasure (Pred := σ₁ → σ₂ → σ₃ → Prop) f).EvalsTo a n s₁ s₂ s₃ = (f a s₁ s₂ s₃ = n) := by
+  simp
+
+@[grind =] theorem evalsTo_ofMeasure_apply_4 {α : Type} {σ₁ σ₂ σ₃ σ₄ : Type} {γ : Type}
+    [WellFoundedRelation γ] (f : α → σ₁ → σ₂ → σ₃ → σ₄ → γ) (a : α) (n : γ) (s₁ : σ₁) (s₂ : σ₂) (s₃ : σ₃) (s₄ : σ₄) :
+    (ofMeasure (Pred := σ₁ → σ₂ → σ₃ → σ₄ → Prop) f).EvalsTo a n s₁ s₂ s₃ s₄ = (f a s₁ s₂ s₃ s₄ = n) := by
+  simp
+
+@[grind =] theorem evalsTo_ofMeasure_apply_5 {α : Type} {σ₁ σ₂ σ₃ σ₄ σ₅ : Type} {γ : Type}
+    [WellFoundedRelation γ] (f : α → σ₁ → σ₂ → σ₃ → σ₄ → σ₅ → γ) (a : α) (n : γ) (s₁ : σ₁) (s₂ : σ₂) (s₃ : σ₃) (s₄ : σ₄) (s₅ : σ₅) :
+    (ofMeasure (Pred := σ₁ → σ₂ → σ₃ → σ₄ → σ₅ → Prop) f).EvalsTo a n s₁ s₂ s₃ s₄ s₅ = (f a s₁ s₂ s₃ s₄ s₅ = n) := by
+  simp
+
+@[grind =] theorem evalsTo_ofMeasure_pure_apply_1 {α : Type} {σ₁ : Type} {γ : Type}
+    [WellFoundedRelation γ] (f : α → γ) (a : α) (n : γ) (s₁ : σ₁) :
+    (ofMeasure (Pred := σ₁ → Prop) f).EvalsTo a n s₁ = (f a = n) := by
+  simp
+
+@[grind =] theorem evalsTo_ofMeasure_pure_apply_2 {α : Type} {σ₁ σ₂ : Type} {γ : Type}
+    [WellFoundedRelation γ] (f : α → γ) (a : α) (n : γ) (s₁ : σ₁) (s₂ : σ₂) :
+    (ofMeasure (Pred := σ₁ → σ₂ → Prop) f).EvalsTo a n s₁ s₂ = (f a = n) := by
+  simp
+
+@[grind =] theorem evalsTo_ofMeasure_pure_apply_3 {α : Type} {σ₁ σ₂ σ₃ : Type} {γ : Type}
+    [WellFoundedRelation γ] (f : α → γ) (a : α) (n : γ) (s₁ : σ₁) (s₂ : σ₂) (s₃ : σ₃) :
+    (ofMeasure (Pred := σ₁ → σ₂ → σ₃ → Prop) f).EvalsTo a n s₁ s₂ s₃ = (f a = n) := by
+  simp
+
+@[grind =] theorem evalsTo_ofMeasure_pure_apply_4 {α : Type} {σ₁ σ₂ σ₃ σ₄ : Type} {γ : Type}
+    [WellFoundedRelation γ] (f : α → γ) (a : α) (n : γ) (s₁ : σ₁) (s₂ : σ₂) (s₃ : σ₃) (s₄ : σ₄) :
+    (ofMeasure (Pred := σ₁ → σ₂ → σ₃ → σ₄ → Prop) f).EvalsTo a n s₁ s₂ s₃ s₄ = (f a = n) := by
+  simp
+
+@[grind =] theorem evalsTo_ofMeasure_pure_apply_5 {α : Type} {σ₁ σ₂ σ₃ σ₄ σ₅ : Type} {γ : Type}
+    [WellFoundedRelation γ] (f : α → γ) (a : α) (n : γ) (s₁ : σ₁) (s₂ : σ₂) (s₃ : σ₃) (s₄ : σ₄) (s₅ : σ₅) :
+    (ofMeasure (Pred := σ₁ → σ₂ → σ₃ → σ₄ → σ₅ → Prop) f).EvalsTo a n s₁ s₂ s₃ s₄ s₅ = (f a = n) := by
+  simp
+
 /-- Decrease along `ofMeasure` is decrease of measure values along the well-founded relation of
 `γ`. Rewriting with this lemma brings a decrease proof obligation into the shape produced by
 `termination_by`, so that `decreasing_tactic` applies. -/
@@ -1998,6 +2054,33 @@ usable `@[grind =]` lemmas where the general `evalsBelow_ofMeasure_apply` is not
     (s₃ : σ₃) (s₄ : σ₄) (s₅ : σ₅) :
     (ofMeasure (Pred := σ₁ → σ₂ → σ₃ → σ₄ → σ₅ → Prop) f).EvalsBelow a' ma s₁ s₂ s₃ s₄ s₅
       = (f a' s₁ s₂ s₃ s₄ s₅ < ma) := by
+  simp
+
+/-! The same specializations for a measure whose value depends on the cursor alone. -/
+
+@[grind =] theorem evalsBelow_ofMeasure_pure_apply_1 {α : Type} {σ₁ : Type}
+    (f : α → Nat) (a' : α) (ma : Nat) (s₁ : σ₁) :
+    (ofMeasure (Pred := σ₁ → Prop) f).EvalsBelow a' ma s₁ = (f a' < ma) := by
+  simp
+
+@[grind =] theorem evalsBelow_ofMeasure_pure_apply_2 {α : Type} {σ₁ σ₂ : Type}
+    (f : α → Nat) (a' : α) (ma : Nat) (s₁ : σ₁) (s₂ : σ₂) :
+    (ofMeasure (Pred := σ₁ → σ₂ → Prop) f).EvalsBelow a' ma s₁ s₂ = (f a' < ma) := by
+  simp
+
+@[grind =] theorem evalsBelow_ofMeasure_pure_apply_3 {α : Type} {σ₁ σ₂ σ₃ : Type}
+    (f : α → Nat) (a' : α) (ma : Nat) (s₁ : σ₁) (s₂ : σ₂) (s₃ : σ₃) :
+    (ofMeasure (Pred := σ₁ → σ₂ → σ₃ → Prop) f).EvalsBelow a' ma s₁ s₂ s₃ = (f a' < ma) := by
+  simp
+
+@[grind =] theorem evalsBelow_ofMeasure_pure_apply_4 {α : Type} {σ₁ σ₂ σ₃ σ₄ : Type}
+    (f : α → Nat) (a' : α) (ma : Nat) (s₁ : σ₁) (s₂ : σ₂) (s₃ : σ₃) (s₄ : σ₄) :
+    (ofMeasure (Pred := σ₁ → σ₂ → σ₃ → σ₄ → Prop) f).EvalsBelow a' ma s₁ s₂ s₃ s₄ = (f a' < ma) := by
+  simp
+
+@[grind =] theorem evalsBelow_ofMeasure_pure_apply_5 {α : Type} {σ₁ σ₂ σ₃ σ₄ σ₅ : Type}
+    (f : α → Nat) (a' : α) (ma : Nat) (s₁ : σ₁) (s₂ : σ₂) (s₃ : σ₃) (s₄ : σ₄) (s₅ : σ₅) :
+    (ofMeasure (Pred := σ₁ → σ₂ → σ₃ → σ₄ → σ₅ → Prop) f).EvalsBelow a' ma s₁ s₂ s₃ s₄ s₅ = (f a' < ma) := by
   simp
 
 end RepeatVariant

--- a/tests/bench/vcgen/test_do_logic.lean
+++ b/tests/bench/vcgen/test_do_logic.lean
@@ -734,7 +734,8 @@ namespace RepeatInvariantOfInvariantAndBreak
 an `onBreak` condition (here the negated loop condition) that additionally holds once the loop
 exits. -/
 
-/-- Counts `i` down from `n`, incrementing the state on each iteration, so the final state is `n`. -/
+/-- Counts `i` down from `n`, incrementing the state on each iteration, so the final state is `n`.
+The measure reads the loop's own variable, which `NondetFun` interprets as that value. -/
 def countdown (n : Nat) : StateT Nat Id Unit := do
   let mut i := n
   while i > 0 do
@@ -763,22 +764,6 @@ theorem countdownStateful_spec (n : Nat) :
       (fun _ s => s ≤ n)
       (fun _ s => s = n)
   | inv2 => .ofMeasure fun _ s => n - s
-  with finish
-
-/-- The measure of a loop in a state monad need not read the state: here it counts down the loop's
-own variable while the state counts up. -/
-def countdownPureMeasure (n : Nat) : StateT Nat Id Unit := do
-  let mut i := n
-  while 0 < i do
-    i := i - 1
-    modify (· + 1)
-  return
-
-theorem countdownPureMeasure_spec (n : Nat) :
-    ⦃ fun s => s = 0 ⦄ countdownPureMeasure n ⦃ fun _ s => s = n ⦄ := by
-  vcgen [countdownPureMeasure] invariants
-  | inv1 => RepeatInvariant.ofInvariantAndBreak (fun i s => s + i = n) (fun i s => s = n)
-  | inv2 => .ofMeasure fun i => i
   with finish
 
 /-- Nested countdown driven by a single `while` loop: `i` counts down and resets `j`, so the

--- a/tests/bench/vcgen/test_do_logic.lean
+++ b/tests/bench/vcgen/test_do_logic.lean
@@ -747,7 +747,6 @@ theorem countdown_spec (n : Nat) :
   vcgen [countdown]
   case inv1 => exact RepeatInvariant.ofInvariantAndBreak (fun i s => s + i = n) (fun i _ => i = 0)
   case inv2 => exact .ofMeasure fun i => i
-  any_goals simp at *
   all_goals grind
 
 /-- Like `countdown`, but termination is measured from the monadic state rather than the loop cursor. -/
@@ -765,7 +764,6 @@ theorem countdownStateful_spec (n : Nat) :
       (fun _ s => s ≤ n)
       (fun _ s => s = n)
   case inv2 => exact .ofMeasure fun _ s => n - s
-  any_goals simp at *
   all_goals grind
 
 /-- The measure of a loop in a state monad need not read the state: here it counts down the loop's

--- a/tests/bench/vcgen/test_do_logic.lean
+++ b/tests/bench/vcgen/test_do_logic.lean
@@ -744,10 +744,10 @@ def countdown (n : Nat) : StateT Nat Id Unit := do
 
 theorem countdown_spec (n : Nat) :
     ⦃ fun s => s = 0 ⦄ countdown n ⦃ fun _ s => s = n ⦄ := by
-  vcgen [countdown]
-  case inv1 => exact RepeatInvariant.ofInvariantAndBreak (fun i s => s + i = n) (fun i _ => i = 0)
-  case inv2 => exact .ofMeasure fun i => i
-  all_goals grind
+  vcgen [countdown] invariants
+  | inv1 => RepeatInvariant.ofInvariantAndBreak (fun i s => s + i = n) (fun i _ => i = 0)
+  | inv2 => .ofMeasure fun i => i
+  with finish
 
 /-- Like `countdown`, but termination is measured from the monadic state rather than the loop cursor. -/
 def countdownStateful (n : Nat) : StateT Nat Id Unit := do
@@ -758,13 +758,12 @@ def countdownStateful (n : Nat) : StateT Nat Id Unit := do
 
 theorem countdownStateful_spec (n : Nat) :
     ⦃ fun _ => True ⦄ countdownStateful n ⦃ fun _ s => s = n ⦄ := by
-  vcgen [countdownStateful]
-  case inv1 =>
-    exact RepeatInvariant.ofInvariantAndBreak
+  vcgen [countdownStateful] invariants
+  | inv1 => RepeatInvariant.ofInvariantAndBreak
       (fun _ s => s ≤ n)
       (fun _ s => s = n)
-  case inv2 => exact .ofMeasure fun _ s => n - s
-  all_goals grind
+  | inv2 => .ofMeasure fun _ s => n - s
+  with finish
 
 /-- The measure of a loop in a state monad need not read the state: here it counts down the loop's
 own variable while the state counts up. -/
@@ -777,10 +776,10 @@ def countdownPureMeasure (n : Nat) : StateT Nat Id Unit := do
 
 theorem countdownPureMeasure_spec (n : Nat) :
     ⦃ fun s => s = 0 ⦄ countdownPureMeasure n ⦃ fun _ s => s = n ⦄ := by
-  vcgen [countdownPureMeasure]
-  case inv1 => exact RepeatInvariant.ofInvariantAndBreak (fun i s => s + i = n) (fun i s => s = n)
-  case inv2 => exact .ofMeasure fun i => i
-  all_goals grind
+  vcgen [countdownPureMeasure] invariants
+  | inv1 => RepeatInvariant.ofInvariantAndBreak (fun i s => s + i = n) (fun i s => s = n)
+  | inv2 => .ofMeasure fun i => i
+  with finish
 
 /-- Nested countdown driven by a single `while` loop: `i` counts down and resets `j`, so the
 decrease is lexicographic in `(i, j)`. -/
@@ -798,9 +797,9 @@ def countdownLex (n : Nat) : StateT Nat Id Unit := do
 
 theorem countdownLex_spec (n : Nat) :
     ⦃ fun _ => True ⦄ countdownLex n ⦃ fun _ _ => True ⦄ := by
-  vcgen [countdownLex]
-  case inv1 => exact RepeatInvariant.ofInvariantAndBreak (fun _ _ => True) (fun _ _ => True)
-  case inv2 => exact .ofMeasure fun (i, j) => (i, j)
+  vcgen [countdownLex] invariants
+  | inv1 => RepeatInvariant.ofInvariantAndBreak (fun _ _ => True) (fun _ _ => True)
+  | inv2 => .ofMeasure fun (i, j) => (i, j)
   all_goals simp_all [RepeatVariant.evalsBelow_ofMeasure]
   all_goals subst_vars
   all_goals decreasing_tactic

--- a/tests/bench/vcgen/test_do_logic.lean
+++ b/tests/bench/vcgen/test_do_logic.lean
@@ -768,6 +768,22 @@ theorem countdownStateful_spec (n : Nat) :
   any_goals simp at *
   all_goals grind
 
+/-- The measure of a loop in a state monad need not read the state: here it counts down the loop's
+own variable while the state counts up. -/
+def countdownPureMeasure (n : Nat) : StateT Nat Id Unit := do
+  let mut i := n
+  while 0 < i do
+    i := i - 1
+    modify (· + 1)
+  return
+
+theorem countdownPureMeasure_spec (n : Nat) :
+    ⦃ fun s => s = 0 ⦄ countdownPureMeasure n ⦃ fun _ s => s = n ⦄ := by
+  vcgen [countdownPureMeasure]
+  case inv1 => exact RepeatInvariant.ofInvariantAndBreak (fun i s => s + i = n) (fun i s => s = n)
+  case inv2 => exact .ofMeasure fun i => i
+  all_goals grind
+
 /-- Nested countdown driven by a single `while` loop: `i` counts down and resets `j`, so the
 decrease is lexicographic in `(i, j)`. -/
 def countdownLex (n : Nat) : StateT Nat Id Unit := do

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -293,7 +293,7 @@ def countIntoState (n : Nat) : StateM Nat Unit
     modify (· + 1)
     i := i + 1
 where finally
-  | spec => all_goals simp_all; omega
+  | spec => all_goals grind
 
 #guard_msgs (drop info) in
 #check @countIntoState.spec
@@ -314,7 +314,7 @@ def countUp (n : Nat) : Id Nat
 where finally
   | spec =>
     case inv1 => exact .ofMeasure fun i => n - i
-    all_goals simp_all; omega
+    all_goals grind
 
 #guard_msgs (drop info) in
 #check @countUp.spec
@@ -324,17 +324,20 @@ measure omitted by `countUp`, and it states an assertion of the monad the loop r
 
 def countMeasureOnly (n : Nat) : StateM Nat Unit
     requires s => s = 0
-    ensures _ s => s = 0 := do
+    ensures _ s => s = n := do
   let mut i := 0
   while i < n
       decreasing n - i
     do
+    modify (· + 1)
     i := i + 1
 where finally
   | spec =>
-    case inv1 => exact fun _ s => s = 0
-    all_goals simp_all
-    all_goals omega
+    case inv1 =>
+      exact fun c s => match c with
+        | .inl i => s = i ∧ i ≤ n
+        | .inr i => s = i ∧ i = n
+    all_goals grind
 
 #guard_msgs (drop info) in
 #check @countMeasureOnly.spec
@@ -352,8 +355,7 @@ def countInvariantOnly (n : Nat) : StateM Nat Unit
 where finally
   | spec =>
     case inv1 => exact .ofMeasure fun i => n - i
-    all_goals simp_all
-    all_goals omega
+    all_goals grind
 
 #guard_msgs (drop info) in
 #check @countInvariantOnly.spec
@@ -372,7 +374,7 @@ def drain (n : Nat) : StateM Nat Unit
     if s = n then break
     set (s + 1)
 where finally
-  | spec => all_goals simp_all; omega
+  | spec => all_goals grind
 
 #guard_msgs (drop info) in
 #check @drain.spec


### PR DESCRIPTION
This PR lets `grind` discharge the verification conditions of a `repeat` or `while` loop that states a termination measure in a monad with state, where the proof had to evaluate the measure with `simp_all` first. `RepeatVariant.EvalsTo` and `RepeatVariant.EvalsBelow` gain the fixed-arity ground instances that `grind` can key on, at arities 1 through 5.