### PR TITLE
chore: `LinearOrderPackage Int`

### DIFF
--- a/src/Init/Data/Int.lean
+++ b/src/Init/Data/Int.lean
@@ -19,3 +19,4 @@ public import Init.Data.Int.Cooper
 public import Init.Data.Int.Linear
 public import Init.Data.Int.OfNat
 public import Init.Data.Int.ToString
+public import Init.Data.Int.Package

--- a/src/Init/Data/Int/Package.lean
+++ b/src/Init/Data/Int/Package.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Julia M. Himmel
+-/
+module
+
+prelude
+public import Init.Data.Order.PackageFactories
+import Init.Data.Int.Order
+import Init.Data.Int.Compare
+import Init.Data.Order.Lemmas
+
+open Std
+
+namespace Int
+
+public instance : LinearOrderPackage Int := .ofLE _ {
+  beq_iff_le_and_ge a b := by simpa using Int.le_antisymm_iff
+}
+
+end Int

--- a/src/Std/Http/Internal/Char.lean
+++ b/src/Std/Http/Internal/Char.lean
@@ -8,7 +8,7 @@ module
 prelude
 public import Init.Data.Char
 public import Init.Data.String.Basic
-public import Init.Data.Int
+public import Init.Data.Int.Basic
 public import Init.Grind
 
 @[expose]


### PR DESCRIPTION
This PR provides `LinearOrderPackage Int`, which in turn provides the missing instance `LawfulOrderBEq Int`.