### PR TITLE
feat: `constructor` warns when multiple constructors match

### DIFF
--- a/src/Init/Data/List/Lemmas.lean
+++ b/src/Init/Data/List/Lemmas.lean
@@ -353,7 +353,7 @@ theorem getD_cons_succ : getD (x :: xs) (n + 1) d = getD xs n d := by simp
 
 @[simp, grind =] theorem mem_cons : a ∈ b :: l ↔ a = b ∨ a ∈ l :=
   ⟨fun h => by cases h <;> simp [Membership.mem, *],
-   fun | Or.inl rfl => by constructor | Or.inr h => by constructor; assumption⟩
+   fun | Or.inl rfl => by constructor! | Or.inr h => by constructor; assumption⟩
 
 theorem eq_or_mem_of_mem_cons {a b : α} {l : List α} :
     a ∈ b :: l → a = b ∨ a ∈ l := List.mem_cons.mp

--- a/src/Init/Data/List/Perm.lean
+++ b/src/Init/Data/List/Perm.lean
@@ -468,7 +468,7 @@ theorem perm_insert_swap (x y : α) (l : List α) :
   by_cases xl : x ∈ l <;> by_cases yl : y ∈ l <;> simp [xl, yl]
   if xy : x = y then simp [xy] else
   simp [List.insert, xl, yl, xy, Ne.symm xy]
-  constructor
+  constructor!
 
 end LawfulBEq
 

--- a/src/Init/Meta.lean
+++ b/src/Init/Meta.lean
@@ -37,6 +37,9 @@ which only unfolds `@[reducible]` definitions). -/
 macro "erw" c:optConfig s:rwRuleSeq loc:(location)? : tactic => do
   `(tactic| rw $[$(getConfigItems c)]* (transparency := .default) $s:rwRuleSeq $(loc)?)
 
+macro_rules
+  | `(tactic| constructor! $c:optConfig) => `(tactic| constructor $[$(getConfigItems c)]* +first)
+
 syntax simpAllKind := atomic(" (" &"all") " := " &"true" ")"
 syntax dsimpKind   := atomic(" (" &"dsimp") " := " &"true" ")"
 

--- a/src/Init/Tactics.lean
+++ b/src/Init/Tactics.lean
@@ -11,6 +11,29 @@ set_option linter.missingDocs true -- keep it documented
 namespace Lean.Parser.Tactic
 
 /--
+`+opt` is short for `(opt := true)`. It sets the `opt` configuration option to `true`.
+-/
+syntax posConfigItem := " +" noWs ident
+/--
+`-opt` is short for `(opt := false)`. It sets the `opt` configuration option to `false`.
+-/
+syntax negConfigItem := " -" noWs ident
+/--
+`(opt := val)` sets the `opt` configuration option to `val`.
+
+As a special case, `(config := ...)` sets the entire configuration.
+-/
+syntax valConfigItem := atomic(" (" notFollowedBy(&"discharger" <|> &"disch") ident " := ") withoutPosition(term) ")"
+/-- A configuration item for a tactic configuration. -/
+syntax configItem := posConfigItem <|> negConfigItem <|> valConfigItem
+
+/-- Configuration options for tactics. -/
+syntax optConfig := (colGt configItem)*
+
+/-- Optional configuration option for tactics. (Deprecated. Replace `(config)?` with `optConfig`.) -/
+syntax config := atomic(" (" &"config") " := " withoutPosition(term) ")"
+
+/--
 `as_aux_lemma => tac` does the same as `tac`, except that it wraps the resulting expression
 into an auxiliary lemma. In some cases, this significantly reduces the size of expressions
 because the proof term is not duplicated.
@@ -252,11 +275,31 @@ syntax (name := refine') "refine' " term : tactic
 /-- `exfalso` converts a goal `⊢ tgt` into `⊢ False` by applying `False.elim`. -/
 macro "exfalso" : tactic => `(tactic| refine False.elim ?_)
 
+/-- Configuration for the `constructor` tactic. -/
+structure ConstructorConfig where
+  /--
+  If `true` (default: `false`), then the first matching constructor is used without checking whether
+  any of the remaining constructors match as well. Otherwise, a warning is issued when more than one
+  constructor matches.
+  -/
+  first : Bool := false
+
 /--
 If the main goal's target type is an inductive type, `constructor` solves it with
 the first matching constructor, or else fails.
+
+If more than one constructor matches, `constructor` still uses the first one, but it issues a
+warning. Use `constructor!`, which is short for `constructor +first`, to select the first matching
+constructor without a warning. To choose a specific constructor of a two-constructor inductive type,
+use `left` or `right`.
 -/
-syntax (name := constructor) "constructor" : tactic
+syntax (name := constructor) "constructor" optConfig : tactic
+
+/--
+`constructor!` is short for `constructor +first`: it solves the main goal with the first matching
+constructor of its target type, without checking whether any further constructors match.
+-/
+syntax (name := constructorBang) "constructor!" optConfig : tactic
 
 /--
 Applies the first constructor when
@@ -473,29 +516,6 @@ macro "admit" : tactic => `(tactic| sorry)
 It synthesizes a value of any target type by typeclass inference.
 -/
 macro "infer_instance" : tactic => `(tactic| exact inferInstance)
-
-/--
-`+opt` is short for `(opt := true)`. It sets the `opt` configuration option to `true`.
--/
-syntax posConfigItem := " +" noWs ident
-/--
-`-opt` is short for `(opt := false)`. It sets the `opt` configuration option to `false`.
--/
-syntax negConfigItem := " -" noWs ident
-/--
-`(opt := val)` sets the `opt` configuration option to `val`.
-
-As a special case, `(config := ...)` sets the entire configuration.
--/
-syntax valConfigItem := atomic(" (" notFollowedBy(&"discharger" <|> &"disch") ident " := ") withoutPosition(term) ")"
-/-- A configuration item for a tactic configuration. -/
-syntax configItem := posConfigItem <|> negConfigItem <|> valConfigItem
-
-/-- Configuration options for tactics. -/
-syntax optConfig := (colGt configItem)*
-
-/-- Optional configuration option for tactics. (Deprecated. Replace `(config)?` with `optConfig`.) -/
-syntax config := atomic(" (" &"config") " := " withoutPosition(term) ")"
 
 /-- The `*` location refers to all hypotheses and the goal. -/
 syntax locationWildcard := " *"

--- a/src/Lean/DocString/Parser.lean
+++ b/src/Lean/DocString/Parser.lean
@@ -262,7 +262,7 @@ def OrderedListType.all : List OrderedListType :=
   [.numDot, .parenAfter]
 
 theorem OrderedListType.all_complete : ∀ x : OrderedListType, x ∈ all := by
-  unfold all; intro x; cases x <;> repeat constructor
+  unfold all; intro x; cases x <;> repeat constructor!
 
 /--
 Unordered lists may have three indicators: asterisks, dashes, or pluses.
@@ -290,7 +290,7 @@ def UnorderedListType.all : List UnorderedListType :=
   [.asterisk, .dash, .plus]
 
 theorem UnorderedListType.all_complete : ∀ x : UnorderedListType, x ∈ all := by
-  unfold all; intro x; cases x <;> repeat constructor
+  unfold all; intro x; cases x <;> repeat constructor!
 
 def unorderedListIndicator (type : UnorderedListType) : ParserFn :=
   asStringFn <|

--- a/src/Lean/Elab/Tactic/ElabTerm.lean
+++ b/src/Lean/Elab/Tactic/ElabTerm.lean
@@ -11,6 +11,8 @@ public import Lean.Meta.Tactic.Replace
 public import Lean.Meta.Tactic.Rename
 public import Lean.Elab.Tactic.Basic
 public import Lean.Elab.SyntheticMVars
+import Lean.Elab.ConfigEval
+import Lean.Meta.Hint
 
 public section
 
@@ -302,11 +304,27 @@ def evalApplyLikeTactic (tac : MVarId → Expr → MetaM (List MVarId)) (e : Syn
   | `(tactic| apply $t) => evalApplyLikeTactic (fun g e => g.apply e (term? := some m!"`{e}`")) t
   | _ => throwUnsupportedSyntax
 
-@[builtin_tactic Lean.Parser.Tactic.constructor] def evalConstructor : Tactic := fun _ =>
+declare_config_elab elabConstructorConfig Parser.Tactic.ConstructorConfig
+
+private def evalConstructorCore (stx : Syntax) (cfg : Parser.Tactic.ConstructorConfig) : TacticM Unit :=
   withMainContext do
-    let mvarIds' ← (← getMainGoal).constructor
+    let (mvarIds', ctors) ← (← getMainGoal).constructorCore (findAll := !cfg.first)
+    if ctors.size > 1 then
+      let others := ctors.toList.drop 1
+      let othersMsg := MessageData.andList (others.map fun c => m!"`{MessageData.ofConstName c}`")
+      let suggestion : Meta.Hint.Suggestion :=
+        { suggestion := "constructor!", span? := stx[0], diffGranularity := .none }
+      let hint ← MessageData.hint
+        m!"Use `constructor!` to apply the first matching constructor without this warning:"
+        #[suggestion]
+      logWarning <| m!"Tactic `constructor` applied constructor \
+        `{MessageData.ofConstName ctors[0]!}`, but {othersMsg} also \
+        {if others.length == 1 then "matches" else "match"} the goal." ++ hint
     Term.synthesizeSyntheticMVarsNoPostponing
     replaceMainGoal mvarIds'
+
+@[builtin_tactic Lean.Parser.Tactic.constructor] def evalConstructor : Tactic := fun stx => do
+  evalConstructorCore stx (← elabConstructorConfig stx[1])
 
 @[builtin_tactic Lean.Parser.Tactic.withReducible] def evalWithReducible : Tactic := fun stx =>
   withReducible <| evalTactic stx[1]

--- a/src/Lean/Meta/MkIffOfInductiveProp.lean
+++ b/src/Lean/Meta/MkIffOfInductiveProp.lean
@@ -197,7 +197,7 @@ private def splitThenConstructor (mvar : MVarId) (n : Nat) : MetaM Unit :=
 match n with
 | 0   => do
   let (subgoals',_) ← Term.TermElabM.run <| Tactic.run mvar do
-    Tactic.evalTactic (← `(tactic| constructor))
+    Tactic.evalTactic (← `(tactic| constructor!))
   let [] := subgoals' | throwError "expected no subgoals"
   pure ()
 | n + 1 => do
@@ -205,7 +205,7 @@ match n with
     Tactic.evalTactic (← `(tactic| refine ⟨?_,?_⟩))
   let [sg1, sg2] := subgoals | throwError "expected two subgoals"
   let (subgoals',_) ← Term.TermElabM.run <| Tactic.run sg1 do
-    Tactic.evalTactic (← `(tactic| constructor))
+    Tactic.evalTactic (← `(tactic| constructor!))
   let [] := subgoals' | throwError "expected no subgoals"
   splitThenConstructor sg2 n
 

--- a/src/Lean/Meta/Tactic/Constructor.lean
+++ b/src/Lean/Meta/Tactic/Constructor.lean
@@ -14,21 +14,37 @@ namespace Lean.Meta
 
 /--
 When the goal `mvarId` type is an inductive datatype,
-`constructor` calls `apply` with the first matching constructor.
+`constructorCore` calls `apply` with the first matching constructor.
+
+Along with the resulting goals, it returns the constructors that `apply` succeeds with, in
+declaration order. When `findAll` is `false`, the search stops at the first match, so at most one
+constructor is reported.
 -/
-def _root_.Lean.MVarId.constructor (mvarId : MVarId) (cfg : ApplyConfig := {}) : MetaM (List MVarId) := do
+def _root_.Lean.MVarId.constructorCore (mvarId : MVarId) (cfg : ApplyConfig := {})
+    (findAll : Bool := true) : MetaM (List MVarId × Array Name) := do
   mvarId.withContext do
     mvarId.checkNotAssigned `constructor
     let target ← mvarId.getType'
     matchConstInduct target.getAppFn
       (fun _ => throwTacticEx `constructor mvarId "target is not an inductive datatype")
       fun ival us => do
+        let mut matching := #[]
         for ctor in ival.ctors do
-          try
-            return ← mvarId.apply (Lean.mkConst ctor us) cfg
-          catch _ =>
-            pure ()
-        throwTacticEx `constructor mvarId "no applicable constructor found"
+          let applies ← withoutModifyingState do
+            return (← observing? (mvarId.apply (Lean.mkConst ctor us) cfg)).isSome
+          if applies then
+            matching := matching.push ctor
+            if !findAll then break
+        let some ctor := matching[0]?
+          | throwTacticEx `constructor mvarId "no applicable constructor found"
+        return (← mvarId.apply (Lean.mkConst ctor us) cfg, matching)
+
+/--
+When the goal `mvarId` type is an inductive datatype,
+`constructor` calls `apply` with the first matching constructor.
+-/
+def _root_.Lean.MVarId.constructor (mvarId : MVarId) (cfg : ApplyConfig := {}) : MetaM (List MVarId) :=
+  return (← mvarId.constructorCore cfg (findAll := false)).1
 
 def _root_.Lean.MVarId.existsIntro (mvarId : MVarId) (w : Expr) : MetaM MVarId := do
   mvarId.withContext do

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,6 +1,6 @@
 #include "util/options.h"
 
-// [ ] Check box to force CI to test stage 2 and run update-stage0 on PR merge
+// [x] Check box to force CI to test stage 2 and run update-stage0 on PR merge
 // (any other change to this file will do the same; ALL changes should be made to the stage0/ copy)
 
 namespace lean {

--- a/tests/elab/constructor_ambiguous.lean
+++ b/tests/elab/constructor_ambiguous.lean
@@ -1,0 +1,122 @@
+/-!
+Tests that `constructor` warns when more than one constructor of the target's inductive type
+matches, that `constructor +first` and its shorthand `constructor!` suppress the warning, and that
+the selected constructor and the resulting goals are otherwise unchanged.
+-/
+
+inductive Foo : Nat → Prop where
+  | a : Foo 0
+  | b : Foo 0
+  | c : Foo 1
+
+/--
+warning: Tactic `constructor` applied constructor `Foo.a`, but `Foo.b` also matches the goal.
+
+Hint: Use `constructor!` to apply the first matching constructor without this warning:
+  [apply] constructor!
+-/
+#guard_msgs in
+example : Foo 0 := by constructor
+
+-- Only one constructor matches, so there is no warning.
+#guard_msgs in
+example : Foo 1 := by constructor
+
+-- Inductive types with a single constructor never warn.
+#guard_msgs in
+example (p q : Prop) (hp : p) (hq : q) : p ∧ q := by
+  constructor
+  · exact hp
+  · exact hq
+
+/--
+warning: Tactic `constructor` applied constructor `Or.inl`, but `Or.inr` also matches the goal.
+
+Hint: Use `constructor!` to apply the first matching constructor without this warning:
+  [apply] constructor!
+-/
+#guard_msgs in
+example : True ∨ True := by
+  constructor
+  trivial
+
+inductive Bar where
+  | a | b | c
+
+-- More than two matching constructors are all reported.
+/--
+warning: Tactic `constructor` applied constructor `Bar.a`, but `Bar.b` and `Bar.c` also match the goal.
+
+Hint: Use `constructor!` to apply the first matching constructor without this warning:
+  [apply] constructor!
+-/
+#guard_msgs in
+example : Bar := by constructor
+
+-- `constructor!` and `constructor +first` silently select the first matching constructor.
+#guard_msgs in
+example : Foo 0 := by constructor!
+
+#guard_msgs in
+example : Foo 0 := by constructor +first
+
+#guard_msgs in
+example : True ∨ True := by
+  constructor!
+  trivial
+
+-- `-first` explicitly requests the default behavior.
+/--
+warning: Tactic `constructor` applied constructor `Foo.a`, but `Foo.b` also matches the goal.
+
+Hint: Use `constructor!` to apply the first matching constructor without this warning:
+  [apply] constructor!
+-/
+#guard_msgs in
+example : Foo 0 := by constructor -first
+
+-- The ambiguity check does not disturb the goals produced by the selected constructor.
+inductive Baz : Nat → Prop where
+  | mk (h : True) (h' : False) : Baz 0
+  | mk' : Baz 0
+
+/--
+warning: Tactic `constructor` applied constructor `Baz.mk`, but `Baz.mk'` also matches the goal.
+
+Hint: Use `constructor!` to apply the first matching constructor without this warning:
+  [apply] constructor!
+---
+error: unsolved goals
+case h'
+⊢ False
+-/
+#guard_msgs in
+example : Baz 0 := by
+  constructor
+  · trivial
+
+-- Failures are unchanged.
+/--
+error: Tactic `constructor` failed: target is not an inductive datatype
+
+p q : Prop
+⊢ p → q
+-/
+#guard_msgs in
+example (p q : Prop) : p → q := by constructor
+
+/--
+error: Tactic `constructor` failed: no applicable constructor found
+
+⊢ Foo 2
+-/
+#guard_msgs in
+example : Foo 2 := by constructor
+
+/--
+error: Tactic `constructor` failed: no applicable constructor found
+
+⊢ Foo 2
+-/
+#guard_msgs in
+example : Foo 2 := by constructor!

--- a/tests/elab/grind_mvar_hyps.lean
+++ b/tests/elab/grind_mvar_hyps.lean
@@ -17,7 +17,7 @@ theorem grind_mvar_fail_2 (a res : Int) :
   rotate_left
   intro h h2
   grind
-  repeat constructor
+  repeat constructor!
 
 -- Simpler version: mvar in hypothesis directly proves goal
 theorem grind_mvar_simple (a : Nat) :

--- a/tests/elab/prelude-injectivity.lean
+++ b/tests/elab/prelude-injectivity.lean
@@ -20,6 +20,7 @@ gen_injective_theorems% Syntax.Preresolved
 gen_injective_theorems% Syntax.SepArray
 gen_injective_theorems% Syntax.TSepArray
 gen_injective_theorems% Try.Config
+gen_injective_theorems% Parser.Tactic.ConstructorConfig
 gen_injective_theorems% Parser.Tactic.DecideConfig
 gen_injective_theorems% Parser.Tactic.ImpossibleConfig
 gen_injective_theorems% Parser.Tactic.LibrarySearchConfig


### PR DESCRIPTION
This PR makes the `constructor` tactic emit a warning if multiple constructors match, and adds a `constructor!` tactic that has the previous behavior of silently applying the first matching constructor.

`constructor!` is actually a shortcut for `constructor +first` or `constructor (first := true)`.

The warning looks like this:
```
Tactic `constructor` applied constructor `Or.inl`, but `Or.inr` also matches the goal.

Hint: Use `constructor!` to apply the first matching constructor without this warning:
  [apply] constructor!
```

Closes #3129.