### PR TITLE
perf: write the constructor header with a single store

### DIFF
--- a/src/include/lean/lean.h
+++ b/src/include/lean/lean.h
@@ -492,8 +492,15 @@ inlined into it.
 
 Requires `sz` to be a positive multiple of `LEAN_OBJECT_SIZE_DELTA` of at most
 `MI_SMALL_SIZE_MAX`. Initializes `m_cs_sz`.
+
+Panics on exhaustion rather than returning `NULL`, so callers need no OOM check.
 */
 LEAN_EXPORT LEAN_ATTR_MALLOC lean_object * lean_alloc_small_object_core(unsigned sz);
+/*
+As above, but leaving the entire header to the caller, so that a caller writing all four header
+fields can do so with a single store.
+*/
+LEAN_EXPORT LEAN_ATTR_MALLOC lean_object * lean_alloc_small_object_raw(unsigned sz);
 #endif
 
 #ifndef __cplusplus
@@ -796,9 +803,37 @@ static inline uint8_t * lean_ctor_scalar_cptr(lean_object * o) {
 
 static inline lean_object * lean_alloc_ctor(unsigned tag, unsigned num_objs, unsigned scalar_sz) {
     assert(tag <= LeanMaxCtorTag && num_objs < LEAN_MAX_CTOR_FIELDS && scalar_sz < LEAN_MAX_CTOR_SCALARS_SIZE);
-    lean_object * o = lean_alloc_ctor_memory(lean_usize_add_checked(lean_usize_add_checked(sizeof(lean_ctor_object), lean_usize_mul_checked(sizeof(void*), num_objs)), scalar_sz));
+    size_t sz = lean_usize_add_checked(lean_usize_add_checked(sizeof(lean_ctor_object), lean_usize_mul_checked(sizeof(void*), num_objs)), scalar_sz);
+#ifdef LEAN_MIMALLOC
+    // NOTE: `sz` is known at compile time for most callers, folding the branches below
+    size_t sz1 = lean_align(sz, LEAN_OBJECT_SIZE_DELTA);
+    lean_object * o;
+    if (LEAN_LIKELY(sz1 <= MI_SMALL_SIZE_MAX)) {
+        o = lean_alloc_small_object_raw((unsigned)sz1);
+    } else {
+        lean_inc_heartbeat();
+        void * mem = mi_malloc(sz1);
+        if (mem == 0) lean_internal_panic_out_of_memory();
+        o = (lean_object*)mem;
+    }
+    if (sz1 > sz) {
+        /* Zero the last word so that the (sz1 - sz) uninitialized trailing bytes do not make the
+           structural comparisons in `maxsharing.cpp` and `compact.cpp` miss sharing. */
+        ((size_t*)((char*)o + sz1))[-1] = 0;
+    }
+    /* Write the full header with adjacent stores; for the constant arguments of compiled code they
+       merge into one. `lean_set_st_header` cannot merge, as it must preserve the `m_cs_sz` that
+       `lean_alloc_small_object_core` has already written. */
+    lean_internal_set_rc(o, 1);
+    o->m_cs_sz = (unsigned)sz1;
+    o->m_other = num_objs;
+    o->m_tag   = tag;
+    return o;
+#else
+    lean_object * o = lean_alloc_ctor_memory((unsigned)sz);
     lean_set_st_header(o, tag, num_objs);
     return o;
+#endif
 }
 
 static inline b_lean_obj_res lean_ctor_get(b_lean_obj_arg o, unsigned i) {

--- a/src/runtime/mimalloc.cpp
+++ b/src/runtime/mimalloc.cpp
@@ -50,3 +50,13 @@ extern "C" LEAN_EXPORT LEAN_ATTR_MALLOC lean_object * lean_alloc_small_object_co
     o->m_cs_sz = sz;
     return o;
 }
+
+extern "C" LEAN_EXPORT LEAN_ATTR_MALLOC lean_object * lean_alloc_small_object_raw(unsigned sz) {
+    lean_runtime_tls * tls = &lean_g_tls;
+    tls->heartbeat++;
+    lean_assert(sz > 0 && sz % LEAN_OBJECT_SIZE_DELTA == 0 && sz <= MI_SMALL_SIZE_MAX);
+    void * mem = mi_theap_malloc_small(tls->mi_theap_default, sz);
+    if (LEAN_UNLIKELY(mem == NULL)) lean_internal_panic_out_of_memory();
+    /* Unlike `lean_alloc_small_object_core`, `m_cs_sz` is left to the caller. */
+    return (lean_object *)mem;
+}


### PR DESCRIPTION
This PR lets `lean_alloc_ctor` write all four header fields at once, replacing the two partial stores a constructor allocation needed before.

`lean_alloc_small_object_core` initializes `m_cs_sz` itself, so a caller that goes on to set the remaining header fields cannot merge its stores with that one. A second entry point `lean_alloc_small_object_raw` leaves the header entirely to the caller, and `lean_alloc_ctor` then writes `m_rc`, `m_cs_sz`, `m_other` and `m_tag` with adjacent stores, which fold into one for the constant arguments of compiled code. Allocating a `List.cons`:

```diff
 mov    edi, 0x18
-call   lean_alloc_small_object_core   ; stores m_cs_sz itself
-mov    DWORD PTR [rax], 0x1           ; m_rc
-mov    WORD PTR [rax+0x6], 0x102      ; m_other, m_tag; cannot merge across m_cs_sz
+call   lean_alloc_small_object_raw    ; leaves the header alone
+movabs rcx, 0x102001800000001         ; m_rc | m_cs_sz | m_other | m_tag
+mov    QWORD PTR [rax], rcx           ; one store
 mov    QWORD PTR [rax+0x8], r14
 mov    QWORD PTR [rax+0x10], rbx
```

What this removes is stores rather than instructions. The new entry point is the same length as `lean_alloc_small_object_core`, the register freed by dropping the `m_cs_sz` store being spent elsewhere, and the call site needs two instructions either way; what changes is that the three header stores a constructor allocation performed become one.
