### PR TITLE
feat: add `lake check` to check a project against external checkers

### DIFF
--- a/src/LeanExport.lean
+++ b/src/LeanExport.lean
@@ -14,12 +14,6 @@ def main (args : List String) : IO Unit := do
   let (imports, constants) := args.span (· != "--")
   let imports := imports.toArray.map fun mod => { module := Syntax.decodeNameLit ("`" ++ mod) |>.get! }
   let env ← importModules imports {}
-  let constants := match constants.tail? with
-    | some cs => cs.map fun c => Syntax.decodeNameLit ("`" ++ c) |>.get!
-    | none    => env.constants.toList.map Prod.fst |>.filter (!·.isInternal)
-  M.run env do
-    let _ ← initState env opts
-    dumpMetadata
-    for c in constants do
-      modify (fun st => { st with noMDataExprs := {} })
-      dumpConstant c
+  let constants? := constants.tail?.map fun cs =>
+    cs.map fun c => Syntax.decodeNameLit ("`" ++ c) |>.get!
+  dumpEnv env constants? opts

--- a/src/LeanExport/Basic.lean
+++ b/src/LeanExport/Basic.lean
@@ -454,4 +454,21 @@ def exportMetadata : Json :=
 public def dumpMetadata : M Unit := do
   IO.println exportMetadata.compress
 
+
+/--
+Exports `constants?` from `env`, or every non-internal constant in scope if none are given.
+
+Each constant is dumped with its dependencies, so the export is closed under them either way.
+-/
+public def dumpEnv
+    (env : Environment) (constants? : Option (List Name) := none) (cliOptions : List String := [])
+: IO Unit :=
+  let constants := constants?.getD (env.constants.toList.map Prod.fst |>.filter (!·.isInternal))
+  M.run env do
+    let _ ← initState env cliOptions
+    dumpMetadata
+    for c in constants do
+      modify fun st => { st with noMDataExprs := {} }
+      dumpConstant c
+
 end LeanExport

--- a/src/lake/Lake/Build/Infos.lean
+++ b/src/lake/Lake/Build/Infos.lean
@@ -120,6 +120,9 @@ builtin_facet deps : Package => Array Package
 /-- The package's complete array of transitive dependencies. -/
 builtin_facet transDeps : Package => Array Package
 
+/-- The Lean modules of the package's default targets. -/
+builtin_facet modules : Package => Array Module
+
 /-!
 ### Facet Build Info Helper Constructors
 
@@ -299,6 +302,10 @@ public abbrev extraDep (self : Package) : BuildInfo :=
 @[inherit_doc depsFacet]
 public abbrev deps (self : Package) : BuildInfo :=
   self.facetCore depsFacet
+
+@[inherit_doc modulesFacet]
+public abbrev modules (self : Package) : BuildInfo :=
+  self.facetCore modulesFacet
 
 @[inherit_doc transDepsFacet]
 public abbrev transDeps (self : Package) : BuildInfo :=

--- a/src/lake/Lake/Build/Infos.lean
+++ b/src/lake/Lake/Build/Infos.lean
@@ -121,7 +121,7 @@ builtin_facet deps : Package => Array Package
 builtin_facet transDeps : Package => Array Package
 
 /-- The Lean modules of the package's default targets. -/
-builtin_facet modules : Package => Array Module
+builtin_facet defaultModules : Package => Array Module
 
 /-!
 ### Facet Build Info Helper Constructors
@@ -303,9 +303,9 @@ public abbrev extraDep (self : Package) : BuildInfo :=
 public abbrev deps (self : Package) : BuildInfo :=
   self.facetCore depsFacet
 
-@[inherit_doc modulesFacet]
-public abbrev modules (self : Package) : BuildInfo :=
-  self.facetCore modulesFacet
+@[inherit_doc defaultModulesFacet]
+public abbrev defaultModules (self : Package) : BuildInfo :=
+  self.facetCore defaultModulesFacet
 
 @[inherit_doc transDepsFacet]
 public abbrev transDeps (self : Package) : BuildInfo :=

--- a/src/lake/Lake/Build/Package.lean
+++ b/src/lake/Lake/Build/Package.lean
@@ -38,6 +38,33 @@ def Package.recComputeTransDeps (self : Package) : FetchM (Job (Array Package)) 
     let depDeps ← (← fetch <| dep.transDeps).await
     return depDeps.foldl (·.insert ·) deps |>.insert dep
 
+/--
+Collects the Lean modules of the package's default targets: the modules of each default library,
+and the root of each default executable together with its local transitive imports. A default
+target that builds no Lean modules, such as a custom target, contributes nothing.
+-/
+def Package.recCollectDefaultModules (self : Package) : FetchM (Job (Array Module)) := ensureJob do
+  let mut mods := #[]
+  let mut seen : ModuleSet := ∅
+  for target in self.defaultTargets do
+    let targetMods ←
+      if let some lib := self.findLeanLib? target then
+        (← lib.modules.fetch).await
+      else if let some exe := self.findLeanExe? target then
+        let imports ← (← exe.root.transImports.fetch).await
+        pure <| imports.push exe.root
+      else
+        pure #[]
+    for mod in targetMods do
+      unless seen.contains mod do
+        seen := seen.insert mod
+        mods := mods.push mod
+  return Job.pure mods
+
+/-- The `PackageFacetConfig` for the builtin `modulesFacet`. -/
+public def Package.modulesFacetConfig : PackageFacetConfig modulesFacet :=
+  mkFacetJobConfig Package.recCollectDefaultModules (buildable := false)
+
 /-- The `PackageFacetConfig` for the builtin `transDepsFacet`. -/
 public def Package.transDepsFacetConfig : PackageFacetConfig transDepsFacet :=
   mkFacetJobConfig recComputeTransDeps (buildable := false)
@@ -228,6 +255,7 @@ public def Package.initFacetConfigs : DNameMap PackageFacetConfig :=
   DNameMap.empty
   |>.insert depsFacet depsFacetConfig
   |>.insert transDepsFacet transDepsFacetConfig
+  |>.insert modulesFacet modulesFacetConfig
   |>.insert extraDepFacet extraDepFacetConfig
   |>.insert optBuildCacheFacet optBuildCacheFacetConfig
   |>.insert buildCacheFacet buildCacheFacetConfig

--- a/src/lake/Lake/Build/Package.lean
+++ b/src/lake/Lake/Build/Package.lean
@@ -61,8 +61,8 @@ def Package.recCollectDefaultModules (self : Package) : FetchM (Job (Array Modul
         mods := mods.push mod
   return Job.pure mods
 
-/-- The `PackageFacetConfig` for the builtin `modulesFacet`. -/
-public def Package.modulesFacetConfig : PackageFacetConfig modulesFacet :=
+/-- The `PackageFacetConfig` for the builtin `defaultModulesFacet`. -/
+public def Package.defaultModulesFacetConfig : PackageFacetConfig defaultModulesFacet :=
   mkFacetJobConfig Package.recCollectDefaultModules (buildable := false)
 
 /-- The `PackageFacetConfig` for the builtin `transDepsFacet`. -/
@@ -255,7 +255,7 @@ public def Package.initFacetConfigs : DNameMap PackageFacetConfig :=
   DNameMap.empty
   |>.insert depsFacet depsFacetConfig
   |>.insert transDepsFacet transDepsFacetConfig
-  |>.insert modulesFacet modulesFacetConfig
+  |>.insert defaultModulesFacet defaultModulesFacetConfig
   |>.insert extraDepFacet extraDepFacetConfig
   |>.insert optBuildCacheFacet optBuildCacheFacetConfig
   |>.insert buildCacheFacet buildCacheFacetConfig

--- a/src/lake/Lake/CLI/Check.lean
+++ b/src/lake/Lake/CLI/Check.lean
@@ -27,8 +27,8 @@ is a challenge to compare against, that it proves the challenge's statements usi
 a whitelist. This backs `lake challenge` and `lake check`.
 
 The code being judged is adversarial input: it is built and exported inside a `landrun` sandbox,
-and no `.olean` produced from it is ever mapped into this process. Only the resulting NDJSON export
-crosses the boundary.
+and no `.olean` produced from it is ever mapped into the process that reports the verdict. Only the
+resulting NDJSON export crosses the boundary.
 -/
 
 namespace Lake.Check
@@ -184,28 +184,47 @@ def safeResolveWorkspace : M (String × String) := do
   return (leanPath, binPath)
 
 /--
-Asks the project which modules its default targets contain, inside the sandbox.
+Materializes the project's dependencies into `.lake`.
 
-Resolving targets means evaluating the project's configuration, which is code, so it happens where
-every other evaluation of it happens. `lake query :modules` reports the modules of the package's
-default targets, one per line.
+Resolution elaborates the project's configuration, which is code, so it runs in the sandbox; it is
+also the only step permitted to reach the network. Nothing has to come back: the process that
+exports loads the workspace itself and so already knows the search path.
 -/
-def safeQueryModules : M (Array Lean.Name) := do
-  IO.println "Resolving targets"
+def safeResolveDeps : M Unit := do
+  IO.println "Resolving dependencies"
   let projectDir ← getProjectDir
-  let whichLake := (← read).whichLake
-  let out ← runSandBoxedWithStdout {
-    cmd := whichLake.toString,
-    args := #["query", ":modules"],
+  let dotLakeDir := projectDir / ".lake"
+  if !(← System.FilePath.pathExists dotLakeDir) then
+    IO.FS.createDir dotLakeDir
+  runSandBoxed {
+    cmd := (← read).whichLake.toString,
+    args := #["resolve-deps"],
     envPass := #["PATH", "HOME", "LEAN_ABORT_ON_PANIC"]
     envOverride := #[("LEAN_ABORT_ON_PANIC", some "1")]
     readablePaths := #[projectDir]
+    writablePaths := #[dotLakeDir]
+    -- `https` and `ssh`, the transports Lake's git dependencies use.
+    connectPorts := #["443", "22"]
+  }
+
+/--
+Builds and exports the project in one sandboxed `lake` process, and returns the export.
+
+`LAKE_CHECK_EXPORT` puts that process into the half of `lake check` that runs inside the sandbox,
+so the modules to check never cross a process boundary: it resolves them, builds them and dumps the
+export itself, writing the export to stdout and everything else to stderr.
+-/
+def safeBuildAndExport : M String := do
+  IO.println "Building and exporting"
+  let projectDir ← getProjectDir
+  runSandBoxedWithStdout {
+    cmd := (← read).whichLake.toString,
+    args := #["check"],
+    envPass := #["PATH", "HOME", "LEAN_ABORT_ON_PANIC"]
+    envOverride := #[("LEAN_ABORT_ON_PANIC", some "1"), ("LAKE_CHECK_EXPORT", some "1")]
+    readablePaths := #[projectDir]
     writablePaths := #[projectDir / ".lake"]
   }
-  let mods := out.split '\n' |>.toStringList |>.filterMap fun line =>
-    let line := line.trimAscii.toString
-    if line.isEmpty then none else some line.toName
-  return mods.toArray
 
 def safeLakeBuild (targets : Array Lean.Name) : M Unit := do
   let targetArgs := targets.map (·.toString)
@@ -482,12 +501,6 @@ def resolveExternalKernels (cfg : Config) : IO (Except ExitCode (Std.TreeMap Str
       return .error (← cannotRun s!"`{kernelName}` kernel `{kernelCommand[0]!}` was not found")
   return .ok externalKernels
 
-/-- Exports everything in scope in `modules`. -/
-def exportModules (modules : Array Lean.Name) : M String := do
-  let moduleArgs := modules.map (·.toString)
-  IO.println s!"Exporting the declarations of {" ".intercalate moduleArgs.toList}"
-  runExporter moduleArgs
-
 def standardAxioms : Array Lean.Name :=
   #[``propext, ``Classical.choice, ``Quot.sound]
 
@@ -504,9 +517,9 @@ def checkUsedAxioms (exported : LeanExport.ExportedEnv) : M Unit := do
       s!"Axiom '{ax}' is not permitted; it is used by '{ref}'"
 
 /-- Checks a set of module roots at once against the kernel with no challenge to compare it to. -/
-def checkModules (modules : Array Lean.Name) : M Unit := do
-  safeLakeBuild modules
-  let exported ← LeanExport.parseStream (← stringStream (← exportModules modules))
+def checkProject : M Unit := do
+  safeResolveDeps
+  let exported ← LeanExport.parseStream (← stringStream (← safeBuildAndExport))
   if let some error ← runBuiltinKernel exported then
     throw <| .userError error
   checkUsedAxioms exported
@@ -573,12 +586,7 @@ public def runCheck (lean : LeanInstall) (lake : LakeInstall)
   if let some rc ← checkManifest "check" base.projectDir then
     return rc
   try
-    let (leanPath, binPath) ← ReaderT.run safeResolveWorkspace base
-    let ctx := { base with leanPath, binPath }
-    let targets ← ReaderT.run safeQueryModules ctx
-    if targets.isEmpty then
-      return ← cannotRun "nothing to check: this project has no default build targets"
-    ReaderT.run (checkModules targets) ctx
+    checkProject.run base
     return 0
   catch e =>
     IO.eprintln s!"error: {e}"

--- a/src/lake/Lake/CLI/Check.lean
+++ b/src/lake/Lake/CLI/Check.lean
@@ -117,29 +117,29 @@ def buildLandrunArgs (spawnArgs : LandrunArgs) : Array String :=
   let args := spawnArgs.connectPorts.foldl (init := args) (fun acc port => acc ++ #["--connect-tcp", port])
   args ++ #["--", spawnArgs.cmd] ++ spawnArgs.args
 
-def runSandBoxedWithStdout (spawnArgs : LandrunArgs) : M String := do
-  let args := buildLandrunArgs spawnArgs
-  let { stdout, stderr, exitCode } ← IO.Process.output {
-    cmd := (← read).whichLandrun,
-    args,
+/-- The `landrun` invocation that puts `spawnArgs` under the sandbox. -/
+def landrunSpawnArgs (spawnArgs : LandrunArgs) : M IO.Process.SpawnArgs := do
+  return {
+    cmd := (← read).whichLandrun
+    args := buildLandrunArgs spawnArgs
     env := spawnArgs.envOverride
-    cwd := (← getProjectDir)
+    cwd := ← getProjectDir
   }
+
+def runSandBoxedWithStdout (spawnArgs : LandrunArgs) : M String := do
+  let { stdout, stderr, exitCode } ← IO.Process.output (← landrunSpawnArgs spawnArgs)
   IO.eprint stderr
   if exitCode != 0 then
     throw <| .userError s!"Child exited with {exitCode}"
   return stdout
 
+/-- Runs `spawnArgs` sandboxed, letting its output through, and returns its exit code. -/
+def runSandBoxedExitCode (spawnArgs : LandrunArgs) : M UInt32 := do
+  let proc ← IO.Process.spawn (← landrunSpawnArgs spawnArgs)
+  proc.wait
 
 def runSandBoxed (spawnArgs : LandrunArgs) : M Unit := do
-  let args := buildLandrunArgs spawnArgs
-  let proc ← IO.Process.spawn {
-    cmd := (← read).whichLandrun,
-    args,
-    env := spawnArgs.envOverride
-    cwd := (← getProjectDir)
-  }
-  let ret ← proc.wait
+  let ret ← runSandBoxedExitCode spawnArgs
   if ret != 0 then
     throw <| .userError s!"Child exited with {ret}"
 
@@ -183,8 +183,34 @@ def safeResolveWorkspace : M (String × String) := do
     throw <| .userError "`lake env` did not report the project's search path"
   return (leanPath, binPath)
 
-def safeLakeBuild (target : Lean.Name) : M Unit := do
-  IO.println s!"Building {target}"
+/--
+Asks the project which modules its default targets contain, inside the sandbox.
+
+Resolving targets means evaluating the project's configuration, which is code, so it happens where
+every other evaluation of it happens. `lake query :modules` reports the modules of the package's
+default targets, one per line.
+-/
+def safeQueryModules : M (Array Lean.Name) := do
+  IO.println "Resolving targets"
+  let projectDir ← getProjectDir
+  let whichLake := (← read).whichLake
+  let out ← runSandBoxedWithStdout {
+    cmd := whichLake.toString,
+    args := #["query", ":modules"],
+    envPass := #["PATH", "HOME", "LEAN_ABORT_ON_PANIC"]
+    envOverride := #[("LEAN_ABORT_ON_PANIC", some "1")]
+    readablePaths := #[projectDir]
+    writablePaths := #[projectDir / ".lake"]
+  }
+  let mods := out.split '\n' |>.toStringList |>.filterMap fun line =>
+    let line := line.trimAscii.toString
+    if line.isEmpty then none else some line.toName
+  return mods.toArray
+
+def safeLakeBuild (targets : Array Lean.Name) : M Unit := do
+  let targetArgs := targets.map (·.toString)
+  let targetList := " ".intercalate targetArgs.toList
+  IO.println s!"Building {targetList}"
   let projectDir ← getProjectDir
   let dotLakeDir := projectDir / ".lake"
 
@@ -194,30 +220,30 @@ def safeLakeBuild (target : Lean.Name) : M Unit := do
   let whichLake := (← read).whichLake
   runSandBoxed {
     cmd := whichLake.toString,
-    args := #["build", target.toString],
+    args := #["build"] ++ targetArgs,
     envPass := #["PATH", "HOME", "LEAN_ABORT_ON_PANIC"]
     envOverride := #[("LEAN_ABORT_ON_PANIC", some "1")]
     readablePaths := #[projectDir]
     writablePaths := #[dotLakeDir]
   }
 
-def safeExport (module : Lean.Name) (decls : Array Lean.Name) : M String := do
-  IO.println s!"Exporting {decls} from {module}"
-  let baseArgs := #[module.toString, "--"]
-  let args := decls.foldl (·.push <| ·.toString) baseArgs
-
+/-- Runs the bundled exporter in the sandbox, with the grants every export needs. -/
+def runExporter (args : Array String) : M String := do
   let projectDir ← getProjectDir
-  let dotLakeDir := projectDir / ".lake"
   let whichLean4Export := (← read).whichLean4Export
   runSandBoxedWithStdout {
     cmd := whichLean4Export.toString
-    args := args,
+    args
     envPass := #["PATH", "HOME", "LEAN_PATH", "LEAN_ABORT_ON_PANIC"]
     envOverride := #[("LEAN_ABORT_ON_PANIC", some "1"), ("LEAN_PATH", some (← read).leanPath),
       ("PATH", some (← read).binPath)]
-    readablePaths := #[projectDir, dotLakeDir]
+    readablePaths := #[projectDir, projectDir / ".lake"]
     writablePaths := #[]
   }
+
+def safeExport (module : Lean.Name) (decls : Array Lean.Name) : M String := do
+  IO.println s!"Exporting {decls} from {module}"
+  runExporter <| #[module.toString, "--"] ++ decls.map (·.toString)
 
 def runExternalKernel (kernelName : String) (kernelCommand : Array String)
     (solutionExport : String) : M (Option String) := do
@@ -253,17 +279,8 @@ def runExternalKernel (kernelName : String) (kernelCommand : Array String)
       readablePaths := #[configPath.toString, solutionPath.toString]
       writablePaths := #[]
     }
-    let args := buildLandrunArgs spawnArgs
-
     try
-      let proc ← IO.Process.spawn {
-        cmd := (← read).whichLandrun,
-        args,
-        env := spawnArgs.envOverride
-        cwd := (← getProjectDir)
-      }
-
-      let ret ← proc.wait
+      let ret ← runSandBoxedExitCode spawnArgs
       if ret != 0 then
         IO.println s!"{kernelName} kernel rejected the solution"
         return some s!"{kernelName} exited with {ret}"
@@ -375,11 +392,11 @@ public def compareIt : M Unit := do
     ++ (← primitiveTargets) ++ (← getDefinitionNames)
 
   let challengeModule ← getChallengeModule
-  safeLakeBuild challengeModule
+  safeLakeBuild #[challengeModule]
   let challengeExport ← safeExport challengeModule exportTargets
 
   let solutionModule ← getSolutionModule
-  safeLakeBuild solutionModule
+  safeLakeBuild #[solutionModule]
   let solutionExport ← safeExport solutionModule exportTargets
 
   verifyMatch challengeExport solutionExport
@@ -465,6 +482,35 @@ def resolveExternalKernels (cfg : Config) : IO (Except ExitCode (Std.TreeMap Str
       return .error (← cannotRun s!"`{kernelName}` kernel `{kernelCommand[0]!}` was not found")
   return .ok externalKernels
 
+/-- Exports everything in scope in `modules`. -/
+def exportModules (modules : Array Lean.Name) : M String := do
+  let moduleArgs := modules.map (·.toString)
+  IO.println s!"Exporting the declarations of {" ".intercalate moduleArgs.toList}"
+  runExporter moduleArgs
+
+def standardAxioms : Array Lean.Name :=
+  #[``propext, ``Classical.choice, ``Quot.sound]
+
+/-- Reports the axioms the checked modules rest on, and rejects any beyond `standardAxioms`. -/
+def checkUsedAxioms (exported : LeanExport.ExportedEnv) : M Unit := do
+  let used := usedAxioms exported
+  if used.isEmpty then
+    IO.println "Uses no axioms"
+  else
+    IO.println s!"Uses axioms: {", ".intercalate (used.toList.map (·.1.toString))}"
+  let illegal := used.filter fun (ax, _) => !standardAxioms.contains ax
+  unless illegal.isEmpty do
+    throw <| .userError <| "\n".intercalate <| illegal.toList.map fun (ax, ref) =>
+      s!"Axiom '{ax}' is not permitted; it is used by '{ref}'"
+
+/-- Checks a set of module roots at once against the kernel with no challenge to compare it to. -/
+def checkModules (modules : Array Lean.Name) : M Unit := do
+  safeLakeBuild modules
+  let exported ← LeanExport.parseStream (← stringStream (← exportModules modules))
+  if let some error ← runBuiltinKernel exported then
+    throw <| .userError error
+  checkUsedAxioms exported
+
 /--
 Runs `lake challenge`: builds and exports the challenge and the solution in a sandbox, then judges
 the solution against the challenge.
@@ -509,6 +555,30 @@ public def runChallenge (configFile? : Option System.FilePath) (lean : LeanInsta
     }
     let (leanPath, binPath) ← ReaderT.run safeResolveWorkspace ctx
     ReaderT.run compareIt { ctx with leanPath, binPath }
+    return 0
+  catch e =>
+    IO.eprintln s!"error: {e}"
+    return 1
+
+/--
+Runs `lake check`: builds and exports the project's default targets in the sandbox and checks them
+with the kernel, with no challenge to compare them against.
+-/
+public def runCheck (lean : LeanInstall) (lake : LakeInstall)
+    (projectDir : System.FilePath) : IO ExitCode := do
+  let base ←
+    match ← mkContext "check" lean lake projectDir with
+    | .error rc => return rc
+    | .ok ctx => pure ctx
+  if let some rc ← checkManifest "check" base.projectDir then
+    return rc
+  try
+    let (leanPath, binPath) ← ReaderT.run safeResolveWorkspace base
+    let ctx := { base with leanPath, binPath }
+    let targets ← ReaderT.run safeQueryModules ctx
+    if targets.isEmpty then
+      return ← cannotRun "nothing to check: this project has no default build targets"
+    ReaderT.run (checkModules targets) ctx
     return 0
   catch e =>
     IO.eprintln s!"error: {e}"

--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -483,11 +483,12 @@ Builds the default build targets, exports them, and replays the result through
 the kernel, erroring on any use of non-standard axioms.
 
 The project is untrusted input: its configuration is evaluated, and its code
-built and exported, inside a `landrun` sandbox, and none of its `.olean` files
-is ever loaded into Lake's own address space. Both the dependencies and the
-targets to check are resolved there, since resolving either evaluates the
-configuration and that is code. `landrun` is required; there is no unsandboxed
-mode, so this command is available on Linux only.
+built, exported and resolved, inside a `landrun` sandbox. Only the export
+crosses back, so none of its `.olean` files is ever loaded outside it. Two
+sandboxed processes do the work: one resolves dependencies, the only step
+allowed to reach the network, and one builds and exports. `landrun` is
+required; there is no unsandboxed mode, so this command is available on Linux
+only.
 
 The project has to carry a `lake-manifest.json`, because dependencies are
 resolved inside the sandbox and it cannot write to the project directory.

--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -31,6 +31,7 @@ COMMANDS:
   clean                 remove build outputs
   shake                 minimize imports in source files
   challenge             judge a solution against a challenge
+  check                 check this project against external checker(s)
   env <cmd> <args>...   execute a command in Lake's environment
   lean <file>           elaborate a Lean file in Lake's context
   update                update dependencies and save them to the manifest
@@ -472,6 +473,48 @@ HARDENING:
     systemd-run --user --pty --property=RestrictAddressFamilies=~AF_UNIX \\
       lake challenge --config challenge.json"
 
+def helpCheck :=
+"Check this project against external checker(s)
+
+USAGE:
+  lake check
+
+Builds the default build targets, exports them, and replays the result through
+the kernel, erroring on any use of non-standard axioms.
+
+The project is untrusted input: its configuration is evaluated, and its code
+built and exported, inside a `landrun` sandbox, and none of its `.olean` files
+is ever loaded into Lake's own address space. Both the dependencies and the
+targets to check are resolved there, since resolving either evaluates the
+configuration and that is code. `landrun` is required; there is no unsandboxed
+mode, so this command is available on Linux only.
+
+The project has to carry a `lake-manifest.json`, because dependencies are
+resolved inside the sandbox and it cannot write to the project directory.
+Building the project once is enough to write one.
+
+EXIT CODES:
+  0                     the kernel accepts the project and it rests only on the
+                        permitted axioms
+  1                     the kernel rejects it, an axiom is not permitted, or a
+                        build did not succeed
+  2                     could not start: `landrun` is missing, the project has
+                        no `lake-manifest.json`, or it has no default targets
+
+ENVIRONMENT:
+  COMPARATOR_LANDRUN    sandbox executable (default: `landrun` on PATH)
+
+  The exporter is always the `leanexport` of this toolchain, and deliberately
+  not configurable: the export format has to match the compiler that produced
+  the `.olean` files being exported.
+
+HARDENING:
+  The sandbox bounds writes and TCP connections exactly as `lake challenge`'s
+  does, and its limits and the `AF_UNIX` caveat apply here too. See the
+  HARDENING section of `lake help challenge`.
+
+See `lake help challenge` to judge a solution against a challenge instead."
+
 def helpCacheCli :=
 "Manage the Lake cache
 
@@ -857,6 +900,7 @@ public def help : (cmd : String) → String
 | "clean"               => helpClean
 | "shake"               => helpShake
 | "challenge"           => helpChallenge
+| "check"               => helpCheck
 | "script"              => helpScriptCli
 | "scripts"             => helpScriptList
 | "run"                 => helpScriptRun

--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -483,12 +483,9 @@ Builds the default build targets, exports them, and replays the result through
 the kernel, erroring on any use of non-standard axioms.
 
 The project is untrusted input: its configuration is evaluated, and its code
-built, exported and resolved, inside a `landrun` sandbox. Only the export
-crosses back, so none of its `.olean` files is ever loaded outside it. Two
-sandboxed processes do the work: one resolves dependencies, the only step
-allowed to reach the network, and one builds and exports. `landrun` is
-required; there is no unsandboxed mode, so this command is available on Linux
-only.
+built and exported, inside a `landrun` sandbox, and none of its `.olean` files
+is ever loaded into Lake's own address space. `landrun` is required; there is
+no unsandboxed mode, so this command is available on Linux only.
 
 The project has to carry a `lake-manifest.json`, because dependencies are
 resolved inside the sandbox and it cannot write to the project directory.

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -1176,6 +1176,17 @@ protected def challenge : CliM PUnit := do
   let cfg ← mkLoadConfig opts
   exit <| ← Check.runChallenge opts.challengeConfig? leanInstall lakeInstall cfg.wsDir
 
+/-- The `lake check` command: check this project against the kernel. -/
+protected def check : CliM PUnit := do
+  processOptions lakeOption
+  let opts ← getThe LakeOptions
+  noArgsRem do
+  let (leanInstall, lakeInstall) ← opts.getInstall
+  -- The workspace is deliberately not loaded here: evaluating the project's configuration is code
+  -- execution, and containing it is what the sandbox is for.
+  let cfg ← mkLoadConfig opts
+  exit <| ← Check.runCheck leanInstall lakeInstall cfg.wsDir
+
 protected def script : CliM PUnit := do
   if let some cmd ← takeArg? then
     processLeadingOptions lakeOption -- between `lake script <cmd>` and args
@@ -1332,6 +1343,7 @@ def lakeCli : (cmd : String) → CliM PUnit
 | "clean"               => lake.clean
 | "shake"               => lake.shake
 | "challenge"           => lake.challenge
+| "check"               => lake.check
 | "script"              => lake.script
 | "scripts"             => lake.script.list
 | "run"                 => lake.script.run

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -13,6 +13,7 @@ public import Lake.CLI.Shake
 public import Lake.CLI.Check
 import Lake.Version
 import Lake.Build.Run
+import Lake.Build.Infos
 import Lake.Build.Targets
 import Lake.Build.Target.Fetch
 import Lake.Load.Package
@@ -25,6 +26,7 @@ import Lake.Util.Cli
 import Lake.CLI.Init
 import Lake.CLI.Help
 import Lake.CLI.Build
+import LeanExport.Basic
 import Lake.CLI.Actions
 import Lake.CLI.Translate
 import Lake.CLI.Serve
@@ -1176,16 +1178,36 @@ protected def challenge : CliM PUnit := do
   let cfg ← mkLoadConfig opts
   exit <| ← Check.runChallenge opts.challengeConfig? leanInstall lakeInstall cfg.wsDir
 
+/--
+The half of `lake check` that runs inside the sandbox, selected by `LAKE_CHECK_EXPORT`.
+
+Resolves the default targets to modules, builds them, and dumps the export of everything in scope.
+The export goes to standard out and everything else to standard error, so the outer half can read
+one from the other.
+-/
+protected def checkExport : CliM PUnit := do
+  let opts ← getThe LakeOptions
+  let ws ← loadWorkspace (← mkLoadConfig opts)
+  let buildConfig := mkBuildConfig opts
+  ws.runBuild (buildSpecs (← parseTargetSpecs ws [])) buildConfig
+  let mods ← ws.runBuild ws.root.modules.fetch buildConfig
+  Lean.initSearchPath ws.lakeEnv.lean.sysroot ws.augmentedLeanPath
+  let env ← Lean.importModules (mods.map fun mod => {module := mod.name}) {}
+  LeanExport.dumpEnv env
+
 /-- The `lake check` command: check this project against the kernel. -/
 protected def check : CliM PUnit := do
   processOptions lakeOption
   let opts ← getThe LakeOptions
-  noArgsRem do
-  let (leanInstall, lakeInstall) ← opts.getInstall
-  -- The workspace is deliberately not loaded here: evaluating the project's configuration is code
-  -- execution, and containing it is what the sandbox is for.
-  let cfg ← mkLoadConfig opts
-  exit <| ← Check.runCheck leanInstall lakeInstall cfg.wsDir
+  if (← IO.getEnv "LAKE_CHECK_EXPORT").isSome then
+    lake.checkExport
+  else
+    noArgsRem do
+    let (leanInstall, lakeInstall) ← opts.getInstall
+    -- The workspace is deliberately not loaded here: evaluating the project's configuration is code
+    -- execution, and containing it is what the sandbox is for.
+    let cfg ← mkLoadConfig opts
+    exit <| ← Check.runCheck leanInstall lakeInstall cfg.wsDir
 
 protected def script : CliM PUnit := do
   if let some cmd ← takeArg? then

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -1190,7 +1190,7 @@ protected def checkExport : CliM PUnit := do
   let ws ← loadWorkspace (← mkLoadConfig opts)
   let buildConfig := mkBuildConfig opts
   ws.runBuild (buildSpecs (← parseTargetSpecs ws [])) buildConfig
-  let mods ← ws.runBuild ws.root.modules.fetch buildConfig
+  let mods ← ws.runBuild ws.root.defaultModules.fetch buildConfig
   Lean.initSearchPath ws.lakeEnv.lean.sysroot ws.augmentedLeanPath
   let env ← Lean.importModules (mods.map fun mod => {module := mod.name}) {}
   LeanExport.dumpEnv env

--- a/src/lake/Lake/Check/Axioms.lean
+++ b/src/lake/Lake/Check/Axioms.lean
@@ -54,6 +54,22 @@ where
 
 end Axioms
 
+/--
+The axioms some other constant in `env` refers to, each paired with one constant that refers to it.
+-/
+public def usedAxioms (env : LeanExport.ExportedEnv) : Array (Lean.Name × Lean.Name) :=
+  -- `constOrder` is the export order, so the result is deterministic without needing an `Ord`.
+  let collect : StateM (Std.HashSet Lean.Name × Array (Lean.Name × Lean.Name)) Unit := do
+    for name in env.constOrder do
+      let some info := env.constMap[name]? | continue
+      runForUsedConsts info fun ref => do
+        -- `runForUsedConsts` reports the constant itself, which is not an incoming reference
+        unless ref == name do
+          if let some (.axiomInfo ..) := env.constMap[ref]? then
+            modify fun (seen, used) =>
+              if seen.contains ref then (seen, used) else (seen.insert ref, used.push (ref, name))
+  (collect.run ({}, #[])).2.2
+
 public def checkAxioms (solution : LeanExport.ExportedEnv) (theoremTargets : Array Lean.Name)
     (definitionTargets : Array Lean.Name) (legalAxioms : Array Lean.Name) : Except String Unit := do
   let mut worklist := #[]

--- a/tests/lake/tests/check-audit-reject/Solution.lean
+++ b/tests/lake/tests/check-audit-reject/Solution.lean
@@ -1,0 +1,22 @@
+import Lean
+
+open Lean
+
+unsafe def badNatUnsafe : Nat := unsafeCast (-4294967296 : Int)
+
+@[implemented_by badNatUnsafe] opaque badNatVal : Nat
+
+run_elab
+  addDecl <| .defnDecl {
+    name        := .str .anonymous "badNat"
+    levelParams := []
+    type        := .const ``Nat []
+    value       := .lit <| .natVal badNatVal
+    hints       := .opaque
+    safety      := .safe
+  }
+
+theorem boom : False := by
+  have truly_marvelous_0 : ¬badNat ≤ 9223372036854775807 := by decide
+  have truly_marvelous_1 : ¬9223372036854775807 < badNat := by decide
+  omega

--- a/tests/lake/tests/check-audit-reject/clean.sh
+++ b/tests/lake/tests/check-audit-reject/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/check-audit-reject/lakefile.toml
+++ b/tests/lake/tests/check-audit-reject/lakefile.toml
@@ -1,0 +1,6 @@
+name = "checktest"
+version = "0.1.0"
+defaultTargets = ["Solution"]
+
+[[lean_lib]]
+name = "Solution"

--- a/tests/lake/tests/check-audit-reject/test.sh
+++ b/tests/lake/tests/check-audit-reject/test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+if [ "`uname`" != Linux ]; then
+  echo "Skipping test: lake check needs Linux Landlock"
+  exit 0
+fi
+
+# Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
+export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
+
+# `lake check` resolves dependencies inside the sandbox, which cannot write to the project
+# directory, so the manifest has to be in place first. Building the project once does the same;
+# this just skips the build.
+"$LAKE" resolve-deps
+
+test_status_out 1 'error:' check
+
+rm -f produced.out

--- a/tests/lake/tests/check-audit/Solution.lean
+++ b/tests/lake/tests/check-audit/Solution.lean
@@ -1,0 +1,2 @@
+theorem comm (n m : Nat) : n + m = m + n := by
+  grind

--- a/tests/lake/tests/check-audit/clean.sh
+++ b/tests/lake/tests/check-audit/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/check-audit/lakefile.toml
+++ b/tests/lake/tests/check-audit/lakefile.toml
@@ -1,0 +1,6 @@
+name = "checktest"
+version = "0.1.0"
+defaultTargets = ["Solution"]
+
+[[lean_lib]]
+name = "Solution"

--- a/tests/lake/tests/check-audit/test.sh
+++ b/tests/lake/tests/check-audit/test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+if [ "`uname`" != Linux ]; then
+  echo "Skipping test: lake check needs Linux Landlock"
+  exit 0
+fi
+
+# Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
+export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
+
+# Without a manifest the command refuses up front, rather than failing inside the sandbox with a
+# bare `permission denied` on the manifest it cannot write.
+test_status_out 2 'has no `lake-manifest.json`' check
+
+# `lake check` resolves dependencies inside the sandbox, which cannot write to the project
+# directory, so the manifest has to be in place first. Building the project once does the same;
+# this just skips the build.
+"$LAKE" resolve-deps
+
+test_status_out 0 'Lean default kernel accepts the solution' check
+match_text 'Uses axioms: Classical.choice, propext, Quot.sound' produced.out
+
+rm -f produced.out

--- a/tests/lake/tests/check-multi/A.lean
+++ b/tests/lake/tests/check-multi/A.lean
@@ -1,0 +1,1 @@
+theorem a_thm : 1 + 1 = 2 := rfl

--- a/tests/lake/tests/check-multi/B.lean
+++ b/tests/lake/tests/check-multi/B.lean
@@ -1,0 +1,1 @@
+theorem b_thm : 2 + 2 = 4 := rfl

--- a/tests/lake/tests/check-multi/clean.sh
+++ b/tests/lake/tests/check-multi/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/check-multi/lakefile.toml
+++ b/tests/lake/tests/check-multi/lakefile.toml
@@ -1,0 +1,9 @@
+name = "checktest"
+version = "0.1.0"
+defaultTargets = ["A", "B"]
+
+[[lean_lib]]
+name = "A"
+
+[[lean_lib]]
+name = "B"

--- a/tests/lake/tests/check-multi/test.sh
+++ b/tests/lake/tests/check-multi/test.sh
@@ -16,11 +16,12 @@ export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
 # this just skips the build.
 "$LAKE" resolve-deps
 
-# Several roots are built, exported and replayed together: the export covers each root's whole
-# import closure, so a pass per root would re-check what they share.
+# Both roots are built, exported and replayed together, in one sandboxed process: the export
+# covers each root's whole import closure, so a pass per root would re-check what they share.
 test_status_out 0 'Lean default kernel accepts the solution' check
-test_exp "`grep -c 'Building A B' produced.out`" = 1
-test_exp "`grep -c 'Exporting the declarations of A B' produced.out`" = 1
+test_exp "`grep -c 'Building and exporting' produced.out`" = 1
 test_exp "`grep -c 'Running Lean default kernel' produced.out`" = 1
+match_text 'Built A' produced.out
+match_text 'Built B' produced.out
 
 rm -f produced.out

--- a/tests/lake/tests/check-multi/test.sh
+++ b/tests/lake/tests/check-multi/test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+if [ "`uname`" != Linux ]; then
+  echo "Skipping test: lake check needs Linux Landlock"
+  exit 0
+fi
+
+# Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
+export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
+
+# `lake check` resolves dependencies inside the sandbox, which cannot write to the project
+# directory, so the manifest has to be in place first. Building the project once does the same;
+# this just skips the build.
+"$LAKE" resolve-deps
+
+# Several roots are built, exported and replayed together: the export covers each root's whole
+# import closure, so a pass per root would re-check what they share.
+test_status_out 0 'Lean default kernel accepts the solution' check
+test_exp "`grep -c 'Building A B' produced.out`" = 1
+test_exp "`grep -c 'Exporting the declarations of A B' produced.out`" = 1
+test_exp "`grep -c 'Running Lean default kernel' produced.out`" = 1
+
+rm -f produced.out

--- a/tests/lake/tests/check-sorry/Solution.lean
+++ b/tests/lake/tests/check-sorry/Solution.lean
@@ -1,0 +1,1 @@
+theorem bad : False := sorry

--- a/tests/lake/tests/check-sorry/clean.sh
+++ b/tests/lake/tests/check-sorry/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out

--- a/tests/lake/tests/check-sorry/lakefile.toml
+++ b/tests/lake/tests/check-sorry/lakefile.toml
@@ -1,0 +1,6 @@
+name = "checktest"
+version = "0.1.0"
+defaultTargets = ["Solution"]
+
+[[lean_lib]]
+name = "Solution"

--- a/tests/lake/tests/check-sorry/test.sh
+++ b/tests/lake/tests/check-sorry/test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+if [ "`uname`" != Linux ]; then
+  echo "Skipping test: lake check needs Linux Landlock"
+  exit 0
+fi
+
+# Landlock cannot be assumed available in CI containers; see `../fake-landrun.sh`.
+export COMPARATOR_LANDRUN="$PWD/../fake-landrun.sh"
+
+# `lake check` resolves dependencies inside the sandbox, which cannot write to the project
+# directory, so the manifest has to be in place first. Building the project once does the same;
+# this just skips the build.
+"$LAKE" resolve-deps
+
+# The kernel accepts `sorryAx`, so only the axiom report catches this.
+test_status_out 1 "Axiom 'sorryAx' is not permitted" check
+match_text "it is used by 'bad'" produced.out
+
+rm -f produced.out


### PR DESCRIPTION
This PR adds `lake check`, a challenge-less variant of `lake challenge`, which builds the current project's default targets, exports them, replays the result through the kernel, and fails on any use of non-standard axioms.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>