### PR TITLE
perf: let Lean's allocations skip mimalloc's free-list scrub

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,8 @@ if(USE_MIMALLOC)
     # cadical, it might be worth reorganizing the directory structure.
     SOURCE_DIR
     "${CMAKE_BINARY_DIR}/mimalloc/src/mimalloc"
+    # Lean-specific allocation knobs; the `checkout` makes re-populating idempotent
+    PATCH_COMMAND git checkout -- . COMMAND git apply "${CMAKE_CURRENT_SOURCE_DIR}/script/mimalloc-lean.patch"
     EXCLUDE_FROM_ALL
   )
   FetchContent_MakeAvailable(mimalloc)

--- a/script/mimalloc-lean.patch
+++ b/script/mimalloc-lean.patch
@@ -1,0 +1,29 @@
+diff --git a/src/alloc.c b/src/alloc.c
+index 0c542af5..f259b370 100644
+--- a/src/alloc.c
++++ b/src/alloc.c
+@@ -29,6 +29,12 @@ terms of the MIT license. A copy of the license can be found in the file
+ // Fast allocation in a page: just pop from the free list.
+ // Fall back to generic allocation only if the list is empty.
+ // Note: in release mode the (inlined) routine is about 7 instructions with a single test.
++// Allow an embedding runtime that always initializes a returned block's header before the block
++// can be read to skip scrubbing the free-list pointer it overlaps. Secure builds scrub regardless.
++#ifndef MI_BLOCK_SCRUB
++#define MI_BLOCK_SCRUB  1
++#endif
++
+ static mi_decl_forceinline void* mi_page_malloc_zero(mi_theap_t* theap, mi_page_t* page, size_t size, bool zero, size_t* usable) mi_attr_noexcept
+ {
+   if (page->block_size != 0) { // not the empty theap
+@@ -77,9 +83,9 @@ static mi_decl_forceinline void* mi_page_malloc_zero(mi_theap_t* theap, mi_page_
+ 
+   // zero the block? note: we need to zero the full block size (issue #63)
+   if mi_likely(!zero) {
+-    // #if MI_SECURE
++    #if MI_BLOCK_SCRUB || MI_SECURE
+     block->next = 0;  // don't leak internal data
+-    // #endif
++    #endif
+     #if (MI_DEBUG>0) && !MI_TRACK_ENABLED && !MI_TSAN
+       if (!mi_page_is_huge(page)) { memset(block, MI_DEBUG_UNINIT, bsize); }
+     #endif    

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -7,7 +7,10 @@ if(USE_MIMALLOC)
   # `MI_MAX_ALIGN_SIZE=8` means that an object with two fields will take 24 bytes instead of 32 bytes.
   # The default value 16 is only necessary for mimalloc to be compatible with the system allocator, which
   # we do not care about.
-  set(MIMALLOC_OPTS -DMI_SHARED_LIB -DMI_SHARED_LIB_EXPORT -O3 -DNDEBUG -DMI_WIN_NOREDIRECT -DMI_MAX_ALIGN_SIZE=8 -Wno-unused-function)
+  # MI_BLOCK_SCRUB=0 (see `script/mimalloc-lean.patch`): every allocation site writes the object
+  # header before the object can be read, so the free-list pointer the scrub would clear is
+  # overwritten anyway. Secure builds scrub regardless.
+  set(MIMALLOC_OPTS -DMI_SHARED_LIB -DMI_SHARED_LIB_EXPORT -O3 -DNDEBUG -DMI_WIN_NOREDIRECT -DMI_MAX_ALIGN_SIZE=8 -DMI_BLOCK_SCRUB=0 -Wno-unused-function)
   if(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang|Clang")
     list(APPEND MIMALLOC_OPTS -Wno-deprecated)
   endif()


### PR DESCRIPTION
This PR drops one store from every small allocation by telling mimalloc that Lean initializes an object's header before the object can be read, worth 0.2% to 0.3% of user instructions on elaboration.

`mi_page_malloc_zero` clears the free-list pointer in a freshly allocated block so that it cannot leak internal data to the caller. That pointer occupies the first word of the block, which for Lean is the object header, and every allocation site writes the header before anything reads it, so the store is dead. `script/mimalloc-lean.patch` puts the scrub behind `MI_BLOCK_SCRUB`, which the runtime's mimalloc variants set to 0; the guard also keeps `MI_SECURE` builds scrubbing regardless. Upstream once guarded this store with `MI_SECURE` and left the guard behind as a comment, which is what the patch reinstates under a name that states the contract.

```diff
 mov    rcx, [rax]                     ; pop the block
 mov    [rdx+0x8], rcx
 inc    WORD PTR [rdx+0x10]            ; page->used++
-mov    QWORD PTR [rax], 0x0           ; scrub the free-list pointer
 mov    WORD PTR [rax+0x4], di         ; m_cs_sz
```