### PR TITLE
fix: invariants of the ST.Ref implementation

### DIFF
--- a/src/Init/System/ST.lean
+++ b/src/Init/System/ST.lean
@@ -187,23 +187,26 @@ private noncomputable def inhabitedFromRef {σ α} (r : Ref σ α) : ST σ α :=
 opaque mkRef {σ α} (a : α) : ST σ (Ref σ α) := pure { ref := Classical.choice RefPointed.property, h := Nonempty.intro a }
 @[extern "lean_st_ref_get"]
 opaque Ref.get {σ α} (r : @& Ref σ α) : ST σ α := inhabitedFromRef r
-@[extern "lean_st_ref_set"]
-opaque Ref.set {σ α} (r : @& Ref σ α) (a : α) : ST σ Unit
 @[extern "lean_st_ref_swap"]
 opaque Ref.swap {σ α} (r : @& Ref σ α) (a : α) : ST σ α := inhabitedFromRef r
 @[extern "lean_st_ref_take"]
 unsafe opaque Ref.take {σ α} (r : @& Ref σ α) : ST σ α := inhabitedFromRef r
+@[extern "lean_st_ref_put"]
+unsafe opaque Ref.put {σ α} (r : @& Ref σ α) (a : α) : ST σ Unit
 @[extern "lean_st_ref_ptr_eq"]
 opaque Ref.ptrEq {σ α} (r1 r2 : @& Ref σ α) : ST σ Bool
 
+@[inline] def Ref.set {σ α : Type} (r : Ref σ α) (a : α) : ST σ Unit := do
+  discard <| Ref.swap r a
+
 @[inline] unsafe def Ref.modifyUnsafe {σ α : Type} (r : Ref σ α) (f : α → α) : ST σ Unit := do
   let v ← Ref.take r
-  Ref.set r (f v)
+  Ref.put r (f v)
 
 @[inline] unsafe def Ref.modifyGetUnsafe {σ α β : Type} (r : Ref σ α) (f : α → β × α) : ST σ β := do
   let v ← Ref.take r
   let (b, a) := f v
-  Ref.set r a
+  Ref.put r a
   pure b
 
 @[implemented_by Ref.modifyUnsafe]
@@ -244,9 +247,18 @@ original value is returned.
 Reads the value of a mutable reference cell, removing it.
 
 This causes subsequent attempts to read from or take the reference cell to block until a new value
-is written using `ST.Ref.set`.
+is written using `ST.Ref.put`.
 -/
 @[inline] unsafe def Ref.take {α : Type} (r : Ref σ α) : m α := liftM <| Prim.Ref.take r
+
+/--
+Puts a value into a mutable reference, finishing the critical section opened by `ST.Ref.take`.
+
+This function assumes that `ST.Ref.take` has been called on `r` before and no other `ST.Ref.put`
+has since acted on `r`. Breaking this invariant may lead to undefined behavior.
+-/
+@[inline] unsafe def Ref.put {α : Type} (r : Ref σ α) (a : α) : m Unit := liftM <| Prim.Ref.put r a
+
 /--
 Checks whether two reference cells are in fact aliases for the same cell.
 

--- a/src/include/lean/lean.h
+++ b/src/include/lean/lean.h
@@ -3034,8 +3034,8 @@ LEAN_EXPORT lean_obj_res lean_mk_io_user_error(lean_obj_arg str);
 /* ST Ref primitives */
 LEAN_EXPORT lean_obj_res lean_st_mk_ref(lean_obj_arg);
 LEAN_EXPORT lean_obj_res lean_st_ref_get(b_lean_obj_arg);
-LEAN_EXPORT lean_obj_res lean_st_ref_set(b_lean_obj_arg, lean_obj_arg);
-LEAN_EXPORT lean_obj_res lean_st_ref_reset(b_lean_obj_arg);
+LEAN_EXPORT lean_obj_res lean_st_ref_put(b_lean_obj_arg, lean_obj_arg);
+LEAN_EXPORT lean_obj_res lean_st_ref_take(b_lean_obj_arg);
 LEAN_EXPORT lean_obj_res lean_st_ref_swap(b_lean_obj_arg, lean_obj_arg);
 
 /* pointer address unsafe primitive  */

--- a/src/runtime/io.cpp
+++ b/src/runtime/io.cpp
@@ -1469,6 +1469,7 @@ extern "C" LEAN_EXPORT obj_res lean_st_ref_get(b_obj_arg ref) {
                 inc(val);
                 object * tmp = val_addr->exchange(val);
                 lean_assert(tmp == nullptr);
+                (void)tmp;
                 return val;
             }
         }
@@ -1507,6 +1508,7 @@ extern "C" LEAN_EXPORT obj_res lean_st_ref_put(b_obj_arg ref, obj_arg a) {
         atomic<object *> * val_addr = mt_ref_val_addr(ref);
         object * old_a = val_addr->exchange(a);
         lean_assert(old_a == nullptr);
+        (void)old_a;
         return box(0);
     } else {
         if (lean_to_ref(ref)->m_value != nullptr)

--- a/src/runtime/io.cpp
+++ b/src/runtime/io.cpp
@@ -1468,10 +1468,7 @@ extern "C" LEAN_EXPORT obj_res lean_st_ref_get(b_obj_arg ref) {
             if (val != nullptr) {
                 inc(val);
                 object * tmp = val_addr->exchange(val);
-                if (tmp != nullptr) {
-                    /* this may happen if another thread wrote `ref` */
-                    dec(tmp);
-                }
+                lean_assert(tmp == nullptr);
                 return val;
             }
         }
@@ -1501,7 +1498,7 @@ extern "C" LEAN_EXPORT obj_res lean_st_ref_take(b_obj_arg ref) {
 
 static_assert(sizeof(atomic<unsigned short>) == sizeof(unsigned short), "`atomic<unsigned short>` and `unsigned short` must have the same size"); // NOLINT
 
-extern "C" LEAN_EXPORT obj_res lean_st_ref_set(b_obj_arg ref, obj_arg a) {
+extern "C" LEAN_EXPORT obj_res lean_st_ref_put(b_obj_arg ref, obj_arg a) {
     if (ref_maybe_mt(ref)) {
         /* We must mark `a` as multi-threaded if `ref` is marked as multi-threaded.
            Reason: our runtime relies on the fact that a single-threaded object
@@ -1509,8 +1506,7 @@ extern "C" LEAN_EXPORT obj_res lean_st_ref_set(b_obj_arg ref, obj_arg a) {
         mark_mt(a);
         atomic<object *> * val_addr = mt_ref_val_addr(ref);
         object * old_a = val_addr->exchange(a);
-        if (old_a != nullptr)
-            dec(old_a);
+        lean_assert(old_a == nullptr);
         return box(0);
     } else {
         if (lean_to_ref(ref)->m_value != nullptr)

--- a/src/runtime/object.h
+++ b/src/runtime/object.h
@@ -474,8 +474,8 @@ LEAN_EXPORT void io_eprintln(obj_arg s);
 // ST ref primitives
 inline obj_res st_mk_ref(obj_arg v) { return lean_st_mk_ref(v); }
 inline obj_res st_ref_get(b_obj_arg r) { return lean_st_ref_get(r); }
-inline obj_res st_ref_set(b_obj_arg r, obj_arg v) { return lean_st_ref_set(r, v); }
-inline obj_res st_ref_reset(b_obj_arg r) { return lean_st_ref_reset(r); }
+inline obj_res st_ref_put(b_obj_arg r, obj_arg v) { return lean_st_ref_put(r, v); }
+inline obj_res st_ref_take(b_obj_arg r) { return lean_st_ref_take(r); }
 inline obj_res st_ref_swap(b_obj_arg r, obj_arg v) { return lean_st_ref_swap(r, v); }
 
 obj_res lean_promise_new();

--- a/tests/elab/baseIO.lean.out.expected
+++ b/tests/elab/baseIO.lean.out.expected
@@ -5,7 +5,7 @@
       cases _x.3 : ST.Out lcAny UInt32
       | ST.Out.mk val.4 state.5 =>
         let _x.6 := 10;
-        let _x.7 := @ST.Prim.Ref.set _ _ val.4 _x.6 state.5;
+        let _x.7 := @ST.Prim.Ref.swap _ _ val.4 _x.6 state.5;
         cases _x.7 : ST.Out lcAny UInt32
         | ST.Out.mk val.8 state.9 =>
           let _x.10 := @ST.Prim.Ref.get _ _ val.4 state.9;

--- a/tests/elab/st_test.lean
+++ b/tests/elab/st_test.lean
@@ -45,7 +45,7 @@ info: 0
 unsafe def takeRegister : IO Unit := do
   let ref1 ← IO.mkRef 0
   IO.println (← ref1.take)
-  ref1.set 5
+  ref1.put 5
   IO.println (← ref1.get)
 
 /--


### PR DESCRIPTION
This PR fixes the remaining issues with `ST.Ref`. We now enforce that `ST.Ref` acts truly like a spinlock by introducing two changes:
1. `ST.Ref.set` is now just `discard <| ST.Ref.swap` and fulfills no special purpose for closing the critical section opened by `ST.Ref.take` anymore
2. We introduce an `unsafe` function called `ST.Ref.put` which may only be called after a critical section has been opened using the `unsafe` `ST.Ref.take`. We then implement `modify` and friends using these operations.

In addition, enforcing that `ST.Ref` is a proper spinlock allows us to remove a few branches around previous races with `ST.Ref.set`.

The PR is accompanied by a (completely AI generated) formalization on the stref-veil repo: https://github.com/leanprover/stref-veil/pull/1