### PR TITLE
fix: bound the size of `Nat` numerals computed by the kernel

### DIFF
--- a/src/include/lean/lean.h
+++ b/src/include/lean/lean.h
@@ -1615,6 +1615,8 @@ LEAN_EXPORT lean_obj_res lean_nat_big_shiftr(b_lean_obj_arg a1, b_lean_obj_arg a
 LEAN_EXPORT lean_obj_res lean_nat_pow(b_lean_obj_arg a1, b_lean_obj_arg a2);
 LEAN_EXPORT lean_obj_res lean_nat_gcd(b_lean_obj_arg a1, b_lean_obj_arg a2);
 LEAN_EXPORT lean_obj_res lean_nat_log2(b_lean_obj_arg a);
+/* Upper bound on the size in bytes of the representation of `a` (one word for scalars). Returns a raw `size_t`, not a boxed `Nat`. */
+LEAN_EXPORT size_t lean_nat_size_in_bytes(b_lean_obj_arg a);
 
 static inline lean_obj_res lean_nat_shiftr(b_lean_obj_arg a1, b_lean_obj_arg a2) {
     if (LEAN_LIKELY(lean_is_scalar(a1) && lean_is_scalar(a2))) {

--- a/src/kernel/type_checker.cpp
+++ b/src/kernel/type_checker.cpp
@@ -7,6 +7,8 @@ Author: Leonardo de Moura
 #include <utility>
 #include <vector>
 #include <limits>
+#include <climits>
+#include <cstdlib>
 #include "runtime/interrupt.h"
 #include "runtime/sstream.h"
 #include "runtime/flet.h"
@@ -26,6 +28,12 @@ static name * g_kernel_fresh = nullptr;
 static expr * g_dont_care    = nullptr;
 static name * g_bool_true    = nullptr;
 static name * g_eager_reduce = nullptr;
+/* Upper bound (in bytes) on the numerals the kernel computes while reducing `Nat`
+   literals (see `reduce_nat`). Protects the kernel from spending unbounded memory
+   and time evaluating giant numerals. Configurable via the `LEAN_NAT_MAX_SIZE`
+   environment variable. */
+static size_t g_nat_max_size = 0;
+static const size_t LEAN_NAT_MAX_SIZE_DEFAULT = 128*1024*1024;    // 128 MB
 static expr * g_nat_zero     = nullptr;
 static expr * g_nat_succ     = nullptr;
 static expr * g_nat_add      = nullptr;
@@ -283,6 +291,35 @@ expr type_checker::infer_proj(expr const & e, bool infer_only) {
     return r;
 }
 
+static size_t nat_size_in_bytes(nat const & n) { return lean_nat_size_in_bytes(n.raw()); }
+
+/* Throw a kernel exception when a `Nat` numeral is larger than `g_nat_max_size`.
+   `num_bytes` is an upper bound on its size. */
+static void check_nat_size(environment const & env, size_t num_bytes) {
+    if (num_bytes > g_nat_max_size)
+        throw kernel_exception(env, "the kernel refused a `Nat` numeral because its "
+            "size exceeds the maximum; increase the LEAN_NAT_MAX_SIZE environment "
+            "variable to allow it");
+}
+
+/* The runtime `Nat.pow` / `Nat.shiftLeft` require their second argument (the
+   exponent / shift amount) to fit in `unsigned int`. Return it as a `size_t`, or
+   throw a clean error instead of the runtime's `lean_internal_panic`. */
+static size_t get_count_arg(environment const & env, nat const & count, char const * op) {
+    if (count > static_cast<unsigned long>(UINT_MAX))
+        throw kernel_exception(env, sstream() << "the kernel refused to evaluate `" << op
+            << "` because its second argument does not fit in a 32-bit unsigned integer");
+    return count.get_small_value();
+}
+
+expr type_checker::infer_lit(expr const & e) {
+    // Bound the size of numerals entering the kernel (e.g. source literals), the
+    // same limit `reduce_nat` enforces on the numerals it computes.
+    if (is_nat_lit(e))
+        check_nat_size(env(), nat_size_in_bytes(lit_value(e).get_nat()));
+    return lit_type(lit_value(e));
+}
+
 /** \brief Return type of expression \c e, if \c infer_only is false, then it also check whether \c e is type correct or not.
     \pre closed(e) */
 expr type_checker::infer_type_core(expr const & e, bool infer_only) {
@@ -298,7 +335,7 @@ expr type_checker::infer_type_core(expr const & e, bool infer_only) {
 
     expr r;
     switch (e.kind()) {
-    case expr_kind::Lit:      r = lit_type(lit_value(e)); break;
+    case expr_kind::Lit:      r = infer_lit(e); break;
     case expr_kind::MData:    r = infer_type_core(mdata_expr(e), infer_only); break;
     case expr_kind::Proj:     r = infer_proj(e, infer_only); break;
     case expr_kind::FVar:     r = infer_fvar(e);  break;
@@ -604,27 +641,52 @@ static inline nat get_nat_val(expr const & e) {
     return lit_value(e).get_nat();
 }
 
-template<typename F> optional<expr> type_checker::reduce_bin_nat_op(F const & f, expr const & e) {
+template<typename F> optional<expr> type_checker::reduce_bin_nat_op(F const & f, expr const & e, bool check_size) {
     expr arg1 = whnf(app_arg(app_fn(e)));
     if (!is_nat_lit_ext(arg1)) return none_expr();
     expr arg2 = whnf(app_arg(e));
     if (!is_nat_lit_ext(arg2)) return none_expr();
     nat v1 = get_nat_val(arg1);
     nat v2 = get_nat_val(arg2);
-    return some_expr(mk_lit(literal(nat(f(v1.raw(), v2.raw())))));
+    nat r(f(v1.raw(), v2.raw()));
+    // `add`/`sub`/`mul` can accumulate large numerals in a recursor loop. Their
+    // operands are already bounded, so computing `r` is cheap; reject once the
+    // result itself exceeds the size limit.
+    if (check_size)
+        check_nat_size(env(), nat_size_in_bytes(r));
+    return some_expr(mk_lit(literal(r)));
 }
-
-#define ReducePowMaxExp 1<<24 // TODO: make it configurable
 
 optional<expr> type_checker::reduce_pow(expr const & e) {
     expr arg1 = whnf(app_arg(app_fn(e)));
     if (!is_nat_lit_ext(arg1)) return none_expr();
     expr arg2 = whnf(app_arg(e));
     if (!is_nat_lit_ext(arg2)) return none_expr();
-    nat v1 = get_nat_val(arg1);
-    nat v2 = get_nat_val(arg2);
-    if (v2 > nat(ReducePowMaxExp)) return none_expr();
-    return some_expr(mk_lit(literal(nat(nat_pow(v1.raw(), v2.raw())))));
+    nat base = get_nat_val(arg1);
+    nat exp  = get_nat_val(arg2);
+    size_t k = get_count_arg(env(), exp, "Nat.pow");
+    // `base^exp` has at most `size(base) * k` bytes (`base <= 1` yields `0`/`1`).
+    // Compare via division to avoid overflowing the product.
+    if (base > nat(1) && k != 0 && nat_size_in_bytes(base) > g_nat_max_size / k)
+        throw kernel_exception(env(), "the kernel refused to evaluate `Nat.pow` because "
+            "the result would exceed the maximum numeral size; increase the "
+            "LEAN_NAT_MAX_SIZE environment variable to allow it");
+    return some_expr(mk_lit(literal(nat(nat_pow(base.raw(), exp.raw())))));
+}
+
+optional<expr> type_checker::reduce_shiftLeft(expr const & e) {
+    expr arg1 = whnf(app_arg(app_fn(e)));
+    if (!is_nat_lit_ext(arg1)) return none_expr();
+    expr arg2 = whnf(app_arg(e));
+    if (!is_nat_lit_ext(arg2)) return none_expr();
+    nat v = get_nat_val(arg1); // value being shifted
+    nat shift = get_nat_val(arg2); // shift amount, in bits
+    // `v <<< shift = v * 2^shift` has about `size(v) + shift/8` bytes; `0 <<< _ = 0`.
+    if (!v.is_zero()) {
+        size_t k = get_count_arg(env(), shift, "Nat.shiftLeft");
+        check_nat_size(env(), nat_size_in_bytes(v) + k / 8 + 1);
+    }
+    return some_expr(mk_lit(literal(nat(lean_nat_shiftl(v.raw(), shift.raw())))));
 }
 
 template<typename F> optional<expr> type_checker::reduce_bin_nat_pred(F const & f, expr const & e) {
@@ -650,9 +712,9 @@ optional<expr> type_checker::reduce_nat(expr const & e) {
     } else if (nargs == 2) {
         expr const & f = app_fn(app_fn(e));
         if (!is_constant(f)) return none_expr();
-        if (f == *g_nat_add) return reduce_bin_nat_op(nat_add, e);
-        if (f == *g_nat_sub) return reduce_bin_nat_op(nat_sub, e);
-        if (f == *g_nat_mul) return reduce_bin_nat_op(nat_mul, e);
+        if (f == *g_nat_add) return reduce_bin_nat_op(nat_add, e, /* check_size */ true);
+        if (f == *g_nat_sub) return reduce_bin_nat_op(nat_sub, e, /* check_size */ true);
+        if (f == *g_nat_mul) return reduce_bin_nat_op(nat_mul, e, /* check_size */ true);
         if (f == *g_nat_pow) return reduce_pow(e);
         if (f == *g_nat_gcd) return reduce_bin_nat_op(nat_gcd, e);
         if (f == *g_nat_mod) return reduce_bin_nat_op(nat_mod, e);
@@ -662,7 +724,7 @@ optional<expr> type_checker::reduce_nat(expr const & e) {
         if (f == *g_nat_land) return reduce_bin_nat_op(nat_land, e);
         if (f == *g_nat_lor)  return reduce_bin_nat_op(nat_lor, e);
         if (f == *g_nat_xor)  return reduce_bin_nat_op(nat_lxor, e);
-        if (f == *g_nat_shiftLeft) return reduce_bin_nat_op(lean_nat_shiftl, e);
+        if (f == *g_nat_shiftLeft) return reduce_shiftLeft(e);
         if (f == *g_nat_shiftRight) return reduce_bin_nat_op(lean_nat_shiftr, e);
     }
     return none_expr();
@@ -1238,7 +1300,21 @@ inline static expr * new_persistent_expr_const(name const & n) {
     return e;
 }
 
+/* Read `var` as a byte count, falling back to `default_value` when it is unset
+   or malformed. */
+static size_t read_nat_size_env(char const * var, size_t default_value) {
+    char const * s = getenv(var);
+    if (s == nullptr)
+        return default_value;
+    char * end = nullptr;
+    unsigned long long v = strtoull(s, &end, 10);
+    if (end == s || *end != '\0')
+        return default_value;
+    return static_cast<size_t>(v);
+}
+
 void initialize_type_checker() {
+    g_nat_max_size = read_nat_size_env("LEAN_NAT_MAX_SIZE", LEAN_NAT_MAX_SIZE_DEFAULT);
     g_kernel_fresh = new name("_kernel_fresh");
     mark_persistent(g_kernel_fresh->raw());
     g_bool_true    = new name{"Bool", "true"};

--- a/src/kernel/type_checker.cpp
+++ b/src/kernel/type_checker.cpp
@@ -707,7 +707,9 @@ optional<expr> type_checker::reduce_nat(expr const & e) {
             expr arg = whnf(app_arg(e));
             if (!is_nat_lit_ext(arg)) return none_expr();
             nat v = get_nat_val(arg);
-            return some_expr(mk_lit(literal(nat(v+nat(1)))));
+            v = v + nat(1);
+            check_nat_size(env(), nat_size_in_bytes(v));
+            return some_expr(mk_lit(literal(v)));
         }
     } else if (nargs == 2) {
         expr const & f = app_fn(app_fn(e));

--- a/src/kernel/type_checker.h
+++ b/src/kernel/type_checker.h
@@ -66,6 +66,7 @@ private:
     expr ensure_pi_core(expr e, expr const & s);
     void check_level(level const & l);
     expr infer_fvar(expr const & e);
+    expr infer_lit(expr const & e);
     expr infer_constant(expr const & e, bool infer_only);
     expr infer_lambda(expr const & e, bool infer_only);
     expr infer_pi(expr const & e, bool infer_only);
@@ -114,9 +115,10 @@ private:
     expr check_ignore_undefined_universes(expr const & e);
     optional<expr> try_unfold_proj_app(expr const & e);
 
-    template<typename F> optional<expr> reduce_bin_nat_op(F const & f, expr const & e);
+    template<typename F> optional<expr> reduce_bin_nat_op(F const & f, expr const & e, bool check_size = false);
     template<typename F> optional<expr> reduce_bin_nat_pred(F const & f, expr const & e);
     optional<expr> reduce_pow(expr const & e);
+    optional<expr> reduce_shiftLeft(expr const & e);
     optional<expr> reduce_nat(expr const & e);
 public:
     // The following two constructor are used only by the old compiler and should be deleted with it

--- a/src/runtime/mpz.cpp
+++ b/src/runtime/mpz.cpp
@@ -222,6 +222,10 @@ size_t mpz::log2() const {
     return r - 1;
 }
 
+size_t mpz::size_in_bytes() const {
+    return mpz_size(m_val) * sizeof(mp_limb_t);
+}
+
 mpz & mpz::operator&=(mpz const & o) {
     mpz_and(m_val, m_val, o.m_val);
     return *this;
@@ -854,6 +858,10 @@ static unsigned log2_uint(unsigned v) {
 
 size_t mpz::log2() const {
     return (m_size - 1)*sizeof(mpn_digit)*8 + log2_uint(m_digits[m_size - 1]);
+}
+
+size_t mpz::size_in_bytes() const {
+    return m_size * sizeof(mpn_digit);
 }
 
 mpz & mpz::operator&=(mpz const & o) {

--- a/src/runtime/mpz.h
+++ b/src/runtime/mpz.h
@@ -284,6 +284,12 @@ public:
     */
     size_t log2() const;
 
+    /**
+       \brief Return an upper bound on the size in bytes of the representation,
+       i.e. the number of limbs times the bytes per limb. Used to bound memory usage.
+    */
+    size_t size_in_bytes() const;
+
     friend void power(mpz & a, mpz const & b, unsigned k);
     friend void _power(mpz & a, mpz const & b, unsigned k) { power(a, b, k); }
     friend mpz pow(mpz a, unsigned k) { power(a, a, k); return a; }

--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -1622,6 +1622,12 @@ extern "C" LEAN_EXPORT lean_obj_res lean_nat_log2(b_lean_obj_arg a) {
     }
 }
 
+extern "C" LEAN_EXPORT size_t lean_nat_size_in_bytes(b_lean_obj_arg a) {
+    if (lean_is_scalar(a))
+        return sizeof(size_t); // a scalar occupies one machine word
+    return mpz_value(a).size_in_bytes();
+}
+
 // =======================================
 // Integers
 

--- a/tests/elab/nat_size_limit.lean
+++ b/tests/elab/nat_size_limit.lean
@@ -1,0 +1,53 @@
+import Lean
+
+/-!
+Tests the kernel's size limits on the numerals it computes while reducing `Nat`
+literals. The limits keep the kernel from spending unbounded memory and time on
+giant numerals. The companion `.init.sh` sets `LEAN_NAT_MAX_SIZE=16` so the guards
+trip on small inputs; the real defaults are far larger.
+-/
+
+open Lean
+
+def kwhnf (a : Name) : CoreM Unit := do
+  let env ← getEnv
+  let r ← ofExceptKernelException (Kernel.whnf env {} (mkConst a))
+  IO.println (toString r)
+
+-- Operands of at most two limbs (<= 16 bytes) are accepted; their three-limb
+-- product exceeds the limit and is rejected.
+def a : Nat := 18446744073709551616            -- 2^64
+def mulOk  : Nat := 4294967296 * 4294967296     -- 2^64, still two limbs
+def mulBig : Nat := a * a                        -- 2^128, three limbs
+
+/-- info: 18446744073709551616 -/
+#guard_msgs in
+#eval kwhnf `mulOk
+
+/-- error: (kernel) the kernel refused a `Nat` numeral because its size exceeds the maximum; increase the LEAN_NAT_MAX_SIZE environment variable to allow it -/
+#guard_msgs in
+#eval kwhnf `mulBig
+
+-- `Nat.pow`: the result and the exponent are both bounded.
+def powBig : Nat := 2 ^ 100
+def powHugeExp : Nat := 2 ^ 4294967296
+
+/-- error: (kernel) the kernel refused to evaluate `Nat.pow` because the result would exceed the maximum numeral size; increase the LEAN_NAT_MAX_SIZE environment variable to allow it -/
+#guard_msgs in
+#eval kwhnf `powBig
+
+/-- error: (kernel) the kernel refused to evaluate `Nat.pow` because its second argument does not fit in a 32-bit unsigned integer -/
+#guard_msgs in
+#eval kwhnf `powHugeExp
+
+-- `Nat.shiftLeft` result limit.
+def shiftBig : Nat := 1 <<< 200
+
+/-- error: (kernel) the kernel refused a `Nat` numeral because its size exceeds the maximum; increase the LEAN_NAT_MAX_SIZE environment variable to allow it -/
+#guard_msgs in
+#eval kwhnf `shiftBig
+
+-- A numeral entering the kernel directly (source literal) is bounded too.
+/-- error: (kernel) the kernel refused a `Nat` numeral because its size exceeds the maximum; increase the LEAN_NAT_MAX_SIZE environment variable to allow it -/
+#guard_msgs in
+def bigLit : Nat := 340282366920938463463374607431768211456   -- 2^128

--- a/tests/elab/nat_size_limit.lean.init.sh
+++ b/tests/elab/nat_size_limit.lean.init.sh
@@ -1,0 +1,1 @@
+export LEAN_NAT_MAX_SIZE=16


### PR DESCRIPTION
This PR makes the kernel reject `Nat` literals and computations whose representation would exceed a configurable size limit (128 MB by default). This prevents pathological or adversarial inputs from driving the kernel to spend unbounded memory and time constructing enormous numerals, and keeps the kernel's arithmetic comfortably within the range where its arbitrary-precision integer backend is well exercised. The limit can be raised with the `LEAN_NAT_MAX_SIZE` environment variable for the rare workloads that legitimately compute very large numerals in the kernel.

Motivation. A compact proof can direct the kernel to evaluate a natural number of many gigabytes. For example a tower of exponentiations, or a product of two already-large numerals. Beyond the immediate resource-exhaustion risk, arbitrary-precision integer libraries have documented capacity limits, and depending on how a particular library build behaves at or near those limits is a source of fragility that a trusted kernel should not rely on. Rather than reason about backend behavior at its extremes, the kernel now enforces its own conservative bound and stays well clear of them.

The kernel maintains a single rule: no `Nat` numeral it produces or accepts may exceed the size budget. It is checked at the four points where a numeral can enter the kernel or grow: literals in the expression being type checked; the results of `Nat.add`, `Nat.sub`, and `Nat.mul`; and, before any computation, `Nat.pow` and `Nat.shiftLeft`. The first three check the result after computing, which is cheap because their operands are already bounded (so the transient result is at most twice the budget). `Nat.pow` and `Nat.shiftLeft` are checked *before* evaluating, from the sizes of their inputs, because their results can be exponentially larger than their operands. The default budget of 128 MB is far below the backend's capacity, leaving ample headroom for the transient result of a single operation while remaining far larger than any numeral a realistic proof needs.

On a violation the kernel throws a kernel exception, so the offending declaration is rejected with a clear diagnostic.

This hardening was motivated by adversarial testing performed by Daniel Selsam (OpenAI) using internal AI systems.

This issue does **not** affect nanoda or any other kernel that does not use GMP. Recall that the official kernel can also be compiled with `USE_GMP=OFF`. In future releases, we will include two versions of `lean4checker`: with and without GMP.