### PR TITLE
fix: correct LEAN_EXPORT attribute order in ffi.cpp

### DIFF
--- a/src/util/ffi.cpp
+++ b/src/util/ffi.cpp
@@ -9,19 +9,19 @@ Author: Sebastian Ullrich
 #include "runtime/string_ref.h"
 
 namespace lean {
-LEAN_EXPORT extern "C" object * lean_get_leanc_extra_flags(object *) {
+extern "C" LEAN_EXPORT object * lean_get_leanc_extra_flags(object *) {
     return lean_mk_string("@LEANC_EXTRA_CC_FLAGS@");
 }
 
-LEAN_EXPORT extern "C" object * lean_get_leanc_internal_flags(object *) {
+extern "C" LEAN_EXPORT object * lean_get_leanc_internal_flags(object *) {
     return lean_mk_string("@LEANC_INTERNAL_FLAGS@");
 }
 
-LEAN_EXPORT extern "C" object * lean_get_linker_flags(uint8 link_static) {
+extern "C" LEAN_EXPORT object * lean_get_linker_flags(uint8 link_static) {
     return lean_mk_string(link_static ? "@LEANC_STATIC_LINKER_FLAGS@ @LEAN_EXTRA_LINKER_FLAGS@" : "@LEANC_SHARED_LINKER_FLAGS@ @LEAN_EXTRA_LINKER_FLAGS@");
 }
 
-LEAN_EXPORT extern "C" object * lean_get_internal_linker_flags(object *) {
+extern "C" LEAN_EXPORT object * lean_get_internal_linker_flags(object *) {
     return lean_mk_string("@LEANC_INTERNAL_LINKER_FLAGS@");
 }
 }


### PR DESCRIPTION
This PR fixes attribute/extern "C" ordering affecting builds with some versions of gcc.  

Specifically, gcc ignores `LEAN_EXPORT` visibility attribute placed before `extern "C"`, so these getters were not exported from `libleanshared`.

This change was drafted with AI assistance.  I confirmed that reordering to `extern "C" LEAN_EXPORT` fixes on GCC 11, 13 and 15.