### PR TITLE
feat: run `lake challenge` dependency resolution inside the sandbox

### DIFF
--- a/src/lake/Lake/CLI/Check.lean
+++ b/src/lake/Lake/CLI/Check.lean
@@ -40,9 +40,6 @@ public structure Context where
   theoremNames : Array Lean.Name
   definitionNames : Array Lean.Name
   legalAxioms : Array Lean.Name
-  leanPrefix : System.FilePath
-  /-- Everything `git` needs to execute inside the sandbox. See `discoverGitExecPaths`. -/
-  gitExecPaths : Array System.FilePath
   /-- The workspace's `LEAN_PATH`. Empty until `safeResolveWorkspace` records it. -/
   leanPath : String
   /--
@@ -64,7 +61,6 @@ structure LandrunArgs where
   envOverride : Array (String × Option String) := #[]
   readablePaths : Array System.FilePath
   writablePaths : Array System.FilePath
-  executablePaths : Array System.FilePath
   /-- TCP ports the child may connect to. Landrun denies all of them by default. -/
   connectPorts : Array String := #[]
 
@@ -89,12 +85,6 @@ def getSolutionModule : M Lean.Name := do return (← read).solutionModule
 @[inline]
 def getLegalAxioms : M (Array Lean.Name) := do return (← read).legalAxioms
 
-@[inline]
-def getLeanPrefix : M System.FilePath := do return (← read).leanPrefix
-
-@[inline]
-def getGitExecPaths : M (Array System.FilePath) := do return (← read).gitExecPaths
-
 /-- Resolves `exe` to an absolute path via `PATH`, or `none` if it is not there. -/
 def whichExe (exe : String) : IO (Option System.FilePath) := do
   let out ←
@@ -104,58 +94,6 @@ def whichExe (exe : String) : IO (Option System.FilePath) := do
     return none
   let path := out.stdout.trimAscii.toString
   return if path.isEmpty then none else some (path : System.FilePath)
-
-/--
-Reports the directories holding the shared libraries an executable loads.
-
-Landlock governs execute permission per path, and mapping a shared library needs it just as much as
-spawning a process does.
--/
-def sharedLibDirs (exe : System.FilePath) : IO (Array String) := do
-  let out ← try IO.Process.output { cmd := "ldd", args := #[exe.toString] } catch _ => return #[]
-  if out.exitCode != 0 then return #[]
-  let mut dirs := #[]
-  for line in out.stdout.split '\n' |>.toStringList do
-    -- `libfoo.so.1 => /usr/lib/libfoo.so.1 (0x00007f...)`
-    if let [_, rest] := line.split "=> " |>.toStringList then
-      if let path :: _ := rest.split ' ' |>.toStringList then
-        let path : System.FilePath := path
-        if path.isAbsolute then
-          if let some parent := path.parent then
-            dirs := dirs.push parent.toString
-  return dirs
-
-/--
-Reports everything `git` needs in order to run inside the sandbox.
-
-Granting the `git` binary alone does not suffice: `git` forks helpers out of its exec-path and runs
-some of them through the shell it was built against, which need not be the system `/bin/sh`. Each
-of those needs execute permission in its own right, as do the libraries they load. `git` is asked
-for all of it, so no path is assumed.
--/
-def discoverGitExecPaths (gitLocation : System.FilePath) : IO (Array System.FilePath) := do
-  let git ← try IO.FS.realPath gitLocation catch _ => pure gitLocation
-  let ask (args : Array String) : IO (Option String) := do
-    let out ← try IO.Process.output { cmd := git.toString, args } catch _ => return none
-    if out.exitCode != 0 then return none
-    let line := out.stdout.trimAscii.toString
-    return if line.isEmpty then none else some line
-
-  let mut paths := #[git.toString]
-  if let some dir := git.parent then
-    paths := paths.push dir.toString
-  if let some execPath ← ask #["--exec-path"] then
-    paths := paths.push execPath
-  let mut executables := #[git]
-  if let some shell ← ask #["var", "GIT_SHELL_PATH"] then
-    paths := paths.push shell
-    executables := executables.push shell
-  for exe in executables do
-    paths := paths ++ (← sharedLibDirs exe)
-
-  let deduped := paths.foldl (init := (#[] : Array String)) fun acc path =>
-    if acc.contains path then acc else acc.push path
-  return deduped.map System.FilePath.mk
 
 def missingLandrunError (cmd exe : String) : String :=
 s!"`lake {cmd}` needs `{exe}` to sandbox the code it checks, and it was not found.
@@ -167,11 +105,15 @@ s!"`lake {cmd}` needs `{exe}` to sandbox the code it checks, and it was not foun
   is built and exported inside the sandbox."
 
 def buildLandrunArgs (spawnArgs : LandrunArgs) : Array String :=
-  let args := #["--best-effort", "--ro", "/", "--rw", "/dev", "-ldd", "-add-exec"]
+  -- Landlock rules are additive, so `--rox /` is read plus execute everywhere, narrowed back only
+  -- by what is granted write access below. Naming executables individually would not confine them:
+  -- Landlock checks execute permission at `execve`, on the binary and the ELF interpreter, and the
+  -- loader will run any dynamically linked binary passed to it as an argument, mapping it with read
+  -- access alone. See `helpChallenge` for what the sandbox does and does not bound.
+  let args := #["--best-effort", "--rox", "/", "--rw", "/dev"]
   let args := spawnArgs.envPass.foldl (init := args) (fun acc env => acc ++ #["--env", env])
   let args := spawnArgs.readablePaths.foldl (init := args) (fun acc path => acc ++ #["--ro", path.toString])
   let args := spawnArgs.writablePaths.foldl (init := args) (fun acc path => acc ++ #["--rwx", path.toString])
-  let args := spawnArgs.executablePaths.foldl (init := args) (fun acc path => acc ++ #["--rox", path.toString])
   let args := spawnArgs.connectPorts.foldl (init := args) (fun acc port => acc ++ #["--connect-tcp", port])
   args ++ #["--", spawnArgs.cmd] ++ spawnArgs.args
 
@@ -207,15 +149,13 @@ defines, as `(LEAN_PATH, PATH)`.
 
 Resolution elaborates the project's configuration, which is code, so it must not run outside the
 sandbox; this is also the only step permitted to reach the network. `lake env` resolves and reports
-in one invocation, which is what lets the export step run the exporter directly: with the search
-path recorded here, that step needs neither `lake` nor `git` executable.
+in one invocation, so the export step can run the exporter directly against the search path
+recorded here.
 -/
 def safeResolveWorkspace : M (String × String) := do
   IO.println "Resolving dependencies"
-  let leanPrefix ← getLeanPrefix
   let projectDir ← getProjectDir
   let dotLakeDir := projectDir / ".lake"
-  let gitExecPaths ← getGitExecPaths
 
   if !(← System.FilePath.pathExists dotLakeDir) then
     IO.FS.createDir dotLakeDir
@@ -228,7 +168,6 @@ def safeResolveWorkspace : M (String × String) := do
     envOverride := #[("LEAN_ABORT_ON_PANIC", some "1")]
     readablePaths := #[projectDir]
     writablePaths := #[dotLakeDir]
-    executablePaths := #[leanPrefix, whichLake] ++ gitExecPaths
     -- `https` and `ssh`, the transports Lake's git dependencies use.
     connectPorts := #["443", "22"]
   }
@@ -246,10 +185,8 @@ def safeResolveWorkspace : M (String × String) := do
 
 def safeLakeBuild (target : Lean.Name) : M Unit := do
   IO.println s!"Building {target}"
-  let leanPrefix ← getLeanPrefix
   let projectDir ← getProjectDir
   let dotLakeDir := projectDir / ".lake"
-  let gitExecPaths ← getGitExecPaths
 
   if !(← System.FilePath.pathExists dotLakeDir) then
     IO.FS.createDir dotLakeDir
@@ -262,7 +199,6 @@ def safeLakeBuild (target : Lean.Name) : M Unit := do
     envOverride := #[("LEAN_ABORT_ON_PANIC", some "1")]
     readablePaths := #[projectDir]
     writablePaths := #[dotLakeDir]
-    executablePaths := #[leanPrefix, whichLake] ++ gitExecPaths
   }
 
 def safeExport (module : Lean.Name) (decls : Array Lean.Name) : M String := do
@@ -270,7 +206,6 @@ def safeExport (module : Lean.Name) (decls : Array Lean.Name) : M String := do
   let baseArgs := #[module.toString, "--"]
   let args := decls.foldl (·.push <| ·.toString) baseArgs
 
-  let leanPrefix ← getLeanPrefix
   let projectDir ← getProjectDir
   let dotLakeDir := projectDir / ".lake"
   let whichLean4Export := (← read).whichLean4Export
@@ -282,7 +217,6 @@ def safeExport (module : Lean.Name) (decls : Array Lean.Name) : M String := do
       ("PATH", some (← read).binPath)]
     readablePaths := #[projectDir, dotLakeDir]
     writablePaths := #[]
-    executablePaths := #[leanPrefix, whichLean4Export]
   }
 
 def runExternalKernel (kernelName : String) (kernelCommand : Array String)
@@ -318,7 +252,6 @@ def runExternalKernel (kernelName : String) (kernelCommand : Array String)
       envPass := #[]
       readablePaths := #[configPath.toString, solutionPath.toString]
       writablePaths := #[]
-      executablePaths := #[]
     }
     let args := buildLandrunArgs spawnArgs
 
@@ -490,7 +423,7 @@ def mkContext (cmd : String) (lean : LeanInstall) (lake : LakeInstall)
   -- Always the bundled exporter: the export format has to match the compiler that produced the
   -- oleans, so letting this be pointed elsewhere would reintroduce the toolchain-pinning problem.
   let whichLean4Export := lean.binDir / "leanexport" |>.addExtension System.FilePath.exeExtension
-  let some gitLocation ← whichExe "git"
+  let some _ ← whichExe "git"
     | return .error (← cannotRun s!"`lake {cmd}` needs `git` on PATH to build inside the sandbox")
 
   return .ok {
@@ -500,8 +433,6 @@ def mkContext (cmd : String) (lean : LeanInstall) (lake : LakeInstall)
     theoremNames := #[]
     definitionNames := #[]
     legalAxioms := #[]
-    leanPrefix := lean.sysroot
-    gitExecPaths := ← discoverGitExecPaths gitLocation
     leanPath := ""
     binPath := ""
     whichLandrun := landrunPath.toString

--- a/src/lake/Lake/CLI/Check.lean
+++ b/src/lake/Lake/CLI/Check.lean
@@ -13,6 +13,8 @@ public import Lake.Util.Exit
 public import Lean.Data.Json.FromToJson
 import Lean.Environment
 import Lean.Replay
+import Init.Data.String.Search
+import Init.Data.String.TakeDrop
 import Init.Data.ToString.Macro
 import Init.System.IO
 import Init.System.Platform
@@ -39,9 +41,15 @@ public structure Context where
   definitionNames : Array Lean.Name
   legalAxioms : Array Lean.Name
   leanPrefix : System.FilePath
-  gitLocation : System.FilePath
-  /-- `LEAN_PATH` for the exporter, so it finds the project's oleans inside the sandbox. -/
+  /-- Everything `git` needs to execute inside the sandbox. See `discoverGitExecPaths`. -/
+  gitExecPaths : Array System.FilePath
+  /-- The workspace's `LEAN_PATH`. Empty until `safeResolveWorkspace` records it. -/
   leanPath : String
+  /--
+  The workspace's `PATH`, so the exporter's own `lean` child resolves to this toolchain. Empty
+  until `safeResolveWorkspace` records it.
+  -/
+  binPath : String
   whichLandrun : String
   whichLake : System.FilePath
   whichLean4Export : System.FilePath
@@ -57,6 +65,8 @@ structure LandrunArgs where
   readablePaths : Array System.FilePath
   writablePaths : Array System.FilePath
   executablePaths : Array System.FilePath
+  /-- TCP ports the child may connect to. Landrun denies all of them by default. -/
+  connectPorts : Array String := #[]
 
 @[inline]
 def getExternalKernels : M (Std.TreeMap String (Array String)) := do return (← read).externalKernels
@@ -83,7 +93,7 @@ def getLegalAxioms : M (Array Lean.Name) := do return (← read).legalAxioms
 def getLeanPrefix : M System.FilePath := do return (← read).leanPrefix
 
 @[inline]
-def getGitLocation : M System.FilePath := do return (← read).gitLocation
+def getGitExecPaths : M (Array System.FilePath) := do return (← read).gitExecPaths
 
 /-- Resolves `exe` to an absolute path via `PATH`, or `none` if it is not there. -/
 def whichExe (exe : String) : IO (Option System.FilePath) := do
@@ -94,6 +104,58 @@ def whichExe (exe : String) : IO (Option System.FilePath) := do
     return none
   let path := out.stdout.trimAscii.toString
   return if path.isEmpty then none else some (path : System.FilePath)
+
+/--
+Reports the directories holding the shared libraries an executable loads.
+
+Landlock governs execute permission per path, and mapping a shared library needs it just as much as
+spawning a process does.
+-/
+def sharedLibDirs (exe : System.FilePath) : IO (Array String) := do
+  let out ← try IO.Process.output { cmd := "ldd", args := #[exe.toString] } catch _ => return #[]
+  if out.exitCode != 0 then return #[]
+  let mut dirs := #[]
+  for line in out.stdout.split '\n' |>.toStringList do
+    -- `libfoo.so.1 => /usr/lib/libfoo.so.1 (0x00007f...)`
+    if let [_, rest] := line.split "=> " |>.toStringList then
+      if let path :: _ := rest.split ' ' |>.toStringList then
+        let path : System.FilePath := path
+        if path.isAbsolute then
+          if let some parent := path.parent then
+            dirs := dirs.push parent.toString
+  return dirs
+
+/--
+Reports everything `git` needs in order to run inside the sandbox.
+
+Granting the `git` binary alone does not suffice: `git` forks helpers out of its exec-path and runs
+some of them through the shell it was built against, which need not be the system `/bin/sh`. Each
+of those needs execute permission in its own right, as do the libraries they load. `git` is asked
+for all of it, so no path is assumed.
+-/
+def discoverGitExecPaths (gitLocation : System.FilePath) : IO (Array System.FilePath) := do
+  let git ← try IO.FS.realPath gitLocation catch _ => pure gitLocation
+  let ask (args : Array String) : IO (Option String) := do
+    let out ← try IO.Process.output { cmd := git.toString, args } catch _ => return none
+    if out.exitCode != 0 then return none
+    let line := out.stdout.trimAscii.toString
+    return if line.isEmpty then none else some line
+
+  let mut paths := #[git.toString]
+  if let some dir := git.parent then
+    paths := paths.push dir.toString
+  if let some execPath ← ask #["--exec-path"] then
+    paths := paths.push execPath
+  let mut executables := #[git]
+  if let some shell ← ask #["var", "GIT_SHELL_PATH"] then
+    paths := paths.push shell
+    executables := executables.push shell
+  for exe in executables do
+    paths := paths ++ (← sharedLibDirs exe)
+
+  let deduped := paths.foldl (init := (#[] : Array String)) fun acc path =>
+    if acc.contains path then acc else acc.push path
+  return deduped.map System.FilePath.mk
 
 def missingLandrunError (cmd exe : String) : String :=
 s!"`lake {cmd}` needs `{exe}` to sandbox the code it checks, and it was not found.
@@ -110,6 +172,7 @@ def buildLandrunArgs (spawnArgs : LandrunArgs) : Array String :=
   let args := spawnArgs.readablePaths.foldl (init := args) (fun acc path => acc ++ #["--ro", path.toString])
   let args := spawnArgs.writablePaths.foldl (init := args) (fun acc path => acc ++ #["--rwx", path.toString])
   let args := spawnArgs.executablePaths.foldl (init := args) (fun acc path => acc ++ #["--rox", path.toString])
+  let args := spawnArgs.connectPorts.foldl (init := args) (fun acc port => acc ++ #["--connect-tcp", port])
   args ++ #["--", spawnArgs.cmd] ++ spawnArgs.args
 
 def runSandBoxedWithStdout (spawnArgs : LandrunArgs) : M String := do
@@ -138,12 +201,55 @@ def runSandBoxed (spawnArgs : LandrunArgs) : M Unit := do
   if ret != 0 then
     throw <| .userError s!"Child exited with {ret}"
 
+/--
+Materializes the project's dependencies into `.lake` and reports the environment the workspace
+defines, as `(LEAN_PATH, PATH)`.
+
+Resolution elaborates the project's configuration, which is code, so it must not run outside the
+sandbox; this is also the only step permitted to reach the network. `lake env` resolves and reports
+in one invocation, which is what lets the export step run the exporter directly: with the search
+path recorded here, that step needs neither `lake` nor `git` executable.
+-/
+def safeResolveWorkspace : M (String × String) := do
+  IO.println "Resolving dependencies"
+  let leanPrefix ← getLeanPrefix
+  let projectDir ← getProjectDir
+  let dotLakeDir := projectDir / ".lake"
+  let gitExecPaths ← getGitExecPaths
+
+  if !(← System.FilePath.pathExists dotLakeDir) then
+    IO.FS.createDir dotLakeDir
+
+  let whichLake := (← read).whichLake
+  let out ← runSandBoxedWithStdout {
+    cmd := whichLake.toString,
+    args := #["env"],
+    envPass := #["PATH", "HOME", "LEAN_ABORT_ON_PANIC"]
+    envOverride := #[("LEAN_ABORT_ON_PANIC", some "1")]
+    readablePaths := #[projectDir]
+    writablePaths := #[dotLakeDir]
+    executablePaths := #[leanPrefix, whichLake] ++ gitExecPaths
+    -- `https` and `ssh`, the transports Lake's git dependencies use.
+    connectPorts := #["443", "22"]
+  }
+
+  let mut leanPath := ""
+  let mut binPath := ""
+  for line in out.split '\n' |>.toStringList do
+    if let some rest := line.dropPrefix? "LEAN_PATH=" then
+      leanPath := rest.toString
+    else if let some rest := line.dropPrefix? "PATH=" then
+      binPath := rest.toString
+  if leanPath.isEmpty || binPath.isEmpty then
+    throw <| .userError "`lake env` did not report the project's search path"
+  return (leanPath, binPath)
+
 def safeLakeBuild (target : Lean.Name) : M Unit := do
   IO.println s!"Building {target}"
   let leanPrefix ← getLeanPrefix
   let projectDir ← getProjectDir
   let dotLakeDir := projectDir / ".lake"
-  let gitLocation ← getGitLocation
+  let gitExecPaths ← getGitExecPaths
 
   if !(← System.FilePath.pathExists dotLakeDir) then
     IO.FS.createDir dotLakeDir
@@ -156,7 +262,7 @@ def safeLakeBuild (target : Lean.Name) : M Unit := do
     envOverride := #[("LEAN_ABORT_ON_PANIC", some "1")]
     readablePaths := #[projectDir]
     writablePaths := #[dotLakeDir]
-    executablePaths := #[leanPrefix, whichLake, gitLocation]
+    executablePaths := #[leanPrefix, whichLake] ++ gitExecPaths
   }
 
 def safeExport (module : Lean.Name) (decls : Array Lean.Name) : M String := do
@@ -172,7 +278,8 @@ def safeExport (module : Lean.Name) (decls : Array Lean.Name) : M String := do
     cmd := whichLean4Export.toString
     args := args,
     envPass := #["PATH", "HOME", "LEAN_PATH", "LEAN_ABORT_ON_PANIC"]
-    envOverride := #[("LEAN_ABORT_ON_PANIC", some "1"), ("LEAN_PATH", some (← read).leanPath)]
+    envOverride := #[("LEAN_ABORT_ON_PANIC", some "1"), ("LEAN_PATH", some (← read).leanPath),
+      ("PATH", some (← read).binPath)]
     readablePaths := #[projectDir, dotLakeDir]
     writablePaths := #[]
     executablePaths := #[leanPrefix, whichLean4Export]
@@ -354,11 +461,24 @@ def cannotRun (msg : String) : IO ExitCode := do
   return 2
 
 /--
+Reports whether the project carries the manifest that sandboxed dependency resolution needs.
+
+Resolution writes the manifest, and the sandbox does not grant write access to the project
+directory, so a project without one fails inside the sandbox with a bare `permission denied`.
+-/
+def checkManifest (cmd : String) (projectDir : System.FilePath) : IO (Option ExitCode) := do
+  if ← (projectDir / "lake-manifest.json").pathExists then
+    return none
+  return some (← cannotRun s!"'{projectDir}' has no `lake-manifest.json`, and `lake {cmd}` resolves \
+    dependencies inside a sandbox that cannot write to the project directory. Run `lake build` \
+    there first.")
+
+/--
 Resolves the external tools the commands need and builds the context they share, or reports why
 that is not possible.
 -/
 def mkContext (cmd : String) (lean : LeanInstall) (lake : LakeInstall)
-    (projectDir : System.FilePath) (leanPath : String) : IO (Except ExitCode Context) := do
+    (projectDir : System.FilePath) : IO (Except ExitCode Context) := do
   if !System.Platform.isLinux then
     return .error (← cannotRun
       s!"`lake {cmd}` sandboxes the code it checks with `landrun`, which needs Linux Landlock. \
@@ -381,8 +501,9 @@ def mkContext (cmd : String) (lean : LeanInstall) (lake : LakeInstall)
     definitionNames := #[]
     legalAxioms := #[]
     leanPrefix := lean.sysroot
-    gitLocation := gitLocation
-    leanPath
+    gitExecPaths := ← discoverGitExecPaths gitLocation
+    leanPath := ""
+    binPath := ""
     whichLandrun := landrunPath.toString
     whichLake := lake.lake
     whichLean4Export
@@ -410,9 +531,9 @@ Runs `lake challenge`: builds and exports the challenge and the solution in a sa
 the solution against the challenge.
 -/
 public def runChallenge (configFile? : Option System.FilePath) (lean : LeanInstall)
-    (lake : LakeInstall) (projectDir : System.FilePath) (leanPath : String) : IO ExitCode := do
+    (lake : LakeInstall) (projectDir : System.FilePath) : IO ExitCode := do
   let base ←
-    match ← mkContext "challenge" lean lake projectDir leanPath with
+    match ← mkContext "challenge" lean lake projectDir with
     | .error rc => return rc
     | .ok ctx => pure ctx
 
@@ -435,8 +556,11 @@ public def runChallenge (configFile? : Option System.FilePath) (lean : LeanInsta
     | .error rc => return rc
     | .ok ks => pure ks
 
+  if let some rc ← checkManifest "challenge" base.projectDir then
+    return rc
+
   try
-    ReaderT.run compareIt { base with
+    let ctx := { base with
       challengeModule := cfg.challenge_module.toName,
       solutionModule := cfg.solution_module.toName,
       theoremNames,
@@ -444,6 +568,8 @@ public def runChallenge (configFile? : Option System.FilePath) (lean : LeanInsta
       legalAxioms := cfg.permitted_axioms.map String.toName,
       externalKernels
     }
+    let (leanPath, binPath) ← ReaderT.run safeResolveWorkspace ctx
+    ReaderT.run compareIt { ctx with leanPath, binPath }
     return 0
   catch e =>
     IO.eprintln s!"error: {e}"

--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -407,10 +407,14 @@ Establishes that every named theorem in the solution proves the same statement
 as the challenge, uses no axiom outside the permitted list, and is accepted by
 the kernel.
 
-The solution is untrusted input: it is built and exported inside a `landrun`
-sandbox, and none of its `.olean` files is ever loaded into Lake's own address
-space. `landrun` is required; there is no unsandboxed mode, so this command is
-available on Linux only.
+The project is untrusted input: its configuration is evaluated, and its code
+built and exported, inside a `landrun` sandbox, and none of its `.olean` files
+is ever loaded into Lake's own address space. `landrun` is required; there is
+no unsandboxed mode, so this command is available on Linux only.
+
+The project has to carry a `lake-manifest.json`, because dependencies are
+resolved inside the sandbox and it cannot write to the project directory.
+Building the project once, before distributing it, is enough to write one.
 
 OPTIONS:
   --config=<file>       JSON file describing the challenge (see below)
@@ -445,8 +449,9 @@ EXIT CODES:
   0                     accepted
   1                     rejected: statement mismatch, forbidden axiom, kernel
                         rejection, or a build that did not succeed
-  2                     could not start: `landrun` is missing, or the
-                        configuration is missing, unreadable or malformed
+  2                     could not start: `landrun` or the manifest is missing,
+                        or the configuration is missing, unreadable or
+                        malformed
 
 ENVIRONMENT:
   COMPARATOR_LANDRUN    sandbox executable (default: `landrun` on PATH)

--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -461,6 +461,15 @@ ENVIRONMENT:
   the `.olean` files being exported.
 
 HARDENING:
+  The sandbox bounds writes and TCP connections: only `.lake` is writable, and
+  only dependency resolution may connect, on the ports git's transports use.
+  It does not bound reads, execution, or non-TCP traffic. Landlock filters the
+  filesystem view rather than constructing one, and its rules only ever grant,
+  so nothing can be carved back out of a broader grant; and it checks execute
+  permission at `execve` alone, which the dynamic loader performs on behalf of
+  any binary handed to it. Where the code being judged must not read the
+  invoking user's files, run the command as a user that cannot see them.
+
   Until the Landlock fix released in Linux 7.1 is widely available, `landrun`
   can be escaped through an `AF_UNIX` socket. Where that matters, run the
   command under a wrapper that removes the capability:

--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -463,12 +463,7 @@ ENVIRONMENT:
 HARDENING:
   The sandbox bounds writes and TCP connections: only `.lake` is writable, and
   only dependency resolution may connect, on the ports git's transports use.
-  It does not bound reads, execution, or non-TCP traffic. Landlock filters the
-  filesystem view rather than constructing one, and its rules only ever grant,
-  so nothing can be carved back out of a broader grant; and it checks execute
-  permission at `execve` alone, which the dynamic loader performs on behalf of
-  any binary handed to it. Where the code being judged must not read the
-  invoking user's files, run the command as a user that cannot see them.
+  It does not bound reads, execution, or non-TCP traffic.
 
   Until the Landlock fix released in Linux 7.1 is widely available, `landrun`
   can be escaped through an `AF_UNIX` socket. Where that matters, run the

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -1171,11 +1171,10 @@ protected def challenge : CliM PUnit := do
   let opts ← getThe LakeOptions
   noArgsRem do
   let (leanInstall, lakeInstall) ← opts.getInstall
-  -- Loading the workspace resolves dependencies and yields the `LEAN_PATH` the exporter needs;
-  -- the sandboxed builds would otherwise have to write the manifest into a read-only project.
-  let ws ← loadWorkspace (← mkLoadConfig opts)
-  exit <| ← Check.runChallenge opts.challengeConfig? leanInstall lakeInstall ws.root.dir
-    ws.augmentedLeanPath.toString
+  -- The workspace is deliberately not loaded here: evaluating the project's configuration is code
+  -- execution, and containing it is what the sandbox is for.
+  let cfg ← mkLoadConfig opts
+  exit <| ← Check.runChallenge opts.challengeConfig? leanInstall lakeInstall cfg.wsDir
 
 protected def script : CliM PUnit := do
   if let some cmd ← takeArg? then

--- a/tests/lake/tests/challenge-def-hole-axiom-issue/test.sh
+++ b/tests/lake/tests/challenge-def-hole-axiom-issue/test.sh
@@ -11,6 +11,11 @@ fi
 # Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
 export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
 
+# `lake challenge` resolves dependencies inside the sandbox, which cannot write to the project
+# directory, so the manifest has to be in place first. Building the project once does the same;
+# this just skips the build.
+"$LAKE" resolve-deps
+
 test_status_out 1 "Illegal axiom detected: 'sorryAx'" challenge --config config.json
 
 rm -f produced.out

--- a/tests/lake/tests/challenge-def-hole-kind-mismatch/test.sh
+++ b/tests/lake/tests/challenge-def-hole-kind-mismatch/test.sh
@@ -11,6 +11,11 @@ fi
 # Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
 export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
 
+# `lake challenge` resolves dependencies inside the sandbox, which cannot write to the project
+# directory, so the manifest has to be in place first. Building the project once does the same;
+# this just skips the build.
+"$LAKE" resolve-deps
+
 test_status_out 1 "Solution constant is not a definition: 'n'" challenge --config config.json
 
 rm -f produced.out

--- a/tests/lake/tests/challenge-def-hole-type-mismatch/test.sh
+++ b/tests/lake/tests/challenge-def-hole-type-mismatch/test.sh
@@ -11,6 +11,11 @@ fi
 # Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
 export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
 
+# `lake challenge` resolves dependencies inside the sandbox, which cannot write to the project
+# directory, so the manifest has to be in place first. Building the project once does the same;
+# this just skips the build.
+"$LAKE" resolve-deps
+
 test_status_out 1 "Const does not match between challenge and target 'n'" challenge --config config.json
 
 rm -f produced.out

--- a/tests/lake/tests/challenge-def-hole/test.sh
+++ b/tests/lake/tests/challenge-def-hole/test.sh
@@ -11,6 +11,11 @@ fi
 # Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
 export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
 
+# `lake challenge` resolves dependencies inside the sandbox, which cannot write to the project
+# directory, so the manifest has to be in place first. Building the project once does the same;
+# this just skips the build.
+"$LAKE" resolve-deps
+
 test_status_out 0 'Your solution is okay!' challenge --config config.json
 
 rm -f produced.out

--- a/tests/lake/tests/challenge-numeric-namespace/test.sh
+++ b/tests/lake/tests/challenge-numeric-namespace/test.sh
@@ -11,6 +11,11 @@ fi
 # Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
 export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
 
+# `lake challenge` resolves dependencies inside the sandbox, which cannot write to the project
+# directory, so the manifest has to be in place first. Building the project once does the same;
+# this just skips the build.
+"$LAKE" resolve-deps
+
 test_status_out 0 'Your solution is okay!' challenge --config config.json
 
 rm -f produced.out

--- a/tests/lake/tests/challenge-olean-issue/test.sh
+++ b/tests/lake/tests/challenge-olean-issue/test.sh
@@ -11,6 +11,11 @@ fi
 # Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
 export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
 
+# `lake challenge` resolves dependencies inside the sandbox, which cannot write to the project
+# directory, so the manifest has to be in place first. Building the project once does the same;
+# this just skips the build.
+"$LAKE" resolve-deps
+
 test_status_out 1 "while replaying declaration 'boom'" challenge --config config.json
 
 rm -f produced.out

--- a/tests/lake/tests/challenge-opaque-value/test.sh
+++ b/tests/lake/tests/challenge-opaque-value/test.sh
@@ -11,6 +11,11 @@ fi
 # Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
 export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
 
+# `lake challenge` resolves dependencies inside the sandbox, which cannot write to the project
+# directory, so the manifest has to be in place first. Building the project once does the same;
+# this just skips the build.
+"$LAKE" resolve-deps
+
 test_status_out 1 "Illegal axiom detected: 'f'" challenge --config config.json
 
 rm -f produced.out

--- a/tests/lake/tests/challenge-primitive-issue/test.sh
+++ b/tests/lake/tests/challenge-primitive-issue/test.sh
@@ -11,6 +11,11 @@ fi
 # Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
 export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
 
+# `lake challenge` resolves dependencies inside the sandbox, which cannot write to the project
+# directory, so the manifest has to be in place first. Building the project once does the same;
+# this just skips the build.
+"$LAKE" resolve-deps
+
 test_status_out 1 "Const does not match between challenge and target 'Nat.gcd'" challenge --config config.json
 
 rm -f produced.out

--- a/tests/lake/tests/challenge-simple-axiom-issue/test.sh
+++ b/tests/lake/tests/challenge-simple-axiom-issue/test.sh
@@ -11,6 +11,11 @@ fi
 # Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
 export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
 
+# `lake challenge` resolves dependencies inside the sandbox, which cannot write to the project
+# directory, so the manifest has to be in place first. Building the project once does the same;
+# this just skips the build.
+"$LAKE" resolve-deps
+
 test_status_out 1 "Illegal axiom detected: 'helper'" challenge --config config.json
 
 rm -f produced.out

--- a/tests/lake/tests/challenge-simple-kind-mismatch/test.sh
+++ b/tests/lake/tests/challenge-simple-kind-mismatch/test.sh
@@ -11,6 +11,11 @@ fi
 # Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
 export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
 
+# `lake challenge` resolves dependencies inside the sandbox, which cannot write to the project
+# directory, so the manifest has to be in place first. Building the project once does the same;
+# this just skips the build.
+"$LAKE" resolve-deps
+
 test_status_out 1 "Illegal axiom detected: 'helper'" challenge --config config.json
 
 rm -f produced.out

--- a/tests/lake/tests/challenge-simple-match/test.sh
+++ b/tests/lake/tests/challenge-simple-match/test.sh
@@ -11,6 +11,15 @@ fi
 # Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
 export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
 
+# Without a manifest the command refuses up front, rather than failing inside the sandbox with a
+# bare `permission denied` on the manifest it cannot write.
+test_status_out 2 'has no `lake-manifest.json`' challenge --config config.json
+
+# `lake challenge` resolves dependencies inside the sandbox, which cannot write to the project
+# directory, so the manifest has to be in place first. Building the project once does the same;
+# this just skips the build.
+"$LAKE" resolve-deps
+
 test_status_out 0 'Your solution is okay!' challenge --config config.json
 
 rm -f produced.out

--- a/tests/lake/tests/challenge-simple-mismatch/test.sh
+++ b/tests/lake/tests/challenge-simple-mismatch/test.sh
@@ -11,6 +11,11 @@ fi
 # Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
 export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
 
+# `lake challenge` resolves dependencies inside the sandbox, which cannot write to the project
+# directory, so the manifest has to be in place first. Building the project once does the same;
+# this just skips the build.
+"$LAKE" resolve-deps
+
 test_status_out 1 "Challenge and solution constant kind don't match: 'comm'" challenge --config config.json
 
 rm -f produced.out


### PR DESCRIPTION
This PR stops `lake challenge` from evaluating the challenge project's configuration outside the sandbox. Dependency resolution now happens inside it, so a project can be pointed at without running any of its code unsandboxed, and projects with git dependencies work at all. The project has to carry a `lake-manifest.json`, since the sandbox cannot write to the project directory; `.lake` itself no longer has to be prepared beforehand.

Loading the workspace was previously done in Lake's own process, to obtain `LEAN_PATH` for the exporter and to write the manifest before the read-only sandbox needed it. Evaluating a `lakefile.lean` is arbitrary code execution (even if not directly of the "solution"), so this was the one place a project could act outside the sandbox. A single sandboxed `lake env` now both resolves the dependencies and reports the environment the workspace defines, so nothing about the project is computed outside. Recording the search path rather than re-deriving it also keeps the export step minimal: it runs the exporter directly rather than through `lake`, against a project directory it cannot write.

The sandbox also stops naming executables one by one and grants execution wholesale, with `--rox /`. Those grants confined nothing: Landlock checks execute permission at `execve`, on the binary and its ELF interpreter, and the dynamic loader runs any dynamically linked binary handed to it as an argument, mapping it with the read access `--ro /` already granted.

Only the resolving step is granted TCP ports, on the ones git's transports use; the build and export steps are granted none. Landlock bounds connections rather than traffic, though, since its network rules cover TCP alone, and it cannot bound reads at all, because its rules only ever grant and nothing can be carved out of the `--ro /` a toolchain needs. `lake help challenge` now says what the sandbox does and does not bound.