### PR TITLE
fix: lake: trace bootstrap `lean.h`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1067,7 +1067,25 @@ if(STAGE GREATER 0 AND INSTALL_LICENSE)
   install(FILES "${CMAKE_SOURCE_DIR}/../LICENSE" "${CMAKE_SOURCE_DIR}/../LICENSES" DESTINATION ".")
 endif()
 
-file(COPY ${CMAKE_SOURCE_DIR}/include/lean DESTINATION ${CMAKE_BINARY_DIR}/include FILES_MATCHING PATTERN "*.h")
+# The runtime headers are included from the build tree, both by the C++ sources and by the C files
+# `lean` generates, and are installed from there. Copying them as a build step instead of at
+# configure time keeps the copy current without a reconfiguration.
+add_custom_target(
+  lean-headers
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_SOURCE_DIR}/include/lean/lean.h"
+    "${CMAKE_SOURCE_DIR}/include/lean/lean_gmp.h" "${CMAKE_SOURCE_DIR}/include/lean/lean_libuv.h"
+    "${CMAKE_BINARY_DIR}/include/lean"
+)
+
+set(LEAN_HEADER_CONSUMERS initialize leanshell make_stdlib)
+if(NOT STAGE GREATER 1)
+  # Later stages reuse the previous stage's C++ artifacts instead of compiling them
+  list(APPEND LEAN_HEADER_CONSUMERS leanrt leanrt_initial-exec util kernel library constructions)
+endif()
+foreach(T ${LEAN_HEADER_CONSUMERS})
+  add_dependencies(${T} lean-headers)
+endforeach()
 
 set(LEAN_INSTALL_PREFIX "" CACHE STRING "If set, set CMAKE_INSTALL_PREFIX to this value + version name")
 if(LEAN_INSTALL_PREFIX)

--- a/src/lake/Lake/Build/Common.lean
+++ b/src/lake/Lake/Build/Common.lean
@@ -851,24 +851,38 @@ which will be computed in the resulting `Job` before building.
     return art.path
 
 /--
+**For internal use only.**
 Build an object file from a source fie job (i.e, a `lean -c` output)
 using the Lean toolchain's C compiler.
 -/
-public def buildLeanO
+public def Internal.buildLeanO
   (oFile : FilePath) (srcJob : Job FilePath)
   (weakArgs traceArgs : Array String := #[])
-  (leanIncludeDir? : Option FilePath := none)
+  (leanIncludeDir? : Option (FilePath × BuildTrace) := none)
 : SpawnM (Job FilePath) :=
   srcJob.mapM fun srcFile => do
     addLeanTrace
+    if let some (_, trace) := leanIncludeDir? then
+      -- Lean-produced C files contain `#include <lean/lean.h>`.
+      -- Usually this dependency is captured by the Lean trace, but not with an override.
+      addTrace trace
     addPureTrace traceArgs "traceArgs"
     addPlatformTrace -- object files are platform-dependent artifacts
     let art ← buildArtifactUnlessUpToDate oFile (ext := "o") do
       let lean ← getLeanInstall
-      let includeDir := leanIncludeDir?.getD lean.includeDir
+      let includeDir := leanIncludeDir?.elim lean.includeDir (·.1)
       let args := #["-I", includeDir.toString] ++ lean.ccFlags ++ weakArgs ++ traceArgs
       compileO oFile srcFile args lean.cc
     return art.path
+
+/--
+Build an object file from a source fie job (i.e, a `lean -c` output)
+using the Lean toolchain's C compiler.
+-/
+@[inline] public def buildLeanO
+  (oFile : FilePath) (srcJob : Job FilePath)
+  (weakArgs traceArgs : Array String := #[])
+: SpawnM (Job FilePath) := Internal.buildLeanO oFile srcJob weakArgs traceArgs
 
 /-- Build a static library from object file jobs using the Lean toolchain's `ar`. -/
 public def buildStaticLib

--- a/src/lake/Lake/Build/Context.lean
+++ b/src/lake/Lake/Build/Context.lean
@@ -81,6 +81,7 @@ public def JobQueue := IO.Ref (Array OpaqueJob)
 /-- A Lake context with a build configuration and additional build data. -/
 public structure BuildContext extends BuildConfig, Context where
   leanTrace : BuildTrace
+  leanIncludeDirs : Array (Option (FilePath × BuildTrace))
   registeredJobs : JobQueue
   /--
   Input-to-output(s) map for hashes of the root package's artifacts.

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -1212,6 +1212,12 @@ public def Module.bcFacetConfig : ModuleFacetConfig bcFacet :=
       addTrace art.trace
       return art.path
 
+@[inline] def Package.getLeanIncludeDir? (pkg : Package) : JobM (Option (FilePath × BuildTrace)) := do
+  if pkg.bootstrap then
+    (← getBuildContext).leanIncludeDirs[pkg.wsIdx]?.join.getDM do
+        error "failed to fetch trace of the Lean include directory"
+  else return none
+
 /--
 Recursively build the module's object file from its C file produced by `lean`
 with `-DLEAN_EXPORTING` set, which exports Lean symbols defined within the C files.
@@ -1221,7 +1227,8 @@ def Module.recBuildLeanCToOExport (self : Module) : FetchM (Job FilePath) := do
   withRegisterJob s!"{self.name}:c.o{suffix}" <| withCurrPackage self.pkg do
   -- TODO: add option to pass a target triplet for cross compilation
   let leancArgs := self.leancArgs ++ #["-DLEAN_EXPORTING"]
-  buildLeanO self.coExportFile (← self.c.fetch) self.weakLeancArgs leancArgs self.leanIncludeDir?
+  let leanIncludeDir? ← self.pkg.getLeanIncludeDir?
+  Internal.buildLeanO self.coExportFile (← self.c.fetch) self.weakLeancArgs leancArgs leanIncludeDir?
 
 /-- The `ModuleFacetConfig` for the builtin `coExportFacet`. -/
 public def Module.coExportFacetConfig : ModuleFacetConfig coExportFacet :=
@@ -1235,7 +1242,8 @@ def Module.recBuildLeanCToONoExport (self : Module) : FetchM (Job FilePath) := d
   let suffix := if (← getIsVerbose) then " (without exports)" else ""
   withRegisterJob s!"{self.name}:c.o{suffix}" <| withCurrPackage self.pkg do
   -- TODO: add option to pass a target triplet for cross compilation
-  buildLeanO self.coNoExportFile (← self.c.fetch) self.weakLeancArgs self.leancArgs self.leanIncludeDir?
+  let leanIncludeDir? ← self.pkg.getLeanIncludeDir?
+  Internal.buildLeanO self.coNoExportFile (← self.c.fetch) self.weakLeancArgs self.leancArgs leanIncludeDir?
 
 /-- The `ModuleFacetConfig` for the builtin `coNoExportFacet`. -/
 public def Module.coNoExportFacetConfig : ModuleFacetConfig coNoExportFacet :=

--- a/src/lake/Lake/Build/Run.lean
+++ b/src/lake/Lake/Build/Run.lean
@@ -22,17 +22,6 @@ open System
 
 namespace Lake
 
-/-- Create a fresh build context from a workspace and a build configuration. -/
-@[deprecated "Deprecated without replacement." (since := "2025-01-08")]
-public def mkBuildContext (ws : Workspace) (config : BuildConfig) : BaseIO BuildContext := do
-  return {
-    opaqueWs := ws,
-    toBuildConfig := config,
-    registeredJobs := ← IO.mkRef #[],
-    leanTrace := .ofHash (pureHash ws.lakeEnv.leanGithash)
-      s!"Lean {Lean.versionStringCore}, commit {ws.lakeEnv.leanGithash}"
-  }
-
 /-- Unicode icons that make up the spinner in animation order. -/
 def Monitor.spinnerFrames :=
   #['⣾','⣷','⣯','⣟','⡿','⢿','⣻','⣽']
@@ -332,7 +321,7 @@ def monitorJob (ctx : MonitorContext) (job : Job α) : BaseIO (BuildResult α) :
   else
     return {toMonitorResult := result, out := .error "build failed"}
 
-def mkBuildContext'
+def mkBuildContext
   (ws : Workspace) (cfg : BuildConfig) (jobs : JobQueue)
 : BaseIO BuildContext := return {
   opaqueWs := ws
@@ -397,7 +386,7 @@ public def Workspace.runFetchM
 : IO α := do
   let jobs ← mkJobQueue
   let mctx ← mkMonitorContext cfg jobs
-  let bctx ← mkBuildContext' ws cfg jobs
+  let bctx ← mkBuildContext ws cfg jobs
   let job ← startBuild bctx build caption
   let result ← monitorJob mctx job
   finalizeBuild cfg bctx mctx result
@@ -426,7 +415,7 @@ public def Workspace.checkNoBuild
   let jobs ← mkJobQueue
   let cfg := {noBuild := true}
   let mctx ← mkMonitorContext cfg jobs
-  let bctx ← mkBuildContext' ws cfg jobs
+  let bctx ← mkBuildContext ws cfg jobs
   let job ← startBuild bctx build
   let result ← monitorBuild mctx job
   return result.isOk -- `isOk` means no failures, and thus no `--no-build` failures
@@ -437,7 +426,7 @@ public def Workspace.runBuild
 : IO α := do
   let jobs ← mkJobQueue
   let mctx ← mkMonitorContext cfg jobs
-  let bctx ← mkBuildContext' ws cfg jobs
+  let bctx ← mkBuildContext ws cfg jobs
   let job ← startBuild bctx build
   let result ← monitorBuild mctx job
   finalizeBuild cfg bctx mctx result

--- a/src/lake/Lake/Build/Run.lean
+++ b/src/lake/Lake/Build/Run.lean
@@ -355,6 +355,14 @@ def mkBuildContext'
   registeredJobs := jobs
   leanTrace := .ofHash (pureHash ws.lakeEnv.leanGithash)
     s!"Lean {Lean.versionStringCore}, commit {ws.lakeEnv.leanGithash}"
+  leanIncludeDirs := ← ws.packages.mapM fun pkg => do
+    unless pkg.bootstrap do
+      return none
+    let dir := pkg.bootstrapIncludeDir
+    let leanH := TextFilePath.mk <|  dir / "lean" / "lean.h"
+    let .ok trace ← (computeTrace (n := IO) leanH).toBaseIO
+      | return none
+    return some (dir, trace)
 }
 
 def Workspace.startBuild

--- a/src/lake/Lake/Build/Run.lean
+++ b/src/lake/Lake/Build/Run.lean
@@ -348,9 +348,19 @@ def mkBuildContext
     unless pkg.bootstrap do
       return none
     let dir := pkg.bootstrapIncludeDir
-    let leanH := TextFilePath.mk <|  dir / "lean" / "lean.h"
-    let .ok trace ← (computeTrace (n := IO) leanH).toBaseIO
-      | return none
+    let mut trace := BuildTrace.nil "Lean includes"
+    -- Must be kept up-to-date with the files `lean.h` can include
+    for header in #["lean.h", "config.h", "version.h", "mimalloc.h"] do
+      let leanH := TextFilePath.mk <| dir / "lean" / header
+      match ← (computeTrace (n := IO) leanH).toBaseIO with
+      | .ok fileTrace =>
+        trace := trace.mix fileTrace
+      | .error (.noFileOrDirectory ..) =>
+        -- some headers (e.g., `mimalloc.h`) are optional
+        -- missing required headers will be caught during compilation
+        continue
+      | _ =>
+        return none
     return some (dir, trace)
 }
 

--- a/src/lake/Lake/Config/Module.lean
+++ b/src/lake/Lake/Config/Module.lean
@@ -209,8 +209,10 @@ public def dynlibSuffix := "-1"
 @[inline] public def weakLinkArgs (self : Module) : Array String :=
   self.lib.weakLinkArgs
 
-@[inline] public def leanIncludeDir? (self : Module) : Option FilePath :=
-  if self.pkg.bootstrap then some <| self.pkg.buildDir / "include" else none
+/-- **For internal use only.** -/
+@[inline, deprecated "Deprecated without replacement." (since := "2026-08-19")]
+public def leanIncludeDir? (self : Module) : Option FilePath :=
+  if self.pkg.bootstrap then some <| self.pkg.bootstrapIncludeDir else none
 
 @[inline] public def platformIndependent (self : Module) : Option Bool :=
   self.lib.platformIndependent

--- a/src/lake/Lake/Config/Package.lean
+++ b/src/lake/Lake/Config/Package.lean
@@ -360,6 +360,10 @@ public def id? (self : Package) : Option PkgId :=
 @[inline] public def leanLibDir (self : Package) : FilePath :=
   self.buildDir / self.config.leanLibDir.normalize
 
+/-- **For internal use only.** The directory containing Lean header files in a bootstrap package. -/
+@[inline] public def bootstrapIncludeDir (self : Package) : FilePath :=
+  self.buildDir / "include"
+
 /--
 Where static libraries for the package are located.
 The package's `buildDir` joined with its `nativeLibDir` configuration.

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,6 +1,6 @@
 #include "util/options.h"
 
-// [ ] Check box to force CI to test stage 2 and run update-stage0 on PR merge
+// [x] Check box to force CI to test stage 2 and run update-stage0 on PR merge
 // (any other change to this file will do the same; ALL changes should be made to the stage0/ copy)
 
 namespace lean {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -285,11 +285,20 @@ set(PART2 "")
 # toolchain: requires elan to download toolchain
 # online: downloads remote repositories
 option(LAKE_CI "Enable full Lake test suite (use `lake-ci` label on PRs)" OFF)
+if(LAKE_CI)
+file(
+  GLOB_RECURSE LEANLAKETESTS
+  "${LEAN_SOURCE_DIR}/../tests/lake/examples/test.sh"
+  "${LEAN_SOURCE_DIR}/../tests/lake/tests/test.sh"
+  "${LEAN_SOURCE_DIR}/../tests/lake/extra/test.sh"
+)
+else()
 file(
   GLOB_RECURSE LEANLAKETESTS
   "${LEAN_SOURCE_DIR}/../tests/lake/examples/test.sh"
   "${LEAN_SOURCE_DIR}/../tests/lake/tests/test.sh"
 )
+endif()
 foreach(T ${LEANLAKETESTS})
   if(NOT T MATCHES ".*(lake-packages|bootstrap|toolchain|online).*")
     get_filename_component(T_DIR ${T} DIRECTORY)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -285,20 +285,15 @@ set(PART2 "")
 # toolchain: requires elan to download toolchain
 # online: downloads remote repositories
 option(LAKE_CI "Enable full Lake test suite (use `lake-ci` label on PRs)" OFF)
+set(LAKE_TEST_GLOBS
+  "${LEAN_SOURCE_DIR}/../tests/lake/examples/test.sh"
+  "${LEAN_SOURCE_DIR}/../tests/lake/tests/test.sh"
+)
+# Witth `lake-ci`, add extra tests that otherwise rarely need exercising
 if(LAKE_CI)
-file(
-  GLOB_RECURSE LEANLAKETESTS
-  "${LEAN_SOURCE_DIR}/../tests/lake/examples/test.sh"
-  "${LEAN_SOURCE_DIR}/../tests/lake/tests/test.sh"
-  "${LEAN_SOURCE_DIR}/../tests/lake/extra/test.sh"
-)
-else()
-file(
-  GLOB_RECURSE LEANLAKETESTS
-  "${LEAN_SOURCE_DIR}/../tests/lake/examples/test.sh"
-  "${LEAN_SOURCE_DIR}/../tests/lake/tests/test.sh"
-)
+  list(APPEND LAKE_TEST_GLOBS "${LEAN_SOURCE_DIR}/../tests/lake/extra/test.sh")
 endif()
+file(GLOB_RECURSE LEANLAKETESTS ${LAKE_TEST_GLOBS})
 foreach(T ${LEANLAKETESTS})
   if(NOT T MATCHES ".*(lake-packages|bootstrap|toolchain|online).*")
     get_filename_component(T_DIR ${T} DIRECTORY)

--- a/tests/lake/extra/includeTrace/Test.lean
+++ b/tests/lake/extra/includeTrace/Test.lean
@@ -1,0 +1,1 @@
+def hello := "world"

--- a/tests/lake/extra/includeTrace/clean.sh
+++ b/tests/lake/extra/includeTrace/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/extra/includeTrace/lakefile.toml
+++ b/tests/lake/extra/includeTrace/lakefile.toml
@@ -1,0 +1,7 @@
+name = "test"
+bootstrap = true
+# `--no-build` succeeds on a cache restore, which would hide a missing rebuild
+enableArtifactCache = false
+
+[[lean_lib]]
+name = "Test"

--- a/tests/lake/extra/includeTrace/test.sh
+++ b/tests/lake/extra/includeTrace/test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Authors: Sebastian Ullrich, Mac Malone, Claude Code
+source ../common.sh
+
+# A `bootstrap` package compiles its C files against the Lean headers in its own build
+# directory rather than the toolchain's, so the toolchain githash does not identify them.
+# Tests that Lake traces those headers instead.
+
+./clean.sh
+
+NO_BUILD_CODE=3
+INCLUDE_DIR=.lake/build/include
+
+test_cmd mkdir -p $INCLUDE_DIR
+test_cmd cp -r "$(norm_path "$(lean --print-prefix)")/include/lean" $INCLUDE_DIR/
+
+test_run build +Test:c.o.export
+test_out "All targets up-to-date" build +Test:c.o.export --no-build
+
+# The C files `lean` emits include only `lean.h`, which pulls in the rest transitively
+for header in lean.h config.h version.h mimalloc.h; do
+  echo "# TEST: a change to $header rebuilds the object file"
+  echo "// touched" >> $INCLUDE_DIR/lean/$header
+  test_status $NO_BUILD_CODE build +Test:c.o.export --no-build
+  test_err "Building Test:c.o" build +Test:c.o.export --no-build
+  test_run build +Test:c.o.export
+  test_out "All targets up-to-date" build +Test:c.o.export --no-build
+done
+
+# `USE_MIMALLOC` controls both whether `mimalloc.h` is in the include directory
+# and whether `config.h` defines the `LEAN_MIMALLOC` that makes `lean.h` include it
+echo "# TEST: an absent optional header does not fail the build"
+test_cmd rm $INCLUDE_DIR/lean/mimalloc.h
+sed_i "/define LEAN_MIMALLOC/d" $INCLUDE_DIR/lean/config.h
+test_run build +Test:c.o.export
+test_out "All targets up-to-date" build +Test:c.o.export --no-build
+
+# Cleanup
+rm -f produced.out

--- a/tests/lake/extra/includeTrace/test.sh
+++ b/tests/lake/extra/includeTrace/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Authors: Sebastian Ullrich, Mac Malone, Claude Code
-source ../common.sh
+source ../../tests/common.sh
 
 # A `bootstrap` package compiles its C files against the Lean headers in its own build
 # directory rather than the toolchain's, so the toolchain githash does not identify them.


### PR DESCRIPTION
This PR includes `lean.h` (and its transitive includes) from an overridden Lean include directory in the trace of built object files, ensuring they are rebuilt if the header changes (e.g., when bootstrapping). To avoid such changes affecting the public API in the future, `leanIncludeDir?` has been removed from the public API `buildLeanO` and moved to an internal `buildLeanO`. 

Similarly, the core CMake build is changed to update each stage's copy of the Lean header files when their source file changes.

Closes #14702.