### PR TITLE
test: a loop over an iterator states its invariant

### DIFF
--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -194,6 +194,43 @@ def sumValues (m : Std.HashMap Nat Nat) : Id Nat
 #guard_msgs (drop info) in
 #check @sumValues.spec
 
+/-! ## A loop over an iterator, and over the iterators a combinator builds
+
+An iterator is a container like any other: it has a `PureForIn` instance, and a combinator returns
+an iterator, so one instance covers `map` and `filter` too. -/
+
+def sumIter (xs : List Nat) : Id Nat
+    ensures r => r = xs.sum := do
+  let mut s := 0
+  for x in xs.iter invariant pref _suff => s = pref.sum do
+    s := s + x
+  return s
+where finally
+  | spec => all_goals grind
+
+#guard_msgs (drop info) in
+#check @sumIter.spec
+
+def sumIterMap (xs : List Nat) : Id Nat
+    ensures r => 0 ≤ r := do
+  let mut s := 0
+  for x in xs.iter.map (· + 1) invariant _pref _suff => 0 ≤ s do
+    s := s + x
+  return s
+
+#guard_msgs (drop info) in
+#check @sumIterMap.spec
+
+def sumIterFilter (xs : List Nat) : Id Nat
+    ensures r => 0 ≤ r := do
+  let mut s := 0
+  for x in xs.iter.filter (· > 2) invariant _pref _suff => 0 ≤ s do
+    s := s + x
+  return s
+
+#guard_msgs (drop info) in
+#check @sumIterFilter.spec
+
 /-! A loop over several collections takes no invariant. -/
 
 /-- error: The `invariant` clause takes a `for` loop over a single collection. -/

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -205,8 +205,6 @@ def sumIter (xs : List Nat) : Id Nat
   for x in xs.iter invariant pref _suff => s = pref.sum do
     s := s + x
   return s
-where finally
-  | spec => all_goals grind
 
 #guard_msgs (drop info) in
 #check @sumIter.spec


### PR DESCRIPTION
This PR covers the `invariant` clause on a loop over an iterator, which reaches it through the `PureForIn` instance every finite iterator has, and on the iterators that `map` and `filter` build. `sumIter` names the elements consumed so far and proves its contract with `grind`.