### PR TITLE
feat: lake: `precompileLibrary` & `precompileImports`

### DIFF
--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -131,19 +131,20 @@ Modules from the same library are loaded individually, while modules
 from other libraries are loaded as part of the whole library.
 -/
 def Module.fetchImportLibs
-  (self : Module) (imps : Array Module) (compileSelf : Bool)
+  (self : Module) (imps : Array Module)
+  (precompileSelf : Bool) (precompileImports : Bool)
 : FetchM (Array (Job Dynlib)) := do
   let (_, jobs) ← imps.foldlM (init := (({} : NameSet), #[])) fun (libs, jobs) imp => do
     if libs.contains imp.lib.name then
       return (libs, jobs)
     else if self.lib.name = imp.lib.name then
       -- The library as a whole cannot be loaded here, as it includes the module itself.
-      if compileSelf then
+      if precompileSelf then
         let job ← imp.dynlib.fetch
         return (libs, jobs.push job)
       else
         return (libs, jobs)
-    else if compileSelf || imp.lib.shouldPrecompileSelf then
+    else if precompileImports || imp.lib.shouldPrecompileSelf then
       let jobs ← jobs.push <$> imp.lib.shared.fetch
       return (libs.insert imp.lib.name, jobs)
     else
@@ -586,7 +587,7 @@ def Module.recFetchPreSetup (mod : Module) : FetchM (Job ModulePreSetup) := ensu
     mod.transImports.fetch else mod.precompileImports.fetch
   let precompileImports ← precompileImports.await
   let impLibsJob ← Job.collectArray (traceCaption := "import dynlibs") <$>
-    mod.fetchImportLibs precompileImports mod.shouldPrecompileSelf
+    mod.fetchImportLibs precompileImports mod.shouldPrecompileSelf mod.shouldPrecompileImports
 
   let externLibsJob ← Job.collectArray (traceCaption := "package external libraries") <$>
     if mod.shouldPrecompileImports then mod.pkg.externLibs.mapM (·.dynlib.fetch) else pure #[]
@@ -1365,7 +1366,7 @@ def Module.recBuildDynlib (mod : Module) : FetchM (Job Dynlib) :=
   -- Fetch dependencies' dynlibs
   let libJobs ← id do
     let imps ← (← mod.imports.fetch).await
-    let libJobs ← mod.fetchImportLibs imps true
+    let libJobs ← mod.fetchImportLibs imps true true
     let libJobs ← mod.lib.moreLinkLibs.foldlM
       (·.push <$> ·.fetchIn mod.pkg) libJobs
     let libJobs ← mod.pkg.externLibs.foldlM
@@ -1449,7 +1450,7 @@ def setupEditedModule
     else
       (← computePrecompileImportsAux fileName localImports).await
   let impLibsJob ← Job.collectArray (traceCaption := "import dynlibs") <$>
-    mod.fetchImportLibs precompileImports mod.shouldPrecompileSelf
+    mod.fetchImportLibs precompileImports mod.shouldPrecompileSelf mod.shouldPrecompileImports
   let externLibsJob ← Job.collectArray (traceCaption := "package external libraries") <$>
     if mod.shouldPrecompileImports then mod.pkg.externLibs.mapM (·.dynlib.fetch) else pure #[]
   let dynlibsJob ← mod.dynlibs.fetchIn mod.pkg "module dynlibs"

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -111,7 +111,7 @@ def computePrecompileImportsAux
   (fileName : String) (imports : Array Module)
 : FetchM (Job (Array Module)) := do
   collectImportsAux fileName imports fun imp =>
-    (imp.lib.shouldPrecompileSelf, ·) <$>
+    (imp.lib.shouldPrecompile, ·) <$>
       if imp.shouldPrecompileImports then
         imp.transImports.fetch
       else
@@ -132,19 +132,19 @@ from other libraries are loaded as part of the whole library.
 -/
 def Module.fetchImportLibs
   (self : Module) (imps : Array Module)
-  (precompileSelf : Bool) (precompileImports : Bool)
+  (precompileModules : Bool) (precompileImports : Bool)
 : FetchM (Array (Job Dynlib)) := do
   let (_, jobs) ← imps.foldlM (init := (({} : NameSet), #[])) fun (libs, jobs) imp => do
     if libs.contains imp.lib.name then
       return (libs, jobs)
     else if self.lib.name = imp.lib.name then
       -- The library as a whole cannot be loaded here, as it includes the module itself.
-      if precompileSelf then
+      if precompileModules then
         let job ← imp.dynlib.fetch
         return (libs, jobs.push job)
       else
         return (libs, jobs)
-    else if precompileImports || imp.lib.shouldPrecompileSelf then
+    else if precompileImports || imp.lib.shouldPrecompile then
       let jobs ← jobs.push <$> imp.lib.shared.fetch
       return (libs.insert imp.lib.name, jobs)
     else
@@ -161,7 +161,7 @@ def fetchImportLibs
   let (_, jobs) ← mods.foldlM (init := (({} : NameSet), #[])) fun (libs, jobs) imp => do
     if libs.contains imp.lib.name then
       return (libs, jobs)
-    else if imp.lib.shouldPrecompileSelf then
+    else if imp.lib.shouldPrecompile then
       let jobs ← jobs.push <$> imp.lib.shared.fetch
       return (libs.insert imp.lib.name, jobs)
     else
@@ -587,7 +587,7 @@ def Module.recFetchPreSetup (mod : Module) : FetchM (Job ModulePreSetup) := ensu
     mod.transImports.fetch else mod.precompileImports.fetch
   let precompileImports ← precompileImports.await
   let impLibsJob ← Job.collectArray (traceCaption := "import dynlibs") <$>
-    mod.fetchImportLibs precompileImports mod.shouldPrecompileSelf mod.shouldPrecompileImports
+    mod.fetchImportLibs precompileImports mod.shouldPrecompile mod.shouldPrecompileImports
 
   let externLibsJob ← Job.collectArray (traceCaption := "package external libraries") <$>
     if mod.shouldPrecompileImports then mod.pkg.externLibs.mapM (·.dynlib.fetch) else pure #[]
@@ -1450,7 +1450,7 @@ def setupEditedModule
     else
       (← computePrecompileImportsAux fileName localImports).await
   let impLibsJob ← Job.collectArray (traceCaption := "import dynlibs") <$>
-    mod.fetchImportLibs precompileImports mod.shouldPrecompileSelf mod.shouldPrecompileImports
+    mod.fetchImportLibs precompileImports mod.shouldPrecompile mod.shouldPrecompileImports
   let externLibsJob ← Job.collectArray (traceCaption := "package external libraries") <$>
     if mod.shouldPrecompileImports then mod.pkg.externLibs.mapM (·.dynlib.fetch) else pure #[]
   let dynlibsJob ← mod.dynlibs.fetchIn mod.pkg "module dynlibs"

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -111,11 +111,8 @@ def computePrecompileImportsAux
   (fileName : String) (imports : Array Module)
 : FetchM (Job (Array Module)) := do
   collectImportsAux fileName imports fun imp =>
-    (imp.lib.shouldPrecompile, ·) <$>
-      if imp.shouldPrecompileImports then
-        imp.transImports.fetch
-      else
-        imp.precompileImports.fetch
+    -- `imp.shouldPrecompile` implies `imp.lib.shouldPrecompile`
+    (imp.lib.shouldPrecompile, ·) <$> imp.precompileImports.fetch
 
 /-- Recursively compute a module's precompiled imports. -/
 def Module.recComputePrecompileImports (mod : Module) : FetchM (Job (Array Module)) := ensureJob do

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -111,10 +111,11 @@ def computePrecompileImportsAux
   (fileName : String) (imports : Array Module)
 : FetchM (Job (Array Module)) := do
   collectImportsAux fileName imports fun imp =>
-    if imp.shouldPrecompile then
-      (true, ·) <$> imp.transImports.fetch
-    else
-      (false, ·) <$> imp.precompileImports.fetch
+    (imp.lib.shouldPrecompileSelf, ·) <$>
+      if imp.shouldPrecompileImports then
+        imp.transImports.fetch
+      else
+        imp.precompileImports.fetch
 
 /-- Recursively compute a module's precompiled imports. -/
 def Module.recComputePrecompileImports (mod : Module) : FetchM (Job (Array Module)) := ensureJob do
@@ -135,10 +136,14 @@ def Module.fetchImportLibs
   let (_, jobs) ← imps.foldlM (init := (({} : NameSet), #[])) fun (libs, jobs) imp => do
     if libs.contains imp.lib.name then
       return (libs, jobs)
-    else if compileSelf && self.lib.name = imp.lib.name then
-      let job ← imp.dynlib.fetch
-      return (libs, jobs.push job)
-    else if compileSelf || imp.shouldPrecompile then
+    else if self.lib.name = imp.lib.name then
+      -- The library as a whole cannot be loaded here, as it includes the module itself.
+      if compileSelf then
+        let job ← imp.dynlib.fetch
+        return (libs, jobs.push job)
+      else
+        return (libs, jobs)
+    else if compileSelf || imp.lib.shouldPrecompileSelf then
       let jobs ← jobs.push <$> imp.lib.shared.fetch
       return (libs.insert imp.lib.name, jobs)
     else
@@ -155,7 +160,7 @@ def fetchImportLibs
   let (_, jobs) ← mods.foldlM (init := (({} : NameSet), #[])) fun (libs, jobs) imp => do
     if libs.contains imp.lib.name then
       return (libs, jobs)
-    else if imp.shouldPrecompile then
+    else if imp.lib.shouldPrecompileSelf then
       let jobs ← jobs.push <$> imp.lib.shared.fetch
       return (libs.insert imp.lib.name, jobs)
     else
@@ -577,14 +582,14 @@ def Module.recFetchPreSetup (mod : Module) : FetchM (Job ModulePreSetup) := ensu
   Remark: It should be possible to avoid transitive imports here when the module
   itself is precompiled, but they are currently kept to preserve the "bad import" errors.
   -/
-  let precompileImports ← if mod.shouldPrecompile then
+  let precompileImports ← if mod.shouldPrecompileImports then
     mod.transImports.fetch else mod.precompileImports.fetch
   let precompileImports ← precompileImports.await
   let impLibsJob ← Job.collectArray (traceCaption := "import dynlibs") <$>
-    mod.fetchImportLibs precompileImports mod.shouldPrecompile
+    mod.fetchImportLibs precompileImports mod.shouldPrecompileSelf
 
   let externLibsJob ← Job.collectArray (traceCaption := "package external libraries") <$>
-    if mod.shouldPrecompile then mod.pkg.externLibs.mapM (·.dynlib.fetch) else pure #[]
+    if mod.shouldPrecompileImports then mod.pkg.externLibs.mapM (·.dynlib.fetch) else pure #[]
   let dynlibsJob ← mod.dynlibs.fetchIn mod.pkg "module dynlibs"
   let pluginsJob ← mod.plugins.fetchIn mod.pkg "module plugins"
 
@@ -1439,14 +1444,14 @@ def setupEditedModule
   let impInfoJob ← fetchImportInfo fileName mod.pkg.keyName mod.name header
     (allowNonModules := mod.allowNonModules)
   let precompileImports ←
-    if mod.shouldPrecompile then
+    if mod.shouldPrecompileImports then
       (← computeTransImportsAux fileName localImports).await
     else
       (← computePrecompileImportsAux fileName localImports).await
   let impLibsJob ← Job.collectArray (traceCaption := "import dynlibs") <$>
-    mod.fetchImportLibs precompileImports mod.shouldPrecompile
+    mod.fetchImportLibs precompileImports mod.shouldPrecompileSelf
   let externLibsJob ← Job.collectArray (traceCaption := "package external libraries") <$>
-    if mod.shouldPrecompile then mod.pkg.externLibs.mapM (·.dynlib.fetch) else pure #[]
+    if mod.shouldPrecompileImports then mod.pkg.externLibs.mapM (·.dynlib.fetch) else pure #[]
   let dynlibsJob ← mod.dynlibs.fetchIn mod.pkg "module dynlibs"
   let pluginsJob ← mod.plugins.fetchIn mod.pkg "module plugins"
   extraDepJob.bindM (sync := true) fun _ => do

--- a/src/lake/Lake/Config/LeanConfig.lean
+++ b/src/lake/Lake/Config/LeanConfig.lean
@@ -254,6 +254,14 @@ public configuration LeanConfig where
   and Lake will not catch it. Defaults to `none`.
   -/
   platformIndependent : Option Bool := none
+  /--
+  Whether to compile the imports of modules into native shared libraries that
+  are loaded when the module is built. This speeds up evaluation of metaprograms
+  and enables the interpreter to run functions marked `@[extern]`.
+
+  Defaults to `false`.
+  -/
+  precompileImports : Bool := false
   /-
   An array of dynamic library targets to load during the elaboration
   of a module (via `lean --load-dynlib`).

--- a/src/lake/Lake/Config/LeanLib.lean
+++ b/src/lake/Lake/Config/LeanLib.lean
@@ -116,7 +116,7 @@ or if the library's modules are precompiled.
 Whether to precompile the library for importers.
 Is true if the library has `precompileLibrary` set or its modules are precompiled.
 -/
-@[inline] public def shouldPrecompileSelf (self : LeanLib) : Bool :=
+@[inline] public def shouldPrecompile (self : LeanLib) : Bool :=
   self.precompileModules || self.config.precompileLibrary
 
 /--

--- a/src/lake/Lake/Config/LeanLib.lean
+++ b/src/lake/Lake/Config/LeanLib.lean
@@ -105,6 +105,14 @@ Is true if either the package or the library have `precompileModules` set.
   self.pkg.precompileModules || self.config.precompileModules
 
 /--
+Whether to precompile the imports of the library's modules.
+Is true if either the package or the library have `precompileImports` set,
+or if the library's modules are precompiled.
+-/
+@[inline] public def precompileImports (self : LeanLib) : Bool :=
+  self.precompileModules || self.pkg.precompileImports || self.config.precompileImports
+
+/--
 Whether to precompile the library for importers.
 Is true if the library has `precompileLibrary` set or its modules are precompiled.
 -/

--- a/src/lake/Lake/Config/LeanLib.lean
+++ b/src/lake/Lake/Config/LeanLib.lean
@@ -105,6 +105,13 @@ Is true if either the package or the library have `precompileModules` set.
   self.pkg.precompileModules || self.config.precompileModules
 
 /--
+Whether to precompile the library for importers.
+Is true if the library has `precompileLibrary` set or its modules are precompiled.
+-/
+@[inline] public def shouldPrecompileSelf (self : LeanLib) : Bool :=
+  self.precompileModules || self.config.precompileLibrary
+
+/--
 Whether to the library's Lean code is platform-independent.
 Returns the library's `platformIndependent` configuration if non-`none`.
 Otherwise, falls back to the package's.

--- a/src/lake/Lake/Config/LeanLibConfig.lean
+++ b/src/lake/Lake/Config/LeanLibConfig.lean
@@ -73,28 +73,25 @@ public configuration LeanLibConfig (name : Name) extends LeanConfig where
   extraDepTargets : Array Name := #[]
 
   /--
-  Whether to compile each of the library's modules into a native shared library
-  that is loaded whenever the module is imported. This speeds up evaluation of
-  metaprograms and enables the interpreter to run functions marked `@[extern]`.
-
-  Defaults to `false`.
-  -/
-  precompileModules : Bool := false
-
-  /--
   Whether to compile the library into a native shared library that is loaded
   whenever one of its modules is imported by a module outside the library.
   This speeds up evaluation of metaprograms and enables the interpreter to run
   functions marked `@[extern]`.
 
-  Unlike `precompileModules`, the library's own modules are not compiled into
-  shared libraries loaded within the library itself, nor are the shared libraries
-  of the library's imports loaded when building it. Thus, `precompileModules`
-  implies `precompileLibrary`, but not vice versa.
-
   Defaults to `false`.
   -/
   precompileLibrary : Bool := false
+
+  /--
+  Whether to compile each of the library's modules into a native shared library
+  that is loaded whenever the module is imported. This speeds up evaluation of
+  metaprograms and enables the interpreter to run functions marked `@[extern]`.
+
+  This implies `precompileImports` and `precompileLibrary`.
+
+  Defaults to `false`.
+  -/
+  precompileModules : Bool := false
 
   /--
   An `Array` of library facets to build on a bare `lake build` of the library.

--- a/src/lake/Lake/Config/LeanLibConfig.lean
+++ b/src/lake/Lake/Config/LeanLibConfig.lean
@@ -82,6 +82,21 @@ public configuration LeanLibConfig (name : Name) extends LeanConfig where
   precompileModules : Bool := false
 
   /--
+  Whether to compile the library into a native shared library that is loaded
+  whenever one of its modules is imported by a module outside the library.
+  This speeds up evaluation of metaprograms and enables the interpreter to run
+  functions marked `@[extern]`.
+
+  Unlike `precompileModules`, the library's own modules are not compiled into
+  shared libraries loaded within the library itself, nor are the shared libraries
+  of the library's imports loaded when building it. Thus, `precompileModules`
+  implies `precompileLibrary`, but not vice versa.
+
+  Defaults to `false`.
+  -/
+  precompileLibrary : Bool := false
+
+  /--
   An `Array` of library facets to build on a bare `lake build` of the library.
   For example, `#[LeanLib.sharedFacet]` will build the shared library facet.
   -/

--- a/src/lake/Lake/Config/Module.lean
+++ b/src/lake/Lake/Config/Module.lean
@@ -223,7 +223,7 @@ public def leanIncludeDir? (self : Module) : Option FilePath :=
 
 /-- Whether the module is built with the native code of its imports loaded. -/
 @[inline] public def shouldPrecompileImports (self : Module) : Bool :=
-  self.lib.precompileModules
+  self.lib.precompileImports
 
 @[inline, deprecated "Use `shouldPrecompileImports` or `shouldPrecompileSelf` instead." (since := "2026-09-04")]
 public def shouldPrecompile (self : Module) : Bool :=

--- a/src/lake/Lake/Config/Module.lean
+++ b/src/lake/Lake/Config/Module.lean
@@ -217,7 +217,16 @@ public def leanIncludeDir? (self : Module) : Option FilePath :=
 @[inline] public def platformIndependent (self : Module) : Option Bool :=
   self.lib.platformIndependent
 
-@[inline] public def shouldPrecompile (self : Module) : Bool :=
+/-- Whether the module is compiled into a shared library loaded by its importers. -/
+@[inline] public def shouldPrecompileSelf (self : Module) : Bool :=
+  self.lib.precompileModules
+
+/-- Whether the module is built with the native code of its imports loaded. -/
+@[inline] public def shouldPrecompileImports (self : Module) : Bool :=
+  self.lib.precompileModules
+
+@[inline, deprecated "Use `shouldPrecompileImports` or `shouldPrecompileSelf` instead." (since := "2026-09-04")]
+public def shouldPrecompile (self : Module) : Bool :=
   self.lib.precompileModules
 
 @[inline] public def nativeFacets (self : Module) (shouldExport : Bool) : Array (ModuleFacet FilePath) :=

--- a/src/lake/Lake/Config/Module.lean
+++ b/src/lake/Lake/Config/Module.lean
@@ -217,16 +217,10 @@ public def leanIncludeDir? (self : Module) : Option FilePath :=
 @[inline] public def platformIndependent (self : Module) : Option Bool :=
   self.lib.platformIndependent
 
-/-- Whether the module is compiled into a shared library loaded by its importers. -/
-@[inline] public def shouldPrecompileSelf (self : Module) : Bool :=
-  self.lib.precompileModules
-
-/-- Whether the module is built with the native code of its imports loaded. -/
 @[inline] public def shouldPrecompileImports (self : Module) : Bool :=
   self.lib.precompileImports
 
-@[inline, deprecated "Use `shouldPrecompileImports` or `shouldPrecompileSelf` instead." (since := "2026-09-04")]
-public def shouldPrecompile (self : Module) : Bool :=
+@[inline] public def shouldPrecompile (self : Module) : Bool :=
   self.lib.precompileModules
 
 @[inline] public def nativeFacets (self : Module) (shouldExport : Bool) : Array (ModuleFacet FilePath) :=

--- a/src/lake/Lake/Config/Package.lean
+++ b/src/lake/Lake/Config/Package.lean
@@ -276,6 +276,10 @@ public def id? (self : Package) : Option PkgId :=
 @[inline] public def precompileModules (self : Package) : Bool :=
   self.config.precompileModules
 
+/-- The package's `precompileImports` configuration. -/
+@[inline] public def precompileImports (self : Package) : Bool :=
+  self.config.precompileImports
+
 /-- The package's `moreGlobalServerArgs` configuration. -/
 @[inline] public def moreGlobalServerArgs (self : Package) : Array String :=
   self.config.moreGlobalServerArgs

--- a/src/lake/schemas/lakefile-toml-schema.json
+++ b/src/lake/schemas/lakefile-toml-schema.json
@@ -132,6 +132,11 @@
                     "type": "boolean",
                     "description": "Asserts whether Lake should assume Lean modules are platform-independent.\n\n* If `false`, Lake will add `System.Platform.target` to the module traces within the code unit (e.g., package or library). This will force Lean code to be re-elaborated on different platforms.\n\n* If `true`, Lake will exclude platform-dependent elements (e.g., precompiled modules, external libraries) from a module's trace, preventing re-elaboration on different platforms. Note that this will not effect modules outside the code unit in question. For example, a platform-independent package which depends on a platform-dependent library will still be platform-dependent.\n\n* If not set, Lake will construct traces as natural. That is, it will include platform-dependent artifacts in the trace if they module depends on them, but otherwise not force modules to be platform-dependent.\n\nThere is no check  for correctness here, so a configuration can lie and Lake will not catch it."
                 },
+                "precompileImports": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to compile the imports of modules into native shared libraries that are loaded when the module is built. This speeds up evaluation of metaprograms and enables the interpreter to run functions marked `@[extern]`."
+                },
                 "dynlibs": {
                     "type": "array",
                     "items": {
@@ -217,10 +222,15 @@
                             "default": [],
                             "description": "Build target identifiers of targets to build before the library's modules.\n\nFormat: `<target>[:<facet>]*`, where:\n- `<target>` is of the form `@<package>`, `@<package>/<targetName>`, +<module>` or `@<package>/+<module>`,\n- `<package>` may be empty to reference the default package,\n- `<facet>` is the name of a target facet."
                         },
+                        "precompileLibrary": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Whether to compile the library into a native shared library that is loaded whenever one of its modules is imported by a module outside the library. This speeds up evaluation of metaprograms and enables the interpreter to run functions marked `@[extern]`."
+                        },
                         "precompileModules": {
                             "type": "boolean",
                             "default": false,
-                            "description": "Whether to compile each of the library's modules into a native shared library that is loaded whenever the module is imported. This speeds up evaluation of metaprograms and enables the interpreter to run functions marked `@[extern]`."
+                            "description": "Whether to compile each of the library's modules into a native shared library that is loaded whenever the module is imported. This speeds up evaluation of metaprograms and enables the interpreter to run functions marked `@[extern]`.\n\nThis implies `precompileImports` and `precompileLibrary`."
                         },
                         "defaultFacets": {
                             "type": "array",

--- a/tests/lake/tests/precompileLink/Lib.lean
+++ b/tests/lake/tests/precompileLink/Lib.lean
@@ -1,0 +1,1 @@
+import Lib.Base

--- a/tests/lake/tests/precompileLink/Lib/Base.lean
+++ b/tests/lake/tests/precompileLink/Lib/Base.lean
@@ -1,0 +1,3 @@
+import LibDep
+
+builtin_initialize libGreetingRef : IO.Ref String ← IO.mkRef libGreeting

--- a/tests/lake/tests/precompileLink/LibDep.lean
+++ b/tests/lake/tests/precompileLink/LibDep.lean
@@ -1,0 +1,1 @@
+def libGreeting := "Hello"

--- a/tests/lake/tests/precompileLink/LibDownstream.lean
+++ b/tests/lake/tests/precompileLink/LibDownstream.lean
@@ -1,0 +1,3 @@
+import Lib
+
+#eval libGreetingRef.get

--- a/tests/lake/tests/precompileLink/LibImports.lean
+++ b/tests/lake/tests/precompileLink/LibImports.lean
@@ -1,0 +1,3 @@
+import LibImportsDep
+
+#eval importsGreetingRef.get

--- a/tests/lake/tests/precompileLink/LibImportsDep.lean
+++ b/tests/lake/tests/precompileLink/LibImportsDep.lean
@@ -1,0 +1,1 @@
+builtin_initialize importsGreetingRef : IO.Ref String ← IO.mkRef "Hello"

--- a/tests/lake/tests/precompileLink/lakefile.lean
+++ b/tests/lake/tests/precompileLink/lakefile.lean
@@ -17,5 +17,12 @@ lean_lib Downstream
 
 lean_lib LakeTest
 
+lean_lib Lib where
+  precompileLibrary := true
+
+lean_lib LibDep
+
+lean_lib LibDownstream
+
 lean_lib PlatformIndependent where
   platformIndependent := if get_config? platformIndependent |>.isSome then true else none

--- a/tests/lake/tests/precompileLink/lakefile.lean
+++ b/tests/lake/tests/precompileLink/lakefile.lean
@@ -24,5 +24,10 @@ lean_lib LibDep
 
 lean_lib LibDownstream
 
+lean_lib LibImports where
+  precompileImports := true
+
+lean_lib LibImportsDep
+
 lean_lib PlatformIndependent where
   platformIndependent := if get_config? platformIndependent |>.isSome then true else none

--- a/tests/lake/tests/precompileLink/test.sh
+++ b/tests/lake/tests/precompileLink/test.sh
@@ -3,6 +3,7 @@ source ../common.sh
 
 ./clean.sh
 
+PKG=precompileArgs
 
 # Test that precompilation works with a Lake import
 # https://github.com/leanprover/lean4/issues/7388
@@ -17,13 +18,24 @@ test_run -v exe orderTest
 test_not_out '"plugins":[]' -v setup-file ImportDownstream.lean
 test_run -v build Downstream
 
+# Test that a library with `precompileLibrary` is precompiled for the modules
+# that import it, but not for its own modules
+test_run -v build Lib
+test_exp ! -f .lake/build/lib/lean/${PKG}_Lib_Base.$SHARED_LIB_EXT
+test_exp ! -f .lake/build/lib/${LIB_PREFIX}${PKG}_Lib.$SHARED_LIB_EXT
+test_exp ! -f .lake/build/lib/${LIB_PREFIX}${PKG}_LibDep.$SHARED_LIB_EXT
+test_out '"plugins":[]' -v setup-file Lib.lean
+test_out '"dynlibs":[]' -v setup-file Lib.lean
+test_run -v build LibDownstream
+test_exp -f .lake/build/lib/${LIB_PREFIX}${PKG}_Lib.$SHARED_LIB_EXT
+test_not_out '"plugins":[]' -v setup-file LibDownstream.lean
+
 # Test that `moreLinkArgs` are included when linking precompiled modules
 ./clean.sh
 test_maybe_err "-lBogus" build -KlinkArgs=-lBogus
 ./clean.sh
 
 # Test that dynlibs are part of the module trace unless `platformIndependent` is set
-PKG=precompileArgs
 test_run build -R
 echo foo > .lake/build/lib/lean/${PKG}_Foo_Bar.$SHARED_LIB_EXT
 test_err "Building Foo" build --rehash

--- a/tests/lake/tests/precompileLink/test.sh
+++ b/tests/lake/tests/precompileLink/test.sh
@@ -27,8 +27,18 @@ test_exp ! -f .lake/build/lib/${LIB_PREFIX}${PKG}_LibDep.$SHARED_LIB_EXT
 test_out '"plugins":[]' -v setup-file Lib.lean
 test_out '"dynlibs":[]' -v setup-file Lib.lean
 test_run -v build LibDownstream
+test_exp ! -f .lake/build/lib/lean/${PKG}_Lib_Base.$SHARED_LIB_EXT
 test_exp -f .lake/build/lib/${LIB_PREFIX}${PKG}_Lib.$SHARED_LIB_EXT
+test_exp -f .lake/build/lib/${LIB_PREFIX}${PKG}_LibDep.$SHARED_LIB_EXT
 test_not_out '"plugins":[]' -v setup-file LibDownstream.lean
+
+# Test that a library with `precompileImports` loads the libraries it imports,
+# but is not itself precompiled
+test_run -v build LibImports
+test_exp -f .lake/build/lib/${LIB_PREFIX}${PKG}_LibImportsDep.$SHARED_LIB_EXT
+test_exp ! -f .lake/build/lib/${LIB_PREFIX}${PKG}_LibImports.$SHARED_LIB_EXT
+test_exp ! -f .lake/build/lib/lean/${PKG}_LibImports.$SHARED_LIB_EXT
+test_not_out '"plugins":[]' -v setup-file LibImports.lean
 
 # Test that `moreLinkArgs` are included when linking precompiled modules
 ./clean.sh


### PR DESCRIPTION
This PR adds two new configuration options that are subsets of `precompileModules`: `precompileLibrary` for `lean_lib` targets and `precompileImports` for all Lean configurations (e.g., settable on `package`, `lean_lib`, or `lean_exe`). `precompileImports` compiles a module's imports but not the module itself. `precompileLibrary` compiles the whole library for importers, but the library's modules do not compile their own imports during elaboration.

Closes #2757 with the finer-grain `precompileLibrary` instead of the more general `precompilePackage`.
