### PR TITLE
feat: add intersection emptiness symmetry lemmas

### DIFF
--- a/src/Std/Data/DHashMap/Internal/RawLemmas.lean
+++ b/src/Std/Data/DHashMap/Internal/RawLemmas.lean
@@ -3308,6 +3308,11 @@ theorem isEmpty_inter_iff [EquivBEq α] [LawfulHashable α] (h₁ : m₁.val.WF)
     (m₁.inter m₂).1.isEmpty ↔ ∀ k, m₁.contains k → m₂.contains k = false := by
   simp_to_model [inter, contains, isEmpty] using List.isEmpty_filter_containsKey_iff
 
+theorem isEmpty_inter_comm [EquivBEq α] [LawfulHashable α]
+    (h₁ : m₁.val.WF) (h₂ : m₂.val.WF) :
+    (m₁.inter m₂).1.isEmpty = (m₂.inter m₁).1.isEmpty := by
+  simp_to_model [inter, contains, isEmpty] using List.isEmpty_filter_containsKey_comm
+
 end Inter
 namespace Const
 

--- a/src/Std/Data/DHashMap/Lemmas.lean
+++ b/src/Std/Data/DHashMap/Lemmas.lean
@@ -2462,6 +2462,11 @@ theorem isEmpty_inter_iff [EquivBEq α] [LawfulHashable α] :
   simpa only [mem_iff_contains, Bool.not_eq_true] using!
     @Raw₀.isEmpty_inter_iff _ _ _ _ ⟨m₁.1, m₁.2.size_buckets_pos⟩ ⟨m₂.1, m₂.2.size_buckets_pos⟩ _ _ m₁.wf m₂.wf
 
+theorem isEmpty_inter_comm [EquivBEq α] [LawfulHashable α] :
+    (m₁ ∩ m₂).isEmpty = (m₂ ∩ m₁).isEmpty :=
+  @Raw₀.isEmpty_inter_comm _ _ _ _
+    ⟨m₁.1, m₁.2.size_buckets_pos⟩ ⟨m₂.1, m₂.2.size_buckets_pos⟩ _ _ m₁.wf m₂.wf
+
 end Inter
 
 namespace Const

--- a/src/Std/Data/DHashMap/Lemmas.lean
+++ b/src/Std/Data/DHashMap/Lemmas.lean
@@ -4582,6 +4582,12 @@ theorem equiv_emptyWithCapacity_iff_isEmpty [EquivBEq α] [LawfulHashable α] {c
 theorem equiv_empty_iff_isEmpty [EquivBEq α] [LawfulHashable α] : m ~m ∅ ↔ m.isEmpty :=
   equiv_emptyWithCapacity_iff_isEmpty
 
+theorem inter_equiv_empty_comm [EquivBEq α] [LawfulHashable α]
+    {m₁ m₂ : DHashMap α β} :
+    (m₁ ∩ m₂) ~m ∅ ↔ (m₂ ∩ m₁) ~m ∅ := by
+  rw [equiv_empty_iff_isEmpty, equiv_empty_iff_isEmpty, ← Bool.eq_iff_iff]
+  exact isEmpty_inter_comm
+
 @[simp]
 theorem emptyWithCapacity_equiv_iff_isEmpty [EquivBEq α] [LawfulHashable α] {c : Nat} :
     emptyWithCapacity c ~m m ↔ m.isEmpty :=

--- a/src/Std/Data/DHashMap/RawLemmas.lean
+++ b/src/Std/Data/DHashMap/RawLemmas.lean
@@ -2818,6 +2818,11 @@ theorem isEmpty_inter_iff [EquivBEq α] [LawfulHashable α] (h₁ : m₁.WF) (h�
   simp only [Inter.inter, Membership.mem]
   simp_to_raw using @Raw₀.isEmpty_inter_iff _ _ _ _ ⟨m₁, _⟩ ⟨m₂, _⟩ _ _
 
+theorem isEmpty_inter_comm [EquivBEq α] [LawfulHashable α] (h₁ : m₁.WF) (h₂ : m₂.WF) :
+    (m₁ ∩ m₂).isEmpty = (m₂ ∩ m₁).isEmpty := by
+  simp only [Inter.inter]
+  simp_to_raw using @Raw₀.isEmpty_inter_comm _ _ _ _ ⟨m₁, _⟩ ⟨m₂, _⟩ _ _
+
 end Inter
 
 namespace Const

--- a/src/Std/Data/DHashMap/RawLemmas.lean
+++ b/src/Std/Data/DHashMap/RawLemmas.lean
@@ -5232,6 +5232,13 @@ theorem equiv_empty_iff_isEmpty [EquivBEq α] [LawfulHashable α] (h : m.WF) :
     m ~m ∅ ↔ m.isEmpty :=
   equiv_emptyWithCapacity_iff_isEmpty h
 
+theorem inter_equiv_empty_comm [EquivBEq α] [LawfulHashable α]
+    {m₁ m₂ : DHashMap.Raw α β} (h₁ : m₁.WF) (h₂ : m₂.WF) :
+    (m₁ ∩ m₂) ~m ∅ ↔ (m₂ ∩ m₁) ~m ∅ := by
+  rw [equiv_empty_iff_isEmpty (h₁.inter h₂), equiv_empty_iff_isEmpty (h₂.inter h₁),
+    ← Bool.eq_iff_iff]
+  exact isEmpty_inter_comm h₁ h₂
+
 theorem emptyWithCapacity_equiv_iff_isEmpty [EquivBEq α] [LawfulHashable α] {c : Nat} (h : m.WF) :
     emptyWithCapacity c ~m m ↔ m.isEmpty :=
   Equiv.comm.trans (equiv_emptyWithCapacity_iff_isEmpty h)

--- a/src/Std/Data/DTreeMap/Internal/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Internal/Lemmas.lean
@@ -4953,11 +4953,20 @@ theorem isEmpty_inter_iff [TransOrd α] (h₁ : m₁.WF) (h₂ : m₂.WF) :
     (m₁.inter m₂ h₁.balanced).isEmpty ↔ ∀ k, m₁.contains k → m₂.contains k = false := by
   simp_to_model [inter, contains, isEmpty] using List.isEmpty_filter_containsKey_iff
 
+theorem isEmpty_inter_comm [TransOrd α] (h₁ : m₁.WF) (h₂ : m₂.WF) :
+    (m₁.inter m₂ h₁.balanced).isEmpty = (m₂.inter m₁ h₂.balanced).isEmpty := by
+  simp_to_model [inter, contains, isEmpty] using List.isEmpty_filter_containsKey_comm
+
 theorem isEmpty_inter!_iff [TransOrd α] (h₁ : m₁.WF) (h₂ : m₂.WF) :
     (m₁.inter! m₂).isEmpty ↔ ∀ k, m₁.contains k → m₂.contains k = false := by
   rw [← inter_eq_inter!]
   apply isEmpty_inter_iff h₁ h₂
   all_goals wf_trivial
+
+theorem isEmpty_inter!_comm [TransOrd α] (h₁ : m₁.WF) (h₂ : m₂.WF) :
+    (m₁.inter! m₂).isEmpty = (m₂.inter! m₁).isEmpty := by
+  rw [← inter_eq_inter!, ← inter_eq_inter!]
+  exact isEmpty_inter_comm h₁ h₂
 
 end Inter
 

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -3005,6 +3005,10 @@ theorem isEmpty_inter_iff [TransCmp cmp] :
     rw [← contains_eq_false_iff_not_mem]
   exact Impl.isEmpty_inter_iff t₁.wf t₂.wf
 
+theorem isEmpty_inter_comm [TransCmp cmp] :
+    (t₁ ∩ t₂).isEmpty = (t₂ ∩ t₁).isEmpty :=
+  Impl.isEmpty_inter_comm t₁.wf t₂.wf
+
 end Inter
 
 namespace Const

--- a/src/Std/Data/DTreeMap/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Lemmas.lean
@@ -6137,6 +6137,12 @@ private theorem equiv_iff_equiv : t₁ ~m t₂ ↔ t₁.1.Equiv t₂.1 :=
 theorem equiv_empty_iff_isEmpty : t ~m empty ↔ t.isEmpty :=
   equiv_iff_equiv.trans Impl.equiv_empty_iff_isEmpty
 
+theorem inter_equiv_empty_comm [TransCmp cmp] :
+    (t₁ ∩ t₂) ~m ∅ ↔ (t₂ ∩ t₁) ~m ∅ := by
+  change (t₁ ∩ t₂) ~m empty ↔ (t₂ ∩ t₁) ~m empty
+  rw [equiv_empty_iff_isEmpty, equiv_empty_iff_isEmpty, ← Bool.eq_iff_iff]
+  exact isEmpty_inter_comm
+
 theorem empty_equiv_iff_isEmpty : empty ~m t ↔ t.isEmpty :=
   Equiv.comm.trans equiv_empty_iff_isEmpty
 

--- a/src/Std/Data/DTreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Raw/Lemmas.lean
@@ -3165,6 +3165,10 @@ theorem isEmpty_inter_iff [TransCmp cmp] (h₁ : t₁.WF) (h₂ : t₂.WF) :
     rw [← contains_eq_false_iff_not_mem]
   exact Impl.isEmpty_inter!_iff h₁ h₂
 
+theorem isEmpty_inter_comm [TransCmp cmp] (h₁ : t₁.WF) (h₂ : t₂.WF) :
+    (t₁ ∩ t₂).isEmpty = (t₂ ∩ t₁).isEmpty :=
+  Impl.isEmpty_inter!_comm h₁ h₂
+
 end Inter
 
 namespace Const

--- a/src/Std/Data/DTreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/DTreeMap/Raw/Lemmas.lean
@@ -5995,6 +5995,12 @@ private theorem equiv_iff : t₁ ~m t₂ ↔ t₁.1.Equiv t₂.1 :=
 theorem equiv_empty_iff_isEmpty : t ~m empty ↔ t.isEmpty :=
   equiv_iff.trans Impl.equiv_empty_iff_isEmpty
 
+theorem inter_equiv_empty_comm [TransCmp cmp] (h₁ : t₁.WF) (h₂ : t₂.WF) :
+    (t₁ ∩ t₂) ~m ∅ ↔ (t₂ ∩ t₁) ~m ∅ := by
+  change (t₁ ∩ t₂) ~m empty ↔ (t₂ ∩ t₁) ~m empty
+  rw [equiv_empty_iff_isEmpty, equiv_empty_iff_isEmpty, ← Bool.eq_iff_iff]
+  exact isEmpty_inter_comm h₁ h₂
+
 theorem empty_equiv_iff_isEmpty : empty ~m t ↔ t.isEmpty :=
   equiv_iff.trans Impl.empty_equiv_iff_isEmpty
 

--- a/src/Std/Data/ExtDHashMap/Lemmas.lean
+++ b/src/Std/Data/ExtDHashMap/Lemmas.lean
@@ -2705,6 +2705,11 @@ theorem isEmpty_inter_comm [EquivBEq α] [LawfulHashable α] :
     (m₁ ∩ m₂).isEmpty = (m₂ ∩ m₁).isEmpty :=
   m₁.inductionOn₂ m₂ fun _ _ => DHashMap.isEmpty_inter_comm
 
+theorem inter_eq_empty_comm [EquivBEq α] [LawfulHashable α] :
+    m₁ ∩ m₂ = ∅ ↔ m₂ ∩ m₁ = ∅ := by
+  rw [← isEmpty_iff, ← isEmpty_iff, ← Bool.eq_iff_iff]
+  exact isEmpty_inter_comm
+
 end Inter
 
 namespace Const

--- a/src/Std/Data/ExtDHashMap/Lemmas.lean
+++ b/src/Std/Data/ExtDHashMap/Lemmas.lean
@@ -2701,6 +2701,10 @@ theorem isEmpty_inter_iff [EquivBEq α] [LawfulHashable α] :
     (m₁ ∩ m₂).isEmpty ↔ ∀ k, k ∈ m₁ → k ∉ m₂ :=
   m₁.inductionOn₂ m₂ fun _ _ => DHashMap.isEmpty_inter_iff
 
+theorem isEmpty_inter_comm [EquivBEq α] [LawfulHashable α] :
+    (m₁ ∩ m₂).isEmpty = (m₂ ∩ m₁).isEmpty :=
+  m₁.inductionOn₂ m₂ fun _ _ => DHashMap.isEmpty_inter_comm
+
 end Inter
 
 namespace Const

--- a/src/Std/Data/ExtDTreeMap/Lemmas.lean
+++ b/src/Std/Data/ExtDTreeMap/Lemmas.lean
@@ -2937,6 +2937,11 @@ theorem isEmpty_inter_comm [TransCmp cmp] :
     (t₁ ∩ t₂).isEmpty = (t₂ ∩ t₁).isEmpty :=
   t₁.inductionOn₂ t₂ fun _ _ => DTreeMap.isEmpty_inter_comm
 
+theorem inter_eq_empty_comm [TransCmp cmp] :
+    t₁ ∩ t₂ = ∅ ↔ t₂ ∩ t₁ = ∅ := by
+  rw [← isEmpty_iff, ← isEmpty_iff, ← Bool.eq_iff_iff]
+  exact isEmpty_inter_comm
+
 end Inter
 
 namespace Const

--- a/src/Std/Data/ExtDTreeMap/Lemmas.lean
+++ b/src/Std/Data/ExtDTreeMap/Lemmas.lean
@@ -2933,6 +2933,10 @@ theorem isEmpty_inter_iff [TransCmp cmp] :
     (t₁ ∩ t₂).isEmpty ↔ ∀ k, k ∈ t₁ → ¬k ∈ t₂ :=
   t₁.inductionOn₂ t₂ fun _ _ => DTreeMap.isEmpty_inter_iff
 
+theorem isEmpty_inter_comm [TransCmp cmp] :
+    (t₁ ∩ t₂).isEmpty = (t₂ ∩ t₁).isEmpty :=
+  t₁.inductionOn₂ t₂ fun _ _ => DTreeMap.isEmpty_inter_comm
+
 end Inter
 
 namespace Const

--- a/src/Std/Data/ExtHashMap/Lemmas.lean
+++ b/src/Std/Data/ExtHashMap/Lemmas.lean
@@ -1784,6 +1784,11 @@ theorem isEmpty_inter_comm [EquivBEq α] [LawfulHashable α] :
     (m₁ ∩ m₂).isEmpty = (m₂ ∩ m₁).isEmpty :=
   ExtDHashMap.isEmpty_inter_comm
 
+theorem inter_eq_empty_comm [EquivBEq α] [LawfulHashable α] :
+    m₁ ∩ m₂ = ∅ ↔ m₂ ∩ m₁ = ∅ := by
+  rw [ext_iff, ext_iff]
+  exact ExtDHashMap.inter_eq_empty_comm
+
 end Inter
 
 section Diff

--- a/src/Std/Data/ExtHashMap/Lemmas.lean
+++ b/src/Std/Data/ExtHashMap/Lemmas.lean
@@ -1780,6 +1780,10 @@ theorem isEmpty_inter_iff [EquivBEq α] [LawfulHashable α] :
     (m₁ ∩ m₂).isEmpty ↔ ∀ k, k ∈ m₁ → k ∉ m₂ :=
   ExtDHashMap.isEmpty_inter_iff
 
+theorem isEmpty_inter_comm [EquivBEq α] [LawfulHashable α] :
+    (m₁ ∩ m₂).isEmpty = (m₂ ∩ m₁).isEmpty :=
+  ExtDHashMap.isEmpty_inter_comm
+
 end Inter
 
 section Diff

--- a/src/Std/Data/ExtHashSet/Lemmas.lean
+++ b/src/Std/Data/ExtHashSet/Lemmas.lean
@@ -1029,6 +1029,11 @@ theorem isEmpty_inter_comm [EquivBEq α] [LawfulHashable α] :
     (m₁ ∩ m₂).isEmpty = (m₂ ∩ m₁).isEmpty :=
   ExtHashMap.isEmpty_inter_comm
 
+theorem inter_eq_empty_comm [EquivBEq α] [LawfulHashable α] :
+    m₁ ∩ m₂ = ∅ ↔ m₂ ∩ m₁ = ∅ := by
+  rw [← isEmpty_iff, ← isEmpty_iff, ← Bool.eq_iff_iff]
+  exact isEmpty_inter_comm
+
 end Inter
 
 section Diff

--- a/src/Std/Data/ExtHashSet/Lemmas.lean
+++ b/src/Std/Data/ExtHashSet/Lemmas.lean
@@ -1025,6 +1025,10 @@ theorem isEmpty_inter_iff [EquivBEq α] [LawfulHashable α] :
     (m₁ ∩ m₂).isEmpty ↔ ∀ k, k ∈ m₁ → k ∉ m₂ :=
   ExtHashMap.isEmpty_inter_iff
 
+theorem isEmpty_inter_comm [EquivBEq α] [LawfulHashable α] :
+    (m₁ ∩ m₂).isEmpty = (m₂ ∩ m₁).isEmpty :=
+  ExtHashMap.isEmpty_inter_comm
+
 end Inter
 
 section Diff

--- a/src/Std/Data/ExtTreeMap/Lemmas.lean
+++ b/src/Std/Data/ExtTreeMap/Lemmas.lean
@@ -1931,6 +1931,10 @@ theorem isEmpty_inter_iff [TransCmp cmp] :
     (t₁ ∩ t₂).isEmpty ↔ ∀ k, k ∈ t₁ → k ∉ t₂ :=
   ExtDTreeMap.isEmpty_inter_iff
 
+theorem isEmpty_inter_comm [TransCmp cmp] :
+    (t₁ ∩ t₂).isEmpty = (t₂ ∩ t₁).isEmpty :=
+  ExtDTreeMap.isEmpty_inter_comm
+
 end Inter
 
 section Diff

--- a/src/Std/Data/ExtTreeMap/Lemmas.lean
+++ b/src/Std/Data/ExtTreeMap/Lemmas.lean
@@ -1935,6 +1935,11 @@ theorem isEmpty_inter_comm [TransCmp cmp] :
     (t₁ ∩ t₂).isEmpty = (t₂ ∩ t₁).isEmpty :=
   ExtDTreeMap.isEmpty_inter_comm
 
+theorem inter_eq_empty_comm [TransCmp cmp] :
+    t₁ ∩ t₂ = ∅ ↔ t₂ ∩ t₁ = ∅ := by
+  rw [← isEmpty_iff, ← isEmpty_iff, ← Bool.eq_iff_iff]
+  exact isEmpty_inter_comm
+
 end Inter
 
 section Diff

--- a/src/Std/Data/ExtTreeSet/Lemmas.lean
+++ b/src/Std/Data/ExtTreeSet/Lemmas.lean
@@ -716,6 +716,10 @@ theorem isEmpty_inter_iff [TransCmp cmp] :
     (t₁ ∩ t₂).isEmpty ↔ ∀ k, k ∈ t₁ → k ∉ t₂ :=
   ExtTreeMap.isEmpty_inter_iff
 
+theorem isEmpty_inter_comm [TransCmp cmp] :
+    (t₁ ∩ t₂).isEmpty = (t₂ ∩ t₁).isEmpty :=
+  ExtTreeMap.isEmpty_inter_comm
+
 end Inter
 
 section Diff

--- a/src/Std/Data/ExtTreeSet/Lemmas.lean
+++ b/src/Std/Data/ExtTreeSet/Lemmas.lean
@@ -720,6 +720,11 @@ theorem isEmpty_inter_comm [TransCmp cmp] :
     (t₁ ∩ t₂).isEmpty = (t₂ ∩ t₁).isEmpty :=
   ExtTreeMap.isEmpty_inter_comm
 
+theorem inter_eq_empty_comm [TransCmp cmp] :
+    t₁ ∩ t₂ = ∅ ↔ t₂ ∩ t₁ = ∅ := by
+  rw [← isEmpty_iff, ← isEmpty_iff, ← Bool.eq_iff_iff]
+  exact isEmpty_inter_comm
+
 end Inter
 
 section Diff

--- a/src/Std/Data/HashMap/Lemmas.lean
+++ b/src/Std/Data/HashMap/Lemmas.lean
@@ -1850,6 +1850,10 @@ theorem isEmpty_inter_iff [EquivBEq α] [LawfulHashable α] :
     (m₁ ∩ m₂).isEmpty ↔ ∀ k, k ∈ m₁ → k ∉ m₂ :=
   @DHashMap.isEmpty_inter_iff α _ _ _ m₁.inner m₂.inner _ _
 
+theorem isEmpty_inter_comm [EquivBEq α] [LawfulHashable α] :
+    (m₁ ∩ m₂).isEmpty = (m₂ ∩ m₁).isEmpty :=
+  @DHashMap.isEmpty_inter_comm α _ _ _ m₁.inner m₂.inner _ _
+
 end Inter
 
 section Diff

--- a/src/Std/Data/HashMap/Lemmas.lean
+++ b/src/Std/Data/HashMap/Lemmas.lean
@@ -3026,6 +3026,11 @@ theorem equiv_emptyWithCapacity_iff_isEmpty [EquivBEq α] [LawfulHashable α] {c
 theorem equiv_empty_iff_isEmpty [EquivBEq α] [LawfulHashable α] : m ~m ∅ ↔ m.isEmpty :=
   equiv_emptyWithCapacity_iff_isEmpty
 
+theorem inter_equiv_empty_comm [EquivBEq α] [LawfulHashable α] :
+    (m₁ ∩ m₂) ~m ∅ ↔ (m₂ ∩ m₁) ~m ∅ := by
+  rw [equiv_empty_iff_isEmpty, equiv_empty_iff_isEmpty, ← Bool.eq_iff_iff]
+  exact isEmpty_inter_comm
+
 @[simp]
 theorem emptyWithCapacity_equiv_iff_isEmpty [EquivBEq α] [LawfulHashable α] {c : Nat} :
     emptyWithCapacity c ~m m ↔ m.isEmpty :=

--- a/src/Std/Data/HashMap/RawLemmas.lean
+++ b/src/Std/Data/HashMap/RawLemmas.lean
@@ -1801,6 +1801,10 @@ theorem isEmpty_inter_iff [EquivBEq α] [LawfulHashable α] (h₁ : m₁.WF) (h�
     (m₁ ∩ m₂).isEmpty ↔ ∀ k, k ∈ m₁ → k ∉ m₂ :=
   @DHashMap.Raw.isEmpty_inter_iff _ _ _ _ m₁.inner m₂.inner _ _ h₁.out h₂.out
 
+theorem isEmpty_inter_comm [EquivBEq α] [LawfulHashable α] (h₁ : m₁.WF) (h₂ : m₂.WF) :
+    (m₁ ∩ m₂).isEmpty = (m₂ ∩ m₁).isEmpty :=
+  @DHashMap.Raw.isEmpty_inter_comm _ _ _ _ m₁.inner m₂.inner _ _ h₁.out h₂.out
+
 end Inter
 
 section Diff

--- a/src/Std/Data/HashMap/RawLemmas.lean
+++ b/src/Std/Data/HashMap/RawLemmas.lean
@@ -3055,6 +3055,13 @@ theorem equiv_empty_iff_isEmpty [EquivBEq α] [LawfulHashable α] (h : m.WF) :
     m ~m ∅ ↔ m.isEmpty :=
   equiv_emptyWithCapacity_iff_isEmpty h
 
+theorem inter_equiv_empty_comm [EquivBEq α] [LawfulHashable α]
+    {m₁ m₂ : HashMap.Raw α β} (h₁ : m₁.WF) (h₂ : m₂.WF) :
+    (m₁ ∩ m₂) ~m ∅ ↔ (m₂ ∩ m₁) ~m ∅ := by
+  rw [equiv_empty_iff_isEmpty (h₁.inter h₂), equiv_empty_iff_isEmpty (h₂.inter h₁),
+    ← Bool.eq_iff_iff]
+  exact isEmpty_inter_comm h₁ h₂
+
 theorem emptyWithCapacity_equiv_iff_isEmpty [EquivBEq α] [LawfulHashable α] {c : Nat} (h : m.WF) :
     emptyWithCapacity c ~m m ↔ m.isEmpty :=
   Equiv.comm.trans (equiv_emptyWithCapacity_iff_isEmpty h)

--- a/src/Std/Data/HashSet/Lemmas.lean
+++ b/src/Std/Data/HashSet/Lemmas.lean
@@ -1462,6 +1462,12 @@ theorem equiv_emptyWithCapacity_iff_isEmpty [EquivBEq α] [LawfulHashable α] {c
 theorem equiv_empty_iff_isEmpty [EquivBEq α] [LawfulHashable α] : m ~m ∅ ↔ m.isEmpty :=
   equiv_emptyWithCapacity_iff_isEmpty
 
+theorem inter_equiv_empty_comm [EquivBEq α] [LawfulHashable α]
+    {m₁ m₂ : HashSet α} :
+    (m₁ ∩ m₂) ~m ∅ ↔ (m₂ ∩ m₁) ~m ∅ := by
+  rw [equiv_empty_iff_isEmpty, equiv_empty_iff_isEmpty, ← Bool.eq_iff_iff]
+  exact isEmpty_inter_comm
+
 @[simp]
 theorem emptyWithCapacity_equiv_iff_isEmpty [EquivBEq α] [LawfulHashable α] {c : Nat} :
     emptyWithCapacity c ~m m ↔ m.isEmpty :=

--- a/src/Std/Data/HashSet/Lemmas.lean
+++ b/src/Std/Data/HashSet/Lemmas.lean
@@ -1114,6 +1114,10 @@ theorem isEmpty_inter_iff [EquivBEq α] [LawfulHashable α] :
     (m₁ ∩ m₂).isEmpty ↔ ∀ k, k ∈ m₁ → k ∉ m₂ :=
   @HashMap.isEmpty_inter_iff α _ _ _ m₁.inner m₂.inner _ _
 
+theorem isEmpty_inter_comm [EquivBEq α] [LawfulHashable α] :
+    (m₁ ∩ m₂).isEmpty = (m₂ ∩ m₁).isEmpty :=
+  @HashMap.isEmpty_inter_comm α _ _ _ m₁.inner m₂.inner _ _
+
 end Inter
 
 section Diff

--- a/src/Std/Data/HashSet/RawLemmas.lean
+++ b/src/Std/Data/HashSet/RawLemmas.lean
@@ -1540,6 +1540,13 @@ theorem equiv_empty_iff_isEmpty [EquivBEq α] [LawfulHashable α] (h : m.WF) :
     m ~m ∅ ↔ m.isEmpty :=
   equiv_emptyWithCapacity_iff_isEmpty h
 
+theorem inter_equiv_empty_comm [EquivBEq α] [LawfulHashable α]
+    {m₁ m₂ : HashSet.Raw α} (h₁ : m₁.WF) (h₂ : m₂.WF) :
+    (m₁ ∩ m₂) ~m ∅ ↔ (m₂ ∩ m₁) ~m ∅ := by
+  rw [equiv_empty_iff_isEmpty (h₁.inter h₂), equiv_empty_iff_isEmpty (h₂.inter h₁),
+    ← Bool.eq_iff_iff]
+  exact isEmpty_inter_comm h₁ h₂
+
 theorem equiv_iff_toList_perm {m₁ m₂ : Raw α} [EquivBEq α] [LawfulHashable α] :
     m₁ ~m m₂ ↔ m₁.toList.Perm m₂.toList :=
   ⟨Equiv.toList_perm, Equiv.of_toList_perm⟩

--- a/src/Std/Data/HashSet/RawLemmas.lean
+++ b/src/Std/Data/HashSet/RawLemmas.lean
@@ -1171,6 +1171,10 @@ theorem isEmpty_inter_iff [EquivBEq α] [LawfulHashable α] (h₁ : m₁.WF) (h�
     (m₁ ∩ m₂).isEmpty ↔ ∀ k, k ∈ m₁ → k ∉ m₂ :=
   @HashMap.Raw.isEmpty_inter_iff _ _ _ _ m₁.inner m₂.inner _ _ h₁.out h₂.out
 
+theorem isEmpty_inter_comm [EquivBEq α] [LawfulHashable α] (h₁ : m₁.WF) (h₂ : m₂.WF) :
+    (m₁ ∩ m₂).isEmpty = (m₂ ∩ m₁).isEmpty :=
+  @HashMap.Raw.isEmpty_inter_comm _ _ _ _ m₁.inner m₂.inner _ _ h₁.out h₂.out
+
 end Inter
 
 section Diff

--- a/src/Std/Data/Internal/List/Associative.lean
+++ b/src/Std/Data/Internal/List/Associative.lean
@@ -7578,6 +7578,16 @@ theorem isEmpty_filter_containsKey_iff [BEq α] [EquivBEq α]
           . exact hyp
           . exact heq2
 
+theorem isEmpty_filter_containsKey_comm [BEq α] [EquivBEq α]
+    {l₁ l₂ : List ((a : α) × β a)} (dl₁ : DistinctKeys l₁) (dl₂ : DistinctKeys l₂) :
+    (List.filter (fun p => containsKey p.fst l₂) l₁).isEmpty =
+      (List.filter (fun p => containsKey p.fst l₁) l₂).isEmpty := by
+  rw [Bool.eq_iff_iff, isEmpty_filter_containsKey_iff dl₁,
+    isEmpty_filter_containsKey_iff dl₂]
+  constructor <;> intro h k hk <;> apply Bool.eq_false_iff.2 <;> intro hk'
+  · exact Bool.eq_false_iff.1 (h k hk') hk
+  · exact Bool.eq_false_iff.1 (h k hk') hk
+
 theorem nil_of_containsKey_eq_false [BEq α] [EquivBEq α] {l : List ((a : α) × β a)} :
     (∀ k, containsKey k l = false) ↔ l = [] := by
   constructor

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -2101,6 +2101,10 @@ theorem isEmpty_inter_iff [TransCmp cmp] :
     (t₁ ∩ t₂).isEmpty ↔ ∀ k, k ∈ t₁ → k ∉ t₂ :=
   DTreeMap.isEmpty_inter_iff
 
+theorem isEmpty_inter_comm [TransCmp cmp] :
+    (t₁ ∩ t₂).isEmpty = (t₂ ∩ t₁).isEmpty :=
+  DTreeMap.isEmpty_inter_comm
+
 end Inter
 
 section

--- a/src/Std/Data/TreeMap/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Lemmas.lean
@@ -4339,6 +4339,12 @@ private theorem equiv_iff_equiv : t₁ ~m t₂ ↔ t₁.1.Equiv t₂.1 :=
 theorem equiv_empty_iff_isEmpty : t ~m empty ↔ t.isEmpty :=
   equiv_iff_equiv.trans DTreeMap.equiv_empty_iff_isEmpty
 
+theorem inter_equiv_empty_comm [TransCmp cmp] :
+    (t₁ ∩ t₂) ~m ∅ ↔ (t₂ ∩ t₁) ~m ∅ := by
+  change (t₁ ∩ t₂) ~m empty ↔ (t₂ ∩ t₁) ~m empty
+  rw [equiv_empty_iff_isEmpty, equiv_empty_iff_isEmpty, ← Bool.eq_iff_iff]
+  exact isEmpty_inter_comm
+
 theorem empty_equiv_iff_isEmpty : empty ~m t ↔ t.isEmpty :=
   Equiv.comm.trans equiv_empty_iff_isEmpty
 

--- a/src/Std/Data/TreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Raw/Lemmas.lean
@@ -4071,6 +4071,12 @@ private theorem equiv_iff : t₁ ~m t₂ ↔ t₁.1.Equiv t₂.1 :=
 theorem equiv_empty_iff_isEmpty : t ~m empty ↔ t.isEmpty :=
   equiv_iff.trans DTreeMap.Raw.equiv_empty_iff_isEmpty
 
+theorem inter_equiv_empty_comm [TransCmp cmp] (h₁ : t₁.WF) (h₂ : t₂.WF) :
+    (t₁ ∩ t₂) ~m ∅ ↔ (t₂ ∩ t₁) ~m ∅ := by
+  change (t₁ ∩ t₂) ~m empty ↔ (t₂ ∩ t₁) ~m empty
+  rw [equiv_empty_iff_isEmpty, equiv_empty_iff_isEmpty, ← Bool.eq_iff_iff]
+  exact isEmpty_inter_comm h₁ h₂
+
 theorem empty_equiv_iff_isEmpty : empty ~m t ↔ t.isEmpty :=
   equiv_iff.trans DTreeMap.Raw.empty_equiv_iff_isEmpty
 

--- a/src/Std/Data/TreeMap/Raw/Lemmas.lean
+++ b/src/Std/Data/TreeMap/Raw/Lemmas.lean
@@ -2151,6 +2151,10 @@ theorem isEmpty_inter_iff [TransCmp cmp] (h₁ : t₁.WF) (h₂ : t₂.WF) :
     (t₁ ∩ t₂).isEmpty ↔ ∀ k, k ∈ t₁ → k ∉ t₂ :=
   DTreeMap.Raw.isEmpty_inter_iff h₁ h₂
 
+theorem isEmpty_inter_comm [TransCmp cmp] (h₁ : t₁.WF) (h₂ : t₂.WF) :
+    (t₁ ∩ t₂).isEmpty = (t₂ ∩ t₁).isEmpty :=
+  DTreeMap.Raw.isEmpty_inter_comm h₁ h₂
+
 end Inter
 
 section

--- a/src/Std/Data/TreeSet/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Lemmas.lean
@@ -2398,6 +2398,12 @@ private theorem equiv_iff_equiv : t₁ ~m t₂ ↔ t₁.1.Equiv t₂.1 :=
 theorem equiv_empty_iff_isEmpty : t ~m empty ↔ t.isEmpty :=
   equiv_iff_equiv.trans TreeMap.equiv_empty_iff_isEmpty
 
+theorem inter_equiv_empty_comm [TransCmp cmp] :
+    (t₁ ∩ t₂) ~m ∅ ↔ (t₂ ∩ t₁) ~m ∅ := by
+  change (t₁ ∩ t₂) ~m empty ↔ (t₂ ∩ t₁) ~m empty
+  rw [equiv_empty_iff_isEmpty, equiv_empty_iff_isEmpty, ← Bool.eq_iff_iff]
+  exact isEmpty_inter_comm
+
 theorem empty_equiv_iff_isEmpty : empty ~m t ↔ t.isEmpty :=
   Equiv.comm.trans equiv_empty_iff_isEmpty
 

--- a/src/Std/Data/TreeSet/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Lemmas.lean
@@ -812,6 +812,10 @@ theorem isEmpty_inter_iff [TransCmp cmp] :
     (t₁ ∩ t₂).isEmpty ↔ ∀ k, k ∈ t₁ → k ∉ t₂ :=
   TreeMap.isEmpty_inter_iff
 
+theorem isEmpty_inter_comm [TransCmp cmp] :
+    (t₁ ∩ t₂).isEmpty = (t₂ ∩ t₁).isEmpty :=
+  TreeMap.isEmpty_inter_comm
+
 end Inter
 
 section

--- a/src/Std/Data/TreeSet/Raw/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Raw/Lemmas.lean
@@ -2221,6 +2221,12 @@ private theorem equiv_iff : t₁ ~m t₂ ↔ t₁.1.Equiv t₂.1 :=
 theorem equiv_empty_iff_isEmpty : t ~m empty ↔ t.isEmpty :=
   equiv_iff.trans TreeMap.Raw.equiv_empty_iff_isEmpty
 
+theorem inter_equiv_empty_comm [TransCmp cmp] (h₁ : t₁.WF) (h₂ : t₂.WF) :
+    (t₁ ∩ t₂) ~m ∅ ↔ (t₂ ∩ t₁) ~m ∅ := by
+  change (t₁ ∩ t₂) ~m empty ↔ (t₂ ∩ t₁) ~m empty
+  rw [equiv_empty_iff_isEmpty, equiv_empty_iff_isEmpty, ← Bool.eq_iff_iff]
+  exact isEmpty_inter_comm h₁ h₂
+
 theorem empty_equiv_iff_isEmpty : empty ~m t ↔ t.isEmpty :=
   equiv_iff.trans TreeMap.Raw.empty_equiv_iff_isEmpty
 

--- a/src/Std/Data/TreeSet/Raw/Lemmas.lean
+++ b/src/Std/Data/TreeSet/Raw/Lemmas.lean
@@ -846,6 +846,10 @@ theorem isEmpty_inter_iff [TransCmp cmp] (h₁ : t₁.WF) (h₂ : t₂.WF) :
     (t₁ ∩ t₂).isEmpty ↔ ∀ k, k ∈ t₁ → k ∉ t₂ :=
   TreeMap.Raw.isEmpty_inter_iff h₁ h₂
 
+theorem isEmpty_inter_comm [TransCmp cmp] (h₁ : t₁.WF) (h₂ : t₂.WF) :
+    (t₁ ∩ t₂).isEmpty = (t₂ ∩ t₁).isEmpty :=
+  TreeMap.Raw.isEmpty_inter_comm h₁ h₂
+
 end Inter
 
 section

--- a/tests/elab/isEmptyInterComm.lean
+++ b/tests/elab/isEmptyInterComm.lean
@@ -1,0 +1,12 @@
+import Std.Data.ExtHashMap
+
+open Std
+
+/-! Check that intersection emptiness symmetry implies symmetry of disjoint hash maps. -/
+
+example [BEq α] [EquivBEq α] [Hashable α] [LawfulHashable α]
+    {m₁ m₂ : ExtHashMap α β} (h : m₁ ∩ m₂ = ∅) :
+    m₂ ∩ m₁ = ∅ := by
+  rw [← ExtHashMap.isEmpty_iff] at h ⊢
+  rw [ExtHashMap.isEmpty_inter_comm]
+  exact h

--- a/tests/elab/isEmptyInterComm.lean
+++ b/tests/elab/isEmptyInterComm.lean
@@ -1,12 +1,16 @@
 import Std.Data.ExtHashMap
 
 open Std
+open scoped DHashMap
 
-/-! Check that intersection emptiness symmetry implies symmetry of disjoint hash maps. -/
+/-! Check intersection emptiness symmetry for extensional and non-extensional hash maps. -/
 
 example [BEq α] [EquivBEq α] [Hashable α] [LawfulHashable α]
-    {m₁ m₂ : ExtHashMap α β} (h : m₁ ∩ m₂ = ∅) :
-    m₂ ∩ m₁ = ∅ := by
-  rw [← ExtHashMap.isEmpty_iff] at h ⊢
-  rw [ExtHashMap.isEmpty_inter_comm]
-  exact h
+    {m₁ m₂ : DHashMap α β} :
+    (m₁ ∩ m₂) ~m ∅ ↔ (m₂ ∩ m₁) ~m ∅ :=
+  DHashMap.inter_equiv_empty_comm
+
+example [BEq α] [EquivBEq α] [Hashable α] [LawfulHashable α]
+    {m₁ m₂ : ExtHashMap α β} :
+    m₁ ∩ m₂ = ∅ ↔ m₂ ∩ m₁ = ∅ :=
+  ExtHashMap.inter_eq_empty_comm

--- a/tests/elab/isEmptyInterComm.lean
+++ b/tests/elab/isEmptyInterComm.lean
@@ -1,10 +1,10 @@
-import Std.Data.ExtHashMap
+import Std.Data
 
 open Std
-open scoped DHashMap
 
-/-! Check intersection emptiness symmetry for extensional and non-extensional hash maps. -/
+/-! Check intersection emptiness symmetry across the public map and set APIs. -/
 
+open scoped DHashMap in
 example [BEq α] [EquivBEq α] [Hashable α] [LawfulHashable α]
     {m₁ m₂ : DHashMap α β} :
     (m₁ ∩ m₂) ~m ∅ ↔ (m₂ ∩ m₁) ~m ∅ :=
@@ -14,3 +14,47 @@ example [BEq α] [EquivBEq α] [Hashable α] [LawfulHashable α]
     {m₁ m₂ : ExtHashMap α β} :
     m₁ ∩ m₂ = ∅ ↔ m₂ ∩ m₁ = ∅ :=
   ExtHashMap.inter_eq_empty_comm
+
+open scoped HashMap in
+example [BEq α] [EquivBEq α] [Hashable α] [LawfulHashable α]
+    {m₁ m₂ : HashMap α β} :
+    (m₁ ∩ m₂) ~m ∅ ↔ (m₂ ∩ m₁) ~m ∅ :=
+  HashMap.inter_equiv_empty_comm
+
+open scoped HashSet in
+example [BEq α] [EquivBEq α] [Hashable α] [LawfulHashable α]
+    {m₁ m₂ : HashSet α} :
+    (m₁ ∩ m₂) ~m ∅ ↔ (m₂ ∩ m₁) ~m ∅ :=
+  HashSet.inter_equiv_empty_comm
+
+example [BEq α] [EquivBEq α] [Hashable α] [LawfulHashable α]
+    {m₁ m₂ : ExtHashSet α} :
+    m₁ ∩ m₂ = ∅ ↔ m₂ ∩ m₁ = ∅ :=
+  ExtHashSet.inter_eq_empty_comm
+
+open scoped DTreeMap in
+example {cmp : α → α → Ordering} [TransCmp cmp] {t₁ t₂ : DTreeMap α β cmp} :
+    (t₁ ∩ t₂) ~m ∅ ↔ (t₂ ∩ t₁) ~m ∅ :=
+  DTreeMap.inter_equiv_empty_comm
+
+example {cmp : α → α → Ordering} [TransCmp cmp] {t₁ t₂ : ExtDTreeMap α β cmp} :
+    t₁ ∩ t₂ = ∅ ↔ t₂ ∩ t₁ = ∅ :=
+  ExtDTreeMap.inter_eq_empty_comm
+
+open scoped TreeMap in
+example {cmp : α → α → Ordering} [TransCmp cmp] {t₁ t₂ : TreeMap α β cmp} :
+    (t₁ ∩ t₂) ~m ∅ ↔ (t₂ ∩ t₁) ~m ∅ :=
+  TreeMap.inter_equiv_empty_comm
+
+example {cmp : α → α → Ordering} [TransCmp cmp] {t₁ t₂ : ExtTreeMap α β cmp} :
+    t₁ ∩ t₂ = ∅ ↔ t₂ ∩ t₁ = ∅ :=
+  ExtTreeMap.inter_eq_empty_comm
+
+open scoped TreeSet in
+example {cmp : α → α → Ordering} [TransCmp cmp] {t₁ t₂ : TreeSet α cmp} :
+    (t₁ ∩ t₂) ~m ∅ ↔ (t₂ ∩ t₁) ~m ∅ :=
+  TreeSet.inter_equiv_empty_comm
+
+example {cmp : α → α → Ordering} [TransCmp cmp] {t₁ t₂ : ExtTreeSet α cmp} :
+    t₁ ∩ t₂ = ∅ ↔ t₂ ∩ t₁ = ∅ :=
+  ExtTreeSet.inter_eq_empty_comm

--- a/tests/elab/isEmptyInterComm.lean
+++ b/tests/elab/isEmptyInterComm.lean
@@ -1,8 +1,10 @@
+module
+
 import Std.Data
 
-open Std
+/-! Check intersection emptiness symmetry across map and set APIs, including Raw variants. -/
 
-/-! Check intersection emptiness symmetry across the public map and set APIs. -/
+open Std
 
 open scoped DHashMap in
 example [BEq α] [EquivBEq α] [Hashable α] [LawfulHashable α]
@@ -58,3 +60,39 @@ example {cmp : α → α → Ordering} [TransCmp cmp] {t₁ t₂ : TreeSet α cm
 example {cmp : α → α → Ordering} [TransCmp cmp] {t₁ t₂ : ExtTreeSet α cmp} :
     t₁ ∩ t₂ = ∅ ↔ t₂ ∩ t₁ = ∅ :=
   ExtTreeSet.inter_eq_empty_comm
+
+example [BEq α] [EquivBEq α] [Hashable α] [LawfulHashable α]
+    {m₁ m₂ : DHashMap.Raw α β} (h₁ : m₁.WF) (h₂ : m₂.WF) :
+    DHashMap.Raw.Equiv (DHashMap.Raw.inter m₁ m₂) (∅ : DHashMap.Raw α β) ↔
+      DHashMap.Raw.Equiv (DHashMap.Raw.inter m₂ m₁) (∅ : DHashMap.Raw α β) :=
+  DHashMap.Raw.inter_equiv_empty_comm h₁ h₂
+
+example [BEq α] [EquivBEq α] [Hashable α] [LawfulHashable α]
+    {m₁ m₂ : HashMap.Raw α β} (h₁ : m₁.WF) (h₂ : m₂.WF) :
+    HashMap.Raw.Equiv (HashMap.Raw.inter m₁ m₂) (∅ : HashMap.Raw α β) ↔
+      HashMap.Raw.Equiv (HashMap.Raw.inter m₂ m₁) (∅ : HashMap.Raw α β) :=
+  HashMap.Raw.inter_equiv_empty_comm h₁ h₂
+
+example [BEq α] [EquivBEq α] [Hashable α] [LawfulHashable α]
+    {m₁ m₂ : HashSet.Raw α} (h₁ : m₁.WF) (h₂ : m₂.WF) :
+    HashSet.Raw.Equiv (HashSet.Raw.inter m₁ m₂) (∅ : HashSet.Raw α) ↔
+      HashSet.Raw.Equiv (HashSet.Raw.inter m₂ m₁) (∅ : HashSet.Raw α) :=
+  HashSet.Raw.inter_equiv_empty_comm h₁ h₂
+
+example {cmp : α → α → Ordering} [TransCmp cmp]
+    {t₁ t₂ : DTreeMap.Raw α β cmp} (h₁ : t₁.WF) (h₂ : t₂.WF) :
+    DTreeMap.Raw.Equiv (DTreeMap.Raw.inter t₁ t₂) (∅ : DTreeMap.Raw α β cmp) ↔
+      DTreeMap.Raw.Equiv (DTreeMap.Raw.inter t₂ t₁) (∅ : DTreeMap.Raw α β cmp) :=
+  DTreeMap.Raw.inter_equiv_empty_comm h₁ h₂
+
+example {cmp : α → α → Ordering} [TransCmp cmp]
+    {t₁ t₂ : TreeMap.Raw α β cmp} (h₁ : t₁.WF) (h₂ : t₂.WF) :
+    TreeMap.Raw.Equiv (TreeMap.Raw.inter t₁ t₂) (∅ : TreeMap.Raw α β cmp) ↔
+      TreeMap.Raw.Equiv (TreeMap.Raw.inter t₂ t₁) (∅ : TreeMap.Raw α β cmp) :=
+  TreeMap.Raw.inter_equiv_empty_comm h₁ h₂
+
+example {cmp : α → α → Ordering} [TransCmp cmp]
+    {t₁ t₂ : TreeSet.Raw α cmp} (h₁ : t₁.WF) (h₂ : t₂.WF) :
+    TreeSet.Raw.Equiv (TreeSet.Raw.inter t₁ t₂) (∅ : TreeSet.Raw α cmp) ↔
+      TreeSet.Raw.Equiv (TreeSet.Raw.inter t₂ t₁) (∅ : TreeSet.Raw α cmp) :=
+  TreeSet.Raw.inter_equiv_empty_comm h₁ h₂


### PR DESCRIPTION
This PR adds `isEmpty_inter_comm` across the synchronized associative-container APIs, starting from associative lists and lifting the result through hash maps, tree maps, and sets. This makes it possible to prove symmetry of disjoint containers without unfolding membership.

This addresses the `disjoint_symm` suggestion in AeneasVerif/kraken#142. Suggested by @TwoFX.

AI assisted with the implementation on searching relevant tactics:)! I manually reviewed the changes and verified them and refactored the proof!