### PR TITLE
fix: require the Lake cache key rather than inferring secret availability

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -212,8 +212,9 @@ jobs:
       - id: upload-lake-cache
         name: Upload Lake Cache
         # Caching on cancellation created some mysterious issues perhaps related to improper build
-        # shutdown. Also, since this needs access to secrets, it cannot be run on forks.
-        if: matrix.lake-cache && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        # shutdown. Also, since this needs access to secrets, it can only run where Actions
+        # secrets are available: not on forks, and not on Dependabot pull requests.
+        if: matrix.lake-cache && !cancelled() && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]'))
         run: |
           curl --version
           cd src

--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -47,6 +47,10 @@ jobs:
       # squelch error message about missing nixpkgs channel
       NIX_BUILD_SHELL: bash
       LSAN_OPTIONS: max_leaks=10
+      # Secrets cannot be referenced in a step `if`, so derive availability here.
+      # The key is absent on fork pull requests and on Dependabot runs, which do
+      # not receive Actions secrets.
+      HAS_LAKE_CACHE_KEY: ${{ secrets.LAKE_CACHE_KEY != '' }}
       # somehow MinGW clang64 (or cmake?) defaults to `g++` even though it doesn't exist
       CXX: c++
       MACOSX_DEPLOYMENT_TARGET: 11.0
@@ -212,9 +216,10 @@ jobs:
       - id: upload-lake-cache
         name: Upload Lake Cache
         # Caching on cancellation created some mysterious issues perhaps related to improper build
-        # shutdown. Also, since this needs access to secrets, it can only run where Actions
-        # secrets are available: not on forks, and not on Dependabot pull requests.
-        if: matrix.lake-cache && !cancelled() && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]'))
+        # shutdown. The upload also needs `LAKE_CACHE_KEY`, so require the key rather than
+        # inferring its presence, and keep the same-repository check so that a configuration
+        # which did expose secrets to forks would not turn this into an upload path for them.
+        if: matrix.lake-cache && !cancelled() && env.HAS_LAKE_CACHE_KEY == 'true' && (github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository)
         run: |
           curl --version
           cd src


### PR DESCRIPTION
This PR makes the Lake cache upload require `LAKE_CACHE_KEY` rather than inferring from the event that a key must be present, so that the step is skipped instead of failing wherever the key is unavailable.

The step's guard tested whether the head branch lives in this repository, as a proxy for "not a fork". Dependabot pushes to `dependabot/...` inside the repository, so that test passed, but GitHub withholds Actions secrets from Dependabot-initiated runs regardless of where the branch lives. `LAKE_CACHE_KEY` expanded to the empty string and `lake cache put` failed against R2 with `Credential access key has length 0, should be 32`. Because steps skip after a failure, the job then stopped at the upload, so `Install`, `Test`, `Build Stage 2` and `Check rebootstrap` never ran: https://github.com/leanprover/lean4/pull/14634, https://github.com/leanprover/lean4/pull/14635, https://github.com/leanprover/lean4/pull/14636, https://github.com/leanprover/lean4/pull/14637 and https://github.com/leanprover/lean4/pull/14638 each have a successful build, no test results, and a red cross that reads as though the bump broke something.

Secrets cannot be referenced in a step `if`, so the job derives `HAS_LAKE_CACHE_KEY` and the step tests that. This covers a missing or rotated secret and any future context that withholds one, not only Dependabot. The same-repository check stays, so a configuration which did expose secrets to fork pull requests would not silently turn this step into an upload path for them; it now tests `github.event.pull_request == null` rather than the event name, so a privileged pull-request event checking out the head SHA cannot bypass it.

`Verify Lake Cache` and `Restore Build` are both conditioned on `steps.upload-lake-cache.outcome == 'success'`, and a skipped step reports `skipped`, so they stay skipped exactly as they already do on fork pull requests.

🤖 Prepared with Claude Code
