### PR TITLE
feat: min/max support in bv_decide

### DIFF
--- a/src/Init/Data/BitVec/Basic.lean
+++ b/src/Init/Data/BitVec/Basic.lean
@@ -909,4 +909,8 @@ def cpopNatRec (x : BitVec w) (pos acc : Nat) : Nat :=
 @[suggest_for BitVec.popcount BitVec.popcnt, implicit_reducible]
 def cpop (x : BitVec w) : BitVec w := BitVec.ofNat w (cpopNatRec x w 0)
 
+instance : Min (BitVec w) := minOfLe
+
+instance : Max (BitVec w) := maxOfLe
+
 end BitVec

--- a/src/Init/Data/BitVec/Lemmas.lean
+++ b/src/Init/Data/BitVec/Lemmas.lean
@@ -6989,4 +6989,10 @@ theorem toNat_cpop_setWidth_eq_of_le {x : BitVec w} {n : Nat} (h : w ≤ n) :
     (x.setWidth n).cpop.toNat = x.cpop.toNat := by
   simp [BitVec.setWidth_eq_append, h]
 
+protected theorem min_def {x y : BitVec w} : min x y = if x ≤ y then x else y := by
+  rfl
+
+protected theorem max_def {x y : BitVec w} : max x y = if x ≤ y then y else x := by
+  rfl
+
 end BitVec

--- a/src/Init/Data/SInt/IntToBitVec.lean
+++ b/src/Init/Data/SInt/IntToBitVec.lean
@@ -9,6 +9,7 @@ prelude
 public import Init.Data.SInt.Lemmas
 public import Init.Data.SInt.Bitwise
 public import Init.Data.UInt.IntToBitVec
+import Init.ByCases
 
 public section
 
@@ -106,6 +107,22 @@ theorem ISize.toBitVec32_mod {a b : ISize} (h : System.Platform.numBits = 32) :
   generalize 32 = x at *
   subst h
   rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_min {a b : ISize} (h : System.Platform.numBits = 32) :
+    (min a b).toBitVec32 h =
+      if (a.toBitVec32 h).sle (b.toBitVec32 h) then a.toBitVec32 h else b.toBitVec32 h := by
+  have : a ≤ b ↔ (a.toBitVec32 h).sle (b.toBitVec32 h) := by
+    simp [ISize.le_iff_toBitVec32_sle, h]
+  simp [ISize.min_def, apply_ite (ISize.toBitVec32 · h), this]
+
+@[int_toBitVec]
+theorem ISize.toBitVec32_max {a b : ISize} (h : System.Platform.numBits = 32) :
+    (max a b).toBitVec32 h =
+      if (a.toBitVec32 h).sle (b.toBitVec32 h) then b.toBitVec32 h else a.toBitVec32 h := by
+  have : a ≤ b ↔ (a.toBitVec32 h).sle (b.toBitVec32 h) := by
+    simp [ISize.le_iff_toBitVec32_sle, h]
+  simp [ISize.max_def, apply_ite (ISize.toBitVec32 · h), this]
 
 @[int_toBitVec]
 theorem ISize.toBitVec32_neg {a : ISize} (h : System.Platform.numBits = 32) :
@@ -367,6 +384,22 @@ theorem ISize.toBitVec64_mod {a b : ISize} (h : System.Platform.numBits = 64) :
   generalize 64 = x at *
   subst h
   rfl
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_min {a b : ISize} (h : System.Platform.numBits = 64) :
+    (min a b).toBitVec64 h =
+      if (a.toBitVec64 h).sle (b.toBitVec64 h) then a.toBitVec64 h else b.toBitVec64 h := by
+  have : a ≤ b ↔ (a.toBitVec64 h).sle (b.toBitVec64 h) := by
+    simp [ISize.le_iff_toBitVec64_sle, h]
+  simp [ISize.min_def, apply_ite (ISize.toBitVec64 · h), this]
+
+@[int_toBitVec]
+theorem ISize.toBitVec64_max {a b : ISize} (h : System.Platform.numBits = 64) :
+    (max a b).toBitVec64 h =
+      if (a.toBitVec64 h).sle (b.toBitVec64 h) then b.toBitVec64 h else a.toBitVec64 h := by
+  have : a ≤ b ↔ (a.toBitVec64 h).sle (b.toBitVec64 h) := by
+    simp [ISize.le_iff_toBitVec64_sle, h]
+  simp [ISize.max_def, apply_ite (ISize.toBitVec64 · h), this]
 
 @[int_toBitVec]
 theorem ISize.toBitVec64_neg {a : ISize} (h : System.Platform.numBits = 64) :

--- a/src/Init/Data/SInt/Lemmas.lean
+++ b/src/Init/Data/SInt/Lemmas.lean
@@ -57,10 +57,22 @@ macro "declare_int_theorems" typeName:ident _bits:term:arg : command => do
   @[simp] protected theorem toBitVec_div {a b : $typeName} : (a / b).toBitVec = a.toBitVec.sdiv b.toBitVec := (rfl)
   @[simp] protected theorem toBitVec_mod {a b : $typeName} : (a % b).toBitVec = a.toBitVec.srem b.toBitVec := (rfl)
 
+  protected theorem min_def {a b : $typeName} : min a b = if a ≤ b then a else b := by rfl
+  protected theorem max_def {a b : $typeName} : max a b = if a ≤ b then b else a := by rfl
+
+  open $typeName (min_def le_iff_toBitVec_sle)
+  @[simp] protected theorem toBitVec_min {a b : $typeName} : (min a b).toBitVec = if a.toBitVec.sle b.toBitVec then a.toBitVec else b.toBitVec := by
+    simp [BitVec.min_def, min_def, apply_ite toBitVec, le_iff_toBitVec_sle]
+
+  open $typeName (max_def le_iff_toBitVec_sle)
+  @[simp] protected theorem toBitVec_max {a b : $typeName} : (max a b).toBitVec = if a.toBitVec.sle b.toBitVec then b.toBitVec else a.toBitVec := by
+    simp [BitVec.max_def, max_def, apply_ite toBitVec, le_iff_toBitVec_sle]
+
   )
   unless isISize do
     let names := #[`le_iff_toBitVec_sle, `lt_iff_toBitVec_slt, `eq_iff_toBitVec_eq, `ne_iff_toBitVec_ne,
-      `toBitVec_add, `toBitVec_sub, `toBitVec_mul, `toBitVec_div, `toBitVec_mod]
+      `toBitVec_add, `toBitVec_sub, `toBitVec_mul, `toBitVec_div, `toBitVec_mod, `toBitVec_min,
+      `toBitVec_max]
     let idents := names.map fun n => mkIdent (typeName.getId ++ n)
     cmds := cmds.push <| ← `(attribute [int_toBitVec] $idents*)
   cmds := cmds.push <| ← `(end $typeName)

--- a/src/Init/Data/UInt/IntToBitVec.lean
+++ b/src/Init/Data/UInt/IntToBitVec.lean
@@ -107,6 +107,22 @@ theorem USize.toBitVec32_neg {a : USize} (h : System.Platform.numBits = 32) :
   rfl
 
 @[int_toBitVec]
+theorem USize.toBitVec32_min {a b : USize} (h : System.Platform.numBits = 32) :
+    (min a b).toBitVec32 h = min (a.toBitVec32 h) (b.toBitVec32 h) := by
+  simp only [USize.toBitVec_min, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec32_max {a b : USize} (h : System.Platform.numBits = 32) :
+    (max a b).toBitVec32 h = max (a.toBitVec32 h) (b.toBitVec32 h) := by
+  simp only [USize.toBitVec_max, USize.toBitVec32_eq_toBitVec]
+  generalize 32 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
 theorem USize.toBitVec32_not {a : USize} (h : System.Platform.numBits = 32) :
     (~~~a).toBitVec32 h = ~~~a.toBitVec32 h := by
   simp only [USize.toBitVec_not, USize.toBitVec32_eq_toBitVec]
@@ -342,6 +358,22 @@ theorem USize.toBitVec64_mod {a b : USize} (h : System.Platform.numBits = 64) :
 theorem USize.toBitVec64_neg {a : USize} (h : System.Platform.numBits = 64) :
     (-a).toBitVec64 h = -a.toBitVec64 h := by
   simp only [USize.toBitVec_neg, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_min {a b : USize} (h : System.Platform.numBits = 64) :
+    (min a b).toBitVec64 h = min (a.toBitVec64 h) (b.toBitVec64 h) := by
+  simp only [USize.toBitVec_min, USize.toBitVec64_eq_toBitVec]
+  generalize 64 = x at *
+  subst h
+  rfl
+
+@[int_toBitVec]
+theorem USize.toBitVec64_max {a b : USize} (h : System.Platform.numBits = 64) :
+    (max a b).toBitVec64 h = max (a.toBitVec64 h) (b.toBitVec64 h) := by
+  simp only [USize.toBitVec_max, USize.toBitVec64_eq_toBitVec]
   generalize 64 = x at *
   subst h
   rfl

--- a/src/Init/Data/UInt/Lemmas.lean
+++ b/src/Init/Data/UInt/Lemmas.lean
@@ -211,6 +211,17 @@ instance : LawfulOrderLT $typeName where
   @[simp] protected theorem toBitVec_mod {a b : $typeName} : (a % b).toBitVec = a.toBitVec % b.toBitVec := (rfl)
   @[simp] protected theorem toBitVec_neg {a : $typeName} : (-a).toBitVec = -a.toBitVec := (rfl)
 
+  protected theorem min_def {a b : $typeName} : min a b = if a ≤ b then a else b := by rfl
+  protected theorem max_def {a b : $typeName} : max a b = if a ≤ b then b else a := by rfl
+
+  open $typeName (min_def le_iff_toBitVec_le) in
+  @[simp] protected theorem toBitVec_min {a b : $typeName} : (min a b).toBitVec = min a.toBitVec b.toBitVec := by
+    simp [BitVec.min_def, min_def, apply_ite toBitVec, le_iff_toBitVec_le]
+
+  open $typeName (max_def le_iff_toBitVec_le) in
+  @[simp] protected theorem toBitVec_max {a b : $typeName} : (max a b).toBitVec = max a.toBitVec b.toBitVec := by
+    simp [BitVec.max_def, max_def, apply_ite toBitVec, le_iff_toBitVec_le]
+
   )
   if let some nbits := bits.raw.isNatLit? then
     if nbits > 8 then
@@ -239,7 +250,8 @@ instance : LawfulOrderLT $typeName where
         `(@[simp] theorem toNat_toUInt64 (x : $typeName) : x.toUInt64.toNat = x.toNat := (rfl))
   unless isUSize do
     let names := #[`le_iff_toBitVec_le, `lt_iff_toBitVec_lt, `eq_iff_toBitVec_eq, `ne_iff_toBitVec_ne,
-      `toBitVec_add, `toBitVec_sub, `toBitVec_mul, `toBitVec_div, `toBitVec_mod, `toBitVec_neg]
+      `toBitVec_add, `toBitVec_sub, `toBitVec_mul, `toBitVec_div, `toBitVec_mod, `toBitVec_neg,
+      `toBitVec_min, `toBitVec_max]
     let idents := names.map fun n => mkIdent (typeName.getId ++ n)
     cmds := cmds.push <| ← `(attribute [int_toBitVec] $idents*)
   cmds := cmds.push <| ← `(end $typeName)

--- a/src/Std/Tactic/BVDecide/Normalize/BitVec.lean
+++ b/src/Std/Tactic/BVDecide/Normalize/BitVec.lean
@@ -42,6 +42,9 @@ theorem BitVec.gt_ult (x y : BitVec w) : x > y ↔ (y.ult x = true) := by
 theorem BitVec.ge_ule (x y : BitVec w) : x ≥ y ↔ ((!x.ult y) = true) := by
   simp [BitVec.le_ult]
 
+attribute [bv_normalize] BitVec.min_def
+attribute [bv_normalize] BitVec.max_def
+
 attribute [bv_normalize] BitVec.zeroExtend_eq_setWidth
 attribute [bv_normalize] BitVec.truncate_eq_setWidth
 attribute [bv_normalize] BitVec.setWidth'_eq

--- a/tests/elab/bv_minmax.lean
+++ b/tests/elab/bv_minmax.lean
@@ -1,0 +1,71 @@
+module
+import Std.Tactic.BVDecide
+meta import Std.Tactic.BVDecide
+
+/-! Test the min/max integration of bv_decide -/
+
+example (a b : BitVec 64) : min a b = min b a := by
+  bv_decide
+
+example (a b : UInt8) : min a b = min b a := by
+  bv_decide
+
+example (a b : UInt16) : min a b = min b a := by
+  bv_decide
+
+example (a b : UInt32) : min a b = min b a := by
+  bv_decide
+
+example (a b : UInt64) : min a b = min b a := by
+  bv_decide
+
+example (a b : USize) : min a b = min b a := by
+  cases System.Platform.numBits_eq <;> bv_decide
+
+example (a b : Int8) : min a b = min b a := by
+  bv_decide
+
+example (a b : Int16) : min a b = min b a := by
+  bv_decide
+
+example (a b : Int32) : min a b = min b a := by
+  bv_decide
+
+example (a b : Int64) : min a b = min b a := by
+  bv_decide
+
+example (a b : ISize) : min a b = min b a := by
+  cases System.Platform.numBits_eq <;> bv_decide
+
+example (a b : BitVec 64) : max a b = max b a := by
+  bv_decide
+
+example (a b : UInt8) : max a b = max b a := by
+  bv_decide
+
+example (a b : UInt16) : max a b = max b a := by
+  bv_decide
+
+example (a b : UInt32) : max a b = max b a := by
+  bv_decide
+
+example (a b : UInt64) : max a b = max b a := by
+  bv_decide
+
+example (a b : USize) : max a b = max b a := by
+  cases System.Platform.numBits_eq <;> bv_decide
+
+example (a b : Int8) : max a b = max b a := by
+  bv_decide
+
+example (a b : Int16) : max a b = max b a := by
+  bv_decide
+
+example (a b : Int32) : max a b = max b a := by
+  bv_decide
+
+example (a b : Int64) : max a b = max b a := by
+  bv_decide
+
+example (a b : ISize) : max a b = max b a := by
+  cases System.Platform.numBits_eq <;> bv_decide


### PR DESCRIPTION
This PR introduces definitions for `min`/`max` on `BitVec` as well as support in `bv_decide` for `min`/`max` on `BitVec` and the `UIntX`/`IntX` family of functions.