### PR TITLE
fix: precedence of range syntax

### DIFF
--- a/src/Init/Data/Range/Polymorphic/PRange.lean
+++ b/src/Init/Data/Range/Polymorphic/PRange.lean
@@ -144,48 +144,52 @@ notation for {lean}`Rii.mk`.
 structure Rii (α : Type u)
 deriving DecidableEq
 
+-- The range notations bind looser than arithmetic operators such as `+` and `*`, so that
+-- `a + 1...2 * b` is `(a + 1)...(2 * b)`, but tighter than relations such as `=` and `∈`, so that
+-- `x ∈ a...b` is `x ∈ (a...b)`. They are non-associative. The forms without a lower bound have
+-- precedence `max` so that they can be used as function arguments without parentheses, like `¬p`.
 /-- `a...*` is the range of elements greater than or equal to {lit}`a`. See also {name}`Std.Rci`. -/
-syntax:max (term "...*") : term
+syntax:51 (term:52 "...*") : term
 /-- `*...*` is the range that is unbounded in both directions. See also {lean}`Std.Rii`. -/
 syntax:max ("*...*") : term
 /-- `a<...*` is the range of elements greater than {lit}`a`. See also {lean}`Std.Roi`. -/
-syntax:max (term "<...*") : term
+syntax:51 (term:52 "<...*") : term
 /--
 `a...<b` is the range of elements greater than or equal to {lit}`a` and less than {lit}`b`.
 See also {lean}`Std.Rco`.
 -/
-syntax:max (term "...<" term) : term
+syntax:51 (term:52 "...<" term:52) : term
 /--
 `a...b` is the range of elements greater than or equal to {lit}`a` and less than {lit}`b`.
 See also {lean}`Std.Rco`.
 -/
-syntax:max (term "..." term) : term
+syntax:51 (term:52 "..." term:52) : term
 /-- `*...<b` is the range of elements less than {lit}`b`. See also {lean}`Std.Rio`. -/
-syntax:max ("*...<" term) : term
+syntax:max ("*...<" term:52) : term
 /-- `*...b` is the range of elements less than {lit}`b`. See also {lean}`Std.Rio`. -/
-syntax:max ("*..." term) : term
+syntax:max ("*..." term:52) : term
 /--
 `a<...<b` is the range of elements greater than {lit}`a` and less than {lit}`b`.
 See also {lean}`Std.Roo`.
 -/
-syntax:max (term "<...<" term) : term
+syntax:51 (term:52 "<...<" term:52) : term
 /--
 `a<...b` is the range of elements greater than {lit}`a` and less than {lit}`b`.
 See also {lean}`Std.Roo`.
 -/
-syntax:max (term "<..." term) : term
+syntax:51 (term:52 "<..." term:52) : term
 /--
 `a...=b` is the range of elements greater than or equal to {lit}`a` and less than or equal to
 {lit}`b`. See also {lean}`Std.Rcc`.
 -/
-syntax:max (term "...=" term) : term
+syntax:51 (term:52 "...=" term:52) : term
 /-- `*...=b` is the range of elements less than or equal to {lit}`b`. See also {lean}`Std.Ric`. -/
-syntax:max ("*...=" term) : term
+syntax:max ("*...=" term:52) : term
 /--
 `a<...=b` is the range of elements greater than {lit}`a` and less than or equal to {lit}`b`.
 See also {lean}`Std.Roc`.
 -/
-syntax:max (term "<...=" term) : term
+syntax:51 (term:52 "<...=" term:52) : term
 
 macro_rules
   | `($a...=$b) => ``(Rcc.mk $a $b)

--- a/src/Init/Data/Slice/Array/Basic.lean
+++ b/src/Init/Data/Slice/Array/Basic.lean
@@ -31,7 +31,7 @@ instance : Rco.Sliceable (Array α) Nat (Subarray α) where
 
 instance : Rci.Sliceable (Array α) Nat (Subarray α) where
   mkSlice xs range :=
-    let halfOpenRange := Rci.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Rci.HasRcoIntersection.intersection range (0...<xs.size)
     xs.toSubarray halfOpenRange.lower halfOpenRange.upper
 
 instance : Roc.Sliceable (Array α) Nat (Subarray α) where
@@ -44,7 +44,7 @@ instance : Roo.Sliceable (Array α) Nat (Subarray α) where
 
 instance : Roi.Sliceable (Array α) Nat (Subarray α) where
   mkSlice xs range :=
-    let halfOpenRange := Roi.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Roi.HasRcoIntersection.intersection range (0...<xs.size)
     xs.toSubarray halfOpenRange.lower halfOpenRange.upper
 
 instance : Ric.Sliceable (Array α) Nat (Subarray α) where
@@ -61,42 +61,42 @@ instance : Rii.Sliceable (Array α) Nat (Subarray α) where
 
 instance : Rcc.Sliceable (Subarray α) Nat (Subarray α) where
   mkSlice xs range :=
-    let halfOpenRange := Rcc.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Rcc.HasRcoIntersection.intersection range (0...<xs.size)
     xs.array[(halfOpenRange.lower + xs.start)...(halfOpenRange.upper + xs.start)]
 
 instance : Rco.Sliceable (Subarray α) Nat (Subarray α) where
   mkSlice xs range :=
-    let halfOpenRange := Rco.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Rco.HasRcoIntersection.intersection range (0...<xs.size)
     xs.array[(halfOpenRange.lower + xs.start)...(halfOpenRange.upper + xs.start)]
 
 instance : Rci.Sliceable (Subarray α) Nat (Subarray α) where
   mkSlice xs range :=
-    let halfOpenRange := Rci.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Rci.HasRcoIntersection.intersection range (0...<xs.size)
     xs.array[(halfOpenRange.lower + xs.start)...(halfOpenRange.upper + xs.start)]
 
 instance : Roc.Sliceable (Subarray α) Nat (Subarray α) where
   mkSlice xs range :=
-    let halfOpenRange := Roc.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Roc.HasRcoIntersection.intersection range (0...<xs.size)
     xs.array[(halfOpenRange.lower + xs.start)...(halfOpenRange.upper + xs.start)]
 
 instance : Roo.Sliceable (Subarray α) Nat (Subarray α) where
   mkSlice xs range :=
-    let halfOpenRange := Roo.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Roo.HasRcoIntersection.intersection range (0...<xs.size)
     xs.array[(halfOpenRange.lower + xs.start)...(halfOpenRange.upper + xs.start)]
 
 instance : Roi.Sliceable (Subarray α) Nat (Subarray α) where
   mkSlice xs range :=
-    let halfOpenRange := Roi.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Roi.HasRcoIntersection.intersection range (0...<xs.size)
     xs.array[(halfOpenRange.lower + xs.start)...(halfOpenRange.upper + xs.start)]
 
 instance : Ric.Sliceable (Subarray α) Nat (Subarray α) where
   mkSlice xs range :=
-    let halfOpenRange := Ric.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Ric.HasRcoIntersection.intersection range (0...<xs.size)
     xs.array[(halfOpenRange.lower + xs.start)...(halfOpenRange.upper + xs.start)]
 
 instance : Rio.Sliceable (Subarray α) Nat (Subarray α) where
   mkSlice xs range :=
-    let halfOpenRange := Rio.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Rio.HasRcoIntersection.intersection range (0...<xs.size)
     xs.array[(halfOpenRange.lower + xs.start)...(halfOpenRange.upper + xs.start)]
 
 instance : Rii.Sliceable (Subarray α) Nat (Subarray α) where

--- a/src/Init/Data/Slice/Notation.lean
+++ b/src/Init/Data/Slice/Notation.lean
@@ -133,17 +133,17 @@ class Rii.Sliceable (α : Type u) (β : outParam (Type v)) (γ : outParam (Type 
   mkSlice (carrier : α) (range : Rii β) : γ
 
 macro_rules
-  | `($c[*...*]) => `(Rii.Sliceable.mkSlice $c *...*)
-  | `($c[$a...*]) => `(Rci.Sliceable.mkSlice $c $a...*)
-  | `($c[$a<...*]) => `(Roi.Sliceable.mkSlice $c $a<...*)
-  | `($c[*...<$b]) => `(Rio.Sliceable.mkSlice $c *...<$b)
-  | `($c[$a...<$b]) => `(Rco.Sliceable.mkSlice $c $a...<$b)
-  | `($c[$a<...<$b]) => `(Roo.Sliceable.mkSlice $c $a<...<$b)
-  | `($c[*...$b]) => `(Rio.Sliceable.mkSlice $c *...<$b)
-  | `($c[$a...$b]) => `(Rco.Sliceable.mkSlice $c $a...<$b)
-  | `($c[$a<...$b]) => `(Roo.Sliceable.mkSlice $c $a<...<$b)
-  | `($c[*...=$b]) => `(Ric.Sliceable.mkSlice $c *...=$b)
-  | `($c[$a...=$b]) => `(Rcc.Sliceable.mkSlice $c $a...=$b)
-  | `($c[$a<...=$b]) => `(Roc.Sliceable.mkSlice $c $a<...=$b)
+  | `($c[*...*]) => `(Rii.Sliceable.mkSlice $c (*...*))
+  | `($c[$a...*]) => `(Rci.Sliceable.mkSlice $c ($a...*))
+  | `($c[$a<...*]) => `(Roi.Sliceable.mkSlice $c ($a<...*))
+  | `($c[*...<$b]) => `(Rio.Sliceable.mkSlice $c (*...<$b))
+  | `($c[$a...<$b]) => `(Rco.Sliceable.mkSlice $c ($a...<$b))
+  | `($c[$a<...<$b]) => `(Roo.Sliceable.mkSlice $c ($a<...<$b))
+  | `($c[*...$b]) => `(Rio.Sliceable.mkSlice $c (*...<$b))
+  | `($c[$a...$b]) => `(Rco.Sliceable.mkSlice $c ($a...<$b))
+  | `($c[$a<...$b]) => `(Roo.Sliceable.mkSlice $c ($a<...<$b))
+  | `($c[*...=$b]) => `(Ric.Sliceable.mkSlice $c (*...=$b))
+  | `($c[$a...=$b]) => `(Rcc.Sliceable.mkSlice $c ($a...=$b))
+  | `($c[$a<...=$b]) => `(Roc.Sliceable.mkSlice $c ($a<...=$b))
 
 end Std

--- a/src/Lean/Meta/Tactic/Apply.lean
+++ b/src/Lean/Meta/Tactic/Apply.lean
@@ -191,10 +191,10 @@ def _root_.Lean.MVarId.apply (mvarId : MVarId) (e : Expr) (cfg : ApplyConfig := 
     ```
     -/
     let rangeNumArgs ← if hasMVarHead then
-      pure numArgs...(numArgs+1)
+      pure (numArgs...(numArgs+1))
     else
       let targetTypeNumArgs ← getExpectedNumArgs targetType
-      pure (numArgs - targetTypeNumArgs)...(numArgs+1)
+      pure ((numArgs - targetTypeNumArgs)...(numArgs+1))
     /-
     Auxiliary function for trying to add `n` underscores where `n ∈ [i: rangeNumArgs.stop)`
     See comment above

--- a/src/Std/Data/ByteSlice.lean
+++ b/src/Std/Data/ByteSlice.lean
@@ -330,42 +330,42 @@ section ByteArray
 
 instance : Rcc.Sliceable ByteArray Nat ByteSlice where
   mkSlice xs range :=
-    let halfOpenRange := Rcc.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Rcc.HasRcoIntersection.intersection range (0...<xs.size)
     (xs.toByteSlice halfOpenRange.lower halfOpenRange.upper)
 
 instance : Rco.Sliceable ByteArray Nat ByteSlice where
   mkSlice xs range :=
-    let halfOpenRange := Rco.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Rco.HasRcoIntersection.intersection range (0...<xs.size)
     (xs.toByteSlice halfOpenRange.lower halfOpenRange.upper)
 
 instance : Rci.Sliceable ByteArray Nat ByteSlice where
   mkSlice xs range :=
-    let halfOpenRange := Rci.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Rci.HasRcoIntersection.intersection range (0...<xs.size)
     (xs.toByteSlice halfOpenRange.lower halfOpenRange.upper)
 
 instance : Roc.Sliceable ByteArray Nat ByteSlice where
   mkSlice xs range :=
-    let halfOpenRange := Roc.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Roc.HasRcoIntersection.intersection range (0...<xs.size)
     (xs.toByteSlice halfOpenRange.lower halfOpenRange.upper)
 
 instance : Roo.Sliceable ByteArray Nat ByteSlice where
   mkSlice xs range :=
-    let halfOpenRange := Roo.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Roo.HasRcoIntersection.intersection range (0...<xs.size)
     (xs.toByteSlice halfOpenRange.lower halfOpenRange.upper)
 
 instance : Roi.Sliceable ByteArray Nat ByteSlice where
   mkSlice xs range :=
-    let halfOpenRange := Roi.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Roi.HasRcoIntersection.intersection range (0...<xs.size)
     (xs.toByteSlice halfOpenRange.lower halfOpenRange.upper)
 
 instance : Ric.Sliceable ByteArray Nat ByteSlice where
   mkSlice xs range :=
-    let halfOpenRange := Ric.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Ric.HasRcoIntersection.intersection range (0...<xs.size)
     (xs.toByteSlice halfOpenRange.lower halfOpenRange.upper)
 
 instance : Rio.Sliceable ByteArray Nat ByteSlice where
   mkSlice xs range :=
-    let halfOpenRange := Rio.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Rio.HasRcoIntersection.intersection range (0...<xs.size)
     (xs.toByteSlice halfOpenRange.lower halfOpenRange.upper)
 
 instance : Rii.Sliceable ByteArray Nat ByteSlice where
@@ -379,42 +379,42 @@ section ByteSlice
 
 instance : Rcc.Sliceable ByteSlice Nat ByteSlice where
   mkSlice xs range :=
-    let halfOpenRange := Rcc.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Rcc.HasRcoIntersection.intersection range (0...<xs.size)
     (xs.slice halfOpenRange.lower halfOpenRange.upper)
 
 instance : Rco.Sliceable ByteSlice Nat ByteSlice where
   mkSlice xs range :=
-    let halfOpenRange := Rco.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Rco.HasRcoIntersection.intersection range (0...<xs.size)
     (xs.slice halfOpenRange.lower halfOpenRange.upper)
 
 instance : Rci.Sliceable ByteSlice Nat ByteSlice where
   mkSlice xs range :=
-    let halfOpenRange := Rci.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Rci.HasRcoIntersection.intersection range (0...<xs.size)
     (xs.slice halfOpenRange.lower halfOpenRange.upper)
 
 instance : Roc.Sliceable ByteSlice Nat ByteSlice where
   mkSlice xs range :=
-    let halfOpenRange := Roc.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Roc.HasRcoIntersection.intersection range (0...<xs.size)
     (xs.slice halfOpenRange.lower halfOpenRange.upper)
 
 instance : Roo.Sliceable ByteSlice Nat ByteSlice where
   mkSlice xs range :=
-    let halfOpenRange := Roo.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Roo.HasRcoIntersection.intersection range (0...<xs.size)
     (xs.slice halfOpenRange.lower halfOpenRange.upper)
 
 instance : Roi.Sliceable ByteSlice Nat ByteSlice where
   mkSlice xs range :=
-    let halfOpenRange := Roi.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Roi.HasRcoIntersection.intersection range (0...<xs.size)
     (xs.slice halfOpenRange.lower halfOpenRange.upper)
 
 instance : Ric.Sliceable ByteSlice Nat ByteSlice where
   mkSlice xs range :=
-    let halfOpenRange := Ric.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Ric.HasRcoIntersection.intersection range (0...<xs.size)
     (xs.slice halfOpenRange.lower halfOpenRange.upper)
 
 instance : Rio.Sliceable ByteSlice Nat ByteSlice where
   mkSlice xs range :=
-    let halfOpenRange := Rio.HasRcoIntersection.intersection range 0...<xs.size
+    let halfOpenRange := Rio.HasRcoIntersection.intersection range (0...<xs.size)
     (xs.slice halfOpenRange.lower halfOpenRange.upper)
 
 instance : Rii.Sliceable ByteSlice Nat ByteSlice where

--- a/tests/elab/rangeSyntaxPrecedence.lean
+++ b/tests/elab/rangeSyntaxPrecedence.lean
@@ -1,0 +1,252 @@
+import Std.Data.Iterators
+import Lean
+
+/-!
+Tests for the precedence of the polymorphic range notations `a...b`, `a<...=b`, `*...b`, `a...*`,
+etc. (#12055). The notations bind looser than arithmetic operators such as `+` and `*` but tighter
+than relations such as `=` and `∈`, and `|>.` applies to the whole range rather than to its upper
+bound.
+-/
+
+/-! `|>.` applies to the range, not to its upper bound, for all forms of the notation. -/
+
+/-- info: [1, 2] -/
+#guard_msgs in
+#eval 1...3 |>.toList
+
+/-- info: [1, 2] -/
+#guard_msgs in
+#eval 1...<3 |>.toList
+
+/-- info: [1, 2, 3] -/
+#guard_msgs in
+#eval 1...=3 |>.toList
+
+/-- info: [2] -/
+#guard_msgs in
+#eval 1<...3 |>.toList
+
+/-- info: [2] -/
+#guard_msgs in
+#eval 1<...<3 |>.toList
+
+/-- info: [2, 3] -/
+#guard_msgs in
+#eval 1<...=3 |>.toList
+
+/-- info: [0, 1, 2] -/
+#guard_msgs in
+#eval *...3 |>.toList
+
+/-- info: [0, 1, 2] -/
+#guard_msgs in
+#eval *...<3 |>.toList
+
+/-- info: [0, 1, 2, 3] -/
+#guard_msgs in
+#eval *...=3 |>.toList
+
+/-- info: [254, 255] -/
+#guard_msgs in
+#eval (254 : UInt8)...* |>.toList
+
+/-- info: [255] -/
+#guard_msgs in
+#eval (254 : UInt8)<...* |>.toList
+
+/-- info: 256 -/
+#guard_msgs in
+#eval (*...* : Std.Rii UInt8) |>.toList |>.length
+
+/-- info: 2 -/
+#guard_msgs in
+#eval 1...3 |>.toList |>.length
+
+/-! Arithmetic operators bind tighter than the range notations, on both sides. -/
+
+/-- info: 1 + 2...3 * 4 : Std.Rco Nat -/
+#guard_msgs in
+#check 1 + 2...3 * 4
+
+/-- info: [3, 4, 5, 6, 7, 8, 9, 10, 11] -/
+#guard_msgs in
+#eval 1 + 2...3 * 4 |>.toList
+
+/-- info: [3, 4, 5, 6, 7, 8, 9, 10, 11, 12] -/
+#guard_msgs in
+#eval 1 + 2...=3 * 4 |>.toList
+
+/-- info: [4, 5, 6, 7, 8, 9, 10, 11] -/
+#guard_msgs in
+#eval 1 + 2<...3 * 4 |>.toList
+
+/-- info: [0, 1, 2] -/
+#guard_msgs in
+#eval *...1 + 2 |>.toList
+
+/-- info: [254, 255] -/
+#guard_msgs in
+#eval (250 : UInt8) + 4...* |>.toList
+
+/-- info: [255] -/
+#guard_msgs in
+#eval (250 : UInt8) + 4<...* |>.toList
+
+/-- info: -1...1 : Std.Rco Int -/
+#guard_msgs in
+#check -1...1
+
+/-- info: [-1, 0] -/
+#guard_msgs in
+#eval -1...1 |>.toList
+
+/-- info: [-2] -/
+#guard_msgs in
+#eval (-2 : Int)...-1 |>.toList
+
+/-- info: [3, 4, 5] -/
+#guard_msgs in
+#eval 2 ^ 2 - 1...=5 |>.toList
+
+/-! Function application binds tighter than the range notations. -/
+
+/-- info: Nat.succ 1...Nat.succ 3 : Std.Rco Nat -/
+#guard_msgs in
+#check Nat.succ 1...Nat.succ 3
+
+/-- info: [2, 3] -/
+#guard_msgs in
+#eval Nat.succ 1...Nat.succ 3 |>.toList
+
+/-- info: Nat.succ 1...Nat.succ 3 : Std.Rco Nat -/
+#guard_msgs in
+#check (Nat.succ 1)...(Nat.succ 3)
+
+/-- info: Nat.succ 1<...=Nat.succ 3 : Std.Roc Nat -/
+#guard_msgs in
+#check (Nat.succ 1)<...=(Nat.succ 3)
+
+/-- info: Nat.succ 1...* : Std.Rci Nat -/
+#guard_msgs in
+#check (Nat.succ 1)...*
+
+/-- info: *...Nat.succ 3 : Std.Rio Nat -/
+#guard_msgs in
+#check *...(Nat.succ 3)
+
+/-!
+The forms without a lower bound have no left operand, so they can be used as function arguments
+without parentheses.
+-/
+
+/-- info: [0, 1, 2] -/
+#guard_msgs in
+#eval id *...3 |>.toList
+
+/-- info: [0, 1, 2, 3] -/
+#guard_msgs in
+#eval id *...=3 |>.toList
+
+/-- info: 256 -/
+#guard_msgs in
+#eval (id *...* : Std.Rii UInt8).toList.length
+
+/-! Relations bind looser than the range notations. -/
+
+/-- info: 2 ∈ 1...3 : Prop -/
+#guard_msgs in
+#check 2 ∈ 1...3
+
+/-- info: true -/
+#guard_msgs in
+#eval 2 ∈ 1...3
+
+/-- info: true -/
+#guard_msgs in
+#eval 2 ∈ 1 + 1...3
+
+/-- info: 1...3 = 1...3 : Prop -/
+#guard_msgs in
+#check 1...3 = 1...3
+
+example : 1...3 = 1...<3 := rfl
+example : 1 + 1...3 = 2...3 := rfl
+example : 1 + 1...* = 2...* := rfl
+example : *...1 + 2 = *...3 := rfl
+example : 1 + 1<...=1 + 2 = 2<...=3 := rfl
+
+/-- info: ∀ (i : Nat), i ∈ 0...3 → i < 3 : Prop -/
+#guard_msgs in
+#check ∀ i ∈ 0...3, i < 3
+
+/-- info: 0 ∈ *...3 ∧ 1 ∈ 0...* : Prop -/
+#guard_msgs in
+#check 0 ∈ *...3 ∧ 1 ∈ 0...*
+
+/-! Pipelines apply to the whole range. -/
+
+/-- info: [1, 2] -/
+#guard_msgs in
+#eval 1...3 |> fun r => r.toList
+
+/-- info: [1, 2] -/
+#guard_msgs in
+#eval (fun (r : Std.Rco Nat) => r.toList) <| 1...3
+
+/-! Arithmetic in the bounds of `for` loops and slices. -/
+
+def sumRange (n : Nat) : Nat := Id.run do
+  let mut s := 0
+  for i in n + 1...2 * n do
+    s := s + i
+  return s
+
+/-- info: 9 -/
+#guard_msgs in
+#eval sumRange 3
+
+def sumRangeTo (n : Nat) : Nat := Id.run do
+  let mut s := 0
+  for i in *...=2 * n do
+    s := s + i
+  return s
+
+/-- info: 21 -/
+#guard_msgs in
+#eval sumRangeTo 3
+
+/-- info: #[2, 3] -/
+#guard_msgs in
+#eval #[0, 1, 2, 3, 4][1 + 1...2 * 2].toArray
+
+/-- info: #[2, 3, 4] -/
+#guard_msgs in
+#eval #[0, 1, 2, 3, 4][1 + 1...*].toArray
+
+/-- info: #[0, 1, 2] -/
+#guard_msgs in
+#eval #[0, 1, 2, 3, 4][*...1 + 2].toArray
+
+/-! The range notations are not associative. -/
+
+open Lean in
+def parseTerm (input : String) : CoreM Unit := do
+  match Parser.runParserCategory (← getEnv) `term input with
+  | .ok _ => IO.println "ok"
+  | .error e => IO.println e
+
+/-- info: <input>:1:5: expected end of input -/
+#guard_msgs in
+#eval parseTerm "1...2...3"
+
+/-- info: <input>:1:6: expected end of input -/
+#guard_msgs in
+#eval parseTerm "1...=2<...=3"
+
+/-- info: <input>:1:5: expected end of input -/
+#guard_msgs in
+#eval parseTerm "1...*...*"
+
+/-- info: ok -/
+#guard_msgs in
+#eval parseTerm "(1...2)...3"


### PR DESCRIPTION
This PR adjusts the precedence of the range syntax so that `1 + 2...3` is `(1+2)...3` and `a...b |>.toList` is `(a...b).toList`.

Closes #12055.