### PR TITLE
fix: link `libLeanExport.a` into executables that link Lake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -550,8 +550,8 @@ if(NOT LEAN_STANDALONE)
   string(APPEND CMAKE_EXE_LINKER_FLAGS " ${LEAN_CXX_STDLIB}")
 endif()
 
-# flags for user binaries = flags for toolchain binaries + Lake
-set(LEANC_STATIC_LINKER_FLAGS " ${TOOLCHAIN_STATIC_LINKER_FLAGS} -lLake")
+# flags for user binaries = flags for toolchain binaries + Lake (and deps)
+set(LEANC_STATIC_LINKER_FLAGS " ${TOOLCHAIN_STATIC_LINKER_FLAGS} -lLake -lLeanExport")
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   set(LEANC_SHARED_LINKER_FLAGS " ${TOOLCHAIN_SHARED_LINKER_FLAGS} -Wl,--as-needed -lLake_shared -Wl,--no-as-needed")
 else()

--- a/tests/lake/tests/linkLake/Main.lean
+++ b/tests/lake/tests/linkLake/Main.lean
@@ -1,0 +1,9 @@
+import Lake.All
+
+/-!
+Root of an executable that links against Lake, to check that the toolchain's static link line
+covers every library Lake references.
+-/
+
+def main : IO Unit :=
+  IO.println s!"Lake {Lake.versionStringCore}"

--- a/tests/lake/tests/linkLake/clean.sh
+++ b/tests/lake/tests/linkLake/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/linkLake/lakefile.toml
+++ b/tests/lake/tests/linkLake/lakefile.toml
@@ -1,0 +1,6 @@
+name = "test"
+defaultTargets = ["main"]
+
+[[lean_exe]]
+name = "main"
+root = "Main"

--- a/tests/lake/tests/linkLake/test.sh
+++ b/tests/lake/tests/linkLake/test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+source ../common.sh
+./clean.sh
+
+# Downstream executables link Lake statically (see `LEANC_STATIC_LINKER_FLAGS`), so every
+# toolchain library Lake pulls in must be on that link line. Importing `Lake.All` initializes
+# every Lake module and thus exercises all of those references.
+
+test_run build
+test_cmd_out "Lake " ./.lake/build/bin/main
+
+# Cleanup
+rm -f produced.out


### PR DESCRIPTION
This PR fixes a link failure in downstream packages that build an executable: `libLake.a` references `LeanExport` symbols, but `-lLeanExport` was missing from the static link line, so linking failed with undefined `initialize_LeanExport_Parse`, `runtime_initialize_LeanExport_Parse` and `l_LeanExport_parseStream`.

`lake challenge` made Lake depend on `LeanExport`, and `LAKESHARED_LINKER_FLAGS` was updated accordingly, but `LEANC_STATIC_LINKER_FLAGS` was not. Lean core libs are linked statically into executables on every platform but Windows (see `LeanExe.sharedLean`), so this affected essentially every downstream executable importing Lake. The new `linkLake` Lake test builds and runs such an executable, importing `Lake.All` so that all of Lake's cross-library references are exercised.