### PR TITLE
fix: make the kernel `is_prop` check require a sort

### DIFF
--- a/src/kernel/type_checker.cpp
+++ b/src/kernel/type_checker.cpp
@@ -344,11 +344,11 @@ expr type_checker::ensure_pi(expr const & e, expr const & s) {
 
 /** \brief Return true iff \c e is a proposition */
 bool type_checker::is_prop(expr const & e) {
-    expr s = whnf(infer_type(e));
+    expr s = ensure_sort(infer_type(e));
     // The level must be tested for zero up to normalization: `imax 1 0` denotes `Prop` without
     // being syntactically `zero`. Comparing `s` against `Prop` syntactically instead would let
     // `infer_proj` extract non-proof data out of a proof, contradicting proof irrelevance.
-    return is_sort(s) && normalizes_to_zero(sort_level(s));
+    return normalizes_to_zero(sort_level(s));
 }
 
 /** \brief Apply normalizer extensions to \c e.

--- a/tests/elab/kernel_is_prop_ensure_sort.lean
+++ b/tests/elab/kernel_is_prop_ensure_sort.lean
@@ -1,0 +1,99 @@
+import Lean
+
+open Lean
+
+set_option Elab.async false
+set_option maxHeartbeats 1000000
+set_option maxRecDepth 10000
+
+namespace PR14806Subst
+
+def step (x : Bool) (n : Nat) (ih : (m : Nat) → m < n → Bool) : Bool :=
+  match n with
+  | 0 => x
+  | k + 1 => ih k (Nat.lt_succ_self k)
+
+def run (x : Bool) (n : Nat) (h : Acc (· < ·) n) : Bool :=
+  Acc.rec (fun m _ => step x m) h
+
+opaque seed : Acc (· < ·) 1 := Nat.lt_wfRel.wf.apply 1
+def a := run false 1 seed
+def b := run false 1 (Acc.intro 1 fun _ => Acc.inv seed)
+def c := run false 0 (Acc.inv seed (Nat.lt_succ_self 0))
+
+theorem run_eq (x : Bool) (n : Nat) (h : Acc (· < ·) n) : run x n h = x := by
+  induction h with
+  | intro n smaller ih =>
+    cases n with
+    | zero => rfl
+    | succ n => simpa only [run, step] using ih n (Nat.lt_succ_self n)
+
+def P : Prop := a = b
+def Q : Prop := a = c
+def R : Prop := a = a
+
+opaque witness : Q := (run_eq false _ _).trans (run_eq false _ _).symm
+
+def gate (h : P) : Type :=
+  Eq.rec (motive := fun _ _ => Type) Prop h
+
+theorem observedProofsFalse (T : Prop) (observe : T → Bool) (p q : T)
+    (onFalse : observe p = false) (onTrue : observe q = true) : False := by
+  have same : p = q := proof_irrel p q
+  exact Bool.noConfusion (onFalse.symm.trans ((congrArg observe same).trans onTrue))
+
+private def checked (env : Environment) (decl : Declaration) : CoreM Environment := do
+  match env.addDeclCore 0 10000 decl none with
+  | .ok next => return next
+  | .error _ => throwError "kernel error"
+
+private def define (env : Environment) (name : Name) (type value : Expr) : CoreM Environment :=
+  checked env (.defnDecl {
+    name := name, levelParams := [], type := type, value := value,
+    hints := .abbrev, safety := .safe })
+
+end PR14806Subst
+
+/-- error: kernel error -/
+#guard_msgs in
+run_meta do
+  let mut env ← getEnv
+  let owner := `PR14806Subst.Owner
+  let p := mkConst ``PR14806Subst.P
+  let bool := mkConst ``Bool
+  let gate := mkConst ``PR14806Subst.gate
+  let ownerType := mkForall `h .default p (mkApp gate (.bvar 0))
+  let ctorType := mkForall `h .default p <|
+    mkForall `bit .default bool (mkApp (mkConst owner) (.bvar 1))
+  env ← PR14806Subst.checked env (.inductDecl [] 1 [{
+    name := owner, type := ownerType,
+    ctors := [{name := .str owner "mk", type := ctorType}]
+  }] false)
+  let some (.recInfo ri) := env.toKernelEnv.find? (mkRecName owner)
+    | throwError "missing owner recursor"
+  unless ri.levelParams.isEmpty do throwError "owner unexpectedly permits large elimination"
+
+  env ← PR14806Subst.define env `PR14806Subst.asProp
+    (mkForall `h .default p (mkSort 0))
+    (mkLambda `h .default p (mkApp (mkConst owner) (.bvar 0)))
+  let witness := mkConst ``PR14806Subst.witness
+  let carrier := mkApp (mkConst `PR14806Subst.asProp) witness
+  env ← PR14806Subst.define env `PR14806Subst.proposition (mkSort 0) carrier
+  let prop := mkConst `PR14806Subst.proposition
+  env ← PR14806Subst.define env `PR14806Subst.observe
+    (mkForall `proof .default prop bool)
+    (mkLambda `proof .default prop (mkProj owner 0 (.bvar 0)))
+  let ctor := mkApp (mkConst (.str owner "mk")) witness
+  let falseBit := mkConst ``Bool.false
+  let trueBit := mkConst ``Bool.true
+  env ← PR14806Subst.define env `PR14806Subst.falseProof prop (mkApp ctor falseBit)
+  env ← PR14806Subst.define env `PR14806Subst.trueProof prop (mkApp ctor trueBit)
+  let refl (bit : Expr) := mkApp2 (mkConst ``Eq.refl [Level.one]) bool bit
+  env ← PR14806Subst.checked env (.thmDecl {
+    name := `kernel_soundness_target, levelParams := [], type := mkConst ``False,
+    value := mkAppN (mkConst ``PR14806Subst.observedProofsFalse)
+      #[prop, mkConst `PR14806Subst.observe,
+        mkConst `PR14806Subst.falseProof, mkConst `PR14806Subst.trueProof,
+        refl falseBit, refl trueBit] })
+  setEnv env
+  logInfo m!"CHECKED PR14806 SUBSTITUTION FALSE; axioms={(← collectAxioms `kernel_soundness_target)}"


### PR DESCRIPTION
This PR fixes a soundness issue.

**TL;DR.** The kernel's `is_prop` decided whether a term is a proposition by taking the weak head normal form of its inferred type and checking that the result is syntactically `Sort 0`. When the inferred type did not reduce to a sort but was left as a stuck term, `is_prop` returned `false` instead of treating the term as ill-formed. This let the proof-irrelevance guard in projection inference be skipped, so a non-proof field could be projected out of a value used as a `Prop`, and `False` derived. The fix computes the inferred type with `ensure_sort`, which reduces it and requires the result to be a sort, raising `(kernel) type expected` otherwise. The bogus proof was also accepted by nanoda, an independent implementation of the Lean kernel. We believe the lean4lean external kernel does not have this bug.

When a field is projected out of a value whose type is a proposition, the kernel requires the field's type to also be a proposition. This is what keeps proof irrelevance sound: any two proofs of the same proposition are definitionally equal, so if a projection could read a piece of data (something not itself a proof) out of a proof, that data would be forced to be equal for all proofs, which is false in general. The guard is expressed in terms of `is_prop`.

`is_prop e` computed `whnf (infer_type e)` and returned whether the result is a sort whose level normalizes to zero. The problem is the case where `infer_type e` is a stuck term that does not reduce to a sort, for example an `Eq.rec` whose major premise is a free variable. There `whnf` returns the stuck term, `is_sort` is `false`, and `is_prop` returns `false`. Returning `false` means "not a proposition", which skips the projection guard even when the value is being used as a `Prop` elsewhere. With the guard skipped, a data field can be projected out of that value, and combined with proof irrelevance this yields `False`.

The fix replaces `whnf` with `ensure_sort`: `is_prop` now reduces the inferred type and requires it to be a sort, raising `(kernel) type expected` if it is not. A value whose type does not reduce to a sort is ill-formed, so rejecting it is correct. On well-typed terms the type of a type is always a genuine sort, so the stricter check never fires spuriously.

The issue was reported by Daniel Selsam (OpenAI) using their internal models. 

The bogus proof was also accepted by nanoda, an independent implementation of the Lean kernel.

We claim that lean4lean, another implementation of the Lean kernel, does **not** have this bug, since their `isProp` already uses `ensureSortCore` (See https://github.com/digama0/lean4lean/blob/master/Lean4Lean/TypeChecker.lean#L224-L230).
