### PR TITLE
fix: classify spec preconditions through `binderNameHint`

### DIFF
--- a/src/Lean/Elab/Tactic/Do/ConjunctivePre.lean
+++ b/src/Lean/Elab/Tactic/Do/ConjunctivePre.lean
@@ -124,14 +124,8 @@ private partial def isConjunctiveIn (qs : Array MVarId) (e : Expr) : Bool :=
   | _ =>
     match e.getAppFn with
     | .mvar m => qs.contains m && e.getAppArgs.all (!occursMVar qs ·)
-    | .const ``binderNameHint _ =>
-      -- `binderNameHint v b e` is definitionally `e`; the hint rides along only to name binders.
-      let args := e.getAppArgs
-      match args[5]? with
-      | some payload =>
-        isConjunctiveIn qs (mkAppN payload (args.extract 6 args.size)) &&
-          (List.range 5).all fun i => !occursMVar qs args[i]!
-      | none => false
+    -- `binderNameHint v b e` is definitionally `e`; the hint rides along only to name binders.
+    | .const ``binderNameHint _ => isConjunctiveIn qs (e.getArg! 5)
     | .const ``EPost.Cons.head _ =>
       -- `EPost.Cons.head` is a `⊓`-morphism (`EPost.Cons.head_meet`); its exception-stack argument
       -- stays in a `⊓`-context, the rest (types and the applied exception) must be `qs`-free.

--- a/src/Lean/Elab/Tactic/Do/ConjunctivePre.lean
+++ b/src/Lean/Elab/Tactic/Do/ConjunctivePre.lean
@@ -6,6 +6,7 @@ Authors: Sebastian Graf
 module
 
 prelude
+import Init.BinderNameHint
 public import Lean.Meta.Basic
 public import Std.WP.Triple.Basic
 
@@ -123,6 +124,14 @@ private partial def isConjunctiveIn (qs : Array MVarId) (e : Expr) : Bool :=
   | _ =>
     match e.getAppFn with
     | .mvar m => qs.contains m && e.getAppArgs.all (!occursMVar qs ·)
+    | .const ``binderNameHint _ =>
+      -- `binderNameHint v b e` is definitionally `e`; the hint rides along only to name binders.
+      let args := e.getAppArgs
+      match args[5]? with
+      | some payload =>
+        isConjunctiveIn qs (mkAppN payload (args.extract 6 args.size)) &&
+          (List.range 5).all fun i => !occursMVar qs args[i]!
+      | none => false
     | .const ``EPost.Cons.head _ =>
       -- `EPost.Cons.head` is a `⊓`-morphism (`EPost.Cons.head_meet`); its exception-stack argument
       -- stays in a `⊓`-context, the rest (types and the applied exception) must be `qs`-free.

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,6 +1,6 @@
 #include "util/options.h"
 
-// [ ] Check box to force CI to test stage 2 and run update-stage0 on PR merge
+// [x] Check box to force CI to test stage 2 and run update-stage0 on PR merge
 // (any other change to this file will do the same; ALL changes should be made to the stage0/ copy)
 
 namespace lean {


### PR DESCRIPTION
This PR makes the conjunctive-precondition classification of `@[spec]` theorems look through `binderNameHint`.