### PR TITLE
fix: do not register the well-founded recursion simprocs globally

### DIFF
--- a/src/Lean/Elab/PreDefinition/WF/Preprocess.lean
+++ b/src/Lean/Elab/PreDefinition/WF/Preprocess.lean
@@ -93,7 +93,7 @@ def mkWfParam (e : Expr) : MetaM Expr :=
   mkAppM ``wfParam #[e]
 
 /-- `f (wfParam x) ==> wfParam (f x)` if `f` is a projection -/
-builtin_dsimproc paramProj (_) := fun e => do
+builtin_dsimproc_decl paramProj (_) := fun e => do
   if h : e.isApp then
     let some a' := isWfParam? (e.appArg h) | return .continue
     let f := e.getAppFn
@@ -105,7 +105,7 @@ builtin_dsimproc paramProj (_) := fun e => do
     return .continue
 
 /-- `match (wfParam x) with con y => alt[y] ==> match x with con y => alt[wfParam y] -/
-builtin_dsimproc paramMatcher (_) := fun e => do
+builtin_dsimproc_decl paramMatcher (_) := fun e => do
   let some matcherApp ← matchMatcherApp? e (alsoCasesOn := true)  | return .continue
   unless matcherApp.discrs.any (isWfParam? · |>.isSome) do return .continue
   let discrs' := matcherApp.discrs.map (fun e => isWfParam? e |>.getD e)
@@ -152,7 +152,7 @@ otherwise `... ==> let x : T := e; body[x]`. (Applies to `have`s too.)
 
 Note: simprocs are provided the head of a let telescope, but not intermediate lets.
 -/
-builtin_dsimproc paramLet (_) := fun e => do
+builtin_dsimproc_decl paramLet (_) := fun e => do
   unless e.isLet || anyLetValueIsWfParam e do return .continue
   return .continue (← processParamLet e)
 


### PR DESCRIPTION
This PR stops the simprocs `Lean.Elab.WF.paramProj`, `paramMatcher` and `paramLet` from taking part in every `simp` and `dsimp` call. They implement one step of the preprocessing of definitions by well-founded recursion and are of no use elsewhere.

They were declared with `builtin_dsimproc`, which adds them to the default simp set. As they use the wildcard pattern `(_)`, they were returned as candidates for every subterm at every argument prefix. `Lean.Elab.WF.preprocess` adds them to its own simp context explicitly, so `builtin_dsimproc_decl` is enough. `simp only [Lean.Elab.WF.paramLet]`, as used in `Std.Tactic.BVDecide`, keeps working.

Noticed while investigating #14919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XqLXLLym6ZLWnSdv3gexs
