### PR TITLE
fix: adjust name mangling in kernel's nested inductive type processing

### DIFF
--- a/src/Lean/Meta/IndPredBelow.lean
+++ b/src/Lean/Meta/IndPredBelow.lean
@@ -452,6 +452,7 @@ where
       let ctorInfo ← getConstInfoCtor ctorName
       let shortCtorName := ctorName.replacePrefix ctorInfo.induct .anonymous
       let belowCtor ← getConstInfoCtor (belowIndName ++ shortCtorName)
+        <|> getConstInfoCtor (belowIndName ++ ctorName)
       let type := belowCtor.instantiateTypeLevelParams us
       let fieldExprs ← fields.toArray.mapM (·.toExpr)
       trace[Meta.IndPredBelow.match] "instantiate {type} with {belowParams} {fieldExprs}}"

--- a/src/kernel/inductive.cpp
+++ b/src/kernel/inductive.cpp
@@ -921,7 +921,7 @@ struct elim_nested_inductive_result {
         expr const & I = get_app_fn(p->first);
         if (!is_constant(I))
             throw kernel_exception(aux_env, "failed to restore nested inductive types, nested occurrence is not an inductive type application");
-        return cnstr_name.replace_prefix(p->second, const_name(I));
+        return cnstr_name.replace_prefix(p->second, name());
     }
 
     expr restore_nested(expr e, environment const & aux_env, name_map<name> const & aux_rec_name_map = name_map<name>()) {
@@ -963,7 +963,7 @@ struct elim_nested_inductive_result {
                         expr I = get_app_args(new_nested, I_args);
                         if (!is_constant(I))
                             throw kernel_exception(aux_env, "failed to restore nested inductive types, nested occurrence is not an inductive type application");
-                        name new_fn_name = const_name(fn).replace_prefix(auxI_name, const_name(I));
+                        name new_fn_name = const_name(fn).replace_prefix(auxI_name, name());
                         expr new_fn = mk_constant(new_fn_name, const_levels(I));
                         expr new_t  = mk_app(mk_app(new_fn, I_args), args.size() - m_params.size(), args.data() + m_params.size());
                         return some_expr(new_t);
@@ -1116,7 +1116,7 @@ struct elim_nested_inductive_fn {
                 buffer<constructor> auxJ_constructors;
                 for (name const & J_cnstr_name : J_info.to_inductive_val().get_cnstrs()) {
                     constant_info J_cnstr_info = m_env.get(J_cnstr_name);
-                    name auxJ_cnstr_name = J_cnstr_name.replace_prefix(J_name, auxJ_name);
+                    name auxJ_cnstr_name = auxJ_name + J_cnstr_name;
                     /* auxJ_cnstr_type still has references to `J`, this will be fixed later when we process it. */
                     expr auxJ_cnstr_type    = instantiate_lparams(J_cnstr_info.get_type(), J_cnstr_info.get_lparams(), I_lvls);
                     auxJ_cnstr_type         = instantiate_pi_params(auxJ_cnstr_type, I_nparams, args.data());

--- a/tests/elab/issue10789.lean
+++ b/tests/elab/issue10789.lean
@@ -1,0 +1,16 @@
+/-!
+# Kernel should accept nested inductives involving private constructors
+
+https://github.com/leanprover/lean4/issues/10789
+-/
+
+/-!
+Example from issue. The `Rec` structure used to report
+`error: (kernel) constant has already been declared '_private.«external:...».0.Box.mk'`
+-/
+structure Box (α : Type u) where
+  private mk ::
+  val : α
+
+structure Rec where
+  box? : Option (Box Rec)

--- a/tests/elab/issue5661.lean
+++ b/tests/elab/issue5661.lean
@@ -33,7 +33,7 @@ theorem failed_before (x : StructLike Nested) : Nested.rec_1
   (motive_1 := fun _ => Bool) (motive_2 := fun _ => Bool)
   (nest := fun _ _ => true)
   (other := true)
-  (mk := fun _ _ => true)
+  (StructLike.mk := fun _ _ => true)
   x = true
   := rfl
 

--- a/tests/elab/new_inductive.lean.out.expected
+++ b/tests/elab/new_inductive.lean.out.expected
@@ -58,7 +58,7 @@ fun {P} {α β} {t} {α' β'} {t'} eq_1 eq_2 eq_3 =>
               ((a : tst1) → motive_1 a → motive_2 (tst2.mk a)) →
                 ((s : Nat → myPair (myPair tst2 Bool) tst2) → ((a : Nat) → motive_4 (s a)) → motive_3 (arrow.mk s)) →
                   ((a : myPair tst2 Bool) → (a_1 : tst2) → motive_5 a → motive_2 a_1 → motive_4 (myPair.mk a a_1)) →
-                    ((a : tst2) → (a_1 : Bool) → motive_2 a → motive_5 (myPair.mk a a_1)) → motive_1 t
+                    ((a : tst2) → (a_1 : Bool) → motive_2 a → motive_5 (_root_.myPair.mk a a_1)) → motive_1 t
 13
 @Rbnode.brecOn : {α : Type u_2} →
   {motive : Rbnode α → Sort u_1} → (t : Rbnode α) → ((t : Rbnode α) → Rbnode.below t → motive t) → motive t
@@ -82,9 +82,12 @@ number of indices: 0
 number of motives: 3
 number of minors: 6
 rules:
-for test.Trie.Empty (0 fields): fun motive_1 motive_2 motive_3 Empty mk leaf redNode blackNode mk_1 => Empty
-for test.Trie.mk (2 fields): fun motive_1 motive_2 motive_3 Empty mk leaf redNode blackNode mk_1 a a_1 =>
-  mk a a_1 (Trie.rec_1 Empty mk leaf redNode blackNode mk_1 a_1)
+for test.Trie.Empty (0 fields): fun motive_1 motive_2 motive_3 Empty mk test.Rbnode.leaf test.Rbnode.redNode
+    test.Rbnode.blackNode myPair.mk =>
+  Empty
+for test.Trie.mk (2 fields): fun motive_1 motive_2 motive_3 Empty mk test.Rbnode.leaf test.Rbnode.redNode
+    test.Rbnode.blackNode myPair.mk a a_1 =>
+  mk a a_1 (Trie.rec_1 Empty mk test.Rbnode.leaf test.Rbnode.redNode test.Rbnode.blackNode myPair.mk a_1)
 @[reducible] protected def test.Trie.noConfusion.{u} : {P : Sort u} →
   {t t' : Trie} → t = t' → Trie.noConfusionType P t t' :=
 fun {P} {t t'} eq => eq ▸ t.casesOn (fun k => k) fun a a_1 k => k ⋯ ⋯

--- a/tests/elab/new_inductive2.lean.out.expected
+++ b/tests/elab/new_inductive2.lean.out.expected
@@ -7,7 +7,7 @@ number of indices: 0
 number of motives: 2
 number of minors: 2
 rules:
-for foo.mk (1 fields): fun motive_1 motive_2 mk mk_1 a => mk a (foo.rec_1 mk mk_1 a)
+for foo.mk (1 fields): fun motive_1 motive_2 mk arrow.mk a => mk a (foo.rec_1 mk arrow.mk a)
 @[reducible] protected def foo.below.{u} : {motive_1 : (t : foo) → Sort u} →
   {motive_2 : (t : arrow.{0, 0} Nat foo) → Sort u} → (t : foo) → Sort (max 1 u) :=
 fun {motive_1 : (t : foo) → Sort u} {motive_2 : (t : arrow.{0, 0} Nat foo) → Sort u} (t : foo) =>


### PR DESCRIPTION
This PR fixes an issue where the kernel would not accept nested inductive types where the type being nested through was public with a private constructor. The kernel assumed that the name of the inductive type was a prefix of each constructor. Now the kernel uses a simpler procedure where the auxiliary type's name is prepended to constructor names, rather than replacing a prefix. Note that a consequence to this is that auxiliary recursors have non-atomic minor premise names (which was already the case for private constructors).

With @berberman

Closes #10789
