### PR TITLE
feat: add a `Decidable` instance for `bif` (`cond`)

### DIFF
--- a/src/Init/Core.lean
+++ b/src/Init/Core.lean
@@ -1230,6 +1230,12 @@ instance {c : Prop} {t : c → Prop} {e : ¬c → Prop} [dC : Decidable c] [dT :
   | isTrue hc  => dT hc
   | isFalse hc => dE hc
 
+@[macro_inline]
+instance {c : Bool} {t e : Prop} [dT : Decidable t] [dE : Decidable e] : Decidable (bif c then t else e) :=
+  match c with
+  | true  => dT
+  | false => dE
+
 /-- Auxiliary definition for generating compact `noConfusion` for enumeration types -/
 abbrev noConfusionTypeEnum {α : Sort u} (f : α → Nat) (P : Sort w) (x y : α) : Sort w :=
   ((f x).beq (f y)).casesOn P (P → P)


### PR DESCRIPTION
This PR adds a missing `Decidable` instance for `bif` (`cond`) expressions, analogous to the existing instance for `if` (`ite`) expressions.

Discussed in https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Decidable.20bif/near/621670745.
