### PR TITLE
perf: give `currRecDepth` its own `ReaderT` layer in `CoreM` 

### DIFF
--- a/src/Lean/CoreM.lean
+++ b/src/Lean/CoreM.lean
@@ -232,10 +232,9 @@ structure Context.Cold where
   inheritedTraceOptions : Std.HashSet Name := {}
   deriving Nonempty
 
-/-- Context for the CoreM monad. -/
+/-- Main context for the CoreM monad. -/
 structure Context extends Context.Cold where
   options        : Options := {}
-  currRecDepth   : Nat := 0
   maxRecDepth    : Nat := 1000
   ref            : Syntax := Syntax.missing
   currNamespace  : Name := Name.anonymous
@@ -255,6 +254,12 @@ structure Context extends Context.Cold where
   suppressElabErrors : Bool := false
   deriving Nonempty
 
+/-- Additional context put in a separate reader for fastest access. -/
+-- Should likely remain a single field for structure unboxing
+structure Context.Hot where
+  currRecDepth   : Nat := 0
+  deriving Inhabited
+
 /-- CoreM is a monad for manipulating the Lean environment.
 It is the base monad for `MetaM`.
 The main features it provides are:
@@ -263,7 +268,13 @@ The main features it provides are:
 - Lean options context
 - the current open namespace
 -/
-abbrev CoreM := ReaderT Context <| StateRefT State (EIO Exception)
+/-
+The current recursion depth has its own reader layer rather than a `Context` field as `withReader`
+cannot reuse the `Context` object still referenced by the caller and modifying the depth is by far
+the most common context change. The layer sits *inside* the `Context` reader so that a bare `read`
+still resolves to `Context`.
+-/
+abbrev CoreM := ReaderT Context <| ReaderT Context.Hot <| StateRefT State (EIO Exception)
 
 -- Make the compiler generate specialized `pure`/`bind` so we do not have to optimize through the
 -- whole monad stack at every use site. May eventually be covered by `deriving`.
@@ -316,8 +327,8 @@ instance : MonadDeclNameGenerator CoreM where
   setDeclNGen ngen := modify fun s => { s with auxDeclNGen := ngen }
 
 instance : MonadRecDepth CoreM where
-  withRecDepth d x := withReader (fun ctx => { ctx with currRecDepth := d }) x
-  getRecDepth := return (← read).currRecDepth
+  withRecDepth d x := fun ctx => withTheReader Context.Hot (fun _ => { ctx with currRecDepth := d }) (x ctx)
+  getRecDepth := fun _ => return (← readThe Context.Hot).currRecDepth
   getMaxRecDepth := return (← read).maxRecDepth
 
 instance : MonadResolveName CoreM where
@@ -437,11 +448,13 @@ that are conditionally inaccessible, depending on the current value of the `tact
 def mkFreshUserName (n : Name) : CoreM Name :=
   mkFreshNameImp n
 
-@[inline] def CoreM.run (x : CoreM α) (ctx : Context) (s : State) : EIO Exception (α × State) :=
-  ((withConsistentCtx x) ctx).run s
+@[inline] def CoreM.run (x : CoreM α) (ctx : Context) (s : State) (ctxHot : Context.Hot := {}) :
+    EIO Exception (α × State) :=
+  (((withConsistentCtx x) ctx) ctxHot).run s
 
-@[inline] def CoreM.run' (x : CoreM α) (ctx : Context) (s : State) : EIO Exception α :=
-  Prod.fst <$> x.run ctx s
+@[inline] def CoreM.run' (x : CoreM α) (ctx : Context) (s : State) (ctxHot : Context.Hot := {}) :
+    EIO Exception α :=
+  Prod.fst <$> x.run ctx s ctxHot
 
 /--
 Run a `CoreM` monad in IO.

--- a/src/Lean/Elab/Command.lean
+++ b/src/Lean/Elab/Command.lean
@@ -267,7 +267,6 @@ private def runCore (x : CoreM α) : CommandElabM α := do
   let coreCtx : Core.Context := {
     fileName           := ctx.fileName
     fileMap            := ctx.fileMap
-    currRecDepth       := ctx.currRecDepth
     maxRecDepth        := s.maxRecDepth
     ref                := ctx.ref
     currNamespace      := scope.currNamespace
@@ -288,7 +287,7 @@ private def runCore (x : CoreM α) : CommandElabM α := do
     infoState.lazyAssignment := s.infoState.lazyAssignment
     traceState := s.traceState
     snapshotTasks := s.snapshotTasks
-  }
+  } (ctxHot := { currRecDepth := ctx.currRecDepth })
   let (ea, coreS) ← liftM x
   modify fun s => { s with
     env                      := coreS.env
@@ -1096,7 +1095,7 @@ private def liftCommandElabMCore (cmd : CommandElabM α) (throwOnError : Bool) :
     cmd.run {
       fileName := ctx.fileName
       fileMap := ctx.fileMap
-      currRecDepth := ctx.currRecDepth
+      currRecDepth := (← MonadRecDepth.getRecDepth)
       currMacroScope := ctx.currMacroScope
       ref := ctx.ref
       snap? := none

--- a/tests/elab/attachJp.lean.out.expected
+++ b/tests/elab/attachJp.lean.out.expected
@@ -78,16 +78,16 @@
       let _x.5 := @Array.mkEmpty _ _x.4;
       let _x.6 := @Array.push _ _x.5 _x.3;
       let _x.7 := PUnit.unit;
-      fun _f.8 _y.9 @&_y.10 @&_y.11 @&_y.12 @&_y.13 @&_y.14 _y.15 : EST.Out Lean.Exception lcAny PUnit :=
-        let _x.16 := Lean.Compiler.compile _x.6 _y.13 _y.14 _y.15;
-        cases _x.16 : EST.Out Lean.Exception lcAny PUnit
-        | EST.Out.ok a.17 a.18 =>
-          let _x.19 := @EST.Out.ok _ _ _ _x.7 a.18;
-          return _x.19
-        | EST.Out.error a.20 a.21 =>
-          return _x.16;
-      let _x.22 := @Lean.Elab.Command.liftTermElabM _ _f.8 a a a.1;
-      return _x.22
+      fun _f.8 _y.9 @&_y.10 @&_y.11 @&_y.12 @&_y.13 @&_y.14 @&_y.15 _y.16 : EST.Out Lean.Exception lcAny PUnit :=
+        let _x.17 := Lean.Compiler.compile _x.6 _y.13 _y.14 _y.15 _y.16;
+        cases _x.17 : EST.Out Lean.Exception lcAny PUnit
+        | EST.Out.ok a.18 a.19 =>
+          let _x.20 := @EST.Out.ok _ _ _ _x.7 a.19;
+          return _x.20
+        | EST.Out.error a.21 a.22 =>
+          return _x.17;
+      let _x.23 := @Lean.Elab.Command.liftTermElabM _ _f.8 a a a.1;
+      return _x.23
 [Compiler.simp] size: 12
     def _private.elab.attachJp.0._eval @&a @&a a.1 : EST.Out Lean.Exception lcAny PUnit :=
       let _x.2 := "f";
@@ -96,16 +96,16 @@
       let _x.5 := @Array.mkEmpty _ _x.4;
       let _x.6 := @Array.push _ _x.5 _x.3;
       let _x.7 := PUnit.unit;
-      fun _f.8 _y.9 @&_y.10 @&_y.11 @&_y.12 @&_y.13 @&_y.14 _y.15 : EST.Out Lean.Exception lcAny PUnit :=
-        let _x.16 := Lean.Compiler.compile _x.6 _y.13 _y.14 _y.15;
-        cases _x.16 : EST.Out Lean.Exception lcAny PUnit
-        | EST.Out.ok a.17 a.18 =>
-          let _x.19 := @EST.Out.ok _ _ _ _x.7 a.18;
-          return _x.19
-        | EST.Out.error a.20 a.21 =>
-          return _x.16;
-      let _x.22 := @Lean.Elab.Command.liftTermElabM _ _f.8 a a a.1;
-      return _x.22
+      fun _f.8 _y.9 @&_y.10 @&_y.11 @&_y.12 @&_y.13 @&_y.14 @&_y.15 _y.16 : EST.Out Lean.Exception lcAny PUnit :=
+        let _x.17 := Lean.Compiler.compile _x.6 _y.13 _y.14 _y.15 _y.16;
+        cases _x.17 : EST.Out Lean.Exception lcAny PUnit
+        | EST.Out.ok a.18 a.19 =>
+          let _x.20 := @EST.Out.ok _ _ _ _x.7 a.19;
+          return _x.20
+        | EST.Out.error a.21 a.22 =>
+          return _x.17;
+      let _x.23 := @Lean.Elab.Command.liftTermElabM _ _f.8 a a a.1;
+      return _x.23
 [Compiler.simp] size: 12
     def _private.elab.attachJp.0._eval @&a @&a a.1 : EST.Out Lean.Exception lcAny PUnit :=
       let _x.2 := "f";
@@ -114,16 +114,16 @@
       let _x.5 := @Array.mkEmpty _ _x.4;
       let _x.6 := @Array.push _ _x.5 _x.3;
       let _x.7 := PUnit.unit;
-      fun _f.8 _y.9 @&_y.10 @&_y.11 @&_y.12 @&_y.13 @&_y.14 _y.15 : EST.Out Lean.Exception lcAny PUnit :=
-        let _x.16 := Lean.Compiler.compile _x.6 _y.13 _y.14 _y.15;
-        cases _x.16 : EST.Out Lean.Exception lcAny PUnit
-        | EST.Out.ok a.17 a.18 =>
-          let _x.19 := @EST.Out.ok _ _ _ _x.7 a.18;
-          return _x.19
-        | EST.Out.error a.20 a.21 =>
-          return _x.16;
-      let _x.22 := @Lean.Elab.Command.liftTermElabM _ _f.8 a a a.1;
-      return _x.22
+      fun _f.8 _y.9 @&_y.10 @&_y.11 @&_y.12 @&_y.13 @&_y.14 @&_y.15 _y.16 : EST.Out Lean.Exception lcAny PUnit :=
+        let _x.17 := Lean.Compiler.compile _x.6 _y.13 _y.14 _y.15 _y.16;
+        cases _x.17 : EST.Out Lean.Exception lcAny PUnit
+        | EST.Out.ok a.18 a.19 =>
+          let _x.20 := @EST.Out.ok _ _ _ _x.7 a.19;
+          return _x.20
+        | EST.Out.error a.21 a.22 =>
+          return _x.17;
+      let _x.23 := @Lean.Elab.Command.liftTermElabM _ _f.8 a a a.1;
+      return _x.23
 [Compiler.simp] size: 12
     def _private.elab.attachJp.0._eval @&a @&a a.1 : EST.Out Lean.Exception lcAny PUnit :=
       let _x.2 := "f";
@@ -132,16 +132,16 @@
       let _x.5 := Array.mkEmpty ◾ _x.4;
       let _x.6 := Array.push ◾ _x.5 _x.3;
       let _x.7 := PUnit.unit;
-      fun _f.8 _y.9 @&_y.10 @&_y.11 @&_y.12 @&_y.13 @&_y.14 _y.15 : EST.Out Lean.Exception lcAny PUnit :=
-        let _x.16 := Lean.Compiler.compile _x.6 _y.13 _y.14 _y.15;
-        cases _x.16 : EST.Out Lean.Exception lcAny PUnit
-        | EST.Out.ok a.17 a.18 =>
-          let _x.19 := @EST.Out.ok ◾ ◾ ◾ _x.7 a.18;
-          return _x.19
-        | EST.Out.error a.20 a.21 =>
-          return _x.16;
-      let _x.22 := Lean.Elab.Command.liftTermElabM._redArg _f.8 a a a.1;
-      return _x.22
+      fun _f.8 _y.9 @&_y.10 @&_y.11 @&_y.12 @&_y.13 @&_y.14 @&_y.15 _y.16 : EST.Out Lean.Exception lcAny PUnit :=
+        let _x.17 := Lean.Compiler.compile _x.6 _y.13 _y.14 _y.15 _y.16;
+        cases _x.17 : EST.Out Lean.Exception lcAny PUnit
+        | EST.Out.ok a.18 a.19 =>
+          let _x.20 := @EST.Out.ok ◾ ◾ ◾ _x.7 a.19;
+          return _x.20
+        | EST.Out.error a.21 a.22 =>
+          return _x.17;
+      let _x.23 := Lean.Elab.Command.liftTermElabM._redArg _f.8 a a a.1;
+      return _x.23
 [Compiler.simp] size: 12
     def _private.elab.attachJp.0._eval @&a @&a a.1 : EST.Out Lean.Exception lcAny PUnit :=
       let _x.2 := "f";
@@ -150,26 +150,26 @@
       let _x.5 := Array.mkEmpty ◾ _x.4;
       let _x.6 := Array.push ◾ _x.5 _x.3;
       let _x.7 := PUnit.unit;
-      fun _f.8 _y.9 @&_y.10 @&_y.11 @&_y.12 @&_y.13 @&_y.14 _y.15 : EST.Out Lean.Exception lcAny PUnit :=
-        let _x.16 := Lean.Compiler.compile _x.6 _y.13 _y.14 _y.15;
-        cases _x.16 : EST.Out Lean.Exception lcAny PUnit
-        | EST.Out.ok a.17 a.18 =>
-          let _x.19 := @EST.Out.ok ◾ ◾ ◾ _x.7 a.18;
-          return _x.19
-        | EST.Out.error a.20 a.21 =>
-          return _x.16;
-      let _x.22 := Lean.Elab.Command.liftTermElabM._redArg _f.8 a a a.1;
-      return _x.22
+      fun _f.8 _y.9 @&_y.10 @&_y.11 @&_y.12 @&_y.13 @&_y.14 @&_y.15 _y.16 : EST.Out Lean.Exception lcAny PUnit :=
+        let _x.17 := Lean.Compiler.compile _x.6 _y.13 _y.14 _y.15 _y.16;
+        cases _x.17 : EST.Out Lean.Exception lcAny PUnit
+        | EST.Out.ok a.18 a.19 =>
+          let _x.20 := @EST.Out.ok ◾ ◾ ◾ _x.7 a.19;
+          return _x.20
+        | EST.Out.error a.21 a.22 =>
+          return _x.17;
+      let _x.23 := Lean.Elab.Command.liftTermElabM._redArg _f.8 a a a.1;
+      return _x.23
 [Compiler.simp] size: 5
-    def _private.elab.attachJp.0._eval._lam_0 _x.1 _x.2 _y.3 @&_y.4 @&_y.5 @&_y.6 @&_y.7 @&_y.8 _y.9 : EST.Out
+    def _private.elab.attachJp.0._eval._lam_0 _x.1 _x.2 _y.3 @&_y.4 @&_y.5 @&_y.6 @&_y.7 @&_y.8 @&_y.9 _y.10 : EST.Out
       Lean.Exception lcAny PUnit :=
-      let _x.10 := Lean.Compiler.compile _x.1 _y.7 _y.8 _y.9;
-      cases _x.10 : EST.Out Lean.Exception lcAny PUnit
-      | EST.Out.ok a.11 a.12 =>
-        let _x.13 := @EST.Out.ok ◾ ◾ ◾ _x.2 a.12;
-        return _x.13
-      | EST.Out.error a.14 a.15 =>
-        return _x.10
+      let _x.11 := Lean.Compiler.compile _x.1 _y.7 _y.8 _y.9 _y.10;
+      cases _x.11 : EST.Out Lean.Exception lcAny PUnit
+      | EST.Out.ok a.12 a.13 =>
+        let _x.14 := @EST.Out.ok ◾ ◾ ◾ _x.2 a.13;
+        return _x.14
+      | EST.Out.error a.15 a.16 =>
+        return _x.11
 [Compiler.simp] size: 8
     def _private.elab.attachJp.0._eval @&a @&a a.1 : EST.Out Lean.Exception lcAny PUnit :=
       let _x.2 := "f";

--- a/tests/elab/casesOnSameCtor.lean
+++ b/tests/elab/casesOnSameCtor.lean
@@ -136,15 +136,15 @@ namespace List
 -- No code is generated for the match_on_same_ctor or match_on_same_ctor.het
 /--
 trace: [Compiler.saveMono] size: 5
-    def _private.elab.casesOnSameCtor.0._eval._lam_0 _x.1 _x.2 _x.3 _y.4 @&_y.5 @&_y.6 @&_y.7 @&_y.8 @&_y.9 _y.10 : EST.Out
+    def _private.elab.casesOnSameCtor.0._eval._lam_0 _x.1 _x.2 _x.3 _y.4 @&_y.5 @&_y.6 @&_y.7 @&_y.8 @&_y.9 @&_y.10 _y.11 : EST.Out
       Exception lcAny PUnit :=
-      let _x.11 := mkCasesOnSameCtor _x.1 _x.2 _y.6 _y.7 _y.8 _y.9 _y.10;
-      cases _x.11 : EST.Out Exception lcAny PUnit
-      | EST.Out.ok a.12 a.13 =>
-        let _x.14 := @EST.Out.ok ◾ ◾ ◾ _x.3 a.13;
-        return _x.14
-      | EST.Out.error a.15 a.16 =>
-        return _x.11
+      let _x.12 := mkCasesOnSameCtor _x.1 _x.2 _y.6 _y.7 _y.8 _y.9 _y.10 _y.11;
+      cases _x.12 : EST.Out Exception lcAny PUnit
+      | EST.Out.ok a.13 a.14 =>
+        let _x.15 := @EST.Out.ok ◾ ◾ ◾ _x.3 a.14;
+        return _x.15
+      | EST.Out.error a.16 a.17 =>
+        return _x.12
 [Compiler.saveMono] size: 7
     def _private.elab.casesOnSameCtor.0._eval @&a @&a a.1 : EST.Out Exception lcAny PUnit :=
       let _x.2 := "List";

--- a/tests/elab/emptyLcnf.lean
+++ b/tests/elab/emptyLcnf.lean
@@ -12,15 +12,15 @@ trace: [Compiler.saveMono] size: 0
       ⊥
 ---
 trace: [Compiler.saveMono] size: 5
-    def _private.elab.emptyLcnf.0._eval._lam_0 _x.1 _x.2 _y.3 @&_y.4 @&_y.5 @&_y.6 @&_y.7 @&_y.8 _y.9 : EST.Out
+    def _private.elab.emptyLcnf.0._eval._lam_0 _x.1 _x.2 _y.3 @&_y.4 @&_y.5 @&_y.6 @&_y.7 @&_y.8 @&_y.9 _y.10 : EST.Out
       Lean.Exception lcAny PUnit :=
-      let _x.10 := Lean.Compiler.compile _x.1 _y.7 _y.8 _y.9;
-      cases _x.10 : EST.Out Lean.Exception lcAny PUnit
-      | EST.Out.ok a.11 a.12 =>
-        let _x.13 := @EST.Out.ok ◾ ◾ ◾ _x.2 a.12;
-        return _x.13
-      | EST.Out.error a.14 a.15 =>
-        return _x.10
+      let _x.11 := Lean.Compiler.compile _x.1 _y.7 _y.8 _y.9 _y.10;
+      cases _x.11 : EST.Out Lean.Exception lcAny PUnit
+      | EST.Out.ok a.12 a.13 =>
+        let _x.14 := @EST.Out.ok ◾ ◾ ◾ _x.2 a.13;
+        return _x.14
+      | EST.Out.error a.15 a.16 =>
+        return _x.11
 [Compiler.saveMono] size: 8
     def _private.elab.emptyLcnf.0._eval @&a @&a a.1 : EST.Out Lean.Exception lcAny PUnit :=
       let _x.2 := "f";

--- a/tests/elab/erased.lean
+++ b/tests/elab/erased.lean
@@ -27,15 +27,15 @@ trace: [Compiler.saveMono] size: 1
 ---
 trace: [Compiler.saveMono] size: 5
     def _private.elab.erased.0._eval._lam_0 (_x.1 : Array
-       Lean.Name) (_x.2 : PUnit) (_y.3 : Lean.Elab.Term.Context) (_y.4 : @&lcAny) (_y.5 : @&Lean.Meta.Context) (_y.6 : @&lcAny) (_y.7 : @&Lean.Core.Context) (_y.8 : @&lcAny) (_y.9 : lcVoid) : EST.Out
+       Lean.Name) (_x.2 : PUnit) (_y.3 : Lean.Elab.Term.Context) (_y.4 : @&lcAny) (_y.5 : @&Lean.Meta.Context) (_y.6 : @&lcAny) (_y.7 : @&Lean.Core.Context) (_y.8 : @&Nat) (_y.9 : @&lcAny) (_y.10 : lcVoid) : EST.Out
       Lean.Exception lcAny PUnit :=
-      let _x.10 : EST.Out Lean.Exception lcAny PUnit := compile _x.1 _y.7 _y.8 _y.9;
-      cases _x.10 : EST.Out Lean.Exception lcAny PUnit
-      | EST.Out.ok (a.11 : PUnit) (a.12 : lcVoid) =>
-        let _x.13 : EST.Out Lean.Exception lcAny PUnit := @EST.Out.ok ◾ ◾ ◾ _x.2 a.12;
-        return _x.13
-      | EST.Out.error (a.14 : Lean.Exception) (a.15 : lcVoid) =>
-        return _x.10
+      let _x.11 : EST.Out Lean.Exception lcAny PUnit := compile _x.1 _y.7 _y.8 _y.9 _y.10;
+      cases _x.11 : EST.Out Lean.Exception lcAny PUnit
+      | EST.Out.ok (a.12 : PUnit) (a.13 : lcVoid) =>
+        let _x.14 : EST.Out Lean.Exception lcAny PUnit := @EST.Out.ok ◾ ◾ ◾ _x.2 a.13;
+        return _x.14
+      | EST.Out.error (a.15 : Lean.Exception) (a.16 : lcVoid) =>
+        return _x.11
 [Compiler.saveMono] size: 9
     def _private.elab.erased.0._eval (a : @&Lean.Elab.Command.Context) (a : @&lcAny) (a.1 : lcVoid) : EST.Out
       Lean.Exception lcAny PUnit :=
@@ -49,7 +49,8 @@ trace: [Compiler.saveMono] size: 5
       let _f.9 : Lean.Elab.Term.Context →
         lcAny →
           Lean.Meta.Context →
-            lcAny → Lean.Core.Context → lcAny → lcVoid → EST.Out Lean.Exception lcAny PUnit := _eval._lam_0 _x.7 _x.8;
+            lcAny →
+              Lean.Core.Context → Nat → lcAny → lcVoid → EST.Out Lean.Exception lcAny PUnit := _eval._lam_0 _x.7 _x.8;
       let _x.10 : EST.Out Lean.Exception lcAny PUnit := Lean.Elab.Command.liftTermElabM._redArg _f.9 a a a.1;
       return _x.10
 -/

--- a/tests/elab/inlineApp.lean
+++ b/tests/elab/inlineApp.lean
@@ -20,10 +20,10 @@ trace: [Compiler.saveMono] size: 8
       return _x.8
 ---
 trace: [Compiler.saveMono] size: 1
-    def _private.elab.inlineApp.0._eval._lam_0 _x.1 _y.2 @&_y.3 @&_y.4 @&_y.5 @&_y.6 @&_y.7 _y.8 : EST.Out
+    def _private.elab.inlineApp.0._eval._lam_0 _x.1 _y.2 @&_y.3 @&_y.4 @&_y.5 @&_y.6 @&_y.7 @&_y.8 _y.9 : EST.Out
       Lean.Exception lcAny PUnit :=
-      let _x.9 := Lean.Compiler.compile _x.1 _y.6 _y.7 _y.8;
-      return _x.9
+      let _x.10 := Lean.Compiler.compile _x.1 _y.6 _y.7 _y.8 _y.9;
+      return _x.10
 [Compiler.saveMono] size: 7
     def _private.elab.inlineApp.0._eval @&a @&a a.1 : EST.Out Lean.Exception lcAny PUnit :=
       let _x.2 := "h";

--- a/tests/elab/lcnfTypes.lean.out.expected
+++ b/tests/elab/lcnfTypes.lean.out.expected
@@ -17,8 +17,12 @@ MonadControl.restoreM : {m : Type u → Type v} → {n : Type u → Type w} → 
 Decidable.casesOn : {p : Prop} → {motive : Decidable ◾ → Sort u} → Decidable ◾ → (Bool → ◾ → motive lcAny) → motive lcAny
 Lean.getConstInfo : {m : Type → Type} → [Monad m] → [MonadEnv m] → [MonadError m] → Name → m ConstantInfo
 Lean.Meta.instMonadMetaM : Monad fun α =>
-  Context → ST.Ref lcAny State → Core.Context → ST.Ref lcAny Core.State → lcVoid → EST.Out Exception lcAny α
-Lean.Meta.inferType : Expr → Context → ST.Ref lcAny State → Core.Context → ST.Ref lcAny Core.State → lcVoid → EST.Out Exception lcAny Expr
+  Context →
+    ST.Ref lcAny State → Core.Context → Core.Context.Hot → ST.Ref lcAny Core.State → lcVoid → EST.Out Exception lcAny α
+Lean.Meta.inferType : Expr →
+  Context →
+    ST.Ref lcAny State →
+      Core.Context → Core.Context.Hot → ST.Ref lcAny Core.State → lcVoid → EST.Out Exception lcAny Expr
 Lean.Elab.Term.elabTerm : Syntax →
   Option Expr →
     Bool →
@@ -26,7 +30,8 @@ Lean.Elab.Term.elabTerm : Syntax →
         Elab.Term.Context →
           ST.Ref lcAny Elab.Term.State →
             Context →
-              ST.Ref lcAny State → Core.Context → ST.Ref lcAny Core.State → lcVoid → EST.Out Exception lcAny Expr
+              ST.Ref lcAny State →
+                Core.Context → Core.Context.Hot → ST.Ref lcAny Core.State → lcVoid → EST.Out Exception lcAny Expr
 Nat.add : Nat → Nat → Nat
 Magma.mul : Magma → lcAny → lcAny → lcAny
 weird1 : Bool → lcAny
@@ -43,10 +48,11 @@ MonadControl.restoreM : {m n : lcErased} → [self : MonadControl lcAny lcAny] �
 Decidable.casesOn : {p motive : lcErased} → Bool → (Bool → lcErased → lcAny) → lcAny
 Lean.getConstInfo : {m : lcErased} → [Monad lcAny] → [MonadEnv lcAny] → [MonadError lcAny] → Name → lcAny
 Lean.Meta.instMonadMetaM : Monad lcAny
-Lean.Meta.inferType : Expr → Context → lcAny → Core.Context → lcAny → lcVoid → EST.Out Exception lcAny Expr
+Lean.Meta.inferType : Expr → Context → lcAny → Core.Context → Nat → lcAny → lcVoid → EST.Out Exception lcAny Expr
 Lean.Elab.Term.elabTerm : Syntax →
   Option Expr →
     Bool →
-      Bool → Elab.Term.Context → lcAny → Context → lcAny → Core.Context → lcAny → lcVoid → EST.Out Exception lcAny Expr
+      Bool →
+        Elab.Term.Context → lcAny → Context → lcAny → Core.Context → Nat → lcAny → lcVoid → EST.Out Exception lcAny Expr
 Nat.add : Nat → Nat → Nat
 Fin.add : {n : Nat} → Nat → Nat → Nat

--- a/tests/elab/meta6.lean.out.expected
+++ b/tests/elab/meta6.lean.out.expected
@@ -1,7 +1,7 @@
 [Meta.debug] ----- tst2 -----
 [Meta.debug] #[a, b, motive, t, inl, inr]
 [Meta.debug] #[a, b, motive, intro, t]
-[Meta.debug] #[x, a, a, a, a, a._@._internal._hyg.0]
+[Meta.debug] #[x, a, a, a, a, a, a._@._internal._hyg.0]
 [Meta.debug] @False.elim.{0}
       (@GT.gt.{0} Nat instLTNat (@OfNat.ofNat.{0} Nat (nat_lit 0) (instOfNatNat (nat_lit 0)))
         (@OfNat.ofNat.{0} Nat (nat_lit 5) (instOfNatNat (nat_lit 5))))


### PR DESCRIPTION
This PR stops the recursion-depth guard from rebuilding `Core.Context` on every recursive step. Roughly 96% of `Core.Context` reconstructions exist only to bump the depth counter, and each one paid a reference count increment per pointer field. -0.77%/-1.10% Mathlib/core instrs, -0.55%/**-2.88%** wall-clock.

`withReader` can never reuse the `Context` record, so keeping `currRecDepth` there made every `withIncRecDepth` rebuild it. As its own reader layer the depth is just an extra argument, so a recursion step neither allocates nor touches a reference count. The layer sits inside the `Context` reader so that a bare `read` still resolves to `Context`, and `CoreM.run` gains an initial-depth parameter so nested command elaboration keeps inheriting its caller's depth.