### PR TITLE
chore: set up downstream-force label

### DIFF
--- a/.github/workflows/adaptation-pr.yml
+++ b/.github/workflows/adaptation-pr.yml
@@ -82,6 +82,8 @@ jobs:
           upstream-pr: ${{ github.event.pull_request.number }}
           upstream-ci-green: ${{ steps.toolchain.outputs.exists }}
           upstream-ci-green-msg: The adaptation PR will be created or updated once the toolchain is available.
+          upstream-label: downstream
+          upstream-label-force: downstream-force
           downstream-repo: leanprover/downstream-lean4
           downstream-clone: downstream
           override-toolchain: ${{ steps.toolchain.outputs.toolchain }}

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -667,6 +667,8 @@ jobs:
           app-slug: ${{ steps.app-token.outputs.app-slug }}
           upstream-pr: ${{ steps.workflow-info.outputs.pullRequestNumber }}
           upstream-ci-green: true # We just created the toolchain release
+          upstream-label: downstream
+          upstream-label-force: downstream-force
           downstream-repo: leanprover/downstream-lean4
           downstream-clone: downstream
           override-toolchain: leanprover/lean4-pr-releases:pr-release-${{ steps.workflow-info.outputs.pullRequestNumber }}-${{ env.SHORT_SHA }}


### PR DESCRIPTION
This label forces creation of an adaptation PR even if the usual sanity checks don't succeed.