### PR TITLE
feat: missing order instances for `Fin`

### DIFF
--- a/src/Init/Data/Fin.lean
+++ b/src/Init/Data/Fin.lean
@@ -12,3 +12,5 @@ public import Init.Data.Fin.Iterate
 public import Init.Data.Fin.Fold
 public import Init.Data.Fin.Lemmas
 public import Init.Data.Fin.OverflowAware
+public import Init.Data.Fin.Package
+public import Init.Data.Fin.MinMax

--- a/src/Init/Data/Fin/MinMax.lean
+++ b/src/Init/Data/Fin/MinMax.lean
@@ -19,7 +19,7 @@ public instance : Min (Fin n) where
 public instance : Max (Fin n) where
   max a b := ⟨max a b, by simpa [Std.max_lt_iff] using ⟨a.isLt, b.isLt⟩⟩
 
-@[simp] public theorem val_min {a b : Fin n} : (min a b).val = min a.val b.val := rfl
-@[simp] public theorem val_max {a b : Fin n} : (max a b).val = max a.val b.val := rfl
+@[simp] public theorem val_min (a b : Fin n) : (min a b).val = min a.val b.val := rfl
+@[simp] public theorem val_max (a b : Fin n) : (max a b).val = max a.val b.val := rfl
 
 end Fin

--- a/src/Init/Data/Fin/MinMax.lean
+++ b/src/Init/Data/Fin/MinMax.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Julia M. Himmel
+-/
+module
+
+prelude
+public import Init.Data.Fin.Basic
+import Init.Data.Order.Lemmas
+import Init.Data.Nat.Order
+import Init.Data.Nat.MinMax
+
+namespace Fin
+
+public instance : Min (Fin n) where
+  min a b := ⟨min a b, by simpa [Std.min_lt_iff] using Or.inl a.isLt⟩
+
+public instance : Max (Fin n) where
+  max a b := ⟨max a b, by simpa [Std.max_lt_iff] using ⟨a.isLt, b.isLt⟩⟩
+
+@[simp] public theorem val_min {a b : Fin n} : (min a b).val = min a.val b.val := rfl
+@[simp] public theorem val_max {a b : Fin n} : (max a b).val = max a.val b.val := rfl
+
+end Fin

--- a/src/Init/Data/Fin/Package.lean
+++ b/src/Init/Data/Fin/Package.lean
@@ -19,7 +19,7 @@ open Std
 namespace Fin
 
 @[simp]
-public theorem compare_val {n : Nat} {a b : Fin n} : compare (a : Nat) (b : Nat) = compare a b := rfl
+public theorem compare_val {n : Nat} (a b : Fin n) : compare (a : Nat) (b : Nat) = compare a b := rfl
 
 public instance {n : Nat} : LinearOrderPackage (Fin n) := .ofLE _ {
   beq_iff_le_and_ge a b := by simpa using Fin.le_antisymm_iff

--- a/src/Init/Data/Fin/Package.lean
+++ b/src/Init/Data/Fin/Package.lean
@@ -19,7 +19,7 @@ open Std
 namespace Fin
 
 @[simp]
-theorem compare_val {n : Nat} {a b : Fin n} : compare (a : Nat) (b : Nat) = compare a b := rfl
+public theorem compare_val {n : Nat} {a b : Fin n} : compare (a : Nat) (b : Nat) = compare a b := rfl
 
 public instance {n : Nat} : LinearOrderPackage (Fin n) := .ofLE _ {
   beq_iff_le_and_ge a b := by simpa using Fin.le_antisymm_iff

--- a/src/Init/Data/Fin/Package.lean
+++ b/src/Init/Data/Fin/Package.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Julia M. Himmel
+-/
+module
+
+prelude
+public import Init.Data.Order.PackageFactories
+public import Init.Data.Fin.MinMax
+import Init.Data.Fin.Lemmas
+import Init.Data.Order.Lemmas
+import Init.Data.Nat.Compare
+import Init.ByCases
+import Init.Data.Nat.Order
+
+open Std
+
+namespace Fin
+
+@[simp]
+theorem compare_val {n : Nat} {a b : Fin n} : compare (a : Nat) (b : Nat) = compare a b := rfl
+
+public instance {n : Nat} : LinearOrderPackage (Fin n) := .ofLE _ {
+  beq_iff_le_and_ge a b := by simpa using Fin.le_antisymm_iff
+  isLE_compare a b := by rw [le_def, ← isLE_compare, compare_val]
+  isGE_compare a b := by rw [le_def, ← isGE_compare, compare_val]
+  min_eq a b := by simp [← val_inj, val_min, apply_ite val, min_eq_ite, le_def]
+  max_eq a b := by simp [← val_inj, val_max, apply_ite val, max_eq_ite, le_def]
+}
+
+end Fin

--- a/src/Init/Data/Order/Lemmas.lean
+++ b/src/Init/Data/Order/Lemmas.lean
@@ -314,6 +314,11 @@ public theorem le_min_iff {α : Type u} [Min α] [LE α]
     a ≤ min b c ↔ a ≤ b ∧ a ≤ c :=
   LawfulOrderInf.le_min_iff a b c
 
+public theorem min_lt_iff {α : Type u} [Min α] [LE α] [LT α] [Total (α := α) (· ≤ ·)]
+    [LawfulOrderInf α] [LawfulOrderLT α] {a b c : α} : min a b < c ↔ a < c ∨ b < c := by
+  classical
+  rw [← Decidable.not_iff_not, not_lt, not_or, le_min_iff, not_lt, not_lt]
+
 public theorem min_le_left {α : Type u} [Min α] [LE α] [Refl (α := α) (· ≤ ·)] [LawfulOrderInf α]
     {a b : α} : min a b ≤ a :=
   le_min_iff.mp (le_refl _) |>.1
@@ -327,6 +332,11 @@ public theorem min_le {α : Type u} [Min α] [LE α] [IsPreorder α] [LawfulOrde
   cases MinEqOr.min_eq_or a b <;> rename_i h
   · simpa [h] using le_trans (h ▸ min_le_right (a := a) (b := b))
   · simpa [h] using le_trans (h ▸ min_le_left (a := a) (b := b))
+
+public theorem lt_min_iff {α : Type u} [Min α] [LE α] [LT α] [IsLinearPreorder α] [LawfulOrderMin α]
+    [LawfulOrderLT α] {a b c : α} : a < min b c ↔ a < b ∧ a < c := by
+  classical
+  rw [← Decidable.not_iff_not, not_lt, Classical.not_and_iff_not_or_not, not_lt, not_lt, min_le]
 
 public theorem min_eq_or {α : Type u} [Min α] [MinEqOr α] {a b : α} :
     min a b = a ∨ min a b = b :=
@@ -464,6 +474,11 @@ public theorem max_le_iff {α : Type u} [Max α] [LE α] [LawfulOrderSup α] {a 
     max a b ≤ c ↔ a ≤ c ∧ b ≤ c :=
   LawfulOrderSup.max_le_iff a b c
 
+public theorem lt_max_iff {α : Type u} [Max α] [LE α] [LT α] [Total (α := α) (· ≤ ·)]
+    [LawfulOrderSup α] [LawfulOrderLT α] {a b c : α} : a < max b c ↔ a < b ∨ a < c := by
+  classical
+  rw [← Decidable.not_iff_not, not_lt, not_or, max_le_iff, not_lt, not_lt]
+
 public theorem left_le_max {α : Type u} [Max α] [LE α] [Refl (α := α) (· ≤ ·)] [LawfulOrderSup α]
     {a b : α} : a ≤ max a b :=
   max_le_iff.mp (le_refl _) |>.1
@@ -477,6 +492,11 @@ public theorem le_max {α : Type u} [Max α] [LE α] [IsPreorder α] [LawfulOrde
   cases MaxEqOr.max_eq_or b c <;> rename_i h
   · simpa [h] using (le_trans · (h ▸ right_le_max))
   · simpa [h] using (le_trans · (h ▸ left_le_max))
+
+public theorem max_lt_iff {α : Type u} [Max α] [LE α] [LT α] [IsLinearPreorder α] [LawfulOrderMax α]
+    [LawfulOrderLT α] {a b c : α} : max a b < c ↔ a < c ∧ b < c := by
+  classical
+  rw [← Decidable.not_iff_not, not_lt, Classical.not_and_iff_not_or_not, not_lt, not_lt, le_max]
 
 public theorem max_eq_or {α : Type u} [Max α] [MaxEqOr α] {a b : α} :
     max a b = a ∨ max a b = b :=


### PR DESCRIPTION
This PR adds a series of missing order instances on `Fin`, including `Min`, `Max`, `LawfulOrderOrd`, etc.