### PR TITLE
fix: deriving ToJson/FromJson for mutual groups with self-recursion

### DIFF
--- a/src/Lean/Elab/Deriving/FromToJson.lean
+++ b/src/Lean/Elab/Deriving/FromToJson.lean
@@ -40,9 +40,20 @@ def mkToJsonBodyForStruct (header : Header) (indName : Name) : TermElabM Term :=
     else ``([($nm, toJson ($target).$(mkIdent field))])
   `(mkObj <| List.flatten [$fields,*])
 
+/--
+The auxiliary function generated for `indVal` itself, which for a `mutual` group
+is not necessarily the first one: `auxFunNames` runs parallel to `typeInfos`.
+Used for a *self*-recursive constructor argument; taking `auxFunNames[0]` there
+generates a call to another member's function and so ill-typed code.
+-/
+private def selfAuxFunName (ctx : Context) (indVal : InductiveVal) : TermElabM Name := do
+  let some i := ctx.typeInfos.findIdx? (·.name == indVal.name)
+    | throwError "deriving: {indVal.name} is not among the types being derived for"
+  return ctx.auxFunNames[i]!
+
 def mkToJsonBodyForInduct (ctx : Context) (header : Header) (indName : Name) : TermElabM Term := do
   let indVal ← getConstInfoInduct indName
-  let toJsonFuncId := mkIdent ctx.auxFunNames[0]!
+  let toJsonFuncId := mkIdent (← selfAuxFunName ctx indVal)
   -- Return syntax to JSONify `id`, either via `ToJson` or recursively
   -- if `id`'s type is the type we're deriving for.
   let mkToJson (id : Ident) (type : Expr) : TermElabM Term := do
@@ -118,6 +129,7 @@ def mkFromJsonBodyForInduct (ctx : Context) (indName : Name) : TermElabM Term :=
     | none => Except.error "no inductive tag found")
 where
   mkAlts (indVal : InductiveVal) : TermElabM (Array (String × Term)) := do
+  let selfFunName ← selfAuxFunName ctx indVal
   let mut alts := #[]
   for ctorName in indVal.ctors do
     let ctorInfo ← getConstInfoCtor ctorName
@@ -132,7 +144,7 @@ where
             userNames := userNames.push localDecl.userName
           let a := mkIdent (← mkFreshUserName `a)
           binders := binders.push (a, localDecl.type)
-        let fromJsonFuncId := mkIdent ctx.auxFunNames[0]!
+        let fromJsonFuncId := mkIdent selfFunName
         -- Return syntax to parse `id`, either via `FromJson` or recursively
         -- if `id`'s type is the type we're deriving for.
         let mkFromJson (idx : Nat) (type : Expr) : TermElabM (TSyntax ``doExpr) :=

--- a/tests/elab/derivingJsonMutualSelfRec.lean
+++ b/tests/elab/derivingJsonMutualSelfRec.lean
@@ -1,0 +1,55 @@
+import Lean.Data.Json
+open Lean
+
+/-!
+`deriving ToJson`/`FromJson` for a `mutual` group used to dispatch a *self*
+recursive constructor argument to the group's *first* auxiliary function rather
+than the one being generated, producing ill-typed code:
+
+    Application type mismatch: The argument a✝
+      has type              B
+      but is expected to have type  A
+    in the application    toJson_1 a✝
+
+Only a member other than the first was affected, since the first member's own
+auxiliary function is the one that was used.
+-/
+
+
+mutual
+inductive A where
+  | a1 : Nat → A
+  | a2 : B → A
+inductive B where
+  | b1 : Nat → B
+  | b2 : B → B          -- self-recursive, in a non-first member
+end
+
+deriving instance ToJson for A, B
+deriving instance FromJson for A, B
+
+/-- info: {"a2": {"b2": {"b1": 7}}} -/
+#guard_msgs in
+#eval toJson (A.a2 (.b2 (.b1 7)))
+
+/-- info: true -/
+#guard_msgs in
+#eval ((fromJson? (toJson (A.a2 (.b2 (.b1 7)))) : Except String A)).toOption.isSome
+
+-- self-recursion three members deep, and in the last member
+mutual
+inductive C where
+  | c1 : D → C
+inductive D where
+  | d1 : E → D
+inductive E where
+  | e1 : Nat → E
+  | e2 : E → E
+end
+
+deriving instance ToJson for C, D, E
+deriving instance FromJson for C, D, E
+
+/-- info: {"c1": {"d1": {"e2": {"e1": 1}}}} -/
+#guard_msgs in
+#eval toJson (C.c1 (.d1 (.e2 (.e1 1))))


### PR DESCRIPTION
This PR fixes `deriving ToJson`/`FromJson` generating ill-typed code for a
`mutual` inductive group when a self-recursive constructor argument occurs in a
member other than the first.

Closes #14958.

## The bug

Both handlers dispatched a **self**-recursive constructor argument to
`ctx.auxFunNames[0]` — the auxiliary function of the group's *first* member —
instead of the one being generated. `auxFunNames` runs parallel to `typeInfos`,
so that is the right function only when the self-recursive type happens to be
listed first; otherwise:

```lean
mutual
inductive A where
  | a1 : Nat → A
  | a2 : B → A
inductive B where
  | b1 : Nat → B
  | b2 : B → B          -- self-recursive, in a non-first member
end

deriving instance ToJson for A, B
```

```
Application type mismatch: The argument a✝
  has type              B
  but is expected to have type  A
in the application    toJson_1 a✝
```

`FromJson` fails symmetrically, decoding an `A` and then applying `B.b2` to it.

Recursion to *another* member of the group was always fine, because that goes
through the member's `ToJson`/`FromJson` instance rather than an auxiliary
function — which is why a mutual chain `T₀ → T₁ → … → T₀` derives cleanly and
only self-recursion is affected.

## The change

Both sites now look the type up in `ctx.typeInfos` rather than assuming index 0,
via a small shared helper. `mkToJsonAuxFunction`/`mkFromJsonAuxFunction` do have
the correct index in hand, but threading it through would change the signatures
of the public `mkToJsonBody`/`mkFromJsonBody`; the lookup keeps the fix local.
For a non-mutual derivation the index is 0, so behaviour there is unchanged.

## Testing

`tests/elab/derivingJsonMutualSelfRec.lean` covers self-recursion in a non-first
member and in the last member of a three-type group, with `#guard_msgs` on
round-tripped values so the generated instances are exercised, not just
elaborated. It fails on current master with 19 errors and passes with this
change.

All 13 existing tests under `tests/` that mention `ToJson`/`FromJson` still pass.

Also checked against the case that prompted this: the Cerberus C AST as
translated to Lean, whose generated syntax module puts 34 types in one `mutual`
block with `direct_declarator` (the twentieth) having two self-recursive
constructors. Deriving both `ToJson` and `FromJson` over that group goes from 101
errors to none.
