### PR TITLE
fix: lake: `meta import` after `import all`

### DIFF
--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -248,30 +248,39 @@ partial def fetchTransImportArts
     let input ← (← mod.input.fetch).await
     let importAll := strictOr nonModule imp.importAll
     return enqueue importAll imp.isMeta input q
-  walk directArts {} q
+  walk directArts {} {} q
 where
-  walk s (metaVisited : NameSet) (q : Array TransImportEntry) := do
+  walk s (allVisited metaVisited : NameSet) (q : Array TransImportEntry) := do
     if h : 0 < q.size then
       let {mod, importAll, needsMeta} := q.back
       let q := q.pop
-      if let some arts := s.find? mod.name then
-        /-
-        A module system `import` may need to be promoted to a
-        wider import (`meta import`, `import all`) on another branch.
-        -/
-        -- Only re-process a module sitting at the plain public-module level: `.server` present =>
-        -- module, no `.private` => not already `import all`. An entry already at `import all` (with
-        -- `.private`) or a non-module (no `.server`) must not be re-inserted, as that would demote it.
-        let needsMeta := needsMeta && !metaVisited.contains mod.name
-        unless (importAll || needsMeta) && arts.oleanServer?.isSome && arts.oleanPrivate?.isNone do
-          return ← walk s metaVisited q
+      /-
+      A module system `import` may need to be promoted to a
+      wider import (`meta import`, `import all`) on another branch.
+
+      Track the two import dimensions separately: `allVisited` = raised to `.private` by
+      `import all`; `metaVisited` = made meta-reachable by a `meta import`. An `import all` visit
+      must not mark a module meta-visited, otherwise a later `meta` visit is skipped and the
+      module's children never inherit the meta requirement.
+      -/
+      let doAll := importAll && !allVisited.contains mod.name
+      let doMeta := needsMeta && !metaVisited.contains mod.name
+      let existing? := s.find? mod.name
+      -- Re-process an existing entry only to widen a module-system entry (`.server` present) with a
+      -- newly-required dimension. Otherwise, leave it untouched (nothing new, or a non-module entry).
+      if let some arts := existing? then
+        unless arts.oleanServer?.isSome && (doAll || doMeta) do
+          return ← walk s allVisited metaVisited q
+      let allVisited := if importAll then allVisited.insert mod.name else allVisited
+      let metaVisited := if needsMeta then metaVisited.insert mod.name else metaVisited
+      -- Widest level seen so far, never below an existing entry's (no demotion).
+      let wantAll := allVisited.contains mod.name || existing?.any (·.oleanPrivate?.isSome)
       let info ← (← mod.exportInfo.fetch).await
-      let arts := if importAll then info.allArts else info.arts
-      let s := s.insert mod.name arts
-      let metaVisited := if importAll || needsMeta then metaVisited.insert mod.name else metaVisited
+      let s := s.insert mod.name (if wantAll then info.allArts else info.arts)
       let input ← (← mod.input.fetch).await
+      -- `import all`/`meta import` are transitive. Propagate both flags to children.
       let q := enqueue importAll needsMeta input q
-      walk s metaVisited q
+      walk s allVisited metaVisited q
     else
       return s
   enqueue importAll needsMeta input q :=

--- a/tests/lake/tests/module/Test/Module/ImportAllImportImport.lean
+++ b/tests/lake/tests/module/Test/Module/ImportAllImportImport.lean
@@ -1,0 +1,3 @@
+module
+
+import all Test.Module.ImportImport

--- a/tests/lake/tests/module/Test/Module/ImportImportImport.lean
+++ b/tests/lake/tests/module/Test/Module/ImportImportImport.lean
@@ -1,0 +1,3 @@
+module
+
+import Test.Module.ImportImport

--- a/tests/lake/tests/module/Test/Module/MetaRevisitAll.lean
+++ b/tests/lake/tests/module/Test/Module/MetaRevisitAll.lean
@@ -1,0 +1,4 @@
+module
+
+import all Test.Module.ImportImport
+meta import Test.Module.ImportImportImport

--- a/tests/lake/tests/module/Test/Module/MetaRevisitTransAll.lean
+++ b/tests/lake/tests/module/Test/Module/MetaRevisitTransAll.lean
@@ -1,0 +1,4 @@
+module
+
+import all Test.Module.ImportAllImportImport
+meta import Test.Module.ImportImportImport

--- a/tests/lake/tests/module/test.sh
+++ b/tests/lake/tests/module/test.sh
@@ -46,6 +46,14 @@ test_cmd grep -F "Module.olean.private" .lake/build/ir/Test/Module/PromoteTransI
 test_run build Test.Module.PromoteMetaImport
 test_cmd grep -F "ImportImport.olean.private" .lake/build/ir/Test/Module/PromoteMetaImport.setup.json
 test_cmd grep -F "Module.ir" .lake/build/ir/Test/Module/PromoteMetaImport.setup.json
+# an `import all` of a module should not block a later transitive `meta import` of it
+# from propagating meta reachability to that module's own non-exported imports
+test_run build Test.Module.MetaRevisitAll
+test_cmd grep -F "ImportImport.olean.private" .lake/build/ir/Test/Module/MetaRevisitAll.setup.json
+test_cmd grep -F "Module.olean" .lake/build/ir/Test/Module/MetaRevisitAll.setup.json
+# and likewise when the `import all` is itself transitive
+test_run build Test.Module.MetaRevisitTransAll
+test_cmd grep -F "Module.olean" .lake/build/ir/Test/Module/MetaRevisitTransAll.setup.json
 # should be imported by a non-module
 test_run build Test.NonModule.Import
 test_cmd grep -F "Module.olean.private" .lake/build/ir/Test/NonModule/Import.setup.json


### PR DESCRIPTION
This PR fixes Lake omitting imports from a module's setup when one of its imports is both an `import all` and reached transitively through a `meta import`. The `import all` suppressed the later `meta import`, so modules reachable only through the latter were left out of the setup passed to lean.

`fetchTransImportArts` tracked both import dimensions in a single visited set, so an `import all` visit of a module marked it meta-visited and cancelled any subsequent `meta import` visit, whose children never inherited the meta requirement. The two dimensions are now tracked separately. The no-demotion rule moves out of the re-visit guard and into the artifact selection, so an entry already raised to `import all` keeps its private olean when it is re-visited to widen the meta dimension.

Split from #13169.

🤖 Prepared with Claude Code
