### PR TITLE
refactor: state the frame closure over `PredTrans` and move both to the order library

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Internal/VCGen/LatticeOp.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal/VCGen/LatticeOp.lean
@@ -9,7 +9,7 @@ prelude
 public import Lean.Meta.Sym.Apply
 public import Std.Internal.Order.Heyting
 public import Lean.Elab.Tactic.Do.Internal.VCGen.FrameProc
-import Std.Internal.Do.WP.Frame
+import Std.Internal.Order.FrameClosure
 import Lean.Meta.Sym.Simp.Rewrite
 import Lean.Meta.AppBuilder
 import Lean.Meta.AbstractMVars
@@ -129,7 +129,7 @@ private partial def mkPointFrameApply (introThm : Name) (opAs pre : Expr) (ss : 
       let ofp ← mkAppOptM ``Lean.Order.CompleteLattice.ofProp #[preTy, none, ← mkEq u s]
       mkLambdaFVars #[u] (← mkAppM ``Lean.Order.meet #[ofp, pre])
     let h ← mkPointFrameApply introThm opAs gate init
-    mkAppM ``Std.Internal.Do.le_apply_of_point_meet_le #[s, pre, Q, h]
+    mkAppM ``Lean.Order.le_apply_of_point_meet_le #[s, pre, Q, h]
 
 /--
 Build a reusable backward rule decomposing `pre ⊑ op … s⃗` for a lattice operator. The operator's

--- a/src/Std/Internal/Do/ExceptPost.lean
+++ b/src/Std/Internal/Do/ExceptPost.lean
@@ -54,21 +54,39 @@ attribute [simp] EPost.Cons.head EPost.Cons.tail
 
 /-- Push an `Except ε α` result into separate normal and exception postconditions:
 `ok a` uses `post a`, and `error e` uses `epost.head e`. -/
-@[simp]
-abbrev EPost.Cons.pushExcept {α : Type u} {ε : Type v} {Pred : Type w} {EPred : Type z}
+def EPost.Cons.pushExcept {α : Type u} {ε : Type v} {Pred : Type w} {EPred : Type z}
     (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) : Except ε α → Pred :=
   fun
   | .ok a => post a
   | .error e => epost.head e
 
+/-- A normal result uses the normal postcondition. -/
+@[simp, grind =] theorem EPost.Cons.pushExcept_ok {α : Type u} {ε : Type v} {Pred : Type w}
+    {EPred : Type z} (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) (a : α) :
+    epost.pushExcept post (.ok a) = post a := rfl
+
+/-- An exceptional result uses the head exception postcondition. -/
+@[simp, grind =] theorem EPost.Cons.pushExcept_error {α : Type u} {ε : Type v} {Pred : Type w}
+    {EPred : Type z} (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) (e : ε) :
+    epost.pushExcept post (.error e) = epost.head e := rfl
+
 /-- Push an `Option α` result into separate normal and none postconditions:
 `some a` uses `post a`, and `none` uses `epost.head`. -/
-@[simp]
-abbrev EPost.Cons.pushOption {α : Type u} {Pred : Type u} {EPred : Type v}
+def EPost.Cons.pushOption {α : Type u} {Pred : Type u} {EPred : Type v}
     (post : α → Pred) (epost : EPost.Cons Pred EPred) : Option α → Pred :=
   fun
   | .some a => post a
   | .none => epost.head
+
+/-- A present result uses the normal postcondition. -/
+@[simp, grind =] theorem EPost.Cons.pushOption_some {α : Type u} {Pred : Type u} {EPred : Type v}
+    (post : α → Pred) (epost : EPost.Cons Pred EPred) (a : α) :
+    epost.pushOption post (.some a) = post a := rfl
+
+/-- An absent result uses the head postcondition. -/
+@[simp, grind =] theorem EPost.Cons.pushOption_none {α : Type u} {Pred : Type u} {EPred : Type v}
+    (post : α → Pred) (epost : EPost.Cons Pred EPred) :
+    epost.pushOption post .none = epost.head := rfl
 
 /-!
 ## Partial Order and Complete Lattice Instances

--- a/src/Std/Internal/Do/ExceptPost.lean
+++ b/src/Std/Internal/Do/ExceptPost.lean
@@ -7,7 +7,7 @@ module
 
 prelude
 public import Std.Internal.Do.Assertion
-universe u v
+universe u v w z
 @[expose] public section
 
 set_option linter.missingDocs true
@@ -47,6 +47,28 @@ structure EPost.Cons (eh : Type u) (et : Type v) where
   tail : et
 
 attribute [simp] EPost.Cons.head EPost.Cons.tail
+
+/-!
+## Pushing Results into Postconditions
+-/
+
+/-- Push an `Except ε α` result into separate normal and exception postconditions:
+`ok a` uses `post a`, and `error e` uses `epost.head e`. -/
+@[simp]
+abbrev EPost.Cons.pushExcept {α : Type u} {ε : Type v} {Pred : Type w} {EPred : Type z}
+    (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) : Except ε α → Pred :=
+  fun
+  | .ok a => post a
+  | .error e => epost.head e
+
+/-- Push an `Option α` result into separate normal and none postconditions:
+`some a` uses `post a`, and `none` uses `epost.head`. -/
+@[simp]
+abbrev EPost.Cons.pushOption {α : Type u} {Pred : Type u} {EPred : Type v}
+    (post : α → Pred) (epost : EPost.Cons Pred EPred) : Option α → Pred :=
+  fun
+  | .some a => post a
+  | .none => epost.head
 
 /-!
 ## Partial Order and Complete Lattice Instances

--- a/src/Std/Internal/Do/WP/Basic.lean
+++ b/src/Std/Internal/Do/WP/Basic.lean
@@ -6,7 +6,8 @@ Authors: Vladimir Gladshtein, Sebastian Graf
 module
 
 prelude
-public import Std.Internal.Do.PredTrans
+public import Std.Internal.Do.ExceptPost
+public import Std.Internal.Order.PredTrans
 universe u v w z
 @[expose] public section
 
@@ -218,6 +219,39 @@ instance Id.instWPMonad : WPMonad Id.{u} Prop EPost.Nil where
   pure_le_wp_pure _ _ _ := PartialOrder.rel_refl
   bind_le_wp_bind _ _ _ _ := PartialOrder.rel_refl
 
+/-- Lift a predicate transformer to one with an additional exception layer (high priority). -/
+instance (priority := high) {ε : Type u} {Pred : Type u} {EPred : Type u} :
+    MonadLift (PredTrans Pred EPred) (PredTrans Pred (EPost.Cons (ε → Pred) EPred)) where
+  monadLift x := ⟨fun post epost => x.apply post epost.tail⟩
+
+/-- `MonadExceptOf` instance for the outermost exception layer:
+`throw` invokes the head exception postcondition, `tryCatch` intercepts it. -/
+instance {ε : Type u} {Pred : Type v} {EPred : Type w} :
+    MonadExceptOf ε (PredTrans Pred (EPost.Cons (ε → Pred) EPred)) where
+  throw e := ⟨fun _post epost => epost.head e⟩
+  tryCatch x handle := ⟨fun post epost => x.apply post ⟨(fun e => (handle e).apply post epost), epost.tail⟩⟩
+
+/-- `MonadExceptOf` instance lifted through an unrelated exception layer:
+delegates to the inner instance, threading the extra exception postcondition. -/
+instance {ε : Type u} {Pred : Type v} {EPred : Type w} {ε' : Type u}
+    [MonadExceptOf ε (PredTrans Pred EPred)] :
+    MonadExceptOf ε (PredTrans Pred (EPost.Cons (ε' → Pred) EPred)) where
+  throw x := ⟨fun post epost => (throw (m := PredTrans Pred EPred) x).apply post epost.tail⟩
+  tryCatch x handle := ⟨fun post epost =>
+    (tryCatch (m := PredTrans Pred EPred)
+      (⟨fun post' epost' => x.apply post' ⟨epost.head, epost'⟩⟩)
+      (fun e => ⟨fun post' epost' => (handle e).apply post' ⟨epost.head, epost'⟩⟩)).apply
+      post epost.tail⟩
+
+/-- Adds an exception layer to a predicate transformer.
+
+Given a transformer over `Except ε α`, produces one over `α` with an additional
+exception postcondition for `ε`. The normal and error postconditions are combined
+via `pushExcept`. -/
+def PredTrans.pushExcept {α : Type u} {ε : Type v} {Pred : Type w} {EPred : Type z}
+    (x : PredTrans Pred EPred (Except ε α)) : PredTrans Pred (EPost.Cons (ε → Pred) EPred) α :=
+  ⟨fun post epost => x.apply (epost.pushExcept post) epost.tail⟩
+
 @[simp, grind =]
 theorem PredTrans.apply_pushExcept {α ε Pred EPred}
     (x : PredTrans Pred EPred (Except ε α)) (post : α → Pred)
@@ -231,8 +265,7 @@ postcondition layer. -/
     WP (ExceptT ε m α) α Pred (EPost.Cons (ε → Pred) EPred) where
   wpTrans x := PredTrans.pushExcept (WP.wpTrans x.run)
   wp_trans_monotone x := fun post post' epost epost' hepost hpost => by
-    change wp x.run (epost.pushExcept post) epost.tail ⊑
-           wp x.run (epost'.pushExcept post') epost'.tail
+    simp only [PredTrans.apply_pushExcept]
     have hepost' : epost.head ⊑ epost'.head ∧ epost.tail ⊑ epost'.tail := by
       simpa [PartialOrder.rel, meet_prop_eq_and] using hepost
     let hhead := hepost'.1
@@ -252,7 +285,8 @@ instance ExceptT.instWPMonad {Pred : Type v}
   pure_le_wp_pure x := fun post epost =>
     WPMonad.pure_le_wp_pure (m := m) (Except.ok x) (epost.pushExcept post) epost.tail
   bind_le_wp_bind x f := fun post epost => by
-    show wp x.run _ epost.tail ⊑ wp (x >>= f).run (epost.pushExcept post) epost.tail
+    show (PredTrans.pushExcept (WP.wpTrans x.run)).apply _ epost ⊑ _
+    simp only [PredTrans.apply_pushExcept]
     apply PartialOrder.rel_trans _ (WPMonad.bind_le_wp_bind (m := m) x.run _ (epost.pushExcept post) epost.tail)
     apply WP.wp_consequence
     intro r; cases r with
@@ -266,6 +300,20 @@ theorem ExceptT.wp_apply_eq {α ε Pred EPred}
   (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     wp x post epost = wp x.run (epost.pushExcept post) epost.tail := rfl
 
+/-- Adds an early-termination layer to a predicate transformer, modelling `Option` as
+early termination. Given a transformer over `Option α`, produces one over `α` with an
+additional exception postcondition for the `none` case. -/
+def PredTrans.pushOption {α : Type u} {Pred : Type u} {EPred : Type v}
+    (x : PredTrans Pred EPred (Option α)) : PredTrans Pred (EPost.Cons Pred EPred) α :=
+  ⟨fun post epost => x.apply (epost.pushOption post) epost.tail⟩
+
+/-- Unfolding `pushOption` through `apply`. -/
+@[simp, grind =]
+theorem PredTrans.apply_pushOption {α : Type u} {Pred : Type u} {EPred : Type v}
+    (x : PredTrans Pred EPred (Option α)) (post : α → Pred)
+    (epost : EPost.Cons Pred EPred) :
+    (PredTrans.pushOption x).apply post epost = x.apply (epost.pushOption post) epost.tail := rfl
+
 /-- `OptionT`'s `WP` interpretation: lift the base interpretation by adding a `PUnit` exception
 postcondition layer. -/
 @[instance_reducible] def OptionT.wpInst {Pred : Type u}
@@ -273,8 +321,7 @@ postcondition layer. -/
     WP (OptionT m α) α Pred (EPost.Cons Pred EPred) where
   wpTrans x := PredTrans.pushOption (WP.wpTrans x.run)
   wp_trans_monotone x := fun post post' epost epost' hepost hpost => by
-    change wp x.run (epost.pushOption post) epost.tail ⊑
-           wp x.run (epost'.pushOption post') epost'.tail
+    simp only [PredTrans.apply_pushOption]
     have hepost' : epost.head ⊑ epost'.head ∧ epost.tail ⊑ epost'.tail := hepost
     apply WP.wp_consequence_econs (x := x.run)
     · intro r; cases r with
@@ -290,7 +337,8 @@ instance OptionT.instWPMonad {Pred : Type u}
   pure_le_wp_pure x := fun post epost =>
     WPMonad.pure_le_wp_pure (m := m) (some x) (epost.pushOption post) epost.tail
   bind_le_wp_bind x f := fun post epost => by
-    show wp x.run _ epost.tail ⊑ wp (x >>= f).run (epost.pushOption post) epost.tail
+    show (PredTrans.pushOption (WP.wpTrans x.run)).apply _ epost ⊑ _
+    simp only [PredTrans.apply_pushOption]
     apply PartialOrder.rel_trans _ (WPMonad.bind_le_wp_bind (m := m) x.run _ (epost.pushOption post) epost.tail)
     apply WP.wp_consequence
     intro r; cases r with

--- a/src/Std/Internal/Do/WP/Basic.lean
+++ b/src/Std/Internal/Do/WP/Basic.lean
@@ -219,11 +219,6 @@ instance Id.instWPMonad : WPMonad Id.{u} Prop EPost.Nil where
   pure_le_wp_pure _ _ _ := PartialOrder.rel_refl
   bind_le_wp_bind _ _ _ _ := PartialOrder.rel_refl
 
-/-- Lift a predicate transformer to one with an additional exception layer (high priority). -/
-instance (priority := high) {ε : Type u} {Pred : Type u} {EPred : Type u} :
-    MonadLift (PredTrans Pred EPred) (PredTrans Pred (EPost.Cons (ε → Pred) EPred)) where
-  monadLift x := ⟨fun post epost => x.apply post epost.tail⟩
-
 /-- `MonadExceptOf` instance for the outermost exception layer:
 `throw` invokes the head exception postcondition, `tryCatch` intercepts it. -/
 instance {ε : Type u} {Pred : Type v} {EPred : Type w} :

--- a/src/Std/Internal/Do/WP/Frame.lean
+++ b/src/Std/Internal/Do/WP/Frame.lean
@@ -8,104 +8,23 @@ module
 prelude
 public import Std.Internal.Do.WP.Basic
 public import Std.Internal.Do.WP.Conjunctive
-public import Std.Internal.Order.OfProp
-public import Std.Internal.Order.PreservesSup
+public import Std.Internal.Order.FrameClosure
 universe u v w z t
 @[expose] public section
 
 set_option linter.missingDocs true
 
-open Lean.Order Std.Internal.Do
+/-!
+# Framing at the `wp` layer
 
-namespace Std.Internal.Do
-
-/-! ## The frame closure
-
-The frame closure internalizes the frame rule into an arbitrary post-transformer. A weakest
-precondition built as `WP.frameClosure op (fun Q => bwp x Q E)` frames every resource by
+`WP.Frames op x F` states that the program `x` commutes `op F ·` into the postcondition of `wp x`.
+A `WP` built as the `Lean.Order.PredTrans.frameClosure` of a base wp frames every resource by
 construction.
 -/
 
-section FrameClosure
+open Lean.Order Std.Internal.Do
 
-variable {α : Type u} [CompleteLattice α]
-
-/-- The **frame closure** of a post-transformer `k` with respect to a family of supremum-preserving
-operators `op r`: the meet over all resources `r` of the `r`-upper-adjoint of `k` framed by `r`. It
-internalizes the frame rule into any `k` (see `WP.frameClosure_frames`), with no assumption on `k`. -/
-noncomputable def WP.frameClosure {R : Type v} {β : Type w} (op : R → α → α)
-    (k : (β → α) → α) (Q : β → α) : α :=
-  ⨅ r, PreservesSup.upperAdjoint (op r) (k (fun a => op r (Q a)))
-
-/-- The frame rule, internalized: for a family of supremum-preserving operators `op r` whose
-resources
-compose by `comp` with the action law `op (comp r r') = op r ∘ op r'`, and any post-transformer `k`,
-`op F (frameClosure op k Q) ⊑ frameClosure op k (fun a => op F (Q a))`. -/
-theorem WP.frameClosure_frames {R : Type v} {β : Type w} (op : R → α → α)
-    [∀ r, PreservesSup (op r)]
-    (comp : R → R → R) (hact : ∀ r r' a, op (comp r r') a = op r (op r' a))
-    (k : (β → α) → α) (Q : β → α) (F : R) :
-    op F (WP.frameClosure op k Q) ⊑ WP.frameClosure op k (fun a => op F (Q a)) := by
-  apply le_iInf
-  intro F'
-  apply PreservesSup.le_upperAdjoint (op F')
-  rw [← hact F' F (WP.frameClosure op k Q)]
-  refine PartialOrder.rel_trans
-    (PreservesSup.map_mono (op (comp F' F)) (iInf_le _ (comp F' F))) ?_
-  refine PartialOrder.rel_trans (PreservesSup.upperAdjoint_le (op (comp F' F)) _) ?_
-  apply PartialOrder.rel_of_eq
-  congr 1
-  funext a
-  rw [hact F' F (Q a)]
-
-/-- Landing below the frame closure, transposed across the Galois connection: `pre ⊑ frameClosure op k Q`
-holds exactly when `op r pre ⊑ k (fun a => op r (Q a))` for every resource `r`. At a unit resource
-(`op e = id`) the `r = e` conjunct is `pre ⊑ k Q`; the remaining conjuncts are the frame conditions on
-`pre`, so a `pre` that cannot frame is forced down to the trivial `⊥`. -/
-theorem WP.le_frameClosure_iff {R : Type v} {β : Type w} (op : R → α → α)
-    [∀ r, PreservesSup (op r)]
-    (k : (β → α) → α) {Q : β → α} {pre : α} :
-    pre ⊑ WP.frameClosure op k Q ↔ ∀ r, op r pre ⊑ k (fun a => op r (Q a)) := by
-  constructor
-  · intro h r
-    exact PartialOrder.rel_trans
-      (PreservesSup.map_mono (op r) (PartialOrder.rel_trans h (iInf_le _ r)))
-      (PreservesSup.upperAdjoint_le (op r) _)
-  · intro h
-    apply le_iInf
-    intro r
-    exact PreservesSup.le_upperAdjoint (op r) (h r)
-
-/-- Landing below the frame closure reduces to landing below the base transformer together with
-framing: if `pre ⊑ k Q` and `k` frames every `op r` (`op r (k Q') ⊑ k (fun a => op r (Q' a))`), then
-`pre ⊑ frameClosure op k Q`. -/
-theorem WP.le_frameClosure {R : Type v} {β : Type w} (op : R → α → α) [∀ r, PreservesSup (op r)]
-    (k : (β → α) → α) {Q : β → α} {pre : α}
-    (hframe : ∀ (r : R) (Q' : β → α), op r (k Q') ⊑ k (fun a => op r (Q' a)))
-    (hpre : pre ⊑ k Q) :
-    pre ⊑ WP.frameClosure op k Q :=
-  (WP.le_frameClosure_iff op k).mpr fun r =>
-    PartialOrder.rel_trans (PreservesSup.map_mono (op r) hpre) (hframe r Q)
-
-/-- The frame closure lies below the base transformer, witnessed at a unit resource `e` with
-`op e = id`. -/
-theorem WP.frameClosure_le {R : Type v} {β : Type w} (op : R → α → α) [∀ r, PreservesSup (op r)]
-    (e : R) (hunit : ∀ a, op e a = a) (k : (β → α) → α) (Q : β → α) :
-    WP.frameClosure op k Q ⊑ k Q := by
-  refine PartialOrder.rel_trans (iInf_le _ e) ?_
-  rw [show (fun a => op e (Q a)) = Q from funext fun a => hunit (Q a)]
-  have h := PreservesSup.upperAdjoint_le (op e) (k Q)
-  rwa [hunit] at h
-
-end FrameClosure
-
-/-- Frame a single state coordinate: from the function-order premise `(fun u => ⌜u = s⌝ ⊓ pre) ⊑ Q`
-conclude the point entailment `pre ⊑ Q s`. Instantiating the premise at `u := s` collapses
-`⌜s = s⌝ ⊓ pre` to `pre`. Iterating it over a state chain point-frames `pre ⊑ Q s₁ … sₙ` to the
-function-order goal `(fun u⃗ => ⌜u⃗ = s⃗⌝ ⊓ pre) ⊑ Q`. -/
-theorem le_apply_of_point_meet_le {σ : Type v} {β : Type w} [CompleteLattice β]
-    (s : σ) (pre : β) (Q : σ → β) (h : (fun u => ⌜u = s⌝ ⊓ pre) ⊑ Q) : pre ⊑ Q s :=
-  (CompleteLattice.ofProp_intro_r (s = s) pre (Q s)).mp (h s) rfl
+namespace Std.Internal.Do
 
 variable {Prog : Type u} {Value : Type v} {Pred : Type w} {EPred : Type z}
   [Assertion Pred] [Assertion EPred] [WP Prog Value Pred EPred]
@@ -134,29 +53,29 @@ theorem WP.Frames.op_wp_upperAdjoint_le_wp {R : Type t} (op : R → Pred → Pre
   intro
   apply PreservesSup.upperAdjoint_le
 
-/-- `WP.le_frameClosure` at the `wp` layer: when `x` frames every resource `r`, landing
+/-- `le_frameClosure` at the `wp` layer: when `x` frames every resource `r`, landing
 below `wp x Q E` suffices to land below the frame closure of `wp x · E`. -/
 theorem WP.Frames.le_frameClosure {R : Type t} (op : R → Pred → Pred) [∀ r, PreservesSup (op r)]
     {x : Prog} (hframes : ∀ r, WP.Frames op x r) {Q : Value → Pred} {E : EPred} {pre : Pred}
     (hpre : pre ⊑ wp x Q E) :
-    pre ⊑ WP.frameClosure op (fun Q => wp x Q E) Q :=
-  WP.le_frameClosure op (fun Q => wp x Q E)
+    pre ⊑ ((WP.wpTrans x).frameClosure op).apply Q E :=
+  PredTrans.le_frameClosure op (WP.wpTrans x)
     (fun r Q' => (hframes r).op_wp_le_wp_op Q' E) hpre
 
-/-- If `wp` is built as `WP.frameClosure op` over a base post-transformer `f x E` (the frame
+/-- If `wp` is built as the `frameClosure op` of a base predicate transformer `f x` (the frame
 rule internalized into `wp`), then every program frames every resource `F` with respect to `op`. -/
 theorem WP.Frames.of_frameClosure {R : Type t} (op : R → Pred → Pred) [∀ r, PreservesSup (op r)]
     (comp : R → R → R) (hact : ∀ r r' a, op (comp r r') a = op r (op r' a))
     {x : Prog} {F : R}
-    (h : ∃ f : Prog → EPred → (Value → Pred) → Pred,
-      ∀ (x : Prog) (Q : Value → Pred) (E : EPred),
-        wp x Q E = WP.frameClosure op (f x E) Q) :
+    (h : ∃ f : Prog → PredTrans Pred EPred Value,
+      ∀ x : Prog, WP.wpTrans x = (f x).frameClosure op) :
     WP.Frames op x F := by
   obtain ⟨f, hf⟩ := h
   constructor
   intro Q E
-  rw [hf x Q E, hf x (fun a => op F (Q a)) E]
-  exact WP.frameClosure_frames op comp hact (f x E) Q F
+  show op F ((WP.wpTrans x).apply Q E) ⊑ (WP.wpTrans x).apply _ E
+  rw [hf x]
+  exact PredTrans.frameClosure_frames op comp hact (f x) Q E F
 
 /-- If `wp x` is conjunctive, then `x` frames `(F ⊓ ·)` when `F` holds before and after running `x`. -/
 theorem WP.Frames.of_conjunctive {Prog : Type u} {Value : Type v} {Pred : Type w} {EPred : Type z}
@@ -173,16 +92,12 @@ theorem WP.Frames.of_conjunctive {Prog : Type u} {Value : Type v} {Pred : Type w
     simp only [meet_apply]
     exact PartialOrder.rel_refl
 
-/-- Reinterpret a `WP` so its weakest precondition is the `WP.frameClosure` of the base
+/-- Reinterpret a `WP` so its weakest precondition is the `frameClosure` of the base
 wp over a family of supremum-preserving resource operators `op r`. -/
 @[instance_reducible] noncomputable def WP.of_frameClosure {R : Type t} (op : R → Pred → Pred)
     [∀ r, PreservesSup (op r)] (base : WP Prog Value Pred EPred) : WP Prog Value Pred EPred where
-  wpTrans x := ⟨fun Q E => WP.frameClosure op (fun Q' => base.wp x Q' E) Q⟩
-  wp_trans_monotone x post post' epost epost' hE hP := by
-    simp only [WP.frameClosure]
-    refine iInf_mono fun r => PreservesSup.upperAdjoint_mono _ ?_
-    exact base.wp_consequence_econs x _ _ epost epost'
-      (fun a => PreservesSup.map_mono (op r) (hP a)) hE
+  wpTrans x := (base.wpTrans x).frameClosure op
+  wp_trans_monotone x := PredTrans.monotone_frameClosure op (base.wp_trans_monotone x)
 
 omit [WP Prog Value Pred EPred] in
 /-- Characterization of the `WP.of_frameClosure` weakest precondition: landing below it is landing
@@ -190,9 +105,8 @@ below the base wp with every resource `op r` framed onto the pre- and postcondit
 theorem WP.of_frameClosure_le_wp_iff {R : Type t} (op : R → Pred → Pred) [∀ r, PreservesSup (op r)]
     (base : WP Prog Value Pred EPred) (x : Prog) (Q : Value → Pred) (E : EPred) (pre : Pred) :
     pre ⊑ (WP.of_frameClosure op base).wp x Q E ↔
-      ∀ r, op r pre ⊑ base.wp x (fun a => op r (Q a)) E := by
-  show pre ⊑ WP.frameClosure op (fun Q' => base.wp x Q' E) Q ↔ _
-  exact WP.le_frameClosure_iff op _
+      ∀ r, op r pre ⊑ base.wp x (fun a => op r (Q a)) E :=
+  PredTrans.le_frameClosure_iff op (base.wpTrans x)
 
 omit [WP Prog Value Pred EPred] in
 /-- Introduction rule for the weakest precondition of a `WP.of_frameClosure` interpretation,
@@ -205,7 +119,7 @@ theorem WP.le_wp_of_frameClosure_eq {R : Type t} {op : R → Pred → Pred} [∀
   subst heq
   exact (WP.of_frameClosure_le_wp_iff op base x Q E pre).mpr h
 
-/-- Reinterpret a `WPMonad m` so its weakest precondition is the `WP.frameClosure` of the
+/-- Reinterpret a `WPMonad m` so its weakest precondition is the `frameClosure` of the
 base wp over a family of supremum-preserving resource operators `op r` that act by `comp` with
 unit `e`.
 The resource frame rule then holds by construction (`WP.Frames.of_frameClosure`). -/
@@ -217,17 +131,17 @@ The resource frame rule then holds by construction (`WP.Frames.of_frameClosure`)
   toLawfulMonad := base.toLawfulMonad
   toWP α := WP.of_frameClosure op (base.toWP α)
   pure_le_wp_pure x post E' := by
-    show post x ⊑ WP.frameClosure op (fun Q' => WP.wp (pure x) Q' E') post
-    refine (WP.le_frameClosure_iff op _).mpr fun r => ?_
+    show post x ⊑ (((base.toWP _).wpTrans (pure x)).frameClosure op).apply post E'
+    refine (PredTrans.le_frameClosure_iff op _).mpr fun r => ?_
     exact base.pure_le_wp_pure x (fun a => op r (post a)) E'
   bind_le_wp_bind x f post E' := by
-    show WP.frameClosure op (fun Q' => WP.wp x Q' E')
-          (fun a => WP.frameClosure op (fun Q' => WP.wp (f a) Q' E') post)
-        ⊑ WP.frameClosure op (fun Q' => WP.wp (x >>= f) Q' E') post
-    refine (WP.le_frameClosure_iff op _).mpr fun r => ?_
-    refine PartialOrder.rel_trans (WP.frameClosure_frames op comp hact _ _ r) ?_
-    refine PartialOrder.rel_trans (WP.frameClosure_le op e hunit _ _) ?_
+    show (((base.toWP _).wpTrans x).frameClosure op).apply
+          (fun a => (((base.toWP _).wpTrans (f a)).frameClosure op).apply post E') E'
+        ⊑ (((base.toWP _).wpTrans (x >>= f)).frameClosure op).apply post E'
+    refine (PredTrans.le_frameClosure_iff op _).mpr fun r => ?_
+    refine PartialOrder.rel_trans (PredTrans.frameClosure_frames op comp hact _ _ _ r) ?_
+    refine PartialOrder.rel_trans (PredTrans.frameClosure_le op e hunit _ _ _) ?_
     refine PartialOrder.rel_trans ?_ (base.bind_le_wp_bind x f (fun a => op r (post a)) E')
     refine WP.wp_consequence x _ _ E' fun a => ?_
-    exact PartialOrder.rel_trans (WP.frameClosure_frames op comp hact _ _ r)
-      (WP.frameClosure_le op e hunit _ _)
+    exact PartialOrder.rel_trans (PredTrans.frameClosure_frames op comp hact _ _ _ r)
+      (PredTrans.frameClosure_le op e hunit _ _ _)

--- a/src/Std/Internal/Order/FrameClosure.lean
+++ b/src/Std/Internal/Order/FrameClosure.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Graf
+-/
+module
+
+prelude
+public import Std.Internal.Order.OfProp
+public import Std.Internal.Order.PreservesSup
+public import Std.Internal.Order.PredTrans
+
+universe u v w x
+@[expose] public section
+
+set_option linter.missingDocs true
+
+/-!
+# The frame closure
+
+The frame closure is an endomap on predicate transformers over a family of supremum-preserving
+operators `op r`, one per resource `r`. It internalizes the frame rule into the transformer it is
+applied to.
+-/
+
+namespace Lean.Order
+
+open Std.Internal.Order
+
+section
+
+variable {Pred : Type u} [CompleteLattice Pred] {EPred : Type v} {β : Type w} {R : Type x}
+
+/-- The **frame closure** of a predicate transformer `t` with respect to a family of
+supremum-preserving operators `op r`: the meet over all resources `r` of the `r`-upper-adjoint of `t`
+framed by `r`. It internalizes the frame rule into any `t` (see `PredTrans.frameClosure_frames`),
+with no assumption on `t`. The exception postcondition is handed to `t` unchanged. -/
+noncomputable def PredTrans.frameClosure (op : R → Pred → Pred) (t : PredTrans Pred EPred β) :
+    PredTrans Pred EPred β :=
+  ⟨fun Q E => ⨅ r, PreservesSup.upperAdjoint (op r) (t.apply (fun a => op r (Q a)) E)⟩
+
+/-- Unfolding `frameClosure` through `apply`. -/
+theorem PredTrans.apply_frameClosure (op : R → Pred → Pred) (t : PredTrans Pred EPred β)
+    (Q : β → Pred) (E : EPred) :
+    (t.frameClosure op).apply Q E =
+      ⨅ r, PreservesSup.upperAdjoint (op r) (t.apply (fun a => op r (Q a)) E) := rfl
+
+/-- The frame closure carries monotonicity: if `t` is monotone, so is `t.frameClosure op`. -/
+theorem PredTrans.monotone_frameClosure [CompleteLattice EPred] (op : R → Pred → Pred)
+    [∀ r, PreservesSup (op r)] {t : PredTrans Pred EPred β} (h : t.monotone) :
+    (t.frameClosure op).monotone := by
+  intro post post' epost epost' hE hP
+  simp only [PredTrans.apply_frameClosure]
+  refine iInf_mono fun r => PreservesSup.upperAdjoint_mono _ ?_
+  exact h _ _ epost epost' hE (fun a => PreservesSup.map_mono (op r) (hP a))
+
+/-- The frame rule, internalized: for a family of supremum-preserving operators `op r` whose
+resources compose by `comp` with the action law `op (comp r r') = op r ∘ op r'`, and any predicate
+transformer `t`, `op F` commutes into the postcondition of `t.frameClosure op`. -/
+theorem PredTrans.frameClosure_frames (op : R → Pred → Pred) [∀ r, PreservesSup (op r)]
+    (comp : R → R → R) (hact : ∀ r r' a, op (comp r r') a = op r (op r' a))
+    (t : PredTrans Pred EPred β) (Q : β → Pred) (E : EPred) (F : R) :
+    op F ((t.frameClosure op).apply Q E) ⊑
+      (t.frameClosure op).apply (fun a => op F (Q a)) E := by
+  apply le_iInf
+  intro F'
+  apply PreservesSup.le_upperAdjoint (op F')
+  rw [← hact F' F ((t.frameClosure op).apply Q E)]
+  refine PartialOrder.rel_trans
+    (PreservesSup.map_mono (op (comp F' F)) (iInf_le _ (comp F' F))) ?_
+  refine PartialOrder.rel_trans (PreservesSup.upperAdjoint_le (op (comp F' F)) _) ?_
+  apply PartialOrder.rel_of_eq
+  congr 1
+  funext a
+  rw [hact F' F (Q a)]
+
+/-- Landing below the frame closure, transposed across the Galois connection:
+`pre ⊑ (t.frameClosure op).apply Q E` holds exactly when `op r pre ⊑ t.apply (fun a => op r (Q a)) E`
+for every resource `r`. At a unit resource (`op e = id`) the `r = e` conjunct is
+`pre ⊑ t.apply Q E`; the remaining conjuncts are the frame conditions on `pre`, so a `pre` that
+cannot frame is forced down to the trivial `⊥`. -/
+theorem PredTrans.le_frameClosure_iff (op : R → Pred → Pred) [∀ r, PreservesSup (op r)]
+    (t : PredTrans Pred EPred β) {Q : β → Pred} {E : EPred} {pre : Pred} :
+    pre ⊑ (t.frameClosure op).apply Q E ↔ ∀ r, op r pre ⊑ t.apply (fun a => op r (Q a)) E := by
+  constructor
+  · intro h r
+    exact PartialOrder.rel_trans
+      (PreservesSup.map_mono (op r) (PartialOrder.rel_trans h (iInf_le _ r)))
+      (PreservesSup.upperAdjoint_le (op r) _)
+  · intro h
+    apply le_iInf
+    intro r
+    exact PreservesSup.le_upperAdjoint (op r) (h r)
+
+/-- Landing below the frame closure reduces to landing below the base transformer together with
+framing: if `pre ⊑ t.apply Q E` and `t` frames every `op r`, then
+`pre ⊑ (t.frameClosure op).apply Q E`. -/
+theorem PredTrans.le_frameClosure (op : R → Pred → Pred) [∀ r, PreservesSup (op r)]
+    (t : PredTrans Pred EPred β) {Q : β → Pred} {E : EPred} {pre : Pred}
+    (hframe : ∀ (r : R) (Q' : β → Pred), op r (t.apply Q' E) ⊑ t.apply (fun a => op r (Q' a)) E)
+    (hpre : pre ⊑ t.apply Q E) :
+    pre ⊑ (t.frameClosure op).apply Q E :=
+  (le_frameClosure_iff op t).mpr fun r =>
+    PartialOrder.rel_trans (PreservesSup.map_mono (op r) hpre) (hframe r Q)
+
+/-- The frame closure lies below the base transformer, witnessed at a unit resource `e` with
+`op e = id`. -/
+theorem PredTrans.frameClosure_le (op : R → Pred → Pred) [∀ r, PreservesSup (op r)]
+    (e : R) (hunit : ∀ a, op e a = a) (t : PredTrans Pred EPred β) (Q : β → Pred) (E : EPred) :
+    (t.frameClosure op).apply Q E ⊑ t.apply Q E := by
+  refine PartialOrder.rel_trans (iInf_le _ e) ?_
+  rw [show (fun a => op e (Q a)) = Q from funext fun a => hunit (Q a)]
+  have h := PreservesSup.upperAdjoint_le (op e) (t.apply Q E)
+  rwa [hunit] at h
+
+end
+
+/-- Frame a single state coordinate: from the function-order premise `(fun u => ⌜u = s⌝ ⊓ pre) ⊑ Q`
+conclude the point entailment `pre ⊑ Q s`. Instantiating the premise at `u := s` collapses
+`⌜s = s⌝ ⊓ pre` to `pre`. Iterating it over a state chain point-frames `pre ⊑ Q s₁ … sₙ` to the
+function-order goal `(fun u⃗ => ⌜u⃗ = s⃗⌝ ⊓ pre) ⊑ Q`. -/
+theorem le_apply_of_point_meet_le {σ : Type v} {β : Type w} [CompleteLattice β]
+    (s : σ) (pre : β) (Q : σ → β) (h : (fun u => ⌜u = s⌝ ⊓ pre) ⊑ Q) : pre ⊑ Q s :=
+  (CompleteLattice.ofProp_intro_r (s = s) pre (Q s)).mp (h s) rfl
+
+end Lean.Order
+
+end -- public section

--- a/src/Std/Internal/Order/PredTrans.lean
+++ b/src/Std/Internal/Order/PredTrans.lean
@@ -6,44 +6,36 @@ Authors: Vladimir Gladshtein, Sebastian Graf
 module
 
 prelude
-public import Std.Internal.Do.Assertion
-public import Std.Internal.Do.ExceptPost
+public import Std.Internal.Order.Basic
+
 universe u v w z
 @[expose] public section
 
 set_option linter.missingDocs true
 
-open Lean.Order
-
 /-!
-# Predicate Transformers
+# Predicate transformers
 
-This module defines the type `PredTrans Pred EPred α` of *predicate transformers* for weakest
-precondition reasoning over monadic programs with exception postconditions.
+`PredTrans Pred EPred α` wraps a map from a normal postcondition `α → Pred` and an exception
+postcondition `EPred` to a precondition `Pred`. The order and the chain-complete suprema are the
+pointwise ones of the function space.
 
-A predicate transformer `x : PredTrans Pred EPred α` takes a normal postcondition `post : α → Pred`,
-an exception postcondition `epost : EPred`, and returns a precondition of type `Pred`.
-
-`PredTrans` forms a monad, so monadic programs can be interpreted by a monad morphism into
-`PredTrans`; this is exactly what `WPMonad` encodes.
-
-## Main definitions
-
-- `PredTrans Pred EPred α` — the type of monotone predicate transformers
-- `PredTrans.pushExcept` — adds an exception layer to a predicate transformer
-- `pushArg` — adds a state argument to a predicate transformer
-- Instances for `Monad`, `LawfulMonad`, `MonadStateOf`, `MonadExceptOf`, etc.
+`PredTrans Pred EPred` is a monad, so monadic programs can be interpreted by a monad morphism into
+it. This module provides that monad structure, the `apply` simp framework of the monadic
+combinators, and `pushArg`, which adds a state argument.
 -/
 
-namespace Std.Internal.Do
+namespace Lean.Order
 
-/-- A monotone predicate transformer from postconditions to preconditions.
+/-- A predicate transformer from postconditions to preconditions.
 
 Given a return type `α`, a lattice `Pred` for assertions, and an exception assertion type `EPred`,
 `PredTrans Pred EPred α` wraps a function `(α → Pred) → EPred → Pred`. -/
 structure PredTrans (Pred : Type u) (EPred : Type v) (α : Type w) where
   /-- Apply the predicate transformer to a postcondition and exception postcondition. -/
   apply : (α → Pred) → EPred → Pred
+
+variable {Pred : Type u} {EPred : Type v} {α : Type w}
 
 /-- Extensionality for predicate transformers. -/
 @[ext] theorem PredTrans.ext {x y : PredTrans Pred EPred α}
@@ -74,6 +66,11 @@ instance [CCPO Pred] : CCPO (PredTrans Pred EPred α) where
     · intro h
       exact (hsup q.apply).mpr fun f ⟨pf, hpf, hpf_eq⟩ => by subst hpf_eq; exact h pf hpf
 
+/-- Monotonicity property for a predicate transformer: if both `post` and `epost` grow,
+then the resulting precondition grows. -/
+def PredTrans.monotone [PartialOrder Pred] [PartialOrder EPred] (pt : PredTrans Pred EPred α) :=
+  ∀ post post' epost epost', epost ⊑ epost' → post ⊑ post' → pt.apply post epost ⊑ pt.apply post' epost'
+
 /-- `Monad` instance for `PredTrans`: `pure` returns the postcondition applied to the value,
 and `bind` threads the postcondition through the continuation. -/
 instance instMonadPredTrans (Pred : Type u) (EPred : Type v) : Monad (PredTrans Pred EPred) where
@@ -91,11 +88,6 @@ instance instLawfulMonadPredTrans (Pred : Type u) (EPred : Type v) : LawfulMonad
   bind_map _ _ := PredTrans.ext fun _ _ => rfl
   pure_bind _ _ := PredTrans.ext fun _ _ => rfl
   bind_assoc _ _ _ := PredTrans.ext fun _ _ => rfl
-
-/-- Monotonicity property for a predicate transformer: if both `post` and `epost` grow,
-then the resulting precondition grows. -/
-def PredTrans.monotone [PartialOrder Pred] [PartialOrder EPred] (pt : PredTrans Pred EPred α) :=
-  ∀ post post' epost epost', epost ⊑ epost' → post ⊑ post' → pt.apply post epost ⊑ pt.apply post' epost'
 
 /-!
 ## `apply_*` simp framework
@@ -151,53 +143,6 @@ theorem PredTrans.apply_ite {Pred : Type u} {EPred : Type v}
   split <;> rfl
 
 /-!
-## Exception Handling
-
-Definitions for pushing and lifting exception layers through predicate transformers.
--/
-
-/-- Push an `Except ε α` result into separate normal and exception postconditions:
-`ok a` uses `post a`, and `error e` uses `epost.head e`. -/
-@[simp]
-abbrev EPost.Cons.pushExcept {α : Type u} {ε : Type v} {Pred : Type w} {EPred : Type z}
-    (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) : Except ε α → Pred :=
-  fun
-  | .ok a => post a
-  | .error e => epost.head e
-
-/-- Adds an exception layer to a predicate transformer.
-
-Given a transformer over `Except ε α`, produces one over `α` with an additional
-exception postcondition for `ε`. The normal and error postconditions are combined
-via `pushExcept`. -/
-def PredTrans.pushExcept {α : Type u} {ε : Type v} {Pred : Type w} {EPred : Type z}
-    (x : PredTrans Pred EPred (Except ε α)) : PredTrans Pred (EPost.Cons (ε → Pred) EPred) α :=
-  ⟨fun post epost => x.apply (epost.pushExcept post) epost.tail⟩
-
-/-- Push an `Option α` result into separate normal and none postconditions:
-`some a` uses `post a`, and `none` uses `epost.head`. -/
-@[simp]
-abbrev EPost.Cons.pushOption {α : Type u} {Pred : Type u} {EPred : Type v}
-    (post : α → Pred) (epost : EPost.Cons Pred EPred) : Option α → Pred :=
-  fun
-  | .some a => post a
-  | .none => epost.head
-
-/-- Adds an early-termination layer to a predicate transformer, modelling `Option` as
-early termination. Given a transformer over `Option α`, produces one over `α` with an
-additional exception postcondition for the `none` case. -/
-def PredTrans.pushOption {α : Type u} {Pred : Type u} {EPred : Type v}
-    (x : PredTrans Pred EPred (Option α)) : PredTrans Pred (EPost.Cons Pred EPred) α :=
-  ⟨fun post epost => x.apply (epost.pushOption post) epost.tail⟩
-
-/-- Unfolding `pushOption` through `apply`. -/
-@[simp, grind =]
-theorem PredTrans.apply_pushOption {α : Type u} {Pred : Type u} {EPred : Type v}
-    (x : PredTrans Pred EPred (Option α)) (post : α → Pred)
-    (epost : EPost.Cons Pred EPred) :
-    (PredTrans.pushOption x).apply post epost = x.apply (epost.pushOption post) epost.tail := rfl
-
-/-!
 ## State Handling
 
 Definitions for adding state arguments to predicate transformers.
@@ -222,11 +167,6 @@ instance {σ : Type u} {Pred : Type v} {EPred : Type w} :
     MonadLift (PredTrans Pred EPred) (PredTrans (σ → Pred) EPred) where
   monadLift x := ⟨fun post epost s => x.apply (fun a => post a s) epost⟩
 
-/-- Lift a predicate transformer to one with an additional exception layer (high priority). -/
-instance (priority := high) {ε : Type u} {Pred : Type u} {EPred : Type u} :
-    MonadLift (PredTrans Pred EPred) (PredTrans Pred (EPost.Cons (ε → Pred) EPred)) where
-  monadLift x := ⟨fun post epost => x.apply post epost.tail⟩
-
 /-!
 ## Monad Instances
 
@@ -246,13 +186,6 @@ instance {σ : Type u} {Pred : Type v} {EPred : Type w} :
     MonadReaderOf σ (PredTrans (σ → Pred) EPred) where
   read := ⟨fun post _epost => fun s => post s s⟩
 
-/-- `MonadExceptOf` instance for the outermost exception layer:
-`throw` invokes the head exception postcondition, `tryCatch` intercepts it. -/
-instance {ε : Type u} {Pred : Type v} {EPred : Type w} :
-    MonadExceptOf ε (PredTrans Pred (EPost.Cons (ε → Pred) EPred)) where
-  throw e := ⟨fun _post epost => epost.head e⟩
-  tryCatch x handle := ⟨fun post epost => x.apply post ⟨(fun e => (handle e).apply post epost), epost.tail⟩⟩
-
 /-- `MonadExceptOf` instance lifted through a state layer:
 delegates `throw` and `tryCatch` to the inner `PredTrans l e` instance. -/
 instance {ε : Type u} {Pred : Type v} {EPred : Type w} {σ : Type z}
@@ -266,16 +199,6 @@ instance {ε : Type u} {Pred : Type v} {EPred : Type w} {σ : Type z}
       (fun e => ⟨fun post epost => (handle e).apply (fun r s => post (r, s)) epost s⟩)).apply
       (fun rs => post rs.1 rs.2) epost⟩
 
-/-- `MonadExceptOf` instance lifted through an unrelated exception layer:
-delegates to the inner instance, threading the extra exception postcondition. -/
-instance {ε : Type u} {Pred : Type v} {EPred : Type w} {ε' : Type u}
-    [MonadExceptOf ε (PredTrans Pred EPred)] :
-    MonadExceptOf ε (PredTrans Pred (EPost.Cons (ε' → Pred) EPred)) where
-  throw x := ⟨fun post epost => (throw (m := PredTrans Pred EPred) x).apply post epost.tail⟩
-  tryCatch x handle := ⟨fun post epost =>
-    (tryCatch (m := PredTrans Pred EPred)
-      (⟨fun post' epost' => x.apply post' ⟨epost.head, epost'⟩⟩)
-      (fun e => ⟨fun post' epost' => (handle e).apply post' ⟨epost.head, epost'⟩⟩)).apply
-      post epost.tail⟩
+end Lean.Order
 
-end Std.Internal.Do
+end -- public section

--- a/tests/elab/vcgenDepAssertionLattice.lean
+++ b/tests/elab/vcgenDepAssertionLattice.lean
@@ -48,7 +48,7 @@ instance Stateful.instWP {α : Type} : WP (Stateful α) α StateProp EPost⟨⟩
       | none => True
       | some res => post res stOut h⟩
   wp_trans_monotone x := by
-    simp only [PredTrans.monotone, Lean.Order.PartialOrder.rel, Stateful.run]; grind
+    simp only [Lean.Order.PredTrans.monotone, Lean.Order.PartialOrder.rel, Stateful.run]; grind
 
 theorem Stateful.wpTrans_apply_eq {α : Type} (x : Stateful α)
     (post : α → StateProp) (epost : EPost⟨⟩) (st : State) (h : st.Invariant) :

--- a/tests/elab/vcgenDyLean.lean
+++ b/tests/elab/vcgenDyLean.lean
@@ -278,7 +278,7 @@ instance: WPMonad Traceful TraceProp EPost⟨⟩ where
     ⟩⟩
 
     wp_trans_monotone x := by
-      simp only [Std.Internal.Do.PredTrans.monotone, Lean.Order.PartialOrder.rel]
+      simp only [Lean.Order.PredTrans.monotone, Lean.Order.PartialOrder.rel]
       grind
   }
 

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -484,7 +484,7 @@ noncomputable instance HeapM.instWPMonad : WPMonad HeapM HProp EPost.Nil :=
 @[grind .]
 theorem frames_sepConj {α : Type} (x : HeapM α) (F : HProp) : WP.Frames sepConj x F :=
   WP.Frames.of_frameClosure sepConj sepConj sepConj_assoc
-    ⟨fun y E Q' => WP.wp y.run Q' E, fun _ _ _ => rfl⟩
+    ⟨fun y => WP.wpTrans y.run, fun _ => rfl⟩
 
 /-- Triple introduction from the base `StateM Heap` interpretation: prove the base triple with an
 arbitrary frame `F` held on both sides. -/

--- a/tests/elab/vcgenTickFrames.lean
+++ b/tests/elab/vcgenTickFrames.lean
@@ -17,7 +17,7 @@ A cost transformer `TickT m := StateT Nat m` whose weakest precondition bakes in
 rule for a resource that is **not** the lattice meet. The resource is a `Nat` tick counter with
 separating conjunction `costConj shift b = fun ticks => ⌜shift ≤ ticks⌝ ⊓ b (ticks - shift)`
 (Day convolution with a point mass: translate `b` by `shift`) and magic wand
-`shift -⋆ b = fun ticks => b (ticks + shift)`. `TickT.wp` is the `WP.frameClosure` of the
+`shift -⋆ b = fun ticks => b (ticks + shift)`. `TickT.wp` is the `frameClosure` of the
 base wp over `costConj`, so every program frames every shift by construction, and a registered
 `@[frameproc]` lets plain `vcgen` infer and frame the shift across calls.
 -/
@@ -140,11 +140,11 @@ def TickT.run [Monad m] {α : Type} (x : TickT m α) : StateT Nat m α := x
 /-- The cost primitive: incur one unit of cost by incrementing the counter. -/
 def tick [Monad m] : TickT m Unit := show StateT Nat m Unit from modify (· + 1)
 
-/-- The frame-internalizing cost weakest precondition: the `WP.frameClosure` of the base
+/-- The frame-internalizing cost weakest precondition: the `frameClosure` of the base
 `StateT` wp over `costConj`. -/
 noncomputable def TickT.wp [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {α : Type} (x : TickT m α) (Q : α → Nat → Pred) (E : EPred) : Nat → Pred :=
-  WP.frameClosure costConj (WP.wp x.run · E) Q
+  ((WP.wpTrans x.run).frameClosure costConj).apply Q E
 
 /-- The simp normal form for `TickT.wp`: the meet over all shifts `r` of the base wp under the
 shifted postcondition `⌜r ≤ m⌝ ⊓ Q a (m - r)`, offset by `r`. -/
@@ -152,7 +152,7 @@ shifted postcondition `⌜r ≤ m⌝ ⊓ Q a (m - r)`, offset by `r`. -/
 theorem TickT.wp_apply_eq [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {α : Type} (x : TickT m α) (Q : α → Nat → Pred) (E : EPred) (n : Nat) :
     TickT.wp x Q E n = ⨅ r, WP.wp x.run (fun a m => ⌜r ≤ m⌝ ⊓ Q a (m - r)) E (n + r) := by
-  simp only [TickT.wp, WP.frameClosure, iInf_apply, costConj_imp]
+  simp only [TickT.wp, PredTrans.apply_frameClosure, iInf_apply, costConj_imp]
   rfl
 
 theorem TickT.le_wp_tick [Monad m] [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
@@ -190,7 +190,7 @@ noncomputable instance TickT.instWPMonad [Assertion Pred] [Assertion EPred] [WPM
 theorem frames_costConj [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]
     {α : Type} (x : TickT m α) (F : Nat) : WP.Frames costConj x F :=
   WP.Frames.of_frameClosure costConj (· + ·) costConj_add
-    ⟨fun y E Q' => WP.wp y.run Q' E, fun _ _ _ => rfl⟩
+    ⟨fun y => WP.wpTrans y.run, fun _ => rfl⟩
 
 /-- The frame rule, pointwise: holding `F` commutes into the postcondition of any `TickT` program. -/
 theorem tickFrames [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred]


### PR DESCRIPTION
This PR states the frame closure as a map from predicate transformers to predicate transformers. It also moves the closure and `PredTrans` to `Std.Internal.Order`.

The closure is now `PredTrans.frameClosure op : PredTrans Pred EPred β → PredTrans Pred EPred β`. The `WP` instance built from it reduces to `wpTrans x := (base.wpTrans x).frameClosure op`.

`Std/Internal/Do/PredTrans.lean` is gone. The structure and its instances are now together in `Lean.Order`, because instances belong with their type. The declarations that name `EPost` remain in `Std.Internal.Do`, because the order library does not import `EPost`. `PredTrans.pushExcept` and `pushOption` join the `WPMonad` instances that use them. The two `EPost.Cons` helpers join the rest of the `EPost` API in `ExceptPost.lean`.