### PR TITLE
chore: update mimalloc to v3.4.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,9 @@ if(USE_MIMALLOC)
     mimalloc
     GIT_REPOSITORY https://github.com/microsoft/mimalloc
     GIT_BRANCH dev3
-    GIT_TAG v3.4.1
+    # v3.4.3 fixes a heap-corruption abort (SIGTRAP out of libmalloc) that v3.4.1 raises while
+    # compiling; do not downgrade without re-running the `tests/compile` suite.
+    GIT_TAG v3.4.3
     # Unnecessarily deep directory structure, but it saves us from a complicated
     # stage0 update for now. If we ever update the other dependencies like
     # cadical, it might be worth reorganizing the directory structure.


### PR DESCRIPTION
This PR updates the vendored mimalloc from v3.4.1 to v3.4.3. v3.4.3 fixes a heap-corruption abort (SIGTRAP out of libmalloc on macOS) that v3.4.1 can raise under heavy allocation while compiling.

This is split out of #14202, which depends on this version to avoid regressions from the mimalloc 3.1 line during libuv finalization.

This PR fixes issues found on the libuv finalization PR and the OpenSSL PR (that requires the `Security` framework from macOS). 

Related: https://github.com/microsoft/mimalloc/issues/1333