### PR TITLE
fix: make interactive `grind`/`sym` handle goals closed during initialization

### DIFF
--- a/src/Lean/Elab/Tactic/Grind/Basic.lean
+++ b/src/Lean/Elab/Tactic/Grind/Basic.lean
@@ -448,8 +448,13 @@ def GrindTacticM.runAtGoal (mvarId : MVarId) (params : Params) (k : GrindTacticM
         if sym then
           /- In sym mode, skip eager intros + by-contradiction. The user controls intro/internalize.
              Preprocess for maximal term sharing, required by Sym operations (introN, BackwardRule.apply, etc.). -/
-          let mvarId ← Sym.preprocessMVar goal.mvarId
-          pure [{ goal with mvarId }]
+          if goal.inconsistent || (← goal.mvarId.isAssigned) then
+            /- Hypothesis internalization closed the goal (e.g. an inconsistent local context).
+               `Sym.preprocessMVar` would overwrite the assignment with a fresh goal. -/
+            pure []
+          else
+            let mvarId ← Sym.preprocessMVar goal.mvarId
+            pure [{ goal with mvarId }]
         else
           let a : Action := Action.intros 0 >> Action.assertAll
           match (← a.run goal) with

--- a/src/Lean/Elab/Tactic/Grind/Main.lean
+++ b/src/Lean/Elab/Tactic/Grind/Main.lean
@@ -270,7 +270,10 @@ def grind
         replaceMainGoal []
       if let some seq := seq? then
         let (result, _) ← Grind.GrindTacticM.runAtGoal mvarId' params do
-          Grind.evalGrindTactic seq
+          -- Initialization can close the goal (e.g. an inconsistent local context);
+          -- run the tactic sequence only on a surviving goal.
+          unless (← Grind.getUnsolvedGoals).isEmpty do
+            Grind.evalGrindTactic seq
           -- **Note**: We are returning only the first goal that could not be solved.
           let goal? := if let goal :: _ := (← get).goals then some goal else none
           let result ← Grind.liftGrindM <| Grind.mkResult params goal?
@@ -362,7 +365,10 @@ private def elabGrindConfig' (config : TSyntax ``Lean.Parser.Tactic.optConfig) (
     let params ← mkGrindParams config only' params mvarId
     Grind.withProtectedMCtx config mvarId fun mvarId' => do
       let (result, _) ← Grind.GrindTacticM.runAtGoal mvarId' params (sym := true) do
-        Grind.evalGrindTactic seq
+        -- Initialization can close the goal (e.g. an inconsistent local context);
+        -- run the tactic sequence only on a surviving goal.
+        unless (← Grind.getUnsolvedGoals).isEmpty do
+          Grind.evalGrindTactic seq
         let goal? := if let goal :: _ := (← get).goals then some goal else none
         Grind.liftGrindM <| Grind.mkResult params goal?
       if result.hasFailed then

--- a/tests/elab/grind_interactive_init_closes_goal.lean
+++ b/tests/elab/grind_interactive_init_closes_goal.lean
@@ -1,0 +1,19 @@
+/-!
+Interactive `grind => seq` and `sym => seq` succeed when initialization already closes the
+goal, for example from an inconsistent local context. The tactic sequence is skipped in that
+case. Previously the sequence ran on an empty goal list and failed with "No goals to be
+solved"; in sym mode the preprocessing additionally overwrote the goal's proof with a fresh
+metavariable.
+-/
+
+example (h : false = true) : True := by
+  grind => finish
+
+example (h : false = true) : True := by
+  sym => exact True.intro
+
+example (h : False) : True := by
+  grind => finish
+
+example (h : False) : True := by
+  sym => exact True.intro

--- a/tests/elab/sym_rw.lean
+++ b/tests/elab/sym_rw.lean
@@ -170,5 +170,5 @@ example (a : Nat) (h : myP a) : myP a := by
 error: tactic is only available in `sym =>` mode
 -/
 #guard_msgs in
-example (a b : Nat) (h : a = b) (h' : myP b) : myP a := by
+example (a b : Nat) (h : a = b) : myP a := by
   grind => rw [h]


### PR DESCRIPTION
This PR makes `grind => seq` and `sym => seq` succeed when initialization already closes the goal, for example from an inconsistent local context. Previously the tactic sequence ran on an empty goal list and failed with `No goals to be solved`.

```lean
example (h : false = true) : True := by
  grind => finish   -- error: No goals to be solved

example (h : false = true) : True := by
  sym => exact True.intro   -- error: No goals to be solved
```

Initialization internalizes the hypotheses (`Config.revert := false` by default), so the hypothesis `h : false = true` lets `closeGoal` assign the goal before any tactic runs. The entry points in `Lean.Elab.Tactic.Grind.Main` now run the sequence only when a goal survives initialization, mirroring the existing "Goal was closed during initialization" handling in `grind?`. In sym mode, `GrindTacticM.runAtGoal` also no longer calls `Sym.preprocessMVar` on a closed goal; `preprocessMVar` assigns the metavariable unconditionally, which overwrote the `False.elim` proof with a fresh unproven goal and produced `proof contains unresolved internal metavariable ?grind`.

The last example in `tests/elab/sym_rw.lean` drops a hypothesis: congruence closure proved its goal during initialization, which now skips the sequence and masked the expected `rw`-outside-`sym` error.
