### PR TITLE
feat: conjunctive Hoare triple lemmas, and two `Std.WP` cleanups

### DIFF
--- a/src/Lean/Elab/Tactic/VCGen/LatticeOp.lean
+++ b/src/Lean/Elab/Tactic/VCGen/LatticeOp.lean
@@ -9,7 +9,6 @@ prelude
 public import Lean.Meta.Sym.Apply
 public import Std.Internal.Order.Heyting
 public import Lean.Elab.Tactic.VCGen.FrameProc
-import Std.Internal.Order.FrameClosure
 import Lean.Meta.Sym.Simp.Rewrite
 import Lean.Meta.AppBuilder
 import Lean.Meta.AbstractMVars

--- a/src/Std/Internal/Order/FrameClosure.lean
+++ b/src/Std/Internal/Order/FrameClosure.lean
@@ -115,14 +115,6 @@ theorem PredTrans.frameClosure_le (op : R → Pred → Pred) [∀ r, PreservesSu
 
 end
 
-/-- Frame a single state coordinate: from the function-order premise `(fun u => ⌜u = s⌝ ⊓ pre) ⊑ Q`
-conclude the point entailment `pre ⊑ Q s`. Instantiating the premise at `u := s` collapses
-`⌜s = s⌝ ⊓ pre` to `pre`. Iterating it over a state chain point-frames `pre ⊑ Q s₁ … sₙ` to the
-function-order goal `(fun u⃗ => ⌜u⃗ = s⃗⌝ ⊓ pre) ⊑ Q`. -/
-theorem le_apply_of_point_meet_le {σ : Type v} {β : Type w} [CompleteLattice β]
-    (s : σ) (pre : β) (Q : σ → β) (h : (fun u => ⌜u = s⌝ ⊓ pre) ⊑ Q) : pre ⊑ Q s :=
-  (CompleteLattice.ofProp_intro_r (s = s) pre (Q s)).mp (h s) rfl
-
 end Lean.Order
 
 end -- public section

--- a/src/Std/Internal/Order/Heyting.lean
+++ b/src/Std/Internal/Order/Heyting.lean
@@ -31,6 +31,11 @@ section Basic
 
 variable {α : Type u} [CompleteLattice α]
 
+/-- A complete lattice whose meets preserve suprema. The Heyting implication `⇨` is then a right
+adjoint, and `⊓` distributes over suprema of arbitrary families. The literature also calls such a
+lattice a frame. -/
+abbrev Heyting (α : Type u) [CompleteLattice α] : Prop := ∀ a : α, PreservesSup (meet a)
+
 /-- Heyting implication: the upper adjoint of the lattice meet. For `Prop` it is `→`. -/
 noncomputable def himp {α : Type u} [CompleteLattice α] (a b : α) : α :=
   PreservesSup.upperAdjoint (meet a) b
@@ -101,7 +106,7 @@ section Derived
 set_option linter.unusedSectionVars false
 
 variable {l : Type u} [CompleteLattice l] {P P' Q Q' R R' T : l} {φ φ₁ φ₂ : Prop}
-variable [∀ a : l, PreservesSup (meet a)]
+variable [Heyting l]
 
 /-! ### Connectives -/
 
@@ -197,7 +202,7 @@ end Derived
 
 /-- `⊤ ⊑ (P ⇨ Q)` iff `P ⊑ Q`. -/
 @[simp] theorem top_le_himp_iff {l : Type u} [CompleteLattice l]
-    [∀ a : l, PreservesSup (meet a)] (P Q : l) :
+    [Heyting l] (P Q : l) :
     ((⊤ : l) ⊑ P ⇨ Q) ↔ (P ⊑ Q) :=
   ⟨fun h => rel_trans
     (le_meet _ _ _ (le_top _) rel_refl)

--- a/src/Std/Internal/Order/OfProp.lean
+++ b/src/Std/Internal/Order/OfProp.lean
@@ -225,6 +225,14 @@ theorem ofProp_forall {β} {Φ : β → Prop} :
 
 end Lemmas
 
+/-- Frame a single state coordinate: from the function-order premise `(fun u => ⌜u = s⌝ ⊓ pre) ⊑ Q`
+conclude the point entailment `pre ⊑ Q s`. Instantiating the premise at `u := s` collapses
+`⌜s = s⌝ ⊓ pre` to `pre`. Iterating it over a state chain point-frames `pre ⊑ Q s₁ … sₙ` to the
+function-order goal `(fun u⃗ => ⌜u⃗ = s⃗⌝ ⊓ pre) ⊑ Q`. -/
+theorem le_apply_of_point_meet_le {σ : Type u} {β : Type v} [CompleteLattice β]
+    (s : σ) (pre : β) (Q : σ → β) (h : (fun u => ⌜u = s⌝ ⊓ pre) ⊑ Q) : pre ⊑ Q s :=
+  (CompleteLattice.ofProp_intro_r (s = s) pre (Q s)).mp (h s) rfl
+
 end Lean.Order
 
 end -- public section

--- a/src/Std/Internal/Order/PreservesSup.lean
+++ b/src/Std/Internal/Order/PreservesSup.lean
@@ -75,6 +75,61 @@ instance {σ : Type v} {β : σ → Type u} [∀ s, CompleteLattice (β s)]
     · rintro ⟨g, ⟨x, hx, rfl⟩, hgt⟩
       exact ⟨x t, ⟨x, hx, rfl⟩, by rw [← hgt, meet_apply]⟩
 
+section PProd
+
+variable {β : Type v} [CompleteLattice β]
+
+private theorem pprod_le {p q : α ×' β} (h₁ : p.1 ⊑ q.1) (h₂ : p.2 ⊑ q.2) : p ⊑ q := by
+  exact ⟨h₁, h₂⟩
+
+/-- `mk` of the componentwise meets is the meet on a product. -/
+theorem PProd.mk_meet (p q : α ×' β) : (⟨p.1 ⊓ q.1, p.2 ⊓ q.2⟩ : α ×' β) = p ⊓ q :=
+  PartialOrder.rel_antisymm
+    (le_meet _ _ _ (pprod_le (meet_le_left _ _) (meet_le_left _ _))
+      (pprod_le (meet_le_right _ _) (meet_le_right _ _)))
+    (pprod_le (le_meet _ _ _ (meet_le_left p q).1 (meet_le_right p q).1)
+      (le_meet _ _ _ (meet_le_left p q).2 (meet_le_right p q).2))
+
+/-- `mk` of the componentwise least upper bounds is the least upper bound on a product. -/
+theorem PProd.mk_sup (c : α ×' β → Prop) :
+    (⟨CompleteLattice.sup fun a => ∃ b, c ⟨a, b⟩,
+      CompleteLattice.sup fun b => ∃ a, c ⟨a, b⟩⟩ : α ×' β) = CompleteLattice.sup c :=
+  PartialOrder.rel_antisymm
+    (pprod_le (sup_le _ fun _ ⟨_, hc⟩ => (le_sup c hc).1)
+      (sup_le _ fun _ ⟨_, hc⟩ => (le_sup c hc).2))
+    (sup_le c fun y hy => pprod_le (le_sup _ ⟨y.2, hy⟩) (le_sup _ ⟨y.1, hy⟩))
+
+private theorem fst_meet (p q : α ×' β) : (p ⊓ q).1 = p.1 ⊓ q.1 := by rw [← PProd.mk_meet]
+private theorem snd_meet (p q : α ×' β) : (p ⊓ q).2 = p.2 ⊓ q.2 := by rw [← PProd.mk_meet]
+
+private theorem fst_sup (c : α ×' β → Prop) :
+    (CompleteLattice.sup c).1 = CompleteLattice.sup fun a => ∃ b, c ⟨a, b⟩ := by
+  rw [← PProd.mk_sup]
+
+private theorem snd_sup (c : α ×' β → Prop) :
+    (CompleteLattice.sup c).2 = CompleteLattice.sup fun b => ∃ a, c ⟨a, b⟩ := by
+  rw [← PProd.mk_sup]
+
+/-- A product lattice preserves suprema componentwise: meets, least upper bounds and the order all
+act on the two components separately. -/
+instance [∀ a : α, PreservesSup (meet a)] [∀ b : β, PreservesSup (meet b)] (p : α ×' β) :
+    PreservesSup (meet p) where
+  map_sup s := by
+    refine PartialOrder.rel_antisymm (pprod_le ?_ ?_)
+      (sup_le _ fun _ ⟨x, hx, hy⟩ => hy ▸ meet_mono PartialOrder.rel_refl (le_sup s hx))
+    · simp only [fst_meet, fst_sup]
+      rw [PreservesSup.map_sup (f := meet p.1)]
+      refine sup_le _ ?_
+      rintro _ ⟨a, ⟨b, hs⟩, rfl⟩
+      exact le_sup _ ⟨p.2 ⊓ b, ⟨a, b⟩, hs, PProd.mk_meet p ⟨a, b⟩⟩
+    · simp only [snd_meet, snd_sup]
+      rw [PreservesSup.map_sup (f := meet p.2)]
+      refine sup_le _ ?_
+      rintro _ ⟨b, ⟨a, hs⟩, rfl⟩
+      exact le_sup _ ⟨p.1 ⊓ a, ⟨a, b⟩, hs, PProd.mk_meet p ⟨a, b⟩⟩
+
+end PProd
+
 namespace PreservesSup
 
 /-- The upper adjoint of `f`: the join of all `x` with `f x ⊑ b`. For `f = (a ⊓ ·)` this is Heyting

--- a/src/Std/WP/ExceptPost.lean
+++ b/src/Std/WP/ExceptPost.lean
@@ -187,6 +187,64 @@ theorem EPost.Cons.mk_meet {eh : Type u} {et : Type v}
     (p ⊓ q).tail = p.tail ⊓ q.tail := by rw [← EPost.Cons.mk_meet]
 
 /-!
+## Supremum Preservation
+
+The Heyting arrow `⇨` of an exception postcondition lattice needs `PreservesSup (meet a)` for each
+`a`. `EPost.Nil` carries a single value. The lattice on `EPost.Cons eh et` is the one on `eh ×' et`
+read through the two projections, so `EPost.Cons` inherits the law from the product.
+-/
+
+/-- `EPost.Nil` carries a single value. -/
+instance : Subsingleton EPost.Nil where
+  allEq p q := by cases p; cases q; rfl
+
+instance (a : EPost.Nil) : PreservesSup (meet a) where
+  map_sup _ := Subsingleton.elim _ _
+
+section Cons
+
+variable {eh : Type u} {et : Type v} [CompleteLattice eh] [CompleteLattice et]
+
+/-- The order on `EPost.Cons eh et` is the order on `eh ×' et` read through the projections. -/
+private theorem EPost.Cons.le_iff (p q : EPost.Cons eh et) :
+    p ⊑ q ↔ (⟨p.head, p.tail⟩ : eh ×' et) ⊑ ⟨q.head, q.tail⟩ := Iff.rfl
+
+omit [CompleteLattice eh] [CompleteLattice et] in
+/-- Two `EPost.Cons` values with the same projections are equal. -/
+private theorem EPost.Cons.eq_of_toPProd_eq {p q : EPost.Cons eh et}
+    (h : (⟨p.head, p.tail⟩ : eh ×' et) = ⟨q.head, q.tail⟩) : p = q := by
+  cases p; cases q; cases h; rfl
+
+/-- The projections of a meet are the meet of the projections. -/
+private theorem EPost.Cons.toPProd_meet (p q : EPost.Cons eh et) :
+    (⟨(p ⊓ q).head, (p ⊓ q).tail⟩ : eh ×' et) = ⟨p.head, p.tail⟩ ⊓ ⟨q.head, q.tail⟩ := by
+  simp only [EPost.Cons.head_meet, EPost.Cons.tail_meet]
+  exact PProd.mk_meet ⟨p.head, p.tail⟩ ⟨q.head, q.tail⟩
+
+/-- The projections of a least upper bound are the least upper bound of the projections. -/
+private theorem EPost.Cons.toPProd_sup (c : EPost.Cons eh et → Prop) :
+    (⟨(CompleteLattice.sup c).head, (CompleteLattice.sup c).tail⟩ : eh ×' et)
+      = CompleteLattice.sup fun x => c ⟨x.1, x.2⟩ :=
+  is_sup_unique
+    (fun x => Iff.trans (CompleteLattice.sup_spec c ⟨x.1, x.2⟩)
+      ⟨fun h y hy => h ⟨y.1, y.2⟩ hy, fun h y hy => h ⟨y.head, y.tail⟩ hy⟩)
+    (CompleteLattice.sup_spec _)
+
+instance [∀ a : eh, PreservesSup (meet a)] [∀ a : et, PreservesSup (meet a)]
+    (a : EPost.Cons eh et) : PreservesSup (meet a) where
+  map_sup s := by
+    refine PartialOrder.rel_antisymm ?_
+      (sup_le _ fun _ ⟨x, hx, hy⟩ => hy ▸ meet_mono PartialOrder.rel_refl (le_sup s hx))
+    rw [EPost.Cons.le_iff, EPost.Cons.toPProd_meet, EPost.Cons.toPProd_sup,
+      EPost.Cons.toPProd_sup, PreservesSup.map_sup (f := meet (⟨a.head, a.tail⟩ : eh ×' et))]
+    refine sup_le _ ?_
+    rintro _ ⟨x, hx, rfl⟩
+    exact le_sup _ ⟨⟨x.1, x.2⟩, hx,
+      EPost.Cons.eq_of_toPProd_eq (EPost.Cons.toPProd_meet a ⟨x.1, x.2⟩).symm⟩
+
+end Cons
+
+/-!
 ## Notation
 
 - `EPost⟨e₁, e₂, ...⟩` builds an exception postcondition **type** (nested `EPost.Cons`).

--- a/src/Std/WP/Gadget/Assert.lean
+++ b/src/Std/WP/Gadget/Assert.lean
@@ -38,7 +38,7 @@ open Gadget
 the Heyting implication `as ⇨ post ⟨⟩`, ensuring the assertion holds and the postcondition
 follows from it. -/
 @[spec]
-theorem Spec.assertGadget (as : Pred) [∀ a : Pred, PreservesSup (meet a)] :
+theorem Spec.assertGadget (as : Pred) [Heyting Pred] :
   Triple (Gadget.assertGadget (m := m) as) (as ⊓ (as ⇨ post ⟨⟩)) post epost := by
   simpa [Gadget.assertGadget] using
     (Triple.pure (m := m) (pre := as ⊓ (as ⇨ post ⟨⟩)) (post := post) (epost := epost)

--- a/src/Std/WP/Monad/Basic.lean
+++ b/src/Std/WP/Monad/Basic.lean
@@ -71,14 +71,6 @@ theorem map_le_wp_map (f : α → β) (x : m α) :
   apply WP.wp_consequence
   intro a; exact pure_le_wp_pure (f a) post epost
 
-/-- Variant of `map_le_wp_map` with an explicit postcondition equality hypothesis. -/
-theorem map_le_wp_map' (f : α → β) (x : m α) :
-  ∀ post post' epost (_ : post = fun a => post' (f a)),
-    wp x post epost ⊑ wp (f <$> x) post' epost := by
-  intro post post' epost h
-  subst h
-  apply map_le_wp_map
-
 /-- Soundness of `Seq.seq`: sequencing `f <*> x` preserves the WP. -/
 theorem seq_le_wp_seq (f : m (α → β)) (x : m α) :
   ∀ post epost,

--- a/src/Std/WP/Triple.lean
+++ b/src/Std/WP/Triple.lean
@@ -7,6 +7,7 @@ module
 
 prelude
 public import Std.WP.Triple.Basic
+public import Std.WP.Triple.Conjunctive
 public import Std.WP.Triple.Monad
 public import Std.WP.Triple.SpecLemmas
 

--- a/src/Std/WP/Triple/Conjunctive.lean
+++ b/src/Std/WP/Triple/Conjunctive.lean
@@ -49,7 +49,7 @@ Let `h₁` establish a basic postcondition `post₁` for `x`, and let `h₂` est
 postcondition `post₂` under the assumption `post₁`. Then `mp h₁ h₂` establishes `post₂` for `x`.
 -/
 theorem mp {x : Prog} [WPConjunctive x]
-    [∀ a : Pred, PreservesSup (meet a)] [∀ a : EPred, PreservesSup (meet a)]
+    [Heyting Pred] [Heyting EPred]
     {pre₁ pre₂ : Pred} {post₁ post₂ : Value → Pred} {epost₁ epost₂ : EPred}
     (h₁ : Triple x pre₁ post₁ epost₁)
     (h₂ : Triple x pre₂ (post₁ ⇨ post₂) (epost₁ ⇨ epost₂)) :
@@ -65,7 +65,7 @@ with postcondition `post`, together with the specification `hgoal` deriving the 
 that holds after a successful run of `obs` already holds before it.
 -/
 theorem observe {Prog' : Type u'} {Value' : Type v'} [WP Prog' Value' Pred EPred]
-    [∀ a : Pred, PreservesSup (meet a)] [∀ a : EPred, PreservesSup (meet a)]
+    [Heyting Pred] [Heyting EPred]
     {obs : Prog} [WPConjunctive obs] {prog : Prog'}
     {pre : Pred} {post : Value → Pred} {epost : EPred}
     {post' : Value' → Pred} {epost' : EPred}

--- a/src/Std/WP/Triple/Conjunctive.lean
+++ b/src/Std/WP/Triple/Conjunctive.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Graf
+-/
+module
+
+prelude
+public import Std.WP.Triple.Basic
+public import Std.WP.Conjunctive
+@[expose] public section
+
+set_option linter.missingDocs true
+
+open Lean.Order
+
+/-!
+# Hoare triples for a conjunctive weakest precondition
+
+Two specifications for one program `x` combine into a single specification when `wp x` is
+conjunctive. `Triple.and` conjoins the two specifications. `Triple.mp` reads the second
+specification as an implication and discharges its antecedent with the first. `Triple.observe`
+runs a program `obs` for the sole purpose of learning a fact, then carries the fact into a
+specification for a second program `prog`.
+-/
+
+namespace Std.WP
+
+namespace Triple
+
+universe u u' v v' w w'
+variable {Prog : Type u} {Value : Type v} {Pred : Type w} {EPred : Type w'}
+  [Assertion Pred] [Assertion EPred] [WP Prog Value Pred EPred]
+
+/--
+Conjunction of two Hoare triple specifications for a program `x`. This theorem decomposes proofs:
+prove unrelated facts about `x` separately, then combine them here.
+-/
+theorem and {x : Prog} [WPConjunctive x] {pre₁ pre₂ : Pred} {post₁ post₂ : Value → Pred}
+    {epost₁ epost₂ : EPred}
+    (h₁ : Triple x pre₁ post₁ epost₁) (h₂ : Triple x pre₂ post₂ epost₂) :
+    Triple x (pre₁ ⊓ pre₂) (post₁ ⊓ post₂) (epost₁ ⊓ epost₂) :=
+  ⟨PartialOrder.rel_trans (meet_mono h₁.le_wp h₂.le_wp)
+    (WPConjunctive.wp_meet_wp_le post₁ post₂ epost₁ epost₂)⟩
+
+/--
+Modus ponens for two Hoare triple specifications of a program `x`. This theorem separates proofs.
+Let `h₁` establish a basic postcondition `post₁` for `x`, and let `h₂` establish the advanced
+postcondition `post₂` under the assumption `post₁`. Then `mp h₁ h₂` establishes `post₂` for `x`.
+-/
+theorem mp {x : Prog} [WPConjunctive x]
+    [∀ a : Pred, PreservesSup (meet a)] [∀ a : EPred, PreservesSup (meet a)]
+    {pre₁ pre₂ : Pred} {post₁ post₂ : Value → Pred} {epost₁ epost₂ : EPred}
+    (h₁ : Triple x pre₁ post₁ epost₁)
+    (h₂ : Triple x pre₂ (post₁ ⇨ post₂) (epost₁ ⇨ epost₂)) :
+    Triple x (pre₁ ⊓ pre₂) (post₁ ⊓ post₂) (epost₁ ⊓ epost₂) :=
+  ⟨PartialOrder.rel_trans (and h₁ h₂).le_wp
+    (WP.wp_consequence_econs x _ _ _ _ meet_himp_le_meet meet_himp_le_meet)⟩
+
+/--
+Observe a fact about the state by running the program `obs`, then carry the fact into the proof
+for the program `prog`. A specification for `prog` follows from the specification `h` for `obs`
+with postcondition `post`, together with the specification `hgoal` deriving the goal
+`wp prog post' epost'` from `post`. The premise `hp` restricts `obs` to observation: an assertion
+that holds after a successful run of `obs` already holds before it.
+-/
+theorem observe {Prog' : Type u'} {Value' : Type v'} [WP Prog' Value' Pred EPred]
+    [∀ a : Pred, PreservesSup (meet a)] [∀ a : EPred, PreservesSup (meet a)]
+    {obs : Prog} [WPConjunctive obs] {prog : Prog'}
+    {pre : Pred} {post : Value → Pred} {epost : EPred}
+    {post' : Value' → Pred} {epost' : EPred}
+    (hp : ∀ C : Pred, wp obs (fun _ => C) ⊥ ⊑ C)
+    (h : Triple obs pre post epost)
+    (hgoal : Triple obs pre (post ⇨ fun _ => wp prog post' epost') (epost ⇨ ⊥)) :
+    Triple prog pre post' epost' :=
+  ⟨PartialOrder.rel_trans (le_meet _ _ _ PartialOrder.rel_refl PartialOrder.rel_refl) <|
+    PartialOrder.rel_trans (mp h hgoal).le_wp <|
+      PartialOrder.rel_trans
+        (WP.wp_consequence_econs obs _ _ _ _ (meet_le_right _ _) (meet_le_right _ _))
+        (hp (wp prog post' epost'))⟩
+
+end Triple
+
+end Std.WP

--- a/src/Std/WP/Triple/SpecLemmas.lean
+++ b/src/Std/WP/Triple/SpecLemmas.lean
@@ -175,7 +175,11 @@ theorem Spec.liftWith_StateT
     (f : (∀{β}, StateT σ m β → m (β × σ)) → m α) (post : α → σ → Pred) :
     Triple (MonadControl.liftWith (m:=m) f : StateT σ m α)
       (fun s => wp (f (fun x => x.run s)) (fun a => post a s) epost) post epost :=
-  Triple.intro (by intro s; simp [WPMonad.wp_liftWith_StateT_apply_eq f]; apply WPMonad.map_le_wp_map'; ext; rfl)
+  Triple.intro (by
+    intro s
+    simp [WPMonad.wp_liftWith_StateT_apply_eq f]
+    exact WPMonad.map_le_wp_map (fun a => (a, s)) (f (fun x => x.run s))
+      (fun ⟨a, s⟩ => post a s) epost)
 
 
 @[spec]
@@ -191,7 +195,10 @@ theorem Spec.liftWith_ExceptT
     (f : (∀{β}, ExceptT ε m β → m (Except ε β)) → m α) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
     Triple (MonadControl.liftWith (m:=m) f : ExceptT ε m α)
       (wp (f (fun x => x.run)) post epost.tail) post epost :=
-  Triple.intro (by simp [WPMonad.wp_liftWith_ExceptT_apply_eq f]; apply WPMonad.map_le_wp_map'; ext; rfl)
+  Triple.intro (by
+    simp [WPMonad.wp_liftWith_ExceptT_apply_eq f]
+    exact WPMonad.map_le_wp_map Except.ok (f (fun x => x.run))
+      (epost.pushExcept post) epost.tail)
 
 
 @[spec]


### PR DESCRIPTION
This PR adds `Triple.and`, `Triple.mp` and `Triple.observe` to `Std.WP`. Each combines two Hoare triple specifications for one program into one.

The lemmas need `WPConjunctive`, so they apply to any program type with a `WP` interpretation. `mp` and `observe` use the implication `⇨`, so both assertion lattices need `Lean.Order.Heyting`. That is a new `abbrev` for `∀ a, PreservesSup (meet a)`, which instance search unfolds. Further commits supply the instances it needs, for `α ×' β` and for `EPost.Cons`.

Two cleanups follow. This PR removes `WPMonad.map_le_wp_map'` and moves `le_apply_of_point_meet_le` to `Std.Internal.Order.OfProp`.
