### PR TITLE
fix: leak when the IR interpreter passes a borrowed scalar argument

### DIFF
--- a/src/Init/Data/Repr.lean
+++ b/src/Init/Data/Repr.lean
@@ -228,7 +228,7 @@ Examples:
  * `USize.repr 307 = "307"`
 -/
 @[extern "lean_string_of_usize"]
-protected def _root_.USize.repr (n : @& USize) : String :=
+protected def _root_.USize.repr (n : USize) : String :=
   String.ofList (toDigits 10 n.toNat)
 
 /-- We statically allocate and memoize reprs for small natural numbers. -/

--- a/src/library/ir_interpreter.cpp
+++ b/src/library/ir_interpreter.cpp
@@ -941,7 +941,7 @@ private:
             for (size_t i = 0; i < args.size(); i++) {
                 type t = param_type(decl_params(e.m_decl)[i]);
                 args2[i] = box_t(eval_arg(args[i]), t);
-                if (e.m_native.m_boxed && param_borrow(decl_params(e.m_decl)[i])) {
+                if (e.m_native.m_boxed && param_borrow(decl_params(e.m_decl)[i]) && !type_is_scalar(t)) {
                     // NOTE: If we chose the boxed version where the IR chose the unboxed one, we need to manually increment
                     // originally borrowed parameters because the wrapper will decrement these after the call.
                     // Basically the wrapper is more homogeneous (removing both unboxed and borrowed parameters) than we


### PR DESCRIPTION
This PR corrects a memory leak. The leak occurs when interpreted code calls a compiled function with a scalar parameter that is marked `@&`.

The interpreter cannot make an unboxed C call. It boxes every argument with `box_t` and calls the `_boxed` wrapper that the compiler emits:

```c
LEAN_EXPORT lean_object* l_usizeReprBorrowed___boxed(lean_object* n) {
  size_t n_unboxed = lean_unbox_usize(n);
  lean_dec(n);
  return lean_string_of_usize(n_unboxed);
}
```

The wrapper owns every parameter. Therefore the `lean_dec` is present for each parameter, with or without `@&` in the signature.

For an object parameter, `box_t` passes on a reference that the interpreted body owns. The interpreter increments that reference, because the wrapper consumes one.

For a scalar parameter, `box_t` allocates a new box. Only this call holds the box, and only the `lean_dec` in the wrapper frees it. Before this change, the interpreter incremented this box too. The box then outlived the call. The interpreter now increments object parameters only. `call_boxed` does the same.

A borrow annotation applies to references, and scalars are not reference counted. Borrow inference removes such an annotation from an ordinary definition. Inference keeps it on an `extern` signature. `USize.repr` had the only one in the library. Its removal keeps the emitted C identical.

Before this change, `#eval USize.repr 42` leaks 24 bytes on a build with the `sanitize` preset.
