### PR TITLE
fix: prevent unsafe fallback axioms from entering safe declarations

### DIFF
--- a/src/Lean/AddDecl.lean
+++ b/src/Lean/AddDecl.lean
@@ -193,11 +193,18 @@ where
           addAsAxiom
           throw ex
   addAsAxiom := do
+    let isUnsafe := match decl with
+      | .axiomDecl d => d.isUnsafe
+      | .defnDecl d => d.safety != .safe
+      | .opaqueDecl d => d.isUnsafe
+      | .mutualDefnDecl ds => ds.any fun d => d.safety != .safe
+      | .inductDecl _ _ _ isUnsafe => isUnsafe
+      | _ => false
     -- try to add as axiom with given type for def/theorem
     match decl with
     | .defnDecl d | .thmDecl d =>
       let fallbackDecl := .axiomDecl {
-        name := d.name, levelParams := d.levelParams, type := d.type, isUnsafe := false
+        name := d.name, levelParams := d.levelParams, type := d.type, isUnsafe
       }
       try
         let env ← (← getEnv).addDeclAux (← getOptions) fallbackDecl (← read).cancelTk?
@@ -211,7 +218,7 @@ where
     for n in decl.getNames do
       let fallbackDecl := .axiomDecl {
         name := n, levelParams := []
-        type := mkApp2 (mkConst ``sorryAx [1]) (mkSort 0) (mkConst ``true), isUnsafe := false
+        type := mkApp2 (mkConst ``sorryAx [1]) (mkSort 0) (mkConst ``true), isUnsafe
       }
       try
         let env ← (← getEnv).addDeclAux (← getOptions) fallbackDecl (← read).cancelTk?

--- a/tests/elab/addDeclUnsafeFallback.lean
+++ b/tests/elab/addDeclUnsafeFallback.lean
@@ -1,0 +1,44 @@
+module
+
+import Lean
+
+/-!
+Tests that fallback axioms for rejected unsafe definitions remain unsafe.
+-/
+
+open Lean
+
+set_option Elab.async false
+
+run_meta do
+  try
+    addDecl <| .defnDecl {
+      name := `unsafeFallbackFalse
+      levelParams := []
+      type := mkConst ``False
+      value := mkConst ``True.intro
+      hints := .opaque
+      safety := .unsafe
+    }
+  catch _ => pure ()
+
+run_meta do
+  let name := `unsafeFallbackOpaque
+  try
+    addDecl <| .opaqueDecl {
+      name
+      levelParams := []
+      type := mkConst ``False
+      value := mkConst ``True.intro
+      isUnsafe := true
+    }
+  catch _ => pure ()
+  let some info := (← getEnv).find? name | throwError "fallback axiom was not added"
+  unless info.isUnsafe do
+    throwError "fallback axiom was not marked unsafe"
+
+/--
+error: (kernel) invalid declaration, it uses unsafe declaration 'unsafeFallbackFalse'
+-/
+#guard_msgs in
+theorem unsafeFallbackExploit : False := unsafeFallbackFalse


### PR DESCRIPTION
this PR prevents rejected unsafe declarations from becoming safe fallback axioms, which allowed metaprograms to use unsafe constants from safe declarations.

declaration checking adds a fallback axiom after a kernel failure so later elaboration can continue. preserve the source declaration's unsafe or partial status on both typed and emergency fallbacks, and cover the safe-theorem and unsafe-opaque paths with a unit test.

the label `changelog-language` probably fits best
