### PR TITLE
fix: close idle HTTP server connections after the keep-alive timeout

### DIFF
--- a/src/Std/Http/Server/Connection.lean
+++ b/src/Std/Http/Server/Connection.lean
@@ -124,6 +124,8 @@ private def pollNextEvent
         selectables := selectables.push (.case (← Selector.sleep (timeout - (← Timestamp.now)).toMilliseconds) (fun _ => pure .timeout))
       else
         selectables := selectables.push (.case (← Selector.sleep sources.timeout) (fun _ => pure .timeout))
+    else
+      selectables := selectables.push (.case (← Selector.sleep sources.timeout) (fun _ => pure .close))
 
   if let some responseBody := sources.responseBody then
     selectables := selectables.push (.case (Body.recvSelector responseBody) (Recv.responseBody · |> pure))

--- a/tests/elab/async_http_idle_timeout.lean
+++ b/tests/elab/async_http_idle_timeout.lean
@@ -1,0 +1,49 @@
+module
+
+import Std.Http.Test.Helpers
+public meta import Std.Http.Test.Helpers
+
+/-!
+Regression tests for #15041: idle HTTP connections close silently before the first request and
+after a response, while a handler may run longer than the idle timeout.
+-/
+
+open Std.Async
+open Std Http Internal Test
+
+private def idleConfig : Config :=
+  { defaultConfig with keepAliveTimeout := ⟨100, by decide⟩ }
+
+private def checkIdleClose (name : String) (request : Option String) (handler : TestHandler)
+    (expect : ByteArray → IO Unit) : IO Unit := runGroup name <| Async.block do
+  let (client, server) ← Mock.new
+  try
+    if let some raw := request then
+      client.send raw.toUTF8
+    Async.race
+      (do
+        Std.Http.Server.serveConnection server handler idleConfig |>.run
+        expect ((← client.recv?).getD .empty)
+        unless (← client.getSendChan.isClosed) do
+          throw <| IO.userError "server did not close the connection")
+      (do
+        sleep 2000
+        throw <| IO.userError "idle connection did not close")
+  finally
+    client.close
+
+#eval checkIdleClose "idle before the first request" none okHandler fun response =>
+  assertExact response ""
+
+#eval checkIdleClose "idle after a response" (some (mkGet)) okHandler fun response => do
+  assertStatus response "HTTP/1.1 200"
+  assertResponseCount response 1
+  assertContains response "ok"
+
+#eval checkIdleClose "handler outlives the idle timeout" (some (mkGet))
+    (fun _ => do
+      sleep 300
+      Response.ok |>.text "ok") fun response => do
+  assertStatus response "HTTP/1.1 200"
+  assertResponseCount response 1
+  assertContains response "ok"


### PR DESCRIPTION
This PR fixes `Std.Http.Server` stalls caused by idle connections retaining connection slots past the configured keep-alive timeout.

Schedule the idle timeout before the first request and between requests, closing the connection silently when it expires. Keep the existing timeout behavior once a request starts. Add regression tests for both idle states and for handlers that run longer than the idle timeout.

AI assistance: Codex assisted with the implementation, regression tests, and this description.

Closes #15041

