### PR TITLE
fix: log `goalsAccomplished` for theorems generated using `elab` (#15044)

### DIFF
--- a/src/Lean/Elab/MutualDef.lean
+++ b/src/Lean/Elab/MutualDef.lean
@@ -1490,7 +1490,9 @@ private def logGoalsAccomplishedSnapshotTask (views : Array DefView)
         msg.severity matches .error || msg.data.hasTag (· == `hasSorry)
     if hasErrorOrSorry then
       return
-    for d in defsParsedSnap.defs, (ref, kind) in views do
+    let defs := if defsParsedSnap.defs.isEmpty then Array.replicate views.size none
+      else defsParsedSnap.defs.map some
+    for d in defs, (ref, kind) in views do
       let logGoalsAccomplished :=
         let msgData := .tagged `goalsAccomplished m!"Goals accomplished!"
         logAt ref msgData (severity := .information) (isSilent := true)
@@ -1498,10 +1500,11 @@ private def logGoalsAccomplishedSnapshotTask (views : Array DefView)
       | .theorem =>
         logGoalsAccomplished
       | .example =>
-        let some processedSnap := d.headerProcessedSnap.get
-          | continue
-        if ! (← isProp processedSnap.view.type) then
-          continue
+        if let some d := d then
+          let some processedSnap := d.headerProcessedSnap.get
+            | continue
+          if ! (← isProp processedSnap.view.type) then
+            continue
         logGoalsAccomplished
       | _ => continue
   let logGoalsAccomplishedTask ← BaseIO.mapTask (t := ← tree.waitAll) logGoalsAccomplishedAct


### PR DESCRIPTION
This PR updates the definition elaborator so that a `goalsAccomplished` message will be logged for theorems that were generated using `elab`.  That causes VS Code to display a double checkmark beside such theorems.

The fix works because when `logGoalsAccomplishedSnapshotTask` is called from `elabMutualDef`, the `defsParsedSnap` argument contains no definitions if we are in a context without a snapshot, which happens when theorems are generated using `elab`.  That argument is used to determine whether an `example` is of type `Prop`, in which case a `goalsAccomplished` message should be logged for it.  With this fix, if `defsParsedSnap` argument has no definitions then we will send a `goalsAccomplished` message for every `example`.  As a consequence, if an `example` is generated using `elab` but is not of type `Prop`, it will get a checkmark in the IDE anyway.  That is imperfect, however that situation should be be quite rare.  

Closes #15044