### PR TITLE
chore: remove redundant `sepBy1` in `subst` parser

### DIFF
--- a/src/Lean/Parser/Term.lean
+++ b/src/Lean/Parser/Term.lean
@@ -977,7 +977,7 @@ See the Chapter "Quantifiers and Equality" in the manual
 "Theorem Proving in Lean" for additional information.
 -/
 @[builtin_term_parser] def subst := trailing_parser:75
-  " ▸ " >> sepBy1 (termParser 75) " ▸ "
+  " ▸ " >> termParser 75
 
 def bracketedBinderF := bracketedBinder  -- no default arg
 instance : Coe (TSyntax ``bracketedBinderF) (TSyntax ``bracketedBinder) where coe s := ⟨s⟩

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,6 +1,6 @@
 #include "util/options.h"
 
-// [ ] Check box to force CI to test stage 2 and run update-stage0 on PR merge
+// [x] Check box to force CI to test stage 2 and run update-stage0 on PR merge
 // (any other change to this file will do the same; ALL changes should be made to the stage0/ copy)
 
 namespace lean {


### PR DESCRIPTION
This PR removes a `sepBy1` that we did not elaborate. `subst` chains are right-associative.