### PR TITLE
refactor: one loop gadget per set of annotations a loop states

### DIFF
--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -210,43 +210,44 @@ private def mkForInPureWithInvariant (g : ForInApp) (invClause : TSyntax ``doLoo
     else ``Std.Internal.Do.Gadget.forInPureWithInvariant
   g.mkCall invClause gadget #[invLam]
 
-/-- Rebuild the loop of a `repeat` as a `forInLoopWithInvariantAndVariant` call carrying the
-`invariant` and `decreasing` clauses, either of which may be absent. Both clauses name the loop's
-mutable variables directly. The `invariant` clause is a function of the `Bool` that says whether the
-loop has left; the cursor's own payload is the state tuple, which the mutable variables already
-name. -/
-private def mkForInLoopWithInvariantAndVariant (g : ForInApp)
+/-- Rebuild the loop of a `repeat` as a call to the gadget carrying the annotations the loop states.
+Both clauses name the loop's mutable variables directly. The `invariant` clause is a function of the
+`Bool` that says whether the loop has left; the cursor's own payload is the state tuple, which the
+mutable variables already name. -/
+private def mkForInLoopGadget (g : ForInApp)
     (inv? : Option (TSyntax ``doLoopInvariant)) (dec? : Option (TSyntax ``doLoopDecreasing)) :
-    DoElabM Expr := do
+    DoElabM (Option Expr) := do
   let pred? ← assertionLanguage?
-  let invArg ← match inv? with
-    | none => `($(mkIdent ``Std.Internal.Do.Gadget.noInvariant))
-    | some invClause =>
-      let (binders, invBody) ← destructInvariant invClause
-      let exitBinder := binders[0]!
-      let assertionBinders := binders.drop 1
-      checkAssertionBinders invClause "invariant" assertionBinders.size pred?
-      let invBody ← mkAssertionFun assertionBinders invBody
-      let cursor := mkIdentFrom invClause (← mkFreshUserName `__c)
-      let invBody ← if exitBinder.raw.isOfKind ``hole then pure invBody else
-        let exitPat : Term := ⟨exitBinder.raw⟩
-        let hasLeft ← `($(mkIdent ``Sum.isRight) $cursor:ident)
-        `(match $hasLeft:term with | $exitPat => $invBody)
-      -- `RepeatInvariant.mk` keeps the clause's declared type on the term. A bare lambda carries
-      -- the unfolded type, and a specification's instance arguments are synthesized before the
-      -- check that would unfold it.
-      `(some ($(mkIdent ``Std.Internal.Do.RepeatInvariant.mk) $(← g.mkCursorFun cursor invBody)))
-  let varArg ← match dec? with
-    | none => `($(mkIdent ``Std.Internal.Do.Gadget.noMeasure))
-    | some decClause =>
-      let (binders, body) ← match decClause with
-        | `(doLoopDecreasing| decreasing $binders* => $body) => pure (binders, body)
-        | `(doLoopDecreasing| decreasing $measure:term) => pure (#[], measure)
-        | _ => throwUnsupportedSyntax
-      checkAssertionBinders decClause "measure" binders.size pred?
-      `(some $(← g.mkStateFun (← mkAssertionFun binders body)))
-  g.mkCall (inv?.map (·.raw) |>.getD (dec?.map (·.raw) |>.getD .missing))
-    ``Std.Internal.Do.Gadget.forInLoopWithInvariantAndVariant #[invArg, varArg]
+  let invArg? ← inv?.mapM fun invClause => do
+    let (binders, invBody) ← destructInvariant invClause
+    let exitBinder := binders[0]!
+    let assertionBinders := binders.drop 1
+    checkAssertionBinders invClause "invariant" assertionBinders.size pred?
+    let invBody ← mkAssertionFun assertionBinders invBody
+    let cursor := mkIdentFrom invClause (← mkFreshUserName `__c)
+    let invBody ← if exitBinder.raw.isOfKind ``hole then pure invBody else
+      let exitPat : Term := ⟨exitBinder.raw⟩
+      let hasLeft ← `($(mkIdent ``Sum.isRight) $cursor:ident)
+      `(match $hasLeft:term with | $exitPat => $invBody)
+    -- `RepeatInvariant.mk` keeps the clause's declared type on the term. A bare lambda carries the
+    -- unfolded type, and a specification's instance arguments are synthesized before the check that
+    -- would unfold it.
+    return ((invClause : Syntax), ← `($(mkIdent ``Std.Internal.Do.RepeatInvariant.mk)
+      $(← g.mkCursorFun cursor invBody)))
+  let varArg? ← dec?.mapM fun decClause => do
+    let (binders, body) ← match decClause with
+      | `(doLoopDecreasing| decreasing $binders* => $body) => pure (binders, body)
+      | `(doLoopDecreasing| decreasing $measure:term) => pure (#[], measure)
+      | _ => throwUnsupportedSyntax
+    checkAssertionBinders decClause "measure" binders.size pred?
+    return ((decClause : Syntax), ← g.mkStateFun (← mkAssertionFun binders body))
+  let some (ref, gadget, annotations) := (match invArg?, varArg? with
+    | some (ref, inv), some (_, var) =>
+      some (ref, ``Std.Internal.Do.Gadget.forInLoopWithInvariantAndVariant, #[inv, var])
+    | some (ref, inv), none => some (ref, ``Std.Internal.Do.Gadget.forInLoopWithInvariant, #[inv])
+    | none, some (ref, var) => some (ref, ``Std.Internal.Do.Gadget.forInLoopWithVariant, #[var])
+    | none, none => none) | return none
+  some <$> g.mkCall ref gadget annotations
 
 @[builtin_doElem_elab Lean.Parser.Term.doFor] def elabDoFor : DoElab := fun stx dec => do
   let `(doFor| for%$tk $[$h? : ]? $x:ident in $xs
@@ -355,7 +356,7 @@ private def mkForInLoopWithInvariantAndVariant (g : ForInApp)
     let g : ForInApp :=
       { xs, init := preS, body, σ, statePat := ← mkStatePat loopMutVars info.returnsEarly }
     if (← instantiateMVars ρ).isConstOf ``Lean.Loop then
-      forIn ← mkForInLoopWithInvariantAndVariant g inv? dec?
+      if let some e ← mkForInLoopGadget g inv? dec? then forIn := e
     else if let some decClause := dec? then
       throwErrorAt decClause "A `for` loop terminates with the collection it iterates; \
         `decreasing` states the termination measure of a `repeat` or `while` loop."

--- a/src/Std/Internal/Do/Gadget/ForIn.lean
+++ b/src/Std/Internal/Do/Gadget/ForIn.lean
@@ -16,9 +16,9 @@ public import Std.Internal.ForIn
 invariant so that `vcgen` reads the invariant from the program. Their `@[spec]` specifications
 restate `Spec.forIn_list`/`Spec.forIn'_list` for every container with a `PureForIn` instance.
 
-`forInLoopWithInvariantAndVariant` does the same for a `repeat` loop, carrying an invariant and a
-termination measure, either of which may be absent. Its specifications restate `Spec.forIn_loop`,
-one per combination a loop annotation produces, leaving an absent annotation to `vcgen` to infer.
+`forInLoopWithInvariant`, `forInLoopWithVariant` and `forInLoopWithInvariantAndVariant` do the same
+for a `repeat` loop, one per set of annotations the loop states. Each restates `Spec.forIn_loop`,
+leaving what the loop does not state to `vcgen` to infer.
 -/
 
 @[expose] public section
@@ -113,21 +113,34 @@ universe uₚ uₑ uq uγ uf
 namespace Gadget
 
 set_option linter.unusedVariables false in
+/-- A `repeat` loop annotated with the loop invariant that `vcgen` reads from the `inv` argument.
+It is definitionally `forIn l init f`, so the annotation is erased at runtime. The invariant ranges
+over the loop's cursor, `.inl` while the loop iterates and `.inr` once it is done. -/
+@[inline] def forInLoopWithInvariant {β : Type u} {m : Type u → Type v} {Pred : Type uₚ}
+    [Monad m] (l : Lean.Loop) (init : β) (f : Unit → β → m (ForInStep β))
+    (inv : RepeatInvariant β β Pred) : m β :=
+  forIn l init f
+
+set_option linter.unusedVariables false in
+/-- A `repeat` loop annotated with the termination measure that `vcgen` reads from the `var`
+argument. It is definitionally `forIn l init f`, so the annotation is erased at runtime. The measure
+is the function a `RepeatVariant` is built from, so that the assertion language it evaluates in is
+the one the specification is applied at. -/
+@[inline] def forInLoopWithVariant {β : Type u} {m : Type u → Type v} {Fun : Type}
+    [Monad m] (l : Lean.Loop) (init : β) (f : Unit → β → m (ForInStep β))
+    (var : β → Fun) : m β :=
+  forIn l init f
+
+set_option linter.unusedVariables false in
 /-- A `repeat` loop annotated with the loop invariant and the termination measure that `vcgen` reads
-from the `inv?` and `var?` arguments. It is definitionally `forIn l init f`, so the annotations are
+from the `inv` and `var` arguments. It is definitionally `forIn l init f`, so the annotations are
 erased at runtime. The invariant ranges over the loop's cursor, `.inl` while the loop iterates and
 `.inr` once it is done. The measure is the function a `RepeatVariant` is built from, so that the
 assertion language it evaluates in is the one the specification is applied at. -/
 @[inline] def forInLoopWithInvariantAndVariant {β : Type u} {m : Type u → Type v} {Pred : Type uₚ}
     {Fun : Type} [Monad m] (l : Lean.Loop) (init : β) (f : Unit → β → m (ForInStep β))
-    (inv? : Option (RepeatInvariant β β Pred)) (var? : Option (β → Fun)) : m β :=
+    (inv : RepeatInvariant β β Pred) (var : β → Fun) : m β :=
   forIn l init f
-
-/-- The invariant slot of a loop that states only its measure, whose assertion language is `Prop`. -/
-def noInvariant {β : Type u} : Option (RepeatInvariant β β Prop) := none
-
-/-- The measure slot of a loop that states only its invariant, whose codomain is `Unit`. -/
-def noMeasure {β : Type u} : Option (β → Unit) := none
 
 end Gadget
 
@@ -152,7 +165,7 @@ theorem Spec.forInLoop_invariant_variant {Fun : Type} {γ : Type uγ'}
           | .done b' => inv (.inr b'))
         einv) :
     Triple
-      (forInLoopWithInvariantAndVariant l init f (some (RepeatInvariant.mk inv)) (some measure))
+      (forInLoopWithInvariantAndVariant l init f (RepeatInvariant.mk inv) measure)
       (inv (.inl init))
       (fun b => inv (.inr b))
       einv := by
@@ -175,11 +188,11 @@ theorem Spec.forInLoop_invariant
           | .done b' => inv (.inr b'))
         einv) :
     Triple
-      (forInLoopWithInvariantAndVariant l init f (some (RepeatInvariant.mk inv)) noMeasure)
+      (forInLoopWithInvariant l init f (RepeatInvariant.mk inv))
       (inv (.inl init))
       (fun b => inv (.inr b))
       einv := by
-  unfold forInLoopWithInvariantAndVariant
+  unfold forInLoopWithInvariant
   exact Spec.forIn_loop measure inv einv step
 
 @[spec]
@@ -199,11 +212,11 @@ theorem Spec.forInLoop_variant {Fun : Type} {γ : Type uγ'}
           | .done b' => inv (.inr b'))
         einv) :
     Triple
-      (forInLoopWithInvariantAndVariant l init f noInvariant (some measure))
+      (forInLoopWithVariant l init f measure)
       (inv (.inl init))
       (fun b => inv (.inr b))
       einv := by
-  unfold forInLoopWithInvariantAndVariant
+  unfold forInLoopWithVariant
   exact Spec.forIn_loop (RepeatVariant.ofMeasure measure) inv einv step
 
 end Loop


### PR DESCRIPTION
This PR gives a `repeat` or `while` loop one gadget per set of annotations it states, `forInLoopWithInvariant`, `forInLoopWithVariant` or `forInLoopWithInvariantAndVariant`, replacing a single gadget that carried both annotations in `Option` slots.