### PR TITLE
feat: complete the `PredTrans` simp framework, and collapse the identity instances

### DIFF
--- a/src/Std/Internal/Order/Instances.lean
+++ b/src/Std/Internal/Order/Instances.lean
@@ -32,15 +32,9 @@ instance [CompleteLattice l] : Std.Associative (α := l) (· ⊓ ·) := ⟨fun _
 instance [CompleteLattice l] : Std.Associative (α := l) (· ⊔ ·) := ⟨fun _ _ _ => join_assoc⟩
 instance [CompleteLattice l] : Std.IdempotentOp (α := l) (· ⊓ ·) := ⟨fun _ => meet_self⟩
 instance [CompleteLattice l] : Std.IdempotentOp (α := l) (· ⊔ ·) := ⟨fun _ => join_self⟩
-instance [CompleteLattice l] : Std.LeftIdentity (· ⊓ ·) (⊤ : l) where
-instance [CompleteLattice l] : Std.RightIdentity (· ⊓ ·) (⊤ : l) where
-instance [CompleteLattice l] : Std.LeftIdentity (· ⊔ ·) (⊥ : l) where
-instance [CompleteLattice l] : Std.RightIdentity (· ⊔ ·) (⊥ : l) where
-instance [CompleteLattice l] : Std.LawfulIdentity (· ⊓ ·) (⊤ : l) where
-  left_id _ := top_meet
+instance [CompleteLattice l] : Std.LawfulCommIdentity (α := l) (· ⊓ ·) ⊤ where
   right_id _ := meet_top
-instance [CompleteLattice l] : Std.LawfulIdentity (· ⊔ ·) (⊥ : l) where
-  left_id _ := bot_join
+instance [CompleteLattice l] : Std.LawfulCommIdentity (α := l) (· ⊔ ·) ⊥ where
   right_id _ := join_bot
 
 end Lean.Order

--- a/src/Std/Internal/Order/PredTrans.lean
+++ b/src/Std/Internal/Order/PredTrans.lean
@@ -186,6 +186,27 @@ instance {σ : Type u} {Pred : Type v} {EPred : Type w} :
     MonadReaderOf σ (PredTrans (σ → Pred) EPred) where
   read := ⟨fun post _epost => fun s => post s s⟩
 
+/-- Unfolding `get` through `apply`. -/
+@[simp, grind =] theorem PredTrans.apply_get {σ : Type u} {Pred : Type v} {EPred : Type w}
+    (post : σ → σ → Pred) (epost : EPred) (s : σ) :
+    (MonadStateOf.get : PredTrans (σ → Pred) EPred σ).apply post epost s = post s s := rfl
+
+/-- Unfolding `set` through `apply`. -/
+@[simp, grind =] theorem PredTrans.apply_set {σ : Type u} {Pred : Type v} {EPred : Type w}
+    (s' : σ) (post : PUnit → σ → Pred) (epost : EPred) (s : σ) :
+    (MonadStateOf.set s' : PredTrans (σ → Pred) EPred PUnit).apply post epost s = post ⟨⟩ s' := rfl
+
+/-- Unfolding `modifyGet` through `apply`. -/
+@[simp, grind =] theorem PredTrans.apply_modifyGet {σ : Type u} {α : Type u} {Pred : Type v}
+    {EPred : Type w} (f : σ → α × σ) (post : α → σ → Pred) (epost : EPred) (s : σ) :
+    (MonadStateOf.modifyGet f : PredTrans (σ → Pred) EPred α).apply post epost s
+      = post (f s).1 (f s).2 := rfl
+
+/-- Unfolding `read` through `apply`. -/
+@[simp, grind =] theorem PredTrans.apply_read {σ : Type u} {Pred : Type v} {EPred : Type w}
+    (post : σ → σ → Pred) (epost : EPred) (s : σ) :
+    (MonadReaderOf.read : PredTrans (σ → Pred) EPred σ).apply post epost s = post s s := rfl
+
 /-- `MonadExceptOf` instance lifted through a state layer:
 delegates `throw` and `tryCatch` to the inner `PredTrans l e` instance. -/
 instance {ε : Type u} {Pred : Type v} {EPred : Type w} {σ : Type z}

--- a/src/Std/WP/Monad/Instances.lean
+++ b/src/Std/WP/Monad/Instances.lean
@@ -55,6 +55,20 @@ instance {ε : Type u} {Pred : Type v} {EPred : Type w} :
   throw e := ⟨fun _post epost => epost.head e⟩
   tryCatch x handle := ⟨fun post epost => x.apply post ⟨(fun e => (handle e).apply post epost), epost.tail⟩⟩
 
+/-- Unfolding `throw` through `apply`: the head exception postcondition at the thrown value. -/
+@[simp, grind =] theorem PredTrans.apply_throw {ε : Type u} {α : Type u} {Pred : Type u}
+    {EPred : Type w} (e : ε) (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
+    (MonadExceptOf.throw e : PredTrans Pred (EPost.Cons (ε → Pred) EPred) α).apply post epost
+      = epost.head e := rfl
+
+/-- Unfolding `tryCatch` through `apply`: the handler replaces the head exception postcondition. -/
+@[simp, grind =] theorem PredTrans.apply_tryCatch {ε : Type u} {α : Type u} {Pred : Type u}
+    {EPred : Type w} (x : PredTrans Pred (EPost.Cons (ε → Pred) EPred) α)
+    (handle : ε → PredTrans Pred (EPost.Cons (ε → Pred) EPred) α)
+    (post : α → Pred) (epost : EPost.Cons (ε → Pred) EPred) :
+    (MonadExceptOf.tryCatch x handle).apply post epost
+      = x.apply post ⟨fun e => (handle e).apply post epost, epost.tail⟩ := rfl
+
 /-- `MonadExceptOf` instance lifted through an unrelated exception layer:
 delegates to the inner instance, threading the extra exception postcondition. -/
 instance {ε : Type u} {Pred : Type v} {EPred : Type w} {ε' : Type u}


### PR DESCRIPTION
This PR adds `apply` equations for the `PredTrans` operations that had none, so that `simp` reduces `get`, `set`, `modifyGet`, `read`, `throw` and `tryCatch` the way it already reduces `pure`, `bind` and the rest.

The identity instances for `⊓` at `⊤` and `⊔` at `⊥` collapse from six to two. `Std.LawfulCommIdentity` derives the left identity from the right one through the `Std.Commutative` instances that `Std.Internal.Order.Instances` already declares, and `Std.LeftIdentity` and `Std.RightIdentity` follow from `Std.LawfulIdentity` by inheritance.