### PR TITLE
chore: credit the running user in generated release notes

### DIFF
--- a/script/release/release_notes.py
+++ b/script/release/release_notes.py
@@ -274,11 +274,19 @@ def pl(n: int, singular: str, plural: str | None = None) -> str:
     return f"{n} {singular if n == 1 else plural}"
 
 
+def get_author(repo: Repo) -> str:
+    name = str(repo.config_reader().get_value("user", "name", ""))
+    if not name:
+        raise SystemExit("Failed to read `user.name` from git config")
+    return name
+
+
 def main(version: Version, refman: Path):
     util.initialize_rich()
     github = util.get_github_instance()
 
     repo = Repo(Path(__file__).parent.parent.parent)
+    author = get_author(repo)
     grepo = github.get_repo(repos.LEAN4.gh_full_name)
     release = grepo.get_release(version.tag)
     date = release.published_at.astimezone(datetime.timezone.utc)
@@ -292,7 +300,7 @@ def main(version: Version, refman: Path):
     lines.append("/-")
     lines.append(f"Copyright (c) {date.year} Lean FRO LLC. All rights reserved.")
     lines.append("Released under Apache 2.0 license as described in the file LICENSE.")
-    lines.append("Author: Joscha Mennicken")
+    lines.append(f"Author: {author}")
     lines.append("-/")
     lines.append("")
     lines.append("import VersoManual")

--- a/script/release/release_notes.py
+++ b/script/release/release_notes.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import repos
-from git import Commit, Repo
+from git import Commit, GitCommandError, Repo
 from github.Repository import Repository
 from rich import print
 from rich.markup import escape as e
@@ -275,9 +275,19 @@ def pl(n: int, singular: str, plural: str | None = None) -> str:
 
 
 def get_author(repo: Repo) -> str:
-    name = str(repo.config_reader().get_value("user", "name", ""))
+    # Ask git rather than reading the config directly, so that conditional
+    # includes and environment overrides are resolved the way git resolves them.
+    try:
+        name = repo.git.config("--get", "user.name").strip()
+    except GitCommandError:
+        name = ""
+
     if not name:
         raise SystemExit("Failed to read `user.name` from git config")
+    # The name is interpolated into a Lean block comment.
+    if "\n" in name or "/-" in name or "-/" in name:
+        raise SystemExit(f"Refusing to use {name!r} as an author")
+
     return name
 
 
@@ -286,7 +296,7 @@ def main(version: Version, refman: Path):
     github = util.get_github_instance()
 
     repo = Repo(Path(__file__).parent.parent.parent)
-    author = get_author(repo)
+    author = get_author(Repo(refman))
     grepo = github.get_repo(repos.LEAN4.gh_full_name)
     release = grepo.get_release(version.tag)
     date = release.published_at.astimezone(datetime.timezone.utc)
@@ -351,7 +361,7 @@ def main(version: Version, refman: Path):
         lines.append("````")
 
     out = refman / util.get_release_notes_path_for(version)
-    out.write_text("\n".join(lines) + "\n")
+    out.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 class Args(Namespace):


### PR DESCRIPTION
This PR takes the author of a generated release notes file from `user.name` in git config rather than hardcoding a name, so whoever runs `release_notes.py` is credited.

The name is resolved by asking git in the reference manual checkout, so conditional includes and environment overrides apply as git applies them, and it is rejected if it is empty or would not survive being interpolated into a Lean block comment. The lookup happens before any GitHub queries, so a missing `user.name` fails immediately instead of part way through generation. The generated file is now written as UTF-8 explicitly.

🤖 Prepared with Claude Code