### PR TITLE
feat: add a warning to transitive deprecations

### DIFF
--- a/src/Lean/Linter/Deprecated.lean
+++ b/src/Lean/Linter/Deprecated.lean
@@ -25,6 +25,12 @@ register_builtin_option linter.deprecated : Bool := {
   descr := "if true, generate deprecation warnings"
 }
 
+register_builtin_option linter.deprecated.deprecatedTarget : Bool := {
+  defValue := true
+  descr := "if true, warn when a `@[deprecated]` attribute points at a declaration that is \
+    itself deprecated"
+}
+
 structure DeprecationEntry where
   newName? : Option Name := none
   text? : Option String := none
@@ -44,7 +50,9 @@ private def areTypesReduciblyDefEq (decl₁ decl₂ : ConstantInfo) : MetaM Bool
   withReducible <| isDefEqGuarded type₁ type₂
 
 builtin_initialize deprecatedAttr : ParametricAttribute DeprecationEntry ←
-  registerParametricAttribute {
+  let ext ← registerParametricAttributeExt (α := DeprecationEntry) `Lean.Linter.deprecatedAttr
+    (preserveOrder := false)
+  registerParametricAttributeForExt (ext := ext) {
     name := `deprecated
     descr := "mark declaration as deprecated",
     getParam := fun declName stx => do
@@ -57,6 +65,20 @@ builtin_initialize deprecatedAttr : ParametricAttribute DeprecationEntry ←
         recordExtraModUseFromDecl (isMeta := false) newName
         if getLinterValue linter.deprecated (← getLinterOptions) then
           let env ← getEnv
+          if linter.deprecated.deprecatedTarget.get (← getOptions) then
+            let disableNote : MessageData := .note m!"This warning can be disabled with \
+              `set_option {linter.deprecated.deprecatedTarget.name} false`"
+            if let some entry := ParametricAttribute.getParamFromExt? ext (preserveOrder := false) env newName then
+              match entry.newName? with
+              | none =>
+                logWarning <| m!"`{.ofConstName newName true}` is itself deprecated, but without an \
+                  explicit replacement; `{.ofConstName declName true}` is being deprecated in favor \
+                  of a deprecated declaration" ++ disableNote
+              | some next =>
+                if next != newName then
+                  logWarning <| m!"`{.ofConstName newName true}` is itself deprecated in favor of \
+                  `{.ofConstName next true}`; consider deprecating `{.ofConstName declName true}` \
+                  in favor of `{.ofConstName next true}` instead" ++ disableNote
           if let some oldDecl := env.find? declName then
             if let some newDecl := env.find? newName then
               if ← MetaM.run' <| areTypesReduciblyDefEq oldDecl newDecl then

--- a/tests/elab/7993.lean
+++ b/tests/elab/7993.lean
@@ -38,6 +38,12 @@ example := foo
 
 abbrev Bar := Nat
 
+/--
+warning: `Foo.foo` is itself deprecated in favor of `Foo.bar`; consider deprecating `Bar.bar` in favor of `Foo.bar` instead
+
+Note: This warning can be disabled with `set_option linter.deprecated.deprecatedTarget false`
+-/
+#guard_msgs in
 @[deprecated Foo.foo (since := "2025-01-01")]
 def Bar.bar : Bar → Bar := id
 

--- a/tests/elab/deprecatedTransitive.lean
+++ b/tests/elab/deprecatedTransitive.lean
@@ -1,0 +1,132 @@
+/-!
+# Warn when a `@[deprecated]` attribute points at an already-deprecated declaration
+
+When `A` is deprecated in favor of `B`, and `B` is itself deprecated in favor of `C`, deprecating
+`A` towards `B` is discouraged: `B`'s deprecation record points at `C`, so `A` should point at `C`
+instead. The `@[deprecated]` attribute inspects `B`'s deprecation record (only one step) and warns
+accordingly. The check can be turned off with `linter.deprecated.deprecatedTarget`.
+-/
+
+set_option linter.deprecated true
+
+def c1 : Nat := 0
+
+@[deprecated c1 (since := "2020-01-01")]
+def b1 : Nat := 0
+
+/--
+warning: `b1` is itself deprecated in favor of `c1`; consider deprecating `a1` in favor of `c1` instead
+
+Note: This warning can be disabled with `set_option linter.deprecated.deprecatedTarget false`
+-/
+#guard_msgs in
+@[deprecated b1 (since := "2020-01-01")]
+def a1 : Nat := 0
+
+/-! Longer chain `a2 → b2 → c2 → d2`: only one step is followed, so `a2` is pointed at `c2`. -/
+
+def d2 : Nat := 0
+
+set_option linter.deprecated false in
+@[deprecated d2 (since := "2020-01-01")]
+def c2 : Nat := 0
+
+set_option linter.deprecated false in
+@[deprecated c2 (since := "2020-01-01")]
+def b2 : Nat := 0
+
+/--
+warning: `b2` is itself deprecated in favor of `c2`; consider deprecating `a2` in favor of `c2` instead
+
+Note: This warning can be disabled with `set_option linter.deprecated.deprecatedTarget false`
+-/
+#guard_msgs in
+@[deprecated b2 (since := "2020-01-01")]
+def a2 : Nat := 0
+
+/-! Text-only terminal: `b3` is deprecated without an explicit replacement. -/
+
+@[deprecated "no replacement" (since := "2020-01-01")]
+def b3 : Nat := 0
+
+/--
+warning: `b3` is itself deprecated, but without an explicit replacement; `a3` is being deprecated in favor of a deprecated declaration
+
+Note: This warning can be disabled with `set_option linter.deprecated.deprecatedTarget false`
+-/
+#guard_msgs in
+@[deprecated b3 (since := "2020-01-01")]
+def a3 : Nat := 0
+
+/-! One step at a target that is itself text-only deprecated: `a4` is pointed at `c4`. -/
+
+@[deprecated "no replacement" (since := "2020-01-01")]
+def c4 : Nat := 0
+
+set_option linter.deprecated false in
+@[deprecated c4 (since := "2020-01-01")]
+def b4 : Nat := 0
+
+/--
+warning: `b4` is itself deprecated in favor of `c4`; consider deprecating `a4` in favor of `c4` instead
+
+Note: This warning can be disabled with `set_option linter.deprecated.deprecatedTarget false`
+-/
+#guard_msgs in
+@[deprecated b4 (since := "2020-01-01")]
+def a4 : Nat := 0
+
+/-! Type disagreement between the initial declaration and the suggested replacement. -/
+
+def c5 : Bool := true
+
+@[deprecated c5 (since := "2020-01-01")]
+def b5 : Bool := true
+
+/--
+warning: `b5` is itself deprecated in favor of `c5`; consider deprecating `a5` in favor of `c5` instead
+
+Note: This warning can be disabled with `set_option linter.deprecated.deprecatedTarget false`
+---
+warning: The updated constant has a different type:
+  Bool
+instead of
+  Nat
+
+This suggests that addressing the deprecation might be more involved than simply replacing the old name with the new name. This is often expected, but sometimes it indicates that the deprecation is in favor of the wrong declaration, or that there is a mistake in one of the statements.
+
+If the type difference is intentional, use `+typeChanged` to silence this warning.
+
+Hint: Add `+typeChanged`:
+  [apply] +typeChanged
+-/
+#guard_msgs in
+@[deprecated b5 (since := "2020-01-01")]
+def a5 : Nat := 0
+
+/-! No warning when the target is not itself deprecated. -/
+
+def c6 : Nat := 0
+
+#guard_msgs in
+@[deprecated c6 (since := "2020-01-01")]
+def a6 : Nat := 0
+
+/-! Disabling via `linter.deprecated.deprecatedTarget` suppresses the check. -/
+
+def c8 : Nat := 0
+
+@[deprecated c8 (since := "2020-01-01")]
+def b8 : Nat := 0
+
+set_option linter.deprecated.deprecatedTarget false in
+#guard_msgs in
+@[deprecated b8 (since := "2020-01-01")]
+def a8 : Nat := 0
+
+/-! Turning off `linter.deprecated` entirely also suppresses the check. -/
+
+set_option linter.deprecated false in
+#guard_msgs in
+@[deprecated b8 (since := "2020-01-01")]
+def a9 : Nat := 0


### PR DESCRIPTION
This PR makes the `@[deprecated]` attribute warn when the given replacement declaration is itself deprecated. When the replacement has a replacement of its own, the warning suggests deprecating directly in favor of that declaration instead. The check can be disabled with `set_option linter.deprecated.deprecatedTarget false`.