### PR TITLE
doc: fix typo in the doc example of List.lex

### DIFF
--- a/src/Init/Data/List/Basic.lean
+++ b/src/Init/Data/List/Basic.lean
@@ -270,7 +270,7 @@ Compares lists lexicographically with respect to a comparison on their elements.
 
 The lexicographic order with respect to `lt` is:
 * `[].lex (b :: bs)` is `true`
-* `as.lex [] = false` is `false`
+* `as.lex []` is `false`
 * `(a :: as).lex (b :: bs)` is true if `lt a b` or `a == b` and `lex lt as bs` is true.
 -/
 @[specialize]


### PR DESCRIPTION
This PR fixes in a typo in an example of the documentation of `List.lex`, namely removing a redundant `= false`.