### PR TITLE
test: state what the VERINA loops maintain

### DIFF
--- a/tests/elab_bench/verina.lean
+++ b/tests/elab_bench/verina.lean
@@ -530,13 +530,30 @@ namespace P_findEvenNumbers
 def isEvenInt (x : Int) : Bool :=
   x % 2 = 0
 
+/-- `idx` witnesses that `sub` is a subsequence of `arr`: it lists, in increasing order, the
+positions of `arr` that `sub` collects. The loop maintains this witness, so it is named rather than
+left under the existential of `Array.Sublist`, and carries no `grind` attribute: unfolding it makes
+every pair of index reads a candidate instantiation. -/
+def IsSublistWitness (arr : Array Int) (sub : Array Int) (idx : Array Nat) : Prop :=
+  idx.size = sub.size ∧
+  (∀ i, i < idx.size → idx[i]! < arr.size) ∧
+  (∀ i, i < idx.size → sub[i]! = arr[idx[i]!]!) ∧
+  (∀ i j, i < j → j < idx.size → idx[i]! < idx[j]!)
+
+/-- The empty witness. -/
+@[local grind]
+theorem IsSublistWitness.empty (arr : Array Int) : IsSublistWitness arr #[] #[] := sorry
+
+/-- Extending the witness by a position past every position it already holds. -/
+@[local grind]
+theorem IsSublistWitness.push {arr sub : Array Int} {idx : Array Nat} {k : Nat}
+    (h : IsSublistWitness arr sub idx) (hk : k < arr.size)
+    (hmax : ∀ i, i < idx.size → idx[i]! < k) :
+    IsSublistWitness arr (sub.push arr[k]!) (idx.push k) := sorry
+
 @[local grind]
 def Array.Sublist (arr : Array Int) (sub : Array Int) : Prop :=
-  ∃ indices : Array Nat,
-    indices.size = sub.size ∧
-    (∀ i, i < indices.size → indices[i]! < arr.size) ∧
-    (∀ i, i < indices.size → sub[i]! = arr[indices[i]!]!) ∧
-    (∀ i j, i < j → j < indices.size → indices[i]! < indices[j]!)
+  ∃ idx, IsSublistWitness arr sub idx
 
 @[local grind =]
 theorem count_extract_succ [DecidableEq α] [Inhabited α] {a : α} {xs : Array α} {n : Nat}
@@ -573,11 +590,8 @@ theorem findEvenNumbers_spec (arr : Array Int) :
       (∀ x, x ∈ result → isEvenInt x = true) ∧
       (∀ x, isEvenInt x = false → result.count x = 0) ∧
       (∀ x, isEvenInt x = true → result.count x = (arr.extract 0 xpref.length).count x) ∧
-      indices.size = result.size ∧
-      (∀ k, k < indices.size → indices[k]! < xpref.length) ∧
-      (∀ k, k < indices.size → indices[k]! < arr.size) ∧
-      (∀ k, k < indices.size → result[k]! = arr[indices[k]!]!) ∧
-      (∀ k j, k < j → j < indices.size → indices[k]! < indices[j]!)
+      IsSublistWitness arr result indices ∧
+      (∀ k, k < indices.size → indices[k]! < xpref.length)
   case vc3 => sorry
   case vc4 => sorry
   all_goals grind [Array.count_push, getElem!_push, count_extract_succ, Array.extract_size_self, -Array.extract_eq_pop, -Nat.min_def]
@@ -768,9 +782,20 @@ end P_isSublist
 
 namespace P_mergeSorted
 
-@[local grind]
+/-- Sortedness carries no `grind` attribute: it is reached through the lemmas below rather than by
+unfolding, which would make every pair of array reads a candidate instantiation. -/
 def isSorted (arr : Array Nat) : Prop :=
   ∀ i j : Nat, i < j → j < arr.size → arr[i]! ≤ arr[j]!
+
+/-- Every element of `xs` is at most `v`. Named for the same reason as `isSorted`. -/
+def AllLE (xs : Array Nat) (v : Nat) : Prop :=
+  ∀ p, p < xs.size → xs[p]! ≤ v
+
+@[local grind]
+theorem isSorted_empty : isSorted #[] := sorry
+
+@[local grind]
+theorem AllLE_empty (v : Nat) : AllLE #[] v := sorry
 
 @[local grind]
 theorem isSorted_le (arr : Array Nat) (i : Nat) :
@@ -801,13 +826,13 @@ theorem getElem!_push_eq {α} [Inhabited α] (xs : Array α) (x : α) :
 @[local grind]
 theorem isSorted_push' (result : Array Nat) (v : Nat)
     (hs : isSorted result)
-    (hall : ∀ p, p < result.size → result[p]! ≤ v) :
+    (hall : AllLE result v) :
     isSorted (result.push v) := sorry
 
 @[local grind]
 theorem push_all_le (result : Array Nat) (v w : Nat)
-    (hall : ∀ p, p < result.size → result[p]! ≤ w) (hvw : v ≤ w) :
-    ∀ p, p < (result.push v).size → (result.push v)[p]! ≤ w := sorry
+    (hall : AllLE result w) (hvw : v ≤ w) :
+    AllLE (result.push v) w := sorry
 def mergeSorted (a1 : Array Nat) (a2 : Array Nat) : Id (Array Nat) := do
   let mut result : Array Nat := #[]
   let mut i : Nat := 0
@@ -839,8 +864,8 @@ theorem mergeSorted_spec (a1 : Array Nat) (a2 : Array Nat) :
       result.size = i + j ∧ result.size = xpref.length ∧
       isSorted result ∧
       (∀ v : Nat, result.count v = (a1.extract 0 i).count v + (a2.extract 0 j).count v) ∧
-      (i < a1.size → ∀ p, p < result.size → result[p]! ≤ a1[i]!) ∧
-      (j < a2.size → ∀ p, p < result.size → result[p]! ≤ a2[j]!)
+      (i < a1.size → AllLE result a1[i]!) ∧
+      (j < a2.size → AllLE result a2[j]!)
   case vc3 => sorry
   case vc4 => sorry
   case vc5 => sorry


### PR DESCRIPTION
This PR names the predicates that two VERINA loops maintain, so their verification conditions are reached through lemmas rather than by unfolding a quantified body. `findEvenNumbers` states `IsSublistWitness arr result indices`, the body of the existential that `Array.Sublist` asserts, with an intro and an extension lemma; `mergeSorted` states `AllLE result a1[i]!` for the bound its result respects, and `isSorted` keeps the lemmas that already characterize it instead of its `grind` attribute.

Unfolding either predicate makes every pair of array reads a candidate instantiation, which is what the invariants were paying for: `findEvenNumbers` spent 9.7s and `mergeSorted` 8.8s of a 26.4s file before `@[spec]` stopped serializing elaboration. With that fixed the file is 3.56s, and this brings it to 3.20s while cutting the work itself, 15.6s of CPU to 14.0s.