### PR TITLE
feat: bundle the `lean4lean` external checker with release toolchains

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -253,6 +253,18 @@ jobs:
         if: matrix.release && !matrix.wasm
         run: |
           make -C build/$TARGET_STAGE leanchecker-paranoid -j$NPROC
+      - name: Build lean4lean
+        if: matrix.release && !matrix.wasm
+        run: |
+          if ! command -v elan > /dev/null; then
+            # Use consistent `ELAN_HOME` across platforms
+            (cd build && export ELAN_HOME=elan &&
+              curl https://elan.lean-lang.org/elan-init.sh -sSf |
+                sh -s -- -y --default-toolchain none --no-modify-path)
+            export PATH="$PWD/build/elan/bin:$PATH"
+          fi
+          elan --version  # fails step if not found
+          make -C build/$TARGET_STAGE lean4lean
       - name: Install
         run: |
           make -C build/$TARGET_STAGE install

--- a/LICENSES
+++ b/LICENSES
@@ -1372,7 +1372,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ==============================================================================
-leantar is by Mario Carneiro and distributed under the Apache 2.0 License:
+leantar and lean4lean are by Mario Carneiro and distributed under the Apache
+2.0 License:
 ==============================================================================
                                  Apache License
                            Version 2.0, January 2004

--- a/script/lean4lean-minimal-init.sh
+++ b/script/lean4lean-minimal-init.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Adds the internal `-linitialize_minimal` flag to the `lean4lean` executable's link arguments
+
+if ! grep -q initialize_minimal lakefile.toml; then
+  awk '{ print }
+    /^\[\[lean_exe\]\]$/ && !done { print "moreLinkArgs = [\"-linitialize_minimal\"]"; done = 1 }
+  ' lakefile.toml > lakefile.toml.new
+  mv lakefile.toml.new lakefile.toml
+fi
+
+grep -q initialize_minimal lakefile.toml ||
+  { echo "lean4lean-minimal-init.sh: could not add -linitialize_minimal to lakefile.toml" >&2; exit 1; }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1033,6 +1033,23 @@ if(NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten")
     VERBATIM
   )
 
+  # NOTE: uses toolchain from contained `lean-toolchain` so bumps are necessary only on kernel
+  # interface changes. Not in `ALL` as it's expensive; release CI builds it explicitly.
+  ExternalProject_Add(
+    lean4lean
+    PREFIX lean4lean
+    EXCLUDE_FROM_ALL ON
+    GIT_REPOSITORY https://github.com/Kha/lean4lean
+    GIT_TAG lean4-bundle-4.35
+    PATCH_COMMAND bash ${LEAN_SOURCE_DIR}/../script/lean4lean-minimal-init.sh
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND lake build lean4lean
+    BUILD_IN_SOURCE ON
+    INSTALL_COMMAND
+      ${CMAKE_COMMAND} -E copy .lake/build/bin/lean4lean${CMAKE_EXECUTABLE_SUFFIX}
+      ${CMAKE_BINARY_DIR}/bin
+  )
+
   # Not `ALL` as it's big; release CI builds it explicitly.
   if(USE_MIMALLOC)
     add_custom_target(

--- a/tests/pkg/lean4lean/run_test.sh
+++ b/tests/pkg/lean4lean/run_test.sh
@@ -1,0 +1,14 @@
+# `lean4lean` is bundled into release toolchains only, where the build injects it into `bin/` before
+# installing. Skip rather than fail when absent, so an ordinary test run needs neither the binary nor
+# the network to build it.
+if ! command -v lean4lean > /dev/null; then
+    echo "lean4lean not built; skipping"
+    exit 0
+fi
+
+# `--import` replays into an empty environment, so this re-adds every kernel-accelerated primitive
+# and exercises the checker's model of them, which drifts silently as Lean's definitions change:
+# `lean4lean` keeps building against its own pinned toolchain either way.
+leanexport Init > "$TMP_DIR/export.txt"
+lean4lean --import "$TMP_DIR/export.txt" | tee "$TMP_DIR/out"
+grep -qE '^checked [1-9][0-9]* declarations$' "$TMP_DIR/out"


### PR DESCRIPTION
This PR bundles the `lean4lean` external checker with release toolchains, so it can be used as an independent checker without a separate install.

Bundles https://github.com/digama0/lean4lean/pull/47, an updated version of the kernel arena branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
