### PR TITLE
fix: add braces around the operator || with lower precedence, make regex portable

### DIFF
--- a/tests/lake/tests/old/test.sh
+++ b/tests/lake/tests/old/test.sh
@@ -10,9 +10,9 @@ LAKE=${LAKE:-../../.lake/build/bin/lake}
 # https://github.com/leanprover/lean4/issues/2822
 
 diff_out() {
-  grep 'Built' || true |
+  { grep 'Built' || true; } |
   sed 's/^.*\[.*\] //' |
-  sed 's/\s*(.*)$//' |
+  sed -E 's/[[:space:]]*(\(.*\))$//' |
   LANG=POSIX sort |
   diff -u --strip-trailing-cr "$1" -
 }


### PR DESCRIPTION
in the test tests/lake/tests/old/test.sh

This fixes this test on FreeBSD.

