### PR TITLE
fix: keep `Info` of elaborations that pass a hole through

### DIFF
--- a/src/Lean/Elab/Term/TermElabM.lean
+++ b/src/Lean/Elab/Term/TermElabM.lean
@@ -1543,7 +1543,7 @@ def mkTermInfo (elaborator : Name) (stx : Syntax) (e : Expr) (expectedType? : Op
     hole, and that the `Info` for the hole is supplied later via `assignInfoHoleId`.
 
     If a nested elaboration already emitted the hole for `mvarId`, then the current elaboration
-    merely passes the hole through and returning another hole would discard all `Info` it produced,
+    merely passes the hole through as returning another hole would discard all `Info` it produced,
     e.g. the `Info` for `type` in `(e : type)` when `e` is a tactic block. In this case, we emit an
     ordinary term node that contains the nested hole.
 

--- a/src/Lean/Elab/Term/TermElabM.lean
+++ b/src/Lean/Elab/Term/TermElabM.lean
@@ -1509,7 +1509,8 @@ partial def removeSaveInfoAnnotation (e : Expr) : Expr :=
 /--
   Return `some mvarId` if `e` corresponds to a hole that is going to be filled "later" by executing a tactic or resuming elaboration.
 
-  We do not save `ofTermInfo` for this kind of node in the `InfoTree`.
+  We do not save `ofTermInfo` for this kind of node in the `InfoTree`, unless the would-be children
+  of the node already contain the `InfoTree.hole` for it.
 -/
 def isTacticOrPostponedHole? (e : Expr) : TermElabM (Option MVarId) := do
   match e with
@@ -1520,14 +1521,41 @@ def isTacticOrPostponedHole? (e : Expr) : TermElabM (Option MVarId) := do
     | _                                  => return none
   | _ => pure none
 
+/--
+Returns `true` if the `InfoTree`s produced by the elaboration that is currently being wrapped in an
+`Info` node already contain an `InfoTree.hole` for `mvarId`, i.e. if the hole was emitted by a
+nested elaboration rather than by the current one.
+-/
+private partial def hasInfoHoleFor (mvarId : MVarId) : TermElabM Bool := do
+  return (← getInfoState).trees.any go
+where
+  go : InfoTree → Bool
+    | .hole mvarId' => mvarId' == mvarId
+    | .context _ t  => go t
+    | .node _ c     => c.any go
+
 def mkTermInfo (elaborator : Name) (stx : Syntax) (e : Expr) (expectedType? : Option Expr := none)
     (lctx? : Option LocalContext := none) (isBinder := false) (isDisplayableTerm := false) :
     TermElabM (Sum Info MVarId) := do
-  match (← isTacticOrPostponedHole? e) with
-  | some mvarId => return Sum.inr mvarId
-  | none =>
-    let e := removeSaveInfoAnnotation e
-    return Sum.inl <| Info.ofTermInfo { elaborator, lctx := lctx?.getD (← getLCtx), expr := e, stx, expectedType?, isBinder, isDisplayableTerm }
+  if let some mvarId ← isTacticOrPostponedHole? e then
+    /-
+    Recall that `withInfoContext'` discards the `InfoTree`s of the elaboration when we return a
+    hole, and that the `Info` for the hole is supplied later via `assignInfoHoleId`.
+
+    If a nested elaboration already emitted the hole for `mvarId`, then the current elaboration
+    merely passes the hole through and returning another hole would discard all `Info` it produced,
+    e.g. the `Info` for `type` in `(e : type)` when `e` is a tactic block. In this case, we emit an
+    ordinary term node that contains the nested hole.
+
+    Otherwise, the current elaboration created the hole (e.g. by postponing) and we must return it
+    so that the `Info` supplied later has somewhere to go. Note that the elaboration may already
+    have produced `InfoTree`s before creating the hole, but those are reproduced when its
+    elaboration is resumed.
+    -/
+    unless (← hasInfoHoleFor mvarId) do
+      return Sum.inr mvarId
+  let e := removeSaveInfoAnnotation e
+  return Sum.inl <| Info.ofTermInfo { elaborator, lctx := lctx?.getD (← getLCtx), expr := e, stx, expectedType?, isBinder, isDisplayableTerm }
 
 def mkPartialTermInfo (elaborator : Name) (stx : Syntax) (expectedType? : Option Expr := none)
     (lctx? : Option LocalContext := none) :

--- a/tests/server_interactive/hoverTacticHoleSibling.lean
+++ b/tests/server_interactive/hoverTacticHoleSibling.lean
@@ -1,0 +1,15 @@
+/-!
+Info nodes for syntax that is elaborated beside a tactic hole must not be discarded.
+
+`elabTypeAscription` elaborates `Nat` and then returns the metavariable of the `by` block, so the
+term info for `Nat` used to be dropped together with the trees of the surrounding node.
+-/
+
+example : Nat := (by exact 0 : Nat)
+                              --^ textDocument/hover
+
+example : Nat := ((by exact 0 : Nat))
+                               --^ textDocument/hover
+
+example : Nat := (0 : Nat)
+                     --^ textDocument/hover

--- a/tests/server_interactive/hoverTacticHoleSibling.lean.out.expected
+++ b/tests/server_interactive/hoverTacticHoleSibling.lean.out.expected
@@ -1,0 +1,24 @@
+{"textDocument": {"uri": "file:///hoverTacticHoleSibling.lean"},
+ "position": {"line": 7, "character": 32}}
+{"range":
+ {"start": {"line": 7, "character": 31}, "end": {"line": 7, "character": 34}},
+ "contents":
+ {"value":
+  "```lean\nNat : Type\n```\n***\nThe natural numbers, starting at zero.\n\nThis type is special-cased by both the kernel and the compiler, and overridden with an efficient\nimplementation. Both use a fast arbitrary-precision arithmetic library (usually\n[GMP](https://gmplib.org/)); at runtime, `Nat` values that are sufficiently small are unboxed.\n\n***\n*import Init.Prelude*",
+  "kind": "markdown"}}
+{"textDocument": {"uri": "file:///hoverTacticHoleSibling.lean"},
+ "position": {"line": 10, "character": 33}}
+{"range":
+ {"start": {"line": 10, "character": 32}, "end": {"line": 10, "character": 35}},
+ "contents":
+ {"value":
+  "```lean\nNat : Type\n```\n***\nThe natural numbers, starting at zero.\n\nThis type is special-cased by both the kernel and the compiler, and overridden with an efficient\nimplementation. Both use a fast arbitrary-precision arithmetic library (usually\n[GMP](https://gmplib.org/)); at runtime, `Nat` values that are sufficiently small are unboxed.\n\n***\n*import Init.Prelude*",
+  "kind": "markdown"}}
+{"textDocument": {"uri": "file:///hoverTacticHoleSibling.lean"},
+ "position": {"line": 13, "character": 23}}
+{"range":
+ {"start": {"line": 13, "character": 22}, "end": {"line": 13, "character": 25}},
+ "contents":
+ {"value":
+  "```lean\nNat : Type\n```\n***\nThe natural numbers, starting at zero.\n\nThis type is special-cased by both the kernel and the compiler, and overridden with an efficient\nimplementation. Both use a fast arbitrary-precision arithmetic library (usually\n[GMP](https://gmplib.org/)); at runtime, `Nat` values that are sufficiently small are unboxed.\n\n***\n*import Init.Prelude*",
+  "kind": "markdown"}}


### PR DESCRIPTION
This PR makes the elaborator keep the `Info` of a term that merely passes a tactic block or a postponed elaboration through, such as the type in `(e : type)` when `e` is a tactic block.

`mkTermInfo` returned an `InfoTree.hole` whenever the elaborated term was a tactic or postponed hole, and `withInfoContext'` discards the `InfoTree`s of an elaboration that returns a hole. It now returns a hole only when the current elaboration created it, and an ordinary term node when a nested elaboration already emitted the hole for that metavariable.