### PR TITLE
fix: do not apply simproc candidates selected for a rewritten expression

### DIFF
--- a/src/Lean/Meta/Tactic/Simp/Simproc.lean
+++ b/src/Lean/Meta/Tactic/Simp/Simproc.lean
@@ -186,6 +186,13 @@ def Simprocs.add (s : Simprocs) (declName : Name) (post : Bool) : CoreM Simprocs
     throwError "Invalid `[simproc]` attribute: `{.ofConstName declName}` is not a simproc"
   return s.addCore keys declName post proc
 
+/--
+Applies `s` to `e` after peeling off `numExtraArgs` trailing arguments, and re-applies them to the
+result. This is how a simproc keyed on `f a b` fires on the over-application `f a b c`.
+
+`numExtraArgs` must be the number `getMatchWithExtra` returned for `e` itself; a number obtained for
+a different expression may exceed the number of arguments `e` has.
+-/
 def SimprocEntry.try (s : SimprocEntry) (numExtraArgs : Nat) (e : Expr) : SimpM Step := do
   let mut extraArgs := #[]
   let mut e := e
@@ -213,6 +220,13 @@ def SimprocEntry.tryD (s : SimprocEntry) (numExtraArgs : Nat) (e : Expr) : SimpM
   | .inl _ => return .continue
   | .inr proc => return (← proc e).addExtraArgs extraArgs
 
+/--
+Runs the applicable simprocs in `s` on `e`, and returns as soon as one of them rewrites `e`.
+
+We must not keep going with the remaining candidates: they were selected for `e`, and the number of
+extra arguments recorded for each of them only makes sense for `e`. The simplifier looks up
+candidates afresh when it revisits the rewritten expression.
+-/
 def simprocCore (post : Bool) (s : SimprocTree) (erased : PHashSet Name) (e : Expr) : SimpM Step := do
   let candidates ← withSimpIndexConfig <| s.getMatchWithExtra e
   if candidates.isEmpty then
@@ -220,36 +234,19 @@ def simprocCore (post : Bool) (s : SimprocTree) (erased : PHashSet Name) (e : Ex
     trace[Debug.Meta.Tactic.simp] "no {tag}-simprocs found for {e}"
     return .continue
   else
-    let mut e  := e
-    let mut proof? : Option Expr := none
-    let mut found := false
-    let mut cache := true
     for (simprocEntry, numExtraArgs) in candidates do
       unless erased.contains simprocEntry.declName do
-        let s ← simprocEntry.try numExtraArgs e
-        match s with
-        | .visit r =>
+        let step ← simprocEntry.try numExtraArgs e
+        match step with
+        | .visit r | .done r | .continue (some r) =>
           trace[Debug.Meta.Tactic.simp] "simproc result {e} => {r.expr}"
           recordSimpTheorem (.decl simprocEntry.declName post)
-          return .visit (← mkEqTransOptProofResult proof? cache r)
-        | .done r =>
-          trace[Debug.Meta.Tactic.simp] "simproc result {e} => {r.expr}"
-          recordSimpTheorem (.decl simprocEntry.declName post)
-          return .done (← mkEqTransOptProofResult proof? cache r)
-        | .continue (some r) =>
-          trace[Debug.Meta.Tactic.simp] "simproc result {e} => {r.expr}"
-          recordSimpTheorem (.decl simprocEntry.declName post)
-          e := r.expr
-          proof? ← mkEqTrans? proof? r.proof?
-          cache := cache && r.cache
-          found := true
+          return step
         | .continue none =>
           pure ()
-    if found then
-      return .continue (some { expr := e, proof?, cache })
-    else
-      return .continue
+    return .continue
 
+/-- Similar to `simprocCore`, but for `DSimproc`s. -/
 def dsimprocCore (post : Bool) (s : SimprocTree) (erased : PHashSet Name) (e : Expr) : SimpM DStep := do
   let candidates ← withSimpIndexConfig <| s.getMatchWithExtra e
   if candidates.isEmpty then
@@ -257,31 +254,17 @@ def dsimprocCore (post : Bool) (s : SimprocTree) (erased : PHashSet Name) (e : E
     trace[Debug.Meta.Tactic.simp] "no {tag}-simprocs found for {e}"
     return .continue
   else
-    let mut e  := e
-    let mut found := false
     for (simprocEntry, numExtraArgs) in candidates do
       unless erased.contains simprocEntry.declName do
-        let s ← simprocEntry.tryD numExtraArgs e
-        match s with
-        | .visit eNew =>
+        let step ← simprocEntry.tryD numExtraArgs e
+        match step with
+        | .visit eNew | .done eNew | .continue (some eNew) =>
           trace[Debug.Meta.Tactic.simp] "simproc result {e} => {eNew}"
           recordSimpTheorem (.decl simprocEntry.declName post)
-          return .visit eNew
-        | .done eNew =>
-          trace[Debug.Meta.Tactic.simp] "simproc result {e} => {eNew}"
-          recordSimpTheorem (.decl simprocEntry.declName post)
-          return .done eNew
-        | .continue (some eNew) =>
-          trace[Debug.Meta.Tactic.simp] "simproc result {e} => {eNew}"
-          recordSimpTheorem (.decl simprocEntry.declName post)
-          e := eNew
-          found := true
+          return step
         | .continue none =>
           pure ()
-    if found then
-      return .continue (some e)
-    else
-      return .continue
+    return .continue
 
 abbrev SimprocsArray := Array Simprocs
 

--- a/tests/elab/issue14919.lean
+++ b/tests/elab/issue14919.lean
@@ -1,0 +1,21 @@
+import Lean
+
+/-!
+Regression test for #14919: `simprocCore` collects all simproc candidates for an expression up
+front, each with the number of trailing arguments to peel off before running it. A simproc that
+returns `.continue` with a smaller expression used to leave those counts stale, so the next
+candidate panicked in `Expr.appArg!`/`Expr.appFn!`.
+-/
+
+open Lean Meta Simp
+
+private def foo (_a _b : Nat) : Nat := 0
+
+/-- Rewrites the whole application to a term that is not an application. -/
+simproc shrink (foo _ _) := fun _ => return .continue (some { expr := mkRawNatLit 0 })
+
+/-- Selected as a candidate for the prefix `foo 1`, that is, with one extra argument. -/
+simproc prefixKey (foo _) := fun _ => return .continue
+
+set_option linter.unusedSimpArgs false in
+example : foo 1 2 = 0 := by simp only [shrink, prefixKey]


### PR DESCRIPTION
This PR fixes `simp` and `dsimp` panicking with `PANIC at Lean.Expr.appArg!` / `Lean.Expr.appFn!: application expected` when one simproc rewrites a term to one with fewer arguments. The panic is logged at `info` severity, so the build still exits successfully while emitting it.

`simprocCore` and `dsimprocCore` looked up all candidates for an expression in the discrimination tree, each with the number of trailing arguments to peel off before running it, and then rewrote the expression as they went. Once a candidate had rewritten the expression, the remaining ones no longer described it, and the number of extra arguments recorded for them could exceed the number of arguments the expression had. They now return as soon as a candidate rewrites the expression, and let the simplifier look up candidates afresh when it revisits the result. `simprocArrayCore` already works this way across simproc sets.

The simprocs observed panicking in #14919 are `Lean.Elab.WF.paramProj`, `paramMatcher` and `paramLet`. They are the victims rather than the cause: they are the only simprocs in the default simp set declared with the wildcard pattern `(_)`, which makes them candidates at every argument prefix. That they are in the default simp set at all is addressed in a separate PR.

Closes #14919

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XqLXLLym6ZLWnSdv3gexs
