### PR TITLE
feat: lake: read persisted code quality entries in `lake lint --code-quality`

### DIFF
--- a/src/Lean/Elab/Command.lean
+++ b/src/Lean/Elab/Command.lean
@@ -11,7 +11,7 @@ public import Lean.Elab.Binders
 public import Lean.Elab.Command.Scope
 public import Lean.Elab.SetOption
 import Lean.Elab.DeprecatedSyntax
-import Lean.Linter.PersistentLintLog
+public import Lean.Linter.PersistentLintLog
 public meta import Lean.Parser.Command
 
 public section
@@ -38,7 +38,7 @@ structure State where
   traceState     : TraceState := {}
   snapshotTasks  : Array (Language.SnapshotTask Language.SnapshotTree) := #[]
   prevLinterStates : Option (Task (Array LinterState)) := none
-  codeQualityEntryTasks : Array (Task (Array Linter.CodeQuality.Entry)) := #[]
+  codeQualityEntryTasks : Array (Task (Array Linter.CodeQualityLogEntry)) := #[]
   deriving Nonempty
 
 structure Context where
@@ -338,12 +338,12 @@ instance : MonadLog CommandElabM where
     modify fun s => { s with messages := s.messages.add msg }
 
 def runLinters (stx : Syntax) (infoTreePromise? : Option (IO.Promise InfoTree) := .none)
-    (codeQualityEntriesPromise? : Option (IO.Promise (Array Linter.CodeQuality.Entry)) := .none) : CommandElabM Unit := do
+    (codeQualityEntriesPromise? : Option (IO.Promise (Array Linter.CodeQualityLogEntry)) := .none) : CommandElabM Unit := do
   profileitM Exception "linting" (← getOptions) do
     withTraceNode `Elab.lint (fun _ => return m!"running linters") do
       let linters ← lintersRef.get
       let producedInfoTrees ← IO.mkRef ({} : PersistentArray InfoTree)
-      let producedCodeQualityEntries ← IO.mkRef (#[] : Array Linter.CodeQuality.Entry)
+      let producedCodeQualityEntries ← IO.mkRef (#[] : Array Linter.CodeQualityLogEntry)
       unless linters.isEmpty do
         for linter in linters do
           withTraceNode `Elab.lint (fun _ => return m!"running linter: {.ofConstName linter.name}")
@@ -379,11 +379,11 @@ def runLinters (stx : Syntax) (infoTreePromise? : Option (IO.Promise InfoTree) :
         codeQualityEntriesPromise.resolve (← producedCodeQualityEntries.get)
 
 def runModuleLinters (cmds : Array Syntax)
-    (codeQualityEntriesPromise? : Option (IO.Promise (Array Linter.CodeQuality.Entry)) := .none) : CommandElabM Unit := do
+    (codeQualityEntriesPromise? : Option (IO.Promise (Array Linter.CodeQualityLogEntry)) := .none) : CommandElabM Unit := do
   profileitM Exception "module linting" (← getOptions) do
     withTraceNode `Elab.lint (fun _ => return m!"running module linters") do
       let linters ← moduleLintersRef.get
-      let producedCodeQualityEntries ← IO.mkRef (#[] : Array Linter.CodeQuality.Entry)
+      let producedCodeQualityEntries ← IO.mkRef (#[] : Array Linter.CodeQualityLogEntry)
       unless linters.isEmpty do
         for linter in linters do
           withTraceNode `Elab.lint (fun _ => return m!"running module linter: {.ofConstName linter.name}")
@@ -407,13 +407,13 @@ def runModuleLinters (cmds : Array Syntax)
 
 def runStatefulLinters (stx : Syntax) (prev : Array LinterState)
     (infoTreePromise? : Option (IO.Promise InfoTree) := .none)
-    (codeQualityEntriesPromise? : Option (IO.Promise (Array Linter.CodeQuality.Entry)) := .none)
+    (codeQualityEntriesPromise? : Option (IO.Promise (Array Linter.CodeQualityLogEntry)) := .none)
      : CommandElabM (Array LinterState) := do
   profileitM Exception "stateful linting" (← getOptions) do
     withTraceNode `Elab.lint (fun _ => return m!"running stateful linters") do
       let linters ← statefulLintersRef.get
       let producedInfoTrees ← IO.mkRef ({} : PersistentArray InfoTree)
-      let producedCodeQualityEntries ← IO.mkRef (#[] : Array Linter.CodeQuality.Entry)
+      let producedCodeQualityEntries ← IO.mkRef (#[] : Array Linter.CodeQualityLogEntry)
       let run {α : Type} (phase : String) (idx : Nat) (onError : CommandElabM α)
           (act : CommandElabM α) : CommandElabM α :=
         withTraceNode `Elab.lint
@@ -533,8 +533,8 @@ def logSnapshotTask (task : Language.SnapshotTask Language.SnapshotTree) : Comma
 
 open Language in
 def runLintersAsync (stx : Syntax) (cmds : Array Syntax) : CommandElabM Unit := do
-  let lintersCodeQualityEntriesPromise ← IO.Promise.new (α := Array Linter.CodeQuality.Entry)
-  let moduleLintersCodeQualityEntriesPromise ← IO.Promise.new (α := Array Linter.CodeQuality.Entry)
+  let lintersCodeQualityEntriesPromise ← IO.Promise.new (α := Array Linter.CodeQualityLogEntry)
+  let moduleLintersCodeQualityEntriesPromise ← IO.Promise.new (α := Array Linter.CodeQualityLogEntry)
   if !Elab.async.get (← getOptions) then
     withoutModifyingEnv do
       runLinters stx (codeQualityEntriesPromise? := lintersCodeQualityEntriesPromise)
@@ -590,7 +590,7 @@ def runLintersAsync (stx : Syntax) (cmds : Array Syntax) : CommandElabM Unit := 
 open Language in
 def runStatefulLintersAsync (stx : Syntax) : CommandElabM Unit := do
   if (← statefulLintersRef.get).isEmpty then return
-  let statefulLintersCodeQualityEntriesPromise ← IO.Promise.new (α := Array Linter.CodeQuality.Entry)
+  let statefulLintersCodeQualityEntriesPromise ← IO.Promise.new (α := Array Linter.CodeQualityLogEntry)
   if !Elab.async.get (← getOptions) then
     -- We only block when switching the `Elab.async` in the middle of elaborating a file.
     let prev := (← prevLinterStatesTask (← get).prevLinterStates).get

--- a/src/Lean/Linter/PersistentLintLog.lean
+++ b/src/Lean/Linter/PersistentLintLog.lean
@@ -36,8 +36,18 @@ def getAllLints (env : Environment) : Array (Name × Array LintEntry) :=
   env.header.moduleNames.mapIdx fun i mod =>
     (mod, lintLogExt.getModuleEntries env i (level := .server))
 
+/--
+A code quality entry recorded into `codeQualityLogExt`, together with the option name of the
+linter that produced it. Entries logged via `logCodeQualityEntryIf` carry their linter's option
+name, which consumers use to filter by linter selection (e.g. `lake lint --lint-only`); entries
+logged via `logCodeQualityEntry` carry `none` and are exempt from such filtering.
+-/
+structure CodeQualityLogEntry where
+  linter? : Option Name
+  entry   : CodeQuality.Entry
+
 builtin_initialize codeQualityLogExt :
-    PersistentEnvExtension CodeQuality.Entry CodeQuality.Entry (Array CodeQuality.Entry) ←
+    PersistentEnvExtension CodeQualityLogEntry CodeQualityLogEntry (Array CodeQualityLogEntry) ←
   registerPersistentEnvExtension {
     mkInitial     := pure #[]
     addImportedFn := fun _ => pure #[]
@@ -46,7 +56,7 @@ builtin_initialize codeQualityLogExt :
       { exported := #[], server := entries, «private» := entries }
   }
 
-def getAllCodeQualityEntries (env : Environment) : Array (Name × Array CodeQuality.Entry) :=
+def getAllCodeQualityEntries (env : Environment) : Array (Name × Array CodeQualityLogEntry) :=
   env.header.moduleNames.mapIdx fun i mod =>
     (mod, codeQualityLogExt.getModuleEntries env i (level := .server))
 
@@ -80,17 +90,25 @@ This can be safely used in Linters. While regular `Lean.Linter`s, module linters
 linters all have their environment changes discarded after running, entries they log are
 captured per command (see `Command.State.codeQualityEntryTasks`) and merged into the final
 environment in `runFrontend`.
+
+The entry is recorded without a linter attribution, so it is recorded unconditionally and no
+linter selection flag (e.g. `lake lint --lint-only`) can suppress it. Inside a linter guarded by
+an option, use `logCodeQualityEntryIf` instead; this variant is meant for unconditional metrics
+not tied to any linter option.
 -/
 def logCodeQualityEntry [Monad m] [MonadEnv m]
     (e : CodeQuality.Entry) : m Unit :=
-  modifyEnv (codeQualityLogExt.addEntry · e)
+  modifyEnv (codeQualityLogExt.addEntry · { linter? := none, entry := e })
 
 /--
 Similar to `logLintIf`, but for `logCodeQualityEntry` - i.e. it logs an entry only if the
-provided linter option is enabled, taking `linter.all` and linter sets into account.
+provided linter option is enabled, taking `linter.all` and linter sets into account. The entry
+is recorded with `linterOption.name` as its attribution, so consumers can filter it by linter
+selection (e.g. `lake lint --lint-only`).
 -/
 def logCodeQualityEntryIf [Monad m] [MonadOptions m] [MonadEnv m]
     (linterOption : Lean.Option Bool) (e : CodeQuality.Entry) : m Unit := do
-  if getLinterValue linterOption (← getLinterOptions) then logCodeQualityEntry e
+  if getLinterValue linterOption (← getLinterOptions) then
+    modifyEnv (codeQualityLogExt.addEntry · { linter? := some linterOption.name, entry := e })
 
 end Lean.Linter

--- a/src/Lean/Message.lean
+++ b/src/Lean/Message.lean
@@ -11,7 +11,6 @@ prelude
 public import Init.Data.Slice.Array
 public import Lean.Util.PPExt
 public import Lean.Util.Sorry
-public import Lean.Linter.CodeQuality.Basic
 import Init.Data.String.Search
 import Init.Data.Format.Macro
 import Init.Data.Iterators.Consumers.Collect
@@ -20,8 +19,6 @@ import Init.Data.String.Length
 public section
 
 namespace Lean
-
-open Linter
 
 /--
 Creates a string describing an error message `msg` produced at `pos`, optionally ending at `endPos`,
@@ -214,17 +211,6 @@ def kind : MessageData → Name
 def originatingSyntax? : MessageData → Option Syntax × MessageData
   | ofOriginatingSyntax stx msg => (some stx, msg)
   | msg => (none, msg)
-
-/--
-Extracts the code quality entry from a message produced by `Lean.Linter.logCodeQualityEntry`,
-looking through the context wrappers added by `logAt`/`addMessageContext`.
--/
-partial def codeQualityEntry? : MessageData → Option CodeQuality.Entry
-  | withContext _ msg             => codeQualityEntry? msg
-  | withNamingContext _ msg       => codeQualityEntry? msg
-  | tagged _ msg                  => codeQualityEntry? msg
-  | ofOriginatingSyntax _ msg     => codeQualityEntry? msg
-  | _                             => none
 
 def isTrace : MessageData → Bool
   | withContext _ msg         => msg.isTrace

--- a/src/lake/Lake/CLI/BuiltinLint.lean
+++ b/src/lake/Lake/CLI/BuiltinLint.lean
@@ -109,6 +109,35 @@ private def collectTextLints
   Linter.getAllLints env |>.foldl (init := #[]) fun acc (mod, entries) =>
     if pkgRoot.isPrefixOf mod && !entries.isEmpty then acc.push (mod, entries) else acc
 
+/--
+Collects the code quality entries recorded during elaboration (via
+`Lean.Linter.logCodeQualityEntry` and `Lean.Linter.logCodeQualityEntryIf`) for the modules of
+the package rooted at `mod.getRoot` that are imported by `env`. Like text-linter warnings, these
+were persisted into `codeQualityLogExt` when each module was built (with the linter overrides
+applied via `leanOptOverrides`) and are recovered here from the `.olean`s, which requires an
+environment imported at the `server` olean level. With `--lint-only`, entries attributed to a
+linter option are additionally filtered to the explicitly enabled linters; unattributed entries
+(logged via `logCodeQualityEntry`) are always kept.
+
+Modules in `collectedModules` were already covered by an earlier lint target and are skipped, so
+that a module imported by several targets contributes its entries only once; the returned set
+extends it with the modules collected here.
+-/
+private def collectRecordedCodeQuality (args : Args) (linterOpts : Linter.LinterOptions)
+    (env : Environment) (mod : Name) (collectedModules : NameSet) :
+    Array CodeQuality.Entry × NameSet := Id.run do
+  let mut collected := collectedModules
+  let mut acc : Array CodeQuality.Entry := #[]
+  for (m, entries) in Linter.getAllCodeQualityEntries env do
+    unless mod.getRoot.isPrefixOf m && !collected.contains m do continue
+    collected := collected.insert m
+    let entries :=
+      if args.lintOnly then
+        entries.filter fun e => e.linter?.all (Lean.Linter.isLinterEnabledByOptions · linterOpts)
+      else entries
+    acc := acc ++ entries.map (·.entry)
+  return (acc, collected)
+
 @[noinline] private def getIsModule (modData : Lean.ModuleData) : BaseIO Bool :=
   return modData.isModule
 
@@ -421,6 +450,9 @@ public def run (args : Args) : IO UInt32 := do
   -- Modules whose deferred docstring checks have already been run. A module can appear in
   -- several targets' import closures, so this runs each such module's checks only once.
   let mut docCheckedModules : NameSet := {}
+  -- Modules whose recorded code quality entries have already been collected, so a module shared
+  -- between several targets' import closures does not contribute its entries more than once.
+  let mut metricsCollectedModules : NameSet := {}
   for mod in mods do
     unsafe Lean.enableInitializersExecution
     -- Peek at the .olean header to learn whether `mod` participates in the module system.
@@ -462,6 +494,10 @@ public def run (args : Args) : IO UInt32 := do
       codeQualityEntries := codeQualityEntries ++ entries
 
     if args.mode == .codeQuality then
+      let (recorded, collected) :=
+        collectRecordedCodeQuality args linterOpts env mod metricsCollectedModules
+      metricsCollectedModules := collected
+      codeQualityEntries := codeQualityEntries ++ recorded
       let ⟨entries, failed⟩ ← runPackageCodeQualityChecks sp env mod
       codeQualityEntries := codeQualityEntries ++ entries
       if failed then anyFailed := true

--- a/tests/lake/tests/builtin-lint-code-quality/Linters.lean
+++ b/tests/lake/tests/builtin-lint-code-quality/Linters.lean
@@ -1,6 +1,6 @@
 import Lean.Linter.EnvLinter
 
-open Lean Meta Lean.Linter
+open Lean Meta Lean.Linter Lean.Elab.Command
 
 /-- Option gating the dummy env linter; on by default so it fires during the
 build without needing `--linters`. -/
@@ -22,3 +22,26 @@ public meta def dummyMarker : Lean.Linter.EnvLinter.EnvLinter where
     if declName.toString.endsWith "DummyMarker" then
       return some "declaration name ends with 'DummyMarker'"
     return none
+
+/-- Option gating the metric-recording text linter; on by default so entries are recorded
+during the build without needing `--linters`. -/
+register_option linter.declMetric : Bool := {
+  defValue := true
+  descr := "(test) record a code quality entry for every declaration command"
+}
+
+-- A text linter recording code quality entries for every `declaration` command, attributed to
+-- the elaborating module. Exercises the recorded-metrics side of the code quality output: the
+-- entries are persisted into the `.olean` during the build and recovered by
+-- `lake lint --code-quality` without re-elaboration. `declCommands` is gated by (and attributed
+-- to) `linter.declMetric`, so linter selection flags apply to it; `declCommandsRaw` is logged
+-- unconditionally without attribution, so no linter selection flag can suppress it.
+def declMetricLinter : Linter where
+  run cmdStx := do
+    unless cmdStx.getKind == ``Lean.Parser.Command.declaration do return
+    logCodeQualityEntryIf linter.declMetric
+      { name := "declCommands", source := .module (← getMainModule), value := .scalar 1.0 }
+    logCodeQualityEntry
+      { name := "declCommandsRaw", source := .module (← getMainModule), value := .scalar 1.0 }
+
+initialize addLinter declMetricLinter

--- a/tests/lake/tests/builtin-lint-code-quality/expected.json
+++ b/tests/lake/tests/builtin-lint-code-quality/expected.json
@@ -1,5 +1,17 @@
 {"value":{"scalar":{"value":1}},"source":{"declaration":{"name":"Inner.nestedDummyMarker","module":"Violations"}},"name":"linter.dummyMarker"}
 {"value":{"scalar":{"value":1}},"source":{"declaration":{"name":"fooDummyMarker","module":"Violations"}},"name":"linter.dummyMarker"}
 {"value":{"scalar":{"value":1}},"source":{"declaration":{"name":"subDummyMarker","module":"Violations.Sub"}},"name":"linter.dummyMarker"}
+{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations"}},"name":"declCommands"}
+{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations"}},"name":"declCommands"}
+{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations"}},"name":"declCommands"}
+{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations"}},"name":"declCommands"}
+{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations"}},"name":"declCommandsRaw"}
+{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations"}},"name":"declCommandsRaw"}
+{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations"}},"name":"declCommandsRaw"}
+{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations"}},"name":"declCommandsRaw"}
+{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations.Sub"}},"name":"declCommands"}
+{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations.Sub"}},"name":"declCommands"}
+{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations.Sub"}},"name":"declCommandsRaw"}
+{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations.Sub"}},"name":"declCommandsRaw"}
 {"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations.Sub"}},"name":"linter.unusedVariables"}
 {"value":{"scalar":{"value":2}},"source":{"module":{"name":"Violations"}},"name":"linter.unusedVariables"}

--- a/tests/lake/tests/builtin-lint-code-quality/test.sh
+++ b/tests/lake/tests/builtin-lint-code-quality/test.sh
@@ -2,13 +2,21 @@
 source ../common.sh
 
 # Exercises `lake lint --code-quality`: instead of reporting linter warnings,
-# each one is emitted as a JSON code quality entry on stdout. Covers both linter
-# flavours:
+# each one is emitted as a JSON code quality entry on stdout. Covers three
+# entry sources:
 #   * text linters (`linter.unusedVariables`), aggregated per module into one
-#     entry whose scalar value is the warning count, and
+#     entry whose scalar value is the warning count,
 #   * env linters (`linter.dummyMarker`, defined in `Linters.lean`), emitted per
-#     flagged declaration together with the module defining it.
-# Both flavours key their entry on the linter's *option* name.
+#     flagged declaration together with the module defining it, and
+#   * entries recorded during elaboration (`Linters.lean`), persisted into the
+#     `.olean` per module and emitted verbatim: `declCommands` is recorded via
+#     `logCodeQualityEntryIf` and attributed to `linter.declMetric`, so linter
+#     selection flags apply to it; `declCommandsRaw` is recorded via
+#     `logCodeQualityEntry` without attribution, so no selection flag can
+#     suppress it.
+# The first two flavours key their entry on the linter's *option* name; recorded
+# entries carry a free-form metric name, with the producing linter's option name
+# (if any) stored alongside internally, which `--lint-only` filters on.
 
 ./clean.sh
 
@@ -25,6 +33,19 @@ collect_json() {
     END { if (buf != "") print buf }
   ' produced.out | tr -d ' ' | LC_ALL=C sort > produced.json
   cat produced.json
+}
+
+# Asserts that `pat` occurs exactly `count` times in the given file.
+count_text() {
+  count=$1; pat=$2; file=$3
+  echo "? grep -c -F \"$pat\" $file = $count"
+  actual="$(grep -c -F -- "$pat" "$file" || true)"
+  if [ "$actual" = "$count" ]; then
+    return 0
+  else
+    echo "FAILURE: found $actual occurrence(s), expected $count"
+    return 1
+  fi
 }
 
 # --- Baseline: in report mode the same violations are reported and fail. ---
@@ -54,23 +75,65 @@ match_text '{"value":{"scalar":{"value":1}},"source":{"declaration":{"name":"foo
 match_text '{"value":{"scalar":{"value":1}},"source":{"declaration":{"name":"subDummyMarker","module":"Violations.Sub"}},"name":"linter.dummyMarker"}' produced.json
 # A declaration-level `set_option linter.dummyMarker false in` is honored.
 no_match_text 'suppressedDummyMarker' produced.json
-# Nothing outside the linted package leaks in (`Linters.lean` defines the linter).
+# Recorded entries are emitted verbatim, one per declaration command per module: four in
+# `Violations` (the `set_option ... in`-wrapped declaration is not a `declaration` command)
+# and two in `Violations.Sub`.
+count_text 4 '{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations"}},"name":"declCommands"}' produced.json
+count_text 2 '{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations.Sub"}},"name":"declCommands"}' produced.json
+count_text 4 '{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations"}},"name":"declCommandsRaw"}' produced.json
+count_text 2 '{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations.Sub"}},"name":"declCommandsRaw"}' produced.json
+# Nothing outside the linted package leaks in (`Linters.lean` defines the linters).
 no_match_text '"module":"Linters"' produced.json
+no_match_text '"name":"Linters"' produced.json
 
 # --- Linter selection. ---
-# `--lint-only` restricts the output to the explicitly enabled linters.
+# `--lint-only` restricts the output to the explicitly enabled linters. Recorded entries are
+# filtered by the linter option name persisted with each entry, so the default-on
+# `linter.declMetric` entries (recorded during the build) are dropped too; the unattributed
+# `declCommandsRaw` entries are exempt from the filter and survive.
 lake_out lint --code-quality --lint-only=linter.dummyMarker Violations
 collect_json
 match_text 'fooDummyMarker' produced.json
 no_match_text 'linter.unusedVariables' produced.json
+no_match_text '"declCommands"' produced.json
+match_text 'declCommandsRaw' produced.json
 
-# Disabling a default-on linter drops its entries; the env linter still reports.
+# ...and explicitly enabling the recording linter keeps its entries.
+lake_out lint --code-quality --lint-only=linter.declMetric Violations
+collect_json
+match_text '"declCommands"' produced.json
+no_match_text 'linter.unusedVariables' produced.json
+no_match_text 'fooDummyMarker' produced.json
+
+# Disabling a default-on linter drops its entries; the env linter and the recorded
+# entries still report.
 lake_out lint --code-quality --linters=-linter.unusedVariables Violations
 collect_json
 no_match_text 'linter.unusedVariables' produced.json
 match_text 'fooDummyMarker' produced.json
+match_text '"declCommands"' produced.json
 
-# --- No violations means no entries. ---
+# Disabling the recording linter suppresses recording of the gated entries at elaboration
+# time; the unattributed entries are still recorded.
+lake_out lint --code-quality --linters=-linter.declMetric Violations
+collect_json
+no_match_text '"declCommands"' produced.json
+match_text 'declCommandsRaw' produced.json
+match_text 'linter.unusedVariables' produced.json
+
+# --- Multiple lint targets. ---
+# `Violations.Sub` sits in the import closure of both targets, but its recorded entries are
+# collected only once.
+lake_out lint --code-quality Violations Violations.Sub
+collect_json
+count_text 2 '{"value":{"scalar":{"value":1}},"source":{"module":{"name":"Violations.Sub"}},"name":"declCommands"}' produced.json
+
+# --- No enabled linters means no linter entries. ---
+# Only the unattributed recorded entries remain: they are not tied to any linter option, so
+# `-linter.all` cannot suppress them.
 lake_out lint --code-quality --lint-only=-linter.all Violations
 collect_json
-test_cmd test ! -s produced.json
+count_text 6 '"name":"declCommandsRaw"' produced.json
+no_match_text '"declCommands"' produced.json
+no_match_text 'linter.unusedVariables' produced.json
+no_match_text 'dummyMarker' produced.json

--- a/tests/pkg/code_quality_log/CQTest/Linters.lean
+++ b/tests/pkg/code_quality_log/CQTest/Linters.lean
@@ -1,17 +1,21 @@
 import Lean
 
 /-!
-Registers two linters that log code quality entries via `logCodeQualityEntryIf`:
+Registers two linters that log code quality entries:
 
-* `linter.cqTest`, a regular linter that logs one entry (named after the declaration) for every
-  declaration command;
-* a stateful linter that logs one entry per declaration, named `stateful:<decl>:<n>` where `n` is
-  the running declaration count threaded through its persistent state across commands.
+* `linter.cqTest`, a regular linter that, for every declaration command, logs one entry named
+  after the declaration via `logCodeQualityEntryIf` (attributed to `linter.cqTest` and gated by
+  it) plus one unattributed entry named `raw:<decl>` via `logCodeQualityEntry` (recorded even
+  when the option is off);
+* a stateful linter that logs one attributed entry per declaration, named `stateful:<decl>:<n>`
+  where `n` is the running declaration count threaded through its persistent state across
+  commands.
 
 Also defines `#inspect_cq_entries`, which awaits the per-command capture tasks in
 `Command.State.codeQualityEntryTasks` and reports what they contain. Every command contributes
 three tasks, in order: regular linters, module linters (empty except on the terminal command),
-and stateful linters.
+and stateful linters. Entries are shown as `<linter option>/<entry name>`, with `_` for
+unattributed entries.
 -/
 
 open Lean Elab Command Linter
@@ -33,6 +37,11 @@ initialize addLinter {
     if let some n := declName? stx then
       logCodeQualityEntryIf linter.cqTest {
         name := toString n
+        source := .declaration (← getMainModule) n
+        value := .scalar 1.0
+      }
+      logCodeQualityEntry {
+        name := s!"raw:{n}"
         source := .declaration (← getMainModule) n
         value := .scalar 1.0
       }
@@ -59,6 +68,9 @@ are discarded, so entries reach the final environment only through the capture t
 -/
 elab "#inspect_cq_entries" : command => do
   let tasks := (← get).codeQualityEntryTasks
+  let describe (e : CodeQualityLogEntry) : String :=
+    s!"{(e.linter?.map toString).getD "_"}/{e.entry.name}"
   logInfo m!"per-command entry counts: {tasks.map (·.get.size)}"
-  logInfo m!"captured entries: {tasks.flatMap (·.get) |>.map (·.name)}"
+  let described := tasks.flatMap (·.get) |>.map describe
+  logInfo m!"captured entries: [{", ".intercalate described.toList}]"
   logInfo m!"entries in current env: {(codeQualityLogExt.getState (← getEnv)).size}"

--- a/tests/pkg/code_quality_log/CQTest/TestAsync.lean
+++ b/tests/pkg/code_quality_log/CQTest/TestAsync.lean
@@ -2,11 +2,12 @@ import CQTest.Linters
 
 /-!
 Exercises capture of code quality entries in asynchronous mode (the default): every `def` makes
-the regular linter and the stateful linter log one entry each, which must land in that command's
-regular- and stateful-linter slots of `Command.State.codeQualityEntryTasks` and nowhere else.
-`hidden` is elaborated with the linter option disabled, so its slots must be empty. The counts
-come in triples per command (regular, module, stateful linters), starting with a triple of zeros
-for this module docstring command.
+the regular linter log an attributed and an unattributed entry and the stateful linter log one
+attributed entry, which must land in that command's regular- and stateful-linter slots of
+`Command.State.codeQualityEntryTasks` and nowhere else. `hidden` is elaborated with the linter
+option disabled, so only the unattributed `raw:` entry (which the option does not gate) is
+captured for it. The counts come in triples per command (regular, module, stateful linters),
+starting with a triple of zeros for this module docstring command.
 -/
 
 def a1 := 1
@@ -19,9 +20,9 @@ def hidden := 3
 set_option linter.cqTest true
 
 /--
-info: per-command entry counts: [0, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+info: per-command entry counts: [0, 0, 0, 2, 0, 1, 2, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0]
 ---
-info: captured entries: [a1, stateful:a1:1, a2, stateful:a2:2]
+info: captured entries: [linter.cqTest/a1, _/raw:a1, linter.cqTest/stateful:a1:1, linter.cqTest/a2, _/raw:a2, linter.cqTest/stateful:a2:2, _/raw:hidden]
 ---
 info: entries in current env: 0
 -/

--- a/tests/pkg/code_quality_log/CQTestSync/TestSync.lean
+++ b/tests/pkg/code_quality_log/CQTestSync/TestSync.lean
@@ -17,9 +17,9 @@ def hidden := 3
 set_option linter.cqTest true
 
 /--
-info: per-command entry counts: [0, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+info: per-command entry counts: [0, 0, 0, 2, 0, 1, 2, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0]
 ---
-info: captured entries: [s1, stateful:s1:1, s2, stateful:s2:2]
+info: captured entries: [linter.cqTest/s1, _/raw:s1, linter.cqTest/stateful:s1:1, linter.cqTest/s2, _/raw:s2, linter.cqTest/stateful:s2:2, _/raw:hidden]
 ---
 info: entries in current env: 0
 -/


### PR DESCRIPTION
This PR makes `lake lint --code-quality` emit the code quality entries that linters record during elaboration. Entries logged via `Lean.Linter.logCodeQualityEntryIf` are attributed to the producing linter's option name and are filtered by `--lint-only`; entries logged via `Lean.Linter.logCodeQualityEntry` carry no attribution and are always emitted, so no linter selection flag can suppress them. Disabling a recording linter (e.g. `--linters=-linter.foo`) suppresses its attributed entries at elaboration time, and a module shared between several lint targets contributes its entries only once.

Builds on #14914, which persists code quality entries in the `codeQualityLogExt` environment extension. The extension now stores `CodeQualityLogEntry`, pairing each entry with the option name of the producing linter (`none` for entries logged unconditionally via `logCodeQualityEntry`). On the Lake side, `collectRecordedCodeQuality` recovers the per-module entries from the `.olean`s of each lint target's import closure and applies the `--lint-only` filter to attributed entries. The now-dead `MessageData.codeQualityEntry?` and the unused `Lean.Linter.CodeQuality.Basic` import in `Lean.Message` are removed.