### PR TITLE
fix: `deprecated_syntax` warnings for syntax that has `.original` source info

### DIFF
--- a/src/Lean/Elab/DeprecatedSyntax.lean
+++ b/src/Lean/Elab/DeprecatedSyntax.lean
@@ -42,8 +42,11 @@ builtin_initialize deprecatedSyntaxExt :
 /--
 Check whether `stx` is a deprecated syntax kind, and if so, emit a warning.
 
-If `macroStack` is non-empty, the warning is attributed to the macro call site rather than the
-syntax itself.
+If `stx` was written by the user (its head token has `.original` source info), the warning is
+attributed to the syntax itself even inside a macro expansion: enclosing macros (e.g. the internal
+`namespace` expansion of `def Foo.bar ...`) merely passed the user's syntax through. Only
+macro-generated syntax (synthetic source info, as produced by syntax quotations) is attributed to
+the macro call site via `macroStack`.
 -/
 def checkDeprecatedSyntax [Monad m] [MonadEnv m] [MonadLog m] [MonadOptions m]
     [AddMessageContext m] [MonadRef m] (stx : Syntax) (macroStack : MacroStack) : m Unit := do
@@ -53,6 +56,10 @@ def checkDeprecatedSyntax [Monad m] [MonadEnv m] [MonadLog m] [MonadOptions m]
     let extraMsg := match entry.text? with
       | some text => m!": {text}"
       | none => m!""
+    if stx.getHeadInfo matches .original .. then
+      Linter.logLintIf Linter.linter.deprecated.syntax stx
+        m!"syntax '{kind}' has been deprecated{extraMsg}"
+      return
     match macroStack with
     | { before := macroStx, .. } :: { before := callerStx, .. } :: _ =>
       let expandedFrom :=

--- a/tests/elab/deprecated_syntax.lean
+++ b/tests/elab/deprecated_syntax.lean
@@ -4,8 +4,8 @@ set_option linter.deprecated.syntax true
 -- Test 1: Direct usage of deprecated term syntax → warning
 deprecated_syntax Lean.Parser.Term.let_fun "use `have` instead" (since := "2026-03-24")
 
--- Note: the paren macro expands to the inner expression, so the warning
--- is attributed to the paren macro call site
+-- Note: the paren macro expands to the inner expression, but the warning
+-- is attributed to the inner expression written by the user.
 #check (let_fun x := 1; x)
 
 /--

--- a/tests/elab/deprecated_syntax.lean.out.expected
+++ b/tests/elab/deprecated_syntax.lean.out.expected
@@ -1,4 +1,4 @@
-deprecated_syntax.lean:9:7-9:26: warning: macro 'Lean.Parser.Term.paren' produces deprecated syntax 'Lean.Parser.Term.let_fun': use `have` instead
+deprecated_syntax.lean:9:8-9:25: warning: syntax 'Lean.Parser.Term.let_fun' has been deprecated: use `have` instead
 
 Note: This linter can be disabled with `set_option linter.deprecated.syntax false`
 have x := 1;

--- a/tests/elab/deprecated_syntax_namespaced.lean
+++ b/tests/elab/deprecated_syntax_namespaced.lean
@@ -1,0 +1,34 @@
+module
+
+/-!
+Tests that the deprecated syntax linter warns directly at deprecated syntax written inside a
+namespaced declaration (`theorem Foo.bar ...`). Such declarations are internally expanded via a
+macro into a `namespace` block; the warning must not be attributed to that macro expansion, but
+behave exactly as in the non-namespaced case.
+-/
+
+set_option linter.deprecated.syntax true
+
+syntax (name := deprecatedProofTactic) "deprecated_proof_tactic" : tactic
+macro_rules
+  | `(tactic| deprecated_proof_tactic) => `(tactic| trivial)
+
+deprecated_syntax deprecatedProofTactic "use `trivial` instead" (since := "2026-08-27")
+
+/--
+warning: syntax 'deprecatedProofTactic' has been deprecated: use `trivial` instead
+
+Note: This linter can be disabled with `set_option linter.deprecated.syntax false`
+-/
+#guard_msgs in
+theorem DeprecatedSyntax.namespacedTheorem : True := by
+  deprecated_proof_tactic
+
+/--
+warning: syntax 'deprecatedProofTactic' has been deprecated: use `trivial` instead
+
+Note: This linter can be disabled with `set_option linter.deprecated.syntax false`
+-/
+#guard_msgs in
+theorem nonNamespacedTheorem : True := by
+  deprecated_proof_tactic


### PR DESCRIPTION
This PR changes the behaviour of `deprecated_syntax` warnings for things that were generated via macro expansion. If a piece of syntax is a result of macro, but comes with `.original` source info, we focus the warning on that piece of syntax. 

Motivation comes from deprecated syntax used within namespaced declarations, that expand via macro. The original handling was obscuring the precise usage of deprecated_syntax in such cases.