### PR TITLE
doc: fix typo in example of SourceInfo.synthetic

### DIFF
--- a/src/Init/Prelude.lean
+++ b/src/Init/Prelude.lean
@@ -4875,7 +4875,7 @@ inductive SourceInfo where
   binders, as in the macro expansion for dependent if:
   ```
   `(if $h : $cond then $t else $e) ~>
-  `(dite $cond (fun $h => $t) (fun $h => $t))
+  `(dite $cond (fun $h => $t) (fun $h => $e))
   ```
   In these cases, if the user hovers over `h` they will see information about both binding sites.
   -/


### PR DESCRIPTION
This PR fixes a typo in the documentation of `SourceInfo.synthetic`.