### PR TITLE
fix: add lawful `BEq` instances for `Sum` and expose the derived `BEq`

### DIFF
--- a/src/Init/Data/Sum/Basic.lean
+++ b/src/Init/Data/Sum/Basic.lean
@@ -48,6 +48,29 @@ namespace Sum
 
 deriving instance BEq for Sum
 
+section BEq
+
+variable [BEq α] [BEq β] [LawfulBEq α] [LawfulBEq β]
+
+instance : LawfulBEq (α ⊕ β) where
+  rfl {a} := by
+    cases a with
+    | inl x => exact BEq.refl x
+    | inr y => exact BEq.refl y
+  eq_of_beq {a b} h := by
+    have ft : ¬false == true := by decide
+    cases a with
+    | inl x =>
+      cases b with
+      | inl z => exact congrArg inl (eq_of_beq h)
+      | inr w => exact absurd h ft
+    | inr y =>
+      cases b with
+      | inl z => exact absurd h ft
+      | inr w => exact congrArg inr (eq_of_beq h)
+
+end BEq
+
 section get
 
 /-- Checks whether a sum is the left injection `inl`. -/

--- a/src/Init/Data/Sum/Basic.lean
+++ b/src/Init/Data/Sum/Basic.lean
@@ -7,6 +7,7 @@ module
 
 prelude
 public import Init.PropLemmas
+import Init.LawfulBEqTactics
 
 public section
 
@@ -46,30 +47,7 @@ universe signature in consequence. The `Prop` version is `Or`.
 
 namespace Sum
 
-deriving instance BEq for Sum
-
-section BEq
-
-variable [BEq α] [BEq β] [LawfulBEq α] [LawfulBEq β]
-
-instance : LawfulBEq (α ⊕ β) where
-  rfl {a} := by
-    cases a with
-    | inl x => exact BEq.refl x
-    | inr y => exact BEq.refl y
-  eq_of_beq {a b} h := by
-    have ft : ¬false == true := by decide
-    cases a with
-    | inl x =>
-      cases b with
-      | inl z => exact congrArg inl (eq_of_beq h)
-      | inr w => exact absurd h ft
-    | inr y =>
-      cases b with
-      | inl z => exact absurd h ft
-      | inr w => exact congrArg inr (eq_of_beq h)
-
-end BEq
+deriving instance BEq, ReflBEq, LawfulBEq for Sum
 
 section get
 

--- a/src/Init/Data/Sum/Basic.lean
+++ b/src/Init/Data/Sum/Basic.lean
@@ -47,7 +47,9 @@ universe signature in consequence. The `Prop` version is `Or`.
 
 namespace Sum
 
+@[expose] section
 deriving instance BEq, ReflBEq, LawfulBEq for Sum
+end
 
 section get
 

--- a/tests/elab/14895.lean
+++ b/tests/elab/14895.lean
@@ -1,0 +1,19 @@
+module
+
+/-!
+Regression test for https://github.com/leanprover/lean4/pull/14895.
+
+`Sum`'s derived `BEq` is exposed, so `==` on sums still reduces from another module, and the
+derived `ReflBEq`/`LawfulBEq` instances transfer from the components.
+-/
+
+example : (Sum.inl 0 == (Sum.inr 0 : Nat ⊕ Nat)) = false := rfl
+example : (Sum.inl 0 == (Sum.inr 0 : Nat ⊕ Nat)) = false := by decide
+example : (Sum.inl 0 == (Sum.inr 0 : Nat ⊕ Nat)) = false := by simp
+
+example : (Sum.inl 0 == (Sum.inl 0 : Nat ⊕ Nat)) = true := rfl
+
+example [BEq α] [BEq β] [ReflBEq α] [ReflBEq β] (x : α ⊕ β) : x == x := BEq.rfl
+
+example [BEq α] [BEq β] [LawfulBEq α] [LawfulBEq β] (x y : α ⊕ β) (h : x == y) : x = y :=
+  eq_of_beq h


### PR DESCRIPTION
This PR adds `ReflBEq` and `LawfulBEq` instances for `Sum` and exposes its derived `BEq`, so that `==` on sums reduces outside the module that defines it.

Previously `(Sum.inl 0 == Sum.inr 0) = false` was not provable by `rfl` or `decide` from another module, as reported at https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/.28Sum.2Einl.200.20.3D.3D.20Sum.2Einr.200.29.20.3D.20false.20is.20unprovable.20in.20module.20mod

The instances come from the `ReflBEq` and `LawfulBEq` deriving handlers; `ReflBEq (α ⊕ β)` needs only `ReflBEq` on the components, not `LawfulBEq`. The deriving command sits in an `@[expose] section`, matching how `Option`, `Prod` and `List` make their `BEq` reduce downstream.
