### PR TITLE
refactor: move the `vcgen` tactic to `Lean.Elab.Tactic.VCGen`

### DIFF
--- a/src/Lean/Elab/Tactic.lean
+++ b/src/Lean/Elab/Tactic.lean
@@ -57,5 +57,6 @@ public import Lean.Elab.Tactic.SimpArith
 public import Lean.Elab.Tactic.Show
 public import Lean.Elab.Tactic.Lets
 public import Lean.Elab.Tactic.Do
+public import Lean.Elab.Tactic.VCGen
 public import Lean.Elab.Tactic.Decide
 public import Lean.Elab.Tactic.Cbv

--- a/src/Lean/Elab/Tactic/Do.lean
+++ b/src/Lean/Elab/Tactic/Do.lean
@@ -13,4 +13,3 @@ public import Lean.Elab.Tactic.Do.Contract
 public import Lean.Elab.Tactic.Do.LetElim
 public import Lean.Elab.Tactic.Do.Spec
 public import Lean.Elab.Tactic.Do.VCGen
-public import Lean.Elab.Tactic.Do.Internal

--- a/src/Lean/Elab/Tactic/Do/Attr.lean
+++ b/src/Lean/Elab/Tactic/Do/Attr.lean
@@ -238,7 +238,7 @@ def getSpecTheorems : CoreM SpecTheorems :=
 
 end Lean.Elab.Tactic.Do.SpecAttr
 
-namespace Lean.Elab.Tactic.Do.Internal.SpecAttr
+namespace Lean.Elab.Tactic.VCGen.SpecAttr
 
 open Lean Meta Std.Internal.Do Lean.Order
 
@@ -678,7 +678,7 @@ def SpecExtension.getTheorems (ext : SpecExtension) : CoreM SpecTheorems :=
 def getSpecTheorems : CoreM SpecTheorems :=
   specAttr.getTheorems
 
-end Lean.Elab.Tactic.Do.Internal.SpecAttr
+end Lean.Elab.Tactic.VCGen.SpecAttr
 
 namespace Lean.Elab.Tactic.Do.SpecAttr
 
@@ -699,7 +699,7 @@ def mkSpecAttr : AttributeImpl where
       catch _ =>
       try
         -- New metatheory `Std.Internal.Do.Triple` / `⊑ wp` specs.
-        Internal.SpecAttr.specAttr.addSpecTheoremFromConst declName prio attrKind
+        _root_.Lean.Elab.Tactic.VCGen.SpecAttr.specAttr.addSpecTheoremFromConst declName prio attrKind
       catch _ =>
       -- Equality / unfold specs: register for legacy `mvcgen` via `mvcgen_simp`, and for the new
       -- metatheory's internal database with the annotated priority (the `mvcgen_simp` hand-off
@@ -709,7 +709,7 @@ def mkSpecAttr : AttributeImpl where
         let newStx ← `(attr| mvcgen_simp)
         let newStx := newStx.raw.setArg 3 stx[1]
         impl.add declName newStx attrKind
-        Internal.SpecAttr.specAttr.addSimpSpecTheoremsFromConst declName prio attrKind
+        _root_.Lean.Elab.Tactic.VCGen.SpecAttr.specAttr.addSimpSpecTheoremsFromConst declName prio attrKind
       catch e =>
       trace[Elab.Tactic.Do.specAttr] "Reason for failure to apply spec attribute: {e.toMessageData}"
       throwError "Invalid 'spec': target was neither a Hoare triple specification nor a 'simp' lemma"

--- a/src/Lean/Elab/Tactic/Do/ConjunctivePre.lean
+++ b/src/Lean/Elab/Tactic/Do/ConjunctivePre.lean
@@ -92,7 +92,7 @@ re-routes the point-frame through the premises: the conclusion VC trivializes an
 lands at the current state, losslessly. The analysis stays with the premise-free fragment.
 -/
 
-namespace Lean.Elab.Tactic.Do.Internal.SpecAttr
+namespace Lean.Elab.Tactic.VCGen.SpecAttr
 
 open Lean Meta Std.Internal.Do Lean.Order
 
@@ -154,4 +154,4 @@ public def isConjunctiveInPosts (concl : Expr) (binders : Array Expr) : MetaM Bo
     if occursMVar qs (← inferType b) then return false
   return isConjunctiveIn qs pre
 
-end Lean.Elab.Tactic.Do.Internal.SpecAttr
+end Lean.Elab.Tactic.VCGen.SpecAttr

--- a/src/Lean/Elab/Tactic/Do/Internal.lean
+++ b/src/Lean/Elab/Tactic/Do/Internal.lean
@@ -1,9 +1,0 @@
-/-
-Copyright (c) 2026 Lean FRO LLC. All rights reserved.
-Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Sebastian Graf
--/
-module
-
-prelude
-public import Lean.Elab.Tactic.Do.Internal.VCGen

--- a/src/Lean/Elab/Tactic/VCGen.lean
+++ b/src/Lean/Elab/Tactic/VCGen.lean
@@ -6,17 +6,17 @@ Authors: Sebastian Graf
 module
 
 prelude
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Reduce
-public import Lean.Elab.Tactic.Do.Internal.VCGen.SpecDB
-public import Lean.Elab.Tactic.Do.Internal.VCGen.RuleConstruction
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Context
-public import Lean.Elab.Tactic.Do.Internal.VCGen.EPost
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Util
-public import Lean.Elab.Tactic.Do.Internal.VCGen.RuleCache
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Entails
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Solve
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Driver
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Frontend
+public import Lean.Elab.Tactic.VCGen.Reduce
+public import Lean.Elab.Tactic.VCGen.SpecDB
+public import Lean.Elab.Tactic.VCGen.RuleConstruction
+public import Lean.Elab.Tactic.VCGen.Context
+public import Lean.Elab.Tactic.VCGen.EPost
+public import Lean.Elab.Tactic.VCGen.Util
+public import Lean.Elab.Tactic.VCGen.RuleCache
+public import Lean.Elab.Tactic.VCGen.Entails
+public import Lean.Elab.Tactic.VCGen.Solve
+public import Lean.Elab.Tactic.VCGen.Driver
+public import Lean.Elab.Tactic.VCGen.Frontend
 
 /-!
 The `vcgen` tactic, split across the modules above.

--- a/src/Lean/Elab/Tactic/VCGen/Context.lean
+++ b/src/Lean/Elab/Tactic/VCGen/Context.lean
@@ -7,17 +7,17 @@ module
 
 prelude
 public import Lean.Elab.Tactic.Do.VCGen.Basic
-public import Lean.Elab.Tactic.Do.Internal.VCGen.SpecDB
-public import Lean.Elab.Tactic.Do.Internal.VCGen.FrameProc
+public import Lean.Elab.Tactic.VCGen.SpecDB
+public import Lean.Elab.Tactic.VCGen.FrameProc
 public import Lean.Meta.Sym.Apply
 public import Lean.Meta.Sym.Simp.DiscrTree
 public import Lean.Meta.Sym.Simp.SimpM
 public import Lean.Meta.Tactic.Grind.Types
 
 open Lean Meta Elab Tactic Sym
-open Lean.Elab.Tactic.Do Lean.Elab.Tactic.Do.Internal.SpecAttr
+open Lean.Elab.Tactic.Do Lean.Elab.Tactic.VCGen.SpecAttr
 
-namespace Lean.Elab.Tactic.Do.Internal
+namespace Lean.Elab.Tactic.VCGen
 
 /-!
 The `VCGenM` monad: its read-only `Context` (a fixed bundle of pre-built
@@ -48,7 +48,7 @@ public structure FrameDB where
 public instance : Inhabited FrameDB := ⟨{}⟩
 
 /-- Pre-built backward rules used by `solve`. -/
-public structure VCGen.BackwardRules where
+public structure BackwardRules where
   /-- The backward rule for `Triple.intro`. Unfolds `⦃P⦄ x ⦃Q; E⦄` into `P ⊑ wp x Q E`. -/
   tripleIntro : BackwardRule
   /-- The backward rule for `Lean.Order.le_of_forall_le`. Peels one excess state argument
@@ -84,7 +84,7 @@ public structure VCGen.BackwardRules where
   forallIntro : BackwardRule
 
 /-- Build the backward rules used by `solve` from their underlying lemmas. -/
-public def VCGen.mkBackwardRules : MetaM VCGen.BackwardRules := do
+public def mkBackwardRules : MetaM BackwardRules := do
   return {
     tripleIntro := ← mkBackwardRuleFromDecl ``Std.Internal.Do.Triple.intro
     stateArgIntro := ← mkBackwardRuleFromDecl ``Lean.Order.le_of_forall_le
@@ -100,12 +100,12 @@ public def VCGen.mkBackwardRules : MetaM VCGen.BackwardRules := do
     forallIntro := ← mkBackwardRuleFromDecl ``Lean.Order.le_forall
   }
 
-public structure VCGen.Context where
+public structure Context where
   /-- Pre-built backward rules used by `solve`. -/
-  backwardRules : VCGen.BackwardRules
+  backwardRules : BackwardRules
   /-- The `@[frameproc]` registry snapshot taken at frontend init. `solve` selects a procedure per
   program node by the node's monad. -/
-  frameProcs : VCGen.FrameProcs := {}
+  frameProcs : FrameProcs := {}
   /-- User-customizable simp methods used to pre-simplify hypotheses. -/
   hypSimpMethods : Option Sym.Simp.Methods := none
   /-- The `trivial` config option: when `true` (default), `Driver.emitVC` runs
@@ -139,7 +139,7 @@ public structure VCGen.Context where
   once the program in `wp⟦e⟧` matches `pat`, before applying a spec. -/
   untilPat? : Option Sym.Pattern := none
 
-public structure VCGen.Scope where
+public structure Scope where
   /-- Spec database in scope: globals plus locals from in-scope hypotheses. -/
   specs : SpecTheorems
   /-- `__do_jp` fvars currently in scope. -/
@@ -151,7 +151,7 @@ public structure VCGen.Scope where
   nextDeclIdx : Nat := 0
   deriving Inhabited
 
-public structure VCGen.State where
+public structure State where
   /--
   A cache mapping registered SpecThms to their backward rule to apply.
   The particular rule depends on the theorem name, the `WPMonad` instance and the number of
@@ -213,9 +213,8 @@ public structure VCGen.State where
   warn about them). -/
   inlineHandledInvariants : Std.HashSet Nat := {}
 
-public abbrev VCGenM := ReaderT VCGen.Context (StateRefT VCGen.State Grind.GrindM)
+public abbrev VCGenM := ReaderT Context (StateRefT State Grind.GrindM)
 
-namespace VCGen
 
 public def Scope.registerJP (s : Scope) (fv : FVarId) (info : JumpSiteInfo) : Scope :=
   { s with jps := s.jps.insert fv info }
@@ -252,6 +251,5 @@ public def burnOne : VCGenM Unit :=
     | .limited (n+1) => .limited n
     | other => other }
 
-end VCGen
 
-end Lean.Elab.Tactic.Do.Internal
+end Lean.Elab.Tactic.VCGen

--- a/src/Lean/Elab/Tactic/VCGen/Driver.lean
+++ b/src/Lean/Elab/Tactic/VCGen/Driver.lean
@@ -7,21 +7,20 @@ module
 
 prelude
 public import Lean.Elab.Tactic.Meta
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Context
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Solve
+public import Lean.Elab.Tactic.VCGen.Context
+public import Lean.Elab.Tactic.VCGen.Solve
 public import Lean.Meta.Sym.Grind
 
 open Lean Meta Elab Tactic Sym
 open Lean.Elab.Tactic.Do.SpecAttr
 
-namespace Lean.Elab.Tactic.Do.Internal
+namespace Lean.Elab.Tactic.VCGen
 
 /-!
 Worklist driver for `vcgen`. Wraps `solve` with a queue of pending goals
 and emits VCs (or invariant holes) for those `solve` cannot decompose further.
 -/
 
-namespace VCGen
 
 /--
 Try to elaborate the user's invariant alt for invariant number `n` inline,
@@ -142,7 +141,7 @@ Return the VCs and invariant goals.
 
 `stepLimit?`, when `some n`, seeds the fuel counter to `n`; when `none`, fuel is unlimited.
 -/
-public partial def run (goal : Grind.Goal) (ctx : Context) (scope : VCGen.Scope)
+public partial def run (goal : Grind.Goal) (ctx : Context) (scope : Scope)
     (stepLimit? : Option Nat := none) (frameDB : FrameDB := {}) :
     Grind.GrindM Result := do
   let initState : State :=
@@ -164,6 +163,5 @@ public partial def run (goal : Grind.Goal) (ctx : Context) (scope : VCGen.Scope)
     inlineHandledInvariants := state.inlineHandledInvariants,
     unmatchedFrames }
 
-end VCGen
 
-end Lean.Elab.Tactic.Do.Internal
+end Lean.Elab.Tactic.VCGen

--- a/src/Lean/Elab/Tactic/VCGen/EPost.lean
+++ b/src/Lean/Elab/Tactic/VCGen/EPost.lean
@@ -13,9 +13,8 @@ public import Lean.Meta.Tactic.Replace
 open Lean Meta Sym
 open Std.Internal.Do Lean.Order
 
-namespace Lean.Elab.Tactic.Do.Internal
+namespace Lean.Elab.Tactic.VCGen
 
-namespace VCGen
 
 /-!
 Helpers for decomposing exception-postcondition (`EPost`) goals: reducing an `EPost.Cons.head`
@@ -105,6 +104,5 @@ public def replaceEPostHeadBot? (goal : MVarId) (target head : Expr) (args : Arr
     mkApp6 (mkConst ``congrArg [uα, .succ .zero]) α (mkSort .zero) (mkAppN head args) curBot relPre acc
   return some (← goal.replaceTargetEq (mkApp relPre curBot) eqProof)
 
-end VCGen
 
-end Lean.Elab.Tactic.Do.Internal
+end Lean.Elab.Tactic.VCGen

--- a/src/Lean/Elab/Tactic/VCGen/Entails.lean
+++ b/src/Lean/Elab/Tactic/VCGen/Entails.lean
@@ -6,17 +6,17 @@ Authors: Sebastian Graf, Vladimir Gladshtein
 module
 
 prelude
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Context
-public import Lean.Elab.Tactic.Do.Internal.VCGen.EPost
-public import Lean.Elab.Tactic.Do.Internal.VCGen.RuleCache
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Util
+public import Lean.Elab.Tactic.VCGen.Context
+public import Lean.Elab.Tactic.VCGen.EPost
+public import Lean.Elab.Tactic.VCGen.RuleCache
+public import Lean.Elab.Tactic.VCGen.Util
 public import Lean.Meta.Sym.Util
 import Lean.Meta.Sym.InferType
 import Lean.Meta.Sym.InstantiateMVarsS
 
 open Lean Meta Elab Tactic Sym Sym.Internal
-open Lean.Elab.Tactic.Do.Internal.SpecAttr
-open Lean.Elab.Tactic.Do.Internal
+open Lean.Elab.Tactic.VCGen.SpecAttr
+open Lean.Elab.Tactic.VCGen
 open Std.Internal.Do Lean.Order
 
 /-!
@@ -25,9 +25,8 @@ introducing excess state arguments and pure preconditions, reducing
 exception-postcondition projections, and decomposing lattice connectives.
 -/
 
-namespace Lean.Elab.Tactic.Do.Internal
+namespace Lean.Elab.Tactic.VCGen
 
-namespace VCGen
 
 /-- Unfold `⦃P⦄ x ⦃Q; E⦄` into the underlying entailment `P ⊑ wp x Q E`. -/
 public def unfoldTriple (goal : MVarId) : VCGenM MVarId := do
@@ -175,6 +174,5 @@ public def elimTopPre (goal : MVarId) : VCGenM MVarId := do
     | throwError "Failed to strip the `⊤ ⊑` wrapper of {goal}"
   return goal
 
-end VCGen
 
-end Lean.Elab.Tactic.Do.Internal
+end Lean.Elab.Tactic.VCGen

--- a/src/Lean/Elab/Tactic/VCGen/FrameProc.lean
+++ b/src/Lean/Elab/Tactic/VCGen/FrameProc.lean
@@ -6,7 +6,7 @@ Authors: Sebastian Graf, Vladimir Gladshtein
 module
 
 prelude
-public import Lean.Elab.Tactic.Do.Internal.VCGen.WPApp
+public import Lean.Elab.Tactic.VCGen.WPApp
 public import Lean.Meta.Sym.Apply
 public import Lean.Meta.Sym.AlphaShareBuilder
 import Std.Internal.Order.Basic
@@ -24,7 +24,7 @@ The metadata a frame inference procedure operates on: the `wp` application metad
 
 open Lean Meta Sym Sym.Internal
 
-namespace Lean.Elab.Tactic.Do.Internal
+namespace Lean.Elab.Tactic.VCGen
 
 /-- How the goal precondition frames through the frame operator: `vcgen` applies the frame rule with
 the `frame`, discharging the split VC `pre ⊑ (op frame residualPre) s⃗` with `proof` and leaving
@@ -33,7 +33,7 @@ which the solver fills after the frame rule applies.
 
 Build a `FrameSplit` with `FrameSplit.withDischargedSplitVC` (proof supplied) or
 `FrameSplit.withDeferredSplitVC` (split VC left as one subgoal). -/
-public structure VCGen.FrameSplit where
+public structure FrameSplit where
   /-- The framed resource. -/
   frame : Expr
   /-- The residual precondition the program runs against once `frame` is framed off: in the split VC
@@ -46,7 +46,7 @@ public structure VCGen.FrameSplit where
   subgoals : List MVarId
 
 /-- Instantiate a `FrameSplit`'s data against the current metavariable context (and reshare). -/
-public def VCGen.FrameSplit.instantiateMVarsS (split : FrameSplit) : SymM FrameSplit :=
+public def FrameSplit.instantiateMVarsS (split : FrameSplit) : SymM FrameSplit :=
   return { split with
            frame := ← Sym.instantiateMVarsS split.frame
            splitVCProof := ← Sym.instantiateMVarsS split.splitVCProof }
@@ -54,7 +54,7 @@ public def VCGen.FrameSplit.instantiateMVarsS (split : FrameSplit) : SymM FrameS
 /-- The inputs to a `FrameInferenceProc`: the goal, how the frame was requested, and the spec being
 applied. Extends the program's `wp` metadata (`WPApp`), so `Pred`, `excessArgs`, etc. are available
 directly. -/
-public structure VCGen.FrameInferenceInfo extends VCGen.WPApp where
+public structure FrameInferenceInfo extends WPApp where
   /-- The entailment goal `pre ⊑ wp …` the frame rule or spec applies to. -/
   goal : MVarId
   /-- The frame pinned by a matching `frames` clause, or `none` to infer the frame, e.g. from the
@@ -71,23 +71,23 @@ public structure VCGen.FrameInferenceInfo extends VCGen.WPApp where
 
 /-- The goal's entailment relation `PartialOrder.rel α inst` (carrier and order instance applied);
 apply it to two operands to build an entailment in the goal's order. -/
-public def VCGen.FrameInferenceInfo.le (i : FrameInferenceInfo) : SymM Expr :=
+public def FrameInferenceInfo.le (i : FrameInferenceInfo) : SymM Expr :=
   return (← i.goal.getType).stripArgsN 2
 
 /-- What holds going in: the left-hand side of the goal entailment `pre ⊑ wp …`. -/
-public def VCGen.FrameInferenceInfo.pre (i : FrameInferenceInfo) : SymM Expr :=
+public def FrameInferenceInfo.pre (i : FrameInferenceInfo) : SymM Expr :=
   return (← i.goal.getType).appFn!.appArg!
 
 /-- A fresh residual-precondition metavariable for a `FrameSplit`: synthetic-opaque; the procedure
 builds the split VC against it and leaves it unassigned. -/
-public def VCGen.FrameInferenceInfo.mkResidualPre (i : FrameInferenceInfo) : SymM MVarId :=
+public def FrameInferenceInfo.mkResidualPre (i : FrameInferenceInfo) : SymM MVarId :=
   return (← mkFreshExprSyntheticOpaqueMVar i.Pred).mvarId!
 
 /-- The spec precondition instantiated at the call site, read off a speculative application of
 `specRule` to `goal` that is rolled back: the precondition VC's metavariables are frozen into a
 telescope and reopened fresh in the restored context, so they outlive the rollback. `none` when the
 rule does not apply or leaves no precondition VC. -/
-public def VCGen.FrameInferenceInfo.specPre? (i : FrameInferenceInfo) : SymM (Option Expr) := do
+public def FrameInferenceInfo.specPre? (i : FrameInferenceInfo) : SymM (Option Expr) := do
   let abs? ← Meta.withoutModifyingMCtx do
     let .goals subgoals ← i.specRule.apply i.goal | return none
     -- The precondition VC is the only bare `pre ⊑ specPre` entailment among the rule's subgoals;
@@ -106,7 +106,7 @@ public def VCGen.FrameInferenceInfo.specPre? (i : FrameInferenceInfo) : SymM (Op
 /-- The split VC proposition `pre ⊑ (op frame footprint) s⃗`: the frame operator applied to `frame`
 and `footprint`, then to the excess state arguments, entailed by `pre` in the goal's order. `frame`
 and `footprint` must be hash-consed (`shareCommon`); the result is. -/
-public def VCGen.FrameInferenceInfo.mkSplitVCS (i : FrameInferenceInfo) (frame footprint : Expr) :
+public def FrameInferenceInfo.mkSplitVCS (i : FrameInferenceInfo) (frame footprint : Expr) :
     SymM Expr := do
   let rhs ← mkAppNS (← mkAppNS (← i.mkOpApp) #[frame, footprint]) i.excessArgs
   let ty ← i.goal.getType
@@ -114,7 +114,7 @@ public def VCGen.FrameInferenceInfo.mkSplitVCS (i : FrameInferenceInfo) (frame f
 
 /-- A `FrameSplit` framing `frame` whose split VC `pre ⊑ (op frame residualPre) s⃗` is deferred as a
 fresh subgoal for the built-in lattice (meet) decomposition to split. -/
-public def VCGen.FrameSplit.withDeferredSplitVC (i : FrameInferenceInfo) (frame : Expr) :
+public def FrameSplit.withDeferredSplitVC (i : FrameInferenceInfo) (frame : Expr) :
     SymM FrameSplit := do
   let residualPre ← i.mkResidualPre
   let m ← mkFreshExprSyntheticOpaqueMVar (← i.mkSplitVCS frame (mkMVar residualPre))
@@ -122,7 +122,7 @@ public def VCGen.FrameSplit.withDeferredSplitVC (i : FrameInferenceInfo) (frame 
 
 /-- A `FrameSplit` framing `frame`, discharging the split VC `pre ⊑ (op frame residualPre) s⃗` with
 `splitVCProof` and leaving its `subgoals`. -/
-public def VCGen.FrameSplit.withDischargedSplitVC (frame : Expr) (residualPre : MVarId)
+public def FrameSplit.withDischargedSplitVC (frame : Expr) (residualPre : MVarId)
     (splitVCProof : Expr) (subgoals : List MVarId := []) : FrameSplit :=
   { frame, residualPre, splitVCProof, subgoals }
 
@@ -130,7 +130,7 @@ public def VCGen.FrameSplit.withDischargedSplitVC (frame : Expr) (residualPre : 
 rule's goal list: the schematic frame and the split VC `pre ⊑ (op frame W) s⃗`, where `W` is the
 weakest footprint baked into the rule. The positions are fixed at rule construction, so applying a
 `FrameSplit` assigns by index. -/
-public structure VCGen.FrameBackwardRule where
+public structure FrameBackwardRule where
   /-- The backward rule concluding `pre ⊑ wp x Q E s⃗`. -/
   rule : Lean.Meta.Sym.BackwardRule
   /-- Position of the split VC `pre ⊑ (op frame W) s⃗`. -/
@@ -146,13 +146,13 @@ The procedure produces the frame and a proof of the split VC `pre ⊑ (op frame 
 must not assign `residualPre`, which the solver fills with the weakest footprint after the frame rule
 applies. Build the result with `FrameSplit.withDischargedSplitVC` (proof supplied) or
 `FrameSplit.withDeferredSplitVC` (split VC left as a subgoal). -/
-public abbrev VCGen.FrameInferenceProc :=
-  VCGen.FrameInferenceInfo → SymM (Option VCGen.FrameSplit)
+public abbrev FrameInferenceProc :=
+  FrameInferenceInfo → SymM (Option FrameSplit)
 
 /-- How to decompose a lattice operator `head … s⃗` on the RHS of an entailment: the distribution and
 unfolding `rewrites` that saturate it, and the terminal `⊑`-introduction `terminals` that close the
 reduced form. `head` keys the split in the `latticeOps` table. -/
-public structure VCGen.LatticeOp where
+public structure LatticeOp where
   /-- Head constant of the operator this split decomposes. Keys the `latticeOps` table. -/
   head : Name
   /-- The number of leading arguments held constant during rule construction: the operator's carrier
@@ -168,48 +168,48 @@ public structure VCGen.LatticeOp where
 
 /-- A frame inference procedure registered with `@[frameproc]`, together with its frame operator. The
 `vcgen` frontend selects the one whose `prog` matches the goal program's monad. -/
-public structure VCGen.FrameProc where
+public structure FrameProc where
   /-- Head constant of the program type (the monad) whose `wp` this procedure frames. Keys the
   procedure in the `byProg` index; `vcgen` consults it for a program with that head. -/
   prog : Name
   /-- Head constant of the frame operator, locating the split VC in the frame rule. -/
   opHead : Name
   /-- Builds the frame operator (head constant `opHead`) applied to the goal's assertion type. -/
-  mkOpAppM : VCGen.WPApp → MetaM Expr
+  mkOpAppM : WPApp → MetaM Expr
   /-- The resource type `R` of the operator `op : R → Pred → Pred`, i.e. the domain of `mkOpAppM`'s
   result. Provided directly so `vcgen` reads it without building the operator, which it does only when
   a frame actually applies. -/
-  mkResourceTy : VCGen.WPApp → MetaM Expr
+  mkResourceTy : WPApp → MetaM Expr
   /-- The frame inference metaprogram. -/
-  proc : VCGen.FrameInferenceProc
+  proc : FrameInferenceProc
 
 /-- The registered frame inference procedures, indexed by the program monad's head constant
 (selected per node in `solve`). -/
-public structure VCGen.FrameProcs where
-  byProg : Std.HashMap Name VCGen.FrameProc := {}
+public structure FrameProcs where
+  byProg : Std.HashMap Name FrameProc := {}
 
-public instance : Inhabited VCGen.FrameProcs := ⟨{}⟩
+public instance : Inhabited FrameProcs := ⟨{}⟩
 
-public def VCGen.FrameProcs.insert (s : FrameProcs) (fp : FrameProc) : FrameProcs :=
+public def FrameProcs.insert (s : FrameProcs) (fp : FrameProc) : FrameProcs :=
   { byProg := s.byProg.insert fp.prog fp }
 
 /-- Default frame inference procedure, agnostic of the frame operator: frame the resource pinned by
 a `frames` clause, with the weakest footprint. -/
-public def VCGen.defaultFrameInferenceProc : FrameInferenceProc := fun i => do
+public def defaultFrameInferenceProc : FrameInferenceProc := fun i => do
   let some frame := i.providedFrame? | return none
   return some (← FrameSplit.withDeferredSplitVC i frame)
 
 /-- The lattice meet operator over the goal's assertion type. -/
-private def meetOp (info : VCGen.WPApp) : MetaM Expr :=
+private def meetOp (info : WPApp) : MetaM Expr :=
   Meta.mkAppOptM ``Lean.Order.meet #[info.Pred, none]
 
 /-- The default frame operator: lattice meet `pre ⊓ frame`, the Hoare frame every complete lattice carries.
 Framed only through an explicit `frames` clause; used for a monad with no registered `@[frameproc]`. -/
-public def VCGen.meetFrameProc : VCGen.FrameProc where
+public def meetFrameProc : FrameProc where
   prog := ``Lean.Order.meet
   mkOpAppM := meetOp
   mkResourceTy info := pure info.Pred
   opHead := ``Lean.Order.meet
   proc := defaultFrameInferenceProc
 
-end Lean.Elab.Tactic.Do.Internal
+end Lean.Elab.Tactic.VCGen

--- a/src/Lean/Elab/Tactic/VCGen/FrameProcAttr.lean
+++ b/src/Lean/Elab/Tactic/VCGen/FrameProcAttr.lean
@@ -6,18 +6,18 @@ Authors: Sebastian Graf
 module
 
 prelude
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Context
+public import Lean.Elab.Tactic.VCGen.Context
 
 /-!
 The `@[frameproc]` attribute registers `FrameProc`s for `vcgen`.
 -/
 
 open Lean Meta Elab Sym
-open Lean.Elab.Tactic.Do.Internal
+open Lean.Elab.Tactic.VCGen
 
 public section
 
-namespace Lean.Elab.Tactic.Do.Internal.VCGen
+namespace Lean.Elab.Tactic.VCGen
 
 unsafe def getFrameProcFromDeclImpl (declName : Name) : ImportM FrameProc := do
   let ctx ← read
@@ -63,4 +63,4 @@ builtin_initialize registerBuiltinAttribute {
   add             := fun declName _stx kind => addFrameProcAttr declName kind
 }
 
-end Lean.Elab.Tactic.Do.Internal.VCGen
+end Lean.Elab.Tactic.VCGen

--- a/src/Lean/Elab/Tactic/VCGen/Frontend.lean
+++ b/src/Lean/Elab/Tactic/VCGen/Frontend.lean
@@ -8,9 +8,9 @@ module
 prelude
 public import Lean.Elab.Tactic.Do.VCGen.SuggestInvariant
 public import Lean.Elab.Tactic.Do.VCGen
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Context
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Driver
-public import Lean.Elab.Tactic.Do.Internal.VCGen.FrameProcAttr
+public import Lean.Elab.Tactic.VCGen.Context
+public import Lean.Elab.Tactic.VCGen.Driver
+public import Lean.Elab.Tactic.VCGen.FrameProcAttr
 public import Lean.Meta.Sym.Simp.Attr
 public import Lean.Meta.Sym.Simp.ControlFlow
 public import Lean.Meta.Sym.Simp.EvalGround
@@ -22,13 +22,13 @@ public import Lean.Elab.Tactic.Grind.Basic
 import Lean.Meta.Sym.ProofInstInfo
 
 open Lean Parser Meta Elab Tactic Sym
-open Lean.Elab.Tactic.Do Lean.Elab.Tactic.Do.Internal.SpecAttr
+open Lean.Elab.Tactic.Do Lean.Elab.Tactic.VCGen.SpecAttr
 
-namespace Lean.Elab.Tactic.Do.Internal
+namespace Lean.Elab.Tactic.VCGen
 
 /-!
 `vcgen` tactic frontend: parse the user-facing argument syntax into a
-`VCGen.Context`, run `VCGen.run`, and replace the main goal with the
+`Context`, run `run`, and replace the main goal with the
 resulting invariants and VCs.
 -/
 
@@ -36,7 +36,6 @@ resulting invariants and VCs.
 private def runTacticM (x : TacticM α) (goals : List MVarId := [])  : TermElabM α :=
   x.run { elaborator := `mvcgen } |>.run' { goals }
 
-namespace VCGen
 
 /--
 Parse the optional `[...]` argument list for `vcgen`, partitioning entries into
@@ -45,7 +44,7 @@ spec theorems and simp lemmas. Follows the same approach as
 and on failure falls back to a simp/unfold lemma processed via `mkSimpContext`.
 -/
 public def mkContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := false) :
-    TermElabM (VCGen.Context × VCGen.Scope) := do
+    TermElabM (Context × Scope) := do
   let mut specThms ← getSpecTheorems
   let mut simpStuff := #[]
   let mut simpTermThms : Array SimpTheorem := #[]
@@ -139,9 +138,9 @@ public def mkContext (lemmas : Syntax) (goal : MVarId) (ignoreStarArg := false) 
           if let some thm ← mkSpecTheoremFromLocal fvar starSpecPrio then
             specThms := specThms.insert thm
         catch _ => continue
-  let backwardRules ← VCGen.mkBackwardRules
+  let backwardRules ← mkBackwardRules
   let allSpecThms ← addSimpSpecs specThms simpThms
-  let ctx : VCGen.Context := { backwardRules }
+  let ctx : Context := { backwardRules }
   return (ctx, { specs := allSpecThms })
 
 /-- True iff `m` carries a `WPMonad m _ _` instance, i.e. it is a genuine weakest-precondition monad
@@ -180,14 +179,13 @@ public def inferProgType? (goalType : Expr) : MetaM (Option Expr) := withReducib
         return some progTy.appFn!
     return some progTy
 
-end VCGen
 
 /-- Warn about `vcgen` config options that are accepted by the parser but currently
 ignored at runtime. As more options gain implementation support, drop their checks
 here. Options with implemented semantics (`trivial`, `elimLets`, `stepLimit`,
 `invariants?`) are silently accepted. -/
-private def warnIgnoredConfig (config : VCGen.Config) : MetaM Unit := do
-  let default : VCGen.Config := {}
+private def warnIgnoredConfig (config : Do.VCGen.Config) : MetaM Unit := do
+  let default : Do.VCGen.Config := {}
   if config.leave != default.leave then
     logWarning "vcgen: the `leave` config option is currently ignored."
 
@@ -287,8 +285,8 @@ private def parseInvariantMap (stx : Syntax) :
 
 /--
 Run after VC generation: iterate the (unfiltered) `invariants` array returned by
-`VCGen.run`, look up each entry in the pre-parsed `alts` map by its 1-based
-position (which equals the `inv<n>` tag the entry carries — `VCGen.run` assigns
+`run`, look up each entry in the pre-parsed `alts` map by its 1-based
+position (which equals the `inv<n>` tag the entry carries — `run` assigns
 tags consecutively), and elaborate the matching alt. Invariants that were already
 elaborated inline by `Driver.emitVC` (tracked in `inlineHandled`) are skipped, so
 we don't warn about alts that were already consumed there. -/
@@ -300,7 +298,7 @@ private def elabRemainingInvariants (alts : Std.HashMap Nat Syntax)
     if handled.contains n then continue
     let some alt := alts[n]? | continue
     handled := handled.insert n
-    discard <| VCGen.elabInvariant alts n invariants[i]
+    discard <| elabInvariant alts n invariants[i]
   -- Warn on user-provided alts that matched no invariant goal (neither inline nor post-hoc).
   for (n, alt) in alts.toArray do
     unless handled.contains n do
@@ -308,9 +306,9 @@ private def elabRemainingInvariants (alts : Std.HashMap Nat Syntax)
 
 /-- Parsed `vcgen` arguments shared by the two entry points. -/
 private structure ParsedArgs where
-  config : VCGen.Config
-  ctx : VCGen.Context
-  scope : VCGen.Scope
+  config : Do.VCGen.Config
+  ctx : Context
+  scope : Scope
   invariantAlts? : Option (Std.HashMap Nat Syntax)
   frameDB : FrameDB
 
@@ -395,12 +393,12 @@ private def parseArgs (stx : Syntax) (goal : MVarId) : TermElabM ParsedArgs := g
   -- `case vcN bs* =>` patterns line up. Re-enabling on opt-in would require detecting
   -- explicit `(elimLets := true)` at the syntax level (upstream `Config` can't
   -- distinguish "default true" from "user-set true"); not yet wired.
-  let (ctx, scope) ← VCGen.mkContext stx[2] goal
+  let (ctx, scope) ← mkContext stx[2] goal
   -- The program type, inferred once from the goal, is the expected type for the `frames`/`until`
   -- program patterns (so overloaded heads resolve). A goal with no program cannot be a `vcgen` goal.
-  let some progTy ← VCGen.inferProgType? (← goal.getType)
+  let some progTy ← inferProgType? (← goal.getType)
     | throwError "vcgen: could not determine the program type of the goal"
-  let frameProcs ← VCGen.getFrameProcs
+  let frameProcs ← getFrameProcs
   let untilPat? ← if stx[3].isNone then pure none
     else some <$> elabUntilPattern progTy ⟨stx[3][1]⟩
   let frameDB ← if stx[4].isNone then pure ({} : FrameDB)
@@ -425,7 +423,7 @@ def evalSymVCGen : Lean.Elab.Tactic.Grind.GrindTactic := fun stx => do
   let goal ← Lean.Elab.Tactic.Grind.getMainGoal
   let args ← parseArgs stx goal.mvarId
   let result ← Lean.Elab.Tactic.Grind.liftGrindM do
-    let result ← VCGen.run goal args.ctx args.scope args.config.stepLimit (frameDB := args.frameDB)
+    let result ← run goal args.ctx args.scope args.config.stepLimit (frameDB := args.frameDB)
     if let some alts := args.invariantAlts? then
       elabRemainingInvariants alts result.invariants result.inlineHandledInvariants
     return result
@@ -487,4 +485,4 @@ public def elabVCGen : Tactic := fun stx => withMainContext do
     Grind.evalGrindTactic step
   replaceMainGoal (state.goals.map (·.mvarId))
 
-end Lean.Elab.Tactic.Do.Internal
+end Lean.Elab.Tactic.VCGen

--- a/src/Lean/Elab/Tactic/VCGen/LatticeOp.lean
+++ b/src/Lean/Elab/Tactic/VCGen/LatticeOp.lean
@@ -8,7 +8,7 @@ module
 prelude
 public import Lean.Meta.Sym.Apply
 public import Std.Internal.Order.Heyting
-public import Lean.Elab.Tactic.Do.Internal.VCGen.FrameProc
+public import Lean.Elab.Tactic.VCGen.FrameProc
 import Std.Internal.Order.FrameClosure
 import Lean.Meta.Sym.Simp.Rewrite
 import Lean.Meta.AppBuilder
@@ -17,9 +17,8 @@ import Lean.Meta.AbstractMVars
 open Lean Meta Sym
 open Lean.Order
 
-namespace Lean.Elab.Tactic.Do.Internal
+namespace Lean.Elab.Tactic.VCGen
 
-namespace VCGen
 
 /-! ## Lattice split rules
 
@@ -180,5 +179,4 @@ public def mkLatticeOpRule (rhs : Expr) (op : LatticeOp) : SymM BackwardRule := 
     let res ← abstractMVars prf
     mkBackwardRuleFromExpr res.expr res.paramNames.toList
 
-end VCGen
-end Lean.Elab.Tactic.Do.Internal
+end Lean.Elab.Tactic.VCGen

--- a/src/Lean/Elab/Tactic/VCGen/Reduce.lean
+++ b/src/Lean/Elab/Tactic/VCGen/Reduce.lean
@@ -12,9 +12,8 @@ import Lean.Meta.Sym.Util
 
 open Lean Meta Sym
 
-namespace Lean.Elab.Tactic.Do.Internal
+namespace Lean.Elab.Tactic.VCGen
 
-namespace VCGen
 
 /-!
 SymM-level head-redex reducer used throughout VCGen.
@@ -80,5 +79,4 @@ public partial def reduceHead? (e : Expr) : SymM (Option Expr) :=
 public def reduceHead (e : Expr) : SymM Expr :=
   return (← reduceHead? e).getD e
 
-end VCGen
-end Lean.Elab.Tactic.Do.Internal
+end Lean.Elab.Tactic.VCGen

--- a/src/Lean/Elab/Tactic/VCGen/RuleCache.lean
+++ b/src/Lean/Elab/Tactic/VCGen/RuleCache.lean
@@ -7,24 +7,23 @@ module
 
 prelude
 public import Lean.Elab.Tactic.Do.VCGen.Split
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Context
-public import Lean.Elab.Tactic.Do.Internal.VCGen.RuleConstruction
-public import Lean.Elab.Tactic.Do.Internal.VCGen.LatticeOp
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Util
+public import Lean.Elab.Tactic.VCGen.Context
+public import Lean.Elab.Tactic.VCGen.RuleConstruction
+public import Lean.Elab.Tactic.VCGen.LatticeOp
+public import Lean.Elab.Tactic.VCGen.Util
 import Lean.Meta.Sym.InferType
 
 open Lean Meta Elab Tactic Sym
-open Lean.Elab.Tactic.Do.Internal.SpecAttr
-open Lean.Elab.Tactic.Do.Internal
+open Lean.Elab.Tactic.VCGen.SpecAttr
+open Lean.Elab.Tactic.VCGen
 
 /-!
 `VCGenM`-level cache wrappers around the `SymM` rule constructors in
 `VCGen.RuleConstruction`.
 -/
 
-namespace Lean.Elab.Tactic.Do.Internal
+namespace Lean.Elab.Tactic.VCGen
 
-namespace VCGen
 
 /--
 Cached version of spec rule construction.
@@ -96,6 +95,5 @@ public def mkFrameBackwardRuleCached (fp : FrameProc) (info : WPApp) :
   modify fun st => { st with frameBackwardRuleCache := st.frameBackwardRuleCache.insert key frule }
   return frule
 
-end VCGen
 
-end Lean.Elab.Tactic.Do.Internal
+end Lean.Elab.Tactic.VCGen

--- a/src/Lean/Elab/Tactic/VCGen/RuleConstruction.lean
+++ b/src/Lean/Elab/Tactic/VCGen/RuleConstruction.lean
@@ -7,18 +7,17 @@ module
 
 prelude
 public import Lean.Elab.Tactic.Do.VCGen.Split
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Context
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Reduce
-public import Lean.Elab.Tactic.Do.Internal.VCGen.SpecDB
+public import Lean.Elab.Tactic.VCGen.Context
+public import Lean.Elab.Tactic.VCGen.Reduce
+public import Lean.Elab.Tactic.VCGen.SpecDB
 public import Lean.Meta.Sym.Apply
 public import Lean.Meta.Sym.Util
 
 open Lean Meta Elab Tactic Sym
-open Lean.Elab.Tactic.Do.Internal.SpecAttr
+open Lean.Elab.Tactic.VCGen.SpecAttr
 
-namespace Lean.Elab.Tactic.Do.Internal
+namespace Lean.Elab.Tactic.VCGen
 
-namespace VCGen
 
 /-!
 Construction of `BackwardRule`s from `SpecTheorem`s and split info, with no knowledge of `VCGenM`.
@@ -453,5 +452,4 @@ public def mkFrameBackwardRule (fp : FrameProc) (info : WPApp) :
     | throwError "frame: could not build the frame rule for operator{indentExpr op}"
   analyzeFrameRule rule fp.opHead info.excessArgs.size
 
-end VCGen
-end Lean.Elab.Tactic.Do.Internal
+end Lean.Elab.Tactic.VCGen

--- a/src/Lean/Elab/Tactic/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/VCGen/Solve.lean
@@ -6,20 +6,20 @@ Authors: Sebastian Graf, Vladimir Gladshtein
 module
 
 prelude
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Context
-public import Lean.Elab.Tactic.Do.Internal.VCGen.RuleCache
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Entails
+public import Lean.Elab.Tactic.VCGen.Context
+public import Lean.Elab.Tactic.VCGen.RuleCache
+public import Lean.Elab.Tactic.VCGen.Entails
 public import Lean.Meta.Sym.InstantiateS
 public import Lean.Meta.Sym.Simp.App
 import Lean.Meta.Sym.InferType
 import Lean.Meta.Sym.InstantiateMVarsS
 
 open Lean Meta Elab Tactic Sym Sym.Internal
-open Lean.Elab.Tactic.Do.Internal.SpecAttr
-open Lean.Elab.Tactic.Do.Internal
+open Lean.Elab.Tactic.VCGen.SpecAttr
+open Lean.Elab.Tactic.VCGen
 open Std.Internal.Do Lean.Order
 
-namespace Lean.Elab.Tactic.Do.Internal
+namespace Lean.Elab.Tactic.VCGen
 
 /-!
 The main `solve` step. Runs once per worklist iteration and either fully
@@ -27,7 +27,6 @@ decomposes the current goal into subgoals, or reports why no further
 progress is possible (`SolveResult`).
 -/
 
-namespace VCGen
 
 /-- The reason why no further VC generation progress is possible on the current goal. -/
 public inductive SolveResult.StopReason where
@@ -46,7 +45,7 @@ public inductive SolveResult.StopReason where
 /-- The result of one `solve` step of VC generation. -/
 public inductive SolveResult where
   /-- Successfully decomposed the goal. These are the subgoals, sharing `scope`. -/
-  | goals (scope : VCGen.Scope) (subgoals : List MVarId)
+  | goals (scope : Scope) (subgoals : List MVarId)
   /-- No further progress possible; emit the current goal as a VC. -/
   | stop (reason : SolveResult.StopReason)
 
@@ -120,7 +119,7 @@ private def rfl? (goal : MVarId) : VCGenM (Option (List MVarId)) := do
 
 /-- The most recently lifted pure precondition (cached in `Scope.lastLiftedPre?`) whose type is
 the same hash-consed expression as `e`, or `none`. Must run in `goal`'s context. -/
-private def liftedPreFor? (scope : VCGen.Scope) (e : Expr) : VCGenM (Option LocalDecl) := do
+private def liftedPreFor? (scope : Scope) (e : Expr) : VCGenM (Option LocalDecl) := do
   let some fvarId := scope.lastLiftedPre? | return none
   let some hyp := (← getLCtx).find? fvarId | return none
   unless isSameExpr e hyp.type do return none
@@ -130,7 +129,7 @@ private def liftedPreFor? (scope : VCGen.Scope) (e : Expr) : VCGenM (Option Loca
 /-- Strategy 10: close `pre ⊑ φ` on the `Prop` lattice against the most recently lifted pure
 precondition. Runs after lattice decomposition, so `φ` is an opaque proposition rather than a
 lattice connective. This is one comparison against one hypothesis, not an assumption search. -/
-private def liftedHyp? (scope : VCGen.Scope) (goal : MVarId) (α pre rhs : Expr) :
+private def liftedHyp? (scope : Scope) (goal : MVarId) (α pre rhs : Expr) :
     VCGenM (Option (List MVarId)) :=
   goal.withContext do
     unless α.isProp do return none
@@ -141,7 +140,7 @@ private def liftedHyp? (scope : VCGen.Scope) (goal : MVarId) (α pre rhs : Expr)
 /-- Close a bare `Prop` residual, such as the subgoal of the `⌜φ⌝` lattice rule, against the
 most recently lifted pure precondition. Runs when the target is not a lattice entailment,
 just before it would be classified as a VC. -/
-private def liftedHypBare? (scope : VCGen.Scope) (goal : MVarId) (target : Expr) :
+private def liftedHypBare? (scope : Scope) (goal : MVarId) (target : Expr) :
     VCGenM (Option (List MVarId)) :=
   goal.withContext do
     let some hyp ← liftedPreFor? scope target | return none
@@ -235,8 +234,8 @@ local context so a later spec application sees a `⊤` precondition. In order: c
 `⌜φ⌝` applied to the introduced state); lift the guard of a `⌜φ⌝ ⊓ P`; eliminate an `iSup`;
 introduce excess state arguments; drop a `True` precondition; lift a bare `Prop` precondition.
 Returns the updated scope, recording any lifted hypothesis. -/
-private def normalizePre? (scope : VCGen.Scope) (goal : MVarId) (α pre target : Expr) :
-    VCGenM (Option (VCGen.Scope × List MVarId)) := do
+private def normalizePre? (scope : Scope) (goal : MVarId) (α pre target : Expr) :
+    VCGenM (Option (Scope × List MVarId)) := do
   if let some g ← stripMeetTopPre? goal pre then
     return some (scope, [g])
   if let some (g, h) ← ofPropPreIntro? goal pre then
@@ -470,7 +469,7 @@ rule does not apply.
   `FrameInferenceInfo.specPre?`: no split applies the spec directly; a split applies the frame rule
   instead, so the spec re-applies against the framed residual where its VCs are solvable.
 -/
-private def applySpec (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) (thm : SpecTheorem) :
+private def applySpec (scope : Scope) (goal : MVarId) (info : WPApp) (thm : SpecTheorem) :
     VCGenM (Option SolveResult) := do
   let some specRule ←
     try
@@ -505,7 +504,7 @@ A candidate is passed over when no rule fits the goal's monad or when the rule d
 spec guarded by an instance the call site does not provide gives way to a less general one, as does a
 spurious candidate of the over-approximating discrimination tree.
 -/
-private def applySpecs (scope : VCGen.Scope) (goal : MVarId) (info : WPApp) :
+private def applySpecs (scope : Scope) (goal : MVarId) (info : WPApp) :
     VCGenM SolveResult := goal.withContext do
   let candidates ← SpecTheorems.findSpecs scope.specs info.prog
   for thm in candidates do
@@ -540,7 +539,7 @@ The function performs the following steps in order:
     hoist/zeta program-head lets, split `ite`/`dite`/match, zeta-unfold fvar program heads,
     reduce projection heads, and finally apply a registered `@[spec]` theorem.
 -/
-public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := goal.withContext do
+public def solve (scope : Scope) (goal : MVarId) : VCGenM SolveResult := goal.withContext do
   if ← outOfFuel then return .stop .outOfFuel
   let target ← goal.getType
   trace[Elab.Tactic.Do.vcgen] "🎯 Target: {target}"
@@ -583,27 +582,26 @@ public def solve (scope : VCGen.Scope) (goal : MVarId) : VCGenM SolveResult := g
     if let some g ← wpConsumeMData? goal info then
       return .goals scope [g]
     if let some g ← wpLet? goal info then
-      VCGen.burnOne
+      burnOne
       return .goals scope [g]
     if let some gs ← wpSimpStateArgs? goal info then
       return .goals scope gs
     if let some gs ← wpMatch? goal info then
-      VCGen.burnOne
+      burnOne
       return .goals scope gs
     if let some g ← wpFVarZeta? goal info then
-      VCGen.burnOne
+      burnOne
       return .goals scope [g]
     if let some g ← wpHeadReduce? goal info then
-      VCGen.burnOne
+      burnOne
       return .goals scope [g]
     let f := info.prog.getAppFn
     if f.isConst || f.isFVar then
-      VCGen.burnOne
+      burnOne
       return ← applySpecs scope goal info
     throwError "Failed to decompose weakest precondition for {info.prog}. This should not happen."
 
   return .stop (.noProgress pre rhs)
 
-end VCGen
 
-end Lean.Elab.Tactic.Do.Internal
+end Lean.Elab.Tactic.VCGen

--- a/src/Lean/Elab/Tactic/VCGen/SpecDB.lean
+++ b/src/Lean/Elab/Tactic/VCGen/SpecDB.lean
@@ -22,9 +22,9 @@ this module adds the operations the VC generator needs on top: instantiating a s
 database, and looking up the specs matching a program.
 -/
 
-namespace Lean.Elab.Tactic.Do.Internal
+namespace Lean.Elab.Tactic.VCGen
 
-open Lean.Elab.Tactic.Do.Internal.SpecAttr
+open Lean.Elab.Tactic.VCGen.SpecAttr
 
 /--
 Internalizes the pattern's expressions into the current `SymM` share table.
@@ -71,7 +71,6 @@ public def SpecAttr.SpecTheorem.instantiate (specThm : SpecTheorem) :
 public def SpecAttr.SpecTheorem.global? (specThm : SpecTheorem) : Option Name :=
   match specThm.proof with | .global decl => some decl | _ => none
 
-namespace VCGen
 
 /--
 Extend the spec `database` with the specs a `vcgen [...]` call's simp-style arguments contribute
@@ -101,7 +100,6 @@ public def addSimpSpecs (database : SpecTheorems) (simpThms : SimpTheorems) :
     specs := Sym.insertPattern specs newSpec.pattern newSpec
   return { specs, erased }
 
-end VCGen
 
 /--
 Look up `SpecTheorem`s in the `@[spec]` database.
@@ -116,4 +114,4 @@ public def SpecAttr.SpecTheorems.findSpecs (database : SpecTheorems) (e : Expr) 
   -- It appears that insertion sort is *much* faster than qsort here.
   return candidates.insertionSort (·.priority > ·.priority)
 
-end Lean.Elab.Tactic.Do.Internal
+end Lean.Elab.Tactic.VCGen

--- a/src/Lean/Elab/Tactic/VCGen/Util.lean
+++ b/src/Lean/Elab/Tactic/VCGen/Util.lean
@@ -7,8 +7,8 @@ module
 
 prelude
 public import Lean.Meta.Tactic.Grind.Main
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Context
-public import Lean.Elab.Tactic.Do.Internal.VCGen.Reduce
+public import Lean.Elab.Tactic.VCGen.Context
+public import Lean.Elab.Tactic.VCGen.Reduce
 public import Lean.Meta.Sym.AlphaShareBuilder
 public import Lean.Meta.Sym.Intro
 public import Lean.Meta.Sym.Simp.Goal
@@ -24,7 +24,7 @@ collapser `solveTrivialConjuncts`. None of these know anything about the entailm
 decomposes.
 -/
 
-namespace Lean.Elab.Tactic.Do.Internal
+namespace Lean.Elab.Tactic.VCGen
 
 /-- Change `goal`'s `Prop`-typed target to the definitionally-equal `targetNew`, mirroring the goal
 update in `Sym.Simp`: a fresh synthetic-opaque goal cast back through `@id`. Unlike
@@ -55,7 +55,7 @@ is reconstructed from `rule.expr.getAppFn` — works for the common case of a
 constant rule. Pass a custom message for dynamically-built rules.
 
 Designed for dot notation: `rule.applyChecked goal`. Requires
-`open Lean.Elab.Tactic.Do.Internal` in scope so that the dot lookup resolves.
+`open Lean.Elab.Tactic.VCGen` in scope so that the dot lookup resolves.
 -/
 public def Lean.Meta.Sym.BackwardRule.applyChecked (rule : BackwardRule) (goal : MVarId)
     (ruleDesc? : Option MessageData := none) : VCGenM ApplyResult := do
@@ -83,10 +83,9 @@ public def Lean.Meta.Sym.BackwardRule.applyChecked (rule : BackwardRule) (goal :
         Re-run with `set_option pp.all true` to see the structural difference."
     return r
 
-namespace VCGen
 
 open Sym Sym.Internal
-open Lean.Elab.Tactic.Do.Internal
+open Lean.Elab.Tactic.VCGen
 
 /-- `Grind.processHypotheses` if `Context.internalize` is `true`, otherwise a no-op. -/
 public def processHypotheses (goal : Grind.Goal) : VCGenM Grind.Goal := do
@@ -187,5 +186,4 @@ public partial def solveTrivialConjuncts (goal : MVarId) : VCGenM (Option MVarId
   else
     return some goal
 
-end VCGen
-end Lean.Elab.Tactic.Do.Internal
+end Lean.Elab.Tactic.VCGen

--- a/src/Lean/Elab/Tactic/VCGen/WPApp.lean
+++ b/src/Lean/Elab/Tactic/VCGen/WPApp.lean
@@ -16,13 +16,13 @@ recognize one.
 
 open Lean Meta Sym
 
-namespace Lean.Elab.Tactic.Do.Internal
+namespace Lean.Elab.Tactic.VCGen
 
 /--
 Common metadata for a goal whose right-hand side is a weakest-precondition application
 `pre ⊑ wp Prog Value Pred EPred instAL instEAL instWP prog post epost s₁ ... sₙ`.
 -/
-public structure VCGen.WPApp where
+public structure WPApp where
   /-- The `wp` function head, separated from its explicit core arguments. -/
   head : Expr
   /-- The ordered core arguments of the `wp` application:
@@ -31,7 +31,7 @@ public structure VCGen.WPApp where
   /-- Extra arguments applied after `wp … prog post epost`, usually concrete state arguments. -/
   excessArgs : Array Expr
 
-namespace VCGen.WPApp
+namespace WPApp
 
 /-- Program type argument of `wp` (e.g. `m α` or a non-monadic program type). -/
 public def Prog (info : WPApp) : Expr := info.args[0]!
@@ -52,14 +52,14 @@ public def prog (info : WPApp) : Expr := info.args[7]!
 /-- Postcondition argument of `wp`. -/
 public def post (info : WPApp) : Expr := info.args[8]!
 
-end VCGen.WPApp
+end WPApp
 
 /-- The `wp` metadata of `rhs`, or `none` when `rhs` is not a `wp` application. -/
-public def VCGen.isWPApp? (rhs : Expr) : Option VCGen.WPApp :=
+public def isWPApp? (rhs : Expr) : Option WPApp :=
   rhs.withApp fun head args =>
     if head.isConstOf ``Std.Internal.Do.wp && args.size ≥ 10 then
       some { head, args := args.take 10, excessArgs := args.drop 10 }
     else
       none
 
-end Lean.Elab.Tactic.Do.Internal
+end Lean.Elab.Tactic.VCGen

--- a/tests/elab/vcgenDyLean.lean
+++ b/tests/elab/vcgenDyLean.lean
@@ -4,9 +4,9 @@ import Lean
 import Std.Tactic.Do
 public import Std.Internal.Do
 import Std.Internal.Do.Triple.SpecLemmas
-public meta import Lean.Elab.Tactic.Do.Internal.VCGen.FrameProc
-public meta import Lean.Elab.Tactic.Do.Internal.VCGen.FrameProcAttr
-public meta import Lean.Elab.Tactic.Do.Internal.VCGen.RuleConstruction
+public meta import Lean.Elab.Tactic.VCGen.FrameProc
+public meta import Lean.Elab.Tactic.VCGen.FrameProcAttr
+public meta import Lean.Elab.Tactic.VCGen.RuleConstruction
 
 set_option mvcgen.warning false
 
@@ -362,7 +362,7 @@ grind_pattern always_meet => Always' p1 ⊓ Always' p2
 
 section DyLeanFrameProc
 open Lean Meta Elab Tactic Sym
-open Lean.Elab.Tactic.Do.Internal Lean.Elab.Tactic.Do.Internal.VCGen
+open Lean.Elab.Tactic.VCGen
 
 /-- Collect the `Always'` conjuncts of a precondition, descending through `⊓`. These are the frames
 that transport to any extension of the current trace. -/

--- a/tests/elab/vcgenSepLogic.lean
+++ b/tests/elab/vcgenSepLogic.lean
@@ -752,7 +752,7 @@ grind_pattern _root_.le_of_le_bot => X ⊑ ⊥, X ⊑ C
 The `@[frameproc]` for `HeapM`: cancel the framed `∗` atoms out of the goal precondition and emit
 the leftover atoms as the footprint. -/
 
-open Lean.Elab.Tactic.Do.Internal Lean.Elab.Tactic.Do.Internal.VCGen
+open Lean.Elab.Tactic.VCGen
 
 /-- Flatten a separating conjunction after mvars are instantiated. -/
 partial def sepAtoms.go (e : Expr) : Array Expr :=

--- a/tests/elab/vcgenTickFrames.lean
+++ b/tests/elab/vcgenTickFrames.lean
@@ -216,7 +216,7 @@ theorem TickT.le_wp_tick' [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPr
 `tickFrameProc` shifts by the current tick count and emits the split VC in its `costConj_apply`
 meet form, so the built-in meet split yields the tick guard and the shifted residual. -/
 
-open Lean.Elab.Tactic.Do.Internal Lean.Elab.Tactic.Do.Internal.VCGen
+open Lean.Elab.Tactic.VCGen
 
 /-- Exact spec for `tick`, registered so `vcgen` can decompose `tick` calls. -/
 @[spec] theorem tick_spec [Assertion Pred] [Assertion EPred] [WPMonad m Pred EPred] :


### PR DESCRIPTION
This PR moves the `vcgen` tactic from the namespace `Lean.Elab.Tactic.Do.Internal` to `Lean.Elab.Tactic.VCGen`, and its modules from `src/Lean/Elab/Tactic/Do/Internal/VCGen/` to `src/Lean/Elab/Tactic/VCGen/`. The tactic works on any program type with a `WP` interpretation, including deep embeddings with no `Monad` instance. The name therefore drops `Do`.

`mvcgen` stays at `Lean.Elab.Tactic.Do.VCGen`. This PR keeps it and does not deprecate it. Both tactics will coexist for some time.
