### PR TITLE
fix: expose Vector DecidableEq for kernel reduction

### DIFF
--- a/src/Init/Data/Vector/Basic.lean
+++ b/src/Init/Data/Vector/Basic.lean
@@ -36,7 +36,7 @@ structure Vector (α : Type u) (n : Nat) where
   toArray : Array α
   /-- Array size. -/
   size_toArray : toArray.size = n
-deriving DecidableEq
+deriving @[expose] DecidableEq
 
 attribute [simp, grind =] Vector.size_toArray
 

--- a/tests/elab/vector_decidable_eq_module.lean
+++ b/tests/elab/vector_decidable_eq_module.lean
@@ -1,0 +1,9 @@
+module
+
+/-!
+Tests kernel reduction of derived `Vector` equality across a module boundary.
+-/
+
+example : (#v[] : Vector Nat 0) = #v[] := by decide
+example : decide ((#v[] : Vector Nat 0) = #v[]) = true := by rfl
+example : (#v[] : Vector Nat 0) = #v[] := by decide +kernel


### PR DESCRIPTION
This PR lets the derived `Vector` `DecidableEq` instance reduce in the kernel across module boundaries.

Opt `Vector` into the supported per-derivation `@[expose]` annotation while leaving derived instances opaque by default. The regression uses an empty vector so it isolates the generated `decEq` helper and does not depend on exposing nonempty `Array` equality.

Split from the original #14270 alongside the independent `Array.ofFn` fix in #14989.

:robot: prepared using Codex+Claude