### PR TITLE
fix: elaborate loop annotations without `open Std.WP`

### DIFF
--- a/src/Lean/Elab/BuiltinDo/For.lean
+++ b/src/Lean/Elab/BuiltinDo/For.lean
@@ -101,14 +101,16 @@ private def checkPureForIn (invClause : Syntax) (h? : Option Syntax) (xs α : Ex
 /-- The assertion language of the `do` block's monad, which `WPMonad` computes as an output
 parameter: synthesizing `WPMonad StateM Nat _ _` assigns `Nat → Prop` for the assertions of
 `StateM Nat`. The result is what the monad's assertions are known to be right here, so a monad
-whose instance is not available reports nothing. The type is built from syntax so that the
-universes and the instance arguments of the class come from elaboration. -/
+whose instance is not available reports nothing. The class's arguments are fresh natural
+metavariables that the found instance assigns, so the query registers no pending instance goals. -/
 private def assertionLanguage? : DoElabM (Option Expr) := do
   unless (← getEnv).contains ``Std.WP.WPMonad do return none
-  let wpTy ← Term.elabType <| ←
-    `($(mkIdent ``Std.WP.WPMonad) $(← Term.exprToSyntax (← read).monadInfo.m) _ _)
-  let .some _ ← trySynthInstance wpTy | return none
-  let some pred := wpTy.getAppArgs[1]? | return none
+  let wpMonad ← mkConstWithFreshMVarLevels ``Std.WP.WPMonad
+  let (args, _, _) ← forallMetaTelescope (← inferType wpMonad)
+  let some m := args[0]? | return none
+  unless ← isDefEq m (← read).monadInfo.m do return none
+  let .some _ ← trySynthInstance (mkAppN wpMonad args) | return none
+  let some pred := args[1]? | return none
   let pred ← instantiateMVars pred
   return if pred.hasExprMVar then none else some pred
 
@@ -168,8 +170,11 @@ private def ForInApp.mkCall (g : ForInApp) (ref : Syntax) (gadget : Name)
   unless (← getEnv).contains gadget do
     throwErrorAt ref "a loop annotation elaborates to a `vcgen` gadget; \
       add `import Std.WP` to use it."
-  let call ← `($(mkIdent gadget) $(← Term.exprToSyntax g.xs) $(← Term.exprToSyntax g.init)
-    $(← Term.exprToSyntax g.body) $annotations*)
+  -- `open scoped` activates the instances of `Std.WP` and the notation of `Lean.Order` for the
+  -- annotations, as the contract's spec theorem does for the `requires` and `ensures` clauses.
+  let call ← `(open scoped Std.WP Lean.Order in
+    $(mkIdent gadget) $(← Term.exprToSyntax g.xs) $(← Term.exprToSyntax g.init)
+      $(← Term.exprToSyntax g.body) $annotations*)
   Term.elabTermEnsuringType call (mkApp (← read).monadInfo.m g.σ)
 
 /-- The binders and body of an `invariant` clause. An ascription covering the binder list would

--- a/src/Lean/Elab/Tactic/Do/Contract.lean
+++ b/src/Lean/Elab/Tactic/Do/Contract.lean
@@ -176,7 +176,11 @@ def elabDoAssertion : DoElab := fun stx dec => do
       "the `assert` element elaborates to a `vcgen` gadget; add `import Std.WP` to use it."
   warnIntrinsicExperimental tk m!"`assert` element"
   let dec ← dec.ensureUnitAt tk
-  let e ← Term.elabTermEnsuringType (← `($(mkCIdent ``Gadget.assertGadget) $as)) (← mkMonadApp (← mkPUnit))
+  -- `open scoped` activates the instances of `Std.WP` and the notation of `Lean.Order` for the
+  -- assertion, as the contract's spec theorem does for the `requires` and `ensures` clauses.
+  let e ← Term.elabTermEnsuringType
+    (← `(open scoped Std.WP Lean.Order in $(mkCIdent ``Gadget.assertGadget) $as))
+    (← mkMonadApp (← mkPUnit))
   dec.mkBindUnlessPure e
 
 end Lean.Elab.Tactic.Do

--- a/tests/elab/intrinsicVerification.lean
+++ b/tests/elab/intrinsicVerification.lean
@@ -39,6 +39,52 @@ def onlyRequire (n : Nat) : Id Nat
 #guard_msgs in
 #check @onlyRequire.spec
 
+/-! Loop annotations and `assert` also elaborate with nothing opened: the `do` elaborator
+activates the scoped instances of `Std.WP` for the annotation terms. -/
+
+def countDownNoOpen (n : Nat) : Id Nat
+    ensures r => r = 0 := do
+  let mut i := n
+  while i > 0
+      invariant exit => if exit then i = 0 else True
+      decreasing i
+    do
+    i := i - 1
+  return i
+
+#guard_msgs (drop info) in
+#check @countDownNoOpen.spec
+
+def sumNoOpen (xs : List Nat) : StateM Nat Unit
+    requires s => s = 0
+    ensures _ s => s = xs.sum
+  := do
+  for x in xs invariant pref _ s => s = pref.sum do
+    modify (· + x)
+
+#guard_msgs (drop info) in
+#check @sumNoOpen.spec
+
+def assertNoOpen (n : Nat) : Id Nat
+    requires n > 0
+    ensures r => r ≥ 2
+  := do
+  let d := 2 * n
+  assert d ≥ 2
+  return d
+
+#guard_msgs (drop info) in
+#check @assertNoOpen.spec
+
+-- A loop annotation elaborates without a contract on the definition.
+def decreasingNoOpen (n : Nat) : Id Nat := do
+  let mut i := n
+  while i > 0
+      decreasing i
+    do
+    i := i - 1
+  return i
+
 open Std.WP Lean.Order
 
 /-! ## An `ensures` contract with a `for … invariant` loop, proved with no manual steps -/


### PR DESCRIPTION
This PR makes `invariant`, `decreasing`, and `assert` in a `do` block elaborate without `open Std.WP`, matching the `requires` and `ensures` clauses of a contract.

The instance behind `Assertion Prop` is scoped in `Std.WP`, and the contract's spec theorem already activates it with `open scoped Std.WP Lean.Order in`. The do elaborator now activates the same scope around the gadget application, which also covers the clause bodies. The `WPMonad` query that computes the assertion language now uses fresh natural metavariables instead of elaborated syntax, so it registers no pending instance goals that would resume after the scope is gone.