### PR TITLE
feat: add a `leanchecker-paranoid` binary with mimalloc mitigations

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -273,6 +273,11 @@ jobs:
           mv build/stage1.bak build/stage1
           cd src
           ../build/stage0/bin/lake cache clean
+      # Not part of the default targets because it is big
+      - name: Build leanchecker-paranoid
+        if: matrix.release && !matrix.wasm
+        run: |
+          make -C build/$TARGET_STAGE leanchecker-paranoid -j$NPROC
       - name: Install
         run: |
           make -C build/$TARGET_STAGE install

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -812,6 +812,9 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
   string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,--whole-archive -lleanmanifest -Wl,--no-whole-archive")
 endif()
 
+# for later stages, this defines only `mimalloc_paranoid`; the rest is imported below instead
+add_subdirectory(runtime)
+
 if(STAGE GREATER 1)
   # reuse C++ parts, which don't change
   add_library(leanrt_initial-exec STATIC IMPORTED)
@@ -847,7 +850,6 @@ if(STAGE GREATER 1)
     add_dependencies(leancpp copy-lean-h-bc)
   endif()
 else()
-  add_subdirectory(runtime)
   if(CMAKE_SYSTEM_NAME MATCHES "Emscripten")
     add_dependencies(leanrt libuv)
     add_dependencies(leanrt_initial-exec libuv)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -637,8 +637,7 @@ endif()
 
 if(NOT CMAKE_SYSTEM_NAME MATCHES "Windows" AND NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten")
   # export symbols for the interpreter (done via `LEAN_EXPORT` for Windows)
-  string(APPEND LEAN_DYN_EXE_LINKER_FLAGS " -rdynamic")
-  string(APPEND CMAKE_EXE_LINKER_FLAGS " -rdynamic")
+  string(APPEND CMAKE_DYN_EXE_LINKER_FLAGS " -rdynamic")
   # hide all other symbols
   string(APPEND CMAKE_CXX_FLAGS " -fvisibility=hidden -fvisibility-inlines-hidden")
   string(APPEND LEANC_EXTRA_CC_FLAGS " -fvisibility=hidden")
@@ -989,7 +988,14 @@ else()
     VERBATIM
   )
 
-  string(APPEND CMAKE_EXE_LINKER_FLAGS " -lInit_shared -lleanshared_2 -lleanshared_1 -lleanshared")
+  string(APPEND CMAKE_DYN_EXE_LINKER_FLAGS " -lInit_shared -lleanshared_2 -lleanshared_1 -lleanshared")
+
+  # NOTE: `mimalloc_paranoid` in front of `leanrt` and no `leanshared` to replace default allocator
+  set(
+    LEANCHECKER_PARANOID_LINKER_FLAGS
+    "${CMAKE_EXE_LINKER_FLAGS} -lmimalloc_paranoid ${LEANC_STATIC_LINKER_FLAGS}"
+  )
+
 endif()
 
 if(NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten")
@@ -1017,6 +1023,17 @@ if(NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten")
     COMMAND $(MAKE) -f ${CMAKE_BINARY_DIR}/stdlib.make leanchecker
     VERBATIM
   )
+
+  # Not `ALL` as it's big; release CI builds it explicitly.
+  if(USE_MIMALLOC)
+    add_custom_target(
+      leanchecker-paranoid
+      WORKING_DIRECTORY ${LEAN_SOURCE_DIR}
+      DEPENDS lake_shared mimalloc_paranoid
+      COMMAND $(MAKE) -f ${CMAKE_BINARY_DIR}/stdlib.make leanchecker-paranoid
+      VERBATIM
+    )
+  endif()
 endif()
 
 if(PREV_STAGE)
@@ -1151,6 +1168,14 @@ endif()
 
 # Escape for `make`. Yes, twice.
 string(REPLACE "$" "\\\$$" CMAKE_EXE_LINKER_FLAGS_MAKE "${CMAKE_EXE_LINKER_FLAGS}")
+string(REPLACE "$" "\\\$$" CMAKE_DYN_EXE_LINKER_FLAGS_MAKE "${CMAKE_DYN_EXE_LINKER_FLAGS}")
+string(
+  REPLACE
+  "$"
+  "\\\$$"
+  LEANCHECKER_PARANOID_LINKER_FLAGS_MAKE
+  "${LEANCHECKER_PARANOID_LINKER_FLAGS}"
+)
 configure_file(${LEAN_SOURCE_DIR}/stdlib.make.in ${CMAKE_BINARY_DIR}/stdlib.make)
 
 # hacky

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -1,3 +1,50 @@
+if(USE_MIMALLOC)
+  set(MIMALLOC_SRC ${LEAN_BINARY_DIR}/../mimalloc/src/mimalloc/src/static.c)
+  # (C flags are incomplete, compile as C++ instead like everything else). A source property rather
+  # than a target one, but it is the same for every variant below.
+  set_source_files_properties(${MIMALLOC_SRC} PROPERTIES LANGUAGE CXX)
+  # make all symbols visible, always build with optimizations as otherwise Lean becomes too slow
+  set(MIMALLOC_OPTS -DMI_SHARED_LIB -DMI_SHARED_LIB_EXPORT -O3 -DNDEBUG -DMI_WIN_NOREDIRECT -Wno-unused-function)
+  if(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang|Clang")
+    list(APPEND MIMALLOC_OPTS -Wno-deprecated)
+  endif()
+
+  # One target per (mitigation level, TLS model) the build needs, each carrying its own
+  # `target_compile_options`. The flags cannot live on the shared source instead: source properties
+  # are directory-scoped and CMake emits them *after* target options, so a target trying to override
+  # the mitigation level would silently lose to whatever the source property set.
+  function(add_mimalloc_variant name type secure)
+    add_library(${name} ${type} ${MIMALLOC_SRC})
+    # Lean code includes it as `lean/mimalloc.h`, but `static.c` itself wants the original directory
+    target_include_directories(${name} PRIVATE ${LEAN_BINARY_DIR}/../mimalloc/src/mimalloc/include)
+    target_compile_options(${name} PRIVATE ${MIMALLOC_OPTS} -DMI_SECURE=${secure} ${ARGN})
+  endfunction()
+
+  # `local-exec` matches the `leanrt` rationale below: those copies are only ever linked into an
+  # executable, never into `leanshared`.
+  set(MIMALLOC_LOCAL_EXEC_OPTS "")
+  if(NOT MSVC)
+    list(APPEND MIMALLOC_LOCAL_EXEC_OPTS -ftls-model=local-exec)
+  endif()
+
+  # Level 3 buys encoded free lists, which turn a stale reference-count operation on a freed object
+  # into a checked abort rather than silent heap corruption, and the padding it implies, which
+  # catches writes past an object. Level 4 adds only a double-free check that reports and continues.
+  # a real archive rather than an object library: the link rule refers to it as `-lmimalloc_paranoid`
+  add_mimalloc_variant(mimalloc_paranoid STATIC 3 ${MIMALLOC_LOCAL_EXEC_OPTS})
+  # only `leanchecker-paranoid` consumes it, and that target is not built by default
+  set_target_properties(
+    mimalloc_paranoid
+    PROPERTIES EXCLUDE_FROM_ALL TRUE ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
+  )
+endif()
+
+# Later stages import the previous stage's copies of everything below (see `src/CMakeLists.txt`).
+# `mimalloc_paranoid` is not among them, as the previous stage does not build it by default.
+if(STAGE GREATER 1)
+  return()
+endif()
+
 set(
   RUNTIME_OBJS
   debug.cpp
@@ -35,47 +82,6 @@ set(
   uv/signal.cpp
   openssl.cpp
 )
-if(USE_MIMALLOC)
-  set(MIMALLOC_SRC ${LEAN_BINARY_DIR}/../mimalloc/src/mimalloc/src/static.c)
-  # (C flags are incomplete, compile as C++ instead like everything else). A source property rather
-  # than a target one, but it is the same for every variant below.
-  set_source_files_properties(${MIMALLOC_SRC} PROPERTIES LANGUAGE CXX)
-  # make all symbols visible, always build with optimizations as otherwise Lean becomes too slow
-  set(MIMALLOC_OPTS -DMI_SHARED_LIB -DMI_SHARED_LIB_EXPORT -O3 -DNDEBUG -DMI_WIN_NOREDIRECT -Wno-unused-function)
-  if(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang|Clang")
-    list(APPEND MIMALLOC_OPTS -Wno-deprecated)
-  endif()
-
-  # One target per (mitigation level, TLS model) the build needs, each carrying its own
-  # `target_compile_options`. The flags cannot live on the shared source instead: source properties
-  # are directory-scoped and CMake emits them *after* target options, so a target trying to override
-  # the mitigation level would silently lose to whatever the source property set.
-  function(add_mimalloc_variant name type secure)
-    add_library(${name} ${type} ${MIMALLOC_SRC})
-    # Lean code includes it as `lean/mimalloc.h`, but `static.c` itself wants the original directory
-    target_include_directories(${name} PRIVATE ${LEAN_BINARY_DIR}/../mimalloc/src/mimalloc/include)
-    target_compile_options(${name} PRIVATE ${MIMALLOC_OPTS} -DMI_SECURE=${secure} ${ARGN})
-  endfunction()
-
-  # `local-exec` matches the `leanrt` rationale below: those copies are only ever linked into an
-  # executable, never into `leanshared`.
-  set(MIMALLOC_LOCAL_EXEC_OPTS "")
-  if(NOT MSVC)
-    list(APPEND MIMALLOC_LOCAL_EXEC_OPTS -ftls-model=local-exec)
-  endif()
-  add_mimalloc_variant(mimalloc_initial-exec OBJECT ${LEAN_MI_SECURE})
-  add_mimalloc_variant(mimalloc_local-exec OBJECT ${LEAN_MI_SECURE} ${MIMALLOC_LOCAL_EXEC_OPTS})
-  # Level 3 buys encoded free lists, which turn a stale reference-count operation on a freed object
-  # into a checked abort rather than silent heap corruption, and the padding it implies, which
-  # catches writes past an object. Level 4 adds only a double-free check that reports and continues.
-  # a real archive rather than an object library: the link rule refers to it as `-lmimalloc_paranoid`
-  add_mimalloc_variant(mimalloc_paranoid STATIC 3 ${MIMALLOC_LOCAL_EXEC_OPTS})
-  # only `leanchecker-paranoid` consumes it, and that target is not built by default
-  set_target_properties(
-    mimalloc_paranoid
-    PROPERTIES EXCLUDE_FROM_ALL TRUE ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
-  )
-endif()
 
 add_library(leanrt_initial-exec STATIC ${RUNTIME_OBJS})
 set_target_properties(leanrt_initial-exec PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
@@ -90,6 +96,8 @@ if(NOT MSVC)
 endif()
 # adds each variant's object to the archive; its `PRIVATE` flags do not propagate to the rest
 if(USE_MIMALLOC)
+  add_mimalloc_variant(mimalloc_initial-exec OBJECT ${LEAN_MI_SECURE})
+  add_mimalloc_variant(mimalloc_local-exec OBJECT ${LEAN_MI_SECURE} ${MIMALLOC_LOCAL_EXEC_OPTS})
   target_link_libraries(leanrt_initial-exec PRIVATE mimalloc_initial-exec)
   target_link_libraries(leanrt PRIVATE mimalloc_local-exec)
 endif()

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -36,20 +36,44 @@ set(
   openssl.cpp
 )
 if(USE_MIMALLOC)
-  list(APPEND RUNTIME_OBJS ${LEAN_BINARY_DIR}/../mimalloc/src/mimalloc/src/static.c)
-  # Lean code includes it as `lean/mimalloc.h` but for compiling `static.c` itself, add original dir
-  include_directories(${LEAN_BINARY_DIR}/../mimalloc/src/mimalloc/include)
+  set(MIMALLOC_SRC ${LEAN_BINARY_DIR}/../mimalloc/src/mimalloc/src/static.c)
+  # (C flags are incomplete, compile as C++ instead like everything else). A source property rather
+  # than a target one, but it is the same for every variant below.
+  set_source_files_properties(${MIMALLOC_SRC} PROPERTIES LANGUAGE CXX)
   # make all symbols visible, always build with optimizations as otherwise Lean becomes too slow
-  set(MIMALLOC_FLAGS "-DMI_SHARED_LIB -DMI_SHARED_LIB_EXPORT -O3 -DNDEBUG -DMI_WIN_NOREDIRECT -DMI_SECURE=${LEAN_MI_SECURE} -Wno-unused-function")
+  set(MIMALLOC_OPTS -DMI_SHARED_LIB -DMI_SHARED_LIB_EXPORT -O3 -DNDEBUG -DMI_WIN_NOREDIRECT -Wno-unused-function)
   if(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang|Clang")
-    string(APPEND MIMALLOC_FLAGS " -Wno-deprecated")
+    list(APPEND MIMALLOC_OPTS -Wno-deprecated)
   endif()
-  set_source_files_properties(
-    ${LEAN_BINARY_DIR}/../mimalloc/src/mimalloc/src/static.c
-    PROPERTIES
-      # (C flags are incomplete, compile as C++ instead like everything else)
-      LANGUAGE CXX
-      COMPILE_FLAGS ${MIMALLOC_FLAGS}
+
+  # One target per (mitigation level, TLS model) the build needs, each carrying its own
+  # `target_compile_options`. The flags cannot live on the shared source instead: source properties
+  # are directory-scoped and CMake emits them *after* target options, so a target trying to override
+  # the mitigation level would silently lose to whatever the source property set.
+  function(add_mimalloc_variant name type secure)
+    add_library(${name} ${type} ${MIMALLOC_SRC})
+    # Lean code includes it as `lean/mimalloc.h`, but `static.c` itself wants the original directory
+    target_include_directories(${name} PRIVATE ${LEAN_BINARY_DIR}/../mimalloc/src/mimalloc/include)
+    target_compile_options(${name} PRIVATE ${MIMALLOC_OPTS} -DMI_SECURE=${secure} ${ARGN})
+  endfunction()
+
+  # `local-exec` matches the `leanrt` rationale below: those copies are only ever linked into an
+  # executable, never into `leanshared`.
+  set(MIMALLOC_LOCAL_EXEC_OPTS "")
+  if(NOT MSVC)
+    list(APPEND MIMALLOC_LOCAL_EXEC_OPTS -ftls-model=local-exec)
+  endif()
+  add_mimalloc_variant(mimalloc_initial-exec OBJECT ${LEAN_MI_SECURE})
+  add_mimalloc_variant(mimalloc_local-exec OBJECT ${LEAN_MI_SECURE} ${MIMALLOC_LOCAL_EXEC_OPTS})
+  # Level 3 buys encoded free lists, which turn a stale reference-count operation on a freed object
+  # into a checked abort rather than silent heap corruption, and the padding it implies, which
+  # catches writes past an object. Level 4 adds only a double-free check that reports and continues.
+  # a real archive rather than an object library: the link rule refers to it as `-lmimalloc_paranoid`
+  add_mimalloc_variant(mimalloc_paranoid STATIC 3 ${MIMALLOC_LOCAL_EXEC_OPTS})
+  # only `leanchecker-paranoid` consumes it, and that target is not built by default
+  set_target_properties(
+    mimalloc_paranoid
+    PROPERTIES EXCLUDE_FROM_ALL TRUE ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
   )
 endif()
 
@@ -63,6 +87,11 @@ add_library(leanrt STATIC ${RUNTIME_OBJS})
 set_target_properties(leanrt PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
 if(NOT MSVC)
   target_compile_options(leanrt PRIVATE -ftls-model=local-exec)
+endif()
+# adds each variant's object to the archive; its `PRIVATE` flags do not propagate to the rest
+if(USE_MIMALLOC)
+  target_link_libraries(leanrt_initial-exec PRIVATE mimalloc_initial-exec)
+  target_link_libraries(leanrt PRIVATE mimalloc_local-exec)
 endif()
 # We do not export Lean symbols when statically linking on Windows.
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")

--- a/src/stdlib.make.in
+++ b/src/stdlib.make.in
@@ -48,7 +48,7 @@ ifeq "${STAGE}" "0"
 endif
 
 # These can be phony since the inner Makefile/Lake will have the correct dependencies and avoid rebuilds
-.PHONY: Init Std Lean leanshared Lake libLake_shared lake lean LeanChecker leanchecker LeanIR
+.PHONY: Init Std Lean leanshared Lake libLake_shared lake lean LeanChecker leanchecker leanchecker-paranoid LeanIR
 
 ifeq "${USE_LAKE}" "ON"
 
@@ -104,6 +104,7 @@ $(OUTBIN)/lake$(EXE): ${LIB}/temp/LakeMain.c.o.export.trace
 $(OUTBIN)/leanc$(EXE): $(OUTARC)/libLeanc.a.trace
 $(OUTBIN)/leanir$(EXE): $(OUTARC)/libLeanIR.a.trace
 $(OUTBIN)/leanchecker$(EXE): $(OUTARC)/libLeanChecker.a.trace
+$(OUTBIN)/leanchecker-paranoid$(EXE): $(OUTARC)/libLeanChecker.a.trace ${LIB}/lean/libInit.a.trace ${LIB}/lean/libStd.a.trace ${LIB}/lean/libLean.a.trace ${LIB}/lean/libLake.a.trace
 endif
 
 # we specify the precise file names here to avoid rebuilds
@@ -181,19 +182,19 @@ libLake_shared: $(OUTLIB)/libLake_shared$(SO)
 
 $(OUTBIN)/lake$(EXE): ${LIB}/temp/LakeMain.*o.export $(OUTLIB)/libLake_shared$(SO)
 	$(link-preamble)
-	$(LEANC_SH) $< -lLake_shared ${CMAKE_EXE_LINKER_FLAGS_MAKE} ${LEANC_OPTS} -o $@
+	$(LEANC_SH) $< -lLake_shared ${CMAKE_EXE_LINKER_FLAGS_MAKE} ${CMAKE_DYN_EXE_LINKER_FLAGS_MAKE} ${LEANC_OPTS} -o $@
 
 lake: $(OUTBIN)/lake$(EXE)
 
 $(OUTBIN)/lean$(EXE): $(OUTLIB)/libInit_shared$(SO) $(OUTLIB)/libleanshared_2$(SO) $(OUTLIB)/libleanshared_1$(SO) $(OUTLIB)/libleanshared$(SO) ${LIB}/temp/libleanmain.a
 	$(link-preamble)
-	$(LEANC_SH) ${LIB}/temp/libleanmain.a ${CMAKE_EXE_LINKER_FLAGS_MAKE} ${LEAN_EXE_LINKER_FLAGS} ${LEANC_OPTS} -o $@
+	$(LEANC_SH) ${LIB}/temp/libleanmain.a ${CMAKE_EXE_LINKER_FLAGS_MAKE} ${CMAKE_DYN_EXE_LINKER_FLAGS_MAKE} ${LEAN_EXE_LINKER_FLAGS} ${LEANC_OPTS} -o $@
 
 lean: $(OUTBIN)/lean$(EXE)
 
 $(OUTBIN)/leanc$(EXE): $(OUTARC)/libLeanc.a
 	$(link-preamble)
-	$(LEANC_SH) $< ${CMAKE_EXE_LINKER_FLAGS_MAKE} ${LEAN_EXE_LINKER_FLAGS} ${LEANC_OPTS} -o $@
+	$(LEANC_SH) $< ${CMAKE_EXE_LINKER_FLAGS_MAKE} ${CMAKE_DYN_EXE_LINKER_FLAGS_MAKE} ${LEAN_EXE_LINKER_FLAGS} ${LEANC_OPTS} -o $@
 
 leanc: $(OUTBIN)/leanc$(EXE)
 
@@ -201,12 +202,25 @@ $(OUTBIN)/leanir$(EXE): $(OUTARC)/libLeanIR.a
 	@echo "[    ] Building $@"
 # on Windows, must remove file before writing a new one (since the old one may be in use)
 	@rm -f $@
-	"${CMAKE_BINARY_DIR}/leanc.sh" $< ${CMAKE_EXE_LINKER_FLAGS_MAKE} ${LEAN_EXE_LINKER_FLAGS} -o $@
+	"${CMAKE_BINARY_DIR}/leanc.sh" $< ${CMAKE_EXE_LINKER_FLAGS_MAKE} ${CMAKE_DYN_EXE_LINKER_FLAGS_MAKE} ${LEAN_EXE_LINKER_FLAGS} -o $@
 
 leanir: $(OUTBIN)/leanir$(EXE)
 
 $(OUTBIN)/leanchecker$(EXE): $(OUTARC)/libLeanChecker.a $(OUTLIB)/libLake_shared$(SO)
 	$(link-preamble)
-	$(LEANC_SH) $< -lLake_shared ${CMAKE_EXE_LINKER_FLAGS_MAKE} ${LEAN_EXE_LINKER_FLAGS} ${LEANC_OPTS} -o $@
+	$(LEANC_SH) $< -lLake_shared ${CMAKE_EXE_LINKER_FLAGS_MAKE} ${CMAKE_DYN_EXE_LINKER_FLAGS_MAKE} ${LEAN_EXE_LINKER_FLAGS} ${LEANC_OPTS} -o $@
 
 leanchecker: $(OUTBIN)/leanchecker$(EXE)
+
+# Statically linked so that it gets its own mimalloc; see `LEANCHECKER_PARANOID_LINKER_FLAGS`.
+# Stripped because static linking makes it two orders of magnitude larger than the other binaries
+# and it neither runs the interpreter nor exports anything.
+$(OUTBIN)/leanchecker-paranoid$(EXE): $(OUTARC)/libLeanChecker.a $(OUTARC)/libmimalloc_paranoid.a
+	$(link-preamble)
+	$(LEANC_SH) $< ${LEANCHECKER_PARANOID_LINKER_FLAGS_MAKE} ${LEANC_OPTS} -o $@
+	"${CMAKE_STRIP}" $@
+# Double-check we've linked against the correct mimalloc; it would be sad if a build system change
+# were to silently disturb this.
+	@grep -q "corrupted free list entry" $@
+
+leanchecker-paranoid: $(OUTBIN)/leanchecker-paranoid$(EXE)

--- a/tests/bench/size/run_bench.sh
+++ b/tests/bench/size/run_bench.sh
@@ -1,3 +1,4 @@
+make -C "$BUILD_DIR" leanchecker-paranoid -j$NPROC  # as in CI
 make -C "$BUILD_DIR" install DESTDIR="$(realpath install)"
 python measure_sizes.py "$SRC_DIR" "$BUILD_DIR" install measurements.jsonl
 rm -rf install


### PR DESCRIPTION
This PR adds `bin/leanchecker-paranoid`, a variant of `leanchecker` built with allocator hardening.

`leanchecker-paranoid` is built with mimalloc's memory-safety mitigations at `MI_SECURE=3`. Level 3 enables encoded free lists and the padding they imply. Encoding is the part that matters for Lean: `lean_object.m_rc` sits at offset 0, exactly where mimalloc keeps a freed block's free-list link, so a reference-count operation through a stale pointer writes into allocator metadata rather than into dead payload. Over 40 runs of a probe modelling that, level 3 eliminates uncontrolled crashes entirely and converts them into a checked abort raised before a bad block is handed out. Padding additionally catches out-of-bounds constructor and array writes. The cost is roughly +26% wall-clock and +17.5% heap size.

The binary is not exposed by `elan`; instead, it will be directly integrated into upcoming checker workflows.