### PR TITLE
fix: remove withPosition in `macro` and `elab`

### DIFF
--- a/src/Lean/Parser/Syntax.lean
+++ b/src/Lean/Parser/Syntax.lean
@@ -114,7 +114,7 @@ def catBehavior := optional (" (" >> nonReservedSymbol "behavior" >> " := " >> (
   optional docComment >> "declare_syntax_cat " >> ident >> catBehavior
 def macroArg  := leading_parser
   optional (atomic (ident >> checkNoWsBefore "no space before ':'" >> ":")) >> syntaxParser argPrec
-def macroRhs : Parser := leading_parser withPosition termParser
+def macroRhs : Parser := leading_parser termParser
 def macroTail := leading_parser atomic (" : " >> ident) >> darrow >> macroRhs
 @[builtin_command_parser] def «macro»       := leading_parser suppressInsideQuot <|
   optional docComment >> optional Term.«attributes» >> Term.attrKind >>
@@ -123,7 +123,7 @@ def macroTail := leading_parser atomic (" : " >> ident) >> darrow >> macroRhs
   optional docComment >> optional Term.«attributes» >> Term.attrKind >>
   "elab_rules" >> optKind >> optional (" : " >> ident) >> optional (" <= " >> ident) >> Term.matchAlts
 def elabArg  := macroArg
-def elabTail := leading_parser atomic (" : " >> ident >> optional (" <= " >> ident)) >> darrow >> withPosition termParser
+def elabTail := leading_parser atomic (" : " >> ident >> optional (" <= " >> ident)) >> darrow >> termParser
 @[builtin_command_parser] def «elab»       := leading_parser suppressInsideQuot <|
   optional docComment >> optional Term.«attributes» >> Term.attrKind >>
   "elab" >> optPrecedence >> optNamedName >> optNamedPrio >> many1 (ppSpace >> elabArg) >> elabTail


### PR DESCRIPTION
This PR removes the `withPosition` marker from the body of `macro` and `elab` declarations.

We typically always use `withPosition` on parts of the syntax that are always layouted to the start of a line so as to not induce visual alignment constraints on a sub-term, only a relative indentation constraint. 
Since bodies of declarations often start with a piece of "sticky" syntax that we append after the separation token before the body of a declaration (e.g. `do`, `by`, `fun`, etc.), declaration bodies are not always layouted to the start of a line, which in turn forces a strange visual alignment constraint on the body.

The `withPosition` was originally added because of this issue, where they body of a macro would keep parsing after the command: [#lean4 > Command terminator @ 💬](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Command.20terminator/near/257674790)
However, this has since been made obsolete by #13229.