### PR TITLE
fix: expose Array.zipWith for kernel reduction

### DIFF
--- a/src/Init/Data/Array/Basic.lean
+++ b/src/Init/Data/Array/Basic.lean
@@ -1998,7 +1998,7 @@ def isPrefixOf [BEq α] (as bs : Array α) : Bool :=
   else
     false
 
-@[specialize]
+@[specialize, expose]
 def zipWithMAux {m : Type v → Type w} [Monad m] (as : Array α) (bs : Array β) (f : α → β → m γ) (i : Nat) (cs : Array γ) : m (Array γ) := do
   if h : i < as.size then
     let a := as[i]
@@ -2021,7 +2021,7 @@ Examples:
 * `#[].zipWith (· + ·) #[5, 6] = #[]`
 * `#[x₁, x₂, x₃].zipWith f #[y₁, y₂, y₃, y₄] = #[f x₁ y₁, f x₂ y₂, f x₃ y₃]`
 -/
-@[inline] def zipWith (f : α → β → γ) (as : Array α) (bs : Array β) : Array γ :=
+@[inline, expose] def zipWith (f : α → β → γ) (as : Array α) (bs : Array β) : Array γ :=
   Id.run (zipWithMAux as bs (pure <| f · ·) 0 #[])
 
 /--

--- a/tests/elab/array_zipWith_module.lean
+++ b/tests/elab/array_zipWith_module.lean
@@ -1,0 +1,14 @@
+module
+
+/-!
+Tests kernel reduction of `Array.zipWith` across a module boundary.
+-/
+
+example : (Array.zipWith (· + ·) #[1, 2, 3] #[10, 20]).toList = [11, 22] := by
+  decide +kernel
+
+example : (Array.zipWith (· + ·) (#[] : Array Nat) #[10, 20]).toList = [] := by
+  decide +kernel
+
+example : (Vector.zipWith (· + ·) #v[1, 2] #v[10, 20]).toList = [11, 22] := by
+  decide +kernel


### PR DESCRIPTION
This PR makes `Array.zipWith` and the corresponding `Vector.zipWith` operation kernel-reducible across module boundaries.

Expose `Array.zipWith` together with its `zipWithMAux` implementation helper, and add downstream module tests covering nonempty, empty, and vector inputs.

:robot: prepared using Codex+Claude