### PR TITLE
chore: `LawfulOrderBEq Nat`

### DIFF
--- a/src/Init/Data/Nat.lean
+++ b/src/Init/Data/Nat.lean
@@ -28,3 +28,4 @@ public import Init.Data.Nat.Fold
 public import Init.Data.Nat.Order
 public import Init.Data.Nat.ToString
 public import Init.Data.Nat.Sqrt
+public import Init.Data.Nat.Package

--- a/src/Init/Data/Nat/Package.lean
+++ b/src/Init/Data/Nat/Package.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Julia M. Himmel
+-/
+module
+
+prelude
+public import Init.Data.Nat.Order
+public import Init.Data.Nat.Compare
+public import Init.Data.Order.PackageFactories
+import Init.Data.Order.Lemmas
+
+open Std
+
+namespace Nat
+
+public instance : LinearOrderPackage Nat := .ofLE _ {
+  beq_iff_le_and_ge a b := by simpa using Nat.le_antisymm_iff
+}
+
+end Nat

--- a/src/Init/Data/Nat/Package.lean
+++ b/src/Init/Data/Nat/Package.lean
@@ -6,9 +6,9 @@ Authors: Julia M. Himmel
 module
 
 prelude
-public import Init.Data.Nat.Order
-public import Init.Data.Nat.Compare
 public import Init.Data.Order.PackageFactories
+import Init.Data.Nat.Order
+import Init.Data.Nat.Compare
 import Init.Data.Order.Lemmas
 
 open Std

--- a/src/Init/Data/Nat/Package.lean
+++ b/src/Init/Data/Nat/Package.lean
@@ -15,8 +15,9 @@ open Std
 
 namespace Nat
 
-public instance : LinearOrderPackage Nat := .ofLE _ {
+-- This should really be a `LinearOrderPackage Nat` instance. However, this would trigger
+-- #15082 in a grind test, so we just provide `LawfulOrderBEq` for now.
+public instance : LawfulOrderBEq Nat where
   beq_iff_le_and_ge a b := by simpa using Nat.le_antisymm_iff
-}
 
 end Nat

--- a/src/Std/Http/Data/URI/Config.lean
+++ b/src/Std/Http/Data/URI/Config.lean
@@ -6,7 +6,7 @@ Authors: Sofia Rodrigues
 module
 
 prelude
-public import Init.Data.Nat
+public import Init.Data.Nat.Basic
 
 public section
 


### PR DESCRIPTION
This PR adds the missing instance `LawfulOrderBEq Nat`.
