### PR TITLE
fix: expose Array.mapM for kernel reduction

### DIFF
--- a/src/Init/Data/Array/Basic.lean
+++ b/src/Init/Data/Array/Basic.lean
@@ -751,7 +751,7 @@ Applies the monadic action `f` to every element in the array, left-to-right, and
 of results.
 -/
 -- Reference implementation for `mapM`
-@[implemented_by mapMUnsafe]
+@[implemented_by mapMUnsafe, expose]
 def mapM {α : Type u} {β : Type v} {m : Type v → Type w} [Monad m] (f : α → m β) (as : Array α) : m (Array β) :=
   -- Note: we cannot use `foldlM` here for the reference implementation because this calls
   -- `bind` and `pure` too many times. (We are not assuming `m` is a `LawfulMonad`)

--- a/tests/elab/array_map_module.lean
+++ b/tests/elab/array_map_module.lean
@@ -1,0 +1,9 @@
+module
+
+/-!
+Tests kernel reduction of `Array.map` across a module boundary.
+-/
+
+example : ((#[1, 2] : Array Nat).map (· + 1)).toList = [2, 3] := by decide +kernel
+example : ((#[] : Array Nat).map (· + 1)).toList = [] := by decide +kernel
+example : ((#v[1, 2] : Vector Nat 2).map (· + 1)).toList = [2, 3] := by decide +kernel


### PR DESCRIPTION
This PR lets `Array.map` and the delegating `Vector.map` reduce in the kernel across module boundaries.

`Array.map` is `@[inline, expose]` but delegates to the `Array.mapM` reference implementation, a plain `def` whose `let rec map` carries the recursion, so downstream module kernels treat the whole loop as opaque. Expose it, matching the neighbouring `foldlM` and `forIn'` reference implementations, which already pair `@[implemented_by]` with `@[expose]`; exposure covers the `let rec` helper. The regressions state the equalities through `toList` with `decide +kernel`, so they do not depend on the nonempty-`Array`/`Vector` `DecidableEq` fixes.

Same mechanism as #14270, #14988, and #14989. Found via a verified graph-canonicalization certificate checker whose kernel replay validates automorphism records with an `Array.map`: the obligations reduced in non-module files and stalled at module finalization.

:robot: prepared using Codex+Claude
