### PR TITLE
fix: literal canonicalization in `grind`

### DIFF
--- a/src/Lean/Meta/LitValues.lean
+++ b/src/Lean/Meta/LitValues.lean
@@ -111,6 +111,27 @@ def getBitVecValue? (e : Expr) : MetaM (Option ((n : Nat) × BitVec n)) := Optio
     let n ← getNatValue? (← whnfD type.appArg!)
     return ⟨n, BitVec.ofNat n v⟩
 
+/--
+Returns the modulus of the wrapping numeric type `α` (`n` for `Fin n`, `2^w` for the
+fixed-width types) if it is known. `USize`/`ISize` are not included: their widths are
+platform-dependent.
+-/
+def getLitValueModulus? (α : Expr) : MetaM (Option Nat) := do
+  match_expr α with
+  | Fin n => getNatValue? n
+  | BitVec w =>
+    let some w ← getNatValue? w | return none
+    return some (2 ^ w)
+  | UInt8 => return some (2 ^ 8)
+  | UInt16 => return some (2 ^ 16)
+  | UInt32 => return some (2 ^ 32)
+  | UInt64 => return some (2 ^ 64)
+  | Int8 => return some (2 ^ 8)
+  | Int16 => return some (2 ^ 16)
+  | Int32 => return some (2 ^ 32)
+  | Int64 => return some (2 ^ 64)
+  | _ => return none
+
 /-- Return `some n` if `e` is an `OfNat.ofNat`-application encoding the `UInt8` with value `n`. -/
 def getUInt8Value? (e : Expr) : MetaM (Option UInt8) := OptionT.run do
   let (n, _) ← getOfNatValue? e ``UInt8

--- a/src/Lean/Meta/Sym/Canon.lean
+++ b/src/Lean/Meta/Sym/Canon.lean
@@ -12,6 +12,8 @@ import Lean.Meta.Sym.SynthInstance
 import Lean.Meta.Sym.Arith.EvalNum
 import Lean.Meta.IntInstTesters
 import Lean.Meta.NatInstTesters
+import Lean.Meta.LitValues
+import Lean.Meta.AppBuilder
 import Lean.Meta.Sym.Eta
 import Lean.Meta.WHNF
 import Init.Grind.Util
@@ -135,6 +137,40 @@ private def normOfNatArgs? (args : Array Expr) : MetaM (Option (Array Expr)) := 
     else if modified then
       return some args.toArray
   return none
+
+/--
+Normalizes numeric literals of wrapping types during canonicalization. Two kinds of
+non-canonical spellings are handled:
+- `BitVec.ofNat`/`BitVec.ofNatLT`/`Fin.ofNat` applications with literal arguments (e.g.,
+  `1#2`, `Fin.ofNat 3 2`) are converted into the `OfNat.ofNat` representation.
+- `OfNat.ofNat` literals of `Fin` and the fixed-width types (see `getLitValueModulus?`) whose numeral
+  is out of range (e.g., `(300 : UInt8)`) are reduced modulo the type's cardinality.
+
+Different representations of the same literal may reach the canonicalizer (e.g., the proposition
+of a `dite` `Decidable` instance keeps the spelling used in the source), and `grind`
+assumes distinct interpreted nodes denote distinct values (see `valueInconsistency` at
+`Grind.addEqStep`), so all representations of the same literal must canonicalize to the same
+term. The result is definitionally equal to the input.
+-/
+public def normNumLit? (e : Expr) : MetaM (Option Expr) := do
+  match_expr e with
+  | BitVec.ofNat _ _ => bitVecOfNatForm e
+  | BitVec.ofNatLT _ _ _ => bitVecOfNatForm e
+  | Fin.ofNat n _ a =>
+    let some n ← getNatValue? n | return none
+    let some a ← getNatValue? a | return none
+    if n == 0 then return none
+    return some (← mkNumeral (mkApp (mkConst ``Fin) (mkNatLit n)) (a % n))
+  | OfNat.ofNat α n _ =>
+    let some m ← getLitValueModulus? α | return none
+    let some v ← getNatValue? n | return none
+    if m == 0 || v < m then return none
+    return some (← mkNumeral α (v % m))
+  | _ => return none
+where
+  bitVecOfNatForm (e : Expr) : MetaM (Option Expr) := do
+    let some ⟨w, v⟩ ← Meta.getBitVecValue? e | return none
+    return some (← mkNumeral (mkApp (mkConst ``BitVec) (mkNatLit w)) v.toNat)
 
 abbrev withCaching (e : Expr) (k : CanonM Expr) : CanonM Expr := do
   if (← read).insideType then
@@ -478,6 +514,12 @@ where
     else
       let f := e.getAppFn
       let .const declName _ := f | return e
+      if declName == ``BitVec.ofNat || declName == ``BitVec.ofNatLT || declName == ``Fin.ofNat
+          || declName == ``OfNat.ofNat then
+        if let some e' ← normNumLit? e then
+          return (← canon e')
+        else
+          return e
       if let some info ← getProjectionFnInfo? declName then
         return (← reduceProjFn? info e).getD e
       else

--- a/src/Lean/Meta/Tactic/Grind/AC/Util.lean
+++ b/src/Lean/Meta/Tactic/Grind/AC/Util.lean
@@ -149,19 +149,10 @@ where
         let neutral ← instantiateExprMVars neutral
         /-
         **Note**: `Std.LawfulIdentity` instances may spell the identity element in a form
-        that is not in `grind` normal form. Example: the `BitVec` instances use `0#n`
-        (i.e., `BitVec.ofNat n 0`), but the `grind` normalizer represents bit-vector literals
-        using `OfNat.ofNat`. Internalizing a non-canonical literal violates the invariant that
-        interpreted nodes are canonical: `grind` assumes distinct interpreted nodes denote
-        distinct values (see `valueInconsistency` at `addEqStep`). We cannot `simp`-normalize
-        `neutral` here: the result would be only propositionally equal to the identity element
-        fixed by `identityInst`, and we need a definitionally equal term.
-        We hardcode the bit-vector case for now. **TODO**: fix this properly in a separate commit.
+        that is not in `grind` normal form (e.g., the `BitVec` instances use `0#n`), and we
+        need a term that is definitionally equal to the identity element fixed by
+        `identityInst`. `preprocessLight` canonicalizes literals (see `Sym.Canon.normNumLit?`).
         -/
-        let neutral ← if let some ⟨w, v⟩ ← getBitVecValue? neutral then
-          mkNumeral (mkApp (mkConst ``BitVec) (mkNatLit w)) v.toNat
-        else
-          pure neutral
         let neutral ← preprocessLight neutral
         internalize neutral (← getGeneration op)
         pure (some identityInst, some neutral)

--- a/src/Lean/Meta/Tactic/Grind/Arith/Cutsat/MBTC.lean
+++ b/src/Lean/Meta/Tactic/Grind/Arith/Cutsat/MBTC.lean
@@ -16,28 +16,6 @@ private def isSignedType (α : Expr) : Bool :=
   α.isConstOf ``Int8 || α.isConstOf ``Int16 || α.isConstOf ``Int32 || α.isConstOf ``Int64
 
 /--
-Returns the modulus of the embedded type `α` (`n` for `Fin n`, `2^w` for the fixed-width
-types) if it is known. Numerals of embedded types with known modulus are not given
-embedding-accessor applications: their embedded value is computed directly (e.g., during
-model-based theory combination).
--/
-def modulus? (α : Expr) : GoalM (Option Nat) := do
-  match_expr α with
-  | Fin n => getNatValue? n
-  | BitVec w =>
-    let some w ← getNatValue? w | return none
-    return some (2 ^ w)
-  | UInt8 => return some (2 ^ 8)
-  | UInt16 => return some (2 ^ 16)
-  | UInt32 => return some (2 ^ 32)
-  | UInt64 => return some (2 ^ 64)
-  | Int8 => return some (2 ^ 8)
-  | Int16 => return some (2 ^ 16)
-  | Int32 => return some (2 ^ 32)
-  | Int64 => return some (2 ^ 64)
-  | _ => return none -- `USize`/`ISize`: platform-dependent width
-
-/--
 Returns the embedded (`Fin.val`/`toNat`/`toInt`) value of a numeral of an embedded type
 (e.g., `(2 : Fin 3) ↦ 2`, `(-1 : Fin 4) ↦ 3`, `(200 : Int8) ↦ -56`). Numerals have no
 embedding-accessor application in the E-graph, so their value is computed directly.
@@ -45,7 +23,7 @@ embedding-accessor application in the E-graph, so their value is computed direct
 private def getEmbeddedLitValue? (e : Expr) : GoalM (Option Rat) := do
   let value? (α k : Expr) (neg : Bool) : GoalM (Option Rat) := do
     let some k ← getNatValue? k | return none
-    let some m ← modulus? α | return none
+    let some m ← getLitValueModulus? α | return none
     let m : Int := m
     let k : Int := if neg then -(k : Int) else (k : Int)
     let v := k % m

--- a/src/Lean/Meta/Tactic/Grind/EMatchTheorem.lean
+++ b/src/Lean/Meta/Tactic/Grind/EMatchTheorem.lean
@@ -393,27 +393,6 @@ private def dontCare := mkConst (Name.mkSimple "[grind_dontcare]")
 def mkGroundPattern (e : Expr) : Expr :=
   mkAnnotation `grind.ground_pat e
 
-/--
-Puts a parametric numeric literal in `grind` normal form.
-
-`grind` represents `BitVec` and `Fin` literals using `OfNat.ofNat` (see
-`isOfNatFinBitVecLiteral`), but a term may spell one as `BitVec.ofNat` (e.g., `1#2`) or
-`Fin.mk`. Ground patterns are internalized without full normalization, and a non-canonical
-literal reaching the E-graph breaks the invariant that distinct interpreted nodes denote
-distinct values, which `addEqStep` relies on to detect `valueInconsistency`.
-
-**TODO**: delete this function. The normalizer should do this, instead of enumerating literal
-kinds here. Waiting on the port of `Sym.dsimp` to `grind`. The same hardcoding is in
-`AC.mkStruct` for identity elements, and should be deleted with it.
--/
-private def canonLit (e : Expr) : MetaM Expr := do
-  if e.isAppOf ``OfNat.ofNat then return e
-  if let some ⟨w, v⟩ ← getBitVecValue? e then
-    return (← mkNumeral (mkApp (mkConst ``BitVec) (mkNatLit w)) v.toNat)
-  if let some ⟨n, v⟩ ← getFinValue? e then
-    return (← mkNumeral (mkApp (mkConst ``Fin) (mkNatLit n)) v.val)
-  return e
-
 def groundPattern? (e : Expr) : Option Expr :=
   annotation? `grind.ground_pat e
 
@@ -703,7 +682,8 @@ where
           ```
           -/
           saveSymbolsAt arg
-        return mkGroundPattern (← canonLit arg)
+        -- Ground patterns are canonicalized at internalization time (see `internalizePattern`).
+        return mkGroundPattern arg
     else match arg with
       | .bvar idx =>
         -- **Note** See comment at `ParentKind.genPattern`.

--- a/src/Lean/Meta/Tactic/Grind/Inv.lean
+++ b/src/Lean/Meta/Tactic/Grind/Inv.lean
@@ -8,6 +8,7 @@ prelude
 public import Lean.Meta.Tactic.Grind.Types
 import Init.Grind.Util
 import Lean.Meta.Tactic.Grind.Util
+import Lean.Meta.Sym.Canon
 namespace Lean.Meta.Grind
 /-!
 Debugging support code for checking basic invariants.
@@ -123,6 +124,10 @@ public def checkInvariants (expensive := false) : GoalM Unit := do
     for e in (← getExprs) do
       let node ← getENode e
       checkParents node.self
+      -- Interpreted nodes must be literals in `grind` normal form: a non-canonical spelling
+      -- breaks the assumption that distinct interpreted nodes denote distinct values.
+      if node.interpreted then
+        assert! (← Sym.Canon.normNumLit? node.self).isNone
       if node.isRoot then
         checkEqc node
     if expensive then

--- a/tests/elab/grind_14521.lean
+++ b/tests/elab/grind_14521.lean
@@ -1,0 +1,54 @@
+/-!
+Tests that the canonicalizer maps all spellings of the same bit-vector literal (e.g. `1#1`
+and `(1 : BitVec 1)`) to a single representation before they reach the E-graph. Two
+representations of the same value used to reach the E-graph as distinct interpreted nodes,
+and `grind` produced an invalid inconsistency proof rejected by the kernel with
+`eq_false_of_decide (eagerReduce (Eq.refl false))`. See #14521. `grind.debug` enables the
+E-graph invariant check that all interpreted nodes are in canonical form.
+-/
+
+set_option grind.debug true
+
+example (i : BitVec (id 32)) (hne : i ≠ 0#32) : i ≠ 0 := by
+  grind
+
+/-!
+Example reported on Zulip: `1#1` occurs inside the `match`-conditions of the negated goal
+and is not normalized to the `OfNat.ofNat` representation used by the `BitVec` literal
+propagators.
+-/
+
+inductive MyInt (w : Nat) where
+  | poison
+  | val (v : BitVec w)
+
+namespace MyInt
+
+def isPoison {w : Nat} : MyInt w → Bool
+  | .poison => true
+  | .val _ => false
+
+def getValue {w : Nat} (x : MyInt w) (h : x.isPoison = false := by grind) : BitVec w :=
+  match x, h with
+  | .val v, _ => v
+
+def select {w : Nat} (c : MyInt 1) (x y : MyInt w) : MyInt w :=
+  match c with
+  | .val c' => if c' == 1#1 then x else y
+  | .poison => .poison
+
+@[grind =]
+theorem isPoison_select {w : Nat} (x y : MyInt w) (c : MyInt 1) :
+    (select c x y).isPoison =
+      if h : c.isPoison = true then true
+      else if c.getValue = 1#1 then x.isPoison else y.isPoison := by
+  cases c with
+  | poison => simp [select, isPoison]
+  | val c' => by_cases hc : c' = 1#1 <;> simp [select, isPoison, hc, getValue]
+
+theorem getValue_select {w : Nat} (x y : MyInt w) (c : MyInt 1) (h : (select c x y).isPoison = false) :
+    (select c x y).getValue h = if _ : c.getValue = 1#1 then x.getValue else y.getValue := by
+  simp [select, getValue]
+  grind
+
+end MyInt

--- a/tests/elab/grind_lit_canon.lean
+++ b/tests/elab/grind_lit_canon.lean
@@ -1,0 +1,41 @@
+/-!
+Tests that the canonicalizer (`Sym.Canon.normNumLit?`) maps all spellings of the same
+numeric literal of a wrapping type (`BitVec`, `Fin`, `UInt8`/…/`UInt64`) to a single
+representation before they reach the E-graph: `BitVec.ofNat`/`BitVec.ofNatLT`/`Fin.ofNat`
+spellings are converted to `OfNat.ofNat`, and out-of-range numerals are reduced modulo the
+type's cardinality. Two representations of the same value used to reach the E-graph as
+distinct interpreted nodes, and `grind` produced an invalid inconsistency proof rejected
+by the kernel. `grind.debug` enables the E-graph invariant check that all interpreted
+nodes are in canonical form.
+-/
+
+set_option linter.unusedVariables false
+set_option grind.debug true
+
+/-! `Fin.ofNat` vs `OfNat.ofNat` -/
+
+example (x : Fin 3) (h1 : x = Fin.ofNat 3 2) (h2 : x = (2 : Fin 3)) : True := by grind
+example (x : Fin 3) (h1 : x = Fin.ofNat 3 2) : x = (2 : Fin 3) := by grind
+example (x : Fin 3) (h1 : x = Fin.ofNat 3 5) : x = (2 : Fin 3) := by grind
+example (x : Fin 3) (h1 : x = Fin.ofNat 3 2) (h2 : x = (1 : Fin 3)) : False := by grind
+
+/-! Out-of-range `Fin` literals -/
+
+example (x : Fin 3) (h1 : x = (5 : Fin 3)) : x = (2 : Fin 3) := by grind
+example (x : Fin 3) (h1 : x = (5 : Fin 3)) (h2 : x = (1 : Fin 3)) : False := by grind
+
+/-! Out-of-range `UInt8`/…/`UInt64` literals -/
+
+example (x : UInt8) (h1 : x = (300 : UInt8)) (h2 : x = (44 : UInt8)) : True := by grind
+example (x : UInt8) (h1 : x = (300 : UInt8)) : x = (44 : UInt8) := by grind
+example (x : UInt8) (h1 : x = (300 : UInt8)) (h2 : x = (45 : UInt8)) : False := by grind
+example (x : UInt16) (h1 : x = (70000 : UInt16)) : x = (4464 : UInt16) := by grind
+example (x : UInt32) (h1 : x = (4294967296 : UInt32)) : x = (0 : UInt32) := by grind
+example (x : UInt64) (h1 : x = (18446744073709551616 : UInt64)) : x = (0 : UInt64) := by grind
+example (x : Int8) (h1 : x = (300 : Int8)) : x = (44 : Int8) := by grind
+example (x : Int16) (h1 : x = (70000 : Int16)) : x = (4464 : Int16) := by grind
+
+/-! Out-of-range `BitVec` `OfNat` literal hidden in a `dite` `Decidable` instance -/
+
+example (x : BitVec 4) (h1 : x = (17 : BitVec 4)) :
+    (if x = (1 : BitVec 4) then 0 else 1) = 0 := by grind


### PR DESCRIPTION
This PR fixes literal canonicalization in `grind`.

Closes #14521
