### PR TITLE
chore: golf two DerivingHelper proofs

### DIFF
--- a/src/Init/LawfulBEqTactics.lean
+++ b/src/Init/LawfulBEqTactics.lean
@@ -34,10 +34,9 @@ theorem deriving_lawful_beq_helper_dep {x y : α} [BEq α] [ReflBEq α]
     (inst : (x == y) = true → x = y)
     (k : (h : x = y) → t (h ▸ ReflBEq.rfl) = true → P) :
     (if h : (x == y) then t h else false) = true → P := by
-  intro h
-  split at h
-  · exact k (inst ‹_›) h
-  · cases h
+  split
+  · exact k (inst ‹_›)
+  · nofun
 
 theorem deriving_lawful_beq_helper_nd {x y : α} [BEq α] [ReflBEq α]
     {P : Prop}

--- a/src/Init/LawfulBEqTactics.lean
+++ b/src/Init/LawfulBEqTactics.lean
@@ -30,31 +30,21 @@ theorem and_true_curry {a b : Bool} {P : Prop}
 
 
 theorem deriving_lawful_beq_helper_dep {x y : α} [BEq α] [ReflBEq α]
-  {t : (x == y) = true → Bool} {P : Prop}
+    {t : (x == y) = true → Bool} {P : Prop}
     (inst : (x == y) = true → x = y)
     (k : (h : x = y) → t (h ▸ ReflBEq.rfl) = true → P) :
     (if h : (x == y) then t h else false) = true → P := by
   intro h
-  by_cases hxy : x = y
-  · subst hxy
-    apply k rfl
-    rw [dite_eq_left (BEq.refl x)] at h
-    exact h
-  · by_cases hxy' : x == y
-    · exact False.elim <| hxy (inst hxy')
-    · rw [dite_eq_right hxy'] at h
-      contradiction
+  split at h
+  · exact k (inst ‹_›) h
+  · cases h
 
 theorem deriving_lawful_beq_helper_nd {x y : α} [BEq α] [ReflBEq α]
     {P : Prop}
     (inst : (x == y) = true → x = y)
     (k : x = y → P) :
-    (x == y) = true → P := by
-  intro h
-  by_cases hxy : x = y
-  · subst hxy
-    apply k rfl
-  · exact False.elim <| hxy (inst h)
+    (x == y) = true → P :=
+  k ∘ inst
 
 end DerivingHelpers
 


### PR DESCRIPTION
In the first `split` can handle all the case splitting, and in the second no case split is needed at all.