### PR TITLE
fix: infer type of range from element type in for loop

### DIFF
--- a/src/Init/Control/Basic.lean
+++ b/src/Init/Control/Basic.lean
@@ -22,6 +22,9 @@ instances are provided for the same type.
 -/
 -- We set the priority to 500 so it is below the default,
 -- but still above the low priority instance from `Stream`.
+-- As a default instance, a stuck `ForIn` problem is solved through a default `ForIn'` instance.
+-- This is how `for (i : Fin 3) in *...*` determines the element type of the full range.
+@[default_instance]
 instance (priority := 500) instForInOfForIn' [ForIn' m ρ α d] : ForIn m ρ α where
   forIn x b f := forIn' x b fun a _ => f a
 

--- a/src/Init/Control/Basic.lean
+++ b/src/Init/Control/Basic.lean
@@ -23,7 +23,8 @@ instances are provided for the same type.
 -- We set the priority to 500 so it is below the default,
 -- but still above the low priority instance from `Stream`.
 -- As a default instance, a stuck `ForIn` problem is solved through a default `ForIn'` instance.
--- This is how `for (i : Fin 3) in *...*` determines the element type of the full range.
+-- This is how `for (i : Int) in 1...3` determines the element type of a range whose bounds are
+-- literals, before those literals would default to `Nat`.
 @[default_instance]
 instance (priority := 500) instForInOfForIn' [ForIn' m ρ α d] : ForIn m ρ α where
   forIn x b f := forIn' x b fun a _ => f a

--- a/src/Init/Data/Range/Polymorphic/Iterators.lean
+++ b/src/Init/Data/Range/Polymorphic/Iterators.lean
@@ -714,7 +714,9 @@ theorem Internal.isPlausibleIndirectOutput_iter_iff
   · obtain ⟨init, hi, hia⟩ := LawfulUpwardEnumerableLeast?.least?_le a
     simpa [Membership.mem, iter, hi] using! hia
 
-@[no_expose]
+-- `*...*` fixes no element type, so `for (i : Fin 3) in *...*` relies on this default instance to
+-- determine `α` from the loop variable.
+@[no_expose, default_instance]
 instance {m} [UpwardEnumerable α] [Least? α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α]
     [Monad m] [Finite (Rxi.Iterator α) Id] :

--- a/src/Init/Data/Range/Polymorphic/Iterators.lean
+++ b/src/Init/Data/Range/Polymorphic/Iterators.lean
@@ -92,7 +92,11 @@ theorem _root_.Std.Rxc.Iterator.upwardEnumerableLe_of_isPlausibleIndirectOutput
   simp only [isPlausibleIndirectOutput_iff, ha, Option.bind_some, exists_and_right] at hout
   exact hout.1
 
-@[no_expose]
+-- The `ForIn'` instances of all range types are default instances so that a loop whose element type
+-- is known can determine the range's type from it, as in `for (i : Int) in 1...3` or
+-- `for (i : Fin 3) in *...*`. Otherwise the literal bounds default to `Nat` first, and `*...*` has
+-- no type at all.
+@[no_expose, default_instance]
 instance {m} [UpwardEnumerable α]
     [LE α] [DecidableLE α] [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
     [Monad m] [Finite (Rxc.Iterator α) Id] :
@@ -178,7 +182,7 @@ theorem _root_.Std.Rxo.Iterator.upwardEnumerableLe_of_isPlausibleIndirectOutput
   simp only [isPlausibleIndirectOutput_iff, ha, Option.bind_some, exists_and_right] at hout
   exact hout.1
 
-@[no_expose]
+@[no_expose, default_instance]
 instance {m} [UpwardEnumerable α] [LE α] [LT α] [DecidableLT α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α] [LawfulUpwardEnumerableLT α]
     [Monad m] [Finite (Rxo.Iterator α) Id] :
@@ -262,7 +266,7 @@ theorem _root_.Std.Rxi.Iterator.upwardEnumerableLe_of_isPlausibleIndirectOutput
   refine ⟨a, ha, ?_⟩
   simpa only [isPlausibleIndirectOutput_iff, ha, Option.bind_some] using! hout
 
-@[no_expose]
+@[no_expose, default_instance]
 instance {m} [UpwardEnumerable α]
     [LE α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
@@ -343,7 +347,7 @@ theorem Internal.isPlausibleIndirectOutput_iter_iff
     exact ⟨n,
       by simp [Internal.iter, hn, ← UpwardEnumerable.succMany?_add_one_eq_succ?_bind_succMany?], hu⟩
 
-@[no_expose]
+@[no_expose, default_instance]
 instance {m} [UpwardEnumerable α]
     [LE α] [DecidableLE α] [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
     [LT α] [LawfulUpwardEnumerableLT α]
@@ -423,7 +427,7 @@ theorem Internal.isPlausibleIndirectOutput_iter_iff
     exact ⟨n,
       by simp [Internal.iter, hn, ← UpwardEnumerable.succMany?_add_one_eq_succ?_bind_succMany?], hu⟩
 
-@[no_expose]
+@[no_expose, default_instance]
 instance {m} [UpwardEnumerable α]
     [LT α] [DecidableLT α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
@@ -500,7 +504,7 @@ theorem Internal.isPlausibleIndirectOutput_iter_iff
     exact ⟨n,
       by simp [Internal.iter, hn, ← UpwardEnumerable.succMany?_add_one_eq_succ?_bind_succMany?]⟩
 
-@[no_expose]
+@[no_expose, default_instance]
 instance {m} [UpwardEnumerable α]
     [LT α] [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
     [Monad m] [Finite (Rxi.Iterator α) Id] :
@@ -573,7 +577,7 @@ theorem Internal.isPlausibleIndirectOutput_iter_iff
     obtain ⟨init, hi, hia⟩ := LawfulUpwardEnumerableLeast?.least?_le a
     simpa [iter, hi] using ⟨hia, hu⟩
 
-@[no_expose]
+@[no_expose, default_instance]
 instance {m} [UpwardEnumerable α]
     [LE α] [DecidableLE α] [Least? α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLE α]
@@ -647,7 +651,7 @@ theorem Internal.isPlausibleIndirectOutput_iter_iff
     obtain ⟨init, hi, hia⟩ := LawfulUpwardEnumerableLeast?.least?_le a
     simpa [iter, hi] using ⟨hia, hu⟩
 
-@[no_expose]
+@[no_expose, default_instance]
 instance {m} [UpwardEnumerable α]
     [LT α] [DecidableLT α] [Least? α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLT α]
@@ -714,8 +718,6 @@ theorem Internal.isPlausibleIndirectOutput_iter_iff
   · obtain ⟨init, hi, hia⟩ := LawfulUpwardEnumerableLeast?.least?_le a
     simpa [Membership.mem, iter, hi] using! hia
 
--- `*...*` fixes no element type, so `for (i : Fin 3) in *...*` relies on this default instance to
--- determine `α` from the loop variable.
 @[no_expose, default_instance]
 instance {m} [UpwardEnumerable α] [Least? α]
     [LawfulUpwardEnumerable α] [LawfulUpwardEnumerableLeast? α]

--- a/tests/elab/ranges_infer.lean
+++ b/tests/elab/ranges_infer.lean
@@ -136,7 +136,7 @@ info: -2
 -/
 #guard_msgs in
 #eval do
-  for (i : Int) in -2...=0 do IO.println i
+  for (i : Int) in (-2)...=0 do IO.println i
 
 /--
 info: 2

--- a/tests/elab/ranges_infer.lean
+++ b/tests/elab/ranges_infer.lean
@@ -1,10 +1,11 @@
 module
 
 /-!
-Tests that a `for` loop over the full range `*...*` determines the range's element type from the
-loop variable, e.g. from an ascription on it or from how it is used in the body. The element type
-is an `outParam` of `ForIn`, so this relies on the default instances on `instForInOfForIn'` and on
-the `ForIn'` instance of `Std.Rii`.
+Tests that a `for` loop over a range whose element type is not fixed by its bounds, such as the full
+range `*...*` or a range with literal bounds like `1...3`, determines the element type from the loop
+variable, e.g. from an ascription on it or from how it is used in the body. The element type is an
+`outParam` of `ForIn`, so this relies on the default instances on `instForInOfForIn'` and on the
+`ForIn'` instances of the range types.
 -/
 
 open Std
@@ -85,3 +86,106 @@ Hint: Adding type annotations and supplying implicit arguments to functions can 
 #guard_msgs in
 def infiniteRange : IO Unit := do
   for (i : Nat) in *...* do IO.println i
+
+/-! Ranges with literal bounds take the element type of the loop before the literals default to
+`Nat`. -/
+
+/--
+info: 1
+2
+-/
+#guard_msgs in
+#eval do
+  for (i : Int) in 1...3 do IO.println i
+
+/--
+info: -9
+-8
+-/
+#guard_msgs in
+#eval do
+  for i in 1...3 do IO.println (i + (-10 : Int))
+
+/-- info: #[1, 2] -/
+#guard_msgs in
+#eval do
+  let mut acc : Array Int := #[]
+  for i in 1...3 do acc := acc.push i
+  IO.println acc
+
+/--
+info: 1
+2
+-/
+#guard_msgs in
+#eval do
+  for (i : Fin 5) in 1...3 do IO.println i
+
+/--
+info: 1
+2
+-/
+#guard_msgs in
+#eval do
+  for _h : (i : Int) in 1...3 do IO.println i
+
+/--
+info: -2
+-1
+0
+-/
+#guard_msgs in
+#eval do
+  for (i : Int) in -2...=0 do IO.println i
+
+/--
+info: 2
+3
+-/
+#guard_msgs in
+#eval do
+  for (i : Int) in 1<...=3 do IO.println i
+
+/--
+info: 0
+1
+2
+-/
+#guard_msgs in
+#eval do
+  for (i : UInt8) in *...3 do IO.println i
+
+/--
+info: -8
+-6
+-/
+#guard_msgs in
+#eval do
+  for i in 1...3 do IO.println (i * 2 + (-10 : Int))
+
+/-! Without information about the element type, literal bounds still default to `Nat`. -/
+
+/--
+info: 0
+0
+-/
+#guard_msgs in
+#eval do
+  for i in 1...3 do IO.println (i - 5)
+
+/-! The default instance does not apply when the range would have no `ForIn` instance at the
+loop's element type: `1...*` over `Int` is infinite, so the literals default to `Nat` as before. -/
+
+/--
+error: failed to synthesize instance of type class
+  ForIn IO (Rci Nat) Int
+
+Hint: Type class instance resolution failures can be inspected with the `set_option trace.Meta.synthInstance true` command.
+---
+error: Aborting evaluation since the expression depends on the 'sorry' axiom, which can lead to runtime instability and crashes.
+
+To attempt to evaluate anyway despite the risks, use the '#eval!' command.
+-/
+#guard_msgs in
+#eval do
+  for (i : Int) in 1...* do IO.println i

--- a/tests/elab/ranges_infer.lean
+++ b/tests/elab/ranges_infer.lean
@@ -1,0 +1,87 @@
+module
+
+/-!
+Tests that a `for` loop over the full range `*...*` determines the range's element type from the
+loop variable, e.g. from an ascription on it or from how it is used in the body. The element type
+is an `outParam` of `ForIn`, so this relies on the default instances on `instForInOfForIn'` and on
+the `ForIn'` instance of `Std.Rii`.
+-/
+
+open Std
+
+set_option pp.mvars.anonymous false
+
+/-- info: [0, 1, 2] -/
+#guard_msgs in
+#eval do
+  let x : List (Fin 3) := *...*.toList
+  IO.println x
+
+/--
+info: 0
+1
+2
+-/
+#guard_msgs in
+#eval do
+  for (i : Fin 3) in *...* do IO.println i
+
+/-- info: #[0, 1, 2] -/
+#guard_msgs in
+#eval do
+  let mut acc : Array (Fin 3) := #[]
+  for i in *...* do acc := acc.push i
+  IO.println acc
+
+/--
+info: 0
+1
+2
+-/
+#guard_msgs in
+#eval do
+  for _h : (i : Fin 3) in *...* do IO.println i
+
+/-- info: 256 -/
+#guard_msgs in
+#eval Id.run do
+  let mut n := 0
+  for (_ : UInt8) in *...* do n := n + 1
+  return n
+
+/-- info: 3 -/
+#guard_msgs in
+#eval Id.run do
+  let mut n := 0
+  for _h : (_ : Fin 3) in *...* do n := n + 1
+  return n
+
+/-! Without any information about the element type, the loop still fails: the default instance only
+applies once the element type is known. -/
+
+/--
+error: typeclass instance problem is stuck
+  ForIn IO (Rii ?_) ?α
+
+Note: Lean will not try to resolve this typeclass instance problem because the second type argument to `ForIn` contains metavariables. This argument must be fully determined before Lean will try to resolve the typeclass.
+
+Hint: Adding type annotations and supplying implicit arguments to functions can give Lean more information for typeclass resolution. For example, if you have a variable `x` that you intend to be a `Nat`, but Lean reports it as having an unresolved type like `?m`, replacing `x` with `(x : Nat)` can get typeclass resolution un-stuck.
+-/
+#guard_msgs in
+def noElementType : IO Unit := do
+  for _ in *...* do pure ()
+
+/-! The full range over `Nat` is infinite and has no `ForIn` instance, so the default instance does
+not apply and the problem stays stuck. -/
+
+/--
+error: typeclass instance problem is stuck
+  ForIn IO (Rii ?_) Nat
+
+Note: Lean will not try to resolve this typeclass instance problem because the second type argument to `ForIn` contains metavariables. This argument must be fully determined before Lean will try to resolve the typeclass.
+
+Hint: Adding type annotations and supplying implicit arguments to functions can give Lean more information for typeclass resolution. For example, if you have a variable `x` that you intend to be a `Nat`, but Lean reports it as having an unresolved type like `?m`, replacing `x` with `(x : Nat)` can get typeclass resolution un-stuck.
+-/
+#guard_msgs in
+def infiniteRange : IO Unit := do
+  for (i : Nat) in *...* do IO.println i


### PR DESCRIPTION
This PR annotates some `ForIn` and `ForIn'` instances with `default_instance`.

The effect of this is that `for (a : Int) in 1...3` and `for (a : Fin 6) in *...*` now work.