### PR TITLE
fix: make the stack overflow handler async-signal-safe

### DIFF
--- a/src/runtime/stack_overflow.cpp
+++ b/src/runtime/stack_overflow.cpp
@@ -20,6 +20,7 @@ Port of the corresponding Rust code (see links below).
 #include <lean/lean.h>
 #include <initializer_list>
 #include "runtime/stack_overflow.h"
+#include "runtime/thread.h"
 
 namespace lean {
 // stack guard of the main thread
@@ -49,23 +50,41 @@ stack_guard::~stack_guard() {}
 // https://github.com/rust-lang/rust/blob/master/library/std/src/sys/pal/unix/stack_overflow.rs
 
 
+#ifndef __APPLE__
+// Lowest address of the current thread's stack, captured by `stack_guard`. Null on threads the
+// runtime did not create; those have no alternate signal stack either.
+static LEAN_THREAD_LOCAL char * g_stackaddr = nullptr;
+#endif
+// close enough; the actual guard might be bigger, but it's unlikely a Lean function will have stack frames that big
+static size_t g_guardsize;
+
 // https://github.com/rust-lang/rust/blob/7c8dbd969dd0ef2af6d8bab9e03ba7ce6cac41a2/src/libstd/sys/unix/thread.rs#L293
+static void capture_stack_bounds() {
+#ifndef __APPLE__
+    pthread_attr_t attr;
+    if (pthread_attr_init(&attr) != 0) return;
+    char * stackaddr;
+    size_t stacksize;
+    if (pthread_getattr_np(pthread_self(), &attr) == 0 &&
+        pthread_attr_getstack(&attr, reinterpret_cast<void **>(&stackaddr), &stacksize) == 0)
+        g_stackaddr = stackaddr;
+    pthread_attr_destroy(&attr);
+#endif
+}
+
+// Must be async-signal-safe: on glibc `pthread_getattr_np` allocates, and the interrupted frame may
+// hold the allocator lock.
 bool is_within_stack_guard(void * addr) {
     char * stackaddr;
 #ifdef __APPLE__
+    // does not allocate, unlike Mach-O `thread_local` on first access
     stackaddr = static_cast<char *>(pthread_get_stackaddr_np(pthread_self())) - pthread_get_stacksize_np(pthread_self());
 #else
-    pthread_attr_t attr;
-    if (pthread_attr_init(&attr) != 0) return false;
-    pthread_getattr_np(pthread_self(), &attr);
-    size_t stacksize;
-    pthread_attr_getstack(&attr, reinterpret_cast<void **>(&stackaddr), &stacksize);
-    pthread_attr_destroy(&attr);
+    stackaddr = g_stackaddr;
+    if (stackaddr == nullptr) return false;
 #endif
-    // close enough; the actual guard might be bigger, but it's unlikely a Lean function will have stack frames that big
-    size_t guardsize = static_cast<size_t>(sysconf(_SC_PAGESIZE));
     // the stack guard is *below* the stack
-    return stackaddr - guardsize <= addr && addr < stackaddr;
+    return stackaddr - g_guardsize <= addr && addr < stackaddr;
 }
 
 extern "C" LEAN_EXPORT void segv_handler(int signum, siginfo_t * info, void *) {
@@ -83,6 +102,7 @@ extern "C" LEAN_EXPORT void segv_handler(int signum, siginfo_t * info, void *) {
 }
 
 stack_guard::stack_guard() {
+    capture_stack_bounds();
     m_signal_stack.ss_sp = malloc(SIGSTKSZ);
     if (m_signal_stack.ss_sp == nullptr) return;
     m_signal_stack.ss_size = SIGSTKSZ;
@@ -99,6 +119,9 @@ stack_guard::~stack_guard() {
 #endif
 
 void initialize_stack_overflow() {
+#ifndef LEAN_WINDOWS
+    g_guardsize = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+#endif
     g_stack_guard = new stack_guard();
 #ifdef LEAN_WINDOWS
     AddVectoredExceptionHandler(0, stack_overflow_handler);

--- a/tests/compile/StackOverflowAlloc.lean
+++ b/tests/compile/StackOverflowAlloc.lean
@@ -1,0 +1,6 @@
+/-! Stack overflow while inside the allocator must abort, not hang (#14992). -/
+
+partial def loop (start : Nat) : Nat := start + loop (start + 1)
+
+@[never_extract]
+def main : IO Unit := IO.println (loop (2 ^ 64))

--- a/tests/compile/StackOverflowAlloc.lean.init.sh
+++ b/tests/compile/StackOverflowAlloc.lean.init.sh
@@ -1,0 +1,3 @@
+TEST_EXIT=nonzero
+# small stack so the bignum-per-frame recursion overflows quickly
+export LEAN_STACK_SIZE_KB=8192

--- a/tests/compile/StackOverflowAlloc.lean.out.expected
+++ b/tests/compile/StackOverflowAlloc.lean.out.expected
@@ -1,0 +1,2 @@
+
+Stack overflow detected. Aborting.


### PR DESCRIPTION
This PR fixes a hang on stack overflow. On Linux a program that ran out of stack while inside the allocator would hang forever instead of printing `Stack overflow detected. Aborting.` and exiting; deep non-tail recursion doing bignum `Nat` arithmetic hits this reliably.

The `SIGSEGV` handler called `pthread_getattr_np` to find the thread's stack bounds. On glibc that reallocs and frees, so when the fault interrupted a frame holding a malloc arena lock the handler blocked on that same lock on the same thread. The bounds are now captured once in `stack_guard`'s constructor, which already runs on every runtime thread and on the main thread, and the handler only reads them. `sysconf(_SC_PAGESIZE)` moves out of the handler for the same reason. The `__APPLE__` branch is unchanged: `pthread_get_stackaddr_np` does not allocate, and a Mach-O `thread_local` would on first access. Threads the runtime did not create have no captured bounds and are treated as not a stack overflow; they had no alternate signal stack before either, so nothing is lost there. The cached bound goes stale if an embedder calls `setrlimit(RLIMIT_STACK)` after startup under `LEAN_MAIN_USE_THREAD=0`; I did not think that worth handling.

After the change `is_within_stack_guard` compiles to a TLS load and two comparisons with no calls, and the only calls left in `segv_handler` are `sigaction`, `write` and `abort`.

`tests/compile/StackOverflowAlloc.lean` is a regression test: an infinite recursion on a growing bignum, so a GMP `realloc` is on the stack when the guard page is hit, under `LEAN_STACK_SIZE_KB=8192` to keep it fast. Without the fix it hangs until ctest's timeout; with it it aborts in about 0.1s. The existing `StackOverflow.lean` never allocates on the way down and so does not catch this. The full test suite passes on Linux with the fix.

Closes #14992
