### PR TITLE
feat: record code quality metrics from linters

### DIFF
--- a/src/Lean/Linter/CodeQuality/Basic.lean
+++ b/src/Lean/Linter/CodeQuality/Basic.lean
@@ -9,7 +9,7 @@ module
 prelude
 
 public import Init.Data.Float
-public import Std.Data.TreeMap
+public import Std.Data.TreeMap.Basic
 public import Init.Data.Ord
 public import Lean.Data.Json
 

--- a/src/Lean/Linter/Init.lean
+++ b/src/Lean/Linter/Init.lean
@@ -47,8 +47,8 @@ participate in `getLinterValue` like any user-declared set.
 -/
 builtin_initialize builtinLinterSetsRef : IO.Ref (Array (Name × NameSet)) ← IO.mkRef #[]
 
-/-- 
-  Register a builtin linter set entry. 
+/--
+  Register a builtin linter set entry.
   Only valid during initialization.
 -/
 def addBuiltinLinterSet (setName : Name) (linterNames : NameSet) : IO Unit := do
@@ -153,6 +153,28 @@ def _root_.Lean.MessageData.isLinterMessage (msg : MessageData) : Bool :=
   msg.hasTag (· == linterMessageTag)
 
 /--
+Tag attached by `logCodeQualityEntry` so consumers
+can distinguish code quality entry-bearing messages from other tagged messages
+such as named errors or unknown-identifier messages.
+-/
+def codeQualityMessageTag : Name := `Lean.Linter._codeQuality
+
+/--
+Logs a message carrying the code quality entry `e` at the position of `stx`. The message is
+logged as silent so it is never displayed to users; it only serves as a carrier for persisting
+the entry into the `.olean` (see `Lean.Linter.recordLints`).
+-/
+def logCodeQualityEntry [Monad m] [MonadLog m] [AddMessageContext m] [MonadOptions m]
+    (stx : Syntax) (e : CodeQuality.Entry) : m Unit :=
+  logAt stx (severity := .information) (isSilent := true) <|
+    .ofCodeQualityEntry e <|
+    .tagged codeQualityMessageTag <| .nil
+
+/-- Returns true if `msg` was produced by `Lean.Linter.logCodeQualityEntry`. -/
+def _root_.Lean.MessageData.isCodeQualityMessage (msg : MessageData) : Bool :=
+  msg.hasTag (· == codeQualityMessageTag)
+
+/--
 If `linterOption` is enabled, print a linter warning message at the position determined by `stx`.
 
 Whether a linter option is enabled or not is determined by the following sequence:
@@ -166,6 +188,14 @@ Whether a linter option is enabled or not is determined by the following sequenc
 def logLintIf [Monad m] [MonadLog m] [AddMessageContext m] [MonadOptions m] [MonadEnv m]
     (linterOption : Lean.Option Bool) (stx : Syntax) (msg : MessageData) : m Unit := do
   if getLinterValue linterOption (← getLinterOptions) then logLint linterOption stx msg
+
+/--
+Similar to `logLintIf`, but for `logCodeQualityEntry` - i.e. it logs an entry only if the
+provided linter option is enabled, taking `linter.all` and linter sets into account.
+-/
+def logCodeQualityEntryIf [Monad m] [MonadLog m] [AddMessageContext m] [MonadOptions m] [MonadEnv m]
+    (linterOption : Lean.Option Bool) (stx : Syntax) (e : CodeQuality.Entry) : m Unit := do
+  if getLinterValue linterOption (← getLinterOptions) then logCodeQualityEntry stx e
 
 abbrev EnvLinterSnapshot := NameMap Bool
 

--- a/src/Lean/Linter/PersistentLintLog.lean
+++ b/src/Lean/Linter/PersistentLintLog.lean
@@ -9,6 +9,7 @@ prelude
 public import Lean.Environment
 public import Lean.Message
 public import Lean.Linter.Init
+public import Lean.Linter.CodeQuality.Basic
 public import Lean.Elab.DeclarationRange
 
 public section
@@ -35,11 +36,27 @@ def getAllLints (env : Environment) : Array (Name × Array LintEntry) :=
   env.header.moduleNames.mapIdx fun i mod =>
     (mod, lintLogExt.getModuleEntries env i (level := .server))
 
+builtin_initialize codeQualityLogExt :
+    PersistentEnvExtension CodeQuality.Entry CodeQuality.Entry (Array CodeQuality.Entry) ←
+  registerPersistentEnvExtension {
+    mkInitial     := pure #[]
+    addImportedFn := fun _ => pure #[]
+    addEntryFn    := Array.push
+    exportEntriesFnEx := fun _ entries =>
+      { exported := #[], server := entries, «private» := entries }
+  }
+
+def getAllCodeQualityEntries (env : Environment) : Array (Name × Array CodeQuality.Entry) :=
+  env.header.moduleNames.mapIdx fun i mod =>
+    (mod, codeQualityLogExt.getModuleEntries env i (level := .server))
+
 instance : MonadFileMap (ReaderT FileMap BaseIO) := ⟨read⟩
 
 /--
 Records linter warnings and looks up positions of their associated commands from a build
 into `lintLogExt` so that consumers (e.g. `lake lint`) can recover them from the `.olean`.
+Messages carrying code quality entries (see `Lean.Linter.logCodeQualityEntry`) are recorded
+into `codeQualityLogExt` instead, without any position information.
 -/
 def recordLints (fileMap : FileMap) (env : Environment)
     (commandLints : Array (Option Syntax × MessageLog)) : BaseIO Environment := do
@@ -49,6 +66,8 @@ def recordLints (fileMap : FileMap) (env : Environment)
       | none     => pure none
     let position? : Option Position := declRange?.map (·.pos)
     messages.reportedPlusUnreported.foldlM (init := env) fun env m => do
+      if let some entry := m.data.codeQualityEntry? then
+        return codeQualityLogExt.addEntry env entry
       unless m.data.isLinterMessage do
         return env
       let kind := m.data.kind

--- a/src/Lean/Message.lean
+++ b/src/Lean/Message.lean
@@ -221,9 +221,17 @@ def originatingSyntax? : MessageData → Option Syntax × MessageData
   | ofOriginatingSyntax stx msg => (some stx, msg)
   | msg => (none, msg)
 
-def codeQualityEntry? : MessageData → Option CodeQuality.Entry × MessageData
-  | ofCodeQualityEntry entry msg => (some entry, msg)
-  | msg => (none, msg)
+/--
+Extracts the code quality entry from a message produced by `Lean.Linter.logCodeQualityEntry`,
+looking through the context wrappers added by `logAt`/`addMessageContext`.
+-/
+partial def codeQualityEntry? : MessageData → Option CodeQuality.Entry
+  | ofCodeQualityEntry entry _    => some entry
+  | withContext _ msg             => codeQualityEntry? msg
+  | withNamingContext _ msg       => codeQualityEntry? msg
+  | tagged _ msg                  => codeQualityEntry? msg
+  | ofOriginatingSyntax _ msg     => codeQualityEntry? msg
+  | _                             => none
 
 def isTrace : MessageData → Bool
   | withContext _ msg         => msg.isTrace

--- a/src/Lean/Message.lean
+++ b/src/Lean/Message.lean
@@ -11,6 +11,7 @@ prelude
 public import Init.Data.Slice.Array
 public import Lean.Util.PPExt
 public import Lean.Util.Sorry
+public import Lean.Linter.CodeQuality.Basic
 import Init.Data.String.Search
 import Init.Data.Format.Macro
 import Init.Data.Iterators.Consumers.Collect
@@ -19,6 +20,8 @@ import Init.Data.String.Length
 public section
 
 namespace Lean
+
+open Linter
 
 /--
 Creates a string describing an error message `msg` produced at `pos`, optionally ending at `endPos`,
@@ -153,6 +156,10 @@ inductive MessageData where
   Preserves the originating syntax of the message.
   -/
   | ofOriginatingSyntax : Syntax → MessageData → MessageData
+  /-
+  Contains a code quality entry to be recorded
+  -/
+  | ofCodeQualityEntry : CodeQuality.Entry →  MessageData → MessageData
   deriving Inhabited, TypeName
 
 namespace MessageData
@@ -190,7 +197,8 @@ partial def hasTag : MessageData → Bool
   | compose msg₁ msg₂           => hasTag msg₁ || hasTag msg₂
   | tagged n msg                => p n || hasTag msg
   | trace data msg msgs         => p data.cls || hasTag msg || msgs.any hasTag
-  | ofOriginatingSyntax _ msg    => hasTag msg
+  | ofOriginatingSyntax _ msg   => hasTag msg
+  | ofCodeQualityEntry _ msg    => hasTag msg
   | _                           => false
 
 /--
@@ -205,11 +213,16 @@ def kind : MessageData → Name
   | withNamingContext _ msg   => kind msg
   | tagged n _                => n
   | trace data _ _            => data.cls
-  | ofOriginatingSyntax _ msg  => kind msg
+  | ofOriginatingSyntax _ msg => kind msg
+  | ofCodeQualityEntry _ msg  => kind msg
   | _                         => .anonymous
 
 def originatingSyntax? : MessageData → Option Syntax × MessageData
   | ofOriginatingSyntax stx msg => (some stx, msg)
+  | msg => (none, msg)
+
+def codeQualityEntry? : MessageData → Option CodeQuality.Entry × MessageData
+  | ofCodeQualityEntry entry msg => (some entry, msg)
   | msg => (none, msg)
 
 def isTrace : MessageData → Bool
@@ -217,7 +230,8 @@ def isTrace : MessageData → Bool
   | withNamingContext _ msg   => msg.isTrace
   | tagged _ msg              => msg.isTrace
   | .trace _ _ _              => true
-  | ofOriginatingSyntax _ msg  => msg.isTrace
+  | ofOriginatingSyntax _ msg => msg.isTrace
+  | ofCodeQualityEntry _ msg  => msg.isTrace
   | _                         => false
 
 /--
@@ -225,11 +239,12 @@ def isTrace : MessageData → Bool
 the resulting message preserves the kind (as given by `MessageData.kind`) of `msg`.
 -/
 def composePreservingKind : MessageData → MessageData → MessageData
-  | withContext ctx msg         , msg' => withContext ctx (composePreservingKind msg msg')
-  | withNamingContext nc msg    , msg' => withNamingContext nc (composePreservingKind msg msg')
-  | tagged t msg                , msg' => tagged t (compose msg msg')
-  | ofOriginatingSyntax stx msg  , msg' => ofOriginatingSyntax stx (composePreservingKind msg msg')
-  | msg                         , msg' => compose msg msg'
+  | withContext ctx msg           , msg' => withContext ctx (composePreservingKind msg msg')
+  | withNamingContext nc msg      , msg' => withNamingContext nc (composePreservingKind msg msg')
+  | tagged t msg                  , msg' => tagged t (compose msg msg')
+  | ofOriginatingSyntax stx msg   , msg' => ofOriginatingSyntax stx (composePreservingKind msg msg')
+  | ofCodeQualityEntry entry msg  , msg' => ofCodeQualityEntry entry (composePreservingKind msg msg')
+  | msg                           , msg' => compose msg msg'
 
 /-- An empty message. -/
 def nil : MessageData :=
@@ -358,7 +373,8 @@ where
   | group msg                 => visit mctx? msg
   | compose msg₁ msg₂         => visit mctx? msg₁ || visit mctx? msg₂
   | tagged _ msg              => visit mctx? msg
-  | ofOriginatingSyntax _ msg  => visit mctx? msg
+  | ofOriginatingSyntax _ msg => visit mctx? msg
+  | ofCodeQualityEntry _ msg  => visit mctx? msg
   | trace _ msg msgs          => visit mctx? msg || msgs.any (visit mctx?)
   | _                         => false
 
@@ -380,6 +396,7 @@ partial def formatAux : NamingContext → Option MessageDataContext → MessageD
   | _,    ctx,       withNamingContext nCtx d => formatAux nCtx ctx d
   | nCtx, ctx,       tagged _ d               => formatAux nCtx ctx d
   | nCtx, ctx,       ofOriginatingSyntax _ d              => formatAux nCtx ctx d
+  | nCtx, ctx,       ofCodeQualityEntry _ d              => formatAux nCtx ctx d
   | nCtx, ctx,       nest n d                 => Format.nest n <$> formatAux nCtx ctx d
   | nCtx, ctx,       compose d₁ d₂            => return (← formatAux nCtx ctx d₁) ++ (← formatAux nCtx ctx d₂)
   | nCtx, ctx,       group d                  => Format.group <$> formatAux nCtx ctx d
@@ -563,7 +580,8 @@ def MessageData.stripNestedTags : MessageData → MessageData
   | .withContext ctx msg => .withContext ctx msg.stripNestedTags
   | .withNamingContext ctx msg => .withNamingContext ctx msg.stripNestedTags
   | .tagged n msg => .tagged (stripNestedNamePrefix n) msg
-  | ofOriginatingSyntax stx msg => ofOriginatingSyntax stx msg.stripNestedTags
+  | .ofOriginatingSyntax stx msg => ofOriginatingSyntax stx msg.stripNestedTags
+  | .ofCodeQualityEntry entry msg => ofCodeQualityEntry entry msg.stripNestedTags
   | msg => msg
 where
   stripNestedNamePrefix : Name → Name

--- a/src/Lean/Widget/InteractiveDiagnostic.lean
+++ b/src/Lean/Widget/InteractiveDiagnostic.lean
@@ -150,7 +150,8 @@ where
   | _,        withContext ctx d        => go nCtx ctx d
   | ctx,      withNamingContext nCtx d => go nCtx ctx d
   | ctx,      tagged _ d               => go nCtx ctx d
-  | ctx,      ofOriginatingSyntax _ d   => go nCtx ctx d
+  | ctx,      ofOriginatingSyntax _ d  => go nCtx ctx d
+  | ctx,      ofCodeQualityEntry _ d   => go nCtx ctx d
   | ctx,      nest n d                 => Format.nest n <$> go nCtx ctx d
   | ctx,      compose d₁ d₂            => do let d₁ ← go nCtx ctx d₁; let d₂ ← go nCtx ctx d₂; pure $ d₁ ++ d₂
   | ctx,      group d                  => Format.group <$> go nCtx ctx d

--- a/tests/elab/code_quality_log.lean
+++ b/tests/elab/code_quality_log.lean
@@ -1,0 +1,74 @@
+import Lean
+
+open Lean Lean.Linter
+
+/-!
+## Tests for the persistent code quality log extension
+
+Code quality entries are logged by `Lean.Linter.logCodeQualityEntry` as silent messages carrying
+an `MessageData.ofCodeQualityEntry` constructor. `Lean.Linter.recordLints` extracts them and
+persists them into `codeQualityLogExt` (without position information), keeping them out of
+`lintLogExt`.
+-/
+
+/-- Build a message shaped like the output of `Linter.logCodeQualityEntry`, including the
+`.withContext` wrapper that `addMessageContext` adds in `logAt`. -/
+def mkCQMessage (e : CodeQuality.Entry) : CoreM Message := do
+  let data ← addMessageContext <| .ofCodeQualityEntry e <| .tagged codeQualityMessageTag .nil
+  return {
+    fileName := "Test.lean"
+    pos := ⟨1, 1⟩
+    severity := .information
+    isSilent := true
+    data
+  }
+
+/--
+Records a single code-quality-shaped message and returns the recorded entry names together with
+the size of the lint log, which must stay empty.
+-/
+def testRecordCodeQualityEntry : CoreM (Array String × Nat) := do
+  let e : CodeQuality.Entry :=
+    { name := "dummy_metric", source := .module `Test, value := .scalar 1.0 }
+  let log := MessageLog.empty.add (← mkCQMessage e)
+  let env ← Linter.recordLints default (← getEnv) #[(none, log)]
+  return ((codeQualityLogExt.getState env).map (·.name), (lintLogExt.getState env).size)
+
+/-- info: (#["dummy_metric"], 0) -/
+#guard_msgs in
+#eval testRecordCodeQualityEntry
+
+/-- Multiple entries across commands are recorded in log order. -/
+def testRecordCodeQualityEntryMultiple : CoreM (Array String) := do
+  let mk (name : String) : CoreM Message :=
+    mkCQMessage { name, source := .module `Test, value := .scalar 1.0 }
+  let log₁ := MessageLog.empty.add (← mk "a") |>.add (← mk "b")
+  let log₂ := MessageLog.empty.add (← mk "c")
+  let env ← Linter.recordLints default (← getEnv) #[(none, log₁), (none, log₂)]
+  return (codeQualityLogExt.getState env).map (·.name)
+
+/-- info: #["a", "b", "c"] -/
+#guard_msgs in
+#eval testRecordCodeQualityEntryMultiple
+
+/-- Linter warnings and plain messages must not be recorded as code quality entries. -/
+def testRecordCodeQualityIgnoresOthers : CoreM Nat := do
+  let lintMsg : Message := {
+    fileName := "Test.lean"
+    pos := ⟨1, 1⟩
+    severity := .warning
+    data := .tagged `linter.dummy (.tagged linterMessageTag m!"unused variable 'x'")
+  }
+  let plainMsg : Message := {
+    fileName := "Test.lean"
+    pos := ⟨1, 1⟩
+    severity := .error
+    data := m!"plain error"
+  }
+  let log := MessageLog.empty.add lintMsg |>.add plainMsg
+  let env ← Linter.recordLints default (← getEnv) #[(none, log)]
+  return (codeQualityLogExt.getState env).size
+
+/-- info: 0 -/
+#guard_msgs in
+#eval testRecordCodeQualityIgnoresOthers


### PR DESCRIPTION
This PR adds the infrastructure to collect code quality metrics from linters. Entries logged during elaboration are saved in the `.olean` file for the module. Build tools can then collect these entries for each module without re-elaborating the code.

A new `MessageData.ofCodeQualityEntry` constructor carries a `Linter.CodeQuality.Entry` through the message log. The `Lean.Linter.logCodeQualityEntry` function logs these messages as silent at information severity. As a result, they never show in CLI or editor output, and they do not interact with `warningAsError`. However, they still reach `Lean.Linter.recordLints`, which extracts the entries into the new `codeQualityLogExt` persistent environment extension.

This extension mirrors `lintLogExt`. Entries are exported at server visibility only and carry no position information. The `Lean.Linter.getAllCodeQualityEntries` function exposes the per-module entries to consumers. A follow-up PR will merge these entries into the `lake lint` code quality mode.
