### PR TITLE
refactor: name the assertion library constants directly again

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Attr.lean
+++ b/src/Lean/Elab/Tactic/Do/Attr.lean
@@ -295,8 +295,7 @@ Normalises a specification proof so its conclusion is in `pre ⊑ wp …` form.
 -/
 def tripleToWpProof? (proof type : Expr) : MetaM (Option (Expr × Expr)) := do
   let type ← whnfR type
-  if let some tripleName := appName? tripleNames type then
-    unless type.getAppNumArgs == 11 do return none
+  if type.isAppOfArity ``Triple 11 then
     -- Build the `Triple.le_wp` projection application explicitly from the `Triple` type's own
     -- arguments rather than via `mkAppM`. `mkAppM` would re-synthesise the instance arguments
     -- (`Monad m`, `WPMonad m …`), which fails for transformer specs whose monad is a partially
@@ -305,7 +304,7 @@ def tripleToWpProof? (proof type : Expr) : MetaM (Option (Expr × Expr)) := do
     -- caller has unified the spec's program against the goal. Reusing the type's arguments keeps
     -- those instance metavariables shared with the proof, so no premature synthesis happens.
     let lvls := type.getAppFn.constLevels!
-    let proof := mkAppN (.const (tripleName ++ `le_wp) lvls) (type.getAppArgs.push proof)
+    let proof := mkAppN (.const ``Triple.le_wp lvls) (type.getAppArgs.push proof)
     let type ← instantiateMVars (← inferType proof)
     return some (proof, type)
   else if type.isAppOfArity ``PartialOrder.rel 4 then
@@ -453,13 +452,13 @@ bare `lhs ⊑ rhs` whose RHS is not a `wp` application (an invariant entailment 
 `none` to skip such non-spec hypotheses instead of failing.
 -/
 def selectProg (type : Expr) : MetaM (Option Expr) := do
-  if let some tripleName := appName? tripleNames type then
-    let some idx ← progArgIdx? tripleName | return none
+  if type.getAppFn.isConstOf ``Triple then
+    let some idx ← progArgIdx? ``Triple | return none
     return type.getAppArgs[idx]?
   match_expr type with
   | PartialOrder.rel _α _inst _pre rhs =>
-    if let some wpName := appName? wpNames rhs then
-      let some idx ← progArgIdx? wpName | return none
+    if rhs.getAppFn.isConstOf ``wp then
+      let some idx ← progArgIdx? ``wp | return none
       return rhs.getAppArgs[idx]?
     return none
   | _ => return none

--- a/src/Lean/Elab/Tactic/Do/ConjunctivePre.lean
+++ b/src/Lean/Elab/Tactic/Do/ConjunctivePre.lean
@@ -96,50 +96,16 @@ namespace Lean.Elab.Tactic.VCGen.SpecAttr
 
 open Lean Meta Std.WP Lean.Order
 
-/-! ## Constant names of the assertion library
-
-The assertion library moves from namespace `Std.Internal.Do` to `Std.WP`. The metaprograms here and
-in `Attr.lean` name its constants, and `stage0` carries those names as compiled atoms, so it looks
-for them while elaborating `src/Std`. Each table below therefore lists a constant under both names,
-which keeps the metaprograms working on either side of one `update-stage0` cycle. Drop the
-`Std.Internal.Do` entries once the snapshot carries the new names.
-
-The `Std.WP` entries are unchecked literals, because those constants exist only after the move. Note
-the doubled `WP.WP` in the name of `wp`: the class is `Std.WP.WP` and `wp` is its member, exported as
-`Std.WP.wp`.
--/
-
-/-- The `Triple` structure. -/
-public def tripleNames : Array Name := #[``Triple, `Std.WP.Triple]
-
-/-- The `wp` function. -/
-public def wpNames : Array Name := #[``wp, `Std.WP.WP.wp]
-
-/-- The `EPost.Cons.head` projection. -/
-public def epostConsHeadNames : Array Name := #[``EPost.Cons.head, `Std.WP.EPost.Cons.head]
-
-/-- The name under which `e` is an application of a constant in `names`. -/
-public def appName? (names : Array Name) (e : Expr) : Option Name :=
-  match e.getAppFn with
-  | .const n _ => if names.contains n then some n else none
-  | _ => none
-
 /-- The precondition, program, postcondition, and exception postcondition of a spec conclusion in
 either `Triple` or `pre ⊑ wp …` shape. -/
 private def specComponents? (concl : Expr) : Option (Expr × Expr × Expr × Expr) :=
   match_expr concl with
   | PartialOrder.rel _ _ pre rhs =>
-    -- `wp x post epost` with its seven leading implicit and instance arguments.
-    if (appName? wpNames rhs).isSome && rhs.getAppNumArgs == 10 then
-      let args := rhs.getAppArgs
-      some (pre, args[7]!, args[8]!, args[9]!)
-    else none
-  | _ =>
-    -- `Triple x pre post epost` with its six leading arguments and the `WP` instance after `x`.
-    if (appName? tripleNames concl).isSome && concl.getAppNumArgs == 11 then
-      let args := concl.getAppArgs
-      some (args[8]!, args[6]!, args[9]!, args[10]!)
-    else none
+    match_expr rhs with
+    | wp _ _ _ _ _ _ _ prog post epost => some (pre, prog, post, epost)
+    | _ => none
+  | Triple _ _ _ _ _ _ x _ pre post epost => some (pre, x, post, epost)
+  | _ => none
 
 /-- Whether any metavariable from `mvarIds` occurs in `e`. -/
 private def occursMVar (mvarIds : Array MVarId) (e : Expr) : Bool :=
@@ -157,24 +123,22 @@ private partial def isConjunctiveIn (qs : Array MVarId) (e : Expr) : Bool :=
   | _ =>
     match e.getAppFn with
     | .mvar m => qs.contains m && e.getAppArgs.all (!occursMVar qs ·)
+    | .const ``EPost.Cons.head _ =>
+      -- `EPost.Cons.head` is a `⊓`-morphism (`EPost.Cons.head_meet`); its exception-stack argument
+      -- stays in a `⊓`-context, the rest (types and the applied exception) must be `qs`-free.
+      let args := e.getAppArgs
+      match args[2]? with
+      | some s => isConjunctiveIn qs s && (List.range args.size).all fun i => i == 2 || !occursMVar qs args[i]!
+      | none => false
     | _ =>
-      if (appName? epostConsHeadNames e).isSome then
-        -- `EPost.Cons.head` is a `⊓`-morphism (`EPost.Cons.head_meet`); its exception-stack argument
-        -- stays in a `⊓`-context, the rest (types and the applied exception) must be `qs`-free.
-        let args := e.getAppArgs
-        match args[2]? with
-        | some s => isConjunctiveIn qs s && (List.range args.size).all fun i => i == 2 || !occursMVar qs args[i]!
-        | none => false
-      else if (appName? wpNames e).isSome && e.getAppNumArgs == 10 then
-        let args := e.getAppArgs
-        !occursMVar qs args[7]! && isConjunctiveIn qs args[8]! && isConjunctiveIn qs args[9]!
-      else
-        match_expr e with
-        | Lean.Order.meet _ _ a b => isConjunctiveIn qs a && isConjunctiveIn qs b
-        | Lean.Order.iInf _ _ _ f => isConjunctiveIn qs f
-        | And a b => isConjunctiveIn qs a && isConjunctiveIn qs b
-        | Lean.Order.himp _ _ a b => !occursMVar qs a && isConjunctiveIn qs b
-        | _ => false
+      match_expr e with
+      | Lean.Order.meet _ _ a b => isConjunctiveIn qs a && isConjunctiveIn qs b
+      | Lean.Order.iInf _ _ _ f => isConjunctiveIn qs f
+      | And a b => isConjunctiveIn qs a && isConjunctiveIn qs b
+      | Lean.Order.himp _ _ a b => !occursMVar qs a && isConjunctiveIn qs b
+      | wp _ _ _ _ _ _ _ prog post epost =>
+        !occursMVar qs prog && isConjunctiveIn qs post && isConjunctiveIn qs epost
+      | _ => false
 
 /-- Whether the spec's precondition is conjunctive in its schematic postconditions (`Q` and/or `E`):
 each occurs only in conjunctive contexts, and in no premise nor in the program. The `binders` are the

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,6 +1,6 @@
 #include "util/options.h"
 
-// [ ] Check box to force CI to test stage 2 and run update-stage0 on PR merge
+// [x] Check box to force CI to test stage 2 and run update-stage0 on PR merge
 // (any other change to this file will do the same; ALL changes should be made to the stage0/ copy)
 
 namespace lean {


### PR DESCRIPTION
This PR removes the name tables that #14780 added to the `@[spec]` attribute and the conjunctivity analysis, now that the library has moved to `Std.WP` and the `stage0` snapshot carries the new names.