### PR TITLE
fix: correct Emscripten UV stub signatures

### DIFF
--- a/src/runtime/uv/event_loop.cpp
+++ b/src/runtime/uv/event_loop.cpp
@@ -145,9 +145,9 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_event_loop_configure(b_obj_arg optio
     return io_result_mk_error("lean_uv_event_loop_configure is not supported");
 }
 
-/* Std.Internal.UV.Loop.alive : BaseIO UInt64 */
-extern "C" LEAN_EXPORT lean_obj_res lean_uv_event_loop_alive() {
-    return io_result_mk_error("lean_uv_event_loop_alive is not supported");
+/* Std.Internal.UV.Loop.alive : BaseIO Bool */
+extern "C" LEAN_EXPORT uint8_t lean_uv_event_loop_alive() {
+    return false;
 }
 
 #endif

--- a/src/runtime/uv/system.cpp
+++ b/src/runtime/uv/system.cpp
@@ -634,7 +634,8 @@ extern "C" LEAN_EXPORT lean_obj_res lean_uv_os_get_passwd() {
 }
 
 // Std.Internal.UV.System.osGetGroup : IO (Option GroupInfo)
-extern "C" LEAN_EXPORT lean_obj_res lean_uv_os_get_group() {
+extern "C" LEAN_EXPORT lean_obj_res lean_uv_os_get_group(uint64_t gid) {
+    (void)gid;
     lean_always_assert(
         false && ("Please build a version of Lean4 with libuv to invoke this.")
     );


### PR DESCRIPTION
This PR aligns two UV fallback definitions selected by `LEAN_EMSCRIPTEN` with their header and Lean extern declarations, allowing `leanrt` to be cross-compiled with Emscripten.

`lean_uv_event_loop_alive` now returns `uint8_t` and reports `false` when the unavailable event loop is queried. `lean_uv_os_get_group` now accepts the missing `uint64_t gid` argument while preserving the existing unsupported-operation behavior.

Validation:

* Build `leanrt` using Emscripten 5.0.6.
* Compile both affected translation units with `LEAN_EMSCRIPTEN`.

Generative AI assisted with the investigation, implementation, and initial draft. I manually reviewed the changes and validation results.

Closes #14973
