### PR TITLE
fix: apply #14807 fix to `inductive.h`

### DIFF
--- a/src/kernel/inductive.h
+++ b/src/kernel/inductive.h
@@ -59,24 +59,24 @@ expr expand_eta_struct(environment const & env, expr const & e_type, expr const 
 
 /* If `e` is not a constructor application and its type `C ...` is a non-recursive structure, return `C.mk e.1 ... e.n`,
    where `C.mk` is `C`s constructor. */
-template<typename WHNF, typename INFER>
+template<typename WHNF, typename INFER, typename IS_PROP>
 inline expr to_cnstr_when_structure(environment const & env, name const & induct_name, expr const & e,
-                                    WHNF const & whnf, INFER const & infer_type) {
+                                    WHNF const & whnf, INFER const & infer_type, IS_PROP const & is_prop) {
     if (!is_non_rec_structure(env, induct_name) || is_constructor_app(env, e))
         return e;
     expr e_type = whnf(infer_type(e));
     if (!is_constant(get_app_fn(e_type), induct_name))
         return e;
-    expr s = whnf(infer_type(e_type));
     // See `type_checker::is_prop`: zero must be tested up to normalization, e.g. `imax 1 0` is `Prop`.
-    if (is_sort(s) && normalizes_to_zero(sort_level(s)))
+    if (is_prop(e_type))
         return e;
     return expand_eta_struct(env, e_type, e);
 }
 
-template<typename WHNF, typename INFER, typename IS_DEF_EQ>
+template<typename WHNF, typename INFER, typename IS_DEF_EQ, typename IS_PROP>
 inline optional<expr> inductive_reduce_rec(environment const & env, expr const & e,
-                                           WHNF const & whnf, INFER const & infer_type, IS_DEF_EQ const & is_def_eq) {
+                                           WHNF const & whnf, INFER const & infer_type, IS_DEF_EQ const & is_def_eq,
+                                           IS_PROP const & is_prop) {
     expr const & rec_fn   = get_app_fn(e);
     if (!is_constant(rec_fn)) return none_expr();
     optional<constant_info> rec_info = env.find(const_name(rec_fn));
@@ -96,7 +96,7 @@ inline optional<expr> inductive_reduce_rec(environment const & env, expr const &
     else if (is_string_lit(major))
         major = whnf(string_lit_to_constructor(major));
     else
-        major = to_cnstr_when_structure(env, rec_val.get_major_induct(), major, whnf, infer_type);
+        major = to_cnstr_when_structure(env, rec_val.get_major_induct(), major, whnf, infer_type, is_prop);
     optional<recursor_rule> rule = get_rec_rule_for(rec_val, major);
     if (!rule) return none_expr();
     buffer<expr> major_args;

--- a/src/kernel/type_checker.cpp
+++ b/src/kernel/type_checker.cpp
@@ -362,7 +362,8 @@ optional<expr> type_checker::reduce_recursor(expr const & e, bool cheap_rec, boo
     if (optional<expr> r = inductive_reduce_rec(env(), e,
                                                 [&](expr const & e) { return cheap_rec ? whnf_core(e, cheap_rec, cheap_proj) : whnf(e); },
                                                 [&](expr const & e) { return infer(e); },
-                                                [&](expr const & e1, expr const & e2) { return is_def_eq(e1, e2); })) {
+                                                [&](expr const & e1, expr const & e2) { return is_def_eq(e1, e2); },
+                                                [&](expr const & e) { return is_prop(e); })) {
         return r;
     }
     return none_expr();


### PR DESCRIPTION
This PR applies the fix from #14807 to `inductive.h`. As the comment in `inductive.h` points out, the code should check whether `e_type` is a proposition using `is_prop`, but it was still inlining the old, buggy version of `is_prop`.
