### PR TITLE
feat: lake: make job cancellation a first-class JobState flag

### DIFF
--- a/src/lake/Lake/Build/Job/Basic.lean
+++ b/src/lake/Lake/Build/Job/Basic.lean
@@ -74,6 +74,8 @@ public structure JobState where
   action : JobAction := .unknown
   /-- Whether this job failed due to a request to rebuild for `--no-build`. -/
   wantsRebuild : Bool := false
+  /-- Whether this job was cut short by the build's cancellation token (see `BuildConfig.failFast`). -/
+  canceled : Bool := false
   /-- Current trace of a build job. -/
   trace : BuildTrace := .nil
   /-- How long the job spent building (in milliseconds). -/
@@ -84,6 +86,7 @@ public def JobState.merge (a b : JobState) : JobState where
   log := a.log ++ b.log
   action := a.action.merge b.action
   wantsRebuild := a.wantsRebuild || b.wantsRebuild
+  canceled := a.canceled || b.canceled
   trace := mixTrace a.trace b.trace
   buildTime := a.buildTime + b.buildTime
 
@@ -105,25 +108,13 @@ public def JobResult.prependLog (log : Log) (self : JobResult α) : JobResult α
   | .error e s => .error ⟨log.size + e.val⟩ <| s.modifyLog (log ++ ·)
 
 /--
-**For internal use only.**
-Log message marking a job continuation canceled by the build's cancellation
-token. Do not match this directly; use `JobResult.isCanceled`.
+Whether this result was cut short by cancellation rather than by a failure
+of its own. A result that carries a genuine failure in its log is a failure,
+even if it was also canceled; use `JobResult.isCanceled` only after checking
+for failure (as the monitor does).
 -/
-public def cancelMessage : String := "canceled after earlier build failure"
-
-/--
-Whether this result is a cancellation.
-
-Also correct on merged results (e.g., from `zipResultWith`, `mix`,
-`collectArray`): a result that contains both a genuine failure and
-cancellations is classified as failed.
--/
-public def JobResult.isCanceled : JobResult α → Bool
-  | .error _ s =>
-    -- Scan the log, not the entry at the error position: merges concatenate
-    -- logs but reset the position. Assumes failures log at error level.
-    s.log.maxLv < .error &&
-    s.log.any fun e => e.level == .trace && e.message == cancelMessage
+@[inline] public def JobResult.isCanceled : JobResult α → Bool
+  | .error _ s => s.canceled
   | .ok .. => false
 
 /-- The `Task` of a Lake job. -/

--- a/src/lake/Lake/Build/Job/Monad.lean
+++ b/src/lake/Lake/Build/Job/Monad.lean
@@ -192,6 +192,20 @@ public protected def await (self : Job α) : LogIO α := do
   | .error n {log, ..} => log.replay; throw n
   | .ok a {log, ..} => log.replay; pure a
 
+/-- Fail the current job as canceled (no log entry; see `JobState.canceled`). -/
+public def cancelJob : JobM α := do
+  modify ({· with canceled := true})
+  failure
+
+/--
+Like `wait?`, but a canceled job cancels the current job as well (via
+`cancelJob`), so `none` only ever means a genuine failure.
+-/
+public def waitUnlessCanceled? (self : Job α) : JobM (Option α) := do
+  match (← self.wait) with
+  | .ok a _ => return some a
+  | r@(.error ..) => if r.isCanceled then cancelJob else return none
+
 /--
 The result of a job continuation canceled by the build's cancellation token
 (see `BuildConfig.failFast`). The trace-level entry only gives `Job.await` a

--- a/src/lake/Lake/Build/Job/Monad.lean
+++ b/src/lake/Lake/Build/Job/Monad.lean
@@ -194,16 +194,12 @@ public protected def await (self : Job α) : LogIO α := do
 
 /--
 The result of a job continuation canceled by the build's cancellation token
-(see `BuildConfig.failFast`). The trace-level log entry keeps the job out of the
-failure summary while still explaining via the verbose output.
-
-Note two conventions we follow here:  
-- the monitor counts a job as failed when `log.maxLv ≥ failLv`, so entries on this path must stay
-below `failLv`
-- the result is an "ordinary" error. We provide `JobResult.isCanceled` to identify cancellations using the log.
+(see `BuildConfig.failFast`). The trace-level entry only gives `Job.await` a
+message to replay; classification uses `JobState.canceled`.
 -/
 @[inline] def canceledResult (s : JobState) : JobResult α :=
-  .error s.log.endPos (s.logEntry (.trace cancelMessage))
+  .error s.log.endPos
+    {s.logEntry (.trace "canceled after earlier build failure") with canceled := true}
 
 /--
 Apply `f` asynchronously to the job's output.

--- a/src/lake/Lake/Build/Library.lean
+++ b/src/lake/Lake/Build/Library.lean
@@ -51,13 +51,8 @@ where
       col := {col with modSet := col.modSet.insert root}
       -- Importers report failures reached through imports. Directly reached modules
       -- stay in the collection so their build jobs report those failures.
-      let imps ← match (← (← root.imports.fetch).wait) with
-        | .ok imps _ => pure imps
-        | r@(.error ..) =>
-          -- Canceled is not a bad import; the module's own job reports it.
-          if r.isCanceled then
-            return if viaImport then col else {col with mods := col.mods.push root}
-          let col' := {col with hasErrors := true}
+      let some imps ← (← root.imports.fetch).waitUnlessCanceled?
+        | let col' := {col with hasErrors := true}
           return if viaImport then col' else {col' with mods := col'.mods.push root}
       for mod in imps do
         if mod.lib.name = self.name then

--- a/src/lake/Lake/Build/Library.lean
+++ b/src/lake/Lake/Build/Library.lean
@@ -51,8 +51,13 @@ where
       col := {col with modSet := col.modSet.insert root}
       -- Importers report failures reached through imports. Directly reached modules
       -- stay in the collection so their build jobs report those failures.
-      let some imps ← (← root.imports.fetch).wait?
-        | let col' := {col with hasErrors := true}
+      let imps ← match (← (← root.imports.fetch).wait) with
+        | .ok imps _ => pure imps
+        | r@(.error ..) =>
+          -- Canceled is not a bad import; the module's own job reports it.
+          if r.isCanceled then
+            return if viaImport then col else {col with mods := col.mods.push root}
+          let col' := {col with hasErrors := true}
           return if viaImport then col' else {col' with mods := col'.mods.push root}
       for mod in imps do
         if mod.lib.name = self.name then

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -1306,12 +1306,8 @@ def recComputeModuleLinkInfo
   let mut libJobs := #[]
   for facet in root.nativeFacets shouldExport do
     objJobs := objJobs.push <| ← facet.fetch root
-  let imports ← match (← (← root.transImports.fetch).wait) with
-    | .ok imports _ => pure imports
-    | r@(.error ..) =>
-      -- Canceled is not a bad import; fail silently (the module's own job reports it).
-      if r.isCanceled then failure
-      error s!"bad imports (see the '{root.name.toString}' job for details)"
+  let some imports ← (← root.transImports.fetch).waitUnlessCanceled?
+    | error s!"bad imports (see the '{root.name.toString}' job for details)"
   for mod in imports do
     for facet in mod.nativeFacets shouldExport do
       objJobs := objJobs.push <| ← facet.fetch mod

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -1306,8 +1306,12 @@ def recComputeModuleLinkInfo
   let mut libJobs := #[]
   for facet in root.nativeFacets shouldExport do
     objJobs := objJobs.push <| ← facet.fetch root
-  let .ok imports _ ← (← root.transImports.fetch).wait
-    | error s!"bad imports (see the '{root.name.toString}' job for details)"
+  let imports ← match (← (← root.transImports.fetch).wait) with
+    | .ok imports _ => pure imports
+    | r@(.error ..) =>
+      -- Canceled is not a bad import; fail silently (the module's own job reports it).
+      if r.isCanceled then failure
+      error s!"bad imports (see the '{root.name.toString}' job for details)"
   for mod in imports do
     for facet in mod.nativeFacets shouldExport do
       objJobs := objJobs.push <| ← facet.fetch mod

--- a/src/lake/Lake/Build/Run.lean
+++ b/src/lake/Lake/Build/Run.lean
@@ -113,9 +113,10 @@ def reportJob (job : OpaqueJob) : MonitorM PUnit := do
   let {jobNo, totalJobs, ..} ← get
   let {failLv, outLv, showOptional, out, useAnsi, showProgress, minAction, showTime, ..} ← read
   let {task, caption, optional, ..} := job
-  let {log, action, wantsRebuild, buildTime, ..} := task.get.state
+  let {log, action, wantsRebuild, canceled, buildTime, ..} := task.get.state
   let maxLv := log.maxLv
   let failed := strictAnd log.hasEntries (maxLv ≥ failLv)
+  let canceled := canceled && !failed
   if wantsRebuild then
     modify fun s => if s.wantsRebuild then s else {s with wantsRebuild := true}
   if failed && !optional then
@@ -123,16 +124,16 @@ def reportJob (job : OpaqueJob) : MonitorM PUnit := do
   let hasOutput := failed || (log.hasEntries && maxLv ≥ outLv)
   let showJob :=
     (!optional || showOptional) &&
-    (hasOutput || (showProgress && !useAnsi && action ≥ minAction))
+    (hasOutput || canceled || (showProgress && !useAnsi && action ≥ minAction))
   if showJob then
-    let verb := action.verb failed
-    let icon := if hasOutput then maxLv.icon else '✔'
+    let verb := if canceled then "Canceled" else action.verb failed
+    let icon := if hasOutput then maxLv.icon else if canceled then '⊘' else '✔'
     let opt := if optional then " (Optional)" else ""
     let time := if showTime && buildTime > 0 then s!" ({formatTime buildTime})" else ""
     let caption := s!"{icon} [{jobNo}/{totalJobs}]{opt} {verb} {caption}{time}"
     let caption :=
       if useAnsi then
-        let color := if hasOutput then maxLv.ansiColor else "32"
+        let color := if hasOutput then maxLv.ansiColor else if canceled then "33" else "32"
         Ansi.chalk color caption
       else
         caption

--- a/tests/lake/tests/failFast/test.sh
+++ b/tests/lake/tests/failFast/test.sh
@@ -19,8 +19,21 @@ test_exp ! -f slowB.produced.out
 test_exp ! -f slowC.produced.out
 test_exp ! -f .lake/build/lib/lean/Slow.olean
 
-# Canceled jobs must not appear in the failure summary (their log is trace-level).
+# Canceled jobs must not appear in the failure summary.
 if grep -E '^- (slowB|slowC|Slow)$' produced.out; then
   echo "FAILURE: canceled job listed as a failure"
+  exit 1
+fi
+
+# Canceled jobs are reported as canceled: neither a failure nor a success.
+test_exp -n "$(grep -E '^⊘ .*Canceled (slowB|slowC|Slow)$' produced.out)"
+if grep -E '(✔|✖) .*(slowB|slowC|Slow)$' produced.out; then
+  echo "FAILURE: canceled job reported as built or failed"
+  exit 1
+fi
+
+# The cancellation must not be misreported as a bad import.
+if grep -E 'bad import' produced.out; then
+  echo "FAILURE: cancellation misreported as a bad import"
   exit 1
 fi


### PR DESCRIPTION
This PR makes job cancellation under `--fail-fast` a first-class notion: canceled jobs are reported as `⊘ Canceled` rather than as successes, and a canceled dependency is no longer misreported as a `bad import`.

This is the follow-up anticipated in #14797's review, where cancellation is recognized by convention (a trace-level log entry with a marker string). Here it is recorded natively as `JobState.canceled`, a per-result flag alongside the existing `wantsRebuild`, which already has exactly this shape (a per-result `Bool`, merged with `||`, read by the monitor). Precedence is therefore defined once, in `JobState.merge`, for every combinator: failure still dominates, because the monitor keeps computing `failed` from the log exactly as before and treats a job as canceled only when it did not itself fail. `JobResult.isCanceled` reads the flag; the marker string and its "for internal use only" constant are removed.

Unlike the first-class attempt in #13075, the error type is unchanged. Cancellation rides in state that already flows through every combinator, so `Job.await`, `ensureJob`, and job registration are untouched and no boundary has to translate a cancellation into something lossy, which is what caused the diagnostic-loss and fabricated-error bugs the earlier approach had. Exit codes, `--wfail`, and log replay are unaffected since `failed` is computed as before.


**What is still missing**

* In-flight builds are not yet interrupted: once the token is set, a `lean` process already running still elaborates to completion, so fail-fast exit time is bounded by the slowest in-flight module. Killing it cleanly needs the `canceled` state this PR introduces.
* `--fail-fast` is still the only thing that sets the token. Graceful Ctrl-C handling and build timeouts are natural future consumers.