### PR TITLE
fix: use CMAKE_COMMAND instead of bare cmake in build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -837,12 +837,12 @@ if(STAGE GREATER 1)
   add_custom_target(
     copy-leancpp
     COMMAND
-      cmake -E copy_if_different "${PREV_STAGE}/runtime/libleanrt_initial-exec.a"
+      ${CMAKE_COMMAND} -E copy_if_different "${PREV_STAGE}/runtime/libleanrt_initial-exec.a"
       "${CMAKE_BINARY_DIR}/runtime/libleanrt_initial-exec.a"
-    COMMAND cmake -E copy_if_different "${PREV_STAGE}/lib/lean/libleanrt.a" "${CMAKE_BINARY_DIR}/lib/lean/libleanrt.a"
-    COMMAND cmake -E copy_if_different "${PREV_STAGE}/lib/lean/libleancpp.a" "${CMAKE_BINARY_DIR}/lib/lean/libleancpp.a"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PREV_STAGE}/lib/lean/libleanrt.a" "${CMAKE_BINARY_DIR}/lib/lean/libleanrt.a"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PREV_STAGE}/lib/lean/libleancpp.a" "${CMAKE_BINARY_DIR}/lib/lean/libleancpp.a"
     COMMAND
-      cmake -E copy_if_different "${PREV_STAGE}/lib/temp/libleancpp_1.a" "${CMAKE_BINARY_DIR}/lib/temp/libleancpp_1.a"
+      ${CMAKE_COMMAND} -E copy_if_different "${PREV_STAGE}/lib/temp/libleancpp_1.a" "${CMAKE_BINARY_DIR}/lib/temp/libleancpp_1.a"
   )
   add_dependencies(leanrt_initial-exec copy-leancpp)
   add_dependencies(leanrt copy-leancpp)
@@ -851,7 +851,7 @@ if(STAGE GREATER 1)
   if(LLVM)
     add_custom_target(
       copy-lean-h-bc
-      COMMAND cmake -E copy_if_different "${PREV_STAGE}/lib/lean/lean.h.bc" "${CMAKE_BINARY_DIR}/lib/lean/lean.h.bc"
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PREV_STAGE}/lib/lean/lean.h.bc" "${CMAKE_BINARY_DIR}/lib/lean/lean.h.bc"
     )
     add_dependencies(leancpp copy-lean-h-bc)
   endif()
@@ -883,7 +883,7 @@ endif()
 if(STAGE GREATER 0 AND CADICAL AND INSTALL_CADICAL)
   add_custom_target(
     copy-cadical
-    COMMAND cmake -E copy_if_different "${CADICAL}" "${CMAKE_BINARY_DIR}/bin/cadical${CMAKE_EXECUTABLE_SUFFIX}"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CADICAL}" "${CMAKE_BINARY_DIR}/bin/cadical${CMAKE_EXECUTABLE_SUFFIX}"
   )
   add_dependencies(leancpp copy-cadical)
 endif()
@@ -891,7 +891,7 @@ endif()
 if(LEANTAR AND INSTALL_LEANTAR)
   add_custom_target(
     copy-leantar
-    COMMAND cmake -E copy_if_different "${LEANTAR}" "${CMAKE_BINARY_DIR}/bin/leantar${CMAKE_EXECUTABLE_SUFFIX}"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${LEANTAR}" "${CMAKE_BINARY_DIR}/bin/leantar${CMAKE_EXECUTABLE_SUFFIX}"
   )
   add_dependencies(leancpp copy-leantar)
 endif()


### PR DESCRIPTION
This PR replaces bare uses of cmake in build script with ${CMAKE_COMMAND} to avoid path issues.

This matches CMake guidance and the file's own existing use of ${CMAKE_COMMAND} elsewhere.

The changes in this commit used AI.