### PR TITLE
refactor: derive `vcgen`'s exception postcondition rules from a type class

### DIFF
--- a/src/Lean/Elab/Tactic/VCGen/RuleConstruction.lean
+++ b/src/Lean/Elab/Tactic/VCGen/RuleConstruction.lean
@@ -43,10 +43,60 @@ private def mkPostPointwisePremise (postSpec postTarget postTy : Expr) (ssTypes 
       let rhs := mkAppN (mkApp postTarget a) ss'
       mkForallFVars (#[a] ++ ss') (← mkAppM ``PartialOrder.rel #[lhs, rhs])
 
+/-- An `AssertionHom E T hom` instance together with the arguments of its type,
+`#[E, T, hom, instE, instT]`. -/
+private structure AssertionHomInst where
+  levels : List Level
+  args : Array Expr
+  inst : Expr
+
+namespace AssertionHomInst
+
+/-- The stack type the conversion targets. -/
+private def T (p : AssertionHomInst) : Expr := p.args[1]!
+/-- The conversion itself. -/
+private def hom (p : AssertionHomInst) : Expr := p.args[2]!
+
+/-- Apply the `AssertionHom` field `field` to `args`. -/
+private def mkField (p : AssertionHomInst) (field : Name) (args : Array Expr) : Expr :=
+  mkAppN (mkConst field p.levels) (p.args ++ #[p.inst] ++ args)
+
+end AssertionHomInst
+
+/-- The `AssertionHom` instance of `E`, or `none` if there is none, in which case `E` is atomic.
+Runs instance synthesis, which is affordable here: rule construction is cached per spec theorem,
+`WPMonad` instance and excess-argument count, so the lookup runs once per shape, not per goal. -/
+private def assertionHom? (E : Expr) : MetaM (Option AssertionHomInst) := withNewMCtxDepth do
+  let some u ← decLevel? (← getLevel E) | return none
+  let .some instE ← trySynthInstance (mkApp (mkConst ``Assertion [u]) E) | return none
+  let T ← mkFreshExprMVar (mkSort (.succ u))
+  let hom ← mkFreshExprMVar (← mkArrow E T)
+  let instT ← mkFreshExprMVar (mkApp (mkConst ``Assertion [u]) T)
+  let .some inst ← trySynthInstance
+      (mkAppN (mkConst ``AssertionHom [u]) #[E, T, hom, instE, instT])
+    | return none
+  let instType ← instantiateMVars (← Meta.inferType inst)
+  let .const _ levels := instType.getAppFn | return none
+  return some { levels, args := instType.getAppArgs, inst := ← instantiateMVars inst }
+
+/-- Reduce a structure projection applied to a constructor application to the projected component,
+so that a factor of a converted exception postcondition is the assertion the user wrote. Any other
+term is returned unchanged; in particular a projection of a free or metavariable stays a
+projection. -/
+private def reduceProjOfCtor (e : Expr) : MetaM Expr := do
+  let .const fn _ := e.getAppFn | return e
+  let some _ ← getProjectionFnInfo? fn | return e
+  if ← isConstructorApp e.appArg!.consumeMData then
+    whnf e
+  else
+    return e
+
 /-- Recursively decompose `epostSpec ⊑ epostAbstract` into per-component proofs.
     - `(head, tail)` → mvar for `head ⊑ epostAbstract.fst`, recurse on `tail`
     - Otherwise, if `EPred` is a product, project `epostSpec.fst`/`.snd` and decompose those
     - Otherwise, if `EPred` is `Unit`, trivial via `Unit.unit_le`
+    - Otherwise, if `EPred` has an `AssertionHom` instance, convert both sides into stacks,
+      decompose the entailment between the images, and reflect it back via `le_of_hom_le`
     - Otherwise → single mvar for `epostSpec ⊑ epostAbstract` -/
 private partial def decomposeProdRel (EPred epostSpec epostAbstract : Expr)
     (stateArgNames : Array Name := #[]) : MetaM Expr := do
@@ -55,6 +105,10 @@ private partial def decomposeProdRel (EPred epostSpec epostAbstract : Expr)
     let absHead ← mkAppM ``Prod.fst #[epostAbstract]
     let absTail ← mkAppM ``Prod.snd #[epostAbstract]
     let hTail ← decomposeProdRel etTy tail absTail stateArgNames
+    -- A factor produced by an `AssertionHom` conversion is a projection of the spec's exception
+    -- postcondition literal. Reduce it, so a schematic factor is recognized and assigned below,
+    -- and the VC for a concrete factor states the assertion the user wrote.
+    let head ← reduceProjOfCtor head
     /- Sometimes, even though `epost` is not schematic itself, its components might be schematic.
       Think of a triple of a kind `⦃ pre ⦄ x ⦃ post; epost₁, ⊥, epost₃, ⊥, ... ⦄`.
       In this case we do not want to create new metavariables for `epost₁`, `epost₃`, etc.
@@ -89,6 +143,14 @@ private partial def decomposeProdRel (EPred epostSpec epostAbstract : Expr)
       -- The terminator is reducibly `PUnit`, under any of its names.
       if (← whnfR EPred).isConstOf ``PUnit then
         mkAppM ``Unit.unit_le #[epostAbstract]
+      else if let some p ← assertionHom? EPred then
+        -- `EPred` converts into a stack: decompose the entailment between the images and reflect
+        -- it back along the hom. The beta-reduced image of a spec's literal is a `Prod.mk`
+        -- application, so the stack cases above apply to it.
+        let homSpec := (mkApp p.hom epostSpec).headBeta
+        let homAbstract := mkApp p.hom epostAbstract
+        let h ← decomposeProdRel p.T homSpec homAbstract stateArgNames
+        return p.mkField ``AssertionHom.le_of_hom_le #[epostSpec, epostAbstract, h]
       else
         let hTy ← mkAppM ``PartialOrder.rel #[epostSpec, epostAbstract]
         mkFreshExprMVar (userName := `epostImpl) hTy
@@ -139,9 +201,11 @@ value, the relation `epostSpec ⊑ epost` is decomposed component by component:
 ∀ e s₁ ... sₙ, epostSpec.fst e s₁ ... sₙ ⊑ epost.fst e s₁ ... sₙ
 ```
 and recursively for the tail. `decomposeProdRel` assembles these component VCs using
-`Prod.mk_le` and `Unit.unit_le`. The proof is then generalized with `WP.wp_econs_le`.
-When the spec exception postcondition is `⊥`, no VC is needed and `WP.wp_econs_bot_le` is
-used instead.
+`Prod.mk_le` and `Unit.unit_le`. An exception postcondition type with an `AssertionHom` instance is
+first converted into a stack, whose components are decomposed the same way, and
+`AssertionHom.le_of_hom_le` reflects the entailment back. The proof is then generalized with
+`WP.wp_econs_le`. When the spec exception postcondition is `⊥`, no VC is needed and
+`WP.wp_econs_bot_le` is used instead.
 
 #### Excess state arguments
 

--- a/src/Std/Internal/Order/PreservesSup.lean
+++ b/src/Std/Internal/Order/PreservesSup.lean
@@ -187,6 +187,11 @@ theorem Prod.snd_bot {α : Type u} {β : Type v} [CCPO α] [CCPO β] :
     (⊥ : α × β).snd = (⊥ : β) :=
   PartialOrder.rel_antisymm (bot_le ((⊥ : α), (⊥ : β))).right (bot_le _)
 
+/-- The pair of the bottom elements is the bottom element. -/
+theorem Prod.mk_bot {α : Type u} {β : Type v} [CCPO α] [CCPO β] :
+    ((⊥ : α), (⊥ : β)) = (⊥ : α × β) :=
+  PartialOrder.rel_antisymm (Prod.mk_le _ _ _ (bot_le _) (bot_le _)) (bot_le _)
+
 /-- The first component of the top element is the top element. Propositional (not
 definitional), because `⊤` is a supremum, not a constructor application. -/
 theorem Prod.fst_top : (⊤ : α × β).fst = (⊤ : α) :=

--- a/src/Std/WP/Assertion.lean
+++ b/src/Std/WP/Assertion.lean
@@ -132,4 +132,24 @@ theorem NondetFun.le_of_total_le {Pred : Type u} {Fun : Type v} {α : Type w}
 
 end Assertion
 
+/-!
+## Order-reflecting conversions
+
+An exception postcondition for a program that can throw at several layers carries one assertion per
+layer, and reasoning about it proceeds layer by layer. `AssertionHom E T hom` converts such an `E`
+into an assertion `T` that exposes the layers as a stack, and `le_of_hom_le` reflects an entailment
+between the stacks back to an entailment between the originals. For a program in
+`ExceptT Nat (ExceptT String (StateM σ))`, `T` is `EStack⟨Nat → σ → Prop, String → σ → Prop⟩`, and
+each factor is the assertion of one layer.
+-/
+
+/-- `hom` converts the assertion `E` into the assertion `T`, reflecting the order and preserving
+the least element. -/
+class AssertionHom (E : Type u) (T : outParam (Type u)) (hom : outParam (E → T))
+    [Assertion E] [Assertion T] where
+  /-- An entailment between the images is an entailment between the arguments. -/
+  le_of_hom_le {x y : E} : hom x ⊑ hom y → x ⊑ y
+  /-- The image of the least assertion is the least assertion. -/
+  hom_bot : hom (⊥ : E) = ⊥
+
 end Std.WP

--- a/tests/elab/vcgenAssertionHom.lean
+++ b/tests/elab/vcgenAssertionHom.lean
@@ -1,0 +1,76 @@
+import Std.Tactic.Do
+import Std.WP
+
+/-!
+`vcgen` weakens the exception postcondition of a spec along the `AssertionHom` instance of the
+exception postcondition type. `Thrown` is such a type outside the stack hierarchy: the
+verification condition for a concrete exception postcondition is stated for the factor of the
+stack that `Thrown` converts to, and a schematic factor is assigned instead of yielding a
+verification condition.
+-/
+
+set_option mvcgen.warning false
+open Std.WP Lean.Order
+
+/-- The exception postcondition of a `Prog`: what holds of the thrown message. -/
+structure Thrown where
+  /-- The assertion about the thrown message. -/
+  onThrow : String → Prop
+
+instance : PartialOrder Thrown where
+  rel p q := p.onThrow ⊑ q.onThrow
+  rel_refl := PartialOrder.rel_refl
+  rel_trans h₁ h₂ := PartialOrder.rel_trans h₁ h₂
+  rel_antisymm h₁ h₂ := congrArg Thrown.mk (PartialOrder.rel_antisymm h₁ h₂)
+
+instance : CompleteLattice Thrown where
+  has_sup c :=
+    let ⟨sup, hsup⟩ := CompleteLattice.has_sup (fun f => c ⟨f⟩)
+    ⟨⟨sup⟩, fun q =>
+      ⟨fun hq p hp => (hsup q.onThrow).mp hq p.onThrow hp,
+       fun h => (hsup q.onThrow).mpr fun f hf => h ⟨f⟩ hf⟩⟩
+
+instance : AssertionHom Thrown EStack⟨String → Prop⟩ (fun t => estack⟨t.onThrow⟩) where
+  le_of_hom_le h := h.1
+  hom_bot := by
+    have h : (⊥ : Thrown).onThrow = ⊥ :=
+      PartialOrder.rel_antisymm (bot_le (⟨⊥⟩ : Thrown)) (bot_le _)
+    rw [h, Subsingleton.elim EStackEnd.mk (⊥ : EStackEnd), Prod.mk_bot]
+
+/-- A program that returns or throws a message. -/
+inductive Prog (α : Type) where
+  | ret (a : α)
+  | throw (e : String)
+
+instance : WP (Prog α) α Prop Thrown where
+  wpTrans
+    | .ret a => ⟨fun post _ => post a⟩
+    | .throw e => ⟨fun _ epost => epost.onThrow e⟩
+  wp_trans_monotone
+    | .ret _ => fun _ _ _ _ _ hpost => hpost _
+    | .throw e => fun _ _ _ _ hepost _ => hepost e
+
+axiom Q : String → Prop
+
+def boom : Prog Unit := .throw "boom"
+
+def boom' : Prog Unit := .throw "boom"
+
+/-- Exception postcondition with a concrete assertion. -/
+@[spec] theorem boom_spec {post : Unit → Prop} :
+    ⦃True⦄ boom ⦃post; (⟨fun e => e = "boom"⟩ : Thrown)⦄ := ⟨fun _ => rfl⟩
+
+/-- Exception postcondition with a schematic assertion. -/
+@[spec] theorem boom'_spec {post : Unit → Prop} {E : String → Prop} :
+    ⦃E "boom"⦄ boom' ⦃post; (⟨E⟩ : Thrown)⦄ := ⟨PartialOrder.rel_refl⟩
+
+/-- The concrete assertion of `boom_spec` yields the verification condition
+`∀ e, e = "boom" → e = "boom" ∨ e = "crash"`. -/
+example : ⦃True⦄ boom ⦃fun _ => True; (⟨fun e => e = "boom" ∨ e = "crash"⟩ : Thrown)⦄ := by
+  vcgen
+  grind
+
+/-- The schematic assertion of `boom'_spec` is assigned the assertion of the goal, so no
+verification condition remains: the precondition VC closes by reflexivity. -/
+example : ⦃Q "boom"⦄ boom' ⦃fun _ => True; (⟨Q⟩ : Thrown)⦄ := by
+  vcgen


### PR DESCRIPTION
This PR lets `vcgen` weaken the exception postcondition of a spec for any exception postcondition type that converts into an assertion stack, not only for the `Prod`/`Unit` stacks themselves.

`AssertionHom E T hom` converts an assertion `E` into a stack `T` whose factors are the assertions of the individual exception layers, reflects an entailment between the images back to an entailment between the arguments, and identifies the image of `⊥`. The spec rule construction decomposes `epostSpec ⊑ epost` over bare `Prod`/`Unit` stacks directly; for an exception postcondition type with an `AssertionHom` instance it converts both sides once, decomposes the entailment between the images factor by factor, and reflects it back with `AssertionHom.le_of_hom_le`. A factor of the converted spec value is a projection of a literal, which the construction reduces so each verification condition states the assertion the user wrote. The instance lookup runs during rule construction, which is cached per spec theorem, `WPMonad` instance and excess-argument count, so no goal pays for it.

The test's `Thrown` structure, converting to `EStack⟨String → Prop⟩`, is the motivating instance: a concrete factor yields a pointwise verification condition, and a schematic factor is assigned the goal's factor instead of yielding one.
