### PR TITLE
fix: ignore heterogeneous equalities in `grind hom` solver hooks

### DIFF
--- a/src/Lean/Meta/Tactic/Grind/Homomorphism.lean
+++ b/src/Lean/Meta/Tactic/Grind/Homomorphism.lean
@@ -136,6 +136,9 @@ because no union takes place.
 -/
 def processNewEq (a b : Expr) : GoalM Unit := do
   unless (← getConfig).hom do return ()
+  -- `a` and `b` may have different types when their classes were merged via `HEq`
+  -- (e.g., `BitVec.cast` terms). The `=`-injection applies only to homogeneous equalities.
+  unless (← hasSameType a b) do return ()
   let eq ← shareCommon (← mkEq a b)
   let some (t, hEqProp) ← applyHomo? eq | return ()
   let fact ← mkEqMP hEqProp (← mkEqProof a b)
@@ -153,6 +156,8 @@ homomorphism.
 -/
 def processNewDiseq (a b : Expr) : GoalM Unit := do
   unless (← getConfig).hom do return ()
+  -- See the same-type check at `processNewEq`.
+  unless (← hasSameType a b) do return ()
   let eq ← shareCommon (← mkEq a b)
   let some (t, hEqProp) ← applyHomo? eq | return ()
   let hne ← mkDiseqProof a b

--- a/tests/elab_bench/grind_bitvec2.lean
+++ b/tests/elab_bench/grind_bitvec2.lean
@@ -3998,7 +3998,11 @@ theorem replicate_append_self {x : BitVec w} :
     conv => lhs; rw [ih]
     simp only [BitVec.cast_cast, BitVec.cast_eq]
     rw [← cast_append_left]
-    · grind
+    -- The goal needs the exponent identity `w + w * n = w * (n + 1)` to relate
+    -- `2 ^ _` terms in the `toNat` images of the appends. `grind` finds it only via a
+    -- model-based theory combination case split, and the homomorphism encoding produces
+    -- enough competing exponent-pair candidates that the default split budget is too small.
+    · grind (splits := 11)
     · rw [Nat.add_comm, Nat.mul_add, Nat.mul_one]; omega
 
 theorem replicate_succ' {x : BitVec w} :

--- a/tests/elab_bench/grind_bitvec2.lean
+++ b/tests/elab_bench/grind_bitvec2.lean
@@ -719,8 +719,6 @@ theorem toNat_eq_nat {x : BitVec w} {y : Nat} :
   · intro eq
     simp [Nat.mod_eq_of_lt, eq]
 
-grind_pattern toNat_eq_nat => BitVec.ofNat w y, x.toNat
-
 /-- Moves one-sided right toNat equality to BitVec equality. -/
 theorem nat_eq_toNat {x : BitVec w} {y : Nat} :
     (y = x.toNat) ↔ (y < 2^w ∧ (x = BitVec.ofNat w y)) := by


### PR DESCRIPTION
This PR fixes an internal `grind` error (`mkEqProof` invoked with terms of different types). An equivalence class can contain terms of different types when they are merged via `HEq` (e.g., `BitVec` terms of different widths related through `cast` terms). The `=`-injection performed by the `[grind hom]` hooks applies only to homogeneous equalities, so `processNewEq` and `processNewDiseq` now skip pairs whose types differ.

It also repairs the `grind_bitvec2` benchmark, which was broken by the eager homomorphism encoding: it removes a redundant `grind_pattern` subsumed by `[grind hom]` whose instances were exhausting the case-split budget, and increases the split budget in one proof that needs a model-based theory combination case split to find the exponent identity `w + w * n = w * (n + 1)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)