### PR TITLE
chore: enforce the requested libuv version

### DIFF
--- a/src/cmake/Modules/FindLibUV.cmake
+++ b/src/cmake/Modules/FindLibUV.cmake
@@ -9,5 +9,7 @@ message(STATUS "LIBUV_LDFLAGS: " ${LIBUV_LDFLAGS})
 message(STATUS "LIBUV_INCLUDE_DIRS: " ${LIBUV_INCLUDE_DIRS})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(LibUV DEFAULT_MSG LIBUV_FOUND)
+find_package_handle_standard_args(LibUV
+  REQUIRED_VARS LIBUV_FOUND
+  VERSION_VAR LIBUV_VERSION)
 mark_as_advanced(LIBUV_INCLUDE_DIRS LIBUV_LDFLAGS)


### PR DESCRIPTION
This PR makes the build actually reject a libuv older than the 1.0.0 it asks for, instead of accepting any version found.

`FindLibUV.cmake` passed `DEFAULT_MSG` to `find_package_handle_standard_args` without a `VERSION_VAR`, so the version argument in `find_package(LibUV 1.0.0 REQUIRED)` was silently ignored. `pkg_search_module` already sets `LIBUV_VERSION`, so it only has to be handed to `find_package_handle_standard_args`.

This was found while working on #14833.