### PR TITLE
feat: lake: dependency partial clones

### DIFF
--- a/src/lake/Lake/Load/Materialize.lean
+++ b/src/lake/Lake/Load/Materialize.lean
@@ -26,72 +26,79 @@ or resolve a local path dependency.
 namespace Lake
 
 /--
-Update the Git package in {lean}`repo` to the revision {lean}`rev?` if not already at it.
-IF no revision is specified (i.e., {lean}`rev? = none`), then uses the latest {lit}`master`.
+Materialize the Git repository from {lean}`url` into {lean}`repo` at {lean}`rev?`.
+
+If no revision is specified (i.e., {lean}`rev? = none`), the latest {lit}`HEAD` is used.
+
+If the repository is already at {lean}`rev?`, return early with no changes.
+Otherwise, fetch the revision {lean}`rev?` from the remote {lean}`url` and check it out.
+If no local repository exists, initialize a new one.
 -/
-def updateGitPkg
-  (name : String) (repo : GitRepo) (rev? : Option GitRev)
-: LoggerIO PUnit := do
-  let rev ← repo.findRemoteRevision rev?
-  if (← repo.getHeadRevision) = rev then
-    if (← repo.hasDiff) then
-      logWarning s!"{name}: repository '{repo.dir}' has local changes"
+def materializeGitRepo
+  (name : String) (repo : GitRepo) (url : String) (rev? : Option GitRev)
+: LoggerIO Unit := do
+  let rev := rev?.getD .head
+  let remote := Git.defaultRemote
+  let url ← resolveUrl url
+  -- # Setup repository
+  if (← repo.gitExists) then
+    if let some oldUrl ← repo.getRemoteUrl? remote then
+      unless oldUrl = url do
+        logInfo s!"{name}: remote URL changed\
+          \n  old: {oldUrl}\
+          \n  new: {url}"
+        repo.setRemoteUrl remote url
+    else
+      repo.addRemote remote url
+    -- Skip fetch if already on revision. Avoids errors when offline.
+    -- https://github.com/leanprover/lake/issues/104
+    if (← repo.getHeadRevision?) = some rev then
+      checkDiff
+      return
+    if rev.isFullSha1 then
+      if (← repo.findCommit? rev).isSome then
+        -- Skip revision fetch if the exact commit is already available.
+        -- May still fetch objects due to the partial clone.
+        checkout rev
+        return
   else
+    logInfo s!"{name}: materializing new dependency"
+    IO.FS.createDirAll repo.dir
+    repo.quietInit
+    repo.addRemote remote url
+  -- # New revision
+  logInfo s!"{name}: fetching revision '{rev}' from {url}"
+  let some rev ← repo.fetchRevision? remote rev
+    | error s!"{name}: failed to fetch the package revision\
+      \n  {rev}\
+      \nfrom the Git repository at\
+      \n  {url}"
+  if (← repo.getHeadRevision?) = some rev then -- e.g., new tag = old rev
+    checkDiff
+    return
+  checkout rev
+  -- Cleanup unreachable references and objects to prevent excessive repository growth
+  repo.pruneRemote remote
+  repo.gc
+where
+  @[inline] resolveUrl url := do
+    if (← FilePath.pathExists url) then
+      let some path ← resolvePath? url
+        | error s!"{name}: failed to resolve path:\n  {url}"
+      return path.toString
+    else
+      return url
+  @[inline] checkout rev := do
     logInfo s!"{name}: checking out revision '{rev}'"
     repo.checkoutDetach rev
-    -- Remove untracked files from tracked folders the package.
+    -- Remove untracked files from tracked folders in the package.
     -- This helps ensure reproducible behavior by removing leftovers.
     -- For example, Lake will trust leftover `.hash` files unconditionally,
     -- so stale ones from the previous revision cause incorrect trace computations.
     repo.clean
-
-/-- Clone the Git package as {lean}`repo`. -/
-def cloneGitPkg
-  (name : String) (repo : GitRepo) (url : String) (rev? : Option GitRev)
-: LoggerIO PUnit := do
-  logInfo s!"{name}: cloning {url}"
-  repo.clone url
-  if let some rev := rev? then
-    let rev ← repo.resolveRemoteRevision rev
-    logInfo s!"{name}: checking out revision '{rev}'"
-    repo.checkoutDetach rev
-
-/--
-Update the Git repository from {lean}`url` in {lean}`repo` to {lean}`rev?`.
-If {lean}`repo` is already from {lean}`url`, just checkout the new revision.
-Otherwise, delete the local repository and clone a fresh copy from {lean}`url`.
--/
-def updateGitRepo
-  (name : String) (repo : GitRepo) (url : String) (rev? : Option String)
-: LoggerIO Unit := do
-  let sameUrl ← EIO.catchExceptions (h := fun _ => pure false) <| show IO Bool from do
-    let some remoteUrl ← repo.getRemoteUrl? | return false
-    if remoteUrl = url then return true
-    return (← IO.FS.realPath remoteUrl) = (← IO.FS.realPath url)
-  if sameUrl then
-    updateGitPkg name repo rev?
-  else
-    if System.Platform.isWindows then
-      -- Deleting git repositories via IO.FS.removeDirAll does not work reliably on windows
-      logInfo s!"{name}: URL has changed; you might need to delete '{repo.dir}' manually"
-      updateGitPkg name repo rev?
-    else
-      logInfo s!"{name}: URL has changed; deleting '{repo.dir}' and cloning again"
-      IO.FS.removeDirAll repo.dir
-      cloneGitPkg name repo url rev?
-
-
-/--
-Materialize the Git repository from {lean}`url` into {lean}`repo` at {lean}`rev?`.
-Clone it if no local copy exists, otherwise update it.
--/
-def materializeGitRepo
-  (name : String) (repo : GitRepo) (url : String) (rev? : Option String)
-: LoggerIO Unit := do
-  if (← repo.dirExists) then
-    updateGitRepo name repo url rev?
-  else
-    cloneGitPkg name repo url rev?
+  @[inline] checkDiff := do
+    if (← repo.hasDiff) then
+      logWarning s!"{name}: repository has local changes:\n  {repo.dir}"
 
 public structure MaterializedDep where
   /-- Absolute path to the materialized package. -/
@@ -242,26 +249,10 @@ public def PackageEntry.materialize
   | .path (dir := relPkgDir) .. =>
     mkDep relPkgDir ""
   | .git (url := url) (rev := rev) (subDir? := subDir?) .. => do
-    let prettyName := manifestEntry.prettyName
     let relGitDir := relPkgsDir / manifestEntry.dirName
-    let gitDir := wsDir / relGitDir
-    let repo := GitRepo.mk gitDir
-    /-
-    Do not update (fetch remote) if already on revision
-    Avoids errors when offline, e.g., [leanprover/lake#104][104].
-
-    [104]: https://github.com/leanprover/lake/issues/104
-    -/
-    if (← repo.dirExists) then
-      if (← repo.getHeadRevision?) = rev then
-        if (← repo.hasDiff) then
-          logWarning s!"{prettyName}: repository '{repo.dir}' has local changes"
-      else
-        let url := lakeEnv.pkgUrlMap.find? manifestEntry.name |>.getD url
-        updateGitRepo prettyName repo url rev
-    else
-      let url := lakeEnv.pkgUrlMap.find? manifestEntry.name |>.getD url
-      cloneGitPkg prettyName repo url rev
+    let repo := GitRepo.mk (wsDir / relGitDir)
+    let url := lakeEnv.pkgUrlMap.getD manifestEntry.name url
+    materializeGitRepo manifestEntry.prettyName repo url rev
     let relPkgDir := match subDir? with | .some subDir => relGitDir / subDir | .none => relGitDir
     mkDep relPkgDir (Git.filterUrl? url |>.getD "")
 where

--- a/src/lake/Lake/Load/Materialize.lean
+++ b/src/lake/Lake/Load/Materialize.lean
@@ -28,7 +28,7 @@ namespace Lake
 /--
 Materialize the Git repository from {lean}`url` into {lean}`repo` at {lean}`rev?`.
 
-If no revision is specified (i.e., {lean}`rev? = none`), the latest {lit}`HEAD` is used.
+If no revision is specified (i.e., {lean}`rev? = none`), the latest {lit}`master` is used.
 
 If the repository is already at {lean}`rev?`, return early with no fetch.
 Otherwise, fetch the revision {lean}`rev?` from the remote {lean}`url` and check it out.
@@ -37,7 +37,7 @@ If no local repository exists, initialize a new one.
 def materializeGitRepo
   (name : String) (repo : GitRepo) (url : String) (rev? : Option GitRev)
 : LoggerIO Unit := do
-  let rev := rev?.getD .head
+  let rev := rev?.getD Git.upstreamBranch
   let remote := Git.defaultRemote
   let url ← resolveUrl url
   -- # Setup repository

--- a/src/lake/Lake/Load/Materialize.lean
+++ b/src/lake/Lake/Load/Materialize.lean
@@ -30,7 +30,7 @@ Materialize the Git repository from {lean}`url` into {lean}`repo` at {lean}`rev?
 
 If no revision is specified (i.e., {lean}`rev? = none`), the latest {lit}`HEAD` is used.
 
-If the repository is already at {lean}`rev?`, return early with no changes.
+If the repository is already at {lean}`rev?`, return early with no fetch.
 Otherwise, fetch the revision {lean}`rev?` from the remote {lean}`url` and check it out.
 If no local repository exists, initialize a new one.
 -/
@@ -42,6 +42,8 @@ def materializeGitRepo
   let url ← resolveUrl url
   -- # Setup repository
   if (← repo.gitExists) then
+    -- The URL may be updated even without a `lake update`.
+    -- This ensures a package's `remoteUrl?` reflects Git's by default.
     if let some oldUrl ← repo.getRemoteUrl? remote then
       unless oldUrl = url do
         logInfo s!"{name}: remote URL changed\
@@ -56,6 +58,9 @@ def materializeGitRepo
       checkDiff
       return
     if rev.isFullSha1 then
+      -- If missing, `findCommit?` will fetch to try and find it (on a partial clone).
+      -- This could be avoided with `--no-lazy-fetch`, but that requires Git 2.45+.
+      -- Fetch will happen anyway next, so the higher minimum is not worth it.
       if (← repo.findCommit? rev).isSome then
         -- Skip revision fetch if the exact commit is already available.
         -- May still fetch objects due to the partial clone.
@@ -79,7 +84,7 @@ def materializeGitRepo
   checkout rev
   -- Cleanup unreachable references and objects to prevent excessive repository growth
   repo.pruneRemote remote
-  repo.gc
+  repo.gcAuto
 where
   @[inline] resolveUrl url := do
     if (← FilePath.pathExists url) then
@@ -96,6 +101,7 @@ where
     -- For example, Lake will trust leftover `.hash` files unconditionally,
     -- so stale ones from the previous revision cause incorrect trace computations.
     repo.clean
+    checkDiff
   @[inline] checkDiff := do
     if (← repo.hasDiff) then
       logWarning s!"{name}: repository has local changes:\n  {repo.dir}"

--- a/src/lake/Lake/Util/Git.lean
+++ b/src/lake/Lake/Util/Git.lean
@@ -101,9 +101,9 @@ public def cwd : GitRepo := ⟨"."⟩
   testProc {cmd := "git", args, cwd := repo.dir}
 
 @[inline] def testExecGit (args : Array String) (repo : GitRepo) : LogIO Bool := do
-  let spanwArgs := {cmd := "git", args, cwd := repo.dir}
-  logVerbose (mkCmdLog spanwArgs)
-  testProc spanwArgs
+  let out ← rawProc {cmd := "git", args, cwd := repo.dir}
+  logOutput out (if out.exitCode = 0 then logVerbose else logInfo)
+  return out.exitCode = 0
 
 public def clone (url : String) (repo : GitRepo) : LogIO PUnit  :=
   proc {cmd := "git", args := #["clone", url, repo.dir.toString]} (quiet := true)
@@ -129,8 +129,8 @@ public def checkoutBranch (branch : String) (repo : GitRepo) : LogIO PUnit :=
 public def checkoutDetach (hash : String) (repo : GitRepo) : LogIO PUnit  :=
   repo.execGit #["checkout", "--detach", hash, "--"]
 
-public def gc (repo : GitRepo) : LogIO PUnit :=
-  repo.execGit #["gc"]
+public def gcAuto (repo : GitRepo) : LogIO PUnit :=
+  repo.execGit #["gc", "--auto"]
 
 /-- Remove untracked files from tracked folders in the repository. -/
 public def clean (repo : GitRepo) : LogIO PUnit :=
@@ -158,7 +158,8 @@ public def getHeadRevision (repo : GitRepo) : LogIO GitRev := do
     the repository may be corrupt, so you may need to remove it and try again"
 
 public def fetchRevision? (repo : GitRepo) (remote : String) (rev : GitRev) : LogIO (Option GitRev) := do
-  let args := #["fetch", "--tags", "--force", "--refetch", "--filter=tree:0", remote, rev]
+  -- `--refetch` is expensive and not needed here as Lake uses a single, fixed filter
+  let args := #["fetch", "--tags", "--force", "--filter=tree:0", remote, rev]
   if (← repo.testExecGit args) then
     let some rev ← repo.resolveRevision? .fetchHead
       | error s!"{repo}: could not resolve 'FETCH_HEAD' to a commit after fetching; \

--- a/src/lake/Lake/Util/Git.lean
+++ b/src/lake/Lake/Util/Git.lean
@@ -84,6 +84,10 @@ public def cwd : GitRepo := ⟨"."⟩
 @[inline] public def dirExists (repo : GitRepo) : BaseIO Bool :=
   repo.dir.isDir
 
+/-- Returns whether `.git` exists at the root of the repository directory. -/
+@[inline] public def gitExists (repo : GitRepo) : BaseIO Bool :=
+  (repo.dir / ".git").pathExists
+
 @[inline] public def captureGit (args : Array String) (repo : GitRepo) : LogIO String :=
   captureProc {cmd := "git", args, cwd := repo.dir}
 
@@ -95,6 +99,11 @@ public def cwd : GitRepo := ⟨"."⟩
 
 @[inline] public def testGit (args : Array String) (repo : GitRepo) : BaseIO Bool :=
   testProc {cmd := "git", args, cwd := repo.dir}
+
+@[inline] def testExecGit (args : Array String) (repo : GitRepo) : LogIO Bool := do
+  let spanwArgs := {cmd := "git", args, cwd := repo.dir}
+  logVerbose (mkCmdLog spanwArgs)
+  testProc spanwArgs
 
 public def clone (url : String) (repo : GitRepo) : LogIO PUnit  :=
   proc {cmd := "git", args := #["clone", url, repo.dir.toString]} (quiet := true)
@@ -119,6 +128,9 @@ public def checkoutBranch (branch : String) (repo : GitRepo) : LogIO PUnit :=
 
 public def checkoutDetach (hash : String) (repo : GitRepo) : LogIO PUnit  :=
   repo.execGit #["checkout", "--detach", hash, "--"]
+
+public def gc (repo : GitRepo) : LogIO PUnit :=
+  repo.execGit #["gc"]
 
 /-- Remove untracked files from tracked folders in the repository. -/
 public def clean (repo : GitRepo) : LogIO PUnit :=
@@ -146,7 +158,8 @@ public def getHeadRevision (repo : GitRepo) : LogIO GitRev := do
     the repository may be corrupt, so you may need to remove it and try again"
 
 public def fetchRevision? (repo : GitRepo) (remote : String) (rev : GitRev) : LogIO (Option GitRev) := do
-  if (← repo.testGit #["fetch", "--tags", "--force", "--refetch", "--filter=tree:0", remote, rev]) then
+  let args := #["fetch", "--tags", "--force", "--refetch", "--filter=tree:0", remote, rev]
+  if (← repo.testExecGit args) then
     let some rev ← repo.resolveRevision? .fetchHead
       | error s!"{repo}: could not resolve 'FETCH_HEAD' to a commit after fetching; \
           this may be an issue with Lake; please report it"
@@ -195,6 +208,9 @@ public def setRemoteUrl (remote : String) (url : String) (repo : GitRepo) : LogI
 public def getFilteredRemoteUrl?
   (remote := Git.defaultRemote) (repo : GitRepo)
 : BaseIO (Option String) := OptionT.run do Git.filterUrl? (← repo.getRemoteUrl? remote)
+
+public def pruneRemote (remote : String) (repo : GitRepo) : LogIO Unit :=
+  repo.execGit #["remote", "prune", remote]
 
 public def hasNoDiff (repo : GitRepo) : BaseIO Bool := do
   repo.testGit #["diff", "--exit-code", "HEAD"]

--- a/tests/lake/tests/clone/test.sh
+++ b/tests/lake/tests/clone/test.sh
@@ -22,9 +22,8 @@ echo "# TESTS"
 
 # test that `LAKE_PKG_URL_MAP` properly overwrites the config-specified Git URL
 LAKE_PKG_URL_MAP=$HELLO_MAP test_out "file://" update
-# test that a second `lake update` is a no-op (with URLs)
-# see https://github.com/leanprover/lean4/commit/6176fdba9e5a888225a23e5d558a005e0d1eb2f6#r125905901
-LAKE_PKG_URL_MAP=$HELLO_MAP test_no_out update --keep-toolchain
+# test that a second `lake update` does not perform another checkout (with URLs)
+LAKE_PKG_URL_MAP=$HELLO_MAP test_not_out "checking out" update --keep-toolchain
 rm -rf .lake/packages
 
 # Test that Lake produces no warnings on a `lake build` after a `lake update`
@@ -33,11 +32,11 @@ rm -rf .lake/packages
 echo "# TEST: lake build after update"
 
 test_run update
-# test that a second `lake update` is a no-op (with file paths)
-test_no_out update --keep-toolchain
-test -d .lake/packages/hello
-# test that Lake produces no warnings
-test_no_warn build
+# test that a second `lake update` does not perform another checkout (with file paths)
+test_not_out "checking out" update --keep-toolchain
+test_exp -d .lake/packages/hello
+# test that Lake produces no logs
+test_no_stderr build
 test_cmd_eq "Hello, world!" ./.lake/build/bin/test
 
 # Test that Lake produces a warning if local changes are made to a dependency
@@ -50,7 +49,7 @@ test_cmd_fails git -C .lake/packages/hello diff --exit-code
 test_out "has local changes" build
 test_cmd_eq "Hello, changes!" ./.lake/build/bin/test
 test_cmd git -C .lake/packages/hello reset --hard
-test_no_warn build
+test_no_stderr build
 
 # Test no `git fetch` on a `lake build` if already on the proper revision
 # See https://github.com/leanprover/lake/issues/104
@@ -60,11 +59,9 @@ echo "# TEST: No fetch"
 TEST_URL=https://example.com/hello.git
 TEST_MAP="{\"hello\" : \"$TEST_URL\"}"
 
-# set invalid remote
-git -C .lake/packages/hello remote set-url origin $TEST_URL
-# build should succeed (do nothing) despite the invalid remote because
-# the remote should not be fetched; Lake should also not produce any warnings
-LAKE_PKG_URL_MAP=$TEST_MAP test_no_warn build
+# build should succeed despite the invalid remote because the
+# remote should not be fetched (and nothing should be checked out)
+LAKE_PKG_URL_MAP=$TEST_MAP test_not_out "checking" build
 
 # Cleanup
 rm -rf hello/.git

--- a/tests/lake/tests/clone/test.sh
+++ b/tests/lake/tests/clone/test.sh
@@ -12,6 +12,18 @@ $LAKE init hello
 rm -f lean-toolchain
 $LAKE update
 init_git
+# `--filter` is silently ignored by a server that does not allow it
+git config uploadpack.allowFilter true
+# add revisions for the tests to switch between
+echo v1 > extra.txt
+git add extra.txt
+git commit -q -m "extra v1"
+REV_A=$(git rev-parse HEAD)
+OLD_BLOB=$(git rev-parse HEAD:extra.txt)
+echo v2 > extra.txt
+git add extra.txt
+git commit -q -m "extra v2"
+REV_B=$(git rev-parse HEAD)
 popd
 
 HELLO_MAP="{\"hello\" : \"file://$(pwd)/hello\"}"
@@ -62,6 +74,40 @@ TEST_MAP="{\"hello\" : \"$TEST_URL\"}"
 # build should succeed despite the invalid remote because the
 # remote should not be fetched (and nothing should be checked out)
 LAKE_PKG_URL_MAP=$TEST_MAP test_not_out "checking" build
+
+# Test that a dependency is materialized as a treeless partial clone
+# See https://github.com/leanprover/lean4/issues/10603
+
+echo "# TEST: Partial clone"
+
+rm -rf .lake/packages
+test_out "checking out revision '$REV_B'" update --keep-toolchain
+test_exp "$(git -C .lake/packages/hello config --get remote.origin.partialclonefilter)" = tree:0
+# a blob reachable only from an older revision should not have been fetched
+# `--batch-all-objects` lists local objects without lazily fetching any
+git -C .lake/packages/hello cat-file --batch-all-objects --batch-check='%(objectname)' 2>/dev/null > .lake/objects.out
+test_cmd_fails grep -F "$OLD_BLOB" .lake/objects.out
+
+# Test that Lake does not fetch a revision already present in the repository
+
+echo "# TEST: Local revision"
+
+# check out an older revision, fetching its trees and blobs
+sed_i "s/$REV_B/$REV_A/" lake-manifest.json
+test_out "checking out revision '$REV_A'" build
+# returning to the newer revision needs no fetch, so an invalid remote is harmless
+sed_i "s/$REV_A/$REV_B/" lake-manifest.json
+LAKE_PKG_URL_MAP=$TEST_MAP test_out "checking out revision '$REV_B'" build
+
+# Test that Lake reuses the repository directory when the URL changes
+# See https://github.com/leanprover/lean4/issues/12901
+
+echo "# TEST: URL change"
+
+touch .lake/packages/hello/marker.txt
+LAKE_PKG_URL_MAP=$HELLO_MAP test_out "remote URL changed" build
+# the repository was reused rather than deleted and cloned again
+test_exp -f .lake/packages/hello/marker.txt
 
 # Cleanup
 rm -rf hello/.git

--- a/tests/lake/tests/common.sh
+++ b/tests/lake/tests/common.sh
@@ -295,7 +295,7 @@ test_no_out() {
   return $rc
 }
 
-test_no_warn() {
+test_no_stderr() {
   echo '$' lake "$@"
   if "$LAKE" "$@" 2>produced.out; then
     diff produced.out /dev/null


### PR DESCRIPTION
This PR overhauls the way Lake clones dependencies. Dependencies are now fetched as treeless partial Git clones of a single revision, minimizing the amount of data downloaded. In addition, switching between branches will now avoid a fetch if the new revision (and its trees and blobs) are already present in the repository. Lake also now reuses the repository directory if the dependency URL changes, avoiding file system churn and the potential loss of the dependency on a failed fetch. To further minimize disk usage, Lake will prune remote references and perform Git garbage collection on a dependency repository after fetching a new version.

One key caveat of the treeless partial clone is that git operations within a dependency can cause lazy fetches. For example, a `git blame` in a dependency will perform a fetch. This may also be triggered automatically if a user views a dependency file via go-to-def and a VSCode extension they have installed tries to `git blame` lines in the file.

Closes #12901. Closes #10603 via a partial clone rather than a shallow one. 