### PR TITLE
feat: apply mvcgen specs whose precondition branches on a condition

### DIFF
--- a/src/Lean/Elab/Tactic/Do/ConjunctivePre.lean
+++ b/src/Lean/Elab/Tactic/Do/ConjunctivePre.lean
@@ -114,7 +114,8 @@ private def occursMVar (mvarIds : Array MVarId) (e : Expr) : Bool :=
 /-- Whether `e` is conjunctive in the metavariables `qs`, as a sufficient syntactic condition: every
 occurrence of a `qs` metavariable lies in a conjunctive context — a `wp` postcondition or
 exception-postcondition argument (assuming the program's `wp` is conjunctive), a `⊓`/`∧`/`⨅` operand,
-a `⇨` consequent, an `EPost.Cons.head` projection, applied at a tail, or under a `λ`. -/
+a `⇨` consequent, an `EPost.Cons.head` projection, a branch of a `qs`-free case analysis, applied at
+a tail, or under a `λ`. -/
 private partial def isConjunctiveIn (qs : Array MVarId) (e : Expr) : Bool :=
   if !occursMVar qs e then true else
   match e with
@@ -135,6 +136,12 @@ private partial def isConjunctiveIn (qs : Array MVarId) (e : Expr) : Bool :=
       | Lean.Order.meet _ _ a b => isConjunctiveIn qs a && isConjunctiveIn qs b
       | Lean.Order.iInf _ _ _ f => isConjunctiveIn qs f
       | And a b => isConjunctiveIn qs a && isConjunctiveIn qs b
+      -- A case analysis whose condition is `qs`-free is conjunctive when both branches are: the meet
+      -- distributes through it (`if c then a₁ else b ⊓ if c then a₂ else b = if c then a₁ ⊓ a₂ else b`,
+      -- using `b ⊓ b = b`), so a premise-free branching spec (a conditional jump's flag test) applies
+      -- directly and its precondition VC splits per branch.
+      | ite _ c _ a b => !occursMVar qs c && isConjunctiveIn qs a && isConjunctiveIn qs b
+      | dite _ c _ a b => !occursMVar qs c && isConjunctiveIn qs a && isConjunctiveIn qs b
       | Lean.Order.himp _ _ a b => !occursMVar qs a && isConjunctiveIn qs b
       | wp _ _ _ _ _ _ _ prog post epost =>
         !occursMVar qs prog && isConjunctiveIn qs post && isConjunctiveIn qs epost

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Context.lean
@@ -171,6 +171,17 @@ public structure VCGen.State where
   -/
   splitBackwardRuleCache : Std.HashMap (Name × ExprPtr × Nat) BackwardRule := {}
   /--
+  A cache mapping case analyses on the right-hand side of an entailment to their splitting backward
+  rule to apply. The particular rule depends on the case analysis's constant prefix (the result type
+  of an `ite`/`dite`, or a matcher together with its parameters and motive), the lattice carrier and
+  its order instance the rule states its conclusion at, and the number of state arguments the case
+  analysis is applied to.
+
+  The prefix, carrier and instance are keyed by `ExprPtr`, so lookups compare them by pointer rather
+  than structurally. This is sound because each is a subterm of the hash-consed goal target.
+  -/
+  topLevelSplitBackwardRuleCache : Std.HashMap (ExprPtr × ExprPtr × ExprPtr × Nat) BackwardRule := {}
+  /--
   A cache mapping lattice connectives to their backward rule to apply, keyed by the `head … cₙ`
   prefix of constant arguments the rule bakes in verbatim and the total argument count that fixes the
   schematic operand and state count.

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleCache.lean
@@ -66,6 +66,29 @@ public def mkBackwardRuleForSplitCached (splitInfo : SplitInfo) (info : WPApp) :
     { st with splitBackwardRuleCache := st.splitBackwardRuleCache.insert key rule }
   return rule
 
+open Lean.Elab.Tactic.Do in
+/--
+Cached version of `mkBackwardRuleForTopLevelSplit`.
+
+Cache key: the constant prefix of the case analysis `subject` (the result type of an `ite`/`dite`,
+or a matcher together with its parameters and motive), the lattice carrier `α` and its order
+instance `inst`, and the number of state arguments the case analysis is applied to. The rule bakes
+the prefix, the carrier and the instance in verbatim, and its state binders are sized by
+`excessArgs`.
+-/
+public def mkBackwardRuleForTopLevelSplitCached (splitInfo : SplitInfo) (subject relFn α inst : Expr)
+    (excessArgs : Array Expr) : VCGenM BackwardRule := do
+  let numConst := match splitInfo with
+    | .ite .. | .dite .. => 1
+    | .matcher matcherApp => matcherApp.params.size + 1
+  let key := (ExprPtr.mk (subject.getAppPrefix numConst), ExprPtr.mk α, ExprPtr.mk inst,
+    excessArgs.size)
+  if let some rule := (← get).topLevelSplitBackwardRuleCache[key]? then return rule
+  let rule ← (← mkBackwardRuleForTopLevelSplit splitInfo relFn α inst excessArgs).shareCommon
+  modify fun st =>
+    { st with topLevelSplitBackwardRuleCache := st.topLevelSplitBackwardRuleCache.insert key rule }
+  return rule
+
 /--
 Cached construction of a lattice-split backward rule for the operator heading `rhs`. On a cache miss
 the rewrite and terminal sets are assembled from the built-in seeds and the operator's `@[frameproc]`

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
@@ -401,6 +401,83 @@ public def mkBackwardRuleForSplit
   let res ← abstractMVars prf
   mkBackwardRuleFromExpr res.expr res.paramNames.toList
 
+open Lean.Elab.Tactic.Do in
+/-- Creates a reusable backward rule for splitting an `ite`, `dite` or matcher that heads the
+right-hand side of an entailment `pre ⊑ subject s₁ … sₙ`, where `subject` is the case analysis and
+`s₁ … sₙ` are the state arguments it is applied to.
+
+The rule concludes the entailment from one premise per alternative, each stating the entailment at
+that alternative's right-hand side under the hypothesis deciding the case. For the conditional-jump
+precondition `if s.zf then E.head jump else post () s`, the rule is
+
+```
+∀ c [Decidable c] t e pre, (c → pre ⊑ t) → (¬c → pre ⊑ e) → pre ⊑ ite c t e
+```
+
+`relFn`, `α` and `inst` are the head and the leading two arguments of the goal's `⊑`, so the rule's
+conclusion is stated at the goal's own lattice carrier and order instance. `excessArgs` supplies the
+types of `s₁ … sₙ`; the rule binds them and re-applies the split subject to them, so a case analysis
+living at a function assertion lattice is split under the state arguments `le_of_forall_le` peeled.
+
+`SplitInfo.withAbstract` introduces the abstract fvars for the split components,
+`SplitInfo.splitWith` builds the splitting proof with the splitter, so overlapping matcher patterns
+get the per-alternative hypotheses of the corresponding `casesOn` chain, and `rwIfOrMatcher`
+discovers each alternative's right-hand side inside the splitter telescope. -/
+public def mkBackwardRuleForTopLevelSplit
+    (splitInfo : SplitInfo) (relFn α inst : Expr) (excessArgs : Array Expr) :
+    MetaM BackwardRule := do
+  -- The type of the split subject: the goal's lattice carrier under the state arguments the subject
+  -- is applied to. `resTy` reads it off the case analysis, so the rule's pattern carries the same
+  -- expression as the goal's `ite` type argument or matcher motive.
+  let some subjTy := splitInfo.resTy
+    | throwError "mkBackwardRuleForTopLevelSplit: the case analysis has a dependent motive"
+  let prf ←
+    splitInfo.withAbstract subjTy fun abstractInfo splitFVars => do
+    -- Eta-reduce matcher alts for the backward rule pattern to avoid expensive
+    -- higher-order unification. The alts are eta-expanded by `withAbstract` so that
+    -- `splitWith`/`matcherApp.transform` can `instantiateLambda` them directly.
+    let abstractSubject := match abstractInfo with
+      | .ite e | .dite e => e
+      | .matcher matcherApp =>
+        { matcherApp with alts := matcherApp.alts.map Expr.eta }.toExpr
+    let excessArgNamesTypes ← excessArgs.mapM fun arg =>
+      return (`s, ← Meta.inferType arg)
+    withLocalDeclsDND excessArgNamesTypes fun ss => do
+    withLocalDeclD `Pre α fun pre => do
+    let mkGoal (subject : Expr) : Expr := mkAppN relFn #[α, inst, pre, mkAppN subject ss]
+    -- Use synthetic opaque mvars so that `rwIfOrMatcher`'s `assumption` cannot
+    -- accidentally assign our subgoal metavariables.
+    let subgoals ← splitInfo.altInfos.mapM fun _ =>
+      mkFreshExprSyntheticOpaqueMVar (mkSort 0)
+    let namedSubgoals := subgoals.mapIdx fun i mv => ((`h).appendIndexAfter (i+1), mv)
+    withLocalDeclsDND namedSubgoals fun subgoalHyps => do
+    let prf ←
+      abstractInfo.splitWith
+        (useSplitter := true)
+        (mkGoal abstractSubject)
+        (fun _name bodyType idx altFVars => do
+          -- Extract the split subject from `bodyType` (the substituted alt goal type) by dropping
+          -- the state arguments it is applied to. For matchers, `bodyType` has the discriminant
+          -- replaced by the constructor pattern (e.g., `Nat.zero` instead of `discr`), which is
+          -- required for `rwMatcher` to discharge the equality hypotheses of congr equation
+          -- theorems. For ite/dite, `bodyType` equals `mkGoal abstractSubject` so this is
+          -- equivalent.
+          let subject := (bodyType.getArg! 3).stripArgsN ss.size
+          let res ← rwIfOrMatcher idx subject
+          if res.proof?.isNone then
+            throwError "mkBackwardRuleForTopLevelSplit: rwIfOrMatcher failed for alt {idx}"
+          let altParams := altFVars.all
+          subgoals[idx]!.mvarId!.assign (← mkForallFVars altParams (mkGoal res.expr))
+          let context ← withLocalDecl `x .default subjTy fun x =>
+            mkLambdaFVars #[x] (mkGoal x)
+          let eqProof ← mkAppM ``congrArg #[context, res.proof?.get!]
+          mkEqMPR eqProof (mkAppN subgoalHyps[idx]! altParams))
+    let prf ← instantiateMVars prf
+    mkLambdaFVars (splitFVars ++ ss ++ #[pre] ++ subgoalHyps) prf
+  let prf ← instantiateMVars prf
+  let res ← abstractMVars prf
+  mkBackwardRuleFromExpr res.expr res.paramNames.toList
+
 /-! ## Frame rules -/
 
 /-- Locate the assignable subgoal positions of a frame backward rule: the split VC (the premise

--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -471,6 +471,53 @@ private def applySpecs (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
     trace[Elab.Tactic.Do.vcgen] "Failed to apply spec {thm.proof} for {info.prog}"
   stopOrErrorOnMissingSpec info.prog info.M candidates
 
+/-- Expose a case analysis heading `rhs`: strip the `noImplicitLambda` annotation a tactic
+`have`/`let`/`suffices` leaves on the goal, and beta-reduce the redex an assertion applied to the
+state arguments leaves behind. -/
+private partial def exposeRhsCase (rhs : Expr) : VCGenM Expr := do
+  let rhs := rhs.consumeMData
+  let f := rhs.getAppFn
+  if f.isLambda then exposeRhsCase (← betaS f rhs.getAppArgs) else return rhs
+
+/-- Strategy 9b: split an `ite`/`dite`/matcher heading the RHS of `pre ⊑ rhs`.
+
+A spec whose precondition analyzes a decidable state condition (a conditional jump's flag test)
+reduces its precondition VC to `pre ⊑ if c then <exception post> else <weakest precondition of the
+rest>`. `splitLatticeOp?` decomposes a `⊓`/`⇨` head, and `wpMatch?` splits a case analysis in program
+position; this splits one in assertion position, so each branch continues with the branch condition
+in the local context and the loop resumes stepping the `wp` the branch exposes. -/
+private def splitRhsCase? (goal : MVarId) (target α inst pre rhs : Expr) :
+    VCGenM (Option (List MVarId)) := do
+  let rhs' ← exposeRhsCase rhs
+  let some splitInfo ← liftMetaM <| Lean.Elab.Tactic.Do.getSplitInfo? rhs' | return none
+  -- The state arguments the case analysis is applied to: the `ite`/`dite` arguments past its five,
+  -- and a matcher's `remaining`.
+  let numArgs := rhs'.getAppNumArgs
+  let some numExcess := (match splitInfo with
+    | .ite _ | .dite _ => if numArgs < 5 then none else some (numArgs - 5)
+    | .matcher matcherApp => some matcherApp.remaining.size : Option Nat) | return none
+  -- The rule states its conclusion at the type of the case analysis, so a matcher whose motive is
+  -- dependent has none and the goal is emitted as a VC with the case analysis intact.
+  unless splitInfo.resTy.isSome do return none
+  let subject := rhs'.stripArgsN numExcess
+  let excessArgs := rhs'.getAppArgs.extract (numArgs - numExcess)
+  let replaceRhs (rhs : Expr) : VCGenM MVarId := do
+    goal.replaceTargetDefEqFast (← mkAppNS target.getAppFn #[α, inst, pre, rhs])
+  if splitInfo matches .matcher .. then
+    if let some rhs'' ← liftMetaM <| withReducible <| reduceRecMatcher? rhs' then
+      return some [← replaceRhs (← shareCommonInc rhs'')]
+  let rule ← mkBackwardRuleForTopLevelSplitCached splitInfo subject target.getAppFn α inst excessArgs
+  let goal ← if isSameExpr rhs rhs' then pure goal else replaceRhs rhs'
+  let .goals goals ← rule.applyChecked goal m!"split rule for{indentExpr subject}"
+    | throwError "Failed to apply split rule for{indentExpr subject}"
+  let mut simpGoals := #[]
+  for g in goals do
+    match ← simpGoalTelescope g with
+    | .goal g' => simpGoals := simpGoals.push g'
+    | .noProgress => simpGoals := simpGoals.push g
+    | .closed => continue
+  return some simpGoals.toList
+
 /--
 The main VC generation step. Operates on a plain `MVarId` with no knowledge of grind.
 Returns `.goals subgoals` when the goal was decomposed, or a classification result
@@ -490,7 +537,8 @@ The function performs the following steps in order:
 7. **Bare pure precondition introduction**: on the `Prop` lattice, replace a `True`
    precondition by `⊤` and lift any other precondition into the local context.
 8. **EPost projection reduction**: reduce an `EPost.Cons.head` RHS to the projected component.
-9. **Lattice decomposition**: decompose `⊓`, `⇨`, `⌜p⌝` and `⊤` RHS connectives.
+9. **Lattice decomposition**: decompose `⊓`, `⇨`, `⌜p⌝` and `⊤` RHS connectives, then split an
+   `ite`/`dite`/matcher RHS on its condition.
 10. **Lifted-hypothesis discharge**: close a residual `pre ⊑ ⌜φ⌝` entailment against the most
     recently lifted precondition `h : φ` in the local context, cached in `Scope.lastLiftedPre?`.
 11. **WP decomposition**: when the RHS is `wp e post epost s₁ ... sₙ`, in order:
@@ -527,6 +575,7 @@ public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := g
   -- forall, then discharge a residual entailment against the lifted hypothesis).
   if let some g ← reduceEPostHead? goal target α inst pre rhs then return .goals scope [g]
   if let some gs ← splitLatticeOp? goal rhs then return .goals scope gs
+  if let some gs ← splitRhsCase? goal target α inst pre rhs then return .goals scope gs
   if let some gs ← splitForallLe? goal rhs then return .goals scope gs
   if let some gs ← liftedHyp? scope goal α pre rhs then return .goals scope gs
 

--- a/tests/elab/vcgenImp.lean
+++ b/tests/elab/vcgenImp.lean
@@ -314,11 +314,11 @@ example : ⦃ fun _ _ => True ⦄ ⟦ x := 5; y := x + x ⟧ ⦃ fun _ _ s => s 
   vcgen
   simp [State.update]
 
-/-- A conditional: `vcgen` applies `Spec.ite`, leaving the guarded weakest precondition as a VC. -/
+/-- A conditional: `vcgen` applies `Spec.ite` and splits its guarded precondition on the guard,
+stepping the assignment of each branch under the decided guard. -/
 example : ⦃ fun _ _ => True ⦄ ⟦ if x then y := 1 else y := 0 fi ⟧
     ⦃ fun _ _ s => s "y" = if s "x" ≠ 0 then 1 else 0 ⦄ := by
-  vcgen
-  simp only [wp_assign_eq, State.update, Expr.eval]; grind
+  vcgen <;> simp only [State.update, Expr.eval] <;> grind
 
 /-- A loop preserved vacuously: the guard fails immediately. -/
 example : ⦃ fun _ s => s "x" = 0 ⦄ ⟦ while x do x := x + 1 od ⟧ ⦃ fun _ _ s => s "x" = 0 ⦄ := by

--- a/tests/elab/vcgenSplitRhsCase.lean
+++ b/tests/elab/vcgenSplitRhsCase.lean
@@ -1,0 +1,138 @@
+import Std.Tactic.Do
+import Std.Internal.Do
+
+/-!
+A `@[spec]` theorem whose precondition analyzes a decidable state condition (a conditional jump
+testing a flag) reduces its precondition VC to `pre ⊑ if c then E.head jump else <weakest
+precondition of the rest>`. `vcgen` splits such a case analysis on the right-hand side of the
+entailment, so each branch continues with the condition decided in the local context and the loop
+resumes stepping the `wp` the branch exposes.
+
+Covered here: an `ite` at the `Prop` lattice, a `match` on a small inductive with `Prop`-typed
+alternatives, and an `ite` at the `Nat → Prop` assertion lattice, where the case analysis is applied
+to the state argument `le_of_forall_le` peels.
+-/
+
+set_option mvcgen.warning false
+
+open Std.Internal.Do Lean.Order
+
+abbrev M := ExceptT String <| StateM Nat
+
+@[spec] theorem spec_throw (e : String) {post : α → Nat → Prop}
+    {E : EPost⟨String → Nat → Prop⟩} :
+    ⦃E.head e⦄ (throw (m := M) e) ⦃post; E⦄ := ⟨PartialOrder.rel_refl⟩
+
+@[spec] theorem spec_modify (f : Nat → Nat) {post : PUnit → Nat → Prop} :
+    ⦃fun s => post ⟨⟩ (f s)⦄ (modify (m := M) f) ⦃post⦄ := ⟨PartialOrder.rel_refl⟩
+
+/-! ## An `ite` on a decidable state condition -/
+
+def jcc (lim : Nat) : M Unit := do
+  let s ← get
+  if s > lim then throw "jump" else modify (· + 1)
+
+@[spec] theorem jcc_spec (lim : Nat) {post : PUnit → Nat → Prop}
+    {E : EPost⟨String → Nat → Prop⟩} :
+    ⦃fun s => if s > lim then E.head "jump" s else post ⟨⟩ (s + 1)⦄
+      (jcc lim) ⦃post; E⦄ := by
+  vcgen [jcc] <;> grind
+
+def jccProg (lim : Nat) : M Unit := do
+  jcc lim
+  jcc lim
+
+example (lim : Nat) :
+    ⦃fun s => s = 0⦄ jccProg lim ⦃fun _ s => s = 2; epost⟨fun _ s => s ≤ 1⟩⦄ := by
+  vcgen [jccProg] <;> grind
+
+/-! ## A `match` on a small inductive -/
+
+inductive Cc where | jump | inc | double
+
+def step (cc : Cc) : M Unit := do
+  match cc with
+  | .jump => throw "jump"
+  | .inc => modify (· + 1)
+  | .double => modify (· * 2)
+
+@[spec] theorem step_spec (cc : Cc) {post : PUnit → Nat → Prop}
+    {E : EPost⟨String → Nat → Prop⟩} :
+    ⦃fun s => match cc with
+      | .jump => E.head "jump" s
+      | .inc => post ⟨⟩ (s + 1)
+      | .double => post ⟨⟩ (s * 2)⦄
+      (step cc) ⦃post; E⦄ := by
+  vcgen [step] <;> grind
+
+def stepProg (cc : Cc) : M Unit := do
+  step cc
+  step cc
+
+example (cc : Cc) :
+    ⦃fun s => s = 1⦄ stepProg cc ⦃fun _ s => s ≥ 2; epost⟨fun _ s => s = 1⟩⦄ := by
+  vcgen [stepProg] <;> grind
+
+/-! ## An `ite` at the assertion lattice, applied to the state argument -/
+
+def jccF (b : Bool) : M Unit := do
+  if b then throw "jump" else modify (· + 1)
+
+/-- The branches are assertions rather than propositions, so the precondition VC reads
+`pre ⊑ (if b then E.head "jump" else fun s => post () (s + 1)) s`. -/
+@[spec] theorem jccF_spec (b : Bool) {post : PUnit → Nat → Prop}
+    {E : EPost⟨String → Nat → Prop⟩} :
+    ⦃if b then E.head "jump" else fun s => post ⟨⟩ (s + 1)⦄
+      (jccF b) ⦃post; E⦄ := by
+  vcgen [jccF] <;> simp_all
+
+def jccFProg (b : Bool) : M Unit := do
+  jccF b
+  jccF b
+
+example (b : Bool) :
+    ⦃fun s => s = 0⦄ jccFProg b ⦃fun _ s => s = 2; epost⟨fun _ s => s ≤ 1⟩⦄ := by
+  vcgen [jccFProg] <;> grind
+
+/-! ## A `dite`, and a `match` at the assertion lattice -/
+
+def jccD (lim : Nat) : M Unit := do
+  let s ← get
+  if _ : s > lim then throw "jump" else modify (· + 1)
+
+@[spec] theorem jccD_spec (lim : Nat) {post : PUnit → Nat → Prop}
+    {E : EPost⟨String → Nat → Prop⟩} :
+    ⦃fun s => if _ : s > lim then E.head "jump" s else post ⟨⟩ (s + 1)⦄
+      (jccD lim) ⦃post; E⦄ := by
+  vcgen [jccD] <;> grind
+
+def jccDProg (lim : Nat) : M Unit := do
+  jccD lim
+  jccD lim
+
+example (lim : Nat) :
+    ⦃fun s => s = 0⦄ jccDProg lim ⦃fun _ s => s = 2; epost⟨fun _ s => s ≤ 1⟩⦄ := by
+  vcgen [jccDProg] <;> grind
+
+def stepF (cc : Cc) : M Unit := do
+  match cc with
+  | .jump => throw "jump"
+  | .inc => modify (· + 1)
+  | .double => modify (· * 2)
+
+@[spec] theorem stepF_spec (cc : Cc) {post : PUnit → Nat → Prop}
+    {E : EPost⟨String → Nat → Prop⟩} :
+    ⦃match cc with
+      | .jump => E.head "jump"
+      | .inc => fun s => post ⟨⟩ (s + 1)
+      | .double => fun s => post ⟨⟩ (s * 2)⦄
+      (stepF cc) ⦃post; E⦄ := by
+  vcgen [stepF] <;> simp_all
+
+def stepFProg (cc : Cc) : M Unit := do
+  stepF cc
+  stepF cc
+
+example (cc : Cc) :
+    ⦃fun s => s = 1⦄ stepFProg cc ⦃fun _ s => s ≥ 2; epost⟨fun _ s => s = 1⟩⦄ := by
+  vcgen [stepFProg] <;> grind


### PR DESCRIPTION
This PR lets `mvcgen` apply a `@[spec]` theorem whose precondition is a case analysis, such as `if s.flags.zf then E (.jump l) s else Q () s` for a conditional-jump instruction, and splits the resulting verification condition on that case, so each branch is stepped separately with the decided condition in the local context.

`isConjunctiveIn` accepts an `ite`/`dite` whose condition does not mention the schematic postconditions and whose branches are conjunctive, since the meet distributes through such a case analysis. `mkBackwardRuleForTopLevelSplit` then builds a cached backward rule splitting an `ite`, `dite` or matcher on the right-hand side of an entailment, mirroring `mkBackwardRuleForSplit` for case analyses in program position: it abstracts the discriminant, eta-reduces matcher alternatives so the rule's pattern stays first-order, uses the matcher's splitter so dependent patterns get the right per-alt hypotheses, binds the excess state arguments, and proves each branch by congruence over the goal. The `solve` strategy `splitRhsCase?` normalizes the right-hand side, applies the rule and simplifies each branch.

`tests/elab/vcgenImp.lean` shows the effect on an existing example: `Spec.ite`'s precondition has exactly this shape, so its conditional program now yields one verification condition per branch, each already stepped through its assignment, instead of a single guarded condition whose branches are left unstepped.