### PR TITLE
perf: unfold `binderNameHint` eagerly in the kernel

### DIFF
--- a/src/Init/BinderNameHint.lean
+++ b/src/Init/BinderNameHint.lean
@@ -43,10 +43,8 @@ It is ineffective in other positions (hypotheses of rewrite rules) or when used 
 (e.g. `apply`).
 -/
 /- `abbrev` for the sake of the kernel: the `.abbrev` reducibility hints make the kernel's lazy
-delta unfold the marker before the payload's definitions, so the cast a consumed hint leaves
-behind compares payloads by pointer. The `attribute` line restores the `[implicit_reducible]`
-transparency that `abbrev` raises to `[reducible]`, so tactics keep treating the marker as
-opaque. -/
+delta unfold the marker eagerly before checking arguments.
+The `attribute` line restores the `[implicit_reducible]` transparency that `abbrev` raises to `[reducible]`, so tactics keep treating the marker as opaque. -/
 abbrev binderNameHint {α : Sort u} {β : Sort v} {γ : Sort w} (v : α) (binder : β) (e : γ) : γ := e
 
 /- One might expect/hope that this was `implicit_reducible` rather than `instance_reducible`.

--- a/src/Init/BinderNameHint.lean
+++ b/src/Init/BinderNameHint.lean
@@ -48,8 +48,6 @@ delta unfold the marker eagerly before checking arguments. The `attribute` line 
 treating the marker as opaque. -/
 abbrev binderNameHint {α : Sort u} {β : Sort v} {γ : Sort w} (v : α) (binder : β) (e : γ) : γ := e
 
-/- One might expect/hope that this was `implicit_reducible` rather than `instance_reducible`.
-Currently, the test `tests/elab/binderNameHintSimp.lean` fails (in a stage 2 build) if we make this change. -/
 set_option allowUnsafeReducibility true in
 attribute [implicit_reducible] binderNameHint
 

--- a/src/Init/BinderNameHint.lean
+++ b/src/Init/BinderNameHint.lean
@@ -42,8 +42,6 @@ This gadget is supported by
 It is ineffective in other positions (hypotheses of rewrite rules) or when used by other tactics
 (e.g. `apply`).
 -/
-/- One might expect/hope that this was `implicit_reducible` rather than `instance_reducible`.
-Currently, the test `tests/elab/binderNameHintSimp.lean` fails (in a stage 2 build) if we make this change. -/
 /- `abbrev` for the sake of the kernel: the `.abbrev` reducibility hints make the kernel's lazy
 delta unfold the marker before the payload's definitions, so the cast a consumed hint leaves
 behind compares payloads by pointer. The `attribute` line restores the `[implicit_reducible]`
@@ -51,6 +49,8 @@ transparency that `abbrev` raises to `[reducible]`, so tactics keep treating the
 opaque. -/
 abbrev binderNameHint {α : Sort u} {β : Sort v} {γ : Sort w} (v : α) (binder : β) (e : γ) : γ := e
 
+/- One might expect/hope that this was `implicit_reducible` rather than `instance_reducible`.
+Currently, the test `tests/elab/binderNameHintSimp.lean` fails (in a stage 2 build) if we make this change. -/
 set_option allowUnsafeReducibility true in
 attribute [implicit_reducible] binderNameHint
 

--- a/src/Init/BinderNameHint.lean
+++ b/src/Init/BinderNameHint.lean
@@ -44,5 +44,16 @@ It is ineffective in other positions (hypotheses of rewrite rules) or when used 
 -/
 /- One might expect/hope that this was `implicit_reducible` rather than `instance_reducible`.
 Currently, the test `tests/elab/binderNameHintSimp.lean` fails (in a stage 2 build) if we make this change. -/
-@[simp ↓, expose, implicit_reducible]
-def binderNameHint {α : Sort u} {β : Sort v} {γ : Sort w} (v : α) (binder : β) (e : γ) : γ := e
+/- `abbrev` for the sake of the kernel: the `.abbrev` reducibility hints make the kernel's lazy
+delta unfold the marker before the payload's definitions, so the cast a consumed hint leaves
+behind compares payloads by pointer. The `attribute` line restores the `[implicit_reducible]`
+transparency that `abbrev` raises to `[reducible]`, so tactics keep treating the marker as
+opaque. -/
+abbrev binderNameHint {α : Sort u} {β : Sort v} {γ : Sort w} (v : α) (binder : β) (e : γ) : γ := e
+
+set_option allowUnsafeReducibility true in
+attribute [implicit_reducible] binderNameHint
+
+/- After the transparency reset, so the `simp` attribute registers the equation rewrite of a
+non-reducible definition rather than an unfold. -/
+attribute [simp ↓] binderNameHint

--- a/src/Init/BinderNameHint.lean
+++ b/src/Init/BinderNameHint.lean
@@ -43,8 +43,9 @@ It is ineffective in other positions (hypotheses of rewrite rules) or when used 
 (e.g. `apply`).
 -/
 /- `abbrev` for the sake of the kernel: the `.abbrev` reducibility hints make the kernel's lazy
-delta unfold the marker eagerly before checking arguments.
-The `attribute` line restores the `[implicit_reducible]` transparency that `abbrev` raises to `[reducible]`, so tactics keep treating the marker as opaque. -/
+delta unfold the marker eagerly before checking arguments. The `attribute` line restores the
+`[implicit_reducible]` transparency that `abbrev` raises to `[reducible]`, so tactics keep
+treating the marker as opaque. -/
 abbrev binderNameHint {α : Sort u} {β : Sort v} {γ : Sort w} (v : α) (binder : β) (e : γ) : γ := e
 
 /- One might expect/hope that this was `implicit_reducible` rather than `instance_reducible`.

--- a/tests/elab/binderNameHintDefEq.lean
+++ b/tests/elab/binderNameHintDefEq.lean
@@ -5,7 +5,12 @@ public section
 /-! `binderNameHint`'s `.abbrev` reducibility hints make a definitional comparison unfold the
 marker before its payload, so a marked type compares against its payload in constant time. A
 marker with regular reducibility hints (`myHint` below) unfolds after the payload, and the
-comparison walks the payload's whole reduction chain instead. -/
+comparison walks the payload's whole reduction chain instead.
+
+The examples observe the unfold ordering in the elaborator's definitional comparison, where
+resource limits detect it deterministically. The kernel orders its lazy delta by the same
+reducibility hints; the marker with regular hints cannot reach it, because elaboration fails
+first. -/
 
 def W : Nat → Prop
   | 0 => True

--- a/tests/elab/binderNameHintDefEq.lean
+++ b/tests/elab/binderNameHintDefEq.lean
@@ -1,3 +1,7 @@
+module
+
+public section
+
 /-! `binderNameHint`'s `.abbrev` reducibility hints make a definitional comparison unfold the
 marker before its payload, so a marked type compares against its payload in constant time. A
 marker with regular reducibility hints (`myHint` below) unfolds after the payload, and the
@@ -7,6 +11,7 @@ def W : Nat → Prop
   | 0 => True
   | n+1 => W n
 
+@[simp ↓, expose, implicit_reducible]
 def myHint {α : Sort u} {β : Sort v} {γ : Sort w} (_v : α) (_binder : β) (e : γ) : γ := e
 
 -- The marker unfolds first: constant time, within a small heartbeat budget.

--- a/tests/elab/binderNameHintDefEq.lean
+++ b/tests/elab/binderNameHintDefEq.lean
@@ -18,11 +18,12 @@ def myHint {α : Sort u} {β : Sort v} {γ : Sort w} (_v : α) (_binder : β) (e
 set_option maxHeartbeats 400 in
 example : binderNameHint 0 (fun n : Nat => n) (W 100000) = W 100000 := rfl
 
+-- A regular definition in marker position unfolds after the payload: the comparison reduces
+-- `W 100000` and exceeds the default recursion depth.
 /--
 error: maximum recursion depth has been reached
 use `set_option maxRecDepth <num>` to increase limit
 use `set_option diagnostics true` to get diagnostic information
 -/
 #guard_msgs in
-set_option maxHeartbeats 400 in
 example : myHint 0 (fun n : Nat => n) (W 100000) = W 100000 := rfl

--- a/tests/elab/binderNameHintDefEq.lean
+++ b/tests/elab/binderNameHintDefEq.lean
@@ -1,0 +1,23 @@
+/-! `binderNameHint`'s `.abbrev` reducibility hints make a definitional comparison unfold the
+marker before its payload, so a marked type compares against its payload in constant time. A
+marker with regular reducibility hints (`myHint` below) unfolds after the payload, and the
+comparison walks the payload's whole reduction chain instead. -/
+
+def W : Nat → Prop
+  | 0 => True
+  | n+1 => W n
+
+def myHint {α : Sort u} {β : Sort v} {γ : Sort w} (_v : α) (_binder : β) (e : γ) : γ := e
+
+-- The marker unfolds first: constant time, within a small heartbeat budget.
+set_option maxHeartbeats 400 in
+example : binderNameHint 0 (fun n : Nat => n) (W 100000) = W 100000 := rfl
+
+/--
+error: maximum recursion depth has been reached
+use `set_option maxRecDepth <num>` to increase limit
+use `set_option diagnostics true` to get diagnostic information
+-/
+#guard_msgs in
+set_option maxHeartbeats 400 in
+example : myHint 0 (fun n : Nat => n) (W 100000) = W 100000 := rfl

--- a/tests/elab/binderNameHintDefEq.lean
+++ b/tests/elab/binderNameHintDefEq.lean
@@ -7,10 +7,11 @@ marker before its payload, so a marked type compares against its payload in cons
 marker with regular reducibility hints (`myHint` below) unfolds after the payload, and the
 comparison walks the payload's whole reduction chain instead.
 
-The examples observe the unfold ordering in the elaborator's definitional comparison, where
-resource limits detect it deterministically. The kernel orders its lazy delta by the same
-reducibility hints; the marker with regular hints cannot reach it, because elaboration fails
-first. -/
+Both markers are `[implicit_reducible]`, so a reducible-transparency comparison treats either as
+opaque; at default transparency both may unfold, and the reducibility hints order the unfolding.
+The examples observe that ordering in the elaborator's definitional comparison, where resource
+limits detect it deterministically. The kernel orders its lazy delta by the same hints; the
+marker with regular hints cannot reach it, because elaboration fails first. -/
 
 def W : Nat → Prop
   | 0 => True

--- a/tests/elab/binderNameHintDefEq.lean
+++ b/tests/elab/binderNameHintDefEq.lean
@@ -2,16 +2,20 @@ module
 
 public section
 
-/-! `binderNameHint`'s `.abbrev` reducibility hints make a definitional comparison unfold the
-marker before its payload, so a marked type compares against its payload in constant time. A
-marker with regular reducibility hints (`myHint` below) unfolds after the payload, and the
-comparison walks the payload's whole reduction chain instead.
+/-! `binderNameHint` carries `.abbrev` reducibility hints so that definitional comparison unfolds
+it eagerly. Consider
 
-Both markers are `[implicit_reducible]`, so a reducible-transparency comparison treats either as
-opaque; at default transparency both may unfold, and the reducibility hints order the unfolding.
-The examples observe that ordering in the elaborator's definitional comparison, where resource
-limits detect it deterministically. The kernel orders its lazy delta by the same hints; the
-marker with regular hints cannot reach it, because elaboration fails first. -/
+    myHint 0 (fun n => n) (W 100000)  =?=  W 100000
+
+Here, `isDefEq` and the kernel both see a constant applied to arguments and must make a choice
+which constant to unfold first. For `ReducibilityHints.regular`, the choice is to unfold `W`
+because it has greater *height* than height 1 for `myHint`, and this problem recurs on the order
+of 100000 times. By contrast, for `.abbrev`, the gadget is chosen and the defeq succeeds in
+constant time.
+
+`myHint` below replicates `binderNameHint` with `.regular` hints: the comparison through it
+exceeds the recursion depth, while the one through `binderNameHint` succeeds within a small
+heartbeat budget. -/
 
 def W : Nat → Prop
   | 0 => True


### PR DESCRIPTION
This PR unfolds `binderNameHint` eagerly in the kernel. The definition becomes an `abbrev` and the `.abbrev` reducibility hint makes the kernel's lazy delta unfold the gadget earerly. Explicit `attribute` lines restore the `[implicit_reducible]` transparency and `simp ↓` attribute, so elaboration and tactics keep treating the gadget as before.

What problem does `.abbrev` fix? Consider
```lean
myHint 0 (fun n => n) (W 100000)  =?=  W 100000
```
Here, `isDefEq` and the kernel both see a constant applied to arguments and must make a choice which constant to unfold first. For `ReducibilityHint.regular`, the choice is to unfold `W` because it has greater *height* than height 1 for `myHint`. And then this problem recurs on the order of 100000 times. By contrast, for `.abbrev`, `myHint` is chosen and the defeq succeeds in constant time.

This caused quadratic kernel checking time (and space) in #14590 and likely would do so in other `binderNameHint`-heavy benchmarks.
