### PR TITLE
fix: reject non-propositions in `Sym.simp` theorem lists

### DIFF
--- a/src/Lean/Meta/Sym/Simp/Theorems.lean
+++ b/src/Lean/Meta/Sym/Simp/Theorems.lean
@@ -116,16 +116,16 @@ rewrite rule in `Sym.simp`. Handles:
 - `¬ p` — adapted to `p = False`
 - `p ↔ q` — adapted to `p = q`
 - `p` (proposition) — adapted to `p = True`
+
+Callers must ensure the theorem's type is a proposition; `type` may contain loose bound
+variables for the stripped quantifiers, so we cannot check it here.
 -/
 private def selectEqKey (type : Expr) : MetaM (Expr × Expr × EqAdaptation) := do
   match_expr type with
   | Eq _ lhs rhs => return (lhs, rhs, .eq)
   | Not p => return (p, mkConst ``False, .eqFalse)
   | Iff lhs rhs => return (lhs, rhs, .iff)
-  | _ =>
-    unless (← isProp type) do
-      throwError "cannot use as a simp theorem, conclusion is not a proposition{indentExpr type}"
-    return (type, mkConst ``True, .eqTrue)
+  | _ => return (type, mkConst ``True, .eqTrue)
 
 /--
 Wrap a proof expression according to the adaptation applied to its type.
@@ -171,7 +171,21 @@ private def mkRhsVarMask (numVars : Nat) (rhs : Expr) : Nat := Id.run do
       mask := mask ||| (1 <<< i)
   return mask
 
+/--
+Throws an error if `type` is not a proposition. `declName?` is the name of the candidate
+theorem, if it is a global declaration.
+-/
+private def ensurePropType (type : Expr) (declName? : Option Name := none) : MetaM Unit := do
+  unless (← isProp type) do
+    let decl := match declName? with
+      | some declName => m!" `{.ofConstName declName}`"
+      | none => m!""
+    throwError "cannot use{decl} as a simp theorem, its type is not a proposition{indentExpr type}"
+
+/-- Create a `Theorem` from a declaration. Handles equalities, `¬`, `↔`, and propositions. -/
 def mkTheoremFromDecl (declName : Name) : MetaM Theorem := do
+  let info ← getConstInfo declName
+  ensurePropType info.type declName
   let (pattern, (rhs, adaptation)) ← mkPatternFromDeclWithKey declName selectEqKey (zetaReduceLHSOnly := true)
   let expr ← wrapProof pattern (mkConst declName) adaptation
   let perm := isPerm pattern.varTypes.size pattern.pattern rhs
@@ -180,6 +194,7 @@ def mkTheoremFromDecl (declName : Name) : MetaM Theorem := do
 
 /-- Create a `Theorem` from a proof expression. Handles equalities, `¬`, `↔`, and propositions. -/
 def mkTheoremFromExpr (e : Expr) : MetaM Theorem := do
+  ensurePropType (← inferType e)
   let (pattern, (rhs, adaptation)) ← mkPatternFromExprWithKey e [] selectEqKey (zetaReduceLHSOnly := true)
   let expr ← wrapProof pattern e adaptation
   let perm := isPerm pattern.varTypes.size pattern.pattern rhs

--- a/tests/elab/sym_simp_non_prop.lean
+++ b/tests/elab/sym_simp_non_prop.lean
@@ -1,0 +1,35 @@
+import Lean
+/-!
+Tests that `Sym.simp` produces a proper error message (instead of the internal
+error `unexpected bound variable #3`) when a declaration or local hypothesis
+that is not a proposition is used as a simp theorem.
+-/
+
+/--
+error: cannot use `HAdd.hAdd` as a simp theorem, its type is not a proposition
+  {α : Type u} → {β : Type v} → {γ : outParam (Type w)} → [self : HAdd α β γ] → α → β → γ
+-/
+#guard_msgs in
+example : 1 + 1 = 2 := by
+  sym =>
+    simp [HAdd.hAdd]
+
+/--
+error: cannot use as a simp theorem, its type is not a proposition
+  Nat
+-/
+#guard_msgs in
+example (x : Nat) : x + 0 = x := by
+  sym =>
+    simp [x]
+
+def myDef : Prop := True
+
+/--
+error: cannot use `myDef` as a simp theorem, its type is not a proposition
+  Prop
+-/
+#guard_msgs in
+example : 1 + 1 = 2 := by
+  sym =>
+    simp [myDef]


### PR DESCRIPTION
This PR fixes an internal error (`unexpected bound variable #3`) when a declaration that is not a proposition is used as a `Sym.simp` theorem, as in `sym => simp [HAdd.hAdd]`. It now produces a proper error message.

The root cause was in `selectEqKey`: it received the conclusion of the candidate theorem after all leading binders had been stripped into loose bound variables, and its fallback `isProp` check invoked `inferType` on an open term. The fix moves the check to `mkTheoremFromDecl` and `mkTheoremFromExpr`. This also fixes the same crash for valid theorems whose conclusion is a bound `Prop` variable, such as `∀ (p : Prop), p → p`.
