### PR TITLE
chore: dynamically link test binaries

### DIFF
--- a/tests/compile/run_test.sh
+++ b/tests/compile/run_test.sh
@@ -14,12 +14,20 @@ elif [[ -f "$1.no_interpret" ]]; then DO_INTERPRET=
 else DO_INTERPRET=1
 fi
 
+# Link against `libleanshared` instead of the static Lean libraries. This massively reduces disk
+# space by avoiding to build one static binary with all of Lean per test.
+LEANC_SHARED_ARGS=(-leanshared -lleanshared)
+if [[ "$OSTYPE" != "cygwin" && "$OSTYPE" != "msys" ]]; then
+  # Windows locates the DLLs via `PATH`, everywhere else the binary needs an `rpath`.
+  LEANC_SHARED_ARGS+=(-Wl,-rpath,"$BUILD_DIR/lib/lean")
+fi
+
 if [[ -n $DO_COMPILE ]]; then
   echo "Compiling and executing lean file"
   run_before "$1"
 
   lean --c="$1.c" -Dcompiler.postponeCompile=false "${TEST_LEAN_ARGS[@]}" "$1" || fail "Failed to compile $1 into $1.c"
-  leanc ${LEANC_OPTS-} -O3 -DNDEBUG -o "$1.out" "${TEST_LEANC_ARGS[@]}" "$1.c" || fail "Failed to compile $1.c"
+  leanc ${LEANC_OPTS-} -O3 -DNDEBUG -o "$1.out" "${TEST_LEANC_ARGS[@]}" "$1.c" "${LEANC_SHARED_ARGS[@]}" || fail "Failed to compile $1.c"
 
   capture_only "$1" \
     "./$1.out" "${TEST_ARGS[@]}"


### PR DESCRIPTION
This PR makes the `test/compile` binaries link dynamically so they don't take up large amounts of
disk space.
