### PR TITLE
chore: handle GitHub API errors when triggering the API docs workflow

### DIFF
--- a/script/release/checklist.py
+++ b/script/release/checklist.py
@@ -808,8 +808,6 @@ class LeanChecker(RepoChecker):
         self.cl.success(f"{what} updated")
 
     def check_api_docs_workflow(self) -> None:
-        grepo = self.github.get_repo(repos.LEAN4_API_DOCS.gh_full_name)
-        workflow = grepo.get_workflow("docs.yaml")
         url = "https://github.com/leanprover/lean4-api-docs/actions/workflows/docs.yaml"
         what = f"[u link={url}]docs.yaml workflow[/u link] on [b]{e(repos.LEAN4_API_DOCS.gh_full_name)}[/b]"
 
@@ -818,14 +816,18 @@ class LeanChecker(RepoChecker):
             return
 
         # Dispatching requires admin rights on lean4-api-docs, which not every
-        # release manager has.
+        # release manager has. This check is independent of the ones after it, so
+        # record a failure rather than letting the API error end the run.
         try:
-            workflow.create_dispatch(ref=grepo.default_branch)
+            grepo = self.github.get_repo(repos.LEAN4_API_DOCS.gh_full_name)
+            workflow = grepo.get_workflow("docs.yaml")
+            triggered = workflow.create_dispatch(ref=grepo.default_branch)
         except GithubException as exc:
-            message = (
-                exc.data.get("message", exc) if isinstance(exc.data, dict) else exc
-            )
-            self.cl.fail(f"{what} not triggered: {e(str(message))}")
+            self.cl.fail(f"{what} not triggered: {e(str(exc))}")
+            return
+
+        if not triggered:
+            self.cl.fail(f"{what} not triggered")
             return
 
         self.cl.success(f"{what} triggered")

--- a/script/release/checklist.py
+++ b/script/release/checklist.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import repos
-from github import Github, UnknownObjectException
+from github import Github, GithubException, UnknownObjectException
 from github.GitRef import GitRef
 from rich import print
 from rich.markup import escape as e
@@ -817,7 +817,17 @@ class LeanChecker(RepoChecker):
             self.cl.fail(f"{what} not triggered")
             return
 
-        workflow.create_dispatch(ref=grepo.default_branch)
+        # Dispatching requires admin rights on lean4-api-docs, which not every
+        # release manager has.
+        try:
+            workflow.create_dispatch(ref=grepo.default_branch)
+        except GithubException as exc:
+            message = (
+                exc.data.get("message", exc) if isinstance(exc.data, dict) else exc
+            )
+            self.cl.fail(f"{what} not triggered: {e(str(message))}")
+            return
+
         self.cl.success(f"{what} triggered")
 
     def check_zulip_post(self) -> None:


### PR DESCRIPTION
This PR stops `checklist.py` from aborting the release run when the API docs workflow cannot be dispatched.

Triggering `docs.yaml` requires admin rights on `leanprover/lean4-api-docs`, which not every release manager has. The resulting 403 propagated out of `check_api_docs_workflow` and skipped the remaining post-release checks; it is now recorded as a failed checklist item instead.

🤖 Prepared with Claude Code