### PR TITLE
perf: avoid `setTransparency` when the transparency is already in effect

### DIFF
--- a/src/Lean/Meta/Basic.lean
+++ b/src/Lean/Meta/Basic.lean
@@ -1304,8 +1304,10 @@ private def Context.setTransparency (ctx : Context) (transparency : Transparency
   { ctx with keyedConfig := ctx.keyedConfig.setTransparency transparency }
 
 @[inline] def withTransparency (mode : TransparencyMode) : n α → n α :=
-  -- We avoid `withConfig` for performance reasons.
-  mapMetaM <| withReader (·.setTransparency mode)
+  -- We avoid `withConfig` for performance reasons. `setTransparency` rebuilds `Config`,
+  -- `ConfigWithKey` and `Context`, so skip it when the mode is already in effect.
+  mapMetaM <| withReader fun ctx =>
+    if ctx.config.transparency == mode then ctx else ctx.setTransparency mode
 
 /-- `withDefault x` executes `x` using the default transparency setting. -/
 @[inline] def withDefault (x : n α) : n α :=
@@ -1338,8 +1340,7 @@ Recall that `.none < .reducible < .instances < .implicit < .default < .all`.
 -/
 @[inline] def withAtLeastTransparency (mode : TransparencyMode) : n α → n α :=
   mapMetaM <| withReader fun ctx =>
-    let modeOld := ctx.config.transparency
-    ctx.setTransparency <| if modeOld.lt mode then mode else modeOld
+    if ctx.config.transparency.lt mode then ctx.setTransparency mode else ctx
 
 /-- Execute `x` allowing `isDefEq` to assign synthetic opaque metavariables. -/
 @[inline] def withAssignableSyntheticOpaque (x : n α) : n α :=


### PR DESCRIPTION
This PR speeds up elaboration by not rebuilding the `MetaM` context when `withTransparency` or `withAtLeastTransparency` is asked for the transparency setting that is already in effect. Mathlib/core -0.3% instrs.

`Context.setTransparency` rebuilds `Config`, `ConfigWithKey` and `Context`, so each such call allocated three objects and retraced the `Context`'s pointer fields even when nothing changed. `withTransparency` did this unconditionally, and `withAtLeastTransparency` did it by construction on the branch where the ambient mode already suffices. Both are hot: `withInferTypeConfig` wraps every `inferType` in `withAtLeastTransparency .default`, as does `getFunInfoAux`, and `.default` is usually the ambient mode already.

Skipping the rebuild is observationally equivalent: `ConfigWithKey.key` is maintained as `Config.toKey`, whose low three bits are exactly `transparency.toUInt64`, so re-applying the current mode reproduces an identical `Config` and an identical key.