### PR TITLE
fix: remove lossy syntax separator array coercions

### DIFF
--- a/src/Init/Meta/Defs.lean
+++ b/src/Init/Meta/Defs.lean
@@ -824,9 +824,6 @@ def SepArray.ofElemsUsingRef [Monad m] [MonadRef m] {sep} (elems : Array Syntax)
   let ref ← getRef;
   return ⟨mkSepArray elems (if String.Internal.isEmpty sep then mkNullNode else mkAtomFrom ref sep)⟩
 
-instance : Coe (Array Syntax) (SepArray sep) where
-  coe := SepArray.ofElems
-
 /--
 Constructs a typed separated array from elements by adding suitable separators.
 The provided array should not include the separators.
@@ -1579,8 +1576,8 @@ instance : EmptyCollection (SepArray sep) where
 instance : EmptyCollection (TSepArray sep k) where
   emptyCollection := ⟨∅⟩
 
-instance : CoeOut (SepArray sep) (Array Syntax) where
-  coe := SepArray.getElems
+instance : CoeOut (TSepArray k sep) (SepArray sep) where
+  coe v := ⟨v.elemsAndSeps⟩
 
 instance : CoeOut (TSepArray k sep) (TSyntaxArray k) where
   coe := TSepArray.getElems


### PR DESCRIPTION
This PR removes the `Array Syntax` -> `SepArray sep` and `SepArray sep` -> `Array Syntax` coercions and adds a separator-`SourceInfo`-preserving `TSepArray ks sep` -> `SepArray sep` coercion instead. Fixes an issue where coercing from `TSepArray ks sep` to `SepArray sep` would lose the `SourceInfo` of the separators.

The former coercion is strange because an `Array Syntax` may be either an array with separators or an array without separators, whereas the latter throws away separators. 