### PR TITLE
refactor: mark simp specs conjunctive in their precondition

### DIFF
--- a/src/Lean/Elab/Tactic/Do/Attr.lean
+++ b/src/Lean/Elab/Tactic/Do/Attr.lean
@@ -548,7 +548,10 @@ def mkSpecTheoremFromSimpDecl? (declName : Name) (prio : Nat) : MetaM (Option Sp
   -- progress (e.g. `getThe.eq_1 : getThe σ = MonadStateOf.get` after reducible unfolding).
   if pattern.pattern == rhs then return none
   let (pattern, etaArgs) := etaExpandEqPattern pattern eqTy
-  return some { pattern, proof := .global declName, kind := .simp etaArgs, priority := prio }
+  -- A rewrite's precondition is the rewritten `wp` application, whose post slot holds the post:
+  -- conjunctive by construction, so the solver applies it without frame machinery.
+  return some { pattern, proof := .global declName, kind := .simp etaArgs, priority := prio,
+                conjunctivePre := true }
 
 /--
 Create a `SpecTheorem` from an elaborated equational proof term `proof : ∀ xs, lhs = rhs`, keyed on
@@ -562,7 +565,8 @@ def mkSpecTheoremFromSimpExpr? (ref : Syntax) (proof : Expr) (levelParams : List
     return (lhs, (eqTy, rhs))
   if pattern.pattern == rhs then return none
   let (pattern, etaArgs) := etaExpandEqPattern pattern eqTy
-  return some { pattern, proof := .stx (← mkFreshId) ref proof, kind := .simp etaArgs, priority := prio }
+  return some { pattern, proof := .stx (← mkFreshId) ref proof, kind := .simp etaArgs,
+                priority := prio, conjunctivePre := true }
 
 /--
 The unfold theorem `declName.eq_def` through which a definition in a simp set's `toUnfold`

--- a/src/Lean/Elab/Tactic/Do/Attr.lean
+++ b/src/Lean/Elab/Tactic/Do/Attr.lean
@@ -339,12 +339,12 @@ structure SpecTheorem where
   /-- The proof for the theorem. -/
   proof : SpecProof
   /-- The kind of spec theorem: triple or simp. -/
-  kind : SpecTheoremKind := .triple
+  kind : SpecTheoremKind
   /-- Whether the precondition is conjunctive in the spec's postconditions, so applying the spec
   directly carries any frame and `vcgen` skips the frame machinery. Opt out with a trivial `Q = Q`
   premise. -/
-  conjunctivePre : Bool := false
-  priority : Nat := eval_prio default
+  conjunctivePre : Bool
+  priority : Nat
   deriving Inhabited
 
 instance : BEq SpecTheorem where
@@ -486,7 +486,7 @@ private def mkSpecTheorem (type : Expr) (proof : SpecProof) (prio : Nat) : MetaM
   let some _ ← selectProg type | return none
   let pattern ← mkSpecPatternFromExpr expr levelParams
   let conjunctivePre ← isConjunctiveInPosts type binders
-  return some { pattern, proof, priority := prio, conjunctivePre }
+  return some { pattern, proof, kind := .triple, priority := prio, conjunctivePre }
 
 def mkSpecTheoremFromConst (declName : Name) (prio : Nat := eval_prio default) : MetaM (Option SpecTheorem) := do
   let info := (← getAsyncConstInfo declName).toConstantVal
@@ -548,8 +548,6 @@ def mkSpecTheoremFromSimpDecl? (declName : Name) (prio : Nat) : MetaM (Option Sp
   -- progress (e.g. `getThe.eq_1 : getThe σ = MonadStateOf.get` after reducible unfolding).
   if pattern.pattern == rhs then return none
   let (pattern, etaArgs) := etaExpandEqPattern pattern eqTy
-  -- A rewrite's precondition is the rewritten `wp` application, whose post slot holds the post:
-  -- conjunctive by construction, so the solver applies it without frame machinery.
   return some { pattern, proof := .global declName, kind := .simp etaArgs, priority := prio,
                 conjunctivePre := true }
 


### PR DESCRIPTION
This PR marks a `simp` spec as conjunctive in its precondition and removes the default values of the `SpecTheorem` fields to avoid such oversights in the future.
