### PR TITLE
chore: sync adaptation PR titles

### DIFF
--- a/.github/workflows/adaptation-pr.yml
+++ b/.github/workflows/adaptation-pr.yml
@@ -10,6 +10,7 @@ on:
       - converted_to_draft
       - ready_for_review
       - synchronize
+      - edited
 
 jobs:
   create-adaptation-pr:


### PR DESCRIPTION
The actual logic for this was implemented in downstream, but without this event, it won't trigger reliably whenever a PR title is edited.