### PR TITLE
test: how costly is eta-for-unit ? 

### DIFF
--- a/src/Init/Ext.lean
+++ b/src/Init/Ext.lean
@@ -85,7 +85,7 @@ attribute [ext] funext propext Subtype.ext Array.ext Char.ext
 attribute [grind ext] funext Array.ext
 
 attribute [ext] PUnit.ext
-protected theorem Unit.ext (x y : Unit) : x = y := rfl
+protected theorem Unit.ext (x y : Unit) : x = y := by cases x; rfl
 
 @[ext] protected theorem Thunk.ext : {a b : Thunk α} → a.get = b.get → a = b
   | {..}, {..}, heq => congrArg _ <| funext fun _ => heq

--- a/src/Lean/Meta/ExprDefEq.lean
+++ b/src/Lean/Meta/ExprDefEq.lean
@@ -2385,7 +2385,7 @@ private def isDefEqLateSpecialCases (t s : Expr) : MetaM LBool := do
   match (← isDefEqProjInst t s) with
   | .undef =>
     match (← isDefEqStringLit t s) with
-    | .undef => return if (← isDefEqUnitLike t s) then .true else .undef
+    | .undef => return /- if (← isDefEqUnitLike t s) then .true else -/ .undef
     | r      => return r
   | r => return r
 

--- a/src/Std/Data/Internal/List/Associative.lean
+++ b/src/Std/Data/Internal/List/Associative.lean
@@ -2401,8 +2401,8 @@ theorem getKey?_ext [BEq α] [EquivBEq α]
   by_cases h' : containsKey a l'
   · rw [getKey?_eq_some_getKey h'] at h
     have h'' := containsKey_eq_isSome_getKey?.trans (h ▸ Option.isSome_some)
-    simp only [h'', getValue?_eq_some_getValue, h', Option.some.injEq]
-    apply Unit.ext
+    simp only [h'', getValue?_eq_some_getValue, h']
+    try exact congrArg some (Unit.ext _ _)
   · rw [getKey?_eq_none ((Bool.not_eq_true _).mp h')] at h
     have h'' := containsKey_eq_isSome_getKey?.trans (h ▸ Option.isSome_none)
     simp only [getValue?_eq_none.mpr, h', h'']

--- a/src/Std/Data/Internal/List/Associative.lean
+++ b/src/Std/Data/Internal/List/Associative.lean
@@ -2401,7 +2401,8 @@ theorem getKey?_ext [BEq α] [EquivBEq α]
   by_cases h' : containsKey a l'
   · rw [getKey?_eq_some_getKey h'] at h
     have h'' := containsKey_eq_isSome_getKey?.trans (h ▸ Option.isSome_some)
-    simp only [getValue?_eq_some_getValue, h', h'']
+    simp only [h'', getValue?_eq_some_getValue, h', Option.some.injEq]
+    apply Unit.ext
   · rw [getKey?_eq_none ((Bool.not_eq_true _).mp h')] at h
     have h'' := containsKey_eq_isSome_getKey?.trans (h ▸ Option.isSome_none)
     simp only [getValue?_eq_none.mpr, h', h'']

--- a/src/kernel/type_checker.cpp
+++ b/src/kernel/type_checker.cpp
@@ -1174,8 +1174,8 @@ bool type_checker::is_def_eq_core(expr const & t, expr const & s) {
     r = try_string_lit_expansion(t_n, s_n);
     if (r != l_undef) return r == l_true;
 
-    if (is_def_eq_unit_like(t_n, s_n))
-        return true;
+    // if (is_def_eq_unit_like(t_n, s_n))
+        // return true;
 
     return false;
 }

--- a/tests/elab/1158.lean
+++ b/tests/elab/1158.lean
@@ -45,14 +45,12 @@ structure C (α) where
 structure D (α) extends A α, B α
 structure E (α) extends C α, B α
 
--- Let's reuse these
-theorem s (a b : Unit) : a = b := rfl
 def op (_ _ : Unit) : Unit := ()
-def i (a : Unit) : op a a = a := s _ a
-def c (a b : Unit) : op a b = op b a := s _ _
+def i (a : Unit) : op a a = a := Unit.ext _ a
+def c (a b : Unit) : op a b = op b a := Unit.ext _ _
 
 -- Successfully defined
-def d : D Unit := have := s; have := i; have := ()
+def d : D Unit := have := Unit.ext; have := i; have := ()
                   { op }
 
 def e : E Unit := have := c; have := i; have := ()
@@ -61,10 +59,10 @@ def e : E Unit := have := c; have := i; have := ()
 structure F (α) extends D α, E α
 structure G (α) extends E α, D α
 
-def f : F Unit := have := s; have := i; have := c; have := ()
+def f : F Unit := have := Unit.ext; have := i; have := c; have := ()
                   { op }
 -- `idempotent`, `fav` missing
-def g : G Unit := have := s; have := i; have := c; have := ()
+def g : G Unit := have := Unit.ext; have := i; have := c; have := ()
                   { op }
 
 end Ex2

--- a/tests/elab/6117.lean
+++ b/tests/elab/6117.lean
@@ -4,9 +4,8 @@ abbrev T.{u} : Unit := (fun (α : Sort u) => ()) PUnit.{u}
 
 set_option pp.universes true
 
-def unitUnique (x y : Unit) : x = y := by rfl
 
-def testUnique.{u, v} : T.{u} = T.{v} := unitUnique _ _
+def testUnique.{u, v} : T.{u} = T.{v} := Unit.ext _ _
 
 def test.{u, v} : T.{u} = T.{v} := rfl
 

--- a/tests/elab/etaStruct.lean
+++ b/tests/elab/etaStruct.lean
@@ -62,11 +62,11 @@ def frob : Nat × Nat → Nat × Nat
 
 example (x : Nat × Nat) : (frob x).2 = 42 := rfl
 
-example (x y : Unit) : x = y := rfl
+example (x y : Unit) : x = y := Unit.ext x y
 
 opaque f : Nat → Unit
 opaque g : Nat → Unit
 
-example (x y : Nat) : f x = f y := rfl
+example (x y : Nat) : f x = f y := Unit.ext _ _
 
-example (x y : Nat) : f x = g y := rfl
+example (x y : Nat) : f x = g y := Unit.ext _ _

--- a/tests/elab/ext.lean
+++ b/tests/elab/ext.lean
@@ -64,9 +64,9 @@ def Set (α : Type u) := α → Prop
 
 structure MyUnit
 
-@[ext (iff := false) high] theorem MyUnit.ext1 (x y : MyUnit) (_h : 0 = 1) : x = y := rfl
-@[ext high] theorem MyUnit.ext2 (x y : MyUnit) (_h : 1 = 1) : x = y := rfl
-@[ext (iff := false)] theorem MyUnit.ext3 (x y : MyUnit) (_h : 2 = 1) : x = y := rfl
+@[ext (iff := false) high] theorem MyUnit.ext1 (x y : MyUnit) (_h : 0 = 1) : x = y := by cases x; rfl
+@[ext high] theorem MyUnit.ext2 (x y : MyUnit) (_h : 1 = 1) : x = y := by cases x; rfl
+@[ext (iff := false)] theorem MyUnit.ext3 (x y : MyUnit) (_h : 2 = 1) : x = y := by cases x; rfl
 
 /-- info: MyUnit.ext2_iff {x y : MyUnit} : x = y ↔ 1 = 1 -/
 #guard_msgs in #check MyUnit.ext2_iff

--- a/tests/elab/ext1.lean
+++ b/tests/elab/ext1.lean
@@ -56,9 +56,9 @@ def Set (α : Type u) := α → Prop
 
 structure MyUnit
 
-@[ext (iff := false) high] theorem MyUnit.ext1 (x y : MyUnit) (_h : 0 = 1) : x = y := rfl
-@[ext high] theorem MyUnit.ext2 (x y : MyUnit) (_h : 1 = 1) : x = y := rfl
-@[ext (iff := false)] theorem MyUnit.ext3 (x y : MyUnit) (_h : 2 = 1) : x = y := rfl
+@[ext (iff := false) high] theorem MyUnit.ext1 (x y : MyUnit) (_h : 0 = 1) : x = y := by cases x; rfl
+@[ext high] theorem MyUnit.ext2 (x y : MyUnit) (_h : 1 = 1) : x = y := by cases x; rfl
+@[ext (iff := false)] theorem MyUnit.ext3 (x y : MyUnit) (_h : 2 = 1) : x = y := by cases x; rfl
 
 example (x y : MyUnit) : x = y := by ext; rfl
 

--- a/tests/elab/grind_inj.lean
+++ b/tests/elab/grind_inj.lean
@@ -73,4 +73,4 @@ error: invalid `[grind inj]` theorem, theorem has universe levels, but no hypoth
 -/
 #guard_msgs in
 @[grind inj] theorem weird_inj : Function.Injective weird := by
-  intro a b; simp
+  intro a b; cases a; simp

--- a/tests/elab/partial_fixpoint.lean
+++ b/tests/elab/partial_fixpoint.lean
@@ -13,7 +13,7 @@ partial_fixpoint
 
 /--
 info: equations:
-@[defeq] theorem loop.eq_1 : ∀ (x : Nat), loop x = loop (x + 1)
+theorem loop.eq_1 : ∀ (x : Nat), loop x = loop (x + 1)
 -/
 #guard_msgs in
 #print equations loop

--- a/tests/elab_fail/guessLexFailures.lean.out.expected
+++ b/tests/elab_fail/guessLexFailures.lean.out.expected
@@ -49,7 +49,7 @@ Please use `termination_by` to specify a decreasing measure.
 guessLexFailures.lean:37:0-43:31: error: Could not find a decreasing measure.
 The basic measures relate at each recursive call as follows:
 (<, ≤, =: relation proved, ? all proofs failed, _: no proof attempted)
-           n m x3
+           n m x4
 1) 39:6-27 = =  =
 2) 40:6-25 = <  _
 3) 41:6-25 < _  _


### PR DESCRIPTION
This PR just tests the perf gains that might be gained from not having eta for unit. The feature should be cheap at the kernel level since it's always used only as a last resort, but one may wonder whether the cost is higher at the elaborator level, where more conversion tests fail and may pass through this defeq test to no avail.