### PR TITLE
feat: create asNode/mkNode abstraction for DiscrTree

### DIFF
--- a/src/Lean/Meta/DiscrTree/Basic.lean
+++ b/src/Lean/Meta/DiscrTree/Basic.lean
@@ -122,20 +122,6 @@ where
       r := r.push (← go)
     return r
 
-/--
-Generate a trie node from values and an array of children.
--/
-@[inline]
-def Trie.mkNode (vs : Array α) (cs : Array (Key × Trie α)) : Trie α :=
-  .node vs cs
-
-/--
-Inspect a trie node as an array of values and an array of children.
--/
-@[inline]
-def Trie.asNode : Trie α → Array α × Array (Key × Trie α)
-  | .node vs cs => ⟨vs, cs⟩
-
 private partial def createNodes (keys : Array Key) (v : α) (i : Nat) : Trie α :=
   if h : i < keys.size then
     let k := keys[i]

--- a/src/Lean/Meta/DiscrTree/Basic.lean
+++ b/src/Lean/Meta/DiscrTree/Basic.lean
@@ -122,6 +122,20 @@ where
       r := r.push (← go)
     return r
 
+/--
+Generate a trie node from values and an array of children.
+-/
+@[inline]
+def Trie.mkNode (vs : Array α) (cs : Array (Key × Trie α)) : Trie α :=
+  .node vs cs
+
+/--
+Inspect a trie node as an array of values and an array of children.
+-/
+@[inline]
+def Trie.asNode : Trie α → Array α × Array (Key × Trie α)
+  | .node vs cs => ⟨vs, cs⟩
+
 private partial def createNodes (keys : Array Key) (v : α) (i : Nat) : Trie α :=
   if h : i < keys.size then
     let k := keys[i]

--- a/src/Lean/Meta/DiscrTree/Util.lean
+++ b/src/Lean/Meta/DiscrTree/Util.lean
@@ -51,9 +51,24 @@ partial def size : Trie α → Nat
     children.foldl (init := vs.size) fun n (_, c) => n + size c
 
 /--
+Generate a trie node from values and an array of children.
+-/
+@[inline]
+def mkNode (vs : Array α) (cs : Array (Key × Trie α)) : Trie α :=
+  .node vs cs
+
+/--
+Inspect a trie node as an array of values and an array of children.
+-/
+@[inline]
+def asNode : Trie α → Array α × Array (Key × Trie α)
+  | .node vs cs => ⟨vs, cs⟩
+
+/--
 Returns the values stored at the current trie node.
 Equivalent to `t.asNode.1`.
 -/
+@[inline]
 def nodeValues : Trie α → Array α
   | .node vs _ => vs
 
@@ -61,6 +76,7 @@ def nodeValues : Trie α → Array α
 Returns the child nodes of the current trie node.
 Equivalent to `t.asNode.2`.
 -/
+@[inline]
 def nodeChildren : Trie α → Array (Key × Trie α)
   | .node _ cs => cs
 

--- a/src/Lean/Meta/DiscrTree/Util.lean
+++ b/src/Lean/Meta/DiscrTree/Util.lean
@@ -51,7 +51,21 @@ partial def size : Trie α → Nat
     children.foldl (init := vs.size) fun n (_, c) => n + size c
 
 /--
-Checks that a trie node has no values and no children.
+Returns the values stored at the current trie node.
+Equivalent to `t.asNode.1`.
+-/
+def nodeValues : Trie α → Array α
+  | .node vs _ => vs
+
+/--
+Returns the child nodes of the current trie node.
+Equivalent to `t.asNode.2`.
+-/
+def nodeChildren : Trie α → Array (Key × Trie α)
+  | .node _ cs => cs
+
+/--
+Checks whether a trie node is empty (no values and no children).
 
 This is only a check for actual trie emptiness (`t.size = 0`) if all operations maintain the
 invariant that no trie node has an empty child node.


### PR DESCRIPTION
This PR creates an additional view abstraction on `DiscrTree.Trie` nodes that allows nodes to be viewed and inspected without direct case analysis.

This interface allows downstream code to tolerate future minor changes to DiscrTree representations (e.g. #12838 or #14805) more gracefully than is currently possible.