### PR TITLE
chore: all register_options should be builtin

### DIFF
--- a/src/Lean/Elab/Tactic/Simpa.lean
+++ b/src/Lean/Elab/Tactic/Simpa.lean
@@ -18,7 +18,7 @@ namespace Lean
 Enables the 'unnecessary `simpa`' linter. This will report if a use of
 `simpa` could be proven using `simp` or `simp at h` instead.
 -/
-register_option linter.unnecessarySimpa : Bool := {
+register_builtin_option linter.unnecessarySimpa : Bool := {
   defValue := true
   descr := "enable the 'unnecessary simpa' linter"
 }

--- a/src/Lean/Message.lean
+++ b/src/Lean/Message.lean
@@ -390,7 +390,7 @@ where
 Maximum number of trace node children to display by default to prevent slowdowns from rendering. In
 the info view, more children can be expanded interactively.
 -/
-register_option maxTraceChildren : Nat := {
+register_builtin_option maxTraceChildren : Nat := {
   defValue := 50
   descr := "Maximum number of trace node children to display"
 }


### PR DESCRIPTION
At least, this is what @Kha suggested to me may as well be true.

Note that there are still about one `initialize` to every ten `builtin_initialize`, so maybe there's more going on here.