### PR TITLE
perf: try eta-expansion before delta-reduction in the kernel

### DIFF
--- a/src/kernel/type_checker.cpp
+++ b/src/kernel/type_checker.cpp
@@ -1202,6 +1202,16 @@ bool type_checker::is_def_eq_core(expr const & t, expr const & s) {
     r = is_def_eq_proof_irrel(t_n, s_n);
     if (r != l_undef) return r == l_true;
 
+    /*
+      Try eta-expansion before delta-reduction, as `Meta.isDefEq` does.
+      Since the kernel has no metavariables, `(fun x => t) =?= s` holds iff `(fun x => t) =?= (fun x => s x)`,
+      so this cannot lose solutions, and it avoids unfolding `s` when the two sides differ only by eta.
+      Without it, `(fun x => f a x) =?= f a` delta-normalizes `f a` symbolically, which is exponential for
+      `f` a structural recursion over a tree (issue #14803).
+    */
+    if (try_eta_expansion(t_n, s_n))
+        return true;
+
     /* NB: `lazy_delta_reduction` updates `t_n` and `s_n` even when returning `l_undef`. */
     r = lazy_delta_reduction(t_n, s_n);
     if (r != l_undef) return r == l_true;
@@ -1230,6 +1240,7 @@ bool type_checker::is_def_eq_core(expr const & t, expr const & s) {
     if (is_def_eq_app(t_n, s_n))
         return true;
 
+    /* Retry: `lazy_delta_reduction` may have exposed a lambda on one of the sides. */
     if (try_eta_expansion(t_n, s_n))
         return true;
 

--- a/tests/elab/14803.lean
+++ b/tests/elab/14803.lean
@@ -1,0 +1,36 @@
+/-!
+Regression test for #14803: the kernel used to try eta-expansion only after
+delta-reduction, so checking `f a =?= fun x => f a x` symbolically normalized
+`f a` instead of eta-expanding it. That normalization is exponential in the
+tree's depth when `f` is a structural recursion over the tree, and it made the
+kernel time out on the proof terms `simp` produces for goals whose two sides
+differ only by eta.
+-/
+
+inductive T where
+  | leaf
+  | node (l r : T)
+
+/-- Complete binary tree of depth `n` with structurally distinct subtrees, so
+pointer-equality caching cannot collapse the comparison. -/
+def mkT : Nat → Nat → T
+  | 0, _ => .leaf
+  | n+1, i => .node (mkT n (2*i)) (mkT n (2*i+1))
+
+/-- Function-valued structural recursion, expensive to normalize symbolically. -/
+def interp : T → Nat → Nat
+  | .leaf => Nat.succ
+  | .node l r => interp l ∘ interp r
+
+/-- The defeq check the kernel has to perform, without `simp` in the picture. -/
+theorem kernelEta : (fun x => interp (mkT 10 0) x) = interp (mkT 10 0) :=
+  @rfl _ (fun x => interp (mkT 10 0) x)
+
+def wrap (f : Nat → Nat) : Nat → Nat := f
+
+theorem wrap_eq (f : Nat → Nat) : wrap f = fun x => f x := rfl
+
+/-- `simp` closes this instantly and emits a proof whose `Eq.trans` forces the
+kernel to check `interp (mkT 10 0) =?= fun x => interp (mkT 10 0) x`. -/
+theorem viaSimp : wrap (interp (mkT 10 0)) = interp (mkT 10 0) := by
+  simp -implicitDefEqProofs only [wrap_eq]


### PR DESCRIPTION
This PR fixes `(kernel) deterministic timeout` errors on proof terms whose two sides differ only by eta, such as the ones `simp` produces when rewriting with a function-valued equation. The kernel now answers those definitional equality checks as quickly as `Meta.isDefEq` already did.

`Meta.isExprDefEqExpensive` tries `isDefEqEta` before `whnfCore` and lazy delta-reduction, but `type_checker::is_def_eq_core` only tried `try_eta_expansion` after `lazy_delta_reduction`. So for `f a =?= fun x => f a x` the kernel delta-normalized `f a` instead of eta-expanding it, and as soon as the unfolded side became a lambda itself, `quick_is_def_eq` committed to `is_def_eq_binding` without backtracking and descended into the normalized subterms. When `f` is a structural recursion over a tree, that is exponential in the tree's depth: the reproducer in `tests/elab/14803.lean` took 19s at depth 8 and timed out at depth 10, and now takes 0.1s.

Since the kernel has no metavariables, `(fun x => t) =?= s` holds iff `(fun x => t) =?= (fun x => s x)`, so trying eta first cannot lose solutions. The `try_eta_expansion` call after `lazy_delta_reduction` is kept because that reduction updates both sides and may expose a lambda the earlier check did not see.

Closes #14803