### PR TITLE
feat: `ChoiceResolutionInfo`

### DIFF
--- a/src/Lean/Elab/App.lean
+++ b/src/Lean/Elab/App.lean
@@ -2057,12 +2057,39 @@ where
           throw ex
       | ex@(.internal _ _) => throw ex
 
+/--
+Adds a `ChoiceResolutionInfo` node for the alternative `chosenAltIdx` of the `choice` node
+`choiceStx` to the saved `InfoState` of a successful elaboration candidate.
+Since `observing` captures the `InfoState` of each candidate and `applyResult` restores it for
+the candidate that is eventually picked, the `ChoiceResolutionInfo` node ends up in the
+`InfoTree` if and only if the candidate is picked. `elabAppAux` drops it again from the
+candidates it retains for an ambiguity error, where no candidate is picked.
+-/
+private def addChoiceResolutionInfo (choiceStx : Syntax) (chosenAltIdx : Nat) :
+    TermElabResult Expr → TermElabResult Expr
+  | .ok e s =>
+    if s.meta.core.infoState.enabled then
+      let tree := InfoTree.node (.ofChoiceResolutionInfo { stx := choiceStx, chosenAltIdx }) {}
+      .ok e { s with meta.core.infoState.trees := s.meta.core.infoState.trees.push tree }
+    else
+      .ok e s
+  | r => r
+
 private partial def elabAppFn (f : Syntax) (lvals : List LVal) (namedArgs : Array NamedArg) (args : Array Arg)
     (expectedType? : Option Expr) (explicit ellipsis overloaded : Bool) (acc : Array (TermElabResult Expr)) : TermElabM (Array (TermElabResult Expr)) := do
   if f.getKind == choiceKind then
     -- Set `errToSorry` to `false` when processing choice nodes. See comment above about the interaction between `errToSorry` and `observing`.
     withReader (fun ctx => { ctx with errToSorry := false }) do
-      f.getArgs.foldlM (init := acc) fun acc f => elabAppFn f lvals namedArgs args expectedType? explicit ellipsis true acc
+      let mut acc := acc
+      for alt in f.getArgs, chosenAltIdx in 0...* do
+        let startIdx := acc.size
+        acc ← elabAppFn alt lvals namedArgs args expectedType? explicit ellipsis true acc
+        -- Record which alternative of the choice node each candidate stems from so that the
+        -- `InfoTree` contains the resolution of the choice node for the candidate that is
+        -- eventually committed in `applyResult`.
+        for candidateIdx in startIdx...acc.size do
+          acc := acc.modify candidateIdx (addChoiceResolutionInfo f chosenAltIdx)
+      return acc
   else
     let elabFieldName (e field : Syntax) (explicitUnivs : List Level) := do
       let comps := field.identComponents
@@ -2220,12 +2247,17 @@ private def elabAppAux (f : Syntax) (namedArgs : Array NamedArg) (args : Array A
           let (tree?, msg) ← withoutModifyingState do
             s.restore
             let msg ← addMessageContext m!"{e} : {← inferType e}"
+            -- Drop the `ChoiceResolutionInfo` of the candidate: no candidate is committed when the
+            -- overload is ambiguous, so recording one as picked would be wrong.
+            let trees := s.meta.core.infoState.trees.filter fun
+              | .node (.ofChoiceResolutionInfo _) _ => false
+              | _ => true
             let tree? : Option InfoTree ←
-              if let some tree := s.meta.core.infoState.trees[0]? then
+              if !trees.isEmpty then
                 let ctx ← CommandContextInfo.save
                 pure <| some <| .context (.commandCtx ctx) <|
                   .node (.ofPartialTermInfo { elaborator := .anonymous, stx := (← getRef), lctx := (← getLCtx), expectedType? })
-                    s.meta.core.infoState.trees
+                    trees
               else
                 pure none
             return (tree?, msg)

--- a/src/Lean/Elab/BuiltinCommand.lean
+++ b/src/Lean/Elab/BuiltinCommand.lean
@@ -269,16 +269,18 @@ private def throwUnnecessaryScopeName (header : Name) : CommandElabM Unit := do
   modify fun s => {s with scopes := s.scopes.drop endSize }
   popScopes endSize
 
-private partial def elabChoiceAux (cmds : Array Syntax) (i : Nat) : CommandElabM Unit :=
-  if h : i < cmds.size then
+private partial def elabChoiceAux (choiceStx : Syntax) (i : Nat) : CommandElabM Unit :=
+  if i < choiceStx.getNumArgs then
     catchInternalId unsupportedSyntaxExceptionId
-      (elabCommand cmds[i])
-      (fun _ => elabChoiceAux cmds (i+1))
+      (do
+        elabCommand (choiceStx.getArg i)
+        pushInfoLeaf <| .ofChoiceResolutionInfo { stx := choiceStx, chosenAltIdx := i })
+      (fun _ => elabChoiceAux choiceStx (i+1))
   else
     throwUnsupportedSyntax
 
 @[builtin_command_elab choice] def elabChoice : CommandElab := fun stx =>
-  elabChoiceAux stx.getArgs 0
+  elabChoiceAux stx 0
 
 @[builtin_command_elab «universe»] def elabUniverse : CommandElab := fun n => do
   n[1].forArgsM addUnivLevel

--- a/src/Lean/Elab/InfoTree/Basic.lean
+++ b/src/Lean/Elab/InfoTree/Basic.lean
@@ -102,23 +102,24 @@ def pushInfoChild : InfoTree → InfoTree → InfoTree
   | t, _ => t
 
 def Info.toElabInfo? : Info → Option ElabInfo
-  | ofTacticInfo i         => some i.toElabInfo
-  | ofTermInfo i           => some i.toElabInfo
-  | ofPartialTermInfo i    => some i.toElabInfo
-  | ofCommandInfo i        => some i.toElabInfo
-  | ofMacroExpansionInfo _ => none
-  | ofOptionInfo _         => none
-  | ofErrorNameInfo _      => none
-  | ofFieldInfo _          => none
-  | ofCompletionInfo _     => none
-  | ofUserWidgetInfo _     => none
-  | ofCustomInfo _         => none
-  | ofFVarAliasInfo _      => none
-  | ofFieldRedeclInfo _    => none
-  | ofDelabTermInfo i      => some i.toElabInfo
-  | ofChoiceInfo i         => some i.toElabInfo
-  | ofDocInfo i            => some i.toElabInfo
-  | ofDocElabInfo i        => some i.toElabInfo
+  | ofTacticInfo i           => some i.toElabInfo
+  | ofTermInfo i             => some i.toElabInfo
+  | ofPartialTermInfo i      => some i.toElabInfo
+  | ofCommandInfo i          => some i.toElabInfo
+  | ofMacroExpansionInfo _   => none
+  | ofOptionInfo _           => none
+  | ofErrorNameInfo _        => none
+  | ofFieldInfo _            => none
+  | ofCompletionInfo _       => none
+  | ofUserWidgetInfo _       => none
+  | ofCustomInfo _           => none
+  | ofFVarAliasInfo _        => none
+  | ofFieldRedeclInfo _      => none
+  | ofDelabTermInfo i        => some i.toElabInfo
+  | ofChoiceInfo i           => some i.toElabInfo
+  | ofChoiceResolutionInfo _ => none
+  | ofDocInfo i              => some i.toElabInfo
+  | ofDocElabInfo i          => some i.toElabInfo
 
 /--
   Helper function for propagating the tactic metavariable context to its children nodes.
@@ -139,23 +140,24 @@ def Info.updateContext? : Option ContextInfo → Info → Option ContextInfo
   | ctx?, _ => ctx?
 
 def Info.stx : Info → Syntax
-  | ofTacticInfo i         => i.stx
-  | ofTermInfo i           => i.stx
-  | ofPartialTermInfo i    => i.stx
-  | ofCommandInfo i        => i.stx
-  | ofMacroExpansionInfo i => i.stx
-  | ofOptionInfo i         => i.stx
-  | ofErrorNameInfo i      => i.stx
-  | ofFieldInfo i          => i.stx
-  | ofCompletionInfo i     => i.stx
-  | ofCustomInfo i         => i.stx
-  | ofUserWidgetInfo i     => i.stx
-  | ofFVarAliasInfo _      => .missing
-  | ofFieldRedeclInfo i    => i.stx
-  | ofDelabTermInfo i      => i.stx
-  | ofChoiceInfo i         => i.stx
-  | ofDocInfo i            => i.stx
-  | ofDocElabInfo i        => i.stx
+  | ofTacticInfo i           => i.stx
+  | ofTermInfo i             => i.stx
+  | ofPartialTermInfo i      => i.stx
+  | ofCommandInfo i          => i.stx
+  | ofMacroExpansionInfo i   => i.stx
+  | ofOptionInfo i           => i.stx
+  | ofErrorNameInfo i        => i.stx
+  | ofFieldInfo i            => i.stx
+  | ofCompletionInfo i       => i.stx
+  | ofCustomInfo i           => i.stx
+  | ofUserWidgetInfo i       => i.stx
+  | ofFVarAliasInfo _        => .missing
+  | ofFieldRedeclInfo i      => i.stx
+  | ofDelabTermInfo i        => i.stx
+  | ofChoiceInfo i           => i.stx
+  | ofChoiceResolutionInfo i => i.stx
+  | ofDocInfo i              => i.stx
+  | ofDocElabInfo i          => i.stx
 
 private def CompletionInfo.setStx (stx : Syntax) : CompletionInfo → CompletionInfo
   | dot i e?              => .dot { i with stx } e?
@@ -169,23 +171,24 @@ private def CompletionInfo.setStx (stx : Syntax) : CompletionInfo → Completion
   | tactic _              => .tactic stx
 
 private def Info.setStx (stx : Syntax) : Info → Info
-  | ofTacticInfo i         => ofTacticInfo { i with stx }
-  | ofTermInfo i           => ofTermInfo { i with stx }
-  | ofPartialTermInfo i    => ofPartialTermInfo { i with stx }
-  | ofCommandInfo i        => ofCommandInfo { i with stx }
-  | ofMacroExpansionInfo i => ofMacroExpansionInfo { i with stx }
-  | ofOptionInfo i         => ofOptionInfo { i with stx }
-  | ofErrorNameInfo i      => ofErrorNameInfo { i with stx }
-  | ofFieldInfo i          => ofFieldInfo { i with stx }
-  | ofCompletionInfo i     => ofCompletionInfo (i.setStx stx)
-  | ofCustomInfo i         => ofCustomInfo { i with stx }
-  | ofUserWidgetInfo i     => ofUserWidgetInfo { i with stx }
-  | ofFVarAliasInfo i      => ofFVarAliasInfo i
-  | ofFieldRedeclInfo i    => ofFieldRedeclInfo { i with stx }
-  | ofDelabTermInfo i      => ofDelabTermInfo { i with stx }
-  | ofChoiceInfo i         => ofChoiceInfo { i with stx }
-  | ofDocInfo i            => ofDocInfo { i with stx }
-  | ofDocElabInfo i        => ofDocElabInfo { i with stx }
+  | ofTacticInfo i           => ofTacticInfo { i with stx }
+  | ofTermInfo i             => ofTermInfo { i with stx }
+  | ofPartialTermInfo i      => ofPartialTermInfo { i with stx }
+  | ofCommandInfo i          => ofCommandInfo { i with stx }
+  | ofMacroExpansionInfo i   => ofMacroExpansionInfo { i with stx }
+  | ofOptionInfo i           => ofOptionInfo { i with stx }
+  | ofErrorNameInfo i        => ofErrorNameInfo { i with stx }
+  | ofFieldInfo i            => ofFieldInfo { i with stx }
+  | ofCompletionInfo i       => ofCompletionInfo (i.setStx stx)
+  | ofCustomInfo i           => ofCustomInfo { i with stx }
+  | ofUserWidgetInfo i       => ofUserWidgetInfo { i with stx }
+  | ofFVarAliasInfo i        => ofFVarAliasInfo i
+  | ofFieldRedeclInfo i      => ofFieldRedeclInfo { i with stx }
+  | ofDelabTermInfo i        => ofDelabTermInfo { i with stx }
+  | ofChoiceInfo i           => ofChoiceInfo { i with stx }
+  | ofChoiceResolutionInfo i => ofChoiceResolutionInfo { i with stx }
+  | ofDocInfo i              => ofDocInfo { i with stx }
+  | ofDocElabInfo i          => ofDocElabInfo { i with stx }
 
 /--
 Adds the given trailing substring to all adjacent syntax in the info tree if any, otherwise returns

--- a/src/Lean/Elab/InfoTree/Main.lean
+++ b/src/Lean/Elab/InfoTree/Main.lean
@@ -162,6 +162,9 @@ def DelabTermInfo.format (ctx : ContextInfo) (info : DelabTermInfo) : IO Format 
 def ChoiceInfo.format (ctx : ContextInfo) (info : ChoiceInfo) : Format :=
   f!"[Choice] @ {formatElabInfo ctx info.toElabInfo}"
 
+def ChoiceResolutionInfo.format (ctx : ContextInfo) (info : ChoiceResolutionInfo) : Format :=
+  f!"[ChoiceResolution] alternative {info.chosenAltIdx} of {info.stx.getNumArgs} ({(info.stx.getArg info.chosenAltIdx).getKind}) @ {formatStxRange ctx info.stx}"
+
 def DocInfo.format (ctx : ContextInfo) (info : DocInfo) : Format :=
   f!"[Doc] {info.stx.getKind} @ {formatElabInfo ctx info.toElabInfo}"
 
@@ -169,23 +172,24 @@ def DocElabInfo.format (ctx : ContextInfo) (info : DocElabInfo) : Format :=
   f!"[DocElab] {info.name} ({repr info.kind}) @ {formatElabInfo ctx info.toElabInfo}"
 
 def Info.format (ctx : ContextInfo) : Info → IO Format
-  | ofTacticInfo i         => i.format ctx
-  | ofTermInfo i           => i.format ctx
-  | ofPartialTermInfo i    => pure <| i.format ctx
-  | ofCommandInfo i        => i.format ctx
-  | ofMacroExpansionInfo i => i.format ctx
-  | ofOptionInfo i         => i.format ctx
-  | ofErrorNameInfo i      => i.format ctx
-  | ofFieldInfo i          => i.format ctx
-  | ofCompletionInfo i     => i.format ctx
-  | ofUserWidgetInfo i     => pure <| i.format
-  | ofCustomInfo i         => pure <| Std.ToFormat.format i
-  | ofFVarAliasInfo i      => pure <| i.format
-  | ofFieldRedeclInfo i    => pure <| i.format ctx
-  | ofDelabTermInfo i      => i.format ctx
-  | ofChoiceInfo i         => pure <| i.format ctx
-  | ofDocInfo i            => pure <| i.format ctx
-  | ofDocElabInfo i        => pure <| i.format ctx
+  | ofTacticInfo i           => i.format ctx
+  | ofTermInfo i             => i.format ctx
+  | ofPartialTermInfo i      => pure <| i.format ctx
+  | ofCommandInfo i          => i.format ctx
+  | ofMacroExpansionInfo i   => i.format ctx
+  | ofOptionInfo i           => i.format ctx
+  | ofErrorNameInfo i        => i.format ctx
+  | ofFieldInfo i            => i.format ctx
+  | ofCompletionInfo i       => i.format ctx
+  | ofUserWidgetInfo i       => pure <| i.format
+  | ofCustomInfo i           => pure <| Std.ToFormat.format i
+  | ofFVarAliasInfo i        => pure <| i.format
+  | ofFieldRedeclInfo i      => pure <| i.format ctx
+  | ofDelabTermInfo i        => i.format ctx
+  | ofChoiceInfo i           => pure <| i.format ctx
+  | ofChoiceResolutionInfo i => pure <| i.format ctx
+  | ofDocInfo i              => pure <| i.format ctx
+  | ofDocElabInfo i          => pure <| i.format ctx
 
 def PartialContextInfo.format (ctx : PartialContextInfo) : Format :=
   match ctx with

--- a/src/Lean/Elab/InfoTree/Types.lean
+++ b/src/Lean/Elab/InfoTree/Types.lean
@@ -223,6 +223,29 @@ the language server provide interactivity even when all overloaded elaborators f
 -/
 structure ChoiceInfo extends ElabInfo where
 
+/--
+Indicates which of the alternatives of the `choice` node `stx` was picked by the elaborator.
+
+The parser produces `choice` nodes when multiple syntax alternatives match the same piece of
+syntax, and only elaboration determines which of the alternatives succeeds. This info node is
+created when an elaborator commits to one of the alternatives, so that consumers of the
+`InfoTree` can determine the picked alternative without having to re-derive it from the
+elaboration results of the alternatives.
+
+Note that elaborators may rewrite the alternatives of `choice` nodes before resolving them
+(e.g. when elaborating patterns), so `stx` is the `choice` node as seen by the elaborator that
+resolved it. Such rewrites map the alternatives one-to-one, so `chosenAltIdx` is also a valid
+index into the alternatives of the original `choice` node produced by the parser. A rewritten
+node is a different `Syntax` object with synthetic positions, so a consumer that correlates this
+info with the parsed syntax must compare source ranges with `canonicalOnly := false`.
+-/
+structure ChoiceResolutionInfo where
+  /-- The `choice` node whose resolution this info describes. -/
+  stx : Syntax
+  /-- The index of the alternative in `stx.getArgs` that was picked by the elaborator. -/
+  chosenAltIdx : Nat
+  deriving Inhabited
+
 inductive DocElabKind where
   | role | codeBlock | directive | command
 deriving Repr
@@ -266,6 +289,7 @@ inductive Info where
   | ofFieldRedeclInfo (i : FieldRedeclInfo)
   | ofDelabTermInfo (i : DelabTermInfo)
   | ofChoiceInfo (i : ChoiceInfo)
+  | ofChoiceResolutionInfo (i : ChoiceResolutionInfo)
   | ofDocInfo (i : DocInfo)
   | ofDocElabInfo (i : DocElabInfo)
   deriving Inhabited

--- a/src/Lean/Elab/PatternVar.lean
+++ b/src/Lean/Elab/PatternVar.lean
@@ -49,6 +49,11 @@ structure State where
   found     : NameSet := {}
   /-- Pattern variables found so far as an array. It contains the order they were found. -/
   vars      : Array PatternVar := #[]
+  /--
+  `choice` nodes that the collector resolved on its own. Only `collectPatternVars` pushes these
+  into the `InfoTree`; the entry points that merely extract pattern variables discard them.
+  -/
+  choiceResolutions : Array ChoiceResolutionInfo := #[]
   deriving Inhabited
 
 abbrev M := StateRefT State TermElabM
@@ -282,16 +287,15 @@ partial def collect (stx : Syntax) : M Syntax := withRef stx <| withFreshMacroSc
   else if k == ``Lean.Parser.Term.quotedName || k == ``Lean.Parser.Term.doubleQuotedName then
     return stx
   else if k == choiceKind then
-    /- Remark: If there are `Term.structInst` alternatives, we keep only them. This is a hack to get rid of
+    let args := stx.getArgs
+    /- Remark: If there is a `Term.structInst` alternative, we resolve the `choice` node to it. This is a hack to get rid of
        Set-like notation in patterns. Recall that in Mathlib `{a, b}` can be a set with two elements or the
        structure instance `{ a := a, b := b }`. Possible alternative solution: add a `pattern` category, or at least register
-       the `Syntax` node kinds that are allowed in patterns. -/
-    let args :=
-      let args := stx.getArgs
-      if args.any (·.isOfKind ``Parser.Term.structInst) then
-        args.filter (·.isOfKind ``Parser.Term.structInst)
-      else
-        args
+       the `Syntax` node kinds that are allowed in patterns.
+       Only one parser produces `Term.structInst`, so a `choice` node has at most one such alternative. -/
+    if let some idx := args.findIdx? (·.isOfKind ``Parser.Term.structInst) then
+      modify fun s => { s with choiceResolutions := s.choiceResolutions.push { stx, chosenAltIdx := idx } }
+      return ← collect args[idx]!
     let stateSaved ← get
     let arg0 ← collect args[0]!
     let stateNew ← get
@@ -302,6 +306,8 @@ partial def collect (stx : Syntax) : M Syntax := withRef stx <| withFreshMacroSc
       unless samePatternsVariables stateSaved.vars.size stateNew (← get) do
         throwError "Invalid pattern: Overloaded notation is only allowed when all alternatives have the same set of pattern variables"
     set stateNew
+    -- The alternatives are rewritten one-to-one, so `chosenAltIdx` of a `ChoiceResolutionInfo`
+    -- for this node is also a valid index into the alternatives of the original node.
     return mkNode choiceKind argsNew
   else match stx with
   | `({ $[$srcs?,* with]? $fields,* $[..%$ell?]? $[: $ty?]? }) =>
@@ -431,6 +437,8 @@ It also returns the updated views.
 -/
 def collectPatternVars (alt : MatchAltView k) : TermElabM (Array PatternVar × MatchAltView k) := do
   let (alt, s) ← (CollectPatternVars.main alt).run {}
+  for info in s.choiceResolutions do
+    pushInfoLeaf <| .ofChoiceResolutionInfo info
   return (s.vars, alt)
 
 /--

--- a/src/Lean/Elab/Tactic/BuiltinTactic.lean
+++ b/src/Lean/Elab/Tactic/BuiltinTactic.lean
@@ -269,17 +269,19 @@ def elabSetOption : Tactic := fun stx => do
 def evalTacticSeq : Tactic :=
   Term.withNarrowedArgTacticReuse (argIdx := 0) evalTactic
 
-partial def evalChoiceAux (tactics : Array Syntax) (i : Nat) : TacticM Unit :=
-  if h : i < tactics.size then
-    let tactic := tactics[i]
+partial def evalChoiceAux (choiceStx : Syntax) (i : Nat) : TacticM Unit :=
+  if i < choiceStx.getNumArgs then
+    let tactic := choiceStx.getArg i
     catchInternalId unsupportedSyntaxExceptionId
-      (evalTactic tactic)
-      (fun _ => evalChoiceAux tactics (i+1))
+      (do
+        evalTactic tactic
+        pushInfoLeaf <| .ofChoiceResolutionInfo { stx := choiceStx, chosenAltIdx := i })
+      (fun _ => evalChoiceAux choiceStx (i+1))
   else
     throwUnsupportedSyntax
 
 @[builtin_tactic choice] def evalChoice : Tactic := fun stx =>
-  evalChoiceAux stx.getArgs 0
+  evalChoiceAux stx 0
 
 @[builtin_tactic skip] def evalSkip : Tactic := fun _ => pure ()
 

--- a/tests/elab/choiceResolutionInfo.lean
+++ b/tests/elab/choiceResolutionInfo.lean
@@ -1,0 +1,84 @@
+import Lean
+
+/-!
+Tests that the elaborator emits `ChoiceResolutionInfo` nodes into the `InfoTree` that identify
+which alternative of a `choice` node (ambiguous syntax) was picked during elaboration of terms,
+tactics, and commands.
+
+Note: the later-declared syntax comes first in the `choice` node, so the `B` variants below are
+the alternatives at index 0.
+-/
+
+structure Foo where
+  abc : Nat
+  foo : Nat
+
+-- Term-level choice node between overloaded syntax: the alternative that fails to elaborate
+-- (`termB`) is discarded and the succeeding one is recorded as picked.
+syntax (name := termA) "myterm" : term
+syntax (name := termB) "myterm" : term
+
+open Lean Elab Term in
+@[term_elab termA] def elabTermA : TermElab := fun _ _ => return Lean.mkNatLit 0
+
+open Lean Elab Term in
+@[term_elab termB] def elabTermB : TermElab := fun _ _ => throwError "termB failed"
+
+-- Ambiguous term-level choice node: both alternatives elaborate, so no candidate is committed.
+syntax (name := ambA) "myamb" : term
+syntax (name := ambB) "myamb" : term
+
+open Lean Elab Term in
+@[term_elab ambA] def elabAmbA : TermElab := fun _ _ => return Lean.mkNatLit 1
+
+open Lean Elab Term in
+@[term_elab ambB] def elabAmbB : TermElab := fun _ _ => return Lean.mkNatLit 2
+
+-- Tactic-level and command-level choice nodes: the elaborator commits to the first alternative
+-- accepted by `evalTactic`/`elabCommand`, which is recorded as picked.
+macro (name := tacA) "mytac" : tactic => `(tactic| exact 41)
+macro (name := tacB) "mytac" : tactic => `(tactic| exact 42)
+
+macro (name := cmdA) "mycmd" : command => `(#eval "cmdA")
+macro (name := cmdB) "mycmd" : command => `(#eval "cmdB")
+
+-- Overloaded infix notation for the pattern-level choice node tests below.
+inductive MySeq where
+  | nil
+  | cons (x : Nat) (s : MySeq)
+
+infixr:67 " ::: " => MySeq.cons
+infixr:67 " ::: " => List.cons
+
+set_option trace.Elab.info true
+
+-- Term-level choice node resolved by type: `{ abc, foo }` is ambiguous between the set-like
+-- `«term{_}»` notation and `Term.structInst`; elaboration picks the structure instance.
+def x (abc foo : Nat) : Foo := { abc, foo }
+
+#check (myterm : Nat)
+
+-- No candidate is picked here, so the `[Choice]` node below must contain no `[ChoiceResolution]`.
+#guard_msgs (drop error) in
+#check (myamb : Nat)
+
+example : Nat := by mytac
+
+mycmd
+
+-- Pattern-level choice node: the pattern elaborator rewrites the alternatives of the `choice`
+-- node for the overloaded `:::` notation into explicit constructor applications before the
+-- elaborator resolves it. The recorded alternative index remains valid for the original
+-- `choice` node.
+def head? (xs : List Nat) : Option Nat :=
+  match xs with
+  | x ::: _ => some x
+  | _ => none
+
+-- Pattern-level choice node with a `Term.structInst` alternative: the pattern elaborator
+-- resolves the `choice` node itself, because set-like notation is not a pattern. It records the
+-- resolution on the `choice` node as the parser produced it, so the reported alternative kind and
+-- count are the ones from the source.
+def y' (v : Foo) : Nat :=
+  match v with
+  | { abc, foo } => abc + foo

--- a/tests/elab/choiceResolutionInfo.lean.out.expected
+++ b/tests/elab/choiceResolutionInfo.lean.out.expected
@@ -1,0 +1,243 @@
+[Elab.info] 
+  • [Command] @ ⟨53, 0⟩-⟨53, 31⟩ @ Lean.Elab.Command.elabSetOption
+    • [Completion] (Command.set_option "set_option" `trace.Elab.info []) @ ⟨53, 0⟩-⟨53, 26⟩
+    • [Option] trace.Elab.info @ ⟨53, 11⟩-⟨53, 26⟩
+    • [CustomInfo(Lean.Elab.LinterInfoGroup)]
+[Elab.info] 
+  • [Command] @ ⟨57, 0⟩-⟨57, 43⟩ @ Lean.Elab.Command.elabDeclaration
+    • [Term] Nat : Type @ ⟨57, 17⟩-⟨57, 20⟩ @ Lean.Elab.Term.elabIdent
+      • [Completion-Id] Nat : some Sort.{?_uniq} @ ⟨57, 17⟩-⟨57, 20⟩
+      • [Term] Nat : Type @ ⟨57, 17⟩-⟨57, 20⟩
+    • [Term] abc (isBinder := true) : Nat @ ⟨57, 7⟩-⟨57, 10⟩
+    • [Term] Nat : Type @ ⟨57, 17⟩-⟨57, 20⟩ @ Lean.Elab.Term.elabIdent
+      • [Completion-Id] Nat : some Sort.{?_uniq} @ ⟨57, 17⟩-⟨57, 20⟩
+      • [Term] Nat : Type @ ⟨57, 17⟩-⟨57, 20⟩
+    • [Term] foo (isBinder := true) : Nat @ ⟨57, 11⟩-⟨57, 14⟩
+    • [Term] Foo : Type @ ⟨57, 24⟩-⟨57, 27⟩ @ Lean.Elab.Term.elabIdent
+      • [Completion-Id] Foo : some Sort.{?_uniq} @ ⟨57, 24⟩-⟨57, 27⟩
+      • [Term] Foo : Type @ ⟨57, 24⟩-⟨57, 27⟩
+    • [Term] abc (isBinder := true) : Nat @ ⟨57, 7⟩-⟨57, 10⟩
+    • [Term] foo (isBinder := true) : Nat @ ⟨57, 11⟩-⟨57, 14⟩
+    • [CustomInfo(Lean.Elab.Term.BodyInfo)]
+      • [Term] { abc := abc, foo := foo } : Foo @ ⟨57, 31⟩-⟨57, 43⟩ @ Lean.Elab.Term.elabChoice
+        • [Term] { abc := abc, foo := foo } : Foo @ ⟨57, 31⟩-⟨57, 43⟩ @ Lean.Elab.Term.StructInst.expandStructInstFields
+          • [MacroExpansion]
+            { abc, foo }
+            ===>
+            { abc := abc, foo := foo }
+            • [Term] { abc := abc, foo := foo } : Foo @ ⟨57, 31⟩-⟨57, 43⟩ @ Lean.Elab.Term.StructInst.elabStructInst
+              • [Completion] `abc @ ⟨57, 33⟩-⟨57, 36⟩
+              • [Completion] `foo @ ⟨57, 38⟩-⟨57, 41⟩
+              • [Term] abc : Nat @ ⟨57, 33⟩-⟨57, 36⟩ @ Lean.Elab.Term.elabIdent
+                • [Completion-Id] abc : some Nat @ ⟨57, 33⟩-⟨57, 36⟩
+                • [Term] abc : Nat @ ⟨57, 33⟩-⟨57, 36⟩
+              • [Field] abc : Nat := abc @ ⟨57, 33⟩-⟨57, 36⟩
+              • [Term] foo : Nat @ ⟨57, 38⟩-⟨57, 41⟩ @ Lean.Elab.Term.elabIdent
+                • [Completion-Id] foo : some Nat @ ⟨57, 38⟩-⟨57, 41⟩
+                • [Term] foo : Nat @ ⟨57, 38⟩-⟨57, 41⟩
+              • [Field] foo : Nat := foo @ ⟨57, 38⟩-⟨57, 41⟩
+        • [ChoiceResolution] alternative 1 of 2 (Lean.Parser.Term.structInst) @ ⟨57, 31⟩-⟨57, 43⟩
+    • [Term] x (isBinder := true) : Nat → Nat → Foo @ ⟨57, 4⟩-⟨57, 5⟩
+    • [Term] x (isBinder := true) : Nat → Nat → Foo @ ⟨57, 4⟩-⟨57, 5⟩
+    • [CustomInfo(Lean.Elab.LinterInfoGroup)]
+0 : Nat
+[Elab.info] 
+  • [Command] @ ⟨59, 0⟩-⟨59, 21⟩ @ Lean.Elab.Command.elabCheck
+    • [Term] 0 : Nat @ ⟨59, 7⟩-⟨59, 21⟩ @ Lean.Elab.Term.elabTypeAscription
+      • [Term] Nat : Type @ ⟨59, 17⟩-⟨59, 20⟩ @ Lean.Elab.Term.elabIdent
+        • [Completion-Id] Nat : some Sort.{?_uniq} @ ⟨59, 17⟩-⟨59, 20⟩
+        • [Term] Nat : Type @ ⟨59, 17⟩-⟨59, 20⟩
+      • [Term] 0 : Nat @ ⟨59, 8⟩-⟨59, 14⟩ @ Lean.Elab.Term.elabChoice
+        • [Term] 0 : Nat @ ⟨59, 8⟩-⟨59, 14⟩ @ elabTermA
+        • [ChoiceResolution] alternative 1 of 2 (termA) @ ⟨59, 8⟩-⟨59, 14⟩
+    • [CustomInfo(Lean.Elab.LinterInfoGroup)]
+[Elab.info] 
+  • [Command] @ ⟨62, 0⟩-⟨63, 20⟩ @ Lean.Elab.Tactic.GuardMsgs.elabGuardMsgs
+    • [Command] @ ⟨63, 0⟩-⟨63, 20⟩ @ Lean.Elab.Command.elabCheck
+      • [Term] sorry : Nat @ ⟨63, 7⟩-⟨63, 20⟩ @ Lean.Elab.Term.elabTypeAscription
+        • [Term] Nat : Type @ ⟨63, 16⟩-⟨63, 19⟩ @ Lean.Elab.Term.elabIdent
+          • [Completion-Id] Nat : some Sort.{?_uniq} @ ⟨63, 16⟩-⟨63, 19⟩
+          • [Term] Nat : Type @ ⟨63, 16⟩-⟨63, 19⟩
+        • [Term] sorry : Nat @ ⟨63, 8⟩-⟨63, 13⟩ @ Lean.Elab.Term.elabChoice
+          • [Choice] @ ⟨63, 8⟩-⟨63, 13⟩
+            • [PartialTerm] @ ⟨63, 8⟩-⟨63, 13⟩
+              • [Term] 2 : Nat @ ⟨63, 8⟩-⟨63, 13⟩ @ elabAmbB
+            • [PartialTerm] @ ⟨63, 8⟩-⟨63, 13⟩
+              • [Term] 1 : Nat @ ⟨63, 8⟩-⟨63, 13⟩ @ elabAmbA
+      • [CustomInfo(Lean.Elab.LinterInfoGroup)]
+[Elab.info] 
+  • [Command] @ ⟨65, 0⟩-⟨65, 25⟩ @ Lean.Elab.Command.elabDeclaration
+    • [Term] Nat : Type @ ⟨65, 10⟩-⟨65, 13⟩ @ Lean.Elab.Term.elabIdent
+      • [Completion-Id] Nat : some Sort.{?_uniq} @ ⟨65, 10⟩-⟨65, 13⟩
+      • [Term] Nat : Type @ ⟨65, 10⟩-⟨65, 13⟩
+    • [CustomInfo(Lean.Elab.Term.BodyInfo)]
+      • [Tactic] @ ⟨65, 17⟩-⟨65, 25⟩
+        (Term.byTactic "by" (Tactic.tacticSeq (Tactic.tacticSeq1Indented [(choice (tacB "mytac") (tacA "mytac"))])))
+        before 
+        ⊢ Nat
+        after no goals
+        • [Tactic] @ ⟨65, 17⟩-⟨65, 19⟩
+          "by"
+          before 
+          ⊢ Nat
+          after no goals
+          • [Tactic] @ ⟨65, 20⟩-⟨65, 25⟩ @ Lean.Elab.Tactic.evalTacticSeq
+            (Tactic.tacticSeq (Tactic.tacticSeq1Indented [(choice (tacB "mytac") (tacA "mytac"))]))
+            before 
+            ⊢ Nat
+            after no goals
+            • [Tactic] @ ⟨65, 20⟩-⟨65, 25⟩ @ Lean.Elab.Tactic.evalTacticSeq1Indented
+              (Tactic.tacticSeq1Indented [(choice (tacB "mytac") (tacA "mytac"))])
+              before 
+              ⊢ Nat
+              after no goals
+              • [Tactic] @ ⟨65, 20⟩-⟨65, 25⟩ @ Lean.Elab.Tactic.evalChoice
+                (choice (tacB "mytac") (tacA "mytac"))
+                before 
+                ⊢ Nat
+                after no goals
+                • [Tactic] @ ⟨65, 20⟩-⟨65, 25⟩ @ _aux_elab_choiceResolutionInfo___macroRules_tacB_1
+                  (tacB "mytac")
+                  before 
+                  ⊢ Nat
+                  after no goals
+                  • [Tactic] @ ⟨65, 20⟩†-⟨65, 25⟩† @ Lean.Elab.Tactic.evalExact
+                    (Tactic.exact "exact" (num "42"))
+                    before 
+                    ⊢ Nat
+                    after no goals
+                    • [Term] 42 : Nat @ ⟨65, 20⟩†-⟨65, 25⟩† @ Lean.Elab.Term.elabNumLit
+                • [ChoiceResolution] alternative 0 of 2 (tacB) @ ⟨65, 20⟩-⟨65, 25⟩
+    • [Term] _example (isBinder := true) : Nat @ ⟨65, 0⟩-⟨65, 7⟩
+    • [Term] _example (isBinder := true) : Nat @ ⟨65, 0⟩†!-⟨65, 7⟩†!
+    • [CustomInfo(Lean.Elab.LinterInfoGroup)]
+"cmdB"
+[Elab.info] 
+  • [Command] @ ⟨67, 0⟩-⟨67, 5⟩ @ Lean.Elab.Command.elabChoice
+    • [Command] @ ⟨67, 0⟩-⟨67, 5⟩ @ _aux_elab_choiceResolutionInfo___macroRules_cmdB_1
+      • [MacroExpansion]
+        mycmd
+          -- Pattern-level choice node: the pattern elaborator rewrites the alternatives of the `choice`
+          -- node for the overloaded `:::` notation into explicit constructor applications before the
+          -- elaborator resolves it. The recorded alternative index remains valid for the original
+          -- `choice` node.
+          
+        ===>
+        #eval "cmdB"
+        • [Command] @ ⟨67, 0⟩†-⟨67, 5⟩† @ Lean.Elab.Command.elabEval
+          • [Term] "cmdB" : String @ ⟨67, 0⟩†-⟨67, 5⟩† @ Lean.Elab.Term.elabStrLit
+          • [Term] Lean.MessageData.ofExpr
+              (Lean.toExpr "cmdB") : Lean.MessageData @ ⟨67, 0⟩†-⟨67, 5⟩† @ Lean.Elab.Term.elabSyntheticHole
+          • [Term] Lean.MessageData : Type @ ⟨67, 0⟩†-⟨67, 5⟩† @ Lean.Elab.Term.elabHole
+          • [CustomInfo(Lean.Elab.Term.BodyInfo)]
+            • [Term] Lean.MessageData.ofExpr
+                (Lean.toExpr "cmdB") : Lean.MessageData @ ⟨67, 0⟩†-⟨67, 5⟩† @ Lean.Elab.Term.elabSyntheticHole
+          • [Term] _eval (isBinder := true) : Lean.MessageData @ ⟨1, 0⟩†-⟨1, 0⟩†
+          • [Term] _eval (isBinder := true) : Lean.MessageData @ ⟨1, 0⟩†-⟨1, 0⟩†
+    • [ChoiceResolution] alternative 0 of 2 (cmdB) @ ⟨67, 0⟩-⟨67, 5⟩
+    • [CustomInfo(Lean.Elab.LinterInfoGroup)]
+[Elab.info] 
+  • [Command] @ ⟨73, 0⟩-⟨76, 13⟩ @ Lean.Elab.Command.elabDeclaration
+    • [Term] List Nat : Type @ ⟨73, 16⟩-⟨73, 24⟩ @ Lean.Elab.Term.elabApp
+      • [Completion-Id] List : some Sort.{?_uniq} @ ⟨73, 16⟩-⟨73, 20⟩
+      • [Term] List : Type → Type @ ⟨73, 16⟩-⟨73, 20⟩
+      • [Term] Nat : Type @ ⟨73, 21⟩-⟨73, 24⟩ @ Lean.Elab.Term.elabIdent
+        • [Completion-Id] Nat : some Type.{?_uniq} @ ⟨73, 21⟩-⟨73, 24⟩
+        • [Term] Nat : Type @ ⟨73, 21⟩-⟨73, 24⟩
+    • [Term] xs (isBinder := true) : List Nat @ ⟨73, 11⟩-⟨73, 13⟩
+    • [Term] Option Nat : Type @ ⟨73, 28⟩-⟨73, 38⟩ @ Lean.Elab.Term.elabApp
+      • [Completion-Id] Option : some Sort.{?_uniq} @ ⟨73, 28⟩-⟨73, 34⟩
+      • [Term] Option : Type → Type @ ⟨73, 28⟩-⟨73, 34⟩
+      • [Term] Nat : Type @ ⟨73, 35⟩-⟨73, 38⟩ @ Lean.Elab.Term.elabIdent
+        • [Completion-Id] Nat : some Type.{?_uniq} @ ⟨73, 35⟩-⟨73, 38⟩
+        • [Term] Nat : Type @ ⟨73, 35⟩-⟨73, 38⟩
+    • [Term] xs (isBinder := true) : List Nat @ ⟨73, 11⟩-⟨73, 13⟩
+    • [CustomInfo(Lean.Elab.Term.BodyInfo)]
+      • [PartialTerm] @ ⟨74, 2⟩-⟨76, 13⟩ @ Lean.Elab.Term.Quotation.elabMatchSyntax
+      • [Term] match xs with
+        | x ::: tail => some x
+        | x => none : Option Nat @ ⟨74, 2⟩-⟨76, 13⟩ @ Lean.Elab.Term.elabMatch
+        • [Term] xs : List Nat @ ⟨74, 8⟩-⟨74, 10⟩ @ Lean.Elab.Term.elabIdent
+          • [Completion-Id] xs : none @ ⟨74, 8⟩-⟨74, 10⟩
+          • [Term] xs : List Nat @ ⟨74, 8⟩-⟨74, 10⟩
+        • [Term] xs : List Nat @ ⟨74, 8⟩-⟨74, 10⟩ @ Lean.Elab.Term.elabIdent
+          • [Completion-Id] xs : none @ ⟨74, 8⟩-⟨74, 10⟩
+          • [Term] xs : List Nat @ ⟨74, 8⟩-⟨74, 10⟩
+        • [Completion-Id] List.cons✝ : none @ ⟨75, 4⟩†-⟨75, 11⟩†
+        • [Term] @List.cons : {α : Type ?u} → α → List α → List α @ ⟨75, 4⟩†-⟨75, 11⟩†
+        • [Completion-Id] x : none @ ⟨75, 4⟩-⟨75, 5⟩
+        • [Completion-Id] MySeq.cons✝ : none @ ⟨75, 4⟩†-⟨75, 11⟩†
+        • [Term] MySeq.cons : Nat → MySeq → MySeq @ ⟨75, 4⟩†-⟨75, 11⟩†
+        • [Completion-Id] x : none @ ⟨75, 4⟩-⟨75, 5⟩
+        • [Completion-Id] List.cons✝ : some List.{0} Nat @ ⟨75, 4⟩†-⟨75, 11⟩†
+        • [Completion-Id] x : some [mdata _patWithRef: ?_uniq] @ ⟨75, 4⟩-⟨75, 5⟩
+        • [ChoiceResolution] alternative 0 of 2 (Lean.Parser.Term.app) @ ⟨75, 4⟩†-⟨75, 11⟩†
+        • [Term] x ::: tail✝ : List Nat @ ⟨75, 4⟩†-⟨75, 11⟩†
+          • [Term] Nat : Type @ ⟨75, 4⟩†-⟨75, 11⟩†
+          • [Term] x (isBinder := true) : Nat @ ⟨75, 4⟩-⟨75, 5⟩
+          • [Term] tail✝ (isBinder := true) : List Nat @ ⟨75, 10⟩†-⟨75, 11⟩†
+        • [Term] some x : Option Nat @ ⟨75, 15⟩-⟨75, 21⟩ @ Lean.Elab.Term.elabApp
+          • [Completion-Id] some : some Option.{0} Nat @ ⟨75, 15⟩-⟨75, 19⟩
+          • [Term] @some : {α : Type} → α → Option α @ ⟨75, 15⟩-⟨75, 19⟩
+          • [Term] x : Nat @ ⟨75, 20⟩-⟨75, 21⟩ @ Lean.Elab.Term.elabIdent
+            • [Completion-Id] x : some ?_uniq @ ⟨75, 20⟩-⟨75, 21⟩
+            • [Term] x : Nat @ ⟨75, 20⟩-⟨75, 21⟩
+        • [Term] x✝ (isBinder := true) : List Nat @ ⟨76, 4⟩†-⟨76, 5⟩†
+        • [Term] none : Option Nat @ ⟨76, 9⟩-⟨76, 13⟩ @ Lean.Elab.Term.elabIdent
+          • [Completion-Id] none : some Option.{0} Nat @ ⟨76, 9⟩-⟨76, 13⟩
+          • [Term] @none : {α : Type} → Option α @ ⟨76, 9⟩-⟨76, 13⟩
+    • [Term] head? (isBinder := true) : List Nat → Option Nat @ ⟨73, 4⟩-⟨73, 9⟩
+    • [Term] head? (isBinder := true) : List Nat → Option Nat @ ⟨73, 4⟩-⟨73, 9⟩
+    • [CustomInfo(Lean.Elab.LinterInfoGroup)]
+[Elab.info] 
+  • [Command] @ ⟨82, 0⟩-⟨84, 29⟩ @ Lean.Elab.Command.elabDeclaration
+    • [Term] Foo : Type @ ⟨82, 12⟩-⟨82, 15⟩ @ Lean.Elab.Term.elabIdent
+      • [Completion-Id] Foo : some Sort.{?_uniq} @ ⟨82, 12⟩-⟨82, 15⟩
+      • [Term] Foo : Type @ ⟨82, 12⟩-⟨82, 15⟩
+    • [Term] v (isBinder := true) : Foo @ ⟨82, 8⟩-⟨82, 9⟩
+    • [Term] Nat : Type @ ⟨82, 19⟩-⟨82, 22⟩ @ Lean.Elab.Term.elabIdent
+      • [Completion-Id] Nat : some Sort.{?_uniq} @ ⟨82, 19⟩-⟨82, 22⟩
+      • [Term] Nat : Type @ ⟨82, 19⟩-⟨82, 22⟩
+    • [Term] v (isBinder := true) : Foo @ ⟨82, 8⟩-⟨82, 9⟩
+    • [CustomInfo(Lean.Elab.Term.BodyInfo)]
+      • [PartialTerm] @ ⟨83, 2⟩-⟨84, 29⟩ @ Lean.Elab.Term.Quotation.elabMatchSyntax
+      • [Term] match v with
+        | { abc := abc, foo := foo } => abc + foo : Nat @ ⟨83, 2⟩-⟨84, 29⟩ @ Lean.Elab.Term.elabMatch
+        • [Term] v : Foo @ ⟨83, 8⟩-⟨83, 9⟩ @ Lean.Elab.Term.elabIdent
+          • [Completion-Id] v : none @ ⟨83, 8⟩-⟨83, 9⟩
+          • [Term] v : Foo @ ⟨83, 8⟩-⟨83, 9⟩
+        • [Term] v : Foo @ ⟨83, 8⟩-⟨83, 9⟩ @ Lean.Elab.Term.elabIdent
+          • [Completion-Id] v : none @ ⟨83, 8⟩-⟨83, 9⟩
+          • [Term] v : Foo @ ⟨83, 8⟩-⟨83, 9⟩
+        • [Completion-Id] abc : none @ ⟨84, 6⟩-⟨84, 9⟩
+        • [Completion-Id] foo : none @ ⟨84, 11⟩-⟨84, 14⟩
+        • [ChoiceResolution] alternative 1 of 2 (Lean.Parser.Term.structInst) @ ⟨84, 4⟩†-⟨84, 16⟩
+        • [Completion] `abc @ ⟨84, 6⟩-⟨84, 9⟩
+        • [Completion] `foo @ ⟨84, 11⟩-⟨84, 14⟩
+        • [Completion-Id] abc : some Nat @ ⟨84, 6⟩-⟨84, 9⟩
+        • [Field] abc : Nat := abc @ ⟨84, 6⟩-⟨84, 9⟩
+        • [Completion-Id] foo : some Nat @ ⟨84, 11⟩-⟨84, 14⟩
+        • [Field] foo : Nat := foo @ ⟨84, 11⟩-⟨84, 14⟩
+        • [Term] { abc := abc, foo := foo } : Foo @ ⟨84, 4⟩†-⟨84, 16⟩†
+          • [Term] abc (isBinder := true) : Nat @ ⟨84, 6⟩-⟨84, 9⟩
+          • [Term] foo (isBinder := true) : Nat @ ⟨84, 11⟩-⟨84, 14⟩
+        • [Term] abc + foo : Nat @ ⟨84, 20⟩-⟨84, 29⟩ @ «_aux_Init_Notation___macroRules_term_+__2»
+          • [MacroExpansion]
+            abc + foo
+            ===>
+            binop% HAdd.hAdd✝ abc foo
+            • [Term] abc + foo : Nat @ ⟨84, 20⟩†-⟨84, 29⟩† @ Lean.Elab.Term.Op.elabBinOp
+              • [Term] abc + foo : Nat @ ⟨84, 20⟩†-⟨84, 29⟩†
+                • [Completion-Id] HAdd.hAdd✝ : none @ ⟨84, 20⟩†-⟨84, 29⟩†
+                • [Term] abc : Nat @ ⟨84, 20⟩-⟨84, 23⟩ @ Lean.Elab.Term.elabIdent
+                  • [Completion-Id] abc : none @ ⟨84, 20⟩-⟨84, 23⟩
+                  • [Term] abc : Nat @ ⟨84, 20⟩-⟨84, 23⟩
+                • [Term] foo : Nat @ ⟨84, 26⟩-⟨84, 29⟩ @ Lean.Elab.Term.elabIdent
+                  • [Completion-Id] foo : none @ ⟨84, 26⟩-⟨84, 29⟩
+                  • [Term] foo : Nat @ ⟨84, 26⟩-⟨84, 29⟩
+    • [Term] y' (isBinder := true) : Foo → Nat @ ⟨82, 4⟩-⟨82, 6⟩
+    • [Term] y' (isBinder := true) : Foo → Nat @ ⟨82, 4⟩-⟨82, 6⟩
+    • [CustomInfo(Lean.Elab.LinterInfoGroup)]
+[Elab.info] 
+  • [Command] @ ⟨85, 0⟩-⟨85, 0⟩ @ Lean.Elab.Command.elabEoi
+    • [CustomInfo(Lean.Elab.LinterInfoGroup)]


### PR DESCRIPTION
This PR adds a `ChoiceResolutionInfo` node to the `InfoTree` that allows downstream code to disambiguate `choice` `Syntax` nodes.