### PR TITLE
fix: return unboxed uint8 from llvm_is_declaration

### DIFF
--- a/src/library/llvm.cpp
+++ b/src/library/llvm.cpp
@@ -1373,14 +1373,13 @@ extern "C" LEAN_EXPORT lean_object *lean_llvm_get_value_name2(size_t ctx, size_t
 #endif  // LEAN_LLVM
 }
 
-extern "C" LEAN_EXPORT lean_object *llvm_is_declaration(size_t ctx, size_t global) {
+extern "C" LEAN_EXPORT uint8_t llvm_is_declaration(size_t ctx, size_t global) {
 #ifndef LEAN_LLVM
     lean_always_assert(
         false && ("Please build a version of Lean4 with -DLLVM=ON to invoke "
                   "the LLVM backend function."));
 #else
-	uint8_t is_bool = LLVMIsDeclaration(lean_to_Value(global));
-	return lean_box(is_bool);
+	return LLVMIsDeclaration(lean_to_Value(global));
 #endif  // LEAN_LLVM
 }
 


### PR DESCRIPTION
This PR fixes llvm_is_declaration. Currently lean_box(0) returns 1 which means LLVM false reads as true whenever the -DLLVM=ON

addresses [issue 14863](https://github.com/leanprover/lean4/issues/14863)
