### PR TITLE
feat: add `let_to_have` tactic to `sym =>` mode

### DIFF
--- a/src/Init/Grind/Interactive.lean
+++ b/src/Init/Grind/Interactive.lean
@@ -402,6 +402,17 @@ Only available in `sym =>` mode.
 -/
 syntax (name := symLiftLets) "lift_lets" : grind
 
+/--
+`let_to_have` converts the nondependent `let` declarations of the goal target into
+`have` declarations. The new goal is definitionally equal to the original one.
+
+Unlike the standalone `let_to_have` tactic, this variant does not support the `at`
+location syntax: in `sym =>` mode hypotheses are never modified.
+
+Only available in `sym =>` mode.
+-/
+syntax (name := symLetToHave) "let_to_have" : grind
+
 @[inherit_doc Lean.Parser.Tactic.bvNormalize]
 syntax (name := bvNormalize) "bv_normalize" optConfig (bvTypes)? : grind
 

--- a/src/Lean/Elab/Tactic/Grind.lean
+++ b/src/Lean/Elab/Tactic/Grind.lean
@@ -20,6 +20,7 @@ public import Lean.Elab.Tactic.Grind.Rewrite
 public import Lean.Elab.Tactic.Grind.DSimp
 public import Lean.Elab.Tactic.Grind.Cbv
 public import Lean.Elab.Tactic.Grind.LiftLet
+public import Lean.Elab.Tactic.Grind.LetToHave
 public import Lean.Elab.Tactic.Grind.SimprocDSL
 public import Lean.Elab.Tactic.Grind.SimprocDSLBuiltin
 public import Lean.Elab.Tactic.Grind.RegisterSymSimp

--- a/src/Lean/Elab/Tactic/Grind/LetToHave.lean
+++ b/src/Lean/Elab/Tactic/Grind/LetToHave.lean
@@ -1,0 +1,24 @@
+/-
+Copyright (c) 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+module
+prelude
+import Lean.Elab.Tactic.Grind.Basic
+import Lean.Meta.Sym.LetToHave
+import Lean.Meta.Tactic.Replace
+namespace Lean.Elab.Tactic.Grind
+open Meta
+
+@[builtin_grind_tactic Parser.Tactic.Grind.symLetToHave] def evalSymLetToHave : GrindTactic := fun _ => withMainContext do
+  ensureSym
+  let goal ← getMainGoal
+  let target ← goal.mvarId.getType
+  let target' ← liftSymM <| Sym.letToHave target
+  if Sym.isSameExpr target target' then
+    throwError "`let_to_have` made no progress"
+  let mvarId ← goal.mvarId.replaceTargetDefEq target'
+  replaceMainGoal [{ goal with mvarId }]
+
+end Lean.Elab.Tactic.Grind

--- a/src/Lean/Meta/Sym.lean
+++ b/src/Lean/Meta/Sym.lean
@@ -17,6 +17,7 @@ public import Lean.Meta.Sym.IsClass
 public import Lean.Meta.Sym.Intro
 public import Lean.Meta.Sym.InstantiateMVarsS
 public import Lean.Meta.Sym.LiftLet
+public import Lean.Meta.Sym.LetToHave
 public import Lean.Meta.Sym.ProofInstInfo
 public import Lean.Meta.Sym.AbstractS
 public import Lean.Meta.Sym.Pattern

--- a/src/Lean/Meta/Sym/AlphaShareCommon.lean
+++ b/src/Lean/Meta/Sym/AlphaShareCommon.lean
@@ -25,7 +25,7 @@ private def alphaHash (e : Expr) : UInt64 :=
   | .bvar .. | .mvar .. | .const .. | .fvar .. | .sort .. | .lit .. =>
     hash e
   | .app f a => mixHash (hashChild f) (hashChild a)
-  | .letE _ _ v b _ => mixHash (hashChild v) (hashChild b)
+  | .letE _ _ v b nondep => mixHash (if nondep then 17 else 19) (mixHash (hashChild v) (hashChild b))
   | .forallE _ d b _ | .lam _ d b _ => mixHash (hashChild d) (hashChild b)
   | .mdata _ b => mixHash 13 (hashChild b)
   | .proj n i b => mixHash (mixHash (hash n) (hash i)) (hashChild b)
@@ -37,9 +37,9 @@ private def alphaEq (e₁ e₂ : Expr) : Bool := Id.run do
   | .app f₁ a₁ =>
     let .app f₂ a₂ := e₂ | false
     isSameExpr f₁ f₂ && isSameExpr a₁ a₂
-  | .letE _ _ v₁ b₁ _ =>
-    let .letE _ _ v₂ b₂ _ := e₂ | false
-    isSameExpr v₁ v₂ && isSameExpr b₁ b₂
+  | .letE _ _ v₁ b₁ nondep₁ =>
+    let .letE _ _ v₂ b₂ nondep₂ := e₂ | false
+    nondep₁ == nondep₂ && isSameExpr v₁ v₂ && isSameExpr b₁ b₂
   | .forallE _ d₁ b₁ _ =>
     let .forallE _ d₂ b₂ _ := e₂ | false
     isSameExpr d₁ d₂ && isSameExpr b₁ b₂

--- a/src/Lean/Meta/Sym/LetToHave.lean
+++ b/src/Lean/Meta/Sym/LetToHave.lean
@@ -1,0 +1,416 @@
+/-
+Copyright (c) 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+module
+prelude
+public import Lean.Meta.Sym.SymM
+import Lean.Meta.Sym.InferType
+import Lean.Meta.Sym.ReplaceS
+import Lean.Meta.Sym.AlphaShareBuilder
+namespace Lean.Meta.Sym
+open Lean.Meta.Sym.Internal
+
+/-!
+# `let`-to-`have` for `SymM`
+
+`Sym.letToHave` converts nondependent `let` declarations of a term into `have`
+declarations (i.e., sets the `nondep` flag of `.letE` nodes). The result is
+definitionally equal to the input, has exactly the same shape, and preserves maximal
+sharing: only the nodes on the path from the root to each converted `let` are rebuilt.
+
+A `let x := v; b` is nondependent if `b` typechecks with `x` opaque. As in
+`Meta.letToHave`, this is decided with the `withTrackingZetaDelta` technique: the body is
+checked with `x` declared as a zeta-expandable declaration, and `x` is nondependent iff
+no check needed to unfold it. Unlike `Meta.letToHave`, the traversal:
+
+- keeps bodies in bound-variable form — no `instantiate`/`abstract` round-trip per
+  binder, which makes the traversal near-linear on nested binders with open bodies
+  (`Meta.letToHave` is quadratic there);
+- discharges checking obligations only on subterms that can reach a candidate `let`:
+  subterms without loose bound variables, and subterms whose loose bound variables all
+  refer to "clean" binders, are skipped in O(1);
+- discharges each obligation via pointer equality (the usual case in the maximally
+  shared world), falling back to the tracked `Meta.isDefEq`.
+
+`instantiate` is used in exactly two places: to put a binder's type (and value, for a
+`let`) into free-variable form before adding the scratch declaration to the local
+context, and to put terms into free-variable form before `inferType`/`isDefEq` calls.
+
+Caching follows the two-tier discipline of `Sym.liftLets`: results and inferred types
+for terms with loose bound variables are cached per binder scope (the scoped caches are
+saved and reset when entering a binder body, and restored on exit — entries computed at
+an outer binder offset must be invisible inside), while results for closed terms are
+context-free and cached for the whole run; closed-term types go through the session
+`Sym.inferType` cache.
+
+Metavariables are opaque for the analysis (the whole run is under `withNewMCtxDepth`,
+so pre-existing metavariables are rigid for `isDefEq` and can never be assigned by an
+obligation), but a dependent `let` whose subtree contains one is conservatively kept:
+a future assignment could depend on the `let` variable's value. Metavariables outside
+a `let`'s subtree do not inhibit its conversion.
+-/
+
+namespace LetToHave
+
+structure Context where
+  /-- FVars for the enclosing binders: bvar `i` maps to `xs[xs.size - i - 1]`. -/
+  xs : PArray Expr := {}
+  /-- Number of candidate `let` declarations in scope. Obligations are discharged iff > 0. -/
+  numCandidates : Nat := 0
+  /--
+  Number of consecutive clean innermost binders. A binder is clean if it is not a
+  candidate and its type cannot reach a candidate. A subterm `e` with
+  `e.looseBVarRange ≤ cleanSuffix` only references clean binders, so type checking it
+  cannot unfold any candidate, and it can be skipped (given it has no `let` to convert).
+  -/
+  cleanSuffix : Nat := 0
+
+structure State where
+  /-- Scoped: transformation results for terms with loose bvars, per binder scope. -/
+  visited : Std.HashMap ExprPtr Expr := {}
+  /-- Scoped: types (in fvar form) for terms with loose bvars, per binder scope. -/
+  types : Std.HashMap ExprPtr Expr := {}
+  /-- Scoped: `substEnv` results, per binder scope. -/
+  subst : Std.HashMap ExprPtr Expr := {}
+  /-- Per-run: transformation results for closed terms. -/
+  visitedClosed : Std.HashMap ExprPtr Expr := {}
+  /-- Per-run: pointer-cached "contains a dependent `let`". -/
+  hasDepLetCache : Std.HashMap ExprPtr Bool := {}
+  /-- Number of converted `let` declarations. -/
+  numConverted : Nat := 0
+
+abbrev M := ReaderT Context (StateRefT State SymM)
+
+/--
+Runs `x` with fresh scoped caches, restoring the current ones afterwards. Used when
+entering a binder body: entries computed at the outer binder offset denote different
+terms inside and must be invisible there.
+-/
+@[inline] def withNewScope (x : M α) : M α := do
+  let (visited, types, subst) ← modifyGet fun s =>
+    ((s.visited, s.types, s.subst), { s with visited := {}, types := {}, subst := {} })
+  try x finally
+    modify fun s => { s with visited, types, subst }
+
+/-- Returns `true` if `e` contains a `.letE` with `nondep := false`. Pointer-cached per run. -/
+partial def hasDepLet (e : Expr) : M Bool := do
+  match e with
+  | .letE (nondep := false) .. => return true
+  | .letE _ t v b true => cached e do hasDepLet t <||> hasDepLet v <||> hasDepLet b
+  | .app f a => cached e do hasDepLet f <||> hasDepLet a
+  | .lam _ t b _ | .forallE _ t b _ => cached e do hasDepLet t <||> hasDepLet b
+  | .mdata _ b | .proj _ _ b => cached e do hasDepLet b
+  | _ => return false
+where
+  cached (e : Expr) (k : M Bool) : M Bool := do
+    if let some r := (← get).hasDepLetCache[{ expr := e : ExprPtr }]? then
+      return r
+    let r ← k
+    modify fun s => { s with hasDepLetCache := s.hasDepLetCache.insert { expr := e } r }
+    return r
+
+/--
+Substitutes the loose bound variables of `e` with the corresponding scratch fvars,
+producing a term in free-variable form. The result is maximally shared.
+
+Not `instantiateRevS`: the environment is a `PArray` (pushing per binder while enclosing
+frames hold their versions would make an `Array` copy on every push), and results are
+cached per binder scope, so repeated substitutions of a subterm across obligations in
+the same scope are one lookup. Same design as `LiftLet.substEnv`.
+-/
+def substEnv (e : Expr) : M Expr := do
+  if !e.hasLooseBVars then
+    return e
+  if let some r := (← get).subst[{ expr := e : ExprPtr }]? then
+    return r
+  let xs := (← read).xs
+  let n := xs.size
+  let r ← replaceS e fun sub offset => do
+    match sub with
+    | .bvar idx =>
+      if idx ≥ offset then
+        pure (some xs[n - (idx - offset) - 1]!)
+      else
+        pure (some sub)
+    | .lit _ | .mvar _ | .fvar _ | .const _ _ | .sort _ => pure (some sub)
+    | _ => if offset ≥ sub.looseBVarRange then pure (some sub) else pure none
+  modify fun s => { s with subst := s.subst.insert { expr := e } r }
+  return r
+
+/--
+Discharges the defeq obligation `t ≡ s` (both in fvar form): pointer equality, then the
+tracked `Meta.isDefEq`. The input term is type correct, so `isDefEq` succeeds and
+records which candidates had to be unfolded.
+-/
+def checkDefEq (t s : Expr) : M Unit := do
+  if isSameExpr t s then
+    return ()
+  unless (← Meta.isDefEq t s) do
+    throwError "`Sym.letToHave` failed, type error{indentExpr t}\nis not definitionally equal to{indentExpr s}"
+
+/-- Ensures `type` (in fvar form) is a `.forallE`, using tracked `whnf` if needed. -/
+def ensureForall (type : Expr) : M Expr := do
+  if type.isForall then
+    return type
+  let type ← whnf type
+  unless type.isForall do
+    throwError "`Sym.letToHave` failed, function expected{indentExpr type}"
+  shareCommon type
+
+/--
+Returns `true` if type checking `e` cannot create an obligation that reaches a
+candidate: `e` is closed, or all its loose bound variables refer to clean binders.
+-/
+@[inline] def isClean (e : Expr) (ctx : Context) : Bool :=
+  e.looseBVarRange ≤ ctx.cleanSuffix
+
+mutual
+
+/--
+Main traversal: converts the `let`s of `e` and discharges the checking obligations of
+the enclosing candidates. `e` is in bound-variable form w.r.t. the enclosing binders.
+-/
+partial def visit (e : Expr) : M Expr := do
+  match e with
+  | .bvar .. | .fvar .. | .mvar .. | .sort .. | .const .. | .lit .. => return e
+  | _ =>
+    let ctx ← read
+    if ctx.numCandidates == 0 || isClean e ctx then
+      -- No obligation can arise from this subterm; visit only if there is a `let` to convert.
+      unless (← hasDepLet e) do
+        return e
+    if !e.hasLooseBVars then
+      visitClosed e
+    else
+      if let some r := (← get).visited[{ expr := e : ExprPtr }]? then
+        return r
+      let r ← visitCore e
+      modify fun s => { s with visited := s.visited.insert { expr := e } r }
+      return r
+
+/--
+Visits a closed term. The result does not depend on the environment: obligations inside
+cannot reach any enclosing candidate, and its own candidates are self-contained. Cached
+for the whole run.
+-/
+partial def visitClosed (e : Expr) : M Expr := do
+  if let some r := (← get).visitedClosed[{ expr := e : ExprPtr }]? then
+    return r
+  let r ← withReader (fun _ => { xs := {}, numCandidates := 0, cleanSuffix := 0 }) do
+    withNewScope do visitCore e
+  modify fun s => { s with visitedClosed := s.visitedClosed.insert { expr := e } r }
+  return r
+
+partial def visitCore (e : Expr) : M Expr := do
+  match e with
+  | .app f a =>
+    let r ← e.updateAppS! (← visit f) (← visit a)
+    if (← read).numCandidates > 0 then
+      checkApp f a
+    return r
+  | .mdata _ b => e.updateMDataS! (← visit b)
+  | .proj _ _ b =>
+    let r ← e.updateProjS! (← visit b)
+    let ctx ← read
+    if ctx.numCandidates > 0 && !isClean b ctx then
+      -- The struct type may need tracked `whnf` to expose the structure.
+      discard <| inferTypeFallback e
+    return r
+  | .lam n t b _ =>
+    let t' ← visit t
+    let tf ← substEnv t'
+    checkDomain t tf
+    withBinder n tf none (tainted := !isClean t (← read)) (isCandidate := false) fun _ => do
+      e.updateLambdaS! t' (← visit b)
+  | .forallE .. => visitForall e
+  | .letE n t v b nondep =>
+    let t' ← visit t
+    let v' ← visit v
+    let tf ← substEnv t'
+    let ctx ← read
+    if ctx.numCandidates > 0 then
+      checkDomain t tf
+      if !isClean t ctx || !isClean v ctx then
+        -- The value's type must match the annotation without unfolding candidates.
+        if v.isLambda then
+          checkFun v tf
+        else
+          checkDefEq (← inferTypeO v) tf
+    let vf ← substEnv v'
+    -- Conservative: a dependent `let` whose subtree contains a metavariable is not a
+    -- candidate — a future assignment could depend on its value (cf. `Meta.letToHave`,
+    -- which keeps such `let`s based on the metavariable's local context; that
+    -- information is not available in bound-variable form). It is still added as a
+    -- zeta-expandable declaration and treated as tainted: its value can leak enclosing
+    -- candidates during checks.
+    let isDep := !nondep
+    let isCandidate := isDep && !e.hasExprMVar
+    withBinder n tf (some (vf, nondep)) (tainted := isDep || !isClean t ctx) isCandidate fun x => do
+      let b' ← visit b
+      let nondep' ←
+        if nondep then pure true
+        else if !isCandidate then pure false
+        else if (← getZetaDeltaFVarIds).contains x.fvarId! then pure false
+        else do
+          modify fun s => { s with numConverted := s.numConverted + 1 }
+          pure true
+      if nondep' == nondep then
+        e.updateLetS! t' v' b'
+      else
+        mkLetS n t' v' b' nondep'
+  | _ => unreachable!
+
+/--
+Visits a `∀`-telescope. Sort obligations: one tracked `getLevel` per non-clean domain,
+and one for the terminal body. Processing the chain in one pass keeps the terminal-body
+obligation linear in the telescope length.
+-/
+partial def visitForall (e : Expr) : M Expr := do
+  match e with
+  | .forallE n t b _ =>
+    let t' ← visit t
+    let tf ← substEnv t'
+    checkDomain t tf
+    withBinder n tf none (tainted := !isClean t (← read)) (isCandidate := false) fun _ => do
+      e.updateForallS! t' (← visitForall b)
+  | _ =>
+    let r ← visit e
+    let ctx ← read
+    if ctx.numCandidates > 0 && !isClean e ctx then
+      discard <| Meta.getLevel (← substEnv r)
+    return r
+
+/--
+Sort obligation for a binder domain: `tf` (the domain in fvar form) must be a type.
+Skipped when the domain cannot reach a candidate.
+-/
+partial def checkDomain (t tf : Expr) : M Unit := do
+  let ctx ← read
+  if ctx.numCandidates > 0 && !isClean t ctx then
+    discard <| Meta.getLevel tf
+
+/--
+Adds the scratch declaration for a binder, installs the extended local context, and runs
+`k` with the extended environment and fresh scoped caches, so every `Meta` operation in
+the binder scope sees the scratch declarations. `value?` provides the (fvar-form) value
+and `nondep` flag for `let`/`have` binders.
+-/
+partial def withBinder (n : Name) (type : Expr) (value? : Option (Expr × Bool))
+    (tainted : Bool) (isCandidate : Bool) (k : Expr → M α) : M α := do
+  let fvarId ← mkFreshFVarId
+  let x ← mkFVarS fvarId
+  let lctx ← getLCtx
+  let lctx := match value? with
+    | some (v, nondep) => lctx.mkLetDecl fvarId n type v nondep
+    | none => lctx.mkLocalDecl fvarId n type
+  withLCtx lctx {} do
+    withReader (fun ctx => { ctx with
+        xs := ctx.xs.push x
+        numCandidates := ctx.numCandidates + (if isCandidate then 1 else 0)
+        cleanSuffix := if tainted then 0 else ctx.cleanSuffix + 1 }) do
+      withNewScope do k x
+
+/--
+Obligation for the application node `f a`: the type of `a` must match the domain of the
+type of `f` without unfolding candidates. When `a` is a lambda, the comparison is
+decomposed binder-wise (`checkFun`) so that the lambda's type is never materialized.
+-/
+partial def checkApp (f a : Expr) : M Unit := do
+  let fnType ← ensureForall (← inferTypeO f)
+  let .forallE _ d _ _ := fnType | unreachable!
+  if !a.hasLooseBVars && !d.hasFVar then
+    -- Neither side can reach a candidate.
+    return ()
+  if a.isLambda then
+    checkFun a d
+  else
+    checkDefEq (← inferTypeO a) d
+
+/--
+Checks that the lambda `e` (in bvar form) has type `expected` (in fvar form) without
+materializing the lambda's type: domains are compared pairwise, and at the leaf the
+body's type is compared with the codomain.
+-/
+partial def checkFun (e : Expr) (expected : Expr) : M Unit := do
+  match e with
+  | .lam n t b _ =>
+    let expected ← ensureForall expected
+    let .forallE _ d body _ := expected | unreachable!
+    let tf ← substEnv t
+    checkDefEq tf d
+    withBinder n tf none (tainted := !isClean t (← read)) (isCandidate := false) fun x => do
+      let body ← if body.hasLooseBVars then share (body.instantiate1 x) else pure body
+      checkFun b body
+  | _ => checkDefEq (← inferTypeO e) expected
+
+/--
+Returns the type (in fvar form, maximally shared) of `e` (in bvar form). Pure
+inference: obligations are discharged by `visit`, not here. Closed terms go through the
+session `Sym.inferType` cache; open terms are cached per binder scope.
+-/
+partial def inferTypeO (e : Expr) : M Expr := do
+  if !e.hasLooseBVars then
+    Sym.inferType e
+  else
+    if let some type := (← get).types[{ expr := e : ExprPtr }]? then
+      return type
+    let type ← match e with
+      | .bvar idx =>
+        let xs := (← read).xs
+        let x := xs[xs.size - idx - 1]!
+        pure ((← getLCtx).getFVar! x).type
+      | .mdata _ b => inferTypeO b
+      | .app f a =>
+        let fnType ← ensureForall (← inferTypeO f)
+        let .forallE _ _ body _ := fnType | unreachable!
+        if body.hasLooseBVars then
+          share (body.instantiate1 (← substEnv a))
+        else
+          pure body
+      | _ => inferTypeFallback e
+    modify fun s => { s with types := s.types.insert { expr := e } type }
+    return type
+
+/--
+Fallback type inference for open terms with binder or projection heads: substitutes the
+scratch fvars and calls `Meta.inferType` (tracked, without the `MetaM` infer-type cache).
+-/
+partial def inferTypeFallback (e : Expr) : M Expr := do
+  let ef ← substEnv e
+  let type ← withTheReader Meta.Context (fun ctx => { ctx with cacheInferType := false }) do
+    Meta.inferType ef
+  -- Not needed for correctness: it keeps the invariant that all cached types are
+  -- maximally shared, so `checkDefEq`'s pointer-equality fast path can fire on them.
+  shareCommon type
+
+end
+
+end LetToHave
+
+open LetToHave in
+/--
+Converts the nondependent `let` declarations of `e` into `have` declarations. The
+result is definitionally equal to `e`, has the same shape (only `nondep` flags change),
+and is maximally shared. If nothing is converted, the result is pointer-equal to `e`
+(check with `isSameExpr`).
+
+Assumptions: `e` is maximally shared, has no loose bound variables, and is type
+correct. Metavariables are treated as opaque values.
+-/
+public def letToHave (e : Expr) : SymM Expr := do
+  if e.hasLooseBVars then
+    throwError "`Sym.letToHave` internal error, input term has loose bound variables"
+  -- The `withConfig` step is the (monad-generic) equivalent of `withInferTypeConfig`.
+  -- `withNewMCtxDepth` makes pre-existing metavariables rigid: obligations cannot assign them.
+  withoutExporting <| withNewMCtxDepth <| withTrackingZetaDelta <| withTransparency TransparencyMode.all <|
+    withConfig (fun cfg => { cfg with
+      beta := true, iota := true, zeta := true, zetaHave := true, zetaDelta := true
+      proj := .yesWithDelta, etaStruct := .all }) do
+    withLCtx (← getLCtx) {} do
+      let x : M Expr := do
+        if (← hasDepLet e) then visit e else return e
+      x.run {} |>.run' {}
+
+end Lean.Meta.Sym

--- a/tests/elab/letToHaveStress.lean
+++ b/tests/elab/letToHaveStress.lean
@@ -1,0 +1,74 @@
+import Lean
+/-!
+# Stress tests for `letToHave` verdicts
+
+Families that are sensitive to the design of the `sym =>` mode `let_to_have`
+(see `sym_let_to_have_perf.md`): dependence discovered only through a
+whnf-to-sort obligation, dependence through instance defeq, and clean closures
+that must not create dependence. The verdicts documented here must be
+reproduced by `Sym.letToHave`.
+-/
+
+set_option pp.letVarTypes true
+
+open Lean Elab Command in
+/--
+`#let_to_have t` elaborates `t` then applies let-to-have. It typechecks `t` before and after.
+-/
+elab "#let_to_have " t:term : command => runTermElabM fun _ => do
+  let e ← Term.elabTermAndSynthesize t none
+  Meta.check e
+  let e' ← Meta.letToHave e
+  Meta.check e'
+  unless ← Meta.isDefEq e e' do
+    throwError "result is not definitionally equal"
+  if e == e' then
+    logInfo m!"no change"
+  else
+    logInfo m!"{e'}"
+
+set_option linter.unusedVariables false
+
+/-!
+Dependence discovered only through a whnf-to-sort obligation: the domain `G x` has type
+`H x`, which is a sort only after zeta-unfolding `x`. The `let` must be kept.
+-/
+def H : Bool → Type 1 := fun b => match b with | true => Type | false => Type
+axiom G : (b : Bool) → H b
+
+/-- info: no change -/
+#guard_msgs in #let_to_have let x := true; fun (y : G x) => True
+
+/-!
+Dependence through instance defeq: elaborating `(1 : α)` uses `instOfNatNat`, which
+requires `α ≡ Nat` by zeta-unfolding. The `let` must be kept.
+-/
+/-- info: no change -/
+#guard_msgs in #let_to_have let α := Nat; ((1, 2) : α × α).1
+
+/-!
+A clean closure under the `let`: the lambda's binder type does not involve `x`, so the
+closure body cannot create a dependence. Must become a `have`.
+-/
+/--
+info: have x : Nat := 10;
+List.foldl (fun a b => a + b) x [1, 2]
+-/
+#guard_msgs in #let_to_have let x := 10; List.foldl (fun a b => a + b) x [1, 2]
+
+/-!
+Projection whose structure type is closed: no dependence. Must become a `have`.
+-/
+/--
+info: have x : Nat × Nat := (1, 2);
+x.fst
+-/
+#guard_msgs in #let_to_have let x := (1, 2); x.1
+
+/-!
+Note for the future `Sym.letToHave` test: add the pointer-sharing family — the same
+shared open `.letE` under two enclosing binders of different types, where the verdicts
+differ per context (e.g. `let w := b; (rfl : w = b)` is nondependent for `b : Unit`
+via eta, dependent for `b : Nat`). Not expressible here: elaborated terms are not
+hash-consed.
+-/

--- a/tests/elab/sym_letToHave.lean
+++ b/tests/elab/sym_letToHave.lean
@@ -1,0 +1,152 @@
+module
+
+import Lean
+
+/-!
+Tests for `Lean.Meta.Sym.letToHave`: converting nondependent `let` declarations of a
+maximally shared term into `have` declarations inside a `SymM` session. The harness
+re-flags every `let`/`have` of an elaborated value as a dependent `let` first, so the
+transformation has to rediscover the nondependent ones. Covers the verdict families of
+`tests/elab/letToHaveStress.lean` (sort-obligation dependence, instance-defeq
+dependence, clean closures), `let`s under binders, lambda arguments (`checkFun`), and
+pointer-equal results when no progress is made.
+-/
+
+open Lean Meta Sym
+
+axiom S : Type
+axiom c : S
+axiom f : S → S → S
+axiom g : S → S
+axiom hof : (S → S) → S
+
+set_option linter.unusedVariables false
+
+/-- Recursively re-flags every `let`/`have` as a dependent `let`. -/
+partial def resetHaves (e : Expr) : Expr :=
+  match e with
+  | .letE n t v b _ => .letE n (resetHaves t) (resetHaves v) (resetHaves b) false
+  | .app fn a => .app (resetHaves fn) (resetHaves a)
+  | .lam n t b bi => .lam n (resetHaves t) (resetHaves b) bi
+  | .forallE n t b bi => .forallE n (resetHaves t) (resetHaves b) bi
+  | .mdata d b => .mdata d (resetHaves b)
+  | .proj s i b => .proj s i (resetHaves b)
+  | _ => e
+
+/--
+Re-flags all `let`s of the value of `declName` as dependent, runs `Sym.letToHave`,
+checks the result is defeq and type correct, and prints it.
+-/
+def checkL2H (declName : Name) : MetaM Unit := do
+  let some info := (← getEnv).find? declName | throwError "unknown declaration {declName}"
+  let e := resetHaves info.value!
+  SymM.run do
+    let e ← shareCommon e
+    let r ← Sym.letToHave e
+    unless ← isDefEq e r do
+      throwError "`Sym.letToHave` result is not defeq to the input{indentExpr r}"
+    check r
+    logInfo m!"{r}"
+
+/-- Like `checkL2H`, but expects `letToHave` to make no progress (pointer-equal result). -/
+def checkNoProgress (declName : Name) : MetaM Unit := do
+  let some info := (← getEnv).find? declName | throwError "unknown declaration {declName}"
+  let e := resetHaves info.value!
+  SymM.run do
+    let e ← shareCommon e
+    let r ← Sym.letToHave e
+    unless isSameExpr e r do
+      throwError "expected pointer-equal result, got{indentExpr r}"
+    logInfo "no progress (pointer-equal)"
+
+/-! A chain of nondependent `let`s: all are converted. -/
+
+noncomputable def exChain : S := let a := c; let b := f a c; let d := f b c; d
+
+/--
+info: have a := c;
+have b := f a c;
+have d := f b c;
+d
+-/
+#guard_msgs in
+run_meta checkL2H ``exChain
+
+/-! Dependence in a `let` value: `x` must stay a `let`, `h` becomes a `have`. -/
+
+def exDepVal : Nat := let x : Nat := 1; let h : x = 1 := rfl; x
+
+/--
+info: let x := 1;
+have h := ⋯;
+x
+-/
+#guard_msgs in
+run_meta checkL2H ``exDepVal
+
+/-!
+Dependence discovered only through a whnf-to-sort obligation: the domain `G x` has type
+`H x`, which is a sort only after zeta-unfolding `x`. The `let` must be kept.
+-/
+
+def H : Bool → Type 1 := fun b => match b with | true => Type | false => Type
+axiom G : (b : Bool) → H b
+
+def exSort : Prop := let x := true; ∀ (_ : G x), True
+
+/-- info: no progress (pointer-equal) -/
+#guard_msgs in
+run_meta checkNoProgress ``exSort
+
+/-!
+Dependence through instance defeq: elaborating `(1 : α)` uses `instOfNatNat`, which
+requires `α ≡ Nat` by zeta-unfolding. The `let` must be kept.
+-/
+
+def exInst := let α := Nat; ((1, 2) : α × α).1
+
+/-- info: no progress (pointer-equal) -/
+#guard_msgs in
+run_meta checkNoProgress ``exInst
+
+/-! A clean closure under the `let`: the closure body cannot create a dependence. -/
+
+def exClosure : Nat := let x := 10; List.foldl (fun a b => a + b) x [1, 2]
+
+/--
+info: have x := 10;
+List.foldl (fun a b => a + b) x [1, 2]
+-/
+#guard_msgs in
+run_meta checkL2H ``exClosure
+
+/-! A nondependent `let` with loose bound variables (under a lambda). -/
+
+noncomputable def exUnder : S → S := fun y => let x := f y y; g x
+
+/--
+info: fun y =>
+  have x := f y y;
+  g x
+-/
+#guard_msgs in
+run_meta checkL2H ``exUnder
+
+/-! A lambda argument mentioning the `let` variable (`checkFun` path). -/
+
+noncomputable def exLamArg : S := let x := c; f (hof (fun y => f y x)) x
+
+/--
+info: have x := c;
+f (hof fun y => f y x) x
+-/
+#guard_msgs in
+run_meta checkL2H ``exLamArg
+
+/-! No `let`s at all: pointer-equal result. -/
+
+noncomputable def exNoLet : S := f c c
+
+/-- info: no progress (pointer-equal) -/
+#guard_msgs in
+run_meta checkNoProgress ``exNoLet

--- a/tests/elab/sym_letToHave_basic.lean
+++ b/tests/elab/sym_letToHave_basic.lean
@@ -1,0 +1,268 @@
+import Lean
+/-!
+# Tests of the `Sym.letToHave` transformation
+
+Port of `tests/elab/letToHave.lean` (the `Meta.letToHave` test suite) to the `sym`
+implementation. Differences from the original suite:
+- the `let_to_have at h`/`at *` tactic tests are not ported: in `sym =>` mode hypotheses
+  are never modified (tactic tests are in `sym_let_to_have_tactic.lean`);
+- there is no trace class, so the cache-reporting test only checks the output term;
+- a dependent `let` whose subtree contains a metavariable is conservatively kept, like
+  `Meta.letToHave`, but without its context-sensitive analysis (fvar identity is lost
+  in bound-variable form): the "metavariable in the value" cases stay `let`s here even
+  though `Meta.letToHave` converts them.
+-/
+
+set_option pp.letVarTypes true
+set_option pp.mvars.anonymous false
+
+open Lean Elab Command Meta Sym in
+/--
+`#sym_let_to_have t` elaborates `t`, hash-conses it, and applies `Sym.letToHave`.
+It typechecks the result and checks it is defeq to the input.
+-/
+elab "#sym_let_to_have " t:term : command => runTermElabM fun _ => do
+  let e ← Term.elabTermAndSynthesize t none
+  Meta.check e
+  SymM.run do
+    let e ← shareCommon e
+    let e' ← Sym.letToHave e
+    Meta.check e'
+    unless ← Meta.isDefEq e e' do
+      throwError "result is not definitionally equal"
+    if Sym.isSameExpr e e' then
+      logInfo m!"no change"
+    else
+      logInfo m!"{e'}"
+
+set_option linter.unusedVariables false
+
+/-!
+Very basic tests where there are no lets.
+-/
+/-- info: no change -/
+#guard_msgs in #sym_let_to_have true
+/-- info: no change -/
+#guard_msgs in #sym_let_to_have fun (x : Nat) => x + 1
+/-- info: no change -/
+#guard_msgs in #sym_let_to_have ∀ (x : Nat), x = x
+/-- info: no change -/
+#guard_msgs in #sym_let_to_have have x := 1; x + 1
+
+/-!
+Basic tests of nondependent `let`s.
+-/
+/--
+info: have x : Nat := 1;
+true
+-/
+#guard_msgs in #sym_let_to_have let x := 1; true
+/--
+info: have x : Nat := 1;
+x + 1
+-/
+#guard_msgs in #sym_let_to_have let x := 1; x + 1
+/--
+info: have x : Nat := 1;
+have x' : Nat := x;
+have x'' : Nat := x + x';
+have x''' : Nat := x + x' + x'';
+x + x' + x'' + x'''
+-/
+#guard_msgs in #sym_let_to_have
+  let x : Nat := 1; let x' := x; let x'' := x + x'; let x''' := x + x' + x''; x + x' + x'' + x'''
+/--
+info: fun x =>
+  have x' : Nat := x;
+  have x'' : Nat := x + x';
+  have x''' : Nat := x + x' + x'';
+  x + x' + x'' + x'''
+-/
+#guard_msgs in #sym_let_to_have
+  fun x : Nat => let x' := x; let x'' := x + x'; let x''' := x + x' + x''; x + x' + x'' + x'''
+/--
+info: (x : Nat) →
+  have x' : Nat := x;
+  have x'' : Nat := x + x';
+  have x''' : Nat := x + x' + x'';
+  Fin (x + x' + x'' + x''')
+-/
+#guard_msgs in #sym_let_to_have
+  ∀ x : Nat, let x' := x; let x'' := x + x'; let x''' := x + x' + x''; Fin (x + x' + x'' + x''')
+
+/-!
+Hash-consing: the two occurrences are the same node and are converted together.
+-/
+/--
+info: (have x : Nat := 1;
+  x + 1) +
+  have x : Nat := 1;
+  x + 1
+-/
+#guard_msgs in
+#sym_let_to_have (let x := 1; x + 1) + (let x := 1; x + 1)
+
+/-!
+Alpha-sharing ignores binder names, so the differently-named copies are also one node.
+-/
+/--
+info: (have x : Nat := 1;
+  x + 1) +
+  have x : Nat := 1;
+  x + 1
+-/
+#guard_msgs in
+#sym_let_to_have (let x := 1; x + 1) + (let y := 1; y + 1)
+
+/-!
+A subterm that first occurs outside any `let`, then needs a type under the `let`.
+-/
+/--
+info: 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 +
+  have y : Nat := 1;
+  1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + y
+-/
+#guard_msgs in
+#sym_let_to_have (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8) + (let y := 1; (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8) + y)
+
+/-!
+Dependence in a let value.
+-/
+/--
+info: let x : Nat := 1;
+have h : x = 1 := ⋯;
+x
+-/
+#guard_msgs in #sym_let_to_have let x := 1; let h : x = 1 := rfl; x
+
+/-!
+Dependence in a let type.
+-/
+/--
+info: let x : Nat := 1;
+have h : 0 = 0 := ⋯;
+x
+-/
+#guard_msgs in #sym_let_to_have let x := 1; let h : (0 : Fin x) = (0 : Fin x) := rfl; x
+
+/-!
+No dependence from the let type.
+-/
+/--
+info: have x : Nat := 1;
+have h : 0 = 0 := ⋯;
+x
+-/
+#guard_msgs in #sym_let_to_have let x := 1; let h : (0 : Fin (x + 1)) = (0 : Fin (x + 1)) := rfl; x
+/-!
+Another dependence in the let type.
+-/
+/--
+info: let x : Nat := 1;
+have h : 0 = 0 := ⋯;
+x
+-/
+#guard_msgs in #sym_let_to_have let x := 1; let h : (0 : Fin (x + 1)) = (0 : Fin (1 + 1)) := rfl; x
+
+/-!
+Dependence in a forall type
+-/
+/--
+info: let U : Type 1 := Type;
+have α : U := Nat;
+∀ (n : α), n = n
+-/
+#guard_msgs in #sym_let_to_have let U := Type; let α : U := Nat; ∀ (n : α), n = n
+
+/-!
+Dependence in a forall body
+-/
+/--
+info: let U : Type 1 := Type;
+have α : U := Nat;
+Bool → α
+-/
+#guard_msgs in #sym_let_to_have let U := Type; let α : U := Nat; Bool → α
+
+/-!
+Dependence in a lambda type
+-/
+/--
+info: let U : Type 1 := Type;
+have α : U := Nat;
+fun n => n
+-/
+#guard_msgs in #sym_let_to_have let U := Type; let α : U := Nat; fun (n : α) => n
+
+/-!
+Metavariable under binder, might be dependent, doesn't change (same as `Meta.letToHave`).
+-/
+/-- info: no change -/
+#guard_msgs in #sym_let_to_have let x := 1; ?m
+/-!
+`Meta.letToHave` converts here (the metavariable's context doesn't include `x`); the
+`sym` version cannot see metavariable contexts and conservatively keeps the `let`.
+-/
+/-- info: no change -/
+#guard_msgs in #sym_let_to_have let x := ?m; ?m
+/-!
+Same: `Meta.letToHave` keeps `x` but converts `y`; the `sym` version keeps both.
+-/
+/-- info: no change -/
+#guard_msgs in #sym_let_to_have let x := 1; let y := ?m; ?m
+
+/-!
+Test with a deep let expression.
+-/
+syntax "deepLets% " num term:arg term:arg : term
+macro_rules
+  | `(deepLets% 0 $b $e) => `(if $b then $e else 0)
+  | `(deepLets% $n $b $e) =>
+    let n' : Lean.Syntax.NumLit := Lean.quote (n.getNat - 1)
+    `(let b' : Bool := !$b; let x : Nat := 1*$e; deepLets% $n' b' x)
+/--
+info: fun a =>
+  have b' : Bool := !true;
+  have x : Nat := 1 * (0 + a);
+  have b' : Bool := !b';
+  have x : Nat := 1 * x;
+  have b' : Bool := !b';
+  have x : Nat := 1 * x;
+  have b' : Bool := !b';
+  have x : Nat := 1 * x;
+  have b' : Bool := !b';
+  have x : Nat := 1 * x;
+  if b' = true then x else 0
+-/
+#guard_msgs in #sym_let_to_have fun a => deepLets% 5 true (0 + a)
+
+/--
+info: fun a =>
+  have b' : Bool := !true;
+  have x : Nat := 1 * (0 + a);
+  have b' : Bool := !b';
+  have x : Nat := 1 * x;
+  have b' : Bool := !b';
+  have x : Nat := 1 * x;
+  have b' : Bool := !b';
+  have x : Nat := 1 * x;
+  have b' : Bool := !b';
+  have x : Nat := ⋯;
+  ⋯
+-/
+#guard_msgs in set_option pp.deepTerms.threshold 10 in #sym_let_to_have fun a => deepLets% 33 true (0 + a)
+/--
+info: fun a =>
+  have b' : Bool := !true;
+  have x : Nat := 1 * (0 + a);
+  have b' : Bool := !b';
+  have x : Nat := 1 * x;
+  have b' : Bool := !b';
+  have x : Nat := 1 * x;
+  have b' : Bool := !b';
+  have x : Nat := 1 * x;
+  have b' : Bool := !b';
+  have x : Nat := ⋯;
+  ⋯
+-/
+#guard_msgs in set_option pp.deepTerms.threshold 10 in #sym_let_to_have fun a => deepLets% 150 true (0 + a)

--- a/tests/elab/sym_let_to_have_tactic.lean
+++ b/tests/elab/sym_let_to_have_tactic.lean
@@ -1,0 +1,135 @@
+import Lean
+set_option warn.sorry false
+
+/-!
+Tests for the `let_to_have` tactic in `sym =>` mode. It converts the nondependent
+`let` declarations of the goal target into `have` declarations, fails when it makes no
+progress, and keeps genuinely dependent `let`s (see `tests/elab/sym_letToHave.lean` for
+the verdict families of the underlying `Sym.letToHave`).
+-/
+
+-- Converts the nondependent `let`: makes progress, no error.
+/--
+trace: case grind
+⊢ (have x := 10; x + 1) = 11
+-/
+#guard_msgs (whitespace := lax) in
+example : (let x := 10; x + 1) = 11 := by
+  sym => let_to_have; show_goals; sorry
+
+-- The target only has a `have`: no progress.
+/-- error: `let_to_have` made no progress -/
+#guard_msgs in
+example : (have x := 10; x + 1) = 11 := by
+  sym => let_to_have; sorry
+
+-- A genuinely dependent `let`: the domain `G x` has type `H x`, which is a sort only
+-- after zeta-unfolding `x`. The `let` is kept, so no progress.
+def H : Bool → Type 1 := fun b => match b with | true => Type | false => Type
+axiom G : (b : Bool) → H b
+
+/-- error: `let_to_have` made no progress -/
+#guard_msgs in
+example : (let x := true; ∀ (_ : G x), True) := by
+  sym => let_to_have; sorry
+
+/--
+trace: case grind
+⊢ (have x := 10; x + 1) = have x := 10; 1 + x
+-/
+#guard_msgs (whitespace := lax) in
+example : (let x : Nat := 10; x + 1) = (have x : Nat := 10; 1 + x) := by
+  sym => let_to_have; show_goals; finish
+
+-- A telescope: both `let`s are converted.
+/--
+trace: case grind
+⊢ (have a := 1; have b := a + 1; a + b) = 3
+-/
+#guard_msgs (whitespace := lax) in
+example : (let a := 1; let b := a + 1; a + b) = 3 := by
+  sym => let_to_have; show_goals; sorry
+
+-- Mixed verdicts in one target: `x` is dependent (the value of `h` needs `x ≡ 1`),
+-- `h` is not.
+set_option linter.unusedVariables false in
+/--
+trace: case grind
+⊢ (let x := 1; have h := ⋯; x + 1) = 2
+-/
+#guard_msgs (whitespace := lax) in
+example : (let x : Nat := 1; let h : x = 1 := rfl; x + 1) = 2 := by
+  sym => let_to_have; show_goals; sorry
+
+-- A lambda value mentioning the outer `let` variable (`checkFun` through the `let`
+-- annotation obligation).
+/--
+trace: case grind
+⊢ (have x := 5; have f := fun y => y + x; f 1) = 6
+-/
+#guard_msgs (whitespace := lax) in
+example : (let x := 5; let f := fun y => y + x; f 1) = 6 := by
+  sym => let_to_have; show_goals; sorry
+
+-- A closure argument mentioning the `let` variable (`checkFun` through `checkApp`).
+/--
+trace: case grind
+⊢ (have x := 5; List.foldl (fun a b => a + b + x) 0 [1]) = 6
+-/
+#guard_msgs (whitespace := lax) in
+example : (let x := 5; List.foldl (fun a b => a + b + x) 0 [1]) = 6 := by
+  sym => let_to_have; show_goals; sorry
+
+-- The `let` annotation is a type alias: `ensureForall` must use `whnf` to expose the
+-- expected function type in `checkFun`.
+def NatFun := Nat → Nat
+
+/--
+trace: case grind
+⊢ (have x := 5; have f := fun y => y + x; f 1) = 6
+-/
+#guard_msgs (whitespace := lax) in
+example : (let x := 5; let f : NatFun := fun y => y + x; f 1) = 6 := by
+  sym => let_to_have; show_goals; sorry
+
+-- A `∀`-telescope whose terminal body mentions the `let` variable (terminal `getLevel`
+-- obligation in `visitForall`).
+/--
+trace: case grind
+⊢ have b := true; ∀ (n : Nat), b = (n == n)
+-/
+#guard_msgs (whitespace := lax) in
+example : (let b := true; ∀ (n : Nat), b = (n == n)) := by
+  sym => let_to_have; show_goals; sorry
+
+-- A projection whose struct mentions the `let` variable (projection obligation).
+/--
+trace: case grind
+⊢ (have p := (1, 2); p.fst) = 1
+-/
+#guard_msgs (whitespace := lax) in
+example : (let p := (1, 2); p.1) = 1 := by
+  sym => let_to_have; show_goals; sorry
+
+-- The same closed `let` subterm on both sides: pointer-shared, visited once, both
+-- occurrences converted.
+/--
+trace: case grind
+⊢ (have x := 5; x + 1) = have x := 5; x + 1
+-/
+#guard_msgs (whitespace := lax) in
+example : (let x := 5; x + 1) = (let x := 5; x + 1) := by
+  sym => let_to_have; show_goals; finish
+
+-- Metavariables are opaque values: the `let` is converted even though the target
+-- contains `?y`, and `?y` is not assigned.
+/--
+trace: case grind
+⊢ (have x := 10; x + 1) = ?y
+-/
+#guard_msgs (whitespace := lax) in
+example : ∃ y, (let x := 10; x + 1) = y := by
+  refine ⟨?y, ?_⟩
+  rotate_left
+  sym => let_to_have; show_goals; sorry
+  exact 11

--- a/tests/elab_bench/let_to_have_chain.lean
+++ b/tests/elab_bench/let_to_have_chain.lean
@@ -1,0 +1,46 @@
+import Lean
+
+/-!
+Benchmark: `Meta.letToHave` on a plain `let` chain
+`P (let x₁ := c; let x₂ := f x₁ c; …; let xₙ := f xₙ₋₁ c; xₙ)`, all flagged dependent.
+
+All lets are actually nondependent, so the whole traversal runs in check mode
+(full typechecking). Near-linear: telescopes are entered in one pass.
+-/
+
+set_option maxHeartbeats 400000000
+
+axiom S : Type
+axiom P : S → Prop
+axiom f : S → S → S
+axiom c : S
+
+open Lean Meta
+
+/-- `P (let x₁ := c; let x₂ := f x₁ c; …; let xₙ := f xₙ₋₁ c; xₙ)` -/
+def mkChain (n : Nat) : Expr := Id.run do
+  let Sc : Expr := mkConst ``S
+  let fc : Expr := mkConst ``f
+  let cc : Expr := mkConst ``c
+  let mut e := Expr.bvar 0
+  for _ in [1:n] do
+    e := .letE `x Sc (mkApp2 fc (.bvar 0) cc) e false
+  return mkApp (mkConst ``P) (.letE `x Sc cc e false)
+
+def countHaves : Expr → Nat
+  | .letE _ _ _ b nondep => countHaves b + (if nondep then 1 else 0)
+  | .app f a => countHaves f + countHaves a
+  | _ => 0
+
+run_meta do
+  let bench := (← IO.getEnv "TEST_BENCH") == some "1"
+  let ns := if bench then [1000, 2000, 4000] else [20]
+  for n in ns do
+    let e := mkChain n
+    let t0 ← IO.monoNanosNow
+    let e' ← Meta.letToHave e
+    let t1 ← IO.monoNanosNow
+    if bench then
+      IO.println s!"chain n={n}: {(t1-t0).toFloat/1e6} ms"
+    unless countHaves e' == n do
+      throwError "expected {n} haves, got {countHaves e'}"

--- a/tests/elab_bench/let_to_have_closed_body.lean
+++ b/tests/elab_bench/let_to_have_closed_body.lean
@@ -1,0 +1,41 @@
+import Lean
+
+/-!
+Benchmark: the check-mode tax of `Meta.letToHave` — one dep-flagged `let` whose big body
+never mentions the `let` variable: `P (let x := c; f (f … (f c c) …) c)`.
+
+The body is closed, so it cannot create a dependence, yet the current implementation
+fully typechecks all of it (`canSkip` requires `approxDepth ≤ 2`). The `sym =>` mode
+implementation must skip it in O(1) (see `sym_let_to_have_perf.md`).
+-/
+
+set_option maxHeartbeats 400000000
+
+axiom S : Type
+axiom P : S → Prop
+axiom f : S → S → S
+axiom c : S
+
+open Lean Meta
+
+/-- `P (let x := c; f-application chain of length n, closed body not using x)` -/
+def mkBigBodyClosed (n : Nat) : Expr := Id.run do
+  let fc : Expr := mkConst ``f
+  let cc : Expr := mkConst ``c
+  let mut b := cc
+  for _ in [0:n] do
+    b := mkApp2 fc b cc
+  return mkApp (mkConst ``P) (.letE `x (mkConst ``S) cc b false)
+
+run_meta do
+  let bench := (← IO.getEnv "TEST_BENCH") == some "1"
+  let ns := if bench then [4000, 8000, 16000] else [20]
+  for n in ns do
+    let e := mkBigBodyClosed n
+    let t0 ← IO.monoNanosNow
+    let e' ← Meta.letToHave e
+    let t1 ← IO.monoNanosNow
+    if bench then
+      IO.println s!"closed_body n={n}: {(t1-t0).toFloat/1e6} ms"
+    unless e'.appArg!.isLet && e'.appArg!.letNondep! do
+      throwError "expected the let to become a have"

--- a/tests/elab_bench/let_to_have_nested.lean
+++ b/tests/elab_bench/let_to_have_nested.lean
@@ -1,0 +1,47 @@
+import Lean
+
+/-!
+Benchmark: `Meta.letToHave` in check mode on deeply *nested* (non-telescope) lambdas
+whose bodies all reference the outer `let` variable:
+`P (let x := c; f (q (fun y₁ => f (q (fun y₂ => …)) x)) x)`.
+
+Every lambda body is open, so `visitLambdaLet` pays one `instantiateRev` on entry and
+one `abstract` in `finalize` per binder level: O(n²). The `sym =>` mode implementation
+must be near-linear on this family (see `sym_let_to_have_perf.md`).
+-/
+
+set_option maxHeartbeats 400000000
+
+axiom S : Type
+axiom P : S → Prop
+axiom f : S → S → S
+axiom q : (S → S) → S
+axiom c : S
+
+open Lean Meta
+
+/-- `fun y => f (q (fun y => f (q …) x)) x` where `x` is the `let` variable:
+    at nesting depth `k` (under `k` lambdas + the let), `x` is bvar `k+1`.
+    Every level mentions `x`, so no subterm is closed. -/
+def nest (n : Nat) (depth : Nat) : Expr :=
+  match n with
+  | 0 => .lam `y (mkConst ``S) (mkApp2 (mkConst ``f) (.bvar 0) (.bvar (depth+1))) .default
+  | k+1 => .lam `y (mkConst ``S)
+      (mkApp2 (mkConst ``f) (mkApp (mkConst ``q) (nest k (depth+1))) (.bvar (depth+1))) .default
+
+def mkNested (n : Nat) : Expr :=
+  let body := mkApp2 (mkConst ``f) (mkApp (mkConst ``q) (nest n 0)) (.bvar 0)
+  mkApp (mkConst ``P) (.letE `x (mkConst ``S) (mkConst ``c) body false)
+
+run_meta do
+  let bench := (← IO.getEnv "TEST_BENCH") == some "1"
+  let ns := if bench then [500, 1000, 2000, 4000] else [20]
+  for n in ns do
+    let e := mkNested n
+    let t0 ← IO.monoNanosNow
+    let e' ← Meta.letToHave e
+    let t1 ← IO.monoNanosNow
+    if bench then
+      IO.println s!"nested n={n}: {(t1-t0).toFloat/1e6} ms"
+    unless e'.appArg!.isLet && e'.appArg!.letNondep! do
+      throwError "expected the let to become a have"

--- a/tests/elab_bench/sym_let_to_have_chain.lean
+++ b/tests/elab_bench/sym_let_to_have_chain.lean
@@ -1,0 +1,45 @@
+import Lean
+
+/-!
+Benchmark: `Sym.letToHave` on the `let`-chain family of `let_to_have_chain.lean`
+(`P (let x₁ := c; let x₂ := f x₁ c; …; let xₙ := f xₙ₋₁ c; xₙ)`, all flagged dependent).
+-/
+
+set_option maxHeartbeats 400000000
+
+axiom S : Type
+axiom P : S → Prop
+axiom f : S → S → S
+axiom c : S
+
+open Lean Meta Sym
+
+/-- See `let_to_have_chain.lean`. -/
+def mkChain (n : Nat) : Expr := Id.run do
+  let Sc : Expr := mkConst ``S
+  let fc : Expr := mkConst ``f
+  let cc : Expr := mkConst ``c
+  let mut e := Expr.bvar 0
+  for _ in [1:n] do
+    e := .letE `x Sc (mkApp2 fc (.bvar 0) cc) e false
+  return mkApp (mkConst ``P) (.letE `x Sc cc e false)
+
+def countHaves : Expr → Nat
+  | .letE _ _ _ b nondep => countHaves b + (if nondep then 1 else 0)
+  | .app f a => countHaves f + countHaves a
+  | _ => 0
+
+run_meta do
+  let bench := (← IO.getEnv "TEST_BENCH") == some "1"
+  let ns := if bench then [1000, 2000, 4000, 8000] else [20]
+  for n in ns do
+    let e := mkChain n
+    SymM.run do
+      let e ← shareCommon e
+      let t0 ← IO.monoNanosNow
+      let e' ← Sym.letToHave e
+      let t1 ← IO.monoNanosNow
+      if bench then
+        IO.println s!"sym chain n={n}: {(t1-t0).toFloat/1e6} ms"
+      unless countHaves e' == n do
+        throwError "expected {n} haves, got {countHaves e'}"

--- a/tests/elab_bench/sym_let_to_have_closed_body.lean
+++ b/tests/elab_bench/sym_let_to_have_closed_body.lean
@@ -1,0 +1,43 @@
+import Lean
+
+/-!
+Benchmark: `Sym.letToHave` on the closed-body family of `let_to_have_closed_body.lean`
+(one dep-flagged `let` whose big body never mentions the `let` variable).
+
+`Meta.letToHave` fully typechecks the body (~1.2 µs/node); the `SymM` implementation
+skips the check entirely — the remaining linear cost is the pointer-cached `hasDepLet`
+scan (~0.2 µs/node).
+-/
+
+set_option maxHeartbeats 400000000
+
+axiom S : Type
+axiom P : S → Prop
+axiom f : S → S → S
+axiom c : S
+
+open Lean Meta Sym
+
+/-- See `let_to_have_closed_body.lean`. -/
+def mkBigBodyClosed (n : Nat) : Expr := Id.run do
+  let fc : Expr := mkConst ``f
+  let cc : Expr := mkConst ``c
+  let mut b := cc
+  for _ in [0:n] do
+    b := mkApp2 fc b cc
+  return mkApp (mkConst ``P) (.letE `x (mkConst ``S) cc b false)
+
+run_meta do
+  let bench := (← IO.getEnv "TEST_BENCH") == some "1"
+  let ns := if bench then [16000, 64000, 256000] else [20]
+  for n in ns do
+    let e := mkBigBodyClosed n
+    SymM.run do
+      let e ← shareCommon e
+      let t0 ← IO.monoNanosNow
+      let e' ← Sym.letToHave e
+      let t1 ← IO.monoNanosNow
+      if bench then
+        IO.println s!"sym closed_body n={n}: {(t1-t0).toFloat/1e6} ms"
+      unless e'.appArg!.isLet && e'.appArg!.letNondep! do
+        throwError "expected the let to become a have"

--- a/tests/elab_bench/sym_let_to_have_nested.lean
+++ b/tests/elab_bench/sym_let_to_have_nested.lean
@@ -1,0 +1,45 @@
+import Lean
+
+/-!
+Benchmark: `Sym.letToHave` on the nested-open-lambda family of
+`let_to_have_nested.lean` (every lambda body references the outer `let` variable).
+
+`Meta.letToHave` is O(n²) on this family (per-binder instantiate/abstract); the `SymM`
+implementation keeps bodies in bound-variable form and is near-linear.
+-/
+
+set_option maxHeartbeats 400000000
+
+axiom S : Type
+axiom P : S → Prop
+axiom f : S → S → S
+axiom q : (S → S) → S
+axiom c : S
+
+open Lean Meta Sym
+
+/-- See `let_to_have_nested.lean`. -/
+def nest (n : Nat) (depth : Nat) : Expr :=
+  match n with
+  | 0 => .lam `y (mkConst ``S) (mkApp2 (mkConst ``f) (.bvar 0) (.bvar (depth+1))) .default
+  | k+1 => .lam `y (mkConst ``S)
+      (mkApp2 (mkConst ``f) (mkApp (mkConst ``q) (nest k (depth+1))) (.bvar (depth+1))) .default
+
+def mkNested (n : Nat) : Expr :=
+  let body := mkApp2 (mkConst ``f) (mkApp (mkConst ``q) (nest n 0)) (.bvar 0)
+  mkApp (mkConst ``P) (.letE `x (mkConst ``S) (mkConst ``c) body false)
+
+run_meta do
+  let bench := (← IO.getEnv "TEST_BENCH") == some "1"
+  let ns := if bench then [500, 1000, 2000, 4000, 8000] else [20]
+  for n in ns do
+    let e := mkNested n
+    SymM.run do
+      let e ← shareCommon e
+      let t0 ← IO.monoNanosNow
+      let e' ← Sym.letToHave e
+      let t1 ← IO.monoNanosNow
+      if bench then
+        IO.println s!"sym nested n={n}: {(t1-t0).toFloat/1e6} ms"
+      unless e'.appArg!.isLet && e'.appArg!.letNondep! do
+        throwError "expected the let to become a have"


### PR DESCRIPTION
This PR implements a `let_to_have` tactic to the interactive `sym =>` mode. It converts the nondependent `let` declarations of the goal target into `have` declarations, producing a definitionally equal goal. This unblocks the efficient `have`-telescope machinery of `Sym.simp` (`simpLet`), which does not process dependent `let`s.

The tactic uses a new `Sym.letToHave` procedure designed for maximally shared terms. Like `Meta.letToHave`, it decides dependence with the `withTrackingZetaDelta` technique: a `let x := v; b` is converted iff no type-checking obligation of `b` needs to zeta-unfold `x`. Unlike `Meta.letToHave`, the traversal keeps bodies in de Bruijn form, so there is no `instantiate`/`abstract` round-trip per binder, and it only discharges obligations on subterms that can reach a candidate `let`: subterms without loose bound variables, and subterms whose loose bound variables all refer to clean binders, are skipped in O(1) using the cached `looseBVarRange`.
Inferred types and results are cached per binder scope (entries computed at an outer binder offset must be invisible inside a binder), with a run-wide tier for closed subterms that goes through the session `Sym.inferType` cache. The result preserves maximal sharing: only the `nondep` flags change, and only the nodes on the path to each converted `let` are rebuilt.

This makes the transformation near-linear on shapes where `Meta.letToHave` is quadratic, and removes the full type-checking pass over closed subterms:

| Benchmark | `Meta.letToHave` (ms) | `Sym.letToHave` (ms) |
|-----------|----------------------:|---------------------:| 
| `nested` n=2000 (open lambda bodies) | 722 | 4.0 | 
| `nested` n=4000 | 3079 | 8.2 |
| `closed_body` n=16000 | 17.1 | 3.6 |
| `chain` n=4000 | 8.2 | 7.2 |

The `nested` family (every lambda body references the enclosing `let` variable) exhibits the O(n²) behavior of `Meta.letToHave` caused by the per-binder `instantiateRev`/`abstract`; the `Sym` implementation is linear on it. On `closed_body`, the remaining linear cost is the pointer-cached "contains a dependent `let`" scan; the type-checking tax is gone.

The PR also changes `alphaEq`/`alphaHash` in `AlphaShareCommon.lean` to include the `nondep` flag of `.letE` nodes in the alpha-sharing identity. Previously `let x := v; b` and `have x := v; b` with pointer-equal components were identified as the same node, so the first-interned flag won for the whole session: flag flips were silently undone by hash-consing, and consumers that branch on the flag (`simpLet`, `toBetaApp`) depended on internalization order when both variants occurred. The identification was sound for definitional equality, but the flag is operationally meaningful, so it must be part of the identity.

Metavariables are handled conservatively: the analysis runs under `withNewMCtxDepth`, so obligations can never assign pre-existing metavariables, and a dependent `let` whose subtree contains a metavariable is kept as a `let` (a future assignment could depend on its value). Metavariables outside a `let`'s subtree do not inhibit its conversion. This is slightly more conservative than `Meta.letToHave`, whose metavariable-context analysis is not available in bound-variable form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
