### PR TITLE
chore: update actions/checkout in lake new template

### DIFF
--- a/src/lake/Lake/CLI/Init.lean
+++ b/src/lake/Lake/CLI/Init.lean
@@ -231,7 +231,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: leanprover/lean-action@v1
 "
 
@@ -254,7 +254,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: leanprover/lean-action@v1
       - uses: leanprover-community/docgen-action@v1
 "


### PR DESCRIPTION
This PR updates `actions/checkout` action to the latest in `lake new` / `lake init` templates.

ref https://github.com/actions/checkout