### PR TITLE
fix: add missing terminfo on structure fields

### DIFF
--- a/src/Init/Data/Vector/Basic.lean
+++ b/src/Init/Data/Vector/Basic.lean
@@ -28,6 +28,8 @@ public section
 set_option linter.listVariables true -- Enforce naming conventions for `List`/`Array`/`Vector` variables.
 set_option linter.indexVariables true -- Enforce naming conventions for index variables.
 
+-- Disable linter for the `toArray` field
+set_option linter.listVariables false in
 /-- `Vector α n` is an `Array α` with size `n`. -/
 structure Vector (α : Type u) (n : Nat) where
   /-- The underlying array. -/

--- a/src/Lean/Elab/Structure.lean
+++ b/src/Lean/Elab/Structure.lean
@@ -1035,6 +1035,7 @@ where
                          numBinders, fvar := fieldFVar, default? := none,
                          binfo := view.binderInfo, paramInfoOverrides,
                          kind := StructFieldKind.newField }
+          Term.addTermInfo' view.nameId fieldFVar (isBinder := true)
           withExporting (isExporting := wasExporting) do
             go (i+1)
       | some info =>

--- a/src/Lean/Elab/Structure.lean
+++ b/src/Lean/Elab/Structure.lean
@@ -1580,16 +1580,18 @@ def elabStructureCommand : InductiveElabDescr where
                   -- Add field docstrings here (after @[class] attribute is applied)
                   -- so that Verso docstrings can use the class.
                   for field in view.fields do
-                    -- may not exist if overriding inherited field
-                    if (← getEnv).contains field.declName then
-                      if let some doc := field.modifiers.docString? then
-                        addDocString field.declName field.binders doc
+                    withoutExporting (when := isPrivateName field.declName) do
+                      -- may not exist if overriding inherited field
+                      if (← getEnv).contains field.declName then
+                        if let some doc := field.modifiers.docString? then
+                          addDocString field.declName field.binders doc
                   -- Add terminfo after docstrings so hovers include the docstring.
                   withSaveInfoContext do
                     for field in view.fields do
-                      -- may not exist if overriding inherited field
-                      if (← getEnv).contains field.declName then
-                        Term.addTermInfo' field.ref (← mkConstWithLevelParams field.declName) (isBinder := true)
+                      withoutExporting (when := isPrivateName field.declName) do
+                        -- may not exist if overriding inherited field
+                        if (← getEnv).contains field.declName then
+                          Term.addTermInfo' field.ref (← mkConstWithLevelParams field.declName) (isBinder := true)
                     -- Add terminfo for parents now that all parent projections exist.
                     for parent in parents do
                       if parent.addTermInfo then

--- a/src/Lean/Linter/ConstructorAsVariable.lean
+++ b/src/Lean/Linter/ConstructorAsVariable.lean
@@ -41,6 +41,7 @@ def constructorNameAsVariable : Linter where
 
     let infoTrees := (← get).infoState.trees.toArray
     let warnings : IO.Ref (Std.HashMap Lean.Syntax.Range (Syntax × Name × Name)) ← IO.mkRef {}
+    let constRanges : IO.Ref (Std.HashSet Lean.Syntax.Range) ← IO.mkRef {}
 
     for tree in infoTrees do
       tree.visitM' (postNode := fun ci info _ => do
@@ -77,13 +78,20 @@ def constructorNameAsVariable : Linter where
                         if cn == s then
                           warnings.modify (·.insert range (info.stx, n, c))
             else pure ()
+          | .const .. =>
+            let some range := info.range? | return
+            let .original .. := info.stx.getHeadInfo | return
+            if ti.isBinder then
+              constRanges.modify fun s => s.insert range
           | _ => pure ()
         | _ => pure ())
 
-    -- Sort the outputs by position
-    for (_range, declStx, userName, ctorName) in (← warnings.get).toArray.qsort (·.1.start < ·.1.start) do
-      logLint linter.constructorNameAsVariable declStx <|
-        m!"Local variable '{userName}' resembles constructor '{ctorName}' - " ++
-        m!"write '.{userName}' (with a dot) or '{ctorName}' to use the constructor."
+    -- Sort the outputs by position, excluding those that are also defining global constants.
+    -- Global constants occur for example in `structure` fields
+    for (range, declStx, userName, ctorName) in (← warnings.get).toArray.qsort (·.1.start < ·.1.start) do
+      unless (← constRanges.get).contains range do
+        logLint linter.constructorNameAsVariable declStx <|
+          m!"Local variable '{userName}' resembles constructor '{ctorName}' - " ++
+          m!"write '.{userName}' (with a dot) or '{ctorName}' to use the constructor."
 
 builtin_initialize addLinter constructorNameAsVariable

--- a/tests/elab/structure.lean
+++ b/tests/elab/structure.lean
@@ -1,4 +1,7 @@
-import Lean
+module
+public import Lean
+
+public section
 
 open Lean
 
@@ -150,6 +153,36 @@ parent infos: #[(A1, (true, A5.toA1))]
 -/
 #guard_msgs in #eval dumpStructInfo `A5
 
+/-!
+Regression test: make sure unused `private` fields are not linted as unused.
+-/
+section
+set_option linter.unusedVariables true
+
+structure Unused1 where
+  private x : Nat
+  y : Nat
+class Unused2 where
+  private x : Nat
+  y : Nat
+
+structure State where
+  macroScope : MacroScope
+  private expandedMacroDecls : List Name := List.nil
+
+end
+
+/-!
+Regression test: make sure fields that look like constructor names are not linted.
+-/
+section
+set_option linter.constructorNameAsVariable true
+
+-- Used to say "Local variable 'zero' resembles constructor 'Nat.zero'"
+structure CtorLikeField where
+  zero : Nat
+
+end
 
 /-!
 Regression test: make sure mathlib `Type*` still elaborates with levels in correct order.

--- a/tests/server_interactive/structGoTo.lean
+++ b/tests/server_interactive/structGoTo.lean
@@ -27,8 +27,9 @@ structure SInvalid where
   a : Nat
 --^ textDocument/hover
   a : Nat
---^ collectDiagnostics
 
 -- Check that the structure is never added to the environment:
 #check SInvalid
-      --^ collectDiagnostics
+
+--^ collectDiagnostics
+--

--- a/tests/server_interactive/structGoTo.lean
+++ b/tests/server_interactive/structGoTo.lean
@@ -2,6 +2,8 @@
 # Testing "go to definition" for `structure` fields
 -/
 
+--^ collectDiagnostics
+
 structure S where
   a : Nat
   /- Dependence in type -/
@@ -30,6 +32,3 @@ structure SInvalid where
 
 -- Check that the structure is never added to the environment:
 #check SInvalid
-
---^ collectDiagnostics
---

--- a/tests/server_interactive/structGoTo.lean
+++ b/tests/server_interactive/structGoTo.lean
@@ -1,5 +1,5 @@
 /-!
-# Testing "go to definition" for `structure`
+# Testing "go to definition" for `structure` fields
 -/
 
 structure S where
@@ -11,12 +11,6 @@ structure S where
   c : Nat := a + b
            --^ textDocument/definition
                --^ textDocument/definition
-
-/-!
-"Go to definition" for the structure itself
--/
-example := S
-         --^ textDocument/definition
 
 /-!
 "Go to definition" for a field

--- a/tests/server_interactive/structGoTo.lean
+++ b/tests/server_interactive/structGoTo.lean
@@ -17,3 +17,18 @@ structure S where
 -/
 example (s : S) := s.b
                    --^ textDocument/definition
+
+/-!
+The field terminfo is still available even if there is an exception during elaboration.
+Field redeclaration currently throws an exception, preventing the step where the projection
+terminfos are added (and preventing adding the structure to the environment).
+-/
+structure SInvalid where
+  a : Nat
+--^ textDocument/hover
+  a : Nat
+--^ collectDiagnostics
+
+-- Check that the structure is never added to the environment:
+#check SInvalid
+      --^ collectDiagnostics

--- a/tests/server_interactive/structGoTo.lean
+++ b/tests/server_interactive/structGoTo.lean
@@ -1,0 +1,25 @@
+/-!
+# Testing "go to definition" for `structure`
+-/
+
+structure S where
+  a : Nat
+  /- Dependence in type -/
+  b : Fin a
+        --^ textDocument/definition
+  /- Dependence in default value. -/
+  c : Nat := a + b
+           --^ textDocument/definition
+               --^ textDocument/definition
+
+/-!
+"Go to definition" for the structure itself
+-/
+example := S
+         --^ textDocument/definition
+
+/-!
+"Go to definition" for a field
+-/
+example (s : S) := s.b
+                   --^ textDocument/definition

--- a/tests/server_interactive/structGoTo.lean.out.expected
+++ b/tests/server_interactive/structGoTo.lean.out.expected
@@ -57,10 +57,10 @@
   {"source": "Lean 4",
    "severity": 1,
    "range":
-   {"start": {"line": 32, "character": 7},
-    "end": {"line": 32, "character": 15}},
+   {"start": {"line": 31, "character": 7},
+    "end": {"line": 31, "character": 15}},
    "message": "Unknown identifier `SInvalid`",
    "fullRange":
-   {"start": {"line": 32, "character": 7},
-    "end": {"line": 32, "character": 15}},
+   {"start": {"line": 31, "character": 7},
+    "end": {"line": 31, "character": 15}},
    "code": "lean.unknownIdentifier"}]}

--- a/tests/server_interactive/structGoTo.lean.out.expected
+++ b/tests/server_interactive/structGoTo.lean.out.expected
@@ -1,47 +1,3 @@
-{"textDocument": {"uri": "file:///structGoTo.lean"},
- "position": {"line": 7, "character": 10}}
-[{"targetUri": "file:///structGoTo.lean",
-  "targetSelectionRange":
-  {"start": {"line": 5, "character": 2}, "end": {"line": 5, "character": 3}},
-  "targetRange":
-  {"start": {"line": 5, "character": 2}, "end": {"line": 5, "character": 3}},
-  "originSelectionRange":
-  {"start": {"line": 7, "character": 10}, "end": {"line": 7, "character": 11}}}]
-{"textDocument": {"uri": "file:///structGoTo.lean"},
- "position": {"line": 10, "character": 13}}
-[{"targetUri": "file:///structGoTo.lean",
-  "targetSelectionRange":
-  {"start": {"line": 5, "character": 2}, "end": {"line": 5, "character": 3}},
-  "targetRange":
-  {"start": {"line": 5, "character": 2}, "end": {"line": 5, "character": 3}},
-  "originSelectionRange":
-  {"start": {"line": 10, "character": 13},
-   "end": {"line": 10, "character": 14}}}]
-{"textDocument": {"uri": "file:///structGoTo.lean"},
- "position": {"line": 10, "character": 17}}
-[{"targetUri": "file:///structGoTo.lean",
-  "targetSelectionRange":
-  {"start": {"line": 7, "character": 2}, "end": {"line": 7, "character": 3}},
-  "targetRange":
-  {"start": {"line": 7, "character": 2}, "end": {"line": 7, "character": 3}},
-  "originSelectionRange":
-  {"start": {"line": 10, "character": 17},
-   "end": {"line": 10, "character": 18}}}]
-{"textDocument": {"uri": "file:///structGoTo.lean"},
- "position": {"line": 17, "character": 21}}
-[{"targetUri": "file:///structGoTo.lean",
-  "targetSelectionRange":
-  {"start": {"line": 7, "character": 2}, "end": {"line": 7, "character": 3}},
-  "targetRange":
-  {"start": {"line": 7, "character": 2}, "end": {"line": 7, "character": 3}},
-  "originSelectionRange":
-  {"start": {"line": 17, "character": 21},
-   "end": {"line": 17, "character": 22}}}]
-{"textDocument": {"uri": "file:///structGoTo.lean"},
- "position": {"line": 26, "character": 2}}
-{"range":
- {"start": {"line": 26, "character": 2}, "end": {"line": 26, "character": 3}},
- "contents": {"value": "```lean\na : Nat\n```", "kind": "markdown"}}
 {"version": 1,
  "uri": "file:///structGoTo.lean",
  "isIncremental": false,
@@ -49,18 +5,62 @@
  [{"source": "Lean 4",
    "severity": 1,
    "range":
-   {"start": {"line": 28, "character": 2}, "end": {"line": 28, "character": 3}},
+   {"start": {"line": 30, "character": 2}, "end": {"line": 30, "character": 3}},
    "message": "Field `a` has already been declared",
    "fullRange":
-   {"start": {"line": 28, "character": 2},
-    "end": {"line": 28, "character": 3}}},
+   {"start": {"line": 30, "character": 2},
+    "end": {"line": 30, "character": 3}}},
   {"source": "Lean 4",
    "severity": 1,
    "range":
-   {"start": {"line": 31, "character": 7},
-    "end": {"line": 31, "character": 15}},
+   {"start": {"line": 33, "character": 7},
+    "end": {"line": 33, "character": 15}},
    "message": "Unknown identifier `SInvalid`",
    "fullRange":
-   {"start": {"line": 31, "character": 7},
-    "end": {"line": 31, "character": 15}},
+   {"start": {"line": 33, "character": 7},
+    "end": {"line": 33, "character": 15}},
    "code": "lean.unknownIdentifier"}]}
+{"textDocument": {"uri": "file:///structGoTo.lean"},
+ "position": {"line": 9, "character": 10}}
+[{"targetUri": "file:///structGoTo.lean",
+  "targetSelectionRange":
+  {"start": {"line": 7, "character": 2}, "end": {"line": 7, "character": 3}},
+  "targetRange":
+  {"start": {"line": 7, "character": 2}, "end": {"line": 7, "character": 3}},
+  "originSelectionRange":
+  {"start": {"line": 9, "character": 10}, "end": {"line": 9, "character": 11}}}]
+{"textDocument": {"uri": "file:///structGoTo.lean"},
+ "position": {"line": 12, "character": 13}}
+[{"targetUri": "file:///structGoTo.lean",
+  "targetSelectionRange":
+  {"start": {"line": 7, "character": 2}, "end": {"line": 7, "character": 3}},
+  "targetRange":
+  {"start": {"line": 7, "character": 2}, "end": {"line": 7, "character": 3}},
+  "originSelectionRange":
+  {"start": {"line": 12, "character": 13},
+   "end": {"line": 12, "character": 14}}}]
+{"textDocument": {"uri": "file:///structGoTo.lean"},
+ "position": {"line": 12, "character": 17}}
+[{"targetUri": "file:///structGoTo.lean",
+  "targetSelectionRange":
+  {"start": {"line": 9, "character": 2}, "end": {"line": 9, "character": 3}},
+  "targetRange":
+  {"start": {"line": 9, "character": 2}, "end": {"line": 9, "character": 3}},
+  "originSelectionRange":
+  {"start": {"line": 12, "character": 17},
+   "end": {"line": 12, "character": 18}}}]
+{"textDocument": {"uri": "file:///structGoTo.lean"},
+ "position": {"line": 19, "character": 21}}
+[{"targetUri": "file:///structGoTo.lean",
+  "targetSelectionRange":
+  {"start": {"line": 9, "character": 2}, "end": {"line": 9, "character": 3}},
+  "targetRange":
+  {"start": {"line": 9, "character": 2}, "end": {"line": 9, "character": 3}},
+  "originSelectionRange":
+  {"start": {"line": 19, "character": 21},
+   "end": {"line": 19, "character": 22}}}]
+{"textDocument": {"uri": "file:///structGoTo.lean"},
+ "position": {"line": 28, "character": 2}}
+{"range":
+ {"start": {"line": 28, "character": 2}, "end": {"line": 28, "character": 3}},
+ "contents": {"value": "```lean\na : Nat\n```", "kind": "markdown"}}

--- a/tests/server_interactive/structGoTo.lean.out.expected
+++ b/tests/server_interactive/structGoTo.lean.out.expected
@@ -37,3 +37,30 @@
   "originSelectionRange":
   {"start": {"line": 17, "character": 21},
    "end": {"line": 17, "character": 22}}}]
+{"textDocument": {"uri": "file:///structGoTo.lean"},
+ "position": {"line": 26, "character": 2}}
+{"range":
+ {"start": {"line": 26, "character": 2}, "end": {"line": 26, "character": 3}},
+ "contents": {"value": "```lean\na : Nat\n```", "kind": "markdown"}}
+{"version": 1,
+ "uri": "file:///structGoTo.lean",
+ "isIncremental": false,
+ "diagnostics":
+ [{"source": "Lean 4",
+   "severity": 1,
+   "range":
+   {"start": {"line": 28, "character": 2}, "end": {"line": 28, "character": 3}},
+   "message": "Field `a` has already been declared",
+   "fullRange":
+   {"start": {"line": 28, "character": 2},
+    "end": {"line": 28, "character": 3}}},
+  {"source": "Lean 4",
+   "severity": 1,
+   "range":
+   {"start": {"line": 32, "character": 7},
+    "end": {"line": 32, "character": 15}},
+   "message": "Unknown identifier `SInvalid`",
+   "fullRange":
+   {"start": {"line": 32, "character": 7},
+    "end": {"line": 32, "character": 15}},
+   "code": "lean.unknownIdentifier"}]}

--- a/tests/server_interactive/structGoTo.lean.out.expected
+++ b/tests/server_interactive/structGoTo.lean.out.expected
@@ -1,0 +1,49 @@
+{"textDocument": {"uri": "file:///structGoTo.lean"},
+ "position": {"line": 7, "character": 10}}
+[{"targetUri": "file:///structGoTo.lean",
+  "targetSelectionRange":
+  {"start": {"line": 5, "character": 2}, "end": {"line": 5, "character": 3}},
+  "targetRange":
+  {"start": {"line": 5, "character": 2}, "end": {"line": 5, "character": 3}},
+  "originSelectionRange":
+  {"start": {"line": 7, "character": 10}, "end": {"line": 7, "character": 11}}}]
+{"textDocument": {"uri": "file:///structGoTo.lean"},
+ "position": {"line": 10, "character": 13}}
+[{"targetUri": "file:///structGoTo.lean",
+  "targetSelectionRange":
+  {"start": {"line": 5, "character": 2}, "end": {"line": 5, "character": 3}},
+  "targetRange":
+  {"start": {"line": 5, "character": 2}, "end": {"line": 5, "character": 3}},
+  "originSelectionRange":
+  {"start": {"line": 10, "character": 13},
+   "end": {"line": 10, "character": 14}}}]
+{"textDocument": {"uri": "file:///structGoTo.lean"},
+ "position": {"line": 10, "character": 17}}
+[{"targetUri": "file:///structGoTo.lean",
+  "targetSelectionRange":
+  {"start": {"line": 7, "character": 2}, "end": {"line": 7, "character": 3}},
+  "targetRange":
+  {"start": {"line": 7, "character": 2}, "end": {"line": 7, "character": 3}},
+  "originSelectionRange":
+  {"start": {"line": 10, "character": 17},
+   "end": {"line": 10, "character": 18}}}]
+{"textDocument": {"uri": "file:///structGoTo.lean"},
+ "position": {"line": 17, "character": 11}}
+[{"targetUri": "file:///structGoTo.lean",
+  "targetSelectionRange":
+  {"start": {"line": 4, "character": 10}, "end": {"line": 4, "character": 11}},
+  "targetRange":
+  {"start": {"line": 4, "character": 0}, "end": {"line": 10, "character": 18}},
+  "originSelectionRange":
+  {"start": {"line": 17, "character": 11},
+   "end": {"line": 17, "character": 12}}}]
+{"textDocument": {"uri": "file:///structGoTo.lean"},
+ "position": {"line": 23, "character": 21}}
+[{"targetUri": "file:///structGoTo.lean",
+  "targetSelectionRange":
+  {"start": {"line": 7, "character": 2}, "end": {"line": 7, "character": 3}},
+  "targetRange":
+  {"start": {"line": 7, "character": 2}, "end": {"line": 7, "character": 3}},
+  "originSelectionRange":
+  {"start": {"line": 23, "character": 21},
+   "end": {"line": 23, "character": 22}}}]

--- a/tests/server_interactive/structGoTo.lean.out.expected
+++ b/tests/server_interactive/structGoTo.lean.out.expected
@@ -28,22 +28,12 @@
   {"start": {"line": 10, "character": 17},
    "end": {"line": 10, "character": 18}}}]
 {"textDocument": {"uri": "file:///structGoTo.lean"},
- "position": {"line": 17, "character": 11}}
-[{"targetUri": "file:///structGoTo.lean",
-  "targetSelectionRange":
-  {"start": {"line": 4, "character": 10}, "end": {"line": 4, "character": 11}},
-  "targetRange":
-  {"start": {"line": 4, "character": 0}, "end": {"line": 10, "character": 18}},
-  "originSelectionRange":
-  {"start": {"line": 17, "character": 11},
-   "end": {"line": 17, "character": 12}}}]
-{"textDocument": {"uri": "file:///structGoTo.lean"},
- "position": {"line": 23, "character": 21}}
+ "position": {"line": 17, "character": 21}}
 [{"targetUri": "file:///structGoTo.lean",
   "targetSelectionRange":
   {"start": {"line": 7, "character": 2}, "end": {"line": 7, "character": 3}},
   "targetRange":
   {"start": {"line": 7, "character": 2}, "end": {"line": 7, "character": 3}},
   "originSelectionRange":
-  {"start": {"line": 23, "character": 21},
-   "end": {"line": 23, "character": 22}}}]
+  {"start": {"line": 17, "character": 21},
+   "end": {"line": 17, "character": 22}}}]


### PR DESCRIPTION
This PR adds terminfo on `structure`/`class` fields so that "go to definition" on dependent usages of a field goes to the field's definition. This also helps with finding uses of a field in a `structure` definition. The PR additionally fixes a bug where terminfo and docstrings weren't applied to private fields of public structures when using the module system.

With @berberman

Note: fields used through an `extends` clause do not yet have the necessary terminfo to support "go to definition". This possibly requires a new kind of info node to link the fvars in the local context of the child `structure` to the projection functions of the parent.