### PR TITLE
feat: mark the intrinsic verification syntax as experimental

### DIFF
--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -142,6 +142,8 @@ private def mkForInWithInvariant (invClause : Syntax) (h? : Option Syntax)
 @[builtin_doElem_elab Lean.Parser.Term.doFor] def elabDoFor : DoElab := fun stx dec => do
   let `(doFor| for%$tk $[$h? : ]? $x:ident in $xs $[$inv?:doForInvariant]? do $body) := stx
     | throwUnsupportedSyntax
+  if let some invClause := inv? then
+    warnIntrinsicExperimental invClause.raw[0] m!"`invariant` clause"
   let dec ← dec.ensureUnitAt tk
   checkMutVarsForShadowing #[x]
   let uα ← mkFreshLevelMVar

--- a/src/Lean/Elab/Do/Basic.lean
+++ b/src/Lean/Elab/Do/Basic.lean
@@ -23,6 +23,22 @@ builtin_initialize registerTraceClass `Elab.do
 builtin_initialize registerTraceClass `Elab.do.match
 builtin_initialize registerTraceClass `Elab.do.step
 
+register_builtin_option experimental.intrinsic : Bool := {
+  defValue := false
+  descr := "acknowledge that the intrinsic verification syntax (the contract clauses of a `def`, \
+the `assert` element, and the `invariant` clause of a loop) is experimental and subject to change; \
+`true` silences the warning that each of these forms reports"
+}
+
+/-- Report that an intrinsic verification form is experimental, at the keyword `kw` that introduces
+it. `what` names the form, as in ``m!"`assert` element"``. -/
+def warnIntrinsicExperimental [Monad m] [MonadLog m] [AddMessageContext m] [MonadOptions m]
+    (kw : Syntax) (what : MessageData) : m Unit := do
+  unless experimental.intrinsic.get (← getOptions) do
+    logWarningAt kw m!"The {what} is part of the experimental intrinsic verification syntax; \
+      `set_option experimental.intrinsic true` acknowledges its experimental status and silences \
+      this warning."
+
 structure MonadInfo where
   /-- The inferred type of the monad of type `Type u → Type v`. -/
   m : Expr

--- a/src/Lean/Elab/Tactic/Do/Contract.lean
+++ b/src/Lean/Elab/Tactic/Do/Contract.lean
@@ -9,6 +9,7 @@ prelude
 public import Std.Tactic.Do.Syntax
 public import Std.Internal.Do
 public import Lean.Elab.Util
+public import Lean.Elab.Command
 public import Lean.Elab.Do.Basic
 import Lean.DocString.Extension
 meta import Lean.Parser.Command
@@ -75,6 +76,12 @@ private def extractSpecSection (v : Syntax) : MacroM (Option Syntax × Syntax) :
   let wf' := wf.setArg 2 (mkNullNode others)
   return (some specs[0]![3], setPath v path (mkNullNode #[wd.setArg 2 (mkNullNode #[wf'])]))
 
+/-- The marker command carrying a `def`'s contract clauses to `elabContractNotice`, which reports
+their experimental status from a monad that can read options and log. It reuses the
+`contractDeclVal` kind, which is never itself a command, and drops the definition's value. -/
+private def mkContractNotice (val : Syntax) : Syntax :=
+  mkNode ``Lean.Parser.Command.contractDeclVal (val.getArgs.pop.push (mkNullNode #[]))
+
 /-- Expand a `def` carrying `requires`/`ensures` clauses into the plain `def` plus a spec theorem
 `@[spec] theorem f.spec : ⦃P⦄ f args ⦃fun b => Q⦄` proved by `vcgen`. A
 `where finally | spec => steps` section supplies `grind`-mode steps for the verification
@@ -137,7 +144,16 @@ discharge them in a `where finally | spec => ...` section of the definition"⟩
       first
       | done
       | fail $msg)
-  return mkNullNode #[cleanDeclaration, thm]
+  return mkNullNode #[mkContractNotice val, cleanDeclaration, thm]
+
+open Lean.Elab.Do in
+/-- Report the experimental status of each contract clause the notice carries. -/
+@[builtin_command_elab Lean.Parser.Command.contractDeclVal]
+def elabContractNotice : Elab.Command.CommandElab := fun stx => do
+  for clause in stx.getArgs.pop do
+    unless clause.isNone do
+      let kw := clause[0][0]
+      warnIntrinsicExperimental kw m!"`{kw.getAtomVal}` clause"
 
 open Lean.Elab.Do Lean.Parser.Term in
 @[builtin_doElem_elab Lean.Parser.Term.doAssertion]
@@ -150,6 +166,7 @@ def elabDoAssertion : DoElab := fun stx dec => do
   unless (← getEnv).contains ``assertGadget do
     throwErrorAt tk
       "the `assert` element elaborates to a `vcgen` gadget; add `import Std.Internal.Do` to use it."
+  warnIntrinsicExperimental tk m!"`assert` element"
   let dec ← dec.ensureUnitAt tk
   let e ← Term.elabTermEnsuringType (← `($(mkCIdent ``assertGadget) $as)) (← mkMonadApp (← mkPUnit))
   dec.mkBindUnlessPure e

--- a/tests/elab/experimentalIntrinsic.lean
+++ b/tests/elab/experimentalIntrinsic.lean
@@ -1,0 +1,67 @@
+import Std.Internal.Do
+
+/-!
+Every form of the intrinsic verification syntax reports that it is experimental, at the keyword that
+introduces the form, and `set_option experimental.intrinsic true` silences those reports.
+-/
+
+open Std.Internal.Do
+
+set_option mvcgen.warning false
+
+/--
+warning: The `requires` clause is part of the experimental intrinsic verification syntax; `set_option experimental.intrinsic true` acknowledges its experimental status and silences this warning.
+---
+warning: The `ensures` clause is part of the experimental intrinsic verification syntax; `set_option experimental.intrinsic true` acknowledges its experimental status and silences this warning.
+-/
+#guard_msgs in
+def identity (n : Nat) : Id Nat
+    requires True
+    ensures r => r = n :=
+  pure n
+
+/--
+warning: The `ensures` clause is part of the experimental intrinsic verification syntax; `set_option experimental.intrinsic true` acknowledges its experimental status and silences this warning.
+---
+warning: The `assert` element is part of the experimental intrinsic verification syntax; `set_option experimental.intrinsic true` acknowledges its experimental status and silences this warning.
+-/
+#guard_msgs in
+def double (n : Nat) : Id Nat
+    ensures r => r = n + n := do
+  let d := n + n
+  assert d = n + n
+  return d
+
+/--
+warning: The `invariant` clause is part of the experimental intrinsic verification syntax; `set_option experimental.intrinsic true` acknowledges its experimental status and silences this warning.
+-/
+#guard_msgs in
+def sum (xs : List Nat) : Id Nat := do
+  let mut acc := 0
+  for _x in xs invariant _pref _suff => 0 ≤ acc do
+    acc := acc + 1
+  return acc
+
+/-! Acknowledging the experimental status silences every form. -/
+
+set_option experimental.intrinsic true
+
+#guard_msgs in
+def identity' (n : Nat) : Id Nat
+    requires True
+    ensures r => r = n :=
+  pure n
+
+#guard_msgs in
+def double' (n : Nat) : Id Nat
+    ensures r => r = n + n := do
+  let d := n + n
+  assert d = n + n
+  return d
+
+#guard_msgs in
+def sum' (xs : List Nat) : Id Nat := do
+  let mut acc := 0
+  for _x in xs invariant _pref _suff => 0 ≤ acc do
+    acc := acc + 1
+  return acc

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -6,6 +6,7 @@ definition plus an `@[spec]`-tagged `f.spec` Hoare triple that `vcgen` proves au
 `for … invariant` clause inside the body supplies the loop invariant it needs. New cases go here. -/
 
 set_option mvcgen.warning false
+set_option experimental.intrinsic true
 
 /-! ## Contracts elaborate with nothing opened
 

--- a/tests/elab/intrinsicVerificationMissingImport.lean
+++ b/tests/elab/intrinsicVerificationMissingImport.lean
@@ -2,6 +2,8 @@
 metatheory reports a helpful error naming the missing import, rather than a downstream elaboration
 failure. -/
 
+set_option experimental.intrinsic true
+
 /--
 error: `requires`/`ensures` contracts elaborate to a `vcgen`-proved specification theorem; add `import Std.Internal.Do` to use them.
 -/


### PR DESCRIPTION
This PR backports #14826, which warns that the intrinsic verification syntax is experimental and adds `set_option experimental.intrinsic true` to silence the warning.

The release branch has diverged from master in three ways, so the diff differs:

* The loop `decreasing` clause does not exist here, so that warning site is absent and the option's description omits it.
* The loop invariant clause is `doForInvariant` rather than `doLoopInvariant`, and there is no `mkForInLoopGadget`, so the warning is emitted from `elabDoFor`.
* The library is `Std.Internal.Do` rather than `Std.WP`.

The option name and the warning wording match master, so a user moving between versions sets the same option.