### PR TITLE
feat: add BitVec.ofNatClamp

### DIFF
--- a/src/Init/Data/BitVec/BasicAux.lean
+++ b/src/Init/Data/BitVec/BasicAux.lean
@@ -7,6 +7,7 @@ module
 
 prelude
 public import Init.Grind.Tactics
+import Init.Data.Nat.Basic
 
 public section
 
@@ -25,6 +26,18 @@ instance instOfNat : OfNat (BitVec n) i where ofNat := .ofNat n i
 
 /-- Return the bound in terms of toNat. -/
 theorem isLt (x : BitVec w) : x.toNat < 2^w := x.toFin.isLt
+
+/--
+Converts a natural number to a bitvector of width `w`, returning the largest representable value
+if the number is too large.
+
+Returns `2^w - 1` for natural numbers greater than or equal to `2^w`.
+-/
+def ofNatClamp (w n : Nat) : BitVec w :=
+  if h : n < 2 ^ w then
+    BitVec.ofNatLT n h
+  else
+    BitVec.ofNatLT (2 ^ w - 1) (Nat.sub_lt (Nat.two_pow_pos w) Nat.one_pos)
 
 end Nat
 

--- a/src/Init/Data/BitVec/Lemmas.lean
+++ b/src/Init/Data/BitVec/Lemmas.lean
@@ -2104,7 +2104,7 @@ theorem getElem_shiftLeft' {x : BitVec w₁} {y : BitVec w₂} {i : Nat} (h : i 
   simp
   omega
 
-theorem shiftLeft_ofNat_eq {x : BitVec w} {k : Nat} : x <<< (BitVec.ofNat w k) = x <<< (k % 2^w) := rfl
+theorem shiftLeft_ofNat_eq {x : BitVec w} {v k : Nat} : x <<< (BitVec.ofNat v k) = x <<< (k % 2^v) := rfl
 
 /-! ### ushiftRight -/
 
@@ -2252,7 +2252,7 @@ theorem setWidth_ushiftRight_eq_extractLsb {b : BitVec w} : (b >>> w').setWidth 
 theorem ushiftRight_eq' (x : BitVec w₁) (y : BitVec w₂) :
     x >>> y = x >>> y.toNat := rfl
 
-theorem ushiftRight_ofNat_eq {x : BitVec w} {k : Nat} : x >>> (BitVec.ofNat w k) = x >>> (k % 2^w) := rfl
+theorem ushiftRight_ofNat_eq {x : BitVec w} {v k : Nat} : x >>> (BitVec.ofNat v k) = x >>> (k % 2^v) := rfl
 
 @[simp]
 theorem ushiftRight_self (n : BitVec w) : n >>> n.toNat = 0#w := by
@@ -2357,7 +2357,7 @@ theorem sshiftRight_or_distrib (x y : BitVec w) (n : Nat) :
 
 
 @[grind =]
-theorem sshiftRight'_ofNat_eq_sshiftRight {x : BitVec w} {k : Nat} : x.sshiftRight' (BitVec.ofNat w k) = x.sshiftRight (k % 2^w) := rfl
+theorem sshiftRight'_ofNat_eq_sshiftRight {x : BitVec w} {v k : Nat} : x.sshiftRight' (BitVec.ofNat v k) = x.sshiftRight (k % 2^v) := rfl
 
 /-- The msb after arithmetic shifting right equals the original msb. -/
 @[simp]
@@ -2497,6 +2497,11 @@ theorem toInt_sshiftRight {x : BitVec w} {n : Nat} :
     norm_cast at *
     exact Int.bmod_eq_of_le (by omega) (by omega)
 
+theorem sshiftRight_eq_sshiftRight_of_le {x : BitVec w} {m n : Nat} (h₁ : w ≤ m) (h₂ : w ≤ n) :
+    x.sshiftRight m = x.sshiftRight n := by
+  ext i h
+  rw [getElem_sshiftRight, getElem_sshiftRight, dite_eq_right (by omega), dite_eq_right (by omega)]
+
 /-! ### sshiftRight reductions from BitVec to Nat -/
 
 @[simp, grind =]
@@ -2555,6 +2560,87 @@ theorem getMsbD_sshiftRight' {x y: BitVec w} {i : Nat} :
 
 theorem msb_sshiftRight' {x y: BitVec w} :
     (x.sshiftRight' y).msb = x.msb := by simp
+
+/-! ### ofNatClamp -/
+
+theorem ofNatClamp_eq_ofNat {w n : Nat} (hn : n < 2 ^ w) :
+    BitVec.ofNatClamp w n = BitVec.ofNat w n := by
+  rw [ofNatClamp, dite_eq_left hn, ofNatLT_eq_ofNat]
+
+theorem ofNatClamp_eq_ofNat_of_le {w n : Nat} (hn : 2 ^ w ≤ n) :
+    BitVec.ofNatClamp w n = BitVec.ofNat w (2 ^ w - 1) := by
+  rw [ofNatClamp, dite_eq_right (by omega), ofNatLT_eq_ofNat]
+
+theorem ofNatClamp_eq_allOnes_of_le {w n : Nat} (hn : 2 ^ w ≤ n) :
+    BitVec.ofNatClamp w n = BitVec.allOnes w := by
+  rw [ofNatClamp, dite_eq_right (by omega)]
+  rfl
+
+theorem toNat_ofNatClamp_of_lt {w n : Nat} (hn : n < 2 ^ w) :
+    (BitVec.ofNatClamp w n).toNat = n := by
+  rw [ofNatClamp, dite_eq_left hn, toNat_ofNatLT]
+
+theorem toNat_ofNatClamp_of_le {w n : Nat} (hn : 2 ^ w ≤ n) :
+    (BitVec.ofNatClamp w n).toNat = 2 ^ w - 1 := by
+  rw [ofNatClamp, dite_eq_right (by omega), toNat_ofNatLT]
+
+theorem toNat_ofNatClamp {w n : Nat} :
+    (BitVec.ofNatClamp w n).toNat = min n (2 ^ w - 1) := by
+  by_cases h : n < 2 ^ w
+  · rw [toNat_ofNatClamp_of_lt h]; omega
+  · rw [toNat_ofNatClamp_of_le (by omega)]; omega
+
+theorem toNat_ofNatClamp_le (w n : Nat) : (BitVec.ofNatClamp w n).toNat ≤ n := by
+  rw [toNat_ofNatClamp]
+  omega
+
+@[simp] theorem ofNatClamp_toNat (x : BitVec w) : BitVec.ofNatClamp w x.toNat = x := by
+  apply eq_of_toNat_eq
+  rw [toNat_ofNatClamp_of_lt x.isLt]
+
+theorem toFin_ofNatClamp_of_lt {w n : Nat} (hn : n < 2 ^ w) :
+    (BitVec.ofNatClamp w n).toFin = ⟨n, hn⟩ := by
+  rw [ofNatClamp, dite_eq_left hn]
+  rfl
+
+theorem toFin_ofNatClamp_of_le {w n : Nat} (hn : 2 ^ w ≤ n) :
+    (BitVec.ofNatClamp w n).toFin =
+      ⟨2 ^ w - 1, Nat.sub_lt (Nat.two_pow_pos w) Nat.one_pos⟩ := by
+  rw [ofNatClamp, dite_eq_right (by omega)]
+  rfl
+
+@[simp] theorem ofNatClamp_finVal (n : Fin (2 ^ w)) :
+    BitVec.ofNatClamp w n.val = BitVec.ofFin n := by
+  rw [ofNatClamp, dite_eq_left n.isLt]
+  rfl
+
+theorem getLsbD_ofNatClamp {w n i : Nat} :
+    (BitVec.ofNatClamp w n).getLsbD i = (min n (2 ^ w - 1)).testBit i := by
+  rw [← toNat_ofNatClamp (w := w) (n := n), testBit_toNat]
+
+theorem ushiftRight_eq_ushiftRight_ofNatClamp {w n v : Nat} {x : BitVec w} (h : w < 2 ^ v) :
+    x >>> n = x >>> BitVec.ofNatClamp v n := by
+  rw [ushiftRight_eq']
+  by_cases hn : n < 2 ^ v
+  · rw [toNat_ofNatClamp_of_lt hn]
+  · rw [toNat_ofNatClamp_of_le (Nat.le_of_not_lt hn), ushiftRight_eq_zero (by omega),
+      ushiftRight_eq_zero (by omega)]
+
+theorem shiftLeft_eq_shiftLeft_ofNatClamp {w n v : Nat} {x : BitVec w} (h : w < 2 ^ v) :
+    x <<< n = x <<< BitVec.ofNatClamp v n := by
+  rw [shiftLeft_eq']
+  by_cases hn : n < 2 ^ v
+  · rw [toNat_ofNatClamp_of_lt hn]
+  · rw [toNat_ofNatClamp_of_le (Nat.le_of_not_lt hn), shiftLeft_eq_zero (by omega),
+      shiftLeft_eq_zero (by omega)]
+
+theorem sshiftRight_eq_sshiftRight'_ofNatClamp {w n v : Nat} {x : BitVec w} (h : w < 2 ^ v) :
+    x.sshiftRight n = x.sshiftRight' (BitVec.ofNatClamp v n) := by
+  rw [sshiftRight_eq']
+  by_cases hn : n < 2 ^ v
+  · rw [toNat_ofNatClamp_of_lt hn]
+  · rw [toNat_ofNatClamp_of_le (Nat.le_of_not_lt hn)]
+    exact sshiftRight_eq_sshiftRight_of_le (by omega) (by omega)
 
 /-! ### signExtend -/
 

--- a/src/Lean/Meta/Sym/DSimp/EvalGround.lean
+++ b/src/Lean/Meta/Sym/DSimp/EvalGround.lean
@@ -447,6 +447,12 @@ def evalBitVecOfNat (n a : Expr) : DSimpM Result := do
   let e ← share <| toExpr (BitVec.ofNat n a)
   return .step e (done := true)
 
+def evalBitVecOfNatClamp (n a : Expr) : DSimpM Result := do
+  let some n := getNatValue? n | return .rfl
+  let some a := getNatValue? a | return .rfl
+  let e ← share <| toExpr (BitVec.ofNatClamp n a)
+  return .step e (done := true)
+
 def evalInt8ToBitVec (a : Expr) : DSimpM Result := do
   let some v := getInt8Value? a | return .rfl
   let e ← share <| toExpr v.toBitVec
@@ -573,6 +579,7 @@ public def evalGround (config : EvalStepConfig := {}) : DSimproc := fun e =>
   | BitVec.allOnes n => evalBitVecAllOnes n
   | BitVec.toNat _ a => evalBitVecToNat a
   | BitVec.ofNat n a => evalBitVecOfNat n a
+  | BitVec.ofNatClamp n a => evalBitVecOfNatClamp n a
   | BitVec.toInt _ a => evalBitVecToInt a
   | BitVec.ofInt n i => evalBitVecOfInt n i
   | BitVec.toFin _ a => evalBitVecToFin a

--- a/src/Lean/Meta/Sym/Simp/EvalGround.lean
+++ b/src/Lean/Meta/Sym/Simp/EvalGround.lean
@@ -595,8 +595,14 @@ def evalBitVecOfNat (n a : Expr) : SimpM Result := do
   let some a ← getNatValue? a |>.run | return .rfl
   if (← getNatValue? n |>.run).isSome then return .rfl -- already in normal form
   let some n ← evalNat n |>.run | return .rfl -- TODO: consider using dsimp
-  let r ← share (toExpr (BitVec.ofNat n a))
+  let r ← share <| toExpr (BitVec.ofNat n a)
   return .step r (mkRflBitVec r n) (done := true)
+
+def evalBitVecOfNatClamp (n a : Expr) : SimpM Result := do
+  let some nv := getNatValue? n | return .rfl
+  let some av := getNatValue? a | return .rfl
+  let r ← share <| toExpr (BitVec.ofNatClamp nv av)
+  return .step r (mkRflBitVec r nv) (done := true)
 
 def evalBitVecToInt (a : Expr) : SimpM Result := do
   let some a := getBitVecValue? a | return .rfl
@@ -769,6 +775,7 @@ public def evalGround (config : EvalStepConfig := {}) : Simproc := fun e =>
   | BitVec.allOnes n => evalBitVecAllOnes n
   | BitVec.toNat _ a => evalBitVecToNat a
   | BitVec.ofNat n a => evalBitVecOfNat n a
+  | BitVec.ofNatClamp n a => evalBitVecOfNatClamp n a
   | BitVec.toInt _ a => evalBitVecToInt a
   | BitVec.ofInt n i => evalBitVecOfInt n i
   | BitVec.toFin _ a => evalBitVecToFin a

--- a/src/Lean/Meta/Tactic/BVDecide/Normalize/Simproc.lean
+++ b/src/Lean/Meta/Tactic/BVDecide/Normalize/Simproc.lean
@@ -416,10 +416,9 @@ def bvShiftRight (α lhs rhs : Expr) : SimprocM (Sym.Simp.Result) := do
   else
     let_expr BitVec.ofNat nExpr kExpr := rhs | return .rfl
     let some n := Sym.getNatValue? nExpr | return .rfl
-    if w != n then return .rfl
     let some k := Sym.getNatValue? kExpr | return .rfl
-    let expr ← BitVec.mkNatShiftRight lhs (← mkLit (k % 2 ^ w)) wExpr
-    let proof := mkApp3 (mkConst ``BitVec.ushiftRight_ofNat_eq) wExpr lhs kExpr
+    let expr ← BitVec.mkNatShiftRight lhs (← mkLit (k % 2 ^ n)) wExpr
+    let proof := mkApp4 (mkConst ``BitVec.ushiftRight_ofNat_eq) wExpr lhs nExpr kExpr
     countRule `bvShiftRight.ushiftRightOfNat
     return .step expr proof
 
@@ -565,13 +564,11 @@ where
 
 def bvShiftLeft (α lhs rhs : Expr) : SimprocM (Sym.Simp.Result) := do
   let_expr BitVec wExpr := α | return .rfl
-  let some w := Sym.getNatValue? wExpr | return .rfl
   let_expr BitVec.ofNat nExpr kExpr := rhs | return .rfl
   let some n := Sym.getNatValue? nExpr | return .rfl
-  if w != n then return .rfl
   let some k := Sym.getNatValue? kExpr | return .rfl
-  let expr ← BitVec.mkNatShiftLeft lhs (← mkLit (k % 2 ^ w)) wExpr
-  let proof := mkApp3 (mkConst ``BitVec.shiftLeft_ofNat_eq) wExpr lhs kExpr
+  let expr ← BitVec.mkNatShiftLeft lhs (← mkLit (k % 2 ^ n)) wExpr
+  let proof := mkApp4 (mkConst ``BitVec.shiftLeft_ofNat_eq) wExpr lhs nExpr kExpr
   countRule `bvShiftLeft
   return .step expr proof
 
@@ -580,11 +577,9 @@ def bvSshiftRight' (nExpr mExpr lhs rhs : Expr) : SimprocM (Sym.Simp.Result) := 
   let some m := Sym.getNatValue? mExpr | return .rfl
   if n != m then return .rfl
   let_expr BitVec.ofNat wExpr kExpr := rhs | return .rfl
-  let some w := Sym.getNatValue? wExpr | return .rfl
-  if n != w then return .rfl
   let some k := Sym.getNatValue? kExpr | return .rfl
-  let expr ← BitVec.mkSshiftRight lhs (← mkLit (k % 2 ^ w)) wExpr
-  let proof := mkApp3 (mkConst ``BitVec.sshiftRight'_ofNat_eq_sshiftRight) wExpr lhs kExpr
+  let expr ← BitVec.mkSshiftRight lhs (← mkLit (k % 2 ^ n)) wExpr
+  let proof := mkApp4 (mkConst ``BitVec.sshiftRight'_ofNat_eq_sshiftRight) wExpr lhs nExpr kExpr
   countRule `bvSshiftRight'
   return .step expr proof
 

--- a/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/BitVec.lean
+++ b/src/Lean/Meta/Tactic/Simp/BuiltinSimprocs/BitVec.lean
@@ -276,6 +276,14 @@ builtin_dsimproc [simp, seval] reduceOfInt (BitVec.ofInt _ _) := fun e => do
   return .done <| (← toExpr' (BitVec.ofInt n i))
 
 set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
+/-- Simplification procedure for `BitVec.ofNatClamp` on literals. -/
+builtin_dsimproc [simp, seval] reduceOfNatClamp (BitVec.ofNatClamp _ _) := fun e => do
+  let_expr BitVec.ofNatClamp w n ← e | return .continue
+  let some w ← Nat.fromExpr? w | return .continue
+  let some n ← Nat.fromExpr? n | return .continue
+  return .done <| (← toExpr' (BitVec.ofNatClamp w n))
+
+set_option linter.coreInternal.internalModule false in -- User-facing builtin simprocs are fine
 /-- Simplification procedure for ensuring `BitVec.ofNat` literals are normalized. -/
 builtin_dsimproc [simp, seval] reduceOfNat (BitVec.ofNat _ _) := fun e => do
   let_expr BitVec.ofNat n v ← e | return .continue

--- a/tests/elab/bitvec_ofNatClamp.lean
+++ b/tests/elab/bitvec_ofNatClamp.lean
@@ -1,0 +1,30 @@
+import Lean
+
+/-!
+Tests for literal evaluation of `BitVec.ofNatClamp` in `simp`/`seval`, in `sym => simp` (via
+`Sym.Simp.evalGround`) and in `sym => dsimp` (via `Sym.DSimp.evalGround`), plus basic sanity
+checks of the `ofNatClamp` theory.
+-/
+
+/-! ## `simp` -/
+
+#check_simp BitVec.ofNatClamp 8 5 ~> 5#8
+#check_simp BitVec.ofNatClamp 8 255 ~> 255#8
+#check_simp BitVec.ofNatClamp 8 256 ~> 255#8
+#check_simp BitVec.ofNatClamp 8 300 ~> 255#8
+#check_simp BitVec.ofNatClamp 0 3 ~> 0#0
+
+example : BitVec.ofNatClamp 8 300 = 255#8 := by simp only [seval]
+
+register_sym_simp clampGround where
+  post := ground
+
+example : BitVec.ofNatClamp 8 300 = 255#8 := by
+  sym => simp clampGround
+
+example (x : BitVec 8) (h : x = 255#8) : x = BitVec.ofNatClamp 8 300 := by
+  sym =>
+    dsimp
+    exact h
+
+example (x : BitVec 12) : BitVec.ofNatClamp 12 x.toNat = x := by simp


### PR DESCRIPTION
This PR introduces `BitVec.ofNatClamp` as a generalization of the already existing `UIntX.ofNatClamped` family of functions.

Future PRs will refactor `UIntX` towards this API and use it within `bv_decide`.