### PR TITLE
feat: add hint to transitive `deprecated` usage warning

### DIFF
--- a/src/Lean/Linter/Deprecated.lean
+++ b/src/Lean/Linter/Deprecated.lean
@@ -76,9 +76,16 @@ builtin_initialize deprecatedAttr : ParametricAttribute DeprecationEntry ←
                   of a deprecated declaration" ++ disableNote
               | some next =>
                 if next != newName then
-                  logWarning <| m!"`{.ofConstName newName true}` is itself deprecated in favor of \
-                  `{.ofConstName next true}`; consider deprecating `{.ofConstName declName true}` \
-                  in favor of `{.ofConstName next true}` instead" ++ disableNote
+                  let mut msg := m!"`{.ofConstName newName true}` is itself deprecated in favor of \
+                    `{.ofConstName next true}`; consider deprecating `{.ofConstName declName true}` \
+                    in favor of `{.ofConstName next true}` instead" ++ disableNote
+                  if let some id := id? then
+                    if (id.raw.getRange? (canonicalOnly := true)).isSome then
+                      if let some replacement ← MetaM.run' <| unresolveNameGlobalAvoidingLocals? next then
+                        msg := msg ++ (← MessageData.hint
+                          m!"Deprecate in favor of `{.ofConstName next true}` instead:"
+                          #[replacement.toString] (ref? := some id.raw))
+                  logWarning msg
           if let some oldDecl := env.find? declName then
             if let some newDecl := env.find? newName then
               if ← MetaM.run' <| areTypesReduciblyDefEq oldDecl newDecl then

--- a/tests/elab/7993.lean
+++ b/tests/elab/7993.lean
@@ -42,6 +42,9 @@ abbrev Bar := Nat
 warning: `Foo.foo` is itself deprecated in favor of `Foo.bar`; consider deprecating `Bar.bar` in favor of `Foo.bar` instead
 
 Note: This warning can be disabled with `set_option linter.deprecated.deprecatedTarget false`
+
+Hint: Deprecate in favor of `Foo.bar` instead:
+  Foo.f̵o̵o̵b̲a̲r̲
 -/
 #guard_msgs in
 @[deprecated Foo.foo (since := "2025-01-01")]

--- a/tests/elab/deprecatedTransitive.lean
+++ b/tests/elab/deprecatedTransitive.lean
@@ -18,6 +18,9 @@ def b1 : Nat := 0
 warning: `b1` is itself deprecated in favor of `c1`; consider deprecating `a1` in favor of `c1` instead
 
 Note: This warning can be disabled with `set_option linter.deprecated.deprecatedTarget false`
+
+Hint: Deprecate in favor of `c1` instead:
+  b̵c̲1
 -/
 #guard_msgs in
 @[deprecated b1 (since := "2020-01-01")]
@@ -39,6 +42,9 @@ def b2 : Nat := 0
 warning: `b2` is itself deprecated in favor of `c2`; consider deprecating `a2` in favor of `c2` instead
 
 Note: This warning can be disabled with `set_option linter.deprecated.deprecatedTarget false`
+
+Hint: Deprecate in favor of `c2` instead:
+  b̵c̲2
 -/
 #guard_msgs in
 @[deprecated b2 (since := "2020-01-01")]
@@ -71,6 +77,9 @@ def b4 : Nat := 0
 warning: `b4` is itself deprecated in favor of `c4`; consider deprecating `a4` in favor of `c4` instead
 
 Note: This warning can be disabled with `set_option linter.deprecated.deprecatedTarget false`
+
+Hint: Deprecate in favor of `c4` instead:
+  b̵c̲4
 -/
 #guard_msgs in
 @[deprecated b4 (since := "2020-01-01")]
@@ -87,6 +96,9 @@ def b5 : Bool := true
 warning: `b5` is itself deprecated in favor of `c5`; consider deprecating `a5` in favor of `c5` instead
 
 Note: This warning can be disabled with `set_option linter.deprecated.deprecatedTarget false`
+
+Hint: Deprecate in favor of `c5` instead:
+  b̵c̲5
 ---
 warning: The updated constant has a different type:
   Bool


### PR DESCRIPTION
This PR adds a hint and a clickable code action to `deprecated` linter, when introducing a transitive deprecation, i.e. when a suggested replacement is itself deprecated.