### PR TITLE
feat: lake: read recorded code quality metrics in `lake lint`

### DIFF
--- a/src/Lean/Linter/Init.lean
+++ b/src/Lean/Linter/Init.lean
@@ -162,12 +162,15 @@ def codeQualityMessageTag : Name := `Lean.Linter._codeQuality
 /--
 Logs a message carrying the code quality entry `e` at the position of `stx`. The message is
 logged as silent so it is never displayed to users; it only serves as a carrier for persisting
-the entry into the `.olean` (see `Lean.Linter.recordLints`).
+the entry into the `.olean` (see `Lean.Linter.recordLints`). Like `logLint`, the message is
+tagged with `linterOption.name`, so consumers can attribute the entry to the linter that
+produced it (e.g. to honor `lake lint --lint-only`).
 -/
 def logCodeQualityEntry [Monad m] [MonadLog m] [AddMessageContext m] [MonadOptions m]
-    (stx : Syntax) (e : CodeQuality.Entry) : m Unit :=
+    (linterOption : Lean.Option Bool) (stx : Syntax) (e : CodeQuality.Entry) : m Unit :=
   logAt stx (severity := .information) (isSilent := true) <|
     .ofCodeQualityEntry e <|
+    .tagged linterOption.name <|
     .tagged codeQualityMessageTag <| .nil
 
 /-- Returns true if `msg` was produced by `Lean.Linter.logCodeQualityEntry`. -/
@@ -195,7 +198,7 @@ provided linter option is enabled, taking `linter.all` and linter sets into acco
 -/
 def logCodeQualityEntryIf [Monad m] [MonadLog m] [AddMessageContext m] [MonadOptions m] [MonadEnv m]
     (linterOption : Lean.Option Bool) (stx : Syntax) (e : CodeQuality.Entry) : m Unit := do
-  if getLinterValue linterOption (← getLinterOptions) then logCodeQualityEntry stx e
+  if getLinterValue linterOption (← getLinterOptions) then logCodeQualityEntry linterOption stx e
 
 abbrev EnvLinterSnapshot := NameMap Bool
 

--- a/src/Lean/Linter/PersistentLintLog.lean
+++ b/src/Lean/Linter/PersistentLintLog.lean
@@ -36,8 +36,14 @@ def getAllLints (env : Environment) : Array (Name × Array LintEntry) :=
   env.header.moduleNames.mapIdx fun i mod =>
     (mod, lintLogExt.getModuleEntries env i (level := .server))
 
+/-- A code quality entry recorded by `Lean.Linter.recordLints`, together with the option name of
+the linter that logged it (the tag attached by `Lean.Linter.logCodeQualityEntry`). -/
+structure CodeQualityLogEntry where
+  linter : Name
+  entry  : CodeQuality.Entry
+
 builtin_initialize codeQualityLogExt :
-    PersistentEnvExtension CodeQuality.Entry CodeQuality.Entry (Array CodeQuality.Entry) ←
+    PersistentEnvExtension CodeQualityLogEntry CodeQualityLogEntry (Array CodeQualityLogEntry) ←
   registerPersistentEnvExtension {
     mkInitial     := pure #[]
     addImportedFn := fun _ => pure #[]
@@ -46,7 +52,7 @@ builtin_initialize codeQualityLogExt :
       { exported := #[], server := entries, «private» := entries }
   }
 
-def getAllCodeQualityEntries (env : Environment) : Array (Name × Array CodeQuality.Entry) :=
+def getAllCodeQualityEntries (env : Environment) : Array (Name × Array CodeQualityLogEntry) :=
   env.header.moduleNames.mapIdx fun i mod =>
     (mod, codeQualityLogExt.getModuleEntries env i (level := .server))
 
@@ -56,7 +62,8 @@ instance : MonadFileMap (ReaderT FileMap BaseIO) := ⟨read⟩
 Records linter warnings and looks up positions of their associated commands from a build
 into `lintLogExt` so that consumers (e.g. `lake lint`) can recover them from the `.olean`.
 Messages carrying code quality entries (see `Lean.Linter.logCodeQualityEntry`) are recorded
-into `codeQualityLogExt` instead, without any position information.
+into `codeQualityLogExt` instead, keyed by the producing linter's option name, without any
+position information.
 -/
 def recordLints (fileMap : FileMap) (env : Environment)
     (commandLints : Array (Option Syntax × MessageLog)) : BaseIO Environment := do
@@ -66,11 +73,15 @@ def recordLints (fileMap : FileMap) (env : Environment)
       | none     => pure none
     let position? : Option Position := declRange?.map (·.pos)
     messages.reportedPlusUnreported.foldlM (init := env) fun env m => do
+      let kind := m.data.kind
       if let some entry := m.data.codeQualityEntry? then
-        return codeQualityLogExt.addEntry env entry
+        -- Without a linter-name tag, `kind` is anonymous (or falls through to the marker tag);
+        -- such entries cannot be attributed to a linter and are dropped.
+        if kind.isAnonymous || kind == codeQualityMessageTag then
+          return env
+        return codeQualityLogExt.addEntry env { linter := kind, entry }
       unless m.data.isLinterMessage do
         return env
-      let kind := m.data.kind
       if kind.isAnonymous then
         return env
       let sm ← m.serialize

--- a/src/lake/Lake/CLI/BuiltinLint.lean
+++ b/src/lake/Lake/CLI/BuiltinLint.lean
@@ -109,6 +109,34 @@ private def collectTextLints
   Linter.getAllLints env |>.foldl (init := #[]) fun acc (mod, entries) =>
     if pkgRoot.isPrefixOf mod && !entries.isEmpty then acc.push (mod, entries) else acc
 
+/--
+Collects the code quality entries recorded during elaboration (via
+`Lean.Linter.logCodeQualityEntry`) for the modules of the package rooted at `mod.getRoot` that
+are imported by `env`. Like text-linter warnings, these were persisted into `codeQualityLogExt`
+when each module was built (with the linter overrides applied via `leanOptOverrides`) and are
+recovered here from the `.olean`s, which requires an environment imported at the `server` olean
+level. With `--lint-only`, the entries are additionally filtered to the explicitly enabled
+linters via the option name recorded with each entry.
+
+Modules in `collectedModules` were already covered by an earlier lint target and are skipped, so
+that a module imported by several targets contributes its entries only once; the returned set
+extends it with the modules collected here.
+-/
+private def collectRecordedCodeQuality (args : Args) (linterOpts : Linter.LinterOptions)
+    (env : Environment) (mod : Name) (collectedModules : NameSet) :
+    Array CodeQuality.Entry × NameSet := Id.run do
+  let mut collected := collectedModules
+  let mut acc : Array CodeQuality.Entry := #[]
+  for (m, entries) in Linter.getAllCodeQualityEntries env do
+    unless mod.getRoot.isPrefixOf m && !collected.contains m do continue
+    collected := collected.insert m
+    let entries :=
+      if args.lintOnly then
+        entries.filter fun e => Lean.Linter.isLinterEnabledByOptions e.linter linterOpts
+      else entries
+    acc := acc ++ entries.map (·.entry)
+  return (acc, collected)
+
 @[noinline] private def getIsModule (modData : Lean.ModuleData) : BaseIO Bool :=
   return modData.isModule
 
@@ -421,6 +449,9 @@ public def run (args : Args) : IO UInt32 := do
   -- Modules whose deferred docstring checks have already been run. A module can appear in
   -- several targets' import closures, so this runs each such module's checks only once.
   let mut docCheckedModules : NameSet := {}
+  -- Modules whose recorded code quality entries have already been collected, so a module shared
+  -- between several targets' import closures does not contribute its entries more than once.
+  let mut metricsCollectedModules : NameSet := {}
   for mod in mods do
     unsafe Lean.enableInitializersExecution
     -- Peek at the .olean header to learn whether `mod` participates in the module system.
@@ -462,6 +493,10 @@ public def run (args : Args) : IO UInt32 := do
       codeQualityEntries := codeQualityEntries ++ entries
 
     if args.mode == .codeQuality then
+      let (recorded, collected) :=
+        collectRecordedCodeQuality args linterOpts env mod metricsCollectedModules
+      metricsCollectedModules := collected
+      codeQualityEntries := codeQualityEntries ++ recorded
       let ⟨entries, failed⟩ ← runPackageCodeQualityChecks sp env mod
       codeQualityEntries := codeQualityEntries ++ entries
       if failed then anyFailed := true

--- a/tests/elab/code_quality_log.lean
+++ b/tests/elab/code_quality_log.lean
@@ -6,15 +6,16 @@ open Lean Lean.Linter
 ## Tests for the persistent code quality log extension
 
 Code quality entries are logged by `Lean.Linter.logCodeQualityEntry` as silent messages carrying
-an `MessageData.ofCodeQualityEntry` constructor. `Lean.Linter.recordLints` extracts them and
-persists them into `codeQualityLogExt` (without position information), keeping them out of
-`lintLogExt`.
+an `MessageData.ofCodeQualityEntry` constructor, tagged with the producing linter's option name.
+`Lean.Linter.recordLints` extracts them and persists them into `codeQualityLogExt` together with
+the linter name (without position information), keeping them out of `lintLogExt`.
 -/
 
 /-- Build a message shaped like the output of `Linter.logCodeQualityEntry`, including the
 `.withContext` wrapper that `addMessageContext` adds in `logAt`. -/
-def mkCQMessage (e : CodeQuality.Entry) : CoreM Message := do
-  let data ← addMessageContext <| .ofCodeQualityEntry e <| .tagged codeQualityMessageTag .nil
+def mkCQMessage (linter : Name) (e : CodeQuality.Entry) : CoreM Message := do
+  let data ← addMessageContext <| .ofCodeQualityEntry e <| .tagged linter <|
+    .tagged codeQualityMessageTag .nil
   return {
     fileName := "Test.lean"
     pos := ⟨1, 1⟩
@@ -24,32 +25,52 @@ def mkCQMessage (e : CodeQuality.Entry) : CoreM Message := do
   }
 
 /--
-Records a single code-quality-shaped message and returns the recorded entry names together with
-the size of the lint log, which must stay empty.
+Records a single code-quality-shaped message and returns the recorded (linter, metric) pairs
+together with the size of the lint log, which must stay empty.
 -/
-def testRecordCodeQualityEntry : CoreM (Array String × Nat) := do
+def testRecordCodeQualityEntry : CoreM (Array (Name × String) × Nat) := do
   let e : CodeQuality.Entry :=
     { name := "dummy_metric", source := .module `Test, value := .scalar 1.0 }
-  let log := MessageLog.empty.add (← mkCQMessage e)
+  let log := MessageLog.empty.add (← mkCQMessage `linter.dummy e)
   let env ← Linter.recordLints default (← getEnv) #[(none, log)]
-  return ((codeQualityLogExt.getState env).map (·.name), (lintLogExt.getState env).size)
+  return ((codeQualityLogExt.getState env).map fun r => (r.linter, r.entry.name),
+          (lintLogExt.getState env).size)
 
-/-- info: (#["dummy_metric"], 0) -/
+/-- info: (#[(`linter.dummy, "dummy_metric")], 0) -/
 #guard_msgs in
 #eval testRecordCodeQualityEntry
 
-/-- Multiple entries across commands are recorded in log order. -/
-def testRecordCodeQualityEntryMultiple : CoreM (Array String) := do
-  let mk (name : String) : CoreM Message :=
-    mkCQMessage { name, source := .module `Test, value := .scalar 1.0 }
-  let log₁ := MessageLog.empty.add (← mk "a") |>.add (← mk "b")
-  let log₂ := MessageLog.empty.add (← mk "c")
+/-- Multiple entries across commands are recorded in log order, each keyed by its linter. -/
+def testRecordCodeQualityEntryMultiple : CoreM (Array (Name × String)) := do
+  let mk (linter : Name) (name : String) : CoreM Message :=
+    mkCQMessage linter { name, source := .module `Test, value := .scalar 1.0 }
+  let log₁ := MessageLog.empty.add (← mk `linter.one "a") |>.add (← mk `linter.two "b")
+  let log₂ := MessageLog.empty.add (← mk `linter.one "c")
   let env ← Linter.recordLints default (← getEnv) #[(none, log₁), (none, log₂)]
-  return (codeQualityLogExt.getState env).map (·.name)
+  return (codeQualityLogExt.getState env).map fun r => (r.linter, r.entry.name)
 
-/-- info: #["a", "b", "c"] -/
+/-- info: #[(`linter.one, "a"), (`linter.two, "b"), (`linter.one, "c")] -/
 #guard_msgs in
 #eval testRecordCodeQualityEntryMultiple
+
+/-- A code-quality message without a linter-name tag has an anonymous kind and is dropped. -/
+def testRecordCodeQualityDropsUntagged : CoreM Nat := do
+  let e : CodeQuality.Entry :=
+    { name := "untagged_metric", source := .module `Test, value := .scalar 1.0 }
+  let data ← addMessageContext <| .ofCodeQualityEntry e <| .tagged codeQualityMessageTag .nil
+  let msg : Message := {
+    fileName := "Test.lean"
+    pos := ⟨1, 1⟩
+    severity := .information
+    isSilent := true
+    data
+  }
+  let env ← Linter.recordLints default (← getEnv) #[(none, MessageLog.empty.add msg)]
+  return (codeQualityLogExt.getState env).size
+
+/-- info: 0 -/
+#guard_msgs in
+#eval testRecordCodeQualityDropsUntagged
 
 /-- Linter warnings and plain messages must not be recorded as code quality entries. -/
 def testRecordCodeQualityIgnoresOthers : CoreM Nat := do

--- a/tests/lake/tests/builtin-lint-code-quality/Linters.lean
+++ b/tests/lake/tests/builtin-lint-code-quality/Linters.lean
@@ -1,6 +1,6 @@
 import Lean.Linter.EnvLinter
 
-open Lean Meta Lean.Linter
+open Lean Meta Lean.Linter Lean.Elab.Command
 
 /-- Option gating the dummy env linter; on by default so it fires during the
 build without needing `--linters`. -/
@@ -22,3 +22,22 @@ public meta def dummyMarker : Lean.Linter.EnvLinter.EnvLinter where
     if declName.toString.endsWith "DummyMarker" then
       return some "declaration name ends with 'DummyMarker'"
     return none
+
+/-- Option gating the metric-recording text linter; on by default so entries are recorded
+during the build without needing `--linters`. -/
+register_option linter.declMetric : Bool := {
+  defValue := true
+  descr := "(test) record a code quality entry for every declaration command"
+}
+
+-- A text linter recording a code quality entry (metric `declCommands`, value 1) for every
+-- `declaration` command, attributed to the elaborating module. Exercises the recorded-metrics
+-- side of the code quality output: the entries are persisted into the `.olean` during the build
+-- and recovered by `lake lint --code-quality` without re-elaboration.
+def declMetricLinter : Linter where
+  run cmdStx := do
+    unless cmdStx.getKind == ``Lean.Parser.Command.declaration do return
+    logCodeQualityEntryIf linter.declMetric cmdStx
+      { name := "declCommands", source := .module (← getMainModule), value := .scalar 1.0 }
+
+initialize addLinter declMetricLinter

--- a/tests/lake/tests/builtin-lint-code-quality/expected.json
+++ b/tests/lake/tests/builtin-lint-code-quality/expected.json
@@ -1,5 +1,11 @@
 {"value":{"scalar":{"value":1}},"source":{"declaration":{"name":"Inner.nestedDummyMarker","module":"Violations"}},"name":"linter.dummyMarker"}
 {"value":{"scalar":{"value":1}},"source":{"declaration":{"name":"fooDummyMarker","module":"Violations"}},"name":"linter.dummyMarker"}
 {"value":{"scalar":{"value":1}},"source":{"declaration":{"name":"subDummyMarker","module":"Violations.Sub"}},"name":"linter.dummyMarker"}
+{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations"}},"name":"declCommands"}
+{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations"}},"name":"declCommands"}
+{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations"}},"name":"declCommands"}
+{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations"}},"name":"declCommands"}
+{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations.Sub"}},"name":"declCommands"}
+{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations.Sub"}},"name":"declCommands"}
 {"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations.Sub"}},"name":"linter.unusedVariables"}
 {"value":{"scalar":{"value":2}},"source":{"module":{"name":"Violations"}},"name":"linter.unusedVariables"}

--- a/tests/lake/tests/builtin-lint-code-quality/test.sh
+++ b/tests/lake/tests/builtin-lint-code-quality/test.sh
@@ -2,13 +2,18 @@
 source ../common.sh
 
 # Exercises `lake lint --code-quality`: instead of reporting linter warnings,
-# each one is emitted as a JSON code quality entry on stdout. Covers both linter
-# flavours:
+# each one is emitted as a JSON code quality entry on stdout. Covers three
+# entry sources:
 #   * text linters (`linter.unusedVariables`), aggregated per module into one
-#     entry whose scalar value is the warning count, and
+#     entry whose scalar value is the warning count,
 #   * env linters (`linter.dummyMarker`, defined in `Linters.lean`), emitted per
-#     flagged declaration together with the module defining it.
-# Both flavours key their entry on the linter's *option* name.
+#     flagged declaration together with the module defining it, and
+#   * entries recorded during elaboration via `logCodeQualityEntryIf`
+#     (`linter.declMetric`, defined in `Linters.lean`), persisted into the
+#     `.olean` per module and emitted verbatim.
+# The first two flavours key their entry on the linter's *option* name; recorded
+# entries carry a free-form metric name but are attributed to their linter's
+# option name internally, which `--lint-only` filters on.
 
 ./clean.sh
 
@@ -25,6 +30,19 @@ collect_json() {
     END { if (buf != "") print buf }
   ' produced.out | tr -d ' ' | LC_ALL=C sort > produced.json
   cat produced.json
+}
+
+# Asserts that the second argument occurs exactly `count` times in the given file.
+count_text() {
+  count=$1; pat=$2; file=$3
+  echo "? grep -c -F \"$pat\" $file = $count"
+  actual="$(grep -c -F -- "$pat" "$file" || true)"
+  if [ "$actual" = "$count" ]; then
+    return 0
+  else
+    echo "FAILURE: found $actual occurrence(s), expected $count"
+    return 1
+  fi
 }
 
 # --- Baseline: in report mode the same violations are reported and fail. ---
@@ -54,21 +72,52 @@ match_text '{"value":{"scalar":{"value":1}},"source":{"declaration":{"name":"foo
 match_text '{"value":{"scalar":{"value":1}},"source":{"declaration":{"name":"subDummyMarker","module":"Violations.Sub"}},"name":"linter.dummyMarker"}' produced.json
 # A declaration-level `set_option linter.dummyMarker false in` is honored.
 no_match_text 'suppressedDummyMarker' produced.json
-# Nothing outside the linted package leaks in (`Linters.lean` defines the linter).
+# Recorded entries are emitted verbatim, one per declaration command per module: four in
+# `Violations` (the `set_option ... in`-wrapped declaration is not a `declaration` command)
+# and two in `Violations.Sub`.
+count_text 4 '{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations"}},"name":"declCommands"}' produced.json
+count_text 2 '{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations.Sub"}},"name":"declCommands"}' produced.json
+# Nothing outside the linted package leaks in (`Linters.lean` defines the linters).
 no_match_text '"module":"Linters"' produced.json
+no_match_text '"name":"Linters"' produced.json
 
 # --- Linter selection. ---
-# `--lint-only` restricts the output to the explicitly enabled linters.
+# `--lint-only` restricts the output to the explicitly enabled linters. Recorded entries are
+# filtered by the linter option name persisted with each entry, so the default-on
+# `linter.declMetric` entries (recorded during the build) are dropped too.
 lake_out lint --code-quality --lint-only=linter.dummyMarker Violations
 collect_json
 match_text 'fooDummyMarker' produced.json
 no_match_text 'linter.unusedVariables' produced.json
+no_match_text 'declCommands' produced.json
 
-# Disabling a default-on linter drops its entries; the env linter still reports.
+# ...and explicitly enabling the recording linter keeps its entries.
+lake_out lint --code-quality --lint-only=linter.declMetric Violations
+collect_json
+match_text 'declCommands' produced.json
+no_match_text 'linter.unusedVariables' produced.json
+no_match_text 'fooDummyMarker' produced.json
+
+# Disabling a default-on linter drops its entries; the env linter and the recorded
+# entries still report.
 lake_out lint --code-quality --linters=-linter.unusedVariables Violations
 collect_json
 no_match_text 'linter.unusedVariables' produced.json
 match_text 'fooDummyMarker' produced.json
+match_text 'declCommands' produced.json
+
+# Disabling the recording linter suppresses recording at elaboration time.
+lake_out lint --code-quality --linters=-linter.declMetric Violations
+collect_json
+no_match_text 'declCommands' produced.json
+match_text 'linter.unusedVariables' produced.json
+
+# --- Multiple lint targets. ---
+# `Violations.Sub` sits in the import closure of both targets, but its recorded entries are
+# collected only once.
+lake_out lint --code-quality Violations Violations.Sub
+collect_json
+count_text 2 '{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations.Sub"}},"name":"declCommands"}' produced.json
 
 # --- No violations means no entries. ---
 lake_out lint --code-quality --lint-only=-linter.all Violations


### PR DESCRIPTION
This PR makes `lake lint --code-quality` emit the code quality entries recorded during elaboration (via `Lean.Linter.logCodeQualityEntry`) alongside the linter-derived and package-check ones. Recorded entries are now attributed to the linter option that produced them, so `--lint-only` restricts them in the same way as ordinary linter warnings.

`Lean.Linter.logCodeQualityEntry` now takes the producing linter's option and tags its message with the option name, mirroring `logLint`. `Lean.Linter.recordLints` persists that name together with the entry in `codeQualityLogExt` (as the new `CodeQualityLogEntry`) and drops entries that carry no linter tag. `lake lint` recovers the entries from the `.olean`s of each lint target's package modules without re-elaboration, filters them under `--lint-only` via the recorded linter name, and collects a module's entries only once when it appears in several targets' import closures.