### PR TITLE
feat: make `Quot` live in `Sort (max 1 u)` rather than `Sort u`

### DIFF
--- a/src/kernel/quot.cpp
+++ b/src/kernel/quot.cpp
@@ -58,12 +58,13 @@ environment environment::add_quot() const {
     name u_name("u");
     local_ctx lctx;
     name_generator g;
-    level u         = mk_univ_param(u_name);
-    expr Sort_u     = mk_sort(u);
-    expr alpha      = lctx.mk_local_decl(g, "α", Sort_u, mk_implicit_binder_info());
-    expr r          = lctx.mk_local_decl(g, "r", mk_arrow(alpha, mk_arrow(alpha, mk_Prop())));
-    /* constant {u} quot {α : Sort u} (r : α → α → Prop) : Sort u */
-    new_env.add_core(constant_info(quot_val(*quot_consts::g_quot, {u_name}, lctx.mk_pi({alpha, r}, Sort_u), quot_kind::Type)));
+    level u           = mk_univ_param(u_name);
+    expr Sort_u       = mk_sort(u);
+    expr Sort_max_1_u = mk_sort(mk_max(mk_level_one(),u));
+    expr alpha        = lctx.mk_local_decl(g, "α", Sort_u, mk_implicit_binder_info());
+    expr r            = lctx.mk_local_decl(g, "r", mk_arrow(alpha, mk_arrow(alpha, mk_Prop())));
+    /* constant {u} quot {α : Sort u} (r : α → α → Prop) : Sort (max 1 u) */
+    new_env.add_core(constant_info(quot_val(*quot_consts::g_quot, {u_name}, lctx.mk_pi({alpha, r}, Sort_max_1_u), quot_kind::Type)));
     expr quot_r     = mk_app(mk_constant(*quot_consts::g_quot, {u}), alpha, r);
     expr a          = lctx.mk_local_decl(g, "a", alpha);
     /* constant {u} quot.mk {α : Sort u} (r : α → α → Prop) (a : α) : @quot.{u} α r */

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,6 +1,6 @@
 #include "util/options.h"
 
-// [ ] Check box to force CI to test stage 2 and run update-stage0 on PR merge
+// [X] Check box to force CI to test stage 2 and run update-stage0 on PR merge
 // (any other change to this file will do the same; ALL changes should be made to the stage0/ copy)
 
 namespace lean {

--- a/tests/elab/quotNotInProp.lean
+++ b/tests/elab/quotNotInProp.lean
@@ -1,3 +1,5 @@
+/-! This test ensures quotients of propositions are types rather than propositions.-/
+
 /-- info: Quot.{u} {α : Sort u} (r : α → α → Prop) : Sort (max 1 u) -/
 #guard_msgs in
 #check Quot

--- a/tests/elab/quotNotInProp.lean
+++ b/tests/elab/quotNotInProp.lean
@@ -1,0 +1,42 @@
+/-- info: Quot.{u} {α : Sort u} (r : α → α → Prop) : Sort (max 1 u) -/
+#guard_msgs in
+#check Quot
+
+variable (s : Squash True)
+def elim  : Nat := Quot.lift (fun _ => 1) (fun _ _ _ => rfl) s
+
+/--
+error: Type mismatch
+  rfl
+has type
+  ?m.5 = ?m.5
+but is expected to have type
+  s = Squash.mk True.intro
+-/
+#guard_msgs in
+#check (rfl : s = Squash.mk .intro)
+
+/--
+error: Type mismatch
+  rfl
+has type
+  ?m.4 = ?m.4
+but is expected to have type
+  elim s = elim (Squash.mk True.intro)
+-/
+#guard_msgs in
+#check (rfl : elim s = elim (Squash.mk .intro))
+
+#guard_msgs(error, drop info) in
+#check (rfl : elim (Squash.mk .intro) = 1)
+
+/--
+error: Type mismatch
+  rfl
+has type
+  ?m.5 = ?m.5
+but is expected to have type
+  elim s = 1
+-/
+#guard_msgs in
+#check (rfl : elim s = 1)


### PR DESCRIPTION
This PR makes it so that quotients of propositions are not themselves propositions, fixing a transitivity issue with the definitional equality algorithm.

Related issue: #14977 