### PR TITLE
refactor: move `PredTrans` combinators into the `PredTrans` namespace

### DIFF
--- a/src/Std/Internal/Order/PredTrans.lean
+++ b/src/Std/Internal/Order/PredTrans.lean
@@ -87,12 +87,10 @@ def bind (x : PredTrans Pred EPred α) (f : α → PredTrans Pred EPred β) :
     PredTrans Pred EPred β :=
   ⟨fun post epost => x.apply (fun a => (f a).apply post epost) epost⟩
 
-/-- `Monad` instance for `PredTrans`, via `PredTrans.pure` and `PredTrans.bind`. -/
 instance instMonad : Monad (PredTrans Pred EPred) where
   pure := pure
   bind := bind
 
-/-- `PredTrans` is a lawful monad: all monad laws hold definitionally. -/
 instance instLawfulMonad : LawfulMonad (PredTrans Pred EPred) where
   map_const := funext fun _ => funext fun _ => ext fun _ _ => rfl
   id_map _ := ext fun _ _ => rfl
@@ -206,7 +204,6 @@ theorem apply_liftArg {σ : Type z} (x : PredTrans Pred EPred α)
     (liftArg x : PredTrans (σ → Pred) EPred α).apply post epost s
       = x.apply (fun a => post a s) epost := rfl
 
-/-- Lift a predicate transformer to one with a state argument, via `PredTrans.liftArg`. -/
 instance {σ : Type z} : MonadLift (PredTrans Pred EPred) (PredTrans (σ → Pred) EPred) where
   monadLift := liftArg
 
@@ -312,8 +309,6 @@ def tryCatch {ε : Type z} (x : PredTrans Pred ((ε → Pred) × EPred) α)
     PredTrans Pred ((ε → Pred) × EPred) α :=
   ⟨fun post epost => x.apply post ((fun e => (handle e).apply post epost), epost.snd)⟩
 
-/-- `MonadExceptOf` instance for the outermost exception layer, via `PredTrans.throw` and
-`PredTrans.tryCatch`. -/
 instance {ε : Type z} : MonadExceptOf ε (PredTrans Pred ((ε → Pred) × EPred)) where
   throw := throw
   tryCatch := tryCatch
@@ -355,8 +350,6 @@ theorem apply_popExcept {eh : Type z} (x : PredTrans Pred (eh × EPred) α) (h :
     (post : α → Pred) (epost : EPred) :
     (x.popExcept h).apply post epost = x.apply post (h, epost) := rfl
 
-/-- `MonadExceptOf` instance lifted through an unrelated exception layer: `throw` and `tryCatch`
-delegate to the inner instance via `PredTrans.liftExcept` and `PredTrans.popExcept`. -/
 instance {ε : Type u} {Pred : Type v} {EPred : Type w} {ε' : Type u}
     [MonadExceptOf ε (PredTrans Pred EPred)] :
     MonadExceptOf ε (PredTrans Pred ((ε' → Pred) × EPred)) where
@@ -384,13 +377,11 @@ computed by `f`. -/
 def modifyGet {σ α : Type z} (f : σ → α × σ) : PredTrans (σ → Pred) EPred α :=
   ⟨fun post _epost s => post (f s).1 (f s).2⟩
 
-/-- `MonadStateOf` instance, via `PredTrans.get`, `PredTrans.set` and `PredTrans.modifyGet`. -/
 instance {σ : Type z} : MonadStateOf σ (PredTrans (σ → Pred) EPred) where
   get := get
   set := set
   modifyGet := modifyGet
 
-/-- `MonadReaderOf` instance: `read` behaves like `PredTrans.get`. -/
 instance {σ : Type z} : MonadReaderOf σ (PredTrans (σ → Pred) EPred) where
   read := get
 
@@ -415,8 +406,6 @@ instance {σ : Type z} : MonadReaderOf σ (PredTrans (σ → Pred) EPred) where
     (post : σ → σ → Pred) (epost : EPred) (s : σ) :
     (MonadReaderOf.read : PredTrans (σ → Pred) EPred σ).apply post epost s = post s s := rfl
 
-/-- `MonadExceptOf` instance lifted through a state layer: `throw` and `tryCatch` delegate to
-the inner instance via `PredTrans.liftArg`, `PredTrans.popArg` and `PredTrans.pushArg`. -/
 instance {ε : Type u'} {σ : Type z} [MonadExceptOf ε (PredTrans Pred EPred)] :
     MonadExceptOf ε (PredTrans (σ → Pred) EPred) where
   throw e := liftArg (MonadExceptOf.throw (m := PredTrans Pred EPred) e)

--- a/src/Std/Internal/Order/PredTrans.lean
+++ b/src/Std/Internal/Order/PredTrans.lean
@@ -22,7 +22,8 @@ pointwise ones of the function space.
 
 `PredTrans Pred EPred` is a monad, so monadic programs can be interpreted by a monad morphism into
 it. This module provides that monad structure, the `apply` simp framework of the monadic
-combinators, and the `push` family that moves a result type into a postcondition.
+combinators, the `push` family that moves a result type into a postcondition, and the standard
+monad class instances.
 -/
 
 namespace Lean.Order
@@ -35,10 +36,12 @@ structure PredTrans (Pred : Type u) (EPred : Type v) (α : Type w) where
   /-- Apply the predicate transformer to a postcondition and exception postcondition. -/
   apply : (α → Pred) → EPred → Pred
 
-variable {Pred : Type u} {EPred : Type v} {α : Type w}
+namespace PredTrans
+
+variable {Pred : Type u} {EPred : Type v} {α β : Type w}
 
 /-- Extensionality for predicate transformers. -/
-@[ext] theorem PredTrans.ext {x y : PredTrans Pred EPred α}
+@[ext] theorem ext {x y : PredTrans Pred EPred α}
     (h : ∀ post epost, x.apply post epost = y.apply post epost) : x = y := by
   cases x; cases y; congr; funext post epost; exact h post epost
 
@@ -47,7 +50,7 @@ instance [PartialOrder Pred] : PartialOrder (PredTrans Pred EPred α) where
   rel x y := x.apply ⊑ y.apply
   rel_refl := PartialOrder.rel_refl
   rel_trans h1 h2 := PartialOrder.rel_trans h1 h2
-  rel_antisymm h1 h2 := PredTrans.ext fun post epost =>
+  rel_antisymm h1 h2 := ext fun post epost =>
     PartialOrder.rel_antisymm (h1 post epost) (h2 post epost)
 
 /-- Chain-complete partial order on predicate transformers, for fixed-point reasoning. -/
@@ -68,26 +71,38 @@ instance [CCPO Pred] : CCPO (PredTrans Pred EPred α) where
 
 /-- Monotonicity property for a predicate transformer: if both `post` and `epost` grow,
 then the resulting precondition grows. -/
-def PredTrans.monotone [PartialOrder Pred] [PartialOrder EPred] (pt : PredTrans Pred EPred α) :=
+def monotone [PartialOrder Pred] [PartialOrder EPred] (pt : PredTrans Pred EPred α) :=
   ∀ post post' epost epost', epost ⊑ epost' → post ⊑ post' → pt.apply post epost ⊑ pt.apply post' epost'
 
-/-- `Monad` instance for `PredTrans`: `pure` returns the postcondition applied to the value,
-and `bind` threads the postcondition through the continuation. -/
-instance instMonadPredTrans (Pred : Type u) (EPred : Type v) : Monad (PredTrans Pred EPred) where
-  pure x := ⟨fun post _epost => post x⟩
-  bind x f := ⟨fun post epost => x.apply (fun a => (f a).apply post epost) epost⟩
+/-!
+## Monad Structure
+-/
+
+/-- `pure a` applies the postcondition to `a`. -/
+def pure (a : α) : PredTrans Pred EPred α :=
+  ⟨fun post _epost => post a⟩
+
+/-- `bind x f` threads the postcondition through the continuation `f`. -/
+def bind (x : PredTrans Pred EPred α) (f : α → PredTrans Pred EPred β) :
+    PredTrans Pred EPred β :=
+  ⟨fun post epost => x.apply (fun a => (f a).apply post epost) epost⟩
+
+/-- `Monad` instance for `PredTrans`, via `PredTrans.pure` and `PredTrans.bind`. -/
+instance instMonad : Monad (PredTrans Pred EPred) where
+  pure := pure
+  bind := bind
 
 /-- `PredTrans` is a lawful monad: all monad laws hold definitionally. -/
-instance instLawfulMonadPredTrans (Pred : Type u) (EPred : Type v) : LawfulMonad (PredTrans Pred EPred) where
-  map_const := funext fun _ => funext fun _ => PredTrans.ext fun _ _ => rfl
-  id_map _ := PredTrans.ext fun _ _ => rfl
-  seqLeft_eq _ _ := PredTrans.ext fun _ _ => rfl
-  seqRight_eq _ _ := PredTrans.ext fun _ _ => rfl
-  pure_seq _ _ := PredTrans.ext fun _ _ => rfl
-  bind_pure_comp _ _ := PredTrans.ext fun _ _ => rfl
-  bind_map _ _ := PredTrans.ext fun _ _ => rfl
-  pure_bind _ _ := PredTrans.ext fun _ _ => rfl
-  bind_assoc _ _ _ := PredTrans.ext fun _ _ => rfl
+instance instLawfulMonad : LawfulMonad (PredTrans Pred EPred) where
+  map_const := funext fun _ => funext fun _ => ext fun _ _ => rfl
+  id_map _ := ext fun _ _ => rfl
+  seqLeft_eq _ _ := ext fun _ _ => rfl
+  seqRight_eq _ _ := ext fun _ _ => rfl
+  pure_seq _ _ := ext fun _ _ => rfl
+  bind_pure_comp _ _ := ext fun _ _ => rfl
+  bind_map _ _ := ext fun _ _ => rfl
+  pure_bind _ _ := ext fun _ _ => rfl
+  bind_assoc _ _ _ := ext fun _ _ => rfl
 
 /-!
 ## `apply_*` simp framework
@@ -95,37 +110,44 @@ instance instLawfulMonadPredTrans (Pred : Type u) (EPred : Type v) : LawfulMonad
 Simp lemmas for reducing `(expr).apply post epost` for each monadic combinator.
 -/
 
+/-- Unfolding `PredTrans.pure` through `apply`. -/
+@[simp, grind =]
+theorem apply_pure (a : α) (post : α → Pred) (epost : EPred) :
+    (PredTrans.pure a : PredTrans Pred EPred α).apply post epost = post a := rfl
+
 /-- Unfolding `pure` through `apply`. -/
 @[simp, grind =]
-theorem PredTrans.apply_pure {Pred : Type u} {EPred : Type v}
-    (a : α) (post : α → Pred) (epost : EPred) :
-    (pure a : PredTrans Pred EPred α).apply post epost = post a := rfl
+theorem apply_Pure_pure (a : α) (post : α → Pred) (epost : EPred) :
+    (Pure.pure a : PredTrans Pred EPred α).apply post epost = post a := rfl
+
+/-- Unfolding `PredTrans.bind` through `apply`. -/
+@[simp, grind =]
+theorem apply_bind (x : PredTrans Pred EPred α) (f : α → PredTrans Pred EPred β)
+    (post : β → Pred) (epost : EPred) :
+    (x.bind f).apply post epost = x.apply (fun a => (f a).apply post epost) epost := rfl
 
 /-- Unfolding `>>=` through `apply`. -/
 @[simp, grind =]
-theorem PredTrans.apply_bind {Pred : Type u} {EPred : Type v}
-    (x : PredTrans Pred EPred α) (f : α → PredTrans Pred EPred β)
+theorem apply_Bind_bind (x : PredTrans Pred EPred α) (f : α → PredTrans Pred EPred β)
     (post : β → Pred) (epost : EPred) :
     (x >>= f).apply post epost = x.apply (fun a => (f a).apply post epost) epost := rfl
 
 /-- Unfolding `<$>` through `apply`. -/
 @[simp, grind =]
-theorem PredTrans.apply_map {Pred : Type u} {EPred : Type v} {α : Type w}
-    (trans : PredTrans Pred EPred α) (f : α → β) (post : β → Pred) (epost : EPred) :
-    (f <$> trans).apply post epost = trans.apply (post ∘ f) epost := rfl
+theorem apply_Functor_map (f : α → β) (x : PredTrans Pred EPred α)
+    (post : β → Pred) (epost : EPred) :
+    (f <$> x).apply post epost = x.apply (post ∘ f) epost := rfl
 
 /-- Unfolding `<*>` through `apply`. -/
 @[simp]
-theorem PredTrans.apply_seq {Pred : Type u} {EPred : Type v}
-    (f : PredTrans Pred EPred (α → β)) (x : PredTrans Pred EPred α)
+theorem apply_Seq_seq (f : PredTrans Pred EPred (α → β)) (x : PredTrans Pred EPred α)
     (post : β → Pred) (epost : EPred) :
     (f <*> x).apply post epost =
       f.apply (fun g => x.apply (fun a => post (g a)) epost) epost := rfl
 
 /-- Unfolding `dite` through `apply`. -/
 @[simp]
-theorem PredTrans.apply_dite {Pred : Type u} {EPred : Type v}
-    (c : Prop) [Decidable c]
+theorem apply_dite (c : Prop) [Decidable c]
     (t : c → PredTrans Pred EPred α) (e : ¬ c → PredTrans Pred EPred α)
     (post : α → Pred) (epost : EPred) :
     (if h : c then t h else e h).apply post epost =
@@ -134,8 +156,7 @@ theorem PredTrans.apply_dite {Pred : Type u} {EPred : Type v}
 
 /-- Unfolding `ite` through `apply`. -/
 @[simp]
-theorem PredTrans.apply_ite {Pred : Type u} {EPred : Type v}
-    (c : Prop) [Decidable c]
+theorem apply_ite (c : Prop) [Decidable c]
     (t : PredTrans Pred EPred α) (e : PredTrans Pred EPred α)
     (post : α → Pred) (epost : EPred) :
     (if c then t else e).apply post epost =
@@ -143,24 +164,66 @@ theorem PredTrans.apply_ite {Pred : Type u} {EPred : Type v}
   split <;> rfl
 
 /-!
-## Arguments and Results
+## Arguments
 
-Definitions for transformer arguments and results.
+Combinators that add or remove a state argument.
 -/
 
 /-- Adds a state argument to a predicate transformer.
 
-Given a state-dependent transformer `σ → PredTrans l e (α × σ)`, produces a transformer
-over `σ → l` that threads the state through postconditions. -/
-def pushArg {σ : Type u} {Pred : Type v} {EPred : Type w} {α : Type z}
-    (x : σ → PredTrans Pred EPred (α × σ)) : PredTrans (σ → Pred) EPred α :=
+Given a state-dependent transformer `σ → PredTrans Pred EPred (α × σ)`, produces a transformer
+over `σ → Pred` that threads the state through postconditions. -/
+def pushArg {σ : Type z} (x : σ → PredTrans Pred EPred (α × σ)) :
+    PredTrans (σ → Pred) EPred α :=
   ⟨fun post epost s => (x s).apply (fun (a, s) => post a s) epost⟩
 
 /-- Unfolding lemma for `pushArg`: applies the state-threaded transformer at state `s`. -/
 @[simp, grind =]
-theorem PredTrans.apply_pushArg {σ : Type u} {Pred : Type v} {EPred : Type w} {α : Type z}
-    (x : σ → PredTrans Pred EPred (α × σ)) (post : α → σ → Pred) (epost : EPred) (s : σ) :
+theorem apply_pushArg {σ : Type z} (x : σ → PredTrans Pred EPred (α × σ))
+    (post : α → σ → Pred) (epost : EPred) (s : σ) :
     (pushArg x).apply post epost s = (x s).apply (fun (a, s) => post a s) epost := rfl
+
+/-- Removes the state argument of a predicate transformer by applying it at state `s`.
+The transformed result carries the final state. -/
+def popArg {σ : Type z} (x : PredTrans (σ → Pred) EPred α) (s : σ) :
+    PredTrans Pred EPred (α × σ) :=
+  ⟨fun post epost => x.apply (fun a s => post (a, s)) epost s⟩
+
+/-- Unfolding `popArg` through `apply`. -/
+@[simp, grind =]
+theorem apply_popArg {σ : Type z} (x : PredTrans (σ → Pred) EPred α) (s : σ)
+    (post : α × σ → Pred) (epost : EPred) :
+    (x.popArg s).apply post epost = x.apply (fun a s => post (a, s)) epost s := rfl
+
+/-- Adds a state argument that the predicate transformer ignores. -/
+def liftArg {σ : Type z} (x : PredTrans Pred EPred α) : PredTrans (σ → Pred) EPred α :=
+  ⟨fun post epost s => x.apply (fun a => post a s) epost⟩
+
+/-- Unfolding `liftArg` through `apply`. -/
+@[simp, grind =]
+theorem apply_liftArg {σ : Type z} (x : PredTrans Pred EPred α)
+    (post : α → σ → Pred) (epost : EPred) (s : σ) :
+    (liftArg x : PredTrans (σ → Pred) EPred α).apply post epost s
+      = x.apply (fun a => post a s) epost := rfl
+
+/-- Lift a predicate transformer to one with a state argument, via `PredTrans.liftArg`. -/
+instance {σ : Type z} : MonadLift (PredTrans Pred EPred) (PredTrans (σ → Pred) EPred) where
+  monadLift := liftArg
+
+/-- Unfolding `monadLift` through `apply`. -/
+@[simp, grind =]
+theorem apply_monadLift {σ : Type z} (x : PredTrans Pred EPred α)
+    (post : α → σ → Pred) (epost : EPred) (s : σ) :
+    (MonadLift.monadLift x : PredTrans (σ → Pred) EPred α).apply post epost s
+      = x.apply (fun a => post a s) epost := rfl
+
+end PredTrans
+
+/-!
+## Results
+
+Postconditions for `Except` and `Option` results, and the transformer combinators built on them.
+-/
 
 /-- The postcondition for an `Except ε α` result: `ok a` uses `post a`, and `error e` uses
 `epost e`. -/
@@ -196,95 +259,171 @@ def pushOption {α : Type u} {Pred : Type w}
     (post : α → Pred) (epost : Unit → Pred) :
     pushOption post epost .none = epost () := rfl
 
+namespace PredTrans
+
+variable {Pred : Type u} {EPred : Type v} {α β : Type w}
+
 /-- Adds an exception postcondition layer to a predicate transformer, mirroring `ExceptT`.
 
 Given a transformer over `Except ε α`, produces one over `α` with an additional exception
 postcondition for `ε`. The normal and error postconditions are combined via `pushExcept`. -/
-def PredTrans.pushExceptT {α : Type u} {ε : Type v} {Pred : Type w} {EPred : Type z}
-    (x : PredTrans Pred EPred (Except ε α)) : PredTrans Pred ((ε → Pred) × EPred) α :=
+def pushExceptT {ε : Type z} (x : PredTrans Pred EPred (Except ε α)) :
+    PredTrans Pred ((ε → Pred) × EPred) α :=
   ⟨fun post epost => x.apply (pushExcept post epost.fst) epost.snd⟩
 
 /-- Unfolding lemma for `pushExceptT`. -/
 @[simp, grind =]
-theorem PredTrans.apply_pushExceptT {α ε Pred EPred}
+theorem apply_pushExceptT {ε : Type z}
     (x : PredTrans Pred EPred (Except ε α)) (post : α → Pred)
     (epost : (ε → Pred) × EPred) :
-    (PredTrans.pushExceptT x).apply post epost
+    (pushExceptT x).apply post epost
       = x.apply (pushExcept post epost.fst) epost.snd := rfl
 
 /-- Adds an early-termination layer to a predicate transformer, mirroring `OptionT`.
 
 Given a transformer over `Option α`, produces one over `α` with an additional exception
 postcondition for the `none` case. -/
-def PredTrans.pushOptionT {α : Type u} {Pred : Type u} {EPred : Type v}
-    (x : PredTrans Pred EPred (Option α)) : PredTrans Pred ((Unit → Pred) × EPred) α :=
+def pushOptionT (x : PredTrans Pred EPred (Option α)) :
+    PredTrans Pred ((Unit → Pred) × EPred) α :=
   ⟨fun post epost => x.apply (pushOption post epost.fst) epost.snd⟩
 
 /-- Unfolding lemma for `pushOptionT`. -/
 @[simp, grind =]
-theorem PredTrans.apply_pushOptionT {α : Type u} {Pred : Type u} {EPred : Type v}
-    (x : PredTrans Pred EPred (Option α)) (post : α → Pred)
+theorem apply_pushOptionT (x : PredTrans Pred EPred (Option α)) (post : α → Pred)
     (epost : (Unit → Pred) × EPred) :
-    (PredTrans.pushOptionT x).apply post epost
+    (pushOptionT x).apply post epost
       = x.apply (pushOption post epost.fst) epost.snd := rfl
 
-/-- Lift a predicate transformer to one with a state argument (pointwise). -/
-instance {σ : Type u} {Pred : Type v} {EPred : Type w} :
-    MonadLift (PredTrans Pred EPred) (PredTrans (σ → Pred) EPred) where
-  monadLift x := ⟨fun post epost s => x.apply (fun a => post a s) epost⟩
-
 /-!
-## Monad Instances
+## Exception Instances
 
-Standard monad class instances for `PredTrans`.
+`throw` and `tryCatch` on the first exception postcondition, and the combinators that lift the
+`MonadExceptOf` instance through further layers.
 -/
 
-/-- `MonadStateOf` instance: `get` returns the state, `set` replaces it,
-`modifyGet` applies a function to the state. -/
-instance {σ : Type u} {Pred : Type v} {EPred : Type w} :
-    MonadStateOf σ (PredTrans (σ → Pred) EPred) where
-  get := ⟨fun post _epost => fun s => post s s⟩
-  set s := ⟨fun post _epost => fun _ => post ⟨⟩ s⟩
-  modifyGet f := ⟨fun post _epost => fun s => post (f s).1 (f s).2⟩
+/-- `throw e` asserts the first exception postcondition at `e`. -/
+def throw {ε : Type z} (e : ε) : PredTrans Pred ((ε → Pred) × EPred) α :=
+  ⟨fun _post epost => epost.fst e⟩
 
-/-- `MonadReaderOf` instance: `read` provides the state without consuming it. -/
-instance {σ : Type u} {Pred : Type v} {EPred : Type w} :
-    MonadReaderOf σ (PredTrans (σ → Pred) EPred) where
-  read := ⟨fun post _epost => fun s => post s s⟩
+/-- `tryCatch x handle` replaces the first exception postcondition of `x` with the precondition
+of the handler. -/
+def tryCatch {ε : Type z} (x : PredTrans Pred ((ε → Pred) × EPred) α)
+    (handle : ε → PredTrans Pred ((ε → Pred) × EPred) α) :
+    PredTrans Pred ((ε → Pred) × EPred) α :=
+  ⟨fun post epost => x.apply post ((fun e => (handle e).apply post epost), epost.snd)⟩
+
+/-- `MonadExceptOf` instance for the outermost exception layer, via `PredTrans.throw` and
+`PredTrans.tryCatch`. -/
+instance {ε : Type z} : MonadExceptOf ε (PredTrans Pred ((ε → Pred) × EPred)) where
+  throw := throw
+  tryCatch := tryCatch
+
+/-- Unfolding `throw` through `apply`: the first exception postcondition at the thrown value. -/
+@[simp, grind =] theorem apply_throw {ε : Type u} {α : Type u} {Pred : Type u}
+    {EPred : Type w} (e : ε) (post : α → Pred) (epost : (ε → Pred) × EPred) :
+    (MonadExceptOf.throw e : PredTrans Pred ((ε → Pred) × EPred) α).apply post epost
+      = epost.fst e := rfl
+
+/-- Unfolding `tryCatch` through `apply`: the handler replaces the first exception
+postcondition. -/
+@[simp, grind =] theorem apply_tryCatch {ε : Type u} {α : Type u} {Pred : Type u}
+    {EPred : Type w} (x : PredTrans Pred ((ε → Pred) × EPred) α)
+    (handle : ε → PredTrans Pred ((ε → Pred) × EPred) α)
+    (post : α → Pred) (epost : (ε → Pred) × EPred) :
+    (MonadExceptOf.tryCatch x handle).apply post epost
+      = x.apply post ((fun e => (handle e).apply post epost), epost.snd) := rfl
+
+/-- Adds a first exception postcondition that the predicate transformer ignores. -/
+def liftExcept {eh : Type z} (x : PredTrans Pred EPred α) : PredTrans Pred (eh × EPred) α :=
+  ⟨fun post epost => x.apply post epost.snd⟩
+
+/-- Unfolding `liftExcept` through `apply`. -/
+@[simp, grind =]
+theorem apply_liftExcept {eh : Type z} (x : PredTrans Pred EPred α) (post : α → Pred)
+    (epost : eh × EPred) :
+    (liftExcept x : PredTrans Pred (eh × EPred) α).apply post epost
+      = x.apply post epost.snd := rfl
+
+/-- Removes the first exception postcondition of a predicate transformer by fixing it to `h`. -/
+def popExcept {eh : Type z} (x : PredTrans Pred (eh × EPred) α) (h : eh) :
+    PredTrans Pred EPred α :=
+  ⟨fun post epost => x.apply post (h, epost)⟩
+
+/-- Unfolding `popExcept` through `apply`. -/
+@[simp, grind =]
+theorem apply_popExcept {eh : Type z} (x : PredTrans Pred (eh × EPred) α) (h : eh)
+    (post : α → Pred) (epost : EPred) :
+    (x.popExcept h).apply post epost = x.apply post (h, epost) := rfl
+
+/-- `MonadExceptOf` instance lifted through an unrelated exception layer: `throw` and `tryCatch`
+delegate to the inner instance via `PredTrans.liftExcept` and `PredTrans.popExcept`. -/
+instance {ε : Type u} {Pred : Type v} {EPred : Type w} {ε' : Type u}
+    [MonadExceptOf ε (PredTrans Pred EPred)] :
+    MonadExceptOf ε (PredTrans Pred ((ε' → Pred) × EPred)) where
+  throw e := liftExcept (MonadExceptOf.throw (m := PredTrans Pred EPred) e)
+  tryCatch x handle := ⟨fun post epost =>
+    (MonadExceptOf.tryCatch (m := PredTrans Pred EPred) (x.popExcept epost.fst)
+      fun e => (handle e).popExcept epost.fst).apply post epost.snd⟩
+
+/-!
+## State Instances
+
+Standard state and reader class instances for `PredTrans`.
+-/
+
+/-- `get` transforms the postcondition into its assertion at the current state. -/
+def get {σ : Type z} : PredTrans (σ → Pred) EPred σ :=
+  ⟨fun post _epost s => post s s⟩
+
+/-- `set s'` transforms the postcondition into its assertion at the state `s'`. -/
+def set {σ : Type z} (s' : σ) : PredTrans (σ → Pred) EPred PUnit :=
+  ⟨fun post _epost _s => post ⟨⟩ s'⟩
+
+/-- `modifyGet f` transforms the postcondition into its assertion at the result and state
+computed by `f`. -/
+def modifyGet {σ α : Type z} (f : σ → α × σ) : PredTrans (σ → Pred) EPred α :=
+  ⟨fun post _epost s => post (f s).1 (f s).2⟩
+
+/-- `MonadStateOf` instance, via `PredTrans.get`, `PredTrans.set` and `PredTrans.modifyGet`. -/
+instance {σ : Type z} : MonadStateOf σ (PredTrans (σ → Pred) EPred) where
+  get := get
+  set := set
+  modifyGet := modifyGet
+
+/-- `MonadReaderOf` instance: `read` behaves like `PredTrans.get`. -/
+instance {σ : Type z} : MonadReaderOf σ (PredTrans (σ → Pred) EPred) where
+  read := get
 
 /-- Unfolding `get` through `apply`. -/
-@[simp, grind =] theorem PredTrans.apply_get {σ : Type u} {Pred : Type v} {EPred : Type w}
+@[simp, grind =] theorem apply_get {σ : Type z}
     (post : σ → σ → Pred) (epost : EPred) (s : σ) :
     (MonadStateOf.get : PredTrans (σ → Pred) EPred σ).apply post epost s = post s s := rfl
 
 /-- Unfolding `set` through `apply`. -/
-@[simp, grind =] theorem PredTrans.apply_set {σ : Type u} {Pred : Type v} {EPred : Type w}
+@[simp, grind =] theorem apply_set {σ : Type z}
     (s' : σ) (post : PUnit → σ → Pred) (epost : EPred) (s : σ) :
     (MonadStateOf.set s' : PredTrans (σ → Pred) EPred PUnit).apply post epost s = post ⟨⟩ s' := rfl
 
 /-- Unfolding `modifyGet` through `apply`. -/
-@[simp, grind =] theorem PredTrans.apply_modifyGet {σ : Type u} {α : Type u} {Pred : Type v}
-    {EPred : Type w} (f : σ → α × σ) (post : α → σ → Pred) (epost : EPred) (s : σ) :
+@[simp, grind =] theorem apply_modifyGet {σ α : Type z}
+    (f : σ → α × σ) (post : α → σ → Pred) (epost : EPred) (s : σ) :
     (MonadStateOf.modifyGet f : PredTrans (σ → Pred) EPred α).apply post epost s
       = post (f s).1 (f s).2 := rfl
 
 /-- Unfolding `read` through `apply`. -/
-@[simp, grind =] theorem PredTrans.apply_read {σ : Type u} {Pred : Type v} {EPred : Type w}
+@[simp, grind =] theorem apply_read {σ : Type z}
     (post : σ → σ → Pred) (epost : EPred) (s : σ) :
     (MonadReaderOf.read : PredTrans (σ → Pred) EPred σ).apply post epost s = post s s := rfl
 
-/-- `MonadExceptOf` instance lifted through a state layer:
-delegates `throw` and `tryCatch` to the inner `PredTrans l e` instance. -/
-instance {ε : Type u} {Pred : Type v} {EPred : Type w} {σ : Type z}
-    [MonadExceptOf ε (PredTrans Pred EPred)] :
+/-- `MonadExceptOf` instance lifted through a state layer: `throw` and `tryCatch` delegate to
+the inner instance via `PredTrans.liftArg`, `PredTrans.popArg` and `PredTrans.pushArg`. -/
+instance {ε : Type u'} {σ : Type z} [MonadExceptOf ε (PredTrans Pred EPred)] :
     MonadExceptOf ε (PredTrans (σ → Pred) EPred) where
-  throw {α} x := ⟨fun post epost s =>
-    (throw (m := PredTrans Pred EPred) (α := α) x).apply (post · s) epost⟩
-  tryCatch x handle := ⟨fun post epost s =>
-    (tryCatch (m := PredTrans Pred EPred)
-      (⟨fun post epost => x.apply (fun r s => post (r, s)) epost s⟩)
-      (fun e => ⟨fun post epost => (handle e).apply (fun r s => post (r, s)) epost s⟩)).apply
-      (fun rs => post rs.1 rs.2) epost⟩
+  throw e := liftArg (MonadExceptOf.throw (m := PredTrans Pred EPred) e)
+  tryCatch x handle := pushArg fun s =>
+    MonadExceptOf.tryCatch (m := PredTrans Pred EPred) (x.popArg s) fun e => (handle e).popArg s
+
+end PredTrans
 
 end Lean.Order
 

--- a/src/Std/WP/Monad/Instances.lean
+++ b/src/Std/WP/Monad/Instances.lean
@@ -18,8 +18,7 @@ open Lean.Order Std.WP
 /-!
 # WPMonad Instances
 
-The weakest precondition interpretation of the base monads and of the monad transformers, together
-with the `PredTrans` helpers that push a result type into an exception postcondition layer.
+The weakest precondition interpretation of the base monads and of the monad transformers.
 
 A monad that throws carries the exception postcondition itself. A transformer stacks a product
 layer on the exception postcondition of the monad below it, and `EStack⟨⟩` closes the stack.
@@ -50,39 +49,6 @@ instance Id.instWPMonad : WPMonad Id.{u} Prop EStack⟨⟩ where
   toWP _ := Id.wpInst
   pure_le_wp_pure _ _ _ := PartialOrder.rel_refl
   bind_le_wp_bind _ _ _ _ := PartialOrder.rel_refl
-
-/-- `MonadExceptOf` instance for the outermost exception layer:
-`throw` invokes the head exception postcondition, `tryCatch` intercepts it. -/
-instance {ε : Type u} {Pred : Type v} {EPred : Type w} :
-    MonadExceptOf ε (PredTrans Pred ((ε → Pred) × EPred)) where
-  throw e := ⟨fun _post epost => epost.fst e⟩
-  tryCatch x handle := ⟨fun post epost => x.apply post ((fun e => (handle e).apply post epost), epost.snd)⟩
-
-/-- Unfolding `throw` through `apply`: the head exception postcondition at the thrown value. -/
-@[simp, grind =] theorem PredTrans.apply_throw {ε : Type u} {α : Type u} {Pred : Type u}
-    {EPred : Type w} (e : ε) (post : α → Pred) (epost : (ε → Pred) × EPred) :
-    (MonadExceptOf.throw e : PredTrans Pred ((ε → Pred) × EPred) α).apply post epost
-      = epost.fst e := rfl
-
-/-- Unfolding `tryCatch` through `apply`: the handler replaces the head exception postcondition. -/
-@[simp, grind =] theorem PredTrans.apply_tryCatch {ε : Type u} {α : Type u} {Pred : Type u}
-    {EPred : Type w} (x : PredTrans Pred ((ε → Pred) × EPred) α)
-    (handle : ε → PredTrans Pred ((ε → Pred) × EPred) α)
-    (post : α → Pred) (epost : (ε → Pred) × EPred) :
-    (MonadExceptOf.tryCatch x handle).apply post epost
-      = x.apply post ((fun e => (handle e).apply post epost), epost.snd) := rfl
-
-/-- `MonadExceptOf` instance lifted through an unrelated exception layer:
-delegates to the inner instance, threading the extra exception postcondition. -/
-instance {ε : Type u} {Pred : Type v} {EPred : Type w} {ε' : Type u}
-    [MonadExceptOf ε (PredTrans Pred EPred)] :
-    MonadExceptOf ε (PredTrans Pred ((ε' → Pred) × EPred)) where
-  throw x := ⟨fun post epost => (throw (m := PredTrans Pred EPred) x).apply post epost.snd⟩
-  tryCatch x handle := ⟨fun post epost =>
-    (tryCatch (m := PredTrans Pred EPred)
-      (⟨fun post' epost' => x.apply post' (epost.fst, epost')⟩)
-      (fun e => ⟨fun post' epost' => (handle e).apply post' (epost.fst, epost')⟩)).apply
-      post epost.snd⟩
 
 /-- `ExceptT`'s `WP` interpretation: lift the base interpretation by adding an exception
 postcondition layer. -/
@@ -163,7 +129,7 @@ theorem OptionT.wp_apply_eq {α : Type u} {Pred : Type u} {EPred}
 @[instance_reducible] def StateT.wpInst {EPred : Type v} {σ : Type u} {Pred : Type w}
   [Assertion Pred] [Assertion EPred] [WP (m (α × σ)) (α × σ) Pred EPred] :
     WP (StateT σ m α) α (σ → Pred) EPred where
-  wpTrans x := pushArg (WP.wpTrans <| x.run ·)
+  wpTrans x := PredTrans.pushArg (WP.wpTrans <| x.run ·)
   wp_trans_monotone x := fun post post' epost epost' hepost hpost s => by
     apply WP.wp_consequence_econs (x := x.run s)
     · intro ⟨a, s'⟩


### PR DESCRIPTION
This PR moves every `PredTrans` combinator into the `Lean.Order.PredTrans` namespace and gives each type class operation of `PredTrans` its own definition.