### PR TITLE
feat: support some symbolic `Nat` operations in `bv_decide`

### DIFF
--- a/src/Lean/Meta/Tactic/BVDecide/Normalize/Simproc.lean
+++ b/src/Lean/Meta/Tactic/BVDecide/Normalize/Simproc.lean
@@ -173,6 +173,27 @@ def mkNatShiftLeft (lhs rhs : Expr) (wExpr : Expr) : SimprocM Expr :=
     let inst := mkApp (mkConst ``BitVec.instHShiftLeftNat) wExpr
     Sym.share <| mkApp4 (mkConst ``HShiftLeft.hShiftLeft [0, 0, 0]) ty (mkConst ``Nat) ty inst
 
+def mkBvShiftRight (lhs rhs : Expr) (wExpr vExpr : Expr) : Sym.SymM Expr := do
+  let lty := mkBitVecTy wExpr
+  let rty := mkBitVecTy vExpr
+  let inst := mkApp2 (mkConst ``BitVec.instHShiftRight) wExpr vExpr
+  Sym.share <| mkApp6 (mkConst ``HShiftRight.hShiftRight [0, 0, 0]) lty rty lty inst lhs rhs
+
+def mkBvShiftLeft (lhs rhs : Expr) (wExpr vExpr : Expr) : Sym.SymM Expr := do
+  let lty := mkBitVecTy wExpr
+  let rty := mkBitVecTy vExpr
+  let inst := mkApp2 (mkConst ``BitVec.instHShiftLeft) wExpr vExpr
+  Sym.share <| mkApp6 (mkConst ``HShiftLeft.hShiftLeft [0, 0, 0]) lty rty lty inst lhs rhs
+
+def mkSshiftRight' (lhs rhs : Expr) (wExpr vExpr : Expr) : Sym.SymM Expr :=
+  Sym.share <| mkApp4 (mkConst ``BitVec.sshiftRight') wExpr vExpr lhs rhs
+
+def mkOfNatClamp (vExpr nExpr : Expr) : Sym.SymM Expr :=
+  Sym.share <| mkApp2 (mkConst ``BitVec.ofNatClamp) vExpr nExpr
+
+def mkSetWidth (oldWidthExpr newWidthExpr target : Expr) : Sym.SymM Expr :=
+  Sym.share <| mkApp3 (mkConst ``BitVec.setWidth) oldWidthExpr newWidthExpr target
+
 def mkBEq (lhs rhs : Expr) (wExpr : Expr) : SimprocM Expr :=
   withCachedBinOp wExpr ``instDecidableEqBitVec lhs rhs fun wExpr => do
     let ty := mkBitVecTy wExpr
@@ -436,6 +457,19 @@ def extractLsb' (wExpr startExpr lenExpr targetExpr : Expr) : SimprocM (Sym.Simp
   let res ← tryExtractFull
   if !res.isRfl then return res
 
+  -- For a symbolic start with known widths, we reduce to shift by the symbolic start + setWidth
+  -- by the known widths. This is sensible as we can perform a limited degree of reasoning on
+  -- symbolic shifts.
+  if (Sym.getNatValue? startExpr).isNone then
+    unless (Sym.getNatValue? wExpr).isSome && (Sym.getNatValue? lenExpr).isSome do return .rfl
+    let shifted ← BitVec.mkNatShiftRight targetExpr startExpr wExpr
+    let expr ← BitVec.mkSetWidth wExpr lenExpr shifted
+    let proof := mkApp4
+      (mkConst ``Std.Tactic.BVDecide.Normalize.BitVec.extractLsb'_eq_setWidth_ushiftRight)
+      wExpr targetExpr startExpr lenExpr
+    countRule `bvExtract.symbolicStart
+    return .step expr proof
+
   match_expr targetExpr with
   | HAnd.hAnd _ _ _ _ lhs rhs =>
     unless isVarValueExtract lhs || isVarValueExtract rhs do return .rfl
@@ -572,14 +606,11 @@ def bvShiftLeft (α lhs rhs : Expr) : SimprocM (Sym.Simp.Result) := do
   countRule `bvShiftLeft
   return .step expr proof
 
-def bvSshiftRight' (nExpr mExpr lhs rhs : Expr) : SimprocM (Sym.Simp.Result) := do
-  let some n := Sym.getNatValue? nExpr | return .rfl
-  let some m := Sym.getNatValue? mExpr | return .rfl
-  if n != m then return .rfl
-  let_expr BitVec.ofNat wExpr kExpr := rhs | return .rfl
-  let some k := Sym.getNatValue? kExpr | return .rfl
-  let expr ← BitVec.mkSshiftRight lhs (← mkLit (k % 2 ^ n)) wExpr
-  let proof := mkApp4 (mkConst ``BitVec.sshiftRight'_ofNat_eq_sshiftRight) wExpr lhs nExpr kExpr
+def bvSshiftRight' (wExpr vExpr lhs rhs : Expr) : SimprocM (Sym.Simp.Result) := do
+  let some ⟨_, k⟩ := Sym.getBitVecValue? rhs | return .rfl
+  let kExpr ← mkLit k.toNat
+  let expr ← BitVec.mkSshiftRight lhs kExpr wExpr
+  let proof := mkApp4 (mkConst ``BitVec.sshiftRight'_ofNat_eq_sshiftRight) wExpr lhs vExpr kExpr
   countRule `bvSshiftRight'
   return .step expr proof
 
@@ -1224,47 +1255,98 @@ def bvMul (α lhs rhs : Expr) : SimprocM (Sym.Simp.Result) := do
   if let some step ← mulTwoPow then return step
   return .rfl
 
+/--
+For a shift of a `BitVec w` by a symbolic `Nat` amount `rhsExpr`, build the amount width
+`v := w.log2 + 1`, the clamped amount `BitVec.ofNatClamp v rhsExpr` and a proof of `w < 2 ^ v`.
+
+Rewriting the shift amount into a `BitVec` this way leaves only the clamped amount as an
+uninterpreted atom for `bv_decide` while the shift itself remains interpreted.
+-/
+def clampShiftAmount (wExpr rhsExpr : Expr) (w : Nat) : SimprocM (Expr × Expr × Expr) := do
+  let vExpr ← mkLit (w.log2 + 1)
+  let clamped ← BitVec.mkOfNatClamp vExpr rhsExpr
+  let h := Nat.mkDecideProofLt wExpr (← Nat.mkPow (← mkLit 2) vExpr)
+  return (vExpr, clamped, h)
+
+def isBitVecToNat (e : Expr) : Bool :=
+  e.isAppOf ``BitVec.toNat
+
 def bvShiftRightNat (α lhsExpr rhsExpr : Expr) : SimprocM (Sym.Simp.Result) := do
-  let some rhs := Sym.getNatValue? rhsExpr | return .rfl
   let_expr BitVec wExpr := α | return .rfl
   let some w := Sym.getNatValue? wExpr | return .rfl
-  if rhs < w then
-    let zero ← mkLit 0#rhs
-    let newLen := w - rhs
-    let newLenExpr ← mkLit newLen
-    let extract ← BitVec.mkExtractLsb' wExpr rhsExpr newLenExpr lhsExpr
-    let expr ← BitVec.mkAppend zero extract (← mkLit rhs) newLenExpr (← mkLit (newLen + rhs))
-    let h := Nat.mkDecideProofLt rhsExpr wExpr
-    let proof := mkApp4 (mkConst ``BitVec.ushiftRight_eq_extractLsb'_of_lt) wExpr lhsExpr rhsExpr h
-    countRule `bvShiftRightNat.extract
-    return .step (← Sym.share expr) proof
-  else
-    let expr ← mkLit 0#w
-    let h := Nat.mkDecideProofLe wExpr rhsExpr
-    let proof := mkApp4 (mkConst ``BitVec.ushiftRight_eq_zero) wExpr lhsExpr rhsExpr h
-    countRule `bvShiftRightNat.zero
-    return .step expr proof (done := true)
+  match Sym.getNatValue? rhsExpr with
+  | some rhs =>
+    if rhs < w then
+      let zero ← mkLit 0#rhs
+      let newLen := w - rhs
+      let newLenExpr ← mkLit newLen
+      let extract ← BitVec.mkExtractLsb' wExpr rhsExpr newLenExpr lhsExpr
+      let expr ← BitVec.mkAppend zero extract (← mkLit rhs) newLenExpr (← mkLit (newLen + rhs))
+      let h := Nat.mkDecideProofLt rhsExpr wExpr
+      let proof := mkApp4 (mkConst ``BitVec.ushiftRight_eq_extractLsb'_of_lt) wExpr lhsExpr rhsExpr h
+      countRule `bvShiftRightNat.extract
+      return .step (← Sym.share expr) proof
+    else
+      let expr ← mkLit 0#w
+      let h := Nat.mkDecideProofLe wExpr rhsExpr
+      let proof := mkApp4 (mkConst ``BitVec.ushiftRight_eq_zero) wExpr lhsExpr rhsExpr h
+      countRule `bvShiftRightNat.zero
+      return .step expr proof (done := true)
+  | none =>
+    -- Handled by other rewrite rules
+    if isBitVecToNat rhsExpr then return .rfl
+    let (vExpr, clamped, h) ← clampShiftAmount wExpr rhsExpr w
+    let expr ← BitVec.mkBvShiftRight lhsExpr clamped wExpr vExpr
+    let proof := mkApp5 (mkConst ``BitVec.ushiftRight_eq_ushiftRight_ofNatClamp)
+      wExpr rhsExpr vExpr lhsExpr h
+    countRule `bvShiftRightNat.clamp
+    return .step expr proof
 
 def bvShiftLeftNat (α lhsExpr rhsExpr : Expr) : SimprocM (Sym.Simp.Result) := do
-  let some rhs := Sym.getNatValue? rhsExpr | return .rfl
   let_expr BitVec wExpr := α | return .rfl
   let some w := Sym.getNatValue? wExpr | return .rfl
-  if rhs < w then
-    let zero ← mkLit 0#rhs
-    let newLen := w - rhs
-    let newLenExpr ← mkLit newLen
-    let extract ← BitVec.mkExtractLsb' wExpr (← mkLit 0) newLenExpr lhsExpr
-    let expr ← BitVec.mkAppend extract zero newLenExpr (← mkLit rhs) (← mkLit (newLen + rhs))
-    let h := Nat.mkDecideProofLt rhsExpr wExpr
-    let proof := mkApp4 (mkConst ``BitVec.shiftLeft_eq_concat_of_lt) wExpr lhsExpr rhsExpr h
-    countRule `bvShiftLeftNat.concat
-    return .step (← Sym.share expr) proof
-  else
-    let expr ← mkLit 0#w
-    let h := Nat.mkDecideProofLe wExpr rhsExpr
-    let proof := mkApp4 (mkConst ``BitVec.shiftLeft_eq_zero) wExpr lhsExpr rhsExpr h
-    countRule `bvShiftLeftNat.zero
-    return .step expr proof (done := true)
+
+  match Sym.getNatValue? rhsExpr with
+  | some rhs =>
+    if rhs < w then
+      let zero ← mkLit 0#rhs
+      let newLen := w - rhs
+      let newLenExpr ← mkLit newLen
+      let extract ← BitVec.mkExtractLsb' wExpr (← mkLit 0) newLenExpr lhsExpr
+      let expr ← BitVec.mkAppend extract zero newLenExpr (← mkLit rhs) (← mkLit (newLen + rhs))
+      let h := Nat.mkDecideProofLt rhsExpr wExpr
+      let proof := mkApp4 (mkConst ``BitVec.shiftLeft_eq_concat_of_lt) wExpr lhsExpr rhsExpr h
+      countRule `bvShiftLeftNat.concat
+      return .step (← Sym.share expr) proof
+    else
+      let expr ← mkLit 0#w
+      let h := Nat.mkDecideProofLe wExpr rhsExpr
+      let proof := mkApp4 (mkConst ``BitVec.shiftLeft_eq_zero) wExpr lhsExpr rhsExpr h
+      countRule `bvShiftLeftNat.zero
+      return .step expr proof (done := true)
+  | none =>
+    -- Handled by other rewrite rules
+    if isBitVecToNat rhsExpr then return .rfl
+    let (vExpr, clamped, h) ← clampShiftAmount wExpr rhsExpr w
+    let expr ← BitVec.mkBvShiftLeft lhsExpr clamped wExpr vExpr
+    let proof := mkApp5 (mkConst ``BitVec.shiftLeft_eq_shiftLeft_ofNatClamp)
+      wExpr rhsExpr vExpr lhsExpr h
+    countRule `bvShiftLeftNat.clamp
+    return .step expr proof
+
+def bvSshiftRightNat (wExpr lhsExpr rhsExpr : Expr) : SimprocM (Sym.Simp.Result) := do
+  -- Literal amounts are bitblasted directly via `BVUnOp.arithShiftRightConst`.
+  if (Sym.getNatValue? rhsExpr).isSome then return .rfl
+  -- Handled by other rewrite rules
+  if isBitVecToNat rhsExpr then return .rfl
+  let some w := Sym.getNatValue? wExpr | return .rfl
+  let (vExpr, clamped, h) ← clampShiftAmount wExpr rhsExpr w
+  let expr ← BitVec.mkSshiftRight' lhsExpr clamped wExpr vExpr
+  let proof := mkApp5 (mkConst ``BitVec.sshiftRight_eq_sshiftRight'_ofNatClamp)
+    wExpr rhsExpr vExpr lhsExpr h
+  countRule `bvSshiftRightNat.clamp
+  return .step expr proof
+
 
 def bvAppend (α β lhs rhs : Expr) : SimprocM (Sym.Simp.Result) := do
   let_expr BitVec wlhs := α | return .rfl
@@ -1475,7 +1557,8 @@ where
     | HMul.hMul α _ _ _ lhs rhs => bvMul α lhs rhs
     | HDiv.hDiv α _ _  _ lhs rhs => bvUdiv α lhs rhs
     | HAppend.hAppend α β _ _ lhs rhs => bvAppend α β lhs rhs
-    | BitVec.sshiftRight' nExpr mExpr lhs rhs => bvSshiftRight' nExpr mExpr lhs rhs
+    | BitVec.sshiftRight' wExpr vExpr lhs rhs => bvSshiftRight' wExpr vExpr lhs rhs
+    | BitVec.sshiftRight wExpr lhs rhs => bvSshiftRightNat wExpr lhs rhs
     | BitVec.extractLsb' wExpr startExpr lenExpr targetExpr =>
       extractLsb' wExpr startExpr lenExpr targetExpr
     | BitVec.cast nExpr mExpr hExpr targetExpr => bvCast nExpr mExpr hExpr targetExpr

--- a/src/Std/Tactic/BVDecide/Normalize/BitVec.lean
+++ b/src/Std/Tactic/BVDecide/Normalize/BitVec.lean
@@ -277,12 +277,20 @@ theorem BitVec.shiftLeft_zero' (n : BitVec w) : n <<< 0#w' = n := by
   simp
 
 @[bv_normalize]
+theorem BitVec.zero_shiftLeft' (n : BitVec w) : 0#w' <<< n = 0#w' := by
+  rw [_root_.BitVec.shiftLeft_eq', _root_.BitVec.zero_shiftLeft]
+
+@[bv_normalize]
 theorem BitVec.shiftLeft_neg {x : BitVec w₁} {y : BitVec w₂} :
     (~~~x + 1#w₁) <<< y = ~~~(x <<< y) + 1 := by
   simp [← BitVec.neg_eq_not_add, _root_.BitVec.shiftLeft_neg]
 
 attribute [bv_normalize] BitVec.zero_sshiftRight
 attribute [bv_normalize] BitVec.sshiftRight_zero
+
+@[bv_normalize]
+theorem BitVec.zero_sshiftRight' (n : BitVec w) : (0#w').sshiftRight' n = 0#w' := by
+  rw [_root_.BitVec.sshiftRight_eq', _root_.BitVec.zero_sshiftRight]
 
 attribute [bv_normalize] BitVec.zero_ushiftRight
 attribute [bv_normalize] BitVec.ushiftRight_zero
@@ -292,6 +300,10 @@ theorem BitVec.ushiftRight_zero' (n : BitVec w) : n >>> 0#w' = n := by
   ext i
   simp only [(· >>> ·)]
   simp
+
+@[bv_normalize]
+theorem BitVec.zero_ushiftRight' (n : BitVec w) : 0#w' >>> n = 0#w' := by
+  rw [_root_.BitVec.ushiftRight_eq', _root_.BitVec.zero_ushiftRight]
 
 theorem BitVec.ushiftRight_self (n : BitVec w) : n >>> n = 0#w := by
   simp
@@ -363,6 +375,11 @@ theorem BitVec.udiv_ofNat_eq_of_lt (w : Nat) (x : BitVec w) (n : Nat) (k : Nat) 
 theorem BitVec.extractLsb'_ite {x y : BitVec w} (s l : Nat) :
     BitVec.extractLsb' s l (bif c then x else y) = bif c then (BitVec.extractLsb' s l x) else (BitVec.extractLsb' s l y) := by
   cases c <;> simp
+
+/-- Used in the `extractLsb'` simproc to reduce extraction at a symbolic offset to a shift. -/
+theorem BitVec.extractLsb'_eq_setWidth_ushiftRight (x : BitVec w) (s l : Nat) :
+    BitVec.extractLsb' s l x = (x >>> s).setWidth l :=
+  BitVec.setWidth_ushiftRight_eq_extractLsb.symm
 
 @[deprecated Std.Tactic.BVDecide.Normalize.BitVec.extractLsb'_ite (since := "2026-07-21")]
 theorem BitVec.extractLsb'_if {w : Nat} {c : Bool} {x : BitVec w} {y : BitVec w} (s : Nat) (l : Nat) : BitVec.extractLsb' s l (bif c then x else y) = bif c then BitVec.extractLsb' s l x else BitVec.extractLsb' s l y := Std.Tactic.BVDecide.Normalize.BitVec.extractLsb'_ite s l

--- a/tests/elab/bv_decide_shift_symbolic.lean
+++ b/tests/elab/bv_decide_shift_symbolic.lean
@@ -1,0 +1,100 @@
+module
+meta import Std.Tactic.BVDecide
+import Std.Tactic.BVDecide
+
+/-!
+Tests for `bv_decide` support for shifts by symbolic `Nat` amounts and for `BitVec.extractLsb'`
+at a symbolic start offset. These are handled by clamping the amount into a `BitVec` via
+`BitVec.ofNatClamp`, so that only the amount becomes an uninterpreted atom while the shift
+structure stays visible to the bitblaster.
+-/
+
+section UShiftRight
+
+example (x y : BitVec 64) (n : Nat) : (x &&& y) >>> n = (x >>> n) &&& (y >>> n) := by
+  bv_decide
+
+example (x y : BitVec 64) (n : Nat) : (x ||| y) >>> n = (x >>> n) ||| (y >>> n) := by
+  bv_decide
+
+example (x : BitVec 16) (n m : Nat) : x >>> n >>> m = x >>> m >>> n := by
+  bv_decide
+
+example (x : BitVec 16) (n : Nat) (h : x = 0) : x >>> n = 0 := by
+  bv_decide
+
+example (x : BitVec 16) (n : Nat) : x >>> n ≤ x := by
+  bv_decide
+
+end UShiftRight
+
+section ShiftLeft
+
+example (x y : BitVec 64) (n : Nat) : (x &&& y) <<< n = (x <<< n) &&& (y <<< n) := by
+  bv_decide
+
+example (x : BitVec 16) (n : Nat) (h : x = 0) : x <<< n = 0 := by
+  bv_decide
+
+end ShiftLeft
+
+section SshiftRight
+
+example (x y : BitVec 16) (n : Nat) :
+    (x &&& y).sshiftRight n = (x.sshiftRight n) &&& (y.sshiftRight n) := by
+  bv_decide
+
+example (n : Nat) : (BitVec.allOnes 16).sshiftRight n = BitVec.allOnes 16 := by
+  bv_decide
+
+example (x : BitVec 16) (n : Nat) (h : x.msb = false) : x.sshiftRight n = x >>> n := by
+  bv_decide
+
+example (x : BitVec 16) (h : BitVec.slt 0 x) (n : Nat) : x.sshiftRight n ≤ x := by
+  bv_decide
+
+end SshiftRight
+
+section ExtractLsb'
+
+example (x y : BitVec 64) (n : Nat) :
+    (x &&& y).extractLsb' n 8 = (x.extractLsb' n 8) &&& (y.extractLsb' n 8) := by
+  bv_decide
+
+example (x : BitVec 64) (n : Nat) : x.extractLsb' n 64 = x >>> n := by
+  bv_decide
+
+example (x : BitVec 64) (n : Nat) : (x >>> n).setWidth 8 = x.extractLsb' n 8 := by
+  bv_decide
+
+example (x : BitVec 64) (n : Nat) : x.extractLsb' n 8 = (x >>> n).extractLsb' 0 8 := by
+  bv_decide
+
+end ExtractLsb'
+
+section Constant
+
+-- Shifts by constant `Nat` amounts keep working.
+example (x : BitVec 64) : x >>> 65 = 0 := by bv_decide
+example (x : BitVec 64) : x <<< 65 = 0 := by bv_decide
+
+-- Shifts by `BitVec` literals of a different width than the shifted value used to fail with an
+-- internal error and are now eliminated like same-width literal shifts.
+example (x : BitVec 8) : x >>> (2 : BitVec 4) = x >>> 2 := by bv_decide
+example (x : BitVec 8) : x <<< (2 : BitVec 4) = x <<< 2 := by bv_decide
+example (x : BitVec 8) : x.sshiftRight' (1#2) = x.sshiftRight 1 := by bv_decide
+
+end Constant
+
+-- A false goal produces a counterexample mentioning the clamped shift amount instead of crashing.
+/--
+error: The prover found a potentially spurious counterexample:
+- It abstracted the following unsupported expressions as opaque variables:
+  - BitVec.ofNatClamp 4 n
+Consider the following assignment:
+x = 255#8
+BitVec.ofNatClamp 4 n = 15#4
+-/
+#guard_msgs in
+example (x : BitVec 8) (n : Nat) : x >>> n = x := by
+  bv_decide


### PR DESCRIPTION
This PR introduces support for symbolic `Nat` shifts and `extractLsb'`. This is done by re-interpreting `x >>> n` as `x >>> BitVec.ofNatClamped (log2 w + 1) n` and `extractLsb'` as a shift + `setWidth`. `bv_decide` will still not perform reasoning over the `n` itself but it will at least know that e.g. in `x >>> n` all output bits are `0` or some of the input bits of `x`. This is achieved by making the `BitVec.ofNatClamped` as an uninterpreted bitvec atom.