### PR TITLE
feat: support unfolding definitions in `Sym.simp` parameters

### DIFF
--- a/src/Init/Grind/Interactive.lean
+++ b/src/Init/Grind/Interactive.lean
@@ -334,6 +334,9 @@ Only available in `sym =>` mode.
 - `simp myVariant` — uses a named variant registered via `register_sym_simp`
 - `simp [thm₁, thm₂, ...]` — default variant with extra rewrite theorems appended to `post`
 - `simp myVariant [thm₁, thm₂, ...]` — named variant with extra theorems
+
+The extra parameters may be theorems, local hypotheses, or definitions. For a definition `f`,
+its equational theorems are used, so `simp [f]` unfolds `f` applications.
 -/
 syntax (name := symSimp) "simp" (ppSpace colGt ident)? (" [" ident,* "]")? : grind
 

--- a/src/Lean/Elab/Tactic/Grind/SimprocDSLBuiltin.lean
+++ b/src/Lean/Elab/Tactic/Grind/SimprocDSLBuiltin.lean
@@ -60,7 +60,8 @@ def elabSimprocRewriteInline : SymSimprocElab := fun stx => do
   let mut thms : Theorems := {}
   for name in names do
     let declName ← realizeGlobalConstNoOverload name
-    thms := thms.insert (← mkTheoremFromDecl declName)
+    for thm in (← mkTheoremsFromDecl declName) do
+      thms := thms.insert thm
   return thms.rewrite (← elabOptDischarger d?)
 
 @[builtin_sym_simproc andThen]

--- a/src/Lean/Elab/Tactic/Grind/Sym.lean
+++ b/src/Lean/Elab/Tactic/Grind/Sym.lean
@@ -159,7 +159,7 @@ def resolveExtraTheorems (ids? :  Option (Array (TSyntax `ident))) : GrindTactic
     else
       let declName ← realizeGlobalConstNoOverload id
       extras := extras.push <| .const declName
-      thms := thms.push (← mkTheoremFromDecl declName)
+      thms := thms ++ (← mkTheoremsFromDecl declName)
   return (extras, thms)
 
 def addExtraTheorems (post : Simproc) (extraThms : Array Theorem) : GrindTacticM Simproc := do

--- a/src/Lean/Meta/Sym/Simp/Attr.lean
+++ b/src/Lean/Meta/Sym/Simp/Attr.lean
@@ -6,8 +6,6 @@ Authors: Leonardo de Moura
 module
 prelude
 public import Lean.Meta.Sym.Simp.Theorems
-import Lean.Meta.Tactic.Simp.SimpTheorems -- for ignoreEquations
-import Lean.Meta.Eqns -- for getEqnsFor?
 public section
 namespace Lean.Meta.Sym.Simp
 
@@ -21,29 +19,13 @@ def addSymSimpTheorem (ext : SymSimpExtension) (declName : Name) (attrKind : Att
 /--
 Adds a declaration to the given `Sym.Simp` theorem extension.
 When `declName` is a proposition, it is added as a rewrite theorem.
-When it is a definition, its equation theorems are added.
-`attrName` is only used in error messages.
+When it is a definition, its equational theorems are added.
 -/
-def addSymSimpDecl (ext : SymSimpExtension) (attrName : String) (declName : Name)
+def addSymSimpDecl (ext : SymSimpExtension) (declName : Name)
     (attrKind : AttributeKind) (validate : Name → MetaM Unit := fun _ => pure ()) : MetaM Unit := do
-  let info ← getAsyncConstInfo declName
-  if (← isProp info.sig.get.type) then
-    validate declName
-    addSymSimpTheorem ext declName attrKind
-  else if info.kind matches .defn then
-    if (← Simp.ignoreEquations declName) then
-      throwError "Cannot add `{attrName}` attribute to `{.ofConstName declName}`: \
-        It is a reducible definition or projection. `Sym.simp` does not support unfolding."
-    else if let some eqns ← getEqnsFor? declName then
-      for eqn in eqns do
-        validate eqn
-        addSymSimpTheorem ext eqn attrKind
-    else
-      throwError "Cannot add `{attrName}` attribute to `{.ofConstName declName}`: \
-        No equation theorems found."
-  else
-    throwError "Cannot add `{attrName}` attribute to `{.ofConstName declName}`: \
-      It is not a proposition nor a definition with equation theorems."
+  for name in (← getSimpTheoremNames declName) do
+    validate name
+    addSymSimpTheorem ext name attrKind
 
 /--
 Creates a `Sym.Simp` attribute for a named theorem set.
@@ -58,7 +40,7 @@ def mkSymSimpAttr (attrName : Name) (attrDescr : String) (ext : SymSimpExtension
     descr := attrDescr
     applicationTime := AttributeApplicationTime.afterCompilation
     add   := fun declName _ attrKind => do
-      discard <| (addSymSimpDecl ext (toString attrName) declName attrKind).run {} {}
+      discard <| (addSymSimpDecl ext declName attrKind).run {} {}
     erase := fun _declName => do
       throwError "Erasing `Sym.simp` attributes is not supported yet."
   }

--- a/src/Lean/Meta/Sym/Simp/Theorems.lean
+++ b/src/Lean/Meta/Sym/Simp/Theorems.lean
@@ -9,6 +9,8 @@ public import Lean.Meta.Sym.Pattern
 public import Lean.Meta.DiscrTree
 import Lean.Meta.Sym.Simp.DiscrTree
 import Lean.Meta.AppBuilder
+import Lean.Meta.Tactic.Simp.SimpTheorems -- for `ignoreEquations`
+import Lean.Meta.Eqns -- for `getEqnsFor?`
 import Lean.ExtraModUses
 import Init.Omega
 import Init.Data.Range.Polymorphic.Iterators
@@ -200,6 +202,30 @@ def mkTheoremFromExpr (e : Expr) : MetaM Theorem := do
   let perm := isPerm pattern.varTypes.size pattern.pattern rhs
   let rhsVarMask := mkRhsVarMask pattern.varTypes.size rhs
   return { expr, pattern, rhs, perm, rhsVarMask }
+
+/--
+Returns the names of the theorems contributed by `declName` when it is used as a `Sym.simp`
+theorem. A proposition contributes itself. A definition contributes its equational theorems,
+so that `simp [f]` unfolds `f` applications.
+-/
+def getSimpTheoremNames (declName : Name) : MetaM (Array Name) := do
+  let info ← getAsyncConstInfo declName
+  if (← isProp info.sig.get.type) then
+    return #[declName]
+  unless info.kind matches .defn do
+    throwError "cannot use `{.ofConstName declName}` as a simp theorem, it is not a proposition nor a definition with equational theorems"
+  if (← Simp.ignoreEquations declName) then
+    throwError "cannot use `{.ofConstName declName}` as a simp theorem, it is a reducible definition or a projection, and `Sym.simp` does not support unfolding them"
+  let some eqns ← getEqnsFor? declName
+    | throwError "cannot use `{.ofConstName declName}` as a simp theorem, it does not have equational theorems"
+  return eqns
+
+/--
+Creates the `Theorem`s contributed by `declName` when it is used as a `Sym.simp` theorem.
+See `getSimpTheoremNames`.
+-/
+def mkTheoremsFromDecl (declName : Name) : MetaM (Array Theorem) := do
+  (← getSimpTheoremNames declName).mapM mkTheoremFromDecl
 
 /--
 Environment extension storing a set of `Sym.Simp` theorems.

--- a/src/Lean/Meta/Tactic/Grind/Homo.lean
+++ b/src/Lean/Meta/Tactic/Grind/Homo.lean
@@ -109,7 +109,7 @@ Validates and registers a `[grind hom]` theorem, recording the source type of
 `=`-injection rules. See `validateHomoTheorem`.
 -/
 def addHomoAttr (declName : Name) (attrKind : AttributeKind) : MetaM Unit := do
-  Sym.Simp.addSymSimpDecl homoExt "grind hom" declName attrKind (validate := fun declName => do
+  Sym.Simp.addSymSimpDecl homoExt declName attrKind (validate := fun declName => do
     validateHomoTheorem declName
     if let some F ← checkEqInjection? declName then
       homoSourceTypesExt.add F attrKind)

--- a/tests/elab/grind_hom_attr.lean
+++ b/tests/elab/grind_hom_attr.lean
@@ -50,7 +50,7 @@ attribute [lia hom] wu_add
 axiom bad : Nat
 
 /--
-error: Cannot add `grind hom` attribute to `bad`: It is not a proposition nor a definition with equation theorems.
+error: cannot use `bad` as a simp theorem, it is not a proposition nor a definition with equational theorems
 -/
 #guard_msgs in
 attribute [grind hom] bad

--- a/tests/elab/sym_simp_non_prop.lean
+++ b/tests/elab/sym_simp_non_prop.lean
@@ -2,12 +2,11 @@ import Lean
 /-!
 Tests that `Sym.simp` produces a proper error message (instead of the internal
 error `unexpected bound variable #3`) when a declaration or local hypothesis
-that is not a proposition is used as a simp theorem.
+that cannot be used as a simp theorem is provided as a parameter.
 -/
 
 /--
-error: cannot use `HAdd.hAdd` as a simp theorem, its type is not a proposition
-  {α : Type u} → {β : Type v} → {γ : outParam (Type w)} → [self : HAdd α β γ] → α → β → γ
+error: cannot use `HAdd.hAdd` as a simp theorem, it is a reducible definition or a projection, and `Sym.simp` does not support unfolding them
 -/
 #guard_msgs in
 example : 1 + 1 = 2 := by
@@ -23,13 +22,10 @@ example (x : Nat) : x + 0 = x := by
   sym =>
     simp [x]
 
-def myDef : Prop := True
-
 /--
-error: cannot use `myDef` as a simp theorem, its type is not a proposition
-  Prop
+error: cannot use `Nat` as a simp theorem, it is not a proposition nor a definition with equational theorems
 -/
 #guard_msgs in
 example : 1 + 1 = 2 := by
   sym =>
-    simp [myDef]
+    simp [Nat]

--- a/tests/elab/sym_simp_unfold_def.lean
+++ b/tests/elab/sym_simp_unfold_def.lean
@@ -1,0 +1,36 @@
+import Lean
+/-!
+Tests that `Sym.simp` unfolds definitions using their equational theorems when a
+function symbol is provided as a parameter, like `Meta.simp` does with `simp [f]`.
+-/
+
+def f (a : Nat) := a + a
+
+-- Non-recursive definition: `simp [f]` uses `f.eq_1`
+example : f 2 = 4 := by
+  sym =>
+    simp [f]
+
+-- Recursive definition defined by pattern matching
+def g : Nat → Nat
+  | 0 => 1
+  | n+1 => g n + 1
+
+example : g 2 = 3 := by
+  sym =>
+    simp [g]
+
+-- Prop-valued definition: unfolds to its value
+def myDef : Prop := True
+
+example : myDef := by
+  sym =>
+    simp [myDef]
+
+-- Definitions also work in the `rewrite [...]` simproc DSL
+register_sym_simp unfoldF where
+  post := ground >> rewrite [f]
+
+example : f 2 = 4 := by
+  sym =>
+    simp unfoldF


### PR DESCRIPTION
This PR adds support for unfolding definitions in `Sym.simp` when a function symbol is provided as a parameter. `sym => simp [f]` now uses the equational theorems of `f`, like `Meta.simp` does, instead of failing.
