### PR TITLE
perf: mark thunk results as multi-threaded only when the thunk is

### DIFF
--- a/src/runtime/object.cpp
+++ b/src/runtime/object.cpp
@@ -550,7 +550,11 @@ extern "C" LEAN_EXPORT b_obj_res lean_thunk_get_core(b_obj_arg t) {
         object * r = lean_apply_1(c, lean_box(0));
         lean_assert(r != nullptr); /* Closure must return a valid lean object */
         lean_assert(lean_to_thunk(t)->m_value == nullptr);
-        mark_mt(r);
+        /* `r` must be marked as multi-threaded if `t` is: another thread may be waiting
+           for `m_value` below. A single-threaded thunk is reachable from its owner thread
+           only, and `lean_mark_mt` descends into `m_value` should it be published later. */
+        if (lean_is_mt(t) || lean_is_persistent(t))
+            mark_mt(r);
         lean_to_thunk(t)->m_value = r;
         return r;
     } else {


### PR DESCRIPTION
`lean_thunk_get_core` unconditionally called `mark_mt` on the forced value, degrading the entire freshly computed result graph to atomic reference counting even for a thunk that only its owner thread can reach. Mark only if the thunk itself is multi-threaded or persistent, matching what `lean_st_ref_set` does for references.

A single-threaded thunk is not reachable from another thread, so neither is its value, and the waiting branch of `lean_thunk_get_core` is unreachable for it. Should the thunk be published later, `lean_mark_mt` and `lean_mark_persistent` descend into `m_value`; `lean_thunk_pure` already relies on this.