### PR TITLE
feat: step vcgen through specs whose program applies a continuation variable

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/Solve.lean
@@ -147,6 +147,22 @@ private def liftedHypBare? (scope : VCGen.Scope) (goal : MVarId) (target : Expr)
     goal.assign hyp.toExpr
     return some []
 
+/-- Replace the `i`-th argument of the application `e`, which has `n` arguments. -/
+private def setAppArg (e : Expr) (i n : Nat) (v : Expr) : Expr :=
+  match e with
+  | .app f a => if n == i + 1 then e.updateApp! f v else e.updateApp! (setAppArg f i (n-1) v) a
+  | _ => e
+
+/-- Instantiate an assigned metavariable in the program of the `wp` application `rhs`. -/
+private def instantiateWPProg? (rhs : Expr) : VCGenM (Option Expr) := do
+  unless rhs.hasMVar do return none
+  let n := rhs.getAppNumArgs
+  unless n > 7 && rhs.getAppFn.isConstOf ``Std.Internal.Do.wp do return none
+  let prog := rhs.getArg! 7 n
+  let prog' ← instantiateMVarsIfMVarAppS prog
+  if isSameExpr prog prog' then return none
+  return some (← shareCommon (setAppArg rhs 7 n prog'))
+
 /-- Instantiate assigned head metavariables in the goal's entailment, so the shape tests in the
 following steps see the assigned form. -/
 private def instantiateGoal? (goal : MVarId) (target : Expr) : VCGenM (Option MVarId) := do
@@ -154,6 +170,7 @@ private def instantiateGoal? (goal : MVarId) (target : Expr) : VCGenM (Option MV
   let α' ← instantiateMVarsIfMVarAppS α
   let pre' ← instantiateMVarsIfMVarAppS pre
   let rhs' ← instantiateMVarsIfMVarAppS rhs
+  let rhs' := (← instantiateWPProg? rhs').getD rhs'
   if isSameExpr α α' && isSameExpr pre pre' && isSameExpr rhs rhs' then return none
   return some (← goal.replaceTargetDefEqFast (← mkAppNS c #[α', inst, pre', rhs']))
 

--- a/tests/bench/vcgen/cases/Cases.lean
+++ b/tests/bench/vcgen/cases/Cases.lean
@@ -1,3 +1,4 @@
+import Cases.AdcChain
 import Cases.AddSubCancel
 import Cases.AddSubCancelDeep
 import Cases.AddSubCancelSimp

--- a/tests/bench/vcgen/cases/Cases/AdcChain.lean
+++ b/tests/bench/vcgen/cases/Cases/AdcChain.lean
@@ -1,0 +1,68 @@
+import Lean
+import Std.Tactic.Do
+
+/-!
+Carry-flag chain in `StateM`: a minimal machine with two registers and a carry flag,
+where each `adc` adds `rbx` and the carry into `rax` and recomputes the carry from the
+overflow condition. Each instruction has an accessor-style spec: the continuation is
+quantified over a fresh post-state characterized by one equation per component, so VC
+generation accumulates a stratified equation system whose carry chain the discharge
+must fold. Minimized from the AeneasVerif/kraken assembly verifier.
+-/
+
+open Lean Meta Order Std.Internal.Do
+
+namespace AdcChain
+
+set_option mvcgen.warning false
+
+structure S where
+  rax : BitVec 64
+  rbx : BitVec 64
+  cf  : Bool
+
+def movRax (i : BitVec 64) : StateM S Unit := modify fun s => { s with rax := i }
+
+def movRbx (i : BitVec 64) : StateM S Unit := modify fun s => { s with rbx := i }
+
+def adc : StateM S Unit := modify fun s =>
+  let v := s.rax + s.rbx + BitVec.ofNat 64 s.cf.toNat
+  { rax := v, rbx := s.rbx,
+    cf := v.toNat != s.rax.toNat + s.rbx.toNat + s.cf.toNat }
+
+/-! Accessor-style specs: the instruction body is unfolded exactly once, in the spec
+proof; VC generation only ever sees the component equations. -/
+
+@[spec] theorem movRax_spec (i : BitVec 64) (post : PUnit → S → Prop) (epost : EPost.Nil) :
+    ⦃ fun s => ∀ s' : S, s'.rax = i → s'.rbx = s.rbx → s'.cf = s.cf → post ⟨⟩ s' ⦄
+      movRax i ⦃ post; epost ⦄ :=
+  ⟨fun _ h => h _ rfl rfl rfl⟩
+
+@[spec] theorem movRbx_spec (i : BitVec 64) (post : PUnit → S → Prop) (epost : EPost.Nil) :
+    ⦃ fun s => ∀ s' : S, s'.rax = s.rax → s'.rbx = i → s'.cf = s.cf → post ⟨⟩ s' ⦄
+      movRbx i ⦃ post; epost ⦄ :=
+  ⟨fun _ h => h _ rfl rfl rfl⟩
+
+@[spec] theorem adc_spec (post : PUnit → S → Prop) (epost : EPost.Nil) :
+    ⦃ fun s => ∀ s' : S,
+        s'.rax = s.rax + s.rbx + BitVec.ofNat 64 s.cf.toNat →
+        s'.rbx = s.rbx →
+        s'.cf = ((s.rax + s.rbx + BitVec.ofNat 64 s.cf.toNat).toNat
+                  != s.rax.toNat + s.rbx.toNat + s.cf.toNat) →
+        post ⟨⟩ s' ⦄
+      adc ⦃ post; epost ⦄ :=
+  ⟨fun _ h => h _ rfl rfl rfl⟩
+
+def chain : Nat → StateM S Unit
+  | 0 => pure ()
+  | n+1 => do adc; chain n
+
+def prog (n : Nat) : StateM S Unit := do
+  movRax 1
+  movRbx 3
+  chain n
+
+def Goal (n : Nat) : Prop :=
+  ⦃ fun _ => True ⦄ prog n ⦃ fun _ s => s.rax = BitVec.ofNat 64 (1 + 3 * n) ⦄
+
+end AdcChain

--- a/tests/bench/vcgen/lakefile.lean
+++ b/tests/bench/vcgen/lakefile.lean
@@ -17,7 +17,7 @@ lean_lib Cases where
 lean_lib VCGenBench where
   roots := #[`vcgen_add_sub_cancel, `vcgen_add_sub_cancel_deep, `vcgen_add_sub_cancel_simp,
              `vcgen_get_throw_set, `vcgen_get_throw_set_grind, `vcgen_pure_precond,
-             `vcgen_reader_state, `vcgen_match_split]
+             `vcgen_reader_state, `vcgen_match_split, `vcgen_adc_chain]
   moreLeanArgs := #["--tstack=102400"] -- 100 MB in KB
 
 @[default_target]

--- a/tests/bench/vcgen/vcgen_adc_chain.lean
+++ b/tests/bench/vcgen/vcgen_adc_chain.lean
@@ -1,0 +1,24 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Graf
+-/
+import Cases.AdcChain
+import Driver
+
+/-!
+Measures `vcgen` on the `AdcChain` carry-flag chain, where every instruction has an accessor-style
+spec, at chain lengths 250, 500 and 750. The VCs are left to `sorry`, so the timings report VC
+generation alone.
+-/
+
+set_option mvcgen.warning false
+
+open Lean Order Parser Meta Elab Tactic Sym Std Internal.Do
+open AdcChain
+
+set_option maxRecDepth 10000
+set_option maxHeartbeats 10000000
+
+#eval runBenchUsingTactic ``Goal [``prog, ``AdcChain.chain] `(tactic| vcgen) `(tactic| sorry)
+  [250, 500, 750]

--- a/tests/elab/vcgenMVarProgram.lean
+++ b/tests/elab/vcgenMVarProgram.lean
@@ -1,0 +1,72 @@
+import Std.Tactic.Do
+import Std.Internal.Do
+
+/-!
+A spec whose program applies a continuation variable under a binder, as in
+`Lang.bnd (fun x => Lang.add (k x) (Lang.nat 0))`. First-order matching leaves `k` open, so
+applying the spec to `Lang.bnd (fun x => Lang.add (Lang.nat x) (Lang.nat 0))` solves `k` while the
+pending unification constraints are processed, i.e. after the emitted goal's type was built. That
+goal's program is the metavariable standing for `k`, applied to `5`, and `vcgen` continues by
+instantiating it.
+-/
+
+set_option mvcgen.warning false
+
+open Std.Internal.Do
+open Lean.Order
+
+inductive Lang where
+  | nat (n : Nat)
+  | add (l r : Lang)
+  /-- Runs its body at `5`. -/
+  | bnd (k : Nat → Lang)
+
+inductive IsValue : Lang → Prop where
+  | nat : IsValue (.nat _n)
+
+def Value : Type _ := { l : Lang // IsValue l }
+
+axiom wp : Lang → (Value → Prop) → Prop
+axiom wp_mono : ∀ (post post' : Value → Prop),
+  (∀ (x : Value), post x → post' x) → wp x post → wp x post'
+axiom wp_nat : ∀ {n : Nat} {Φ : Value → Prop}, Φ ⟨.nat n, .nat⟩ → wp (Lang.nat n) Φ
+axiom wp_add : ∀ {l r : Lang} {Φ : Value → Prop},
+  wp l (fun vl => wp r (fun vr => ∀ nl nr,
+    vl.val = Lang.nat nl → vr.val = Lang.nat nr → Φ ⟨.nat (nl + nr), .nat⟩)) →
+  wp (Lang.add l r) Φ
+axiom wp_bnd : ∀ {k : Nat → Lang} {Φ : Value → Prop},
+  wp (Lang.add (k 5) (Lang.nat 0)) Φ →
+  wp (Lang.bnd (fun x => Lang.add (k x) (Lang.nat 0))) Φ
+
+instance instWP_Lang : WP Lang Value Prop EPost.Nil where
+  wpTrans l := ⟨fun Φ _ => wp l Φ⟩
+  wp_trans_monotone x := by
+    simp [PredTrans.monotone, Lean.Order.PartialOrder.rel]
+    intros; apply wp_mono <;> trivial
+
+@[spec]
+theorem spec_nat {n : Nat} {Φ : Value → Prop} : ⦃ Φ ⟨.nat n, .nat⟩ ⦄ (Lang.nat n) ⦃ Φ; epost⟨⟩⦄ :=
+  Triple.iff.mpr wp_nat
+
+@[spec]
+theorem spec_add {l r} {Φ : Value → Prop} :
+    ⦃ Std.Internal.Do.wp l
+        (fun vl => Std.Internal.Do.wp r
+          (fun vr => ∀ nl nr, vl.val = Lang.nat nl → vr.val = Lang.nat nr →
+            Φ ⟨.nat (nl + nr), .nat⟩) epost⟨⟩) epost⟨⟩ ⦄
+      (Lang.add l r) ⦃ Φ; epost⟨⟩⦄ := by
+  refine Triple.iff.mpr ?_
+  simp only [Lean.Order.le_prop_eq_imp]
+  intro h; exact wp_add h
+
+@[spec]
+theorem spec_bnd {k : Nat → Lang} {Φ : Value → Prop} :
+    ⦃ Std.Internal.Do.wp (Lang.add (k 5) (Lang.nat 0)) Φ epost⟨⟩ ⦄
+      (Lang.bnd (fun x => Lang.add (k x) (Lang.nat 0))) ⦃ Φ; epost⟨⟩⦄ := by
+  refine Triple.iff.mpr ?_
+  simp only [Lean.Order.le_prop_eq_imp]
+  intro h; exact wp_bnd h
+
+example : ⦃ True ⦄ Lang.bnd (fun x => Lang.add (Lang.nat x) (Lang.nat 0))
+    ⦃ fun v => v.val = Lang.nat 5 ⦄ := by
+  vcgen <;> grind


### PR DESCRIPTION
This PR lets `vcgen` continue through a spec whose program applies a continuation variable under a binder, such as for `k` in `Lang.bnd (fun x => Lang.add (k x) (Lang.nat 0))`. First-order matching leaves `k` open and unification assigns it while the pending constraints are processed, which happens after the emitted goal's type has been built, so that goal's program is the metavariable standing for `k` applied to its arguments. `vcgen` used to give up on such a goal with "Failed to decompose weakest precondition … This should not happen". Now it instantiates in the right place.