### PR TITLE
feat: add `monotonicity_by` clause to `coinductive` predicates

### DIFF
--- a/src/Init/Internal/Order/Tactic.lean
+++ b/src/Init/Internal/Order/Tactic.lean
@@ -19,6 +19,6 @@ using lemma tagged with `@[partial_fixpoint_monotone]`.
 This tactic is mostly used internally by lean in `partial_fixpoint` definitions, but
 can be useful on its own for debugging or when proving new `@[partial_fixpoint_monotone]` lemmas.
 -/
-scoped syntax (name := monotonicity) "monotonicity" : tactic
+scoped syntax (name := «monotonicity») "monotonicity" : tactic
 
 end Lean.Order

--- a/src/Init/Internal/Order/Tactic.lean
+++ b/src/Init/Internal/Order/Tactic.lean
@@ -19,6 +19,6 @@ using lemma tagged with `@[partial_fixpoint_monotone]`.
 This tactic is mostly used internally by lean in `partial_fixpoint` definitions, but
 can be useful on its own for debugging or when proving new `@[partial_fixpoint_monotone]` lemmas.
 -/
-scoped syntax (name := «monotonicity») "monotonicity" : tactic
+scoped syntax (name := monotonicity) "monotonicity" : tactic
 
 end Lean.Order

--- a/src/Lean/Elab/Coinductive.lean
+++ b/src/Lean/Elab/Coinductive.lean
@@ -112,7 +112,7 @@ public structure CoinductiveElabData where
   keywords, and hence we need to record this information.
   -/
   isGreatest : Bool
-  /-- Explicit monotonicity proof from the `monotonicity` clause, if provided. -/
+  /-- Explicit monotonicity proof from the `monotonicity_by` clause, if provided. -/
   monotonicity? : Option Term
   deriving Inhabited
 

--- a/src/Lean/Elab/Coinductive.lean
+++ b/src/Lean/Elab/Coinductive.lean
@@ -112,6 +112,8 @@ public structure CoinductiveElabData where
   keywords, and hence we need to record this information.
   -/
   isGreatest : Bool
+  /-- Explicit monotonicity proof from the `monotonicity` clause, if provided. -/
+  monotonicity? : Option Term
   deriving Inhabited
 
 
@@ -481,7 +483,7 @@ public def elabCoinductive (coinductiveElabData : Array CoinductiveElabData) : T
         terminationBy? := .none
         partialFixpoint? := .some {
             ref := coinductiveElabData[idx]!.ref
-            term? := .none
+            term? := coinductiveElabData[idx]!.monotonicity?
             fixpointType := if coinductiveElabData[idx]!.isGreatest then
                               .coinductiveFixpoint else .inductiveFixpoint
         }

--- a/src/Lean/Elab/Inductive.lean
+++ b/src/Lean/Elab/Inductive.lean
@@ -85,6 +85,7 @@ private def inductiveSyntaxToView (modifiers : Modifiers) (decl : Syntax) (isCoi
     let computedFields ← (decl[5].getOptional?.map (·[1].getArgs) |>.getD #[]).mapM fun cf => withRef cf do
       return { ref := cf, modifiers := cf[0], fieldId := cf[1].getId, type := ⟨cf[3]⟩, matchAlts := ⟨cf[4]⟩ }
     let classes ← getOptDerivingClasses decl[6]
+    let monotonicity? : Option Term := decl[7].getOptional?.map fun stx => ⟨stx[1]⟩
     if decl[3][0].isToken ":=" then
       -- https://github.com/leanprover/lean4/issues/5236
       withRef decl[0] <| Linter.logLintIf Linter.linter.deprecated decl[3]
@@ -100,6 +101,7 @@ private def inductiveSyntaxToView (modifiers : Modifiers) (decl : Syntax) (isCoi
       computedFields
       docString?
       isCoinductive := isCoinductive
+      monotonicity?
     }
 
 private def isInductiveFamily (numParams : Nat) (indFVar : Expr) : TermElabM Bool := do

--- a/src/Lean/Elab/Inductive.lean
+++ b/src/Lean/Elab/Inductive.lean
@@ -85,7 +85,10 @@ private def inductiveSyntaxToView (modifiers : Modifiers) (decl : Syntax) (isCoi
     let computedFields ← (decl[5].getOptional?.map (·[1].getArgs) |>.getD #[]).mapM fun cf => withRef cf do
       return { ref := cf, modifiers := cf[0], fieldId := cf[1].getId, type := ⟨cf[3]⟩, matchAlts := ⟨cf[4]⟩ }
     let classes ← getOptDerivingClasses decl[6]
-    let monotonicity? : Option Term := decl[7].getOptional?.map fun stx => ⟨stx[1]⟩
+    -- Wrap the `monotonicity_by` tactic block into a `by` term; the fixpoint machinery
+    -- elaborates it against the `monotone` goal of this predicate's functor.
+    let monotonicity? : Option Term ← decl[7].getOptional?.mapM fun stx =>
+      withRef stx `(by $(⟨stx[1]⟩))
     if decl[3][0].isToken ":=" then
       -- https://github.com/leanprover/lean4/issues/5236
       withRef decl[0] <| Linter.logLintIf Linter.linter.deprecated decl[3]

--- a/src/Lean/Elab/MutualInductive.lean
+++ b/src/Lean/Elab/MutualInductive.lean
@@ -107,9 +107,9 @@ structure InductiveView where
   /-- The declaration docstring. -/
   docString?      : Option (TSyntax ``Lean.Parser.Command.docComment)
   isCoinductive : Bool := false
-  /-- Explicit monotonicity proof from a `monotonicity` clause. Only meaningful for predicates
-  elaborated via the lattice-theoretic fixpoint machinery (`coinductive`, or `inductive` in a
-  mutual clique with `coinductive`). -/
+  /-- Explicit monotonicity proof from a `monotonicity_by` clause, as a `by` term. Only
+  meaningful for predicates elaborated via the lattice-theoretic fixpoint machinery
+  (`coinductive`, or `inductive` in a mutual clique with `coinductive`). -/
   monotonicity?   : Option Term := none
   deriving Inhabited
 
@@ -1720,7 +1720,7 @@ def elabInductives (inductives : Array (Modifiers × Syntax)) : CommandElabM Uni
   else
     for e in elabs do
       if let some proof := e.view.monotonicity? then
-        throwErrorAt proof "The `monotonicity` clause is only allowed on `coinductive` predicates, or on `inductive` predicates in a `mutual` block together with a `coinductive` predicate"
+        throwErrorAt proof "`monotonicity_by` is only allowed on `coinductive` predicates, or on `inductive` predicates in a `mutual` block together with a `coinductive` predicate"
     let res ← runTermElabM fun vars => do
       elabInductiveViews vars elabs
     elabInductiveViewsFinalize (elabs.map (·.view)) res

--- a/src/Lean/Elab/MutualInductive.lean
+++ b/src/Lean/Elab/MutualInductive.lean
@@ -107,6 +107,10 @@ structure InductiveView where
   /-- The declaration docstring. -/
   docString?      : Option (TSyntax ``Lean.Parser.Command.docComment)
   isCoinductive : Bool := false
+  /-- Explicit monotonicity proof from a `monotonicity` clause. Only meaningful for predicates
+  elaborated via the lattice-theoretic fixpoint machinery (`coinductive`, or `inductive` in a
+  mutual clique with `coinductive`). -/
+  monotonicity?   : Option Term := none
   deriving Inhabited
 
 /-- Elaborated header for an inductive type before fvars for each inductive are added to the local context. -/
@@ -1698,6 +1702,7 @@ def InductiveViewToCoinductiveElab (e : InductiveElabStep1) : CoinductiveElabDat
   modifiers := e.view.modifiers
   ctorSyntax := e.view.ctors.map (·.ref)
   isGreatest := e.view.isCoinductive
+  monotonicity? := e.view.monotonicity?
 
 def elabInductives (inductives : Array (Modifiers × Syntax)) : CommandElabM Unit := do
   let elabs ← runTermElabM fun _ => inductives.mapM fun (modifiers, stx) => mkInductiveView modifiers stx
@@ -1713,6 +1718,9 @@ def elabInductives (inductives : Array (Modifiers × Syntax)) : CommandElabM Uni
       discard <| flatElabs.mapM fun e => MetaM.run' do mkSumOfProducts e.view.declName
       elabCoinductive (flatElabs.map InductiveViewToCoinductiveElab)
   else
+    for e in elabs do
+      if let some proof := e.view.monotonicity? then
+        throwErrorAt proof "The `monotonicity` clause is only allowed on `coinductive` predicates, or on `inductive` predicates in a `mutual` block together with a `coinductive` predicate"
     let res ← runTermElabM fun vars => do
       elabInductiveViews vars elabs
     elabInductiveViewsFinalize (elabs.map (·.view)) res

--- a/src/Lean/Elab/PreDefinition/PartialFixpoint/Main.lean
+++ b/src/Lean/Elab/PreDefinition/PartialFixpoint/Main.lean
@@ -159,7 +159,9 @@ def partialFixpoint (docCtx : LocalContext × LocalInstances) (preDefs : Array P
           -- replaceRecApps needs the constants in the env to typecheck things
           preDefs.forM (addAsAxiom ·)
           replaceRecApps declNames fixedParamPerms f body
-        mkLambdaFVars #[f] body'
+        -- Values coming from `elabCoinductive` are a redex over the `.existential` lambda;
+        -- beta-reduce so monotonicity goals and errors are stated in terms of its body.
+        mkLambdaFVars #[f] body'.headBeta
 
     -- Construct and solve monotonicity goals for each function separately
     -- This way we preserve the user's parameter names as much as possible

--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -244,13 +244,12 @@ def computedField    := leading_parser
 def computedFields   := leading_parser
   "with" >> manyIndent (ppLine >> ppGroup computedField)
 /--
-Provides an explicit proof that the predicate functor is `Lean.Order.monotone`, instead of the
+Manually prove that the predicate functor is `Lean.Order.monotone`, instead of relying on the
 proof search performed by the `Lean.Order.monotonicity` tactic. Only supported on `coinductive`
 predicates and on `inductive` predicates that share a `mutual` block with a `coinductive` one.
 -/
-@[builtin_doc] def monotonicityHint := leading_parser
-  ppDedent ppLine >> withPosition ("monotonicity " >>
-    checkColGt "indented monotonicity proof" >> termParser)
+@[builtin_doc] def monotonicityBy := leading_parser
+  ppDedent ppLine >> "monotonicity_by " >> Tactic.tacticSeqIndentGt
 /--
 In Lean, every concrete type other than the universes
 and every type constructor other than dependent arrows
@@ -272,10 +271,10 @@ for more information.
 -/
 @[builtin_doc] def «inductive» := leading_parser
   "inductive " >> recover declId skipUntilWsOrDelim >> ppIndent optDeclSig >> optional (symbol " :=" <|> " where") >>
-  many ctor >> optional (ppDedent ppLine >> computedFields) >> optDeriving >> optional monotonicityHint
+  many ctor >> optional (ppDedent ppLine >> computedFields) >> optDeriving >> optional monotonicityBy
 @[builtin_doc] def «coinductive» := leading_parser
   "coinductive " >> recover declId skipUntilWsOrDelim >> ppIndent optDeclSig >> optional (symbol " :=" <|> " where") >>
-  many ctor >> optional (ppDedent ppLine >> computedFields) >> optDeriving >> optional monotonicityHint
+  many ctor >> optional (ppDedent ppLine >> computedFields) >> optDeriving >> optional monotonicityBy
 def classInductive   := leading_parser
   atomic (group (symbol "class " >> "inductive ")) >>
   recover declId skipUntilWsOrDelim >> ppIndent optDeclSig >>

--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -244,6 +244,14 @@ def computedField    := leading_parser
 def computedFields   := leading_parser
   "with" >> manyIndent (ppLine >> ppGroup computedField)
 /--
+Provides an explicit proof that the predicate functor is `Lean.Order.monotone`, instead of the
+proof search performed by the `Lean.Order.monotonicity` tactic. Only supported on `coinductive`
+predicates and on `inductive` predicates that share a `mutual` block with a `coinductive` one.
+-/
+@[builtin_doc] def monotonicityHint := leading_parser
+  ppDedent ppLine >> withPosition ("monotonicity " >>
+    checkColGt "indented monotonicity proof" >> termParser)
+/--
 In Lean, every concrete type other than the universes
 and every type constructor other than dependent arrows
 is an instance of a general family of type constructions known as inductive types.
@@ -264,10 +272,10 @@ for more information.
 -/
 @[builtin_doc] def «inductive» := leading_parser
   "inductive " >> recover declId skipUntilWsOrDelim >> ppIndent optDeclSig >> optional (symbol " :=" <|> " where") >>
-  many ctor >> optional (ppDedent ppLine >> computedFields) >> optDeriving
+  many ctor >> optional (ppDedent ppLine >> computedFields) >> optDeriving >> optional monotonicityHint
 @[builtin_doc] def «coinductive» := leading_parser
   "coinductive " >> recover declId skipUntilWsOrDelim >> ppIndent optDeclSig >> optional (symbol " :=" <|> " where") >>
-  many ctor >> optional (ppDedent ppLine >> computedFields) >> optDeriving
+  many ctor >> optional (ppDedent ppLine >> computedFields) >> optDeriving >> optional monotonicityHint
 def classInductive   := leading_parser
   atomic (group (symbol "class " >> "inductive ")) >>
   recover declId skipUntilWsOrDelim >> ppIndent optDeclSig >>

--- a/src/Lean/Parser/Term.lean
+++ b/src/Lean/Parser/Term.lean
@@ -653,7 +653,7 @@ the syntax `partial_fixpoint monotonicity by $tac` the proof can be done manuall
 @[builtin_doc] def partialFixpoint := leading_parser
   withPosition (
     "partial_fixpoint" >>
-    optional (checkColGt "indentation" >> nonReservedSymbol "monotonicity " >>
+    optional (checkColGt "indentation" >> "monotonicity " >>
               checkColGt "indented monotonicity proof" >> termParser))
 
 /--
@@ -670,7 +670,7 @@ of monotonicity if needed.
 def coinductiveFixpoint := leading_parser
   withPosition (
     "coinductive_fixpoint" >>
-    optional (checkColGt "indentation" >> nonReservedSymbol "monotonicity " >>
+    optional (checkColGt "indentation" >> "monotonicity " >>
               checkColGt "indented monotonicity proof" >> termParser))
 
 /--
@@ -687,7 +687,7 @@ of monotonicity if needed.
 def inductiveFixpoint := leading_parser
   withPosition (
     "inductive_fixpoint" >>
-    optional (checkColGt "indentation" >> nonReservedSymbol "monotonicity " >>
+    optional (checkColGt "indentation" >> "monotonicity " >>
               checkColGt "indented monotonicity proof" >> termParser))
 
 /--

--- a/src/Lean/Parser/Term.lean
+++ b/src/Lean/Parser/Term.lean
@@ -653,7 +653,7 @@ the syntax `partial_fixpoint monotonicity by $tac` the proof can be done manuall
 @[builtin_doc] def partialFixpoint := leading_parser
   withPosition (
     "partial_fixpoint" >>
-    optional (checkColGt "indentation" >> "monotonicity " >>
+    optional (checkColGt "indentation" >> nonReservedSymbol "monotonicity " >>
               checkColGt "indented monotonicity proof" >> termParser))
 
 /--
@@ -670,7 +670,7 @@ of monotonicity if needed.
 def coinductiveFixpoint := leading_parser
   withPosition (
     "coinductive_fixpoint" >>
-    optional (checkColGt "indentation" >> "monotonicity " >>
+    optional (checkColGt "indentation" >> nonReservedSymbol "monotonicity " >>
               checkColGt "indented monotonicity proof" >> termParser))
 
 /--
@@ -687,7 +687,7 @@ of monotonicity if needed.
 def inductiveFixpoint := leading_parser
   withPosition (
     "inductive_fixpoint" >>
-    optional (checkColGt "indentation" >> "monotonicity " >>
+    optional (checkColGt "indentation" >> nonReservedSymbol "monotonicity " >>
               checkColGt "indented monotonicity proof" >> termParser))
 
 /--

--- a/tests/elab/coinductive_keyword_monotonicity.lean
+++ b/tests/elab/coinductive_keyword_monotonicity.lean
@@ -1,5 +1,5 @@
 /-!
-Tests for the `monotonicity` clause on the `coinductive` and `inductive` keywords, which provides
+Tests for the `monotonicity_by` clause on the `coinductive` and `inductive` keywords, which provides
 an explicit monotonicity proof for the underlying lattice-theoretic fixpoint construction,
 analogously to `coinductive_fixpoint monotonicity ...` / `inductive_fixpoint monotonicity ...`.
 -/
@@ -13,7 +13,7 @@ variable (α : Type)
 
 coinductive infSeq (r : α → α → Prop) : α → Prop where
   | step : r a b → infSeq r b → infSeq r a
-monotonicity by repeat monotonicity
+monotonicity_by repeat monotonicity
 
 /--
 info: infSeq.step (α : Type) (r : α → α → Prop) {a b : α} : r a b → infSeq α r b → infSeq α r a
@@ -40,7 +40,7 @@ warning: declaration uses `sorry`
 #guard_msgs in
 coinductive infSeq' (r : α → α → Prop) : α → Prop where
   | step : r a b → infSeq' r b → infSeq' r a
-monotonicity sorry
+monotonicity_by sorry
 
 /--
 info: infSeq'.step (α : Type) (r : α → α → Prop) {a b : α} : r a b → infSeq' α r b → infSeq' α r a
@@ -64,7 +64,7 @@ warning: declaration uses `sorry`
 #guard_msgs in
 coinductive infSeq'' (r : α → α → Prop) : α → Prop where
   | step : r a b → infSeq'' r b → infSeq'' r a
-monotonicity by trace_state; sorry
+monotonicity_by trace_state; sorry
 
 end
 
@@ -86,14 +86,14 @@ warning: declaration uses `sorry`
 #guard_msgs in
 coinductive selfNeg : Prop where
   | mk : ¬selfNeg → selfNeg
-monotonicity ()
+monotonicity_by exact ()
 
 -- Mutual clique of two coinductive predicates, clause on only one member
 
 mutual
   coinductive tick : Prop where
     | mk : tock → tick
-  monotonicity by repeat monotonicity
+  monotonicity_by repeat monotonicity
 
   coinductive tock : Prop where
     | mk : tick → tock
@@ -108,11 +108,11 @@ end
 mutual
   coinductive ping : Prop where
     | mk : ¬pong → ping
-  monotonicity by repeat monotonicity
+  monotonicity_by repeat monotonicity
 
   inductive pong : Prop where
     | mk : ¬ping → pong
-  monotonicity by repeat monotonicity
+  monotonicity_by repeat monotonicity
 end
 
 /-- info: ping.mk : ¬pong → ping -/
@@ -126,22 +126,22 @@ end
 -- The clause is rejected on ordinary inductive types
 
 /--
-error: The `monotonicity` clause is only allowed on `coinductive` predicates, or on `inductive` predicates in a `mutual` block together with a `coinductive` predicate
+error: `monotonicity_by` is only allowed on `coinductive` predicates, or on `inductive` predicates in a `mutual` block together with a `coinductive` predicate
 -/
 #guard_msgs in
 inductive Plain : Prop where
   | mk : Plain
-monotonicity by repeat monotonicity
+monotonicity_by repeat monotonicity
 
 /--
-error: The `monotonicity` clause is only allowed on `coinductive` predicates, or on `inductive` predicates in a `mutual` block together with a `coinductive` predicate
+error: `monotonicity_by` is only allowed on `coinductive` predicates, or on `inductive` predicates in a `mutual` block together with a `coinductive` predicate
 -/
 #guard_msgs in
 mutual
   inductive Even : Nat → Prop where
     | zero : Even 0
     | succ : Odd n → Even (n + 1)
-  monotonicity by repeat monotonicity
+  monotonicity_by repeat monotonicity
 
   inductive Odd : Nat → Prop where
     | succ : Even n → Odd (n + 1)

--- a/tests/elab/coinductive_keyword_monotonicity.lean
+++ b/tests/elab/coinductive_keyword_monotonicity.lean
@@ -1,0 +1,148 @@
+/-!
+Tests for the `monotonicity` clause on the `coinductive` and `inductive` keywords, which provides
+an explicit monotonicity proof for the underlying lattice-theoretic fixpoint construction,
+analogously to `coinductive_fixpoint monotonicity ...` / `inductive_fixpoint monotonicity ...`.
+-/
+
+open Lean.Order
+
+section
+variable (α : Type)
+
+-- Explicit tactic proof on a plain coinductive predicate
+
+coinductive infSeq (r : α → α → Prop) : α → Prop where
+  | step : r a b → infSeq r b → infSeq r a
+monotonicity by repeat monotonicity
+
+/--
+info: infSeq.step (α : Type) (r : α → α → Prop) {a b : α} : r a b → infSeq α r b → infSeq α r a
+-/
+#guard_msgs in
+#check infSeq.step
+
+/--
+info: infSeq.coinduct (α : Type) (r : α → α → Prop) (pred : α → Prop) (hyp : ∀ (a : α), pred a → ∃ b, r a b ∧ pred b)
+  (a✝ : α) : pred a✝ → infSeq α r a✝
+-/
+#guard_msgs in
+#check infSeq.coinduct
+
+-- Term-style proof with `sorry` still produces the predicate and its constructors
+
+/--
+warning: declaration uses `sorry`
+---
+warning: declaration uses `sorry`
+---
+warning: declaration uses `sorry`
+-/
+#guard_msgs in
+coinductive infSeq' (r : α → α → Prop) : α → Prop where
+  | step : r a b → infSeq' r b → infSeq' r a
+monotonicity sorry
+
+/--
+info: infSeq'.step (α : Type) (r : α → α → Prop) {a b : α} : r a b → infSeq' α r b → infSeq' α r a
+-/
+#guard_msgs in
+#check infSeq'.step
+
+-- The goal the explicit proof is elaborated against
+
+/--
+trace: α✝ α : Type
+r : α → α → Prop
+⊢ monotone fun f a => ∃ b, r a b ∧ f b
+---
+warning: declaration uses `sorry`
+---
+warning: declaration uses `sorry`
+---
+warning: declaration uses `sorry`
+-/
+#guard_msgs in
+coinductive infSeq'' (r : α → α → Prop) : α → Prop where
+  | step : r a b → infSeq'' r b → infSeq'' r a
+monotonicity by trace_state; sorry
+
+end
+
+-- Type errors in the provided proof are reported at the term
+
+/--
+error: Type mismatch
+  ()
+has type
+  Unit
+of sort `Type` but is expected to have type
+  monotone fun f => ¬f
+of sort `Prop`
+---
+warning: declaration uses `sorry`
+---
+warning: declaration uses `sorry`
+-/
+#guard_msgs in
+coinductive selfNeg : Prop where
+  | mk : ¬selfNeg → selfNeg
+monotonicity ()
+
+-- Mutual clique of two coinductive predicates, clause on only one member
+
+mutual
+  coinductive tick : Prop where
+    | mk : tock → tick
+  monotonicity by repeat monotonicity
+
+  coinductive tock : Prop where
+    | mk : tick → tock
+end
+
+/-- info: tick.mk : tock → tick -/
+#guard_msgs in
+#check tick.mk
+
+-- Mixed `inductive`/`coinductive` clique with a clause on each member
+
+mutual
+  coinductive ping : Prop where
+    | mk : ¬pong → ping
+  monotonicity by repeat monotonicity
+
+  inductive pong : Prop where
+    | mk : ¬ping → pong
+  monotonicity by repeat monotonicity
+end
+
+/-- info: ping.mk : ¬pong → ping -/
+#guard_msgs in
+#check ping.mk
+
+/-- info: pong.mk : ¬ping → pong -/
+#guard_msgs in
+#check pong.mk
+
+-- The clause is rejected on ordinary inductive types
+
+/--
+error: The `monotonicity` clause is only allowed on `coinductive` predicates, or on `inductive` predicates in a `mutual` block together with a `coinductive` predicate
+-/
+#guard_msgs in
+inductive Plain : Prop where
+  | mk : Plain
+monotonicity by repeat monotonicity
+
+/--
+error: The `monotonicity` clause is only allowed on `coinductive` predicates, or on `inductive` predicates in a `mutual` block together with a `coinductive` predicate
+-/
+#guard_msgs in
+mutual
+  inductive Even : Nat → Prop where
+    | zero : Even 0
+    | succ : Odd n → Even (n + 1)
+  monotonicity by repeat monotonicity
+
+  inductive Odd : Nat → Prop where
+    | succ : Even n → Odd (n + 1)
+end

--- a/tests/elab_fail/partial_fixpoint_parseerrors.lean.out.expected
+++ b/tests/elab_fail/partial_fixpoint_parseerrors.lean.out.expected
@@ -1,2 +1,2 @@
 partial_fixpoint_parseerrors.lean:6:0: error: expected indented monotonicity proof
-partial_fixpoint_parseerrors.lean:10:0-10:12: error: unexpected identifier; expected command
+partial_fixpoint_parseerrors.lean:10:0-10:12: error: unexpected token 'monotonicity'; expected command

--- a/tests/elab_fail/partial_fixpoint_parseerrors.lean.out.expected
+++ b/tests/elab_fail/partial_fixpoint_parseerrors.lean.out.expected
@@ -1,2 +1,2 @@
 partial_fixpoint_parseerrors.lean:6:0: error: expected indented monotonicity proof
-partial_fixpoint_parseerrors.lean:10:0-10:12: error: unexpected token 'monotonicity'; expected command
+partial_fixpoint_parseerrors.lean:10:0-10:12: error: unexpected identifier; expected command


### PR DESCRIPTION
This PR adds a `monotonicity_by` clause to `coinductive` and `inductive` predicate declarations, allowing users to prove monotonicity of the underlying fixpoint functor with an explicit tactic block when the automatic `monotonicity` proof search does not succeed. The clause enters tactic mode directly, analogously to `decreasing_by`, and may be attached to individual members of mutual cliques, including mixed `inductive`/`coinductive` ones:

```lean
mutual
  coinductive tick : Prop where
    | mk : ¬tock → tick
  monotonicity_by repeat monotonicity

  inductive tock : Prop where
    | mk : ¬tick → tock
end
```

The clause is parsed as a trailing declaration suffix introduced by the new `monotonicity_by` keyword, wrapped into a `by` term while building the `InductiveView`, and threaded through `CoinductiveElabData` into the `term?` field of the `PartialFixpoint` termination hint, so it reuses the elaboration path of `coinductive_fixpoint monotonicity ...`. Monotonicity goals for functors coming from the `coinductive` elaborator are now beta-reduced, so goals and error messages are stated in terms of the predicate body instead of the internal `.existential` auxiliaries. Using the clause on an `inductive` that is not part of a clique with a `coinductive` predicate is reported as an error.
