### PR TITLE
doc: fix imprecision in IO.FS.Stream.getLine and IO.FS.Handle.getLine

### DIFF
--- a/src/Init/System/IO.lean
+++ b/src/Init/System/IO.lean
@@ -720,7 +720,7 @@ structure FS.Stream where
   /--
   Reads text up to and including the next newline from the stream.
 
-  If the returned string is empty, an end-of-file marker (EOF) has been reached.
+  If the returned string does not end with a newline, an end-of-file marker (EOF) has been reached.
   An EOF does not actually close a stream, so further reads may block and return more data.
   -/
   getLine : IO String
@@ -855,7 +855,7 @@ Writing to a handle is typically buffered, and may not immediately modify the fi
 
 /--
 Reads UTF-8-encoded text up to and including the next line break from the handle. If the returned
-string is empty, an end-of-file marker (EOF) has been reached.
+string does not end with a line break, an end-of-file marker (EOF) has been reached.
 
 Encountering an EOF does not close a handle. Subsequent reads may block and return more data.
 -/


### PR DESCRIPTION
This PR fixes imprecise documentation for `IO.FS.Stream.getLine` and `IO.FS.Handle.getLine`. If the stream does not end with a newline (or line break), then `getLine` will return a `String` that does not end with a newline. Reciprocally, this situation can only occur when reaching an EOF.

Note that the documentation of `read` does not necessarily need to be similarly updated. This is because `read` will always emit an empty array, even after a partially filled array.

This is based on testing only, not necessarily intent of the code. Here are reproduction steps:

```lean4
def main : IO Unit := do
  repeat do
    let line ← (← IO.getStdin).getLine
    IO.println s!"XXX{line}YYY"
```

Running with the following input where `%` indicates EOF (e.g. using Ctrl-D if there was no input since last newline or EOF, or using Ctrl-D twice there was: once to flush the buffer and once to indicate EOF):

```
hello

foo%%
```

gives the following output (when `YYY` does not start a line, it means `getLine` did not end with a newline):

```
XXXhello
YYY
XXX
YYY
XXXfooYYY
XXXYYY
```
