### PR TITLE
fix: keep a schematic exception postcondition when applying a spec

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/RuleConstruction.lean
@@ -222,8 +222,12 @@ private def mkSpecBackwardProof
     /- if `epost` is `⊥`, then `epost ⊑ epostAbstract` holds trivially and
       abstracting `epost` can be simply done by `WP.wp_econs_bot_le` without
       introducing a new premise. This case is quite common, that's why we handle
-      it specially. -/
-    let isBot ← try
+      it specially.
+      The test runs at a fresh metavariable depth, where a schematic component of
+      `epost` such as `E` in `epost⟨E⟩` is read-only. `decomposeEPostRel` below
+      assigns `E` the matching component of `epostAbstract`. -/
+    let isBot ← withNewMCtxDepth do
+      try
         let botEPost ← mkAppOptM ``Lean.Order.bot #[epostTy, none]
         isDefEqGuarded epostSpec botEPost
       catch _ => pure false

--- a/tests/elab/vcgenSchematicEPost.lean
+++ b/tests/elab/vcgenSchematicEPost.lean
@@ -1,0 +1,41 @@
+import Std.Tactic.Do
+import Std.Internal.Do
+
+/-!
+Tests that `vcgen` keeps the exception postcondition of a spec that states it as `epost⟨E⟩` with `E`
+schematic, and that a spec stating `⊥` still weakens without emitting an exception postcondition
+verification condition.
+-/
+
+set_option mvcgen.warning false
+open Std.Internal.Do Lean.Order
+
+abbrev M := ExceptT String Id
+
+axiom Q : String → Prop
+
+def boom : M Unit := throw "boom"
+
+def boom' : M Unit := throw "boom"
+
+def boomBot : M Unit := throw "boom"
+
+/-- Exception postcondition stated as `epost⟨E⟩` with `E` schematic. -/
+@[spec] theorem boom_spec {E : String → Prop} :
+    ⦃E "boom"⦄ boom ⦃fun _ => True; epost⟨E⟩⦄ := ⟨PartialOrder.rel_refl⟩
+
+/-- Exception postcondition stated as a whole schematic `EPost`. -/
+@[spec] theorem boom'_spec {E : EPost⟨String → Prop⟩} :
+    ⦃E.head "boom"⦄ boom' ⦃fun _ => True; E⦄ := ⟨PartialOrder.rel_refl⟩
+
+/-- Exception postcondition stated as `⊥`. -/
+@[spec] axiom boomBot_spec : ⦃True⦄ boomBot ⦃fun _ => True; ⊥⦄
+
+example : ⦃Q "boom"⦄ boom ⦃fun _ => True; epost⟨Q⟩⦄ := by
+  vcgen
+
+example : ⦃Q "boom"⦄ boom' ⦃fun _ => True; epost⟨Q⟩⦄ := by
+  vcgen
+
+example : ⦃True⦄ boomBot ⦃fun _ => True; epost⟨Q⟩⦄ := by
+  vcgen


### PR DESCRIPTION
This PR makes `vcgen` keep the exception postcondition of a `@[spec]` theorem that states it as ``epost⟨E⟩`` with `E` schematic. Such a spec was applied with its exception postcondition weakened to `⊥`, leaving the verification condition `⊥`.

`mkSpecBackwardProof` tests the spec's exception postcondition against `⊥` to take the `WP.wp_econs_bot_le` shortcut. The test ran at the metavariable depth at which the spec theorem was instantiated, so on ``epost⟨?E⟩`` it succeeded by assigning `?E := ⊥`. It now runs at a fresh metavariable depth, where `?E` is read-only. `decomposeEPostRel` then assigns `?E` the matching component of the abstracted exception postcondition, so the spec applies with the exception postcondition of the goal.
