### PR TITLE
fix: dependency order when rebuilding `have` telescopes in `Sym.simp`

### DIFF
--- a/src/Lean/Meta/Sym/Simp/Have.lean
+++ b/src/Lean/Meta/Sym/Simp/Have.lean
@@ -255,7 +255,7 @@ def toHave (e : Expr) (varDeps : Array (Array Nat)) : SymM Expr :=
       let varPos := varDeps[i]
       let ys := varPos.map fun i => xs[i]!
       let type := consumeForallN t varPos.size
-      let val ← share <| args[i].betaRev ys
+      let val ← share <| args[i].beta ys
       withLetDecl (nondep := true) n type val fun x => do
       go b (xs.push (← share x)) (i+1)
     else

--- a/tests/elab/sym_simp_have_14804.lean
+++ b/tests/elab/sym_simp_have_14804.lean
@@ -1,0 +1,35 @@
+/-!
+Regression tests for #14804.
+
+`Sym.Simp.toHave` used to pass the dependencies of a `have` to `Expr.betaRev` in forward
+order, but `betaRev` expects them reversed. Any `have` whose value depends on two or more
+earlier `have`s of the same telescope was therefore rebuilt with its dependencies swapped.
+-/
+
+/-! The arguments of `f` have different types, so swapping them makes the reconstructed
+`have` ill-typed and the kernel rejects the proof term. -/
+
+def f (a : Nat) (b : Bool) : Nat := if b then a else 0
+
+example :
+    (have a := 1 + 1
+     have b := true
+     have c := f a b
+     c = 2) := by
+  sym =>
+    simp [f]
+    finish
+
+/-! The arguments of `g` have the same type, so swapping them is silent: `c` is rebuilt as
+`2 * b + a` and the goal becomes unprovable. -/
+
+def g (a b : Nat) : Nat := 2 * a + b
+
+example :
+    (have a := 1 + 1
+     have b := 3
+     have c := g a b
+     c = 7) := by
+  sym =>
+    simp [g]
+    finish


### PR DESCRIPTION
This PR fixes `Lean.Meta.Sym.Simp.toHave`, which passed the dependencies of a `have` to `Expr.betaRev` in forward order even though `betaRev` expects them reversed. Any `have` whose value depended on two or more earlier `have`s of the same telescope was rebuilt with its dependencies swapped, producing an ill-typed proof term that the kernel rejects with an application type mismatch.

In `toHave`, `varDeps[i]` (and hence `ys`) is ordered forward, and `args[i]` is the lambda `fun y₁ ... yₖ => vᵢ` that `toBetaApp` built with `mkLambdaFVars ys v` — also forward. `Expr.betaRev` treats its array as `revArgs`, so `args[i].betaRev ys` reduced to `vᵢ[y₁ := yₖ, ..., yₖ := y₁]`. Using `Expr.beta` (defined as `betaRev f args.reverse`) applies them in the order they were abstracted.

The bug was invisible for `have`s with fewer than two dependencies, which is why it survived until now.

Reproducer from the issue, on `nightly-2026-09-05`:

```lean
def f (a : Nat) (b : Bool) : Nat := if b then a else 0

theorem test (y : Bool) :
    (have a := 1 + 1
     have b := y
     have c := f a b
     c = 0) := by
  sym =>
    simp
    sorry
```

```text
error: (kernel) application type mismatch
  f b
argument has type
  Bool
but function has type
  Nat → Bool → Nat
```

`tests/elab/sym_simp_have_14804.lean` adds two regression tests, both of which fail before the fix:

* one where the two dependencies have different types, so the swap makes the rebuilt `have` ill-typed and the kernel rejects the proof term;
* one where they have the same type, so the swap is silent and simply computes the wrong value.

Closes #14804

---

**Verification.** The `build / Linux release` job on this branch is green: the new test passes on the patched build (`3287/4155 Test #3299: elab/sym_simp_have_14804.lean ... Passed`), with 4155/4155 tests passing and no regressions elsewhere. I could not build a patched toolchain locally, so before opening the PR I checked against `nightly-2026-09-05` that both new tests fail without the fix, and that `(fun a b => f a b).betaRev #[x, y]` evaluates to `f y x` while `.beta #[x, y]` evaluates to `f x y`.

**AI assistance.** The diagnosis was already in the issue. Claude Code was used to confirm the root cause against the source, write the regression tests, and draft this description. I reviewed the change and the test file before opening the PR.
