### PR TITLE
fix: support `macro_inline` on `csimp`-ed declarations

### DIFF
--- a/src/Lean/Compiler/LCNF/ToDecl.lean
+++ b/src/Lean/Compiler/LCNF/ToDecl.lean
@@ -80,16 +80,21 @@ partial def inlineMatchers (e : Expr) : CoreM Expr :=
       return .continue
 
 /--
-Replace nested occurrences of `unsafeRec` names with the safe ones.
+Replace constants that occur in our input for reasons related to Lean's logic vs execution model:
+- nested occurrences of `unsafeRec` names with the safe ones
+- `csimp` tagged names with their efficient equivalent. Note that we still need to run csimp later
+  on because things like macro inlining etc. might open new `csimp` opportunities.
 -/
-private def replaceUnsafeRecNames (value : Expr) : CoreM Expr :=
-  Core.transform value fun e =>
+private def replaceLogicConstants (value : Expr) : CoreM Expr :=
+  Core.transform value fun e => do
     match e with
     | .const declName us =>
-      if let some safeDeclName := isUnsafeRecName? declName then
-        return .done (.const safeDeclName us)
-      else
-        return .done e
+      let e :=
+        if let some safeDeclName := isUnsafeRecName? declName then
+          .const safeDeclName us
+        else
+          e
+      return .done (← CSimp.replaceConstant (← getEnv) e)
     | _ => return .continue
 
 /--
@@ -153,7 +158,7 @@ def toDecl (declName : Name) : CompilerM (Decl .pure) := do
     let (type, value) ← Meta.MetaM.run' do
       let type  ← toLCNFType info.type
       let value ← Meta.lambdaTelescope value fun xs body => do Meta.mkLambdaFVars xs (← Meta.etaExpand body)
-      let value ← replaceUnsafeRecNames value
+      let value ← replaceLogicConstants value
       let value ← macroInline value
       /- Recall that some declarations tagged with `macro_inline` contain matchers. -/
       let value ← inlineMatchers value

--- a/tests/elab/csimp_macroinline.lean
+++ b/tests/elab/csimp_macroinline.lean
@@ -1,0 +1,40 @@
+/-! We need to execute `csimp` both before and after `macr_inline` -/
+
+@[macro_inline]
+def myLength (xs : List Nat) : Nat := xs.length
+
+/--
+trace: [Compiler.init] size: 1
+    def myLengthTest xs : Nat :=
+      let _x.1 := @List.lengthTR _ xs;
+      return _x.1
+-/
+#guard_msgs in
+set_option trace.Compiler.init true in
+def myLengthTest (xs : List Nat) : Nat := myLength xs
+
+@[noinline]
+def myIte (c : Bool) (t e : Nat) : Nat := if c then t else e
+
+@[macro_inline]
+def myIte' (c : Bool) (t e : Nat) : Nat := if c then t else e
+
+@[csimp]
+theorem myIteThm : @myIte = @myIte' := rfl
+
+/--
+trace: [Compiler.init] size: 7
+    def myIteTest c t e : Nat :=
+      let _x.1 := true;
+      let _x.2 := instDecidableEqBool c _x.1;
+      cases _x.2 : Nat
+      | Decidable.isFalse x.3 =>
+        let _x.4 := Nat.add e e;
+        return _x.4
+      | Decidable.isTrue x.5 =>
+        let _x.6 := Nat.add t t;
+        return _x.6
+-/
+#guard_msgs in
+set_option trace.Compiler.init true in
+def myIteTest (c : Bool) (t e : Nat) : Nat := myIte c (Nat.add t t) (Nat.add e e)


### PR DESCRIPTION
This PR makes the compiler `macro_inline` results of `csimp` lemmas.