### PR TITLE
feat: add `ext` theorems for `ULift`, `PULift`, `PLift`, and `MProd`

### DIFF
--- a/src/Init/Ext.lean
+++ b/src/Init/Ext.lean
@@ -79,7 +79,7 @@ macro "ext1" xs:(colGt ppSpace rintroPat)* : tactic =>
 end Elab.Tactic.Ext
 end Lean
 
-attribute [ext] Prod PProd Sigma PSigma
+attribute [ext] Prod PProd MProd Sigma PSigma PLift ULift PULift
 attribute [ext] funext propext Subtype.ext Array.ext Char.ext
 
 attribute [grind ext] funext Array.ext

--- a/tests/elab/ext.lean
+++ b/tests/elab/ext.lean
@@ -88,6 +88,26 @@ example (xs : Array α) : xs.map id = xs := by
   . simp
   . simp
 
+example (a b : ULift α) (h : a.down = b.down) : a = b := by
+  ext
+  guard_target = a.down = b.down
+  exact h
+
+example (a b : PULift α) (h : a.down = b.down) : a = b := by
+  ext
+  guard_target = a.down = b.down
+  exact h
+
+example (a b : PLift α) (h : a.down = b.down) : a = b := by
+  ext
+  guard_target = a.down = b.down
+  exact h
+
+example (a b : MProd Nat Bool) (h1 : a.fst = b.fst) (h2 : a.snd = b.snd) : a = b := by
+  ext
+  · guard_target = a.fst = b.fst; exact h1
+  · guard_target = a.snd = b.snd; exact h2
+
 @[ext (iff := false)] theorem ext_intros {n m : Nat} (w : ∀ n m : Nat, n = m) : n = m := by apply w
 
 #guard_msgs (drop warning) in

--- a/tests/elab/ext1.lean
+++ b/tests/elab/ext1.lean
@@ -72,6 +72,23 @@ example (f : ℕ × (ℕ → ℕ)) : f = f := by
 example (f : Empty → Empty) : f = f := by
   ext ⟨⟩
 
+example (a b : ULift α) : a = b := by
+  ext
+  guard_target = a.down = b.down; exact mySorry
+
+example (a b : PULift α) : a = b := by
+  ext
+  guard_target = a.down = b.down; exact mySorry
+
+example (a b : PLift α) : a = b := by
+  ext
+  guard_target = a.down = b.down; exact mySorry
+
+example (a b : MProd Nat Bool) : a = b := by
+  ext
+  guard_target = a.fst = b.fst; exact mySorry
+  guard_target = a.snd = b.snd; exact mySorry
+
 @[ext (iff := false)] theorem ext_intros {n m : Nat} (w : ∀ n m : Nat, n = m) : n = m := by apply w
 
 example : 3 = 7 := by

--- a/tests/elab/ext1.lean.out.expected
+++ b/tests/elab/ext1.lean.out.expected
@@ -1,2 +1,2 @@
-ext1.lean:77:0-77:7: warning: declaration uses `sorry`
-ext1.lean:83:0-83:7: warning: declaration uses `sorry`
+ext1.lean:94:0-94:7: warning: declaration uses `sorry`
+ext1.lean:100:0-100:7: warning: declaration uses `sorry`


### PR DESCRIPTION
This PR registers `ext` and `ext_iff` theorems for `ULift`, `PULift`, `PLift`, and `MProd`, so the `ext` tactic applies to equalities of these structures.