### PR TITLE
fix: expose Array.modify for kernel reduction

### DIFF
--- a/src/Init/Data/Array/Basic.lean
+++ b/src/Init/Data/Array/Basic.lean
@@ -547,7 +547,7 @@ It was 3
 #[1, 2, 3, 4]
 ```
 -/
-@[implemented_by modifyMUnsafe]
+@[implemented_by modifyMUnsafe, expose]
 def modifyM [Monad m] (xs : Array α) (i : Nat) (f : α → m α) : m (Array α) := do
   if h : i < xs.size then
     let v   := xs[i]
@@ -565,7 +565,7 @@ Examples:
  * `#[1, 2, 3].modify 2 (· * 10) = #[1, 2, 30]`
  * `#[1, 2, 3].modify 3 (· * 10) = #[1, 2, 3]`
 -/
-@[inline]
+@[inline, expose]
 def modify (xs : Array α) (i : Nat) (f : α → α) : Array α :=
   Id.run <| modifyM xs i (pure <| f ·)
 

--- a/tests/elab/array_modify_module.lean
+++ b/tests/elab/array_modify_module.lean
@@ -1,0 +1,15 @@
+module
+
+/-!
+Tests kernel reduction of `Array.modify` across a module boundary.
+-/
+
+example : ((#[1, 2] : Array Nat).modify 0 (· + 10)).toList = [11, 2] := by
+  decide +kernel
+
+example : ((#[1, 2] : Array Nat).modify 3 (· + 10)).toList = [1, 2] := by
+  decide +kernel
+
+example :
+    (Id.run ((#[1, 2] : Array Nat).modifyM 1 (fun x => pure (x + 10)))).toList = [1, 12] := by
+  decide +kernel


### PR DESCRIPTION
This PR makes `Array.modify` and `Array.modifyM` kernel-reducible across module boundaries.

Expose both the pure wrapper and its monadic reference implementation, and add downstream module tests covering in-bounds, out-of-bounds, and monadic modification.

:robot: prepared using Codex+Claude