### PR TITLE
fix: infer `do←` binder types from the wrapper

### DIFF
--- a/src/Lean/Elab/BuiltinDo/Forward.lean
+++ b/src/Lean/Elab/BuiltinDo/Forward.lean
@@ -81,7 +81,14 @@ public def tryElabForwardApp? (e : Term) (dec : DoElemCont) : DoElabM (Option Ex
   let bodyInfo ← InferControlInfo.ofSeq arg.body
   let forwarder ← EffectForwarder.ofCont bodyInfo dec
   let liftedBody ← controlAtTermElabM fun runInBase => do
-    Term.elabFunBinders (arg.binders.map (·.raw)) none fun bsExpr _ => runInBase do
+    -- The binders take their types from the wrapper's body slot.
+    let slotType ← instantiateMVars (← inferType forwarded)
+    let (binders, _, isPattern) ←
+      liftMacroM <| Term.expandFunBinders (arg.binders.map (·.raw)) (← `(_))
+    if isPattern then
+      throwError "\
+        A `do←` binder must be a variable. Bind a variable and `match` on it in the body."
+    Term.elabFunBinders binders (some slotType) fun bsExpr _ => runInBase do
       mkLambdaFVars bsExpr (← forwarder.lift (elabDoSeq arg.body))
   unless ← forwarded.mvarId!.checkedAssign liftedBody do
     throwError "the lifted body's type does not match the wrapper's body slot type"

--- a/tests/elab/doForward.lean
+++ b/tests/elab/doForward.lean
@@ -195,6 +195,45 @@ example : IO Nat := do
     return acc + n
   return total
 
+/-! ### Binder types
+
+The binders of a forwarded body take their types from the wrapper's body slot. -/
+
+-- Field notation on a binder resolves.
+/-- info: 3 -/
+#guard_msgs in
+#eval show IO Nat from do
+  let mut n := 0
+  withInjected #[1, 2, 3] (fun as => do← n := as.size)
+  return n
+
+-- An ascribed binder is accepted.
+/-- info: 3 -/
+#guard_msgs in
+#eval show IO Nat from do
+  let mut n := 0
+  withInjected #[1, 2, 3] (fun (as : Array Nat) => do← n := as.size)
+  return n
+
+/-- A wrapper that invokes `k` with two arguments. -/
+def withInjected2 [Monad m] (x : α) (y : β) (k : α → β → m γ) : m γ := k x y
+
+-- Every binder takes its type from the wrapper.
+/-- info: 5 -/
+#guard_msgs in
+#eval show IO Nat from do
+  let mut n := 0
+  withInjected2 #[1, 2] "abc" (fun as s => do← n := as.size + s.length)
+  return n
+
+-- A pattern binder is rejected.
+/-- error: A `do←` binder must be a variable. Bind a variable and `match` on it in the body. -/
+#guard_msgs in
+example : IO Nat := do
+  let mut n := 0
+  withInjected (1, 2) (fun (a, b) => do← n := a + b)
+  return n
+
 /-! ### Control-info assertion -/
 
 -- The forwarded body has two regular exits (both `if` branches fall through).


### PR DESCRIPTION
This PR types the `fun` binders of a `do←` argument from the wrapper's signature, so field notation such as `bs.extract` resolves in the forwarded body. A binder with a type ascription is accepted as well, and a pattern binder gets a dedicated error message.

Before this PR, `forallTelescope e fun bs _ => do← …` reported ``Invalid field notation: Type of `bs` is not known`` for `bs.extract`, and `fun (bs : Array Expr) _ => do← …` reported ``unexpected `do` element syntax``.