### PR TITLE
fix: lake: apply `moreServerOptions` to package modules

### DIFF
--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -1465,7 +1465,7 @@ def setupEditedModule
       importArts := transImpArts
       dynlibs := dynlibs.map (·.path)
       plugins := plugins.map (·.path)
-      options := mod.leanOptions
+      options := mod.serverOptions
     }
 
 /--

--- a/tests/lake/tests/setupFile/moreServerOptions.toml
+++ b/tests/lake/tests/setupFile/moreServerOptions.toml
@@ -1,0 +1,7 @@
+name = "test"
+
+[moreServerOptions]
+weak.foo = "baz"
+
+[[lean_lib]]
+name = "Test"

--- a/tests/lake/tests/setupFile/test.sh
+++ b/tests/lake/tests/setupFile/test.sh
@@ -33,6 +33,12 @@ test_out '"options":{}' setup-file ImportFoo.lean
 # Lake can identify the module corresponding to the path.
 test_out '"options":{"weak.foo":"bar"}' setup-file Test.lean
 
+# Test that `moreServerOptions` applies to external modules.
+test_out '"options":{"weak.foo":"baz"}' -f moreServerOptions.toml setup-file ImportTest.lean
+
+# Test that `moreServerOptions` applies to internal modules.
+test_out '"options":{"weak.foo":"baz"}' -f moreServerOptions.toml setup-file Test.lean
+
 # Test that `setup-file` on an invalid Lean configuration file succeeds.
 test_run -f invalid.lean setup-file invalid.lean
 


### PR DESCRIPTION
This PR fixes a Lake bug where the `moreServerOptions` configuration was only applied to modules outside the package (e.g., when editing scratch fiiles) and not to modules within a package.
