### PR TITLE
refactor: a contract clause binds like a `fun`

### DIFF
--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -125,9 +125,9 @@ private def checkAssertionBinders (ref : Syntax) (what : String) (binders : Nat)
     throwErrorAt ref "The {what} of a loop in this monad takes {takes}, and this clause has \
       {has}. The loop's mutable variables are named without binding them."
 
-/-- Bind the arguments of an assertion, which the clause states after the loop's own binders. The
-result declares their types, so `invariant _pref _suff (lo, hi) => lo ≤ hi` in `StateM (Nat × Nat)`
-reads as `(fun (lo, hi) => lo ≤ hi : Nat × Nat → _)`. -/
+/-- Given the `(lo, hi) => lo ≤ hi` part of `invariant _pref _suff (lo, hi) => lo ≤ hi` in
+`StateM (Nat × Nat)`, return the ascripted lambda `(fun (lo, hi) => lo ≤ hi : Nat × Nat → _)` so
+that the pair successfully elaborates. -/
 private def mkAssertionFun (binders : TSyntaxArray ``Lean.Parser.Term.funBinder) (body : Term)
     (pred? : Option Expr) : DoElabM Term := do
   if binders.isEmpty then return body

--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -125,10 +125,21 @@ private def checkAssertionBinders (ref : Syntax) (what : String) (binders : Nat)
     throwErrorAt ref "The {what} of a loop in this monad takes {takes}, and this clause has \
       {has}. The loop's mutable variables are named without binding them."
 
-/-- Bind the arguments of an assertion, which the clause states after the loop's own binders. -/
-private def mkAssertionFun (binders : TSyntaxArray ``Lean.Parser.Term.funBinder) (body : Term) :
-    DoElabM Term :=
-  if binders.isEmpty then pure body else `(fun $binders* => $body)
+/-- Bind the arguments of an assertion, which the clause states after the loop's own binders. The
+result declares their types, so `invariant _pref _suff (lo, hi) => lo ≤ hi` in `StateM (Nat × Nat)`
+reads as `(fun (lo, hi) => lo ≤ hi : Nat × Nat → _)`. -/
+private def mkAssertionFun (binders : TSyntaxArray ``Lean.Parser.Term.funBinder) (body : Term)
+    (pred? : Option Expr) : DoElabM Term := do
+  if binders.isEmpty then return body
+  let f ← `(fun $binders* => $body)
+  let some pred := pred? | return f
+  let mut tys := #[]
+  let mut pred := pred
+  for _ in binders do
+    let .forallE _ d b _ := pred | return f
+    tys := tys.push (← Term.exprToSyntax d)
+    pred := b
+  `(($f : $(← tys.foldrM (init := ← `(_)) fun ty acc => `($ty → $acc))))
 
 /-- The pattern that names the loop's mutable variables in the state tuple, whose layout is
 `[return?, mutVars…, unit?]`; the early-return slot becomes a wildcard. -/
@@ -196,8 +207,9 @@ private def mkForInPureWithInvariant (g : ForInApp) (invClause : TSyntax ``doLoo
       consumed so far and the elements remaining."
   let loopBinders := binders.take 2
   let assertionBinders := binders.drop 2
-  checkAssertionBinders invClause "invariant" assertionBinders.size (← assertionLanguage?)
-  let invBody ← mkAssertionFun assertionBinders invBody
+  let pred? ← assertionLanguage?
+  checkAssertionBinders invClause "invariant" assertionBinders.size pred?
+  let invBody ← mkAssertionFun assertionBinders invBody pred?
   let invLam ← `(fun $loopBinders* => $(← g.mkStateFun invBody))
   let gadget := if h?.isSome then ``Std.WP.Gadget.forInPureWithInvariant'
     else ``Std.WP.Gadget.forInPureWithInvariant
@@ -216,7 +228,7 @@ private def mkForInLoopGadget (g : ForInApp)
     let exitBinder := binders[0]!
     let assertionBinders := binders.drop 1
     checkAssertionBinders invClause "invariant" assertionBinders.size pred?
-    let invBody ← mkAssertionFun assertionBinders invBody
+    let invBody ← mkAssertionFun assertionBinders invBody pred?
     let exitVar := mkIdentFrom invClause (← mkFreshUserName `__exit)
     let invBody ← if exitBinder.raw.isOfKind ``hole then pure invBody else
       let exitPat : Term := ⟨exitBinder.raw⟩
@@ -232,7 +244,7 @@ private def mkForInLoopGadget (g : ForInApp)
       | `(doLoopDecreasing| decreasing $measure:term) => pure (#[], measure)
       | _ => throwUnsupportedSyntax
     checkAssertionBinders decClause "measure" binders.size pred?
-    return ((decClause : Syntax), ← g.mkStateFun (← mkAssertionFun binders body))
+    return ((decClause : Syntax), ← g.mkStateFun (← mkAssertionFun binders body pred?))
   let some (ref, gadget, annotations) := (match invArg?, varArg? with
     | some (ref, inv), some (_, var) =>
       some (ref, ``Std.WP.Gadget.forInLoopWithInvariantAndVariant, #[inv, var])

--- a/src/Lean/Elab/Tactic/Do/Contract.lean
+++ b/src/Lean/Elab/Tactic/Do/Contract.lean
@@ -128,7 +128,6 @@ theorem; add `import Std.WP` to use them."
   let post : Term ← if ensuresStx.isNone then `(fun _ => ⊤) else
     match ensuresStx[0] with
     | `(ensuresClause| ensures $f:basicFun) => `(fun $f:basicFun)
-    | `(ensuresClause| ensures $alts:matchAlts) => `(fun $alts:matchAlts)
     | _ => Macro.throwUnsupported
   let msg : TSyntax `str := ⟨Syntax.mkStrLit <|
     if specStep?.isSome then

--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -140,8 +140,7 @@ arguments of the assertion itself, such as the state of a state monad. -/
 def requiresClause := leading_parser
   ppIndent (ppLine >> nonReservedSymbol "requires" >>
     withForbidden "ensures" (atomic Term.basicFun <|> (ppSpace >> termParser)))
-/-- The `ensures b => Q` postcondition clause of a `def` contract, binding the result `b`. A binder
-may name the components of the result, as in `ensures (lo, hi) => lo ≤ hi`. -/
+/-- The `ensures b => Q` postcondition clause of a `def` contract, binding the result `b`. -/
 def ensuresClause := leading_parser
   ppIndent (ppLine >> nonReservedSymbol "ensures" >> Term.basicFun)
 /-- The `: type` of a `def`. It may carry contract clauses, so we forbid `given`, `requires` and

--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -140,10 +140,10 @@ arguments of the assertion itself, such as the state of a state monad. -/
 def requiresClause := leading_parser
   ppIndent (ppLine >> nonReservedSymbol "requires" >>
     withForbidden "ensures" (atomic Term.basicFun <|> (ppSpace >> termParser)))
-/-- The `ensures b => Q` postcondition clause of a `def` contract, binding the result `b`. -/
+/-- The `ensures b => Q` postcondition clause of a `def` contract, binding the result `b`. A binder
+may name the components of the result, as in `ensures (lo, hi) => lo ≤ hi`. -/
 def ensuresClause := leading_parser
-  ppIndent (ppLine >> nonReservedSymbol "ensures" >>
-    (Term.basicFun <|> ppIndent Term.matchAlts))
+  ppIndent (ppLine >> nonReservedSymbol "ensures" >> Term.basicFun)
 /-- The `: type` of a `def`. It may carry contract clauses, so we forbid `given`, `requires` and
 `ensures` in the type. -/
 def defTypeSpec := withForbiddens #["given", "requires", "ensures"] Term.typeSpec

--- a/tests/elab/formatTerm.lean
+++ b/tests/elab/formatTerm.lean
@@ -26,7 +26,7 @@ def fmt (stx : CoreM Syntax) : CoreM Format := do PrettyPrinter.ppTerm ⟨← st
 #eval fmt `(command| def clampLow (n lo : Nat) : Id Nat requires lo ≤ n ensures r => r = n := pure n)
 #eval fmt `(command| def k (x : Nat) requires s => s > x ensures r => r ≥ x := pure x)
 #eval fmt `(command| def g (x : Nat) requires x > 0 ensures r => r ≥ x := pure x)
-#eval fmt `(command| def m (x : Nat) requires x > 0 ensures | 0 => False | (n+1) => n ≥ x := pure x)
+#eval fmt `(command| def m (x : Nat) requires x > 0 ensures (lo, hi) => lo ≤ hi := pure (x, x))
 #eval fmt `(command| def h (x : Nat) : Id Nat ensures r => r = x := pure x
 where finally
   | spec => skip)

--- a/tests/elab/formatTerm.lean.out.expected
+++ b/tests/elab/formatTerm.lean.out.expected
@@ -95,10 +95,8 @@ def g✝ (x✝ : Nat✝)
   pure✝ x✝
 def m✝ (x✝ : Nat✝)
     requires x✝ > 0
-    ensures
-      | 0 => False✝
-      | (n✝ + 1) => n✝ ≥ x✝ :=
-  pure✝ x✝
+    ensures (lo✝, hi✝) => lo✝ ≤ hi✝ :=
+  pure✝ (x✝, x✝)
 def h✝ (x✝ : Nat✝) : Id✝ Nat✝
     ensures r✝ => r✝ = x✝ :=
   pure✝ x✝

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -284,18 +284,75 @@ def ensuresAscribed (n : Nat) : Id Nat
 #guard_msgs in
 #check @ensuresAscribed.spec
 
-/-! ## An `ensures` clause written with match alternatives
+/-! ## The binders of a clause
 
-The clause is a `fun`, so it may state the postcondition per shape of the result. -/
+A clause binds like a `fun`, so a binder may name the components of the value it stands for. A
+postcondition that tells the shapes of the result apart states a `match`. -/
+
+def bounds (n : Nat) : Id (Nat × Nat)
+    ensures (lo, hi) => lo ≤ hi
+  := pure (n, n)
+
+#guard_msgs (drop info) in
+#check @bounds.spec
 
 def halve (n : Nat) : Id (Option Nat)
-    ensures
+    ensures r => match r with
       | none => False
       | some v => 2 * v ≤ n
   := pure (some (n / 2))
 
 #guard_msgs (drop info) in
 #check @halve.spec
+
+/-! A `requires`, `invariant` or `assert` clause binds the same way. Here the state of the monad is
+a pair, and every clause names both components. -/
+
+def sumInto (xs : List Nat) : StateM (Nat × Nat) Unit
+    requires (lo, _hi) => lo = 0
+    ensures _ (lo, _hi) => lo = 0 := do
+  assert (lo, _hi) => lo = 0
+  for x in xs invariant _pref _suff (lo, _hi) => lo = 0 do
+    modify fun (lo, hi) => (lo, hi + x)
+
+#guard_msgs (drop info) in
+#check @sumInto.spec
+
+/-! A clause declares the type of the argument it binds, so a projection of the state resolves. -/
+
+def sumIntoProj (xs : List Nat) : StateM (Nat × Nat) Unit
+    requires (lo, _hi) => lo = 0
+    ensures _ (lo, _hi) => lo = 0 := do
+  for x in xs invariant _pref _suff s => s.1 = 0 do
+    modify fun (lo, hi) => (lo, hi + x)
+
+#guard_msgs (drop info) in
+#check @sumIntoProj.spec
+
+/-! A `while` loop states both of its clauses over the state. -/
+
+def countInto : StateM (Nat × Nat) Unit
+    requires (lo, hi) => lo ≤ hi
+    ensures _ (lo, hi) => lo ≤ hi := do
+  while (← get).1 < (← get).2
+      invariant _exit (lo, hi) => lo ≤ hi
+      decreasing (lo, hi) => hi - lo
+    do
+    modify fun (lo, hi) => (lo + 1, hi)
+
+#guard_msgs (drop info) in
+#check @countInto.spec
+
+/-! A binder that leaves a shape of the value out is reported as a missing case. -/
+
+/--
+error: Missing cases:
+none
+-/
+#guard_msgs in
+def halveSome (n : Nat) : Id (Option Nat)
+    ensures (some v) => 2 * v ≤ n
+  := pure (some (n / 2))
 
 /-! ## A `repeat` or `while` loop binds whether it has left
 


### PR DESCRIPTION
This PR removes the match-alternatives form of the `ensures` clause. Except for that, every clause of a contract (`requires`, `ensures`, `assert`, `invariant`, `decreasign`) elaborates like a `fun` telescope, including tuple patterns as in `ensures (lo, hi) => lo ≤ hi`.