### PR TITLE
fix: do not panic when numExtraArgs exceeds the application spine

### DIFF
--- a/src/Lean/Meta/Tactic/Simp/Rewrite.lean
+++ b/src/Lean/Meta/Tactic/Simp/Rewrite.lean
@@ -164,6 +164,11 @@ private def tryTheoremCore (lhs : Expr) (xs : Array Expr) (bis : Array BinderInf
   let mut extraArgs := #[]
   let mut e := e
   for _ in *...numExtraArgs do
+    -- `numExtraArgs` may exceed the raw application spine: the non-indexed path
+    -- computes it from a reduced form of `e`, and `simprocCore` can shorten `e`
+    -- after the candidates were selected. Decline rather than panic in the
+    -- partial accessors below.
+    unless e.isApp do return none
     extraArgs := extraArgs.push e.appArg!
     e := e.appFn!
   extraArgs := extraArgs.reverse

--- a/src/Lean/Meta/Tactic/Simp/Simproc.lean
+++ b/src/Lean/Meta/Tactic/Simp/Simproc.lean
@@ -190,6 +190,12 @@ def SimprocEntry.try (s : SimprocEntry) (numExtraArgs : Nat) (e : Expr) : SimpM 
   let mut extraArgs := #[]
   let mut e := e
   for _ in *...numExtraArgs do
+    -- `numExtraArgs` was computed by `getMatchWithExtra` for the expression as
+    -- it was when the candidates were selected. `simprocCore` rewrites `e` when
+    -- an earlier candidate returns `.continue (some r)`, so by the time a later
+    -- candidate runs the count can exceed the current application spine.
+    -- Decline rather than panic in the partial accessors below.
+    unless e.isApp do return .continue
     extraArgs := extraArgs.push e.appArg!
     e := e.appFn!
   extraArgs := extraArgs.reverse
@@ -206,6 +212,12 @@ def SimprocEntry.tryD (s : SimprocEntry) (numExtraArgs : Nat) (e : Expr) : SimpM
   let mut extraArgs := #[]
   let mut e := e
   for _ in *...numExtraArgs do
+    -- `numExtraArgs` was computed by `getMatchWithExtra` for the expression as
+    -- it was when the candidates were selected. `simprocCore` rewrites `e` when
+    -- an earlier candidate returns `.continue (some r)`, so by the time a later
+    -- candidate runs the count can exceed the current application spine.
+    -- Decline rather than panic in the partial accessors below.
+    unless e.isApp do return .continue
     extraArgs := extraArgs.push e.appArg!
     e := e.appFn!
   extraArgs := extraArgs.reverse

--- a/tests/elab/simprocStaleNumExtraArgs.lean
+++ b/tests/elab/simprocStaleNumExtraArgs.lean
@@ -1,0 +1,35 @@
+/-!
+Regression test for the partial `Expr.appArg!`/`Expr.appFn!` stripping loops in
+`Lean.Meta.Simp.SimprocEntry.try`, `SimprocEntry.tryD` and
+`Lean.Meta.Simp.tryTheoremCore`.
+
+Each loop strips `numExtraArgs` arguments using the partial accessors without
+checking that it still has an application. `numExtraArgs` can exceed the
+current application spine in two independent ways:
+
+* in the non-indexed rewriting path, it is computed from a *reduced* form of the
+  expression while the stripping happens on the *raw* one, which is what the
+  example below exercises: the count comes from `g 0 1`, which has two
+  arguments, while `foo 1` has one;
+* in `simprocCore`, the candidates and their counts are computed once, but an
+  earlier candidate returning `.continue (some r)` rewrites the expression, so a
+  later candidate can receive a count for a longer, superseded spine.
+
+When the loop ran off the end, `panic!` returned its `Inhabited` fallback and
+`_inhabitedExprDummy` leaked into elaboration, producing a spurious
+`Unknown constant` error. Because a panic is logged at `info` severity, builds
+still exited successfully while emitting them.
+-/
+
+opaque g : Nat → Nat → Unit
+
+@[reducible] def foo : Nat → Unit := g 0
+
+theorem all_unit (x : Unit) : x = () := Subsingleton.elim _ _
+
+-- `all_unit` is reported unused because `simp` closes the goal by other means
+-- once it no longer panics; it still has to be in the simp set to reach the
+-- rewriting path under test.
+set_option linter.unusedSimpArgs false in
+example : foo 1 = () := by
+  simp (config := { index := false }) only [all_unit]


### PR DESCRIPTION
This PR stops `simp` panicking when the number of extra arguments to strip
exceeds the expression's application spine, which also removes a spurious
`Unknown constant` error that the panic's fallback value produced.

Closes #14919.

`SimprocEntry.try`, `SimprocEntry.tryD` and `Simp.tryTheoremCore` each strip
`numExtraArgs` arguments using `Expr.appArg!` and `Expr.appFn!` without checking
that an application remains. `getMatchWithExtra` is not at fault: its recursion
increments only after checking the raw expression is an application, so for the
expression it is handed, `numExtraArgs ≤ e.getAppNumArgs`. The count becomes
wrong afterwards, in two independent ways.

In `simprocCore` the candidate list and its counts are computed once, but the
loop rewrites the expression as it goes:

```lean
let candidates ← withSimpIndexConfig <| s.getMatchWithExtra e
let mut e := e
for (simprocEntry, numExtraArgs) in candidates do
    let s ← simprocEntry.try numExtraArgs e
    ...
    | .continue (some r) => e := r.expr
```

A later candidate then holds a count for the superseded, longer spine.
`dsimprocCore` has the same structure. In the case this was found in, the
expression `![![1]] 0 0` has a spine of six and produces wildcard candidates at
every prefix, including three at `extra=6`. `Matrix.cons_val` rewrites it to
`![1] 0`, a spine of five, and the three stale candidates then strip six
arguments from five, reaching `Expr.const ``Matrix.vecCons` and calling the
accessors on a constant.

In the non-indexed rewriting path the count is computed from a reduced form of
the expression while the stripping happens on the raw one. That case is
independent of simprocs and is what the added test covers:

```lean
opaque g : Nat → Nat → Unit
@[reducible] def foo : Nat → Unit := g 0
theorem all_unit (x : Unit) : x = () := Subsingleton.elim _ _

example : foo 1 = () := by
  simp (config := { index := false }) only [all_unit]
```

`getMatchLiberal` sees the reduced `g 0 1`, two arguments, while
`tryTheoremCore` strips from the raw `foo 1`, one.

The consequence was not confined to log noise. `panic!` returns its `Inhabited`
fallback, so a dummy `Expr` reached elaboration and the example above reported

```
error: Unknown constant `_inhabitedExprDummy`
```

in addition to the panics. Since panics are logged at `info` severity, builds
still exited successfully; one file in the project where this surfaced emitted
972 of them without failing.

Guarding the loops is the appropriate layer: the mismatch is a reachable state
rather than evidence that the discrimination tree malfunctioned, so an assertion
would be wrong. Discarding the partially collected arguments is correct, because
without a valid decomposition into a matched prefix plus trailing arguments the
simproc or theorem must not be applied; any earlier successful result is already
held in `simprocCore`'s own accumulators.

Verified on a build of this branch: the reproducer above goes from an error plus
two panics to clean output with the goal closed, and 622 `simp`-related tests in
`tests/elab` pass, with seven failures that are identical on an unpatched build
of the same commit.

The added regression test covers the `tryTheoremCore` path. I was not able to
reduce the `simprocCore` stale-candidate path to a Mathlib-free test, since it
needs a rewriting simproc in the same discrimination tree as the wildcard ones;
that path is evidenced by the original Mathlib case described above.