### PR TITLE
fix: simproc panic on stale extra-argument count

### DIFF
--- a/src/Lean/Elab/PreDefinition/WF/Preprocess.lean
+++ b/src/Lean/Elab/PreDefinition/WF/Preprocess.lean
@@ -93,7 +93,7 @@ def mkWfParam (e : Expr) : MetaM Expr :=
   mkAppM ``wfParam #[e]
 
 /-- `f (wfParam x) ==> wfParam (f x)` if `f` is a projection -/
-builtin_dsimproc paramProj (_) := fun e => do
+builtin_dsimproc_decl paramProj (_) := fun e => do
   if h : e.isApp then
     let some a' := isWfParam? (e.appArg h) | return .continue
     let f := e.getAppFn
@@ -105,7 +105,7 @@ builtin_dsimproc paramProj (_) := fun e => do
     return .continue
 
 /-- `match (wfParam x) with con y => alt[y] ==> match x with con y => alt[wfParam y] -/
-builtin_dsimproc paramMatcher (_) := fun e => do
+builtin_dsimproc_decl paramMatcher (_) := fun e => do
   let some matcherApp ← matchMatcherApp? e (alsoCasesOn := true)  | return .continue
   unless matcherApp.discrs.any (isWfParam? · |>.isSome) do return .continue
   let discrs' := matcherApp.discrs.map (fun e => isWfParam? e |>.getD e)
@@ -152,7 +152,7 @@ otherwise `... ==> let x : T := e; body[x]`. (Applies to `have`s too.)
 
 Note: simprocs are provided the head of a let telescope, but not intermediate lets.
 -/
-builtin_dsimproc paramLet (_) := fun e => do
+builtin_dsimproc_decl paramLet (_) := fun e => do
   unless e.isLet || anyLetValueIsWfParam e do return .continue
   return .continue (← processParamLet e)
 

--- a/src/Lean/Meta/Tactic/Simp/Simproc.lean
+++ b/src/Lean/Meta/Tactic/Simp/Simproc.lean
@@ -186,7 +186,15 @@ def Simprocs.add (s : Simprocs) (declName : Name) (post : Bool) : CoreM Simprocs
     throwError "Invalid `[simproc]` attribute: `{.ofConstName declName}` is not a simproc"
   return s.addCore keys declName post proc
 
+/--
+Applies `s` to `e` after peeling off `numExtraArgs` trailing arguments.
+
+`numExtraArgs` may be stale: `simprocCore` collects all candidates for one expression up front and
+then rewrites that expression as it goes, so `e` may by now have fewer arguments than the expression
+the candidate was selected for. Such a candidate declines.
+-/
 def SimprocEntry.try (s : SimprocEntry) (numExtraArgs : Nat) (e : Expr) : SimpM Step := do
+  if e.getAppNumArgs < numExtraArgs then return .continue
   let mut extraArgs := #[]
   let mut e := e
   for _ in *...numExtraArgs do
@@ -203,6 +211,7 @@ def SimprocEntry.try (s : SimprocEntry) (numExtraArgs : Nat) (e : Expr) : SimpM 
 
 /-- Similar to `try`, but only consider `DSimproc` case. That is, if `s.proc` is a `Simproc`, treat it as a `.continue`. -/
 def SimprocEntry.tryD (s : SimprocEntry) (numExtraArgs : Nat) (e : Expr) : SimpM DStep := do
+  if e.getAppNumArgs < numExtraArgs then return .continue
   let mut extraArgs := #[]
   let mut e := e
   for _ in *...numExtraArgs do

--- a/tests/elab/issue14919.lean
+++ b/tests/elab/issue14919.lean
@@ -1,0 +1,21 @@
+import Lean
+
+/-!
+Regression test for #14919: `simprocCore` collects all simproc candidates for an expression up
+front, each with the number of trailing arguments to peel off before running it. A simproc that
+returns `.continue` with a smaller expression used to leave those counts stale, so the next
+candidate panicked in `Expr.appArg!`/`Expr.appFn!`.
+-/
+
+open Lean Meta Simp
+
+private def foo (_a _b : Nat) : Nat := 0
+
+/-- Rewrites the whole application to a term that is not an application. -/
+simproc shrink (foo _ _) := fun _ => return .continue (some { expr := mkRawNatLit 0 })
+
+/-- Selected as a candidate for the prefix `foo 1`, that is, with one extra argument. -/
+simproc prefixKey (foo _) := fun _ => return .continue
+
+set_option linter.unusedSimpArgs false in
+example : foo 1 2 = 0 := by simp only [shrink, prefixKey]


### PR DESCRIPTION
This PR fixes `simp` and `dsimp` panicking with "PANIC at Lean.Expr.appArg!/appFn!: application expected" when one simproc rewrites a term to something with fewer arguments. The panics were logged at `info` severity, so the build kept going and exited successfully while emitting them.

`simprocCore` and `dsimprocCore` collect all candidates for an expression up front, each with the number of trailing arguments to peel off before running it, and then rewrite the expression as they go. A candidate selected for the original expression could thus be asked to peel arguments off a term that no longer has them. Such a candidate now declines instead.

The three well-founded recursion simprocs `paramProj`, `paramMatcher` and `paramLet` were the ones observed panicking because they are the only simprocs in the default simp set with a wildcard pattern, which makes them candidates at every argument prefix. They are now declared with `builtin_dsimproc_decl`, so they are no longer part of the default simp set; `Lean.Elab.WF.preprocess` adds them explicitly anyway.

Closes #14919

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019XqLXLLym6ZLWnSdv3gexs
