### PR TITLE
fix: `sym =>` mode initialization

### DIFF
--- a/src/Lean/Elab/Tactic/Grind/Basic.lean
+++ b/src/Lean/Elab/Tactic/Grind/Basic.lean
@@ -446,10 +446,15 @@ def GrindTacticM.runAtGoal (mvarId : MVarId) (params : Params) (k : GrindTacticM
   let (methods, ctx, sctx, state) ← liftMetaM <| GrindM.runAtGoal mvarId params' (evalTactic? := some evalTactic) fun goal => do
       let goals ←
         if sym then
-          /- In sym mode, skip eager intros + by-contradiction. The user controls intro/internalize.
-             Preprocess for maximal term sharing, required by Sym operations (introN, BackwardRule.apply, etc.). -/
-          let mvarId ← Sym.preprocessMVar goal.mvarId
-          pure [{ goal with mvarId }]
+          if goal.inconsistent then
+            /- The goal was already closed while preprocessing the hypotheses, and `goal.mvarId`
+               has been assigned. `Sym.preprocessMVar` would clobber that assignment. -/
+            pure []
+          else
+            /- In sym mode, skip eager intros + by-contradiction. The user controls intro/internalize.
+               Preprocess for maximal term sharing, required by Sym operations (introN, BackwardRule.apply, etc.). -/
+            let mvarId ← Sym.preprocessMVar goal.mvarId
+            pure [{ goal with mvarId }]
         else
           let a : Action := Action.intros 0 >> Action.assertAll
           match (← a.run goal) with

--- a/tests/elab/sym_interactive_bugs.lean
+++ b/tests/elab/sym_interactive_bugs.lean
@@ -19,3 +19,11 @@ example : ∃ x, x = a := by
   sym =>
     apply Exists.intro
     apply Eq.refl
+
+-- The goal is closed while preprocessing the contradictory hypothesis, before the
+-- tactic sequence runs. `sym` must not preprocess the already assigned metavariable.
+example (h : false = true) : True = True := by
+  sym => done
+
+example (h : False) : 1 = 2 := by
+  sym => done


### PR DESCRIPTION
This PR fixes a bug in `sym =>` initialization. It now correctly handles the case the goal is closed during preprocessing.
