### PR TITLE
chore: forbid process narrative in PR descriptions in CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -113,6 +113,8 @@ Subject should use imperative present tense ("add" not "added"), no capitalizati
 
 **Body format:** The first paragraph must start with "This PR". This paragraph is automatically incorporated into release notes, so keep it short, focus on user-side impact, and avoid implementation-specific wording. Save the implementation details for a follow-up paragraph. Use imperative present tense. Do NOT use markdown headings (`## Summary`, `## Test plan`, etc.) in PR bodies.
 
+**No process narrative:** Describe the change as it stands. Do not narrate how it was developed or verified ("validated locally against nightly X", "relying on CI for the full build", what earlier drafts did).
+
 **Line wrapping:** Do NOT hard-wrap lines in commit messages or PR descriptions. Write each paragraph as a single line and let display tools (GitHub, `git log`, terminals) soft-wrap. Bullet lists are still fine; just keep each `* item` body on one line.
 
 Example:


### PR DESCRIPTION
This PR adds a note to .claude/CLAUDE.md that PR descriptions should describe the change as it stands, without narrating how it was developed or verified.

🤖 Prepared with Claude Code