### PR TITLE
feat: allow `optParam` and `autoParam` in implicit binders

### DIFF
--- a/src/Lean/Elab/App.lean
+++ b/src/Lean/Elab/App.lean
@@ -122,6 +122,10 @@ def eraseNamedArg (namedArgs : List NamedArg) (binderName : Name) : List NamedAr
 private def hasOptAutoParams (type : Expr) : MetaM Bool := do
   forallTelescopeReducing type fun xs _ =>
     xs.anyM fun x => do
+      -- Fallbacks on implicit binders must not force eta-expansion: the parameter is inserted
+      -- automatically anyway, and pinning it to its fallback would defeat unification.
+      unless (← x.fvarId!.getBinderInfo).isExplicit do
+        return false
       let xType ← inferType x
       return xType.isOptParam || xType.isAutoParam
 
@@ -726,6 +730,27 @@ where
     else
       return false
 
+/--
+Builds the `by ..` block for the `autoParam` tactic `tactic` of parameter `argName`.
+-/
+private def mkAutoParamTacticBlock (argName : Name) (tactic : Expr) : M Syntax := do
+  let .const tacticDecl _ := tactic
+    | throwError "Internal error when elaborating function application: autoParam `{argName}` is not a constant"
+  match evalSyntaxConstant (← getEnv) (← getOptions) tacticDecl with
+  | .error err => throwError err
+  | .ok tacticSyntax =>
+    let tacticBlock ← `(by $(⟨tacticSyntax⟩))
+    /-
+    We insert position information from the current ref into `stx` everywhere, simulating this being
+    a tactic script inserted by the user, which ensures error messages and logging will always be attributed
+    to this application rather than sometimes being placed at position (1,0) in the file.
+    Placing position information on `by` syntax alone is not sufficient since incrementality
+    (in particular, `Lean.Elab.Term.withReuseContext`) controls the ref to avoid leakage of outside data.
+    Note that `tacticSyntax` contains no position information itself, since it is erased by `Lean.Elab.Term.quoteAutoTactic`.
+    -/
+    let info := (← getRef).getHeadInfo.nonCanonicalSynthetic
+    return tacticBlock.raw.rewriteBottomUp (·.setInfo info)
+
 mutual
   /--
   Create a fresh local variable with the current binder name and argument type, add it to `etaArgs` and `f`,
@@ -756,6 +781,21 @@ mutual
     else
       mkFreshExprMVar argType
     modify fun s => { s with toSetErrorCtx := s.toSetErrorCtx.push arg.mvarId! }
+    /-
+    An `optParam`/`autoParam` on an implicit binder is only a fallback: `arg` is a regular
+    metavariable that unification may assign, and the default value or tactic is used only if it is
+    still unassigned once everything else has been synthesized.
+    Ellipsis suppresses fallbacks, just as it does for explicit binders.
+    -/
+    unless (← read).ellipsis do
+      let paramType ← getParamType
+      if let some defVal := paramType.getOptParamDefault? then
+        registerSyntheticMVarWithCurrRef arg.mvarId! (.defaultValue defVal argName)
+      else if let some tactic := paramType.getAutoParamTactic? then
+        let tacticBlock ← mkAutoParamTacticBlock argName tactic
+        registerTacticMVar arg.mvarId! tacticBlock (.autoParam argName)
+        -- See the note in `processExplicitArg` about `addTermInfo'`.
+        addTermInfo' tacticBlock arg
     addNewArg argName arg
     main
 
@@ -826,32 +866,15 @@ mutual
       let paramType ← getParamType
       match (← read).explicit, paramType.getOptParamDefault?, paramType.getAutoParamTactic? with
       | false, some defVal, _  => addNewArg argName defVal; main
-      | false, _, some (.const tacticDecl _) =>
-        let env ← getEnv
-        let opts ← getOptions
-        match evalSyntaxConstant env opts tacticDecl with
-        | Except.error err       => throwError err
-        | Except.ok tacticSyntax =>
-          let tacticBlock ← `(by $(⟨tacticSyntax⟩))
-          /-
-          We insert position information from the current ref into `stx` everywhere, simulating this being
-          a tactic script inserted by the user, which ensures error messages and logging will always be attributed
-          to this application rather than sometimes being placed at position (1,0) in the file.
-          Placing position information on `by` syntax alone is not sufficient since incrementality
-          (in particular, `Lean.Elab.Term.withReuseContext`) controls the ref to avoid leakage of outside data.
-          Note that `tacticSyntax` contains no position information itself, since it is erased by `Lean.Elab.Term.quoteAutoTactic`.
-          -/
-          let info := (← getRef).getHeadInfo.nonCanonicalSynthetic
-          let tacticBlock := tacticBlock.raw.rewriteBottomUp (·.setInfo info)
-          let mvar ← mkTacticMVar (← getArgExpectedType) tacticBlock (.autoParam argName)
-          -- Note(kmill): We are adding terminfo to simulate a previous implementation that elaborated `tacticBlock`.
-          -- We should look into removing this since terminfo for synthetic syntax is suspect,
-          -- but we noted it was necessary to preserve the behavior of the unused variable linter.
-          addTermInfo' tacticBlock mvar
-          addNewArg argName mvar
-          main
-      | false, _, some _ =>
-        throwError "Internal error when elaborating function application: autoParam `{argName}` is not a constant"
+      | false, _, some tactic =>
+        let tacticBlock ← mkAutoParamTacticBlock argName tactic
+        let mvar ← mkTacticMVar (← getArgExpectedType) tacticBlock (.autoParam argName)
+        -- Note(kmill): We are adding terminfo to simulate a previous implementation that elaborated `tacticBlock`.
+        -- We should look into removing this since terminfo for synthetic syntax is suspect,
+        -- but we noted it was necessary to preserve the behavior of the unused variable linter.
+        addTermInfo' tacticBlock mvar
+        addNewArg argName mvar
+        main
       | _, _, _ =>
         if (← read).ellipsis then
           addImplicitArg argName

--- a/src/Lean/Elab/Binders.lean
+++ b/src/Lean/Elab/Binders.lean
@@ -149,10 +149,11 @@ private def toBinderViews (stx : Syntax) : TermElabM (Array BinderView) := do
     let optModifier := stx[3]
     ids.mapM fun id => do pure { ref := id, id := (← expandBinderIdent id), type := (← expandBinderModifier (expandBinderType id type) optModifier), bi := .default }
   else if k == ``Lean.Parser.Term.implicitBinder then
-    -- `{` binderIdent+ binderType `}`
+    -- `{` binderIdent+ binderType (binderDefault <|> binderTactic)? `}`
     let ids ← getBinderIds stx[1]
-    let type := stx[2]
-    ids.mapM fun id => do pure { ref := id, id := (← expandBinderIdent id), type := expandBinderType id type, bi := .implicit }
+    let type        := stx[2]
+    let optModifier := stx[3]
+    ids.mapM fun id => do pure { ref := id, id := (← expandBinderIdent id), type := (← expandBinderModifier (expandBinderType id type) optModifier), bi := .implicit }
   else if k == ``Lean.Parser.Term.strictImplicitBinder then
     -- `⦃` binderIdent+ binderType `⦄`
     let ids ← getBinderIds stx[1]

--- a/src/Lean/Elab/BuiltinCommand.lean
+++ b/src/Lean/Elab/BuiltinCommand.lean
@@ -356,7 +356,11 @@ private def replaceBinderAnnotation (binder : TSyntax ``Parser.Term.bracketedBin
             if containsId ids binderId then
               throwErrorAt binderId "cannot update binder annotation of variables with default values/tactics"
         pure (ids, ty?, .default)
-      | `(bracketedBinderF|{$ids* $[: $ty?]?}) =>
+      | `(bracketedBinderF|{$ids* $[: $ty?]? $(annot?)?}) =>
+        if annot?.isSome then
+          for binderId in binderIds do
+            if containsId ids binderId then
+              throwErrorAt binderId "cannot update binder annotation of variables with default values/tactics"
         pure (ids, ty?, .implicit)
       | `(bracketedBinderF|⦃$ids* $[: $ty?]?⦄) =>
         pure (ids, ty?, .strictImplicit)

--- a/src/Lean/Elab/Command.lean
+++ b/src/Lean/Elab/Command.lean
@@ -893,7 +893,7 @@ open Lean.Parser.Term in
 /-- Return identifier names in the given bracketed binder. -/
 def getBracketedBinderIds : Syntax → CommandElabM (Array Name)
   | `(bracketedBinderF|($ids* $[: $ty?]? $(_annot?)?)) => return ids.map Syntax.getId
-  | `(bracketedBinderF|{$ids* $[: $ty?]?})             => return ids.map Syntax.getId
+  | `(bracketedBinderF|{$ids* $[: $ty?]? $(_annot?)?}) => return ids.map Syntax.getId
   | `(bracketedBinderF|⦃$ids* : $_⦄)                   => return ids.map Syntax.getId
   | `(bracketedBinderF|[$id : $_])                     => return #[id.getId]
   | `(bracketedBinderF|[$_])                           => return #[Name.anonymous]

--- a/src/Lean/Elab/ConfigEval/Builtins.lean
+++ b/src/Lean/Elab/ConfigEval/Builtins.lean
@@ -91,7 +91,7 @@ open Lean.Parser.Term in
 private def getBracketedBinderArgs (stx : Syntax) : MacroM (Array Term) :=
   match stx with
   | `(bracketedBinderF|($ids:ident* $[: $ty?]? $(_annot?)?)) => return ids
-  | `(bracketedBinderF|{$ids:ident* $[: $_]?})               => return ids
+  | `(bracketedBinderF|{$ids:ident* $[: $_]? $(_annot?)?})   => return ids
   | `(bracketedBinderF|⦃$ids:ident* : $_⦄)                    => return ids
   | `(bracketedBinderF|[$id:ident : $_])                     => return #[id]
   | `(bracketedBinderF|[$_])                                 => return #[mkHole stx]

--- a/src/Lean/Elab/SyntheticMVars.lean
+++ b/src/Lean/Elab/SyntheticMVars.lean
@@ -418,6 +418,24 @@ private def markAsResolved (mvarId : MVarId) : TermElabM Unit :=
   modify fun s => { s with syntheticMVars := s.syntheticMVars.erase mvarId }
 
 /--
+Returns the metavariable a fallback (an `optParam` or `autoParam` on an implicit binder) applies to,
+or `none` if the parameter has already been determined.
+
+Unification may have solved the parameter outright, in which case the fallback goes unused, or it
+may merely have aliased it to another unassigned metavariable, in which case the fallback applies to
+that one instead. It does not apply if the alias is somebody else's to synthesize.
+-/
+private def fallbackMVar? (mvarId : MVarId) : TermElabM (Option MVarId) := do
+  if (← mvarId.isDelayedAssigned) then
+    return none
+  let .mvar mvarId' ← instantiateMVars (mkMVar mvarId) | return none
+  if mvarId' == mvarId then
+    return mvarId
+  if (← mvarId'.isReadOnlyOrSyntheticOpaque) || (← getSyntheticMVarDecl? mvarId').isSome then
+    return none
+  return mvarId'
+
+/--
 Auxiliary type for `synthesizeSyntheticMVars`. It specifies
 whether pending synthetic metavariables can be postponed or not.
 -/
@@ -561,12 +579,24 @@ mutual
     -- NOTE: actual processing at `synthesizeSyntheticMVarsAux`
     | .postponed savedContext => resumePostponed savedContext mvarSyntheticDecl.stx mvarId postponeOnError
     | .tactic tacticCode savedContext kind delayOnMVars =>
+      -- An `autoParam` on an implicit binder is assignable by unification; its tactic only applies
+      -- if unification left the parameter undetermined.
+      let some mvarId ← fallbackMVar? mvarId | return true
       withSavedContext savedContext do
         if runTactics && !(delayOnMVars && (← mvarId.getType >>= instantiateExprMVars).hasExprMVar) then
           runTactic mvarId tacticCode kind
           return true
         else
           return false
+    | .defaultValue defaultVal argName =>
+      let some mvarId ← fallbackMVar? mvarId | return true
+      unless runTactics do
+        return false
+      mvarId.withContext do
+        unless (← isDefEq (mkMVar mvarId) defaultVal) do
+          logError m!"failed to assign default value to parameter `{argName}`{indentExpr defaultVal}"
+          mvarId.admit
+        return true
   /--
     Try to synthesize the current list of pending synthetic metavariables.
     Return `true` if at least one of them was synthesized. -/

--- a/src/Lean/Elab/Term/TermElabM.lean
+++ b/src/Lean/Elab/Term/TermElabM.lean
@@ -87,6 +87,12 @@ inductive SyntheticMVarKind where
   expr metavariables.
   -/
   | tactic (tacticCode : Syntax) (ctx : SavedContext) (kind : TacticMVarKind) (delayOnMVars := false)
+  /--
+  Assign `defaultVal` to the metavariable if it is still unassigned once everything else has been
+  synthesized. Used for `optParam`s on implicit binders, where the default value is only a fallback
+  for a parameter unification failed to determine.
+  -/
+  | defaultValue (defaultVal : Expr) (argName : Name)
   /-- Metavariable represents a hole whose elaboration has been postponed. -/
   | postponed (ctx : SavedContext)
   deriving Inhabited
@@ -99,10 +105,11 @@ def extraMsgToMsg (extraErrorMsg? : Option MessageData) : MessageData :=
 
 instance : ToString SyntheticMVarKind where
   toString
-    | .typeClass .. => "typeclass"
-    | .coe ..       => "coe"
-    | .tactic ..    => "tactic"
-    | .postponed .. => "postponed"
+    | .typeClass ..    => "typeclass"
+    | .coe ..          => "coe"
+    | .tactic ..       => "tactic"
+    | .defaultValue .. => "default value"
+    | .postponed ..    => "postponed"
 
 structure SyntheticMVarDecl where
   stx : Syntax
@@ -1461,6 +1468,15 @@ register_builtin_option debug.byAsSorry : Bool := {
 }
 
 /--
+Schedules `tacticCode` to be run on `mvarId` if it is still unassigned when synthetic
+metavariables are synthesized.
+The `tacticCode` syntax is the full `by ..` syntax.
+-/
+def registerTacticMVar (mvarId : MVarId) (tacticCode : Syntax) (kind : TacticMVarKind)
+    (delayOnMVars := false) : TermElabM Unit := do
+  registerSyntheticMVar (← getRef) mvarId <| .tactic tacticCode (← saveContext) kind delayOnMVars
+
+/--
 Creates a new metavariable of type `type` that will be synthesized using the tactic code.
 The `tacticCode` syntax is the full `by ..` syntax.
 -/
@@ -1470,9 +1486,7 @@ def mkTacticMVar (type : Expr) (tacticCode : Syntax) (kind : TacticMVarKind)
     withRef tacticCode <| mkLabeledSorry type false (unique := true)
   else
     let mvar ← mkFreshExprMVar type MetavarKind.syntheticOpaque
-    let mvarId := mvar.mvarId!
-    let ref ← getRef
-    registerSyntheticMVar ref mvarId <| .tactic tacticCode (← saveContext) kind delayOnMVars
+    registerTacticMVar mvar.mvarId! tacticCode kind delayOnMVars
     return mvar
 
 /--

--- a/src/Lean/Parser/Term/Basic.lean
+++ b/src/Lean/Parser/Term/Basic.lean
@@ -212,10 +212,15 @@ then a `_` placeholder is automatically inserted for this parameter.
 Implicit parameters should be able to be determined from the other arguments and the return type
 by unification.
 
+A fallback can be specified using `{x : A := v}` syntax, and tactics using `{x : A := by tac}`.
+Unlike for explicit binders, the fallback is used only if unification leaves the parameter
+unassigned.
+
 In `@` explicit mode, implicit binders behave like explicit binders.
 -/
 @[builtin_doc] def implicitBinder (requireType := false) := leading_parser ppGroup <|
-  "{" >> withoutPosition (many1 binderIdent >> binderType requireType) >> "}"
+  "{" >> withoutPosition (many1 binderIdent >> binderType requireType >>
+    optional (binderTactic <|> binderDefault)) >> "}"
 def strictImplicitLeftBracket := atomic (group (symbol "{" >> "{")) <|> "⦃"
 def strictImplicitRightBracket := atomic (group (symbol "}" >> "}")) <|> "⦄"
 /--

--- a/src/Lean/PrettyPrinter/Delaborator/Builtins.lean
+++ b/src/Lean/PrettyPrinter/Delaborator/Builtins.lean
@@ -1605,25 +1605,35 @@ where
       -/
       let mkGroup : Array Ident → DelabM Syntax ← withBindingDomain do
         match i with
-        | .implicit       => let ty ← delabTy; pure fun curIds => `(bracketedBinderF|{$curIds* : $ty})
+        | .implicit =>
+          match ← delabFallback? d with
+          | some (ty, .inl val) => pure fun curIds => `(bracketedBinderF|{$curIds* : $ty := $val})
+          | some (ty, .inr tac) => pure fun curIds => `(bracketedBinderF|{$curIds* : $ty := by $tac})
+          | none => let ty ← delabTy; pure fun curIds => `(bracketedBinderF|{$curIds* : $ty})
         | .strictImplicit => let ty ← delabTy; pure fun curIds => `(bracketedBinderF|⦃$curIds* : $ty⦄)
         | .instImplicit   => let ty ← delabTy; pure fun curIds => `(bracketedBinderF|[$(curIds[0]!) : $ty])
         | _ =>
-          if d.isOptParam then
-            let ty ← withAppFn <| withAppArg delabTy
-            let val ← withAppArg delabTy
-            pure fun curIds => `(bracketedBinderF|($curIds* : $ty := $val))
-          else if let some (.const tacticDecl _) := d.getAutoParamTactic? then
-            let ty ← withAppFn <| withAppArg delabTy
-            let tacticSyntax ← ofExcept <| evalSyntaxConstant (← getEnv) (← getOptions) tacticDecl
-            pure fun curIds => `(bracketedBinderF|($curIds* : $ty := by $tacticSyntax))
-          else
-            let ty ← delabTy
-            pure fun curIds => `(bracketedBinderF|($curIds* : $ty))
+          match ← delabFallback? d with
+          | some (ty, .inl val) => pure fun curIds => `(bracketedBinderF|($curIds* : $ty := $val))
+          | some (ty, .inr tac) => pure fun curIds => `(bracketedBinderF|($curIds* : $ty := by $tac))
+          | none => let ty ← delabTy; pure fun curIds => `(bracketedBinderF|($curIds* : $ty))
       withBindingBody' n (mkAnnotatedIdent n) fun stxN => do
         let curIds := curIds.push stxN
         let group ← mkGroup curIds
         delabParams bindingNames (groups.push group)
+  /--
+  Delaborates the domain `d` of a binder carrying an `optParam` or `autoParam`, returning the
+  underlying type along with the default value or the tactic script.
+  -/
+  delabFallback? (d : Expr) : DelabM (Option (Term × (Term ⊕ Syntax))) := do
+    if d.isOptParam then
+      let ty ← withAppFn <| withAppArg delabTy
+      return some (ty, .inl (← withAppArg delabTy))
+    else if let some (.const tacticDecl _) := d.getAutoParamTactic? then
+      let ty ← withAppFn <| withAppArg delabTy
+      return some (ty, .inr (← ofExcept <| evalSyntaxConstant (← getEnv) (← getOptions) tacticDecl))
+    else
+      return none
   /-
   Given the forall `e` with body `e'`, determines if the binder from `e'` (if it is a forall) should be grouped with `e`'s binder.
   -/

--- a/src/lake/Lake/Util/Binder.lean
+++ b/src/lake/Lake/Util/Binder.lean
@@ -134,14 +134,16 @@ public def expandBinderCore
       modifier?
     }
   else if k == ``Lean.Parser.Term.implicitBinder then
-    -- `{` binderIdent+ binderType `}`
+    -- `{` binderIdent+ binderType (binderDefault <|> binderTactic)? `}`
     let ids ← getBinderIds stx[1]
     let type := stx[2]
+    let modifier? := expandBinderModifier stx[3]
     ids.foldlM (init := binders) fun binders id => return binders.push {
       ref := stx
       id := ← expandBinderIdent id
       type := expandBinderType id type
       info := .implicit
+      modifier?
     }
   else if k == ``Lean.Parser.Term.strictImplicitBinder then
     -- `⦃` binderIdent+ binderType `⦄`

--- a/tests/elab/implicitAutoParam.lean
+++ b/tests/elab/implicitAutoParam.lean
@@ -1,0 +1,177 @@
+/-!
+# `optParam` and `autoParam` in implicit binders
+
+A default value or auto-param tactic on an implicit binder is only a fallback: the parameter is a
+regular metavariable that unification may assign, and the fallback is used only if it is still
+unassigned once everything else has been synthesized.
+-/
+
+inductive Color where
+  | red
+  | green
+
+inductive Tagged : Color → Type where
+  | mk : Tagged c
+
+/-! ## `autoParam` -/
+
+def tagged {c : Color := by exact .red} : Tagged c := .mk
+
+/-- info: tagged {c : Color := by exact .red} : Tagged c -/
+#guard_msgs in
+#check tagged
+
+-- Nothing determines `c`, so the tactic runs.
+/-- info: @tagged Color.red : Tagged Color.red -/
+#guard_msgs in
+set_option pp.explicit true in
+#check (tagged : Tagged _)
+
+-- The expected type determines `c`, so the tactic does not run.
+/-- info: @tagged Color.green : Tagged Color.green -/
+#guard_msgs in
+set_option pp.explicit true in
+#check (tagged : Tagged .green)
+
+-- The expected type of an argument determines it just as well.
+def use (_ : Tagged .green) : Nat := 0
+
+/-- info: use (@tagged Color.green) : Nat -/
+#guard_msgs in
+set_option pp.explicit true in
+#check use tagged
+
+-- Named arguments and `@` still work.
+/-- info: @tagged Color.green : Tagged Color.green -/
+#guard_msgs in
+set_option pp.explicit true in
+#check (tagged (c := .green))
+
+/-- info: @tagged Color.green : Tagged Color.green -/
+#guard_msgs in
+set_option pp.explicit true in
+#check @tagged .green
+
+-- `..` suppresses the fallback, as it does for explicit binders.
+/-- info: @tagged ?_ : Tagged ?_ -/
+#guard_msgs in
+set_option pp.explicit true in
+set_option pp.mvars false in
+#check (tagged ..)
+
+/-! ## `optParam` -/
+
+def otagged {c : Color := .red} : Tagged c := .mk
+
+/-- info: otagged {c : Color := Color.red} : Tagged c -/
+#guard_msgs in
+#check otagged
+
+/-- info: @otagged Color.red : Tagged Color.red -/
+#guard_msgs in
+set_option pp.explicit true in
+#check (otagged : Tagged _)
+
+/-- info: @otagged Color.green : Tagged Color.green -/
+#guard_msgs in
+set_option pp.explicit true in
+#check (otagged : Tagged .green)
+
+/-! ## Proof obligations -/
+
+def firstOf (xs : List Nat) {h : xs ≠ [] := by simp} : Nat := xs.head h
+
+/-- info: 1 -/
+#guard_msgs in
+#eval firstOf [1, 2, 3]
+
+-- The tactic's own error is reported, not `don't know how to synthesize implicit argument`.
+/--
+error: could not synthesize default value for parameter 'h' using tactics
+---
+error: unsolved goals
+⊢ False
+---
+info: firstOf [] : Nat
+-/
+#guard_msgs in
+#check firstOf []
+
+-- An explicitly supplied proof suppresses the tactic.
+/-- info: 7 -/
+#guard_msgs in
+#eval firstOf [7] (h := by simp)
+
+/-! ## No spurious eta-expansion
+
+A fallback on an implicit binder must not force eta-expansion, which would pin the parameter to the
+fallback instead of leaving it to unification. An implicit binder with a fallback therefore behaves
+exactly like a plain implicit binder here, while an explicit one still eta-expands.
+
+The raw `autoParam` in the mismatch message is a pre-existing gap: only the signature delaborator
+undoes the annotation, not the one for general `forall`s.
+-/
+
+def add3 (k : Nat) {n : Nat := by exact 3} : Nat := n + k
+def add3' (k : Nat) (n : Nat := by exact 3) : Nat := n + k
+
+/-- info: fun k => add3' k 3 : Nat → Nat -/
+#guard_msgs in
+#check (add3' : Nat → Nat)
+
+/--
+error: Type mismatch
+  add3
+has type
+  Nat → {n : autoParam Nat add3._auto_1} → Nat
+but is expected to have type
+  Nat → Nat
+-/
+#guard_msgs in
+#check (add3 : Nat → Nat)
+
+/-! ## Metavariable aliases
+
+Unification may not solve the parameter outright but merely alias it to another unassigned
+metavariable, as with the `_` below. The fallback still applies, to that metavariable.
+-/
+
+def dim {n : Nat := by exact 3} (_v : Vector Nat n) : Nat := n
+
+-- The argument determines `n`.
+/-- info: 2 -/
+#guard_msgs in
+#eval dim #v[10, 20]
+
+-- Nothing does, so the tactic runs and fills the `_` too.
+/-- info: 3 -/
+#guard_msgs in
+#eval dim (Vector.replicate _ 0)
+
+/-! ## Section variables -/
+
+section
+variable {k : Nat := by exact 9}
+
+def useK : Nat × Nat := (k, k)
+
+/-- error: cannot update binder annotation of variables with default values/tactics -/
+#guard_msgs in
+variable (k)
+
+end
+
+/-- info: useK {k : Nat := by exact 9} : Nat × Nat -/
+#guard_msgs in
+#check useK
+
+/-- info: (9, 9) -/
+#guard_msgs in
+#eval useK
+
+-- Defaults may refer to earlier parameters.
+def pair {a : Nat := 1} {b : Nat := a + 1} : Nat × Nat := (a, b)
+
+/-- info: (1, 2) -/
+#guard_msgs in
+#eval pair

--- a/tests/elab/implicitAutoParamClass.lean
+++ b/tests/elab/implicitAutoParamClass.lean
@@ -1,0 +1,123 @@
+/-!
+# A fallback on a class parameter
+
+The motivating use for a fallback on an implicit binder, from
+https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/Emulating.20eager.20default.20instance.3F
+and https://github.com/leanprover-community/iris-lean/pull/576: a class parameter that users almost
+never want to write, which should be determined by unification where possible and otherwise take a
+section-wide default.
+
+Emulating this with a `@[default_instance]` routes the default through a class goal (`SIdx ?SI`)
+that ordinary synthesis attacks and gets stuck on, so the number of aborted searches per
+declaration header grows as `k² + 4k` in the number of binders. Attaching the fallback to the class
+parameter directly removes the class goal, leaving `6k`.
+
+This file pins the elaboration behaviour, not the counts.
+-/
+
+class SIdx (I : Type u) where
+  lt : I → I → Prop
+
+class DefaultSI (SI : outParam (Type u)) where
+  sidx : SIdx SI
+
+/--
+The ambient step-index type, read off the `DefaultSI` instance in scope.
+
+Being reducible this is defeq to the type it names, but it does stay in elaborated types, which
+read `OFE (defaultSI Nat ..) α` below rather than `OFE Nat α`. A term elaborator returning the
+metavariable that the `outParam` assigned avoids that.
+-/
+abbrev defaultSI (SI : Type u) [DefaultSI SI] : Type u := SI
+
+/-- `SI` is solved by unification like any implicit argument; the tactic runs only if nothing
+determined it. -/
+class OFE {SI : Type _ := by exact defaultSI _} [SIdx SI] (α : Type _) where
+  Dist : SI → α → α → Prop
+  dist_eqv : Equivalence (Dist n)
+
+section
+variable {SI : Type _} [instSI : SIdx SI]
+
+-- What a `local stepindex SI` command would expand to.
+set_option synthInstance.checkSynthOrder false in
+local instance (priority := 10000) instDefaultSI : DefaultSI SI := ⟨instSI⟩
+
+/-- The declaration reported in the thread. Its statement is the same as without the fallback. -/
+theorem dist_equivalence [OFE α] {n : SI} : Equivalence (OFE.Dist (α := α) n) :=
+  OFE.dist_eqv
+
+/--
+info: @dist_equivalence : ∀ {SI : Type u_2} [instSI : SIdx SI] {α : Type u_1} [inst : OFE α] {n : SI},
+  Equivalence (OFE.Dist n)
+-/
+#guard_msgs in
+#check @dist_equivalence
+
+-- Several binders in one header all take the ambient default.
+theorem k3 {α₀ α₁ α₂ : Type} [OFE α₀] [OFE α₁] [OFE α₂] : True := trivial
+
+/-- info: @k3 : ∀ {SI : Type u_1} [instSI : SIdx SI] {α₀ α₁ α₂ : Type} [OFE α₀] [OFE α₁] [OFE α₂], True -/
+#guard_msgs in
+#check @k3
+
+end
+
+/-! ## The fallback is only a fallback
+
+Outside the section there is no `DefaultSI` at all, and unification still determines `SI`. -/
+
+instance instSIdxNat : SIdx Nat := ⟨(· < ·)⟩
+instance instSIdxBool : SIdx Bool := ⟨fun _ _ => True⟩
+
+theorem pinned {α : Type} [OFE (SI := Nat) α] : True := trivial
+
+/-- info: @pinned : ∀ {α : Type} [OFE α], True -/
+#guard_msgs in
+#check @pinned
+
+-- With nothing to determine it, the tactic's own failure is reported rather than
+-- "don't know how to synthesize implicit argument".
+/--
+error: could not synthesize default value for parameter 'SI' using tactics
+---
+error: failed to synthesize instance of type class
+  DefaultSI ?m.3
+
+Hint: Type class instance resolution failures can be inspected with the `set_option trace.Meta.synthInstance true` command.
+-/
+#guard_msgs in
+theorem undetermined {α : Type} [OFE α] : True := trivial
+
+/-! ## Nested synthesis subgoals do not get the fallback
+
+Like `@[default_instance]`, a binder fallback lives in the term elaborator, so an `OFE ?SI α`
+arising as a *subgoal* of instance synthesis gets neither. Here the ambient default is `Nat`: a
+surface occurrence takes it, while the same query reached through `Wrap` picks `Bool` instead.
+Substituting a `@[default_instance]` formulation gives the same two answers, so this pins existing
+behaviour rather than a regression. -/
+
+instance : DefaultSI Nat := ⟨instSIdxNat⟩
+
+instance boolOFE : OFE (SI := Bool) Unit :=
+  ⟨fun _ _ _ => True, ⟨fun _ => trivial, fun _ => trivial, fun _ _ => trivial⟩⟩
+instance natOFE : OFE (SI := Nat) Unit :=
+  ⟨fun _ _ _ => True, ⟨fun _ => trivial, fun _ => trivial, fun _ _ => trivial⟩⟩
+
+class Wrap (α : Type) where dummy : Unit
+
+set_option synthInstance.checkSynthOrder false in
+instance wrapOfOFE {SI : Type} [SIdx SI] {α : Type} [OFE (SI := SI) α] : Wrap α := ⟨()⟩
+
+/--
+info: @inferInstance (@OFE (@defaultSI Nat instDefaultSINat) instSIdxNat Unit)
+  natOFE : @OFE (@defaultSI Nat instDefaultSINat) instSIdxNat Unit
+-/
+#guard_msgs in
+set_option pp.explicit true in
+#check (inferInstance : OFE Unit)
+
+/-- info: @inferInstance (Wrap Unit) (@wrapOfOFE Bool instSIdxBool Unit boolOFE) : Wrap Unit -/
+#guard_msgs in
+set_option pp.explicit true in
+#check (inferInstance : Wrap Unit)


### PR DESCRIPTION
This PR allows default values and auto-param tactics on implicit binders, as in `{n : Nat := 5}` and `{h : i < n := by omega}`. Such a parameter is solved by unification like a regular implicit argument; the default value or tactic is used only if unification leaves it unassigned.

Previously this syntax was a parse error, and an `optParam`/`autoParam` annotation reaching an implicit binder by other means was silently ignored.

This PR is a mere prototype.

## Open Questions

* Does the feature solve real-world issues? Does it pull its weight?
* Is it actually robust? We ignore trivial mvar assignments, is that correct?
* Is `synthesizeSyntheticMVars` the right trigger? `autoParam` already documents that it does not contribute to nested TC problems, but does the new notation still make that sufficiently clear?
* Does it interact correctly with `[implicit_reducible]`?