### PR TITLE
feat: add strong (co)induction principles for lattice-theoretic predicates

### DIFF
--- a/src/Init/Internal/Order/Basic.lean
+++ b/src/Init/Internal/Order/Basic.lean
@@ -377,6 +377,9 @@ Strong Park induction for the least fixpoint of a monotone function `f`: to show
 it suffices to show `f w ⊑ x` where `w` is a greatest lower bound of `x` and `lfp f`.
 The meet is passed as an explicit witness `w` (together with a proof of `is_meet x (lfp f) w`)
 so that callers can supply a definitionally convenient form of it.
+
+This is intended to be used in the construction of the strong induction principles of
+`inductive_fixpoint` and `coinductive_fixpoint`, and not meant to be used otherwise.
 -/
 theorem lfp_le_of_le_meet {f : α → α} (hm : monotone f) {x w : α}
     (hw : is_meet x (lfp f) w) (h : f w ⊑ x) : lfp f ⊑ x :=
@@ -385,6 +388,9 @@ theorem lfp_le_of_le_meet {f : α → α} (hm : monotone f) {x w : α}
 
 /--
 Same as `lfp_le_of_le_meet`, but uses the version of `lfp` that takes a witness of monotonicity.
+
+This is intended to be used in the construction of the strong induction principles of
+`inductive_fixpoint` and `coinductive_fixpoint`, and not meant to be used otherwise.
 -/
 theorem lfp_le_of_le_meet_monotone (f : α → α) {hm : monotone f} (x w : α)
     (hw : is_meet x (lfp_monotone f hm) w) :

--- a/src/Init/Internal/Order/Basic.lean
+++ b/src/Init/Internal/Order/Basic.lean
@@ -80,6 +80,15 @@ theorem is_sup_unique {α} [PartialOrder α] {c : α → Prop} {s₁ s₂ : α}
     intro y hy
     apply (h₁ s₁).mp PartialOrder.rel_refl y hy
 
+/--
+`is_meet x y w` states that `w` is a greatest lower bound of `x` and `y`.
+
+This is intended to be used in the construction of the strong induction principles of
+`inductive_fixpoint` and `coinductive_fixpoint`, and not meant to be used otherwise.
+-/
+@[expose] def is_meet (x y w : α) : Prop :=
+  w ⊑ x ∧ w ⊑ y ∧ ∀ z, z ⊑ x → z ⊑ y → z ⊑ w
+
 end PartialOrder
 
 section CCPO
@@ -363,6 +372,25 @@ theorem lfp_le_of_le_monotone (f : α → α) {hm : monotone f} (x : α):
     unfold lfp_monotone
     apply lfp_le_of_le
 
+/--
+Strong Park induction for the least fixpoint of a monotone function `f`: to show `lfp f ⊑ x`,
+it suffices to show `f w ⊑ x` where `w` is a greatest lower bound of `x` and `lfp f`.
+The meet is passed as an explicit witness `w` (together with a proof of `is_meet x (lfp f) w`)
+so that callers can supply a definitionally convenient form of it.
+-/
+theorem lfp_le_of_le_meet {f : α → α} (hm : monotone f) {x w : α}
+    (hw : is_meet x (lfp f) w) (h : f w ⊑ x) : lfp f ⊑ x :=
+  have hfw : f w ⊑ lfp f := rel_trans (hm _ _ hw.2.1) (lfp_prefixed (hm := hm))
+  rel_trans (lfp_le_of_le (hw.2.2 _ h hfw)) hw.1
+
+/--
+Same as `lfp_le_of_le_meet`, but uses the version of `lfp` that takes a witness of monotonicity.
+-/
+theorem lfp_le_of_le_meet_monotone (f : α → α) {hm : monotone f} (x w : α)
+    (hw : is_meet x (lfp_monotone f hm) w) :
+    f w ⊑ x → lfp_monotone f hm ⊑ x :=
+  lfp_le_of_le_meet hm hw
+
 end lattice_fix
 
 section fix
@@ -506,6 +534,12 @@ theorem monotone_apply [PartialOrder γ] [∀ x, PartialOrder (β x)] (a : α) (
     (h : monotone f) :
     monotone (fun x => f x a) := fun _ _ hfg => h _ _ hfg a
 
+/-- A pointwise greatest lower bound is a greatest lower bound in the pointwise order. -/
+theorem is_meet_pi [∀ x, PartialOrder (β x)] {f g w : ∀ x, β x}
+    (h : ∀ x, is_meet (f x) (g x) (w x)) : is_meet f g w :=
+  ⟨fun x => (h x).1, fun x => (h x).2.1,
+   fun z hzf hzg x => (h x).2.2 (z x) (hzf x) (hzg x)⟩
+
 theorem chain_apply [∀ x, PartialOrder (β x)] {c : (∀ x, β x) → Prop} (hc : chain c) (x : α) :
     chain (fun y => ∃ f, c f ∧ f x = y) := by
   intro _ _ ⟨f, hf, hfeq⟩ ⟨g, hg, hgeq⟩
@@ -628,6 +662,12 @@ instance [PartialOrder α] [PartialOrder β] : PartialOrder (α ×' β) where
     cases a; cases b;
     dsimp at *
     rw [rel_antisymm ha.1 hb.1, rel_antisymm ha.2 hb.2]
+
+/-- A componentwise greatest lower bound is a greatest lower bound in the product order. -/
+theorem is_meet_pprod [PartialOrder α] [PartialOrder β] {x y w : α ×' β}
+    (h₁ : is_meet x.1 y.1 w.1) (h₂ : is_meet x.2 y.2 w.2) : is_meet x y w :=
+  ⟨⟨h₁.1, h₂.1⟩, ⟨h₁.2.1, h₂.2.1⟩,
+   fun z hzx hzy => ⟨h₁.2.2 z.1 hzx.1 hzy.1, h₂.2.2 z.2 hzx.2 hzy.2⟩⟩
 
 @[partial_fixpoint_monotone]
 theorem PProd.monotone_mk [PartialOrder α] [PartialOrder β] [PartialOrder γ]
@@ -1114,6 +1154,10 @@ instance ImplicationOrder.instCompleteLattice : CompleteLattice ImplicationOrder
     | Or.inl hfx₁ => Or.inl (h₁ x y hxy hfx₁)
     | Or.inr hfx₂ => Or.inr (h₂ x y hxy hfx₂)
 
+/-- In the implication order the meet of two propositions is their conjunction. -/
+theorem ImplicationOrder.is_meet_and (x y : ImplicationOrder) : is_meet x y (x ∧ y : Prop) :=
+  ⟨And.left, And.right, fun _ hzx hzy hz => ⟨hzx hz, hzy hz⟩⟩
+
 end implication_order
 
 section reverse_implication_order
@@ -1173,6 +1217,12 @@ instance ReverseImplicationOrder.instCompleteLattice : CompleteLattice ReverseIm
     match h with
     | Or.inl hfx₁ => Or.inl (h₁ x y hxy hfx₁)
     | Or.inr hfx₂ => Or.inr (h₂ x y hxy hfx₂)
+
+/-- In the reverse implication order the meet of two propositions is their disjunction. -/
+theorem ReverseImplicationOrder.is_meet_or (x y : ReverseImplicationOrder) :
+    is_meet x y (x ∨ y : Prop) :=
+  ⟨Or.inl, Or.inr, fun _ hzx hzy hw => hw.elim hzx hzy⟩
+
 end reverse_implication_order
 
 section antitone

--- a/src/Lean/Elab/PreDefinition/PartialFixpoint/Induction.lean
+++ b/src/Lean/Elab/PreDefinition/PartialFixpoint/Induction.lean
@@ -102,25 +102,75 @@ private def numberNames (n : Nat) (base : String) : Array Name :=
   .ofFn (n := n) fun ⟨i, _⟩ =>
     if n == 1 then .mkSimple base else .mkSimple s!"{base}_{i+1}"
 
-def getInductionPrinciplePostfix (name : Name) (isMutual : Bool) : MetaM Name := do
+def getInductionPrinciplePostfix (name : Name) (isMutual : Bool) (strong : Bool := false) : MetaM Name := do
   let some eqnInfo := eqnInfoExt.find? (← getEnv) name | throwError "{name} is not defined by partial_fixpoint, inductive_fixpoint, nor coinductive_fixpoint"
   let idx := eqnInfo.declNames.idxOf name
   let some res := eqnInfo.fixpointType[idx]? | throwError "Cannot get fixpoint type for {name}"
-  match res, isMutual with
-  | .partialFixpoint, false => return `fixpoint_induct
-  | .inductiveFixpoint, false => return `induct
-  | .coinductiveFixpoint, false => return `coinduct
-  | .partialFixpoint, true => return `mutual_fixpoint_induct
-  | _, true => return `mutual_induct
+  match res, isMutual, strong with
+  | .partialFixpoint, _, true => throwError "There is no strong induction principle for functions defined by partial_fixpoint"
+  | .partialFixpoint, false, false => return `fixpoint_induct
+  | .inductiveFixpoint, false, false => return `induct
+  | .coinductiveFixpoint, false, false => return `coinduct
+  | .inductiveFixpoint, false, true => return `strong_induct
+  | .coinductiveFixpoint, false, true => return `strong_coinduct
+  | .partialFixpoint, true, false => return `mutual_fixpoint_induct
+  | _, true, false => return `mutual_induct
+  | _, true, true => return `strong_mutual_induct
 
-def deriveInduction (name : Name) (isMutual : Bool) : MetaM Unit := do
-  let postFix ← getInductionPrinciplePostfix name isMutual
+/--
+Constructs a proof of `is_meet x y w` in the packed lattice of a (co)inductive fixpoint, where
+`x = ⟨pred₁, …⟩` is the tuple of candidate predicates, `y = ⟨f₁, …⟩` the tuple of the defined
+predicates, and `w = ⟨w₁, …⟩` the tuple of pointwise meets
+`wᵢ = fun xs => predᵢ xs ∨ fᵢ xs` (resp. `∧` for inductive components).
+
+The proof is composed from `is_meet_pprod` along the tuple, `is_meet_pi` along the parameters of
+each predicate, and the meet characterizations of `ImplicationOrder`/`ReverseImplicationOrder`.
+-/
+def mkIsMeetProof (predTypes predVars wComponents fInsts : Array Expr)
+    (fixpointTypes : Array PartialFixpointType) : MetaM Expr := do
+  -- Note: all carriers and `PartialOrder` instances are passed explicitly. The carriers
+  -- (`ImplicationOrder`/`ReverseImplicationOrder` and their pi types) are definitionally but not
+  -- syntactically equal to the types of the predicates, so instance synthesis cannot find them.
+  let componentProofs ← predTypes.mapIdxM fun i predType =>
+    forallTelescopeReducing predType fun ts _ => do
+      let leafLemma := if isCoinductiveFixpoint fixpointTypes[i]! then
+          ``ReverseImplicationOrder.is_meet_or
+        else
+          ``ImplicationOrder.is_meet_and
+      let mut proof := mkApp2 (mkConst leafLemma) (mkAppN predVars[i]! ts) (fInsts[i]!.beta ts)
+      for t in ts.reverse do
+        let ty ← inferType proof
+        let_expr is_meet σ inst a b w := ty
+          | throwError "mkIsMeetProof: unexpected proof type{indentExpr ty}"
+        proof ← mkAppOptM ``is_meet_pi #[← inferType t,
+          ← mkLambdaFVars #[t] σ, ← mkLambdaFVars #[t] inst, ← mkLambdaFVars #[t] a,
+          ← mkLambdaFVars #[t] b, ← mkLambdaFVars #[t] w, ← mkLambdaFVars #[t] proof]
+      return proof
+  let mut proof := componentProofs.back!
+  for j in (Array.range (predTypes.size - 1)).reverse do
+    let ty₂ ← inferType proof
+    let_expr is_meet σ₂ inst₂ _ _ _ := ty₂
+      | throwError "mkIsMeetProof: unexpected proof type{indentExpr ty₂}"
+    let ty₁ ← inferType componentProofs[j]!
+    let_expr is_meet σ₁ inst₁ _ _ _ := ty₁
+      | throwError "mkIsMeetProof: unexpected proof type{indentExpr ty₁}"
+    let subX ← PProdN.mk 0 predVars[j:].toArray
+    let subY ← PProdN.mk 0 fInsts[j:].toArray
+    let subW ← PProdN.mk 0 wComponents[j:].toArray
+    proof ← mkAppOptM ``is_meet_pprod
+      #[σ₁, σ₂, inst₁, inst₂, subX, subY, subW, componentProofs[j]!, proof]
+  return proof
+
+def deriveInduction (name : Name) (isMutual : Bool) (strong : Bool := false) : MetaM Unit := do
+  let postFix ← getInductionPrinciplePostfix name isMutual strong
   let inductName := name ++ postFix
   realizeConst name inductName do
   trace[Elab.definition.partialFixpoint] "Called deriveInduction for {inductName}"
   prependError m!"Cannot derive fixpoint induction principle (please report this issue)" do
     let some eqnInfo := eqnInfoExt.find? (← getEnv) name |
       throwError "{name} is not defined by partial_fixpoint"
+    if strong && !eqnInfo.fixpointType.all isLatticeTheoretic then
+      throwError "strong induction principles are only supported for inductive_fixpoint and coinductive_fixpoint"
     let infos ← eqnInfo.declNames.mapM getConstInfoDefn
     let e' ← eqnInfo.fixedParamPerms.perms[0]!.forallTelescope infos[0]!.type fun xs => do
       -- Now look at the body of an arbitrary of the functions (they are essentially the same
@@ -135,60 +185,124 @@ def deriveInduction (name : Name) (isMutual : Bool) : MetaM Unit := do
           | throwError "Unexpected function body {body}, could not whnfUntil lfp_monotone"
         let_expr lfp_monotone α instcomplete_lattice F hmono := fixApp
           | throwError "Unexpected function body {body}, not an application of lfp_monotone"
-        let e' ← mkAppOptM ``lfp_le_of_le_monotone #[α, instcomplete_lattice, F, hmono]
-        -- All definitions from `mutual` block as PProdN
-        let packedConclusion ← PProdN.mk 1 <| ← infos.mapIdxM fun i defVal => do
+        -- The definitions from the `mutual` block, eta-expanded and folded
+        let fInsts ← infos.mapIdxM fun i defVal => do
           let f ← mkConstWithLevelParams defVal.name
           let fEtaExpanded ← lambdaTelescope defVal.value fun ys _ =>
             mkLambdaFVars ys (mkAppN f ys)
-            let fInst ← eqnInfo.fixedParamPerms.perms[i]!.instantiateLambda fEtaExpanded xs
-            return fInst.eta
-        -- We get the type of the induction principle
-        let eTyp ← inferType e'
-        -- And unfold the conclusion, upon replacing references to the fixpoint theorem with the defined functions
-        let eTyp ← forallTelescope eTyp fun args body => do
-          let_expr PartialOrder.rel α pord _ pred := body
-            | throwError "Unexpected function type {body}, not an application of PartialOrder.rel"
-          let newBody ← mkAppOptM ``PartialOrder.rel #[α, pord, packedConclusion, pred]
-          let unfolded ← unfoldPredRelMutual eqnInfo newBody
-          let newBody ← PProdN.pack 0 unfolded
-          mkForallFVars args newBody
-        let e' ← mkExpectedTypeHint e' eTyp
-        -- We obtain the premises of (co)induction proof principle
-        let motives ← forallTelescope eTyp fun args _ => do
-          let motives ← unfoldPredRelMutual eqnInfo (←inferType args[1]!) (reduceConclusion := true)
-          motives.mapM (fun x => mkForallFVars #[args[0]!] x)
-        -- For each predicate in the mutual group we generate an appropriate candidate predicate
-        let predicates := (numberNames infos.size "pred").zip <| ← PProdN.unpack α infos.size
-        -- Then we make the induction principle more readable, by currying the hypotheses and projecting the conclusion
-        withLocalDeclsDND predicates fun predVars => do
-          -- A joint approximation to the fixpoint
-          let predVar ← PProdN.mk 0 predVars
-          -- All motives get instantiated with the newly created variables
-          let newMotives ← motives.mapM (instantiateForall · #[predVar])
-          let newMotives ← newMotives.mapM (PProdN.reduceProjs ·)
-          -- Then, we introduce hypotheses
-          withLocalDeclsDND ((numberNames infos.size "hyp").zip newMotives) fun motiveVars => do
-            let e' := mkApp e' predVar
-            let eTyp ← inferType e'
-            -- Conclusion gets cleaned up from `PProd` projections
-            let e' ← mkExpectedTypeHint e' (← PProdN.reduceProjs eTyp)
-            -- We apply all the premises
-            let packedPremise ← PProdN.mk 0 motiveVars
-            let e' := mkApp e' packedPremise
-            -- For the `mutual_induct` variant, we are done.
-            -- Else, project out the appropriate element
-            let e' ← if isMutual then
-                pure e'
-              else
-                PProdN.projM infos.size (eqnInfo.declNames.idxOf name) e'
-            -- Finally, we bind all the free variables with lambdas
-            let e' ← mkLambdaFVars motiveVars e'
-            let e' ← mkLambdaFVars predVars e'
-            let e' ← mkLambdaFVars (binderInfoForMVars := .default) (usedOnly := true) xs e'
-            let e' ← instantiateMVars e'
-            trace[Elab.definition.partialFixpoint.induction] "Complete body of fixpoint induction principle:{indentExpr e'}"
-            pure e'
+          let fInst ← eqnInfo.fixedParamPerms.perms[i]!.instantiateLambda fEtaExpanded xs
+          return fInst.eta
+        -- All definitions from `mutual` block as PProdN
+        let packedConclusion ← PProdN.mk 1 fInsts
+        if strong then
+          let predTypes ← PProdN.unpack α infos.size
+          -- For each predicate in the mutual group we generate an appropriate candidate predicate
+          let predicates := (numberNames infos.size "pred").zip predTypes
+          withLocalDeclsDND predicates fun predVars => do
+            -- A joint approximation to the fixpoint
+            let predVar ← PProdN.mk 0 predVars
+            -- The pointwise meet of the candidate predicates and the defined predicates:
+            -- disjunction for coinductive components, conjunction for inductive ones
+            let wComponents ← predTypes.mapIdxM fun i predType =>
+              forallTelescopeReducing predType fun ts _ => do
+                let conn := if isCoinductiveFixpoint eqnInfo.fixpointType[i]! then ``Or else ``And
+                mkLambdaFVars ts <|
+                  mkApp2 (mkConst conn) (mkAppN predVars[i]! ts) (fInsts[i]!.beta ts)
+            let wPacked ← PProdN.mk 0 wComponents
+            let hw ← mkIsMeetProof predTypes predVars wComponents fInsts eqnInfo.fixpointType
+            -- The type of `hw` mentions the folded predicates where the expected argument type
+            -- mentions the `lfp_monotone` application; these are definitionally equal, but only
+            -- the kernel can see this (`lfp_monotone` is not exposed), so we apply `hw` without
+            -- an elaboration-time check.
+            let e' ← mkAppOptM ``lfp_le_of_le_meet_monotone
+              #[α, instcomplete_lattice, F, hmono, predVar, wPacked]
+            let e' := mkApp e' hw
+            -- The type of `e'` is now `F w ⊑ pred → lfp F hmono ⊑ pred`;
+            -- we unfold its premise into per-predicate quantified implications
+            let .forallE _ premiseType _ _ ← inferType e'
+              | throwError "Unexpected type of strong induction principle"
+            let premises ← unfoldPredRelMutual eqnInfo premiseType (reduceConclusion := true)
+            let premises ← premises.mapM fun p => do Core.betaReduce (← PProdN.reduceProjs p)
+            -- Then, we introduce hypotheses
+            withLocalDeclsDND ((numberNames infos.size "hyp").zip premises) fun hypVars => do
+              let packedHyp ← PProdN.mk 0 hypVars
+              let e' := mkApp e' packedHyp
+              -- In the conclusion, we replace the `lfp` application by the folded predicates
+              -- and unfold the partial order relation
+              let conclType ← inferType e'
+              let_expr PartialOrder.rel cType pord _ cPred := conclType
+                | throwError "Unexpected conclusion {conclType}, not an application of PartialOrder.rel"
+              let newConcl ← mkAppOptM ``PartialOrder.rel #[cType, pord, packedConclusion, cPred]
+              let unfolded ← unfoldPredRelMutual eqnInfo newConcl
+              -- Definitions with a fixed parameter after a varying one do not eta-reduce to a
+              -- partial application in `fInsts`, leaving beta redexes in the conclusion
+              let unfolded ← unfolded.mapM (Core.betaReduce ·)
+              let conclType ← PProdN.reduceProjs (← PProdN.pack 0 unfolded)
+              let e' ← mkExpectedTypeHint e' conclType
+              -- For the `strong_mutual_induct` variant, we are done.
+              -- Else, project out the appropriate element
+              let e' ← if isMutual then
+                  pure e'
+                else
+                  PProdN.projM infos.size (eqnInfo.declNames.idxOf name) e'
+              -- Finally, we bind all the free variables with lambdas
+              let e' ← mkLambdaFVars hypVars e'
+              let e' ← mkLambdaFVars predVars e'
+              let e' ← mkLambdaFVars (binderInfoForMVars := .default) (usedOnly := true) xs e'
+              let e' ← instantiateMVars e'
+              trace[Elab.definition.partialFixpoint.induction] "Complete body of strong fixpoint induction principle:{indentExpr e'}"
+              pure e'
+        else
+          let e' ← mkAppOptM ``lfp_le_of_le_monotone #[α, instcomplete_lattice, F, hmono]
+          -- We get the type of the induction principle
+          let eTyp ← inferType e'
+          -- And unfold the conclusion, upon replacing references to the fixpoint theorem with the defined functions
+          let eTyp ← forallTelescope eTyp fun args body => do
+            let_expr PartialOrder.rel α pord _ pred := body
+              | throwError "Unexpected function type {body}, not an application of PartialOrder.rel"
+            let newBody ← mkAppOptM ``PartialOrder.rel #[α, pord, packedConclusion, pred]
+            let unfolded ← unfoldPredRelMutual eqnInfo newBody
+            -- Definitions with a fixed parameter after a varying one do not eta-reduce to a
+            -- partial application in `packedConclusion`, leaving beta redexes in the conclusion
+            let unfolded ← unfolded.mapM (Core.betaReduce ·)
+            let newBody ← PProdN.pack 0 unfolded
+            mkForallFVars args newBody
+          let e' ← mkExpectedTypeHint e' eTyp
+          -- We obtain the premises of (co)induction proof principle
+          let motives ← forallTelescope eTyp fun args _ => do
+            let motives ← unfoldPredRelMutual eqnInfo (←inferType args[1]!) (reduceConclusion := true)
+            motives.mapM (fun x => mkForallFVars #[args[0]!] x)
+          -- For each predicate in the mutual group we generate an appropriate candidate predicate
+          let predicates := (numberNames infos.size "pred").zip <| ← PProdN.unpack α infos.size
+          -- Then we make the induction principle more readable, by currying the hypotheses and projecting the conclusion
+          withLocalDeclsDND predicates fun predVars => do
+            -- A joint approximation to the fixpoint
+            let predVar ← PProdN.mk 0 predVars
+            -- All motives get instantiated with the newly created variables
+            let newMotives ← motives.mapM (instantiateForall · #[predVar])
+            let newMotives ← newMotives.mapM (PProdN.reduceProjs ·)
+            -- Then, we introduce hypotheses
+            withLocalDeclsDND ((numberNames infos.size "hyp").zip newMotives) fun motiveVars => do
+              let e' := mkApp e' predVar
+              let eTyp ← inferType e'
+              -- Conclusion gets cleaned up from `PProd` projections
+              let e' ← mkExpectedTypeHint e' (← PProdN.reduceProjs eTyp)
+              -- We apply all the premises
+              let packedPremise ← PProdN.mk 0 motiveVars
+              let e' := mkApp e' packedPremise
+              -- For the `mutual_induct` variant, we are done.
+              -- Else, project out the appropriate element
+              let e' ← if isMutual then
+                  pure e'
+                else
+                  PProdN.projM infos.size (eqnInfo.declNames.idxOf name) e'
+              -- Finally, we bind all the free variables with lambdas
+              let e' ← mkLambdaFVars motiveVars e'
+              let e' ← mkLambdaFVars predVars e'
+              let e' ← mkLambdaFVars (binderInfoForMVars := .default) (usedOnly := true) xs e'
+              let e' ← instantiateMVars e'
+              trace[Elab.definition.partialFixpoint.induction] "Complete body of fixpoint induction principle:{indentExpr e'}"
+              pure e'
       else
         let some fixApp ← whnfUntil body' ``fix
           | throwError "Unexpected function body {body}, could not whnfUntil fix"
@@ -282,17 +396,17 @@ def isInductName (env : Environment) (name : Name) : Bool := Id.run do
     if let some eqnInfo := eqnInfoExt.find? env p then
       return eqnInfo.fixpointType.all isPartialFixpoint
     return false
-  | "coinduct" =>
+  | "coinduct" | "strong_coinduct" =>
     if let some eqnInfo := eqnInfoExt.find? env p then
       let idx := eqnInfo.declNames.idxOf p
       return isCoinductiveFixpoint eqnInfo.fixpointType[idx]!
     return false
-  | "induct" =>
+  | "induct" | "strong_induct" =>
     if let some eqnInfo := eqnInfoExt.find? env p then
       let idx := eqnInfo.declNames.idxOf p
       return isInductiveFixpoint eqnInfo.fixpointType[idx]!
     return false
-  | "mutual_induct" =>
+  | "mutual_induct" | "strong_mutual_induct" =>
     if let some eqnInfo := eqnInfoExt.find? env p then
       return eqnInfo.declNames[0]! == p && eqnInfo.declNames.size > 1 && eqnInfo.fixpointType.all isLatticeTheoretic
     return false
@@ -309,7 +423,8 @@ builtin_initialize
     if isInductName (← getEnv) name then
       let .str p s := name | return false
       let isMutual := s.endsWith "mutual_induct" || s.endsWith "mutual_fixpoint_induct"
-      MetaM.run' <| deriveInduction p isMutual
+      let strong := s.startsWith "strong_"
+      MetaM.run' <| deriveInduction p isMutual strong
       return true
     return false
 

--- a/src/Lean/Elab/PreDefinition/PartialFixpoint/Induction.lean
+++ b/src/Lean/Elab/PreDefinition/PartialFixpoint/Induction.lean
@@ -128,9 +128,6 @@ each predicate, and the meet characterizations of `ImplicationOrder`/`ReverseImp
 -/
 def mkIsMeetProof (predTypes predVars wComponents fInsts : Array Expr)
     (fixpointTypes : Array PartialFixpointType) : MetaM Expr := do
-  -- Note: all carriers and `PartialOrder` instances are passed explicitly. The carriers
-  -- (`ImplicationOrder`/`ReverseImplicationOrder` and their pi types) are definitionally but not
-  -- syntactically equal to the types of the predicates, so instance synthesis cannot find them.
   let componentProofs ← predTypes.mapIdxM fun i predType =>
     forallTelescopeReducing predType fun ts _ => do
       let leafLemma := if isCoinductiveFixpoint fixpointTypes[i]! then
@@ -194,90 +191,84 @@ def deriveInduction (name : Name) (isMutual : Bool) (strong : Bool := false) : M
           return fInst.eta
         -- All definitions from `mutual` block as PProdN
         let packedConclusion ← PProdN.mk 1 fInsts
-        if strong then
-          let predTypes ← PProdN.unpack α infos.size
-          -- For each predicate in the mutual group we generate an appropriate candidate predicate
-          let predicates := (numberNames infos.size "pred").zip predTypes
-          withLocalDeclsDND predicates fun predVars => do
-            -- A joint approximation to the fixpoint
-            let predVar ← PProdN.mk 0 predVars
-            -- The pointwise meet of the candidate predicates and the defined predicates:
-            -- disjunction for coinductive components, conjunction for inductive ones
-            let wComponents ← predTypes.mapIdxM fun i predType =>
-              forallTelescopeReducing predType fun ts _ => do
-                let conn := if isCoinductiveFixpoint eqnInfo.fixpointType[i]! then ``Or else ``And
-                mkLambdaFVars ts <|
-                  mkApp2 (mkConst conn) (mkAppN predVars[i]! ts) (fInsts[i]!.beta ts)
-            let wPacked ← PProdN.mk 0 wComponents
-            let hw ← mkIsMeetProof predTypes predVars wComponents fInsts eqnInfo.fixpointType
-            -- The type of `hw` mentions the folded predicates where the expected argument type
-            -- mentions the `lfp_monotone` application; these are definitionally equal, but only
-            -- the kernel can see this (`lfp_monotone` is not exposed), so we apply `hw` without
-            -- an elaboration-time check.
-            let e' ← mkAppOptM ``lfp_le_of_le_meet_monotone
-              #[α, instcomplete_lattice, F, hmono, predVar, wPacked]
-            let e' := mkApp e' hw
-            -- The type of `e'` is now `F w ⊑ pred → lfp F hmono ⊑ pred`;
-            -- we unfold its premise into per-predicate quantified implications
-            let .forallE _ premiseType _ _ ← inferType e'
-              | throwError "Unexpected type of strong induction principle"
-            let premises ← unfoldPredRelMutual eqnInfo premiseType (reduceConclusion := true)
-            let premises ← premises.mapM fun p => do Core.betaReduce (← PProdN.reduceProjs p)
-            -- Then, we introduce hypotheses
-            withLocalDeclsDND ((numberNames infos.size "hyp").zip premises) fun hypVars => do
-              let packedHyp ← PProdN.mk 0 hypVars
-              let e' := mkApp e' packedHyp
-              -- In the conclusion, we replace the `lfp` application by the folded predicates
-              -- and unfold the partial order relation
-              let conclType ← inferType e'
-              let_expr PartialOrder.rel cType pord _ cPred := conclType
-                | throwError "Unexpected conclusion {conclType}, not an application of PartialOrder.rel"
-              let newConcl ← mkAppOptM ``PartialOrder.rel #[cType, pord, packedConclusion, cPred]
-              let unfolded ← unfoldPredRelMutual eqnInfo newConcl
+        -- For each predicate in the mutual group we generate an appropriate candidate predicate
+        let predTypes ← PProdN.unpack α infos.size
+        let predicates := (numberNames infos.size "pred").zip predTypes
+        withLocalDeclsDND predicates fun predVars => do
+          -- A joint approximation to the fixpoint
+          let predVar ← PProdN.mk 0 predVars
+          if strong then
+              -- The pointwise meet of the candidate predicates and the defined predicates:
+              -- disjunction for coinductive components, conjunction for inductive ones
+              let wComponents ← predTypes.mapIdxM fun i predType =>
+                forallTelescopeReducing predType fun ts _ => do
+                  let conn := if isCoinductiveFixpoint eqnInfo.fixpointType[i]! then ``Or else ``And
+                  mkLambdaFVars ts <|
+                    mkApp2 (mkConst conn) (mkAppN predVars[i]! ts) (fInsts[i]!.beta ts)
+              let wPacked ← PProdN.mk 0 wComponents
+              let hw ← mkIsMeetProof predTypes predVars wComponents fInsts eqnInfo.fixpointType
+              -- The type of `hw` mentions the folded predicates where the expected argument type
+              -- mentions the `lfp_monotone` application; these are definitionally equal, but only
+              -- the kernel can see this (`lfp_monotone` is not exposed), so we apply `hw` without
+              -- an elaboration-time check.
+              let e' ← mkAppOptM ``lfp_le_of_le_meet_monotone
+                #[α, instcomplete_lattice, F, hmono, predVar, wPacked]
+              let e' := mkApp e' hw
+              -- The type of `e'` is now `F w ⊑ pred → lfp F hmono ⊑ pred`;
+              -- we unfold its premise into per-predicate quantified implications
+              let .forallE _ premiseType _ _ ← inferType e'
+                | throwError "Unexpected type of strong induction principle"
+              let premises ← unfoldPredRelMutual eqnInfo premiseType (reduceConclusion := true)
+              let premises ← premises.mapM fun p => do Core.betaReduce (← PProdN.reduceProjs p)
+              -- Then, we introduce hypotheses
+              withLocalDeclsDND ((numberNames infos.size "hyp").zip premises) fun motiveVars => do
+                let packedHyp ← PProdN.mk 0 motiveVars
+                let e' := mkApp e' packedHyp
+                -- In the conclusion, we replace the `lfp` application by the folded predicates
+                -- and unfold the partial order relation
+                let conclType ← inferType e'
+                let_expr PartialOrder.rel cType pord _ cPred := conclType
+                  | throwError "Unexpected conclusion {conclType}, not an application of PartialOrder.rel"
+                let newConcl ← mkAppOptM ``PartialOrder.rel #[cType, pord, packedConclusion, cPred]
+                let unfolded ← unfoldPredRelMutual eqnInfo newConcl
+                -- Definitions with a fixed parameter after a varying one do not eta-reduce to a
+                -- partial application in `fInsts`, leaving beta redexes in the conclusion
+                let unfolded ← unfolded.mapM (Core.betaReduce ·)
+                let conclType ← PProdN.reduceProjs (← PProdN.pack 0 unfolded)
+                let e' ← mkExpectedTypeHint e' conclType
+                -- For the `strong_mutual_induct` variant, we are done.
+                -- Else, project out the appropriate element
+                let e' ← if isMutual then
+                    pure e'
+                  else
+                    PProdN.projM infos.size (eqnInfo.declNames.idxOf name) e'
+                -- Finally, we bind all the free variables with lambdas
+                let e' ← mkLambdaFVars motiveVars e'
+                let e' ← mkLambdaFVars predVars e'
+                let e' ← mkLambdaFVars (binderInfoForMVars := .default) (usedOnly := true) xs e'
+                let e' ← instantiateMVars e'
+                trace[Elab.definition.partialFixpoint.induction] "Complete body of strong fixpoint induction principle:{indentExpr e'}"
+                pure e'
+          else
+            let e' ← mkAppOptM ``lfp_le_of_le_monotone #[α, instcomplete_lattice, F, hmono]
+            -- We get the type of the induction principle
+            let eTyp ← inferType e'
+            -- And unfold the conclusion, upon replacing references to the fixpoint theorem with the defined functions
+            let eTyp ← forallTelescope eTyp fun args body => do
+              let_expr PartialOrder.rel α pord _ pred := body
+                | throwError "Unexpected function type {body}, not an application of PartialOrder.rel"
+              let newBody ← mkAppOptM ``PartialOrder.rel #[α, pord, packedConclusion, pred]
+              let unfolded ← unfoldPredRelMutual eqnInfo newBody
               -- Definitions with a fixed parameter after a varying one do not eta-reduce to a
-              -- partial application in `fInsts`, leaving beta redexes in the conclusion
+              -- partial application in `packedConclusion`, leaving beta redexes in the conclusion
               let unfolded ← unfolded.mapM (Core.betaReduce ·)
-              let conclType ← PProdN.reduceProjs (← PProdN.pack 0 unfolded)
-              let e' ← mkExpectedTypeHint e' conclType
-              -- For the `strong_mutual_induct` variant, we are done.
-              -- Else, project out the appropriate element
-              let e' ← if isMutual then
-                  pure e'
-                else
-                  PProdN.projM infos.size (eqnInfo.declNames.idxOf name) e'
-              -- Finally, we bind all the free variables with lambdas
-              let e' ← mkLambdaFVars hypVars e'
-              let e' ← mkLambdaFVars predVars e'
-              let e' ← mkLambdaFVars (binderInfoForMVars := .default) (usedOnly := true) xs e'
-              let e' ← instantiateMVars e'
-              trace[Elab.definition.partialFixpoint.induction] "Complete body of strong fixpoint induction principle:{indentExpr e'}"
-              pure e'
-        else
-          let e' ← mkAppOptM ``lfp_le_of_le_monotone #[α, instcomplete_lattice, F, hmono]
-          -- We get the type of the induction principle
-          let eTyp ← inferType e'
-          -- And unfold the conclusion, upon replacing references to the fixpoint theorem with the defined functions
-          let eTyp ← forallTelescope eTyp fun args body => do
-            let_expr PartialOrder.rel α pord _ pred := body
-              | throwError "Unexpected function type {body}, not an application of PartialOrder.rel"
-            let newBody ← mkAppOptM ``PartialOrder.rel #[α, pord, packedConclusion, pred]
-            let unfolded ← unfoldPredRelMutual eqnInfo newBody
-            -- Definitions with a fixed parameter after a varying one do not eta-reduce to a
-            -- partial application in `packedConclusion`, leaving beta redexes in the conclusion
-            let unfolded ← unfolded.mapM (Core.betaReduce ·)
-            let newBody ← PProdN.pack 0 unfolded
-            mkForallFVars args newBody
-          let e' ← mkExpectedTypeHint e' eTyp
-          -- We obtain the premises of (co)induction proof principle
-          let motives ← forallTelescope eTyp fun args _ => do
-            let motives ← unfoldPredRelMutual eqnInfo (←inferType args[1]!) (reduceConclusion := true)
-            motives.mapM (fun x => mkForallFVars #[args[0]!] x)
-          -- For each predicate in the mutual group we generate an appropriate candidate predicate
-          let predicates := (numberNames infos.size "pred").zip <| ← PProdN.unpack α infos.size
-          -- Then we make the induction principle more readable, by currying the hypotheses and projecting the conclusion
-          withLocalDeclsDND predicates fun predVars => do
-            -- A joint approximation to the fixpoint
-            let predVar ← PProdN.mk 0 predVars
+              let newBody ← PProdN.pack 0 unfolded
+              mkForallFVars args newBody
+            let e' ← mkExpectedTypeHint e' eTyp
+            -- We obtain the premises of (co)induction proof principle
+            let motives ← forallTelescope eTyp fun args _ => do
+              let motives ← unfoldPredRelMutual eqnInfo (←inferType args[1]!) (reduceConclusion := true)
+              motives.mapM (fun x => mkForallFVars #[args[0]!] x)
             -- All motives get instantiated with the newly created variables
             let newMotives ← motives.mapM (instantiateForall · #[predVar])
             let newMotives ← newMotives.mapM (PProdN.reduceProjs ·)

--- a/tests/elab/coinductive_predicates.lean
+++ b/tests/elab/coinductive_predicates.lean
@@ -41,7 +41,7 @@ inductive_fixpoint
 
 /--
 info: star_ind.induct.{u_1} {α : Sort u_1} (tr : α → α → Prop) (q₂ : α) (pred : α → Prop)
-  (hyp : ∀ (q₁ : α), (∃ z, q₁ = q₂ ∨ tr q₁ z ∧ pred z) → pred q₁) (q₁ : α) : (fun q₁ => star_ind tr q₁ q₂) q₁ → pred q₁
+  (hyp : ∀ (q₁ : α), (∃ z, q₁ = q₂ ∨ tr q₁ z ∧ pred z) → pred q₁) (q₁ : α) : star_ind tr q₁ q₂ → pred q₁
 -/
 #guard_msgs in #check star_ind.induct
 

--- a/tests/elab/strong_fixpoint_induction.lean
+++ b/tests/elab/strong_fixpoint_induction.lean
@@ -1,0 +1,164 @@
+/-!
+Tests the strong (co)induction principles (`strong_coinduct`, `strong_induct`,
+`strong_mutual_induct`) generated for predicates defined by `inductive_fixpoint`,
+`coinductive_fixpoint` and the `coinductive` keyword. These strengthen the Park
+(co)induction principles: recursive occurrences in the hypothesis carry the candidate
+predicate joined (`∨`) with the coinductive predicate itself, respectively met (`∧`)
+with the inductive predicate itself.
+-/
+
+namespace StrongCoinduction
+
+def infseq {α : Sort u} (R : α → α → Prop) (x : α) : Prop :=
+  ∃ y, R x y ∧ infseq R y
+  coinductive_fixpoint
+
+/--
+info: StrongCoinduction.infseq.strong_coinduct.{u} {α : Sort u} (R : α → α → Prop) (pred : α → Prop)
+  (hyp : ∀ (x : α), pred x → ∃ y, R x y ∧ (pred y ∨ infseq R y)) (x : α) : pred x → infseq R x
+-/
+#guard_msgs in
+#check infseq.strong_coinduct
+
+-- The `∨`-strengthening lets a proof by coinduction stop as soon as it enters the
+-- coinductive predicate itself.
+theorem infseq_step_into {α} {R : α → α → Prop} {x y : α} (hxy : R x y) (hy : infseq R y) :
+    infseq R x := by
+  apply infseq.strong_coinduct R (fun a => a = x) _ _ rfl
+  intro a ha
+  subst ha
+  exact ⟨y, hxy, Or.inr hy⟩
+
+end StrongCoinduction
+
+namespace StrongInduction
+
+def star (R : α → α → Prop) (x y : α) : Prop :=
+  x = y ∨ ∃ z, R x z ∧ star R z y
+  inductive_fixpoint
+
+/--
+info: StrongInduction.star.strong_induct.{u_1} {α : Sort u_1} (R : α → α → Prop) (y : α) (pred : α → Prop)
+  (hyp : ∀ (x : α), (x = y ∨ ∃ z, R x z ∧ pred z ∧ star R z y) → pred x) (x : α) : star R x y → pred x
+-/
+#guard_msgs in
+#check star.strong_induct
+
+-- The `∧`-strengthening gives access to the inductive predicate itself in the
+-- induction hypothesis.
+theorem star_unfold {α} {R : α → α → Prop} {x y : α} (h : star R x y) :
+    x = y ∨ ∃ z, R x z ∧ star R z y := by
+  apply star.strong_induct R y (fun a => a = y ∨ ∃ z, R a z ∧ star R z y) _ x h
+  intro a hab
+  cases hab with
+  | inl h => exact Or.inl h
+  | inr h => exact Or.inr ⟨h.choose, h.choose_spec.1, h.choose_spec.2.2⟩
+
+end StrongInduction
+
+namespace MutualStrongCoinduction
+
+mutual
+  def f : Prop :=
+    g
+  coinductive_fixpoint
+
+  def g : Prop :=
+    f
+  coinductive_fixpoint
+end
+
+/--
+info: MutualStrongCoinduction.f.strong_coinduct (pred_1 pred_2 : Prop) (hyp_1 : pred_1 → pred_2 ∨ g)
+  (hyp_2 : pred_2 → pred_1 ∨ f) : pred_1 → f
+-/
+#guard_msgs in
+#check f.strong_coinduct
+
+/--
+info: MutualStrongCoinduction.f.strong_mutual_induct (pred_1 pred_2 : Prop) (hyp_1 : pred_1 → pred_2 ∨ g)
+  (hyp_2 : pred_2 → pred_1 ∨ f) : (pred_1 → f) ∧ (pred_2 → g)
+-/
+#guard_msgs in
+#check f.strong_mutual_induct
+
+/--
+info: MutualStrongCoinduction.g.strong_coinduct (pred_1 pred_2 : Prop) (hyp_1 : pred_1 → pred_2 ∨ g)
+  (hyp_2 : pred_2 → pred_1 ∨ f) : pred_2 → g
+-/
+#guard_msgs in
+#check g.strong_coinduct
+
+-- A mutual block where the predicates take arguments, exercising the meet construction
+-- both along the tuple of predicates and along their parameters.
+mutual
+  def tick (R : α → α → Prop) (x : α) : Prop :=
+    ∃ y, R x y ∧ tock R y
+  coinductive_fixpoint
+
+  def tock (R : α → α → Prop) (x : α) : Prop :=
+    ∃ y, R x y ∧ tick R y
+  coinductive_fixpoint
+end
+
+/--
+info: MutualStrongCoinduction.tick.strong_mutual_induct.{u_1} {α : Sort u_1} (R : α → α → Prop) (pred_1 pred_2 : α → Prop)
+  (hyp_1 : ∀ (x : α), pred_1 x → ∃ y, R x y ∧ (pred_2 y ∨ tock R y))
+  (hyp_2 : ∀ (x : α), pred_2 x → ∃ y, R x y ∧ (pred_1 y ∨ tick R y)) :
+  (∀ (x : α), pred_1 x → tick R x) ∧ ∀ (x : α), pred_2 x → tock R x
+-/
+#guard_msgs in
+#check tick.strong_mutual_induct
+
+end MutualStrongCoinduction
+
+namespace MixedStrongInduction
+
+-- A mixed mutual block: the strengthening is `∧` for the inductive component and
+-- `∨` for the coinductive one.
+mutual
+  def p : Prop :=
+    ¬ q
+  inductive_fixpoint
+
+  def q : Prop :=
+    ¬ p
+  coinductive_fixpoint
+end
+
+/--
+info: MixedStrongInduction.p.strong_mutual_induct (pred_1 pred_2 : Prop) (hyp_1 : (pred_2 ∨ q → False) → pred_1)
+  (hyp_2 : pred_2 → pred_1 ∧ p → False) : (p → pred_1) ∧ (pred_2 → q)
+-/
+#guard_msgs in
+#check p.strong_mutual_induct
+
+end MixedStrongInduction
+
+namespace CoinductiveKeyword
+
+coinductive infSeq (r : α → α → Prop) : α → Prop where
+  | step : r a b → infSeq r b → infSeq r a
+
+/--
+info: CoinductiveKeyword.infSeq.strong_coinduct.{u_1} {α : Sort u_1} (r : α → α → Prop) (pred : α → Prop)
+  (hyp : ∀ (a : α), pred a → ∃ b, r a b ∧ (pred b ∨ infSeq r b)) (a✝ : α) : pred a✝ → infSeq r a✝
+-/
+#guard_msgs in
+#check infSeq.strong_coinduct
+
+end CoinductiveKeyword
+
+namespace NoStrongForPartialFixpoint
+
+def loop (x : Nat) : Option Nat :=
+  loop (x + 1)
+  partial_fixpoint
+
+/--
+error: Unknown constant `NoStrongForPartialFixpoint.loop.strong_induct`
+-/
+#guard_msgs in
+#check loop.strong_induct
+
+end NoStrongForPartialFixpoint


### PR DESCRIPTION
This PR adds strong (co)induction proof principles for lattice-theoretic (co)inductive predicates. For predicates defined by `coinductive_fixpoint`, the generated `strong_coinduct` principle strengthens `coinduct`: in the hypothesis, occurrences of the candidate predicate are joined by disjunction with the coinductive predicate itself, so a proof by coinduction may conclude as soon as it re-enters the predicate. Dually, `inductive_fixpoint` definitions receive a `strong_induct` principle whose induction hypothesis additionally provides membership in the predicate itself, and mutual (including mixed) definitions receive `strong_mutual_induct` with the connective chosen per component. The conclusions of the generated principles are now also beta-reduced, e.g. `star_ind tr q₁ q₂ → pred q₁` instead of `(fun q₁ => star_ind tr q₁ q₂) q₁ → pred q₁`.

All principles are derived from a single strengthened Park induction theorem for least fixpoints in complete lattices, `f w ⊑ x → lfp f ⊑ x` for `w` a greatest lower bound of `x` and `lfp f`, instantiated at `ImplicationOrder`/`ReverseImplicationOrder` where the binary meet is conjunction resp. disjunction.