### PR TITLE
feat: mutual inductives with multiple universes

### DIFF
--- a/src/Lean/Elab.lean
+++ b/src/Lean/Elab.lean
@@ -26,6 +26,7 @@ public import Lean.Elab.Syntax
 public import Lean.Elab.Do
 public import Lean.Elab.StructInst
 public import Lean.Elab.StructInstHint
+public import Lean.Elab.MultiuniverseInductive
 public import Lean.Elab.MutualInductive
 public import Lean.Elab.Inductive
 public import Lean.Elab.Structure

--- a/src/Lean/Elab/Declaration.lean
+++ b/src/Lean/Elab/Declaration.lean
@@ -236,7 +236,12 @@ where
     | _, _ => .anonymous
 
 
-@[builtin_macro Lean.Parser.Command.mutual]
+/-! The three `mutual` preprocessing macros below only rearrange `stx[1]`, the
+block's elements, so they apply verbatim to `mutual_multiuniverse`, whose
+syntax has the same shape. -/
+
+@[builtin_macro Lean.Parser.Command.mutual,
+  builtin_macro Lean.Parser.Command.mutualMultiuniverse]
 def expandMutualNamespace : Macro := fun stx => do
   let mut nss := #[]
   for elem in stx[1].getArgs do
@@ -254,7 +259,8 @@ def expandMutualNamespace : Macro := fun stx => do
   let stxNew := stx.setArg 1 (mkNullNode elemsNew)
   `(namespace $ns $(⟨stxNew⟩) end $ns)
 
-@[builtin_macro Lean.Parser.Command.mutual]
+@[builtin_macro Lean.Parser.Command.mutual,
+  builtin_macro Lean.Parser.Command.mutualMultiuniverse]
 def expandMutualElement : Macro := fun stx => do
   let mut elemsNew := #[]
   let mut modified := false
@@ -275,7 +281,8 @@ def expandMutualElement : Macro := fun stx => do
   else
     Macro.throwUnsupported
 
-@[builtin_macro Lean.Parser.Command.mutual]
+@[builtin_macro Lean.Parser.Command.mutual,
+  builtin_macro Lean.Parser.Command.mutualMultiuniverse]
 def expandMutualPreamble : Macro := fun stx =>
   match splitMutualPreamble stx[1].getArgs with
   | none => Macro.throwUnsupported
@@ -296,6 +303,15 @@ def elabMutual : CommandElab := fun stx => do
       elabMutualInductive stx[1].getArgs
     else
       throwError "invalid mutual block: either all elements of the block must be inductive/structure declarations, or they must all be definitions/theorems/abbrevs"
+
+@[builtin_command_elab «mutualMultiuniverse»]
+def elabMutualMultiuniverse : CommandElab := fun stx => do
+  withExporting (isExporting := (← getScope).isPublic) do
+  withoutCommandIncrementality true do
+    unless ← isMutualInductive stx do
+      throwError "invalid `mutual_multiuniverse` block: every element of the block must be an \
+        `inductive` declaration"
+    elabMultiuniverseInductive stx[1].getArgs
 
 /- leading_parser "attribute " >> "[" >> sepBy1 (eraseAttr <|> Term.attrInstance) ", " >> "]" >> many1 ident -/
 @[builtin_command_elab «attribute»] def elabAttr : CommandElab := fun stx => do

--- a/src/Lean/Elab/MultiuniverseInductive.lean
+++ b/src/Lean/Elab/MultiuniverseInductive.lean
@@ -1,0 +1,1002 @@
+/-
+Copyright (c) 2026 Alex Meiburg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex Meiburg
+-/
+module
+
+prelude
+public import Lean.Meta.Constructions
+public import Lean.Meta.SizeOf
+import Lean.Meta.Constructions.CtorIdx
+import Lean.Meta.Constructions.CtorElim
+import Lean.Meta.IndPredBelow
+import Lean.Meta.Injective
+
+public section
+
+/-!
+# Lowering a universe-heterogeneous mutual inductive block
+
+Lean requires every member of a mutual inductive block to live in the same
+universe.  The restriction is checked three times over: once while the headers
+are elaborated, once after the constructors are, and once by the kernel.  So a
+block like
+
+```
+mutual
+inductive A : Prop where
+  | fromB : B → A
+  | fromC : C → A
+inductive B : Type 0 where
+  | fromA : Nat → A → B
+inductive C : Type 2 where
+  | fromA : A → C
+  | higherUniv : Nat → Type → C
+end
+```
+
+is rejected, even though it denotes something perfectly sensible.
+
+This module implements the lowering used by `mutual_multiuniverse`, which
+accepts such a block by translating it into ordinary declarations.  Everything
+it adds to the environment is an ordinary inductive type, definition or
+theorem, so no part of it asks anything new of the kernel and the worst it can
+do is fail.
+
+## The translation
+
+1. An all-`Prop` **shadow** of the whole block, `X_i._shadow`.  Every block has
+   one: the side condition on a constructor field of a `Prop`-valued inductive
+   is `imax l' 0 ≤ 0`, which is vacuous, so the fields can be copied verbatim
+   with member occurrences redirected to the shadow.
+
+2. The **data** members, declared under the users' own names, against the
+   shadow.  They are grouped into strongly connected components of the
+   data-only dependency graph and emitted in topological order.  Each SCC is
+   necessarily universe-homogeneous -- an edge `i → j` forces `l_j ≤ l_i`, so a
+   cycle forces equality -- hence each is an ordinary mutual block.
+
+3. The `Prop` members' user-facing names (reducible abbreviations for their
+   shadows) and constructors, the squash maps `X._squash : X → X._shadow`, and
+   a block-wide recursor `X.mutualRec` for every member.
+
+Only the `Prop` members are mangled.  Data members are honest inductive types
+under the names the user wrote, so `match`, `induction`, `cases`, `injection`,
+`noConfusion`, `deriving`, `sizeOf` and the code generator all work on them as
+usual, and the block's computational content stays computable.  A `Prop`
+member's constructors have to be re-derived, because their fields have the
+wrong types in the shadow: `A.fromB` must take a real `B`, not a `B._shadow`.
+
+## Why the recursors come out right
+
+* A `Prop` member of a block with at least two members is never
+  large-eliminating, and the shadow has the same number of members, so it has
+  exactly the original's elimination strength.  Squashing the data members
+  loses nothing.  (This is also the safety boundary: we derive *universes* per
+  member, never *elimination* per member.)
+* A `Prop` member's iota rules are equations between proofs, so they hold by
+  proof irrelevance.
+* All computational content sits in the data recursors, which are the native
+  recursors of the honestly-declared data members, so their iota rules hold by
+  delta on `mutualRec` followed by native iota.
+
+The one place a choice principle is unavoidable is a `Prop` member with a
+constructor field that is a *function into* a data member: the data witnesses
+then have to be selected pointwise, which needs `Classical.choice`.  A block
+without such a field produces axiom-free recursors.
+-/
+
+namespace Lean.Elab.MultiuniverseInductive
+
+open Lean Meta
+
+/-! ## Auxiliary names -/
+
+/-- The all-`Prop` shadow of member `n`. -/
+def shadowName (n : Name) : Name := n ++ `_shadow
+
+/-- `X._squash : X → X._shadow`, the map that forgets a data member's data. -/
+def squashName (n : Name) : Name := n ++ `_squash
+
+/-- Re-root a constructor name `X.c` at `newRoot`, giving `newRoot.c`. -/
+def reroot (memberName newRoot ctorName : Name) : Name :=
+  ctorName.replacePrefix memberName newRoot
+
+/-- `List.replicate` as an `Array`. -/
+private def rep {α : Type _} (n : Nat) (a : α) : Array α := (List.replicate n a).toArray
+
+/-! ## Input -/
+
+/--
+The elaborated block, as `mutual_multiuniverse` hands it to the lowering.  This
+is exactly the information `Lean.Elab.Command.mkInductiveDeclCore` has already
+computed, with the members still represented by free variables.
+-/
+structure Input where
+  levelParams : List Name
+  /-- Number of leading section `variable`s; `numVars ≤ numParams`.  A member's
+  free variable stands for the member *already applied* to these, so
+  substituting a constant for it means applying that constant to them, exactly
+  as `replaceIndFVarsWithConsts` does. -/
+  numVars     : Nat
+  numParams   : Nat
+  /-- The free variables standing for the members. -/
+  memberFVars : Array Expr
+  memberNames : Array Name
+  /-- `∀ params idxs, Sort l`, with all `numParams` binders. -/
+  memberTypes : Array Expr
+  ctorNames   : Array (Array Name)
+  /-- `∀ params fields, X_owner params idxs`, members as free variables. -/
+  ctorTypes   : Array (Array Expr)
+  /-- Whether the block declares classes; if so, `SizeOf` instances and
+  injectivity theorems are not generated, as for `mutual`. -/
+  isClass     : Bool := false
+
+/-! ## Block description -/
+
+/-- What a recursive constructor field recurses into. -/
+structure RecField where
+  /-- Index of the member this field recurses into. -/
+  member : Nat
+  /-- Number of leading `∀` binders before the member is reached.  Nonzero
+  means the field is a *function into* the member; these are the fields that
+  force `Classical.choice` when the recursor's target is a `Prop`. -/
+  arity  : Nat
+  deriving Inhabited, Repr
+
+/-- One constructor of the block. -/
+structure CtorInfo where
+  name      : Name
+  /-- Index of the member it belongs to. -/
+  owner     : Nat
+  /-- `∀ params fields, X_owner params idxs`, members as free variables. -/
+  type      : Expr
+  numFields : Nat
+  /-- One entry per field; `none` for a non-recursive field. -/
+  fields    : Array (Option RecField)
+  deriving Inhabited
+
+/-- One member of the block. -/
+structure MemberInfo where
+  name   : Name
+  /-- `∀ params idxs, Sort l`.  Contains no member occurrences. -/
+  type   : Expr
+  level  : Level
+  isProp : Bool
+  ctors  : Array CtorInfo
+  deriving Inhabited
+
+/-- The elaborated block plus the results of the analysis. -/
+structure Block where
+  levelParams : List Name
+  numVars     : Nat
+  numParams   : Nat
+  memberFVars : Array Expr
+  members     : Array MemberInfo
+  /-- Every constructor, in block order (member 0's, then member 1's, ...).
+  This is the order in which minor premises appear in every recursor. -/
+  allCtors    : Array CtorInfo
+  /-- Data-only SCCs, in topological order (dependencies first). -/
+  sccs        : Array (Array Nat)
+  /-- For each member, its SCC index, or `none` if it is a `Prop` member. -/
+  sccOf       : Array (Option Nat)
+  /-- One fresh universe parameter per data SCC. -/
+  sccLevel    : Array Name
+  /-- Whether any member is a `Prop`, i.e. whether a shadow is needed. -/
+  hasProp     : Bool
+  isClass     : Bool
+  deriving Inhabited
+
+def Block.size (b : Block) : Nat := b.members.size
+
+/--
+The name a member is actually declared under.  Data members keep the users'
+own names and are honest inductives; only `Prop` members are mangled.
+-/
+def Block.realName (b : Block) (i : Nat) : Name :=
+  let m := b.members[i]!
+  if m.isProp then shadowName m.name else m.name
+
+/--
+The universe of `X_i`'s motive: `Prop` for a `Prop` member, the member's SCC
+parameter otherwise.  Members of one SCC must share a parameter, because the
+native recursor of an SCC has a single elimination universe -- and they are
+universe-homogeneous anyway.
+-/
+def Block.motiveLevel (b : Block) (i : Nat) : Level :=
+  match b.sccOf[i]! with
+  | none   => .zero
+  | some s => .param b.sccLevel[s]!
+
+def Block.ownLevels (b : Block) : List Level := b.levelParams.map .param
+
+/-- Every generated recursor carries one extra universe parameter per data SCC,
+ahead of the block's own parameters, as Lean puts elimination universes first. -/
+def Block.recLevelParams (b : Block) : List Name := b.sccLevel.toList ++ b.levelParams
+
+def Block.recLevels (b : Block) : List Level := b.recLevelParams.map .param
+
+/--
+The block-wide recursor: motives and minor premises for *every* member of the
+block.  Data members already have a native `X.rec`, whose motives range over
+their own SCC only, so the block-wide one needs a name of its own.  A `Prop`
+member has no native recursor under its user-facing name, so it additionally
+answers to `X.rec`.
+-/
+def Block.recName (b : Block) (i : Nat) : Name := b.members[i]!.name ++ `mutualRec
+
+/-! ## Moving between the three "worlds"
+
+During elaboration the members are free variables.  Emitting a declaration
+means replacing those free variables by constants: by the shadow names, or by
+the names the members are declared under (which for a data member is the
+user-facing name).  The substitution has to happen underneath the parameter
+telescope, because a member free variable stands for the member applied to the
+section variables.
+-/
+
+private def Block.substMembers (b : Block) (targets : Array Name) (ctorType : Expr) :
+    MetaM Expr :=
+  forallBoundedTelescope ctorType b.numParams fun params body => do
+    let vars := params.extract 0 b.numVars
+    let mut m : ExprMap Expr := {}
+    for h : i in *...b.memberFVars.size do
+      m := m.insert b.memberFVars[i] (mkAppN (mkConst targets[i]! b.ownLevels) vars)
+    let body := body.replace fun e =>
+      if !e.isFVar then none else m[e]?
+    mkForallFVars params body
+
+/-- Substitute the shadow names of all members. -/
+def Block.toShadow (b : Block) (e : Expr) : MetaM Expr :=
+  b.substMembers (b.members.map fun m => shadowName m.name) e
+
+/-- Substitute the user-facing names of all members. -/
+def Block.toUser (b : Block) (e : Expr) : MetaM Expr :=
+  b.substMembers (b.members.map (·.name)) e
+
+/-! ## Small helpers -/
+
+/-- Overwrite the binder annotations of the first `bis.size` `∀`-binders. -/
+private partial def forceBinderInfos (e : Expr) (bis : Array BinderInfo) (i : Nat := 0) : Expr :=
+  if h : i < bis.size then
+    match e with
+    | .forallE n d b _ => .forallE n d (forceBinderInfos b bis (i + 1)) bis[i]
+    | _ => e
+  else e
+
+/-- Replace the resulting `Sort _` of an arity by `Prop`. -/
+private partial def resultToProp : Expr → Expr
+  | .forallE n d b bi => .forallE n d (resultToProp b) bi
+  | _ => mkSort .zero
+
+/--
+Add a plain safe definition and hand it to the code generator.  `logErrors :=
+false` makes the compiler mark a declaration `noncomputable` rather than fail,
+which is the right behaviour for the `Prop` members' constructors and for the
+block-wide recursors (a bare recursor application is never compilable, exactly
+as for `Nat.rec`).
+-/
+def addDef (name : Name) (levelParams : List Name) (type value : Expr)
+    (hints : ReducibilityHints := .regular 0) : MetaM Unit := do
+  let decl := Declaration.defnDecl { name, levelParams, type, value, hints, safety := .safe }
+  addDecl decl
+  compileDecl decl (logErrors := false)
+
+/--
+Add an inductive declaration and everything Lean normally builds alongside one.
+This mirrors `Lean.Elab.Command.elabInductiveViews`: compile first (`sizeOf`
+and friends depend on it), then the per-member constructions, then `brecOn` in
+a second pass, then the block-wide ones.  `brecOn` in particular is what
+structural recursion and the equation compiler need, so without it a `match`
+on a member would not elaborate.
+-/
+def addInd (levelParams : List Name) (numParams : Nat) (indTypes : Array InductiveType)
+    (isClass : Bool := false) : MetaM Unit := do
+  let decl := Declaration.inductDecl levelParams numParams indTypes.toList false
+  addDecl decl
+  let names := indTypes.map (·.name)
+  Lean.compileDecls names
+  let env ← getEnv
+  let hasEq   := env.contains ``Eq
+  let hasHEq  := env.contains ``HEq
+  let hasUnit := env.contains ``PUnit
+  let hasProd := env.contains ``Prod
+  let hasNat  := env.contains ``Nat
+  for n in names do
+    -- `mkRecOn` reuses `casesOn` where it can, so build that first
+    if hasUnit then mkCasesOn n
+    mkRecOn n
+    if hasNat then mkCtorIdx n
+    if hasNat then mkCtorElim n
+    if hasUnit && hasEq && hasHEq then mkNoConfusion n
+    if hasUnit && hasProd then mkBelow n
+  for n in names do
+    if hasUnit && hasProd then mkBRecOn n
+  unless isClass do
+    -- these are generated for the whole block from its first member
+    mkSizeOfInstances names[0]!
+    IndPredBelow.mkBelow names[0]!
+    for n in names do
+      mkInjectiveTheorems n
+
+/--
+`Nonempty ((w : α) ×' β w)`: a `Prop` that still remembers a data witness, and
+whose eliminator lands in `Prop`, which is all the minor premises of a `Prop`
+member's recursor ever need.
+-/
+private def mkNESig (α β : Expr) : MetaM Expr := do
+  mkAppM ``Nonempty #[← mkAppOptM ``PSigma #[some α, some β]]
+
+/--
+The levels to instantiate the recursor `recName` at, given that its motives
+live at `elim` and the block's own levels are `own`.  A small-eliminating
+`Prop` has no separate elimination universe, so the extra level is only
+prepended when the recursor actually has one.
+-/
+private def recLevelsFor (recName : Name) (elim : Level) (own : List Level) :
+    MetaM (List Level) := do
+  let info ← getConstInfoRec recName
+  if info.levelParams.length == own.length then
+    return own
+  else
+    return elim :: own
+
+/-! ## Analysis
+
+Deciding *whether* a block can be lowered, and rejecting the shapes the
+lowering cannot express.
+-/
+
+/--
+Condensation of the data-only dependency graph, in topological order
+(dependencies first).  Returns the components and, for each member, its
+component index (`none` for a `Prop` member).
+
+`n` is the number of members of one `mutual` block, so the cubic reachability
+closure is not worth optimising.
+-/
+def computeSCCs (n : Nat) (isData : Array Bool) (edges : Array (Array Bool)) :
+    Array (Array Nat) × Array (Option Nat) := Id.run do
+  -- transitive closure
+  let mut r := edges
+  for k in *...n do
+    for i in *...n do
+      if r[i]![k]! then
+        for j in *...n do
+          if r[k]![j]! && !r[i]![j]! then
+            r := r.set! i (r[i]!.set! j true)
+  -- raw components: `i ~ j` iff mutually reachable
+  let mut compOf : Array (Option Nat) := rep n none
+  let mut comps : Array (Array Nat) := #[]
+  for i in *...n do
+    if isData[i]! && compOf[i]!.isNone then
+      let mut c := #[]
+      for j in *...n do
+        if isData[j]! && compOf[j]!.isNone && (j == i || (r[i]![j]! && r[j]![i]!)) then
+          c := c.push j
+      for j in c do
+        compOf := compOf.set! j (some comps.size)
+      comps := comps.push c
+  -- topologically order the condensation: a component may be emitted once
+  -- every component it depends on has been emitted
+  let m := comps.size
+  let mut emitted : Array Bool := rep m false
+  let mut order : Array Nat := #[]
+  for _pass in *...m do
+    if order.size == m then
+      break
+    for a in *...m do
+      if !emitted[a]! then
+        let mut ok := true
+        for i in comps[a]! do
+          for j in *...n do
+            if r[i]![j]! then
+              if let some bc := compOf[j]! then
+                if bc != a && !emitted[bc]! then
+                  ok := false
+        if ok then
+          emitted := emitted.set! a true
+          order := order.push a
+  -- renumber into topological order
+  let mut newOf : Array Nat := rep m 0
+  for pos in *...order.size do
+    newOf := newOf.set! order[pos]! pos
+  let sccs := order.map (comps[·]!)
+  let sccOf := compOf.map (fun o => o.map (newOf[·]!))
+  return (sccs, sccOf)
+
+/-- Pick `n` level parameter names not clashing with `avoid`. -/
+def freshLevelNames (avoid : List Name) (n : Nat) : Array Name := Id.run do
+  let cands : Array Name := #[`u, `v, `w, `x, `y, `z]
+  let mut used := avoid
+  let mut out := #[]
+  let mut next := 0
+  for i in *...n do
+    let mut nm := if h : i < cands.size then cands[i] else Name.mkSimple s!"u_{i}"
+    while used.contains nm do
+      next := next + 1
+      nm := Name.mkSimple s!"u_{next}"
+    used := nm :: used
+    out := out.push nm
+  return out
+
+/-- Does `e` mention any of the block's members? -/
+private def mentionsMember (fvars : Array Expr) (e : Expr) : Bool :=
+  fvars.any fun f => e.containsFVar f.fvarId!
+
+/--
+Classify one constructor field.
+
+Accepts a non-recursive field (no member occurrence at all), or a field of the
+form `∀ ys, X_j params idxs` where neither the `ys` domains nor the `idxs`
+mention any member.  Everything else -- in particular a *nested* occurrence
+such as `List (X_j ...)` -- is rejected: the shadow has no data to rebuild such
+a field from without lowering the surrounding type constructor too.
+-/
+private def analyzeField (inp : Input) (fieldTy : Expr) (ctor : Name) (k : Nat) :
+    MetaM (Option RecField) := do
+  if !mentionsMember inp.memberFVars fieldTy then
+    return none
+  forallTelescope fieldTy fun ys body => do
+    for y in ys do
+      if mentionsMember inp.memberFVars (← inferType y) then
+        throwError m!"Unsupported constructor field in `mutual_multiuniverse` block: field \
+          {k + 1} of `{ctor}` takes an argument whose type mentions a member of the block"
+          ++ .note "This is not a strictly positive occurrence, so the lowering has nothing \
+            to translate it to"
+    let some j := inp.memberFVars.findIdx? (· == body.getAppFn)
+      | throwError m!"Unsupported constructor field in `mutual_multiuniverse` block: field \
+          {k + 1} of `{ctor}` mentions a member of the block in a nested position, in the \
+          type{indentExpr fieldTy}"
+          ++ .note "Nested occurrences are not supported: the shadow of a data member carries \
+            no data, so there is nothing to rebuild such a field from without lowering the \
+            surrounding type as well"
+    for a in body.getAppArgs do
+      if mentionsMember inp.memberFVars a then
+        throwError m!"Unsupported constructor field in `mutual_multiuniverse` block: field \
+          {k + 1} of `{ctor}` has a type that applies a member of the block to an argument \
+          mentioning another one, in the type{indentExpr fieldTy}"
+          ++ .note "Nested occurrences are not supported"
+    return some { member := j, arity := ys.size }
+
+/--
+Reject a constructor whose *result indices* depend on a field of data-member
+type.
+
+The lowering identifies the shadow world and the real world at every index
+position: the shadow constructor is applied to shadow fields, the real one to
+real fields, and the two must land at the same indices.  Fields that are not
+members, and fields of `Prop`-member type, are literally the same variable in
+both worlds; a field of data-member type is not.
+
+This is a defensive check.  Reaching it needs a function from a member of the
+block into an index type, and there is none to be had: headers are elaborated
+before any member is in scope, so no member's indices can mention another
+member, and nested occurrences are rejected outright.
+-/
+private def checkIndices (isProp : Array Bool) (c : CtorInfo)
+    (fields : Array Expr) (idxs : Array Expr) : MetaM Unit := do
+  let mut bad : Array Expr := #[]
+  for k in *...c.numFields do
+    if let some rf := c.fields[k]! then
+      if !isProp[rf.member]! then
+        bad := bad.push fields[k]!
+  if bad.isEmpty then return
+  for idx in idxs do
+    for f in bad do
+      if idx.containsFVar f.fvarId! then
+        throwError m!"Unsupported constructor in `mutual_multiuniverse` block: `{c.name}` \
+          computes a result index from a field whose type is a non-`Prop` member of the block"
+          ++ .note "The lowering cannot keep the shadow block and the real one in step across \
+            such an index, since the shadow's data fields carry no data"
+
+/-- Build a `Block` from freshly elaborated inductive data, or throw. -/
+def analyze (inp : Input) : MetaM Block := do
+  let n := inp.memberTypes.size
+  -- 1. the members' universes
+  let mut levels : Array Level := #[]
+  let mut isProp : Array Bool := #[]
+  for i in *...n do
+    let l ← forallTelescope inp.memberTypes[i]! fun _ body => do
+      let .sort l := (← whnf body)
+        | throwError "The type of `{inp.memberNames[i]!}` does not end in a sort:\
+            {indentExpr inp.memberTypes[i]!}"
+      return l
+    levels := levels.push l
+    isProp := isProp.push (match l.normalize with | .zero => true | _ => false)
+  -- 2. the constructors, and the data-only dependency graph
+  let mut members : Array MemberInfo := #[]
+  let mut allCtors : Array CtorInfo := #[]
+  let mut edges : Array (Array Bool) := rep n (rep n false)
+  for i in *...n do
+    let mut ctors : Array CtorInfo := #[]
+    for j in *...inp.ctorNames[i]!.size do
+      let cname := inp.ctorNames[i]![j]!
+      let cty := inp.ctorTypes[i]![j]!
+      let c ← forallBoundedTelescope cty (some inp.numParams) fun _params inner =>
+        forallTelescope inner fun fields result => do
+          let mut fs : Array (Option RecField) := #[]
+          for k in *...fields.size do
+            fs := fs.push (← analyzeField inp (← inferType fields[k]!) cname k)
+          let c : CtorInfo :=
+            { name := cname, owner := i, type := cty, numFields := fields.size, fields := fs }
+          let args := result.getAppArgs
+          checkIndices isProp c fields (args.extract inp.numParams args.size)
+          return c
+      if !isProp[i]! then
+        for f? in c.fields do
+          if let some rf := f? then
+            if !isProp[rf.member]! then
+              edges := edges.set! i (edges[i]!.set! rf.member true)
+      ctors := ctors.push c
+      allCtors := allCtors.push c
+    members := members.push
+      { name := inp.memberNames[i]!, type := inp.memberTypes[i]!,
+        level := levels[i]!, isProp := isProp[i]!, ctors }
+  -- 3. condensation of the data-only graph
+  let isData := isProp.map not
+  let (sccs, sccOf) := computeSCCs n isData edges
+  let sccLevel := freshLevelNames inp.levelParams sccs.size
+  return { levelParams := inp.levelParams, numVars := inp.numVars, numParams := inp.numParams,
+           memberFVars := inp.memberFVars, members, allCtors,
+           sccs, sccOf, sccLevel, hasProp := isProp.any id, isClass := inp.isClass }
+
+/-- Is every member at the same universe?  Then the block is an ordinary
+`mutual` block and the lowering should not touch it. -/
+def Block.isHomogeneous (b : Block) : Bool :=
+  b.members.all fun m => m.level.normalize == b.members[0]!.level.normalize
+
+/-! ## The lowering
+
+Emission order; each step only mentions constants emitted by earlier steps.
+
+0. if the block is homogeneous, emit it natively and stop;
+1. `X_i._shadow`   -- the all-`Prop` shadow of the whole block;
+2. `X_i` for `Prop` members -- reducible abbreviations for their shadows;
+3. `X_i` for data members   -- honest inductives, one SCC at a time, in
+                              topological order;
+4. `X_i._squash`   -- `X_i → X_i._shadow`, one SCC at a time;
+5. `X_i.c` for `Prop` members -- the user-facing constructors;
+6. `X_i.mutualRec` for `Prop` members -- from the shadow recursor;
+7. `X_i.mutualRec` for data members, in SCC order -- from the native recursors.
+
+Step 6 only mentions data *constructors*, never data recursors, so 6 and 7 do
+not form a cycle.
+-/
+
+/-- Walk `n` `∀`-binders of `ty`, building an argument for each via `mk` and
+instantiating as we go, so later domains see the earlier arguments. -/
+private def buildArgs (ty : Expr) (n : Nat) (mk : Nat → Expr → MetaM Expr) :
+    MetaM (Array Expr) := do
+  let mut ty := ty
+  let mut args := #[]
+  for i in *...n do
+    let ty' ← whnf ty
+    let .forallE _ d body _ := ty'
+      | throwError "(internal) `mutual_multiuniverse`: expected {n} arguments in\
+          {indentExpr ty}"
+    let a ← mk i d
+    args := args.push a
+    ty := body.instantiate1 a
+  return args
+
+/-- The constructors of SCC `s`, as indices into `b.allCtors`, in the order the
+native recursor of that SCC expects its minor premises. -/
+private def sccCtorIndices (b : Block) (s : Nat) : Array Nat := Id.run do
+  let mut out := #[]
+  for j in b.sccs[s]! do
+    for q in *...b.allCtors.size do
+      if b.allCtors[q]!.owner == j then
+        out := out.push q
+  return out
+
+/-- `X_i.mutualRec := X_i.rec`, for a block whose native recursor already ranges
+over every member.  Keeps the generated API the same on the native path as on
+the lowered one. -/
+private def aliasNativeRecs (b : Block) : MetaM Unit := do
+  for i in *...b.size do
+    let rn := b.members[i]!.name ++ `rec
+    let info ← getConstInfoRec rn
+    addDef (b.recName i) info.levelParams info.type
+      (mkConst rn (info.levelParams.map Level.param))
+
+/-- A homogeneous block is an ordinary `mutual` block; emit it unchanged, so
+that `mutual_multiuniverse` is a strict superset of `mutual`. -/
+private def emitNative (b : Block) : MetaM Unit := do
+  let mut indTypes : Array InductiveType := #[]
+  for i in *...b.size do
+    let m := b.members[i]!
+    let ctors ← m.ctors.mapM fun c =>
+      return ({ name := c.name, type := ← b.toUser c.type } : Constructor)
+    indTypes := indTypes.push { name := m.name, type := m.type, ctors := ctors.toList }
+  addInd b.levelParams b.numParams indTypes b.isClass
+  aliasNativeRecs b
+
+/-- The all-`Prop` shadow.  Only the resulting sorts change: constructor fields
+are copied verbatim, with member occurrences redirected to the shadow, which is
+legal because a `Prop`-valued inductive imposes no constraint on its fields. -/
+private def emitShadow (b : Block) : MetaM Unit := do
+  let mut indTypes : Array InductiveType := #[]
+  for i in *...b.size do
+    let m := b.members[i]!
+    let sn := shadowName m.name
+    let ctors ← m.ctors.mapM fun c =>
+      return ({ name := reroot m.name sn c.name, type := ← b.toShadow c.type } : Constructor)
+    indTypes := indTypes.push { name := sn, type := resultToProp m.type, ctors := ctors.toList }
+  addInd b.levelParams b.numParams indTypes
+
+/-- A `Prop` member *is* its shadow -- the shadow only squashes data members --
+so its user-facing name is a reducible abbreviation.  These come before the
+data members, whose constructors mention them. -/
+private def emitPropAliases (b : Block) : MetaM Unit := do
+  for i in *...b.size do
+    let m := b.members[i]!
+    if m.isProp then
+      addDef m.name b.levelParams m.type (mkConst (b.realName i) b.ownLevels) .abbrev
+      setReducibleAttribute m.name
+
+/--
+One SCC of the data-only dependency graph, declared under the users' own names.
+Its members are necessarily at the same universe (an edge `i → j` forces
+`l_j ≤ l_i`, so a cycle forces equality), hence this is an ordinary,
+homogeneous mutual block.  Fields of `Prop`-member type refer to the aliases,
+which the kernel unfolds to the shadow; being outside the block, they impose no
+positivity obligation.
+-/
+private def emitDataSCC (b : Block) (s : Nat) : MetaM Unit := do
+  let mut indTypes : Array InductiveType := #[]
+  for i in b.sccs[s]! do
+    let m := b.members[i]!
+    let ctors ← m.ctors.mapM fun c =>
+      return ({ name := c.name, type := ← b.toUser c.type } : Constructor)
+    indTypes := indTypes.push { name := m.name, type := m.type, ctors := ctors.toList }
+  addInd b.levelParams b.numParams indTypes b.isClass
+
+/-- `X_j._squash params idxs v`, lifted pointwise through any leading `∀`s of
+`v`'s type. -/
+private def squashApply (b : Block) (j : Nat) (v : Expr) : MetaM Expr := do
+  forallTelescope (← inferType v) fun ys body => do
+    let sq := mkConst (squashName b.members[j]!.name) b.ownLevels
+    mkLambdaFVars ys (mkAppN sq (body.getAppArgs ++ #[mkAppN v ys]))
+
+/-- Minor premise for `X_i._squash`: rebuild the constructor in the shadow. -/
+private def mkSquashMinor (b : Block) (s : Nat) (params : Array Expr) (c : CtorInfo)
+    (minorTy : Expr) : MetaM Expr := do
+  forallTelescope minorTy fun args _ => do
+    let fields := args.extract 0 c.numFields
+    let ihs := args.extract c.numFields args.size
+    let mut gs := #[]
+    let mut p := 0
+    for k in *...c.numFields do
+      match c.fields[k]! with
+      | none => gs := gs.push fields[k]!
+      | some rf =>
+        if b.members[rf.member]!.isProp then
+          -- already a shadow inhabitant: `X_j` *is* `X_j._shadow`
+          gs := gs.push fields[k]!
+        else if b.sccOf[rf.member]! == some s then
+          -- the induction hypothesis *is* the shadow image
+          gs := gs.push ihs[p]!
+          p := p + 1
+        else
+          -- an earlier SCC: its squash map is already defined
+          gs := gs.push (← squashApply b rf.member fields[k]!)
+    let m := b.members[c.owner]!
+    let sctor := mkConst (reroot m.name (shadowName m.name) c.name) b.ownLevels
+    mkLambdaFVars args (mkAppN sctor (params ++ gs))
+
+private def emitSquashSCC (b : Block) (s : Nat) : MetaM Unit := do
+  let ctorIdx := sccCtorIndices b s
+  for i in b.sccs[s]! do
+    let m := b.members[i]!
+    forallBoundedTelescope m.type (some b.numParams) fun params _ => do
+      let dataOf (j : Nat) (jidxs : Array Expr) : Expr :=
+        mkAppN (mkConst b.members[j]!.name b.ownLevels) (params ++ jidxs)
+      let shadowOf (j : Nat) (jidxs : Array Expr) : Expr :=
+        mkAppN (mkConst (shadowName b.members[j]!.name) b.ownLevels) (params ++ jidxs)
+      let mut motives := #[]
+      for j in b.sccs[s]! do
+        let aj ← instantiateForall b.members[j]!.type params
+        let mot ← forallTelescope aj fun jidxs _ =>
+          withLocalDeclD `t (dataOf j jidxs) fun tv =>
+            mkLambdaFVars (jidxs ++ #[tv]) (shadowOf j jidxs)
+        motives := motives.push mot
+      let recName := m.name ++ `rec
+      let recFn := mkConst recName (← recLevelsFor recName .zero b.ownLevels)
+      let ty0 ← instantiateForall (← inferType recFn) params
+      let ty1 ← instantiateForall ty0 motives
+      let minors ← buildArgs ty1 ctorIdx.size fun q minorTy =>
+        mkSquashMinor b s params b.allCtors[ctorIdx[q]!]! minorTy
+      let ai ← instantiateForall m.type params
+      forallTelescope ai fun idxs _ =>
+        withLocalDeclD `t (dataOf i idxs) fun tv => do
+          let all := params ++ idxs ++ #[tv]
+          let ty ← mkForallFVars all (shadowOf i idxs)
+          let val ← mkLambdaFVars all (mkAppN recFn (params ++ motives ++ minors ++ idxs ++ #[tv]))
+          addDef (squashName m.name) b.levelParams ty val
+
+/--
+The `Prop` members' constructors.  The data members' constructors are the
+native ones and need no help; a `Prop` member's shadow constructor wants shadow
+arguments, so each data field is sent through its squash map.
+-/
+private def emitPropCtors (b : Block) : MetaM Unit := do
+  for i in *...b.size do
+    let m := b.members[i]!
+    if !m.isProp then continue
+    for c in m.ctors do
+      let cty ← b.toUser c.type
+      forallBoundedTelescope cty (some b.numParams) fun params inner =>
+        forallTelescope inner fun fields _ => do
+          let mut gs := #[]
+          for k in *...c.numFields do
+            match c.fields[k]! with
+            | some rf =>
+              if b.members[rf.member]!.isProp then
+                gs := gs.push fields[k]!
+              else
+                gs := gs.push (← squashApply b rf.member fields[k]!)
+            | none => gs := gs.push fields[k]!
+          let realCtor := mkConst (reroot m.name (b.realName i) c.name) b.ownLevels
+          -- reuse the elaborated type verbatim, so the constructor keeps the
+          -- binder annotations it would have got from `mutual`
+          addDef c.name b.levelParams cty
+            (← mkLambdaFVars (params ++ fields) (mkAppN realCtor (params ++ gs)))
+
+/-! ### Recursors
+
+Every generated recursor has the *same* signature apart from its major premise
+and result:
+
+```
+{params} {motive_1 .. motive_n} (case_1 .. case_K) {idxs} (t : X_i idxs)
+  : motive_i idxs t
+```
+
+with `motive_j` at `Prop` for a `Prop` member and at that member's SCC universe
+otherwise.  This uniformity is what lets a data recursor plug `X_j.mutualRec`
+in as the induction hypothesis for a field it has no native IH for: the
+arguments it already has are exactly the ones `X_j.mutualRec` wants.
+-/
+
+/-- The type of the minor premise for constructor `c`: all fields, then one
+induction hypothesis per recursive field, in field order. -/
+private def mkMinorType (b : Block) (params motives : Array Expr) (c : CtorInfo) :
+    MetaM Expr := do
+  let inner ← instantiateForall (← b.toUser c.type) params
+  forallTelescope inner fun fields result => do
+    let args := result.getAppArgs
+    let idxs := args.extract b.numParams args.size
+    let ctorApp := mkAppN (mkConst c.name b.ownLevels) (params ++ fields)
+    let mut concl := mkAppN motives[c.owner]! (idxs ++ #[ctorApp])
+    let mut ihs : Array (Name × Expr) := #[]
+    for k in *...c.numFields do
+      if let some rf := c.fields[k]! then
+        let ih ← forallTelescope (← inferType fields[k]!) fun ys fbody => do
+          let fargs := fbody.getAppArgs
+          let fidxs := fargs.extract b.numParams fargs.size
+          mkForallFVars ys (mkAppN motives[rf.member]! (fidxs ++ #[mkAppN fields[k]! ys]))
+        ihs := ihs.push (Name.mkSimple s!"ih_{k + 1}", ih)
+    -- no induction hypothesis is ever referred to, so plain `forallE` is safe
+    for (nm, t) in ihs.reverse do
+      concl := .forallE nm t concl .default
+    mkForallFVars fields concl
+
+/-- Set up the common outer telescope and hand the body builder the pieces. -/
+private def withRecTelescope (b : Block) (i : Nat)
+    (mkBody : Array Expr → Array Expr → Array Expr → Array Expr → Expr → MetaM Expr) :
+    MetaM (Expr × Expr) := do
+  forallBoundedTelescope b.members[i]!.type (some b.numParams) fun params _ => do
+    let userOf (j : Nat) (jidxs : Array Expr) : Expr :=
+      mkAppN (mkConst b.members[j]!.name b.ownLevels) (params ++ jidxs)
+    let mut motiveDecls : Array (Name × BinderInfo × (Array Expr → MetaM Expr)) := #[]
+    for j in *...b.size do
+      let aj ← instantiateForall b.members[j]!.type params
+      let mt ← forallTelescope aj fun jidxs _ =>
+        withLocalDeclD `t (userOf j jidxs) fun tv =>
+          mkForallFVars (jidxs ++ #[tv]) (mkSort (b.motiveLevel j))
+      motiveDecls := motiveDecls.push
+        (Name.mkSimple s!"motive_{j + 1}", .implicit, fun _ => pure mt)
+    withLocalDecls motiveDecls fun motives => do
+      let mut minorDecls : Array (Name × BinderInfo × (Array Expr → MetaM Expr)) := #[]
+      for q in *...b.allCtors.size do
+        let mt ← mkMinorType b params motives b.allCtors[q]!
+        minorDecls := minorDecls.push
+          (Name.mkSimple s!"case_{q + 1}", .default, fun _ => pure mt)
+      withLocalDecls minorDecls fun minors => do
+        let ai ← instantiateForall b.members[i]!.type params
+        forallTelescope ai fun idxs _ =>
+          withLocalDeclD `t (userOf i idxs) fun major => do
+            let body ← mkBody params motives minors idxs major
+            let all := params ++ motives ++ minors ++ idxs ++ #[major]
+            let ty ← mkForallFVars all (mkAppN motives[i]! (idxs ++ #[major]))
+            let bis := rep b.numParams BinderInfo.implicit
+                    ++ rep b.size BinderInfo.implicit
+                    ++ rep b.allCtors.size BinderInfo.default
+                    ++ rep idxs.size BinderInfo.implicit
+                    ++ #[BinderInfo.default]
+            return (forceBinderInfos ty bis, ← mkLambdaFVars all body)
+
+/-- `X_j.mutualRec` applied at the current motives and minors, lifted pointwise
+through any leading `∀`s of `v`'s type. -/
+private def recCall (b : Block) (params motives minors : Array Expr) (j : Nat) (v : Expr) :
+    MetaM Expr := do
+  forallTelescope (← inferType v) fun ys body => do
+    let allArgs := body.getAppArgs
+    let jidxs := allArgs.extract b.numParams allArgs.size
+    let r := mkConst (b.recName j) b.recLevels
+    mkLambdaFVars ys (mkAppN r (params ++ motives ++ minors ++ jidxs ++ #[mkAppN v ys]))
+
+/--
+Build the body of a shadow minor premise, walking the constructor's fields.
+
+The shadow's fields for data members are useless -- they carry no data -- so we
+*discard* them and take the real element out of the corresponding induction
+hypothesis, whose motive was chosen to be `Nonempty ((w : X_j) ×' motive_j w)`
+precisely so that it would still contain one.  This is legal because everything
+built here is a `Prop`.
+-/
+private partial def propMinorBody (b : Block) (params motives minors : Array Expr)
+    (c : CtorInfo) (q : Nat) (sf sih : Array Expr) (target : Expr)
+    (k ihPos : Nat) (realF realIH : Array Expr) : MetaM Expr := do
+  if k ≥ c.numFields then
+    let minorApp := mkAppN minors[q]! (realF ++ realIH)
+    let m := b.members[c.owner]!
+    if m.isProp then
+      -- the shadow field and the real field are equal by proof irrelevance
+      return minorApp
+    else
+      -- repackage as `⟨⟨X_m.c realF, case realF realIH⟩⟩`
+      let sigTy := target.appArg!
+      let sargs := sigTy.getAppArgs
+      let ctorApp := mkAppN (mkConst c.name b.ownLevels) (params ++ realF)
+      let mk ← mkAppOptM ``PSigma.mk
+        #[some sargs[0]!, some sargs[1]!, some ctorApp, some minorApp]
+      mkAppOptM ``Nonempty.intro #[some sigTy, some mk]
+  else
+    let cont := propMinorBody b params motives minors c q sf sih target
+    match c.fields[k]! with
+    | none => cont (k + 1) ihPos (realF.push sf[k]!) realIH
+    | some rf =>
+      let ih := sih[ihPos]!
+      if b.members[rf.member]!.isProp then
+        -- `X_j` *is* `X_j._shadow`, so the shadow field and IH are already right
+        cont (k + 1) (ihPos + 1) (realF.push sf[k]!) (realIH.push ih)
+      else if rf.arity == 0 then
+        -- destructure the witness; `Nonempty.rec` lands in `Prop`, which the
+        -- target is, so no choice principle is needed
+        let ihTy ← whnf (← inferType ih)
+        let sigTy := ihTy.appArg!
+        let lvl ← getLevel sigTy
+        withLocalDeclD (Name.mkSimple s!"w_{k + 1}") sigTy fun wv => do
+          let bb ← mkAppM ``PSigma.fst #[wv]
+          let pp ← mkAppM ``PSigma.snd #[wv]
+          let rest ← cont (k + 1) (ihPos + 1) (realF.push bb) (realIH.push pp)
+          let f ← mkLambdaFVars #[wv] rest
+          let mot := Expr.lam `h ihTy target .default
+          return mkAppN (mkConst ``Nonempty.rec [lvl]) #[sigTy, mot, f, ih]
+      else
+        -- a function *into* a data member: the witnesses have to be selected
+        -- pointwise, which is the one place `Classical.choice` is unavoidable
+        let ihTy ← inferType ih
+        let kf ← forallTelescope ihTy fun ys neBody => do
+          let sigTy := (← whnf neBody).appArg!
+          let lvl ← getLevel sigTy
+          mkLambdaFVars ys (mkAppN (mkConst ``Classical.choice [lvl]) #[sigTy, mkAppN ih ys])
+        let bb ← forallTelescope ihTy fun ys _ => do
+          mkLambdaFVars ys (← mkAppM ``PSigma.fst #[mkAppN kf ys])
+        let pp ← forallTelescope ihTy fun ys _ => do
+          mkLambdaFVars ys (← mkAppM ``PSigma.snd #[mkAppN kf ys])
+        cont (k + 1) (ihPos + 1) (realF.push bb) (realIH.push pp)
+
+private def mkPropRecBody (b : Block) (i : Nat)
+    (params motives minors idxs : Array Expr) (major : Expr) : MetaM Expr := do
+  let mut smotives := #[]
+  for j in *...b.size do
+    let aj ← instantiateForall b.members[j]!.type params
+    let mot ← forallTelescope aj fun jidxs _ => do
+      let sTy := mkAppN (mkConst (shadowName b.members[j]!.name) b.ownLevels) (params ++ jidxs)
+      withLocalDeclD `t sTy fun tv => do
+        let body ←
+          if b.members[j]!.isProp then
+            pure (mkAppN motives[j]! (jidxs ++ #[tv]))
+          else
+            let dTy := mkAppN (mkConst b.members[j]!.name b.ownLevels) (params ++ jidxs)
+            withLocalDeclD `w dTy fun wv => do
+              mkNESig dTy (← mkLambdaFVars #[wv] (mkAppN motives[j]! (jidxs ++ #[wv])))
+        mkLambdaFVars (jidxs ++ #[tv]) body
+    smotives := smotives.push mot
+  let recName := shadowName b.members[i]!.name ++ `rec
+  let recFn := mkConst recName (← recLevelsFor recName .zero b.ownLevels)
+  let ty0 ← instantiateForall (← inferType recFn) params
+  let ty1 ← instantiateForall ty0 smotives
+  let sminors ← buildArgs ty1 b.allCtors.size fun q minorTy => do
+    let c := b.allCtors[q]!
+    forallTelescope minorTy fun args target => do
+      let sf := args.extract 0 c.numFields
+      let sih := args.extract c.numFields args.size
+      let body ← propMinorBody b params motives minors c q sf sih (← whnf target) 0 0 #[] #[]
+      mkLambdaFVars args body
+  return mkAppN recFn (params ++ smotives ++ sminors ++ idxs ++ #[major])
+
+private def mkDataRecBody (b : Block) (i : Nat)
+    (params motives minors idxs : Array Expr) (major : Expr) : MetaM Expr := do
+  let some s := b.sccOf[i]!
+    | throwError "(internal) `mutual_multiuniverse`: data member without an SCC"
+  let mut nmotives := #[]
+  for j in b.sccs[s]! do
+    let aj ← instantiateForall b.members[j]!.type params
+    let mot ← forallTelescope aj fun jidxs _ => do
+      let dTy := mkAppN (mkConst b.members[j]!.name b.ownLevels) (params ++ jidxs)
+      withLocalDeclD `t dTy fun tv =>
+        mkLambdaFVars (jidxs ++ #[tv]) (mkAppN motives[j]! (jidxs ++ #[tv]))
+    nmotives := nmotives.push mot
+  let recName := b.members[i]!.name ++ `rec
+  let recFn := mkConst recName (← recLevelsFor recName (b.motiveLevel i) b.ownLevels)
+  let ty0 ← instantiateForall (← inferType recFn) params
+  let ty1 ← instantiateForall ty0 nmotives
+  let ctorIdx := sccCtorIndices b s
+  let nminors ← buildArgs ty1 ctorIdx.size fun q minorTy => do
+    let gq := ctorIdx[q]!
+    let c := b.allCtors[gq]!
+    forallTelescope minorTy fun args _ => do
+      let fields := args.extract 0 c.numFields
+      let nih := args.extract c.numFields args.size
+      let mut userIH := #[]
+      let mut p := 0
+      for k in *...c.numFields do
+        if let some rf := c.fields[k]! then
+          if b.sccOf[rf.member]! == some s then
+            -- the native recursor already provides this one
+            userIH := userIH.push nih[p]!
+            p := p + 1
+          else
+            -- a `Prop` member, or a data member of an earlier SCC: its
+            -- block-wide recursor is already defined and takes exactly our
+            -- arguments
+            userIH := userIH.push (← recCall b params motives minors rf.member fields[k]!)
+      mkLambdaFVars args (mkAppN minors[gq]! (fields ++ userIH))
+  return mkAppN recFn (params ++ nmotives ++ nminors ++ idxs ++ #[major])
+
+private def emitRec (b : Block) (i : Nat) : MetaM Unit := do
+  let m := b.members[i]!
+  let (ty, val) ← withRecTelescope b i fun params motives minors idxs major =>
+    if m.isProp then
+      mkPropRecBody b i params motives minors idxs major
+    else
+      mkDataRecBody b i params motives minors idxs major
+  addDef (b.recName i) b.recLevelParams ty val
+  -- a `Prop` member has no native recursor under its user-facing name, so the
+  -- block-wide one may as well also answer to `X.rec`
+  if m.isProp then
+    addDef (m.name ++ `rec) b.recLevelParams ty val
+
+/--
+Lower an elaborated `mutual_multiuniverse` block to ordinary declarations.
+
+A homogeneous block is emitted natively, so `mutual_multiuniverse` accepts
+everything `mutual` does and means the same thing by it.
+-/
+def lower (inp : Input) : MetaM Unit := do
+  let b ← analyze inp
+  if b.isHomogeneous then
+    emitNative b
+    return
+  if b.hasProp then
+    emitShadow b
+    emitPropAliases b
+  for s in *...b.sccs.size do
+    emitDataSCC b s
+  if b.hasProp then
+    for s in *...b.sccs.size do
+      emitSquashSCC b s
+    emitPropCtors b
+    for i in *...b.size do
+      if b.members[i]!.isProp then
+        emitRec b i
+  for s in *...b.sccs.size do
+    for i in b.sccs[s]! do
+      emitRec b i
+
+end Lean.Elab.MultiuniverseInductive

--- a/src/Lean/Elab/MultiuniverseInductive.lean
+++ b/src/Lean/Elab/MultiuniverseInductive.lean
@@ -12,6 +12,7 @@ import Lean.Meta.Constructions.CtorIdx
 import Lean.Meta.Constructions.CtorElim
 import Lean.Meta.IndPredBelow
 import Lean.Meta.Injective
+import Lean.Compiler.Old
 
 public section
 
@@ -85,6 +86,10 @@ The one place a choice principle is unavoidable is a `Prop` member with a
 constructor field that is a *function into* a data member: the data witnesses
 then have to be selected pointwise, which needs `Classical.choice`.  A block
 without such a field produces axiom-free recursors.
+
+The recursors are also computable, which takes a little work, as the code
+generator compiles no recursor application at all; see the section on
+companions below.
 -/
 
 namespace Lean.Elab.MultiuniverseInductive
@@ -272,16 +277,20 @@ private partial def resultToProp : Expr → Expr
 
 /--
 Add a plain safe definition and hand it to the code generator.  `logErrors :=
-false` makes the compiler mark a declaration `noncomputable` rather than fail,
-which is the right behaviour for the `Prop` members' constructors and for the
-block-wide recursors (a bare recursor application is never compilable, exactly
-as for `Nat.rec`).
+false` makes the compiler mark a declaration `noncomputable` rather than report
+an error.
+
+`compile := false` leaves code generation to someone else, and is how the data
+members' recursors are added: their bodies are recursor applications and so are
+not compilable as written, and the companions emitted afterwards are compiled
+in their place.
 -/
 def addDef (name : Name) (levelParams : List Name) (type value : Expr)
-    (hints : ReducibilityHints := .regular 0) : MetaM Unit := do
+    (hints : ReducibilityHints := .regular 0) (compile := true) : MetaM Unit := do
   let decl := Declaration.defnDecl { name, levelParams, type, value, hints, safety := .safe }
   addDecl decl
-  compileDecl decl (logErrors := false)
+  if compile then
+    compileDecl decl (logErrors := false)
 
 /--
 Add an inductive declaration and everything Lean normally builds alongside one.
@@ -329,14 +338,15 @@ private def mkNESig (α β : Expr) : MetaM Expr := do
   mkAppM ``Nonempty #[← mkAppOptM ``PSigma #[some α, some β]]
 
 /--
-The levels to instantiate the recursor `recName` at, given that its motives
-live at `elim` and the block's own levels are `own`.  A small-eliminating
-`Prop` has no separate elimination universe, so the extra level is only
-prepended when the recursor actually has one.
+The levels to instantiate the eliminator `elimName` -- a recursor or a
+`casesOn` -- at, given that its motives live at `elim` and the block's own
+levels are `own`.  A small-eliminating `Prop` has no separate elimination
+universe, so the extra level is only prepended when the eliminator actually has
+one.
 -/
-private def recLevelsFor (recName : Name) (elim : Level) (own : List Level) :
+private def elimLevelsFor (elimName : Name) (elim : Level) (own : List Level) :
     MetaM (List Level) := do
-  let info ← getConstInfoRec recName
+  let info ← getConstInfo elimName
   if info.levelParams.length == own.length then
     return own
   else
@@ -599,7 +609,7 @@ private def aliasNativeRecs (b : Block) : MetaM Unit := do
     let rn := b.members[i]!.name ++ `rec
     let info ← getConstInfoRec rn
     addDef (b.recName i) info.levelParams info.type
-      (mkConst rn (info.levelParams.map Level.param))
+      (mkConst rn (info.levelParams.map Level.param)) (compile := false)
 
 /-- A homogeneous block is an ordinary `mutual` block; emit it unchanged, so
 that `mutual_multiuniverse` is a strict superset of `mutual`. -/
@@ -703,7 +713,7 @@ private def emitSquashSCC (b : Block) (s : Nat) : MetaM Unit := do
             mkLambdaFVars (jidxs ++ #[tv]) (shadowOf j jidxs)
         motives := motives.push mot
       let recName := m.name ++ `rec
-      let recFn := mkConst recName (← recLevelsFor recName .zero b.ownLevels)
+      let recFn := mkConst recName (← elimLevelsFor recName .zero b.ownLevels)
       let ty0 ← instantiateForall (← inferType recFn) params
       let ty1 ← instantiateForall ty0 motives
       let minors ← buildArgs ty1 ctorIdx.size fun q minorTy =>
@@ -818,15 +828,22 @@ private def withRecTelescope (b : Block) (i : Nat)
                     ++ #[BinderInfo.default]
             return (forceBinderInfos ty bis, ← mkLambdaFVars all body)
 
-/-- `X_j.mutualRec` applied at the current motives and minors, lifted pointwise
-through any leading `∀`s of `v`'s type. -/
-private def recCall (b : Block) (params motives minors : Array Expr) (j : Nat) (v : Expr) :
-    MetaM Expr := do
+/-- `nameOf j` -- `X_j.mutualRec`, or the companion of it built below -- applied
+at the current motives and minors, lifted pointwise through any leading `∀`s of
+`v`'s type.  Every recursor in the block takes the same arguments, so the ones
+we already have are exactly the ones it wants. -/
+private def recCallTo (b : Block) (nameOf : Nat → Name) (levels : List Level)
+    (params motives minors : Array Expr) (j : Nat) (v : Expr) : MetaM Expr := do
   forallTelescope (← inferType v) fun ys body => do
     let allArgs := body.getAppArgs
     let jidxs := allArgs.extract b.numParams allArgs.size
-    let r := mkConst (b.recName j) b.recLevels
+    let r := mkConst (nameOf j) levels
     mkLambdaFVars ys (mkAppN r (params ++ motives ++ minors ++ jidxs ++ #[mkAppN v ys]))
+
+/-- `X_j.mutualRec` applied at the current motives and minors. -/
+private def recCall (b : Block) (params motives minors : Array Expr) (j : Nat) (v : Expr) :
+    MetaM Expr :=
+  recCallTo b b.recName b.recLevels params motives minors j v
 
 /--
 Build the body of a shadow minor premise, walking the constructor's fields.
@@ -908,7 +925,7 @@ private def mkPropRecBody (b : Block) (i : Nat)
         mkLambdaFVars (jidxs ++ #[tv]) body
     smotives := smotives.push mot
   let recName := shadowName b.members[i]!.name ++ `rec
-  let recFn := mkConst recName (← recLevelsFor recName .zero b.ownLevels)
+  let recFn := mkConst recName (← elimLevelsFor recName .zero b.ownLevels)
   let ty0 ← instantiateForall (← inferType recFn) params
   let ty1 ← instantiateForall ty0 smotives
   let sminors ← buildArgs ty1 b.allCtors.size fun q minorTy => do
@@ -933,7 +950,7 @@ private def mkDataRecBody (b : Block) (i : Nat)
         mkLambdaFVars (jidxs ++ #[tv]) (mkAppN motives[j]! (jidxs ++ #[tv]))
     nmotives := nmotives.push mot
   let recName := b.members[i]!.name ++ `rec
-  let recFn := mkConst recName (← recLevelsFor recName (b.motiveLevel i) b.ownLevels)
+  let recFn := mkConst recName (← elimLevelsFor recName (b.motiveLevel i) b.ownLevels)
   let ty0 ← instantiateForall (← inferType recFn) params
   let ty1 ← instantiateForall ty0 nmotives
   let ctorIdx := sccCtorIndices b s
@@ -966,11 +983,161 @@ private def emitRec (b : Block) (i : Nat) : MetaM Unit := do
       mkPropRecBody b i params motives minors idxs major
     else
       mkDataRecBody b i params motives minors idxs major
-  addDef (b.recName i) b.recLevelParams ty val
+  -- a data member's recursor is left uncompiled: its body is a recursor
+  -- application, so compiling it here would fail and mark it `noncomputable`,
+  -- and its code comes instead from the companion emitted afterwards.  A `Prop`
+  -- member's is a proof, so it erases and may as well go through now
+  addDef (b.recName i) b.recLevelParams ty val (compile := m.isProp)
   -- a `Prop` member has no native recursor under its user-facing name, so the
   -- block-wide one may as well also answer to `X.rec`
   if m.isProp then
     addDef (m.name ++ `rec) b.recLevelParams ty val
+
+/-! ### Making the recursors computable
+
+The code generator compiles no recursor application at all -- `X.rec` exactly
+as little as `Nat.rec` -- so a `mutualRec` whose body is one would be
+`noncomputable`, and so would everything downstream of it.  That would be a real
+loss: the point of keeping the data members as honest inductives is that the
+block stays computable, and `mutualRec` is the only way to write a recursion
+that genuinely crosses members.
+
+The restriction is about the shape of the term, not about the function: the
+same recursion written with `match` compiles fine, in a lowered block and in an
+ordinary `mutual` one alike.  Lean's own structural recursion is in this
+position too, and gets out of it by pairing each definition with a `partial`
+companion `f._unsafe_rec` that recurses directly instead of going through
+`brecOn`; the code generator looks the companion up by name and compiles that.
+Do the same here: give each data member's `mutualRec` a companion that splits
+on its major premise with `X.casesOn`, which the code generator does compile,
+and calls itself and its siblings directly for the induction hypotheses.
+
+The companions are compiler-only.  They are never unfolded by the kernel, never
+appear in a term, and leave `mutualRec` itself untouched, so the iota rules and
+`#print axioms` are exactly what they were.  A `Prop` member needs none: the
+result of its recursor is a `Prop`, hence so is the recursor's whole type, so it
+is a proof and is erased.
+
+Compiling a companion is what compiles the recursor: the code generator strips
+the `_unsafe_rec` suffix from the name and from every self-reference, so the
+code it produces is the recursor's.  The recursors therefore have to be in the
+environment already, uncompiled, when the companions are added -- the same
+order `Lean.Elab.addAndCompilePartialRec` is used in.
+-/
+
+/-- The compiler-only companion of `X_i.mutualRec`. -/
+def Block.unsafeRecName (b : Block) (i : Nat) : Name :=
+  Compiler.mkUnsafeRecName (b.recName i)
+
+/--
+The body of `X_i.mutualRec._unsafe_rec`: one `X_i.casesOn`, with every induction
+hypothesis supplied by a direct call.  `levels` are the levels the companions
+are instantiated at, which differ between the lowered and the native path.
+-/
+private def mkUnsafeRecBody (b : Block) (levels : List Level) (i : Nat)
+    (params motives minors idxs : Array Expr) (major : Expr) : MetaM Expr := do
+  let m := b.members[i]!
+  let ai ← instantiateForall m.type params
+  let mot ← forallTelescope ai fun jidxs _ => do
+    let dTy := mkAppN (mkConst m.name b.ownLevels) (params ++ jidxs)
+    withLocalDeclD `t dTy fun tv =>
+      mkLambdaFVars (jidxs ++ #[tv]) (mkAppN motives[i]! (jidxs ++ #[tv]))
+  let casesName := m.name ++ `casesOn
+  let elim ← getLevel (mkAppN motives[i]! (idxs ++ #[major]))
+  let casesFn := mkConst casesName (← elimLevelsFor casesName elim b.ownLevels)
+  let ty0 ← instantiateForall (← inferType casesFn) params
+  let ty1 ← instantiateForall ty0 #[mot]
+  let ty2 ← instantiateForall ty1 (idxs ++ #[major])
+  -- the `Prop` members' recursors are proofs, so they have no companion and are
+  -- called under their own names
+  let nameOf (j : Nat) : Name :=
+    if b.members[j]!.isProp then b.recName j else b.unsafeRecName j
+  let mut ctorIdx := #[]
+  for q in *...b.allCtors.size do
+    if b.allCtors[q]!.owner == i then
+      ctorIdx := ctorIdx.push q
+  let cminors ← buildArgs ty2 ctorIdx.size fun q minorTy => do
+    let gq := ctorIdx[q]!
+    let c := b.allCtors[gq]!
+    -- `casesOn` offers no induction hypotheses, so its minor premise binds the
+    -- fields and nothing else
+    forallBoundedTelescope minorTy (some c.numFields) fun fields _ => do
+      let mut ihs := #[]
+      for k in *...c.numFields do
+        if let some rf := c.fields[k]! then
+          ihs := ihs.push (← recCallTo b nameOf levels params motives minors rf.member fields[k]!)
+      mkLambdaFVars fields (mkAppN minors[gq]! (fields ++ ihs))
+  return mkAppN casesFn (params ++ #[mot] ++ idxs ++ #[major] ++ cminors)
+
+/-- Add the companions as one mutual block, so that they can call each other. -/
+private def addUnsafeRecs (defns : Array DefinitionVal) : MetaM Unit := do
+  if defns.isEmpty then return
+  let decl := Declaration.mutualDefnDecl defns.toList
+  addDecl decl
+  compileDecl decl (logErrors := false)
+
+/-- Companions for a lowered block, whose recursors all have the uniform
+signature. -/
+private def emitUnsafeRecs (b : Block) : MetaM Unit := do
+  let mut names := #[]
+  for i in *...b.size do
+    unless b.members[i]!.isProp do
+      names := names.push (b.unsafeRecName i)
+  let all := names.toList
+  let mut defns := #[]
+  for i in *...b.size do
+    if b.members[i]!.isProp then continue
+    let (type, value) ← withRecTelescope b i fun params motives minors idxs major =>
+      mkUnsafeRecBody b b.recLevels i params motives minors idxs major
+    defns := defns.push
+      { name := b.unsafeRecName i, levelParams := b.recLevelParams, type, value,
+        hints := .opaque, safety := .partial, all }
+  addUnsafeRecs defns
+
+/--
+Companions for a homogeneous block, whose `mutualRec`s are aliases of the
+native recursors and so have the native signature -- one elimination universe
+for the whole block rather than one per component.
+-/
+private def emitNativeUnsafeRecs (b : Block) : MetaM Unit := do
+  -- an all-`Prop` homogeneous block computes nothing, so it gets no companion;
+  -- compile the aliases as they stand, which erases the small-eliminating ones
+  -- and leaves a large-eliminating one `noncomputable`, just as its own `rec` is
+  if b.members.all (·.isProp) then
+    for i in *...b.size do
+      compileDecl (.defnDecl (← getConstInfoDefn (b.recName i))) (logErrors := false)
+    return
+  let info ← getConstInfoRec (b.members[0]!.name ++ `rec)
+  -- the native recursor of a mutual block ranges over every member; if some
+  -- future change makes that false, compile the aliases as they stand, which
+  -- fails quietly and leaves them `noncomputable`
+  unless info.numMotives == b.size && info.numMinors == b.allCtors.size do
+    for i in *...b.size do
+      compileDecl (.defnDecl (← getConstInfoDefn (b.recName i))) (logErrors := false)
+    return
+  let levels := info.levelParams.map Level.param
+  let mut names := #[]
+  for i in *...b.size do
+    names := names.push (b.unsafeRecName i)
+  let all := names.toList
+  let nfront := info.numParams + info.numMotives + info.numMinors
+  let mut defns := #[]
+  for i in *...b.size do
+    let ri ← getConstInfoRec (b.members[i]!.name ++ `rec)
+    let value ←
+      forallBoundedTelescope ri.type (some nfront) fun front rest =>
+        forallBoundedTelescope rest (some (ri.numIndices + 1)) fun tail _ => do
+          let params  := front.extract 0 info.numParams
+          let motives := front.extract info.numParams (info.numParams + info.numMotives)
+          let minors  := front.extract (info.numParams + info.numMotives) front.size
+          let idxs    := tail.extract 0 ri.numIndices
+          let major   := tail[ri.numIndices]!
+          let body ← mkUnsafeRecBody b levels i params motives minors idxs major
+          mkLambdaFVars (front ++ tail) body
+    defns := defns.push
+      { name := b.unsafeRecName i, levelParams := ri.levelParams, type := ri.type, value,
+        hints := .opaque, safety := .partial, all }
+  addUnsafeRecs defns
 
 /--
 Lower an elaborated `mutual_multiuniverse` block to ordinary declarations.
@@ -982,6 +1149,7 @@ def lower (inp : Input) : MetaM Unit := do
   let b ← analyze inp
   if b.isHomogeneous then
     emitNative b
+    emitNativeUnsafeRecs b
     return
   if b.hasProp then
     emitShadow b
@@ -998,5 +1166,6 @@ def lower (inp : Input) : MetaM Unit := do
   for s in *...b.sccs.size do
     for i in b.sccs[s]! do
       emitRec b i
+  emitUnsafeRecs b
 
 end Lean.Elab.MultiuniverseInductive

--- a/src/Lean/Elab/MultiuniverseInductive.lean
+++ b/src/Lean/Elab/MultiuniverseInductive.lean
@@ -12,7 +12,8 @@ import Lean.Meta.Constructions.CtorIdx
 import Lean.Meta.Constructions.CtorElim
 import Lean.Meta.IndPredBelow
 import Lean.Meta.Injective
-import Lean.Compiler.Old
+public import Lean.Elab.PreDefinition.Structural
+import Lean.Compiler.CSimpAttr
 
 public section
 
@@ -89,7 +90,7 @@ without such a field produces axiom-free recursors.
 
 The recursors are also computable, which takes a little work, as the code
 generator compiles no recursor application at all; see the section on
-companions below.
+implementations below.
 -/
 
 namespace Lean.Elab.MultiuniverseInductive
@@ -282,8 +283,8 @@ an error.
 
 `compile := false` leaves code generation to someone else, and is how the data
 members' recursors are added: their bodies are recursor applications and so are
-not compilable as written, and the companions emitted afterwards are compiled
-in their place.
+not compilable as written, and the implementations emitted afterwards supply
+their code instead.
 -/
 def addDef (name : Name) (levelParams : List Name) (type value : Expr)
     (hints : ReducibilityHints := .regular 0) (compile := true) : MetaM Unit := do
@@ -828,10 +829,10 @@ private def withRecTelescope (b : Block) (i : Nat)
                     ++ #[BinderInfo.default]
             return (forceBinderInfos ty bis, ← mkLambdaFVars all body)
 
-/-- `nameOf j` -- `X_j.mutualRec`, or the companion of it built below -- applied
-at the current motives and minors, lifted pointwise through any leading `∀`s of
-`v`'s type.  Every recursor in the block takes the same arguments, so the ones
-we already have are exactly the ones it wants. -/
+/-- `nameOf j` -- `X_j.mutualRec`, or the implementation of it built below --
+applied at the current motives and minors, lifted pointwise through any leading
+`∀`s of `v`'s type.  Every recursor in the block takes the same arguments, so
+the ones we already have are exactly the ones it wants. -/
 private def recCallTo (b : Block) (nameOf : Nat → Name) (levels : List Level)
     (params motives minors : Array Expr) (j : Nat) (v : Expr) : MetaM Expr := do
   forallTelescope (← inferType v) fun ys body => do
@@ -985,8 +986,8 @@ private def emitRec (b : Block) (i : Nat) : MetaM Unit := do
       mkDataRecBody b i params motives minors idxs major
   -- a data member's recursor is left uncompiled: its body is a recursor
   -- application, so compiling it here would fail and mark it `noncomputable`,
-  -- and its code comes instead from the companion emitted afterwards.  A `Prop`
-  -- member's is a proof, so it erases and may as well go through now
+  -- and its code comes instead from the implementation emitted afterwards.  A
+  -- `Prop` member's is a proof, so it erases and may as well go through now
   addDef (b.recName i) b.recLevelParams ty val (compile := m.isProp)
   -- a `Prop` member has no native recursor under its user-facing name, so the
   -- block-wide one may as well also answer to `X.rec`
@@ -1003,38 +1004,59 @@ block stays computable, and `mutualRec` is the only way to write a recursion
 that genuinely crosses members.
 
 The restriction is about the shape of the term, not about the function: the
-same recursion written with `match` compiles fine, in a lowered block and in an
-ordinary `mutual` one alike.  Lean's own structural recursion is in this
-position too, and gets out of it by pairing each definition with a `partial`
-companion `f._unsafe_rec` that recurses directly instead of going through
-`brecOn`; the code generator looks the companion up by name and compiles that.
-Do the same here: give each data member's `mutualRec` a companion that splits
-on its major premise with `X.casesOn`, which the code generator does compile,
-and calls itself and its siblings directly for the induction hypotheses.
+same recursion written by cases compiles fine, in a lowered block and in an
+ordinary `mutual` one alike.  So each data member's `mutualRec` is paired with
+an *implementation*
 
-The companions are compiler-only.  They are never unfolded by the kernel, never
-appear in a term, and leave `mutualRec` itself untouched, so the iota rules and
-`#print axioms` are exactly what they were.  A `Prop` member needs none: the
-result of its recursor is a `Prop`, hence so is the recursor's whole type, so it
-is a proof and is erased.
+```
+X_i.mutualRec.impl : <the type of X_i.mutualRec, verbatim>
+```
 
-Compiling a companion is what compiles the recursor: the code generator strips
-the `_unsafe_rec` suffix from the name and from every self-reference, so the
-code it produces is the recursor's.  The recursors therefore have to be in the
-environment already, uncompiled, when the companions are added -- the same
-order `Lean.Elab.addAndCompilePartialRec` is used in.
+which splits on its major premise with `X_i.casesOn` and calls itself and its
+siblings directly, and with a theorem
+
+```
+X_i.mutualRec.eq_impl : @X_i.mutualRec = @X_i.mutualRec.impl
+```
+
+tagged `@[csimp]`, which is what makes the code generator emit the
+implementation's code wherever `X_i.mutualRec` is used.
+
+Nothing about this is taken on trust.  The implementation is a `def` like any
+other, handed to Lean's own structural recursion (`Structural.structuralRecursion`,
+not `addPreDefinitions`, which would quietly fall back to `partial` or `sorry`
+on failure), so it is only accepted if that machinery can see it terminates.
+The theorem is an ordinary proof, checked by the kernel.  A wrong one is an
+error at the point of the block, which is the right place to find out that the
+proof generator needs work; the alternative -- an unchecked companion the code
+generator believes -- would be a miscompilation instead.
+
+`mutualRec` itself is untouched: the iota rules and `#print axioms` are exactly
+what they were, and `eq_impl`'s use of `funext` stays inside `eq_impl`.  A `Prop`
+member needs no implementation at all: the result of its recursor is a `Prop`,
+hence so is the recursor's whole type, so it is a proof and is erased.
+
+The implementations recurse directly only within their own SCC.  For a field in
+an earlier SCC an implementation calls that member's `mutualRec`, whose
+`@[csimp]` theorem is registered by then and rewrites the call when the code
+generator gets to it; that keeps each proof one congruence deep and means
+nothing has to be threaded across components by hand.
 -/
 
-/-- The compiler-only companion of `X_i.mutualRec`. -/
-def Block.unsafeRecName (b : Block) (i : Nat) : Name :=
-  Compiler.mkUnsafeRecName (b.recName i)
+/-- The computable implementation of `X_i.mutualRec`. -/
+def Block.implName (b : Block) (i : Nat) : Name := b.recName i ++ `impl
+
+/-- The `@[csimp]` theorem `@X_i.mutualRec = @X_i.mutualRec.impl`. -/
+def Block.implEqName (b : Block) (i : Nat) : Name := b.recName i ++ `eq_impl
 
 /--
-The body of `X_i.mutualRec._unsafe_rec`: one `X_i.casesOn`, with every induction
-hypothesis supplied by a direct call.  `levels` are the levels the companions
-are instantiated at, which differ between the lowered and the native path.
+The body of `X_i.mutualRec.impl`: one `X_i.casesOn`, with every induction
+hypothesis supplied by a direct call -- to a sibling's implementation inside
+`group`, and to `X_j.mutualRec` outside it, where that member's own `@[csimp]`
+theorem takes over.  `levels` are the levels the recursors are instantiated at,
+which differ between the lowered and the native path.
 -/
-private def mkUnsafeRecBody (b : Block) (levels : List Level) (i : Nat)
+private def mkImplBody (b : Block) (group : Array Nat) (levels : List Level) (i : Nat)
     (params motives minors idxs : Array Expr) (major : Expr) : MetaM Expr := do
   let m := b.members[i]!
   let ai ← instantiateForall m.type params
@@ -1048,10 +1070,11 @@ private def mkUnsafeRecBody (b : Block) (levels : List Level) (i : Nat)
   let ty0 ← instantiateForall (← inferType casesFn) params
   let ty1 ← instantiateForall ty0 #[mot]
   let ty2 ← instantiateForall ty1 (idxs ++ #[major])
-  -- the `Prop` members' recursors are proofs, so they have no companion and are
-  -- called under their own names
+  -- outside the group -- an earlier SCC, or a `Prop` member, whose recursor is a
+  -- proof and needs no implementation -- go through `mutualRec` and let `csimp`
+  -- rewrite the call
   let nameOf (j : Nat) : Name :=
-    if b.members[j]!.isProp then b.recName j else b.unsafeRecName j
+    if group.contains j then b.implName j else b.recName j
   let mut ctorIdx := #[]
   for q in *...b.allCtors.size do
     if b.allCtors[q]!.owner == i then
@@ -1069,75 +1092,187 @@ private def mkUnsafeRecBody (b : Block) (levels : List Level) (i : Nat)
       mkLambdaFVars fields (mkAppN minors[gq]! (fields ++ ihs))
   return mkAppN casesFn (params ++ #[mot] ++ idxs ++ #[major] ++ cminors)
 
-/-- Add the companions as one mutual block, so that they can call each other. -/
-private def addUnsafeRecs (defns : Array DefinitionVal) : MetaM Unit := do
-  if defns.isEmpty then return
-  let decl := Declaration.mutualDefnDecl defns.toList
-  addDecl decl
-  compileDecl decl (logErrors := false)
+/--
+Open the telescope of `X_i.mutualRec` -- `{params} {motive_1 .. motive_n}
+(case_1 .. case_K) {idxs} (t)` -- and hand `k` the whole telescope and each of
+its five parts.
 
-/-- Companions for a lowered block, whose recursors all have the uniform
-signature. -/
-private def emitUnsafeRecs (b : Block) : MetaM Unit := do
-  let mut names := #[]
-  for i in *...b.size do
-    unless b.members[i]!.isProp do
-      names := names.push (b.unsafeRecName i)
-  let all := names.toList
-  let mut defns := #[]
-  for i in *...b.size do
-    if b.members[i]!.isProp then continue
-    let (type, value) ← withRecTelescope b i fun params motives minors idxs major =>
-      mkUnsafeRecBody b b.recLevels i params motives minors idxs major
-    defns := defns.push
-      { name := b.unsafeRecName i, levelParams := b.recLevelParams, type, value,
-        hints := .opaque, safety := .partial, all }
-  addUnsafeRecs defns
+Both paths agree on the split.  A lowered block's recursors have this signature
+by construction, and a homogeneous block's `mutualRec` is an alias of a native
+recursor, whose motives and minor premises range over the whole block; the
+caller checks that.
+-/
+private def withMutualRecTelescope {α} [Inhabited α] (b : Block) (i : Nat)
+    (k : Array Expr → Array Expr → Array Expr → Array Expr → Array Expr → Expr → MetaM α) :
+    MetaM α := do
+  let info ← getConstInfoDefn (b.recName i)
+  forallTelescope info.type fun xs _ => do
+    let nfront := b.numParams + b.size + b.allCtors.size
+    if xs.size ≤ nfront then
+      throwError "(internal) `mutual_multiuniverse`: unexpected signature for \
+        `{b.recName i}`:{indentExpr info.type}"
+    k xs (xs.extract 0 b.numParams)
+      (xs.extract b.numParams (b.numParams + b.size))
+      (xs.extract (b.numParams + b.size) nfront)
+      (xs.extract nfront (xs.size - 1)) xs[xs.size - 1]!
+
+/-- `h : ∀ ys, f ys = g ys` becomes `f = g`, one `funext` per binder. -/
+private def mkFunExtN (h : Expr) (n : Nat) : MetaM Expr := do
+  if n == 0 then return h
+  forallBoundedTelescope (← inferType h) (some n) fun ys _ => do
+    let mut p := mkAppN h ys
+    for k in *...n do
+      p ← mkFunExt (← mkLambdaFVars #[ys[n - 1 - k]!] p)
+    return p
+
+/-- The constructors of `group`, as indices into `b.allCtors`, in the order the
+recursor whose motives range over exactly `group` expects its minor premises. -/
+private def groupCtorIndices (b : Block) (group : Array Nat) : Array Nat := Id.run do
+  let mut out := #[]
+  for j in group do
+    for q in *...b.allCtors.size do
+      if b.allCtors[q]!.owner == j then
+        out := out.push q
+  return out
 
 /--
-Companions for a homogeneous block, whose `mutualRec`s are aliases of the
-native recursors and so have the native signature -- one elimination universe
-for the whole block rather than one per component.
+A proof of `X_i.mutualRec args idxs major = X_i.mutualRec.impl args idxs major`,
+by induction on `major` with `X_i.rec`.
+
+`motiveGroup` is what that recursor's motives range over, `implGroup` the
+members being implemented -- the same thing on the lowered path, where the
+recursor belongs to the SCC, but not on the native one, where it belongs to the
+whole block.  For a member of `motiveGroup` outside `implGroup` the two sides of
+the equation are the same term, so its statement is reflexive and its minor
+premises are `rfl`.
+
+Everywhere else the two sides differ only at the induction hypotheses: the
+recursor's iota rule leaves `X_l.mutualRec .. field` where the implementation
+leaves `X_l.mutualRec.impl .. field`, for `l` in `implGroup`, and the same term
+otherwise.  So each minor premise is a chain of congruences over the induction
+hypotheses -- legal because no minor premise's later argument types depend on
+them -- and closes by `rfl` at the head.
 -/
-private def emitNativeUnsafeRecs (b : Block) : MetaM Unit := do
-  -- an all-`Prop` homogeneous block computes nothing, so it gets no companion;
-  -- compile the aliases as they stand, which erases the small-eliminating ones
-  -- and leaves a large-eliminating one `noncomputable`, just as its own `rec` is
-  if b.members.all (·.isProp) then
+private def mkImplEqBody (b : Block) (implGroup motiveGroup : Array Nat) (levels : List Level)
+    (i : Nat) (params motives minors idxs : Array Expr) (major : Expr) : MetaM Expr := do
+  let apply (nm : Name) (jidxs : Array Expr) (t : Expr) : Expr :=
+    mkAppN (mkConst nm levels) (params ++ motives ++ minors ++ jidxs ++ #[t])
+  let implOf (j : Nat) : Name := if implGroup.contains j then b.implName j else b.recName j
+  let mut pmotives := #[]
+  for j in motiveGroup do
+    let aj ← instantiateForall b.members[j]!.type params
+    let mot ← forallTelescope aj fun jidxs _ => do
+      let dTy := mkAppN (mkConst b.members[j]!.name b.ownLevels) (params ++ jidxs)
+      withLocalDeclD `t dTy fun tv => do
+        mkLambdaFVars (jidxs ++ #[tv])
+          (← mkEq (apply (b.recName j) jidxs tv) (apply (implOf j) jidxs tv))
+    pmotives := pmotives.push mot
+  let recName := b.members[i]!.name ++ `rec
+  let recFn := mkConst recName (← elimLevelsFor recName .zero b.ownLevels)
+  let ty0 ← instantiateForall (← inferType recFn) params
+  let ty1 ← instantiateForall ty0 pmotives
+  let ctorIdx := groupCtorIndices b motiveGroup
+  let pminors ← buildArgs ty1 ctorIdx.size fun q minorTy => do
+    let gq := ctorIdx[q]!
+    let c := b.allCtors[gq]!
+    forallTelescope minorTy fun args target => do
+      let some (_, lhs, _) := (← whnf target).eq?
+        | throwError "(internal) `mutual_multiuniverse`: the induction motive for \
+            `{b.members[c.owner]!.name}` is not an equation"
+      if !implGroup.contains c.owner then
+        return ← mkLambdaFVars args (← mkEqRefl lhs)
+      let fields := args.extract 0 c.numFields
+      let nih := args.extract c.numFields args.size
+      let mut pf ← mkEqRefl (mkAppN minors[gq]! fields)
+      let mut p := 0
+      for k in *...c.numFields do
+        if let some rf := c.fields[k]! then
+          -- the recursor offers an induction hypothesis for every field of a
+          -- member it has a motive for, and only those
+          let inMotive := motiveGroup.contains rf.member
+          let h ←
+            if inMotive && implGroup.contains rf.member then
+              mkFunExtN nih[p]! rf.arity
+            else
+              mkEqRefl (← recCallTo b b.recName levels params motives minors rf.member fields[k]!)
+          if inMotive then
+            p := p + 1
+          pf ← mkCongr pf h
+      mkLambdaFVars args pf
+  return mkAppN recFn (params ++ pmotives ++ pminors ++ idxs ++ #[major])
+
+/--
+The implementations of one group of members' recursors, and their `@[csimp]`
+theorems.
+
+`implGroup` is a strongly connected component of the data-only dependency
+graph, so its implementations are exactly the ones that have to be defined by
+mutual recursion; `motiveGroup` is what the native recursors used to prove the
+theorems range over, which on the native path is the whole block.
+-/
+private def emitImplGroup (b : Block) (implGroup motiveGroup : Array Nat) : TermElabM Unit := do
+  if implGroup.isEmpty then return
+  let docCtx := (← getLCtx, ← getLocalInstances)
+  let names := implGroup.map b.implName
+  let mut preDefs : Array PreDefinition := #[]
+  for i in implGroup do
+    let info ← getConstInfoDefn (b.recName i)
+    let levels := info.levelParams.map Level.param
+    let value ← withMutualRecTelescope b i fun xs params motives minors idxs major => do
+      mkLambdaFVars xs (← mkImplBody b implGroup levels i params motives minors idxs major)
+    preDefs := preDefs.push
+      { ref := .missing, kind := .def, levelParams := info.levelParams, modifiers := {},
+        declName := b.implName i, binders := .missing, type := info.type, value,
+        termination := TerminationHints.none }
+  -- `structuralRecursion` throws if it cannot see that the definitions
+  -- terminate; `addPreDefinitions` would instead fall back to `partial` or
+  -- `sorry`, which is exactly the silent degradation we are avoiding
+  if preDefs.any fun p => p.value.getUsedConstants.any (names.contains ·) then
+    Structural.structuralRecursion docCtx preDefs
+      (preDefs.map fun _ => (none : Option TerminationMeasure))
+  else
+    for preDef in preDefs do
+      addAndCompileNonRec docCtx preDef
+  for i in implGroup do
+    let info ← getConstInfoDefn (b.recName i)
+    let levels := info.levelParams.map Level.param
+    let value ← withMutualRecTelescope b i fun xs params motives minors idxs major => do
+      let mut pf ← mkImplEqBody b implGroup motiveGroup levels i params motives minors idxs major
+      -- `∀ args, f args = g args` becomes `f = g`, which is `@X_i.mutualRec =
+      -- @X_i.mutualRec.impl` up to eta -- the shape `csimp` wants
+      for k in *...xs.size do
+        pf ← mkFunExt (← mkLambdaFVars #[xs[xs.size - 1 - k]!] pf)
+      return pf
+    let type ← mkEq (mkConst (b.recName i) levels) (mkConst (b.implName i) levels)
+    addDecl (.thmDecl { name := b.implEqName i, levelParams := info.levelParams, type, value })
+    Compiler.CSimp.add (b.implEqName i) .global
+
+/--
+Implementations for a homogeneous block, whose `mutualRec`s are aliases of the
+native recursors and so have the native signature -- one elimination universe
+for the whole block rather than one per component, and motives ranging over
+every member.
+-/
+private def emitNativeImpls (b : Block) : TermElabM Unit := do
+  -- compile the aliases as they stand: this erases the small-eliminating ones
+  -- and leaves anything else `noncomputable`, just as its own `rec` is
+  let compileAliases : TermElabM Unit := do
     for i in *...b.size do
-      compileDecl (.defnDecl (← getConstInfoDefn (b.recName i))) (logErrors := false)
-    return
+      Lean.compileDecl (.defnDecl (← getConstInfoDefn (b.recName i))) (logErrors := false)
+  -- an all-`Prop` homogeneous block computes nothing, so it needs no
+  -- implementation
+  if b.members.all (·.isProp) then
+    return ← compileAliases
   let info ← getConstInfoRec (b.members[0]!.name ++ `rec)
   -- the native recursor of a mutual block ranges over every member; if some
-  -- future change makes that false, compile the aliases as they stand, which
-  -- fails quietly and leaves them `noncomputable`
-  unless info.numMotives == b.size && info.numMinors == b.allCtors.size do
-    for i in *...b.size do
-      compileDecl (.defnDecl (← getConstInfoDefn (b.recName i))) (logErrors := false)
-    return
-  let levels := info.levelParams.map Level.param
-  let mut names := #[]
-  for i in *...b.size do
-    names := names.push (b.unsafeRecName i)
-  let all := names.toList
-  let nfront := info.numParams + info.numMotives + info.numMinors
-  let mut defns := #[]
-  for i in *...b.size do
-    let ri ← getConstInfoRec (b.members[i]!.name ++ `rec)
-    let value ←
-      forallBoundedTelescope ri.type (some nfront) fun front rest =>
-        forallBoundedTelescope rest (some (ri.numIndices + 1)) fun tail _ => do
-          let params  := front.extract 0 info.numParams
-          let motives := front.extract info.numParams (info.numParams + info.numMotives)
-          let minors  := front.extract (info.numParams + info.numMotives) front.size
-          let idxs    := tail.extract 0 ri.numIndices
-          let major   := tail[ri.numIndices]!
-          let body ← mkUnsafeRecBody b levels i params motives minors idxs major
-          mkLambdaFVars (front ++ tail) body
-    defns := defns.push
-      { name := b.unsafeRecName i, levelParams := ri.levelParams, type := ri.type, value,
-        hints := .opaque, safety := .partial, all }
-  addUnsafeRecs defns
+  -- future change makes that false, fall back to the aliases as they stand
+  unless info.numParams == b.numParams && info.numMotives == b.size
+      && info.numMinors == b.allCtors.size do
+    return ← compileAliases
+  -- a homogeneous block that is not all-`Prop` has no `Prop` member at all, so
+  -- every member is in one of the data SCCs
+  for s in *...b.sccs.size do
+    emitImplGroup b b.sccs[s]! (Array.range b.size)
 
 /--
 Lower an elaborated `mutual_multiuniverse` block to ordinary declarations.
@@ -1145,11 +1280,11 @@ Lower an elaborated `mutual_multiuniverse` block to ordinary declarations.
 A homogeneous block is emitted natively, so `mutual_multiuniverse` accepts
 everything `mutual` does and means the same thing by it.
 -/
-def lower (inp : Input) : MetaM Unit := do
+def lower (inp : Input) : TermElabM Unit := do
   let b ← analyze inp
   if b.isHomogeneous then
     emitNative b
-    emitNativeUnsafeRecs b
+    emitNativeImpls b
     return
   if b.hasProp then
     emitShadow b
@@ -1163,9 +1298,11 @@ def lower (inp : Input) : MetaM Unit := do
     for i in *...b.size do
       if b.members[i]!.isProp then
         emitRec b i
+  -- one SCC at a time, so that an implementation's calls into an earlier
+  -- component are already backed by a `@[csimp]` theorem
   for s in *...b.sccs.size do
     for i in b.sccs[s]! do
       emitRec b i
-  emitUnsafeRecs b
+    emitImplGroup b b.sccs[s]! b.sccs[s]!
 
 end Lean.Elab.MultiuniverseInductive

--- a/src/Lean/Elab/MutualInductive.lean
+++ b/src/Lean/Elab/MutualInductive.lean
@@ -12,6 +12,7 @@ public import Lean.Meta.MkIffOfInductiveProp
 public import Lean.Elab.Coinductive
 public import Lean.Elab.Deriving.Basic
 import Lean.Elab.ComputedFields
+import Lean.Elab.MultiuniverseInductive
 import Lean.Meta.Constructions.CtorIdx
 import Lean.Meta.Constructions.CtorElim
 import Lean.Meta.IndPredBelow
@@ -290,7 +291,8 @@ def withExplicitToImplicit (xs : Array Expr) (k : TermElabM α) : TermElabM α :
 /--
 Auxiliary function for checking whether the types in mutually inductive declaration are compatible.
 -/
-private def checkParamsAndResultType (type firstType : Expr) (numParams : Nat) : TermElabM Unit := do
+private def checkParamsAndResultType (type firstType : Expr) (numParams : Nat)
+    (heterogeneousUniverses := false) : TermElabM Unit := do
   try
     forallTelescopeCompatible type firstType numParams fun _ type firstType =>
     forallTelescopeReducing type fun _ type =>
@@ -298,7 +300,7 @@ private def checkParamsAndResultType (type firstType : Expr) (numParams : Nat) :
       let type ← whnfD type
       match type with
       | .sort .. =>
-        unless (← isDefEq firstType type) do
+        unless heterogeneousUniverses || (← isDefEq firstType type) do
           throwError m!"The resulting type of this declaration{indentExpr type}\ndiffers from a preceding one{indentExpr firstType}"
             ++ .note "All inductive types declared in the same `mutual` block must belong to the same type universe"
       | _ =>
@@ -311,17 +313,18 @@ private def checkParamsAndResultType (type firstType : Expr) (numParams : Nat) :
 /--
 Auxiliary function for checking whether the types in mutually inductive declaration are compatible.
 -/
-private def checkHeaders (rs : Array PreElabHeaderResult) (numParams : Nat) (i : Nat) (firstType? : Option Expr) : TermElabM Unit := do
+private def checkHeaders (rs : Array PreElabHeaderResult) (numParams : Nat) (i : Nat)
+    (firstType? : Option Expr) (heterogeneousUniverses := false) : TermElabM Unit := do
   if h : i < rs.size then
     let type ← checkHeader rs[i] numParams firstType?
-    checkHeaders rs numParams (i+1) type
+    checkHeaders rs numParams (i+1) type heterogeneousUniverses
 where
   checkHeader (r : PreElabHeaderResult) (numParams : Nat) (firstType? : Option Expr) : TermElabM Expr := do
     let type := r.type
     match firstType? with
     | none           => return type
     | some firstType =>
-      withRef r.view.ref <| checkParamsAndResultType type firstType numParams
+      withRef r.view.ref <| checkParamsAndResultType type firstType numParams heterogeneousUniverses
       return firstType
 
 private def elabHeadersAux (views : Array InductiveView) (i : Nat) (acc : Array PreElabHeaderResult) : TermElabM (Array PreElabHeaderResult) :=
@@ -360,13 +363,14 @@ private def elabHeadersAux (views : Array InductiveView) (i : Nat) (acc : Array 
 /--
 Elaborates all the headers in the inductive views.
 -/
-private def elabHeaders (views : Array InductiveView) : TermElabM (Array PreElabHeaderResult) := do
+private def elabHeaders (views : Array InductiveView) (heterogeneousUniverses := false) :
+    TermElabM (Array PreElabHeaderResult) := do
   let rs ← elabHeadersAux views 0 #[]
   if rs.size > 1 then
     checkUnsafe rs
     checkClass rs
     let numParams ← checkNumParams rs
-    checkHeaders rs numParams 0 none
+    checkHeaders rs numParams 0 none heterogeneousUniverses
   return rs
 
 /--
@@ -413,13 +417,16 @@ private def ElabHeaderResult.checkLevelNames (rs : Array PreElabHeaderResult) : 
       unless r.levelNames == levelNames do
         throwLevelNameMismatch r.levelNames levelNames r.view.declName rs[0].view.shortDeclName
 
-private def getResultingUniverse : List InductiveType → TermElabM Level
-  | []           => throwError "Unexpected empty inductive declaration"
-  | indType :: _ => forallTelescopeReducing indType.type fun _ r => do
+private def getIndTypeUniverse (indType : InductiveType) : TermElabM Level :=
+  forallTelescopeReducing indType.type fun _ r => do
     let r ← whnfD r
     match r with
     | Expr.sort u => return u
     | _           => throwError "Unexpected inductive type resulting type{indentExpr r}"
+
+private def getResultingUniverse : List InductiveType → TermElabM Level
+  | []           => throwError "Unexpected empty inductive declaration"
+  | indType :: _ => getIndTypeUniverse indType
 
 private def instantiateMVarsAtInductive (indType : InductiveType) : TermElabM InductiveType := do
   let type ← instantiateMVars indType.type
@@ -1139,29 +1146,50 @@ private def checkResultingUniversePolymorphism (views : Array InductiveView) (u 
       -- TODO: heuristic for allowing `Sort` polymorphism?
       doErrFor views[0]!
 
+/-- Checks the universe constraints for the constructors of a single type of the block. -/
+private def checkCtorUniverses (views : Array InductiveView) (elabs' : Array InductiveElabStep2)
+    (numParams : Nat) (i : Nat) (indType : InductiveType) (u : Level) : TermElabM Unit := do
+  if u.isZero then return
+  -- See if there is a custom error. If so, this should throw an error first:
+  elabs'[i]!.checkUniverses numParams u
+  indType.ctors.forM fun ctor =>
+  forallTelescopeReducing ctor.type fun ctorArgs _ => do
+    for ctorArg in ctorArgs[numParams...*] do
+      let type ← inferType ctorArg
+      let v := (← instantiateLevelMVars (← getLevel type)).normalize
+      unless u.geq v do
+        let mut msg := m!"Invalid universe level in constructor `{ctor.name}`: Parameter"
+        unless (← ctorArg.fvarId!.getUserName).hasMacroScopes do
+          msg := msg ++ m!" `{ctorArg}`"
+        msg := msg ++ m!" has type{indentExpr type}\n\
+          at universe level{indentD v}\n\
+          which is not less than or equal to the inductive type's resulting universe level{indentD u}"
+        withCtorRef views ctor.name <| throwError msg
+
 /-- Checks the universe constraints for each constructor. -/
 private def checkResultingUniverses (views : Array InductiveView) (elabs' : Array InductiveElabStep2)
     (numParams : Nat) (indTypes : List InductiveType) : TermElabM Unit := do
   let u := (← instantiateLevelMVars (← getResultingUniverse indTypes)).normalize
   checkResultingUniversePolymorphism views u numParams indTypes
-  unless u.isZero do
-    for h : i in *...indTypes.length do
-      let indType := indTypes[i]
-      -- See if there is a custom error. If so, this should throw an error first:
-      elabs'[i]!.checkUniverses numParams u
-      indType.ctors.forM fun ctor =>
-      forallTelescopeReducing ctor.type fun ctorArgs _ => do
-        for ctorArg in ctorArgs[numParams...*] do
-          let type ← inferType ctorArg
-          let v := (← instantiateLevelMVars (← getLevel type)).normalize
-          unless u.geq v do
-            let mut msg := m!"Invalid universe level in constructor `{ctor.name}`: Parameter"
-            unless (← ctorArg.fvarId!.getUserName).hasMacroScopes do
-              msg := msg ++ m!" `{ctorArg}`"
-            msg := msg ++ m!" has type{indentExpr type}\n\
-              at universe level{indentD v}\n\
-              which is not less than or equal to the inductive type's resulting universe level{indentD u}"
-            withCtorRef views ctor.name <| throwError msg
+  for h : i in *...indTypes.length do
+    checkCtorUniverses views elabs' numParams i indTypes[i] u
+
+/--
+Like `checkResultingUniverses`, but checks each type's constructors against *that type's* own
+resulting universe rather than against the whole block's.
+
+This is what `mutual_multiuniverse` needs: its members are ultimately declared in separate
+inductive declarations, so a member's constructor fields only ever have to fit in that member's
+own universe.
+-/
+private def checkResultingUniversesPerType (views : Array InductiveView)
+    (elabs' : Array InductiveElabStep2) (numParams : Nat) (indTypes : List InductiveType) :
+    TermElabM Unit := do
+  for h : i in *...indTypes.length do
+    let indType := indTypes[i]
+    let u := (← instantiateLevelMVars (← getIndTypeUniverse indType)).normalize
+    checkResultingUniversePolymorphism #[views[i]!] u numParams indTypes
+    checkCtorUniverses views elabs' numParams i indType u
 
 private def collectUsed (indTypes : List InductiveType) : StateRefT CollectFVars.State MetaM Unit := do
   indTypes.forM fun indType => do
@@ -1443,9 +1471,18 @@ private def addTermInfoViews (views : Array InductiveView) : TermElabM Unit := -
           Term.addTermInfo' ctor.declId (← mkConstWithLevelParams ctor.declName) (isBinder := true)
           enableRealizationsForConst ctor.declName
 
+/--
+Elaborates the headers and constructors of a mutual inductive block, then hands the result to
+`callback`, which is responsible for actually adding declarations to the environment.
+
+If `heterogeneousUniverses` is true, each member's constructor fields are checked against that
+member's own resulting universe rather than the block's common one.  Only
+`mutual_multiuniverse` sets this; see `checkResultingUniversesPerType`.
+-/
 private def mkInductiveDeclCore
   (callback : AddAndFinalizeContext → TermElabM α) (vars : Array Expr)
-  (elabs : Array InductiveElabStep1) (rs : Array PreElabHeaderResult) (scopeLevelNames : List Name) : TermElabM α := do
+  (elabs : Array InductiveElabStep1) (rs : Array PreElabHeaderResult) (scopeLevelNames : List Name)
+  (heterogeneousUniverses := false) : TermElabM α := do
   let views := elabs.map (·.view)
   let view0 := views[0]!
   let isCoinductive := views.any (·.isCoinductive)
@@ -1503,7 +1540,10 @@ private def mkInductiveDeclCore
       withoutExporting do
         elabs'.forM fun elab' => elab'.finalizeTermElab
         ensureNoUnassignedLevelMVarsAtInductives views indTypes
-        checkResultingUniverses views elabs' numParams indTypes
+        if heterogeneousUniverses then
+          checkResultingUniversesPerType views elabs' numParams indTypes
+        else
+          checkResultingUniverses views elabs' numParams indTypes
       let usedLevelNames := collectLevelParamsInInductive indTypes
       match sortDeclLevelParams scopeLevelNames allUserLevelNames usedLevelNames with
       | .error msg      => throwErrorAt view0.declId msg
@@ -1524,7 +1564,8 @@ private def mkInductiveDeclCore
         }
 
 private def withElaboratedHeaders (vars : Array Expr) (elabs : Array InductiveElabStep1)
-  (k : Array Expr → Array InductiveElabStep1 → Array PreElabHeaderResult → List Name → TermElabM α ) : TermElabM α :=
+  (k : Array Expr → Array InductiveElabStep1 → Array PreElabHeaderResult → List Name → TermElabM α )
+  (heterogeneousUniverses := false) : TermElabM α :=
 Term.withoutSavingRecAppSyntax do
   let views := elabs.map (·.view)
   let view0 := views[0]!
@@ -1532,7 +1573,7 @@ Term.withoutSavingRecAppSyntax do
   InductiveElabStep1.checkLevelNames views
   let allUserLevelNames := view0.levelNames
   withRef view0.ref <| Term.withLevelNames allUserLevelNames do
-    let rs ← elabHeaders views
+    let rs ← elabHeaders views heterogeneousUniverses
     Term.synthesizeSyntheticMVarsNoPostponing
     ElabHeaderResult.checkLevelNames rs
     trace[Elab.inductive] "level names: {allUserLevelNames}"
@@ -1581,6 +1622,44 @@ private def elabInductiveViews (vars : Array Expr) (elabs : Array InductiveElabS
         IndPredBelow.mkBelow view0.declName
         for e in elabs do
           mkInjectiveTheorems e.view.declName
+    for e in elabs do
+      enableRealizationsForConst e.view.declName
+      for ctor in e.view.ctors do
+        enableRealizationsForConst ctor.declName
+    return res
+
+/--
+Like `elabInductiveViews`, but for a `mutual_multiuniverse` block: rather than adding the block as
+one mutual inductive declaration, which the kernel would reject unless all its members share a
+universe, the block is lowered to declarations the kernel does accept.
+
+`MultiuniverseInductive.lower` makes the auxiliary constructions itself, as it emits each of those
+declarations, so there is nothing left to do for them here.
+-/
+private def elabMultiuniverseInductiveViews (vars : Array Expr) (elabs : Array InductiveElabStep1) :
+    TermElabM FinalizeContext := do
+  let view0 := elabs[0]!.view
+  let ref := view0.ref
+  Term.withDeclName view0.declName do withRef ref do
+  withExporting (isExporting := !isPrivateName view0.declName) do
+    let res ← withElaboratedHeaders (heterogeneousUniverses := true) vars elabs
+      fun vars elabs rs scopeLevelNames =>
+      mkInductiveDeclCore (callback := fun context => do
+          let indTypes := context.indTypes.toArray
+          MultiuniverseInductive.lower {
+            levelParams := context.levelParams
+            numVars     := context.numVars
+            numParams   := context.numParams
+            memberFVars := context.indFVars
+            memberNames := indTypes.map (·.name)
+            memberTypes := indTypes.map (·.type)
+            ctorNames   := indTypes.map (·.ctors.toArray.map (·.name))
+            ctorTypes   := indTypes.map (·.ctors.toArray.map (·.type))
+            isClass     := view0.isClass
+          }
+          buildFinalizeContext context.elabs' context.levelParams context.vars context.params
+            context.views context.indFVars context.rs)
+        vars elabs rs scopeLevelNames (heterogeneousUniverses := true)
     for e in elabs do
       enableRealizationsForConst e.view.declName
       for ctor in e.view.ctors do
@@ -1746,5 +1825,40 @@ def elabMutualInductive (elems : Array Syntax) : CommandElabM Unit := do
   if inductives.any (·.1.isMeta) && inductives.any (!·.1.isMeta) then
     throwError "A mix of `meta` and non-`meta` declarations in the same `mutual` block is not supported"
   elabInductives inductives
+
+/--
+Elaborates a `mutual_multiuniverse` block (`Lean.Parser.Command.mutualMultiuniverse`), assuming the
+commands satisfy `Lean.Elab.Command.isMutualInductive`.
+
+The block is elaborated exactly as `mutual` elaborates one -- same headers, same constructors, same
+parameter and universe analysis, except that constructor fields are checked against their own
+member's universe -- and then lowered by `Lean.Elab.MultiuniverseInductive.lower`.
+-/
+def elabMultiuniverseInductive (elems : Array Syntax) : CommandElabM Unit := do
+  let inductives ← elems.mapM fun stx => do
+    let modifiers ← elabModifiers ⟨stx[0]⟩
+    unless stx[1].getKind == ``Parser.Command.inductive do
+      throwErrorAt stx[1] "invalid `mutual_multiuniverse` block: every element of the block must \
+        be an `inductive` declaration"
+    pure (modifiers, stx[1])
+  if inductives.any (·.1.isMeta) && inductives.any (!·.1.isMeta) then
+    throwError "A mix of `meta` and non-`meta` declarations in the same `mutual_multiuniverse` \
+      block is not supported"
+  let elabs ← runTermElabM fun _ => inductives.mapM fun (modifiers, stx) =>
+    mkInductiveView modifiers stx
+  for e in elabs do
+    if e.view.isCoinductive then
+      throwErrorAt e.view.declId "`coinductive` predicates are not supported in a \
+        `mutual_multiuniverse` block"
+    if let some proof := e.view.monotonicity? then
+      throwErrorAt proof "`monotonicity_by` is only allowed on `coinductive` predicates, or on \
+        `inductive` predicates in a `mutual` block together with a `coinductive` predicate"
+  checkNoInductiveNameConflicts elabs
+  elabs.forM fun e => checkValidInductiveModifier e.view.modifiers
+  liftTermElabM <| elabs.forM fun e => withRef e.view.ref do
+    Term.applyAttributesAt e.view.declName e.view.modifiers.attrs .beforeElaboration
+  let res ← runTermElabM fun vars => elabMultiuniverseInductiveViews vars elabs
+  elabInductiveViewsFinalize (elabs.map (·.view)) res
+  elabInductiveViewsPostprocessing (elabs.map (·.view))
 
 end Lean.Elab.Command

--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -932,7 +932,13 @@ strongly connected component of the block.
 The recursors are axiom-free, with one exception: if a `Prop` member has a
 constructor field that is a *function into* a data member, recursing on it has
 to choose data witnesses pointwise, and the recursors that do so depend on
-`Classical.choice`.
+`Classical.choice`.  That does not cost computability: the choice happens under
+a `Prop`, so it carries no computational content.
+
+The recursors are computable.  The code generator compiles no recursor
+application at all -- `X.rec` no more than `Nat.rec` -- so each `X.mutualRec` is
+given a compiled companion that does the same recursion by cases, and
+definitions built from it both reduce in the kernel and `#eval`.
 
 A block whose members all live at the same universe is emitted natively, so
 `mutual_multiuniverse` accepts everything `mutual` does and means the same

--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -937,8 +937,10 @@ a `Prop`, so it carries no computational content.
 
 The recursors are computable.  The code generator compiles no recursor
 application at all -- `X.rec` no more than `Nat.rec` -- so each `X.mutualRec` is
-given a compiled companion that does the same recursion by cases, and
-definitions built from it both reduce in the kernel and `#eval`.
+paired with an implementation `X.mutualRec.impl` that does the same recursion by
+cases and a proved `@[csimp]` theorem `X.mutualRec.eq_impl` that puts it in the
+compiler's hands.  Definitions built from `X.mutualRec` therefore both reduce in
+the kernel and `#eval`.
 
 A block whose members all live at the same universe is emitted natively, so
 `mutual_multiuniverse` accepts everything `mutual` does and means the same

--- a/src/Lean/Parser/Command.lean
+++ b/src/Lean/Parser/Command.lean
@@ -901,6 +901,47 @@ end
 @[builtin_command_parser] def «mutual» := leading_parser
   "mutual" >> many1 (ppLine >> notSymbol "end" >> commandParser) >>
   ppDedent (ppLine >> "end")
+
+/--
+A `mutual` block of inductive types whose members may live at *different*
+universes.
+
+The kernel requires the members of a mutual inductive block to share a
+universe, so such a block cannot be declared with `mutual`.  This command
+elaborates its contents exactly as `mutual` does, then translates the block
+into ordinary declarations the kernel does accept, and defines the types,
+constructors and recursors the block would have had.  It requires no extension
+of the type theory.
+
+```
+mutual_multiuniverse
+inductive Even : Nat → Prop where
+  | zero : Even 0
+  | succ : (n : Nat) → OddData n → Even (n + 1)
+inductive OddData : Nat → Type where
+  | succ : (n : Nat) → Even n → Nat → OddData (n + 1)
+end
+```
+
+The block-wide recursor -- the one whose motives range over every member -- is
+`X.mutualRec`.  Data members are honest inductive types under their own names,
+so `match`, `induction`, `cases`, `injection` and `#eval` all work on them as
+usual; `X.rec` is their native recursor, whose motives range over their
+strongly connected component of the block.
+
+The recursors are axiom-free, with one exception: if a `Prop` member has a
+constructor field that is a *function into* a data member, recursing on it has
+to choose data witnesses pointwise, and the recursors that do so depend on
+`Classical.choice`.
+
+A block whose members all live at the same universe is emitted natively, so
+`mutual_multiuniverse` accepts everything `mutual` does and means the same
+thing by it.
+-/
+@[builtin_command_parser] def «mutualMultiuniverse» := leading_parser
+  "mutual_multiuniverse" >> many1 (ppLine >> notSymbol "end" >> commandParser) >>
+  ppDedent (ppLine >> "end")
+
 def initializeKeyword := leading_parser
   "initialize " <|> "builtin_initialize "
 @[builtin_command_parser] def «initialize» := leading_parser

--- a/tests/elab/mutualMultiuniverse.lean
+++ b/tests/elab/mutualMultiuniverse.lean
@@ -1,0 +1,172 @@
+/-!
+# `mutual_multiuniverse`
+
+A mutual inductive block whose members live at three different universes:
+`Prop`, `Type 0` and `Type 2`.  The kernel cannot accept such a block directly,
+so the command lowers it; what the user sees is the block they asked for.
+-/
+
+mutual_multiuniverse
+inductive A : Prop where
+  | fromB : B → A
+  | fromC : C → A
+inductive B : Type 0 where
+  | fromA : Nat → A → B
+  | wrap : B → B
+inductive C : Type 2 where
+  | fromA : A → C
+  | higherUniv : Nat → Type → C
+  | pair : B → C → C
+end
+
+/-! The block-wide recursor has one motive per member, each at that member's
+own universe, and every member's is at the same telescope: that uniformity is
+what lets one member's recursor supply the induction hypothesis for a field of
+another member's type. -/
+
+/--
+info: @A.mutualRec : ∀ {motive_1 : A → Prop} {motive_2 : B → Sort u_1} {motive_3 : C → Sort u_2},
+  (∀ (a : B) (ih_1 : motive_2 a), motive_1 (A.fromB a)) →
+    (∀ (a : C) (ih_1 : motive_3 a), motive_1 (A.fromC a)) →
+      ∀ (case_3 : (a : Nat) → (a_1 : A) → motive_1 a_1 → motive_2 (B.fromA a a_1))
+        (case_4 : (a : B) → motive_2 a → motive_2 a.wrap) (case_5 : (a : A) → motive_1 a → motive_3 (C.fromA a))
+        (case_6 : (a : Nat) → (a_1 : Type) → motive_3 (C.higherUniv a a_1))
+        (case_7 : (a : B) → (a_1 : C) → motive_2 a → motive_3 a_1 → motive_3 (C.pair a a_1)) (t : A), motive_1 t
+-/
+#guard_msgs in
+set_option pp.proofs true in
+#check @A.mutualRec
+
+/--
+info: @C.mutualRec : {motive_1 : A → Prop} →
+  {motive_2 : B → Sort u_1} →
+    {motive_3 : C → Sort u_2} →
+      (∀ (a : B) (ih_1 : motive_2 a), motive_1 (A.fromB a)) →
+        (∀ (a : C) (ih_1 : motive_3 a), motive_1 (A.fromC a)) →
+          ((a : Nat) → (a_1 : A) → motive_1 a_1 → motive_2 (B.fromA a a_1)) →
+            ((a : B) → motive_2 a → motive_2 a.wrap) →
+              ((a : A) → motive_1 a → motive_3 (C.fromA a)) →
+                ((a : Nat) → (a_1 : Type) → motive_3 (C.higherUniv a a_1)) →
+                  ((a : B) → (a_1 : C) → motive_2 a → motive_3 a_1 → motive_3 (C.pair a a_1)) → (t : C) → motive_3 t
+-/
+#guard_msgs in
+set_option pp.proofs true in
+#check @C.mutualRec
+
+/-! The data members are declared as honest inductive types, so they also have
+their own native recursors.  `B` and `C` end up in separate strongly connected
+components of the data-only dependency graph (`C` mentions `B`, but not the
+other way round), so `C.rec` has a single motive and gives no induction
+hypothesis for `C.pair`'s `B` field.  `C.mutualRec` is the one that does. -/
+
+/--
+info: @C.rec : {motive : C → Sort u_1} →
+  ((a : A) → motive (C.fromA a)) →
+    ((a : Nat) → (a_1 : Type) → motive (C.higherUniv a a_1)) →
+      ((a : B) → (a_1 : C) → motive a_1 → motive (C.pair a a_1)) → (t : C) → motive t
+-/
+#guard_msgs in
+#check @C.rec
+
+/-- info: 'A.mutualRec' does not depend on any axioms -/
+#guard_msgs in
+#print axioms A.mutualRec
+
+/-- info: 'B.mutualRec' does not depend on any axioms -/
+#guard_msgs in
+#print axioms B.mutualRec
+
+/-- info: 'C.mutualRec' does not depend on any axioms -/
+#guard_msgs in
+#print axioms C.mutualRec
+
+/-- A `Prop` member has no native recursor to compete with, so it also answers
+to `A.rec`. -/
+example : @A.rec = @A.mutualRec := rfl
+
+/-! Every iota rule holds by `rfl`, including the ones that cross between
+universes. -/
+
+section
+variable {mA : A → Prop} {mB : B → Sort u} {mC : C → Sort v}
+  (fAB : (b : B) → mB b → mA (A.fromB b))
+  (fAC : (c : C) → mC c → mA (A.fromC c))
+  (fBa : (n : Nat) → (a : A) → mA a → mB (B.fromA n a))
+  (fBw : (b : B) → mB b → mB (B.wrap b))
+  (fCa : (a : A) → mA a → mC (C.fromA a))
+  (fCh : (n : Nat) → (t : Type) → mC (C.higherUniv n t))
+  (fCp : (b : B) → (c : C) → mB b → mC c → mC (C.pair b c))
+
+example (b : B) :
+    @B.mutualRec mA mB mC fAB fAC fBa fBw fCa fCh fCp (B.wrap b)
+      = fBw b (@B.mutualRec mA mB mC fAB fAC fBa fBw fCa fCh fCp b) := rfl
+
+example (n : Nat) (a : A) :
+    @B.mutualRec mA mB mC fAB fAC fBa fBw fCa fCh fCp (B.fromA n a)
+      = fBa n a (@A.mutualRec mA mB mC fAB fAC fBa fBw fCa fCh fCp a) := rfl
+
+example (a : A) :
+    @C.mutualRec mA mB mC fAB fAC fBa fBw fCa fCh fCp (C.fromA a)
+      = fCa a (@A.mutualRec mA mB mC fAB fAC fBa fBw fCa fCh fCp a) := rfl
+
+example (n : Nat) (t : Type) :
+    @C.mutualRec mA mB mC fAB fAC fBa fBw fCa fCh fCp (C.higherUniv n t) = fCh n t := rfl
+
+example (b : B) (c : C) :
+    @C.mutualRec mA mB mC fAB fAC fBa fBw fCa fCh fCp (C.pair b c)
+      = fCp b c (@B.mutualRec mA mB mC fAB fAC fBa fBw fCa fCh fCp b)
+               (@C.mutualRec mA mB mC fAB fAC fBa fBw fCa fCh fCp c) := rfl
+
+-- the `Prop` member's iota rules hold by proof irrelevance
+example (b : B) :
+    @A.mutualRec mA mB mC fAB fAC fBa fBw fCa fCh fCp (A.fromB b)
+      = fAB b (@B.mutualRec mA mB mC fAB fAC fBa fBw fCa fCh fCp b) := rfl
+
+example (c : C) :
+    @A.mutualRec mA mB mC fAB fAC fBa fBw fCa fCh fCp (A.fromC c)
+      = fAC c (@C.mutualRec mA mB mC fAB fAC fBa fBw fCa fCh fCp c) := rfl
+end
+
+/-! The data members are honest inductive types, so `match`, structural
+recursion, `induction`, `injection` and `#eval` all work on them natively and
+the block's computational content is not stuck behind a recursor. -/
+
+def sizeB : B → Nat
+  | .fromA n _ => n
+  | .wrap b => sizeB b + 1
+
+def sizeC : C → Nat
+  | .fromA _ => 0
+  | .higherUniv n _ => n
+  | .pair b c => sizeB b + sizeC c
+
+/-- info: 7 -/
+#guard_msgs in
+#eval sizeB (B.wrap (B.wrap (B.fromA 5 (A.fromC (C.higherUniv 3 Nat)))))
+
+/-- info: 15 -/
+#guard_msgs in
+#eval sizeC (C.pair (B.wrap (B.fromA 4 (A.fromC (C.higherUniv 1 Nat)))) (C.higherUniv 10 Nat))
+
+example (b : B) : sizeB (B.wrap b) = sizeB b + 1 := rfl
+
+example (b : B) : 0 < sizeB (B.wrap b) := by
+  induction b with
+  | fromA n a => simp [sizeB]
+  | wrap b ih => simp [sizeB]
+
+example (m n : Nat) (a a' : A) (h : B.fromA m a = B.fromA n a') : m = n := by
+  injection h
+
+example (n : Nat) (a : A) (b : B) : B.fromA n a ≠ B.wrap b := by
+  intro h; cases h
+
+/-! The block-wide recursor is what to use when the recursion genuinely crosses
+members.  It is `noncomputable` for exactly the reason `Nat.rec` is: the code
+generator does not compile bare recursor applications. -/
+
+noncomputable def depth : B → Nat :=
+  @B.mutualRec (fun _ => True) (fun _ => Nat) (fun _ => Nat)
+    (fun _ _ => trivial) (fun _ _ => trivial)
+    (fun _ _ _ => 0) (fun _ ih => ih + 1)
+    (fun _ _ => 0) (fun n _ => n) (fun _ _ ihb ihc => ihb + ihc)

--- a/tests/elab/mutualMultiuniverse.lean
+++ b/tests/elab/mutualMultiuniverse.lean
@@ -163,9 +163,10 @@ example (n : Nat) (a : A) (b : B) : B.fromA n a ≠ B.wrap b := by
 
 /-! The block-wide recursor is what to use when the recursion genuinely crosses
 members, and it is computable.  The code generator compiles no recursor
-application -- `B.rec` no more than `Nat.rec` -- so `B.mutualRec` is given a
-compiled companion that does the same recursion by cases, and definitions built
-from it both reduce in the kernel and evaluate. -/
+application -- `B.rec` no more than `Nat.rec` -- so `B.mutualRec` is paired with
+an implementation that does the same recursion by cases and a proved `@[csimp]`
+theorem that hands it to the compiler, and definitions built from it both reduce
+in the kernel and evaluate. -/
 
 def depth : B → Nat :=
   @B.mutualRec (fun _ => True) (fun _ => Nat) (fun _ => Nat)
@@ -194,7 +195,7 @@ example : depthC (C.pair (B.wrap (B.fromA 4 (A.fromC (C.higherUniv 1 Nat))))
 #guard_msgs in
 #eval depthC (C.pair (B.wrap (B.fromA 4 (A.fromC (C.higherUniv 1 Nat)))) (C.higherUniv 10 Nat))
 
--- the companion is compiler-only, so it changes nothing about the term
+-- `mutualRec` itself is untouched, so the term is what it was
 /-- info: 'depth' does not depend on any axioms -/
 #guard_msgs in
 #print axioms depth

--- a/tests/elab/mutualMultiuniverse.lean
+++ b/tests/elab/mutualMultiuniverse.lean
@@ -162,11 +162,39 @@ example (n : Nat) (a : A) (b : B) : B.fromA n a ≠ B.wrap b := by
   intro h; cases h
 
 /-! The block-wide recursor is what to use when the recursion genuinely crosses
-members.  It is `noncomputable` for exactly the reason `Nat.rec` is: the code
-generator does not compile bare recursor applications. -/
+members, and it is computable.  The code generator compiles no recursor
+application -- `B.rec` no more than `Nat.rec` -- so `B.mutualRec` is given a
+compiled companion that does the same recursion by cases, and definitions built
+from it both reduce in the kernel and evaluate. -/
 
-noncomputable def depth : B → Nat :=
+def depth : B → Nat :=
   @B.mutualRec (fun _ => True) (fun _ => Nat) (fun _ => Nat)
     (fun _ _ => trivial) (fun _ _ => trivial)
     (fun _ _ _ => 0) (fun _ ih => ih + 1)
     (fun _ _ => 0) (fun n _ => n) (fun _ _ ihb ihc => ihb + ihc)
+
+def depthC : C → Nat :=
+  @C.mutualRec (fun _ => True) (fun _ => Nat) (fun _ => Nat)
+    (fun _ _ => trivial) (fun _ _ => trivial)
+    (fun _ _ _ => 0) (fun _ ih => ih + 1)
+    (fun _ _ => 0) (fun n _ => n) (fun _ _ ihb ihc => ihb + ihc)
+
+example : depth (B.wrap (B.wrap (B.fromA 5 (A.fromC (C.higherUniv 3 Nat))))) = 2 := rfl
+
+/-- info: 2 -/
+#guard_msgs in
+#eval depth (B.wrap (B.wrap (B.fromA 5 (A.fromC (C.higherUniv 3 Nat)))))
+
+-- `C.pair` folds a `Type 0` value into a `Type 2` recursion, so this crosses
+-- both the `Prop` member and the two data universes
+example : depthC (C.pair (B.wrap (B.fromA 4 (A.fromC (C.higherUniv 1 Nat))))
+    (C.higherUniv 10 Nat)) = 11 := rfl
+
+/-- info: 11 -/
+#guard_msgs in
+#eval depthC (C.pair (B.wrap (B.fromA 4 (A.fromC (C.higherUniv 1 Nat)))) (C.higherUniv 10 Nat))
+
+-- the companion is compiler-only, so it changes nothing about the term
+/-- info: 'depth' does not depend on any axioms -/
+#guard_msgs in
+#print axioms depth

--- a/tests/elab/mutualMultiuniverseErrors.lean
+++ b/tests/elab/mutualMultiuniverseErrors.lean
@@ -74,3 +74,21 @@ inductive U1 : Prop where
 inductive U2 : Type 0 where
   | mk : (t : Type 1) → U1 → U2
 end
+
+/-! ## A large-eliminating `Prop` is reported the way `mutual` reports it
+
+`mutualRec` is computable wherever the block has data to compute with.  A
+block that is all `Prop` has none, so a large-eliminating member's `mutualRec`
+is `noncomputable`, exactly as that member's own `rec` is -- and says so
+rather than failing inside the code generator. -/
+
+mutual_multiuniverse
+inductive Sq : Prop where
+  | mk : Sq
+end
+
+/--
+error: failed to compile definition, consider marking it as 'noncomputable' because it depends on 'Sq.mutualRec', which is 'noncomputable'
+-/
+#guard_msgs in
+def sqNat : Sq → Nat := fun s => Sq.mutualRec (motive := fun _ => Nat) 5 s

--- a/tests/elab/mutualMultiuniverseErrors.lean
+++ b/tests/elab/mutualMultiuniverseErrors.lean
@@ -92,3 +92,67 @@ error: failed to compile definition, consider marking it as 'noncomputable' beca
 -/
 #guard_msgs in
 def sqNat : Sq → Nat := fun s => Sq.mutualRec (motive := fun _ => Nat) 5 s
+
+/-! ## A member whose `Prop`-ness depends on a universe parameter
+
+Whether a member is `Prop` decides whether it becomes a shadow or an honest
+inductive, so it has to be decidable from the declaration.  A member at `Sort u`
+or `Sort (imax u v)` is `Prop` for some instantiations and not for others, and
+is refused upstream before the lowering runs.  Contrast a *field* at
+`Sort (imax _ _)`, which is fine -- see `mutualMultiuniverseFeatures`. -/
+
+universe u v
+
+/--
+error: Invalid universe polymorphic resulting type: The resulting universe is not `Prop`, but it may be `Prop` for some parameter values:
+  Sort u
+
+Hint: A possible solution is to use levels of the form `max 1 _` or `_ + 1` to ensure the universe is of the form `Type _`
+-/
+#guard_msgs in
+mutual_multiuniverse
+inductive EA : Prop where
+  | mk : EB → EA
+inductive EB : Sort u where
+  | leaf : Nat → EB
+  | fromA : EA → EB
+end
+
+/--
+error: Invalid universe polymorphic resulting type: The resulting universe is not `Prop`, but it may be `Prop` for some parameter values:
+  Sort (imax u v)
+
+Hint: A possible solution is to use levels of the form `max 1 _` or `_ + 1` to ensure the universe is of the form `Type _`
+-/
+#guard_msgs in
+mutual_multiuniverse
+inductive FA (α : Type u) (P : α → Sort v) : Prop where
+  | mk : FB α P → FA α P
+inductive FB (α : Type u) (P : α → Sort v) : Sort (imax u v) where
+  | fn : ((a : α) → P a) → FB α P
+  | back : FA α P → FB α P
+end
+
+/-! ## Two data members of one component at different universes
+
+They hold each other, so each universe would have to be at most the other; only
+the first direction gets as far as being reported. -/
+
+/--
+error: Invalid universe level in constructor `GB.toC`: Parameter has type
+  GC
+at universe level
+  v + 1
+which is not less than or equal to the inductive type's resulting universe level
+  u + 1
+-/
+#guard_msgs in
+mutual_multiuniverse
+inductive GA : Prop where
+  | mk : GB → GA
+inductive GB : Type u where
+  | leaf : Nat → GB
+  | toC : GC → GB
+inductive GC : Type v where
+  | fromB : GB → GC
+end

--- a/tests/elab/mutualMultiuniverseErrors.lean
+++ b/tests/elab/mutualMultiuniverseErrors.lean
@@ -1,0 +1,76 @@
+/-!
+# `mutual_multiuniverse`: blocks the lowering must refuse
+
+Each block below must produce an error rather than a silently wrong
+translation, so the messages are pinned.
+-/
+
+/-! ## A nested occurrence of a block member
+
+`List N2` is not a field the shadow can reconstruct: the shadow's `N2` carries
+no data, so there is nothing to squash a `List N2` into elementwise without
+lowering `List` itself. -/
+
+/--
+error: Unsupported constructor field in `mutual_multiuniverse` block: field 1 of `N1.mk` mentions a member of the block in a nested position, in the type
+  List N2
+
+Note: Nested occurrences are not supported: the shadow of a data member carries no data, so there is nothing to rebuild such a field from without lowering the surrounding type as well
+-/
+#guard_msgs in
+mutual_multiuniverse
+inductive N1 : Prop where
+  | mk : List N2 → N1
+inductive N2 : Type where
+  | mk : N1 → N2
+end
+
+/-! ## A member occurring in the *domain* of a field
+
+`(N4 → Nat) → N3` is not strictly positive; `mutual` rejects it too, but the
+lowering has to say so before the kernel gets a chance. -/
+
+/--
+error: Unsupported constructor field in `mutual_multiuniverse` block: field 1 of `N3.mk` takes an argument whose type mentions a member of the block
+
+Note: This is not a strictly positive occurrence, so the lowering has nothing to translate it to
+-/
+#guard_msgs in
+mutual_multiuniverse
+inductive N3 : Prop where
+  | mk : (N4 → Nat) → N3
+inductive N4 : Type where
+  | mk : N3 → N4
+end
+
+/-! ## Only `inductive` declarations are allowed -/
+
+/--
+error: invalid `mutual_multiuniverse` block: every element of the block must be an `inductive` declaration
+-/
+#guard_msgs in
+mutual_multiuniverse
+inductive S1 : Prop where
+  | mk : S2 → S1
+structure S2 : Type 1 where
+  fld : Type
+end
+
+/-! ## A field that does not fit its own member's universe is still an error;
+the check is just made per member rather than for the block as a whole. -/
+
+/--
+error: Invalid universe level in constructor `U2.mk`: Parameter `t` has type
+  Type 1
+at universe level
+  3
+which is not less than or equal to the inductive type's resulting universe level
+  1
+-/
+#guard_msgs in
+mutual_multiuniverse
+inductive U1 : Prop where
+  | mk : U2 → U1
+inductive U2 : Type 0 where
+  | mk : (t : Type 1) → U1 → U2
+end

--- a/tests/elab/mutualMultiuniverseFeatures.lean
+++ b/tests/elab/mutualMultiuniverseFeatures.lean
@@ -87,7 +87,9 @@ example : odPayload 3 three = 9 := rfl
 
 This is the one shape that needs a choice principle: to recurse into a
 `Nat → Stream'` field from a `Prop`, the witnesses have to be selected
-pointwise. -/
+pointwise.  It is the field's type that matters, not which member carries it --
+a `Prop` member's recursor goes through the shadow of the whole block, so an
+infinitary field on a *data* member does it too. -/
 
 mutual_multiuniverse
 inductive Total : Prop where
@@ -357,6 +359,71 @@ def uTag' {α : Type u} : UD α → Nat :=
 #guard_msgs in
 #eval uTag' (UD.back (UP.mk (UD.val (3 : Nat) Nat)))
 
+/-! ## What makes the recursors computable
+
+The code generator compiles no recursor application, so each data member's
+`X.mutualRec` is paired with an implementation that does the same recursion by
+cases, and a `@[csimp]` theorem relating the two.  Both are ordinary
+declarations under predictable names; the theorem is proved rather than
+asserted, and the implementation is checked to terminate by Lean's own
+structural recursion.
+
+`CD.branch` also makes this the case where a *data* member recurses under a
+binder, so the implementation has to as well. -/
+
+mutual_multiuniverse
+inductive CP : Prop where
+  | mk : CD → CP
+inductive CD : Type 0 where
+  | leaf : Nat → CD
+  | branch : (Nat → CD) → CD
+end
+
+/-- info: CD.mutualRec.eq_impl : @CD.mutualRec = @CD.mutualRec.impl -/
+#guard_msgs in
+#check @CD.mutualRec.eq_impl
+
+-- `CD.branch` is infinitary, so the `Prop` member's recursor selects witnesses
+-- pointwise as above -- but the data member's recursor never touches the
+-- shadow, and neither does the implementation
+/-- info: 'CP.mutualRec' depends on axioms: [Classical.choice] -/
+#guard_msgs in
+#print axioms CP.mutualRec
+
+/-- info: 'CD.mutualRec' does not depend on any axioms -/
+#guard_msgs in
+#print axioms CD.mutualRec
+
+-- `funext` is all the proof needs, and it stays inside the theorem
+/-- info: 'CD.mutualRec.eq_impl' depends on axioms: [Quot.sound] -/
+#guard_msgs in
+#print axioms CD.mutualRec.eq_impl
+
+/-- info: 'CD.mutualRec.impl' does not depend on any axioms -/
+#guard_msgs in
+#print axioms CD.mutualRec.impl
+
+def cdSum : CD → Nat :=
+  @CD.mutualRec (fun _ => True) (fun _ => Nat)
+    (fun _ _ => trivial)
+    (fun n => n) (fun _ ih => ih 3)
+
+example : cdSum (CD.branch fun n => CD.leaf (n * 2)) = 6 := rfl
+
+/-- info: 6 -/
+#guard_msgs in
+#eval cdSum (CD.branch fun n => CD.leaf (n * 2))
+
+-- two levels of `branch`, so the implementation recurses under a binder twice
+/-- info: 33 -/
+#guard_msgs in
+#eval cdSum (CD.branch fun n => CD.branch fun m => CD.leaf (n * 10 + m))
+
+-- neither the implementation nor its theorem reaches the term
+/-- info: 'cdSum' does not depend on any axioms -/
+#guard_msgs in
+#print axioms cdSum
+
 /-! ## A homogeneous block is an ordinary `mutual` block
 
 `mutual_multiuniverse` accepts everything `mutual` does and means the same
@@ -377,8 +444,8 @@ example : @T1.mutualRec = @T1.rec := rfl
 #guard_msgs in
 #print axioms T1.rec
 
--- the alias still gets a compiled companion, so `mutualRec` is computable here
--- as well, even though the recursor it unfolds to is not
+-- the alias still gets an implementation and a `@[csimp]` theorem, so `mutualRec`
+-- is computable here as well, even though the recursor it unfolds to is not
 def t1Depth : T1 → Nat :=
   @T1.mutualRec (fun _ => Nat) (fun _ => Nat)
     (fun _ ih => ih + 1) (fun _ ih => ih + 1) 0
@@ -389,11 +456,48 @@ example : t1Depth (T1.mk (T2.mk (T1.mk T2.stop))) = 3 := rfl
 #guard_msgs in
 #eval t1Depth (T1.mk (T2.mk (T1.mk T2.stop)))
 
+/-! A homogeneous block can still fall into several components: `U` mentions
+`V`, but not the other way round.  The implementations follow the components
+rather than the block, so `U.mutualRec.impl` does not recurse into `V` itself --
+it calls `V.mutualRec`, and `V`'s own `@[csimp]` theorem, already registered by
+then, is what puts the code there. -/
+
+mutual_multiuniverse
+inductive V1 : Type where
+  | nil : V1
+  | wrap : V1 → V1
+inductive U1 : Type where
+  | mk : V1 → U1
+  | more : U1 → U1
+end
+
+/-- info: U1.mutualRec.eq_impl : @U1.mutualRec = @U1.mutualRec.impl -/
+#guard_msgs in
+#check @U1.mutualRec.eq_impl
+
+/-- info: V1.mutualRec.eq_impl : @V1.mutualRec = @V1.mutualRec.impl -/
+#guard_msgs in
+#check @V1.mutualRec.eq_impl
+
+def u1Len : U1 → Nat :=
+  @U1.mutualRec (fun _ => Nat) (fun _ => Nat) 0 (fun _ ih => ih + 1) (fun _ ih => ih)
+    (fun _ ih => ih + 100)
+
+example : u1Len (U1.more (U1.mk (V1.wrap (V1.wrap V1.nil)))) = 102 := rfl
+
+/-- info: 102 -/
+#guard_msgs in
+#eval u1Len (U1.more (U1.mk (V1.wrap (V1.wrap V1.nil))))
+
+/-- info: 'u1Len' does not depend on any axioms -/
+#guard_msgs in
+#print axioms u1Len
+
 /-! ## An all-`Prop` homogeneous block
 
-There is nothing to compute here, so no companion is emitted: the recursors are
-proofs and are erased.  Such a block still has to come out of the native path in
-one piece. -/
+There is nothing to compute here, so no implementation is emitted: the recursors
+are proofs and are erased.  Such a block still has to come out of the native
+path in one piece. -/
 
 mutual_multiuniverse
 inductive PEven : Nat → Prop where

--- a/tests/elab/mutualMultiuniverseFeatures.lean
+++ b/tests/elab/mutualMultiuniverseFeatures.lean
@@ -26,6 +26,15 @@ def boxTag {α : Type} : Box α → Nat
 #guard_msgs in
 #eval boxTag (Box.back (Wrap.mk (Box.val 3 Nat)))
 
+-- the same thing through the block-wide recursor, which is computable too
+def boxTag' {α : Type} : Box α → Nat :=
+  @Box.mutualRec α (fun _ => True) (fun _ => Nat)
+    (fun _ _ => trivial) (fun _ _ => 0) (fun _ _ => 1)
+
+/-- info: 1 -/
+#guard_msgs in
+#eval boxTag' (Box.back (Wrap.mk (Box.val 3 Nat)))
+
 /-! ## Indices, with the data member carrying data
 
 `Ev n` says `n` is even; `Od n` is a *datum* attached to an odd `n`.  The two
@@ -61,6 +70,19 @@ example (n : Nat) (e : Ev n) (k : Nat)
     @Od.mutualRec mE mO cz cs co (n + 1) (Od.succ n e k)
       = co n e k (@Ev.mutualRec mE mO cz cs co n e) := rfl
 
+-- and it is computable, indices and all.  Only one level of payload is
+-- reachable: the recursion into `Od` goes through `Ev`, whose motive is a
+-- `Prop`, so there is nothing to accumulate -- which is the whole point.
+def odPayload : (n : Nat) → Od n → Nat :=
+  @Od.mutualRec (fun _ _ => True) (fun _ _ => Nat)
+    trivial (fun _ _ _ => trivial) (fun _ _ k _ => k)
+
+example : odPayload 3 three = 9 := rfl
+
+/-- info: 9 -/
+#guard_msgs in
+#eval odPayload 3 three
+
 /-! ## A function *into* a data member
 
 This is the one shape that needs a choice principle: to recurse into a
@@ -90,6 +112,19 @@ end
 /-- info: 'Stream'.rec' does not depend on any axioms -/
 #guard_msgs in
 #print axioms Stream'.rec
+
+-- depending on `Classical.choice` and being computable are not in conflict
+-- here: the choice happens under a `Prop`, so it has no computational content
+-- and the compiled code never reaches it
+def sLen : Stream' → Nat :=
+  @Stream'.mutualRec (fun _ => True) (fun _ => Nat)
+    (fun _ _ => trivial) (fun _ _ ih => ih + 1) 0 (fun _ _ => 0)
+
+example : sLen (Stream'.cons Nat (Stream'.cons Bool Stream'.nil)) = 2 := rfl
+
+/-- info: 2 -/
+#guard_msgs in
+#eval sLen (Stream'.cons Nat (Stream'.cons Bool Stream'.nil))
 
 /-! ## No `Prop` member at all
 
@@ -251,6 +286,31 @@ end
 #guard_msgs in
 #eval gxSize (GX.mk (GY.mk (GX.leaf 5)))
 
+-- so does the block-wide recursor, both within the component and across it
+def gxDepth : GX → Nat :=
+  @GX.mutualRec (fun _ => True) (fun _ => Nat) (fun _ => Nat) (fun _ => Nat)
+    (fun _ _ => trivial) (fun _ _ => trivial)
+    (fun _ ih => ih + 1) (fun n => n)
+    (fun _ ih => ih + 1) (fun _ _ => 0)
+    (fun _ _ _ ihx ihy => ihx + ihy)
+
+def gzSize : GZ → Nat :=
+  @GZ.mutualRec (fun _ => True) (fun _ => Nat) (fun _ => Nat) (fun _ => Nat)
+    (fun _ _ => trivial) (fun _ _ => trivial)
+    (fun _ ih => ih + 1) (fun n => n)
+    (fun _ ih => ih + 1) (fun _ _ => 0)
+    (fun _ _ _ ihx ihy => ihx + ihy)
+
+example : gxDepth (GX.mk (GY.mk (GX.leaf 5))) = 7 := rfl
+
+/-- info: 7 -/
+#guard_msgs in
+#eval gxDepth (GX.mk (GY.mk (GX.leaf 5)))
+
+/-- info: 7 -/
+#guard_msgs in
+#eval gzSize (GZ.mk (GX.mk (GY.mk (GX.leaf 5))) (GY.fromP (GP.fromX (GX.leaf 2))) (Type 0))
+
 /-! ## Universe polymorphism -/
 
 mutual_multiuniverse
@@ -289,6 +349,14 @@ def uTag {α : Type u} : UD α → Nat
 #guard_msgs in
 #eval uTag (UD.val (3 : Nat) Nat)
 
+def uTag' {α : Type u} : UD α → Nat :=
+  @UD.mutualRec α (fun _ => True) (fun _ => Nat)
+    (fun _ _ => trivial) (fun _ _ => 0) (fun _ _ => 1)
+
+/-- info: 1 -/
+#guard_msgs in
+#eval uTag' (UD.back (UP.mk (UD.val (3 : Nat) Nat)))
+
 /-! ## A homogeneous block is an ordinary `mutual` block
 
 `mutual_multiuniverse` accepts everything `mutual` does and means the same
@@ -308,3 +376,46 @@ example : @T1.mutualRec = @T1.rec := rfl
 /-- info: 'T1.rec' does not depend on any axioms -/
 #guard_msgs in
 #print axioms T1.rec
+
+-- the alias still gets a compiled companion, so `mutualRec` is computable here
+-- as well, even though the recursor it unfolds to is not
+def t1Depth : T1 → Nat :=
+  @T1.mutualRec (fun _ => Nat) (fun _ => Nat)
+    (fun _ ih => ih + 1) (fun _ ih => ih + 1) 0
+
+example : t1Depth (T1.mk (T2.mk (T1.mk T2.stop))) = 3 := rfl
+
+/-- info: 3 -/
+#guard_msgs in
+#eval t1Depth (T1.mk (T2.mk (T1.mk T2.stop)))
+
+/-! ## An all-`Prop` homogeneous block
+
+There is nothing to compute here, so no companion is emitted: the recursors are
+proofs and are erased.  Such a block still has to come out of the native path in
+one piece. -/
+
+mutual_multiuniverse
+inductive PEven : Nat → Prop where
+  | zero : PEven 0
+  | succ : (n : Nat) → POdd n → PEven (n + 1)
+inductive POdd : Nat → Prop where
+  | succ : (n : Nat) → PEven n → POdd (n + 1)
+end
+
+example : @PEven.mutualRec = @PEven.rec := rfl
+
+example : POdd 3 := .succ 2 (.succ 1 (.succ 0 .zero))
+
+theorem POdd.ne_zero : ∀ n, POdd n → n ≠ 0 :=
+  @POdd.mutualRec (fun _ _ => True) (fun n _ => n ≠ 0)
+    trivial (fun _ _ _ => trivial) (fun n _ _ => Nat.succ_ne_zero n)
+
+-- `propext` comes from `Nat.succ_ne_zero`, not from the block
+/-- info: 'POdd.ne_zero' depends on axioms: [propext] -/
+#guard_msgs in
+#print axioms POdd.ne_zero
+
+/-- info: 'POdd.mutualRec' does not depend on any axioms -/
+#guard_msgs in
+#print axioms POdd.mutualRec

--- a/tests/elab/mutualMultiuniverseFeatures.lean
+++ b/tests/elab/mutualMultiuniverseFeatures.lean
@@ -315,6 +315,8 @@ example : gxDepth (GX.mk (GY.mk (GX.leaf 5))) = 7 := rfl
 
 /-! ## Universe polymorphism -/
 
+/-! ### A parameter and its universe -/
+
 mutual_multiuniverse
 inductive UP (α : Type u) : Prop where
   | mk : UD α → UP α
@@ -358,6 +360,246 @@ def uTag' {α : Type u} : UD α → Nat :=
 /-- info: 1 -/
 #guard_msgs in
 #eval uTag' (UD.back (UP.mk (UD.val (3 : Nat) Nat)))
+
+section
+universe u v w
+
+/-! ### Three universes at once
+
+`Prop`, `Type u` and `Type (u + 1)`, all mutually referring to each other. The
+universes have to be declared up front: with auto-bound implicits each member
+gets its own level parameter, and a block whose members disagree about their
+level parameters is rejected before we ever see it. -/
+
+mutual_multiuniverse
+inductive PA : Prop where
+  | fromB : PB → PA
+  | fromC : PC → PA
+inductive PB : Type u where
+  | leaf : Nat → PB
+  | fromA : PA → PB
+  | wrap : PB → PB
+inductive PC : Type (u + 1) where
+  | fromA : PA → PC
+  | higher : Type u → PC
+  | pair : PB → PC → PC
+end
+
+/-- info: PC.{u} : Type (u + 1) -/
+#guard_msgs in
+#check PC
+
+section
+variable {mA : PA.{u} → Prop} {mB : PB.{u} → Sort w} {mC : PC.{u} → Sort v}
+  (fAB : (b : PB) → mB b → mA (PA.fromB b))
+  (fAC : (c : PC) → mC c → mA (PA.fromC c))
+  (fBl : (n : Nat) → mB (PB.leaf n))
+  (fBa : (a : PA) → mA a → mB (PB.fromA a))
+  (fBw : (b : PB) → mB b → mB (PB.wrap b))
+  (fCa : (a : PA) → mA a → mC (PC.fromA a))
+  (fCh : (t : Type u) → mC (PC.higher t))
+  (fCp : (b : PB) → (c : PC) → mB b → mC c → mC (PC.pair b c))
+
+-- the iota rule holds at a *variable* universe, not just at instantiations of it
+example (b : PB.{u}) (c : PC.{u}) :
+    @PC.mutualRec mA mB mC fAB fAC fBl fBa fBw fCa fCh fCp (PC.pair b c)
+      = fCp b c (@PB.mutualRec mA mB mC fAB fAC fBl fBa fBw fCa fCh fCp b)
+               (@PC.mutualRec mA mB mC fAB fAC fBl fBa fBw fCa fCh fCp c) := rfl
+end
+
+def cDepth : PC.{u} → Nat :=
+  @PC.mutualRec (fun _ => True) (fun _ => Nat) (fun _ => Nat)
+    (fun _ _ => trivial) (fun _ _ => trivial)
+    (fun n => n) (fun _ _ => 0) (fun _ ih => ih + 1)
+    (fun _ _ => 0) (fun _ => 0) (fun _ _ ihb ihc => ihb + ihc)
+
+-- a universe-polymorphic definition has to be instantiated to be evaluated
+/-- info: 5 -/
+#guard_msgs in
+#eval cDepth.{0} (PC.pair (PB.wrap (PB.leaf 4)) (PC.fromA (PA.fromB (PB.leaf 3))))
+
+/-- info: 5 -/
+#guard_msgs in
+#eval cDepth.{3} (PC.pair (PB.wrap (PB.leaf 4)) (PC.fromA (PA.fromB (PB.leaf 3))))
+
+/-- info: 'cDepth' does not depend on any axioms -/
+#guard_msgs in
+#print axioms cDepth
+
+/-! ### The `csimp` pair is polymorphic too
+
+`isConstantReplacement?` insists that the two sides of the equation be bare
+constants with the same level parameters, so the theorem is stated about the
+whole polymorphic family rather than an instantiation of it. -/
+
+/-- info: PB.mutualRec.eq_impl : @PB.mutualRec = @PB.mutualRec.impl -/
+#guard_msgs in
+#check @PB.mutualRec.eq_impl
+
+/-- info: 'PB.mutualRec.impl' does not depend on any axioms -/
+#guard_msgs in
+#print axioms PB.mutualRec.impl
+
+/-! ### `imax` in a field
+
+A dependent function `(a : α) → P a` lives at `Sort (imax (u+1) v)`, which is
+`Prop` when `v` is. That is fine here: it is the *member's* universe that has to
+be decidably `Prop`-or-not, and `IB` is declared at `Type (max u v)`. A member
+declared at `Sort (imax u v)` is rejected -- see `mutualMultiuniverseErrors`. -/
+
+mutual_multiuniverse
+inductive IA (α : Type u) (P : α → Sort v) : Prop where
+  | mk : IB α P → IA α P
+inductive IB (α : Type u) (P : α → Sort v) : Type (max u v) where
+  | fn : ((a : α) → P a) → IB α P
+  | back : IA α P → IB α P
+  | tag : Nat → IB α P
+end
+
+/-- info: IB.{u, v} (α : Type u) (P : α → Sort v) : Type (max u v) -/
+#guard_msgs in
+#check IB
+
+def iTag {α : Type u} {P : α → Sort v} : IB α P → Nat :=
+  @IB.mutualRec α P (fun _ => True) (fun _ => Nat)
+    (fun _ _ => trivial) (fun _ => 0) (fun _ _ => 1) (fun n => n)
+
+/-- info: 7 -/
+#guard_msgs in
+#eval iTag.{0, 0} (α := Nat) (P := fun _ => True) (IB.tag 7)
+
+-- the dependent-function constructor, at a `Prop`-valued `P`, so the `imax`
+-- collapses to `0` and the field is erased
+/-- info: 0 -/
+#guard_msgs in
+#eval iTag.{0, 0} (α := Nat) (P := fun _ => True) (IB.fn fun _ => trivial)
+
+-- and at a `Type`-valued `P`, so it does not
+/-- info: 0 -/
+#guard_msgs in
+#eval iTag.{0, 1} (α := Nat) (P := fun _ => Nat) (IB.fn fun n => n)
+
+/-- info: 'iTag' does not depend on any axioms -/
+#guard_msgs in
+#print axioms iTag
+
+/-! ### Three universe parameters, used unevenly
+
+`MB` uses only `u` and `MC` uses all three. They are in different components of
+the data-only dependency graph, which is what lets them sit at different
+universes. Note that a field of type `Type v` needs the member at `v + 1`, not
+at `v`. -/
+
+mutual_multiuniverse
+inductive MA : Prop where
+  | fromB : MB → MA
+  | fromC : MC → MA
+inductive MB : Type u where
+  | leaf : Nat → MB
+  | fromA : MA → MB
+inductive MC : Type (max u (max (v + 1) (w + 1))) where
+  | fromB : MB → MC
+  | big : Type v → Type w → MC
+end
+
+/-- info: MC.{u, v, w} : Type (max u (v + 1) (w + 1)) -/
+#guard_msgs in
+#check MC
+
+def mTag : MC.{u, v, w} → Nat :=
+  @MC.mutualRec (fun _ => True) (fun _ => Nat) (fun _ => Nat)
+    (fun _ _ => trivial) (fun _ _ => trivial)
+    (fun n => n) (fun _ _ => 0) (fun _ ih => ih + 1) (fun _ _ => 0)
+
+/-- info: 5 -/
+#guard_msgs in
+#eval mTag.{0, 0, 0} (MC.fromB (MB.leaf 4))
+
+/-! ### Members of one data component share a universe
+
+`KB` and `KC` hold each other, so each one's universe has to be at least the
+other's -- they have to be equal. That still leaves them polymorphic, it just
+means one variable does for both. -/
+
+mutual_multiuniverse
+inductive KA : Prop where
+  | mk : KB → KA
+inductive KB : Type u where
+  | leaf : Nat → KB
+  | toC : KC → KB
+inductive KC : Type u where
+  | fromB : KB → KC
+  | fromA : KA → KC
+end
+
+def kTag : KB.{u} → Nat :=
+  @KB.mutualRec (fun _ => True) (fun _ => Nat) (fun _ => Nat)
+    (fun _ _ => trivial) (fun n => n) (fun _ ih => ih + 1)
+    (fun _ ih => ih + 1) (fun _ _ => 0)
+
+/-- info: 8 -/
+#guard_msgs in
+#eval kTag.{0} (KB.toC (KC.fromB (KB.leaf 6)))
+
+/-! ### `Sort (max 1 u)`
+
+Not syntactically `Type _`, but never `Prop` either, so it is a data member. -/
+
+mutual_multiuniverse
+inductive SA : Prop where
+  | mk : SB → SA
+inductive SB : Sort (max 1 u) where
+  | leaf : Nat → SB
+  | fromA : SA → SB
+end
+
+/-- info: SB.{u} : Sort (max 1 u) -/
+#guard_msgs in
+#check SB
+
+def sbTag : SB.{u} → Nat :=
+  @SB.mutualRec (fun _ => True) (fun _ => Nat) (fun _ _ => trivial)
+    (fun n => n) (fun _ _ => 0)
+
+/-- info: 4 -/
+#guard_msgs in
+#eval sbTag.{0} (SB.leaf 4)
+
+/-! ### Indices and universe polymorphism together -/
+
+mutual_multiuniverse
+inductive XEv : Nat → Prop where
+  | zero : XEv 0
+  | succ : (n : Nat) → XOd n → XEv (n + 1)
+inductive XOd : Nat → Type u where
+  | one : XOd 1
+  | succ : (n : Nat) → XEv (n + 1) → XOd n → Nat → XOd (n + 2)
+end
+
+/-- info: XOd.{u} : Nat → Type u -/
+#guard_msgs in
+#check XOd
+
+def xSum : (n : Nat) → XOd.{u} n → Nat :=
+  fun n t => @XOd.mutualRec (fun _ _ => True) (fun _ _ => Nat)
+    trivial (fun _ _ _ => trivial) 0 (fun _ _ _ k _ ih => ih + k) n t
+
+/-- info: 10 -/
+#guard_msgs in
+#eval xSum.{0} 5 (.succ 3 (.succ 3 (.succ 1 (.succ 1 .one) .one 4)) (.succ 1 (.succ 1 .one) .one 4) 6)
+
+/-! ### Small elimination at a variable universe
+
+Universes are derived per member, elimination is not: the motives may all land
+in `Prop` whatever `u` is. -/
+
+example (b : PB.{u}) : True :=
+  @PB.mutualRec (fun _ => True) (fun _ => True) (fun _ => True)
+    (fun _ _ => trivial) (fun _ _ => trivial)
+    (fun _ => trivial) (fun _ _ => trivial) (fun _ _ => trivial)
+    (fun _ _ => trivial) (fun _ => trivial) (fun _ _ _ _ => trivial) b
+
+end
 
 /-! ## What makes the recursors computable
 

--- a/tests/elab/mutualMultiuniverseFeatures.lean
+++ b/tests/elab/mutualMultiuniverseFeatures.lean
@@ -1,0 +1,310 @@
+/-!
+# `mutual_multiuniverse`: parameters, indices, choice, and the degenerate cases
+-/
+
+/-! ## Parameters -/
+
+mutual_multiuniverse
+inductive Wrap (α : Type) : Prop where
+  | mk : Box α → Wrap α
+inductive Box (α : Type) : Type 1 where
+  | val : α → Type → Box α
+  | back : Wrap α → Box α
+end
+
+/-- info: 'Wrap.rec' does not depend on any axioms -/
+#guard_msgs in
+#print axioms Wrap.rec
+
+example (α : Type) (b : Box α) : Wrap α := Wrap.mk b
+
+def boxTag {α : Type} : Box α → Nat
+  | .val _ _ => 0
+  | .back _ => 1
+
+/-- info: 1 -/
+#guard_msgs in
+#eval boxTag (Box.back (Wrap.mk (Box.val 3 Nat)))
+
+/-! ## Indices, with the data member carrying data
+
+`Ev n` says `n` is even; `Od n` is a *datum* attached to an odd `n`.  The two
+are genuinely mutually recursive and genuinely at different universes. -/
+
+mutual_multiuniverse
+inductive Ev : Nat → Prop where
+  | zero : Ev 0
+  | succ : (n : Nat) → Od n → Ev (n + 1)
+inductive Od : Nat → Type 0 where
+  | succ : (n : Nat) → Ev n → Nat → Od (n + 1)
+end
+
+/-- info: 'Od.mutualRec' does not depend on any axioms -/
+#guard_msgs in
+#print axioms Od.mutualRec
+
+def three : Od 3 := Od.succ 2 (Ev.succ 1 (Od.succ 0 Ev.zero 7)) 9
+
+def payload : {n : Nat} → Od n → Nat
+  | _, .succ _ _ k => k
+
+/-- info: 9 -/
+#guard_msgs in
+#eval payload three
+
+-- iota for the indexed data member
+example (n : Nat) (e : Ev n) (k : Nat)
+    {mE : (n : Nat) → Ev n → Prop} {mO : (n : Nat) → Od n → Sort u}
+    (cz : mE 0 Ev.zero)
+    (cs : (n : Nat) → (o : Od n) → mO n o → mE (n + 1) (Ev.succ n o))
+    (co : (n : Nat) → (e : Ev n) → (k : Nat) → mE n e → mO (n + 1) (Od.succ n e k)) :
+    @Od.mutualRec mE mO cz cs co (n + 1) (Od.succ n e k)
+      = co n e k (@Ev.mutualRec mE mO cz cs co n e) := rfl
+
+/-! ## A function *into* a data member
+
+This is the one shape that needs a choice principle: to recurse into a
+`Nat → Stream'` field from a `Prop`, the witnesses have to be selected
+pointwise. -/
+
+mutual_multiuniverse
+inductive Total : Prop where
+  | mk : (Nat → Stream') → Total
+inductive Stream' : Type 1 where
+  | cons : Type → Stream' → Stream'
+  | nil : Stream'
+  | fromTotal : Total → Stream'
+end
+
+/-- info: 'Total.rec' depends on axioms: [Classical.choice] -/
+#guard_msgs in
+#print axioms Total.rec
+
+-- and `Stream'.mutualRec` inherits it, since the induction hypothesis for
+-- `Stream'.fromTotal`'s field *is* `Total.mutualRec`
+/-- info: 'Stream'.mutualRec' depends on axioms: [Classical.choice] -/
+#guard_msgs in
+#print axioms Stream'.mutualRec
+
+-- the native recursor is unaffected: it does not recurse into `Total` at all
+/-- info: 'Stream'.rec' does not depend on any axioms -/
+#guard_msgs in
+#print axioms Stream'.rec
+
+/-! ## No `Prop` member at all
+
+Two data members at different universes, with only one direction of dependency
+("unnecessarily mutual").  No shadow is built and no choice is needed. -/
+
+mutual_multiuniverse
+inductive Low : Type 0 where
+  | z : Low
+  | s : Low → Low
+inductive High : Type 3 where
+  | mk : Low → Type 2 → High
+  | nest : High → High
+end
+
+/-- info: 'High.mutualRec' does not depend on any axioms -/
+#guard_msgs in
+#print axioms High.mutualRec
+
+def lowSize : Low → Nat
+  | .z => 0
+  | .s l => lowSize l + 1
+
+/-- info: 2 -/
+#guard_msgs in
+#eval lowSize (Low.s (Low.s Low.z))
+
+example (l : Low) (t : Type 2)
+    {mL : Low → Sort u} {mH : High → Sort v}
+    (cz : mL Low.z) (cs : (l : Low) → mL l → mL l.s)
+    (cm : (l : Low) → (t : Type 2) → mL l → mH (High.mk l t))
+    (cn : (h : High) → mH h → mH h.nest) :
+    @High.mutualRec mL mH cz cs cm cn (High.mk l t)
+      = cm l t (@Low.mutualRec mL mH cz cs cm cn l) := rfl
+
+/-! ## Section variables and `deriving`
+
+A section `variable` used by any member becomes a parameter of the whole block,
+exactly as under `mutual`.  A member's free variable stands for the member
+*already applied* to those variables, so the lowering substitutes for it under
+the parameter telescope. -/
+
+section
+variable (α : Type)
+
+mutual_multiuniverse
+inductive SWrap : Prop where
+  | mk : SBox → SWrap
+inductive SBox : Type 1 where
+  | val : α → Type → SBox
+  | back : SWrap → SBox
+end
+
+end
+
+/-- info: SWrap : Type → Prop -/
+#guard_msgs in
+#check @SWrap
+
+/-- info: @SBox.val : {α : Type} → α → Type → SBox α -/
+#guard_msgs in
+#check @SBox.val
+
+/--
+info: @SWrap.mutualRec : ∀ {α : Type} {motive_1 : SWrap α → Prop} {motive_2 : SBox α → Sort u_1},
+  (∀ (a : SBox α) (ih_1 : motive_2 a), motive_1 (SWrap.mk a)) →
+    ∀ (case_2 : (a : α) → (a_1 : Type) → motive_2 (SBox.val a a_1))
+      (case_3 : (a : SWrap α) → motive_1 a → motive_2 (SBox.back a)) (t : SWrap α), motive_1 t
+-/
+#guard_msgs in
+set_option pp.proofs true in
+#check @SWrap.mutualRec
+
+/-- info: 'SWrap.mutualRec' does not depend on any axioms -/
+#guard_msgs in
+#print axioms SWrap.mutualRec
+
+def sTag {α : Type} : SBox α → Nat
+  | .val _ _ => 0
+  | .back _ => 1
+
+/-- info: 1 -/
+#guard_msgs in
+#eval sTag (SBox.back (SWrap.mk (SBox.val (3 : Nat) Nat)))
+
+-- a `deriving` clause on a data member is honoured, since the data members are
+-- ordinary inductive types by the time the handlers run
+mutual_multiuniverse
+inductive DP : Prop where
+  | mk : DD → DP
+inductive DD : Type 1 where
+  | z
+  | s : DD → DD
+  deriving Repr
+end
+
+/-- info: DD.s (DD.z) -/
+#guard_msgs in
+#eval repr (DD.s DD.z)
+
+/-! ## A genuine cycle among the data members
+
+`GX` and `GY` are mutually recursive at the same universe, so they form one
+strongly connected component and are declared as a single ordinary `mutual`
+block; `GZ` depends on both and forms a later one.  A member's native `X.rec`
+ranges over its own component, so `GX.rec` has two motives and `GZ.rec` has
+one. -/
+
+mutual_multiuniverse
+inductive GP : Prop where
+  | fromX : GX → GP
+  | fromY : GY → GP
+inductive GX : Type 0 where
+  | mk : GY → GX
+  | leaf : Nat → GX
+inductive GY : Type 0 where
+  | mk : GX → GY
+  | fromP : GP → GY
+inductive GZ : Type 2 where
+  | mk : GX → GY → Type 1 → GZ
+end
+
+/--
+info: @GX.rec : {motive_1 : GX → Sort u_1} →
+  {motive_2 : GY → Sort u_1} →
+    ((a : GY) → motive_2 a → motive_1 (GX.mk a)) →
+      ((a : Nat) → motive_1 (GX.leaf a)) →
+        ((a : GX) → motive_1 a → motive_2 (GY.mk a)) → ((a : GP) → motive_2 (GY.fromP a)) → (t : GX) → motive_1 t
+-/
+#guard_msgs in
+#check @GX.rec
+
+/--
+info: @GZ.rec : {motive : GZ → Sort u_1} →
+  ((a : GX) → (a_1 : GY) → (a_2 : Type 1) → motive (GZ.mk a a_1 a_2)) → (t : GZ) → motive t
+-/
+#guard_msgs in
+#check @GZ.rec
+
+/-- info: 'GP.mutualRec' does not depend on any axioms -/
+#guard_msgs in
+#print axioms GP.mutualRec
+
+/-- info: 'GZ.mutualRec' does not depend on any axioms -/
+#guard_msgs in
+#print axioms GZ.mutualRec
+
+-- structural recursion works across the component
+mutual
+def gxSize : GX → Nat
+  | .mk y => gySize y + 1
+  | .leaf n => n
+def gySize : GY → Nat
+  | .mk x => gxSize x + 1
+  | .fromP _ => 0
+end
+
+/-- info: 7 -/
+#guard_msgs in
+#eval gxSize (GX.mk (GY.mk (GX.leaf 5)))
+
+/-! ## Universe polymorphism -/
+
+mutual_multiuniverse
+inductive UP (α : Type u) : Prop where
+  | mk : UD α → UP α
+inductive UD (α : Type u) : Type (u + 1) where
+  | val : α → Type u → UD α
+  | back : UP α → UD α
+end
+
+/-- info: UD : Type u_1 → Type (u_1 + 1) -/
+#guard_msgs in
+#check @UD
+
+/--
+info: @UD.mutualRec : {α : Type u_2} →
+  {motive_1 : UP α → Prop} →
+    {motive_2 : UD α → Sort u_1} →
+      (∀ (a : UD α) (ih_1 : motive_2 a), motive_1 (UP.mk a)) →
+        ((a : α) → (a_1 : Type u_2) → motive_2 (UD.val a a_1)) →
+          ((a : UP α) → motive_1 a → motive_2 (UD.back a)) → (t : UD α) → motive_2 t
+-/
+#guard_msgs in
+set_option pp.proofs true in
+#check @UD.mutualRec
+
+/-- info: 'UD.mutualRec' does not depend on any axioms -/
+#guard_msgs in
+#print axioms UD.mutualRec
+
+def uTag {α : Type u} : UD α → Nat
+  | .val _ _ => 0
+  | .back _ => 1
+
+/-- info: 0 -/
+#guard_msgs in
+#eval uTag (UD.val (3 : Nat) Nat)
+
+/-! ## A homogeneous block is an ordinary `mutual` block
+
+`mutual_multiuniverse` accepts everything `mutual` does and means the same
+thing by it; the block below is emitted natively and `mutualRec` is just
+another name for the native recursor. -/
+
+mutual_multiuniverse
+inductive T1 : Type where
+  | mk : T2 → T1
+inductive T2 : Type where
+  | mk : T1 → T2
+  | stop : T2
+end
+
+example : @T1.mutualRec = @T1.rec := rfl
+
+/-- info: 'T1.rec' does not depend on any axioms -/
+#guard_msgs in
+#print axioms T1.rec


### PR DESCRIPTION
This PR adds a `mutual_multiuniverse` elaborator that allows `mutual` blocks with unequal universes on the contained types. The elaborator first lowers the types to an equal-universe mutual block then derives appropriate recursors.

This is a demonstration of RFC #14944.

The generated recursors satisfy the expected iota reduction rules, but are noncomputable. In order to make the derived types useful for computation, the elaborator also generates computable variants of the recursors (via match statements, so ultimately via brec's `_unsafe_def`), and these are added as `@[csimp]` variants. This permits both the correct kernel reduction you'd want from an inductive definition, as well as useful code. An earlier draft produced `_unsafe_def`'s for the computational variants directly, but it seemed safer to generate the `csimp` theorems, as a catch in case something was incorrect about the computational variant.

At the moment this is a separate `mutual_multiuniverse` elaborator, which of course also shares a lot of code with `mutual`. One could imagine that eventually this functionality gets merged entirely into `mutual`. (It already falls back to the unlowered-version if the block has only one universe.) At the moment, this elaborator only supports inductive blocks inside; no structures defs or theorems.

The elaborator and lowering was substantially written with AI assistance. I have read through the code and believe it to be correct and true to all my intentions. Naturally, I have some trouble confidently vouching that all combinations of (mutual × nested × indexed × large-eliminating) blocks will proceed without kernel rejection errors, but I've verified that all the changes are of course well above the kernel level and so should be unable to produce soundness issues, and I believe the testing suite to be sufficiently extensive that it appears reasonably robust.