### PR TITLE
feat: add ground evaluation Nat.log2 support

### DIFF
--- a/src/Lean/Meta/Sym/DSimp/EvalGround.lean
+++ b/src/Lean/Meta/Sym/DSimp/EvalGround.lean
@@ -41,6 +41,12 @@ abbrev evalUnaryInt16 : (op : Int16 → Int16) → (a : Expr) → DSimpM Result 
 abbrev evalUnaryInt32 : (op : Int32 → Int32) → (a : Expr) → DSimpM Result := evalUnary getInt32Value?
 abbrev evalUnaryInt64 : (op : Int64 → Int64) → (a : Expr) → DSimpM Result := evalUnary getInt64Value?
 
+def evalLog2 (a : Expr) (maxExponent : Nat) : DSimpM Result := do
+  let some n := getNatValue? a | return .rfl
+  if n > 2^maxExponent then return .rfl
+  let e ← share <| toExpr n.log2
+  return .step e (done := true)
+
 abbrev evalUnaryFin' (op : {n : Nat} → Fin n → Fin n) (a : Expr) : DSimpM Result := do
   let some a := getFinValue? a | return .rfl
   let e ← share <| toExpr (op a.val)
@@ -519,6 +525,7 @@ public def evalGround (config : EvalStepConfig := {}) : DSimproc := fun e =>
   | Complement.complement α _ a => evalComplement α a
   | Nat.gcd a b => evalBinNat Nat.gcd a b
   | Nat.succ a => evalUnaryNat (· + 1) a
+  | Nat.log2 a => evalLog2 a config.maxExponent
   | Int.gcd a b => evalIntGcd a b
   | Int.tdiv a b => evalBinInt Int.tdiv a b
   | Int.fdiv a b => evalBinInt Int.fdiv a b

--- a/src/Lean/Meta/Sym/Simp/EvalGround.lean
+++ b/src/Lean/Meta/Sym/Simp/EvalGround.lean
@@ -342,6 +342,12 @@ def evalIntBDiv (a b : Expr) : SimpM Result := do
   let e ← share <| toExpr (Int.bdiv a b)
   return .step e (mkApp2 (mkConst ``Eq.refl [1]) Int.mkType e) (done := true)
 
+def evalLog2 (a : Expr) (maxExponent : Nat) : SimpM Result := do
+  let some n := getNatValue? a | return .rfl
+  if n > 2^maxExponent then return .rfl
+  let e ← share <| toExpr n.log2
+  return .step e (mkApp2 (mkConst ``Eq.refl [1]) Nat.mkType e) (done := true)
+
 abbrev evalBinPred (toValue? : Expr → Option α) (trueThm falseThm : Expr) (op : α → α → Bool) (a b : Expr) : SimpM Result := do
   let some va := toValue? a | return .rfl
   let some vb := toValue? b | return .rfl
@@ -710,6 +716,7 @@ public def evalGround (config : EvalStepConfig := {}) : Simproc := fun e =>
   | Complement.complement α _ a => evalComplement α a
   | Nat.gcd a b => evalBinNat Nat.gcd a b
   | Nat.succ a => evalUnaryNat (· + 1) a
+  | Nat.log2 a => evalLog2 a config.maxExponent
   | Int.gcd a b => evalIntGcd a b
   | Int.tdiv a b => evalBinInt Int.tdiv a b
   | Int.fdiv a b => evalBinInt Int.fdiv a b

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Nat.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/Nat.lean
@@ -49,6 +49,9 @@ open Lean Meta Simp Lean.Nat
 
 set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 builtin_dsimproc [simp, seval] reduceSucc (Nat.succ _) := reduceUnary ``Nat.succ 1 (· + 1)
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
+builtin_dsimproc [simp, seval] reduceLog2 (Nat.log2 _) := reduceUnary ``Nat.log2 1 Nat.log2
+
 
 /-
 The following code assumes users did not override the `Nat` instances for the arithmetic operators.

--- a/tests/elab/nat_log2_eval.lean
+++ b/tests/elab/nat_log2_eval.lean
@@ -1,0 +1,34 @@
+import Lean
+
+/-!
+Tests for literal evaluation of `Nat.log2` in `simp`/`seval`, in `sym => simp` (via
+`Sym.Simp.evalGround`) and in `sym => dsimp` (via `Sym.DSimp.evalGround`).
+-/
+
+section
+variable (x : Nat)
+
+#check_simp x = Nat.log2 0 ~> x = 0
+#check_simp x = Nat.log2 1 ~> x = 0
+#check_simp x = Nat.log2 8 ~> x = 3
+#check_simp x = Nat.log2 1000 ~> x = 9
+
+end
+
+example : Nat.log2 32 = 5 := by simp only [seval]
+
+example : Nat.log2 (2 ^ 100) = 100 := by simp
+
+register_sym_simp log2Ground where
+  post := ground
+
+example : Nat.log2 8 = 3 := by
+  sym => simp log2Ground
+
+example : Nat.log2 (2 ^ 100) = 100 := by
+  sym => simp log2Ground
+
+example (x : Nat) (h : x = 3) : x = Nat.log2 8 := by
+  sym =>
+    dsimp
+    exact h


### PR DESCRIPTION
This PR adds support for evaluating `Nat.log2` to the ground evaluators of `Sym.simp` and `Meta.simp`. Despite working by recursion, it still manages to evaluate efficiently by reduction because it only runs logarithmically many kernel-accelerated operations.