### PR TITLE
feat: add `lake challenge` as a `comparator` frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,7 +325,8 @@ jobs:
                 "CMAKE_PRESET": "relwithassert",
                 // * `elab_bench/big_do` crashes with exit code 134
                 // * `compile_bench/channel` randomly segfaults
-                "CTEST_OPTIONS": "-E 'elab_bench/big_do|compile_bench/channel'",
+                // * `challenge-olean-issue` intentionally breaks memsafety
+                "CTEST_OPTIONS": "-E 'elab_bench/big_do|compile_bench/channel|challenge-olean-issue'",
               },
               {
                 "name": "Linux fsanitize",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -607,7 +607,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   string(APPEND LEANSHARED_LINKER_FLAGS " -Wl,-soname=libleanshared.so")
   string(
     APPEND LAKESHARED_LINKER_FLAGS
-    " -Wl,--whole-archive ${CMAKE_BINARY_DIR}/lib/lean/libLake.a.export -Wl,--no-whole-archive -Wl,-soname=libLake_shared.so"
+    " -Wl,--whole-archive ${CMAKE_BINARY_DIR}/lib/lean/libLake.a.export -Wl,--no-whole-archive ${CMAKE_BINARY_DIR}/lib/lean/libLeanExport.a.export -Wl,-soname=libLake_shared.so"
   )
   string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath=$ORIGIN/../lib:$ORIGIN/../lib/lean")
 elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
@@ -618,7 +618,7 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   string(APPEND LEANSHARED_LINKER_FLAGS " -install_name @rpath/libleanshared.dylib")
   string(
     APPEND LAKESHARED_LINKER_FLAGS
-    " -Wl,-force_load,${CMAKE_BINARY_DIR}/lib/lean/libLake.a.export -install_name @rpath/libLake_shared.dylib"
+    " -Wl,-force_load,${CMAKE_BINARY_DIR}/lib/lean/libLake.a.export ${CMAKE_BINARY_DIR}/lib/lean/libLeanExport.a.export -install_name @rpath/libLake_shared.dylib"
   )
   string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath,@executable_path/../lib -Wl,-rpath,@executable_path/../lib/lean")
 elseif(CMAKE_SYSTEM_NAME MATCHES "Emscripten")
@@ -627,7 +627,7 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Emscripten")
 elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
   string(
     APPEND LAKESHARED_LINKER_FLAGS
-    " -Wl,--out-implib,${CMAKE_BINARY_DIR}/lib/lean/libLake_shared.dll.a -Wl,--whole-archive ${CMAKE_BINARY_DIR}/lib/lean/libLake.a.export -Wl,--no-whole-archive"
+    " -Wl,--out-implib,${CMAKE_BINARY_DIR}/lib/lean/libLake_shared.dll.a -Wl,--whole-archive ${CMAKE_BINARY_DIR}/lib/lean/libLake.a.export -Wl,--no-whole-archive ${CMAKE_BINARY_DIR}/lib/lean/libLeanExport.a.export"
   )
 endif()
 
@@ -922,6 +922,7 @@ set(
   Init
   Std
   Lean
+  LeanExport
   Leanc
   LeanIR
 )
@@ -1051,6 +1052,7 @@ endif()
 
 if(NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten")
   add_custom_target(leanir ALL DEPENDS leanshared COMMAND $(MAKE) -f ${CMAKE_BINARY_DIR}/stdlib.make leanir VERBATIM)
+  add_custom_target(leanexport ALL DEPENDS leanshared COMMAND $(MAKE) -f ${CMAKE_BINARY_DIR}/stdlib.make leanexport VERBATIM)
 endif()
 
 # use Bash version for building, use Lean version in bin/ for tests & distribution

--- a/src/LeanExport.lean
+++ b/src/LeanExport.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Henrik Böving
+-/
+import LeanExport.Basic
+import LeanExport.Parse
+
+open Lean LeanExport
+
+def main (args : List String) : IO Unit := do
+  initSearchPath (← findSysroot)
+  let (opts, args) := args.partition (fun s => s.startsWith "--" && s.length ≥ 3)
+  let (imports, constants) := args.span (· != "--")
+  let imports := imports.toArray.map fun mod => { module := Syntax.decodeNameLit ("`" ++ mod) |>.get! }
+  let env ← importModules imports {}
+  let constants := match constants.tail? with
+    | some cs => cs.map fun c => Syntax.decodeNameLit ("`" ++ c) |>.get!
+    | none    => env.constants.toList.map Prod.fst |>.filter (!·.isInternal)
+  M.run env do
+    let _ ← initState env opts
+    dumpMetadata
+    for c in constants do
+      modify (fun st => { st with noMDataExprs := {} })
+      dumpConstant c

--- a/src/LeanExport/Basic.lean
+++ b/src/LeanExport/Basic.lean
@@ -1,0 +1,457 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Henrik Böving
+-/
+module
+
+prelude
+public import Lean
+public import Std.Data.HashMap.Basic
+
+/-!
+# Writer for the Lean 4 NDJSON export format
+
+Serializes an `Environment`'s constants as newline-delimited JSON. See `doc/dev/export_format.md`
+for the format itself.
+-/
+
+open Lean
+open Std (HashMap)
+
+def Lean.BinderInfo.toJson : BinderInfo → Json
+  | .default => "default"
+  | .implicit => "implicit"
+  | .strictImplicit => "strictImplicit"
+  | .instImplicit => "instImplicit"
+
+def Lean.ReducibilityHints.toJson : ReducibilityHints → Json
+  | .opaque => "opaque"
+  | .abbrev => "abbrev"
+  | .regular n => .mkObj [("regular", n.toNat)]
+
+def Lean.QuotKind.toJson : QuotKind → Json
+  | type => "type"
+  | ctor => "ctor"
+  | lift => "lift"
+  | ind => "ind"
+
+def Lean.DefinitionSafety.toJson : DefinitionSafety → Json
+  | «unsafe» => "unsafe"
+  | safe => "safe"
+  | «partial» => "partial"
+
+def Lean.KVMap.toJson (kvs: Lean.KVMap) : Json :=
+  .mkObj <| kvs.entries.map (fun (k, v) => (k.toString, reprStr v))
+
+namespace LeanExport
+
+public structure Context where
+  env : Environment
+
+public structure State where
+  visitedNames : HashMap Name Nat := HashMap.emptyWithCapacity 200000 |>.insert .anonymous 0
+  visitedLevels : HashMap Level Nat := HashMap.emptyWithCapacity 1000 |>.insert .zero 0
+  visitedExprs : HashMap Expr Nat := HashMap.emptyWithCapacity 10000000
+  visitedConstants : NameHashSet := {}
+  noMDataExprs : HashMap Expr Expr := HashMap.emptyWithCapacity 100000
+  exportMData : Bool := false
+  exportUnsafe : Bool := false
+  ignoreMissing : Bool := false
+  /-- Maps the name of an inductive type to a list of names of corresponding recursors.
+  This is used to facilitate exporting of related inductives, constructors, and recursors as a unit. -/
+  recursorMap : NameMap NameSet := {}
+
+public abbrev M := ReaderT Context <| StateT State IO
+
+public def M.run (env : Environment) (act : M α) : IO α :=
+  StateT.run' (s := {}) do
+    ReaderT.run (r := { env }) do
+      act
+
+/--
+Initialize the exporter state from an environment and cli options.
+The `recursorMap` maps each inductive declaration's name to the list
+of relevant recursors, which is used to ensure that for any inductive
+declaration, the inductives, constructors, and recursors are exported
+together in that order.
+-/
+public def initState (env : Environment) (cliOptions : List String := []) : M Unit := do
+  let mut recursorMap : NameMap NameSet := {}
+  for (_, constInfo) in env.constants do
+    if let .recInfo recVal := constInfo then
+      for indName in recVal.all do
+        recursorMap := recursorMap.alter indName <|
+          fun
+          | none => some <| NameSet.empty.insert recVal.name
+          | some recNames => some <| recNames.insert recVal.name
+  modify fun st => { st with
+    exportMData   := cliOptions.any (· == "--export-mdata")
+    exportUnsafe  := cliOptions.any (· == "--export-unsafe")
+    ignoreMissing := cliOptions.any (· == "--ignore-missing")
+    recursorMap
+  }
+
+/--
+For a given primitive (name, level, expr) to be exported:
+IFF it's been seen before, return its index within the export file
+IFF it has not been seen before, add it to the cache, print it into the export, and return its cache index.
+-/
+@[inline]
+def getIdx [Hashable α] [BEq α] (x : α) (namespaced: String) (getM : State → HashMap α Nat) (setM : State → HashMap α Nat → State) (rec : M Json) : M Nat := do
+  let m ← getM <$> get
+  if let some idx := m[x]? then
+    return idx
+  let s ← rec
+  let m ← getM <$> get
+  let idx := m.size
+  IO.println (s.setObjVal! namespaced idx).compress
+  modify fun st => setM st ((getM st).insert x idx)
+  return idx
+
+def dumpName (n : Name) : M Nat := getIdx n "in" (·.visitedNames) ({ · with visitedNames := · }) do
+  match n with
+  | .anonymous => unreachable!
+  | .str n s =>
+    return .mkObj [
+      ("str", .mkObj [
+        ("pre", ← dumpName n),
+        ("str", s)
+      ])
+    ]
+  | .num n i =>
+    return .mkObj [
+      ("num", .mkObj [
+        ("pre", ← dumpName n),
+        ("i", i)
+      ])
+    ]
+
+def dumpLevel (l : Level) : M Nat := getIdx l "il" (·.visitedLevels) ({ · with visitedLevels := · }) do
+  match l with
+  | .zero | .mvar _ => unreachable!
+  | .succ l => return .mkObj [("succ", ← dumpLevel l)]
+  | .max l1 l2 => return .mkObj [("max", Json.arr #[← dumpLevel l1, ← dumpLevel l2])]
+  | .imax l1 l2 => return .mkObj [("imax", Json.arr #[← dumpLevel l1, ← dumpLevel l2])]
+  | .param n => return .mkObj [("param", ← dumpName n)]
+
+def dumpUparams (uparams : List Name) : M Json := do
+  let nameIdxs ← uparams.mapM dumpName
+  let _ ← (uparams.map (Level.param)).mapM dumpLevel
+  pure nameIdxs.toJson
+
+def dumpNames (uparams : List Name) : M Json := do
+  let nameIdxs ← uparams.mapM dumpName
+  return nameIdxs.toJson
+
+def removeMData (e : Expr) : M Expr := do
+  if let some x := (← get).noMDataExprs[e]? then
+    return x
+  let e' ← match e with
+  | .mdata _ e' => removeMData e'
+  | .fvar .. | .mvar ..=> unreachable!
+  | .bvar .. | .sort .. | .const .. | .lit _ => pure e
+  | .app f a =>
+    pure <| e.updateApp! (← removeMData f) (← removeMData a)
+  | .lam _ d b _ =>
+    pure <| e.updateLambdaE! (← removeMData d) (← removeMData b)
+  | .letE _ d v b _ =>
+    -- Normalize `nonDep` to `false` to avoid duplicate expression indices.
+    -- Lean's `BEq` for `Expr` considers the `nonDep` flag, but external type checkers
+    -- (e.g., nanoda_lib) treat expressions as identical regardless of this optimization hint.
+    -- Without normalization, the same expression can get different indices, causing parse errors.
+    -- See: https://github.com/ammkrn/lean4export/commit/eb023e5
+    pure <| e.updateLet! (← removeMData d) (← removeMData v) (← removeMData b) false
+  | .forallE _ d b _ =>
+    pure <| e.updateForallE! (← removeMData d) (← removeMData b)
+  | .proj _ _ e2 =>
+    pure <| e.updateProj! (← removeMData e2)
+  modify (fun st => { st with noMDataExprs := st.noMDataExprs.insert e e' })
+  pure e'
+
+mutual
+
+public partial def dumpExprAux (e : Expr) : M Nat := do
+  getIdx e "ie" (·.visitedExprs) ({ · with visitedExprs := · }) do
+    match e with
+    | .fvar .. | .mvar .. => panic! "cannot export free variables or metavariables"
+    | .mdata a e' =>
+      return .mkObj [
+        ("mdata", .mkObj [
+            ("data", a.toJson),
+            ("expr", ← dumpExprAux e')
+        ])
+      ]
+    | .bvar i => return .mkObj [("bvar", i)]
+    | .lit (.natVal i) => dumpNatDeps; return .mkObj [("natVal", s!"{i}")]
+    | .lit (.strVal s) => dumpStrDeps; return .mkObj [("strVal", s)]
+    | .sort l => return .mkObj [("sort", ← dumpLevel l)]
+    | .const n us => return .mkObj [
+      ("const", .mkObj [
+        ("name", ← dumpName n),
+        ("us", (← us.mapM dumpLevel).toJson)
+      ])
+    ]
+    | .app f a => return .mkObj [
+      ("app", .mkObj [
+        ("fn", ← dumpExprAux f),
+        ("arg", ← dumpExprAux a)
+      ])
+    ]
+    | .lam n d b bi => return .mkObj [
+      ("lam", .mkObj [
+        ("name", ← dumpName n),
+        ("type", ← dumpExprAux d),
+        ("body", ← dumpExprAux b),
+        ("binderInfo", bi.toJson)
+      ])
+    ]
+    | .forallE n d b bi => return .mkObj [
+      ("forallE", .mkObj [
+        ("name", ← dumpName n),
+        ("type", ← dumpExprAux d),
+        ("body", ← dumpExprAux b),
+        ("binderInfo", bi.toJson)
+      ])
+    ]
+    | .letE n d v b nondep => return .mkObj [
+      ("letE", .mkObj [
+        ("name", ← dumpName n),
+        ("type", ← dumpExprAux d),
+        ("value", ← dumpExprAux v),
+        ("body", ← dumpExprAux b),
+        ("nondep", nondep)
+      ])
+    ]
+    | .proj s i e => return .mkObj [
+      ("proj", .mkObj [
+        ("typeName", ← dumpName s),
+        ("idx", i),
+        ("struct", ← dumpExprAux e)
+      ])
+    ]
+where
+  dumpNatDeps : M Unit := do
+    let nat := ``Nat
+    if (!(← get).visitedConstants.contains nat) && ((← read).env.find? nat).isSome
+    then dumpConstant nat
+  dumpStrDeps : M Unit := do
+    let charOfNat := ``Char.ofNat
+    if (!(← get).visitedConstants.contains charOfNat) && ((← read).env.find? charOfNat).isSome
+    then dumpConstant charOfNat
+    let stringOfList := ``String.ofList
+    if (!(← get).visitedConstants.contains stringOfList) && ((← read).env.find? stringOfList).isSome
+    then dumpConstant stringOfList
+
+public partial def dumpExpr (e : Expr) : M Nat := do
+    let aux (e : Expr) : M Expr := do
+      modify (fun st => { st with noMDataExprs := HashMap.emptyWithCapacity })
+      removeMData e
+    dumpExprAux <| ← if (← get).exportMData then pure e else aux e
+
+public partial def dumpConstant (c : Name) : M Unit := do
+  let some declar := (← read).env.find? c
+    | if (← get).ignoreMissing then return else panic! s!"Constant {c} not found in environment."
+  if (declar.isUnsafe && !(← get).exportUnsafe) || (← get).visitedConstants.contains c then
+    return
+  modify fun st => { st with visitedConstants := st.visitedConstants.insert c }
+  match declar with
+  | .axiomInfo val => do
+    dumpDeps val.type
+    dumpObj [
+      ("axiom", Json.mkObj [
+        ("name", ← dumpName val.name),
+        ("levelParams", ← dumpUparams val.levelParams),
+        ("type", ← dumpExpr val.type),
+        ("isUnsafe", val.isUnsafe)
+      ])
+    ]
+  | .defnInfo val => do
+    dumpDeps val.type
+    dumpDeps val.value
+    dumpObj [
+      ("def", Json.mkObj [
+        ("name", ← dumpName val.name),
+        ("levelParams", ← dumpUparams val.levelParams),
+        ("type", ← dumpExpr val.type),
+        ("value", ← dumpExpr val.value),
+        ("hints", val.hints.toJson),
+        ("safety", val.safety.toJson),
+        ("all", ← dumpNames val.all)
+      ])
+    ]
+  | .opaqueInfo val => do
+    dumpDeps val.type
+    dumpDeps val.value
+    dumpObj [
+      ("opaque", Json.mkObj [
+        ("name", ← dumpName val.name),
+        ("levelParams", ← dumpUparams val.levelParams),
+        ("type", ← dumpExpr val.type),
+        ("value", ← dumpExpr val.value),
+        ("all", ← dumpNames val.all),
+        ("isUnsafe", val.isUnsafe)
+      ])
+    ]
+  | .thmInfo val => do
+    dumpDeps val.type
+    dumpDeps val.value
+    dumpObj [
+      ("thm", Json.mkObj [
+        ("name", ← dumpName val.name),
+        ("levelParams", ← dumpUparams val.levelParams),
+        ("type", ← dumpExpr val.type),
+        ("value", ← dumpExpr val.value),
+        ("all", ← dumpNames val.all)
+      ])
+    ]
+  | .quotInfo _ =>
+    -- Always dump full Quot package in the sensible order
+    dumpConstant ``Eq
+    for c in [`Quot, ``Quot.mk, ``Quot.lift, ``Quot.ind] do
+      let some (.quotInfo val) := (← read).env.find? c
+        | if (← get).ignoreMissing then return else panic! s!"Constant {c} not found in environment."
+      modify fun st => { st with visitedConstants := st.visitedConstants.insert c }
+      dumpObj [
+        ("quot", .mkObj [
+          ("name", ← dumpName val.name),
+          ("levelParams", ← dumpUparams val.levelParams),
+          ("type", ← dumpExpr val.type),
+          ("kind", val.kind.toJson)
+        ])
+      ]
+  | .inductInfo baseIndVal => do
+    let mut indVals := #[]
+    let mut ctorVals := #[]
+    let mut recursorNames := NameSet.empty
+    for indName in baseIndVal.all do
+      let val := ((← read).env.find? indName |>.get!).inductiveVal!
+      assert! ((!val.isUnsafe) || (← get).exportUnsafe)
+      indVals := indVals.push val
+      for ctor in val.ctors do
+        match ((← read).env.find? ctor |>.get!) with
+        | .ctorInfo ctorVal =>
+          assert! ((!ctorVal.isUnsafe) || (← get).exportUnsafe)
+          ctorVals := ctorVals.push ctorVal
+        | _ => panic! "Expected a `ConstantInfo.ctorInfo`."
+      modify fun st => { st with visitedConstants:= st.visitedConstants.insert indName }
+      dumpDeps val.type
+      if let .some names := (← get).recursorMap.get? baseIndVal.name
+      then recursorNames := recursorNames.union names
+      else assert! ctorVals.size == 0
+
+    /- We dump the constructor dependencies (which will not include the inductives in this block since we've
+    added the names to `visitedConstants`) before actually outputting anything in this inductive block to
+    ensure e.g. the `LT` in `Fin.mk` is dumped before this inductive block appears in the export file. -/
+    for ctorVal in ctorVals do
+      modify fun st => { st with visitedConstants:= st.visitedConstants.insert ctorVal.name }
+      dumpDeps ctorVal.type
+
+    let mut recursorVals := #[]
+    for recursorName in recursorNames do
+      match ((← read).env.find? recursorName |>.get!) with
+      | .recInfo recVal =>
+        assert! ((!recVal.isUnsafe) || (← get).exportUnsafe)
+        recursorVals := recursorVals.push recVal
+      | _ => panic! "expected a `constantinfo.recinfo`."
+    for recursorVal in recursorVals do
+      modify fun st => { st with visitedConstants:= st.visitedConstants.insert recursorVal.name }
+      dumpDeps recursorVal.type
+
+    /- We only dump these after we've already dumped the `recursorVal` type and added the name
+    to `visitedConstants` so that `dumpDeps` does not retry dumping the appearance of `Foo.rec` -/
+    for recursorVal in recursorVals do
+      for rule in recursorVal.rules do
+        dumpDeps rule.rhs
+
+    let inductiveValsJson ← indVals.mapM <| fun indVal => do
+      pure <| Json.mkObj [
+          ("name", ← dumpName indVal.name),
+          ("levelParams", ← dumpUparams indVal.levelParams),
+          ("type", ← dumpExpr indVal.type),
+          ("numParams", indVal.numParams),
+          ("numIndices", indVal.numIndices),
+          ("all", ← dumpNames indVal.all),
+          ("ctors", ← dumpNames indVal.ctors),
+          ("numNested", indVal.numNested),
+          ("isRec", indVal.isRec),
+          ("isReflexive", indVal.isReflexive),
+          ("isUnsafe", indVal.isUnsafe),
+      ]
+    let ctorValsJson ← ctorVals.mapM <| fun ctorVal => do
+      pure <| Json.mkObj [
+          ("name", ← dumpName ctorVal.name),
+          ("levelParams", ← dumpUparams ctorVal.levelParams),
+          ("type", ← dumpExpr ctorVal.type),
+          ("induct", ← dumpName ctorVal.induct),
+          ("cidx", ctorVal.cidx),
+          ("numParams", ctorVal.numParams),
+          ("numFields", ctorVal.numFields),
+          ("isUnsafe", ctorVal.isUnsafe)
+      ]
+    let recursorValsJson ← recursorVals.mapM <| fun recursorVal => do
+      pure <| Json.mkObj [
+          ("name", ← dumpName recursorVal.name),
+          ("levelParams", ← dumpUparams recursorVal.levelParams),
+          ("type", ← dumpExpr recursorVal.type),
+          ("all", ← dumpNames recursorVal.all),
+          ("numParams", recursorVal.numParams),
+          ("numIndices", recursorVal.numIndices),
+          ("numMotives", recursorVal.numMotives),
+          ("numMinors", recursorVal.numMinors),
+          ("rules", (← recursorVal.rules.mapM dumpRecRule).toJson),
+          ("k", recursorVal.k),
+          ("isUnsafe", recursorVal.isUnsafe),
+      ]
+    dumpObj [
+      ("inductive", Json.mkObj [
+        ("types", inductiveValsJson.toJson),
+        ("ctors", ctorValsJson.toJson),
+        ("recs", recursorValsJson.toJson),
+      ])
+    ]
+  | .ctorInfo val => dumpConstant val.induct
+  | .recInfo val =>
+    for indName in val.all do
+      dumpConstant indName
+where
+  dumpDeps e := do
+    for c in e.getUsedConstants do
+      dumpConstant c
+  /- Return these for inclusion inline with the exported `recInfo`. -/
+  dumpRecRule (rule : RecursorRule) : M Json := do
+    return Json.mkObj [
+      ("ctor", ← dumpName rule.ctor),
+      ("nfields", rule.nfields),
+      ("rhs", ← dumpExpr rule.rhs),
+    ]
+  dumpObj (fields : List (String × Json)) : M Unit :=
+    IO.println <| Json.mkObj fields |>.compress
+
+end
+
+def exportMetadata : Json :=
+  let leanMeta := Json.mkObj [
+    ("version", versionString),
+    ("githash", githash)
+  ]
+  let exporterMeta := Json.mkObj [
+    ("name", "lean4export"),
+    ("version", "3.1.0")
+  ]
+  let formatMeta := Json.mkObj [
+    ("version", "3.1.0")
+  ]
+
+  Json.mkObj [
+    ("meta", Json.mkObj [
+      ("exporter", exporterMeta),
+      ("lean", leanMeta),
+      ("format", formatMeta)
+    ])
+  ]
+
+public def dumpMetadata : M Unit := do
+  IO.println exportMetadata.compress
+
+end LeanExport

--- a/src/LeanExport/Parse.lean
+++ b/src/LeanExport/Parse.lean
@@ -1,0 +1,523 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Henrik Böving
+-/
+module
+
+prelude
+public import Std.Data.HashMap
+public import Lean.Declaration
+import Init.Data.Array.GetLit
+import Init.Data.String.Search
+import Init.System.IO
+import Std.Internal.Parsec.String
+import Lean.Data.Json.Parser
+
+/-!
+# Reader for the Lean 4 NDJSON export format
+
+Reconstructs a constant map from an export produced by `LeanExport.Basic`. The result is a plain
+`Std.HashMap`, not an `Environment`: nothing here is trusted, and nothing is added to the
+environment of the process doing the reading.
+-/
+
+namespace LeanExport
+
+public structure ExportedEnv where
+  constMap : Std.HashMap Lean.Name Lean.ConstantInfo
+  constOrder : Array Lean.Name
+  deriving Inhabited
+
+namespace Parse
+
+
+open Std.Internal.Parsec Std.Internal.Parsec.String Lean
+
+structure State where
+  stream : IO.FS.Stream
+  nameMap : Std.HashMap Nat Lean.Name := { (0, .anonymous) }
+  levelMap : Std.HashMap Nat Lean.Level := { (0, .zero) }
+  exprMap : Std.HashMap Nat Lean.Expr := {}
+  recursorRuleMap : Std.HashMap Nat Lean.RecursorRule := {}
+  constMap : Std.HashMap Lean.Name Lean.ConstantInfo := {}
+  constOrder : Array Lean.Name := #[]
+
+abbrev M := StateT State <| IO
+
+def M.run (x : M α) (stream : IO.FS.Stream) : IO (α × State) := do
+  StateT.run x { stream := stream }
+
+@[inline]
+def fail (msg : String) : M α :=
+  throw (.userError msg)
+
+@[inline]
+def getName (nidx : Nat) : M Lean.Name := do
+  let some n := (← get).nameMap[nidx]? | fail s!"Name not found {nidx}"
+  return n
+
+@[inline]
+def addName (nidx : Nat) (n : Lean.Name) : M Unit := do
+  modify fun s => { s with nameMap := s.nameMap.insert nidx n }
+
+@[inline]
+def getLevel (uidx : Nat) : M Lean.Level := do
+  let some l := (← get).levelMap[uidx]? | fail s!"Level not found {uidx}"
+  return l
+
+@[inline]
+def addLevel (uidx : Nat) (l : Lean.Level) : M Unit := do
+  modify fun s => { s with levelMap := s.levelMap.insert uidx l }
+
+@[inline]
+def getExpr (eidx : Nat) : M Lean.Expr := do
+  let some e := (← get).exprMap[eidx]? | fail s!"Expr not found {eidx}"
+  return e
+
+@[inline]
+def addExpr (eidx : Nat) (e : Lean.Expr) : M Unit := do
+  modify fun s => { s with exprMap := s.exprMap.insert eidx e }
+
+@[inline]
+def getRecursorRule (ridx : Nat) : M Lean.RecursorRule := do
+  let some r := (← get).recursorRuleMap[ridx]? | fail s!"RecursorRule not found {ridx}"
+  return r
+
+@[inline]
+def addRecursorRule (ridx : Nat) (r : Lean.RecursorRule) : M Unit := do
+  modify fun s => { s with recursorRuleMap := s.recursorRuleMap.insert ridx r }
+
+@[inline]
+def addConst (name : Lean.Name) (d : Lean.ConstantInfo) : M Unit := do
+  if (← get).constMap.contains name then
+    fail s!"Duplicate declaration: {name}"
+  modify fun s => {
+    s with
+      constMap := s.constMap.insert name d
+      constOrder := s.constOrder.push name
+    }
+
+@[inline]
+def parseJsonObj (line : String) : M (Std.TreeMap.Raw String Json) := do
+  let .ok (.obj obj) := Json.Parser.anyCore.run line | fail "Expected JSON object"
+  return obj
+
+def parseNameStr (json : Json) : M Name := do
+  let .obj data := json | fail s!"Name.str invalid"
+  let some (.num (preIdx : Nat)) := data["pre"]? | fail s!"Name.str invalid"
+  let some (.str str) := data["str"]? | fail s!"Name.str invalid"
+  return .str (← getName preIdx) str
+
+def parseNameNum (json : Json) : M Name := do
+  let .obj data := json | fail s!"Name.num invalid"
+  let some (.num (preIdx : Nat)) := data["pre"]? | fail s!"Name.str invalid"
+  let some (.num (i : Nat)) := data["i"]? | fail s!"Name.num invalid"
+  return .num (← getName preIdx) i
+
+def parseLevelSucc (json : Json) : M Level := do
+  let .num (lIdx : Nat) := json | fail s!"Level.succ invalid"
+  return .succ (← getLevel lIdx)
+
+def parseLevelMax (json : Json) : M Level := do
+  let .arr #[.num (lhsIdx : Nat), .num (rhsIdx : Nat)] := json
+    | fail s!"Level.max invalid"
+  return .max (← getLevel lhsIdx) (← getLevel rhsIdx)
+
+def parseLevelImax (json : Json) : M Level := do
+  let .arr #[.num (lhsIdx : Nat), .num (rhsIdx : Nat)] := json
+    | fail s!"Level.imax invalid"
+  return .imax (← getLevel lhsIdx) (← getLevel rhsIdx)
+
+def parseLevelParam (json : Json) : M Level := do
+  let .num (nIdx : Nat) := json | fail s!"Level.param invalid"
+  return .param (← getName nIdx)
+
+def parseExprBVar (json : Json) : M Expr := do
+  let .num (deBruijnIndex : Nat) := json | fail s!"Expr.bvar invalid"
+  return .bvar deBruijnIndex
+
+def parseExprSort (json : Json) : M Expr := do
+  let .num (uIdx : Nat) := json | fail s!"Expr.sort invalid"
+  return .sort (← getLevel uIdx)
+
+def parseExprConst (json : Json) : M Expr := do
+  let .obj data := json | fail s!"Expr.const invalid"
+  let some (.num (declNameIdx : Nat)) := data["name"]? | fail s!"Expr.const invalid"
+  let some (.arr usIdxs) := data["us"]? | fail s!"Expr.const invalid"
+
+  let declName ← getName declNameIdx
+  let us ← usIdxs.mapM fun uIdx => do
+    let (.num (uIdx : Nat)) := uIdx | fail s!"Expr.const invalid"
+    getLevel uIdx
+
+  return .const declName us.toList
+
+def parseExprApp (json : Json) : M Expr := do
+  let .obj data := json | fail s!"Expr.app invalid"
+  let some (.num (fnIdx : Nat)) := data["fn"]? | fail s!"Expr.app invalid"
+  let some (.num (argIdx : Nat)) := data["arg"]? | fail s!"Expr.app invalid"
+  let fn ← getExpr fnIdx
+  let arg ← getExpr argIdx
+
+  return .app fn arg
+
+def parseBinderInfo (info : String) : M BinderInfo :=
+  match info with
+  | "default" => return .default
+  | "implicit" => return .implicit
+  | "strictImplicit" => return .strictImplicit
+  | "instImplicit" => return .instImplicit
+  | _ => fail s!"Invalid binder info: {info}"
+
+def parseExprLam (json : Json) : M Expr := do
+  let .obj data := json | fail s!"Expr.lam invalid"
+  let some (.num (binderNameIdx : Nat)) := data["name"]? | fail s!"Expr.lam invalid"
+  let some (.num (binderTypeIdx : Nat)) := data["type"]? | fail s!"Expr.lam invalid"
+  let some (.num (bodyIdx : Nat)) := data["body"]? | fail s!"Expr.lam invalid"
+  let some (.str binderInfoStr) := data["binderInfo"]? | fail s!"Expr.lam invalid"
+
+  let binderName ← getName binderNameIdx
+  let binderType ← getExpr binderTypeIdx
+  let body ← getExpr bodyIdx
+  let binderInfo ← parseBinderInfo binderInfoStr
+
+  return .lam binderName binderType body binderInfo
+
+def parseExprForallE (json : Json) : M Expr := do
+  let .obj data := json | fail s!"Expr.forallE invalid"
+  let some (.num (binderNameIdx : Nat)) := data["name"]? | fail s!"Expr.forallE invalid"
+  let some (.num (binderTypeIdx : Nat)) := data["type"]? | fail s!"Expr.forallE invalid"
+  let some (.num (bodyIdx : Nat)) := data["body"]? | fail s!"Expr.forallE invalid"
+  let some (.str binderInfoStr) := data["binderInfo"]? | fail s!"Expr.forallE invalid"
+
+  let binderName ← getName binderNameIdx
+  let binderType ← getExpr binderTypeIdx
+  let body ← getExpr bodyIdx
+  let binderInfo ← parseBinderInfo binderInfoStr
+
+  return .forallE binderName binderType body binderInfo
+
+def parseExprLetE (json : Json) : M Expr := do
+  let .obj data := json | fail s!"Expr.letE invalid"
+  let some (.num (binderNameIdx : Nat)) := data["name"]? | fail s!"Expr.letE invalid"
+  let some (.num (binderTypeIdx : Nat)) := data["type"]? | fail s!"Expr.letE invalid"
+  let some (.num (valueIdx : Nat)) := data["value"]? | fail s!"Expr.letE invalid"
+  let some (.num (bodyIdx : Nat)) := data["body"]? | fail s!"Expr.letE invalid"
+  let some (.bool nondep) := data["nondep"]? | fail s!"Expr.letE invalid"
+
+  let binderName ← getName binderNameIdx
+  let binderType ← getExpr binderTypeIdx
+  let value ← getExpr valueIdx
+  let body ← getExpr bodyIdx
+
+  return .letE binderName binderType value body nondep
+
+def parseExprProj (json : Json) : M Expr := do
+  let .obj data := json | fail s!"Expr.proj invalid"
+  let some (.num (typeNameIdx : Nat)) := data["typeName"]? | fail s!"Expr.proj invalid"
+  let some (.num (projIdx : Nat)) := data["idx"]? | fail s!"Expr.proj invalid"
+  let some (.num (structIdx : Nat)) := data["struct"]? | fail s!"Expr.proj invalid"
+
+  let typeName ← getName typeNameIdx
+  let struct ← getExpr structIdx
+
+  return .proj typeName projIdx struct
+
+def parseExprNatLit (json : Json) : M Expr := do
+  let .str natValStr := json | fail s!"Expr.lit natVal invalid"
+  let some natVal := String.toNat? natValStr | fail s!"Expr.lit natVal invalid"
+
+  return .lit (.natVal natVal)
+
+def parseExprStrLit (json : Json) : M Expr := do
+  let .str strVal := json | fail s!"Expr.lit strVal invalid"
+  return .lit (.strVal strVal)
+
+def parseExprMdata (json : Json) : M Expr := do
+  let .obj data := json | fail s!"Expr.mdata invalid"
+  let some (.num (exprIdx : Nat)) := data["expr"]? | fail s!"Expr.mdata invalid"
+  let some (.obj _dataObj) := data["data"]? | fail s!"Expr.mdata invalid"
+  let expr ← getExpr exprIdx
+
+  -- TODO: Unclear how to perfectly recover with the current output format
+  return .mdata {} expr
+
+def getNameList (idxs : Array Json) : M (List Name) := do
+  idxs.toList.mapM fun idx => do
+    let (.num (idx : Nat)) := idx | fail s!"failed to convert to name idx"
+    getName idx
+
+def parseAxiomInfo (data : Std.TreeMap.Raw String Json) : M Unit := do
+  let some (.num (nameIdx : Nat)) := data["name"]? | fail s!"axiomInfo invalid"
+  let some (.arr levelParamsIdxs) := data["levelParams"]? | fail s!"axiomInfo invalid"
+  let some (.num (typeIdx : Nat)) := data["type"]? | fail s!"axiomInfo invalid"
+  let some (.bool isUnsafe) := data["isUnsafe"]? | fail s!"axiomInfo invalid"
+
+  let name ← getName nameIdx
+  let levelParams ← getNameList levelParamsIdxs
+  let type ← getExpr typeIdx
+
+  addConst name <| .axiomInfo { name, levelParams, type, isUnsafe }
+
+def parseDefnInfo (data : Std.TreeMap.Raw String Json) : M Unit := do
+  let some (.num (nameIdx : Nat)) := data["name"]? | fail s!"defnInfo invalid"
+  let some (.arr levelParamsIdxs) := data["levelParams"]? | fail s!"defnInfo invalid"
+  let some (.num (typeIdx : Nat)) := data["type"]? | fail s!"defnInfo invalid"
+  let some (.num (valueIdx : Nat)) := data["value"]? | fail s!"defnInfo invalid"
+  let some hints := data["hints"]? | fail s!"defnInfo invalid"
+  let some (.str safetyStr) := data["safety"]? | fail s!"defnInfo invalid"
+  let some (.arr allIdxs) := data["all"]? | fail s!"defnInfo invalid"
+
+  let name ← getName nameIdx
+  let levelParams ← getNameList levelParamsIdxs
+  let type ← getExpr typeIdx
+  let value ← getExpr valueIdx
+  let hints ←
+    match hints with
+    | .str "opaque" => pure .opaque
+    | .str "abbrev" => pure .abbrev
+    | .obj obj =>
+      let some (.num (level : Nat)) := obj["regular"]? | fail s!"defnInfo invalid"
+      pure <| .regular level.toUInt32
+    | _ => fail s!"defnInfo invalid"
+  let safety ←
+    match safetyStr with
+    | "unsafe" => pure .unsafe
+    | "safe" => pure .safe
+    | "partial" => pure .partial
+    | _ => fail s!"Unknown safety parameter: {safetyStr}"
+  let all ← getNameList allIdxs
+
+  addConst name <| .defnInfo { name, levelParams, type, value, hints, safety, all }
+
+def parseThmInfo (data : Std.TreeMap.Raw String Json) : M Unit := do
+  let some (.num (nameIdx : Nat)) := data["name"]? | fail s!"thmInfo invalid"
+  let some (.arr levelParamsIdxs) := data["levelParams"]? | fail s!"thmInfo invalid"
+  let some (.num (typeIdx : Nat)) := data["type"]? | fail s!"thmInfo invalid"
+  let some (.num (valueIdx : Nat)) := data["value"]? | fail s!"thmInfo invalid"
+  let some (.arr allIdxs) := data["all"]? | fail s!"thmInfo invalid"
+
+  let name ← getName nameIdx
+  let levelParams ← getNameList levelParamsIdxs
+  let type ← getExpr typeIdx
+  let value ← getExpr valueIdx
+  let all ← getNameList allIdxs
+
+  addConst name <| .thmInfo { name, levelParams, type, value, all }
+
+def parseOpaqueInfo (data : Std.TreeMap.Raw String Json) : M Unit := do
+  let some (.num (nameIdx : Nat)) := data["name"]? | fail s!"opaqueInfo invalid"
+  let some (.arr levelParamsIdxs) := data["levelParams"]? | fail s!"opaqueInfo invalid"
+  let some (.num (typeIdx : Nat)) := data["type"]? | fail s!"opaqueInfo invalid"
+  let some (.num (valueIdx : Nat)) := data["value"]? | fail s!"opaqueInfo invalid"
+  -- Work around until the exporter always includes isUnsafe
+  let (.bool isUnsafe) := data["isUnsafe"]?.getD (.bool false) | fail s!"axiomInfo invalid"
+  let some (.arr allIdxs) := data["all"]? | fail s!"opaqueInfo invalid"
+
+  let name ← getName nameIdx
+  let levelParams ← getNameList levelParamsIdxs
+  let type ← getExpr typeIdx
+  let value ← getExpr valueIdx
+  let all ← getNameList allIdxs
+
+  addConst name <| .opaqueInfo { name, levelParams, type, value, all, isUnsafe }
+
+def parseQuotInfo (data : Std.TreeMap.Raw String Json) : M Unit := do
+  let some (.num (nameIdx : Nat)) := data["name"]? | fail s!"quotInfo invalid"
+  let some (.arr levelParamsIdxs) := data["levelParams"]? | fail s!"quotInfo invalid"
+  let some (.num (typeIdx : Nat)) := data["type"]? | fail s!"quotInfo invalid"
+  let some (.str kindStr) := data["kind"]? | fail s!"quotInfo invalid"
+
+  let name ← getName nameIdx
+  let levelParams ← getNameList levelParamsIdxs
+  let type ← getExpr typeIdx
+  let kind ←
+    match kindStr with
+    | "type" => pure .type
+    | "ctor" => pure .ctor
+    | "lift" => pure .lift
+    | "ind" => pure .ind
+    | _ => fail s!"unknown quot kind: {kindStr}"
+
+  addConst name <| .quotInfo { name, levelParams, type, kind }
+
+def parseInductInfo (json : Json) : M Unit := do
+  let .obj data := json | fail "inductInfo invalid: Expected JSON object"
+  let some (.num (nameIdx : Nat)) := data["name"]? | fail s!"inductInfo invalid"
+  let some (.arr levelParamsIdxs) := data["levelParams"]? | fail s!"inductInfo invalid"
+  let some (.num (typeIdx : Nat)) := data["type"]? | fail s!"inductInfo invalid"
+  let some (.num (numParams : Nat)) := data["numParams"]? | fail s!"inductInfo invalid"
+  let some (.num (numIndices : Nat)) := data["numIndices"]? | fail s!"inductInfo invalid"
+  let some (.arr allIdxs) := data["all"]? | fail s!"inductInfo invalid"
+  let some (.arr ctorsIdxs) := data["ctors"]? | fail s!"inductInfo invalid"
+  let some (.num (numNested : Nat)) := data["numNested"]? | fail s!"inductInfo invalid"
+  let some (.bool isRec) := data["isRec"]? | fail s!"inductInfo invalid"
+  let some (.bool isUnsafe) := data["isUnsafe"]? | fail s!"inductInfo invalid"
+  let some (.bool isReflexive) := data["isReflexive"]? | fail s!"inductInfo invalid"
+
+  let name ← getName nameIdx
+  let levelParams ← getNameList levelParamsIdxs
+  let type ← getExpr typeIdx
+  let all ← getNameList allIdxs
+  let ctors ← getNameList ctorsIdxs
+
+  addConst name <| .inductInfo {
+    name,
+    levelParams,
+    type,
+    numParams,
+    numIndices,
+    all,
+    ctors,
+    numNested,
+    isRec,
+    isUnsafe,
+    isReflexive,
+  }
+
+def parseCtorInfo (json : Json) : M Unit := do
+  let .obj data := json | fail s!"ctorInfo invalid"
+  let some (.num (nameIdx : Nat)) := data["name"]? | fail s!"ctorInfo invalid"
+  let some (.arr levelParamsIdxs) := data["levelParams"]? | fail s!"ctorInfo invalid"
+  let some (.num (typeIdx : Nat)) := data["type"]? | fail s!"ctorInfo invalid"
+  let some (.num (inductIdx : Nat)) := data["induct"]? | fail s!"ctorInfo invalid"
+  let some (.num (cidx : Nat)) := data["cidx"]? | fail s!"ctorInfo invalid"
+  let some (.num (numParams : Nat)) := data["numParams"]? | fail s!"ctorInfo invalid"
+  let some (.num (numFields : Nat)) := data["numFields"]? | fail s!"ctorInfo invalid"
+  let some (.bool isUnsafe) := data["isUnsafe"]? | fail s!"ctorInfo invalid"
+
+  let name ← getName nameIdx
+  let levelParams ← getNameList levelParamsIdxs
+  let type ← getExpr typeIdx
+  let induct ← getName inductIdx
+
+  addConst name <| .ctorInfo {
+    name,
+    levelParams,
+    type,
+    induct,
+    cidx,
+    numParams,
+    numFields,
+    isUnsafe,
+  }
+
+def parseRecInfo (json : Json) : M Unit := do
+  let .obj data := json | fail s!"recInfo invalid"
+  let some (.num (nameIdx : Nat)) := data["name"]? | fail s!"recInfo invalid"
+  let some (.arr levelParamsIdxs) := data["levelParams"]? | fail s!"recInfo invalid"
+  let some (.num (typeIdx : Nat)) := data["type"]? | fail s!"recInfo invalid"
+  let some (.arr allIdxs) := data["all"]? | fail s!"recInfo invalid"
+  let some (.num (numParams : Nat)) := data["numParams"]? | fail s!"recInfo invalid"
+  let some (.num (numIndices : Nat)) := data["numIndices"]? | fail s!"recInfo invalid"
+  let some (.num (numMotives : Nat)) := data["numMotives"]? | fail s!"recInfo invalid"
+  let some (.num (numMinors : Nat)) := data["numMinors"]? | fail s!"recInfo invalid"
+  let some (.bool k) := data["k"]? | fail s!"recInfo invalid"
+  let some (.arr rules) := data["rules"]? | fail s!"recInfo invalid"
+  let some (.bool isUnsafe) := data["isUnsafe"]? | fail s!"recInfo invalid"
+
+  let name ← getName nameIdx
+  let levelParams ← getNameList levelParamsIdxs
+  let type ← getExpr typeIdx
+  let all ← getNameList allIdxs
+  let rules ← rules.toList.mapM fun rule => do
+    let .obj rule := rule | fail s!"recInfo invalid"
+    let some (.num (ctorIdx : Nat)) := rule["ctor"]? | fail s!"recInfo invalid"
+    let some (.num (nfields : Nat)) := rule["nfields"]? | fail s!"recInfo invalid"
+    let some (.num (rhsIdx : Nat)) := rule["rhs"]? | fail s!"recInfo invalid"
+
+    let ctor ← getName ctorIdx
+    let rhs ← getExpr rhsIdx
+    return { ctor, nfields, rhs }
+
+  addConst name <| .recInfo {
+    name,
+    levelParams,
+    type,
+    all,
+    numParams,
+    numIndices,
+    numMotives,
+    numMinors,
+    rules,
+    k,
+    isUnsafe,
+  }
+
+def parseInductive (data : Std.TreeMap.Raw String Json) : M Unit := do
+  let some (.arr types) := data["types"]? | fail s!"Inductive invalid, no `types`"
+  let some (.arr ctors) := data["ctors"]? | fail s!"Inductive invalid, no `ctors`"
+  let some (.arr recs) := data["recs"]? | fail s!"Inductive invalid, no `recs`"
+  types.forM parseInductInfo
+  ctors.forM parseCtorInfo
+  recs.forM parseRecInfo
+
+def parseItem (line : String) : M Unit := do
+  let obj ← parseJsonObj line
+  let kv := obj.toList
+  -- Normalize key order...
+  let kv := match kv with
+    | [x, y@("in", _)] => [y,x]
+    | [x, y@("ie", _)] => [y,x]
+    | [x, y@("il", _)] => [y,x]
+    | _ =>kv
+  -- so that we can match on it easily
+  match kv with
+  | [("in", .num (idx : Nat)),("str", data)] =>   addName idx <| ← parseNameStr data
+  | [("in", .num (idx : Nat)),("num", data)] =>   addName idx <| ← parseNameNum data
+  | [("il", .num (idx : Nat)),("succ", data)] =>  addLevel idx <| ← parseLevelSucc data
+  | [("il", .num (idx : Nat)),("max", data)] =>   addLevel idx <| ← parseLevelMax data
+  | [("il", .num (idx : Nat)),("imax", data)] =>  addLevel idx <| ← parseLevelImax data
+  | [("il", .num (idx : Nat)),("param", data)] => addLevel idx <| ← parseLevelParam data
+  | [("ie", .num (idx : Nat)),("bvar", data)] =>  addExpr idx <| ← parseExprBVar data
+  | [("ie", .num (idx : Nat)),("sort", data)] =>  addExpr idx <| ← parseExprSort data
+  | [("ie", .num (idx : Nat)),("const", data)] => addExpr idx <| ← parseExprConst data
+  | [("ie", .num (idx : Nat)),("app", data)] =>   addExpr idx <| ← parseExprApp data
+  | [("ie", .num (idx : Nat)),("lam", data)] =>   addExpr idx <| ← parseExprLam data
+  | [("ie", .num (idx : Nat)),("forallE", data)] =>addExpr idx <| ← parseExprForallE data
+  | [("ie", .num (idx : Nat)),("letE", data)] =>   addExpr idx <| ← parseExprLetE data
+  | [("ie", .num (idx : Nat)),("proj", data)] =>   addExpr idx <| ← parseExprProj data
+  | [("ie", .num (idx : Nat)),("natVal", data)] => addExpr idx <| ← parseExprNatLit data
+  | [("ie", .num (idx : Nat)),("strVal", data)] => addExpr idx <| ← parseExprStrLit data
+  | [("ie", .num (idx : Nat)),("mdata", data)] => addExpr idx <| ← parseExprMdata data
+  | [("axiom", .obj data)] => parseAxiomInfo data
+  | [("def", .obj data)] => parseDefnInfo data
+  | [("thm", .obj data)] => parseThmInfo data
+  | [("opaque", .obj data)] => parseOpaqueInfo data
+  | [("quot", .obj data)] => parseQuotInfo data
+  | [("inductive", .obj data)] => parseInductive data
+  | _ => fail s!"Unknown export object with keys {obj.keys}"
+
+partial def parseItems : M Unit :=
+  go
+where
+  go : M Unit := do
+    let line ← (← get).stream.getLine
+    unless line.isEmpty do
+      parseItem line
+      go
+
+def parseMdata : M Unit := do
+  let _line ← (← get).stream.getLine
+
+def parseFile : M Unit := do
+  parseMdata
+  parseItems
+
+end Parse
+
+public def parseStream (stream : IO.FS.Stream) : IO ExportedEnv := do
+  let (_, state) ← Parse.M.run Parse.parseFile stream
+  let { constMap, constOrder, .. } := state
+  return {
+    constMap,
+    constOrder,
+  }
+
+-- We cannot turn pure Strings into Streams?
+-- def parse (input : String) : Except String ExportedEnv := do
+--   parseStream (IO.FS.Stream.ofString input)
+
+
+end LeanExport

--- a/src/lake/Lake/CLI/Check.lean
+++ b/src/lake/Lake/CLI/Check.lean
@@ -8,11 +8,14 @@ module
 prelude
 public import Lake.Check.Axioms
 public import Lake.Check.Compare
+public import Lake.Config.InstallPath
+public import Lake.Util.Exit
 public import Lean.Data.Json.FromToJson
 import Lean.Environment
 import Lean.Replay
 import Init.Data.ToString.Macro
 import Init.System.IO
+import Init.System.Platform
 
 /-!
 # Judging Lean code against the kernel, and against a challenge
@@ -37,8 +40,11 @@ public structure Context where
   legalAxioms : Array Lean.Name
   leanPrefix : System.FilePath
   gitLocation : System.FilePath
+  /-- `LEAN_PATH` for the exporter, so it finds the project's oleans inside the sandbox. -/
+  leanPath : String
   whichLandrun : String
-  whichLean4Export : String
+  whichLake : System.FilePath
+  whichLean4Export : System.FilePath
   externalKernels : (Std.TreeMap String (Array String))
 
 public abbrev M := ReaderT Context IO
@@ -79,22 +85,24 @@ def getLeanPrefix : M System.FilePath := do return (← read).leanPrefix
 @[inline]
 def getGitLocation : M System.FilePath := do return (← read).gitLocation
 
-def queryGitLocation : IO System.FilePath := do
-  let out ← IO.Process.run {
-    cmd := "which",
-    args := #["git"],
-    stdout := .piped,
-  }
-  return out.trimAscii.toString
+/-- Resolves `exe` to an absolute path via `PATH`, or `none` if it is not there. -/
+def whichExe (exe : String) : IO (Option System.FilePath) := do
+  let out ←
+    try IO.Process.output { cmd := "which", args := #[exe] }
+    catch _ => return none
+  if out.exitCode != 0 then
+    return none
+  let path := out.stdout.trimAscii.toString
+  return if path.isEmpty then none else some (path : System.FilePath)
 
-def queryLeanPrefix (projectDir : System.FilePath) : IO System.FilePath := do
-  let out ← IO.Process.run {
-    cmd := "lean",
-    args := #["--print-prefix"],
-    stdout := .piped,
-    cwd := projectDir
-  }
-  return out.trimAscii.toString
+def missingLandrunError (cmd exe : String) : String :=
+s!"`lake {cmd}` needs `{exe}` to sandbox the code it checks, and it was not found.
+
+  Install it from https://github.com/Zouuup/landrun (build from `main`)
+  and put it on PATH, or set COMPARATOR_LANDRUN to its full path.
+
+  There is no unsandboxed mode: the code being checked is untrusted, and it
+  is built and exported inside the sandbox."
 
 def buildLandrunArgs (spawnArgs : LandrunArgs) : Array String :=
   let args := #["--best-effort", "--ro", "/", "--rw", "/dev", "-ldd", "-add-exec"]
@@ -140,14 +148,15 @@ def safeLakeBuild (target : Lean.Name) : M Unit := do
   if !(← System.FilePath.pathExists dotLakeDir) then
     IO.FS.createDir dotLakeDir
 
+  let whichLake := (← read).whichLake
   runSandBoxed {
-    cmd := "lake",
+    cmd := whichLake.toString,
     args := #["build", target.toString],
     envPass := #["PATH", "HOME", "LEAN_ABORT_ON_PANIC"]
     envOverride := #[("LEAN_ABORT_ON_PANIC", some "1")]
     readablePaths := #[projectDir]
     writablePaths := #[dotLakeDir]
-    executablePaths := #[leanPrefix, gitLocation]
+    executablePaths := #[leanPrefix, whichLake, gitLocation]
   }
 
 def safeExport (module : Lean.Name) (decls : Array Lean.Name) : M String := do
@@ -158,14 +167,15 @@ def safeExport (module : Lean.Name) (decls : Array Lean.Name) : M String := do
   let leanPrefix ← getLeanPrefix
   let projectDir ← getProjectDir
   let dotLakeDir := projectDir / ".lake"
+  let whichLean4Export := (← read).whichLean4Export
   runSandBoxedWithStdout {
-    cmd := (← read).whichLean4Export
+    cmd := whichLean4Export.toString
     args := args,
     envPass := #["PATH", "HOME", "LEAN_PATH", "LEAN_ABORT_ON_PANIC"]
-    envOverride := #[("LEAN_ABORT_ON_PANIC", some "1")]
+    envOverride := #[("LEAN_ABORT_ON_PANIC", some "1"), ("LEAN_PATH", some (← read).leanPath)]
     readablePaths := #[projectDir, dotLakeDir]
     writablePaths := #[]
-    executablePaths := #[leanPrefix]
+    executablePaths := #[leanPrefix, whichLean4Export]
   }
 
 def runExternalKernel (kernelName : String) (kernelCommand : Array String)
@@ -338,41 +348,105 @@ public structure Config where
   external_kernels? : Option (Std.TreeMap String (Array String))
   deriving Lean.FromJson, Lean.ToJson, Repr
 
-public def M.run (x : M α) (cfg : Config) : IO α := do
-  let cwd ← IO.Process.getCurrentDir
-  let leanPrefix ← queryLeanPrefix cwd
-  let gitLocation ← queryGitLocation
-  let whichLean4Export := (← IO.getEnv "COMPARATOR_LEAN4EXPORT").getD "lean4export"
+/-- Reports a failure to even start, which is distinct from a judgment. -/
+def cannotRun (msg : String) : IO ExitCode := do
+  IO.eprintln s!"error: {msg}"
+  return 2
+
+/--
+Resolves the external tools the commands need and builds the context they share, or reports why
+that is not possible.
+-/
+def mkContext (cmd : String) (lean : LeanInstall) (lake : LakeInstall)
+    (projectDir : System.FilePath) (leanPath : String) : IO (Except ExitCode Context) := do
+  if !System.Platform.isLinux then
+    return .error (← cannotRun
+      s!"`lake {cmd}` sandboxes the code it checks with `landrun`, which needs Linux Landlock. \
+      There is no unsandboxed mode, so the command is unavailable on this platform.")
+
   let whichLandrun := (← IO.getEnv "COMPARATOR_LANDRUN").getD "landrun"
+  let some landrunPath ← whichExe whichLandrun
+    | return .error (← cannotRun (missingLandrunError cmd whichLandrun))
+  -- Always the bundled exporter: the export format has to match the compiler that produced the
+  -- oleans, so letting this be pointed elsewhere would reintroduce the toolchain-pinning problem.
+  let whichLean4Export := lean.binDir / "leanexport" |>.addExtension System.FilePath.exeExtension
+  let some gitLocation ← whichExe "git"
+    | return .error (← cannotRun s!"`lake {cmd}` needs `git` on PATH to build inside the sandbox")
+
+  return .ok {
+    projectDir := ← IO.FS.realPath projectDir
+    challengeModule := .anonymous
+    solutionModule := .anonymous
+    theoremNames := #[]
+    definitionNames := #[]
+    legalAxioms := #[]
+    leanPrefix := lean.sysroot
+    gitLocation := gitLocation
+    leanPath
+    whichLandrun := landrunPath.toString
+    whichLake := lake.lake
+    whichLean4Export
+    externalKernels := {}
+  }
+
+/-- Resolves the external kernels a configuration asks for. -/
+def resolveExternalKernels (cfg : Config) : IO (Except ExitCode (Std.TreeMap String (Array String))) := do
   let mut externalKernels := cfg.external_kernels?.getD {}
-  let defaultNanoda := "nanoda_bin"
-  let nanodaOverride? ← IO.getEnv "COMPARATOR_NANODA"
-
   if cfg.enable_nanoda?.getD false && !externalKernels.isEmpty then
-    throw <| .userError "Cannot use enable_nanoda and an external kernel list at the same time, register nanoda in the list instead."
-
+    return .error (← cannotRun "cannot use `enable_nanoda` and `external_kernels` at the same \
+      time; register nanoda in the list instead")
   for (kernelName, kernelCommand) in externalKernels do
     if kernelCommand.isEmpty then
-      throw <| .userError s!"{kernelName} has an empty command"
-
+      return .error (← cannotRun s!"`{kernelName}` has an empty command")
   if cfg.enable_nanoda?.getD false then
-    let whichNanoda := nanodaOverride?.getD defaultNanoda
-    externalKernels := externalKernels.insert "nanoda" #[whichNanoda]
-  else if let some nanodaOverride := nanodaOverride? then
-    externalKernels := externalKernels.modify "nanoda" fun cmd => cmd.set! 0 nanodaOverride
+    externalKernels := externalKernels.insert "nanoda" #["nanoda_bin"]
+  for (kernelName, kernelCommand) in externalKernels do
+    if (← whichExe kernelCommand[0]!).isNone then
+      return .error (← cannotRun s!"`{kernelName}` kernel `{kernelCommand[0]!}` was not found")
+  return .ok externalKernels
 
-  ReaderT.run x {
-    projectDir := cwd
-    challengeModule := cfg.challenge_module.toName,
-    solutionModule := cfg.solution_module.toName,
-    theoremNames := cfg.theorem_names.map String.toName,
-    definitionNames := cfg.definition_names.getD #[] |>.map String.toName,
-    legalAxioms := cfg.permitted_axioms.map String.toName,
-    leanPrefix := leanPrefix,
-    gitLocation := gitLocation,
-    whichLean4Export := whichLean4Export,
-    whichLandrun := whichLandrun,
-    externalKernels := externalKernels
-  }
+/--
+Runs `lake challenge`: builds and exports the challenge and the solution in a sandbox, then judges
+the solution against the challenge.
+-/
+public def runChallenge (configFile? : Option System.FilePath) (lean : LeanInstall)
+    (lake : LakeInstall) (projectDir : System.FilePath) (leanPath : String) : IO ExitCode := do
+  let base ←
+    match ← mkContext "challenge" lean lake projectDir leanPath with
+    | .error rc => return rc
+    | .ok ctx => pure ctx
+
+  let some configFile := configFile?
+    | return ← cannotRun "no challenge configuration given; pass `--config <file>`"
+  let contents ←
+    try IO.FS.readFile configFile
+    catch e => return ← cannotRun s!"could not read the configuration: {e}"
+  let cfg ←
+    match Lean.Json.parse contents >>= Lean.fromJson? (α := Config) with
+    | .error e => return ← cannotRun s!"malformed configuration in '{configFile}': {e}"
+    | .ok cfg => pure cfg
+
+  let theoremNames := cfg.theorem_names.map String.toName
+  let definitionNames := cfg.definition_names.getD #[] |>.map String.toName
+  if theoremNames.isEmpty && definitionNames.isEmpty then
+    return ← cannotRun "nothing to check: the configuration names no theorems or definitions"
+  let externalKernels ←
+    match ← resolveExternalKernels cfg with
+    | .error rc => return rc
+    | .ok ks => pure ks
+
+  try
+    ReaderT.run compareIt { base with
+      challengeModule := cfg.challenge_module.toName,
+      solutionModule := cfg.solution_module.toName,
+      theoremNames,
+      definitionNames,
+      legalAxioms := cfg.permitted_axioms.map String.toName,
+      externalKernels
+    }
+    return 0
+  catch e =>
+    IO.eprintln s!"error: {e}"
+    return 1
 
 end Lake.Check

--- a/src/lake/Lake/CLI/Check.lean
+++ b/src/lake/Lake/CLI/Check.lean
@@ -1,0 +1,378 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Henrik Böving
+-/
+module
+
+prelude
+public import Lake.Check.Axioms
+public import Lake.Check.Compare
+public import Lean.Data.Json.FromToJson
+import Lean.Environment
+import Lean.Replay
+import Init.Data.ToString.Macro
+import Init.System.IO
+
+/-!
+# Judging Lean code against the kernel, and against a challenge
+
+Builds and exports Lean code, then establishes that it is accepted by the kernel and, where there
+is a challenge to compare against, that it proves the challenge's statements using no axiom outside
+a whitelist. This backs `lake challenge` and `lake check`.
+
+The code being judged is adversarial input: it is built and exported inside a `landrun` sandbox,
+and no `.olean` produced from it is ever mapped into this process. Only the resulting NDJSON export
+crosses the boundary.
+-/
+
+namespace Lake.Check
+
+public structure Context where
+  projectDir : System.FilePath
+  challengeModule : Lean.Name
+  solutionModule : Lean.Name
+  theoremNames : Array Lean.Name
+  definitionNames : Array Lean.Name
+  legalAxioms : Array Lean.Name
+  leanPrefix : System.FilePath
+  gitLocation : System.FilePath
+  whichLandrun : String
+  whichLean4Export : String
+  externalKernels : (Std.TreeMap String (Array String))
+
+public abbrev M := ReaderT Context IO
+
+structure LandrunArgs where
+  cmd : String
+  args : Array String
+  envPass : Array String
+  envOverride : Array (String × Option String) := #[]
+  readablePaths : Array System.FilePath
+  writablePaths : Array System.FilePath
+  executablePaths : Array System.FilePath
+
+@[inline]
+def getExternalKernels : M (Std.TreeMap String (Array String)) := do return (← read).externalKernels
+
+@[inline]
+def getTheoremNames : M (Array Lean.Name) := do return (← read).theoremNames
+
+@[inline]
+def getDefinitionNames : M (Array Lean.Name) := do return (← read).definitionNames
+
+@[inline]
+def getProjectDir : M System.FilePath := do return (← read).projectDir
+
+@[inline]
+def getChallengeModule : M Lean.Name := do return (← read).challengeModule
+
+@[inline]
+def getSolutionModule : M Lean.Name := do return (← read).solutionModule
+
+@[inline]
+def getLegalAxioms : M (Array Lean.Name) := do return (← read).legalAxioms
+
+@[inline]
+def getLeanPrefix : M System.FilePath := do return (← read).leanPrefix
+
+@[inline]
+def getGitLocation : M System.FilePath := do return (← read).gitLocation
+
+def queryGitLocation : IO System.FilePath := do
+  let out ← IO.Process.run {
+    cmd := "which",
+    args := #["git"],
+    stdout := .piped,
+  }
+  return out.trimAscii.toString
+
+def queryLeanPrefix (projectDir : System.FilePath) : IO System.FilePath := do
+  let out ← IO.Process.run {
+    cmd := "lean",
+    args := #["--print-prefix"],
+    stdout := .piped,
+    cwd := projectDir
+  }
+  return out.trimAscii.toString
+
+def buildLandrunArgs (spawnArgs : LandrunArgs) : Array String :=
+  let args := #["--best-effort", "--ro", "/", "--rw", "/dev", "-ldd", "-add-exec"]
+  let args := spawnArgs.envPass.foldl (init := args) (fun acc env => acc ++ #["--env", env])
+  let args := spawnArgs.readablePaths.foldl (init := args) (fun acc path => acc ++ #["--ro", path.toString])
+  let args := spawnArgs.writablePaths.foldl (init := args) (fun acc path => acc ++ #["--rwx", path.toString])
+  let args := spawnArgs.executablePaths.foldl (init := args) (fun acc path => acc ++ #["--rox", path.toString])
+  args ++ #["--", spawnArgs.cmd] ++ spawnArgs.args
+
+def runSandBoxedWithStdout (spawnArgs : LandrunArgs) : M String := do
+  let args := buildLandrunArgs spawnArgs
+  let { stdout, stderr, exitCode } ← IO.Process.output {
+    cmd := (← read).whichLandrun,
+    args,
+    env := spawnArgs.envOverride
+    cwd := (← getProjectDir)
+  }
+  IO.eprint stderr
+  if exitCode != 0 then
+    throw <| .userError s!"Child exited with {exitCode}"
+  return stdout
+
+
+def runSandBoxed (spawnArgs : LandrunArgs) : M Unit := do
+  let args := buildLandrunArgs spawnArgs
+  let proc ← IO.Process.spawn {
+    cmd := (← read).whichLandrun,
+    args,
+    env := spawnArgs.envOverride
+    cwd := (← getProjectDir)
+  }
+  let ret ← proc.wait
+  if ret != 0 then
+    throw <| .userError s!"Child exited with {ret}"
+
+def safeLakeBuild (target : Lean.Name) : M Unit := do
+  IO.println s!"Building {target}"
+  let leanPrefix ← getLeanPrefix
+  let projectDir ← getProjectDir
+  let dotLakeDir := projectDir / ".lake"
+  let gitLocation ← getGitLocation
+
+  if !(← System.FilePath.pathExists dotLakeDir) then
+    IO.FS.createDir dotLakeDir
+
+  runSandBoxed {
+    cmd := "lake",
+    args := #["build", target.toString],
+    envPass := #["PATH", "HOME", "LEAN_ABORT_ON_PANIC"]
+    envOverride := #[("LEAN_ABORT_ON_PANIC", some "1")]
+    readablePaths := #[projectDir]
+    writablePaths := #[dotLakeDir]
+    executablePaths := #[leanPrefix, gitLocation]
+  }
+
+def safeExport (module : Lean.Name) (decls : Array Lean.Name) : M String := do
+  IO.println s!"Exporting {decls} from {module}"
+  let baseArgs := #[module.toString, "--"]
+  let args := decls.foldl (·.push <| ·.toString) baseArgs
+
+  let leanPrefix ← getLeanPrefix
+  let projectDir ← getProjectDir
+  let dotLakeDir := projectDir / ".lake"
+  runSandBoxedWithStdout {
+    cmd := (← read).whichLean4Export
+    args := args,
+    envPass := #["PATH", "HOME", "LEAN_PATH", "LEAN_ABORT_ON_PANIC"]
+    envOverride := #[("LEAN_ABORT_ON_PANIC", some "1")]
+    readablePaths := #[projectDir, dotLakeDir]
+    writablePaths := #[]
+    executablePaths := #[leanPrefix]
+  }
+
+def runExternalKernel (kernelName : String) (kernelCommand : Array String)
+    (solutionExport : String) : M (Option String) := do
+  IO.println s!"Running {kernelName} kernel on solution"
+  -- just always put out a nanoda-like config file for now
+  IO.FS.withTempFile fun configHandle configPath => do
+  IO.FS.withTempFile fun solutionHandle solutionPath => do
+    let legalAxioms ← getLegalAxioms
+    configHandle.putStr <| Lean.Json.compress <| Lean.Json.mkObj [
+      ("use_stdin", false),
+      ("export_file_path", solutionPath.toString),
+      ("permitted_axioms", .arr <| legalAxioms.map (.str ∘ Lean.Name.toString)),
+      ("unpermitted_axiom_hard_error", true),
+      ("num_threads", 4),
+      ("nat_extension", true),
+      ("string_extension", true),
+    ]
+    configHandle.flush
+
+    solutionHandle.putStr solutionExport
+    solutionHandle.flush
+
+    let mut kernelArgs := kernelCommand[1...*].toArray
+    if isNanodaKernel kernelName then
+      kernelArgs := kernelArgs.push configPath.toString
+    else
+      kernelArgs := kernelArgs.push solutionPath.toString
+
+    let spawnArgs := {
+      cmd := kernelCommand[0]!,
+      args := kernelArgs,
+      envPass := #[]
+      readablePaths := #[configPath.toString, solutionPath.toString]
+      writablePaths := #[]
+      executablePaths := #[]
+    }
+    let args := buildLandrunArgs spawnArgs
+
+    try
+      let proc ← IO.Process.spawn {
+        cmd := (← read).whichLandrun,
+        args,
+        env := spawnArgs.envOverride
+        cwd := (← getProjectDir)
+      }
+
+      let ret ← proc.wait
+      if ret != 0 then
+        IO.println s!"{kernelName} kernel rejected the solution"
+        return some s!"{kernelName} exited with {ret}"
+      else
+        IO.println s!"{kernelName} kernel accepts the solution"
+        return none
+    catch e => do
+      IO.println s!"Error while interacting with {kernelName} kernel"
+      return some s!"Error while interacting with {kernelName} kernel: {e.toString}"
+where
+  isNanodaKernel (kernelName : String) : Bool :=
+    -- TODO: get rid of this heuristic
+    kernelName.contains "noda"
+
+def runBuiltinKernel (solution : LeanExport.ExportedEnv) : M (Option String) := do
+  IO.println "Running Lean default kernel on solution."
+  let env ← Lean.mkEmptyEnvironment
+  let mut kernelEnv := env.toKernelEnv
+  let origConstMap := solution.constMap
+  -- Lean's kernel interprets just the addition of `Quot as adding all of these so adding them
+  -- multiple times leads to errors.
+  let quotTargets := [`Quot.mk, `Quot.lift, `Quot.ind]
+  let kernelConstMap := quotTargets.foldl (init := origConstMap) (·.erase ·)
+  try
+    kernelEnv ← kernelEnv.replay kernelConstMap
+    IO.println "Lean default kernel accepts the solution"
+  catch e =>
+    IO.println "Lean default kernel rejects the solution"
+    return some e.toString
+
+  try
+    let verifyTargets := `Quot :: quotTargets
+    for quotTarget in verifyTargets do
+      if let some info := origConstMap[quotTarget]? then
+        let some info' := kernelEnv.find? quotTarget |
+          throw <| .userError s!"Could not find quotient constant in final kernel env: {quotTarget}"
+        if info != info' then
+          throw <| .userError s!"Quotient constant mismatch on: {quotTarget}"
+    return none
+  catch e =>
+    IO.println "Quotient post-check rejects the solution"
+    return some e.toString
+
+def primitiveTargets : M (Array Lean.Name) := do
+  -- The challenge needs to have all the built-in constants of the kernel, as the
+  -- kernel makes no guarantees when fed other definitions here.
+  -- List from `git grep new_persistent_expr_const src/kernel/`
+  return #[
+    -- ``Nat.zero,
+    -- ``Nat.succ,
+    ``Nat.add,
+    ``Nat.sub,
+    ``Nat.mul,
+    ``Nat.pow,
+    ``Nat.gcd,
+    ``Nat.div,
+    ``Nat.mod,
+    ``Nat.beq,
+    ``Nat.ble,
+    ``Nat.land,
+    ``Nat.lor,
+    ``Nat.xor,
+    ``Nat.shiftLeft,
+    ``Nat.shiftRight,
+    ``String.ofList,
+    ``Char.ofNat,
+    ``List,
+    ``eagerReduce,
+  ]
+
+def builtinTargets : M (Array Lean.Name) := do
+  let mut additional := #[``Nat, ``String, ``String.mk, ``Char]
+  if (← getLegalAxioms).contains ``Quot.sound then
+    additional := additional ++ #[``Quot, ``Quot.mk, ``Quot.lift, ``Quot.ind]
+  return additional
+
+def stringStream (s : String) : BaseIO IO.FS.Stream := do
+  let ref ← IO.mkRef {
+    data := s.toByteArray
+  }
+  return IO.FS.Stream.ofBuffer ref
+
+def verifyMatch (challengeExport : String) (solutionExport : String) :
+    M Unit := do
+  let challenge ← LeanExport.parseStream (← stringStream challengeExport)
+  let solution ← LeanExport.parseStream (← stringStream solutionExport)
+  let theoremNames ← getTheoremNames
+  let definitionNames ← getDefinitionNames
+  let targets := (← getTheoremNames) ++ (← getLegalAxioms)
+  IO.ofExcept <| compareAt challenge solution targets definitionNames (← primitiveTargets)
+  IO.ofExcept <| checkAxioms solution theoremNames definitionNames (← getLegalAxioms)
+  let mut result := none
+  for (kernelName, kernelCommand) in ← getExternalKernels do
+    result := result <|> (← runExternalKernel kernelName kernelCommand solutionExport)
+  result := result <|> (← runBuiltinKernel solution)
+  if let some error := result then
+    throw <| IO.userError error
+
+public def compareIt : M Unit := do
+  let exportTargets := (← builtinTargets) ++ (← getTheoremNames) ++ (← getLegalAxioms)
+    ++ (← primitiveTargets) ++ (← getDefinitionNames)
+
+  let challengeModule ← getChallengeModule
+  safeLakeBuild challengeModule
+  let challengeExport ← safeExport challengeModule exportTargets
+
+  let solutionModule ← getSolutionModule
+  safeLakeBuild solutionModule
+  let solutionExport ← safeExport solutionModule exportTargets
+
+  verifyMatch challengeExport solutionExport
+
+  IO.println "Your solution is okay!"
+
+public structure Config where
+  challenge_module : String
+  solution_module : String
+  theorem_names : Array String
+  definition_names : Option (Array String) := none
+  permitted_axioms : Array String
+  enable_nanoda? : Option Bool
+  external_kernels? : Option (Std.TreeMap String (Array String))
+  deriving Lean.FromJson, Lean.ToJson, Repr
+
+public def M.run (x : M α) (cfg : Config) : IO α := do
+  let cwd ← IO.Process.getCurrentDir
+  let leanPrefix ← queryLeanPrefix cwd
+  let gitLocation ← queryGitLocation
+  let whichLean4Export := (← IO.getEnv "COMPARATOR_LEAN4EXPORT").getD "lean4export"
+  let whichLandrun := (← IO.getEnv "COMPARATOR_LANDRUN").getD "landrun"
+  let mut externalKernels := cfg.external_kernels?.getD {}
+  let defaultNanoda := "nanoda_bin"
+  let nanodaOverride? ← IO.getEnv "COMPARATOR_NANODA"
+
+  if cfg.enable_nanoda?.getD false && !externalKernels.isEmpty then
+    throw <| .userError "Cannot use enable_nanoda and an external kernel list at the same time, register nanoda in the list instead."
+
+  for (kernelName, kernelCommand) in externalKernels do
+    if kernelCommand.isEmpty then
+      throw <| .userError s!"{kernelName} has an empty command"
+
+  if cfg.enable_nanoda?.getD false then
+    let whichNanoda := nanodaOverride?.getD defaultNanoda
+    externalKernels := externalKernels.insert "nanoda" #[whichNanoda]
+  else if let some nanodaOverride := nanodaOverride? then
+    externalKernels := externalKernels.modify "nanoda" fun cmd => cmd.set! 0 nanodaOverride
+
+  ReaderT.run x {
+    projectDir := cwd
+    challengeModule := cfg.challenge_module.toName,
+    solutionModule := cfg.solution_module.toName,
+    theoremNames := cfg.theorem_names.map String.toName,
+    definitionNames := cfg.definition_names.getD #[] |>.map String.toName,
+    legalAxioms := cfg.permitted_axioms.map String.toName,
+    leanPrefix := leanPrefix,
+    gitLocation := gitLocation,
+    whichLean4Export := whichLean4Export,
+    whichLandrun := whichLandrun,
+    externalKernels := externalKernels
+  }
+
+end Lake.Check

--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -30,6 +30,7 @@ COMMANDS:
   check-lint            check if there is a properly configured lint driver
   clean                 remove build outputs
   shake                 minimize imports in source files
+  challenge             judge a solution against a challenge
   env <cmd> <args>...   execute a command in Lake's environment
   lean <file>           elaborate a Lean file in Lake's context
   update                update dependencies and save them to the manifest
@@ -395,6 +396,72 @@ ANNOTATIONS:
 
   * `import X -- shake: keep`
     Preserves this specific import"
+
+def helpChallenge :=
+"Judge a solution against a challenge
+
+USAGE:
+  lake challenge --config <FILE>
+
+Establishes that every named theorem in the solution proves the same statement
+as the challenge, uses no axiom outside the permitted list, and is accepted by
+the kernel.
+
+The solution is untrusted input: it is built and exported inside a `landrun`
+sandbox, and none of its `.olean` files is ever loaded into Lake's own address
+space. `landrun` is required; there is no unsandboxed mode, so this command is
+available on Linux only.
+
+OPTIONS:
+  --config=<file>       JSON file describing the challenge (see below)
+
+CONFIGURATION:
+  The challenge author writes the file and distributes it with the project, so
+  that a solver need only point `lake challenge` at it:
+
+  {
+    \"challenge_module\": \"Challenge\",
+    \"solution_module\": \"Solution\",
+    \"theorem_names\": [\"imo2024_p1\"],
+    \"definition_names\": [],
+    \"permitted_axioms\": [\"propext\", \"Quot.sound\", \"Classical.choice\"],
+    \"external_kernels\": {\"nanoda\": [\"nanoda_bin\"]}
+  }
+
+  `challenge_module`, `solution_module`, `theorem_names` and
+  `permitted_axioms` are required; the rest may be omitted.
+  `definition_names` lists the challenge's definition holes.
+  `permitted_axioms` is deliberately not defaulted: it is what the verdict
+  means, so the challenge author states it. The three above are the ones
+  `#print axioms` treats as a clean proof.
+
+  `external_kernels` names additional checkers to run over the export, each as
+  the command to execute; the solution must satisfy every one of them as well
+  as Lean's own kernel. `enable_nanoda: true` is still accepted and is
+  equivalent to a \"nanoda\" entry of [\"nanoda_bin\"]; name the command in
+  `external_kernels` instead to run it from elsewhere.
+
+EXIT CODES:
+  0                     accepted
+  1                     rejected: statement mismatch, forbidden axiom, kernel
+                        rejection, or a build that did not succeed
+  2                     could not start: `landrun` is missing, or the
+                        configuration is missing, unreadable or malformed
+
+ENVIRONMENT:
+  COMPARATOR_LANDRUN    sandbox executable (default: `landrun` on PATH)
+
+  The exporter is always the `leanexport` of this toolchain, and deliberately
+  not configurable: the export format has to match the compiler that produced
+  the `.olean` files being exported.
+
+HARDENING:
+  Until the Landlock fix released in Linux 7.1 is widely available, `landrun`
+  can be escaped through an `AF_UNIX` socket. Where that matters, run the
+  command under a wrapper that removes the capability:
+
+    systemd-run --user --pty --property=RestrictAddressFamilies=~AF_UNIX \\
+      lake challenge --config challenge.json"
 
 def helpCacheCli :=
 "Manage the Lake cache
@@ -780,6 +847,7 @@ public def help : (cmd : String) → String
 | "check-lint"          => helpCheckLint
 | "clean"               => helpClean
 | "shake"               => helpShake
+| "challenge"           => helpChallenge
 | "script"              => helpScriptCli
 | "scripts"             => helpScriptList
 | "run"                 => helpScriptRun

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -10,6 +10,7 @@ public import Lake.Util.Exit
 public import Lake.Load.Config
 public import Lake.CLI.Error
 public import Lake.CLI.Shake
+public import Lake.CLI.Check
 import Lake.Version
 import Lake.Build.Run
 import Lake.Build.Targets
@@ -77,6 +78,7 @@ public structure LakeOptions where
   rev? : Option GitRev := none
   maxRevs : Nat := 100
   shake : Shake.Args := {}
+  challengeConfig? : Option FilePath := none
   builtinLint : BuiltinLint.Args := {}
   /-- Whether `lake lint` should also run builtin lints (via `--builtin-lint`). -/
   runBuiltinLint : Bool := false
@@ -397,6 +399,10 @@ def lakeLongOption : (opt : String) → CliM PUnit
   let mod ← takeOptArg "--only" "minimize only this module"
   modifyThe LakeOptions fun opts =>
     {opts with shake.onlyMods := opts.shake.onlyMods.push mod.toName}
+-- Challenge options
+| "--config" => do
+  let file ← takeOptArg "--config" "path"
+  modifyThe LakeOptions ({· with challengeConfig? := some file})
 | opt             =>  throw <| CliError.unknownLongOption opt
 
 def lakeOption :=
@@ -1159,6 +1165,18 @@ protected def shake : CliM PUnit := do
   if exitCode != 0 then
     exit exitCode
 
+/-- The `lake challenge` command: judge a solution against a challenge. -/
+protected def challenge : CliM PUnit := do
+  processOptions lakeOption
+  let opts ← getThe LakeOptions
+  noArgsRem do
+  let (leanInstall, lakeInstall) ← opts.getInstall
+  -- Loading the workspace resolves dependencies and yields the `LEAN_PATH` the exporter needs;
+  -- the sandboxed builds would otherwise have to write the manifest into a read-only project.
+  let ws ← loadWorkspace (← mkLoadConfig opts)
+  exit <| ← Check.runChallenge opts.challengeConfig? leanInstall lakeInstall ws.root.dir
+    ws.augmentedLeanPath.toString
+
 protected def script : CliM PUnit := do
   if let some cmd ← takeArg? then
     processLeadingOptions lakeOption -- between `lake script <cmd>` and args
@@ -1314,6 +1332,7 @@ def lakeCli : (cmd : String) → CliM PUnit
 | "check-lint"          => lake.checkLint
 | "clean"               => lake.clean
 | "shake"               => lake.shake
+| "challenge"           => lake.challenge
 | "script"              => lake.script
 | "scripts"             => lake.script.list
 | "run"                 => lake.script.run

--- a/src/lake/Lake/Check/Axioms.lean
+++ b/src/lake/Lake/Check/Axioms.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Henrik Böving
+-/
+module
+
+prelude
+public import LeanExport.Parse
+import Lake.Check.Util
+import Init.Data.ToString.Macro
+import Std.Data.HashSet
+
+namespace Lake.Check
+
+namespace Axioms
+
+structure Context where
+  solution : LeanExport.ExportedEnv
+  legalAxioms : Std.HashSet Lean.Name
+
+structure State where
+  worklist : Array Lean.Name
+  checked : Std.HashSet Lean.Name
+
+abbrev AxiomsM := ReaderT Context <| StateT State <| Except String
+
+partial def loop : AxiomsM Unit := do
+  if (← get).worklist.isEmpty then
+    return ()
+
+  let target ← modifyGet fun s => (s.worklist.back!, { s with worklist := s.worklist.pop })
+  if (← get).checked.contains target then
+    loop
+  else
+    let some info := (← read).solution.constMap[target]?
+      | throw s!"Constant not found in solution '{target}'"
+
+    runForUsedConsts info validateConst
+
+    modify fun s => { s with checked := s.checked.insert target }
+    loop
+where
+  validateConst (n : Lean.Name) : AxiomsM Unit := do
+    let some info := (← read).solution.constMap[n]?
+      | throw s!"Constant not found in solution '{n}'"
+
+    if let .axiomInfo info := info then
+      if !(← read).legalAxioms.contains info.name then
+        throw s!"Illegal axiom detected: '{n}'"
+
+    if !(← get).checked.contains n then
+      modify fun s => { s with worklist := s.worklist.push n }
+
+end Axioms
+
+public def checkAxioms (solution : LeanExport.ExportedEnv) (theoremTargets : Array Lean.Name)
+    (definitionTargets : Array Lean.Name) (legalAxioms : Array Lean.Name) : Except String Unit := do
+  let mut worklist := #[]
+  for target in theoremTargets do
+    let some solutionConst := solution.constMap[target]?
+      | throw s!"Const not found in solution: '{target}'"
+    let .thmInfo solutionConst := solutionConst
+      | throw s!"Solution constant is not a theorem: '{target}'"
+    worklist := worklist.push solutionConst.name
+
+  for target in definitionTargets do
+    let some solutionConst := solution.constMap[target]?
+      | throw s!"Const not found in solution: '{target}'"
+    let .defnInfo solutionConst := solutionConst
+      | throw s!"Solution constant is not a definition: '{target}'"
+    worklist := worklist.push solutionConst.name
+
+  let legalAxioms := Std.HashSet.ofArray legalAxioms
+  Axioms.loop.run { solution, legalAxioms } |>.run' { worklist, checked := {} }
+
+end Lake.Check

--- a/src/lake/Lake/Check/Compare.lean
+++ b/src/lake/Lake/Check/Compare.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Henrik Böving
+-/
+module
+
+prelude
+public import LeanExport.Parse
+import Lake.Check.Util
+import Init.Data.ToString.Macro
+import Std.Data.HashSet
+
+namespace Lake.Check
+
+namespace Compare
+
+structure Context where
+  challenge : LeanExport.ExportedEnv
+  solution : LeanExport.ExportedEnv
+  definitionTargets : Std.HashSet Lean.Name
+  theoremTargets : Std.HashSet Lean.Name
+
+structure State where
+  worklist : Array Lean.Name
+  checked : Std.HashSet Lean.Name
+
+abbrev CompareM := ReaderT Context <| StateT State <| Except String
+
+deriving instance BEq for Lean.QuotKind
+deriving instance BEq for Lean.QuotVal
+deriving instance BEq for Lean.InductiveVal
+deriving instance BEq for Lean.ConstantInfo
+
+def addWorklist (n : Lean.Name) : CompareM Unit := do
+  if !(← get).checked.contains n then
+    modify fun s => { s with worklist := s.worklist.push n }
+
+def addRelevantConsts (info : Lean.ConstantInfo) : CompareM Unit := do
+  runForUsedConsts info addWorklist
+
+partial def loop : CompareM Unit := do
+  if (← get).worklist.isEmpty then
+    return ()
+
+  let target ← modifyGet fun s => (s.worklist.back!, { s with worklist := s.worklist.pop })
+  if (← get).checked.contains target then
+    loop
+  else
+    let some challengeConst := (← read).challenge.constMap[target]?
+      | throw s!"Const not found in challenge '{target}'"
+    let some solutionConst := (← read).solution.constMap[target]?
+      | throw s!"Const not found in solution '{target}'"
+
+    if (← read).definitionTargets.contains solutionConst.name
+        || (← read).theoremTargets.contains solutionConst.name then
+      solutionConst.type.getUsedConstants.forM addWorklist
+    else
+      if challengeConst != solutionConst then
+        throw s!"Const does not match between challenge and target '{target}'"
+      addRelevantConsts solutionConst
+
+    modify fun s => { s with checked := s.checked.insert target }
+    loop
+
+end Compare
+
+public def definitionHoleMatches (challengeHole solutionHole : Lean.DefinitionVal) : Bool :=
+  challengeHole.toConstantVal == solutionHole.toConstantVal
+    && challengeHole.safety == solutionHole.safety
+
+public def compareAt (challenge solution : LeanExport.ExportedEnv) (theoremTargets : Array Lean.Name)
+    (definitionTargets : Array Lean.Name) (primitive : Array Lean.Name) : Except String Unit := do
+  let mut worklist := primitive
+
+  for target in theoremTargets do
+    let some challengeConst := challenge.constMap[target]?
+      | throw s!"Const not found in challenge: '{target}'"
+
+    let some solutionConst := solution.constMap[target]?
+      | throw s!"Const not found in solution: '{target}'"
+
+    let (challengeConst, solutionConst) ←
+      match challengeConst, solutionConst with
+      | .thmInfo cc, .thmInfo sc
+      | .axiomInfo cc, .axiomInfo sc => pure (cc.toConstantVal, sc.toConstantVal)
+      | _, _ => throw s!"Challenge and solution constant kind don't match: '{target}'"
+
+    if challengeConst != solutionConst then
+      throw s!"Challenge and solution theorem statement do not match: '{target}'"
+
+    worklist := worklist ++ challengeConst.type.getUsedConstants
+
+  for target in definitionTargets do
+    let some challengeConst := challenge.constMap[target]?
+      | throw s!"Const not found in challenge: '{target}'"
+
+    let some solutionConst := solution.constMap[target]?
+      | throw s!"Const not found in solution: '{target}'"
+
+    let .defnInfo challengeConst := challengeConst
+      | throw s!"Challenge constant is not a definition: '{target}'"
+    let .defnInfo solutionConst := solutionConst
+      | throw s!"Solution constant is not a definition: '{target}'"
+
+    if !definitionHoleMatches challengeConst solutionConst then
+      throw s!"Const does not match between challenge and target '{target}'"
+
+    worklist := worklist.push solutionConst.name
+
+  let definitionTargets := Std.HashSet.ofArray definitionTargets
+  let theoremTargets := Std.HashSet.ofArray theoremTargets
+  Compare.loop.run { challenge, solution, definitionTargets, theoremTargets } |>.run' { worklist, checked := {} }
+
+end Lake.Check

--- a/src/lake/Lake/Check/Util.lean
+++ b/src/lake/Lake/Check/Util.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Henrik Böving
+-/
+module
+
+prelude
+public import Lean.Declaration
+public import Lean.Util.FoldConsts
+
+namespace Lake.Check
+
+public def runForUsedConsts [Monad m] (info : Lean.ConstantInfo) (f : Lean.Name → m Unit) : m Unit := do
+  info.type.getUsedConstants.forM f
+  f info.name
+  if let some val := info.value? (allowOpaque := true) then
+    val.getUsedConstants.forM f
+
+  match info with
+  | .axiomInfo .. | .quotInfo .. | .defnInfo .. | .thmInfo .. | .opaqueInfo .. => return ()
+  | .inductInfo info =>
+    info.ctors.forM f
+    info.all.forM f
+  | .ctorInfo info =>
+    f info.induct
+  | .recInfo info =>
+    info.rules.forM fun rule => do
+      f rule.ctor
+      rule.rhs.getUsedConstants.forM f
+
+end Lake.Check

--- a/src/lakefile.toml.in
+++ b/src/lakefile.toml.in
@@ -8,7 +8,7 @@
 name = "lean4"
 bootstrap = true
 
-defaultTargets = ["Init", "Std", "Lean", "Lake", "LakeMain", "LeanIR", "Leanc", "LeanChecker"]
+defaultTargets = ["Init", "Std", "Lean", "LeanExport", "Lake", "LakeMain", "LeanIR", "Leanc", "LeanChecker"]
 
 # Have Lake use CMake's build type (e.g., `Release`, `Debug`) where possible
 buildType = "${CMAKE_BUILD_TYPE_TOML}"
@@ -76,6 +76,12 @@ globs = [
   # New compiler orphan file used in tests
   "Lean.Compiler.LCNF.Probing",
 ]
+
+[[lean_lib]]
+name = "LeanExport"
+globs = ["LeanExport.*"]
+# `Lake` links the parser into `libLake_shared`, so the export facet is required as well
+defaultFacets = ["static", "static.export"]
 
 [[lean_lib]]
 name = "Lake"

--- a/src/stdlib.make.in
+++ b/src/stdlib.make.in
@@ -48,7 +48,7 @@ ifeq "${STAGE}" "0"
 endif
 
 # These can be phony since the inner Makefile/Lake will have the correct dependencies and avoid rebuilds
-.PHONY: Init Std Lean leanshared Lake libLake_shared lake lean LeanChecker leanchecker leanchecker-paranoid LeanIR
+.PHONY: Init Std Lean leanshared Lake libLake_shared lake lean LeanChecker leanchecker leanchecker-paranoid LeanIR LeanExport leanexport
 
 ifeq "${USE_LAKE}" "ON"
 
@@ -56,7 +56,7 @@ ifeq "${USE_LAKE}" "ON"
 Init:
 	LEAN_GITHASH=${LAKE_LEAN_GITHASH} ${PREV_STAGE}/bin/lake build -f ${CMAKE_BINARY_DIR}/lakefile.toml ${LEAN_EXTRA_LAKE_OPTS} $(LAKE_EXTRA_ARGS)
 
-Std Lean Lake Leanc LeanChecker LeanIR: Init
+Std Lean LeanExport Lake Leanc LeanChecker LeanIR: Init
 
 else
 
@@ -78,7 +78,10 @@ ifneq "${STAGE}" "0"
 	+"${LEAN_BIN}/leanmake" -C "${CMAKE_BINARY_DIR}/leanc" lib PKG=Leanc $(LEANMAKE_OPTS) OUT="$(OUTARC)" LIB_OUT="$(OUTARC)" OLEAN_OUT="$(OUTARC)"
 endif
 
-Lake: Lean
+LeanExport: Lean
+	+"${LEAN_BIN}/leanmake" lib lib.export PKG=LeanExport $(LEANMAKE_OPTS) OUT="$(OUTARC)" LIB_OUT="$(OUTARC)" TEMP_OUT="${LIB}/temp" OLEAN_OUT="$(OUTARC)"
+
+Lake: LeanExport
 # lake is in its own subdirectory, so must adjust relative paths...
 	+"${LEAN_BIN}/leanmake" -C lake lib lib.export ../${LIB}/temp/LakeMain.o.export  PKG=Lake $(LEANMAKE_OPTS) OUT="../${LIB}" LIB_OUT="../${LIB}/lean" TEMP_OUT="../${LIB}/temp" OLEAN_OUT="../${LIB}/lean" EXTRA_SRC_ROOTS=LakeMain.lean
 
@@ -99,12 +102,13 @@ ${LIB}/temp/empty.c:
 ifeq "${USE_LAKE}" "ON"
 $(OUTLIB)/libInit_shared$(SO): ${LIB}/lean/libInit.a.export.trace ${LIB}/lean/libStd.a.export.trace
 $(OUTLIB)/libleanshared$(SO): ${LIB}/lean/libLean.a.export.trace
-$(OUTLIB)/libLake_shared$(SO): ${LIB}/lean/libLean.a.export.trace ${LIB}/lean/libLake.a.export.trace
+$(OUTLIB)/libLake_shared$(SO): ${LIB}/lean/libLean.a.export.trace ${LIB}/lean/libLake.a.export.trace ${LIB}/lean/libLeanExport.a.export.trace
 $(OUTBIN)/lake$(EXE): ${LIB}/temp/LakeMain.c.o.export.trace
 $(OUTBIN)/leanc$(EXE): $(OUTARC)/libLeanc.a.trace
 $(OUTBIN)/leanir$(EXE): $(OUTARC)/libLeanIR.a.trace
 $(OUTBIN)/leanchecker$(EXE): $(OUTARC)/libLeanChecker.a.trace
 $(OUTBIN)/leanchecker-paranoid$(EXE): $(OUTARC)/libLeanChecker.a.trace ${LIB}/lean/libInit.a.trace ${LIB}/lean/libStd.a.trace ${LIB}/lean/libLean.a.trace ${LIB}/lean/libLake.a.trace
+$(OUTBIN)/leanexport$(EXE): $(OUTARC)/libLeanExport.a.trace
 endif
 
 # we specify the precise file names here to avoid rebuilds
@@ -173,7 +177,7 @@ endif
 
 leanshared: $(OUTLIB)/libleanshared$(SO)
 
-$(OUTLIB)/libLake_shared$(SO): $(OUTLIB)/libInit_shared$(SO) $(OUTLIB)/libleanshared_2$(SO) $(OUTLIB)/libleanshared_1$(SO) $(OUTLIB)/libleanshared$(SO) ${LIB}/lean/libLean.a.export ${LIB}/lean/libLake.a.export
+$(OUTLIB)/libLake_shared$(SO): $(OUTLIB)/libInit_shared$(SO) $(OUTLIB)/libleanshared_2$(SO) $(OUTLIB)/libleanshared_1$(SO) $(OUTLIB)/libleanshared$(SO) ${LIB}/lean/libLean.a.export ${LIB}/lean/libLake.a.export ${LIB}/lean/libLeanExport.a.export
 	$(link-preamble)
 	$(LEANC_SH) -shared -o $@ \
 	  ${LAKESHARED_LINKER_FLAGS} -lleanshared -lleanshared_2 -lleanshared_1 -lInit_shared ${TOOLCHAIN_SHARED_LINKER_FLAGS} ${LEANC_OPTS}
@@ -205,6 +209,12 @@ $(OUTBIN)/leanir$(EXE): $(OUTARC)/libLeanIR.a
 	"${CMAKE_BINARY_DIR}/leanc.sh" $< ${CMAKE_EXE_LINKER_FLAGS_MAKE} ${CMAKE_DYN_EXE_LINKER_FLAGS_MAKE} ${LEAN_EXE_LINKER_FLAGS} -o $@
 
 leanir: $(OUTBIN)/leanir$(EXE)
+
+$(OUTBIN)/leanexport$(EXE): $(OUTARC)/libLeanExport.a
+	$(link-preamble)
+	$(LEANC_SH) $< ${CMAKE_EXE_LINKER_FLAGS_MAKE} ${CMAKE_DYN_EXE_LINKER_FLAGS_MAKE} ${LEAN_EXE_LINKER_FLAGS} ${LEANC_OPTS} -o $@
+
+leanexport: $(OUTBIN)/leanexport$(EXE)
 
 $(OUTBIN)/leanchecker$(EXE): $(OUTARC)/libLeanChecker.a $(OUTLIB)/libLake_shared$(SO)
 	$(link-preamble)

--- a/tests/lake/lakefile.toml
+++ b/tests/lake/lakefile.toml
@@ -5,6 +5,14 @@ defaultTargets = ["Lake", "lake"]
 [[lean_lib]]
 name = "Lake"
 defaultFacets = ["shared"]
+# `Lake.Check` links the export parser, which lives beside `src/lake`
+needs = ["LeanExport"]
+
+[[lean_lib]]
+name = "LeanExport"
+srcDir = ".."
+globs = ["LeanExport.*"]
+defaultFacets = ["shared"]
 
 [[lean_exe]]
 name = "lake"

--- a/tests/lake/tests/challenge-bad-config/Challenge.lean
+++ b/tests/lake/tests/challenge-bad-config/Challenge.lean
@@ -1,0 +1,2 @@
+theorem comm (n m : Nat) : n + m = m + n := by
+  sorry

--- a/tests/lake/tests/challenge-bad-config/Solution.lean
+++ b/tests/lake/tests/challenge-bad-config/Solution.lean
@@ -1,0 +1,2 @@
+theorem comm (n m : Nat) : n + m = m + n := by
+  grind

--- a/tests/lake/tests/challenge-bad-config/clean.sh
+++ b/tests/lake/tests/challenge-bad-config/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/challenge-bad-config/incomplete.json
+++ b/tests/lake/tests/challenge-bad-config/incomplete.json
@@ -1,0 +1,1 @@
+{ "challenge_module": "Challenge" }

--- a/tests/lake/tests/challenge-bad-config/lakefile.toml
+++ b/tests/lake/tests/challenge-bad-config/lakefile.toml
@@ -1,0 +1,8 @@
+name = "checktest"
+version = "0.1.0"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Challenge"

--- a/tests/lake/tests/challenge-bad-config/malformed.json
+++ b/tests/lake/tests/challenge-bad-config/malformed.json
@@ -1,0 +1,1 @@
+{ "challenge_module": "Challenge",

--- a/tests/lake/tests/challenge-bad-config/test.sh
+++ b/tests/lake/tests/challenge-bad-config/test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+if [ "`uname`" != Linux ]; then
+  echo "Skipping test: lake challenge needs Linux Landlock"
+  exit 0
+fi
+
+# Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
+export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
+
+# A configuration that is not JSON at all.
+test_status_out 2 'malformed configuration' challenge --config malformed.json
+
+# A configuration that parses but leaves out a required key.
+test_status_out 2 'solution_module' challenge --config incomplete.json
+
+# A configuration that is not there.
+test_status_out 2 'could not read the configuration' challenge --config absent.json
+
+# No configuration at all.
+test_status_out 2 'pass `--config <file>`' challenge
+
+rm -f produced.out

--- a/tests/lake/tests/challenge-def-hole-axiom-issue/Challenge.lean
+++ b/tests/lake/tests/challenge-def-hole-axiom-issue/Challenge.lean
@@ -1,0 +1,3 @@
+def n : Nat := sorry
+
+theorem foo : n + 17 = 34 := sorry

--- a/tests/lake/tests/challenge-def-hole-axiom-issue/Solution.lean
+++ b/tests/lake/tests/challenge-def-hole-axiom-issue/Solution.lean
@@ -1,0 +1,9 @@
+-- Adversarial solution: hides `sorryAx` (an axiom that is NOT in permitted_axioms)
+-- inside the hole body. The kernel accepts the proof of `foo` because `n + 17`
+-- β-reduces to `17 + 17 = 34` regardless of which `Unit` argument is passed. The
+-- stored term for `foo` (written as `@Eq.refl Nat 34`) does not syntactically
+-- reference `n`, so without explicit hole-body axiom checking this illegal
+-- axiom usage would escape validation.
+noncomputable def n : Nat := (fun _ : Nat => 17) (sorryAx Nat false)
+
+theorem foo : n + 17 = 34 := @Eq.refl Nat 34

--- a/tests/lake/tests/challenge-def-hole-axiom-issue/clean.sh
+++ b/tests/lake/tests/challenge-def-hole-axiom-issue/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/challenge-def-hole-axiom-issue/config.json
+++ b/tests/lake/tests/challenge-def-hole-axiom-issue/config.json
@@ -1,0 +1,8 @@
+{
+    "challenge_module": "Challenge",
+    "solution_module": "Solution",
+    "theorem_names": ["foo"],
+    "definition_names": ["n"],
+    "permitted_axioms": ["propext", "Quot.sound", "Classical.choice"],
+    "enable_nanoda": false
+}

--- a/tests/lake/tests/challenge-def-hole-axiom-issue/lakefile.toml
+++ b/tests/lake/tests/challenge-def-hole-axiom-issue/lakefile.toml
@@ -1,0 +1,8 @@
+name = "checktest"
+version = "0.1.0"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Challenge"

--- a/tests/lake/tests/challenge-def-hole-axiom-issue/test.sh
+++ b/tests/lake/tests/challenge-def-hole-axiom-issue/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+if [ "`uname`" != Linux ]; then
+  echo "Skipping test: lake challenge needs Linux Landlock"
+  exit 0
+fi
+
+# Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
+export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
+
+test_status_out 1 "Illegal axiom detected: 'sorryAx'" challenge --config config.json
+
+rm -f produced.out

--- a/tests/lake/tests/challenge-def-hole-kind-mismatch/Challenge.lean
+++ b/tests/lake/tests/challenge-def-hole-kind-mismatch/Challenge.lean
@@ -1,0 +1,3 @@
+def n : Nat := sorry
+
+theorem foo : n + 17 = 34 := sorry

--- a/tests/lake/tests/challenge-def-hole-kind-mismatch/Solution.lean
+++ b/tests/lake/tests/challenge-def-hole-kind-mismatch/Solution.lean
@@ -1,0 +1,5 @@
+-- Solution tries to satisfy the hole with an axiom rather than a def.
+-- Should be rejected because the kind does not match.
+axiom n : Nat
+
+theorem foo : n + 17 = 34 := sorry

--- a/tests/lake/tests/challenge-def-hole-kind-mismatch/clean.sh
+++ b/tests/lake/tests/challenge-def-hole-kind-mismatch/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/challenge-def-hole-kind-mismatch/config.json
+++ b/tests/lake/tests/challenge-def-hole-kind-mismatch/config.json
@@ -1,0 +1,8 @@
+{
+    "challenge_module": "Challenge",
+    "solution_module": "Solution",
+    "theorem_names": ["foo"],
+    "definition_names": ["n"],
+    "permitted_axioms": ["propext", "Quot.sound", "Classical.choice"],
+    "enable_nanoda": false
+}

--- a/tests/lake/tests/challenge-def-hole-kind-mismatch/lakefile.toml
+++ b/tests/lake/tests/challenge-def-hole-kind-mismatch/lakefile.toml
@@ -1,0 +1,8 @@
+name = "checktest"
+version = "0.1.0"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Challenge"

--- a/tests/lake/tests/challenge-def-hole-kind-mismatch/test.sh
+++ b/tests/lake/tests/challenge-def-hole-kind-mismatch/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+if [ "`uname`" != Linux ]; then
+  echo "Skipping test: lake challenge needs Linux Landlock"
+  exit 0
+fi
+
+# Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
+export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
+
+test_status_out 1 "Solution constant is not a definition: 'n'" challenge --config config.json
+
+rm -f produced.out

--- a/tests/lake/tests/challenge-def-hole-type-mismatch/Challenge.lean
+++ b/tests/lake/tests/challenge-def-hole-type-mismatch/Challenge.lean
@@ -1,0 +1,3 @@
+def n : Nat := sorry
+
+theorem foo : 17 + 17 = 34 := sorry

--- a/tests/lake/tests/challenge-def-hole-type-mismatch/Solution.lean
+++ b/tests/lake/tests/challenge-def-hole-type-mismatch/Solution.lean
@@ -1,0 +1,5 @@
+-- Solution's hole has a different type; should be rejected even though the
+-- theorem body is `sorry`.
+def n : Int := 17
+
+theorem foo : 17 + 17 = 34 := sorry

--- a/tests/lake/tests/challenge-def-hole-type-mismatch/clean.sh
+++ b/tests/lake/tests/challenge-def-hole-type-mismatch/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/challenge-def-hole-type-mismatch/config.json
+++ b/tests/lake/tests/challenge-def-hole-type-mismatch/config.json
@@ -1,0 +1,8 @@
+{
+    "challenge_module": "Challenge",
+    "solution_module": "Solution",
+    "theorem_names": ["foo"],
+    "definition_names": ["n"],
+    "permitted_axioms": ["propext", "Quot.sound", "Classical.choice"],
+    "enable_nanoda": false
+}

--- a/tests/lake/tests/challenge-def-hole-type-mismatch/lakefile.toml
+++ b/tests/lake/tests/challenge-def-hole-type-mismatch/lakefile.toml
@@ -1,0 +1,8 @@
+name = "checktest"
+version = "0.1.0"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Challenge"

--- a/tests/lake/tests/challenge-def-hole-type-mismatch/test.sh
+++ b/tests/lake/tests/challenge-def-hole-type-mismatch/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+if [ "`uname`" != Linux ]; then
+  echo "Skipping test: lake challenge needs Linux Landlock"
+  exit 0
+fi
+
+# Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
+export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
+
+test_status_out 1 "Const does not match between challenge and target 'n'" challenge --config config.json
+
+rm -f produced.out

--- a/tests/lake/tests/challenge-def-hole/Challenge.lean
+++ b/tests/lake/tests/challenge-def-hole/Challenge.lean
@@ -1,0 +1,3 @@
+def n : Nat := sorry
+
+theorem foo : n + 17 = 34 := sorry

--- a/tests/lake/tests/challenge-def-hole/Solution.lean
+++ b/tests/lake/tests/challenge-def-hole/Solution.lean
@@ -1,0 +1,3 @@
+def n : Nat := 17
+
+theorem foo : n + 17 = 34 := rfl

--- a/tests/lake/tests/challenge-def-hole/clean.sh
+++ b/tests/lake/tests/challenge-def-hole/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/challenge-def-hole/config.json
+++ b/tests/lake/tests/challenge-def-hole/config.json
@@ -1,0 +1,8 @@
+{
+    "challenge_module": "Challenge",
+    "solution_module": "Solution",
+    "theorem_names": ["foo"],
+    "definition_names": ["n"],
+    "permitted_axioms": ["propext", "Quot.sound", "Classical.choice"],
+    "enable_nanoda": false
+}

--- a/tests/lake/tests/challenge-def-hole/lakefile.toml
+++ b/tests/lake/tests/challenge-def-hole/lakefile.toml
@@ -1,0 +1,8 @@
+name = "checktest"
+version = "0.1.0"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Challenge"

--- a/tests/lake/tests/challenge-def-hole/test.sh
+++ b/tests/lake/tests/challenge-def-hole/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+if [ "`uname`" != Linux ]; then
+  echo "Skipping test: lake challenge needs Linux Landlock"
+  exit 0
+fi
+
+# Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
+export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
+
+test_status_out 0 'Your solution is okay!' challenge --config config.json
+
+rm -f produced.out

--- a/tests/lake/tests/challenge-no-landrun/Challenge.lean
+++ b/tests/lake/tests/challenge-no-landrun/Challenge.lean
@@ -1,0 +1,2 @@
+theorem comm (n m : Nat) : n + m = m + n := by
+  sorry

--- a/tests/lake/tests/challenge-no-landrun/Solution.lean
+++ b/tests/lake/tests/challenge-no-landrun/Solution.lean
@@ -1,0 +1,2 @@
+theorem comm (n m : Nat) : n + m = m + n := by
+  grind

--- a/tests/lake/tests/challenge-no-landrun/clean.sh
+++ b/tests/lake/tests/challenge-no-landrun/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/challenge-no-landrun/config.json
+++ b/tests/lake/tests/challenge-no-landrun/config.json
@@ -1,0 +1,7 @@
+{
+    "challenge_module": "Challenge",
+    "solution_module": "Solution",
+    "theorem_names": ["comm"],
+    "permitted_axioms": ["propext", "Quot.sound", "Classical.choice"],
+    "enable_nanoda": false
+}

--- a/tests/lake/tests/challenge-no-landrun/lakefile.toml
+++ b/tests/lake/tests/challenge-no-landrun/lakefile.toml
@@ -1,0 +1,8 @@
+name = "checktest"
+version = "0.1.0"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Challenge"

--- a/tests/lake/tests/challenge-no-landrun/test.sh
+++ b/tests/lake/tests/challenge-no-landrun/test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+if [ "`uname`" != Linux ]; then
+  echo "Skipping test: lake challenge needs Linux Landlock"
+  exit 0
+fi
+
+# Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
+export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
+
+# Naming a sandbox that is not on PATH takes the same lookup path as having no `landrun` at all,
+# without depending on whether the machine running the tests happens to have one installed.
+export COMPARATOR_LANDRUN=lake-challenge-missing-sandbox
+
+test_status_out 2 'There is no unsandboxed mode' challenge --config config.json
+test_status_out 2 'lake-challenge-missing-sandbox' challenge --config config.json
+
+rm -f produced.out

--- a/tests/lake/tests/challenge-numeric-namespace/Challenge/12.34/5.lean
+++ b/tests/lake/tests/challenge-numeric-namespace/Challenge/12.34/5.lean
@@ -1,0 +1,4 @@
+namespace «123»
+theorem foo : 1 + 1 = 2 := by
+  sorry
+end «123»

--- a/tests/lake/tests/challenge-numeric-namespace/Solution.lean
+++ b/tests/lake/tests/challenge-numeric-namespace/Solution.lean
@@ -1,0 +1,4 @@
+namespace «123»
+theorem foo : 1 + 1 = 2 := by
+  rfl
+end «123»

--- a/tests/lake/tests/challenge-numeric-namespace/clean.sh
+++ b/tests/lake/tests/challenge-numeric-namespace/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/challenge-numeric-namespace/config.json
+++ b/tests/lake/tests/challenge-numeric-namespace/config.json
@@ -1,0 +1,7 @@
+{
+    "challenge_module": "Challenge.«12.34».«5»",
+    "solution_module": "Solution",
+    "theorem_names": ["«123».foo"],
+    "permitted_axioms": ["propext", "Quot.sound", "Classical.choice"],
+    "enable_nanoda": false
+}

--- a/tests/lake/tests/challenge-numeric-namespace/lakefile.toml
+++ b/tests/lake/tests/challenge-numeric-namespace/lakefile.toml
@@ -1,0 +1,9 @@
+name = "comparatortest"
+version = "0.1.0"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Challenge"
+globs = ["Challenge.+"]

--- a/tests/lake/tests/challenge-numeric-namespace/test.sh
+++ b/tests/lake/tests/challenge-numeric-namespace/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+if [ "`uname`" != Linux ]; then
+  echo "Skipping test: lake challenge needs Linux Landlock"
+  exit 0
+fi
+
+# Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
+export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
+
+test_status_out 0 'Your solution is okay!' challenge --config config.json
+
+rm -f produced.out

--- a/tests/lake/tests/challenge-olean-issue/Challenge.lean
+++ b/tests/lake/tests/challenge-olean-issue/Challenge.lean
@@ -1,0 +1,1 @@
+theorem boom : False := sorry

--- a/tests/lake/tests/challenge-olean-issue/Solution.lean
+++ b/tests/lake/tests/challenge-olean-issue/Solution.lean
@@ -1,0 +1,22 @@
+import Lean
+
+open Lean
+
+unsafe def badNatUnsafe : Nat := unsafeCast (-4294967296 : Int)
+
+@[implemented_by badNatUnsafe] opaque badNatVal : Nat
+
+run_elab
+  addDecl <| .defnDecl {
+    name        := .str .anonymous "badNat"
+    levelParams := []
+    type        := .const ``Nat []
+    value       := .lit <| .natVal badNatVal
+    hints       := .opaque
+    safety      := .safe
+  }
+
+theorem boom : False := by
+  have truly_marvelous_0 : ¬badNat ≤ 9223372036854775807 := by decide
+  have truly_marvelous_1 : ¬9223372036854775807 < badNat := by decide
+  omega

--- a/tests/lake/tests/challenge-olean-issue/clean.sh
+++ b/tests/lake/tests/challenge-olean-issue/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/challenge-olean-issue/config.json
+++ b/tests/lake/tests/challenge-olean-issue/config.json
@@ -1,0 +1,7 @@
+{
+    "challenge_module": "Challenge",
+    "solution_module": "Solution",
+    "theorem_names": ["boom"],
+    "permitted_axioms": ["propext", "Quot.sound", "Classical.choice"],
+    "enable_nanoda": false
+}

--- a/tests/lake/tests/challenge-olean-issue/lakefile.toml
+++ b/tests/lake/tests/challenge-olean-issue/lakefile.toml
@@ -1,0 +1,8 @@
+name = "checktest"
+version = "0.1.0"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Challenge"

--- a/tests/lake/tests/challenge-olean-issue/test.sh
+++ b/tests/lake/tests/challenge-olean-issue/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+if [ "`uname`" != Linux ]; then
+  echo "Skipping test: lake challenge needs Linux Landlock"
+  exit 0
+fi
+
+# Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
+export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
+
+test_status_out 1 "while replaying declaration 'boom'" challenge --config config.json
+
+rm -f produced.out

--- a/tests/lake/tests/challenge-opaque-value/Challenge.lean
+++ b/tests/lake/tests/challenge-opaque-value/Challenge.lean
@@ -1,0 +1,1 @@
+theorem boom : False := sorry

--- a/tests/lake/tests/challenge-opaque-value/Solution.lean
+++ b/tests/lake/tests/challenge-opaque-value/Solution.lean
@@ -1,0 +1,3 @@
+axiom f : False
+opaque v : False := f
+theorem boom : False := v

--- a/tests/lake/tests/challenge-opaque-value/clean.sh
+++ b/tests/lake/tests/challenge-opaque-value/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/challenge-opaque-value/config.json
+++ b/tests/lake/tests/challenge-opaque-value/config.json
@@ -1,0 +1,7 @@
+{
+    "challenge_module": "Challenge",
+    "solution_module": "Solution",
+    "theorem_names": ["boom"],
+    "permitted_axioms": ["propext", "Quot.sound", "Classical.choice"],
+    "enable_nanoda": false
+}

--- a/tests/lake/tests/challenge-opaque-value/lakefile.toml
+++ b/tests/lake/tests/challenge-opaque-value/lakefile.toml
@@ -1,0 +1,8 @@
+name = "checktest"
+version = "0.1.0"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Challenge"

--- a/tests/lake/tests/challenge-opaque-value/test.sh
+++ b/tests/lake/tests/challenge-opaque-value/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+if [ "`uname`" != Linux ]; then
+  echo "Skipping test: lake challenge needs Linux Landlock"
+  exit 0
+fi
+
+# Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
+export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
+
+test_status_out 1 "Illegal axiom detected: 'f'" challenge --config config.json
+
+rm -f produced.out

--- a/tests/lake/tests/challenge-primitive-issue/Challenge.lean
+++ b/tests/lake/tests/challenge-primitive-issue/Challenge.lean
@@ -1,0 +1,1 @@
+theorem boom : False := sorry

--- a/tests/lake/tests/challenge-primitive-issue/Solution.lean
+++ b/tests/lake/tests/challenge-primitive-issue/Solution.lean
@@ -1,0 +1,17 @@
+prelude
+import Init.Prelude
+import Init.Core
+-- Supplies the kernel built-ins the comparison exports, so that `Nat.gcd` below is the only
+-- constant that differs from the challenge.
+import Init.Data.String.Bootstrap
+
+def Nat.gcd (_ _ : Nat) : Nat := 0
+
+theorem thm1 a b : Nat.gcd a b = 0 := by
+  unfold Nat.gcd
+  rfl
+
+theorem thm2 : Nat.gcd 1 1 = 1 := rfl
+
+theorem boom : False :=
+  Nat.noConfusion <| Eq.trans (thm1 1 1).symm thm2

--- a/tests/lake/tests/challenge-primitive-issue/clean.sh
+++ b/tests/lake/tests/challenge-primitive-issue/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/challenge-primitive-issue/config.json
+++ b/tests/lake/tests/challenge-primitive-issue/config.json
@@ -1,0 +1,7 @@
+{
+    "challenge_module": "Challenge",
+    "solution_module": "Solution",
+    "theorem_names": ["boom"],
+    "permitted_axioms": ["propext", "Quot.sound", "Classical.choice"],
+    "enable_nanoda": false
+}

--- a/tests/lake/tests/challenge-primitive-issue/lakefile.toml
+++ b/tests/lake/tests/challenge-primitive-issue/lakefile.toml
@@ -1,0 +1,8 @@
+name = "checktest"
+version = "0.1.0"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Challenge"

--- a/tests/lake/tests/challenge-primitive-issue/test.sh
+++ b/tests/lake/tests/challenge-primitive-issue/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+if [ "`uname`" != Linux ]; then
+  echo "Skipping test: lake challenge needs Linux Landlock"
+  exit 0
+fi
+
+# Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
+export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
+
+test_status_out 1 "Const does not match between challenge and target 'Nat.gcd'" challenge --config config.json
+
+rm -f produced.out

--- a/tests/lake/tests/challenge-simple-axiom-issue/Challenge.lean
+++ b/tests/lake/tests/challenge-simple-axiom-issue/Challenge.lean
@@ -1,0 +1,2 @@
+theorem comm (n m : Nat) : n + m = m + n := by
+  sorry

--- a/tests/lake/tests/challenge-simple-axiom-issue/Solution.lean
+++ b/tests/lake/tests/challenge-simple-axiom-issue/Solution.lean
@@ -1,0 +1,5 @@
+
+axiom helper {α : Sort u} : α
+
+theorem comm (n m : Nat) : n + m = m + n := by
+  exact helper

--- a/tests/lake/tests/challenge-simple-axiom-issue/clean.sh
+++ b/tests/lake/tests/challenge-simple-axiom-issue/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/challenge-simple-axiom-issue/config.json
+++ b/tests/lake/tests/challenge-simple-axiom-issue/config.json
@@ -1,0 +1,7 @@
+{
+    "challenge_module": "Challenge",
+    "solution_module": "Solution",
+    "theorem_names": ["comm"],
+    "permitted_axioms": ["propext", "Quot.sound", "Classical.choice"],
+    "enable_nanoda": false
+}

--- a/tests/lake/tests/challenge-simple-axiom-issue/lakefile.toml
+++ b/tests/lake/tests/challenge-simple-axiom-issue/lakefile.toml
@@ -1,0 +1,8 @@
+name = "checktest"
+version = "0.1.0"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Challenge"

--- a/tests/lake/tests/challenge-simple-axiom-issue/test.sh
+++ b/tests/lake/tests/challenge-simple-axiom-issue/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+if [ "`uname`" != Linux ]; then
+  echo "Skipping test: lake challenge needs Linux Landlock"
+  exit 0
+fi
+
+# Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
+export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
+
+test_status_out 1 "Illegal axiom detected: 'helper'" challenge --config config.json
+
+rm -f produced.out

--- a/tests/lake/tests/challenge-simple-kind-mismatch/Challenge.lean
+++ b/tests/lake/tests/challenge-simple-kind-mismatch/Challenge.lean
@@ -1,0 +1,2 @@
+theorem comm (n m : Nat) : n + m = m + n := by
+  sorry

--- a/tests/lake/tests/challenge-simple-kind-mismatch/Solution.lean
+++ b/tests/lake/tests/challenge-simple-kind-mismatch/Solution.lean
@@ -1,0 +1,5 @@
+
+axiom helper {α : Sort u} : α
+
+theorem comm (n m : Nat) : n + m = m + n := by
+  exact helper

--- a/tests/lake/tests/challenge-simple-kind-mismatch/clean.sh
+++ b/tests/lake/tests/challenge-simple-kind-mismatch/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/challenge-simple-kind-mismatch/config.json
+++ b/tests/lake/tests/challenge-simple-kind-mismatch/config.json
@@ -1,0 +1,7 @@
+{
+    "challenge_module": "Challenge",
+    "solution_module": "Solution",
+    "theorem_names": ["comm"],
+    "permitted_axioms": ["propext", "Quot.sound", "Classical.choice"],
+    "enable_nanoda": false
+}

--- a/tests/lake/tests/challenge-simple-kind-mismatch/lakefile.toml
+++ b/tests/lake/tests/challenge-simple-kind-mismatch/lakefile.toml
@@ -1,0 +1,8 @@
+name = "checktest"
+version = "0.1.0"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Challenge"

--- a/tests/lake/tests/challenge-simple-kind-mismatch/test.sh
+++ b/tests/lake/tests/challenge-simple-kind-mismatch/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+if [ "`uname`" != Linux ]; then
+  echo "Skipping test: lake challenge needs Linux Landlock"
+  exit 0
+fi
+
+# Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
+export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
+
+test_status_out 1 "Illegal axiom detected: 'helper'" challenge --config config.json
+
+rm -f produced.out

--- a/tests/lake/tests/challenge-simple-match/Challenge.lean
+++ b/tests/lake/tests/challenge-simple-match/Challenge.lean
@@ -1,0 +1,2 @@
+theorem comm (n m : Nat) : n + m = m + n := by
+  sorry

--- a/tests/lake/tests/challenge-simple-match/Solution.lean
+++ b/tests/lake/tests/challenge-simple-match/Solution.lean
@@ -1,0 +1,2 @@
+theorem comm (n m : Nat) : n + m = m + n := by
+  grind

--- a/tests/lake/tests/challenge-simple-match/clean.sh
+++ b/tests/lake/tests/challenge-simple-match/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/challenge-simple-match/config.json
+++ b/tests/lake/tests/challenge-simple-match/config.json
@@ -1,0 +1,7 @@
+{
+    "challenge_module": "Challenge",
+    "solution_module": "Solution",
+    "theorem_names": ["comm"],
+    "permitted_axioms": ["propext", "Quot.sound", "Classical.choice"],
+    "enable_nanoda": false
+}

--- a/tests/lake/tests/challenge-simple-match/lakefile.toml
+++ b/tests/lake/tests/challenge-simple-match/lakefile.toml
@@ -1,0 +1,8 @@
+name = "checktest"
+version = "0.1.0"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Challenge"

--- a/tests/lake/tests/challenge-simple-match/test.sh
+++ b/tests/lake/tests/challenge-simple-match/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+if [ "`uname`" != Linux ]; then
+  echo "Skipping test: lake challenge needs Linux Landlock"
+  exit 0
+fi
+
+# Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
+export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
+
+test_status_out 0 'Your solution is okay!' challenge --config config.json
+
+rm -f produced.out

--- a/tests/lake/tests/challenge-simple-mismatch/Challenge.lean
+++ b/tests/lake/tests/challenge-simple-mismatch/Challenge.lean
@@ -1,0 +1,2 @@
+theorem comm (n m : Nat) : n + m = m + n := by
+  sorry

--- a/tests/lake/tests/challenge-simple-mismatch/Solution.lean
+++ b/tests/lake/tests/challenge-simple-mismatch/Solution.lean
@@ -1,0 +1,1 @@
+axiom comm (n m : Nat) : m + m = m + m

--- a/tests/lake/tests/challenge-simple-mismatch/clean.sh
+++ b/tests/lake/tests/challenge-simple-mismatch/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/challenge-simple-mismatch/config.json
+++ b/tests/lake/tests/challenge-simple-mismatch/config.json
@@ -1,0 +1,7 @@
+{
+    "challenge_module": "Challenge",
+    "solution_module": "Solution",
+    "theorem_names": ["comm"],
+    "permitted_axioms": ["propext", "Quot.sound", "Classical.choice"],
+    "enable_nanoda": false
+}

--- a/tests/lake/tests/challenge-simple-mismatch/lakefile.toml
+++ b/tests/lake/tests/challenge-simple-mismatch/lakefile.toml
@@ -1,0 +1,8 @@
+name = "checktest"
+version = "0.1.0"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Challenge"

--- a/tests/lake/tests/challenge-simple-mismatch/test.sh
+++ b/tests/lake/tests/challenge-simple-mismatch/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+if [ "`uname`" != Linux ]; then
+  echo "Skipping test: lake challenge needs Linux Landlock"
+  exit 0
+fi
+
+# Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
+export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
+
+test_status_out 1 "Challenge and solution constant kind don't match: 'comm'" challenge --config config.json
+
+rm -f produced.out

--- a/tests/lake/tests/common.sh
+++ b/tests/lake/tests/common.sh
@@ -127,6 +127,19 @@ test_status() {
   fi
 }
 
+test_status_out() {
+  expected_rc=$1; shift
+  expected=$1; shift
+  if lake_out "$@"; then rc=$?; else rc=$?; fi
+  match_text "$expected" produced.out
+  if [ $rc = $expected_rc ]; then
+    return 0
+  else
+    echo "FAILURE: Expected Lake to exit with code $expected_rc."
+    return 1
+  fi
+}
+
 program_out() {
   echo '$' "$@"
   if "$@" >produced.out 2>&1; then

--- a/tests/lake/tests/fake-landrun.sh
+++ b/tests/lake/tests/fake-landrun.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# A `landrun` stand-in for the `check-*` tests: it accepts landrun's flags, ignores them, and runs
+# the command unsandboxed. Landlock cannot be assumed available in CI containers.
+#
+# This provides no isolation whatsoever. `lake check` reaches it only through `COMPARATOR_LANDRUN`,
+# which is the documented escape hatch, so it adds no new way to fake a verdict.
+
+set -euo pipefail
+
+# Flags that take a value (consume the next arg).
+# Add more here if anything's missing.
+flags_with_value=(
+  --ro --rox --rw --rwx
+  --bind-tcp --connect-tcp
+  --log-level
+  --env
+)
+
+is_value_flag() {
+  local f="$1"
+  for vf in "${flags_with_value[@]}"; do
+    [[ "$f" == "$vf" ]] && return 0
+  done
+  return 1
+}
+
+# Handle subcommands / help / version like the real binary. Sorta.
+case "${1:-}" in
+  -h|--help)
+    cat <<'EOF'
+fake landrun shim/fake/stub - does nothing, runs your command unsandboxed
+
+Usage: landrun [flags] <command> [args...]
+
+Flags are accepted and ignored.
+EOF
+    exit 0
+    ;;
+  -V|--version)
+    echo "XXX NOT LANDRUN, FAKE SHIM XXX" >&2
+    exit 0
+    ;;
+esac
+
+# Parse and discard landrun's own flags until we hit `--` or a non-flag token.
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --) shift; break ;; # End of flags
+    -*)
+      # Drop twice if it's a value-taking flag, always drop once
+      is_value_flag "$1" && shift
+      shift
+      ;;
+    *) break ;; # First non-flag token is the command to run
+  esac
+done
+
+if [[ $# -eq 0 ]]; then
+  echo "landrun shim: no command given" >&2
+  exit 2
+fi
+
+echo "WARNING: THIS IS NOT REAL LANDRUN! UNSAFELY RUNNING exec $*" >&2
+exec "$@"

--- a/tests/lake/tests/shake/Lib/A.lean
+++ b/tests/lake/tests/shake/Lib/A.lean
@@ -1,0 +1,3 @@
+module
+
+public def valueA : Nat := 42

--- a/tests/lake/tests/shake/Lib/B.lean
+++ b/tests/lake/tests/shake/Lib/B.lean
@@ -1,0 +1,3 @@
+module
+
+public def valueB : Nat := 99

--- a/tests/lake/tests/shake/Lib/C.lean
+++ b/tests/lake/tests/shake/Lib/C.lean
@@ -1,0 +1,3 @@
+module
+
+@[expose] public def valueC : Nat := 34

--- a/tests/lake/tests/shake/Lib/CSimp.lean
+++ b/tests/lake/tests/shake/Lib/CSimp.lean
@@ -1,0 +1,8 @@
+module
+public import Lib.C
+
+public def valueC' : Nat := 34
+
+@[csimp]
+public theorem valueC_eq_valueC' : valueC = valueC' := by
+  rfl

--- a/tests/lake/tests/shake/Main.lean
+++ b/tests/lake/tests/shake/Main.lean
@@ -1,0 +1,9 @@
+module
+
+import Lib.A
+import Lib.CSimp
+
+def myValue : Nat := valueA
+def myCSimpedValue : Nat := valueC
+
+public def mainVal := 0

--- a/tests/lake/tests/shake/lakefile.toml
+++ b/tests/lake/tests/shake/lakefile.toml
@@ -1,0 +1,11 @@
+name = "test"
+version = "0.1.0"
+defaultTargets = ["Main"]
+
+[[lean_lib]]
+name = "Lib"
+globs = ["Lib.**"]
+
+[[lean_lib]]
+name = "Main"
+roots = ["Main", "DepMain"]

--- a/tests/lake/tests/shake/lean-toolchain
+++ b/tests/lake/tests/shake/lean-toolchain
@@ -1,0 +1,1 @@
+../../../../../build/release/stage1


### PR DESCRIPTION
This PR ships `lake challenge` as a frontend to `comparator`, significantly simplifying its setup. `landrun` remains a hard requirement with no unsandboxed mode, so the command is available on Linux only for now.

The configuration is unchanged from comparator, passed with `--config`. Exit codes have become more fine-grained: 2 for failing to start at all, such as a missing `landrun` or a configuration that is absent or malformed, and 1 for a rejected solution, so that a caller can tell an environment problem from a judgment.

`lean4export` becomes the `leanexport` toolchain binary, vendored at `3de59f10`, and comparator's libraries land under `Lake.Check` (no separate executable), vendored at `8d84e678`.

To follow: additional checking modes and configurations.