### PR TITLE
feat: register missing builtin node kinds

### DIFF
--- a/src/Lean/Parser/Extension.lean
+++ b/src/Lean/Parser/Extension.lean
@@ -33,6 +33,9 @@ builtin_initialize
   registerBuiltinNodeKind scientificLitKind
   registerBuiltinNodeKind charLitKind
   registerBuiltinNodeKind nameLitKind
+  registerBuiltinNodeKind fieldIdxKind
+  registerBuiltinNodeKind hexnumKind
+  registerBuiltinNodeKind interpolatedStrKind
 
 builtin_initialize builtinParserCategoriesRef : IO.Ref ParserCategories ← IO.mkRef {}
 


### PR DESCRIPTION
This PR registers the following missing builtin node kinds: `fieldIdxKind`, `hexnumKind` and `interpolatedStrKind`