### PR TITLE
fix: do not unfold partially applied constants in `cbv`

### DIFF
--- a/src/Lean/Meta/Tactic/Cbv/Main.lean
+++ b/src/Lean/Meta/Tactic/Cbv/Main.lean
@@ -155,6 +155,13 @@ def tryCbvTheorems : Simproc := fun e => do
 def handleConstApp : Simproc := fun e => do
   tryEquations <|> tryUnfold <| e
 
+def isPartialApp (e : Expr) : Sym.SymM Bool := do
+  let eType ← Sym.inferType e
+  -- Fast path: a syntactically functional type cannot whnf to a non-function.
+  if eType matches .forallE .. then return true
+  let eType ← whnfD eType
+  return eType matches .forallE ..
+
 /--
 Post-pass handler for applications. For a constant-headed application, if the
 constant is `@[cbv_opaque]`, only `@[cbv_eval]` rules are tried (and the result
@@ -167,6 +174,8 @@ def handleApp : Simproc := fun e => do
   match fn with
   | .const constName _ =>
     if (← isCbvOpaque constName) then
+      return markAsDoneIfFailed <| ← tryCbvTheorems e
+    if (← isPartialApp e) then
       return markAsDoneIfFailed <| ← tryCbvTheorems e
     let info ← getConstInfo constName
     tryCbvTheorems <|> (guardSimproc (fun _ => info.hasValue) handleConstApp) <|> reduceRecMatcher <| e
@@ -316,11 +325,7 @@ def handleConst : Simproc := fun e => do
   let .const n lvls := e | return .rfl
   let info ← getConstInfo n
   unless info.isDefinition do return .rfl
-  let eType := info.type
-  -- Fast path: a syntactically functional type cannot whnf to a non-function.
-  if eType matches .forallE .. then return .rfl
-  let eType ← whnfD eType
-  if eType matches .forallE .. then return .rfl
+  if (← isPartialApp e) then return .rfl
   unless info.hasValue && info.levelParams.length == lvls.length do return .rfl
   let fBody ← instantiateValueLevelParams info lvls
   let fBody ← Sym.unfoldReducible fBody

--- a/tests/elab/cbv_unfolding_add.lean
+++ b/tests/elab/cbv_unfolding_add.lean
@@ -1,0 +1,22 @@
+/-!
+  Regression test making sure that partially applied operations with special casing,
+  i.e. these supported by `EvalGround.lean` do not get unfolded, but they still are reduced
+  in the kernel.
+
+  Reported by Robin Arnez (@rob23oba).
+-/
+
+def coolApply (f : Nat → Nat → Nat) (x y : Nat) : Nat := f x y
+
+def coolAdd := coolApply (· + ·)
+
+def coolMul := coolApply (· * ·)
+
+-- The reason we use `conv=>` mode is that we make sure that the proof doesn't go via defeq
+example : coolAdd 13499 1341389 = 1354888 := by conv =>
+  lhs;
+  cbv
+
+example : coolMul 13499 1341389 = 18107410111 := by conv =>
+  lhs;
+  cbv


### PR DESCRIPTION
This PR changes the `cbv` tactic to treat partially applied
constants as function values instead of unfolding them. Previously, a
partially applied operation passed as a function argument (e.g. `(· + ·)`)
was unfolded down to its underlying definition (e.g. `Nat.add`), which
bypassed the ground-evaluation fast path and caused a maximum recursion depth
error on large literals; it also leaked internal terms such as
`instAddNat.1` into stuck goals.

Under call-by-value semantics a partial application is a value, so
`handleApp` now marks constant-headed applications whose type is still a
function type as done, mirroring the existing guard for bare constants in
`handleConst`. `@[cbv_eval]` rules are still tried on partial applications,
matching the behavior for `@[cbv_opaque]` constants.