### PR TITLE
refactor: remove the binder form of the Hoare triple notation

### DIFF
--- a/src/Std/WP/Triple/Basic.lean
+++ b/src/Std/WP/Triple/Basic.lean
@@ -71,27 +71,15 @@ attribute [scoped instance] Lean.Order.instCCPOOfCompleteLattice
 after the precondition ascribes the program to monad `…`. -/
 scoped syntax:60 (name := tripleNotation)
   "⦃ " term " ⦄ " (atomic("(" ident " := ") term ")")? term " ⦃ " term " ⦄" : term
-/-- Hoare triple notation with a binder for the return value. -/
-scoped syntax:60 (name := tripleBinderNotation)
-  "⦃ " term " ⦄ " (atomic("(" ident " := ") term ")")? term " ⦃ " ident ", " term " ⦄" : term
 /-- Hoare triple notation with an exception postcondition:
 `⦃ P ⦄ x ⦃ Q; E ⦄ := Triple x P Q E`. -/
 scoped syntax:60 (name := tripleExceptPost)
   "⦃ " term " ⦄ " (atomic("(" ident " := ") term ")")? term " ⦃ " term "; " term " ⦄" : term
-/-- Hoare triple notation with a binder for the return value and an exception postcondition. -/
-scoped syntax:60 (name := tripleBinderExceptPost)
-  "⦃ " term " ⦄ " (atomic("(" ident " := ") term ")")? term " ⦃ " ident ", " term "; " term " ⦄" : term
 
 macro_rules (kind := tripleNotation)
   | `(⦃ $P ⦄ $[(m := $m)]? $c ⦃ $Q ⦄) => do `(Triple $(← hintProgram c m) $P $Q Lean.Order.bot)
-macro_rules (kind := tripleBinderNotation)
-  | `(⦃ $P ⦄ $[(m := $m)]? $c ⦃ $v, $Q ⦄) => do
-      `(Triple $(← hintProgram c m) $P (fun $v => $Q) Lean.Order.bot)
 macro_rules (kind := tripleExceptPost)
   | `(⦃ $P ⦄ $[(m := $m)]? $c ⦃ $Q; $E ⦄) => do `(Triple $(← hintProgram c m) $P $Q $E)
-macro_rules (kind := tripleBinderExceptPost)
-  | `(⦃ $P ⦄ $[(m := $m)]? $c ⦃ $v, $Q; $E ⦄) => do
-      `(Triple $(← hintProgram c m) $P (fun $v => $Q) $E)
 
 /-- Pretty-print `Triple` applications back as `⦃ … ⦄` notation. -/
 @[app_unexpander Triple]

--- a/tests/elab/vcgenFinish.lean
+++ b/tests/elab/vcgenFinish.lean
@@ -53,14 +53,14 @@ theorem eat_spec_finish (s0 : List Nat) (fuel : Nat) (hfuel : s0.length < fuel) 
 /-! An inconsistent local context closes the goal during initialisation, leaving nothing for the
 `vcgen` step. The first example is the same goal without the contradictory hypothesis. -/
 
-example : ⦃ True ⦄ (pure 3 : Id Nat) ⦃ r, r = 3 ⦄ := by
+example : ⦃ True ⦄ (pure 3 : Id Nat) ⦃ fun r => r = 3 ⦄ := by
   vcgen
 
-example (hFalse : false = true) : ⦃ True ⦄ (pure 3 : Id Nat) ⦃ r, r = 3 ⦄ := by
+example (hFalse : false = true) : ⦃ True ⦄ (pure 3 : Id Nat) ⦃ fun r => r = 3 ⦄ := by
   vcgen
 
-example (hFalse : False) : ⦃ True ⦄ (pure 3 : Id Nat) ⦃ r, r = 3 ⦄ := by
+example (hFalse : False) : ⦃ True ⦄ (pure 3 : Id Nat) ⦃ fun r => r = 3 ⦄ := by
   vcgen
 
-example (hFalse : false = true) : ⦃ True ⦄ (pure 3 : Id Nat) ⦃ r, r = 3 ⦄ := by
+example (hFalse : false = true) : ⦃ True ⦄ (pure 3 : Id Nat) ⦃ fun r => r = 3 ⦄ := by
   vcgen with finish


### PR DESCRIPTION
This PR removes the `⦃ P ⦄ c ⦃ v, Q ⦄` form of the Hoare triple notation. The `⦃ P ⦄ c ⦃ fun v => Q ⦄` expansion is easier to understand.