### PR TITLE
fix: correct lean_kernel_diag_is_enabled declaration to match generated C

### DIFF
--- a/src/kernel/environment.cpp
+++ b/src/kernel/environment.cpp
@@ -25,7 +25,7 @@ extern "C" uint8 lean_environment_quot_init(object*);
 extern "C" object* lean_kernel_record_unfold (object*, object*);
 extern "C" object* lean_kernel_get_diag(object*);
 extern "C" object* lean_kernel_set_diag(object*, object*);
-extern "C" uint8* lean_kernel_diag_is_enabled(object*);
+extern "C" uint8 lean_kernel_diag_is_enabled(object*);
 
 void diagnostics::record_unfold(name const & decl_name) {
     m_obj = lean_kernel_record_unfold(m_obj, decl_name.to_obj_arg());


### PR DESCRIPTION

This PR fixes the lean_kernel_diag_is_enabled C++ declaration to match generated C. This issue is manifesting only for wasm64 output but it is an issue nonetheless. C++ compiled to wasm64 via emscripten incorrectly translates based on the C++ external declaration.

Closes #14865