### PR TITLE
fix: match a vcgen frames clause once per goal

### DIFF
--- a/src/Lean/Elab/Tactic/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/VCGen/Solve.lean
@@ -523,11 +523,6 @@ rule applies to the goal.
 A candidate is passed over when no rule fits the goal's monad or when the rule does not apply, so a
 spec guarded by an instance the call site does not provide gives way to a less general one, as does a
 spurious candidate of the over-approximating discrimination tree.
-
-The frame procedure for the monad (the `@[frameproc]` registered for the program type, or the
-default meet frame) is selected per goal, since sub-programs may reach a different monad (e.g. a
-`monadLift`ed base call). A matching `frames` clause is likewise consumed once per goal, before the
-candidate loop, so a passed-over candidate leaves the pinned frame for the next one.
 -/
 private def applySpecs (scope : Scope) (goal : MVarId) (info : WPApp) :
     VCGenM SolveResult := goal.withContext do

--- a/src/Lean/Elab/Tactic/VCGen/Solve.lean
+++ b/src/Lean/Elab/Tactic/VCGen/Solve.lean
@@ -486,16 +486,14 @@ frame procedure produces a split. `none` when no backward rule fits the goal's m
 rule does not apply.
 
 - A spec with a conjunctive precondition, or an already-framed residual, applies its spec directly.
-- Otherwise the frame procedure for the monad is selected (the `@[frameproc]` registered for the
-  program type, or the default meet frame). The choice is per node, since sub-programs may reach a
-  different monad (e.g. a `monadLift`ed base call).
-- An explicit `frames` clause elaborates a frame and passes it to the procedure.
-- Failing that, the procedure may read the spec's precondition through
+- Otherwise the frame procedure `fp` runs, with `providedFrame?` carrying the frame pinned by a
+  matching `frames` clause (both selected once per goal in `applySpecs`).
+- Without a pinned frame, the procedure may read the spec's precondition through
   `FrameInferenceInfo.specPre?`: no split applies the spec directly; a split applies the frame rule
   instead, so the spec re-applies against the framed residual where its VCs are solvable.
 -/
-private def applySpec (scope : Scope) (goal : MVarId) (info : WPApp) (thm : SpecTheorem) :
-    VCGenM (Option SolveResult) := do
+private def applySpec (scope : Scope) (goal : MVarId) (info : WPApp) (thm : SpecTheorem)
+    (fp : FrameProc) (providedFrame? : Option Expr) : VCGenM (Option SolveResult) := do
   let some specRule ←
     try
       mkBackwardRuleFromSpecCached thm info |>.run
@@ -507,9 +505,6 @@ private def applySpec (scope : Scope) (goal : MVarId) (info : WPApp) (thm : Spec
         excessArgs: {info.excessArgs}"
     | return none
   unless thm.conjunctivePre || isFramedPost info.post do
-    let procs := (← read).frameProcs.byProg
-    let fp := info.M.getAppFn.constName?.bind (procs[·]?) |>.getD meetFrameProc
-    let providedFrame? ← matchFrame? fp info
     let inferInfo : FrameInferenceInfo :=
       { info with goal, providedFrame?, spec? := thm.global?, specRule,
                   mkOpApp := do shareCommon (← fp.mkOpAppM info) }
@@ -528,12 +523,21 @@ rule applies to the goal.
 A candidate is passed over when no rule fits the goal's monad or when the rule does not apply, so a
 spec guarded by an instance the call site does not provide gives way to a less general one, as does a
 spurious candidate of the over-approximating discrimination tree.
+
+The frame procedure for the monad (the `@[frameproc]` registered for the program type, or the
+default meet frame) is selected per goal, since sub-programs may reach a different monad (e.g. a
+`monadLift`ed base call). A matching `frames` clause is likewise consumed once per goal, before the
+candidate loop, so a passed-over candidate leaves the pinned frame for the next one.
 -/
 private def applySpecs (scope : Scope) (goal : MVarId) (info : WPApp) :
     VCGenM SolveResult := goal.withContext do
   let candidates ← SpecTheorems.findSpecs scope.specs info.prog
+  let procs := (← read).frameProcs.byProg
+  let fp := info.M.getAppFn.constName?.bind (procs[·]?) |>.getD meetFrameProc
+  let providedFrame? ←
+    if candidates.isEmpty || isFramedPost info.post then pure none else matchFrame? fp info
   for thm in candidates do
-    if let some res ← applySpec scope goal info thm then
+    if let some res ← applySpec scope goal info thm fp providedFrame? then
       return res
     trace[Elab.Tactic.Do.vcgen] "Failed to apply spec {thm.proof} for {info.prog}"
   stopOrErrorOnMissingSpec info.prog info.M candidates

--- a/tests/elab/vcgenFrames.lean
+++ b/tests/elab/vcgenFrames.lean
@@ -265,3 +265,46 @@ example {m : Type → Type v} {Pred : Type w} {EPred : Type w'} [Monad m] [Asser
     ⦃ fun r s => ⌜r = n ∧ s.1 = n + 1⌝ ⦄ := by
   unfold mkFreshNat
   vcgen <;> simp_all
+
+/-! ## A pinned frame survives a passed-over spec candidate
+
+`mkFreshNat_spec_guarded` is the highest-priority candidate, but its `Never γ` instance is never
+synthesizable, so its rule fails to apply and the next candidate runs. `selectiveFP` frames only
+`mkFreshNat_spec_lossy`, so the `frames` clause must still pin the frame when that next candidate
+applies: the clause is matched once per goal, not once per candidate. -/
+
+/-- An unsatisfiable instance guard: a spec rule with a `Never γ` premise never applies. -/
+class Never (α : Type) : Prop where
+  absurd : False
+
+/-- The lossy spec, guarded by an instance on a `γ` that nothing determines. -/
+@[spec high]
+theorem mkFreshNat_spec_guarded {γ : Type} [Never γ] [Monad m] [Assertion Pred] [Assertion EPred]
+    [WPMonad m Pred EPred] :
+    ⦃ fun s => ⌜s.1 = n⌝ ⦄ (mkFreshNat : StateT AppState m Nat)
+    ⦃ fun r s => ⌜r = n ∧ s.1 = n + 1⌝ ⦄ :=
+  (Never.absurd (α := γ)).elim
+
+open Lean.Elab.Tactic.VCGen
+
+/-- Frames the pinned resource for `mkFreshNat_spec_lossy` and declines every other spec. -/
+def selectiveFrameProc : FrameInferenceProc := fun i => do
+  let some frame := i.providedFrame? | return none
+  unless i.spec? == some ``mkFreshNat_spec_lossy do return none
+  return some (← FrameSplit.withDeferredSplitVC i frame)
+
+/-- The meet frame operator with `selectiveFrameProc` as inference procedure. -/
+@[frameproc] def selectiveFP : FrameProc where
+  prog := ``StateT
+  mkOpAppM := fun info => Lean.Meta.mkAppOptM ``Lean.Order.meet #[info.Pred, none]
+  mkResourceTy := fun info => pure info.Pred
+  opHead := ``Lean.Order.meet
+  proc := selectiveFrameProc
+
+/-- `mkFreshNat_spec_guarded` is passed over; the clause still frames `s.2 = 7` when
+`mkFreshNat_spec_lossy` applies. -/
+theorem recovers_snd_second_candidate [Assertion Pred] [Assertion EPred] [WPMonad Id Pred EPred]
+    [∀ β (y : Id β), WPConjunctive y] [∀ a : Pred, PreservesSup (meet a)] :
+    ⦃ fun s => ⌜s.1 = 0 ∧ s.2 = 7⌝ ⦄ (mkFreshNat : StateT AppState Id Nat)
+    ⦃ fun r s => ⌜r = 0 ∧ s.2 = 7⌝ ⦄ := by
+  vcgen frames | mkFreshNat => fun s => ⌜s.2 = 7⌝ with finish


### PR DESCRIPTION
This PR moves the `vcgen frames` clause lookup from `applySpec` into `applySpecs`, so a matching clause is consumed once per goal instead of once per spec candidate. A candidate that fails to apply after the lookup, for example because one of its instance arguments cannot be synthesized, no longer retires the clause, and the next candidate still sees the same provided frame.