### PR TITLE
perf: initialize only the core modules `leanchecker-paranoid` needs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -995,7 +995,7 @@ else()
   # NOTE: `mimalloc_paranoid` in front of `leanrt` and no `leanshared` to replace default allocator
   set(
     LEANCHECKER_PARANOID_LINKER_FLAGS
-    "${CMAKE_EXE_LINKER_FLAGS} -lmimalloc_paranoid ${LEANC_STATIC_LINKER_FLAGS}"
+    "${CMAKE_EXE_LINKER_FLAGS} -lmimalloc_paranoid -linitialize_minimal ${LEANC_STATIC_LINKER_FLAGS}"
   )
 
 endif()
@@ -1031,7 +1031,7 @@ if(NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten")
     add_custom_target(
       leanchecker-paranoid
       WORKING_DIRECTORY ${LEAN_SOURCE_DIR}
-      DEPENDS lake_shared mimalloc_paranoid
+      DEPENDS lake_shared mimalloc_paranoid initialize_minimal
       COMMAND $(MAKE) -f ${CMAKE_BINARY_DIR}/stdlib.make leanchecker-paranoid
       VERBATIM
     )

--- a/src/initialize/CMakeLists.txt
+++ b/src/initialize/CMakeLists.txt
@@ -1,1 +1,11 @@
 add_library(initialize OBJECT init.cpp)
+
+# `leanchecker` only replays declarations through the kernel; it never elaborates Lean source, so it
+# does not need `initialize_Lean` and the whole library it drags in. Only this file varies, so a
+# second copy of it suffices, linked ahead of `libleancpp.a` so its `lean_initialize` wins.
+add_library(initialize_minimal STATIC EXCLUDE_FROM_ALL init.cpp)
+set_target_properties(
+  initialize_minimal
+  PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
+)
+target_compile_definitions(initialize_minimal PRIVATE LEAN_MINIMAL_CORE_INIT)

--- a/src/initialize/init.cpp
+++ b/src/initialize/init.cpp
@@ -19,6 +19,26 @@ namespace lean {
 extern "C" object* initialize_Init(uint8_t);
 extern "C" object* initialize_Std(uint8_t);
 extern "C" object* initialize_Lean(uint8_t);
+#ifdef LEAN_MINIMAL_CORE_INIT
+extern "C" object* initialize_Lean_Compiler_ExportAttr(uint8_t);
+extern "C" object* initialize_Lean_Compiler_IR_CompilerM(uint8_t);
+extern "C" object* initialize_Lean_Compiler_IR_EmitLLVM(uint8_t);
+extern "C" object* initialize_Lean_Compiler_IR_Format(uint8_t);
+extern "C" object* initialize_Lean_Compiler_InitAttr(uint8_t);
+extern "C" object* initialize_Lean_Compiler_ModPkgExt(uint8_t);
+extern "C" object* initialize_Lean_Compiler_NameMangling(uint8_t);
+extern "C" object* initialize_Lean_Data_KVMap(uint8_t);
+extern "C" object* initialize_Lean_Data_Options(uint8_t);
+extern "C" object* initialize_Lean_Declaration(uint8_t);
+extern "C" object* initialize_Lean_Environment(uint8_t);
+extern "C" object* initialize_Lean_Expr(uint8_t);
+extern "C" object* initialize_Lean_Level(uint8_t);
+extern "C" object* initialize_Lean_LoadDynlib(uint8_t);
+extern "C" object* initialize_Lean_LocalContext(uint8_t);
+extern "C" object* initialize_Lean_MetavarContext(uint8_t);
+extern "C" object* initialize_Lean_Util_Profile(uint8_t);
+extern "C" object* initialize_Lean_Util_Trace(uint8_t);
+#endif
 
 static bool g_initialized = false;
 /* Initializes the Lean runtime. Before executing any code which uses the Lean package,
@@ -34,14 +54,61 @@ extern "C" LEAN_EXPORT void lean_initialize() {
     save_stack_info();
     initialize_util_module();
     uint8_t builtin = 1;
-    // Initializing the core libs explicitly is necessary because of references to them other than
-    // via `import`, such as:
-    // * calling exported Lean functions from C++
-    // * calling into native code of the current module from a previous stage when `prefer_native`
-    //   is set
+    /* The core libs are initialized explicitly because they are referenced other than via `import`:
+       C++ calls exported Lean functions, and native code of the current module may be called from a
+       previous stage when `prefer_native` is set. Of the three, only `Init` is referenced from C++
+       directly (37 symbols across 7 modules); `Std` is referenced by none, and stays for the
+       run-time reachability reason below. */
     consume_io_result(initialize_Init(builtin));
     consume_io_result(initialize_Std(builtin));
+#ifdef LEAN_MINIMAL_CORE_INIT
+    /* Initializing `Lean` initializes every module it transitively imports, which makes the whole
+       library reachable from `main` and so keeps it in any statically linked binary: for
+       `leanchecker` that is the elaborator, the tactic frameworks and the language server, about
+       three quarters of the binary. This lists instead the modules defining the exported Lean
+       functions the C++ side calls, i.e. those of `libLean.a` defining a symbol that `libleancpp.a`
+       or `libleanrt.a` references but does not define. Regenerate it by taking that difference over
+       the object files. Downstream Lean code is unaffected either way: a module's own initializer
+       still initializes everything it imports.
+
+       Only sound for a binary that never elaborates Lean source; see `initialize_minimal` in
+       `src/initialize/CMakeLists.txt`. */
+    consume_io_result(initialize_Lean_Compiler_ExportAttr(builtin));
+    consume_io_result(initialize_Lean_Compiler_IR_CompilerM(builtin));
+    consume_io_result(initialize_Lean_Compiler_IR_EmitLLVM(builtin));
+    consume_io_result(initialize_Lean_Compiler_IR_Format(builtin));
+    consume_io_result(initialize_Lean_Compiler_InitAttr(builtin));
+    consume_io_result(initialize_Lean_Compiler_ModPkgExt(builtin));
+    consume_io_result(initialize_Lean_Compiler_NameMangling(builtin));
+    consume_io_result(initialize_Lean_Data_KVMap(builtin));
+    consume_io_result(initialize_Lean_Data_Options(builtin));
+    consume_io_result(initialize_Lean_Declaration(builtin));
+    consume_io_result(initialize_Lean_Environment(builtin));
+    consume_io_result(initialize_Lean_Expr(builtin));
+    consume_io_result(initialize_Lean_Level(builtin));
+    consume_io_result(initialize_Lean_LoadDynlib(builtin));
+    consume_io_result(initialize_Lean_LocalContext(builtin));
+    consume_io_result(initialize_Lean_MetavarContext(builtin));
+    consume_io_result(initialize_Lean_Util_Profile(builtin));
+    consume_io_result(initialize_Lean_Util_Trace(builtin));
+#else
+    /* Initializing `Lean` initializes the whole library, which is critical in two ways that neither
+       the import graph nor the C++ call sites make visible.
+
+       It is the pass that registers the builtin elaborators and attributes: those live in leaf
+       modules, `Lean.Elab.BuiltinCommand` and friends, which import the framework rather than the
+       other way round, so nothing reaches them except this aggregate. Even the `Lean.Elab`
+       initializer does not reach all builtins.
+
+       The other exception is modules like `Lean.Meta.ExprDefEq` that are reachable from
+       extern-export pairs, which may be called at run time without having the module in the direct
+       import closure.
+
+       As almost all binaries shipped with Lean link against `libleanshared`, there is no advantage
+       for them of resolving the above issues to allow for leaner linking and so we make an
+       exception only for the separately linked, never-elaborating paranoid build as above. */
     consume_io_result(initialize_Lean(builtin));
+#endif
     initialize_kernel_module();
     init_default_print_fn();
     initialize_library_core_module();

--- a/src/stdlib.make.in
+++ b/src/stdlib.make.in
@@ -215,7 +215,7 @@ leanchecker: $(OUTBIN)/leanchecker$(EXE)
 # Statically linked so that it gets its own mimalloc; see `LEANCHECKER_PARANOID_LINKER_FLAGS`.
 # Stripped because static linking makes it two orders of magnitude larger than the other binaries
 # and it neither runs the interpreter nor exports anything.
-$(OUTBIN)/leanchecker-paranoid$(EXE): $(OUTARC)/libLeanChecker.a $(OUTARC)/libmimalloc_paranoid.a
+$(OUTBIN)/leanchecker-paranoid$(EXE): $(OUTARC)/libLeanChecker.a $(OUTARC)/libmimalloc_paranoid.a $(OUTARC)/libinitialize_minimal.a
 	$(link-preamble)
 	$(LEANC_SH) $< ${LEANCHECKER_PARANOID_LINKER_FLAGS_MAKE} ${LEANC_OPTS} -o $@
 	"${CMAKE_STRIP}" $@


### PR DESCRIPTION
This PR shrinks `leanchecker-paranoid` from 78 MB to 7 MB (18.9 MiB to 2.0 MiB compressed) by not initializing the whole Lean library in a binary that never elaborates Lean source.

`lean_initialize` calls `initialize_Lean`, which transitively initializes every module of the library. That makes all of `Lean` reachable from `main`, so `--gc-sections` cannot drop any of it and a statically linked binary carries the elaborator, the tactic frameworks and the language server whatever it uses.

Only `src/initialize/init.cpp` varies with this, so `initialize_minimal` compiles a second copy of it under `LEAN_MINIMAL_CORE_INIT`, listing instead the modules that define the exported Lean functions the C++ side calls. That list is derived from the symbols `libleancpp.a` and `libleanrt.a` reference but do not define, which is exactly what this binary links. The archive is listed ahead of `libleancpp.a` so that its `lean_initialize` wins, the same ordering the hardened mimalloc already relies on, and it is `EXCLUDE_FROM_ALL` so no other target pays for it.

Binaries that call into elaboration (must) still call `initialize_Lean`, and there would be no size advantage for them not to do so as they are all linked against `libleanshared` anyway.