### PR TITLE
perf: drop borrow annotations from scalar IR parameters

### DIFF
--- a/src/Lean/Compiler/IR/Basic.lean
+++ b/src/Lean/Compiler/IR/Basic.lean
@@ -207,7 +207,6 @@ inductive Expr where
 
 structure Param where
   x : VarId
-  /-- Whether the caller keeps ownership of the argument. Scalar parameters are owned. -/
   borrow : Bool
   ty : IRType
   deriving Inhabited, Repr

--- a/src/Lean/Compiler/IR/Basic.lean
+++ b/src/Lean/Compiler/IR/Basic.lean
@@ -207,6 +207,7 @@ inductive Expr where
 
 structure Param where
   x : VarId
+  /-- Whether the caller keeps ownership of the argument. Scalar parameters are owned. -/
   borrow : Bool
   ty : IRType
   deriving Inhabited, Repr

--- a/src/Lean/Compiler/IR/ToIR.lean
+++ b/src/Lean/Compiler/IR/ToIR.lean
@@ -73,7 +73,7 @@ def lowerArg (a : LCNF.Arg .impure) : M Arg := do
 def lowerParam (p : LCNF.Param .impure) : M Param := do
   let x ← bindVar p.fvarId
   let ty := toIRType p.type
-  return { x, borrow := p.borrow, ty }
+  return { x, borrow := p.borrow && !ty.isScalar, ty }
 
 @[inline]
 def lowerCtorInfo (i : LCNF.CtorInfo) : CtorInfo :=

--- a/src/library/ir_interpreter.cpp
+++ b/src/library/ir_interpreter.cpp
@@ -941,11 +941,14 @@ private:
             for (size_t i = 0; i < args.size(); i++) {
                 type t = param_type(decl_params(e.m_decl)[i]);
                 args2[i] = box_t(eval_arg(args[i]), t);
-                if (e.m_native.m_boxed && param_borrow(decl_params(e.m_decl)[i]) && !type_is_scalar(t)) {
+                if (e.m_native.m_boxed && param_borrow(decl_params(e.m_decl)[i])) {
                     // NOTE: If we chose the boxed version where the IR chose the unboxed one, we need to manually increment
                     // originally borrowed parameters because the wrapper will decrement these after the call.
                     // Basically the wrapper is more homogeneous (removing both unboxed and borrowed parameters) than we
                     // would need in this instance.
+                    // A scalar parameter would break this: `box_t` allocates a box that this call alone owns and the
+                    // wrapper's decrement frees. `Lean.IR.ToIR.lowerParam` establishes that such a parameter is owned.
+                    lean_assert(!type_is_scalar(t));
                     inc(args2[i]);
                 }
             }

--- a/tests/elab/externBorrowedScalar.lean
+++ b/tests/elab/externBorrowedScalar.lean
@@ -1,0 +1,9 @@
+module
+
+/-! A borrow annotation on a scalar parameter of an `[extern]` declaration is dropped in the IR. -/
+
+set_option trace.compiler.ir.result true
+
+@[extern "lean_string_of_usize"]
+def usizeReprBorrowed (n : @& USize) : String :=
+  ""

--- a/tests/elab/externBorrowedScalar.lean.out.expected
+++ b/tests/elab/externBorrowedScalar.lean.out.expected
@@ -1,0 +1,7 @@
+[Compiler.IR] [result]
+    extern _private.elab.externBorrowedScalar.0.usizeReprBorrowed (x_1 : usize) : obj
+    def _private.elab.externBorrowedScalar.0.usizeReprBorrowed._boxed (x_1 : tobj) : obj :=
+      let x_2 : usize := unbox x_1;
+      dec x_1;
+      let x_3 : obj := _private.elab.externBorrowedScalar.0.usizeReprBorrowed x_2;
+      ret x_3


### PR DESCRIPTION
This PR restores the interpreter's argument-passing path to the form it had before #14749, which regressed some benchmarks. A borrow annotation on a scalar parameter carries no information, and `Lean.IR.ToIR.lowerParam` now drops it. The interpreter can therefore assume that every borrowed parameter is a reference, and the test that #14749 added at each argument becomes a `lean_assert`.